### PR TITLE
[lldb][NFC] Actually test which method we call in TestCallOverriddenMethod

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/commands/expression/call-overridden-method/TestCallOverriddenMethod.py
+++ b/lldb/packages/Python/lldbsuite/test/commands/expression/call-overridden-method/TestCallOverriddenMethod.py
@@ -41,7 +41,7 @@ class ExprCommandCallOverriddenMethod(TestBase):
 
         # Test call to method in base class (this should always work as the base
         # class method is never an override).
-        self.expect("expr b->foo()")
+        self.expect("expr b->foo()", substrs=["2"])
 
         # Test call to overridden method in derived class (this will fail if the
         # overrides table is not correctly set up, as Derived::foo will be assigned

--- a/lldb/packages/Python/lldbsuite/test/commands/expression/call-overridden-method/main.cpp
+++ b/lldb/packages/Python/lldbsuite/test/commands/expression/call-overridden-method/main.cpp
@@ -1,12 +1,12 @@
 class Base {
 public:
   virtual ~Base() {}
-  virtual void foo() {}
+  virtual int foo() { return 1; }
 };
 
 class Derived : public Base {
 public:
-  virtual void foo() {}
+  virtual int foo() { return 2; }
 };
 
 int main() {


### PR DESCRIPTION
llvm-svn: 373051

This commit is needed to let the test added for the [artificial constructor fix](https://github.com/apple/llvm-project/commit/d1dfc9b50c76ad9568830355b800aaa555522074) pass.