### PR TITLE
[compiler-rt] Use signal on Windows

### DIFF
--- a/compiler-rt/lib/profile/InstrProfilingFile.c
+++ b/compiler-rt/lib/profile/InstrProfilingFile.c
@@ -366,6 +366,18 @@ static void exitSignalHandler(int sig) {
   exit(0);
 }
 
+#if defined(_WIN32)
+// sigaction isn't available on Windows, so just use signal.
+static void installExitSignalHandlers(void) {
+  unsigned I;
+  for (I = 0; I < lprofCurFilename.NumExitSignals; ++I) {
+    if (signal(lprofCurFilename.ExitOnSignals[I], exitSignalHandler) == SIG_ERR)
+      PROF_WARN(
+          "Unable to install an exit signal handler for %d (errno = %d).\n",
+          lprofCurFilename.ExitOnSignals[I], errno);
+  }
+}
+#else
 static void installExitSignalHandlers(void) {
   unsigned I;
   struct sigaction sigact;
@@ -380,6 +392,7 @@ static void installExitSignalHandlers(void) {
           lprofCurFilename.ExitOnSignals[I], err);
   }
 }
+#endif
 
 static const char *DefaultProfileName = "default.profraw";
 static void resetFilenameToDefault(void) {


### PR DESCRIPTION
sigaction doesn't exist on Windows, so use signal directly. Prefer
sigaction on other platforms because its semantics are well-defined.

Note that the Windows semantics for signal do reset the handler to
SIG_DFL, so we'd normally have to reinstall it manually. In this case,
our handler just exits, so we don't need to.