### PR TITLE
Cherry-pick "Fix darwin-ld-lto test for some special path" to stable

### DIFF
--- a/clang/test/Driver/darwin-ld-lto.c
+++ b/clang/test/Driver/darwin-ld-lto.c
@@ -23,8 +23,10 @@
 // RUN: %clang -target x86_64-apple-darwin10 %s -flto=full -### 2>&1 | \
 // RUN:   FileCheck -check-prefix=FULL_LTO_OBJECT_PATH %s
 // FULL_LTO_OBJECT_PATH: {{ld(.exe)?"}}
-// FULL_LTO_OBJECT_PATH-SAME: "-object_path_lto" "{{[a-zA-Z0-9_\/]+\/cc\-[a-zA-Z0-9_]+.o}}"
+// FULL_LTO_OBJECT_PATH-SAME: "-object_path_lto"
+// FULL_LTO_OBJECT_PATH-SAME: {{cc\-[a-zA-Z0-9_]+.o}}"
 // RUN: %clang -target x86_64-apple-darwin10 %s -flto=thin -### 2>&1 | \
 // RUN:   FileCheck -check-prefix=THIN_LTO_OBJECT_PATH %s
 // THIN_LTO_OBJECT_PATH: {{ld(.exe)?"}}
-// THIN_LTO_OBJECT_PATH-SAME: "-object_path_lto" "{{[a-zA-Z0-9_\/]+\/thinlto\-[a-zA-Z0-9_]+}}"
+// THIN_LTO_OBJECT_PATH-SAME: "-object_path_lto"
+// THIN_LTO_OBJECT_PATH-SAME: {{thinlto\-[a-zA-Z0-9_]+}}


### PR DESCRIPTION
Cherry-picking @cachemeifyoucan's test fix over to stable to unblock CI bots with hyphens in their temp directory.

Original message:
Fix the test by not assuming the prefix path of the temp directory can
be matched by a regex.

rdar://problem/56259195

llvm-svn: 375027