### PR TITLE
move registrations out of SwiftREPL::CompleteCode

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -553,10 +553,6 @@ int SwiftREPL::CompleteCode(const std::string &current_code,
         llvm::dyn_cast_or_null<SwiftASTContext>(&*type_system_or_err);
     if (target_swift_ast)
       m_swift_ast_sp.reset(new SwiftASTContext(*target_swift_ast));
-    auto &ctx = *m_swift_ast_sp.get()->GetASTContext();
-    swift::registerIDERequestFunctions(ctx.evaluator);
-    swift::registerTypeCheckerRequestFunctions(ctx.evaluator);
-    swift::createTypeChecker(ctx);
   }
   SwiftASTContext *swift_ast = m_swift_ast_sp.get();
 

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -3467,6 +3467,7 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
 
   // Set up the required state for the evaluator in the TypeChecker.
   (void)swift::createTypeChecker(*m_ast_context_ap);
+  registerIDERequestFunctions(m_ast_context_ap->evaluator);
   registerParseRequestFunctions(m_ast_context_ap->evaluator);
   registerTypeCheckerRequestFunctions(m_ast_context_ap->evaluator);
 


### PR DESCRIPTION
The calls to `registerTypeCheckerRequestFunctions` and `createTypeChecker` in `SwiftREPL::CompleteCode` are already done in `SwiftASTContext::GetASTContext`. Multiple calls to `register*RequestFunctions` are not allowed, and the symptom is the following assertion failure when you try to use autocomplete in the LLDB REPL:

```
lldb: /home/buildnode/jenkins/workspace/oss-swift-package-linux-ubuntu-18_04/swift/lib/AST/Evaluator.cpp:58: void swift::Evaluator::registerRequestFunctions(swift::Zone, ArrayRef<swift::AbstractRequestFunction *>): Assertion `zone.first != zoneID' failed.
```

So this PR removes these calls from `SwiftREPL::CompleteCode`.

This PR also moves `registerIDERequestFunctions` from `SwiftREPL::CompleteCode` to `SwiftASTContext::GetASTContext` because it seems like a more consistent place to do it that will cause fewer problems in the future.