### PR TITLE
[lldb] Adjust for the new class_rw_t layout.

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
@@ -111,6 +111,18 @@ bool ClassDescriptorV2::class_rw_t::Read(Process *process, lldb::addr_t addr) {
   m_firstSubclass = extractor.GetAddress_unchecked(&cursor);
   m_nextSiblingClass = extractor.GetAddress_unchecked(&cursor);
 
+  if (m_ro_ptr & 1) {
+    DataBufferHeap buffer(ptr_size, '\0');
+    process->ReadMemory(m_ro_ptr ^ 1, buffer.GetBytes(), ptr_size, error);
+    if (error.Fail())
+      return false;
+    cursor = 0;
+    DataExtractor extractor(buffer.GetBytes(), ptr_size,
+                            process->GetByteOrder(),
+                            process->GetAddressByteSize());
+    m_ro_ptr = extractor.GetAddress_unchecked(&cursor);
+  }
+
   return true;
 }
 


### PR DESCRIPTION
The field holding the "ro" will now be a union. If the low bit is set,
then it isn't an ro and it needs to be dereferenced once more to get to
it. If the low bit isn't set, then it is a proper class_ro_t

No dedicated test is needed as this code path will trigger when running
the existing Objective-C tests under a current version of the runtime.

(cherry picked from commit 0bff9bd26e3d8b424f96f66b4297a73a873c4e53)