### PR TITLE
[Driver] Force llvm to install its handlers before lldb's

### DIFF
--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -862,6 +862,25 @@ main(int argc, char const *argv[])
   }
   SBHostOS::ThreadCreated("<lldb.driver.main-thread>");
 
+  // Install llvm's signal handlers up front to prevent lldb's handlers from
+  // being ignored. This is (hopefully) a stopgap workaround.
+  //
+  // When lldb invokes an llvm API that installs signal handlers (e.g.
+  // llvm::sys::RemoveFileOnSignal, possibly via a compiler embedded within
+  // lldb), lldb's signal handlers are overriden if llvm is installing its
+  // handlers for the first time.
+  //
+  // To work around llvm's behavior, force it to install its handlers up front,
+  // and *then* install lldb's handlers. In practice this is used to prevent
+  // lldb test processes from exiting due to IO_ERR when SIGPIPE is received.
+  //
+  // Note that when llvm installs its handlers, it 1) records the old handlers
+  // it replaces and 2) re-installs the old handlers when its new handler is
+  // invoked. That means that a signal not explicitly handled by lldb can fall
+  // back to being handled by llvm's handler the first time it is received,
+  // and then by the default handler the second time it is received.
+  llvm::sys::AddSignalHandler([](void *) -> void {}, nullptr);
+
   signal(SIGINT, sigint_handler);
 #if !defined(_MSC_VER)
   signal(SIGPIPE, SIG_IGN);


### PR DESCRIPTION
Install llvm's signal handlers up front to prevent lldb's handlers from being
ignored. This is (hopefully) a stopgap workaround.

When lldb invokes an llvm API that installs signal handlers (e.g.
llvm::sys::RemoveFileOnSignal, possibly via a compiler embedded within lldb),
lldb's signal handlers are overriden if llvm is installing its handlers for the
first time.

To work around llvm's behavior, force it to install its handlers up front, and
*then* install lldb's handlers. In practice this is used to prevent lldb test
processes from exiting due to IO_ERR when SIGPIPE is received.

Note that when llvm installs its handlers, it 1) records the old handlers it
replaces and 2) re-installs the old handlers when its new handler is invoked.
That means that a signal not explicitly handled by lldb can fall back to being
handled by llvm's handler the first time it is received, and then by the
default handler the second time it is received.

Differential Revision: https://reviews.llvm.org/D69403

(cherry picked from commit 0877dd14e4e85550f8e267b5ceeff1d3409c41ba)