### PR TITLE
[TSan] Fix CI test failures

### DIFF
--- a/compiler-rt/test/sanitizer_common/lit.common.cfg
+++ b/compiler-rt/test/sanitizer_common/lit.common.cfg
@@ -35,6 +35,7 @@ if config.host_os == 'Darwin':
   # On Darwin, we default to `abort_on_error=1`, which would make tests run
   # much slower. Let's override this and run lit tests with 'abort_on_error=0'.
   default_tool_options += ['abort_on_error=0']
+  default_tool_options += ['ignore_interceptors_accesses=0']
 elif config.android:
   # The same as on Darwin, we default to "abort_on_error=1" which slows down
   # testing. Also, all existing tests are using "not" instead of "not --crash"

--- a/compiler-rt/test/tsan/Unit/lit.site.cfg.in
+++ b/compiler-rt/test/tsan/Unit/lit.site.cfg.in
@@ -21,3 +21,4 @@ if config.host_os == 'Darwin':
     config.environment['TSAN_OPTIONS'] += ':ignore_noninstrumented_modules=0'
   else:
     config.environment['TSAN_OPTIONS'] = 'ignore_noninstrumented_modules=0'
+  config.environment['TSAN_OPTIONS'] += ':ignore_interceptors_accesses=0'

--- a/compiler-rt/test/tsan/lit.cfg
+++ b/compiler-rt/test/tsan/lit.cfg
@@ -28,6 +28,7 @@ if config.host_os == 'Darwin':
   # suppresses some races the tests are supposed to find. Let's run without this
   # setting, but turn it back on for Darwin tests (see Darwin/lit.local.cfg).
   default_tsan_opts += ':ignore_noninstrumented_modules=0'
+  default_tsan_opts += ':ignore_interceptors_accesses=0'
 
 # Platform-specific default TSAN_OPTIONS for lit tests.
 if default_tsan_opts:


### PR DESCRIPTION
I think this fix didn't get propagated in the transition from
llvm:stable to llvm-project:swift/master because the filename changed
from `lit.cfg` to `lit.cfg.py` at the same time.

rdar://56545824

Original commit:
>   [TSan] Follow-up for my previous commit
> 
>   I enabled ignore_interceptors_accesses, but forgot to disable it for
>   tests to avoid false negatives.
> 
>   apple-llvm-split-commit: 77a1e0d62108f1363fbe868b09eb53d42b923aae
>   apple-llvm-split-dir: compiler-rt/
> 
(cherry picked from commit 67bb9b1bef011490b28f05fbef91f2235baf69cd)