### PR TITLE
More fixup for "[TSan] Turn on ignore_interceptors_accesses"

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Darwin/abort_on_error.cc
+++ b/compiler-rt/test/sanitizer_common/TestCases/Darwin/abort_on_error.cc
@@ -4,7 +4,7 @@
 // RUN: %clangxx -DUSING_%tool_name %s -o %t
 
 // Intentionally don't inherit the default options.
-// RUN: env %tool_options='' not --crash %run %t 2>&1
+// RUN: env %tool_options='' TSAN_OPTIONS=ignore_interceptors_accesses=0 not --crash %run %t 2>&1
 
 // When we use lit's default options, we shouldn't crash.
 // RUN: not %run %t 2>&1

--- a/compiler-rt/test/sanitizer_common/lit.common.cfg
+++ b/compiler-rt/test/sanitizer_common/lit.common.cfg
@@ -35,7 +35,8 @@ if config.host_os == 'Darwin':
   # On Darwin, we default to `abort_on_error=1`, which would make tests run
   # much slower. Let's override this and run lit tests with 'abort_on_error=0'.
   default_tool_options += ['abort_on_error=0']
-  default_tool_options += ['ignore_interceptors_accesses=0']
+  if config.tool_name == "tsan":
+    default_tool_options += ['ignore_interceptors_accesses=0']
 elif config.android:
   # The same as on Darwin, we default to "abort_on_error=1" which slows down
   # testing. Also, all existing tests are using "not" instead of "not --crash"


### PR DESCRIPTION
rdar://56545824

Original commit:
  More fixup for previous commit: 0f52cc47d62a27311bf4b92d9d25584d7936be11

  apple-llvm-split-commit: 11240e9836b9baf408d9290e246ecf0530503a14
  apple-llvm-split-dir: compiler-rt/

(cherry picked from commit e72e6304c11670d11915c61af446ad965cbf308b)