### PR TITLE
[lit] Drop the user-site packages directory from search paths when ru…

### DIFF
--- a/llvm/utils/lit/tests/lit.cfg
+++ b/llvm/utils/lit/tests/lit.cfg
@@ -37,6 +37,10 @@ else:
 
 # Required because some tests import the lit module
 llvm_config.with_environment('PYTHONPATH', lit_path, append_path=True)
+# Do not add user-site packages directory to the python search path. This avoids test failures if there's an
+# incompatible lit module installed inside the user-site packages directory, as it gets prioritized over the lit
+# from the PYTHONPATH.
+config.environment['PYTHONNOUSERSITE'] = '1'
 
 # Add llvm and lit tools directories if this config is being loaded indirectly.
 for attribute in ('llvm_tools_dir', 'lit_tools_dir'):


### PR DESCRIPTION
…nning tests

Do not add user-site packages directory to the python search path.
This avoids test failures if there's an incompatible lit module installed
inside the user-site packages directory, as it gets prioritized over the lit
from the PYTHONPATH.

(cherry picked from commit 32837a60ac4ff43182699073729daed2cd0ed421)