### PR TITLE
Mark all Swift-specific changes in API with comments. NFC

### DIFF
--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -1,3 +1,4 @@
+## BEGIN SWIFT
 set(LLVM_NO_RTTI 1)
 
 include(AddLLVM)
@@ -5,6 +6,7 @@ include(AddLLVM)
 if (LLDB_ENABLE_SWIFT_SUPPORT)
   include(SwiftAddCustomCommandTarget)
 endif()
+## END SWIFT
 
 if ( CMAKE_SYSTEM_NAME MATCHES "Windows" )
   add_definitions( -DEXPORT_LIBLLDB )
@@ -106,7 +108,9 @@ add_lldb_library(liblldb SHARED
     lldbTarget
     lldbUtility
     ${LLDB_ALL_PLUGINS}
+## BEGIN SWIFT
     ${SWIFT_ALL_LIBS}
+## END SWIFT
   LINK_COMPONENTS
     Support
 
@@ -180,6 +184,7 @@ if(LLDB_BUILD_FRAMEWORK)
   include(LLDBFramework)
 endif()
 
+## BEGIN SWIFT
 set(lib_dir "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib${LLVM_LIBDIR_SUFFIX}")
 
 if(EXISTS ${SWIFT_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/swift/clang)
@@ -241,3 +246,4 @@ if(LLDB_BUILT_STANDALONE)
     DESTINATION lib${LLVM_LIBDIR_SUFFIX}/lldb/)
 endif()
 endif()
+## END SWIFT

--- a/lldb/source/API/SBExpressionOptions.cpp
+++ b/lldb/source/API/SBExpressionOptions.cpp
@@ -185,6 +185,8 @@ void SBExpressionOptions::SetCancelCallback(
   m_opaque_up->SetCancelCallback(callback, baton);
 }
 
+// BEGIN SWIFT
+
 bool SBExpressionOptions::GetPlaygroundTransformEnabled() const {
   return m_opaque_up->GetPlaygroundTransformEnabled();
 }
@@ -205,6 +207,8 @@ void SBExpressionOptions::SetREPLMode(bool enable_repl_mode) {
   if (enable_repl_mode == true)
     SetTrapExceptions(false);
 }
+
+// END SWIFT
 
 bool SBExpressionOptions::GetGenerateDebugInfo() {
   LLDB_RECORD_METHOD_NO_ARGS(bool, SBExpressionOptions, GetGenerateDebugInfo);

--- a/lldb/source/API/SBFrame.cpp
+++ b/lldb/source/API/SBFrame.cpp
@@ -30,7 +30,6 @@
 #include "lldb/Symbol/Variable.h"
 #include "lldb/Symbol/VariableList.h"
 #include "lldb/Target/ExecutionContext.h"
-#include "lldb/Target/LanguageRuntime.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/RegisterContext.h"
 #include "lldb/Target/StackFrame.h"
@@ -51,6 +50,10 @@
 #include "lldb/API/SBVariablesOptions.h"
 
 #include "llvm/Support/PrettyStackTrace.h"
+
+// BEGIN SWIFT
+#include "lldb/Target/LanguageRuntime.h"
+// END SWIFT
 
 using namespace lldb;
 using namespace lldb_private;
@@ -1205,6 +1208,7 @@ lldb::LanguageType SBFrame::GuessLanguage() const {
   return eLanguageTypeUnknown;
 }
 
+// BEGIN SWIFT
 bool SBFrame::IsSwiftThunk() const {
   std::unique_lock<std::recursive_mutex> lock;
   ExecutionContext exe_ctx(m_opaque_sp.get(), lock);
@@ -1229,6 +1233,7 @@ bool SBFrame::IsSwiftThunk() const {
     return false;
   return runtime->IsSymbolARuntimeThunk(*sc.symbol);
 }
+// END SWIFT
 
 const char *SBFrame::GetFunctionName() const {
   LLDB_RECORD_METHOD_CONST_NO_ARGS(const char *, SBFrame, GetFunctionName);

--- a/lldb/source/API/SBFunction.cpp
+++ b/lldb/source/API/SBFunction.cpp
@@ -245,12 +245,14 @@ bool SBFunction::GetIsOptimized() {
   return false;
 }
 
+// BEGIN SWIFT
 bool SBFunction::GetCanThrow() {
   if (m_opaque_ptr) {
       return m_opaque_ptr->CanThrow();
   }
   return false;
 }
+// END SWIFT
 
 namespace lldb_private {
 namespace repro {

--- a/lldb/source/API/SBHostOS.cpp
+++ b/lldb/source/API/SBHostOS.cpp
@@ -80,8 +80,10 @@ SBFileSpec SBHostOS::GetLLDBPath(lldb::PathType path_type) {
     fspec = GetClangResourceDir();
     break;
 
+  // BEGIN SWIFT
   case ePathTypeSwiftDir:
     break;
+  // END SWIFT
   }
 
   SBFileSpec sb_fspec;

--- a/lldb/source/API/SBModule.cpp
+++ b/lldb/source/API/SBModule.cpp
@@ -23,9 +23,12 @@
 #include "lldb/Symbol/Symtab.h"
 #include "lldb/Symbol/TypeSystem.h"
 #include "lldb/Symbol/VariableList.h"
-#include "lldb/Target/Language.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/StreamString.h"
+
+// BEGIN SWIFT
+#include "lldb/Target/Language.h"
+// END SWIFT
 
 using namespace lldb;
 using namespace lldb_private;
@@ -674,6 +677,7 @@ lldb::SBAddress SBModule::GetObjectFileHeaderAddress() const {
   return LLDB_RECORD_RESULT(sb_addr);
 }
 
+// BEGIN SWIFT
 lldb::SBError SBModule::IsTypeSystemCompatible(lldb::LanguageType language) {
   SBError sb_error;
   ModuleSP module_sp(GetSP());
@@ -691,6 +695,7 @@ lldb::SBError SBModule::IsTypeSystemCompatible(lldb::LanguageType language) {
   }
   return sb_error;
 }
+// END SWIFT
 
 lldb::SBAddress SBModule::GetObjectFileEntryPointAddress() const {
   LLDB_RECORD_METHOD_CONST_NO_ARGS(lldb::SBAddress, SBModule,

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -25,12 +25,10 @@
 #include "lldb/API/SBStringList.h"
 #include "lldb/API/SBStructuredData.h"
 #include "lldb/API/SBSymbolContextList.h"
-#include "lldb/Breakpoint/Breakpoint.h"
 #include "lldb/Breakpoint/BreakpointID.h"
 #include "lldb/Breakpoint/BreakpointIDList.h"
 #include "lldb/Breakpoint/BreakpointList.h"
 #include "lldb/Breakpoint/BreakpointLocation.h"
-#include "lldb/Breakpoint/BreakpointPrecondition.h"
 #include "lldb/Core/Address.h"
 #include "lldb/Core/AddressResolver.h"
 #include "lldb/Core/AddressResolverName.h"
@@ -70,6 +68,10 @@
 #include "lldb/Interpreter/CommandReturnObject.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Regex.h"
+
+// BEGIN SWIFT
+#include "lldb/Breakpoint/BreakpointPrecondition.h"
+// END SWIFT
 
 using namespace lldb;
 using namespace lldb_private;
@@ -1078,11 +1080,14 @@ SBTarget::BreakpointCreateForException(lldb::LanguageType language,
                      (lldb::LanguageType, bool, bool), language, catch_bp,
                      throw_bp);
 
+  // BEGIN SWIFT
   SBStringList no_extra_args;
   return BreakpointCreateForException(language, catch_bp, throw_bp,
                                       no_extra_args);
+  // END SWIFT
 }
 
+// BEGIN SWIFT
 lldb::SBBreakpoint
 SBTarget::BreakpointCreateForException(lldb::LanguageType language,
                                        bool catch_bp, bool throw_bp,
@@ -1118,6 +1123,7 @@ SBTarget::BreakpointCreateForException(lldb::LanguageType language,
 
   return LLDB_RECORD_RESULT(sb_bp);
 }
+// END SWIFT
 
 lldb::SBBreakpoint SBTarget::BreakpointCreateFromScript(
     const char *class_name, SBStructuredData &extra_args,
@@ -1874,6 +1880,7 @@ lldb::SBType SBTarget::FindFirstType(const char *typename_cstr) {
     }
 
     // Didn't find the type in the symbols; Try the loaded language runtimes
+    // BEGIN SWIFT
     // FIXME: This depends on clang, but should be able to support any
     // TypeSystem/compiler.
     if (auto process_sp = target_sp->GetProcessSP()) {
@@ -1892,6 +1899,7 @@ lldb::SBType SBTarget::FindFirstType(const char *typename_cstr) {
         }
       }
     }
+    // END SWIFT
 
     // No matches, search for basic typename matches
     for (auto *type_system : target_sp->GetScratchTypeSystems())
@@ -1937,6 +1945,7 @@ lldb::SBTypeList SBTarget::FindTypes(const char *typename_cstr) {
     }
 
     // Try the loaded language runtimes
+    // BEGIN SWIFT
     // FIXME: This depends on clang, but should be able to support any
     // TypeSystem/compiler.
     if (auto process_sp = target_sp->GetProcessSP()) {
@@ -1956,6 +1965,7 @@ lldb::SBTypeList SBTarget::FindTypes(const char *typename_cstr) {
         }
       }
     }
+    // END SWIFT
 
     if (sb_type_list.GetSize() == 0) {
       // No matches, search for basic typename matches

--- a/lldb/source/API/SBThread.cpp
+++ b/lldb/source/API/SBThread.cpp
@@ -412,14 +412,17 @@ size_t SBThread::GetStopDescription(char *dst, size_t dst_len) {
 SBValue SBThread::GetStopReturnValue() {
   LLDB_RECORD_METHOD_NO_ARGS(lldb::SBValue, SBThread, GetStopReturnValue);
 
+  // BEGIN SWIFT
   bool is_swift_error_value = false;
   SBValue return_value = GetStopReturnOrErrorValue(is_swift_error_value);
   if (is_swift_error_value)
     return SBValue();
   else
     return return_value;
+  // END SWIFT
 }
 
+// BEGIN SWIFT
 SBValue SBThread::GetStopErrorValue() {
   bool is_swift_error_value = false;
   SBValue return_value = GetStopReturnOrErrorValue(is_swift_error_value);
@@ -448,6 +451,7 @@ SBValue SBThread::GetStopReturnOrErrorValue(bool &is_swift_error_value) {
 
   return LLDB_RECORD_RESULT(SBValue(return_valobj_sp));
 }
+// END SWIFT
 
 void SBThread::SetThread(const ThreadSP &lldb_object_sp) {
   m_opaque_sp->SetThreadSP(lldb_object_sp);

--- a/lldb/source/API/SBType.cpp
+++ b/lldb/source/API/SBType.cpp
@@ -158,6 +158,9 @@ bool SBType::IsReferenceType() {
 
   if (!IsValid())
     return false;
+
+  // BEGIN SWIFT
+
   // FIXME: Swift class types are really like references, they are
   // accessed by the same operator as Values, but their value is the
   // location of the type.  But reporting true from the Compiler Type
@@ -169,6 +172,8 @@ bool SBType::IsReferenceType() {
   uint32_t flags = type.GetTypeInfo();
   if (flags & eTypeIsSwift)
     return flags & eTypeHasValue;
+
+  // END SWIFT
 
   return m_opaque_sp->GetCompilerType(true).IsReferenceType();
 }

--- a/lldb/source/API/SystemInitializerFull.cpp
+++ b/lldb/source/API/SystemInitializerFull.cpp
@@ -19,7 +19,6 @@
 #include "lldb/Initialization/SystemInitializerCommon.h"
 #include "lldb/Interpreter/CommandInterpreter.h"
 #include "lldb/Symbol/ClangASTContext.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Utility/Timer.h"
 
 #include "Plugins/ABI/MacOSX-arm/ABIMacOSX_arm.h"
@@ -55,7 +54,6 @@
 #include "Plugins/InstrumentationRuntime/MainThreadChecker/MainThreadCheckerRuntime.h"
 #include "Plugins/InstrumentationRuntime/TSan/TSanRuntime.h"
 #include "Plugins/InstrumentationRuntime/UBSan/UBSanRuntime.h"
-#include "Plugins/InstrumentationRuntime/SwiftRuntimeReporting/SwiftRuntimeReporting.h"
 #include "Plugins/JITLoader/GDB/JITLoaderGDB.h"
 #include "Plugins/Language/CPlusPlus/CPlusPlusLanguage.h"
 #include "Plugins/Language/ObjC/ObjCLanguage.h"
@@ -119,11 +117,13 @@
 #include "lldb/Host/windows/windows.h"
 #endif
 
-#if defined(__APPLE__) || defined(__linux__) || defined(_WIN32)
+// BEGIN SWIFT
 #include "Plugins/ExpressionParser/Swift/SwiftREPL.h"
+#include "Plugins/InstrumentationRuntime/SwiftRuntimeReporting/SwiftRuntimeReporting.h"
 #include "Plugins/Language/Swift/SwiftLanguage.h"
+#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
-#endif
+// END SWIFT
 
 #include "llvm/Support/TargetSelect.h"
 
@@ -140,6 +140,7 @@ SystemInitializerFull::SystemInitializerFull() {}
 
 SystemInitializerFull::~SystemInitializerFull() {}
 
+// BEGIN SWIFT
 static void SwiftInitialize() {
 #if defined(__APPLE__) || defined(__linux__) || defined(_WIN32)
   SwiftLanguage::Initialize();
@@ -155,6 +156,7 @@ static void SwiftTerminate() {
   SwiftREPL::Terminate();
 #endif
 }
+// END SWIFT
 
 #define LLDB_PROCESS_AArch64(op)                                               \
   ABIMacOSX_arm64::op();                                                       \
@@ -231,7 +233,9 @@ llvm::Error SystemInitializerFull::Initialize() {
   llvm::InitializeAllDisassemblers();
 
   ClangASTContext::Initialize();
+  // BEGIN SWIFT
   SwiftASTContext::Initialize();
+  // END SWIFT
 
 #define LLVM_TARGET(t) LLDB_PROCESS_ ## t(Initialize)
 #include "llvm/Config/Targets.def"
@@ -251,7 +255,9 @@ llvm::Error SystemInitializerFull::Initialize() {
   ThreadSanitizerRuntime::Initialize();
   UndefinedBehaviorSanitizerRuntime::Initialize();
   MainThreadCheckerRuntime::Initialize();
+  // BEGIN SWIFT
   SwiftRuntimeReporting::Initialize();
+  // END SWIFT
 
   SymbolVendorELF::Initialize();
   breakpad::SymbolFileBreakpad::Initialize();
@@ -277,7 +283,9 @@ llvm::Error SystemInitializerFull::Initialize() {
   CPlusPlusLanguage::Initialize();
   ObjCLanguage::Initialize();
   ObjCPlusPlusLanguage::Initialize();
+  // BEGIN SWIFT
   ::SwiftInitialize();
+  // END SWIFT
 
 #if defined(_WIN32)
   ProcessWindows::Initialize();
@@ -332,7 +340,9 @@ void SystemInitializerFull::Terminate() {
   PluginManager::Terminate();
 
   ClangASTContext::Terminate();
+  // BEGIN SWIFT
   SwiftASTContext::Terminate();
+  // END SWIFT
 
   ArchitectureArm::Terminate();
   ArchitectureMips::Terminate();
@@ -352,7 +362,9 @@ void SystemInitializerFull::Terminate() {
   ThreadSanitizerRuntime::Terminate();
   UndefinedBehaviorSanitizerRuntime::Terminate();
   MainThreadCheckerRuntime::Terminate();
+  // BEGIN SWIFT
   SwiftRuntimeReporting::Terminate();
+  // END SWIFT
   SymbolVendorELF::Terminate();
   breakpad::SymbolFileBreakpad::Terminate();
   SymbolFileDWARF::Terminate();
@@ -374,7 +386,9 @@ void SystemInitializerFull::Terminate() {
   SystemRuntimeMacOSX::Terminate();
   RenderScriptRuntime::Terminate();
 
+  // BEGIN SWIFT
   ::SwiftTerminate();
+  // END SWIFT
 
   CPlusPlusLanguage::Terminate();
   ObjCLanguage::Terminate();


### PR DESCRIPTION
This is to facilitate identifying divergences and thus encourage
upstreaming them and/or make merge conflict resolutions more obvious.