### PR TITLE
Mark all Swift-specific changes in Breakpoint with comments. NFC

### DIFF
--- a/lldb/source/Breakpoint/BreakpointLocation.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocation.cpp
@@ -254,7 +254,9 @@ bool BreakpointLocation::ConditionSaysStop(ExecutionContext &exe_ctx,
       language = comp_unit->GetLanguage();
 
     m_user_expression_sp.reset(GetTarget().GetUserExpressionForLanguage(
+        // BEGIN SWIFT
         exe_ctx,
+        // END SWIFT
         condition_text, llvm::StringRef(), language, Expression::eResultTypeAny,
         EvaluateExpressionOptions(), nullptr, error));
     if (error.Fail()) {

--- a/lldb/source/Breakpoint/BreakpointResolverFileLine.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverFileLine.cpp
@@ -12,7 +12,6 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/Function.h"
-#include "lldb/Symbol/SymbolFile.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/StreamString.h"
 

--- a/lldb/source/Breakpoint/Watchpoint.cpp
+++ b/lldb/source/Breakpoint/Watchpoint.cpp
@@ -286,9 +286,13 @@ void Watchpoint::SetCondition(const char *condition) {
   } else {
     // Pass nullptr for expr_prefix (no translation-unit level definitions).
     Status error;
+    // BEGIN SWIFT
     ExecutionContext exe_scope(m_target);
+    // END SWIFT
     m_condition_up.reset(m_target.GetUserExpressionForLanguage(
+        // BEGIN SWIFT
         exe_scope,
+        // END SWIFT
         condition, llvm::StringRef(), lldb::eLanguageTypeUnknown,
         UserExpression::eResultTypeAny, EvaluateExpressionOptions(), nullptr,
         error));


### PR DESCRIPTION
This is to facilitate identifying divergences and thus encourage
upstreaming them and/or make merge conflict resolutions more obvious.