### PR TITLE
Rename a flang test case

### DIFF
--- a/clang/test/Driver/flang/flang.f90
+++ b/clang/test/Driver/flang/flang.f90
@@ -1,6 +1,6 @@
 ! Check that flang -fc1 is invoked when in --driver-mode=flang.
 
-! This is a copy of flang.F90 because the driver has logic in it which
+! This is a copy of flang_ucase.F90 because the driver has logic in it which
 ! differentiates between F90 and f90 files. Flang will not treat these files
 ! differently.
 

--- a/clang/test/Driver/flang/flang_ucase.F90
+++ b/clang/test/Driver/flang/flang_ucase.F90
@@ -48,4 +48,4 @@
 ! CHECK-EMIT-OBJ-DAG: "-o" "{{[^"]*}}.o"
 
 ! Should end in the input file.
-! ALL: "{{.*}}flang.F90"{{$}}
+! ALL: "{{.*}}flang_ucase.F90"{{$}}


### PR DESCRIPTION
On Windows and macOS, the filesystem is case insensitive, and these files
interfere with each other. Reading through, the case of the file extension
is part of the test. I've altered the rest of the name instead.

(cherry picked from commit 6c0a160c2d33e54aecf1538bf7c85d8da92051be)