### PR TITLE
test: remove import for `lldbsuite.support.fs`

### DIFF
--- a/lldb/scripts/prepare_bindings.py
+++ b/lldb/scripts/prepare_bindings.py
@@ -17,7 +17,6 @@ import sys
 
 # LLDB modules:
 import use_lldb_suite
-from lldbsuite.support import fs
 
 
 def prepare_binding_for_language(scripts_dir, script_lang, options):


### PR DESCRIPTION
This has been removed upstream and is not used in the script.  Simply
remove the import.