### PR TITLE
Remove unused parameter in ClangASTContext::CreateInstance

### DIFF
--- a/lldb/include/lldb/Symbol/ClangASTContext.h
+++ b/lldb/include/lldb/Symbol/ClangASTContext.h
@@ -68,9 +68,7 @@ public:
   static ConstString GetPluginNameStatic();
 
   static lldb::TypeSystemSP CreateInstance(lldb::LanguageType language,
-                                           Module *module, Target *target,
-                                           const char *compiler_options);
-
+                                           Module *module, Target *target);
   static LanguageSet GetSupportedLanguagesForTypes();
   static LanguageSet GetSupportedLanguagesForExpressions();
 

--- a/lldb/source/Symbol/ClangASTContext.cpp
+++ b/lldb/source/Symbol/ClangASTContext.cpp
@@ -555,10 +555,9 @@ ConstString ClangASTContext::GetPluginName() {
 
 uint32_t ClangASTContext::GetPluginVersion() { return 1; }
 
-lldb::TypeSystemSP
-ClangASTContext::CreateInstance(lldb::LanguageType language,
-                                lldb_private::Module *module, Target *target,
-                                const char *compiler_options) {
+lldb::TypeSystemSP ClangASTContext::CreateInstance(lldb::LanguageType language,
+                                                   lldb_private::Module *module,
+                                                   Target *target) {
   if (ClangASTContextSupportsLanguage(language)) {
     ArchSpec arch;
     if (module)


### PR DESCRIPTION
Also restores the formatting we use upstream to fully get rid of this downstream change.