### PR TITLE
Revert added friend decl in SBError.h

### DIFF
--- a/lldb/include/lldb/API/SBError.h
+++ b/lldb/include/lldb/API/SBError.h
@@ -61,7 +61,6 @@ protected:
   friend class SBData;
   friend class SBDebugger;
   friend class SBHostOS;
-  friend class SBModule;
   friend class SBPlatform;
   friend class SBProcess;
   friend class SBReproducer;


### PR DESCRIPTION
That's a difference from upstream.