### PR TITLE
Stop xcode build scripts' attempt to check out other sources.

### DIFF
--- a/lldb/scripts/Xcode/build-llvm.py
+++ b/lldb/scripts/Xcode/build-llvm.py
@@ -58,6 +58,7 @@ def dirs_exist(names):
     return True
 
 def XCODE_REPOSITORIES():
+    return []
     names = ["llvm", "clang", "swift", "cmark", "ninja"]
     if dirs_exist(names):
         return [fallback_repo(n) for n in names]


### PR DESCRIPTION
The trees are already all checked out; it doesn't need to
worry about this.