### PR TITLE
[upstreaming] Revert adding empty implementation of deregisterEHFrames

### DIFF
--- a/lldb/include/lldb/Expression/IRExecutionUnit.h
+++ b/lldb/include/lldb/Expression/IRExecutionUnit.h
@@ -310,10 +310,6 @@ private:
     void registerEHFrames(uint8_t *Addr, uint64_t LoadAddr,
                           size_t Size) override {}
 
-    virtual void deregisterEHFrames() override {
-      return;
-    }
-
     uint64_t getSymbolAddress(const std::string &Name) override;
     
     // Find the address of the symbol Name.  If Name is a missing weak symbol


### PR DESCRIPTION
We already disabled the registration, so this is no-op.