### PR TITLE
[upstreaming] Revert changes to {Clang}ExpressionParser::Parse

### DIFF
--- a/lldb/include/lldb/Expression/ExpressionParser.h
+++ b/lldb/include/lldb/Expression/ExpressionParser.h
@@ -76,19 +76,6 @@ public:
   virtual bool Complete(CompletionRequest &request, unsigned line, unsigned pos,
                         unsigned typed_pos) = 0;
 
-  /// Parse a single expression and convert it to IR using Clang.  Don't wrap
-  /// the expression in anything at all.
-  ///
-  /// \param[in] diagnostic_manager
-  ///     The diagnostic manager in which to store the errors and warnings.
-  ///
-  /// \return
-  ///     The number of errors encountered during parsing.  0 means
-  ///     success.
-  virtual unsigned Parse(DiagnosticManager &diagnostic_manager,
-                         uint32_t first_line = 0,
-                         uint32_t last_line = UINT32_MAX) = 0;
-
   /// Try to use the FixIts in the diagnostic_manager to rewrite the
   /// expression.  If successful, the rewritten expression is stored in the
   /// diagnostic_manager, get it out with GetFixedExpression.

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -859,12 +859,7 @@ bool ClangExpressionParser::Complete(CompletionRequest &request, unsigned line,
   return true;
 }
 
-// Swift only
-// Extra arguments are only used in Swift. We should get rid of them
-// to avoid clashes when merging from upstream.
-// End Swift only
-unsigned ClangExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
-                                      uint32_t first_line, uint32_t last_line) {
+unsigned ClangExpressionParser::Parse(DiagnosticManager &diagnostic_manager) {
   return ParseInternal(diagnostic_manager);
 }
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.h
@@ -72,9 +72,7 @@ public:
   /// \return
   ///     The number of errors encountered during parsing.  0 means
   ///     success.
-  //------------------------------------------------------------------
-  unsigned Parse(DiagnosticManager &diagnostic_manager, uint32_t first_line = 0,
-                 uint32_t last_line = UINT32_MAX) override;
+  unsigned Parse(DiagnosticManager &diagnostic_manager);
 
   bool RewriteExpression(DiagnosticManager &diagnostic_manager) override;
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangFunctionCaller.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangFunctionCaller.cpp
@@ -186,10 +186,10 @@ ClangFunctionCaller::CompileFunction(lldb::ThreadSP thread_to_use_sp,
   lldb::ProcessSP jit_process_sp(m_jit_process_wp.lock());
   if (jit_process_sp) {
     const bool generate_debug_info = true;
-    m_parser.reset(new ClangExpressionParser(jit_process_sp.get(), *this,
-                                             generate_debug_info));
-
-    num_errors = m_parser->Parse(diagnostic_manager);
+    auto *clang_parser = new ClangExpressionParser(jit_process_sp.get(), *this,
+                                                   generate_debug_info);
+    num_errors = clang_parser->Parse(diagnostic_manager);
+    m_parser.reset(clang_parser);
   } else {
     diagnostic_manager.PutString(eDiagnosticSeverityError,
                                  "no process - unable to inject function");

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -83,7 +83,7 @@ public:
   ///     success.
   //------------------------------------------------------------------
   unsigned Parse(DiagnosticManager &diagnostic_manager, uint32_t first_line = 0,
-                 uint32_t last_line = UINT32_MAX) override;
+                 uint32_t last_line = UINT32_MAX);
 
   //------------------------------------------------------------------
   /// Ready an already-parsed expression for execution, possibly

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -377,12 +377,11 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
     exe_scope = exe_ctx.GetTargetPtr();
   } while (0);
 
-  m_parser =
-      std::make_unique<SwiftExpressionParser>(exe_scope, *this, m_options);
-
-  unsigned error_code = m_parser->Parse(
+  auto *swift_parser = new SwiftExpressionParser(exe_scope, *this, m_options);
+  unsigned error_code = swift_parser->Parse(
       diagnostic_manager, first_body_line,
       first_body_line + source_code->GetNumBodyLines());
+  m_parser.reset(swift_parser);
 
   if (error_code == 2) {
     m_fixed_text = m_expr_text;


### PR DESCRIPTION
I do the same refactoring in LLVM's upstream: https://reviews.llvm.org/D69710 This is the same change but also adapt the SwiftExpressionParser to the new API.