### PR TITLE
[upstreaming] Revert changes to EmulateInstructionMIPS64.cpp

### DIFF
--- a/lldb/source/Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.cpp
+++ b/lldb/source/Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.cpp
@@ -975,13 +975,10 @@ bool EmulateInstructionMIPS64::EvaluateInstruction(uint32_t evaluate_options) {
    * mc_insn.getOpcode() returns decoded opcode. However to make use
    * of llvm::Mips::<insn> we would need "MipsGenInstrInfo.inc".
   */
-  llvm::StringRef op_name_ref = m_insn_info->getName(mc_insn.getOpcode());
+  const char *op_name = m_insn_info->getName(mc_insn.getOpcode()).data();
 
-  if (op_name_ref.empty())
+  if (op_name == nullptr)
     return false;
-
-  std::string op_name_str = op_name_ref;
-  const char *op_name = op_name_str.c_str();
 
   /*
    * Decoding has been done already. Just get the call-back function
@@ -1267,9 +1264,7 @@ bool EmulateInstructionMIPS64::Emulate_DSUBU_DADDU(llvm::MCInst &insn) {
   bool success = false;
   uint64_t result;
   uint8_t src, dst, rt;
-  llvm::StringRef op_name_ref = m_insn_info->getName(insn.getOpcode());
-  std::string op_name_str = op_name_ref;
-  const char *op_name = op_name_str.c_str();
+  const char *op_name = m_insn_info->getName(insn.getOpcode()).data();
 
   dst = m_reg_info->getEncodingValue(insn.getOperand(0).getReg());
   src = m_reg_info->getEncodingValue(insn.getOperand(1).getReg());
@@ -1348,9 +1343,7 @@ bool EmulateInstructionMIPS64::Emulate_BXX_3ops(llvm::MCInst &insn) {
   bool success = false;
   uint32_t rs, rt;
   int64_t offset, pc, rs_val, rt_val, target = 0;
-  llvm::StringRef op_name_ref = m_insn_info->getName(insn.getOpcode());
-  std::string op_name_str = op_name_ref;
-  const char *op_name = op_name_str.c_str();
+  const char *op_name = m_insn_info->getName(insn.getOpcode()).data();
 
   rs = m_reg_info->getEncodingValue(insn.getOperand(0).getReg());
   rt = m_reg_info->getEncodingValue(insn.getOperand(1).getReg());
@@ -1402,9 +1395,7 @@ bool EmulateInstructionMIPS64::Emulate_Bcond_Link(llvm::MCInst &insn) {
   uint32_t rs;
   int64_t offset, pc, target = 0;
   int64_t rs_val;
-  llvm::StringRef op_name_ref = m_insn_info->getName(insn.getOpcode());
-  std::string op_name_str = op_name_ref;
-  const char *op_name = op_name_str.c_str();
+  const char *op_name = m_insn_info->getName(insn.getOpcode()).data();
 
   rs = m_reg_info->getEncodingValue(insn.getOperand(0).getReg());
   offset = insn.getOperand(1).getImm();
@@ -1514,9 +1505,7 @@ bool EmulateInstructionMIPS64::Emulate_Bcond_Link_C(llvm::MCInst &insn) {
   bool success = false;
   uint32_t rs;
   int64_t offset, pc, rs_val, target = 0;
-  llvm::StringRef op_name_ref = m_insn_info->getName(insn.getOpcode());
-  std::string op_name_str = op_name_ref;
-  const char *op_name = op_name_str.c_str();
+  const char *op_name = m_insn_info->getName(insn.getOpcode()).data();
 
   rs = m_reg_info->getEncodingValue(insn.getOperand(0).getReg());
   offset = insn.getOperand(1).getImm();
@@ -1584,9 +1573,7 @@ bool EmulateInstructionMIPS64::Emulate_BXX_2ops(llvm::MCInst &insn) {
   bool success = false;
   uint32_t rs;
   int64_t offset, pc, rs_val, target = 0;
-  llvm::StringRef op_name_ref = m_insn_info->getName(insn.getOpcode());
-  std::string op_name_str = op_name_ref;
-  const char *op_name = op_name_str.c_str();
+  const char *op_name = m_insn_info->getName(insn.getOpcode()).data();
 
   rs = m_reg_info->getEncodingValue(insn.getOperand(0).getReg());
   offset = insn.getOperand(1).getImm();
@@ -1671,9 +1658,7 @@ bool EmulateInstructionMIPS64::Emulate_BXX_3ops_C(llvm::MCInst &insn) {
   bool success = false;
   uint32_t rs, rt;
   int64_t offset, pc, rs_val, rt_val, target = 0;
-  llvm::StringRef op_name_ref = m_insn_info->getName(insn.getOpcode());
-  std::string op_name_str = op_name_ref;
-  const char *op_name = op_name_str.c_str();
+  const char *op_name = m_insn_info->getName(insn.getOpcode()).data();
   uint32_t current_inst_size = m_insn_info->get(insn.getOpcode()).getSize();
 
   rs = m_reg_info->getEncodingValue(insn.getOperand(0).getReg());
@@ -1753,9 +1738,7 @@ bool EmulateInstructionMIPS64::Emulate_BXX_2ops_C(llvm::MCInst &insn) {
   uint32_t rs;
   int64_t offset, pc, target = 0;
   int64_t rs_val;
-  llvm::StringRef op_name_ref = m_insn_info->getName(insn.getOpcode());
-  std::string op_name_str = op_name_ref;
-  const char *op_name = op_name_str.c_str();
+  const char *op_name = m_insn_info->getName(insn.getOpcode()).data();
   uint32_t current_inst_size = m_insn_info->get(insn.getOpcode()).getSize();
 
   rs = m_reg_info->getEncodingValue(insn.getOperand(0).getReg());
@@ -1995,9 +1978,7 @@ bool EmulateInstructionMIPS64::Emulate_FP_branch(llvm::MCInst &insn) {
   bool success = false;
   uint32_t cc, fcsr;
   int64_t pc, offset, target = 0;
-  llvm::StringRef op_name_ref = m_insn_info->getName(insn.getOpcode());
-  std::string op_name_str = op_name_ref;
-  const char *op_name = op_name_str.c_str();
+  const char *op_name = m_insn_info->getName(insn.getOpcode()).data();
 
   /*
    * BC1F cc, offset
@@ -2122,9 +2103,7 @@ bool EmulateInstructionMIPS64::Emulate_3D_branch(llvm::MCInst &insn) {
   bool success = false;
   uint32_t cc, fcsr;
   int64_t pc, offset, target = 0;
-  llvm::StringRef op_name_ref = m_insn_info->getName(insn.getOpcode());
-  std::string op_name_str = op_name_ref;
-  const char *op_name = op_name_str.c_str();
+  const char *op_name = m_insn_info->getName(insn.getOpcode()).data();
 
   cc = m_reg_info->getEncodingValue(insn.getOperand(0).getReg());
   offset = insn.getOperand(1).getImm();


### PR DESCRIPTION
This wasn't correctly merged it seems and is also not in swift/master,
so let's remove it.