### PR TITLE
[upstreaming] Include TargetOptions.h in SwiftASTContext

### DIFF
--- a/lldb/include/lldb/Core/ClangForward.h
+++ b/lldb/include/lldb/Core/ClangForward.h
@@ -128,7 +128,6 @@ class APInt;
 class APSInt;
 class LLVMContext;
 class ExecutionEngine;
-class TargetOptions;
 }
 
 #endif // #if defined(__cplusplus)

--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -27,6 +27,7 @@
 
 #include "llvm/ADT/Optional.h"
 #include "llvm/Support/Threading.h"
+#include "llvm/Target/TargetOptions.h"
 
 #include <map>
 #include <set>


### PR DESCRIPTION
Otherwise we need to upstream forward declaration in ClangForward.h
(and there is no other user of llvm::TargetOptions in LLDB that could
need it, so that would be dead code).