### PR TITLE
[dsymutil] Add DW_TAG_common_block to dieNeedsChildrenToBeMeaningful

### DIFF
--- a/llvm/tools/dsymutil/DwarfLinker.cpp
+++ b/llvm/tools/dsymutil/DwarfLinker.cpp
@@ -359,11 +359,12 @@ static bool dieNeedsChildrenToBeMeaningful(uint32_t Tag) {
   switch (Tag) {
   default:
     return false;
-  case dwarf::DW_TAG_subprogram:
-  case dwarf::DW_TAG_lexical_block:
-  case dwarf::DW_TAG_subroutine_type:
-  case dwarf::DW_TAG_structure_type:
   case dwarf::DW_TAG_class_type:
+  case dwarf::DW_TAG_common_block:
+  case dwarf::DW_TAG_lexical_block:
+  case dwarf::DW_TAG_structure_type:
+  case dwarf::DW_TAG_subprogram:
+  case dwarf::DW_TAG_subroutine_type:
   case dwarf::DW_TAG_union_type:
     return true;
   }


### PR DESCRIPTION
Ensure we walk the children of common blocks when deciding what DIEs to
keep. Otherwise we might incorrectly discard them leading to missing
variables in the linked debug info.

This also sorts the list of DW_TAGs alphabetically.

(cherry picked from commit 96bbf478b6718b13b19ac52fd790e64d4ed56fe9)