### PR TITLE
[CodeView] Add pragma push/pop_macro for ARM64_FPSR to enum header

### DIFF
--- a/llvm/include/llvm/DebugInfo/CodeView/CodeViewRegisters.def
+++ b/llvm/include/llvm/DebugInfo/CodeView/CodeViewRegisters.def
@@ -368,6 +368,11 @@ CV_REGISTER(AMD64_K7, 765)
 
 #if defined(CV_REGISTERS_ALL) || defined(CV_REGISTERS_ARM64)
 
+// arm64intr.h from MSVC defines ARM64_FPSR, which conflicts with
+// these declarations.
+#pragma push_macro("ARM64_FPSR")
+#undef ARM64_FPSR
+
 // ARM64 registers
 
 CV_REGISTER(ARM64_NOREG, 0)
@@ -555,5 +560,7 @@ CV_REGISTER(ARM64_Q31, 211)
 // Floating point status register
 
 CV_REGISTER(ARM64_FPSR, 220)
+
+#pragma pop_macro("ARM64_FPSR")
 
 #endif // defined(CV_REGISTERS_ALL) || defined(CV_REGISTERS_ARM64)


### PR DESCRIPTION
This fixes (one aspect of) compilation of LLDB with MSVC for ARM64.

LLDB source files include intrin.h, and the MSVC intrin.h transitively
includes arm64intr.h, which has an ARM64_FPSR define, which clashes
with the enum declaration.

Differential Revision: https://reviews.llvm.org/D67864

llvm-svn: 372481
(cherry picked from commit 1bfdab52a76bf667aa345b5026f1d524ed6d4ac8)