### PR TITLE
Adapt to Swift compiler representation change of bound generic enums.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lang/swift/optimized_code/bound_generic_enum/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/optimized_code/bound_generic_enum/Makefile
@@ -1,0 +1,7 @@
+LEVEL = ../../../../make
+
+SWIFT_SOURCES := main.swift
+
+SWIFTFLAGS_EXTRAS := -Xfrontend -disable-debugger-shadow-copies
+
+include $(LEVEL)/Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/optimized_code/bound_generic_enum/TestSwiftOptimizedBoundGenericEnum.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/optimized_code/bound_generic_enum/TestSwiftOptimizedBoundGenericEnum.py
@@ -1,0 +1,29 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+
+class TestSwiftOptimizedBoundGenericEnum(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    def test(self):
+        """Test the bound generic enum types in "optimized" code."""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(self,
+            'break one', lldb.SBFileSpec('main.swift'))
+        bkpt_two = target.BreakpointCreateBySourceRegex(
+            'break two', lldb.SBFileSpec('main.swift'))
+        self.assertGreater(bkpt_two.GetNumLocations(), 0)
+
+
+        var_self = self.frame().FindVariable("self")
+        # FIXME, this fails with a data extractor error.
+        lldbutil.check_variable(self, var_self, False, value=None)
+        lldbutil.continue_to_breakpoint(process, bkpt_two)
+        var_self = self.frame().FindVariable("self")
+        lldbutil.check_variable(self, var_self, True, value="success")

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/optimized_code/bound_generic_enum/main.swift
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/optimized_code/bound_generic_enum/main.swift
@@ -1,0 +1,40 @@
+public enum Result<Value> {
+  case success(Value)
+  case failure(Error)
+}
+
+extension Result {
+  public func map<U>(_ transform: (Value) -> U) -> Result<U> {
+    switch self {
+    case .success(let value):
+      return .success(transform(value))
+    case .failure(let error):
+      return .failure(error)
+    }
+  }
+}
+
+func use<T>(_ t : T) {
+}
+
+public class SomeClass {
+  public let s = "hello"
+}
+
+extension Result where Value : SomeClass {
+  public func f() -> Self {
+    use(self) // break one
+    return map({ $0 })
+  }  
+}
+
+extension Result {
+  public func g() {
+    use(self) // break two
+  }  
+}
+
+let x : Result<SomeClass> = .success(SomeClass())
+let y : Result<(Int64, Int64, Int64, Int64)> = .success((1, 2, 3, 4))
+x.f()
+y.g()

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -112,6 +112,13 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
     }
   }
 
+  if (!name && !mangled_name && die.Tag() == DW_TAG_structure_type) {
+    DWARFDIE type_die =
+      die.GetFirstChild().GetAttributeValueAsReferenceDIE(DW_AT_type);
+    // This is a sized container for a bound generic.
+    return ParseTypeFromDWARF(sc, type_die, log, type_is_new_ptr);
+  }
+
   if (!mangled_name && name) {
     if (name.GetStringRef().equals("$swift.fixedbuffer")) {
       DWARFDIE type_die =


### PR DESCRIPTION
They are now  nested inside a container struct to  avoid type uniquing
clashes.

rdar://problem/56521648