### PR TITLE
Static analyzer cherrypicks 2

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
@@ -2034,8 +2034,6 @@ bool bugreporter::trackExpressionValue(const ExplodedNode *InputNode,
 
   // Is it a symbolic value?
   if (auto L = V.getAs<loc::MemRegionVal>()) {
-    report.addVisitor(llvm::make_unique<UndefOrNullArgVisitor>(L->getRegion()));
-
     // FIXME: this is a hack for fixing a later crash when attempting to
     // dereference a void* pointer.
     // We should not try to dereference pointers at all when we don't care
@@ -2056,10 +2054,14 @@ bool bugreporter::trackExpressionValue(const ExplodedNode *InputNode,
     else if (CanDereference)
       RVal = LVState->getSVal(L->getRegion());
 
-    if (CanDereference)
+    if (CanDereference) {
+      report.addVisitor(
+          std::make_unique<UndefOrNullArgVisitor>(L->getRegion()));
+
       if (auto KV = RVal.getAs<KnownSVal>())
         report.addVisitor(llvm::make_unique<FindLastStoreBRVisitor>(
             *KV, L->getRegion(), EnableNullFPSuppression, TKind, SFC));
+    }
 
     const MemRegion *RegionRVal = RVal.getAsRegion();
     if (RegionRVal && isa<SymbolicRegion>(RegionRVal)) {

--- a/clang/test/Analysis/novoidtypecrash.c
+++ b/clang/test/Analysis/novoidtypecrash.c
@@ -1,8 +1,27 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=core %s
+x;
+y(void **z) { // no-crash
+  *z = x;
+  int *w;
+  y(&w);
+  *w;
+}
+
 a;
-b(void **c) { // no-crash
-  *c = a;
-  int *d;
-  b(&d);
-  *d;
+b(*c) {}
+e(*c) {
+  void *d = f();
+  b(d);
+  *c = d;
+}
+void *g() {
+  e(&a);
+  return a;
+}
+j() {
+  int h;
+  char i = g();
+  if (i)
+    for (; h;)
+      ;
 }

--- a/clang/test/Analysis/track-control-dependency-conditions.m
+++ b/clang/test/Analysis/track-control-dependency-conditions.m
@@ -1,0 +1,32 @@
+// RUN: %clang_analyze_cc1 -w -analyzer-checker=core,nullability -verify %s
+
+// expected-no-diagnostics
+
+@class C;
+
+#pragma clang assume_nonnull begin
+@interface I
+- foo:(C *)c;
+@end
+#pragma clang assume_nonnull end
+
+@interface J
+@property C *c;
+@end
+
+J *conjure_J();
+
+@implementation I
+- (void)bar {
+  if (self) { // no-crash
+    J *j = conjure_J();
+    if (j.c)
+      [self bar];
+    // FIXME: Should warn.
+    [self foo:j.c]; // no-warning
+  }
+}
+@end
+
+@implementation J
+@end


### PR DESCRIPTION
Clang Static Analyzer is traditionally kept reasonably fresh on stable branches through continuous cherry-picking.