### PR TITLE
[lldb] Make sure to eliminate ownership after the diagnostic passes, …

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1673,6 +1673,7 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   }
 
   runSILDiagnosticPasses(*sil_module);
+  runSILOwnershipEliminatorPass(*sil_module);
 
   if (log) {
     std::string s;


### PR DESCRIPTION
…but before IRGen.

Before I flip the switch, this will be a no-op. It is needed though after I flip
the switch since IRgen is not meant to see ownership SIL.