### PR TITLE
[upstreaming] Revert downstream changes to {Clang}ExpressionParser and update SwiftExpressionParser

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -871,12 +871,7 @@ bool ClangExpressionParser::Complete(CompletionRequest &request, unsigned line,
   return true;
 }
 
-// Swift only
-// Extra arguments are only used in Swift. We should get rid of them
-// to avoid clashes when merging from upstream.
-// End Swift only
-unsigned ClangExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
-                                      uint32_t first_line, uint32_t last_line) {
+unsigned ClangExpressionParser::Parse(DiagnosticManager &diagnostic_manager) {
   return ParseInternal(diagnostic_manager);
 }
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -83,7 +83,7 @@ public:
   ///     success.
   //------------------------------------------------------------------
   unsigned Parse(DiagnosticManager &diagnostic_manager, uint32_t first_line = 0,
-                 uint32_t last_line = UINT32_MAX) override;
+                 uint32_t last_line = UINT32_MAX);
 
   //------------------------------------------------------------------
   /// Ready an already-parsed expression for execution, possibly

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -377,12 +377,11 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
     exe_scope = exe_ctx.GetTargetPtr();
   } while (0);
 
-  m_parser =
-      std::make_unique<SwiftExpressionParser>(exe_scope, *this, m_options);
-
-  unsigned error_code = m_parser->Parse(
+  auto *swift_parser = new SwiftExpressionParser(exe_scope, *this, m_options);
+  unsigned error_code = swift_parser->Parse(
       diagnostic_manager, first_body_line,
       first_body_line + source_code->GetNumBodyLines());
+  m_parser.reset(swift_parser);
 
   if (error_code == 2) {
     m_fixed_text = m_expr_text;


### PR DESCRIPTION
D69710 landed which allows us to implement the SwiftExpressionParser without changing
the ClangExpressionParser