### PR TITLE
clang/Modules: fix a use-after-free when a CompilerInstance is reused

### DIFF
--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -126,10 +126,6 @@ class CompilerInstance : public ModuleLoader {
 
   std::vector<std::shared_ptr<DependencyCollector>> DependencyCollectors;
 
-  /// The set of top-level modules that has already been loaded,
-  /// along with the module map
-  llvm::DenseMap<const IdentifierInfo *, Module *> KnownModules;
-
   /// The set of top-level modules that has already been built on the
   /// fly as part of this overall compilation action.
   std::map<std::string, std::string> BuiltModules;

--- a/clang/include/clang/Lex/ModuleMap.h
+++ b/clang/include/clang/Lex/ModuleMap.h
@@ -14,17 +14,18 @@
 #ifndef LLVM_CLANG_LEX_MODULEMAP_H
 #define LLVM_CLANG_LEX_MODULEMAP_H
 
+#include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/Module.h"
 #include "clang/Basic/SourceLocation.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PointerIntPair.h"
-#include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/ADT/Twine.h"
 #include <ctime>
@@ -107,6 +108,10 @@ class ModuleMap {
 
   /// The top-level modules that are known.
   llvm::StringMap<Module *> Modules;
+
+  /// Module loading cache that includes submodules, indexed by IdentifierInfo.
+  /// nullptr is stored for modules that are known to fail to load.
+  llvm::DenseMap<const IdentifierInfo *, Module *> CachedModuleLoads;
 
   /// Shadow modules created while building this module map.
   llvm::SmallVector<Module*, 2> ShadowModules;
@@ -695,6 +700,16 @@ public:
 
   module_iterator module_begin() const { return Modules.begin(); }
   module_iterator module_end()   const { return Modules.end(); }
+
+  /// Cache a module load.  M might be nullptr.
+  void cacheModuleLoad(const IdentifierInfo &II, Module *M) {
+    CachedModuleLoads[&II] = M;
+  }
+
+  /// Return a cached module load.
+  Module *getCachedModuleLoad(const IdentifierInfo &II) {
+    return CachedModuleLoads.lookup(&II);
+  }
 };
 
 } // namespace clang

--- a/clang/include/clang/Lex/ModuleMap.h
+++ b/clang/include/clang/Lex/ModuleMap.h
@@ -707,8 +707,11 @@ public:
   }
 
   /// Return a cached module load.
-  Module *getCachedModuleLoad(const IdentifierInfo &II) {
-    return CachedModuleLoads.lookup(&II);
+  llvm::Optional<Module *> getCachedModuleLoad(const IdentifierInfo &II) {
+    auto I = CachedModuleLoads.find(&II);
+    if (I == CachedModuleLoads.end())
+      return None;
+    return I->second;
   }
 };
 

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1652,10 +1652,11 @@ CompilerInstance::loadModule(SourceLocation ImportLoc,
   }
 
   // If we don't already have information on this module, load the module now.
+  Module *Module = nullptr;
   ModuleMap &MM = getPreprocessor().getHeaderSearchInfo().getModuleMap();
-  clang::Module *Module = MM.getCachedModuleLoad(*Path[0].first);
-  if (Module) {
-    // Nothing to do here, we found it.
+  if (auto MaybeModule = MM.getCachedModuleLoad(*Path[0].first)) {
+    // Use the cached result, which may be nullptr.
+    Module = *MaybeModule;
   } else if (ModuleName == getLangOpts().CurrentModule) {
     // This is the module we're building.
     Module = PP->getHeaderSearchInfo().lookupModule(


### PR DESCRIPTION
Swift's ClangImporter appears to reuse the same CompilerInstance for different FrontendActions.  This fixes a use-after-free that occurs in that scenario.  It's possible it'll fix a persistent "missing submodule 'X'" problem that has been showing up on Linux bots.