### PR TITLE
[upstreaming] Move swift-specific functions in PlatformDarwin to SwiftASTContext

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1671,60 +1671,6 @@ lldb_private::FileSpec PlatformDarwin::LocateExecutable(const char *basename) {
   return FileSpec();
 }
 
-bool PlatformDarwin::IsUnitTestExecutable(lldb_private::Module &module) {
-  static ConstString s_xctest("xctest");
-  static ConstString s_XCTRunner("XCTRunner");
-  ConstString executable_name = module.GetFileSpec().GetFilename();
-  return (executable_name == s_xctest || executable_name == s_XCTRunner);
-}
-
-lldb::ModuleSP
-PlatformDarwin::GetUnitTestModule(lldb_private::ModuleList &modules) {
-  ConstString test_bundle_executable;
-
-  for (size_t mi = 0, num_images = modules.GetSize(); mi != num_images; ++mi) {
-    ModuleSP module_sp = modules.GetModuleAtIndex(mi);
-
-    std::string module_path = module_sp->GetFileSpec().GetPath();
-
-    const char deep_substr[] = ".xctest/Contents/";
-    size_t pos = module_path.rfind(deep_substr);
-    if (pos == std::string::npos) {
-      const char flat_substr[] = ".xctest/";
-      pos = module_path.rfind(flat_substr);
-
-      if (pos == std::string::npos) {
-        continue;
-      } else {
-        module_path.erase(pos + strlen(flat_substr));
-      }
-    } else {
-      module_path.erase(pos + strlen(deep_substr));
-    }
-
-    if (!test_bundle_executable) {
-      module_path.append("Info.plist");
-
-      ApplePropertyList info_plist(module_path.c_str());
-
-      std::string cf_bundle_executable;
-      if (info_plist.GetValueAsString("CFBundleExecutable",
-                                      cf_bundle_executable)) {
-        test_bundle_executable = ConstString(cf_bundle_executable);
-      } else {
-        return ModuleSP();
-      }
-    }
-
-    if (test_bundle_executable &&
-        module_sp->GetFileSpec().GetFilename() == test_bundle_executable) {
-      return module_sp;
-    }
-  }
-
-  return ModuleSP();
-}
-
 lldb_private::Status
 PlatformDarwin::LaunchProcess(lldb_private::ProcessLaunchInfo &launch_info) {
   // Starting in Fall 2016 OSes, NSLog messages only get mirrored to stderr if

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -73,9 +73,6 @@ public:
 
   lldb_private::FileSpec LocateExecutable(const char *basename) override;
 
-  static bool IsUnitTestExecutable(lldb_private::Module &module);
-  static lldb::ModuleSP GetUnitTestModule(lldb_private::ModuleList &modules);
-
   lldb_private::Status
   LaunchProcess(lldb_private::ProcessLaunchInfo &launch_info) override;
 


### PR DESCRIPTION
These functions are only used there, so no need to touch upstream files to
implement them. They also don't use any PlatformDarwin logic.