### PR TITLE
[upstreaming] Revert downstream changes to gdb-remote/CMakeLists.txt

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/gdb-remote/CMakeLists.txt
@@ -8,8 +8,6 @@ lldb_tablegen(ProcessGDBRemotePropertiesEnum.inc -gen-lldb-property-enum-defs
 
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
   include_directories(${LIBXML2_INCLUDE_DIR})
-elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
-  list(APPEND LLDB_PLUGINS lldbPluginProcessLinux)
 endif()
 
 set(LLDB_PLUGINS


### PR DESCRIPTION
This change is not doing anything as appending anything LLDB_PLUGINS
will be overwritten in the next line when set call set(LLDB_PLUGINS ...).