### PR TITLE
fix duplicate request function registration

### DIFF
--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -3473,9 +3473,6 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
   registerParseRequestFunctions(m_ast_context_ap->evaluator);
   registerTypeCheckerRequestFunctions(m_ast_context_ap->evaluator);
 
-  // SWIFT_ENABLE_TENSORFLOW
-  registerIDERequestFunctions(m_ast_context_ap->evaluator);
-
   GetASTMap().Insert(m_ast_context_ap.get(), this);
 
   VALID_OR_RETURN(nullptr);


### PR DESCRIPTION
Upstream recently added `registerIDERequestFunctions`. We had previously added it as a tensorflow patch. So we're now calling it twice, which is forbidden. This PR removes our call, putting us in sync with upstream.

This fixes the following error from https://github.com/apple/swift/pull/28080#issuecomment-549960297:
```
lldb: /home/danielzheng/swift-merge2/swift/lib/AST/Evaluator.cpp:58: void swift::Evaluator::registerRequestFunctions(swift::Zone, ArrayRef<swift::AbstractRequestFunction *>): Assertion `zone.first != zoneID' failed.
```