### PR TITLE
fix TestSwiftCompletions for merge

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lang/swift/completions/TestSwiftCompletions.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/completions/TestSwiftCompletions.py
@@ -20,7 +20,6 @@ class TestSwiftCompletions(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
-    @decorators.add_test_categories(["swiftpr"])
     def test_completions(self):
         self.build()
         self.do_test()

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/completions/TestSwiftCompletions.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/completions/TestSwiftCompletions.py
@@ -198,24 +198,6 @@ class TestSwiftCompletions(TestBase):
             }
             Base().""",
             ["replacedFunc()", "self"])
-        # Asking for completions multiple times when an extension is defined in
-        # your cell causes the extenion's function to appear multiple times in
-        # the completion.
-        self.assertCompletions(
-            """
-            extension Base {
-              func replacedFunc () {}
-            }
-            Base().""",
-            ["replacedFunc", "replacedFunc()", "self"])
-        self.evaluate("""
-                      extension Base {
-                        func replacedFunc() {}
-                      }
-                      """)
-        self.assertCompletions(
-            """Base().""",
-            ["replacedFunc", "replacedFunc()", "self"])
 
         # === Redefining a func in an extension ===
 


### PR DESCRIPTION
**Removes swiftpr tag**

This tag was removed in upstream in https://github.com/apple/swift-lldb/pull/1517, causing a test error in our branch:
```
UNRESOLVED: lldb-Suite :: lang/swift/completions/TestSwiftCompletions.py (103 of 300)
******************** TEST 'lldb-Suite :: lang/swift/completions/TestSwiftCompletions.py' FAILED ********************
Unable to find 'RESULT: PASSED' in dotest output (exit code 1):

lldb version 7.0.0 (https://github.com/apple/llvm-project.git revision 44c229456377f2ac4ea8fce3718786da80e9933f)
Swift version 5.1.1-dev (Swift ca180f8775)
LLDB library dir: /usr/local/google/home/marcrasi/swift-base-merge/build/buildbot_linux/lldb-linux-x86_64/bin
LLDB import library dir: /usr/local/google/home/marcrasi/swift-base-merge/build/buildbot_linux/lldb-linux-x86_64/bin
Libc++ tests will not be run because: Unable to find libc++ installation
Skipping following debug info categories: ['dsym', 'gmodules']
fatal error: category 'swiftpr' is not a valid category
if you have added a new category, please edit test_categories.py, adding your new category to all_categories
else, please specify one or more of the following: ['libc++', 'stresstest', 'dwarf', 'gmodules', 'darwin-log', 'watchpoint', 'libstdcxx', 'basic_process', 'cmdline', 'objc', 'dataformatters', 'flakey', 'pyapi', 'frame-diagnose', 'expression', 'dwo', 'dyntype', 'dsym']

********************
```

Not sure why the test error is only showing up now, since https://github.com/apple/swift-lldb/pull/1517 was merged many months ago. Anyways, this PR should fix it.

**Updates assertion**

We had an assertion asserting some incorrect behavior. The behavior has fixed itself, updated the assertion.