### PR TITLE
SwiftDWARFImporterDelegate: Add an early exit for mangled Swift names.

### DIFF
--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -3231,6 +3231,10 @@ public:
   void lookupValue(StringRef name, llvm::Optional<swift::ClangTypeKind> kind,
                    StringRef inModule,
                    llvm::SmallVectorImpl<clang::Decl *> &results) override {
+    // We will not find any Swift types in the Clang compile units.
+    if (SwiftLanguageRuntime::IsSwiftMangledName(name.str().c_str()))
+      return;
+
     auto clang_importer = m_swift_ast_ctx.GetClangImporter();
     if (!clang_importer)
       return;


### PR DESCRIPTION
This is a performance / NFC change.

rdar://problem/56582727