### PR TITLE
[Reproducer] Disable parallel module import in SwiftASTContext during replay

### DIFF
--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -1948,7 +1948,10 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
     // the Clang modules that were imported in this module. This can
     // be a lot of work (potentially ten seconds per module), but it
     // can be performed in parallel.
-    llvm::ThreadPool pool;
+    const unsigned threads = repro::Reproducer::Instance().IsReplaying()
+                                 ? 1
+                                 : llvm::hardware_concurrency();
+    llvm::ThreadPool pool(threads);
     for (size_t mi = 0; mi != num_images; ++mi) {
       auto module_sp = target.GetImages().GetModuleAtIndex(mi);
       pool.async([=] {


### PR DESCRIPTION
The Swift AST context can imports all modules in parallel. While this
leads to a great performance improvement, it introduces a level of
non-determinism during replay. We should disable this functionality
during replay. Although it's still possible that this hides a bug, it
means that at least replays will be deterministic.

rdar://56947303