### PR TITLE
Testuite: Support Asan test with remote testing

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/functionalities/asan/TestMemoryHistory.py
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/asan/TestMemoryHistory.py
@@ -17,7 +17,6 @@ class AsanTestCase(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
-    @skipIfRemote
     @skipUnlessAddressSanitizer
     def test(self):
         self.build()
@@ -33,9 +32,10 @@ class AsanTestCase(TestBase):
 
     def asan_tests(self):
         exe = self.getBuildArtifact("a.out")
-        self.expect(
-            "file " + exe,
-            patterns=["Current executable set to .*a.out"])
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        self.registerSanitizerLibrariesWithTarget(target)
 
         self.runCmd("breakpoint set -f main.c -l %d" % self.line_breakpoint)
 

--- a/lldb/packages/Python/lldbsuite/test/functionalities/asan/TestReportData.py
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/asan/TestReportData.py
@@ -17,7 +17,6 @@ class AsanTestReportDataCase(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
-    @skipIfRemote
     @skipUnlessAddressSanitizer
     @skipIf(archs=['i386'], bugnumber="llvm.org/PR36710")
     def test(self):
@@ -36,9 +35,11 @@ class AsanTestReportDataCase(TestBase):
 
     def asan_tests(self):
         exe = self.getBuildArtifact("a.out")
-        self.expect(
-            "file " + exe,
-            patterns=["Current executable set to .*a.out"])
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        self.registerSanitizerLibrariesWithTarget(target)
+
         self.runCmd("run")
 
         stop_reason = self.dbg.GetSelectedTarget().process.GetSelectedThread().GetStopReason()

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1939,6 +1939,15 @@ class TestBase(Base):
 
         return environment
 
+    def registerSanitizerLibrariesWithTarget(self, target):
+        runtimes = []
+        for m in target.module_iter():
+            libspec = m.GetFileSpec()
+            if "clang_rt" in libspec.GetFilename():
+                runtimes.append(os.path.join(libspec.GetDirectory(),
+                                             libspec.GetFilename()))
+        return self.registerSharedLibrariesWithTarget(target, runtimes)
+
     # utility methods that tests can use to access the current objects
     def target(self):
         if not self.dbg:


### PR DESCRIPTION
To do so, we need to register the sanitizer libraries with the target
so that they get uploaded before running. This patch adds a helper to
the test class to this effect.

(cherry picked from commit 8243918f43c6eedc2b018c1edc9c6b72fe9b3c1e)