### PR TITLE
Builtin fixes

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -94,7 +94,8 @@ function(darwin_test_archs os valid_archs)
    
     set(arch_linker_flags "-arch ${arch} ${os_linker_flags}")
     if(TEST_COMPILE_ONLY)
-      try_compile_only(CAN_TARGET_${os}_${arch} FLAGS -v -arch ${arch} ${DARWIN_${os}_CFLAGS})
+      # `-w` is used to surpress compiler warnings which `try_compile_only()` treats as an error.
+      try_compile_only(CAN_TARGET_${os}_${arch} FLAGS -v -arch ${arch} ${DARWIN_${os}_CFLAGS} -w)
     else()
       set(SAVED_CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
       set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${arch_linker_flags}")
@@ -282,7 +283,7 @@ macro(darwin_add_builtin_libraries)
                       ../profile/InstrProfilingPlatformDarwin
                       ../profile/InstrProfilingWriter)
   foreach (os ${ARGN})
-    list_intersect(DARWIN_BUILTIN_ARCHS DARWIN_${os}_ARCHS BUILTIN_SUPPORTED_ARCH)
+    list_intersect(DARWIN_BUILTIN_ARCHS DARWIN_${os}_BUILTIN_ARCHS BUILTIN_SUPPORTED_ARCH)
     foreach (arch ${DARWIN_BUILTIN_ARCHS})
       darwin_find_excluded_builtins_list(${arch}_${os}_EXCLUDED_BUILTINS
                               OS ${os}

--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -39,6 +39,41 @@ function(find_darwin_sdk_dir var sdk_name)
   set(DARWIN_${sdk_name}_CACHED_SYSROOT ${var_internal} CACHE STRING "Darwin SDK path for SDK ${sdk_name}." FORCE)
 endfunction()
 
+function(find_darwin_sdk_version var sdk_name)
+  # We deliberately don't cache the result here because
+  # CMake's caching causes too many problems.
+  set(result_process 1)
+  if(NOT DARWIN_PREFER_PUBLIC_SDK)
+    # Let's first try the internal SDK, otherwise use the public SDK.
+    execute_process(
+      COMMAND xcodebuild -version -sdk ${sdk_name}.internal SDKVersion
+      RESULT_VARIABLE result_process
+      OUTPUT_VARIABLE var_internal
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_FILE /dev/null
+    )
+  endif()
+  if((NOT ${result_process} EQUAL 0) OR "" STREQUAL "${var_internal}")
+    execute_process(
+      COMMAND xcodebuild -version -sdk ${sdk_name} SDKVersion
+      RESULT_VARIABLE result_process
+      OUTPUT_VARIABLE var_internal
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_FILE /dev/null
+    )
+  endif()
+  if(NOT result_process EQUAL 0)
+    message(FATAL_ERROR
+      "Failed to determine SDK version for \"${sdk_name}\" SDK")
+  endif()
+  # Check reported version looks sane.
+  if (NOT "${var_internal}" MATCHES "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$")
+    message(FATAL_ERROR
+      "Reported SDK version \"${var_internal}\" does not look like a version")
+  endif()
+  set(${var} ${var_internal} PARENT_SCOPE)
+endfunction()
+
 # There isn't a clear mapping of what architectures are supported with a given
 # target platform, but ld's version output does list the architectures it can
 # link for.
@@ -75,11 +110,22 @@ function(darwin_test_archs os valid_archs)
     message(STATUS "Finding valid architectures for ${os}...")
     set(SIMPLE_C ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/src.c)
     file(WRITE ${SIMPLE_C} "#include <stdio.h>\nint main() { printf(__FILE__); return 0; }\n")
-  
+
     set(os_linker_flags)
     foreach(flag ${DARWIN_${os}_LINK_FLAGS})
       set(os_linker_flags "${os_linker_flags} ${flag}")
     endforeach()
+
+    # Disable building for i386 for macOS SDK >= 10.15. The SDK doesn't support
+    # linking for i386 and the corresponding OS doesn't allow running macOS i386
+    # binaries.
+    if ("${os}" STREQUAL "osx")
+      find_darwin_sdk_version(macosx_sdk_version "macosx")
+      if ("${macosx_sdk_version}" VERSION_GREATER 10.15 OR "${macosx_sdk_version}" VERSION_EQUAL 10.15)
+        message(STATUS "Disabling i386 slice for ${valid_archs}")
+        list(REMOVE_ITEM archs "i386")
+      endif()
+    endif()
   endif()
 
   # The simple program will build for x86_64h on the simulator because it is 

--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -15,7 +15,7 @@ function(find_darwin_sdk_dir var sdk_name)
   if(NOT DARWIN_PREFER_PUBLIC_SDK)
     # Let's first try the internal SDK, otherwise use the public SDK.
     execute_process(
-      COMMAND xcodebuild -version -sdk ${sdk_name}.internal Path
+      COMMAND xcrun --sdk ${sdk_name}.internal --show-sdk-path
       RESULT_VARIABLE result_process
       OUTPUT_VARIABLE var_internal
       OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -24,7 +24,7 @@ function(find_darwin_sdk_dir var sdk_name)
   endif()
   if((NOT result_process EQUAL 0) OR "" STREQUAL "${var_internal}")
     execute_process(
-      COMMAND xcodebuild -version -sdk ${sdk_name} Path
+      COMMAND xcrun --sdk ${sdk_name} --show-sdk-path
       RESULT_VARIABLE result_process
       OUTPUT_VARIABLE var_internal
       OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -36,6 +36,7 @@ function(find_darwin_sdk_dir var sdk_name)
   if(result_process EQUAL 0)
     set(${var} ${var_internal} PARENT_SCOPE)
   endif()
+  message(STATUS "Checking DARWIN_${sdk_name}_SYSROOT - '${var_internal}'")
   set(DARWIN_${sdk_name}_CACHED_SYSROOT ${var_internal} CACHE STRING "Darwin SDK path for SDK ${sdk_name}." FORCE)
 endfunction()
 

--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -112,7 +112,7 @@ function(darwin_test_archs os valid_archs)
     endif()
   endforeach()
   set(${valid_archs} ${working_archs}
-    CACHE STRING "List of valid architectures for platform ${os}.")
+    CACHE STRING "List of valid architectures for platform ${os}." FORCE)
 endfunction()
 
 # This function checks the host cpusubtype to see if it is post-haswell. Haswell

--- a/compiler-rt/cmake/builtin-config-ix.cmake
+++ b/compiler-rt/cmake/builtin-config-ix.cmake
@@ -62,6 +62,7 @@ if(APPLE)
   set(DARWIN_osx_BUILTIN_MIN_VER 10.5)
   set(DARWIN_osx_BUILTIN_MIN_VER_FLAG
       -mmacosx-version-min=${DARWIN_osx_BUILTIN_MIN_VER})
+  set(DARWIN_osx_BUILTIN_ALL_POSSIBLE_ARCHS ${X86} ${X86_64})
 
   if(COMPILER_RT_ENABLE_IOS)
     list(APPEND DARWIN_EMBEDDED_PLATFORMS ios)
@@ -69,6 +70,8 @@ if(APPLE)
     set(DARWIN_ios_BUILTIN_MIN_VER 6.0)
     set(DARWIN_ios_BUILTIN_MIN_VER_FLAG
       ${DARWIN_ios_MIN_VER_FLAG}=${DARWIN_ios_BUILTIN_MIN_VER})
+    set(DARWIN_ios_BUILTIN_ALL_POSSIBLE_ARCHS ${ARM64} ${ARM32})
+    set(DARWIN_iossim_BUILTIN_ALL_POSSIBLE_ARCHS ${X86} ${X86_64})
   endif()
   if(COMPILER_RT_ENABLE_WATCHOS)
     list(APPEND DARWIN_EMBEDDED_PLATFORMS watchos)
@@ -76,6 +79,8 @@ if(APPLE)
     set(DARWIN_watchos_BUILTIN_MIN_VER 2.0)
     set(DARWIN_watchos_BUILTIN_MIN_VER_FLAG
       ${DARWIN_watchos_MIN_VER_FLAG}=${DARWIN_watchos_BUILTIN_MIN_VER})
+    set(DARWIN_watchos_BUILTIN_ALL_POSSIBLE_ARCHS armv7 armv7k)
+    set(DARWIN_watchossim_BUILTIN_ALL_POSSIBLE_ARCHS ${X86})
   endif()
   if(COMPILER_RT_ENABLE_TVOS)
     list(APPEND DARWIN_EMBEDDED_PLATFORMS tvos)
@@ -83,6 +88,8 @@ if(APPLE)
     set(DARWIN_tvos_BUILTIN_MIN_VER 9.0)
     set(DARWIN_tvos_BUILTIN_MIN_VER_FLAG
       ${DARWIN_tvos_MIN_VER_FLAG}=${DARWIN_tvos_BUILTIN_MIN_VER})
+    set(DARWIN_tvos_BUILTIN_ALL_POSSIBLE_ARCHS armv7 arm64)
+    set(DARWIN_tvossim_BUILTIN_ALL_POSSIBLE_ARCHS ${X86} ${X86_64})
   endif()
 
   set(BUILTIN_SUPPORTED_OS osx)
@@ -90,15 +97,16 @@ if(APPLE)
   # We're setting the flag manually for each target OS
   set(CMAKE_OSX_DEPLOYMENT_TARGET "")
 
-  if(NOT DARWIN_osx_ARCHS)
-    set(DARWIN_osx_ARCHS i386 x86_64 x86_64h)
-  endif()
-
-  set(DARWIN_sim_ARCHS i386 x86_64)
-  set(DARWIN_device_ARCHS armv7 armv7s armv7k arm64)
-
-  message(STATUS "OSX supported arches: ${DARWIN_osx_ARCHS}")
-  foreach(arch ${DARWIN_osx_ARCHS})
+  # NOTE: We deliberately avoid using `DARWIN_<os>_ARCHS` here because that is
+  # used by `config-ix.cmake` in the context of building the rest of
+  # compiler-rt where the global `${TEST_COMPILE_ONLY}` (used by
+  # `darwin_test_archs()`) has a different value.
+  darwin_test_archs(osx
+    DARWIN_osx_BUILTIN_ARCHS
+    ${DARWIN_osx_BUILTIN_ALL_POSSIBLE_ARCHS}
+  )
+  message(STATUS "OSX supported builtin arches: ${DARWIN_osx_BUILTIN_ARCHS}")
+  foreach(arch ${DARWIN_osx_BUILTIN_ARCHS})
     list(APPEND COMPILER_RT_SUPPORTED_ARCH ${arch})
     set(CAN_TARGET_${arch} 1)
   endforeach()
@@ -112,38 +120,30 @@ if(APPLE)
 
       set(DARWIN_${platform}sim_SKIP_CC_KEXT On)
 
-      set(test_arches ${DARWIN_sim_ARCHS})
-      if(DARWIN_${platform}sim_ARCHS)
-        set(test_arches DARWIN_${platform}sim_ARCHS)
-      endif()
-
       darwin_test_archs(${platform}sim
-        DARWIN_${platform}sim_ARCHS
-        ${test_arches})
-      message(STATUS "${platform} Simulator supported builtin arches: ${DARWIN_${platform}sim_ARCHS}")
-      if(DARWIN_${platform}sim_ARCHS)
+        DARWIN_${platform}sim_BUILTIN_ARCHS
+        ${DARWIN_${platform}sim_BUILTIN_ALL_POSSIBLE_ARCHS}
+      )
+      message(STATUS "${platform} Simulator supported builtin arches: ${DARWIN_${platform}sim_BUILTIN_ARCHS}")
+      if(DARWIN_${platform}sim_BUILTIN_ARCHS)
         list(APPEND BUILTIN_SUPPORTED_OS ${platform}sim)
       endif()
-      foreach(arch ${DARWIN_${platform}sim_ARCHS})
+      foreach(arch ${DARWIN_${platform}sim_BUILTIN_ARCHS})
         list(APPEND COMPILER_RT_SUPPORTED_ARCH ${arch})
         set(CAN_TARGET_${arch} 1)
       endforeach()
     endif()
 
     if(DARWIN_${platform}_SYSROOT)
-      set(test_arches ${DARWIN_device_ARCHS})
-      if(DARWIN_${platform}_ARCHS)
-        set(test_arches DARWIN_${platform}_ARCHS)
-      endif()
-
       darwin_test_archs(${platform}
-        DARWIN_${platform}_ARCHS
-        ${test_arches})
-      message(STATUS "${platform} supported builtin arches: ${DARWIN_${platform}_ARCHS}")
-      if(DARWIN_${platform}_ARCHS)
+        DARWIN_${platform}_BUILTIN_ARCHS
+        ${DARWIN_${platform}_BUILTIN_ALL_POSSIBLE_ARCHS}
+      )
+      message(STATUS "${platform} supported builtin arches: ${DARWIN_${platform}_BUILTIN_ARCHS}")
+      if(DARWIN_${platform}_BUILTIN_ARCHS)
         list(APPEND BUILTIN_SUPPORTED_OS ${platform})
       endif()
-      foreach(arch ${DARWIN_${platform}_ARCHS})
+      foreach(arch ${DARWIN_${platform}_BUILTIN_ARCHS})
         list(APPEND COMPILER_RT_SUPPORTED_ARCH ${arch})
         set(CAN_TARGET_${arch} 1)
       endforeach()

--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -283,6 +283,7 @@ if(APPLE)
   find_darwin_sdk_dir(DARWIN_tvos_SYSROOT appletvos)
 
   if(NOT DARWIN_osx_SYSROOT)
+    message(WARNING "Could not determine OS X sysroot, trying /usr/include")
     if(EXISTS /usr/include)
       set(DARWIN_osx_SYSROOT /)
     else()

--- a/compiler-rt/test/builtins/CMakeLists.txt
+++ b/compiler-rt/test/builtins/CMakeLists.txt
@@ -25,9 +25,12 @@ if (MSVC AND NOT "${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
 endif()
 pythonize_bool(BUILTINS_IS_MSVC)
 
-#TODO: Add support for Apple.
-if (NOT APPLE)
-foreach(arch ${BUILTIN_SUPPORTED_ARCH})
+set(BUILTIN_TEST_ARCH ${BUILTIN_SUPPORTED_ARCH})
+if(APPLE)
+  darwin_filter_host_archs(BUILTIN_SUPPORTED_ARCH BUILTIN_TEST_ARCH)
+endif()
+
+foreach(arch ${BUILTIN_TEST_ARCH})
   set(BUILTINS_TEST_TARGET_ARCH ${arch})
   string(TOLOWER "-${arch}-${OS_NAME}" BUILTINS_TEST_CONFIG_SUFFIX)
   get_test_cc_for_arch(${arch} BUILTINS_TEST_TARGET_CC BUILTINS_TEST_TARGET_CFLAGS)
@@ -76,7 +79,8 @@ foreach(arch ${BUILTIN_SUPPORTED_ARCH})
     )
   list(APPEND BUILTINS_TESTSUITES ${CMAKE_CURRENT_BINARY_DIR}/Unit/${CONFIG_NAME})
 endforeach()
-endif()
+
+# TODO: Add support for running tests on iOS and iOS simulator.
 
 add_lit_testsuite(check-builtins "Running the Builtins tests"
   ${BUILTINS_TESTSUITES}

--- a/compiler-rt/test/builtins/CMakeLists.txt
+++ b/compiler-rt/test/builtins/CMakeLists.txt
@@ -41,6 +41,33 @@ foreach(arch ${BUILTIN_SUPPORTED_ARCH})
     string(REPLACE ";" " " BUILTINS_TEST_TARGET_CFLAGS "${BUILTINS_TEST_TARGET_CFLAGS}")
   endif()
 
+  # Compute builtins available in library and add them as lit features.
+  if(APPLE)
+    # TODO: Support other Apple platforms.
+    set(BUILTIN_LIB_TARGET_NAME "clang_rt.builtins_${arch}_osx")
+  else()
+    set(BUILTIN_LIB_TARGET_NAME "clang_rt.builtins-${arch}")
+  endif()
+  if (NOT TARGET "${BUILTIN_LIB_TARGET_NAME}")
+    message(FATAL_ERROR "Target ${BUILTIN_LIB_TARGET_NAME} does not exist")
+  endif()
+  get_target_property(BUILTIN_LIB_SOURCES "${BUILTIN_LIB_TARGET_NAME}" SOURCES)
+  list(LENGTH BUILTIN_LIB_SOURCES BUILTIN_LIB_SOURCES_LENGTH)
+  if (BUILTIN_LIB_SOURCES_LENGTH EQUAL 0)
+    message(FATAL_ERROR "Failed to find source files for ${arch} builtin library")
+  endif()
+  set(BUILTINS_LIT_SOURCE_FEATURES "")
+  foreach (file_name ${BUILTIN_LIB_SOURCES})
+    # Strip off any directories and file extensions. This approach means we add
+    # add a single feature if there is a C source file or assembly override
+    # present in the builtin library.
+    # E.g.
+    # "hexagon/udivsi3.S" => "udivsi3"
+    # "udivsi3.c" => "udivsi3"
+    get_filename_component(FILE_NAME_FILTERED "${file_name}" NAME_WE)
+    list(APPEND BUILTINS_LIT_SOURCE_FEATURES "librt_has_${FILE_NAME_FILTERED}")
+  endforeach()
+
   string(TOUPPER ${arch} ARCH_UPPER_CASE)
   set(CONFIG_NAME ${ARCH_UPPER_CASE}${OS_NAME}Config)
   configure_lit_site_cfg(

--- a/compiler-rt/test/builtins/Unit/absvdi2_test.c
+++ b/compiler-rt/test/builtins/Unit/absvdi2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_absvdi2
 //===-- absvdi2_test.c - Test __absvdi2 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/absvsi2_test.c
+++ b/compiler-rt/test/builtins/Unit/absvsi2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_absvsi2
 //===-- absvsi2_test.c - Test __absvsi2 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/absvti2_test.c
+++ b/compiler-rt/test/builtins/Unit/absvti2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_absvti2
 // REQUIRES: int128
 //===-- absvti2_test.c - Test __absvti2 -----------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/adddf3vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/adddf3vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_adddf3vfp
 //===-- adddf3vfp_test.c - Test __adddf3vfp -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/addsf3vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/addsf3vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_addsf3vfp
 //===-- addsf3vfp_test.c - Test __addsf3vfp -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/addtf3_test.c
+++ b/compiler-rt/test/builtins/Unit/addtf3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_addtf3
 //===--------------- addtf3_test.c - Test __addtf3 ------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/addvdi3_test.c
+++ b/compiler-rt/test/builtins/Unit/addvdi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_addvdi3
 //===-- addvdi3_test.c - Test __addvdi3 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/addvsi3_test.c
+++ b/compiler-rt/test/builtins/Unit/addvsi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_addvsi3
 //===-- addvsi3_test.c - Test __addvsi3 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/addvti3_test.c
+++ b/compiler-rt/test/builtins/Unit/addvti3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_addvti3
 // REQUIRES: int128
 //===-- addvti3_test.c - Test __addvti3 -----------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/ashldi3_test.c
+++ b/compiler-rt/test/builtins/Unit/ashldi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_ashldi3
 //===-- ashldi3_test.c - Test __ashldi3 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/ashlti3_test.c
+++ b/compiler-rt/test/builtins/Unit/ashlti3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_ashlti3
 // REQUIRES: int128
 //===-- ashlti3_test.c - Test __ashlti3 -----------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/ashrdi3_test.c
+++ b/compiler-rt/test/builtins/Unit/ashrdi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_ashrdi3
 //===-- ashrdi3_test.c - Test __ashrdi3 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/ashrti3_test.c
+++ b/compiler-rt/test/builtins/Unit/ashrti3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_ashrti3
 // REQUIRES: int128
 //===-- ashrti3_test.c - Test __ashrti3 -----------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/bswapdi2_test.c
+++ b/compiler-rt/test/builtins/Unit/bswapdi2_test.c
@@ -1,5 +1,6 @@
 // UNSUPPORTED: armv6m-target-arch
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_bswapdi2
 //===-- bswapdi2_test.c - Test __bswapdi2 ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/bswapsi2_test.c
+++ b/compiler-rt/test/builtins/Unit/bswapsi2_test.c
@@ -1,5 +1,6 @@
 // UNSUPPORTED: armv6m-target-arch
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_bswapsi2
 //===-- bswapsi2_test.c - Test __bswapsi2 ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/clear_cache_test.c
+++ b/compiler-rt/test/builtins/Unit/clear_cache_test.c
@@ -1,6 +1,7 @@
 // REQUIRES: native-run
 // UNSUPPORTED: arm, aarch64
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_clear_cache
 //===-- clear_cache_test.c - Test clear_cache -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/clear_cache_test.c
+++ b/compiler-rt/test/builtins/Unit/clear_cache_test.c
@@ -49,7 +49,7 @@ int main()
 #if !defined(_WIN32)
     uint8_t *execution_buffer = mmap(0, kSize,
                                      PROT_READ | PROT_WRITE | PROT_EXEC,
-                                     MAP_ANON | MAP_PRIVATE, 0, 0);
+                                     MAP_ANON | MAP_PRIVATE, -1, 0);
     if (execution_buffer == MAP_FAILED)
       return 1;
 #else

--- a/compiler-rt/test/builtins/Unit/clear_cache_test.c
+++ b/compiler-rt/test/builtins/Unit/clear_cache_test.c
@@ -14,24 +14,15 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
+
 #if defined(_WIN32)
 #include <windows.h>
-static uintptr_t get_page_size() {
-    SYSTEM_INFO si;
-    GetSystemInfo(&si);
-    return si.dwPageSize;
-}
 #else
 #include <unistd.h>
 #include <sys/mman.h>
-
-static uintptr_t get_page_size() {
-    return sysconf(_SC_PAGE_SIZE);
-}
 #endif
 
 extern void __clear_cache(void* start, void* end);
-
 
 typedef int (*pfunc)(void);
 
@@ -52,34 +43,36 @@ memcpy_f(void *dst, const void *src, size_t n) {
 #endif
 }
 
-unsigned char execution_buffer[128] __attribute__((aligned(8)));
-
 int main()
 {
-    // make executable the page containing execution_buffer 
-    uintptr_t page_size = get_page_size();
-    char* start = (char*)((uintptr_t)execution_buffer & (-page_size));
-    char* end = (char*)((uintptr_t)(&execution_buffer[128+page_size]) & (-page_size));
-#if defined(_WIN32)
-    DWORD dummy_oldProt;
-    MEMORY_BASIC_INFORMATION b;
-    if (!VirtualQuery(start, &b, sizeof(b)))
-        return 1;
-    if (!VirtualProtect(b.BaseAddress, b.RegionSize, PAGE_EXECUTE_READWRITE, &b.Protect))
+    const int kSize = 128;
+#if !defined(_WIN32)
+    uint8_t *execution_buffer = mmap(0, kSize,
+                                     PROT_READ | PROT_WRITE | PROT_EXEC,
+                                     MAP_ANON | MAP_PRIVATE, 0, 0);
+    if (execution_buffer == MAP_FAILED)
+      return 1;
 #else
-    if (mprotect(start, end-start, PROT_READ|PROT_WRITE|PROT_EXEC) != 0)
-#endif
+    HANDLE mapping = CreateFileMapping(INVALID_HANDLE_VALUE, NULL,
+                                       PAGE_EXECUTE_READWRITE, 0, kSize, NULL);
+    if (mapping == NULL)
         return 1;
 
+    uint8_t* execution_buffer = MapViewOfFile(
+        mapping, FILE_MAP_ALL_ACCESS | FILE_MAP_EXECUTE, 0, 0, 0);
+    if (execution_buffer == NULL)
+        return 1;
+#endif
+
     // verify you can copy and execute a function
-    pfunc f1 = (pfunc)memcpy_f(execution_buffer, func1, 128);
-    __clear_cache(execution_buffer, &execution_buffer[128]);
+    pfunc f1 = (pfunc)memcpy_f(execution_buffer, func1, kSize);
+    __clear_cache(execution_buffer, execution_buffer + kSize);
     if ((*f1)() != 1)
         return 1;
 
     // verify you can overwrite a function with another
-    pfunc f2 = (pfunc)memcpy_f(execution_buffer, func2, 128);
-    __clear_cache(execution_buffer, &execution_buffer[128]);
+    pfunc f2 = (pfunc)memcpy_f(execution_buffer, func2, kSize);
+    __clear_cache(execution_buffer, execution_buffer + kSize);
     if ((*f2)() != 2)
         return 1;
 

--- a/compiler-rt/test/builtins/Unit/clzdi2_test.c
+++ b/compiler-rt/test/builtins/Unit/clzdi2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_clzdi2
 //===-- clzdi2_test.c - Test __clzdi2 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/clzsi2_test.c
+++ b/compiler-rt/test/builtins/Unit/clzsi2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_clzsi2
 //===-- clzsi2_test.c - Test __clzsi2 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/clzti2_test.c
+++ b/compiler-rt/test/builtins/Unit/clzti2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_clzti2
 // REQUIRES: int128
 //===-- clzti2_test.c - Test __clzti2 -------------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/cmpdi2_test.c
+++ b/compiler-rt/test/builtins/Unit/cmpdi2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_cmpdi2
 //===-- cmpdi2_test.c - Test __cmpdi2 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/cmpti2_test.c
+++ b/compiler-rt/test/builtins/Unit/cmpti2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_cmpti2
 // REQUIRES: int128
 //===-- cmpti2_test.c - Test __cmpti2 -------------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/comparedf2_test.c
+++ b/compiler-rt/test/builtins/Unit/comparedf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_comparedf2
 
 //===-- cmpdf2_test.c - Test __cmpdf2 -------------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/comparesf2_test.c
+++ b/compiler-rt/test/builtins/Unit/comparesf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_comparesf2
 
 //===-- cmpsf2_test.c - Test __cmpsf2 -------------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/compiler_rt_logbf_test.c
+++ b/compiler-rt/test/builtins/Unit/compiler_rt_logbf_test.c
@@ -13,15 +13,19 @@
 //===----------------------------------------------------------------------===//
 
 #define SINGLE_PRECISION
+#include "fp_lib.h"
+#include "int_math.h"
 #include <math.h>
 #include <stdio.h>
-#include "fp_lib.h"
 
 int test__compiler_rt_logbf(fp_t x) {
   fp_t crt_value = __compiler_rt_logbf(x);
   fp_t libm_value = logbf(x);
-  // Compare actual rep, e.g. to avoid NaN != the same NaN
-  if (toRep(crt_value) != toRep(libm_value)) {
+  // `!=` operator on fp_t returns false for NaNs so also check if operands are
+  // both NaN. We don't do `toRepr(crt_value) != toRepr(libm_value)` because
+  // that treats different representations of NaN as not equivalent.
+  if (crt_value != libm_value &&
+      !(crt_isnan(crt_value) && crt_isnan(libm_value))) {
     printf("error: in __compiler_rt_logb(%a [%X]) = %a [%X] !=  %a [%X]\n", x,
            toRep(x), crt_value, toRep(crt_value), libm_value,
            toRep(libm_value));

--- a/compiler-rt/test/builtins/Unit/cpu_model_test.c
+++ b/compiler-rt/test/builtins/Unit/cpu_model_test.c
@@ -2,6 +2,7 @@
 // XFAIL: *
 // REQUIRES: x86-target-arch
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_cpu_model
 //===-- cpu_model_test.c - Test __builtin_cpu_supports --------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/ctzdi2_test.c
+++ b/compiler-rt/test/builtins/Unit/ctzdi2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_ctzdi2
 //===-- ctzdi2_test.c - Test __ctzdi2 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/ctzsi2_test.c
+++ b/compiler-rt/test/builtins/Unit/ctzsi2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_ctzsi2
 //===-- ctzsi2_test.c - Test __ctzsi2 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/ctzti2_test.c
+++ b/compiler-rt/test/builtins/Unit/ctzti2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_ctzti2
 // REQUIRES: int128
 //===-- ctzti2_test.c - Test __ctzti2 -------------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/divdc3_test.c
+++ b/compiler-rt/test/builtins/Unit/divdc3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_divdc3
 //===-- divdc3_test.c - Test __divdc3 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/divdf3_test.c
+++ b/compiler-rt/test/builtins/Unit/divdf3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_divdf3
 //===--------------- divdf3_test.c - Test __divdf3 ------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/divdf3vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/divdf3vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_divdf3vfp
 //===-- divdf3vfp_test.c - Test __divdf3vfp -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/divdi3_test.c
+++ b/compiler-rt/test/builtins/Unit/divdi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_divdi3
 //===-- divdi3_test.c - Test __divdi3 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/divmodsi4_test.c
+++ b/compiler-rt/test/builtins/Unit/divmodsi4_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_divmodsi4
 //===-- divmodsi4_test.c - Test __divmodsi4 -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/divsc3_test.c
+++ b/compiler-rt/test/builtins/Unit/divsc3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -lm -o %t && %run %t
+// REQUIRES: librt_has_divsc3
 //===-- divsc3_test.c - Test __divsc3 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/divsf3_test.c
+++ b/compiler-rt/test/builtins/Unit/divsf3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_divsf3
 //===--------------- divsf3_test.c - Test __divsf3 ------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/divsf3vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/divsf3vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_divsf3vfp
 //===-- divsf3vfp_test.c - Test __divsf3vfp -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/divsi3_test.c
+++ b/compiler-rt/test/builtins/Unit/divsi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_divsi3
 //===-- divsi3_test.c - Test __divsi3 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/divtc3_test.c
+++ b/compiler-rt/test/builtins/Unit/divtc3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -lm -o %t && %run %t
+// REQUIRES: librt_has_divtc3
 //===-- divtc3_test.c - Test __divtc3 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/divtf3_test.c
+++ b/compiler-rt/test/builtins/Unit/divtf3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_divtf3
 //===--------------- divtf3_test.c - Test __divtf3 ------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/divti3_test.c
+++ b/compiler-rt/test/builtins/Unit/divti3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_divti3
 // REQUIRES: int128
 //===-- divti3_test.c - Test __divti3 -------------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/divxc3_test.c
+++ b/compiler-rt/test/builtins/Unit/divxc3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -lm -o %t && %run %t
+// REQUIRES: librt_has_divxc3
 // REQUIRES: x86-target-arch
 // UNSUPPORTED: powerpc64
 //===-- divxc3_test.c - Test __divxc3 -------------------------------------===//

--- a/compiler-rt/test/builtins/Unit/enable_execute_stack_test.c
+++ b/compiler-rt/test/builtins/Unit/enable_execute_stack_test.c
@@ -1,5 +1,6 @@
 // REQUIRES: native-run
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_enable_execute_stack
 //===-- enable_execute_stack_test.c - Test __enable_execute_stack ----------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/eqdf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/eqdf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_eqdf2vfp
 
 //===-- eqdf2vfp_test.c - Test __eqdf2vfp ---------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/eqsf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/eqsf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_eqsf2vfp
 
 //===-- eqsf2vfp_test.c - Test __eqsf2vfp ---------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/eqtf2_test.c
+++ b/compiler-rt/test/builtins/Unit/eqtf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_comparetf2
 //===------------ eqtf2_test.c - Test __eqtf2------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/extenddftf2_test.c
+++ b/compiler-rt/test/builtins/Unit/extenddftf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_extenddftf2
 //===--------------- extenddftf2_test.c - Test __extenddftf2 --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/extendhfsf2_test.c
+++ b/compiler-rt/test/builtins/Unit/extendhfsf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_extendhfsf2
 //===--------------- extendhfsf2_test.c - Test __extendhfsf2 --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/extendsfdf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/extendsfdf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_extendsfdf2vfp
 //===-- extendsfdf2vfp_test.c - Test __extendsfdf2vfp ---------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/extendsftf2_test.c
+++ b/compiler-rt/test/builtins/Unit/extendsftf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_extendsftf2
 //===--------------- extendsftf2_test.c - Test __extendsftf2 --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/ffsdi2_test.c
+++ b/compiler-rt/test/builtins/Unit/ffsdi2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_ffsdi2
 //===-- ffsdi2_test.c - Test __ffsdi2 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/ffssi2_test.c
+++ b/compiler-rt/test/builtins/Unit/ffssi2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_ffssi2
 //===-- ffssi2_test.c - Test __ffssi2 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/ffsti2_test.c
+++ b/compiler-rt/test/builtins/Unit/ffsti2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_ffsti2
 // REQUIRES: int128
 //===-- ffsti2_test.c - Test __ffsti2 -------------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/fixdfdi_test.c
+++ b/compiler-rt/test/builtins/Unit/fixdfdi_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixdfdi
 //===-- fixdfdi_test.c - Test __fixdfdi -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/fixdfsivfp_test.c
+++ b/compiler-rt/test/builtins/Unit/fixdfsivfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixdfsivfp
 
 //===-- fixdfsivfp_test.c - Test __fixdfsivfp -----------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/fixdfti_test.c
+++ b/compiler-rt/test/builtins/Unit/fixdfti_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixdfti
 // REQUIRES: int128
 //===-- fixdfti_test.c - Test __fixdfti -----------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/fixsfdi_test.c
+++ b/compiler-rt/test/builtins/Unit/fixsfdi_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixsfdi
 //===-- fixsfdi_test.c - Test __fixsfdi -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/fixsfsivfp_test.c
+++ b/compiler-rt/test/builtins/Unit/fixsfsivfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixsfsivfp
 
 //===-- fixsfsivfp_test.c - Test __fixsfsivfp -----------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/fixsfti_test.c
+++ b/compiler-rt/test/builtins/Unit/fixsfti_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixsfti
 // REQUIRES: int128
 //===-- fixsfti_test.c - Test __fixsfti -----------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/fixtfdi_test.c
+++ b/compiler-rt/test/builtins/Unit/fixtfdi_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixtfdi
 //===--------------- fixtfdi_test.c - Test __fixtfdi ----------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/fixtfsi_test.c
+++ b/compiler-rt/test/builtins/Unit/fixtfsi_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixtfsi
 //===--------------- fixtfsi_test.c - Test __fixtfsi ----------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/fixtfti_test.c
+++ b/compiler-rt/test/builtins/Unit/fixtfti_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixtfti
 //===--------------- fixtfti_test.c - Test __fixtfti ----------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/fixunsdfdi_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunsdfdi_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixunsdfdi
 //===-- fixunsdfdi_test.c - Test __fixunsdfdi -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/fixunsdfsi_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunsdfsi_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixunsdfsi
 //===-- fixunsdfsi_test.c - Test __fixunsdfsi -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/fixunsdfsivfp_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunsdfsivfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixunsdfsivfp
 //===-- fixunsdfsivfp_test.c - Test __fixunsdfsivfp -----------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/fixunsdfti_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunsdfti_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixunsdfti
 // REQUIRES: int128
 //===-- fixunsdfti_test.c - Test __fixunsdfti -----------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/fixunssfdi_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunssfdi_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixunssfdi
 //===-- fixunssfdi_test.c - Test __fixunssfdi -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/fixunssfsi_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunssfsi_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixunssfsi
 //===-- fixunssfsi_test.c - Test __fixunssfsi -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/fixunssfsivfp_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunssfsivfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixunssfsivfp
 
 //===-- fixunssfsivfp_test.c - Test __fixunssfsivfp -----------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/fixunssfti_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunssfti_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixunssfti
 // REQUIRES: int128
 //===-- fixunssfti_test.c - Test __fixunssfti -----------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/fixunstfdi_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunstfdi_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixunstfdi
 //===-- fixunstfdi_test.c - Test __fixunstfdi -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/fixunstfsi_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunstfsi_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixunstfsi
 //===--------------- fixunstfsi_test.c - Test __fixunstfsi ----------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/fixunstfti_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunstfti_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixunstfti
 //===-- fixunstfti_test.c - Test __fixunstfti -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/fixunsxfdi_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunsxfdi_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixunsxfdi
 //===-- fixunsxfdi_test.c - Test __fixunsxfdi -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/fixunsxfsi_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunsxfsi_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixunsxfsi
 //===-- fixunsxfsi_test.c - Test __fixunsxfsi -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/fixunsxfti_test.c
+++ b/compiler-rt/test/builtins/Unit/fixunsxfti_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixunsxfti
 // REQUIRES: x86-target-arch
 
 //===-- fixunsxfti_test.c - Test __fixunsxfti -----------------------------===//

--- a/compiler-rt/test/builtins/Unit/fixxfdi_test.c
+++ b/compiler-rt/test/builtins/Unit/fixxfdi_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixxfdi
 //===-- fixxfdi_test.c - Test __fixxfdi -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/fixxfti_test.c
+++ b/compiler-rt/test/builtins/Unit/fixxfti_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_fixxfti
 // REQUIRES: x86-target-arch
 
 //===-- fixxfti_test.c - Test __fixxfti -----------------------------------===//

--- a/compiler-rt/test/builtins/Unit/floatdidf_test.c
+++ b/compiler-rt/test/builtins/Unit/floatdidf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatdidf
 //===-- floatdidf.c - Test __floatdidf ------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/floatdisf_test.c
+++ b/compiler-rt/test/builtins/Unit/floatdisf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatdisf
 //===-- floatdisf_test.c - Test __floatdisf -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/floatditf_test.c
+++ b/compiler-rt/test/builtins/Unit/floatditf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatditf
 //===-- floatditf_test.c - Test __floatditf -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/floatdixf_test.c
+++ b/compiler-rt/test/builtins/Unit/floatdixf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatdixf
 //===-- floatdixf_test.c - Test __floatdixf -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/floatsidfvfp_test.c
+++ b/compiler-rt/test/builtins/Unit/floatsidfvfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatsidfvfp
 //===-- floatsidfvfp_test.c - Test __floatsidfvfp -------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/floatsisfvfp_test.c
+++ b/compiler-rt/test/builtins/Unit/floatsisfvfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatsisfvfp
 //===-- floatsisfvfp_test.c - Test __floatsisfvfp -------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/floatsitf_test.c
+++ b/compiler-rt/test/builtins/Unit/floatsitf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatsitf
 //===--------------- floatsitf_test.c - Test __floatsitf ------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/floattidf_test.c
+++ b/compiler-rt/test/builtins/Unit/floattidf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floattidf
 // REQUIRES: int128
 //===-- floattidf.c - Test __floattidf ------------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/floattisf_test.c
+++ b/compiler-rt/test/builtins/Unit/floattisf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floattisf
 // REQUIRES: int128
 //===-- floattisf_test.c - Test __floattisf -------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/floattitf_test.c
+++ b/compiler-rt/test/builtins/Unit/floattitf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floattitf
 //===-- floattitf.c - Test __floattitf ------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/floattixf_test.c
+++ b/compiler-rt/test/builtins/Unit/floattixf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floattixf
 // REQUIRES: x86-target-arch
 
 //===-- floattixf.c - Test __floattixf ------------------------------------===//

--- a/compiler-rt/test/builtins/Unit/floatundidf_test.c
+++ b/compiler-rt/test/builtins/Unit/floatundidf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatundidf
 //===-- floatundidf_test.c - Test __floatundidf ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/floatundisf_test.c
+++ b/compiler-rt/test/builtins/Unit/floatundisf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatundisf
 //===-- floatundisf_test.c - Test __floatundisf ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/floatunditf_test.c
+++ b/compiler-rt/test/builtins/Unit/floatunditf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatunditf
 //===-- floatunditf_test.c - Test __floatunditf ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/floatundixf_test.c
+++ b/compiler-rt/test/builtins/Unit/floatundixf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatundixf
 //===-- floatundixf_test.c - Test __floatundixf ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/floatunsitf_test.c
+++ b/compiler-rt/test/builtins/Unit/floatunsitf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatunsitf
 //===--------------- floatunsitf_test.c - Test __floatunsitf --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/floatunssidfvfp_test.c
+++ b/compiler-rt/test/builtins/Unit/floatunssidfvfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatunssidfvfp
 //===-- floatunssidfvfp_test.c - Test __floatunssidfvfp -------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/floatunssisfvfp_test.c
+++ b/compiler-rt/test/builtins/Unit/floatunssisfvfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatunssisfvfp
 //===-- floatunssisfvfp_test.c - Test __floatunssisfvfp -------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/floatuntidf_test.c
+++ b/compiler-rt/test/builtins/Unit/floatuntidf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatuntidf
 // REQUIRES: int128
 //===-- floatuntidf.c - Test __floatuntidf --------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/floatuntisf_test.c
+++ b/compiler-rt/test/builtins/Unit/floatuntisf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatuntisf
 //===-- floatuntisf.c - Test __floatuntisf --------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/floatuntitf_test.c
+++ b/compiler-rt/test/builtins/Unit/floatuntitf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatuntitf
 //===-- floatuntitf.c - Test __floatuntitf --------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/floatuntixf_test.c
+++ b/compiler-rt/test/builtins/Unit/floatuntixf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_floatuntixf
 // REQUIRES: x86-target-arch
 
 //===-- floatuntixf.c - Test __floatuntixf --------------------------------===//

--- a/compiler-rt/test/builtins/Unit/gedf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/gedf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_gedf2vfp
 
 //===-- gedf2vfp_test.c - Test __gedf2vfp ---------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/gesf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/gesf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_gesf2vfp
 
 //===-- gesf2vfp_test.c - Test __gesf2vfp ---------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/getf2_test.c
+++ b/compiler-rt/test/builtins/Unit/getf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_comparetf2
 //===------------ getf2_test.c - Test __getf2------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/gtdf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/gtdf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_gtdf2vfp
 
 //===-- gtdf2vfp_test.c - Test __gtdf2vfp ---------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/gtsf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/gtsf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_gtsf2vfp
 
 //===-- gtsf2vfp_test.c - Test __gtsf2vfp ---------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/gttf2_test.c
+++ b/compiler-rt/test/builtins/Unit/gttf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_comparetf2
 //===------------ gttf2_test.c - Test __gttf2------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/ledf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/ledf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_ledf2vfp
 
 //===-- ledf2vfp_test.c - Test __ledf2vfp ---------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/lesf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/lesf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_lesf2vfp
 
 //===-- lesf2vfp_test.c - Test __lesf2vfp ---------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/letf2_test.c
+++ b/compiler-rt/test/builtins/Unit/letf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_comparetf2
 //===------------ letf2_test.c - Test __letf2------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/lit.cfg
+++ b/compiler-rt/test/builtins/Unit/lit.cfg
@@ -29,6 +29,9 @@ if is_msvc:
   base_lib = os.path.join(config.compiler_rt_libdir, "clang_rt.builtins%s.lib "
                           % config.target_suffix)
   config.substitutions.append( ("%librt ", base_lib) )
+elif config.host_os  == 'Darwin':
+  base_lib = os.path.join(config.compiler_rt_libdir, "libclang_rt.osx.a ")
+  config.substitutions.append( ("%librt ", base_lib + ' -lSystem ') )
 else:
   base_lib = os.path.join(config.compiler_rt_libdir, "libclang_rt.builtins%s.a"
                           % config.target_suffix)

--- a/compiler-rt/test/builtins/Unit/lit.cfg
+++ b/compiler-rt/test/builtins/Unit/lit.cfg
@@ -91,3 +91,25 @@ config.suffixes = ['.c', '.cc', '.cpp']
 
 if not config.emulator:
   config.available_features.add('native-run')
+
+# Add features for available sources
+builtins_source_features = config.builtins_lit_source_features.split(';')
+# Sanity checks
+if not builtins_source_features:
+  lit_config.fatal('builtins_source_features cannot be empty')
+builtins_source_features_set = set()
+builtins_source_feature_duplicates = []
+for builtin_source_feature in builtins_source_features:
+  if len(builtin_source_feature) == 0:
+    lit_config.fatal('builtins_source_feature cannot contain empty features')
+  if builtin_source_feature not in builtins_source_features_set:
+    builtins_source_features_set.add(builtin_source_feature)
+  else:
+    builtins_source_feature_duplicates.append(builtin_source_feature)
+
+if len(builtins_source_feature_duplicates) > 0:
+  lit_config.fatal(
+    'builtins_source_features contains duplicates: {}'.format(
+      builtins_source_feature_duplicates)
+  )
+config.available_features.update(builtins_source_features)

--- a/compiler-rt/test/builtins/Unit/lit.site.cfg.in
+++ b/compiler-rt/test/builtins/Unit/lit.site.cfg.in
@@ -6,6 +6,8 @@ config.target_cflags = "@BUILTINS_TEST_TARGET_CFLAGS@"
 config.target_arch = "@BUILTINS_TEST_TARGET_ARCH@"
 config.is_msvc = @MSVC_PYBOOL@
 config.builtins_is_msvc = @BUILTINS_IS_MSVC_PYBOOL@
+config.builtins_lit_source_features = "@BUILTINS_LIT_SOURCE_FEATURES@"
+
 # Load common config for all compiler-rt lit tests.
 lit_config.load_config(config, "@COMPILER_RT_BINARY_DIR@/test/lit.common.configured")
 

--- a/compiler-rt/test/builtins/Unit/lshrdi3_test.c
+++ b/compiler-rt/test/builtins/Unit/lshrdi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_lshrdi3
 //===-- lshrdi3_test.c - Test __lshrdi3 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/lshrti3_test.c
+++ b/compiler-rt/test/builtins/Unit/lshrti3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_lshrti3
 // REQUIRES: int128
 //===-- lshrti3_test.c - Test __lshrti3 -----------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/ltdf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/ltdf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_ltdf2vfp
 
 //===-- ltdf2vfp_test.c - Test __ltdf2vfp ---------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/ltsf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/ltsf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_ltsf2vfp
 
 //===-- ltsf2vfp_test.c - Test __ltsf2vfp ---------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/lttf2_test.c
+++ b/compiler-rt/test/builtins/Unit/lttf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_comparetf2
 //===------------ lttf2_test.c - Test __lttf2------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/moddi3_test.c
+++ b/compiler-rt/test/builtins/Unit/moddi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_moddi3
 //===-- moddi3_test.c - Test __moddi3 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/modsi3_test.c
+++ b/compiler-rt/test/builtins/Unit/modsi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_modsi3
 /* ===-- modsi3_test.c - Test __modsi3 -------------------------------------===
  *
  * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/modti3_test.c
+++ b/compiler-rt/test/builtins/Unit/modti3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_modti3
 // REQUIRES: int128
 //===-- modti3_test.c - Test __modti3 -------------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/muldc3_test.c
+++ b/compiler-rt/test/builtins/Unit/muldc3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -lm -o %t && %run %t
+// REQUIRES: librt_has_muldc3
 //===-- muldc3_test.c - Test __muldc3 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/muldf3vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/muldf3vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_muldf3vfp
 //===-- muldf3vfp_test.c - Test __muldf3vfp -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/muldi3_test.c
+++ b/compiler-rt/test/builtins/Unit/muldi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_muldi3
 //===-- muldi3_test.c - Test __muldi3 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/mulodi4_test.c
+++ b/compiler-rt/test/builtins/Unit/mulodi4_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_mulodi4
 //===-- mulodi4_test.c - Test __mulodi4 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/mulosi4_test.c
+++ b/compiler-rt/test/builtins/Unit/mulosi4_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_mulosi4
 //===-- mulosi4_test.c - Test __mulosi4 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/muloti4_test.c
+++ b/compiler-rt/test/builtins/Unit/muloti4_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_muloti4
 // REQUIRES: int128
 //===-- muloti4_test.c - Test __muloti4 -----------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/mulsc3_test.c
+++ b/compiler-rt/test/builtins/Unit/mulsc3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -lm -o %t && %run %t
+// REQUIRES: librt_has_mulsc3
 //===-- mulsc3_test.c - Test __mulsc3 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/mulsf3vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/mulsf3vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_mulsf3vfp
 //===-- mulsf3vfp_test.c - Test __mulsf3vfp -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/multc3_test.c
+++ b/compiler-rt/test/builtins/Unit/multc3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_multc3
 //===-- multc3_test.c - Test __multc3 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/multf3_test.c
+++ b/compiler-rt/test/builtins/Unit/multf3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_multf3
 //===--------------- multf3_test.c - Test __multf3 ------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/multi3_test.c
+++ b/compiler-rt/test/builtins/Unit/multi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_multi3
 // REQUIRES: int128
 //===-- multi3_test.c - Test __multi3 -------------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/mulvdi3_test.c
+++ b/compiler-rt/test/builtins/Unit/mulvdi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_mulvdi3
 //===-- mulvdi3_test.c - Test __mulvdi3 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/mulvsi3_test.c
+++ b/compiler-rt/test/builtins/Unit/mulvsi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_mulvsi3
 //===-- mulvsi3_test.c - Test __mulvsi3 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/mulvti3_test.c
+++ b/compiler-rt/test/builtins/Unit/mulvti3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_mulvti3
 // REQUIRES: int128
 //===-- mulvti3_test.c - Test __mulvti3 -----------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/mulxc3_test.c
+++ b/compiler-rt/test/builtins/Unit/mulxc3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -lm -o %t && %run %t
+// REQUIRES: librt_has_mulxc3
 // UNSUPPORTED: powerpc64
 // REQUIRES: x86-target-arch
 //===-- mulxc3_test.c - Test __mulxc3 -------------------------------------===//

--- a/compiler-rt/test/builtins/Unit/nedf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/nedf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_nedf2vfp
 
 //===-- nedf2vfp_test.c - Test __nedf2vfp ---------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/negdf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/negdf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_negdf2vfp
 //===-- negdf2vfp_test.c - Test __negdf2vfp -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/negdi2_test.c
+++ b/compiler-rt/test/builtins/Unit/negdi2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_negdi2
 //===-- negdi2_test.c - Test __negdi2 -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/negsf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/negsf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_negsf2vfp
 //===-- negsf2vfp_test.c - Test __negsf2vfp -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/negti2_test.c
+++ b/compiler-rt/test/builtins/Unit/negti2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_negti2
 // REQUIRES: int128
 //===-- negti2_test.c - Test __negti2 -------------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/negvdi2_test.c
+++ b/compiler-rt/test/builtins/Unit/negvdi2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_negvdi2
 //===-- negvdi2_test.c - Test __negvdi2 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/negvsi2_test.c
+++ b/compiler-rt/test/builtins/Unit/negvsi2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_negvsi2
 //===-- negvsi2_test.c - Test __negvsi2 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/negvti2_test.c
+++ b/compiler-rt/test/builtins/Unit/negvti2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_negvti2
 // REQUIRES: int128
 //===-- negvti2_test.c - Test __negvti2 -----------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/nesf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/nesf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_nesf2vfp
 
 //===-- nesf2vfp_test.c - Test __nesf2vfp ---------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/netf2_test.c
+++ b/compiler-rt/test/builtins/Unit/netf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_comparetf2
 //===------------ netf2_test.c - Test __netf2------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/paritydi2_test.c
+++ b/compiler-rt/test/builtins/Unit/paritydi2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_paritydi2
 //===-- paritydi2_test.c - Test __paritydi2 -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/paritysi2_test.c
+++ b/compiler-rt/test/builtins/Unit/paritysi2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_paritysi2
 //===-- paritysi2_test.c - Test __paritysi2 -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/parityti2_test.c
+++ b/compiler-rt/test/builtins/Unit/parityti2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_parityti2
 // REQUIRES: int128
 //===-- parityti2_test.c - Test __parityti2 -------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/popcountdi2_test.c
+++ b/compiler-rt/test/builtins/Unit/popcountdi2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_popcountdi2
 //===-- popcountdi2_test.c - Test __popcountdi2 ----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/popcountsi2_test.c
+++ b/compiler-rt/test/builtins/Unit/popcountsi2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_popcountsi2
 //===-- popcountsi2_test.c - Test __popcountsi2 ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/popcountti2_test.c
+++ b/compiler-rt/test/builtins/Unit/popcountti2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_popcountti2
 // REQUIRES: int128
 //===-- popcountti2_test.c - Test __popcountti2 ----------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/powidf2_test.c
+++ b/compiler-rt/test/builtins/Unit/powidf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_powidf2
 //===-- powidf2_test.cpp - Test __powidf2 ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/powisf2_test.c
+++ b/compiler-rt/test/builtins/Unit/powisf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_powisf2
 //===-- powisf2_test.cpp - Test __powisf2 ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/powitf2_test.c
+++ b/compiler-rt/test/builtins/Unit/powitf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_powitf2
 //===-- powitf2_test.cpp - Test __powitf2 ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/powixf2_test.c
+++ b/compiler-rt/test/builtins/Unit/powixf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_powixf2
 // UNSUPPORTED: powerpc64
 // REQUIRES: x86-target-arch
 //===-- powixf2_test.cpp - Test __powixf2 ---------------------------------===//

--- a/compiler-rt/test/builtins/Unit/subdf3vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/subdf3vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_subdf3vfp
 //===-- subdf3vfp_test.c - Test __subdf3vfp -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/subsf3vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/subsf3vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_subsf3vfp
 //===-- subsf3vfp_test.c - Test __subsf3vfp -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/subtf3_test.c
+++ b/compiler-rt/test/builtins/Unit/subtf3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_subtf3
 //===--------------- subtf3_test.c - Test __subtf3 ------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/subvdi3_test.c
+++ b/compiler-rt/test/builtins/Unit/subvdi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_subvdi3
 //===-- subvdi3_test.c - Test __subvdi3 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/subvsi3_test.c
+++ b/compiler-rt/test/builtins/Unit/subvsi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_subvsi3
 //===-- subvsi3_test.c - Test __subvsi3 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/subvti3_test.c
+++ b/compiler-rt/test/builtins/Unit/subvti3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_subvti3
 // REQUIRES: int128
 //===-- subvti3_test.c - Test __subvti3 -----------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/trampoline_setup_test.c
+++ b/compiler-rt/test/builtins/Unit/trampoline_setup_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -fnested-functions -o %t && %run %t
+// REQUIRES: librt_has_trampoline_setup
 /* ===-- trampoline_setup_test.c - Test __trampoline_setup -----------------===
  *
  * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/truncdfhf2_test.c
+++ b/compiler-rt/test/builtins/Unit/truncdfhf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_truncdfhf2
 
 //===--------------- truncdfhf2_test.c - Test __truncdfhf2 ----------------===//
 //

--- a/compiler-rt/test/builtins/Unit/truncdfsf2_test.c
+++ b/compiler-rt/test/builtins/Unit/truncdfsf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_truncdfsf2
 
 //===--------------- truncdfsf2_test.c - Test __truncdfsf2 ----------------===//
 //

--- a/compiler-rt/test/builtins/Unit/truncdfsf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/truncdfsf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_truncdfsf2vfp
 //===-- truncdfsf2vfp_test.c - Test __truncdfsf2vfp -----------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/truncsfhf2_test.c
+++ b/compiler-rt/test/builtins/Unit/truncsfhf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_truncsfhf2
 
 //===--------------- truncsfhf2_test.c - Test __truncsfhf2 ----------------===//
 //

--- a/compiler-rt/test/builtins/Unit/trunctfdf2_test.c
+++ b/compiler-rt/test/builtins/Unit/trunctfdf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_trunctfdf2
 //===-------------- trunctfdf2_test.c - Test __trunctfdf2 -----------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/trunctfsf2_test.c
+++ b/compiler-rt/test/builtins/Unit/trunctfsf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_trunctfsf2
 //===--------------- trunctfsf2_test.c - Test __trunctfsf2 ----------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/ucmpdi2_test.c
+++ b/compiler-rt/test/builtins/Unit/ucmpdi2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_ucmpdi2
 //===-- ucmpdi2_test.c - Test __ucmpdi2 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/ucmpti2_test.c
+++ b/compiler-rt/test/builtins/Unit/ucmpti2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_ucmpti2
 // REQUIRES: int128
 //===-- ucmpti2_test.c - Test __ucmpti2 -----------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/udivdi3_test.c
+++ b/compiler-rt/test/builtins/Unit/udivdi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_udivdi3
 //===-- udivdi3_test.c - Test __udivdi3 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/udivmoddi4_test.c
+++ b/compiler-rt/test/builtins/Unit/udivmoddi4_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_udivmoddi4
 //===-- udivmoddi4_test.c - Test __udivmoddi4 -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/udivmodsi4_test.c
+++ b/compiler-rt/test/builtins/Unit/udivmodsi4_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_udivmodsi4
 //===-- udivmodsi4_test.c - Test __udivmodsi4 -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/udivsi3_test.c
+++ b/compiler-rt/test/builtins/Unit/udivsi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_udivsi3
 //===-- udivsi3_test.c - Test __udivsi3 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/udivti3_test.c
+++ b/compiler-rt/test/builtins/Unit/udivti3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_udivti3
 // REQUIRES: int128
 //===-- udivti3_test.c - Test __udivti3 -----------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/umoddi3_test.c
+++ b/compiler-rt/test/builtins/Unit/umoddi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_umoddi3
 //===-- umoddi3_test.c - Test __umoddi3 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/umodsi3_test.c
+++ b/compiler-rt/test/builtins/Unit/umodsi3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_umodsi3
 //===-- umodsi3_test.c - Test __umodsi3 -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/test/builtins/Unit/umodti3_test.c
+++ b/compiler-rt/test/builtins/Unit/umodti3_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_umodti3
 // REQUIRES: int128
 //===-- umodti3_test.c - Test __umodti3 -----------------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/unorddf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/unorddf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_unorddf2vfp
 
 //===-- unorddf2vfp_test.c - Test __unorddf2vfp ---------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/unordsf2vfp_test.c
+++ b/compiler-rt/test/builtins/Unit/unordsf2vfp_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_unordsf2vfp
 
 //===-- unordsf2vfp_test.c - Test __unordsf2vfp ---------------------------===//
 //

--- a/compiler-rt/test/builtins/Unit/unordtf2_test.c
+++ b/compiler-rt/test/builtins/Unit/unordtf2_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// REQUIRES: librt_has_comparetf2
 //===------------ unordtf2_test.c - Test __unordtf2------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
This is a collection of upstream fixes that makes it possible to run the builtin tests on macOS.

Included also is fix for running `check-asan`. Although I didn't really want to couple these things together it turns out this change also stops the macOS i386 built-in tests from running on 10.15 which is what we want.