### PR TITLE
SwiftDWARFImporterDelegate: Cache type lookups to avoid searching the…

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -125,6 +125,8 @@ public:
 
   ~SwiftASTContext();
 
+  const std::string &GetDescription() const;
+
   // PluginInterface functions
   ConstString GetPluginName() override;
 
@@ -313,6 +315,7 @@ public:
   CompilerType ImportType(CompilerType &type, Status &error);
 
   swift::ClangImporter *GetClangImporter();
+  swift::DWARFImporterDelegate *GetDWARFImporterDelegate();
 
   struct TupleElement {
     ConstString element_name;

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
@@ -39,6 +39,7 @@ class TestSwiftDWARFImporterObjC(lldbtest.TestBase):
     @swiftTest
     def test_dwarf_importer(self):
         self.runCmd("settings set symbols.use-swift-dwarfimporter true")
+
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('main.swift'))
@@ -58,5 +59,5 @@ class TestSwiftDWARFImporterObjC(lldbtest.TestBase):
         # This is a Clang type, since Clang doesn't generate DWARF for protocols.
         self.expect("target var -d no-dyn proto", substrs=["(id)", "proto"])
         # This is a Swift type.
-        self.expect("target var -d run proto", substrs=["(ProtoImpl?)", "proto"])
+        self.expect("target var -d run proto", substrs=["(ProtoImpl)", "proto"])
         self.expect("target var -O proto", substrs=["<ProtoImpl"])

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/Inputs/Modules/module.modulemap
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/Inputs/Modules/module.modulemap
@@ -1,0 +1,4 @@
+module ObjCModule {
+  header "objc-header.h"
+  export *
+}

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/Inputs/Modules/objc-header.h
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/Inputs/Modules/objc-header.h
@@ -1,0 +1,9 @@
+/* -*- ObjC -*- */
+@import Foundation;
+
+@interface ObjCClass : NSObject
+- (instancetype)init;
+- (NSString *)getString;
+- (id)getMangled;
+- (id)getRawname;
+@end

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/Library.swift
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/Library.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// This is an object exposed to Objective-C as "_Tt7Library10SwiftClassC".
+@objc public class MangledSwiftClass : NSObject {
+  @objc public func getString() -> NSString { return "Hello from Swift!" }
+}
+
+/// This is an object exposed to Objective-C as "RawNameSwiftClass".
+@objc(RawNameSwiftClass) public class RawNameSwiftClass : NSObject {
+  @objc public func getString() -> NSString { return "Hello from Swift!" }
+}

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/Makefile
@@ -1,0 +1,19 @@
+LEVEL = ../../../../make
+
+MAKE_GMODULES := YES
+SWIFT_OBJC_INTEROP = 1
+SWIFT_SOURCES := main.swift
+OBJC_SOURCES := objc.m
+CFLAGS_EXTRAS = -I$(BUILDDIR)/include
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)/include
+LD_EXTRAS := libLibrary.dylib
+
+include $(LEVEL)/Makefile.rules
+
+objc.o: libLibrary.dylib
+
+libLibrary.dylib: Library.swift
+	$(MAKE) -f $(MAKEFILE_RULES) \
+		DYLIB_SWIFT_SOURCES=Library.swift \
+		DYLIB_NAME=Library \
+		SWIFTFLAGS_EXTRAS="-emit-objc-header-path $(BUILDDIR)/include/Library-Swift.h"

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
@@ -1,0 +1,53 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+
+class TestSwiftDWARFImporter_Swift(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    def build(self):
+        include = self.getBuildArtifact('include')
+        inputs = self.getSourcePath(os.path.join('Inputs', 'Modules'))
+        lldbutil.mkdir_p(include)
+        import shutil
+        for f in ['module.modulemap', 'objc-header.h']:
+            shutil.copyfile(os.path.join(inputs, f), os.path.join(include, f))
+
+        super(TestSwiftDWARFImporter_Swift, self).build()
+
+        # Remove the header files to thwart ClangImporter.
+        self.assertTrue(os.path.isdir(include))
+        shutil.rmtree(include)
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.runCmd("settings set symbols.use-swift-dwarfimporter true")
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        log = self.getBuildArtifact("types.log")
+        self.runCmd('log enable lldb types -f "%s"' % log)
+
+        self.expect("target var -d run myobj", substrs=["(ObjCClass)"])
+
+        found = 0
+        response = 0
+        logfile = open(log, "r")
+        for line in logfile:
+            if 'SwiftDWARFImporterDelegate::lookupValue("ObjCClass")' in line:
+                found += 1
+            elif found == 1 and response == 0 and 'SwiftDWARFImporterDelegate' in line:
+                self.assertTrue('from debug info' in line, line)
+                response += 1
+            elif found == 2 and response == 1 and 'SwiftDWARFImporterDelegate' in line:
+                self.assertTrue('found in cache' in line, line)
+                response += 1
+        self.assertEqual(found, 2)
+        self.assertEqual(response, 2)

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/main.swift
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/main.swift
@@ -1,0 +1,10 @@
+import ObjCModule
+
+func use<T>(_ t : T) {}
+
+guard let obj = ObjCClass() else { exit(1) }
+let myobj = obj
+let mangled = obj.getMangled()!
+let rawname = obj.getRawname()!
+let s = obj.getString()
+use(s) // break here

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/objc.m
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/objc.m
@@ -1,0 +1,31 @@
+@import ObjCModule;
+#include "Library-Swift.h"
+
+@implementation ObjCClass {
+  id mangled_swift_obj;
+  id rawname_swift_obj;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    mangled_swift_obj = [MangledSwiftClass new];
+    rawname_swift_obj = [RawNameSwiftClass new];
+  }
+  return self;
+}
+
+- (id)getMangled {
+  return mangled_swift_obj;
+}
+
+- (id)getRawname {
+  return rawname_swift_obj;
+}
+
+- (NSString *)getString {
+  return [mangled_swift_obj getString];
+}
+
+@end
+

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -920,6 +920,8 @@ SwiftASTContext::~SwiftASTContext() {
   }
 }
 
+const std::string &SwiftASTContext::GetDescription() const { return m_description; }
+
 ConstString SwiftASTContext::GetPluginNameStatic() {
   return ConstString("swift");
 }
@@ -3103,6 +3105,11 @@ private:
 /// Clang AST to ClangImporter to import the type into Swift.
 class SwiftDWARFImporterDelegate : public swift::DWARFImporterDelegate {
   SwiftASTContext &m_swift_ast_ctx;
+  using ModuleAndName = std::pair<const char *, const char *>;
+  /// Caches successful lookups for the scratch context.
+  llvm::DenseMap<ModuleAndName, llvm::SmallVector<clang::QualType, 1>>
+      m_decl_cache;
+  std::string m_description;
 
   /// Used to filter out types with mismatching kinds.
   bool HasTypeKind(TypeSP clang_type_sp, swift::ClangTypeKind kind) {
@@ -3170,9 +3177,42 @@ class SwiftDWARFImporterDelegate : public swift::DWARFImporterDelegate {
     }
   }
 
+  /// Import \p qual_type from one clang ASTContext to another and
+  /// add it to \p results if successful.
+  void importType(clang::QualType qual_type, clang::ASTContext &from_ctx,
+                  clang::ASTContext &to_ctx,
+                  llvm::Optional<swift::ClangTypeKind> kind,
+                  llvm::SmallVectorImpl<clang::Decl *> &results) {
+    clang::FileSystemOptions file_system_options;
+    clang::FileManager file_manager(
+        file_system_options, FileSystem::Instance().GetVirtualFileSystem());
+    clang::ASTImporter importer(to_ctx, file_manager, from_ctx, file_manager,
+                                false);
+    llvm::Expected<clang::QualType> clang_type(importer.Import(qual_type));
+    if (!clang_type) {
+      llvm::consumeError(clang_type.takeError());
+      return;
+    }
+
+    // Retrieve the imported type's Decl.
+    if (kind) {
+      if (clang::Decl *clang_decl = GetDeclForTypeAndKind(*clang_type, *kind))
+        results.push_back(clang_decl);
+    } else {
+      swift::ClangTypeKind kinds[] = {
+          swift::ClangTypeKind::Typedef, // =swift::ClangTypeKind::ObjCClass,
+          swift::ClangTypeKind::Tag, swift::ClangTypeKind::ObjCProtocol};
+      for (auto kind : kinds)
+        if (clang::Decl *clang_decl = GetDeclForTypeAndKind(*clang_type, kind))
+          results.push_back(clang_decl);
+    }
+  }
+
 public:
   SwiftDWARFImporterDelegate(SwiftASTContext &swift_ast_ctx)
-      : m_swift_ast_ctx(swift_ast_ctx) {}
+      : m_swift_ast_ctx(swift_ast_ctx),
+        m_description(swift_ast_ctx.GetDescription() +
+                      "::SwiftDWARFImporterDelegate") {}
 
   /// Look up a clang::Decl by name.
   ///
@@ -3231,6 +3271,8 @@ public:
   void lookupValue(StringRef name, llvm::Optional<swift::ClangTypeKind> kind,
                    StringRef inModule,
                    llvm::SmallVectorImpl<clang::Decl *> &results) override {
+    LOG_PRINTF(LIBLLDB_LOG_TYPES, "(\"%s\")", name.str().c_str());
+
     // We will not find any Swift types in the Clang compile units.
     if (SwiftLanguageRuntime::IsSwiftMangledName(name.str().c_str()))
       return;
@@ -3241,15 +3283,16 @@ public:
 
     // Find the type in the debug info.
     TypeMap clang_types;
+    ConstString name_cs(name);
+    ConstString module_cs(inModule);
 
     llvm::SmallVector<CompilerContext, 3> decl_context;
     // Perform a lookup in a specific module, if requested.
     if (!inModule.empty())
-      decl_context.push_back(
-          {CompilerContextKind::Module, ConstString(inModule)});
+      decl_context.push_back({CompilerContextKind::Module, module_cs});
     // Swift doesn't keep track of submodules.
     decl_context.push_back({CompilerContextKind::AnyModule, ConstString()});
-    decl_context.push_back({GetCompilerContextKind(kind), ConstString(name)});
+    decl_context.push_back({GetCompilerContextKind(kind), name_cs});
     auto search = [&](Module &module) {
       return module.FindTypes(decl_context,
                               ClangASTContext::GetSupportedLanguagesForTypes(),
@@ -3258,16 +3301,46 @@ public:
     if (Module *module = m_swift_ast_ctx.GetModule())
       search(*module);
     else if (TargetSP target_sp = m_swift_ast_ctx.GetTarget().lock()) {
-      // In a scratch context, search everywhere.
+      // In a scratch context, check the module's DWARFImporterDelegates first.
+      //
+      // It's a common pattern that a type is revisited immediately
+      // after looking it up in a per-module context in the scratch
+      // context for dynamic type resolution.
       auto images = target_sp->GetImages();
-      for (size_t i = 0; i != images.GetSize(); ++i)
-        if (search(*images.GetModuleAtIndex(i)))
-          break;
+      for (size_t i = 0; i != images.GetSize(); ++i) {
+        auto module_sp = images.GetModuleAtIndex(i);
+        auto ts = module_sp->GetTypeSystemForLanguage(lldb::eLanguageTypeSwift);
+        if (!ts) {
+          llvm::consumeError(ts.takeError());
+          continue;
+        }
+        auto *swift_ast_ctx = static_cast<SwiftASTContext *>(&*ts);
+        auto *dwarf_imp = static_cast<SwiftDWARFImporterDelegate *>(
+            swift_ast_ctx->GetDWARFImporterDelegate());
+        if (!dwarf_imp)
+          continue;
+        auto it = dwarf_imp->m_decl_cache.find(
+            {module_cs.GetCString(), name_cs.GetCString()});
+        if (it == dwarf_imp->m_decl_cache.end())
+          continue;
+
+        auto *from_clang_importer = swift_ast_ctx->GetClangImporter();
+        if (!from_clang_importer)
+          continue;
+        auto &from_ctx = from_clang_importer->getClangASTContext();
+        auto &to_ctx = clang_importer->getClangASTContext();
+        for (clang::QualType qual_type : it->second)
+          importType(qual_type, from_ctx, to_ctx, kind, results);
+      }
+      LOG_PRINTF(LIBLLDB_LOG_TYPES, "%d types found in cache.", results.size());
+
+      // TODO: Otherwise, the correct thing to do is to invoke
+      //       search() on all modules. In practice, however, this is
+      //       prohibitively expensive, so we need to do something
+      //       more targeted.
+      return;
     }
 
-    clang::FileSystemOptions file_system_options;
-    clang::FileManager file_manager(
-        file_system_options, FileSystem::Instance().GetVirtualFileSystem());
     clang_types.ForEach([&](lldb::TypeSP &clang_type_sp) {
       if (!clang_type_sp)
         return true;
@@ -3290,29 +3363,19 @@ public:
       clang::ASTContext *from_ctx = type_system->getASTContext();
       if (!from_ctx)
         return true;
-      clang::ASTImporter importer(to_ctx, file_manager, *from_ctx, file_manager,
-                                  false);
-      llvm::Expected<clang::QualType> clang_type(
-          importer.Import(ClangUtil::GetQualType(compiler_type)));
-      if (!clang_type) {
-        llvm::consumeError(clang_type.takeError());
-        return true;
-      }
 
-      // Retrieve the imported type's Decl.
-      if (kind) {
-        if (clang::Decl *clang_decl = GetDeclForTypeAndKind(*clang_type, *kind))
-          results.push_back(clang_decl);
-      } else {
-        swift::ClangTypeKind kinds[] = {
-            swift::ClangTypeKind::Typedef, // =swift::ClangTypeKind::ObjCClass,
-            swift::ClangTypeKind::Tag, swift::ClangTypeKind::ObjCProtocol};
-        for (auto kind : kinds)
-          if (clang::Decl *clang_decl = GetDeclForTypeAndKind(*clang_type, kind))
-            results.push_back(clang_decl);
-      }
+      clang::QualType qual_type = ClangUtil::GetQualType(compiler_type);
+      importType(qual_type, *from_ctx, to_ctx, kind, results);
+
+      // If this is a module context, cache the result for the scratch context.
+      if (m_swift_ast_ctx.GetModule())
+        m_decl_cache[{module_cs.GetCString(), name_cs.GetCString()}].push_back(
+            qual_type);
+
       return true;
     });
+
+    LOG_PRINTF(LIBLLDB_LOG_TYPES, "%d types from debug info.", results.size());
   }
 };
 } // namespace lldb_private
@@ -3490,6 +3553,12 @@ swift::ClangImporter *SwiftASTContext::GetClangImporter() {
 
   GetASTContext();
   return m_clang_importer;
+}
+
+swift::DWARFImporterDelegate *SwiftASTContext::GetDWARFImporterDelegate() {
+  VALID_OR_RETURN(nullptr);
+
+  return m_dwarf_importer_delegate_up.get();
 }
 
 bool SwiftASTContext::AddClangArgument(std::string clang_arg, bool unique) {


### PR DESCRIPTION
… world.

When a type is being looked up on behalf of a per-module context, it
is often looked up again immediately afterwards in the scratch context
for the purpose of dynamic type resolution. This time hoewever we
search all lldb::Modules for the type since the scratch context
doesn't know where the query is coming from. This patch adds caching
to avoid this situation at the cost of potentially missing
scratch-context-only lookups.

rdar://problem/56582727