### PR TITLE
[lldb] Reland 370734: Test 'frame select -r' and fix that INT32_MIN b…

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/commands/frame/select/TestFrameSelect.py
+++ b/lldb/packages/Python/lldbsuite/test/commands/frame/select/TestFrameSelect.py
@@ -36,3 +36,42 @@ class TestFrameSelect(TestBase):
 
         self.expect("frame select -r 100")
         self.expect("frame select -r 1", error=True, substrs=["Already at the top of the stack."])
+
+    @no_debug_info_test
+    @skipIfWindows
+    def test_mixing_relative_and_abs(self):
+        self.build()
+
+        lldbutil.run_to_source_breakpoint(self,
+            "// Set break point at this line.", lldb.SBFileSpec("main.cpp"))
+
+        # The function associated with each frame index can change depending
+        # on the function calling main (e.g. `start`), so this only tests that
+        # the frame index number is correct. We test the actual functions
+        # in the relative test.
+
+        # Jump to the top of the stack.
+        self.expect("frame select 0", substrs=["frame #0"])
+
+        # Run some relative commands.
+        self.expect("up", substrs=["frame #1"])
+        self.expect("frame select -r 1", substrs=["frame #2"])
+        self.expect("frame select -r -1", substrs=["frame #1"])
+
+        # Test that absolute indices still work.
+        self.expect("frame select 2", substrs=["frame #2"])
+        self.expect("frame select 1", substrs=["frame #1"])
+        self.expect("frame select 3", substrs=["frame #3"])
+        self.expect("frame select 0", substrs=["frame #0"])
+        self.expect("frame select 1", substrs=["frame #1"])
+
+        # Run some other relative frame select commands.
+        self.expect("down", substrs=["frame #0"])
+        self.expect("frame select -r 1", substrs=["frame #1"])
+        self.expect("frame select -r -1", substrs=["frame #0"])
+
+        # Test that absolute indices still work.
+        self.expect("frame select 2", substrs=["frame #2"])
+        self.expect("frame select 1", substrs=["frame #1"])
+        self.expect("frame select 3", substrs=["frame #3"])
+        self.expect("frame select 0", substrs=["frame #0"])

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -263,8 +263,10 @@ public:
       return error;
     }
 
-    void OptionParsingStarting(ExecutionContext *execution_context) override {}
-    
+    void OptionParsingStarting(ExecutionContext *execution_context) override {
+      relative_frame_offset.reset();
+    }
+
     llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
       return llvm::makeArrayRef(g_frame_select_options);
     }


### PR DESCRIPTION
…reaks the option parser

The problem with r370734 was that it removed the code for resetting the options in
OptionParsingStarting. This caused that once a 'frame select -r ...' command was executed,
we kept the relative index argument for all following 'frame select ...' invocations (even
the ones with an absolute index as they are the same command object). See rdar://55791276.

This relands the patch but keeps the code that resets the command options before execution.

llvm-svn: 373201