### PR TITLE
Avoid adding any framework paths in /System/Library in process_one_mo…

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lang/swift/system_framework/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/system_framework/Makefile
@@ -1,0 +1,7 @@
+LEVEL = ../../../make
+
+SWIFT_SOURCES := main.swift
+
+SWIFT_FLAGS_EXTRAS := -framwork CoreGraphics
+
+include $(LEVEL)/Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/system_framework/TestSwiftSystemFramework.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/system_framework/TestSwiftSystemFramework.py
@@ -6,11 +6,12 @@ import os
 import unittest2
 
 
-class TestSwiftAnyType(lldbtest.TestBase):
+class TestSwiftSystemFramework(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @skipIf(oslist=no_match(["macosx"]))
     def test_system_framework(self):
         """Make sure no framework paths into /System/Library are added"""
         self.build()

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/system_framework/TestSwiftSystemFramework.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/system_framework/TestSwiftSystemFramework.py
@@ -1,0 +1,34 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+
+class TestSwiftAnyType(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    def test_system_framework(self):
+        """Make sure no framework paths into /System/Library are added"""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        log = self.getBuildArtifact("types.log")
+        self.runCmd('log enable lldb types -f "%s"' % log)
+        self.expect("settings set target.use-all-compiler-flags true")
+        self.expect("expression -- 0")
+        pos = 0
+        neg = 0
+        with open(log, "r") as logfile:
+            for line in logfile:
+                if "process_one_module rejecting framework path" in line:
+                    pos += 1
+                elif "/System/Library/Frameworks" in line:
+                    neg += 1
+
+        self.assertGreater(pos, 0, "sanity check failed")
+        self.assertEqual(neg, 0, "found /System/Library/Frameworks in log")

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/system_framework/main.swift
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/system_framework/main.swift
@@ -1,0 +1,6 @@
+import ApplicationServices
+
+func stop() {}
+
+let a = ATSFSSpec()
+stop() // break here

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -2146,7 +2146,10 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
                 std::string parent_path =
                     module_path.substr(0, framework_offset);
 
-                if (!StringRef(parent_path).equals("/System/Library") &&
+                // Never add framework paths pointing into the
+                // system. These modules must be imported from the
+                // SDK instead.
+                if (!StringRef(parent_path).startswith("/System/Library") &&
                     !IsDeviceSupport(parent_path.c_str()))
                   framework_search_paths.push_back(
                       {std::move(parent_path), /*system*/ false});


### PR DESCRIPTION
…dule.

The merit of process_one_module can be debated, but these are
definitely wrong, system modules must be imported from the SDK instead.

<rdar://problem/56280346>

(cherry picked from commit e9e842b72f8a9e7578c493e73eb09786d03fce54)