### PR TITLE
[upstreaming] Revert changes to ClangASTContext::IsObjCObjectOrInterf…

### DIFF
--- a/lldb/source/Symbol/ClangASTContext.cpp
+++ b/lldb/source/Symbol/ClangASTContext.cpp
@@ -3627,7 +3627,7 @@ bool ClangASTContext::IsObjCClassType(const CompilerType &type) {
 }
 
 bool ClangASTContext::IsObjCObjectOrInterfaceType(const CompilerType &type) {
-  if (type && ClangUtil::IsClangType(type))
+  if (ClangUtil::IsClangType(type))
     return ClangUtil::GetCanonicalQualType(type)->isObjCObjectOrInterfaceType();
   return false;
 }


### PR DESCRIPTION
…aceType

The check if type is valid has been upstreamed into IsClangType.