### PR TITLE
[Reproducer] Quit the debugger after generating a reproducer

### DIFF
--- a/lldb/source/Commands/CommandObjectReproducer.cpp
+++ b/lldb/source/Commands/CommandObjectReproducer.cpp
@@ -78,7 +78,7 @@ public:
             interpreter, "reproducer generate",
             "Generate reproducer on disk. When the debugger is in capture "
             "mode, this command will output the reproducer to a directory on "
-            "disk. In replay mode this command in a no-op.",
+            "disk and quit. In replay mode this command in a no-op.",
             nullptr) {}
 
   ~CommandObjectReproducerGenerate() override = default;
@@ -110,7 +110,9 @@ protected:
         << "Please have a look at the directory to assess if you're willing to "
            "share the contained information.\n";
 
-    result.SetStatus(eReturnStatusSuccessFinishResult);
+    m_interpreter.BroadcastEvent(
+        CommandInterpreter::eBroadcastBitQuitCommandReceived);
+    result.SetStatus(eReturnStatusQuit);
     return result.Succeeded();
   }
 };


### PR DESCRIPTION
Currently nothing prevents you from continuing your debug session after
generating the reproducer. This can cause the reproducer to end up in an
inconsistent state. Most of the time this doesn't matter, but I want to
prevent this from causing bugs in the future.

(cherry picked from commit 0cf86da1741fb1a4278dc31dfc8f1538c9186892)