### PR TITLE
[NFC] Drop typeCheckExternalDefinitions

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1498,7 +1498,6 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     }
   } else {
     swift::performPlaygroundTransform(parsed_expr->source_file, true);
-    swift::typeCheckExternalDefinitions(parsed_expr->source_file);
   }
 
   // FIXME: We now should have to do the name binding and type


### PR DESCRIPTION
performTypeChecking will handle the nitty-gritty of closure captures,
and synthesized declarations are now eagerly typechecked.  There's no
reason to call this after the playground transform.