### PR TITLE
[upstreaming] Move CompilerType(swift::Type) constructor to SwiftASTC…

### DIFF
--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -13,7 +13,6 @@
 #include <string>
 #include <vector>
 
-#include "lldb/Core/SwiftForward.h"
 #include "lldb/lldb-private.h"
 #include "llvm/ADT/APSInt.h"
 
@@ -32,7 +31,6 @@ class CompilerType {
 public:
   // Constructors and Destructors
   CompilerType(TypeSystem *type_system, lldb::opaque_compiler_type_t type);
-  CompilerType(swift::Type qual_type);
 
   CompilerType(const CompilerType &rhs)
       : m_type(rhs.m_type), m_type_system(rhs.m_type_system) {}

--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -15,6 +15,7 @@
 
 #include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 #include "lldb/Core/ClangForward.h"
+#include "lldb/Core/SwiftForward.h"
 #include "lldb/Core/ThreadSafeDenseMap.h"
 #include "lldb/Core/ThreadSafeDenseSet.h"
 #include "lldb/Symbol/CompilerType.h"
@@ -65,6 +66,8 @@ class SwiftEnumDescriptor;
 namespace lldb_private {
 
 struct SourceModule;
+
+CompilerType ToCompilerType(swift::Type qual_type);
 
 class SwiftASTContext : public TypeSystem {
 public:

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -14,6 +14,7 @@
 
 #include "lldb/Expression/ExpressionParser.h"
 #include "lldb/Expression/ExpressionSourceCode.h"
+#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/Log.h"
@@ -744,7 +745,7 @@ void SwiftASTManipulator::FindVariableDeclarations(
     auto type = var_decl->getDeclContext()->mapTypeIntoContext(
         var_decl->getInterfaceType());
     persistent_info.m_name = name;
-    persistent_info.m_type = {type.getPointer()};
+    persistent_info.m_type = ToCompilerType({type.getPointer()});
     persistent_info.m_decl = var_decl;
 
     m_variables.push_back(persistent_info);
@@ -810,7 +811,7 @@ void SwiftASTManipulator::InsertResult(
     SwiftASTManipulator::ResultLocationInfo &result_info) {
   swift::ASTContext &ast_context = m_source_file.getASTContext();
 
-  CompilerType return_ast_type(result_type.getPointer());
+  CompilerType return_ast_type = ToCompilerType(result_type.getPointer());
 
   result_var->overwriteAccess(swift::AccessLevel::Public);
   result_var->overwriteSetterAccess(swift::AccessLevel::Public);
@@ -851,7 +852,7 @@ void SwiftASTManipulator::InsertError(swift::VarDecl *error_var,
 
   swift::ASTContext &ast_context = m_source_file.getASTContext();
 
-  CompilerType error_ast_type(error_type.getPointer());
+  CompilerType error_ast_type = ToCompilerType(error_type.getPointer());
 
   error_var->overwriteAccess(swift::AccessLevel::Public);
   error_var->overwriteSetterAccess(swift::AccessLevel::Public);
@@ -951,7 +952,7 @@ bool SwiftASTManipulator::FixupResultAfterTypeChecking(Status &error) {
 
   swift::ASTContext &ast_context = m_source_file.getASTContext();
 
-  CompilerType return_ast_type(result_type.getPointer());
+  CompilerType return_ast_type = ToCompilerType(result_type.getPointer());
   swift::Identifier result_var_name =
       ast_context.getIdentifier(GetResultName());
   SwiftASTManipulatorBase::VariableMetadataSP metadata_sp(
@@ -995,7 +996,8 @@ bool SwiftASTManipulator::FixupResultAfterTypeChecking(Status &error) {
               continue;
 
             swift::Type error_type = var_decl->getInterfaceType();
-            CompilerType error_ast_type(error_type.getPointer());
+            CompilerType error_ast_type =
+                ToCompilerType(error_type.getPointer());
             SwiftASTManipulatorBase::VariableMetadataSP error_metadata_sp(
                 new VariableMetadataError());
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
@@ -15,6 +15,7 @@
 
 #include "SwiftExpressionVariable.h"
 
+#include "lldb/Core/SwiftForward.h"
 #include "lldb/Expression/ExpressionVariable.h"
 
 #include "llvm/ADT/DenseMap.h"

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.h
@@ -13,6 +13,7 @@
 #ifndef liblldb_SwiftREPLMaterializer_h
 #define liblldb_SwiftREPLMaterializer_h
 
+#include "lldb/Core/SwiftForward.h"
 #include "lldb/Expression/Materializer.h"
 
 namespace lldb_private {

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -1044,7 +1044,7 @@ bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
   if (generic_args.size() != 1)
     return false;
   auto swift_arg_type = generic_args[0];
-  CompilerType arg_type(swift_arg_type);
+  CompilerType arg_type = ToCompilerType(swift_arg_type);
 
   llvm::Optional<uint64_t> opt_arg_size = arg_type.GetByteSize(nullptr);
   if (!opt_arg_size)

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1315,7 +1315,7 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
                              name_parts.size() == 1 &&
                              name_parts.front() == module->getName().str())
                     results.insert(
-                        CompilerType(swift::ModuleType::get(module)));
+                        ToCompilerType(swift::ModuleType::get(module)));
                 }
               };
 
@@ -1462,7 +1462,7 @@ LazyBool SwiftLanguage::IsLogicalTrue(ValueObject &valobj, Status &error) {
   Scalar scalar_value;
 
   auto swift_ty = GetCanonicalSwiftType(valobj.GetCompilerType());
-  CompilerType valobj_type(swift_ty);
+  CompilerType valobj_type = ToCompilerType(swift_ty);
   Flags type_flags(valobj_type.GetTypeInfo());
   if (llvm::isa<SwiftASTContext>(valobj_type.GetTypeSystem())) {
     if (type_flags.AllSet(eTypeIsStructUnion) &&

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -206,7 +206,7 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
         return {};
       }
       preferred_name = name;
-      compiler_type = {swift_ast_ctx->TheRawPointerType};
+      compiler_type = ToCompilerType({swift_ast_ctx->TheRawPointerType});
     }
   }
 

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -10,7 +10,6 @@
 
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/StreamFile.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Symbol/Type.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/Process.h"
@@ -24,20 +23,12 @@
 #include <iterator>
 #include <mutex>
 
-#include "swift/AST/Type.h"
-#include "swift/AST/Types.h"
-
 using namespace lldb;
 using namespace lldb_private;
 
 CompilerType::CompilerType(TypeSystem *type_system,
                            lldb::opaque_compiler_type_t type)
     : m_type(type), m_type_system(type_system) {}
-
-CompilerType::CompilerType(swift::Type qual_type)
-    : m_type(qual_type.getPointer()),
-      m_type_system(
-          SwiftASTContext::GetSwiftASTContext(&qual_type->getASTContext())) {}
 
 CompilerType::~CompilerType() {}
 

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -1900,7 +1900,8 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Protocol(
   }
 
   auto type_and_address = result.getValue();
-  class_type_or_name.SetCompilerType(type_and_address.InstanceType);
+  class_type_or_name.SetCompilerType(
+      ToCompilerType(type_and_address.InstanceType));
   address.SetRawAddress(type_and_address.PayloadAddress.getAddressData());
   return true;
 }
@@ -2059,7 +2060,7 @@ SwiftLanguageRuntime::DoArchetypeBindingForType(StackFrame &stack_frame,
         swift::SubstFlags::DesugarMemberTypes);
     assert(target_swift_type);
 
-    return {target_swift_type.getPointer()};
+    return ToCompilerType({target_swift_type.getPointer()});
   }
   return base_type;
 }
@@ -2577,7 +2578,7 @@ lldb::addr_t SwiftLanguageRuntime::FixupAddress(lldb::addr_t addr,
 const swift::reflection::TypeInfo *
 SwiftLanguageRuntime::GetTypeInfo(CompilerType type) {
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
-  CompilerType can_type(swift_can_type);
+  CompilerType can_type = ToCompilerType(swift_can_type);
   ConstString mangled_name(can_type.GetMangledTypeName());
   StringRef mangled_no_prefix =
       swift::Demangle::dropSwiftManglingPrefix(mangled_name.GetStringRef());


### PR DESCRIPTION
…ontext

Moves the constructor from swift::Type -> CompilerType to SwiftASTContext, which is
the main user of this constructor. This makes our diff towards upstream smaller,
patching CompilerType with swift-specific code is in general against the idea of
CompilerType and we get rid of the tricky implicit conversion we get from having this
implicit constructor. I removed one really obvious swift::Type->CompilerType->swift::Type
conversion in this patch in `GetArchetypeNames` but there are few other places that
I didn't want to drive-by refactor in this patch.