### PR TITLE
Update LLVM-RTTI in SwiftUserExpression to the new version upstream

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -44,6 +44,8 @@
 
 using namespace lldb_private;
 
+char SwiftUserExpression::ID;
+
 SwiftUserExpression::SwiftUserExpression(
     ExecutionContextScope &exe_scope, llvm::StringRef expr,
     llvm::StringRef prefix, lldb::LanguageType language,

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -39,11 +39,15 @@ class SwiftExpressionParser;
 /// uses the Clang parser to produce LLVM IR from the expression.
 //----------------------------------------------------------------------
 class SwiftUserExpression : public LLVMUserExpression {
+  // LLVM RTTI support
+  static char ID;
+
 public:
-  /// LLVM-style RTTI support.
-  static bool classof(const Expression *E) {
-    return E->getKind() == eKindSwiftUserExpression;
+  bool isA(const void *ClassID) const override {
+    return ClassID == &ID || LLVMUserExpression::isA(ClassID);
   }
+  static bool classof(const Expression *obj) { return obj->isA(&ID); }
+
   enum { kDefaultTimeout = 500000u };
 
   class SwiftUserExpressionHelper : public ExpressionTypeSystemHelper {


### PR DESCRIPTION
Upstream stopped using the Kind enum but instead unique static vars.