### PR TITLE
Update test to not hard code the specific ref count that we see.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lang/swift/swift_reference_counting/main.swift
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/swift_reference_counting/main.swift
@@ -25,7 +25,7 @@ func lambda(_ Arg : Patatino) -> Int {
 
 func main() -> Int {
   var LiveObj = Patatino(37) //%self.expect('language swift refcount Blah', substrs=['unresolved identifier \'Blah\''], error=True)
-  var Ret : Int = lambda(LiveObj) //%self.expect('language swift refcount LiveObj', substrs=['(strong = 3, unowned = 1, weak = 1)'])
+  var Ret : Int = lambda(LiveObj) //%self.expect('language swift refcount LiveObj', substrs=['(strong =', 'unowned =', 'weak ='])
   var MyStruct = Tinky() //%self.expect('language swift refcount MyStruct', substrs=['refcount only available for class types'], error=True)
   return Ret
 }


### PR DESCRIPTION
We just want to make sure that we get some output, we don't care about the
actual ref count number in the output.