### PR TITLE
[upstreaming] Move CompilerType(swift::Type) constructor to SwiftASTC…

### DIFF
--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -13,7 +13,6 @@
 #include <string>
 #include <vector>
 
-#include "lldb/Core/SwiftForward.h"
 #include "lldb/lldb-private.h"
 #include "llvm/ADT/APSInt.h"
 
@@ -32,7 +31,6 @@ class CompilerType {
 public:
   // Constructors and Destructors
   CompilerType(TypeSystem *type_system, lldb::opaque_compiler_type_t type);
-  CompilerType(swift::Type qual_type);
 
   CompilerType(const CompilerType &rhs)
       : m_type(rhs.m_type), m_type_system(rhs.m_type_system) {}

--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -15,6 +15,7 @@
 
 #include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 #include "lldb/Core/ClangForward.h"
+#include "lldb/Core/SwiftForward.h"
 #include "lldb/Core/ThreadSafeDenseMap.h"
 #include "lldb/Core/ThreadSafeDenseSet.h"
 #include "lldb/Symbol/CompilerType.h"
@@ -65,6 +66,8 @@ class SwiftEnumDescriptor;
 namespace lldb_private {
 
 struct SourceModule;
+
+CompilerType ToCompilerType(swift::Type qual_type);
 
 class SwiftASTContext : public TypeSystem {
 public:

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -14,6 +14,7 @@
 
 #include "lldb/Expression/ExpressionParser.h"
 #include "lldb/Expression/ExpressionSourceCode.h"
+#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/Log.h"
@@ -744,7 +745,7 @@ void SwiftASTManipulator::FindVariableDeclarations(
     auto type = var_decl->getDeclContext()->mapTypeIntoContext(
         var_decl->getInterfaceType());
     persistent_info.m_name = name;
-    persistent_info.m_type = {type.getPointer()};
+    persistent_info.m_type = ToCompilerType({type.getPointer()});
     persistent_info.m_decl = var_decl;
 
     m_variables.push_back(persistent_info);
@@ -810,7 +811,7 @@ void SwiftASTManipulator::InsertResult(
     SwiftASTManipulator::ResultLocationInfo &result_info) {
   swift::ASTContext &ast_context = m_source_file.getASTContext();
 
-  CompilerType return_ast_type(result_type.getPointer());
+  CompilerType return_ast_type = ToCompilerType(result_type.getPointer());
 
   result_var->overwriteAccess(swift::AccessLevel::Public);
   result_var->overwriteSetterAccess(swift::AccessLevel::Public);
@@ -851,7 +852,7 @@ void SwiftASTManipulator::InsertError(swift::VarDecl *error_var,
 
   swift::ASTContext &ast_context = m_source_file.getASTContext();
 
-  CompilerType error_ast_type(error_type.getPointer());
+  CompilerType error_ast_type = ToCompilerType(error_type.getPointer());
 
   error_var->overwriteAccess(swift::AccessLevel::Public);
   error_var->overwriteSetterAccess(swift::AccessLevel::Public);
@@ -951,7 +952,7 @@ bool SwiftASTManipulator::FixupResultAfterTypeChecking(Status &error) {
 
   swift::ASTContext &ast_context = m_source_file.getASTContext();
 
-  CompilerType return_ast_type(result_type.getPointer());
+  CompilerType return_ast_type = ToCompilerType(result_type.getPointer());
   swift::Identifier result_var_name =
       ast_context.getIdentifier(GetResultName());
   SwiftASTManipulatorBase::VariableMetadataSP metadata_sp(
@@ -995,7 +996,8 @@ bool SwiftASTManipulator::FixupResultAfterTypeChecking(Status &error) {
               continue;
 
             swift::Type error_type = var_decl->getInterfaceType();
-            CompilerType error_ast_type(error_type.getPointer());
+            CompilerType error_ast_type =
+                ToCompilerType(error_type.getPointer());
             SwiftASTManipulatorBase::VariableMetadataSP error_metadata_sp(
                 new VariableMetadataError());
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
@@ -15,6 +15,7 @@
 
 #include "SwiftExpressionVariable.h"
 
+#include "lldb/Core/SwiftForward.h"
 #include "lldb/Expression/ExpressionVariable.h"
 
 #include "llvm/ADT/DenseMap.h"

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.h
@@ -13,6 +13,7 @@
 #ifndef liblldb_SwiftREPLMaterializer_h
 #define liblldb_SwiftREPLMaterializer_h
 
+#include "lldb/Core/SwiftForward.h"
 #include "lldb/Expression/Materializer.h"
 
 namespace lldb_private {

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -1043,7 +1043,7 @@ bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
   if (generic_args.size() != 1)
     return false;
   auto swift_arg_type = generic_args[0];
-  CompilerType arg_type(swift_arg_type);
+  CompilerType arg_type = ToCompilerType(swift_arg_type);
 
   llvm::Optional<uint64_t> opt_arg_size = arg_type.GetByteSize(nullptr);
   if (!opt_arg_size)

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1314,7 +1314,7 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
                              name_parts.size() == 1 &&
                              name_parts.front() == module->getName().str())
                     results.insert(
-                        CompilerType(swift::ModuleType::get(module)));
+                        ToCompilerType(swift::ModuleType::get(module)));
                 }
               };
 
@@ -1461,7 +1461,7 @@ LazyBool SwiftLanguage::IsLogicalTrue(ValueObject &valobj, Status &error) {
   Scalar scalar_value;
 
   auto swift_ty = GetCanonicalSwiftType(valobj.GetCompilerType());
-  CompilerType valobj_type(swift_ty);
+  CompilerType valobj_type = ToCompilerType(swift_ty);
   Flags type_flags(valobj_type.GetTypeInfo());
   if (llvm::isa<SwiftASTContext>(valobj_type.GetTypeSystem())) {
     if (type_flags.AllSet(eTypeIsStructUnion) &&

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -207,7 +207,7 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
         return {};
       }
       preferred_name = name;
-      compiler_type = {swift_ast_ctx->TheRawPointerType};
+      compiler_type = ToCompilerType({swift_ast_ctx->TheRawPointerType});
     }
   }
 

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -10,7 +10,6 @@
 
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/StreamFile.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Symbol/Type.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/Process.h"
@@ -24,20 +23,12 @@
 #include <iterator>
 #include <mutex>
 
-#include "swift/AST/Type.h"
-#include "swift/AST/Types.h"
-
 using namespace lldb;
 using namespace lldb_private;
 
 CompilerType::CompilerType(TypeSystem *type_system,
                            lldb::opaque_compiler_type_t type)
     : m_type(type), m_type_system(type_system) {}
-
-CompilerType::CompilerType(swift::Type qual_type)
-    : m_type(qual_type.getPointer()),
-      m_type_system(
-          SwiftASTContext::GetSwiftASTContext(&qual_type->getASTContext())) {}
 
 CompilerType::~CompilerType() {}
 

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -167,6 +167,12 @@ std::recursive_mutex g_log_mutex;
 using namespace lldb;
 using namespace lldb_private;
 
+CompilerType lldb_private::ToCompilerType(swift::Type qual_type) {
+  return CompilerType(
+      SwiftASTContext::GetSwiftASTContext(&qual_type->getASTContext()),
+      qual_type.getPointer());
+}
+
 typedef lldb_private::ThreadSafeDenseMap<swift::ASTContext *, SwiftASTContext *>
     ThreadSafeSwiftASTMap;
 
@@ -540,10 +546,10 @@ public:
       auto arg_type = case_decl->getArgumentInterfaceType();
       CompilerType case_type;
       if (arg_type) {
-        case_type = {
-            swift_can_type->getTypeOfMember(module_ctx, case_decl, arg_type)
-                ->getCanonicalType()
-                .getPointer()};
+        case_type = ToCompilerType(
+            {swift_can_type->getTypeOfMember(module_ctx, case_decl, arg_type)
+                 ->getCanonicalType()
+                 .getPointer()});
       }
 
       const bool is_indirect =
@@ -780,7 +786,7 @@ SwiftEnumDescriptor *SwiftASTContext::GetCachedEnumInfo(void *type) {
       return pos->second.get();
 
     swift::CanType swift_can_type(GetCanonicalSwiftType(type));
-    if (!SwiftASTContext::IsFullyRealized({swift_can_type}))
+    if (!SwiftASTContext::IsFullyRealized(ToCompilerType({swift_can_type})))
       return nullptr;
 
     SwiftEnumDescriptorSP enum_info_sp;
@@ -4380,7 +4386,7 @@ SwiftASTContext::GetTypeFromMangledTypename(ConstString mangled_typename,
     LOG_PRINTF(LIBLLDB_LOG_TYPES, "(\"%s\") -- found in the positive cache",
                mangled_cstr);
     assert(&found_type->getASTContext() == ast_ctx);
-    return {found_type};
+    return ToCompilerType({found_type});
   }
 
   if (m_negative_type_cache.Lookup(mangled_cstr)) {
@@ -4400,7 +4406,7 @@ SwiftASTContext::GetTypeFromMangledTypename(ConstString mangled_typename,
     found_type =
         convertSILFunctionTypesToASTFunctionTypes(found_type).getPointer();
     CacheDemangledType(mangled_typename, found_type);
-    CompilerType result_type(found_type);
+    CompilerType result_type = ToCompilerType(found_type);
     assert(&found_type->getASTContext() == ast_ctx);
     LOG_PRINTF(LIBLLDB_LOG_TYPES, "(\"%s\") -- found %s", mangled_cstr,
                result_type.GetTypeName().GetCString());
@@ -4417,7 +4423,7 @@ SwiftASTContext::GetTypeFromMangledTypename(ConstString mangled_typename,
 CompilerType SwiftASTContext::GetAnyObjectType() {
   VALID_OR_RETURN(CompilerType());
   swift::ASTContext *ast = GetASTContext();
-  return {ast->getAnyObjectType()};
+  return ToCompilerType({ast->getAnyObjectType()});
 }
 
 CompilerType SwiftASTContext::GetVoidFunctionType() {
@@ -4426,7 +4432,8 @@ CompilerType SwiftASTContext::GetVoidFunctionType() {
   if (!m_void_function_type) {
     swift::ASTContext *ast = GetASTContext();
     swift::Type empty_tuple_type(swift::TupleType::getEmpty(*ast));
-    m_void_function_type = {swift::FunctionType::get({}, empty_tuple_type)};
+    m_void_function_type =
+        ToCompilerType({swift::FunctionType::get({}, empty_tuple_type)});
   }
   return m_void_function_type;
 }
@@ -4441,7 +4448,7 @@ static CompilerType ValueDeclToType(swift::ValueDecl *decl,
       swift::Type swift_type = swift::TypeAliasType::get(
           alias_decl, swift::Type(), swift::SubstitutionMap(),
           alias_decl->getUnderlyingType());
-      return {swift_type.getPointer()};
+      return ToCompilerType({swift_type.getPointer()});
     }
 
     case swift::DeclKind::Enum:
@@ -4451,7 +4458,7 @@ static CompilerType ValueDeclToType(swift::ValueDecl *decl,
       swift::NominalTypeDecl *nominal_decl =
           swift::cast<swift::NominalTypeDecl>(decl);
       swift::Type swift_type = nominal_decl->getDeclaredType();
-      return {swift_type.getPointer()};
+      return ToCompilerType({swift_type.getPointer()});
     }
 
     default:
@@ -4498,7 +4505,7 @@ static SwiftASTContext::TypeOrDecl DeclToTypeOrDecl(swift::ASTContext *ast,
       swift::Type swift_type = swift::TypeAliasType::get(
           alias_decl, swift::Type(), swift::SubstitutionMap(),
           alias_decl->getUnderlyingType());
-      return CompilerType(swift_type.getPointer());
+      return ToCompilerType(swift_type.getPointer());
     }
     case swift::DeclKind::Enum:
     case swift::DeclKind::Struct:
@@ -4507,7 +4514,7 @@ static SwiftASTContext::TypeOrDecl DeclToTypeOrDecl(swift::ASTContext *ast,
       swift::NominalTypeDecl *nominal_decl =
           swift::cast<swift::NominalTypeDecl>(decl);
       swift::Type swift_type = nominal_decl->getDeclaredType();
-      return CompilerType(swift_type.getPointer());
+      return ToCompilerType(swift_type.getPointer());
     }
 
     case swift::DeclKind::Func:
@@ -4613,7 +4620,7 @@ size_t SwiftASTContext::FindTypes(const char *name,
                   swift::dyn_cast_or_null<swift::ValueDecl>(decl)) {
             swift::Type swift_type = value_decl->getInterfaceType();
             if (swift_type)
-              return {swift_type->getMetatypeInstanceType()};
+              return ToCompilerType({swift_type->getMetatypeInstanceType()});
           }
           return CompilerType();
         });
@@ -4717,7 +4724,7 @@ CompilerType SwiftASTContext::ImportType(CompilerType &type, Status &error) {
     swift::TypeBase *our_type_base =
         m_mangled_name_to_type_map.lookup(mangled_name.GetCString());
     if (our_type_base)
-      return {our_type_base};
+      return ToCompilerType({our_type_base});
     else {
       Status error;
 
@@ -4859,7 +4866,7 @@ SwiftASTContext::CreateTupleType(const std::vector<TupleElement> &elements) {
 
   Status error;
   if (elements.size() == 0)
-    return {GetASTContext()->TheEmptyTupleType};
+    return ToCompilerType({GetASTContext()->TheEmptyTupleType});
   else {
     std::vector<swift::TupleTypeElt> tuple_elems;
     for (const TupleElement &element : elements) {
@@ -4874,7 +4881,8 @@ SwiftASTContext::CreateTupleType(const std::vector<TupleElement> &elements) {
         return {};
     }
     llvm::ArrayRef<swift::TupleTypeElt> fields(tuple_elems);
-    return {swift::TupleType::get(fields, *GetASTContext()).getPointer()};
+    return ToCompilerType(
+        {swift::TupleType::get(fields, *GetASTContext()).getPointer()});
   }
 }
 
@@ -4889,7 +4897,7 @@ CompilerType SwiftASTContext::GetErrorType() {
     swift::NominalTypeDecl *error_type_decl = GetASTContext()->getErrorDecl();
     if (error_type_decl) {
       auto error_type = error_type_decl->getDeclaredType().getPointer();
-      return {error_type};
+      return ToCompilerType({error_type});
     }
   }
   return {};
@@ -4905,7 +4913,7 @@ uint32_t SwiftASTContext::GetPointerByteSize() {
 
   if (m_pointer_byte_size == 0)
     m_pointer_byte_size =
-        CompilerType(GetASTContext()->TheRawPointerType.getPointer())
+        ToCompilerType(GetASTContext()->TheRawPointerType.getPointer())
             .GetByteSize(nullptr)
             .getValueOr(0);
   return m_pointer_byte_size;
@@ -5142,7 +5150,7 @@ bool SwiftASTContext::IsArrayType(void *type, CompilerType *element_type_ptr,
     if (size)
       *size = 0;
     if (element_type_ptr)
-      *element_type_ptr = CompilerType(args[0].getPointer());
+      *element_type_ptr = ToCompilerType(args[0].getPointer());
     return true;
   }
 
@@ -5423,7 +5431,7 @@ SwiftASTContext::GetReferentType(const CompilerType &compiler_type) {
       return compiler_type;
 
     auto ref_type = swift_type->getReferenceStorageReferent();
-    return {ref_type};
+    return ToCompilerType({ref_type});
   }
 
   return {};
@@ -5461,7 +5469,7 @@ bool SwiftASTContext::GetProtocolTypeInfo(const CompilerType &type,
     protocol_info.m_is_errortype = layout.isErrorExistential();
 
     if (auto superclass = layout.explicitSuperclass) {
-      protocol_info.m_superclass = {superclass.getPointer()};
+      protocol_info.m_superclass = ToCompilerType({superclass.getPointer()});
     }
 
     unsigned num_witness_tables = 0;
@@ -5550,11 +5558,10 @@ ConstString SwiftASTContext::GetTypeName(void *type) {
 
 /// Build a dictionary of Archetype names that appear in \p type.
 static llvm::DenseMap<swift::CanType, swift::Identifier>
-GetArchetypeNames(swift::Type type, swift::ASTContext &ast_ctx,
+GetArchetypeNames(swift::Type swift_type, swift::ASTContext &ast_ctx,
                   const SymbolContext *sc) {
   llvm::DenseMap<swift::CanType, swift::Identifier> dict;
 
-  swift::Type swift_type(GetSwiftType(type));
   assert(&swift_type->getASTContext() == &ast_ctx);
   if (!sc)
     return dict;
@@ -5662,7 +5669,7 @@ SwiftASTContext::GetTypeInfo(void *type,
   case swift::TypeKind::UnmanagedStorage:
   case swift::TypeKind::UnownedStorage:
   case swift::TypeKind::WeakStorage:
-    swift_flags |= CompilerType(swift_can_type->getReferenceStorageReferent())
+    swift_flags |= ToCompilerType(swift_can_type->getReferenceStorageReferent())
                        .GetTypeInfo(pointee_or_element_clang_type);
     break;
   case swift::TypeKind::BoundGenericEnum:
@@ -5772,7 +5779,7 @@ lldb::TypeClass SwiftASTContext::GetTypeClass(void *type) {
   case swift::TypeKind::UnmanagedStorage:
   case swift::TypeKind::UnownedStorage:
   case swift::TypeKind::WeakStorage:
-    return CompilerType(swift_can_type->getReferenceStorageReferent())
+    return ToCompilerType(swift_can_type->getReferenceStorageReferent())
         .GetTypeClass();
   case swift::TypeKind::GenericTypeParam:
     return lldb::eTypeClassOther;
@@ -5869,7 +5876,7 @@ CompilerType SwiftASTContext::GetArrayElementType(void *type,
             0 == strcmp(declname, "Array") ||
             0 == strcmp(declname, "ArraySlice")) {
           assert(GetASTContext() == &args[0].getPointer()->getASTContext());
-          element_type = CompilerType(args[0].getPointer());
+          element_type = ToCompilerType(args[0].getPointer());
         }
       }
     }
@@ -5881,7 +5888,7 @@ CompilerType SwiftASTContext::GetCanonicalType(void *type) {
   VALID_OR_RETURN(CompilerType());
 
   if (type)
-    return {GetCanonicalSwiftType(type).getPointer()};
+    return ToCompilerType({GetCanonicalSwiftType(type).getPointer()});
   return CompilerType();
 }
 
@@ -5908,15 +5915,15 @@ CompilerType SwiftASTContext::GetInstanceType(void *type) {
          "input type belongs to different SwiftASTContext");
   auto metatype_type = swift::dyn_cast<swift::AnyMetatypeType>(swift_can_type);
   if (metatype_type)
-    return {metatype_type.getInstanceType().getPointer()};
+    return ToCompilerType({metatype_type.getInstanceType().getPointer()});
 
-  return {GetSwiftType(type)};
+  return ToCompilerType({GetSwiftType(type)});
 }
 
 CompilerType SwiftASTContext::GetFullyUnqualifiedType(void *type) {
   VALID_OR_RETURN(CompilerType());
 
-  return {GetSwiftType(type)};
+  return ToCompilerType({GetSwiftType(type)});
 }
 
 int SwiftASTContext::GetFunctionArgumentCount(void *type) {
@@ -5935,7 +5942,7 @@ CompilerType SwiftASTContext::GetFunctionReturnType(void *type) {
     auto func =
         swift::dyn_cast<swift::AnyFunctionType>(GetCanonicalSwiftType(type));
     if (func)
-      return {func.getResult().getPointer()};
+      return ToCompilerType({func.getResult().getPointer()});
   }
   return {};
 }
@@ -6018,7 +6025,7 @@ TypeMemberFunctionImpl SwiftASTContext::GetMemberFunctionAtIndex(void *type,
                 }
               }
               }
-              result_type = CompilerType(
+              result_type = ToCompilerType(
                   abstract_func_decl->getInterfaceType().getPointer());
             }
           } else
@@ -6042,7 +6049,7 @@ CompilerType SwiftASTContext::GetLValueReferenceType(void *type) {
   VALID_OR_RETURN(CompilerType());
 
   if (type)
-    return {swift::LValueType::get(GetSwiftType(type))};
+    return ToCompilerType({swift::LValueType::get(GetSwiftType(type))});
   return {};
 }
 
@@ -6056,7 +6063,7 @@ CompilerType SwiftASTContext::GetNonReferenceType(void *type) {
 
     swift::LValueType *lvalue = swift_can_type->getAs<swift::LValueType>();
     if (lvalue)
-      return {lvalue->getObjectType().getPointer()};
+      return ToCompilerType({lvalue->getObjectType().getPointer()});
   }
   return {};
 }
@@ -6070,7 +6077,7 @@ CompilerType SwiftASTContext::GetPointerType(void *type) {
     swift::Type swift_type(::GetSwiftType(type));
     const swift::TypeKind type_kind = swift_type->getKind();
     if (type_kind == swift::TypeKind::BuiltinRawPointer)
-      return {swift_type};
+      return ToCompilerType({swift_type});
   }
   return {};
 }
@@ -6083,7 +6090,7 @@ CompilerType SwiftASTContext::GetTypedefedType(void *type) {
     swift::TypeAliasType *name_alias_type =
         swift::dyn_cast<swift::TypeAliasType>(swift_type.getPointer());
     if (name_alias_type) {
-      return {name_alias_type->getSinglyDesugaredType()};
+      return ToCompilerType({name_alias_type->getSinglyDesugaredType()});
     }
   }
 
@@ -6101,11 +6108,11 @@ SwiftASTContext::GetUnboundType(lldb::opaque_compiler_type_t type) {
     if (bound_generic_type) {
       swift::NominalTypeDecl *nominal_type_decl = bound_generic_type->getDecl();
       if (nominal_type_decl)
-        return {nominal_type_decl->getDeclaredType()};
+        return ToCompilerType({nominal_type_decl->getDeclaredType()});
     }
   }
 
-  return {GetSwiftType(type)};
+  return ToCompilerType({GetSwiftType(type)});
 }
 
 CompilerType SwiftASTContext::GetTypeForDecl(void *opaque_decl) {
@@ -6307,7 +6314,7 @@ lldb::Encoding SwiftASTContext::GetEncoding(void *type, uint64_t &count) {
   case swift::TypeKind::UnmanagedStorage:
   case swift::TypeKind::UnownedStorage:
   case swift::TypeKind::WeakStorage:
-    return CompilerType(swift_can_type->getReferenceStorageReferent())
+    return ToCompilerType(swift_can_type->getReferenceStorageReferent())
         .GetEncoding(count);
     break;
 
@@ -6395,7 +6402,7 @@ lldb::Format SwiftASTContext::GetFormat(void *type) {
   case swift::TypeKind::UnmanagedStorage:
   case swift::TypeKind::UnownedStorage:
   case swift::TypeKind::WeakStorage:
-    return CompilerType(swift_can_type->getReferenceStorageReferent())
+    return ToCompilerType(swift_can_type->getReferenceStorageReferent())
         .GetFormat();
     break;
 
@@ -6473,7 +6480,7 @@ uint32_t SwiftASTContext::GetNumChildren(void *type,
   case swift::TypeKind::UnmanagedStorage:
   case swift::TypeKind::UnownedStorage:
   case swift::TypeKind::WeakStorage:
-    return CompilerType(swift_can_type->getReferenceStorageReferent())
+    return ToCompilerType(swift_can_type->getReferenceStorageReferent())
         .GetNumChildren(omit_empty_base_classes, exe_ctx);
   case swift::TypeKind::GenericTypeParam:
   case swift::TypeKind::DependentMember:
@@ -6500,7 +6507,7 @@ uint32_t SwiftASTContext::GetNumChildren(void *type,
   case swift::TypeKind::Protocol:
   case swift::TypeKind::ProtocolComposition: {
     ProtocolInfo protocol_info;
-    if (!GetProtocolTypeInfo(CompilerType(GetSwiftType(type)), protocol_info))
+    if (!GetProtocolTypeInfo(ToCompilerType(GetSwiftType(type)), protocol_info))
       break;
 
     return protocol_info.m_num_storage_words;
@@ -6519,7 +6526,7 @@ uint32_t SwiftASTContext::GetNumChildren(void *type,
     swift::TypeBase *deref_type = lvalue_type->getObjectType().getPointer();
 
     uint32_t num_pointee_children =
-        CompilerType(deref_type)
+        ToCompilerType(deref_type)
             .GetNumChildren(omit_empty_base_classes, exe_ctx);
     // If this type points to a simple type (or to a class), then it
     // has 1 child.
@@ -6601,7 +6608,7 @@ uint32_t SwiftASTContext::GetNumFields(void *type) {
   case swift::TypeKind::UnmanagedStorage:
   case swift::TypeKind::UnownedStorage:
   case swift::TypeKind::WeakStorage:
-    return CompilerType(swift_can_type->getReferenceStorageReferent())
+    return ToCompilerType(swift_can_type->getReferenceStorageReferent())
         .GetNumFields();
   case swift::TypeKind::GenericTypeParam:
   case swift::TypeKind::DependentMember:
@@ -6676,7 +6683,7 @@ SwiftASTContext::GetDirectBaseClassAtIndex(void *opaque_type, size_t idx,
     if (class_decl) {
       swift::Type base_class_type = class_decl->getSuperclass();
       if (base_class_type)
-        return {base_class_type.getPointer()};
+        return ToCompilerType({base_class_type.getPointer()});
     }
   }
   return {};
@@ -6728,7 +6735,7 @@ GetExistentialTypeChild(swift::ASTContext *swift_ast_ctx, CompilerType type,
     llvm::raw_string_ostream(name) << "payload_data_" << idx;
 
     auto raw_pointer = swift_ast_ctx->TheRawPointerType;
-    return {CompilerType(raw_pointer.getPointer()), std::move(name)};
+    return {ToCompilerType(raw_pointer.getPointer()), std::move(name)};
   }
 
   // The instance for a class-bound existential.
@@ -6738,7 +6745,7 @@ GetExistentialTypeChild(swift::ASTContext *swift_ast_ctx, CompilerType type,
       class_type = protocol_info.m_superclass;
     } else {
       auto raw_pointer = swift_ast_ctx->TheRawPointerType;
-      class_type = CompilerType(raw_pointer.getPointer());
+      class_type = ToCompilerType(raw_pointer.getPointer());
     }
 
     return {class_type, "instance"};
@@ -6747,7 +6754,7 @@ GetExistentialTypeChild(swift::ASTContext *swift_ast_ctx, CompilerType type,
   // The instance for an error existential.
   if (idx == 0 && protocol_info.m_is_errortype) {
     auto raw_pointer = swift_ast_ctx->TheRawPointerType;
-    return {CompilerType(raw_pointer.getPointer()), "error_instance"};
+    return {ToCompilerType(raw_pointer.getPointer()), "error_instance"};
   }
 
   // The metatype for a non-class, non-error existential.
@@ -6755,7 +6762,7 @@ GetExistentialTypeChild(swift::ASTContext *swift_ast_ctx, CompilerType type,
     // The metatype for a non-class, non-error existential.
     auto any_metatype =
         swift::ExistentialMetatypeType::get(swift_ast_ctx->TheAnyType);
-    return {CompilerType(any_metatype), "instance_type"};
+    return {ToCompilerType(any_metatype), "instance_type"};
   }
 
   // A witness table. Figure out which protocol it corresponds to.
@@ -6778,7 +6785,7 @@ GetExistentialTypeChild(swift::ASTContext *swift_ast_ctx, CompilerType type,
   }
 
   auto raw_pointer = swift_ast_ctx->TheRawPointerType;
-  return {CompilerType(raw_pointer.getPointer()), std::move(name)};
+  return {ToCompilerType(raw_pointer.getPointer()), std::move(name)};
 }
 
 CompilerType SwiftASTContext::GetFieldAtIndex(void *type, size_t idx,
@@ -6807,7 +6814,7 @@ CompilerType SwiftASTContext::GetFieldAtIndex(void *type, size_t idx,
   case swift::TypeKind::UnmanagedStorage:
   case swift::TypeKind::UnownedStorage:
   case swift::TypeKind::WeakStorage:
-    return CompilerType(swift_can_type->getReferenceStorageReferent())
+    return ToCompilerType(swift_can_type->getReferenceStorageReferent())
         .GetFieldAtIndex(idx, name, bit_offset_ptr, bitfield_bit_size_ptr,
                          is_bitfield_ptr);
   case swift::TypeKind::GenericTypeParam:
@@ -6849,7 +6856,7 @@ CompilerType SwiftASTContext::GetFieldAtIndex(void *type, size_t idx,
     name = GetTupleElementName(tuple_type, idx);
 
     const auto &child = tuple_type->getElement(idx);
-    return CompilerType(child.getType().getPointer());
+    return ToCompilerType(child.getType().getPointer());
   }
 
   case swift::TypeKind::Class:
@@ -6858,7 +6865,8 @@ CompilerType SwiftASTContext::GetFieldAtIndex(void *type, size_t idx,
     if (class_decl->hasSuperclass()) {
       if (idx == 0) {
         swift::Type superclass_swift_type = swift_can_type->getSuperclass();
-        CompilerType superclass_type(superclass_swift_type.getPointer());
+        CompilerType superclass_type =
+            ToCompilerType(superclass_swift_type.getPointer());
 
         name = GetSuperclassName(superclass_type);
 
@@ -6902,19 +6910,19 @@ CompilerType SwiftASTContext::GetFieldAtIndex(void *type, size_t idx,
 
     swift::Type child_swift_type = swift_can_type->getTypeOfMember(
         nominal->getModuleContext(), property, nullptr);
-    return CompilerType(child_swift_type.getPointer());
+    return ToCompilerType(child_swift_type.getPointer());
   }
 
   case swift::TypeKind::Protocol:
   case swift::TypeKind::ProtocolComposition: {
     ProtocolInfo protocol_info;
-    if (!GetProtocolTypeInfo(CompilerType(GetSwiftType(type)), protocol_info))
+    if (!GetProtocolTypeInfo(ToCompilerType(GetSwiftType(type)), protocol_info))
       break;
 
     if (idx >= protocol_info.m_num_storage_words)
       break;
 
-    CompilerType compiler_type(GetSwiftType(type));
+    CompilerType compiler_type = ToCompilerType(GetSwiftType(type));
     CompilerType child_type;
     std::tie(child_type, name) = GetExistentialTypeChild(
         GetASTContext(), compiler_type, protocol_info, idx);
@@ -7106,21 +7114,21 @@ bool SwiftASTContext::IsNonTriviallyManagedReferenceType(
     case swift::TypeKind::UnmanagedStorage: {
       strategy = NonTriviallyManagedReferenceStrategy::eUnmanaged;
       if (underlying_type)
-        *underlying_type = CompilerType(
+        *underlying_type = ToCompilerType(
             swift_can_type->getReferenceStorageReferent().getPointer());
     }
       return true;
     case swift::TypeKind::UnownedStorage: {
       strategy = NonTriviallyManagedReferenceStrategy::eUnowned;
       if (underlying_type)
-        *underlying_type = CompilerType(
+        *underlying_type = ToCompilerType(
             swift_can_type->getReferenceStorageReferent().getPointer());
     }
       return true;
     case swift::TypeKind::WeakStorage: {
       strategy = NonTriviallyManagedReferenceStrategy::eWeak;
       if (underlying_type)
-        *underlying_type = CompilerType(
+        *underlying_type = ToCompilerType(
             swift_can_type->getReferenceStorageReferent().getPointer());
     }
       return true;
@@ -7170,7 +7178,7 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
   case swift::TypeKind::UnmanagedStorage:
   case swift::TypeKind::UnownedStorage:
   case swift::TypeKind::WeakStorage:
-    return CompilerType(swift_can_type->getReferenceStorageReferent())
+    return ToCompilerType(swift_can_type->getReferenceStorageReferent())
         .GetChildCompilerTypeAtIndex(
             exe_ctx, idx, transparent_pointers, omit_empty_base_classes,
             ignore_array_bounds, child_name, child_byte_size, child_byte_offset,
@@ -7198,7 +7206,7 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
       child_is_deref_of_parent = false;
       if (element_info->is_indirect) {
         language_flags |= LanguageFlags::eIsIndirectEnumCase;
-        return CompilerType(GetASTContext()->TheRawPointerType.getPointer());
+        return ToCompilerType(GetASTContext()->TheRawPointerType.getPointer());
       } else
         return element_info->payload_type;
     }
@@ -7216,13 +7224,13 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
     llvm::raw_svector_ostream(printed_idx) << idx;
     child_name = GetTupleElementName(tuple_type, idx, printed_idx);
 
-    CompilerType child_type(child.getType().getPointer());
+    CompilerType child_type = ToCompilerType(child.getType().getPointer());
     if (!get_type_size(child_byte_size, child_type))
       return {};
     child_is_base_class = false;
     child_is_deref_of_parent = false;
 
-    CompilerType compiler_type(GetSwiftType(type));
+    CompilerType compiler_type = ToCompilerType(GetSwiftType(type));
     llvm::Optional<uint64_t> offset = GetInstanceVariableOffset(
         valobj, exe_ctx, compiler_type, printed_idx.c_str(), child_type);
     if (!offset)
@@ -7242,7 +7250,8 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
     if (class_decl->hasSuperclass()) {
       if (idx == 0) {
         swift::Type superclass_swift_type = swift_can_type->getSuperclass();
-        CompilerType superclass_type(superclass_swift_type.getPointer());
+        CompilerType superclass_type =
+            ToCompilerType(superclass_swift_type.getPointer());
 
         child_name = GetSuperclassName(superclass_type);
         if (!get_type_size(child_byte_size, superclass_type))
@@ -7276,14 +7285,14 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
     swift::Type child_swift_type = swift_can_type->getTypeOfMember(
         nominal->getModuleContext(), property, nullptr);
 
-    CompilerType child_type(child_swift_type.getPointer());
+    CompilerType child_type = ToCompilerType(child_swift_type.getPointer());
     child_name = property->getBaseName().userFacingName();
     if (!get_type_size(child_byte_size, child_type))
       return {};
     child_is_base_class = false;
     child_is_deref_of_parent = false;
 
-    CompilerType compiler_type(GetSwiftType(type));
+    CompilerType compiler_type = ToCompilerType(GetSwiftType(type));
     llvm::Optional<uint64_t> offset = GetInstanceVariableOffset(
         valobj, exe_ctx, compiler_type, child_name.c_str(), child_type);
     if (!offset)
@@ -7298,13 +7307,13 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
   case swift::TypeKind::Protocol:
   case swift::TypeKind::ProtocolComposition: {
     ProtocolInfo protocol_info;
-    if (!GetProtocolTypeInfo(CompilerType(GetSwiftType(type)), protocol_info))
+    if (!GetProtocolTypeInfo(ToCompilerType(GetSwiftType(type)), protocol_info))
       break;
 
     if (idx >= protocol_info.m_num_storage_words)
       break;
 
-    CompilerType compiler_type(GetSwiftType(type));
+    CompilerType compiler_type = ToCompilerType(GetSwiftType(type));
     CompilerType child_type;
     std::tie(child_type, child_name) = GetExistentialTypeChild(
         GetASTContext(), compiler_type, protocol_info, idx);
@@ -7435,7 +7444,7 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
     case swift::TypeKind::UnmanagedStorage:
     case swift::TypeKind::UnownedStorage:
     case swift::TypeKind::WeakStorage:
-      return CompilerType(swift_can_type->getReferenceStorageReferent())
+      return ToCompilerType(swift_can_type->getReferenceStorageReferent())
           .GetIndexOfChildMemberWithName(name, omit_empty_base_classes,
                                          child_indexes);
     case swift::TypeKind::GenericTypeParam:
@@ -7514,7 +7523,8 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
 
         // Look in the superclass.
         swift::Type superclass_swift_type = swift_can_type->getSuperclass();
-        CompilerType superclass_type(superclass_swift_type.getPointer());
+        CompilerType superclass_type =
+            ToCompilerType(superclass_swift_type.getPointer());
         if (superclass_type.GetIndexOfChildMemberWithName(
                 name, omit_empty_base_classes, child_indexes))
           return child_indexes.size();
@@ -7529,10 +7539,11 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
     case swift::TypeKind::Protocol:
     case swift::TypeKind::ProtocolComposition: {
       ProtocolInfo protocol_info;
-      if (!GetProtocolTypeInfo(CompilerType(GetSwiftType(type)), protocol_info))
+      if (!GetProtocolTypeInfo(ToCompilerType(GetSwiftType(type)),
+                               protocol_info))
         break;
 
-      CompilerType compiler_type(GetSwiftType(type));
+      CompilerType compiler_type = ToCompilerType(GetSwiftType(type));
       for (unsigned idx : swift::range(protocol_info.m_num_storage_words)) {
         CompilerType child_type;
         std::string child_name;
@@ -7697,7 +7708,8 @@ CompilerType SwiftASTContext::GetBoundGenericType(void *type, size_t idx) {
     if (auto *bound_generic_type =
             swift_can_type->getAs<swift::BoundGenericType>())
       if (idx < bound_generic_type->getGenericArgs().size())
-        return {bound_generic_type->getGenericArgs()[idx].getPointer()};
+        return ToCompilerType(
+            {bound_generic_type->getGenericArgs()[idx].getPointer()});
   }
   return {};
 }
@@ -7714,8 +7726,8 @@ CompilerType SwiftASTContext::GetUnboundGenericType(void *type, size_t idx) {
       swift::GenericSignature generic_sig =
           nominal_type_decl->getGenericSignature();
       auto depTy = generic_sig->getGenericParams()[idx];
-      return {nominal_type_decl->mapTypeIntoContext(depTy)
-                  ->castTo<swift::ArchetypeType>()};
+      return ToCompilerType({nominal_type_decl->mapTypeIntoContext(depTy)
+                                 ->castTo<swift::ArchetypeType>()});
     }
   }
   return {};
@@ -7753,7 +7765,7 @@ CompilerType SwiftASTContext::GetTypeForFormatters(void *type) {
   if (type) {
     swift::Type swift_type(GetSwiftType(type));
     assert(&swift_type->getASTContext() == GetASTContext());
-    return {swift_type};
+    return ToCompilerType({swift_type});
   }
   return {};
 }
@@ -7926,7 +7938,7 @@ bool SwiftASTContext::DumpTypeValue(
   case swift::TypeKind::UnmanagedStorage:
   case swift::TypeKind::UnownedStorage:
   case swift::TypeKind::WeakStorage:
-    return CompilerType(swift_can_type->getReferenceStorageReferent())
+    return ToCompilerType(swift_can_type->getReferenceStorageReferent())
         .DumpTypeValue(s, format, data, byte_offset, byte_size,
                        bitfield_bit_size, bitfield_bit_offset, exe_scope,
                        is_base_class);
@@ -8130,8 +8142,8 @@ void SwiftASTContext::DumpTypeDescription(void *type, Stream *s,
           swift::TypeDecl *type_decl =
               llvm::dyn_cast_or_null<swift::TypeDecl>(decl);
           if (type_decl) {
-            CompilerType clang_type(
-                type_decl->getDeclaredInterfaceType().getPointer());
+            CompilerType clang_type(ToCompilerType(
+                type_decl->getDeclaredInterfaceType().getPointer()));
             if (clang_type) {
               Flags clang_type_flags(clang_type.GetTypeInfo());
               DumpTypeDescription(clang_type.GetOpaqueQualType(), s,

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -1905,7 +1905,8 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Protocol(
   }
 
   auto type_and_address = result.getValue();
-  class_type_or_name.SetCompilerType(type_and_address.InstanceType);
+  class_type_or_name.SetCompilerType(
+      ToCompilerType(type_and_address.InstanceType));
   address.SetRawAddress(type_and_address.PayloadAddress.getAddressData());
   return true;
 }
@@ -2064,7 +2065,7 @@ SwiftLanguageRuntime::DoArchetypeBindingForType(StackFrame &stack_frame,
         swift::SubstFlags::DesugarMemberTypes);
     assert(target_swift_type);
 
-    return {target_swift_type.getPointer()};
+    return ToCompilerType({target_swift_type.getPointer()});
   }
   return base_type;
 }
@@ -2582,7 +2583,7 @@ lldb::addr_t SwiftLanguageRuntime::FixupAddress(lldb::addr_t addr,
 const swift::reflection::TypeInfo *
 SwiftLanguageRuntime::GetTypeInfo(CompilerType type) {
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
-  CompilerType can_type(swift_can_type);
+  CompilerType can_type = ToCompilerType(swift_can_type);
   ConstString mangled_name(can_type.GetMangledTypeName());
   StringRef mangled_no_prefix =
       swift::Demangle::dropSwiftManglingPrefix(mangled_name.GetStringRef());


### PR DESCRIPTION
…ontext

Moves the constructor from swift::Type -> CompilerType to SwiftASTContext, which is
the main user of this constructor. This makes our diff towards upstream smaller,
patching CompilerType with swift-specific code is in general against the idea of
CompilerType and we get rid of the tricky implicit conversion we get from having this
implicit constructor. I removed one really obvious swift::Type->CompilerType->swift::Type
conversion in this patch in `GetArchetypeNames` but there are few other places that
I didn't want to drive-by refactor in this patch.