### PR TITLE
[llvm-bcanalyzer] Don't dump the contents if -dump is not passed

### DIFF
--- a/llvm/test/Other/bcanalyzer-dump-option.txt
+++ b/llvm/test/Other/bcanalyzer-dump-option.txt
@@ -1,0 +1,11 @@
+RUN: llvm-bcanalyzer -dump %S/Inputs/has-block-info.bc | FileCheck -check-prefix=WITH-DUMP %s
+RUN: llvm-bcanalyzer %S/Inputs/has-block-info.bc | FileCheck -check-prefix=WITHOUT-DUMP %s
+
+WITH-DUMP: <ABC
+WITHOUT-DUMP-NOT: <ABC
+WITH-DUMP: </ABC>
+WITHOUT-DUMP-NOT: </ABC>
+WITH-DUMP: <XYZ
+WITHOUT-DUMP-NOT: <XYZ
+WITH-DUMP: </XYZ>
+WITHOUT-DUMP-NOT: </XYZ>

--- a/llvm/test/tools/dsymutil/X86/remarks-linking-bundle.test
+++ b/llvm/test/tools/dsymutil/X86/remarks-linking-bundle.test
@@ -5,7 +5,7 @@ RUN: cat %p/../Inputs/remarks/basic.macho.remarks.x86_64 > %t/basic.macho.remark
 RUN: dsymutil -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/basic.macho.remarks.x86_64
 
 Check that the remark file in the bundle exists and is sane:
-RUN: llvm-bcanalyzer %t/basic.macho.remarks.x86_64.dSYM/Contents/Resources/Remarks/basic.macho.remarks.x86_64 | FileCheck %s
+RUN: llvm-bcanalyzer -dump %t/basic.macho.remarks.x86_64.dSYM/Contents/Resources/Remarks/basic.macho.remarks.x86_64 | FileCheck %s
 
 Now emit it in a different format: YAML.
 RUN: dsymutil -remarks-output-format=yaml -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/basic.macho.remarks.x86_64

--- a/llvm/test/tools/dsymutil/X86/remarks-linking-fat-bundle.test
+++ b/llvm/test/tools/dsymutil/X86/remarks-linking-fat-bundle.test
@@ -7,9 +7,9 @@ RUN: cat %p/../Inputs/remarks/fat.macho.remarks.x86 > %t/fat.macho.remarks.x86
 RUN: dsymutil -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/fat.macho.remarks.x86
 
 Check that the remark files in the bundle exist and are all sane:
-RUN: llvm-bcanalyzer %t/fat.macho.remarks.x86.dSYM/Contents/Resources/Remarks/fat.macho.remarks.x86-x86_64h | FileCheck %s
-RUN: llvm-bcanalyzer %t/fat.macho.remarks.x86.dSYM/Contents/Resources/Remarks/fat.macho.remarks.x86-x86_64 | FileCheck %s
-RUN: llvm-bcanalyzer %t/fat.macho.remarks.x86.dSYM/Contents/Resources/Remarks/fat.macho.remarks.x86-i386 | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-i386
+RUN: llvm-bcanalyzer -dump %t/fat.macho.remarks.x86.dSYM/Contents/Resources/Remarks/fat.macho.remarks.x86-x86_64h | FileCheck %s
+RUN: llvm-bcanalyzer -dump %t/fat.macho.remarks.x86.dSYM/Contents/Resources/Remarks/fat.macho.remarks.x86-x86_64 | FileCheck %s
+RUN: llvm-bcanalyzer -dump %t/fat.macho.remarks.x86.dSYM/Contents/Resources/Remarks/fat.macho.remarks.x86-i386 | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-i386
 
 CHECK: <Meta
 CHECK: <Remark Num

--- a/llvm/tools/llvm-bcanalyzer/llvm-bcanalyzer.cpp
+++ b/llvm/tools/llvm-bcanalyzer/llvm-bcanalyzer.cpp
@@ -102,8 +102,9 @@ int main(int argc, char **argv) {
   O.Symbolic = !NonSymbolic;
   O.ShowBinaryBlobs = ShowBinaryBlobs;
 
-  ExitOnErr(
-      BA.analyze(O, CheckHash.empty() ? None : Optional<StringRef>(CheckHash)));
+  ExitOnErr(BA.analyze(
+      Dump ? Optional<BCDumpOptions>(O) : Optional<BCDumpOptions>(None),
+      CheckHash.empty() ? None : Optional<StringRef>(CheckHash)));
 
   if (Dump)
     outs() << "\n\n";


### PR DESCRIPTION
With all the previous refactorings this slipped through and now we
always dump the contents of the bitcode files, even if -dump is not
passed.

(cherry picked from commit 1ca85b3d33a14394c9c11d68a40d038075d7e8ee)