### PR TITLE
Revert "[CGDebugInfo] Emit subprograms for decls when AT_tail_call is…

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -3773,7 +3773,9 @@ void CGDebugInfo::EmitFunctionDecl(GlobalDecl GD, SourceLocation Loc,
 void CGDebugInfo::EmitFuncDeclForCallSite(llvm::CallBase *CallOrInvoke,
                                           QualType CalleeType,
                                           const FunctionDecl *CalleeDecl) {
-  if (!CallOrInvoke || getCallSiteRelatedAttrs() == llvm::DINode::FlagZero)
+  auto &CGOpts = CGM.getCodeGenOpts();
+  if (!CGOpts.EnableDebugEntryValues || !CGM.getLangOpts().Optimize ||
+      !CallOrInvoke)
     return;
 
   auto *Func = CallOrInvoke->getCalledFunction();
@@ -4847,10 +4849,10 @@ llvm::DINode::DIFlags CGDebugInfo::getCallSiteRelatedAttrs() const {
   bool SupportsDWARFv4Ext =
       CGM.getCodeGenOpts().DwarfVersion == 4 &&
       (CGM.getCodeGenOpts().getDebuggerTuning() == llvm::DebuggerKind::LLDB ||
-       CGM.getCodeGenOpts().getDebuggerTuning() == llvm::DebuggerKind::GDB);
+       (CGM.getCodeGenOpts().EnableDebugEntryValues &&
+       CGM.getCodeGenOpts().getDebuggerTuning() == llvm::DebuggerKind::GDB));
 
-  if (!SupportsDWARFv4Ext && CGM.getCodeGenOpts().DwarfVersion < 5 &&
-      !CGM.getCodeGenOpts().EnableDebugEntryValues)
+  if (!SupportsDWARFv4Ext && CGM.getCodeGenOpts().DwarfVersion < 5)
     return llvm::DINode::FlagZero;
 
   return llvm::DINode::FlagAllCallsDescribed;

--- a/clang/test/CodeGen/debug-info-extern-call.c
+++ b/clang/test/CodeGen/debug-info-extern-call.c
@@ -1,21 +1,8 @@
-// When entry values are emitted, expect a subprogram for extern decls so that
-// the dwarf generator can describe call site parameters at extern call sites.
-//
-// RUN: %clang -Xclang -femit-debug-entry-values -g -O2 -target x86_64-none-linux-gnu -S -emit-llvm %s -o - | FileCheck %s -check-prefix=ENTRY-VAL
-// ENTRY-VAL: !DISubprogram(name: "fn1"
+// RUN: %clang -Xclang -femit-debug-entry-values -g -O2 -target x86_64-none-linux-gnu -S -emit-llvm %s -o - | FileCheck %s -check-prefix=CHECK-EXT
+// CHECK-EXT: !DISubprogram(name: "fn1"
 
-// Similarly, when the debugger tuning is gdb, expect a subprogram for extern
-// decls so that the dwarf generator can describe information needed for tail
-// call frame reconstrution.
-//
-// RUN: %clang -g -O2 -target x86_64-none-linux-gnu -ggdb -S -emit-llvm %s -o - | FileCheck %s -check-prefix=GDB
-// GDB: !DISubprogram(name: "fn1"
-//
-// Do not emit a subprogram for extern decls when entry values are disabled and
-// the tuning is not set to gdb.
-//
-// RUN: %clang -g -O2 -target x86_64-none-linux-gnu -gsce -S -emit-llvm %s -o - | FileCheck %s -check-prefix=SCE
-// SCE-NOT: !DISubprogram(name: "fn1"
+// RUN: %clang -g -O2 -target x86_64-none-linux-gnu -S -emit-llvm %s -o - | FileCheck %s
+// CHECK-NOT: !DISubprogram(name: "fn1"
 
 extern int fn1(int a, int b);
 

--- a/clang/test/CodeGenCXX/dbg-info-all-calls-described.cpp
+++ b/clang/test/CodeGenCXX/dbg-info-all-calls-described.cpp
@@ -56,7 +56,6 @@
 
 // NO-ATTR-NOT: FlagAllCallsDescribed
 
-// HAS-ATTR-DAG: DISubprogram(name: "declaration1", {{.*}}, flags: DIFlagPrototyped
 // HAS-ATTR-DAG: DISubprogram(name: "declaration2", {{.*}}, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition
 // HAS-ATTR-DAG: DISubprogram(name: "struct1", {{.*}}, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
 // HAS-ATTR-DAG: DISubprogram(name: "struct1", {{.*}}, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition

--- a/llvm/test/DebugInfo/X86/dwarf-callsite-related-attrs.ll
+++ b/llvm/test/DebugInfo/X86/dwarf-callsite-related-attrs.ll
@@ -25,14 +25,6 @@
 
 @sink = global i32 0, align 4, !dbg !0
 
-define void @__has_no_subprogram() {
-entry:
-  %0 = load volatile i32, i32* @sink, align 4
-  %inc = add nsw i32 %0, 1
-  store volatile i32 %inc, i32* @sink, align 4
-  ret void
-}
-
 ; ASM: DW_TAG_subprogram
 ; ASM:   DW_AT_call_all_calls
 ; OBJ: [[bat_sp:.*]]: DW_TAG_subprogram
@@ -78,7 +70,6 @@ entry:
 ; OBJ:     DW_AT_call_tail_call
 define void @_Z3foov() !dbg !25 {
 entry:
-  tail call void @__has_no_subprogram()
   tail call void @_Z3barv(), !dbg !26
   tail call void @_Z3batv(), !dbg !27
   tail call void @_Z3barv(), !dbg !26


### PR DESCRIPTION
… understood"

This reverts commit a5c8ec4baa2c00d8dbca36ffd236a40f9e0c07ed (this was
reverted upstream as well).

rdar://problem/57166214