### PR TITLE
[upstreaming][NFC] Remove undefined method in ClangASTContext::Remove…

### DIFF
--- a/lldb/include/lldb/Symbol/ClangASTContext.h
+++ b/lldb/include/lldb/Symbol/ClangASTContext.h
@@ -684,8 +684,6 @@ public:
   // If the current object represents a typedef type, get the underlying type
   CompilerType GetTypedefedType(lldb::opaque_compiler_type_t type) override;
 
-  static CompilerType RemoveFastQualifiers(const CompilerType &type);
-
   // Create related types using the current type's AST
   CompilerType GetBasicTypeFromAST(lldb::BasicType basic_type) override;
 


### PR DESCRIPTION
…FastQualifiers