### PR TITLE
Correct function declarations; NFC.

### DIFF
--- a/clang/include/clang-c/FatalErrorHandler.h
+++ b/clang/include/clang-c/FatalErrorHandler.h
@@ -18,14 +18,14 @@ extern "C" {
  * Installs error handler that prints error message to stderr and calls abort().
  * Replaces currently installed error handler (if any).
  */
-void clang_install_aborting_llvm_fatal_error_handler();
+void clang_install_aborting_llvm_fatal_error_handler(void);
 
 /**
  * Removes currently installed error handler (if any).
  * If no error handler is intalled, the default strategy is to print error
  * message to stderr and call exit(1).
  */
-void clang_uninstall_llvm_fatal_error_handler();
+void clang_uninstall_llvm_fatal_error_handler(void);
 
 #ifdef __cplusplus
 }

--- a/clang/tools/libclang/FatalErrorHandler.cpp
+++ b/clang/tools/libclang/FatalErrorHandler.cpp
@@ -18,11 +18,13 @@ static void aborting_fatal_error_handler(void *, const std::string &reason,
   ::abort();
 }
 
-void clang_install_aborting_llvm_fatal_error_handler() {
+extern "C" {
+void clang_install_aborting_llvm_fatal_error_handler(void) {
   llvm::remove_fatal_error_handler();
   llvm::install_fatal_error_handler(aborting_fatal_error_handler, nullptr);
 }
 
-void clang_uninstall_llvm_fatal_error_handler() {
+void clang_uninstall_llvm_fatal_error_handler(void) {
   llvm::remove_fatal_error_handler();
+}
 }


### PR DESCRIPTION
This header is included by C code so the functions need to have a prototype. Also, fix the function definitions so that they have C linkage rather than C++ linkage.

llvm-svn: 373213
(cherry picked from commit bddecba4b333f7772029b4937d2c34f9f2fda6ca)

rdar://problem/56999236