### PR TITLE
Remove the context parameter from performTypeChecking

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1463,9 +1463,7 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     return 2;
   }
 
-  // Not persistent because we're building source files one at a time.
-  swift::TopLevelContext top_level_context;
-  swift::performTypeChecking(parsed_expr->source_file, top_level_context);
+  swift::performTypeChecking(parsed_expr->source_file);
 
   if (swift_ast_ctx->HasErrors()) {
     DiagnoseSwiftASTContextError();


### PR DESCRIPTION
Supports apple/swift#28246

(cherry picked from commit 81dff85e45081b0c97045f28590ddb760b801d90)