### PR TITLE
repl: use CMake to handle RPATHs

### DIFF
--- a/lldb/tools/repl/swift/CMakeLists.txt
+++ b/lldb/tools/repl/swift/CMakeLists.txt
@@ -1,13 +1,3 @@
-# Set the correct rpath to locate libswiftCore.
-if( CMAKE_SYSTEM_NAME MATCHES "Linux" )
-  if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "ppc64le")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath,${SWIFT_LIBRARY_DIR}/swift/linux/powerpc64le")
-  else()
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath,${SWIFT_LIBRARY_DIR}/swift/linux")
-  endif()
-  set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib/swift/linux:${CMAKE_INSTALL_RPATH}")
-endif()
-
 # Only set LLVM_CODESIGNING_IDENTITY for building on Apple hosts for Apple
 # targets
 if (CMAKE_HOST_APPLE AND APPLE)
@@ -25,6 +15,17 @@ target_link_libraries(repl_swift PRIVATE ${CMAKE_DL_LIBS})
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   set_target_properties(repl_swift PROPERTIES
     WIN32_EXECUTABLE TRUE)
+elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES ppc64le)
+    set_target_properties(repl_swift PROPERTIES
+      BUILD_RPATH ${SWIFT_LIBRARY_DIR}/swift/linux/powerpc64le)
+  else()
+    set_target_properties(repl_swift PROPERTIES
+      BUILD_RPATH ${SWIFT_LIBRARY_DIR}/swift/linux)
+  endif()
+  set_target_properties(repl_swift PROPERTIES
+    BUILD_WITH_INSTALL_RPATH NO
+    INSTALL_RPATH "$ORIGIN/../lib/swift/linux")
 endif()
 
 # The dummy repl executable is a C program, but we always look for a mangled


### PR DESCRIPTION
Setup the build RPATH and install RPATH properly using CMake.  This
closes a possible security attack vector by removing the build RPATHs
from the binary.  It also is more strict about the library loading from
the correct location.