### PR TITLE
[CodeGen] Assign locations to calls to special struct helpers

### DIFF
--- a/clang/lib/CodeGen/CGNonTrivialStruct.cpp
+++ b/clang/lib/CodeGen/CGNonTrivialStruct.cpp
@@ -817,6 +817,7 @@ template <class G, size_t N>
 static void callSpecialFunction(G &&Gen, StringRef FuncName, QualType QT,
                                 bool IsVolatile, CodeGenFunction &CGF,
                                 std::array<Address, N> Addrs) {
+  auto SetArtificialLoc = ApplyDebugLocation::CreateArtificial(CGF);
   for (unsigned I = 0; I < N; ++I)
     Addrs[I] = CGF.Builder.CreateBitCast(Addrs[I], CGF.CGM.Int8PtrPtrTy);
   QT = IsVolatile ? QT.withVolatile() : QT;

--- a/clang/test/CodeGenObjC/nontrivial-c-struct-exception.m
+++ b/clang/test/CodeGenObjC/nontrivial-c-struct-exception.m
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple arm64-apple-ios11 -fobjc-arc -fblocks -fobjc-runtime=ios-11.0 -fobjc-exceptions -fexceptions -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple arm64-apple-ios11 -fobjc-arc -fblocks -fobjc-runtime=ios-11.0 -fobjc-exceptions -fexceptions -debug-info-kind=line-tables-only -emit-llvm -o - %s | FileCheck %s
 
 // CHECK: %[[STRUCT_STRONG:.*]] = type { i32, i8* }
 // CHECK: %[[STRUCT_WEAK:.*]] = type { i32, i8* }
@@ -25,8 +25,8 @@ typedef struct {
 // CHECK-NEXT: ret void
 
 // CHECK: landingpad { i8*, i32 }
-// CHECK: %[[V9:.*]] = bitcast %[[STRUCT_STRONG]]* %[[AGG_TMP]] to i8**
-// CHECK: call void @__destructor_8_s8(i8** %[[V9]])
+// CHECK: %[[V9:.*]] = bitcast %[[STRUCT_STRONG]]* %[[AGG_TMP]] to i8**{{.*}}, !dbg [[ARTIFICIAL_LOC_1:![0-9]+]]
+// CHECK: call void @__destructor_8_s8(i8** %[[V9]]){{.*}}, !dbg [[ARTIFICIAL_LOC_1]]
 // CHECK: br label
 
 // CHECK: resume
@@ -48,8 +48,8 @@ void testStrongException(void) {
 // CHECK: ret void
 
 // CHECK: landingpad { i8*, i32 }
-// CHECK: %[[V3:.*]] = bitcast %[[STRUCT_WEAK]]* %[[AGG_TMP]] to i8**
-// CHECK: call void @__destructor_8_w8(i8** %[[V3]])
+// CHECK: %[[V3:.*]] = bitcast %[[STRUCT_WEAK]]* %[[AGG_TMP]] to i8**{{.*}}, !dbg [[ARTIFICIAL_LOC_2:![0-9]+]]
+// CHECK: call void @__destructor_8_w8(i8** %[[V3]]){{.*}}, !dbg [[ARTIFICIAL_LOC_2]]
 // CHECK: br label
 
 // CHECK: resume
@@ -60,3 +60,6 @@ void calleeWeak(Weak, Weak);
 void testWeakException(void) {
   calleeWeak(genWeak(), genWeak());
 }
+
+// CHECK-DAG: [[ARTIFICIAL_LOC_1]] = !DILocation(line: 0
+// CHECK-DAG: [[ARTIFICIAL_LOC_2]] = !DILocation(line: 0


### PR DESCRIPTION
Assign artificial locations to calls to special struct-related helper
functions.

Such calls may not inherit a location if emitted within FinishFunction,
at which point the lexical scope stack may be empty, causing CGDebugInfo
to report the current DebugLoc as empty.

Fixes an IR verifier complaint about a call to '__destructor_8_s0' not
having a !dbg location attached.

rdar://57293361
(cherry picked from commit ea1db31d20a74e5025a86b0df49163d5bfecb67b)