### PR TITLE
[SanitizerCommon] Print the current value of options when printing out help

### DIFF
--- a/compiler-rt/lib/msan/msan.cpp
+++ b/compiler-rt/lib/msan/msan.cpp
@@ -122,6 +122,10 @@ class FlagHandlerKeepGoing : public FlagHandlerBase {
     *halt_on_error_ = !tmp;
     return true;
   }
+  bool Format(char *buffer, uptr size) final {
+    const char *keep_going_str = (*halt_on_error_) ? "false" : "true";
+    return FormatString(buffer, size, keep_going_str);
+  }
 };
 
 static void RegisterMsanFlags(FlagParser *parser, Flags *f) {

--- a/compiler-rt/lib/sanitizer_common/sanitizer_flag_parser.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_flag_parser.cpp
@@ -56,9 +56,16 @@ char *FlagParser::ll_strndup(const char *s, uptr n) {
 }
 
 void FlagParser::PrintFlagDescriptions() {
+  char buffer[128];
+  buffer[sizeof(buffer) - 1] = '\0';
   Printf("Available flags for %s:\n", SanitizerToolName);
-  for (int i = 0; i < n_flags_; ++i)
-    Printf("\t%s\n\t\t- %s\n", flags_[i].name, flags_[i].desc);
+  for (int i = 0; i < n_flags_; ++i) {
+    bool truncated = !(flags_[i].handler->Format(buffer, sizeof(buffer)));
+    CHECK_EQ(buffer[sizeof(buffer) - 1], '\0');
+    const char *truncation_str = truncated ? " Truncated" : "";
+    Printf("\t%s\n\t\t- %s (Current Value%s: %s)\n", flags_[i].name,
+           flags_[i].desc, truncation_str, buffer);
+  }
 }
 
 void FlagParser::fatal_error(const char *err) {

--- a/compiler-rt/lib/sanitizer_common/sanitizer_flags.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_flags.cpp
@@ -75,11 +75,13 @@ void SubstituteForFlagValue(const char *s, char *out, uptr out_size) {
 class FlagHandlerInclude : public FlagHandlerBase {
   FlagParser *parser_;
   bool ignore_missing_;
+  const char *original_path_;
 
  public:
   explicit FlagHandlerInclude(FlagParser *parser, bool ignore_missing)
-      : parser_(parser), ignore_missing_(ignore_missing) {}
+      : parser_(parser), ignore_missing_(ignore_missing), original_path_("") {}
   bool Parse(const char *value) final {
+    original_path_ = value;
     if (internal_strchr(value, '%')) {
       char *buf = (char *)MmapOrDie(kMaxPathLength, "FlagHandlerInclude");
       SubstituteForFlagValue(value, buf, kMaxPathLength);
@@ -88,6 +90,12 @@ class FlagHandlerInclude : public FlagHandlerBase {
       return res;
     }
     return parser_->ParseFile(value, ignore_missing_);
+  }
+  bool Format(char *buffer, uptr size) {
+    // Note `original_path_` isn't actually what's parsed due to `%`
+    // substitutions. Printing the substituted path would require holding onto
+    // mmap'ed memory.
+    return FormatString(buffer, size, original_path_);
   }
 };
 

--- a/compiler-rt/test/sanitizer_common/TestCases/options-help.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/options-help.cpp
@@ -1,8 +1,43 @@
 // RUN: %clangxx -O0 %s -o %t
-// RUN: %env_tool_opts=help=1 %run %t 2>&1 | FileCheck %s
+// RUN: %env_tool_opts=help=1,include_if_exists=___some_path_that_does_not_exist___  %run %t 2>&1 | FileCheck %s
+// RUN: %env_tool_opts=help=1,symbolize=0 %run %t 2>&1 | FileCheck --check-prefix=CHECK-CV %s
+// RUN: %env_tool_opts=help=1,sancov_path=/long/path/that/requires/truncation/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaB \
+// RUN:   %run %t 2>&1 | FileCheck --check-prefix=CHECK-TRUNCATION %s
 
 int main() {
 }
 
 // CHECK: Available flags for {{.*}}Sanitizer:
-// CHECK: handle_segv
+
+//
+// Bool option
+// CHECK: {{^[ \t]+symbolize$}}
+// CHECK-NEXT: (Current Value: true)
+//
+// String option
+// CHECK: {{^[ \t]+log_path$}}
+// CHECK-NEXT: (Current Value: {{.+}})
+//
+// int option
+// CHECK: {{^[ \t]+verbosity$}}
+// CHECK-NEXT: (Current Value: {{-?[0-9]+}})
+//
+// HandleSignalMode option
+// CHECK: {{^[ \t]+handle_segv$}}
+// CHECK-NEXT: (Current Value: {{0|1|2}})
+//
+// uptr option
+// CHECK: {{^[ \t]+mmap_limit_mb$}}
+// CHECK-NEXT: (Current Value: 0x{{[0-9a-fA-F]+}})
+//
+// FlagHandlerInclude option
+// CHECK: include_if_exists
+// CHECK-NEXT: (Current Value: ___some_path_that_does_not_exist___)
+
+// Test we show the current value and not the default.
+// CHECK-CV: {{^[ \t]+symbolize$}}
+// CHECK-CV-NEXT: (Current Value: false)
+
+// Test truncation of long paths.
+// CHECK-TRUNCATION: sancov_path
+// CHECK-TRUNCATION-NEXT: (Current Value Truncated: /long/path/that/requires/truncation/aaa{{a+}})


### PR DESCRIPTION
Summary:
Previously it wasn't obvious what the default value of various sanitizer
options were. A very close approximation of the "default values" for the
options are the current value of the options at the time of printing the
help output.

In the case that no other options are provided then the current values
are the default values (apart from `help`).

```
ASAN_OPTIONS=help=1 ./program
```

This patch causes the current option values to be printed when the
`help` output is enabled. The original intention for this patch was to append
`(Default: <value>)` to an option's help text. However because this
is technically wrong (and misleading) I've opted to append
`(Current Value: <value>)` instead.

When trying to implement a way of displaying the default value of the
options I tried another solution where the default value used in `*.inc` files
were used to create compile time strings that where used when printing
the help output. This solution was not satisfactory for several reasons:

* Stringifying the default values with the preprocessor did not work very
well in several cases.  Some options contain boolean operators which no
amount of macro expansion can get rid of.
* It was much more invasive than this patch. Every sanitizer had to be changed.
* The settings of `__<sanitizer>_default_options()` are ignored.

For those reasons I opted for the solution in this patch.

rdar://problem/42567204

Reviewers: kubamracek, yln, kcc, dvyukov, vitalybuka, cryptoad, eugenis, samsonov

Subscribers: #sanitizers, llvm-commits

Tags: #sanitizers, #llvm

Differential Revision: https://reviews.llvm.org/D69546

(cherry picked from commit 4c39f341996cea2fd8619fc14c8c66ab567744fb)