### PR TITLE
TF-965: Change LLDB to use PIC

### DIFF
--- a/lldb/source/Expression/IRExecutionUnit.cpp
+++ b/lldb/source/Expression/IRExecutionUnit.cpp
@@ -284,9 +284,9 @@ void IRExecutionUnit::GetRunnableInfo(Status &error, lldb::addr_t &func_addr,
 
   builder.setEngineKind(llvm::EngineKind::JIT)
       .setErrorStr(&error_string)
-      .setRelocationModel(triple.isOSBinFormatMachO()
-                              ? llvm::Reloc::PIC_
-                              : llvm::Reloc::Static)
+      // SWIFT_ENABLE_TENSORFLOW
+      // See TF-965.
+      .setRelocationModel(llvm::Reloc::PIC_)
       .setMCJITMemoryManager(
           std::unique_ptr<MemoryManager>(new MemoryManager(*this)))
       .setOptLevel(llvm::CodeGenOpt::Less);


### PR DESCRIPTION
Swift generates code with 32-bit relative addresses. If we load more than ~2gb of shared libraries into an LLDB REPL on Linux, the LLVM JIT starts failing to relocate these addresses [1]. We can fix this by changing the engine relocation model [2] to always be `llvm::Reloc::PIC_`.

I think the reason this works is that position independent code doesn't need to be relocated, so the linker doesn't need to write the >2gb offsets into the 32-bit relative address fields. I'm a bit fuzzy on the exact details.

This seems like a thing that should be committed upstream, but since it's a S4TF v0.6 release blocker, seems like we should commit this into our branch ASAP. I have inquired on the lldb slack channel about the right way to do this upstream.

Resolves TF-965.

[1] Specifically, an assertion failure happens here: https://github.com/apple/llvm-project/blob/b45d5b6fbb9d9b1716e8010e851aa1e86729b471/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp#L307
[2] https://github.com/apple/llvm-project/blob/b45d5b6fbb9d9b1716e8010e851aa1e86729b471/lldb/source/Expression/IRExecutionUnit.cpp#L268