### PR TITLE
install python in liblldb component

### DIFF
--- a/lldb/scripts/CMakeLists.txt
+++ b/lldb/scripts/CMakeLists.txt
@@ -63,11 +63,16 @@ if(NOT LLDB_BUILD_FRAMEWORK)
   set(SWIG_INSTALL_DIR lib${LLVM_LIBDIR_SUFFIX})
 
   # Install the LLDB python module
-  install(DIRECTORY ${SWIG_PYTHON_DIR} DESTINATION ${SWIG_INSTALL_DIR})
+  # SWIFT_ENABLE_TENSORFLOW: Install in liblldb component so that it gets included in the toolchain.
+  # TODO: There are some upstream changes that install python in a "lldb-python-scripts" component.
+  #       (f6bedd81cca5c1a60ef5faa5a5e9cb3d5737ffdd, 61f471a705a5df3d581ba4905337f433bac3ba1f, and more).
+  #       When merging those changes, we should delete the tensorflow-branch changes, and add
+  #       "lldb-python-scripts" to "lldb/cmake/caches/Apple-lldb-Linux.cmake".
+  install(DIRECTORY ${SWIG_PYTHON_DIR} DESTINATION ${SWIG_INSTALL_DIR} COMPONENT liblldb)
   
   # SWIFT_ENABLE_TENSORFLOW
   # The build might have generated some "python3.x" symlinks. See the comment in
   # "finishSwigPythonLLDB.py" for more information. Install them, if they exist.
-  install(DIRECTORY "${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/python3.6" DESTINATION ${SWIG_INSTALL_DIR} OPTIONAL)
-  install(DIRECTORY "${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/python3.7" DESTINATION ${SWIG_INSTALL_DIR} OPTIONAL)
+  install(DIRECTORY "${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/python3.6" DESTINATION ${SWIG_INSTALL_DIR} OPTIONAL COMPONENT liblldb)
+  install(DIRECTORY "${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/python3.7" DESTINATION ${SWIG_INSTALL_DIR} OPTIONAL COMPONENT liblldb)
 endif()


### PR DESCRIPTION
https://github.com/apple/swift/pull/27920 changes the swift toolchain build to only include "distribution" components in lldb. The python lldb lib is not included in any component, so it stopped being in the toolchain.

https://github.com/apple/llvm-project/blob/12bbae1fd6e12a3ff45fae6ee07a197089fd55ea/lldb/cmake/caches/Apple-lldb-Linux.cmake specifies which components are included in the "distribution".

This PR puts the python lldb lib in liblldb so that it gets included in the toolchain.

As noted in the comment, there are a bunch of upstream changes doing a similar thing. Those changes are big and complicated and they have not yet been pulled into the swift llvm, so it is easier to do this for now and then use the upstream changes after they get pulled into the swift llvm.
