### PR TITLE
Support: repair Windows build

### DIFF
--- a/llvm/lib/Support/PrettyStackTrace.cpp
+++ b/llvm/lib/Support/PrettyStackTrace.cpp
@@ -21,6 +21,7 @@
 #include "llvm/Support/Watchdog.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <atomic>
 #include <cstdarg>
 #include <cstdio>
 #include <tuple>


### PR DESCRIPTION
Include <atomic> for the use of `std::atomic`.