### PR TITLE
[LTO][Legacy] Add API for passing LLVM options separately

### DIFF
--- a/llvm/include/llvm-c/lto.h
+++ b/llvm/include/llvm-c/lto.h
@@ -44,7 +44,7 @@ typedef bool lto_bool_t;
  * @{
  */
 
-#define LTO_API_VERSION 24
+#define LTO_API_VERSION 26
 
 /**
  * \since prior to LTO_API_VERSION=3
@@ -514,10 +514,23 @@ lto_api_version(void);
 /**
  * Sets options to help debug codegen bugs.
  *
+ * This function takes one or more options separated by spaces.
+ * Warning: passing file paths through this function may confuse the argument
+ * parser if the paths contain spaces.
+ *
  * \since prior to LTO_API_VERSION=3
  */
 extern void
 lto_codegen_debug_options(lto_code_gen_t cg, const char *);
+
+/**
+ * Same as the previous function, but takes every option separately through an
+ * array.
+ *
+ * \since prior to LTO_API_VERSION=26
+ */
+extern void lto_codegen_debug_options_array(lto_code_gen_t cg,
+                                            const char *const *, int number);
 
 /**
  * Initializes LLVM disassemblers.

--- a/llvm/include/llvm/LTO/legacy/LTOCodeGenerator.h
+++ b/llvm/include/llvm/LTO/legacy/LTOCodeGenerator.h
@@ -35,6 +35,7 @@
 #define LLVM_LTO_LTOCODEGENERATOR_H
 
 #include "llvm-c/lto.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSet.h"
@@ -121,7 +122,7 @@ struct LTOCodeGenerator {
   /// name is misleading).  This function should be called before
   /// LTOCodeGenerator::compilexxx(), and
   /// LTOCodeGenerator::writeMergedModules().
-  void setCodeGenDebugOptions(StringRef Opts);
+  void setCodeGenDebugOptions(ArrayRef<const char *> Opts);
 
   /// Parse the options set in setCodeGenDebugOptions.
   ///

--- a/llvm/lib/LTO/LTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/LTOCodeGenerator.cpp
@@ -619,12 +619,9 @@ bool LTOCodeGenerator::compileOptimized(ArrayRef<raw_pwrite_stream *> Out) {
   return true;
 }
 
-/// setCodeGenDebugOptions - Set codegen debugging options to aid in debugging
-/// LTO problems.
-void LTOCodeGenerator::setCodeGenDebugOptions(StringRef Options) {
-  for (std::pair<StringRef, StringRef> o = getToken(Options); !o.first.empty();
-       o = getToken(o.second))
-    CodegenOptions.push_back(o.first);
+void LTOCodeGenerator::setCodeGenDebugOptions(ArrayRef<const char *> Options) {
+  for (StringRef Option : Options)
+    CodegenOptions.push_back(Option);
 }
 
 void LTOCodeGenerator::parseCodeGenDebugOptions() {

--- a/llvm/tools/lto/lto.cpp
+++ b/llvm/tools/lto/lto.cpp
@@ -13,6 +13,7 @@
 
 #include "llvm-c/lto.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/CodeGen/CommandFlags.inc"
 #include "llvm/IR/DiagnosticInfo.h"
@@ -453,7 +454,17 @@ bool lto_codegen_compile_to_file(lto_code_gen_t cg, const char **name) {
 }
 
 void lto_codegen_debug_options(lto_code_gen_t cg, const char *opt) {
-  unwrap(cg)->setCodeGenDebugOptions(opt);
+  std::vector<const char *> Options;
+  for (std::pair<StringRef, StringRef> o = getToken(opt); !o.first.empty();
+       o = getToken(o.second))
+    Options.push_back(o.first.data());
+
+  unwrap(cg)->setCodeGenDebugOptions(Options);
+}
+
+void lto_codegen_debug_options_array(lto_code_gen_t cg,
+                                     const char *const *options, int number) {
+  unwrap(cg)->setCodeGenDebugOptions(makeArrayRef(options, number));
 }
 
 unsigned int lto_api_version() { return LTO_API_VERSION; }

--- a/llvm/tools/lto/lto.exports
+++ b/llvm/tools/lto/lto.exports
@@ -33,6 +33,7 @@ lto_codegen_set_debug_model
 lto_codegen_set_pic_model
 lto_codegen_write_merged_modules
 lto_codegen_debug_options
+lto_codegen_debug_options_array
 lto_codegen_set_assembler_args
 lto_codegen_set_assembler_path
 lto_codegen_set_cpu


### PR DESCRIPTION
In order to correctly pass options to LLVM, including options containing
spaces which are used as delimiters for multiple options in
lto_codegen_debug_options, add a new API:
lto_codegen_debug_options_array.

Unfortunately, tools/lto has no testing infrastructure yet, so there are
no tests associated with this patch.

Differential Revision: https://reviews.llvm.org/D70463

(cherry picked from commit bffdee8ef379126de3f2581214d89c1b29f440b7)

 Conflicts:
	llvm/include/llvm-c/lto.h

rdar://55418069