### PR TITLE
[FileCollector] Ignore empty paths.

### DIFF
--- a/llvm/include/llvm/Support/FileCollector.h
+++ b/llvm/include/llvm/Support/FileCollector.h
@@ -46,7 +46,11 @@ public:
 private:
   void addFileImpl(StringRef SrcPath);
 
-  bool markAsSeen(StringRef Path) { return Seen.insert(Path).second; }
+  bool markAsSeen(StringRef Path) {
+    if (Path.empty())
+      return false;
+    return Seen.insert(Path).second;
+  }
 
   bool getRealPath(StringRef SrcPath, SmallVectorImpl<char> &Result);
 


### PR DESCRIPTION
Don't insert empty strings into the StringSet<> because that triggers an
assert in its implementation.

(cherry picked from commit a9bb669e59f4b2270caa8a35128ca3b2de0595fe)