### PR TITLE
[debugserver] Set arch based on TARGET_TRIPLE

### DIFF
--- a/lldb/tools/debugserver/source/MacOSX/CMakeLists.txt
+++ b/lldb/tools/debugserver/source/MacOSX/CMakeLists.txt
@@ -1,17 +1,17 @@
 # The debugserver build needs to conditionally include files depending on the
 # target architecture.
 #
-# Switch on the architecture specified by LLVM_DEFAULT_TARGET_TRIPLE, as
+# Switch on the architecture specified by TARGET_TRIPLE, as
 # the llvm and swift build systems use this variable to identify the
-# target (the latter, indirectly, through LLVM_HOST_TRIPLE).
+# target (through LLVM_HOST_TRIPLE).
 #
 # It would be possible to switch on CMAKE_OSX_ARCHITECTURES, but the swift
 # build does not provide it, preferring instead to pass arch-specific
 # CFLAGS etc explicitly. Switching on LLVM_HOST_TRIPLE is also an option,
 # but it breaks down when cross-compiling.
 
-if(LLVM_DEFAULT_TARGET_TRIPLE)
-  string(REGEX MATCH "^[^-]*" LLDB_DEBUGSERVER_ARCH ${LLVM_DEFAULT_TARGET_TRIPLE})
+if(TARGET_TRIPLE)
+  string(REGEX MATCH "^[^-]*" LLDB_DEBUGSERVER_ARCH ${TARGET_TRIPLE})
 else()
   set(LLDB_DEBUGSERVER_ARCH ${CMAKE_OSX_ARCHITECTURES})
 endif()


### PR DESCRIPTION
Use TARGET_TRIPLE instead of LLVM_DEFAULT_TARGET_TRIPLE, as the latter
isn't exported by LLVMConfig.cmake, which means arch detection fails if
lldb is built separately from llvm.

(cherry picked from commit af331cbe14e8376c696441bb4c26a68be733b884)