### PR TITLE
Make `mach_vm_allocate.c` test less flaky

### DIFF
--- a/compiler-rt/test/tsan/Darwin/mach_vm_allocate.c
+++ b/compiler-rt/test/tsan/Darwin/mach_vm_allocate.c
@@ -3,8 +3,6 @@
 // RUN: %clang_tsan %s -o %t
 // RUN: %run %t 2>&1 | FileCheck %s --implicit-check-not='ThreadSanitizer'
 
-// REQUIRES: rdar57365733
-
 #include <mach/mach.h>
 #include <mach/mach_vm.h>
 #include <pthread.h>
@@ -31,9 +29,11 @@ static int *alloc() {
 
 static void alloc_fixed(int *ptr) {
   mach_vm_address_t addr = (mach_vm_address_t)ptr;
-  kern_return_t res =
-      mach_vm_allocate(mach_task_self(), &addr, alloc_size, VM_FLAGS_FIXED);
-  assert(res == KERN_SUCCESS);
+  kern_return_t res;
+  // Re-allocation via VM_FLAGS_FIXED sporadically fails.
+  do {
+    res = mach_vm_allocate(mach_task_self(), &addr, alloc_size, VM_FLAGS_FIXED);
+  } while (res != KERN_SUCCESS);
 }
 
 static void dealloc(int *ptr) {
@@ -46,8 +46,9 @@ static void *Thread(void *arg) {
   *global_ptr = 7;  // Assignment 1
 
   // We want to test that TSan does not report a race between the two
-  // assignments to global_ptr when memory is re-allocated here. The calls to
-  // the API itself are racy though, so ignore them.
+  // assignments to *global_ptr when the underlying memory is re-allocated
+  // between assignments. The calls to the API itself are racy though, so ignore
+  // them.
   AnnotateIgnoreWritesBegin(__FILE__, __LINE__);
   dealloc(global_ptr);
   alloc_fixed(global_ptr);


### PR DESCRIPTION
How can I test this without annoying everyone/blocking PR?  I can't reproduce the flaky behavior locally.  (I tried running the test in an infinite loop).