### PR TITLE
[modulemap] Add AArch64SVEACLETypes.def

### DIFF
--- a/clang/include/clang/module.modulemap
+++ b/clang/include/clang/module.modulemap
@@ -31,6 +31,7 @@ module Clang_Basic {
   requires cplusplus
   umbrella "Basic"
 
+  textual header "Basic/AArch64SVEACLETypes.def"
   textual header "Basic/BuiltinsAArch64.def"
   textual header "Basic/BuiltinsAMDGPU.def"
   textual header "Basic/BuiltinsARM.def"


### PR DESCRIPTION
Update modulemap with a new textual header.

llvm-svn: 368508
(cherry picked from commit 3ab587df82c8f917a7048e7797b90267694ad938)