### PR TITLE
[clangd][NFC] Decrease template depth limit in RecursiveHierarchyUnbo…

### DIFF
--- a/clang-tools-extra/clangd/unittests/TypeHierarchyTests.cpp
+++ b/clang-tools-extra/clangd/unittests/TypeHierarchyTests.cpp
@@ -390,6 +390,7 @@ TEST(TypeHierarchy, RecursiveHierarchyUnbounded) {
   )cpp");
 
   TestTU TU = TestTU::withCode(Source.code());
+  TU.ExtraArgs.push_back("-ftemplate-depth=10");
   auto AST = TU.build();
 
   // The compiler should produce a diagnostic for hitting the


### PR DESCRIPTION
…unded test

...to minimize the chance of stack overflow before reaching the limit.

llvm-svn: 365804
(cherry picked from commit a286aae4d818f8a2e0eb70c68c0605cae6874a44)