### PR TITLE
[Driver] Fix newline at the end of help output

### DIFF
--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -782,9 +782,8 @@ EXAMPLES:
     lldb -K /source/before/crash -k /source/after/crash
 
   Note: In REPL mode no file is loaded, so commands specified to run after
-  loading the file (via -o or -s) will be ignored.
-  )___";
-  llvm::outs() << examples;
+  loading the file (via -o or -s) will be ignored.)___";
+  llvm::outs() << examples << '\n';
 }
 
 llvm::Optional<int> InitializeReproducer(opt::InputArgList &input_args) {


### PR DESCRIPTION
Print a regular newline at the end of the help output. The current
string literal seems to throw off shells.

(cherry picked from commit 6c2e4e88010827034250fcec0840c84dca4cc354)