### PR TITLE
[Reproducer] Fix incorrect %clang substitution

### DIFF
--- a/lldb/lit/Reproducer/TestGDBRemoteRepro.test
+++ b/lldb/lit/Reproducer/TestGDBRemoteRepro.test
@@ -6,7 +6,7 @@
 # process. To ensure we're not actually running the original binary we check
 # that the string "testing" is not printed.
 
-# RUN: %clang_host %S/Inputs/simple.c -g -o %t.out
+# RUN: %clang %S/Inputs/simple.c -g -o %t.out
 
 # Test reproducer generate command.
 # RUN: rm -rf %t.repro

--- a/lldb/test/Shell/Reproducer/Functionalities/TestExpressionEvaluation.test
+++ b/lldb/test/Shell/Reproducer/Functionalities/TestExpressionEvaluation.test
@@ -4,7 +4,7 @@
 # reproducer.
 
 # RUN: rm -rf %t.repro
-# RUN: %clangxx_host %S/Inputs/foo.cpp -g -o %t.out
+# RUN: %clangxx %S/Inputs/foo.cpp -g -o %t.out
 
 # RUN: %lldb -x -b -s %S/Inputs/ExpressionEvaluation.in --capture --capture-path %t.repro %t.out | FileCheck %s
 # RUN: %lldb --replay %t.repro | FileCheck %s

--- a/lldb/test/Shell/Reproducer/TestDiscard.test
+++ b/lldb/test/Shell/Reproducer/TestDiscard.test
@@ -4,7 +4,7 @@
 # Build the inferior.
 # RUN: mkdir -p %t
 # RUN: rm -rf %t.repro
-# RUN: %clang_host %S/Inputs/simple.c -g -o %t/reproducer.out
+# RUN: %clang %S/Inputs/simple.c -g -o %t/reproducer.out
 
 # Capture but don't generate the reproducer.
 # RUN: %lldb -x -b -s %S/Inputs/Discard.in --capture --capture-path %t.repro %t/reproducer.out


### PR DESCRIPTION
The substitution variable for clang was renamed upstream to include a
`_host` prefix. However, we don't have that commit on the
`apple/stable/20190619` branch, which caused some cherry-picked tests to
fail.