### PR TITLE
[LLDB] Fix/silence CMake developer warning for LLDB framework.

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -35,7 +35,7 @@ function(add_lldb_library name)
   # only supported parameters to this macro are the optional
   # MODULE;SHARED;STATIC library type and source files
   cmake_parse_arguments(PARAM
-    "MODULE;SHARED;STATIC;OBJECT;PLUGIN"
+    "MODULE;SHARED;STATIC;OBJECT;PLUGIN;FRAMEWORK"
     "INSTALL_PREFIX;ENTITLEMENTS"
     "EXTRA_CXXFLAGS;DEPENDS;LINK_LIBS;LINK_COMPONENTS"
     ${ARGN})
@@ -91,6 +91,14 @@ function(add_lldb_library name)
       ${pass_ENTITLEMENTS}
       ${pass_NO_INSTALL_RPATH}
     )
+  endif()
+
+  # A target cannot be changed to a FRAMEWORK after calling install() because
+  # this may result in the wrong install DESTINATION. The FRAMEWORK property
+  # must be set earlier.
+  if(PARAM_FRAMEWORK)
+    message(WARNING "{name} is now a FRAMEWORK")
+    set_target_properties(liblldb PROPERTIES FRAMEWORK ON)
   endif()
 
   if(PARAM_SHARED)

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -13,7 +13,7 @@ if(LLDB_BUILD_FRAMEWORK)
   set(option_install_prefix INSTALL_PREFIX ${LLDB_FRAMEWORK_INSTALL_DIR})
 endif()
 
-add_lldb_library(liblldb SHARED
+add_lldb_library(liblldb SHARED FRAMEWORK
   SBAddress.cpp
   SBAttachInfo.cpp
   SBBlock.cpp


### PR DESCRIPTION
This fixes the following warning for developers:

  Target 'liblldb' was changed to a FRAMEWORK sometime after install().  This
  may result in the wrong install DESTINATION.  Set the FRAMEWORK property
  earlier.

The solution is to pass the FRAMEWORK flag to add_lldb_library and set
the target property before install(). For now liblldb is the only
customer.

(cherry picked from commit a247bd1f274e49ea83b2ad39c6ff062753e9e779)