### PR TITLE
[lldb] Fix that Objective-C methods were never variadic

### DIFF
--- a/lldb/source/Symbol/ClangASTContext.cpp
+++ b/lldb/source/Symbol/ClangASTContext.cpp
@@ -8698,7 +8698,7 @@ clang::ObjCMethodDecl *ClangASTContext::AddMethodToObjCObjectType(
     return nullptr;
 
   const bool isInstance = (name[0] == '-');
-  const bool isVariadic = false;
+  const bool isVariadic = is_variadic;
   const bool isPropertyAccessor = false;
   const bool isSynthesizedAccessorStub = false;
   /// Force this to true because we don't have source locations.


### PR DESCRIPTION
In 952413c24961cf195622a1991cc5827ed29ff561 we just hardcoded a
false in there instead of taking the value of is_variadic.