### PR TITLE
[TSan] Fix TSan flag for Swift on Linux testing

### DIFF
--- a/compiler-rt/test/sanitizer_common/lit.common.cfg.py
+++ b/compiler-rt/test/sanitizer_common/lit.common.cfg.py
@@ -37,6 +37,9 @@ if config.host_os == 'Darwin':
   default_tool_options += ['abort_on_error=0']
   if config.tool_name == "tsan":
     default_tool_options += ['ignore_interceptors_accesses=0']
+elif config.host_os == 'Linux' and config.tool_name == 'tsan':
+    # For Swift, the above also applies on Linux.
+    default_tool_options += ['ignore_interceptors_accesses=0']
 elif config.android:
   # The same as on Darwin, we default to "abort_on_error=1" which slows down
   # testing. Also, all existing tests are using "not" instead of "not --crash"

--- a/compiler-rt/test/tsan/Unit/lit.site.cfg.py.in
+++ b/compiler-rt/test/tsan/Unit/lit.site.cfg.py.in
@@ -15,6 +15,8 @@ config.test_source_root = config.test_exec_root
 if config.host_os == 'Darwin':
   config.parallelism_group = config.darwin_sanitizer_parallelism_group_func
 
+# For Swift, the following also applies on Linux.
+if config.host_os == 'Darwin' or config.host_os == 'Linux':
   # On Darwin, we default to ignore_noninstrumented_modules=1, which also
   # suppresses some races the tests are supposed to find.  See tsan/lit.cfg.py.
   if 'TSAN_OPTIONS' in config.environment:

--- a/compiler-rt/test/tsan/lit.cfg.py
+++ b/compiler-rt/test/tsan/lit.cfg.py
@@ -24,6 +24,9 @@ if config.host_os == 'Darwin':
   # On Darwin, we default to `abort_on_error=1`, which would make tests run
   # much slower. Let's override this and run lit tests with 'abort_on_error=0'.
   default_tsan_opts += ':abort_on_error=0'
+
+# For Swift, the following also applies on Linux.
+if config.host_os == 'Darwin' or config.host_os == 'Linux':
   # On Darwin, we default to ignore_noninstrumented_modules=1, which also
   # suppresses some races the tests are supposed to find. Let's run without this
   # setting, but turn it back on for Darwin tests (see Darwin/lit.local.cfg.py).


### PR DESCRIPTION
For Swift, we turn on `ignore_noninstrumented_modules` and
`ignore_interceptors_accesses` even on Linux (where they are usually
disabled).  We have to account for that when running LLVM-Swift on
Linux.

rdar://57436887
(cherry picked from commit 71fbf9fc705195d6f3e3116f6d026448a53838fa)