### PR TITLE
[EditLine] Fix RecallHistory to make it go in the right direction.

### DIFF
--- a/lldb/include/lldb/Host/Editline.h
+++ b/lldb/include/lldb/Host/Editline.h
@@ -133,6 +133,15 @@ enum class CursorLocation {
   /// session
   BlockEnd
 };
+
+/// Operation for the history.
+enum class HistoryOperation {
+  Oldest,
+  Older,
+  Current,
+  Newer,
+  Newest
+};
 }
 
 using namespace line_editor;
@@ -258,11 +267,7 @@ private:
   StringList GetInputAsStringList(int line_count = UINT32_MAX);
 
   /// Replaces the current multi-line session with the next entry from history.
-  /// When the parameter is
-  /// true it will take the next earlier entry from history, when it is false it
-  /// takes the next most
-  /// recent.
-  unsigned char RecallHistory(bool earlier);
+  unsigned char RecallHistory(HistoryOperation op);
 
   /// Character reading implementation for EditLine that supports our multi-line
   /// editing trickery.


### PR DESCRIPTION
The naming used by editline for the history operations is counter
intuitive to how it's used in lldb for the REPL.

 - The H_PREV operation returns the previous element in the history,
   which is newer than the current one.
 - The H_NEXT operation returns the next element in the history, which
   is older than the current one.

This exposed itself as a bug in the REPL where the behavior of up- and
down-arrow was inverted. This wasn't immediately obvious because of how
we save the current "live" entry.

This patch fixes the bug and introduces and enum to wrap the editline
operations that match the semantics of lldb.

Differential revision: https://reviews.llvm.org/D70932

(cherry picked from commit 0e9b0b6d11e882efec8505d97c4b65e1562e6715)