### PR TITLE
Fix `ignore_noninstrumented_modules` on Linux

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cc
@@ -629,6 +629,10 @@ class DynamicSegment {
       last_symbol = Max(buckets[i], last_symbol);
     }
 
+    if (last_symbol < header->symoffset) {
+      return header->symoffset;
+    }
+
     // Walk the bucket's chain to add the chain length to the total.
     uint32_t chain_entry;
     do {


### PR DESCRIPTION
My initial implementation of `ignore_noninstrumented_modules` for Linux (landed
in 61592420d3e2a896ff64b6bcd9728dd359d7d479) did not consider that the GNU
symbol table could be present but empty.  "Empty" means: void of real symbol
entries, but potential "terminator/placeholder" symbols that are skipped via
`header->symoffset`. In this case `last_symbol` is zero and we should avoid
computing `chains[last_symbol - header->symoffset]`.

This bug seems to only manifest in combination with `LD_PRELOAD` (counterpart of
`DYLD_INSERT_LIBRARIES` for Linux) and for small binaries, (e.g., the "not"
utility from the llvm test suite) that have segments without any real symbols.

This should fix the remaining failing ASan tests on the Swift Linux CI.

rdar://57566645
