### PR TITLE
[lldb/Reproducers] Override capture with LLDB_CAPTURE_REPRODUCER env var

### DIFF
--- a/lldb/lit/Reproducer/TestCaptureEnvOverride.test
+++ b/lldb/lit/Reproducer/TestCaptureEnvOverride.test
@@ -1,0 +1,20 @@
+# UNSUPPORTED: system-windows
+# This tests the LLDB_CAPTURE_REPRODUCER override.
+
+# RUN: %lldb -b -o 'reproducer status' --capture --capture-path %t.repro /bin/ls | FileCheck %s --check-prefix CAPTURE
+# RUN: %lldb -b -o 'reproducer status' --capture | FileCheck %s --check-prefix CAPTURE
+
+# RUN: LLDB_CAPTURE_REPRODUCER=1 %lldb -b -o 'reproducer status' | FileCheck %s --check-prefix CAPTURE
+# RUN: LLDB_CAPTURE_REPRODUCER=ON %lldb -b -o 'reproducer status' | FileCheck %s --check-prefix CAPTURE
+# RUN: LLDB_CAPTURE_REPRODUCER=on %lldb -b -o 'reproducer status' | FileCheck %s --check-prefix CAPTURE
+
+# RUN: LLDB_CAPTURE_REPRODUCER=0 %lldb -b -o 'reproducer status' --capture --capture-path %t.repro | FileCheck %s --check-prefix OFF
+# RUN: LLDB_CAPTURE_REPRODUCER=0 %lldb -b -o 'reproducer status' --capture | FileCheck %s --check-prefix OFF
+# RUN: LLDB_CAPTURE_REPRODUCER=OFF %lldb -b -o 'reproducer status' --capture --capture-path %t.repro | FileCheck %s --check-prefix OFF
+# RUN: LLDB_CAPTURE_REPRODUCER=off %lldb -b -o 'reproducer status' --capture | FileCheck %s --check-prefix OFF
+
+# RUN: LLDB_CAPTURE_REPRODUCER=bogus %lldb -b -o 'reproducer status' --capture | FileCheck %s --check-prefix CAPTURE
+# RUN: LLDB_CAPTURE_REPRODUCER=bogus %lldb -b -o 'reproducer status' | FileCheck %s --check-prefix OFF
+
+# CAPTURE: Reproducer is in capture mode.
+# OFF: Reproducer is off.

--- a/lldb/lit/Reproducer/lit.local.cfg
+++ b/lldb/lit/Reproducer/lit.local.cfg
@@ -1,0 +1,3 @@
+# Enable crash reports for the reproducer tests.
+del config.environment['LLVM_DISABLE_CRASH_REPORT']
+del config.environment['LLDB_CAPTURE_REPRODUCER']

--- a/lldb/source/Utility/Reproducer.cpp
+++ b/lldb/source/Utility/Reproducer.cpp
@@ -25,6 +25,16 @@ llvm::Error Reproducer::Initialize(ReproducerMode mode,
   lldbassert(!InstanceImpl() && "Already initialized.");
   InstanceImpl().emplace();
 
+  // The environment can override the capture mode.
+  if (mode != ReproducerMode::Replay) {
+    std::string env =
+        llvm::StringRef(getenv("LLDB_CAPTURE_REPRODUCER")).lower();
+    if (env == "0" || env == "off")
+      mode = ReproducerMode::Off;
+    else if (env == "1" || env == "on")
+      mode = ReproducerMode::Capture;
+  }
+
   switch (mode) {
   case ReproducerMode::Capture: {
     if (!root) {


### PR DESCRIPTION
Make it possible to override reproducer capture with the
LLDB_CAPTURE_REPRODUCER environment variable.

The goal of this change is twofold.

(1) I want to be able to enable capturing reproducers during regular
    test runs, both locally and on the bots. To do so I need a way to
    force capture. I cannot do this through the Python API, because
    reproducer capture must be enabled *before* the debugger
    initialized, which happens automatically when doing `import lldb`.

(2) I want to provide an escape hatch for when reproducers are enabled
    by default. Downstream we have reproducer capture enabled by default
    in the driver.

This patch solves both problems by overriding the reproducer mode based
on the environment variable. Acceptable values are 0/1 and ON/OFF.

(cherry picked from commit dfe9a7943bf7a926e51b319a2c2f73e4b4b4cf43)