### PR TITLE
[DebugInfo] Ensure fallback artificial location is available for clea…

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -726,6 +726,8 @@ public:
     Other.CGF = nullptr;
   }
 
+  ApplyDebugLocation &operator=(ApplyDebugLocation &&) = default;
+
   ~ApplyDebugLocation();
 
   /// Apply TemporaryLocation if it is valid. Otherwise switch

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -332,9 +332,15 @@ void CodeGenFunction::FinishFunction(SourceLocation EndLoc) {
   if (HasCleanups) {
     // Make sure the line table doesn't jump back into the body for
     // the ret after it's been at EndLoc.
-    if (CGDebugInfo *DI = getDebugInfo())
+    Optional<ApplyDebugLocation> AL;
+    if (CGDebugInfo *DI = getDebugInfo()) {
       if (OnlySimpleReturnStmts)
         DI->EmitLocation(Builder, EndLoc);
+      else
+        // We may not have a valid end location. Try to apply it anyway, and
+        // fall back to an artificial location if needed.
+        AL = ApplyDebugLocation::CreateDefaultArtificial(*this, EndLoc);
+    }
 
     PopCleanupBlocks(PrologueCleanupDepth);
   }

--- a/clang/test/CodeGenObjCXX/property-object-cleanup.mm
+++ b/clang/test/CodeGenObjCXX/property-object-cleanup.mm
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -triple arm64e-apple-ios13.4.0 -debug-info-kind=standalone -fobjc-arc \
+// RUN:   %s -emit-llvm -o - | FileCheck %s
+
+@interface NSObject
++ (id)alloc;
+@end
+
+@interface NSString : NSObject
+@end
+
+// CHECK: define {{.*}}@"\01-[MyData setData:]"
+// CHECK: [[DATA:%.*]] = alloca %struct.Data
+// CHECK: call %struct.Data* @_ZN4DataD1Ev(%struct.Data* [[DATA]]){{.*}}, !dbg [[LOC:![0-9]+]]
+// CHECK-NEXT: ret void
+
+// [[LOC]] = !DILocation(line: 0
+
+@interface MyData : NSObject
+struct Data {
+    NSString *name;
+};
+@property struct Data data;
+@end
+@implementation MyData
+@end


### PR DESCRIPTION
…nups

While finishing a function without a valid end location, fall back to an
artificial debug location when generating IR for cleanups. This fixes a
verifier failure ("inlinable function call without debug info").

rdar://57630879