### PR TITLE
[OPENMP]Fix crash in LoopCounterRefChecker when MemberExpr is not Var or Field

### DIFF
--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -4967,7 +4967,8 @@ public:
   bool VisitMemberExpr(const MemberExpr *E) {
     if (isa<CXXThisExpr>(E->getBase()->IgnoreParens())) {
       const ValueDecl *VD = E->getMemberDecl();
-      return checkDecl(E, VD);
+      if (isa<VarDecl>(VD) || isa<FieldDecl>(VD))
+        return checkDecl(E, VD);
     }
     return false;
   }

--- a/clang/test/OpenMP/for_loop_messages.cpp
+++ b/clang/test/OpenMP/for_loop_messages.cpp
@@ -626,12 +626,20 @@ template <typename IT, int ST>
 class TC {
   int ii, iii, kk;
 public:
+  enum { myconstant = 42 };
+  int ub();
   int dotest_lt(IT begin, IT end) {
 #pragma omp parallel
 // expected-error@+3 3 {{the loop initializer expression depends on the current loop control variable}}
 // expected-error@+2 6 {{the loop condition expression depends on the current loop control variable}}
 #pragma omp for
   for (ii = ii * 10 + 25; ii < ii / ii - 23; ii += 1)
+    ;
+
+// Check that member function calls and enum constants in the condition is
+// handled.
+#pragma omp for
+  for (ii = 0; ii < ub() + this->myconstant; ii += 1) // expected-no-error
     ;
 
 #pragma omp parallel


### PR DESCRIPTION
checkDecl is only valid for VarDecls or FieldDecls, since getCanonicalDecl
expects only these. Prevent other Decl kinds (such as CXXMethodDecls and
EnumConstantDecls) from entering and asserting.

Differential Revision: https://reviews.llvm.org/D64842

llvm-svn: 366336
(cherry picked from commit 552c2c09d354a3ad9c1c9647e0a3bb5099c31088)

rdar://problem/50204595