### PR TITLE
[llvm/dwarfdump] Use the architecture string to filter.

### DIFF
--- a/llvm/test/tools/llvm-dwarfdump/AArch64/arch.ll
+++ b/llvm/test/tools/llvm-dwarfdump/AArch64/arch.ll
@@ -1,6 +1,5 @@
 ; RUN: llc -O0 %s -filetype=obj -o %t.o
 ; RUN: llvm-dwarfdump -arch arm64   %t.o | FileCheck %s
-; RUN: llvm-dwarfdump -arch aarch64 %t.o | FileCheck %s
 ; RUN: llvm-dwarfdump -arch 0x0100000c %t.o | FileCheck %s
 ; CHECK: file format Mach-O arm64
 ;

--- a/llvm/test/tools/llvm-dwarfdump/filter.test
+++ b/llvm/test/tools/llvm-dwarfdump/filter.test
@@ -1,0 +1,4 @@
+Make sure that passing --arch armv7s only shows the armv7s slice and not the armv7 slice.
+
+RUN: llvm-dwarfdump -arch armv7s %S/../dsymutil/Inputs/fat-test.arm.dylib | FileCheck %s
+CHECK-NOT: (armv7)

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -271,7 +271,7 @@ static bool filterArch(ObjectFile &Obj) {
           return true;
 
       // Match as name.
-      if (MachO->getArchTriple().getArch() == Triple(Arch).getArch())
+      if (MachO->getArchTriple().getArchName() == Triple(Arch).getArchName())
         return true;
     }
   }


### PR DESCRIPTION
Currently dwarfdump uses the ArchType to filter out architectures, which
is problematic for architectures like arm64e and x86_64h that map back
to arm64 and x86_64 respectively. The result is that the filter doesn't
work for these architectures because it matches all the variants. This
is especially bad because usually these architectures are the reason to
use the filter in the first place.

Instead, we should match the architecture based on the string name. This
means the filter works for the values printed by dwarfdump. It has the
unfortunate side effect of not working for aliases, like AArch64, but I
think that's worth the trade-off.

rdar://53653014

Differential revision: https://reviews.llvm.org/D71230

(cherry picked from commit d9466653e4ddbde5e787ac8cdbe67c1f356a5f69)