### PR TITLE
[lldb] Actually enable wchar support in Editline when it is defined i…

### DIFF
--- a/lldb/include/lldb/Host/Editline.h
+++ b/lldb/include/lldb/Host/Editline.h
@@ -32,6 +32,8 @@
 #define liblldb_Editline_h_
 #if defined(__cplusplus)
 
+#include "lldb/Host/Config.h"
+
 #if LLDB_EDITLINE_USE_WCHAR
 #include <codecvt>
 #endif

--- a/lldb/packages/Python/lldbsuite/test/iohandler/unicode/TestUnicode.py
+++ b/lldb/packages/Python/lldbsuite/test/iohandler/unicode/TestUnicode.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""
+Test unicode handling in LLDB.
+"""
+
+import os
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.lldbpexpect import PExpectTest
+
+class TestCase(PExpectTest):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    # PExpect uses many timeouts internally and doesn't play well
+    # under ASAN on a loaded machine..
+    @skipIfAsan
+    def test_unicode_input(self):
+        self.launch()
+
+        # Send some unicode input to LLDB.
+        # We should get back that this is an invalid command with our character as UTF-8.
+        self.expect(u'\u1234', substrs=[u"error: '\u1234' is not a valid command.".encode('utf-8')])
+
+        self.quit()


### PR DESCRIPTION
…n the host config

Summary:
Our Editline implementation in LLDB supports using the wchar interface of Editline which
should improve handling of unicode input when using Editline. At the moment we essentially
just ignore unicode input and echo the escaped unicode code point (`\U1234`) to the command line
(which we then also incorrectly treat as multiple characters, so console navigation is also broken afterwards).

This patch just adds the include to the host config file which already contains the LLDB_EDITLINE_USE_WCHAR
define to enable the Editline support (we just never included it in the file before). With this we now actually
echo back unicode characters on macOS and we no longer ignore unicode input. On Linux this doesn't
seem to improve the echoing back of characters but at least it fixes that we ignore unicode input.

Reviewers: labath

Reviewed By: labath

Subscribers: JDevlieghere, lldb-commits

Tags: #lldb

Differential Revision: https://reviews.llvm.org/D71251