### PR TITLE
lldbutil: Forward ASan launch info to test inferiors

### DIFF
--- a/lldb/lit/Suite/lit.cfg
+++ b/lldb/lit/Suite/lit.cfg
@@ -69,6 +69,12 @@ if config.dotest_lit_args_str:
 if config.llvm_libs_dir:
   dotest_cmd += ['--env', 'LLVM_LIBS_DIR=' + config.llvm_libs_dir]
 
+# Forward ASan-specific environment variables to tests, as a test may load an
+# ASan-ified dylib.
+for env_var in ('ASAN_OPTIONS', 'DYLD_INSERT_LIBRARIES'):
+  if env_var in config.environment:
+    dotest_cmd += ['--inferior-env', env_var + '=' + config.environment[env_var]]
+
 if config.lldb_build_directory:
   dotest_cmd += ['--build-dir', config.lldb_build_directory]
 


### PR DESCRIPTION
This is a WIP patch to address ASan failures in some swift lldb tests.

I've created the PR to get additional test coverage, but the real change should happen on llvm.org.