### PR TITLE
Reduce stack space usage in libprofile

### DIFF
--- a/compiler-rt/lib/profile/InstrProfilingFile.c
+++ b/compiler-rt/lib/profile/InstrProfilingFile.c
@@ -126,11 +126,23 @@ static uint32_t fileWriter(ProfDataWriter *This, ProfDataIOVec *IOVecs,
                            uint32_t NumIOVecs) {
   uint32_t I;
   FILE *File = (FILE *)This->WriterCtx;
+  char Zeroes[sizeof(uint64_t)] = {0};
   for (I = 0; I < NumIOVecs; I++) {
     if (IOVecs[I].Data) {
       if (fwrite(IOVecs[I].Data, IOVecs[I].ElmSize, IOVecs[I].NumElm, File) !=
           IOVecs[I].NumElm)
         return 1;
+    } else if (IOVecs[I].UseZeroPadding) {
+      size_t BytesToWrite = IOVecs[I].ElmSize * IOVecs[I].NumElm;
+      while (BytesToWrite > 0) {
+        size_t PartialWriteLen =
+            (sizeof(uint64_t) > BytesToWrite) ? BytesToWrite : sizeof(uint64_t);
+        if (fwrite(Zeroes, sizeof(uint8_t), PartialWriteLen, File) !=
+            PartialWriteLen) {
+          return 1;
+        }
+        BytesToWrite -= PartialWriteLen;
+      }
     } else {
       if (fseek(File, IOVecs[I].ElmSize * IOVecs[I].NumElm, SEEK_CUR) == -1)
         return 1;

--- a/compiler-rt/lib/profile/InstrProfilingInternal.h
+++ b/compiler-rt/lib/profile/InstrProfilingInternal.h
@@ -41,11 +41,18 @@ int __llvm_profile_write_buffer_internal(
 /*!
  * The data structure describing the data to be written by the
  * low level writer callback function.
+ *
+ * If \ref ProfDataIOVec.Data is null, and \ref ProfDataIOVec.UseZeroPadding is
+ * 0, the write is skipped (the writer simply advances ElmSize*NumElm bytes).
+ *
+ * If \ref ProfDataIOVec.Data is null, and \ref ProfDataIOVec.UseZeroPadding is
+ * nonzero, ElmSize*NumElm zero bytes are written.
  */
 typedef struct ProfDataIOVec {
   const void *Data;
   size_t ElmSize;
   size_t NumElm;
+  int UseZeroPadding;
 } ProfDataIOVec;
 
 struct ProfDataWriter;

--- a/compiler-rt/lib/profile/InstrProfilingPlatformFuchsia.c
+++ b/compiler-rt/lib/profile/InstrProfilingPlatformFuchsia.c
@@ -115,6 +115,8 @@ static uint32_t lprofVMOWriter(ProfDataWriter *This, ProfDataIOVec *IOVecs,
                              __llvm_profile_offset, Length);
       if (Status != ZX_OK)
         return -1;
+    } else if (IOVecs[I].UseZeroPadding) {
+      /* Resizing the VMO should zero fill. */
     }
     __llvm_profile_offset += Length;
   }

--- a/compiler-rt/test/profile/instrprof-set-filename.c
+++ b/compiler-rt/test/profile/instrprof-set-filename.c
@@ -1,3 +1,5 @@
+// RUN: rm -f %t.profraw
+//
 // 1. Test that __llvm_profile_set_filename has higher precedence than
 //    the default path.
 // RUN: %clang_profgen -o %t -O3 %s

--- a/compiler-rt/test/profile/instrprof-value-prof.test
+++ b/compiler-rt/test/profile/instrprof-value-prof.test
@@ -1,3 +1,4 @@
+// RUN: rm -f %t.profraw %t.ir.profraw %t.ir.dyn.profraw
 // RUN: %clang_profgen -O2 -mllvm -enable-value-profiling=true -mllvm -vp-static-alloc=true -mllvm -vp-counters-per-site=256 -o %t %S/Inputs/instrprof-value-prof-real.c
 // RUN: env LLVM_PROFILE_FILE=%t.profraw LLVM_VP_MAX_NUM_VALS_PER_SITE=255 %run %t
 // RUN: llvm-profdata merge -o %t.profdata %t.profraw


### PR DESCRIPTION
When writing out a profile, avoid allocating a page on the stack for the
purpose of writing out zeroes, as some embedded environments do not have
enough stack space to accomodate this.

Instead, use a small, fixed-size zero buffer that can be written
repeatedly.

rdar://57810014