### PR TITLE
lldb: Disable lit/Reproducer/Swift/TestModule.test

### DIFF
--- a/lldb/lit/Reproducer/Swift/TestModule.test
+++ b/lldb/lit/Reproducer/Swift/TestModule.test
@@ -1,3 +1,4 @@
+# REQUIRES: rdar57847698
 # UNSUPPORTED: system-windows, system-freebsd
 
 # This tests replaying a Swift reproducer with bridging.


### PR DESCRIPTION
The test is failing with:

```
10:16:25 error: Expression can't be run, because there is no JIT compiled function
10:16:25 /Users/buildslave/jenkins/workspace/fs-llvm-project-apple-stable-2019-06-19-to-swift-master/llvm-project/lldb/lit/Reproducer/Swift/TestModule.test:36:10: error: CHECK: expected string not found in input
10:16:25 # CHECK: $R0 = 95126
10:16:25          ^
10:16:25 <stdin>:18:77: note: scanning from here
10:16:25  frame #0: 0x0000000100000b24 TestModule.test.tmp.out`main() at Module.swift:5:1
10:16:25                                                                             ^
10:16:25 <stdin>:34:22: note: possible intended match here
10:16:25 (lldb) p let $bar = Foo(i: 95126)
```

rdar://57847698