### PR TITLE
Added -D_DEFAULT_SOURCE flag to fix macro expansion error in pthread.h

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -571,7 +571,7 @@ if (APPLE)
 else ()
   set(BUILTIN_CFLAGS "")
 
-  append_list_if(COMPILER_RT_HAS_STD_C11_FLAG -std=c11 BUILTIN_CFLAGS)
+  append_list_if(COMPILER_RT_HAS_STD_C11_FLAG -std=c11 -D_DEFAULT_SOURCE BUILTIN_CFLAGS)
 
   # These flags would normally be added to CMAKE_C_FLAGS by the llvm
   # cmake step. Add them manually if this is a standalone build.


### PR DESCRIPTION
due to an issue with expanding a pthread macro with std=c11 per https://sourceware.org/bugzilla/show_bug.cgi?id=25271. 

The file in question is `emutls.c` and the error is:
```
error: use of undeclared identifier 'PTHREAD_MUTEX_DEFAULT'
static pthread_mutex_t emutls_mutex = PTHREAD_MUTEX_INITIALIZER;
                                       ^
 /usr/include/pthread.h:87:36: note: expanded from macro 'PTHREAD_MUTEX_INITIALIZER'
  { {  __PTHREAD_MUTEX_INITIALIZER (PTHREAD_MUTEX_DEFAULT) } }
                                    ^
 1 error generated.
```

I thought it might be a bug in glibc and spend the ticket referenced above, but the responder indicated that an additional flag will solve the issue; I tested it locally and it does, in fact, fix the compile error.