### PR TITLE
Revert "Disable SwiftDWARFImporterDelegate by default."

### DIFF
--- a/lldb/lit/Swift/No.swiftmodule-ObjC.test
+++ b/lldb/lit/Swift/No.swiftmodule-ObjC.test
@@ -11,7 +11,6 @@
 # RUN: %target-swiftc -o %t/a.out %t/main.o %t/ObjCStuff.o
 # RUN: %lldb %t/a.out -s %s | FileCheck %S/Inputs/No.swiftmodule-ObjC.swift
 
-settings set symbols.use-swift-dwarfimporter true
 breakpoint set -p "break here"
 run
 frame variable -d no-dynamic

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -10,7 +10,7 @@ let Definition = "modulelist" in {
     DefaultStringValue<"">,
     Desc<"The path to the clang modules cache directory (-fmodules-cache-path).">;
   def UseDWARFImporter: Property<"use-swift-dwarfimporter", "Boolean">,
-    DefaultFalse,
+    DefaultTrue,
     Desc<"Reconstruct Clang module dependencies from DWARF when debugging Swift code">;
   def SwiftModuleLoadingMode: Property<"swift-module-loading-mode", "Enum">,
     DefaultEnumValue<"eSwiftModuleLoadingModePreferSerialized">,


### PR DESCRIPTION
This reverts commit 746e52ae4f4fbc397720d3c10eb60cfe4d2a2176.

I have addressed all performance regressions that I am aware of.