### PR TITLE
Two patches to get the testsuite running on arm64 devices.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lang/objc/foundation/TestObjCMethods2.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/objc/foundation/TestObjCMethods2.py
@@ -100,7 +100,6 @@ class FoundationTestCase2(TestBase):
         self.expect('expression str = (id)[NSString stringWithCString: "new"]')
         self.runCmd("process continue")
 
-    @expectedFailureAll(archs=["i[3-6]86"], bugnumber="<rdar://problem/28814052>")
     def test_MyString_dump_with_runtime(self):
         """Test dump of a known Objective-C object by dereferencing it."""
         self.build()
@@ -121,9 +120,7 @@ class FoundationTestCase2(TestBase):
                 "\(MyBase\)"])
         self.runCmd("process continue")
 
-    @expectedFailureAll(archs=["i[3-6]86"], bugnumber="<rdar://problem/28814052>")
-    @expectedFailureAll(oslist=["macosx"], debug_info=["gmodules"],
-                        bugnumber="rdar://28983234")
+    @expectedFailureAll(debug_info=["gmodules"], bugnumber="rdar://28983234")
     def test_runtime_types(self):
         """Test commands that require runtime types"""
         self.build()
@@ -151,7 +148,6 @@ class FoundationTestCase2(TestBase):
                 "be completed."])
         self.runCmd("process continue")
 
-    @expectedFailureAll(archs=["i[3-6]86"], bugnumber="<rdar://problem/28814052>")
     def test_NSError_p(self):
         """Test that p of the result of an unknown method does require a cast."""
         self.build()

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/multi_optionals/TestMultiOptionals.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/multi_optionals/TestMultiOptionals.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,
+                           expectedFailureAll(archs=['arm64', 'arm64e', 'arm64_32'], bugnumber="<rdar://problem/57854589>")])
+


### PR DESCRIPTION
Mark TestMultiOptionals.py as expected fail on arm64 devices
Generalize the -gmodules exepcted-fail in TestObjCMethods2.py