### PR TITLE
[apple-llvm-config] Update upstream to swift/swift-5.2-branch

### DIFF
--- a/apple-llvm-config/am/swift-master.json
+++ b/apple-llvm-config/am/swift-master.json
@@ -1,3 +1,3 @@
 {
-  "upstream": "apple/stable/20190619"
+  "upstream": "swift/swift-5.2-branch"
 }


### PR DESCRIPTION
Upstream for "swift/master" is now "swift/swift-5.2-branch".