### PR TITLE
Add support for C unions in Swift.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/union/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/union/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -I$(SRCDIR)
+
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/union/TestSwiftCUnion.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/union/TestSwiftCUnion.py
@@ -1,0 +1,19 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+
+class TestSwiftAnyType(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    def test_c_unions(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+        self.expect("target variable -- i", substrs=['42'])
+        self.expect("target variable -- d", substrs=['23'])

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/union/main.swift
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/union/main.swift
@@ -1,0 +1,7 @@
+import U
+
+func use<T>(_ t : T) {}
+
+let i = IntDoubleUnion(i: 42)
+let d = IntDoubleUnion(d: 23)
+use((i, d)) // break here

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/union/module.modulemap
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/union/module.modulemap
@@ -1,0 +1,1 @@
+module U { header "union.h" }

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/union/union.h
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/union/union.h
@@ -1,0 +1,4 @@
+union IntDoubleUnion {
+  int i;
+  double d;
+};

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -6648,6 +6648,16 @@ uint32_t SwiftASTContext::GetNumFields(void *type) {
   case swift::TypeKind::BoundGenericClass:
   case swift::TypeKind::BoundGenericStruct: {
     auto nominal = swift_can_type->getAnyNominal();
+    // Imported unions don't have stored properties.
+    if (auto *ntd =
+            llvm::dyn_cast_or_null<swift::NominalTypeDecl>(nominal->getDecl()))
+      if (auto *rd = llvm::dyn_cast_or_null<clang::RecordDecl>(ntd->getClangDecl()))
+        if (rd->isUnion()) {
+          swift::DeclRange ms = ntd->getMembers();
+          return std::count_if(ms.begin(), ms.end(), [](swift::Decl *D) {
+            return llvm::isa<swift::VarDecl>(D);
+          });
+        }
     return GetStoredProperties(nominal).size();
   }
 
@@ -7295,6 +7305,38 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
   case swift::TypeKind::Struct:
   case swift::TypeKind::BoundGenericStruct: {
     auto nominal = swift_can_type->getAnyNominal();
+
+    // Imported unions don't have stored properties, iterate over the
+    // VarDecls instead.
+    if (auto *ntd =
+            llvm::dyn_cast_or_null<swift::NominalTypeDecl>(nominal->getDecl()))
+      if (auto *rd = llvm::dyn_cast_or_null<clang::RecordDecl>(ntd->getClangDecl()))
+        if (rd->isUnion()) {
+          unsigned count = 0;
+          for (swift::Decl *D : ntd->getMembers()) {
+            auto *VD = llvm::dyn_cast_or_null<swift::VarDecl>(D);
+            if (!VD)
+              continue;
+            if (count++ < idx)
+              continue;
+
+            swift::Type child_swift_type = VD->getType();
+
+            CompilerType child_type =
+                ToCompilerType(VD->getType().getPointer());
+            child_name = VD->getNameStr();
+            if (!get_type_size(child_byte_size, child_type))
+              return {};
+            child_is_base_class = false;
+            child_is_deref_of_parent = false;
+            child_byte_offset = 0;
+            child_bitfield_bit_size = 0;
+            child_bitfield_bit_offset = 0;
+            return child_type;
+          }
+          return {};
+        }
+
     auto stored_properties = GetStoredProperties(nominal);
     if (idx >= stored_properties.size())
       break;


### PR DESCRIPTION
C unions are struct types in Swift, but their fields are not
implemented as stored properties, so the default implementation did
not work for them. This patch adds special handling for unions by
iterating over the imported VarDecls.

rdar://problem/55026321