### PR TITLE
Adapt LLDB to clang API change in ObjCMethodDecl::create().

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCDeclVendor.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCDeclVendor.cpp
@@ -330,7 +330,8 @@ public:
 
     const bool isInstance = instance;
     const bool isVariadic = false;
-    const bool isSynthesized = false;
+    const bool isPropertyAccessor = false;
+    const bool isSynthesizedAccessorStub = false;
     const bool isImplicitlyDeclared = true;
     const bool isDefined = false;
     const clang::ObjCMethodDecl::ImplementationControl impControl =
@@ -377,8 +378,8 @@ public:
     clang::ObjCMethodDecl *ret = clang::ObjCMethodDecl::Create(
         ast_ctx, clang::SourceLocation(), clang::SourceLocation(), sel,
         ret_type, nullptr, interface_decl, isInstance, isVariadic,
-        isSynthesized, isImplicitlyDeclared, isDefined, impControl,
-        HasRelatedResultType);
+        isPropertyAccessor, isSynthesizedAccessorStub, isImplicitlyDeclared,
+        isDefined, impControl, HasRelatedResultType);
 
     std::vector<clang::ParmVarDecl *> parm_vars;
 


### PR DESCRIPTION
Adapt LLDB to clang API change in ObjCMethodDecl::create().
(cherry picked from commit 454acae97ca4ad25cac582afe66c616ad46e4dd1)