### PR TITLE
[driver][darwin] Use explicit -mlinker-version in the -platform_versi…

### DIFF
--- a/clang/test/Driver/darwin-ld-platform-version-ios.c
+++ b/clang/test/Driver/darwin-ld-platform-version-ios.c
@@ -1,8 +1,8 @@
 // RUN: touch %t.o
 
-// RUN: %clang -target arm64-apple-ios12.3 -isysroot %S/Inputs/iPhoneOS13.0.sdk -### %t.o 2>&1 \
+// RUN: %clang -target arm64-apple-ios12.3 -isysroot %S/Inputs/iPhoneOS13.0.sdk -mlinker-version=520 -### %t.o 2>&1 \
 // RUN:   | FileCheck %s
-// RUN: %clang -target x86_64-apple-ios13-simulator -isysroot %S/Inputs/iPhoneOS13.0.sdk -### %t.o 2>&1 \
+// RUN: %clang -target x86_64-apple-ios13-simulator -isysroot %S/Inputs/iPhoneOS13.0.sdk -mlinker-version=520 -### %t.o 2>&1 \
 // RUN:   | FileCheck --check-prefix=SIMUL %s
 
 // CHECK: "-platform_version" "ios" "12.3.0" "13.0"

--- a/clang/test/Driver/darwin-ld-platform-version-macos.c
+++ b/clang/test/Driver/darwin-ld-platform-version-macos.c
@@ -1,12 +1,12 @@
 // RUN: touch %t.o
 
-// RUN: %clang -target x86_64-apple-macos10.13 -isysroot %S/Inputs/MacOSX10.14.sdk -### %t.o 2>&1 \
+// RUN: %clang -target x86_64-apple-macos10.13 -isysroot %S/Inputs/MacOSX10.14.sdk -mlinker-version=0 -### %t.o 2>&1 \
 // RUN:   | FileCheck %s
 // RUN: env SDKROOT=%S/Inputs/MacOSX10.14.sdk %clang -target x86_64-apple-macos10.13.0.1 -mlinker-version=520 -### %t.o 2>&1 \
 // RUN:   | FileCheck %s
 
 // CHECK: "-platform_version" "macos" "10.13.0" "10.14"
 
-// RUN: %clang -target x86_64-apple-macos10.13 -### %t.o 2>&1 \
+// RUN: %clang -target x86_64-apple-macos10.13  -mlinker-version=520 -### %t.o 2>&1 \
 // RUN:   | FileCheck --check-prefix=NOSDK %s
 // NOSDK: "-platform_version" "macos" "10.13.0" "0.0.0"

--- a/clang/test/Driver/darwin-ld-platform-version-tvos.c
+++ b/clang/test/Driver/darwin-ld-platform-version-tvos.c
@@ -1,8 +1,8 @@
 // RUN: touch %t.o
 
-// RUN: %clang -target arm64-apple-tvos12.3 -isysroot %S/Inputs/iPhoneOS13.0.sdk -### %t.o 2>&1 \
+// RUN: %clang -target arm64-apple-tvos12.3 -isysroot %S/Inputs/iPhoneOS13.0.sdk -mlinker-version=520 -### %t.o 2>&1 \
 // RUN:   | FileCheck %s
-// RUN: %clang -target x86_64-apple-tvos13-simulator -isysroot %S/Inputs/iPhoneOS13.0.sdk -### %t.o 2>&1 \
+// RUN: %clang -target x86_64-apple-tvos13-simulator -isysroot %S/Inputs/iPhoneOS13.0.sdk -mlinker-version=520 -### %t.o 2>&1 \
 // RUN:   | FileCheck --check-prefix=SIMUL %s
 
 // CHECK: "-platform_version" "tvos" "12.3.0" "13.0"

--- a/clang/test/Driver/darwin-ld-platform-version-watchos.c
+++ b/clang/test/Driver/darwin-ld-platform-version-watchos.c
@@ -1,8 +1,8 @@
 // RUN: touch %t.o
 
-// RUN: %clang -target arm64_32-apple-watchos5.2 -isysroot %S/Inputs/WatchOS6.0.sdk -### %t.o 2>&1 \
+// RUN: %clang -target arm64_32-apple-watchos5.2 -isysroot %S/Inputs/WatchOS6.0.sdk -mlinker-version=520 -### %t.o 2>&1 \
 // RUN:   | FileCheck %s
-// RUN: %clang -target x86_64-apple-watchos6-simulator -isysroot %S/Inputs/WatchOS6.0.sdk -### %t.o 2>&1 \
+// RUN: %clang -target x86_64-apple-watchos6-simulator -isysroot %S/Inputs/WatchOS6.0.sdk -mlinker-version=520 -### %t.o 2>&1 \
 // RUN:   | FileCheck --check-prefix=SIMUL %s
 
 // CHECK: "-platform_version" "watchos" "5.2.0" "6.0.0"


### PR DESCRIPTION
…on tests

The driver actually adds a default -mlinker-version, based on HOST_LINK_VERSION
cmake variable. The tests should be explicit about which version they're using to
trigger the right behavior.

(cherry picked from commit be88a20c900463c4919433109e4c17cd001da580)