### PR TITLE
SwiftLanguageRuntime: Lazily initialize SetupABIBit()

### DIFF
--- a/lldb/lit/Swift/Inputs/RuntimeInit.swift
+++ b/lldb/lit/Swift/Inputs/RuntimeInit.swift
@@ -1,0 +1,7 @@
+func use<T>(_ t: T) {}
+
+protocol P { var p: Int { get } }
+class C: P { let p: Int = 42 }
+
+let p2: P = C()
+use(p2) // break here

--- a/lldb/lit/Swift/runtime-initialization.test
+++ b/lldb/lit/Swift/runtime-initialization.test
@@ -1,0 +1,20 @@
+# RUN: rm -rf %t && mkdir %t
+# RUN: %target-swiftc -g \
+# RUN:          -module-cache-path %t/cache %S/Inputs/RuntimeInit.swift \
+# RUN:          -module-name a -o %t/a.out
+# RUN: %lldb %t/a.out -s %s | FileCheck %s
+
+# When SwiftLanguageRuntime initializes the global flag it uses to
+# communicate the Swift ABI version to the Swift runtime library
+# before it loaded the Objective-C module (as triggered by setting the
+# exception breakpoint) the flag would be wrong and dynamic type
+# resolution doesn't work.
+
+b -p here
+br set -E swift
+r
+target var p2
+# CHECK: (a.C) p2
+# CHECK-SAME: (p = 42)
+q
+


### PR DESCRIPTION
SwiftLanguageRuntime: Lazily initialize SetupABIBit()
    
and all member variables that are initialized by looking for a symbol
in one the runtime libraries to avoid calling FindSymbolForSwiftObject
before the repective runtime library is loaded. Swift::reflection and
LLDB communicate the ABI version through a global variable defined in
LLDB which is initialized by looking for a symbol in the Objective-C
runtime.
    
After this patch LLDB also diagnoses when the requested runtime
library cannot be found. As a side-effect, the lookup now filters for
the module name, and is thus in theory also marginally faster.
    
<rdar://problem/57756684>