### PR TITLE
Don't assume that __cxa_current_exception_type exists.

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
@@ -559,6 +559,9 @@ ValueObjectSP ItaniumABILanguageRuntime::GetExceptionObjectForThread(
   modules.FindSymbolsWithNameAndType(
       ConstString("__cxa_current_exception_type"), eSymbolTypeCode, contexts);
   contexts.GetContextAtIndex(0, context);
+  if (!context.symbol) {
+    return {};
+  }
   Address addr = context.symbol->GetAddress();
 
   Status error;


### PR DESCRIPTION
Normally you shouldn't be able to have a process with an ItaniumABI plugin
that doesn't have this symbol.  But if the loader crashes before loading
libc++abi.dylib (on MacOS), then the symbol might not be present.  So we
should check before accessing the pointer.

There isn't a good way to write a test for this, but the change is obvious.