### PR TITLE
Mark two swift URL formatter tests as expected fails on arm64.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lang/swift/array_tuple_resilient/TestSwiftArrayTupleResilient.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/array_tuple_resilient/TestSwiftArrayTupleResilient.py
@@ -1,4 +1,5 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipUnlessDarwin])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipUnlessDarwin,
+    expectedFailureAll(archs=['arm64', 'arm64e', 'arm64_32'], bugnumber="<rdar://problem/58065423>")])

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
@@ -13,4 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipUnlessDarwin])
+                          decorators=[swiftTest,skipUnlessDarwin,
+                            expectedFailureAll(archs=['arm64', 'arm64e', 'arm64_32'], bugnumber="<rdar://problem/58065423>")])


### PR DESCRIPTION
Mark two swift URL formatter tests as expected fails on arm64.
rdar://problem/58065423