### PR TITLE
[Modules] Handle tag types and complain about bad merges in C/Objective-C mode

### DIFF
--- a/clang/include/clang/AST/ASTStructuralEquivalence.h
+++ b/clang/include/clang/AST/ASTStructuralEquivalence.h
@@ -69,15 +69,20 @@ struct StructuralEquivalenceContext {
   /// \c true if the last diagnostic came from ToCtx.
   bool LastDiagFromC2 = false;
 
+  /// \c true if canonical types should be used for each Decl before
+  /// comparing for structural equivalnce
+  bool UseCanonicalDecls;
+
   StructuralEquivalenceContext(
       ASTContext &FromCtx, ASTContext &ToCtx,
       llvm::DenseSet<std::pair<Decl *, Decl *>> &NonEquivalentDecls,
       StructuralEquivalenceKind EqKind,
       bool StrictTypeSpelling = false, bool Complain = true,
-      bool ErrorOnTagTypeMismatch = false)
+      bool ErrorOnTagTypeMismatch = false, bool UseCanonicalDecls = true)
       : FromCtx(FromCtx), ToCtx(ToCtx), NonEquivalentDecls(NonEquivalentDecls),
         EqKind(EqKind), StrictTypeSpelling(StrictTypeSpelling),
-        ErrorOnTagTypeMismatch(ErrorOnTagTypeMismatch), Complain(Complain) {}
+        ErrorOnTagTypeMismatch(ErrorOnTagTypeMismatch), Complain(Complain),
+        UseCanonicalDecls(UseCanonicalDecls) {}
 
   DiagnosticBuilder Diag1(SourceLocation Loc, unsigned DiagID);
   DiagnosticBuilder Diag2(SourceLocation Loc, unsigned DiagID);

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -1077,6 +1077,10 @@ private:
   /// been completed.
   std::deque<PendingDeclContextInfo> PendingDeclContextInfos;
 
+  /// C/ObjC definitions in which the structural equivalence check fails
+  llvm::SmallDenseMap<NamedDecl *, llvm::SmallVector<NamedDecl *, 2>, 2>
+      PendingStructuralMismatches;
+
   /// The set of NamedDecls that have been loaded, but are members of a
   /// context that has been merged into another context where the corresponding
   /// declaration is either missing or has not yet been loaded.
@@ -1407,6 +1411,7 @@ private:
 
   void finishPendingActions();
   void diagnoseOdrViolations();
+  void diagnoseStructuralMismatches();
 
   void pushExternalDeclIntoScope(NamedDecl *D, DeclarationName Name);
 

--- a/clang/lib/AST/ASTStructuralEquivalence.cpp
+++ b/clang/lib/AST/ASTStructuralEquivalence.cpp
@@ -1574,8 +1574,10 @@ static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,
                                      Decl *D1, Decl *D2) {
   // FIXME: Check for known structural equivalences via a callback of some sort.
 
-  D1 = D1->getCanonicalDecl();
-  D2 = D2->getCanonicalDecl();
+  if (Context.UseCanonicalDecls) {
+    D1 = D1->getCanonicalDecl();
+    D2 = D2->getCanonicalDecl();
+  }
   std::pair<Decl *, Decl *> P{D1, D2};
 
   // Check whether we already know that these two declarations are not

--- a/clang/test/Modules/Inputs/merge-in-c/tag-types/module.modulemap
+++ b/clang/test/Modules/Inputs/merge-in-c/tag-types/module.modulemap
@@ -1,0 +1,10 @@
+
+module X {
+  header "x.h"
+  export *
+}
+
+module Y {
+  header "y.h"
+  export *
+}

--- a/clang/test/Modules/Inputs/merge-in-c/tag-types/x.h
+++ b/clang/test/Modules/Inputs/merge-in-c/tag-types/x.h
@@ -1,0 +1,4 @@
+
+struct Z {
+  int m;
+};

--- a/clang/test/Modules/Inputs/merge-in-c/tag-types/y.h
+++ b/clang/test/Modules/Inputs/merge-in-c/tag-types/y.h
@@ -1,0 +1,4 @@
+
+struct Z {
+  double m;
+};

--- a/clang/test/Modules/merge-tag-types.c
+++ b/clang/test/Modules/merge-tag-types.c
@@ -1,0 +1,14 @@
+// RUN: rm -rf %t
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache -x objective-c -I%S/Inputs/merge-in-c/tag-types -verify %s
+
+@import Y;
+@import X;
+
+void foo() {
+  struct Z z;
+  z.m = 2.0;
+}
+
+// expected-error@y.h:2 {{type 'struct Z' has incompatible definitions in different translation units}}
+// expected-note@y.h:3 {{field 'm' has type 'double' here}}
+// expected-note@x.h:3 {{field 'm' has type 'int' here}}


### PR DESCRIPTION
Take `struct Z {...}` defined differently and imported from both modules
X and Y. While in C/Objective-C mode, clang used to pick one of the
definitions and ignore the other even though they are not structurally
equivalent. Hook up a mechanism to check for it and reject such
conflicts. Instead of silently compiling, clang now emits:

```
In module 'Y' imported from t.m:2:
./y.h:2:8: error: type 'struct Z' has incompatible definitions in different translation units
struct Z {
       ^
./y.h:3:10: note: field 'm' has type 'double' here
  double m;
         ^
./x.h:3:7: note: field 'm' has type 'int' here
  int m;
      ^
```

rdar://problem/56764293