### PR TITLE
[lldb/MachO] "Fix" intentional out-of-bounds error (NFC)

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -480,12 +480,13 @@ public:
       switch (flavor) {
       case GPRAltRegSet:
       case GPRRegSet:
-        for (uint32_t i = 0; i < count; ++i) {
+        // On ARM, the CPSR register is also included in the count but it is
+        // not included in gpr.r so loop until (count-1).
+        for (uint32_t i = 0; i < (count - 1); ++i) {
           gpr.r[i] = data.GetU32(&offset);
         }
-
-        // Note that gpr.cpsr is also copied by the above loop; this loop
-        // technically extends one element past the end of the gpr.r[] array.
+        // Save cpsr explicitly.
+        gpr.cpsr = data.GetU32(&offset);
 
         SetError(GPRRegSet, Read, 0);
         offset = next_thread_state;

--- a/lldb/source/Plugins/Process/Utility/RegisterContextDarwin_arm.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextDarwin_arm.cpp
@@ -1146,10 +1146,11 @@ bool RegisterContextDarwin_arm::ReadRegister(const RegisterInfo *reg_info,
   case gpr_sp:
   case gpr_lr:
   case gpr_pc:
-  case gpr_cpsr:
     value.SetUInt32(gpr.r[reg - gpr_r0]);
     break;
-
+  case gpr_cpsr:
+    value.SetUInt32(gpr.cpsr);
+    break;
   case fpu_s0:
   case fpu_s1:
   case fpu_s2:


### PR DESCRIPTION
Remove the hack that populates the cpsr register in the gpr struct by
writing past the end of the array. This was tripping up ASan.

Patch by: Reva Cuthbertson

(cherry picked from commit e194d890126007bc8e5acb655f007ef76002edb7)