### PR TITLE
Include ptrauth key and diversity information in the mangled name of

### DIFF
--- a/clang/lib/CodeGen/CGNonTrivialStruct.cpp
+++ b/clang/lib/CodeGen/CGNonTrivialStruct.cpp
@@ -265,6 +265,9 @@ struct GenBinaryFuncName : CopyStructVisitor<GenBinaryFuncName<IsMove>, IsMove>,
   void visitPtrAuth(QualType FT, const FieldDecl *FD,
                     CharUnits CurStructOffset) {
     this->appendStr("_pa");
+    PointerAuthQualifier PtrAuth = FT.getPointerAuth();
+    this->appendStr(llvm::to_string(PtrAuth.getKey()) + "_");
+    this->appendStr(llvm::to_string(PtrAuth.getExtraDiscriminator()) + "_");
     CharUnits FieldOffset = CurStructOffset + this->getFieldOffset(FD);
     this->appendStr(llvm::to_string(FieldOffset.getQuantity()));
   }

--- a/clang/test/CodeGen/ptrauth-in-c-struct.c
+++ b/clang/test/CodeGen/ptrauth-in-c-struct.c
@@ -1,17 +1,24 @@
 // RUN: %clang_cc1 -triple arm64-apple-ios -fblocks -fptrauth-calls -fptrauth-returns -fptrauth-intrinsics -emit-llvm -o - %s | FileCheck %s
 
-#define AQ __ptrauth(1,1,50)
+#define AQ1_50 __ptrauth(1,1,50)
+#define AQ2_30 __ptrauth(2,1,30)
 #define IQ __ptrauth(1,0,50)
 
 typedef void (^BlockTy)(void);
 
 // CHECK: %[[STRUCT_SA:.*]] = type { i32, i32* }
+// CHECK: %[[STRUCT_SA2:.*]] = type { i32, i32* }
 // CHECK: %[[STRUCT_SI:.*]] = type { i32* }
 
 typedef struct {
   int f0;
-  int * AQ f1; // Signed using address discrimination.
+  int * AQ1_50 f1; // Signed using address discrimination.
 } SA;
+
+typedef struct {
+  int f0;
+  int * AQ2_30 f1; // Signed using address discrimination.
+} SA2;
 
 typedef struct {
   int * IQ f; // No address discrimination.
@@ -21,9 +28,9 @@ SA getSA(void);
 void calleeSA(SA);
 
 // CHECK: define void @test_copy_constructor_SA(%[[STRUCT_SA]]* %{{.*}})
-// CHECK: call void @__copy_constructor_8_8_t0w4_pa8(
+// CHECK: call void @__copy_constructor_8_8_t0w4_pa1_50_8(
 
-// CHECK: define linkonce_odr hidden void @__copy_constructor_8_8_t0w4_pa8(i8** %[[DST:.*]], i8** %[[SRC:.*]])
+// CHECK: define linkonce_odr hidden void @__copy_constructor_8_8_t0w4_pa1_50_8(i8** %[[DST:.*]], i8** %[[SRC:.*]])
 // CHECK: %[[DST_ADDR:.*]] = alloca i8**, align 8
 // CHECK: %[[SRC_ADDR:.*]] = alloca i8**, align 8
 // CHECK: store i8** %[[DST]], i8*** %[[DST_ADDR]], align 8
@@ -48,10 +55,38 @@ void test_copy_constructor_SA(SA *s) {
   SA t = *s;
 }
 
-// CHECK: define void @test_copy_assignment_SA(
-// CHECK: call void @__copy_assignment_8_8_t0w4_pa8(
+// CHECK: define void @test_copy_constructor_SA2(%[[STRUCT_SA2]]* %{{.*}})
+// CHECK: call void @__copy_constructor_8_8_t0w4_pa2_30_8(
 
-// CHECK: define linkonce_odr hidden void @__copy_assignment_8_8_t0w4_pa8(
+// CHECK: define linkonce_odr hidden void @__copy_constructor_8_8_t0w4_pa2_30_8(i8** %[[DST:.*]], i8** %[[SRC:.*]])
+// CHECK: %[[DST_ADDR:.*]] = alloca i8**, align 8
+// CHECK: %[[SRC_ADDR:.*]] = alloca i8**, align 8
+// CHECK: store i8** %[[DST]], i8*** %[[DST_ADDR]], align 8
+// CHECK: store i8** %[[SRC]], i8*** %[[SRC_ADDR]], align 8
+// CHECK: %[[V0:.*]] = load i8**, i8*** %[[DST_ADDR]], align 8
+// CHECK: %[[V1:.*]] = load i8**, i8*** %[[SRC_ADDR]], align 8
+// CHECK: %[[V5:.*]] = bitcast i8** %[[V0]] to i8*
+// CHECK: %[[V6:.*]] = getelementptr inbounds i8, i8* %[[V5]], i64 8
+// CHECK: %[[V7:.*]] = bitcast i8* %[[V6]] to i8**
+// CHECK: %[[V8:.*]] = bitcast i8** %[[V1]] to i8*
+// CHECK: %[[V9:.*]] = getelementptr inbounds i8, i8* %[[V8]], i64 8
+// CHECK: %[[V10:.*]] = bitcast i8* %[[V9]] to i8**
+// CHECK: %[[V11:.*]] = load i8*, i8** %[[V10]], align 8
+// CHECK: %[[V12:.*]] = ptrtoint i8** %[[V10]] to i64
+// CHECK: %[[V13:.*]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[V12]], i64 30)
+// CHECK: %[[V14:.*]] = ptrtoint i8** %[[V7]] to i64
+// CHECK: %[[V15:.*]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[V14]], i64 30)
+// CHECK: %[[V17:.*]] = ptrtoint i8* %[[V11]] to i64
+// CHECK: %[[V18:.*]] = call i64 @llvm.ptrauth.resign.i64(i64 %[[V17]], i32 2, i64 %[[V13]], i32 2, i64 %[[V15]])
+
+void test_copy_constructor_SA2(SA2 *s) {
+  SA2 t = *s;
+}
+
+// CHECK: define void @test_copy_assignment_SA(
+// CHECK: call void @__copy_assignment_8_8_t0w4_pa1_50_8(
+
+// CHECK: define linkonce_odr hidden void @__copy_assignment_8_8_t0w4_pa1_50_8(
 
 void test_copy_assignment_SA(SA *d, SA *s) {
   *d = *s;
@@ -59,7 +94,7 @@ void test_copy_assignment_SA(SA *d, SA *s) {
 
 // CHECK: define void @test_move_constructor_SA(
 // CHECK: define internal void @__Block_byref_object_copy_(
-// CHECK: define linkonce_odr hidden void @__move_constructor_8_8_t0w4_pa8(
+// CHECK: define linkonce_odr hidden void @__move_constructor_8_8_t0w4_pa1_50_8(
 
 void test_move_constructor_SA(void) {
   __block SA t;
@@ -67,8 +102,8 @@ void test_move_constructor_SA(void) {
 }
 
 // CHECK: define void @test_move_assignment_SA(
-// CHECK: call void @__move_assignment_8_8_t0w4_pa8(
-// CHECK: define linkonce_odr hidden void @__move_assignment_8_8_t0w4_pa8(
+// CHECK: call void @__move_assignment_8_8_t0w4_pa1_50_8(
+// CHECK: define linkonce_odr hidden void @__move_assignment_8_8_t0w4_pa1_50_8(
 
 void test_move_assignment_SA(SA *p) {
   *p = getSA();
@@ -88,7 +123,7 @@ void test_parameter_SA(SA a) {
 // CHECK: %[[V0:.*]] = load %[[STRUCT_SA]]*, %[[STRUCT_SA]]** %[[A_ADDR]], align 8
 // CHECK: %[[V1:.*]] = bitcast %[[STRUCT_SA]]* %[[AGG_TMP]] to i8**
 // CHECK: %[[V2:.*]] = bitcast %[[STRUCT_SA]]* %[[V0]] to i8**
-// CHECK: call void @__copy_constructor_8_8_t0w4_pa8(i8** %[[V1]], i8** %[[V2]]) #5
+// CHECK: call void @__copy_constructor_8_8_t0w4_pa1_50_8(i8** %[[V1]], i8** %[[V2]]) #5
 // CHECK: call void @calleeSA(%[[STRUCT_SA]]* %[[AGG_TMP]])
 // CHECK-NOT: call
 // CHECK: ret void
@@ -103,7 +138,7 @@ void test_argument_SA(SA *a) {
 // CHECK: %[[V0:.*]] = load %[[STRUCT_SA]]*, %[[STRUCT_SA]]** %[[A_ADDR]], align 8
 // CHECK: %[[V1:.*]] = bitcast %[[STRUCT_SA]]* %[[AGG_RESULT]] to i8**
 // CHECK: %[[V2:.*]] = bitcast %[[STRUCT_SA]]* %[[V0]] to i8**
-// CHECK: call void @__copy_constructor_8_8_t0w4_pa8(i8** %[[V1]], i8** %[[V2]]) #5
+// CHECK: call void @__copy_constructor_8_8_t0w4_pa1_50_8(i8** %[[V1]], i8** %[[V2]]) #5
 // CHECK-NOT: call
 // CHECK: ret void
 


### PR DESCRIPTION
non-trivial C copy constructors

rdar://problem/58101919
(cherry picked from commit 4a4ae8ba5058b8c98b98523a1aa851441508a6e1)