### PR TITLE
[Swift]: Using Located<T> instead of std::pair<SourceLoc, T>

### DIFF
--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -38,6 +38,7 @@
 #include "swift/ASTSectionImporter/ASTSectionImporter.h"
 #include "swift/Basic/Dwarf.h"
 #include "swift/Basic/LangOptions.h"
+#include "swift/Basic/Located.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/PrimarySpecificPaths.h"
 #include "swift/Basic/SourceManager.h"
@@ -3725,7 +3726,7 @@ swift::ModuleDecl *SwiftASTContext::GetModule(const SourceModule &module,
     return nullptr;
   }
 
-  typedef std::pair<swift::Identifier, swift::SourceLoc> ModuleNameSpec;
+  typedef swift::Located<swift::Identifier> ModuleNameSpec;
   llvm::StringRef module_basename_sref = module.path.front().GetStringRef();
   ModuleNameSpec name_pair(ast->getIdentifier(module_basename_sref),
                            swift::SourceLoc());
@@ -3808,7 +3809,7 @@ swift::ModuleDecl *SwiftASTContext::GetModule(const FileSpec &module_spec,
         ast->SearchPathOpts.ImportSearchPaths.push_back(
             std::move(module_directory));
 
-      typedef std::pair<swift::Identifier, swift::SourceLoc> ModuleNameSpec;
+      typedef swift::Located<swift::Identifier> ModuleNameSpec;
       llvm::StringRef module_basename_sref(module_basename.GetCString());
       ModuleNameSpec name_pair(ast->getIdentifier(module_basename_sref),
                                swift::SourceLoc());


### PR DESCRIPTION
To successfully compile project after Located were introduced through Compiler. We need to use Located into lldb source code.

https://bugs.swift.org/browse/SR-11889
https://github.com/apple/swift/pull/28643

@varungandhi-apple, @CodaFi 