### PR TITLE
Mark the derived test as xfail on arm64; tighten up expected str.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/commands/expression/call-overridden-method/TestCallOverriddenMethod.py
+++ b/lldb/packages/Python/lldbsuite/test/commands/expression/call-overridden-method/TestCallOverriddenMethod.py
@@ -40,12 +40,13 @@ class ExprCommandCallOverriddenMethod(TestBase):
 
         # Test call to method in base class (this should always work as the base
         # class method is never an override).
-        self.expect("expr b->foo()", substrs=["2"])
+        self.expect("expr b->foo()", substrs=["= 2"])
 
         # Test calling the base class.
-        self.expect("expr realbase.foo()", substrs=["1"])
+        self.expect("expr realbase.foo()", substrs=["= 1"])
 
     @skipIfLinux # Returns wrong result code on some platforms.
+    @expectedFailureAll(archs=['arm64', 'arm64e'], bugnumber="<rdar://problem/56828233>")
     def test_call_on_derived(self):
         """Test calls to overridden methods in derived classes."""
         self.build()
@@ -61,7 +62,7 @@ class ExprCommandCallOverriddenMethod(TestBase):
         # Test call to overridden method in derived class (this will fail if the
         # overrides table is not correctly set up, as Derived::foo will be assigned
         # a vtable entry that does not exist in the compiled program).
-        self.expect("expr d.foo()", substrs=["2"])
+        self.expect("expr d.foo()", substrs=["= 2"])
 
     @skipIfLinux # Calling constructor causes SIGABRT
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr43707")
@@ -78,5 +79,5 @@ class ExprCommandCallOverriddenMethod(TestBase):
         self.runCmd("run", RUN_SUCCEEDED)
 
         # Test with locally constructed instances.
-        self.expect("expr Base().foo()", substrs=["1"])
-        self.expect("expr Derived().foo()", substrs=["2"])
+        self.expect("expr Base().foo()", substrs=["= 1"])
+        self.expect("expr Derived().foo()", substrs=["= 2"])


### PR DESCRIPTION
Mark the derived test as xfail on arm64; tighten up expected str.
<rdar://problem/56828233>