### PR TITLE
[dwarfdump] Verify DW_AT_type is set and points to a compatible DIE.

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -167,9 +167,20 @@ unsigned DWARFVerifier::verifyUnitContents(DWARFUnit &Unit) {
     if (Die.getTag() == DW_TAG_null)
       continue;
 
+    bool HasTypeAttr = false;
     for (auto AttrValue : Die.attributes()) {
       NumUnitErrors += verifyDebugInfoAttribute(Die, AttrValue);
       NumUnitErrors += verifyDebugInfoForm(Die, AttrValue);
+      HasTypeAttr |= (AttrValue.Attr == DW_AT_type);
+    }
+
+    if (!HasTypeAttr && (Die.getTag() == DW_TAG_formal_parameter ||
+                         Die.getTag() == DW_TAG_variable ||
+                         Die.getTag() == DW_TAG_array_type)) {
+      error() << "DIE with tag " << TagString(Die.getTag())
+              << " is missing type attribute:\n";
+      dump(Die) << '\n';
+      NumUnitErrors++;
     }
 
     NumUnitErrors += verifyDebugInfoCallSite(Die);

--- a/llvm/test/tools/llvm-dwarfdump/X86/verify_debug_info.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/verify_debug_info.s
@@ -22,6 +22,13 @@
 # CHECK-NEXT: DW_AT_prototyped [DW_FORM_flag_present]   (true)
 # CHECK-NEXT: DW_AT_type [DW_FORM_ref4] (cu + 0x0052 => {0x00000052} "")
 # CHECK-NEXT: DW_AT_external [DW_FORM_flag_present]     (true){{[[:space:]]}}
+# CHECK-NEXT: error: DIE with tag DW_TAG_variable is missing type attribute:{{[[:space:]]}}
+# CHECK-NEXT: 0x00000044: DW_TAG_variable [3]
+# CHECK-NEXT: DW_AT_location [DW_FORM_exprloc]  (DW_OP_fbreg -8)
+# CHECK-NEXT: DW_AT_name [DW_FORM_strp] ( .debug_str[0x0000006a] = "a")
+# CHECK-NEXT: DW_AT_decl_file [DW_FORM_data1]   (0x01)
+# CHECK-NEXT: DW_AT_decl_line [DW_FORM_data1]   (2)
+# CHECK-NEXT: DW_AT_use_location [DW_FORM_ref4] (cu + 0x0053 => {0x00000053}){{[[:space:]]}}
 # CHECK-NEXT: error: Compilation unit root DIE is not a unit DIE: DW_TAG_null.
 # CHECK-NEXT: error: Compilation unit type (DW_UT_compile) and root DIE (DW_TAG_null) do not match.
 # CHECK-NEXT: error: Units[2] - start offset: 0x00000068


### PR DESCRIPTION
This extends the verifier to catch three new errors:

  * Missing DW_AT_type attributes for DW_TAG_formal_parameter,
    DW_TAG_variable and DW_TAG_array_type.

  * Valid references for DW_AT_type pointing to a non-type tag.

Differential revision: https://reviews.llvm.org/D52223

llvm-svn: 342713
(cherry picked from commit b32274242d7eb86e7841a391303da59fce59f98e)