### PR TITLE
Remove assertion.

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -251,7 +251,6 @@ FindSymbolForSwiftObject(Process &process, RuntimeKind runtime_kind,
         "Couldn't find the %s runtime library in loaded images.\n",
         (runtime_kind == RuntimeKind::Swift) ? "Swift" : "Objective-C");
   }
-  lldbassert(found_module && "couldn't find runtime library in loaded images");
   return {};
 }
 


### PR DESCRIPTION
This newly-added assertion currently triggers in Swift programs that
don't depend on the Swift stdlib, but a proper fix is too disruptive
for swift-5.2-branch.