### PR TITLE
LLDB updates to support multi-pattern catches (SE-0276)

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -320,7 +320,7 @@ void SwiftASTManipulatorBase::DoInitialization() {
     if (do_stmt) {
       // There should only be one catch:
       assert(m_do_stmt->getCatches().size() == 1);
-      swift::CatchStmt *our_catch = m_do_stmt->getCatches().front();
+      swift::CaseStmt *our_catch = m_do_stmt->getCatches().front();
       if (our_catch)
         m_catch_stmt = our_catch;
     }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -23,7 +23,7 @@
 #include "llvm/ADT/SmallVector.h"
 
 namespace swift {
-class CatchStmt;
+class CaseStmt;
 class DoCatchStmt;
 class ExtensionDecl;
 class FuncDecl;
@@ -133,7 +133,7 @@ protected:
   swift::DoCatchStmt *m_do_stmt = nullptr;
   /// The body of the catch - we patch the assignment there to capture
   /// any error thrown.
-  swift::CatchStmt *m_catch_stmt = nullptr;
+  swift::CaseStmt *m_catch_stmt = nullptr;
 };
 
 class SwiftASTManipulator : public SwiftASTManipulatorBase {


### PR DESCRIPTION
Counterpart to https://github.com/apple/swift/pull/27776 and https://github.com/apple/swift/pull/27905 . Updates LLDB to reflect the `CatchStmt` -> `CaseStmt` change for catch clauses.