### PR TITLE
Add missing nullptr checks.

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -96,7 +96,11 @@ bool SwiftExpressionSourceCode::GetText(
     }
 
     SwiftPersistentExpressionState *persistent_state =
-      llvm::cast<SwiftPersistentExpressionState>(target->GetPersistentExpressionStateForLanguage(lldb::eLanguageTypeSwift));
+        llvm::cast<SwiftPersistentExpressionState>(
+            target->GetPersistentExpressionStateForLanguage(
+                lldb::eLanguageTypeSwift));
+    if (!persistent_state)
+      return false;
     std::vector<swift::ValueDecl *> persistent_results;
     // Check if we have already declared the playground stub debug functions
     persistent_state->GetSwiftPersistentDecls(ConstString("__builtin_log_with_id"), {},

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
@@ -122,6 +122,7 @@ public:
     if (!persistent_state) {
       err.SetErrorString("Couldn't dematerialize a result variable: language "
                          "doesn't have persistent state");
+      return;
     }
 
     auto prefix = persistent_state->GetPersistentVariablePrefix();

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -3355,11 +3355,6 @@ void SwiftLanguageRuntime::RegisterGlobalError(Target &target, ConstString name,
 
   auto *ast_context = llvm::dyn_cast_or_null<SwiftASTContext>(&*type_system_or_err);
   if (ast_context && !ast_context->HasFatalErrors()) {
-    SwiftPersistentExpressionState *persistent_state =
-        llvm::cast<SwiftPersistentExpressionState>(
-            target.GetPersistentExpressionStateForLanguage(
-                lldb::eLanguageTypeSwift));
-
     std::string module_name = "$__lldb_module_for_";
     module_name.append(&name.GetCString()[1]);
     SourceModule module_info;
@@ -3380,6 +3375,13 @@ void SwiftLanguageRuntime::RegisterGlobalError(Target &target, ConstString name,
                          module_decl);
       var_decl->setInterfaceType(GetSwiftType(ast_context->GetErrorType()));
       var_decl->setDebuggerVar(true);
+
+      SwiftPersistentExpressionState *persistent_state =
+          llvm::cast<SwiftPersistentExpressionState>(
+              target.GetPersistentExpressionStateForLanguage(
+                  lldb::eLanguageTypeSwift));
+      if (!persistent_state)
+        return;
 
       persistent_state->RegisterSwiftPersistentDecl(var_decl);
 

--- a/lldb/source/Target/ThreadPlanCallFunction.cpp
+++ b/lldb/source/Target/ThreadPlanCallFunction.cpp
@@ -497,6 +497,8 @@ bool ThreadPlanCallFunction::BreakpointsExplainStop() {
         PersistentExpressionState *persistent_state =
             GetTarget().GetPersistentExpressionStateForLanguage(
                 eLanguageTypeSwift);
+        if (!persistent_state)
+          return false;
         const bool is_error = true;
         auto prefix = persistent_state->GetPersistentVariablePrefix(is_error);
         ConstString persistent_variable_name(


### PR DESCRIPTION
GetPersistentExpressionStateForLanguage() can return a nullptr if it
cannot construct a typesystem. This patch adds missing nullptr checks
at all uses.

rdar://problem/58317195
(cherry picked from commit 3d5f0872638834e23a29d8e5118a37ee295c91d8)