### PR TITLE
[lldb] Add missing nullptr checks to ObjCLanguageRuntime::Get calls

### DIFF
--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -362,23 +362,25 @@ CompilerType ValueObject::MaybeCalculateCompleteType() {
   }
 
   // then try the runtime
-  std::vector<CompilerDecl> compiler_decls;
-  auto *objc_language_runtime = ObjCLanguageRuntime::Get(*process_sp);
-  if (auto runtime_vendor = objc_language_runtime->GetDeclVendor()) {
-    if (runtime_vendor->FindDecls(class_name, false, UINT32_MAX,
-                                  compiler_decls) > 0 &&
-        compiler_decls.size() > 0) {
-      auto *ctx = llvm::dyn_cast<ClangASTContext>(compiler_decls[0].GetTypeSystem());
-      if (ctx) {
-        CompilerType runtime_type =
-            ctx->GetTypeForDecl(compiler_decls[0].GetOpaqueDecl());
-        m_override_type =
-          is_pointer_type ? runtime_type.GetPointerType() : runtime_type;
+  if (auto *objc_language_runtime = ObjCLanguageRuntime::Get(*process_sp)) {
+    if (auto runtime_vendor = objc_language_runtime->GetDeclVendor()) {
+      std::vector<CompilerDecl> compiler_decls;
+      if (runtime_vendor->FindDecls(class_name, false, UINT32_MAX,
+                                    compiler_decls) > 0 &&
+          compiler_decls.size() > 0) {
+        auto *ctx =
+            llvm::dyn_cast<ClangASTContext>(compiler_decls[0].GetTypeSystem());
+        if (ctx) {
+          CompilerType runtime_type =
+              ctx->GetTypeForDecl(compiler_decls[0].GetOpaqueDecl());
+          m_override_type =
+              is_pointer_type ? runtime_type.GetPointerType() : runtime_type;
+        }
       }
-    }
 
-    if (m_override_type.IsValid())
-      return m_override_type;
+      if (m_override_type.IsValid())
+        return m_override_type;
+    }
   }
   return compiler_type;
 }

--- a/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
@@ -159,8 +159,12 @@ bool lldb_private::formatters::swift::Measurement_SummaryProvider(
   if (!process_sp)
     return false;
 
-  auto descriptor_sp(
-      ObjCLanguageRuntime::Get(*process_sp)->GetClassDescriptor(*unit_sp));
+  ObjCLanguageRuntime *objc_runtime =
+      ObjCLanguageRuntime::Get(*process_sp);
+  if (!objc_runtime)
+    return false;
+
+  auto descriptor_sp(objc_runtime->GetClassDescriptor(*unit_sp));
   if (!descriptor_sp)
     return false;
 


### PR DESCRIPTION
If there is not ObjCLanguageRuntime we otherwise would crash.

Fixes rdar://58423589