### PR TITLE
[lldb] Add missing nullptr checks to ObjCLanguageRuntime::Get calls

### DIFF
--- a/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
@@ -159,8 +159,12 @@ bool lldb_private::formatters::swift::Measurement_SummaryProvider(
   if (!process_sp)
     return false;
 
-  auto descriptor_sp(
-      ObjCLanguageRuntime::Get(*process_sp)->GetClassDescriptor(*unit_sp));
+  ObjCLanguageRuntime *objc_runtime =
+      ObjCLanguageRuntime::Get(*process_sp);
+  if (!objc_runtime)
+    return false;
+
+  auto descriptor_sp(objc_runtime->GetClassDescriptor(*unit_sp));
   if (!descriptor_sp)
     return false;
 


### PR DESCRIPTION
If there is not ObjCLanguageRuntime we otherwise would crash.

Fixes rdar://58423589