### PR TITLE
[master-rebranch] [SwiftASTContext] Be more defensive when the type can't be bound.

### DIFF
--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -6195,7 +6195,7 @@ SwiftASTContext::GetBitSize(lldb::opaque_compiler_type_t type,
     swift::CanType swift_bound_type(GetCanonicalSwiftType(bound_type));
     if (swift_bound_type->hasTypeParameter()) {
       LOG_PRINTF(LIBLLDB_LOG_TYPES, "GetBitSize: Can't bind type: %s",
-                 type.GetTypeName().AsCString());
+                 bound_type.GetTypeName().AsCString());
       return {};
     }
 


### PR DESCRIPTION
rdar://problem/58097436
