### PR TITLE
🍒-pick d3ba1e026db

### DIFF
--- a/lldb/include/lldb/API/SBReproducer.h
+++ b/lldb/include/lldb/API/SBReproducer.h
@@ -20,7 +20,8 @@ class LLDB_API SBReproducer {
 public:
   static const char *Capture();
   static const char *Capture(const char *path);
-  static const char *Replay(const char *path, bool skip_version_check = false);
+  static const char *Replay(const char *path);
+  static const char *Replay(const char *path, bool skip_version_check);
   static const char *GetPath();
   static bool Generate();
 };

--- a/lldb/source/API/SBReproducer.cpp
+++ b/lldb/source/API/SBReproducer.cpp
@@ -124,6 +124,10 @@ const char *SBReproducer::Capture(const char *path) {
   return nullptr;
 }
 
+const char *SBReproducer::Replay(const char *path) {
+  return SBReproducer::Replay(path, false);
+}
+
 const char *SBReproducer::Replay(const char *path, bool skip_version_check) {
   static std::string error;
   if (auto e = Reproducer::Initialize(ReproducerMode::Replay, FileSpec(path))) {


### PR DESCRIPTION
I modified the SBAPI under the assumption that nobody was using the old
API yet. However, that turns out to be false. So instead of adding the
deafault argument I've reintroduced the old API and made the new one an
overload.

(cherry picked from commit d3ba1e026dbc44e9097ce6ea1c92d065f1fe33e8)