### PR TITLE
Target: return value from `IsInLibraryNegativeCache`

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -237,7 +237,10 @@ public:
   }
 
   void AddToLibraryNegativeCache(llvm::StringRef library_name) {}
-  bool IsInLibraryNegativeCache(llvm::StringRef library_name) {}
+
+  bool IsInLibraryNegativeCache(llvm::StringRef library_name) {
+    return false;
+  }
 
   void ReleaseAssociatedRemoteASTContext(swift::ASTContext *ctx) {}
 


### PR DESCRIPTION
The member function is marked as returning a `bool` but returns no
value.  Explicitly return a `false`.  This fixes the build with VS2019.