### PR TITLE
build: correct python for dependency

### DIFF
--- a/lldb/bindings/CMakeLists.txt
+++ b/lldb/bindings/CMakeLists.txt
@@ -45,7 +45,7 @@ if (LLDB_ENABLE_PYTHON)
     DEPENDS ${SWIG_SOURCES}
     DEPENDS ${SWIG_INTERFACES}
     DEPENDS ${SWIG_HEADERS}
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/python/prepare_binding_Python.py
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/python/prepare_binding_python.py
     COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/prepare_bindings.py
         ${framework_arg}
         --srcRoot=${LLDB_SOURCE_DIR}


### PR DESCRIPTION
This corrects the case for the file dependency for case sensitive file
systems such as EXT.