### PR TITLE
[lldb/Docs] Extend description section of the main page

### DIFF
--- a/lldb/docs/man/lldb.rst
+++ b/lldb/docs/man/lldb.rst
@@ -13,8 +13,15 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-:program:`lldb` is a fully featured debugger. It is a command line interface to
-the LLDB debugger library.
+:program:`lldb` is a next generation, high-performance debugger. It is built as
+a set of reusable components which highly leverage existing libraries in the
+larger LLVM Project, such as the Clang expression parser and LLVM disassembler.
+
+:program:`lldb` is the default debugger in Xcode on macOS and supports
+debugging C, Objective-C and C++ on the desktop and iOS devices and simulator.
+
+All of the code in the LLDB project is available under the Apache 2.0 License
+with LLVM exceptions.
 
 ATTACHING
 ---------


### PR DESCRIPTION
The current description is a bit terse. I've copy/pasted the
introduction form the website.

(cherry picked from commit 9d30d769041b14c0ff29770d59027e679e6b7edc)