### PR TITLE
[lldb] Fix that Objective-C methods were never variadic

### DIFF
--- a/lldb/source/Symbol/ClangASTContext.cpp
+++ b/lldb/source/Symbol/ClangASTContext.cpp
@@ -8666,7 +8666,7 @@ clang::ObjCMethodDecl *ClangASTContext::AddMethodToObjCObjectType(
     return nullptr;
 
   const bool isInstance = (name[0] == '-');
-  const bool isVariadic = false;
+  const bool isVariadic = is_variadic;
   const bool isPropertyAccessor = false;
   const bool isSynthesizedAccessorStub = false;
   /// Force this to true because we don't have source locations.


### PR DESCRIPTION
In 952413c24961cf195622a1991cc5827ed29ff561 we just hardcoded a
false in there instead of taking the value of is_variadic.

(cherry picked from commit f6af6c3ed2e3d5aa9d4534552ee7aadb85b0eab4)