### PR TITLE
TSan cherry picks

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp
@@ -621,6 +621,10 @@ class DynamicSegment {
       last_symbol = Max(buckets[i], last_symbol);
     }
 
+    if (last_symbol < header->symoffset) {
+      return header->symoffset;
+    }
+
     // Walk the bucket's chain to add the chain length to the total.
     uint32_t chain_entry;
     do {

--- a/compiler-rt/test/sanitizer_common/lit.common.cfg.py
+++ b/compiler-rt/test/sanitizer_common/lit.common.cfg.py
@@ -37,6 +37,9 @@ if config.host_os == 'Darwin':
   default_tool_options += ['abort_on_error=0']
   if config.tool_name == "tsan":
     default_tool_options += ['ignore_interceptors_accesses=0']
+elif config.host_os == 'Linux' and config.tool_name == 'tsan':
+    # For Swift, the above also applies on Linux.
+    default_tool_options += ['ignore_interceptors_accesses=0']
 elif config.android:
   # The same as on Darwin, we default to "abort_on_error=1" which slows down
   # testing. Also, all existing tests are using "not" instead of "not --crash"

--- a/compiler-rt/test/tsan/Unit/lit.site.cfg.py.in
+++ b/compiler-rt/test/tsan/Unit/lit.site.cfg.py.in
@@ -15,6 +15,8 @@ config.test_source_root = config.test_exec_root
 if config.host_os == 'Darwin':
   config.parallelism_group = config.darwin_sanitizer_parallelism_group_func
 
+# For Swift, the following also applies on Linux.
+if config.host_os == 'Darwin' or config.host_os == 'Linux':
   # On Darwin, we default to ignore_noninstrumented_modules=1, which also
   # suppresses some races the tests are supposed to find.  See tsan/lit.cfg.py.
   if 'TSAN_OPTIONS' in config.environment:

--- a/compiler-rt/test/tsan/lit.cfg.py
+++ b/compiler-rt/test/tsan/lit.cfg.py
@@ -24,6 +24,9 @@ if config.host_os == 'Darwin':
   # On Darwin, we default to `abort_on_error=1`, which would make tests run
   # much slower. Let's override this and run lit tests with 'abort_on_error=0'.
   default_tsan_opts += ':abort_on_error=0'
+
+# For Swift, the following also applies on Linux.
+if config.host_os == 'Darwin' or config.host_os == 'Linux':
   # On Darwin, we default to ignore_noninstrumented_modules=1, which also
   # suppresses some races the tests are supposed to find. Let's run without this
   # setting, but turn it back on for Darwin tests (see Darwin/lit.local.cfg.py).


### PR DESCRIPTION
I originally cherry-picked these changes into `swift/master-next`.  Turns out these should really live in `apple/master`.  

https://github.com/apple/swift/blob/master/docs/Branches.md
Alex Lorenz:
> Yeah that document is wrong. Only LLDB commits should go into swift/master-next, but others should either go upstream or apple/master. I'll update it