### PR TITLE
[llvm-exegesis] Initialize const bitvector member

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/MCInstrDescView.cpp
+++ b/llvm/tools/llvm-exegesis/lib/MCInstrDescView.cpp
@@ -301,7 +301,7 @@ void Instruction::dump(const MCRegisterInfo &RegInfo,
 
 InstructionsCache::InstructionsCache(const MCInstrInfo &InstrInfo,
                                      const RegisterAliasingTrackerCache &RATC)
-    : InstrInfo(InstrInfo), RATC(RATC) {}
+    : InstrInfo(InstrInfo), RATC(RATC), BVC() {}
 
 const Instruction &InstructionsCache::getInstr(unsigned Opcode) const {
   auto &Found = Instructions[Opcode];


### PR DESCRIPTION
This causes an error with older versions of clang: constructor for
'llvm::exegesis::InstructionsCache' must explicitly initialize the const
member 'BVC'

(cherry picked from commit 09db6e320985f2bee22634049857224e0a5e58f8)