### PR TITLE
[lldb/Utility] Add std::move to make placate clang 3.8

### DIFF
--- a/lldb/source/Utility/StructuredData.cpp
+++ b/lldb/source/Utility/StructuredData.cpp
@@ -78,7 +78,7 @@ static StructuredData::ObjectSP ParseJSONObject(json::Object *object) {
     if (StructuredData::ObjectSP value_sp = ParseJSONValue(value))
       dict_up->AddItem(key, value_sp);
   }
-  return dict_up;
+  return std::move(dict_up);
 }
 
 static StructuredData::ObjectSP ParseJSONArray(json::Array *array) {
@@ -87,7 +87,7 @@ static StructuredData::ObjectSP ParseJSONArray(json::Array *array) {
     if (StructuredData::ObjectSP value_sp = ParseJSONValue(value))
       array_up->AddItem(value_sp);
   }
-  return array_up;
+  return std::move(array_up);
 }
 
 StructuredData::ObjectSP


### PR DESCRIPTION
This fixes an error thrown by clang 3.8 that no viable conversion from
returned value to the function return type.

(cherry picked from commit d1e3b23be46ac3ada8f5fe844629ad5bc233c24d)