### PR TITLE
[lldb/Expression] Improve interpreter error message with a non-running target

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/commands/expression/dont_allow_jit/TestAllowJIT.py
+++ b/lldb/packages/Python/lldbsuite/test/commands/expression/dont_allow_jit/TestAllowJIT.py
@@ -40,7 +40,7 @@ class TestAllowJIT(TestBase):
                                    "Set a breakpoint here", self.main_source_file)
 
         frame = thread.GetFrameAtIndex(0)
-        
+
         # First make sure we can call the function with 
         interp = self.dbg.GetCommandInterpreter()
         self.expect("expr --allow-jit 1 -- call_me(10)",
@@ -48,8 +48,8 @@ class TestAllowJIT(TestBase):
         # Now make sure it fails with the "can't IR interpret message" if allow-jit is false:
         self.expect("expr --allow-jit 0 -- call_me(10)",
                     error=True,
-                    substrs = ["Can't run the expression locally"])
-        
+                    substrs = ["Can't evaluate the expression without a running target"])
+
     def expr_options_test(self):
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(self,
                                    "Set a breakpoint here", self.main_source_file)
@@ -74,7 +74,7 @@ class TestAllowJIT(TestBase):
         # Again use it and ensure we fail:
         result = frame.EvaluateExpression("call_me(10)", options)
         self.assertTrue(result.GetError().Fail(), "expression failed with no JIT")
-        self.assertTrue("Can't run the expression locally" in result.GetError().GetCString(), "Got right error")
+        self.assertTrue("Can't evaluate the expression without a running target" in result.GetError().GetCString(), "Got right error")
 
         # Finally set the allow JIT value back to true and make sure that works:
         options.SetAllowJIT(True)

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -1253,8 +1253,9 @@ lldb_private::Status ClangExpressionParser::PrepareForExecution(
           interpret_error, interpret_function_calls);
 
       if (!can_interpret && execution_policy == eExecutionPolicyNever) {
-        err.SetErrorStringWithFormat("Can't run the expression locally: %s",
-                                     interpret_error.AsCString());
+        err.SetErrorStringWithFormat(
+            "Can't evaluate the expression without a running target due to: %s",
+            interpret_error.AsCString());
         return err;
       }
     }


### PR DESCRIPTION
When trying to interpret an expression with a function call, if the
process hasn't been launched, the expression fails to be interpreted
and the user gets the following  error message:

```error: Can't run the expression locally```

This message doesn't explain why the expression failed to be
interpreted, that's why this patch improves the error message that is
displayed when trying to run an expression while no process is running.

rdar://11991708

Differential Revision: https://reviews.llvm.org/D72510

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>