### PR TITLE
[Remarks][LTO] Infer remarks file path from -object_path_lto

### DIFF
--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -405,6 +405,11 @@ output format of the diagnostics that it generates.
     On Darwin platforms, this is incompatible with passing multiple
     ``-arch <arch>`` options.
 
+   On Darwin platforms, if ``-flto`` is used and the file path is not provided,
+   the output file will be chosen according to the linker argument
+   ``-object_path_lto`` if present, or according to the output file specified
+   through ``-o`` otherwise.
+
 .. _opt_foptimization-record-passes:
 
 **-foptimization-record-passes**

--- a/clang/test/Driver/darwin-ld.c
+++ b/clang/test/Driver/darwin-ld.c
@@ -315,6 +315,20 @@
 // PASS_REMARKS_OUTPUT: "-mllvm" "-lto-pass-remarks-output" "-mllvm" "foo/bar.out.opt.yaml"
 // PASS_REMARKS_OUTPUT-NOT: -lto-pass-remarks-with-hotness
 
+// Check that when -object_path_lto is used, we're passing the right path to -lto-pass-remarks-output.
+// RUN: %clang -target x86_64-apple-darwin12 %t.o -fsave-optimization-record -### -o foo/bar.out -Wl,-object_path_lto,foo/bar_lto.o 2> %t.log
+// RUN: FileCheck -check-prefix=REMARKS_OBJECT_PATH_LTO_WL %s < %t.log
+// REMARKS_OBJECT_PATH_LTO_WL: "-mllvm" "-lto-pass-remarks-output" "-mllvm" "foo/bar_lto.o.opt.yaml"
+// Also check for -Xlinker.
+// RUN: %clang -target x86_64-apple-darwin12 %t.o -fsave-optimization-record -### -o foo/bar.out -Xlinker -object_path_lto -Xlinker foo/bar_lto.o 2> %t.log
+// RUN: FileCheck -check-prefix=REMARKS_OBJECT_PATH_LTO_XLINKER %s < %t.log
+// REMARKS_OBJECT_PATH_LTO_XLINKER: "-mllvm" "-lto-pass-remarks-output" "-mllvm" "foo/bar_lto.o.opt.yaml"
+// Make sure that we pick the path based on -o if there is no second -Xlinker
+// with the path after -object_path_lto.
+// RUN: %clang -target x86_64-apple-darwin12 %t.o -fsave-optimization-record -### -o foo/bar.out -Xlinker -object_path_lto 2> %t.log
+// RUN: FileCheck -check-prefix=REMARKS_OBJECT_PATH_LTO_XLINKER_MISSING %s < %t.log
+// REMARKS_OBJECT_PATH_LTO_XLINKER_MISSING: "-mllvm" "-lto-pass-remarks-output" "-mllvm" "foo/bar.out.opt.yaml"
+
 // RUN: %clang -target x86_64-apple-darwin12 %t.o -fsave-optimization-record -### 2> %t.log
 // RUN: FileCheck -check-prefix=PASS_REMARKS_OUTPUT_NO_O %s < %t.log
 // PASS_REMARKS_OUTPUT_NO_O: "-mllvm" "-lto-pass-remarks-output" "-mllvm" "a.out.opt.yaml"


### PR DESCRIPTION
In the common flow, remarks are expected to be in the .dSYM bundle after
dsymutil collects them from the object files and creates a standalone
remark file. After that, the linked binary and the .dSYM bundle are
sufficient to execute, debug, and process the remarks.

Even if users pass -object_path_lto to the linker, we generate the
temporary remark files based on the output file requested through `-o`,
which is very inconvenient when users try to separate their intermediate
products from their final products. This will leave intermediate remarks
in the final products, like Frameworks or other bundles.

This patch will change that behavior to try to infer the remarks file
path from the path specified in -object_path_lto.

It is a little messy as the driver will try to read flags that are
intended to be passed to the linker, but for now, it's the only option
and `hasExportSymbolDirective` is already doing this.

The cleaner way to do this would be to add an interface for the linker
to specify the remark output file when setting up LTO.

rdar://58571567