### PR TITLE
[lldb][NFC] Fix call-overridden-method test by adding virtual destructor

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/commands/expression/call-overridden-method/TestCallOverriddenMethod.py
+++ b/lldb/packages/Python/lldbsuite/test/commands/expression/call-overridden-method/TestCallOverriddenMethod.py
@@ -45,8 +45,6 @@ class ExprCommandCallOverriddenMethod(TestBase):
         # Test calling the base class.
         self.expect("expr realbase.foo()", substrs=["= 1"])
 
-    @skipIfLinux # Returns wrong result code on some platforms.
-    @expectedFailureAll(archs=['arm64', 'arm64e'], bugnumber="<rdar://problem/56828233>")
     def test_call_on_derived(self):
         """Test calls to overridden methods in derived classes."""
         self.build()
@@ -64,7 +62,6 @@ class ExprCommandCallOverriddenMethod(TestBase):
         # a vtable entry that does not exist in the compiled program).
         self.expect("expr d.foo()", substrs=["= 2"])
 
-    @skipIfLinux # Calling constructor causes SIGABRT
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr43707")
     def test_call_on_temporary(self):
         """Test calls to overridden methods in derived classes."""

--- a/lldb/packages/Python/lldbsuite/test/commands/expression/call-overridden-method/main.cpp
+++ b/lldb/packages/Python/lldbsuite/test/commands/expression/call-overridden-method/main.cpp
@@ -6,6 +6,7 @@ public:
 
 class Derived : public Base {
 public:
+  virtual ~Derived() {}
   virtual int foo() { return 2; }
 };
 


### PR DESCRIPTION
If we have a subclass without a virtual destructor but a base class
with a virtual destructor we currently get the vtable index wrong
when calling virtual functions. This happens in this test case and
is causing it to fail. This is fixed upstream but its still failing
on the 5.2 branch. This patch adds the virtual constructor which
should fix the test on all platforms (and is less aggressive than
disabling it which means we completely stop testing virtual
function calls).