### PR TITLE
xfail the inheritance method call test in TestCallOverriddenMethod.py

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/commands/expression/call-overridden-method/TestCallOverriddenMethod.py
+++ b/lldb/packages/Python/lldbsuite/test/commands/expression/call-overridden-method/TestCallOverriddenMethod.py
@@ -46,7 +46,7 @@ class ExprCommandCallOverriddenMethod(TestBase):
         self.expect("expr realbase.foo()", substrs=["= 1"])
 
     @skipIfLinux # Returns wrong result code on some platforms.
-    @expectedFailureAll(archs=['arm64', 'arm64e'], bugnumber="<rdar://problem/56828233>")
+    @expectedFailureAll(bugnumber="<rdar://problem/56828233>")
     def test_call_on_derived(self):
         """Test calls to overridden methods in derived classes."""
         self.build()


### PR DESCRIPTION
xfail the inheritance method call test in TestCallOverriddenMethod.py
This is fixed on top of tree llvm.org via r372538, r372548) but
the changes are too large scale to pull on to swift-5.2-branch;
this is not a regression on swift-5.2 but a long standing bug.
The testsuite would often pass because the check for returned
value was not strict enough; I tightened up that string match
and now it fails regularly.