### PR TITLE
[lldb] Fix asan failures in data-formatter-objc tests (Backport)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSData.py
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSData.py
@@ -24,7 +24,7 @@ class ObjCDataFormatterNSData(ObjCDataFormatterTestCase):
         self.expect(
             'frame variable immutableData mutableData data_ref mutable_data_ref mutable_string_ref concreteData concreteMutableData',
             substrs=[
-                '(NSData *) immutableData = ', ' 4 bytes',
+                '(NSData *) immutableData = ', ' 5 bytes',
                 '(NSData *) mutableData = ', ' 14 bytes',
                 '(CFDataRef) data_ref = ', '@"5 bytes"',
                 '(CFMutableDataRef) mutable_data_ref = ', '@"5 bytes"',

--- a/lldb/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/main.m
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/main.m
@@ -401,7 +401,7 @@ int main (int argc, const char * argv[])
 
 	    [mutableGetConst length];
 
-	    NSData *immutableData = [[NSData alloc] initWithBytes:"HELLO" length:4];
+	    NSData *immutableData = [[NSData alloc] initWithBytes:"HELLO" length:5];
 	    NSData *mutableData = [[NSMutableData alloc] initWithBytes:"NODATA" length:6];
 
 	    // No-copy versions of NSData initializers use NSConcreteData if over 2^16 elements are specified.


### PR DESCRIPTION
Backport of a fix for the ASAN commit that was back ported to swift/master here: #446

Original commit text:
The test is currently failing on some systems with ASAN enabled due to:
```
==22898==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x603000003da4 at pc 0x00010951c33d bp 0x7ffee6709e00 sp 0x7ffee67095c0
READ of size 5 at 0x603000003da4 thread T0
    #0 0x10951c33c in wrap_memmove+0x16c (libclang_rt.asan_osx_dynamic.dylib:x86_64+0x1833c)
    #1 0x7fff4a327f57 in CFDataReplaceBytes+0x1ba (CoreFoundation:x86_64+0x13f57)
    #2 0x7fff4a415a44 in __CFDataInit+0x2db (CoreFoundation:x86_64+0x101a44)
    #3 0x1094f8490 in main main.m:424
    #4 0x7fff77482084 in start+0x0 (libdyld.dylib:x86_64+0x17084)
0x603000003da4 is located 0 bytes to the right of 20-byte region [0x603000003d90,0x603000003da4)
allocated by thread T0 here:
    #0 0x109547c02 in wrap_calloc+0xa2 (libclang_rt.asan_osx_dynamic.dylib:x86_64+0x43c02)
    #1 0x7fff763ad3ef in class_createInstance+0x52 (libobjc.A.dylib:x86_64+0x73ef)
    #2 0x7fff4c6b2d73 in NSAllocateObject+0x12 (Foundation:x86_64+0x1d73)
    #3 0x7fff4c6b5e5f in -[_NSPlaceholderData initWithBytes:length:copy:deallocator:]+0x40 (Foundation:x86_64+0x4e5f)
    #4 0x7fff4c6d4cf1 in -[NSData(NSData) initWithBytes:length:]+0x24 (Foundation:x86_64+0x23cf1)
    #5 0x1094f8245 in main main.m:404
    #6 0x7fff77482084 in start+0x0 (libdyld.dylib:x86_64+0x17084)
```

The reason is that we create a string "HELLO" but get the size wrong (it's 5 bytes instead
of 4). Later on we read the buffer and pretend it is 5 bytes long, causing an OOB read
which ASAN detects.

In general this test probably needs some cleanup as it produces on macOS 10.15 around
100 compiler warnings which isn't great, but let's first get the bot green.