### PR TITLE
Adapt construction to of IRGen module in SwiftASTContext to swift API…

### DIFF
--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -4853,10 +4853,11 @@ swift::irgen::IRGenModule &SwiftASTContext::GetIRGenModule() {
 
         std::lock_guard<std::recursive_mutex> global_context_locker(
             IRExecutionUnit::GetLLVMGlobalContextMutex());
+        llvm::StringRef PrivateDiscriminator = "";
         m_ir_gen_module_ap.reset(new swift::irgen::IRGenModule(
             ir_generator, ir_generator.createTargetMachine(), nullptr,
             GetGlobalLLVMContext(), ir_gen_opts.ModuleName, PSPs.OutputFilename,
-            PSPs.MainInputFilenameForDebugInfo));
+            PSPs.MainInputFilenameForDebugInfo, PrivateDiscriminator));
         llvm::Module *llvm_module = m_ir_gen_module_ap->getModule();
         llvm_module->setDataLayout(data_layout.getStringRepresentation());
         llvm_module->setTargetTriple(llvm_triple.str());


### PR DESCRIPTION
… change

The swift change eb619310122cb347854dac2f59720dcf64dc594c requires that this
constructor now takes a PrivateDiscriminator. We don't have one in lldb it seems
and the swift change usually passes an empty string along in these situations,
so let's do the same for LLDB to get it to build again.