### PR TITLE
[upstreaming] Revert some changes to downstream test cases

### DIFF
--- a/lldb/packages/Python/lldbsuite/support/encoded_file.py
+++ b/lldb/packages/Python/lldbsuite/support/encoded_file.py
@@ -9,7 +9,6 @@ to see a description of the supported command line arguments.
 
 # Python modules:
 import io
-import sys
 
 # Third party modules
 import six

--- a/lldb/packages/Python/lldbsuite/test/commands/expression/argument_passing_restrictions/TestArgumentPassingRestrictions.py
+++ b/lldb/packages/Python/lldbsuite/test/commands/expression/argument_passing_restrictions/TestArgumentPassingRestrictions.py
@@ -14,6 +14,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
+
 class TestArgumentPassingRestrictions(TestBase):
 
   mydir = TestBase.compute_mydir(__file__)

--- a/lldb/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/atomic/TestLibCxxAtomic.py
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/atomic/TestLibCxxAtomic.py
@@ -21,7 +21,7 @@ class LibCxxAtomicTestCase(TestBase):
         var.SetPreferSyntheticValue(True)
         return var
 
-    @skipIf(compiler="gcc")
+    @skipIf(compiler=["gcc"])
     @add_test_categories(["libc++"])
     def test(self):
         """Test that std::atomic as defined by libc++ is correctly printed by LLDB"""

--- a/lldb/packages/Python/lldbsuite/test/functionalities/process_group/TestChangeProcessGroup.py
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/process_group/TestChangeProcessGroup.py
@@ -14,8 +14,6 @@ class ChangeProcessGroupTestCase(TestBase):
     mydir = TestBase.compute_mydir(__file__)
     NO_DEBUG_INFO_TESTCASE = True
 
-    NO_DEBUG_INFO_TESTCASE = True
-
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/packages/Python/lldbsuite/test/lang/cpp/gmodules/TestWithModuleDebugging.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/cpp/gmodules/TestWithModuleDebugging.py
@@ -3,7 +3,6 @@ import os
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
-from lldbsuite.test import decorators
 
 
 class TestWithGmodulesDebugInfo(TestBase):

--- a/lldb/packages/Python/lldbsuite/test/lang/cpp/symbols/TestSymbols.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/cpp/symbols/TestSymbols.py
@@ -4,5 +4,4 @@ from lldbsuite.test import decorators
 lldbinline.MakeInlineTest(
     __file__, globals(), [
         decorators.expectedFailureAll(
-            oslist=["windows"], bugnumber="llvm.org/pr24764")
-        ])
+            oslist=["windows"], bugnumber="llvm.org/pr24764")])

--- a/lldb/packages/Python/lldbsuite/test/lldbbench.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbbench.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 # System modules
 import time
-#import numpy
-from lldbsuite.test.lldbtest import *
 
 # Third-party modules
 

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -17,7 +17,6 @@ import sys
 import tempfile
 import time
 from lldbsuite.test import configuration
-from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.support import seven
 from lldbgdbserverutils import *

--- a/lldb/packages/Python/lldbsuite/test_event/formatter/__init__.py
+++ b/lldb/packages/Python/lldbsuite/test_event/formatter/__init__.py
@@ -38,9 +38,6 @@ class CreatedFormatter(object):
         self.cleanup_func = cleanup_func
 
 
-SOCKET_ACK_BYTE_VALUE = b'*'  # ASCII for chr(42)
-
-
 def create_results_formatter(config):
     """Sets up a test results formatter.
 


### PR DESCRIPTION
These are all downstream NFC whitespace changes, declaring unused variables
or import unused libraries. This patch reverts these downstream changes.