### PR TITLE
[upstreaming] Make IsSwiftMangledName take a StringRef to get rid of …

### DIFF
--- a/lldb/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/lldb/include/lldb/Target/SwiftLanguageRuntime.h
@@ -133,7 +133,7 @@ public:
   /// \{
   /// Use these passthrough functions rather than calling into Swift directly,
   /// since some day we may want to support more than one swift variant.
-  static bool IsSwiftMangledName(const char *name);
+  static bool IsSwiftMangledName(llvm::StringRef name);
 
   static std::string DemangleSymbolAsString(llvm::StringRef symbol,
                                             bool simplified = false,

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -645,7 +645,7 @@ Module::LookupInfo::LookupInfo(ConstString name,
              ObjCLanguage::IsPossibleObjCMethodName(name_cstr))
       m_name_type_mask = eFunctionNameTypeFull;
     // BEGIN SWIFT
-    else if (SwiftLanguageRuntime::IsSwiftMangledName(name_cstr))
+    else if (SwiftLanguageRuntime::IsSwiftMangledName(name.GetStringRef()))
       m_name_type_mask = eFunctionNameTypeFull;
     // END SWIFT
     else if (Language::LanguageIsC(language)) {

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -127,7 +127,7 @@ SwiftLanguage::GetMethodNameVariants(ConstString method_name) const {
 
   ConstString counterpart;
   if (method_name.GetMangledCounterpart(counterpart))
-    if (SwiftLanguageRuntime::IsSwiftMangledName(counterpart.GetCString()))
+    if (SwiftLanguageRuntime::IsSwiftMangledName(counterpart.GetStringRef()))
       variant_names.emplace_back(counterpart);
   return variant_names;
 }

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -131,7 +131,7 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
         return type_sp;
       }
     }
-    if (SwiftLanguageRuntime::IsSwiftMangledName(name.GetCString()))
+    if (SwiftLanguageRuntime::IsSwiftMangledName(name.GetStringRef()))
       mangled_name = name;
   }
 
@@ -241,7 +241,7 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
 
   // Cache this type.
   if (type_sp && mangled_name &&
-      SwiftLanguageRuntime::IsSwiftMangledName(mangled_name.GetCString()))
+      SwiftLanguageRuntime::IsSwiftMangledName(mangled_name.GetStringRef()))
     m_ast.SetCachedType(mangled_name, type_sp);
   die.GetDWARF()->GetDIEToType()[die.GetDIE()] = type_sp.get();
 

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -3291,7 +3291,7 @@ public:
 
     // We will not find any Swift types in the Clang compile units.
     ConstString name_cs(name);
-    if (SwiftLanguageRuntime::IsSwiftMangledName(name_cs.GetCString()))
+    if (SwiftLanguageRuntime::IsSwiftMangledName(name_cs.GetStringRef()))
       return;
 
     auto clang_importer = m_swift_ast_ctx.GetClangImporter();
@@ -4367,7 +4367,7 @@ SwiftASTContext::GetTypeFromMangledTypename(ConstString mangled_typename,
 
   const char *mangled_cstr = mangled_typename.AsCString();
   if (mangled_typename.IsEmpty() ||
-      !SwiftLanguageRuntime::IsSwiftMangledName(mangled_cstr)) {
+      !SwiftLanguageRuntime::IsSwiftMangledName(mangled_typename.GetStringRef())) {
     error.SetErrorStringWithFormat(
         "typename \"%s\" is not a valid Swift mangled name", mangled_cstr);
     return {};

--- a/lldb/source/Symbol/Symtab.cpp
+++ b/lldb/source/Symbol/Symtab.cpp
@@ -299,7 +299,7 @@ void Symtab::InitNameIndexes() {
         if (type == eSymbolTypeCode || type == eSymbolTypeResolver) {
           if (mangled.DemangleWithRichManglingInfo(rmc, lldb_skip_name))
             RegisterMangledNameEntry(value, class_contexts, backlog, rmc);
-	  else if (SwiftLanguageRuntime::IsSwiftMangledName(name.AsCString())) {
+	  else if (SwiftLanguageRuntime::IsSwiftMangledName(name.GetStringRef())) {
             lldb_private::ConstString basename;
             bool is_method = false;
             ConstString mangled_name = mangled.GetMangledName();

--- a/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
@@ -324,7 +324,7 @@ static lldb::ThreadPlanSP GetStepThroughTrampolinePlan(Thread &thread,
   return new_thread_plan_sp;
 }
 
-bool SwiftLanguageRuntime::IsSwiftMangledName(const char *name) {
+bool SwiftLanguageRuntime::IsSwiftMangledName(llvm::StringRef name) {
   return swift::Demangle::isSwiftSymbol(name);
 }
 


### PR DESCRIPTION
…change to cstring_is_mangled

We changed this the cstring_is_mangled to take a ConstString because IsSwiftMangledName
is taking a C-String in this function as a downstream change. This is not only slower (we
rebuild the StringRef from the passed in C-String later on in Swift) but also causes
unnecessary downstream changes.

This just changes IsSwiftMangledName to take a StringRef.