### PR TITLE
Increase timeout in gdbclientutils.py to decrease chance of test fail…

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/functionalities/gdb_remote_client/gdbclientutils.py
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/gdb_remote_client/gdbclientutils.py
@@ -298,7 +298,7 @@ class MockGDBServer:
         try:
             # accept() is stubborn and won't fail even when the socket is
             # shutdown, so we'll use a timeout
-            self._socket.settimeout(2.0)
+            self._socket.settimeout(20.0)
             client, client_addr = self._socket.accept()
             self._client = client
             # The connected client inherits its timeout from self._socket,


### PR DESCRIPTION
Increase timeout in gdbclientutils.py to decrease chance of test failing under ASAN.

llvm-svn: 374371
(cherry picked from commit cba575e8ffb052266ab93c0623f44b383ee793ff)