### PR TITLE
[lldb] Fix Debugger build errors after rename of m_input_reader_stack

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -201,7 +201,7 @@ public:
   bool RemoveIOHandler(const lldb::IOHandlerSP &reader_sp);
 
   ///  Remove the given IO handlers if it's currently active.
-  bool RemoveIOHandlers(const lldb::IOHandlerSP &reader1_sp,
+  uint32_t RemoveIOHandlers(const lldb::IOHandlerSP &reader1_sp,
                         const lldb::IOHandlerSP &reader2_sp);
 
   bool IsTopIOHandler(const lldb::IOHandlerSP &reader_sp);
@@ -325,9 +325,9 @@ public:
 
   Status RunREPL(lldb::LanguageType language, const char *repl_options);
 
-  bool REPLIsActive() { return m_input_reader_stack.REPLIsActive(); }
+  bool REPLIsActive() { return m_io_handler_stack.REPLIsActive(); }
 
-  bool REPLIsEnabled() { return m_input_reader_stack.REPLIsEnabled(); }
+  bool REPLIsEnabled() { return m_io_handler_stack.REPLIsEnabled(); }
 
   // This is for use in the command interpreter, when you either want the
   // selected target, or if no target is present you want to prime the dummy

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -1048,25 +1048,25 @@ uint32_t Debugger::RemoveIOHandlers(const IOHandlerSP &reader1_sp,
                                     const IOHandlerSP &reader2_sp) {
   uint32_t result = 0;
 
-  std::lock_guard<std::recursive_mutex> guard(m_input_reader_stack.GetMutex());
+  std::lock_guard<std::recursive_mutex> guard(m_io_handler_stack.GetMutex());
 
   // The reader on the stop of the stack is done, so let the next
   // read on the stack refresh its prompt and if there is one...
-  if (!m_input_reader_stack.IsEmpty()) {
-    IOHandlerSP reader_sp(m_input_reader_stack.Top());
+  if (!m_io_handler_stack.IsEmpty()) {
+    IOHandlerSP reader_sp(m_io_handler_stack.Top());
 
     if (!reader1_sp || reader1_sp.get() == reader_sp.get()) {
       reader_sp->Deactivate();
       reader_sp->Cancel();
-      m_input_reader_stack.Pop();
+      m_io_handler_stack.Pop();
       ++result;
 
-      reader_sp = m_input_reader_stack.Top();
+      reader_sp = m_io_handler_stack.Top();
 
       if (reader2_sp && reader2_sp.get() == reader_sp.get()) {
-        m_input_reader_stack.Pop();
+        m_io_handler_stack.Pop();
         ++result;
-        reader_sp = m_input_reader_stack.Top();
+        reader_sp = m_io_handler_stack.Top();
       }
 
       if (reader_sp)


### PR DESCRIPTION
This was renamed in 7ce2de2ce4e7d4dd8e1e5a7a5b35c0f98e46681d.

Also fixed that RemoveIOHandlers is now returning uint32_t and not bool which was
caused when resolving a merge conflict it seems.