### PR TITLE
Swift: fix the GCC build (NFC)

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1118,6 +1118,7 @@ static void SplitDottedName(llvm::StringRef name,
 
 std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
   class SwiftTypeScavenger : public Language::TypeScavenger {
+    friend std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger();
   private:
     typedef SwiftASTContext::TypeOrDecl TypeOrDecl;
     typedef SwiftASTContext::TypesOrDecls TypesOrDecls;


### PR DESCRIPTION
This fixes an issue with the build with a GCC toolchain.  The class
although scoped to the function needs to be explicitly friended to
permit construction.