### PR TITLE
[lldb/CMake] Set LLVM_HOST_TRIPLE from TARGET_TRIPLE in standalone bu…

### DIFF
--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -116,6 +116,10 @@ if(TARGET clang)
   endif()
 endif()
 
+if (LLDB_BUILT_STANDALONE)
+  set(LLVM_HOST_TRIPLE ${TARGET_TRIPLE})
+endif()
+
 add_lldb_test_dependency(
   lit-cpuid
   llc


### PR DESCRIPTION
…ilds.

LLVMConfig doesn't export LLVM_HOST_TRIPLE, but it sets the
TARGET_TRIPLE based on this variable. So use that again for the compiler
invocations in the shell tests.

(cherry picked from commit 25cf941275edacd5199550fef638005f2ecfd35b)