### PR TITLE
[lldb] Update calls to SILModule::print to use SILOptions.

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1644,8 +1644,9 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   if (log) {
     std::string s;
     llvm::raw_string_ostream ss(s);
-    const bool verbose = false;
-    sil_module->print(ss, verbose, &parsed_expr->module);
+    swift::SILOptions silOpts;
+    silOpts.EmitVerboseSIL = false;
+    sil_module->print(ss, &parsed_expr->module, silOpts);
     ss.flush();
 
     log->Printf("SIL module before linking:");
@@ -1660,8 +1661,9 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   if (log) {
     std::string s;
     llvm::raw_string_ostream ss(s);
-    const bool verbose = false;
-    sil_module->print(ss, verbose, &parsed_expr->module);
+    swift::SILOptions silOpts;
+    silOpts.EmitVerboseSIL = false;
+    sil_module->print(ss, &parsed_expr->module, silOpts);
     ss.flush();
 
     log->Printf("Generated SIL module:");
@@ -1674,8 +1676,9 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   if (log) {
     std::string s;
     llvm::raw_string_ostream ss(s);
-    const bool verbose = false;
-    sil_module->print(ss, verbose, &parsed_expr->module);
+    swift::SILOptions silOpts;
+    silOpts.EmitVerboseSIL = false;
+    sil_module->print(ss, &parsed_expr->module, silOpts);
     ss.flush();
 
     log->Printf("SIL module after diagnostic passes:");


### PR DESCRIPTION
See also: https://github.com/apple/swift/pull/29239