### PR TITLE
[lldb/teststuie] Allow test to run on remote platforms.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
@@ -30,7 +30,8 @@ class TestSwiftDWARFImporter_Swift(lldbtest.TestBase):
         self.runCmd("settings set symbols.use-swift-dwarfimporter true")
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
-            self, 'break here', lldb.SBFileSpec('main.swift'))
+            self, 'break here', lldb.SBFileSpec('main.swift'),
+            extra_images = ['Library'])
 
         log = self.getBuildArtifact("types.log")
         self.runCmd('log enable lldb types -f "%s"' % log)


### PR DESCRIPTION
TestSwiftDWARFImporter-Swift.py was not registering its dylib with
the target.