### PR TITLE
update TestThreadStepOut.py to expect correct source line on arm64.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/functionalities/thread/step_out/TestThreadStepOut.py
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/thread/step_out/TestThreadStepOut.py
@@ -71,9 +71,9 @@ class ThreadStepOutTestCase(TestBase):
         self.bkpt_string = '// Set breakpoint here'
         self.breakpoint = line_number('main.cpp', self.bkpt_string)       
 
-        if "gcc" in self.getCompiler() or self.isIntelCompiler():
+        if "gcc" in self.getCompiler() or self.isIntelCompiler() or self.getArchitecture() in ['arm64', 'arm64e']:
             self.step_out_destination = line_number(
-                'main.cpp', '// Expect to stop here after step-out (icc and gcc)')
+                'main.cpp', '// Expect to stop here after step-out (icc and gcc; arm64)')
         else:
             self.step_out_destination = line_number(
                 'main.cpp', '// Expect to stop here after step-out (clang)')

--- a/lldb/packages/Python/lldbsuite/test/functionalities/thread/step_out/main.cpp
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/thread/step_out/main.cpp
@@ -30,7 +30,7 @@ thread_func ()
     step_out_of_here(); // Expect to stop here after step-out (clang)
 
     // Return
-    return NULL;  // Expect to stop here after step-out (icc and gcc)
+    return NULL;  // Expect to stop here after step-out (icc and gcc; arm64)
 }
 
 int main ()


### PR DESCRIPTION
Turns out you fixed this upstream, Jason. It just didn't propagate properly.