### PR TITLE
[llvm-cov] Fix lcov coverage report contains functions from other compilation units.

### DIFF
--- a/llvm/test/tools/llvm-cov/multiple-files.test
+++ b/llvm/test/tools/llvm-cov/multiple-files.test
@@ -1,6 +1,7 @@
 // RUN: llvm-profdata merge %S/Inputs/multiple-files.proftext -o %t.profdata
 // RUN: llvm-cov report %S/Inputs/multiple-files.covmapping -instr-profile %t.profdata | FileCheck %s -check-prefix=MANY_COMPONENTS
 // RUN: llvm-cov report %S/Inputs/multiple-files2.covmapping -instr-profile %t.profdata | FileCheck %s -check-prefix=ONE_COMPONENT
+// RUN: llvm-cov export %S/Inputs/multiple-files.covmapping -instr-profile %t.profdata -format=lcov | FileCheck %s -check-prefix=LCOV
 
 // MANY_COMPONENTS: Filename
 // MANY_COMPONENTS-NEXT: ---
@@ -13,3 +14,14 @@
 // ONE_COMPONENT-NEXT: ---
 // ONE_COMPONENT-NEXT: {{^}}cov.c
 // ONE_COMPONENT-NEXT: {{^}}cov.h
+
+// LCOV-LABEL: SF:{{.*}}a{{[/\\]}}f2.c
+// LCOV: FN:1,f2
+// No extra funcs
+// LCOV-NOT: FN:
+// LCOV-LABEL: SF:{{.*}}b{{[/\\]}}c{{[/\\]}}f4.c
+// LCOV: FN:1,f4
+// LCOV-LABEL: SF:{{.*}}b{{[/\\]}}f3.c
+// LCOV: FN:1,f3
+// LCOV-LABEL: SF:{{.*}}f1.c
+// LCOV: FN:1,f1

--- a/llvm/tools/llvm-cov/CoverageExporterLcov.cpp
+++ b/llvm/tools/llvm-cov/CoverageExporterLcov.cpp
@@ -82,7 +82,7 @@ void renderFile(raw_ostream &OS, const coverage::CoverageMapping &Coverage,
   OS << "SF:" << Filename << '\n';
 
   if (!ExportSummaryOnly) {
-    renderFunctions(OS, Coverage.getCoveredFunctions());
+    renderFunctions(OS, Coverage.getCoveredFunctions(Filename));
   }
   renderFunctionSummary(OS, FileReport);
 


### PR DESCRIPTION
Summary: Patch by Chuan Qiu (@eagleonhill).

Reviewers: Dor1s

Reviewed By: Dor1s

Subscribers: lebedev.ri, llvm-commits

Tags: #llvm

Differential Revision: https://reviews.llvm.org/D63571

llvm-svn: 364653
(cherry picked from commit 176b9f651685c52bce25e700a758bd33e6a5354d)