### PR TITLE
Revert "[lldb] Update calls to SILModule::print to use SILOptions."

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1644,9 +1644,8 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   if (log) {
     std::string s;
     llvm::raw_string_ostream ss(s);
-    swift::SILOptions silOpts;
-    silOpts.EmitVerboseSIL = false;
-    sil_module->print(ss, &parsed_expr->module, silOpts);
+    const bool verbose = false;
+    sil_module->print(ss, verbose, &parsed_expr->module);
     ss.flush();
 
     log->Printf("SIL module before linking:");
@@ -1661,9 +1660,8 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   if (log) {
     std::string s;
     llvm::raw_string_ostream ss(s);
-    swift::SILOptions silOpts;
-    silOpts.EmitVerboseSIL = false;
-    sil_module->print(ss, &parsed_expr->module, silOpts);
+    const bool verbose = false;
+    sil_module->print(ss, verbose, &parsed_expr->module);
     ss.flush();
 
     log->Printf("Generated SIL module:");
@@ -1676,9 +1674,8 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   if (log) {
     std::string s;
     llvm::raw_string_ostream ss(s);
-    swift::SILOptions silOpts;
-    silOpts.EmitVerboseSIL = false;
-    sil_module->print(ss, &parsed_expr->module, silOpts);
+    const bool verbose = false;
+    sil_module->print(ss, verbose, &parsed_expr->module);
     ss.flush();
 
     log->Printf("SIL module after diagnostic passes:");


### PR DESCRIPTION
Reverts apple/llvm-project#609

See https://github.com/apple/swift/pull/29350