### PR TITLE
[lldb] s/lldb/%lldb in two tests

### DIFF
--- a/lldb/test/Shell/ObjectFile/ELF/PT_LOAD-overlap-PT_TLS.yaml
+++ b/lldb/test/Shell/ObjectFile/ELF/PT_LOAD-overlap-PT_TLS.yaml
@@ -2,7 +2,7 @@
 
 # RUN: yaml2obj %s > %t
 # RUN: lldb-test object-file %t | FileCheck %s
-# RUN: lldb %t -o "image lookup -a 0x1000" -b | FileCheck --check-prefix=LOOKUP %s
+# RUN: %lldb %t -o "image lookup -a 0x1000" -b | FileCheck --check-prefix=LOOKUP %s
 
 # CHECK:        Index: 0
 # CHECK-NEXT:   ID: 0xffffffffffffffff

--- a/lldb/test/Shell/ObjectFile/ELF/PT_TLS-overlap-PT_LOAD.yaml
+++ b/lldb/test/Shell/ObjectFile/ELF/PT_TLS-overlap-PT_LOAD.yaml
@@ -2,7 +2,7 @@
 
 # RUN: yaml2obj %s > %t
 # RUN: lldb-test object-file %t | FileCheck %s
-# RUN: lldb %t -o "image lookup -a 0x1000" -b | FileCheck --check-prefix=LOOKUP %s
+# RUN: %lldb %t -o "image lookup -a 0x1000" -b | FileCheck --check-prefix=LOOKUP %s
 
 # CHECK:        Index: 0
 # CHECK-NEXT:   ID: 0xffffffffffffffff


### PR DESCRIPTION
%lldb is the proper substitution. Using "lldb" can cause us to execute
the system lldb instead of the one we are testing. This happens at least
in standalone builds.

(cherry picked from commit 889a4f55c9100d55f9c120b8408c16491d73c7b5)