### PR TITLE
[AArch64] Don't rename registers with pseudo defs in Ld/St opt.

### DIFF
--- a/llvm/test/CodeGen/AArch64/stp-opt-with-renaming.mir
+++ b/llvm/test/CodeGen/AArch64/stp-opt-with-renaming.mir
@@ -469,3 +469,36 @@ body:             |
     RET undef $lr
 
 ...
+# Make sure we do not rename if pseudo-defs. Noop pseudo instructions like KILL
+# may lead to a missing definition of the rename register.
+#
+# CHECK-LABEL: name: test14_pseudo
+# CHECK: bb.0:
+# CHECK-NEXT:    liveins: $w8, $fp, $w25
+# CHECK:         renamable $w8 = KILL killed renamable $w8, implicit-def $x8
+# CHECK-NEXT:    STURXi killed renamable $x8, $fp, -40 :: (store 8)
+# CHECK-NEXT:    $w8 = ORRWrs $wzr, killed $w25, 0, implicit-def $x8
+# CHECK-NEXT:    STURXi killed renamable $x8, $fp, -32 :: (store 8)
+# CHECK-NEXT:    RET undef $lr
+#
+name:            test14_pseudo
+alignment:       4
+tracksRegLiveness: true
+liveins:
+  - { reg: '$x0' }
+  - { reg: '$x1' }
+  - { reg: '$x8' }
+frameInfo:
+  maxAlignment:    1
+  maxCallFrameSize: 0
+machineFunctionInfo: {}
+body:             |
+  bb.0:
+    liveins: $w8, $fp, $w25
+
+    renamable $w8 = KILL killed renamable $w8, implicit-def $x8
+    STURXi killed renamable $x8, $fp, -40 :: (store 8)
+    $w8 = ORRWrs $wzr, killed $w25, 0, implicit-def $x8
+    STURXi killed renamable $x8, $fp, -32 :: (store 8)
+    RET undef $lr
+...


### PR DESCRIPTION
If the root def of for renaming is a noop-pseudo instruction like kill,
we would end up without a correct def for the renamed register, causing
miscompiles.

This patch conservatively bails out on any pseudo instruction.

This fixes https://bugs.chromium.org/p/chromium/issues/detail?id=1037912#c70

(Cherry-picked from 300997c41a00b705ca10264c15910dd8d691ab75)