### PR TITLE
[lldb/Reproducers] Don't instrument SBFileSpec::GetPath

### DIFF
--- a/lldb/source/API/SBFileSpec.cpp
+++ b/lldb/source/API/SBFileSpec.cpp
@@ -143,7 +143,7 @@ void SBFileSpec::SetDirectory(const char *directory) {
 }
 
 uint32_t SBFileSpec::GetPath(char *dst_path, size_t dst_len) const {
-  LLDB_RECORD_METHOD_CONST(uint32_t, SBFileSpec, GetPath, (char *, size_t),
+  LLDB_RECORD_DUMMY(uint32_t, SBFileSpec, GetPath, (char *, size_t),
                            dst_path, dst_len);
 
   uint32_t result = m_opaque_up->GetPath(dst_path, dst_len);


### PR DESCRIPTION
This method uses a char* and length as output arguments and the
reproducer instrumentation doesn't know how to deal with that (yet).

(cherry picked from commit 039d4b3aa20a8f36ad058f2b9692b73c6909c612)