### PR TITLE
[lldb/Utility] Don't forward directories to the file collector

### DIFF
--- a/lldb/include/lldb/Host/FileSystem.h
+++ b/lldb/include/lldb/Host/FileSystem.h
@@ -186,6 +186,7 @@ public:
   }
 
 private:
+  void AddFile(const llvm::Twine &file);
   static llvm::Optional<FileSystem> &InstanceImpl();
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> m_fs;
   FileCollector *m_collector;

--- a/lldb/source/Host/common/FileSystem.cpp
+++ b/lldb/source/Host/common/FileSystem.cpp
@@ -279,8 +279,7 @@ void FileSystem::Resolve(FileSpec &file_spec) {
 std::shared_ptr<DataBufferLLVM>
 FileSystem::CreateDataBuffer(const llvm::Twine &path, uint64_t size,
                              uint64_t offset) {
-  if (m_collector)
-    m_collector->AddFile(path);
+  AddFile(path);
 
   const bool is_volatile = !IsLocal(path);
   const ErrorOr<std::string> external_path = GetExternalPath(path);
@@ -417,8 +416,7 @@ static mode_t GetOpenMode(uint32_t permissions) {
 
 Status FileSystem::Open(File &File, const FileSpec &file_spec, uint32_t options,
                         uint32_t permissions, bool should_close_fd) {
-  if (m_collector)
-    m_collector->AddFile(file_spec);
+  AddFile(file_spec.GetPath());
 
   if (File.IsValid())
     File.Close();
@@ -468,4 +466,10 @@ ErrorOr<std::string> FileSystem::GetExternalPath(const llvm::Twine &path) {
 
 ErrorOr<std::string> FileSystem::GetExternalPath(const FileSpec &file_spec) {
   return GetExternalPath(file_spec.GetPath());
+}
+
+void FileSystem::AddFile(const llvm::Twine &file) {
+  if (m_collector && !llvm::sys::fs::is_directory(file)) {
+    m_collector->addFile(file);
+  }
 }


### PR DESCRIPTION
The VFS mapping writer assumes that all the paths it gets are files.
When passed a directory, it ends up as a file in the VFS mapping twice,
once as a file and once as a directory.

  {
    'type': 'file',
    'name': "Output",
    'external-contents': "/root/path/to/Output"
  },
  {
    'type': 'directory',
    'name': "Output",
    'contents': [ ... ]
  }

(cherry picked from commit 4c2b0a63661576c1849862bad3978050fc6a2ff7)