### PR TITLE
[lldb][NFC] Rename ClangASTContext references in Swift LLDB code

### DIFF
--- a/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
+++ b/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
@@ -3245,7 +3245,7 @@ void LLDBSwigPythonCallPythonLogOutputCallback(const char *str, void *baton);
 #define SWIGTYPE_p_std__shared_ptrT_lldb_private__VariableList_t swig_types[211]
 #define SWIGTYPE_p_std__shared_ptrT_lldb_private__Variable_t swig_types[212]
 #define SWIGTYPE_p_std__shared_ptrT_lldb_private__Watchpoint_t swig_types[213]
-#define SWIGTYPE_p_std__unique_ptrT_lldb_private__ClangASTContext_t swig_types[214]
+#define SWIGTYPE_p_std__unique_ptrT_lldb_private__TypeSystemClang_t swig_types[214]
 #define SWIGTYPE_p_std__unique_ptrT_lldb_private__ClangModulesDeclVendor_t swig_types[215]
 #define SWIGTYPE_p_std__unique_ptrT_lldb_private__ClangPersistentVariables_t swig_types[216]
 #define SWIGTYPE_p_std__unique_ptrT_lldb_private__DynamicCheckerFunctions_t swig_types[217]
@@ -85110,7 +85110,7 @@ static swig_type_info _swigt__p_std__shared_ptrT_lldb_private__Value_t = {"_p_st
 static swig_type_info _swigt__p_std__shared_ptrT_lldb_private__VariableList_t = {"_p_std__shared_ptrT_lldb_private__VariableList_t", "std::shared_ptr< lldb_private::VariableList > *|lldb::VariableListSP *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__shared_ptrT_lldb_private__Variable_t = {"_p_std__shared_ptrT_lldb_private__Variable_t", "lldb::VariableSP *|std::shared_ptr< lldb_private::Variable > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__shared_ptrT_lldb_private__Watchpoint_t = {"_p_std__shared_ptrT_lldb_private__Watchpoint_t", "lldb::WatchpointSP *|std::shared_ptr< lldb_private::Watchpoint > *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__unique_ptrT_lldb_private__ClangASTContext_t = {"_p_std__unique_ptrT_lldb_private__ClangASTContext_t", "lldb::ClangASTContextUP *|std::unique_ptr< lldb_private::ClangASTContext > *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_std__unique_ptrT_lldb_private__TypeSystemClang_t = {"_p_std__unique_ptrT_lldb_private__TypeSystemClang_t", "lldb::TypeSystemClangUP *|std::unique_ptr< lldb_private::TypeSystemClang > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__unique_ptrT_lldb_private__ClangModulesDeclVendor_t = {"_p_std__unique_ptrT_lldb_private__ClangModulesDeclVendor_t", "std::unique_ptr< lldb_private::ClangModulesDeclVendor > *|lldb::ClangModulesDeclVendorUP *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__unique_ptrT_lldb_private__ClangPersistentVariables_t = {"_p_std__unique_ptrT_lldb_private__ClangPersistentVariables_t", "std::unique_ptr< lldb_private::ClangPersistentVariables > *|lldb::ClangPersistentVariablesUP *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__unique_ptrT_lldb_private__DynamicCheckerFunctions_t = {"_p_std__unique_ptrT_lldb_private__DynamicCheckerFunctions_t", "lldb::DynamicCheckerFunctionsUP *|std::unique_ptr< lldb_private::DynamicCheckerFunctions > *", 0, 0, (void*)0, 0};
@@ -85368,7 +85368,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_std__shared_ptrT_lldb_private__VariableList_t,
   &_swigt__p_std__shared_ptrT_lldb_private__Variable_t,
   &_swigt__p_std__shared_ptrT_lldb_private__Watchpoint_t,
-  &_swigt__p_std__unique_ptrT_lldb_private__ClangASTContext_t,
+  &_swigt__p_std__unique_ptrT_lldb_private__TypeSystemClang_t,
   &_swigt__p_std__unique_ptrT_lldb_private__ClangModulesDeclVendor_t,
   &_swigt__p_std__unique_ptrT_lldb_private__ClangPersistentVariables_t,
   &_swigt__p_std__unique_ptrT_lldb_private__DynamicCheckerFunctions_t,
@@ -85626,7 +85626,7 @@ static swig_cast_info _swigc__p_std__shared_ptrT_lldb_private__Value_t[] = {  {&
 static swig_cast_info _swigc__p_std__shared_ptrT_lldb_private__VariableList_t[] = {  {&_swigt__p_std__shared_ptrT_lldb_private__VariableList_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__shared_ptrT_lldb_private__Variable_t[] = {  {&_swigt__p_std__shared_ptrT_lldb_private__Variable_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__shared_ptrT_lldb_private__Watchpoint_t[] = {  {&_swigt__p_std__shared_ptrT_lldb_private__Watchpoint_t, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_std__unique_ptrT_lldb_private__ClangASTContext_t[] = {  {&_swigt__p_std__unique_ptrT_lldb_private__ClangASTContext_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_std__unique_ptrT_lldb_private__TypeSystemClang_t[] = {  {&_swigt__p_std__unique_ptrT_lldb_private__TypeSystemClang_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__unique_ptrT_lldb_private__ClangModulesDeclVendor_t[] = {  {&_swigt__p_std__unique_ptrT_lldb_private__ClangModulesDeclVendor_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__unique_ptrT_lldb_private__ClangPersistentVariables_t[] = {  {&_swigt__p_std__unique_ptrT_lldb_private__ClangPersistentVariables_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__unique_ptrT_lldb_private__DynamicCheckerFunctions_t[] = {  {&_swigt__p_std__unique_ptrT_lldb_private__DynamicCheckerFunctions_t, 0, 0, 0},{0, 0, 0, 0}};
@@ -85884,7 +85884,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_std__shared_ptrT_lldb_private__VariableList_t,
   _swigc__p_std__shared_ptrT_lldb_private__Variable_t,
   _swigc__p_std__shared_ptrT_lldb_private__Watchpoint_t,
-  _swigc__p_std__unique_ptrT_lldb_private__ClangASTContext_t,
+  _swigc__p_std__unique_ptrT_lldb_private__TypeSystemClang_t,
   _swigc__p_std__unique_ptrT_lldb_private__ClangModulesDeclVendor_t,
   _swigc__p_std__unique_ptrT_lldb_private__ClangPersistentVariables_t,
   _swigc__p_std__unique_ptrT_lldb_private__DynamicCheckerFunctions_t,

--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -662,7 +662,7 @@ public:
                    const DataExtractor &data, lldb::offset_t data_offset,
                    size_t data_byte_size) override;
 
-  // TODO: Determine if these methods should move to ClangASTContext.
+  // TODO: Determine if these methods should move to TypeSystemClang.
 
   bool IsPointerOrReferenceType(void *type,
                                 CompilerType *pointee_type) override;

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -43,7 +43,7 @@
 #include "lldb/Core/ValueObjectList.h"
 #include "lldb/Core/ValueObjectVariable.h"
 #include "lldb/Host/Host.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/DeclVendor.h"
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Symbol/SymbolFile.h"
@@ -1892,7 +1892,7 @@ lldb::SBType SBTarget::FindFirstType(const char *typename_cstr) {
           if (vendor->FindDecls(const_typename, /*append*/ true,
                                 /*max_matches*/ 1, decls) > 0) {
             auto compiler_decl = decls.front();
-            auto *ctx = llvm::dyn_cast<ClangASTContext>(compiler_decl.GetTypeSystem());
+            auto *ctx = llvm::dyn_cast<TypeSystemClang>(compiler_decl.GetTypeSystem());
             if (ctx)
               if (CompilerType type =
                       ctx->GetTypeForDecl(compiler_decl.GetOpaqueDecl()))
@@ -1957,7 +1957,7 @@ lldb::SBTypeList SBTarget::FindTypes(const char *typename_cstr) {
           if (vendor->FindDecls(const_typename, /*append*/ true,
                                 /*max_matches*/ 1, decls) > 0) {
             for (auto decl : decls) {
-              auto *ctx = llvm::dyn_cast<ClangASTContext>(decl.GetTypeSystem());
+              auto *ctx = llvm::dyn_cast<TypeSystemClang>(decl.GetTypeSystem());
               if (ctx)
                 if (CompilerType type =
                         ctx->GetTypeForDecl(decl.GetOpaqueDecl()))

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -384,9 +384,9 @@ CompilerType ValueObject::MaybeCalculateCompleteType() {
   std::vector<clang::NamedDecl *> decls;
   CompilerType class_type;
   bool is_pointer_type = false;
-  if (ClangASTContext::IsObjCObjectPointerType(compiler_type, &class_type))
+  if (TypeSystemClang::IsObjCObjectPointerType(compiler_type, &class_type))
     is_pointer_type = true;
-  else if (ClangASTContext::IsObjCObjectOrInterfaceType(compiler_type))
+  else if (TypeSystemClang::IsObjCObjectOrInterfaceType(compiler_type))
     class_type = compiler_type;
   else
     return compiler_type;
@@ -421,7 +421,7 @@ CompilerType ValueObject::MaybeCalculateCompleteType() {
                                     compiler_decls) > 0 &&
           compiler_decls.size() > 0) {
         auto *ctx =
-            llvm::dyn_cast<ClangASTContext>(compiler_decls[0].GetTypeSystem());
+            llvm::dyn_cast<TypeSystemClang>(compiler_decls[0].GetTypeSystem());
         if (ctx) {
           CompilerType runtime_type =
               ctx->GetTypeForDecl(compiler_decls[0].GetOpaqueDecl());

--- a/lldb/source/Plugins/InstrumentationRuntime/SwiftRuntimeReporting/SwiftRuntimeReporting.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/SwiftRuntimeReporting/SwiftRuntimeReporting.cpp
@@ -12,7 +12,7 @@
 #include "lldb/Breakpoint/StoppointCallbackContext.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/Symbol.h"
 #include "lldb/Symbol/SymbolContext.h"
 #include "lldb/Symbol/Variable.h"
@@ -217,7 +217,7 @@ SwiftRuntimeReporting::RetrieveReportData(ExecutionContextRef exe_ctx_ref) {
     return StructuredData::ObjectSP();
 
   // Prepare the argument types: treat all of them as pointers
-  ClangASTContext *clang_ast_context = ClangASTContext::GetScratch(target);
+  TypeSystemClang *clang_ast_context = TypeSystemClang::GetScratch(target);
   ValueList args;
   Value input_value;
   input_value.SetCompilerType(

--- a/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
@@ -18,7 +18,7 @@
 #include "Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h"
 #include "lldb/Core/ValueObject.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
 #include "lldb/Target/Target.h"

--- a/lldb/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.cpp
+++ b/lldb/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.cpp
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ObjCRuntimeSyntheticProvider.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/DeclVendor.h"
 
 #include "lldb/lldb-public.h"
@@ -91,7 +91,7 @@ ObjCRuntimeSyntheticProvider::FrontEnd::GetChildAtIndex(size_t idx) {
           const bool can_create = true;
           if (decls.empty())
             break;
-          auto *ctx = llvm::dyn_cast<ClangASTContext>(decls[0].GetTypeSystem());
+          auto *ctx = llvm::dyn_cast<TypeSystemClang>(decls[0].GetTypeSystem());
           if (!ctx)
             break;
           CompilerType type = ctx->GetTypeForDecl(decls[0].GetOpaqueDecl());

--- a/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -14,7 +14,7 @@
 
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
@@ -140,8 +140,8 @@ SwiftArrayBridgedBufferHandler::SwiftArrayBridgedBufferHandler(
     ProcessSP process_sp, lldb::addr_t native_ptr)
     : SwiftArrayBufferHandler(), m_elem_type(), m_synth_array_sp(),
       m_frontend(nullptr) {
-  ClangASTContext *clang_ast_context =
-        ClangASTContext::GetScratch(process_sp->GetTarget());
+  TypeSystemClang *clang_ast_context =
+        TypeSystemClang::GetScratch(process_sp->GetTarget());
   if (!clang_ast_context)
     return;
   m_elem_type = clang_ast_context->GetBasicType(
@@ -290,8 +290,8 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
 
   if (!valobj.GetTargetSP())
     return nullptr;
-  ClangASTContext *clang_ast_context =
-      ClangASTContext::GetScratch(*valobj.GetTargetSP());
+  TypeSystemClang *clang_ast_context =
+      TypeSystemClang::GetScratch(*valobj.GetTargetSP());
   if (!clang_ast_context)
     return nullptr;
 

--- a/lldb/source/Plugins/Language/Swift/SwiftDictionary.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftDictionary.cpp
@@ -13,7 +13,7 @@
 #include "SwiftDictionary.h"
 
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -13,7 +13,7 @@
 #include "SwiftFormatters.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
 #include "lldb/DataFormatters/StringPrinter.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
 #include "lldb/Utility/DataBufferHeap.h"
@@ -316,8 +316,8 @@ bool lldb_private::formatters::swift::StringGuts_SummaryProvider(
     "native/shared strings already handled");
 
   if ((discriminator & 0xE0) == 0x40) { // 010xxxxx: Bridged
-    ClangASTContext *clang_ast_context =
-        ClangASTContext::GetScratch(process->GetTarget());
+    TypeSystemClang *clang_ast_context =
+        TypeSystemClang::GetScratch(process->GetTarget());
     if (!clang_ast_context)
       return false;
 

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -15,7 +15,7 @@
 #include "Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h"
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
@@ -324,8 +324,8 @@ HashedCollectionConfig::CocoaObjectAtAddress(
   ProcessSP process_sp = exe_ctx.GetProcessSP();
   if (!process_sp)
     return nullptr;
-  ClangASTContext *clang_ast_context =
-        ClangASTContext::GetScratch(process_sp->GetTarget());
+  TypeSystemClang *clang_ast_context =
+        TypeSystemClang::GetScratch(process_sp->GetTarget());
   if (!clang_ast_context)
     return nullptr;
   CompilerType id = clang_ast_context->GetBasicType(lldb::eBasicTypeObjCID);

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -21,7 +21,7 @@
 #include "lldb/DataFormatters/FormattersHelpers.h"
 #include "lldb/DataFormatters/StringPrinter.h"
 
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/Variable.h"
@@ -842,8 +842,8 @@ SwiftLanguage::GetHardcodedSynthetics() {
            FormatManager &format_manager) -> lldb::SyntheticChildrenSP {
           struct IsEligible {
             static bool Check(const CompilerType &type) {
-              if ((ClangASTContext::IsObjCObjectPointerType(type) ||
-                   ClangASTContext::IsObjCObjectOrInterfaceType(type)) &&
+              if ((TypeSystemClang::IsObjCObjectPointerType(type) ||
+                   TypeSystemClang::IsObjCObjectOrInterfaceType(type)) &&
                   SwiftLanguageRuntime::IsSwiftClassName(type.GetTypeName().GetCString()))
                 return true;
 

--- a/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
@@ -14,7 +14,7 @@
 
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Core/ValueObject.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/CompilerType.h"
 #include "lldb/Symbol/SwiftASTContext.h"
 
@@ -45,7 +45,7 @@ static clang::EnumDecl *GetAsEnumDecl(CompilerType swift_type) {
   if (!clang_type.IsValid())
     return nullptr;
 
-  if (!llvm::isa<ClangASTContext>(clang_type.GetTypeSystem()))
+  if (!llvm::isa<TypeSystemClang>(clang_type.GetTypeSystem()))
     return nullptr;
 
   auto qual_type =

--- a/lldb/source/Plugins/Language/Swift/SwiftSet.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftSet.cpp
@@ -13,7 +13,7 @@
 #include "SwiftSet.h"
 
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -480,7 +480,7 @@ bool AppleObjCRuntimeV2::GetDynamicTypeAndAddress(
             std::vector<CompilerDecl> decls;
             if (vendor->FindDecls(class_name, false, 1, decls) &&
                 decls.size()) {
-              auto *ctx = llvm::dyn_cast<ClangASTContext>(decls[0].GetTypeSystem());
+              auto *ctx = llvm::dyn_cast<TypeSystemClang>(decls[0].GetTypeSystem());
               if (ctx)
                 if (CompilerType type =
                         ctx->GetTypeForDecl(decls[0].GetOpaqueDecl()))

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -26,7 +26,7 @@
 #include "clang/AST/DeclObjC.h"
 
 #include "lldb/Core/Module.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/ObjectFile.h"
@@ -162,7 +162,7 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
       return nullptr;
     }
 
-    if (auto *clang_ctx = llvm::dyn_cast_or_null<ClangASTContext>(&*type_system_or_err)) {
+    if (auto *clang_ctx = llvm::dyn_cast_or_null<TypeSystemClang>(&*type_system_or_err)) {
       DWARFASTParserClang *clang_ast_parser =
           static_cast<DWARFASTParserClang *>(clang_ctx->GetDWARFParser());
       TypeMap clang_types;
@@ -290,7 +290,7 @@ void DWARFASTParserSwift::GetClangType(lldb_private::CompileUnit &comp_unit,
 
   // The Swift projection of all Clang type is a struct; search every kind.
   decl_context.back().kind = CompilerContextKind::AnyType;
-  LanguageSet clang_languages = ClangASTContext::GetSupportedLanguagesForTypes();
+  LanguageSet clang_languages = TypeSystemClang::GetSupportedLanguagesForTypes();
   // Search any modules referenced by DWARF.
   llvm::DenseSet<SymbolFile *> searched_symbol_files;
   sym_file.FindTypes(decl_context, clang_languages, searched_symbol_files,

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -101,7 +101,7 @@
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Host/StringConvert.h"
 #include "lldb/Host/XML.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangUtil.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/ObjectFile.h"
@@ -893,7 +893,7 @@ ConstString SwiftASTContext::GetPluginNameStatic() {
 }
 
 ConstString SwiftASTContext::GetPluginName() {
-  return ClangASTContext::GetPluginNameStatic();
+  return TypeSystemClang::GetPluginNameStatic();
 }
 
 uint32_t SwiftASTContext::GetPluginVersion() { return 1; }
@@ -3312,7 +3312,7 @@ public:
     llvm::DenseSet<SymbolFile *> searched_symbol_files;
     auto search = [&](Module &module) {
       module.FindTypes(decl_context,
-                       ClangASTContext::GetSupportedLanguagesForTypes(),
+                       TypeSystemClang::GetSupportedLanguagesForTypes(),
                        searched_symbol_files, clang_types);
     };
     if (Module *module = m_swift_ast_ctx.GetModule())
@@ -3370,7 +3370,7 @@ public:
       CompilerType compiler_type = clang_type_sp->GetFullCompilerType();
 
       // Filter our non-Clang types.
-      auto *type_system = llvm::dyn_cast_or_null<ClangASTContext>(
+      auto *type_system = llvm::dyn_cast_or_null<TypeSystemClang>(
           compiler_type.GetTypeSystem());
       if (!type_system)
         return true;
@@ -8067,7 +8067,7 @@ bool SwiftASTContext::IsImportedType(const CompilerType &type,
         if (const clang::ObjCInterfaceDecl *objc_interface_decl =
                 llvm::dyn_cast<clang::ObjCInterfaceDecl>(clang_decl)) {
           *original_type =
-              CompilerType(ClangASTContext::GetASTContext(
+              CompilerType(TypeSystemClang::GetASTContext(
                                &objc_interface_decl->getASTContext()),
                            clang::QualType::getFromOpaquePtr(
                                objc_interface_decl->getTypeForDecl())
@@ -8075,7 +8075,7 @@ bool SwiftASTContext::IsImportedType(const CompilerType &type,
         } else if (const clang::TypeDecl *type_decl =
                        llvm::dyn_cast<clang::TypeDecl>(clang_decl)) {
           *original_type = CompilerType(
-              ClangASTContext::GetASTContext(&type_decl->getASTContext()),
+              TypeSystemClang::GetASTContext(&type_decl->getASTContext()),
               clang::QualType::getFromOpaquePtr(type_decl->getTypeForDecl())
                   .getAsOpaquePtr());
         } else {
@@ -8098,7 +8098,7 @@ bool SwiftASTContext::IsImportedObjectiveCType(const CompilerType &type,
 
     if (IsImportedType(type, &local_original_type)) {
       if (local_original_type.IsValid()) {
-        ClangASTContext *clang_ast = llvm::dyn_cast_or_null<ClangASTContext>(
+        TypeSystemClang *clang_ast = llvm::dyn_cast_or_null<TypeSystemClang>(
             local_original_type.GetTypeSystem());
         if (clang_ast &&
             clang_ast->IsObjCObjectOrInterfaceType(local_original_type)) {

--- a/lldb/source/Symbol/TypeSystemClang.cpp
+++ b/lldb/source/Symbol/TypeSystemClang.cpp
@@ -721,7 +721,7 @@ TypeSystemClang *TypeSystemClang::GetASTContext(clang::ASTContext *ast) {
   TypeSystemClang *clang_ast = GetASTMap().Lookup(ast);
   if (!clang_ast)
     clang_ast = new TypeSystemClang(
-        "ASTContext from ClangASTContext::GetASTContext", *ast);
+        "ASTContext from TypeSystemClang::GetASTContext", *ast);
   return clang_ast;
 }
 

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -24,7 +24,7 @@
 #include "lldb/Interpreter/CommandObject.h"
 #include "lldb/Interpreter/CommandObjectMultiword.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/VariableList.h"
 #include "lldb/Target/RegisterContext.h"
@@ -963,7 +963,7 @@ void SwiftLanguageRuntime::FindFunctionPointersInCall(
                 ABISP abi_sp(frame.GetThread()->GetProcess()->GetABI());
                 ValueList argument_values;
                 Value input_value;
-                auto clang_ctx = ClangASTContext::GetScratch(target);
+                auto clang_ctx = TypeSystemClang::GetScratch(target);
                 if (!clang_ctx)
                   continue;
 

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -13,7 +13,7 @@
 #include "SwiftLanguageRuntimeImpl.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
 
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/Variable.h"
 #include "lldb/Symbol/VariableList.h"
@@ -252,8 +252,8 @@ const CompilerType &SwiftLanguageRuntimeImpl::GetBoxMetadataType() {
 
   static ConstString g_type_name("__lldb_autogen_boxmetadata");
   const bool is_packed = false;
-  if (ClangASTContext *ast_ctx =
-          ClangASTContext::GetScratch(m_process.GetTarget())) {
+  if (TypeSystemClang *ast_ctx =
+          TypeSystemClang::GetScratch(m_process.GetTarget())) {
     CompilerType voidstar =
         ast_ctx->GetBasicType(lldb::eBasicTypeVoid).GetPointerType();
     CompilerType uint32 = ast_ctx->GetIntTypeFromBitSize(32, false);
@@ -1545,7 +1545,7 @@ TypeAndOrName SwiftLanguageRuntimeImpl::FixUpDynamicType(
   CompilerType static_type = static_value.GetCompilerType();
   CompilerType dynamic_type = type_and_or_name.GetCompilerType();
   // The logic in this function only applies to static/dynamic Swift types.
-  if (llvm::isa<ClangASTContext>(static_type.GetTypeSystem()))
+  if (llvm::isa<TypeSystemClang>(static_type.GetTypeSystem()))
     return type_and_or_name;
 
   bool should_be_made_into_ref = false;


### PR DESCRIPTION
Upstream renamed ClangASTContext to TypeSystemClang so this
adapts the Swift-code that is referencing that class to also
use TypeSystemClang.