### PR TITLE
[20200108] [indexstore] Fix ABI of indexstore_unit_event_kind_t

### DIFF
--- a/clang/include/indexstore/indexstore.h
+++ b/clang/include/indexstore/indexstore.h
@@ -158,10 +158,10 @@ INDEXSTORE_PUBLIC bool
 indexstore_unit_event_notification_is_initial(indexstore_unit_event_notification_t);
 
 typedef enum {
-  INDEXSTORE_UNIT_EVENT_REMOVED = 1,
-  INDEXSTORE_UNIT_EVENT_MODIFIED = 2,
-  INDEXSTORE_UNIT_EVENT_DIRECTORY_DELETED = 3,
-  INDEXSTORE_UNIT_EVENT_FAILURE = 4,
+  INDEXSTORE_UNIT_EVENT_REMOVED = 2,
+  INDEXSTORE_UNIT_EVENT_MODIFIED = 3,
+  INDEXSTORE_UNIT_EVENT_DIRECTORY_DELETED = 4,
+  INDEXSTORE_UNIT_EVENT_FAILURE = 5,
 } indexstore_unit_event_kind_t;
 
 INDEXSTORE_PUBLIC indexstore_unit_event_kind_t


### PR DESCRIPTION
Preserve the original numeric constants so that it does not change
meaning across versions. This fixes a breakage introduced in 3dab785d525e.

rdar://58838243
(cherry picked from commit 821a6436ba5624c589ca42fe2edf6a94ff60fd71)