### PR TITLE
[lldb] s/lldb/%lldb in another test

### DIFF
--- a/lldb/test/Shell/SymbolFile/DWARF/debug_aranges-empty-section.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/debug_aranges-empty-section.s
@@ -3,7 +3,7 @@
 # REQUIRES: x86
 
 # RUN: llvm-mc %s -triple x86_64-pc-linux -filetype=obj >%t
-# RUN: lldb %t -o "breakpoint set -n f" -b | FileCheck %s
+# RUN: %lldb %t -o "breakpoint set -n f" -b | FileCheck %s
 
 # CHECK: Breakpoint 1: where = {{.*}}`f, address = 0x0000000000000047
 


### PR DESCRIPTION
As explained in Pavel's previous commit message: %lldb is the proper
substitution. Using "lldb" can cause us to execute the system lldb
instead of the one we are testing. This happens at least in standalone
builds.

(cherry picked from commit 794b8a0329d1356455970fe1ae26f5d3b38e7906)