### PR TITLE
🍒/6672a4f5b64f6b5a17cba63b421fcf313003b5b8

### DIFF
--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -589,6 +589,7 @@ enum CommandArgumentType {
   eArgTypeWatchType,
   eArgRawInput,
   eArgTypeCommand,
+  eArgTypeColumnNum,
   eArgTypeLastArg // Always keep this entry as the last entry in this
                   // enumeration!!
 };

--- a/lldb/lit/Settings/command-breakpoint-col.test
+++ b/lldb/lit/Settings/command-breakpoint-col.test
@@ -1,0 +1,5 @@
+# RUN: %clang_host -g -O0 %S/Inputs/main.c -o %t.out
+# RUN: %lldb -b -o 'help breakpoint set' -o 'breakpoint set -f main.c -l 2 -u 21' %t.out | FileCheck %s
+# CHECK: -u <column> ( --column <column> )
+# CHECK: Specifies the column number on which to set this breakpoint.
+# CHECK: at main.c:2:21

--- a/lldb/lit/Settings/command-breakpoint-col.test
+++ b/lldb/lit/Settings/command-breakpoint-col.test
@@ -1,3 +1,5 @@
+# UNSUPPORTED: system-windows
+#
 # RUN: %clang_host -g -O0 %S/Inputs/main.c -o %t.out
 # RUN: %lldb -b -o 'help breakpoint set' -o 'breakpoint set -f main.c -l 2 -u 21' %t.out | FileCheck %s
 # CHECK: -u <column> ( --column <column> )

--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -289,7 +289,7 @@ public:
         m_func_name_type_mask |= eFunctionNameTypeBase;
         break;
 
-      case 'C':
+      case 'u':
         if (option_arg.getAsInteger(0, m_column))
           error.SetErrorStringWithFormat("invalid column number: %s",
                                          option_arg.str().c_str());

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -113,6 +113,8 @@ let Command = "breakpoint set" in {
   def breakpoint_set_line : Option<"line", "l">, Group<1>, Arg<"LineNum">,
     Required,
     Desc<"Specifies the line number on which to set this breakpoint.">;
+  def breakpoint_set_column : Option<"column", "u">, Group<1>, Arg<"ColumnNum">,
+    Desc<"Specifies the column number on which to set this breakpoint.">;
   def breakpoint_set_address : Option<"address", "a">, Group<2>,
     Arg<"AddressOrExpression">, Required,
     Desc<"Set the breakpoint at the specified address.  If the address maps "

--- a/lldb/source/Interpreter/CommandObject.cpp
+++ b/lldb/source/Interpreter/CommandObject.cpp
@@ -1105,7 +1105,8 @@ CommandObject::ArgumentTableEntry CommandObject::g_arguments_data[] = {
     { eArgTypeWatchpointIDRange, "watchpt-id-list", CommandCompletions::eNoCompletion, { nullptr, false }, "For example, '1-3' or '1 to 3'." },
     { eArgTypeWatchType, "watch-type", CommandCompletions::eNoCompletion, { nullptr, false }, "Specify the type for a watchpoint." },
     { eArgRawInput, "raw-input", CommandCompletions::eNoCompletion, { nullptr, false }, "Free-form text passed to a command without prior interpretation, allowing spaces without requiring quotes.  To pass arguments and free form text put two dashes ' -- ' between the last argument and any raw input." },
-    { eArgTypeCommand, "command", CommandCompletions::eNoCompletion, { nullptr, false }, "An LLDB Command line command." }
+    { eArgTypeCommand, "command", CommandCompletions::eNoCompletion, { nullptr, false }, "An LLDB Command line command." },
+    { eArgTypeColumnNum, "column", CommandCompletions::eNoCompletion, { nullptr, false }, "Column number in a source file." }
     // clang-format on
 };
 


### PR DESCRIPTION
```
commit a8930d256d982f456f6d337efabfabfdfc2d705f
Author: Jonas Devlieghere <jonas@devlieghere.com>
Date:   Thu Jan 23 14:17:48 2020 -0800

    [lldb/Test] Disable command-breakpoint-col.test on Windows

    I guess PDB doesn't have column information?

    (cherry picked from commit d8acf8852dbfbe2d6f2e2fdb4fa0ec18a4194da3)

commit 2efadd4e3096aec614cef3aa7c43e480c1cc3023
Author: Jonas Devlieghere <jonas@devlieghere.com>
Date:   Thu Jan 23 11:25:16 2020 -0800

    [lldb/Commands] Fix, rename and document column number arg to breakpoint set.

    We were incorrectly parsing the -C argument to breakpoint set as the
    column breakpoint, even though according to the help this should be the
    breakpoint command. This fixes that by renaming the option to -u, adding
    it to help, and adding a test case.

    Differential revision: https://reviews.llvm.org/D73284

    (cherry picked from commit 6672a4f5b64f6b5a17cba63b421fcf313003b5b8)
```