### PR TITLE
[lldb/Test] Disallow using substituted binaries in shell test.

### DIFF
--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -9,6 +9,15 @@ from lit.llvm import llvm_config
 from lit.llvm.subst import FindTool
 from lit.llvm.subst import ToolSubst
 
+def _disallow(config, execName):
+  warning = '''
+    echo '*** Do not use \'{0}\' in tests; use \'%''{0}\'. ***' &&
+    exit 1 && echo
+  '''
+  config.substitutions.append((' {0} '.format(execName),
+                               warning.format(execName)))
+
+
 def use_lldb_substitutions(config):
     # Set up substitutions for primary tools.  These tools must come from config.lldb_tools_dir
     # which is basically the build output directory.  We do not want to find these in path or
@@ -52,6 +61,10 @@ def use_lldb_substitutions(config):
                   command="'" + sys.executable + "'",
                   extra_args=build_script_args)
         ]
+
+    _disallow(config, 'lldb')
+    _disallow(config, 'debugserver')
+    _disallow(config, 'platformserver')
 
     llvm_config.add_tool_substitutions(primary_tools,
                                        [config.lldb_tools_dir])
@@ -135,3 +148,5 @@ def use_support_substitutions(config):
                      'llvm-objcopy', 'lli']
     additional_tool_dirs += [config.lldb_tools_dir, config.llvm_tools_dir]
     llvm_config.add_tool_substitutions(support_tools, additional_tool_dirs)
+
+    _disallow(config, 'clang')


### PR DESCRIPTION
Explicitly disallow using lldb instead of %lldb in the shell tests. This
is a clever trick that is used by Swift to achieve the same results.

Differential revision: https://reviews.llvm.org/D73289

(cherry picked from commit 8d508c597aaf5b483f4430300eda22f4d235f2ba)