### PR TITLE
Clang added a new feature to the ObjC compiler that will translate me…

### DIFF
--- a/lldb/include/lldb/Target/ThreadPlan.h
+++ b/lldb/include/lldb/Target/ThreadPlan.h
@@ -461,8 +461,12 @@ public:
   virtual void WillPop();
 
   // This pushes a plan onto the plan stack of the current plan's thread.
+  // Also sets the plans to private and not master plans.  A plan pushed by 
+  // another thread plan is never either of the above.
   void PushPlan(lldb::ThreadPlanSP &thread_plan_sp) {
     m_thread.PushPlan(thread_plan_sp);
+    thread_plan_sp->SetPrivate(false);
+    thread_plan_sp->SetIsMasterPlan(false);
   }
 
   ThreadPlanKind GetKind() const { return m_kind; }

--- a/lldb/include/lldb/Target/ThreadPlanStepInRange.h
+++ b/lldb/include/lldb/Target/ThreadPlanStepInRange.h
@@ -49,6 +49,12 @@ public:
 
   bool IsVirtualStep() override;
 
+  // Plans that are implementing parts of a step in might need to follow the
+  // behavior of this plan w.r.t. StepThrough.  They can get that from here.
+  static uint32_t GetDefaultFlagsValue() {
+    return s_default_flag_values;
+  }
+
 protected:
   static bool DefaultShouldStopHereCallback(ThreadPlan *current_plan,
                                             Flags &flags,

--- a/lldb/packages/Python/lldbsuite/test/lang/objc/direct-dispatch-step/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/objc/direct-dispatch-step/Makefile
@@ -1,0 +1,4 @@
+OBJC_SOURCES := stepping-tests.m
+LD_EXTRAS := -lobjc -framework Foundation
+
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/objc/direct-dispatch-step/TestObjCDirectDispatchStepping.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/objc/direct-dispatch-step/TestObjCDirectDispatchStepping.py
@@ -1,0 +1,50 @@
+"""Test stepping through ObjC method dispatch in various forms."""
+
+from __future__ import print_function
+
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestObjCDirectDispatchStepping(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def setUp(self):
+        # Call super's setUp().
+        TestBase.setUp(self)
+        # Find the line numbers that we will step to in main:
+        self.main_source = lldb.SBFileSpec("stepping-tests.m")
+
+    @skipUnlessDarwin
+    @add_test_categories(['pyapi', 'basic_process'])
+    def test_with_python_api(self):
+        """Test stepping through the 'direct dispatch' optimized method calls."""
+        self.build()
+
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(self,
+                                                                            "Stop here to start stepping",
+                                                                            self.main_source)
+        stop_bkpt = target.BreakpointCreateBySourceRegex("// Stop Location [0-9]+", self.main_source)
+        self.assertEqual(stop_bkpt.GetNumLocations(), 15)
+                                                         
+        # Here we step through all the overridden methods of OverridesALot
+        # The last continue will get us to the call ot OverridesInit.
+        for idx in range(2,16):
+            thread.StepInto()
+            func_name = thread.GetFrameAtIndex(0).GetFunctionName()
+            self.assertTrue("OverridesALot" in func_name, "%d'th step did not match name: %s"%(idx, func_name))
+            stop_threads = lldbutil.continue_to_breakpoint(process, stop_bkpt)
+            self.assertEqual(len(stop_threads), 1)
+            self.assertEqual(stop_threads[0], thread)
+
+        thread.StepInto()
+        func_name = thread.GetFrameAtIndex(0).GetFunctionName()
+        self.assertEqual(func_name, "-[OverridesInit init]", "Stopped in [OverridesInit init]")
+        
+
+            

--- a/lldb/packages/Python/lldbsuite/test/lang/objc/direct-dispatch-step/stepping-tests.m
+++ b/lldb/packages/Python/lldbsuite/test/lang/objc/direct-dispatch-step/stepping-tests.m
@@ -1,0 +1,117 @@
+#import <Foundation/Foundation.h>
+
+@interface OverridesALot: NSObject
+
+- (void)boring;
+
+@end
+
+@implementation OverridesALot
+
++ (id)alloc {
+  NSLog(@"alloc");
+  return [super alloc];
+}
+
++ (id)allocWithZone: (NSZone *)z {
+  NSLog(@"allocWithZone:");
+  return [super allocWithZone: z];
+}
+
++ (id)new {
+  NSLog(@"new");
+  return [super new];
+}
+
+- (id)init {
+  NSLog(@"init");
+  return [super init];
+}
+
+- (id)self {
+  NSLog(@"self");
+  return [super self];
+}
+
++ (id)class {
+  NSLog(@"class");
+  return [super class];
+}
+
+- (BOOL)isKindOfClass: (Class)c {
+  NSLog(@"isKindOfClass:");
+  return [super isKindOfClass: c];
+}
+
+- (BOOL)respondsToSelector: (SEL)s {
+  NSLog(@"respondsToSelector:");
+  return [super respondsToSelector: s];
+}
+
+- (id)retain {
+  NSLog(@"retain");
+  return [super retain];
+}
+
+- (oneway void)release {
+  NSLog(@"release");
+  [super release];
+}
+
+- (id)autorelease { 
+  NSLog(@"autorelease");
+  return [super autorelease];
+}
+
+- (void)boring {
+  NSLog(@"boring");
+}
+
+@end
+
+@interface OverridesInit: NSObject
+
+- (void)boring;
+
+@end
+
+@implementation OverridesInit
+
+- (id)init {
+  NSLog(@"init");
+  return [super init];
+}
+
+@end
+
+int main() {
+  id obj;
+
+  // First make an object of the class that overrides everything,
+  // and make sure we step into all the methods:
+  
+  obj = [OverridesALot alloc]; // Stop here to start stepping
+  [obj release]; // Stop Location 2
+  
+  obj = [OverridesALot allocWithZone: NULL]; // Stop Location 3
+  [obj release]; // Stop Location 4
+  
+  obj = [OverridesALot new]; // Stop Location 5
+  [obj release]; // Stop Location 6
+  
+  obj = [[OverridesALot alloc] init]; // Stop Location 7
+  [obj self]; // Stop Location 8
+  [obj isKindOfClass: [OverridesALot class]]; // Stop Location 9
+  [obj respondsToSelector: @selector(hello)]; // Stop Location 10
+  [obj retain];  // Stop Location 11
+  [obj autorelease]; // Stop Location 12
+  [obj boring]; // Stop Location 13
+  [obj release]; // Stop Location 14
+
+  // Now try a class that only overrides init but not alloc, to make
+  // sure we get into the second method in a combined call:
+  
+  obj = [[OverridesInit alloc] init]; // Stop Location 15
+
+  return 0; // Stop Location 15
+}

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.h
@@ -47,6 +47,9 @@ public:
 
   lldb::addr_t SetupDispatchFunction(Thread &thread,
                                      ValueList &dispatch_values);
+  const DispatchFunction *FindDispatchFunction(lldb::addr_t addr);
+  void ForEachDispatchFunction(std::function<void(lldb::addr_t, 
+                                                  const DispatchFunction &)>);
 
 private:
   static const char *g_lookup_implementation_function_name;
@@ -136,11 +139,13 @@ private:
   };
 
   static const DispatchFunction g_dispatch_functions[];
+  static const char *g_opt_dispatch_names[];
 
-  typedef std::map<lldb::addr_t, int> MsgsendMap; // This table maps an dispatch
+  using MsgsendMap = std::map<lldb::addr_t, int>; // This table maps an dispatch
                                                   // fn address to the index in
                                                   // g_dispatch_functions
   MsgsendMap m_msgSend_map;
+  MsgsendMap m_opt_dispatch_map;
   lldb::ProcessWP m_process_wp;
   lldb::ModuleSP m_objc_module_sp;
   const char *m_lookup_implementation_function_code;

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleThreadPlanStepThroughObjCTrampoline.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleThreadPlanStepThroughObjCTrampoline.h
@@ -12,6 +12,9 @@
 #include "AppleObjCTrampolineHandler.h"
 #include "lldb/Core/Value.h"
 #include "lldb/Target/ThreadPlan.h"
+#include "lldb/Target/ThreadPlanStepInRange.h"
+#include "lldb/Target/ThreadPlanStepOut.h"
+#include "lldb/Target/ThreadPlanShouldStopHere.h"
 #include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-types.h"
 
@@ -20,7 +23,7 @@ namespace lldb_private {
 class AppleThreadPlanStepThroughObjCTrampoline : public ThreadPlan {
 public:
   AppleThreadPlanStepThroughObjCTrampoline(
-      Thread &thread, AppleObjCTrampolineHandler *trampoline_handler,
+      Thread &thread, AppleObjCTrampolineHandler &trampoline_handler,
       ValueList &values, lldb::addr_t isa_addr, lldb::addr_t sel_addr,
       bool stop_others);
 
@@ -52,23 +55,60 @@ protected:
 private:
   bool InitializeFunctionCaller();
 
-  AppleObjCTrampolineHandler *m_trampoline_handler; // FIXME - ensure this
-                                                    // doesn't go away on us?
-                                                    // SP maybe?
-  lldb::addr_t m_args_addr; // Stores the address for our step through function
-                            // result structure.
-  // lldb::addr_t m_object_addr;  // This is only for Description.
+  AppleObjCTrampolineHandler &m_trampoline_handler; /// The handler itself.
+  lldb::addr_t m_args_addr; /// Stores the address for our step through function
+                            /// result structure.
   ValueList m_input_values;
-  lldb::addr_t m_isa_addr; // isa_addr and sel_addr are the keys we will use to
-                           // cache the implementation.
+  lldb::addr_t m_isa_addr; /// isa_addr and sel_addr are the keys we will use to
+                           /// cache the implementation.
   lldb::addr_t m_sel_addr;
-  lldb::ThreadPlanSP m_func_sp; // This is the function call plan.  We fill it
-                                // at start, then set it
-  // to NULL when this plan is done.  That way we know to go to:
-  lldb::ThreadPlanSP m_run_to_sp;  // The plan that runs to the target.
-  FunctionCaller *m_impl_function; // This is a pointer to a impl function that
-  // is owned by the client that pushes this plan.
-  bool m_stop_others;
+  lldb::ThreadPlanSP m_func_sp; /// This is the function call plan.  We fill it
+                                /// at start, then set it to NULL when this plan
+                                /// is done.  That way we know to go on to:
+  lldb::ThreadPlanSP m_run_to_sp;  /// The plan that runs to the target.
+  FunctionCaller *m_impl_function; /// This is a pointer to a impl function that
+                                   /// is owned by the client that pushes this
+                                   /// plan.
+  bool m_stop_others;  /// Whether we should stop other threads.
+};
+
+class AppleThreadPlanStepThroughDirectDispatch: public ThreadPlanStepOut {
+public:
+  AppleThreadPlanStepThroughDirectDispatch(
+      Thread &thread, AppleObjCTrampolineHandler &handler,
+      llvm::StringRef dispatch_func_name, bool stop_others,
+      LazyBool step_in_avoids_code_without_debug_info);
+
+  ~AppleThreadPlanStepThroughDirectDispatch() override;
+
+  void GetDescription(Stream *s, lldb::DescriptionLevel level) override;
+
+  bool ShouldStop(Event *event_ptr) override;
+
+  bool StopOthers() override { return m_stop_others; }
+
+  bool MischiefManaged() override;
+
+  bool DoWillResume(lldb::StateType resume_state, bool current_plan) override;
+
+  void SetFlagsToDefault() override {
+          GetFlags().Set(ThreadPlanStepInRange::GetDefaultFlagsValue());
+  }
+
+protected:
+  bool DoPlanExplainsStop(Event *event_ptr) override;
+
+  AppleObjCTrampolineHandler &m_trampoline_handler;
+  std::string m_dispatch_func_name;  /// Which dispatch function we're stepping
+                                     /// through.
+  lldb::ThreadPlanSP m_objc_step_through_sp; /// When we hit an objc_msgSend,
+                                             /// we'll use this plan to get to
+                                             /// its target.
+  std::vector<lldb::BreakpointSP> m_msgSend_bkpts; /// Breakpoints on the objc
+                                                   /// dispatch functions.
+  bool m_at_msg_send;  /// Are we currently handling an msg_send
+  bool m_stop_others;  /// Whether we should stop other threads.
+
 };
 
 } // namespace lldb_private


### PR DESCRIPTION
…thod

calls to commonly un-overridden methods into a function that checks whether
the method is overridden anywhere and if not directly dispatches to the
NSObject implementation.

That means if you do override any of these methods, "step-in" will not step
into your code, since we hit the wrapper function, which has no debug info,
and immediately step out again.

Add code to recognize these functions as "trampolines" and a thread plan that
will get us from the function to the user code, if overridden.

<rdar://problem/54404114>

Differential Revision: https://reviews.llvm.org/D73225