### PR TITLE
[lldb][NFC] Rename ClangASTContext to TypeSystemClang

### DIFF
--- a/lldb/include/lldb/Symbol/ClangASTImporter.h
+++ b/lldb/include/lldb/Symbol/ClangASTImporter.h
@@ -48,11 +48,11 @@ public:
       : m_file_manager(clang::FileSystemOptions(),
                        FileSystem::Instance().GetVirtualFileSystem()) {}
 
-  CompilerType CopyType(ClangASTContext &dst, const CompilerType &src_type);
+  CompilerType CopyType(TypeSystemClang &dst, const CompilerType &src_type);
 
   clang::Decl *CopyDecl(clang::ASTContext *dst_ctx, clang::Decl *decl);
 
-  CompilerType DeportType(ClangASTContext &dst, const CompilerType &src_type);
+  CompilerType DeportType(TypeSystemClang &dst, const CompilerType &src_type);
 
   clang::Decl *DeportDecl(clang::ASTContext *dst_ctx, clang::Decl *decl);
 

--- a/lldb/include/lldb/Symbol/ClangExternalASTSourceCallbacks.h
+++ b/lldb/include/lldb/Symbol/ClangExternalASTSourceCallbacks.h
@@ -9,16 +9,16 @@
 #ifndef liblldb_ClangExternalASTSourceCallbacks_h_
 #define liblldb_ClangExternalASTSourceCallbacks_h_
 
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "clang/AST/ExternalASTSource.h"
 
 namespace lldb_private {
 
-class ClangASTContext;
+class TypeSystemClang;
 
 class ClangExternalASTSourceCallbacks : public clang::ExternalASTSource {
 public:
-  ClangExternalASTSourceCallbacks(ClangASTContext &ast) : m_ast(ast) {}
+  ClangExternalASTSourceCallbacks(TypeSystemClang &ast) : m_ast(ast) {}
 
   void FindExternalLexicalDecls(
       const clang::DeclContext *DC,
@@ -38,7 +38,7 @@ public:
           &VirtualBaseOffsets) override;
 
 private:
-  ClangASTContext &m_ast;
+  TypeSystemClang &m_ast;
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Symbol/CompilerDeclContext.h
+++ b/lldb/include/lldb/Symbol/CompilerDeclContext.h
@@ -38,7 +38,7 @@ public:
   /// This constructor should only be called from the respective TypeSystem
   /// implementation.
   ///
-  /// \see lldb_private::ClangASTContext::CreateDeclContext(clang::DeclContext*)
+  /// \see lldb_private::TypeSystemClang::CreateDeclContext(clang::DeclContext*)
   CompilerDeclContext(TypeSystem *type_system, void *decl_ctx)
       : m_type_system(type_system), m_opaque_decl_ctx(decl_ctx) {}
 

--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -37,7 +37,7 @@ public:
   /// This constructor should only be called from the respective TypeSystem
   /// implementation.
   ///
-  /// \see lldb_private::ClangASTContext::GetType(clang::QualType)
+  /// \see lldb_private::TypeSystemClang::GetType(clang::QualType)
   CompilerType(TypeSystem *type_system, lldb::opaque_compiler_type_t type)
       : m_type(type), m_type_system(type_system) {}
 

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -380,7 +380,7 @@ public:
                            lldb::offset_t data_offset,
                            size_t data_byte_size) = 0;
 
-  // TODO: Determine if these methods should move to ClangASTContext.
+  // TODO: Determine if these methods should move to TypeSystemClang.
 
   virtual bool IsPointerOrReferenceType(lldb::opaque_compiler_type_t type,
                                         CompilerType *pointee_type) = 0;

--- a/lldb/include/lldb/Symbol/TypeSystemClang.h
+++ b/lldb/include/lldb/Symbol/TypeSystemClang.h
@@ -1,4 +1,4 @@
-//===-- ClangASTContext.h ---------------------------------------*- C++ -*-===//
+//===-- TypeSystemClang.h ---------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef liblldb_ClangASTContext_h_
-#define liblldb_ClangASTContext_h_
+#ifndef liblldb_TypeSystemClang_h_
+#define liblldb_TypeSystemClang_h_
 
 #include <stdint.h>
 
@@ -42,7 +42,7 @@ namespace lldb_private {
 
 class Declaration;
 
-class ClangASTContext : public TypeSystem {
+class TypeSystemClang : public TypeSystem {
   // LLVM RTTI support
   static char ID;
 
@@ -55,21 +55,21 @@ public:
   bool isA(const void *ClassID) const override { return ClassID == &ID; }
   static bool classof(const TypeSystem *ts) { return ts->isA(&ID); }
 
-  /// Constructs a ClangASTContext with an ASTContext using the given triple.
+  /// Constructs a TypeSystemClang with an ASTContext using the given triple.
   ///
   /// \param triple The llvm::Triple used for the ASTContext. The triple defines
   ///               certain characteristics of the ASTContext and its types
   ///               (e.g., whether certain primitive types exist or what their
   ///               signedness is).
-  explicit ClangASTContext(llvm::Triple triple = llvm::Triple());
+  explicit TypeSystemClang(llvm::Triple triple = llvm::Triple());
 
-  /// Constructs a ClangASTContext that uses an existing ASTContext internally.
+  /// Constructs a TypeSystemClang that uses an existing ASTContext internally.
   /// Useful when having an existing ASTContext created by Clang.
   ///
   /// \param existing_ctxt An existing ASTContext.
-  explicit ClangASTContext(clang::ASTContext &existing_ctxt);
+  explicit TypeSystemClang(clang::ASTContext &existing_ctxt);
 
-  ~ClangASTContext() override;
+  ~TypeSystemClang() override;
 
   void Finalize() override;
 
@@ -90,18 +90,18 @@ public:
 
   static void Terminate();
 
-  static ClangASTContext *GetASTContext(clang::ASTContext *ast_ctx);
+  static TypeSystemClang *GetASTContext(clang::ASTContext *ast_ctx);
 
-  static ClangASTContext *GetScratch(Target &target,
+  static TypeSystemClang *GetScratch(Target &target,
                                      bool create_on_demand = true) {
     auto type_system_or_err = target.GetScratchTypeSystemForLanguage(
         lldb::eLanguageTypeC, create_on_demand);
     if (auto err = type_system_or_err.takeError()) {
       LLDB_LOG_ERROR(lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_TARGET),
-                     std::move(err), "Couldn't get scratch ClangASTContext");
+                     std::move(err), "Couldn't get scratch TypeSystemClang");
       return nullptr;
     }
-    return llvm::dyn_cast<ClangASTContext>(&type_system_or_err.get());
+    return llvm::dyn_cast<TypeSystemClang>(&type_system_or_err.get());
   }
 
   clang::ASTContext &getASTContext();
@@ -121,7 +121,7 @@ public:
       llvm::IntrusiveRefCntPtr<clang::ExternalASTSource> &ast_source_up);
 
   bool GetCompleteDecl(clang::Decl *decl) {
-    return ClangASTContext::GetCompleteDecl(&getASTContext(), decl);
+    return TypeSystemClang::GetCompleteDecl(&getASTContext(), decl);
   }
 
   static void DumpDeclHiearchy(clang::Decl *decl);
@@ -169,16 +169,16 @@ public:
                            bool ignore_qualifiers = false);
 
   /// Creates a CompilerType form the given QualType with the current
-  /// ClangASTContext instance as the CompilerType's typesystem.
+  /// TypeSystemClang instance as the CompilerType's typesystem.
   /// \param qt The QualType for a type that belongs to the ASTContext of this
-  ///           ClangASTContext.
+  ///           TypeSystemClang.
   /// \return The CompilerType representing the given QualType. If the
   ///         QualType's type pointer is a nullptr then the function returns an
   ///         invalid CompilerType.
   CompilerType GetType(clang::QualType qt) {
     if (qt.getTypePtrOrNull() == nullptr)
       return CompilerType();
-    // Check that the type actually belongs to this ClangASTContext.
+    // Check that the type actually belongs to this TypeSystemClang.
     assert(qt->getAsTagDecl() == nullptr ||
            &qt->getAsTagDecl()->getASTContext() == &getASTContext());
     return CompilerType(this, qt.getAsOpaquePtr());
@@ -319,7 +319,7 @@ public:
                                        int *assigned_accessibilities,
                                        size_t num_assigned_accessibilities);
 
-  // Returns a mask containing bits from the ClangASTContext::eTypeXXX
+  // Returns a mask containing bits from the TypeSystemClang::eTypeXXX
   // enumerations
 
   // Namespace Declarations
@@ -385,7 +385,7 @@ public:
   DWARFASTParser *GetDWARFParser() override;
   PDBASTParser *GetPDBParser() override;
 
-  // ClangASTContext callbacks for external source lookups.
+  // TypeSystemClang callbacks for external source lookups.
   void CompleteTagDecl(clang::TagDecl *);
 
   void CompleteObjCInterfaceDecl(clang::ObjCInterfaceDecl *);
@@ -417,9 +417,9 @@ public:
   // CompilerDeclContext override functions
 
   /// Creates a CompilerDeclContext from the given DeclContext
-  /// with the current ClangASTContext instance as its typesystem.
+  /// with the current TypeSystemClang instance as its typesystem.
   /// The DeclContext has to come from the ASTContext of this
-  /// ClangASTContext.
+  /// TypeSystemClang.
   CompilerDeclContext CreateDeclContext(clang::DeclContext *ctx);
 
   std::vector<CompilerDecl>
@@ -459,7 +459,7 @@ public:
                                                   const clang::Decl *object);
 
   static clang::ASTContext *
-  DeclContextGetClangASTContext(const CompilerDeclContext &dc);
+  DeclContextGetTypeSystemClang(const CompilerDeclContext &dc);
 
   // Tests
 
@@ -893,7 +893,7 @@ public:
   clang::ClassTemplateDecl *ParseClassTemplateDecl(
       clang::DeclContext *decl_ctx, lldb::AccessType access_type,
       const char *parent_name, int tag_decl_kind,
-      const ClangASTContext::TemplateParameterInfos &template_param_infos);
+      const TypeSystemClang::TemplateParameterInfos &template_param_infos);
 
   clang::BlockDecl *CreateBlockDeclaration(clang::DeclContext *ctx);
 
@@ -931,7 +931,7 @@ private:
   const clang::ClassTemplateSpecializationDecl *
   GetAsTemplateSpecialization(lldb::opaque_compiler_type_t type);
 
-  // Classes that inherit from ClangASTContext can see and modify these
+  // Classes that inherit from TypeSystemClang can see and modify these
   std::string m_target_triple;
   std::unique_ptr<clang::ASTContext> m_ast_up;
   std::unique_ptr<clang::LangOptions> m_language_options_up;
@@ -963,19 +963,19 @@ private:
   /// ASTContext wasn't created by parsing source code.
   clang::Sema *m_sema = nullptr;
 
-  // For ClangASTContext only
-  ClangASTContext(const ClangASTContext &);
-  const ClangASTContext &operator=(const ClangASTContext &);
+  // For TypeSystemClang only
+  TypeSystemClang(const TypeSystemClang &);
+  const TypeSystemClang &operator=(const TypeSystemClang &);
   /// Creates the internal ASTContext.
   void CreateASTContext();
   void SetTargetTriple(llvm::StringRef target_triple);
 };
 
-class ClangASTContextForExpressions : public ClangASTContext {
+class TypeSystemClangForExpressions : public TypeSystemClang {
 public:
-  ClangASTContextForExpressions(Target &target, llvm::Triple triple);
+  TypeSystemClangForExpressions(Target &target, llvm::Triple triple);
 
-  ~ClangASTContextForExpressions() override = default;
+  ~TypeSystemClangForExpressions() override = default;
 
   void Finalize() override;
 
@@ -1005,4 +1005,4 @@ private:
 
 } // namespace lldb_private
 
-#endif // liblldb_ClangASTContext_h_
+#endif // liblldb_TypeSystemClang_h_

--- a/lldb/include/lldb/lldb-forward.h
+++ b/lldb/include/lldb/lldb-forward.h
@@ -45,7 +45,7 @@ class BroadcastEventSpec;
 class Broadcaster;
 class BroadcasterManager;
 class CallFrameInfo;
-class ClangASTContext;
+class TypeSystemClang;
 class ClangASTImporter;
 class ClangASTMetadata;
 class ClangASTSource;
@@ -304,7 +304,7 @@ typedef std::shared_ptr<lldb_private::BreakpointResolver> BreakpointResolverSP;
 typedef std::shared_ptr<lldb_private::Broadcaster> BroadcasterSP;
 typedef std::shared_ptr<lldb_private::BroadcasterManager> BroadcasterManagerSP;
 typedef std::weak_ptr<lldb_private::BroadcasterManager> BroadcasterManagerWP;
-typedef std::unique_ptr<lldb_private::ClangASTContext> ClangASTContextUP;
+typedef std::unique_ptr<lldb_private::TypeSystemClang> TypeSystemClangUP;
 typedef std::shared_ptr<lldb_private::ClangASTImporter> ClangASTImporterSP;
 typedef std::unique_ptr<lldb_private::ClangModulesDeclVendor>
     ClangModulesDeclVendorUP;

--- a/lldb/packages/Python/lldbsuite/test/lang/c/enum_types/TestEnumTypes.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/c/enum_types/TestEnumTypes.py
@@ -40,7 +40,7 @@ class EnumTypesTestCase(TestBase):
         self.expect("fr var all", DATA_TYPES_DISPLAYED_CORRECTLY,
                     patterns=[' = ALL$'])
         # Test that an enum that doesn't match the heuristic we use in
-        # ClangASTContext::DumpEnumValue, gets printed as a raw integer.
+        # TypeSystemClang::DumpEnumValue, gets printed as a raw integer.
         self.expect("fr var omega", DATA_TYPES_DISPLAYED_CORRECTLY,
                     patterns=[' = 7$'])
         # Test the behavior in case have a variable of a type considered

--- a/lldb/source/API/SystemInitializerFull.cpp
+++ b/lldb/source/API/SystemInitializerFull.cpp
@@ -22,7 +22,7 @@
 #include "lldb/Host/Host.h"
 #include "lldb/Initialization/SystemInitializerCommon.h"
 #include "lldb/Interpreter/CommandInterpreter.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Utility/Timer.h"
 
 #include "Plugins/ABI/MacOSX-arm/ABIMacOSX_arm.h"
@@ -214,7 +214,7 @@ llvm::Error SystemInitializerFull::Initialize() {
   llvm::InitializeAllTargetMCs();
   llvm::InitializeAllDisassemblers();
 
-  ClangASTContext::Initialize();
+  TypeSystemClang::Initialize();
 
 #define LLVM_TARGET(t) LLDB_PROCESS_ ## t(Initialize)
 #include "llvm/Config/Targets.def"
@@ -312,7 +312,7 @@ void SystemInitializerFull::Terminate() {
   // Terminate and unload and loaded system or user LLDB plug-ins
   PluginManager::Terminate();
 
-  ClangASTContext::Terminate();
+  TypeSystemClang::Terminate();
 
   ArchitectureArm::Terminate();
   ArchitectureMips::Terminate();

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -25,7 +25,7 @@
 #include "lldb/DataFormatters/ValueObjectPrinter.h"
 #include "lldb/Expression/ExpressionVariable.h"
 #include "lldb/Host/Config.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/CompilerType.h"
 #include "lldb/Symbol/Declaration.h"
@@ -2019,7 +2019,7 @@ bool ValueObject::GetBaseClassPath(Stream &s) {
         GetParent() && GetParent()->GetBaseClassPath(s);
     CompilerType compiler_type = GetCompilerType();
     llvm::Optional<std::string> cxx_class_name =
-        ClangASTContext::GetCXXClassName(compiler_type);
+        TypeSystemClang::GetCXXClassName(compiler_type);
     if (cxx_class_name) {
       if (parent_had_base_class)
         s.PutCString("::");

--- a/lldb/source/Plugins/ABI/SysV-ppc64/ABISysV_ppc64.cpp
+++ b/lldb/source/Plugins/ABI/SysV-ppc64/ABISysV_ppc64.cpp
@@ -19,7 +19,7 @@
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/Core/ValueObjectMemory.h"
 #include "lldb/Core/ValueObjectRegister.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/UnwindPlan.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/RegisterContext.h"
@@ -806,10 +806,10 @@ private:
     // case 3: get from GPRs
 
     // first, check if this is a packed struct or not
-    ClangASTContext *ast =
-        llvm::dyn_cast<ClangASTContext>(m_type.GetTypeSystem());
+    TypeSystemClang *ast =
+        llvm::dyn_cast<TypeSystemClang>(m_type.GetTypeSystem());
     if (ast) {
-      clang::RecordDecl *record_decl = ClangASTContext::GetAsRecordDecl(m_type);
+      clang::RecordDecl *record_decl = TypeSystemClang::GetAsRecordDecl(m_type);
 
       if (record_decl) {
         auto attrs = record_decl->attrs();

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -16,7 +16,7 @@
 #include "lldb/Core/Section.h"
 #include "lldb/Expression/DiagnosticManager.h"
 #include "lldb/Host/FileSystem.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Target/ABI.h"
@@ -1072,8 +1072,8 @@ DynamicLoaderDarwin::GetThreadLocalData(const lldb::ModuleSP module_sp,
         }
         StackFrameSP frame_sp = thread_sp->GetStackFrameAtIndex(0);
         if (frame_sp) {
-          ClangASTContext *clang_ast_context =
-              ClangASTContext::GetScratch(target);
+          TypeSystemClang *clang_ast_context =
+              TypeSystemClang::GetScratch(target);
 
           if (!clang_ast_context)
             return LLDB_INVALID_ADDRESS;

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.cpp
@@ -11,7 +11,7 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/Section.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Symbol/SymbolVendor.h"
 #include "lldb/Target/ABI.h"
@@ -222,8 +222,8 @@ bool DynamicLoaderMacOS::NotifyBreakpointHit(void *baton,
     // Build up the value array to store the three arguments given above, then
     // get the values from the ABI:
 
-    ClangASTContext *clang_ast_context =
-        ClangASTContext::GetScratch(process->GetTarget());
+    TypeSystemClang *clang_ast_context =
+        TypeSystemClang::GetScratch(process->GetTarget());
     if (!clang_ast_context)
       return false;
 

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOSXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOSXDYLD.cpp
@@ -12,7 +12,7 @@
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/Section.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Target/ABI.h"
@@ -341,8 +341,8 @@ bool DynamicLoaderMacOSXDYLD::NotifyBreakpointHit(
     // Build up the value array to store the three arguments given above, then
     // get the values from the ABI:
 
-    ClangASTContext *clang_ast_context =
-        ClangASTContext::GetScratch(process->GetTarget());
+    TypeSystemClang *clang_ast_context =
+        TypeSystemClang::GetScratch(process->GetTarget());
     if (!clang_ast_context)
       return false;
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ASTResultSynthesizer.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ASTResultSynthesizer.cpp
@@ -10,7 +10,7 @@
 
 #include "ClangPersistentVariables.h"
 
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangASTImporter.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/LLDBAssert.h"
@@ -450,7 +450,7 @@ void ASTResultSynthesizer::CommitPersistentDecls() {
   PersistentExpressionState *state =
       m_target.GetPersistentExpressionStateForLanguage(lldb::eLanguageTypeC);
   auto *persistent_vars = llvm::cast<ClangPersistentVariables>(state);
-  ClangASTContext *scratch_ctx = ClangASTContext::GetScratch(m_target);
+  TypeSystemClang *scratch_ctx = TypeSystemClang::GetScratch(m_target);
 
   for (clang::NamedDecl *decl : m_decls) {
     StringRef name = decl->getName();

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
@@ -13,7 +13,7 @@
 
 #include "lldb/Core/Module.h"
 #include "lldb/Core/ModuleList.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangUtil.h"
 #include "lldb/Symbol/CompilerDeclContext.h"
 #include "lldb/Symbol/Function.h"
@@ -56,7 +56,7 @@ ClangASTSource::ClangASTSource(const lldb::TargetSP &target,
   m_ast_importer_sp = importer;
 }
 
-void ClangASTSource::InstallASTContext(ClangASTContext &clang_ast_context) {
+void ClangASTSource::InstallASTContext(TypeSystemClang &clang_ast_context) {
   m_ast_context = &clang_ast_context.getASTContext();
   m_clang_ast_context = &clang_ast_context;
   m_file_manager = &m_ast_context->getSourceManager().getFileManager();
@@ -73,9 +73,9 @@ ClangASTSource::~ClangASTSource() {
     return;
   // We are in the process of destruction, don't create clang ast context on
   // demand by passing false to
-  // Target::GetScratchClangASTContext(create_on_demand).
-  ClangASTContext *scratch_clang_ast_context =
-      ClangASTContext::GetScratch(*m_target, false);
+  // Target::GetScratchTypeSystemClang(create_on_demand).
+  TypeSystemClang *scratch_clang_ast_context =
+      TypeSystemClang::GetScratch(*m_target, false);
 
   if (!scratch_clang_ast_context)
     return;
@@ -319,7 +319,7 @@ void ClangASTSource::CompleteType(TagDecl *tag_decl) {
         // We have found a type by basename and we need to make sure the decl
         // contexts are the same before we can try to complete this type with
         // another
-        if (!ClangASTContext::DeclsAreEquivalent(tag_decl, candidate_tag_decl))
+        if (!TypeSystemClang::DeclsAreEquivalent(tag_decl, candidate_tag_decl))
           continue;
 
         if (m_ast_importer_sp->CompleteTagDeclWithOrigin(tag_decl,
@@ -965,7 +965,7 @@ bool ClangASTSource::FindObjCMethodDeclsWithOrigin(
 
   llvm::SmallVector<NamedDecl *, 1> methods;
 
-  ClangASTContext::GetCompleteDecl(original_ctx, original_interface_decl);
+  TypeSystemClang::GetCompleteDecl(original_ctx, original_interface_decl);
 
   if (ObjCMethodDecl *instance_method_decl =
           original_interface_decl->lookupInstanceMethod(original_selector)) {
@@ -1162,7 +1162,7 @@ void ClangASTSource::FindObjCMethodDecls(NameSearchContext &context) {
         continue;
 
       ObjCMethodDecl *method_decl =
-          ClangASTContext::DeclContextGetAsObjCMethodDecl(function_decl_ctx);
+          TypeSystemClang::DeclContextGetAsObjCMethodDecl(function_decl_ctx);
 
       if (!method_decl)
         continue;
@@ -1594,7 +1594,7 @@ bool ClangASTSource::layoutRecordType(const RecordDecl *record, uint64_t &size,
   BaseOffsetMap origin_base_offsets;
   BaseOffsetMap origin_virtual_base_offsets;
 
-  ClangASTContext::GetCompleteDecl(
+  TypeSystemClang::GetCompleteDecl(
       &origin_record->getASTContext(),
       const_cast<RecordDecl *>(origin_record.decl));
 
@@ -1790,11 +1790,11 @@ NamespaceDecl *ClangASTSource::AddNamespace(
   const CompilerDeclContext &namespace_decl = namespace_decls->begin()->second;
 
   clang::ASTContext *src_ast =
-      ClangASTContext::DeclContextGetClangASTContext(namespace_decl);
+      TypeSystemClang::DeclContextGetTypeSystemClang(namespace_decl);
   if (!src_ast)
     return nullptr;
   clang::NamespaceDecl *src_namespace_decl =
-      ClangASTContext::DeclContextGetAsNamespaceDecl(namespace_decl);
+      TypeSystemClang::DeclContextGetAsNamespaceDecl(namespace_decl);
 
   if (!src_namespace_decl)
     return nullptr;
@@ -1836,8 +1836,8 @@ ClangASTImporter::DeclOrigin ClangASTSource::GetDeclOrigin(const clang::Decl *de
 }
 
 CompilerType ClangASTSource::GuardedCopyType(const CompilerType &src_type) {
-  ClangASTContext *src_ast =
-      llvm::dyn_cast_or_null<ClangASTContext>(src_type.GetTypeSystem());
+  TypeSystemClang *src_ast =
+      llvm::dyn_cast_or_null<TypeSystemClang>(src_type.GetTypeSystem());
   if (src_ast == nullptr)
     return CompilerType();
 
@@ -1870,8 +1870,8 @@ clang::NamedDecl *NameSearchContext::AddVarDecl(const CompilerType &type) {
   if (!type.IsValid())
     return nullptr;
 
-  ClangASTContext *lldb_ast =
-      llvm::dyn_cast<ClangASTContext>(type.GetTypeSystem());
+  TypeSystemClang *lldb_ast =
+      llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
   if (!lldb_ast)
     return nullptr;
 
@@ -1897,8 +1897,8 @@ clang::NamedDecl *NameSearchContext::AddFunDecl(const CompilerType &type,
   if (m_function_types.count(type))
     return nullptr;
 
-  ClangASTContext *lldb_ast =
-      llvm::dyn_cast<ClangASTContext>(type.GetTypeSystem());
+  TypeSystemClang *lldb_ast =
+      llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
   if (!lldb_ast)
     return nullptr;
 
@@ -1968,8 +1968,8 @@ clang::NamedDecl *NameSearchContext::AddFunDecl(const CompilerType &type,
   // will crash in clang.
   clang::OverloadedOperatorKind op_kind = clang::NUM_OVERLOADED_OPERATORS;
   if (func_proto_type &&
-      ClangASTContext::IsOperator(decl_name.getAsString().c_str(), op_kind)) {
-    if (!ClangASTContext::CheckOverloadedOperatorKindParameterCount(
+      TypeSystemClang::IsOperator(decl_name.getAsString().c_str(), op_kind)) {
+    if (!TypeSystemClang::CheckOverloadedOperatorKindParameterCount(
             false, op_kind, func_proto_type->getNumParams()))
       return nullptr;
   }

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.h
@@ -60,7 +60,7 @@ public:
   }
   void MaterializeVisibleDecls(const clang::DeclContext *DC) { return; }
 
-  void InstallASTContext(ClangASTContext &ast_context);
+  void InstallASTContext(TypeSystemClang &ast_context);
 
   //
   // APIs for ExternalASTSource
@@ -307,7 +307,7 @@ protected:
   ///     is the containing object.
   void FindObjCPropertyAndIvarDecls(NameSearchContext &context);
 
-  /// A wrapper for ClangASTContext::CopyType that sets a flag that
+  /// A wrapper for TypeSystemClang::CopyType that sets a flag that
   /// indicates that we should not respond to queries during import.
   ///
   /// \param[in] src_type
@@ -370,8 +370,8 @@ protected:
   const lldb::TargetSP m_target;
   /// The AST context requests are coming in for.
   clang::ASTContext *m_ast_context;
-  /// The ClangASTContext for m_ast_context.
-  ClangASTContext *m_clang_ast_context;
+  /// The TypeSystemClang for m_ast_context.
+  TypeSystemClang *m_clang_ast_context;
   /// The file manager paired with the AST context.
   clang::FileManager *m_file_manager;
   /// The target's AST importer.

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangDeclVendor.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangDeclVendor.cpp
@@ -8,7 +8,7 @@
 
 #include "Plugins/ExpressionParser/Clang/ClangDeclVendor.h"
 
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Utility/ConstString.h"
 
 using namespace lldb_private;

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
@@ -18,7 +18,7 @@
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/Core/ValueObjectVariable.h"
 #include "lldb/Expression/Materializer.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangUtil.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/CompilerDecl.h"
@@ -109,7 +109,7 @@ bool ClangExpressionDeclMap::WillParse(ExecutionContext &exe_ctx,
     m_parser_vars->m_persistent_vars = llvm::cast<ClangPersistentVariables>(
         target->GetPersistentExpressionStateForLanguage(eLanguageTypeC));
 
-    if (!ClangASTContext::GetScratch(*target))
+    if (!TypeSystemClang::GetScratch(*target))
       return false;
   }
 
@@ -174,10 +174,10 @@ ClangExpressionDeclMap::TargetInfo ClangExpressionDeclMap::GetTargetInfo() {
   return ret;
 }
 
-TypeFromUser ClangExpressionDeclMap::DeportType(ClangASTContext &target,
-                                                ClangASTContext &source,
+TypeFromUser ClangExpressionDeclMap::DeportType(TypeSystemClang &target,
+                                                TypeSystemClang &source,
                                                 TypeFromParser parser_type) {
-  assert(&target == ClangASTContext::GetScratch(*m_target));
+  assert(&target == TypeSystemClang::GetScratch(*m_target));
   assert((TypeSystem *)&source == parser_type.GetTypeSystem());
   assert(&source.getASTContext() == m_ast_context);
 
@@ -196,8 +196,8 @@ bool ClangExpressionDeclMap::AddPersistentVariable(const NamedDecl *decl,
                                                    bool is_lvalue) {
   assert(m_parser_vars.get());
 
-  ClangASTContext *ast =
-      llvm::dyn_cast_or_null<ClangASTContext>(parser_type.GetTypeSystem());
+  TypeSystemClang *ast =
+      llvm::dyn_cast_or_null<TypeSystemClang>(parser_type.GetTypeSystem());
   if (ast == nullptr)
     return false;
 
@@ -209,7 +209,7 @@ bool ClangExpressionDeclMap::AddPersistentVariable(const NamedDecl *decl,
     if (target == nullptr)
       return false;
 
-    auto *clang_ast_context = ClangASTContext::GetScratch(*target);
+    auto *clang_ast_context = TypeSystemClang::GetScratch(*target);
     if (!clang_ast_context)
       return false;
 
@@ -248,7 +248,7 @@ bool ClangExpressionDeclMap::AddPersistentVariable(const NamedDecl *decl,
   if (target == nullptr)
     return false;
 
-  ClangASTContext *context = ClangASTContext::GetScratch(*target);
+  TypeSystemClang *context = TypeSystemClang::GetScratch(*target);
   if (!context)
     return false;
 
@@ -610,7 +610,7 @@ lldb::VariableSP ClangExpressionDeclMap::FindGlobalVariable(
   return vars.GetVariableAtIndex(0);
 }
 
-ClangASTContext *ClangExpressionDeclMap::GetClangASTContext() {
+TypeSystemClang *ClangExpressionDeclMap::GetTypeSystemClang() {
   StackFrame *frame = m_parser_vars->m_exe_ctx.GetFramePtr();
   if (frame == nullptr)
     return nullptr;
@@ -624,7 +624,7 @@ ClangASTContext *ClangExpressionDeclMap::GetClangASTContext() {
   if (!frame_decl_context)
     return nullptr;
 
-  return llvm::dyn_cast_or_null<ClangASTContext>(
+  return llvm::dyn_cast_or_null<TypeSystemClang>(
       frame_decl_context.GetTypeSystem());
 }
 
@@ -731,7 +731,7 @@ clang::NamedDecl *ClangExpressionDeclMap::GetPersistentDecl(ConstString name) {
   if (!target)
     return nullptr;
 
-  ClangASTContext::GetScratch(*target);
+  TypeSystemClang::GetScratch(*target);
 
   return m_parser_vars->m_persistent_vars->GetPersistentDecl(name);
 }
@@ -809,7 +809,7 @@ void ClangExpressionDeclMap::LookUpLldbClass(NameSearchContext &context,
     return;
 
   clang::CXXMethodDecl *method_decl =
-      ClangASTContext::DeclContextGetAsCXXMethodDecl(function_decl_ctx);
+      TypeSystemClang::DeclContextGetAsCXXMethodDecl(function_decl_ctx);
 
   if (method_decl) {
     clang::CXXRecordDecl *class_decl = method_decl->getParent();
@@ -910,7 +910,7 @@ void ClangExpressionDeclMap::LookUpLldbObjCClass(NameSearchContext &context,
     return;
 
   clang::ObjCMethodDecl *method_decl =
-      ClangASTContext::DeclContextGetAsObjCMethodDecl(function_decl_ctx);
+      TypeSystemClang::DeclContextGetAsObjCMethodDecl(function_decl_ctx);
 
   if (method_decl) {
     ObjCInterfaceDecl *self_interface = method_decl->getClassInterface();
@@ -979,10 +979,10 @@ void ClangExpressionDeclMap::LookUpLldbObjCClass(NameSearchContext &context,
 
   CompilerType self_clang_type = self_type->GetFullCompilerType();
 
-  if (ClangASTContext::IsObjCClassType(self_clang_type)) {
+  if (TypeSystemClang::IsObjCClassType(self_clang_type)) {
     return;
   }
-  if (!ClangASTContext::IsObjCObjectPointerType(self_clang_type))
+  if (!TypeSystemClang::IsObjCObjectPointerType(self_clang_type))
     return;
   self_clang_type = self_clang_type.GetPointeeType();
 
@@ -1010,7 +1010,7 @@ void ClangExpressionDeclMap::LookupLocalVarNamespace(
   if (!frame_decl_context)
     return;
 
-  ClangASTContext *frame_ast = llvm::dyn_cast_or_null<ClangASTContext>(
+  TypeSystemClang *frame_ast = llvm::dyn_cast_or_null<TypeSystemClang>(
       frame_decl_context.GetTypeSystem());
   if (!frame_ast)
     return;
@@ -1143,7 +1143,7 @@ SymbolContextList ClangExpressionDeclMap::SearchFunctionsInSymbolContexts(
   decl_infos.reserve(num_indices);
   clang::DeclContext *frame_decl_ctx =
       (clang::DeclContext *)frame_decl_context.GetOpaqueDeclContext();
-  ClangASTContext *ast = llvm::dyn_cast_or_null<ClangASTContext>(
+  TypeSystemClang *ast = llvm::dyn_cast_or_null<TypeSystemClang>(
       frame_decl_context.GetTypeSystem());
 
   for (uint32_t index = 0; index < num_indices; ++index) {
@@ -1494,7 +1494,7 @@ bool ClangExpressionDeclMap::GetVariableValue(VariableSP &var,
     return false;
   }
 
-  ClangASTContext *clang_ast = llvm::dyn_cast_or_null<ClangASTContext>(
+  TypeSystemClang *clang_ast = llvm::dyn_cast_or_null<TypeSystemClang>(
       var_type->GetForwardCompilerType().GetTypeSystem());
 
   if (!clang_ast) {
@@ -1666,7 +1666,7 @@ void ClangExpressionDeclMap::AddOneGenericVariable(NameSearchContext &context,
   if (target == nullptr)
     return;
 
-  ClangASTContext *scratch_ast_context = ClangASTContext::GetScratch(*target);
+  TypeSystemClang *scratch_ast_context = TypeSystemClang::GetScratch(*target);
   if (!scratch_ast_context)
     return;
 
@@ -1775,7 +1775,7 @@ void ClangExpressionDeclMap::AddOneFunction(NameSearchContext &context,
 
     if (!extern_c) {
       TypeSystem *type_system = function->GetDeclContext().GetTypeSystem();
-      if (llvm::isa<ClangASTContext>(type_system)) {
+      if (llvm::isa<TypeSystemClang>(type_system)) {
         clang::DeclContext *src_decl_context =
             (clang::DeclContext *)function->GetDeclContext()
                 .GetOpaqueDeclContext();

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.h
@@ -641,18 +641,18 @@ private:
   /// export all components of the type also.
   ///
   /// \param[in] target
-  ///     The ClangASTContext to move to.
+  ///     The TypeSystemClang to move to.
   /// \param[in] source
-  ///     The ClangASTContext to move from.  This is assumed to be going away.
+  ///     The TypeSystemClang to move from.  This is assumed to be going away.
   /// \param[in] parser_type
   ///     The type as it appears in the source context.
   ///
   /// \return
   ///     Returns the moved type, or an empty type if there was a problem.
-  TypeFromUser DeportType(ClangASTContext &target, ClangASTContext &source,
+  TypeFromUser DeportType(TypeSystemClang &target, TypeSystemClang &source,
                           TypeFromParser parser_type);
 
-  ClangASTContext *GetClangASTContext();
+  TypeSystemClang *GetTypeSystemClang();
 };
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -75,7 +75,7 @@
 #include "lldb/Expression/IRInterpreter.h"
 #include "lldb/Host/File.h"
 #include "lldb/Host/HostInfo.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/SymbolVendor.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/Language.h"
@@ -605,7 +605,7 @@ ClangExpressionParser::ClangExpressionParser(
   m_compiler->createASTContext();
   clang::ASTContext &ast_context = m_compiler->getASTContext();
 
-  m_ast_context.reset(new ClangASTContext(ast_context));
+  m_ast_context.reset(new TypeSystemClang(ast_context));
 
   std::string module_name("$__lldb_module");
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.h
@@ -171,7 +171,7 @@ private:
   class LLDBPreprocessorCallbacks;
   LLDBPreprocessorCallbacks *m_pp_callbacks; ///< Called when the preprocessor
                                              ///encounters module imports
-  std::unique_ptr<ClangASTContext> m_ast_context;
+  std::unique_ptr<TypeSystemClang> m_ast_context;
 
   std::vector<std::string> m_include_directories;
   /// File name used for the user expression.

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangFunctionCaller.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangFunctionCaller.cpp
@@ -26,7 +26,7 @@
 #include "lldb/Core/ValueObjectList.h"
 #include "lldb/Expression/IRExecutionUnit.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/Type.h"
 #include "lldb/Target/ExecutionContext.h"

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
@@ -27,7 +27,7 @@
 #include "lldb/Core/ModuleList.h"
 #include "lldb/Host/Host.h"
 #include "lldb/Host/HostInfo.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/SourceModule.h"
 #include "lldb/Target/Target.h"
@@ -108,9 +108,9 @@ private:
   typedef std::set<ModuleID> ImportedModuleSet;
   ImportedModuleMap m_imported_modules;
   ImportedModuleSet m_user_imported_modules;
-  // We assume that every ASTContext has an ClangASTContext, so we also store
-  // a custom ClangASTContext for our internal ASTContext.
-  std::unique_ptr<ClangASTContext> m_ast_context;
+  // We assume that every ASTContext has an TypeSystemClang, so we also store
+  // a custom TypeSystemClang for our internal ASTContext.
+  std::unique_ptr<TypeSystemClang> m_ast_context;
 };
 } // anonymous namespace
 
@@ -159,8 +159,8 @@ ClangModulesDeclVendorImpl::ClangModulesDeclVendorImpl(
       m_compiler_instance(std::move(compiler_instance)),
       m_parser(std::move(parser)) {
 
-  // Initialize our ClangASTContext.
-  m_ast_context.reset(new ClangASTContext(m_compiler_instance->getASTContext()));
+  // Initialize our TypeSystemClang.
+  m_ast_context.reset(new TypeSystemClang(m_compiler_instance->getASTContext()));
 }
 
 void ClangModulesDeclVendorImpl::ReportModuleExportsHelper(

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.cpp
@@ -9,7 +9,7 @@
 #include "ClangPersistentVariables.h"
 
 #include "lldb/Core/Value.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/Log.h"
@@ -82,7 +82,7 @@ ClangPersistentVariables::GetCompilerTypeFromPersistentDecl(
 
 void ClangPersistentVariables::RegisterPersistentDecl(ConstString name,
                                                       clang::NamedDecl *decl,
-                                                      ClangASTContext *ctx) {
+                                                      TypeSystemClang *ctx) {
   PersistentDecl p = {decl, ctx};
   m_persistent_decls.insert(std::make_pair(name.GetCString(), p));
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.h
@@ -63,7 +63,7 @@ public:
   GetCompilerTypeFromPersistentDecl(ConstString type_name) override;
 
   void RegisterPersistentDecl(ConstString name, clang::NamedDecl *decl,
-                              ClangASTContext *ctx);
+                              TypeSystemClang *ctx);
 
   clang::NamedDecl *GetPersistentDecl(ConstString name);
 
@@ -84,8 +84,8 @@ private:
   struct PersistentDecl {
     /// The persistent decl.
     clang::NamedDecl *m_decl = nullptr;
-    /// The ClangASTContext for the ASTContext of m_decl.
-    ClangASTContext *m_context = nullptr;
+    /// The TypeSystemClang for the ASTContext of m_decl.
+    TypeSystemClang *m_context = nullptr;
   };
 
   typedef llvm::DenseMap<const char *, PersistentDecl> PersistentDeclMap;

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
@@ -37,7 +37,7 @@
 #include "lldb/Expression/Materializer.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Symbol/Block.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangASTMetadata.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/Function.h"
@@ -154,7 +154,7 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
     }
     m_needs_object_ptr = true;
   } else if (clang::CXXMethodDecl *method_decl =
-          ClangASTContext::DeclContextGetAsCXXMethodDecl(decl_context)) {
+          TypeSystemClang::DeclContextGetAsCXXMethodDecl(decl_context)) {
     if (m_allow_cxx && method_decl->isInstance()) {
       if (m_enforce_valid_object) {
         lldb::VariableListSP variable_list_sp(
@@ -183,7 +183,7 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
       m_needs_object_ptr = true;
     }
   } else if (clang::ObjCMethodDecl *method_decl =
-                 ClangASTContext::DeclContextGetAsObjCMethodDecl(
+                 TypeSystemClang::DeclContextGetAsObjCMethodDecl(
                      decl_context)) {
     if (m_allow_objc) {
       if (m_enforce_valid_object) {
@@ -216,7 +216,7 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
         m_in_static_method = true;
     }
   } else if (clang::FunctionDecl *function_decl =
-                 ClangASTContext::DeclContextGetAsFunctionDecl(decl_context)) {
+                 TypeSystemClang::DeclContextGetAsFunctionDecl(decl_context)) {
     // We might also have a function that said in the debug information that it
     // captured an object pointer.  The best way to deal with getting to the
     // ivars at present is by pretending that this is a method of a class in
@@ -224,7 +224,7 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
     // that here.
 
     ClangASTMetadata *metadata =
-        ClangASTContext::DeclContextGetMetaData(decl_context, function_decl);
+        TypeSystemClang::DeclContextGetMetaData(decl_context, function_decl);
     if (metadata && metadata->HasObjectPtr()) {
       lldb::LanguageType language = metadata->GetObjectPtrLanguage();
       if (language == lldb::eLanguageTypeC_plus_plus) {
@@ -292,9 +292,9 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
             return;
           }
 
-          if (ClangASTContext::IsObjCClassType(self_clang_type)) {
+          if (TypeSystemClang::IsObjCClassType(self_clang_type)) {
             return;
-          } else if (ClangASTContext::IsObjCObjectPointerType(
+          } else if (TypeSystemClang::IsObjCObjectPointerType(
                          self_clang_type)) {
             m_in_objectivec_method = true;
             m_needs_object_ptr = true;

--- a/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
@@ -27,7 +27,7 @@
 #include "lldb/Core/dwarf.h"
 #include "lldb/Expression/IRExecutionUnit.h"
 #include "lldb/Expression/IRInterpreter.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangUtil.h"
 #include "lldb/Symbol/CompilerType.h"
 #include "lldb/Utility/ConstString.h"
@@ -284,7 +284,7 @@ bool IRForTarget::CreateResultVariable(llvm::Function &llvm_function) {
 
       m_result_type = lldb_private::TypeFromParser(
           element_qual_type.getAsOpaquePtr(),
-          lldb_private::ClangASTContext::GetASTContext(
+          lldb_private::TypeSystemClang::GetASTContext(
               &result_decl->getASTContext()));
     } else if (pointer_objcobjpointertype) {
       clang::QualType element_qual_type =
@@ -292,7 +292,7 @@ bool IRForTarget::CreateResultVariable(llvm::Function &llvm_function) {
 
       m_result_type = lldb_private::TypeFromParser(
           element_qual_type.getAsOpaquePtr(),
-          lldb_private::ClangASTContext::GetASTContext(
+          lldb_private::TypeSystemClang::GetASTContext(
               &result_decl->getASTContext()));
     } else {
       LLDB_LOG(log, "Expected result to have pointer type, but it did not");
@@ -306,7 +306,7 @@ bool IRForTarget::CreateResultVariable(llvm::Function &llvm_function) {
   } else {
     m_result_type = lldb_private::TypeFromParser(
         result_var->getType().getAsOpaquePtr(),
-        lldb_private::ClangASTContext::GetASTContext(
+        lldb_private::TypeSystemClang::GetASTContext(
             &result_decl->getASTContext()));
   }
 
@@ -1093,7 +1093,7 @@ bool IRForTarget::RewritePersistentAlloc(llvm::Instruction *persistent_alloc) {
 
   lldb_private::TypeFromParser result_decl_type(
       decl->getType().getAsOpaquePtr(),
-      lldb_private::ClangASTContext::GetASTContext(&decl->getASTContext()));
+      lldb_private::TypeSystemClang::GetASTContext(&decl->getASTContext()));
 
   StringRef decl_name(decl->getName());
   lldb_private::ConstString persistent_variable_name(decl_name.data(),
@@ -1224,7 +1224,7 @@ bool IRForTarget::MaybeHandleVariable(Value *llvm_value_ptr) {
       return false;
 
     lldb_private::CompilerType compiler_type(
-        lldb_private::ClangASTContext::GetASTContext(
+        lldb_private::TypeSystemClang::GetASTContext(
             &value_decl->getASTContext()),
         value_decl->getType().getAsOpaquePtr());
 

--- a/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
@@ -10,7 +10,7 @@
 
 #include "lldb/Core/ValueObject.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangASTImporter.h"
 #include "lldb/Symbol/CompilerType.h"
 #include "lldb/Symbol/TypeSystem.h"
@@ -45,12 +45,12 @@ public:
     if (auto err = type_system_or_err.takeError()) {
       LLDB_LOG_ERROR(
           lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_DATAFORMATTERS),
-          std::move(err), "Failed to get scratch ClangASTContext");
+          std::move(err), "Failed to get scratch TypeSystemClang");
       return;
     }
 
-    ClangASTContext *clang_ast_context =
-        llvm::dyn_cast<ClangASTContext>(&type_system_or_err.get());
+    TypeSystemClang *clang_ast_context =
+        llvm::dyn_cast<TypeSystemClang>(&type_system_or_err.get());
 
     if (!clang_ast_context) {
       return;

--- a/lldb/source/Plugins/Language/CPlusPlus/CxxStringTypes.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CxxStringTypes.cpp
@@ -16,7 +16,7 @@
 #include "lldb/DataFormatters/StringPrinter.h"
 #include "lldb/DataFormatters/TypeSummary.h"
 #include "lldb/Host/Time.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/ProcessStructReader.h"
 #include "lldb/Target/SectionLoadList.h"
 #include "lldb/Target/Target.h"

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -17,7 +17,7 @@
 #include "lldb/DataFormatters/StringPrinter.h"
 #include "lldb/DataFormatters/TypeSummary.h"
 #include "lldb/DataFormatters/VectorIterator.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/ProcessStructReader.h"
 #include "lldb/Target/SectionLoadList.h"
 #include "lldb/Target/Target.h"
@@ -241,8 +241,8 @@ bool lldb_private::formatters::LibCxxMapIteratorSyntheticFrontEnd::Update() {
       auto addr(m_pair_ptr->GetValueAsUnsigned(LLDB_INVALID_ADDRESS));
       m_pair_ptr = nullptr;
       if (addr && addr != LLDB_INVALID_ADDRESS) {
-        ClangASTContext *ast_ctx =
-            llvm::dyn_cast_or_null<ClangASTContext>(pair_type.GetTypeSystem());
+        TypeSystemClang *ast_ctx =
+            llvm::dyn_cast_or_null<TypeSystemClang>(pair_type.GetTypeSystem());
         if (!ast_ctx)
           return false;
         CompilerType tree_node_type = ast_ctx->CreateStructForIdentifier(
@@ -572,8 +572,8 @@ bool lldb_private::formatters::LibcxxWStringSummaryProvider(
   location_sp->GetPointeeData(extractor, 0, size);
 
   // std::wstring::size() is measured in 'characters', not bytes
-  ClangASTContext *ast_context =
-      ClangASTContext::GetScratch(*valobj.GetTargetSP());
+  TypeSystemClang *ast_context =
+      TypeSystemClang::GetScratch(*valobj.GetTargetSP());
   if (!ast_context)
     return false;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxBitset.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxBitset.cpp
@@ -8,7 +8,7 @@
 
 #include "LibCxx.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/Target.h"
 
 using namespace lldb;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
@@ -11,7 +11,7 @@
 #include "lldb/Core/ValueObject.h"
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/Endian.h"

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
@@ -11,7 +11,7 @@
 #include "lldb/Core/ValueObject.h"
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/Endian.h"
@@ -298,8 +298,8 @@ void lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::GetValueOffset(
       UINT32_MAX) {
     m_skip_size = bit_offset / 8u;
   } else {
-    ClangASTContext *ast_ctx =
-        llvm::dyn_cast_or_null<ClangASTContext>(node_type.GetTypeSystem());
+    TypeSystemClang *ast_ctx =
+        llvm::dyn_cast_or_null<TypeSystemClang>(node_type.GetTypeSystem());
     if (!ast_ctx)
       return;
     CompilerType tree_node_type = ast_ctx->CreateStructForIdentifier(

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -11,7 +11,7 @@
 #include "lldb/Core/ValueObject.h"
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/Endian.h"

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
@@ -12,7 +12,7 @@
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/StringPrinter.h"
 #include "lldb/DataFormatters/VectorIterator.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/Endian.h"

--- a/lldb/source/Plugins/Language/ObjC/CF.cpp
+++ b/lldb/source/Plugins/Language/ObjC/CF.cpp
@@ -12,7 +12,7 @@
 #include "lldb/Core/ValueObject.h"
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/Language.h"
 #include "lldb/Target/StackFrame.h"
 #include "lldb/Target/Target.h"

--- a/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -15,7 +15,7 @@
 #include "lldb/DataFormatters/StringPrinter.h"
 #include "lldb/DataFormatters/TypeSummary.h"
 #include "lldb/Host/Time.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/Language.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/ProcessStructReader.h"

--- a/lldb/source/Plugins/Language/ObjC/NSArray.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSArray.cpp
@@ -16,7 +16,7 @@
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
 #include "lldb/Expression/FunctionCaller.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/Language.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/DataBufferHeap.h"
@@ -436,7 +436,7 @@ lldb_private::formatters::NSArrayMSyntheticFrontEndBase::NSArrayMSyntheticFrontE
     : SyntheticChildrenFrontEnd(*valobj_sp), m_exe_ctx_ref(), m_ptr_size(8),
       m_id_type() {
   if (valobj_sp) {
-    auto *clang_ast_context = ClangASTContext::GetScratch(
+    auto *clang_ast_context = TypeSystemClang::GetScratch(
         *valobj_sp->GetExecutionContextRef().GetTargetSP());
     if (clang_ast_context)
       m_id_type = CompilerType(
@@ -584,7 +584,7 @@ lldb_private::formatters::GenericNSArrayISyntheticFrontEnd<D32, D64, Inline>::
   if (valobj_sp) {
     CompilerType type = valobj_sp->GetCompilerType();
     if (type) {
-      auto *clang_ast_context = ClangASTContext::GetScratch(
+      auto *clang_ast_context = TypeSystemClang::GetScratch(
           *valobj_sp->GetExecutionContextRef().GetTargetSP());
       if (clang_ast_context)
         m_id_type = clang_ast_context->GetType(
@@ -753,7 +753,7 @@ lldb_private::formatters::NSArray1SyntheticFrontEnd::GetChildAtIndex(
 
   if (idx == 0) {
     auto *clang_ast_context =
-        ClangASTContext::GetScratch(*m_backend.GetTargetSP());
+        TypeSystemClang::GetScratch(*m_backend.GetTargetSP());
     if (clang_ast_context) {
       CompilerType id_type(
           clang_ast_context->GetBasicType(lldb::eBasicTypeObjCID));

--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -17,7 +17,7 @@
 #include "lldb/Core/ValueObject.h"
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/Language.h"
 #include "lldb/Target/StackFrame.h"
 #include "lldb/Target/Target.h"
@@ -65,7 +65,7 @@ NSDictionary_Additionals::GetAdditionalSynthetics() {
 static CompilerType GetLLDBNSPairType(TargetSP target_sp) {
   CompilerType compiler_type;
 
-  ClangASTContext *target_ast_context = ClangASTContext::GetScratch(*target_sp);
+  TypeSystemClang *target_ast_context = TypeSystemClang::GetScratch(*target_sp);
 
   if (target_ast_context) {
     ConstString g___lldb_autogen_nspair("__lldb_autogen_nspair");
@@ -80,14 +80,14 @@ static CompilerType GetLLDBNSPairType(TargetSP target_sp) {
           clang::TTK_Struct, lldb::eLanguageTypeC);
 
       if (compiler_type) {
-        ClangASTContext::StartTagDeclarationDefinition(compiler_type);
+        TypeSystemClang::StartTagDeclarationDefinition(compiler_type);
         CompilerType id_compiler_type =
             target_ast_context->GetBasicType(eBasicTypeObjCID);
-        ClangASTContext::AddFieldToRecordType(
+        TypeSystemClang::AddFieldToRecordType(
             compiler_type, "key", id_compiler_type, lldb::eAccessPublic, 0);
-        ClangASTContext::AddFieldToRecordType(
+        TypeSystemClang::AddFieldToRecordType(
             compiler_type, "value", id_compiler_type, lldb::eAccessPublic, 0);
-        ClangASTContext::CompleteTagDeclarationDefinition(compiler_type);
+        TypeSystemClang::CompleteTagDeclarationDefinition(compiler_type);
       }
     }
   }

--- a/lldb/source/Plugins/Language/ObjC/NSError.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSError.cpp
@@ -13,7 +13,7 @@
 #include "lldb/Core/ValueObject.h"
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/ProcessStructReader.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/DataBufferHeap.h"
@@ -87,7 +87,7 @@ bool lldb_private::formatters::NSError_SummaryProvider(
   ValueObjectSP domain_str_sp = ValueObject::CreateValueObjectFromData(
       "domain_str", isw.GetAsData(process_sp->GetByteOrder()),
       valobj.GetExecutionContextRef(),
-      ClangASTContext::GetScratch(process_sp->GetTarget())
+      TypeSystemClang::GetScratch(process_sp->GetTarget())
           ->GetBasicType(lldb::eBasicTypeVoid)
           .GetPointerType());
 
@@ -156,7 +156,7 @@ public:
     m_child_sp = CreateValueObjectFromData(
         "_userInfo", isw.GetAsData(process_sp->GetByteOrder()),
         m_backend.GetExecutionContextRef(),
-        ClangASTContext::GetScratch(process_sp->GetTarget())
+        TypeSystemClang::GetScratch(process_sp->GetTarget())
             ->GetBasicType(lldb::eBasicTypeObjCID));
     return false;
   }

--- a/lldb/source/Plugins/Language/ObjC/NSException.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSException.cpp
@@ -13,7 +13,7 @@
 #include "lldb/Core/ValueObject.h"
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/ProcessStructReader.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/DataBufferHeap.h"
@@ -69,7 +69,7 @@ static bool ExtractFields(ValueObject &valobj, ValueObjectSP *name_sp,
   InferiorSizedWord userinfo_isw(userinfo, *process_sp);
   InferiorSizedWord reserved_isw(reserved, *process_sp);
 
-  auto *clang_ast_context = ClangASTContext::GetScratch(process_sp->GetTarget());
+  auto *clang_ast_context = TypeSystemClang::GetScratch(process_sp->GetTarget());
   if (!clang_ast_context)
     return false;
 

--- a/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
@@ -12,7 +12,7 @@
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
 #include "lldb/DataFormatters/TypeSynthetic.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/Target.h"
 
@@ -53,7 +53,7 @@ public:
     if (!type_system)
       return false;
 
-    ClangASTContext *ast = ClangASTContext::GetScratch(
+    TypeSystemClang *ast = TypeSystemClang::GetScratch(
         *m_backend.GetExecutionContextRef().GetTargetSP());
     if (!ast)
       return false;

--- a/lldb/source/Plugins/Language/ObjC/NSSet.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSSet.cpp
@@ -12,7 +12,7 @@
 #include "lldb/Core/ValueObject.h"
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/Language.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/DataBufferHeap.h"

--- a/lldb/source/Plugins/Language/ObjC/NSString.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSString.cpp
@@ -13,7 +13,7 @@
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
 #include "lldb/DataFormatters/StringPrinter.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/Language.h"
 #include "lldb/Target/ProcessStructReader.h"
 #include "lldb/Target/Target.h"
@@ -35,7 +35,7 @@ NSString_Additionals::GetAdditionalSummaries() {
 static CompilerType GetNSPathStore2Type(Target &target) {
   static ConstString g_type_name("__lldb_autogen_nspathstore2");
 
-  ClangASTContext *ast_ctx = ClangASTContext::GetScratch(target);
+  TypeSystemClang *ast_ctx = TypeSystemClang::GetScratch(target);
 
   if (!ast_ctx)
     return CompilerType();

--- a/lldb/source/Plugins/Language/ObjC/ObjCLanguage.cpp
+++ b/lldb/source/Plugins/Language/ObjC/ObjCLanguage.cpp
@@ -14,7 +14,7 @@
 #include "lldb/Core/ValueObject.h"
 #include "lldb/DataFormatters/DataVisualization.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangUtil.h"
 #include "lldb/Symbol/CompilerType.h"
 #include "lldb/Target/Target.h"

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
@@ -20,7 +20,7 @@
 
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/UniqueCStringMap.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Target/ABI.h"
 #include "lldb/Target/ExecutionContext.h"

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
@@ -21,7 +21,7 @@
 #include "lldb/Interpreter/CommandObject.h"
 #include "lldb/Interpreter/CommandObjectMultiword.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/Symbol.h"
 #include "lldb/Symbol/SymbolFile.h"
 #include "lldb/Symbol/TypeList.h"
@@ -118,7 +118,7 @@ TypeAndOrName ItaniumABILanguageRuntime::GetTypeInfoFromVTableAddress(
             if (class_types.GetSize() == 1) {
               type_sp = class_types.GetTypeAtIndex(0);
               if (type_sp) {
-                if (ClangASTContext::IsCXXClassType(
+                if (TypeSystemClang::IsCXXClassType(
                         type_sp->GetForwardCompilerType())) {
                   LLDB_LOGF(
                       log,
@@ -150,7 +150,7 @@ TypeAndOrName ItaniumABILanguageRuntime::GetTypeInfoFromVTableAddress(
               for (i = 0; i < class_types.GetSize(); i++) {
                 type_sp = class_types.GetTypeAtIndex(i);
                 if (type_sp) {
-                  if (ClangASTContext::IsCXXClassType(
+                  if (TypeSystemClang::IsCXXClassType(
                           type_sp->GetForwardCompilerType())) {
                     LLDB_LOGF(
                         log,
@@ -238,7 +238,7 @@ bool ItaniumABILanguageRuntime::GetDynamicTypeAndAddress(
   if (!type)
     return true;
 
-  if (ClangASTContext::AreTypesSame(in_value.GetCompilerType(), type)) {
+  if (TypeSystemClang::AreTypesSame(in_value.GetCompilerType(), type)) {
     // The dynamic type we found was the same type, so we don't have a
     // dynamic type here...
     return false;
@@ -536,8 +536,8 @@ ValueObjectSP ItaniumABILanguageRuntime::GetExceptionObjectForThread(
   if (!thread_sp->SafeToCallFunctions())
     return {};
 
-  ClangASTContext *clang_ast_context =
-      ClangASTContext::GetScratch(m_process->GetTarget());
+  TypeSystemClang *clang_ast_context =
+      TypeSystemClang::GetScratch(m_process->GetTarget());
   if (!clang_ast_context)
     return {};
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCDeclVendor.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCDeclVendor.cpp
@@ -309,7 +309,7 @@ public:
   }
 
   clang::ObjCMethodDecl *
-  BuildMethod(ClangASTContext &clang_ast_ctxt,
+  BuildMethod(TypeSystemClang &clang_ast_ctxt,
               clang::ObjCInterfaceDecl *interface_decl, const char *name,
               bool instance,
               ObjCLanguageRuntime::EncodingToTypeSP type_realizer_sp) {

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCDeclVendor.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCDeclVendor.h
@@ -9,7 +9,7 @@
 #ifndef liblldb_AppleObjCDeclVendor_h_
 #define liblldb_AppleObjCDeclVendor_h_
 
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/lldb-private.h"
 
 #include "Plugins/ExpressionParser/Clang/ClangDeclVendor.h"
@@ -37,7 +37,7 @@ private:
   bool FinishDecl(clang::ObjCInterfaceDecl *decl);
 
   ObjCLanguageRuntime &m_runtime;
-  ClangASTContext m_ast_ctx;
+  TypeSystemClang m_ast_ctx;
   ObjCLanguageRuntime::EncodingToTypeSP m_type_realizer_sp;
   AppleObjCExternalASTSource *m_external_source;
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
@@ -22,7 +22,7 @@
 #include "lldb/DataFormatters/FormattersHelpers.h"
 #include "lldb/Expression/DiagnosticManager.h"
 #include "lldb/Expression/FunctionCaller.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/Process.h"
@@ -105,13 +105,13 @@ bool AppleObjCRuntime::GetObjectDescription(Stream &strm, Value &value,
   Target *target = exe_ctx.GetTargetPtr();
   CompilerType compiler_type = value.GetCompilerType();
   if (compiler_type) {
-    if (!ClangASTContext::IsObjCObjectPointerType(compiler_type)) {
+    if (!TypeSystemClang::IsObjCObjectPointerType(compiler_type)) {
       strm.Printf("Value doesn't point to an ObjC object.\n");
       return false;
     }
   } else {
     // If it is not a pointer, see if we can make it into a pointer.
-    ClangASTContext *ast_context = ClangASTContext::GetScratch(*target);
+    TypeSystemClang *ast_context = TypeSystemClang::GetScratch(*target);
     if (!ast_context)
       return false;
 
@@ -126,7 +126,7 @@ bool AppleObjCRuntime::GetObjectDescription(Stream &strm, Value &value,
   arg_value_list.PushValue(value);
 
   // This is the return value:
-  ClangASTContext *ast_context = ClangASTContext::GetScratch(*target);
+  TypeSystemClang *ast_context = TypeSystemClang::GetScratch(*target);
   if (!ast_context)
     return false;
 
@@ -499,8 +499,8 @@ ThreadSP AppleObjCRuntime::GetBacktraceThreadFromException(
   reserved_dict = reserved_dict->GetSyntheticValue();
   if (!reserved_dict) return ThreadSP();
 
-  ClangASTContext *clang_ast_context =
-      ClangASTContext::GetScratch(*exception_sp->GetTargetSP());
+  TypeSystemClang *clang_ast_context =
+      TypeSystemClang::GetScratch(*exception_sp->GetTargetSP());
   if (!clang_ast_context)
     return ThreadSP();
   CompilerType objc_id =

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
@@ -18,7 +18,7 @@
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Expression/FunctionCaller.h"
 #include "lldb/Expression/UtilityFunction.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/Symbol.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/Process.h"

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -35,7 +35,7 @@
 #include "lldb/Interpreter/CommandReturnObject.h"
 #include "lldb/Interpreter/OptionArgParser.h"
 #include "lldb/Interpreter/OptionValueBoolean.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Symbol/Symbol.h"
 #include "lldb/Symbol/TypeList.h"
@@ -1301,7 +1301,7 @@ AppleObjCRuntimeV2::UpdateISAToDescriptorMapDynamic(
     return DescriptorMapUpdateResult::Fail();
 
   thread_sp->CalculateExecutionContext(exe_ctx);
-  ClangASTContext *ast = ClangASTContext::GetScratch(process->GetTarget());
+  TypeSystemClang *ast = TypeSystemClang::GetScratch(process->GetTarget());
 
   if (!ast)
     return DescriptorMapUpdateResult::Fail();
@@ -1563,7 +1563,7 @@ AppleObjCRuntimeV2::UpdateISAToDescriptorMapSharedCache() {
     return DescriptorMapUpdateResult::Fail();
 
   thread_sp->CalculateExecutionContext(exe_ctx);
-  ClangASTContext *ast = ClangASTContext::GetScratch(process->GetTarget());
+  TypeSystemClang *ast = TypeSystemClang::GetScratch(process->GetTarget());
 
   if (!ast)
     return DescriptorMapUpdateResult::Fail();
@@ -2672,8 +2672,8 @@ class ObjCExceptionRecognizedStackFrame : public RecognizedStackFrame {
     const lldb::ABISP &abi = process_sp->GetABI();
     if (!abi) return;
 
-    ClangASTContext *clang_ast_context =
-        ClangASTContext::GetScratch(process_sp->GetTarget());
+    TypeSystemClang *clang_ast_context =
+        TypeSystemClang::GetScratch(process_sp->GetTarget());
     if (!clang_ast_context)
       return;
     CompilerType voidstar =

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.cpp
@@ -19,7 +19,7 @@
 #include "lldb/Expression/FunctionCaller.h"
 #include "lldb/Expression/UserExpression.h"
 #include "lldb/Expression/UtilityFunction.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/Symbol.h"
 #include "lldb/Target/ABI.h"
 #include "lldb/Target/ExecutionContext.h"
@@ -521,8 +521,8 @@ bool AppleObjCTrampolineHandler::AppleObjCVTables::RefreshTrampolines(
     Process *process = exe_ctx.GetProcessPtr();
     const ABI *abi = process->GetABI().get();
 
-    ClangASTContext *clang_ast_context =
-        ClangASTContext::GetScratch(process->GetTarget());
+    TypeSystemClang *clang_ast_context =
+        TypeSystemClang::GetScratch(process->GetTarget());
     if (!clang_ast_context)
       return false;
 
@@ -804,8 +804,8 @@ AppleObjCTrampolineHandler::SetupDispatchFunction(Thread &thread,
       }
 
       // Next make the runner function for our implementation utility function.
-      ClangASTContext *clang_ast_context =
-          ClangASTContext::GetScratch(thread.GetProcess()->GetTarget());
+      TypeSystemClang *clang_ast_context =
+          TypeSystemClang::GetScratch(thread.GetProcess()->GetTarget());
       if (!clang_ast_context)
         return LLDB_INVALID_ADDRESS;
 
@@ -901,7 +901,7 @@ AppleObjCTrampolineHandler::GetStepThroughDispatchPlan(Thread &thread,
 
     TargetSP target_sp(thread.CalculateTarget());
 
-    ClangASTContext *clang_ast_context = ClangASTContext::GetScratch(*target_sp);
+    TypeSystemClang *clang_ast_context = TypeSystemClang::GetScratch(*target_sp);
     if (!clang_ast_context)
       return ret_plan_sp;
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTypeEncodingParser.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTypeEncodingParser.cpp
@@ -8,7 +8,7 @@
 
 #include "AppleObjCTypeEncodingParser.h"
 
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangUtil.h"
 #include "lldb/Symbol/CompilerType.h"
 #include "lldb/Target/Process.h"
@@ -23,7 +23,7 @@ AppleObjCTypeEncodingParser::AppleObjCTypeEncodingParser(
     ObjCLanguageRuntime &runtime)
     : ObjCLanguageRuntime::EncodingToType(), m_runtime(runtime) {
   if (!m_scratch_ast_ctx_up)
-    m_scratch_ast_ctx_up.reset(new ClangASTContext(runtime.GetProcess()
+    m_scratch_ast_ctx_up.reset(new TypeSystemClang(runtime.GetProcess()
                                                        ->GetTarget()
                                                        .GetArchitecture()
                                                        .GetTriple()));
@@ -61,7 +61,7 @@ AppleObjCTypeEncodingParser::StructElement::StructElement()
     : name(""), type(clang::QualType()), bitfield(0) {}
 
 AppleObjCTypeEncodingParser::StructElement
-AppleObjCTypeEncodingParser::ReadStructElement(ClangASTContext &ast_ctx,
+AppleObjCTypeEncodingParser::ReadStructElement(TypeSystemClang &ast_ctx,
                                                StringLexer &type,
                                                bool for_expression) {
   StructElement retval;
@@ -76,19 +76,19 @@ AppleObjCTypeEncodingParser::ReadStructElement(ClangASTContext &ast_ctx,
 }
 
 clang::QualType AppleObjCTypeEncodingParser::BuildStruct(
-    ClangASTContext &ast_ctx, StringLexer &type, bool for_expression) {
+    TypeSystemClang &ast_ctx, StringLexer &type, bool for_expression) {
   return BuildAggregate(ast_ctx, type, for_expression, '{', '}',
                         clang::TTK_Struct);
 }
 
 clang::QualType AppleObjCTypeEncodingParser::BuildUnion(
-    ClangASTContext &ast_ctx, StringLexer &type, bool for_expression) {
+    TypeSystemClang &ast_ctx, StringLexer &type, bool for_expression) {
   return BuildAggregate(ast_ctx, type, for_expression, '(', ')',
                         clang::TTK_Union);
 }
 
 clang::QualType AppleObjCTypeEncodingParser::BuildAggregate(
-    ClangASTContext &ast_ctx, StringLexer &type, bool for_expression,
+    TypeSystemClang &ast_ctx, StringLexer &type, bool for_expression,
     char opener, char closer, uint32_t kind) {
   if (!type.NextIf(opener))
     return clang::QualType();
@@ -125,7 +125,7 @@ clang::QualType AppleObjCTypeEncodingParser::BuildAggregate(
   CompilerType union_type(ast_ctx.CreateRecordType(
       nullptr, lldb::eAccessPublic, name, kind, lldb::eLanguageTypeC));
   if (union_type) {
-    ClangASTContext::StartTagDeclarationDefinition(union_type);
+    TypeSystemClang::StartTagDeclarationDefinition(union_type);
 
     unsigned int count = 0;
     for (auto element : elements) {
@@ -134,18 +134,18 @@ clang::QualType AppleObjCTypeEncodingParser::BuildAggregate(
         elem_name.Printf("__unnamed_%u", count);
         element.name = elem_name.GetString();
       }
-      ClangASTContext::AddFieldToRecordType(
+      TypeSystemClang::AddFieldToRecordType(
           union_type, element.name.c_str(), ast_ctx.GetType(element.type),
           lldb::eAccessPublic, element.bitfield);
       ++count;
     }
-    ClangASTContext::CompleteTagDeclarationDefinition(union_type);
+    TypeSystemClang::CompleteTagDeclarationDefinition(union_type);
   }
   return ClangUtil::GetQualType(union_type);
 }
 
 clang::QualType AppleObjCTypeEncodingParser::BuildArray(
-    ClangASTContext &ast_ctx, StringLexer &type, bool for_expression) {
+    TypeSystemClang &ast_ctx, StringLexer &type, bool for_expression) {
   if (!type.NextIf('['))
     return clang::QualType();
   uint32_t size = ReadNumber(type);
@@ -163,7 +163,7 @@ clang::QualType AppleObjCTypeEncodingParser::BuildArray(
 // consume but ignore the type info and always return an 'id'; if anything,
 // dynamic typing will resolve things for us anyway
 clang::QualType AppleObjCTypeEncodingParser::BuildObjCObjectPointerType(
-    ClangASTContext &clang_ast_ctx, StringLexer &type, bool for_expression) {
+    TypeSystemClang &clang_ast_ctx, StringLexer &type, bool for_expression) {
   if (!type.NextIf('@'))
     return clang::QualType();
 
@@ -247,7 +247,7 @@ clang::QualType AppleObjCTypeEncodingParser::BuildObjCObjectPointerType(
 }
 
 clang::QualType
-AppleObjCTypeEncodingParser::BuildType(ClangASTContext &clang_ast_ctx,
+AppleObjCTypeEncodingParser::BuildType(TypeSystemClang &clang_ast_ctx,
                                        StringLexer &type, bool for_expression,
                                        uint32_t *bitfield_bit_size) {
   if (!type.HasAtLeast(1))
@@ -353,7 +353,7 @@ AppleObjCTypeEncodingParser::BuildType(ClangASTContext &clang_ast_ctx,
   }
 }
 
-CompilerType AppleObjCTypeEncodingParser::RealizeType(ClangASTContext &ast_ctx,
+CompilerType AppleObjCTypeEncodingParser::RealizeType(TypeSystemClang &ast_ctx,
                                                       const char *name,
                                                       bool for_expression) {
   if (name && name[0]) {

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTypeEncodingParser.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTypeEncodingParser.h
@@ -22,7 +22,7 @@ public:
   AppleObjCTypeEncodingParser(ObjCLanguageRuntime &runtime);
   ~AppleObjCTypeEncodingParser() override = default;
 
-  CompilerType RealizeType(ClangASTContext &ast_ctx, const char *name,
+  CompilerType RealizeType(TypeSystemClang &ast_ctx, const char *name,
                            bool for_expression) override;
 
 private:
@@ -35,29 +35,29 @@ private:
     ~StructElement() = default;
   };
 
-  clang::QualType BuildType(ClangASTContext &clang_ast_ctx, StringLexer &type,
+  clang::QualType BuildType(TypeSystemClang &clang_ast_ctx, StringLexer &type,
                             bool for_expression,
                             uint32_t *bitfield_bit_size = nullptr);
 
-  clang::QualType BuildStruct(ClangASTContext &ast_ctx, StringLexer &type,
+  clang::QualType BuildStruct(TypeSystemClang &ast_ctx, StringLexer &type,
                               bool for_expression);
 
-  clang::QualType BuildAggregate(ClangASTContext &clang_ast_ctx,
+  clang::QualType BuildAggregate(TypeSystemClang &clang_ast_ctx,
                                  StringLexer &type, bool for_expression,
                                  char opener, char closer, uint32_t kind);
 
-  clang::QualType BuildUnion(ClangASTContext &ast_ctx, StringLexer &type,
+  clang::QualType BuildUnion(TypeSystemClang &ast_ctx, StringLexer &type,
                              bool for_expression);
 
-  clang::QualType BuildArray(ClangASTContext &ast_ctx, StringLexer &type,
+  clang::QualType BuildArray(TypeSystemClang &ast_ctx, StringLexer &type,
                              bool for_expression);
 
   std::string ReadStructName(StringLexer &type);
 
-  StructElement ReadStructElement(ClangASTContext &ast_ctx, StringLexer &type,
+  StructElement ReadStructElement(TypeSystemClang &ast_ctx, StringLexer &type,
                                   bool for_expression);
 
-  clang::QualType BuildObjCObjectPointerType(ClangASTContext &clang_ast_ctx,
+  clang::QualType BuildObjCObjectPointerType(TypeSystemClang &clang_ast_ctx,
                                              StringLexer &type,
                                              bool for_expression);
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.cpp
@@ -13,7 +13,7 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/ValueObject.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/SymbolContext.h"
 #include "lldb/Symbol/SymbolFile.h"
 #include "lldb/Symbol/Type.h"
@@ -127,7 +127,7 @@ ObjCLanguageRuntime::LookupInCompleteClassCache(ConstString &name) {
     for (uint32_t i = 0; i < types.GetSize(); ++i) {
       TypeSP type_sp(types.GetTypeAtIndex(i));
 
-      if (ClangASTContext::IsObjCObjectOrInterfaceType(
+      if (TypeSystemClang::IsObjCObjectOrInterfaceType(
               type_sp->GetForwardCompilerType())) {
         if (type_sp->IsCompleteObjCClass()) {
           m_complete_class_cache[name] = type_sp;
@@ -395,9 +395,9 @@ ObjCLanguageRuntime::GetRuntimeType(CompilerType base_type) {
   CompilerType class_type;
   bool is_pointer_type = false;
 
-  if (ClangASTContext::IsObjCObjectPointerType(base_type, &class_type))
+  if (TypeSystemClang::IsObjCObjectPointerType(base_type, &class_type))
     is_pointer_type = true;
-  else if (ClangASTContext::IsObjCObjectOrInterfaceType(base_type))
+  else if (TypeSystemClang::IsObjCObjectOrInterfaceType(base_type))
     class_type = base_type;
   else
     return llvm::None;

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -144,12 +144,12 @@ public:
   public:
     virtual ~EncodingToType();
 
-    virtual CompilerType RealizeType(ClangASTContext &ast_ctx, const char *name,
+    virtual CompilerType RealizeType(TypeSystemClang &ast_ctx, const char *name,
                                      bool for_expression) = 0;
     virtual CompilerType RealizeType(const char *name, bool for_expression);
 
   protected:
-    std::unique_ptr<ClangASTContext> m_scratch_ast_ctx_up;
+    std::unique_ptr<TypeSystemClang> m_scratch_ast_ctx_up;
   };
 
   class ObjCExceptionPrecondition : public BreakpointPrecondition {

--- a/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
+++ b/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
@@ -22,7 +22,7 @@
 #include "lldb/Host/Host.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Host/ProcessLaunchInfo.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Target/DynamicLoader.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/Process.h"
@@ -706,7 +706,7 @@ PlatformPOSIX::MakeLoadImageUtilityFunction(ExecutionContext &exe_ctx,
   FunctionCaller *do_dlopen_function = nullptr;
 
   // Fetch the clang types we will need:
-  ClangASTContext *ast = ClangASTContext::GetScratch(process->GetTarget());
+  TypeSystemClang *ast = TypeSystemClang::GetScratch(process->GetTarget());
   if (!ast)
     return nullptr;
 
@@ -950,9 +950,9 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
 
   Value return_value;
   // Fetch the clang types we will need:
-  ClangASTContext *ast = ClangASTContext::GetScratch(process->GetTarget());
+  TypeSystemClang *ast = TypeSystemClang::GetScratch(process->GetTarget());
   if (!ast) {
-    error.SetErrorString("dlopen error: Unable to get ClangASTContext");
+    error.SetErrorString("dlopen error: Unable to get TypeSystemClang");
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -55,7 +55,7 @@
 
 using namespace lldb;
 using namespace lldb_private;
-DWARFASTParserClang::DWARFASTParserClang(ClangASTContext &ast)
+DWARFASTParserClang::DWARFASTParserClang(TypeSystemClang &ast)
     : m_ast(ast), m_die_to_decl_ctx(), m_decl_ctx_to_die() {}
 
 DWARFASTParserClang::~DWARFASTParserClang() {}
@@ -243,7 +243,7 @@ TypeSP DWARFASTParserClang::ParseTypeFromClangModule(const SymbolContext &sc,
 
   dwarf->GetTypeList().Insert(type_sp);
   dwarf->GetDIEToType()[die.GetDIE()] = type_sp.get();
-  clang::TagDecl *tag_decl = ClangASTContext::GetAsTagDecl(type);
+  clang::TagDecl *tag_decl = TypeSystemClang::GetAsTagDecl(type);
   if (tag_decl)
     LinkDeclContextToDIE(tag_decl, die);
   else {
@@ -255,7 +255,7 @@ TypeSP DWARFASTParserClang::ParseTypeFromClangModule(const SymbolContext &sc,
   return type_sp;
 }
 
-static void CompleteExternalTagDeclType(ClangASTContext &ast,
+static void CompleteExternalTagDeclType(TypeSystemClang &ast,
                                         ClangASTImporter &ast_importer,
                                         clang::DeclContext *decl_ctx,
                                         DWARFDIE die,
@@ -277,8 +277,8 @@ static void CompleteExternalTagDeclType(ClangASTContext &ast,
         type_name_cstr ? type_name_cstr : "", die.GetOffset());
     // We need to make the type look complete otherwise, we might crash in
     // Clang when adding children.
-    if (ClangASTContext::StartTagDeclarationDefinition(type))
-      ClangASTContext::CompleteTagDeclarationDefinition(type);
+    if (TypeSystemClang::StartTagDeclarationDefinition(type))
+      TypeSystemClang::CompleteTagDeclarationDefinition(type);
   }
 }
 
@@ -824,21 +824,21 @@ TypeSP DWARFASTParserClang::ParseEnum(const SymbolContext &sc,
         m_ast.GetEnumerationIntegerType(clang_type.GetOpaqueQualType());
   }
 
-  LinkDeclContextToDIE(ClangASTContext::GetDeclContextForType(clang_type), die);
+  LinkDeclContextToDIE(TypeSystemClang::GetDeclContextForType(clang_type), die);
 
   type_sp = std::make_shared<Type>(
       die.GetID(), dwarf, attrs.name, attrs.byte_size, nullptr,
       dwarf->GetUID(attrs.type.Reference()), Type::eEncodingIsUID, &attrs.decl,
       clang_type, Type::ResolveState::Forward);
 
-  if (ClangASTContext::StartTagDeclarationDefinition(clang_type)) {
+  if (TypeSystemClang::StartTagDeclarationDefinition(clang_type)) {
     if (die.HasChildren()) {
       bool is_signed = false;
       enumerator_clang_type.IsIntegerType(is_signed);
       ParseChildEnumerators(clang_type, is_signed,
                             type_sp->GetByteSize().getValueOr(0), die);
     }
-    ClangASTContext::CompleteTagDeclarationDefinition(clang_type);
+    TypeSystemClang::CompleteTagDeclarationDefinition(clang_type);
   } else {
     dwarf->GetObjectFile()->GetModule()->ReportError(
         "DWARF DIE at 0x%8.8x named \"%s\" was not able to start its "
@@ -948,7 +948,7 @@ TypeSP DWARFASTParserClang::ParseSubroutine(const DWARFDIE &die,
           if (complete_objc_class_type_sp) {
             CompilerType type_clang_forward_type =
                 complete_objc_class_type_sp->GetForwardCompilerType();
-            if (ClangASTContext::IsObjCObjectOrInterfaceType(
+            if (TypeSystemClang::IsObjCObjectOrInterfaceType(
                     type_clang_forward_type))
               class_opaque_type = type_clang_forward_type;
           }
@@ -1053,7 +1053,7 @@ TypeSP DWARFASTParserClang::ParseSubroutine(const DWARFDIE &die,
           } else {
             CompilerType class_opaque_type =
                 class_type->GetForwardCompilerType();
-            if (ClangASTContext::IsCXXClassType(class_opaque_type)) {
+            if (TypeSystemClang::IsCXXClassType(class_opaque_type)) {
               if (class_opaque_type.IsBeingDefined() || alternate_defn) {
                 if (!is_static && !die.HasChildren()) {
                   // We have a C++ member function with no children (this
@@ -1206,7 +1206,7 @@ TypeSP DWARFASTParserClang::ParseSubroutine(const DWARFDIE &die,
             attrs.is_inline);
 
         if (has_template_params) {
-          ClangASTContext::TemplateParameterInfos template_param_infos;
+          TypeSystemClang::TemplateParameterInfos template_param_infos;
           ParseTemplateParameterInfos(die, template_param_infos);
           template_function_decl = m_ast.CreateFunctionDeclaration(
               ignore_containing_context ? m_ast.GetTranslationUnitDecl()
@@ -1279,7 +1279,7 @@ TypeSP DWARFASTParserClang::ParseArrayType(const DWARFDIE &die,
     attrs.byte_stride = element_type->GetByteSize().getValueOr(0);
   CompilerType array_element_type = element_type->GetForwardCompilerType();
 
-  if (ClangASTContext::IsCXXClassType(array_element_type) &&
+  if (TypeSystemClang::IsCXXClassType(array_element_type) &&
       !array_element_type.GetCompleteType()) {
     ModuleSP module_sp = die.GetModule();
     if (module_sp) {
@@ -1306,8 +1306,8 @@ TypeSP DWARFASTParserClang::ParseArrayType(const DWARFDIE &die,
     // trying to layout the class. Since we provide layout
     // assistance, all ivars in this class and other classes will be
     // fine, this is the best we can do short of crashing.
-    if (ClangASTContext::StartTagDeclarationDefinition(array_element_type)) {
-      ClangASTContext::CompleteTagDeclarationDefinition(array_element_type);
+    if (TypeSystemClang::StartTagDeclarationDefinition(array_element_type)) {
+      TypeSystemClang::CompleteTagDeclarationDefinition(array_element_type);
     } else {
       module_sp->ReportError("DWARF DIE at 0x%8.8x was not able to "
                              "start its definition.\nPlease file a "
@@ -1357,7 +1357,7 @@ TypeSP DWARFASTParserClang::ParsePointerToMemberType(
   CompilerType pointee_clang_type = pointee_type->GetForwardCompilerType();
   CompilerType class_clang_type = class_type->GetLayoutCompilerType();
 
-  CompilerType clang_type = ClangASTContext::CreateMemberPointerType(
+  CompilerType clang_type = TypeSystemClang::CreateMemberPointerType(
       class_clang_type, pointee_clang_type);
 
   if (llvm::Optional<uint64_t> clang_type_size =
@@ -1611,7 +1611,7 @@ DWARFASTParserClang::ParseStructureLikeDIE(const SymbolContext &sc,
     metadata.SetIsDynamicCXXType(dwarf->ClassOrStructIsVirtual(die));
 
     if (attrs.name.GetStringRef().contains('<')) {
-      ClangASTContext::TemplateParameterInfos template_param_infos;
+      TypeSystemClang::TemplateParameterInfos template_param_infos;
       if (ParseTemplateParameterInfos(die, template_param_infos)) {
         clang::ClassTemplateDecl *class_template_decl =
             m_ast.ParseClassTemplateDecl(decl_ctx, attrs.accessibility,
@@ -1705,8 +1705,8 @@ DWARFASTParserClang::ParseStructureLikeDIE(const SymbolContext &sc,
     // these child definitions.
     if (!die.HasChildren()) {
       // No children for this struct/union/class, lets finish it
-      if (ClangASTContext::StartTagDeclarationDefinition(clang_type)) {
-        ClangASTContext::CompleteTagDeclarationDefinition(clang_type);
+      if (TypeSystemClang::StartTagDeclarationDefinition(clang_type)) {
+        TypeSystemClang::CompleteTagDeclarationDefinition(clang_type);
       } else {
         dwarf->GetObjectFile()->GetModule()->ReportError(
             "DWARF DIE at 0x%8.8x named \"%s\" was not able to start its "
@@ -1718,7 +1718,7 @@ DWARFASTParserClang::ParseStructureLikeDIE(const SymbolContext &sc,
       if (tag == DW_TAG_structure_type) // this only applies in C
       {
         clang::RecordDecl *record_decl =
-            ClangASTContext::GetAsRecordDecl(clang_type);
+            TypeSystemClang::GetAsRecordDecl(clang_type);
 
         if (record_decl) {
           GetClangASTImporter().SetRecordLayout(
@@ -1736,7 +1736,7 @@ DWARFASTParserClang::ParseStructureLikeDIE(const SymbolContext &sc,
 
       if (attrs.class_language != eLanguageTypeObjC &&
           attrs.class_language != eLanguageTypeObjC_plus_plus)
-        ClangASTContext::StartTagDeclarationDefinition(clang_type);
+        TypeSystemClang::StartTagDeclarationDefinition(clang_type);
 
       // Leave this as a forward declaration until we need to know the
       // details of the type. lldb_private::Type will automatically call
@@ -1826,7 +1826,7 @@ public:
   }
 
   bool Finalize() {
-    return ClangASTContext::AddObjCClassProperty(
+    return TypeSystemClang::AddObjCClassProperty(
         m_class_opaque_type, m_property_name, m_property_opaque_type,
         m_ivar_decl, m_property_setter_name, m_property_getter_name,
         m_property_attributes, m_metadata_up.get());
@@ -1845,14 +1845,14 @@ private:
 
 bool DWARFASTParserClang::ParseTemplateDIE(
     const DWARFDIE &die,
-    ClangASTContext::TemplateParameterInfos &template_param_infos) {
+    TypeSystemClang::TemplateParameterInfos &template_param_infos) {
   const dw_tag_t tag = die.Tag();
   bool is_template_template_argument = false;
 
   switch (tag) {
   case DW_TAG_GNU_template_parameter_pack: {
     template_param_infos.packed_args.reset(
-      new ClangASTContext::TemplateParameterInfos);
+      new TypeSystemClang::TemplateParameterInfos);
     for (DWARFDIE child_die = die.GetFirstChild(); child_die.IsValid();
          child_die = child_die.GetSibling()) {
       if (!ParseTemplateDIE(child_die, *template_param_infos.packed_args))
@@ -1954,7 +1954,7 @@ bool DWARFASTParserClang::ParseTemplateDIE(
 
 bool DWARFASTParserClang::ParseTemplateParameterInfos(
     const DWARFDIE &parent_die,
-    ClangASTContext::TemplateParameterInfos &template_param_infos) {
+    TypeSystemClang::TemplateParameterInfos &template_param_infos) {
 
   if (!parent_die)
     return false;
@@ -1991,11 +1991,11 @@ bool DWARFASTParserClang::CompleteRecordType(const DWARFDIE &die,
   {
     if (die.HasChildren()) {
       LanguageType class_language = eLanguageTypeUnknown;
-      if (ClangASTContext::IsObjCObjectOrInterfaceType(clang_type)) {
+      if (TypeSystemClang::IsObjCObjectOrInterfaceType(clang_type)) {
         class_language = eLanguageTypeObjC;
         // For objective C we don't start the definition when the class is
         // created.
-        ClangASTContext::StartTagDeclarationDefinition(clang_type);
+        TypeSystemClang::StartTagDeclarationDefinition(clang_type);
       }
 
       int tag_decl_kind = -1;
@@ -2105,9 +2105,9 @@ bool DWARFASTParserClang::CompleteRecordType(const DWARFDIE &die,
               // provide layout assistance, all ivars in this class and other
               // classes will be fine, this is the best we can do short of
               // crashing.
-              if (ClangASTContext::StartTagDeclarationDefinition(
+              if (TypeSystemClang::StartTagDeclarationDefinition(
                       base_class_type)) {
-                ClangASTContext::CompleteTagDeclarationDefinition(
+                TypeSystemClang::CompleteTagDeclarationDefinition(
                     base_class_type);
               }
             }
@@ -2121,8 +2121,8 @@ bool DWARFASTParserClang::CompleteRecordType(const DWARFDIE &die,
   }
 
   m_ast.AddMethodOverridesForCXXRecordType(clang_type.GetOpaqueQualType());
-  ClangASTContext::BuildIndirectFields(clang_type);
-  ClangASTContext::CompleteTagDeclarationDefinition(clang_type);
+  TypeSystemClang::BuildIndirectFields(clang_type);
+  TypeSystemClang::CompleteTagDeclarationDefinition(clang_type);
 
   if (!layout_info.field_offsets.empty() || !layout_info.base_offsets.empty() ||
       !layout_info.vbase_offsets.empty()) {
@@ -2144,14 +2144,14 @@ bool DWARFASTParserClang::CompleteRecordType(const DWARFDIE &die,
 bool DWARFASTParserClang::CompleteEnumType(const DWARFDIE &die,
                                            lldb_private::Type *type,
                                            CompilerType &clang_type) {
-  if (ClangASTContext::StartTagDeclarationDefinition(clang_type)) {
+  if (TypeSystemClang::StartTagDeclarationDefinition(clang_type)) {
     if (die.HasChildren()) {
       bool is_signed = false;
       clang_type.IsIntegerType(is_signed);
       ParseChildEnumerators(clang_type, is_signed,
                             type->GetByteSize().getValueOr(0), die);
     }
-    ClangASTContext::CompleteTagDeclarationDefinition(clang_type);
+    TypeSystemClang::CompleteTagDeclarationDefinition(clang_type);
   }
   return (bool)clang_type;
 }
@@ -2640,7 +2640,7 @@ void DWARFASTParserClang::ParseSingleMember(
       if (var_type) {
         if (accessibility == eAccessNone)
           accessibility = eAccessPublic;
-        ClangASTContext::AddVariableToRecordType(
+        TypeSystemClang::AddVariableToRecordType(
             class_clang_type, name, var_type->GetLayoutCompilerType(),
             accessibility);
       }
@@ -2783,7 +2783,7 @@ void DWARFASTParserClang::ParseSingleMember(
 
               if (anon_field_info.IsValid()) {
                 clang::FieldDecl *unnamed_bitfield_decl =
-                    ClangASTContext::AddFieldToRecordType(
+                    TypeSystemClang::AddFieldToRecordType(
                         class_clang_type, llvm::StringRef(),
                         m_ast.GetBuiltinTypeForEncodingAndBitSize(eEncodingSint,
                                                                   word_width),
@@ -2839,7 +2839,7 @@ void DWARFASTParserClang::ParseSingleMember(
             }
           }
 
-          if (ClangASTContext::IsCXXClassType(member_clang_type) &&
+          if (TypeSystemClang::IsCXXClassType(member_clang_type) &&
               !member_clang_type.GetCompleteType()) {
             if (die.GetCU()->GetProducer() == eProducerClang)
               module_sp->ReportError(
@@ -2862,9 +2862,9 @@ void DWARFASTParserClang::ParseSingleMember(
             // when trying to layout the class. Since we provide layout
             // assistance, all ivars in this class and other classes will
             // be fine, this is the best we can do short of crashing.
-            if (ClangASTContext::StartTagDeclarationDefinition(
+            if (TypeSystemClang::StartTagDeclarationDefinition(
                     member_clang_type)) {
-              ClangASTContext::CompleteTagDeclarationDefinition(
+              TypeSystemClang::CompleteTagDeclarationDefinition(
                   member_clang_type);
             } else {
               module_sp->ReportError(
@@ -2878,7 +2878,7 @@ void DWARFASTParserClang::ParseSingleMember(
             }
           }
 
-          field_decl = ClangASTContext::AddFieldToRecordType(
+          field_decl = TypeSystemClang::AddFieldToRecordType(
               class_clang_type, name, member_clang_type, accessibility,
               bit_size);
 
@@ -2936,8 +2936,8 @@ bool DWARFASTParserClang::ParseChildMembers(
   BitfieldInfo last_field_info;
 
   ModuleSP module_sp = parent_die.GetDWARF()->GetObjectFile()->GetModule();
-  ClangASTContext *ast =
-      llvm::dyn_cast_or_null<ClangASTContext>(class_clang_type.GetTypeSystem());
+  TypeSystemClang *ast =
+      llvm::dyn_cast_or_null<TypeSystemClang>(class_clang_type.GetTypeSystem());
   if (ast == nullptr)
     return false;
 
@@ -3366,7 +3366,7 @@ clang::Decl *DWARFASTParserClang::GetClangDeclForDIE(const DWARFDIE &die) {
     if (dwarf && type) {
       const char *name = die.GetName();
       clang::DeclContext *decl_context =
-          ClangASTContext::DeclContextGetAsDeclContext(
+          TypeSystemClang::DeclContextGetAsDeclContext(
               dwarf->GetDeclContextContainingUID(die.GetID()));
       decl = m_ast.CreateVariableDeclaration(
           decl_context, name,
@@ -3381,7 +3381,7 @@ clang::Decl *DWARFASTParserClang::GetClangDeclForDIE(const DWARFDIE &die) {
       CompilerDecl imported_decl = imported_uid.GetDecl();
       if (imported_decl) {
         clang::DeclContext *decl_context =
-            ClangASTContext::DeclContextGetAsDeclContext(
+            TypeSystemClang::DeclContextGetAsDeclContext(
                 dwarf->GetDeclContextContainingUID(die.GetID()));
         if (clang::NamedDecl *clang_imported_decl =
                 llvm::dyn_cast<clang::NamedDecl>(
@@ -3400,10 +3400,10 @@ clang::Decl *DWARFASTParserClang::GetClangDeclForDIE(const DWARFDIE &die) {
       CompilerDeclContext imported_decl_ctx = imported_uid.GetDeclContext();
       if (imported_decl_ctx) {
         clang::DeclContext *decl_context =
-            ClangASTContext::DeclContextGetAsDeclContext(
+            TypeSystemClang::DeclContextGetAsDeclContext(
                 dwarf->GetDeclContextContainingUID(die.GetID()));
         if (clang::NamespaceDecl *ns_decl =
-                ClangASTContext::DeclContextGetAsNamespaceDecl(
+                TypeSystemClang::DeclContextGetAsNamespaceDecl(
                     imported_decl_ctx))
           decl = m_ast.CreateUsingDirectiveDeclaration(decl_context, ns_decl);
       }

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.h
@@ -21,7 +21,7 @@
 #include "LogChannelDWARF.h"
 #include "lldb/Core/ClangForward.h"
 #include "lldb/Core/PluginInterface.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangASTImporter.h"
 
 #include <vector>
@@ -36,7 +36,7 @@ struct ParsedDWARFTypeAttributes;
 
 class DWARFASTParserClang : public DWARFASTParser {
 public:
-  DWARFASTParserClang(lldb_private::ClangASTContext &ast);
+  DWARFASTParserClang(lldb_private::TypeSystemClang &ast);
 
   ~DWARFASTParserClang() override;
 
@@ -82,7 +82,7 @@ protected:
       DIEToDeclMap;
   typedef llvm::DenseMap<const clang::Decl *, DIEPointerSet> DeclToDIEMap;
 
-  lldb_private::ClangASTContext &m_ast;
+  lldb_private::TypeSystemClang &m_ast;
   DIEToDeclMap m_die_to_decl;
   DeclToDIEMap m_decl_to_die;
   DIEToDeclContextMap m_die_to_decl_ctx;
@@ -97,11 +97,11 @@ protected:
   clang::NamespaceDecl *ResolveNamespaceDIE(const DWARFDIE &die);
 
   bool ParseTemplateDIE(const DWARFDIE &die,
-                        lldb_private::ClangASTContext::TemplateParameterInfos
+                        lldb_private::TypeSystemClang::TemplateParameterInfos
                             &template_param_infos);
   bool ParseTemplateParameterInfos(
       const DWARFDIE &parent_die,
-      lldb_private::ClangASTContext::TemplateParameterInfos
+      lldb_private::TypeSystemClang::TemplateParameterInfos
           &template_param_infos);
 
   bool ParseChildMembers(

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -35,7 +35,7 @@
 #include "lldb/Interpreter/OptionValueProperties.h"
 
 #include "lldb/Symbol/Block.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangUtil.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/CompilerDecl.h"
@@ -1416,8 +1416,8 @@ bool SymbolFileDWARF::HasForwardDeclForClangType(
   }
   TypeSystem *type_system = compiler_type.GetTypeSystem();
 
-  ClangASTContext *clang_type_system =
-      llvm::dyn_cast_or_null<ClangASTContext>(type_system);
+  TypeSystemClang *clang_type_system =
+      llvm::dyn_cast_or_null<TypeSystemClang>(type_system);
   if (!clang_type_system)
     return false;
   DWARFASTParserClang *ast_parser =
@@ -1428,8 +1428,8 @@ bool SymbolFileDWARF::HasForwardDeclForClangType(
 bool SymbolFileDWARF::CompleteType(CompilerType &compiler_type) {
   std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
 
-  ClangASTContext *clang_type_system =
-      llvm::dyn_cast_or_null<ClangASTContext>(compiler_type.GetTypeSystem());
+  TypeSystemClang *clang_type_system =
+      llvm::dyn_cast_or_null<TypeSystemClang>(compiler_type.GetTypeSystem());
   if (clang_type_system) {
     DWARFASTParserClang *ast_parser =
         static_cast<DWARFASTParserClang *>(clang_type_system->GetDWARFParser());
@@ -3972,8 +3972,8 @@ void SymbolFileDWARF::DumpClangAST(Stream &s) {
   auto ts_or_err = GetTypeSystemForLanguage(eLanguageTypeC_plus_plus);
   if (!ts_or_err)
     return;
-  ClangASTContext *clang =
-      llvm::dyn_cast_or_null<ClangASTContext>(&ts_or_err.get());
+  TypeSystemClang *clang =
+      llvm::dyn_cast_or_null<TypeSystemClang>(&ts_or_err.get());
   if (!clang)
     return;
   clang->Dump(s);

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.cpp
@@ -16,7 +16,7 @@
 
 #include "Plugins/Language/CPlusPlus/MSVCUndecoratedNameParser.h"
 #include "lldb/Core/Module.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangASTMetadata.h"
 #include "lldb/Symbol/ClangUtil.h"
 #include "lldb/Symbol/ObjectFile.h"
@@ -202,7 +202,7 @@ static bool IsAnonymousNamespaceName(llvm::StringRef name) {
   return name == "`anonymous namespace'" || name == "`anonymous-namespace'";
 }
 
-PdbAstBuilder::PdbAstBuilder(ObjectFile &obj, PdbIndex &index, ClangASTContext &clang)
+PdbAstBuilder::PdbAstBuilder(ObjectFile &obj, PdbIndex &index, TypeSystemClang &clang)
     : m_index(index), m_clang(clang) {
   BuildParentMap();
 }
@@ -656,7 +656,7 @@ bool PdbAstBuilder::CompleteTagDecl(clang::TagDecl &tag) {
   lldbassert(IsTagRecord(type_id, m_index.tpi()));
 
   clang::QualType tag_qt = m_clang.getASTContext().getTypeDeclType(&tag);
-  ClangASTContext::SetHasExternalStorage(tag_qt.getAsOpaquePtr(), false);
+  TypeSystemClang::SetHasExternalStorage(tag_qt.getAsOpaquePtr(), false);
 
   TypeIndex tag_ti = type_id.index;
   CVType cvt = m_index.tpi().getType(tag_ti);
@@ -781,7 +781,7 @@ clang::QualType PdbAstBuilder::CreateRecordType(PdbTypeSymId id,
 
   lldbassert(ct.IsValid());
 
-  ClangASTContext::StartTagDeclarationDefinition(ct);
+  TypeSystemClang::StartTagDeclarationDefinition(ct);
 
   // Even if it's possible, don't complete it at this point. Just mark it
   // forward resolved, and if/when LLDB needs the full definition, it can
@@ -789,7 +789,7 @@ clang::QualType PdbAstBuilder::CreateRecordType(PdbTypeSymId id,
   clang::QualType result =
       clang::QualType::getFromOpaquePtr(ct.GetOpaqueQualType());
 
-  ClangASTContext::SetHasExternalStorage(result.getAsOpaquePtr(), true);
+  TypeSystemClang::SetHasExternalStorage(result.getAsOpaquePtr(), true);
   return result;
 }
 
@@ -1105,8 +1105,8 @@ clang::QualType PdbAstBuilder::CreateEnumType(PdbTypeSymId id,
       uname.c_str(), decl_context, declaration, ToCompilerType(underlying_type),
       er.isScoped());
 
-  ClangASTContext::StartTagDeclarationDefinition(enum_ct);
-  ClangASTContext::SetHasExternalStorage(enum_ct.GetOpaqueQualType(), true);
+  TypeSystemClang::StartTagDeclarationDefinition(enum_ct);
+  TypeSystemClang::SetHasExternalStorage(enum_ct.GetOpaqueQualType(), true);
 
   return clang::QualType::getFromOpaquePtr(enum_ct.GetOpaqueQualType());
 }

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.h
@@ -51,7 +51,7 @@ struct DeclStatus {
 class PdbAstBuilder {
 public:
   // Constructors and Destructors
-  PdbAstBuilder(ObjectFile &obj, PdbIndex &index, ClangASTContext &clang);
+  PdbAstBuilder(ObjectFile &obj, PdbIndex &index, TypeSystemClang &clang);
 
   lldb_private::CompilerDeclContext GetTranslationUnitDecl();
 
@@ -80,7 +80,7 @@ public:
   clang::Decl *FromCompilerDecl(CompilerDecl decl);
   clang::DeclContext *FromCompilerDeclContext(CompilerDeclContext context);
 
-  ClangASTContext &clang() { return m_clang; }
+  TypeSystemClang &clang() { return m_clang; }
   ClangASTImporter &importer() { return m_importer; }
 
   void Dump(Stream &stream);
@@ -129,7 +129,7 @@ private:
   clang::QualType CreateSimpleType(TypeIndex ti);
 
   PdbIndex &m_index;
-  ClangASTContext &m_clang;
+  TypeSystemClang &m_clang;
 
   ClangASTImporter m_importer;
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -19,7 +19,7 @@
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/StreamBuffer.h"
 #include "lldb/Core/StreamFile.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangUtil.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/LineTable.h"
@@ -331,7 +331,7 @@ void SymbolFileNativePDB::InitializeObject() {
                    std::move(err), "Failed to initialize");
   } else {
     ts_or_err->SetSymbolFile(this);
-    auto *clang = llvm::cast_or_null<ClangASTContext>(&ts_or_err.get());
+    auto *clang = llvm::cast_or_null<TypeSystemClang>(&ts_or_err.get());
     lldbassert(clang);
     m_ast = std::make_unique<PdbAstBuilder>(*m_objfile_sp, *m_index, *clang);
   }

--- a/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
@@ -5,7 +5,7 @@
 #include "PdbSymUid.h"
 #include "PdbUtil.h"
 
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangASTImporter.h"
 #include "lldb/Symbol/Type.h"
 #include "lldb/Utility/LLDBAssert.h"
@@ -128,7 +128,7 @@ Error UdtRecordCompleter::visitKnownMember(
 
   lldb::AccessType access =
       TranslateMemberAccess(static_data_member.getAccess());
-  ClangASTContext::AddVariableToRecordType(
+  TypeSystemClang::AddVariableToRecordType(
       m_derived_ct, static_data_member.Name, member_ct, access);
 
   // FIXME: Add a PdbSymUid namespace for field list members and update
@@ -164,7 +164,7 @@ Error UdtRecordCompleter::visitKnownMember(CVMemberRecord &cvr,
 
   lldb::AccessType access = TranslateMemberAccess(data_member.getAccess());
 
-  clang::FieldDecl *decl = ClangASTContext::AddFieldToRecordType(
+  clang::FieldDecl *decl = TypeSystemClang::AddFieldToRecordType(
       m_derived_ct, data_member.Name, m_ast_builder.ToCompilerType(member_qt),
       access, bitfield_width);
   // FIXME: Add a PdbSymUid namespace for field list members and update
@@ -223,12 +223,12 @@ void UdtRecordCompleter::complete() {
   for (auto &ib : m_bases)
     bases.push_back(std::move(ib.second));
 
-  ClangASTContext &clang = m_ast_builder.clang();
+  TypeSystemClang &clang = m_ast_builder.clang();
   clang.TransferBaseClasses(m_derived_ct.GetOpaqueQualType(), std::move(bases));
 
   clang.AddMethodOverridesForCXXRecordType(m_derived_ct.GetOpaqueQualType());
-  ClangASTContext::BuildIndirectFields(m_derived_ct);
-  ClangASTContext::CompleteTagDeclarationDefinition(m_derived_ct);
+  TypeSystemClang::BuildIndirectFields(m_derived_ct);
+  TypeSystemClang::CompleteTagDeclarationDefinition(m_derived_ct);
 
   if (auto *record_decl = llvm::dyn_cast<clang::CXXRecordDecl>(&m_tag_decl)) {
     m_ast_builder.importer().SetRecordLayout(record_decl, m_layout);

--- a/lldb/source/Plugins/SymbolFile/PDB/PDBASTParser.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/PDBASTParser.cpp
@@ -15,7 +15,7 @@
 #include "clang/AST/DeclCXX.h"
 
 #include "lldb/Core/Module.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangASTMetadata.h"
 #include "lldb/Symbol/ClangUtil.h"
 #include "lldb/Symbol/Declaration.h"
@@ -100,7 +100,7 @@ static lldb::Encoding TranslateEnumEncoding(PDB_VariantType type) {
 }
 
 static CompilerType
-GetBuiltinTypeForPDBEncodingAndBitSize(ClangASTContext &clang_ast,
+GetBuiltinTypeForPDBEncodingAndBitSize(TypeSystemClang &clang_ast,
                                        const PDBSymbolTypeBuiltin &pdb_type,
                                        Encoding encoding, uint32_t width) {
   clang::ASTContext &ast = clang_ast.getASTContext();
@@ -353,7 +353,7 @@ static clang::CallingConv TranslateCallingConvention(PDB_CallingConv pdb_cc) {
   }
 }
 
-PDBASTParser::PDBASTParser(lldb_private::ClangASTContext &ast) : m_ast(ast) {}
+PDBASTParser::PDBASTParser(lldb_private::TypeSystemClang &ast) : m_ast(ast) {}
 
 PDBASTParser::~PDBASTParser() {}
 
@@ -422,15 +422,15 @@ lldb::TypeSP PDBASTParser::CreateLLDBTypeFromPDBType(const PDBSymbol &type) {
           m_ast.getASTContext(), GetMSInheritance(*udt));
       record_decl->addAttr(inheritance_attr);
 
-      ClangASTContext::StartTagDeclarationDefinition(clang_type);
+      TypeSystemClang::StartTagDeclarationDefinition(clang_type);
 
       auto children = udt->findAllChildren();
       if (!children || children->getChildCount() == 0) {
         // PDB does not have symbol of forwarder. We assume we get an udt w/o
         // any fields. Just complete it at this point.
-        ClangASTContext::CompleteTagDeclarationDefinition(clang_type);
+        TypeSystemClang::CompleteTagDeclarationDefinition(clang_type);
 
-        ClangASTContext::SetHasExternalStorage(clang_type.GetOpaqueQualType(),
+        TypeSystemClang::SetHasExternalStorage(clang_type.GetOpaqueQualType(),
                                                false);
 
         type_resolve_state = Type::ResolveState::Full;
@@ -439,7 +439,7 @@ lldb::TypeSP PDBASTParser::CreateLLDBTypeFromPDBType(const PDBSymbol &type) {
         // an endless recursion in CompleteTypeFromUdt function.
         m_forward_decl_to_uid[record_decl] = type.getSymIndexId();
 
-        ClangASTContext::SetHasExternalStorage(clang_type.GetOpaqueQualType(),
+        TypeSystemClang::SetHasExternalStorage(clang_type.GetOpaqueQualType(),
                                                true);
 
         type_resolve_state = Type::ResolveState::Forward;
@@ -499,7 +499,7 @@ lldb::TypeSP PDBASTParser::CreateLLDBTypeFromPDBType(const PDBSymbol &type) {
       ast_enum = m_ast.CreateEnumerationType(name.c_str(), decl_context, decl,
                                              builtin_type, isScoped);
 
-      auto enum_decl = ClangASTContext::GetAsEnumDecl(ast_enum);
+      auto enum_decl = TypeSystemClang::GetAsEnumDecl(ast_enum);
       assert(enum_decl);
       m_uid_to_decl[type.getSymIndexId()] = enum_decl;
 
@@ -512,8 +512,8 @@ lldb::TypeSP PDBASTParser::CreateLLDBTypeFromPDBType(const PDBSymbol &type) {
         }
       }
 
-      if (ClangASTContext::StartTagDeclarationDefinition(ast_enum))
-        ClangASTContext::CompleteTagDeclarationDefinition(ast_enum);
+      if (TypeSystemClang::StartTagDeclarationDefinition(ast_enum))
+        TypeSystemClang::CompleteTagDeclarationDefinition(ast_enum);
     }
 
     if (enum_type->isConstType())
@@ -553,7 +553,7 @@ lldb::TypeSP PDBASTParser::CreateLLDBTypeFromPDBType(const PDBSymbol &type) {
       if (!ast_typedef)
         return nullptr;
 
-      auto typedef_decl = ClangASTContext::GetAsTypedefDecl(ast_typedef);
+      auto typedef_decl = TypeSystemClang::GetAsTypedefDecl(ast_typedef);
       assert(typedef_decl);
       m_uid_to_decl[type.getSymIndexId()] = typedef_decl;
     }
@@ -660,10 +660,10 @@ lldb::TypeSP PDBASTParser::CreateLLDBTypeFromPDBType(const PDBSymbol &type) {
 
     CompilerType element_ast_type = element_type->GetForwardCompilerType();
     // If element type is UDT, it needs to be complete.
-    if (ClangASTContext::IsCXXClassType(element_ast_type) &&
+    if (TypeSystemClang::IsCXXClassType(element_ast_type) &&
         !element_ast_type.GetCompleteType()) {
-      if (ClangASTContext::StartTagDeclarationDefinition(element_ast_type)) {
-        ClangASTContext::CompleteTagDeclarationDefinition(element_ast_type);
+      if (TypeSystemClang::StartTagDeclarationDefinition(element_ast_type)) {
+        TypeSystemClang::CompleteTagDeclarationDefinition(element_ast_type);
       } else {
         // We are not able to start defintion.
         return nullptr;
@@ -721,7 +721,7 @@ lldb::TypeSP PDBASTParser::CreateLLDBTypeFromPDBType(const PDBSymbol &type) {
       assert(class_parent_type);
 
       CompilerType pointer_ast_type;
-      pointer_ast_type = ClangASTContext::CreateMemberPointerType(
+      pointer_ast_type = TypeSystemClang::CreateMemberPointerType(
           class_parent_type->GetLayoutCompilerType(),
           pointee_type->GetForwardCompilerType());
       assert(pointer_ast_type);
@@ -787,7 +787,7 @@ bool PDBASTParser::CompleteTypeFromPDB(
 
   m_forward_decl_to_uid.erase(uid_it);
 
-  ClangASTContext::SetHasExternalStorage(compiler_type.GetOpaqueQualType(),
+  TypeSystemClang::SetHasExternalStorage(compiler_type.GetOpaqueQualType(),
                                          false);
 
   switch (symbol->getSymTag()) {
@@ -1190,8 +1190,8 @@ bool PDBASTParser::CompleteTypeFromUDT(
     AddRecordMethods(symbol_file, compiler_type, *methods_enum);
 
   m_ast.AddMethodOverridesForCXXRecordType(compiler_type.GetOpaqueQualType());
-  ClangASTContext::BuildIndirectFields(compiler_type);
-  ClangASTContext::CompleteTagDeclarationDefinition(compiler_type);
+  TypeSystemClang::BuildIndirectFields(compiler_type);
+  TypeSystemClang::CompleteTagDeclarationDefinition(compiler_type);
 
   clang::CXXRecordDecl *record_decl =
       m_ast.GetAsCXXRecordDecl(compiler_type.GetOpaqueQualType());
@@ -1225,8 +1225,8 @@ void PDBASTParser::AddRecordMembers(
           "which does not have a complete definition.",
           record_type.GetTypeName().GetCString(), member_name.c_str(),
           member_comp_type.GetTypeName().GetCString());
-      if (ClangASTContext::StartTagDeclarationDefinition(member_comp_type))
-        ClangASTContext::CompleteTagDeclarationDefinition(member_comp_type);
+      if (TypeSystemClang::StartTagDeclarationDefinition(member_comp_type))
+        TypeSystemClang::CompleteTagDeclarationDefinition(member_comp_type);
     }
 
     auto access = TranslateMemberAccess(member->getAccess());
@@ -1239,7 +1239,7 @@ void PDBASTParser::AddRecordMembers(
       if (location_type == PDB_LocType::ThisRel)
         bit_size *= 8;
 
-      auto decl = ClangASTContext::AddFieldToRecordType(
+      auto decl = TypeSystemClang::AddFieldToRecordType(
           record_type, member_name.c_str(), member_comp_type, access, bit_size);
       if (!decl)
         continue;
@@ -1255,7 +1255,7 @@ void PDBASTParser::AddRecordMembers(
       break;
     }
     case PDB_DataKind::StaticMember: {
-      auto decl = ClangASTContext::AddVariableToRecordType(
+      auto decl = TypeSystemClang::AddVariableToRecordType(
           record_type, member_name.c_str(), member_comp_type, access);
       if (!decl)
         continue;
@@ -1289,8 +1289,8 @@ void PDBASTParser::AddRecordBases(
           "which does not have a complete definition.",
           record_type.GetTypeName().GetCString(),
           base_comp_type.GetTypeName().GetCString());
-      if (ClangASTContext::StartTagDeclarationDefinition(base_comp_type))
-        ClangASTContext::CompleteTagDeclarationDefinition(base_comp_type);
+      if (TypeSystemClang::StartTagDeclarationDefinition(base_comp_type))
+        TypeSystemClang::CompleteTagDeclarationDefinition(base_comp_type);
     }
 
     auto access = TranslateMemberAccess(base->getAccess());
@@ -1346,8 +1346,8 @@ PDBASTParser::AddRecordMethod(lldb_private::SymbolFile &symbol_file,
         ":: Class '%s' has a method '%s' whose type cannot be completed.",
         record_type.GetTypeName().GetCString(),
         method_comp_type.GetTypeName().GetCString());
-    if (ClangASTContext::StartTagDeclarationDefinition(method_comp_type))
-      ClangASTContext::CompleteTagDeclarationDefinition(method_comp_type);
+    if (TypeSystemClang::StartTagDeclarationDefinition(method_comp_type))
+      TypeSystemClang::CompleteTagDeclarationDefinition(method_comp_type);
   }
 
   AccessType access = TranslateMemberAccess(method.getAccess());

--- a/lldb/source/Plugins/SymbolFile/PDB/PDBASTParser.h
+++ b/lldb/source/Plugins/SymbolFile/PDB/PDBASTParser.h
@@ -23,7 +23,7 @@ class RecordDecl;
 } // namespace clang
 
 namespace lldb_private {
-class ClangASTContext;
+class TypeSystemClang;
 class CompilerType;
 } // namespace lldb_private
 
@@ -42,7 +42,7 @@ class PDBSymbolTypeUDT;
 
 class PDBASTParser {
 public:
-  PDBASTParser(lldb_private::ClangASTContext &ast);
+  PDBASTParser(lldb_private::TypeSystemClang &ast);
   ~PDBASTParser();
 
   lldb::TypeSP CreateLLDBTypeFromPDBType(const llvm::pdb::PDBSymbol &type);
@@ -103,7 +103,7 @@ private:
                   lldb_private::CompilerType &record_type,
                   const llvm::pdb::PDBSymbolFunc &method) const;
 
-  lldb_private::ClangASTContext &m_ast;
+  lldb_private::TypeSystemClang &m_ast;
   lldb_private::ClangASTImporter m_ast_importer;
 
   CXXRecordDeclToUidMap m_forward_decl_to_uid;

--- a/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
@@ -15,7 +15,7 @@
 
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/LineTable.h"
 #include "lldb/Symbol/ObjectFile.h"
@@ -310,8 +310,8 @@ SymbolFilePDB::ParseCompileUnitFunctionForPDBFunc(const PDBSymbolFunc &pdb_func,
     return nullptr;
   }
 
-  ClangASTContext *clang_type_system =
-    llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
+  TypeSystemClang *clang_type_system =
+    llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
   if (!clang_type_system)
     return nullptr;
   clang_type_system->GetPDBParser()->GetDeclForSymbol(pdb_func);
@@ -560,8 +560,8 @@ lldb_private::Type *SymbolFilePDB::ResolveTypeUID(lldb::user_id_t type_uid) {
     return nullptr;
   }
 
-  ClangASTContext *clang_type_system =
-      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
+  TypeSystemClang *clang_type_system =
+      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
   if (!clang_type_system)
     return nullptr;
   PDBASTParser *pdb = clang_type_system->GetPDBParser();
@@ -597,8 +597,8 @@ bool SymbolFilePDB::CompleteType(lldb_private::CompilerType &compiler_type) {
     return false;
   }
 
-  ClangASTContext *clang_ast_ctx =
-      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
+  TypeSystemClang *clang_ast_ctx =
+      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
 
   if (!clang_ast_ctx)
     return false;
@@ -619,8 +619,8 @@ lldb_private::CompilerDecl SymbolFilePDB::GetDeclForUID(lldb::user_id_t uid) {
     return CompilerDecl();
   }
 
-  ClangASTContext *clang_ast_ctx =
-      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
+  TypeSystemClang *clang_ast_ctx =
+      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
   if (!clang_ast_ctx)
     return CompilerDecl();
 
@@ -649,8 +649,8 @@ SymbolFilePDB::GetDeclContextForUID(lldb::user_id_t uid) {
     return CompilerDeclContext();
   }
 
-  ClangASTContext *clang_ast_ctx =
-      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
+  TypeSystemClang *clang_ast_ctx =
+      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
   if (!clang_ast_ctx)
     return CompilerDeclContext();
 
@@ -679,8 +679,8 @@ SymbolFilePDB::GetDeclContextContainingUID(lldb::user_id_t uid) {
     return CompilerDeclContext();
   }
 
-  ClangASTContext *clang_ast_ctx =
-      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
+  TypeSystemClang *clang_ast_ctx =
+      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
   if (!clang_ast_ctx)
     return CompilerDeclContext();
 
@@ -708,8 +708,8 @@ void SymbolFilePDB::ParseDeclsForContext(
     return;
   }
 
-  ClangASTContext *clang_ast_ctx =
-      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
+  TypeSystemClang *clang_ast_ctx =
+      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
   if (!clang_ast_ctx)
     return;
 
@@ -1450,7 +1450,7 @@ void SymbolFilePDB::DumpClangAST(Stream &s) {
   }
 
   auto *clang_type_system =
-      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
+      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
   if (!clang_type_system)
     return;
   clang_type_system->Dump(s);
@@ -1663,7 +1663,7 @@ PDBASTParser *SymbolFilePDB::GetPDBAstParser() {
   }
 
   auto *clang_type_system =
-      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
+      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
   if (!clang_type_system)
     return nullptr;
 
@@ -1685,7 +1685,7 @@ lldb_private::CompilerDeclContext SymbolFilePDB::FindNamespace(
   }
 
   auto *clang_type_system =
-      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
+      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
   if (!clang_type_system)
     return CompilerDeclContext();
 

--- a/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetItemInfoHandler.cpp
+++ b/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetItemInfoHandler.cpp
@@ -15,7 +15,7 @@
 #include "lldb/Expression/DiagnosticManager.h"
 #include "lldb/Expression/FunctionCaller.h"
 #include "lldb/Expression/UtilityFunction.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/Symbol.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/Process.h"
@@ -229,7 +229,7 @@ AppleGetItemInfoHandler::GetItemInfo(Thread &thread, uint64_t item,
   lldb::StackFrameSP thread_cur_frame = thread.GetStackFrameAtIndex(0);
   ProcessSP process_sp(thread.CalculateProcess());
   TargetSP target_sp(thread.CalculateTarget());
-  ClangASTContext *clang_ast_context = ClangASTContext::GetScratch(*target_sp);
+  TypeSystemClang *clang_ast_context = TypeSystemClang::GetScratch(*target_sp);
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_SYSTEM_RUNTIME));
 
   GetItemInfoReturnInfo return_value;

--- a/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetPendingItemsHandler.cpp
+++ b/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetPendingItemsHandler.cpp
@@ -15,7 +15,7 @@
 #include "lldb/Expression/DiagnosticManager.h"
 #include "lldb/Expression/FunctionCaller.h"
 #include "lldb/Expression/UtilityFunction.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/Symbol.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/Process.h"
@@ -176,8 +176,8 @@ lldb::addr_t AppleGetPendingItemsHandler::SetupGetPendingItemsFunction(
 
       // Next make the runner function for our implementation utility function.
       Status error;
-      ClangASTContext *clang_ast_context =
-          ClangASTContext::GetScratch(thread.GetProcess()->GetTarget());
+      TypeSystemClang *clang_ast_context =
+          TypeSystemClang::GetScratch(thread.GetProcess()->GetTarget());
       CompilerType get_pending_items_return_type =
           clang_ast_context->GetBasicType(eBasicTypeVoid).GetPointerType();
       get_pending_items_caller =
@@ -228,7 +228,7 @@ AppleGetPendingItemsHandler::GetPendingItems(Thread &thread, addr_t queue,
   lldb::StackFrameSP thread_cur_frame = thread.GetStackFrameAtIndex(0);
   ProcessSP process_sp(thread.CalculateProcess());
   TargetSP target_sp(thread.CalculateTarget());
-  ClangASTContext *clang_ast_context = ClangASTContext::GetScratch(*target_sp);
+  TypeSystemClang *clang_ast_context = TypeSystemClang::GetScratch(*target_sp);
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_SYSTEM_RUNTIME));
 
   GetPendingItemsReturnInfo return_value;

--- a/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetQueuesHandler.cpp
+++ b/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetQueuesHandler.cpp
@@ -13,7 +13,7 @@
 #include "lldb/Expression/DiagnosticManager.h"
 #include "lldb/Expression/FunctionCaller.h"
 #include "lldb/Expression/UtilityFunction.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/Symbol.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/Process.h"
@@ -190,8 +190,8 @@ AppleGetQueuesHandler::SetupGetQueuesFunction(Thread &thread,
     }
 
     // Next make the runner function for our implementation utility function.
-    ClangASTContext *clang_ast_context =
-        ClangASTContext::GetScratch(thread.GetProcess()->GetTarget());
+    TypeSystemClang *clang_ast_context =
+        TypeSystemClang::GetScratch(thread.GetProcess()->GetTarget());
     CompilerType get_queues_return_type =
         clang_ast_context->GetBasicType(eBasicTypeVoid).GetPointerType();
     Status error;
@@ -231,7 +231,7 @@ AppleGetQueuesHandler::GetCurrentQueues(Thread &thread, addr_t page_to_free,
   lldb::StackFrameSP thread_cur_frame = thread.GetStackFrameAtIndex(0);
   ProcessSP process_sp(thread.CalculateProcess());
   TargetSP target_sp(thread.CalculateTarget());
-  ClangASTContext *clang_ast_context = ClangASTContext::GetScratch(*target_sp);
+  TypeSystemClang *clang_ast_context = TypeSystemClang::GetScratch(*target_sp);
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_SYSTEM_RUNTIME));
 
   GetQueuesReturnInfo return_value;

--- a/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetThreadItemInfoHandler.cpp
+++ b/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetThreadItemInfoHandler.cpp
@@ -16,7 +16,7 @@
 #include "lldb/Expression/Expression.h"
 #include "lldb/Expression/FunctionCaller.h"
 #include "lldb/Expression/UtilityFunction.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/Symbol.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/Process.h"
@@ -185,8 +185,8 @@ lldb::addr_t AppleGetThreadItemInfoHandler::SetupGetThreadItemInfoFunction(
 
       // Also make the FunctionCaller for this UtilityFunction:
 
-      ClangASTContext *clang_ast_context =
-          ClangASTContext::GetScratch(thread.GetProcess()->GetTarget());
+      TypeSystemClang *clang_ast_context =
+          TypeSystemClang::GetScratch(thread.GetProcess()->GetTarget());
       CompilerType get_thread_item_info_return_type =
           clang_ast_context->GetBasicType(eBasicTypeVoid).GetPointerType();
 
@@ -237,7 +237,7 @@ AppleGetThreadItemInfoHandler::GetThreadItemInfo(Thread &thread,
   lldb::StackFrameSP thread_cur_frame = thread.GetStackFrameAtIndex(0);
   ProcessSP process_sp(thread.CalculateProcess());
   TargetSP target_sp(thread.CalculateTarget());
-  ClangASTContext *clang_ast_context = ClangASTContext::GetScratch(*target_sp);
+  TypeSystemClang *clang_ast_context = TypeSystemClang::GetScratch(*target_sp);
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_SYSTEM_RUNTIME));
 
   GetThreadItemInfoReturnInfo return_value;

--- a/lldb/source/Plugins/SystemRuntime/MacOSX/SystemRuntimeMacOSX.cpp
+++ b/lldb/source/Plugins/SystemRuntime/MacOSX/SystemRuntimeMacOSX.cpp
@@ -12,7 +12,7 @@
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/Section.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Symbol/SymbolContext.h"
 #include "lldb/Target/Process.h"
@@ -411,8 +411,8 @@ void SystemRuntimeMacOSX::ReadLibdispatchTSDIndexes() {
         }
 #endif
 
-    ClangASTContext *ast_ctx =
-        ClangASTContext::GetScratch(m_process->GetTarget());
+    TypeSystemClang *ast_ctx =
+        TypeSystemClang::GetScratch(m_process->GetTarget());
     if (m_dispatch_tsd_indexes_addr != LLDB_INVALID_ADDRESS) {
       CompilerType uint16 =
           ast_ctx->GetBuiltinTypeForEncodingAndBitSize(eEncodingUint, 16);
@@ -420,20 +420,20 @@ void SystemRuntimeMacOSX::ReadLibdispatchTSDIndexes() {
           nullptr, lldb::eAccessPublic, "__lldb_dispatch_tsd_indexes_s",
           clang::TTK_Struct, lldb::eLanguageTypeC);
 
-      ClangASTContext::StartTagDeclarationDefinition(dispatch_tsd_indexes_s);
-      ClangASTContext::AddFieldToRecordType(dispatch_tsd_indexes_s,
+      TypeSystemClang::StartTagDeclarationDefinition(dispatch_tsd_indexes_s);
+      TypeSystemClang::AddFieldToRecordType(dispatch_tsd_indexes_s,
                                             "dti_version", uint16,
                                             lldb::eAccessPublic, 0);
-      ClangASTContext::AddFieldToRecordType(dispatch_tsd_indexes_s,
+      TypeSystemClang::AddFieldToRecordType(dispatch_tsd_indexes_s,
                                             "dti_queue_index", uint16,
                                             lldb::eAccessPublic, 0);
-      ClangASTContext::AddFieldToRecordType(dispatch_tsd_indexes_s,
+      TypeSystemClang::AddFieldToRecordType(dispatch_tsd_indexes_s,
                                             "dti_voucher_index", uint16,
                                             lldb::eAccessPublic, 0);
-      ClangASTContext::AddFieldToRecordType(dispatch_tsd_indexes_s,
+      TypeSystemClang::AddFieldToRecordType(dispatch_tsd_indexes_s,
                                             "dti_qos_class_index", uint16,
                                             lldb::eAccessPublic, 0);
-      ClangASTContext::CompleteTagDeclarationDefinition(dispatch_tsd_indexes_s);
+      TypeSystemClang::CompleteTagDeclarationDefinition(dispatch_tsd_indexes_s);
 
       ProcessStructReader struct_reader(m_process, m_dispatch_tsd_indexes_addr,
                                         dispatch_tsd_indexes_s);

--- a/lldb/source/Symbol/CMakeLists.txt
+++ b/lldb/source/Symbol/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 add_lldb_library(lldbSymbol
   ArmUnwindInfo.cpp
   Block.cpp
-  ClangASTContext.cpp
+  TypeSystemClang.cpp
   ClangASTImporter.cpp
   ClangASTMetadata.cpp
   ClangExternalASTSourceCallbacks.cpp

--- a/lldb/source/Symbol/ClangASTImporter.cpp
+++ b/lldb/source/Symbol/ClangASTImporter.cpp
@@ -8,7 +8,7 @@
 
 #include "lldb/Symbol/ClangASTImporter.h"
 #include "lldb/Core/Module.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangASTMetadata.h"
 #include "lldb/Symbol/ClangUtil.h"
 #include "lldb/Utility/LLDBAssert.h"
@@ -25,12 +25,12 @@
 using namespace lldb_private;
 using namespace clang;
 
-CompilerType ClangASTImporter::CopyType(ClangASTContext &dst_ast,
+CompilerType ClangASTImporter::CopyType(TypeSystemClang &dst_ast,
                                         const CompilerType &src_type) {
   clang::ASTContext &dst_clang_ast = dst_ast.getASTContext();
 
-  ClangASTContext *src_ast =
-      llvm::dyn_cast_or_null<ClangASTContext>(src_type.GetTypeSystem());
+  TypeSystemClang *src_ast =
+      llvm::dyn_cast_or_null<TypeSystemClang>(src_type.GetTypeSystem());
   if (!src_ast)
     return CompilerType();
 
@@ -250,7 +250,7 @@ public:
       Decl *original_decl = to_context_md->m_origins[decl].decl;
 
       // Complete the decl now.
-      ClangASTContext::GetCompleteDecl(m_src_ctx, original_decl);
+      TypeSystemClang::GetCompleteDecl(m_src_ctx, original_decl);
       if (auto *tag_decl = dyn_cast<TagDecl>(decl)) {
         if (auto *original_tag_decl = dyn_cast<TagDecl>(original_decl)) {
           if (original_tag_decl->isCompleteDefinition()) {
@@ -292,12 +292,12 @@ public:
 };
 } // namespace
 
-CompilerType ClangASTImporter::DeportType(ClangASTContext &dst,
+CompilerType ClangASTImporter::DeportType(TypeSystemClang &dst,
                                           const CompilerType &src_type) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
 
-  ClangASTContext *src_ctxt =
-      llvm::cast<ClangASTContext>(src_type.GetTypeSystem());
+  TypeSystemClang *src_ctxt =
+      llvm::cast<TypeSystemClang>(src_type.GetTypeSystem());
 
   LLDB_LOG(log,
            "    [ClangASTImporter] DeportType called on ({0}Type*){1:x} "
@@ -505,11 +505,11 @@ bool ClangASTImporter::CompleteType(const CompilerType &compiler_type) {
     return false;
 
   if (Import(compiler_type)) {
-    ClangASTContext::CompleteTagDeclarationDefinition(compiler_type);
+    TypeSystemClang::CompleteTagDeclarationDefinition(compiler_type);
     return true;
   }
 
-  ClangASTContext::SetHasExternalStorage(compiler_type.GetOpaqueQualType(),
+  TypeSystemClang::SetHasExternalStorage(compiler_type.GetOpaqueQualType(),
                                          false);
   return false;
 }
@@ -580,7 +580,7 @@ bool ClangASTImporter::CompleteTagDecl(clang::TagDecl *decl) {
   if (!decl_origin.Valid())
     return false;
 
-  if (!ClangASTContext::GetCompleteDecl(decl_origin.ctx, decl_origin.decl))
+  if (!TypeSystemClang::GetCompleteDecl(decl_origin.ctx, decl_origin.decl))
     return false;
 
   ImporterDelegateSP delegate_sp(
@@ -598,7 +598,7 @@ bool ClangASTImporter::CompleteTagDeclWithOrigin(clang::TagDecl *decl,
                                                  clang::TagDecl *origin_decl) {
   clang::ASTContext *origin_ast_ctx = &origin_decl->getASTContext();
 
-  if (!ClangASTContext::GetCompleteDecl(origin_ast_ctx, origin_decl))
+  if (!TypeSystemClang::GetCompleteDecl(origin_ast_ctx, origin_decl))
     return false;
 
   ImporterDelegateSP delegate_sp(
@@ -623,7 +623,7 @@ bool ClangASTImporter::CompleteObjCInterfaceDecl(
   if (!decl_origin.Valid())
     return false;
 
-  if (!ClangASTContext::GetCompleteDecl(decl_origin.ctx, decl_origin.decl))
+  if (!TypeSystemClang::GetCompleteDecl(decl_origin.ctx, decl_origin.decl))
     return false;
 
   ImporterDelegateSP delegate_sp(
@@ -738,10 +738,10 @@ ClangASTMetadata *ClangASTImporter::GetDeclMetadata(const clang::Decl *decl) {
   DeclOrigin decl_origin = GetDeclOrigin(decl);
 
   if (decl_origin.Valid()) {
-    ClangASTContext *ast = ClangASTContext::GetASTContext(decl_origin.ctx);
+    TypeSystemClang *ast = TypeSystemClang::GetASTContext(decl_origin.ctx);
     return ast->GetMetadata(decl_origin.decl);
   }
-  ClangASTContext *ast = ClangASTContext::GetASTContext(&decl->getASTContext());
+  TypeSystemClang *ast = TypeSystemClang::GetASTContext(&decl->getASTContext());
   return ast->GetMetadata(decl);
 }
 

--- a/lldb/source/Symbol/ClangExternalASTSourceCallbacks.cpp
+++ b/lldb/source/Symbol/ClangExternalASTSourceCallbacks.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Symbol/ClangExternalASTSourceCallbacks.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 
 #include "clang/AST/Decl.h"
 

--- a/lldb/source/Symbol/ClangUtil.cpp
+++ b/lldb/source/Symbol/ClangUtil.cpp
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Symbol/ClangUtil.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 
 using namespace clang;
 using namespace lldb_private;
@@ -19,7 +19,7 @@ bool ClangUtil::IsClangType(const CompilerType &ct) {
   if (!ct)
     return false;
 
-  if (llvm::dyn_cast_or_null<ClangASTContext>(ct.GetTypeSystem()) == nullptr)
+  if (llvm::dyn_cast_or_null<TypeSystemClang>(ct.GetTypeSystem()) == nullptr)
     return false;
 
   if (!ct.GetOpaqueQualType())

--- a/lldb/source/Symbol/CxxModuleHandler.cpp
+++ b/lldb/source/Symbol/CxxModuleHandler.cpp
@@ -8,7 +8,7 @@
 
 #include "lldb/Symbol/CxxModuleHandler.h"
 
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Utility/Log.h"
 #include "clang/Sema/Lookup.h"
 #include "llvm/Support/Error.h"
@@ -18,7 +18,7 @@ using namespace clang;
 
 CxxModuleHandler::CxxModuleHandler(ASTImporter &importer, ASTContext *target)
     : m_importer(&importer),
-      m_sema(ClangASTContext::GetASTContext(target)->getSema()) {
+      m_sema(TypeSystemClang::GetASTContext(target)->getSema()) {
 
   std::initializer_list<const char *> supported_names = {
       // containers

--- a/lldb/source/Symbol/Type.cpp
+++ b/lldb/source/Symbol/Type.cpp
@@ -536,7 +536,7 @@ bool Type::ResolveClangType(ResolveState compiler_type_resolve_state) {
         LLDB_LOG_ERROR(
             lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_SYMBOLS),
             std::move(err),
-            "Unable to construct void type from ClangASTContext");
+            "Unable to construct void type from TypeSystemClang");
       } else {
         CompilerType void_compiler_type =
             type_system_or_err->GetBasicTypeFromAST(eBasicTypeVoid);

--- a/lldb/source/Symbol/TypeSystemClang.cpp
+++ b/lldb/source/Symbol/TypeSystemClang.cpp
@@ -1,4 +1,4 @@
-//===-- ClangASTContext.cpp -------------------------------------*- C++ -*-===//
+//===-- TypeSystemClang.cpp -------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 
 #include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -90,7 +90,7 @@ static void VerifyDecl(clang::Decl *decl) {
 #endif
 
 static inline bool
-ClangASTContextSupportsLanguage(lldb::LanguageType language) {
+TypeSystemClangSupportsLanguage(lldb::LanguageType language) {
   return language == eLanguageTypeUnknown || // Clang is the default type system
          lldb_private::Language::LanguageIsC(language) ||
          lldb_private::Language::LanguageIsCPlusPlus(language) ||
@@ -300,7 +300,7 @@ static bool GetVBaseBitOffset(VTableContextBase &vtable_ctx,
   return true;
 }
 
-typedef lldb_private::ThreadSafeDenseMap<clang::ASTContext *, ClangASTContext *>
+typedef lldb_private::ThreadSafeDenseMap<clang::ASTContext *, TypeSystemClang *>
     ClangASTMap;
 
 static ClangASTMap &GetASTMap() {
@@ -312,9 +312,9 @@ static ClangASTMap &GetASTMap() {
   return *g_map_ptr;
 }
 
-char ClangASTContext::ID;
+char TypeSystemClang::ID;
 
-bool ClangASTContext::IsOperator(llvm::StringRef name,
+bool TypeSystemClang::IsOperator(llvm::StringRef name,
                                  clang::OverloadedOperatorKind &op_kind) {
   // All operators have to start with "operator".
   if (!name.consume_front("operator"))
@@ -395,7 +395,7 @@ bool ClangASTContext::IsOperator(llvm::StringRef name,
 }
 
 clang::AccessSpecifier
-ClangASTContext::ConvertAccessTypeToAccessSpecifier(AccessType access) {
+TypeSystemClang::ConvertAccessTypeToAccessSpecifier(AccessType access) {
   switch (access) {
   default:
     break;
@@ -499,15 +499,15 @@ static void ParseLangArgs(LangOptions &Opts, InputKind IK, const char *triple) {
   Opts.NoInlineDefine = !Opt;
 }
 
-ClangASTContext::ClangASTContext(llvm::Triple target_triple) {
+TypeSystemClang::TypeSystemClang(llvm::Triple target_triple) {
   if (!target_triple.str().empty())
     SetTargetTriple(target_triple.str());
   // The caller didn't pass an ASTContext so create a new one for this
-  // ClangASTContext.
+  // TypeSystemClang.
   CreateASTContext();
 }
 
-ClangASTContext::ClangASTContext(ASTContext &existing_ctxt) {
+TypeSystemClang::TypeSystemClang(ASTContext &existing_ctxt) {
   SetTargetTriple(existing_ctxt.getTargetInfo().getTriple().str());
 
   m_ast_up.reset(&existing_ctxt);
@@ -515,22 +515,22 @@ ClangASTContext::ClangASTContext(ASTContext &existing_ctxt) {
 }
 
 // Destructor
-ClangASTContext::~ClangASTContext() { Finalize(); }
+TypeSystemClang::~TypeSystemClang() { Finalize(); }
 
-ConstString ClangASTContext::GetPluginNameStatic() {
+ConstString TypeSystemClang::GetPluginNameStatic() {
   return ConstString("clang");
 }
 
-ConstString ClangASTContext::GetPluginName() {
-  return ClangASTContext::GetPluginNameStatic();
+ConstString TypeSystemClang::GetPluginName() {
+  return TypeSystemClang::GetPluginNameStatic();
 }
 
-uint32_t ClangASTContext::GetPluginVersion() { return 1; }
+uint32_t TypeSystemClang::GetPluginVersion() { return 1; }
 
-lldb::TypeSystemSP ClangASTContext::CreateInstance(lldb::LanguageType language,
+lldb::TypeSystemSP TypeSystemClang::CreateInstance(lldb::LanguageType language,
                                                    lldb_private::Module *module,
                                                    Target *target) {
-  if (!ClangASTContextSupportsLanguage(language))
+  if (!TypeSystemClangSupportsLanguage(language))
     return lldb::TypeSystemSP();
   ArchSpec arch;
   if (module)
@@ -557,13 +557,13 @@ lldb::TypeSystemSP ClangASTContext::CreateInstance(lldb::LanguageType language,
   }
 
   if (module)
-    return std::make_shared<ClangASTContext>(triple);
+    return std::make_shared<TypeSystemClang>(triple);
   else if (target && target->IsValid())
-    return std::make_shared<ClangASTContextForExpressions>(*target, triple);
+    return std::make_shared<TypeSystemClangForExpressions>(*target, triple);
   return lldb::TypeSystemSP();
 }
 
-LanguageSet ClangASTContext::GetSupportedLanguagesForTypes() {
+LanguageSet TypeSystemClang::GetSupportedLanguagesForTypes() {
   LanguageSet languages;
   languages.Insert(lldb::eLanguageTypeC89);
   languages.Insert(lldb::eLanguageTypeC);
@@ -579,7 +579,7 @@ LanguageSet ClangASTContext::GetSupportedLanguagesForTypes() {
   return languages;
 }
 
-LanguageSet ClangASTContext::GetSupportedLanguagesForExpressions() {
+LanguageSet TypeSystemClang::GetSupportedLanguagesForExpressions() {
   LanguageSet languages;
   languages.Insert(lldb::eLanguageTypeC_plus_plus);
   languages.Insert(lldb::eLanguageTypeObjC_plus_plus);
@@ -589,17 +589,17 @@ LanguageSet ClangASTContext::GetSupportedLanguagesForExpressions() {
   return languages;
 }
 
-void ClangASTContext::Initialize() {
+void TypeSystemClang::Initialize() {
   PluginManager::RegisterPlugin(
       GetPluginNameStatic(), "clang base AST context plug-in", CreateInstance,
       GetSupportedLanguagesForTypes(), GetSupportedLanguagesForExpressions());
 }
 
-void ClangASTContext::Terminate() {
+void TypeSystemClang::Terminate() {
   PluginManager::UnregisterPlugin(CreateInstance);
 }
 
-void ClangASTContext::Finalize() {
+void TypeSystemClang::Finalize() {
   assert(m_ast_up);
   GetASTMap().Erase(m_ast_up.get());
   if (!m_ast_owned)
@@ -615,28 +615,28 @@ void ClangASTContext::Finalize() {
   m_language_options_up.reset();
 }
 
-void ClangASTContext::setSema(Sema *s) {
+void TypeSystemClang::setSema(Sema *s) {
   // Ensure that the new sema actually belongs to our ASTContext.
   assert(s == nullptr || &s->getASTContext() == m_ast_up.get());
   m_sema = s;
 }
 
-const char *ClangASTContext::GetTargetTriple() {
+const char *TypeSystemClang::GetTargetTriple() {
   return m_target_triple.c_str();
 }
 
-void ClangASTContext::SetTargetTriple(llvm::StringRef target_triple) {
+void TypeSystemClang::SetTargetTriple(llvm::StringRef target_triple) {
   m_target_triple = target_triple.str();
 }
 
-void ClangASTContext::SetExternalSource(
+void TypeSystemClang::SetExternalSource(
     llvm::IntrusiveRefCntPtr<ExternalASTSource> &ast_source_up) {
   ASTContext &ast = getASTContext();
   ast.setExternalSource(ast_source_up);
   ast.getTranslationUnitDecl()->setHasExternalLexicalStorage(true);
 }
 
-ASTContext &ClangASTContext::getASTContext() {
+ASTContext &TypeSystemClang::getASTContext() {
   assert(m_ast_up);
   return *m_ast_up;
 }
@@ -665,7 +665,7 @@ private:
   Log *m_log;
 };
 
-void ClangASTContext::CreateASTContext() {
+void TypeSystemClang::CreateASTContext() {
   assert(!m_ast_up);
   m_ast_owned = true;
 
@@ -710,18 +710,18 @@ void ClangASTContext::CreateASTContext() {
   SetExternalSource(ast_source_up);
 }
 
-ClangASTContext *ClangASTContext::GetASTContext(clang::ASTContext *ast) {
-  ClangASTContext *clang_ast = GetASTMap().Lookup(ast);
+TypeSystemClang *TypeSystemClang::GetASTContext(clang::ASTContext *ast) {
+  TypeSystemClang *clang_ast = GetASTMap().Lookup(ast);
   return clang_ast;
 }
 
-clang::MangleContext *ClangASTContext::getMangleContext() {
+clang::MangleContext *TypeSystemClang::getMangleContext() {
   if (m_mangle_ctx_up == nullptr)
     m_mangle_ctx_up.reset(getASTContext().createMangleContext());
   return m_mangle_ctx_up.get();
 }
 
-std::shared_ptr<clang::TargetOptions> &ClangASTContext::getTargetOptions() {
+std::shared_ptr<clang::TargetOptions> &TypeSystemClang::getTargetOptions() {
   if (m_target_options_rp == nullptr && !m_target_triple.empty()) {
     m_target_options_rp = std::make_shared<clang::TargetOptions>();
     if (m_target_options_rp != nullptr)
@@ -730,7 +730,7 @@ std::shared_ptr<clang::TargetOptions> &ClangASTContext::getTargetOptions() {
   return m_target_options_rp;
 }
 
-TargetInfo *ClangASTContext::getTargetInfo() {
+TargetInfo *TypeSystemClang::getTargetInfo() {
   // target_triple should be something like "x86_64-apple-macosx"
   if (m_target_info_up == nullptr && !m_target_triple.empty())
     m_target_info_up.reset(TargetInfo::CreateTargetInfo(
@@ -747,7 +747,7 @@ static inline bool QualTypeMatchesBitSize(const uint64_t bit_size,
 }
 
 CompilerType
-ClangASTContext::GetBuiltinTypeForEncodingAndBitSize(Encoding encoding,
+TypeSystemClang::GetBuiltinTypeForEncodingAndBitSize(Encoding encoding,
                                                      size_t bit_size) {
   ASTContext &ast = getASTContext();
   switch (encoding) {
@@ -808,7 +808,7 @@ ClangASTContext::GetBuiltinTypeForEncodingAndBitSize(Encoding encoding,
 }
 
 lldb::BasicType
-ClangASTContext::GetBasicTypeEnumeration(ConstString name) {
+TypeSystemClang::GetBasicTypeEnumeration(ConstString name) {
   if (name) {
     typedef UniqueCStringMap<lldb::BasicType> TypeNameToBasicTypeMap;
     static TypeNameToBasicTypeMap g_type_map;
@@ -873,7 +873,7 @@ ClangASTContext::GetBasicTypeEnumeration(ConstString name) {
   return eBasicTypeInvalid;
 }
 
-uint32_t ClangASTContext::GetPointerByteSize() {
+uint32_t TypeSystemClang::GetPointerByteSize() {
   if (m_pointer_byte_size == 0)
     if (auto size = GetBasicType(lldb::eBasicTypeVoid)
                         .GetPointerType()
@@ -882,7 +882,7 @@ uint32_t ClangASTContext::GetPointerByteSize() {
   return m_pointer_byte_size;
 }
 
-CompilerType ClangASTContext::GetBasicType(lldb::BasicType basic_type) {
+CompilerType TypeSystemClang::GetBasicType(lldb::BasicType basic_type) {
   clang::ASTContext &ast = getASTContext();
 
   lldb::opaque_compiler_type_t clang_type =
@@ -893,7 +893,7 @@ CompilerType ClangASTContext::GetBasicType(lldb::BasicType basic_type) {
   return CompilerType();
 }
 
-CompilerType ClangASTContext::GetBuiltinTypeForDWARFEncodingAndBitSize(
+CompilerType TypeSystemClang::GetBuiltinTypeForDWARFEncodingAndBitSize(
     llvm::StringRef type_name, uint32_t dw_ate, uint32_t bit_size) {
   ASTContext &ast = getASTContext();
 
@@ -1106,7 +1106,7 @@ CompilerType ClangASTContext::GetBuiltinTypeForDWARFEncodingAndBitSize(
   return CompilerType();
 }
 
-CompilerType ClangASTContext::GetCStringType(bool is_const) {
+CompilerType TypeSystemClang::GetCStringType(bool is_const) {
   ASTContext &ast = getASTContext();
   QualType char_type(ast.CharTy);
 
@@ -1116,10 +1116,10 @@ CompilerType ClangASTContext::GetCStringType(bool is_const) {
   return GetType(ast.getPointerType(char_type));
 }
 
-bool ClangASTContext::AreTypesSame(CompilerType type1, CompilerType type2,
+bool TypeSystemClang::AreTypesSame(CompilerType type1, CompilerType type2,
                                    bool ignore_qualifiers) {
-  ClangASTContext *ast =
-      llvm::dyn_cast_or_null<ClangASTContext>(type1.GetTypeSystem());
+  TypeSystemClang *ast =
+      llvm::dyn_cast_or_null<TypeSystemClang>(type1.GetTypeSystem());
   if (!ast || ast != type2.GetTypeSystem())
     return false;
 
@@ -1137,7 +1137,7 @@ bool ClangASTContext::AreTypesSame(CompilerType type1, CompilerType type2,
   return ast->getASTContext().hasSameType(type1_qual, type2_qual);
 }
 
-CompilerType ClangASTContext::GetTypeForDecl(void *opaque_decl) {
+CompilerType TypeSystemClang::GetTypeForDecl(void *opaque_decl) {
   if (!opaque_decl)
     return CompilerType();
 
@@ -1147,13 +1147,13 @@ CompilerType ClangASTContext::GetTypeForDecl(void *opaque_decl) {
   return CompilerType();
 }
 
-CompilerDeclContext ClangASTContext::CreateDeclContext(DeclContext *ctx) {
+CompilerDeclContext TypeSystemClang::CreateDeclContext(DeclContext *ctx) {
   // Check that the DeclContext actually belongs to this ASTContext.
   assert(&ctx->getParentASTContext() == &getASTContext());
   return CompilerDeclContext(this, ctx);
 }
 
-CompilerType ClangASTContext::GetTypeForDecl(clang::NamedDecl *decl) {
+CompilerType TypeSystemClang::GetTypeForDecl(clang::NamedDecl *decl) {
   if (clang::ObjCInterfaceDecl *interface_decl =
       llvm::dyn_cast<clang::ObjCInterfaceDecl>(decl))
     return GetTypeForDecl(interface_decl);
@@ -1162,17 +1162,17 @@ CompilerType ClangASTContext::GetTypeForDecl(clang::NamedDecl *decl) {
   return CompilerType();
 }
 
-CompilerType ClangASTContext::GetTypeForDecl(TagDecl *decl) {
+CompilerType TypeSystemClang::GetTypeForDecl(TagDecl *decl) {
   return GetType(getASTContext().getTagDeclType(decl));
 }
 
-CompilerType ClangASTContext::GetTypeForDecl(ObjCInterfaceDecl *decl) {
+CompilerType TypeSystemClang::GetTypeForDecl(ObjCInterfaceDecl *decl) {
   return GetType(getASTContext().getObjCInterfaceType(decl));
 }
 
 #pragma mark Structure, Unions, Classes
 
-CompilerType ClangASTContext::CreateRecordType(DeclContext *decl_ctx,
+CompilerType TypeSystemClang::CreateRecordType(DeclContext *decl_ctx,
                                                AccessType access_type,
                                                llvm::StringRef name, int kind,
                                                LanguageType language,
@@ -1254,7 +1254,7 @@ namespace {
 
 static TemplateParameterList *CreateTemplateParameterList(
     ASTContext *ast,
-    const ClangASTContext::TemplateParameterInfos &template_param_infos,
+    const TypeSystemClang::TemplateParameterInfos &template_param_infos,
     llvm::SmallVector<NamedDecl *, 8> &template_param_decls) {
   const bool parameter_pack = false;
   const bool is_typename = false;
@@ -1310,7 +1310,7 @@ static TemplateParameterList *CreateTemplateParameterList(
   return template_param_list;
 }
 
-clang::FunctionTemplateDecl *ClangASTContext::CreateFunctionTemplateDecl(
+clang::FunctionTemplateDecl *TypeSystemClang::CreateFunctionTemplateDecl(
     clang::DeclContext *decl_ctx, clang::FunctionDecl *func_decl,
     const char *name, const TemplateParameterInfos &template_param_infos) {
   //    /// Create a function template node.
@@ -1338,7 +1338,7 @@ clang::FunctionTemplateDecl *ClangASTContext::CreateFunctionTemplateDecl(
   return func_tmpl_decl;
 }
 
-void ClangASTContext::CreateFunctionTemplateSpecializationInfo(
+void TypeSystemClang::CreateFunctionTemplateSpecializationInfo(
     FunctionDecl *func_decl, clang::FunctionTemplateDecl *func_tmpl_decl,
     const TemplateParameterInfos &infos) {
   TemplateArgumentList *template_args_ptr =
@@ -1348,7 +1348,7 @@ void ClangASTContext::CreateFunctionTemplateSpecializationInfo(
                                                template_args_ptr, nullptr);
 }
 
-ClassTemplateDecl *ClangASTContext::CreateClassTemplateDecl(
+ClassTemplateDecl *TypeSystemClang::CreateClassTemplateDecl(
     DeclContext *decl_ctx, lldb::AccessType access_type, const char *class_name,
     int kind, const TemplateParameterInfos &template_param_infos) {
   ASTContext &ast = getASTContext();
@@ -1415,7 +1415,7 @@ ClassTemplateDecl *ClangASTContext::CreateClassTemplateDecl(
 }
 
 TemplateTemplateParmDecl *
-ClangASTContext::CreateTemplateTemplateParmDecl(const char *template_name) {
+TypeSystemClang::CreateTemplateTemplateParmDecl(const char *template_name) {
   ASTContext &ast = getASTContext();
 
   auto *decl_ctx = ast.getTranslationUnitDecl();
@@ -1423,7 +1423,7 @@ ClangASTContext::CreateTemplateTemplateParmDecl(const char *template_name) {
   IdentifierInfo &identifier_info = ast.Idents.get(template_name);
   llvm::SmallVector<NamedDecl *, 8> template_param_decls;
 
-  ClangASTContext::TemplateParameterInfos template_param_infos;
+  TypeSystemClang::TemplateParameterInfos template_param_infos;
   TemplateParameterList *template_param_list = CreateTemplateParameterList(
       &ast, template_param_infos, template_param_decls);
 
@@ -1438,7 +1438,7 @@ ClangASTContext::CreateTemplateTemplateParmDecl(const char *template_name) {
 }
 
 ClassTemplateSpecializationDecl *
-ClangASTContext::CreateClassTemplateSpecializationDecl(
+TypeSystemClang::CreateClassTemplateSpecializationDecl(
     DeclContext *decl_ctx, ClassTemplateDecl *class_template_decl, int kind,
     const TemplateParameterInfos &template_param_infos) {
   ASTContext &ast = getASTContext();
@@ -1462,7 +1462,7 @@ ClangASTContext::CreateClassTemplateSpecializationDecl(
   return class_template_specialization_decl;
 }
 
-CompilerType ClangASTContext::CreateClassTemplateSpecializationType(
+CompilerType TypeSystemClang::CreateClassTemplateSpecializationType(
     ClassTemplateSpecializationDecl *class_template_specialization_decl) {
   if (class_template_specialization_decl) {
     ASTContext &ast = getASTContext();
@@ -1490,7 +1490,7 @@ static inline bool check_op_param(bool is_method,
     return false;
 }
 
-bool ClangASTContext::CheckOverloadedOperatorKindParameterCount(
+bool TypeSystemClang::CheckOverloadedOperatorKindParameterCount(
     bool is_method, clang::OverloadedOperatorKind op_kind,
     uint32_t num_params) {
   switch (op_kind) {
@@ -1516,7 +1516,7 @@ bool ClangASTContext::CheckOverloadedOperatorKindParameterCount(
 }
 
 clang::AccessSpecifier
-ClangASTContext::UnifyAccessSpecifiers(clang::AccessSpecifier lhs,
+TypeSystemClang::UnifyAccessSpecifiers(clang::AccessSpecifier lhs,
                                        clang::AccessSpecifier rhs) {
   // Make the access equal to the stricter of the field and the nested field's
   // access
@@ -1529,7 +1529,7 @@ ClangASTContext::UnifyAccessSpecifiers(clang::AccessSpecifier lhs,
   return AS_public;
 }
 
-bool ClangASTContext::FieldIsBitfield(FieldDecl *field,
+bool TypeSystemClang::FieldIsBitfield(FieldDecl *field,
                                       uint32_t &bitfield_bit_size) {
   ASTContext &ast = getASTContext();
   if (field == nullptr)
@@ -1548,7 +1548,7 @@ bool ClangASTContext::FieldIsBitfield(FieldDecl *field,
   return false;
 }
 
-bool ClangASTContext::RecordHasFields(const RecordDecl *record_decl) {
+bool TypeSystemClang::RecordHasFields(const RecordDecl *record_decl) {
   if (record_decl == nullptr)
     return false;
 
@@ -1573,7 +1573,7 @@ bool ClangASTContext::RecordHasFields(const RecordDecl *record_decl) {
 
 #pragma mark Objective-C Classes
 
-CompilerType ClangASTContext::CreateObjCClass(llvm::StringRef name,
+CompilerType TypeSystemClang::CreateObjCClass(llvm::StringRef name,
                                               DeclContext *decl_ctx,
                                               bool isForwardDecl,
                                               bool isInternal,
@@ -1596,11 +1596,11 @@ CompilerType ClangASTContext::CreateObjCClass(llvm::StringRef name,
 }
 
 static inline bool BaseSpecifierIsEmpty(const CXXBaseSpecifier *b) {
-  return !ClangASTContext::RecordHasFields(b->getType()->getAsCXXRecordDecl());
+  return !TypeSystemClang::RecordHasFields(b->getType()->getAsCXXRecordDecl());
 }
 
 uint32_t
-ClangASTContext::GetNumBaseClasses(const CXXRecordDecl *cxx_record_decl,
+TypeSystemClang::GetNumBaseClasses(const CXXRecordDecl *cxx_record_decl,
                                    bool omit_empty_base_classes) {
   uint32_t num_bases = 0;
   if (cxx_record_decl) {
@@ -1624,7 +1624,7 @@ ClangASTContext::GetNumBaseClasses(const CXXRecordDecl *cxx_record_decl,
 
 #pragma mark Namespace Declarations
 
-NamespaceDecl *ClangASTContext::GetUniqueNamespaceDeclaration(
+NamespaceDecl *TypeSystemClang::GetUniqueNamespaceDeclaration(
     const char *name, DeclContext *decl_ctx, bool is_inline) {
   NamespaceDecl *namespace_decl = nullptr;
   ASTContext &ast = getASTContext();
@@ -1685,7 +1685,7 @@ NamespaceDecl *ClangASTContext::GetUniqueNamespaceDeclaration(
 }
 
 clang::BlockDecl *
-ClangASTContext::CreateBlockDeclaration(clang::DeclContext *ctx) {
+TypeSystemClang::CreateBlockDeclaration(clang::DeclContext *ctx) {
   if (ctx != nullptr) {
     clang::BlockDecl *decl =
         clang::BlockDecl::Create(getASTContext(), ctx, clang::SourceLocation());
@@ -1712,7 +1712,7 @@ clang::DeclContext *FindLCABetweenDecls(clang::DeclContext *left,
   return nullptr;
 }
 
-clang::UsingDirectiveDecl *ClangASTContext::CreateUsingDirectiveDeclaration(
+clang::UsingDirectiveDecl *TypeSystemClang::CreateUsingDirectiveDeclaration(
     clang::DeclContext *decl_ctx, clang::NamespaceDecl *ns_decl) {
   if (decl_ctx != nullptr && ns_decl != nullptr) {
     auto *translation_unit = getASTContext().getTranslationUnitDecl();
@@ -1728,7 +1728,7 @@ clang::UsingDirectiveDecl *ClangASTContext::CreateUsingDirectiveDeclaration(
 }
 
 clang::UsingDecl *
-ClangASTContext::CreateUsingDeclaration(clang::DeclContext *current_decl_ctx,
+TypeSystemClang::CreateUsingDeclaration(clang::DeclContext *current_decl_ctx,
                                         clang::NamedDecl *target) {
   if (current_decl_ctx != nullptr && target != nullptr) {
     clang::UsingDecl *using_decl = clang::UsingDecl::Create(
@@ -1744,7 +1744,7 @@ ClangASTContext::CreateUsingDeclaration(clang::DeclContext *current_decl_ctx,
   return nullptr;
 }
 
-clang::VarDecl *ClangASTContext::CreateVariableDeclaration(
+clang::VarDecl *TypeSystemClang::CreateVariableDeclaration(
     clang::DeclContext *decl_context, const char *name, clang::QualType type) {
   if (decl_context != nullptr) {
     clang::VarDecl *var_decl = clang::VarDecl::Create(
@@ -1760,7 +1760,7 @@ clang::VarDecl *ClangASTContext::CreateVariableDeclaration(
 }
 
 lldb::opaque_compiler_type_t
-ClangASTContext::GetOpaqueCompilerType(clang::ASTContext *ast,
+TypeSystemClang::GetOpaqueCompilerType(clang::ASTContext *ast,
                                        lldb::BasicType basic_type) {
   switch (basic_type) {
   case eBasicTypeVoid:
@@ -1833,7 +1833,7 @@ ClangASTContext::GetOpaqueCompilerType(clang::ASTContext *ast,
 #pragma mark Function Types
 
 clang::DeclarationName
-ClangASTContext::GetDeclarationName(const char *name,
+TypeSystemClang::GetDeclarationName(const char *name,
                                     const CompilerType &function_clang_type) {
   if (!name || !name[0])
     return clang::DeclarationName();
@@ -1855,14 +1855,14 @@ ClangASTContext::GetDeclarationName(const char *name,
 
   const bool is_method = false;
   const unsigned int num_params = function_type->getNumParams();
-  if (!ClangASTContext::CheckOverloadedOperatorKindParameterCount(
+  if (!TypeSystemClang::CheckOverloadedOperatorKindParameterCount(
           is_method, op_kind, num_params))
     return clang::DeclarationName();
 
   return getASTContext().DeclarationNames.getCXXOperatorName(op_kind);
 }
 
-FunctionDecl *ClangASTContext::CreateFunctionDeclaration(
+FunctionDecl *TypeSystemClang::CreateFunctionDeclaration(
     DeclContext *decl_ctx, const char *name,
     const CompilerType &function_clang_type, int storage, bool is_inline) {
   FunctionDecl *func_decl = nullptr;
@@ -1891,7 +1891,7 @@ FunctionDecl *ClangASTContext::CreateFunctionDeclaration(
 }
 
 CompilerType
-ClangASTContext::CreateFunctionType(const CompilerType &result_type,
+TypeSystemClang::CreateFunctionType(const CompilerType &result_type,
                                     const CompilerType *args, unsigned num_args,
                                     bool is_variadic, unsigned type_quals,
                                     clang::CallingConv cc) {
@@ -1929,7 +1929,7 @@ ClangASTContext::CreateFunctionType(const CompilerType &result_type,
       ClangUtil::GetQualType(result_type), qual_type_args, proto_info));
 }
 
-ParmVarDecl *ClangASTContext::CreateParameterDeclaration(
+ParmVarDecl *TypeSystemClang::CreateParameterDeclaration(
     clang::DeclContext *decl_ctx, const char *name,
     const CompilerType &param_type, int storage, bool add_decl) {
   ASTContext &ast = getASTContext();
@@ -1944,7 +1944,7 @@ ParmVarDecl *ClangASTContext::CreateParameterDeclaration(
   return decl;
 }
 
-void ClangASTContext::SetFunctionParameters(FunctionDecl *function_decl,
+void TypeSystemClang::SetFunctionParameters(FunctionDecl *function_decl,
                                             ParmVarDecl **params,
                                             unsigned num_params) {
   if (function_decl)
@@ -1952,7 +1952,7 @@ void ClangASTContext::SetFunctionParameters(FunctionDecl *function_decl,
 }
 
 CompilerType
-ClangASTContext::CreateBlockPointerType(const CompilerType &function_type) {
+TypeSystemClang::CreateBlockPointerType(const CompilerType &function_type) {
   QualType block_type = m_ast_up->getBlockPointerType(
       clang::QualType::getFromOpaquePtr(function_type.GetOpaqueQualType()));
 
@@ -1961,7 +1961,7 @@ ClangASTContext::CreateBlockPointerType(const CompilerType &function_type) {
 
 #pragma mark Array Types
 
-CompilerType ClangASTContext::CreateArrayType(const CompilerType &element_type,
+CompilerType TypeSystemClang::CreateArrayType(const CompilerType &element_type,
                                               size_t element_count,
                                               bool is_vector) {
   if (element_type.IsValid()) {
@@ -1986,7 +1986,7 @@ CompilerType ClangASTContext::CreateArrayType(const CompilerType &element_type,
   return CompilerType();
 }
 
-CompilerType ClangASTContext::CreateStructForIdentifier(
+CompilerType TypeSystemClang::CreateStructForIdentifier(
     ConstString type_name,
     const std::initializer_list<std::pair<const char *, CompilerType>>
         &type_fields,
@@ -2011,7 +2011,7 @@ CompilerType ClangASTContext::CreateStructForIdentifier(
   return type;
 }
 
-CompilerType ClangASTContext::GetOrCreateStructForIdentifier(
+CompilerType TypeSystemClang::GetOrCreateStructForIdentifier(
     ConstString type_name,
     const std::initializer_list<std::pair<const char *, CompilerType>>
         &type_fields,
@@ -2026,7 +2026,7 @@ CompilerType ClangASTContext::GetOrCreateStructForIdentifier(
 #pragma mark Enumeration Types
 
 CompilerType
-ClangASTContext::CreateEnumerationType(const char *name, DeclContext *decl_ctx,
+TypeSystemClang::CreateEnumerationType(const char *name, DeclContext *decl_ctx,
                                        const Declaration &decl,
                                        const CompilerType &integer_clang_type,
                                        bool is_scoped) {
@@ -2058,7 +2058,7 @@ ClangASTContext::CreateEnumerationType(const char *name, DeclContext *decl_ctx,
   return CompilerType();
 }
 
-CompilerType ClangASTContext::GetIntTypeFromBitSize(size_t bit_size,
+CompilerType TypeSystemClang::GetIntTypeFromBitSize(size_t bit_size,
                                                     bool is_signed) {
   clang::ASTContext &ast = getASTContext();
 
@@ -2102,12 +2102,12 @@ CompilerType ClangASTContext::GetIntTypeFromBitSize(size_t bit_size,
   return CompilerType();
 }
 
-CompilerType ClangASTContext::GetPointerSizedIntType(bool is_signed) {
+CompilerType TypeSystemClang::GetPointerSizedIntType(bool is_signed) {
   return GetIntTypeFromBitSize(
       getASTContext().getTypeSize(getASTContext().VoidPtrTy), is_signed);
 }
 
-void ClangASTContext::DumpDeclContextHiearchy(clang::DeclContext *decl_ctx) {
+void TypeSystemClang::DumpDeclContextHiearchy(clang::DeclContext *decl_ctx) {
   if (decl_ctx) {
     DumpDeclContextHiearchy(decl_ctx->getParent());
 
@@ -2121,7 +2121,7 @@ void ClangASTContext::DumpDeclContextHiearchy(clang::DeclContext *decl_ctx) {
   }
 }
 
-void ClangASTContext::DumpDeclHiearchy(clang::Decl *decl) {
+void TypeSystemClang::DumpDeclHiearchy(clang::Decl *decl) {
   if (decl == nullptr)
     return;
   DumpDeclContextHiearchy(decl->getDeclContext());
@@ -2143,7 +2143,7 @@ void ClangASTContext::DumpDeclHiearchy(clang::Decl *decl) {
   }
 }
 
-bool ClangASTContext::DeclsAreEquivalent(clang::Decl *lhs_decl,
+bool TypeSystemClang::DeclsAreEquivalent(clang::Decl *lhs_decl,
                                          clang::Decl *rhs_decl) {
   if (lhs_decl && rhs_decl) {
     // Make sure the decl kinds match first
@@ -2226,7 +2226,7 @@ bool ClangASTContext::DeclsAreEquivalent(clang::Decl *lhs_decl,
   }
   return false;
 }
-bool ClangASTContext::GetCompleteDecl(clang::ASTContext *ast,
+bool TypeSystemClang::GetCompleteDecl(clang::ASTContext *ast,
                                       clang::Decl *decl) {
   if (!decl)
     return false;
@@ -2262,45 +2262,45 @@ bool ClangASTContext::GetCompleteDecl(clang::ASTContext *ast,
   }
 }
 
-void ClangASTContext::SetMetadataAsUserID(const clang::Decl *decl,
+void TypeSystemClang::SetMetadataAsUserID(const clang::Decl *decl,
                                           user_id_t user_id) {
   ClangASTMetadata meta_data;
   meta_data.SetUserID(user_id);
   SetMetadata(decl, meta_data);
 }
 
-void ClangASTContext::SetMetadataAsUserID(const clang::Type *type,
+void TypeSystemClang::SetMetadataAsUserID(const clang::Type *type,
                                           user_id_t user_id) {
   ClangASTMetadata meta_data;
   meta_data.SetUserID(user_id);
   SetMetadata(type, meta_data);
 }
 
-void ClangASTContext::SetMetadata(const clang::Decl *object,
+void TypeSystemClang::SetMetadata(const clang::Decl *object,
                                   ClangASTMetadata &metadata) {
   m_decl_metadata[object] = metadata;
 }
 
-void ClangASTContext::SetMetadata(const clang::Type *object,
+void TypeSystemClang::SetMetadata(const clang::Type *object,
                                   ClangASTMetadata &metadata) {
   m_type_metadata[object] = metadata;
 }
 
-ClangASTMetadata *ClangASTContext::GetMetadata(const clang::Decl *object) {
+ClangASTMetadata *TypeSystemClang::GetMetadata(const clang::Decl *object) {
   auto It = m_decl_metadata.find(object);
   if (It != m_decl_metadata.end())
     return &It->second;
   return nullptr;
 }
 
-ClangASTMetadata *ClangASTContext::GetMetadata(const clang::Type *object) {
+ClangASTMetadata *TypeSystemClang::GetMetadata(const clang::Type *object) {
   auto It = m_type_metadata.find(object);
   if (It != m_type_metadata.end())
     return &It->second;
   return nullptr;
 }
 
-bool ClangASTContext::SetTagTypeKind(clang::QualType tag_qual_type,
+bool TypeSystemClang::SetTagTypeKind(clang::QualType tag_qual_type,
                                      int kind) const {
   const clang::Type *clang_type = tag_qual_type.getTypePtr();
   if (clang_type) {
@@ -2317,7 +2317,7 @@ bool ClangASTContext::SetTagTypeKind(clang::QualType tag_qual_type,
   return false;
 }
 
-bool ClangASTContext::SetDefaultAccessForRecordFields(
+bool TypeSystemClang::SetDefaultAccessForRecordFields(
     clang::RecordDecl *record_decl, int default_accessibility,
     int *assigned_accessibilities, size_t num_assigned_accessibilities) {
   if (record_decl) {
@@ -2337,7 +2337,7 @@ bool ClangASTContext::SetDefaultAccessForRecordFields(
 }
 
 clang::DeclContext *
-ClangASTContext::GetDeclContextForType(const CompilerType &type) {
+TypeSystemClang::GetDeclContextForType(const CompilerType &type) {
   return GetDeclContextForType(ClangUtil::GetQualType(type));
 }
 
@@ -2372,7 +2372,7 @@ RemoveWrappingTypes(QualType type, ArrayRef<clang::Type::TypeClass> mask = {}) {
 }
 
 clang::DeclContext *
-ClangASTContext::GetDeclContextForType(clang::QualType type) {
+TypeSystemClang::GetDeclContextForType(clang::QualType type) {
   if (type.isNull())
     return nullptr;
 
@@ -2533,7 +2533,7 @@ ConvertAccessTypeToObjCIvarAccessControl(AccessType access) {
 
 // Tests
 
-bool ClangASTContext::IsAggregateType(lldb::opaque_compiler_type_t type) {
+bool TypeSystemClang::IsAggregateType(lldb::opaque_compiler_type_t type) {
   clang::QualType qual_type(RemoveWrappingTypes(GetCanonicalQualType(type)));
 
   const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -2554,7 +2554,7 @@ bool ClangASTContext::IsAggregateType(lldb::opaque_compiler_type_t type) {
   return false;
 }
 
-bool ClangASTContext::IsAnonymousType(lldb::opaque_compiler_type_t type) {
+bool TypeSystemClang::IsAnonymousType(lldb::opaque_compiler_type_t type) {
   clang::QualType qual_type(RemoveWrappingTypes(GetCanonicalQualType(type)));
 
   const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -2576,7 +2576,7 @@ bool ClangASTContext::IsAnonymousType(lldb::opaque_compiler_type_t type) {
   return false;
 }
 
-bool ClangASTContext::IsArrayType(lldb::opaque_compiler_type_t type,
+bool TypeSystemClang::IsArrayType(lldb::opaque_compiler_type_t type,
                                   CompilerType *element_type_ptr,
                                   uint64_t *size, bool *is_incomplete) {
   clang::QualType qual_type(RemoveWrappingTypes(GetCanonicalQualType(type)));
@@ -2645,7 +2645,7 @@ bool ClangASTContext::IsArrayType(lldb::opaque_compiler_type_t type,
   return false;
 }
 
-bool ClangASTContext::IsVectorType(lldb::opaque_compiler_type_t type,
+bool TypeSystemClang::IsVectorType(lldb::opaque_compiler_type_t type,
                                    CompilerType *element_type, uint64_t *size) {
   clang::QualType qual_type(GetCanonicalQualType(type));
 
@@ -2680,7 +2680,7 @@ bool ClangASTContext::IsVectorType(lldb::opaque_compiler_type_t type,
   return false;
 }
 
-bool ClangASTContext::IsRuntimeGeneratedType(
+bool TypeSystemClang::IsRuntimeGeneratedType(
     lldb::opaque_compiler_type_t type) {
   clang::DeclContext *decl_ctx = GetDeclContextForType(GetQualType(type));
   if (!decl_ctx)
@@ -2698,21 +2698,21 @@ bool ClangASTContext::IsRuntimeGeneratedType(
   return (ast_metadata->GetISAPtr() != 0);
 }
 
-bool ClangASTContext::IsCharType(lldb::opaque_compiler_type_t type) {
+bool TypeSystemClang::IsCharType(lldb::opaque_compiler_type_t type) {
   return GetQualType(type).getUnqualifiedType()->isCharType();
 }
 
-bool ClangASTContext::IsCompleteType(lldb::opaque_compiler_type_t type) {
+bool TypeSystemClang::IsCompleteType(lldb::opaque_compiler_type_t type) {
   const bool allow_completion = false;
   return GetCompleteQualType(&getASTContext(), GetQualType(type),
                              allow_completion);
 }
 
-bool ClangASTContext::IsConst(lldb::opaque_compiler_type_t type) {
+bool TypeSystemClang::IsConst(lldb::opaque_compiler_type_t type) {
   return GetQualType(type).isConstQualified();
 }
 
-bool ClangASTContext::IsCStringType(lldb::opaque_compiler_type_t type,
+bool TypeSystemClang::IsCStringType(lldb::opaque_compiler_type_t type,
                                     uint32_t &length) {
   CompilerType pointee_or_element_clang_type;
   length = 0;
@@ -2737,7 +2737,7 @@ bool ClangASTContext::IsCStringType(lldb::opaque_compiler_type_t type,
   return false;
 }
 
-bool ClangASTContext::IsFunctionType(lldb::opaque_compiler_type_t type,
+bool TypeSystemClang::IsFunctionType(lldb::opaque_compiler_type_t type,
                                      bool *is_variadic_ptr) {
   if (type) {
     clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
@@ -2773,7 +2773,7 @@ bool ClangASTContext::IsFunctionType(lldb::opaque_compiler_type_t type,
 
 // Used to detect "Homogeneous Floating-point Aggregates"
 uint32_t
-ClangASTContext::IsHomogeneousAggregate(lldb::opaque_compiler_type_t type,
+TypeSystemClang::IsHomogeneousAggregate(lldb::opaque_compiler_type_t type,
                                         CompilerType *base_type_ptr) {
   if (!type)
     return 0;
@@ -2854,7 +2854,7 @@ ClangASTContext::IsHomogeneousAggregate(lldb::opaque_compiler_type_t type,
   return 0;
 }
 
-size_t ClangASTContext::GetNumberOfFunctionArguments(
+size_t TypeSystemClang::GetNumberOfFunctionArguments(
     lldb::opaque_compiler_type_t type) {
   if (type) {
     clang::QualType qual_type(GetCanonicalQualType(type));
@@ -2867,7 +2867,7 @@ size_t ClangASTContext::GetNumberOfFunctionArguments(
 }
 
 CompilerType
-ClangASTContext::GetFunctionArgumentAtIndex(lldb::opaque_compiler_type_t type,
+TypeSystemClang::GetFunctionArgumentAtIndex(lldb::opaque_compiler_type_t type,
                                             const size_t index) {
   if (type) {
     clang::QualType qual_type(GetQualType(type));
@@ -2881,7 +2881,7 @@ ClangASTContext::GetFunctionArgumentAtIndex(lldb::opaque_compiler_type_t type,
   return CompilerType();
 }
 
-bool ClangASTContext::IsFunctionPointerType(lldb::opaque_compiler_type_t type) {
+bool TypeSystemClang::IsFunctionPointerType(lldb::opaque_compiler_type_t type) {
   if (type) {
     clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
 
@@ -2906,7 +2906,7 @@ bool ClangASTContext::IsFunctionPointerType(lldb::opaque_compiler_type_t type) {
   return false;
 }
 
-bool ClangASTContext::IsBlockPointerType(
+bool TypeSystemClang::IsBlockPointerType(
     lldb::opaque_compiler_type_t type,
     CompilerType *function_pointer_type_ptr) {
   if (type) {
@@ -2943,7 +2943,7 @@ bool ClangASTContext::IsBlockPointerType(
   return false;
 }
 
-bool ClangASTContext::IsIntegerType(lldb::opaque_compiler_type_t type,
+bool TypeSystemClang::IsIntegerType(lldb::opaque_compiler_type_t type,
                                     bool &is_signed) {
   if (!type)
     return false;
@@ -2962,7 +2962,7 @@ bool ClangASTContext::IsIntegerType(lldb::opaque_compiler_type_t type,
   return false;
 }
 
-bool ClangASTContext::IsEnumerationType(lldb::opaque_compiler_type_t type,
+bool TypeSystemClang::IsEnumerationType(lldb::opaque_compiler_type_t type,
                                         bool &is_signed) {
   if (type) {
     const clang::EnumType *enum_type = llvm::dyn_cast<clang::EnumType>(
@@ -2978,7 +2978,7 @@ bool ClangASTContext::IsEnumerationType(lldb::opaque_compiler_type_t type,
   return false;
 }
 
-bool ClangASTContext::IsPointerType(lldb::opaque_compiler_type_t type,
+bool TypeSystemClang::IsPointerType(lldb::opaque_compiler_type_t type,
                                     CompilerType *pointee_type) {
   if (type) {
     clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
@@ -3030,7 +3030,7 @@ bool ClangASTContext::IsPointerType(lldb::opaque_compiler_type_t type,
   return false;
 }
 
-bool ClangASTContext::IsPointerOrReferenceType(
+bool TypeSystemClang::IsPointerOrReferenceType(
     lldb::opaque_compiler_type_t type, CompilerType *pointee_type) {
   if (type) {
     clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
@@ -3095,7 +3095,7 @@ bool ClangASTContext::IsPointerOrReferenceType(
   return false;
 }
 
-bool ClangASTContext::IsReferenceType(lldb::opaque_compiler_type_t type,
+bool TypeSystemClang::IsReferenceType(lldb::opaque_compiler_type_t type,
                                       CompilerType *pointee_type,
                                       bool *is_rvalue) {
   if (type) {
@@ -3131,7 +3131,7 @@ bool ClangASTContext::IsReferenceType(lldb::opaque_compiler_type_t type,
   return false;
 }
 
-bool ClangASTContext::IsFloatingPointType(lldb::opaque_compiler_type_t type,
+bool TypeSystemClang::IsFloatingPointType(lldb::opaque_compiler_type_t type,
                                           uint32_t &count, bool &is_complex) {
   if (type) {
     clang::QualType qual_type(GetCanonicalQualType(type));
@@ -3169,7 +3169,7 @@ bool ClangASTContext::IsFloatingPointType(lldb::opaque_compiler_type_t type,
   return false;
 }
 
-bool ClangASTContext::IsDefined(lldb::opaque_compiler_type_t type) {
+bool TypeSystemClang::IsDefined(lldb::opaque_compiler_type_t type) {
   if (!type)
     return false;
 
@@ -3195,7 +3195,7 @@ bool ClangASTContext::IsDefined(lldb::opaque_compiler_type_t type) {
   return true;
 }
 
-bool ClangASTContext::IsObjCClassType(const CompilerType &type) {
+bool TypeSystemClang::IsObjCClassType(const CompilerType &type) {
   if (ClangUtil::IsClangType(type)) {
     clang::QualType qual_type(ClangUtil::GetCanonicalQualType(type));
 
@@ -3208,13 +3208,13 @@ bool ClangASTContext::IsObjCClassType(const CompilerType &type) {
   return false;
 }
 
-bool ClangASTContext::IsObjCObjectOrInterfaceType(const CompilerType &type) {
+bool TypeSystemClang::IsObjCObjectOrInterfaceType(const CompilerType &type) {
   if (ClangUtil::IsClangType(type))
     return ClangUtil::GetCanonicalQualType(type)->isObjCObjectOrInterfaceType();
   return false;
 }
 
-bool ClangASTContext::IsClassType(lldb::opaque_compiler_type_t type) {
+bool TypeSystemClang::IsClassType(lldb::opaque_compiler_type_t type) {
   if (!type)
     return false;
   clang::QualType qual_type(GetCanonicalQualType(type));
@@ -3222,7 +3222,7 @@ bool ClangASTContext::IsClassType(lldb::opaque_compiler_type_t type) {
   return (type_class == clang::Type::Record);
 }
 
-bool ClangASTContext::IsEnumType(lldb::opaque_compiler_type_t type) {
+bool TypeSystemClang::IsEnumType(lldb::opaque_compiler_type_t type) {
   if (!type)
     return false;
   clang::QualType qual_type(GetCanonicalQualType(type));
@@ -3230,7 +3230,7 @@ bool ClangASTContext::IsEnumType(lldb::opaque_compiler_type_t type) {
   return (type_class == clang::Type::Enum);
 }
 
-bool ClangASTContext::IsPolymorphicClass(lldb::opaque_compiler_type_t type) {
+bool TypeSystemClang::IsPolymorphicClass(lldb::opaque_compiler_type_t type) {
   if (type) {
     clang::QualType qual_type(GetCanonicalQualType(type));
     const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -3256,7 +3256,7 @@ bool ClangASTContext::IsPolymorphicClass(lldb::opaque_compiler_type_t type) {
   return false;
 }
 
-bool ClangASTContext::IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
+bool TypeSystemClang::IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
                                             CompilerType *dynamic_pointee_type,
                                             bool check_cplusplus,
                                             bool check_objc) {
@@ -3385,39 +3385,39 @@ bool ClangASTContext::IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
   return false;
 }
 
-bool ClangASTContext::IsScalarType(lldb::opaque_compiler_type_t type) {
+bool TypeSystemClang::IsScalarType(lldb::opaque_compiler_type_t type) {
   if (!type)
     return false;
 
   return (GetTypeInfo(type, nullptr) & eTypeIsScalar) != 0;
 }
 
-bool ClangASTContext::IsTypedefType(lldb::opaque_compiler_type_t type) {
+bool TypeSystemClang::IsTypedefType(lldb::opaque_compiler_type_t type) {
   if (!type)
     return false;
   return GetQualType(type)->getTypeClass() == clang::Type::Typedef;
 }
 
-bool ClangASTContext::IsVoidType(lldb::opaque_compiler_type_t type) {
+bool TypeSystemClang::IsVoidType(lldb::opaque_compiler_type_t type) {
   if (!type)
     return false;
   return GetCanonicalQualType(type)->isVoidType();
 }
 
-bool ClangASTContext::CanPassInRegisters(const CompilerType &type) {
+bool TypeSystemClang::CanPassInRegisters(const CompilerType &type) {
   if (auto *record_decl =
-      ClangASTContext::GetAsRecordDecl(type)) {
+      TypeSystemClang::GetAsRecordDecl(type)) {
     return record_decl->canPassInRegisters();
   }
   return false;
 }
 
-bool ClangASTContext::SupportsLanguage(lldb::LanguageType language) {
-  return ClangASTContextSupportsLanguage(language);
+bool TypeSystemClang::SupportsLanguage(lldb::LanguageType language) {
+  return TypeSystemClangSupportsLanguage(language);
 }
 
 Optional<std::string>
-ClangASTContext::GetCXXClassName(const CompilerType &type) {
+TypeSystemClang::GetCXXClassName(const CompilerType &type) {
   if (!type)
     return llvm::None;
 
@@ -3432,7 +3432,7 @@ ClangASTContext::GetCXXClassName(const CompilerType &type) {
   return std::string(cxx_record_decl->getIdentifier()->getNameStart());
 }
 
-bool ClangASTContext::IsCXXClassType(const CompilerType &type) {
+bool TypeSystemClang::IsCXXClassType(const CompilerType &type) {
   if (!type)
     return false;
 
@@ -3440,7 +3440,7 @@ bool ClangASTContext::IsCXXClassType(const CompilerType &type) {
   return !qual_type.isNull() && qual_type->getAsCXXRecordDecl() != nullptr;
 }
 
-bool ClangASTContext::IsBeingDefined(lldb::opaque_compiler_type_t type) {
+bool TypeSystemClang::IsBeingDefined(lldb::opaque_compiler_type_t type) {
   if (!type)
     return false;
   clang::QualType qual_type(GetCanonicalQualType(type));
@@ -3450,7 +3450,7 @@ bool ClangASTContext::IsBeingDefined(lldb::opaque_compiler_type_t type) {
   return false;
 }
 
-bool ClangASTContext::IsObjCObjectPointerType(const CompilerType &type,
+bool TypeSystemClang::IsObjCObjectPointerType(const CompilerType &type,
                                               CompilerType *class_type_ptr) {
   if (!ClangUtil::IsClangType(type))
     return false;
@@ -3480,7 +3480,7 @@ bool ClangASTContext::IsObjCObjectPointerType(const CompilerType &type,
 
 // Type Completion
 
-bool ClangASTContext::GetCompleteType(lldb::opaque_compiler_type_t type) {
+bool TypeSystemClang::GetCompleteType(lldb::opaque_compiler_type_t type) {
   if (!type)
     return false;
   const bool allow_completion = true;
@@ -3488,7 +3488,7 @@ bool ClangASTContext::GetCompleteType(lldb::opaque_compiler_type_t type) {
                              allow_completion);
 }
 
-ConstString ClangASTContext::GetTypeName(lldb::opaque_compiler_type_t type) {
+ConstString TypeSystemClang::GetTypeName(lldb::opaque_compiler_type_t type) {
   std::string type_name;
   if (type) {
     clang::PrintingPolicy printing_policy(getASTContext().getPrintingPolicy());
@@ -3507,7 +3507,7 @@ ConstString ClangASTContext::GetTypeName(lldb::opaque_compiler_type_t type) {
 }
 
 uint32_t
-ClangASTContext::GetTypeInfo(lldb::opaque_compiler_type_t type,
+TypeSystemClang::GetTypeInfo(lldb::opaque_compiler_type_t type,
                              CompilerType *pointee_or_element_clang_type) {
   if (!type)
     return 0;
@@ -3708,7 +3708,7 @@ ClangASTContext::GetTypeInfo(lldb::opaque_compiler_type_t type,
 }
 
 lldb::LanguageType
-ClangASTContext::GetMinimumLanguage(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetMinimumLanguage(lldb::opaque_compiler_type_t type) {
   if (!type)
     return lldb::eLanguageTypeC;
 
@@ -3792,7 +3792,7 @@ ClangASTContext::GetMinimumLanguage(lldb::opaque_compiler_type_t type) {
 }
 
 lldb::TypeClass
-ClangASTContext::GetTypeClass(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetTypeClass(lldb::opaque_compiler_type_t type) {
   if (!type)
     return lldb::eTypeClassInvalid;
 
@@ -3912,7 +3912,7 @@ ClangASTContext::GetTypeClass(lldb::opaque_compiler_type_t type) {
   return lldb::eTypeClassOther;
 }
 
-unsigned ClangASTContext::GetTypeQualifiers(lldb::opaque_compiler_type_t type) {
+unsigned TypeSystemClang::GetTypeQualifiers(lldb::opaque_compiler_type_t type) {
   if (type)
     return GetQualType(type).getQualifiers().getCVRQualifiers();
   return 0;
@@ -3921,7 +3921,7 @@ unsigned ClangASTContext::GetTypeQualifiers(lldb::opaque_compiler_type_t type) {
 // Creating related types
 
 CompilerType
-ClangASTContext::GetArrayElementType(lldb::opaque_compiler_type_t type,
+TypeSystemClang::GetArrayElementType(lldb::opaque_compiler_type_t type,
                                      uint64_t *stride) {
   if (type) {
     clang::QualType qual_type(GetCanonicalQualType(type));
@@ -3945,7 +3945,7 @@ ClangASTContext::GetArrayElementType(lldb::opaque_compiler_type_t type,
   return CompilerType();
 }
 
-CompilerType ClangASTContext::GetArrayType(lldb::opaque_compiler_type_t type,
+CompilerType TypeSystemClang::GetArrayType(lldb::opaque_compiler_type_t type,
                                            uint64_t size) {
   if (type) {
     clang::QualType qual_type(GetCanonicalQualType(type));
@@ -3963,7 +3963,7 @@ CompilerType ClangASTContext::GetArrayType(lldb::opaque_compiler_type_t type,
 }
 
 CompilerType
-ClangASTContext::GetCanonicalType(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetCanonicalType(lldb::opaque_compiler_type_t type) {
   if (type)
     return GetType(GetCanonicalQualType(type));
   return CompilerType();
@@ -3983,14 +3983,14 @@ static clang::QualType GetFullyUnqualifiedType_Impl(clang::ASTContext *ast,
 }
 
 CompilerType
-ClangASTContext::GetFullyUnqualifiedType(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetFullyUnqualifiedType(lldb::opaque_compiler_type_t type) {
   if (type)
     return GetType(
         GetFullyUnqualifiedType_Impl(&getASTContext(), GetQualType(type)));
   return CompilerType();
 }
 
-int ClangASTContext::GetFunctionArgumentCount(
+int TypeSystemClang::GetFunctionArgumentCount(
     lldb::opaque_compiler_type_t type) {
   if (type) {
     const clang::FunctionProtoType *func =
@@ -4001,7 +4001,7 @@ int ClangASTContext::GetFunctionArgumentCount(
   return -1;
 }
 
-CompilerType ClangASTContext::GetFunctionArgumentTypeAtIndex(
+CompilerType TypeSystemClang::GetFunctionArgumentTypeAtIndex(
     lldb::opaque_compiler_type_t type, size_t idx) {
   if (type) {
     const clang::FunctionProtoType *func =
@@ -4016,7 +4016,7 @@ CompilerType ClangASTContext::GetFunctionArgumentTypeAtIndex(
 }
 
 CompilerType
-ClangASTContext::GetFunctionReturnType(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetFunctionReturnType(lldb::opaque_compiler_type_t type) {
   if (type) {
     clang::QualType qual_type(GetQualType(type));
     const clang::FunctionProtoType *func =
@@ -4028,7 +4028,7 @@ ClangASTContext::GetFunctionReturnType(lldb::opaque_compiler_type_t type) {
 }
 
 size_t
-ClangASTContext::GetNumMemberFunctions(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetNumMemberFunctions(lldb::opaque_compiler_type_t type) {
   size_t num_functions = 0;
   if (type) {
     clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
@@ -4088,7 +4088,7 @@ ClangASTContext::GetNumMemberFunctions(lldb::opaque_compiler_type_t type) {
 }
 
 TypeMemberFunctionImpl
-ClangASTContext::GetMemberFunctionAtIndex(lldb::opaque_compiler_type_t type,
+TypeSystemClang::GetMemberFunctionAtIndex(lldb::opaque_compiler_type_t type,
                                           size_t idx) {
   std::string name;
   MemberFunctionKind kind(MemberFunctionKind::eMemberFunctionKindUnknown);
@@ -4205,25 +4205,25 @@ ClangASTContext::GetMemberFunctionAtIndex(lldb::opaque_compiler_type_t type,
 }
 
 CompilerType
-ClangASTContext::GetNonReferenceType(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetNonReferenceType(lldb::opaque_compiler_type_t type) {
   if (type)
     return GetType(GetQualType(type).getNonReferenceType());
   return CompilerType();
 }
 
-CompilerType ClangASTContext::CreateTypedefType(
+CompilerType TypeSystemClang::CreateTypedefType(
     const CompilerType &type, const char *typedef_name,
     const CompilerDeclContext &compiler_decl_ctx) {
   if (type && typedef_name && typedef_name[0]) {
-    ClangASTContext *ast =
-        llvm::dyn_cast<ClangASTContext>(type.GetTypeSystem());
+    TypeSystemClang *ast =
+        llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
     if (!ast)
       return CompilerType();
     clang::ASTContext &clang_ast = ast->getASTContext();
     clang::QualType qual_type(ClangUtil::GetQualType(type));
 
     clang::DeclContext *decl_ctx =
-        ClangASTContext::DeclContextGetAsDeclContext(compiler_decl_ctx);
+        TypeSystemClang::DeclContextGetAsDeclContext(compiler_decl_ctx);
     if (decl_ctx == nullptr)
       decl_ctx = ast->getASTContext().getTranslationUnitDecl();
 
@@ -4243,7 +4243,7 @@ CompilerType ClangASTContext::CreateTypedefType(
 }
 
 CompilerType
-ClangASTContext::GetPointeeType(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetPointeeType(lldb::opaque_compiler_type_t type) {
   if (type) {
     clang::QualType qual_type(GetQualType(type));
     return GetType(qual_type.getTypePtr()->getPointeeType());
@@ -4252,7 +4252,7 @@ ClangASTContext::GetPointeeType(lldb::opaque_compiler_type_t type) {
 }
 
 CompilerType
-ClangASTContext::GetPointerType(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetPointerType(lldb::opaque_compiler_type_t type) {
   if (type) {
     clang::QualType qual_type(GetQualType(type));
 
@@ -4270,7 +4270,7 @@ ClangASTContext::GetPointerType(lldb::opaque_compiler_type_t type) {
 }
 
 CompilerType
-ClangASTContext::GetLValueReferenceType(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetLValueReferenceType(lldb::opaque_compiler_type_t type) {
   if (type)
     return GetType(getASTContext().getLValueReferenceType(GetQualType(type)));
   else
@@ -4278,21 +4278,21 @@ ClangASTContext::GetLValueReferenceType(lldb::opaque_compiler_type_t type) {
 }
 
 CompilerType
-ClangASTContext::GetRValueReferenceType(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetRValueReferenceType(lldb::opaque_compiler_type_t type) {
   if (type)
     return GetType(getASTContext().getRValueReferenceType(GetQualType(type)));
   else
     return CompilerType();
 }
 
-CompilerType ClangASTContext::GetAtomicType(lldb::opaque_compiler_type_t type) {
+CompilerType TypeSystemClang::GetAtomicType(lldb::opaque_compiler_type_t type) {
   if (!type)
     return CompilerType();
   return GetType(getASTContext().getAtomicType(GetQualType(type)));
 }
 
 CompilerType
-ClangASTContext::AddConstModifier(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::AddConstModifier(lldb::opaque_compiler_type_t type) {
   if (type) {
     clang::QualType result(GetQualType(type));
     result.addConst();
@@ -4302,7 +4302,7 @@ ClangASTContext::AddConstModifier(lldb::opaque_compiler_type_t type) {
 }
 
 CompilerType
-ClangASTContext::AddVolatileModifier(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::AddVolatileModifier(lldb::opaque_compiler_type_t type) {
   if (type) {
     clang::QualType result(GetQualType(type));
     result.addVolatile();
@@ -4312,7 +4312,7 @@ ClangASTContext::AddVolatileModifier(lldb::opaque_compiler_type_t type) {
 }
 
 CompilerType
-ClangASTContext::AddRestrictModifier(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::AddRestrictModifier(lldb::opaque_compiler_type_t type) {
   if (type) {
     clang::QualType result(GetQualType(type));
     result.addRestrict();
@@ -4322,7 +4322,7 @@ ClangASTContext::AddRestrictModifier(lldb::opaque_compiler_type_t type) {
 }
 
 CompilerType
-ClangASTContext::CreateTypedef(lldb::opaque_compiler_type_t type,
+TypeSystemClang::CreateTypedef(lldb::opaque_compiler_type_t type,
                                const char *typedef_name,
                                const CompilerDeclContext &compiler_decl_ctx) {
   if (type) {
@@ -4330,7 +4330,7 @@ ClangASTContext::CreateTypedef(lldb::opaque_compiler_type_t type,
     clang::QualType qual_type(GetQualType(type));
 
     clang::DeclContext *decl_ctx =
-        ClangASTContext::DeclContextGetAsDeclContext(compiler_decl_ctx);
+        TypeSystemClang::DeclContextGetAsDeclContext(compiler_decl_ctx);
     if (decl_ctx == nullptr)
       decl_ctx = getASTContext().getTranslationUnitDecl();
 
@@ -4362,7 +4362,7 @@ ClangASTContext::CreateTypedef(lldb::opaque_compiler_type_t type,
 }
 
 CompilerType
-ClangASTContext::GetTypedefedType(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetTypedefedType(lldb::opaque_compiler_type_t type) {
   if (type) {
     const clang::TypedefType *typedef_type =
         llvm::dyn_cast<clang::TypedefType>(GetQualType(type));
@@ -4374,13 +4374,13 @@ ClangASTContext::GetTypedefedType(lldb::opaque_compiler_type_t type) {
 
 // Create related types using the current type's AST
 
-CompilerType ClangASTContext::GetBasicTypeFromAST(lldb::BasicType basic_type) {
-  return ClangASTContext::GetBasicType(basic_type);
+CompilerType TypeSystemClang::GetBasicTypeFromAST(lldb::BasicType basic_type) {
+  return TypeSystemClang::GetBasicType(basic_type);
 }
 // Exploring the type
 
 const llvm::fltSemantics &
-ClangASTContext::GetFloatTypeSemantics(size_t byte_size) {
+TypeSystemClang::GetFloatTypeSemantics(size_t byte_size) {
   clang::ASTContext &ast = getASTContext();
   const size_t bit_size = byte_size * 8;
   if (bit_size == ast.getTypeSize(ast.FloatTy))
@@ -4395,7 +4395,7 @@ ClangASTContext::GetFloatTypeSemantics(size_t byte_size) {
 }
 
 Optional<uint64_t>
-ClangASTContext::GetBitSize(lldb::opaque_compiler_type_t type,
+TypeSystemClang::GetBitSize(lldb::opaque_compiler_type_t type,
                             ExecutionContextScope *exe_scope) {
   if (GetCompleteType(type)) {
     clang::QualType qual_type(GetCanonicalQualType(type));
@@ -4459,14 +4459,14 @@ ClangASTContext::GetBitSize(lldb::opaque_compiler_type_t type,
 }
 
 llvm::Optional<size_t>
-ClangASTContext::GetTypeBitAlign(lldb::opaque_compiler_type_t type,
+TypeSystemClang::GetTypeBitAlign(lldb::opaque_compiler_type_t type,
                                  ExecutionContextScope *exe_scope) {
   if (GetCompleteType(type))
     return getASTContext().getTypeAlign(GetQualType(type));
   return {};
 }
 
-lldb::Encoding ClangASTContext::GetEncoding(lldb::opaque_compiler_type_t type,
+lldb::Encoding TypeSystemClang::GetEncoding(lldb::opaque_compiler_type_t type,
                                             uint64_t &count) {
   if (!type)
     return lldb::eEncodingInvalid;
@@ -4722,7 +4722,7 @@ lldb::Encoding ClangASTContext::GetEncoding(lldb::opaque_compiler_type_t type,
   return lldb::eEncodingInvalid;
 }
 
-lldb::Format ClangASTContext::GetFormat(lldb::opaque_compiler_type_t type) {
+lldb::Format TypeSystemClang::GetFormat(lldb::opaque_compiler_type_t type) {
   if (!type)
     return lldb::eFormatDefault;
 
@@ -4879,7 +4879,7 @@ static bool ObjCDeclHasIVars(clang::ObjCInterfaceDecl *class_interface_decl,
 }
 
 static Optional<SymbolFile::ArrayInfo>
-GetDynamicArrayInfo(ClangASTContext &ast, SymbolFile *sym_file,
+GetDynamicArrayInfo(TypeSystemClang &ast, SymbolFile *sym_file,
                     clang::QualType qual_type,
                     const ExecutionContext *exe_ctx) {
   if (qual_type->isIncompleteArrayType())
@@ -4889,7 +4889,7 @@ GetDynamicArrayInfo(ClangASTContext &ast, SymbolFile *sym_file,
   return llvm::None;
 }
 
-uint32_t ClangASTContext::GetNumChildren(lldb::opaque_compiler_type_t type,
+uint32_t TypeSystemClang::GetNumChildren(lldb::opaque_compiler_type_t type,
                                          bool omit_empty_base_classes,
                                          const ExecutionContext *exe_ctx) {
   if (!type)
@@ -4938,7 +4938,7 @@ uint32_t ClangASTContext::GetNumChildren(lldb::opaque_compiler_type_t type,
                         ->getDecl());
 
             // Skip empty base classes
-            if (!ClangASTContext::RecordHasFields(base_class_decl))
+            if (!TypeSystemClang::RecordHasFields(base_class_decl))
               continue;
 
             num_children++;
@@ -5051,12 +5051,12 @@ uint32_t ClangASTContext::GetNumChildren(lldb::opaque_compiler_type_t type,
   return num_children;
 }
 
-CompilerType ClangASTContext::GetBuiltinTypeByName(ConstString name) {
+CompilerType TypeSystemClang::GetBuiltinTypeByName(ConstString name) {
   return GetBasicType(GetBasicTypeEnumeration(name));
 }
 
 lldb::BasicType
-ClangASTContext::GetBasicTypeEnumeration(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetBasicTypeEnumeration(lldb::opaque_compiler_type_t type) {
   if (type) {
     clang::QualType qual_type(GetQualType(type));
     const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -5128,7 +5128,7 @@ ClangASTContext::GetBasicTypeEnumeration(lldb::opaque_compiler_type_t type) {
   return eBasicTypeInvalid;
 }
 
-void ClangASTContext::ForEachEnumerator(
+void TypeSystemClang::ForEachEnumerator(
     lldb::opaque_compiler_type_t type,
     std::function<bool(const CompilerType &integer_type,
                        ConstString name,
@@ -5154,7 +5154,7 @@ void ClangASTContext::ForEachEnumerator(
 
 #pragma mark Aggregate Types
 
-uint32_t ClangASTContext::GetNumFields(lldb::opaque_compiler_type_t type) {
+uint32_t TypeSystemClang::GetNumFields(lldb::opaque_compiler_type_t type) {
   if (!type)
     return 0;
 
@@ -5271,7 +5271,7 @@ GetObjCFieldAtIndex(clang::ASTContext *ast,
   return nullptr;
 }
 
-CompilerType ClangASTContext::GetFieldAtIndex(lldb::opaque_compiler_type_t type,
+CompilerType TypeSystemClang::GetFieldAtIndex(lldb::opaque_compiler_type_t type,
                                               size_t idx, std::string &name,
                                               uint64_t *bit_offset_ptr,
                                               uint32_t *bitfield_bit_size_ptr,
@@ -5374,7 +5374,7 @@ CompilerType ClangASTContext::GetFieldAtIndex(lldb::opaque_compiler_type_t type,
 }
 
 uint32_t
-ClangASTContext::GetNumDirectBaseClasses(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetNumDirectBaseClasses(lldb::opaque_compiler_type_t type) {
   uint32_t count = 0;
   clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
   const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -5426,7 +5426,7 @@ ClangASTContext::GetNumDirectBaseClasses(lldb::opaque_compiler_type_t type) {
 }
 
 uint32_t
-ClangASTContext::GetNumVirtualBaseClasses(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetNumVirtualBaseClasses(lldb::opaque_compiler_type_t type) {
   uint32_t count = 0;
   clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
   const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -5446,7 +5446,7 @@ ClangASTContext::GetNumVirtualBaseClasses(lldb::opaque_compiler_type_t type) {
   return count;
 }
 
-CompilerType ClangASTContext::GetDirectBaseClassAtIndex(
+CompilerType TypeSystemClang::GetDirectBaseClassAtIndex(
     lldb::opaque_compiler_type_t type, size_t idx, uint32_t *bit_offset_ptr) {
   clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
   const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -5541,7 +5541,7 @@ CompilerType ClangASTContext::GetDirectBaseClassAtIndex(
   return CompilerType();
 }
 
-CompilerType ClangASTContext::GetVirtualBaseClassAtIndex(
+CompilerType TypeSystemClang::GetVirtualBaseClassAtIndex(
     lldb::opaque_compiler_type_t type, size_t idx, uint32_t *bit_offset_ptr) {
   clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
   const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -5589,7 +5589,7 @@ CompilerType ClangASTContext::GetVirtualBaseClassAtIndex(
 // different result. For example, an "int *" has one child that is an integer,
 // but a function pointer doesn't have any children. Likewise if a Record type
 // claims it has no children, then there really is nothing to show.
-uint32_t ClangASTContext::GetNumPointeeChildren(clang::QualType type) {
+uint32_t TypeSystemClang::GetNumPointeeChildren(clang::QualType type) {
   if (type.isNull())
     return 0;
 
@@ -5722,7 +5722,7 @@ uint32_t ClangASTContext::GetNumPointeeChildren(clang::QualType type) {
   return 0;
 }
 
-CompilerType ClangASTContext::GetChildCompilerTypeAtIndex(
+CompilerType TypeSystemClang::GetChildCompilerTypeAtIndex(
     lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
     bool transparent_pointers, bool omit_empty_base_classes,
     bool ignore_array_bounds, std::string &child_name,
@@ -5792,7 +5792,7 @@ CompilerType ClangASTContext::GetChildCompilerTypeAtIndex(
           if (omit_empty_base_classes) {
             base_class_decl = llvm::cast<clang::CXXRecordDecl>(
                 base_class->getType()->getAs<clang::RecordType>()->getDecl());
-            if (!ClangASTContext::RecordHasFields(base_class_decl))
+            if (!TypeSystemClang::RecordHasFields(base_class_decl))
               continue;
           }
 
@@ -6204,7 +6204,7 @@ static uint32_t GetIndexForRecordBase(const clang::RecordDecl *record_decl,
 static uint32_t GetIndexForRecordChild(const clang::RecordDecl *record_decl,
                                        clang::NamedDecl *canonical_decl,
                                        bool omit_empty_base_classes) {
-  uint32_t child_idx = ClangASTContext::GetNumBaseClasses(
+  uint32_t child_idx = TypeSystemClang::GetNumBaseClasses(
       llvm::dyn_cast<clang::CXXRecordDecl>(record_decl),
       omit_empty_base_classes);
 
@@ -6251,7 +6251,7 @@ static uint32_t GetIndexForRecordChild(const clang::RecordDecl *record_decl,
 // class C (since class B doesn't have any members it doesn't count) The second
 // index 1 is the child index for "m_b" within class A
 
-size_t ClangASTContext::GetIndexOfChildMemberWithName(
+size_t TypeSystemClang::GetIndexOfChildMemberWithName(
     lldb::opaque_compiler_type_t type, const char *name,
     bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
   if (type && name && name[0]) {
@@ -6288,7 +6288,7 @@ size_t ClangASTContext::GetIndexOfChildMemberWithName(
           } else if (field_name.equals(name_sref)) {
             // We have to add on the number of base classes to this index!
             child_indexes.push_back(
-                child_idx + ClangASTContext::GetNumBaseClasses(
+                child_idx + TypeSystemClang::GetNumBaseClasses(
                                 cxx_record_decl, omit_empty_base_classes));
             return child_indexes.size();
           }
@@ -6446,7 +6446,7 @@ size_t ClangASTContext::GetIndexOfChildMemberWithName(
     //                clang::QualType pointee_type =
     //                mem_ptr_type->getPointeeType();
     //
-    //                if (ClangASTContext::IsAggregateType
+    //                if (TypeSystemClang::IsAggregateType
     //                (pointee_type.getAsOpaquePtr()))
     //                {
     //                    return GetIndexOfChildWithName (ast,
@@ -6490,7 +6490,7 @@ size_t ClangASTContext::GetIndexOfChildMemberWithName(
 // matches can include base class names.
 
 uint32_t
-ClangASTContext::GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
+TypeSystemClang::GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
                                          const char *name,
                                          bool omit_empty_base_classes) {
   if (type && name && name[0]) {
@@ -6524,7 +6524,7 @@ ClangASTContext::GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
                         ->getAs<clang::RecordType>()
                         ->getDecl());
             if (omit_empty_base_classes &&
-                !ClangASTContext::RecordHasFields(base_class_decl))
+                !TypeSystemClang::RecordHasFields(base_class_decl))
               continue;
 
             CompilerType base_class_clang_type = GetType(base_class->getType());
@@ -6627,7 +6627,7 @@ ClangASTContext::GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
     //                clang::QualType pointee_type =
     //                mem_ptr_type->getPointeeType();
     //
-    //                if (ClangASTContext::IsAggregateType
+    //                if (TypeSystemClang::IsAggregateType
     //                (pointee_type.getAsOpaquePtr()))
     //                {
     //                    return GetIndexOfChildWithName (ast,
@@ -6685,7 +6685,7 @@ ClangASTContext::GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
 }
 
 size_t
-ClangASTContext::GetNumTemplateArguments(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetNumTemplateArguments(lldb::opaque_compiler_type_t type) {
   if (!type)
     return 0;
 
@@ -6714,7 +6714,7 @@ ClangASTContext::GetNumTemplateArguments(lldb::opaque_compiler_type_t type) {
 }
 
 const clang::ClassTemplateSpecializationDecl *
-ClangASTContext::GetAsTemplateSpecialization(
+TypeSystemClang::GetAsTemplateSpecialization(
     lldb::opaque_compiler_type_t type) {
   if (!type)
     return nullptr;
@@ -6739,7 +6739,7 @@ ClangASTContext::GetAsTemplateSpecialization(
 }
 
 lldb::TemplateArgumentKind
-ClangASTContext::GetTemplateArgumentKind(lldb::opaque_compiler_type_t type,
+TypeSystemClang::GetTemplateArgumentKind(lldb::opaque_compiler_type_t type,
                                          size_t arg_idx) {
   const clang::ClassTemplateSpecializationDecl *template_decl =
       GetAsTemplateSpecialization(type);
@@ -6778,7 +6778,7 @@ ClangASTContext::GetTemplateArgumentKind(lldb::opaque_compiler_type_t type,
 }
 
 CompilerType
-ClangASTContext::GetTypeTemplateArgument(lldb::opaque_compiler_type_t type,
+TypeSystemClang::GetTypeTemplateArgument(lldb::opaque_compiler_type_t type,
                                          size_t idx) {
   const clang::ClassTemplateSpecializationDecl *template_decl =
       GetAsTemplateSpecialization(type);
@@ -6794,7 +6794,7 @@ ClangASTContext::GetTypeTemplateArgument(lldb::opaque_compiler_type_t type,
 }
 
 Optional<CompilerType::IntegralTemplateArgument>
-ClangASTContext::GetIntegralTemplateArgument(lldb::opaque_compiler_type_t type,
+TypeSystemClang::GetIntegralTemplateArgument(lldb::opaque_compiler_type_t type,
                                              size_t idx) {
   const clang::ClassTemplateSpecializationDecl *template_decl =
       GetAsTemplateSpecialization(type);
@@ -6810,13 +6810,13 @@ ClangASTContext::GetIntegralTemplateArgument(lldb::opaque_compiler_type_t type,
       {template_arg.getAsIntegral(), GetType(template_arg.getIntegralType())}};
 }
 
-CompilerType ClangASTContext::GetTypeForFormatters(void *type) {
+CompilerType TypeSystemClang::GetTypeForFormatters(void *type) {
   if (type)
     return ClangUtil::RemoveFastQualifiers(CompilerType(this, type));
   return CompilerType();
 }
 
-clang::EnumDecl *ClangASTContext::GetAsEnumDecl(const CompilerType &type) {
+clang::EnumDecl *TypeSystemClang::GetAsEnumDecl(const CompilerType &type) {
   const clang::EnumType *enutype =
       llvm::dyn_cast<clang::EnumType>(ClangUtil::GetCanonicalQualType(type));
   if (enutype)
@@ -6824,7 +6824,7 @@ clang::EnumDecl *ClangASTContext::GetAsEnumDecl(const CompilerType &type) {
   return nullptr;
 }
 
-clang::RecordDecl *ClangASTContext::GetAsRecordDecl(const CompilerType &type) {
+clang::RecordDecl *TypeSystemClang::GetAsRecordDecl(const CompilerType &type) {
   const clang::RecordType *record_type =
       llvm::dyn_cast<clang::RecordType>(ClangUtil::GetCanonicalQualType(type));
   if (record_type)
@@ -6832,12 +6832,12 @@ clang::RecordDecl *ClangASTContext::GetAsRecordDecl(const CompilerType &type) {
   return nullptr;
 }
 
-clang::TagDecl *ClangASTContext::GetAsTagDecl(const CompilerType &type) {
+clang::TagDecl *TypeSystemClang::GetAsTagDecl(const CompilerType &type) {
   return ClangUtil::GetAsTagDecl(type);
 }
 
 clang::TypedefNameDecl *
-ClangASTContext::GetAsTypedefDecl(const CompilerType &type) {
+TypeSystemClang::GetAsTypedefDecl(const CompilerType &type) {
   const clang::TypedefType *typedef_type =
       llvm::dyn_cast<clang::TypedefType>(ClangUtil::GetQualType(type));
   if (typedef_type)
@@ -6846,12 +6846,12 @@ ClangASTContext::GetAsTypedefDecl(const CompilerType &type) {
 }
 
 clang::CXXRecordDecl *
-ClangASTContext::GetAsCXXRecordDecl(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetAsCXXRecordDecl(lldb::opaque_compiler_type_t type) {
   return GetCanonicalQualType(type)->getAsCXXRecordDecl();
 }
 
 clang::ObjCInterfaceDecl *
-ClangASTContext::GetAsObjCInterfaceDecl(const CompilerType &type) {
+TypeSystemClang::GetAsObjCInterfaceDecl(const CompilerType &type) {
   const clang::ObjCObjectType *objc_class_type =
       llvm::dyn_cast<clang::ObjCObjectType>(
           ClangUtil::GetCanonicalQualType(type));
@@ -6860,14 +6860,14 @@ ClangASTContext::GetAsObjCInterfaceDecl(const CompilerType &type) {
   return nullptr;
 }
 
-clang::FieldDecl *ClangASTContext::AddFieldToRecordType(
+clang::FieldDecl *TypeSystemClang::AddFieldToRecordType(
     const CompilerType &type, llvm::StringRef name,
     const CompilerType &field_clang_type, AccessType access,
     uint32_t bitfield_bit_size) {
   if (!type.IsValid() || !field_clang_type.IsValid())
     return nullptr;
-  ClangASTContext *ast =
-      llvm::dyn_cast_or_null<ClangASTContext>(type.GetTypeSystem());
+  TypeSystemClang *ast =
+      llvm::dyn_cast_or_null<TypeSystemClang>(type.GetTypeSystem());
   if (!ast)
     return nullptr;
   clang::ASTContext &clang_ast = ast->getASTContext();
@@ -6914,7 +6914,7 @@ clang::FieldDecl *ClangASTContext::AddFieldToRecordType(
 
     if (field) {
       field->setAccess(
-          ClangASTContext::ConvertAccessTypeToAccessSpecifier(access));
+          TypeSystemClang::ConvertAccessTypeToAccessSpecifier(access));
 
       record_decl->addDecl(field);
 
@@ -6952,11 +6952,11 @@ clang::FieldDecl *ClangASTContext::AddFieldToRecordType(
   return field;
 }
 
-void ClangASTContext::BuildIndirectFields(const CompilerType &type) {
+void TypeSystemClang::BuildIndirectFields(const CompilerType &type) {
   if (!type)
     return;
 
-  ClangASTContext *ast = llvm::dyn_cast<ClangASTContext>(type.GetTypeSystem());
+  TypeSystemClang *ast = llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
   if (!ast)
     return;
 
@@ -7005,7 +7005,7 @@ void ClangASTContext::BuildIndirectFields(const CompilerType &type) {
 
           indirect_field->setImplicit();
 
-          indirect_field->setAccess(ClangASTContext::UnifyAccessSpecifiers(
+          indirect_field->setAccess(TypeSystemClang::UnifyAccessSpecifiers(
               field_pos->getAccess(), nested_field_decl->getAccess()));
 
           indirect_fields.push_back(indirect_field);
@@ -7035,7 +7035,7 @@ void ClangASTContext::BuildIndirectFields(const CompilerType &type) {
 
           indirect_field->setImplicit();
 
-          indirect_field->setAccess(ClangASTContext::UnifyAccessSpecifiers(
+          indirect_field->setAccess(TypeSystemClang::UnifyAccessSpecifiers(
               field_pos->getAccess(), nested_indirect_field_decl->getAccess()));
 
           indirect_fields.push_back(indirect_field);
@@ -7058,10 +7058,10 @@ void ClangASTContext::BuildIndirectFields(const CompilerType &type) {
   }
 }
 
-void ClangASTContext::SetIsPacked(const CompilerType &type) {
+void TypeSystemClang::SetIsPacked(const CompilerType &type) {
   if (type) {
-    ClangASTContext *ast =
-        llvm::dyn_cast<ClangASTContext>(type.GetTypeSystem());
+    TypeSystemClang *ast =
+        llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
     if (ast) {
       clang::RecordDecl *record_decl = GetAsRecordDecl(type);
 
@@ -7074,13 +7074,13 @@ void ClangASTContext::SetIsPacked(const CompilerType &type) {
   }
 }
 
-clang::VarDecl *ClangASTContext::AddVariableToRecordType(
+clang::VarDecl *TypeSystemClang::AddVariableToRecordType(
     const CompilerType &type, llvm::StringRef name,
     const CompilerType &var_type, AccessType access) {
   if (!type.IsValid() || !var_type.IsValid())
     return nullptr;
 
-  ClangASTContext *ast = llvm::dyn_cast<ClangASTContext>(type.GetTypeSystem());
+  TypeSystemClang *ast = llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
   if (!ast)
     return nullptr;
 
@@ -7106,7 +7106,7 @@ clang::VarDecl *ClangASTContext::AddVariableToRecordType(
     return nullptr;
 
   var_decl->setAccess(
-      ClangASTContext::ConvertAccessTypeToAccessSpecifier(access));
+      TypeSystemClang::ConvertAccessTypeToAccessSpecifier(access));
   record_decl->addDecl(var_decl);
 
 #ifdef LLDB_CONFIGURATION_DEBUG
@@ -7116,7 +7116,7 @@ clang::VarDecl *ClangASTContext::AddVariableToRecordType(
   return var_decl;
 }
 
-clang::CXXMethodDecl *ClangASTContext::AddMethodToCXXRecordType(
+clang::CXXMethodDecl *TypeSystemClang::AddMethodToCXXRecordType(
     lldb::opaque_compiler_type_t type, const char *name, const char *mangled_name,
     const CompilerType &method_clang_type, lldb::AccessType access,
     bool is_virtual, bool is_static, bool is_inline, bool is_explicit,
@@ -7195,7 +7195,7 @@ clang::CXXMethodDecl *ClangASTContext::AddMethodToCXXRecordType(
         // create a method and add it to the class, clang will assert and
         // crash, so we need to make sure things are acceptable.
         const bool is_method = true;
-        if (!ClangASTContext::CheckOverloadedOperatorKindParameterCount(
+        if (!TypeSystemClang::CheckOverloadedOperatorKindParameterCount(
                 is_method, op_kind, num_params))
           return nullptr;
         cxx_method_decl = clang::CXXMethodDecl::Create(
@@ -7232,7 +7232,7 @@ clang::CXXMethodDecl *ClangASTContext::AddMethodToCXXRecordType(
   }
 
   clang::AccessSpecifier access_specifier =
-      ClangASTContext::ConvertAccessTypeToAccessSpecifier(access);
+      TypeSystemClang::ConvertAccessTypeToAccessSpecifier(access);
 
   cxx_method_decl->setAccess(access_specifier);
   cxx_method_decl->setVirtualAsWritten(is_virtual);
@@ -7299,7 +7299,7 @@ clang::CXXMethodDecl *ClangASTContext::AddMethodToCXXRecordType(
   return cxx_method_decl;
 }
 
-void ClangASTContext::AddMethodOverridesForCXXRecordType(
+void TypeSystemClang::AddMethodOverridesForCXXRecordType(
     lldb::opaque_compiler_type_t type) {
   if (auto *record = GetAsCXXRecordDecl(type))
     for (auto *method : record->methods())
@@ -7309,7 +7309,7 @@ void ClangASTContext::AddMethodOverridesForCXXRecordType(
 #pragma mark C++ Base Classes
 
 std::unique_ptr<clang::CXXBaseSpecifier>
-ClangASTContext::CreateBaseClassSpecifier(lldb::opaque_compiler_type_t type,
+TypeSystemClang::CreateBaseClassSpecifier(lldb::opaque_compiler_type_t type,
                                           AccessType access, bool is_virtual,
                                           bool base_of_class) {
   if (!type)
@@ -7317,12 +7317,12 @@ ClangASTContext::CreateBaseClassSpecifier(lldb::opaque_compiler_type_t type,
 
   return std::make_unique<clang::CXXBaseSpecifier>(
       clang::SourceRange(), is_virtual, base_of_class,
-      ClangASTContext::ConvertAccessTypeToAccessSpecifier(access),
+      TypeSystemClang::ConvertAccessTypeToAccessSpecifier(access),
       getASTContext().getTrivialTypeSourceInfo(GetQualType(type)),
       clang::SourceLocation());
 }
 
-bool ClangASTContext::TransferBaseClasses(
+bool TypeSystemClang::TransferBaseClasses(
     lldb::opaque_compiler_type_t type,
     std::vector<std::unique_ptr<clang::CXXBaseSpecifier>> bases) {
   if (!type)
@@ -7341,10 +7341,10 @@ bool ClangASTContext::TransferBaseClasses(
   return true;
 }
 
-bool ClangASTContext::SetObjCSuperClass(
+bool TypeSystemClang::SetObjCSuperClass(
     const CompilerType &type, const CompilerType &superclass_clang_type) {
-  ClangASTContext *ast =
-      llvm::dyn_cast_or_null<ClangASTContext>(type.GetTypeSystem());
+  TypeSystemClang *ast =
+      llvm::dyn_cast_or_null<TypeSystemClang>(type.GetTypeSystem());
   if (!ast)
     return false;
   clang::ASTContext &clang_ast = ast->getASTContext();
@@ -7364,7 +7364,7 @@ bool ClangASTContext::SetObjCSuperClass(
   return false;
 }
 
-bool ClangASTContext::AddObjCClassProperty(
+bool TypeSystemClang::AddObjCClassProperty(
     const CompilerType &type, const char *property_name,
     const CompilerType &property_clang_type, clang::ObjCIvarDecl *ivar_decl,
     const char *property_setter_name, const char *property_getter_name,
@@ -7372,7 +7372,7 @@ bool ClangASTContext::AddObjCClassProperty(
   if (!type || !property_clang_type.IsValid() || property_name == nullptr ||
       property_name[0] == '\0')
     return false;
-  ClangASTContext *ast = llvm::dyn_cast<ClangASTContext>(type.GetTypeSystem());
+  TypeSystemClang *ast = llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
   if (!ast)
     return false;
   clang::ASTContext &clang_ast = ast->getASTContext();
@@ -7553,7 +7553,7 @@ bool ClangASTContext::AddObjCClassProperty(
   return true;
 }
 
-bool ClangASTContext::IsObjCClassTypeAndHasIVars(const CompilerType &type,
+bool TypeSystemClang::IsObjCClassTypeAndHasIVars(const CompilerType &type,
                                                  bool check_superclass) {
   clang::ObjCInterfaceDecl *class_interface_decl = GetAsObjCInterfaceDecl(type);
   if (class_interface_decl)
@@ -7561,7 +7561,7 @@ bool ClangASTContext::IsObjCClassTypeAndHasIVars(const CompilerType &type,
   return false;
 }
 
-clang::ObjCMethodDecl *ClangASTContext::AddMethodToObjCObjectType(
+clang::ObjCMethodDecl *TypeSystemClang::AddMethodToObjCObjectType(
     const CompilerType &type,
     const char *name, // the full symbol name as seen in the symbol table
                       // (lldb::opaque_compiler_type_t type, "-[NString
@@ -7575,8 +7575,8 @@ clang::ObjCMethodDecl *ClangASTContext::AddMethodToObjCObjectType(
 
   if (class_interface_decl == nullptr)
     return nullptr;
-  ClangASTContext *lldb_ast =
-      llvm::dyn_cast<ClangASTContext>(type.GetTypeSystem());
+  TypeSystemClang *lldb_ast =
+      llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
   if (lldb_ast == nullptr)
     return nullptr;
   clang::ASTContext &ast = lldb_ast->getASTContext();
@@ -7693,7 +7693,7 @@ clang::ObjCMethodDecl *ClangASTContext::AddMethodToObjCObjectType(
   return objc_method_decl;
 }
 
-bool ClangASTContext::SetHasExternalStorage(lldb::opaque_compiler_type_t type,
+bool TypeSystemClang::SetHasExternalStorage(lldb::opaque_compiler_type_t type,
                                             bool has_extern) {
   if (!type)
     return false;
@@ -7746,7 +7746,7 @@ bool ClangASTContext::SetHasExternalStorage(lldb::opaque_compiler_type_t type,
 
 #pragma mark TagDecl
 
-bool ClangASTContext::StartTagDeclarationDefinition(const CompilerType &type) {
+bool TypeSystemClang::StartTagDeclarationDefinition(const CompilerType &type) {
   clang::QualType qual_type(ClangUtil::GetQualType(type));
   if (!qual_type.isNull()) {
     const clang::TagType *tag_type = qual_type->getAs<clang::TagType>();
@@ -7771,12 +7771,12 @@ bool ClangASTContext::StartTagDeclarationDefinition(const CompilerType &type) {
   return false;
 }
 
-bool ClangASTContext::CompleteTagDeclarationDefinition(
+bool TypeSystemClang::CompleteTagDeclarationDefinition(
     const CompilerType &type) {
   clang::QualType qual_type(ClangUtil::GetQualType(type));
   if (!qual_type.isNull()) {
     // Make sure we use the same methodology as
-    // ClangASTContext::StartTagDeclarationDefinition() as to how we start/end
+    // TypeSystemClang::StartTagDeclarationDefinition() as to how we start/end
     // the definition. Previously we were calling
     const clang::TagType *tag_type = qual_type->getAs<clang::TagType>();
     if (tag_type) {
@@ -7803,8 +7803,8 @@ bool ClangASTContext::CompleteTagDeclarationDefinition(
 
       if (enum_decl) {
         if (!enum_decl->isCompleteDefinition()) {
-          ClangASTContext *lldb_ast =
-              llvm::dyn_cast<ClangASTContext>(type.GetTypeSystem());
+          TypeSystemClang *lldb_ast =
+              llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
           if (lldb_ast == nullptr)
             return false;
           clang::ASTContext &ast = lldb_ast->getASTContext();
@@ -7840,7 +7840,7 @@ bool ClangASTContext::CompleteTagDeclarationDefinition(
   return false;
 }
 
-clang::EnumConstantDecl *ClangASTContext::AddEnumerationValueToEnumerationType(
+clang::EnumConstantDecl *TypeSystemClang::AddEnumerationValueToEnumerationType(
     const CompilerType &enum_type, const Declaration &decl, const char *name,
     const llvm::APSInt &value) {
 
@@ -7885,7 +7885,7 @@ clang::EnumConstantDecl *ClangASTContext::AddEnumerationValueToEnumerationType(
   return enumerator_decl;
 }
 
-clang::EnumConstantDecl *ClangASTContext::AddEnumerationValueToEnumerationType(
+clang::EnumConstantDecl *TypeSystemClang::AddEnumerationValueToEnumerationType(
     const CompilerType &enum_type, const Declaration &decl, const char *name,
     int64_t enum_value, uint32_t enum_value_bit_size) {
   CompilerType underlying_type =
@@ -7900,7 +7900,7 @@ clang::EnumConstantDecl *ClangASTContext::AddEnumerationValueToEnumerationType(
 }
 
 CompilerType
-ClangASTContext::GetEnumerationIntegerType(lldb::opaque_compiler_type_t type) {
+TypeSystemClang::GetEnumerationIntegerType(lldb::opaque_compiler_type_t type) {
   clang::QualType enum_qual_type(GetCanonicalQualType(type));
   const clang::Type *clang_type = enum_qual_type.getTypePtr();
   if (clang_type) {
@@ -7916,12 +7916,12 @@ ClangASTContext::GetEnumerationIntegerType(lldb::opaque_compiler_type_t type) {
 }
 
 CompilerType
-ClangASTContext::CreateMemberPointerType(const CompilerType &type,
+TypeSystemClang::CreateMemberPointerType(const CompilerType &type,
                                          const CompilerType &pointee_type) {
   if (type && pointee_type.IsValid() &&
       type.GetTypeSystem() == pointee_type.GetTypeSystem()) {
-    ClangASTContext *ast =
-        llvm::dyn_cast<ClangASTContext>(type.GetTypeSystem());
+    TypeSystemClang *ast =
+        llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
     if (!ast)
       return CompilerType();
     return ast->GetType(ast->getASTContext().getMemberPointerType(
@@ -7936,7 +7936,7 @@ ClangASTContext::CreateMemberPointerType(const CompilerType &type,
 
 #ifndef NDEBUG
 LLVM_DUMP_METHOD void
-ClangASTContext::dump(lldb::opaque_compiler_type_t type) const {
+TypeSystemClang::dump(lldb::opaque_compiler_type_t type) const {
   if (!type)
     return;
   clang::QualType qual_type(GetQualType(type));
@@ -7944,12 +7944,12 @@ ClangASTContext::dump(lldb::opaque_compiler_type_t type) const {
 }
 #endif
 
-void ClangASTContext::Dump(Stream &s) {
+void TypeSystemClang::Dump(Stream &s) {
   Decl *tu = Decl::castFromDeclContext(GetTranslationUnitDecl());
   tu->dump(s.AsRawOstream());
 }
 
-void ClangASTContext::DumpFromSymbolFile(Stream &s,
+void TypeSystemClang::DumpFromSymbolFile(Stream &s,
                                          llvm::StringRef symbol_name) {
   SymbolFile *symfile = GetSymbolFile();
 
@@ -7989,7 +7989,7 @@ void ClangASTContext::DumpFromSymbolFile(Stream &s,
   }
 }
 
-void ClangASTContext::DumpValue(
+void TypeSystemClang::DumpValue(
     lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, Stream *s,
     lldb::Format format, const lldb_private::DataExtractor &data,
     lldb::offset_t data_byte_offset, size_t data_byte_size,
@@ -8026,7 +8026,7 @@ void ClangASTContext::DumpValue(
                   base_class->getType()->getAs<clang::RecordType>()->getDecl());
 
           // Skip empty base classes
-          if (!verbose && !ClangASTContext::RecordHasFields(base_class_decl))
+          if (!verbose && !TypeSystemClang::RecordHasFields(base_class_decl))
             continue;
 
           if (base_class->isVirtual())
@@ -8443,7 +8443,7 @@ static bool DumpEnumValue(const clang::QualType &qual_type, Stream *s,
   return true;
 }
 
-bool ClangASTContext::DumpTypeValue(
+bool TypeSystemClang::DumpTypeValue(
     lldb::opaque_compiler_type_t type, Stream *s, lldb::Format format,
     const lldb_private::DataExtractor &data, lldb::offset_t byte_offset,
     size_t byte_size, uint32_t bitfield_bit_size, uint32_t bitfield_bit_offset,
@@ -8566,7 +8566,7 @@ bool ClangASTContext::DumpTypeValue(
   return false;
 }
 
-void ClangASTContext::DumpSummary(lldb::opaque_compiler_type_t type,
+void TypeSystemClang::DumpSummary(lldb::opaque_compiler_type_t type,
                                   ExecutionContext *exe_ctx, Stream *s,
                                   const lldb_private::DataExtractor &data,
                                   lldb::offset_t data_byte_offset,
@@ -8611,7 +8611,7 @@ void ClangASTContext::DumpSummary(lldb::opaque_compiler_type_t type,
   }
 }
 
-void ClangASTContext::DumpTypeDescription(lldb::opaque_compiler_type_t type) {
+void TypeSystemClang::DumpTypeDescription(lldb::opaque_compiler_type_t type) {
   StreamFile s(stdout, false);
   DumpTypeDescription(type, &s);
 
@@ -8623,7 +8623,7 @@ void ClangASTContext::DumpTypeDescription(lldb::opaque_compiler_type_t type) {
   }
 }
 
-void ClangASTContext::DumpTypeDescription(lldb::opaque_compiler_type_t type,
+void TypeSystemClang::DumpTypeDescription(lldb::opaque_compiler_type_t type,
                                           Stream *s) {
   if (type) {
     clang::QualType qual_type =
@@ -8703,7 +8703,7 @@ void ClangASTContext::DumpTypeDescription(lldb::opaque_compiler_type_t type,
   }
 }
 
-void ClangASTContext::DumpTypeName(const CompilerType &type) {
+void TypeSystemClang::DumpTypeName(const CompilerType &type) {
   if (ClangUtil::IsClangType(type)) {
     clang::QualType qual_type(
         ClangUtil::GetCanonicalQualType(ClangUtil::RemoveFastQualifiers(type)));
@@ -8769,16 +8769,16 @@ void ClangASTContext::DumpTypeName(const CompilerType &type) {
           llvm::cast<clang::ParenType>(qual_type)->desugar().getAsOpaquePtr()));
 
     default:
-      printf("ClangASTContext::DumpTypeName() type_class = %u", type_class);
+      printf("TypeSystemClang::DumpTypeName() type_class = %u", type_class);
       break;
     }
   }
 }
 
-clang::ClassTemplateDecl *ClangASTContext::ParseClassTemplateDecl(
+clang::ClassTemplateDecl *TypeSystemClang::ParseClassTemplateDecl(
     clang::DeclContext *decl_ctx, lldb::AccessType access_type,
     const char *parent_name, int tag_decl_kind,
-    const ClangASTContext::TemplateParameterInfos &template_param_infos) {
+    const TypeSystemClang::TemplateParameterInfos &template_param_infos) {
   if (template_param_infos.IsValid()) {
     std::string template_basename(parent_name);
     template_basename.erase(template_basename.find('<'));
@@ -8790,7 +8790,7 @@ clang::ClassTemplateDecl *ClangASTContext::ParseClassTemplateDecl(
   return nullptr;
 }
 
-void ClangASTContext::CompleteTagDecl(clang::TagDecl *decl) {
+void TypeSystemClang::CompleteTagDecl(clang::TagDecl *decl) {
   SymbolFile *sym_file = GetSymbolFile();
   if (sym_file) {
     CompilerType clang_type = GetTypeForDecl(decl);
@@ -8799,7 +8799,7 @@ void ClangASTContext::CompleteTagDecl(clang::TagDecl *decl) {
   }
 }
 
-void ClangASTContext::CompleteObjCInterfaceDecl(
+void TypeSystemClang::CompleteObjCInterfaceDecl(
     clang::ObjCInterfaceDecl *decl) {
   SymbolFile *sym_file = GetSymbolFile();
   if (sym_file) {
@@ -8809,19 +8809,19 @@ void ClangASTContext::CompleteObjCInterfaceDecl(
   }
 }
 
-DWARFASTParser *ClangASTContext::GetDWARFParser() {
+DWARFASTParser *TypeSystemClang::GetDWARFParser() {
   if (!m_dwarf_ast_parser_up)
     m_dwarf_ast_parser_up.reset(new DWARFASTParserClang(*this));
   return m_dwarf_ast_parser_up.get();
 }
 
-PDBASTParser *ClangASTContext::GetPDBParser() {
+PDBASTParser *TypeSystemClang::GetPDBParser() {
   if (!m_pdb_ast_parser_up)
     m_pdb_ast_parser_up.reset(new PDBASTParser(*this));
   return m_pdb_ast_parser_up.get();
 }
 
-bool ClangASTContext::LayoutRecordType(
+bool TypeSystemClang::LayoutRecordType(
     const clang::RecordDecl *record_decl, uint64_t &bit_size,
     uint64_t &alignment,
     llvm::DenseMap<const clang::FieldDecl *, uint64_t> &field_offsets,
@@ -8843,7 +8843,7 @@ bool ClangASTContext::LayoutRecordType(
 
 // CompilerDecl override functions
 
-ConstString ClangASTContext::DeclGetName(void *opaque_decl) {
+ConstString TypeSystemClang::DeclGetName(void *opaque_decl) {
   if (opaque_decl) {
     clang::NamedDecl *nd =
         llvm::dyn_cast<NamedDecl>((clang::Decl *)opaque_decl);
@@ -8853,7 +8853,7 @@ ConstString ClangASTContext::DeclGetName(void *opaque_decl) {
   return ConstString();
 }
 
-ConstString ClangASTContext::DeclGetMangledName(void *opaque_decl) {
+ConstString TypeSystemClang::DeclGetMangledName(void *opaque_decl) {
   if (opaque_decl) {
     clang::NamedDecl *nd =
         llvm::dyn_cast<clang::NamedDecl>((clang::Decl *)opaque_decl);
@@ -8879,13 +8879,13 @@ ConstString ClangASTContext::DeclGetMangledName(void *opaque_decl) {
   return ConstString();
 }
 
-CompilerDeclContext ClangASTContext::DeclGetDeclContext(void *opaque_decl) {
+CompilerDeclContext TypeSystemClang::DeclGetDeclContext(void *opaque_decl) {
   if (opaque_decl)
     return CreateDeclContext(((clang::Decl *)opaque_decl)->getDeclContext());
   return CompilerDeclContext();
 }
 
-CompilerType ClangASTContext::DeclGetFunctionReturnType(void *opaque_decl) {
+CompilerType TypeSystemClang::DeclGetFunctionReturnType(void *opaque_decl) {
   if (clang::FunctionDecl *func_decl =
           llvm::dyn_cast<clang::FunctionDecl>((clang::Decl *)opaque_decl))
     return GetType(func_decl->getReturnType());
@@ -8896,7 +8896,7 @@ CompilerType ClangASTContext::DeclGetFunctionReturnType(void *opaque_decl) {
     return CompilerType();
 }
 
-size_t ClangASTContext::DeclGetFunctionNumArguments(void *opaque_decl) {
+size_t TypeSystemClang::DeclGetFunctionNumArguments(void *opaque_decl) {
   if (clang::FunctionDecl *func_decl =
           llvm::dyn_cast<clang::FunctionDecl>((clang::Decl *)opaque_decl))
     return func_decl->param_size();
@@ -8907,7 +8907,7 @@ size_t ClangASTContext::DeclGetFunctionNumArguments(void *opaque_decl) {
     return 0;
 }
 
-CompilerType ClangASTContext::DeclGetFunctionArgumentType(void *opaque_decl,
+CompilerType TypeSystemClang::DeclGetFunctionArgumentType(void *opaque_decl,
                                                           size_t idx) {
   if (clang::FunctionDecl *func_decl =
           llvm::dyn_cast<clang::FunctionDecl>((clang::Decl *)opaque_decl)) {
@@ -8927,7 +8927,7 @@ CompilerType ClangASTContext::DeclGetFunctionArgumentType(void *opaque_decl,
 
 // CompilerDeclContext functions
 
-std::vector<CompilerDecl> ClangASTContext::DeclContextFindDeclByName(
+std::vector<CompilerDecl> TypeSystemClang::DeclContextFindDeclByName(
     void *opaque_decl_ctx, ConstString name, const bool ignore_using_decls) {
   std::vector<CompilerDecl> found_decls;
   if (opaque_decl_ctx) {
@@ -9024,7 +9024,7 @@ std::vector<CompilerDecl> ClangASTContext::DeclContextFindDeclByName(
 // below the global scope.  More work needs to be done to recognise that, if
 // the decl we're trying to look up is static, we should compare its source
 // file with that of the current scope and return a lower number for it.
-uint32_t ClangASTContext::CountDeclLevels(clang::DeclContext *frame_decl_ctx,
+uint32_t TypeSystemClang::CountDeclLevels(clang::DeclContext *frame_decl_ctx,
                                           clang::DeclContext *child_decl_ctx,
                                           ConstString *child_name,
                                           CompilerType *child_type) {
@@ -9106,7 +9106,7 @@ uint32_t ClangASTContext::CountDeclLevels(clang::DeclContext *frame_decl_ctx,
   return LLDB_INVALID_DECL_LEVEL;
 }
 
-ConstString ClangASTContext::DeclContextGetName(void *opaque_decl_ctx) {
+ConstString TypeSystemClang::DeclContextGetName(void *opaque_decl_ctx) {
   if (opaque_decl_ctx) {
     clang::NamedDecl *named_decl =
         llvm::dyn_cast<clang::NamedDecl>((clang::DeclContext *)opaque_decl_ctx);
@@ -9117,7 +9117,7 @@ ConstString ClangASTContext::DeclContextGetName(void *opaque_decl_ctx) {
 }
 
 ConstString
-ClangASTContext::DeclContextGetScopeQualifiedName(void *opaque_decl_ctx) {
+TypeSystemClang::DeclContextGetScopeQualifiedName(void *opaque_decl_ctx) {
   if (opaque_decl_ctx) {
     clang::NamedDecl *named_decl =
         llvm::dyn_cast<clang::NamedDecl>((clang::DeclContext *)opaque_decl_ctx);
@@ -9128,7 +9128,7 @@ ClangASTContext::DeclContextGetScopeQualifiedName(void *opaque_decl_ctx) {
   return ConstString();
 }
 
-bool ClangASTContext::DeclContextIsClassMethod(
+bool TypeSystemClang::DeclContextIsClassMethod(
     void *opaque_decl_ctx, lldb::LanguageType *language_ptr,
     bool *is_instance_method_ptr, ConstString *language_object_name_ptr) {
   if (opaque_decl_ctx) {
@@ -9168,7 +9168,7 @@ bool ClangASTContext::DeclContextIsClassMethod(
   return false;
 }
 
-bool ClangASTContext::DeclContextIsContainedInLookup(
+bool TypeSystemClang::DeclContextIsContainedInLookup(
     void *opaque_decl_ctx, void *other_opaque_decl_ctx) {
   auto *decl_ctx = (clang::DeclContext *)opaque_decl_ctx;
   auto *other = (clang::DeclContext *)other_opaque_decl_ctx;
@@ -9186,18 +9186,18 @@ bool ClangASTContext::DeclContextIsContainedInLookup(
 }
 
 static bool IsClangDeclContext(const CompilerDeclContext &dc) {
-  return dc.IsValid() && isa<ClangASTContext>(dc.GetTypeSystem());
+  return dc.IsValid() && isa<TypeSystemClang>(dc.GetTypeSystem());
 }
 
 clang::DeclContext *
-ClangASTContext::DeclContextGetAsDeclContext(const CompilerDeclContext &dc) {
+TypeSystemClang::DeclContextGetAsDeclContext(const CompilerDeclContext &dc) {
   if (IsClangDeclContext(dc))
     return (clang::DeclContext *)dc.GetOpaqueDeclContext();
   return nullptr;
 }
 
 ObjCMethodDecl *
-ClangASTContext::DeclContextGetAsObjCMethodDecl(const CompilerDeclContext &dc) {
+TypeSystemClang::DeclContextGetAsObjCMethodDecl(const CompilerDeclContext &dc) {
   if (IsClangDeclContext(dc))
     return llvm::dyn_cast<clang::ObjCMethodDecl>(
         (clang::DeclContext *)dc.GetOpaqueDeclContext());
@@ -9205,7 +9205,7 @@ ClangASTContext::DeclContextGetAsObjCMethodDecl(const CompilerDeclContext &dc) {
 }
 
 CXXMethodDecl *
-ClangASTContext::DeclContextGetAsCXXMethodDecl(const CompilerDeclContext &dc) {
+TypeSystemClang::DeclContextGetAsCXXMethodDecl(const CompilerDeclContext &dc) {
   if (IsClangDeclContext(dc))
     return llvm::dyn_cast<clang::CXXMethodDecl>(
         (clang::DeclContext *)dc.GetOpaqueDeclContext());
@@ -9213,7 +9213,7 @@ ClangASTContext::DeclContextGetAsCXXMethodDecl(const CompilerDeclContext &dc) {
 }
 
 clang::FunctionDecl *
-ClangASTContext::DeclContextGetAsFunctionDecl(const CompilerDeclContext &dc) {
+TypeSystemClang::DeclContextGetAsFunctionDecl(const CompilerDeclContext &dc) {
   if (IsClangDeclContext(dc))
     return llvm::dyn_cast<clang::FunctionDecl>(
         (clang::DeclContext *)dc.GetOpaqueDeclContext());
@@ -9221,7 +9221,7 @@ ClangASTContext::DeclContextGetAsFunctionDecl(const CompilerDeclContext &dc) {
 }
 
 clang::NamespaceDecl *
-ClangASTContext::DeclContextGetAsNamespaceDecl(const CompilerDeclContext &dc) {
+TypeSystemClang::DeclContextGetAsNamespaceDecl(const CompilerDeclContext &dc) {
   if (IsClangDeclContext(dc))
     return llvm::dyn_cast<clang::NamespaceDecl>(
         (clang::DeclContext *)dc.GetOpaqueDeclContext());
@@ -9229,24 +9229,24 @@ ClangASTContext::DeclContextGetAsNamespaceDecl(const CompilerDeclContext &dc) {
 }
 
 ClangASTMetadata *
-ClangASTContext::DeclContextGetMetaData(const CompilerDeclContext &dc,
+TypeSystemClang::DeclContextGetMetaData(const CompilerDeclContext &dc,
                                         const Decl *object) {
-  ClangASTContext *ast = llvm::cast<ClangASTContext>(dc.GetTypeSystem());
+  TypeSystemClang *ast = llvm::cast<TypeSystemClang>(dc.GetTypeSystem());
   return ast->GetMetadata(object);
 }
 
 clang::ASTContext *
-ClangASTContext::DeclContextGetClangASTContext(const CompilerDeclContext &dc) {
-  ClangASTContext *ast =
-      llvm::dyn_cast_or_null<ClangASTContext>(dc.GetTypeSystem());
+TypeSystemClang::DeclContextGetTypeSystemClang(const CompilerDeclContext &dc) {
+  TypeSystemClang *ast =
+      llvm::dyn_cast_or_null<TypeSystemClang>(dc.GetTypeSystem());
   if (ast)
     return &ast->getASTContext();
   return nullptr;
 }
 
-ClangASTContextForExpressions::ClangASTContextForExpressions(
+TypeSystemClangForExpressions::TypeSystemClangForExpressions(
     Target &target, llvm::Triple triple)
-    : ClangASTContext(triple), m_target_wp(target.shared_from_this()),
+    : TypeSystemClang(triple), m_target_wp(target.shared_from_this()),
       m_persistent_variables(new ClangPersistentVariables) {
   m_scratch_ast_source_up.reset(new ClangASTSource(
       target.shared_from_this(), target.GetClangASTImporter()));
@@ -9256,12 +9256,12 @@ ClangASTContextForExpressions::ClangASTContextForExpressions(
   SetExternalSource(proxy_ast_source);
 }
 
-void ClangASTContextForExpressions::Finalize() {
-  ClangASTContext::Finalize();
+void TypeSystemClangForExpressions::Finalize() {
+  TypeSystemClang::Finalize();
   m_scratch_ast_source_up.reset();
 }
 
-UserExpression *ClangASTContextForExpressions::GetUserExpression(
+UserExpression *TypeSystemClangForExpressions::GetUserExpression(
     llvm::StringRef expr, llvm::StringRef prefix, lldb::LanguageType language,
     Expression::ResultType desired_type,
     const EvaluateExpressionOptions &options,
@@ -9274,7 +9274,7 @@ UserExpression *ClangASTContextForExpressions::GetUserExpression(
                                  desired_type, options, ctx_obj);
 }
 
-FunctionCaller *ClangASTContextForExpressions::GetFunctionCaller(
+FunctionCaller *TypeSystemClangForExpressions::GetFunctionCaller(
     const CompilerType &return_type, const Address &function_address,
     const ValueList &arg_value_list, const char *name) {
   TargetSP target_sp = m_target_wp.lock();
@@ -9290,7 +9290,7 @@ FunctionCaller *ClangASTContextForExpressions::GetFunctionCaller(
 }
 
 UtilityFunction *
-ClangASTContextForExpressions::GetUtilityFunction(const char *text,
+TypeSystemClangForExpressions::GetUtilityFunction(const char *text,
                                                   const char *name) {
   TargetSP target_sp = m_target_wp.lock();
   if (!target_sp)
@@ -9300,6 +9300,6 @@ ClangASTContextForExpressions::GetUtilityFunction(const char *text,
 }
 
 PersistentExpressionState *
-ClangASTContextForExpressions::GetPersistentExpressionState() {
+TypeSystemClangForExpressions::GetPersistentExpressionState() {
   return m_persistent_variables.get();
 }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -36,7 +36,7 @@
 #include "lldb/Interpreter/OptionGroupWatchpoint.h"
 #include "lldb/Interpreter/OptionValues.h"
 #include "lldb/Interpreter/Property.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangASTImporter.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/ObjectFile.h"

--- a/lldb/tools/lldb-test/SystemInitializerTest.cpp
+++ b/lldb/tools/lldb-test/SystemInitializerTest.cpp
@@ -12,7 +12,7 @@
 #include "lldb/Host/Host.h"
 #include "lldb/Initialization/SystemInitializerCommon.h"
 #include "lldb/Interpreter/CommandInterpreter.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Utility/Timer.h"
 
 #include "Plugins/ABI/MacOSX-arm/ABIMacOSX_arm.h"
@@ -175,7 +175,7 @@ llvm::Error SystemInitializerTest::Initialize() {
   llvm::InitializeAllTargetMCs();
   llvm::InitializeAllDisassemblers();
 
-  ClangASTContext::Initialize();
+  TypeSystemClang::Initialize();
 
 #define LLVM_TARGET(t) LLDB_PROCESS_ ## t(Initialize)
 #include "llvm/Config/Targets.def"
@@ -266,7 +266,7 @@ void SystemInitializerTest::Terminate() {
   // Terminate and unload and loaded system or user LLDB plug-ins
   PluginManager::Terminate();
 
-  ClangASTContext::Terminate();
+  TypeSystemClang::Terminate();
 
 #define LLVM_TARGET(t) LLDB_PROCESS_ ## t(Terminate)
 #include "llvm/Config/Targets.def"

--- a/lldb/tools/lldb-test/lldb-test.cpp
+++ b/lldb/tools/lldb-test/lldb-test.cpp
@@ -18,7 +18,7 @@
 #include "lldb/Initialization/SystemLifetimeManager.h"
 #include "lldb/Interpreter/CommandInterpreter.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/LineTable.h"
 #include "lldb/Symbol/SymbolFile.h"
@@ -596,12 +596,12 @@ Error opts::symbols::dumpAST(lldb_private::Module &Module) {
   llvm::Expected<TypeSystem &> type_system_or_err =
       symfile->GetTypeSystemForLanguage(eLanguageTypeC_plus_plus);
   if (!type_system_or_err)
-    return make_string_error("Can't retrieve ClangASTContext");
+    return make_string_error("Can't retrieve TypeSystemClang");
 
   auto *clang_ast_ctx =
-      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
+      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
   if (!clang_ast_ctx)
-    return make_string_error("Retrieved TypeSystem was not a ClangASTContext");
+    return make_string_error("Retrieved TypeSystem was not a TypeSystemClang");
 
   clang::ASTContext &ast_ctx = clang_ast_ctx->getASTContext();
 
@@ -624,12 +624,12 @@ Error opts::symbols::dumpClangAST(lldb_private::Module &Module) {
   llvm::Expected<TypeSystem &> type_system_or_err =
       symfile->GetTypeSystemForLanguage(eLanguageTypeObjC_plus_plus);
   if (!type_system_or_err)
-    return make_string_error("Can't retrieve ClangASTContext");
+    return make_string_error("Can't retrieve TypeSystemClang");
 
   auto *clang_ast_ctx =
-      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
+      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
   if (!clang_ast_ctx)
-    return make_string_error("Retrieved TypeSystem was not a ClangASTContext");
+    return make_string_error("Retrieved TypeSystem was not a TypeSystemClang");
 
   StreamString Stream;
   clang_ast_ctx->DumpFromSymbolFile(Stream, Name);

--- a/lldb/unittests/Expression/ClangExpressionDeclMapTest.cpp
+++ b/lldb/unittests/Expression/ClangExpressionDeclMapTest.cpp
@@ -11,7 +11,7 @@
 #include "TestingSupport/Symbol/ClangTestUtils.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangUtil.h"
 #include "lldb/lldb-defines.h"
 #include "gtest/gtest.h"
@@ -26,7 +26,7 @@ struct FakeClangExpressionDeclMap : public ClangExpressionDeclMap {
                                nullptr) {
     m_scratch_context = clang_utils::createAST();
   }
-  std::unique_ptr<ClangASTContext> m_scratch_context;
+  std::unique_ptr<TypeSystemClang> m_scratch_context;
   /// Adds a persistent decl that can be found by the ClangExpressionDeclMap
   /// via GetPersistentDecl.
   void AddPersistentDeclForTest(clang::NamedDecl *d) {
@@ -63,7 +63,7 @@ struct ClangExpressionDeclMapTest : public testing::Test {
   std::unique_ptr<FakeClangExpressionDeclMap> decl_map;
 
   /// The target AST that lookup results should be imported to.
-  std::unique_ptr<ClangASTContext> target_ast;
+  std::unique_ptr<TypeSystemClang> target_ast;
 
   void SetUp() override {
     importer = std::make_shared<ClangASTImporter>();

--- a/lldb/unittests/Symbol/CMakeLists.txt
+++ b/lldb/unittests/Symbol/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_lldb_unittest(SymbolTests
   LocateSymbolFileTest.cpp
   PostfixExpressionTest.cpp
-  TestClangASTContext.cpp
+  TestTypeSystemClang.cpp
   TestClangASTImporter.cpp
   TestDWARFCallFrameInfo.cpp
   TestType.cpp

--- a/lldb/unittests/Symbol/TestClangASTImporter.cpp
+++ b/lldb/unittests/Symbol/TestClangASTImporter.cpp
@@ -12,7 +12,7 @@
 #include "TestingSupport/Symbol/ClangTestUtils.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangASTImporter.h"
 #include "lldb/Symbol/ClangASTMetadata.h"
 #include "lldb/Symbol/ClangUtil.h"
@@ -42,7 +42,7 @@ TEST_F(TestClangASTImporter, CopyDeclTagDecl) {
   // Tests that the ClangASTImporter::CopyDecl can copy TagDecls.
   clang_utils::SourceASTWithRecord source;
 
-  std::unique_ptr<ClangASTContext> target_ast = clang_utils::createAST();
+  std::unique_ptr<TypeSystemClang> target_ast = clang_utils::createAST();
 
   ClangASTImporter importer;
   clang::Decl *imported =
@@ -67,7 +67,7 @@ TEST_F(TestClangASTImporter, CopyTypeTagDecl) {
   // Tests that the ClangASTImporter::CopyType can copy TagDecls types.
   clang_utils::SourceASTWithRecord source;
 
-  std::unique_ptr<ClangASTContext> target_ast = clang_utils::createAST();
+  std::unique_ptr<TypeSystemClang> target_ast = clang_utils::createAST();
 
   ClangASTImporter importer;
   CompilerType imported = importer.CopyType(*target_ast, source.record_type);
@@ -92,7 +92,7 @@ TEST_F(TestClangASTImporter, DeportDeclTagDecl) {
   // Tests that the ClangASTImporter::DeportDecl completely copies TagDecls.
   clang_utils::SourceASTWithRecord source;
 
-  std::unique_ptr<ClangASTContext> target_ast = clang_utils::createAST();
+  std::unique_ptr<TypeSystemClang> target_ast = clang_utils::createAST();
 
   ClangASTImporter importer;
   clang::Decl *imported =
@@ -114,7 +114,7 @@ TEST_F(TestClangASTImporter, DeportTypeTagDecl) {
   // Tests that the ClangASTImporter::CopyType can deport TagDecl types.
   clang_utils::SourceASTWithRecord source;
 
-  std::unique_ptr<ClangASTContext> target_ast = clang_utils::createAST();
+  std::unique_ptr<TypeSystemClang> target_ast = clang_utils::createAST();
 
   ClangASTImporter importer;
   CompilerType imported = importer.DeportType(*target_ast, source.record_type);
@@ -139,7 +139,7 @@ TEST_F(TestClangASTImporter, MetadataPropagation) {
   const lldb::user_id_t metadata = 123456;
   source.ast->SetMetadataAsUserID(source.record_decl, metadata);
 
-  std::unique_ptr<ClangASTContext> target_ast = clang_utils::createAST();
+  std::unique_ptr<TypeSystemClang> target_ast = clang_utils::createAST();
 
   ClangASTImporter importer;
   clang::Decl *imported =
@@ -161,14 +161,14 @@ TEST_F(TestClangASTImporter, MetadataPropagationIndirectImport) {
   const lldb::user_id_t metadata = 123456;
   source.ast->SetMetadataAsUserID(source.record_decl, metadata);
 
-  std::unique_ptr<ClangASTContext> temporary_ast = clang_utils::createAST();
+  std::unique_ptr<TypeSystemClang> temporary_ast = clang_utils::createAST();
 
   ClangASTImporter importer;
   clang::Decl *temporary_imported =
       importer.CopyDecl(&temporary_ast->getASTContext(), source.record_decl);
   ASSERT_NE(nullptr, temporary_imported);
 
-  std::unique_ptr<ClangASTContext> target_ast = clang_utils::createAST();
+  std::unique_ptr<TypeSystemClang> target_ast = clang_utils::createAST();
   clang::Decl *imported =
       importer.CopyDecl(&target_ast->getASTContext(), temporary_imported);
   ASSERT_NE(nullptr, imported);
@@ -185,7 +185,7 @@ TEST_F(TestClangASTImporter, MetadataPropagationAfterCopying) {
   clang_utils::SourceASTWithRecord source;
   const lldb::user_id_t metadata = 123456;
 
-  std::unique_ptr<ClangASTContext> target_ast = clang_utils::createAST();
+  std::unique_ptr<TypeSystemClang> target_ast = clang_utils::createAST();
 
   ClangASTImporter importer;
   clang::Decl *imported =

--- a/lldb/unittests/Symbol/TestLineEntry.cpp
+++ b/lldb/unittests/Symbol/TestLineEntry.cpp
@@ -16,7 +16,7 @@
 #include "Plugins/SymbolFile/DWARF/SymbolFileDWARF.h"
 #include "TestingSupport/SubsystemRAII.h"
 #include "TestingSupport/TestUtilities.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 
 #include "lldb/Core/Module.h"
 #include "lldb/Host/FileSystem.h"
@@ -33,7 +33,7 @@ using namespace lldb;
 
 class LineEntryTest : public testing::Test {
   SubsystemRAII<FileSystem, HostInfo, ObjectFileMachO, SymbolFileDWARF,
-                ClangASTContext>
+                TypeSystemClang>
       subsystem;
 
 public:

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -1,4 +1,4 @@
-//===-- TestClangASTContext.cpp ---------------------------------*- C++ -*-===//
+//===-- TestTypeSystemClang.cpp ---------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,7 +10,7 @@
 #include "TestingSupport/Symbol/ClangTestUtils.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangUtil.h"
 #include "lldb/Symbol/Declaration.h"
 #include "clang/AST/DeclCXX.h"
@@ -21,18 +21,18 @@ using namespace clang;
 using namespace lldb;
 using namespace lldb_private;
 
-class TestClangASTContext : public testing::Test {
+class TestTypeSystemClang : public testing::Test {
 public:
   SubsystemRAII<FileSystem, HostInfo> subsystems;
 
   void SetUp() override {
-    m_ast.reset(new ClangASTContext(HostInfo::GetTargetTriple()));
+    m_ast.reset(new TypeSystemClang(HostInfo::GetTargetTriple()));
   }
 
   void TearDown() override { m_ast.reset(); }
 
 protected:
-  std::unique_ptr<ClangASTContext> m_ast;
+  std::unique_ptr<TypeSystemClang> m_ast;
 
   QualType GetBasicQualType(BasicType type) const {
     return ClangUtil::GetQualType(m_ast->GetBasicTypeFromAST(type));
@@ -44,7 +44,7 @@ protected:
   }
 };
 
-TEST_F(TestClangASTContext, TestGetBasicTypeFromEnum) {
+TEST_F(TestTypeSystemClang, TestGetBasicTypeFromEnum) {
   clang::ASTContext &context = m_ast->getASTContext();
 
   EXPECT_TRUE(
@@ -107,7 +107,7 @@ TEST_F(TestClangASTContext, TestGetBasicTypeFromEnum) {
       context.hasSameType(GetBasicQualType(eBasicTypeWChar), context.WCharTy));
 }
 
-TEST_F(TestClangASTContext, TestGetBasicTypeFromName) {
+TEST_F(TestTypeSystemClang, TestGetBasicTypeFromName) {
   EXPECT_EQ(GetBasicQualType(eBasicTypeChar), GetBasicQualType("char"));
   EXPECT_EQ(GetBasicQualType(eBasicTypeSignedChar),
             GetBasicQualType("signed char"));
@@ -158,7 +158,7 @@ TEST_F(TestClangASTContext, TestGetBasicTypeFromName) {
   EXPECT_EQ(GetBasicQualType(eBasicTypeNullPtr), GetBasicQualType("nullptr"));
 }
 
-void VerifyEncodingAndBitSize(ClangASTContext &clang_context,
+void VerifyEncodingAndBitSize(TypeSystemClang &clang_context,
                               lldb::Encoding encoding, unsigned int bit_size) {
   clang::ASTContext &context = clang_context.getASTContext();
 
@@ -196,7 +196,7 @@ void VerifyEncodingAndBitSize(ClangASTContext &clang_context,
   }
 }
 
-TEST_F(TestClangASTContext, TestBuiltinTypeForEncodingAndBitSize) {
+TEST_F(TestTypeSystemClang, TestBuiltinTypeForEncodingAndBitSize) {
   // Make sure we can get types of every possible size in every possible
   // encoding.
   // We can't make any guarantee about which specific type we get, because the
@@ -220,10 +220,10 @@ TEST_F(TestClangASTContext, TestBuiltinTypeForEncodingAndBitSize) {
   VerifyEncodingAndBitSize(*m_ast, eEncodingIEEE754, 64);
 }
 
-TEST_F(TestClangASTContext, TestIsClangType) {
+TEST_F(TestTypeSystemClang, TestIsClangType) {
   clang::ASTContext &context = m_ast->getASTContext();
   lldb::opaque_compiler_type_t bool_ctype =
-      ClangASTContext::GetOpaqueCompilerType(&context, lldb::eBasicTypeBool);
+      TypeSystemClang::GetOpaqueCompilerType(&context, lldb::eBasicTypeBool);
   CompilerType bool_type(m_ast.get(), bool_ctype);
   CompilerType record_type = m_ast->CreateRecordType(
       nullptr, lldb::eAccessPublic, "FooRecord", clang::TTK_Struct,
@@ -236,7 +236,7 @@ TEST_F(TestClangASTContext, TestIsClangType) {
   EXPECT_FALSE(ClangUtil::IsClangType(CompilerType()));
 }
 
-TEST_F(TestClangASTContext, TestRemoveFastQualifiers) {
+TEST_F(TestTypeSystemClang, TestRemoveFastQualifiers) {
   CompilerType record_type = m_ast->CreateRecordType(
       nullptr, lldb::eAccessPublic, "FooRecord", clang::TTK_Struct,
       lldb::eLanguageTypeC_plus_plus, nullptr);
@@ -254,84 +254,84 @@ TEST_F(TestClangASTContext, TestRemoveFastQualifiers) {
   EXPECT_EQ(0u, qt.getLocalFastQualifiers());
 }
 
-TEST_F(TestClangASTContext, TestConvertAccessTypeToAccessSpecifier) {
+TEST_F(TestTypeSystemClang, TestConvertAccessTypeToAccessSpecifier) {
   EXPECT_EQ(AS_none,
-            ClangASTContext::ConvertAccessTypeToAccessSpecifier(eAccessNone));
-  EXPECT_EQ(AS_none, ClangASTContext::ConvertAccessTypeToAccessSpecifier(
+            TypeSystemClang::ConvertAccessTypeToAccessSpecifier(eAccessNone));
+  EXPECT_EQ(AS_none, TypeSystemClang::ConvertAccessTypeToAccessSpecifier(
                          eAccessPackage));
   EXPECT_EQ(AS_public,
-            ClangASTContext::ConvertAccessTypeToAccessSpecifier(eAccessPublic));
-  EXPECT_EQ(AS_private, ClangASTContext::ConvertAccessTypeToAccessSpecifier(
+            TypeSystemClang::ConvertAccessTypeToAccessSpecifier(eAccessPublic));
+  EXPECT_EQ(AS_private, TypeSystemClang::ConvertAccessTypeToAccessSpecifier(
                             eAccessPrivate));
-  EXPECT_EQ(AS_protected, ClangASTContext::ConvertAccessTypeToAccessSpecifier(
+  EXPECT_EQ(AS_protected, TypeSystemClang::ConvertAccessTypeToAccessSpecifier(
                               eAccessProtected));
 }
 
-TEST_F(TestClangASTContext, TestUnifyAccessSpecifiers) {
+TEST_F(TestTypeSystemClang, TestUnifyAccessSpecifiers) {
   // Unifying two of the same type should return the same type
   EXPECT_EQ(AS_public,
-            ClangASTContext::UnifyAccessSpecifiers(AS_public, AS_public));
+            TypeSystemClang::UnifyAccessSpecifiers(AS_public, AS_public));
   EXPECT_EQ(AS_private,
-            ClangASTContext::UnifyAccessSpecifiers(AS_private, AS_private));
+            TypeSystemClang::UnifyAccessSpecifiers(AS_private, AS_private));
   EXPECT_EQ(AS_protected,
-            ClangASTContext::UnifyAccessSpecifiers(AS_protected, AS_protected));
+            TypeSystemClang::UnifyAccessSpecifiers(AS_protected, AS_protected));
 
   // Otherwise the result should be the strictest of the two.
   EXPECT_EQ(AS_private,
-            ClangASTContext::UnifyAccessSpecifiers(AS_private, AS_public));
+            TypeSystemClang::UnifyAccessSpecifiers(AS_private, AS_public));
   EXPECT_EQ(AS_private,
-            ClangASTContext::UnifyAccessSpecifiers(AS_private, AS_protected));
+            TypeSystemClang::UnifyAccessSpecifiers(AS_private, AS_protected));
   EXPECT_EQ(AS_private,
-            ClangASTContext::UnifyAccessSpecifiers(AS_public, AS_private));
+            TypeSystemClang::UnifyAccessSpecifiers(AS_public, AS_private));
   EXPECT_EQ(AS_private,
-            ClangASTContext::UnifyAccessSpecifiers(AS_protected, AS_private));
+            TypeSystemClang::UnifyAccessSpecifiers(AS_protected, AS_private));
   EXPECT_EQ(AS_protected,
-            ClangASTContext::UnifyAccessSpecifiers(AS_protected, AS_public));
+            TypeSystemClang::UnifyAccessSpecifiers(AS_protected, AS_public));
   EXPECT_EQ(AS_protected,
-            ClangASTContext::UnifyAccessSpecifiers(AS_public, AS_protected));
+            TypeSystemClang::UnifyAccessSpecifiers(AS_public, AS_protected));
 
   // None is stricter than everything (by convention)
   EXPECT_EQ(AS_none,
-            ClangASTContext::UnifyAccessSpecifiers(AS_none, AS_public));
+            TypeSystemClang::UnifyAccessSpecifiers(AS_none, AS_public));
   EXPECT_EQ(AS_none,
-            ClangASTContext::UnifyAccessSpecifiers(AS_none, AS_protected));
+            TypeSystemClang::UnifyAccessSpecifiers(AS_none, AS_protected));
   EXPECT_EQ(AS_none,
-            ClangASTContext::UnifyAccessSpecifiers(AS_none, AS_private));
+            TypeSystemClang::UnifyAccessSpecifiers(AS_none, AS_private));
   EXPECT_EQ(AS_none,
-            ClangASTContext::UnifyAccessSpecifiers(AS_public, AS_none));
+            TypeSystemClang::UnifyAccessSpecifiers(AS_public, AS_none));
   EXPECT_EQ(AS_none,
-            ClangASTContext::UnifyAccessSpecifiers(AS_protected, AS_none));
+            TypeSystemClang::UnifyAccessSpecifiers(AS_protected, AS_none));
   EXPECT_EQ(AS_none,
-            ClangASTContext::UnifyAccessSpecifiers(AS_private, AS_none));
+            TypeSystemClang::UnifyAccessSpecifiers(AS_private, AS_none));
 }
 
-TEST_F(TestClangASTContext, TestRecordHasFields) {
+TEST_F(TestTypeSystemClang, TestRecordHasFields) {
   CompilerType int_type = m_ast->GetBasicType(eBasicTypeInt);
 
   // Test that a record with no fields returns false
   CompilerType empty_base = m_ast->CreateRecordType(
       nullptr, lldb::eAccessPublic, "EmptyBase", clang::TTK_Struct,
       lldb::eLanguageTypeC_plus_plus, nullptr);
-  ClangASTContext::StartTagDeclarationDefinition(empty_base);
-  ClangASTContext::CompleteTagDeclarationDefinition(empty_base);
+  TypeSystemClang::StartTagDeclarationDefinition(empty_base);
+  TypeSystemClang::CompleteTagDeclarationDefinition(empty_base);
 
-  RecordDecl *empty_base_decl = ClangASTContext::GetAsRecordDecl(empty_base);
+  RecordDecl *empty_base_decl = TypeSystemClang::GetAsRecordDecl(empty_base);
   EXPECT_NE(nullptr, empty_base_decl);
-  EXPECT_FALSE(ClangASTContext::RecordHasFields(empty_base_decl));
+  EXPECT_FALSE(TypeSystemClang::RecordHasFields(empty_base_decl));
 
   // Test that a record with direct fields returns true
   CompilerType non_empty_base = m_ast->CreateRecordType(
       nullptr, lldb::eAccessPublic, "NonEmptyBase", clang::TTK_Struct,
       lldb::eLanguageTypeC_plus_plus, nullptr);
-  ClangASTContext::StartTagDeclarationDefinition(non_empty_base);
+  TypeSystemClang::StartTagDeclarationDefinition(non_empty_base);
   FieldDecl *non_empty_base_field_decl = m_ast->AddFieldToRecordType(
       non_empty_base, "MyField", int_type, eAccessPublic, 0);
-  ClangASTContext::CompleteTagDeclarationDefinition(non_empty_base);
+  TypeSystemClang::CompleteTagDeclarationDefinition(non_empty_base);
   RecordDecl *non_empty_base_decl =
-      ClangASTContext::GetAsRecordDecl(non_empty_base);
+      TypeSystemClang::GetAsRecordDecl(non_empty_base);
   EXPECT_NE(nullptr, non_empty_base_decl);
   EXPECT_NE(nullptr, non_empty_base_field_decl);
-  EXPECT_TRUE(ClangASTContext::RecordHasFields(non_empty_base_decl));
+  EXPECT_TRUE(TypeSystemClang::RecordHasFields(non_empty_base_decl));
 
   std::vector<std::unique_ptr<clang::CXXBaseSpecifier>> bases;
 
@@ -339,50 +339,50 @@ TEST_F(TestClangASTContext, TestRecordHasFields) {
   CompilerType empty_derived = m_ast->CreateRecordType(
       nullptr, lldb::eAccessPublic, "EmptyDerived", clang::TTK_Struct,
       lldb::eLanguageTypeC_plus_plus, nullptr);
-  ClangASTContext::StartTagDeclarationDefinition(empty_derived);
+  TypeSystemClang::StartTagDeclarationDefinition(empty_derived);
   std::unique_ptr<clang::CXXBaseSpecifier> non_empty_base_spec =
       m_ast->CreateBaseClassSpecifier(non_empty_base.GetOpaqueQualType(),
                                       lldb::eAccessPublic, false, false);
   bases.push_back(std::move(non_empty_base_spec));
   bool result = m_ast->TransferBaseClasses(empty_derived.GetOpaqueQualType(),
                                            std::move(bases));
-  ClangASTContext::CompleteTagDeclarationDefinition(empty_derived);
+  TypeSystemClang::CompleteTagDeclarationDefinition(empty_derived);
   EXPECT_TRUE(result);
   CXXRecordDecl *empty_derived_non_empty_base_cxx_decl =
       m_ast->GetAsCXXRecordDecl(empty_derived.GetOpaqueQualType());
   RecordDecl *empty_derived_non_empty_base_decl =
-      ClangASTContext::GetAsRecordDecl(empty_derived);
-  EXPECT_EQ(1u, ClangASTContext::GetNumBaseClasses(
+      TypeSystemClang::GetAsRecordDecl(empty_derived);
+  EXPECT_EQ(1u, TypeSystemClang::GetNumBaseClasses(
                     empty_derived_non_empty_base_cxx_decl, false));
   EXPECT_TRUE(
-      ClangASTContext::RecordHasFields(empty_derived_non_empty_base_decl));
+      TypeSystemClang::RecordHasFields(empty_derived_non_empty_base_decl));
 
   // Test that a record with no direct fields, but fields in a virtual base
   // returns true
   CompilerType empty_derived2 = m_ast->CreateRecordType(
       nullptr, lldb::eAccessPublic, "EmptyDerived2", clang::TTK_Struct,
       lldb::eLanguageTypeC_plus_plus, nullptr);
-  ClangASTContext::StartTagDeclarationDefinition(empty_derived2);
+  TypeSystemClang::StartTagDeclarationDefinition(empty_derived2);
   std::unique_ptr<CXXBaseSpecifier> non_empty_vbase_spec =
       m_ast->CreateBaseClassSpecifier(non_empty_base.GetOpaqueQualType(),
                                       lldb::eAccessPublic, true, false);
   bases.push_back(std::move(non_empty_vbase_spec));
   result = m_ast->TransferBaseClasses(empty_derived2.GetOpaqueQualType(),
                                       std::move(bases));
-  ClangASTContext::CompleteTagDeclarationDefinition(empty_derived2);
+  TypeSystemClang::CompleteTagDeclarationDefinition(empty_derived2);
   EXPECT_TRUE(result);
   CXXRecordDecl *empty_derived_non_empty_vbase_cxx_decl =
       m_ast->GetAsCXXRecordDecl(empty_derived2.GetOpaqueQualType());
   RecordDecl *empty_derived_non_empty_vbase_decl =
-      ClangASTContext::GetAsRecordDecl(empty_derived2);
-  EXPECT_EQ(1u, ClangASTContext::GetNumBaseClasses(
+      TypeSystemClang::GetAsRecordDecl(empty_derived2);
+  EXPECT_EQ(1u, TypeSystemClang::GetNumBaseClasses(
                     empty_derived_non_empty_vbase_cxx_decl, false));
   EXPECT_TRUE(
-      ClangASTContext::RecordHasFields(empty_derived_non_empty_vbase_decl));
+      TypeSystemClang::RecordHasFields(empty_derived_non_empty_vbase_decl));
 }
 
-TEST_F(TestClangASTContext, TemplateArguments) {
-  ClangASTContext::TemplateParameterInfos infos;
+TEST_F(TestTypeSystemClang, TemplateArguments) {
+  TypeSystemClang::TemplateParameterInfos infos;
   infos.names.push_back("T");
   infos.args.push_back(TemplateArgument(m_ast->getASTContext().IntTy));
   infos.names.push_back("I");
@@ -445,34 +445,34 @@ static QualType makeConstInt(clang::ASTContext &ctxt) {
   return result;
 }
 
-TEST_F(TestClangASTContext, TestGetTypeClassDeclType) {
+TEST_F(TestTypeSystemClang, TestGetTypeClassDeclType) {
   clang::ASTContext &ctxt = m_ast->getASTContext();
   auto *nullptr_expr = new (ctxt) CXXNullPtrLiteralExpr(ctxt.NullPtrTy, SourceLocation());
   QualType t = ctxt.getDecltypeType(nullptr_expr, makeConstInt(ctxt));
   EXPECT_EQ(lldb::eTypeClassBuiltin, m_ast->GetTypeClass(t.getAsOpaquePtr()));
 }
 
-TEST_F(TestClangASTContext, TestGetTypeClassTypeOf) {
+TEST_F(TestTypeSystemClang, TestGetTypeClassTypeOf) {
   clang::ASTContext &ctxt = m_ast->getASTContext();
   QualType t = ctxt.getTypeOfType(makeConstInt(ctxt));
   EXPECT_EQ(lldb::eTypeClassBuiltin, m_ast->GetTypeClass(t.getAsOpaquePtr()));
 }
 
-TEST_F(TestClangASTContext, TestGetTypeClassTypeOfExpr) {
+TEST_F(TestTypeSystemClang, TestGetTypeClassTypeOfExpr) {
   clang::ASTContext &ctxt = m_ast->getASTContext();
   auto *nullptr_expr = new (ctxt) CXXNullPtrLiteralExpr(ctxt.NullPtrTy, SourceLocation());
   QualType t = ctxt.getTypeOfExprType(nullptr_expr);
   EXPECT_EQ(lldb::eTypeClassBuiltin, m_ast->GetTypeClass(t.getAsOpaquePtr()));
 }
 
-TEST_F(TestClangASTContext, TestGetTypeClassNested) {
+TEST_F(TestTypeSystemClang, TestGetTypeClassNested) {
   clang::ASTContext &ctxt = m_ast->getASTContext();
   QualType t_base = ctxt.getTypeOfType(makeConstInt(ctxt));
   QualType t = ctxt.getTypeOfType(t_base);
   EXPECT_EQ(lldb::eTypeClassBuiltin, m_ast->GetTypeClass(t.getAsOpaquePtr()));
 }
 
-TEST_F(TestClangASTContext, TestFunctionTemplateConstruction) {
+TEST_F(TestTypeSystemClang, TestFunctionTemplateConstruction) {
   // Tests creating a function template.
 
   CompilerType int_type = m_ast->GetBasicType(lldb::eBasicTypeInt);
@@ -483,7 +483,7 @@ TEST_F(TestClangASTContext, TestFunctionTemplateConstruction) {
       m_ast->CreateFunctionType(int_type, nullptr, 0U, false, 0U);
   FunctionDecl *func =
       m_ast->CreateFunctionDeclaration(TU, "foo", clang_type, 0, false);
-  ClangASTContext::TemplateParameterInfos empty_params;
+  TypeSystemClang::TemplateParameterInfos empty_params;
 
   // Create the actual function template.
   clang::FunctionTemplateDecl *func_template =
@@ -494,7 +494,7 @@ TEST_F(TestClangASTContext, TestFunctionTemplateConstruction) {
   EXPECT_EQ(clang::AccessSpecifier::AS_none, func_template->getAccess());
 }
 
-TEST_F(TestClangASTContext, TestFunctionTemplateInRecordConstruction) {
+TEST_F(TestTypeSystemClang, TestFunctionTemplateInRecordConstruction) {
   // Tests creating a function template inside a record.
 
   CompilerType int_type = m_ast->GetBasicType(lldb::eBasicTypeInt);
@@ -509,7 +509,7 @@ TEST_F(TestClangASTContext, TestFunctionTemplateInRecordConstruction) {
       m_ast->CreateFunctionType(int_type, nullptr, 0U, false, 0U);
   FunctionDecl *func =
       m_ast->CreateFunctionDeclaration(record, "foo", clang_type, 0, false);
-  ClangASTContext::TemplateParameterInfos empty_params;
+  TypeSystemClang::TemplateParameterInfos empty_params;
 
   // Create the actual function template.
   clang::FunctionTemplateDecl *func_template =

--- a/lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp
+++ b/lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp
@@ -16,7 +16,7 @@ using namespace lldb;
 using namespace lldb_private;
 
 class DWARFASTParserClangTests : public testing::Test {
-  SubsystemRAII<FileSystem, ClangASTContext> subsystems;
+  SubsystemRAII<FileSystem, TypeSystemClang> subsystems;
 };
 
 namespace {
@@ -38,7 +38,7 @@ public:
 // defining here, causing this test to fail, feel free to delete it.
 TEST_F(DWARFASTParserClangTests,
        EnsureAllDIEsInDeclContextHaveBeenParsedParsesOnlyMatchingEntries) {
-  ClangASTContext ast_ctx;
+  TypeSystemClang ast_ctx;
   DWARFASTParserClangStub ast_parser(ast_ctx);
 
   DWARFUnit *unit = nullptr;

--- a/lldb/unittests/SymbolFile/DWARF/SymbolFileDWARFTests.cpp
+++ b/lldb/unittests/SymbolFile/DWARF/SymbolFileDWARFTests.cpp
@@ -27,7 +27,7 @@
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/LineTable.h"
 #include "lldb/Utility/ArchSpec.h"
@@ -42,7 +42,7 @@ using namespace lldb_private;
 
 class SymbolFileDWARFTests : public testing::Test {
   SubsystemRAII<FileSystem, HostInfo, ObjectFilePECOFF, SymbolFileDWARF,
-                ClangASTContext, SymbolFilePDB>
+                TypeSystemClang, SymbolFilePDB>
       subsystems;
 
 public:

--- a/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
+++ b/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
@@ -24,7 +24,7 @@
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/LineTable.h"
 #include "lldb/Symbol/TypeMap.h"
@@ -54,7 +54,7 @@ public:
     HostInfo::Initialize();
     ObjectFilePECOFF::Initialize();
     SymbolFileDWARF::Initialize();
-    ClangASTContext::Initialize();
+    TypeSystemClang::Initialize();
     SymbolFilePDB::Initialize();
 
     m_pdb_test_exe = GetInputFilePath("test-pdb.exe");
@@ -63,7 +63,7 @@ public:
 
   void TearDown() override {
     SymbolFilePDB::Terminate();
-    ClangASTContext::Initialize();
+    TypeSystemClang::Initialize();
     SymbolFileDWARF::Terminate();
     ObjectFilePECOFF::Terminate();
     HostInfo::Terminate();
@@ -360,7 +360,7 @@ TEST_F(SymbolFilePDBTests, TestSimpleClassTypes) {
   lldb::TypeSP udt_type = results.GetTypeAtIndex(0);
   EXPECT_EQ(ConstString("Class"), udt_type->GetName());
   CompilerType compiler_type = udt_type->GetForwardCompilerType();
-  EXPECT_TRUE(ClangASTContext::IsClassType(compiler_type.GetOpaqueQualType()));
+  EXPECT_TRUE(TypeSystemClang::IsClassType(compiler_type.GetOpaqueQualType()));
   EXPECT_EQ(GetGlobalConstantInteger(session, "sizeof_Class"),
             udt_type->GetByteSize());
 }
@@ -381,7 +381,7 @@ TEST_F(SymbolFilePDBTests, TestNestedClassTypes) {
   ASSERT_THAT_EXPECTED(clang_ast_ctx_or_err, llvm::Succeeded());
 
   auto clang_ast_ctx =
-      llvm::dyn_cast_or_null<ClangASTContext>(&clang_ast_ctx_or_err.get());
+      llvm::dyn_cast_or_null<TypeSystemClang>(&clang_ast_ctx_or_err.get());
   EXPECT_NE(nullptr, clang_ast_ctx);
 
   symfile->FindTypes(ConstString("Class"), nullptr, 0, searched_files, results);
@@ -412,7 +412,7 @@ TEST_F(SymbolFilePDBTests, TestNestedClassTypes) {
   EXPECT_EQ(ConstString("NestedClass"), udt_type->GetName());
 
   CompilerType compiler_type = udt_type->GetForwardCompilerType();
-  EXPECT_TRUE(ClangASTContext::IsClassType(compiler_type.GetOpaqueQualType()));
+  EXPECT_TRUE(TypeSystemClang::IsClassType(compiler_type.GetOpaqueQualType()));
 
   EXPECT_EQ(GetGlobalConstantInteger(session, "sizeof_NestedClass"),
             udt_type->GetByteSize());
@@ -434,7 +434,7 @@ TEST_F(SymbolFilePDBTests, TestClassInNamespace) {
   ASSERT_THAT_EXPECTED(clang_ast_ctx_or_err, llvm::Succeeded());
 
   auto clang_ast_ctx =
-      llvm::dyn_cast_or_null<ClangASTContext>(&clang_ast_ctx_or_err.get());
+      llvm::dyn_cast_or_null<TypeSystemClang>(&clang_ast_ctx_or_err.get());
   EXPECT_NE(nullptr, clang_ast_ctx);
 
   clang::ASTContext &ast_ctx = clang_ast_ctx->getASTContext();
@@ -456,7 +456,7 @@ TEST_F(SymbolFilePDBTests, TestClassInNamespace) {
   EXPECT_EQ(ConstString("NSClass"), udt_type->GetName());
 
   CompilerType compiler_type = udt_type->GetForwardCompilerType();
-  EXPECT_TRUE(ClangASTContext::IsClassType(compiler_type.GetOpaqueQualType()));
+  EXPECT_TRUE(TypeSystemClang::IsClassType(compiler_type.GetOpaqueQualType()));
 
   EXPECT_EQ(GetGlobalConstantInteger(session, "sizeof_NSClass"),
             udt_type->GetByteSize());
@@ -479,8 +479,8 @@ TEST_F(SymbolFilePDBTests, TestEnumTypes) {
     lldb::TypeSP enum_type = results.GetTypeAtIndex(0);
     EXPECT_EQ(ConstString(Enum), enum_type->GetName());
     CompilerType compiler_type = enum_type->GetFullCompilerType();
-    EXPECT_TRUE(ClangASTContext::IsEnumType(compiler_type.GetOpaqueQualType()));
-    clang::EnumDecl *enum_decl = ClangASTContext::GetAsEnumDecl(compiler_type);
+    EXPECT_TRUE(TypeSystemClang::IsEnumType(compiler_type.GetOpaqueQualType()));
+    clang::EnumDecl *enum_decl = TypeSystemClang::GetAsEnumDecl(compiler_type);
     EXPECT_NE(nullptr, enum_decl);
     EXPECT_EQ(2, std::distance(enum_decl->enumerator_begin(),
                                enum_decl->enumerator_end()));
@@ -528,8 +528,8 @@ TEST_F(SymbolFilePDBTests, TestTypedefs) {
     lldb::TypeSP typedef_type = results.GetTypeAtIndex(0);
     EXPECT_EQ(ConstString(Typedef), typedef_type->GetName());
     CompilerType compiler_type = typedef_type->GetFullCompilerType();
-    ClangASTContext *clang_type_system =
-        llvm::dyn_cast_or_null<ClangASTContext>(compiler_type.GetTypeSystem());
+    TypeSystemClang *clang_type_system =
+        llvm::dyn_cast_or_null<TypeSystemClang>(compiler_type.GetTypeSystem());
     EXPECT_TRUE(
         clang_type_system->IsTypedefType(compiler_type.GetOpaqueQualType()));
 

--- a/lldb/unittests/TestingSupport/Symbol/ClangTestUtils.h
+++ b/lldb/unittests/TestingSupport/Symbol/ClangTestUtils.h
@@ -10,22 +10,22 @@
 #define LLDB_UNITTESTS_TESTINGSUPPORT_SYMBOL_CLANGTESTUTILS_H
 
 #include "lldb/Host/HostInfo.h"
-#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Symbol/TypeSystemClang.h"
 #include "lldb/Symbol/ClangUtil.h"
 
 namespace lldb_private {
 namespace clang_utils {
-inline clang::DeclarationName getDeclarationName(ClangASTContext &ast,
+inline clang::DeclarationName getDeclarationName(TypeSystemClang &ast,
                                                  llvm::StringRef name) {
   clang::IdentifierInfo &II = ast.getASTContext().Idents.get(name);
   return ast.getASTContext().DeclarationNames.getIdentifier(&II);
 }
 
-inline std::unique_ptr<ClangASTContext> createAST() {
-  return std::make_unique<ClangASTContext>(HostInfo::GetTargetTriple());
+inline std::unique_ptr<TypeSystemClang> createAST() {
+  return std::make_unique<TypeSystemClang>(HostInfo::GetTargetTriple());
 }
 
-inline CompilerType createRecord(ClangASTContext &ast, llvm::StringRef name) {
+inline CompilerType createRecord(TypeSystemClang &ast, llvm::StringRef name) {
   return ast.CreateRecordType(ast.getASTContext().getTranslationUnitDecl(),
                               lldb::AccessType::eAccessPublic, name, 0,
                               lldb::LanguageType::eLanguageTypeC);
@@ -33,25 +33,25 @@ inline CompilerType createRecord(ClangASTContext &ast, llvm::StringRef name) {
 
 /// Create a record with the given name and a field with the given type
 /// and name.
-inline CompilerType createRecordWithField(ClangASTContext &ast,
+inline CompilerType createRecordWithField(TypeSystemClang &ast,
                                           llvm::StringRef record_name,
                                           CompilerType field_type,
                                           llvm::StringRef field_name) {
   CompilerType t = createRecord(ast, record_name);
 
-  ClangASTContext::StartTagDeclarationDefinition(t);
+  TypeSystemClang::StartTagDeclarationDefinition(t);
   ast.AddFieldToRecordType(t, field_name, field_type,
                            lldb::AccessType::eAccessPublic, 7);
-  ClangASTContext::CompleteTagDeclarationDefinition(t);
+  TypeSystemClang::CompleteTagDeclarationDefinition(t);
 
   return t;
 }
 
-/// Constructs a ClangASTContext that contains a single RecordDecl that contains
+/// Constructs a TypeSystemClang that contains a single RecordDecl that contains
 /// a single FieldDecl. Utility class as this setup is a common starting point
 /// for unit test that exercise the ASTImporter.
 struct SourceASTWithRecord {
-  std::unique_ptr<ClangASTContext> ast;
+  std::unique_ptr<TypeSystemClang> ast;
   CompilerType record_type;
   clang::RecordDecl *record_decl = nullptr;
   clang::FieldDecl *field_decl = nullptr;


### PR DESCRIPTION
This commit renames ClangASTContext to TypeSystemClang to better reflect what this class is actually supposed to do
(implement the TypeSystem interface for Clang). It also gets rid of the very confusing situation that we have both a
`clang::ASTContext` and a `ClangASTContext` in clang (which sometimes causes Clang people to think I'm fiddling
with Clang's ASTContext when I'm actually just doing LLDB work).

I also have plans to potentially have multiple clang::ASTContext instances associated with one ClangASTContext so
the ASTContext naming will then become even more confusing to people.

Reviewers: #lldb, aprantl, shafik, clayborg, labath, JDevlieghere, davide, espindola, jdoerfert, xiaobai

Reviewed By: clayborg, labath, xiaobai

Subscribers: wuzish, emaste, nemanjai, mgorny, kbarton, MaskRay, arphaman, jfb, usaxena95, jingham, xiaobai, abidh, JDevlieghere, lldb-commits

Tags: #lldb

Differential Revision: https://reviews.llvm.org/D72684