### PR TITLE
Suppress some diagnostics

### DIFF
--- a/clang/lib/Tooling/Refactor/IndexerQueries.cpp
+++ b/clang/lib/Tooling/Refactor/IndexerQueries.cpp
@@ -131,7 +131,7 @@ IndexerQuery::loadResultsFromYAML(StringRef Source,
   if (QueryResults.size() != Queries.size())
     return llvm::make_error<llvm::StringError>("Mismatch in query results size",
                                                llvm::errc::invalid_argument);
-  for (const auto &QueryTuple : llvm::zip(Queries, QueryResults)) {
+  for (auto QueryTuple : llvm::zip(Queries, QueryResults)) {
     IndexerQuery *Query = std::get<0>(QueryTuple);
     const QueryYAMLNode &Result = std::get<1>(QueryTuple);
     if ((Query->NameUID && Query->NameUID != Result.Name) &&
@@ -152,7 +152,7 @@ IndexerQuery::loadResultsFromYAML(StringRef Source,
         if (PredicateResult.Name != ActualPredicate.Name)
           continue;
         std::vector<Indexed<PersistentDeclRef<Decl>>> Output;
-        for (const auto &ResultTuple :
+        for (auto ResultTuple :
              zip(DQ->getInputs(), PredicateResult.IntegerValues)) {
           const Decl *D = std::get<0>(ResultTuple);
           int Result = std::get<1>(ResultTuple);

--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -767,9 +767,6 @@ public:
     } Payload;
 
     PtrAuthData(unsigned FromRawData) { Payload.RawData = FromRawData; }
-    PtrAuthData(const PtrAuthData &Copy) {
-      Payload.RawData = Copy.Payload.RawData;
-    }
     PtrAuthData(unsigned Key, bool IsDiscr, unsigned Discriminator) {
       assert(Key < 8);
       assert(Discriminator <= 0xffff);


### PR DESCRIPTION
Silence cases of -Wdeprecated-copy and -Wrange-loop-analysis.  See commit messages for details

* clang: Quash some -Wrange-loop-analysis warnings, NFC.  These are always copies because llvm::zip returns a tuple (of references) by value.  Make -Wrange-loop-analysis happy by making that clear in the source.
* clang: Quash an instance of -Wdeprecated-copy, NFC.  Remove an explicit copy constructor, which was triggering -Wdeprecated-copy where the copy assignment operator was being implicitly generated.  The implicit ones do the right thing.
