### PR TITLE
[llvm][TextAPI/MachO] Support writing single macCatalyst platform

### DIFF
--- a/llvm/lib/TextAPI/MachO/TextStubCommon.cpp
+++ b/llvm/lib/TextAPI/MachO/TextStubCommon.cpp
@@ -74,6 +74,9 @@ void ScalarTraits<PlatformSet>::output(const PlatformSet &Values, void *IO,
   case PlatformKind::bridgeOS:
     OS << "bridgeos";
     break;
+  case PlatformKind::macCatalyst:
+    OS << "iosmac";
+    break;
   }
 }
 

--- a/llvm/unittests/TextAPI/TextStubV2Tests.cpp
+++ b/llvm/unittests/TextAPI/TextStubV2Tests.cpp
@@ -234,14 +234,14 @@ TEST(TBDv2, WriteFile) {
 }
 
 TEST(TBDv2, Platform_macOS) {
-  static const char tbd_v1_platform_macos[] = "--- !tapi-tbd-v2\n"
+  static const char tbd_v2_platform_macos[] = "--- !tapi-tbd-v2\n"
                                               "archs: [ x86_64 ]\n"
                                               "platform: macosx\n"
                                               "install-name: Test.dylib\n"
                                               "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_platform_macos, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v2_platform_macos, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto File = std::move(Result.get());
   auto Platform = PlatformKind::macOS;
@@ -251,14 +251,14 @@ TEST(TBDv2, Platform_macOS) {
 }
 
 TEST(TBDv2, Platform_iOS) {
-  static const char tbd_v1_platform_ios[] = "--- !tapi-tbd-v2\n"
+  static const char tbd_v2_platform_ios[] = "--- !tapi-tbd-v2\n"
                                             "archs: [ arm64 ]\n"
                                             "platform: ios\n"
                                             "install-name: Test.dylib\n"
                                             "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_platform_ios, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v2_platform_ios, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto Platform = PlatformKind::iOS;
   auto File = std::move(Result.get());
@@ -268,14 +268,14 @@ TEST(TBDv2, Platform_iOS) {
 }
 
 TEST(TBDv2, Platform_watchOS) {
-  static const char tbd_v1_platform_watchos[] = "--- !tapi-tbd-v2\n"
+  static const char tbd_v2_platform_watchos[] = "--- !tapi-tbd-v2\n"
                                                 "archs: [ armv7k ]\n"
                                                 "platform: watchos\n"
                                                 "install-name: Test.dylib\n"
                                                 "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_platform_watchos, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v2_platform_watchos, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto Platform = PlatformKind::watchOS;
   auto File = std::move(Result.get());
@@ -285,14 +285,14 @@ TEST(TBDv2, Platform_watchOS) {
 }
 
 TEST(TBDv2, Platform_tvOS) {
-  static const char tbd_v1_platform_tvos[] = "--- !tapi-tbd-v2\n"
+  static const char tbd_v2_platform_tvos[] = "--- !tapi-tbd-v2\n"
                                              "archs: [ arm64 ]\n"
                                              "platform: tvos\n"
                                              "install-name: Test.dylib\n"
                                              "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_platform_tvos, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v2_platform_tvos, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto Platform = PlatformKind::tvOS;
   auto File = std::move(Result.get());
@@ -302,14 +302,14 @@ TEST(TBDv2, Platform_tvOS) {
 }
 
 TEST(TBDv2, Platform_bridgeOS) {
-  static const char tbd_v1_platform_bridgeos[] = "--- !tapi-tbd-v2\n"
+  static const char tbd_v2_platform_bridgeos[] = "--- !tapi-tbd-v2\n"
                                                  "archs: [ armv7k ]\n"
                                                  "platform: bridgeos\n"
                                                  "install-name: Test.dylib\n"
                                                  "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_platform_bridgeos, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v2_platform_bridgeos, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto Platform = PlatformKind::bridgeOS;
   auto File = std::move(Result.get());
@@ -319,7 +319,7 @@ TEST(TBDv2, Platform_bridgeOS) {
 }
 
 TEST(TBDv2, Swift_1_0) {
-  static const char tbd_v1_swift_1_0[] = "--- !tapi-tbd-v2\n"
+  static const char tbd_v2_swift_1_0[] = "--- !tapi-tbd-v2\n"
                                          "archs: [ arm64 ]\n"
                                          "platform: ios\n"
                                          "install-name: Test.dylib\n"
@@ -327,7 +327,7 @@ TEST(TBDv2, Swift_1_0) {
                                          "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_swift_1_0, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v2_swift_1_0, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V2, File->getFileType());
@@ -335,7 +335,7 @@ TEST(TBDv2, Swift_1_0) {
 }
 
 TEST(TBDv2, Swift_1_1) {
-  static const char tbd_v1_swift_1_1[] = "--- !tapi-tbd-v2\n"
+  static const char tbd_v2_swift_1_1[] = "--- !tapi-tbd-v2\n"
                                          "archs: [ arm64 ]\n"
                                          "platform: ios\n"
                                          "install-name: Test.dylib\n"
@@ -343,7 +343,7 @@ TEST(TBDv2, Swift_1_1) {
                                          "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_swift_1_1, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v2_swift_1_1, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V2, File->getFileType());
@@ -351,7 +351,7 @@ TEST(TBDv2, Swift_1_1) {
 }
 
 TEST(TBDv2, Swift_2_0) {
-  static const char tbd_v1_swift_2_0[] = "--- !tapi-tbd-v2\n"
+  static const char tbd_v2_swift_2_0[] = "--- !tapi-tbd-v2\n"
                                          "archs: [ arm64 ]\n"
                                          "platform: ios\n"
                                          "install-name: Test.dylib\n"
@@ -359,7 +359,7 @@ TEST(TBDv2, Swift_2_0) {
                                          "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_swift_2_0, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v2_swift_2_0, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V2, File->getFileType());
@@ -367,7 +367,7 @@ TEST(TBDv2, Swift_2_0) {
 }
 
 TEST(TBDv2, Swift_3_0) {
-  static const char tbd_v1_swift_3_0[] = "--- !tapi-tbd-v2\n"
+  static const char tbd_v2_swift_3_0[] = "--- !tapi-tbd-v2\n"
                                          "archs: [ arm64 ]\n"
                                          "platform: ios\n"
                                          "install-name: Test.dylib\n"
@@ -375,7 +375,7 @@ TEST(TBDv2, Swift_3_0) {
                                          "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_swift_3_0, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v2_swift_3_0, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V2, File->getFileType());
@@ -383,7 +383,7 @@ TEST(TBDv2, Swift_3_0) {
 }
 
 TEST(TBDv2, Swift_4_0) {
-  static const char tbd_v1_swift_4_0[] = "--- !tapi-tbd-v2\n"
+  static const char tbd_v2_swift_4_0[] = "--- !tapi-tbd-v2\n"
                                          "archs: [ arm64 ]\n"
                                          "platform: ios\n"
                                          "install-name: Test.dylib\n"
@@ -391,7 +391,7 @@ TEST(TBDv2, Swift_4_0) {
                                          "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_swift_4_0, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v2_swift_4_0, "Test.tbd"));
   EXPECT_FALSE(!!Result);
   auto errorMessage = toString(Result.takeError());
   EXPECT_EQ("malformed file\nTest.tbd:5:16: error: invalid Swift ABI "
@@ -400,14 +400,14 @@ TEST(TBDv2, Swift_4_0) {
 }
 
 TEST(TBDv2, Swift_5) {
-  static const char tbd_v1_swift_5[] = "--- !tapi-tbd-v2\n"
+  static const char tbd_v2_swift_5[] = "--- !tapi-tbd-v2\n"
                                        "archs: [ arm64 ]\n"
                                        "platform: ios\n"
                                        "install-name: Test.dylib\n"
                                        "swift-version: 5\n"
                                        "...\n";
 
-  auto Result = TextAPIReader::get(MemoryBufferRef(tbd_v1_swift_5, "Test.tbd"));
+  auto Result = TextAPIReader::get(MemoryBufferRef(tbd_v2_swift_5, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V2, File->getFileType());
@@ -415,7 +415,7 @@ TEST(TBDv2, Swift_5) {
 }
 
 TEST(TBDv2, Swift_99) {
-  static const char tbd_v1_swift_99[] = "--- !tapi-tbd-v2\n"
+  static const char tbd_v2_swift_99[] = "--- !tapi-tbd-v2\n"
                                         "archs: [ arm64 ]\n"
                                         "platform: ios\n"
                                         "install-name: Test.dylib\n"
@@ -423,7 +423,7 @@ TEST(TBDv2, Swift_99) {
                                         "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_swift_99, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v2_swift_99, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V2, File->getFileType());

--- a/llvm/unittests/TextAPI/TextStubV3Tests.cpp
+++ b/llvm/unittests/TextAPI/TextStubV3Tests.cpp
@@ -190,14 +190,14 @@ TEST(TBDv3, WriteFile) {
 }
 
 TEST(TBDv3, Platform_macOS) {
-  static const char tbd_v1_platform_macos[] = "--- !tapi-tbd-v3\n"
+  static const char tbd_v3_platform_macos[] = "--- !tapi-tbd-v3\n"
                                               "archs: [ x86_64 ]\n"
                                               "platform: macosx\n"
                                               "install-name: Test.dylib\n"
                                               "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_platform_macos, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v3_platform_macos, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto Platform = PlatformKind::macOS;
   auto File = std::move(Result.get());
@@ -207,14 +207,14 @@ TEST(TBDv3, Platform_macOS) {
 }
 
 TEST(TBDv3, Platform_iOS) {
-  static const char tbd_v1_platform_ios[] = "--- !tapi-tbd-v3\n"
+  static const char tbd_v3_platform_ios[] = "--- !tapi-tbd-v3\n"
                                             "archs: [ arm64 ]\n"
                                             "platform: ios\n"
                                             "install-name: Test.dylib\n"
                                             "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_platform_ios, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v3_platform_ios, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto Platform = PlatformKind::iOS;
   auto File = std::move(Result.get());
@@ -224,14 +224,14 @@ TEST(TBDv3, Platform_iOS) {
 }
 
 TEST(TBDv3, Platform_watchOS) {
-  static const char tbd_v1_platform_watchos[] = "--- !tapi-tbd-v3\n"
+  static const char tbd_v3_platform_watchos[] = "--- !tapi-tbd-v3\n"
                                                 "archs: [ armv7k ]\n"
                                                 "platform: watchos\n"
                                                 "install-name: Test.dylib\n"
                                                 "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_platform_watchos, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v3_platform_watchos, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto Platform = PlatformKind::watchOS;
   auto File = std::move(Result.get());
@@ -241,14 +241,14 @@ TEST(TBDv3, Platform_watchOS) {
 }
 
 TEST(TBDv3, Platform_tvOS) {
-  static const char tbd_v1_platform_tvos[] = "--- !tapi-tbd-v3\n"
+  static const char tbd_v3_platform_tvos[] = "--- !tapi-tbd-v3\n"
                                              "archs: [ arm64 ]\n"
                                              "platform: tvos\n"
                                              "install-name: Test.dylib\n"
                                              "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_platform_tvos, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v3_platform_tvos, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto File = std::move(Result.get());
   auto Platform = PlatformKind::tvOS;
@@ -258,14 +258,14 @@ TEST(TBDv3, Platform_tvOS) {
 }
 
 TEST(TBDv3, Platform_bridgeOS) {
-  static const char tbd_v1_platform_bridgeos[] = "--- !tapi-tbd-v3\n"
+  static const char tbd_v3_platform_bridgeos[] = "--- !tapi-tbd-v3\n"
                                                  "archs: [ armv7k ]\n"
                                                  "platform: bridgeos\n"
                                                  "install-name: Test.dylib\n"
                                                  "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_platform_bridgeos, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v3_platform_bridgeos, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto Platform = PlatformKind::bridgeOS;
   auto File = std::move(Result.get());
@@ -275,14 +275,14 @@ TEST(TBDv3, Platform_bridgeOS) {
 }
 
 TEST(TBDv3, Platform_macCatalyst) {
-  static const char tbd_v1_platform_iosmac[] = "--- !tapi-tbd-v3\n"
+  static const char tbd_v3_platform_iosmac[] = "--- !tapi-tbd-v3\n"
                                                  "archs: [ armv7k ]\n"
                                                  "platform: iosmac\n"
                                                  "install-name: Test.dylib\n"
                                                  "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_platform_iosmac, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v3_platform_iosmac, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto Platform = PlatformKind::macCatalyst;
   auto File = std::move(Result.get());
@@ -291,14 +291,14 @@ TEST(TBDv3, Platform_macCatalyst) {
 }
 
 TEST(TBDv3, Platform_zippered) {
-  static const char tbd_v1_platform_zip[] = "--- !tapi-tbd-v3\n"
+  static const char tbd_v3_platform_zip[] = "--- !tapi-tbd-v3\n"
                                                  "archs: [ armv7k ]\n"
                                                  "platform: zippered\n"
                                                  "install-name: Test.dylib\n"
                                                  "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_platform_zip, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v3_platform_zip, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());
@@ -312,7 +312,7 @@ TEST(TBDv3, Platform_zippered) {
 }
 
 TEST(TBDv3, Swift_1_0) {
-  static const char tbd_v1_swift_1_0[] = "--- !tapi-tbd-v3\n"
+  static const char tbd_v3_swift_1_0[] = "--- !tapi-tbd-v3\n"
                                          "archs: [ arm64 ]\n"
                                          "platform: ios\n"
                                          "install-name: Test.dylib\n"
@@ -320,7 +320,7 @@ TEST(TBDv3, Swift_1_0) {
                                          "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_swift_1_0, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v3_swift_1_0, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());
@@ -328,7 +328,7 @@ TEST(TBDv3, Swift_1_0) {
 }
 
 TEST(TBDv3, Swift_1_1) {
-  static const char tbd_v1_swift_1_1[] = "--- !tapi-tbd-v3\n"
+  static const char tbd_v3_swift_1_1[] = "--- !tapi-tbd-v3\n"
                                          "archs: [ arm64 ]\n"
                                          "platform: ios\n"
                                          "install-name: Test.dylib\n"
@@ -336,7 +336,7 @@ TEST(TBDv3, Swift_1_1) {
                                          "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_swift_1_1, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v3_swift_1_1, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());
@@ -344,7 +344,7 @@ TEST(TBDv3, Swift_1_1) {
 }
 
 TEST(TBDv3, Swift_2_0) {
-  static const char tbd_v1_swift_2_0[] = "--- !tapi-tbd-v3\n"
+  static const char tbd_v3_swift_2_0[] = "--- !tapi-tbd-v3\n"
                                          "archs: [ arm64 ]\n"
                                          "platform: ios\n"
                                          "install-name: Test.dylib\n"
@@ -352,7 +352,7 @@ TEST(TBDv3, Swift_2_0) {
                                          "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_swift_2_0, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v3_swift_2_0, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());
@@ -360,7 +360,7 @@ TEST(TBDv3, Swift_2_0) {
 }
 
 TEST(TBDv3, Swift_3_0) {
-  static const char tbd_v1_swift_3_0[] = "--- !tapi-tbd-v3\n"
+  static const char tbd_v3_swift_3_0[] = "--- !tapi-tbd-v3\n"
                                          "archs: [ arm64 ]\n"
                                          "platform: ios\n"
                                          "install-name: Test.dylib\n"
@@ -368,7 +368,7 @@ TEST(TBDv3, Swift_3_0) {
                                          "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_swift_3_0, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v3_swift_3_0, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());
@@ -376,7 +376,7 @@ TEST(TBDv3, Swift_3_0) {
 }
 
 TEST(TBDv3, Swift_4_0) {
-  static const char tbd_v1_swift_4_0[] = "--- !tapi-tbd-v3\n"
+  static const char tbd_v3_swift_4_0[] = "--- !tapi-tbd-v3\n"
                                          "archs: [ arm64 ]\n"
                                          "platform: ios\n"
                                          "install-name: Test.dylib\n"
@@ -384,7 +384,7 @@ TEST(TBDv3, Swift_4_0) {
                                          "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_swift_4_0, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v3_swift_4_0, "Test.tbd"));
   EXPECT_FALSE(!!Result);
   auto errorMessage = toString(Result.takeError());
   EXPECT_EQ("malformed file\nTest.tbd:5:20: error: invalid Swift ABI "
@@ -393,14 +393,14 @@ TEST(TBDv3, Swift_4_0) {
 }
 
 TEST(TBDv3, Swift_5) {
-  static const char tbd_v1_swift_5[] = "--- !tapi-tbd-v3\n"
+  static const char tbd_v3_swift_5[] = "--- !tapi-tbd-v3\n"
                                        "archs: [ arm64 ]\n"
                                        "platform: ios\n"
                                        "install-name: Test.dylib\n"
                                        "swift-abi-version: 5\n"
                                        "...\n";
 
-  auto Result = TextAPIReader::get(MemoryBufferRef(tbd_v1_swift_5, "Test.tbd"));
+  auto Result = TextAPIReader::get(MemoryBufferRef(tbd_v3_swift_5, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());
@@ -408,7 +408,7 @@ TEST(TBDv3, Swift_5) {
 }
 
 TEST(TBDv3, Swift_99) {
-  static const char tbd_v1_swift_99[] = "--- !tapi-tbd-v3\n"
+  static const char tbd_v3_swift_99[] = "--- !tapi-tbd-v3\n"
                                         "archs: [ arm64 ]\n"
                                         "platform: ios\n"
                                         "install-name: Test.dylib\n"
@@ -416,7 +416,7 @@ TEST(TBDv3, Swift_99) {
                                         "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_swift_99, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v3_swift_99, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());

--- a/llvm/unittests/TextAPI/TextStubV3Tests.cpp
+++ b/llvm/unittests/TextAPI/TextStubV3Tests.cpp
@@ -34,6 +34,11 @@ inline bool operator==(const ExportedSymbol &lhs, const ExportedSymbol &rhs) {
          std::tie(rhs.Kind, rhs.Name, rhs.WeakDefined, rhs.ThreadLocalValue);
 }
 
+inline std::string stripWhitespace(std::string s) {
+  s.erase(std::remove_if(s.begin(), s.end(), ::isspace), s.end());
+  return s;
+}
+
 static ExportedSymbol TBDv3Symbols[] = {
     {SymbolKind::GlobalSymbol, "$ld$hide$os9.0$_sym1", false, false},
     {SymbolKind::GlobalSymbol, "_sym1", false, false},
@@ -204,6 +209,13 @@ TEST(TBDv3, Platform_macOS) {
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());
   EXPECT_EQ(File->getPlatforms().size(), 1U);
   EXPECT_EQ(Platform, *File->getPlatforms().begin());
+
+  SmallString<4096> Buffer;
+  raw_svector_ostream OS(Buffer);
+  auto WriteResult = TextAPIWriter::writeToStream(OS, *File);
+  EXPECT_TRUE(!WriteResult);
+  EXPECT_EQ(stripWhitespace(tbd_v3_platform_macos),
+            stripWhitespace(Buffer.c_str()));
 }
 
 TEST(TBDv3, Platform_iOS) {
@@ -221,6 +233,13 @@ TEST(TBDv3, Platform_iOS) {
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());
   EXPECT_EQ(File->getPlatforms().size(), 1U);
   EXPECT_EQ(Platform, *File->getPlatforms().begin());
+
+  SmallString<4096> Buffer;
+  raw_svector_ostream OS(Buffer);
+  auto WriteResult = TextAPIWriter::writeToStream(OS, *File);
+  EXPECT_TRUE(!WriteResult);
+  EXPECT_EQ(stripWhitespace(tbd_v3_platform_ios),
+            stripWhitespace(Buffer.c_str()));
 }
 
 TEST(TBDv3, Platform_watchOS) {
@@ -238,6 +257,13 @@ TEST(TBDv3, Platform_watchOS) {
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());
   EXPECT_EQ(File->getPlatforms().size(), 1U);
   EXPECT_EQ(Platform, *File->getPlatforms().begin());
+
+  SmallString<4096> Buffer;
+  raw_svector_ostream OS(Buffer);
+  auto WriteResult = TextAPIWriter::writeToStream(OS, *File);
+  EXPECT_TRUE(!WriteResult);
+  EXPECT_EQ(stripWhitespace(tbd_v3_platform_watchos),
+            stripWhitespace(Buffer.c_str()));
 }
 
 TEST(TBDv3, Platform_tvOS) {
@@ -255,6 +281,13 @@ TEST(TBDv3, Platform_tvOS) {
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());
   EXPECT_EQ(File->getPlatforms().size(), 1U);
   EXPECT_EQ(Platform, *File->getPlatforms().begin());
+
+  SmallString<4096> Buffer;
+  raw_svector_ostream OS(Buffer);
+  auto WriteResult = TextAPIWriter::writeToStream(OS, *File);
+  EXPECT_TRUE(!WriteResult);
+  EXPECT_EQ(stripWhitespace(tbd_v3_platform_tvos),
+            stripWhitespace(Buffer.c_str()));
 }
 
 TEST(TBDv3, Platform_bridgeOS) {
@@ -272,6 +305,13 @@ TEST(TBDv3, Platform_bridgeOS) {
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());
   EXPECT_EQ(File->getPlatforms().size(), 1U);
   EXPECT_EQ(Platform, *File->getPlatforms().begin());
+
+  SmallString<4096> Buffer;
+  raw_svector_ostream OS(Buffer);
+  auto WriteResult = TextAPIWriter::writeToStream(OS, *File);
+  EXPECT_TRUE(!WriteResult);
+  EXPECT_EQ(stripWhitespace(tbd_v3_platform_bridgeos),
+            stripWhitespace(Buffer.c_str()));
 }
 
 TEST(TBDv3, Platform_macCatalyst) {
@@ -288,6 +328,16 @@ TEST(TBDv3, Platform_macCatalyst) {
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());
   EXPECT_EQ(Platform, *File->getPlatforms().begin());
+
+  // It's not currently possible to emit the iomac platform. Enable this once
+  // that's fixed.
+#if 0
+  SmallString<4096> Buffer;
+  raw_svector_ostream OS(Buffer);
+  auto WriteResult = TextAPIWriter::writeToStream(OS, *File);
+  EXPECT_TRUE(!WriteResult);
+  EXPECT_EQ(stripWhitespace(tbd_v3_platform_iosmac), stripWhitespace(Buffer.c_str()));
+#endif
 }
 
 TEST(TBDv3, Platform_zippered) {
@@ -309,6 +359,13 @@ TEST(TBDv3, Platform_zippered) {
   EXPECT_EQ(Platforms.size(), File->getPlatforms().size());
   for (auto Platform : File->getPlatforms())
 	    EXPECT_EQ(Platforms.count(Platform), 1U);
+
+  SmallString<4096> Buffer;
+  raw_svector_ostream OS(Buffer);
+  auto WriteResult = TextAPIWriter::writeToStream(OS, *File);
+  EXPECT_TRUE(!WriteResult);
+  EXPECT_EQ(stripWhitespace(tbd_v3_platform_zip),
+            stripWhitespace(Buffer.c_str()));
 }
 
 TEST(TBDv3, Swift_1_0) {
@@ -325,6 +382,12 @@ TEST(TBDv3, Swift_1_0) {
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());
   EXPECT_EQ(1U, File->getSwiftABIVersion());
+
+  SmallString<4096> Buffer;
+  raw_svector_ostream OS(Buffer);
+  auto WriteResult = TextAPIWriter::writeToStream(OS, *File);
+  EXPECT_TRUE(!WriteResult);
+  EXPECT_EQ(stripWhitespace(tbd_v3_swift_1_0), stripWhitespace(Buffer.c_str()));
 }
 
 TEST(TBDv3, Swift_1_1) {
@@ -341,6 +404,12 @@ TEST(TBDv3, Swift_1_1) {
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());
   EXPECT_EQ(2U, File->getSwiftABIVersion());
+
+  SmallString<4096> Buffer;
+  raw_svector_ostream OS(Buffer);
+  auto WriteResult = TextAPIWriter::writeToStream(OS, *File);
+  EXPECT_TRUE(!WriteResult);
+  EXPECT_EQ(stripWhitespace(tbd_v3_swift_1_1), stripWhitespace(Buffer.c_str()));
 }
 
 TEST(TBDv3, Swift_2_0) {
@@ -357,6 +426,12 @@ TEST(TBDv3, Swift_2_0) {
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());
   EXPECT_EQ(3U, File->getSwiftABIVersion());
+
+  SmallString<4096> Buffer;
+  raw_svector_ostream OS(Buffer);
+  auto WriteResult = TextAPIWriter::writeToStream(OS, *File);
+  EXPECT_TRUE(!WriteResult);
+  EXPECT_EQ(stripWhitespace(tbd_v3_swift_2_0), stripWhitespace(Buffer.c_str()));
 }
 
 TEST(TBDv3, Swift_3_0) {
@@ -373,6 +448,12 @@ TEST(TBDv3, Swift_3_0) {
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());
   EXPECT_EQ(4U, File->getSwiftABIVersion());
+
+  SmallString<4096> Buffer;
+  raw_svector_ostream OS(Buffer);
+  auto WriteResult = TextAPIWriter::writeToStream(OS, *File);
+  EXPECT_TRUE(!WriteResult);
+  EXPECT_EQ(stripWhitespace(tbd_v3_swift_3_0), stripWhitespace(Buffer.c_str()));
 }
 
 TEST(TBDv3, Swift_4_0) {

--- a/llvm/unittests/TextAPI/TextStubV3Tests.cpp
+++ b/llvm/unittests/TextAPI/TextStubV3Tests.cpp
@@ -329,15 +329,11 @@ TEST(TBDv3, Platform_macCatalyst) {
   EXPECT_EQ(FileType::TBD_V3, File->getFileType());
   EXPECT_EQ(Platform, *File->getPlatforms().begin());
 
-  // It's not currently possible to emit the iomac platform. Enable this once
-  // that's fixed.
-#if 0
   SmallString<4096> Buffer;
   raw_svector_ostream OS(Buffer);
   auto WriteResult = TextAPIWriter::writeToStream(OS, *File);
   EXPECT_TRUE(!WriteResult);
   EXPECT_EQ(stripWhitespace(tbd_v3_platform_iosmac), stripWhitespace(Buffer.c_str()));
-#endif
 }
 
 TEST(TBDv3, Platform_zippered) {

--- a/llvm/unittests/TextAPI/TextStubV4Tests.cpp
+++ b/llvm/unittests/TextAPI/TextStubV4Tests.cpp
@@ -434,14 +434,14 @@ TEST(TBDv4, Swift_1) {
 }
 
 TEST(TBDv4, Swift_2) {
-  static const char tbd_v1_swift_2[] = "--- !tapi-tbd\n"
+  static const char tbd_v4_swift_2[] = "--- !tapi-tbd\n"
                                        "tbd-version: 4\n"
                                        "targets: [  x86_64-macos ]\n"
                                        "install-name: Test.dylib\n"
                                        "swift-abi-version: 2\n"
                                        "...\n";
 
-  auto Result = TextAPIReader::get(MemoryBufferRef(tbd_v1_swift_2, "Test.tbd"));
+  auto Result = TextAPIReader::get(MemoryBufferRef(tbd_v4_swift_2, "Test.tbd"));
   EXPECT_TRUE(!!Result);
   auto File = std::move(Result.get());
   EXPECT_EQ(FileType::TBD_V4, File->getFileType());
@@ -545,7 +545,7 @@ TEST(TBDv4, MalformedFile2) {
 }
 
 TEST(TBDv4, MalformedFile3) {
-  static const char tbd_v1_swift_1_1[] = "--- !tapi-tbd\n"
+  static const char tbd_v4_swift_1_1[] = "--- !tapi-tbd\n"
                                          "tbd-version: 4\n"
                                          "targets: [  x86_64-macos ]\n"
                                          "install-name: Test.dylib\n"
@@ -553,7 +553,7 @@ TEST(TBDv4, MalformedFile3) {
                                          "...\n";
 
   auto Result =
-      TextAPIReader::get(MemoryBufferRef(tbd_v1_swift_1_1, "Test.tbd"));
+      TextAPIReader::get(MemoryBufferRef(tbd_v4_swift_1_1, "Test.tbd"));
   EXPECT_FALSE(!!Result);
   auto errorMessage = toString(Result.takeError());
   EXPECT_EQ("malformed file\nTest.tbd:5:20: error: invalid Swift ABI "


### PR DESCRIPTION
TAPI currently lacks a way to emit the macCatalyst platform. For TBD_V3
is does support zippered frameworks given that both macOS and
macCatalyst are part of the PlatformSet.

Differential revision: https://reviews.llvm.org/D73325

(cherry picked from commit 3ed88b052b198285d4464166b728ec2e236f814e)