### PR TITLE
[cherry-pick][libc++] Make sure std::is_scalar returns true for block types

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -463,6 +463,10 @@ typedef __char32_t char32_t;
 #define _LIBCPP_HAS_OBJC_ARC_WEAK
 #endif
 
+#if __has_extension(blocks)
+#  define _LIBCPP_HAS_EXTENSION_BLOCKS
+#endif
+
 #if !(__has_feature(cxx_relaxed_constexpr))
 #define _LIBCPP_HAS_NO_CXX14_CONSTEXPR
 #endif

--- a/libcxx/include/type_traits
+++ b/libcxx/include/type_traits
@@ -1016,11 +1016,17 @@ _LIBCPP_INLINE_VAR _LIBCPP_CONSTEXPR bool is_fundamental_v
 
 // is_scalar
 
+template <class _Tp> struct __is_block : false_type {};
+#if defined(_LIBCPP_HAS_EXTENSION_BLOCKS)
+template <class _Rp, class ..._Args> struct __is_block<_Rp (^)(_Args...)> : true_type {};
+#endif
+
 template <class _Tp> struct _LIBCPP_TEMPLATE_VIS is_scalar
     : public integral_constant<bool, is_arithmetic<_Tp>::value     ||
                                      is_member_pointer<_Tp>::value ||
                                      is_pointer<_Tp>::value        ||
                                      __is_nullptr_t<_Tp>::value    ||
+                                     __is_block<_Tp>::value        ||
                                      is_enum<_Tp>::value           > {};
 
 template <> struct _LIBCPP_TEMPLATE_VIS is_scalar<nullptr_t> : public true_type {};

--- a/libcxx/test/libcxx/type_traits/is_scalar.objc.pass.mm
+++ b/libcxx/test/libcxx/type_traits/is_scalar.objc.pass.mm
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// UNSUPPORTED: c++98, c++03
+
+// <type_traits>
+
+// std::is_scalar
+
+// Make sure we report that blocks are scalar types.
+
+#include <type_traits>
+#include <optional>
+
+struct Foo { };
+template <int> struct Arg { };
+
+static_assert(std::is_scalar<void (^)(void)>::value, "");
+static_assert(std::is_scalar<void (^)()>::value, "");
+static_assert(std::is_scalar<void (^)(Arg<0>)>::value, "");
+static_assert(std::is_scalar<void (^)(Arg<0>, Arg<1>)>::value, "");
+static_assert(std::is_scalar<void (^)(Arg<0>, Arg<1>, Arg<2>)>::value, "");
+static_assert(std::is_scalar<Foo (^)(void)>::value, "");
+static_assert(std::is_scalar<Foo (^)()>::value, "");
+static_assert(std::is_scalar<Foo (^)(Arg<0>)>::value, "");
+static_assert(std::is_scalar<Foo (^)(Arg<0>, Arg<1>)>::value, "");
+static_assert(std::is_scalar<Foo (^)(Arg<0>, Arg<1>, Arg<2>)>::value, "");
+
+
+int main(int, char**) {
+    std::optional<Foo (^)(Arg<0>)> opt; (void)opt;
+    return 0;
+}

--- a/libcxx/test/libcxx/utilities/optional/block.objc.pass.mm
+++ b/libcxx/test/libcxx/utilities/optional/block.objc.pass.mm
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03, c++11, c++14
+
+// <optional>
+
+// This test makes sure that we can create a `std::optional` containing
+// an Objective-C++ block.
+
+#include <optional>
+#include <cassert>
+
+int main(int, char**)
+{
+    using Block = void (^)(void);
+    std::optional<Block> block;
+    assert(!block);
+
+    return 0;
+}


### PR DESCRIPTION
This is a cherry-pick of the following commit on `master`:

> commit 8ae404a2f6ba553368498870c2b3e39484a6312d
> Author: Louis Dionne <ldionne@apple.com>
> Date:   Tue Jan 21 12:39:43 2020 -0800
> 
>     [libc++] Make sure std::is_scalar returns true for block types
> 
>     Summary:
>     The compiler already treats them as scalar types, so the library should
>     too. Furthermore, this allows blocks to be used in more places, for
>     example in std::optional, which requires an object type.
> 
>     rdar://problem/57892832
> 
>     Reviewers: dexonsmith, EricWF, mclow.lists
>     Differential Revision: https://reviews.llvm.org/D72708
