### PR TITLE
Fix an assertion failure in DwarfExpression's subregister composition  …

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.h
@@ -107,8 +107,21 @@ protected:
   /// Holds information about all subregisters comprising a register location.
   struct Register {
     int DwarfRegNo;
-    unsigned Size;
+    unsigned SubRegSize;
     const char *Comment;
+
+    /// Create a full register, no extra DW_OP_piece operators necessary.
+    static Register createRegister(int RegNo, const char *Comment) {
+      return {RegNo, 0, Comment};
+    }
+
+    /// Create a subregister that needs a DW_OP_piece operator with SizeInBits.
+    static Register createSubRegister(int RegNo, unsigned SizeInBits,
+                                      const char *Comment) {
+      return {RegNo, SizeInBits, Comment};
+    }
+
+    bool isSubRegister() const { return SubRegSize; }
   };
 
   /// Whether we are currently emitting an entry value operation.

--- a/llvm/test/DebugInfo/MIR/ARM/subregister-full-piece.mir
+++ b/llvm/test/DebugInfo/MIR/ARM/subregister-full-piece.mir
@@ -1,0 +1,47 @@
+# RUN: llc -start-after=livedebugvalues -filetype=obj -o - %s | \
+# RUN:    llvm-dwarfdump - | FileCheck %s
+#
+# This tests the edge-case where a complex fragment has exactly
+# the size of a subregister of the register the DBG_VALUE points to.
+#
+# CHECK: .debug_info contents:
+# CHECK: DW_TAG_variable
+# CHECK-NOT: DW_TAG
+# CHECK:   DW_AT_location
+#                                    Q8 = {D16, D17}
+# CHECK-NEXT:                   DW_OP_regx D16, DW_OP_piece 0x8)
+# CHECK-NOT: DW_TAG
+# CHECK:   DW_AT_name	("q8")
+# CHECK: DW_TAG_variable
+# CHECK-NOT: DW_TAG
+# CHECK:   DW_AT_location
+#                                     Q9 = {D18, D19}
+# CHECK-NEXT:                    DW_OP_regx D18, DW_OP_piece 0x7)
+# CHECK-NOT: DW_TAG
+# CHECK:   DW_AT_name	("q9")
+
+--- |
+  target triple = "thumbv7s-apple-ios"
+  define hidden void @f() !dbg !5 {
+  for.body:
+  ret void, !dbg !20
+  }
+  !llvm.module.flags = !{!1, !2}
+  !llvm.dbg.cu = !{!3}
+  !1 = !{i32 7, !"Dwarf Version", i32 4}
+  !2 = !{i32 2, !"Debug Info Version", i32 3}
+  !3 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !4, isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug)
+  !4 = !DIFile(filename: "t.cpp", directory: "/")
+  !5 = distinct !DISubprogram(name: "f",scope: !4, file: !4, line: 1, type: !6, scopeLine: 1, unit: !3)
+  !6 = !DISubroutineType(types: !{})
+  !7 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "uint8x8x2_t", file: !4, line: 113, size: 128, flags: DIFlagTypePassByValue, elements: !{})
+  !8 = !DILocalVariable(name: "q8", scope: !5, file: !4, line: 1, type: !7)
+  !9 = !DILocalVariable(name: "q9", scope: !5, file: !4, line: 1, type: !7)
+  !20 = !DILocation(line: 0, scope: !5)
+name:            f
+body:             |
+  bb.2.for.body:
+    t2Bcc %bb.2.for.body, 0, killed $cpsr, debug-location !20
+    DBG_VALUE $q8, $noreg, !8, !DIExpression(DW_OP_LLVM_fragment, 0, 64), debug-location !20
+    DBG_VALUE $q9, $noreg, !9, !DIExpression(DW_OP_LLVM_fragment, 0, 56), debug-location !20
+    tB %bb.2.for.body, 14, $noreg


### PR DESCRIPTION
This patch fixes an assertion failure in DwarfExpression that is
triggered when a complex fragment has exactly the size of a
subregister of the register the DBG_VALUE points to *and* there is no
DWARF encoding for the super-register.

I took the opportunity to replace/document some magic values with
static constructor functions to make this code less confusing to read.

rdar://problem/58489125

Differential Revision: https://reviews.llvm.org/D72938

(cherry picked from commit a095d149c2c82f9f13bd2ec5597a9e3f257b14c6)