### PR TITLE
[lldb/Commands] Make column available through _regexp-break

### DIFF
--- a/lldb/lit/Settings/command-breakpoint-col.test
+++ b/lldb/lit/Settings/command-breakpoint-col.test
@@ -1,7 +1,10 @@
 # UNSUPPORTED: system-windows
 #
 # RUN: %clang_host -g -O0 %S/Inputs/main.c -o %t.out
-# RUN: %lldb -b -o 'help breakpoint set' -o 'breakpoint set -f main.c -l 2 -u 21' %t.out | FileCheck %s
-# CHECK: -u <column> ( --column <column> )
-# CHECK: Specifies the column number on which to set this breakpoint.
+# RUN: %lldb -b -o 'help breakpoint set' -o 'breakpoint set -f main.c -l 2 -u 21' %t.out | FileCheck %s --check-prefix HELP --check-prefix CHECK
+# RUN: %lldb -b -o 'help _regexp-break' -o 'b main.c:2:21' %t.out | FileCheck %s --check-prefix HELP-REGEX --check-prefix CHECK
+# HELP: -u <column> ( --column <column> )
+# HELP: Specifies the column number on which to set this breakpoint.
+# HELP-REGEX: _regexp-break <filename>:<linenum>:<colnum>
+# HELP-REGEX: main.c:12:21{{.*}}Break at line 12 and column 21 of main.c
 # CHECK: at main.c:2:21

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -486,7 +486,10 @@ void CommandInterpreter::LoadCommandDictionary() {
   m_command_dict["language"] =
       CommandObjectSP(new CommandObjectLanguage(*this));
 
+  // clang-format off
   const char *break_regexes[][2] = {
+      {"^(.*[^[:space:]])[[:space:]]*:[[:space:]]*([[:digit:]]+)[[:space:]]*:[[:space:]]*([[:digit:]]+)[[:space:]]*$",
+       "breakpoint set --file '%1' --line %2 --column %3"},
       {"^(.*[^[:space:]])[[:space:]]*:[[:space:]]*([[:digit:]]+)[[:space:]]*$",
        "breakpoint set --file '%1' --line %2"},
       {"^/([^/]+)/$", "breakpoint set --source-pattern-regexp '%1'"},
@@ -501,6 +504,7 @@ void CommandInterpreter::LoadCommandDictionary() {
        "breakpoint set --name '%1' --skip-prologue=0"},
       {"^[\"']?(.*[^[:space:]\"'])[\"']?[[:space:]]*$",
        "breakpoint set --name '%1'"}};
+  // clang-format on
 
   size_t num_regexes = llvm::array_lengthof(break_regexes);
 
@@ -509,6 +513,9 @@ void CommandInterpreter::LoadCommandDictionary() {
           *this, "_regexp-break",
           "Set a breakpoint using one of several shorthand formats.",
           "\n"
+          "_regexp-break <filename>:<linenum>:<colnum>\n"
+          "              main.c:12:21          // Break at line 12 and column "
+          "21 of main.c\n\n"
           "_regexp-break <filename>:<linenum>\n"
           "              main.c:12             // Break at line 12 of "
           "main.c\n\n"
@@ -532,7 +539,7 @@ void CommandInterpreter::LoadCommandDictionary() {
           "current file\n"
           "                                    // containing text 'break "
           "here'.\n",
-          2,
+          3,
           CommandCompletions::eSymbolCompletion |
               CommandCompletions::eSourceFileCompletion,
           false));
@@ -559,6 +566,9 @@ void CommandInterpreter::LoadCommandDictionary() {
           *this, "_regexp-tbreak",
           "Set a one-shot breakpoint using one of several shorthand formats.",
           "\n"
+          "_regexp-break <filename>:<linenum>:<colnum>\n"
+          "              main.c:12:21          // Break at line 12 and column "
+          "21 of main.c\n\n"
           "_regexp-break <filename>:<linenum>\n"
           "              main.c:12             // Break at line 12 of "
           "main.c\n\n"


### PR DESCRIPTION
Update _regexp-break to interpret main.c:8:21 as:

  breakpoint set --line 8 --column 21

Differential revision: https://reviews.llvm.org/D73314

(cherry picked from commit 223a209027b44daeac53508bea154bc29314bddb)