### PR TITLE
[Modules][ODRHash] Trigger ODR hashes for methods in a safe way

### DIFF
--- a/clang/lib/AST/ODRHash.cpp
+++ b/clang/lib/AST/ODRHash.cpp
@@ -474,6 +474,10 @@ void ODRHash::AddSubDecl(const Decl *D) {
 void ODRHash::AddObjCInterfaceDecl(const ObjCInterfaceDecl *IF) {
   AddDecl(IF);
 
+  // Trigger ODR computation for methods (if not yet computed)
+  for (auto *M : IF->methods())
+    reinterpret_cast<ObjCMethodDecl *>(M)->getODRHash();
+
   auto *SuperClass = IF->getSuperClass();
   AddBoolean(SuperClass);
   if (SuperClass)

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -1163,10 +1163,6 @@ void ASTDeclReader::MergeDefinitionData(ObjCInterfaceDecl *D,
       NewDD.CategoryList)
     return;
 
-  // Trigger computation for methods (if they aren't yet computed)
-  for (auto *M : D->methods())
-    M->getODRHash();
-
   if (D->getODRHash() != NewDD.ODRHash)
     DetectedOdrViolation = true;
 

--- a/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -757,9 +757,6 @@ void ASTDeclWriter::VisitObjCInterfaceDecl(ObjCInterfaceDecl *D) {
     Record.AddSourceLocation(D->getEndOfDefinitionLoc());
     Record.push_back(Data.HasDesignatedInitializers);
 
-    // Trigger ODR hashing computation for methods.
-    for (auto *M : D->methods())
-      M->getODRHash();
     Record.push_back(D->getODRHash());
 
     // Write out the protocols that are directly referenced by the @interface.

--- a/clang/test/Modules/odr_hash.m
+++ b/clang/test/Modules/odr_hash.m
@@ -265,6 +265,22 @@ M3 *m3;
 #endif
 
 #if defined(FIRST)
+@interface SuperM4
+- (void)sayHello;
+@end
+@interface M4 : SuperM4
+@end
+#elif defined(SECOND)
+@interface SuperM4
+- (void)sayHello;
+@end
+@interface M4 : SuperM4
+@end
+#else
+M4 *m4;
+#endif
+
+#if defined(FIRST)
 @interface MP1
 - (void)compute:(int)arg;
 @end


### PR DESCRIPTION
Instead of patching the clients to trigger it, make it an implementation
detail and let the ObjCInterfaceDecl hashing logic trigger it instead.

This was leading to crashes in LLDB.

rdar://problem/58928623