### PR TITLE
[Symbolize] Handle error after the notes loop

### DIFF
--- a/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
+++ b/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
@@ -300,6 +300,7 @@ Optional<ArrayRef<uint8_t>> getBuildID(const ELFFile<ELFT> *Obj) {
     for (auto N : Obj->notes(P, Err))
       if (N.getType() == ELF::NT_GNU_BUILD_ID && N.getName() == ELF::ELF_NOTE_GNU)
         return N.getDesc();
+    consumeError(std::move(Err));
   }
   return {};
 }

--- a/llvm/test/DebugInfo/symbolize-build-id-error.test
+++ b/llvm/test/DebugInfo/symbolize-build-id-error.test
@@ -1,0 +1,23 @@
+# RUN: yaml2obj %s -o %t
+
+# RUN: llvm-symbolizer --debug-file-directory=%p/Inputs --obj=%t 0x20112f | FileCheck %s
+
+# CHECK:      ??
+# CHECK-NEXT: ??:0:0
+
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_EXEC
+  Machine: EM_X86_64
+Sections:
+  - Name:    .note.invalid
+    Type:    SHT_NOTE
+    Flags:   [ SHF_ALLOC ]
+    Content: 0123456789
+ProgramHeaders:
+  - Type: PT_NOTE
+    Flags: [ PF_R ]
+    Sections:
+      - Section: .note.invalid


### PR DESCRIPTION
We always have to check the error, even if we're going to ignore it.

(cherry picked from commit 369ea47b9249f1843730d8d0c0ca5df46826d032)