### PR TITLE
[lldb] Rewrite Swift REPL completion to use CompletionRequest

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lang/swift/completion/TestSwiftREPLCompletion.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/completion/TestSwiftREPLCompletion.py
@@ -1,22 +1,42 @@
-from __future__ import print_function
-import pexpect
-import os
+
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
-from lldbsuite.test import lldbutil
+from lldbsuite.test.lldbpexpect import PExpectTest
 
+class SwiftCompletionTest(PExpectTest):
 
-class TestSwiftREPLCompletion(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
+    # PExpect uses many timeouts internally and doesn't play well
+    # under ASAN on a loaded machine..
+    @skipIfAsan
     @skipUnlessDarwin
-    def test_repl_completion(self):
-        prompt = "Welcome to"
-        child = pexpect.spawn('%s --repl' % (lldbtest_config.lldbExec))
-        # Assign to make sure the sessions are killed during teardown
-        self.child = child
-        # Send a <TAB> and make sure we don't crash.
-        child.sendline("import Foundatio\t")
-        child.sendline("print(NSString(\"patatino\"))")
-        child.expect("patatino")
+    def test_basic_completion(self):
+
+        self.launch(extra_args=["--repl"], executable=None, dimensions=(100,500))
+
+        # Wait on the first prompt
+        self.child.expect_exact("1>")
+        # Press tab a few times which should do nothing.
+        # Note that we don't get any indentation whitespace as
+        # pexpect is not recognized as a interactive terminal by pexpect it seems.
+        self.child.send("\t\t\t")
+
+        # Try completing something that only has one result "Hasabl" -> "Hashable".
+        self.child.send("Hashabl\t")
+        self.child.expect_exact("Hashable")
+        self.child.sendline("")
+
+        # Try completing something that has multiple completions.
+        self.child.send("Hash\t")
+        self.child.expect_exact("Available completions:")
+        self.child.expect_exact("Hashable")
+        self.child.expect_exact("Hasher")
+        self.child.sendline("")
+
+    def setUpCommands(self):
+        return [] # REPL doesn't take any setup commands.
+
+    def expect_prompt(self):
+        pass # No constant prompt on the REPL.

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.h
@@ -68,8 +68,8 @@ protected:
                         lldb::ValueObjectSP &valobj_sp,
                         ExpressionVariable *var = nullptr) override;
 
-  int CompleteCode(const std::string &current_code,
-                   StringList &matches) override;
+  void CompleteCode(const std::string &current_code,
+                    CompletionRequest &request) override;
 
 public:
   static bool classof(const REPL *repl) {


### PR DESCRIPTION
This removes all the workaround and problematic code that was needed
for the old interface. With the CompletionRequest we no longer need
to calculate the common prefix ourselves and we don't need to calculate
the magic return value. On the other hand we can no longer provide
'appendix' completions (E.g. completing "Suff" with "ix", instead
we now need to provide the completion "Suffix"), so in one case
we now need to prefix the completion with the existing prefix from
the CompletionRequest (as Swift only returns the string to append
and not the whole token).

Also rewrites the TestSwiftREPLCompletion.py to test all the
problematic cases and some more.