### PR TITLE
[Clang][cc1] Support -fno-implicit-module-maps in -cc1.

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1548,7 +1548,7 @@ def fno_merge_all_constants : Flag<["-"], "fno-merge-all-constants">, Group<f_Gr
 def fno_modules : Flag <["-"], "fno-modules">, Group<f_Group>,
   Flags<[DriverOption]>;
 def fno_implicit_module_maps : Flag <["-"], "fno-implicit-module-maps">, Group<f_Group>,
-  Flags<[DriverOption]>;
+  Flags<[DriverOption, CC1Option]>;
 def fno_module_maps : Flag <["-"], "fno-module-maps">, Alias<fno_implicit_module_maps>;
 def fno_modules_decluse : Flag <["-"], "fno-modules-decluse">, Group<f_Group>,
   Flags<[DriverOption]>;

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2231,7 +2231,8 @@ static void ParseHeaderSearchArgs(HeaderSearchOptions &Opts, ArgList &Args,
   Opts.ModulesStrictContextHash = Args.hasArg(OPT_fmodules_strict_context_hash);
   Opts.ModulesValidateDiagnosticOptions =
       !Args.hasArg(OPT_fmodules_disable_diagnostic_validation);
-  Opts.ImplicitModuleMaps = Args.hasArg(OPT_fimplicit_module_maps);
+  Opts.ImplicitModuleMaps = Args.hasFlag(OPT_fimplicit_module_maps,
+                                         OPT_fno_implicit_module_maps, false);
   Opts.ModuleMapFileHomeIsCwd = Args.hasArg(OPT_fmodule_map_file_home_is_cwd);
   Opts.ModuleCachePruneInterval =
       getLastArgIntValue(Args, OPT_fmodules_prune_interval, 7 * 24 * 60 * 60);

--- a/clang/test/Modules/no-implicit-maps.cpp
+++ b/clang/test/Modules/no-implicit-maps.cpp
@@ -1,3 +1,6 @@
 // RUN: rm -rf %t
 // RUN: %clang_cc1 -x objective-c -fmodules-cache-path=%t -fmodules -I %S/Inputs/private %s -verify
+// RUN: %clang_cc1 -x objective-c -fmodules-cache-path=%t -fmodules \
+// RUN:   -I %S/Inputs/private %s -verify -fimplicit-module-maps \
+// RUN:   -fno-implicit-module-maps
 @import libPrivate1;  // expected-error {{not found}}


### PR DESCRIPTION
Gives the last of -f{no-}implicit-module-maps precedence.

rdar://58883354