### PR TITLE
Include fixit hints in -diagnostic-log-file output

### DIFF
--- a/clang/include/clang/Frontend/LogDiagnosticPrinter.h
+++ b/clang/include/clang/Frontend/LogDiagnosticPrinter.h
@@ -19,6 +19,38 @@ class DiagnosticOptions;
 class LangOptions;
 
 class LogDiagnosticPrinter : public DiagnosticConsumer {
+  struct DiagEntryLocation {
+    /// The source file name, if available and if different from DiagEntry's
+    /// Filename.
+    std::string Filename;
+
+    /// The source file line number, if available.
+    unsigned Line;
+
+    /// The source file column number, if available.
+    unsigned Column;
+
+    /// The source file offset, if available.
+    unsigned Offset;
+  };
+
+  struct DiagEntryRange {
+    /// The range start.
+    LogDiagnosticPrinter::DiagEntryLocation Start;
+
+    /// The range end.
+    LogDiagnosticPrinter::DiagEntryLocation End;
+  };
+
+  struct DiagEntryFixIt {
+    /// The range of existing source file to act upon.
+    LogDiagnosticPrinter::DiagEntryRange RemoveRange;
+
+    /// The code to insert at the start of the range,
+    ///   after removal of the range; may be empty for pure removal.
+    std::string CodeToInsert;
+  };
+
   struct DiagEntry {
     /// The primary message line of the diagnostic.
     std::string Message;
@@ -40,7 +72,17 @@ class LogDiagnosticPrinter : public DiagnosticConsumer {
 
     /// The level of the diagnostic.
     DiagnosticsEngine::Level DiagnosticLevel;
+
+    /// The source ranges of the diagnostic.
+    SmallVector<LogDiagnosticPrinter::DiagEntryRange, 2> SourceRanges;
+
+    /// The fix-its for the diagnostic.
+    SmallVector<LogDiagnosticPrinter::DiagEntryFixIt, 2> FixIts;
   };
+
+  void
+  EmitDiagEntryLocation(llvm::raw_ostream &OS, StringRef Indent,
+                        const LogDiagnosticPrinter::DiagEntryLocation &Del);
 
   void EmitDiagEntry(llvm::raw_ostream &OS,
                      const LogDiagnosticPrinter::DiagEntry &DE);

--- a/clang/lib/Frontend/LogDiagnosticPrinter.cpp
+++ b/clang/lib/Frontend/LogDiagnosticPrinter.cpp
@@ -11,6 +11,7 @@
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/PlistSupport.h"
 #include "clang/Basic/SourceManager.h"
+#include "clang/Lex/Lexer.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
@@ -33,6 +34,27 @@ static StringRef getLevelName(DiagnosticsEngine::Level Level) {
   case DiagnosticsEngine::Fatal:   return "fatal error";
   }
   llvm_unreachable("Invalid DiagnosticsEngine level!");
+}
+
+void LogDiagnosticPrinter::EmitDiagEntryLocation(
+    llvm::raw_ostream &OS, StringRef Indent,
+    const LogDiagnosticPrinter::DiagEntryLocation &Del) {
+  OS << Indent << "<dict>\n";
+  if (!Del.Filename.empty()) {
+    OS << Indent << "  <key>filename</key>\n";
+    OS << Indent << "  ";
+    EmitString(OS, Del.Filename) << '\n';
+  }
+  OS << Indent << "  <key>line</key>\n";
+  OS << Indent << "  ";
+  EmitInteger(OS, Del.Line) << '\n';
+  OS << Indent << "  <key>column</key>\n";
+  OS << Indent << "  ";
+  EmitInteger(OS, Del.Column) << '\n';
+  OS << Indent << "  <key>offset</key>\n";
+  OS << Indent << "  ";
+  EmitInteger(OS, Del.Offset) << '\n';
+  OS << Indent << "</dict>\n";
 }
 
 void
@@ -69,6 +91,41 @@ LogDiagnosticPrinter::EmitDiagEntry(llvm::raw_ostream &OS,
     OS << "      <key>WarningOption</key>\n"
        << "      ";
     EmitString(OS, DE.WarningOption) << '\n';
+  }
+  if (!DE.SourceRanges.empty()) {
+    OS << "      <key>source-ranges</key>\n"
+       << "      <array>\n";
+    for (auto R = DE.SourceRanges.begin(), E = DE.SourceRanges.end(); R != E;
+         ++R) {
+      OS << "        <dict>\n";
+      OS << "          <key>start-at</key>\n";
+      EmitDiagEntryLocation(OS, "          ", R->Start);
+      OS << "          <key>end-before</key>\n";
+      EmitDiagEntryLocation(OS, "          ", R->End);
+      OS << "        </dict>\n";
+    }
+    OS << "      </array>\n";
+  }
+  if (!DE.FixIts.empty()) {
+    OS << "      <key>fixits</key>\n"
+       << "      <array>\n";
+    for (auto F = DE.FixIts.begin(), E = DE.FixIts.end(); F != E; ++F) {
+      OS << "        <dict>\n";
+      OS << "          <key>start-at</key>\n";
+      EmitDiagEntryLocation(OS, "          ", F->RemoveRange.Start);
+      OS << "          <key>end-before</key>\n";
+      EmitDiagEntryLocation(OS, "          ", F->RemoveRange.End);
+      // Always issue a replacement key/value, even if CodeToInsert is empty.
+      OS << "          <key>replacement</key>\n"
+         << "          ";
+      if (F->CodeToInsert.empty()) {
+        OS << "<string/>\n";
+      } else {
+        EmitString(OS, F->CodeToInsert) << '\n';
+      }
+      OS << "        </dict>\n";
+    }
+    OS << "      </array>\n";
   }
   OS << "    </dict>\n";
 }
@@ -158,7 +215,72 @@ void LogDiagnosticPrinter::HandleDiagnostic(DiagnosticsEngine::Level Level,
     }
   }
 
+  auto InitDer = [](DiagEntryRange &Der, const CharSourceRange &R,
+                    const DiagEntry &DE, const Diagnostic &Info,
+                    const LangOptions *LangOpts) -> bool {
+    if (!R.isValid() || !Info.hasSourceManager())
+      return false;
+
+    SourceManager &SM = Info.getSourceManager();
+    FullSourceLoc StartLoc = FullSourceLoc(R.getBegin(), SM);
+    FullSourceLoc EndLoc = FullSourceLoc(R.getEnd(), SM);
+    if (StartLoc.isInvalid() || EndLoc.isInvalid())
+      return false;
+
+    PresumedLoc StartPLoc =
+        StartLoc.hasManager() ? StartLoc.getPresumedLoc() : PresumedLoc();
+    StringRef StartFilename = StartPLoc.getFilename();
+    if (!DE.Filename.empty() && DE.Filename == StartFilename)
+      StartFilename = "";
+
+    PresumedLoc EndPLoc =
+        EndLoc.hasManager() ? EndLoc.getPresumedLoc() : PresumedLoc();
+    StringRef EndFilename = EndPLoc.getFilename();
+    if (!DE.Filename.empty() && DE.Filename == EndFilename)
+      EndFilename = "";
+
+    unsigned TokSize = 0;
+    if (R.isTokenRange())
+      TokSize = Lexer::MeasureTokenLength(R.getEnd(), SM, *LangOpts);
+    Der = {{StartFilename, StartPLoc.getLine(), StartPLoc.getColumn(),
+            StartLoc.getFileOffset()},
+           {EndFilename, EndPLoc.getLine(), EndPLoc.getColumn() + TokSize,
+            EndLoc.getFileOffset() + TokSize}};
+    return true;
+  };
+
+  ArrayRef<CharSourceRange> ranges = Info.getRanges();
+  for (ArrayRef<CharSourceRange>::iterator R = ranges.begin(),
+       E = ranges.end(); R != E; ++R) {
+    DiagEntryRange Der;
+    bool Success = InitDer(Der, *R, DE, Info, LangOpts);
+    if (Success)
+      DE.SourceRanges.push_back(Der);
+  }
+
+  ArrayRef<FixItHint> fixits = Info.getFixItHints();
+  for (ArrayRef<FixItHint>::iterator F = fixits.begin(), E = fixits.end();
+       F != E; ++F) {
+    // We follow FixItRewriter's example in not (yet) handling
+    // fix-its in macros.
+    if (F->RemoveRange.getBegin().isMacroID() ||
+        F->RemoveRange.getEnd().isMacroID()) {
+      // If any bad FixItHint, skip all of them; the rest
+      // might not make sense independent of the skipped ones.
+      DE.FixIts.clear();
+      break;
+    }
+    if (F->isNull())
+      continue;
+
+    DiagEntryFixIt FI;
+    bool Success = InitDer(FI.RemoveRange, F->RemoveRange, DE, Info, LangOpts);
+    if (Success) {
+      FI.CodeToInsert = F->CodeToInsert;
+      DE.FixIts.push_back(FI);
+    }
+  }
+
   // Record the diagnostic entry.
   Entries.push_back(DE);
 }
-

--- a/clang/test/Misc/logfile-diags-fixits.c
+++ b/clang/test/Misc/logfile-diags-fixits.c
@@ -1,0 +1,95 @@
+// RUN: %clang_cc1 -Wall -fsyntax-only %s -diagnostic-log-file %t.diag
+// RUN: FileCheck --input-file=%t.diag %s
+// RUN: rm -f %t
+
+void foo() {
+  int voodoo;
+  voodoo = voodoo + 1;
+}
+
+// CHECK: <dict>
+// CHECK:   <key>main-file</key>
+// CHECK:   <string>{{.*}}logfile-diags-fixits.c</string>
+// CHECK:   <key>diagnostics</key>
+// CHECK:   <array>
+// CHECK:     <dict>
+// CHECK:       <key>level</key>
+// CHECK:       <string>warning</string>
+// CHECK:       <key>filename</key>
+// CHECK:       <string>{{.*}}logfile-diags-fixits.c</string>
+// CHECK:       <key>line</key>
+// CHECK:       <integer>7</integer>
+// CHECK:       <key>column</key>
+// CHECK:       <integer>12</integer>
+// CHECK:       <key>message</key>
+// CHECK:       <string>variable &apos;voodoo&apos; is uninitialized when used here</string>
+// CHECK:       <key>ID</key>
+// CHECK:       <integer>{{.*}}</integer>
+// CHECK:       <key>WarningOption</key>
+// CHECK:       <string>uninitialized</string>
+// CHECK:       <key>source-ranges</key>
+// CHECK:       <array>
+// CHECK:         <dict>
+// CHECK:           <key>start-at</key>
+// CHECK:           <dict>
+// CHECK:             <key>line</key>
+// CHECK:             <integer>7</integer>
+// CHECK:             <key>column</key>
+// CHECK:             <integer>12</integer>
+// CHECK:             <key>offset</key>
+// CHECK:             <integer>169</integer>
+// CHECK:           </dict>
+// CHECK:           <key>end-before</key>
+// CHECK:           <dict>
+// CHECK:             <key>line</key>
+// CHECK:             <integer>7</integer>
+// CHECK:             <key>column</key>
+// CHECK:             <integer>18</integer>
+// CHECK:             <key>offset</key>
+// CHECK:             <integer>175</integer>
+// CHECK:           </dict>
+// CHECK:         </dict>
+// CHECK:       </array>
+// CHECK:     </dict>
+// CHECK:     <dict>
+// CHECK:       <key>level</key>
+// CHECK:       <string>note</string>
+// CHECK:       <key>filename</key>
+// CHECK:       <string>{{.*}}logfile-diags-fixits.c</string>
+// CHECK:       <key>line</key>
+// CHECK:       <integer>6</integer>
+// CHECK:       <key>column</key>
+// CHECK:       <integer>13</integer>
+// CHECK:       <key>message</key>
+// CHECK:       <string>initialize the variable &apos;voodoo&apos; to silence this warning</string>
+// CHECK:       <key>ID</key>
+// CHECK:       <integer>{{.*}}</integer>
+// CHECK:       <key>fixits</key>
+// CHECK:       <array>
+// CHECK:         <dict>
+// CHECK:           <key>start-at</key>
+// CHECK:           <dict>
+// CHECK:             <key>line</key>
+// CHECK:             <integer>6</integer>
+// CHECK:             <key>column</key>
+// CHECK:             <integer>13</integer>
+// CHECK:             <key>offset</key>
+// CHECK:             <integer>156</integer>
+// CHECK:           </dict>
+// CHECK:           <key>end-before</key>
+// CHECK:           <dict>
+// CHECK:             <key>line</key>
+// CHECK:             <integer>6</integer>
+// CHECK:             <key>column</key>
+// CHECK:             <integer>13</integer>
+// CHECK:             <key>offset</key>
+// CHECK:             <integer>156</integer>
+// CHECK:           </dict>
+// CHECK:           <key>replacement</key>
+// CHECK:           <string> = 0</string>
+// CHECK:         </dict>
+// CHECK:       </array>
+// CHECK:     </dict>
+// CHECK:   </array>
+// CHECK: </dict>
+


### PR DESCRIPTION
When you use the -diagnostic-log-file option, the resulting plist file
does not contain the FixItHints associated with each diagnostic.  The
serialized diagnostic file format does save the FixItHints. The plist
diagnostics file should too.

rdar://problem/57327549
(cherry picked from commit 12fd2bff9ba127e637938c559a8b9c2f8c1d5cd7)