### PR TITLE
[SwiftExpressionObjCContext] Register shlibs for on-device testing.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
@@ -36,6 +36,9 @@ class TestSwiftExpressionObjCContext(TestBase):
         target = self.dbg.CreateTarget(exe)
         self.assertTrue(target, VALID_TARGET)
 
+        # Register shlib so it can run on-device.
+        self.registerSharedLibrariesWithTarget(target, ['Foo'])
+
         # Set the breakpoints
         foo_breakpoint = target.BreakpointCreateBySourceRegex(
             'break here', lldb.SBFileSpec('main.m'))


### PR DESCRIPTION
Fixes the last failure on arm64!