### PR TITLE
Explicit llvm::StringRef -> std::string

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -219,7 +219,7 @@ public:
   }
 
   void SetPlatformSDKPath(llvm::StringRef path) {
-    m_platform_sdk_path = path;
+    m_platform_sdk_path = std::string(path);
   }
 
   const swift::SearchPathOptions *GetSearchPathOptions() const;
@@ -310,7 +310,7 @@ public:
   swift::irgen::IRGenModule &GetIRGenModule();
 
   lldb::TargetWP GetTarget() const { return m_target_wp; }
-  
+
   llvm::Triple GetTriple() const;
 
   bool SetTriple(const llvm::Triple triple,
@@ -408,7 +408,7 @@ public:
                                 lldb::LanguageType *language_ptr,
                                 bool *is_instance_method_ptr,
                                 ConstString *language_object_name_ptr) override;
-                                
+
   bool DeclContextIsContainedInLookup(void *opaque_decl_ctx,
                                       void *other_opaque_decl_ctx) override {
     if (opaque_decl_ctx == other_opaque_decl_ctx)

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -119,7 +119,7 @@ bool SwiftExpressionSourceCode::GetText(
                                         os_vers.str(),
                                         first_body_line);
 
-    text = wrap_stream.GetString();
+    text = std::string(wrap_stream.GetString());
   } else {
     text.append(m_body);
   }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
@@ -136,7 +136,7 @@ void SwiftPersistentExpressionState::SwiftDeclMap::AddDecl(
   std::string name_str;
 
   if (alias.IsEmpty()) {
-    name_str = (value_decl->getBaseName().getIdentifier().str());
+    name_str = std::string((value_decl->getBaseName().getIdentifier().str()));
   } else {
     name_str.assign(alias.GetCString());
   }

--- a/lldb/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.cpp
+++ b/lldb/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.cpp
@@ -27,7 +27,7 @@ std::string ObjCRuntimeSyntheticProvider::GetDescription() {
               SkipsReferences() ? " (skip references)" : "",
               m_descriptor_sp->GetClassName().AsCString("<unknown>"));
 
-  return sstr.GetString();
+  return std::string(sstr.GetString());
 }
 
 size_t ObjCRuntimeSyntheticProvider::FrontEnd::GetNumBases() {


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/777180a32b61070a10dd330b4f038bf24e916af1 got rid of implicit casting for llvm::StringRef; it's an expensive operation. This change attempts to respect this upcoming work by dumbly migrating StringRef -> std::string sites (as exposed by my local build).