### PR TITLE
[AArch64] Provide Darwin variants of most calling conventions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64CallingConvention.td
+++ b/llvm/lib/Target/AArch64/AArch64CallingConvention.td
@@ -377,12 +377,6 @@ def CSR_AArch64_AAPCS : CalleeSavedRegs<(add X19, X20, X21, X22, X23, X24,
                                            D8,  D9,  D10, D11,
                                            D12, D13, D14, D15)>;
 
-// Darwin puts the frame-record at the top of the callee-save area.
-def CSR_Darwin_AArch64_AAPCS : CalleeSavedRegs<(add LR, FP, X19, X20, X21, X22,
-                                           X23, X24, X25, X26, X27, X28,
-                                           D8,  D9,  D10, D11,
-                                           D12, D13, D14, D15)>;
-
 // Win64 has unwinding codes for an (FP,LR) pair, save_fplr and save_fplr_x.
 // We put FP before LR, so that frame lowering logic generates (FP,LR) pairs,
 // and not (LR,FP) pairs.
@@ -421,6 +415,44 @@ def CSR_AArch64_SVE_AAPCS : CalleeSavedRegs<(add (sequence "Z%u", 8, 23),
 def CSR_AArch64_AAPCS_ThisReturn : CalleeSavedRegs<(add CSR_AArch64_AAPCS, X0)>;
 
 def CSR_AArch64_AAPCS_SwiftError
+    : CalleeSavedRegs<(sub CSR_AArch64_AAPCS, X21)>;
+
+// The ELF stub used for TLS-descriptor access saves every feasible
+// register. Only X0 and LR are clobbered.
+def CSR_AArch64_TLS_ELF
+    : CalleeSavedRegs<(add (sequence "X%u", 1, 28), FP,
+                           (sequence "Q%u", 0, 31))>;
+
+def CSR_AArch64_AllRegs
+    : CalleeSavedRegs<(add (sequence "W%u", 0, 30), WSP,
+                           (sequence "X%u", 0, 28), FP, LR, SP,
+                           (sequence "B%u", 0, 31), (sequence "H%u", 0, 31),
+                           (sequence "S%u", 0, 31), (sequence "D%u", 0, 31),
+                           (sequence "Q%u", 0, 31))>;
+
+def CSR_AArch64_NoRegs : CalleeSavedRegs<(add)>;
+
+def CSR_AArch64_RT_MostRegs :  CalleeSavedRegs<(add CSR_AArch64_AAPCS,
+                                                (sequence "X%u", 9, 15))>;
+def CSR_AArch64_StackProbe_Windows
+    : CalleeSavedRegs<(add (sequence "X%u", 0, 15),
+                           (sequence "X%u", 18, 28), FP, SP,
+                           (sequence "Q%u", 0, 31))>;
+
+// Darwin variants of AAPCS.
+// Darwin puts the frame-record at the top of the callee-save area.
+def CSR_Darwin_AArch64_AAPCS : CalleeSavedRegs<(add LR, FP, X19, X20, X21, X22,
+                                                X23, X24, X25, X26, X27, X28,
+                                                D8,  D9,  D10, D11,
+                                                D12, D13, D14, D15)>;
+
+def CSR_Darwin_AArch64_AAVPCS : CalleeSavedRegs<(add LR, FP, X19, X20, X21,
+                                                 X22, X23, X24, X25, X26, X27,
+                                                 X28, (sequence "Q%u", 8, 23))>;
+def CSR_Darwin_AArch64_AAPCS_ThisReturn
+    : CalleeSavedRegs<(add CSR_Darwin_AArch64_AAPCS, X0)>;
+
+def CSR_Darwin_AArch64_AAPCS_SwiftError
     : CalleeSavedRegs<(sub CSR_Darwin_AArch64_AAPCS, X21)>;
 
 // The function used by Darwin to obtain the address of a thread-local variable
@@ -449,28 +481,8 @@ def CSR_AArch64_CXX_TLS_Darwin_PE
 def CSR_AArch64_CXX_TLS_Darwin_ViaCopy
     : CalleeSavedRegs<(sub CSR_AArch64_CXX_TLS_Darwin, LR, FP)>;
 
-// The ELF stub used for TLS-descriptor access saves every feasible
-// register. Only X0 and LR are clobbered.
-def CSR_AArch64_TLS_ELF
-    : CalleeSavedRegs<(add (sequence "X%u", 1, 28), FP,
-                           (sequence "Q%u", 0, 31))>;
-
-def CSR_AArch64_AllRegs
-    : CalleeSavedRegs<(add (sequence "W%u", 0, 30), WSP,
-                           (sequence "X%u", 0, 28), FP, LR, SP,
-                           (sequence "B%u", 0, 31), (sequence "H%u", 0, 31),
-                           (sequence "S%u", 0, 31), (sequence "D%u", 0, 31),
-                           (sequence "Q%u", 0, 31))>;
-
-def CSR_AArch64_NoRegs : CalleeSavedRegs<(add)>;
-
-def CSR_AArch64_RT_MostRegs :  CalleeSavedRegs<(add CSR_AArch64_AAPCS,
-                                                (sequence "X%u", 9, 15))>;
-
-def CSR_AArch64_StackProbe_Windows
-    : CalleeSavedRegs<(add (sequence "X%u", 0, 15),
-                           (sequence "X%u", 18, 28), FP, SP,
-                           (sequence "Q%u", 0, 31))>;
+def CSR_Darwin_AArch64_RT_MostRegs
+    : CalleeSavedRegs<(add CSR_Darwin_AArch64_AAPCS, (sequence "X%u", 9, 15))>;
 
 // Variants of the standard calling conventions for shadow call stack.
 // These all preserve x18 in addition to any other registers.
@@ -490,3 +502,7 @@ def CSR_AArch64_SVE_AAPCS_SCS
     : CalleeSavedRegs<(add CSR_AArch64_SVE_AAPCS, X18)>;
 def CSR_AArch64_AAPCS_SCS
     : CalleeSavedRegs<(add CSR_AArch64_AAPCS, X18)>;
+def CSR_Darwin_AArch64_AAPCS_SCS
+    : CalleeSavedRegs<(add CSR_Darwin_AArch64_AAPCS, X18)>;
+
+

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.h
@@ -44,10 +44,13 @@ public:
 
   /// Code Generation virtual methods...
   const MCPhysReg *getCalleeSavedRegs(const MachineFunction *MF) const override;
+  const MCPhysReg *getDarwinCalleeSavedRegs(const MachineFunction *MF) const;
   const MCPhysReg *
   getCalleeSavedRegsViaCopy(const MachineFunction *MF) const;
   const uint32_t *getCallPreservedMask(const MachineFunction &MF,
                                        CallingConv::ID) const override;
+  const uint32_t *getDarwinCallPreservedMask(const MachineFunction &MF,
+                                             CallingConv::ID) const;
 
   unsigned getCSRFirstUseCost() const override {
     // The cost will be compared against BlockFrequency where entry has the

--- a/llvm/test/CodeGen/AArch64/GlobalISel/call-translator-tail-call-weak.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/call-translator-tail-call-weak.ll
@@ -7,7 +7,7 @@ define void @test_extern_weak() {
   ; DARWIN-LABEL: name: test_extern_weak
   ; DARWIN: bb.1 (%ir-block.0):
   ; DARWIN:   ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-  ; DARWIN:   BL @extern_weak_fn, csr_aarch64_aapcs, implicit-def $lr, implicit $sp
+  ; DARWIN:   BL @extern_weak_fn, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp
   ; DARWIN:   ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
   ; DARWIN:   RET_ReallyLR
   tail call void @extern_weak_fn()

--- a/llvm/test/CodeGen/AArch64/GlobalISel/call-translator-tail-call.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/call-translator-tail-call.ll
@@ -6,7 +6,7 @@ declare void @simple_fn()
 define void @tail_call() {
   ; COMMON-LABEL: name: tail_call
   ; COMMON: bb.1 (%ir-block.0):
-  ; COMMON:   TCRETURNdi @simple_fn, 0, csr_aarch64_aapcs, implicit $sp
+  ; COMMON:   TCRETURNdi @simple_fn, 0, csr{{.*}}aarch64_aapcs, implicit $sp
   tail call void @simple_fn()
   ret void
 }
@@ -18,7 +18,7 @@ define void @indirect_tail_call(void()* %func) {
   ; COMMON: bb.1 (%ir-block.0):
   ; COMMON:   liveins: $x0
   ; COMMON:   [[COPY:%[0-9]+]]:tcgpr64(p0) = COPY $x0
-  ; COMMON:   TCRETURNri [[COPY]](p0), 0, csr_aarch64_aapcs, implicit $sp
+  ; COMMON:   TCRETURNri [[COPY]](p0), 0, csr{{.*}}aarch64_aapcs, implicit $sp
   tail call void %func()
   ret void
 }
@@ -30,7 +30,7 @@ define void @test_outgoing_args(i32 %a) {
   ; COMMON:   liveins: $w0
   ; COMMON:   [[COPY:%[0-9]+]]:_(s32) = COPY $w0
   ; COMMON:   $w0 = COPY [[COPY]](s32)
-  ; COMMON:   TCRETURNdi @outgoing_args_fn, 0, csr_aarch64_aapcs, implicit $sp, implicit $w0
+  ; COMMON:   TCRETURNdi @outgoing_args_fn, 0, csr{{.*}}aarch64_aapcs, implicit $sp, implicit $w0
   tail call void @outgoing_args_fn(i32 %a)
   ret void
 }
@@ -44,7 +44,7 @@ define void @test_outgoing_stack_args([8 x <2 x double>], <4 x half> %arg) {
   ; COMMON:   [[FRAME_INDEX:%[0-9]+]]:_(p0) = G_FRAME_INDEX %fixed-stack.0
   ; COMMON:   [[LOAD:%[0-9]+]]:_(<4 x s16>) = G_LOAD [[FRAME_INDEX]](p0) :: (invariant load 8 from %fixed-stack.0, align 1)
   ; COMMON:   $d0 = COPY [[LOAD]](<4 x s16>)
-  ; COMMON:   TCRETURNdi @outgoing_stack_args_fn, 0, csr_aarch64_aapcs, implicit $sp, implicit $d0
+  ; COMMON:   TCRETURNdi @outgoing_stack_args_fn, 0, csr{{.*}}aarch64_aapcs, implicit $sp, implicit $d0
   tail call void @outgoing_stack_args_fn(<4 x half> %arg)
   ret void
 }
@@ -70,7 +70,7 @@ declare i32 @nonvoid_ret()
 define i32 @test_nonvoid_ret() {
   ; COMMON-LABEL: name: test_nonvoid_ret
   ; COMMON: bb.1 (%ir-block.0):
-  ; COMMON:   TCRETURNdi @nonvoid_ret, 0, csr_aarch64_aapcs, implicit $sp
+  ; COMMON:   TCRETURNdi @nonvoid_ret, 0, csr{{.*}}aarch64_aapcs, implicit $sp
   %call = tail call i32 @nonvoid_ret()
   ret i32 %call
 }
@@ -85,7 +85,7 @@ define void @test_varargs() {
   ; COMMON:   $w0 = COPY [[C]](s32)
   ; COMMON:   $d0 = COPY [[C1]](s64)
   ; COMMON:   $x1 = COPY [[C2]](s64)
-  ; COMMON:   TCRETURNdi @varargs, 0, csr_aarch64_aapcs, implicit $sp, implicit $w0, implicit $d0, implicit $x1
+  ; COMMON:   TCRETURNdi @varargs, 0, csr{{.*}}aarch64_aapcs, implicit $sp, implicit $w0, implicit $d0, implicit $x1
   tail call void(i32, double, i64, ...) @varargs(i32 42, double 1.0, i64 12)
   ret void
 }
@@ -96,7 +96,7 @@ define void @test_varargs() {
 define void @test_varargs_2() {
   ; DARWIN-LABEL: name: test_varargs_2
   ; DARWIN-NOT: TCRETURNdi @varargs
-  ; DARWIN:   BL @varargs, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $w0, implicit $d0, implicit $x1
+  ; DARWIN:   BL @varargs, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $w0, implicit $d0, implicit $x1
   ; DARWIN:   ADJCALLSTACKUP 8, 0, implicit-def $sp, implicit $sp
   ; DARWIN:   RET_ReallyLR
 
@@ -121,7 +121,7 @@ define void @test_varargs_2() {
 define void @test_varargs_3([8 x <2 x double>], <4 x half> %arg) {
   ; DARWIN-LABEL: name: test_varargs_3
   ; DARWIN-NOT: TCRETURNdi @varargs
-  ; DARWIN:   BL @varargs, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $w0, implicit $d0, implicit $x1
+  ; DARWIN:   BL @varargs, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $w0, implicit $d0, implicit $x1
   ; DARWIN:   ADJCALLSTACKUP 8, 0, implicit-def $sp, implicit $sp
   ; DARWIN:   RET_ReallyLR
 
@@ -172,7 +172,7 @@ define void @test_byval(i8* byval %ptr) {
   ; COMMON:   [[FRAME_INDEX:%[0-9]+]]:_(p0) = G_FRAME_INDEX %fixed-stack.0
   ; COMMON:   [[LOAD:%[0-9]+]]:_(p0) = G_LOAD [[FRAME_INDEX]](p0) :: (invariant load 8 from %fixed-stack.0, align 1)
   ; COMMON:   ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-  ; COMMON:   BL @simple_fn, csr_aarch64_aapcs, implicit-def $lr, implicit $sp
+  ; COMMON:   BL @simple_fn, csr{{.*}}aarch64_aapcs, implicit-def $lr, implicit $sp
   ; COMMON:   ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
   ; COMMON:   RET_ReallyLR
   tail call void @simple_fn()
@@ -186,7 +186,7 @@ define void @test_inreg(i8* inreg %ptr) {
   ; COMMON:   liveins: $x0
   ; COMMON:   [[COPY:%[0-9]+]]:_(p0) = COPY $x0
   ; COMMON:   ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-  ; COMMON:   BL @simple_fn, csr_aarch64_aapcs, implicit-def $lr, implicit $sp
+  ; COMMON:   BL @simple_fn, csr{{.*}}aarch64_aapcs, implicit-def $lr, implicit $sp
   ; COMMON:   ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
   ; COMMON:   RET_ReallyLR
   tail call void @simple_fn()
@@ -197,7 +197,7 @@ declare fastcc void @fast_fn()
 define void @test_mismatched_caller() {
   ; COMMON-LABEL: name: test_mismatched_caller
   ; COMMON: bb.1 (%ir-block.0):
-  ; COMMON:   TCRETURNdi @fast_fn, 0, csr_aarch64_aapcs, implicit $sp
+  ; COMMON:   TCRETURNdi @fast_fn, 0, csr{{.*}}aarch64_aapcs, implicit $sp
   tail call fastcc void @fast_fn()
   ret void
 }
@@ -207,7 +207,7 @@ declare void @llvm.assume(i1)
 define void @test_assume() local_unnamed_addr {
   ; COMMON-LABEL: name: test_assume
   ; COMMON: bb.1.entry:
-  ; COMMON:   TCRETURNdi @nonvoid_ret, 0, csr_aarch64_aapcs, implicit $sp
+  ; COMMON:   TCRETURNdi @nonvoid_ret, 0, csr{{.*}}aarch64_aapcs, implicit $sp
 entry:
   %x = tail call i32 @nonvoid_ret()
   %y = icmp ne i32 %x, 0
@@ -222,7 +222,7 @@ define void @test_lifetime() local_unnamed_addr {
   ; COMMON: bb.1.entry:
   ; COMMON:   [[FRAME_INDEX:%[0-9]+]]:_(p0) = G_FRAME_INDEX %stack.0.t
   ; COMMON:   LIFETIME_START %stack.0.t
-  ; COMMON:   TCRETURNdi @nonvoid_ret, 0, csr_aarch64_aapcs, implicit $sp
+  ; COMMON:   TCRETURNdi @nonvoid_ret, 0, csr{{.*}}aarch64_aapcs, implicit $sp
 entry:
   %t = alloca i8, align 1
   call void @llvm.lifetime.start.p0i8(i64 1, i8* %t)
@@ -242,11 +242,11 @@ define hidden swiftcc i64 @swiftself_indirect_tail(i64* swiftself %arg) {
   ; COMMON:   liveins: $x20
   ; COMMON:   [[COPY:%[0-9]+]]:_(p0) = COPY $x20
   ; COMMON:   ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-  ; COMMON:   BL @pluto, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit-def $x0
+  ; COMMON:   BL @pluto, csr{{.*}}aarch64_aapcs, implicit-def $lr, implicit $sp, implicit-def $x0
   ; COMMON:   [[COPY1:%[0-9]+]]:tcgpr64(p0) = COPY $x0
   ; COMMON:   ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
   ; COMMON:   $x20 = COPY [[COPY]](p0)
-  ; COMMON:   TCRETURNri [[COPY1]](p0), 0, csr_aarch64_aapcs, implicit $sp, implicit $x20
+  ; COMMON:   TCRETURNri [[COPY1]](p0), 0, csr{{.*}}aarch64_aapcs, implicit $sp, implicit $x20
   %tmp = call i8* @pluto()
   %tmp1 = bitcast i8* %tmp to i64 (i64*)*
   %tmp2 = tail call swiftcc i64 %tmp1(i64* swiftself %arg)
@@ -263,7 +263,7 @@ define void @foo(i32*) {
   ; COMMON:   [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 0
   ; COMMON:   [[INTTOPTR:%[0-9]+]]:_(p0) = G_INTTOPTR [[C]](s64)
   ; COMMON:   $x0 = COPY [[INTTOPTR]](p0)
-  ; COMMON:   TCRETURNdi @must_callee, 0, csr_aarch64_aapcs, implicit $sp, implicit $x0
+  ; COMMON:   TCRETURNdi @must_callee, 0, csr{{.*}}aarch64_aapcs, implicit $sp, implicit $x0
   musttail call void @must_callee(i8* null)
   ret void
 }

--- a/llvm/test/CodeGen/AArch64/GlobalISel/integration-shuffle-vector.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/integration-shuffle-vector.ll
@@ -14,7 +14,7 @@ define void @shuffle_to_concat_vector(<2 x i64> %a, <2 x i64> %b) {
   ; CHECK:   ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
   ; CHECK:   $q0 = COPY [[COPY]]
   ; CHECK:   $q1 = COPY [[COPY1]]
-  ; CHECK:   BL @bar, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $q0, implicit $q1
+  ; CHECK:   BL @bar, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $q0, implicit $q1
   ; CHECK:   ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
   ; CHECK:   RET_ReallyLR
   %vec = shufflevector <2 x i64> %a, <2 x i64> %b, <4 x i32> <i32 0, i32 1, i32 2, i32 3>

--- a/llvm/test/CodeGen/AArch64/GlobalISel/irtranslator-exceptions.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/irtranslator-exceptions.ll
@@ -12,7 +12,7 @@ declare i32 @llvm.eh.typeid.for(i8*)
 ; CHECK:     successors: %[[GOOD:bb.[0-9]+]]{{.*}}%[[BAD:bb.[0-9]+]]
 ; CHECK:     EH_LABEL
 ; CHECK:     $w0 = COPY
-; CHECK:     BL @foo, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $w0, implicit-def $w0
+; CHECK:     BL @foo, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $w0, implicit-def $w0
 ; CHECK:     {{%[0-9]+}}:_(s32) = COPY $w0
 ; CHECK:     EH_LABEL
 ; CHECK:     G_BR %[[GOOD]]

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-memcpy-et-al.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-memcpy-et-al.mir
@@ -17,7 +17,7 @@ body:             |
     ; CHECK: $x0 = COPY [[COPY]](p0)
     ; CHECK: $x1 = COPY [[COPY1]](p0)
     ; CHECK: $x2 = COPY [[ZEXT]](s64)
-    ; CHECK: BL &memcpy, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $x0, implicit $x1, implicit $x2
+    ; CHECK: BL &memcpy, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $x0, implicit $x1, implicit $x2
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: RET_ReallyLR
     %0:_(p0) = COPY $x0
@@ -44,7 +44,7 @@ body:             |
     ; CHECK: $x0 = COPY [[COPY]](p0)
     ; CHECK: $x1 = COPY [[COPY1]](p0)
     ; CHECK: $x2 = COPY [[ZEXT]](s64)
-    ; CHECK: TCRETURNdi &memcpy, 0, csr_aarch64_aapcs, implicit $sp, implicit $x0, implicit $x1, implicit $x2
+    ; CHECK: TCRETURNdi &memcpy, 0, csr_darwin_aarch64_aapcs, implicit $sp, implicit $x0, implicit $x1, implicit $x2
     %0:_(p0) = COPY $x0
     %1:_(p0) = COPY $x1
     %2:_(s32) = COPY $w2
@@ -70,7 +70,7 @@ body:             |
     ; CHECK: $x0 = COPY [[COPY]](p0)
     ; CHECK: $x1 = COPY [[COPY1]](p0)
     ; CHECK: $x2 = COPY [[ZEXT]](s64)
-    ; CHECK: BL &memmove, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $x0, implicit $x1, implicit $x2
+    ; CHECK: BL &memmove, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $x0, implicit $x1, implicit $x2
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: RET_ReallyLR
     %0:_(p0) = COPY $x0
@@ -99,7 +99,7 @@ body:             |
     ; CHECK: [[COPY3:%[0-9]+]]:_(s32) = COPY [[COPY1]](s32)
     ; CHECK: $w1 = COPY [[COPY3]](s32)
     ; CHECK: $x2 = COPY [[ZEXT]](s64)
-    ; CHECK: BL &memset, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $x0, implicit $w1, implicit $x2
+    ; CHECK: BL &memset, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $x0, implicit $w1, implicit $x2
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: RET_ReallyLR
     %0:_(p0) = COPY $x0
@@ -128,7 +128,7 @@ body:             |
     ; CHECK: $x0 = COPY [[COPY]](p0)
     ; CHECK: $x1 = COPY [[COPY1]](p0)
     ; CHECK: $x2 = COPY [[ZEXT]](s64)
-    ; CHECK: BL &memcpy, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $x0, implicit $x1, implicit $x2
+    ; CHECK: BL &memcpy, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $x0, implicit $x1, implicit $x2
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $x0 = COPY [[ZEXT]](s64)
     ; CHECK: RET_ReallyLR implicit $x0
@@ -157,13 +157,13 @@ body:             |
     ; CHECK: $x0 = COPY [[COPY]](p0)
     ; CHECK: $x1 = COPY [[COPY1]](p0)
     ; CHECK: $x2 = COPY [[ZEXT]](s64)
-    ; CHECK: BL &memcpy, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $x0, implicit $x1, implicit $x2
+    ; CHECK: BL &memcpy, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $x0, implicit $x1, implicit $x2
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK: TCRETURNdi &memset, 0, csr_aarch64_aapcs, implicit $sp
+    ; CHECK: TCRETURNdi &memset, 0, csr_darwin_aarch64_aapcs, implicit $sp
     %0:_(p0) = COPY $x0
     %1:_(p0) = COPY $x1
     %2:_(s32) = COPY $w2
     %4:_(s1) = G_CONSTANT i1 false
     %3:_(s64) = G_ZEXT %2(s32)
     G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.memcpy), %0(p0), %1(p0), %3(s64), 1
-    TCRETURNdi &memset, 0, csr_aarch64_aapcs, implicit $sp
+    TCRETURNdi &memset, 0, csr_darwin_aarch64_aapcs, implicit $sp

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-pow.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-pow.mir
@@ -12,14 +12,14 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $d0 = COPY [[COPY]](s64)
     ; CHECK: $d1 = COPY [[COPY1]](s64)
-    ; CHECK: BL &pow, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $d0, implicit $d1, implicit-def $d0
+    ; CHECK: BL &pow, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $d0, implicit $d1, implicit-def $d0
     ; CHECK: [[COPY4:%[0-9]+]]:_(s64) = COPY $d0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $x0 = COPY [[COPY4]](s64)
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[COPY2]](s32)
     ; CHECK: $s1 = COPY [[COPY3]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY5:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $w0 = COPY [[COPY5]](s32)
@@ -52,7 +52,7 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[FPEXT]](s32)
     ; CHECK: $s1 = COPY [[FPEXT1]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY2]](s32)
@@ -61,7 +61,7 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[FPEXT2]](s32)
     ; CHECK: $s1 = COPY [[FPEXT3]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY3:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY3]](s32)
@@ -70,7 +70,7 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[FPEXT4]](s32)
     ; CHECK: $s1 = COPY [[FPEXT5]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY4:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: [[FPTRUNC2:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY4]](s32)
@@ -79,7 +79,7 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[FPEXT6]](s32)
     ; CHECK: $s1 = COPY [[FPEXT7]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY5:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: [[FPTRUNC3:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY5]](s32)
@@ -112,7 +112,7 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[FPEXT]](s32)
     ; CHECK: $s1 = COPY [[FPEXT1]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY2]](s32)
@@ -121,7 +121,7 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[FPEXT2]](s32)
     ; CHECK: $s1 = COPY [[FPEXT3]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY3:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY3]](s32)
@@ -130,7 +130,7 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[FPEXT4]](s32)
     ; CHECK: $s1 = COPY [[FPEXT5]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY4:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: [[FPTRUNC2:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY4]](s32)
@@ -139,7 +139,7 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[FPEXT6]](s32)
     ; CHECK: $s1 = COPY [[FPEXT7]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY5:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: [[FPTRUNC3:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY5]](s32)
@@ -148,7 +148,7 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[FPEXT8]](s32)
     ; CHECK: $s1 = COPY [[FPEXT9]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY6:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: [[FPTRUNC4:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY6]](s32)
@@ -157,7 +157,7 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[FPEXT10]](s32)
     ; CHECK: $s1 = COPY [[FPEXT11]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY7:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: [[FPTRUNC5:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY7]](s32)
@@ -166,7 +166,7 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[FPEXT12]](s32)
     ; CHECK: $s1 = COPY [[FPEXT13]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY8:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: [[FPTRUNC6:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY8]](s32)
@@ -175,7 +175,7 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[FPEXT14]](s32)
     ; CHECK: $s1 = COPY [[FPEXT15]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY9:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: [[FPTRUNC7:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY9]](s32)
@@ -206,13 +206,13 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[UV]](s32)
     ; CHECK: $s1 = COPY [[UV2]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[UV1]](s32)
     ; CHECK: $s1 = COPY [[UV3]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY3:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY2]](s32), [[COPY3]](s32)
@@ -242,25 +242,25 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[UV]](s32)
     ; CHECK: $s1 = COPY [[UV4]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[UV1]](s32)
     ; CHECK: $s1 = COPY [[UV5]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY3:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[UV2]](s32)
     ; CHECK: $s1 = COPY [[UV6]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY4:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[UV3]](s32)
     ; CHECK: $s1 = COPY [[UV7]](s32)
-    ; CHECK: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &powf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY5:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_BUILD_VECTOR [[COPY2]](s32), [[COPY3]](s32), [[COPY4]](s32), [[COPY5]](s32)
@@ -290,13 +290,13 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $d0 = COPY [[UV]](s64)
     ; CHECK: $d1 = COPY [[UV2]](s64)
-    ; CHECK: BL &pow, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $d0, implicit $d1, implicit-def $d0
+    ; CHECK: BL &pow, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $d0, implicit $d1, implicit-def $d0
     ; CHECK: [[COPY2:%[0-9]+]]:_(s64) = COPY $d0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $d0 = COPY [[UV1]](s64)
     ; CHECK: $d1 = COPY [[UV3]](s64)
-    ; CHECK: BL &pow, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $d0, implicit $d1, implicit-def $d0
+    ; CHECK: BL &pow, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $d0, implicit $d1, implicit-def $d0
     ; CHECK: [[COPY3:%[0-9]+]]:_(s64) = COPY $d0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[COPY2]](s64), [[COPY3]](s64)

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-rem.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-rem.mir
@@ -82,7 +82,7 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $d0 = COPY [[COPY]](s64)
     ; CHECK: $d1 = COPY [[COPY1]](s64)
-    ; CHECK: BL &fmod, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $d0, implicit $d1, implicit-def $d0
+    ; CHECK: BL &fmod, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $d0, implicit $d1, implicit-def $d0
     ; CHECK: [[COPY2:%[0-9]+]]:_(s64) = COPY $d0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $x0 = COPY [[COPY2]](s64)
@@ -91,7 +91,7 @@ body:             |
     ; CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $s0 = COPY [[TRUNC]](s32)
     ; CHECK: $s1 = COPY [[TRUNC1]](s32)
-    ; CHECK: BL &fmodf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
+    ; CHECK: BL &fmodf, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK: [[COPY3:%[0-9]+]]:_(s32) = COPY $s0
     ; CHECK: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
     ; CHECK: $w0 = COPY [[COPY3]](s32)

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-s128-div.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-s128-div.mir
@@ -34,7 +34,7 @@ body:             |
     ; CHECK: $x1 = COPY [[UV1]](s64)
     ; CHECK: $x2 = COPY [[UV2]](s64)
     ; CHECK: $x3 = COPY [[UV3]](s64)
-    ; CHECK: BL &__udivti3, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $x0, implicit $x1, implicit $x2, implicit $x3, implicit-def $x0, implicit-def $x1
+    ; CHECK: BL &__udivti3, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $x0, implicit $x1, implicit $x2, implicit $x3, implicit-def $x0, implicit-def $x1
     ; CHECK: [[COPY2:%[0-9]+]]:_(s64) = COPY $x0
     ; CHECK: [[COPY3:%[0-9]+]]:_(s64) = COPY $x1
     ; CHECK: [[MV:%[0-9]+]]:_(s128) = G_MERGE_VALUES [[COPY2]](s64), [[COPY3]](s64)
@@ -75,7 +75,7 @@ body:             |
     ; CHECK: $x1 = COPY [[UV1]](s64)
     ; CHECK: $x2 = COPY [[UV2]](s64)
     ; CHECK: $x3 = COPY [[UV3]](s64)
-    ; CHECK: BL &__divti3, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $x0, implicit $x1, implicit $x2, implicit $x3, implicit-def $x0, implicit-def $x1
+    ; CHECK: BL &__divti3, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $x0, implicit $x1, implicit $x2, implicit $x3, implicit-def $x0, implicit-def $x1
     ; CHECK: [[COPY2:%[0-9]+]]:_(s64) = COPY $x0
     ; CHECK: [[COPY3:%[0-9]+]]:_(s64) = COPY $x1
     ; CHECK: [[MV:%[0-9]+]]:_(s128) = G_MERGE_VALUES [[COPY2]](s64), [[COPY3]](s64)


### PR DESCRIPTION
With the new SVE stack layout, we now need to provide a Darwin variant
for all the calling conventions based on the main AAPCS CSR save order.

This also changes APCS_SwiftError to have a Darwin and a non-Darwin
version, assuming it could be used on other platforms these days.

Differential Revision: https://reviews.llvm.org/D73805

Note: this is committed before the review got accepted to help unblock
swift's rebranch.

rdar://58940512