### PR TITLE
[indexstore] Create unit directory if it does not exist before watching

### DIFF
--- a/clang/lib/IndexDataStore/IndexDataStore.cpp
+++ b/clang/lib/IndexDataStore/IndexDataStore.cpp
@@ -137,6 +137,13 @@ bool IndexDataStoreImpl::startEventListening(bool waitInitialSync, std::string &
     }
   };
 
+  // Create the unit path if necessary so that the directory watcher can start
+  // even if the data has not been populated yet.
+  if (std::error_code EC = llvm::sys::fs::create_directories(UnitPath)) {
+    Error = EC.message();
+    return true;
+  }
+
   llvm::Expected<std::unique_ptr<DirectoryWatcher>> ExpectedDirWatcher =
       DirectoryWatcher::create(UnitPath.str(), OnUnitsChange, waitInitialSync);
   if (!ExpectedDirWatcher) {


### PR DESCRIPTION
The directory that is passed to the DirectoryWatcher needs to exist or
else it will fail (at least on Linux), and we want to support watching
for unit events before any data has been written. We cannot expect the
client of libIndexStore to create this directly, because the directory
structure underneath the top-level index store path is an implementation
detail.