### PR TITLE
[lldb/Symbol] Use StringRef ctor to prevent incorrect overload

### DIFF
--- a/lldb/source/Symbol/TypeSystem.cpp
+++ b/lldb/source/Symbol/TypeSystem.cpp
@@ -239,7 +239,7 @@ TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
       }
       error = llvm::make_error<llvm::StringError>(
           "TypeSystem for language " +
-              llvm::toStringRef(Language::GetNameForLanguageType(language)) +
+              llvm::StringRef(Language::GetNameForLanguageType(language)) +
               " doesn't exist",
           llvm::inconvertibleErrorCode());
       return std::move(error);
@@ -256,7 +256,7 @@ TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
         }
         error = llvm::make_error<llvm::StringError>(
             "TypeSystem for language " +
-                llvm::toStringRef(Language::GetNameForLanguageType(language)) +
+                llvm::StringRef(Language::GetNameForLanguageType(language)) +
                 " doesn't exist",
             llvm::inconvertibleErrorCode());
         return std::move(error);
@@ -266,7 +266,7 @@ TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
     if (!can_create) {
       error = llvm::make_error<llvm::StringError>(
           "Unable to find type system for language " +
-              llvm::toStringRef(Language::GetNameForLanguageType(language)),
+              llvm::StringRef(Language::GetNameForLanguageType(language)),
           llvm::inconvertibleErrorCode());
     } else {
       // Cache even if we get a shared pointer that contains a null type system
@@ -279,7 +279,7 @@ TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
       }
       error = llvm::make_error<llvm::StringError>(
           "TypeSystem for language " +
-              llvm::toStringRef(Language::GetNameForLanguageType(language)) +
+              llvm::StringRef(Language::GetNameForLanguageType(language)) +
               " doesn't exist",
           llvm::inconvertibleErrorCode());
     }
@@ -308,7 +308,7 @@ TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
       }
       error = llvm::make_error<llvm::StringError>(
           "TypeSystem for language " +
-              llvm::toStringRef(Language::GetNameForLanguageType(language)) +
+              llvm::StringRef(Language::GetNameForLanguageType(language)) +
               " doesn't exist",
           llvm::inconvertibleErrorCode());
       return std::move(error);
@@ -325,7 +325,7 @@ TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
         }
         error = llvm::make_error<llvm::StringError>(
             "TypeSystem for language " +
-                llvm::toStringRef(Language::GetNameForLanguageType(language)) +
+                llvm::StringRef(Language::GetNameForLanguageType(language)) +
                 " doesn't exist",
             llvm::inconvertibleErrorCode());
         return std::move(error);
@@ -335,7 +335,7 @@ TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
     if (!can_create) {
       error = llvm::make_error<llvm::StringError>(
           "Unable to find type system for language " +
-              llvm::toStringRef(Language::GetNameForLanguageType(language)),
+              llvm::StringRef(Language::GetNameForLanguageType(language)),
           llvm::inconvertibleErrorCode());
     } else {
       // Cache even if we get a shared pointer that contains a null type system
@@ -348,7 +348,7 @@ TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
       }
       error = llvm::make_error<llvm::StringError>(
           "TypeSystem for language " +
-              llvm::toStringRef(Language::GetNameForLanguageType(language)) +
+              llvm::StringRef(Language::GetNameForLanguageType(language)) +
               " doesn't exist",
           llvm::inconvertibleErrorCode());
     }


### PR DESCRIPTION
Use the StringRef constructor instead of toStringRef so we don't end up
with the wrong overload (llvm::toStringRef(bool)).

Fixes PR44736

(cherry picked from commit 574685b879acff462faa1e5e480825033c589778)