### PR TITLE
[lldb] Add needed forward declaration after upstream change

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
@@ -54,6 +54,7 @@ class SymbolFileDWARFDwo;
 class SymbolFileDWARFDwp;
 
 namespace lldb_private {
+  class ClangASTImporter;
   class SwiftASTContext;
 }
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/7c9ebdd3d6ae removes some
forward declarations, so we need to add our own.