### PR TITLE
[lldb] Complete return types of CXXMethodDecls to prevent crashing du…

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/commands/expression/call-function/TestCallBuiltinFunction.py
+++ b/lldb/packages/Python/lldbsuite/test/commands/expression/call-function/TestCallBuiltinFunction.py
@@ -39,7 +39,7 @@ class ExprCommandCallBuiltinFunction(TestBase):
 
         # Test different builtin functions.
 
-        self.expect("expr __builtin_isinf(0.0f)", substrs=["(int) $", " = 0\n"])
-        self.expect("expr __builtin_isnormal(0.0f)", substrs=["(int) $", " = 0\n"])
-        self.expect("expr __builtin_constant_p(1)", substrs=["(int) $", " = 1\n"])
-        self.expect("expr __builtin_abs(-14)", substrs=["(int) $", " = 14\n"])
+        self.expect_expr("__builtin_isinf(0.0f)", result_type="int", result_value="0")
+        self.expect_expr("__builtin_isnormal(0.0f)", result_type="int", result_value="0")
+        self.expect_expr("__builtin_constant_p(1)", result_type="int", result_value="1")
+        self.expect_expr("__builtin_abs(-14)", result_type="int", result_value="14")

--- a/lldb/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/string/TestDataFormatterLibcxxString.py
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/string/TestDataFormatterLibcxxString.py
@@ -96,10 +96,11 @@ class LibcxxStringDataFormatterTestCase(TestBase):
             cappedSummary.find("someText") <= 0,
             "cappedSummary includes the full string")
 
+        self.expect_expr("s", result_type=ns+"::wstring", result_summary='L"hello world! מזל טוב!"')
+
         self.expect(
             "frame variable",
             substrs=[
-                '(%s::wstring) s = L"hello world! מזל טוב!"'%ns,
                 '(%s::wstring) S = L"!!!!!"'%ns,
                 '(const wchar_t *) mazeltov = 0x',
                 'L"מזל טוב"',

--- a/lldb/packages/Python/lldbsuite/test/lang/cpp/covariant-return-types/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/cpp/covariant-return-types/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/cpp/covariant-return-types/TestCovariantReturnTypes.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/cpp/covariant-return-types/TestCovariantReturnTypes.py
@@ -1,0 +1,40 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self,"// break here", lldb.SBFileSpec("main.cpp"))
+
+        # Test covariant return types for pointers to class that contains the called function.
+        self.expect_expr("derived.getPtr()", result_type="Derived *")
+        self.expect_expr("base_ptr_to_derived->getPtr()", result_type="Base *")
+        self.expect_expr("base.getPtr()", result_type="Base *")
+        # The same tests with reference types. LLDB drops the reference when it turns the
+        # result into a SBValue so check for the the underlying type of the result.
+        self.expect_expr("derived.getRef()", result_type="Derived")
+        self.expect_expr("base_ptr_to_derived->getRef()", result_type="Base")
+        self.expect_expr("base.getRef()", result_type="Base")
+
+        # Test covariant return types for pointers to class that does *not* contain the called function.
+        self.expect_expr("derived.getOtherPtr()", result_type="OtherDerived *")
+        self.expect_expr("base_ptr_to_derived->getOtherPtr()", result_type="OtherBase *")
+        self.expect_expr("base.getOtherPtr()", result_type="OtherBase *")
+        # The same tests with reference types. LLDB drops the reference when it turns the
+        # result into a SBValue so check for the the underlying type of the result.
+        self.expect_expr("derived.getOtherRef()", result_type="OtherDerived")
+        self.expect_expr("base_ptr_to_derived->getOtherRef()", result_type="OtherBase")
+        self.expect_expr("base.getOtherRef()", result_type="OtherBase")
+
+        # Test that we call the right function and get the right value back.
+        self.expect_expr("derived.getOtherPtr()->value()", result_summary='"derived"')
+        self.expect_expr("base_ptr_to_derived->getOtherPtr()->value()", result_summary='"derived"')
+        self.expect_expr("base.getOtherPtr()->value()", result_summary='"base"')
+        self.expect_expr("derived.getOtherRef().value()", result_summary='"derived"')
+        self.expect_expr("base_ptr_to_derived->getOtherRef().value()", result_summary='"derived"')
+        self.expect_expr("base.getOtherRef().value()", result_summary='"base"')

--- a/lldb/packages/Python/lldbsuite/test/lang/cpp/covariant-return-types/main.cpp
+++ b/lldb/packages/Python/lldbsuite/test/lang/cpp/covariant-return-types/main.cpp
@@ -1,0 +1,40 @@
+struct OtherBase {
+  // Allow checking actual type from the test by giving
+  // this class and the subclass unique values here.
+  virtual const char *value() { return "base"; }
+};
+struct OtherDerived : public OtherBase {
+  const char *value() override { return "derived"; }
+};
+
+// Those have to be globals as they would be completed if they
+// are members (which would make this test always pass).
+OtherBase other_base;
+OtherDerived other_derived;
+
+struct Base {
+  // Function with covariant return type that is same class.
+  virtual Base* getPtr() { return this; }
+  virtual Base& getRef() { return *this; }
+  // Function with covariant return type that is a different class.
+  virtual OtherBase* getOtherPtr() { return &other_base; }
+  virtual OtherBase& getOtherRef() { return other_base; }
+};
+
+struct Derived : public Base {
+  Derived* getPtr() override { return this; }
+  Derived& getRef() override { return *this; }
+  OtherDerived* getOtherPtr() override { return &other_derived; }
+  OtherDerived& getOtherRef() override { return other_derived; }
+};
+
+int main() {
+  Derived derived;
+  Base base;
+  Base *base_ptr_to_derived = &derived;
+  (void)base_ptr_to_derived->getPtr();
+  (void)base_ptr_to_derived->getRef();
+  (void)base_ptr_to_derived->getOtherPtr();
+  (void)base_ptr_to_derived->getOtherRef();
+  return 0; // break here
+}

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2366,6 +2366,45 @@ FileCheck output:
         self.assertTrue(matched if matching else not matched,
                         msg if msg else EXP_MSG(str, output, exe))
 
+    def expect_expr(
+            self,
+            expr,
+            result_summary=None,
+            result_value=None,
+            result_type=None,
+            error_msg=None,
+            ):
+        """
+        Evaluates the given expression and verifies the result.
+        :param expr: The expression as a string.
+        :param result_summary: The summary that the expression should have. None if the summary should not be checked.
+        :param result_value: The value that the expression should have. None if the value should not be checked.
+        :param result_type: The type that the expression result should have. None if the type should not be checked.
+        :param error_msg: The error message the expression should return. None if the error output should not be checked.
+        """
+        self.assertTrue(expr.strip() == expr, "Expression contains trailing/leading whitespace: '" + expr + "'")
+
+        frame = self.frame()
+        eval_result = frame.EvaluateExpression(expr)
+
+        if error_msg:
+            self.assertFalse(eval_result.IsValid())
+            self.assertEqual(error_msg, eval_result.GetError().GetCString())
+            return
+
+        if not eval_result.GetError().Success():
+            self.assertTrue(eval_result.GetError().Success(),
+                "Unexpected failure with msg: " + eval_result.GetError().GetCString())
+
+        if result_type:
+            self.assertEqual(result_type, eval_result.GetTypeName())
+
+        if result_value:
+            self.assertEqual(result_value, eval_result.GetValue())
+
+        if result_summary:
+            self.assertEqual(result_summary, eval_result.GetSummary())
+
     def invoke(self, obj, name, trace=False):
         """Use reflection to call a method dynamically with no argument."""
         trace = (True if traceAlways else trace)

--- a/lldb/source/Symbol/ClangASTImporter.cpp
+++ b/lldb/source/Symbol/ClangASTImporter.cpp
@@ -971,6 +971,25 @@ void ClangASTImporter::ASTImporterDelegate::ImportDefinitionTo(
   }
 }
 
+/// Takes a CXXMethodDecl and completes the return type if necessary. This
+/// is currently only necessary for virtual functions with covariant return
+/// types where Clang's CodeGen expects that the underlying records are already
+/// completed.
+static void MaybeCompleteReturnType(ClangASTImporter &importer,
+                                        CXXMethodDecl *to_method) {
+  if (!to_method->isVirtual())
+    return;
+  QualType return_type = to_method->getReturnType();
+  if (!return_type->isPointerType() && !return_type->isReferenceType())
+    return;
+
+  clang::RecordDecl *rd = return_type->getPointeeType()->getAsRecordDecl();
+  if (!rd)
+    return;
+
+  importer.CompleteTagDecl(rd);
+}
+
 void ClangASTImporter::ASTImporterDelegate::Imported(clang::Decl *from,
                                                      clang::Decl *to) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
@@ -1126,6 +1145,9 @@ void ClangASTImporter::ASTImporterDelegate::Imported(clang::Decl *from,
       }
     }
   }
+
+  if (clang::CXXMethodDecl *to_method = dyn_cast<CXXMethodDecl>(to))
+    MaybeCompleteReturnType(m_master, to_method);
 }
 
 clang::Decl *


### PR DESCRIPTION
…e to covariant return types

Summary:
Currently we crash in Clang's CodeGen when we call functions with covariant return types with this assert:
```
Assertion failed: (DD && "queried property of class with no definition"), function data, file clang/include/clang/AST/DeclCXX.h, line 433.
```
when calling `clang::CXXRecordDecl::isDerivedFrom` from the `ItaniumVTableBuilder`.

Clang seems to assume that the underlying record decls of covariant return types are already completed.
This is true during a normal Clang invocation as there the type checker will complete both decls when
checking if the overloaded function is valid (i.e., the return types are covariant).

When we minimally import our AST into the expression in LLDB we don't do this type checking (which
would complete the record decls) and we end up trying to access the invalid record decls from CodeGen
which makes us trigger the assert.

This patch just completes the underlying types of ptr/ref return types of virtual function so that the
underlying records are complete and we behave as Clang expects us to do.

Fixes rdar://38048657

Reviewers: lhames, shafik

Reviewed By: shafik

Subscribers: abidh, JDevlieghere, lldb-commits

Tags: #lldb

Differential Revision: https://reviews.llvm.org/D73024