### PR TITLE
[llvm-cov] Add support for -skip-functions to lcov

### DIFF
--- a/llvm/test/tools/llvm-cov/export_functions-lcov.test
+++ b/llvm/test/tools/llvm-cov/export_functions-lcov.test
@@ -1,0 +1,8 @@
+# Test that llvm-cov export produces function data by default and that it can be
+# turned off with a flag.
+
+RUN: llvm-cov export -format lcov %S/Inputs/report.covmapping -instr-profile %S/Inputs/report.profdata 2>&1 | FileCheck %s
+RUN: llvm-cov export -format lcov %S/Inputs/report.covmapping -instr-profile %S/Inputs/report.profdata -skip-functions 2>&1 | FileCheck -check-prefix=SKIP-FUNCTIONS %s
+
+CHECK: FN:
+SKIP-FUNCTIONS-NOT: FN:

--- a/llvm/tools/llvm-cov/CoverageExporterLcov.cpp
+++ b/llvm/tools/llvm-cov/CoverageExporterLcov.cpp
@@ -78,10 +78,11 @@ void renderLineSummary(raw_ostream &OS, const FileCoverageSummary &Summary) {
 
 void renderFile(raw_ostream &OS, const coverage::CoverageMapping &Coverage,
                 const std::string &Filename,
-                const FileCoverageSummary &FileReport, bool ExportSummaryOnly) {
+                const FileCoverageSummary &FileReport, bool ExportSummaryOnly,
+                bool SkipFunctions) {
   OS << "SF:" << Filename << '\n';
 
-  if (!ExportSummaryOnly) {
+  if (!ExportSummaryOnly && !SkipFunctions) {
     renderFunctions(OS, Coverage.getCoveredFunctions(Filename));
   }
   renderFunctionSummary(OS, FileReport);
@@ -99,9 +100,10 @@ void renderFile(raw_ostream &OS, const coverage::CoverageMapping &Coverage,
 void renderFiles(raw_ostream &OS, const coverage::CoverageMapping &Coverage,
                  ArrayRef<std::string> SourceFiles,
                  ArrayRef<FileCoverageSummary> FileReports,
-                 bool ExportSummaryOnly) {
+                 bool ExportSummaryOnly, bool SkipFunctions) {
   for (unsigned I = 0, E = SourceFiles.size(); I < E; ++I)
-    renderFile(OS, Coverage, SourceFiles[I], FileReports[I], ExportSummaryOnly);
+    renderFile(OS, Coverage, SourceFiles[I], FileReports[I], ExportSummaryOnly,
+               SkipFunctions);
 }
 
 } // end anonymous namespace
@@ -119,6 +121,6 @@ void CoverageExporterLcov::renderRoot(ArrayRef<std::string> SourceFiles) {
   FileCoverageSummary Totals = FileCoverageSummary("Totals");
   auto FileReports = CoverageReport::prepareFileReports(Coverage, Totals,
                                                         SourceFiles, Options);
-  renderFiles(OS, Coverage, SourceFiles, FileReports,
-              Options.ExportSummaryOnly);
+  renderFiles(OS, Coverage, SourceFiles, FileReports, Options.ExportSummaryOnly,
+              Options.SkipFunctions);
 }


### PR DESCRIPTION
Summary:
This flag was added for the json format to exclude functions from the
output. This mirrors that behavior in lcov (where it was previously
accepted but ignored). This makes the output file smaller which can be
beneficial depending on how you consume it, especially if you don't use
this data anyways.

Patch by Keith Smiley (@keith).

Reviewers: kastiglione, Dor1s, vsk, allevato

Reviewed By: Dor1s, allevato

Subscribers: llvm-commits

Tags: #llvm

Differential Revision: https://reviews.llvm.org/D73160

(cherry picked from commit 8ded83ff7e048bb45e56889f1bf00e36c63e1982)