### PR TITLE
build: avoid linking to tensorflow

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -17,8 +17,6 @@ function(add_tensorflow_compiler_flags target)
     set(rpath_toolchain_lldb_python_lib "../../../${rpath_lldb_binary}")
     set_property(TARGET "${target}" APPEND_STRING PROPERTY
       INSTALL_RPATH "$ORIGIN/${rpath_lldb_binary}:$ORIGIN/${rpath_toolchain_lldb_binary}:$ORIGIN/${rpath_lldb_python_lib}:$ORIGIN/${rpath_toolchain_lldb_python_lib}")
-    set_property(TARGET "${target}" APPEND_STRING PROPERTY
-      LINK_FLAGS " -L${LLDB_PATH_TO_SWIFT_BUILD}/lib/swift/${HOST_VARIANT} -ltensorflow -ltensorflow_framework")
   endif()
 endfunction()
 function(lldb_tablegen)


### PR DESCRIPTION
This merely stops linking against tensorflow.  This is an immediate fix
to repair an internal bot.  However, this code largely should be
possible to remove as the tensorflow dependency is strictly for the
`TensorFlow` Swift module now.