### PR TITLE
fix jupyter completion api

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lang/swift/completions/TestSwiftCompletions.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/completions/TestSwiftCompletions.py
@@ -219,16 +219,15 @@ class TestSwiftCompletions(TestBase):
             }
             Base.""",
             ["ReplacedStruct", "ReplacedStruct", "Type", "init()", "self"])
-        # Asking for a completion again adds another copy of the type.
+        # Asking for a completion again does not add another copy of the type.
         self.assertCompletions(
             """
             extension Base {
               struct ReplacedStruct {}
             }
             Base.""",
-            ["ReplacedStruct", "ReplacedStruct", "ReplacedStruct", "Type",
-             "init()", "self"])
-        # Executing the extension adds another copy of the type.
+            ["ReplacedStruct", "ReplacedStruct", "Type", "init()", "self"])
+        # Executing the extension does not add another copy of the type.
         self.evaluate("""
                       extension Base {
                         struct ReplacedStruct {}
@@ -236,8 +235,7 @@ class TestSwiftCompletions(TestBase):
                       """)
         self.assertCompletions(
             """Base.""",
-            ["ReplacedStruct", "ReplacedStruct", "ReplacedStruct",
-             "ReplacedStruct", "Type", "init()", "self"])
+            ["ReplacedStruct", "ReplacedStruct", "Type", "init()", "self"])
 
         # === TF-249: Crashes when completing a keypath naming a struct with a
         #             private field ===

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1262,8 +1262,6 @@ ParseAndImport(SwiftASTContext *swift_ast_context, Expression &expr,
       /*Keep tokens*/ false);
   module.addFile(*source_file);
 
-  bool done = false;
-
   LLDBNameLookup *external_lookup;
   if (options.GetPlaygroundTransformEnabled() || options.GetREPLEnabled()) {
     external_lookup = new LLDBREPLNameLookup(*source_file, variable_map, sc,
@@ -1278,22 +1276,13 @@ ParseAndImport(SwiftASTContext *swift_ast_context, Expression &expr,
   //        inserting them in.
   swift_ast_context->AddDebuggerClient(external_lookup);
 
-  swift::PersistentParserState persistent_state(*ast_context);
+  // Note, we disable delayed parsing for the swift expression parser.
+  swift::parseIntoSourceFile(*source_file, buffer_id,
+                             /*PersistentState=*/nullptr,
+                             /*DelayBodyParsing=*/false);
 
-  while (!done) {
-    // Note, we disable delayed parsing for the swift expression parser.
-    swift::parseIntoSourceFile(*source_file, buffer_id, &done, nullptr,
-                               &persistent_state,
-                               /*DelayBodyParsing=*/false);
-
-    if (swift_ast_context->HasErrors())
-      return make_error<SwiftASTContextError>();
-  }
-
-  if (!done)
-    return make_error<llvm::StringError>(
-        "Parse did not consume the whole expression.",
-        inconvertibleErrorCode());
+  if (swift_ast_context->HasErrors())
+    return make_error<SwiftASTContextError>();
 
   std::unique_ptr<SwiftASTManipulator> code_manipulator;
   if (repl || !playground) {


### PR DESCRIPTION
This is the main PR fixing https://bugs.swift.org/browse/SR-12076 in swift-jupyter. There are three parts to the fix:
* A PR into apple/swift cherry-picking fixes https://github.com/apple/swift/pull/29619 and https://github.com/apple/swift/pull/29664 from master: https://github.com/apple/swift/pull/29707.
* This PR cherry-picks the https://github.com/apple/llvm-project/pull/712 fix from apple:swift/master llvm-project.
* This PR also makes additional fixes in SwiftCodeCompletion.cpp, which is a custom thing in the `tensorflow` branch of llvm-project.

**Background on SwiftCodeCompletion.cpp**

The existing REPL code completion implementation ([REPLCodeCompletion.cpp](https://github.com/apple/swift/blob/167fea2c78ba334c8248dc05d32e50ccb848122f/lib/IDE/REPLCodeCompletion.cpp)) had some problems making it unsuitable for implementing code completion in swift-jupyter:
* It didn't handle redeclarations correctly.
* It didn't have an API that was callable from Python.

So I duplicated it into `SwiftCodeCompletion.cpp` and made improvements.

I'm planning to upstream these improvements soon so that we don't have this duplicate implementation, but for now we have it.

Whenever someone makes an important change in `REPLCodeCompletion.cpp`, we need to make the corresponding change in `SwiftCodeCompletion.cpp`.

**This PR's fixes to SwiftCodeCompletion.cpp**

https://github.com/apple/swift/pull/29664 fixes https://bugs.swift.org/browse/SR-12076 for `REPLCodeCompletion.cpp` by changing it from reusing an existing source file to creating a new source file for every completion request.

So this PR makes a corresponding change in `SwiftCodeCompletion.cpp`, making it create new source files for every request. This actually simplifies the logic in `SwiftCodeCompletion.cpp` quite a lot, because we don't have to deal with existing state in the files.

Also, while making this change, I noticed that `SwiftCodeCompletion.cpp` wastefully parsed and typechecked a file merely to calculate the completion offset (see explanation in doc comment `FindCompletionPrefixOffset` for explanation of what completion offset it). So I switched it to calculate the completion offset by looking at the characters, inspired by logic in [sourcekit-lsp](https://github.com/apple/sourcekit-lsp/blob/9b8e4c714651ac56dea4c268650b7e68fb918814/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift#L537).