### PR TITLE
[lldb] Fix+re-enable Assert StackFrame Recognizer on Linux

### DIFF
--- a/lldb/source/Target/AssertFrameRecognizer.cpp
+++ b/lldb/source/Target/AssertFrameRecognizer.cpp
@@ -16,26 +16,6 @@ using namespace lldb;
 using namespace lldb_private;
 
 namespace lldb_private {
-/// Checkes if the module containing a symbol has debug info.
-///
-/// \param[in] target
-///    The target containing the module.
-/// \param[in] module_spec
-///    The module spec that should contain the symbol.
-/// \param[in] symbol_name
-///    The symbol's name that should be contained in the debug info.
-/// \return
-///    If  \b true the symbol was found, \b false otherwise.
-bool ModuleHasDebugInfo(Target &target, FileSpec &module_spec,
-                        StringRef symbol_name) {
-  ModuleSP module_sp = target.GetImages().FindFirstModule(module_spec);
-
-  if (!module_sp)
-    return false;
-
-  return module_sp->FindFirstSymbolWithNameAndType(ConstString(symbol_name));
-}
-
 /// Fetches the abort frame location depending on the current platform.
 ///
 /// \param[in] process_sp
@@ -60,9 +40,7 @@ GetAbortLocation(Process *process) {
     break;
   case llvm::Triple::Linux:
     module_spec = FileSpec("libc.so.6");
-    symbol_name = "__GI_raise";
-    if (!ModuleHasDebugInfo(target, module_spec, symbol_name))
-      symbol_name = "raise";
+    symbol_name = "raise";
     break;
   default:
     Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_UNWIND));
@@ -98,9 +76,7 @@ GetAssertLocation(Process *process) {
     break;
   case llvm::Triple::Linux:
     module_spec = FileSpec("libc.so.6");
-    symbol_name = "__GI___assert_fail";
-    if (!ModuleHasDebugInfo(target, module_spec, symbol_name))
-      symbol_name = "__assert_fail";
+    symbol_name = "__assert_fail";
     break;
   default:
     Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_UNWIND));

--- a/lldb/test/Shell/Recognizer/assert.test
+++ b/lldb/test/Shell/Recognizer/assert.test
@@ -1,4 +1,4 @@
-# UNSUPPORTED: system-windows, system-linux
+# UNSUPPORTED: system-windows
 # RUN: %clang_host -g -O0 %S/Inputs/assert.c -o %t.out
 # RUN: %lldb -b -s %s %t.out | FileCheck %s
 run


### PR DESCRIPTION
D73303 was failing on Fedora Linux and so it was disabled by Skip the
AssertFrameRecognizer test for Linux.

On Fedora 30 x86_64 I have:
        $ readelf -Ws /lib64/libc.so.6 |grep '^Symbol\|.*assert_fail'
        Symbol table '.dynsym' contains 2362 entries:
           630: 0000000000030520    70 FUNC    GLOBAL DEFAULT   14 __assert_fail@@GLIBC_2.2.5
        Symbol table '.symtab' contains 22711 entries:
           922: 000000000002275a    15 FUNC    LOCAL  DEFAULT   14 __assert_fail_base.cold
         18044: 0000000000030520    70 FUNC    LOCAL  DEFAULT   14 __GI___assert_fail
         20081: 00000000000303a0   370 FUNC    LOCAL  DEFAULT   14 __assert_fail_base
         21766: 0000000000030520    70 FUNC    GLOBAL DEFAULT   14 __assert_fail

The patch should never expect __GI___assert_fail:

.symtab can be present or not but that should not change that
__assert_fail always wins - it is always present from .dynsym and it can
never be overriden by __GI___assert_fail as __GI___assert_fail has only
local binding. Global binding is preferred since D63540.

External debug info symbols do not matter since D55859 (and DWARF should
never be embedded in system libc.so.6).

Differential Revision: https://reviews.llvm.org/D74252