### PR TITLE
[ODRHash] Check references protocols as part of MergeDefintionData

### DIFF
--- a/clang/lib/AST/ODRHash.cpp
+++ b/clang/lib/AST/ODRHash.cpp
@@ -499,11 +499,6 @@ void ODRHash::AddObjCInterfaceDecl(const ObjCInterfaceDecl *IF) {
   AddBoolean(SuperClass);
   if (SuperClass)
     ID.AddInteger(SuperClass->getODRHash());
-  ID.AddInteger(IF->getReferencedProtocols().size());
-  for (auto *P : IF->protocols()) {
-    unsigned ProtoHash = reinterpret_cast<ObjCProtocolDecl *>(P)->getODRHash();
-    ID.AddInteger(ProtoHash);
-  }
 
   // Filter out sub-Decls which will not be processed in order to get an
   // accurate count of Decl's.
@@ -523,13 +518,6 @@ void ODRHash::AddObjCProtocolDecl(const ObjCProtocolDecl *P) {
   // Trigger ODR computation for methods.
   for (auto *M : P->methods())
     reinterpret_cast<ObjCMethodDecl *>(M)->getODRHash();
-
-  // Store the hash of each referenced protocol.
-  ID.AddInteger(P->getReferencedProtocols().size());
-  for (auto *RefP : P->protocols()) {
-    unsigned RefHash = reinterpret_cast<ObjCProtocolDecl *>(RefP)->getODRHash();
-    ID.AddInteger(RefHash);
-  }
 
   // Filter out sub-Decls which will not be processed in order to get an
   // accurate count of Decl's.

--- a/clang/test/Modules/odr_hash.m
+++ b/clang/test/Modules/odr_hash.m
@@ -46,6 +46,10 @@ __attribute__((objc_root_class))
 @protocol P2
 @end
 
+@protocol UP1;
+@protocol UP2;
+@protocol UP3;
+
 @interface I1
 @end
 
@@ -621,6 +625,55 @@ WI1 *wi1;
 // expected-note@second.h:* {{but in 'SecondModule' found 'optional' method control}}
 @interface IMW5 <MW5> // No diagnostics: @required is the default.
 @end
+#endif
+
+#if defined(FIRST)
+@protocol PP1 <UP1>
+@end
+#elif defined(SECOND)
+@protocol UP1
+@end
+@protocol PP11 <UP1>
+@end
+#else
+@interface II0 <PP1>
+@end
+II0 *ii0;
+#endif
+
+#if defined(FIRST)
+@protocol PP2 <UP2>
+@end
+#elif defined(SECOND)
+@protocol PP2 <UP2>
+@end
+#else
+#endif
+
+#if defined(FIRST)
+@protocol PP3 <UP2>
+@end
+#elif defined(SECOND)
+@protocol PP3 <UP3>
+@end
+#else
+@protocol PP4 <PP3>
+@end
+// expected-error@first.h:* {{'PP3' has different definitions in different modules; first difference is definition in module 'FirstModule' found with 1st protocol named 'UP2'}}
+// expected-note@second.h:* {{but in 'SecondModule' found with 1st protocol named 'UP3'}}
+#endif
+
+#if defined(FIRST)
+@interface II1 <UP3>
+@end
+// expected-warning@first.h:* {{cannot find protocol definition for 'UP3'}}
+// expected-note@first.h:* {{protocol 'UP3' has no definition}}
+#elif defined(SECOND)
+@protocol UP3
+@end
+@interface II1 <UP3>
+@end
+#else
 #endif
 
 // Keep macros contained to one file.


### PR DESCRIPTION
Do this instead of ODR hashing the protocols in the list (which might be
unaccurate since there could be protocols without definitions).

rdar://problem/59271523