### PR TITLE
[ubsan] Null-check and adjust TypeLoc before using it

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -2991,7 +2991,7 @@ void CodeGenFunction::EmitReturnValueCheck(llvm::Value *RV) {
   } else {
     if (auto *DD = dyn_cast<DeclaratorDecl>(CurCodeDecl))
       if (auto *TSI = DD->getTypeSourceInfo())
-        if (auto FTL = TSI->getTypeLoc().castAs<FunctionTypeLoc>())
+        if (auto FTL = TSI->getTypeLoc().getAsAdjusted<FunctionTypeLoc>())
           AttrLoc = FTL.getReturnLoc().findNullabilityLoc();
     CheckKind = SanitizerKind::NullabilityReturn;
     Handler = SanitizerHandler::NullabilityReturn;

--- a/clang/test/CodeGenObjCXX/ubsan-nullability-return-notypeloc.mm
+++ b/clang/test/CodeGenObjCXX/ubsan-nullability-return-notypeloc.mm
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -fsanitize=nullability-return -emit-llvm %s -o - -triple x86_64-apple-macosx10.10.0 | FileCheck %s
+
+// CHECK: [[ATTR_LOC:@[0-9]+]] = {{.*}} global { {{.*}} i32 15, i32 38
+
+// CHECK-LABEL: define i8* @_Z3foov()
+// CHECK: [[CALL:%.*]] = call i8* @_Z6helperv()
+// CHECK: icmp ne i8* [[CALL]]
+// CHECK: call void @__ubsan_handle_nullability_return_v1_abort({{.*}}[[ATTR_LOC]]
+
+struct S {
+  using PtrTy = id;
+};
+
+#pragma clang assume_nonnull begin
+__attribute__((ns_returns_retained)) S::PtrTy foo(void) {
+  extern S::PtrTy helper(void);
+  return helper();
+}
+#pragma clang assume_nonnull end


### PR DESCRIPTION
Null-check and adjut a TypeLoc before casting it to a FunctionTypeLoc.
This fixes a crash in -fsanitize=nullability-return, and also makes the
location of the nonnull type available when the return type is adjusted.

rdar://59263039

Differential Revision: https://reviews.llvm.org/D74355

(cherry picked from commit 8b81ebfe7eba089ed2016d523cc5ee9d05e957a7)