### PR TITLE
[lldb/test] Add alternate symbol to StackFrame Recognizer

### DIFF
--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -960,14 +960,26 @@ protected:
     bool any_printed = false;
     StackFrameRecognizerManager::ForEach(
         [&result, &any_printed](uint32_t recognizer_id, std::string name,
-                                std::string function, std::string symbol,
+                                std::string module, std::string symbol,
                                 std::string alternate_symbol, bool regexp) {
-          if (name == "")
+          Stream &stream = result.GetOutputStream();
+
+          if (name.empty())
             name = "(internal)";
-          result.GetOutputStream().Printf(
-              "%d: %s, module %s, function %s{%s}%s\n", recognizer_id,
-              name.c_str(), function.c_str(), symbol.c_str(),
-              alternate_symbol.c_str(), regexp ? " (regexp)" : "");
+
+          stream << std::to_string(recognizer_id) << ": " << name;
+          if (!module.empty())
+            stream << ", module " << module;
+          if (!symbol.empty())
+            stream << ", function " << symbol;
+          if (!alternate_symbol.empty())
+            stream << ", symbol " << alternate_symbol;
+          if (regexp)
+            stream << " (regexp)";
+
+          stream.EOL();
+          stream.Flush();
+
           any_printed = true;
         });
 

--- a/lldb/source/Target/AssertFrameRecognizer.cpp
+++ b/lldb/source/Target/AssertFrameRecognizer.cpp
@@ -16,97 +16,90 @@ using namespace lldb;
 using namespace lldb_private;
 
 namespace lldb_private {
+
+/// Stores a function module spec, symbol name and possibly an alternate symbol
+/// name.
+struct SymbolLocation {
+  FileSpec module_spec;
+  ConstString symbol_name;
+  ConstString alternate_symbol_name;
+};
+
 /// Fetches the abort frame location depending on the current platform.
 ///
-/// \param[in] process_sp
-///    The process that is currently aborting. This will give us information on
-///    the target and the platform.
+/// \param[in] os
+///    The target's os type.
+/// \param[in,out] location
+///    The struct that will contain the abort module spec and symbol names.
 /// \return
-///    If the platform is supported, returns an optional tuple containing
-///    the abort module as a \a FileSpec and two symbol names as two \a
-///    StringRef. The second \a StringRef may be empty.
-///    Otherwise, returns \a llvm::None.
-llvm::Optional<std::tuple<FileSpec, StringRef, StringRef>>
-GetAbortLocation(Process *process) {
-  Target &target = process->GetTarget();
-
-  FileSpec module_spec;
-  StringRef symbol_name, alternate_symbol_name;
-
-  switch (target.GetArchitecture().GetTriple().getOS()) {
+///    \b true, if the platform is supported
+///    \b false, otherwise.
+bool GetAbortLocation(llvm::Triple::OSType os, SymbolLocation &location) {
+  switch (os) {
   case llvm::Triple::Darwin:
   case llvm::Triple::MacOSX:
-    module_spec = FileSpec("libsystem_kernel.dylib");
-    symbol_name = "__pthread_kill";
+    location.module_spec = FileSpec("libsystem_kernel.dylib");
+    location.symbol_name.SetString("__pthread_kill");
     break;
   case llvm::Triple::Linux:
-    module_spec = FileSpec("libc.so.6");
-    symbol_name = "raise";
-    alternate_symbol_name = "__GI_raise";
+    location.module_spec = FileSpec("libc.so.6");
+    location.symbol_name.SetString("raise");
+    location.alternate_symbol_name.SetString("__GI_raise");
     break;
   default:
     Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_UNWIND));
     LLDB_LOG(log, "AssertFrameRecognizer::GetAbortLocation Unsupported OS");
-    return llvm::None;
+    return false;
   }
 
-  return std::make_tuple(module_spec, symbol_name, alternate_symbol_name);
+  return true;
 }
 
 /// Fetches the assert frame location depending on the current platform.
 ///
-/// \param[in] process_sp
-///    The process that is currently asserting. This will give us information on
-///    the target and the platform.
+/// \param[in] os
+///    The target's os type.
+/// \param[in,out] location
+///    The struct that will contain the assert module spec and symbol names.
 /// \return
-///    If the platform is supported, returns an optional tuple containing
-///    the asserting frame module as a \a FileSpec and two possible symbol
-///    names as two \a StringRef. The second \a StringRef may be empty.
-///    Otherwise, returns \a llvm::None.
-llvm::Optional<std::tuple<FileSpec, StringRef, StringRef>>
-GetAssertLocation(Process *process) {
-  Target &target = process->GetTarget();
-
-  FileSpec module_spec;
-  StringRef symbol_name, alternate_symbol_name;
-
-  switch (target.GetArchitecture().GetTriple().getOS()) {
+///    \b true, if the platform is supported
+///    \b false, otherwise.
+bool GetAssertLocation(llvm::Triple::OSType os, SymbolLocation &location) {
+  switch (os) {
   case llvm::Triple::Darwin:
   case llvm::Triple::MacOSX:
-    module_spec = FileSpec("libsystem_c.dylib");
-    symbol_name = "__assert_rtn";
+    location.module_spec = FileSpec("libsystem_c.dylib");
+    location.symbol_name.SetString("__assert_rtn");
     break;
   case llvm::Triple::Linux:
-    module_spec = FileSpec("libc.so.6");
-    symbol_name = "__assert_fail";
-    alternate_symbol_name = "__GI___assert_fail";
+    location.module_spec = FileSpec("libc.so.6");
+    location.symbol_name.SetString("__assert_fail");
+    location.alternate_symbol_name.SetString("__GI___assert_fail");
     break;
   default:
     Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_UNWIND));
     LLDB_LOG(log, "AssertFrameRecognizer::GetAssertLocation Unsupported OS");
-    return llvm::None;
+    return false;
   }
 
-  return std::make_tuple(module_spec, symbol_name, alternate_symbol_name);
+  return true;
 }
 
 void RegisterAssertFrameRecognizer(Process *process) {
   static llvm::once_flag g_once_flag;
   llvm::call_once(g_once_flag, [process]() {
-    auto abort_location = GetAbortLocation(process);
+    Target &target = process->GetTarget();
+    llvm::Triple::OSType os = target.GetArchitecture().GetTriple().getOS();
+    SymbolLocation location;
 
-    if (!abort_location.hasValue())
+    if (!GetAbortLocation(os, location))
       return;
-
-    FileSpec module_spec;
-    StringRef function_name, alternate_function_name;
-    std::tie(module_spec, function_name, alternate_function_name) =
-        *abort_location;
 
     StackFrameRecognizerManager::AddRecognizer(
         StackFrameRecognizerSP(new AssertFrameRecognizer()),
-        module_spec.GetFilename(), ConstString(function_name),
-        ConstString(alternate_function_name), /*first_instruction_only*/ false);
+        location.module_spec.GetFilename(), ConstString(location.symbol_name),
+        ConstString(location.alternate_symbol_name),
+        /*first_instruction_only*/ false);
   });
 }
 
@@ -116,16 +109,12 @@ lldb::RecognizedStackFrameSP
 AssertFrameRecognizer::RecognizeFrame(lldb::StackFrameSP frame_sp) {
   ThreadSP thread_sp = frame_sp->GetThread();
   ProcessSP process_sp = thread_sp->GetProcess();
+  Target &target = process_sp->GetTarget();
+  llvm::Triple::OSType os = target.GetArchitecture().GetTriple().getOS();
+  SymbolLocation location;
 
-  auto assert_location = GetAssertLocation(process_sp.get());
-
-  if (!assert_location.hasValue())
+  if (!GetAssertLocation(os, location))
     return RecognizedStackFrameSP();
-
-  FileSpec module_spec;
-  StringRef function_name, alternate_function_name;
-  std::tie(module_spec, function_name, alternate_function_name) =
-      *assert_location;
 
   const uint32_t frames_to_fetch = 5;
   const uint32_t last_frame_index = frames_to_fetch - 1;
@@ -145,13 +134,14 @@ AssertFrameRecognizer::RecognizeFrame(lldb::StackFrameSP frame_sp) {
     SymbolContext sym_ctx =
         prev_frame_sp->GetSymbolContext(eSymbolContextEverything);
 
-    if (!sym_ctx.module_sp->GetFileSpec().FileEquals(module_spec))
+    if (!sym_ctx.module_sp->GetFileSpec().FileEquals(location.module_spec))
       continue;
 
     ConstString func_name = sym_ctx.GetFunctionName();
-    if (func_name == ConstString(function_name) ||
-        alternate_function_name.empty() ||
-        func_name == ConstString(alternate_function_name)) {
+
+    if (func_name == location.symbol_name ||
+        (!location.alternate_symbol_name.IsEmpty() &&
+         func_name == location.alternate_symbol_name)) {
 
       // We go a frame beyond the assert location because the most relevant
       // frame for the user is the one in which the assert function was called.

--- a/lldb/source/Target/StackFrameRecognizer.cpp
+++ b/lldb/source/Target/StackFrameRecognizer.cpp
@@ -86,9 +86,13 @@ public:
                  symbol_name, {}, true);
 
       } else {
+        std::string alternate_symbol;
+        if (!entry.alternate_symbol.IsEmpty())
+          alternate_symbol.append(entry.alternate_symbol.GetCString());
+
         callback(entry.recognizer_id, entry.recognizer->GetName(),
                  entry.module.GetCString(), entry.symbol.GetCString(),
-                 entry.alternate_symbol.GetCString(), false);
+                 alternate_symbol, false);
       }
     }
   }


### PR DESCRIPTION
This reimplements commit 6b2979c12300b90a1e69791d43ee9cff14f4265e and updates
the tests to reflect the addition of the alternate symbol attribute.

Differential Revision: https://reviews.llvm.org/D74388

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>