### PR TITLE
[ODRHash] Use desugared type for ObjCProperty with nullable types

### DIFF
--- a/clang/lib/AST/ODRHash.cpp
+++ b/clang/lib/AST/ODRHash.cpp
@@ -329,7 +329,16 @@ public:
   void VisitObjCPropertyDecl(const ObjCPropertyDecl *D) {
     ID.AddInteger(D->getPropertyAttributes());
     ID.AddInteger(D->getPropertyImplementation());
-    AddQualType(D->getType());
+    // Presence of nullability might occur as part of extra annotations from
+    // APINotes. When ODR checking merged definitions between an APINotes'd
+    // module and a non-modular header, skip the nullability annotation to
+    // prevent ODR errors - they are too conservative here and there's
+    // currently no properly reason given that APINotes only applies to one
+    // specific modules.
+    if (D->getType()->canHaveNullability())
+      Hash.AddType(D->getType()->getUnqualifiedDesugaredType());
+    else
+      AddQualType(D->getType());
     AddDecl(D);
 
     Inherited::VisitObjCPropertyDecl(D);

--- a/clang/test/Modules/odr_hash.m
+++ b/clang/test/Modules/odr_hash.m
@@ -77,6 +77,7 @@ __attribute__((objc_root_class))
 - (void)multiple:(int)arg1 :(int)arg2 args:(int)arg3;
 @end
 
+@class WS;
 #endif
 
 #if defined(FIRST)
@@ -675,6 +676,22 @@ II0 *ii0;
 @end
 #else
 #endif
+
+#if defined(FIRST)
+@interface IP9
+@property (nonatomic, readonly, strong) WS * _Nullable ws;
+@end
+#elif defined(SECOND)
+@interface WS
+- (void)sayHello;
+@end
+@interface IP9
+@property (nonatomic, readonly, strong) WS * ws;
+@end
+#else
+IP9 *ip9;
+#endif
+
 
 // Keep macros contained to one file.
 #ifdef FIRST


### PR DESCRIPTION
Presence of nullability might occur as part of extra annotations from
APINotes. When ODR checking merged definitions between an APINotes'd
module and a non-modular header, skip the nullability annotation to
prevent ODR errors - they are too conservative here and there's
currently no properly reason given that APINotes only applies to one
specific modules.

rdar://problem/59161592