### PR TITLE
fix name of swig file in prepare_binding_python.py

### DIFF
--- a/lldb/bindings/python/prepare_binding_python.py
+++ b/lldb/bindings/python/prepare_binding_python.py
@@ -419,7 +419,7 @@ def main(options):
 
     # Setup paths used during swig invocation.
     settings.input_file = os.path.normcase(
-        os.path.join(options.src_root, "bindings", "lldb.swig"))
+        os.path.join(options.src_root, "bindings", "python.swig"))
     bindings_python_dir = os.path.dirname(os.path.realpath(__file__))
     settings.extensions_file = os.path.normcase(
         os.path.join(bindings_python_dir, "python-extensions.swig"))


### PR DESCRIPTION
If you run `./swift/utils/build-script --release --assertions --lldb --extra-cmake-options=-DLLDB_USE_STATIC_BINDINGS=OFF` (on Linux, don't know about macos), then you get an error:
```
ERROR:root:swig failed with error code 1: stdout=, stderr=Unable to find file '/usr/local/google/home/marcrasi/swift-base-master/llvm-project/lldb/bindings/lldb.swig'.
```

This PR fixes it.