### PR TITLE
Fixing build breaks in master-next due to CompilerType refactoring.

### DIFF
--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -390,7 +390,7 @@ CompilerType ValueObject::MaybeCalculateCompleteType() {
   else
     return compiler_type;
 
-  ConstString class_name(class_type.GetConstTypeName());
+  ConstString class_name(class_type.GetTypeName());
   if (!class_name)
     return compiler_type;
 

--- a/lldb/source/Core/ValueObjectDynamicValue.cpp
+++ b/lldb/source/Core/ValueObjectDynamicValue.cpp
@@ -56,7 +56,7 @@ ConstString ValueObjectDynamicValue::GetTypeName() {
   const bool success = UpdateValueIfNeeded(false);
   if (success) {
     if (m_dynamic_type_info.HasType())
-      return GetCompilerType().GetConstTypeName();
+      return GetCompilerType().GetTypeName();
     if (m_dynamic_type_info.HasName())
       return m_dynamic_type_info.GetName();
   }
@@ -75,7 +75,7 @@ ConstString ValueObjectDynamicValue::GetQualifiedTypeName() {
   const bool success = UpdateValueIfNeeded(false);
   if (success) {
     if (m_dynamic_type_info.HasType())
-      return GetCompilerType().GetConstQualifiedTypeName();
+      return GetCompilerType().GetTypeName();
     if (m_dynamic_type_info.HasName())
       return m_dynamic_type_info.GetName();
   }


### PR DESCRIPTION
Some lldb changes in llvm.org llvm-project have caused some build breaks
on apple/swift/master-next llvm-project lldb due to swift specific
changes. The llvm.org change causing the build failure was:

https://github.com/llvm/llvm-project/commit/30ce956aec94ab3785025346a890f4a8cbbe1c58