### PR TITLE
Fix a reentrance bug with deserializing ObjC type parameters

### DIFF
--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -550,7 +550,7 @@ void ASTDeclReader::Visit(Decl *D) {
 
 void ASTDeclReader::VisitDecl(Decl *D) {
   if (D->isTemplateParameter() || D->isTemplateParameterPack() ||
-      isa<ParmVarDecl>(D)) {
+      isa<ParmVarDecl>(D) || isa<ObjCTypeParamDecl>(D)) {
     // We don't want to deserialize the DeclContext of a template
     // parameter or of a parameter of a function template immediately.   These
     // entities might be used in the formulation of its DeclContext (for

--- a/clang/test/Modules/Inputs/module.map
+++ b/clang/test/Modules/Inputs/module.map
@@ -193,6 +193,10 @@ module weird_objc {
   header "weird_objc.h"
 }
 
+module objc_type_param {
+  header "objc_type_param.h"
+}
+
 module ignored_macros {
   header "ignored_macros.h"
 }

--- a/clang/test/Modules/Inputs/objc_type_param.h
+++ b/clang/test/Modules/Inputs/objc_type_param.h
@@ -1,0 +1,13 @@
+__attribute__((objc_root_class))
+@interface Root {
+  Class isa;
+}
+@end
+
+@interface A<T,U> : Root
+@end
+
+@interface B<T,U> : A<T,U>
+typedef void (*BCallback)(T, U);
++ (id) newWithCallback: (BCallback) callback;
+@end

--- a/clang/test/Modules/objc-type-param.m
+++ b/clang/test/Modules/objc-type-param.m
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t -x objective-c -fmodule-name=objc_type_param -emit-module %S/Inputs/module.map
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t -I %S/Inputs %s -verify
+
+@import objc_type_param;
+
+id make(BCallback callback, id arg) {
+  return callback(arg); // expected-error {{too few arguments to function call}}
+}


### PR DESCRIPTION
This is a longstanding bug that seems to have been hidden by a combination of (1) the normal flow being to deserialize the interface before deserializing its parameter and (2) a precise ordering of work that was apparently recently disturbed, perhaps by my abstract-serialization work or Bruno's ObjC module merging work.

Fixes rdar://59153545.