### PR TITLE
Fixing build break on downstream arm64e code due to upstream case change.

### DIFF
--- a/llvm/test/MC/AArch64/arm64e-subtype.s
+++ b/llvm/test/MC/AArch64/arm64e-subtype.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -triple=arm64e-apple-ios -filetype=obj %s -o - | llvm-objdump -macho -d -p - | FileCheck %s
+; RUN: llvm-mc -triple=arm64e-apple-ios -filetype=obj %s -o - | llvm-objdump --macho -d -p - | FileCheck %s
 
 ; CHECK: _foo:
 ; CHECK: 0: c0 03 5f d6   ret


### PR DESCRIPTION
The following change from llvm.org:

https://github.com/llvm/llvm-project/commit/0dce409cee17811c725749d651df89ad62dd38bb

changes the case for EmitAlignment to emitAlignment. This patch makes
things consistent with that change.