### PR TITLE
[lldb/Editline] Fix mistake in HistoryOperation mapping

### DIFF
--- a/lldb/source/Host/common/Editline.cpp
+++ b/lldb/source/Host/common/Editline.cpp
@@ -99,18 +99,24 @@ bool IsOnlySpaces(const EditLineStringType &content) {
 
 static int GetOperation(HistoryOperation op) {
   // The naming used by editline for the history operations is counter
-  // intuitive to how it's used here.
+  // intuitive to how it's used in LLDB's editline implementation.
+  //
+  //  - The H_LAST returns the oldest entry in the history.
   //
   //  - The H_PREV operation returns the previous element in the history, which
   //    is newer than the current one.
   //
+  //  - The H_CURR returns the current entry in the history.
+  //
   //  - The H_NEXT operation returns the next element in the history, which is
   //    older than the current one.
+  //
+  //  - The H_FIRST returns the most recent entry in the history.
   //
   // The naming of the enum entries match the semantic meaning.
   switch(op) {
     case HistoryOperation::Oldest:
-      return H_FIRST;
+      return H_LAST;
     case HistoryOperation::Older:
       return H_NEXT;
     case HistoryOperation::Current:
@@ -118,7 +124,7 @@ static int GetOperation(HistoryOperation op) {
     case HistoryOperation::Newer:
       return H_PREV;
     case HistoryOperation::Newest:
-      return H_LAST;
+      return H_FIRST;
   }
 }
 


### PR DESCRIPTION
In 0e9b0b6d11e882efec8505d97c4b65e1562e6715 I introduced the
HistoryOperation enum to navigate the history. While this fixed the
behavior of HistoryOperation::Older and HistoryOperation::Newer, it
confused the mapping for HistoryOperation::Oldest and
HistoryOperation::Newest.

I tried to write a PExpect test to make sure this doesn't regress, but
I'm unable to prime the history in such a way that it recalls a known
element. I suspect this is an LLDB bug, but the  most recent entry
doesn't get update with entries from the current session. I considered
spoofing the home directory but that needs to happen before libLLDB is
loaded and you'll need to account for the widechar support. If anyone
has another suggestion I'd love to hear it.

(cherry picked from commit 4f2cccc5ce89855bfc5cc44f9bb45fec745e7de9)