### PR TITLE
[swift] Don't leak TypeSystemClang for ClangImporter ASTContext

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -853,6 +853,10 @@ protected:
   typedef ThreadSafeDenseMap<const char *, lldb::TypeSP> SwiftTypeMap;
   SwiftTypeMap m_swift_type_map;
 
+  /// The TypeSystemClang of this swift:ASTContext's ClangImporter.
+  /// Lazily initialized in IsImportedType.
+  std::unique_ptr<TypeSystem> m_importer_type_system;
+
   /// Used in the logs.
   std::string m_description;
   /// @}


### PR DESCRIPTION
We currently have a downstream patch in TypeSystemClang::GetASTContext
that will create a new TypeSystemClang when there is no known
existing TypeSystemClang instance in the global TypeSystemClang map.
This downstream patch is really flawed as it gives the `GetASTContext`
method really flawed behavior:
* It now returns both TypeSystemClang instances that are owned by
  someone else and that are supposed to be owned by the caller. This
  makes it impossible to use this method without leaking memory as
  there is no way for the caller to know if it owns the result or not.
* It is not thread safe anymore as the patch is outside the mutex.

The only user of this functionality seems to be SwiftASTContext::IsImportedType
which is calling it to create the returned CompilerType instances.
The ASTContext used here is the ASTContext of the ClangImporter in Swift which
currently doesn't have an corresponding TypeSystemClang in LLDB. The
TypeSystemClang here is leaked as we can't know if the `GetASTContext` calls
return a TypeSystemClang that is already owned by someone else.

This patch explicitly creates the TypeSystemClang for the ClangImporter
on the first call of IsImportedType and assigns it to a unique_ptr
in the SwiftASTContext to fix the memory leak. We now also no longer
need the downstream patch to TypeSystemClang::GetASTContext so I can
revert it in a follow-up commit.