### PR TITLE
fix compileModuleAndReadAST write to InMemoryOutputFileSystem

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1333,11 +1333,8 @@ static bool compileModuleAndReadAST(CompilerInstance &ImportingInstance,
   // is okay because the locks are only necessary for performance, not
   // correctness.
   if (ImportingInstance.getInMemoryOutputFileSystem()) {
-    InputKind IK(getLanguageFromOptions(ImportingInstance.getLangOpts()),
-                 InputKind::ModuleMap);
-    FrontendInputFile Input(ModuleFileName, IK, +Module->IsSystem);
-    if (!compileModuleImpl(ImportingInstance, ImportLoc, Module->Name,
-                           Input, StringRef(), ModuleFileName)) {
+    if (!compileModule(ImportingInstance, ModuleNameLoc, Module,
+                       ModuleFileName)) {
       diagnoseBuildFailure();
       return false;
     }


### PR DESCRIPTION
Apparently the correct way to call `compileModule` has changed. Our call to `compileModule` is just a copy of the later call in this function, so I pasted in the new call code and it fixed our internal test.

I also have an open source test for this checked into the swift repo's tensorflow branch, so I'm going to separately investigate why that did not trigger.