### PR TITLE
Recompute runtime library search path after discovering the SDK

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lang/swift/runtime_library_path/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/runtime_library_path/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -Xfrontend -no-serialize-debugging-options
+
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/runtime_library_path/TestSwiftRuntimeLibraryPath.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/runtime_library_path/TestSwiftRuntimeLibraryPath.py
@@ -1,0 +1,39 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+
+class TestSwiftRuntimeLibraryPath(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @swiftTest
+    @skipUnlessDarwin
+    def test_allocator_self(self):
+        """That the default runtime library path can be recovered even if
+        paths weren't serialized."""
+        self.build()
+        log = self.getBuildArtifact("types.log")
+        command_result = lldb.SBCommandReturnObject()
+        interpreter = self.dbg.GetCommandInterpreter()
+        interpreter.HandleCommand("log enable lldb types -f "+log, command_result)
+
+        target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(
+            self, 'main')
+
+        self.expect("p 1")
+        logfile = open(log, "r")
+        in_expr_log = 0
+        found = 0
+        for line in logfile:
+            if line.startswith(" SwiftASTContextForExpressions::LogConfiguration"):
+                in_expr_log += 1
+            if in_expr_log and "Runtime library paths" in line and \
+               "2 items" in line:
+                found += 1
+        self.assertEqual(in_expr_log, 1)
+        self.assertEqual(found, 1)

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/runtime_library_path/main.swift
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/runtime_library_path/main.swift
@@ -1,0 +1,1 @@
+print("I have loaded Swift successfully - break here")

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -2719,17 +2719,16 @@ swift::SearchPathOptions &SwiftASTContext::GetSearchPathOptions() {
 }
 
 void SwiftASTContext::InitializeSearchPathOptions(
-    llvm::ArrayRef<std::string> module_search_paths,
-    llvm::ArrayRef<std::pair<std::string, bool>> framework_search_paths) {
-  swift::SearchPathOptions &search_path_opts =
-      GetCompilerInvocation().getSearchPathOptions();
+    llvm::ArrayRef<std::string> extra_module_search_paths,
+    llvm::ArrayRef<std::pair<std::string, bool>> extra_framework_search_paths) {
+  swift::CompilerInvocation &invocation = GetCompilerInvocation();
 
   assert(!m_initialized_search_path_options);
   m_initialized_search_path_options = true;
 
   bool set_sdk = false;
-  if (!search_path_opts.SDKPath.empty()) {
-    FileSpec provided_sdk_path(search_path_opts.SDKPath);
+  if (!invocation.getSDKPath().empty()) {
+    FileSpec provided_sdk_path(invocation.getSDKPath());
     if (FileSystem::Instance().Exists(provided_sdk_path)) {
       // We don't check whether the SDK supports swift because we figure if
       // someone is passing this to us on the command line (e.g., for the
@@ -2742,7 +2741,7 @@ void SwiftASTContext::InitializeSearchPathOptions(
 
     if (FileSystem::Instance().Exists(platform_sdk) &&
         SDKSupportsSwift(platform_sdk, SDKType::unknown)) {
-      search_path_opts.SDKPath = m_platform_sdk_path.c_str();
+      invocation.setSDKPath(m_platform_sdk_path.c_str());
       set_sdk = true;
     }
   }
@@ -2763,38 +2762,45 @@ void SwiftASTContext::InitializeSearchPathOptions(
     if (sdk.sdk_type != SDKType::unknown) {
       auto dir = GetSDKDirectory(sdk.sdk_type, sdk.min_version_major,
                                  sdk.min_version_minor);
-      search_path_opts.SDKPath = dir.AsCString("");
+      // Note that calling setSDKPath() also recomputes all paths that
+      // depend on the SDK path including the
+      // RuntimeLibraryImportPaths, which are *only* initialized
+      // through this mechanism.
+      invocation.setSDKPath(dir.AsCString(""));
     }
 
-    std::vector<std::string>& lpaths = search_path_opts.LibrarySearchPaths;
+    std::vector<std::string> &lpaths =
+        invocation.getSearchPathOptions().LibrarySearchPaths;
     lpaths.insert(lpaths.begin(), "/usr/lib/swift");
   }
 
   llvm::StringMap<bool> processed;
+  std::vector<std::string> &invocation_import_paths =
+      invocation.getSearchPathOptions().ImportSearchPaths;
   // Add all deserialized paths to the map.
-  for (const auto &path : search_path_opts.ImportSearchPaths)
+  for (const auto &path : invocation_import_paths)
     processed.insert({path, false});
 
   // Add/unique all extra paths.
-  for (const auto &path : module_search_paths) {
-    search_path_opts.ImportSearchPaths.push_back(path);
+  for (const auto &path : extra_module_search_paths) {
     auto it_notseen = processed.insert({path, false});
     if (it_notseen.second)
-      search_path_opts.ImportSearchPaths.push_back(path);
+      invocation_import_paths.push_back(path);
   }
 
   // This preserves the IsSystem bit, but deduplicates entries ignoring it.
   processed.clear();
+  auto &invocation_framework_paths =
+      invocation.getSearchPathOptions().FrameworkSearchPaths;
   // Add all deserialized paths to the map.
-  for (const auto &path : search_path_opts.FrameworkSearchPaths)
+  for (const auto &path : invocation_framework_paths)
     processed.insert({path.Path, path.IsSystem});
 
   // Add/unique all extra paths.
-  for (const auto &path : framework_search_paths) {
+  for (const auto &path : extra_framework_search_paths) {
     auto it_notseen = processed.insert(path);
     if (it_notseen.second)
-      search_path_opts.FrameworkSearchPaths.push_back(
-          {path.first, path.second});
+      invocation_framework_paths.push_back({path.first, path.second});
   }
 }
 


### PR DESCRIPTION
This fixes a failure to import the Swift runtime library when
debugging a program that was compiled without serialized earch path
options.

rdar://problem/59429786