### PR TITLE
[🍒][libc++] Make sure that vector copy-construction is disabled for non-copyable types

### DIFF
--- a/libcxx/include/memory
+++ b/libcxx/include/memory
@@ -1695,7 +1695,7 @@ struct _LIBCPP_TEMPLATE_VIS allocator_traits
         static
         typename enable_if
         <
-            is_trivially_move_constructible<_DestTp>::value &&
+            is_trivially_copy_constructible<_DestTp>::value &&
             is_same<_RawSourceTp, _RawDestTp>::value &&
             (__is_default_allocator<allocator_type>::value ||
              !__has_construct<allocator_type, _DestTp*, _SourceTp&>::value),

--- a/libcxx/test/std/containers/sequences/vector/vector.cons/copy.move_only.fail.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.cons/copy.move_only.fail.cpp
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Make sure that a std::vector containing move-only types can't be copied.
+
+// UNSUPPORTED: c++98, c++03
+// REQUIRES: verify-support
+
+#include <vector>
+
+struct move_only
+{
+    move_only() = default;
+    move_only(move_only&&) = default;
+    move_only& operator=(move_only&&) = default;
+};
+
+int main(int, char**)
+{
+    std::vector<move_only> v;
+    std::vector<move_only> copy = v; // expected-error@memory:* {{call to implicitly-deleted copy constructor of 'move_only'}}
+    return 0;
+}


### PR DESCRIPTION
The Standard requires the value_type of the vector to be Cpp17CopyInsertable in order for copy-construction to be enabled:

	http://eel.is/c++draft/container.requirements#tab:container.req

rdar://problem/56674564

Differential Revision: https://reviews.llvm.org/D74251