### PR TITLE
Regain the ability to detect a failure to load the Swift stdlib.

### DIFF
--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -8427,9 +8427,6 @@ static void DescribeFileUnit(Stream &s, swift::FileUnit *file_unit) {
   s.PutCString("kind = ");
 
   switch (file_unit->getKind()) {
-  default: {
-    s.PutCString("<unknown>");
-  }
   case swift::FileUnitKind::Source: {
     s.PutCString("Source, ");
     if (swift::SourceFile *source_file =
@@ -8460,7 +8457,10 @@ static void DescribeFileUnit(Stream &s, swift::FileUnit *file_unit) {
     swift::LoadedFile *loaded_file = llvm::cast<swift::LoadedFile>(file_unit);
     s.Printf("filename = \"%s\"", loaded_file->getFilename().str().c_str());
   } break;
+  case swift::FileUnitKind::DWARFModule:
+    s.PutCString("DWARF");
   };
+  s.PutCString(";");
 }
 
 // Gets the full module name from the module passed in.
@@ -8500,7 +8500,7 @@ LoadOneModule(const SourceModule &module, SwiftASTContext &swift_ast_context,
 
   error.Clear();
   ConstString toplevel = module.path.front();
-  llvm::SmallString<1> m_description;
+  const std::string &m_description = swift_ast_context.GetDescription();
   LOG_PRINTF(LIBLLDB_LOG_EXPRESSIONS, "Importing module %s",
              toplevel.AsCString());
   swift::ModuleDecl *swift_module = nullptr;
@@ -8530,14 +8530,11 @@ LoadOneModule(const SourceModule &module, SwiftASTContext &swift_ast_context,
   }
 
   if (lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS)) {
-    LOG_PRINTF(LIBLLDB_LOG_EXPRESSIONS, "Importing %s with source files:",
-               module.path.front().AsCString());
-
-    for (swift::FileUnit *file_unit : swift_module->getFiles()) {
-      StreamString ss;
+    StreamString ss;
+    for (swift::FileUnit *file_unit : swift_module->getFiles())
       DescribeFileUnit(ss, file_unit);
-      LOG_PRINTF(LIBLLDB_LOG_EXPRESSIONS, "  %s", ss.GetData());
-    }
+    LOG_PRINTF(LIBLLDB_LOG_EXPRESSIONS, "Imported module %s from {%s}",
+               module.path.front().AsCString(), ss.GetData());
   }
 
   additional_imports.push_back(swift::SourceFile::ImportedModuleDesc(

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -1858,6 +1858,17 @@ static lldb::ModuleSP GetUnitTestModule(lldb_private::ModuleList &modules) {
   return ModuleSP();
 }
 
+/// Detect whether a Swift module was "imported" by DWARFImporter.
+/// All this *really* means is that it couldn't be loaded through any
+/// other mechanism.
+static bool IsDWARFImported(swift::ModuleDecl &module) {
+  return std::any_of(module.getFiles().begin(), module.getFiles().end(),
+                     [](swift::FileUnit *file_unit) {
+                       return (file_unit->getKind() ==
+                               swift::FileUnitKind::DWARFModule);
+                     });
+}
+
 lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
                                                    Target &target,
                                                    const char *extra_options) {
@@ -2216,7 +2227,9 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
   }
 
   const bool can_create = true;
-  if (!swift_ast_sp->m_ast_context_ap->getStdlibModule(can_create)) {
+  swift::ModuleDecl *stdlib =
+      swift_ast_sp->m_ast_context_ap->getStdlibModule(can_create);
+  if (!stdlib || IsDWARFImported(*stdlib)) {
     logError("couldn't load the Swift stdlib");
     return {};
   }
@@ -8519,6 +8532,16 @@ LoadOneModule(const SourceModule &module, SwiftASTContext &swift_ast_context,
       swift_module = swift_ast_context.GetModule(module, error);
   } else
     swift_module = swift_ast_context.GetModule(module, error);
+
+  if (swift_module && IsDWARFImported(*swift_module)) {
+    // This module was "imported" from DWARF. This basically means the
+    // import as a Swift or Clang module failed. We have not yet
+    // checked that DWARF debug info for this module actually exists
+    // and there is no good mechanism to do so ahead of time.
+    // We do know that we never load the stdlib from DWARF though.
+    if (toplevel.GetStringRef() == swift::STDLIB_NAME)
+      swift_module = nullptr;
+  }
 
   if (!swift_module || !error.Success() || swift_ast_context.HasFatalErrors()) {
     LOG_PRINTF(LIBLLDB_LOG_EXPRESSIONS, "Couldn't import module %s: %s",


### PR DESCRIPTION
This fixes a regression caused by turning on DWARFImporter by default.