### PR TITLE
[lldb] Fix missing return in SwiftASTContext

### DIFF
--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -5054,8 +5054,11 @@ void SwiftASTContext::LogConfiguration() {
   LOG_PRINTF(LIBLLDB_LOG_TYPES,
              "(SwiftASTContext*)%p:", static_cast<void *>(this));
 
-  if (!m_ast_context_ap)
+  if (!m_ast_context_ap) {
     log->Printf("  (no AST context)");
+    return;
+  }
+
   log->Printf("  Architecture                 : %s",
               m_ast_context_ap->LangOpts.Target.getTriple().c_str());
   log->Printf("  SDK path                     : %s",


### PR DESCRIPTION
(cherry picked from commit d6ca36285af15222efe368e27fed127765982a70)