### PR TITLE
[clang][doxygen] Fix false -Wdocumentation warning for tag typedefs

### DIFF
--- a/clang/include/clang/AST/CommentSema.h
+++ b/clang/include/clang/AST/CommentSema.h
@@ -217,6 +217,9 @@ public:
   bool isTemplateOrSpecialization();
   bool isRecordLikeDecl();
   bool isClassOrStructDecl();
+  /// \return \c true if the declaration that this comment is attached to
+  /// declares either struct, class or tag typedef.
+  bool isClassOrStructOrTagTypedefDecl();
   bool isUnionDecl();
   bool isObjCInterfaceDecl();
   bool isObjCProtocolDecl();

--- a/clang/test/Sema/warn-documentation-tag-typedef.cpp
+++ b/clang/test/Sema/warn-documentation-tag-typedef.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -Wdocumentation -fsyntax-only %s 2>&1 | FileCheck -allow-empty %s
+
+/*!
+@class Foo
+*/
+typedef class { } Foo;
+// CHECK-NOT: warning:
+
+/*! 
+@struct Bar
+*/
+typedef struct { } Bar;
+// CHECK-NOT: warning:


### PR DESCRIPTION
For tag typedefs like this one:

/*!
@class Foo
*/
typedef class { } Foo;

clang -Wdocumentation gives:

warning: '@class' command should not be used in a comment attached to a
non-struct declaration [-Wdocumentation]

... while doxygen seems fine with it.

Differential Revision: https://reviews.llvm.org/D74746