### PR TITLE
Avoid scanning the same Swift module for its dependencies more than once

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -853,6 +853,9 @@ protected:
   typedef ThreadSafeDenseMap<const char *, lldb::TypeSP> SwiftTypeMap;
   SwiftTypeMap m_swift_type_map;
 
+  /// Keeps track of the Swift modules for whil all dylibs have been loaded.
+  ThreadSafeDenseSet<swift::ModuleDecl *> m_linked_libraries_loaded;
+  
   /// Used in the logs.
   std::string m_description;
   /// @}

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/load_module/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/load_module/Makefile
@@ -1,0 +1,26 @@
+SWIFT_SOURCES := main.swift
+# In bottom-up order, because we didn't capture the dependencies.
+BREADTH := 4
+ALL_LIBS := \
+  $(patsubst %,d%,$(shell seq 1 $(BREADTH))) \
+  $(patsubst %,c%,$(shell seq 1 $(BREADTH))) \
+  $(patsubst %,b%,$(shell seq 1 $(BREADTH))) \
+  $(patsubst %,a%,$(shell seq 1 $(BREADTH))) 
+
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR) -autolink-force-load
+LD_EXTRAS = -L$(BUILDDIR) $(patsubst %, -l%, $(patsubst %,a%,$(shell seq 1 $(BREADTH))))
+
+all: $(patsubst %, lib%.dylib, $(ALL_LIBS)) $(EXE)
+
+include Makefile.rules
+
+lib%.dylib: %.swift
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC="$(CC)" SWIFTC="$(SWIFTC)" \
+		ARCH=$(ARCH) DSYMUTIL="$(DSYMUTIL)" VPATH="$(BUILDDIR)"  \
+		SWIFTSDKROOT=$(SWIFTSDKROOT) \
+		SWIFT_MODULE_CACHE_FLAGS="$(SWIFT_MODULE_CACHE_FLAGS)" \
+		SWIFTFLAGS_EXTRAS="$(SWIFTFLAGS_EXTRAS) -module-link-name $(shell basename $< .swift)" \
+		LD_EXTRAS="-L$(BUILDDIR)" \
+		BASENAME=$(shell basename $< .swift) \
+		-f $(SRCDIR)/dylib.mk
+

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/load_module/TestSwiftLoadModule.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/load_module/TestSwiftLoadModule.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+import re
+
+class TestSwiftRuntimeLibraryPath(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+    NO_DEBUG_INFO_TEST = True
+
+    @swiftTest
+    @skipUnlessPlatform(["macosx"])
+    def test_load_link_library(self):
+        """That the default runtime library path can be recovered even if
+        paths weren't serialized."""
+        
+        # a0   a1 ⋯ aN
+        # | \ /| 
+        # |  X | 
+        # | / \| 
+        # b0   b1 ⋯ bN
+        # | \ /| 
+        # |  X | 
+        # | / \| 
+        # c0   c1 ⋯ cN
+        # ⋮
+
+        breadth = 4+1
+        with open(self.getBuildArtifact("main.swift"), "w") as main:
+            for i in range(1, breadth):
+                main.write("import a%d\n"%i)
+            for i in range(1, breadth):
+                main.write("print(d%d)\n"%i)
+        for i in range(1, breadth):
+            with open(self.getBuildArtifact("a%d.swift"%i), "w") as a:
+                for j in range(1, breadth):
+                    a.write("@_exported import b%d\n"%(j))
+                    a.write("public let a%d = 0\n"%j)
+            with open(self.getBuildArtifact("b%d.swift"%i), "w") as b:
+                for j in range(1, breadth):
+                    b.write("@_exported import c%d\n"%(j))
+                    b.write("public let b%d = 0\n"%j)
+            with open(self.getBuildArtifact("c%d.swift"%i), "w") as c:
+                for j in range(1, breadth):
+                    c.write("@_exported import d%d\n"%j)
+                    c.write("public let c%d = 0\n"%j)
+            with open(self.getBuildArtifact("d%d.swift"%i), "w") as d:
+                d.write("public let d%d = 0\n"%i)
+           
+        self.build()
+        # Remove the .swiftmodule that carries the correct SDK path.
+        log = self.getBuildArtifact("types.log")
+        self.expect("log enable lldb types expr -f "+log)
+
+        target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(
+            self, 'main')
+
+        self.expect("p 1")
+        logfile = open(log, "r")
+        count = dict()
+        for level in ["a", "b", "c", "d"]:
+            for i in range(1, breadth):
+                count["%s%d"%(level, i)] = 0
+
+        regexp = re.compile('Loading link library "([a-d][0-9]+)"')
+        for line in logfile:
+            m = regexp.search(line)
+            if m:
+                count[m.group(1)] += 1
+
+        for level in ["a", "b", "c", "d"]:
+            for i in range(1, breadth):
+                # LoadModule is not the only entry point, so libraries
+                # found via collectLinkLibraries are still counted
+                # multiple times. Uniquing them is more difficult
+                # because their names may be contextual.
+                self.assertLessEqual(count["%s%d"%(level, i)], 4)

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/load_module/dylib.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/load_module/dylib.mk
@@ -1,0 +1,5 @@
+DYLIB_ONLY := YES
+DYLIB_NAME := $(BASENAME)
+DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
+
+include Makefile.rules


### PR DESCRIPTION
This patch reduces the number of lookups in a testcase with 64 modules
that import Cocoa from ~350.000 to double-digits.

Unfortunately LoadModule is not the only entry point, so libraries
found via collectLinkLibraries are still counted multiple
times. Uniquing them is more difficult because their names may be
contextual.

rdar://problem/59297440