### PR TITLE
Fix SR-12224 (rdar://problem/59655505)

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
@@ -1126,8 +1126,9 @@ CHECK_SIZE_AND_OFFSET(ipc_perm, uid);
 CHECK_SIZE_AND_OFFSET(ipc_perm, gid);
 CHECK_SIZE_AND_OFFSET(ipc_perm, cuid);
 CHECK_SIZE_AND_OFFSET(ipc_perm, cgid);
-#if !defined(__aarch64__) || !SANITIZER_LINUX || __GLIBC_PREREQ (2, 21)
-/* On aarch64 glibc 2.20 and earlier provided incorrect mode field.  */
+#if !SANITIZER_LINUX || __GLIBC_PREREQ(2, 31)
+/* glibc 2.30 and earlier provided 16-bit mode field instead of 32-bit
+   on many architectures.  */
 CHECK_SIZE_AND_OFFSET(ipc_perm, mode);
 #endif
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
@@ -203,26 +203,13 @@ namespace __sanitizer {
     u64 __unused1;
     u64 __unused2;
 #elif defined(__sparc__)
-#if defined(__arch64__)
     unsigned mode;
-    unsigned short __pad1;
-#else
-    unsigned short __pad1;
-    unsigned short mode;
     unsigned short __pad2;
-#endif
     unsigned short __seq;
     unsigned long long __unused1;
     unsigned long long __unused2;
-#elif defined(__mips__) || defined(__aarch64__) || defined(__s390x__)
-    unsigned int mode;
-    unsigned short __seq;
-    unsigned short __pad1;
-    unsigned long __unused1;
-    unsigned long __unused2;
 #else
-    unsigned short mode;
-    unsigned short __pad1;
+    unsigned int mode;
     unsigned short __seq;
     unsigned short __pad2;
 #if defined(__x86_64__) && !defined(_LP64)


### PR DESCRIPTION
Cherry-pick's 947f9692440836dcb8d88b74b69dd379d85974ce from llvm.org/master. The cherry-pick didn't apply cleanly due to formatting changes in 48eb4a27d1d1f2f6e7f6036d47fb282e6eb49310 but I managed to make it work. The sanitizer linter still passes and this fixes the build on an Arch Linux system with glibc 2.31-1