### PR TITLE
[lldb/Plugins] Move SBTarget::GetExtendedCrashInformation to SBProcess

### DIFF
--- a/lldb/bindings/interface/SBProcess.i
+++ b/lldb/bindings/interface/SBProcess.i
@@ -346,6 +346,11 @@ public:
     bool
     GetDescription (lldb::SBStream &description);
 
+    %feature("autodoc", "
+    Returns the process' extended crash information.") GetExtendedCrashInformation;
+    lldb::SBStructuredData
+    GetExtendedCrashInformation ();
+
     uint32_t
     GetNumSupportedHardwareWatchpoints (lldb::SBError &error) const;
 

--- a/lldb/bindings/interface/SBTarget.i
+++ b/lldb/bindings/interface/SBTarget.i
@@ -949,12 +949,6 @@ public:
     void
     SetLaunchInfo (const lldb::SBLaunchInfo &launch_info);
 
-    %feature("autodoc", "
-    Returns the platform's process extended crash information.") GetExtendedCrashInformation;
-    lldb::SBStructuredData
-    GetExtendedCrashInformation ();
-
-
     void SetCollectingStats(bool v);
 
     bool GetCollectingStats();

--- a/lldb/include/lldb/API/SBProcess.h
+++ b/lldb/include/lldb/API/SBProcess.h
@@ -222,6 +222,8 @@ public:
 
   bool GetDescription(lldb::SBStream &description);
 
+  SBStructuredData GetExtendedCrashInformation();
+
   /// Start Tracing with the given SBTraceOptions.
   ///
   /// \param[in] options

--- a/lldb/include/lldb/API/SBStructuredData.h
+++ b/lldb/include/lldb/API/SBStructuredData.h
@@ -91,6 +91,7 @@ protected:
   friend class SBTraceOptions;
   friend class SBDebugger;
   friend class SBTarget;
+  friend class SBProcess;
   friend class SBThread;
   friend class SBThreadPlan;
   friend class SBBreakpoint;

--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -819,8 +819,6 @@ public:
 
   void SetLaunchInfo(const lldb::SBLaunchInfo &launch_info);
 
-  SBStructuredData GetExtendedCrashInformation();
-
 protected:
   friend class SBAddress;
   friend class SBBlock;

--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -831,8 +831,8 @@ public:
   /// nullptr. This dictionnary is generic and extensible, as it contains an
   /// array for each different type of crash information.
   ///
-  /// \param[in] target
-  ///     The target running the crashed process.
+  /// \param[in] process
+  ///     The crashed process.
   ///
   /// \return
   ///     A structured data dictionnary containing at each entry, the crash
@@ -840,7 +840,7 @@ public:
   ///     entry value. \b nullptr if not implemented or  if the process has no
   ///     crash information entry. \b error if an error occured.
   virtual llvm::Expected<StructuredData::DictionarySP>
-  FetchExtendedCrashInformation(lldb_private::Target &target) {
+  FetchExtendedCrashInformation(lldb_private::Process &process) {
     return nullptr;
   }
 

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -2388,30 +2388,6 @@ void SBTarget::SetLaunchInfo(const lldb::SBLaunchInfo &launch_info) {
     m_opaque_sp->SetProcessLaunchInfo(launch_info.ref());
 }
 
-SBStructuredData SBTarget::GetExtendedCrashInformation() {
-  LLDB_RECORD_METHOD_NO_ARGS(lldb::SBStructuredData, SBTarget,
-                             GetExtendedCrashInformation);
-  SBStructuredData data;
-  TargetSP target_sp(GetSP());
-  if (!target_sp)
-    return LLDB_RECORD_RESULT(data);
-
-  PlatformSP platform_sp = target_sp->GetPlatform();
-
-  if (!target_sp)
-    return LLDB_RECORD_RESULT(data);
-
-  auto expected_data =
-      platform_sp->FetchExtendedCrashInformation(*target_sp.get());
-
-  if (!expected_data)
-    return LLDB_RECORD_RESULT(data);
-
-  StructuredData::ObjectSP fetched_data = *expected_data;
-  data.m_impl_up->SetObjectSP(fetched_data);
-  return LLDB_RECORD_RESULT(data);
-}
-
 namespace lldb_private {
 namespace repro {
 
@@ -2654,8 +2630,6 @@ void RegisterMethods<SBTarget>(Registry &R) {
   LLDB_REGISTER_METHOD_CONST(lldb::SBLaunchInfo, SBTarget, GetLaunchInfo, ());
   LLDB_REGISTER_METHOD(void, SBTarget, SetLaunchInfo,
                        (const lldb::SBLaunchInfo &));
-  LLDB_REGISTER_METHOD(lldb::SBStructuredData, SBTarget,
-                       GetExtendedCrashInformation, ());
   LLDB_REGISTER_METHOD(
       size_t, SBTarget, ReadMemory,
       (const lldb::SBAddress, void *, size_t, lldb::SBError &));

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -1283,7 +1283,7 @@ protected:
       }
 
       auto expected_crash_info =
-          platform_sp->FetchExtendedCrashInformation(process->GetTarget());
+          platform_sp->FetchExtendedCrashInformation(*process);
 
       if (!expected_crash_info) {
         result.AppendError(llvm::toString(expected_crash_info.takeError()));

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -87,7 +87,7 @@ public:
   };
 
   llvm::Expected<lldb_private::StructuredData::DictionarySP>
-  FetchExtendedCrashInformation(lldb_private::Target &target) override;
+  FetchExtendedCrashInformation(lldb_private::Process &process) override;
 
 protected:
   struct CrashInfoAnnotations {
@@ -108,15 +108,15 @@ protected:
   /// extract the section to gather the messages annotations and the abort
   /// cause.
   ///
-  /// \param[in] target
-  ///     The target running the crashed process.
+  /// \param[in] process
+  ///     The crashed process.
   ///
   /// \return
   ///     A  structured data array containing at each entry in each entry, the
   ///     module spec, its UUID, the crash messages and the abort cause.
   ///     \b nullptr if process has no crash information annotations.
   lldb_private::StructuredData::ArraySP
-  ExtractCrashInfoAnnotations(lldb_private::Target &target);
+  ExtractCrashInfoAnnotations(lldb_private::Process &process);
 
   void ReadLibdispatchOffsetsAddress(lldb_private::Process *process);
 

--- a/lldb/test/API/functionalities/process_crash_info/main.c
+++ b/lldb/test/API/functionalities/process_crash_info/main.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
+
 int main() {
-  int *var = malloc(sizeof(int));
+  int *var = malloc(sizeof(int)); // break here
   free(var);
   free(var);
   return 0;


### PR DESCRIPTION
This patch moves the SB API method GetExtendedCrashInformation from
SBTarget to SBProcess since it only makes sense to call this method on a
sane process which might not be the case on a SBTarget object.

It also addresses some feedbacks received after landing the first patch
for the 'crash-info' feature.

Differential Revision: https://reviews.llvm.org/D75049

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>