### PR TITLE
[lldb] Color the line marker

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -285,6 +285,10 @@ public:
 
   uint32_t GetDisassemblyLineCount() const;
 
+  llvm::StringRef GetStopShowLineMarkerAnsiPrefix() const;
+
+  llvm::StringRef GetStopShowLineMarkerAnsiSuffix() const;
+
   bool GetAutoOneLineSummaries() const;
 
   bool GetAutoIndent() const;

--- a/lldb/packages/Python/lldbsuite/test/source-manager/TestSourceManager.py
+++ b/lldb/packages/Python/lldbsuite/test/source-manager/TestSourceManager.py
@@ -93,7 +93,7 @@ class SourceManagerTestCase(TestBase):
         #    6    }
         self.expect(stream.GetData(), "Source code displayed correctly:\n" + stream.GetData(),
                     exe=False,
-                    patterns=['=> %d.*Hello world' % self.line,
+                    patterns=['=>', '%d.*Hello world' % self.line,
                               needle_regex])
 
         # Boundary condition testings for SBStream().  LLDB should not crash!

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -71,6 +71,14 @@ let Definition = "debugger" in {
     Global,
     DefaultStringValue<"${ansi.normal}">,
     Desc<"When displaying the column marker in a color-enabled (i.e. ANSI) terminal, use the ANSI terminal code specified in this format immediately after the column to be marked.">;
+  def StopShowLineMarkerAnsiPrefix: Property<"stop-show-line-ansi-prefix", "String">,
+    Global,
+    DefaultStringValue<"${ansi.fg.yellow}">,
+    Desc<"When displaying the line marker in a color-enabled (i.e. ANSI) terminal, use the ANSI terminal code specified in this format at the immediately before the line to be marked.">;
+  def StopShowLineMarkerAnsiSuffix: Property<"stop-show-line-ansi-suffix", "String">,
+    Global,
+    DefaultStringValue<"${ansi.normal}">,
+    Desc<"When displaying the line marker in a color-enabled (i.e. ANSI) terminal, use the ANSI terminal code specified in this format immediately after the line to be marked.">;
   def TerminalWidth: Property<"term-width", "SInt64">,
     Global,
     DefaultUnsignedValue<80>,

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -438,6 +438,16 @@ llvm::StringRef Debugger::GetStopShowColumnAnsiSuffix() const {
   return m_collection_sp->GetPropertyAtIndexAsString(nullptr, idx, "");
 }
 
+llvm::StringRef Debugger::GetStopShowLineMarkerAnsiPrefix() const {
+  const uint32_t idx = ePropertyStopShowLineMarkerAnsiPrefix;
+  return m_collection_sp->GetPropertyAtIndexAsString(nullptr, idx, "");
+}
+
+llvm::StringRef Debugger::GetStopShowLineMarkerAnsiSuffix() const {
+  const uint32_t idx = ePropertyStopShowLineMarkerAnsiSuffix;
+  return m_collection_sp->GetPropertyAtIndexAsString(nullptr, idx, "");
+}
+
 uint32_t Debugger::GetStopSourceLineCount(bool before) const {
   const uint32_t idx =
       before ? ePropertyStopLineCountBefore : ePropertyStopLineCountAfter;

--- a/lldb/test/Shell/Settings/TestLineMarkerColor.test
+++ b/lldb/test/Shell/Settings/TestLineMarkerColor.test
@@ -1,0 +1,17 @@
+# RUN: %clang_host -g -O0 %S/Inputs/main.c -o %t.out
+# RUN: %lldb -x -b -s %s %t.out | FileCheck %s
+settings set use-color true
+settings set stop-show-line-ansi-prefix "prefix"
+settings set stop-show-line-ansi-suffix "suffix"
+b foo
+run
+c
+settings set stop-show-line-ansi-prefix ${ansi.fg.green}
+settings set stop-show-line-ansi-suffix ${ansi.normal}
+run
+q
+
+# Check the ASCII escape code
+# CHECK-NOT: prefix->suffix
+# CHECK: ->
+# CHECK: {{.*}}->{{.*}}


### PR DESCRIPTION
Highlight the color marker similar to what we do for the column marker.
The default color matches the color of the current PC marker (->) in the
default disassembly format.

Differential revision: https://reviews.llvm.org/D75070

(cherry picked from commit 841be9854c496adb1944fbf33af055814366ec86)