### PR TITLE
[lldb][swift] Let SwiftREPL and SwiftASTContext explicitly call init …

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -270,6 +270,7 @@ lldb::REPLSP SwiftREPL::CreateInstanceFromDebugger(Status &err,
 LLDB_PLUGIN_DEFINE_ADV(SwiftREPL, ExpressionParserSwift)
 
 void SwiftREPL::Initialize() {
+  SwiftASTContext::Initialize();
   LanguageSet swift;
   swift.Insert(lldb::eLanguageTypeSwift);
   PluginManager::RegisterPlugin(ConstString("swift"), "The Swift REPL",
@@ -278,6 +279,7 @@ void SwiftREPL::Initialize() {
 
 void SwiftREPL::Terminate() {
   PluginManager::UnregisterPlugin(&CreateInstance);
+  SwiftASTContext::Terminate();
 }
 
 SwiftREPL::SwiftREPL(Target &target)

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -2247,6 +2247,7 @@ static lldb::TypeSystemSP CreateTypeSystemInstance(lldb::LanguageType language,
 
 void SwiftASTContext::Initialize() {
   LanguageSet swift;
+  SwiftLanguageRuntime::Initialize();
   swift.Insert(lldb::eLanguageTypeSwift);
   PluginManager::RegisterPlugin(GetPluginNameStatic(),
                                 "swift AST context plug-in",
@@ -2255,6 +2256,7 @@ void SwiftASTContext::Initialize() {
 
 void SwiftASTContext::Terminate() {
   PluginManager::UnregisterPlugin(CreateTypeSystemInstance);
+  SwiftLanguageRuntime::Terminate();
 }
 
 bool SwiftASTContext::SupportsLanguage(lldb::LanguageType language) {


### PR DESCRIPTION
…for swift plugins outside plugin system

SwiftLanguageRuntime and SwiftASTContext aren't part of the plugin system as they are not plugins, so
they won't receive calls from the SystemInitializerFull. This just adds the respective calls to the SwiftREPL
and SwiftASTContext which are reachable by the plugin system initializer calls. SwiftREPL initializes the
SwiftASTContext which in turn initializes the SwiftLanguageRuntime.