### PR TITLE
cherry-pick: [lldb/Test] XFAIL TestRequireHWBreakpoints when HW BPs are avialable

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/functionalities/breakpoint/require_hw_breakpoints/TestRequireHWBreakpoints.py
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/breakpoint/require_hw_breakpoints/TestRequireHWBreakpoints.py
@@ -13,6 +13,17 @@ class BreakpointLocationsTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     mydir = TestBase.compute_mydir(__file__)
 
+    def supports_hw_breakpoints(self):
+        self.build()
+        self.runCmd("file " + self.getBuildArtifact("a.out"),
+                    CURRENT_EXECUTABLE_SET)
+        self.runCmd("breakpoint set -b main --hardware")
+        self.runCmd("run")
+        print(self.res.GetOutput())
+        if 'stopped' in self.res.GetOutput():
+            return 'Hardware breakpoints are supported'
+        return None
+
     def test_breakpoint(self):
         """Test regular breakpoints when hardware breakpoints are required."""
         self.build()
@@ -25,8 +36,7 @@ class BreakpointLocationsTestCase(TestBase):
         self.assertTrue(breakpoint.IsHardware())
 
     @skipIfWindows
-    @expectedFailureAll(archs="aarch64", oslist="linux",
-                        bugnumber="https://bugs.llvm.org/show_bug.cgi?id=44055")
+    @expectedFailure(supports_hw_breakpoints)
     def test_step_range(self):
         """Test stepping when hardware breakpoints are required."""
         self.build()
@@ -48,8 +58,7 @@ class BreakpointLocationsTestCase(TestBase):
                         in error.GetCString())
 
     @skipIfWindows
-    @expectedFailureAll(archs="aarch64", oslist="linux",
-                        bugnumber="https://bugs.llvm.org/show_bug.cgi?id=44055")
+    @expectedFailure(supports_hw_breakpoints)
     def test_step_out(self):
         """Test stepping out when hardware breakpoints are required."""
         self.build()
@@ -70,8 +79,7 @@ class BreakpointLocationsTestCase(TestBase):
                         in error.GetCString())
 
     @skipIfWindows
-    @expectedFailureAll(archs="aarch64", oslist="linux",
-                        bugnumber="https://bugs.llvm.org/show_bug.cgi?id=44055")
+    @expectedFailure(supports_hw_breakpoints)
     def test_step_over(self):
         """Test stepping over when hardware breakpoints are required."""
         self.build()
@@ -90,8 +98,7 @@ class BreakpointLocationsTestCase(TestBase):
             ])
 
     @skipIfWindows
-    @expectedFailureAll(archs="aarch64", oslist="linux",
-                        bugnumber="https://bugs.llvm.org/show_bug.cgi?id=44055")
+    @expectedFailure(supports_hw_breakpoints)
     def test_step_until(self):
         """Test stepping until when hardware breakpoints are required."""
         self.build()


### PR DESCRIPTION
Resolves PR44055

=======

I'm cherry-picking this as this is failing on my machine otherwise.