### PR TITLE
[compiler-rt] Build all alias in builtin as private external on Darwin

### DIFF
--- a/compiler-rt/lib/builtins/int_lib.h
+++ b/compiler-rt/lib/builtins/int_lib.h
@@ -52,8 +52,15 @@
 #define COMPILER_RT_ALIAS(name, aliasname) \
   COMPILER_RT_ABI __typeof(name) aliasname __attribute__((__alias__(#name)));
 #elif defined(__APPLE__)
+#if defined(VISIBILITY_HIDDEN)
+#define COMPILER_RT_ALIAS_VISIBILITY(name) \
+  __asm__(".private_extern " SYMBOL_NAME(name));
+#else
+#define COMPILER_RT_ALIAS_VISIBILITY(name)
+#endif
 #define COMPILER_RT_ALIAS(name, aliasname) \
   __asm__(".globl " SYMBOL_NAME(aliasname)); \
+  COMPILER_RT_ALIAS_VISIBILITY(aliasname) \
   __asm__(SYMBOL_NAME(aliasname) " = " SYMBOL_NAME(name)); \
   COMPILER_RT_ABI __typeof(name) aliasname;
 #elif defined(_WIN32)


### PR DESCRIPTION
Summary:
For builtin compiler-rt, it is built with visibility hidden by default
to avoid the client exporting symbols from libclang static library. The
compiler option -fvisibility=hidden doesn't work on the aliases in c files
because they are created with inline assembly. On Darwin platform,
thoses aliases are exported by default if they are reference by the client.

Fix the issue by adding ".private_extern" to all the aliases if the
library is built with visibility hidden.

rdar://problem/58960296

Reviewers: dexonsmith, arphaman, delcypher, kledzik

Reviewed By: delcypher

Subscribers: dberris, jkorous, ributzka, #sanitizers, llvm-commits

Tags: #sanitizers, #llvm

Differential Revision: https://reviews.llvm.org/D73577

(cherry picked from commit 387c3f74fd8efdc0be464b0e1a8033cc1eeb739c)