### PR TITLE
[PATCH] [ODRHash] Add basic support for hashing attributes

### DIFF
--- a/clang/include/clang/AST/Attr.h
+++ b/clang/include/clang/AST/Attr.h
@@ -109,6 +109,10 @@ public:
 
   // Pretty print this attribute.
   void printPretty(raw_ostream &OS, const PrintingPolicy &Policy) const;
+
+  // Compare two attributes, used for sorting attributes in a Subject.
+  // FIXME: this should be auto generated from Attr.td
+  static bool compare(const Attr *A, const Attr *B);
 };
 
 class TypeAttr : public Attr {

--- a/clang/include/clang/AST/ODRHash.h
+++ b/clang/include/clang/AST/ODRHash.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_CLANG_AST_ODRHASH_H
 #define LLVM_CLANG_AST_ODRHASH_H
 
+#include "clang/AST/Attr.h"
 #include "clang/AST/DeclarationName.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/TemplateBase.h"
@@ -89,6 +90,10 @@ public:
   // while AddDecl does not.
   void AddSubDecl(const Decl *D);
 
+  // Process attributes attached to a type that is being hashed.
+  void AddAttrs(const NamedDecl *D);
+  void AddAttr(const Attr *A);
+
   // Reset the object for reuse.
   void clear();
 
@@ -111,6 +116,7 @@ public:
   void AddBoolean(bool value);
 
   static bool isWhitelistedDecl(const Decl* D, const DeclContext *Parent);
+  static bool isWhitelistedAttr(const Attr *A);
 
 private:
   void AddDeclarationNameImpl(DeclarationName Name);

--- a/clang/include/clang/Basic/DiagnosticSerializationKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSerializationKinds.td
@@ -285,6 +285,7 @@ def err_module_odr_violation_mismatch_decl_diff : Error<
     " property attribute|"
   "%select{no|'required'|'optional'}4 %select{property|method}5 control|"
   "with %ordinal4 protocol named %5|"
+  "%select{no attribute|%5}4|"
   "}3">;
 
 def note_module_odr_violation_mismatch_decl_diff : Note<"but in '%0' found "
@@ -368,6 +369,7 @@ def note_module_odr_violation_mismatch_decl_diff : Note<"but in '%0' found "
   "no written or default attribute for property|"
   "%select{no|'required'|'optional'}2 %select{property|method}3 control|"
   "with %ordinal2 protocol named %3|"
+  "%select{no attribute|%3}2|"
   "}1">;
 
 def err_module_odr_violation_function : Error<

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -174,6 +174,7 @@ BENIGN_LANGOPT(ModulesErrorRecovery, 1, 1, "automatically importing modules as n
 BENIGN_LANGOPT(ImplicitModules, 1, 1, "building modules that are not specified via -fmodule-file")
 COMPATIBLE_LANGOPT(ModulesLocalVisibility, 1, 0, "local submodule visibility")
 COMPATIBLE_LANGOPT(ModulesHashErrorDiags, 1, 0, "hash out diagnostic errors as part of the module hash")
+COMPATIBLE_LANGOPT(ODRCheckAttributes, 1, 0, "enable ODR hash checking for attributes")
 COMPATIBLE_LANGOPT(Optimize          , 1, 0, "__OPTIMIZE__ predefined macro")
 COMPATIBLE_LANGOPT(OptimizeSize      , 1, 0, "__OPTIMIZE_SIZE__ predefined macro")
 COMPATIBLE_LANGOPT(Static            , 1, 0, "__STATIC__ predefined macro (as opposed to __DYNAMIC__)")

--- a/clang/include/clang/Driver/CC1Options.td
+++ b/clang/include/clang/Driver/CC1Options.td
@@ -574,6 +574,9 @@ def ftest_module_file_extension_EQ :
            "The argument is parsed as blockname:major:minor:hashed:user info">;
 def fconcepts_ts : Flag<["-"], "fconcepts-ts">,
   HelpText<"Enable C++ Extensions for Concepts.">;
+def fodr_hash_attributes:
+  Flag<["-"], "fodr-hash-attributes">,
+  HelpText<"Enable ODR hash checking for attributes ">;
 
 let Group = Action_Group in {
 

--- a/clang/lib/AST/AttrImpl.cpp
+++ b/clang/lib/AST/AttrImpl.cpp
@@ -17,3 +17,33 @@
 using namespace clang;
 
 #include "clang/AST/AttrImpl.inc"
+
+// FIXME: this should be auto generated from Attr.td
+bool Attr::compare(const Attr *A, const Attr *B) {
+  if (A->getKind() != B->getKind())
+    return A->getKind() < B->getKind();
+
+  switch (A->getKind()) {
+  case attr::ObjCBridge: {
+    auto *MA = cast<ObjCBridgeAttr>(A);
+    auto *MB = cast<ObjCBridgeAttr>(B);
+    if (!MA->getBridgedType())
+      return true;
+    if (!MB->getBridgedType())
+      return false;
+    return MA->getBridgedType()->getName() < MB->getBridgedType()->getName();
+  }
+  case attr::ObjCBridgeMutable: {
+    auto *MA = cast<ObjCBridgeMutableAttr>(A);
+    auto *MB = cast<ObjCBridgeMutableAttr>(B);
+    if (!MA->getBridgedType())
+      return true;
+    if (!MB->getBridgedType())
+      return false;
+    return MA->getBridgedType()->getName() < MB->getBridgedType()->getName();
+  }
+  default:
+    llvm_unreachable("Not implemented");
+  }
+  return false;
+}

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2928,6 +2928,7 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   Opts.ModulesLocalVisibility =
       Args.hasArg(OPT_fmodules_local_submodule_visibility) || Opts.ModulesTS ||
       Opts.CPlusPlusModules;
+  Opts.ODRCheckAttributes = Args.hasArg(OPT_fodr_hash_attributes);
   Opts.ModulesCodegen = Args.hasArg(OPT_fmodules_codegen);
   Opts.ModulesDebugInfo = Args.hasArg(OPT_fmodules_debuginfo);
   Opts.ModulesHashErrorDiags = Args.hasArg(OPT_fmodules_hash_error_diagnostics);

--- a/clang/test/Modules/odr_hash-attributes.c
+++ b/clang/test/Modules/odr_hash-attributes.c
@@ -1,0 +1,69 @@
+// Clear and create directories
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: mkdir %t/cache
+// RUN: mkdir %t/Inputs
+
+// Build first header file
+// RUN: echo "#define FIRST" >> %t/Inputs/first.h
+// RUN: cat %s               >> %t/Inputs/first.h
+
+// Build second header file
+// RUN: echo "#define SECOND" >> %t/Inputs/second.h
+// RUN: cat %s                >> %t/Inputs/second.h
+
+// Test that each header can compile
+// RUN: %clang_cc1 -fsyntax-only -x c %t/Inputs/first.h -fblocks -fobjc-arc -Wno-objc-root-class
+// RUN: %clang_cc1 -fsyntax-only -x c %t/Inputs/second.h -fblocks -fobjc-arc -Wno-objc-root-class
+
+// Build module map file
+// RUN: echo "module FirstModule {"     >> %t/Inputs/module.map
+// RUN: echo "    header \"first.h\""   >> %t/Inputs/module.map
+// RUN: echo "}"                        >> %t/Inputs/module.map
+// RUN: echo "module SecondModule {"    >> %t/Inputs/module.map
+// RUN: echo "    header \"second.h\""  >> %t/Inputs/module.map
+// RUN: echo "}"                        >> %t/Inputs/module.map
+
+// Run test
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache -x c -I%t/Inputs -verify %s -fblocks -fobjc-arc -Wno-objc-root-class -fodr-hash-attributes
+
+#if !defined(FIRST) && !defined(SECOND)
+#include "first.h"
+#include "second.h"
+#endif
+
+#if defined(FIRST) || defined(SECOND)
+#endif
+
+#if defined(FIRST)
+typedef struct __attribute__((objc_bridge_mutable(NSMutableDictionary))) __CFDictionary *CFMutableDictionaryRef;
+typedef struct __CFArray *CFMutableArrayRef;
+typedef struct __attribute__ ((objc_bridge(NSError))) __CFErrorRef *CFErrorRef;
+typedef struct __attribute__ ((objc_bridge(NSSomething), objc_bridge_mutable(NSMutableSomething)))  __CFSomethingRef *CFSomethingRef;
+#elif defined(SECOND)
+typedef struct __CFDictionary *CFMutableDictionaryRef;
+typedef struct __attribute__((objc_bridge_mutable(NSMutableArray))) __CFArray *CFMutableArrayRef;
+typedef struct __attribute__ ((objc_bridge(NSOtherError))) __CFErrorRef *CFErrorRef;
+// This shouldn't trigger ODR -> order does not matter.
+typedef struct __attribute__ ((objc_bridge_mutable(NSMutableSomething), objc_bridge(NSSomething)))  __CFSomethingRef *CFSomethingRef;
+#else
+CFMutableDictionaryRef D;
+CFMutableArrayRef A;
+CFErrorRef E;
+CFSomethingRef S;
+// expected-error@first.h:* {{'__CFDictionary' has different definitions in different modules; first difference is definition in module 'FirstModule' found  __attribute__((objc_bridge_mutable(NSMutableDictionary)))}}
+// expected-note@second.h:* {{but in 'SecondModule' found no attribute}}
+// expected-error@first.h:* {{'__CFArray' has different definitions in different modules; first difference is definition in module 'FirstModule' found no attribute}}
+// expected-note@second.h:* {{but in 'SecondModule' found  __attribute__((objc_bridge_mutable(NSMutableArray)))}}
+// expected-error@first.h:* {{'__CFErrorRef' has different definitions in different modules; first difference is definition in module 'FirstModule' found  __attribute__((objc_bridge(NSError)))}}
+// expected-note@second.h:* {{but in 'SecondModule' found  __attribute__((objc_bridge(NSOtherError)))}}
+#endif
+
+// Keep macros contained to one file.
+#ifdef FIRST
+#undef FIRST
+#endif
+
+#ifdef SECOND
+#undef SECOND
+#endif


### PR DESCRIPTION
- Add overall capabilities for attributes. Since attributes are very
  different, lets add a few more before using tablegen.
- This adds only a selected few: objc_bridge and obj_bridge_mutable.
- Disabled by default, since it turns out this catches too many issues.
  Can be enabled with -fodr-hash-attributes.

Note that clang already odr diagnose other attributes in ObjC already:
designated initializers, direct methods, etc.

rdar://problem/57203473