### PR TITLE
[modules] Allow frameworks to have only a private module without a public one.

### DIFF
--- a/clang/lib/Lex/HeaderSearch.cpp
+++ b/clang/lib/Lex/HeaderSearch.cpp
@@ -1567,6 +1567,16 @@ HeaderSearch::lookupModuleMapFile(const DirectoryEntry *Dir, bool IsFramework) {
   llvm::sys::path::append(ModuleMapFileName, "module.map");
   if (auto F = FileMgr.getFile(ModuleMapFileName))
     return *F;
+
+  // For frameworks, allow to have a private module map with a preferred
+  // spelling when a public module map is absent.
+  if (IsFramework) {
+    ModuleMapFileName = Dir->getName();
+    llvm::sys::path::append(ModuleMapFileName, "Modules",
+                            "module.private.modulemap");
+    if (auto F = FileMgr.getFile(ModuleMapFileName))
+      return *F;
+  }
   return nullptr;
 }
 

--- a/clang/test/Modules/Inputs/implicit-private-without-public/DeprecatedModuleMapLocation.framework/PrivateHeaders/A.h
+++ b/clang/test/Modules/Inputs/implicit-private-without-public/DeprecatedModuleMapLocation.framework/PrivateHeaders/A.h
@@ -1,0 +1,1 @@
+void a(void);

--- a/clang/test/Modules/Inputs/implicit-private-without-public/DeprecatedModuleMapLocation.framework/module_private.map
+++ b/clang/test/Modules/Inputs/implicit-private-without-public/DeprecatedModuleMapLocation.framework/module_private.map
@@ -1,0 +1,4 @@
+framework module DeprecatedModuleMapLocation_Private {
+  header "A.h"
+  export *
+}

--- a/clang/test/Modules/Inputs/implicit-private-without-public/Foo.framework/Modules/module.private.modulemap
+++ b/clang/test/Modules/Inputs/implicit-private-without-public/Foo.framework/Modules/module.private.modulemap
@@ -1,0 +1,4 @@
+framework module Foo_Private {
+  header "Foo_Priv.h"
+  export *
+}

--- a/clang/test/Modules/Inputs/implicit-private-without-public/Foo.framework/PrivateHeaders/Foo_Priv.h
+++ b/clang/test/Modules/Inputs/implicit-private-without-public/Foo.framework/PrivateHeaders/Foo_Priv.h
@@ -1,0 +1,1 @@
+void foo_private(void);

--- a/clang/test/Modules/implicit-private-without-public.m
+++ b/clang/test/Modules/implicit-private-without-public.m
@@ -1,0 +1,11 @@
+// REQUIRES: shell
+// RUN: rm -rf %t
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t \
+// RUN:   -F%S/Inputs/implicit-private-without-public \
+// RUN:   -fsyntax-only %s -verify
+
+@import Foo_Private;
+
+// Private module map without a public one isn't supported for deprecated module map locations.
+@import DeprecatedModuleMapLocation_Private;
+// expected-error@-1{{module 'DeprecatedModuleMapLocation_Private' not found}}


### PR DESCRIPTION
Support only preferred spelling 'Modules/module.private.modulemap' and
not the deprecated 'module_private.map'.

rdar://problem/57715533

Reviewed By: bruno

Differential Revision: https://reviews.llvm.org/D75311

(cherry picked from commit 4069dd14124e9a84b46f48153d4fbc4da811a45e)