### PR TITLE
[lldb/testsuite] Skip 2 tests failing on arm64e

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/commands/target/basic/TestTargetCommand.py
+++ b/lldb/packages/Python/lldbsuite/test/commands/target/basic/TestTargetCommand.py
@@ -44,6 +44,7 @@ class targetCommandTestCase(TestBase):
         self.buildAll()
         self.do_target_command()
 
+    @expectedFailureAll(archs=['arm64e']) # <rdar://problem/37773624>
     def test_target_variable_command(self):
         """Test 'target variable' command before and after starting the inferior."""
         d = {'C_SOURCES': 'globals.c', 'EXE': self.getBuildArtifact('globals')}
@@ -52,6 +53,7 @@ class targetCommandTestCase(TestBase):
 
         self.do_target_variable_command('globals')
 
+    @expectedFailureAll(archs=['arm64e']) # <rdar://problem/37773624>
     def test_target_variable_command_no_fail(self):
         """Test 'target variable' command before and after starting the inferior."""
         d = {'C_SOURCES': 'globals.c', 'EXE': self.getBuildArtifact('globals')}

--- a/lldb/packages/Python/lldbsuite/test/lang/c/global_variables/TestGlobalVariables.py
+++ b/lldb/packages/Python/lldbsuite/test/lang/c/global_variables/TestGlobalVariables.py
@@ -21,6 +21,7 @@ class GlobalVariablesTestCase(TestBase):
         self.shlib_names = ["a"]
 
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764")
+    @expectedFailureAll(archs=["arm64e"]) # <rdar://problem/37773624>
     def test_without_process(self):
         """Test that static initialized variables can be inspected without
         process."""


### PR DESCRIPTION
LLDB doesn't know how to parse the arm64e chained relocs, thus those tests
are failling when run remotely on a device. As examining global variables
without a runnin process is not a very common operation, let's just xfail
those for know.

This is in spirit a cherry-pick of 0159c21119ed and 2560a93b706 by
Davide, but it was done manually beacuse files have moved around
upstream.