### PR TITLE
[lldb][upstreaming] Revert duplicated downstream code in UserExpression

### DIFF
--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -220,16 +220,6 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
       language = frame->GetLanguage();
   }
 
-  // If the language was not specified in the expression command,
-  // set it to the language in the target's properties if
-  // specified, else default to the langage for the frame.
-  if (language == lldb::eLanguageTypeUnknown) {
-    if (target->GetLanguage() != lldb::eLanguageTypeUnknown)
-      language = target->GetLanguage();
-    else if (StackFrame *frame = exe_ctx.GetFramePtr())
-      language = frame->GetLanguage();
-  }
-
   lldb::UserExpressionSP user_expression_sp(
       target->GetUserExpressionForLanguage(expr, full_prefix, language,
                                            desired_type, options, ctx_obj,


### PR DESCRIPTION
The same code already exists directly above so so we can remove the
duplicated downstream code.