### PR TITLE
[clang][scan-deps] Always use the raw module format.

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -122,6 +122,12 @@ public:
     Compiler.setFileManager(FileMgr);
     Compiler.createSourceManager(*FileMgr);
 
+    // Only clang -cc1 and c-index-test register the object module loader, so
+    // force it to use the raw AST format. This avoids the requirement to link
+    // against the LLVM target backends, and the object format is useless
+    // anyway for scanning as no debug info or code gets generated.
+    Compiler.getHeaderSearchOpts().ModuleFormat = "raw";
+
     // Create the dependency collector that will collect the produced
     // dependencies.
     //

--- a/clang/test/ClangScanDeps/Inputs/modules_cdb.json
+++ b/clang/test/ClangScanDeps/Inputs/modules_cdb.json
@@ -1,7 +1,7 @@
 [
 {
   "directory": "DIR",
-  "command": "clang -E DIR/modules_cdb_input2.cpp -IInputs -D INCLUDE_HEADER2 -MD -MF DIR/modules_cdb2.d -fmodules -fcxx-modules -fmodules-cache-path=DIR/module-cache -fimplicit-modules -fimplicit-module-maps",
+  "command": "clang -E DIR/modules_cdb_input2.cpp -IInputs -D INCLUDE_HEADER2 -MD -MF DIR/modules_cdb2.d -fmodules -fcxx-modules -fmodules-cache-path=DIR/module-cache -fimplicit-modules -fimplicit-module-maps -gmodules",
   "file": "DIR/modules_cdb_input2.cpp"
 },
 {


### PR DESCRIPTION
Only clang -cc1 and c-index-test support the object format used by
-gmodules. clang-scan-deps and libclang.{dll,dylib,so} don't. It's
also not useful during the scan as the scan doesn't generate any debug
info or code.

This patch forces the format to raw for all scanning jobs.

rdar://59353281