### PR TITLE
Fix CreateExceptionResolver API

### DIFF
--- a/lldb/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/lldb/include/lldb/Target/SwiftLanguageRuntime.h
@@ -202,7 +202,7 @@ public:
                                 Value::ValueType &value_type) override;
   TypeAndOrName FixUpDynamicType(const TypeAndOrName &type_and_or_name,
                                  ValueObject &static_value) override;
-  lldb::BreakpointResolverSP CreateExceptionResolver(Breakpoint *bkpt,
+  lldb::BreakpointResolverSP CreateExceptionResolver(const lldb::BreakpointSP &bkpt,
                                                      bool catch_bp,
                                                      bool throw_bp) override;
   bool CouldHaveDynamicValue(ValueObject &in_value) override;

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -161,7 +161,7 @@ FindSymbolForSwiftObject(Process &process, RuntimeKind runtime_kind,
 }
 
 static lldb::BreakpointResolverSP
-CreateExceptionResolver(Breakpoint *bkpt, bool catch_bp, bool throw_bp) {
+CreateExceptionResolver(const lldb::BreakpointSP &bkpt, bool catch_bp, bool throw_bp) {
   BreakpointResolverSP resolver_sp;
 
   if (throw_bp)
@@ -1727,7 +1727,7 @@ llvm::Optional<Value> SwiftLanguageRuntime::GetErrorReturnLocationBeforeReturn(
 }
 
 lldb::BreakpointResolverSP
-SwiftLanguageRuntime::CreateExceptionResolver(Breakpoint *bkpt, bool catch_bp,
+SwiftLanguageRuntime::CreateExceptionResolver(const lldb::BreakpointSP &bkpt, bool catch_bp,
                                               bool throw_bp) {
   return ::CreateExceptionResolver(bkpt, catch_bp, throw_bp);
 }


### PR DESCRIPTION
https://github.com/apple/llvm-project/commit/6c17cc531f9f4ee94f2298200fc4813c02999d78 updated the base LanguageRuntime class to accept a weak pointer. Fix up the Swift class to use it, too. 