### PR TITLE
[CodeGen] Avoid applying an offset to a constant function lvalue when…

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -1483,8 +1483,11 @@ CodeGenFunction::tryEmitAsConstant(DeclRefExpr *refExpr) {
     return ConstantEmission();
 
   // Emit as a constant.
-  auto C = ConstantEmitter(*this).emitAbstract(refExpr->getLocation(),
-                                               result.Val, resultType);
+  // Try to emit as a constant.
+  llvm::Constant *C =
+      ConstantEmitter(*this).tryEmitAbstract(result.Val, resultType);
+  if (!C)
+    return ConstantEmission();
 
   // Make sure we emit a debug reference to the global variable.
   // This should probably fire even for

--- a/clang/lib/CodeGen/CGExprConstant.cpp
+++ b/clang/lib/CodeGen/CGExprConstant.cpp
@@ -1905,13 +1905,25 @@ ConstantLValueEmitter::tryEmitBase(const APValue::LValueBase &base) {
       return CGM.GetWeakRefReference(D).getPointer();
 
     if (auto FD = dyn_cast<FunctionDecl>(D)) {
+      llvm::Constant *C = CGM.getRawFunctionPointer(FD);
       if (auto pointerAuth = DestType.getPointerAuth()) {
-        llvm::Constant *C = CGM.getRawFunctionPointer(FD);
         C = applyOffset(C);
         C = tryEmitConstantSignedPointer(C, pointerAuth);
         return ConstantLValue(C, /*applied offset*/ true, /*signed*/ true);
       }
-      return CGM.getFunctionPointer(FD);
+
+      if (CGPointerAuthInfo AuthInfo =
+              CGM.getFunctionPointerAuthInfo(DestType)) {
+        if (hasNonZeroOffset())
+          return ConstantLValue(nullptr);
+        C = CGM.getConstantSignedPointer(
+            C, AuthInfo.getKey(),
+            /*storageAddress=*/nullptr,
+            cast_or_null<llvm::Constant>(AuthInfo.getDiscriminator()));
+        return ConstantLValue(C, /*AppliedOffset=*/true, /*Signed=*/true);
+      }
+
+      return ConstantLValue(C);
     }
 
     if (auto VD = dyn_cast<VarDecl>(D)) {

--- a/clang/test/CodeGen/ptrauth-function-init-fail.c
+++ b/clang/test/CodeGen/ptrauth-function-init-fail.c
@@ -1,0 +1,5 @@
+// RUN: %clang_cc1 -triple arm64e-apple-ios -fptrauth-calls %s -verify -emit-llvm
+
+void f(void);
+
+int *pf = (int *)&f + 1; // expected-error{{cannot compile this static initializer yet}}

--- a/clang/test/CodeGen/ptrauth-function-init.c
+++ b/clang/test/CodeGen/ptrauth-function-init.c
@@ -1,0 +1,33 @@
+// RUN: %clang_cc1 %s       -triple arm64e-apple-ios13 -fptrauth-calls -fptrauth-intrinsics -disable-llvm-passes -emit-llvm -o- | FileCheck %s
+// RUN: %clang_cc1 -xc++ %s -triple arm64e-apple-ios13 -fptrauth-calls -fptrauth-intrinsics -disable-llvm-passes -emit-llvm -o- | FileCheck %s --check-prefixes=CHECK,CXX
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void f(void);
+
+// CHECK: @f.ptrauth = private constant { i8*, i32, i64, i64 } { i8* bitcast (void ()* @f to i8*), i32 0, i64 0, i64 0 }, section "llvm.ptrauth"
+
+#ifdef __cplusplus
+
+// CXX-LABEL: define internal void @__cxx_global_var_init()
+// CXX: store void ()* bitcast (i32* getelementptr inbounds (i32, i32* bitcast ({ i8*, i32, i64, i64 }* @f.ptrauth to i32*), i64 2) to void ()*), void ()** @_ZL2fp, align 8
+
+__attribute__((used))
+void (*const fp)(void) = (void (*)(void))((int *)&f + 2); // Error in C mode.
+
+#endif
+
+// CHECK-LABEL: define void @t1()
+void t1() {
+  // CHECK: [[PF:%.*]] = alloca void ()*
+  // CHECK: store void ()* bitcast (i32* getelementptr inbounds (i32, i32* bitcast ({ i8*, i32, i64, i64 }* @f.ptrauth to i32*), i64 2) to void ()*), void ()** [[PF]]
+
+  void (*pf)(void) = (void (*)(void))((int *)&f + 2);
+  (void)pf;
+}
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
… ptrauth is enabled

These are unrepresentable in relocations, so prefer generating dynamic
initializers in C++, or erroring out early otherwise.

rdar://problem/60052657