### PR TITLE
Re-apply "Avoid the need for LEVEL= makefile boilerplate" for Swift

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/benchmarks/swiftdictionary/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/benchmarks/swiftdictionary/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/functionalities/asan/swift/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/asan/swift/Makefile
@@ -1,7 +1,5 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 SWIFTFLAGS += -sanitize=address

--- a/lldb/packages/Python/lldbsuite/test/functionalities/breakpoint/swift_exception/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/breakpoint/swift_exception/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/functionalities/data-formatter/swift-typealias/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/data-formatter/swift-typealias/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/functionalities/mtc/swift-property/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/mtc/swift-property/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/functionalities/mtc/swift/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/mtc/swift/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/functionalities/swift-runtime-reporting/abi-v2/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/swift-runtime-reporting/abi-v2/Makefile
@@ -1,8 +1,6 @@
-LEVEL = ../../../make
-
 DYLIB_NAME := swiftCore
 DYLIB_CXX_SOURCES := library.cpp
 
 CXX_SOURCES := main.cpp
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/functionalities/swift-runtime-reporting/exclusivity-violation/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/swift-runtime-reporting/exclusivity-violation/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/functionalities/swift-runtime-reporting/objc-inference/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/swift-runtime-reporting/objc-inference/Makefile
@@ -1,7 +1,5 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 SWIFTFLAGS += -Xfrontend -enable-swift3-objc-inference

--- a/lldb/packages/Python/lldbsuite/test/functionalities/tsan/swift-access-race/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/tsan/swift-access-race/Makefile
@@ -1,7 +1,5 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 SWIFTFLAGS += -sanitize=thread

--- a/lldb/packages/Python/lldbsuite/test/functionalities/tsan/swift/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/functionalities/tsan/swift/Makefile
@@ -1,7 +1,5 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 SWIFTFLAGS += -sanitize=thread

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/accelerate_simd/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/accelerate_simd/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/address_of/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/address_of/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/any/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/any/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/any_object/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/any_object/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/anytype_array/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/anytype_array/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/archetype_resolution/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/archetype_resolution/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/archetype_resolution_subclass/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/archetype_resolution_subclass/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/array_element/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/array_element/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/array_enum/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/array_enum/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/array_tuple_resilient/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/array_tuple_resilient/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/associated_self_type/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/associated_self_type/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/associated_type_resolution/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/associated_type_resolution/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/availability/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/availability/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/backwards_compatibility/simple/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/backwards_compatibility/simple/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/break_by_partial_name/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/break_by_partial_name/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/bridged_metatype/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/bridged_metatype/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/bt_printing/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/bt_printing/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/bridging_header_headermap/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/bridging_header_headermap/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 SWIFT_OBJC_INTEROP := 1
 SWIFT_SOURCES := main.swift
 MAKE_DSYM := NO
@@ -14,7 +13,7 @@ all: libdylib.dylib a.out
 # but it is in a different directory. We are using a headermap to
 # switch between the two versions of "Foo.h" during build time.
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 libdylib.dylib: dylib.swift
 	$(MAKE) MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/bridging_header_headermap/dylib.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/bridging_header_headermap/dylib.mk
@@ -1,6 +1,5 @@
-LEVEL = ../../../../make
 DYLIB_ONLY := YES
 DYLIB_NAME := $(BASENAME)
 DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/Makefile
@@ -1,11 +1,10 @@
-LEVEL = ../../../../make
 SWIFT_OBJC_INTEROP := 1
 SWIFT_SOURCES := main.swift
 SWIFTFLAGS_EXTRAS := -Xcc -DDEBUG=1 -Xcc -DSPACE -Xcc -UNDEBUG -I. -L. -lDylib
 
 all: libDylib.dylib a.out
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 libDylib.dylib: dylib.swift
 	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/dylib.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/dylib.mk
@@ -1,8 +1,7 @@
-LEVEL = ../../../../make
 SWIFT_OBJC_INTEROP := 1
 DYLIB_SWIFT_SOURCES := dylib.swift
 DYLIB_NAME := Dylib
 
 SWIFTFLAGS_EXTRAS = -Xcc -DDEBUG=1 -Xcc -D -Xcc SPACE -Xcc -U -Xcc NDEBUG
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES=main.swift
 SWIFT_OBJC_INTEROP := 1
 LD_EXTRAS=-lDylib -lConflict -L$(shell pwd)
@@ -6,7 +5,7 @@ SWIFTFLAGS_EXTRAS= -Xcc -I$(SRCDIR)/hidden/Bar -I. -import-objc-header $(SRCDIR)
 
 all: libDylib.dylib libConflict.dylib a.out
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 # This testcase causes the scratch context to get destroyed by a
 # conflict that is triggered via dynamic type resolution. The two

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/dylib.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/dylib.mk
@@ -1,7 +1,6 @@
-LEVEL = ../../../../make
 DYLIB_ONLY := YES
 DYLIB_NAME := $(BASENAME)
 DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
 SWIFT_OBJC_INTEROP := 1
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/extra_clang_flags/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/extra_clang_flags/Makefile
@@ -1,7 +1,6 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 SWIFTFLAGS += -I$(SRCDIR)
 SWIFTFLAGS += -import-objc-header $(SRCDIR)/bridging-header.h

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/headermap_conflict/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/headermap_conflict/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 SWIFT_OBJC_INTEROP := 1
 SWIFT_SOURCES := main.swift
 SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR) -Xcc -I$(SRCDIR)/Bar -I.
@@ -12,7 +11,7 @@ LD_EXTRAS := -ldylib -L$(shell pwd)
 
 all: libdylib.dylib a.out
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 libdylib.dylib: dylib.swift
 	$(MAKE) MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/headermap_conflict/dylib.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/headermap_conflict/dylib.mk
@@ -1,7 +1,6 @@
-LEVEL = ../../../../make
 DYLIB_ONLY := YES
 DYLIB_NAME := $(BASENAME)
 DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
 SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR)/foo.hmap  -Xcc -I$(SRCDIR)
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES = main.swift
 SWIFT_OBJC_INTEROP := 1
 LD_EXTRAS = -ldylib -L$(BUILDDIR)
@@ -11,7 +10,7 @@ LD_EXTRAS = -ldylib -L$(BUILDDIR)
 
 all: libdylib.dylib a.out
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 SWIFTFLAGS += -Xcc -I$(SRCDIR)/Bar -I. -Xcc -I$(SRCDIR)/Foo
 
 libdylib.dylib: dylib.swift

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/dylib.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/dylib.mk
@@ -1,7 +1,6 @@
-LEVEL = ../../../../make
 DYLIB_ONLY := YES
 DYLIB_NAME := $(BASENAME)
 DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
 SWIFT_OBJC_INTEROP := 1
 SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR) -Xcc -I$(SRCDIR)/Foo
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/macro_conflict/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/macro_conflict/Makefile
@@ -1,11 +1,10 @@
-LEVEL = ../../../../make
 SRCDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 SWIFT_OBJC_INTEROP := 1
 
 # This test builds an Objective-C main program that imports two Swift
 # .dylibs with conflicting -D macro definitions.
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 a.out: main.m libFoo.dylib libBar.dylib
 	$(CC) $(CFLAGS) $(MANDATORY_MODULE_BUILD_CFLAGS) -I$(shell pwd) -lFoo -lBar -L$(shell pwd) -o $@ $<

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/macro_conflict/dylib.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/macro_conflict/dylib.mk
@@ -1,8 +1,7 @@
-LEVEL = ../../../../make
 DYLIB_ONLY := YES
 DYLIB_NAME := $(BASENAME)
 DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
 SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR) -Xcc -I$(SRCDIR)/$(BASENAME) \
   -emit-objc-header-path $(BASENAME).h -Xcc -DSTRUCTNAME=C$(BASENAME)
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Makefile
@@ -1,10 +1,9 @@
-LEVEL = ../../../../make
 SWIFT_OBJC_INTEROP := 1
 
 # This test builds an Objective-C main program that imports two Swift
 # .dylibs with conflicting ClangImporter search paths.
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 a.out: main.m libFoo.dylib libBar.dylib
 	$(CC) $(CFLAGS) $(MANDATORY_MODULE_BUILD_CFLAGS) -I$(shell pwd) -lFoo -lBar -L$(shell pwd) -o $@ $<

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/Makefile
@@ -1,10 +1,9 @@
-LEVEL = ../../../../make
 SWIFT_OBJC_INTEROP := 1
 
 # This test builds an Objective-C main program that imports two Swift
 # .dylibs with conflicting ClangImporter search paths.
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 a.out: main.m libFoo.dylib libBar.dylib
 	$(CC) $(CFLAGS) $(MANDATORY_MODULE_BUILD_CFLAGS) -I$(shell pwd) -lFoo -lBar -L$(shell pwd) -o $@ $<

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/dylib.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/dylib.mk
@@ -1,10 +1,9 @@
-LEVEL = ../../../../make
 DYLIB_ONLY := YES
 DYLIB_NAME := $(BASENAME)
 DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
 SWIFT_OBJC_INTEROP := 1
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 SWIFTFLAGS += -Xcc -I$(SRCDIR) \
   -emit-objc-header-path $(DYLIB_NAME)-Swift.h \

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 OBJC_SOURCES := main.m
 LD_EXTRAS = -lFoo -lBar -L$(BUILDDIR)
 CFLAGS_EXTRAS = -I$(BUILDDIR) -fmodules
@@ -9,7 +7,7 @@ CFLAGS_EXTRAS = -I$(BUILDDIR) -fmodules
 
 all: libFoo.dylib libBar.dylib a.out
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 lib%.dylib: %.swift
 	$(MAKE) MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/dylib.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/dylib.mk
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 DYLIB_ONLY := YES
 DYLIB_NAME := $(BASENAME)
 DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
@@ -8,4 +7,4 @@ SWIFTFLAGS_EXTRAS = \
 
 SWIFT_OBJC_INTEROP := 1
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/remoteast_import/Library.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/remoteast_import/Library.mk
@@ -1,8 +1,7 @@
-LEVEL = ../../../../make
 DYLIB_SWIFT_SOURCES := Library.swift
 DYLIB_NAME := Library
 DYLIB_ONLY := YES
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 SWIFTFLAGS += -I.

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/remoteast_import/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/remoteast_import/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 SRCDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 SWIFT_SOURCES := main.swift
 # This Makefile overwrites the default rules.
@@ -6,7 +5,7 @@ EXE := a.out
 
 all: libLibrary a.out
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 SWIFTFLAGS += -I. -Xcc -DSYNTAX_ERROR=1
 LD_EXTRAS += -lLibrary -L.

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Makefile
@@ -1,7 +1,6 @@
-LEVEL = ../../../../make
 SWIFT_OBJC_INTEROP := 1
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 BUILDDIR := $(realpath $(shell pwd))
 BOTDIR := $(BUILDDIR)/buildbot

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/dylib.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/dylib.mk
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 DYLIB_ONLY := YES
 DYLIB_NAME := $(BASENAME)
 DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
@@ -13,4 +12,4 @@ SWIFTFLAGS_EXTRAS = \
 	    -import-objc-header $(BOTDIR)/Foo/bridge.h \
 	    -Xcc -ivfsoverlay -Xcc buildbot/Foo/overlay.yaml
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 SWIFT_OBJC_INTEROP := 1
 # This Makefile overwrites the default rules.
 USESWIFTDRIVER := 0
@@ -9,7 +8,7 @@ all: a.out
 # This test builds an Objective-C main program that imports two Swift
 # .dylibs with conflicting ClangImporter search paths.
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 a.out: main.o
 	$(SWIFTC) $(SWIFTFLAGS) $< -lFoo -lBar -L$(shell pwd) -o $@ \

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/class_empty/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/class_empty/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/class_error/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/class_error/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/class_static/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/class_static/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/closure_shortcuts/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/closure_shortcuts/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/closures/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/closures/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/conditional_breakpoints/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/conditional_breakpoints/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/cross_module_extension/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/cross_module_extension/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 EXE=main
 SWIFT_SOURCES=main.swift
 LD_EXTRAS=-lmoda -lmodb -L$(shell pwd)
@@ -7,7 +5,7 @@ SWIFTFLAGS_EXTRAS=-I$(shell pwd)
 
 all: libmoda.dylib libmodb.dylib main
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 
 libmoda.dylib: moda.swift

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/cross_module_extension/dylib.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/cross_module_extension/dylib.mk
@@ -1,7 +1,6 @@
-LEVEL = ../../../make
 DYLIB_ONLY := YES
 DYLIB_NAME := $(BASENAME)
 DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
 SWIFTFLAGS_EXTRAS = -I$(shell pwd)
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/custom_triple/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/custom_triple/Makefile
@@ -1,7 +1,5 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 TRIPLE := x86_64-awesomevendor-linux
 SWIFTFLAGS_EXTRAS := -parse-stdlib
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/debug_prefix_map/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/debug_prefix_map/Makefile
@@ -1,8 +1,6 @@
-LEVEL = ../../../make
-
 all: a.out
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 a.out: main.swift
 	# A common use case for -debug-prefix-map is to invoke the compiler such

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/delayed_parsing_crash/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/delayed_parsing_crash/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/deployment_target/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/deployment_target/Makefile
@@ -1,8 +1,6 @@
-LEVEL = ../../../make
-
 all: a.out dlopen_module
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 # This test only works on macOS 10.11+.
 

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/deserialization_failure/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/deserialization_failure/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/different_clang_flags/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/different_clang_flags/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 EXE := main
 SWIFT_SOURCES := main.swift
 SWIFTFLAGS_EXTRAS = -I$(BUILDDIR) -I$(SRCDIR)/moda_dir/cdeps -I$(SRCDIR)/modb_dir/cdeps
@@ -7,7 +5,7 @@ LD_EXTRAS = -L$(BUILDDIR) -lmoda -lmodb
 
 all: libmoda.dylib libmodb.dylib main
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 lib%.dylib:
 	$(MAKE) -f $(MAKEFILE_RULES) VPATH=$(VPATH)/$*_dir \

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/BridgingPCH/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/BridgingPCH/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
 # Hack to force the bridging-header.pch rule to be built before everything else.
@@ -11,7 +9,7 @@ bridging-header.pch: bridging-header.h
 
 SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)/include
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 clean::
 	rm -rf bridging-header.pch

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/C/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/C/Makefile
@@ -1,6 +1,4 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 SWIFTFLAGS_EXTRAS := -I$(shell pwd)/include -Xcc -I$(shell pwd)/include
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/Makefile
@@ -1,9 +1,7 @@
-LEVEL = ../../../../make
-
 MAKE_GMODULES := YES
 SWIFT_OBJC_INTEROP = 1
 SWIFT_SOURCES := main.swift
 OBJC_SOURCES := impl.m
 SWIFTFLAGS_EXTRAS := -I$(shell pwd)/include
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/objc-header/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 MAKE_GMODULES := YES
 SWIFT_OBJC_INTEROP = 1
 SWIFT_SOURCES := main.swift
@@ -8,7 +6,7 @@ CFLAGS_EXTRAS = -I$(BUILDDIR)/include
 SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)/include
 LD_EXTRAS := libLibrary.dylib
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 objc.o: libLibrary.dylib
 

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/dynamic_value/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/dynamic_value/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/enum_associated/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/enum_associated/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/enum_objc/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/enum_objc/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
 SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR) -Xfrontend -validate-tbd-against-ir=none
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/enum_tagged/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/enum_tagged/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/access_control/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/access_control/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/allocator/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/allocator/Makefile
@@ -1,3 +1,2 @@
 SWIFT_SOURCES := main.swift
-
 include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/basic/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/basic/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/class_constrained_protocol/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/class_constrained_protocol/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/classes/fromobjc/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/classes/fromobjc/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/classes/pureswift/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/classes/pureswift/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/empty_self/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/empty_self/Makefile
@@ -1,6 +1,5 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 cleanup:
 	rm -f Makefile *.d

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/errors/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/errors/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/exclusivity_suppression/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/exclusivity_suppression/Makefile
@@ -1,5 +1,4 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES :=main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 SWIFTFLAGS += -enforce-exclusivity=checked
 

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/generic/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/generic/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/generic_protocol_extension/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/generic_protocol_extension/Makefile
@@ -1,6 +1,5 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 cleanup:
 	rm -f Makefile *.d

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/mutating_struct_extension/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/mutating_struct_extension/Makefile
@@ -1,6 +1,5 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 cleanup:
 	rm -f Makefile *.d

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/no_calculator/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/no_calculator/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/Makefile
@@ -1,10 +1,9 @@
-LEVEL = ../../../../make
 SWIFT_OBJC_INTEROP := 1
 
 # This test builds an Objective-C main program that imports two Swift
 # .dylibs with conflicting ClangImporter search paths.
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 a.out: main.m libFoo.dylib
 	$(CC) $(CFLAGS) $(MANDATORY_MODULE_BUILD_CFLAGS) -I$(shell pwd) -lFoo -L$(shell pwd) -o $@ $<

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/dylib.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/dylib.mk
@@ -1,7 +1,6 @@
-LEVEL = ../../../../make
 DYLIB_ONLY := YES
 DYLIB_NAME := $(BASENAME)
 DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
 SWIFTFLAGS_EXTRAS = -emit-objc-header-path $(BASENAME).h
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/overload/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/overload/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/protocol_extension/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/protocol_extension/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/scopes/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/scopes/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/self/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/self/Makefile
@@ -1,6 +1,5 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 cleanup:
 	rm -f Makefile *.d

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/simple/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/simple/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/static/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/static/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/submodule_import/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/submodule_import/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/expression/weak_self/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/expression/weak_self/Makefile
@@ -1,6 +1,5 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 cleanup:
 	rm -f Makefile *.d

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/file_private/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/file_private/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift a.swift b.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/first_expr_module_load/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/first_expr_module_load/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/fixits/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/fixits/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/foundation/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/foundation/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP = 1
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/data/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/data/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/date/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/date/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/decimal/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/decimal/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/indexpath/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/indexpath/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/measurement/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/measurement/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/notification/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/notification/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/url/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/url/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/urlcomponents/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/urlcomponents/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/uuid/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/uuid/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/frame_var_object_fully_realized/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/frame_var_object_fully_realized/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/generic_arg_in_extension/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/generic_arg_in_extension/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/generic_class_arg/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/generic_class_arg/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/generic_error/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/generic_error/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/generic_error_tuple/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/generic_error_tuple/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/generic_existentials/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/generic_existentials/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/generic_extension/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/generic_extension/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/generic_extensions_typealias/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/generic_extensions_typealias/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/generic_objcclasswrapper/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/generic_objcclasswrapper/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/generic_self/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/generic_self/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/generic_tuple/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/generic_tuple/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/generic_type_of_nested_archetype/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/generic_type_of_nested_archetype/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/generics/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/generics/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/get_value/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/get_value/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/hashed_containers_enums/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/hashed_containers_enums/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/hide_runtimesupport/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/hide_runtimesupport/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/dylib.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/dylib.mk
@@ -1,5 +1,4 @@
 # There's one extra level here because this is called from the tests in the subdirectories.
-LEVEL = ../../../../make
 DYLIB_ONLY := YES
 DYLIB_NAME := $(BASENAME)
 DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
@@ -9,4 +8,4 @@ EXCLUDE_WRAPPED_SWIFTMODULE := YES
 SWIFTFLAGS := -gnone -I. -module-link-name $(BASENAME)
 LD_EXTRAS := -L.
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/Makefile
@@ -1,12 +1,10 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES=main.swift
 SWIFTFLAGS_EXTRAS= -I.
 LD_EXTRAS=-L.
 
 all: SomeLibraryCore.swiftmodule SomeLibrary.swiftmodule a.out
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 SomeLibraryCore.swiftmodule: SomeLibraryCore.swift
 	$(MAKE) BASENAME=$(shell basename $@ .swiftmodule) \

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/Makefile
@@ -1,12 +1,10 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES=main.swift
 SWIFTFLAGS_EXTRAS= -I.
 LD_EXTRAS=-L.
 
 all: SomeLibraryCore.swiftmodule SomeLibrary.swiftmodule a.out
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 SomeLibraryCore.swiftmodule: SomeLibraryCore.swift
 	$(MAKE) BASENAME=$(shell basename $@ .swiftmodule) \

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES=main.swift
 SWIFTFLAGS_EXTRAS= -I$(shell pwd)
 MODULENAME=main
@@ -7,7 +5,7 @@ LD_EXTRAS=-L$(shell pwd)
 
 all: SomeLibrary.swiftmodule a.out
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 SomeLibrary.swiftmodule: SomeLibrary.swift
 	$(MAKE) BASENAME=$(shell basename $@ .swiftmodule) \

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/imported_types/cgtypes/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/imported_types/cgtypes/Makefile
@@ -1,6 +1,4 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/instance_pointer_set_sp/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/instance_pointer_set_sp/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/let_int/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/let_int/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/local_closure_types/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/local_closure_types/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/local_types/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/local_types/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/materializer_archetype_binding/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/materializer_archetype_binding/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/meta/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/meta/Makefile
@@ -1,6 +1,4 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := hello.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/metatype/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/metatype/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/missing_sdk/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/missing_sdk/Makefile
@@ -1,8 +1,6 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 fakesdk:
 	ln -s $(SDKROOT) $@

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/mix_any_object/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/mix_any_object/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/module_search_paths/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/module_search_paths/Makefile
@@ -1,5 +1,4 @@
 SWIFT_SOURCES := main.swift
-
 all: module-build
 
 include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/multi_optionals/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/multi_optionals/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/multibases/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/multibases/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/multilang_category/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/multilang_category/Makefile
@@ -1,6 +1,4 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/multipayload_enum/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/multipayload_enum/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/nested_arrays/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/nested_arrays/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/nested_c_enums/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/nested_c_enums/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/nonmodular-include/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/nonmodular-include/Makefile
@@ -1,10 +1,9 @@
-LEVEL = ../../../make
 SWIFT_OBJC_INTEROP := 1
 SWIFT_SOURCES := main.swift
 
 all: module.modulemap conflict.h a.out
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 SWIFTFLAGS += -Xcc -F$(SRCDIR) -I$(SRCDIR) -I$(BUILDDIR)
 
 # Create a nonmodular include by removing the modulemap after building.

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/nsarray_code_running_formatter/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/nsarray_code_running_formatter/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/nserror/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/nserror/Makefile
@@ -1,6 +1,4 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/objc-interop/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/objc-interop/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP = 1
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/objc_inherited_ivars/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/objc_inherited_ivars/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/one_case_enum/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/one_case_enum/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/opaque_existentials/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/opaque_existentials/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/opaque_return_types/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/opaque_return_types/Makefile
@@ -1,4 +1,2 @@
-
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/optimized_code/bound_generic_enum/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/optimized_code/bound_generic_enum/Makefile
@@ -1,7 +1,5 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
 SWIFTFLAGS_EXTRAS := -Xfrontend -disable-debugger-shadow-copies
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/optional_url/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/optional_url/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/optionset/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/optionset/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/dsym/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/dsym/Makefile
@@ -1,5 +1,3 @@
-LEVEL := ../../../../make
-
 EXE := a.out
 SWIFT_SOURCES := main.swift
 LD_EXTRAS = -L$(BUILDDIR) -lAA -Xlinker -rpath -Xlinker $(BUILDDIR)
@@ -10,7 +8,7 @@ DYLIB_DSYM ?= NO
 # setup `all` to run each of the below before building the main executable
 all: setup sharedA clear_modules
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 setup:
 	# copy the source files into the build directory because we delete them

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/dsym/libs/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/dsym/libs/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 DYLIB_NAME := $(BASENAME)
 DYLIB_SWIFT_SOURCES := libs/$(BASENAME).swift
 
@@ -15,7 +13,7 @@ SWIFTFLAGS=-Onone -Xfrontend -serialize-debugging-options -enable-library-evolut
 EXCLUDE_WRAPPED_SWIFTMODULE=1
 endif
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 clean::
 	rm -f $(BASENAME).swiftinterface

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/shared/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/shared/Makefile
@@ -1,5 +1,3 @@
-LEVEL := ../../../../make
-
 EXE := main
 SWIFT_SOURCES := main.swift
 LD_EXTRAS = -L$(BUILDDIR) -lAA -lBB -lCC -Xlinker -rpath -Xlinker $(BUILDDIR)
@@ -11,7 +9,7 @@ SWIFT_MODULE_CACHE_FLAGS = -module-cache-path MCP
 # setup `all` to run each of the below before building the main executable
 all: setup sharedA sharedB sharedC clear_modules
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 setup:
 	# copy the source files into the build directory because we delete them

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/shared/libs/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/shared/libs/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 DYLIB_NAME := $(BASENAME)
 DYLIB_SWIFT_SOURCES := libs/$(BASENAME).swift
 
@@ -13,7 +11,7 @@ SWIFTFLAGS=-Onone -Xfrontend -serialize-debugging-options -enable-library-evolut
 # .swiftinterface loading path can be exercised.
 EXCLUDE_WRAPPED_SWIFTMODULE=1
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 clean::
 	rm -f $(BASENAME).swiftinterface

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/static/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/static/Makefile
@@ -1,5 +1,3 @@
-LEVEL := ../../../../make
-
 EXE := main
 SWIFT_SOURCES := main.swift
 LD_EXTRAS = -L$(BUILDDIR) -lAA -lBB -lCC
@@ -9,7 +7,7 @@ SWIFT_MODULE_CACHE_FLAGS = -module-cache-path MCP
 # setup `all` to run each of the below before building the main executable
 all: setup staticA staticB staticC clear_modules
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 setup:
 	# copy the source files into the build directory because we delete them

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/static/libs/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/static/libs/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 # Set the dylib variables so the rules for generating swift objects and
 # modules are active.
 DYLIB_NAME := $(BASENAME)
@@ -22,7 +20,7 @@ ARCHIVE_OBJECTS = $(strip $(DYLIB_SWIFT_SOURCES:.swift=.o))
 
 $(ARCHIVE_NAME): $(BASENAME).swiftmodule
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 # Generate only the static lib (all would generate a dylib as well).
 static_only: $(ARCHIVE_NAME)

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/partially_generic_func/class/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/partially_generic_func/class/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/partially_generic_func/continuations/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/partially_generic_func/continuations/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/partially_generic_func/enum/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/partially_generic_func/enum/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/partially_generic_func/struct/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/partially_generic_func/struct/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/path_with_colons/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/path_with_colons/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/po/conflicted_name/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/po/conflicted_name/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/po/nested_nsdict/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/po/nested_nsdict/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/po/recursive/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/po/recursive/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/po/ref_types/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/po/ref_types/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/po/sys_types/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/po/sys_types/Makefile
@@ -1,4 +1,3 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/po/uninitialized/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/po/uninitialized/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/po/val_types/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/po/val_types/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/printdecl/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/printdecl/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/private_decl_name/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/private_decl_name/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift a.swift b.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/private_generic_self/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/private_generic_self/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/private_import/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/private_import/Makefile
@@ -1,9 +1,8 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
 
 all: libInvisible.dylib libLibrary.dylib a.out
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 LD_EXTRAS = -lLibrary -L$(BUILDDIR)
 SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
 

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/private_import/dylib.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/private_import/dylib.mk
@@ -1,5 +1,4 @@
-LEVEL = ../../../make
 DYLIB_ONLY := YES
 DYLIB_NAME := $(BASENAME)
 DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/private_self/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/private_self/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/private_typealias/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/private_typealias/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/private_var/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/private_var/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/protocol_extension_computed_property/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/protocol_extension_computed_property/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/protocol_extension_two/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/protocol_extension_two/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/protocol_optional/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/protocol_optional/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/protocols/class_protocol/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/protocols/class_protocol/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/ranges/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/ranges/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/reference_storage_types/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/reference_storage_types/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/repl_in_c/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/repl_in_c/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 C_SOURCES := main.c
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/resilience/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/resilience/Makefile
@@ -1,9 +1,7 @@
-LEVEL = ../../../make
-
 EXE=
 all: libmod.a.dylib libmod.b.dylib main.a main.b
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 libmod.%.dylib: mod.%.swift
 	ln -sf $< mod.swift

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/resilience/dylib.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/resilience/dylib.mk
@@ -1,6 +1,5 @@
-LEVEL = ../../../make
 DYLIB_ONLY := YES
 DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
 SWIFTFLAGS_EXTRAS = -I$(shell pwd) -enable-library-evolution
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/resilience/exe.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/resilience/exe.mk
@@ -1,6 +1,5 @@
-LEVEL = ../../../make
 EXE := main
 SWIFT_SOURCES := main.swift
 SWIFTFLAGS_EXTRAS = -I$(shell pwd)
 LD_EXTRAS = -lmod -L$(shell pwd)
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/return/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/return/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/split_debug/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/split_debug/Makefile
@@ -1,7 +1,5 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
 SPLIT_DEBUG_SYMBOLS=YES
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/static_linking/macOS/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/static_linking/macOS/Makefile
@@ -1,7 +1,5 @@
 # Build swift modules with debug info
 
-LEVEL=../../../../make
-
 # Don't use 'all' target.  There is a default build rule that will kick in that
 # will be wrong.  WE use 'first' so that the normal 'make' command (without
 # a target) selects the first (but not 'all') target so we avoid the undesired
@@ -10,7 +8,7 @@ first: main
 
 SWIFT_OBJC_INTEROP=1
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 # Add back the SDK settings to the swift flags.  Normally this happens
 # automatically, but since we're overriding the normal swiftc invocation,

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/step_into_override/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/step_into_override/Makefile
@@ -1,6 +1,5 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 cleanup:
 	rm -f Makefile *.d

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/stepping/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/stepping/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/struct_change_rerun/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/struct_change_rerun/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/struct_init_display/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/struct_init_display/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/substituted_typealias/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/substituted_typealias/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/swift_callback/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/swift_callback/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/swift_reference_counting/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/swift_reference_counting/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/swift_version/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/swift_version/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 EXE=main
 SWIFT_SOURCES=main.swift
 SWIFTFLAGS_EXTRAS= -I$(shell pwd)
@@ -7,7 +5,7 @@ LD_EXTRAS=-L$(shell pwd) -lmod5 -lmod4
 
 all: libmod5.dylib libmod4.dylib main
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 MOD5_FLAGS = -swift-version 5
 MOD4_FLAGS = -swift-version 4

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/swift_version/dylib.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/swift_version/dylib.mk
@@ -1,6 +1,5 @@
-LEVEL = ../../../make
 DYLIB_ONLY := YES
 DYLIB_NAME := $(BASENAME)
 DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/swiftieformatting/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/swiftieformatting/Makefile
@@ -1,6 +1,4 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/system_framework/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/system_framework/Makefile
@@ -1,7 +1,5 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
 SWIFT_FLAGS_EXTRAS := -framwork CoreGraphics
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/tagged_pointer/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/tagged_pointer/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/tuple/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/tuple/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/type_metadata/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/type_metadata/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/typealias_expression_parser/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/typealias_expression_parser/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/unit-tests/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/unit-tests/Makefile
@@ -1,10 +1,8 @@
-LEVEL = ../../../make
-
 all: dylib xctest
 C_SOURCES=xctest.c
 EXE=xctest
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 .PHONY: dylib
 dylib:

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/unit-tests/dylib.mk
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/unit-tests/dylib.mk
@@ -1,11 +1,9 @@
-LEVEL = ../../../make
-
 all: UnitTest.xctest/Contents/MacOS/test UnitTest.xctest/Contents/Info.plist
 
 DYLIB_SWIFT_SOURCES := test.swift
 DYLIB_NAME := test
 DYLIB_ONLY := YES
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 UnitTest.xctest/Contents/MacOS/test: $(DYLIB_FILENAME) $(DSYM)
 	mkdir -p $(BUILDDIR)/UnitTest.xctest/Contents/MacOS

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/unknown_reference/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/unknown_reference/Makefile
@@ -1,6 +1,4 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/unknown_self/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/unknown_self/Makefile
@@ -1,6 +1,4 @@
-LEVEL = ../../../make
-
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/array/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/array/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/bool/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/bool/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/bridged_array/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/bridged_array/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/bridged_string/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/bridged_string/Makefile
@@ -1,7 +1,5 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/bulky_enums/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/bulky_enums/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/cgtypes/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/cgtypes/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/class/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/class/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/dict_nsobj_anyobj/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/dict_nsobj_anyobj/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/dictionary/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/dictionary/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/enums/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/enums/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/error_type/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/error_type/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/func/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/func/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/generic_enums/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/generic_enums/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_apply/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_apply/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_array/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_array/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_flatmap/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_flatmap/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/generic_tuple_labels/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/generic_tuple_labels/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/generics/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/generics/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/globals/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/globals/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/indirect_enums/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/indirect_enums/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/inout/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/inout/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/let/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/let/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/objc/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/objc/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/objc_optionals/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/objc_optionals/Makefile
@@ -1,6 +1,4 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 SWIFT_OBJC_INTEROP := 1
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/optionals/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/optionals/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/protocol/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/protocol/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/set/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/set/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/static_string/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/static_string/Makefile
@@ -1,7 +1,5 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 SWIFT_OBJC_INTEROP := 1

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/string/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/string/Makefile
@@ -1,7 +1,5 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules
 
 SWIFT_OBJC_INTEROP := 1

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/swift/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/swift/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/tuples/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/tuples/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/variables/value_of_optionals/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/variables/value_of_optionals/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/lang/swift/zero_size_generic_self/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/lang/swift/zero_size_generic_self/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/python_api/sbvalue_updates/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/python_api/sbvalue_updates/Makefile
@@ -1,5 +1,3 @@
-LEVEL = ../../make
-
 SWIFT_SOURCES := main.swift
 
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/repl/array/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/repl/array/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules

--- a/lldb/packages/Python/lldbsuite/test/repl/subclassing/Makefile
+++ b/lldb/packages/Python/lldbsuite/test/repl/subclassing/Makefile
@@ -1,3 +1,2 @@
-LEVEL = ../../make
 SWIFT_SOURCES := main.swift
-include $(LEVEL)/Makefile.rules
+include Makefile.rules


### PR DESCRIPTION
Applies the changes from the following commit to Swift:

```
commit 2934308b42130ba554d8d399f66bcce204314c76
Author: Pavel Labath <pavel@labath.sk>
Date:   Wed Sep 4 07:46:25 2019 +0000

   [dotest] Avoid the need for LEVEL= makefile boilerplate

   Summary:
   Instead of each test case knowing its depth relative to the test root,
   we can just have dotest add the folder containing Makefile.rules to the
   include path.

   This was motivated by r370616, though I have been wanting to do this
   ever since we moved to building tests out-of-tree.

   The only manually modified files in this patch are lldbinline.py and
   plugins/builder_base.py. The rest of the patch has been produced by this
   shell command:
     find . \( -name Makefile -o -name '*.mk' \)  -exec sed --in-place -e '/LEVEL *:\?=/d' -e '1,2{/^$/d}' -e 's,\$(LEVEL)/,,' {} +

   Reviewers: teemperor, aprantl, espindola, jfb

   Subscribers: emaste, javed.absar, arichardson, christof, arphaman, lldb-commits

   Differential Revision: https://reviews.llvm.org/D67083
```