### PR TITLE
dotest.py: Add option to pass extra lldb settings to dotest

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -46,6 +46,10 @@ compiler = None    # Must be initialized after option parsing
 # The overriden dwarf verison.
 dwarf_version = 0
 
+# Any overridden settings.
+# Always disable default dynamic types for testing purposes.
+settings = [('target.prefer-dynamic-value', 'no-dynamic-values')]
+
 # Path to the FileCheck testing tool. Not optional.
 filecheck = None
 

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -339,6 +339,14 @@ def parseOptionsAndInitTestdirs():
         # that explicitly require no debug info.
         os.environ['CFLAGS'] = '-gdwarf-{}'.format(configuration.dwarf_version)
 
+    if args.settings:
+        for setting in args.settings:
+            if not len(setting) == 1 or not setting[0].count('='):
+                logging.error('"%s" is not a setting in the form "key=value"',
+                              setting[0])
+                sys.exit(-1)
+            configuration.settings.append(setting[0].split('=', 1))
+
     if args.d:
         sys.stdout.write(
             "Suspending the process %d to wait for debugger to attach...\n" %
@@ -762,17 +770,15 @@ def visit(prefix, dir, names):
             raise
 
 
-def disabledynamics():
+def setSetting(setting, value):
     import lldb
     ci = lldb.DBG.GetCommandInterpreter()
     res = lldb.SBCommandReturnObject()
-    ci.HandleCommand(
-        "setting set target.prefer-dynamic-value no-dynamic-values",
-        res,
-        False)
+    cmd = 'setting set %s %s'%(setting, value)
+    print(cmd)
+    ci.HandleCommand(cmd, res, False)
     if not res.Succeeded():
-        raise Exception('disabling dynamic type support failed')
-
+        raise Exception('failed to run "%s"'%cmd)
 
 # ======================================== #
 #                                          #
@@ -1057,8 +1063,9 @@ def run_suite():
     # Now that we have loaded all the test cases, run the whole test suite.
     #
 
-    # Disable default dynamic types for testing purposes
-    disabledynamics()
+    # Set any user-overridden settings.
+    for key, value in configuration.settings:
+        setSetting(key, value)
 
     # Install the control-c handler.
     unittest2.signals.installHandler()

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -110,6 +110,14 @@ def create_parser():
         type=int,
         help='Override the DWARF version.')
     group.add_argument(
+        '--setting',
+        metavar='SETTING=VALUE',
+        dest='settings',
+        type=str,
+        nargs=1,
+        action='append',
+        help='Run "setting set SETTING VALUE" before executing any test.')
+    group.add_argument(
         '-s',
         metavar='name',
         help='Specify the name of the dir created to store the session files of tests with errored or failed status. If not specified, the test driver uses the timestamp as the session dir name')


### PR DESCRIPTION
The primary motivation for this is to add another dimension to the
Swift LLDB test matrix, but this seems generally useful.

Differential Revision: https://reviews.llvm.org/D72662

(cherry picked from commit b53d44b17a1685e405415cd32c4b6eb89cc4c3a1)