### PR TITLE
[InstCombine] Support vectors in SimplifyAddWithRemainder.

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1044,8 +1044,7 @@ Value *InstCombiner::SimplifyAddWithRemainder(BinaryOperator &I) {
       // Match RemOpV = X / C0
       if (MatchDiv(RemOpV, DivOpV, DivOpC, IsSigned) && X == DivOpV &&
           C0 == DivOpC && !MulWillOverflow(C0, C1, IsSigned)) {
-        Value *NewDivisor =
-            ConstantInt::get(X->getType()->getContext(), C0 * C1);
+        Value *NewDivisor = ConstantInt::get(X->getType(), C0 * C1);
         return IsSigned ? Builder.CreateSRem(X, NewDivisor, "srem")
                         : Builder.CreateURem(X, NewDivisor, "urem");
       }

--- a/llvm/test/Transforms/InstCombine/add4.ll
+++ b/llvm/test/Transforms/InstCombine/add4.ll
@@ -18,6 +18,20 @@ bb:
   ret i64 %tmp4
 }
 
+define <2 x i64> @match_unsigned_vector(<2 x i64> %x) {
+; CHECK-LABEL: @match_unsigned_vector(
+; CHECK-NEXT:  bb:
+; CHECK-NEXT:    [[UREM:%.*]] = urem <2 x i64> [[X:%.*]], <i64 19136, i64 19136>
+; CHECK-NEXT:    ret <2 x i64> [[UREM]]
+;
+bb:
+  %tmp = urem <2 x i64> %x, <i64 299, i64 299>
+  %tmp1 = udiv <2 x i64> %x, <i64 299, i64 299>
+  %tmp2 = urem <2 x i64> %tmp1, <i64 64, i64 64>
+  %tmp3 = mul <2 x i64> %tmp2, <i64 299, i64 299>
+  %tmp4 = add <2 x i64> %tmp, %tmp3
+  ret <2 x i64> %tmp4
+}
 define i64 @match_andAsRem_lshrAsDiv_shlAsMul(i64 %x) {
 ; CHECK-LABEL: @match_andAsRem_lshrAsDiv_shlAsMul(
 ; CHECK-NEXT:  bb:
@@ -50,6 +64,25 @@ bb:
   %tmp7 = mul i64 %tmp4, 19136
   %tmp8 = add i64 %tmp6, %tmp7
   ret i64 %tmp8
+}
+
+define <2 x i64> @match_signed_vector(<2 x i64> %x) {
+; CHECK-LABEL: @match_signed_vector(
+; CHECK-NEXT:  bb:
+; CHECK-NEXT:    [[SREM1:%.*]] = srem <2 x i64> [[X:%.*]], <i64 172224, i64 172224>
+; CHECK-NEXT:    ret <2 x i64> [[SREM1]]
+;
+bb:
+  %tmp = srem <2 x i64> %x, <i64 299, i64 299>
+  %tmp1 = sdiv <2 x i64> %x, <i64 299, i64 299>
+  %tmp2 = srem <2 x i64> %tmp1, <i64 64, i64 64>
+  %tmp3 = sdiv <2 x i64> %x, <i64 19136, i64 19136>
+  %tmp4 = srem <2 x i64> %tmp3, <i64 9, i64 9>
+  %tmp5 = mul <2 x i64> %tmp2, <i64 299, i64 299>
+  %tmp6 = add <2 x i64> %tmp, %tmp5
+  %tmp7 = mul <2 x i64> %tmp4, <i64 19136, i64 19136>
+  %tmp8 = add <2 x i64> %tmp6, %tmp7
+  ret <2 x i64> %tmp8
 }
 
 define i64 @not_match_inconsistent_signs(i64 %x) {


### PR DESCRIPTION
SimplifyAddWithRemainder currently also matches for vector types, but
tries to create an integer constant, which causes a crash.

By using Constant::getIntegerValue() we can support both the scalar and
vector cases.

The 2 added test cases crash without the fix.

Reviewers: spatel, lebedev.ri

Reviewed By: spatel, lebedev.ri

Differential Revision: https://reviews.llvm.org/D75906

(Cherry-picked from c8c14d979abc417d24081cc96c46a2844ce192c2)