### PR TITLE
[CodeGenObjC] Privatize some ObjC metadata symbols

### DIFF
--- a/clang/lib/CodeGen/CGObjCMac.cpp
+++ b/clang/lib/CodeGen/CGObjCMac.cpp
@@ -6246,11 +6246,9 @@ void CGObjCNonFragileABIMac::AddModuleClassList(
   assert((!CGM.getTriple().isOSBinFormatMachO() ||
           SectionName.startswith("__DATA")) &&
          "SectionName expected to start with __DATA on MachO");
-  llvm::GlobalValue::LinkageTypes LT =
-      getLinkageTypeForObjCMetadata(CGM, SectionName);
-  llvm::GlobalVariable *GV =
-    new llvm::GlobalVariable(CGM.getModule(), Init->getType(), false, LT, Init,
-                             SymbolName);
+  llvm::GlobalVariable *GV = new llvm::GlobalVariable(
+      CGM.getModule(), Init->getType(), false,
+      llvm::GlobalValue::PrivateLinkage, Init, SymbolName);
   GV->setAlignment(
       llvm::Align(CGM.getDataLayout().getABITypeAlignment(Init->getType())));
   GV->setSection(SectionName);
@@ -7550,10 +7548,9 @@ CGObjCNonFragileABIMac::EmitSuperClassRef(CodeGenFunction &CGF,
     llvm::Constant *ClassGV = GetClassGlobalForClassRef(ID);
     std::string SectionName =
         GetSectionName("__objc_superrefs", "regular,no_dead_strip");
-    Entry = new llvm::GlobalVariable(
-        CGM.getModule(), ClassGV->getType(), false,
-        getLinkageTypeForObjCMetadata(CGM, SectionName), ClassGV,
-        "OBJC_CLASSLIST_SUP_REFS_$_");
+    Entry = new llvm::GlobalVariable(CGM.getModule(), ClassGV->getType(), false,
+                                     llvm::GlobalValue::PrivateLinkage, ClassGV,
+                                     "OBJC_CLASSLIST_SUP_REFS_$_");
     Entry->setAlignment(CGF.getPointerAlign().getAsAlign());
     Entry->setSection(SectionName);
     CGM.addCompilerUsedGlobal(Entry);
@@ -7574,10 +7571,9 @@ llvm::Value *CGObjCNonFragileABIMac::EmitMetaClassRef(CodeGenFunction &CGF,
     auto MetaClassGV = GetClassGlobal(ID, /*metaclass*/ true, NotForDefinition);
     std::string SectionName =
         GetSectionName("__objc_superrefs", "regular,no_dead_strip");
-    Entry = new llvm::GlobalVariable(
-        CGM.getModule(), ObjCTypes.ClassnfABIPtrTy, false,
-        getLinkageTypeForObjCMetadata(CGM, SectionName), MetaClassGV,
-        "OBJC_CLASSLIST_SUP_REFS_$_");
+    Entry = new llvm::GlobalVariable(CGM.getModule(), ObjCTypes.ClassnfABIPtrTy,
+                                     false, llvm::GlobalValue::PrivateLinkage,
+                                     MetaClassGV, "OBJC_CLASSLIST_SUP_REFS_$_");
     Entry->setAlignment(Align.getAsAlign());
     Entry->setSection(SectionName);
     CGM.addCompilerUsedGlobal(Entry);

--- a/clang/test/CodeGenObjC/class-stubs.m
+++ b/clang/test/CodeGenObjC/class-stubs.m
@@ -11,18 +11,18 @@
 //
 // Metaclasses do not use the "stub" mechanism and are referenced statically.
 //
-// CHECK-LABEL: @"OBJC_CLASSLIST_SUP_REFS_$_" = internal global %struct._class_t* @"OBJC_METACLASS_$_Derived", section "__DATA,__objc_superrefs,regular,no_dead_strip", align 8
+// CHECK-LABEL: @"OBJC_CLASSLIST_SUP_REFS_$_" = private global %struct._class_t* @"OBJC_METACLASS_$_Derived", section "__DATA,__objc_superrefs,regular,no_dead_strip", align 8
 
 // -- classref for the super message send in anotherInstanceMethod()
 //
 // The class is declared with objc_class_stub, so LSB of the class pointer
 // must be set to 1.
 //
-// CHECK-LABEL: @"OBJC_CLASSLIST_SUP_REFS_$_.1" = internal global i8* getelementptr (i8, i8* bitcast (%struct._class_t* @"OBJC_CLASS_$_Derived" to i8*), i32 1), section "__DATA,__objc_superrefs,regular,no_dead_strip", align 8
+// CHECK-LABEL: @"OBJC_CLASSLIST_SUP_REFS_$_.1" = private global i8* getelementptr (i8, i8* bitcast (%struct._class_t* @"OBJC_CLASS_$_Derived" to i8*), i32 1), section "__DATA,__objc_superrefs,regular,no_dead_strip", align 8
 
 // -- category list for class stubs goes in __objc_catlist2.
 //
-// CHECK-LABEL: @"OBJC_LABEL_STUB_CATEGORY_$" = internal global [1 x i8*] [i8* bitcast (%struct._category_t* @"_OBJC_$_CATEGORY_Derived_$_MyCategory" to i8*)], section "__DATA,__objc_catlist2,regular,no_dead_strip", align 8
+// CHECK-LABEL: @"OBJC_LABEL_STUB_CATEGORY_$" = private global [1 x i8*] [i8* bitcast (%struct._category_t* @"_OBJC_$_CATEGORY_Derived_$_MyCategory" to i8*)], section "__DATA,__objc_catlist2,regular,no_dead_strip", align 8
 
 __attribute__((objc_class_stub))
 __attribute__((objc_subclassing_restricted))

--- a/clang/test/CodeGenObjC/exceptions-asm-attribute.m
+++ b/clang/test/CodeGenObjC/exceptions-asm-attribute.m
@@ -15,7 +15,7 @@
 // CHECK-X86_64: @"OBJC_EHTYPE_$_MySecretNamespace.EH1" = weak global {{.*}}, align 8
 // CHECK-X86_64: @"OBJC_EHTYPE_$_MySecretNamespace.EH2" = external global
 // CHECK-X86_64: @"OBJC_EHTYPE_$_MySecretNamespace.EH3" = global {{.*}}, section "__DATA,__objc_const", align 8
-// CHECK-X86_64: @"OBJC_LABEL_CLASS_$" = internal global {{.*}}, section "__DATA,__objc_classlist,regular,no_dead_strip", align 8
+// CHECK-X86_64: @"OBJC_LABEL_CLASS_$" = private global {{.*}}, section "__DATA,__objc_classlist,regular,no_dead_strip", align 8
 // CHECK-X86_64: define internal void @"\01-[A im0]"
 // CHECK-X86_64: define internal void @"\01-[A(Cat) im1]"
 
@@ -39,7 +39,7 @@
 // CHECK-ARMV6: @"OBJC_EHTYPE_$_MySecretNamespace.EH1" = weak global {{.*}}, align 4
 // CHECK-ARMV6: @"OBJC_EHTYPE_$_MySecretNamespace.EH2" = external global
 // CHECK-ARMV6: @"OBJC_EHTYPE_$_MySecretNamespace.EH3" = global {{.*}}, section "__DATA,__objc_const", align 4
-// CHECK-ARMV6: @"OBJC_LABEL_CLASS_$" = internal global {{.*}}, section "__DATA,__objc_classlist,regular,no_dead_strip", align 4
+// CHECK-ARMV6: @"OBJC_LABEL_CLASS_$" = private global {{.*}}, section "__DATA,__objc_classlist,regular,no_dead_strip", align 4
 // CHECK-ARMV6: define internal void @"\01-[A im0]"
 // CHECK-ARMV6: define internal void @"\01-[A(Cat) im1]"
 

--- a/clang/test/CodeGenObjC/metadata-symbols-64.m
+++ b/clang/test/CodeGenObjC/metadata-symbols-64.m
@@ -23,14 +23,14 @@
 // CHECK: @"_OBJC_$_CATEGORY_INSTANCE_METHODS_A_$_Cat" = internal global {{.*}} section "__DATA, __objc_const", align 8
 // CHECK: @"_OBJC_$_CATEGORY_CLASS_METHODS_A_$_Cat" = internal global {{.*}} section "__DATA, __objc_const", align 8
 // CHECK: @"_OBJC_$_CATEGORY_A_$_Cat" = internal global {{.*}} section "__DATA, __objc_const", align 8
-// CHECK: @"OBJC_CLASSLIST_SUP_REFS_$_{{[0-9]*}}" = internal global {{.*}} section "__DATA,__objc_superrefs,regular,no_dead_strip", align 8
+// CHECK: @"OBJC_CLASSLIST_SUP_REFS_$_{{[0-9]*}}" = private global {{.*}} section "__DATA,__objc_superrefs,regular,no_dead_strip", align 8
 // CHECK: @OBJC_SELECTOR_REFERENCES_ = internal externally_initialized global {{.*}} section "__DATA,__objc_selrefs,literal_pointers,no_dead_strip"
-// CHECK: @"OBJC_CLASSLIST_SUP_REFS_$_{{[\.0-9]*}}" = internal global {{.*}} section "__DATA,__objc_superrefs,regular,no_dead_strip", align 8
+// CHECK: @"OBJC_CLASSLIST_SUP_REFS_$_{{[\.0-9]*}}" = private global {{.*}} section "__DATA,__objc_superrefs,regular,no_dead_strip", align 8
 // CHECK: @"OBJC_CLASS_$_B" = external global
 // CHECK: @"OBJC_CLASSLIST_REFERENCES_$_{{[0-9]*}}" = internal global {{.*}} section "__DATA,__objc_classrefs,regular,no_dead_strip", align 8
 // CHECK: @_objc_msgSend_fixup_alloc = weak hidden global {{.*}} section "__DATA,__objc_msgrefs,coalesced", align 16
-// CHECK: @"OBJC_LABEL_CLASS_$" = internal global {{.*}} section "__DATA,__objc_classlist,regular,no_dead_strip", align 8
-// CHECK: @"OBJC_LABEL_CATEGORY_$" = internal global {{.*}} section "__DATA,__objc_catlist,regular,no_dead_strip", align 8
+// CHECK: @"OBJC_LABEL_CLASS_$" = private global {{.*}} section "__DATA,__objc_classlist,regular,no_dead_strip", align 8
+// CHECK: @"OBJC_LABEL_CATEGORY_$" = private global {{.*}} section "__DATA,__objc_catlist,regular,no_dead_strip", align 8
 // CHECK: @objc_msgSend_fpret(
 // CHECK: @objc_msgSend_fixup(
 

--- a/clang/test/CodeGenObjC/metadata_symbols.m
+++ b/clang/test/CodeGenObjC/metadata_symbols.m
@@ -14,7 +14,7 @@
 // CHECK-X86_64: @"OBJC_EHTYPE_$_EH1" = weak global {{.*}}, align 8
 // CHECK-X86_64: @"OBJC_EHTYPE_$_EH2" = external global
 // CHECK-X86_64: @"OBJC_EHTYPE_$_EH3" = global {{.*}}, section "__DATA,__objc_const", align 8
-// CHECK-X86_64: @"OBJC_LABEL_CLASS_$" = internal global {{.*}}, section "__DATA,__objc_classlist,regular,no_dead_strip", align 8
+// CHECK-X86_64: @"OBJC_LABEL_CLASS_$" = private global {{.*}}, section "__DATA,__objc_classlist,regular,no_dead_strip", align 8
 // CHECK-X86_64: define internal void @"\01-[A im0]"
 // CHECK-X86_64: define internal void @"\01-[A(Cat) im1]"
 
@@ -38,7 +38,7 @@
 // CHECK-ARMV6: @"OBJC_EHTYPE_$_EH1" = weak global {{.*}}, align 4
 // CHECK-ARMV6: @"OBJC_EHTYPE_$_EH2" = external global
 // CHECK-ARMV6: @"OBJC_EHTYPE_$_EH3" = global {{.*}}, section "__DATA,__objc_const", align 4
-// CHECK-ARMV6: @"OBJC_LABEL_CLASS_$" = internal global {{.*}}, section "__DATA,__objc_classlist,regular,no_dead_strip", align 4
+// CHECK-ARMV6: @"OBJC_LABEL_CLASS_$" = private global {{.*}}, section "__DATA,__objc_classlist,regular,no_dead_strip", align 4
 // CHECK-ARMV6: define internal void @"\01-[A im0]"
 // CHECK-ARMV6: define internal void @"\01-[A(Cat) im1]"
 

--- a/clang/test/CodeGenObjC/non-lazy-classes.m
+++ b/clang/test/CodeGenObjC/non-lazy-classes.m
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -triple x86_64-apple-darwin10 -Wno-objc-root-class -emit-llvm -o - %s | FileCheck %s
 
-// CHECK: @"OBJC_LABEL_NONLAZY_CLASS_$" = internal global [3 x {{.*}}]{{.*}}@"OBJC_CLASS_$_A"{{.*}},{{.*}}@"OBJC_CLASS_$_D"{{.*}},{{.*}}"OBJC_CLASS_$_E"{{.*}} section "__DATA,__objc_nlclslist,regular,no_dead_strip", align 8
-// CHECK: @"OBJC_LABEL_NONLAZY_CATEGORY_$" = internal global [2 x {{.*}}] {{.*}}@"_OBJC_$_CATEGORY_A_$_Cat"{{.*}},{{.*}}@"_OBJC_$_CATEGORY_E_$_MyCat"{{.*}}, section "__DATA,__objc_nlcatlist,regular,no_dead_strip", align 8
+// CHECK: @"OBJC_LABEL_NONLAZY_CLASS_$" = private global [3 x {{.*}}]{{.*}}@"OBJC_CLASS_$_A"{{.*}},{{.*}}@"OBJC_CLASS_$_D"{{.*}},{{.*}}"OBJC_CLASS_$_E"{{.*}} section "__DATA,__objc_nlclslist,regular,no_dead_strip", align 8
+// CHECK: @"OBJC_LABEL_NONLAZY_CATEGORY_$" = private global [2 x {{.*}}] {{.*}}@"_OBJC_$_CATEGORY_A_$_Cat"{{.*}},{{.*}}@"_OBJC_$_CATEGORY_E_$_MyCat"{{.*}}, section "__DATA,__objc_nlcatlist,regular,no_dead_strip", align 8
 
 @interface A @end
 @implementation A

--- a/clang/test/CodeGenObjC/sections.m
+++ b/clang/test/CodeGenObjC/sections.m
@@ -61,15 +61,15 @@ _Bool f(J *j) {
 // CHECK-ELF: !{{[0-9]+}} = !{i32 1, !"Objective-C Image Info Section", !"objc_imageinfo"}
 
 // CHECK-MACHO: @"_OBJC_$_CLASS_METHODS_I" = internal {{.*}}, section "__DATA, __objc_const"
-// CHECK-MACHO: @"OBJC_CLASSLIST_SUP_REFS_$_" = internal {{.*}}, section "__DATA,__objc_superrefs,regular,no_dead_strip"
+// CHECK-MACHO: @"OBJC_CLASSLIST_SUP_REFS_$_" = private {{.*}}, section "__DATA,__objc_superrefs,regular,no_dead_strip"
 // CHECK-MACHO: @OBJC_SELECTOR_REFERENCES_ = internal {{.*}}, section "__DATA,__objc_selrefs,literal_pointers,no_dead_strip"
 // CHECK-MACHO: @"OBJC_CLASSLIST_REFERENCES_$_" = internal {{.*}}, section "__DATA,__objc_classrefs,regular,no_dead_strip"
 // CHECK-MACHO: @_objc_msgSend_fixup_class = {{.*}}, section "__DATA,__objc_msgrefs,coalesced"
 // CHECK-MACHO: @"_OBJC_LABEL_PROTOCOL_$_P" = {{.*}}, section "__DATA,__objc_protolist,coalesced,no_dead_strip"
 // CHECK-MACHO: @"_OBJC_PROTOCOL_REFERENCE_$_P" = {{.*}}, section "__DATA,__objc_protorefs,coalesced,no_dead_strip"
-// CHECK-MACHO: @"OBJC_LABEL_CLASS_$" = internal {{.*}}, section "__DATA,__objc_classlist,regular,no_dead_strip"
-// CHECK-MACHO: @"OBJC_LABEL_NONLAZY_CLASS_$" = internal {{.*}}, section "__DATA,__objc_nlclslist,regular,no_dead_strip"
-// CHECK-MACHO: @"OBJC_LABEL_CATEGORY_$" = internal {{.*}}, section "__DATA,__objc_catlist,regular,no_dead_strip"
-// CHECK-MACHO: @"OBJC_LABEL_NONLAZY_CATEGORY_$" = internal {{.*}}, section "__DATA,__objc_nlcatlist,regular,no_dead_strip"
+// CHECK-MACHO: @"OBJC_LABEL_CLASS_$" = private {{.*}}, section "__DATA,__objc_classlist,regular,no_dead_strip"
+// CHECK-MACHO: @"OBJC_LABEL_NONLAZY_CLASS_$" = private {{.*}}, section "__DATA,__objc_nlclslist,regular,no_dead_strip"
+// CHECK-MACHO: @"OBJC_LABEL_CATEGORY_$" = private {{.*}}, section "__DATA,__objc_catlist,regular,no_dead_strip"
+// CHECK-MACHO: @"OBJC_LABEL_NONLAZY_CATEGORY_$" = private {{.*}}, section "__DATA,__objc_nlcatlist,regular,no_dead_strip"
 // CHECK-MACHO: !{{[0-9]+}} = !{i32 1, !"Objective-C Image Info Section", !"__DATA,__objc_imageinfo,regular,no_dead_strip"}
 


### PR DESCRIPTION
Nobody needs these symbols, so there isn't any benefit in including them. This
saves some code-size in Objective-C binaries. Partially reverts:
https://reviews.llvm.org/D61454. rdar://56579760

Differential revision: https://reviews.llvm.org/D75491