### PR TITLE
[lldb] Fix lldb-dotest

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -95,7 +95,7 @@ verbose = 0
 # By default, search from the script directory.
 # We can't use sys.path[0] to determine the script directory
 # because it doesn't work under a debugger
-testdirs = [os.path.dirname(os.path.realpath(__file__))]
+testdirs = [lldbsuite.lldb_test_root]
 
 # Separator string.
 separator = '-' * 70


### PR DESCRIPTION
to account for the new location of test files from 99451b445.

(cherry picked from commit 91e0c258c2e80b180c0c99af322cb6bf09df86d4)