### PR TITLE
Add a decorator option to skip tests based on a default setting.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -158,7 +158,8 @@ def _decorateTest(mode,
                   debug_info=None,
                   swig_version=None, py_version=None,
                   macos_version=None,
-                  remote=None, dwarf_version=None):
+                  remote=None, dwarf_version=None,
+                  setting=None):
     def fn(self):
         skip_for_os = _match_decorator_property(
             lldbplatform.translate(oslist), self.getPlatform())
@@ -196,6 +197,8 @@ def _decorateTest(mode,
         skip_for_dwarf_version = (dwarf_version is None) or (
             _check_expected_version(dwarf_version[0], dwarf_version[1],
                                     self.getDwarfVersion()))
+        skip_for_setting = (setting is None) or (
+            setting in configuration.settings)
 
         # For the test to be skipped, all specified (e.g. not None) parameters must be True.
         # An unspecified parameter means "any", so those are marked skip by default.  And we skip
@@ -210,7 +213,8 @@ def _decorateTest(mode,
                       (py_version, skip_for_py_version, "python version"),
                       (macos_version, skip_for_macos_version, "macOS version"),
                       (remote, skip_for_remote, "platform locality (remote/local)"),
-                      (dwarf_version, skip_for_dwarf_version, "dwarf version")]
+                      (dwarf_version, skip_for_dwarf_version, "dwarf version"),
+                      (setting, skip_for_setting, "setting")]
         reasons = []
         final_skip_result = True
         for this_condition in conditions:
@@ -279,7 +283,8 @@ def skipIf(bugnumber=None,
            debug_info=None,
            swig_version=None, py_version=None,
            macos_version=None,
-           remote=None, dwarf_version=None):
+           remote=None, dwarf_version=None,
+           setting=None):
     return _decorateTest(DecorateMode.Skip,
                          bugnumber=bugnumber,
                          oslist=oslist, hostoslist=hostoslist,
@@ -288,7 +293,8 @@ def skipIf(bugnumber=None,
                          debug_info=debug_info,
                          swig_version=swig_version, py_version=py_version,
                          macos_version=macos_version,
-                         remote=remote, dwarf_version=dwarf_version)
+                         remote=remote, dwarf_version=dwarf_version,
+                         setting=setting)
 
 
 def _skip_for_android(reason, api_levels, archs):

--- a/lldb/test/API/sanity/TestSettingSkipping.py
+++ b/lldb/test/API/sanity/TestSettingSkipping.py
@@ -1,0 +1,29 @@
+"""
+This is a sanity check that verifies that test can be sklipped based on settings.
+"""
+
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class SettingSkipSanityTestCase(TestBase):
+
+  mydir = TestBase.compute_mydir(__file__)
+
+  NO_DEBUG_INFO_TESTCASE = True
+
+  @skipIf(setting=('target.prefer-dynamic-value', 'no-dynamic-values'))
+  def testSkip(self):
+    """This setting is on by default"""
+    self.assertTrue(False, "This test should not run!")
+
+  @skipIf(setting=('target.prefer-dynamic-value', 'run-target'))
+  def testNoMatch(self):
+    self.assertTrue(True, "This test should run!")
+
+  @skipIf(setting=('target.i-made-this-one-up', 'true'))
+  def testNotExisting(self):
+    self.assertTrue(True, "This test should run!")
+


### PR DESCRIPTION
This patch allows skipping a test based on a default setting, which is
useful when running the testsuite in different "modes" based on a
default setting. This is a feature I need for the Swift testsuite, but
I think it's generally useful.

Differential Revision: https://reviews.llvm.org/D75864

(cherry picked from commit 0396aa4c05a4b97101da14b5e813c8ab3a34e9d0)