### PR TITLE
[DwarfDebug] Fix an assertion error when emitting call site info that…

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -623,12 +623,15 @@ static void addToFwdRegWorklist(FwdRegWorklist &Worklist, unsigned Reg,
     // instructions we may have already created an expression for the
     // parameter when walking through the instructions. Append that to the
     // new expression.
+    std::vector<uint64_t> ParamElts = Param.Expr->getElements().vec();
+    // Avoid multiple DW_OP_stack_values.
+    if (Expr->isImplicit() && Param.Expr->isImplicit())
+      erase_if(ParamElts,
+               [](uint64_t Op) { return Op == dwarf::DW_OP_stack_value; });
     const DIExpression *CombinedExpr =
         (Param.Expr->getNumElements() > 0)
-            ? DIExpression::append(Expr, Param.Expr->getElements())
+            ? DIExpression::append(Expr, ParamElts)
             : Expr;
-    assert(CombinedExpr->isValid() && "Combined debug expression is invalid");
-
     ParamsForFwdReg.push_back({Param.ParamReg, CombinedExpr});
   }
 }

--- a/llvm/lib/IR/DebugInfoMetadata.cpp
+++ b/llvm/lib/IR/DebugInfoMetadata.cpp
@@ -1117,7 +1117,9 @@ DIExpression *DIExpression::append(const DIExpression *Expr,
   }
 
   NewOps.append(Ops.begin(), Ops.end());
-  return DIExpression::get(Expr->getContext(), NewOps);
+  auto *result = DIExpression::get(Expr->getContext(), NewOps);
+  assert(result->isValid() && "concatenated expression is not valid");
+  return result;
 }
 
 DIExpression *DIExpression::appendToStack(const DIExpression *Expr,

--- a/llvm/test/DebugInfo/MIR/X86/callsite-stack-value.mir
+++ b/llvm/test/DebugInfo/MIR/X86/callsite-stack-value.mir
@@ -1,0 +1,68 @@
+# RUN: llc -start-after=livedebugvalues -mtriple=x86_64-apple-darwin -o - %s -filetype=obj \
+# RUN:   | llvm-dwarfdump - | FileCheck %s -implicit-check-not=call_site_parameter
+
+# CHECK: DW_TAG_formal_parameter
+# CHECK-NEXT: DW_AT_location
+# CHECK-NEXT: DW_OP_reg17
+
+# struct S {
+#   float w;
+# };
+# void f(long w, long b);
+# void g(struct S s) {
+#   int w = s.w;
+#   f(w, w*4);
+# }
+
+--- |
+  define void @g(float %s.coerce) local_unnamed_addr !dbg !20 {
+  entry:
+    ret void, !dbg !31
+  }
+  declare !dbg !14 void @f(i64, i64) local_unnamed_addr
+  !llvm.module.flags = !{!6, !7, !8, !9}
+  !llvm.dbg.cu = !{!10}
+  !6 = !{i32 7, !"Dwarf Version", i32 4}
+  !7 = !{i32 2, !"Debug Info Version", i32 3}
+  !8 = !{i32 1, !"wchar_size", i32 4}
+  !9 = !{i32 7, !"PIC Level", i32 2}
+  !10 = distinct !DICompileUnit(language: DW_LANG_ObjC, file: !15, producer: "", isOptimized: true, runtimeVersion: 2, emissionKind: FullDebug, enums: !12, retainedTypes: !13, nameTableKind: None, sysroot: "/")
+  !12 = !{}
+  !13 = !{!14}
+  !14 = !DISubprogram(name: "f", scope: !15, file: !15, line: 4, type: !16, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized, retainedNodes: !12)
+  !15 = !DIFile(filename: "test.m", directory: "/")
+  !16 = !DISubroutineType(types: !17)
+  !17 = !{null, !18, !18}
+  !18 = !DIBasicType(name: "long int", size: 64, encoding: DW_ATE_signed)
+  !20 = distinct !DISubprogram(name: "g", scope: !15, file: !15, line: 5, type: !21, scopeLine: 5, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !10, retainedNodes: !27)
+  !21 = !DISubroutineType(types: !22)
+  !22 = !{null, !23}
+  !23 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "S", file: !15, line: 1, size: 32, elements: !24)
+  !24 = !{!25}
+  !25 = !DIDerivedType(tag: DW_TAG_member, name: "w", scope: !23, file: !15, line: 2, baseType: !26, size: 32)
+  !26 = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+  !27 = !{!28, !29}
+  !28 = !DILocalVariable(name: "s", arg: 1, scope: !20, file: !15, line: 5, type: !23)
+  !29 = !DILocalVariable(name: "w", scope: !20, file: !15, line: 6, type: !30)
+  !30 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+  !31 = !DILocation(line: 0, scope: !20)
+name:            g
+callSites:
+  - { bb: 0, offset: 13, fwdArgRegs: 
+      - { arg: 1, reg: '$rsi' } }
+body:             |
+  bb.0.entry:
+    DBG_VALUE $xmm0, $noreg, !28, !DIExpression(), debug-location !31
+    DBG_VALUE $xmm0, $noreg, !28, !DIExpression(), debug-location !31
+    frame-setup PUSH64r killed $rbp, implicit-def $rsp, implicit $rsp
+    CFI_INSTRUCTION def_cfa_offset 16
+    CFI_INSTRUCTION offset $rbp, -16
+    $rbp = frame-setup MOV64rr $rsp
+    CFI_INSTRUCTION def_cfa_register $rbp
+    renamable $eax = CVTTSS2SIrr killed renamable $xmm0, implicit $mxcsr, debug-location !31
+    DBG_VALUE $eax, $noreg, !29, !DIExpression(), debug-location !31
+    renamable $rdi = MOVSX64rr32 killed renamable $eax, debug-location !31
+    renamable $eax = LEA64_32r $noreg, 4, renamable $rdi, 0, $noreg, debug-location !31
+    renamable $rsi = MOVSX64rr32 killed renamable $eax, debug-location !31
+    $rbp = frame-destroy POP64r implicit-def $rsp, implicit $rsp, debug-location !31
+    TAILJMPd64 @f, csr_64, implicit $rsp, implicit $ssp, implicit $rsp, implicit $ssp, implicit $rdi, implicit $rsi, debug-location !31


### PR DESCRIPTION
… combines two DW_OP_stack_values

When compiling

```
struct S {
  float w;
};
void f(long w, long b);
void g(struct S s) {
  int w = s.w;
  f(w, w*4);
}
```

I get Assertion failed: ((!CombinedExpr || CombinedExpr->isValid()) && "Combined debug expression is invalid").

That's because we combine two epxressions that both end in DW_OP_stack_value:

```
(lldb) p Expr->dump()
!DIExpression(DW_OP_LLVM_convert, 32, DW_ATE_signed, DW_OP_LLVM_convert, 64, DW_ATE_signed, DW_OP_stack_value)
(lldb) p Param.Expr->dump()
!DIExpression(DW_OP_constu, 4, DW_OP_mul, DW_OP_LLVM_convert, 32, DW_ATE_signed, DW_OP_LLVM_convert, 64, DW_ATE_signed, DW_OP_stack_value)
(lldb) p CombinedExpr->isValid()
(bool) $0 = false
(lldb) p CombinedExpr->dump()
!DIExpression(4097, 32, 5, 4097, 64, 5, 16, 4, 30, 4097, 32, 5, 4097, 64, 5, 159, 159)
```

I believe that in this particular case combining two stack values is
safe, but I didn't want to sink the special handling into
DIExpression::append() because I do want everyone to think about what
they are doing.

Patch by Adrian Prantl.

Fixes PR45181.
rdar://problem/60383095

Differential Revision: https://reviews.llvm.org/D76164

(cherry picked from commit 526c51e6fdc834b703e14ca851a8c95c7f1c9b2f)