### PR TITLE
[lldb/Bindings] Check that process isn't None before calling is_alive.

### DIFF
--- a/lldb/bindings/interface/SBAddress.i
+++ b/lldb/bindings/interface/SBAddress.i
@@ -154,7 +154,7 @@ public:
 
         def __int__(self):
             '''Convert an address to a load address if there is a process and that process is alive, or to a file address otherwise.'''
-            if process.is_alive:
+            if process and process.is_alive:
                 return self.GetLoadAddress (target)
             else:
                 return self.GetFileAddress ()


### PR DESCRIPTION
Make sure that `process` is not None before calling is_alive. Otherwise
this might result in an AttributeError: 'NoneType' object has no
attribute 'is_alive'.

Although lldb.process and friends could already be None in the past, for
example after leaving an interactive scripting session, the issue became
more prevalent after `fc1fd6bf9fcfac412b10b4193805ec5de0e8df57`.

I audited the other interface files for usages of target, process,
thread and frame, but this seems the only place where a global is used
from an SB class.

(cherry picked from commit a11b330418819d9cc9c4f0ecd31acdc2e0bbb703)