### PR TITLE
Fixing arm64e-subtype.s test to work with changes in upstream --macho flag.

### DIFF
--- a/llvm/test/MC/AArch64/arm64e-subtype.s
+++ b/llvm/test/MC/AArch64/arm64e-subtype.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -triple=arm64e-apple-ios -filetype=obj %s -o - | llvm-objdump -macho -d -p - | FileCheck %s
+; RUN: llvm-mc -triple=arm64e-apple-ios -filetype=obj %s -o - | llvm-objdump --macho -d -p - | FileCheck %s
 
 ; CHECK: _foo:
 ; CHECK: 0: c0 03 5f d6   ret


### PR DESCRIPTION
Number of dashes for flags like -macho to llvm-objdump and others changed. 