### PR TITLE
rdar://60513353 (lldb-rpc-server crash in SwiftLanguageRuntime::Metad…

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftMetatype.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftMetatype.cpp
@@ -43,6 +43,8 @@ bool lldb_private::formatters::swift::SwiftMetatype_SummaryProvider(
       return false;
     SwiftLanguageRuntime::MetadataPromiseSP metadata_promise_sp =
       swift_runtime->GetMetadataPromise(metadata_ptr, valobj);
+    if (!metadata_promise_sp)
+      return false;
     if (CompilerType resolved_type =
             metadata_promise_sp->FulfillTypePromise()) {
       stream.Printf("%s", resolved_type.GetDisplayTypeName().AsCString());


### PR DESCRIPTION
…ataPromise::FulfillTypePromise)

Null-check the GetMetadataPromise result before using it. I checked, all
other users of GetMetadataPromise perform the null check already.

No test, as I'm not sure how to reproduce the issue.

This is https://github.com/apple/llvm-project/pull/929 for master-next.

rdar://60513353
(cherry picked from commit 1e696e381b28c1e1564579e0453bd009557b5db9)