### PR TITLE
[upstreaming] Revert UserExpression free'ing in UserExpression.cpp

### DIFF
--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -262,11 +262,6 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
     execution_results = lldb::eExpressionParseError;
     if (fixed_expression && !fixed_expression->empty() &&
         options.GetAutoApplyFixIts()) {
-      // Swift: temporarily release scratch context lock held by
-      // SwiftUserExpression, so the context can be restored if necessary.
-      if (expr == *fixed_expression)
-        user_expression_sp = nullptr;
-
       lldb::UserExpressionSP fixed_expression_sp(
           target->GetUserExpressionForLanguage(fixed_expression->c_str(),
                                                full_prefix, language,


### PR DESCRIPTION
The upstream change 50f198535363c6882b02c3dde7bec31e723c4762 should do the
same thing.