### PR TITLE
fix iteration in jupyter code completion

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
@@ -253,8 +253,8 @@ SwiftCompleteCode(SwiftASTContext &SwiftCtx,
     // `completionCodeFile`, so that declarations that have been re-declared in
     // the user's current code take precedence over persistent declarations.
     DenseMap<Identifier, SmallVector<ValueDecl *, 1>> newDecls;
-    for (auto it = completionCodeFile.getTopLevelDecls().begin();
-         it != completionCodeFile.getTopLevelDecls().end(); it++)
+    auto topLevelDecls = completionCodeFile.getTopLevelDecls();
+    for (auto it = topLevelDecls.begin(); it != topLevelDecls.end(); it++)
       if (auto *newValueDecl = dyn_cast<ValueDecl>(*it))
         newDecls.FindAndConstruct(newValueDecl->getBaseName().getIdentifier())
             .second.push_back(newValueDecl);

--- a/lldb/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
@@ -253,9 +253,8 @@ SwiftCompleteCode(SwiftASTContext &SwiftCtx,
     // `completionCodeFile`, so that declarations that have been re-declared in
     // the user's current code take precedence over persistent declarations.
     DenseMap<Identifier, SmallVector<ValueDecl *, 1>> newDecls;
-    auto topLevelDecls = completionCodeFile.getTopLevelDecls();
-    for (auto it = topLevelDecls.begin(); it != topLevelDecls.end(); it++)
-      if (auto *newValueDecl = dyn_cast<ValueDecl>(*it))
+    for (auto *decl : completionCodeFile.getTopLevelDecls())
+      if (auto *newValueDecl = dyn_cast<ValueDecl>(decl))
         newDecls.FindAndConstruct(newValueDecl->getBaseName().getIdentifier())
             .second.push_back(newValueDecl);
 


### PR DESCRIPTION
The implementation of `getTopLevelDecls` changed from something that returns the same thing every time you call it to something that constructs a new thing every time you call it. The change broke our iteration over it. This PR fixes our iteration over it.