### PR TITLE
[lldb] Fix C++ error message to make TestTemplateFunction.py pass

### DIFF
--- a/lldb/test/API/lang/cpp/template-function/TestTemplateFunctions.py
+++ b/lldb/test/API/lang/cpp/template-function/TestTemplateFunctions.py
@@ -19,7 +19,7 @@ class TemplateFunctionsTestCase(TestBase):
         if add_cast:
           self.expect_expr("(int) foo(42)", result_type="int", result_value="42")
         else:
-          self.expect("expr b1 <=> b2",  error=True, substrs=["warning: <user expression 0>:1:4: '<=>' is a single token in C++20; add a space to avoid a change in behavior"])
+          self.expect("expr b1 <=> b2",  error=True, substrs=["warning: <user expression 0>:1:4: '<=>' is a single token in C++2a; add a space to avoid a change in behavior"])
 
           self.expect_expr("foo(42)", result_type="int", result_value="42")
 


### PR DESCRIPTION
When backporting D75761 the error message wasn't adapted to 'C++2a' from 'C++20'.