### PR TITLE
Fix type-dependency of bitfields in templates

### DIFF
--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -1685,6 +1685,11 @@ MemberExpr *MemberExpr::Create(
     CXXRecordDecl *RD = dyn_cast_or_null<CXXRecordDecl>(DC);
     if (RD && RD->isDependentContext() && RD->isCurrentInstantiation(DC))
       E->setTypeDependent(T->isDependentType());
+
+    // Bitfield with value-dependent width is type-dependent.
+    FieldDecl *FD = dyn_cast<FieldDecl>(MemberDecl);
+    if (FD && FD->isBitField() && FD->getBitWidth()->isValueDependent())
+      E->setTypeDependent(true);
   }
 
   if (HasQualOrFound) {

--- a/clang/test/SemaTemplate/enum-argument.cpp
+++ b/clang/test/SemaTemplate/enum-argument.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
+// expected-no-diagnostics
 
 enum Enum { val = 1 };
 template <Enum v> struct C {
@@ -30,7 +31,7 @@ namespace rdar8020920 {
     unsigned long long bitfield : e0;
 
     void f(int j) {
-      bitfield + j; // expected-warning {{expression result unused}}
+      bitfield + j;
     }
   };
 }

--- a/clang/test/SemaTemplate/value-dependent-bitfield-cond.cpp
+++ b/clang/test/SemaTemplate/value-dependent-bitfield-cond.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+// expected-no-diagnostics
+
+template <int b>
+class A {
+  int c : b;
+
+public:
+  void f() {
+    if (c)
+      ;
+  }
+};


### PR DESCRIPTION
This patch is a follow up to 878a24ee244a24. Name of bitfields
with value-dependent width should be set as type-dependent. This
patch adds the required value-dependency check and sets the
type-dependency accordingly.

Patch fixes PR44886

Differential revision: https://reviews.llvm.org/D72242