### PR TITLE
Backport [lldb] Mark expressions that couldn't be parsed or executed as failed

### DIFF
--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -398,9 +398,9 @@ CommandObjectExpression::GetEvalOptions(const Target &target) {
 }
 
 bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
-                                                 Stream *output_stream,
-                                                 Stream *error_stream,
-                                                 CommandReturnObject *result) {
+                                                 Stream &output_stream,
+                                                 Stream &error_stream,
+                                                 CommandReturnObject &result) {
   // Don't use m_exe_ctx as this might be called asynchronously after the
   // command object DoExecute has finished when doing multi-line expression
   // that use an input reader...
@@ -420,11 +420,10 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
 
   // We only tell you about the FixIt if we applied it.  The compiler errors
   // will suggest the FixIt if it parsed.
-  if (error_stream && !m_fixed_expression.empty() &&
-      target->GetEnableNotifyAboutFixIts()) {
+  if (!m_fixed_expression.empty() && target->GetEnableNotifyAboutFixIts()) {
     if (success == eExpressionCompleted)
-      error_stream->Printf("  Fix-it applied, fixed expression was: \n    %s\n",
-                           m_fixed_expression.c_str());
+      error_stream.Printf("  Fix-it applied, fixed expression was: \n    %s\n",
+                          m_fixed_expression.c_str());
   }
 
   if (result_valobj_sp) {
@@ -438,10 +437,10 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
         if (m_varobj_options.elem_count > 0) {
           Status error(CanBeUsedForElementCountPrinting(*result_valobj_sp));
           if (error.Fail()) {
-            result->AppendErrorWithFormat(
+            result.AppendErrorWithFormat(
                 "expression cannot be used with --element-count %s\n",
                 error.AsCString(""));
-            result->SetStatus(eReturnStatusFailed);
+            result.SetStatus(eReturnStatusFailed);
             return false;
           }
         }
@@ -451,36 +450,33 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
         options.SetVariableFormatDisplayLanguage(
             result_valobj_sp->GetPreferredDisplayLanguage());
 
-        result_valobj_sp->Dump(*output_stream, options);
+        result_valobj_sp->Dump(output_stream, options);
 
-        if (result)
-          result->SetStatus(eReturnStatusSuccessFinishResult);
+        result.SetStatus(eReturnStatusSuccessFinishResult);
       }
     } else {
       if (result_valobj_sp->GetError().GetError() ==
           UserExpression::kNoResult) {
         if (format != eFormatVoid && GetDebugger().GetNotifyVoid()) {
-          error_stream->PutCString("(void)\n");
+          error_stream.PutCString("(void)\n");
         }
 
-        if (result)
-          result->SetStatus(eReturnStatusSuccessFinishResult);
+        result.SetStatus(eReturnStatusSuccessFinishResult);
       } else {
         const char *error_cstr = result_valobj_sp->GetError().AsCString();
         if (error_cstr && error_cstr[0]) {
           const size_t error_cstr_len = strlen(error_cstr);
           const bool ends_with_newline = error_cstr[error_cstr_len - 1] == '\n';
           if (strstr(error_cstr, "error:") != error_cstr)
-            error_stream->PutCString("error: ");
-          error_stream->Write(error_cstr, error_cstr_len);
+            error_stream.PutCString("error: ");
+          error_stream.Write(error_cstr, error_cstr_len);
           if (!ends_with_newline)
-            error_stream->EOL();
+            error_stream.EOL();
         } else {
-          error_stream->PutCString("error: unknown error\n");
+          error_stream.PutCString("error: unknown error\n");
         }
 
-        if (result)
-          result->SetStatus(eReturnStatusFailed);
+        result.SetStatus(eReturnStatusFailed);
       }
     }
   }
@@ -497,7 +493,8 @@ void CommandObjectExpression::IOHandlerInputComplete(IOHandler &io_handler,
   StreamFileSP output_sp = io_handler.GetOutputStreamFileSP();
   StreamFileSP error_sp = io_handler.GetErrorStreamFileSP();
 
-  EvaluateExpression(line.c_str(), output_sp.get(), error_sp.get());
+  CommandReturnObject return_obj;
+  EvaluateExpression(line.c_str(), *output_sp, *error_sp, return_obj);
   if (output_sp)
     output_sp->Flush();
   if (error_sp)
@@ -647,8 +644,8 @@ bool CommandObjectExpression::DoExecute(llvm::StringRef command,
   }
 
   Target &target = GetSelectedOrDummyTarget();
-  if (EvaluateExpression(expr, &(result.GetOutputStream()),
-                         &(result.GetErrorStream()), &result)) {
+  if (EvaluateExpression(expr, result.GetOutputStream(),
+                         result.GetErrorStream(), result)) {
 
     if (!m_fixed_expression.empty() && target.GetEnableNotifyAboutFixIts()) {
       CommandHistory &history = m_interpreter.GetCommandHistory();

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -481,7 +481,8 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
     }
   }
 
-  return true;
+  return (success != eExpressionSetupError &&
+          success != eExpressionParseError);
 }
 
 void CommandObjectExpression::IOHandlerInputComplete(IOHandler &io_handler,

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -357,29 +357,13 @@ CanBeUsedForElementCountPrinting(ValueObject &valobj) {
   return Status();
 }
 
-bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
-                                                 Stream *output_stream,
-                                                 Stream *error_stream,
-                                                 CommandReturnObject *result) {
-  // Don't use m_exe_ctx as this might be called asynchronously after the
-  // command object DoExecute has finished when doing multi-line expression
-  // that use an input reader...
-  ExecutionContext exe_ctx(m_interpreter.GetExecutionContext());
-
-  Target *target = exe_ctx.GetTargetPtr();
-
-  if (!target)
-    target = &GetDummyTarget();
-
-  lldb::ValueObjectSP result_valobj_sp;
-  bool keep_in_memory = true;
-  StackFrame *frame = exe_ctx.GetFramePtr();
-
+EvaluateExpressionOptions
+CommandObjectExpression::GetEvalOptions(const Target &target) {
   EvaluateExpressionOptions options;
   options.SetCoerceToId(m_varobj_options.use_objc);
   options.SetUnwindOnError(m_command_options.unwind_on_error);
   options.SetIgnoreBreakpoints(m_command_options.ignore_breakpoints);
-  options.SetKeepInMemory(keep_in_memory);
+  options.SetKeepInMemory(true);
   options.SetUseDynamic(m_varobj_options.use_dynamic);
   options.SetTryAllThreads(m_command_options.try_all_threads);
   options.SetDebug(m_command_options.debug);
@@ -391,7 +375,7 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
 
   bool auto_apply_fixits;
   if (m_command_options.auto_apply_fixits == eLazyBoolCalculate)
-    auto_apply_fixits = target->GetEnableAutoApplyFixIts();
+    auto_apply_fixits = target.GetEnableAutoApplyFixIts();
   else
     auto_apply_fixits = m_command_options.auto_apply_fixits == eLazyBoolYes;
 
@@ -410,7 +394,27 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
     options.SetTimeout(std::chrono::microseconds(m_command_options.timeout));
   else
     options.SetTimeout(llvm::None);
+  return options;
+}
 
+bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
+                                                 Stream *output_stream,
+                                                 Stream *error_stream,
+                                                 CommandReturnObject *result) {
+  // Don't use m_exe_ctx as this might be called asynchronously after the
+  // command object DoExecute has finished when doing multi-line expression
+  // that use an input reader...
+  ExecutionContext exe_ctx(m_interpreter.GetExecutionContext());
+
+  Target *target = exe_ctx.GetTargetPtr();
+
+  if (!target)
+    target = &GetDummyTarget();
+
+  lldb::ValueObjectSP result_valobj_sp;
+  StackFrame *frame = exe_ctx.GetFramePtr();
+
+  const EvaluateExpressionOptions options = GetEvalOptions(*target);
   ExpressionResults success = target->EvaluateExpression(
       expr, frame, result_valobj_sp, options, &m_fixed_expression);
 

--- a/lldb/source/Commands/CommandObjectExpression.h
+++ b/lldb/source/Commands/CommandObjectExpression.h
@@ -71,6 +71,16 @@ protected:
   /// expression in the given target.
   EvaluateExpressionOptions GetEvalOptions(const Target &target);
 
+  /// Evaluates the given expression.
+  /// \param output_stream The stream to which the evaluation result will be
+  ///                      printed.
+  /// \param error_stream Contains error messages that should be displayed to
+  ///                     the user in case the evaluation fails.
+  /// \param result A CommandReturnObject which status will be set to the
+  ///               appropriate value depending on evaluation success and
+  ///               whether the expression produced any result.
+  /// \return Returns true iff the expression was successfully evaluated,
+  ///         executed and the result could be printed to the output stream.
   bool EvaluateExpression(llvm::StringRef expr, Stream &output_stream,
                           Stream &error_stream, CommandReturnObject &result);
 

--- a/lldb/source/Commands/CommandObjectExpression.h
+++ b/lldb/source/Commands/CommandObjectExpression.h
@@ -71,9 +71,8 @@ protected:
   /// expression in the given target.
   EvaluateExpressionOptions GetEvalOptions(const Target &target);
 
-  bool EvaluateExpression(llvm::StringRef expr, Stream *output_stream,
-                          Stream *error_stream,
-                          CommandReturnObject *result = nullptr);
+  bool EvaluateExpression(llvm::StringRef expr, Stream &output_stream,
+                          Stream &error_stream, CommandReturnObject &result);
 
   void GetMultilineExpression();
 

--- a/lldb/source/Commands/CommandObjectExpression.h
+++ b/lldb/source/Commands/CommandObjectExpression.h
@@ -14,7 +14,9 @@
 #include "lldb/Interpreter/OptionGroupBoolean.h"
 #include "lldb/Interpreter/OptionGroupFormat.h"
 #include "lldb/Interpreter/OptionGroupValueObjectDisplay.h"
+#include "lldb/Target/Target.h"
 #include "lldb/lldb-private-enumerations.h"
+
 namespace lldb_private {
 
 class CommandObjectExpression : public CommandObjectRaw,
@@ -64,6 +66,10 @@ protected:
                                 StringList &lines) override;
 
   bool DoExecute(llvm::StringRef command, CommandReturnObject &result) override;
+
+  /// Return the appropriate expression options used for evaluating the
+  /// expression in the given target.
+  EvaluateExpressionOptions GetEvalOptions(const Target &target);
 
   bool EvaluateExpression(llvm::StringRef expr, Stream *output_stream,
                           Stream *error_stream,

--- a/lldb/test/API/commands/statistics/basic/Makefile
+++ b/lldb/test/API/commands/statistics/basic/Makefile
@@ -1,0 +1,2 @@
+C_SOURCES := main.c
+include Makefile.rules

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -21,6 +21,20 @@ class TestCase(TestBase):
         self.expect("statistics dump", substrs=['expr evaluation successes : 1\n',
                                                 'expr evaluation failures : 0\n'])
 
+        self.expect("statistics enable")
+        # Doesn't parse.
+        self.expect("expr doesnt_exist", error=True,
+                    substrs=["undeclared identifier 'doesnt_exist'"])
+        # Doesn't successfully execute.
+        self.expect("expr int *i = nullptr; *i", error=True)
+        # Interpret an integer as an array with 3 elements is also a failure.
+        self.expect("expr -Z 3 -- 1", error=True,
+                    substrs=["expression cannot be used with --element-count"])
+        self.expect("statistics disable")
+        # We should have gotten 3 new failures and the previous success.
+        self.expect("statistics dump", substrs=['expr evaluation successes : 1\n',
+                                                'expr evaluation failures : 3\n'])
+
         # 'frame var' with disabled statistics shouldn't change stats.
         self.expect("frame var", substrs=['27'])
 

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -18,8 +18,8 @@ class TestCase(TestBase):
         self.expect("statistics enable", substrs=['already enabled'], error=True)
         self.expect("expr patatino", substrs=['27'])
         self.expect("statistics disable")
-        self.expect("statistics dump", substrs=['expr evaluation successes : 1',
-                                                'expr evaluation failures : 0'])
+        self.expect("statistics dump", substrs=['expr evaluation successes : 1\n',
+                                                'expr evaluation failures : 0\n'])
 
         # 'frame var' with disabled statistics shouldn't change stats.
         self.expect("frame var", substrs=['27'])
@@ -28,5 +28,5 @@ class TestCase(TestBase):
         # 'frame var' with enabled statistics will change stats.
         self.expect("frame var", substrs=['27'])
         self.expect("statistics disable")
-        self.expect("statistics dump", substrs=['frame var successes : 1',
-                                                'frame var failures : 0'])
+        self.expect("statistics dump", substrs=['frame var successes : 1\n',
+                                                'frame var failures : 0\n'])

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -1,5 +1,32 @@
-from lldbsuite.test import lldbinline
-from lldbsuite.test import decorators
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), [decorators.no_debug_info_test])
+class TestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "// break here", lldb.SBFileSpec("main.c"))
+
+        self.expect("statistics disable", substrs=['need to enable statistics before disabling'], error=True)
+
+        # 'expression' should change the statistics.
+        self.expect("statistics enable")
+        self.expect("statistics enable", substrs=['already enabled'], error=True)
+        self.expect("expr patatino", substrs=['27'])
+        self.expect("statistics disable")
+        self.expect("statistics dump", substrs=['expr evaluation successes : 1',
+                                                'expr evaluation failures : 0'])
+
+        # 'frame var' with disabled statistics shouldn't change stats.
+        self.expect("frame var", substrs=['27'])
+
+        self.expect("statistics enable")
+        # 'frame var' with enabled statistics will change stats.
+        self.expect("frame var", substrs=['27'])
+        self.expect("statistics disable")
+        self.expect("statistics dump", substrs=['frame var successes : 1',
+                                                'frame var failures : 0'])

--- a/lldb/test/API/commands/statistics/basic/main.c
+++ b/lldb/test/API/commands/statistics/basic/main.c
@@ -2,17 +2,6 @@
 
 int main(void) {
   int patatino = 27;
-  //%self.expect("statistics disable", substrs=['need to enable statistics before disabling'], error=True)
-  //%self.expect("statistics enable")
-  //%self.expect("statistics enable", substrs=['already enabled'], error=True)
-  //%self.expect("expr patatino", substrs=['27'])
-  //%self.expect("statistics disable")
-  //%self.expect("statistics dump", substrs=['expr evaluation successes : 1', 'expr evaluation failures : 0'])
-  //%self.expect("frame var", substrs=['27'])
-  //%self.expect("statistics enable")
-  //%self.expect("frame var", substrs=['27'])
-  //%self.expect("statistics disable")
-  //%self.expect("statistics dump", substrs=['frame var successes : 1', 'frame var failures : 0'])
 
-  return 0;
+  return 0; // break here
 }


### PR DESCRIPTION
This is just back porting this patch plus the necessary refactors to fix the merge conflicts.