### PR TITLE
[AppleObjCRuntimeV2] Force lazily allocated class names to be resolved.

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -1176,6 +1176,28 @@ AppleObjCRuntimeV2::GetClassDescriptorFromISA(ObjCISA isa) {
   return class_descriptor_sp;
 }
 
+static std::pair<bool, ConstString> ObjCGetClassNameRaw(
+                                      AppleObjCRuntime::ObjCISA isa,
+                                      Process *process) {
+  StreamString expr_string;
+  std::string input = std::to_string(isa);
+  expr_string.Printf("(const char *)objc_debug_class_getNameRaw(%s)",
+                     input.c_str());
+
+  ValueObjectSP result_sp;
+  EvaluateExpressionOptions eval_options;
+  eval_options.SetLanguage(lldb::eLanguageTypeObjC);
+  eval_options.SetResultIsInternal(true);
+  eval_options.SetGenerateDebugInfo(true);
+  eval_options.SetTimeout(process->GetUtilityExpressionTimeout());
+  auto eval_result = process->GetTarget().EvaluateExpression(
+      expr_string.GetData(),
+      process->GetThreadList().GetSelectedThread()->GetSelectedFrame().get(),
+      result_sp, eval_options);
+  ConstString type_name(result_sp->GetSummaryAsCString());
+  return std::make_pair(eval_result == eExpressionCompleted, type_name);
+}
+
 ObjCLanguageRuntime::ClassDescriptorSP
 AppleObjCRuntimeV2::GetClassDescriptor(ValueObject &valobj) {
   ClassDescriptorSP objc_class_sp;
@@ -1211,7 +1233,10 @@ AppleObjCRuntimeV2::GetClassDescriptor(ValueObject &valobj) {
     return objc_class_sp;
 
   objc_class_sp = GetClassDescriptorFromISA(isa);
-  if (isa && !objc_class_sp) {
+
+  if (objc_class_sp)
+    return objc_class_sp;
+  else {
     Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_PROCESS |
                                       LIBLLDB_LOG_TYPES));
     LLDB_LOGF(log,
@@ -1219,6 +1244,13 @@ AppleObjCRuntimeV2::GetClassDescriptor(ValueObject &valobj) {
               ": AppleObjCRuntimeV2::GetClassDescriptor() ISA was "
               "not in class descriptor cache 0x%" PRIx64,
               isa_pointer, isa);
+  }
+
+  ClassDescriptorSP descriptor_sp(new ClassDescriptorV2(*this, isa, nullptr));
+  auto resolved = ObjCGetClassNameRaw(isa, process);
+  if (resolved.first == true) {
+    AddClass(isa, descriptor_sp, resolved.second.AsCString());
+    objc_class_sp = descriptor_sp;
   }
   return objc_class_sp;
 }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -1208,7 +1208,8 @@ AppleObjCRuntimeV2::GetClassDescriptor(ValueObject &valobj) {
         if (isa != LLDB_INVALID_ADDRESS) {
           objc_class_sp = GetClassDescriptorFromISA(isa);
           if (isa && !objc_class_sp) {
-            Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_PROCESS));
+            Log *log(GetLogIfAnyCategoriesSet(LIBLLDB_LOG_PROCESS |
+                                              LIBLLDB_LOG_TYPES));
             LLDB_LOGF(log,
                       "0x%" PRIx64
                       ": AppleObjCRuntimeV2::GetClassDescriptor() ISA was "

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -1192,33 +1192,33 @@ AppleObjCRuntimeV2::GetClassDescriptor(ValueObject &valobj) {
   // if we get an invalid VO (which might still happen when playing around with
   // pointers returned by the expression parser, don't consider this a valid
   // ObjC object)
-  if (valobj.GetCompilerType().IsValid()) {
-    addr_t isa_pointer = valobj.GetPointerValue();
+  if (!valobj.GetCompilerType().IsValid())
+    return objc_class_sp;
+  addr_t isa_pointer = valobj.GetPointerValue();
 
-    // tagged pointer
-    if (IsTaggedPointer(isa_pointer)) {
-      return m_tagged_pointer_vendor_up->GetClassDescriptor(isa_pointer);
-    } else {
-      ExecutionContext exe_ctx(valobj.GetExecutionContextRef());
+  // tagged pointer
+  if (IsTaggedPointer(isa_pointer))
+    return m_tagged_pointer_vendor_up->GetClassDescriptor(isa_pointer);
+  ExecutionContext exe_ctx(valobj.GetExecutionContextRef());
 
-      Process *process = exe_ctx.GetProcessPtr();
-      if (process) {
-        Status error;
-        ObjCISA isa = process->ReadPointerFromMemory(isa_pointer, error);
-        if (isa != LLDB_INVALID_ADDRESS) {
-          objc_class_sp = GetClassDescriptorFromISA(isa);
-          if (isa && !objc_class_sp) {
-            Log *log(GetLogIfAnyCategoriesSet(LIBLLDB_LOG_PROCESS |
-                                              LIBLLDB_LOG_TYPES));
-            LLDB_LOGF(log,
-                      "0x%" PRIx64
-                      ": AppleObjCRuntimeV2::GetClassDescriptor() ISA was "
-                      "not in class descriptor cache 0x%" PRIx64,
-                      isa_pointer, isa);
-          }
-        }
-      }
-    }
+  Process *process = exe_ctx.GetProcessPtr();
+  if (!process)
+    return objc_class_sp;
+
+  Status error;
+  ObjCISA isa = process->ReadPointerFromMemory(isa_pointer, error);
+  if (isa == LLDB_INVALID_ADDRESS)
+    return objc_class_sp;
+
+  objc_class_sp = GetClassDescriptorFromISA(isa);
+  if (isa && !objc_class_sp) {
+    Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_PROCESS |
+                                      LIBLLDB_LOG_TYPES));
+    LLDB_LOGF(log,
+              "0x%" PRIx64
+              ": AppleObjCRuntimeV2::GetClassDescriptor() ISA was "
+              "not in class descriptor cache 0x%" PRIx64,
+              isa_pointer, isa);
   }
   return objc_class_sp;
 }

--- a/lldb/test/Shell/ExecControl/StopHook/stop-hook.test
+++ b/lldb/test/Shell/ExecControl/StopHook/stop-hook.test
@@ -46,12 +46,12 @@ target stop-hook list
 run
 # Stopping inside of the stop hook range
 # CHECK: (lldb) run
-# CHECK-NEXT: (void *) $0 = 0x
+# CHECK-NEXT: (void *) ${{.*}} = 0x
 
 thread step-over
 # Stepping inside of the stop hook range
 # CHECK: (lldb) thread step-over
-# CHECK-NEXT: (void *) $2 = 0x
+# CHECK-NEXT: (void *) ${{.*}} = 0x
 # CHECK: ->{{.*}} // We should stop here after stepping.
 
 process continue

--- a/lldb/test/Shell/ExecControl/StopHook/stop-hook.test
+++ b/lldb/test/Shell/ExecControl/StopHook/stop-hook.test
@@ -51,7 +51,7 @@ run
 thread step-over
 # Stepping inside of the stop hook range
 # CHECK: (lldb) thread step-over
-# CHECK-NEXT: (void *) $1 = 0x
+# CHECK-NEXT: (void *) $2 = 0x
 # CHECK: ->{{.*}} // We should stop here after stepping.
 
 process continue


### PR DESCRIPTION
Cherry-pick of the fix and related changes.