### PR TITLE
Disables the DWARF importer when initializing the Swift REPL

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -51,6 +51,7 @@ public:
 
   bool GetUseSwiftClangImporter() const;
   bool GetUseSwiftDWARFImporter() const;
+  bool SetUseSwiftDWARFImporter(bool new_value);
   FileSpec GetClangModulesCachePath() const;
   bool SetClangModulesCachePath(llvm::StringRef path);
   SwiftModuleLoadingMode GetSwiftModuleLoadingMode() const;

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -136,6 +136,11 @@ bool ModuleListProperties::GetUseSwiftDWARFImporter() const {
   return m_collection_sp->GetPropertyAtIndexAsBoolean(
       NULL, idx, g_modulelist_properties[idx].default_uint_value != 0);
 }
+
+bool ModuleListProperties::SetUseSwiftDWARFImporter(bool new_value) {
+    return m_collection_sp->SetPropertyAtIndexAsBoolean(
+            nullptr, ePropertyUseSwiftDWARFImporter, new_value);
+}
 // END SWIFT
 
 bool ModuleListProperties::SetClangModulesCachePath(llvm::StringRef path) {

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -266,6 +266,16 @@ void Target::SetREPL(lldb::LanguageType language, lldb::REPLSP repl_sp) {
   lldbassert(!m_repl_map.count(language));
 
   m_repl_map[language] = repl_sp;
+
+  if (language == eLanguageTypeSwift) {
+    // The DWARFImporter always claims to be able to load a module, even if it
+    // doesn't exist, because it doesn't "import" anything until the first type is
+    // requested. To make the REPL behave more like the compiler and diagnose when
+    // Clang modules can't be located up front, the DWARFImporter is disabled in
+    // the REPL. There are use-cases for loading Clang types from debug info, but
+    // this needs a better diagnostic mechanism before it can be enabled.
+    ModuleList::GetGlobalModuleListProperties().SetUseSwiftDWARFImporter(repl_sp == NULL);
+  }
 }
 
 void Target::Destroy() {

--- a/lldb/test/Shell/SwiftREPL/ImportError.test
+++ b/lldb/test/Shell/SwiftREPL/ImportError.test
@@ -1,0 +1,6 @@
+// Test that importing non-existing module fails.
+
+// RUN: %lldb --repl < %s 2>&1 | FileCheck %s
+
+import ModuleThatDoesNotExist
+// CHECK: error: no such module 'ModuleThatDoesNotExist'


### PR DESCRIPTION
This pull request solves issue [SR-11990](https://bugs.swift.org/browse/SR-11990), where importing non-existent modules would fail silently, by disabling the DWARF importer when initializing the Swift REPL.