### PR TITLE
[lldb/PlatformDarwin] Always delete destination file first in PutFile

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -58,6 +58,17 @@ PlatformDarwin::PlatformDarwin(bool is_host)
 /// inherited from by the plug-in instance.
 PlatformDarwin::~PlatformDarwin() {}
 
+lldb_private::Status
+PlatformDarwin::PutFile(const lldb_private::FileSpec &source,
+                        const lldb_private::FileSpec &destination, uint32_t uid,
+                        uint32_t gid) {
+  // Unconditionally unlink the destination. If it is an executable,
+  // simply opening it and truncating its contents would invalidate
+  // its cached code signature.
+  Unlink(destination);
+  return PlatformPOSIX::PutFile(source, destination, uid, gid);
+}
+
 FileSpecList PlatformDarwin::LocateExecutableScriptingResources(
     Target *target, Module &module, Stream *feedback_stream) {
   FileSpecList file_list;

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -26,6 +26,11 @@ public:
 
   ~PlatformDarwin() override;
 
+  lldb_private::Status PutFile(const lldb_private::FileSpec &source,
+                               const lldb_private::FileSpec &destination,
+                               uint32_t uid = UINT32_MAX,
+                               uint32_t gid = UINT32_MAX) override;
+
   // lldb_private::Platform functions
   lldb_private::Status
   ResolveSymbolFile(lldb_private::Target &target,


### PR DESCRIPTION
Summary:
The default behavior of Platform::PutFile is to open the file and
truncate it if it already exists. This works fine and is a sensible
default, but it interacts badly with code-signing on iOS, as doing so
invalidates the signature of the file (even if the new content has a
valid code signature).

We have a couple tests which on purpose reload a different binary with
the same name. Those tests are currently broken because of the above
interaction.

This patch simply makes the Darwin platform unconditionally delete the
destination file before sending the new one to work around this issue.

Reviewers: jasonmolenda

Subscribers: lldb-commits

Tags: #lldb

Differential Revision: https://reviews.llvm.org/D76450

(cherry picked from commit b6ae8937e031cde2e70e6a83d46c21e940fdf4ac)