### PR TITLE
[lldb/Utils] Use PYTHON_EXECUTABLE to configure lldb-dotest's shebang

### DIFF
--- a/lldb/utils/lldb-dotest/lldb-dotest.in
+++ b/lldb/utils/lldb-dotest/lldb-dotest.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@PYTHON_EXECUTABLE@
 import subprocess
 import sys
 


### PR DESCRIPTION
Ideally we'd want all shebangs to be configurable, but that's not a
viable solution. Given that lldb-dotest is already configured, we might
as well make sure it uses the correct interpreter.

Differential revision: https://reviews.llvm.org/D76167

(cherry picked from commit 2059d28bfd3cfedfcf7420f1c4627219811e81c4)