### PR TITLE
Re-enable tests working on Linux

### DIFF
--- a/lldb/test/API/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
+++ b/lldb/test/API/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
@@ -24,7 +24,6 @@ class TestSwiftConditionalBreakpoint(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @skipIfLinux
     def test_swift_conditional_breakpoint(self):
         """Tests that we can set a conditional breakpoint in Swift code"""
         self.build()

--- a/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
+++ b/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
@@ -25,7 +25,6 @@ class TestSwiftStepping(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @skipIfLinux
     def test_swift_stepping(self):
         """Tests that we can step reliably in swift code."""
         self.build()


### PR DESCRIPTION
This PR re-enables tests `TestSwiftConditionalBreakpoint` and `TestSwiftStepping`, which are currently disabled on Linux, but pass successfully.