### PR TITLE
[Swift] Replace calls to FuncDecl::getName & EnumElementDecl::getName with ValueDecl::getBaseIdentifier

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -283,8 +283,8 @@ void SwiftASTManipulatorBase::DoInitialization() {
             break;
           }
         }
-      } else if (FD->hasName() &&
-                 FD->getName().str().startswith(m_wrapper_func_prefix)) {
+      } else if (FD->hasName() && FD->getBaseIdentifier().str()
+                                    .startswith(m_wrapper_func_prefix)) {
         m_wrapper_decl = FD;
       }
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -250,7 +250,7 @@ public:
       // must be moved to the source-file level to be legal.  But we
       // don't want to register them with lldb unless they are of the
       // kind lldb explicitly wants to globalize.
-      if (shouldGlobalize(value_decl->getBaseName().getIdentifier(),
+      if (shouldGlobalize(value_decl->getBaseIdentifier(),
                           value_decl->getKind()))
         m_staged_decls.AddDecl(value_decl, false, ConstString());
     }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
@@ -136,7 +136,7 @@ void SwiftPersistentExpressionState::SwiftDeclMap::AddDecl(
   std::string name_str;
 
   if (alias.IsEmpty()) {
-    name_str = (value_decl->getBaseName().getIdentifier().str());
+    name_str = (value_decl->getBaseIdentifier().str());
   } else {
     name_str.assign(alias.GetCString());
   }

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -948,7 +948,7 @@ public:
                Dump(m_nopayload_elems_bitmask).c_str());
 
     for (auto enum_case : elements_with_no_payload) {
-      ConstString case_name(enum_case.decl->getName().str());
+      ConstString case_name(enum_case.decl->getBaseIdentifier().str());
       swift::ClusteredBitVector case_value =
           enum_impl_strategy.getBitPatternForNoPayloadElement(enum_case.decl);
 
@@ -1081,7 +1081,7 @@ public:
     auto module_ctx = enum_decl->getModuleContext();
     const bool has_payload = true;
     for (auto enum_case : elements_with_payload) {
-      ConstString case_name(enum_case.decl->getName().str());
+      ConstString case_name(enum_case.decl->getBaseIdentifier().str());
 
       swift::EnumElementDecl *case_decl = enum_case.decl;
       assert(case_decl);
@@ -6542,10 +6542,10 @@ TypeMemberFunctionImpl SwiftASTContext::GetMemberFunctionAtIndex(void *type,
                 swift::FuncDecl *func_decl =
                     llvm::dyn_cast<swift::FuncDecl>(*iter);
                 if (func_decl) {
-                  if (func_decl->getName().empty())
+                  if (func_decl->getBaseIdentifier().empty())
                     name.clear();
                   else
-                    name.assign(func_decl->getName().get());
+                    name.assign(func_decl->getBaseIdentifier().get());
                   if (func_decl->isStatic())
                     kind = lldb::eMemberFunctionKindStaticMethod;
                   else


### PR DESCRIPTION
 for apple/swift#30606