### PR TITLE
[lldb] Fix undefined behavior when having fixits in undefined top lev…

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
@@ -621,7 +621,10 @@ bool ClangUserExpression::Parse(DiagnosticManager &diagnostic_manager,
         size_t fixed_end;
         const std::string &fixed_expression =
             diagnostic_manager.GetFixedExpression();
-        if (m_source_code->GetOriginalBodyBounds(fixed_expression, m_expr_lang,
+        // Retrieve the original expression in case we don't have a top level
+        // expression (which has no surrounding source code).
+        if (m_source_code &&
+            m_source_code->GetOriginalBodyBounds(fixed_expression, m_expr_lang,
                                                  fixed_start, fixed_end))
           m_fixed_text =
               fixed_expression.substr(fixed_start, fixed_end - fixed_start);


### PR DESCRIPTION
…el exprs

In top level expressions, we don't have a m_source_code and we don't need to change
the source bounds (as no wrapping happend there). Fixes the test on the
sanitizer bot.

llvm-svn: 372817
(cherry picked from commit 06e98a8f4098a0ac702143fa52d8ab5e9b01803e)
Fixes rdar://problem/60920942