### PR TITLE
[dsymutil] Only set a translation lambda if the translator is valid

### DIFF
--- a/llvm/tools/dsymutil/DwarfLinker.cpp
+++ b/llvm/tools/dsymutil/DwarfLinker.cpp
@@ -2777,7 +2777,11 @@ bool DwarfLinker::link(const DebugMap &Map) {
   // This Dwarf string pool which is used for emission. It must be used
   // serially as the order of calling getStringOffset matters for
   // reproducibility.
-  OffsetsStringPool OffsetsStringPool(Options.Translator, true);
+  std::function<StringRef(StringRef)> TranslationLambda =
+      Options.Translator
+          ? [&](StringRef Input) { return Options.Translator(Input); }
+          : static_cast<std::function<StringRef(StringRef)>>(nullptr);
+  OffsetsStringPool OffsetsStringPool(TranslationLambda, true);
 
   // ODR Contexts for the link.
   DeclContextTree ODRContexts;


### PR DESCRIPTION
The SymbolMapTranslator defines an operator bool() which checks whether
we should translate at all. This returns false if the list of obfuscated
strings is empty.

The NonRelocatableStringPool (OffsetsStringPool) takes a lambda for
translating obfuscated strings rather than a SymbolMapTranslator.
However, we were unconditionally passing the SymbolMapTranslator, which
got implicitly converted to a std::function because it defines an
operator().

In the string pool, we call operator bool but on the lambda, and not on
the SymbolMapTranslator. This would always be true, because we were
passing the translator unconditionally. This caused spurious warnings
about obfuscated strings not being found.

This patch fixes the problem by only passing the translation lambda when
SymbolMapTranslator::operator bool() is true.