### PR TITLE
Fix result numbering

### DIFF
--- a/lldb/include/lldb/Expression/ExpressionVariable.h
+++ b/lldb/include/lldb/Expression/ExpressionVariable.h
@@ -222,11 +222,7 @@ public:
                            uint32_t addr_byte_size) = 0;
 
   /// Return a new persistent variable name with the specified prefix.
-  ConstString GetNextPersistentVariableName(Target &target,
-                                            llvm::StringRef prefix);
-
-  virtual llvm::StringRef
-  GetPersistentVariablePrefix(bool is_error = false) const = 0;
+  virtual ConstString GetNextPersistentVariableName(bool is_error = false) = 0;
 
   virtual void
   RemovePersistentVariable(lldb::ExpressionVariableSP variable) = 0;
@@ -239,6 +235,10 @@ public:
   void RegisterExecutionUnit(lldb::IRExecutionUnitSP &execution_unit_sp);
 
   void RegisterSymbol(ConstString name, lldb::addr_t address);
+
+protected:
+  virtual llvm::StringRef
+  GetPersistentVariablePrefix(bool is_error = false) const = 0;
 
 private:
   LLVMCastKind m_kind;

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1187,11 +1187,6 @@ public:
 
   lldb::ExpressionVariableSP GetPersistentVariable(ConstString name);
 
-  /// Return the next available number for numbered persistent variables.
-  unsigned GetNextPersistentVariableIndex() {
-    return m_next_persistent_variable_index++;
-  }
-
   lldb::addr_t GetPersistentSymbol(ConstString name);
 
   /// This method will return the address of the starting function for

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -3344,9 +3344,7 @@ ValueObjectSP ValueObject::Persist() {
   if (!persistent_state)
     return nullptr;
 
-  auto prefix = persistent_state->GetPersistentVariablePrefix();
-  ConstString name =
-      persistent_state->GetNextPersistentVariableName(*target_sp, prefix);
+  ConstString name = persistent_state->GetNextPersistentVariableName();
 
   ValueObjectSP const_result_sp =
       ValueObjectConstResult::Create(target_sp.get(), GetValue(), name);

--- a/lldb/source/Expression/ExpressionVariable.cpp
+++ b/lldb/source/Expression/ExpressionVariable.cpp
@@ -81,13 +81,3 @@ void PersistentExpressionState::RegisterExecutionUnit(
     }
   }
 }
-
-ConstString PersistentExpressionState::GetNextPersistentVariableName(
-    Target &target, llvm::StringRef Prefix) {
-  llvm::SmallString<64> name;
-  {
-    llvm::raw_svector_ostream os(name);
-    os << Prefix << target.GetNextPersistentVariableIndex();
-  }
-  return ConstString(name);
-}

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -954,11 +954,9 @@ public:
       return;
     }
 
-    ConstString name =
-        m_delegate
-            ? m_delegate->GetName()
-            : persistent_state->GetNextPersistentVariableName(
-                  *target_sp, persistent_state->GetPersistentVariablePrefix());
+    ConstString name = m_delegate
+                           ? m_delegate->GetName()
+                           : persistent_state->GetNextPersistentVariableName();
 
     lldb::ExpressionVariableSP ret = persistent_state->CreatePersistentVariable(
         exe_scope, name, m_type, map.GetByteOrder(), map.GetAddressByteSize());

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.cpp
@@ -118,3 +118,14 @@ clang::NamedDecl *
 ClangPersistentVariables::GetPersistentDecl(ConstString name) {
   return m_persistent_decls.lookup(name.GetCString()).m_decl;
 }
+
+ConstString
+ClangPersistentVariables::GetNextPersistentVariableName(bool is_error) {
+  llvm::SmallString<64> name;
+  {
+    llvm::raw_svector_ostream os(name);
+    os << GetPersistentVariablePrefix(is_error)
+       << m_next_persistent_variable_id++;
+  }
+  return ConstString(name);
+}

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.h
@@ -53,9 +53,7 @@ public:
 
   void RemovePersistentVariable(lldb::ExpressionVariableSP variable) override;
 
-  llvm::StringRef GetPersistentVariablePrefix(bool is_error) const override {
-    return "$";
-  }
+  virtual ConstString GetNextPersistentVariableName(bool is_error = false);
 
   // This just adds this module to the list of hand-loaded modules, it doesn't
   // actually load it.
@@ -96,6 +94,12 @@ public:
 
   const ClangModulesDeclVendor::ModuleVector &GetHandLoadedClangModules() {
     return m_hand_loaded_clang_modules;
+  }
+
+protected:
+  llvm::StringRef
+  GetPersistentVariablePrefix(bool is_error = false) const override {
+    return "$";
   }
 
 private:

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
@@ -914,9 +914,7 @@ void ClangUserExpression::ClangUserExpressionHelper::CommitPersistentDecls() {
 }
 
 ConstString ClangUserExpression::ResultDelegate::GetName() {
-  auto prefix = m_persistent_state->GetPersistentVariablePrefix();
-  return m_persistent_state->GetNextPersistentVariableName(*m_target_sp,
-                                                           prefix);
+  return m_persistent_state->GetNextPersistentVariableName(false);
 }
 
 void ClangUserExpression::ResultDelegate::DidDematerialize(

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
@@ -226,3 +226,15 @@ bool SwiftPersistentExpressionState::GetSwiftPersistentDecls(
   return m_swift_persistent_decls.FindMatchingDecls(name, excluding_equivalents,
                                                     matches);
 }
+
+ConstString
+SwiftPersistentExpressionState::GetNextPersistentVariableName(bool is_error) {
+  llvm::SmallString<64> name;
+  {
+    llvm::raw_svector_ostream os(name);
+    uint32_t variable_num = is_error ? m_next_persistent_error_id++
+                                     : m_next_persistent_variable_id++;
+    os << GetPersistentVariablePrefix(is_error) << variable_num;
+  }
+  return ConstString(name);
+}

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
@@ -92,6 +92,8 @@ public:
 
   void RemovePersistentVariable(lldb::ExpressionVariableSP variable) override;
 
+  ConstString GetNextPersistentVariableName(bool is_error = false) override;
+
   llvm::Optional<CompilerType>
   GetCompilerTypeFromPersistentDecl(ConstString type_name) override;
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
@@ -124,11 +124,9 @@ public:
                          "doesn't have persistent state");
     }
 
-    auto prefix = persistent_state->GetPersistentVariablePrefix();
-    ConstString name =
-        m_delegate ? m_delegate->GetName()
-                   : persistent_state->GetNextPersistentVariableName(*target_sp,
-                                                                     prefix);
+    ConstString name = m_delegate
+                           ? m_delegate->GetName()
+                           : persistent_state->GetNextPersistentVariableName();
 
     lldb::ExpressionVariableSP ret;
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -569,9 +569,7 @@ SwiftUserExpression::ResultDelegate::ResultDelegate(
     : m_target_sp(target), m_is_error(is_error) {}
 
 ConstString SwiftUserExpression::ResultDelegate::GetName() {
-  auto prefix = m_persistent_state->GetPersistentVariablePrefix(m_is_error);
-  return m_persistent_state->GetNextPersistentVariableName(*m_target_sp,
-                                                           prefix);
+  return m_persistent_state->GetNextPersistentVariableName(m_is_error);
 }
 
 void SwiftUserExpression::ResultDelegate::DidDematerialize(

--- a/lldb/source/Target/ABI.cpp
+++ b/lldb/source/Target/ABI.cpp
@@ -95,10 +95,8 @@ ValueObjectSP ABI::GetReturnValueObject(Thread &thread, CompilerType &ast_type,
     if (!persistent_expression_state)
       return ValueObjectSP();
 
-    auto prefix = persistent_expression_state->GetPersistentVariablePrefix();
     ConstString persistent_variable_name =
-        persistent_expression_state->GetNextPersistentVariableName(target,
-                                                                   prefix);
+        persistent_expression_state->GetNextPersistentVariableName();
 
     lldb::ValueObjectSP const_valobj_sp;
 

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -1098,10 +1098,8 @@ ValueObjectSP SwiftLanguageRuntime::CalculateErrorValueObjectFromValue(
     auto *persistent_state =
         target.GetSwiftPersistentExpressionState(*exe_scope);
 
-    const bool is_error = true;
-    auto prefix = persistent_state->GetPersistentVariablePrefix(is_error);
     ConstString persistent_variable_name(
-        persistent_state->GetNextPersistentVariableName(target, prefix));
+        persistent_state->GetNextPersistentVariableName(/*is_error*/ true));
 
     lldb::ValueObjectSP const_valobj_sp;
 

--- a/lldb/source/Target/ThreadPlanCallFunction.cpp
+++ b/lldb/source/Target/ThreadPlanCallFunction.cpp
@@ -477,6 +477,7 @@ bool ThreadPlanCallFunction::BreakpointsExplainStop() {
     }
   }
   if (m_error_backstop_bp_sp) {
+<<<<<<< HEAD
     uint64_t break_site_id = stop_info_sp->GetValue();
     if (m_process.GetBreakpointSiteList().BreakpointSiteContainsBreakpoint(
             break_site_id, m_error_backstop_bp_sp->GetID())) {
@@ -490,11 +491,8 @@ bool ThreadPlanCallFunction::BreakpointsExplainStop() {
       PersistentExpressionState *persistent_state =
           GetTarget().GetPersistentExpressionStateForLanguage(
               eLanguageTypeSwift);
-      const bool is_error = true;
-      auto prefix = persistent_state->GetPersistentVariablePrefix(is_error);
       ConstString persistent_variable_name(
-          persistent_state->GetNextPersistentVariableName(GetTarget(),
-                                                          prefix));
+              persistent_state->GetNextPersistentVariableName(/*is_error*/ true));
       if (m_return_valobj_sp = SwiftLanguageRuntime::CalculateErrorValue(
               frame_sp, persistent_variable_name)) {
 

--- a/lldb/source/Target/ThreadPlanCallFunction.cpp
+++ b/lldb/source/Target/ThreadPlanCallFunction.cpp
@@ -477,7 +477,6 @@ bool ThreadPlanCallFunction::BreakpointsExplainStop() {
     }
   }
   if (m_error_backstop_bp_sp) {
-<<<<<<< HEAD
     uint64_t break_site_id = stop_info_sp->GetValue();
     if (m_process.GetBreakpointSiteList().BreakpointSiteContainsBreakpoint(
             break_site_id, m_error_backstop_bp_sp->GetID())) {

--- a/lldb/test/API/commands/expression/result_numbering/Makefile
+++ b/lldb/test/API/commands/expression/result_numbering/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
+
+include Makefile.rules

--- a/lldb/test/API/commands/expression/result_numbering/TestResultNumbering.py
+++ b/lldb/test/API/commands/expression/result_numbering/TestResultNumbering.py
@@ -1,0 +1,48 @@
+"""
+Make sure running internal expressions doesn't
+influence the result variable numbering.
+"""
+
+
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+
+
+class TestExpressionResultNumbering(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_sample_rename_this(self):
+        self.build()
+        self.main_source_file = lldb.SBFileSpec("main.c")
+        self.do_numbering_test()
+
+    def do_numbering_test(self):
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(self,
+                                   "Set a breakpoint here", self.main_source_file)
+
+        bkpt = target.BreakpointCreateBySourceRegex("Add conditions to this breakpoint",
+                                                    self.main_source_file)
+        self.assertEqual(bkpt.GetNumLocations(), 1, "Set the breakpoint")
+
+        bkpt.SetCondition("call_me(value) < 6")
+
+        # Get the number of the last expression:
+        result = thread.frames[0].EvaluateExpression("call_me(200)")
+        self.assertTrue(result.GetError().Success(), "Our expression succeeded")
+        name = result.GetName()
+        ordinal = int(name[1:])
+        
+        process.Continue()
+
+        # The condition evaluation had to run a 4 expressions, but we haven't
+        # run any user expressions.
+        result = thread.frames[0].EvaluateExpression("call_me(200)")
+        self.assertTrue(result.GetError().Success(), "Our expression succeeded the second time")
+        after_name = result.GetName()
+        after_ordinal = int(after_name[1:])
+        self.assertEqual(ordinal + 1, after_ordinal) 

--- a/lldb/test/API/commands/expression/result_numbering/main.c
+++ b/lldb/test/API/commands/expression/result_numbering/main.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+
+int
+call_me(int input)
+{
+  return input;
+}
+
+int
+main()
+{
+  int value = call_me(0); // Set a breakpoint here
+  while (value < 10)
+    {
+      printf("Add conditions to this breakpoint: %d.\n", value++);
+    }
+  return 0;
+}


### PR DESCRIPTION
Pulling the two commits from swift/master-next to fix the result so that Private expression results don't take up result numbering slots.