### PR TITLE
[SwiftASTContext] Add missing null check in ImportType

### DIFF
--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -5322,7 +5322,7 @@ CompilerType SwiftASTContext::ImportType(CompilerType &type, Status &error) {
   auto *ts = type.GetTypeSystem();
   SwiftASTContext *swift_ast_ctx = llvm::dyn_cast_or_null<SwiftASTContext>(ts);
 
-  if (swift_ast_ctx == nullptr && !llvm::isa<TypeSystemSwift>(ts)) {
+  if (swift_ast_ctx == nullptr && (!ts || !llvm::isa<TypeSystemSwift>(ts))) {
     error.SetErrorString("Can't import clang type into a Swift ASTContext.");
     return CompilerType();
   } else if (swift_ast_ctx == this) {

--- a/lldb/test/Shell/Swift/Inputs/No.swiftmodule.swift
+++ b/lldb/test/Shell/Swift/Inputs/No.swiftmodule.swift
@@ -1,5 +1,11 @@
+import NoSwiftmoduleHelper
+
 // The struct could not possibly be resolved with just the mangled type name.
 struct s { let i = 0 }
+
+func useTypeFromOtherModule(x: S2) {
+  // break here
+}
 
 func f<T>(_ t: T) {
   let number = 1                   // CHECK-DAG: (Int) number = 1
@@ -7,10 +13,12 @@ func f<T>(_ t: T) {
   let string = "hello"             // CHECK-DAG: (String) string = "hello"
   let tuple = (0, 1)               // CHECK-DAG: (Int, Int) tuple = (0 = 0, 1 = 1)
   let strct = s()                  // CHECK-DAG: strct ={{$}}
+  let strct2 = S2()                // CHECK-DAG: strct2 = <extracting data from value failed>
   let generic = t                  // CHECK-DAG: (Int) generic = 23
   let generic_tuple = (t, t)       // CHECK-DAG: generic_tuple =
                             // FIXME: CHECK-DAG: <read memory {{.*}} failed
-  print(number) // break here
+  print(number)
+  useTypeFromOtherModule(x: S2())
 }
 
 f(23)

--- a/lldb/test/Shell/Swift/Inputs/NoSwiftmoduleHelper.swift
+++ b/lldb/test/Shell/Swift/Inputs/NoSwiftmoduleHelper.swift
@@ -1,0 +1,3 @@
+public struct S2 {
+  public init() {}
+}

--- a/lldb/test/Shell/Swift/No.swiftmodule.test
+++ b/lldb/test/Shell/Swift/No.swiftmodule.test
@@ -1,13 +1,28 @@
 # This tests debugging without the presence of a .swiftmodule.
 
 # RUN: rm -rf %t && mkdir %t && cd %t
+#
+# Test what happens when we import NoSwiftmoduleHelper from main and use types
+# from it (this used to crash, see rdar://60734897).
 # RUN: %target-swift-frontend -c -g -serialize-debugging-options \
 # RUN:          -module-cache-path %t/cache \
+# RUN:          -parse-as-library \
+# RUN:          -module-name NoSwiftmoduleHelper \
+# RUN:          -emit-module \
+# RUN:          -emit-module-path NoSwiftmoduleHelper.swiftmodule \
+# RUN:          %S/Inputs/NoSwiftmoduleHelper.swift \
+# RUN:          -o NoSwiftmoduleHelper.o
+
+# RUN: %target-swift-frontend -c -g -serialize-debugging-options \
+# RUN:          -module-cache-path %t/cache -I %t \
 # RUN:          -primary-file %S/Inputs/No.swiftmodule.swift \
 # RUN:          -module-name main -o %t/main.o
-# RUN: %target-swiftc -o %t/a.out %t/main.o
+#
+# RUN: %target-swiftc -o %t/a.out %t/main.o %t/NoSwiftmoduleHelper.o
 # RUN: %lldb %t/a.out -s %s | FileCheck %S/Inputs/No.swiftmodule.swift
 
 breakpoint set -p "break here"
 run
+fr var
+up
 fr var


### PR DESCRIPTION
Add a missing null check in ImportType. Without this, a program that
does not contain an N_AST reference pointing back to a swiftmodule it
uses can cause lldb to crash.

rdar://60734897
(cherry picked from commit 1634e7413f63945a146bc3041175473b0a1800a4)