### PR TITLE
Fix unknown type cast crash

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -612,6 +612,7 @@ public:
 
   /// Reconstruct a Swift AST type from a mangled name by looking its
   /// components up in Swift modules.
+  swift::TypeBase *ReconstructType(ConstString mangled_typename);
   swift::TypeBase *ReconstructType(ConstString mangled_typename, Status &error);
   CompilerType GetTypeFromMangledTypename(ConstString mangled_typename);
 
@@ -667,6 +668,7 @@ public:
   void ClearDiagnostics();
 
   bool SetColorizeDiagnostics(bool b);
+  void AddErrorStatusAsGenericDiagnostic(Status error);
 
   void PrintDiagnostics(DiagnosticManager &diagnostic_manager,
                         uint32_t bufferID = UINT32_MAX, uint32_t first_line = 0,

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -244,7 +244,7 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
     self_type = ToCompilerType(object_type.getPointer());
 
   // Handle weak self.
-  if (auto *ref_type = llvm::dyn_cast<swift::ReferenceStorageType>(
+  if (auto *ref_type = llvm::dyn_cast_or_null<swift::ReferenceStorageType>(
           GetSwiftType(self_type).getPointer())) {
     if (ref_type->getOwnership() == swift::ReferenceOwnership::Weak) {
       m_is_class = true;


### PR DESCRIPTION
This PR fixes the crash reported [here](https://bugs.swift.org/browse/SR-11746). In addition, it improves the error message when type reconstruction fails in the `SwiftASTContext` class.