### PR TITLE
[lldb/test] Fix Swift testsuite environemnt

### DIFF
--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -31,12 +31,12 @@ option(LLDB_TEST_SWIFT "Use in-tree swift when testing lldb" On)
 
 if(LLDB_TEST_SWIFT)
   set(LLDB_SWIFTC ${SWIFT_BINARY_DIR}/bin/swiftc CACHE STRING "Path to swift compiler")
-  set(LLDB_SWIFT_LIBS ${SWIFT_LIBRARY_DIR}/swift/macosx CACHE STRING "Path to swift libraries")
+  set(LLDB_SWIFT_LIBS ${SWIFT_LIBRARY_DIR}/swift CACHE STRING "Path to swift libraries")
   set(SWIFT_TEST_ARGS
     --swift-compiler ${LLDB_SWIFTC}
-    --inferior-env "DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}\\\""
-    --inferior-env "LD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}\\\""
-    --inferior-env "SIMCTL_CHILD_DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}\\\""
+    --inferior-env "DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/macosx\\\""
+    --inferior-env "LD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/${CMAKE_SYSTEM_PROCESSOR}\\\""
+    --inferior-env "SIMCTL_CHILD_DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/macosx\\\""
   )
 endif()
 # END - Swift Mods

--- a/lldb/test/Shell/lit-lldb-init.in
+++ b/lldb/test/Shell/lit-lldb-init.in
@@ -1,5 +1,5 @@
 # LLDB init file for the LIT tests.
-env DYLD_LIBRARY_PATH='@LLDB_SWIFT_LIBS@' LD_LIBRARY_PATH='@LLDB_SWIFT_LIBS@' SIMCTL_CHILD_DYLD_LIBRARY_PATH='@LLDB_SWIFT_LIBS@'
+env DYLD_LIBRARY_PATH='@LLDB_SWIFT_LIBS@/macosx' LD_LIBRARY_PATH='@LLDB_SWIFT_LIBS@/@CMAKE_SYSTEM_PROCESSOR@' SIMCTL_CHILD_DYLD_LIBRARY_PATH='@LLDB_SWIFT_LIBS@/macosx'
 settings set symbols.enable-external-lookup false
 settings set plugin.process.gdb-remote.packet-timeout 60
 settings set interpreter.echo-comment-commands false


### PR DESCRIPTION
We have tried chaging `LLDB_SWIFT_LIBS` in `test/API/CMakelists.txt` before
to point it to a directory that actually contains the just built runtime
libraries. Unfortunately, `LLDB_SWIFT_LIBS` is a cache variable that gets
passed by `build-script`, so this change has no effect.

Instead, add `macosx` to the uses of the variable. For `LD_LIBRARY_PATH`,
which is used on non-darwin systems, use `CMAKE_SYSTEM_PROCESSOR` instead
which is what the Swift test code seems to be doing.

This also fixed the same issue in the Shell tests.