### PR TITLE
[lldb/DataFormatters] Fix the `$$deference$$` synthetic child

### DIFF
--- a/lldb/docs/use/variable.rst
+++ b/lldb/docs/use/variable.rst
@@ -845,7 +845,7 @@ adheres to a given interface (the word is italicized because Python has no
 explicit notion of interface, by that word we mean a given set of methods must
 be implemented by the Python class):
 
-::
+.. code-block:: python
 
    class SyntheticChildrenProvider:
       def __init__(self, valobj, internal_dict):
@@ -882,9 +882,30 @@ As a shortcut for this, you can inherit from lldb.SBSyntheticValueProvider, and
 just define get_value as other methods are defaulted in the superclass as
 returning default no-children responses.
 
-If a synthetic child provider supplies a special child named $$dereference$$
-then it will be used when evaluating opertaor* and operator-> in the frame
-variable command and related SB API functions.
+If a synthetic child provider supplies a special child named
+``$$dereference$$`` then it will be used when evaluating ``operator *`` and
+``operator ->`` in the frame variable command and related SB API
+functions. It is possible to declare this synthetic child without
+including it in the range of children displayed by LLDB. For example,
+this subset of a synthetic children provider class would allow the
+synthetic value to be dereferenced without actually showing any
+synthtic children in the UI:
+
+.. code-block:: python
+
+      class SyntheticChildrenProvider:
+          [...]
+          def num_children(self):
+              return 0
+          def get_child_index(self, name):
+              if name == '$$dereference$$':
+                  return 0
+              return -1
+          def get_child_at_index(self, index):
+              if index == 0:
+                  return <valobj resulting from dereference>
+              return None
+
 
 For examples of how synthetic children are created, you are encouraged to look
 at examples/synthetic in the LLDB trunk. Please, be aware that the code in

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -2859,6 +2859,9 @@ ValueObjectSP ValueObject::Dereference(Status &error) {
         GetSyntheticValue()
             ->GetChildMemberWithName(ConstString("$$dereference$$"), true)
             .get();
+  } else if (IsSynthetic()) {
+    m_deref_valobj =
+        GetChildMemberWithName(ConstString("$$dereference$$"), true).get();
   }
 
   if (m_deref_valobj) {

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-python-synth/fooSynthProvider.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-python-synth/fooSynthProvider.py
@@ -28,3 +28,29 @@ class fooSynthProvider:
 
     def update(self):
         return True
+
+
+class wrapfooSynthProvider:
+
+    def __init__(self, valobj, dict):
+        self.valobj = valobj
+
+    def num_children(self):
+        return 1
+
+    def get_child_at_index(self, index):
+        if index == 0:
+            return self.valobj.GetChildMemberWithName('ptr')
+        if index == 1:
+            return self.valobj.GetChildMemberWithName('ptr').Dereference()
+        return None
+
+    def get_child_index(self, name):
+        if name == 'ptr':
+            return 0
+        if name == '$$dereference$$':
+            return 1
+        return -1
+
+    def update(self):
+        return True

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-python-synth/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-python-synth/main.cpp
@@ -46,11 +46,17 @@ struct wrapint
     wrapint(int X) : x(X) {}
 };
 
+struct wrapfoo
+{
+    foo *ptr;
+};
+
 int main()
 {
     foo f00_1(1);
     foo *f00_ptr = new foo(12);
-    
+    wrapfoo wrapper{f00_ptr};
+
     f00_1.a++; // Set break point at this line.
     
     wrapint test_cast('A' +


### PR DESCRIPTION
Summary:
The ValueObject code checks for a special `$$dereference$$` synthetic
child to allow formatter providers to implement a natural
dereferencing behavior in `frame variable` for objects like smart
pointers.

This support was broken when used directly throught the Python API and
not trhough `frame variable`. The reason is that
SBFrame.FindVariable() will return by default the synthetic variable
if it exists, while `frame variable` will not do this eagerly. The
code in `ValueObject::Dereference()` accounted for the latter but not
for the former. The fix is trivial. The test change includes
additional covergage for the already-working bahevior as it wasn't
covered by the testsuite before.

This commit also adds a short piece of documentatione explaining that
it is possible (even advisable) to provide this synthetic child
outstide of the range of the normal children.

Reviewers: jingham

Subscribers: lldb-commits

Tags: #lldb

Differential Revision: https://reviews.llvm.org/D73053

(cherry picked from commit 0478eadf73c191199cba12c85785cfafb8bfa174)