### PR TITLE
[debugserver/ARM64] Make sure watchpoints hit are attributed correctly.

### DIFF
--- a/lldb/test/API/commands/watchpoints/watchpoint_count/Makefile
+++ b/lldb/test/API/commands/watchpoints/watchpoint_count/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/commands/watchpoints/watchpoint_count/TestWatchpointCount.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_count/TestWatchpointCount.py
@@ -1,0 +1,43 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+class TestWatchpointCount(TestBase):
+    mydir = TestBase.compute_mydir(__file__)
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    def test_watchpoint_count(self):
+        self.build()
+        (_, process, thread, _) = lldbutil.run_to_source_breakpoint(self, "patatino", lldb.SBFileSpec("main.c"))
+        frame = thread.GetFrameAtIndex(0)
+        first_var = frame.FindVariable("x1")
+        second_var = frame.FindVariable("x2")
+
+        error = lldb.SBError()
+        first_watch = first_var.Watch(True, False, True, error)
+        if not error.Success():
+            self.fail(
+                "Failed to make watchpoint for x1: %s" %
+                (error.GetCString()))
+
+        second_watch = second_var.Watch(True, False, True, error)
+        if not error.Success():
+            self.fail(
+                "Failed to make watchpoint for x2: %s" %
+                (error.GetCString()))
+        process.Continue()
+
+        stop_reason = thread.GetStopReason()
+        self.assertEqual(stop_reason, lldb.eStopReasonWatchpoint, "watchpoint for x1 not hit")
+        stop_reason_descr = thread.GetStopDescription(256)
+        self.assertEqual(stop_reason_descr, "watchpoint 1")
+
+        process.Continue()
+        stop_reason = thread.GetStopReason()
+        self.assertEqual(stop_reason, lldb.eStopReasonWatchpoint, "watchpoint for x2 not hit")
+        stop_reason_descr = thread.GetStopDescription(256)
+        self.assertEqual(stop_reason_descr, "watchpoint 2")

--- a/lldb/test/API/commands/watchpoints/watchpoint_count/main.c
+++ b/lldb/test/API/commands/watchpoints/watchpoint_count/main.c
@@ -1,0 +1,13 @@
+#include <stdint.h>
+#include <stdio.h>
+
+int main() {
+  uint8_t x1 = 0;
+  uint16_t x2 = 0;
+
+  printf("patatino\n");
+
+  x1 += 1;
+  x2 += 2;
+  return 0;
+}


### PR DESCRIPTION
This didn't happen for arm64 if you have watches for variables
that are contigous in memory.

<rdar://problem/55135006>