### PR TITLE
[20200108] [pch] Honour -fallow-pch-with-compiler-errors for overall compilation status

### DIFF
--- a/clang/include/clang/Frontend/FrontendAction.h
+++ b/clang/include/clang/Frontend/FrontendAction.h
@@ -312,6 +312,7 @@ protected:
   bool BeginSourceFileAction(CompilerInstance &CI) override;
   void ExecuteAction() override;
   void EndSourceFileAction() override;
+  bool shouldEraseOutputFiles() override;
 
 public:
   /// Construct a WrapperFrontendAction from an existing action, taking

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -1096,6 +1096,9 @@ void WrapperFrontendAction::ExecuteAction() {
 void WrapperFrontendAction::EndSourceFileAction() {
   WrappedAction->EndSourceFileAction();
 }
+bool WrapperFrontendAction::shouldEraseOutputFiles() {
+  return WrappedAction->shouldEraseOutputFiles();
+}
 
 bool WrapperFrontendAction::usesPreprocessorOnly() const {
   return WrappedAction->usesPreprocessorOnly();

--- a/clang/lib/Serialization/GeneratePCH.cpp
+++ b/clang/lib/Serialization/GeneratePCH.cpp
@@ -57,6 +57,11 @@ void PCHGenerator::HandleTranslationUnit(ASTContext &Ctx) {
     }
   }
 
+  // Errors that do not prevent the PCH from being written should not cause the
+  // overall compilation to fail either.
+  if (AllowASTWithErrors)
+    PP.getDiagnostics().getClient()->clear();
+
   // Emit the PCH file to the Buffer.
   assert(SemaPtr && "No Sema?");
   Buffer->Signature =

--- a/clang/test/Index/pch-with-errors.c
+++ b/clang/test/Index/pch-with-errors.c
@@ -42,3 +42,6 @@ void foo(void) {
 
 // RUN: not c-index-test -write-pch %t.pch foobar.c 2>&1 | FileCheck -check-prefix=NONEXISTENT %s
 // NONEXISTENT: Unable to load translation unit
+
+// RUN: %clang -x c-header %s -o %t-clang.h.pch -Xclang -detailed-preprocessing-record -Xclang -fallow-pch-with-compiler-errors
+// RUN: c-index-test -index-file %s -include %t-clang.h -Xclang -detailed-preprocessing-record | FileCheck -check-prefix=CHECK-INDEX %s


### PR DESCRIPTION
Cherry-pick cc3fddb411d55d4d0902a772a9f3db11fc4f002e and c322d328aa331639f647711aee44c5dddfadd337 to apple/stable/20200108

---

Previously we would emit a PCH with errors, but fail the overall
compilation. If run using the driver, that would result in removing the
just-produced PCH. Instead, we should have the compilation result match
whether we were able to emit the PCH.

rdar://61110294