### PR TITLE
[lldb] Fix a usage of SwiftFunc::getName to account for Swift change

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -283,8 +283,8 @@ void SwiftASTManipulatorBase::DoInitialization() {
             break;
           }
         }
-      } else if (FD->hasName() &&
-                 FD->getName().str().startswith(m_wrapper_func_prefix)) {
+      } else if (FD->hasName() && FD->getBaseIdentifier().str().startswith(
+                                      m_wrapper_func_prefix)) {
         m_wrapper_decl = FD;
       }
 


### PR DESCRIPTION
Swift changes this member to SwiftFunc::getBaseIdentifier in master-next