### PR TITLE
Fix unknown type cast crash

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -639,6 +639,7 @@ public:
 
   /// Reconstruct a Swift AST type from a mangled name by looking its
   /// components up in Swift modules.
+  swift::TypeBase *ReconstructType(ConstString mangled_typename);
   swift::TypeBase *ReconstructType(ConstString mangled_typename, Status &error);
   CompilerType GetTypeFromMangledTypename(ConstString mangled_typename);
 
@@ -694,6 +695,7 @@ public:
   void ClearDiagnostics();
 
   bool SetColorizeDiagnostics(bool b);
+  void AddErrorStatusAsGenericDiagnostic(Status error);
 
   void PrintDiagnostics(DiagnosticManager &diagnostic_manager,
                         uint32_t bufferID = UINT32_MAX, uint32_t first_line = 0,

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -244,7 +244,7 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
     self_type = ToCompilerType(object_type.getPointer());
 
   // Handle weak self.
-  if (auto *ref_type = llvm::dyn_cast<swift::ReferenceStorageType>(
+  if (auto *ref_type = llvm::dyn_cast_or_null<swift::ReferenceStorageType>(
           GetSwiftType(self_type).getPointer())) {
     if (ref_type->getOwnership() == swift::ReferenceOwnership::Weak) {
       m_is_class = true;

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -196,11 +196,10 @@ swift::Type TypeSystemSwiftTypeRef::GetSwiftType(CompilerType compiler_type) {
   if (!ts)
     return {};
 
-  Status error;
   // FIXME: Suboptimal performance, because the ConstString is looked up again.
   ConstString mangled_name(
       reinterpret_cast<const char *>(compiler_type.GetOpaqueQualType()));
-  return ts->m_swift_ast_context->ReconstructType(mangled_name, error);
+  return ts->m_swift_ast_context->ReconstructType(mangled_name);
 }
 
 swift::Type SwiftASTContext::GetSwiftType(CompilerType compiler_type) {
@@ -2921,8 +2920,8 @@ protected:
 class StoringDiagnosticConsumer : public swift::DiagnosticConsumer {
 public:
   StoringDiagnosticConsumer(SwiftASTContext &ast_context)
-      : m_ast_context(ast_context), m_diagnostics(), m_num_errors(0),
-        m_colorize(false) {
+      : m_ast_context(ast_context), m_raw_diagnostics(), m_diagnostics(),
+        m_num_errors(0), m_colorize(false) {
     m_ast_context.GetDiagnosticEngine().resetHadAnyError();
     m_ast_context.GetDiagnosticEngine().addConsumer(*this);
   }
@@ -2994,20 +2993,20 @@ public:
       std::string &message_ref = os.str();
 
       if (message_ref.empty())
-        m_diagnostics.push_back(RawDiagnostic(
-                                              std::string(text), info.Kind, bufferName, bufferID, line_col.first,
+        m_raw_diagnostics.push_back(RawDiagnostic(
+            std::string(text), info.Kind, bufferName, bufferID, line_col.first,
             line_col.second,
             use_fixits ? info.FixIts
             : llvm::ArrayRef<swift::Diagnostic::FixIt>()));
       else
-        m_diagnostics.push_back(RawDiagnostic(
+        m_raw_diagnostics.push_back(RawDiagnostic(
             message_ref, info.Kind, bufferName, bufferID, line_col.first,
             line_col.second,
             use_fixits ? info.FixIts
                        : llvm::ArrayRef<swift::Diagnostic::FixIt>()));
     } else {
-      m_diagnostics.push_back(RawDiagnostic(
-                                            std::string(text), info.Kind, bufferName, bufferID, line_col.first,
+      m_raw_diagnostics.push_back(RawDiagnostic(
+          std::string(text), info.Kind, bufferName, bufferID, line_col.first,
           line_col.second, llvm::ArrayRef<swift::Diagnostic::FixIt>()));
     }
 
@@ -3017,6 +3016,7 @@ public:
 
   void Clear() {
     m_ast_context.GetDiagnosticEngine().resetHadAnyError();
+    m_raw_diagnostics.clear();
     m_diagnostics.clear();
     m_num_errors = 0;
   }
@@ -3048,8 +3048,13 @@ public:
   void PrintDiagnostics(DiagnosticManager &diagnostic_manager,
                         uint32_t bufferID = UINT32_MAX, uint32_t first_line = 0,
                         uint32_t last_line = UINT32_MAX) {
-    bool added_one_diagnostic = false;
-    for (const RawDiagnostic &diagnostic : m_diagnostics) {
+    bool added_one_diagnostic = !m_diagnostics.empty();
+
+    for (std::unique_ptr<Diagnostic> &diagnostic : m_diagnostics) {
+      diagnostic_manager.AddDiagnostic(std::move(diagnostic));
+    }
+
+    for (const RawDiagnostic &diagnostic : m_raw_diagnostics) {
       // We often make expressions and wrap them in some code.  When
       // we see errors we want the line numbers to be correct so we
       // correct them below. LLVM stores in SourceLoc objects as
@@ -3122,7 +3127,7 @@ public:
       // This will report diagnostic errors from outside the
       // expression's source range. Those are not interesting to
       // users, so we only emit them in debug builds.
-      for (const RawDiagnostic &diagnostic : m_diagnostics) {
+      for (const RawDiagnostic &diagnostic : m_raw_diagnostics) {
         const DiagnosticSeverity severity = SeverityForKind(diagnostic.kind);
         const DiagnosticOrigin origin = eDiagnosticOriginSwift;
         diagnostic_manager.AddDiagnostic(diagnostic.description.c_str(),
@@ -3137,6 +3142,10 @@ public:
     const bool old = m_colorize;
     m_colorize = b;
     return old;
+  }
+
+  void AddDiagnostic(std::unique_ptr<Diagnostic> diagnostic) {
+    m_diagnostics.push_back(std::move(diagnostic));
   }
 
 private:
@@ -3164,9 +3173,12 @@ private:
     std::vector<swift::DiagnosticInfo::FixIt> fixits;
   };
   typedef std::vector<RawDiagnostic> RawDiagnosticBuffer;
+  typedef std::vector<std::unique_ptr<Diagnostic>> DiagnosticList;
 
   SwiftASTContext &m_ast_context;
-  RawDiagnosticBuffer m_diagnostics;
+  RawDiagnosticBuffer m_raw_diagnostics;
+  DiagnosticList m_diagnostics;
+
   unsigned m_num_errors = 0;
   bool m_colorize;
 };
@@ -4426,9 +4438,8 @@ swift::Type convertSILFunctionTypesToASTFunctionTypes(swift::Type t) {
 
 CompilerType
 SwiftASTContext::GetTypeFromMangledTypename(ConstString mangled_typename) {
-  Status error;
   if (llvm::isa<SwiftASTContextForExpressions>(this))
-    return GetCompilerType(ReconstructType(mangled_typename, error));
+    return GetCompilerType(ReconstructType(mangled_typename));
   return GetCompilerType(mangled_typename);
 }
 
@@ -4474,6 +4485,17 @@ CompilerType SwiftASTContext::GetAsClangType(ConstString mangled_name) {
   if (!clang_type)
     clang_type = clang_ctx->GetBasicType(eBasicTypeObjCID);
   return clang_type;
+}
+
+swift::TypeBase *SwiftASTContext::ReconstructType(ConstString mangled_typename) {
+  Status error;
+
+  auto reconstructed_type =
+      this->ReconstructType(mangled_typename, error);
+  if (!error.Success()) {
+    this->AddErrorStatusAsGenericDiagnostic(error);
+  }
+  return reconstructed_type;
 }
 
 swift::TypeBase *SwiftASTContext::ReconstructType(ConstString mangled_typename,
@@ -5065,6 +5087,17 @@ bool SwiftASTContext::SetColorizeDiagnostics(bool b) {
                m_diagnostic_consumer_ap.get())
         ->SetColorize(b);
   return false;
+}
+
+void SwiftASTContext::AddErrorStatusAsGenericDiagnostic(Status error) {
+  assert(!error.Success() && "status should be in an error state");
+
+  auto diagnostic = std::make_unique<Diagnostic>(
+      error.AsCString(), eDiagnosticSeverityError, eDiagnosticOriginLLDB,
+      LLDB_INVALID_COMPILER_ID);
+  if (m_diagnostic_consumer_ap.get())
+    static_cast<StoringDiagnosticConsumer *>(m_diagnostic_consumer_ap.get())
+        ->AddDiagnostic(std::move(diagnostic));
 }
 
 void SwiftASTContext::PrintDiagnostics(DiagnosticManager &diagnostic_manager,


### PR DESCRIPTION
This PR fixes the crash reported [here](https://bugs.swift.org/browse/SR-11746). In addition, it improves the error message when type reconstruction fails in the `SwiftASTContext` class.