### PR TITLE
[Refactor] Speculative fix for assert in isBeforeInTranslationUnit()

### DIFF
--- a/clang/lib/Tooling/Refactor/ASTSlice.cpp
+++ b/clang/lib/Tooling/Refactor/ASTSlice.cpp
@@ -182,6 +182,9 @@ ASTSlice::ASTSlice(SourceLocation Location, SourceRange SelectionRange,
   ASTSliceFinder Visitor(Location, SelectionRange, Context);
   SourceLocation EndLoc;
   for (auto *CurrDecl : Context.getTranslationUnitDecl()->decls()) {
+    if (CurrDecl->getBeginLoc().isInvalid())
+      continue;
+
     if (EndLoc.isValid() &&
         !Context.getSourceManager().isBeforeInTranslationUnit(
             CurrDecl->getBeginLoc(), EndLoc))


### PR DESCRIPTION
I don't have a reproducer but the failing assert is that
LHS.isValid() && RHS.isValid() in SourceManager::isBeforeInTranslationUnit()
which is called from ASTSlice constructor.

We might be hitting some implicit declarations.

rdar://problem/59811864