### PR TITLE
[Sema] Check that return and argument types of a virtual member funct…

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -770,6 +770,11 @@ def err_ptrauth_string_not_literal : Error<
 def err_ptrauth_type_disc_variably_modified : Error<
    "cannot pass variably-modified type %0 to "
    "'__builtin_ptrauth_type_discriminator'">;
+def note_ptrauth_virtual_function_pointer_incomplete_arg_ret :
+  Note<"cannot take an address of a virtual member function if its return or "
+       "argument types are incomplete">;
+def note_ptrauth_virtual_function_incomplete_arg_ret_type :
+  Note<"%0 is incomplete">;
 
 // __ptrauth qualifier
 def err_ptrauth_qualifier_return : Error<

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -12529,6 +12529,39 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
 
     QualType MPTy = Context.getMemberPointerType(
         op->getType(), Context.getTypeDeclType(MD->getParent()).getTypePtr());
+
+    if (getLangOpts().PointerAuthCalls && MD->isVirtual() &&
+        !isUnevaluatedContext() && !MPTy->isDependentType()) {
+      // When pointer authentication is enabled, argument and return types of
+      // vitual member functions must be complete. This is because vitrual
+      // member function pointers are implemented using virtual dispatch
+      // thunks and the thunks cannot be emitted if the argument or return
+      // types are incomplete.
+      auto ReturnOrParamTypeIsIncomplete = [&](QualType T,
+                                               SourceLocation DeclRefLoc,
+                                               SourceLocation RetArgTypeLoc) {
+        if (RequireCompleteType(DeclRefLoc, T, diag::err_incomplete_type)) {
+          Diag(DeclRefLoc,
+               diag::note_ptrauth_virtual_function_pointer_incomplete_arg_ret);
+          Diag(RetArgTypeLoc,
+               diag::note_ptrauth_virtual_function_incomplete_arg_ret_type)
+              << T;
+          return true;
+        }
+        return false;
+      };
+      QualType RetTy = MD->getReturnType();
+      bool IsIncomplete =
+          !RetTy->isVoidType() &&
+          ReturnOrParamTypeIsIncomplete(
+              RetTy, OpLoc, MD->getReturnTypeSourceRange().getBegin());
+      for (auto *PVD : MD->parameters())
+        IsIncomplete |= ReturnOrParamTypeIsIncomplete(PVD->getType(), OpLoc,
+                                                      PVD->getBeginLoc());
+      if (IsIncomplete)
+        return QualType();
+    }
+
     // Under the MS ABI, lock down the inheritance model now.
     if (Context.getTargetInfo().getCXXABI().isMicrosoft())
       (void)isCompleteType(OpLoc, MPTy);

--- a/clang/test/SemaCXX/ptrauth.cpp
+++ b/clang/test/SemaCXX/ptrauth.cpp
@@ -1,7 +1,41 @@
-// RUN: %clang_cc1 -triple arm64-apple-ios -std=c++17 -fsyntax-only -verify -fptrauth-intrinsics %s
+// RUN: %clang_cc1 -triple arm64-apple-ios -std=c++17 -fsyntax-only -verify -fptrauth-intrinsics -fptrauth-calls %s
+
+struct Incomplete0; // expected-note 3 {{forward declaration of 'Incomplete0'}}
+
+template <class T>
+struct Incomplete1; // expected-note {{template is declared here}}
+
+struct Complete0 {
+};
+
+template <class T>
+struct Complete1 {
+};
 
 struct S {
   virtual int foo();
+  virtual Incomplete0 virtual0(); // expected-note 2 {{'Incomplete0' is incomplete}}
+  virtual void virtual1(Incomplete1<int>); // expected-note {{'Incomplete1<int>' is incomplete}}
+  virtual Complete0 virtual2();
+  virtual Complete1<int> virtual3();
+  Incomplete0 nonvirtual0();
+  template <class T>
+  void m0() {
+    (void)&S::virtual0; // expected-error {{incomplete type 'Incomplete0'}} expected-note {{cannot take an address of a virtual}}
+  }
+};
+
+template <bool T>
+struct S2 {
+  virtual Incomplete0 virtual0() noexcept(T); // expected-note {{'Incomplete0' is incomplete}}
+
+  void m0() {
+    (void)&S2<T>::virtual0;
+  }
+
+  void m1() {
+    (void)&S2<T>::virtual0; // expected-error {{incomplete type 'Incomplete0'}} expected-note {{cannot take an address of a virtual}}
+  }
 };
 
 template <class T>
@@ -30,4 +64,14 @@ void test_builtin_ptrauth_type_discriminator(unsigned s) {
   __builtin_ptrauth_type_discriminator(t); // expected-error {{unknown type name 't'}}
   __builtin_ptrauth_type_discriminator(&t); // expected-error {{expected a type}}
   __builtin_ptrauth_type_discriminator(decltype(vmarray)); // expected-error {{cannot pass variably-modified type 'decltype(vmarray)'}}
+}
+
+void test_incomplete_virtual_member_function_return_arg_type() {
+  (void)&S::virtual0; // expected-error {{incomplete type 'Incomplete0}} expected-note {{cannot take an address of a virtual member function}}
+  (void)&S::virtual1; // expected-error {{implicit instantiation of undefined template 'Incomplete1<int>'}} expected-note {{cannot take an address of a virtual member function}}
+  (void)&S::virtual2;
+  (void)&S::virtual3;
+  (void)&S::nonvirtual0;
+  int s = sizeof(&S::virtual0);
+  S2<true>().m1(); // expected-note {{in instantiation of}}
 }


### PR DESCRIPTION
…ion (#993)

* [Sema] Check that return and argument types of a virtual member function
are complete if the address of the member function is taken

If they aren't complete, reject the code.

rdar://problem/60888064

* Address review comments

Explain why the types must be complete when pointer authentication is
enabled. Check that virual function pointers aren't diagnosed in
unevaluated contexts. Change the variable and diagnostic names to
improve indentation.

* Check that a pointer to a virtual function pointer with a dependent
noexcept clause isn't diagnosed

Test virtual functions of templated classes.

(cherry picked from commit 7cd35e28affde4988126a2e08fb2bdd1e3381ed8)