### PR TITLE
Target: print the message with formatting

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -189,9 +189,10 @@ public:
 
 #define STUB_LOG()                                                             \
   do {                                                                         \
-    LLDB_LOG(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS |  \
-                                                    LIBLLDB_LOG_TYPES),        \
-             g_stub_log_message, GetStandardLibraryName(m_process));           \
+    LLDB_LOGF(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS | \
+                                                     LIBLLDB_LOG_TYPES),       \
+              g_stub_log_message,                                              \
+              GetStandardLibraryName(m_process).AsCString());                  \
     assert(false && "called into swift language runtime stub");                \
   } while (0)
 


### PR DESCRIPTION
The message has a format specifier but was being printed unformatted.
This corrects the macro usage to use the formatting version.  Improves
the debug logging only.