### PR TITLE
[lldb/Swift] Use the just-built modules for the testsuite

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -294,6 +294,9 @@ DEBUG_INFO_FLAG ?= -g
 CFLAGS ?= $(DEBUG_INFO_FLAG) -O0 -fno-builtin
 SWIFTFLAGS ?= $(DEBUG_INFO_FLAG) -Onone -Xfrontend -serialize-debugging-options
 
+# Use the just-built standard library
+SWIFTFLAGS += -I $(dirname $(SWIFTC))/../lib/swift/
+
 ifeq "$(OS)" "Darwin"
 	ifneq "$(SDKROOT)" ""
 		CFLAGS += -isysroot "$(SDKROOT)"


### PR DESCRIPTION
I recently fixed the environment passing to run against the
just-built standard library, but we were not building against
those modules. This usually doesn't matter, but in rare cases
where there are incompatible evolutions in the module format
(for example because some @_... has been added or removed),
we might not be able to build the modules from the SDK.

This patch adds a -I argument to our testsuite swiftc invocations
which points to the swift library directory, hopefully
providing modules consistent with our compiler.