### PR TITLE
Define SWIFT_INLINE_NAMESPACE for swiftDemangling inclusions. (master-next)

### DIFF
--- a/lldb/source/Core/CMakeLists.txt
+++ b/lldb/source/Core/CMakeLists.txt
@@ -90,6 +90,11 @@ add_lldb_library(lldbCore
     Demangle
   )
 
+# Necessary to ensure that the SWIFT_INLINE_NAMESPACE macro is defined for
+# swiftDemangling inclusions.
+target_compile_definitions(lldbCore PRIVATE
+  SWIFT_INLINE_NAMESPACE=compiler)
+
 add_dependencies(lldbCore
   LLDBCorePropertiesGen
   LLDBCorePropertiesEnumGen)

--- a/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
@@ -43,3 +43,8 @@ add_lldb_library(lldbPluginExpressionParserSwift PLUGIN
     Support
     Core
   )
+
+# Necessary to ensure that the SWIFT_INLINE_NAMESPACE macro is defined for
+# swiftDemangling inclusions.
+target_compile_definitions(lldbPluginExpressionParserSwift PRIVATE
+  SWIFT_INLINE_NAMESPACE=compiler)

--- a/lldb/source/Plugins/SymbolFile/DWARF/CMakeLists.txt
+++ b/lldb/source/Plugins/SymbolFile/DWARF/CMakeLists.txt
@@ -70,3 +70,8 @@ add_lldb_library(lldbPluginSymbolFileDWARF PLUGIN
 add_dependencies(lldbPluginSymbolFileDWARF
   LLDBPluginSymbolFileDWARFPropertiesGen
   LLDBPluginSymbolFileDWARFPropertiesEnumGen)
+
+# Necessary to ensure that the SWIFT_INLINE_NAMESPACE macro is defined for
+# swiftDemangling inclusions.
+target_compile_definitions(lldbPluginSymbolFileDWARF PRIVATE
+  SWIFT_INLINE_NAMESPACE=compiler)

--- a/lldb/source/Symbol/CMakeLists.txt
+++ b/lldb/source/Symbol/CMakeLists.txt
@@ -75,3 +75,8 @@ add_lldb_library(lldbSymbol
 if(CMAKE_CXX_COMPILER_ID STREQUAL Clang AND NOT SWIFT_COMPILER_IS_MSVC_LIKE)
   target_compile_options(lldbSymbol PRIVATE -Wno-dollar-in-identifier-extension)
 endif()
+
+# Necessary to ensure that the SWIFT_INLINE_NAMESPACE macro is defined for
+# swiftDemangling inclusions.
+target_compile_definitions(lldbSymbol PRIVATE
+  SWIFT_INLINE_NAMESPACE=compiler)

--- a/lldb/source/Target/CMakeLists.txt
+++ b/lldb/source/Target/CMakeLists.txt
@@ -118,3 +118,8 @@ endif()
 add_dependencies(lldbTarget
   LLDBTargetPropertiesGen
   LLDBTargetPropertiesEnumGen)
+
+# Necessary to ensure that the SWIFT_INLINE_NAMESPACE macro is defined for
+# swiftDemangling inclusions.
+target_compile_definitions(lldbTarget PRIVATE
+  SWIFT_INLINE_NAMESPACE=compiler)


### PR DESCRIPTION
(_Cherry-pick of #1023 from swift/master._)

https://github.com/apple/swift/pull/30733 will begin requiring
this in a change that allows the swiftDemangling symbols to be
conditionally renamed using an inline namespace so that compiler
and runtime symbols don't collide if statically linked in the
same binary.

The namespace `compiler` was chosen for lldb since that's what
would have been used if its build was properly inheriting the
public definition from the Swift CMake target.