### PR TITLE
Thread plans outlive threads

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -2199,19 +2199,75 @@ public:
   }
 
   void SetDynamicCheckers(DynamicCheckerFunctions *dynamic_checkers);
-  
+
+/// Prune ThreadPlanStacks for unreported threads.
+///
+/// \param[in] tid
+///     The tid whose Plan Stack we are seeking to prune.
+///
+/// \return
+///     \b true if the TID is found or \b false if not.
+bool PruneThreadPlansForTID(lldb::tid_t tid);
+
+/// Prune ThreadPlanStacks for all unreported threads.
+void PruneThreadPlans();
+
   /// Find the thread plan stack associated with thread with \a tid.
   ///
   /// \param[in] tid
-  ///     The tid whose Plan Stack we are seeking..
+  ///     The tid whose Plan Stack we are seeking.
   ///
   /// \return
   ///     Returns a ThreadPlan if the TID is found or nullptr if not.
   ThreadPlanStack *FindThreadPlans(lldb::tid_t tid);
-  
-  void AddThreadPlansForThread(Thread &thread);
-  
-  void RemoveThreadPlansForTID(lldb::tid_t tid);
+
+  /// Dump the thread plans associated with thread with \a tid.
+  ///
+  /// \param[in/out] strm
+  ///     The stream to which to dump the output
+  ///
+  /// \param[in] tid
+  ///     The tid whose Plan Stack we are dumping
+  ///
+  /// \param[in] desc_level
+  ///     How much detail to dump
+  ///
+  /// \param[in] internal
+  ///     If \b true dump all plans, if false only user initiated plans
+  ///
+  /// \param[in] condense_trivial
+  ///     If true, only dump a header if the plan stack is just the base plan.
+  ///
+  /// \param[in] skip_unreported_plans
+  ///     If true, only dump a plan if it is currently backed by an
+  ///     lldb_private::Thread *.
+  ///
+  /// \return
+  ///     Returns \b true if TID was found, \b false otherwise
+  bool DumpThreadPlansForTID(Stream &strm, lldb::tid_t tid,
+                             lldb::DescriptionLevel desc_level, bool internal,
+                             bool condense_trivial, bool skip_unreported_plans);
+
+  /// Dump all the thread plans for this process.
+  ///
+  /// \param[in/out] strm
+  ///     The stream to which to dump the output
+  ///
+  /// \param[in] desc_level
+  ///     How much detail to dump
+  ///
+  /// \param[in] internal
+  ///     If \b true dump all plans, if false only user initiated plans
+  ///
+  /// \param[in] condense_trivial
+  ///     If true, only dump a header if the plan stack is just the base plan.
+  ///
+  /// \param[in] skip_unreported_plans
+  ///     If true, skip printing all thread plan stacks that don't currently
+  ///     have a backing lldb_private::Thread *.
+  void DumpThreadPlans(Stream &strm, lldb::DescriptionLevel desc_level,
+                       bool internal, bool condense_trivial,
+                       bool skip_unreported_plans);
 
   /// Call this to set the lldb in the mode where it breaks on new thread
   /// creations, and then auto-restarts.  This is useful when you are trying
@@ -2548,7 +2604,7 @@ protected:
     virtual EventActionResult HandleBeingInterrupted() = 0;
     virtual const char *GetExitString() = 0;
     void RequestResume() { m_process->m_resume_requested = true; }
-    
+
   protected:
     Process *m_process;
   };

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -37,6 +37,7 @@
 #include "lldb/Target/Memory.h"
 #include "lldb/Target/QueueList.h"
 #include "lldb/Target/ThreadList.h"
+#include "lldb/Target/ThreadPlanStack.h"
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/Broadcaster.h"
 #include "lldb/Utility/Event.h"
@@ -2198,6 +2199,19 @@ public:
   }
 
   void SetDynamicCheckers(DynamicCheckerFunctions *dynamic_checkers);
+  
+  /// Find the thread plan stack associated with thread with \a tid.
+  ///
+  /// \param[in] tid
+  ///     The tid whose Plan Stack we are seeking..
+  ///
+  /// \return
+  ///     Returns a ThreadPlan if the TID is found or nullptr if not.
+  ThreadPlanStack *FindThreadPlans(lldb::tid_t tid);
+  
+  void AddThreadPlansForThread(Thread &thread);
+  
+  void RemoveThreadPlansForTID(lldb::tid_t tid);
 
   /// Call this to set the lldb in the mode where it breaks on new thread
   /// creations, and then auto-restarts.  This is useful when you are trying
@@ -2534,7 +2548,7 @@ protected:
     virtual EventActionResult HandleBeingInterrupted() = 0;
     virtual const char *GetExitString() = 0;
     void RequestResume() { m_process->m_resume_requested = true; }
-
+    
   protected:
     Process *m_process;
   };
@@ -2668,6 +2682,10 @@ protected:
                             ///see them. This is usually the same as
   ///< m_thread_list_real, but might be different if there is an OS plug-in
   ///creating memory threads
+  ThreadPlanStackMap m_thread_plans; ///< This is the list of thread plans for
+                                     /// threads in m_thread_list, as well as
+                                     /// threads we knew existed, but haven't
+                                     /// determined that they have died yet.
   ThreadList m_extended_thread_list; ///< Owner for extended threads that may be
                                      ///generated, cleared on natural stops
   uint32_t m_extended_thread_stop_id; ///< The natural stop id when

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -202,12 +202,17 @@ public:
   bool GetInjectLocalVariables(ExecutionContext *exe_ctx) const;
 
   void SetInjectLocalVariables(ExecutionContext *exe_ctx, bool b);
+  
+  bool GetOSPluginReportsAllThreads() const;
+
+  void SetOSPluginReportsAllThreads(bool does_report);
 
   void SetRequireHardwareBreakpoints(bool b);
 
   bool GetRequireHardwareBreakpoints() const;
 
   void UpdateLaunchInfoFromProperties();
+
 
 private:
   // Callbacks for m_launch_info.

--- a/lldb/include/lldb/Target/Thread.h
+++ b/lldb/include/lldb/Target/Thread.h
@@ -1021,16 +1021,6 @@ public:
   ///    otherwise.
   bool DiscardUserThreadPlansUpToIndex(uint32_t thread_index);
 
-  /// Prints the current plan stack.
-  ///
-  /// \param[in] s
-  ///    The stream to which to dump the plan stack info.
-  ///
-  void DumpThreadPlans(
-      Stream *s,
-      lldb::DescriptionLevel desc_level = lldb::eDescriptionLevelVerbose,
-      bool include_internal = true, bool ignore_boring = false) const;
-
   virtual bool CheckpointThreadState(ThreadStateCheckpoint &saved_state);
 
   virtual bool
@@ -1188,7 +1178,7 @@ protected:
   // thread is still in good shape to call virtual thread methods.  This must
   // be called by classes that derive from Thread in their destructor.
   virtual void DestroyThread();
-  
+
   ThreadPlanStack &GetPlans() const;
 
   void PushPlan(lldb::ThreadPlanSP plan_sp);
@@ -1262,6 +1252,7 @@ protected:
   bool m_destroy_called; // This is used internally to make sure derived Thread
                          // classes call DestroyThread.
   LazyBool m_override_should_notify;
+  mutable std::unique_ptr<ThreadPlanStack> m_null_plan_stack_up;
 
 private:
   bool m_extended_info_fetched; // Have we tried to retrieve the m_extended_info
@@ -1269,7 +1260,6 @@ private:
   StructuredData::ObjectSP m_extended_info; // The extended info for this thread
 
 private:
-  
   void BroadcastSelectedFrameChange(StackID &new_frame_id);
 
   DISALLOW_COPY_AND_ASSIGN(Thread);

--- a/lldb/include/lldb/Target/Thread.h
+++ b/lldb/include/lldb/Target/Thread.h
@@ -28,6 +28,8 @@
 
 namespace lldb_private {
 
+class ThreadPlanStack;
+
 class ThreadProperties : public Properties {
 public:
   ThreadProperties(bool is_global);
@@ -119,7 +121,7 @@ public:
                            // bit of data.
     lldb::StopInfoSP stop_info_sp; // You have to restore the stop info or you
                                    // might continue with the wrong signals.
-    std::vector<lldb::ThreadPlanSP> m_completed_plan_stack;
+    size_t m_completed_plan_checkpoint;
     lldb::RegisterCheckpointSP
         register_backup_sp; // You need to restore the registers, of course...
     uint32_t current_inlined_depth;
@@ -914,7 +916,7 @@ public:
   ///
   /// \return
   ///     A pointer to the next executed plan.
-  ThreadPlan *GetCurrentPlan();
+  ThreadPlan *GetCurrentPlan() const;
 
   /// Unwinds the thread stack for the innermost expression plan currently
   /// on the thread plan stack.
@@ -929,14 +931,14 @@ public:
   ///
   /// \return
   ///     A pointer to the last completed plan.
-  lldb::ThreadPlanSP GetCompletedPlan();
+  lldb::ThreadPlanSP GetCompletedPlan() const;
 
   /// Gets the outer-most return value from the completed plans
   ///
   /// \return
   ///     A ValueObjectSP, either empty if there is no return value,
   ///     or containing the return value.
-  lldb::ValueObjectSP GetReturnValueObject();
+  lldb::ValueObjectSP GetReturnValueObject() const;
 
   /// Gets the outer-most expression variable from the completed plans
   ///
@@ -944,7 +946,7 @@ public:
   ///     A ExpressionVariableSP, either empty if there is no
   ///     plan completed an expression during the current stop
   ///     or the expression variable that was made for the completed expression.
-  lldb::ExpressionVariableSP GetExpressionVariable();
+  lldb::ExpressionVariableSP GetExpressionVariable() const;
 
   ///  Checks whether the given plan is in the completed plans for this
   ///  stop.
@@ -955,7 +957,7 @@ public:
   /// \return
   ///     Returns true if the input plan is in the completed plan stack,
   ///     false otherwise.
-  bool IsThreadPlanDone(ThreadPlan *plan);
+  bool IsThreadPlanDone(ThreadPlan *plan) const;
 
   ///  Checks whether the given plan is in the discarded plans for this
   ///  stop.
@@ -966,14 +968,14 @@ public:
   /// \return
   ///     Returns true if the input plan is in the discarded plan stack,
   ///     false otherwise.
-  bool WasThreadPlanDiscarded(ThreadPlan *plan);
+  bool WasThreadPlanDiscarded(ThreadPlan *plan) const;
 
   /// Check if we have completed plan to override breakpoint stop reason
   ///
   /// \return
   ///     Returns true if completed plan stack is not empty
   ///     false otherwise.
-  bool CompletedPlanOverridesBreakpoint();
+  bool CompletedPlanOverridesBreakpoint() const;
 
   /// Queues a generic thread plan.
   ///
@@ -1186,16 +1188,16 @@ protected:
   // thread is still in good shape to call virtual thread methods.  This must
   // be called by classes that derive from Thread in their destructor.
   virtual void DestroyThread();
+  
+  ThreadPlanStack &GetPlans() const;
 
-  void PushPlan(lldb::ThreadPlanSP &plan_sp);
+  void PushPlan(lldb::ThreadPlanSP plan_sp);
 
   void PopPlan();
 
   void DiscardPlan();
 
-  ThreadPlan *GetPreviousPlan(ThreadPlan *plan);
-
-  typedef std::vector<lldb::ThreadPlanSP> plan_stack;
+  ThreadPlan *GetPreviousPlan(ThreadPlan *plan) const;
 
   virtual lldb_private::Unwind *GetUnwinder();
 
@@ -1240,13 +1242,6 @@ protected:
   lldb::StateType m_state;                  ///< The state of our process.
   mutable std::recursive_mutex
       m_state_mutex;       ///< Multithreaded protection for m_state.
-  plan_stack m_plan_stack; ///< The stack of plans this thread is executing.
-  plan_stack m_completed_plan_stack; ///< Plans that have been completed by this
-                                     ///stop.  They get deleted when the thread
-                                     ///resumes.
-  plan_stack m_discarded_plan_stack; ///< Plans that have been discarded by this
-                                     ///stop.  They get deleted when the thread
-                                     ///resumes.
   mutable std::recursive_mutex
       m_frame_mutex; ///< Multithreaded protection for m_state.
   lldb::StackFrameListSP m_curr_frames_sp; ///< The stack frames that get lazily
@@ -1274,8 +1269,7 @@ private:
   StructuredData::ObjectSP m_extended_info; // The extended info for this thread
 
 private:
-  bool PlanIsBasePlan(ThreadPlan *plan_ptr);
-
+  
   void BroadcastSelectedFrameChange(StackID &new_frame_id);
 
   DISALLOW_COPY_AND_ASSIGN(Thread);

--- a/lldb/include/lldb/Target/ThreadPlan.h
+++ b/lldb/include/lldb/Target/ThreadPlan.h
@@ -376,7 +376,9 @@ public:
   const Target &GetTarget() const;
 
   /// Print a description of this thread to the stream \a s.
-  /// \a thread.
+  /// \a thread.  Don't expect that the result of GetThread is valid in
+  /// the description method.  This might get called when the underlying
+  /// Thread has not been reported, so we only know the TID and not the thread.
   ///
   /// \param[in] s
   ///    The stream to which to print the description.
@@ -598,7 +600,9 @@ private:
   // For ThreadPlan only
   static lldb::user_id_t GetNextID();
 
-  Thread *m_thread;
+  Thread *m_thread; // Stores a cached value of the thread, which is set to
+                    // nullptr when the thread resumes.  Don't use this anywhere
+                    // but ThreadPlan::GetThread().
   ThreadPlanKind m_kind;
   std::string m_name;
   std::recursive_mutex m_plan_complete_mutex;

--- a/lldb/include/lldb/Target/ThreadPlan.h
+++ b/lldb/include/lldb/Target/ThreadPlan.h
@@ -371,9 +371,9 @@ public:
   ///   A  pointer to the thread plan's owning thread.
   Thread &GetThread();
 
-  Target &GetTarget() { return m_process.GetTarget(); }
+  Target &GetTarget();
 
-  const Target &GetTarget() const { return m_process.GetTarget(); }
+  const Target &GetTarget() const;
 
   /// Print a description of this thread to the stream \a s.
   /// \a thread.

--- a/lldb/include/lldb/Target/ThreadPlanPython.h
+++ b/lldb/include/lldb/Target/ThreadPlanPython.h
@@ -55,6 +55,8 @@ protected:
   bool DoPlanExplainsStop(Event *event_ptr) override;
 
   lldb::StateType GetPlanRunState() override;
+  
+  ScriptInterpreter *GetScriptInterpreter();
 
 private:
   std::string m_class_name;

--- a/lldb/include/lldb/Target/ThreadPlanStack.h
+++ b/lldb/include/lldb/Target/ThreadPlanStack.h
@@ -1,0 +1,153 @@
+//===-- ThreadPlanStack.h ---------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_TARGET_THREADPLANSTACK_H
+#define LLDB_TARGET_THREADPLANSTACK_H
+
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "lldb/Target/Target.h"
+#include "lldb/Target/Thread.h"
+#include "lldb/lldb-private-forward.h"
+#include "lldb/lldb-private.h"
+
+namespace lldb_private {
+
+// The ThreadPlans have a thread for use when they are asked all the ThreadPlan
+// state machine questions, but they should never cache any pointers from their
+// owning lldb_private::Thread.  That's because we want to be able to detach
+// them from an owning thread, then reattach them by TID.
+// The ThreadPlanStack holds the ThreadPlans for a given TID.  All its methods
+// are private, and it should only be accessed through the owning thread.  When
+// it is detached from a thread, all you can do is reattach it or delete it.
+class ThreadPlanStack {
+  friend class lldb_private::Thread;
+
+public:
+  ThreadPlanStack(Thread &thread) {}
+  ~ThreadPlanStack() {}
+
+  enum StackKind { ePlans, eCompletedPlans, eDiscardedPlans };
+
+  using PlanStack = std::vector<lldb::ThreadPlanSP>;
+
+  void DumpThreadPlans(Stream *s, lldb::DescriptionLevel desc_level,
+                       bool include_internal) const;
+
+  size_t CheckpointCompletedPlans();
+
+  void RestoreCompletedPlanCheckpoint(size_t checkpoint);
+
+  void DiscardCompletedPlanCheckpoint(size_t checkpoint);
+
+  void ThreadDestroyed(Thread *thread);
+
+  void EnableTracer(bool value, bool single_stepping);
+
+  void SetTracer(lldb::ThreadPlanTracerSP &tracer_sp);
+
+  void PushPlan(lldb::ThreadPlanSP new_plan_sp);
+
+  lldb::ThreadPlanSP PopPlan();
+
+  lldb::ThreadPlanSP DiscardPlan();
+
+  // If the input plan is nullptr, discard all plans.  Otherwise make sure this
+  // plan is in the stack, and if so discard up to and including it.
+  void DiscardPlansUpToPlan(ThreadPlan *up_to_plan_ptr);
+
+  void DiscardAllPlans();
+
+  void DiscardConsultingMasterPlans();
+
+  lldb::ThreadPlanSP GetCurrentPlan() const;
+
+  lldb::ThreadPlanSP GetCompletedPlan(bool skip_private = true) const;
+
+  lldb::ThreadPlanSP GetPlanByIndex(uint32_t plan_idx,
+                                    bool skip_private = true) const;
+
+  lldb::ValueObjectSP GetReturnValueObject() const;
+
+  lldb::ExpressionVariableSP GetExpressionVariable() const;
+
+  bool AnyPlans() const;
+
+  bool AnyCompletedPlans() const;
+
+  bool AnyDiscardedPlans() const;
+
+  bool IsPlanDone(ThreadPlan *plan) const;
+
+  bool WasPlanDiscarded(ThreadPlan *plan) const;
+
+  ThreadPlan *GetPreviousPlan(ThreadPlan *current_plan) const;
+
+  ThreadPlan *GetInnermostExpression() const;
+
+  void WillResume();
+
+private:
+  const PlanStack &GetStackOfKind(ThreadPlanStack::StackKind kind) const;
+
+  PlanStack m_plans;           ///< The stack of plans this thread is executing.
+  PlanStack m_completed_plans; ///< Plans that have been completed by this
+                               /// stop.  They get deleted when the thread
+                               /// resumes.
+  PlanStack m_discarded_plans; ///< Plans that have been discarded by this
+                               /// stop.  They get deleted when the thread
+                               /// resumes.
+  size_t m_completed_plan_checkpoint = 0; // Monotonically increasing token for
+                                          // completed plan checkpoints.
+  std::unordered_map<size_t, PlanStack> m_completed_plan_store;
+};
+
+class ThreadPlanStackMap {
+public:
+  ThreadPlanStackMap() {}
+  ~ThreadPlanStackMap() {}
+
+  void AddThread(Thread &thread) {
+    lldb::tid_t tid = thread.GetID();
+    auto result = m_plans_list.emplace(tid, thread);
+  }
+
+  bool RemoveTID(lldb::tid_t tid) {
+    auto result = m_plans_list.find(tid);
+    if (result == m_plans_list.end())
+      return false;
+    result->second.ThreadDestroyed(nullptr);
+    m_plans_list.erase(result);
+    return true;
+  }
+
+  ThreadPlanStack *Find(lldb::tid_t tid) {
+    auto result = m_plans_list.find(tid);
+    if (result == m_plans_list.end())
+      return nullptr;
+    else
+      return &result->second;
+  }
+
+  void Clear() {
+    for (auto plan : m_plans_list)
+      plan.second.ThreadDestroyed(nullptr);
+    m_plans_list.clear();
+  }
+
+private:
+  using PlansList = std::unordered_map<lldb::tid_t, ThreadPlanStack>;
+  PlansList m_plans_list;
+};
+
+} // namespace lldb_private
+
+#endif // LLDB_TARGET_THREADPLANSTACK_H

--- a/lldb/include/lldb/Target/ThreadPlanTracer.h
+++ b/lldb/include/lldb/Target/ThreadPlanTracer.h
@@ -57,9 +57,12 @@ public:
   }
 
   bool SingleStepEnabled() { return m_single_step; }
+  
+  Thread &GetThread();
 
 protected:
-  Thread &m_thread;
+  Process &m_process;
+  lldb::tid_t m_tid;
 
   Stream *GetLogStream();
 
@@ -71,6 +74,7 @@ private:
   bool m_single_step;
   bool m_enabled;
   lldb::StreamSP m_stream_sp;
+  Thread *m_thread;
 };
 
 class ThreadPlanAssemblyTracer : public ThreadPlanTracer {

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -964,6 +964,11 @@ let Command = "thread plan list" in {
     Desc<"Display more information about the thread plans">;
   def thread_plan_list_internal : Option<"internal", "i">, Group<1>,
     Desc<"Display internal as well as user thread plans">;
+  def thread_plan_list_thread_id : Option<"thread-id", "t">, Group<1>,
+    Arg<"ThreadID">, Desc<"List the thread plans for this TID, can be "
+    "specified more than once.">;
+  def thread_plan_list_unreported : Option<"unreported", "u">, Group<1>,
+    Desc<"Display thread plans for unreported threads">;
 }
 
 let Command = "type summary add" in {

--- a/lldb/source/Target/CMakeLists.txt
+++ b/lldb/source/Target/CMakeLists.txt
@@ -62,6 +62,7 @@ add_lldb_library(lldbTarget
   ThreadPlanStepThrough.cpp
   ThreadPlanStepUntil.cpp
   ThreadPlanTracer.cpp
+  ThreadPlanStack.cpp
   ThreadSpec.cpp
   UnixSignals.cpp
   UnwindAssembly.cpp

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -60,6 +60,7 @@
 #include "lldb/Target/ThreadPlan.h"
 #include "lldb/Target/ThreadPlanBase.h"
 #include "lldb/Target/ThreadPlanCallFunction.h"
+#include "lldb/Target/ThreadPlanStack.h"
 #include "lldb/Target/UnixSignals.h"
 #include "lldb/Utility/Event.h"
 #include "lldb/Utility/Log.h"
@@ -607,6 +608,7 @@ void Process::Finalize() {
   m_system_runtime_up.reset();
   m_dyld_up.reset();
   m_jit_loaders_up.reset();
+  m_thread_plans.Clear();
   m_thread_list_real.Destroy();
   m_thread_list.Destroy();
   m_extended_thread_list.Destroy();
@@ -1260,6 +1262,20 @@ void Process::UpdateThreadListIfNeeded() {
       }
     }
   }
+}
+
+ThreadPlanStack *Process::FindThreadPlans(lldb::tid_t tid) {
+  return m_thread_plans.Find(tid);
+}
+
+void Process::AddThreadPlansForThread(Thread &thread) {
+  if (m_thread_plans.Find(thread.GetID()))
+    return;
+  m_thread_plans.AddThread(thread);
+}
+
+void Process::RemoveThreadPlansForTID(lldb::tid_t tid) {
+  m_thread_plans.RemoveTID(tid);
 }
 
 void Process::UpdateQueueListIfNeeded() {
@@ -3241,6 +3257,10 @@ Status Process::Detach(bool keep_stopped) {
 }
 
 Status Process::Destroy(bool force_kill) {
+  // If we've already called Process::Finalize then there's nothing useful to
+  // be done here.  Finalize has actually called Destroy already.
+  if (m_finalize_called)
+    return {};
 
   // Tell ourselves we are in the process of destroying the process, so that we
   // don't do any unnecessary work that might hinder the destruction.  Remember

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -485,7 +485,7 @@ Process::Process(lldb::TargetSP target_sp, ListenerSP listener_sp,
       m_mod_id(), m_process_unique_id(0), m_thread_index_id(0),
       m_thread_id_to_index_id_map(), m_exit_status(-1), m_exit_string(),
       m_exit_status_mutex(), m_thread_mutex(), m_thread_list_real(this),
-      m_thread_list(this), m_extended_thread_list(this),
+      m_thread_list(this), m_thread_plans(*this), m_extended_thread_list(this),
       m_extended_thread_stop_id(0), m_queue_list(this), m_queue_list_stop_id(0),
       m_notifications(), m_image_tokens(), m_listener_sp(listener_sp),
       m_breakpoint_site_list(), m_dynamic_checkers_up(),
@@ -1194,9 +1194,12 @@ void Process::UpdateThreadListIfNeeded() {
   const uint32_t stop_id = GetStopID();
   if (m_thread_list.GetSize(false) == 0 ||
       stop_id != m_thread_list.GetStopID()) {
+    bool clear_unused_threads = true;
     const StateType state = GetPrivateState();
     if (StateIsStoppedState(state, true)) {
       std::lock_guard<std::recursive_mutex> guard(m_thread_list.GetMutex());
+      m_thread_list.SetStopID(stop_id);
+
       // m_thread_list does have its own mutex, but we need to hold onto the
       // mutex between the call to UpdateThreadList(...) and the
       // os->UpdateThreadList(...) so it doesn't change on us
@@ -1217,6 +1220,10 @@ void Process::UpdateThreadListIfNeeded() {
           size_t num_old_threads = old_thread_list.GetSize(false);
           for (size_t i = 0; i < num_old_threads; ++i)
             old_thread_list.GetThreadAtIndex(i, false)->ClearBackingThread();
+          // See if the OS plugin reports all threads.  If it does, then
+          // it is safe to clear unseen thread's plans here.  Otherwise we 
+          // should preserve them in case they show up again:
+          clear_unused_threads = GetTarget().GetOSPluginReportsAllThreads();
 
           // Turn off dynamic types to ensure we don't run any expressions.
           // Objective-C can run an expression to determine if a SBValue is a
@@ -1243,7 +1250,7 @@ void Process::UpdateThreadListIfNeeded() {
             target.SetPreferDynamicValue(saved_prefer_dynamic);
         } else {
           // No OS plug-in, the new thread list is the same as the real thread
-          // list
+          // list.
           new_thread_list = real_thread_list;
         }
 
@@ -1260,6 +1267,12 @@ void Process::UpdateThreadListIfNeeded() {
           m_queue_list_stop_id = GetLastNaturalStopID();
         }
       }
+      // Now update the plan stack map.
+      // If we do have an OS plugin, any absent real threads in the
+      // m_thread_list have already been removed from the ThreadPlanStackMap.
+      // So any remaining threads are OS Plugin threads, and those we want to
+      // preserve in case they show up again.
+      m_thread_plans.Update(m_thread_list, clear_unused_threads);
     }
   }
 }
@@ -1268,14 +1281,26 @@ ThreadPlanStack *Process::FindThreadPlans(lldb::tid_t tid) {
   return m_thread_plans.Find(tid);
 }
 
-void Process::AddThreadPlansForThread(Thread &thread) {
-  if (m_thread_plans.Find(thread.GetID()))
-    return;
-  m_thread_plans.AddThread(thread);
+bool Process::PruneThreadPlansForTID(lldb::tid_t tid) {
+  return m_thread_plans.PrunePlansForTID(tid);
 }
 
-void Process::RemoveThreadPlansForTID(lldb::tid_t tid) {
-  m_thread_plans.RemoveTID(tid);
+void Process::PruneThreadPlans() {
+  m_thread_plans.Update(GetThreadList(), true, false);
+}
+
+bool Process::DumpThreadPlansForTID(Stream &strm, lldb::tid_t tid,
+                                    lldb::DescriptionLevel desc_level,
+                                    bool internal, bool condense_trivial,
+                                    bool skip_unreported_plans) {
+  return m_thread_plans.DumpPlansForTID(
+      strm, tid, desc_level, internal, condense_trivial, skip_unreported_plans);
+}
+void Process::DumpThreadPlans(Stream &strm, lldb::DescriptionLevel desc_level,
+                              bool internal, bool condense_trivial,
+                              bool skip_unreported_plans) {
+  m_thread_plans.DumpPlans(strm, desc_level, internal, condense_trivial,
+                           skip_unreported_plans);
 }
 
 void Process::UpdateQueueListIfNeeded() {

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3507,6 +3507,34 @@ void TargetProperties::SetInjectLocalVariables(ExecutionContext *exe_ctx,
                                             true);
 }
 
+bool TargetProperties::GetOSPluginReportsAllThreads() const {
+  const bool fail_value = true;
+  const Property *exp_property =
+      m_collection_sp->GetPropertyAtIndex(nullptr, true, ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (!exp_values)
+    return fail_value;
+    
+  return 
+      exp_values->GetPropertyAtIndexAsBoolean(nullptr, 
+                                              ePropertyOSPluginReportsAllThreads,
+                                              fail_value);
+}
+
+void TargetProperties::SetOSPluginReportsAllThreads(bool does_report) {
+  const Property *exp_property =
+      m_collection_sp->GetPropertyAtIndex(nullptr, true, ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    exp_values->SetPropertyAtIndexAsBoolean(nullptr, 
+                                            ePropertyOSPluginReportsAllThreads,
+                                            does_report);
+}
+
+
+
 ArchSpec TargetProperties::GetDefaultArchitecture() const {
   OptionValueArch *value = m_collection_sp->GetPropertyAtIndexAsOptionValueArch(
       nullptr, ePropertyDefaultArch);

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -4,6 +4,10 @@ let Definition = "experimental" in {
   def InjectLocalVars : Property<"inject-local-vars", "Boolean">,
     Global, DefaultTrue,
     Desc<"If true, inject local variables explicitly into the expression text. This will fix symbol resolution when there are name collisions between ivars and local variables. But it can make expressions run much more slowly.">;
+  def OSPluginReportsAllThreads: Property<"os-plugin-reports-all-threads", "Boolean">,
+    Global,
+    DefaultTrue,
+    Desc<"Set to False if your OS Plugins doesn't report all threads on each stop.">;
 }
 
 let Definition = "target" in {

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -242,10 +242,6 @@ Thread::Thread(Process &process, lldb::tid_t tid, bool use_invalid_index_id)
             static_cast<void *>(this), GetID());
 
   CheckInWithManager();
-  
-  process.AddThreadPlansForThread(*this);
-  
-  QueueFundamentalPlan(true);
 }
 
 Thread::~Thread() {
@@ -779,7 +775,9 @@ bool Thread::ShouldStop(Event *event_ptr) {
     LLDB_LOGF(log, "^^^^^^^^ Thread::ShouldStop Begin ^^^^^^^^");
     StreamString s;
     s.IndentMore();
-    DumpThreadPlans(&s);
+    GetProcess()->DumpThreadPlansForTID(
+        s, GetID(), eDescriptionLevelVerbose, true /* internal */,
+        false /* condense_trivial */, true /* skip_unreported */);
     LLDB_LOGF(log, "Plan stack initial state:\n%s", s.GetData());
   }
 
@@ -943,7 +941,9 @@ bool Thread::ShouldStop(Event *event_ptr) {
   if (log) {
     StreamString s;
     s.IndentMore();
-    DumpThreadPlans(&s);
+    GetProcess()->DumpThreadPlansForTID(
+        s, GetID(), eDescriptionLevelVerbose, true /* internal */,
+        false /* condense_trivial */, true /* skip_unreported */);
     LLDB_LOGF(log, "Plan stack final state:\n%s", s.GetData());
     LLDB_LOGF(log, "vvvvvvvv Thread::ShouldStop End (returning %i) vvvvvvvv",
               should_stop);
@@ -1049,8 +1049,18 @@ bool Thread::MatchesSpec(const ThreadSpec *spec) {
 
 ThreadPlanStack &Thread::GetPlans() const {
   ThreadPlanStack *plans = GetProcess()->FindThreadPlans(GetID());
-  assert(plans && "Can't have a thread with no plans");
-  return *plans;
+  if (plans)
+    return *plans;
+
+  // History threads don't have a thread plan, but they do ask get asked to
+  // describe themselves, which usually involves pulling out the stop reason.
+  // That in turn will check for a completed plan on the ThreadPlanStack.
+  // Instead of special-casing at that point, we return a Stack with a
+  // ThreadPlanNull as its base plan.  That will give the right answers to the
+  // queries GetDescription makes, and only assert if you try to run the thread.
+  if (!m_null_plan_stack_up)
+    m_null_plan_stack_up.reset(new ThreadPlanStack(*this, true));
+  return *(m_null_plan_stack_up.get());
 }
 
 void Thread::PushPlan(ThreadPlanSP thread_plan_sp) {
@@ -1369,26 +1379,6 @@ lldb::ThreadPlanSP Thread::QueueThreadPlanForStepScripted(
 }
 
 uint32_t Thread::GetIndexID() const { return m_index_id; }
-
-void Thread::DumpThreadPlans(Stream *s, lldb::DescriptionLevel desc_level,
-                             bool include_internal,
-                             bool ignore_boring_threads) const {
-  if (ignore_boring_threads) {
-    if (!GetPlans().AnyPlans() && !GetPlans().AnyCompletedPlans()
-        && !GetPlans().AnyDiscardedPlans()) {
-      s->Printf("thread #%u: tid = 0x%4.4" PRIx64 "\n", GetIndexID(), GetID());
-      s->IndentMore();
-      s->Indent();
-      s->Printf("No active thread plans\n");
-      s->IndentLess();
-      return;
-    }
-  }
-  
-  s->Indent();
-  s->Printf("thread #%u: tid = 0x%4.4" PRIx64 ":\n", GetIndexID(), GetID());
-  GetPlans().DumpThreadPlans(s, desc_level, include_internal);
-}
 
 TargetSP Thread::CalculateTarget() {
   TargetSP target_sp;

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -35,6 +35,7 @@
 #include "lldb/Target/ThreadPlanCallFunction.h"
 #include "lldb/Target/ThreadPlanPython.h"
 #include "lldb/Target/ThreadPlanRunToAddress.h"
+#include "lldb/Target/ThreadPlanStack.h"
 #include "lldb/Target/ThreadPlanStepInRange.h"
 #include "lldb/Target/ThreadPlanStepInstruction.h"
 #include "lldb/Target/ThreadPlanStepOut.h"
@@ -230,8 +231,7 @@ Thread::Thread(Process &process, lldb::tid_t tid, bool use_invalid_index_id)
       m_index_id(use_invalid_index_id ? LLDB_INVALID_INDEX32
                                       : process.GetNextThreadIndexID(tid)),
       m_reg_context_sp(), m_state(eStateUnloaded), m_state_mutex(),
-      m_plan_stack(), m_completed_plan_stack(), m_frame_mutex(),
-      m_curr_frames_sp(), m_prev_frames_sp(),
+      m_frame_mutex(), m_curr_frames_sp(), m_prev_frames_sp(),
       m_resume_signal(LLDB_INVALID_SIGNAL_NUMBER),
       m_resume_state(eStateRunning), m_temporary_resume_state(eStateRunning),
       m_unwinder_up(), m_destroy_called(false),
@@ -242,7 +242,9 @@ Thread::Thread(Process &process, lldb::tid_t tid, bool use_invalid_index_id)
             static_cast<void *>(this), GetID());
 
   CheckInWithManager();
-
+  
+  process.AddThreadPlansForThread(*this);
+  
   QueueFundamentalPlan(true);
 }
 
@@ -256,30 +258,7 @@ Thread::~Thread() {
 }
 
 void Thread::DestroyThread() {
-  // Tell any plans on the plan stacks that the thread is being destroyed since
-  // any plans that have a thread go away in the middle of might need to do
-  // cleanup, or in some cases NOT do cleanup...
-  for (auto plan : m_plan_stack)
-    plan->ThreadDestroyed();
-
-  for (auto plan : m_discarded_plan_stack)
-    plan->ThreadDestroyed();
-
-  for (auto plan : m_completed_plan_stack)
-    plan->ThreadDestroyed();
-
   m_destroy_called = true;
-  m_plan_stack.clear();
-  m_discarded_plan_stack.clear();
-  m_completed_plan_stack.clear();
-
-  // Push a ThreadPlanNull on the plan stack.  That way we can continue
-  // assuming that the plan stack is never empty, but if somebody errantly asks
-  // questions of a destroyed thread without checking first whether it is
-  // destroyed, they won't crash.
-  ThreadPlanSP null_plan_sp(new ThreadPlanNull(*this));
-  m_plan_stack.push_back(null_plan_sp);
-
   m_stop_info_sp.reset();
   m_reg_context_sp.reset();
   m_unwinder_up.reset();
@@ -524,7 +503,8 @@ bool Thread::CheckpointThreadState(ThreadStateCheckpoint &saved_state) {
   if (process_sp)
     saved_state.orig_stop_id = process_sp->GetStopID();
   saved_state.current_inlined_depth = GetCurrentInlinedDepth();
-  saved_state.m_completed_plan_stack = m_completed_plan_stack;
+  saved_state.m_completed_plan_checkpoint =
+      GetPlans().CheckpointCompletedPlans();
 
   return true;
 }
@@ -558,7 +538,8 @@ bool Thread::RestoreThreadStateFromCheckpoint(
   SetStopInfo(saved_state.stop_info_sp);
   GetStackFrameList()->SetCurrentInlinedDepth(
       saved_state.current_inlined_depth);
-  m_completed_plan_stack = saved_state.m_completed_plan_stack;
+  GetPlans().RestoreCompletedPlanCheckpoint(
+      saved_state.m_completed_plan_checkpoint);
   return true;
 }
 
@@ -687,8 +668,7 @@ void Thread::SetupForResume() {
 
 bool Thread::ShouldResume(StateType resume_state) {
   // At this point clear the completed plan stack.
-  m_completed_plan_stack.clear();
-  m_discarded_plan_stack.clear();
+  GetPlans().WillResume();
   m_override_should_notify = eLazyBoolCalculate;
 
   StateType prev_resume_state = GetTemporaryResumeState();
@@ -882,7 +862,7 @@ bool Thread::ShouldStop(Event *event_ptr) {
               current_plan->GetName(), over_ride_stop);
 
     // We're starting from the base plan, so just let it decide;
-    if (PlanIsBasePlan(current_plan)) {
+    if (current_plan->IsBasePlan()) {
       should_stop = current_plan->ShouldStop(event_ptr);
       LLDB_LOGF(log, "Base plan says should stop: %i.", should_stop);
     } else {
@@ -890,7 +870,7 @@ bool Thread::ShouldStop(Event *event_ptr) {
       // to do, since presumably if there were other plans they would know what
       // to do...
       while (true) {
-        if (PlanIsBasePlan(current_plan))
+        if (current_plan->IsBasePlan())
           break;
 
         should_stop = current_plan->ShouldStop(event_ptr);
@@ -936,7 +916,7 @@ bool Thread::ShouldStop(Event *event_ptr) {
 
     // Discard the stale plans and all plans below them in the stack, plus move
     // the completed plans to the completed plan stack
-    while (!PlanIsBasePlan(plan_ptr)) {
+    while (!plan_ptr->IsBasePlan()) {
       bool stale = plan_ptr->IsPlanStale();
       ThreadPlan *examined_plan = plan_ptr;
       plan_ptr = GetPreviousPlan(examined_plan);
@@ -1002,13 +982,14 @@ Vote Thread::ShouldReportStop(Event *event_ptr) {
     return eVoteNoOpinion;
   }
 
-  if (m_completed_plan_stack.size() > 0) {
-    // Don't use GetCompletedPlan here, since that suppresses private plans.
+  if (GetPlans().AnyCompletedPlans()) {
+    // Pass skip_private = false to GetCompletedPlan, since we want to ask 
+    // the last plan, regardless of whether it is private or not.
     LLDB_LOGF(log,
               "Thread::ShouldReportStop() tid = 0x%4.4" PRIx64
               ": returning vote  for complete stack's back plan",
               GetID());
-    return m_completed_plan_stack.back()->ShouldReportStop(event_ptr);
+    return GetPlans().GetCompletedPlan(false)->ShouldReportStop(event_ptr);
   } else {
     Vote thread_vote = eVoteNoOpinion;
     ThreadPlan *plan_ptr = GetCurrentPlan();
@@ -1017,7 +998,7 @@ Vote Thread::ShouldReportStop(Event *event_ptr) {
         thread_vote = plan_ptr->ShouldReportStop(event_ptr);
         break;
       }
-      if (PlanIsBasePlan(plan_ptr))
+      if (plan_ptr->IsBasePlan())
         break;
       else
         plan_ptr = GetPreviousPlan(plan_ptr);
@@ -1039,16 +1020,17 @@ Vote Thread::ShouldReportRun(Event *event_ptr) {
   }
 
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_STEP));
-  if (m_completed_plan_stack.size() > 0) {
-    // Don't use GetCompletedPlan here, since that suppresses private plans.
+  if (GetPlans().AnyCompletedPlans()) {
+    // Pass skip_private = false to GetCompletedPlan, since we want to ask 
+    // the last plan, regardless of whether it is private or not.
     LLDB_LOGF(log,
               "Current Plan for thread %d(%p) (0x%4.4" PRIx64
               ", %s): %s being asked whether we should report run.",
               GetIndexID(), static_cast<void *>(this), GetID(),
               StateAsCString(GetTemporaryResumeState()),
-              m_completed_plan_stack.back()->GetName());
+              GetCompletedPlan()->GetName());
 
-    return m_completed_plan_stack.back()->ShouldReportRun(event_ptr);
+    return GetPlans().GetCompletedPlan(false)->ShouldReportRun(event_ptr);
   } else {
     LLDB_LOGF(log,
               "Current Plan for thread %d(%p) (0x%4.4" PRIx64
@@ -1065,148 +1047,75 @@ bool Thread::MatchesSpec(const ThreadSpec *spec) {
   return (spec == nullptr) ? true : spec->ThreadPassesBasicTests(*this);
 }
 
-void Thread::PushPlan(ThreadPlanSP &thread_plan_sp) {
-  if (thread_plan_sp) {
-    // If the thread plan doesn't already have a tracer, give it its parent's
-    // tracer:
-    if (!thread_plan_sp->GetThreadPlanTracer()) {
-      assert(!m_plan_stack.empty());
-      thread_plan_sp->SetThreadPlanTracer(
-          m_plan_stack.back()->GetThreadPlanTracer());
-    }
-    m_plan_stack.push_back(thread_plan_sp);
+ThreadPlanStack &Thread::GetPlans() const {
+  ThreadPlanStack *plans = GetProcess()->FindThreadPlans(GetID());
+  assert(plans && "Can't have a thread with no plans");
+  return *plans;
+}
 
-    thread_plan_sp->DidPush();
+void Thread::PushPlan(ThreadPlanSP thread_plan_sp) {
+  assert(thread_plan_sp && "Don't push an empty thread plan.");
 
-    Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_STEP));
-    if (log) {
-      StreamString s;
-      thread_plan_sp->GetDescription(&s, lldb::eDescriptionLevelFull);
-      LLDB_LOGF(log, "Thread::PushPlan(0x%p): \"%s\", tid = 0x%4.4" PRIx64 ".",
-                static_cast<void *>(this), s.GetData(),
-                thread_plan_sp->GetThread().GetID());
-    }
+  Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_STEP));
+  if (log) {
+    StreamString s;
+    thread_plan_sp->GetDescription(&s, lldb::eDescriptionLevelFull);
+    LLDB_LOGF(log, "Thread::PushPlan(0x%p): \"%s\", tid = 0x%4.4" PRIx64 ".",
+              static_cast<void *>(this), s.GetData(),
+              thread_plan_sp->GetThread().GetID());
   }
+  
+  GetPlans().PushPlan(std::move(thread_plan_sp));
 }
 
 void Thread::PopPlan() {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_STEP));
-
-  if (m_plan_stack.size() <= 1)
-    return;
-  else {
-    ThreadPlanSP &plan = m_plan_stack.back();
-    if (log) {
-      LLDB_LOGF(log, "Popping plan: \"%s\", tid = 0x%4.4" PRIx64 ".",
-                plan->GetName(), plan->GetThread().GetID());
-    }
-    m_completed_plan_stack.push_back(plan);
-    plan->WillPop();
-    m_plan_stack.pop_back();
+  ThreadPlanSP popped_plan_sp = GetPlans().PopPlan();
+  if (log) {
+    LLDB_LOGF(log, "Popping plan: \"%s\", tid = 0x%4.4" PRIx64 ".",
+              popped_plan_sp->GetName(), popped_plan_sp->GetThread().GetID());
   }
 }
 
 void Thread::DiscardPlan() {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_STEP));
-  if (m_plan_stack.size() > 1) {
-    ThreadPlanSP &plan = m_plan_stack.back();
-    LLDB_LOGF(log, "Discarding plan: \"%s\", tid = 0x%4.4" PRIx64 ".",
-              plan->GetName(), plan->GetThread().GetID());
+  ThreadPlanSP discarded_plan_sp = GetPlans().PopPlan();
 
-    m_discarded_plan_stack.push_back(plan);
-    plan->WillPop();
-    m_plan_stack.pop_back();
-  }
+  LLDB_LOGF(log, "Discarding plan: \"%s\", tid = 0x%4.4" PRIx64 ".",
+            discarded_plan_sp->GetName(), 
+            discarded_plan_sp->GetThread().GetID());
 }
 
-ThreadPlan *Thread::GetCurrentPlan() {
-  // There will always be at least the base plan.  If somebody is mucking with
-  // a thread with an empty plan stack, we should assert right away.
-  return m_plan_stack.empty() ? nullptr : m_plan_stack.back().get();
+ThreadPlan *Thread::GetCurrentPlan() const {
+  return GetPlans().GetCurrentPlan().get();
 }
 
-ThreadPlanSP Thread::GetCompletedPlan() {
-  ThreadPlanSP empty_plan_sp;
-  if (!m_completed_plan_stack.empty()) {
-    for (int i = m_completed_plan_stack.size() - 1; i >= 0; i--) {
-      ThreadPlanSP completed_plan_sp;
-      completed_plan_sp = m_completed_plan_stack[i];
-      if (!completed_plan_sp->GetPrivate())
-        return completed_plan_sp;
-    }
-  }
-  return empty_plan_sp;
+ThreadPlanSP Thread::GetCompletedPlan() const {
+  return GetPlans().GetCompletedPlan();
 }
 
-ValueObjectSP Thread::GetReturnValueObject() {
-  if (!m_completed_plan_stack.empty()) {
-    for (int i = m_completed_plan_stack.size() - 1; i >= 0; i--) {
-      ValueObjectSP return_valobj_sp;
-      return_valobj_sp = m_completed_plan_stack[i]->GetReturnValueObject();
-      if (return_valobj_sp)
-        return return_valobj_sp;
-    }
-  }
-  return ValueObjectSP();
+ValueObjectSP Thread::GetReturnValueObject() const {
+  return GetPlans().GetReturnValueObject();
 }
 
-ExpressionVariableSP Thread::GetExpressionVariable() {
-  if (!m_completed_plan_stack.empty()) {
-    for (int i = m_completed_plan_stack.size() - 1; i >= 0; i--) {
-      ExpressionVariableSP expression_variable_sp;
-      expression_variable_sp =
-          m_completed_plan_stack[i]->GetExpressionVariable();
-      if (expression_variable_sp)
-        return expression_variable_sp;
-    }
-  }
-  return ExpressionVariableSP();
+ExpressionVariableSP Thread::GetExpressionVariable() const {
+  return GetPlans().GetExpressionVariable();
 }
 
-bool Thread::IsThreadPlanDone(ThreadPlan *plan) {
-  if (!m_completed_plan_stack.empty()) {
-    for (int i = m_completed_plan_stack.size() - 1; i >= 0; i--) {
-      if (m_completed_plan_stack[i].get() == plan)
-        return true;
-    }
-  }
-  return false;
+bool Thread::IsThreadPlanDone(ThreadPlan *plan) const {
+  return GetPlans().IsPlanDone(plan);
 }
 
-bool Thread::WasThreadPlanDiscarded(ThreadPlan *plan) {
-  if (!m_discarded_plan_stack.empty()) {
-    for (int i = m_discarded_plan_stack.size() - 1; i >= 0; i--) {
-      if (m_discarded_plan_stack[i].get() == plan)
-        return true;
-    }
-  }
-  return false;
+bool Thread::WasThreadPlanDiscarded(ThreadPlan *plan) const {
+  return GetPlans().WasPlanDiscarded(plan);
 }
 
-bool Thread::CompletedPlanOverridesBreakpoint() {
-  return (!m_completed_plan_stack.empty()) ;
+bool Thread::CompletedPlanOverridesBreakpoint() const {
+  return GetPlans().AnyCompletedPlans();
 }
 
-ThreadPlan *Thread::GetPreviousPlan(ThreadPlan *current_plan) {
-  if (current_plan == nullptr)
-    return nullptr;
-
-  int stack_size = m_completed_plan_stack.size();
-  for (int i = stack_size - 1; i > 0; i--) {
-    if (current_plan == m_completed_plan_stack[i].get())
-      return m_completed_plan_stack[i - 1].get();
-  }
-
-  if (stack_size > 0 && m_completed_plan_stack[0].get() == current_plan) {
-    return GetCurrentPlan();
-  }
-
-  stack_size = m_plan_stack.size();
-  for (int i = stack_size - 1; i > 0; i--) {
-    if (current_plan == m_plan_stack[i].get())
-      return m_plan_stack[i - 1].get();
-  }
-  return nullptr;
+ThreadPlan *Thread::GetPreviousPlan(ThreadPlan *current_plan) const{
+  return GetPlans().GetPreviousPlan(current_plan);
 }
 
 Status Thread::QueueThreadPlan(ThreadPlanSP &thread_plan_sp,
@@ -1240,38 +1149,18 @@ Status Thread::QueueThreadPlan(ThreadPlanSP &thread_plan_sp,
 }
 
 void Thread::EnableTracer(bool value, bool single_stepping) {
-  int stack_size = m_plan_stack.size();
-  for (int i = 0; i < stack_size; i++) {
-    if (m_plan_stack[i]->GetThreadPlanTracer()) {
-      m_plan_stack[i]->GetThreadPlanTracer()->EnableTracing(value);
-      m_plan_stack[i]->GetThreadPlanTracer()->EnableSingleStep(single_stepping);
-    }
-  }
+  GetPlans().EnableTracer(value, single_stepping);
 }
 
 void Thread::SetTracer(lldb::ThreadPlanTracerSP &tracer_sp) {
-  int stack_size = m_plan_stack.size();
-  for (int i = 0; i < stack_size; i++)
-    m_plan_stack[i]->SetThreadPlanTracer(tracer_sp);
+  GetPlans().SetTracer(tracer_sp);
 }
 
-bool Thread::DiscardUserThreadPlansUpToIndex(uint32_t thread_index) {
+bool Thread::DiscardUserThreadPlansUpToIndex(uint32_t plan_index) {
   // Count the user thread plans from the back end to get the number of the one
   // we want to discard:
 
-  uint32_t idx = 0;
-  ThreadPlan *up_to_plan_ptr = nullptr;
-
-  for (ThreadPlanSP plan_sp : m_plan_stack) {
-    if (plan_sp->GetPrivate())
-      continue;
-    if (idx == thread_index) {
-      up_to_plan_ptr = plan_sp.get();
-      break;
-    } else
-      idx++;
-  }
-
+  ThreadPlan *up_to_plan_ptr = GetPlans().GetPlanByIndex(plan_index).get();
   if (up_to_plan_ptr == nullptr)
     return false;
 
@@ -1289,30 +1178,7 @@ void Thread::DiscardThreadPlansUpToPlan(ThreadPlan *up_to_plan_ptr) {
             "Discarding thread plans for thread tid = 0x%4.4" PRIx64
             ", up to %p",
             GetID(), static_cast<void *>(up_to_plan_ptr));
-
-  int stack_size = m_plan_stack.size();
-
-  // If the input plan is nullptr, discard all plans.  Otherwise make sure this
-  // plan is in the stack, and if so discard up to and including it.
-
-  if (up_to_plan_ptr == nullptr) {
-    for (int i = stack_size - 1; i > 0; i--)
-      DiscardPlan();
-  } else {
-    bool found_it = false;
-    for (int i = stack_size - 1; i > 0; i--) {
-      if (m_plan_stack[i].get() == up_to_plan_ptr)
-        found_it = true;
-    }
-    if (found_it) {
-      bool last_one = false;
-      for (int i = stack_size - 1; i > 0 && !last_one; i--) {
-        if (GetCurrentPlan() == up_to_plan_ptr)
-          last_one = true;
-        DiscardPlan();
-      }
-    }
-  }
+  GetPlans().DiscardPlansUpToPlan(up_to_plan_ptr);
 }
 
 void Thread::DiscardThreadPlans(bool force) {
@@ -1325,73 +1191,20 @@ void Thread::DiscardThreadPlans(bool force) {
   }
 
   if (force) {
-    int stack_size = m_plan_stack.size();
-    for (int i = stack_size - 1; i > 0; i--) {
-      DiscardPlan();
-    }
+    GetPlans().DiscardAllPlans();
     return;
   }
-
-  while (true) {
-    int master_plan_idx;
-    bool discard = true;
-
-    // Find the first master plan, see if it wants discarding, and if yes
-    // discard up to it.
-    for (master_plan_idx = m_plan_stack.size() - 1; master_plan_idx >= 0;
-         master_plan_idx--) {
-      if (m_plan_stack[master_plan_idx]->IsMasterPlan()) {
-        discard = m_plan_stack[master_plan_idx]->OkayToDiscard();
-        break;
-      }
-    }
-
-    if (discard) {
-      // First pop all the dependent plans:
-      for (int i = m_plan_stack.size() - 1; i > master_plan_idx; i--) {
-        // FIXME: Do we need a finalize here, or is the rule that
-        // "PrepareForStop"
-        // for the plan leaves it in a state that it is safe to pop the plan
-        // with no more notice?
-        DiscardPlan();
-      }
-
-      // Now discard the master plan itself.
-      // The bottom-most plan never gets discarded.  "OkayToDiscard" for it
-      // means discard it's dependent plans, but not it...
-      if (master_plan_idx > 0) {
-        DiscardPlan();
-      }
-    } else {
-      // If the master plan doesn't want to get discarded, then we're done.
-      break;
-    }
-  }
-}
-
-bool Thread::PlanIsBasePlan(ThreadPlan *plan_ptr) {
-  if (plan_ptr->IsBasePlan())
-    return true;
-  else if (m_plan_stack.size() == 0)
-    return false;
-  else
-    return m_plan_stack[0].get() == plan_ptr;
+  GetPlans().DiscardConsultingMasterPlans();
 }
 
 Status Thread::UnwindInnermostExpression() {
   Status error;
-  int stack_size = m_plan_stack.size();
-
-  // If the input plan is nullptr, discard all plans.  Otherwise make sure this
-  // plan is in the stack, and if so discard up to and including it.
-
-  for (int i = stack_size - 1; i > 0; i--) {
-    if (m_plan_stack[i]->GetKind() == ThreadPlan::eKindCallFunction) {
-      DiscardThreadPlansUpToPlan(m_plan_stack[i].get());
-      return error;
-    }
-  }
-  error.SetErrorString("No expressions currently active on this thread");
+  ThreadPlan *innermost_expr_plan = GetPlans().GetInnermostExpression();
+  if (!innermost_expr_plan) {
+    error.SetErrorString("No expressions currently active on this thread");
+    return error;
+  }  
+  DiscardThreadPlansUpToPlan(innermost_expr_plan);
   return error;
 }
 
@@ -1557,40 +1370,12 @@ lldb::ThreadPlanSP Thread::QueueThreadPlanForStepScripted(
 
 uint32_t Thread::GetIndexID() const { return m_index_id; }
 
-static void PrintPlanElement(Stream *s, const ThreadPlanSP &plan,
-                             lldb::DescriptionLevel desc_level,
-                             int32_t elem_idx) {
-  s->IndentMore();
-  s->Indent();
-  s->Printf("Element %d: ", elem_idx);
-  plan->GetDescription(s, desc_level);
-  s->EOL();
-  s->IndentLess();
-}
-
-static void PrintPlanStack(Stream *s,
-                           const std::vector<lldb::ThreadPlanSP> &plan_stack,
-                           lldb::DescriptionLevel desc_level,
-                           bool include_internal) {
-  int32_t print_idx = 0;
-  for (ThreadPlanSP plan_sp : plan_stack) {
-    if (include_internal || !plan_sp->GetPrivate()) {
-      PrintPlanElement(s, plan_sp, desc_level, print_idx++);
-    }
-  }
-}
-
 void Thread::DumpThreadPlans(Stream *s, lldb::DescriptionLevel desc_level,
                              bool include_internal,
                              bool ignore_boring_threads) const {
-  uint32_t stack_size;
-
   if (ignore_boring_threads) {
-    uint32_t stack_size = m_plan_stack.size();
-    uint32_t completed_stack_size = m_completed_plan_stack.size();
-    uint32_t discarded_stack_size = m_discarded_plan_stack.size();
-    if (stack_size == 1 && completed_stack_size == 0 &&
-        discarded_stack_size == 0) {
+    if (!GetPlans().AnyPlans() && !GetPlans().AnyCompletedPlans()
+        && !GetPlans().AnyDiscardedPlans()) {
       s->Printf("thread #%u: tid = 0x%4.4" PRIx64 "\n", GetIndexID(), GetID());
       s->IndentMore();
       s->Indent();
@@ -1599,29 +1384,10 @@ void Thread::DumpThreadPlans(Stream *s, lldb::DescriptionLevel desc_level,
       return;
     }
   }
-
+  
   s->Indent();
   s->Printf("thread #%u: tid = 0x%4.4" PRIx64 ":\n", GetIndexID(), GetID());
-  s->IndentMore();
-  s->Indent();
-  s->Printf("Active plan stack:\n");
-  PrintPlanStack(s, m_plan_stack, desc_level, include_internal);
-
-  stack_size = m_completed_plan_stack.size();
-  if (stack_size > 0) {
-    s->Indent();
-    s->Printf("Completed Plan Stack:\n");
-    PrintPlanStack(s, m_completed_plan_stack, desc_level, include_internal);
-  }
-
-  stack_size = m_discarded_plan_stack.size();
-  if (stack_size > 0) {
-    s->Indent();
-    s->Printf("Discarded Plan Stack:\n");
-    PrintPlanStack(s, m_discarded_plan_stack, desc_level, include_internal);
-  }
-
-  s->IndentLess();
+  GetPlans().DumpThreadPlans(s, desc_level, include_internal);
 }
 
 TargetSP Thread::CalculateTarget() {

--- a/lldb/source/Target/ThreadList.cpp
+++ b/lldb/source/Target/ThreadList.cpp
@@ -715,6 +715,11 @@ void ThreadList::Update(ThreadList &rhs) {
     // to work around the issue
     collection::iterator rhs_pos, rhs_end = rhs.m_threads.end();
     for (rhs_pos = rhs.m_threads.begin(); rhs_pos != rhs_end; ++rhs_pos) {
+      // If this thread has already been destroyed, we don't need to look for
+      // it to destroy it again.
+      if (!(*rhs_pos)->IsValid())
+        continue;
+
       const lldb::tid_t tid = (*rhs_pos)->GetID();
       bool thread_is_alive = false;
       const uint32_t num_threads = m_threads.size();
@@ -728,7 +733,6 @@ void ThreadList::Update(ThreadList &rhs) {
       }
       if (!thread_is_alive) {
         (*rhs_pos)->DestroyThread();
-        m_process->RemoveThreadPlansForTID((*rhs_pos)->GetID());
       }
     }
   }

--- a/lldb/source/Target/ThreadList.cpp
+++ b/lldb/source/Target/ThreadList.cpp
@@ -726,8 +726,10 @@ void ThreadList::Update(ThreadList &rhs) {
           break;
         }
       }
-      if (!thread_is_alive)
+      if (!thread_is_alive) {
         (*rhs_pos)->DestroyThread();
+        m_process->RemoveThreadPlansForTID((*rhs_pos)->GetID());
+      }
     }
   }
 }

--- a/lldb/source/Target/ThreadPlan.cpp
+++ b/lldb/source/Target/ThreadPlan.cpp
@@ -34,6 +34,10 @@ ThreadPlan::ThreadPlan(ThreadPlanKind kind, const char *name, Thread &thread,
 // Destructor
 ThreadPlan::~ThreadPlan() = default;
 
+Target &ThreadPlan::GetTarget() { return m_process.GetTarget(); }
+
+const Target &ThreadPlan::GetTarget() const { return m_process.GetTarget(); }
+
 Thread &ThreadPlan::GetThread() {
   if (m_thread)
     return *m_thread;

--- a/lldb/source/Target/ThreadPlanBase.cpp
+++ b/lldb/source/Target/ThreadPlanBase.cpp
@@ -34,11 +34,11 @@ ThreadPlanBase::ThreadPlanBase(Thread &thread)
 #define THREAD_PLAN_USE_ASSEMBLY_TRACER 1
 
 #ifdef THREAD_PLAN_USE_ASSEMBLY_TRACER
-  ThreadPlanTracerSP new_tracer_sp(new ThreadPlanAssemblyTracer(m_thread));
+  ThreadPlanTracerSP new_tracer_sp(new ThreadPlanAssemblyTracer(thread));
 #else
   ThreadPlanTracerSP new_tracer_sp(new ThreadPlanTracer(m_thread));
 #endif
-  new_tracer_sp->EnableTracing(m_thread.GetTraceEnabledState());
+  new_tracer_sp->EnableTracing(thread.GetTraceEnabledState());
   SetThreadPlanTracer(new_tracer_sp);
   SetIsMasterPlan(true);
 }
@@ -58,7 +58,7 @@ bool ThreadPlanBase::DoPlanExplainsStop(Event *event_ptr) {
 }
 
 Vote ThreadPlanBase::ShouldReportStop(Event *event_ptr) {
-  StopInfoSP stop_info_sp = m_thread.GetStopInfo();
+  StopInfoSP stop_info_sp = GetThread().GetStopInfo();
   if (stop_info_sp) {
     bool should_notify = stop_info_sp->ShouldNotify(event_ptr);
     if (should_notify)
@@ -96,8 +96,8 @@ bool ThreadPlanBase::ShouldStop(Event *event_ptr) {
             log,
             "Base plan discarding thread plans for thread tid = 0x%4.4" PRIx64
             " (breakpoint hit.)",
-            m_thread.GetID());
-        m_thread.DiscardThreadPlans(false);
+            m_tid);
+        GetThread().DiscardThreadPlans(false);
         return true;
       }
       // If we aren't going to stop at this breakpoint, and it is internal,
@@ -125,9 +125,9 @@ bool ThreadPlanBase::ShouldStop(Event *event_ptr) {
       LLDB_LOGF(
           log,
           "Base plan discarding thread plans for thread tid = 0x%4.4" PRIx64
-          " (exception: %s)",
-          m_thread.GetID(), stop_info_sp->GetDescription());
-      m_thread.DiscardThreadPlans(false);
+          " (exception: %s)", 
+          m_tid, stop_info_sp->GetDescription());
+      GetThread().DiscardThreadPlans(false);
       return true;
 
     case eStopReasonExec:
@@ -138,8 +138,8 @@ bool ThreadPlanBase::ShouldStop(Event *event_ptr) {
           log,
           "Base plan discarding thread plans for thread tid = 0x%4.4" PRIx64
           " (exec.)",
-          m_thread.GetID());
-      m_thread.DiscardThreadPlans(false);
+          m_tid);
+      GetThread().DiscardThreadPlans(false);
       return true;
 
     case eStopReasonThreadExiting:
@@ -148,9 +148,9 @@ bool ThreadPlanBase::ShouldStop(Event *event_ptr) {
         LLDB_LOGF(
             log,
             "Base plan discarding thread plans for thread tid = 0x%4.4" PRIx64
-            " (signal: %s)",
-            m_thread.GetID(), stop_info_sp->GetDescription());
-        m_thread.DiscardThreadPlans(false);
+            " (signal: %s)", 
+            m_tid, stop_info_sp->GetDescription());
+        GetThread().DiscardThreadPlans(false);
         return true;
       } else {
         // We're not going to stop, but while we are here, let's figure out

--- a/lldb/source/Target/ThreadPlanCallFunction.cpp
+++ b/lldb/source/Target/ThreadPlanCallFunction.cpp
@@ -146,7 +146,7 @@ void ThreadPlanCallFunction::ReportRegisterState(const char *message) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_STEP));
   if (log && log->GetVerbose()) {
     StreamString strm;
-    RegisterContext *reg_ctx = m_thread.GetRegisterContext().get();
+    RegisterContext *reg_ctx = GetThread().GetRegisterContext().get();
 
     log->PutCString(message);
 
@@ -178,19 +178,19 @@ void ThreadPlanCallFunction::DoTakedown(bool success) {
   }
 
   if (!m_takedown_done) {
+    Thread &thread = GetThread();
     if (success) {
       SetReturnValue();
     }
     LLDB_LOGF(log,
               "ThreadPlanCallFunction(%p): DoTakedown called for thread "
               "0x%4.4" PRIx64 ", m_valid: %d complete: %d.\n",
-              static_cast<void *>(this), m_thread.GetID(), m_valid,
-              IsPlanComplete());
+              static_cast<void *>(this), m_tid, m_valid, IsPlanComplete());
     m_takedown_done = true;
     m_stop_address =
-        m_thread.GetStackFrameAtIndex(0)->GetRegisterContext()->GetPC();
+        thread.GetStackFrameAtIndex(0)->GetRegisterContext()->GetPC();
     m_real_stop_info_sp = GetPrivateStopInfo();
-    if (!m_thread.RestoreRegisterStateFromCheckpoint(m_stored_thread_state)) {
+    if (!thread.RestoreRegisterStateFromCheckpoint(m_stored_thread_state)) {
       LLDB_LOGF(log,
                 "ThreadPlanCallFunction(%p): DoTakedown failed to restore "
                 "register state",
@@ -205,8 +205,7 @@ void ThreadPlanCallFunction::DoTakedown(bool success) {
     LLDB_LOGF(log,
               "ThreadPlanCallFunction(%p): DoTakedown called as no-op for "
               "thread 0x%4.4" PRIx64 ", m_valid: %d complete: %d.\n",
-              static_cast<void *>(this), m_thread.GetID(), m_valid,
-              IsPlanComplete());
+              static_cast<void *>(this), m_tid, m_valid, IsPlanComplete());
   }
 }
 
@@ -216,9 +215,8 @@ void ThreadPlanCallFunction::GetDescription(Stream *s, DescriptionLevel level) {
   if (level == eDescriptionLevelBrief) {
     s->Printf("Function call thread plan");
   } else {
-    TargetSP target_sp(m_thread.CalculateTarget());
     s->Printf("Thread plan to call 0x%" PRIx64,
-              m_function_addr.GetLoadAddress(target_sp.get()));
+              m_function_addr.GetLoadAddress(&GetTarget()));
   }
 }
 
@@ -283,11 +281,9 @@ bool ThreadPlanCallFunction::DoPlanExplainsStop(Event *event_ptr) {
   // m_ignore_breakpoints.
 
   if (stop_reason == eStopReasonBreakpoint) {
-    ProcessSP process_sp(m_thread.CalculateProcess());
     uint64_t break_site_id = m_real_stop_info_sp->GetValue();
     BreakpointSiteSP bp_site_sp;
-    if (process_sp)
-      bp_site_sp = process_sp->GetBreakpointSiteList().FindByID(break_site_id);
+    bp_site_sp = m_process.GetBreakpointSiteList().FindByID(break_site_id);
     if (bp_site_sp) {
       uint32_t num_owners = bp_site_sp->GetNumberOfOwners();
       bool is_internal = true;
@@ -374,10 +370,11 @@ void ThreadPlanCallFunction::DidPush() {
   GetThread().SetStopInfoToNothing();
 
 #ifndef SINGLE_STEP_EXPRESSIONS
-  m_subplan_sp = std::make_shared<ThreadPlanRunToAddress>(
-      m_thread, m_start_addr, m_stop_other_threads);
+  Thread &thread = GetThread();
+  m_subplan_sp = std::make_shared<ThreadPlanRunToAddress>(thread, m_start_addr, 
+                                                          m_stop_other_threads);
 
-  m_thread.QueueThreadPlan(m_subplan_sp, false);
+  thread.QueueThreadPlan(m_subplan_sp, false);
   m_subplan_sp->SetPrivate(true);
 #endif
 }
@@ -399,11 +396,10 @@ bool ThreadPlanCallFunction::MischiefManaged() {
 }
 
 void ThreadPlanCallFunction::SetBreakpoints() {
-  ProcessSP process_sp(m_thread.CalculateProcess());
-  if (m_trap_exceptions && process_sp) {
+  if (m_trap_exceptions) {
     m_cxx_language_runtime =
-        process_sp->GetLanguageRuntime(eLanguageTypeC_plus_plus);
-    m_objc_language_runtime = process_sp->GetLanguageRuntime(eLanguageTypeObjC);
+        m_process.GetLanguageRuntime(eLanguageTypeC_plus_plus);
+    m_objc_language_runtime = m_process.GetLanguageRuntime(eLanguageTypeObjC);
 
     if (m_cxx_language_runtime) {
       m_should_clear_cxx_exception_bp =
@@ -463,11 +459,10 @@ bool ThreadPlanCallFunction::RestoreThreadState() {
 }
 
 void ThreadPlanCallFunction::SetReturnValue() {
-  ProcessSP process_sp(m_thread.GetProcess());
-  const ABI *abi = process_sp ? process_sp->GetABI().get() : nullptr;
+  const ABI *abi = m_process.GetABI().get();
   if (abi && m_return_type.IsValid()) {
     const bool persistent = false;
     m_return_valobj_sp =
-        abi->GetReturnValueObject(m_thread, m_return_type, persistent);
+        abi->GetReturnValueObject(GetThread(), m_return_type, persistent);
   }
 }

--- a/lldb/source/Target/ThreadPlanCallFunctionUsingABI.cpp
+++ b/lldb/source/Target/ThreadPlanCallFunctionUsingABI.cpp
@@ -49,20 +49,18 @@ void ThreadPlanCallFunctionUsingABI::GetDescription(Stream *s,
   if (level == eDescriptionLevelBrief) {
     s->Printf("Function call thread plan using ABI instead of JIT");
   } else {
-    TargetSP target_sp(m_thread.CalculateTarget());
     s->Printf("Thread plan to call 0x%" PRIx64 " using ABI instead of JIT",
-              m_function_addr.GetLoadAddress(target_sp.get()));
+              m_function_addr.GetLoadAddress(&GetTarget()));
   }
 }
 
 void ThreadPlanCallFunctionUsingABI::SetReturnValue() {
-  ProcessSP process_sp(m_thread.GetProcess());
-  const ABI *abi = process_sp ? process_sp->GetABI().get() : nullptr;
+  const ABI *abi = m_process.GetABI().get();
 
   // Ask the abi for the return value
   if (abi) {
     const bool persistent = false;
     m_return_valobj_sp =
-        abi->GetReturnValueObject(m_thread, m_return_type, persistent);
+        abi->GetReturnValueObject(GetThread(), m_return_type, persistent);
   }
 }

--- a/lldb/source/Target/ThreadPlanCallUserExpression.cpp
+++ b/lldb/source/Target/ThreadPlanCallUserExpression.cpp
@@ -101,8 +101,7 @@ StopInfoSP ThreadPlanCallUserExpression::GetRealStopInfo() {
 
   if (stop_info_sp) {
     lldb::addr_t addr = GetStopAddress();
-    DynamicCheckerFunctions *checkers =
-        m_thread.GetProcess()->GetDynamicCheckers();
+    DynamicCheckerFunctions *checkers = m_process.GetDynamicCheckers();
     StreamString s;
 
     if (checkers && checkers->DoCheckersExplainStop(addr, s))

--- a/lldb/source/Target/ThreadPlanPython.cpp
+++ b/lldb/source/Target/ThreadPlanPython.cpp
@@ -55,15 +55,16 @@ bool ThreadPlanPython::ValidatePlan(Stream *error) {
   return true;
 }
 
+ScriptInterpreter *ThreadPlanPython::GetScriptInterpreter() {
+  return m_process.GetTarget().GetDebugger().GetScriptInterpreter();
+}
+
 void ThreadPlanPython::DidPush() {
   // We set up the script side in DidPush, so that it can push other plans in
   // the constructor, and doesn't have to care about the details of DidPush.
   m_did_push = true;
   if (!m_class_name.empty()) {
-    ScriptInterpreter *script_interp = m_thread.GetProcess()
-                                           ->GetTarget()
-                                           .GetDebugger()
-                                           .GetScriptInterpreter();
+    ScriptInterpreter *script_interp = GetScriptInterpreter();
     if (script_interp) {
       m_implementation_sp = script_interp->CreateScriptedThreadPlan(
           m_class_name.c_str(), m_args_data, m_error_str, 
@@ -79,10 +80,7 @@ bool ThreadPlanPython::ShouldStop(Event *event_ptr) {
 
   bool should_stop = true;
   if (m_implementation_sp) {
-    ScriptInterpreter *script_interp = m_thread.GetProcess()
-                                           ->GetTarget()
-                                           .GetDebugger()
-                                           .GetScriptInterpreter();
+    ScriptInterpreter *script_interp = GetScriptInterpreter();
     if (script_interp) {
       bool script_error;
       should_stop = script_interp->ScriptedThreadPlanShouldStop(
@@ -101,10 +99,7 @@ bool ThreadPlanPython::IsPlanStale() {
 
   bool is_stale = true;
   if (m_implementation_sp) {
-    ScriptInterpreter *script_interp = m_thread.GetProcess()
-                                           ->GetTarget()
-                                           .GetDebugger()
-                                           .GetScriptInterpreter();
+    ScriptInterpreter *script_interp = GetScriptInterpreter();
     if (script_interp) {
       bool script_error;
       is_stale = script_interp->ScriptedThreadPlanIsStale(m_implementation_sp,
@@ -123,10 +118,7 @@ bool ThreadPlanPython::DoPlanExplainsStop(Event *event_ptr) {
 
   bool explains_stop = true;
   if (m_implementation_sp) {
-    ScriptInterpreter *script_interp = m_thread.GetProcess()
-                                           ->GetTarget()
-                                           .GetDebugger()
-                                           .GetScriptInterpreter();
+    ScriptInterpreter *script_interp = GetScriptInterpreter();
     if (script_interp) {
       bool script_error;
       explains_stop = script_interp->ScriptedThreadPlanExplainsStop(
@@ -159,10 +151,7 @@ lldb::StateType ThreadPlanPython::GetPlanRunState() {
             m_class_name.c_str());
   lldb::StateType run_state = eStateRunning;
   if (m_implementation_sp) {
-    ScriptInterpreter *script_interp = m_thread.GetProcess()
-                                           ->GetTarget()
-                                           .GetDebugger()
-                                           .GetScriptInterpreter();
+    ScriptInterpreter *script_interp = GetScriptInterpreter();
     if (script_interp) {
       bool script_error;
       run_state = script_interp->ScriptedThreadPlanGetRunState(

--- a/lldb/source/Target/ThreadPlanStack.cpp
+++ b/lldb/source/Target/ThreadPlanStack.cpp
@@ -1,0 +1,370 @@
+//===-- ThreadPlanStack.cpp -------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Target/ThreadPlanStack.h"
+#include "lldb/Target/Process.h"
+#include "lldb/Target/Target.h"
+#include "lldb/Target/Thread.h"
+#include "lldb/Target/ThreadPlan.h"
+#include "lldb/Utility/Log.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+static void PrintPlanElement(Stream *s, const ThreadPlanSP &plan,
+                             lldb::DescriptionLevel desc_level,
+                             int32_t elem_idx) {
+  s->IndentMore();
+  s->Indent();
+  s->Printf("Element %d: ", elem_idx);
+  plan->GetDescription(s, desc_level);
+  s->EOL();
+  s->IndentLess();
+}
+
+void ThreadPlanStack::DumpThreadPlans(Stream *s,
+                                      lldb::DescriptionLevel desc_level,
+                                      bool include_internal) const {
+
+  uint32_t stack_size;
+
+  s->IndentMore();
+  s->Indent();
+  s->Printf("Active plan stack:\n");
+  int32_t print_idx = 0;
+  for (auto plan : m_plans) {
+    PrintPlanElement(s, plan, desc_level, print_idx++);
+  }
+
+  if (AnyCompletedPlans()) {
+    print_idx = 0;
+    s->Indent();
+    s->Printf("Completed Plan Stack:\n");
+    for (auto plan : m_completed_plans)
+      PrintPlanElement(s, plan, desc_level, print_idx++);
+  }
+
+  if (AnyDiscardedPlans()) {
+    print_idx = 0;
+    s->Indent();
+    s->Printf("Discarded Plan Stack:\n");
+    for (auto plan : m_discarded_plans)
+      PrintPlanElement(s, plan, desc_level, print_idx++);
+  }
+
+  s->IndentLess();
+}
+
+size_t ThreadPlanStack::CheckpointCompletedPlans() {
+  m_completed_plan_checkpoint++;
+  m_completed_plan_store.insert(
+      std::make_pair(m_completed_plan_checkpoint, m_completed_plans));
+  return m_completed_plan_checkpoint;
+}
+
+void ThreadPlanStack::RestoreCompletedPlanCheckpoint(size_t checkpoint) {
+  auto result = m_completed_plan_store.find(checkpoint);
+  assert(result != m_completed_plan_store.end() &&
+         "Asked for a checkpoint that didn't exist");
+  m_completed_plans.swap((*result).second);
+  m_completed_plan_store.erase(result);
+}
+
+void ThreadPlanStack::DiscardCompletedPlanCheckpoint(size_t checkpoint) {
+  m_completed_plan_store.erase(checkpoint);
+}
+
+void ThreadPlanStack::ThreadDestroyed(Thread *thread) {
+  // Tell the plan stacks that this thread is going away:
+  for (ThreadPlanSP plan : m_plans)
+    plan->ThreadDestroyed();
+
+  for (ThreadPlanSP plan : m_discarded_plans)
+    plan->ThreadDestroyed();
+
+  for (ThreadPlanSP plan : m_completed_plans)
+    plan->ThreadDestroyed();
+
+  // Now clear the current plan stacks:
+  m_plans.clear();
+  m_discarded_plans.clear();
+  m_completed_plans.clear();
+
+  // Push a ThreadPlanNull on the plan stack.  That way we can continue
+  // assuming that the plan stack is never empty, but if somebody errantly asks
+  // questions of a destroyed thread without checking first whether it is
+  // destroyed, they won't crash.
+  if (thread != nullptr) {
+    lldb::ThreadPlanSP null_plan_sp(new ThreadPlanNull(*thread));
+    m_plans.push_back(null_plan_sp);
+  }
+}
+
+void ThreadPlanStack::EnableTracer(bool value, bool single_stepping) {
+  for (ThreadPlanSP plan : m_plans) {
+    if (plan->GetThreadPlanTracer()) {
+      plan->GetThreadPlanTracer()->EnableTracing(value);
+      plan->GetThreadPlanTracer()->EnableSingleStep(single_stepping);
+    }
+  }
+}
+
+void ThreadPlanStack::SetTracer(lldb::ThreadPlanTracerSP &tracer_sp) {
+  for (ThreadPlanSP plan : m_plans)
+    plan->SetThreadPlanTracer(tracer_sp);
+}
+
+void ThreadPlanStack::PushPlan(lldb::ThreadPlanSP new_plan_sp) {
+  // If the thread plan doesn't already have a tracer, give it its parent's
+  // tracer:
+  // The first plan has to be a base plan:
+  assert(m_plans.size() > 0 ||
+         new_plan_sp->IsBasePlan() && "Zeroth plan must be a base plan");
+
+  if (!new_plan_sp->GetThreadPlanTracer()) {
+    assert(!m_plans.empty());
+    new_plan_sp->SetThreadPlanTracer(m_plans.back()->GetThreadPlanTracer());
+  }
+  m_plans.push_back(new_plan_sp);
+  new_plan_sp->DidPush();
+}
+
+lldb::ThreadPlanSP ThreadPlanStack::PopPlan() {
+  assert(m_plans.size() > 1 && "Can't pop the base thread plan");
+
+  lldb::ThreadPlanSP &plan_sp = m_plans.back();
+  m_completed_plans.push_back(plan_sp);
+  plan_sp->WillPop();
+  m_plans.pop_back();
+  return plan_sp;
+}
+
+lldb::ThreadPlanSP ThreadPlanStack::DiscardPlan() {
+  assert(m_plans.size() > 1 && "Can't discard the base thread plan");
+
+  lldb::ThreadPlanSP &plan_sp = m_plans.back();
+  m_discarded_plans.push_back(plan_sp);
+  plan_sp->WillPop();
+  m_plans.pop_back();
+  return plan_sp;
+}
+
+// If the input plan is nullptr, discard all plans.  Otherwise make sure this
+// plan is in the stack, and if so discard up to and including it.
+void ThreadPlanStack::DiscardPlansUpToPlan(ThreadPlan *up_to_plan_ptr) {
+  int stack_size = m_plans.size();
+
+  if (up_to_plan_ptr == nullptr) {
+    for (int i = stack_size - 1; i > 0; i--)
+      DiscardPlan();
+    return;
+  }
+
+  bool found_it = false;
+  for (int i = stack_size - 1; i > 0; i--) {
+    if (m_plans[i].get() == up_to_plan_ptr) {
+      found_it = true;
+      break;
+    }
+  }
+
+  if (found_it) {
+    bool last_one = false;
+    for (int i = stack_size - 1; i > 0 && !last_one; i--) {
+      if (GetCurrentPlan().get() == up_to_plan_ptr)
+        last_one = true;
+      DiscardPlan();
+    }
+  }
+}
+
+void ThreadPlanStack::DiscardAllPlans() {
+  int stack_size = m_plans.size();
+  for (int i = stack_size - 1; i > 0; i--) {
+    DiscardPlan();
+  }
+  return;
+}
+
+void ThreadPlanStack::DiscardConsultingMasterPlans() {
+  while (true) {
+    int master_plan_idx;
+    bool discard = true;
+
+    // Find the first master plan, see if it wants discarding, and if yes
+    // discard up to it.
+    for (master_plan_idx = m_plans.size() - 1; master_plan_idx >= 0;
+         master_plan_idx--) {
+      if (m_plans[master_plan_idx]->IsMasterPlan()) {
+        discard = m_plans[master_plan_idx]->OkayToDiscard();
+        break;
+      }
+    }
+
+    // If the master plan doesn't want to get discarded, then we're done.
+    if (!discard)
+      return;
+
+    // First pop all the dependent plans:
+    for (int i = m_plans.size() - 1; i > master_plan_idx; i--) {
+      DiscardPlan();
+    }
+
+    // Now discard the master plan itself.
+    // The bottom-most plan never gets discarded.  "OkayToDiscard" for it
+    // means discard it's dependent plans, but not it...
+    if (master_plan_idx > 0) {
+      DiscardPlan();
+    }
+  }
+}
+
+lldb::ThreadPlanSP ThreadPlanStack::GetCurrentPlan() const {
+  assert(m_plans.size() != 0 && "There will always be a base plan.");
+  return m_plans.back();
+}
+
+lldb::ThreadPlanSP ThreadPlanStack::GetCompletedPlan(bool skip_private) const {
+  if (m_completed_plans.empty())
+    return {};
+
+  if (!skip_private)
+    return m_completed_plans.back();
+
+  for (int i = m_completed_plans.size() - 1; i >= 0; i--) {
+    lldb::ThreadPlanSP completed_plan_sp;
+    completed_plan_sp = m_completed_plans[i];
+    if (!completed_plan_sp->GetPrivate())
+      return completed_plan_sp;
+  }
+  return {};
+}
+
+lldb::ThreadPlanSP ThreadPlanStack::GetPlanByIndex(uint32_t plan_idx,
+                                                   bool skip_private) const {
+  uint32_t idx = 0;
+  ThreadPlan *up_to_plan_ptr = nullptr;
+
+  for (lldb::ThreadPlanSP plan_sp : m_plans) {
+    if (skip_private && plan_sp->GetPrivate())
+      continue;
+    if (idx == plan_idx)
+      return plan_sp;
+    idx++;
+  }
+  return {};
+}
+
+lldb::ValueObjectSP ThreadPlanStack::GetReturnValueObject() const {
+  if (m_completed_plans.empty())
+    return {};
+
+  for (int i = m_completed_plans.size() - 1; i >= 0; i--) {
+    lldb::ValueObjectSP return_valobj_sp;
+    return_valobj_sp = m_completed_plans[i]->GetReturnValueObject();
+    if (return_valobj_sp)
+      return return_valobj_sp;
+  }
+  return {};
+}
+
+lldb::ExpressionVariableSP ThreadPlanStack::GetExpressionVariable() const {
+  if (m_completed_plans.empty())
+    return {};
+
+  for (int i = m_completed_plans.size() - 1; i >= 0; i--) {
+    lldb::ExpressionVariableSP expression_variable_sp;
+    expression_variable_sp = m_completed_plans[i]->GetExpressionVariable();
+    if (expression_variable_sp)
+      return expression_variable_sp;
+  }
+  return {};
+}
+bool ThreadPlanStack::AnyPlans() const {
+  // There is always a base plan...
+  return m_plans.size() > 1;
+}
+
+bool ThreadPlanStack::AnyCompletedPlans() const {
+  return !m_completed_plans.empty();
+}
+
+bool ThreadPlanStack::AnyDiscardedPlans() const {
+  return !m_discarded_plans.empty();
+}
+
+bool ThreadPlanStack::IsPlanDone(ThreadPlan *in_plan) const {
+  for (auto plan : m_completed_plans) {
+    if (plan.get() == in_plan)
+      return true;
+  }
+  return false;
+}
+
+bool ThreadPlanStack::WasPlanDiscarded(ThreadPlan *in_plan) const {
+  for (auto plan : m_discarded_plans) {
+    if (plan.get() == in_plan)
+      return true;
+  }
+  return false;
+}
+
+ThreadPlan *ThreadPlanStack::GetPreviousPlan(ThreadPlan *current_plan) const {
+  if (current_plan == nullptr)
+    return nullptr;
+
+  // Look first in the completed plans, if the plan is here and there is
+  // a completed plan above it, return that.
+  int stack_size = m_completed_plans.size();
+  for (int i = stack_size - 1; i > 0; i--) {
+    if (current_plan == m_completed_plans[i].get())
+      return m_completed_plans[i - 1].get();
+  }
+
+  // If this is the first completed plan, the previous one is the
+  // bottom of the regular plan stack.
+  if (stack_size > 0 && m_completed_plans[0].get() == current_plan) {
+    return GetCurrentPlan().get();
+  }
+
+  // Otherwise look for it in the regular plans.
+  stack_size = m_plans.size();
+  for (int i = stack_size - 1; i > 0; i--) {
+    if (current_plan == m_plans[i].get())
+      return m_plans[i - 1].get();
+  }
+  return nullptr;
+}
+
+ThreadPlan *ThreadPlanStack::GetInnermostExpression() const {
+  int stack_size = m_plans.size();
+
+  for (int i = stack_size - 1; i > 0; i--) {
+    if (m_plans[i]->GetKind() == ThreadPlan::eKindCallFunction)
+      return m_plans[i].get();
+  }
+  return nullptr;
+}
+
+void ThreadPlanStack::WillResume() {
+  m_completed_plans.clear();
+  m_discarded_plans.clear();
+}
+
+const ThreadPlanStack::PlanStack &
+ThreadPlanStack::GetStackOfKind(ThreadPlanStack::StackKind kind) const {
+  switch (kind) {
+  case ePlans:
+    return m_plans;
+  case eCompletedPlans:
+    return m_completed_plans;
+  case eDiscardedPlans:
+    return m_discarded_plans;
+  }
+  llvm_unreachable("Invalid StackKind value");
+}

--- a/lldb/source/Target/ThreadPlanStepOut.cpp
+++ b/lldb/source/Target/ThreadPlanStepOut.cpp
@@ -47,13 +47,11 @@ ThreadPlanStepOut::ThreadPlanStepOut(
   SetFlagsToDefault();
   SetupAvoidNoDebug(step_out_avoids_code_without_debug_info);
 
-  m_step_from_insn = m_thread.GetRegisterContext()->GetPC(0);
+  m_step_from_insn = thread.GetRegisterContext()->GetPC(0);
 
   uint32_t return_frame_index = frame_idx + 1;
-  StackFrameSP return_frame_sp(
-      m_thread.GetStackFrameAtIndex(return_frame_index));
-  StackFrameSP immediate_return_from_sp(
-      m_thread.GetStackFrameAtIndex(frame_idx));
+  StackFrameSP return_frame_sp(thread.GetStackFrameAtIndex(return_frame_index));
+  StackFrameSP immediate_return_from_sp(thread.GetStackFrameAtIndex(frame_idx));
 
   if (!return_frame_sp || !immediate_return_from_sp)
     return; // we can't do anything here.  ValidatePlan() will return false.
@@ -63,7 +61,7 @@ ThreadPlanStepOut::ThreadPlanStepOut(
     m_stepped_past_frames.push_back(return_frame_sp);
 
     ++return_frame_index;
-    return_frame_sp = m_thread.GetStackFrameAtIndex(return_frame_index);
+    return_frame_sp = thread.GetStackFrameAtIndex(return_frame_index);
 
     // We never expect to see an artificial frame without a regular ancestor.
     // If this happens, log the issue and defensively refuse to step out.
@@ -85,7 +83,7 @@ ThreadPlanStepOut::ThreadPlanStepOut(
       // First queue a plan that gets us to this inlined frame, and when we get
       // there we'll queue a second plan that walks us out of this frame.
       m_step_out_to_inline_plan_sp = std::make_shared<ThreadPlanStepOut>(
-          m_thread, nullptr, false, stop_others, eVoteNoOpinion, eVoteNoOpinion,
+          thread, nullptr, false, stop_others, eVoteNoOpinion, eVoteNoOpinion,
           frame_idx - 1, eLazyBoolNo, continue_to_next_branch);
       static_cast<ThreadPlanStepOut *>(m_step_out_to_inline_plan_sp.get())
           ->SetShouldStopHereCallbacks(nullptr, nullptr);
@@ -114,22 +112,20 @@ ThreadPlanStepOut::ThreadPlanStepOut(
         range = return_address_sc.line_entry.GetSameLineContiguousAddressRange(
             include_inlined_functions);
         if (range.GetByteSize() > 0) {
-          return_address =
-              m_thread.GetProcess()->AdvanceAddressToNextBranchInstruction(
-                  return_address, range);
+          return_address = m_process.AdvanceAddressToNextBranchInstruction(
+              return_address, range);
         }
       }
     }
-    m_return_addr =
-        return_address.GetLoadAddress(&m_thread.GetProcess()->GetTarget());
+    m_return_addr = return_address.GetLoadAddress(&m_process.GetTarget());
 
     if (m_return_addr == LLDB_INVALID_ADDRESS)
       return;
 
     // Perform some additional validation on the return address.
     uint32_t permissions = 0;
-    if (!m_thread.GetProcess()->GetLoadAddressPermissions(m_return_addr,
-                                                          permissions)) {
+    if (!m_process->GetLoadAddressPermissions(m_return_addr,
+                                              permissions)) {
       m_constructor_errors.Printf("Return address (0x%" PRIx64
                                   ") permissions not found.",
                                   m_return_addr);
@@ -145,14 +141,13 @@ ThreadPlanStepOut::ThreadPlanStepOut(
       return;
     }
 
-    Breakpoint *return_bp = m_thread.CalculateTarget()
-                                ->CreateBreakpoint(m_return_addr, true, false)
-                                .get();
+    Breakpoint *return_bp = 
+        GetTarget().CreateBreakpoint(m_return_addr, true, false).get();
 
     if (return_bp != nullptr) {
       if (return_bp->IsHardware() && !return_bp->HasResolvedLocations())
         m_could_not_resolve_hw_bp = true;
-      return_bp->SetThreadID(m_thread.GetID());
+      return_bp->SetThreadID(m_tid);
       m_return_bp_id = return_bp->GetID();
       return_bp->SetBreakpointKind("step-out");
     }
@@ -178,7 +173,7 @@ void ThreadPlanStepOut::SetupAvoidNoDebug(
     avoid_nodebug = false;
     break;
   case eLazyBoolCalculate:
-    avoid_nodebug = m_thread.GetStepOutAvoidsNoDebug();
+    avoid_nodebug = GetThread().GetStepOutAvoidsNoDebug();
     break;
   }
   if (avoid_nodebug)
@@ -188,15 +183,16 @@ void ThreadPlanStepOut::SetupAvoidNoDebug(
 }
 
 void ThreadPlanStepOut::DidPush() {
+  Thread &thread = GetThread();
   if (m_step_out_to_inline_plan_sp)
-    m_thread.QueueThreadPlan(m_step_out_to_inline_plan_sp, false);
+    thread.QueueThreadPlan(m_step_out_to_inline_plan_sp, false);
   else if (m_step_through_inline_plan_sp)
-    m_thread.QueueThreadPlan(m_step_through_inline_plan_sp, false);
+    thread.QueueThreadPlan(m_step_through_inline_plan_sp, false);
 }
 
 ThreadPlanStepOut::~ThreadPlanStepOut() {
   if (m_return_bp_id != LLDB_INVALID_BREAK_ID)
-    m_thread.CalculateTarget()->RemoveBreakpointByID(m_return_bp_id);
+    GetThread().CalculateTarget()->RemoveBreakpointByID(m_return_bp_id);
 }
 
 void ThreadPlanStepOut::GetDescription(Stream *s,
@@ -296,12 +292,12 @@ bool ThreadPlanStepOut::DoPlanExplainsStop(Event *event_ptr) {
       // If this is OUR breakpoint, we're fine, otherwise we don't know why
       // this happened...
       BreakpointSiteSP site_sp(
-          m_thread.GetProcess()->GetBreakpointSiteList().FindByID(
-              stop_info_sp->GetValue()));
+          m_process.GetBreakpointSiteList().FindByID(stop_info_sp->GetValue()));
       if (site_sp && site_sp->IsBreakpointAtThisSite(m_return_bp_id)) {
         bool done;
 
-        StackID frame_zero_id = m_thread.GetStackFrameAtIndex(0)->GetStackID();
+        StackID frame_zero_id =
+            GetThread().GetStackFrameAtIndex(0)->GetStackID();
 
         if (m_step_out_to_id == frame_zero_id)
           done = true;
@@ -368,7 +364,7 @@ bool ThreadPlanStepOut::ShouldStop(Event *event_ptr) {
   }
 
   if (!done) {
-    StackID frame_zero_id = m_thread.GetStackFrameAtIndex(0)->GetStackID();
+    StackID frame_zero_id = GetThread().GetStackFrameAtIndex(0)->GetStackID();
     done = !(frame_zero_id < m_step_out_to_id);
   }
 
@@ -402,8 +398,7 @@ bool ThreadPlanStepOut::DoWillResume(StateType resume_state,
     return false;
 
   if (current_plan) {
-    Breakpoint *return_bp =
-        m_thread.CalculateTarget()->GetBreakpointByID(m_return_bp_id).get();
+    Breakpoint *return_bp = GetTarget().GetBreakpointByID(m_return_bp_id).get();
     if (return_bp != nullptr)
       return_bp->SetEnabled(true);
   }
@@ -412,8 +407,7 @@ bool ThreadPlanStepOut::DoWillResume(StateType resume_state,
 
 bool ThreadPlanStepOut::WillStop() {
   if (m_return_bp_id != LLDB_INVALID_BREAK_ID) {
-    Breakpoint *return_bp =
-        m_thread.CalculateTarget()->GetBreakpointByID(m_return_bp_id).get();
+    Breakpoint *return_bp = GetTarget().GetBreakpointByID(m_return_bp_id).get();
     if (return_bp != nullptr)
       return_bp->SetEnabled(false);
   }
@@ -434,7 +428,7 @@ bool ThreadPlanStepOut::MischiefManaged() {
     if (log)
       LLDB_LOGF(log, "Completed step out plan.");
     if (m_return_bp_id != LLDB_INVALID_BREAK_ID) {
-      m_thread.CalculateTarget()->RemoveBreakpointByID(m_return_bp_id);
+      GetTarget().RemoveBreakpointByID(m_return_bp_id);
       m_return_bp_id = LLDB_INVALID_BREAK_ID;
     }
 
@@ -449,7 +443,8 @@ bool ThreadPlanStepOut::QueueInlinedStepPlan(bool queue_now) {
   // Now figure out the range of this inlined block, and set up a "step through
   // range" plan for that.  If we've been provided with a context, then use the
   // block in that context.
-  StackFrameSP immediate_return_from_sp(m_thread.GetStackFrameAtIndex(0));
+  Thread &thread = GetThread();
+  StackFrameSP immediate_return_from_sp(thread.GetStackFrameAtIndex(0));
   if (!immediate_return_from_sp)
     return false;
 
@@ -476,7 +471,7 @@ bool ThreadPlanStepOut::QueueInlinedStepPlan(bool queue_now) {
 
         m_step_through_inline_plan_sp =
             std::make_shared<ThreadPlanStepOverRange>(
-                m_thread, inline_range, inlined_sc, run_mode, avoid_no_debug);
+                thread, inline_range, inlined_sc, run_mode, avoid_no_debug);
         ThreadPlanStepOverRange *step_through_inline_plan_ptr =
             static_cast<ThreadPlanStepOverRange *>(
                 m_step_through_inline_plan_sp.get());
@@ -496,7 +491,7 @@ bool ThreadPlanStepOut::QueueInlinedStepPlan(bool queue_now) {
         }
 
         if (queue_now)
-          m_thread.QueueThreadPlan(m_step_through_inline_plan_sp, false);
+          thread.QueueThreadPlan(m_step_through_inline_plan_sp, false);
         return true;
       }
     }
@@ -517,10 +512,10 @@ void ThreadPlanStepOut::CalculateReturnValue() {
         m_immediate_step_from_function->GetCompilerType()
             .GetFunctionReturnType();
     if (return_compiler_type) {
-      lldb::ABISP abi_sp = m_thread.GetProcess()->GetABI();
+      lldb::ABISP abi_sp = m_process.GetABI();
       if (abi_sp)
         m_return_valobj_sp =
-            abi_sp->GetReturnValueObject(m_thread, return_compiler_type);
+            abi_sp->GetReturnValueObject(GetThread(), return_compiler_type);
     }
   }
 }
@@ -529,6 +524,6 @@ bool ThreadPlanStepOut::IsPlanStale() {
   // If we are still lower on the stack than the frame we are returning to,
   // then there's something for us to do.  Otherwise, we're stale.
 
-  StackID frame_zero_id = m_thread.GetStackFrameAtIndex(0)->GetStackID();
+  StackID frame_zero_id = GetThread().GetStackFrameAtIndex(0)->GetStackID();
   return !(frame_zero_id < m_step_out_to_id);
 }

--- a/lldb/source/Target/ThreadPlanStepOut.cpp
+++ b/lldb/source/Target/ThreadPlanStepOut.cpp
@@ -192,7 +192,7 @@ void ThreadPlanStepOut::DidPush() {
 
 ThreadPlanStepOut::~ThreadPlanStepOut() {
   if (m_return_bp_id != LLDB_INVALID_BREAK_ID)
-    GetThread().CalculateTarget()->RemoveBreakpointByID(m_return_bp_id);
+    GetTarget().RemoveBreakpointByID(m_return_bp_id);
 }
 
 void ThreadPlanStepOut::GetDescription(Stream *s,
@@ -208,7 +208,7 @@ void ThreadPlanStepOut::GetDescription(Stream *s,
       s->Printf("Stepping out from ");
       Address tmp_address;
       if (tmp_address.SetLoadAddress(m_step_from_insn, &GetTarget())) {
-        tmp_address.Dump(s, &GetThread(), Address::DumpStyleResolvedDescription,
+        tmp_address.Dump(s, &m_process, Address::DumpStyleResolvedDescription,
                          Address::DumpStyleLoadAddress);
       } else {
         s->Printf("address 0x%" PRIx64 "", (uint64_t)m_step_from_insn);
@@ -220,7 +220,7 @@ void ThreadPlanStepOut::GetDescription(Stream *s,
 
       s->Printf(" returning to frame at ");
       if (tmp_address.SetLoadAddress(m_return_addr, &GetTarget())) {
-        tmp_address.Dump(s, &GetThread(), Address::DumpStyleResolvedDescription,
+        tmp_address.Dump(s, &m_process, Address::DumpStyleResolvedDescription,
                          Address::DumpStyleLoadAddress);
       } else {
         s->Printf("address 0x%" PRIx64 "", (uint64_t)m_return_addr);
@@ -230,6 +230,9 @@ void ThreadPlanStepOut::GetDescription(Stream *s,
         s->Printf(" using breakpoint site %d", m_return_bp_id);
     }
   }
+
+  if (m_stepped_past_frames.empty())
+    return;
 
   s->Printf("\n");
   for (StackFrameSP frame_sp : m_stepped_past_frames) {

--- a/lldb/source/Target/ThreadPlanStepOverBreakpoint.cpp
+++ b/lldb/source/Target/ThreadPlanStepOverBreakpoint.cpp
@@ -30,9 +30,9 @@ ThreadPlanStepOverBreakpoint::ThreadPlanStepOverBreakpoint(Thread &thread)
       m_auto_continue(false), m_reenabled_breakpoint_site(false)
 
 {
-  m_breakpoint_addr = m_thread.GetRegisterContext()->GetPC();
+  m_breakpoint_addr = thread.GetRegisterContext()->GetPC();
   m_breakpoint_site_id =
-      m_thread.GetProcess()->GetBreakpointSiteList().FindIDByAddress(
+      thread.GetProcess()->GetBreakpointSiteList().FindIDByAddress(
           m_breakpoint_addr);
 }
 
@@ -86,7 +86,7 @@ bool ThreadPlanStepOverBreakpoint::DoPlanExplainsStop(Event *event_ptr) {
         // Be careful, however, as we may have "seen a breakpoint under the PC
         // because we stopped without changing the PC, in which case we do want
         // to re-claim this stop so we'll try again.
-        lldb::addr_t pc_addr = m_thread.GetRegisterContext()->GetPC();
+        lldb::addr_t pc_addr = GetThread().GetRegisterContext()->GetPC();
 
         if (pc_addr == m_breakpoint_addr) {
           LLDB_LOGF(log,
@@ -120,10 +120,9 @@ bool ThreadPlanStepOverBreakpoint::DoWillResume(StateType resume_state,
                                                 bool current_plan) {
   if (current_plan) {
     BreakpointSiteSP bp_site_sp(
-        m_thread.GetProcess()->GetBreakpointSiteList().FindByAddress(
-            m_breakpoint_addr));
+        m_process.GetBreakpointSiteList().FindByAddress(m_breakpoint_addr));
     if (bp_site_sp && bp_site_sp->IsEnabled()) {
-      m_thread.GetProcess()->DisableBreakpointSite(bp_site_sp.get());
+      m_process.DisableBreakpointSite(bp_site_sp.get());
       m_reenabled_breakpoint_site = false;
     }
   }
@@ -140,7 +139,7 @@ void ThreadPlanStepOverBreakpoint::WillPop() {
 }
 
 bool ThreadPlanStepOverBreakpoint::MischiefManaged() {
-  lldb::addr_t pc_addr = m_thread.GetRegisterContext()->GetPC();
+  lldb::addr_t pc_addr = GetThread().GetRegisterContext()->GetPC();
 
   if (pc_addr == m_breakpoint_addr) {
     // If we are still at the PC of our breakpoint, then for some reason we
@@ -161,10 +160,9 @@ void ThreadPlanStepOverBreakpoint::ReenableBreakpointSite() {
   if (!m_reenabled_breakpoint_site) {
     m_reenabled_breakpoint_site = true;
     BreakpointSiteSP bp_site_sp(
-        m_thread.GetProcess()->GetBreakpointSiteList().FindByAddress(
-            m_breakpoint_addr));
+        m_process.GetBreakpointSiteList().FindByAddress(m_breakpoint_addr));
     if (bp_site_sp) {
-      m_thread.GetProcess()->EnableBreakpointSite(bp_site_sp.get());
+      m_process.EnableBreakpointSite(bp_site_sp.get());
     }
   }
 }
@@ -181,5 +179,5 @@ bool ThreadPlanStepOverBreakpoint::ShouldAutoContinue(Event *event_ptr) {
 }
 
 bool ThreadPlanStepOverBreakpoint::IsPlanStale() {
-  return m_thread.GetRegisterContext()->GetPC() != m_breakpoint_addr;
+  return GetThread().GetRegisterContext()->GetPC() != m_breakpoint_addr;
 }

--- a/lldb/source/Target/ThreadPlanStepOverRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepOverRange.cpp
@@ -85,7 +85,7 @@ void ThreadPlanStepOverRange::SetupAvoidNoDebug(
     avoid_nodebug = false;
     break;
   case eLazyBoolCalculate:
-    avoid_nodebug = m_thread.GetStepOutAvoidsNoDebug();
+    avoid_nodebug = GetThread().GetStepOutAvoidsNoDebug();
     break;
   }
   if (avoid_nodebug)
@@ -125,12 +125,12 @@ bool ThreadPlanStepOverRange::IsEquivalentContext(
 
 bool ThreadPlanStepOverRange::ShouldStop(Event *event_ptr) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_STEP));
+  Thread &thread = GetThread();
 
   if (log) {
     StreamString s;
-    DumpAddress(
-        s.AsRawOstream(), m_thread.GetRegisterContext()->GetPC(),
-        m_thread.CalculateTarget()->GetArchitecture().GetAddressByteSize());
+    DumpAddress(s.AsRawOstream(), thread.GetRegisterContext()->GetPC(),
+                GetTarget().GetArchitecture().GetAddressByteSize());
     LLDB_LOGF(log, "ThreadPlanStepOverRange reached %s.", s.GetData());
   }
 
@@ -151,8 +151,8 @@ bool ThreadPlanStepOverRange::ShouldStop(Event *event_ptr) {
     // because the trampoline confused the backtracer. As below, we step
     // through first, and then try to figure out how to get back out again.
 
-    new_plan_sp = m_thread.QueueThreadPlanForStepThrough(m_stack_id, false,
-                                                         stop_others, m_status);
+    new_plan_sp = thread.QueueThreadPlanForStepThrough(m_stack_id, false,
+                                                       stop_others, m_status);
 
     if (new_plan_sp && log)
       LLDB_LOGF(log,
@@ -161,7 +161,7 @@ bool ThreadPlanStepOverRange::ShouldStop(Event *event_ptr) {
     // Make sure we really are in a new frame.  Do that by unwinding and seeing
     // if the start function really is our start function...
     for (uint32_t i = 1;; ++i) {
-      StackFrameSP older_frame_sp = m_thread.GetStackFrameAtIndex(i);
+      StackFrameSP older_frame_sp = thread.GetStackFrameAtIndex(i);
       if (!older_frame_sp) {
         // We can't unwind the next frame we should just get out of here &
         // stop...
@@ -171,12 +171,12 @@ bool ThreadPlanStepOverRange::ShouldStop(Event *event_ptr) {
       const SymbolContext &older_context =
           older_frame_sp->GetSymbolContext(eSymbolContextEverything);
       if (IsEquivalentContext(older_context)) {
-        new_plan_sp = m_thread.QueueThreadPlanForStepOutNoShouldStop(
+        new_plan_sp = thread.QueueThreadPlanForStepOutNoShouldStop(
             false, nullptr, true, stop_others, eVoteNo, eVoteNoOpinion, 0,
             m_status, true);
         break;
       } else {
-        new_plan_sp = m_thread.QueueThreadPlanForStepThrough(
+        new_plan_sp = thread.QueueThreadPlanForStepThrough(
             m_stack_id, false, stop_others, m_status);
         // If we found a way through, then we should stop recursing.
         if (new_plan_sp)
@@ -196,8 +196,8 @@ bool ThreadPlanStepOverRange::ShouldStop(Event *event_ptr) {
       // we are in a stub then it's likely going to be hard to get out from
       // here.  It is probably easiest to step into the stub, and then it will
       // be straight-forward to step out.
-      new_plan_sp = m_thread.QueueThreadPlanForStepThrough(
-          m_stack_id, false, stop_others, m_status);
+      new_plan_sp = thread.QueueThreadPlanForStepThrough(m_stack_id, false, 
+                                                         stop_others, m_status);
     } else {
       // The current clang (at least through 424) doesn't always get the
       // address range for the DW_TAG_inlined_subroutines right, so that when
@@ -212,7 +212,7 @@ bool ThreadPlanStepOverRange::ShouldStop(Event *event_ptr) {
 
       if (m_addr_context.line_entry.IsValid()) {
         SymbolContext sc;
-        StackFrameSP frame_sp = m_thread.GetStackFrameAtIndex(0);
+        StackFrameSP frame_sp = thread.GetStackFrameAtIndex(0);
         sc = frame_sp->GetSymbolContext(eSymbolContextEverything);
         if (sc.line_entry.IsValid()) {
           if (sc.line_entry.original_file !=
@@ -278,7 +278,7 @@ bool ThreadPlanStepOverRange::ShouldStop(Event *event_ptr) {
                         m_addr_context.line_entry.original_file) {
                       const bool abort_other_plans = false;
                       const RunMode stop_other_threads = RunMode::eAllThreads;
-                      lldb::addr_t cur_pc = m_thread.GetStackFrameAtIndex(0)
+                      lldb::addr_t cur_pc = thread.GetStackFrameAtIndex(0)
                                                 ->GetRegisterContext()
                                                 ->GetPC();
                       AddressRange step_range(
@@ -286,7 +286,7 @@ bool ThreadPlanStepOverRange::ShouldStop(Event *event_ptr) {
                           next_line_address.GetLoadAddress(&GetTarget()) -
                               cur_pc);
 
-                      new_plan_sp = m_thread.QueueThreadPlanForStepOverRange(
+                      new_plan_sp = thread.QueueThreadPlanForStepOverRange(
                           abort_other_plans, step_range, sc, stop_other_threads,
                           m_status);
                       break;
@@ -365,23 +365,24 @@ bool ThreadPlanStepOverRange::DoWillResume(lldb::StateType resume_state,
   if (resume_state != eStateSuspended && m_first_resume) {
     m_first_resume = false;
     if (resume_state == eStateStepping && current_plan) {
+      Thread &thread = GetThread();
       // See if we are about to step over an inlined call in the middle of the
       // inlined stack, if so figure out its extents and reset our range to
       // step over that.
-      bool in_inlined_stack = m_thread.DecrementCurrentInlinedDepth();
+      bool in_inlined_stack = thread.DecrementCurrentInlinedDepth();
       if (in_inlined_stack) {
         Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_STEP));
         LLDB_LOGF(log,
                   "ThreadPlanStepInRange::DoWillResume: adjusting range to "
                   "the frame at inlined depth %d.",
-                  m_thread.GetCurrentInlinedDepth());
-        StackFrameSP stack_sp = m_thread.GetStackFrameAtIndex(0);
+                  thread.GetCurrentInlinedDepth());
+        StackFrameSP stack_sp = thread.GetStackFrameAtIndex(0);
         if (stack_sp) {
           Block *frame_block = stack_sp->GetFrameBlock();
-          lldb::addr_t curr_pc = m_thread.GetRegisterContext()->GetPC();
+          lldb::addr_t curr_pc = thread.GetRegisterContext()->GetPC();
           AddressRange my_range;
           if (frame_block->GetRangeContainingLoadAddress(
-                  curr_pc, m_thread.GetProcess()->GetTarget(), my_range)) {
+                  curr_pc, m_process.GetTarget(), my_range)) {
             m_address_ranges.clear();
             m_address_ranges.push_back(my_range);
             if (log) {

--- a/lldb/source/Target/ThreadPlanStepRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepRange.cpp
@@ -41,8 +41,8 @@ ThreadPlanStepRange::ThreadPlanStepRange(ThreadPlanKind kind, const char *name,
       m_given_ranges_only(given_ranges_only) {
   m_use_fast_step = GetTarget().GetUseFastStepping();
   AddRange(range);
-  m_stack_id = m_thread.GetStackFrameAtIndex(0)->GetStackID();
-  StackFrameSP parent_stack = m_thread.GetStackFrameAtIndex(1);
+  m_stack_id = thread.GetStackFrameAtIndex(0)->GetStackID();
+  StackFrameSP parent_stack = thread.GetStackFrameAtIndex(1);
   if (parent_stack)
     m_parent_stack_id = parent_stack->GetStackID();
 }
@@ -86,15 +86,14 @@ void ThreadPlanStepRange::AddRange(const AddressRange &new_range) {
 }
 
 void ThreadPlanStepRange::DumpRanges(Stream *s) {
+  Thread &thread = GetThread();
   size_t num_ranges = m_address_ranges.size();
   if (num_ranges == 1) {
-    m_address_ranges[0].Dump(s, m_thread.CalculateTarget().get(),
-                             Address::DumpStyleLoadAddress);
+    m_address_ranges[0].Dump(s, &GetTarget(), Address::DumpStyleLoadAddress);
   } else {
     for (size_t i = 0; i < num_ranges; i++) {
       s->Printf(" %" PRIu64 ": ", uint64_t(i));
-      m_address_ranges[i].Dump(s, m_thread.CalculateTarget().get(),
-                               Address::DumpStyleLoadAddress);
+      m_address_ranges[i].Dump(s, &GetTarget(), Address::DumpStyleLoadAddress);
     }
   }
 }
@@ -102,20 +101,20 @@ void ThreadPlanStepRange::DumpRanges(Stream *s) {
 bool ThreadPlanStepRange::InRange() {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_STEP));
   bool ret_value = false;
-
-  lldb::addr_t pc_load_addr = m_thread.GetRegisterContext()->GetPC();
+  Thread &thread = GetThread();
+  lldb::addr_t pc_load_addr = thread.GetRegisterContext()->GetPC();
 
   size_t num_ranges = m_address_ranges.size();
   for (size_t i = 0; i < num_ranges; i++) {
-    ret_value = m_address_ranges[i].ContainsLoadAddress(
-        pc_load_addr, m_thread.CalculateTarget().get());
+    ret_value = 
+        m_address_ranges[i].ContainsLoadAddress(pc_load_addr, &GetTarget());
     if (ret_value)
       break;
   }
 
   if (!ret_value && !m_given_ranges_only) {
     // See if we've just stepped to another part of the same line number...
-    StackFrame *frame = m_thread.GetStackFrameAtIndex(0).get();
+    StackFrame *frame = thread.GetStackFrameAtIndex(0).get();
 
     SymbolContext new_context(
         frame->GetSymbolContext(eSymbolContextEverything));
@@ -132,8 +131,8 @@ bool ThreadPlanStepRange::InRange() {
           ret_value = true;
           if (log) {
             StreamString s;
-            m_addr_context.line_entry.Dump(&s, m_thread.CalculateTarget().get(),
-                                           true, Address::DumpStyleLoadAddress,
+            m_addr_context.line_entry.Dump(&s, &GetTarget(), true,
+                                           Address::DumpStyleLoadAddress,
                                            Address::DumpStyleLoadAddress, true);
 
             LLDB_LOGF(
@@ -151,8 +150,8 @@ bool ThreadPlanStepRange::InRange() {
           ret_value = true;
           if (log) {
             StreamString s;
-            m_addr_context.line_entry.Dump(&s, m_thread.CalculateTarget().get(),
-                                           true, Address::DumpStyleLoadAddress,
+            m_addr_context.line_entry.Dump(&s, &GetTarget(), true,
+                                           Address::DumpStyleLoadAddress,
                                            Address::DumpStyleLoadAddress, true);
 
             LLDB_LOGF(log,
@@ -161,7 +160,7 @@ bool ThreadPlanStepRange::InRange() {
                       s.GetData());
           }
         } else if (new_context.line_entry.range.GetBaseAddress().GetLoadAddress(
-                       m_thread.CalculateTarget().get()) != pc_load_addr) {
+                       &GetTarget()) != pc_load_addr) {
           // Another thing that sometimes happens here is that we step out of
           // one line into the MIDDLE of another line.  So far I mostly see
           // this due to bugs in the debug information. But we probably don't
@@ -174,8 +173,8 @@ bool ThreadPlanStepRange::InRange() {
           ret_value = true;
           if (log) {
             StreamString s;
-            m_addr_context.line_entry.Dump(&s, m_thread.CalculateTarget().get(),
-                                           true, Address::DumpStyleLoadAddress,
+            m_addr_context.line_entry.Dump(&s, &GetTarget(), true,
+                                           Address::DumpStyleLoadAddress,
                                            Address::DumpStyleLoadAddress, true);
 
             LLDB_LOGF(log,
@@ -195,14 +194,14 @@ bool ThreadPlanStepRange::InRange() {
 }
 
 bool ThreadPlanStepRange::InSymbol() {
-  lldb::addr_t cur_pc = m_thread.GetRegisterContext()->GetPC();
+  lldb::addr_t cur_pc = GetThread().GetRegisterContext()->GetPC();
   if (m_addr_context.function != nullptr) {
     return m_addr_context.function->GetAddressRange().ContainsLoadAddress(
-        cur_pc, m_thread.CalculateTarget().get());
+        cur_pc, &GetTarget());
   } else if (m_addr_context.symbol && m_addr_context.symbol->ValueIsAddress()) {
     AddressRange range(m_addr_context.symbol->GetAddressRef(),
                        m_addr_context.symbol->GetByteSize());
-    return range.ContainsLoadAddress(cur_pc, m_thread.CalculateTarget().get());
+    return range.ContainsLoadAddress(cur_pc, &GetTarget());
   }
   return false;
 }
@@ -216,15 +215,15 @@ bool ThreadPlanStepRange::InSymbol() {
 
 lldb::FrameComparison ThreadPlanStepRange::CompareCurrentFrameToStartFrame() {
   FrameComparison frame_order;
-
-  StackID cur_frame_id = m_thread.GetStackFrameAtIndex(0)->GetStackID();
+  Thread &thread = GetThread();
+  StackID cur_frame_id = thread.GetStackFrameAtIndex(0)->GetStackID();
 
   if (cur_frame_id == m_stack_id) {
     frame_order = eFrameCompareEqual;
   } else if (cur_frame_id < m_stack_id) {
     frame_order = eFrameCompareYounger;
   } else {
-    StackFrameSP cur_parent_frame = m_thread.GetStackFrameAtIndex(1);
+    StackFrameSP cur_parent_frame = thread.GetStackFrameAtIndex(1);
     StackID cur_parent_id;
     if (cur_parent_frame)
       cur_parent_id = cur_parent_frame->GetStackID();
@@ -378,11 +377,10 @@ bool ThreadPlanStepRange::SetNextBranchBreakpoint() {
                     "ThreadPlanStepRange::SetNextBranchBreakpoint - Setting "
                     "breakpoint %d (site %d) to run to address 0x%" PRIx64,
                     m_next_branch_bp_sp->GetID(), bp_site_id,
-                    run_to_address.GetLoadAddress(
-                        &m_thread.GetProcess()->GetTarget()));
+                    run_to_address.GetLoadAddress(&m_process.GetTarget()));
         }
 
-        m_next_branch_bp_sp->SetThreadID(m_thread.GetID());
+        m_next_branch_bp_sp->SetThreadID(m_tid);
         m_next_branch_bp_sp->SetBreakpointKind("next-branch-location");
 
         return true;
@@ -401,7 +399,7 @@ bool ThreadPlanStepRange::NextRangeBreakpointExplainsStop(
 
   break_id_t bp_site_id = stop_info_sp->GetValue();
   BreakpointSiteSP bp_site_sp =
-      m_thread.GetProcess()->GetBreakpointSiteList().FindByID(bp_site_id);
+      m_process.GetBreakpointSiteList().FindByID(bp_site_id);
   if (!bp_site_sp)
     return false;
   else if (!bp_site_sp->IsBreakpointAtThisSite(m_next_branch_bp_sp->GetID()))
@@ -488,11 +486,11 @@ bool ThreadPlanStepRange::IsPlanStale() {
     // check that we are in the same symbol.
     if (!InRange()) {
       // Set plan Complete when we reach next instruction just after the range
-      lldb::addr_t addr = m_thread.GetRegisterContext()->GetPC() - 1;
+      lldb::addr_t addr = GetThread().GetRegisterContext()->GetPC() - 1;
       size_t num_ranges = m_address_ranges.size();
       for (size_t i = 0; i < num_ranges; i++) {
-        bool in_range = m_address_ranges[i].ContainsLoadAddress(
-            addr, m_thread.CalculateTarget().get());
+        bool in_range = 
+            m_address_ranges[i].ContainsLoadAddress(addr, &GetTarget());
         if (in_range) {
           SetPlanComplete();
         }

--- a/lldb/source/Target/ThreadPlanStepUntil.cpp
+++ b/lldb/source/Target/ThreadPlanStepUntil.cpp
@@ -34,17 +34,16 @@ ThreadPlanStepUntil::ThreadPlanStepUntil(Thread &thread,
       m_should_stop(false), m_ran_analyze(false), m_explains_stop(false),
       m_until_points(), m_stop_others(stop_others) {
   // Stash away our "until" addresses:
-  TargetSP target_sp(m_thread.CalculateTarget());
+  TargetSP target_sp(thread.CalculateTarget());
 
-  StackFrameSP frame_sp(m_thread.GetStackFrameAtIndex(frame_idx));
+  StackFrameSP frame_sp(thread.GetStackFrameAtIndex(frame_idx));
   if (frame_sp) {
     m_step_from_insn = frame_sp->GetStackID().GetPC();
-    lldb::user_id_t thread_id = m_thread.GetID();
 
     // Find the return address and set a breakpoint there:
     // FIXME - can we do this more securely if we know first_insn?
 
-    StackFrameSP return_frame_sp(m_thread.GetStackFrameAtIndex(frame_idx + 1));
+    StackFrameSP return_frame_sp(thread.GetStackFrameAtIndex(frame_idx + 1));
     if (return_frame_sp) {
       // TODO: add inline functionality
       m_return_addr = return_frame_sp->GetStackID().GetPC();
@@ -54,7 +53,7 @@ ThreadPlanStepUntil::ThreadPlanStepUntil(Thread &thread,
       if (return_bp != nullptr) {
         if (return_bp->IsHardware() && !return_bp->HasResolvedLocations())
           m_could_not_resolve_hw_bp = true;
-        return_bp->SetThreadID(thread_id);
+        return_bp->SetThreadID(m_tid);
         m_return_bp_id = return_bp->GetID();
         return_bp->SetBreakpointKind("until-return-backstop");
       }
@@ -67,7 +66,7 @@ ThreadPlanStepUntil::ThreadPlanStepUntil(Thread &thread,
       Breakpoint *until_bp =
           target_sp->CreateBreakpoint(address_list[i], true, false).get();
       if (until_bp != nullptr) {
-        until_bp->SetThreadID(thread_id);
+        until_bp->SetThreadID(m_tid);
         m_until_points[address_list[i]] = until_bp->GetID();
         until_bp->SetBreakpointKind("until-target");
       } else {
@@ -80,17 +79,15 @@ ThreadPlanStepUntil::ThreadPlanStepUntil(Thread &thread,
 ThreadPlanStepUntil::~ThreadPlanStepUntil() { Clear(); }
 
 void ThreadPlanStepUntil::Clear() {
-  TargetSP target_sp(m_thread.CalculateTarget());
-  if (target_sp) {
-    if (m_return_bp_id != LLDB_INVALID_BREAK_ID) {
-      target_sp->RemoveBreakpointByID(m_return_bp_id);
-      m_return_bp_id = LLDB_INVALID_BREAK_ID;
-    }
+  Target &target = GetTarget();
+  if (m_return_bp_id != LLDB_INVALID_BREAK_ID) {
+    target.RemoveBreakpointByID(m_return_bp_id);
+    m_return_bp_id = LLDB_INVALID_BREAK_ID;
+  }
 
-    until_collection::iterator pos, end = m_until_points.end();
-    for (pos = m_until_points.begin(); pos != end; pos++) {
-      target_sp->RemoveBreakpointByID((*pos).second);
-    }
+  until_collection::iterator pos, end = m_until_points.end();
+  for (pos = m_until_points.begin(); pos != end; pos++) {
+    target.RemoveBreakpointByID((*pos).second);
   }
   m_until_points.clear();
   m_could_not_resolve_hw_bp = false;
@@ -158,8 +155,7 @@ void ThreadPlanStepUntil::AnalyzeStop() {
       // If this is OUR breakpoint, we're fine, otherwise we don't know why
       // this happened...
       BreakpointSiteSP this_site =
-          m_thread.GetProcess()->GetBreakpointSiteList().FindByID(
-              stop_info_sp->GetValue());
+          m_process.GetBreakpointSiteList().FindByID(stop_info_sp->GetValue());
       if (!this_site) {
         m_explains_stop = false;
         return;
@@ -196,17 +192,17 @@ void ThreadPlanStepUntil::AnalyzeStop() {
         for (pos = m_until_points.begin(); pos != end; pos++) {
           if (this_site->IsBreakpointAtThisSite((*pos).second)) {
             // If we're at the right stack depth, then we're done.
-
+            Thread &thread = GetThread();
             bool done;
             StackID frame_zero_id =
-                m_thread.GetStackFrameAtIndex(0)->GetStackID();
+                thread.GetStackFrameAtIndex(0)->GetStackID();
 
             if (frame_zero_id == m_stack_id)
               done = true;
             else if (frame_zero_id < m_stack_id)
               done = false;
             else {
-              StackFrameSP older_frame_sp = m_thread.GetStackFrameAtIndex(1);
+              StackFrameSP older_frame_sp = thread.GetStackFrameAtIndex(1);
 
               // But if we can't even unwind one frame we should just get out
               // of here & stop...
@@ -280,20 +276,16 @@ StateType ThreadPlanStepUntil::GetPlanRunState() { return eStateRunning; }
 bool ThreadPlanStepUntil::DoWillResume(StateType resume_state,
                                        bool current_plan) {
   if (current_plan) {
-    TargetSP target_sp(m_thread.CalculateTarget());
-    if (target_sp) {
-      Breakpoint *return_bp =
-          target_sp->GetBreakpointByID(m_return_bp_id).get();
-      if (return_bp != nullptr)
-        return_bp->SetEnabled(true);
+    Target &target = GetTarget();
+    Breakpoint *return_bp = target.GetBreakpointByID(m_return_bp_id).get();
+    if (return_bp != nullptr)
+      return_bp->SetEnabled(true);
 
-      until_collection::iterator pos, end = m_until_points.end();
-      for (pos = m_until_points.begin(); pos != end; pos++) {
-        Breakpoint *until_bp =
-            target_sp->GetBreakpointByID((*pos).second).get();
-        if (until_bp != nullptr)
-          until_bp->SetEnabled(true);
-      }
+    until_collection::iterator pos, end = m_until_points.end();
+    for (pos = m_until_points.begin(); pos != end; pos++) {
+      Breakpoint *until_bp = target.GetBreakpointByID((*pos).second).get();
+      if (until_bp != nullptr)
+        until_bp->SetEnabled(true);
     }
   }
 
@@ -304,18 +296,16 @@ bool ThreadPlanStepUntil::DoWillResume(StateType resume_state,
 }
 
 bool ThreadPlanStepUntil::WillStop() {
-  TargetSP target_sp(m_thread.CalculateTarget());
-  if (target_sp) {
-    Breakpoint *return_bp = target_sp->GetBreakpointByID(m_return_bp_id).get();
-    if (return_bp != nullptr)
-      return_bp->SetEnabled(false);
+  Target &target = GetTarget();
+  Breakpoint *return_bp = target.GetBreakpointByID(m_return_bp_id).get();
+  if (return_bp != nullptr)
+    return_bp->SetEnabled(false);
 
-    until_collection::iterator pos, end = m_until_points.end();
-    for (pos = m_until_points.begin(); pos != end; pos++) {
-      Breakpoint *until_bp = target_sp->GetBreakpointByID((*pos).second).get();
-      if (until_bp != nullptr)
-        until_bp->SetEnabled(false);
-    }
+  until_collection::iterator pos, end = m_until_points.end();
+  for (pos = m_until_points.begin(); pos != end; pos++) {
+    Breakpoint *until_bp = target.GetBreakpointByID((*pos).second).get();
+    if (until_bp != nullptr)
+      until_bp->SetEnabled(false);
   }
   return true;
 }

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/Makefile
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/Makefile
@@ -1,0 +1,4 @@
+CXX_SOURCES := main.cpp
+ENABLE_THREADS := YES
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/TestOSPluginStepping.py
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/TestOSPluginStepping.py
@@ -1,0 +1,113 @@
+"""
+Test that stepping works even when the OS Plugin doesn't report
+all threads at every stop.
+"""
+
+from __future__ import print_function
+
+
+import os
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestOSPluginStepping(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_python_os_plugin(self):
+        """Test that stepping works when the OS Plugin doesn't report all
+           threads at every stop"""
+        self.build()
+        self.main_file = lldb.SBFileSpec('main.cpp')
+        self.run_python_os_step_missing_thread(False)
+
+    def test_python_os_plugin_prune(self):
+        """Test that pruning the unreported PlanStacks works"""
+        self.build()
+        self.main_file = lldb.SBFileSpec('main.cpp')
+        self.run_python_os_step_missing_thread(True)
+
+    def get_os_thread(self):
+        return self.process.GetThreadByID(0x111111111)
+
+    def is_os_thread(self, thread):
+        id = thread.GetID()
+        return id == 0x111111111
+    
+    def run_python_os_step_missing_thread(self, do_prune):
+        """Test that the Python operating system plugin works correctly"""
+
+        # Our OS plugin does NOT report all threads:
+        result = self.dbg.HandleCommand("settings set target.experimental.os-plugin-reports-all-threads false")
+
+        python_os_plugin_path = os.path.join(self.getSourceDir(),
+                                             "operating_system.py")
+        (target, self.process, thread, thread_bkpt) = lldbutil.run_to_source_breakpoint(
+            self, "first stop in thread - do a step out", self.main_file)
+
+        main_bkpt = target.BreakpointCreateBySourceRegex('Stop here and do not make a memory thread for thread_1',
+                                                         self.main_file)
+        self.assertEqual(main_bkpt.GetNumLocations(), 1, "Main breakpoint has one location")
+
+        # There should not be an os thread before we load the plugin:
+        self.assertFalse(self.get_os_thread().IsValid(), "No OS thread before loading plugin")
+        
+        # Now load the python OS plug-in which should update the thread list and we should have
+        # an OS plug-in thread overlaying thread_1 with id 0x111111111
+        command = "settings set target.process.python-os-plugin-path '%s'" % python_os_plugin_path
+        self.dbg.HandleCommand(command)
+
+        # Verify our OS plug-in threads showed up
+        os_thread = self.get_os_thread()
+        self.assertTrue(
+            os_thread.IsValid(),
+            "Make sure we added the thread 0x111111111 after we load the python OS plug-in")
+        
+        # Now we are going to step-out.  This should get interrupted by main_bkpt.  We've
+        # set up the OS plugin so at this stop, we have lost the OS thread 0x111111111.
+        # Make sure both of these are true:
+        os_thread.StepOut()
+        
+        stopped_threads = lldbutil.get_threads_stopped_at_breakpoint(self.process, main_bkpt)
+        self.assertEqual(len(stopped_threads), 1, "Stopped at main_bkpt")
+        thread = self.process.GetThreadByID(0x111111111)
+        self.assertFalse(thread.IsValid(), "No thread 0x111111111 on second stop.")
+        
+        # Make sure we still have the thread plans for this thread:
+        # First, don't show unreported threads, that should fail:
+        command = "thread plan list -t 0x111111111"
+        result = lldb.SBCommandReturnObject()
+        interp = self.dbg.GetCommandInterpreter() 
+        interp.HandleCommand(command, result)
+        self.assertFalse(result.Succeeded(), "We found no plans for the unreported thread.")
+        # Now do it again but with the -u flag:
+        command	= "thread plan list -u -t 0x111111111"
+        result = lldb.SBCommandReturnObject()
+        interp.HandleCommand(command, result)
+        self.assertTrue(result.Succeeded(), "We found plans for the unreported thread.")
+        
+        if do_prune:
+            # Prune the thread plan and continue, and we will run to exit.
+            interp.HandleCommand("thread plan prune 0x111111111", result)
+            self.assertTrue(result.Succeeded(), "Found the plan for 0x111111111 and pruned it")
+
+            # List again, make sure it doesn't work:
+            command	= "thread plan list -u -t 0x111111111"
+            interp.HandleCommand(command, result)
+            self.assertFalse(result.Succeeded(), "We still found plans for the unreported thread.")
+            
+            self.process.Continue()
+            self.assertEqual(self.process.GetState(), lldb.eStateExited, "We exited.")
+        else:
+            # Now we are going to continue, and when we hit the step-out breakpoint, we will
+            # put the OS plugin thread back, lldb will recover its ThreadPlanStack, and
+            # we will stop with a "step-out" reason.
+            self.process.Continue()
+            os_thread = self.get_os_thread()
+            self.assertTrue(os_thread.IsValid(), "The OS thread is back after continue")
+            self.assertTrue("step out" in os_thread.GetStopDescription(100), "Completed step out plan")
+        
+        

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/main.cpp
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/main.cpp
@@ -1,0 +1,55 @@
+// This test will present lldb with two threads one of which the test will
+// overlay with an OSPlugin thread.  Then we'll do a step out on the thread_1,
+// but arrange to hit a breakpoint in main before the step out completes. At
+// that point we will not report an OS plugin thread for thread_1. Then we'll
+// run again and hit the step out breakpoint.  Make sure we haven't deleted
+// that, and recognize it.
+
+#include <condition_variable>
+#include <mutex>
+#include <stdio.h>
+#include <thread>
+
+static int g_value = 0; // I don't have access to the real threads in the
+                        // OS Plugin, and I don't want to have to count
+                        // StopID's. So I'm using this value to tell me which
+                        // stop point the program has reached.
+std::mutex g_mutex;
+std::condition_variable g_cv;
+static int g_condition = 0; // Using this as the variable backing g_cv
+                            // to prevent spurious wakeups.
+
+void step_out_of_here() {
+  std::unique_lock<std::mutex> func_lock(g_mutex);
+  // Set a breakpoint:first stop in thread - do a step out.
+  g_condition = 1;
+  g_cv.notify_one();
+  g_cv.wait(func_lock, [&] { return g_condition == 2; });
+}
+
+void *thread_func() {
+  // Do something
+  step_out_of_here();
+
+  // Return
+  return NULL;
+}
+
+int main() {
+  // Lock the mutex so we can block the thread:
+  std::unique_lock<std::mutex> main_lock(g_mutex);
+  // Create the thread
+  std::thread thread_1(thread_func);
+  g_cv.wait(main_lock, [&] { return g_condition == 1; });
+  g_value = 1;
+  g_condition = 2;
+  // Stop here and do not make a memory thread for thread_1.
+  g_cv.notify_one();
+  g_value = 2;
+  main_lock.unlock();
+
+  // Wait for the threads to finish
+  thread_1.join();
+
+  return 0;
+}

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/operating_system.py
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/operating_system.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+
+import lldb
+import struct
+
+
+class OperatingSystemPlugIn(object):
+    """Class that provides a OS plugin that along with the particular code in main.cpp
+       emulates the following scenario:
+             a) We stop in an OS Plugin created thread - which should be thread index 1
+             b) We step-out from that thread
+             c) We hit a breakpoint in another thread, and DON'T produce the OS Plugin thread.
+             d) We continue, and when we hit the step out breakpoint, we again produce the same
+                OS Plugin thread.
+             main.cpp sets values into the global variable g_value, which we use to tell the OS
+             plugin whether to produce the OS plugin thread or not.
+             Since we are always producing an OS plugin thread with a backing thread, we don't
+             need to implement get_register_info or get_register_data.
+    """
+
+    def __init__(self, process):
+        '''Initialization needs a valid.SBProcess object.
+
+        This plug-in will get created after a live process is valid and has stopped for the
+        first time.'''
+        print("Plugin initialized.")
+        self.process = None
+        self.start_stop_id = 0
+        self.g_value = lldb.SBValue()
+        
+        if isinstance(process, lldb.SBProcess) and process.IsValid():
+            self.process = process
+            self.g_value = process.GetTarget().FindFirstGlobalVariable("g_value")
+            if not self.g_value.IsValid():
+                print("Could not find g_value")
+            
+    def create_thread(self, tid, context):
+        print("Called create thread with tid: ", tid)
+        return None
+
+    def get_thread_info(self):
+        g_value = self.g_value.GetValueAsUnsigned()
+        print("Called get_thread_info: g_value: %d"%(g_value))
+        if g_value == 0 or g_value == 2:
+            return [{'tid': 0x111111111,
+                             'name': 'one',
+                             'queue': 'queue1',
+                             'state': 'stopped',
+                             'stop_reason': 'breakpoint',
+                             'core' : 1 }]
+        else:
+            return []
+
+    def get_register_info(self):
+        print ("called get_register_info")
+        return None
+
+    
+    def get_register_data(self, tid):
+        print("Get register data called for tid: %d"%(tid))
+        return None
+

--- a/lldb/test/API/functionalities/thread_plan/Makefile
+++ b/lldb/test/API/functionalities/thread_plan/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/thread_plan/TestThreadPlanCommands.py
+++ b/lldb/test/API/functionalities/thread_plan/TestThreadPlanCommands.py
@@ -1,0 +1,164 @@
+"""
+Test that thread plan listing, and deleting works.
+"""
+
+
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+
+
+class TestThreadPlanCommands(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_thread_plan_actions(self):
+        self.build()
+        self.main_source_file = lldb.SBFileSpec("main.c")
+        self.thread_plan_test()
+
+    def check_list_output(self, command, active_plans = [], completed_plans = [], discarded_plans = []):
+        # Check the "thread plan list" output against a list of active & completed and discarded plans.
+        # If all three check arrays are empty, that means the command is expected to fail. 
+
+        interp = self.dbg.GetCommandInterpreter()
+        result = lldb.SBCommandReturnObject()
+
+        num_active = len(active_plans)
+        num_completed = len(completed_plans)
+        num_discarded = len(discarded_plans)
+
+        interp.HandleCommand(command, result)
+        if self.TraceOn():
+            print("Command: %s"%(command))
+            print(result.GetOutput())
+
+        if num_active == 0 and num_completed == 0 and num_discarded == 0:
+            self.assertFalse(result.Succeeded(), "command: '%s' succeeded when it should have failed: '%s'"%
+                             (command, result.GetError()))
+            return
+
+        self.assertTrue(result.Succeeded(), "command: '%s' failed: '%s'"%(command, result.GetError()))
+        result_arr = result.GetOutput().splitlines()
+        num_results = len(result_arr)
+
+        # Match the expected number of elements.
+        # Adjust the count for the number of header lines we aren't matching:
+        fudge = 0
+        
+        if num_completed == 0 and num_discarded == 0:
+            # The fudge is 3: Thread header, Active Plan header and base plan
+            fudge = 3
+        elif num_completed == 0 or num_discarded == 0:
+            # The fudge is 4: The above plus either the Completed or Discarded Plan header:
+            fudge = 4
+        else:
+            # The fudge is 5 since we have both headers:
+            fudge = 5
+
+        self.assertEqual(num_results, num_active + num_completed + num_discarded + fudge,
+                             "Too many elements in match arrays")
+            
+        # Now iterate through the results array and pick out the results.
+        result_idx = 0
+        self.assertIn("thread #", result_arr[result_idx], "Found thread header") ; result_idx += 1
+        self.assertIn("Active plan stack", result_arr[result_idx], "Found active header") ; result_idx += 1
+        self.assertIn("Element 0: Base thread plan", result_arr[result_idx], "Found base plan") ; result_idx += 1
+
+        for text in active_plans:
+            self.assertFalse("Completed plan stack" in result_arr[result_idx], "Found Completed header too early.")
+            self.assertIn(text, result_arr[result_idx], "Didn't find active plan: %s"%(text)) ; result_idx += 1
+
+        if len(completed_plans) > 0:
+            self.assertIn("Completed plan stack:", result_arr[result_idx], "Found completed plan stack header") ; result_idx += 1
+            for text in completed_plans:
+                self.assertIn(text, result_arr[result_idx], "Didn't find completed plan: %s"%(text)) ; result_idx += 1
+
+        if len(discarded_plans) > 0:
+            self.assertIn("Discarded plan stack:", result_arr[result_idx], "Found discarded plan stack header") ; result_idx += 1
+            for text in discarded_plans:
+                self.assertIn(text, result_arr[result_idx], "Didn't find completed plan: %s"%(text)) ; result_idx += 1
+
+
+    def thread_plan_test(self):
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(self,
+                                   "Set a breakpoint here", self.main_source_file)
+
+        # Now set a breakpoint in call_me and step over.  We should have
+        # two public thread plans
+        call_me_bkpt = target.BreakpointCreateBySourceRegex("Set another here", self.main_source_file)
+        self.assertTrue(call_me_bkpt.GetNumLocations() > 0, "Set the breakpoint successfully")
+        thread.StepOver()
+        threads = lldbutil.get_threads_stopped_at_breakpoint(process, call_me_bkpt)
+        self.assertEqual(len(threads), 1, "Hit my breakpoint while stepping over")
+
+        current_id = threads[0].GetIndexID()
+        current_tid = threads[0].GetThreadID()
+        # Run thread plan list without the -i flag:
+        command = "thread plan list %d"%(current_id)
+        self.check_list_output (command, ["Stepping over line main.c"], [])
+
+        # Run thread plan list with the -i flag:
+        command = "thread plan list -i %d"%(current_id)
+        self.check_list_output(command, ["Stepping over line main.c", "Stepping out from"])
+
+        # Run thread plan list providing TID, output should be the same:
+        command = "thread plan list -t %d"%(current_tid)
+        self.check_list_output(command, ["Stepping over line main.c"])
+
+        # Provide both index & tid, and make sure we only print once:
+        command = "thread plan list -t %d %d"%(current_tid, current_id)
+        self.check_list_output(command, ["Stepping over line main.c"])
+
+        # Try a fake TID, and make sure that fails:
+        fake_tid = 0
+        for i in range(100, 10000, 100):
+            fake_tid = current_tid + i
+            thread = process.GetThreadByID(fake_tid)
+            if not thread:
+                break
+        
+        command = "thread plan list -t %d"%(fake_tid)
+        self.check_list_output(command)
+
+        # Now continue, and make sure we printed the completed plan:
+        process.Continue()
+        threads = lldbutil.get_stopped_threads(process, lldb.eStopReasonPlanComplete)
+        self.assertEqual(len(threads), 1, "One thread completed a step")
+        
+        # Run thread plan list - there aren't any private plans at this point:
+        command = "thread plan list %d"%(current_id)
+        self.check_list_output(command, [], ["Stepping over line main.c"])
+
+        # Set another breakpoint that we can run to, to try deleting thread plans.
+        second_step_bkpt = target.BreakpointCreateBySourceRegex("Run here to step over again",
+                                                                self.main_source_file)
+        self.assertTrue(second_step_bkpt.GetNumLocations() > 0, "Set the breakpoint successfully")
+        final_bkpt = target.BreakpointCreateBySourceRegex("Make sure we get here on last continue",
+                                                          self.main_source_file)
+        self.assertTrue(final_bkpt.GetNumLocations() > 0, "Set the breakpoint successfully")
+
+        threads = lldbutil.continue_to_breakpoint(process, second_step_bkpt)
+        self.assertEqual(len(threads), 1, "Hit the second step breakpoint")
+
+        threads[0].StepOver()
+        threads = lldbutil.get_threads_stopped_at_breakpoint(process, call_me_bkpt)
+
+        result = lldb.SBCommandReturnObject()
+        interp = self.dbg.GetCommandInterpreter()
+        interp.HandleCommand("thread plan discard 1", result)
+        self.assertTrue(result.Succeeded(), "Deleted the step over plan: %s"%(result.GetOutput()))
+
+        # Make sure the plan gets listed in the discarded plans:
+        command = "thread plan list %d"%(current_id)
+        self.check_list_output(command, [], [], ["Stepping over line main.c:"])
+
+        process.Continue()
+        threads = lldbutil.get_threads_stopped_at_breakpoint(process, final_bkpt)
+        self.assertEqual(len(threads), 1, "Ran to final breakpoint")
+        threads = lldbutil.get_stopped_threads(process, lldb.eStopReasonPlanComplete)
+        self.assertEqual(len(threads), 0, "Did NOT complete the step over plan")
+

--- a/lldb/test/API/functionalities/thread_plan/main.c
+++ b/lldb/test/API/functionalities/thread_plan/main.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+void
+call_me(int value) {
+  printf("called with %d\n", value); // Set another here.
+}
+
+int
+main(int argc, char **argv)
+{
+  call_me(argc); // Set a breakpoint here.
+  printf("This just spaces the two calls\n");
+  call_me(argc); // Run here to step over again.
+  printf("More spacing\n");
+  return 0; // Make sure we get here on last continue
+}


### PR DESCRIPTION
This change allows lldb to support OS Plugins that don't report all their threads on every stop.  The xnu OS plugin is the most prominent such plugin.