### PR TITLE
[lldb/Test] Convert stdout to str by calling decode('utf-8') on it.

### DIFF
--- a/lldb/test/API/functionalities/reproducers/attach/TestReproducerAttach.py
+++ b/lldb/test/API/functionalities/reproducers/attach/TestReproducerAttach.py
@@ -53,7 +53,8 @@ class ReproducerAttachTestCase(TestBase):
                                    stdin=subprocess.PIPE,
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)
-        outs, errs = capture.communicate()
+        outs, _ = capture.communicate()
+        outs = outs.decode('utf-8')
         self.assertIn('Process {} stopped'.format(pid), outs)
         self.assertIn('Reproducer written', outs)
 
@@ -63,7 +64,8 @@ class ReproducerAttachTestCase(TestBase):
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
-        outs, errs = replay.communicate()
+        outs, _ = replay.communicate()
+        outs = outs.decode('utf-8')
         self.assertIn('Process {} stopped'.format(pid), outs)
 
         # We can dump the reproducer in the current context.


### PR DESCRIPTION
Make sure both arguments to assertIn are of type str. This should fix
the following error:

TypeError: a bytes-like object is required, not 'str'.
(cherry picked from commit 17bdb7a17912bb4d961cf292c035b08c9d0c13ba)