### PR TITLE
[lldb] Fix that a crashing test is marked as unsupported when it prin…

### DIFF
--- a/lldb/test/API/lldbtest.py
+++ b/lldb/test/API/lldbtest.py
@@ -114,13 +114,11 @@ class LLDBTest(TestFormat):
             return lit.Test.TIMEOUT, output
 
         if exitCode:
-            # Match FAIL but not XFAIL.
-            for line in out.splitlines() + err.splitlines():
-                if line.startswith('FAIL:'):
-                    return lit.Test.FAIL, output
-
             if 'XPASS:' in out or 'XPASS:' in err:
                 return lit.Test.XPASS, output
+
+            # Otherwise this is just a failure.
+            return lit.Test.FAIL, output
 
         has_unsupported_tests = 'UNSUPPORTED:' in out or 'UNSUPPORTED:' in err
         has_passing_tests = 'PASS:' in out or 'PASS:' in err


### PR DESCRIPTION
…ts UNSUPPORTED before crashing

Summary:
I added an `abort()` call to some code and noticed that the test suite was still passing and it just marked my test as "UNSUPPORTED".

It seems the reason for that is that we expect failing tests to print "FAIL:" which doesn't happen when we crash. If we then also
have an unsupported because we skipped some debug information in the output, we just mark the test passing because it is unsupported
on the current platform.

This patch marks any test that has a non-zero exit code as failing even if it doesn't print "FAIL:" (e.g., because it crashed).

Reviewers: labath, JDevlieghere

Reviewed By: labath, JDevlieghere

Subscribers: aprantl, lldb-commits

Tags: #lldb

Differential Revision: https://reviews.llvm.org/D75031