### PR TITLE
[Driver] Only pass LTO remark arguments if the driver asks for it

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -541,7 +541,8 @@ void darwin::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   // we follow suite for ease of comparison.
   AddLinkArgs(C, Args, CmdArgs, Inputs);
 
-  if (checkRemarksOptions(getToolChain().getDriver(), Args,
+  if (willEmitRemarks(Args) &&
+      checkRemarksOptions(getToolChain().getDriver(), Args,
                           getToolChain().getTriple()))
     renderRemarksOptions(Args, CmdArgs, getToolChain().getTriple(), Output, JA);
 

--- a/clang/test/Driver/darwin-opt-record-ld.c
+++ b/clang/test/Driver/darwin-opt-record-ld.c
@@ -2,6 +2,10 @@
 
 // RUN: touch %t.o
 //
+// Check that we're not passing -lto-pass-remarks-output if not requested
+// RUN: %clang -target x86_64-apple-darwin12 %t.o -### -o foo/bar.out 2> %t.log
+// RUN: FileCheck -check-prefix=NO_PASS_REMARKS_OUTPUT %s < %t.log
+// NO_PASS_REMARKS_OUTPUT-NOT: -lto-pass-remarks
 // Check that we're passing -lto-pass-remarks-output for LTO
 // RUN: %clang -target x86_64-apple-darwin12 %t.o -fsave-optimization-record -### -o foo/bar.out 2> %t.log
 // RUN: FileCheck -check-prefix=PASS_REMARKS_OUTPUT %s < %t.log


### PR DESCRIPTION
Previous fix missed a check to willEmitRemarks, causing remarks to
always be enabled for LTO.

(cherry picked from commit 9e6670b03ceaa5980eccb06e2dd037e6a9584c66)

rdar://61402840