### PR TITLE
Don't access reference to a vector after pop_back

### DIFF
--- a/lldb/source/Target/ThreadPlanStack.cpp
+++ b/lldb/source/Target/ThreadPlanStack.cpp
@@ -159,7 +159,7 @@ void ThreadPlanStack::PushPlan(lldb::ThreadPlanSP new_plan_sp) {
 lldb::ThreadPlanSP ThreadPlanStack::PopPlan() {
   assert(m_plans.size() > 1 && "Can't pop the base thread plan");
 
-  lldb::ThreadPlanSP &plan_sp = m_plans.back();
+  lldb::ThreadPlanSP plan_sp = std::move(m_plans.back());
   m_completed_plans.push_back(plan_sp);
   plan_sp->WillPop();
   m_plans.pop_back();
@@ -169,7 +169,7 @@ lldb::ThreadPlanSP ThreadPlanStack::PopPlan() {
 lldb::ThreadPlanSP ThreadPlanStack::DiscardPlan() {
   assert(m_plans.size() > 1 && "Can't discard the base thread plan");
 
-  lldb::ThreadPlanSP &plan_sp = m_plans.back();
+  lldb::ThreadPlanSP plan_sp = std::move(m_plans.back());
   m_discarded_plans.push_back(plan_sp);
   plan_sp->WillPop();
   m_plans.pop_back();


### PR DESCRIPTION
This is undefined behavior. Found by asan's detect_container_overflow.

(cherry picked from commit 873b79b8675d0c8eca6055ae8a874fe52b033c28)