### PR TITLE
Don't fail step out if remote server doesn't implement qMemoryRegionInfo

### DIFF
--- a/lldb/source/Target/ThreadPlanStepOut.cpp
+++ b/lldb/source/Target/ThreadPlanStepOut.cpp
@@ -126,12 +126,9 @@ ThreadPlanStepOut::ThreadPlanStepOut(
     uint32_t permissions = 0;
     if (!m_process->GetLoadAddressPermissions(m_return_addr,
                                               permissions)) {
-      m_constructor_errors.Printf("Return address (0x%" PRIx64
-                                  ") permissions not found.",
-                                  m_return_addr);
-      LLDB_LOGF(log, "ThreadPlanStepOut(%p): %s", static_cast<void *>(this),
-                m_constructor_errors.GetData());
-      return;
+      LLDB_LOGF(log, "ThreadPlanStepOut(%p): Return address (0x%" PRIx64
+              ") permissions not found.", static_cast<void *>(this),
+              m_return_addr);
     } else if (!(permissions & ePermissionsExecutable)) {
       m_constructor_errors.Printf("Return address (0x%" PRIx64
                                   ") did not point to executable memory.",


### PR DESCRIPTION
Don't fail step out if remote server doesn't implement qMemoryRegionInfo

Summary:
The return address validation in D71372 will fail if the memory permissions can't be determined. Many embedded stubs either don't implement the qMemoryRegionInfo packet, or don't have memory permissions at all.

Remove the return from the if clause that calls GetLoadAddressPermissions, so this call failing doesn't cause the step out to abort. Instead, assume that the memory permission check doesn't apply to this type of target.

Reviewers: labath, jingham, clayborg, mossberg

Reviewed By: labath, jingham

Subscribers: lldb-commits

Tags: #lldb

Differential Revision: https://reviews.llvm.org/D72513

(cherry picked from commit 6fd818c5a9c565b8aaeaf1ca85ad14735ee0eb0c)