### PR TITLE
Remove the old SecTaskAccess entry from debugserver's plist

### DIFF
--- a/lldb/tools/debugserver/resources/lldb-debugserver-Info.plist
+++ b/lldb/tools/debugserver/resources/lldb-debugserver-Info.plist
@@ -12,10 +12,5 @@
     <string>debugserver</string>
     <key>CFBundleVersion</key>
     <string>2</string>
-	<key>SecTaskAccess</key>
-	<array>
-		<string>allowed</string>
-		<string>debug</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Remove the old SecTaskAccess entry from debugserver's plist
<rdar://problem/60230324>

(cherry picked from commit 8aa07f81b85b7af4b0678a813dd4f5a98293b955)