### PR TITLE
LLDB updates to support conditionally compiled and multi-pattern catches

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -320,7 +320,7 @@ void SwiftASTManipulatorBase::DoInitialization() {
     if (do_stmt) {
       // There should only be one catch:
       assert(m_do_stmt->getCatches().size() == 1);
-      swift::CatchStmt *our_catch = m_do_stmt->getCatches().front();
+      swift::CaseStmt *our_catch = m_do_stmt->getCatches().front();
       if (our_catch)
         m_catch_stmt = our_catch;
     }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -22,7 +22,7 @@
 #include "llvm/ADT/SmallVector.h"
 
 namespace swift {
-class CatchStmt;
+class CaseStmt;
 class DoCatchStmt;
 class ExtensionDecl;
 class FuncDecl;
@@ -132,7 +132,7 @@ protected:
   swift::DoCatchStmt *m_do_stmt = nullptr;
   /// The body of the catch - we patch the assignment there to capture
   /// any error thrown.
-  swift::CatchStmt *m_catch_stmt = nullptr;
+  swift::CaseStmt *m_catch_stmt = nullptr;
 };
 
 class SwiftASTManipulator : public SwiftASTManipulatorBase {


### PR DESCRIPTION
Swift recently introduced a change to replace CatchStmt with CaseStmt  which is part of the recent implementation of multi-pattern catch clauses: https://github.com/apple/swift/commit/43e2d107e1e5bf9e1ea325d884c0ff79f3e514aa#diff-14a9a5c95cf0b5b9826e01783a637d14

llvm-project:swift/master already updated lldb accordingly with https://github.com/apple/llvm-project/commit/cfc3051a519f73e6c675f2d12aea00e4252e9059

This PR is a cherry pick from apple/llvm-project:swift/master  into apple/llvm-project:swift/master-next.  I've not had a successful lldb build all week.  So there are likely other things to fix up before we can test this patch out.  This was just one hurdle in an effort to bring  master-next back to a building state.