### PR TITLE
[lldb][swift] Make sure we have a StackFrame in GetDynamicTypeAndAddress

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1518,11 +1518,11 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress(
                                                 class_type_or_name, address);
   else {
     // Perform archetype binding in the scratch context.
-    auto *frame = in_value.GetExecutionContextRef().GetFrameSP().get();
+    StackFrameSP frame = in_value.GetExecutionContextRef().GetFrameSP();
     if (!frame)
       return false;
 
-    CompilerType bound_type = DoArchetypeBindingForType(*frame, val_type);
+    CompilerType bound_type = DoArchetypeBindingForType(*frame.get(), val_type);
     if (!bound_type)
       return false;
 


### PR DESCRIPTION
…dress

We got a report of getting a bad weak ptr abort from the stack frame here.

This just makes sure that we have a valid shared_ptr when we call
DoArchetypeBindingForType as this might later call get_shared_from_this()
(via SwiftLanguageRuntime::GetConcreteType -> StackFrame::CalculateStackFrame).

(Potentially) Fixes rdar://problem/61384698