### PR TITLE
Remove const qualifier from Modules returned by ExternalASTSource. (NFC)

### DIFF
--- a/clang/include/clang/AST/ExternalASTSource.h
+++ b/clang/include/clang/AST/ExternalASTSource.h
@@ -173,7 +173,7 @@ public:
     StringRef Path;
     StringRef ASTFile;
     ASTFileSignature Signature;
-    const Module *ClangModule = nullptr;
+    Module *ClangModule = nullptr;
 
   public:
     ASTSourceDescriptor() = default;
@@ -181,13 +181,13 @@ public:
                         ASTFileSignature Signature)
         : PCHModuleName(std::move(Name)), Path(std::move(Path)),
           ASTFile(std::move(ASTFile)), Signature(Signature) {}
-    ASTSourceDescriptor(const Module &M);
+    ASTSourceDescriptor(Module &M);
 
     std::string getModuleName() const;
     StringRef getPath() const { return Path; }
     StringRef getASTFile() const { return ASTFile; }
     ASTFileSignature getSignature() const { return Signature; }
-    const Module *getModuleOrNull() const { return ClangModule; }
+    Module *getModuleOrNull() const { return ClangModule; }
   };
 
   /// Return a descriptor for the corresponding module, if one exists.

--- a/clang/lib/AST/ExternalASTSource.cpp
+++ b/clang/lib/AST/ExternalASTSource.cpp
@@ -38,7 +38,7 @@ ExternalASTSource::hasExternalDefinitions(const Decl *D) {
   return EK_ReplyHazy;
 }
 
-ExternalASTSource::ASTSourceDescriptor::ASTSourceDescriptor(const Module &M)
+ExternalASTSource::ASTSourceDescriptor::ASTSourceDescriptor(Module &M)
   : Signature(M.Signature), ClangModule(&M) {
   if (M.Directory)
     Path = M.Directory->getName();

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -8488,7 +8488,7 @@ unsigned ASTReader::getModuleFileID(ModuleFile *F) {
 
 llvm::Optional<ExternalASTSource::ASTSourceDescriptor>
 ASTReader::getSourceDescriptor(unsigned ID) {
-  if (const Module *M = getSubmodule(ID))
+  if (Module *M = getSubmodule(ID))
     return ExternalASTSource::ASTSourceDescriptor(*M);
 
   // If there is only a single PCH, return it instead.


### PR DESCRIPTION
This API is used by LLDB to attach owning module information to
Declarations deserialized from DWARF.

Differential Revision: https://reviews.llvm.org/D75561

(cherry picked from commit f4754ea0ed7ddc35042bacbc47d661bfe660f132)

 Conflicts:
	clang/include/clang/Basic/Module.h
	clang/lib/Basic/Module.cpp
	clang/lib/Serialization/ASTReader.cpp