### PR TITLE
test: Explicit string conversion for Python3 compatibility

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1163,7 +1163,7 @@ def applySubstitutions(script, substitutions):
             # short-lived, since the set of substitutions is fairly small, and
             # since thrashing has such bad consequences, not bounding the cache
             # seems reasonable.
-            ln = _caching_re_compile(a).sub(b, ln)
+            ln = _caching_re_compile(a).sub(str(b), ln)
 
         # Strip the trailing newline and any extra whitespace.
         return ln.strip()


### PR DESCRIPTION
Python3 requires `b` to be a string and not a "bytes like object". This patch explicitly makes it a string.