### PR TITLE
[lldb] Update for removal of SourceFile::addImports

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1283,6 +1283,13 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
   if (swift_ast_context->HasErrors())
     return make_error<SwiftASTContextError>();
 
+  // Resolve the file's imports, including the implicit ones returned from
+  // GetImplicitImports.
+  swift::performImportResolution(*source_file);
+
+  if (swift_ast_context->HasErrors())
+    return make_error<SwiftASTContextError>();
+
   std::unique_ptr<SwiftASTManipulator> code_manipulator;
   if (repl || !playground) {
     code_manipulator =
@@ -1330,11 +1337,6 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
 
     stack_frame_sp.reset();
   }
-
-  swift::performImportResolution(*source_file);
-
-  if (swift_ast_context->HasErrors())
-    return make_error<SwiftASTContextError>();
 
   // Cache the source file's imports such that they're accessible to future
   // expression evaluations.

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -3611,8 +3611,9 @@ SwiftASTContext::GetCachedModule(const SourceModule &module) {
   return nullptr;
 }
 
-swift::ModuleDecl *SwiftASTContext::CreateModule(const SourceModule &module,
-                                                 Status &error) {
+swift::ModuleDecl *
+SwiftASTContext::CreateModule(const SourceModule &module, Status &error,
+                              swift::ImplicitImportInfo importInfo) {
   VALID_OR_RETURN(nullptr);
   if (!module.path.size()) {
     error.SetErrorStringWithFormat("invalid module name (empty)");
@@ -3633,7 +3634,7 @@ swift::ModuleDecl *SwiftASTContext::CreateModule(const SourceModule &module,
 
   swift::Identifier module_id(
       ast->getIdentifier(module.path.front().GetCString()));
-  auto *module_decl = swift::ModuleDecl::create(module_id, *ast);
+  auto *module_decl = swift::ModuleDecl::create(module_id, *ast, importInfo);
   if (!module_decl) {
     error.SetErrorStringWithFormat("failed to create module for \"%s\"",
                                    module.path.front().GetCString());
@@ -8353,14 +8354,12 @@ static void GetNameFromModule(swift::ModuleDecl *module, std::string &result) {
   }
 }
 
-static bool
-LoadOneModule(const SourceModule &module, SwiftASTContext &swift_ast_context,
-              lldb::StackFrameWP &stack_frame_wp,
-              llvm::SmallVectorImpl<swift::SourceFile::ImportedModuleDesc>
-                  &additional_imports,
-              Status &error) {
+static swift::ModuleDecl *LoadOneModule(const SourceModule &module,
+                                        SwiftASTContext &swift_ast_context,
+                                        lldb::StackFrameWP &stack_frame_wp,
+                                        Status &error) {
   if (!module.path.size())
-    return false;
+    return nullptr;
 
   error.Clear();
   ConstString toplevel = module.path.front();
@@ -8399,7 +8398,7 @@ LoadOneModule(const SourceModule &module, SwiftASTContext &swift_ast_context,
                toplevel.AsCString(), error.AsCString());
 
     if (!swift_module || swift_ast_context.HasFatalErrors()) {
-      return false;
+      return nullptr;
     }
   }
 
@@ -8410,23 +8409,42 @@ LoadOneModule(const SourceModule &module, SwiftASTContext &swift_ast_context,
     LOG_PRINTF(LIBLLDB_LOG_EXPRESSIONS, "Imported module %s from {%s}",
                module.path.front().AsCString(), ss.GetData());
   }
+  return swift_module;
+}
 
-  additional_imports.push_back(swift::SourceFile::ImportedModuleDesc(
-      std::make_pair(swift::ModuleDecl::AccessPathTy(), swift_module),
-      swift::SourceFile::ImportOptions()));
+bool SwiftASTContext::GetImplicitImports(
+    SwiftASTContext &swift_ast_context, SymbolContext &sc,
+    ExecutionContextScope &exe_scope, lldb::StackFrameWP &stack_frame_wp,
+    llvm::SmallVectorImpl<swift::ModuleDecl *> &modules, Status &error) {
+  if (!GetCompileUnitImports(swift_ast_context, sc, stack_frame_wp, modules,
+                             error)) {
+    return false;
+  }
+
+  auto *persistent_expression_state =
+      sc.target_sp->GetSwiftPersistentExpressionState(exe_scope);
+
+  // Get the hand-loaded modules from the SwiftPersistentExpressionState.
+  for (ConstString name : persistent_expression_state->GetHandLoadedModules()) {
+    SourceModule module_info;
+    module_info.path.push_back(name);
+    auto *module = LoadOneModule(module_info, swift_ast_context, stack_frame_wp,
+                                 error);
+    if (!module)
+      return false;
+
+    modules.push_back(module);
+  }
   return true;
 }
 
-bool SwiftASTContext::PerformUserImport(SwiftASTContext &swift_ast_context,
-                                        SymbolContext &sc,
-                                        ExecutionContextScope &exe_scope,
-                                        lldb::StackFrameWP &stack_frame_wp,
-                                        swift::SourceFile &source_file,
-                                        Status &error) {
+bool SwiftASTContext::CacheUserImports(SwiftASTContext &swift_ast_context,
+                                       SymbolContext &sc,
+                                       ExecutionContextScope &exe_scope,
+                                       lldb::StackFrameWP &stack_frame_wp,
+                                       swift::SourceFile &source_file,
+                                       Status &error) {
   llvm::SmallString<1> m_description;
-  llvm::SmallVector<swift::SourceFile::ImportedModuleDesc, 2>
-      additional_imports;
-
   llvm::SmallVector<swift::ModuleDecl::ImportedModule, 2> parsed_imports;
 
   swift::ModuleDecl::ImportFilter import_filter;
@@ -8450,7 +8468,7 @@ bool SwiftASTContext::PerformUserImport(SwiftASTContext &swift_ast_context,
                    "Performing auto import on found module: %s.\n",
                    module_name.c_str());
         if (!LoadOneModule(module_info, swift_ast_context, stack_frame_wp,
-                           additional_imports, error))
+                           error))
           return false;
 
         // How do we tell we are in REPL or playground mode?
@@ -8458,54 +8476,43 @@ bool SwiftASTContext::PerformUserImport(SwiftASTContext &swift_ast_context,
       }
     }
   }
-  // Finally get the hand-loaded modules from the
-  // SwiftPersistentExpressionState and load them into this context:
-  for (ConstString name : persistent_expression_state->GetHandLoadedModules()) {
-    SourceModule module_info;
-    module_info.path.push_back(name);
-    if (!LoadOneModule(module_info, swift_ast_context, stack_frame_wp,
-                       additional_imports, error))
-      return false;
-  }
-
-  source_file.addImports(additional_imports);
   return true;
 }
 
-bool SwiftASTContext::PerformAutoImport(SwiftASTContext &swift_ast_context,
-                                        SymbolContext &sc,
-                                        lldb::StackFrameWP &stack_frame_wp,
-                                        swift::SourceFile *source_file,
-                                        Status &error) {
-  llvm::SmallVector<swift::SourceFile::ImportedModuleDesc, 2>
-      additional_imports;
-
-  // Import the Swift standard library and its dependecies.
+bool SwiftASTContext::GetCompileUnitImports(
+    SwiftASTContext &swift_ast_context, SymbolContext &sc,
+    lldb::StackFrameWP &stack_frame_wp,
+    llvm::SmallVectorImpl<swift::ModuleDecl *> &modules, Status &error) {
+  // Import the Swift standard library and its dependencies.
   SourceModule swift_module;
   swift_module.path.push_back(ConstString("Swift"));
-  if (!LoadOneModule(swift_module, swift_ast_context, stack_frame_wp,
-                     additional_imports, error))
+  auto *stdlib =
+      LoadOneModule(swift_module, swift_ast_context, stack_frame_wp, error);
+  if (!stdlib)
     return false;
 
-  CompileUnit *compile_unit = sc.comp_unit;
-  if (compile_unit && compile_unit->GetLanguage() == lldb::eLanguageTypeSwift)
-    for (const SourceModule &module : compile_unit->GetImportedModules()) {
-      // When building the Swift stdlib with debug info these will
-      // show up in "Swift.o", but we already imported them and
-      // manually importing them will fail.
-      if (module.path.size() &&
-          llvm::StringSwitch<bool>(module.path.front().GetStringRef())
-              .Cases("Swift", "SwiftShims", "Builtin", true)
-              .Default(false))
-        continue;
+  modules.push_back(stdlib);
 
-      if (!LoadOneModule(module, swift_ast_context, stack_frame_wp,
-                         additional_imports, error))
-        return false;
-    }
-  // source_file might be NULL outside of the expression parser, where
-  // we don't need to notify the source file of additional imports.
-  if (source_file)
-    source_file->addImports(additional_imports);
+  CompileUnit *compile_unit = sc.comp_unit;
+  if (!compile_unit || compile_unit->GetLanguage() != lldb::eLanguageTypeSwift)
+    return true;
+
+  for (const SourceModule &module : compile_unit->GetImportedModules()) {
+    // When building the Swift stdlib with debug info these will
+    // show up in "Swift.o", but we already imported them and
+    // manually importing them will fail.
+    if (module.path.size() &&
+        llvm::StringSwitch<bool>(module.path.front().GetStringRef())
+            .Cases("Swift", "SwiftShims", "Builtin", true)
+            .Default(false))
+      continue;
+
+    auto *loaded_module =
+        LoadOneModule(module, swift_ast_context, stack_frame_wp, error);
+    if (!loaded_module)
+      return false;
+
+    modules.push_back(loaded_module);
+  }
   return true;
 }

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -1198,7 +1198,8 @@ void SwiftLanguageRuntime::RegisterGlobalError(Target &target, ConstString name,
 
     Status module_creation_error;
     swift::ModuleDecl *module_decl =
-        ast_context->CreateModule(module_info, module_creation_error);
+        ast_context->CreateModule(module_info, module_creation_error,
+                                  /*importInfo*/ {});
 
     if (module_creation_error.Success() && module_decl) {
       const bool is_static = false;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2499,7 +2499,9 @@ SwiftASTContextReader Target::GetScratchSwiftASTContext(
       !swift_ast_ctx->HasFatalErrors()) {
     StackFrameWP frame_wp(frame_sp);
     SymbolContext sc = frame_sp->GetSymbolContext(lldb::eSymbolContextEverything);
-    swift_ast_ctx->PerformAutoImport(*swift_ast_ctx, sc, frame_wp, nullptr, error);
+    llvm::SmallVector<swift::ModuleDecl *, 16> modules;
+    swift_ast_ctx->GetCompileUnitImports(*swift_ast_ctx, sc, frame_wp, modules,
+                                         error);
   }
 
   return SwiftASTContextReader(GetSwiftScratchContextLock(), swift_ast_ctx);


### PR DESCRIPTION
https://github.com/apple/swift/pull/31016 removes this API. Additional modules to be implicitly imported now need to be provided upfront when constructing the `ModuleDecl`.

To enable this change, split `PerformUserImport` into `GetImplicitImports`, which retrieves the necessary modules to import, and `CacheUserImports`, which deals with caching the imports from the parsed source file such that they're available to future expression evaluations.

Note I'm not planning on merging this until after the 5.3 re-branch.