### PR TITLE
[lldb/Test] Decode stdout and stderr in case it contains Unicode.

### DIFF
--- a/lldb/test/API/lldbtest.py
+++ b/lldb/test/API/lldbtest.py
@@ -99,6 +99,11 @@ class LLDBTest(TestFormat):
             timeoutInfo = 'Reached timeout of {} seconds'.format(
                 litConfig.maxIndividualTestTime)
 
+        if sys.version_info.major == 2:
+            # In Python 2, string objects can contain Unicode characters.
+            out = out.decode('utf-8')
+            err = err.decode('utf-8')
+
         output = """Script:\n--\n%s\n--\nExit Code: %d\n""" % (
             ' '.join(cmd), exitCode)
         if timeoutInfo is not None:


### PR DESCRIPTION
Lit's to_string will just return the string when it's a `str` instance,
which in Python 2 can still contain UTF-8 characters.

Differential revision: https://reviews.llvm.org/D76955

(cherry picked from commit 2de52422acf04662b45599f77c14ce1b2cec2b81)