### PR TITLE
Update automerger config

### DIFF
--- a/apple-llvm-config/am/am-config.json
+++ b/apple-llvm-config/am/am-config.json
@@ -14,8 +14,13 @@
   "test_commits_in_bundle": true
 },
 {
-  "target": "swift/master",
+  "target": "swift/release/5.3",
   "upstream": "apple/stable/20200108",
+  "test_commits_in_bundle": true
+},
+{
+  "target": "swift/master",
+  "upstream": "swift/release/5.3",
   "test_commits_in_bundle": true
 }
 ]


### PR DESCRIPTION
We have a new branch "swift/release/5.3".

The edges are now:
 - apple/stable/20200108 -> swift/release/5.3
 - swift/release/5.3 -> swift/master