### PR TITLE
[swift][master-next] Pipe description level arg through SwiftASTContext

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -101,7 +101,7 @@ public:
                     : Flags(m_payload).Clear(FixedValueBufferBit);
   }
 };
-  
+
 /// Abstract base class for all Swift TypeSystems.
 ///
 /// Swift CompilerTypes are either a mangled name or a Swift AST
@@ -152,11 +152,14 @@ public:
   };
   virtual CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) = 0;
-  virtual void DumpTypeDescription(void *type, bool print_help_if_available,
-                                   bool print_extensions_if_available) = 0;
-  virtual void DumpTypeDescription(void *type, Stream *s,
-                                   bool print_help_if_available,
-                                   bool print_extensions_if_available) = 0;
+  virtual void DumpTypeDescription(
+      void *type, bool print_help_if_available,
+      bool print_extensions_if_available,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) = 0;
+  virtual void DumpTypeDescription(
+      void *type, Stream *s, bool print_help_if_available,
+      bool print_extensions_if_available,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) = 0;
 
   /// Unavailable hardcoded functions that don't make sense for Swift.
   /// \{
@@ -375,8 +378,12 @@ public:
                      ExecutionContextScope *exe_scope,
                      bool is_base_class) override;
 
-  void DumpTypeDescription(void *type) override;
-  void DumpTypeDescription(void *type, Stream *s) override;
+  void DumpTypeDescription(
+      void *type,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
+  void DumpTypeDescription(
+      void *type, Stream *s,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
   void DumpSummary(void *type, ExecutionContext *exe_ctx, Stream *s,
                    const DataExtractor &data, lldb::offset_t data_offset,
                    size_t data_byte_size) override;
@@ -413,10 +420,14 @@ public:
   TypeAllocationStrategy GetAllocationStrategy(CompilerType type) override;
   CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) override;
-  void DumpTypeDescription(void *type, bool print_help_if_available,
-                           bool print_extensions_if_available) override;
-  void DumpTypeDescription(void *type, Stream *s, bool print_help_if_available,
-                           bool print_extensions_if_available) override;
+  void DumpTypeDescription(
+      void *type, bool print_help_if_available,
+      bool print_extensions_if_available,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
+  void DumpTypeDescription(
+      void *type, Stream *s, bool print_help_if_available,
+      bool print_extensions_if_available,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
 
 private:
   /// Helper that creates an AST type from \p type.
@@ -1008,15 +1019,23 @@ public:
                      ExecutionContextScope *exe_scope,
                      bool is_base_class) override;
 
-  void DumpTypeDescription(void *type) override; // Dump to stdout
+  void
+  DumpTypeDescription(void *type,
+                      lldb::DescriptionLevel level) override; // Dump to stdout
 
-  void DumpTypeDescription(void *type, Stream *s) override;
+  void DumpTypeDescription(
+      void *type, Stream *s,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
 
-  void DumpTypeDescription(void *type, bool print_help_if_available,
-                           bool print_extensions_if_available) override;
+  void DumpTypeDescription(
+      void *type, bool print_help_if_available,
+      bool print_extensions_if_available,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
 
-  void DumpTypeDescription(void *type, Stream *s, bool print_help_if_available,
-                           bool print_extensions_if_available) override;
+  void DumpTypeDescription(
+      void *type, Stream *s, bool print_help_if_available,
+      bool print_extensions_if_available,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
 
   // TODO: These methods appear unused. Should they be removed?
 

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -8082,21 +8082,25 @@ void SwiftASTContext::DumpSummary(void *type, ExecutionContext *exe_ctx,
                                   lldb::offset_t data_byte_offset,
                                   size_t data_byte_size) {}
 
-void SwiftASTContext::DumpTypeDescription(void *type) {
+void SwiftASTContext::DumpTypeDescription(void *type,
+                                          lldb::DescriptionLevel level) {
   StreamFile s(stdout, false);
-  DumpTypeDescription(type, &s);
+  DumpTypeDescription(type, &s, level);
 }
 
-void SwiftASTContext::DumpTypeDescription(void *type, Stream *s) {
-  DumpTypeDescription(type, s, false, true);
+void SwiftASTContext::DumpTypeDescription(void *type, Stream *s,
+                                          lldb::DescriptionLevel level) {
+  DumpTypeDescription(type, s, false, true, level);
 }
 
 void SwiftASTContext::DumpTypeDescription(void *type,
+                                          lldb::DescriptionLevel level,
                                           bool print_help_if_available,
-                                          bool print_extensions_if_available) {
+                                          bool print_extensions_if_available,
+                                          lldb::DescriptionLevel level) {
   StreamFile s(stdout, false);
   DumpTypeDescription(type, &s, print_help_if_available,
-                      print_extensions_if_available);
+                      print_extensions_if_available, level);
 }
 
 static void PrintSwiftNominalType(swift::NominalTypeDecl *nominal_type_decl,
@@ -8127,9 +8131,10 @@ static void PrintSwiftNominalType(swift::NominalTypeDecl *nominal_type_decl,
   }
 }
 
-void SwiftASTContext::DumpTypeDescription(void *type, Stream *s,
+void SwiftASTContext::DumpTypeDescription(void *type, Stream *s, lldb::DescriptionLevel level,
                                           bool print_help_if_available,
-                                          bool print_extensions_if_available) {
+                                          bool print_extensions_if_available,
+                                          lldb::DescriptionLevel level) {
   llvm::SmallVector<char, 1024> buf;
   llvm::raw_svector_ostream llvm_ostrm(buf);
 
@@ -8153,9 +8158,9 @@ void SwiftASTContext::DumpTypeDescription(void *type, Stream *s,
                 type_decl->getDeclaredInterfaceType().getPointer()));
             if (clang_type) {
               Flags clang_type_flags(clang_type.GetTypeInfo());
-              DumpTypeDescription(clang_type.GetOpaqueQualType(), s,
+              DumpTypeDescription(clang_type.GetOpaqueQualType(), s, level,
                                   print_help_if_available,
-                                  print_extensions_if_available);
+                                  print_extensions_if_available, level);
             }
           }
         } else if (kind == swift::DeclKind::Func ||
@@ -8189,7 +8194,7 @@ void SwiftASTContext::DumpTypeDescription(void *type, Stream *s,
                           imported_value_decl->getInterfaceType()
                               .getPointer()) {
                     DumpTypeDescription(decl_type, s, print_help_if_available,
-                                        print_extensions_if_available);
+                                        print_extensions_if_available, level);
                   }
                 }
               }
@@ -8204,9 +8209,9 @@ void SwiftASTContext::DumpTypeDescription(void *type, Stream *s,
       s->PutCString("metatype ");
       swift::MetatypeType *metatype_type =
           swift_can_type->castTo<swift::MetatypeType>();
-      DumpTypeDescription(metatype_type->getInstanceType().getPointer(),
+      DumpTypeDescription(metatype_type->getInstanceType().getPointer(), level,
                           print_help_if_available,
-                          print_extensions_if_available);
+                          print_extensions_if_available, level);
     } break;
     case swift::TypeKind::UnboundGeneric: {
       swift::UnboundGenericType *unbound_generic_type =

--- a/lldb/source/Symbol/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Symbol/TypeSystemSwiftTypeRef.cpp
@@ -772,16 +772,17 @@ CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
 }
 void TypeSystemSwiftTypeRef::DumpTypeDescription(
     void *type, bool print_help_if_available,
-    bool print_extensions_if_available) {
+    bool print_extensions_if_available, lldb::DescriptionLevel level) {
   return m_swift_ast_context->DumpTypeDescription(
-      ReconstructType(type), print_help_if_available, print_help_if_available);
+      ReconstructType(type), print_help_if_available, print_help_if_available,
+      level);
 }
 void TypeSystemSwiftTypeRef::DumpTypeDescription(
     void *type, Stream *s, bool print_help_if_available,
-    bool print_extensions_if_available) {
+    bool print_extensions_if_available, lldb::DescriptionLevel level) {
   return m_swift_ast_context->DumpTypeDescription(
       ReconstructType(type), s, print_help_if_available,
-      print_extensions_if_available);
+      print_extensions_if_available, level);
 }
 
 // Dumping types
@@ -815,11 +816,14 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
       bitfield_bit_size, bitfield_bit_offset, exe_scope, is_base_class);
 }
 
-void TypeSystemSwiftTypeRef::DumpTypeDescription(void *type) {
-  return m_swift_ast_context->DumpTypeDescription(ReconstructType(type));
+void TypeSystemSwiftTypeRef::DumpTypeDescription(void *type,
+                                                 lldb::DescriptionLevel level) {
+  return m_swift_ast_context->DumpTypeDescription(ReconstructType(type), level);
 }
-void TypeSystemSwiftTypeRef::DumpTypeDescription(void *type, Stream *s) {
-  return m_swift_ast_context->DumpTypeDescription(ReconstructType(type), s);
+void TypeSystemSwiftTypeRef::DumpTypeDescription(void *type, Stream *s,
+                                                 lldb::DescriptionLevel level) {
+  return m_swift_ast_context->DumpTypeDescription(ReconstructType(type), s,
+                                                  level);
 }
 void TypeSystemSwiftTypeRef::DumpSummary(void *type, ExecutionContext *exe_ctx,
                                          Stream *s, const DataExtractor &data,


### PR DESCRIPTION
https://github.com/apple/llvm-project/commit/681466f5e6412350a0b066791450e72325c2c074
was recently merged into the branch. Because function signatures
changed, the Swift-based classes no longer properly override the defined
virtual functions.

Address this by piping the description level arg throughout the classes.
It functionally does nothing, as this change is intended to fix a build
break.