### PR TITLE
[5.3] Revert "[lldb] Update for removal of SourceFile::addImports"

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -39,7 +39,6 @@ enum class IRGenDebugInfoLevel : unsigned;
 class CanType;
 class DependencyTracker;
 class DWARFImporterDelegate;
-struct ImplicitImportInfo;
 class IRGenOptions;
 class NominalTypeDecl;
 class SearchPathOptions;
@@ -596,13 +595,7 @@ public:
   /// \return the ExtraArgs of the ClangImporterOptions.
   const std::vector<std::string> &GetClangArguments();
 
-  /// Attempt to create a Swift module, returning \c nullptr and setting
-  /// \p error if unsuccessful.
-  ///
-  /// \param importInfo Information about which modules should be implicitly
-  /// imported by each file of the module.
-  swift::ModuleDecl *CreateModule(const SourceModule &module, Status &error,
-                                  swift::ImplicitImportInfo importInfo);
+  swift::ModuleDecl *CreateModule(const SourceModule &module, Status &error);
 
   // This function should only be called when all search paths
   // for all items in a swift::ASTContext have been setup to
@@ -1071,30 +1064,16 @@ public:
 
   void SetCachedType(ConstString mangled, const lldb::TypeSP &type_sp) override;
 
-  /// Retrieves the modules that need to be implicitly imported in a given
-  /// execution scope. This includes the modules imported by both the compile
-  /// unit as well as any imports from previous expression evaluations.
-  static bool
-  GetImplicitImports(SwiftASTContext &swift_ast_context, SymbolContext &sc,
-                     ExecutionContextScope &exe_scope,
-                     lldb::StackFrameWP &stack_frame_wp,
-                     llvm::SmallVectorImpl<swift::ModuleDecl *> &modules,
-                     Status &error);
+  static bool PerformUserImport(SwiftASTContext &swift_ast_context,
+                                SymbolContext &sc,
+                                ExecutionContextScope &exe_scope,
+                                lldb::StackFrameWP &stack_frame_wp,
+                                swift::SourceFile &source_file, Status &error);
 
-  /// Cache the user's imports from a SourceFile in a given execution scope such
-  /// that they are carried over into future expression evaluations.
-  static bool CacheUserImports(SwiftASTContext &swift_ast_context,
-                               SymbolContext &sc,
-                               ExecutionContextScope &exe_scope,
-                               lldb::StackFrameWP &stack_frame_wp,
-                               swift::SourceFile &source_file, Status &error);
-
-  /// Retrieve the modules imported by the compilation unit.
-  static bool
-  GetCompileUnitImports(SwiftASTContext &swift_ast_context, SymbolContext &sc,
-                        lldb::StackFrameWP &stack_frame_wp,
-                        llvm::SmallVectorImpl<swift::ModuleDecl *> &modules,
-                        Status &error);
+  static bool PerformAutoImport(SwiftASTContext &swift_ast_context,
+                                SymbolContext &sc,
+                                lldb::StackFrameWP &stack_frame_wp,
+                                swift::SourceFile *source_file, Status &error);
 
 protected:
   /// This map uses the string value of ConstStrings as the key, and the

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1197,28 +1197,13 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
   snprintf(expr_name_buf, sizeof(expr_name_buf), "__lldb_expr_%u",
            options.GetExpressionNumber());
 
-  // Gather the modules that need to be implicitly imported.
-  // The Swift stdlib needs to be imported before the SwiftLanguageRuntime can
-  // be used.
-  Status implicit_import_error;
-  llvm::SmallVector<swift::ModuleDecl *, 16> additional_imports;
-  if (!SwiftASTContext::GetImplicitImports(*swift_ast_context, sc, exe_scope,
-                                           stack_frame_wp, additional_imports,
-                                           implicit_import_error)) {
-    return make_error<ModuleImportError>(llvm::Twine("in implicit-import:\n") +
-                                         implicit_import_error.AsCString());
-  }
-
-  swift::ImplicitImportInfo importInfo;
-  importInfo.StdlibKind = swift::ImplicitStdlibKind::Stdlib;
-  for (auto *module : additional_imports)
-    importInfo.AdditionalModules.emplace_back(module, /*exported*/ false);
-
   auto module_id = ast_context->getIdentifier(expr_name_buf);
-  auto &module = *swift::ModuleDecl::create(module_id, *ast_context,
-                                            importInfo);
+  auto &module = *swift::ModuleDecl::create(module_id, *ast_context);
+  const auto implicit_import_kind =
+      swift::SourceFile::ImplicitModuleImportKind::Stdlib;
 
   swift::SourceFileKind source_file_kind = swift::SourceFileKind::Library;
+
   if (playground || repl) {
     source_file_kind = swift::SourceFileKind::Main;
   }
@@ -1226,10 +1211,20 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
   // Create the source file. Note, we disable delayed parsing for the
   // swift expression parser.
   swift::SourceFile *source_file = new (*ast_context) swift::SourceFile(
-      module, source_file_kind, buffer_id, /*Keep tokens*/ false,
-      /*KeepSyntaxTree*/ false,
+      module, source_file_kind, buffer_id, implicit_import_kind,
+      /*Keep tokens*/ false, /*KeepSyntaxTree*/ false,
       swift::SourceFile::ParsingFlags::DisableDelayedBodies);
   module.addFile(*source_file);
+
+
+  // The Swift stdlib needs to be imported before the
+  // SwiftLanguageRuntime can be used.
+  Status auto_import_error;
+  if (!SwiftASTContext::PerformAutoImport(*swift_ast_context, sc,
+                                          stack_frame_wp, source_file,
+                                          auto_import_error))
+    return make_error<ModuleImportError>(llvm::Twine("in auto-import:\n") +
+                                         auto_import_error.AsCString());
 
   // Swift Modules that rely on shared libraries (not frameworks)
   // don't record the link information in the swiftmodule file, so we
@@ -1284,13 +1279,6 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
   if (swift_ast_context->HasErrors())
     return make_error<SwiftASTContextError>();
 
-  // Resolve the file's imports, including the implicit ones returned from
-  // GetImplicitImports.
-  swift::performImportResolution(*source_file);
-
-  if (swift_ast_context->HasErrors())
-    return make_error<SwiftASTContextError>();
-
   std::unique_ptr<SwiftASTManipulator> code_manipulator;
   if (repl || !playground) {
     code_manipulator =
@@ -1339,16 +1327,21 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
     stack_frame_sp.reset();
   }
 
-  // Cache the source file's imports such that they're accessible to future
-  // expression evaluations.
+  swift::performImportResolution(*source_file);
+
+  if (swift_ast_context->HasErrors())
+    return make_error<SwiftASTContextError>();
+
+  // Do the auto-importing after Name Binding, that's when the Imports
+  // for the source file are figured out.
   {
     std::lock_guard<std::recursive_mutex> global_context_locker(
         IRExecutionUnit::GetLLVMGlobalContextMutex());
 
     Status auto_import_error;
-    if (!SwiftASTContext::CacheUserImports(*swift_ast_context, sc, exe_scope,
-                                           stack_frame_wp, *source_file,
-                                           auto_import_error)) {
+    if (!SwiftASTContext::PerformUserImport(*swift_ast_context, sc, exe_scope,
+                                            stack_frame_wp, *source_file,
+                                            auto_import_error)) {
       return make_error<ModuleImportError>(llvm::Twine("in user-import:\n") +
                                            auto_import_error.AsCString());
     }

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -3611,9 +3611,8 @@ SwiftASTContext::GetCachedModule(const SourceModule &module) {
   return nullptr;
 }
 
-swift::ModuleDecl *
-SwiftASTContext::CreateModule(const SourceModule &module, Status &error,
-                              swift::ImplicitImportInfo importInfo) {
+swift::ModuleDecl *SwiftASTContext::CreateModule(const SourceModule &module,
+                                                 Status &error) {
   VALID_OR_RETURN(nullptr);
   if (!module.path.size()) {
     error.SetErrorStringWithFormat("invalid module name (empty)");
@@ -3634,7 +3633,7 @@ SwiftASTContext::CreateModule(const SourceModule &module, Status &error,
 
   swift::Identifier module_id(
       ast->getIdentifier(module.path.front().GetCString()));
-  auto *module_decl = swift::ModuleDecl::create(module_id, *ast, importInfo);
+  auto *module_decl = swift::ModuleDecl::create(module_id, *ast);
   if (!module_decl) {
     error.SetErrorStringWithFormat("failed to create module for \"%s\"",
                                    module.path.front().GetCString());
@@ -8356,12 +8355,14 @@ static void GetNameFromModule(swift::ModuleDecl *module, std::string &result) {
   }
 }
 
-static swift::ModuleDecl *LoadOneModule(const SourceModule &module,
-                                        SwiftASTContext &swift_ast_context,
-                                        lldb::StackFrameWP &stack_frame_wp,
-                                        Status &error) {
+static bool
+LoadOneModule(const SourceModule &module, SwiftASTContext &swift_ast_context,
+              lldb::StackFrameWP &stack_frame_wp,
+              llvm::SmallVectorImpl<swift::SourceFile::ImportedModuleDesc>
+                  &additional_imports,
+              Status &error) {
   if (!module.path.size())
-    return nullptr;
+    return false;
 
   error.Clear();
   ConstString toplevel = module.path.front();
@@ -8400,7 +8401,7 @@ static swift::ModuleDecl *LoadOneModule(const SourceModule &module,
                toplevel.AsCString(), error.AsCString());
 
     if (!swift_module || swift_ast_context.HasFatalErrors()) {
-      return nullptr;
+      return false;
     }
   }
 
@@ -8411,42 +8412,23 @@ static swift::ModuleDecl *LoadOneModule(const SourceModule &module,
     LOG_PRINTF(LIBLLDB_LOG_EXPRESSIONS, "Imported module %s from {%s}",
                module.path.front().AsCString(), ss.GetData());
   }
-  return swift_module;
-}
 
-bool SwiftASTContext::GetImplicitImports(
-    SwiftASTContext &swift_ast_context, SymbolContext &sc,
-    ExecutionContextScope &exe_scope, lldb::StackFrameWP &stack_frame_wp,
-    llvm::SmallVectorImpl<swift::ModuleDecl *> &modules, Status &error) {
-  if (!GetCompileUnitImports(swift_ast_context, sc, stack_frame_wp, modules,
-                             error)) {
-    return false;
-  }
-
-  auto *persistent_expression_state =
-      sc.target_sp->GetSwiftPersistentExpressionState(exe_scope);
-
-  // Get the hand-loaded modules from the SwiftPersistentExpressionState.
-  for (ConstString name : persistent_expression_state->GetHandLoadedModules()) {
-    SourceModule module_info;
-    module_info.path.push_back(name);
-    auto *module = LoadOneModule(module_info, swift_ast_context, stack_frame_wp,
-                                 error);
-    if (!module)
-      return false;
-
-    modules.push_back(module);
-  }
+  additional_imports.push_back(swift::SourceFile::ImportedModuleDesc(
+      std::make_pair(swift::ModuleDecl::AccessPathTy(), swift_module),
+      swift::SourceFile::ImportOptions()));
   return true;
 }
 
-bool SwiftASTContext::CacheUserImports(SwiftASTContext &swift_ast_context,
-                                       SymbolContext &sc,
-                                       ExecutionContextScope &exe_scope,
-                                       lldb::StackFrameWP &stack_frame_wp,
-                                       swift::SourceFile &source_file,
-                                       Status &error) {
+bool SwiftASTContext::PerformUserImport(SwiftASTContext &swift_ast_context,
+                                        SymbolContext &sc,
+                                        ExecutionContextScope &exe_scope,
+                                        lldb::StackFrameWP &stack_frame_wp,
+                                        swift::SourceFile &source_file,
+                                        Status &error) {
   llvm::SmallString<1> m_description;
+  llvm::SmallVector<swift::SourceFile::ImportedModuleDesc, 2>
+      additional_imports;
+
   llvm::SmallVector<swift::ModuleDecl::ImportedModule, 2> parsed_imports;
 
   swift::ModuleDecl::ImportFilter import_filter;
@@ -8470,7 +8452,7 @@ bool SwiftASTContext::CacheUserImports(SwiftASTContext &swift_ast_context,
                    "Performing auto import on found module: %s.\n",
                    module_name.c_str());
         if (!LoadOneModule(module_info, swift_ast_context, stack_frame_wp,
-                           error))
+                           additional_imports, error))
           return false;
 
         // How do we tell we are in REPL or playground mode?
@@ -8478,43 +8460,54 @@ bool SwiftASTContext::CacheUserImports(SwiftASTContext &swift_ast_context,
       }
     }
   }
+  // Finally get the hand-loaded modules from the
+  // SwiftPersistentExpressionState and load them into this context:
+  for (ConstString name : persistent_expression_state->GetHandLoadedModules()) {
+    SourceModule module_info;
+    module_info.path.push_back(name);
+    if (!LoadOneModule(module_info, swift_ast_context, stack_frame_wp,
+                       additional_imports, error))
+      return false;
+  }
+
+  source_file.addImports(additional_imports);
   return true;
 }
 
-bool SwiftASTContext::GetCompileUnitImports(
-    SwiftASTContext &swift_ast_context, SymbolContext &sc,
-    lldb::StackFrameWP &stack_frame_wp,
-    llvm::SmallVectorImpl<swift::ModuleDecl *> &modules, Status &error) {
-  // Import the Swift standard library and its dependencies.
+bool SwiftASTContext::PerformAutoImport(SwiftASTContext &swift_ast_context,
+                                        SymbolContext &sc,
+                                        lldb::StackFrameWP &stack_frame_wp,
+                                        swift::SourceFile *source_file,
+                                        Status &error) {
+  llvm::SmallVector<swift::SourceFile::ImportedModuleDesc, 2>
+      additional_imports;
+
+  // Import the Swift standard library and its dependecies.
   SourceModule swift_module;
   swift_module.path.push_back(ConstString("Swift"));
-  auto *stdlib =
-      LoadOneModule(swift_module, swift_ast_context, stack_frame_wp, error);
-  if (!stdlib)
+  if (!LoadOneModule(swift_module, swift_ast_context, stack_frame_wp,
+                     additional_imports, error))
     return false;
 
-  modules.push_back(stdlib);
-
   CompileUnit *compile_unit = sc.comp_unit;
-  if (!compile_unit || compile_unit->GetLanguage() != lldb::eLanguageTypeSwift)
-    return true;
+  if (compile_unit && compile_unit->GetLanguage() == lldb::eLanguageTypeSwift)
+    for (const SourceModule &module : compile_unit->GetImportedModules()) {
+      // When building the Swift stdlib with debug info these will
+      // show up in "Swift.o", but we already imported them and
+      // manually importing them will fail.
+      if (module.path.size() &&
+          llvm::StringSwitch<bool>(module.path.front().GetStringRef())
+              .Cases("Swift", "SwiftShims", "Builtin", true)
+              .Default(false))
+        continue;
 
-  for (const SourceModule &module : compile_unit->GetImportedModules()) {
-    // When building the Swift stdlib with debug info these will
-    // show up in "Swift.o", but we already imported them and
-    // manually importing them will fail.
-    if (module.path.size() &&
-        llvm::StringSwitch<bool>(module.path.front().GetStringRef())
-            .Cases("Swift", "SwiftShims", "Builtin", true)
-            .Default(false))
-      continue;
-
-    auto *loaded_module =
-        LoadOneModule(module, swift_ast_context, stack_frame_wp, error);
-    if (!loaded_module)
-      return false;
-
-    modules.push_back(loaded_module);
-  }
+      if (!LoadOneModule(module, swift_ast_context, stack_frame_wp,
+                         additional_imports, error))
+        return false;
+    }
+  // source_file might be NULL outside of the expression parser, where
+  // we don't need to notify the source file of additional imports.
+  if (source_file)
+    source_file->addImports(additional_imports);
   return true;
 }

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -1198,8 +1198,7 @@ void SwiftLanguageRuntime::RegisterGlobalError(Target &target, ConstString name,
 
     Status module_creation_error;
     swift::ModuleDecl *module_decl =
-        ast_context->CreateModule(module_info, module_creation_error,
-                                  /*importInfo*/ {});
+        ast_context->CreateModule(module_info, module_creation_error);
 
     if (module_creation_error.Success() && module_decl) {
       const bool is_static = false;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2499,9 +2499,7 @@ SwiftASTContextReader Target::GetScratchSwiftASTContext(
       !swift_ast_ctx->HasFatalErrors()) {
     StackFrameWP frame_wp(frame_sp);
     SymbolContext sc = frame_sp->GetSymbolContext(lldb::eSymbolContextEverything);
-    llvm::SmallVector<swift::ModuleDecl *, 16> modules;
-    swift_ast_ctx->GetCompileUnitImports(*swift_ast_ctx, sc, frame_wp, modules,
-                                         error);
+    swift_ast_ctx->PerformAutoImport(*swift_ast_ctx, sc, frame_wp, nullptr, error);
   }
 
   return SwiftASTContextReader(GetSwiftScratchContextLock(), swift_ast_ctx);


### PR DESCRIPTION
Looks like this got pulled into release/5.3, but the Swift half https://github.com/apple/swift/pull/31016 didn't. I wasn't planning on pulling the Swift half into 5.3, so let's revert the LLDB half.