### PR TITLE
Added <cstdlib> header for std::abort

### DIFF
--- a/clang-tools-extra/clangd/Shutdown.cpp
+++ b/clang-tools-extra/clangd/Shutdown.cpp
@@ -9,6 +9,7 @@
 #include "Shutdown.h"
 
 #include <atomic>
+#include <cstdlib>
 #include <thread>
 
 namespace clang {


### PR DESCRIPTION
`std::abort` had been implicitly included, which Clang 10 does not like.