### PR TITLE
[lldb/Dataformatter] Add support for CoreFoundation Dictionaries and Sets.

### DIFF
--- a/lldb/source/Plugins/Language/ObjC/CFBasicHash.cpp
+++ b/lldb/source/Plugins/Language/ObjC/CFBasicHash.cpp
@@ -1,0 +1,114 @@
+#include "CFBasicHash.h"
+
+#include "lldb/Utility/Endian.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+bool CFBasicHash::IsValid() const {
+  if (m_address != LLDB_INVALID_ADDRESS) {
+    if (m_ptr_size == 4 && m_ht_32)
+      return true;
+    else if (m_ptr_size == 8 && m_ht_64)
+      return true;
+    else
+      return false;
+  }
+  return false;
+}
+
+bool CFBasicHash::Update(addr_t addr, ExecutionContextRef exe_ctx_rf) {
+  if (addr == LLDB_INVALID_ADDRESS || !addr)
+    return false;
+
+  m_address = addr;
+  m_exe_ctx_ref = exe_ctx_rf;
+  m_ptr_size =
+      m_exe_ctx_ref.GetTargetSP()->GetArchitecture().GetAddressByteSize();
+  m_byte_order = m_exe_ctx_ref.GetTargetSP()->GetArchitecture().GetByteOrder();
+
+  if (m_ptr_size == 4)
+    return UpdateFor(m_ht_32);
+  else if (m_ptr_size == 8)
+    return UpdateFor(m_ht_64);
+  return false;
+
+  llvm_unreachable(
+      "Unsupported architecture. Only 32bits and 64bits supported.");
+}
+
+template <typename T>
+bool CFBasicHash::UpdateFor(std::unique_ptr<__CFBasicHash<T>> &m_ht) {
+  if (m_byte_order != endian::InlHostByteOrder())
+    return false;
+  
+  Status error;
+  Target *target = m_exe_ctx_ref.GetTargetSP().get();
+  addr_t addr = m_address.GetLoadAddress(target);
+  size_t size = sizeof(typename __CFBasicHash<T>::RuntimeBase) +
+                sizeof(typename __CFBasicHash<T>::Bits);
+
+  m_ht = std::make_unique<__CFBasicHash<T>>();
+  m_exe_ctx_ref.GetProcessSP()->ReadMemory(addr, m_ht.get(),
+                                           size, error);
+  if (error.Fail())
+    return false;
+
+  m_mutable = !(m_ht->base.cfinfoa & (1 << 6));
+  m_multi = m_ht->bits.counts_offset;
+  m_type = static_cast<HashType>(m_ht->bits.keys_offset);
+  addr_t ptr_offset = addr + size;
+  size_t ptr_count = GetPointerCount();
+  size = ptr_count * sizeof(T);
+
+  m_exe_ctx_ref.GetProcessSP()->ReadMemory(ptr_offset, m_ht->pointers, size,
+                                           error);
+
+  if (error.Fail()) {
+    m_ht = nullptr;
+    return false;
+  }
+
+  return true;
+}
+
+size_t CFBasicHash::GetCount() const {
+  if (!IsValid())
+    return 0;
+
+  if (!m_multi)
+    return (m_ptr_size == 4) ? m_ht_32->bits.used_buckets
+                             : m_ht_64->bits.used_buckets;
+
+  //  FIXME: Add support for multi
+  return 0;
+}
+
+size_t CFBasicHash::GetPointerCount() const {
+  if (!IsValid())
+    return 0;
+
+  if (m_multi)
+    return 3; // Bits::counts_offset;
+  return (m_type == HashType::dict) + 1;
+}
+
+addr_t CFBasicHash::GetKeyPointer() const {
+  if (!IsValid())
+    return LLDB_INVALID_ADDRESS;
+
+  if (m_ptr_size == 4)
+    return m_ht_32->pointers[m_ht_32->bits.keys_offset];
+
+  return m_ht_64->pointers[m_ht_64->bits.keys_offset];
+}
+
+addr_t CFBasicHash::GetValuePointer() const {
+  if (!IsValid())
+    return LLDB_INVALID_ADDRESS;
+
+  if (m_ptr_size == 4)
+    return m_ht_32->pointers[0];
+
+  return m_ht_64->pointers[0];
+}

--- a/lldb/source/Plugins/Language/ObjC/CFBasicHash.h
+++ b/lldb/source/Plugins/Language/ObjC/CFBasicHash.h
@@ -1,0 +1,77 @@
+//===-- CFBasicHash.h -------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_LANGUAGE_OBJC_CFBASICHASH_H
+#define LLDB_SOURCE_PLUGINS_LANGUAGE_OBJC_CFBASICHASH_H
+
+#include "lldb/Target/Process.h"
+#include "lldb/Target/Target.h"
+
+namespace lldb_private {
+
+class CFBasicHash {
+public:
+  enum class HashType { set = 0, dict };
+
+  CFBasicHash() = default;
+  ~CFBasicHash() = default;
+
+  bool Update(lldb::addr_t addr, ExecutionContextRef exe_ctx_rf);
+
+  bool IsValid() const;
+
+  bool IsMutable() const { return m_mutable; };
+  bool IsMultiVariant() const { return m_multi; }
+  HashType GetType() const { return m_type; }
+
+  size_t GetCount() const;
+  lldb::addr_t GetKeyPointer() const;
+  lldb::addr_t GetValuePointer() const;
+
+private:
+  template <typename T> struct __CFBasicHash {
+    struct RuntimeBase {
+      T cfisa;
+      T cfinfoa;
+    } base;
+
+    struct Bits {
+      uint16_t __reserved0;
+      uint16_t __reserved1 : 2;
+      uint16_t keys_offset : 1;
+      uint16_t counts_offset : 2;
+      uint16_t counts_width : 2;
+      uint16_t __reserved2 : 9;
+      uint32_t used_buckets;        // number of used buckets
+      uint64_t deleted : 16;        // number of elements deleted
+      uint64_t num_buckets_idx : 8; // index to number of buckets
+      uint64_t __reserved3 : 40;
+      uint64_t __reserved4;
+    } bits;
+
+    T pointers[3];
+  };
+  template <typename T> bool UpdateFor(std::unique_ptr<__CFBasicHash<T>> &m_ht);
+
+  size_t GetPointerCount() const;
+
+private:
+  uint32_t m_ptr_size = UINT32_MAX;
+  lldb::ByteOrder m_byte_order = lldb::eByteOrderInvalid;
+  Address m_address = LLDB_INVALID_ADDRESS;
+  std::unique_ptr<__CFBasicHash<uint32_t>> m_ht_32 = nullptr;
+  std::unique_ptr<__CFBasicHash<uint64_t>> m_ht_64 = nullptr;
+  ExecutionContextRef m_exe_ctx_ref;
+  bool m_mutable = true;
+  bool m_multi = false;
+  HashType m_type;
+};
+
+}; // namespace lldb_private
+
+#endif // LLDB_SOURCE_PLUGINS_LANGUAGE_OBJC_CFBASICHASH_H

--- a/lldb/source/Plugins/Language/ObjC/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/ObjC/CMakeLists.txt
@@ -11,6 +11,7 @@ endif ()
 add_lldb_library(lldbPluginObjCLanguage PLUGIN
   ObjCLanguage.cpp
   CF.cpp
+  CFBasicHash.cpp
   Cocoa.cpp
   CoreMedia.cpp
   NSArray.cpp

--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.h
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.h
@@ -1,5 +1,4 @@
-//===-- NSDictionary.h ---------------------------------------------------*- C++
-//-*-===//
+//===-- NSDictionary.h ------------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lldb/source/Plugins/Language/ObjC/ObjCLanguage.cpp
+++ b/lldb/source/Plugins/Language/ObjC/ObjCLanguage.cpp
@@ -604,6 +604,11 @@ static void LoadObjCFormatters(TypeCategoryImplSP objc_category_sp) {
                   lldb_private::formatters::NSSetSyntheticFrontEndCreator,
                   "__NSSetM synthetic children", ConstString("__NSSetM"),
                   ScriptedSyntheticChildren::Flags());
+  AddCXXSynthetic(objc_category_sp,
+                  lldb_private::formatters::NSSetSyntheticFrontEndCreator,
+                  "__NSCFSet synthetic children", ConstString("__NSCFSet"),
+                  ScriptedSyntheticChildren::Flags());
+
   AddCXXSynthetic(
       objc_category_sp, lldb_private::formatters::NSSetSyntheticFrontEndCreator,
       "NSMutableSet synthetic children", ConstString("NSMutableSet"),

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSContainer.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSContainer.py
@@ -23,8 +23,16 @@ class ObjCDataFormatterNSContainer(ObjCDataFormatterTestCase):
         self.expect(
             'frame variable newArray nsDictionary newDictionary nscfDictionary cfDictionaryRef newMutableDictionary cfarray_ref mutable_array_ref',
             substrs=[
-                '(NSArray *) newArray = ', '@"50 elements"',
-                '(NSDictionary *) newDictionary = ', ' 12 key/value pairs',
+                '(NSArray *) newArray = ',
+                ' @"50 elements"',
+                '(NSDictionary *) nsDictionary = ',
+                ' 2 key/value pairs',
+                '(NSDictionary *) newDictionary = ',
+                ' 12 key/value pairs',
+                '(NSDictionary *) nscfDictionary = ',
+                ' 4 key/value pairs',
+                '(CFDictionaryRef) cfDictionaryRef = ',
+                ' 3 key/value pairs',
                 '(NSDictionary *) newMutableDictionary = ',
                 ' 21 key/value pairs', '(NSDictionary *) nsDictionary = ',
                 ' 2 key/value pairs', '(CFDictionaryRef) cfDictionaryRef = ',
@@ -32,6 +40,36 @@ class ObjCDataFormatterNSContainer(ObjCDataFormatterTestCase):
                 '@"3 elements"', '(CFMutableArrayRef) mutable_array_ref = ',
                 '@"11 elements"'
             ])
+
+        self.expect(
+            'frame variable -d run-target *nscfDictionary',
+            patterns=[
+                '\(__NSCFDictionary\) \*nscfDictionary =',
+                'key = 0x.* @"foo"',
+                'value = 0x.* @"foo"',
+                'key = 0x.* @"bar"',
+                'value = 0x.* @"bar"',
+                'key = 0x.* @"baz"',
+                'value = 0x.* @"baz"',
+                'key = 0x.* @"quux"',
+                'value = 0x.* @"quux"',
+                ])
+
+
+        self.expect(
+          'frame var nscfSet',
+          substrs=[
+          '(NSSet *) nscfSet = ',
+          '2 elements',
+          ])
+
+        self.expect(
+          'frame variable -d run-target *nscfSet',
+          patterns=[
+              '\(__NSCFSet\) \*nscfSet =',
+              '\[0\] = 0x.* @".*"',
+              '\[1\] = 0x.* @".*"',
+                    ])
 
         self.expect(
             'frame variable iset1 iset2 imset',

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/main.m
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/main.m
@@ -384,13 +384,19 @@ int main (int argc, const char * argv[])
 	    [newMutableDictionary setObject:@"foo" forKey:@"bar19"];
 	    [newMutableDictionary setObject:@"foo" forKey:@"bar20"];
 
-	    id cfKeys[2] = { @"foo", @"bar", @"baz", @"quux" };
-	    id cfValues[2] = { @"foo", @"bar", @"baz", @"quux" };
-	    NSDictionary *nsDictionary = CFBridgingRelease(CFDictionaryCreate(nil, (void *)cfKeys, (void *)cfValues, 2, nil, nil));
-	    CFDictionaryRef cfDictionaryRef = CFDictionaryCreate(nil, (void *)cfKeys, (void *)cfValues, 3, nil, nil);
+            id cfKeys[4] = {@"foo", @"bar", @"baz", @"quux"};
+            id cfValues[4] = {@"foo", @"bar", @"baz", @"quux"};
+            NSDictionary *nsDictionary = CFBridgingRelease(CFDictionaryCreate(
+                nil, (void *)cfKeys, (void *)cfValues, 2, nil, nil));
+            NSDictionary *nscfDictionary = CFBridgingRelease(CFDictionaryCreate(
+                nil, (void *)cfKeys, (void *)cfValues, 4, nil, nil));
+            CFDictionaryRef cfDictionaryRef = CFDictionaryCreate(
+                nil, (void *)cfKeys, (void *)cfValues, 3, nil, nil);
 
-	    NSAttributedString* attrString = [[NSAttributedString alloc] initWithString:@"hello world from foo" attributes:newDictionary];
-	    [attrString isEqual:nil];
+            NSAttributedString *attrString = [[NSAttributedString alloc]
+                initWithString:@"hello world from foo"
+                    attributes:newDictionary];
+            [attrString isEqual:nil];
 	    NSAttributedString* mutableAttrString = [[NSMutableAttributedString alloc] initWithString:@"hello world from foo" attributes:newDictionary];
 	    [mutableAttrString isEqual:nil];
 
@@ -419,9 +425,11 @@ int main (int argc, const char * argv[])
 
 	    NSSet* nsset = [[NSSet alloc] initWithObjects:str1,str2,str3,nil];
 	    NSSet *nsmutableset = [[NSMutableSet alloc] initWithObjects:str1,str2,str3,nil];
-	    [nsmutableset addObject:str4];
+            [nsmutableset addObject:str4];
+            NSSet *nscfSet =
+                CFBridgingRelease(CFSetCreate(nil, (void *)cfValues, 2, nil));
 
-	    CFDataRef data_ref = CFDataCreate(kCFAllocatorDefault, [immutableData bytes], 5);
+            CFDataRef data_ref = CFDataCreate(kCFAllocatorDefault, [immutableData bytes], 5);
 
 	    CFMutableDataRef mutable_data_ref = CFDataCreateMutable(kCFAllocatorDefault, 8);
 	    CFDataAppendBytes(mutable_data_ref, [mutableData bytes], 5);


### PR DESCRIPTION
This patch improves data formatting for CoreFoundation containers:
CFDictionary and CFSet.

These data formatters make the containers and their children appear in Xcode's
variables view (and on the command line) without having to expand the
data structure.

Previous implementation only supported showing the container's element count.

```
(lldb) frame var dict
(__NSCFDictionary *) dict = 0x00000001004062b0 2 key/value pairs

(lldb) frame var set
(__NSCFSet *) set = 0x0000000100406330 2 elements
```
Now the variable can be dereferenced to dispaly the container's children:

```
(lldb) frame var *dict
(__NSCFDictionary) *dict = {
  [0] = {
    key = 0x0000000100004050 @"123"
    value = 0x0000000100004090 @"456"
  }
  [1] = {
    key = 0x0000000100004030 @"abc"
    value = 0x0000000100004070 @"def"
  }
}

(lldb) frame var *set
(__NSCFSet) *set = {
  [0] = 0x0000000100004050 @"123"
  [1] = 0x0000000100004030 @"abc"
}
```

rdar://39882287

Differential Revision: https://reviews.llvm.org/D78396

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>