### PR TITLE
Preserve the owning module information from DWARF in the synthesized AST

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -1789,14 +1789,14 @@ NamespaceDecl *TypeSystemClang::GetUniqueNamespaceDeclaration(
       }
     }
   }
+#ifdef LLDB_CONFIGURATION_DEBUG
+  VerifyDecl(namespace_decl);
+#endif
 
   // Note: namespaces can span multiple modules, so perhaps this isn't a good
   // idea.
   SetOwningModule(namespace_decl, owning_module);
 
-#ifdef LLDB_CONFIGURATION_DEBUG
-  VerifyDecl(namespace_decl);
-#endif
   return namespace_decl;
 }
 


### PR DESCRIPTION
Types that came from a Clang module are nested in DW_TAG_module tags
in DWARF. This patch recreates the Clang module hierarchy in LLDB and
1;95;0csets the owning module information accordingly. My primary motivation
is to facilitate looking up per-module APINotes for individual
declarations, but this likely also has other applications.

This reapplies the previously reverted commit, but without support for
ClassTemplateSpecializations, which I'm going to look into separately.

rdar://problem/59634380

Differential Revision: https://reviews.llvm.org/D75488

(cherry picked from commit 143d507c9ff90db93e547f0e1131e92db06e2675)