### PR TITLE
Fix use-after-free

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -1228,7 +1228,7 @@ protected:
   void RemapClangImporterOptions(const PathMappingList &path_map);
 
   /// Infer the appropriate Swift resource directory for a target triple.
-  llvm::StringRef GetResourceDir(const llvm::Triple &target);
+  std::string GetResourceDir(const llvm::Triple &target);
 
   /// Implementation of \c GetResourceDir.
   static std::string GetResourceDir(llvm::StringRef platform_sdk_path,

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -1006,7 +1006,7 @@ StringRef SwiftASTContext::GetSwiftStdlibOSDir(const llvm::Triple &target,
   return target.getOSName();
 }
 
-StringRef SwiftASTContext::GetResourceDir(const llvm::Triple &triple) {
+std::string SwiftASTContext::GetResourceDir(const llvm::Triple &triple) {
   static std::mutex g_mutex;
   std::lock_guard<std::mutex> locker(g_mutex);
   StringRef platform_sdk_path = GetPlatformSDKPath();
@@ -1706,7 +1706,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
   }
 
   triple = swift_ast_sp->GetTriple();
-  StringRef resource_dir = swift_ast_sp->GetResourceDir(triple);
+  std::string resource_dir = swift_ast_sp->GetResourceDir(triple);
   ConfigureResourceDirs(swift_ast_sp->GetCompilerInvocation(),
                         FileSpec(resource_dir), triple);
 
@@ -2014,7 +2014,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
   }
 
   llvm::Triple triple = swift_ast_sp->GetTriple();
-  StringRef resource_dir = swift_ast_sp->GetResourceDir(triple);
+  std::string resource_dir = swift_ast_sp->GetResourceDir(triple);
   ConfigureResourceDirs(swift_ast_sp->GetCompilerInvocation(),
                         FileSpec(resource_dir), triple);
 
@@ -2679,7 +2679,7 @@ void SwiftASTContext::InitializeSearchPathOptions(
   }
 
   llvm::Triple triple(GetTriple());
-  StringRef resource_dir = GetResourceDir(triple);
+  std::string resource_dir = GetResourceDir(triple);
   ConfigureResourceDirs(GetCompilerInvocation(), FileSpec(resource_dir),
                         triple);
 
@@ -3437,7 +3437,7 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
   // Compute the prebuilt module cache path to use:
   // <resource-dir>/<platform>/prebuilt-modules
   llvm::Triple triple(GetTriple());
-  llvm::SmallString<128> prebuiltModuleCachePath = GetResourceDir(triple);
+  llvm::SmallString<128> prebuiltModuleCachePath(GetResourceDir(triple));
   StringRef platform;
   if (swift::tripleIsMacCatalystEnvironment(triple)) {
     // The prebuilt cache for macCatalyst is the same as the one for macOS,


### PR DESCRIPTION
The underlying function in upstream LLDB no longer returns a constant string.