### PR TITLE
Fix use-after-free

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -1219,8 +1219,8 @@ protected:
 
   /// Return the name of the OS-specific subdirectory containing the
   /// Swift stdlib needed for \p target.
-  static llvm::StringRef GetSwiftStdlibOSDir(const llvm::Triple &target,
-                                             const llvm::Triple &host);
+  static std::string GetSwiftStdlibOSDir(const llvm::Triple &target,
+                                         const llvm::Triple &host);
 };
 
 class SwiftASTContextForExpressions : public SwiftASTContext {

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -995,8 +995,8 @@ static SDKTypeMinVersion GetSDKType(const llvm::Triple &target,
 
 /// Return the name of the OS-specific subdirectory containing the
 /// Swift stdlib needed for \p target.
-StringRef SwiftASTContext::GetSwiftStdlibOSDir(const llvm::Triple &target,
-                                               const llvm::Triple &host) {
+std::string SwiftASTContext::GetSwiftStdlibOSDir(const llvm::Triple &target,
+                                                 const llvm::Triple &host) {
   auto sdk = GetSDKType(target, host);
   XcodeSDK::Info sdk_info;
   sdk_info.type = sdk.sdk_type;

--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -71,7 +71,7 @@ struct SwiftASTContextTester : public SwiftASTContext {
         platform_sdk_path, swift_dir, swift_stdlib_os_dir, xcode_contents_path,
         toolchain_path, cl_tools_path);
   }
-  static llvm::StringRef GetSwiftStdlibOSDir(const llvm::Triple &target,
+  static std::string GetSwiftStdlibOSDir(const llvm::Triple &target,
                                              const llvm::Triple &host) {
     return SwiftASTContext::GetSwiftStdlibOSDir(target, host);
   }


### PR DESCRIPTION
The underlying function in upstream LLDB no longer returns a constant string.