### PR TITLE
[lldb][swift] Make some more Swift-specific sources dependend on LLDB…

### DIFF
--- a/lldb/source/Symbol/CMakeLists.txt
+++ b/lldb/source/Symbol/CMakeLists.txt
@@ -4,7 +4,10 @@ if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
   set(PLATFORM_SOURCES LocateSymbolFileMacOSX.cpp)
 endif()
 
-set(SWIFT_SOURCES SwiftASTContext.cpp)
+set(SWIFT_SOURCES
+    SwiftASTContext.cpp
+    TypeSystemSwiftTypeRef.cpp
+)
 set(SWIFT_LIBS
     swiftAST
     swiftASTSectionImporter
@@ -23,7 +26,6 @@ endif()
 add_lldb_library(lldbSymbol
   ArmUnwindInfo.cpp
   Block.cpp
-  TypeSystemSwiftTypeRef.cpp
   CompactUnwindInfo.cpp
   CompileUnit.cpp
   CompilerDecl.cpp

--- a/lldb/source/Target/CMakeLists.txt
+++ b/lldb/source/Target/CMakeLists.txt
@@ -58,9 +58,6 @@ add_lldb_library(lldbTarget
   StackID.cpp
   StopInfo.cpp
   StructuredDataPlugin.cpp
-  SwiftLanguageRuntime.cpp
-  SwiftLanguageRuntimeDynamicTypeResolution.cpp
-  SwiftLanguageRuntimeNames.cpp
   SystemRuntime.cpp
   Target.cpp
   TargetList.cpp

--- a/lldb/unittests/Symbol/CMakeLists.txt
+++ b/lldb/unittests/Symbol/CMakeLists.txt
@@ -1,4 +1,7 @@
-set(SWIFT_SOURCES TestSwiftASTContext.cpp)
+set(SWIFT_SOURCES
+  TestSwiftASTContext.cpp
+  TestTypeSystemSwiftTypeRef.cpp
+)
 set(LLVM_OPTIONAL_SOURCES ${SWIFT_SOURCES})
 if (NOT LLDB_ENABLE_SWIFT_SUPPORT)
   unset(SWIFT_SOURCES)
@@ -11,8 +14,6 @@ add_lldb_unittest(SymbolTests
   TestClangASTImporter.cpp
   TestDWARFCallFrameInfo.cpp
   TestType.cpp
-  TestTypeSystemSwiftTypeRef.cpp
-  TestSwiftASTContext.cpp
   TestLineEntry.cpp
 
   ${SWIFT_SOURCES}


### PR DESCRIPTION
…_ENABLE_SWIFT_SUPPORT

Swift sources should only be compiled when LLDB_ENABLE_SWIFT_SUPPORT is set.
This moves a few Swift files that were always compiled into the proper
SWIFT_SOURCES variable that we use to hold optional Swift-specific source files.