### PR TITLE
[lldb][swift] Only compile LLDB code that depends on Swift when Swift…

### DIFF
--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -70,6 +70,9 @@ option(LLDB_SKIP_STRIP "Whether to skip stripping of binaries when installing ll
 option(LLDB_ENABLE_SWIFT_SUPPORT "Enable swift support" ON)
 option(LLDB_USE_STATIC_BINDINGS "Use the static Python bindings." OFF)
 option(LLDB_ENABLE_WERROR "Fail and stop if a warning is triggered." ${LLVM_ENABLE_WERROR})
+if(LLDB_ENABLE_SWIFT_SUPPORT)
+  add_definitions( -DLLDB_ENABLE_SWIFT )
+endif()
 # END SWIFT CODE
 
 if (LLDB_USE_SYSTEM_DEBUGSERVER)

--- a/lldb/include/lldb/Core/ValueObject.h
+++ b/lldb/include/lldb/Core/ValueObject.h
@@ -582,7 +582,9 @@ public:
 
   virtual bool HasSyntheticValue();
 
+#ifdef LLDB_ENABLE_SWIFT
   SwiftASTContextReader GetScratchSwiftASTContext();
+#endif // LLDB_ENABLE_SWIFT
 
   virtual bool IsSynthetic() { return false; }
 

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1086,8 +1086,10 @@ public:
   PersistentExpressionState *
   GetPersistentExpressionStateForLanguage(lldb::LanguageType language);
 
+#ifdef LLDB_ENABLE_SWIFT
   SwiftPersistentExpressionState *
   GetSwiftPersistentExpressionState(ExecutionContextScope &exe_scope);
+#endif // LLDB_ENABLE_SWIFT
 
   const TypeSystemMap &GetTypeSystemMap();
 
@@ -1126,6 +1128,7 @@ public:
                                                  Status &error);
 
 
+#ifdef LLDB_ENABLE_SWIFT
   /// Get the lock guarding the scratch typesystem from being re-initialized.
   SharedMutex &GetSwiftScratchContextLock() {
     return m_scratch_typesystem_lock;
@@ -1138,6 +1141,7 @@ public:
 private:
   void DisplayFallbackSwiftContextErrors(
       SwiftASTContextForExpressions *swift_ast_ctx);
+#endif // LLDB_ENABLE_SWIFT
 
 public:
 

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -53,10 +53,10 @@
 #include "Plugins/Language/CPlusPlus/CPlusPlusLanguage.h"
 #include "Plugins/Language/ObjC/ObjCLanguage.h"
 
-// BEGIN SWIFT
+#ifdef LLDB_ENABLE_SWIFT
 #include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
-// END SWIFT
+#endif // LLDB_ENABLE_SWIFT
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Compiler.h"
@@ -646,10 +646,10 @@ Module::LookupInfo::LookupInfo(ConstString name,
               Language::LanguageIsObjC(language)) &&
              ObjCLanguage::IsPossibleObjCMethodName(name_cstr))
       m_name_type_mask = eFunctionNameTypeFull;
-    // BEGIN SWIFT
+#ifdef LLDB_ENABLE_SWIFT
     else if (SwiftLanguageRuntime::IsSwiftMangledName(name.GetStringRef()))
       m_name_type_mask = eFunctionNameTypeFull;
-    // END SWIFT
+#endif // LLDB_ENABLE_SWIFT
     else if (Language::LanguageIsC(language)) {
       m_name_type_mask = eFunctionNameTypeFull;
     } else {
@@ -660,7 +660,7 @@ Module::LookupInfo::LookupInfo(ConstString name,
 
       CPlusPlusLanguage::MethodName cpp_method(name);
 
-      // BEGIN SWIFT
+#ifdef LLDB_ENABLE_SWIFT
       SwiftLanguageRuntime::MethodName swift_method(name, true);
 
       if ((language == eLanguageTypeUnknown ||
@@ -673,7 +673,7 @@ Module::LookupInfo::LookupInfo(ConstString name,
                 language == eLanguageTypeObjC_plus_plus) &&
                cpp_method.IsValid())
         basename = cpp_method.GetBasename();
-      // END SWIFT
+#endif // LLDB_ENABLE_SWIFT
 
       if (basename.empty()) {
         if (CPlusPlusLanguage::ExtractContextAndIdentifier(name_cstr, context,
@@ -694,9 +694,11 @@ Module::LookupInfo::LookupInfo(ConstString name,
       CPlusPlusLanguage::MethodName cpp_method(name);
 
       // BEGIN SWIFT
+#ifdef LLDB_ENABLE_SWIFT
       SwiftLanguageRuntime::MethodName swift_method(name, true);
       if (swift_method.IsValid())
         basename = swift_method.GetBasename();
+#endif // LLDB_ENABLE_SWIFT
       if (cpp_method.IsValid())
         basename = cpp_method.GetBasename();
       if (!basename.empty()) {
@@ -1572,10 +1574,11 @@ bool Module::SetArchitecture(const ArchSpec &new_arch) {
       llvm::consumeError(type_system_or_err.takeError());
       return true;
     }
-
+#ifdef LLDB_ENABLE_SWIFT
     if (auto *swift_ast =
             llvm::dyn_cast_or_null<SwiftASTContext>(&*type_system_or_err))
       swift_ast->SetTriple(new_arch.GetTriple());
+#endif // LLDB_ENABLE_SWIFT
     return true;
   }
   return m_arch.IsCompatibleMatch(new_arch);
@@ -1698,8 +1701,10 @@ void Module::ClearModuleDependentCaches() {
     return;
   }
 
+#ifdef LLDB_ENABLE_SWIFT
   if (auto *swift_ast = llvm::dyn_cast_or_null<SwiftASTContext>(&*type_system_or_err))
     swift_ast->ClearModuleDependentCaches();
+#endif // LLDB_ENABLE_SWIFT
 }
 
 void Module::ForEachTypeSystem(

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -1748,6 +1748,7 @@ LanguageType ValueObject::GetObjectRuntimeLanguage() {
   return lldb::eLanguageTypeUnknown;
 }
 
+#ifdef LLDB_ENABLE_SWIFT
 SwiftASTContextReader ValueObject::GetScratchSwiftASTContext() {
   lldb::TargetSP target_sp(GetTargetSP());
   if (!target_sp)
@@ -1757,6 +1758,7 @@ SwiftASTContextReader ValueObject::GetScratchSwiftASTContext() {
   auto *exe_scope = ctx.GetBestExecutionContextScope();
   return target_sp->GetScratchSwiftASTContext(error, *exe_scope);
 }
+#endif // LLDB_ENABLE_SWIFT
 
 void ValueObject::AddSyntheticChild(ConstString key,
                                     ValueObject *valobj) {
@@ -2818,7 +2820,9 @@ void ValueObject::LogValueObject(Log *log,
 void ValueObject::Dump(Stream &s) { Dump(s, DumpValueObjectOptions(*this)); }
 
 void ValueObject::Dump(Stream &s, const DumpValueObjectOptions &options) {
+#ifdef LLDB_ENABLE_SWIFT
   auto swift_scratch_ctx_lock = SwiftASTContextLock(GetSwiftExeCtx(*this));
+#endif // LLDB_ENABLE_SWIFT
   ValueObjectPrinter printer(this, &s, options);
   printer.PrintValueObject();
 }
@@ -3360,6 +3364,7 @@ ValueObjectSP ValueObject::Persist() {
     return nullptr;
 
   PersistentExpressionState *persistent_state;
+#ifdef LLDB_ENABLE_SWIFT
   if (GetPreferredDisplayLanguage() == eLanguageTypeSwift) {
     ExecutionContext ctx = GetExecutionContextRef().Lock(false);
     auto *exe_scope = ctx.GetBestExecutionContextScope();
@@ -3367,6 +3372,7 @@ ValueObjectSP ValueObject::Persist() {
       return nullptr;
     persistent_state = target_sp->GetSwiftPersistentExpressionState(*exe_scope);
   } else
+#endif // LLDB_ENABLE_SWIFT
     persistent_state = target_sp->GetPersistentExpressionStateForLanguage(
         GetPreferredDisplayLanguage());
 

--- a/lldb/source/Core/ValueObjectDynamicValue.cpp
+++ b/lldb/source/Core/ValueObjectDynamicValue.cpp
@@ -148,7 +148,9 @@ bool ValueObjectDynamicValue::UpdateValue() {
     m_data.SetAddressByteSize(target->GetArchitecture().GetAddressByteSize());
   }
 
+#ifdef LLDB_ENABLE_SWIFT
   auto swift_scratch_ctx_lock = SwiftASTContextLock(&exe_ctx);
+#endif // LLDB_ENABLE_SWIFT
 
   // First make sure our Type and/or Address haven't changed:
   Process *process = exe_ctx.GetProcessPtr();
@@ -431,6 +433,10 @@ bool ValueObjectDynamicValue::DynamicValueTypeInfoNeedsUpdate() {
   if (!m_dynamic_type_info.HasType())
     return false;
 
+#ifdef LLDB_ENABLE_SWIFT
   auto *cached_ctx = m_value.GetCompilerType().GetTypeSystem();
   return cached_ctx == GetScratchSwiftASTContext().get();
+#else // !LLDB_ENABLE_SWIFT
+  return false;
+#endif // LLDB_ENABLE_SWIFT
 }

--- a/lldb/source/Core/ValueObjectVariable.cpp
+++ b/lldb/source/Core/ValueObjectVariable.cpp
@@ -260,7 +260,7 @@ bool ValueObjectVariable::UpdateValue() {
         break;
       }
 
-      // BEGIN Swift
+#ifdef LLDB_ENABLE_SWIFT
       if (auto type = variable->GetType())
         if (llvm::dyn_cast_or_null<TypeSystemSwift>(
                 type->GetForwardCompilerType().GetTypeSystem()) &&
@@ -281,7 +281,7 @@ bool ValueObjectVariable::UpdateValue() {
                 }
               }
             }
-      // END Swift
+#endif // LLDB_ENABLE_SWIFT
 
       switch (value_type) {
       case Value::eValueTypeVector:

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -419,8 +419,12 @@ public:
     m_alignment = 8;
     m_is_reference =
         m_variable_sp->GetType()->GetForwardCompilerType().IsReferenceType();
+#ifdef LLDB_ENABLE_SWIFT
     m_is_generic = SwiftASTContext::IsGenericType(
         m_variable_sp->GetType()->GetForwardCompilerType());
+#else // !LLDB_ENABLE_SWIFT
+    m_is_generic = false;
+#endif // LLDB_ENABLE_SWIFT
   }
 
   void Materialize(lldb::StackFrameSP &frame_sp, IRMemoryMap &map,
@@ -661,9 +665,11 @@ public:
 
       CompilerType valobj_type = valobj_sp->GetCompilerType();
 
+#ifdef LLDB_ENABLE_SWIFT
       if (SwiftASTContext::IsGenericType(valobj_type)) {
         valobj_sp = valobj_sp->GetDynamicValue(lldb::eDynamicDontRunTarget);
       }
+#endif // LLDB_ENABLE_SWIFT
 
       lldb_private::DataExtractor data;
 
@@ -922,6 +928,7 @@ public:
     PersistentExpressionState *persistent_state = nullptr;
 
     if (m_type.GetMinimumLanguage() == lldb::eLanguageTypeSwift) {
+#ifdef LLDB_ENABLE_SWIFT
       Status status;
       auto type_system =
           target_sp->GetScratchSwiftASTContext(status, *exe_scope).get();
@@ -933,6 +940,7 @@ public:
       }
       persistent_state =
           target_sp->GetSwiftPersistentExpressionState(*exe_scope);
+#endif // LLDB_ENABLE_SWIFT
     } else {
       auto type_system_or_err =
           target_sp->GetScratchTypeSystemForLanguage(m_type.GetMinimumLanguage());

--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -399,12 +399,15 @@ UserExpression::Execute(DiagnosticManager &diagnostic_manager,
       diagnostic_manager, exe_ctx, options, shared_ptr_to_me, result_var);
   Target *target = exe_ctx.GetTargetPtr();
   if (options.GetResultIsInternal() && result_var && target) {
+#ifdef LLDB_ENABLE_SWIFT
     if (m_language == lldb::eLanguageTypeSwift) {
       if (auto *exe_scope = exe_ctx.GetBestExecutionContextScope())
         if (auto *persistent_state =
                 target->GetSwiftPersistentExpressionState(*exe_scope))
           persistent_state->RemovePersistentVariable(result_var);
-    } else if (auto *persistent_state =
+    } else
+#endif // LLDB_ENABLE_SWIFT
+    if (auto *persistent_state =
                    target->GetPersistentExpressionStateForLanguage(m_language))
       persistent_state->RemovePersistentVariable(result_var);
   }

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.cpp
@@ -17,11 +17,12 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/StreamString.h"
 
+#ifdef LLDB_ENABLE_SWIFT
 #include "lldb/Symbol/SwiftASTContext.h" // Needed for llvm::isa<SwiftASTContext>(...)
 #include "lldb/Symbol/TypeSystem.h"
-
 #include "swift/AST/Decl.h"
 #include "swift/AST/Pattern.h"
+#endif // LLDB_ENABLE_SWIFT
 #include "clang/AST/Decl.h"
 
 #include "llvm/ADT/StringMap.h"

--- a/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
@@ -12,7 +12,6 @@
 #include "lldb/Breakpoint/StoppointCallbackContext.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Symbol/Symbol.h"
 #include "lldb/Symbol/SymbolContext.h"
 #include "lldb/Symbol/Variable.h"
@@ -24,9 +23,12 @@
 #include "lldb/Target/Target.h"
 #include "lldb/Target/Thread.h"
 #include "lldb/Utility/RegularExpression.h"
+#ifdef LLDB_ENABLE_SWIFT
+#include "lldb/Symbol/SwiftASTContext.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#endif // LLDB_ENABLE_SWIFT
 
 #include <memory>
 
@@ -82,6 +84,7 @@ bool InstrumentationRuntimeMainThreadChecker::CheckIfRuntimeIsValid(
   return symbol != nullptr;
 }
 
+#ifdef LLDB_ENABLE_SWIFT
 static std::string TranslateObjCNameToSwiftName(std::string className,
                                                 std::string selector,
                                                 StackFrameSP swiftFrame) {
@@ -155,6 +158,7 @@ static std::string TranslateObjCNameToSwiftName(std::string className,
   llvm::SmallString<32> scratchSpace;
   return className + "." + consumer.result.getString(scratchSpace).str();
 }
+#endif // LLDB_ENABLE_SWIFT
 
 StructuredData::ObjectSP
 InstrumentationRuntimeMainThreadChecker::RetrieveReportData(
@@ -221,7 +225,8 @@ InstrumentationRuntimeMainThreadChecker::RetrieveReportData(
     lldb::addr_t PC = addr.GetLoadAddress(&target);
     trace->AddItem(StructuredData::ObjectSP(new StructuredData::Integer(PC)));
   }
-  
+
+#ifdef LLDB_ENABLE_SWIFT
   if (responsible_frame) {
     if (responsible_frame->GetLanguage() == eLanguageTypeSwift) {
       std::string swiftApiName =
@@ -230,7 +235,8 @@ InstrumentationRuntimeMainThreadChecker::RetrieveReportData(
         apiName = swiftApiName;
     }
   }
-  
+#endif // LLDB_ENABLE_SWIFT
+
   auto *d = new StructuredData::Dictionary();
   auto dict_sp = StructuredData::ObjectSP(d);
   d->AddStringItem("instrumentation_class", "MainThreadChecker");

--- a/lldb/source/Symbol/Symtab.cpp
+++ b/lldb/source/Symbol/Symtab.cpp
@@ -24,7 +24,9 @@
 
 #include "llvm/ADT/StringRef.h"
 
+#ifdef LLDB_ENABLE_SWIFT
 #include "lldb/Target/SwiftLanguageRuntime.h"
+#endif // LLDB_ENABLE_SWIFT
 
 using namespace lldb;
 using namespace lldb_private;
@@ -299,6 +301,7 @@ void Symtab::InitNameIndexes() {
         if (type == eSymbolTypeCode || type == eSymbolTypeResolver) {
           if (mangled.DemangleWithRichManglingInfo(rmc, lldb_skip_name))
             RegisterMangledNameEntry(value, class_contexts, backlog, rmc);
+#ifdef LLDB_ENABLE_SWIFT
 	  else if (SwiftLanguageRuntime::IsSwiftMangledName(name.GetStringRef())) {
             lldb_private::ConstString basename;
             bool is_method = false;
@@ -314,6 +317,7 @@ void Symtab::InitNameIndexes() {
               }
             }
           }
+#endif // LLDB_ENABLE_SWIFT
         }
       }
 

--- a/lldb/source/Target/ABI.cpp
+++ b/lldb/source/Target/ABI.cpp
@@ -93,10 +93,12 @@ ValueObjectSP ABI::GetReturnValueObject(Thread &thread, CompilerType &ast_type,
     lldb::LanguageType lang = ast_type.GetMinimumLanguage();
     PersistentExpressionState *persistent_expression_state;
     Target &target = *thread.CalculateTarget();
+#ifdef LLDB_ENABLE_SWIFT
     if (lang == lldb::eLanguageTypeSwift)
       persistent_expression_state = 
         target.GetSwiftPersistentExpressionState(thread);
     else
+#endif // LLDB_ENABLE_SWIFT
       persistent_expression_state =
         target.GetPersistentExpressionStateForLanguage(lang);
     

--- a/lldb/source/Target/ThreadPlanCallFunction.cpp
+++ b/lldb/source/Target/ThreadPlanCallFunction.cpp
@@ -417,6 +417,7 @@ void ThreadPlanCallFunction::SetBreakpoints() {
       m_objc_language_runtime->SetExceptionBreakpoints();
     }
   }
+#ifdef LLDB_ENABLE_SWIFT
   if (GetExpressionLanguage() == eLanguageTypeSwift) {
     auto *swift_runtime 
         = SwiftLanguageRuntime::Get(m_process.shared_from_this());
@@ -436,6 +437,7 @@ void ThreadPlanCallFunction::SetBreakpoints() {
       }
     }
   }
+#endif // LLDB_ENABLE_SWIFT
 }
 
 void ThreadPlanCallFunction::ClearBreakpoints() {
@@ -492,6 +494,7 @@ bool ThreadPlanCallFunction::BreakpointsExplainStop() {
               eLanguageTypeSwift);
       if (!persistent_state)
         return false;
+#ifdef LLDB_ENABLE_SWIFT
       ConstString persistent_variable_name(
           persistent_state->GetNextPersistentVariableName(/*is_error*/ true));
       if (m_return_valobj_sp = SwiftLanguageRuntime::CalculateErrorValue(
@@ -513,6 +516,7 @@ bool ThreadPlanCallFunction::BreakpointsExplainStop() {
         m_hit_error_backstop = true;
         return true;
       }
+#endif // LLDB_ENABLE_SWIFT
     }
   }
 

--- a/lldb/source/Target/ThreadPlanStepOut.cpp
+++ b/lldb/source/Target/ThreadPlanStepOut.cpp
@@ -175,6 +175,7 @@ ThreadPlanStepOut::ThreadPlanStepOut(
 
   if (frame_idx == 0) {
     StackFrameSP frame_sp = GetThread().GetStackFrameAtIndex(0);
+#ifdef LLDB_ENABLE_SWIFT
     if (frame_sp->GuessLanguage() == eLanguageTypeSwift) {
       auto *swift_runtime 
           = SwiftLanguageRuntime::Get(m_process.shared_from_this());
@@ -184,6 +185,7 @@ ThreadPlanStepOut::ThreadPlanStepOut(
                 frame_sp, m_swift_error_check_after_return);
       }
     }
+#endif // LLDB_ENABLE_SWIFT
   }
 }
 
@@ -545,6 +547,7 @@ void ThreadPlanStepOut::CalculateReturnValue() {
     return;
   // First check if we have an error return address, and if that pointer
   // contains a valid error return, grab it.
+#ifdef LLDB_ENABLE_SWIFT
   auto *swift_runtime = SwiftLanguageRuntime::Get(m_process.shared_from_this());
   if (swift_runtime) {
     // In some ABI's the error is in a memory location in the caller's frame
@@ -572,6 +575,7 @@ void ThreadPlanStepOut::CalculateReturnValue() {
       return;
     }
   }
+#endif // LLDB_ENABLE_SWIFT
 
   // We don't have a swift error, so let's compute the actual return:
   if (m_immediate_step_from_function != nullptr) {

--- a/lldb/source/lldb.cpp
+++ b/lldb/source/lldb.cpp
@@ -12,7 +12,9 @@ using namespace lldb;
 using namespace lldb_private;
 
 #include "clang/Basic/Version.h"
+#ifdef LLDB_ENABLE_SWIFT
 #include "swift/Basic/Version.h"
+#endif // LLDB_ENABLE_SWIFT
 
 #ifdef HAVE_VCS_VERSION_INC
 #include "VCSVersion.inc"
@@ -76,8 +78,10 @@ const char *lldb_private::GetVersion() {
       g_version_str += " (buildbot " + build_date + ")";
 #endif
 
+#ifdef LLDB_ENABLE_SWIFT
     auto const swift_version = swift::version::getSwiftFullVersion();
     g_version_str += "\n" + swift_version;
+#endif // LLDB_ENABLE_SWIFT
 
     // getSwiftFullVersion() also prints clang and llvm versions, no
     // need to print them again. We keep this code here to not diverge


### PR DESCRIPTION
… support is enabled.

With this commit turning of LLDB_ENABLE_SWIFT_SUPPORT will also unset the
LLDB_ENABLE_SWIFT define. It also puts all LLDB code that depends on Swift
behind an #ifdef LLDB_ENABLE_SWIFT so that we can now build an LLDB that
is as close as possible to a LLDB with Swift support without actually needing
any Swift code.