### PR TITLE
[FileCollector] Lock Mutex in copyFiles

### DIFF
--- a/llvm/include/llvm/Support/FileCollector.h
+++ b/llvm/include/llvm/Support/FileCollector.h
@@ -69,7 +69,7 @@ protected:
   addDirectoryImpl(const llvm::Twine &Dir,
                    IntrusiveRefCntPtr<vfs::FileSystem> FS, std::error_code &EC);
 
-  /// Synchronizes adding files.
+  /// Synchronizes access to Seen, VFSWriter and SymlinkMap.
   std::mutex Mutex;
 
   /// The root directory where files are copied.

--- a/llvm/lib/Support/FileCollector.cpp
+++ b/llvm/lib/Support/FileCollector.cpp
@@ -150,6 +150,8 @@ copyAccessAndModificationTime(StringRef Filename,
 }
 
 std::error_code FileCollector::copyFiles(bool StopOnError) {
+  std::lock_guard<std::mutex> lock(Mutex);
+
   for (auto &entry : VFSWriter.getMappings()) {
     // Create directory tree.
     if (std::error_code EC =


### PR DESCRIPTION
We should synchronize reading of VFSWriter's data with the rest of the methods.

Differential revision: https://reviews.llvm.org/D78956

(cherry picked from commit 1e43cab3c6724b2f9089a0a2b42e8dfdfdd1a299)