### PR TITLE
[AST] Fix a crash on a dependent vector_size attribute

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -3629,10 +3629,10 @@ ASTContext::getDependentVectorType(QualType VecType, Expr *SizeExpr,
       (void)CanonCheck;
       DependentVectorTypes.InsertNode(New, InsertPos);
     } else {
-      QualType Canon = getDependentSizedExtVectorType(CanonVecTy, SizeExpr,
-                                                      SourceLocation());
+      QualType CanonTy = getDependentVectorType(CanonVecTy, SizeExpr,
+                                                SourceLocation(), VecKind);
       New = new (*this, TypeAlignment) DependentVectorType(
-          *this, VecType, Canon, SizeExpr, AttrLoc, VecKind);
+          *this, VecType, CanonTy, SizeExpr, AttrLoc, VecKind);
     }
   }
 

--- a/clang/test/SemaCXX/vector.cpp
+++ b/clang/test/SemaCXX/vector.cpp
@@ -400,3 +400,12 @@ namespace swizzle_typo_correction {
     return A.xyzw < B.x && B.y > A.y; // OK, not a typo for 'xyzv'
   }
 }
+
+namespace rdar60092165 {
+template <class T> void f() {
+  typedef T first_type __attribute__((vector_size(sizeof(T) * 4)));
+  typedef T second_type __attribute__((vector_size(sizeof(T) * 4)));
+
+  second_type st;
+}
+}


### PR DESCRIPTION
Looks like this was just a copy & paste mistake from
getDependentSizedExtVectorType. rdar://60092165

Differential revision: https://reviews.llvm.org/D79012

Conflicts:
	clang/lib/AST/ASTContext.cpp
	clang/test/SemaCXX/vector.cpp