### PR TITLE
Fix a dangling-gsl warning and avoid transitively including string.

### DIFF
--- a/lldb/include/lldb/Utility/XcodeSDK.h
+++ b/lldb/include/lldb/Utility/XcodeSDK.h
@@ -47,6 +47,7 @@ public:
   void Merge(XcodeSDK other);
 
   XcodeSDK &operator=(XcodeSDK other);
+  XcodeSDK(const XcodeSDK&) = default;
   bool operator==(XcodeSDK other);
 
   /// A parsed SDK directory name.

--- a/lldb/source/Utility/XcodeSDK.cpp
+++ b/lldb/source/Utility/XcodeSDK.cpp
@@ -10,6 +10,7 @@
 #include "lldb/Utility/XcodeSDK.h"
 
 #include "lldb/lldb-types.h"
+#include <string>
 
 using namespace lldb;
 using namespace lldb_private;
@@ -187,7 +188,7 @@ bool XcodeSDK::SDKSupportsModules(XcodeSDK::Type desired_type,
     const std::string sdk_name_lower = sdk_name.lower();
     Info info;
     info.type = desired_type;
-    const llvm::StringRef sdk_string = GetCanonicalName(info);
+    const std::string sdk_string = GetCanonicalName(info);
     if (!llvm::StringRef(sdk_name_lower).startswith(sdk_string))
       return false;
 


### PR DESCRIPTION
(cherry picked from commit 6a9edce25778e6c131914ab2e6c3f8528785a8df)