### PR TITLE
[5.3] Update diagnostic text in tests matching Swift PR #31384

### DIFF
--- a/lldb/test/API/lang/cpp/static_members/TestCPPStaticMembers.py
+++ b/lldb/test/API/lang/cpp/static_members/TestCPPStaticMembers.py
@@ -45,7 +45,7 @@ class CPPStaticMembersTestCase(TestBase):
 
         # should not be available in global scope
         self.expect("expression s_d",
-                    startstr="error: use of undeclared identifier 's_d'")
+                    startstr="error: cannot find 's_d' in scope")
 
         self.runCmd("process continue")
         self.expect("expression m_c",

--- a/lldb/test/API/lang/swift/closure_shortcuts/main.swift
+++ b/lldb/test/API/lang/swift/closure_shortcuts/main.swift
@@ -14,7 +14,7 @@ func main() -> Int {
 
   return 0 //%self.expect('expr tinky.map({$0 * 2})', substrs=['[0] = 4', '[1] = 8'])
            //%self.expect('expr [2,4].map({$0 * 2})', substrs=['[0] = 4', '[1] = 8'])
-           //%self.expect('expr $0', substrs=['unresolved identifier \'$0\''], error=True)
+           //%self.expect('expr $0', substrs=['cannot find \'$0\' in scope'], error=True)
 }
 
 _ = main()

--- a/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
+++ b/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
@@ -46,7 +46,7 @@ class TestSwiftExpressionObjCContext(TestBase):
         # This is expected to fail because we can't yet import ObjC
         # modules into a Swift context.
         self.expect("expr -lang Swift -- Bar()", "failure",
-                    substrs=["unresolved identifier 'Bar'"],
+                    substrs=["cannot find 'Bar' in scope"],
                     error=True)
         self.expect("expr -lang Swift -- [1, 2, 3]",
                     "context-less swift expression works",

--- a/lldb/test/API/lang/swift/swift_reference_counting/main.swift
+++ b/lldb/test/API/lang/swift/swift_reference_counting/main.swift
@@ -24,7 +24,7 @@ func lambda(_ Arg : Patatino) -> Int {
 }
 
 func main() -> Int {
-  var LiveObj = Patatino(37) //%self.expect('language swift refcount Blah', substrs=['unresolved identifier \'Blah\''], error=True)
+  var LiveObj = Patatino(37) //%self.expect('language swift refcount Blah', substrs=['cannot find \'Blah\' in scope'], error=True)
   var Ret : Int = lambda(LiveObj) //%self.expect('language swift refcount LiveObj', substrs=['(strong =', 'unowned =', 'weak ='])
   var MyStruct = Tinky() //%self.expect('language swift refcount MyStruct', substrs=['refcount only available for class types'], error=True)
   return Ret

--- a/lldb/test/Shell/SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
+++ b/lldb/test/Shell/SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
@@ -27,7 +27,7 @@
 import AA
 
 let x: OtherType = testValue
-// NOT-LOADED: use of undeclared type 'OtherType'
+// NOT-LOADED: cannot find type 'OtherType' in scope
 // FROM-INTERFACE: cannot convert value of type 'FromInterface' to specified type 'OtherType'
 // FROM-SERIALIZED: cannot convert value of type 'FromSerialized' to specified type 'OtherType'
 // INVALID: error: invalid enumeration value '{{.*}}', valid values are: {{.*}}

--- a/lldb/test/Shell/SymbolFile/DWARF/debug-types-missing-signature.test
+++ b/lldb/test/Shell/SymbolFile/DWARF/debug-types-missing-signature.test
@@ -15,10 +15,10 @@ RUN: %lldb %t -b -o "type lookup EC" | FileCheck --check-prefix=LOOKUPEC %s
 LOOKUPEC: no type was found matching 'EC'
 
 RUN: %lldb %t -b -o "print (E) 1" 2>&1 | FileCheck --check-prefix=PRINTE %s
-PRINTE: use of undeclared identifier 'E'
+PRINTE: cannot find 'E' in scope
 
 RUN: %lldb %t -b -o "print (EC) 1" 2>&1 | FileCheck --check-prefix=PRINTEC %s
-PRINTEC: use of undeclared identifier 'EC'
+PRINTEC: cannot find 'EC' in scope
 
 RUN: %lldb %t -b -o "target variable a e ec" | FileCheck --check-prefix=VARS %s
 VARS: (const (anonymous struct)) a = {}


### PR DESCRIPTION
Cherry-pick https://github.com/apple/llvm-project/pull/1128 onto 5.3.