### PR TITLE
[lldb] Improve error message when --func-regex parameter for the brea…

### DIFF
--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -620,7 +620,7 @@ protected:
       RegularExpression regexp(m_options.m_func_regexp);
       if (llvm::Error err = regexp.GetError()) {
         result.AppendErrorWithFormat(
-            "Function name regular expression could not be compiled: \"%s\"",
+            "Function name regular expression could not be compiled: %s",
             llvm::toString(std::move(err)).c_str());
         result.SetStatus(eReturnStatusFailed);
         return false;

--- a/lldb/source/Utility/RegularExpression.cpp
+++ b/lldb/source/Utility/RegularExpression.cpp
@@ -35,7 +35,7 @@ llvm::StringRef RegularExpression::GetText() const { return m_regex_text; }
 llvm::Error RegularExpression::GetError() const {
   std::string error;
   if (!m_regex.isValid(error))
-    return llvm::make_error<llvm::StringError>(llvm::inconvertibleErrorCode(),
-                                               error);
+    return llvm::make_error<llvm::StringError>(error,
+                                               llvm::inconvertibleErrorCode());
   return llvm::Error::success();
 }

--- a/lldb/test/API/commands/breakpoint/set/func-regex/TestBreakpointRegexError.py
+++ b/lldb/test/API/commands/breakpoint/set/func-regex/TestBreakpointRegexError.py
@@ -1,0 +1,14 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+class TestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @no_debug_info_test
+    def test_error(self):
+        self.expect("breakpoint set --func-regex (", error=True,
+                    substrs=["error: Function name regular expression could " +
+                             "not be compiled: parentheses not balanced"])


### PR DESCRIPTION
…kpoint command is invalid

Summary:
Currently the breakpoint command is prompting the user to file a bug report if the provided regex is invalid:
```
(lldb) rbreak *foo
error: Function name regular expression could not be compiled: "Inconvertible error value. An error has occurred that could not be converted to a known std::error_code. Please file a bug. repetition-operator operand invalid"
```

The reason is simply that we are using the wrong StringError constructor (the one with the error code as the first parameter
is also printing the string version of the error code, and the inconvertible error code is just an invalid place holder code with
that description). Switching the StringError constructor parameters will only print the error message we get from the regex
engine when we convert the error into a string.

I checked the rest of the code base and I couldn't find the same issue anywhere else.

Fixes rdar://62233561

Reviewers: JDevlieghere

Reviewed By: JDevlieghere

Subscribers: lldb-commits

Differential Revision: https://reviews.llvm.org/D78808

(cherry picked from commit b58af8d254ee1b1a7d2806b1fdfe295df925748a)