### PR TITLE
[lldb] Fix typo in breakpoint set -r description

### DIFF
--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -152,7 +152,7 @@ let Command = "breakpoint set" in {
     "multiple times tomake one breakpoint for multiple methods.">;
   def breakpoint_set_func_regex : Option<"func-regex", "r">, Group<7>,
     Arg<"RegularExpression">, Required, Desc<"Set the breakpoint by function "
-    "name, evaluating a regular-expression to findthe function name(s).">;
+    "name, evaluating a regular-expression to find the function name(s).">;
   def breakpoint_set_basename : Option<"basename", "b">, Group<8>,
     Arg<"FunctionName">, Required, Completion<"Symbol">,
     Desc<"Set the breakpoint by function basename (C++ namespaces and arguments"


### PR DESCRIPTION
(cherry picked from commit e327ea4a82874f535b6ea93e39ea58643aef88bd)