### PR TITLE
Remove a duplicate flag in Makefile.rules

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -567,9 +567,6 @@ endif
 
 ifeq "$(USESWIFTDRIVER)" "1"
 	LDFLAGS +=-L"$(SWIFTLIBS)"
-	ifneq "$(TRIPLE)" ""
-		SWIFTFLAGS += -target $(TRIPLE)
-	endif
 	ifeq "$(OS)" "Darwin"
 		SWIFTFLAGS += -sdk "$(SWIFTSDKROOT)"
 	endif


### PR DESCRIPTION
The occurrence of
	ifneq "$(TRIPLE)" ""
		SWIFTFLAGS += -target $(TRIPLE)
	endif

on line 563 is completely redundant with

SWIFTFLAGS += $(TRIPLE_SWIFTFLAGS)

on line 317 and thus duplicates the -target flag.

<rdar://problem/62138197>

(cherry picked from commit 7ae6529b2671e5b24911527675b0e06411566307)