### PR TITLE
 Swift SR-12247: Convert ModuleDecl::ImportedModule from std::pair to struct 

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1267,7 +1267,7 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
                 swift::ModuleDecl::AccessPathTy access_path;
 
                 for (auto imported_module : swift::namelookup::getAllImports(module)) {
-                  auto module = imported_module.second;
+                  auto module = imported_module.importedModule;
                   TypesOrDecls local_results;
                   ast_ctx->FindTypesOrDecls(input, module, local_results,
                                             false);

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -4047,7 +4047,7 @@ void SwiftASTContext::LoadModule(swift::ModuleDecl *swift_module,
   };
 
   for (auto import : swift::namelookup::getAllImports(swift_module)) {
-    import.second->collectLinkLibraries(addLinkLibrary);
+    import.importedModule->collectLinkLibraries(addLinkLibrary);
   }
   error = current_error;
 }
@@ -8466,7 +8466,7 @@ bool SwiftASTContext::CacheUserImports(SwiftASTContext &swift_ast_context,
       sc.target_sp->GetSwiftPersistentExpressionState(exe_scope);
 
   for (auto module_pair : parsed_imports) {
-    swift::ModuleDecl *module = module_pair.second;
+    swift::ModuleDecl *module = module_pair.importedModule;
     if (module) {
       std::string module_name;
       GetNameFromModule(module, module_name);


### PR DESCRIPTION
This is to support the change above in lldb. @varungandhi-apple has been looking at this with me.