### PR TITLE
Revert part of be11447340e73b8

### DIFF
--- a/lldb/test/Shell/SymbolFile/DWARF/debug-types-missing-signature.test
+++ b/lldb/test/Shell/SymbolFile/DWARF/debug-types-missing-signature.test
@@ -15,10 +15,10 @@ RUN: %lldb %t -b -o "type lookup EC" | FileCheck --check-prefix=LOOKUPEC %s
 LOOKUPEC: no type was found matching 'EC'
 
 RUN: %lldb %t -b -o "print (E) 1" 2>&1 | FileCheck --check-prefix=PRINTE %s
-PRINTE: cannot find 'E' in scope
+PRINTE:  use of undeclared identifier 'E'
 
 RUN: %lldb %t -b -o "print (EC) 1" 2>&1 | FileCheck --check-prefix=PRINTEC %s
-PRINTEC: cannot find 'EC' in scope
+PRINTEC: use of undeclared identifier 'EC'
 
 RUN: %lldb %t -b -o "target variable a e ec" | FileCheck --check-prefix=VARS %s
 VARS: (const (anonymous struct)) a = {}


### PR DESCRIPTION
This update to the tests must have been generated using a regex
and never tested.