### PR TITLE
Revert "[lldb/Platform] Return a std::string from GetSDKPath"

### DIFF
--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -432,9 +432,7 @@ public:
     return lldb_private::ConstString();
   }
 
-  virtual std::string GetSDKPath(lldb_private::XcodeSDK sdk) {
-    return {};
-  }
+  virtual llvm::StringRef GetSDKPath(lldb_private::XcodeSDK sdk) { return {}; }
 
   const std::string &GetRemoteURL() const { return m_remote_url; }
 

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1761,12 +1761,12 @@ PlatformDarwin::FindXcodeContentsDirectoryInPath(llvm::StringRef path) {
   return {};
 }
 
-std::string PlatformDarwin::GetSDKPath(XcodeSDK sdk) {
+llvm::StringRef PlatformDarwin::GetSDKPath(XcodeSDK sdk) {
   std::lock_guard<std::mutex> guard(m_sdk_path_mutex);
   std::string &path = m_sdk_path[sdk.GetString()];
-  if (!path.empty())
-    return path;
-  return HostInfo::GetXcodeSDK(sdk);
+  if (path.empty())
+    path = HostInfo::GetXcodeSDK(sdk);
+  return path;
 }
 
 FileSpec PlatformDarwin::GetXcodeContentsDirectory() {

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -90,7 +90,7 @@ public:
   llvm::Expected<lldb_private::StructuredData::DictionarySP>
   FetchExtendedCrashInformation(lldb_private::Process &process) override;
 
-  std::string GetSDKPath(lldb_private::XcodeSDK sdk) override;
+  llvm::StringRef GetSDKPath(lldb_private::XcodeSDK sdk) override;
 
   static lldb_private::FileSpec GetXcodeContentsDirectory();
   static lldb_private::FileSpec GetXcodeDeveloperDirectory();


### PR DESCRIPTION
This reverts commit b14c37a29a5455853419f5fe0605f6023c51de89.

And restores the caching functionality!