### PR TITLE
[lldb] Adjust for upstream 4b354039423f

### DIFF
--- a/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
+++ b/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
@@ -3105,6 +3105,7 @@ bool SetNumberFromPyObject<double>(double &number, PyObject *obj) {
 #include "lldb/API/SBBreakpointName.h"
 #include "lldb/API/SBBroadcaster.h"
 #include "lldb/API/SBCommandInterpreter.h"
+#include "lldb/API/SBCommandInterpreterRunOptions.h"
 #include "lldb/API/SBCommandReturnObject.h"
 #include "lldb/API/SBCommunication.h"
 #include "lldb/API/SBCompileUnit.h"


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/4b354039423f moves
SBCommandInterpreterRunOption into its own header, so we need to include
that header now, otherwise the SBCommandInterpreterRunOption type is
incomplete and we get build failures.