### PR TITLE
Test that clang flags pointing into an SDK on a different machine are…

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/Makefile
@@ -1,0 +1,29 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -Xcc -I$(BUILD_SDK)/usr/include/net
+
+include Makefile.rules
+
+BUILD_SDK := $(BUILDDIR)/LocalSDK/$(shell basename $(SDKROOT))
+
+$(EXE): $(SWIFT_SOURCES)
+	rm -rf $(BUILDDIR)/LocalSDK
+	echo "Symlinking iOS SDK into build directory as a fake macOS SDK"
+	mkdir $(BUILDDIR)/LocalSDK
+	ln -s $(SDKROOT) $(BUILD_SDK)
+	echo "Building using SDK in build directory"
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		SDKROOT=$(BUILD_SDK) \
+		SWIFTFLAGS_EXTRAS="$(SWIFTFLAGS_EXTRAS)" \
+		-f  $(SRCDIR)/helper.mk clean main.o a.swiftmodule
+	echo "Sanity check that our SDK shenanigns worked"
+	dwarfdump -r 0 $(BUILDDIR)/main.o | grep DW_AT_LLVM_isysroot | grep -q LocalSDK
+	echo "Linking with regular SDK (otherwise the linker complains)"
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		SDKROOT=$(SDKROOT) \
+		-f  $(SRCDIR)/helper.mk all
+	echo "Deleting build SDK"
+	rm -rf $(BUILDDIR)/LocalSDK

--- a/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
+++ b/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
@@ -1,0 +1,35 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+class TestSwiftRewriteClangPaths(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    @expectedFailureAll(debug_info='dwarf', bugnumber="rdar://problem/62750529")
+    @skipUnlessDarwin
+    @skipIfDarwinEmbedded
+    @swiftTest
+    def test(self):
+        """Test that clang flags pointing into an SDK on a different machine are remapped"""
+        self.build()
+        log = self.getBuildArtifact("types.log")
+        self.runCmd('log enable lldb types -f "%s"' % log)
+        target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(
+            self, 'main')
+        self.expect("p 1", "1")
+
+        # Scan through the types log.
+        logfile = open(log, "r")
+        found = 0
+        for line in logfile:
+            if line.startswith(' SwiftASTContext("a.out")::RemapClangImporterOptions() -- remapped'):
+                if '/LocalSDK/' in line:
+                    found += 1
+        self.assertEqual(found, 1)

--- a/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/helper.mk
+++ b/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/helper.mk
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/main.swift
@@ -1,0 +1,1 @@
+// This space left intentionally blank.


### PR DESCRIPTION
… remapped.

This test is currently XFAILed for debug maps, because the path
remaping dictionaries of the OSOs aren't accessible to the main module
yet.

<rdar://problem/62750529>