### PR TITLE
[lldb/DWARF] Fix a leak in line table construction

### DIFF
--- a/lldb/include/lldb/Symbol/LineTable.h
+++ b/lldb/include/lldb/Symbol/LineTable.h
@@ -42,6 +42,13 @@ public:
   ///     The compile unit to which this line table belongs.
   LineTable(CompileUnit *comp_unit);
 
+  /// Construct with entries found in \a sequences.
+  ///
+  /// \param[in] sequences
+  ///     Unsorted list of line sequences.
+  LineTable(CompileUnit *comp_unit,
+            std::vector<std::unique_ptr<LineSequence>> &&sequences);
+
   /// Destructor.
   ~LineTable();
 
@@ -64,7 +71,7 @@ public:
                        bool is_epilogue_begin, bool is_terminal_entry);
 
   // Used to instantiate the LineSequence helper class
-  LineSequence *CreateLineSequenceContainer();
+  static std::unique_ptr<LineSequence> CreateLineSequenceContainer();
 
   // Append an entry to a caller-provided collection that will later be
   // inserted in this line table.
@@ -259,6 +266,8 @@ protected:
     public:
       LessThanBinaryPredicate(LineTable *line_table);
       bool operator()(const LineTable::Entry &, const LineTable::Entry &) const;
+      bool operator()(const std::unique_ptr<LineSequence> &,
+                      const std::unique_ptr<LineSequence> &) const;
 
     protected:
       LineTable *m_line_table;

--- a/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
@@ -1817,7 +1817,7 @@ bool SymbolFilePDB::ParseCompileUnitLineTable(CompileUnit &comp_unit,
             prev_source_idx, false, false, false, false, true);
 
         line_table->InsertSequence(sequence.release());
-        sequence.reset(line_table->CreateLineSequenceContainer());
+        sequence = line_table->CreateLineSequenceContainer();
       }
 
       if (ShouldAddLine(match_line, lno, length)) {
@@ -1854,7 +1854,7 @@ bool SymbolFilePDB::ParseCompileUnitLineTable(CompileUnit &comp_unit,
           prev_source_idx, false, false, false, false, true);
     }
 
-    line_table->InsertSequence(sequence.release());
+    line_table->InsertSequence(sequence.get());
   }
 
   if (line_table->GetSize()) {


### PR DESCRIPTION
We were creating a bunch of LineSequence objects but never deleting
them.

This fixes the leak and changes the code to use std::unique_ptr, to make
it harder to make the same mistake again.