### PR TITLE
Add support for the dynamic self type.

### DIFF
--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -5350,6 +5350,11 @@ bool SwiftASTContext::IsPossibleDynamicType(void *type,
         can_type->isAnyExistentialType())
       return true;
 
+    // Dynamic Self types are resolved inside DoArchetypeBindingForType(),
+    // right before the actual archetype binding.
+    if (can_type->hasDynamicSelfType())
+      return true;
+
     if (can_type->hasArchetype() || can_type->hasOpaqueArchetype() ||
         can_type->hasTypeParameter())
       return true;
@@ -5711,6 +5716,8 @@ SwiftASTContext::GetTypeInfo(void *type,
     swift_flags |= eTypeHasChildren | eTypeIsReference | eTypeHasValue;
     break;
   case swift::TypeKind::DynamicSelf:
+    swift_flags |= eTypeIsGeneric | eTypeIsBound | eTypeHasValue;
+    break;
   case swift::TypeKind::SILBox:
   case swift::TypeKind::SILFunction:
   case swift::TypeKind::SILBlockStorage:

--- a/lldb/test/API/lang/swift/dynamic_self/Makefile
+++ b/lldb/test/API/lang/swift/dynamic_self/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/dynamic_self/TestSwiftDynamicSelf.py
+++ b/lldb/test/API/lang/swift/dynamic_self/TestSwiftDynamicSelf.py
@@ -1,0 +1,27 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+class TestSwiftDynamicSelf(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    def test_dynamic_self(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        frame = thread.frames[0]
+        var_self = frame.FindVariable("self")
+        self.assertEqual(var_self.GetNumChildren(), 0)
+        dyn_self = var_self.GetDynamicValue(True)
+        self.assertEqual(dyn_self.GetNumChildren(), 1)
+        var_self_base = dyn_self.GetChildAtIndex(0)
+        member_c = var_self_base.GetChildMemberWithName("c")
+        member_v = var_self_base.GetChildMemberWithName("v")
+        lldbutil.check_variable(self, member_c, False, value="100")
+        lldbutil.check_variable(self, member_v, False, value="210")

--- a/lldb/test/API/lang/swift/dynamic_self/main.swift
+++ b/lldb/test/API/lang/swift/dynamic_self/main.swift
@@ -1,0 +1,20 @@
+class Base {
+  func show() -> Self {
+    return self
+  }
+  let c = 100
+  var v = 200
+}
+
+func use<T>(_ t: T) {}
+
+class Child : Base {
+  override func show() -> Self {
+    v += 10
+    use((self.c, self.v)) // break here
+    return self
+  }
+}
+
+var child = Child()
+child.show()


### PR DESCRIPTION
This is implemented by treating types that include dynamic self types
as dynamic, and resolving every dynamic self type to its static self
type right before doing the archetype binding.

<rdar://problem/59499479>