### PR TITLE
[lldb/SwiftUserExpression] Simplify ScanContext logic

### DIFF
--- a/lldb/include/lldb/Expression/Expression.h
+++ b/lldb/include/lldb/Expression/Expression.h
@@ -51,7 +51,9 @@ public:
 
   /// Return the language that should be used when parsing.  To use the
   /// default, return eLanguageTypeUnknown.
-  virtual lldb::LanguageType Language() { return lldb::eLanguageTypeUnknown; }
+  virtual lldb::LanguageType Language() const {
+    return lldb::eLanguageTypeUnknown;
+  }
 
   /// Return the Materializer that the parser should use when registering
   /// external values.

--- a/lldb/include/lldb/Expression/UserExpression.h
+++ b/lldb/include/lldb/Expression/UserExpression.h
@@ -194,7 +194,7 @@ public:
 
   /// Return the language that should be used when parsing.  To use the
   /// default, return eLanguageTypeUnknown.
-  lldb::LanguageType Language() override { return m_language; }
+  lldb::LanguageType Language() const override { return m_language; }
 
   /// Return the desired result type of the function, or eResultTypeAny if
   /// indifferent.

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -101,8 +101,7 @@ static bool isSwiftLanguageSymbolContext(const SwiftUserExpression &expr,
                                          const SymbolContext &sym_ctx) {
   if (sym_ctx.comp_unit && (expr.Language() == lldb::eLanguageTypeUnknown ||
                             expr.Language() == lldb::eLanguageTypeSwift)) {
-    if (sym_ctx.comp_unit->GetLanguage() == lldb::eLanguageTypeSwift ||
-        sym_ctx.comp_unit->GetLanguage() == lldb::eLanguageTypePLI)
+    if (sym_ctx.comp_unit->GetLanguage() == lldb::eLanguageTypeSwift)
       return true;
   } else if (sym_ctx.symbol && expr.Language() == lldb::eLanguageTypeUnknown) {
     if (sym_ctx.symbol->GetMangled().GuessLanguage() ==

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -36,7 +36,7 @@ class SwiftExpressionParser;
 /// LLDB uses expressions for various purposes, notably to call functions
 /// and as a backend for the expr command.  SwiftUserExpression encapsulates
 /// the objects needed to parse and interpret or JIT an expression.  It
-/// uses the Clang parser to produce LLVM IR from the expression.
+/// uses the Swift parser to produce LLVM IR from the expression.
 //----------------------------------------------------------------------
 class SwiftUserExpression : public LLVMUserExpression {
   // LLVM RTTI support


### PR DESCRIPTION
- Remove redundant null checks
- Add missing logging information
- Avoid re-computing the type of self and its type flags