### PR TITLE
[lldb] Warn the user about starting the --func-regex parameter with a…

### DIFF
--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -622,6 +622,14 @@ protected:
         result.AppendErrorWithFormat(
             "Function name regular expression could not be compiled: %s",
             llvm::toString(std::move(err)).c_str());
+        // Check if the incorrect regex looks like a globbing expression and
+        // warn the user about it.
+        if (!m_options.m_func_regexp.empty()) {
+          if (m_options.m_func_regexp[0] == '*' ||
+              m_options.m_func_regexp[0] == '?')
+            result.AppendWarning(
+                "Function name regex does not accept glob patterns.");
+        }
         result.SetStatus(eReturnStatusFailed);
         return false;
       }

--- a/lldb/test/API/commands/breakpoint/set/func-regex/TestBreakpointRegexError.py
+++ b/lldb/test/API/commands/breakpoint/set/func-regex/TestBreakpointRegexError.py
@@ -12,3 +12,19 @@ class TestCase(TestBase):
         self.expect("breakpoint set --func-regex (", error=True,
                     substrs=["error: Function name regular expression could " +
                              "not be compiled: parentheses not balanced"])
+
+        # Point out if looks like the user provided a globbing expression.
+        self.expect("breakpoint set --func-regex *a", error=True,
+                    substrs=["error: Function name regular expression could " +
+                             "not be compiled: repetition-operator operand invalid",
+                             "warning: Function name regex does not accept glob patterns."])
+        self.expect("breakpoint set --func-regex ?a", error=True,
+                    substrs=["error: Function name regular expression could " +
+                             "not be compiled: repetition-operator operand invalid",
+                             "warning: Function name regex does not accept glob patterns."])
+        # Make sure that warning is only shown for invalid regular expressions
+        # that look like a globbing expression (i.e., they have a leading * or ?).
+        self.expect("breakpoint set --func-regex a*+", error=True, matching=False,
+                    substrs=["warning: Function name regex does not accept glob patterns."])
+        self.expect("breakpoint set --func-regex a?+", error=True, matching=False,
+                    substrs=["warning: Function name regex does not accept glob patterns."])


### PR DESCRIPTION
…n asterisk

Summary:
Sometimes users think that setting a function regex for all function that contain the word 'needle' in their
name looks like this: `*needle*`. However, LLDB only searches the function name and doesn't fully match
it against the regex, so the leading and trailing '*' operators don't do anything and actually just cause the
regex engine to reject the regular expression with "repetition-operator operand invalid".

This patch makes this a bit more obvious to the user by printing a warning that a leading '*' before this
regular expression here doesn't have any purpose (and will cause an error). This doesn't attempt to detect
a case where there is only a trailing '*' as that would involve parsing the regex and it seems the most
common way to end up in this situation is by doing `rbreak *needle*`.

Reviewers: JDevlieghere

Reviewed By: JDevlieghere

Differential Revision: https://reviews.llvm.org/D78809

Small follow-up for rdar://problem/62233561
(cherry picked from commit aaf68cd9ce2fda224e02fd0f860e6372b4b00e47)