### PR TITLE
Relax testcase.

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/Makefile
@@ -18,7 +18,7 @@ $(EXE): $(SWIFT_SOURCES)
 		SWIFTFLAGS_EXTRAS="$(SWIFTFLAGS_EXTRAS)" \
 		-f  $(SRCDIR)/helper.mk clean main.o a.swiftmodule
 	echo "Sanity check that our SDK shenanigns worked"
-	dwarfdump -r 0 $(BUILDDIR)/main.o | grep DW_AT_LLVM_isysroot | grep -q LocalSDK
+	dwarfdump -r 0 $(BUILDDIR)/main.o | egrep 'DW_AT_LLVM_i?sysroot' | grep -q LocalSDK
 	echo "Linking with regular SDK (otherwise the linker complains)"
 	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \


### PR DESCRIPTION
The name of the attribute depends on the version of dwarfdump.

rdar://62945575
(cherry picked from commit d24388a276605dd0463e75eb61653a731d94150f)