### PR TITLE
Add a new lockdownd plist for launching posix processes

### DIFF
--- a/lldb/tools/debugserver/source/com.apple.debugserver.posix.internal.plist
+++ b/lldb/tools/debugserver/source/com.apple.debugserver.posix.internal.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.apple.debugserver.posix.internal</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Developer/usr/bin/debugserver</string>
+		<string>--lockdown</string>
+		<string>--launch=posix</string>
+	</array>
+    <key>AllowByProxy</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
Add a new lockdownd plist for launching posix processes

Similar to
com.apple.debugserver.plist & com.apple.debugserver.internal.plist
com.apple.debugserver.applist.plist & com.apple.debugserver.applist.internal.plist
add a variant of the posix plist.

<rdar://problem/62995567>

(cherry picked from commit 2ea7187ab9b7f0eab38a0b5be45c48b1f4f4938d)