### PR TITLE
[lldb] Make module-ownership.mm test more robust against AST node ord…

### DIFF
--- a/lldb/test/Shell/SymbolFile/DWARF/Inputs/ModuleOwnership/B.h
+++ b/lldb/test/Shell/SymbolFile/DWARF/Inputs/ModuleOwnership/B.h
@@ -1,5 +1,5 @@
 typedef struct {
-  int b;
+  int anon_field_b;
 } StructB;
 
 namespace Namespace {

--- a/lldb/test/Shell/SymbolFile/DWARF/module-ownership.mm
+++ b/lldb/test/Shell/SymbolFile/DWARF/module-ownership.mm
@@ -25,8 +25,8 @@ Struct s2;
 // CHECK-ANON-S1: CXXRecordDecl {{.*}} imported in A struct
 
 StructB s3;
-// CHECK-ANON-S2: CXXRecordDecl {{.*}} imported in A.B struct
-// CHECK-ANON-S2: -FieldDecl {{.*}} in A.B b 'int'
+// CHECK-ANON-S2: CXXRecordDecl {{.*}} imported in A.B {{.*}} struct
+// CHECK-ANON-S2: -FieldDecl {{.*}} in A.B anon_field_b 'int'
 
 Nested s4;
 // CHECK-DAG: CXXRecordDecl {{.*}} imported in A struct Nested

--- a/lldb/test/Shell/SymbolFile/DWARF/module-ownership.mm
+++ b/lldb/test/Shell/SymbolFile/DWARF/module-ownership.mm
@@ -1,6 +1,8 @@
 // RUN: %clang --target=x86_64-apple-macosx -g -gmodules \
 // RUN:    -fmodules -fmodules-cache-path=%t.cache \
 // RUN:    -c -o %t.o %s -I%S/Inputs
+// RUN: lldb-test symbols -dump-clang-ast %t.o | FileCheck --check-prefix CHECK-ANON-S1 %s
+// RUN: lldb-test symbols -dump-clang-ast %t.o | FileCheck --check-prefix CHECK-ANON-S2 %s
 // RUN: lldb-test symbols -dump-clang-ast %t.o | FileCheck %s
 // Verify that the owning module information from DWARF is preserved in the AST.
 
@@ -20,11 +22,11 @@ TopLevelStruct s1;
 // CHECK-TOPLEVELSTRUCT: -FieldDecl {{.*}} in A a 'int'
 
 Struct s2;
-// CHECK-DAG: CXXRecordDecl {{.*}} imported in A struct
+// CHECK-ANON-S1: CXXRecordDecl {{.*}} imported in A struct
 
 StructB s3;
-// CHECK-DAG: CXXRecordDecl {{.*}} imported in A.B struct
-// CHECK-DAG: -FieldDecl {{.*}} in A.B b 'int'
+// CHECK-ANON-S2: CXXRecordDecl {{.*}} imported in A.B struct
+// CHECK-ANON-S2: -FieldDecl {{.*}} in A.B b 'int'
 
 Nested s4;
 // CHECK-DAG: CXXRecordDecl {{.*}} imported in A struct Nested


### PR DESCRIPTION
…ering

The current test is checking both the anonymous structs and the template
specializations in one FileCheck run, but the anonymous struct line can
partially match the AST dump of a template specialization, causing that
FileCheck won't match that same line later against the template specialization
check and incorrectly fails on that check. This only happens when the
template specialization node somehow ends up before the anonymous struct node.

This patch just puts the checks for the anonymous structs in their own FileCheck
run to prevent them from partially matching any other record decl.

Fixes rdar://62997926

(cherry picked from commit 710fa2c4ee346e1ec2db66ac5fdf6909e79d9a8c)