### PR TITLE
Add an API to construct an XcodeSDK from an SDK type.

### DIFF
--- a/lldb/include/lldb/Utility/XcodeSDK.h
+++ b/lldb/include/lldb/Utility/XcodeSDK.h
@@ -25,13 +25,7 @@ class XcodeSDK {
   std::string m_name;
 
 public:
-  XcodeSDK() = default;
-  /// Initialize an XcodeSDK object with an SDK name. The SDK name is the last
-  /// directory component of a path one would pass to clang's -isysroot
-  /// parameter. For example, "MacOSX.10.14.sdk".
-  XcodeSDK(std::string &&name) : m_name(std::move(name)) {}
-  static XcodeSDK GetAnyMacOS() { return XcodeSDK("MacOSX.sdk"); }
-
+  /// Different types of Xcode SDKs.
   enum Type : int {
     MacOSX = 0,
     iPhoneSimulator,
@@ -42,18 +36,9 @@ public:
     watchOS,
     bridgeOS,
     Linux,
-    numSDKTypes,
     unknown = -1
   };
-
-  /// The merge function follows a strict order to maintain monotonicity:
-  /// 1. SDK with the higher SDKType wins.
-  /// 2. The newer SDK wins.
-  void Merge(XcodeSDK other);
-
-  XcodeSDK &operator=(XcodeSDK other);
-  XcodeSDK(const XcodeSDK&) = default;
-  bool operator==(XcodeSDK other);
+  static constexpr int numSDKTypes = Linux + 1;
 
   /// A parsed SDK directory name.
   struct Info {
@@ -63,7 +48,28 @@ public:
 
     Info() = default;
     bool operator<(const Info &other) const;
+    bool operator==(const Info &other) const;
   };
+
+
+  /// Default constructor, constructs an empty string.
+  XcodeSDK() = default;
+  /// Construct an XcodeSDK object from a specification.
+  XcodeSDK(Info info);
+  /// Initialize an XcodeSDK object with an SDK name. The SDK name is the last
+  /// directory component of a path one would pass to clang's -isysroot
+  /// parameter. For example, "MacOSX.10.14.sdk".
+  XcodeSDK(std::string &&name) : m_name(std::move(name)) {}
+  static XcodeSDK GetAnyMacOS() { return XcodeSDK("MacOSX.sdk"); }
+
+  /// The merge function follows a strict order to maintain monotonicity:
+  /// 1. SDK with the higher SDKType wins.
+  /// 2. The newer SDK wins.
+  void Merge(XcodeSDK other);
+
+  XcodeSDK &operator=(XcodeSDK other);
+  XcodeSDK(const XcodeSDK&) = default;
+  bool operator==(XcodeSDK other);
 
   /// Return parsed SDK type and version number.
   Info Parse() const;

--- a/lldb/unittests/Utility/XcodeSDKTest.cpp
+++ b/lldb/unittests/Utility/XcodeSDKTest.cpp
@@ -95,67 +95,82 @@ TEST(XcodeSDKTest, SDKSupportsSwift) {
   EXPECT_FALSE(XcodeSDK("EverythingElse.sdk").SupportsSwift());
 }
 
-TEST(XcodeSDKTest, GetCanonicalName) {
+TEST(XcodeSDKTest, GetCanonicalNameAndConstruct) {
   XcodeSDK::Info info;
   info.type = XcodeSDK::Type::MacOSX;
   EXPECT_EQ("macosx", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::iPhoneSimulator;
   EXPECT_EQ("iphonesimulator", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::iPhoneOS;
   EXPECT_EQ("iphoneos", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::AppleTVSimulator;
   EXPECT_EQ("appletvsimulator", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::AppleTVOS;
   EXPECT_EQ("appletvos", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::WatchSimulator;
   EXPECT_EQ("watchsimulator", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::watchOS;
   EXPECT_EQ("watchos", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::Linux;
   EXPECT_EQ("linux", XcodeSDK::GetCanonicalName(info));
-
-  info.type = XcodeSDK::Type::numSDKTypes;
-  EXPECT_EQ("", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::unknown;
   EXPECT_EQ("", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.internal = true;
   info.type = XcodeSDK::Type::MacOSX;
   EXPECT_EQ("macosx.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::iPhoneSimulator;
   EXPECT_EQ("iphonesimulator.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::iPhoneOS;
   EXPECT_EQ("iphoneos.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::AppleTVSimulator;
   EXPECT_EQ("appletvsimulator.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::AppleTVOS;
   EXPECT_EQ("appletvos.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::WatchSimulator;
   EXPECT_EQ("watchsimulator.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::watchOS;
   EXPECT_EQ("watchos.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::MacOSX;
   info.version = llvm::VersionTuple(10, 9);
   EXPECT_EQ("macosx10.9.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::iPhoneOS;
   info.version = llvm::VersionTuple(7, 0);
   EXPECT_EQ("iphoneos7.0.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 }
 
 TEST(XcodeSDKTest, GetSDKTypeForTriple) {


### PR DESCRIPTION
Also, this moves numSDKs out of the actual enum, as to not mess with
the switch-cases-covered warning.

Differential Revision: https://reviews.llvm.org/D79603

(cherry picked from commit ae920a81ffa3c7e3c14de131d0d55abd31bbff7d)