### PR TITLE
[lldb/test][Darwin] Ask dyld where the real python is

### DIFF
--- a/lldb/test/API/get_darwin_real_python.py
+++ b/lldb/test/API/get_darwin_real_python.py
@@ -1,0 +1,14 @@
+# On macOS, system python binaries like /usr/bin/python and $(xcrun -f python3)
+# are shims. They do some light validation work and then spawn the "real" python
+# binary. Find the "real" python by asking dyld -- sys.executable reports the
+# wrong thing more often than not. This is also useful when we're running under
+# a Homebrew python3 binary, which also appears to be some kind of shim.
+def getDarwinRealPythonExecutable():
+    import ctypes
+    dyld = ctypes.cdll.LoadLibrary('/usr/lib/system/libdyld.dylib')
+    namelen = ctypes.c_ulong(1024)
+    name = ctypes.create_string_buffer(b'\000', namelen.value)
+    dyld._NSGetExecutablePath(ctypes.byref(name), ctypes.byref(namelen))
+    return name.value.decode('utf-8').strip()
+
+print(getDarwinRealPythonExecutable())


### PR DESCRIPTION
Summary:
On macOS, we can't do the DYLD_INSERT_LIBRARIES trick with a shim
python binary as the ASan interceptors get loaded too late. Find the
"real" python binary, copy it, and invoke it.

Hopefully this makes the GreenDragon and swift-ci sanitizer bots
happy...

I tested this out by running `../llvm-macosx-x86_64/bin/llvm-lit test
--filter TestNSDictionarySynthetic.py` in an ASanified swift-lldb build
directory and it worked (i.e. no more "interceptors loaded too late"
messages).

Reviewers: JDevlieghere

Subscribers: lldb-commits

Tags: #lldb

Differential Revision: https://reviews.llvm.org/D79607

(cherry picked from commit 8cb86ead77417f889bf32a8f83da299215f78545)