### PR TITLE
Remove redundant SDK selection code from SwiftASTContext (NFC)

### DIFF
--- a/lldb/include/lldb/Utility/XcodeSDK.h
+++ b/lldb/include/lldb/Utility/XcodeSDK.h
@@ -9,6 +9,7 @@
 #ifndef LLDB_UTILITY_SDK_H
 #define LLDB_UTILITY_SDK_H
 
+#include "lldb/lldb-forward.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/VersionTuple.h"
 #include <tuple>

--- a/lldb/include/lldb/Utility/XcodeSDK.h
+++ b/lldb/include/lldb/Utility/XcodeSDK.h
@@ -25,13 +25,7 @@ class XcodeSDK {
   std::string m_name;
 
 public:
-  XcodeSDK() = default;
-  /// Initialize an XcodeSDK object with an SDK name. The SDK name is the last
-  /// directory component of a path one would pass to clang's -isysroot
-  /// parameter. For example, "MacOSX.10.14.sdk".
-  XcodeSDK(std::string &&name) : m_name(std::move(name)) {}
-  static XcodeSDK GetAnyMacOS() { return XcodeSDK("MacOSX.sdk"); }
-
+  /// Different types of Xcode SDKs.
   enum Type : int {
     MacOSX = 0,
     iPhoneSimulator,
@@ -42,18 +36,9 @@ public:
     watchOS,
     bridgeOS,
     Linux,
-    numSDKTypes,
     unknown = -1
   };
-
-  /// The merge function follows a strict order to maintain monotonicity:
-  /// 1. SDK with the higher SDKType wins.
-  /// 2. The newer SDK wins.
-  void Merge(XcodeSDK other);
-
-  XcodeSDK &operator=(XcodeSDK other);
-  XcodeSDK(const XcodeSDK&) = default;
-  bool operator==(XcodeSDK other);
+  static constexpr int numSDKTypes = Linux + 1;
 
   /// A parsed SDK directory name.
   struct Info {
@@ -63,7 +48,28 @@ public:
 
     Info() = default;
     bool operator<(const Info &other) const;
+    bool operator==(const Info &other) const;
   };
+
+
+  /// Default constructor, constructs an empty string.
+  XcodeSDK() = default;
+  /// Construct an XcodeSDK object from a specification.
+  XcodeSDK(Info info);
+  /// Initialize an XcodeSDK object with an SDK name. The SDK name is the last
+  /// directory component of a path one would pass to clang's -isysroot
+  /// parameter. For example, "MacOSX.10.14.sdk".
+  XcodeSDK(std::string &&name) : m_name(std::move(name)) {}
+  static XcodeSDK GetAnyMacOS() { return XcodeSDK("MacOSX.sdk"); }
+
+  /// The merge function follows a strict order to maintain monotonicity:
+  /// 1. SDK with the higher SDKType wins.
+  /// 2. The newer SDK wins.
+  void Merge(XcodeSDK other);
+
+  XcodeSDK &operator=(XcodeSDK other);
+  XcodeSDK(const XcodeSDK&) = default;
+  bool operator==(XcodeSDK other);
 
   /// Return parsed SDK type and version number.
   Info Parse() const;

--- a/lldb/include/lldb/Utility/XcodeSDK.h
+++ b/lldb/include/lldb/Utility/XcodeSDK.h
@@ -70,7 +70,10 @@ public:
   llvm::VersionTuple GetVersion() const;
   Type GetType() const;
   llvm::StringRef GetString() const;
+  /// Whether this Xcode SDK supports Swift.
+  bool SupportsSwift() const;
 
+  /// Whether LLDB feels confident importing Clang modules from this SDK.
   static bool SDKSupportsModules(Type type, llvm::VersionTuple version);
   static bool SDKSupportsModules(Type desired_type, const FileSpec &sdk_path);
   /// Return the canonical SDK name, such as "macosx" for the macOS SDK.

--- a/lldb/include/lldb/Utility/XcodeSDK.h
+++ b/lldb/include/lldb/Utility/XcodeSDK.h
@@ -13,6 +13,10 @@
 #include "llvm/Support/VersionTuple.h"
 #include <tuple>
 
+namespace llvm {
+class Triple;
+}
+
 namespace lldb_private {
 
 /// An abstraction for Xcode-style SDKs that works like \ref ArchSpec.
@@ -71,6 +75,8 @@ public:
   static bool SDKSupportsModules(Type desired_type, const FileSpec &sdk_path);
   /// Return the canonical SDK name, such as "macosx" for the macOS SDK.
   static std::string GetCanonicalName(Info info);
+  /// Return the best-matching SDK type for a specific triple.
+  static XcodeSDK::Type GetSDKTypeForTriple(const llvm::Triple &triple);
 };
 
 } // namespace lldb_private

--- a/lldb/source/Utility/XcodeSDK.cpp
+++ b/lldb/source/Utility/XcodeSDK.cpp
@@ -182,25 +182,11 @@ bool XcodeSDK::SDKSupportsModules(XcodeSDK::Type desired_type,
                                   const FileSpec &sdk_path) {
   ConstString last_path_component = sdk_path.GetLastPathComponent();
 
-  if (last_path_component) {
-    const llvm::StringRef sdk_name = last_path_component.GetStringRef();
+  if (!last_path_component)
+    return false;
 
-    const std::string sdk_name_lower = sdk_name.lower();
-    Info info;
-    info.type = desired_type;
-    const std::string sdk_string = GetCanonicalName(info);
-    if (!llvm::StringRef(sdk_name_lower).startswith(sdk_string))
-      return false;
-
-    auto version_part = sdk_name.drop_front(sdk_string.size());
-    version_part.consume_back(".sdk");
-    version_part.consume_back(".Internal");
-
-    llvm::VersionTuple version;
-    if (version.tryParse(version_part))
-      return false;
-    return SDKSupportsModules(desired_type, version);
-  }
-
-  return false;
+  XcodeSDK sdk(last_path_component.GetStringRef().str());
+  if (sdk.GetType() != desired_type)
+    return false;
+  return SDKSupportsModules(sdk.GetType(), sdk.GetVersion());
 }

--- a/lldb/source/Utility/XcodeSDK.cpp
+++ b/lldb/source/Utility/XcodeSDK.cpp
@@ -181,6 +181,27 @@ bool XcodeSDK::SDKSupportsModules(XcodeSDK::Type sdk_type,
   return false;
 }
 
+bool XcodeSDK::SupportsSwift() const {
+  XcodeSDK::Info info = Parse();
+  switch (info.type) {
+  case Type::MacOSX:
+    return info.version.empty() || info.version >= llvm::VersionTuple(10, 10);
+  case Type::iPhoneOS:
+  case Type::iPhoneSimulator:
+    return info.version.empty() || info.version >= llvm::VersionTuple(8);
+  case Type::AppleTVSimulator:
+  case Type::AppleTVOS:
+    return info.version.empty() || info.version >= llvm::VersionTuple(9);
+  case Type::WatchSimulator:
+  case Type::watchOS:
+    return info.version.empty() || info.version >= llvm::VersionTuple(2);
+  case Type::Linux:
+    return true;
+  default:
+    return false;
+  }
+}
+
 bool XcodeSDK::SDKSupportsModules(XcodeSDK::Type desired_type,
                                   const FileSpec &sdk_path) {
   ConstString last_path_component = sdk_path.GetLastPathComponent();

--- a/lldb/source/Utility/XcodeSDK.cpp
+++ b/lldb/source/Utility/XcodeSDK.cpp
@@ -6,10 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/XcodeSDK.h"
+#include "lldb/Utility/FileSpec.h"
 
 #include "lldb/lldb-types.h"
+
+#include "llvm/ADT/Triple.h"
+
 #include <string>
 
 using namespace lldb;
@@ -189,4 +192,34 @@ bool XcodeSDK::SDKSupportsModules(XcodeSDK::Type desired_type,
   if (sdk.GetType() != desired_type)
     return false;
   return SDKSupportsModules(sdk.GetType(), sdk.GetVersion());
+}
+
+XcodeSDK::Type XcodeSDK::GetSDKTypeForTriple(const llvm::Triple &triple) {
+  using namespace llvm;
+  switch (triple.getOS()) {
+  case Triple::MacOSX:
+  case Triple::Darwin:
+    return XcodeSDK::MacOSX;
+  case Triple::IOS:
+    switch (triple.getEnvironment()) {
+    case Triple::MacABI:
+      return XcodeSDK::MacOSX;
+    case Triple::Simulator:
+      return XcodeSDK::iPhoneSimulator;
+    default:
+      return XcodeSDK::iPhoneOS;
+    }
+  case Triple::TvOS:
+    if (triple.getEnvironment() == Triple::Simulator)
+      return XcodeSDK::AppleTVSimulator;
+    return XcodeSDK::AppleTVOS;
+  case Triple::WatchOS:
+    if (triple.getEnvironment() == Triple::Simulator)
+      return XcodeSDK::WatchSimulator;
+    return XcodeSDK::watchOS;
+  case Triple::Linux:
+    return XcodeSDK::Linux;
+  default:
+    return XcodeSDK::unknown;
+  }
 }

--- a/lldb/unittests/Utility/XcodeSDKTest.cpp
+++ b/lldb/unittests/Utility/XcodeSDKTest.cpp
@@ -84,6 +84,17 @@ TEST(XcodeSDKTest, SDKSupportsModules) {
       FileSpec(base + "MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk")));
 }
 
+TEST(XcodeSDKTest, SDKSupportsSwift) {
+  EXPECT_TRUE(XcodeSDK("iPhoneSimulator12.0.sdk").SupportsSwift());
+  EXPECT_TRUE(XcodeSDK("iPhoneSimulator12.0.Internal.sdk").SupportsSwift());
+  EXPECT_FALSE(XcodeSDK("iPhoneSimulator7.2.sdk").SupportsSwift());
+  EXPECT_TRUE(XcodeSDK("MacOSX10.10.sdk").SupportsSwift());
+  EXPECT_FALSE(XcodeSDK("MacOSX10.9.sdk").SupportsSwift());
+  EXPECT_TRUE(XcodeSDK("Linux.sdk").SupportsSwift());
+  EXPECT_TRUE(XcodeSDK("MacOSX.sdk").SupportsSwift());
+  EXPECT_FALSE(XcodeSDK("EverythingElse.sdk").SupportsSwift());
+}
+
 TEST(XcodeSDKTest, GetCanonicalName) {
   XcodeSDK::Info info;
   info.type = XcodeSDK::Type::MacOSX;

--- a/lldb/unittests/Utility/XcodeSDKTest.cpp
+++ b/lldb/unittests/Utility/XcodeSDKTest.cpp
@@ -95,67 +95,82 @@ TEST(XcodeSDKTest, SDKSupportsSwift) {
   EXPECT_FALSE(XcodeSDK("EverythingElse.sdk").SupportsSwift());
 }
 
-TEST(XcodeSDKTest, GetCanonicalName) {
+TEST(XcodeSDKTest, GetCanonicalNameAndConstruct) {
   XcodeSDK::Info info;
   info.type = XcodeSDK::Type::MacOSX;
   EXPECT_EQ("macosx", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::iPhoneSimulator;
   EXPECT_EQ("iphonesimulator", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::iPhoneOS;
   EXPECT_EQ("iphoneos", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::AppleTVSimulator;
   EXPECT_EQ("appletvsimulator", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::AppleTVOS;
   EXPECT_EQ("appletvos", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::WatchSimulator;
   EXPECT_EQ("watchsimulator", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::watchOS;
   EXPECT_EQ("watchos", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::Linux;
   EXPECT_EQ("linux", XcodeSDK::GetCanonicalName(info));
-
-  info.type = XcodeSDK::Type::numSDKTypes;
-  EXPECT_EQ("", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::unknown;
   EXPECT_EQ("", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.internal = true;
   info.type = XcodeSDK::Type::MacOSX;
   EXPECT_EQ("macosx.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::iPhoneSimulator;
   EXPECT_EQ("iphonesimulator.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::iPhoneOS;
   EXPECT_EQ("iphoneos.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::AppleTVSimulator;
   EXPECT_EQ("appletvsimulator.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::AppleTVOS;
   EXPECT_EQ("appletvos.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::WatchSimulator;
   EXPECT_EQ("watchsimulator.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::watchOS;
   EXPECT_EQ("watchos.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::MacOSX;
   info.version = llvm::VersionTuple(10, 9);
   EXPECT_EQ("macosx10.9.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 
   info.type = XcodeSDK::Type::iPhoneOS;
   info.version = llvm::VersionTuple(7, 0);
   EXPECT_EQ("iphoneos7.0.internal", XcodeSDK::GetCanonicalName(info));
+  EXPECT_EQ(XcodeSDK(info).Parse(), info);
 }
 
 TEST(XcodeSDKTest, GetSDKTypeForTriple) {

--- a/lldb/unittests/Utility/XcodeSDKTest.cpp
+++ b/lldb/unittests/Utility/XcodeSDKTest.cpp
@@ -12,6 +12,7 @@
 #include "lldb/Utility/XcodeSDK.h"
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Triple.h"
 
 #include <tuple>
 
@@ -144,4 +145,34 @@ TEST(XcodeSDKTest, GetCanonicalName) {
   info.type = XcodeSDK::Type::iPhoneOS;
   info.version = llvm::VersionTuple(7, 0);
   EXPECT_EQ("iphoneos7.0.internal", XcodeSDK::GetCanonicalName(info));
+}
+
+TEST(XcodeSDKTest, GetSDKTypeForTriple) {
+  EXPECT_EQ(
+      XcodeSDK::GetSDKTypeForTriple(llvm::Triple("x86_64-apple-macosx10.14")),
+      XcodeSDK::Type::MacOSX);
+  EXPECT_EQ(XcodeSDK::GetSDKTypeForTriple(llvm::Triple("x86_64-apple-darwin")),
+            XcodeSDK::Type::MacOSX);
+  EXPECT_EQ(XcodeSDK::GetSDKTypeForTriple(
+                llvm::Triple("x86_64-apple-ios13.4-simulator")),
+            XcodeSDK::Type::iPhoneSimulator);
+  EXPECT_EQ(XcodeSDK::GetSDKTypeForTriple(llvm::Triple("arm64-apple-ios13.4")),
+            XcodeSDK::Type::iPhoneOS);
+  EXPECT_EQ(XcodeSDK::GetSDKTypeForTriple(
+                llvm::Triple("x86_64-apple-ios13.4-macabi")),
+            XcodeSDK::Type::MacOSX);
+  EXPECT_EQ(XcodeSDK::GetSDKTypeForTriple(
+                llvm::Triple("x86_64-apple-tvos-simulator")),
+            XcodeSDK::Type::AppleTVSimulator);
+  EXPECT_EQ(XcodeSDK::GetSDKTypeForTriple(llvm::Triple("arm64-apple-tvos")),
+            XcodeSDK::Type::AppleTVOS);
+  EXPECT_EQ(XcodeSDK::GetSDKTypeForTriple(
+                llvm::Triple("x86_64-apple-watchos-simulator")),
+            XcodeSDK::Type::WatchSimulator);
+  EXPECT_EQ(XcodeSDK::GetSDKTypeForTriple(llvm::Triple("arm64-apple-watchos")),
+            XcodeSDK::Type::watchOS);
+  EXPECT_EQ(XcodeSDK::GetSDKTypeForTriple(llvm::Triple("x86_64-unknown-linux")),
+            XcodeSDK::Type::Linux);
+  EXPECT_EQ(XcodeSDK::GetSDKTypeForTriple(llvm::Triple("i386-unknown-netbsd")),
+            XcodeSDK::Type::unknown);
 }


### PR DESCRIPTION
Most of the complexity in this function is there to select an SDK
recent enough to support Swift, however, lldb no longer targets any
systems old enough that would be a problem.

(The cherry-picks are just for getting ahead of the automerger)