### PR TITLE
Fix FP-math flags due to ParseLangArgs/ParseCodeGenArgs ordering issues.

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3787,6 +3787,10 @@ bool CompilerInvocation::CreateFromArgs(CompilerInvocation &Res,
 
   ParsePointerAuthArgs(LangOpts, Args);
 
+  Success &= ParseCodeGenArgs(Res.getCodeGenOpts(), Args, DashX, Diags,
+                              LangOpts, Res.getTargetOpts(),
+                              Res.getFrontendOpts());
+
   llvm::Triple T(Res.getTargetOpts().Triple);
   if (DashX.getFormat() == InputKind::Precompiled ||
       DashX.getLanguage() == Language::LLVM_IR) {
@@ -3822,9 +3826,6 @@ bool CompilerInvocation::CreateFromArgs(CompilerInvocation &Res,
   LangOpts.FunctionAlignment =
       getLastArgIntValue(Args, OPT_function_alignment, 0, Diags);
 
-  Success &= ParseCodeGenArgs(Res.getCodeGenOpts(), Args, DashX, Diags,
-                              LangOpts, Res.getTargetOpts(),
-                              Res.getFrontendOpts());
 
   if (LangOpts.CUDA) {
     // During CUDA device-side compilation, the aux triple is the


### PR DESCRIPTION
Upstream, there have been some changes to floating point flags in
https://reviews.llvm.org/D72841, and because of this I noticed that the
following started failing:

  Clang :: CodeGen/finite-math.c
  Clang :: CodeGen/fp-floatcontrol-stack.cpp
  Clang :: CodeGenOpenCL/relaxed-fpmath.cl
  Clang :: Driver/cl-showfilenames.c

I tracked this down to ParseLangArgs and ParseCodeGenArgs being called
in the wrong order (different from upstream), which cause NoHonorNaNs to not
get set properly by NoNaNsFPMath (as well as other flags) because
ParseCodeGenArgs (which sets NoNaNsFPMath) was not called before ParseLangArgs
(which tests NoHonorNaNs from NoNaNsFPMath).