### PR TITLE
Partially cherry-pick change from llvm.org

### DIFF
--- a/llvm/include/llvm/MC/SubtargetFeature.h
+++ b/llvm/include/llvm/MC/SubtargetFeature.h
@@ -214,7 +214,7 @@ public:
   }
 
   /// Return string stripped of flag.
-  static std::string StripFlag(StringRef Feature) {
+  static StringRef StripFlag(StringRef Feature) {
     return hasFlag(Feature) ? Feature.substr(1) : Feature;
   }
 


### PR DESCRIPTION
Partially cherry-pick adcd02683856c30ba6f349279509acecd90063df into the swift branch.  This will enable the runtime to use a local copy of LLVMSupport.