### PR TITLE
Restore code that was accidentally deleted in 85620b7b92b63.

### DIFF
--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -2557,7 +2557,7 @@ void SwiftASTContext::InitializeSearchPathOptions(
   ConfigureResourceDirs(GetCompilerInvocation(), FileSpec(resource_dir),
                         triple);
 
-  std::string sdk_path;
+  std::string sdk_path = GetPlatformSDKPath();
   if (TargetSP target_sp = m_target_wp.lock())
     if (FileSpec &manual_override_sdk = target_sp->GetSDKPath()) {
       set_sdk = false;


### PR DESCRIPTION
This broke support for the internal SDK and is unfortunately difficult
to test on swift.org.

rdar://problem/63103620
(cherry picked from commit 2b831f3479ebbe965b4f3c4518dee008d3d02acc)