### PR TITLE
Remove all API that take a CompilerType as an in-argument from TypeSystemSwift

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -137,7 +137,7 @@ public:
   virtual bool IsImportedType(lldb::opaque_compiler_type_t type,
                               CompilerType *original_type) = 0;
   virtual CompilerType GetErrorType() = 0;
-  virtual CompilerType GetReferentType(CompilerType compiler_type) = 0;
+  virtual CompilerType GetReferentType(lldb::opaque_compiler_type_t type) = 0;
   static CompilerType GetInstanceType(CompilerType ct);
   virtual CompilerType GetInstanceType(void *type) = 0;
   enum class TypeAllocationStrategy { eInline, ePointer, eDynamic, eUnknown };
@@ -411,7 +411,7 @@ public:
   bool IsImportedType(lldb::opaque_compiler_type_t type,
                       CompilerType *original_type) override;
   CompilerType GetErrorType() override;
-  CompilerType GetReferentType(CompilerType compiler_type) override;
+  CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
   CompilerType GetInstanceType(void *type) override;
   TypeAllocationStrategy GetAllocationStrategy(CompilerType type) override;
   CompilerType
@@ -1078,7 +1078,7 @@ public:
   bool IsImportedType(lldb::opaque_compiler_type_t type,
                       CompilerType *original_type) override;
 
-  CompilerType GetReferentType(CompilerType compiler_type) override;
+  CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
 
   lldb::TypeSP GetCachedType(ConstString mangled) override;
 

--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -141,7 +141,8 @@ public:
   static CompilerType GetInstanceType(CompilerType ct);
   virtual CompilerType GetInstanceType(void *type) = 0;
   enum class TypeAllocationStrategy { eInline, ePointer, eDynamic, eUnknown };
-  virtual TypeAllocationStrategy GetAllocationStrategy(CompilerType type) = 0;
+  virtual TypeAllocationStrategy
+  GetAllocationStrategy(lldb::opaque_compiler_type_t type) = 0;
   struct TupleElement {
     ConstString element_name;
     CompilerType element_type;
@@ -413,7 +414,8 @@ public:
   CompilerType GetErrorType() override;
   CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
   CompilerType GetInstanceType(void *type) override;
-  TypeAllocationStrategy GetAllocationStrategy(CompilerType type) override;
+  TypeAllocationStrategy
+  GetAllocationStrategy(lldb::opaque_compiler_type_t type) override;
   CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) override;
   void DumpTypeDescription(
@@ -859,7 +861,8 @@ public:
   static bool GetProtocolTypeInfo(const CompilerType &type,
                                   ProtocolInfo &protocol_info);
 
-  TypeAllocationStrategy GetAllocationStrategy(CompilerType type) override;
+  TypeAllocationStrategy
+  GetAllocationStrategy(lldb::opaque_compiler_type_t type) override;
 
   enum class NonTriviallyManagedReferenceStrategy {
     eWeak,

--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -136,7 +136,6 @@ public:
                              const lldb::TypeSP &type_sp) = 0;
   virtual bool IsImportedType(CompilerType type,
                               CompilerType *original_type) = 0;
-  virtual bool IsErrorType(CompilerType compiler_type) = 0;
   virtual CompilerType GetErrorType() = 0;
   virtual CompilerType GetReferentType(CompilerType compiler_type) = 0;
   static CompilerType GetInstanceType(CompilerType ct);
@@ -410,7 +409,6 @@ public:
   lldb::TypeSP GetCachedType(ConstString mangled) override;
   void SetCachedType(ConstString mangled, const lldb::TypeSP &type_sp) override;
   bool IsImportedType(CompilerType type, CompilerType *original_type) override;
-  bool IsErrorType(CompilerType compiler_type) override;
   CompilerType GetErrorType() override;
   CompilerType GetReferentType(CompilerType compiler_type) override;
   CompilerType GetInstanceType(void *type) override;
@@ -831,7 +829,8 @@ public:
 
   static bool IsGenericType(const CompilerType &compiler_type);
 
-  bool IsErrorType(CompilerType compiler_type) override;
+  /// Whether this is the Swift error type.
+  bool IsErrorType(void *type);
 
   static bool IsFullyRealized(const CompilerType &compiler_type);
 

--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -19,8 +19,8 @@
 #include "lldb/Core/ThreadSafeDenseMap.h"
 #include "lldb/Core/ThreadSafeDenseSet.h"
 #include "lldb/Symbol/CompilerType.h"
-#include "lldb/Symbol/TypeSystem.h"
 #include "lldb/Symbol/SymbolFile.h"
+#include "lldb/Symbol/TypeSystem.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/lldb-private.h"
 
@@ -81,6 +81,7 @@ class TypePayloadSwift {
   Type::Payload m_payload = 0;
 
   static constexpr unsigned FixedValueBufferBit = 1;
+
 public:
   TypePayloadSwift() = default;
   explicit TypePayloadSwift(bool is_fixed_value_buffer);
@@ -91,7 +92,9 @@ public:
   /// \return whether this is a Swift fixed-size buffer. Resilient variables in
   /// fixed-size buffers may be indirect depending on the runtime size of the
   /// type. This is more a property of the value than of its type.
-  bool IsFixedValueBuffer() { return Flags(m_payload).Test(FixedValueBufferBit); }
+  bool IsFixedValueBuffer() {
+    return Flags(m_payload).Test(FixedValueBufferBit);
+  }
   void SetIsFixedValueBuffer(bool is_fixed_value_buffer) {
     m_payload = is_fixed_value_buffer
                     ? Flags(m_payload).Set(FixedValueBufferBit)
@@ -139,7 +142,7 @@ public:
   virtual CompilerType GetErrorType() = 0;
   virtual CompilerType GetReferentType(lldb::opaque_compiler_type_t type) = 0;
   static CompilerType GetInstanceType(CompilerType ct);
-  virtual CompilerType GetInstanceType(void *type) = 0;
+  virtual CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) = 0;
   enum class TypeAllocationStrategy { eInline, ePointer, eDynamic, eUnknown };
   virtual TypeAllocationStrategy
   GetAllocationStrategy(lldb::opaque_compiler_type_t type) = 0;
@@ -150,12 +153,12 @@ public:
   virtual CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) = 0;
   virtual void DumpTypeDescription(
-      void *type, bool print_help_if_available,
+      lldb::opaque_compiler_type_t type, bool print_help_if_available,
       bool print_extensions_if_available,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) = 0;
   virtual void DumpTypeDescription(
-      void *type, Stream *s, bool print_help_if_available,
-      bool print_extensions_if_available,
+      lldb::opaque_compiler_type_t type, Stream *s,
+      bool print_help_if_available, bool print_extensions_if_available,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) = 0;
 
   /// Unavailable hardcoded functions that don't make sense for Swift.
@@ -171,33 +174,47 @@ public:
                            ConstString *language_object_name_ptr) override {
     return false;
   }
-  bool IsRuntimeGeneratedType(void *type) override { return false; }
-  bool IsCharType(void *type) override { return false; }
-  bool IsCompleteType(void *type) override { return true; }
-  bool IsConst(void *type) override { return false; }
-  bool IsCStringType(void *type, uint32_t &length) override { return false; }
-  bool IsVectorType(void *type, CompilerType *element_type,
-                    uint64_t *size) override {
+  bool IsRuntimeGeneratedType(lldb::opaque_compiler_type_t type) override {
     return false;
   }
-  uint32_t IsHomogeneousAggregate(void *type,
+  bool IsCharType(lldb::opaque_compiler_type_t type) override { return false; }
+  bool IsCompleteType(lldb::opaque_compiler_type_t type) override {
+    return true;
+  }
+  bool IsConst(lldb::opaque_compiler_type_t type) override { return false; }
+  bool IsCStringType(lldb::opaque_compiler_type_t type,
+                     uint32_t &length) override {
+    return false;
+  }
+  bool IsVectorType(lldb::opaque_compiler_type_t type,
+                    CompilerType *element_type, uint64_t *size) override {
+    return false;
+  }
+  uint32_t IsHomogeneousAggregate(lldb::opaque_compiler_type_t type,
                                   CompilerType *base_type_ptr) override {
     return 0;
   }
-  bool IsBlockPointerType(void *type,
+  bool IsBlockPointerType(lldb::opaque_compiler_type_t type,
                           CompilerType *function_pointer_type_ptr) override {
     return false;
   }
-  bool IsPolymorphicClass(void *type) override { return false; }
-  bool IsBeingDefined(void *type) override { return false; }
+  bool IsPolymorphicClass(lldb::opaque_compiler_type_t type) override {
+    return false;
+  }
+  bool IsBeingDefined(lldb::opaque_compiler_type_t type) override {
+    return false;
+  }
   bool CanPassInRegisters(const CompilerType &type) override {
     // FIXME: Implement this. There was an abort() here to figure out which
     // tests where hitting this code. At least TestSwiftReturns and
     // TestSwiftStepping were failing because of this Darwin.
     return false;
   }
-  unsigned GetTypeQualifiers(void *type) override { return 0; }
-  CompilerType GetTypeForDecl(void *opaque_decl) override {
+  unsigned GetTypeQualifiers(lldb::opaque_compiler_type_t type) override {
+    return 0;
+  }
+  CompilerType
+  GetTypeForDecl(lldb::opaque_compiler_type_t opaque_decl) override {
     llvm_unreachable("GetTypeForDecl not implemented");
   }
   CompilerType GetBasicTypeFromAST(lldb::BasicType basic_type) override {
@@ -208,12 +225,17 @@ public:
     // is only used by DumpDataExtractor for the C type system.
     llvm_unreachable("GetFloatTypeSemantics not implemented.");
   }
-  lldb::BasicType GetBasicTypeEnumeration(void *type) override {
+  lldb::BasicType
+  GetBasicTypeEnumeration(lldb::opaque_compiler_type_t type) override {
     return lldb::eBasicTypeInvalid;
   }
-  uint32_t GetNumVirtualBaseClasses(void *opaque_type) override { return 0; }
-  CompilerType GetVirtualBaseClassAtIndex(void *opaque_type, size_t idx,
-                                          uint32_t *bit_offset_ptr) override {
+  uint32_t
+  GetNumVirtualBaseClasses(lldb::opaque_compiler_type_t opaque_type) override {
+    return 0;
+  }
+  CompilerType
+  GetVirtualBaseClassAtIndex(lldb::opaque_compiler_type_t opaque_type,
+                             size_t idx, uint32_t *bit_offset_ptr) override {
     return {};
   }
   /// \}
@@ -276,48 +298,59 @@ public:
 #ifndef NDEBUG
   bool Verify(lldb::opaque_compiler_type_t type) override;
 #endif
-  bool IsArrayType(void *type, CompilerType *element_type, uint64_t *size,
+  bool IsArrayType(lldb::opaque_compiler_type_t type,
+                   CompilerType *element_type, uint64_t *size,
                    bool *is_incomplete) override;
-  bool IsAggregateType(void *type) override;
-  bool IsDefined(void *type) override;
-  bool IsFloatingPointType(void *type, uint32_t &count,
+  bool IsAggregateType(lldb::opaque_compiler_type_t type) override;
+  bool IsDefined(lldb::opaque_compiler_type_t type) override;
+  bool IsFloatingPointType(lldb::opaque_compiler_type_t type, uint32_t &count,
                            bool &is_complex) override;
-  bool IsFunctionType(void *type, bool *is_variadic_ptr) override;
-  size_t GetNumberOfFunctionArguments(void *type) override;
-  CompilerType GetFunctionArgumentAtIndex(void *type,
+  bool IsFunctionType(lldb::opaque_compiler_type_t type,
+                      bool *is_variadic_ptr) override;
+  size_t
+  GetNumberOfFunctionArguments(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetFunctionArgumentAtIndex(lldb::opaque_compiler_type_t type,
                                           const size_t index) override;
-  bool IsFunctionPointerType(void *type) override;
-  bool IsIntegerType(void *type, bool &is_signed) override;
-  bool IsPossibleDynamicType(void *type,
+  bool IsFunctionPointerType(lldb::opaque_compiler_type_t type) override;
+  bool IsIntegerType(lldb::opaque_compiler_type_t type,
+                     bool &is_signed) override;
+  bool IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
                              CompilerType *target_type, // Can pass NULL
                              bool check_cplusplus, bool check_objc) override;
-  bool IsPointerType(void *type, CompilerType *pointee_type) override;
-  bool IsScalarType(void *type) override;
-  bool IsVoidType(void *type) override;
+  bool IsPointerType(lldb::opaque_compiler_type_t type,
+                     CompilerType *pointee_type) override;
+  bool IsScalarType(lldb::opaque_compiler_type_t type) override;
+  bool IsVoidType(lldb::opaque_compiler_type_t type) override;
   // Type Completion
-  bool GetCompleteType(void *type) override;
+  bool GetCompleteType(lldb::opaque_compiler_type_t type) override;
   // AST related queries
   uint32_t GetPointerByteSize() override;
   // Accessors
-  ConstString GetTypeName(void *type) override;
-  ConstString GetDisplayTypeName(void *type, const SymbolContext *sc) override;
-  ConstString GetMangledTypeName(void *type) override;
-  uint32_t GetTypeInfo(void *type,
+  ConstString GetTypeName(lldb::opaque_compiler_type_t type) override;
+  ConstString GetDisplayTypeName(lldb::opaque_compiler_type_t type,
+                                 const SymbolContext *sc) override;
+  ConstString GetMangledTypeName(lldb::opaque_compiler_type_t type) override;
+  uint32_t GetTypeInfo(lldb::opaque_compiler_type_t type,
                        CompilerType *pointee_or_element_clang_type) override;
-  lldb::LanguageType GetMinimumLanguage(void *type) override;
-  lldb::TypeClass GetTypeClass(void *type) override;
+  lldb::LanguageType
+  GetMinimumLanguage(lldb::opaque_compiler_type_t type) override;
+  lldb::TypeClass GetTypeClass(lldb::opaque_compiler_type_t type) override;
 
   // Creating related types
-  CompilerType GetArrayElementType(void *type, uint64_t *stride) override;
-  CompilerType GetCanonicalType(void *type) override;
-  int GetFunctionArgumentCount(void *type) override;
-  CompilerType GetFunctionArgumentTypeAtIndex(void *type, size_t idx) override;
-  CompilerType GetFunctionReturnType(void *type) override;
-  size_t GetNumMemberFunctions(void *type) override;
-  TypeMemberFunctionImpl GetMemberFunctionAtIndex(void *type,
-                                                  size_t idx) override;
-  CompilerType GetPointeeType(void *type) override;
-  CompilerType GetPointerType(void *type) override;
+  CompilerType GetArrayElementType(lldb::opaque_compiler_type_t type,
+                                   uint64_t *stride) override;
+  CompilerType GetCanonicalType(lldb::opaque_compiler_type_t type) override;
+  int GetFunctionArgumentCount(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetFunctionArgumentTypeAtIndex(lldb::opaque_compiler_type_t type,
+                                              size_t idx) override;
+  CompilerType
+  GetFunctionReturnType(lldb::opaque_compiler_type_t type) override;
+  size_t GetNumMemberFunctions(lldb::opaque_compiler_type_t type) override;
+  TypeMemberFunctionImpl
+  GetMemberFunctionAtIndex(lldb::opaque_compiler_type_t type,
+                           size_t idx) override;
+  CompilerType GetPointeeType(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetPointerType(lldb::opaque_compiler_type_t type) override;
 
   // Exploring the type
   llvm::Optional<uint64_t>
@@ -326,33 +359,38 @@ public:
   llvm::Optional<uint64_t>
   GetByteStride(lldb::opaque_compiler_type_t type,
                 ExecutionContextScope *exe_scope) override;
-  lldb::Encoding GetEncoding(void *type, uint64_t &count) override;
-  lldb::Format GetFormat(void *type) override;
-  uint32_t GetNumChildren(void *type, bool omit_empty_base_classes,
+  lldb::Encoding GetEncoding(lldb::opaque_compiler_type_t type,
+                             uint64_t &count) override;
+  lldb::Format GetFormat(lldb::opaque_compiler_type_t type) override;
+  uint32_t GetNumChildren(lldb::opaque_compiler_type_t type,
+                          bool omit_empty_base_classes,
                           const ExecutionContext *exe_ctx) override;
-  uint32_t GetNumFields(void *type) override;
-  CompilerType GetFieldAtIndex(void *type, size_t idx, std::string &name,
-                               uint64_t *bit_offset_ptr,
+  uint32_t GetNumFields(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetFieldAtIndex(lldb::opaque_compiler_type_t type, size_t idx,
+                               std::string &name, uint64_t *bit_offset_ptr,
                                uint32_t *bitfield_bit_size_ptr,
                                bool *is_bitfield_ptr) override;
   CompilerType GetChildCompilerTypeAtIndex(
-      void *type, ExecutionContext *exe_ctx, size_t idx,
+      lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
       bool transparent_pointers, bool omit_empty_base_classes,
       bool ignore_array_bounds, std::string &child_name,
       uint32_t &child_byte_size, int32_t &child_byte_offset,
       uint32_t &child_bitfield_bit_size, uint32_t &child_bitfield_bit_offset,
       bool &child_is_base_class, bool &child_is_deref_of_parent,
       ValueObject *valobj, uint64_t &language_flags) override;
-  uint32_t GetIndexOfChildWithName(void *type, const char *name,
+  uint32_t GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
+                                   const char *name,
                                    bool omit_empty_base_classes) override;
   size_t
-  GetIndexOfChildMemberWithName(void *type, const char *name,
-                                bool omit_empty_base_classes,
+  GetIndexOfChildMemberWithName(lldb::opaque_compiler_type_t type,
+                                const char *name, bool omit_empty_base_classes,
                                 std::vector<uint32_t> &child_indexes) override;
-  size_t GetNumTemplateArguments(void *type) override;
-  CompilerType GetTypeForFormatters(void *type) override;
-  LazyBool ShouldPrintAsOneLiner(void *type, ValueObject *valobj) override;
-  bool IsMeaninglessWithoutDynamicResolution(void *type) override;
+  size_t GetNumTemplateArguments(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetTypeForFormatters(lldb::opaque_compiler_type_t type) override;
+  LazyBool ShouldPrintAsOneLiner(lldb::opaque_compiler_type_t type,
+                                 ValueObject *valobj) override;
+  bool IsMeaninglessWithoutDynamicResolution(
+      lldb::opaque_compiler_type_t type) override;
 
   // Dumping types
 #ifndef NDEBUG
@@ -361,48 +399,53 @@ public:
   dump(lldb::opaque_compiler_type_t type) const override;
 #endif
 
-  void DumpValue(void *type, ExecutionContext *exe_ctx, Stream *s,
-                 lldb::Format format, const DataExtractor &data,
+  void DumpValue(lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
+                 Stream *s, lldb::Format format, const DataExtractor &data,
                  lldb::offset_t data_offset, size_t data_byte_size,
                  uint32_t bitfield_bit_size, uint32_t bitfield_bit_offset,
                  bool show_types, bool show_summary, bool verbose,
                  uint32_t depth) override;
 
-  bool DumpTypeValue(void *type, Stream *s, lldb::Format format,
-                     const DataExtractor &data, lldb::offset_t data_offset,
-                     size_t data_byte_size, uint32_t bitfield_bit_size,
-                     uint32_t bitfield_bit_offset,
+  bool DumpTypeValue(lldb::opaque_compiler_type_t type, Stream *s,
+                     lldb::Format format, const DataExtractor &data,
+                     lldb::offset_t data_offset, size_t data_byte_size,
+                     uint32_t bitfield_bit_size, uint32_t bitfield_bit_offset,
                      ExecutionContextScope *exe_scope,
                      bool is_base_class) override;
 
   void DumpTypeDescription(
-      void *type,
+      lldb::opaque_compiler_type_t type,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
   void DumpTypeDescription(
-      void *type, Stream *s,
+      lldb::opaque_compiler_type_t type, Stream *s,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
-  void DumpSummary(void *type, ExecutionContext *exe_ctx, Stream *s,
-                   const DataExtractor &data, lldb::offset_t data_offset,
-                   size_t data_byte_size) override;
-  bool IsPointerOrReferenceType(void *type,
+  void DumpSummary(lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
+                   Stream *s, const DataExtractor &data,
+                   lldb::offset_t data_offset, size_t data_byte_size) override;
+  bool IsPointerOrReferenceType(lldb::opaque_compiler_type_t type,
                                 CompilerType *pointee_type) override;
   llvm::Optional<size_t>
-  GetTypeBitAlign(void *type, ExecutionContextScope *exe_scope) override;
+  GetTypeBitAlign(lldb::opaque_compiler_type_t type,
+                  ExecutionContextScope *exe_scope) override;
   CompilerType GetBuiltinTypeForEncodingAndBitSize(lldb::Encoding encoding,
                                                    size_t bit_size) override {
     return CompilerType();
   }
-  bool IsTypedefType(void *type) override;
-  CompilerType GetTypedefedType(void *type) override;
-  CompilerType GetFullyUnqualifiedType(void *type) override;
-  CompilerType GetNonReferenceType(void *type) override;
-  CompilerType GetLValueReferenceType(void *type) override;
-  CompilerType GetRValueReferenceType(void *opaque_type) override;
-  uint32_t GetNumDirectBaseClasses(void *opaque_type) override;
-  CompilerType GetDirectBaseClassAtIndex(void *opaque_type, size_t idx,
+  bool IsTypedefType(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetTypedefedType(lldb::opaque_compiler_type_t type) override;
+  CompilerType
+  GetFullyUnqualifiedType(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetNonReferenceType(lldb::opaque_compiler_type_t type) override;
+  CompilerType
+  GetLValueReferenceType(lldb::opaque_compiler_type_t type) override;
+  CompilerType
+  GetRValueReferenceType(lldb::opaque_compiler_type_t type) override;
+  uint32_t GetNumDirectBaseClasses(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetDirectBaseClassAtIndex(lldb::opaque_compiler_type_t type,
+                                         size_t idx,
                                          uint32_t *bit_offset_ptr) override;
-  bool IsReferenceType(void *type, CompilerType *pointee_type,
-                       bool *is_rvalue) override;
+  bool IsReferenceType(lldb::opaque_compiler_type_t type,
+                       CompilerType *pointee_type, bool *is_rvalue) override;
   bool
   ShouldTreatScalarValueAsAddress(lldb::opaque_compiler_type_t type) override;
 
@@ -413,25 +456,25 @@ public:
                       CompilerType *original_type) override;
   CompilerType GetErrorType() override;
   CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
-  CompilerType GetInstanceType(void *type) override;
+  CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) override;
   TypeAllocationStrategy
   GetAllocationStrategy(lldb::opaque_compiler_type_t type) override;
   CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) override;
   void DumpTypeDescription(
-      void *type, bool print_help_if_available,
+      lldb::opaque_compiler_type_t type, bool print_help_if_available,
       bool print_extensions_if_available,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
   void DumpTypeDescription(
-      void *type, Stream *s, bool print_help_if_available,
-      bool print_extensions_if_available,
+      lldb::opaque_compiler_type_t type, Stream *s,
+      bool print_help_if_available, bool print_extensions_if_available,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
 
 private:
   /// Helper that creates an AST type from \p type.
-  void *ReconstructType(void *type);
+  void *ReconstructType(lldb::opaque_compiler_type_t type);
   /// Cast \p opaque_type as a mangled name.
-  const char *AsMangledName(void *opaque_type);
+  const char *AsMangledName(lldb::opaque_compiler_type_t opaque_type);
 
   /// Wrap \p node as \p Global(TypeMangling(node)), remangle the type
   /// and create a CompilerType from it.
@@ -443,7 +486,8 @@ private:
   ///
   /// \return the child of Type or a nullptr.
   swift::Demangle::NodePointer
-  DemangleCanonicalType(swift::Demangle::Demangler &Dem, void *opaque_type);
+  DemangleCanonicalType(swift::Demangle::Demangler &Dem,
+                        lldb::opaque_compiler_type_t type);
   /// The sibling SwiftASTContext.
   SwiftASTContext *m_swift_ast_context = nullptr;
 };
@@ -703,8 +747,9 @@ public:
   CompilerType GetCompilerType(swift::TypeBase *swift_type);
   CompilerType GetCompilerType(ConstString mangled_name);
   swift::Type GetSwiftType(CompilerType compiler_type);
-  swift::Type GetSwiftType(void *opaque_type);
-  swift::CanType GetCanonicalSwiftType(void *opaque_type);
+  swift::Type GetSwiftType(lldb::opaque_compiler_type_t opaque_type);
+  swift::CanType
+  GetCanonicalSwiftType(lldb::opaque_compiler_type_t opaque_type);
 
   // Imports the type from the passed in type into this SwiftASTContext. The
   // type must be a Swift type. If the type can be imported, returns the
@@ -765,9 +810,11 @@ public:
   Status GetFatalErrors();
   void DiagnoseWarnings(Process &process, Module &module) const override;
 
-  const swift::irgen::TypeInfo *GetSwiftTypeInfo(void *type);
+  const swift::irgen::TypeInfo *
+  GetSwiftTypeInfo(lldb::opaque_compiler_type_t type);
 
-  const swift::irgen::FixedTypeInfo *GetSwiftFixedTypeInfo(void *type);
+  const swift::irgen::FixedTypeInfo *
+  GetSwiftFixedTypeInfo(lldb::opaque_compiler_type_t type);
 
   bool IsFixedSize(CompilerType compiler_type);
 
@@ -799,41 +846,46 @@ public:
   bool Verify(lldb::opaque_compiler_type_t type) override;
 #endif
 
-  bool IsArrayType(void *type, CompilerType *element_type, uint64_t *size,
+  bool IsArrayType(lldb::opaque_compiler_type_t type,
+                   CompilerType *element_type, uint64_t *size,
                    bool *is_incomplete) override;
 
-  bool IsAggregateType(void *type) override;
+  bool IsAggregateType(lldb::opaque_compiler_type_t type) override;
 
-  bool IsDefined(void *type) override;
+  bool IsDefined(lldb::opaque_compiler_type_t type) override;
 
-  bool IsFloatingPointType(void *type, uint32_t &count,
+  bool IsFloatingPointType(lldb::opaque_compiler_type_t type, uint32_t &count,
                            bool &is_complex) override;
 
-  bool IsFunctionType(void *type, bool *is_variadic_ptr) override;
+  bool IsFunctionType(lldb::opaque_compiler_type_t type,
+                      bool *is_variadic_ptr) override;
 
-  size_t GetNumberOfFunctionArguments(void *type) override;
+  size_t
+  GetNumberOfFunctionArguments(lldb::opaque_compiler_type_t type) override;
 
-  CompilerType GetFunctionArgumentAtIndex(void *type,
+  CompilerType GetFunctionArgumentAtIndex(lldb::opaque_compiler_type_t type,
                                           const size_t index) override;
 
-  bool IsFunctionPointerType(void *type) override;
+  bool IsFunctionPointerType(lldb::opaque_compiler_type_t type) override;
 
-  bool IsIntegerType(void *type, bool &is_signed) override;
+  bool IsIntegerType(lldb::opaque_compiler_type_t type,
+                     bool &is_signed) override;
 
-  bool IsPossibleDynamicType(void *type,
+  bool IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
                              CompilerType *target_type, // Can pass NULL
                              bool check_cplusplus, bool check_objc) override;
 
-  bool IsPointerType(void *type, CompilerType *pointee_type) override;
+  bool IsPointerType(lldb::opaque_compiler_type_t type,
+                     CompilerType *pointee_type) override;
 
-  bool IsScalarType(void *type) override;
+  bool IsScalarType(lldb::opaque_compiler_type_t type) override;
 
-  bool IsVoidType(void *type) override;
+  bool IsVoidType(lldb::opaque_compiler_type_t type) override;
 
   static bool IsGenericType(const CompilerType &compiler_type);
 
   /// Whether this is the Swift error type.
-  bool IsErrorType(void *type);
+  bool IsErrorType(lldb::opaque_compiler_type_t type);
 
   static bool IsFullyRealized(const CompilerType &compiler_type);
 
@@ -876,7 +928,7 @@ public:
 
   // Type Completion
 
-  bool GetCompleteType(void *type) override;
+  bool GetCompleteType(lldb::opaque_compiler_type_t type) override;
 
   // AST related queries
 
@@ -884,43 +936,49 @@ public:
 
   // Accessors
 
-  ConstString GetTypeName(void *type) override;
+  ConstString GetTypeName(lldb::opaque_compiler_type_t type) override;
 
-  ConstString GetDisplayTypeName(void *type, const SymbolContext *sc) override;
+  ConstString GetDisplayTypeName(lldb::opaque_compiler_type_t type,
+                                 const SymbolContext *sc) override;
 
-  ConstString GetMangledTypeName(void *type) override;
+  ConstString GetMangledTypeName(lldb::opaque_compiler_type_t type) override;
 
-  uint32_t GetTypeInfo(void *type,
+  uint32_t GetTypeInfo(lldb::opaque_compiler_type_t type,
                        CompilerType *pointee_or_element_clang_type) override;
 
-  lldb::LanguageType GetMinimumLanguage(void *type) override;
+  lldb::LanguageType
+  GetMinimumLanguage(lldb::opaque_compiler_type_t type) override;
 
-  lldb::TypeClass GetTypeClass(void *type) override;
+  lldb::TypeClass GetTypeClass(lldb::opaque_compiler_type_t type) override;
 
   // Creating related types
 
-  CompilerType GetArrayElementType(void *type, uint64_t *stride) override;
+  CompilerType GetArrayElementType(lldb::opaque_compiler_type_t type,
+                                   uint64_t *stride) override;
 
-  CompilerType GetCanonicalType(void *type) override;
+  CompilerType GetCanonicalType(lldb::opaque_compiler_type_t type) override;
 
-  CompilerType GetInstanceType(void *type) override;
+  CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) override;
 
   // Returns -1 if this isn't a function of if the function doesn't have a
   // prototype. Returns a value >override if there is a prototype.
-  int GetFunctionArgumentCount(void *type) override;
+  int GetFunctionArgumentCount(lldb::opaque_compiler_type_t type) override;
 
-  CompilerType GetFunctionArgumentTypeAtIndex(void *type, size_t idx) override;
+  CompilerType GetFunctionArgumentTypeAtIndex(lldb::opaque_compiler_type_t type,
+                                              size_t idx) override;
 
-  CompilerType GetFunctionReturnType(void *type) override;
+  CompilerType
+  GetFunctionReturnType(lldb::opaque_compiler_type_t type) override;
 
-  size_t GetNumMemberFunctions(void *type) override;
+  size_t GetNumMemberFunctions(lldb::opaque_compiler_type_t type) override;
 
-  TypeMemberFunctionImpl GetMemberFunctionAtIndex(void *type,
-                                                  size_t idx) override;
+  TypeMemberFunctionImpl
+  GetMemberFunctionAtIndex(lldb::opaque_compiler_type_t type,
+                           size_t idx) override;
 
-  CompilerType GetPointeeType(void *type) override;
+  CompilerType GetPointeeType(lldb::opaque_compiler_type_t type) override;
 
-  CompilerType GetPointerType(void *type) override;
+  CompilerType GetPointerType(lldb::opaque_compiler_type_t type) override;
 
   // Exploring the type
 
@@ -932,22 +990,24 @@ public:
   GetByteStride(lldb::opaque_compiler_type_t type,
                 ExecutionContextScope *exe_scope) override;
 
-  lldb::Encoding GetEncoding(void *type, uint64_t &count) override;
+  lldb::Encoding GetEncoding(lldb::opaque_compiler_type_t type,
+                             uint64_t &count) override;
 
-  lldb::Format GetFormat(void *type) override;
+  lldb::Format GetFormat(lldb::opaque_compiler_type_t type) override;
 
-  uint32_t GetNumChildren(void *type, bool omit_empty_base_classes,
+  uint32_t GetNumChildren(lldb::opaque_compiler_type_t type,
+                          bool omit_empty_base_classes,
                           const ExecutionContext *exe_ctx) override;
 
-  uint32_t GetNumFields(void *type) override;
+  uint32_t GetNumFields(lldb::opaque_compiler_type_t type) override;
 
-  CompilerType GetFieldAtIndex(void *type, size_t idx, std::string &name,
-                               uint64_t *bit_offset_ptr,
+  CompilerType GetFieldAtIndex(lldb::opaque_compiler_type_t type, size_t idx,
+                               std::string &name, uint64_t *bit_offset_ptr,
                                uint32_t *bitfield_bit_size_ptr,
                                bool *is_bitfield_ptr) override;
 
   CompilerType GetChildCompilerTypeAtIndex(
-      void *type, ExecutionContext *exe_ctx, size_t idx,
+      lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
       bool transparent_pointers, bool omit_empty_base_classes,
       bool ignore_array_bounds, std::string &child_name,
       uint32_t &child_byte_size, int32_t &child_byte_offset,
@@ -957,7 +1017,8 @@ public:
 
   // Lookup a child given a name. This function will match base class names
   // and member names in "clang_type" only, not descendants.
-  uint32_t GetIndexOfChildWithName(void *type, const char *name,
+  uint32_t GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
+                                   const char *name,
                                    bool omit_empty_base_classes) override;
 
   // Lookup a child member given a name. This function will match member names
@@ -967,23 +1028,29 @@ public:
   // vector<vector<uint32_t>> so we catch all names that match a given child
   // name, not just the first.
   size_t
-  GetIndexOfChildMemberWithName(void *type, const char *name,
-                                bool omit_empty_base_classes,
+  GetIndexOfChildMemberWithName(lldb::opaque_compiler_type_t type,
+                                const char *name, bool omit_empty_base_classes,
                                 std::vector<uint32_t> &child_indexes) override;
 
-  size_t GetNumTemplateArguments(void *type) override;
+  size_t GetNumTemplateArguments(lldb::opaque_compiler_type_t type) override;
 
-  lldb::GenericKind GetGenericArgumentKind(void *type, size_t idx);
-  CompilerType GetUnboundGenericType(void *type, size_t idx);
-  CompilerType GetBoundGenericType(void *type, size_t idx);
+  lldb::GenericKind GetGenericArgumentKind(lldb::opaque_compiler_type_t type,
+                                           size_t idx);
+  CompilerType GetUnboundGenericType(lldb::opaque_compiler_type_t type,
+                                     size_t idx);
+  CompilerType GetBoundGenericType(lldb::opaque_compiler_type_t type,
+                                   size_t idx);
   static CompilerType GetGenericArgumentType(CompilerType ct, size_t idx);
-  CompilerType GetGenericArgumentType(void *type, size_t idx);
+  CompilerType GetGenericArgumentType(lldb::opaque_compiler_type_t type,
+                                      size_t idx);
 
-  CompilerType GetTypeForFormatters(void *type) override;
+  CompilerType GetTypeForFormatters(lldb::opaque_compiler_type_t type) override;
 
-  LazyBool ShouldPrintAsOneLiner(void *type, ValueObject *valobj) override;
+  LazyBool ShouldPrintAsOneLiner(lldb::opaque_compiler_type_t type,
+                                 ValueObject *valobj) override;
 
-  bool IsMeaninglessWithoutDynamicResolution(void *type) override;
+  bool IsMeaninglessWithoutDynamicResolution(
+      lldb::opaque_compiler_type_t type) override;
 
   static bool GetSelectedEnumCase(const CompilerType &type,
                                   const DataExtractor &data, ConstString *name,
@@ -997,86 +1064,83 @@ public:
   dump(lldb::opaque_compiler_type_t type) const override;
 #endif
 
-  void DumpValue(void *type, ExecutionContext *exe_ctx, Stream *s,
-                 lldb::Format format, const DataExtractor &data,
+  void DumpValue(lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
+                 Stream *s, lldb::Format format, const DataExtractor &data,
                  lldb::offset_t data_offset, size_t data_byte_size,
                  uint32_t bitfield_bit_size, uint32_t bitfield_bit_offset,
                  bool show_types, bool show_summary, bool verbose,
                  uint32_t depth) override;
 
-  bool DumpTypeValue(void *type, Stream *s, lldb::Format format,
-                     const DataExtractor &data, lldb::offset_t data_offset,
-                     size_t data_byte_size, uint32_t bitfield_bit_size,
-                     uint32_t bitfield_bit_offset,
+  bool DumpTypeValue(lldb::opaque_compiler_type_t type, Stream *s,
+                     lldb::Format format, const DataExtractor &data,
+                     lldb::offset_t data_offset, size_t data_byte_size,
+                     uint32_t bitfield_bit_size, uint32_t bitfield_bit_offset,
                      ExecutionContextScope *exe_scope,
                      bool is_base_class) override;
 
   void
-  DumpTypeDescription(void *type,
+  DumpTypeDescription(lldb::opaque_compiler_type_t type,
                       lldb::DescriptionLevel level) override; // Dump to stdout
 
   void DumpTypeDescription(
-      void *type, Stream *s,
+      lldb::opaque_compiler_type_t type, Stream *s,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
 
   void DumpTypeDescription(
-      void *type, bool print_help_if_available,
+      lldb::opaque_compiler_type_t type, bool print_help_if_available,
       bool print_extensions_if_available,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
 
   void DumpTypeDescription(
-      void *type, Stream *s, bool print_help_if_available,
-      bool print_extensions_if_available,
+      lldb::opaque_compiler_type_t type, Stream *s,
+      bool print_help_if_available, bool print_extensions_if_available,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
 
   // TODO: These methods appear unused. Should they be removed?
 
-  void DumpSummary(void *type, ExecutionContext *exe_ctx, Stream *s,
-                   const DataExtractor &data, lldb::offset_t data_offset,
-                   size_t data_byte_size) override;
+  void DumpSummary(lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
+                   Stream *s, const DataExtractor &data,
+                   lldb::offset_t data_offset, size_t data_byte_size) override;
 
   // TODO: Determine if these methods should move to TypeSystemClang.
 
-  bool IsPointerOrReferenceType(void *type,
+  bool IsPointerOrReferenceType(lldb::opaque_compiler_type_t type,
                                 CompilerType *pointee_type) override;
 
   llvm::Optional<size_t>
-  GetTypeBitAlign(void *type, ExecutionContextScope *exe_scope) override;
+  GetTypeBitAlign(lldb::opaque_compiler_type_t type,
+                  ExecutionContextScope *exe_scope) override;
 
   CompilerType GetBuiltinTypeForEncodingAndBitSize(lldb::Encoding encoding,
                                                    size_t bit_size) override {
     return CompilerType();
   }
 
-  bool IsTypedefType(void *type) override;
+  bool IsTypedefType(lldb::opaque_compiler_type_t type) override;
 
   // If the current object represents a typedef type, get the underlying type
-  CompilerType GetTypedefedType(void *type) override;
-
+  CompilerType GetTypedefedType(lldb::opaque_compiler_type_t type) override;
   CompilerType GetUnboundType(lldb::opaque_compiler_type_t type);
-
   std::string GetSuperclassName(const CompilerType &superclass_type);
-
-  CompilerType GetFullyUnqualifiedType(void *type) override;
-
-  CompilerType GetNonReferenceType(void *type) override;
-
-  CompilerType GetLValueReferenceType(void *type) override;
-
-  CompilerType GetRValueReferenceType(void *opaque_type) override;
-
-  uint32_t GetNumDirectBaseClasses(void *opaque_type) override;
-
-  CompilerType GetDirectBaseClassAtIndex(void *opaque_type, size_t idx,
+  CompilerType
+  GetFullyUnqualifiedType(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetNonReferenceType(lldb::opaque_compiler_type_t type) override;
+  CompilerType
+  GetLValueReferenceType(lldb::opaque_compiler_type_t type) override;
+  CompilerType
+  GetRValueReferenceType(lldb::opaque_compiler_type_t type) override;
+  uint32_t GetNumDirectBaseClasses(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetDirectBaseClassAtIndex(lldb::opaque_compiler_type_t type,
+                                         size_t idx,
                                          uint32_t *bit_offset_ptr) override;
 
-  bool IsReferenceType(void *type, CompilerType *pointee_type,
-                       bool *is_rvalue) override;
+  bool IsReferenceType(lldb::opaque_compiler_type_t type,
+                       CompilerType *pointee_type, bool *is_rvalue) override;
 
   bool
   ShouldTreatScalarValueAsAddress(lldb::opaque_compiler_type_t type) override;
 
-  uint32_t GetNumPointeeChildren(void *type);
+  uint32_t GetNumPointeeChildren(lldb::opaque_compiler_type_t type);
 
   bool IsImportedType(lldb::opaque_compiler_type_t type,
                       CompilerType *original_type) override;
@@ -1221,7 +1285,7 @@ protected:
   llvm::ArrayRef<swift::VarDecl *>
   GetStoredProperties(swift::NominalTypeDecl *nominal);
 
-  SwiftEnumDescriptor *GetCachedEnumInfo(void *type);
+  SwiftEnumDescriptor *GetCachedEnumInfo(lldb::opaque_compiler_type_t type);
 
   friend class CompilerType;
 

--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -134,7 +134,7 @@ public:
   virtual lldb::TypeSP GetCachedType(ConstString mangled) = 0;
   virtual void SetCachedType(ConstString mangled,
                              const lldb::TypeSP &type_sp) = 0;
-  virtual bool IsImportedType(CompilerType type,
+  virtual bool IsImportedType(lldb::opaque_compiler_type_t type,
                               CompilerType *original_type) = 0;
   virtual CompilerType GetErrorType() = 0;
   virtual CompilerType GetReferentType(CompilerType compiler_type) = 0;
@@ -408,7 +408,8 @@ public:
   // Swift-specific methods.
   lldb::TypeSP GetCachedType(ConstString mangled) override;
   void SetCachedType(ConstString mangled, const lldb::TypeSP &type_sp) override;
-  bool IsImportedType(CompilerType type, CompilerType *original_type) override;
+  bool IsImportedType(lldb::opaque_compiler_type_t type,
+                      CompilerType *original_type) override;
   CompilerType GetErrorType() override;
   CompilerType GetReferentType(CompilerType compiler_type) override;
   CompilerType GetInstanceType(void *type) override;
@@ -1074,7 +1075,8 @@ public:
 
   uint32_t GetNumPointeeChildren(void *type);
 
-  bool IsImportedType(CompilerType type, CompilerType *original_type) override;
+  bool IsImportedType(lldb::opaque_compiler_type_t type,
+                      CompilerType *original_type) override;
 
   CompilerType GetReferentType(CompilerType compiler_type) override;
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -1138,9 +1138,11 @@ bool SwiftASTManipulator::AddExternalVariables(
           variable.m_type.GetTypeSystem());
 
       CompilerType referent_type;
-
       if (swift_ast_ctx)
-        referent_type = swift_ast_ctx->GetReferentType(variable.m_type);
+        referent_type =
+            swift_ast_ctx->GetReferentType(variable.m_type.GetOpaqueQualType());
+      if (!referent_type)
+        continue;
 
       // One tricky bit here is that this var may be an argument to the function
       // whose context we are

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -531,7 +531,7 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
   // extend the referent:
   imported_self_type =
       llvm::cast<TypeSystemSwift>(imported_self_type.GetTypeSystem())
-          ->GetReferentType(imported_self_type);
+          ->GetReferentType(imported_self_type.GetOpaqueQualType());
 
   // If we are extending a generic class it's going to be a metatype,
   // and we have to grab the instance type:
@@ -553,7 +553,6 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
   if (swift::WeakStorageType *weak_storage_type =
           GetSwiftType(imported_self_type)->getAs<swift::WeakStorageType>()) {
     swift::Type referent_type = weak_storage_type->getReferentType();
-
     swift::BoundGenericEnumType *optional_type =
         referent_type->getAs<swift::BoundGenericEnumType>();
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -244,14 +244,13 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
     self_type = ToCompilerType(object_type.getPointer());
 
   // Handle weak self.
-  if (self_type)
-    if (auto *ref_type = llvm::dyn_cast<swift::ReferenceStorageType>(
-            GetSwiftType(self_type).getPointer())) {
-      if (ref_type->getOwnership() == swift::ReferenceOwnership::Weak) {
-        m_is_class = true;
-        m_is_weak_self = true;
-      }
+  if (auto *ref_type = llvm::dyn_cast_or_null<swift::ReferenceStorageType>(
+          GetSwiftType(self_type).getPointer())) {
+    if (ref_type->getOwnership() == swift::ReferenceOwnership::Weak) {
+      m_is_class = true;
+      m_is_weak_self = true;
     }
+  }
 
   if (Flags(self_type.GetTypeInfo())
           .AllSet(lldb::eTypeIsSwift | lldb::eTypeIsStructUnion |

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -244,13 +244,14 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
     self_type = ToCompilerType(object_type.getPointer());
 
   // Handle weak self.
-  if (auto *ref_type = llvm::dyn_cast_or_null<swift::ReferenceStorageType>(
-          GetSwiftType(self_type).getPointer())) {
-    if (ref_type->getOwnership() == swift::ReferenceOwnership::Weak) {
-      m_is_class = true;
-      m_is_weak_self = true;
+  if (self_type)
+    if (auto *ref_type = llvm::dyn_cast<swift::ReferenceStorageType>(
+            GetSwiftType(self_type).getPointer())) {
+      if (ref_type->getOwnership() == swift::ReferenceOwnership::Weak) {
+        m_is_class = true;
+        m_is_weak_self = true;
+      }
     }
-  }
 
   if (Flags(self_type.GetTypeInfo())
           .AllSet(lldb::eTypeIsSwift | lldb::eTypeIsStructUnion |

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -780,8 +780,8 @@ SwiftLanguage::GetHardcodedSynthetics() {
                 TypeSystemSwift *swift_ast_ctx =
                     llvm::dyn_cast_or_null<TypeSystemSwift>(
                         type.GetTypeSystem());
-                if (swift_ast_ctx &&
-                    swift_ast_ctx->IsImportedType(type, nullptr))
+                if (swift_ast_ctx && swift_ast_ctx->IsImportedType(
+                                         type.GetOpaqueQualType(), nullptr))
                   is_imported = true;
               }
 

--- a/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
@@ -39,7 +39,8 @@ static clang::EnumDecl *GetAsEnumDecl(CompilerType swift_type) {
     return nullptr;
 
   CompilerType clang_type;
-  if (!swift_ast_ctx->IsImportedType(swift_type, &clang_type))
+  if (!swift_ast_ctx->IsImportedType(swift_type.GetOpaqueQualType(),
+                                     &clang_type))
     return nullptr;
 
   if (!clang_type.IsValid())

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -5294,23 +5294,22 @@ bool SwiftASTContext::GetProtocolTypeInfo(const CompilerType &type,
 }
 
 TypeSystemSwift::TypeAllocationStrategy
-SwiftASTContext::GetAllocationStrategy(CompilerType type) {
-  if (swift::Type swift_type = ::GetSwiftType(type)) {
-    auto *ast = GetSwiftASTContext(&swift_type->getASTContext());
-    const swift::irgen::TypeInfo *type_info =
-        ast->GetSwiftTypeInfo(swift_type.getPointer());
-    if (!type_info)
-      return TypeAllocationStrategy::eUnknown;
-    switch (type_info->getFixedPacking(ast->GetIRGenModule())) {
-    case swift::irgen::FixedPacking::OffsetZero:
-      return TypeAllocationStrategy::eInline;
-    case swift::irgen::FixedPacking::Allocate:
-      return TypeAllocationStrategy::ePointer;
-    case swift::irgen::FixedPacking::Dynamic:
-      return TypeAllocationStrategy::eDynamic;
-    }
+SwiftASTContext::GetAllocationStrategy(void *type) {
+  swift::Type swift_type = GetSwiftType(type);
+  if (!swift_type)
+    return TypeAllocationStrategy::eUnknown;
+  const swift::irgen::TypeInfo *type_info =
+      GetSwiftTypeInfo(swift_type.getPointer());
+  if (!type_info)
+    return TypeAllocationStrategy::eUnknown;
+  switch (type_info->getFixedPacking(GetIRGenModule())) {
+  case swift::irgen::FixedPacking::OffsetZero:
+    return TypeAllocationStrategy::eInline;
+  case swift::irgen::FixedPacking::Allocate:
+    return TypeAllocationStrategy::ePointer;
+  case swift::irgen::FixedPacking::Dynamic:
+    return TypeAllocationStrategy::eDynamic;
   }
-
   return TypeAllocationStrategy::eUnknown;
 }
 

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -5210,14 +5210,12 @@ static CompilerType BindAllArchetypes(CompilerType type,
   return type;
 }
 
-bool SwiftASTContext::IsErrorType(CompilerType compiler_type) {
-  if (!compiler_type.IsValid())
+bool SwiftASTContext::IsErrorType(void *type) {
+  if (!type)
     return false;
-  if (!llvm::isa<TypeSystemSwift>(compiler_type.GetTypeSystem()))
-    return false;
-  ProtocolInfo protocol_info;
 
-  if (GetProtocolTypeInfo(compiler_type, protocol_info))
+  ProtocolInfo protocol_info;
+  if (GetProtocolTypeInfo({this, type}, protocol_info))
     return protocol_info.m_is_errortype;
   return false;
 }

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -5222,19 +5222,18 @@ bool SwiftASTContext::IsErrorType(void *type) {
   return false;
 }
 
-CompilerType SwiftASTContext::GetReferentType(CompilerType compiler_type) {
+CompilerType SwiftASTContext::GetReferentType(void *type) {
   VALID_OR_RETURN(CompilerType());
 
-  if (swift::Type swift_type = ::GetSwiftType(compiler_type)) {
-    swift::TypeBase *swift_typebase = swift_type.getPointer();
-    if (swift_type && llvm::isa<swift::WeakStorageType>(swift_typebase))
-      return compiler_type;
+  swift::Type swift_type = GetSwiftType(type);
+  if (!swift_type)
+    return {};
+  swift::TypeBase *swift_typebase = swift_type.getPointer();
+  if (swift_type && llvm::isa<swift::WeakStorageType>(swift_typebase))
+    return {this, type};
 
-    auto ref_type = swift_type->getReferenceStorageReferent();
-    return ToCompilerType({ref_type});
-  }
-
-  return {};
+  auto ref_type = swift_type->getReferenceStorageReferent();
+  return ToCompilerType({ref_type});
 }
 
 bool SwiftASTContext::IsFullyRealized(const CompilerType &compiler_type) {

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -209,19 +209,20 @@ swift::Type SwiftASTContext::GetSwiftType(CompilerType compiler_type) {
   return {};
 }
 
-swift::Type SwiftASTContext::GetSwiftType(void *opaque_type) {
+swift::Type SwiftASTContext::GetSwiftType(opaque_compiler_type_t opaque_type) {
   assert(opaque_type && *reinterpret_cast<const char *>(opaque_type) != '$' &&
          "wrong type system");
   return lldb_private::GetSwiftType(CompilerType(this, opaque_type));
 }
 
-swift::CanType SwiftASTContext::GetCanonicalSwiftType(void *opaque_type) {
+swift::CanType
+SwiftASTContext::GetCanonicalSwiftType(opaque_compiler_type_t opaque_type) {
   assert(opaque_type && *reinterpret_cast<const char *>(opaque_type) != '$' &&
          "wrong type system");
   return lldb_private::GetCanonicalSwiftType(CompilerType(this, opaque_type));
 }
 
-ConstString SwiftASTContext::GetMangledTypeName(void *type) {
+ConstString SwiftASTContext::GetMangledTypeName(opaque_compiler_type_t type) {
   return GetMangledTypeName(GetSwiftType({this, type}).getPointer());
 }
 
@@ -246,7 +247,7 @@ static ThreadSafeSwiftASTMap &GetASTMap() {
 class SwiftEnumDescriptor;
 
 typedef std::shared_ptr<SwiftEnumDescriptor> SwiftEnumDescriptorSP;
-typedef llvm::DenseMap<lldb::opaque_compiler_type_t, SwiftEnumDescriptorSP>
+typedef llvm::DenseMap<opaque_compiler_type_t, SwiftEnumDescriptorSP>
     EnumInfoCache;
 typedef std::shared_ptr<EnumInfoCache> EnumInfoCacheSP;
 typedef llvm::DenseMap<const swift::ASTContext *, EnumInfoCacheSP>
@@ -825,7 +826,8 @@ GetEnumInfoFromEnumDecl(swift::ASTContext *ast, swift::CanType swift_can_type,
   return SwiftEnumDescriptor::CreateDescriptor(ast, swift_can_type, enum_decl);
 }
 
-SwiftEnumDescriptor *SwiftASTContext::GetCachedEnumInfo(void *type) {
+SwiftEnumDescriptor *
+SwiftASTContext::GetCachedEnumInfo(opaque_compiler_type_t type) {
   VALID_OR_RETURN(nullptr);
 
   if (type) {
@@ -1655,7 +1657,8 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
     llvm::SmallString<0> error;
     llvm::raw_svector_ostream errs(error);
     if (DeserializeAllCompilerFlags(*swift_ast_sp, module, m_description, errs,
-                                    got_serialized_options, found_swift_modules)) {
+                                    got_serialized_options,
+                                    found_swift_modules)) {
       // Validation errors are not fatal for the context.
       swift_ast_sp->m_module_import_warnings.push_back(error.str());
     }
@@ -4182,11 +4185,11 @@ CompilerType SwiftASTContext::GetAsClangType(ConstString mangled_name) {
   return clang_type;
 }
 
-swift::TypeBase *SwiftASTContext::ReconstructType(ConstString mangled_typename) {
+swift::TypeBase *
+SwiftASTContext::ReconstructType(ConstString mangled_typename) {
   Status error;
 
-  auto reconstructed_type =
-      this->ReconstructType(mangled_typename, error);
+  auto reconstructed_type = this->ReconstructType(mangled_typename, error);
   if (!error.Success()) {
     this->AddErrorStatusAsGenericDiagnostic(error);
   }
@@ -4958,7 +4961,7 @@ void SwiftASTContext::AddDebuggerClient(
 }
 
 #ifndef NDEBUG
-bool SwiftASTContext::Verify(lldb::opaque_compiler_type_t type) {
+bool SwiftASTContext::Verify(opaque_compiler_type_t type) {
   // Manual casting to avoid construction a temporary CompilerType
   // that would recursively trigger another call to Verify().
   swift::TypeBase *swift_type = reinterpret_cast<swift::TypeBase *>(type);
@@ -4967,7 +4970,8 @@ bool SwiftASTContext::Verify(lldb::opaque_compiler_type_t type) {
 }
 #endif
 
-bool SwiftASTContext::IsArrayType(void *type, CompilerType *element_type_ptr,
+bool SwiftASTContext::IsArrayType(opaque_compiler_type_t type,
+                                  CompilerType *element_type_ptr,
                                   uint64_t *size, bool *is_incomplete) {
   VALID_OR_RETURN(false);
 
@@ -4997,7 +5001,7 @@ bool SwiftASTContext::IsArrayType(void *type, CompilerType *element_type_ptr,
   return false;
 }
 
-bool SwiftASTContext::IsAggregateType(void *type) {
+bool SwiftASTContext::IsAggregateType(opaque_compiler_type_t type) {
   if (type) {
     swift::CanType swift_can_type(GetCanonicalSwiftType(type));
     auto referent_type = swift_can_type->getReferenceStorageReferent();
@@ -5009,7 +5013,8 @@ bool SwiftASTContext::IsAggregateType(void *type) {
   return false;
 }
 
-bool SwiftASTContext::IsFunctionType(void *type, bool *is_variadic_ptr) {
+bool SwiftASTContext::IsFunctionType(opaque_compiler_type_t type,
+                                     bool *is_variadic_ptr) {
   if (type) {
     swift::CanType swift_can_type(GetCanonicalSwiftType(type));
     const swift::TypeKind type_kind = swift_can_type->getKind();
@@ -5026,7 +5031,8 @@ bool SwiftASTContext::IsFunctionType(void *type, bool *is_variadic_ptr) {
   return false;
 }
 
-size_t SwiftASTContext::GetNumberOfFunctionArguments(void *type) {
+size_t
+SwiftASTContext::GetNumberOfFunctionArguments(opaque_compiler_type_t type) {
   if (type) {
     swift::CanType swift_can_type(GetCanonicalSwiftType(type));
     auto func = swift::dyn_cast_or_null<swift::AnyFunctionType>(swift_can_type);
@@ -5037,8 +5043,9 @@ size_t SwiftASTContext::GetNumberOfFunctionArguments(void *type) {
   return 0;
 }
 
-CompilerType SwiftASTContext::GetFunctionArgumentAtIndex(void *type,
-                                                         const size_t index) {
+CompilerType
+SwiftASTContext::GetFunctionArgumentAtIndex(opaque_compiler_type_t type,
+                                            const size_t index) {
   VALID_OR_RETURN(CompilerType());
 
   if (type) {
@@ -5055,15 +5062,17 @@ CompilerType SwiftASTContext::GetFunctionArgumentAtIndex(void *type,
   return {};
 }
 
-bool SwiftASTContext::IsFunctionPointerType(void *type) {
+bool SwiftASTContext::IsFunctionPointerType(opaque_compiler_type_t type) {
   return IsFunctionType(type, nullptr); // FIXME: think about this
 }
 
-bool SwiftASTContext::IsIntegerType(void *type, bool &is_signed) {
+bool SwiftASTContext::IsIntegerType(opaque_compiler_type_t type,
+                                    bool &is_signed) {
   return (GetTypeInfo(type, nullptr) & eTypeIsInteger);
 }
 
-bool SwiftASTContext::IsPointerType(void *type, CompilerType *pointee_type) {
+bool SwiftASTContext::IsPointerType(opaque_compiler_type_t type,
+                                    CompilerType *pointee_type) {
   VALID_OR_RETURN(false);
 
   if (type) {
@@ -5080,19 +5089,20 @@ bool SwiftASTContext::IsPointerType(void *type, CompilerType *pointee_type) {
   return false;
 }
 
-bool SwiftASTContext::IsPointerOrReferenceType(void *type,
+bool SwiftASTContext::IsPointerOrReferenceType(opaque_compiler_type_t type,
                                                CompilerType *pointee_type) {
   return IsPointerType(type, pointee_type) ||
          IsReferenceType(type, pointee_type, nullptr);
 }
 
 bool SwiftASTContext::ShouldTreatScalarValueAsAddress(
-    lldb::opaque_compiler_type_t type) {
+    opaque_compiler_type_t type) {
   return Flags(GetTypeInfo(type, nullptr))
       .AnySet(eTypeInstanceIsPointer | eTypeIsReference);
 }
 
-bool SwiftASTContext::IsReferenceType(void *type, CompilerType *pointee_type,
+bool SwiftASTContext::IsReferenceType(opaque_compiler_type_t type,
+                                      CompilerType *pointee_type,
                                       bool *is_rvalue) {
   if (type) {
     swift::CanType swift_can_type(GetCanonicalSwiftType(type));
@@ -5111,8 +5121,8 @@ bool SwiftASTContext::IsReferenceType(void *type, CompilerType *pointee_type,
   return false;
 }
 
-bool SwiftASTContext::IsFloatingPointType(void *type, uint32_t &count,
-                                          bool &is_complex) {
+bool SwiftASTContext::IsFloatingPointType(opaque_compiler_type_t type,
+                                          uint32_t &count, bool &is_complex) {
   if (type) {
     if (GetTypeInfo(type, nullptr) & eTypeIsFloat) {
       count = 1;
@@ -5125,14 +5135,14 @@ bool SwiftASTContext::IsFloatingPointType(void *type, uint32_t &count,
   return false;
 }
 
-bool SwiftASTContext::IsDefined(void *type) {
+bool SwiftASTContext::IsDefined(opaque_compiler_type_t type) {
   if (!type)
     return false;
 
   return true;
 }
 
-bool SwiftASTContext::IsPossibleDynamicType(void *type,
+bool SwiftASTContext::IsPossibleDynamicType(opaque_compiler_type_t type,
                                             CompilerType *dynamic_pointee_type,
                                             bool check_cplusplus,
                                             bool check_objc) {
@@ -5169,21 +5179,21 @@ bool SwiftASTContext::IsPossibleDynamicType(void *type,
   return false;
 }
 
-bool SwiftASTContext::IsScalarType(void *type) {
+bool SwiftASTContext::IsScalarType(opaque_compiler_type_t type) {
   if (!type)
     return false;
 
   return (GetTypeInfo(type, nullptr) & eTypeIsScalar) != 0;
 }
 
-bool SwiftASTContext::IsTypedefType(void *type) {
+bool SwiftASTContext::IsTypedefType(opaque_compiler_type_t type) {
   if (!type)
     return false;
   swift::Type swift_type(GetSwiftType(type));
   return swift::isa<swift::TypeAliasType>(swift_type.getPointer());
 }
 
-bool SwiftASTContext::IsVoidType(void *type) {
+bool SwiftASTContext::IsVoidType(opaque_compiler_type_t type) {
   VALID_OR_RETURN(false);
 
   if (!type)
@@ -5212,7 +5222,7 @@ static CompilerType BindAllArchetypes(CompilerType type,
   return type;
 }
 
-bool SwiftASTContext::IsErrorType(void *type) {
+bool SwiftASTContext::IsErrorType(opaque_compiler_type_t type) {
   if (!type)
     return false;
 
@@ -5222,7 +5232,7 @@ bool SwiftASTContext::IsErrorType(void *type) {
   return false;
 }
 
-CompilerType SwiftASTContext::GetReferentType(void *type) {
+CompilerType SwiftASTContext::GetReferentType(opaque_compiler_type_t type) {
   VALID_OR_RETURN(CompilerType());
 
   swift::Type swift_type = GetSwiftType(type);
@@ -5294,7 +5304,7 @@ bool SwiftASTContext::GetProtocolTypeInfo(const CompilerType &type,
 }
 
 TypeSystemSwift::TypeAllocationStrategy
-SwiftASTContext::GetAllocationStrategy(void *type) {
+SwiftASTContext::GetAllocationStrategy(opaque_compiler_type_t type) {
   swift::Type swift_type = GetSwiftType(type);
   if (!swift_type)
     return TypeAllocationStrategy::eUnknown;
@@ -5317,9 +5327,11 @@ SwiftASTContext::GetAllocationStrategy(void *type) {
 // Type Completion
 //----------------------------------------------------------------------
 
-bool SwiftASTContext::GetCompleteType(void *type) { return true; }
+bool SwiftASTContext::GetCompleteType(opaque_compiler_type_t type) {
+  return true;
+}
 
-ConstString SwiftASTContext::GetTypeName(void *type) {
+ConstString SwiftASTContext::GetTypeName(opaque_compiler_type_t type) {
   std::string type_name;
   if (type) {
     swift::Type swift_type(GetSwiftType(type));
@@ -5372,7 +5384,7 @@ GetArchetypeNames(swift::Type swift_type, swift::ASTContext &ast_ctx,
   return dict;
 }
 
-ConstString SwiftASTContext::GetDisplayTypeName(void *type,
+ConstString SwiftASTContext::GetDisplayTypeName(opaque_compiler_type_t type,
                                                 const SymbolContext *sc) {
   VALID_OR_RETURN(ConstString("<invalid Swift context>"));
   std::string type_name(GetTypeName(type).AsCString(""));
@@ -5390,7 +5402,7 @@ ConstString SwiftASTContext::GetDisplayTypeName(void *type,
 }
 
 uint32_t
-SwiftASTContext::GetTypeInfo(void *type,
+SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
                              CompilerType *pointee_or_element_clang_type) {
   VALID_OR_RETURN(0);
 
@@ -5531,14 +5543,15 @@ SwiftASTContext::GetTypeInfo(void *type,
   return swift_flags;
 }
 
-lldb::LanguageType SwiftASTContext::GetMinimumLanguage(void *type) {
+lldb::LanguageType
+SwiftASTContext::GetMinimumLanguage(opaque_compiler_type_t type) {
   if (!type)
     return lldb::eLanguageTypeC;
 
   return lldb::eLanguageTypeSwift;
 }
 
-lldb::TypeClass SwiftASTContext::GetTypeClass(void *type) {
+lldb::TypeClass SwiftASTContext::GetTypeClass(opaque_compiler_type_t type) {
   VALID_OR_RETURN(lldb::eTypeClassInvalid);
 
   if (!type)
@@ -5640,7 +5653,7 @@ lldb::TypeClass SwiftASTContext::GetTypeClass(void *type) {
 // Creating related types
 //----------------------------------------------------------------------
 
-CompilerType SwiftASTContext::GetArrayElementType(void *type,
+CompilerType SwiftASTContext::GetArrayElementType(opaque_compiler_type_t type,
                                                   uint64_t *stride) {
   VALID_OR_RETURN(CompilerType());
 
@@ -5671,7 +5684,7 @@ CompilerType SwiftASTContext::GetArrayElementType(void *type,
   return element_type;
 }
 
-CompilerType SwiftASTContext::GetCanonicalType(void *type) {
+CompilerType SwiftASTContext::GetCanonicalType(opaque_compiler_type_t type) {
   VALID_OR_RETURN(CompilerType());
 
   if (type)
@@ -5679,7 +5692,7 @@ CompilerType SwiftASTContext::GetCanonicalType(void *type) {
   return CompilerType();
 }
 
-CompilerType SwiftASTContext::GetInstanceType(void *type) {
+CompilerType SwiftASTContext::GetInstanceType(opaque_compiler_type_t type) {
   if (!type)
     return {};
 
@@ -5693,22 +5706,25 @@ CompilerType SwiftASTContext::GetInstanceType(void *type) {
   return ToCompilerType({GetSwiftType(type)});
 }
 
-CompilerType SwiftASTContext::GetFullyUnqualifiedType(void *type) {
+CompilerType
+SwiftASTContext::GetFullyUnqualifiedType(opaque_compiler_type_t type) {
   VALID_OR_RETURN(CompilerType());
 
   return ToCompilerType({GetSwiftType(type)});
 }
 
-int SwiftASTContext::GetFunctionArgumentCount(void *type) {
+int SwiftASTContext::GetFunctionArgumentCount(opaque_compiler_type_t type) {
   return GetNumberOfFunctionArguments(type);
 }
 
-CompilerType SwiftASTContext::GetFunctionArgumentTypeAtIndex(void *type,
-                                                             size_t idx) {
+CompilerType
+SwiftASTContext::GetFunctionArgumentTypeAtIndex(opaque_compiler_type_t type,
+                                                size_t idx) {
   return GetFunctionArgumentAtIndex(type, idx);
 }
 
-CompilerType SwiftASTContext::GetFunctionReturnType(void *type) {
+CompilerType
+SwiftASTContext::GetFunctionReturnType(opaque_compiler_type_t type) {
   VALID_OR_RETURN(CompilerType());
 
   if (type) {
@@ -5720,7 +5736,7 @@ CompilerType SwiftASTContext::GetFunctionReturnType(void *type) {
   return {};
 }
 
-size_t SwiftASTContext::GetNumMemberFunctions(void *type) {
+size_t SwiftASTContext::GetNumMemberFunctions(opaque_compiler_type_t type) {
   size_t num_functions = 0;
   if (type) {
     swift::CanType swift_can_type(GetCanonicalSwiftType(type));
@@ -5745,8 +5761,9 @@ size_t SwiftASTContext::GetNumMemberFunctions(void *type) {
   return num_functions;
 }
 
-TypeMemberFunctionImpl SwiftASTContext::GetMemberFunctionAtIndex(void *type,
-                                                                 size_t idx) {
+TypeMemberFunctionImpl
+SwiftASTContext::GetMemberFunctionAtIndex(opaque_compiler_type_t type,
+                                          size_t idx) {
   VALID_OR_RETURN(TypeMemberFunctionImpl());
 
   std::string name("");
@@ -5818,7 +5835,8 @@ TypeMemberFunctionImpl SwiftASTContext::GetMemberFunctionAtIndex(void *type,
   return TypeMemberFunctionImpl();
 }
 
-CompilerType SwiftASTContext::GetLValueReferenceType(void *type) {
+CompilerType
+SwiftASTContext::GetLValueReferenceType(opaque_compiler_type_t type) {
   VALID_OR_RETURN(CompilerType());
 
   if (type)
@@ -5826,9 +5844,12 @@ CompilerType SwiftASTContext::GetLValueReferenceType(void *type) {
   return {};
 }
 
-CompilerType SwiftASTContext::GetRValueReferenceType(void *type) { return {}; }
+CompilerType
+SwiftASTContext::GetRValueReferenceType(opaque_compiler_type_t type) {
+  return {};
+}
 
-CompilerType SwiftASTContext::GetNonReferenceType(void *type) {
+CompilerType SwiftASTContext::GetNonReferenceType(opaque_compiler_type_t type) {
   VALID_OR_RETURN(CompilerType());
 
   if (type) {
@@ -5841,9 +5862,11 @@ CompilerType SwiftASTContext::GetNonReferenceType(void *type) {
   return {};
 }
 
-CompilerType SwiftASTContext::GetPointeeType(void *type) { return {}; }
+CompilerType SwiftASTContext::GetPointeeType(opaque_compiler_type_t type) {
+  return {};
+}
 
-CompilerType SwiftASTContext::GetPointerType(void *type) {
+CompilerType SwiftASTContext::GetPointerType(opaque_compiler_type_t type) {
   VALID_OR_RETURN(CompilerType());
 
   if (type) {
@@ -5855,7 +5878,7 @@ CompilerType SwiftASTContext::GetPointerType(void *type) {
   return {};
 }
 
-CompilerType SwiftASTContext::GetTypedefedType(void *type) {
+CompilerType SwiftASTContext::GetTypedefedType(opaque_compiler_type_t type) {
   VALID_OR_RETURN(CompilerType());
 
   if (type) {
@@ -5870,8 +5893,7 @@ CompilerType SwiftASTContext::GetTypedefedType(void *type) {
   return {};
 }
 
-CompilerType
-SwiftASTContext::GetUnboundType(lldb::opaque_compiler_type_t type) {
+CompilerType SwiftASTContext::GetUnboundType(opaque_compiler_type_t type) {
   VALID_OR_RETURN(CompilerType());
 
   if (type) {
@@ -5892,7 +5914,8 @@ SwiftASTContext::GetUnboundType(lldb::opaque_compiler_type_t type) {
 // Exploring the type
 //----------------------------------------------------------------------
 
-const swift::irgen::TypeInfo *SwiftASTContext::GetSwiftTypeInfo(void *type) {
+const swift::irgen::TypeInfo *
+SwiftASTContext::GetSwiftTypeInfo(opaque_compiler_type_t type) {
   VALID_OR_RETURN(nullptr);
 
   if (type) {
@@ -5905,7 +5928,7 @@ const swift::irgen::TypeInfo *SwiftASTContext::GetSwiftTypeInfo(void *type) {
 }
 
 const swift::irgen::FixedTypeInfo *
-SwiftASTContext::GetSwiftFixedTypeInfo(void *type) {
+SwiftASTContext::GetSwiftFixedTypeInfo(opaque_compiler_type_t type) {
   VALID_OR_RETURN(nullptr);
 
   const swift::irgen::TypeInfo *type_info = GetSwiftTypeInfo(type);
@@ -5926,7 +5949,7 @@ bool SwiftASTContext::IsFixedSize(CompilerType compiler_type) {
 }
 
 llvm::Optional<uint64_t>
-SwiftASTContext::GetBitSize(lldb::opaque_compiler_type_t type,
+SwiftASTContext::GetBitSize(opaque_compiler_type_t type,
                             ExecutionContextScope *exe_scope) {
   if (!type)
     return {};
@@ -5976,7 +5999,7 @@ SwiftASTContext::GetBitSize(lldb::opaque_compiler_type_t type,
 }
 
 llvm::Optional<uint64_t>
-SwiftASTContext::GetByteStride(lldb::opaque_compiler_type_t type,
+SwiftASTContext::GetByteStride(opaque_compiler_type_t type,
                                ExecutionContextScope *exe_scope) {
   if (!type)
     return {};
@@ -6009,7 +6032,8 @@ SwiftASTContext::GetByteStride(lldb::opaque_compiler_type_t type,
 }
 
 llvm::Optional<size_t>
-SwiftASTContext::GetTypeBitAlign(void *type, ExecutionContextScope *exe_scope) {
+SwiftASTContext::GetTypeBitAlign(opaque_compiler_type_t type,
+                                 ExecutionContextScope *exe_scope) {
   if (!type)
     return {};
 
@@ -6039,7 +6063,8 @@ SwiftASTContext::GetTypeBitAlign(void *type, ExecutionContextScope *exe_scope) {
   return {};
 }
 
-lldb::Encoding SwiftASTContext::GetEncoding(void *type, uint64_t &count) {
+lldb::Encoding SwiftASTContext::GetEncoding(opaque_compiler_type_t type,
+                                            uint64_t &count) {
   VALID_OR_RETURN(lldb::eEncodingInvalid);
 
   if (!type)
@@ -6125,7 +6150,7 @@ lldb::Encoding SwiftASTContext::GetEncoding(void *type, uint64_t &count) {
   return lldb::eEncodingInvalid;
 }
 
-lldb::Format SwiftASTContext::GetFormat(void *type) {
+lldb::Format SwiftASTContext::GetFormat(opaque_compiler_type_t type) {
   VALID_OR_RETURN(lldb::eFormatInvalid);
 
   if (!type)
@@ -6211,7 +6236,7 @@ lldb::Format SwiftASTContext::GetFormat(void *type) {
   return lldb::eFormatBytes;
 }
 
-uint32_t SwiftASTContext::GetNumChildren(void *type,
+uint32_t SwiftASTContext::GetNumChildren(opaque_compiler_type_t type,
                                          bool omit_empty_base_classes,
                                          const ExecutionContext *exe_ctx) {
   VALID_OR_RETURN(0);
@@ -6325,7 +6350,8 @@ uint32_t SwiftASTContext::GetNumChildren(void *type,
 
 #pragma mark Aggregate Types
 
-uint32_t SwiftASTContext::GetNumDirectBaseClasses(void *opaque_type) {
+uint32_t
+SwiftASTContext::GetNumDirectBaseClasses(opaque_compiler_type_t opaque_type) {
   if (!opaque_type)
     return 0;
 
@@ -6339,7 +6365,7 @@ uint32_t SwiftASTContext::GetNumDirectBaseClasses(void *opaque_type) {
   return 0;
 }
 
-uint32_t SwiftASTContext::GetNumFields(void *type) {
+uint32_t SwiftASTContext::GetNumFields(opaque_compiler_type_t type) {
   VALID_OR_RETURN(0);
 
   if (!type)
@@ -6437,9 +6463,8 @@ uint32_t SwiftASTContext::GetNumFields(void *type) {
   return count;
 }
 
-CompilerType
-SwiftASTContext::GetDirectBaseClassAtIndex(void *opaque_type, size_t idx,
-                                           uint32_t *bit_offset_ptr) {
+CompilerType SwiftASTContext::GetDirectBaseClassAtIndex(
+    opaque_compiler_type_t opaque_type, size_t idx, uint32_t *bit_offset_ptr) {
   VALID_OR_RETURN(CompilerType());
 
   if (opaque_type) {
@@ -6550,8 +6575,8 @@ GetExistentialTypeChild(swift::ASTContext *swift_ast_ctx, CompilerType type,
   return {ToCompilerType(raw_pointer.getPointer()), std::move(name)};
 }
 
-CompilerType SwiftASTContext::GetFieldAtIndex(void *type, size_t idx,
-                                              std::string &name,
+CompilerType SwiftASTContext::GetFieldAtIndex(opaque_compiler_type_t type,
+                                              size_t idx, std::string &name,
                                               uint64_t *bit_offset_ptr,
                                               uint32_t *bitfield_bit_size_ptr,
                                               bool *is_bitfield_ptr) {
@@ -6729,7 +6754,7 @@ CompilerType SwiftASTContext::GetFieldAtIndex(void *type, size_t idx,
 // child that is an integer, but a function pointer doesn't have any
 // children. Likewise if a Record type claims it has no children, then
 // there really is nothing to show.
-uint32_t SwiftASTContext::GetNumPointeeChildren(void *type) {
+uint32_t SwiftASTContext::GetNumPointeeChildren(opaque_compiler_type_t type) {
   if (!type)
     return 0;
 
@@ -6883,7 +6908,7 @@ bool SwiftASTContext::IsNonTriviallyManagedReferenceType(
 }
 
 CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
-    void *type, ExecutionContext *exe_ctx, size_t idx,
+    opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
     bool transparent_pointers, bool omit_empty_base_classes,
     bool ignore_array_bounds, std::string &child_name,
     uint32_t &child_byte_size, int32_t &child_byte_offset,
@@ -7200,7 +7225,7 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
 // second index 1 is the child index for "m_b" within class A.
 
 size_t SwiftASTContext::GetIndexOfChildMemberWithName(
-    void *type, const char *name, bool omit_empty_base_classes,
+    opaque_compiler_type_t type, const char *name, bool omit_empty_base_classes,
     std::vector<uint32_t> &child_indexes) {
   VALID_OR_RETURN(0);
 
@@ -7384,7 +7409,8 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
 /// function doesn't descend into the children, but only looks one
 /// level deep and name matches can include base class names.
 uint32_t
-SwiftASTContext::GetIndexOfChildWithName(void *type, const char *name,
+SwiftASTContext::GetIndexOfChildWithName(opaque_compiler_type_t type,
+                                         const char *name,
                                          bool omit_empty_base_classes) {
   VALID_OR_RETURN(UINT32_MAX);
 
@@ -7394,7 +7420,7 @@ SwiftASTContext::GetIndexOfChildWithName(void *type, const char *name,
   return num_child_indexes == 1 ? child_indexes.front() : UINT32_MAX;
 }
 
-size_t SwiftASTContext::GetNumTemplateArguments(void *type) {
+size_t SwiftASTContext::GetNumTemplateArguments(opaque_compiler_type_t type) {
   if (!type)
     return 0;
 
@@ -7451,8 +7477,9 @@ bool SwiftASTContext::GetSelectedEnumCase(const CompilerType &type,
   return true;
 }
 
-lldb::GenericKind SwiftASTContext::GetGenericArgumentKind(void *type,
-                                                          size_t idx) {
+lldb::GenericKind
+SwiftASTContext::GetGenericArgumentKind(opaque_compiler_type_t type,
+                                        size_t idx) {
   if (type) {
     swift::CanType swift_can_type(GetCanonicalSwiftType(type));
     if (auto *unbound_generic_type =
@@ -7466,7 +7493,8 @@ lldb::GenericKind SwiftASTContext::GetGenericArgumentKind(void *type,
   return eNullGenericKindType;
 }
 
-CompilerType SwiftASTContext::GetBoundGenericType(void *type, size_t idx) {
+CompilerType SwiftASTContext::GetBoundGenericType(opaque_compiler_type_t type,
+                                                  size_t idx) {
   VALID_OR_RETURN(CompilerType());
 
   if (type) {
@@ -7481,7 +7509,8 @@ CompilerType SwiftASTContext::GetBoundGenericType(void *type, size_t idx) {
   return {};
 }
 
-CompilerType SwiftASTContext::GetUnboundGenericType(void *type, size_t idx) {
+CompilerType SwiftASTContext::GetUnboundGenericType(opaque_compiler_type_t type,
+                                                    size_t idx) {
   VALID_OR_RETURN(CompilerType());
 
   if (type) {
@@ -7509,7 +7538,9 @@ CompilerType SwiftASTContext::GetGenericArgumentType(CompilerType ct,
   return {};
 }
 
-CompilerType SwiftASTContext::GetGenericArgumentType(void *type, size_t idx) {
+CompilerType
+SwiftASTContext::GetGenericArgumentType(opaque_compiler_type_t type,
+                                        size_t idx) {
   VALID_OR_RETURN(CompilerType());
 
   switch (GetGenericArgumentKind(type, idx)) {
@@ -7523,7 +7554,8 @@ CompilerType SwiftASTContext::GetGenericArgumentType(void *type, size_t idx) {
   return {};
 }
 
-CompilerType SwiftASTContext::GetTypeForFormatters(void *type) {
+CompilerType
+SwiftASTContext::GetTypeForFormatters(opaque_compiler_type_t type) {
   VALID_OR_RETURN(CompilerType());
 
   if (type) {
@@ -7534,7 +7566,7 @@ CompilerType SwiftASTContext::GetTypeForFormatters(void *type) {
   return {};
 }
 
-LazyBool SwiftASTContext::ShouldPrintAsOneLiner(void *type,
+LazyBool SwiftASTContext::ShouldPrintAsOneLiner(opaque_compiler_type_t type,
                                                 ValueObject *valobj) {
   if (type) {
     CompilerType can_compiler_type(GetCanonicalType(type));
@@ -7553,7 +7585,8 @@ LazyBool SwiftASTContext::ShouldPrintAsOneLiner(void *type,
   return eLazyBoolCalculate;
 }
 
-bool SwiftASTContext::IsMeaninglessWithoutDynamicResolution(void *type) {
+bool SwiftASTContext::IsMeaninglessWithoutDynamicResolution(
+    opaque_compiler_type_t type) {
   if (type) {
     swift::CanType swift_can_type(GetCanonicalSwiftType(type));
     return swift_can_type->hasTypeParameter();
@@ -7576,8 +7609,7 @@ bool SwiftASTContext::IsMeaninglessWithoutDynamicResolution(void *type) {
 #define DEPTH_INCREMENT 2
 
 #ifndef NDEBUG
-LLVM_DUMP_METHOD void
-SwiftASTContext::dump(lldb::opaque_compiler_type_t type) const {
+LLVM_DUMP_METHOD void SwiftASTContext::dump(opaque_compiler_type_t type) const {
   if (!type)
     return;
   swift::Type swift_type =
@@ -7587,14 +7619,14 @@ SwiftASTContext::dump(lldb::opaque_compiler_type_t type) const {
 #endif
 
 void SwiftASTContext::DumpValue(
-    void *type, ExecutionContext *exe_ctx, Stream *s, lldb::Format format,
-    const lldb_private::DataExtractor &data, lldb::offset_t data_byte_offset,
-    size_t data_byte_size, uint32_t bitfield_bit_size,
-    uint32_t bitfield_bit_offset, bool show_types, bool show_summary,
-    bool verbose, uint32_t depth) {}
+    opaque_compiler_type_t type, ExecutionContext *exe_ctx, Stream *s,
+    lldb::Format format, const lldb_private::DataExtractor &data,
+    lldb::offset_t data_byte_offset, size_t data_byte_size,
+    uint32_t bitfield_bit_size, uint32_t bitfield_bit_offset, bool show_types,
+    bool show_summary, bool verbose, uint32_t depth) {}
 
 bool SwiftASTContext::DumpTypeValue(
-    void *type, Stream *s, lldb::Format format,
+    opaque_compiler_type_t type, Stream *s, lldb::Format format,
     const lldb_private::DataExtractor &data, lldb::offset_t byte_offset,
     size_t byte_size, uint32_t bitfield_bit_size, uint32_t bitfield_bit_offset,
     ExecutionContextScope *exe_scope, bool is_base_class) {
@@ -7765,7 +7797,8 @@ bool SwiftASTContext::DumpTypeValue(
   return 0;
 }
 
-bool SwiftASTContext::IsImportedType(void *type, CompilerType *original_type) {
+bool SwiftASTContext::IsImportedType(opaque_compiler_type_t type,
+                                     CompilerType *original_type) {
   bool success = false;
 
   if (swift::CanType swift_can_type = GetCanonicalSwiftType(type)) {
@@ -7809,24 +7842,25 @@ bool SwiftASTContext::IsImportedType(void *type, CompilerType *original_type) {
   return success;
 }
 
-void SwiftASTContext::DumpSummary(void *type, ExecutionContext *exe_ctx,
-                                  Stream *s,
+void SwiftASTContext::DumpSummary(opaque_compiler_type_t type,
+                                  ExecutionContext *exe_ctx, Stream *s,
                                   const lldb_private::DataExtractor &data,
                                   lldb::offset_t data_byte_offset,
                                   size_t data_byte_size) {}
 
-void SwiftASTContext::DumpTypeDescription(void *type,
+void SwiftASTContext::DumpTypeDescription(opaque_compiler_type_t type,
                                           lldb::DescriptionLevel level) {
   StreamFile s(stdout, false);
   DumpTypeDescription(type, &s, level);
 }
 
-void SwiftASTContext::DumpTypeDescription(void *type, Stream *s,
+void SwiftASTContext::DumpTypeDescription(opaque_compiler_type_t type,
+                                          Stream *s,
                                           lldb::DescriptionLevel level) {
   DumpTypeDescription(type, s, false, true, level);
 }
 
-void SwiftASTContext::DumpTypeDescription(void *type,
+void SwiftASTContext::DumpTypeDescription(opaque_compiler_type_t type,
                                           bool print_help_if_available,
                                           bool print_extensions_if_available,
                                           lldb::DescriptionLevel level) {
@@ -7863,7 +7897,8 @@ static void PrintSwiftNominalType(swift::NominalTypeDecl *nominal_type_decl,
   }
 }
 
-void SwiftASTContext::DumpTypeDescription(void *type, Stream *s,
+void SwiftASTContext::DumpTypeDescription(opaque_compiler_type_t type,
+                                          Stream *s,
                                           bool print_help_if_available,
                                           bool print_extensions_if_available,
                                           lldb::DescriptionLevel level) {

--- a/lldb/source/Symbol/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Symbol/TypeSystemSwiftTypeRef.cpp
@@ -742,11 +742,6 @@ bool TypeSystemSwiftTypeRef::IsImportedType(CompilerType type,
       {m_swift_ast_context, ReconstructType(type.GetOpaqueQualType())},
       original_type);
 }
-bool TypeSystemSwiftTypeRef::IsErrorType(CompilerType compiler_type) {
-  return m_swift_ast_context->IsErrorType(
-      {m_swift_ast_context,
-       ReconstructType(compiler_type.GetOpaqueQualType())});
-}
 CompilerType TypeSystemSwiftTypeRef::GetErrorType() {
   return m_swift_ast_context->GetErrorType();
 }

--- a/lldb/source/Symbol/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Symbol/TypeSystemSwiftTypeRef.cpp
@@ -736,11 +736,10 @@ bool TypeSystemSwiftTypeRef::IsMeaninglessWithoutDynamicResolution(void *type) {
   return m_swift_ast_context->IsMeaninglessWithoutDynamicResolution(
       ReconstructType(type));
 }
-bool TypeSystemSwiftTypeRef::IsImportedType(CompilerType type,
+bool TypeSystemSwiftTypeRef::IsImportedType(void *type,
                                             CompilerType *original_type) {
-  return m_swift_ast_context->IsImportedType(
-      {m_swift_ast_context, ReconstructType(type.GetOpaqueQualType())},
-      original_type);
+  return m_swift_ast_context->IsImportedType(ReconstructType(type),
+                                             original_type);
 }
 CompilerType TypeSystemSwiftTypeRef::GetErrorType() {
   return m_swift_ast_context->GetErrorType();

--- a/lldb/source/Symbol/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Symbol/TypeSystemSwiftTypeRef.cpp
@@ -746,10 +746,8 @@ CompilerType TypeSystemSwiftTypeRef::GetErrorType() {
 }
 
 CompilerType
-TypeSystemSwiftTypeRef::GetReferentType(CompilerType compiler_type) {
-  return m_swift_ast_context->GetReferentType(
-      {m_swift_ast_context,
-       ReconstructType(compiler_type.GetOpaqueQualType())});
+TypeSystemSwiftTypeRef::GetReferentType(void *type) {
+  return m_swift_ast_context->GetReferentType(ReconstructType(type));
 }
 
 CompilerType TypeSystemSwiftTypeRef::GetInstanceType(void *type) {

--- a/lldb/source/Symbol/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Symbol/TypeSystemSwiftTypeRef.cpp
@@ -754,9 +754,8 @@ CompilerType TypeSystemSwiftTypeRef::GetInstanceType(void *type) {
   return m_swift_ast_context->GetInstanceType(ReconstructType(type));
 }
 TypeSystemSwift::TypeAllocationStrategy
-TypeSystemSwiftTypeRef::GetAllocationStrategy(CompilerType type) {
-  return m_swift_ast_context->GetAllocationStrategy(
-      {m_swift_ast_context, ReconstructType(type.GetOpaqueQualType())});
+TypeSystemSwiftTypeRef::GetAllocationStrategy(void * type) {
+  return m_swift_ast_context->GetAllocationStrategy(ReconstructType(type));
 }
 CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
     const std::vector<TupleElement> &elements) {

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1312,11 +1312,11 @@ Value::ValueType SwiftLanguageRuntimeImpl::GetValueType(
       if (auto *ts = llvm::dyn_cast_or_null<TypeSystemSwiftTypeRef>(
               static_type.GetTypeSystem()))
         static_type = ts->ReconstructType(static_type);
-      TypeSystemSwift *swift_ast_ctx =
-          llvm::dyn_cast_or_null<TypeSystemSwift>(static_type.GetTypeSystem());
+      SwiftASTContext *swift_ast_ctx =
+          llvm::dyn_cast_or_null<SwiftASTContext>(static_type.GetTypeSystem());
       if (!swift_ast_ctx)
         return {};
-      if (swift_ast_ctx->IsErrorType(static_type)) {
+      if (swift_ast_ctx->IsErrorType(static_type.GetOpaqueQualType())) {
         // ErrorType values are always a pointer
         return Value::eValueTypeLoadAddress;
       }

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1321,18 +1321,20 @@ Value::ValueType SwiftLanguageRuntimeImpl::GetValueType(
         return Value::eValueTypeLoadAddress;
       }
 
-      switch (swift_ast_ctx->GetAllocationStrategy(dynamic_type)) {
-      case SwiftASTContext::TypeAllocationStrategy::eDynamic:
-      case SwiftASTContext::TypeAllocationStrategy::eUnknown:
-        break;
-      case SwiftASTContext::TypeAllocationStrategy::eInline: // inline data;
-                                                             // same as the
-                                                             // static data
-        return static_value_type;
-      case SwiftASTContext::TypeAllocationStrategy::ePointer: // pointed-to; in
-                                                              // the target
-        return Value::eValueTypeLoadAddress;
-      }
+      if (auto *ts = llvm::dyn_cast_or_null<TypeSystemSwift>(
+              dynamic_type.GetTypeSystem()))
+        switch (ts->GetAllocationStrategy(dynamic_type.GetOpaqueQualType())) {
+        case SwiftASTContext::TypeAllocationStrategy::eDynamic:
+        case SwiftASTContext::TypeAllocationStrategy::eUnknown:
+          break;
+        case SwiftASTContext::TypeAllocationStrategy::eInline: // inline data;
+                                                               // same as the
+                                                               // static data
+          return static_value_type;
+        case SwiftASTContext::TypeAllocationStrategy::ePointer: // pointed-to;
+                                                                // in the target
+          return Value::eValueTypeLoadAddress;
+        }
     }
     if (static_type_flags.AllSet(eTypeIsSwift | eTypeIsGenericTypeParam)) {
       // if I am handling a non-pointer Swift type obtained from an archetype,


### PR DESCRIPTION
This is a series of NFC commits that remove all remaining methods that take a CompilerType as an in-argument from TypeSystemSwift. Since a CompilerType carries its own TypeSystem, it is  ambiguous what a TypeSystem method is expected to do with it. Usually TypeSystem methods take an opaque type pointer and expect to have been dispatched through CompilerType.

Since all of these Swift-specific functions are very specialized and have 1-2 call sites each, I didn;t go that far, but made the dynamic dispatch explicit at the call site instead.

<rdar://problem/63051847>