### PR TITLE
Diagnose broken Clang command line options in the expression evaluator.

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -820,6 +820,11 @@ public:
   Status GetFatalErrors();
   void DiagnoseWarnings(Process &process, Module &module) const override;
 
+  /// Return a list of warnings collected from ClangImporter.
+  const std::vector<std::string> &GetModuleImportWarnings() const {
+    return m_module_import_warnings;
+  }
+
   const swift::irgen::TypeInfo *
   GetSwiftTypeInfo(lldb::opaque_compiler_type_t type);
 

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -2291,7 +2291,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
     logError("couldn't load the Swift stdlib");
     return {};
   }
-
+  
   return swift_ast_sp;
 }
 
@@ -3286,15 +3286,17 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
       // Handle any errors.
       if (!clang_importer_ap || HasErrors()) {
         std::string message;
-        if (!HasErrors())
+        if (!HasErrors()) {
           message = "failed to create ClangImporter.";
-        else {
+          m_module_import_warnings.push_back(message);
+        } else {
           DiagnosticManager diagnostic_manager;
           PrintDiagnostics(diagnostic_manager);
+          std::string underlying_error = diagnostic_manager.GetString();
           message = "failed to initialize ClangImporter: ";
-          message += diagnostic_manager.GetString();
+          message += underlying_error;
+          m_module_import_warnings.push_back(underlying_error);
         }
-        m_module_import_warnings.push_back(message);
         LOG_PRINTF(LIBLLDB_LOG_TYPES, "%s", message.c_str());
       }
       if (clang_importer_ap)

--- a/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/Foo.swift
+++ b/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/Foo.swift
@@ -1,0 +1,3 @@
+public func foo(_ x : Int) -> Int {
+  return x + x
+}

--- a/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/Makefile
@@ -1,0 +1,25 @@
+SWIFT_SOURCES := main.swift
+SWIFT_OBJC_INTEROP := 1
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
+LD_EXTRAS = -L$(BUILDDIR) -lFoo
+
+all: libFoo.dylib $(EXE)
+
+include Makefile.rules
+
+OVERLAY := $(BUILDDIR)/overlay.yaml
+lib%.dylib: %.swift
+	rm -f $(OVERLAY)
+	echo "{ 'version': 0, 'roots': [] }" >$(OVERLAY)
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=$(shell basename $< .swift) \
+		SWIFTFLAGS_EXTRAS="-Xcc -ivfsoverlay -Xcc $(OVERLAY)" \
+		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
+	rm -f $(OVERLAY)
+
+clean::
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=$(shell basename $< .swift) \
+		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk clean

--- a/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/TestSwiftMissingVFSOverlay.py
+++ b/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/TestSwiftMissingVFSOverlay.py
@@ -1,0 +1,29 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+class TestSwiftMacroConflict(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    NO_DEBUG_INFO_TESTCASE = True
+    
+    def setUp(self):
+        TestBase.setUp(self)
+
+    # Don't run ClangImporter tests if Clangimporter is disabled.
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Test that a broken Clang command line option is diagnosed
+           in the expression evaluator"""
+        self.build()
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.registerSharedLibrariesWithTarget(target, ['Foo'])
+
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+        self.expect("expr y", error=True, substrs=["overlay.yaml", "IRGen"])

--- a/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/dylib.mk
+++ b/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/dylib.mk
@@ -1,0 +1,5 @@
+DYLIB_ONLY := YES
+DYLIB_NAME := $(BASENAME)
+DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/main.swift
@@ -1,0 +1,4 @@
+import Foo
+
+let y = foo(21)
+print(y) // break here


### PR DESCRIPTION
This patch ensures that the error message showing the root cause of
the failure reported in https://bugs.swift.org/browse/SR-12783 is
surfaced in the expression evaluator as its error message.

<rdar://problem/63089113>

(cherry picked from commit 5380ea9c86a23791b18de322fc3326d1af5601e9)