### PR TITLE
Partially fix LLDB on swift/master-next

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -309,7 +309,7 @@ bool SwiftREPL::SourceIsComplete(const std::string &source) {
       llvm::MemoryBuffer::getMemBuffer(source));
   swift::ide::SourceCompleteResult result =
       swift::ide::isSourceInputComplete(std::move(source_buffer_ap),
-                                        swift::SourceFileKind::REPL);
+                                        swift::SourceFileKind::Main);
   return result.IsComplete;
 }
 
@@ -344,7 +344,7 @@ lldb::offset_t SwiftREPL::GetDesiredIndentation(const StringList &lines,
       llvm::MemoryBuffer::getMemBuffer(source_string));
   swift::ide::SourceCompleteResult result =
       swift::ide::isSourceInputComplete(std::move(source_buffer_ap),
-                                        swift::SourceFileKind::REPL);
+                                        swift::SourceFileKind::Main);
 
   int desired_indent =
       (result.IndentLevel * tab_size) + result.IndentPrefix.length();
@@ -576,7 +576,7 @@ void SwiftREPL::CompleteCode(const std::string &current_code,
                                             importInfo);
       llvm::Optional<unsigned> bufferID;
       swift::SourceFile *repl_source_file = new (*ast)
-          swift::SourceFile(*repl_module, swift::SourceFileKind::REPL, bufferID,
+          swift::SourceFile(*repl_module, swift::SourceFileKind::Main, bufferID,
                             /*Keep tokens*/false);
       repl_module->addFile(*repl_source_file);
       swift::performImportResolution(*repl_source_file);
@@ -584,7 +584,7 @@ void SwiftREPL::CompleteCode(const std::string &current_code,
     }
     if (repl_module) {
       swift::SourceFile &repl_source_file =
-          repl_module->getMainSourceFile(swift::SourceFileKind::REPL);
+          repl_module->getMainSourceFile(swift::SourceFileKind::Main);
 
       // Swift likes to give us strings to append to the current token but
       // the CompletionRequest requires a replacement for the full current

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -1799,7 +1799,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
           sdk.Merge(
               sym_file->ParseXcodeSDK(*sym_file->GetCompileUnitAtIndex(i)));
 
-      std::string sdk_path = HostInfo::GetXcodeSDKPath(sdk);
+      std::string sdk_path = HostInfo::GetXcodeSDKPath(sdk).str();
       LOG_PRINTF(LIBLLDB_LOG_TYPES, "Host SDK path is %s.", sdk_path.c_str());
       if (FileSystem::Instance().Exists(sdk_path)) {
         swift_ast_sp->SetPlatformSDKPath(sdk_path);
@@ -2560,7 +2560,7 @@ void SwiftASTContext::InitializeSearchPathOptions(
   ConfigureResourceDirs(GetCompilerInvocation(), FileSpec(resource_dir),
                         triple);
 
-  std::string sdk_path = GetPlatformSDKPath();
+  std::string sdk_path = GetPlatformSDKPath().str();
   if (TargetSP target_sp = m_target_wp.lock())
     if (FileSpec &manual_override_sdk = target_sp->GetSDKPath()) {
       set_sdk = false;
@@ -2582,7 +2582,7 @@ void SwiftASTContext::InitializeSearchPathOptions(
       info.type = XcodeSDK::GetSDKTypeForTriple(
           HostInfo::GetArchitecture().GetTriple());
       XcodeSDK sdk(info);
-      sdk_path = HostInfo::GetXcodeSDKPath(sdk);
+      sdk_path = HostInfo::GetXcodeSDKPath(sdk).str();
     }
     if (!sdk_path.empty()) {
       // Note that calling setSDKPath() also recomputes all paths that

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -8230,8 +8230,6 @@ static void DescribeFileUnit(Stream &s, swift::FileUnit *file_unit) {
         s.PutCString("Library");
       case swift::SourceFileKind::Main:
         s.PutCString("Main");
-      case swift::SourceFileKind::REPL:
-        s.PutCString("REPL");
       case swift::SourceFileKind::SIL:
         s.PutCString("SIL");
       }


### PR DESCRIPTION
LLDB is currently failing to build on swift/master-next. It appears there are three major issues, two of which are addressed in this PR. The two that I have aimed to fix here are:

1. The removal of `SourceFileKind::REPL` from swift, which LLDB was relying on. @slavapestov fixed this on swift/master, but the change didn't make its way over to swift/master-next. This is a simple cherry-pick.

2. Some changes were made to SwiftASTContext that had implicit StringRef to std::string conversions. These now require explicit casts, which I have added.

The last issue blocking swift/master-next from building has to do with the static bindings in LLDB. I'm not sure how to address this particular problem, but it seems that the issue was introduced when [this patch](https://reviews.llvm.org/D78462) was landed upstream.

cc @eeckstein 