### PR TITLE
[AArch64] Don't promote constants with float ConstantExpr.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64PromoteConstant.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PromoteConstant.cpp
@@ -250,6 +250,20 @@ static bool isConstantUsingVectorTy(const Type *CstTy) {
   return false;
 }
 
+// Returns true if \p C contains only ConstantData leafs and no global values,
+// block addresses or constant expressions. Traverses ConstantAggregates.
+static bool containsOnlyConstantData(const Constant *C) {
+  if (isa<ConstantData>(C))
+    return true;
+
+  if (isa<GlobalValue>(C) || isa<BlockAddress>(C) || isa<ConstantExpr>(C))
+    return false;
+
+  return all_of(C->operands(), [](const Use &U) {
+    return containsOnlyConstantData(cast<Constant>(&U));
+  });
+}
+
 /// Check if the given use (Instruction + OpIdx) of Cst should be converted into
 /// a load of a global variable initialized with Cst.
 /// A use should be converted if it is legal to do so.
@@ -550,9 +564,10 @@ bool AArch64PromoteConstant::runOnFunction(Function &F,
     for (Use &U : I.operands()) {
       Constant *Cst = dyn_cast<Constant>(U);
       // There is no point in promoting global values as they are already
-      // global. Do not promote constant expressions either, as they may
-      // require some code expansion.
-      if (!Cst || isa<GlobalValue>(Cst) || isa<ConstantExpr>(Cst))
+      // global. Do not promote constants containing constant expression, global
+      // values or blockaddresses either, as they may require some code
+      // expansion.
+      if (!Cst || isa<GlobalValue>(Cst) || !containsOnlyConstantData(Cst))
         continue;
 
       // Check if this constant is worth promoting.

--- a/llvm/test/CodeGen/AArch64/arm64-promote-const-complex-initializers.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-promote-const-complex-initializers.ll
@@ -1,0 +1,64 @@
+; RUN: llc -o - %s | FileCheck %s
+
+; AsmPrinter cannot lower floating point constant expressions in global
+; initializers. Check that we do not create new globals with float constant
+; expressions in initializers.
+
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+target triple = "arm64-apple-ios14.0.0"
+
+define [1 x <4 x float>] @test1() {
+; CHECK-LABEL:    .p2align    4               ; -- Begin function test1
+; CHECK-NEXT: lCPI0_0:
+; CHECK-NEXT:     .quad   0                       ; 0x0
+; CHECK-NEXT:     .quad   4575657221408423936     ; 0x3f80000000000000
+; CHECK-NEXT:     .section    __TEXT,__text,regular,pure_instructions
+; CHECK-NEXT:     .globl  _test1
+; CHECK-NEXT:     .p2align    2
+; CHECK-NEXT: _test1:                                 ; @test1
+; CHECK-NEXT:     .cfi_startproc
+; CHECK-NEXT: ; %bb.0:
+; CHECK-NEXT: Lloh0:
+; CHECK-NEXT:     adrp    x8, lCPI0_0@PAGE
+; CHECK-NEXT: Lloh1:
+; CHECK-NEXT:     ldr q0, [x8, lCPI0_0@PAGEOFF]
+; CHECK-NEXT:     ret
+
+  ret [1 x <4 x float>] [<4 x float> bitcast (<1 x i128> <i128 84405977732342157929391748327801880576> to <4 x float>)]
+}
+
+define [1 x <4 x float>] @test2() {
+; CHECK-LABEL:    .p2align    4               ; -- Begin function test2
+; CHECK-NEXT: lCPI1_0:
+; CHECK-NEXT:     .long   0 ; float 0
+; CHECK-NEXT:     .long   0 ; float 0
+; CHECK-NEXT:     .long   0 ; float 0
+; CHECK-NEXT:     .long   1065353216 ; float 1
+; CHECK-NEXT:     .section    __TEXT,__text,regular,pure_instructions
+; CHECK-NEXT:     .globl  _test2
+; CHECK-NEXT:     .p2align    2
+; CHECK-NEXT: _test2:                                 ; @test2
+; CHECK-NEXT:     .cfi_startproc
+; CHECK-NEXT: ; %bb.0:
+; CHECK-NEXT: Lloh2:
+; CHECK-NEXT:     adrp    x8, lCPI1_0@PAGE
+; CHECK-NEXT: Lloh3:
+; CHECK-NEXT:     ldr q1, [x8, lCPI1_0@PAGEOFF]
+; CHECK-NEXT:     mov s2, v1[1]
+; CHECK-NEXT:     fneg    s0, s1
+; CHECK-NEXT:     mov s3, v1[2]
+; CHECK-NEXT:     fneg    s2, s2
+; CHECK-NEXT:     mov s1, v1[3]
+; CHECK-NEXT:     fneg    s3, s3
+; CHECK-NEXT:     mov.s   v0[1], v2[0]
+; CHECK-NEXT:     mov.s   v0[2], v3[0]
+; CHECK-NEXT:     fneg    s1, s1
+; CHECK-NEXT:     mov.s   v0[3], v1[0]
+; CHECK-NEXT:     ret
+;
+  ret [1 x <4 x float>] [<4 x float>
+    <float fneg (float extractelement (<4 x float> bitcast (<1 x i128> <i128 84405977732342157929391748327801880576> to <4 x float>), i32 0)),
+     float fneg (float extractelement (<4 x float> bitcast (<1 x i128> <i128 84405977732342157929391748327801880576> to <4 x float>), i32 1)),
+     float fneg (float extractelement (<4 x float> bitcast (<1 x i128> <i128 84405977732342157929391748327801880576> to <4 x float>), i32 2)),
+     float fneg (float extractelement (<4 x float> bitcast (<1 x i128> <i128 84405977732342157929391748327801880576> to <4 x float>), i32 3))>]
+}


### PR DESCRIPTION
Currently the AsmPrinter cannot emit some floating point constant
expressions in global initializers. Avoid generating them.

Reviewers: dmgreen, t.p.northover, arsenm, efriedma, Gerolf

Reviewed By: efriedma

Differential Revision: https://reviews.llvm.org/D79865