### PR TITLE
[analyzer] Fix crash for non-pointers annotated as nonnull

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/NonNullParamChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/NonNullParamChecker.cpp
@@ -253,12 +253,18 @@ void NonNullParamChecker::checkBeginFunction(CheckerContext &Context) const {
     if (!ParameterNonNullMarks.test(Parameter->getFunctionScopeIndex()))
       continue;
 
+    // 2. Check that parameter is a pointer.
+    //    Nonnull attribute can be applied to non-pointers (by default
+    //    __attribute__(nonnull) implies "all parameters").
+    if (!Parameter->getType()->isPointerType())
+      continue;
+
     Loc ParameterLoc = State->getLValue(Parameter, LocContext);
     // We never consider top-level function parameters undefined.
     auto StoredVal =
         State->getSVal(ParameterLoc).castAs<DefinedOrUnknownSVal>();
 
-    // 2. Assume that it is indeed non-null
+    // 3. Assume that it is indeed non-null
     if (ProgramStateRef NewState = State->assume(StoredVal, true)) {
       State = NewState;
     }

--- a/clang/test/Analysis/UserNullabilityAnnotations.m
+++ b/clang/test/Analysis/UserNullabilityAnnotations.m
@@ -1,4 +1,5 @@
 // RUN: %clang_analyze_cc1 -verify -Wno-objc-root-class %s \
+// RUN:   -Wno-tautological-pointer-compare \
 // RUN:   -analyzer-checker=core \
 // RUN:   -analyzer-checker=nullability \
 // RUN:   -analyzer-checker=debug.ExprInspection
@@ -33,4 +34,16 @@ void f1(NestedNonnullMember *Root) {
   clang_analyzer_eval(Root->Value != 0);         // expected-warning{{TRUE}}
   clang_analyzer_eval(Grandson->Value != 0);     // expected-warning{{TRUE}}
   clang_analyzer_eval(foo()->Child->Value != 0); // expected-warning{{TRUE}}
+}
+
+// Check that we correctly process situations when non-pointer parameters
+// get nonnul attributes.
+// Original problem: rdar://problem/63150074
+typedef struct {
+  long a;
+} B;
+__attribute__((nonnull)) void c(B x, int *y);
+
+void c(B x, int *y) {
+  clang_analyzer_eval(y != 0); // expected-warning{{TRUE}}
 }


### PR DESCRIPTION
Summary:
Nonnull attribute can be applied to non-pointers.  This caused assertion
failures in NonNullParamChecker when we tried to *assume* such parameters
to be non-zero.

rdar://problem/63150074

Differential Revision: https://reviews.llvm.org/D79843

(cherry picked from commit 855f0ce79bf3bdf34a390d1f5fd842a6aa79d5ef)