### PR TITLE
[indexstore] Remove conditional strong enums from the API

### DIFF
--- a/clang/include/indexstore/indexstore.h
+++ b/clang/include/indexstore/indexstore.h
@@ -99,7 +99,7 @@
 #define INDEXSTORE_OPTIONS_ATTRS INDEXSTORE_OPEN_ENUM_ATTR INDEXSTORE_FLAG_ENUM_ATTR
 
 #if defined(__has_extension)
-#if __has_extension(cxx_strong_enums) || __has_feature(objc_fixed_enum)
+#if __has_feature(objc_fixed_enum)
 # define INDEXSTORE_OPTIONS(_type, _name) enum INDEXSTORE_OPTIONS_ATTRS _name : _type _name; enum INDEXSTORE_OPTIONS_ATTRS _name : _type
 #endif
 #endif

--- a/clang/include/indexstore/indexstore.h
+++ b/clang/include/indexstore/indexstore.h
@@ -98,12 +98,6 @@
 
 #define INDEXSTORE_OPTIONS_ATTRS INDEXSTORE_OPEN_ENUM_ATTR INDEXSTORE_FLAG_ENUM_ATTR
 
-#if defined(__has_extension)
-#if __has_extension(cxx_strong_enums) || __has_feature(objc_fixed_enum)
-# define INDEXSTORE_OPTIONS(_type, _name) enum INDEXSTORE_OPTIONS_ATTRS _name : _type _name; enum INDEXSTORE_OPTIONS_ATTRS _name : _type
-#endif
-#endif
-
 #ifndef INDEXSTORE_OPTIONS
 # define INDEXSTORE_OPTIONS(_type, _name) _type _name; enum INDEXSTORE_OPTIONS_ATTRS
 #endif

--- a/clang/include/indexstore/indexstore.h
+++ b/clang/include/indexstore/indexstore.h
@@ -98,6 +98,12 @@
 
 #define INDEXSTORE_OPTIONS_ATTRS INDEXSTORE_OPEN_ENUM_ATTR INDEXSTORE_FLAG_ENUM_ATTR
 
+#if defined(__has_extension)
+#if __has_extension(cxx_strong_enums) || __has_feature(objc_fixed_enum)
+# define INDEXSTORE_OPTIONS(_type, _name) enum INDEXSTORE_OPTIONS_ATTRS _name : _type _name; enum INDEXSTORE_OPTIONS_ATTRS _name : _type
+#endif
+#endif
+
 #ifndef INDEXSTORE_OPTIONS
 # define INDEXSTORE_OPTIONS(_type, _name) _type _name; enum INDEXSTORE_OPTIONS_ATTRS
 #endif


### PR DESCRIPTION
We got a stage2 build failure after this patch landed:
d6425e2c14d6425e2c143 2020-05-10 Richard Smith:  Properly implement 'enum class' parsing.

Since this should remain a pure C API we are sticking to simple enums.

rdar://problem/63156155