### PR TITLE
Implement TypeSystemSwiftTypeRef::GetTypeName()

### DIFF
--- a/lldb/include/lldb/Symbol/SymbolFile.h
+++ b/lldb/include/lldb/Symbol/SymbolFile.h
@@ -204,6 +204,9 @@ public:
   virtual CompilerDeclContext GetDeclContextContainingUID(lldb::user_id_t uid) {
     return CompilerDeclContext();
   }
+  virtual void
+  GetDeclContextForUID(llvm::SmallVectorImpl<CompilerContext> &context,
+                       lldb::user_id_t uid) {}
   virtual uint32_t ResolveSymbolContext(const Address &so_addr,
                                         lldb::SymbolContextItem resolve_scope,
                                         SymbolContext &sc) = 0;

--- a/lldb/include/lldb/Symbol/Type.h
+++ b/lldb/include/lldb/Symbol/Type.h
@@ -173,6 +173,9 @@ public:
 
   const lldb_private::Declaration &GetDeclaration() const;
 
+  void GetDeclContext(
+      llvm::SmallVectorImpl<lldb_private::CompilerContext> &context) const;
+
   // Get the clang type, and resolve definitions for any
   // class/struct/union/enum types completely.
   CompilerType GetFullCompilerType();

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -1387,6 +1387,12 @@ SymbolFileDWARF::GetDeclContextContainingUID(lldb::user_id_t type_uid) {
   return CompilerDeclContext();
 }
 
+void SymbolFileDWARF::GetDeclContextForUID(
+    llvm::SmallVectorImpl<CompilerContext> &context, lldb::user_id_t type_uid) {
+  if (DWARFDIE die = GetDIE(type_uid))
+    return die.GetDeclContext(context);
+}
+
 Type *SymbolFileDWARF::ResolveTypeUID(lldb::user_id_t type_uid) {
   std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
   // Anytime we have a lldb::user_id_t, we must get the DIE by calling

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
@@ -162,6 +162,10 @@ public:
   lldb_private::CompilerDeclContext
   GetDeclContextContainingUID(lldb::user_id_t uid) override;
 
+  void GetDeclContextForUID(
+      llvm::SmallVectorImpl<lldb_private::CompilerContext> &context,
+      lldb::user_id_t type_uid) override;
+
   void
   ParseDeclsForContext(lldb_private::CompilerDeclContext decl_ctx) override;
 

--- a/lldb/source/Symbol/Type.cpp
+++ b/lldb/source/Symbol/Type.cpp
@@ -643,6 +643,11 @@ uint32_t Type::GetEncodingMask() {
   return encoding_mask;
 }
 
+void Type::GetDeclContext(
+    llvm::SmallVectorImpl<lldb_private::CompilerContext> &context) const {
+  m_symbol_file->GetDeclContextForUID(context, GetID());
+}
+
 CompilerType Type::GetFullCompilerType() {
   ResolveClangType(ResolveState::Full);
   return m_compiler_type;

--- a/lldb/test/API/lang/swift/bridged_metatype/TestSwiftBridgedMetatype.py
+++ b/lldb/test/API/lang/swift/bridged_metatype/TestSwiftBridgedMetatype.py
@@ -16,9 +16,6 @@ class TestSwiftBridgedMetatype(TestBase):
     def setUp(self):
         TestBase.setUp(self)
 
-    @expectedFailureAll(bugnumber="rdar://60396797",
-                        oslist=lldbplatform.darwin_all,
-                        setting=('symbols.use-swift-clangimporter', 'false'))
     @swiftTest
     def test_swift_bridged_metatype(self):
         """Test the formatting of bridged Swift metatypes"""

--- a/lldb/test/API/lang/swift/bridged_metatype/main.swift
+++ b/lldb/test/API/lang/swift/bridged_metatype/main.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 func main<T>(_ x: T) {
+  let s = NSString("This is necessary to actually pull in the Foundation dependency")
   var k = NSString.self
   print("Set breakpoint here")
 }

--- a/lldb/test/API/lang/swift/dwarfimporter/BridgingPCH/TestSwiftDWARFImporterBridgingPCH.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/BridgingPCH/TestSwiftDWARFImporterBridgingPCH.py
@@ -53,7 +53,7 @@ class TestSwiftDWARFImporterBridgingHeader(lldbtest.TestBase):
                                 value="42")
         lldbutil.check_variable(self,
                                 target.FindFirstGlobalVariable("point"),
-                                typename='__ObjC.Point', num_children=2)
+                                typename='bridging-header.h.Point', num_children=2)
         self.expect("ta v -d no-dyn point", substrs=["x = 1", "y = 2"])
         self.expect("ta v -d no-dyn swiftStructCMember",
                     substrs=[

--- a/lldb/test/API/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
@@ -50,7 +50,7 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
                                 value="42")
         lldbutil.check_variable(self,
                                 target.FindFirstGlobalVariable("point"),
-                                typename='__ObjC.Point', num_children=2)
+                                typename='CModule.Point', num_children=2)
         self.expect("target variable point", substrs=["x = 1", "y = 2"])
         self.expect("target variable enumerator", substrs=[".yellow"])
         self.expect("target variable pureSwiftStruct", substrs=["pure swift"])
@@ -82,7 +82,7 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
                                 value="42")
         lldbutil.check_variable(self,
                                 target.FindFirstGlobalVariable("point"),
-                                typename='__ObjC.Point', num_children=2)
+                                typename='CModule.Point', num_children=2)
         self.expect("expr point", substrs=["x = 1", "y = 2"])
         self.expect("expr enumerator", substrs=[".yellow"])
         self.expect("expr pureSwiftStruct", substrs=["pure swift"])

--- a/lldb/test/API/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
@@ -48,7 +48,7 @@ class TestSwiftDWARFImporterObjC(lldbtest.TestBase):
                                 value="42")
         lldbutil.check_variable(self,
                                 target.FindFirstGlobalVariable("obj"),
-                                typename="Swift.Optional<__ObjC.ObjCClass>",
+                                typename="Swift.Optional<ObjCModule.ObjCClass>",
                                 num_children=0)
         self.expect("target var obj", substrs=["ObjCClass",
                                                "private_ivar", "42"])
@@ -74,7 +74,7 @@ class TestSwiftDWARFImporterObjC(lldbtest.TestBase):
                                 value="42")
         lldbutil.check_variable(self,
                                 target.FindFirstGlobalVariable("obj"),
-                                typename="Swift.Optional<__ObjC.ObjCClass>",
+                                typename="Swift.Optional<ObjCModule.ObjCClass>",
                                 num_children=0)
         self.expect("expr obj", substrs=["ObjCClass",
                                          "private_ivar", "42"])

--- a/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
@@ -108,7 +108,12 @@ class TestSwiftInterfaceDSYM(TestBase):
 
         # We should not find a type for x.
         var = self.frame().FindVariable("x")
-        self.assertEqual(var.GetTypeName(), "<invalid>")
+        # This was true for SwiftASTContext, but
+        # TypeSystemSwiftTyperef succeeds, because this test it only
+        # prints the type *name*.
+        self.assertEqual(var.GetTypeName(), "AA.MyPoint")
+        # Evaluating an expression fails, though.
+        self.expect("p x", error=1)
 
     @swiftTest
     @skipIf(archs=no_match("x86_64"))


### PR DESCRIPTION
This (rather large) patch implements all the bits and pieces necessary
to implement GetTypeName without a SwiftASTContext. Since extra Clang
type information is read out of DWARF, the new type names are
sometimes more precise than the old ones since they now contain Clang
module names instead of the generic __ObjC module. The three tests
that fail the comparison and had to be whitelisted are tests of
ambiguous Clang types and one occurence of a non-PCH bridging header.

The one regression this patch introduces is that we cannot read Clang
type information from non-precompiled bridging headers, since none was
generated. This is acceptable because the Swift driver defaults to
precompiling bridging headers.

This patch improves several DWARFImporter tests (due to the ability of
reading Clang module names, and APINotes) and un-XFAILs on regular
test in DWARFImporter-only mode.

<rdar://problem/63041601>