### PR TITLE
Debug Info: Mark os_log helper functions as artificial

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -1251,6 +1251,8 @@ llvm::Function *CodeGenFunction::generateBuiltinOSLogHelperFunction(
   FunctionDecl *FD = FunctionDecl::Create(
       Ctx, Ctx.getTranslationUnitDecl(), SourceLocation(), SourceLocation(), II,
       FuncionTy, nullptr, SC_PrivateExtern, false, false);
+  // Avoid generating debug location info for the function.
+  FD->setImplicit();
 
   StartFunction(FD, ReturnTy, Fn, FI, Args);
 

--- a/clang/test/CodeGen/debug-info-oslog.c
+++ b/clang/test/CodeGen/debug-info-oslog.c
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -triple x86_64-darwin-apple -debug-info-kind=limited \
+// RUN:   %s -emit-llvm -o -  | FileCheck %s
+void test_builtin_os_log(void *buf, int i, const char *data) {
+  __builtin_os_log_format(buf, "%d", i);
+}
+
+// CHECK: define linkonce_odr {{.*}}@__os_log_helper_1_0_1_4_0(
+// CHECK-SAME:   !dbg ![[OS_LOG_HELPER:[0-9]+]]
+
+// This helper is going to be uniqued, so it should not have a line
+// number between file and type.
+
+// CHECK: distinct !DISubprogram(name: "__os_log_helper_1_0_1_4_0",
+// CHECK-SAME:                   file: !{{[0-9+]}}, type
+// CHECK-SAME:                   flags: DIFlagArtificial


### PR DESCRIPTION
The os_log helper functions are linkonce_odr and supposed to be
uniqued across TUs, so attachine a DW_AT_decl_line on it is highly
misleading. By setting the function decl to implicit, CGDebugInfo
properly marks the functions as artificial and uses a default file /
line 0 location for the function.

rdar://problem/63450824

Differential Revision: https://reviews.llvm.org/D80463

(cherry picked from commit b59b3640bcbdfc6cf4b35ff3a6ad5f524a073b45)