### PR TITLE
Let @skipUnlessAddressSanitizer imply @skipIfAsan

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -785,10 +785,21 @@ def skipUnlessUndefinedBehaviorSanitizer(func):
 
     return skipTestIfFn(is_compiler_clang_with_ubsan)(func)
 
+def is_running_under_asan():
+    if ('ASAN_OPTIONS' in os.environ):
+        return "ASAN unsupported"
+    return None
+
 def skipUnlessAddressSanitizer(func):
     """Decorate the item to skip test unless Clang -fsanitize=thread is supported."""
 
     def is_compiler_with_address_sanitizer(self):
+        # Also don't run tests that use address sanitizer inside an
+        # address-sanitized LLDB. The tests don't support that
+        # configuration.
+        if is_running_under_asan():
+            return "Address sanitizer tests are disabled when runing under ASAN"
+
         compiler_path = self.getCompiler()
         compiler = os.path.basename(compiler_path)
         f = tempfile.NamedTemporaryFile()
@@ -802,6 +813,10 @@ def skipUnlessAddressSanitizer(func):
             return "Compiler cannot compile with -fsanitize=address"
         return None
     return skipTestIfFn(is_compiler_with_address_sanitizer)(func)
+
+def skipIfAsan(func):
+    """Skip this test if the environment is set up to run LLDB *itself* under ASAN."""
+    return skipTestIfFn(is_running_under_asan)(func)
 
 def _get_bool_config_skip_if_decorator(key):
     config = lldb.SBDebugger.GetBuildConfiguration()
@@ -847,10 +862,10 @@ def skipUnlessFeature(feature):
                 return "%s is not supported on this system." % feature
     return skipTestIfFn(is_feature_enabled)
 
-def skipIfAsan(func):
-    """Skip this test if the environment is set up to run LLDB itself under ASAN."""
-    def is_asan():
-        if ('ASAN_OPTIONS' in os.environ):
-            return "ASAN unsupported"
+def skipIfReproducer(func):
+    """Skip this test if the environment is set up to run LLDB with reproducers."""
+    def is_reproducer():
+        if configuration.capture_path or configuration.replay_path:
+            return "reproducers unsupported"
         return None
-    return skipTestIfFn(is_asan)(func)
+    return skipTestIfFn(is_reproducer)(func)


### PR DESCRIPTION
Don't run tests that use address sanitizer inside an address-sanitized
LLDB. The tests don't support that configuration. Incidentally they
were skipped on green dragon for a different reason, so this hasn't
come up there before.

(cherry picked from commit 09de6e0fbd0b6ca7fa8760ac3513be6bbbba5a81)

 Conflicts:
	lldb/packages/Python/lldbsuite/test/decorators.py