### PR TITLE
Also cache negative results in GetXcodeSDKPath (NFC)

### DIFF
--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -367,8 +367,10 @@ llvm::StringRef HostInfoMacOSX::GetXcodeSDKPath(XcodeSDK sdk) {
   static std::mutex g_sdk_path_mutex;
 
   std::lock_guard<std::mutex> guard(g_sdk_path_mutex);
-  std::string &path = g_sdk_path[sdk.GetString()];
-  if (path.empty())
-    path = GetXcodeSDK(sdk);
+  auto it = g_sdk_path.find(sdk.GetString());
+  if (it != g_sdk_path.end())
+    return it->second;
+  std::string path = GetXcodeSDK(sdk);
+  g_sdk_path.insert({sdk.GetString(), path});
   return path;
 }


### PR DESCRIPTION
This fixes a performance issue in the failure case.

rdar://63547920

Differential Revision: https://reviews.llvm.org/D80595

(cherry picked from commit 334552150770faaa407fecab42f5333bb2a898a6)