### PR TITLE
[lldb][target] Remove merge markers.

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -1324,7 +1324,6 @@ public:
   ///     pre-computed.
   void PrintWarningOptimization(const SymbolContext &sc);
 
-<<<<<<< HEAD
   /// Prints a async warning message to the user one time per Process
   /// for a Module whose Swift AST sections couldn't be loaded because
   /// they aren't buildable on the current machine.
@@ -1333,13 +1332,12 @@ public:
   ///     The affected Module.
   void PrintWarningCantLoadSwiftModule(const Module &module,
                                        std::string details);
-=======
+
   /// Print a user-visible warning about a function written in a
   /// language that this version of LLDB doesn't support.
   ///
   /// \see PrintWarningOptimization
   void PrintWarningUnsupportedLanguage(const SymbolContext &sc);
->>>>>>> refs/am/changes/09c86369abd518e8a1872a807cbce20d8be9fbb4_swift/master-next
 
   virtual bool GetProcessInfo(ProcessInstanceInfo &info);
 


### PR DESCRIPTION
https://github.com/apple/llvm-project/commit/8ce6ab43d900322283eecc7d21ae30c49cefac10 was a merge commit, but the markers were accidentally left in.