### PR TITLE
Fix a use-after-free in GetXcodeSDKPath

### DIFF
--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -370,7 +370,6 @@ llvm::StringRef HostInfoMacOSX::GetXcodeSDKPath(XcodeSDK sdk) {
   auto it = g_sdk_path.find(sdk.GetString());
   if (it != g_sdk_path.end())
     return it->second;
-  std::string path = GetXcodeSDK(sdk);
-  g_sdk_path.insert({sdk.GetString(), path});
-  return path;
+  auto it_new = g_sdk_path.insert({sdk.GetString(), GetXcodeSDK(sdk)});
+  return it_new.first->second;
 }


### PR DESCRIPTION
Introduced in https://reviews.llvm.org/D80595. Thanks Jonas for noticing!

Differential Revision: https://reviews.llvm.org/D80666

(cherry picked from commit a57a67c59b3f7529f4aa30009b214248772b544b)

<rdar://problem/63547920>