### PR TITLE
[lldb][typesystem] Fix a StringRef to std::string conversion.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -1277,7 +1277,7 @@ OptionalClangModuleID TypeSystemClang::GetOrCreateClangModule(
   if (!created)
     return ast_source->GetIDForModule(module);
 
-  module->APINotesFile = apinotes;
+  module->APINotesFile = apinotes.str();
   return ast_source->RegisterModule(module);
 }
 

--- a/lldb/source/Symbol/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Symbol/TypeSystemSwiftTypeRef.cpp
@@ -449,7 +449,7 @@ GetNodeForPrinting(const std::string &m_description, lldb_private::Module &M,
       break;
 
     // Read the Swift name from the APINotes.
-    std::string swift_name = ident;
+    std::string swift_name = ident.str();
     if (unsigned id = clang_decl->getOwningModuleID()) {
       auto *clang_typesystem = llvm::dyn_cast_or_null<TypeSystemClang>(
           compiler_type.GetTypeSystem());

--- a/lldb/source/Symbol/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Symbol/TypeSystemSwiftTypeRef.cpp
@@ -326,7 +326,7 @@ clang::api_notes::APINotesManager *TypeSystemSwiftTypeRef::GetAPINotesManager(
   std::string path;
   for (clang::Module *parent = module; parent; parent = parent->Parent) {
     if (!parent->APINotesFile.empty()) {
-      path = llvm::sys::path::parent_path(parent->APINotesFile);
+      path = llvm::sys::path::parent_path(parent->APINotesFile).str();
       break;
     }
   }


### PR DESCRIPTION
Explictly call StringRef::str, the implicit conversion operator was
removed in an earlier commit: (See llvm/llvm-project@adcd026)

(Please summon the test bot)