### PR TITLE
Revert "Revert "[lldb/Test] XFAIL TestDataFormatterObjCNSError except…

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSError.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSError.py
@@ -15,6 +15,7 @@ from ObjCDataFormatterTestCase import ObjCDataFormatterTestCase
 class ObjCDataFormatterNSError(ObjCDataFormatterTestCase):
 
     @skipUnlessDarwin
+    @expectedFailureAll(debug_info=["dwarf", "dsym", "dwo"], bugnumber="rdar://25587546")
     def test_nserror_with_run_command(self):
         """Test formatters for NSError."""
         self.appkit_tester_impl(self.nserror_data_formatter_commands)


### PR DESCRIPTION
… for gmodules.""

This reverts commit 18b06f6a7ec6d3f8393cb3861dd3d80c088f0f67.

This test fails upon conditions that we don't fully understand yet.
It consistently fails on ci.swift.org so I'm reverting this to get
the bots running again.