### PR TITLE
Fix the crashlog.py script's use of the load_address property.

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -791,11 +791,11 @@ def save_crashlog(debugger, command, exe_ctx, result, dict):
                     block_range = block.range[frame.addr]
                     if block_range:
                         block_start_addr = block_range[0]
-                        frame_offset = frame_pc - block_start_addr.load_addr
+                        frame_offset = frame_pc - block_start_addr.GetLoadAddress(target)
                     else:
-                        frame_offset = frame_pc - frame.function.addr.load_addr
+                        frame_offset = frame_pc - frame.function.addr.GetLoadAddress(target)
                 elif frame.symbol:
-                    frame_offset = frame_pc - frame.symbol.addr.load_addr
+                    frame_offset = frame_pc - frame.symbol.addr.GetLoadAddress(target)
                 out_file.write(
                     '%-3u %-32s 0x%16.16x %s' %
                     (frame_idx, frame.module.file.basename, frame_pc, frame.name))

--- a/lldb/test/API/macosx/save_crashlog/Makefile
+++ b/lldb/test/API/macosx/save_crashlog/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
+
+include Makefile.rules

--- a/lldb/test/API/macosx/save_crashlog/TestSaveCrashlog.py
+++ b/lldb/test/API/macosx/save_crashlog/TestSaveCrashlog.py
@@ -1,0 +1,68 @@
+"""
+Test that the save_crashlog command functions
+"""
+
+
+import os
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class TestSaveCrashlog(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    # If your test case doesn't stress debug info, the
+    # set this to true.  That way it won't be run once for
+    # each debug info format.
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @skipUnlessDarwin
+    def test_save_crashlog(self):
+        """There can be many tests in a test case - describe this test here."""
+        self.build()
+        self.main_source_file = lldb.SBFileSpec("main.c")
+        self.save_crashlog()
+
+    def save_crashlog(self):
+
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(self,
+                                   "I was called", self.main_source_file)
+
+        self.runCmd("command script import lldb.macosx.crashlog")
+        out_file = os.path.join(self.getBuildDir(), "crash.log")
+        self.runCmd("save_crashlog '%s'"%(out_file))
+
+        # Make sure we wrote the file:
+        self.assertTrue(os.path.exists(out_file), "We wrote our file")
+        
+        # Now scan the file to make sure it looks right:
+        # First get a few facts we'll use:
+        exe_module = target.FindModule(target.GetExecutable())
+        uuid_str = exe_module.GetUUIDString()
+
+        # We'll set these to true when we find the elements in the file
+        found_call_me = False
+        found_main_line = False
+        found_thread_header = False
+        found_uuid_str = False
+
+        with open(out_file, "r") as f:
+            # We want to see a line with
+            for line in f:
+                if "Thread 0:" in line:
+                    found_thread_header = True
+                if "call_me" in line and "main.c:" in line:
+                    found_call_me = True
+                if "main" in line and "main.c:" in line:
+                    found_main_line = True
+                if uuid_str in line and "a.out" in line:
+                    found_uuid_str = True
+        
+        self.assertTrue(found_thread_header, "Found thread header")
+        self.assertTrue(found_call_me, "Found call_me line in stack")
+        self.assertTrue(found_uuid_str, "Found main binary UUID")
+        self.assertTrue(found_main_line, "Found main line in call stack")
+                        

--- a/lldb/test/API/macosx/save_crashlog/main.c
+++ b/lldb/test/API/macosx/save_crashlog/main.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+
+void
+call_me() {
+  printf("I was called");
+}
+
+int
+main()
+{
+  call_me();
+  return 0;
+}


### PR DESCRIPTION
This property is explicitly for use only in the interactive editor,
and NOT in commands.  It's use worked until we got more careful about
not leaving lldb.target lying around in the script interpreter.

I also added a quick sniff test for the save_crashlog command.

<rdar://problem/60350620>
Differential Revision: https://reviews.llvm.org/D80680