### PR TITLE
[lldb/test] Fix TestAppleSimulatorOSType when multiple runtimes are i…

### DIFF
--- a/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
+++ b/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
@@ -18,6 +18,7 @@ class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
         sim_devices = json.loads(sim_devices_str)['devices']
         # Find an available simulator for the requested platform
         deviceUDID = None
+        deviceRuntime = None
         for simulator in sim_devices:
             if isinstance(simulator,dict):
                 runtime = simulator['name']
@@ -32,9 +33,11 @@ class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
                     continue
                 if 'isAvailable' in device and device['isAvailable'] != True:
                     continue
+                if deviceRuntime and runtime < deviceRuntime:
+                    continue
                 deviceUDID = device['udid']
-                break
-            if deviceUDID != None:
+                deviceRuntime = runtime
+                # Stop searching in this runtime
                 break
 
         # Launch the process using simctl


### PR DESCRIPTION
…nstalled

One can have multiple simulator runtimes installed, supporting
various generations of OSs. The logic in TestAppleSimulatorOSType
might select a rnutime older than the one targeted by the current
tools, preventing the executable from running. This commit changes
the test to look for the most recent runtime available instead.

(cherry picked from commit 977f00123a6d94c634d22356cae1da2a22f0e3df)