### PR TITLE
[Docs] Correct description of lldbinit behavior

### DIFF
--- a/lldb/docs/man/lldb.rst
+++ b/lldb/docs/man/lldb.rst
@@ -296,13 +296,17 @@ CONFIGURATION FILES
 -------------------
 
 :program:`lldb` reads things like settings, aliases and commands from the
-.lldbinit file. First, it will read the application specific init file whose
-name is ~/.lldbinit followed by a "-" and the name of the current program. This
-would be ~/.lldbinit-lldb for the command line :program:`lldb` and
-~/.lldbinit-Xcode for Xcode. Secondly, the global ~/.lldbinit will be read.
-Finally, :program:`lldb` will look for an .lldbinit file in the current working
-directory. For security reasons, :program:`lldb` will print a warning and not
-source this file by default. This behavior can be changed by changing the
+.lldbinit file.
+
+First, it will read the application specific init file whose name is
+~/.lldbinit followed by a "-" and the name of the current program. This would
+be ~/.lldbinit-lldb for the command line :program:`lldb` and ~/.lldbinit-Xcode
+for Xcode. If there is no application specific init file, the global
+~/.lldbinit is read.
+
+Secondly, it will look for an .lldbinit file in the current working directory.
+For security reasons, :program:`lldb` will print a warning and not source this
+file by default. This behavior can be changed by changing the
 target.load-cwd-lldbinit setting.
 
 To always load the .lldbinit file in the current working directory, add the


### PR DESCRIPTION
Jim pointed out that "every time somebody has touched the documentation
on startup files they have stated that we source the application one and
then the global one, even though in actual fact we’ve never done that."

Indeed, when we read the application specific .lldbinit file, the global
one is not read. This patch updates the man page to reflect that.

(cherry picked from commit ac1dc1336ad76d719445d706654ca0ec4ff5557c)