### PR TITLE
[lldb/Bindings] Raise exception when using properties that rely on lldb.target

### DIFF
--- a/lldb/bindings/CMakeLists.txt
+++ b/lldb/bindings/CMakeLists.txt
@@ -1,4 +1,4 @@
-file(GLOB SWIG_INTERFACES interfaces/*.i)
+file(GLOB SWIG_INTERFACES interface/*.i)
 file(GLOB_RECURSE SWIG_SOURCES *.swig)
 file(GLOB SWIG_HEADERS
   ${LLDB_SOURCE_DIR}/include/lldb/API/*.h

--- a/lldb/bindings/interface/SBAddress.i
+++ b/lldb/bindings/interface/SBAddress.i
@@ -144,27 +144,34 @@ public:
 
 #ifdef SWIGPYTHON
     %pythoncode %{
+        __runtime_error_str = 'This resolves the SBAddress using the SBTarget from lldb.target so this property can ONLY be used in the interactive script interpreter (i.e. under the lldb script command). For things like Python based commands and breakpoint callbacks use GetLoadAddress instead.'
+
         def __get_load_addr_property__ (self):
-            '''Get the load address for a lldb.SBAddress using the current target.'''
+            '''Get the load address for a lldb.SBAddress using the current target. This resolves the SBAddress using the SBTarget from lldb.target so this property can ONLY be used in the interactive script interpreter (i.e. under the lldb script command). For things like Python based commands and breakpoint callbacks use GetLoadAddress instead.'''
+            if not target:
+                raise RuntimeError(self.__runtime_error_str)
             return self.GetLoadAddress (target)
 
         def __set_load_addr_property__ (self, load_addr):
-            '''Set the load address for a lldb.SBAddress using the current target.'''
+            '''Set the load address for a lldb.SBAddress using the current target. This resolves the SBAddress using the SBTarget from lldb.target so this property can ONLY be used in the interactive script interpreter (i.e. under the lldb script command). For things like Python based commands and breakpoint callbacks use GetLoadAddress instead.'''
+            if not target:
+                raise RuntimeError(self.__runtime_error_str)
             return self.SetLoadAddress (load_addr, target)
 
         def __int__(self):
-            '''Convert an address to a load address if there is a process and that process is alive, or to a file address otherwise.'''
-            if process and process.is_alive:
+            '''Convert an address to a load address if there is a process and that process is alive, or to a file address otherwise. This resolves the SBAddress using the SBTarget from lldb.target so this property can ONLY be used in the interactive script interpreter (i.e. under the lldb script command). For things like Python based commands and breakpoint callbacks use GetLoadAddress instead.'''
+            if not process or not target:
+                raise RuntimeError(self.__runtime_error_str)
+            if process.is_alive:
                 return self.GetLoadAddress (target)
-            else:
-                return self.GetFileAddress ()
+            return self.GetFileAddress ()
 
         def __oct__(self):
-            '''Convert the address to an octal string'''
+            '''Convert the address to an octal string. This resolves the SBAddress using the SBTarget from lldb.target so this property can ONLY be used in the interactive script interpreter (i.e. under the lldb script command). For things like Python based commands and breakpoint callbacks use GetLoadAddress instead.'''
             return '%o' % int(self)
 
         def __hex__(self):
-            '''Convert the address to an hex string'''
+            '''Convert the address to an hex string. This resolves the SBAddress using the SBTarget from lldb.target so this property can ONLY be used in the interactive script interpreter (i.e. under the lldb script command). For things like Python based commands and breakpoint callbacks use GetLoadAddress instead.'''
             return '0x%x' % int(self)
 
         module = property(GetModule, None, doc='''A read only property that returns an lldb object that represents the module (lldb.SBModule) that this address resides within.''')
@@ -176,7 +183,7 @@ public:
         offset = property(GetOffset, None, doc='''A read only property that returns the section offset in bytes as an integer.''')
         section = property(GetSection, None, doc='''A read only property that returns an lldb object that represents the section (lldb.SBSection) that this address resides within.''')
         file_addr = property(GetFileAddress, None, doc='''A read only property that returns file address for the section as an integer. This is the address that represents the address as it is found in the object file that defines it.''')
-        load_addr = property(__get_load_addr_property__, __set_load_addr_property__, doc='''A read/write property that gets/sets the SBAddress using load address. The setter resolves SBAddress using the SBTarget from lldb.target so this property can ONLY be used in the interactive script interpreter (i.e. under the lldb script command) and not in Python based commands, or breakpoint commands.''')
+        load_addr = property(__get_load_addr_property__, __set_load_addr_property__, doc='''A read/write property that gets/sets the SBAddress using load address. This resolves the SBAddress using the SBTarget from lldb.target so this property can ONLY be used in the interactive script interpreter (i.e. under the lldb script command). For things like Python based commands and breakpoint callbacks use GetLoadAddress instead.''')
     %}
 #endif
 

--- a/lldb/test/Shell/ScriptInterpreter/Python/Inputs/sbaddress.py
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Inputs/sbaddress.py
@@ -1,0 +1,7 @@
+import lldb
+
+def test(debugger, command, result, internal_dict):
+    return int(lldb.SBAddress())
+
+def __lldb_init_module(debugger, internal_dict):
+    debugger.HandleCommand('command script add -f sbaddress.test test')

--- a/lldb/test/Shell/ScriptInterpreter/Python/sb_address_exception.test
+++ b/lldb/test/Shell/ScriptInterpreter/Python/sb_address_exception.test
@@ -1,0 +1,8 @@
+# REQUIRES: python
+# UNSUPPORTED: lldb-repro
+#
+# Test that the SBAddress properties throw an exception when used outside of
+# the interactive script interpreter.
+#
+# RUN: %lldb --script-language python -o 'command script import %S/Inputs/sbaddress.py' -o 'test' 2>&1 | FileCheck %s
+# CHECK: RuntimeError: This resolves the SBAddress using the SBTarget from lldb.target so this property can ONLY be used in the interactive script interpreter (i.e. under the lldb script command). For things like Python based commands and breakpoint callbacks use GetLoadAddress instead.


### PR DESCRIPTION
Several SBAddress properties use the lldb.target or lldb.process
convenience variables which are only set under the interactive script
interpreter. Unfortunately, users have been using these properties in
Python script and commands. This patch raises a Python exception to
force users to use GetLoadAddress instead.

Differential revision: https://reviews.llvm.org/D80848