### PR TITLE
Revert "Define SWIFT_INLINE_NAMESPACE for swiftDemangling inclusions."

### DIFF
--- a/lldb/source/Core/CMakeLists.txt
+++ b/lldb/source/Core/CMakeLists.txt
@@ -90,11 +90,6 @@ add_lldb_library(lldbCore
     Demangle
   )
 
-# Necessary to ensure that the SWIFT_INLINE_NAMESPACE macro is defined for
-# swiftDemangling inclusions.
-target_compile_definitions(lldbCore PRIVATE
-  SWIFT_INLINE_NAMESPACE=compiler)
-
 add_dependencies(lldbCore
   LLDBCorePropertiesGen
   LLDBCorePropertiesEnumGen)

--- a/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
@@ -43,8 +43,3 @@ add_lldb_library(lldbPluginExpressionParserSwift PLUGIN
     Support
     Core
   )
-
-# Necessary to ensure that the SWIFT_INLINE_NAMESPACE macro is defined for
-# swiftDemangling inclusions.
-target_compile_definitions(lldbPluginExpressionParserSwift PRIVATE
-  SWIFT_INLINE_NAMESPACE=compiler)

--- a/lldb/source/Plugins/SymbolFile/DWARF/CMakeLists.txt
+++ b/lldb/source/Plugins/SymbolFile/DWARF/CMakeLists.txt
@@ -66,8 +66,3 @@ add_lldb_library(lldbPluginSymbolFileDWARF PLUGIN
 add_dependencies(lldbPluginSymbolFileDWARF
   LLDBPluginSymbolFileDWARFPropertiesGen
   LLDBPluginSymbolFileDWARFPropertiesEnumGen)
-
-# Necessary to ensure that the SWIFT_INLINE_NAMESPACE macro is defined for
-# swiftDemangling inclusions.
-target_compile_definitions(lldbPluginSymbolFileDWARF PRIVATE
-  SWIFT_INLINE_NAMESPACE=compiler)

--- a/lldb/source/Symbol/CMakeLists.txt
+++ b/lldb/source/Symbol/CMakeLists.txt
@@ -63,8 +63,3 @@ add_lldb_library(lldbSymbol
 if(CMAKE_CXX_COMPILER_ID STREQUAL Clang AND NOT SWIFT_COMPILER_IS_MSVC_LIKE)
   target_compile_options(lldbSymbol PRIVATE -Wno-dollar-in-identifier-extension)
 endif()
-
-# Necessary to ensure that the SWIFT_INLINE_NAMESPACE macro is defined for
-# swiftDemangling inclusions.
-target_compile_definitions(lldbSymbol PRIVATE
-  SWIFT_INLINE_NAMESPACE=compiler)

--- a/lldb/source/Target/CMakeLists.txt
+++ b/lldb/source/Target/CMakeLists.txt
@@ -99,8 +99,3 @@ endif()
 add_dependencies(lldbTarget
   LLDBTargetPropertiesGen
   LLDBTargetPropertiesEnumGen)
-
-# Necessary to ensure that the SWIFT_INLINE_NAMESPACE macro is defined for
-# swiftDemangling inclusions.
-target_compile_definitions(lldbTarget PRIVATE
-  SWIFT_INLINE_NAMESPACE=compiler)


### PR DESCRIPTION
This reverts commit 0f6908ee5451a3391208a1b947db07068a31f150.

The original intent of #1023 (when paired with https://github.com/apple/swift/pull/30733) was to have the `swift::Demangling::` namespace symbols nested in either `compiler::` or `runtime::` inline namespace to avoid potential ODRs between the compiler and runtime. Unfortunately the forward declarations introduced in https://github.com/apple/llvm-project/commit/6deae69d73d3975e58d2d56410c971389f98273f break this because they declare them without the namespace macros in swift/Demangling (and SwiftASTContext.h does not include that file).

So it's better now to update https://github.com/apple/swift/pull/30733 to just omit the inline namespace entirely for the compiler's (and lldb's) symbols and only inject it for the runtime, which allows these forward decls to continue to work. Thus, these CMake changes are no longer needed.