### PR TITLE
[lldb] Add support for evaluation of generic variables

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -138,6 +138,7 @@ protected:
   /// The body of the catch - we patch the assignment there to capture
   /// any error thrown.
   swift::CaseStmt *m_catch_stmt = nullptr;
+  swift::CallExpr *m_call = nullptr;
 };
 
 class SwiftASTManipulator : public SwiftASTManipulatorBase {

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1457,7 +1457,8 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     parsed_expr->code_manipulator->MakeDeclarationsPublic();
   }
 
-//  parsed_expr->code_manipulator->FixReturnInner();
+  parsed_expr->code_manipulator->FixReturnInner();
+  swift::performTypeChecking(parsed_expr->source_file);
 
   Status error;
   if (!playground) {


### PR DESCRIPTION
This PR is work towards fixing [issue SR-12397](https://bugs.swift.org/browse/SR-12397).

The problem being solved is evaluating generics variables as such, even if they have a substituted type at the current evaluation point. For example, evaluating `foo != nil` inside the function below should evaluate to true instead of false:
```
func f<T>(_ foo: T) {
    let test = foo != nil
    print(test)
}
let x: Int? = nil
f(x)
```

We achieve this by introducing a second function, `$__lldb_inner_expr`, and passing all the variables in the current environment as arguments to said function, making them generic if their type was substituted.

We start setting up `$__lldb_expr` and `$__lldb_inner_expr`:
```
func $__lldb_inner_expr() throws {
  /*__LLDB_USER_START__*/
  foo != nil // user expression inserted here
  /*__LLDB_USER_END__*/
}
@LLDBDebuggerFunction 
func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {
  do {
    $__lldb_inner_expr()
  } catch (let __lldb_tmp_error) {
    var $__lldb_error_result = __lldb_tmp_error
  }
}
``` 

We update `$__lldb_inner_expr`'s signature to receive all the variables in `$__lldb_expr`, as well as update the call site to pass those parameters along. This is done in `SwiftASTManipulator::SetupParametersForInnerFunction`. For the example, let's say that `foo` is a variable with substituted type `Int?` and `bar` has type `String`:

```
func $__lldb_inner_expr<T0>(foo: T0, bar: String) throws {
  /*__LLDB_USER_START__*/
  foo != nil
  /*__LLDB_USER_END__*/
}
@LLDBDebuggerFunction 
func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {
  do {
    $__lldb_inner_expr(foo: foo, bar: bar)
  } catch (let __lldb_tmp_error) {
    var $__lldb_error_result = __lldb_tmp_error
  }
}
``` 

After type-checking is done, we update the return type of `$__lldb_inner_expr` to the correct type and return the last expression. We should also update the call site to expect a value of that type, this is what's missing.
```
func $__lldb_inner_expr<T0>(foo: T0, bar: String) throws -> Bool {
  /*__LLDB_USER_START__*/
  return foo != nil
  /*__LLDB_USER_END__*/
}
@LLDBDebuggerFunction 
func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {
  do {
   // expect a value of type `Bool` here, currently working on this
    $__lldb_inner_expr(foo: foo, bar: bar) 
  } catch (let __lldb_tmp_error) {
    var $__lldb_error_result = __lldb_tmp_error
  }
}
``` 
After that evaluation continues as normal.

--------------

@vedantk @adrian-prantl I left it in a state that is runnable so you can test it if you want. Essentially, what is missing in order to support evaluating an expression outside an extension is making `FixReturnInner` correctly update the caller's type. There are also a couple of hacks left to clean up which I haven't forgotten.

Also, as I said on the issue, this depends on adding a function `GenericContext::setGenericParams` in the Swift side. I'm not sure if there's a reason that this function doesn't exist or not. If it shouldn't exist, I can try cloning my function setting the correct `GenericParamList` instead. If it's ok, I can open a PR to the swift repo as well.