### PR TITLE
Remove redundant code (NFC)

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -684,15 +684,8 @@ bool DynamicLoaderDarwin::AddModulesUsingImageInfos(
       // Update the module's platform with the DYLD info.
       ArchSpec dyld_spec = image_infos[idx].GetArchitecture();
       if (dyld_spec.GetTriple().getOS() == llvm::Triple::IOS &&
-          dyld_spec.GetTriple().getEnvironment() == llvm::Triple::MacABI) {
+          dyld_spec.GetTriple().getEnvironment() == llvm::Triple::MacABI)
         image_module_sp->MergeArchitecture(dyld_spec);
-        const auto &target_triple = target.GetArchitecture().GetTriple();
-        // If dyld reports the process as being loaded as MACCATALYST,
-        // force-update the target's architecture to MACCATALYST.
-        if (!(target_triple.getOS() == llvm::Triple::IOS &&
-              target_triple.getEnvironment() == llvm::Triple::MacABI))
-          target.SetArchitecture(dyld_spec);
-      }
     }
   }
 


### PR DESCRIPTION
This has no effect on the testsuite and was only needed in an early
prototype from before debugserver was able to report the correct
platform.

(cherry picked from commit 2d2a603d663328e25774982947e3a8a65e098678)