### PR TITLE
[LLDB] nullptr and false are not the same

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
@@ -90,7 +90,7 @@ bool SwiftUnsafeBufferPointer::Update() {
     argument_type = SwiftASTContext::GetGenericArgumentType(type, 0);
 
   if (!argument_type.IsValid())
-    return nullptr;
+    return false;
 
   m_elem_type = argument_type;
 


### PR DESCRIPTION
Newer versions of clang reject this code.