### PR TITLE
NFC: Fix -Welaborated-enum-base error

### DIFF
--- a/clang/include/indexstore/indexstore.h
+++ b/clang/include/indexstore/indexstore.h
@@ -109,7 +109,7 @@
 #endif
 
 #ifndef INDEXSTORE_OPTIONS
-# define INDEXSTORE_OPTIONS(_type, _name) _type _name; enum INDEXSTORE_OPTIONS_ATTRS
+# define INDEXSTORE_OPTIONS(_type, _name) typedef _type _name; enum INDEXSTORE_OPTIONS_ATTRS
 #endif
 
 INDEXSTORE_BEGIN_DECLS

--- a/clang/include/indexstore/indexstore.h
+++ b/clang/include/indexstore/indexstore.h
@@ -100,7 +100,11 @@
 
 #if defined(__has_extension)
 #if __has_feature(objc_fixed_enum)
-# define INDEXSTORE_OPTIONS(_type, _name) enum INDEXSTORE_OPTIONS_ATTRS _name : _type _name; enum INDEXSTORE_OPTIONS_ATTRS _name : _type
+#ifdef __cplusplus
+# define INDEXSTORE_OPTIONS(_type, _name) enum INDEXSTORE_OPTIONS_ATTRS _name : _type
+#else
+# define INDEXSTORE_OPTIONS(_type, _name) enum _name : _type; typedef enum _name _name; enum INDEXSTORE_OPTIONS_ATTRS _name : _type
+#endif
 #endif
 #endif
 
@@ -287,7 +291,7 @@ typedef enum {
   INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORMODIFY = 1015,
 } indexstore_symbol_subkind_t;
 
-typedef INDEXSTORE_OPTIONS(uint64_t, indexstore_symbol_property_t) {
+INDEXSTORE_OPTIONS(uint64_t, indexstore_symbol_property_t) {
   INDEXSTORE_SYMBOL_PROPERTY_GENERIC                          = 1 << 0,
   INDEXSTORE_SYMBOL_PROPERTY_TEMPLATE_PARTIAL_SPECIALIZATION  = 1 << 1,
   INDEXSTORE_SYMBOL_PROPERTY_TEMPLATE_SPECIALIZATION          = 1 << 2,
@@ -307,7 +311,7 @@ typedef enum {
   INDEXSTORE_SYMBOL_LANG_SWIFT = 100,
 } indexstore_symbol_language_t;
 
-typedef INDEXSTORE_OPTIONS(uint64_t, indexstore_symbol_role_t) {
+INDEXSTORE_OPTIONS(uint64_t, indexstore_symbol_role_t) {
   INDEXSTORE_SYMBOL_ROLE_DECLARATION  = 1 << 0,
   INDEXSTORE_SYMBOL_ROLE_DEFINITION   = 1 << 1,
   INDEXSTORE_SYMBOL_ROLE_REFERENCE    = 1 << 2,


### PR DESCRIPTION
Recent versions of clang default -Welaborated-enum-base to -Werror.

The index store is Apple specific.