### PR TITLE
[dsymutil] Don't emit N_AST symbol entries in the Mach-O companion file

### DIFF
--- a/llvm/test/tools/dsymutil/X86/swift-ast-x86_64.test
+++ b/llvm/test/tools/dsymutil/X86/swift-ast-x86_64.test
@@ -18,3 +18,6 @@ READOBJ-NEXT: |.|
 
 RUN: dsymutil -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -no-output -verbose 2>&1 | FileCheck %s --check-prefix=TIMESTAMP
 TIMESTAMP: warning: Timestamp mismatch
+
+RUN: dsymutil -s %T/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=NAST
+NAST-NOT: N_AST

--- a/llvm/tools/dsymutil/MachOUtils.cpp
+++ b/llvm/tools/dsymutil/MachOUtils.cpp
@@ -163,7 +163,15 @@ static bool transferSymbol(NListTy NList, bool IsLittleEndian,
   if ((NList.n_type & MachO::N_TYPE) == MachO::N_UNDF)
     return false;
 
+  // Do not transfer N_AST symbols as their content is copied into a section of
+  // the Mach-O companion file.
+  if (NList.n_type == MachO::N_AST)
+    return false;
+
   StringRef Name = StringRef(Strings.begin() + NList.n_strx);
+
+  // An N_SO with a filename opens a debugging scope and another one without a
+  // name closes it. Don't transfer anything in the debugging scope.
   if (InDebugNote) {
     InDebugNote =
         (NList.n_type != MachO::N_SO) || (!Name.empty() && Name[0] != '\0');


### PR DESCRIPTION
Treat N_AST symbol table entries like other debug entries and don't emit
them in the linked binary.

Differential revision: https://reviews.llvm.org/D81205

(cherry picked from commit fe82d3a3ae32843069349eace204593520403964)