### PR TITLE
Added <cstdlib> header for std::abort

### DIFF
--- a/clang-tools-extra/clangd/Shutdown.cpp
+++ b/clang-tools-extra/clangd/Shutdown.cpp
@@ -10,6 +10,7 @@
 
 #include <atomic>
 #include <thread>
+#include <cstdlib>
 
 namespace clang {
 namespace clangd {


### PR DESCRIPTION
std::abort had been implicitly included, which Clang 10 does not like.