### PR TITLE
Cherry-pick a boatload of commits

### DIFF
--- a/lldb/include/lldb/Host/HostInfoBase.h
+++ b/lldb/include/lldb/Host/HostInfoBase.h
@@ -92,6 +92,9 @@ public:
   static bool ComputePathRelativeToLibrary(FileSpec &file_spec,
                                            llvm::StringRef dir);
 
+  static FileSpec GetXcodeContentsDirectory() { return {}; }
+  static FileSpec GetXcodeDeveloperDirectory() { return {}; }
+  
   /// Return the directory containing a specific Xcode SDK.
   static llvm::StringRef GetXcodeSDKPath(XcodeSDK sdk) { return {}; }
 

--- a/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
+++ b/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
@@ -32,7 +32,8 @@ public:
   static bool GetOSBuildString(std::string &s);
   static bool GetOSKernelDescription(std::string &s);
   static FileSpec GetProgramFileSpec();
-  static std::string FindXcodeContentsDirectoryInPath(llvm::StringRef path);
+  static FileSpec GetXcodeContentsDirectory();
+  static FileSpec GetXcodeDeveloperDirectory();
 
   /// Query xcrun to find an Xcode SDK directory.
   static llvm::StringRef GetXcodeSDKPath(XcodeSDK sdk);

--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -713,7 +713,8 @@ public:
   void LoadModule(swift::ModuleDecl *swift_module, Process &process,
                   Status &error);
 
-  bool RegisterSectionModules(Module &module,
+  /// Collect Swift modules in the .swift_ast section of \p module.
+  void RegisterSectionModules(Module &module,
                               std::vector<std::string> &module_names);
 
   void ValidateSectionModules(Module &module, // this is used to print errors

--- a/lldb/include/lldb/Utility/XcodeSDK.h
+++ b/lldb/include/lldb/Utility/XcodeSDK.h
@@ -87,6 +87,8 @@ public:
   static std::string GetCanonicalName(Info info);
   /// Return the best-matching SDK type for a specific triple.
   static XcodeSDK::Type GetSDKTypeForTriple(const llvm::Triple &triple);
+
+  static std::string FindXcodeContentsDirectoryInPath(llvm::StringRef path);
 };
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <thread>
 #include "lldb/Host/PseudoTerminal.h"
+#include "lldb/Host/HostInfo.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Utility/LLDBAssert.h"
 #include "lldb/Utility/Status.h"
@@ -77,7 +78,7 @@ void PlatformAppleSimulator::GetStatus(Stream &strm) {
   // simulator
   PlatformAppleSimulator::LoadCoreSimulator();
 
-  std::string developer_dir = GetXcodeDeveloperDirectory().GetPath();
+  std::string developer_dir = HostInfo::GetXcodeDeveloperDirectory().GetPath();
   CoreSimulatorSupport::DeviceSet devices =
       CoreSimulatorSupport::DeviceSet::GetAvailableDevices(
           developer_dir.c_str());
@@ -124,7 +125,7 @@ Status PlatformAppleSimulator::ConnectRemote(Args &args) {
     const char *arg_cstr = args.GetArgumentAtIndex(0);
     if (arg_cstr) {
       std::string arg_str(arg_cstr);
-      std::string developer_dir = GetXcodeDeveloperDirectory().GetPath();
+      std::string developer_dir = HostInfo::GetXcodeDeveloperDirectory().GetPath();
       CoreSimulatorSupport::DeviceSet devices =
           CoreSimulatorSupport::DeviceSet::GetAvailableDevices(
               developer_dir.c_str());
@@ -214,7 +215,7 @@ FileSpec PlatformAppleSimulator::GetCoreSimulatorPath() {
 #if defined(__APPLE__)
   std::lock_guard<std::mutex> guard(m_core_sim_path_mutex);
   if (!m_core_simulator_framework_path.hasValue()) {
-    if (FileSpec fspec = GetXcodeDeveloperDirectory()) {
+    if (FileSpec fspec = HostInfo::GetXcodeDeveloperDirectory()) {
       std::string developer_dir = fspec.GetPath();
       StreamString cs_path;
       cs_path.Printf(
@@ -247,7 +248,7 @@ CoreSimulatorSupport::Device PlatformAppleSimulator::GetSimulatorDevice() {
   if (!m_device.hasValue()) {
     const CoreSimulatorSupport::DeviceType::ProductFamilyID dev_id =
         CoreSimulatorSupport::DeviceType::ProductFamilyID::iPhone;
-    std::string developer_dir = GetXcodeDeveloperDirectory().GetPath();
+    std::string developer_dir = HostInfo::GetXcodeDeveloperDirectory().GetPath();
     m_device = CoreSimulatorSupport::DeviceSet::GetAvailableDevices(
                    developer_dir.c_str())
                    .GetFanciest(dev_id);

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.cpp
@@ -255,7 +255,7 @@ EnumerateDirectoryCallback(void *baton, llvm::sys::fs::file_type ft,
 const char *PlatformAppleTVSimulator::GetSDKDirectoryAsCString() {
   std::lock_guard<std::mutex> guard(m_sdk_dir_mutex);
   if (m_sdk_directory.empty()) {
-    if (FileSpec fspec = GetXcodeDeveloperDirectory()) {
+    if (FileSpec fspec = HostInfo::GetXcodeDeveloperDirectory()) {
       std::string developer_dir = fspec.GetPath();
       char sdks_directory[PATH_MAX];
       char sdk_dirname[PATH_MAX];

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.cpp
@@ -255,7 +255,7 @@ EnumerateDirectoryCallback(void *baton, llvm::sys::fs::file_type ft,
 const char *PlatformAppleWatchSimulator::GetSDKDirectoryAsCString() {
   std::lock_guard<std::mutex> guard(m_sdk_dir_mutex);
   if (m_sdk_directory.empty()) {
-    if (FileSpec fspec = GetXcodeDeveloperDirectory()) {
+    if (FileSpec fspec = HostInfo::GetXcodeDeveloperDirectory()) {
       std::string developer_dir = fspec.GetPath();
       char sdks_directory[PATH_MAX];
       char sdk_dirname[PATH_MAX];

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -89,9 +89,6 @@ public:
   llvm::Expected<lldb_private::StructuredData::DictionarySP>
   FetchExtendedCrashInformation(lldb_private::Process &process) override;
 
-  static lldb_private::FileSpec GetXcodeContentsDirectory();
-  static lldb_private::FileSpec GetXcodeDeveloperDirectory();
-
   /// Return the toolchain directory the current LLDB instance is located in.
   static lldb_private::FileSpec GetCurrentToolchainDirectory();
 
@@ -165,7 +162,6 @@ protected:
 
   static std::string FindComponentInPath(llvm::StringRef path,
                                          llvm::StringRef component);
-  static std::string FindXcodeContentsDirectoryInPath(llvm::StringRef path);
 
   std::string m_developer_directory;
   llvm::StringMap<std::string> m_sdk_path;

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
@@ -17,6 +17,7 @@
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Host/Host.h"
+#include "lldb/Host/HostInfo.h"
 #include "lldb/Interpreter/OptionValueFileSpecList.h"
 #include "lldb/Interpreter/OptionValueProperties.h"
 #include "lldb/Interpreter/Property.h"
@@ -327,7 +328,7 @@ void PlatformDarwinKernel::CollectKextAndKernelDirectories() {
 
   // DeveloperDirectory is something like
   // "/Applications/Xcode.app/Contents/Developer"
-  std::string developer_dir = GetXcodeDeveloperDirectory().GetPath();
+  std::string developer_dir = HostInfo::GetXcodeDeveloperDirectory().GetPath();
   if (developer_dir.empty())
     developer_dir = "/Applications/Xcode.app/Contents/Developer";
 

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
@@ -197,7 +197,7 @@ ConstString PlatformMacOSX::GetSDKDirectory(lldb_private::Target &target) {
     return {};
 
   // First try to find an SDK that matches the given SDK version.
-  if (FileSpec fspec = GetXcodeContentsDirectory()) {
+  if (FileSpec fspec = HostInfo::GetXcodeContentsDirectory()) {
     StreamString sdk_path;
     sdk_path.Printf("%s/Developer/Platforms/MacOSX.platform/Developer/"
                     "SDKs/MacOSX%u.%u.sdk",

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.cpp
@@ -15,6 +15,7 @@
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/Host.h"
+#include "lldb/Host/HostInfo.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/FileSpec.h"
@@ -342,7 +343,7 @@ PlatformRemoteDarwinDevice::GetSDKDirectoryForLatestOSVersion() {
 const char *PlatformRemoteDarwinDevice::GetDeviceSupportDirectory() {
   std::string platform_dir = "/Platforms/" + GetPlatformName() + "/DeviceSupport";
   if (m_device_support_directory.empty()) {
-    if (FileSpec fspec = GetXcodeDeveloperDirectory()) {
+    if (FileSpec fspec = HostInfo::GetXcodeDeveloperDirectory()) {
       m_device_support_directory = fspec.GetPath();
       m_device_support_directory.append(platform_dir.c_str());
     } else {

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.cpp
@@ -260,7 +260,7 @@ EnumerateDirectoryCallback(void *baton, llvm::sys::fs::file_type ft,
 const char *PlatformiOSSimulator::GetSDKDirectoryAsCString() {
   std::lock_guard<std::mutex> guard(m_sdk_dir_mutex);
   if (m_sdk_directory.empty()) {
-    if (FileSpec fspec = GetXcodeDeveloperDirectory()) {
+    if (FileSpec fspec = HostInfo::GetXcodeDeveloperDirectory()) {
       std::string developer_dir = fspec.GetPath();
       char sdks_directory[PATH_MAX];
       char sdk_dirname[PATH_MAX];

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -3415,6 +3415,7 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
   registerIRGenRequestFunctions(m_ast_context_ap->evaluator);
 
   registerIRGenSILTransforms(*m_ast_context_ap);
+  registerTBDGenRequestFunctions(m_ast_context_ap->evaluator);
 
   GetASTMap().Insert(m_ast_context_ap.get(), this);
 

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -6060,7 +6060,7 @@ SwiftASTContext::GetBitSize(opaque_compiler_type_t type,
     swift::CanType swift_bound_type(::GetCanonicalSwiftType(bound_type));
     if (swift_bound_type->hasTypeParameter()) {
       LOG_PRINTF(LIBLLDB_LOG_TYPES, "GetBitSize: Can't bind type: %s",
-                 bound_type.GetTypeName().AsCString());
+                 type.GetTypeName().AsCString());
       return {};
     }
 

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -3420,6 +3420,7 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
   }
 
   // Set up the required state for the evaluator in the TypeChecker.
+  m_ast_context_ap->setLegacySemanticQueriesEnabled();
   registerIDERequestFunctions(m_ast_context_ap->evaluator);
   registerParseRequestFunctions(m_ast_context_ap->evaluator);
   registerTypeCheckerRequestFunctions(m_ast_context_ap->evaluator);

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -2707,7 +2707,7 @@ public:
 
       if (message_ref.empty())
         m_raw_diagnostics.push_back(RawDiagnostic(
-            std::string(text), info.Kind, bufferName, bufferID, line_col.first,
+            text.str(), info.Kind, bufferName, bufferID, line_col.first,
             line_col.second,
             use_fixits ? info.FixIts
             : llvm::ArrayRef<swift::Diagnostic::FixIt>()));
@@ -2719,7 +2719,7 @@ public:
                        : llvm::ArrayRef<swift::Diagnostic::FixIt>()));
     } else {
       m_raw_diagnostics.push_back(RawDiagnostic(
-          std::string(text), info.Kind, bufferName, bufferID, line_col.first,
+          text.str(), info.Kind, bufferName, bufferID, line_col.first,
           line_col.second, llvm::ArrayRef<swift::Diagnostic::FixIt>()));
     }
 

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -3413,9 +3413,7 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
   registerSILOptimizerRequestFunctions(m_ast_context_ap->evaluator);
   registerTBDGenRequestFunctions(m_ast_context_ap->evaluator);
   registerIRGenRequestFunctions(m_ast_context_ap->evaluator);
-
   registerIRGenSILTransforms(*m_ast_context_ap);
-  registerTBDGenRequestFunctions(m_ast_context_ap->evaluator);
 
   GetASTMap().Insert(m_ast_context_ap.get(), this);
 

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -2707,10 +2707,10 @@ public:
 
       if (message_ref.empty())
         m_raw_diagnostics.push_back(RawDiagnostic(
-            text.str(), info.Kind, bufferName, bufferID, line_col.first,
+            std::string(text), info.Kind, bufferName, bufferID, line_col.first,
             line_col.second,
             use_fixits ? info.FixIts
-            : llvm::ArrayRef<swift::Diagnostic::FixIt>()));
+                       : llvm::ArrayRef<swift::Diagnostic::FixIt>()));
       else
         m_raw_diagnostics.push_back(RawDiagnostic(
             message_ref, info.Kind, bufferName, bufferID, line_col.first,
@@ -2719,7 +2719,7 @@ public:
                        : llvm::ArrayRef<swift::Diagnostic::FixIt>()));
     } else {
       m_raw_diagnostics.push_back(RawDiagnostic(
-          text.str(), info.Kind, bufferName, bufferID, line_col.first,
+          std::string(text), info.Kind, bufferName, bufferID, line_col.first,
           line_col.second, llvm::ArrayRef<swift::Diagnostic::FixIt>()));
     }
 

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -8223,9 +8223,6 @@ static void DescribeFileUnit(Stream &s, swift::FileUnit *file_unit) {
   s.PutCString("kind = ");
 
   switch (file_unit->getKind()) {
-  default: {
-    s.PutCString("<unknown>");
-  }
   case swift::FileUnitKind::Source: {
     s.PutCString("Source, ");
     if (swift::SourceFile *source_file =
@@ -8257,7 +8254,10 @@ static void DescribeFileUnit(Stream &s, swift::FileUnit *file_unit) {
     swift::LoadedFile *loaded_file = llvm::cast<swift::LoadedFile>(file_unit);
     s.Printf("filename = \"%s\"", loaded_file->getFilename().str().c_str());
   } break;
+  case swift::FileUnitKind::DWARFModule:
+    s.PutCString("DWARF");
   };
+  s.PutCString(";");
 }
 
 // Gets the full module name from the module passed in.
@@ -8295,7 +8295,7 @@ static swift::ModuleDecl *LoadOneModule(const SourceModule &module,
 
   error.Clear();
   ConstString toplevel = module.path.front();
-  llvm::SmallString<1> m_description;
+  const std::string &m_description = swift_ast_context.GetDescription();
   LOG_PRINTF(LIBLLDB_LOG_EXPRESSIONS, "Importing module %s",
              toplevel.AsCString());
   swift::ModuleDecl *swift_module = nullptr;
@@ -8325,14 +8325,11 @@ static swift::ModuleDecl *LoadOneModule(const SourceModule &module,
   }
 
   if (lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS)) {
-    LOG_PRINTF(LIBLLDB_LOG_EXPRESSIONS, "Importing %s with source files:",
-               module.path.front().AsCString());
-
-    for (swift::FileUnit *file_unit : swift_module->getFiles()) {
-      StreamString ss;
+    StreamString ss;
+    for (swift::FileUnit *file_unit : swift_module->getFiles())
       DescribeFileUnit(ss, file_unit);
-      LOG_PRINTF(LIBLLDB_LOG_EXPRESSIONS, "  %s", ss.GetData());
-    }
+    LOG_PRINTF(LIBLLDB_LOG_EXPRESSIONS, "Imported module %s from {%s}",
+               module.path.front().AsCString(), ss.GetData());
   }
   return swift_module;
 }

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -6060,7 +6060,7 @@ SwiftASTContext::GetBitSize(opaque_compiler_type_t type,
     swift::CanType swift_bound_type(::GetCanonicalSwiftType(bound_type));
     if (swift_bound_type->hasTypeParameter()) {
       LOG_PRINTF(LIBLLDB_LOG_TYPES, "GetBitSize: Can't bind type: %s",
-                 type.GetTypeName().AsCString());
+                 bound_type.GetTypeName().AsCString());
       return {};
     }
 

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -3420,7 +3420,6 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
   }
 
   // Set up the required state for the evaluator in the TypeChecker.
-  m_ast_context_ap->setLegacySemanticQueriesEnabled();
   registerIDERequestFunctions(m_ast_context_ap->evaluator);
   registerParseRequestFunctions(m_ast_context_ap->evaluator);
   registerTypeCheckerRequestFunctions(m_ast_context_ap->evaluator);

--- a/lldb/source/Utility/XcodeSDK.cpp
+++ b/lldb/source/Utility/XcodeSDK.cpp
@@ -285,3 +285,25 @@ XcodeSDK::Type XcodeSDK::GetSDKTypeForTriple(const llvm::Triple &triple) {
     return XcodeSDK::unknown;
   }
 }
+
+std::string XcodeSDK::FindXcodeContentsDirectoryInPath(llvm::StringRef path) {
+  auto begin = llvm::sys::path::begin(path);
+  auto end = llvm::sys::path::end(path);
+
+  // Iterate over the path components until we find something that ends with
+  // .app. If the next component is Contents then we've found the Contents
+  // directory.
+  for (auto it = begin; it != end; ++it) {
+    if (it->endswith(".app")) {
+      auto next = it;
+      if (++next != end && *next == "Contents") {
+        llvm::SmallString<128> buffer;
+        llvm::sys::path::append(buffer, begin, ++next,
+                                llvm::sys::path::Style::posix);
+        return buffer.str().str();
+      }
+    }
+  }
+
+  return {};
+}

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -20,7 +20,6 @@ using namespace lldb_private;
 struct PlatformDarwinTester : public PlatformDarwin {
 public:
   using PlatformDarwin::FindComponentInPath;
-  using PlatformDarwin::FindXcodeContentsDirectoryInPath;
 };
 
 TEST(PlatformDarwinTest, TestParseVersionBuildDir) {
@@ -49,44 +48,6 @@ TEST(PlatformDarwinTest, TestParseVersionBuildDir) {
 
   std::tie(V, D) = PlatformDarwin::ParseVersionBuildDir("3.4.5");
   EXPECT_EQ(llvm::VersionTuple(3, 4, 5), V);
-}
-
-TEST(PlatformDarwinTest, FindXcodeContentsDirectoryInPath) {
-  std::string standard =
-      "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/"
-      "Developer/SDKs/MacOSX.sdk";
-  EXPECT_EQ("/Applications/Xcode.app/Contents",
-            PlatformDarwinTester::FindXcodeContentsDirectoryInPath(standard));
-
-  std::string standard_version =
-      "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/"
-      "Developer/SDKs/MacOSX10.15.sdk";
-  EXPECT_EQ(
-      "/Applications/Xcode.app/Contents",
-      PlatformDarwinTester::FindXcodeContentsDirectoryInPath(standard_version));
-
-  std::string beta = "/Applications/Xcode-beta.app/Contents/Developer/"
-                     "Platforms/MacOSX.platform/"
-                     "Developer/SDKs/MacOSX10.15.sdk";
-  EXPECT_EQ("/Applications/Xcode-beta.app/Contents",
-            PlatformDarwinTester::FindXcodeContentsDirectoryInPath(beta));
-
-  std::string no_app =
-      "/Applications/Xcode/Contents/Developer/Platforms/MacOSX.platform/"
-      "Developer/SDKs/MacOSX10.15.sdk";
-  EXPECT_EQ("", PlatformDarwinTester::FindXcodeContentsDirectoryInPath(no_app));
-
-  std::string no_contents =
-      "/Applications/Xcode.app/Developer/Platforms/MacOSX.platform/"
-      "Developer/SDKs/MacOSX10.15.sdk";
-  EXPECT_EQ(
-      "", PlatformDarwinTester::FindXcodeContentsDirectoryInPath(no_contents));
-
-  std::string no_capitalization =
-      "/Applications/Xcode.app/contents/Developer/Platforms/MacOSX.platform/"
-      "Developer/SDKs/MacOSX10.15.sdk";
-  EXPECT_EQ("", PlatformDarwinTester::FindXcodeContentsDirectoryInPath(
-                    no_capitalization));
 }
 
 TEST(PlatformDarwinTest, FindComponentInPath) {

--- a/lldb/unittests/Utility/XcodeSDKTest.cpp
+++ b/lldb/unittests/Utility/XcodeSDKTest.cpp
@@ -204,3 +204,38 @@ TEST(XcodeSDKTest, GetSDKTypeForTriple) {
   EXPECT_EQ(XcodeSDK::GetSDKTypeForTriple(llvm::Triple("i386-unknown-netbsd")),
             XcodeSDK::Type::unknown);
 }
+
+TEST(XcodeSDKTest, FindXcodeContentsDirectoryInPath) {
+  std::string standard =
+      "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/"
+      "Developer/SDKs/MacOSX.sdk";
+  EXPECT_EQ("/Applications/Xcode.app/Contents",
+            XcodeSDK::FindXcodeContentsDirectoryInPath(standard));
+
+  std::string standard_version =
+      "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/"
+      "Developer/SDKs/MacOSX10.15.sdk";
+  EXPECT_EQ("/Applications/Xcode.app/Contents",
+            XcodeSDK::FindXcodeContentsDirectoryInPath(standard_version));
+
+  std::string beta = "/Applications/Xcode-beta.app/Contents/Developer/"
+                     "Platforms/MacOSX.platform/"
+                     "Developer/SDKs/MacOSX10.15.sdk";
+  EXPECT_EQ("/Applications/Xcode-beta.app/Contents",
+            XcodeSDK::FindXcodeContentsDirectoryInPath(beta));
+
+  std::string no_app =
+      "/Applications/Xcode/Contents/Developer/Platforms/MacOSX.platform/"
+      "Developer/SDKs/MacOSX10.15.sdk";
+  EXPECT_EQ("", XcodeSDK::FindXcodeContentsDirectoryInPath(no_app));
+
+  std::string no_contents =
+      "/Applications/Xcode.app/Developer/Platforms/MacOSX.platform/"
+      "Developer/SDKs/MacOSX10.15.sdk";
+  EXPECT_EQ("", XcodeSDK::FindXcodeContentsDirectoryInPath(no_contents));
+
+  std::string no_capitalization =
+      "/Applications/Xcode.app/contents/Developer/Platforms/MacOSX.platform/"
+      "Developer/SDKs/MacOSX10.15.sdk";
+  EXPECT_EQ("", XcodeSDK::FindXcodeContentsDirectoryInPath(no_capitalization));
+}


### PR DESCRIPTION
Cherry-pick a boatload of commits that touched SwiftASTContext that were present on swift/release/5.3 but missing on swift/master-next.