### PR TITLE
[ObjC] Fix AST serialization for pseudo-strong parameters

### DIFF
--- a/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -1095,8 +1095,6 @@ void ASTDeclWriter::VisitParmVarDecl(ParmVarDecl *D) {
     Record.AddStmt(D->getUninstantiatedDefaultArg());
   Code = serialization::DECL_PARM_VAR;
 
-  assert(!D->isARCPseudoStrong()); // can be true of ImplicitParamDecl
-
   // If the assumptions about the DECL_PARM_VAR abbrev are true, use it.  Here
   // we dynamically check for the properties that we optimize for, but don't
   // know are true of all PARM_VAR_DECLs.
@@ -2096,7 +2094,7 @@ void ASTWriter::WriteDeclAbbrevs() {
   Abv->Add(BitCodeAbbrevOp(0));                       // SClass
   Abv->Add(BitCodeAbbrevOp(0));                       // TSCSpec
   Abv->Add(BitCodeAbbrevOp(0));                       // InitStyle
-  Abv->Add(BitCodeAbbrevOp(0));                       // ARCPseudoStrong
+  Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // isARCPseudoStrong
   Abv->Add(BitCodeAbbrevOp(0));                       // Linkage
   Abv->Add(BitCodeAbbrevOp(0));                       // HasInit
   Abv->Add(BitCodeAbbrevOp(0));                   // HasMemberSpecializationInfo

--- a/clang/test/PCH/externally-retained.m
+++ b/clang/test/PCH/externally-retained.m
@@ -1,0 +1,30 @@
+// Test for assertion failure due to objc_externally_retained on a function.
+
+// Without PCH
+// RUN: %clang_cc1 -fsyntax-only -verify -fobjc-arc -include %s %s
+
+// With PCH
+// RUN: %clang_cc1 %s -emit-pch -fobjc-arc -o %t
+// RUN: %clang_cc1 -emit-llvm-only -verify %s -fobjc-arc -include-pch %t -debug-info-kind=limited
+
+// expected-no-diagnostics
+
+#ifndef HEADER
+#define HEADER
+//===----------------------------------------------------------------------===//
+// Header
+
+__attribute__((objc_externally_retained)) void doSomething(id someObject);
+
+id sharedObject = 0;
+
+//===----------------------------------------------------------------------===//
+#else
+//===----------------------------------------------------------------------===//
+
+void callDoSomething() {
+  doSomething(sharedObject);
+}
+
+//===----------------------------------------------------------------------===//
+#endif


### PR DESCRIPTION
This bit was assumed to be always false for ParmVarDecls, but attribute
objc_externally_retained now can produce it.

Differential revision: https://reviews.llvm.org/D74417