### PR TITLE
Set CXXRecordDecl's copy assignment flags when the record is a C++ union that has address-discriminated ptrauth fields

### DIFF
--- a/clang/lib/AST/DeclCXX.cpp
+++ b/clang/lib/AST/DeclCXX.cpp
@@ -1057,9 +1057,11 @@ void CXXRecordDecl::addedMember(Decl *D) {
         if (isUnion()) {
           data().DefaultedCopyConstructorIsDeleted = true;
           data().DefaultedMoveConstructorIsDeleted = true;
+          data().DefaultedCopyAssignmentIsDeleted = true;
           data().DefaultedMoveAssignmentIsDeleted = true;
           data().NeedOverloadResolutionForCopyConstructor = true;
           data().NeedOverloadResolutionForMoveConstructor = true;
+          data().NeedOverloadResolutionForCopyAssignment = true;
           data().NeedOverloadResolutionForMoveAssignment = true;
         }
       }

--- a/clang/test/SemaCXX/ptrauth-qualifier.cpp
+++ b/clang/test/SemaCXX/ptrauth-qualifier.cpp
@@ -55,7 +55,7 @@ namespace test_union {
 
   struct S1 {
     union {
-      union { // expected-note 2 {{'S1' is implicitly deleted because variant field '' has a non-trivial}} expected-note 2 {{'S1' is implicitly deleted because field '' has a deleted}}
+      union { // expected-note 4 {{'S1' is implicitly deleted because field '' has a deleted}}
         int * AQ f0;
         char f1;
       };


### PR DESCRIPTION
This fixes an assertion failure caused by the following commit:

commit 825e3bb58082eafa8db87a9034379b88f892ce9d
Author: Richard Smith <richard@metafoo.co.uk>
Date:   Thu Jun 4 19:16:05 2020 -0700

PR46209: properly determine whether a copy assignment operator is
trivial.

The commit also caused changes in the diagnostic message emitted in
ptrauth-qualifier.cpp, so fix the check strings too.

rdar://problem/64194621