### PR TITLE
debugserver: Enable -DLLDB_ENERGY when compiling against an internal SDK 

### DIFF
--- a/lldb/tools/debugserver/source/CMakeLists.txt
+++ b/lldb/tools/debugserver/source/CMakeLists.txt
@@ -129,6 +129,14 @@ if(LLDB_USE_ENTITLEMENTS)
   endif()
 endif()
 
+if($ENV{SDKROOT} MATCHES ".Internal.sdk$")
+  message(STATUS "LLDB debugserver energy support is enabled")
+  add_definitions(-DLLDB_ENERGY)
+  set(ENERGY_LIBRARY -lpmenergy -lpmsample)
+else()
+  message(STATUS "LLDB debugserver energy support is disabled")
+endif()
+
 set(generated_mach_interfaces
   ${CMAKE_CURRENT_BINARY_DIR}/mach_exc.h
   ${CMAKE_CURRENT_BINARY_DIR}/mach_excServer.c
@@ -208,7 +216,8 @@ target_link_libraries(lldbDebugserverCommon
                       lldbDebugserverDarwin_DarwinLog
                       ${FOUNDATION_LIBRARY}
                       ${SECURITY_LIBRARY}
-                      ${LIBCOMPRESSION})
+                      ${LIBCOMPRESSION}
+                      ${ENERGY_LIBRARY})
 if(HAVE_LIBCOMPRESSION)
   set_property(TARGET lldbDebugserverCommon APPEND PROPERTY
                 COMPILE_DEFINITIONS HAVE_LIBCOMPRESSION)


### PR DESCRIPTION
This brings over functionality from the xcodeproject that went missing during the CMake transition.

rdar://problem/63840635

Differential Revision: https://reviews.llvm.org/D81300

(cherry picked from commit 661fcfcd8afa4fbf4284a1ea8c0fc948dcc8fcac)