### PR TITLE
[clang] Use IsVolatile=true and RequiresNullTerminator=false for PCMs

### DIFF
--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -179,12 +179,15 @@ ModuleManager::addModule(StringRef FileName, ModuleKind Type,
     if (FileName == "-") {
       Buf = llvm::MemoryBuffer::getSTDIN();
     } else {
-      // Get a buffer of the file and close the file descriptor when done. Use
-      // IsVolatile=true since PCMs with same signature can have different sizes
-      // due to different content in the unhashed control block (e.g. diagnostic
-      // options). Tha said, concurrent creation & access of the same PCM
-      // filename can lead to reading past the buffer size otherwise.
-      Buf = FileMgr.getBufferForFile(NewModule->File, /*IsVolatile=*/true);
+      // Get a buffer of the file and close the file descriptor when done.
+      // The file is volatile because in a parallel build we expect multiple
+      // compiler processes to use the same module file rebuilding it if needed.
+      //
+      // RequiresNullTerminator is false because module files don't need it, and
+      // this allows the file to still be mmapped.
+      Buf = FileMgr.getBufferForFile(NewModule->File,
+                                     /*IsVolatile=*/true,
+                                     /*RequiresNullTerminator=*/false);
     }
 
     if (!Buf) {


### PR DESCRIPTION
This change got missed while upstreaming
https://reviews.llvm.org/D77772. This is the part of that change that
actually passes the correct arguments when opening a PCM.

The test didn't catch this because it starts at the
`MemoryBuffer::getOpenFile` level. It's not really possible to test
`ModuleManager::addModule` itself to verify how the file was opened.

(cherry picked from commit 1727c6aab34012f0cefc8a3f29ede5f1f718c832)

rdar://59908962