### PR TITLE
Fix swift master-next

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -576,8 +576,7 @@ void SwiftREPL::CompleteCode(const std::string &current_code,
                                             importInfo);
       llvm::Optional<unsigned> bufferID;
       swift::SourceFile *repl_source_file = new (*ast)
-          swift::SourceFile(*repl_module, swift::SourceFileKind::Main, bufferID,
-                            /*Keep tokens*/false);
+          swift::SourceFile(*repl_module, swift::SourceFileKind::Main, bufferID);
       repl_module->addFile(*repl_source_file);
       swift::performImportResolution(*repl_source_file);
       m_completion_module_initialized = true;


### PR DESCRIPTION
The option flags are now represented as a set according to https://github.com/apple/swift/blob/master/include/swift/AST/SourceFile.h#L325

Rely on the default empty flag set as a result.