### PR TITLE
Revert "[ORC] Always use ObjectLinkingLayer/JITLink for MachO on x86-…

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
@@ -52,7 +52,9 @@ Error LLJITBuilderState::prepareForConstruction() {
 
   // If the client didn't configure any linker options then auto-configure the
   // JIT linker.
-  if (!CreateObjectLinkingLayer) {
+  if (!CreateObjectLinkingLayer && JTMB->getCodeModel() == None &&
+      JTMB->getRelocationModel() == None) {
+
     auto &TT = JTMB->getTargetTriple();
     if (TT.isOSBinFormatMachO() &&
         (TT.getArch() == Triple::aarch64 || TT.getArch() == Triple::x86_64)) {


### PR DESCRIPTION
…64 and arm64."

This reverts commit 03a1fc722e64247adddabb040107275fb91f797b.

The switch to ObjectLinkingLayer/JITLink led to failures in a few tests on the builders. Reverting while I investigate.