### PR TITLE
Remove obsolete manual test runner logic. (NFC)

### DIFF
--- a/lldb/test/API/lang/swift/address_of/TestSwiftAddressOf.py
+++ b/lldb/test/API/lang/swift/address_of/TestSwiftAddressOf.py
@@ -93,10 +93,3 @@ class TestSwiftAddressOf(lldbtest.TestBase):
         # the inout type appears as direct.
         self.check_variable("in_struct", False, 12345)
         
-        
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/any/TestSwiftAnyType.py
+++ b/lldb/test/API/lang/swift/any/TestSwiftAnyType.py
@@ -40,9 +40,3 @@ class TestSwiftAnyType(lldbtest.TestBase):
 
         self.expect("expression -d run -- q", substrs=['12'])
         self.expect("frame variable -d run -- q", substrs=['12'])
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/any_object/TestSwiftAnyObjectType.py
+++ b/lldb/test/API/lang/swift/any_object/TestSwiftAnyObjectType.py
@@ -55,9 +55,3 @@ class TestSwiftAnyObjectType(TestBase):
             use_dynamic=False,
             value='12',
             typename="Swift.Int")
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/archetype_resolution/TestSwiftArchetypeResolution.py
+++ b/lldb/test/API/lang/swift/archetype_resolution/TestSwiftArchetypeResolution.py
@@ -120,9 +120,3 @@ class TestSwiftArchetypeResolution(TestBase):
         self.assertTrue(var_x.GetValue() == 'A', "GE case fails")
         if self.TraceOn():
             self.runCmd("frame variable -d run")
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
+++ b/lldb/test/API/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
@@ -51,9 +51,3 @@ class TestSwiftArchetypeResolution(TestBase):
                             (i, var.GetError().GetCString()))
             value = child.GetValueAsUnsigned()
             self.assertEqual(value, i, "Wrong value: %d not %d."%(value, i))
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/backwards_compatibility/simple/TestSwiftBackwardsCompatibilitySimple.py
+++ b/lldb/test/API/lang/swift/backwards_compatibility/simple/TestSwiftBackwardsCompatibilitySimple.py
@@ -45,8 +45,3 @@ class TestSwiftBackwardsCompatibilitySimple(lldbtest.TestBase):
         # FIXME: This doesn't work.
         #self.expect("fr v generic", substrs=['-1'])
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
+++ b/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
@@ -55,9 +55,3 @@ class SwiftPartialBreakTest(TestBase):
         self.runCmd("continue", RUN_SUCCEEDED)
 
         self.expect("frame select 0", substrs=['Accumulator', 'incr'])
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/bt_printing/TestSwiftBacktracePrinting.py
+++ b/lldb/test/API/lang/swift/bt_printing/TestSwiftBacktracePrinting.py
@@ -58,8 +58,3 @@ class TestSwiftBacktracePrinting(TestBase):
                                    'arg1=12', 'arg2="Hello world"'])
         self.expect("breakpoint set -p other", substrs=['g<U, T>'])
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/clangimporter/bridging_header_headermap/TestSwiftBridgingHeaderHeadermap.py
+++ b/lldb/test/API/lang/swift/clangimporter/bridging_header_headermap/TestSwiftBridgingHeaderHeadermap.py
@@ -55,9 +55,3 @@ class TestSwiftBridgingHeaderHeadermap(TestBase):
                     substrs=['(dylib.C<a.Wrapper>.Something)', "hello"])
         self.assertTrue(os.path.isdir(mod_cache), "module cache exists")
         
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -81,9 +81,3 @@ class TestSwiftDedupMacros(TestBase):
         self.assertTrue(space == 1)
         self.assertTrue(space_with_space == 0)
         self.assertTrue(ndebug == 1)
-        
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
@@ -65,10 +65,3 @@ class TestSwiftHeadermapConflict(TestBase):
         self.assertTrue((not value.GetError().Success()) or
                          not value.GetSummary())
         self.runCmd("settings set symbols.use-swift-dwarfimporter true")
-      
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
@@ -64,10 +64,3 @@ class TestSwiftIncludeConflict(TestBase):
         self.assertTrue((not value.GetError().Success()) or
                          not value.GetSummary())
         self.runCmd("settings set symbols.use-swift-dwarfimporter true")
-        
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
@@ -93,9 +93,3 @@ class TestSwiftMacroConflict(TestBase):
         self.expect("v foo", substrs=["42"])
         self.assertTrue(os.path.isdir(mod_cache), "module cache exists")
         lldb.SBDebugger.MemoryPressureDetected()
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
@@ -71,9 +71,3 @@ class TestSwiftObjCMainConflictingDylibs(TestBase):
         self.expect("p baz", "correct baz", substrs=["i_am_from_Foo"])
         self.expect("fr var baz", "correct baz", substrs=["i_am_from_Foo"])
         
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
@@ -60,9 +60,3 @@ class TestSwiftObjCMainConflictingDylibsBridgingHeader(TestBase):
         self.expect("p foo", "expected result", substrs=["23"])
         self.expect("p $R6", "expected result", substrs=["23"])
         self.expect("p $R8", "expected result", substrs=["23"])
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
@@ -76,8 +76,3 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
         self.expect("p $R6", "expected result", substrs=["23"])
         self.expect("p $R8", "expected result", substrs=["23"])
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
@@ -50,9 +50,3 @@ class TestSwiftRemoteASTImport(TestBase):
                     substrs=['(Library.LibraryProtocol) $R0'])
         self.expect("expr -d run-target -- input",
                     substrs=['(a.FromMainModule) $R2'])
-        
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -130,9 +130,3 @@ class TestSwiftRewriteClangPaths(TestBase):
             self.assertEqual(found_ovl, 2)
         else:
             self.assertTrue(errs > 0, "expected module import error")
-        
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
+++ b/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
@@ -16,7 +16,6 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 import os
 import unittest2
-import shutil
 
 class TestSwiftStaticArchiveTwoSwiftmodules(TestBase):
 
@@ -56,9 +55,3 @@ class TestSwiftStaticArchiveTwoSwiftmodules(TestBase):
         process.Continue()
         self.expect("fr var bar", "expected result", substrs=["42"])
         self.expect("p bar", "expected result", substrs=["j", "42"])
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
+++ b/lldb/test/API/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
@@ -63,8 +63,3 @@ class TestSwiftConditionalBreakpoint(TestBase):
 
         self.check_x_and_y(threads[0].frames[0], '3', '1')
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/cross_module_extension/TestSwiftCrossModuleExtension.py
+++ b/lldb/test/API/lang/swift/cross_module_extension/TestSwiftCrossModuleExtension.py
@@ -60,8 +60,3 @@ class TestSwiftCrossModuleExtension(TestBase):
         lldbutil.check_variable(self, var, False, typename="moda.S.A")
         lldbutil.check_variable(self, child_v, False, value="3")
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/different_clang_flags/TestSwiftDifferentClangFlags.py
+++ b/lldb/test/API/lang/swift/different_clang_flags/TestSwiftDifferentClangFlags.py
@@ -83,8 +83,3 @@ class TestSwiftDifferentClangFlags(TestBase):
         var = self.frame().EvaluateExpression("fA()")
         lldbutil.check_variable(self, var, False, value="2")
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/dwarfimporter/BridgingPCH/TestSwiftDWARFImporterBridgingPCH.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/BridgingPCH/TestSwiftDWARFImporterBridgingPCH.py
@@ -63,9 +63,3 @@ class TestSwiftDWARFImporterBridgingHeader(lldbtest.TestBase):
         process.Clear()
         target.Clear()
         lldb.SBDebugger.MemoryPressureDetected()
-       
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/dynamic_value/TestSwiftDynamicValue.py
+++ b/lldb/test/API/lang/swift/dynamic_value/TestSwiftDynamicValue.py
@@ -79,9 +79,3 @@ class SwiftDynamicValueTest(TestBase):
                 ".Base = {",
                 "v = 449493530",
                 "q = 3735928559"])
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/expression/access_control/TestExpressionAccessControl.py
+++ b/lldb/test/API/lang/swift/expression/access_control/TestExpressionAccessControl.py
@@ -49,8 +49,3 @@ class TestSwiftExpressionAccessControl(TestBase):
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
         self.check_expression("foo.m_a", "3", use_summary=False)
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/expression/classes/fromobjc/TestSwiftExpressionsInMethodsFromObjc.py
+++ b/lldb/test/API/lang/swift/expression/classes/fromobjc/TestSwiftExpressionsInMethodsFromObjc.py
@@ -54,8 +54,3 @@ class TestExpressionsInSwiftMethodsFromObjC(TestBase):
         self.check_expression("m_ivar", "10", use_summary=False)
         self.check_expression("self.m_ivar == 11", "false")
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
+++ b/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
@@ -50,8 +50,3 @@ class TestExpressionsInSwiftMethodsPureSwift(TestBase):
         self.check_expression("m_ivar", "10", use_summary=False)
         self.check_expression("self.m_ivar == 11", "false")
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/expression/equality_operators/TestEqualityOperators.py
+++ b/lldb/test/API/lang/swift/expression/equality_operators/TestEqualityOperators.py
@@ -126,8 +126,3 @@ class TestUnitTests(TestBase):
             value.GetSummary() == "false",
             "1 == 2 didn't return false.")
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/expression/errors/TestExpressionErrors.py
+++ b/lldb/test/API/lang/swift/expression/errors/TestExpressionErrors.py
@@ -130,8 +130,3 @@ class TestExpressionErrors(TestBase):
             "Expected 'Over 100', got %s" %
             (message.GetSummary()))
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
+++ b/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
@@ -100,8 +100,3 @@ class TestExclusivitySuppression(TestBase):
         self.assertTrue(answer == expected_result, report_str)
 
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
+++ b/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
@@ -133,8 +133,3 @@ class TestSwiftGenericExpressions(lldbtest.TestBase):
 
             self.runCmd("continue")
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/expression/no_calculator/TestSwiftNoProcess.py
+++ b/lldb/test/API/lang/swift/expression/no_calculator/TestSwiftNoProcess.py
@@ -60,8 +60,3 @@ class TestSwiftNoProcess(TestBase):
                         "Swift expressions with no process should fail.")
 
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
+++ b/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
@@ -65,8 +65,3 @@ class TestDefiningOverloadedFunctions(TestBase):
         self.check_expression('$overload(10)', '1', False)
         self.check_expression('$overload("some string")', '2', False)
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/expression/protocol_extension/TestExprInProtocolExtension.py
+++ b/lldb/test/API/lang/swift/expression/protocol_extension/TestExprInProtocolExtension.py
@@ -149,8 +149,3 @@ class TestSwiftExprInProtocolExtension(TestBase):
         self.check_expression("local_var", "222", False)
 
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/expression/scopes/TestExpressionScopes.py
+++ b/lldb/test/API/lang/swift/expression/scopes/TestExpressionScopes.py
@@ -174,8 +174,3 @@ class TestSwiftExpressionScopes(TestBase):
         self.check_expression("a", "\"foo\"", use_summary=True)
         self.check_expression("self.b", "5", use_summary=False)
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/expression/simple/TestSimpleExpressions.py
+++ b/lldb/test/API/lang/swift/expression/simple/TestSimpleExpressions.py
@@ -182,8 +182,3 @@ class TestSimpleSwiftExpressions(TestBase):
         self.check_expression(
             "var enum_six : SomeValues = SomeValues.Six; return enum_six == .Six", "true")
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
+++ b/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
@@ -78,8 +78,3 @@ class TestSwiftExpressionsInClassFunctions(TestBase):
               self.check_expression("self", "a.H<Int>")
             self.runCmd("continue")
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/expression/submodule_import/TestSubmoduleImport.py
+++ b/lldb/test/API/lang/swift/expression/submodule_import/TestSubmoduleImport.py
@@ -61,8 +61,3 @@ class TestSwiftSubmoduleImport(TestBase):
             "The import was not successful: %s" %
             (value.GetError().GetCString()))
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lambda: lldb.SBDebugger.Terminate())
-    unittest2.main()

--- a/lldb/test/API/lang/swift/file_private/TestFilePrivate.py
+++ b/lldb/test/API/lang/swift/file_private/TestFilePrivate.py
@@ -93,8 +93,3 @@ class TestFilePrivate(TestBase):
         self.check_expression("privateVariable as Int", "3", False)
         self.check_expression("privateVariable as String", "\"five\"")
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lambda: lldb.SBDebugger.Terminate())
-    unittest2.main()

--- a/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
+++ b/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
@@ -88,9 +88,3 @@ class TestSwiftFixIts(TestBase):
         self.assertTrue(tmp_value.GetError().Success())
         self.assertTrue(tmp_value.GetSummary() == 'true')
 
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/generics/TestSwiftGenericsResolution.py
+++ b/lldb/test/API/lang/swift/generics/TestSwiftGenericsResolution.py
@@ -84,10 +84,3 @@ class SwiftDynamicTypeGenericsTest(TestBase):
             substrs=[
                 "(a.Outer<Int>.Inner) self ="
             ])
-
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/get_value/TestSwiftGetValueAsUnsigned.py
+++ b/lldb/test/API/lang/swift/get_value/TestSwiftGetValueAsUnsigned.py
@@ -63,9 +63,3 @@ class SwiftGetValueAsUnsignedAPITest(TestBase):
             classValue != 0,
             "Class types are aggregates with pointer values")
 
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/hide_runtimesupport/TestSwiftHideRuntimeSupport.py
+++ b/lldb/test/API/lang/swift/hide_runtimesupport/TestSwiftHideRuntimeSupport.py
@@ -89,10 +89,3 @@ class TestSwiftHideRuntimeSupport(TestBase):
             'frame variable -d run',
             substrs=['_0_0'],
             matching=False)
-
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
+++ b/lldb/test/API/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
@@ -46,9 +46,3 @@ class TestSwiftCGImportedTypes(TestBase):
             x_native.IsValid(),
             "Got valid native from cgrect.origin.x")
         self.assertTrue(x_native.GetValue() == "10", "Value of x is correct")
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/instance_pointer_set_sp/TestSwiftInstancePointerSetSP.py
+++ b/lldb/test/API/lang/swift/instance_pointer_set_sp/TestSwiftInstancePointerSetSP.py
@@ -73,8 +73,3 @@ class TestSwiftInstancePointerSetSP(lldbtest.TestBase):
                 '{...}'],
             matching=True)
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/let_int/TestSwiftLetInt.py
+++ b/lldb/test/API/lang/swift/let_int/TestSwiftLetInt.py
@@ -49,8 +49,3 @@ class TestSwiftLetIntSupport(TestBase):
         self.assertTrue(local_vars.GetFirstValueByName("y").IsValid())
         self.assertTrue(not local_vars.GetFirstValueByName("z").IsValid())
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
+++ b/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
@@ -47,9 +47,3 @@ class TestSwiftMetatype(TestBase):
         lldbutil.check_variable(self, var_f, False, "(Int) -> Int")
         lldbutil.check_variable(self, var_t, False, "(Int, Int, String)")
         lldbutil.check_variable(self, var_p, False, "a.P")
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/mix_any_object/TestSwiftMixAnyObjectType.py
+++ b/lldb/test/API/lang/swift/mix_any_object/TestSwiftMixAnyObjectType.py
@@ -76,9 +76,3 @@ class TestSwiftMixAnyObjectType(TestBase):
                 'text = "Instance of MyClass"',
                 'key = "Two"',
                 'text = "Instance Two"'])
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
+++ b/lldb/test/API/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
@@ -56,9 +56,3 @@ class TestSwiftModuleSearchPaths(TestBase):
         self.match(
             "e plusTen(10)", "error: Couldn't lookup symbols:", error=True)
 
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/multilang_category/TestMultilangFormatterCategories.py
+++ b/lldb/test/API/lang/swift/multilang_category/TestMultilangFormatterCategories.py
@@ -54,9 +54,3 @@ class TestMultilangFormatterCategories(TestBase):
             use_dynamic=True,
             typename="Swift.Optional<Foundation.NSURL>",
             summary='"http://www.google.com"')
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lambda: lldb.SBDebugger.Terminate())
-    unittest2.main()

--- a/lldb/test/API/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
+++ b/lldb/test/API/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
@@ -39,9 +39,3 @@ class TestSwiftMultipayloadEnum(TestBase):
 
         self.expect("expression one", substrs=['One', '1234'])
         self.expect("expression two", substrs=['TheOther', '"some value"'])
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/nested_arrays/TestSwiftNestedArray.py
+++ b/lldb/test/API/lang/swift/nested_arrays/TestSwiftNestedArray.py
@@ -61,8 +61,3 @@ class TestSwiftNestedArray(TestBase):
             var_aCChild = var_aC.GetChildAtIndex(i)
             lldbutil.check_children(self, var_aCChild, check_for_C)
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/nserror/TestNSError.py
+++ b/lldb/test/API/lang/swift/nserror/TestNSError.py
@@ -61,9 +61,3 @@ class SwiftNSErrorTest(TestBase):
                     'value = 0',
                     'value = 3',
                     'value = 4'])
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/objc_inherited_ivars/TestSwiftAtObjCIvars.py
+++ b/lldb/test/API/lang/swift/objc_inherited_ivars/TestSwiftAtObjCIvars.py
@@ -48,9 +48,3 @@ class TestSwiftAtObjCIvars(TestBase):
 
         self.check_foo(foo_objc)
         self.check_foo(foo_swift)
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
+++ b/lldb/test/API/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
@@ -63,9 +63,3 @@ class TestSwiftOneCaseEnum(TestBase):
         lldbutil.check_variable(self, maybeEvent, use_dynamic=False, use_synthetic=True, value="Goofus")
         lldbutil.check_variable(self, event, use_dynamic=False, use_synthetic=True, value="Goofus")
 
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
@@ -194,9 +194,3 @@ def is_old(file):
     """Checks the modified time of the given file matches the timestamp set my make_old"""
     return os.stat(file).st_mtime == OLD_TIMESTAMP
 
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
@@ -134,9 +134,3 @@ def is_old(file):
     """Checks the modified time of the given file matches the timestamp set my make_old"""
     return os.stat(file).st_mtime == OLD_TIMESTAMP
 
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/path_with_colons/TestSwiftPathWithColons.py
+++ b/lldb/test/API/lang/swift/path_with_colons/TestSwiftPathWithColons.py
@@ -84,8 +84,3 @@ include $(LEVEL)/Makefile.rules
 
         self.expect('run', substrs=['return x + y - z'])
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/playgrounds-repl/old_playground/TestNonREPLPlayground.py
+++ b/lldb/test/API/lang/swift/playgrounds-repl/old_playground/TestNonREPLPlayground.py
@@ -75,9 +75,3 @@ class TestNonREPLPlayground(TestBase):
         self.assertTrue("a=\\'3\\'" in playground_output)
         self.assertTrue("b=\\'5\\'" in playground_output)
         self.assertTrue("=\\'8\\'" in playground_output)
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/playgrounds/TestPlaygrounds.py
+++ b/lldb/test/API/lang/swift/playgrounds/TestPlaygrounds.py
@@ -115,9 +115,3 @@ class TestSwiftPlaygrounds(TestBase):
         self.assertTrue("=\\'8\\'" in playground_output)
         self.assertTrue("=\\'11\\'" in playground_output)
 
-       
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
+++ b/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
@@ -114,9 +114,3 @@ class TestSwiftTypeLookup(TestBase):
                 '/// ',
                 'func print'],
             matching=True)
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/private_decl_name/TestSwiftPrivateDeclName.py
+++ b/lldb/test/API/lang/swift/private_decl_name/TestSwiftPrivateDeclName.py
@@ -80,8 +80,3 @@ class TestSwiftPrivateDeclName(TestBase):
         lldbutil.check_variable(self, child_b, False, '"goodbye"')
         lldbutil.check_variable(self, child_c, False, value='1.25')
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/private_typealias/TestSwiftPrivateTypeAlias.py
+++ b/lldb/test/API/lang/swift/private_typealias/TestSwiftPrivateTypeAlias.py
@@ -62,8 +62,3 @@ class TestSwiftPrivateTypeAlias(TestBase):
         lldbutil.check_variable(self, child_0, False, '"hello"')
         lldbutil.check_variable(self, child_1, False, value='234')
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/ranges/TestSwiftRangeTypes.py
+++ b/lldb/test/API/lang/swift/ranges/TestSwiftRangeTypes.py
@@ -40,9 +40,3 @@ class TestSwiftRangeType(TestBase):
                     '(ClosedRange<Int>) c = 1...100'])
         self.expect("frame variable d", substrs=[
                     '(Range<Int>) d = 1..<100'])
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
+++ b/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
@@ -82,9 +82,3 @@ class TestSwiftReferenceStorageTypes(TestBase):
         sub_004_type.GetTypeClass()
         sub_005_type.GetTypeClass()
         sub_006_type.GetTypeClass()
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/resilience/TestResilience.py
+++ b/lldb/test/API/lang/swift/resilience/TestResilience.py
@@ -168,9 +168,3 @@ class TestResilience(TestBase):
         process.Kill()
 
         self.cleanupSymlinks()
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/return/TestSwiftReturns.py
+++ b/lldb/test/API/lang/swift/return/TestSwiftReturns.py
@@ -213,9 +213,3 @@ class TestSwiftReturns(TestBase):
         self.thread.StepOut()
         return_value = self.thread.GetStopReturnValue()
         self.assertTrue(not return_value.IsValid())
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/split_debug/TestSwiftSplitDebug.py
+++ b/lldb/test/API/lang/swift/split_debug/TestSwiftSplitDebug.py
@@ -49,8 +49,3 @@ class TestSwiftSplitDebug(lldbtest.TestBase):
         self.check_val("c.c_x", "12345")
         self.check_val("c.c_y", "6789")
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
+++ b/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
@@ -349,9 +349,3 @@ class TestSwiftStepping(lldbtest.TestBase):
         self.dbg.HandleCommand(
             "settings clear target.process.thread.step-avoid-libraries")
         super(TestSwiftStepping, self).tearDown()
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
+++ b/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
@@ -87,8 +87,3 @@ class TestSwiftStructChangeRerun(TestBase):
         self.assertTrue(var_a_c.IsValid(), "make sure a.c does exist")
         lldbutil.check_variable(self, var_a_c, False, value='12.125')
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/struct_init_display/TestSwiftStructInit.py
+++ b/lldb/test/API/lang/swift/struct_init_display/TestSwiftStructInit.py
@@ -43,9 +43,3 @@ class TestSwiftStructInit(TestBase):
 
         var_b = theself.GetChildMemberWithName("b")
         lldbutil.check_variable(self, var_b, False, '"Hey"')
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/swift_version/TestSwiftVersion.py
+++ b/lldb/test/API/lang/swift/swift_version/TestSwiftVersion.py
@@ -77,8 +77,3 @@ class TestSwiftVersion(TestBase):
           self.assertTrue(t['substr'] in str(val.GetValue()), "Expression " + t['expr'] + " result " + val.GetValue() + " has substring " + t['substr'])
           process.Continue()
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/swiftieformatting/TestSwiftieFormatting.py
+++ b/lldb/test/API/lang/swift/swiftieformatting/TestSwiftieFormatting.py
@@ -113,9 +113,3 @@ class TestSwiftieFormatting(TestBase):
                 ("Int%d(1)" % IntWidth),
                 ("Int%d(2)" % IntWidth),
                 ("Int%d(3)" % IntWidth)])
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
+++ b/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
@@ -38,9 +38,3 @@ class TestSwiftTuple(TestBase):
 
         self.expect("expression s.tup.0", substrs=['123'])
         self.expect("expression s.tup.1()", substrs=['321'])
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/type_metadata/TestSwiftTypeMetadata.py
+++ b/lldb/test/API/lang/swift/type_metadata/TestSwiftTypeMetadata.py
@@ -86,9 +86,3 @@ class SwiftTypeMetadataTest(TestBase):
             "frame variable -d run -- x",
             substrs=['(a.AnotherDerivedClass) x'])  # second stop on bat
         self.runCmd("continue", RUN_SUCCEEDED)
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/unknown_reference/TestSwiftUnknownReference.py
+++ b/lldb/test/API/lang/swift/unknown_reference/TestSwiftUnknownReference.py
@@ -46,9 +46,3 @@ class TestSwiftUnknownReference(lldbtest.TestBase):
         m_objc_ref = var_self.GetChildMemberWithName("objc_ref")
         self.check_class(m_objc_ref)
 
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
+++ b/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
@@ -61,8 +61,3 @@ class TestSwiftUnknownSelf(lldbtest.TestBase):
         self.assertTrue(thread.GetStopReason() != lldb.eStopReasonBreakpoint)
 
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/array/TestSwiftArrayType.py
+++ b/lldb/test/API/lang/swift/variables/array/TestSwiftArrayType.py
@@ -122,8 +122,3 @@ class TestSwiftArrayType(lldbtest.TestBase):
                 "[1] = 2",
                 "[2] = 3",
                 "[3] = 4"])
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/bool/TestSwiftBool.py
+++ b/lldb/test/API/lang/swift/variables/bool/TestSwiftBool.py
@@ -77,8 +77,3 @@ class TestSwiftBool(TestBase):
             self.assertTrue(summary == "false", "%s should be false, was: %s"%(name, summary))
 
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/bridged_array/TestSwiftBridgedArray.py
+++ b/lldb/test/API/lang/swift/variables/bridged_array/TestSwiftBridgedArray.py
@@ -70,8 +70,3 @@ class TestSwiftBridgedArray(TestBase):
             "expression -d run -- swarr",
             substrs=['Int(123456)', 'Int32(234567)', 'UInt16(45678)', 'Double(1.250000)', 'Float(2.500000)'])
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
@@ -52,8 +52,3 @@ class TestSwiftBridgedStringVariables(TestBase):
         lldbutil.check_variable(self, s5, use_dynamic=True, summary='"abc"')
         lldbutil.check_variable(self, s6, summary='"abc"')
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
+++ b/lldb/test/API/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
@@ -47,8 +47,3 @@ class TestBulkyEnumVariables(TestBase):
                 'b = (a = 100, b = 200)',
                 'a = (a = 300, b = 400)'])
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/cgtypes/TestCGTypes.py
+++ b/lldb/test/API/lang/swift/variables/cgtypes/TestCGTypes.py
@@ -62,8 +62,3 @@ class TestSwiftCoreGraphicsTypes(TestBase):
                 'height : 0.0'])
 
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/class/TestSwiftClassTypes.py
+++ b/lldb/test/API/lang/swift/variables/class/TestSwiftClassTypes.py
@@ -68,8 +68,3 @@ class TestSwiftClassTypes(TestBase):
                              '(Int) x = 12',
                              '(Float) y = 2.25'])
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/class/TestSwiftMetadataSymbols.py
+++ b/lldb/test/API/lang/swift/variables/class/TestSwiftMetadataSymbols.py
@@ -49,8 +49,3 @@ class TestSwiftMetadataSymbols(TestBase):
                     patterns=['Metadata.*type metadata for'])
 
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lambda: lldb.SBDebugger.Terminate())
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
+++ b/lldb/test/API/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
@@ -60,8 +60,3 @@ class TestDictionaryNSObjectAnyObject(TestBase):
                 'key = "hello"',
                 'value = 123'])
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
+++ b/lldb/test/API/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
@@ -121,8 +121,3 @@ class TestSwiftStdlibDictionary(TestBase):
             value_summary='"43"',
             fail_on_missing=False)
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/enums/TestEnumVariables.py
+++ b/lldb/test/API/lang/swift/variables/enums/TestEnumVariables.py
@@ -112,8 +112,3 @@ class TestEnumVariables(TestBase):
                     substrs=['Some', 'one1 = A', 'one2 = A'])
         self.expect('frame variable ContainerOfEnums_Nil', substrs=['nil'])
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/func/TestFunctionVariables.py
+++ b/lldb/test/API/lang/swift/variables/func/TestFunctionVariables.py
@@ -79,8 +79,3 @@ class TestFunctionVariables(TestBase):
         # function
         self.assertEqual('a.bar() -> ()', func_ptr_function.name)
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/generic_enums/TestSwiftGenericEnums.py
+++ b/lldb/test/API/lang/swift/variables/generic_enums/TestSwiftGenericEnums.py
@@ -110,8 +110,3 @@ class TestSwiftGenericEnumTypes(TestBase):
             summary='"Now with Content"',
             typename='String?')
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/generic_tuple_labels/TestSwiftGenericTupleLabels.py
+++ b/lldb/test/API/lang/swift/variables/generic_tuple_labels/TestSwiftGenericTupleLabels.py
@@ -54,8 +54,3 @@ class TestSwiftGenericTupleLabels(lldbtest.TestBase):
         self.expect('frame variable -d run -- x.w', substrs=['72'])
         self.expect('expression -d run -- x.z', substrs=['36'])
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/generics/TestSwiftGenericTypes.py
+++ b/lldb/test/API/lang/swift/variables/generics/TestSwiftGenericTypes.py
@@ -84,9 +84,3 @@ class TestSwiftGenericTypes(TestBase):
             substrs=[
                 '(String?) o_some = "Hello"',
                 '(String?) o_none = nil'])
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/globals/TestSwiftGlobals.py
+++ b/lldb/test/API/lang/swift/variables/globals/TestSwiftGlobals.py
@@ -149,8 +149,3 @@ class TestSwiftGlobals(TestBase):
             value == 20,
             "my_large_dude value is the uninitialized one.")
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
+++ b/lldb/test/API/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
@@ -191,8 +191,3 @@ class TestIndirectEnumVariables(TestBase):
                 0],
             child_value='12')
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/inout/TestInOutVariables.py
+++ b/lldb/test/API/lang/swift/variables/inout/TestInOutVariables.py
@@ -214,8 +214,3 @@ class TestInOutVariables(TestBase):
         func_sc = target.ResolveSymbolContextForAddress(target.ResolveLoadAddress(func_value.GetValueAsUnsigned()), lldb.eSymbolContextFunction)
         self.assertTrue(func_sc.GetFunction().IsValid(), "We couldn't look up the function target.") 
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/objc/TestObjCImportedTypes.py
+++ b/lldb/test/API/lang/swift/variables/objc/TestObjCImportedTypes.py
@@ -76,8 +76,3 @@ class TestSwiftObjCImportedTypes(TestBase):
             use_dynamic=True,
             summary='1 key/value pair')
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
+++ b/lldb/test/API/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
@@ -73,8 +73,3 @@ class TestSwiftObjCOptionalType(TestBase):
             use_dynamic=False,
             num_children=0)
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
+++ b/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
@@ -103,8 +103,3 @@ class TestSwiftOptionalType(TestBase):
             use_dynamic=False,
             num_children=1)
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
+++ b/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
@@ -117,8 +117,3 @@ class TestSwiftProtocolTypes(TestBase):
         self.expect("expression --dynamic-type run-target -- loc3dSuper",
                     substrs=['Point3D) $R', 'x = 1.25', 'y = 2.5', 'z = 1.25'])
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/set/TestSwiftStdlibSet.py
+++ b/lldb/test/API/lang/swift/variables/set/TestSwiftStdlibSet.py
@@ -43,8 +43,3 @@ class TestSwiftStdlibSet(TestBase):
                 ' = 4'])
 
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/static_string/TestSwiftStaticStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/static_string/TestSwiftStaticStringVariables.py
@@ -76,8 +76,3 @@ class TestSwiftStaticStringVariables(TestBase):
             IContainZerosUnicode,
             summary='"HFIHЗIHF\\0VЭHVHЗ90HGЭ"')
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/string/TestSwiftStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/string/TestSwiftStringVariables.py
@@ -83,8 +83,3 @@ class TestSwiftStringVariables(TestBase):
             'expression -l objc++ -- (char*)"Hello\b\b\b\b\bGoodbye"',
             substrs=['"Hello\\b\\b\\b\\b\\bGoodbye"'])
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
+++ b/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
@@ -206,8 +206,3 @@ class TestSwiftTypes(TestBase):
             'frame variable uint64_max',
             substrs=['18446744073709551615'])
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/tuples/TestSwiftTupleTypes.py
+++ b/lldb/test/API/lang/swift/variables/tuples/TestSwiftTupleTypes.py
@@ -88,8 +88,3 @@ class TestSwiftTupleTypes(TestBase):
                              'FPIEEE32)', 'value = 4.5',
                              'FPIEEE32)', 'value = 8.75'])
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/lldb/test/API/lang/swift/variables/value_of_optionals/TestSwiftValueOfOptionals.py
+++ b/lldb/test/API/lang/swift/variables/value_of_optionals/TestSwiftValueOfOptionals.py
@@ -43,8 +43,3 @@ class TestSwiftValueOfOptionalType(TestBase):
         self.assertTrue(s.GetValueAsUnsigned(0) == 0, "reading value fails")
         self.assertTrue(s.GetValueAsUnsigned(1) == 1, "reading value fails")
 
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()


### PR DESCRIPTION
This doesn't work any more and has been superceded by lldb-dotest -p "TestName".