### PR TITLE
[testing] Cherry-pick part of c90d38e4b9bb84a53b65ce1c136e04df77bfd094

### DIFF
--- a/clang/test/CodeGen/ptrauth-function-init-fail.c
+++ b/clang/test/CodeGen/ptrauth-function-init-fail.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple arm64e-apple-ios -fptrauth-calls %s -verify -emit-llvm
+// RUN: %clang_cc1 -triple arm64e-apple-ios -fptrauth-calls %s -verify -emit-llvm -S -o -
 
 void f(void);
 


### PR DESCRIPTION
Otherwise building with read-only source does not work.