### PR TITLE
Upstream two performance monitor collectors to MachTask

### DIFF
--- a/lldb/tools/debugserver/source/MacOSX/MachTask.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachTask.mm
@@ -64,6 +64,10 @@ extern "C" {
 #include <pmsample.h>
 #endif
 
+extern "C" int
+proc_get_cpumon_params(pid_t pid, int *percentage,
+                       int *interval); // <libproc_internal.h> SPI
+
 //----------------------------------------------------------------------
 // MachTask constructor
 //----------------------------------------------------------------------
@@ -469,6 +473,16 @@ std::string MachTask::GetProfileData(DNBProfileDataScanType scanType) {
       }
     }
 #endif
+
+    if (scanType & eProfileEnergyCPUCap) {
+      int percentage = -1;
+      int interval = -1;
+      int result = proc_get_cpumon_params(pid, &percentage, &interval);
+      if ((result == 0) && (percentage >= 0) && (interval >= 0)) {
+        profile_data_stream << "cpu_cap_p:" << percentage << ';';
+        profile_data_stream << "cpu_cap_t:" << interval << ';';
+      }
+    }
 
     profile_data_stream << "--end--;";
 


### PR DESCRIPTION
Upstream two performance monitor collectors to MachTask
Add two more perf monitors to MachTask::GetProfileData.

<rdar://problem/63984105>

(cherry picked from commit 480a383551e96d9f6fb0ddcdcc9d893faf37e5b3)