### PR TITLE
Add linker private global support to jit

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/MachOLinkGraphBuilder.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/MachOLinkGraphBuilder.cpp
@@ -64,12 +64,14 @@ Linkage MachOLinkGraphBuilder::getLinkage(uint16_t Desc) {
 }
 
 Scope MachOLinkGraphBuilder::getScope(StringRef Name, uint8_t Type) {
-  if (Name.startswith("l"))
-    return Scope::Local;
   if (Type & MachO::N_PEXT)
     return Scope::Hidden;
-  if (Type & MachO::N_EXT)
-    return Scope::Default;
+  if (Type & MachO::N_EXT) {
+    if (Name.startswith("l"))
+      return Scope::Hidden;
+    else
+      return Scope::Default;
+  }
   return Scope::Local;
 }
 

--- a/llvm/lib/ExecutionEngine/JITLink/MachO_arm64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/MachO_arm64.cpp
@@ -582,7 +582,8 @@ private:
       *(ulittle32_t *)FixupPtr = Value;
       break;
     }
-    case Pointer64: {
+    case Pointer64:
+    case Pointer64Anon: {
       uint64_t Value = E.getTarget().getAddress() + E.getAddend();
       *(ulittle64_t *)FixupPtr = Value;
       break;

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/JITSymbol.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/JITSymbol.cpp
@@ -14,6 +14,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/GlobalAlias.h"
 #include "llvm/IR/GlobalValue.h"
+#include "llvm/IR/Module.h"
 #include "llvm/Object/ObjectFile.h"
 
 using namespace llvm;

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/JITSymbol.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/JITSymbol.cpp
@@ -19,6 +19,8 @@
 using namespace llvm;
 
 JITSymbolFlags llvm::JITSymbolFlags::fromGlobalValue(const GlobalValue &GV) {
+  assert(GV.hasName() && "Can't get flags for anonymous symbol");
+
   JITSymbolFlags Flags = JITSymbolFlags::None;
   if (GV.hasWeakLinkage() || GV.hasLinkOnceLinkage())
     Flags |= JITSymbolFlags::Weak;
@@ -32,6 +34,16 @@ JITSymbolFlags llvm::JITSymbolFlags::fromGlobalValue(const GlobalValue &GV) {
   else if (isa<GlobalAlias>(GV) &&
            isa<Function>(cast<GlobalAlias>(GV).getAliasee()))
     Flags |= JITSymbolFlags::Callable;
+
+  // Check for a linker-private-global-prefix on the symbol name, in which
+  // case it must be marked as non-exported.
+  if (auto *M = GV.getParent()) {
+    const auto &DL = M->getDataLayout();
+    StringRef LPGP = DL.getLinkerPrivateGlobalPrefix();
+    if (!LPGP.empty() && GV.getName().front() == '\01' &&
+        GV.getName().substr(1).startswith(LPGP))
+      Flags &= ~JITSymbolFlags::Exported;
+  }
 
   return Flags;
 }

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/LLVMBuild.txt
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/LLVMBuild.txt
@@ -18,4 +18,4 @@
 type = Library
 name = RuntimeDyld
 parent = ExecutionEngine
-required_libraries = MC Object Support
+required_libraries = Core MC Object Support

--- a/llvm/test/ExecutionEngine/JITLink/X86/Inputs/MachO_global_linker_private_def.s
+++ b/llvm/test/ExecutionEngine/JITLink/X86/Inputs/MachO_global_linker_private_def.s
@@ -1,0 +1,12 @@
+# Supplies a global definition, l_foo, with a linker-private prefix. Since this
+# definition is marked as global it should be resolvable outside the object.
+
+	.section	__TEXT,__text,regular,pure_instructions
+	.macosx_version_min 10, 14
+        .globl          l_foo
+	.p2align	4, 0x90
+l_foo:
+	xorl	%eax, %eax
+	retq
+
+.subsections_via_symbols

--- a/llvm/test/ExecutionEngine/JITLink/X86/Inputs/MachO_internal_linker_private_def.s
+++ b/llvm/test/ExecutionEngine/JITLink/X86/Inputs/MachO_internal_linker_private_def.s
@@ -1,0 +1,12 @@
+# Supplies an internal definition, l_foo, with a linker-private prefix. Since
+# this definition is not marked as global it should not be resolvable outside
+# the object.
+
+	.section	__TEXT,__text,regular,pure_instructions
+	.macosx_version_min 10, 14
+	.p2align	4, 0x90
+l_foo:
+	xorl	%eax, %eax
+	retq
+
+.subsections_via_symbols

--- a/llvm/test/ExecutionEngine/JITLink/X86/MachO_linker_private_symbols.s
+++ b/llvm/test/ExecutionEngine/JITLink/X86/MachO_linker_private_symbols.s
@@ -1,0 +1,22 @@
+# RUN: rm -rf %t && mkdir -p %t
+# RUN: llvm-mc -triple=x86_64-apple-macosx10.9 -filetype=obj \
+# RUN:   -o %t/global_lp_def.o %S/Inputs/MachO_global_linker_private_def.s
+# RUN: llvm-mc -triple=x86_64-apple-macosx10.9 -filetype=obj \
+# RUN:   -o %t/internal_lp_def.o %S/Inputs/MachO_internal_linker_private_def.s
+# RUN: llvm-mc -triple=x86_64-apple-macosx10.9 -filetype=obj \
+# RUN:   -o %t/macho_lp_test.o %s
+# RUN: llvm-jitlink -noexec %t/global_lp_def.o %t/macho_lp_test.o
+# RUN: not llvm-jitlink -noexec %t/internal_lp_def.o %t/macho_lp_test.o
+#
+# Check that we can resolve global symbols whose names start with the
+# linker-private prefix 'l' across object boundaries, and that we can't resolve
+# internals with the linker-private prefix across object boundaries.
+
+	.section	__TEXT,__text,regular,pure_instructions
+	.macosx_version_min 10, 14
+	.globl	_main
+	.p2align	4, 0x90
+_main:
+	jmp	l_foo
+
+.subsections_via_symbols

--- a/llvm/test/ExecutionEngine/OrcLazy/private_linkage.ll
+++ b/llvm/test/ExecutionEngine/OrcLazy/private_linkage.ll
@@ -1,12 +1,18 @@
 ; RUN: lli -jit-kind=orc-lazy %s
 
-define private void @_ZL3foov() {
+define private void @foo() {
+entry:
+  ret void
+}
+
+define void @"\01l_bar"() {
 entry:
   ret void
 }
 
 define i32 @main(i32 %argc, i8** nocapture readnone %argv) {
 entry:
-  tail call void @_ZL3foov()
+  call void @foo()
+  call void @"\01l_bar"()
   ret i32 0
 }


### PR DESCRIPTION
This teaches the JIT to recognize that MachO global symbols starting with 'l' are linker-private.

Support for linker-private globals is required before we can switch back to JITLink as the default JIT linker on Darwin (see rdar://64227444).

rdar://64415149