### PR TITLE
[lldb/formatter] Add Swift.Unsafe[Mutable][Raw]Pointer data formatter

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -318,7 +318,7 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
 
   AddCXXSummary(
       swift_category_sp,
-      lldb_private::formatters::swift::UnsafeBufferPointerSummaryProvider,
+      lldb_private::formatters::swift::UnsafeTypeSummaryProvider,
       "Swift.Unsafe[Mutable][Raw][Buffer]Pointer",
       ConstString("^Swift.Unsafe(Mutable)?(Raw)?(Buffer)?Pointer(<.+>)?$"),
       summary_flags, true);
@@ -382,8 +382,7 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
 
   AddCXXSynthetic(
       swift_category_sp,
-      lldb_private::formatters::swift::
-          UnsafeBufferPointerSyntheticFrontEndCreator,
+      lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEndCreator,
       "Swift.Unsafe[Mutable][Raw][Buffer]Pointer",
       ConstString("^Swift.Unsafe(Mutable)?(Raw)?(Buffer)?Pointer(<.+>)?$"),
       synth_flags, true);

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -259,16 +259,6 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       swift_category_sp,
       lldb_private::formatters::swift::SwiftBasicTypeSyntheticFrontEndCreator,
       "Swift.UWord", ConstString("Swift.UWord"), basic_synth_flags);
-  AddCXXSynthetic(
-      swift_category_sp,
-      lldb_private::formatters::swift::SwiftBasicTypeSyntheticFrontEndCreator,
-      "Swift.UnsafePointer", ConstString("^Swift.UnsafePointer<.+>$"),
-      basic_synth_flags, true);
-  AddCXXSynthetic(
-      swift_category_sp,
-      lldb_private::formatters::swift::SwiftBasicTypeSyntheticFrontEndCreator,
-      "Swift.UnsafeMutablePointer",
-      ConstString("^Swift.UnsafeMutablePointer<.+>$"), basic_synth_flags, true);
 
   AddFormat(swift_category_sp, lldb::eFormatPointer,
             ConstString("Swift.OpaquePointer"), format_flags, false);
@@ -329,8 +319,8 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   AddCXXSummary(
       swift_category_sp,
       lldb_private::formatters::swift::UnsafeBufferPointerSummaryProvider,
-      "Swift.Unsafe[Mutable][Raw]BufferPointer",
-      ConstString("^Swift.Unsafe(Mutable)?(Raw)?BufferPointer(<.+>)?$"),
+      "Swift.Unsafe[Mutable][Raw][Buffer]Pointer",
+      ConstString("^Swift.Unsafe(Mutable)?(Raw)?(Buffer)?Pointer(<.+>)?$"),
       summary_flags, true);
 
   DictionaryConfig::Get()
@@ -394,8 +384,8 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       swift_category_sp,
       lldb_private::formatters::swift::
           UnsafeBufferPointerSyntheticFrontEndCreator,
-      "Swift.Unsafe[Mutable][Raw]BufferPointer",
-      ConstString("^Swift.Unsafe(Mutable)?(Raw)?BufferPointer(<.+>)?$"),
+      "Swift.Unsafe[Mutable][Raw][Buffer]Pointer",
+      ConstString("^Swift.Unsafe(Mutable)?(Raw)?(Buffer)?Pointer(<.+>)?$"),
       synth_flags, true);
 
   DictionaryConfig::Get()

--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
@@ -461,7 +461,7 @@ std::unique_ptr<SwiftUnsafeType> SwiftUnsafeType::Create(ValueObject &valobj) {
 
 } // namespace
 
-bool lldb_private::formatters::swift::UnsafeBufferPointerSummaryProvider(
+bool lldb_private::formatters::swift::UnsafeTypeSummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
   std::unique_ptr<SwiftUnsafeType> unsafe_ptr = SwiftUnsafeType::Create(valobj);
 
@@ -487,9 +487,9 @@ bool lldb_private::formatters::swift::UnsafeBufferPointerSummaryProvider(
 namespace lldb_private {
 namespace formatters {
 namespace swift {
-class UnsafeBufferPointerSyntheticFrontEnd : public SyntheticChildrenFrontEnd {
+class UnsafeTypeSyntheticFrontEnd : public SyntheticChildrenFrontEnd {
 public:
-  UnsafeBufferPointerSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp);
+  UnsafeTypeSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp);
 
   virtual size_t CalculateNumChildren();
 
@@ -501,7 +501,7 @@ public:
 
   virtual size_t GetIndexOfChildWithName(ConstString name);
 
-  virtual ~UnsafeBufferPointerSyntheticFrontEnd() = default;
+  virtual ~UnsafeTypeSyntheticFrontEnd() = default;
 
 private:
   ExecutionContextRef m_exe_ctx_ref;
@@ -517,8 +517,8 @@ private:
 } // namespace formatters
 } // namespace lldb_private
 
-lldb_private::formatters::swift::UnsafeBufferPointerSyntheticFrontEnd::
-    UnsafeBufferPointerSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp)
+lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::
+    UnsafeTypeSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp)
     : SyntheticChildrenFrontEnd(*valobj_sp.get()) {
 
   ProcessSP process_sp = valobj_sp->GetProcessSP();
@@ -537,13 +537,14 @@ lldb_private::formatters::swift::UnsafeBufferPointerSyntheticFrontEnd::
     Update();
 }
 
-size_t lldb_private::formatters::swift::UnsafeBufferPointerSyntheticFrontEnd::
+size_t lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::
     CalculateNumChildren() {
   return m_unsafe_ptr->GetCount();
 }
 
-lldb::ValueObjectSP lldb_private::formatters::swift::
-    UnsafeBufferPointerSyntheticFrontEnd::GetChildAtIndex(size_t idx) {
+lldb::ValueObjectSP
+lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::GetChildAtIndex(
+    size_t idx) {
   const size_t num_children = CalculateNumChildren();
 
   if (idx >= num_children || idx >= m_children.size())
@@ -552,8 +553,7 @@ lldb::ValueObjectSP lldb_private::formatters::swift::
   return m_children[idx];
 }
 
-bool lldb_private::formatters::swift::UnsafeBufferPointerSyntheticFrontEnd::
-    Update() {
+bool lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::Update() {
   m_children.clear();
   ValueObjectSP valobj_sp = m_backend.GetSP();
   if (!valobj_sp)
@@ -602,20 +602,20 @@ bool lldb_private::formatters::swift::UnsafeBufferPointerSyntheticFrontEnd::
   return m_children.size() == num_children;
 }
 
-bool lldb_private::formatters::swift::UnsafeBufferPointerSyntheticFrontEnd::
+bool lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::
     MightHaveChildren() {
   return m_unsafe_ptr->GetCount();
 }
 
-size_t lldb_private::formatters::swift::UnsafeBufferPointerSyntheticFrontEnd::
+size_t lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   return UINT32_MAX;
 }
 
 SyntheticChildrenFrontEnd *
-lldb_private::formatters::swift::UnsafeBufferPointerSyntheticFrontEndCreator(
+lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEndCreator(
     CXXSyntheticChildren *, lldb::ValueObjectSP valobj_sp) {
   if (!valobj_sp)
     return nullptr;
-  return (new UnsafeBufferPointerSyntheticFrontEnd(valobj_sp));
+  return (new UnsafeTypeSyntheticFrontEnd(valobj_sp));
 }

--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.h
@@ -20,12 +20,11 @@ namespace lldb_private {
 namespace formatters {
 namespace swift {
 
-bool UnsafeBufferPointerSummaryProvider(ValueObject &valobj, Stream &stream,
-                                        const TypeSummaryOptions &);
+bool UnsafeTypeSummaryProvider(ValueObject &valobj, Stream &stream,
+                               const TypeSummaryOptions &);
 
 SyntheticChildrenFrontEnd *
-UnsafeBufferPointerSyntheticFrontEndCreator(CXXSyntheticChildren *,
-                                            lldb::ValueObjectSP);
+UnsafeTypeSyntheticFrontEndCreator(CXXSyntheticChildren *, lldb::ValueObjectSP);
 
 }; // namespace swift
 }; // namespace formatters

--- a/lldb/test/API/functionalities/data-formatter/swift-unsafe/main.swift
+++ b/lldb/test/API/functionalities/data-formatter/swift-unsafe/main.swift
@@ -69,7 +69,28 @@ func main() {
     //%            ])
   }
 
-  let colors = [ColorCode.RGB(155,219,255), ColorCode.Hex(0x4545ff)]
+  var colors = [ColorCode.RGB(155,219,255), ColorCode.Hex(0x4545ff)]
+
+  let unsafe_ptr = UnsafePointer(&colors[0])
+  //% self.expect("frame variable -d run-target unsafe_ptr",
+  //%            patterns=[
+  //%            '\(UnsafePointer<(.*)\.ColorCode>\) unsafe_ptr = 0[xX][0-9a-fA-F]+ {',
+  //%            '\[0\] = RGB {',
+  //%            'RGB = \(0 = 155, 1 = 219, 2 = 255\)'
+  //%            ])
+
+  var unsafe_mutable_ptr = UnsafeMutablePointer(&colors[1])
+  //% self.expect("frame variable -d run-target unsafe_mutable_ptr",
+  //%            patterns=[
+  //%            '\(UnsafeMutablePointer<(.*)\.ColorCode>\) unsafe_mutable_ptr = 0[xX][0-9a-fA-F]+ {',
+  //%            '\[0\] = Hex \(Hex = 4539903\)'
+  //%            ])
+
+  let unsafe_raw_ptr = UnsafeRawPointer(&colors[0])
+  //% self.expect("frame variable -d run-target unsafe_raw_ptr",
+  //%            patterns=[
+  //%            '\(UnsafeRawPointer\) unsafe_raw_ptr = 0[xX][0-9a-fA-F]+'
+  //%            ])
 
   colors.withUnsafeBufferPointer {
     let buf = $0


### PR DESCRIPTION
[lldb/formatter] Add Swift.Unsafe[Mutable][Raw]Pointer data formatter

This patch adds support for Swift's Unsafe[Mutable]Pointer and
UnsafeRaw[Mutable]Pointer data formatting.

Since the 2 types have a similar layout, this patch makes use of the
SwiftUnsafeType factory to create a single helper class for the 2 types.

This commit also removes the old basic summary provider to these 2 types.

rdar://54462095

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>