### PR TITLE
Fix a typo that prevents non-host SDKs from being detected.

### DIFF
--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -2489,7 +2489,7 @@ void SwiftASTContext::InitializeSearchPathOptions(
       XcodeSDK::Info info;
       info.type = XcodeSDK::GetSDKTypeForTriple(triple);
       XcodeSDK sdk(info);
-      StringRef sdk_path = HostInfo::GetXcodeSDKPath(sdk);
+      sdk_path = HostInfo::GetXcodeSDKPath(sdk);
     }
     if (sdk_path.empty()) {
       // This fallback is questionable. Perhaps it should be removed.


### PR DESCRIPTION
Unfortunately the test for this requires simulator infrastructure
support that has not yet landed.

<rdar://problem/58477904>

(cherry picked from commit 4d9bda3f65a3d5daf3782e7c7d1ae3dc36ffd7d9)