### PR TITLE
Re-apply "[ORC] Always use ObjectLinkingLayer/JITLink for MachO on x8…

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
@@ -52,9 +52,7 @@ Error LLJITBuilderState::prepareForConstruction() {
 
   // If the client didn't configure any linker options then auto-configure the
   // JIT linker.
-  if (!CreateObjectLinkingLayer && JTMB->getCodeModel() == None &&
-      JTMB->getRelocationModel() == None) {
-
+  if (!CreateObjectLinkingLayer) {
     auto &TT = JTMB->getTargetTriple();
     if (TT.isOSBinFormatMachO() &&
         (TT.getArch() == Triple::aarch64 || TT.getArch() == Triple::x86_64)) {


### PR DESCRIPTION
…6-64..."

This re-applies 03a1fc722e6, which was temporarily reverted in 1f510b4eb40 as
it broke some swift regression tests. The test failures were traced to a
lack of support for linker private globals (rdar://64227444) which
should be addressed by PR1348.

rdar://64415149