### PR TITLE
Fix a nullptr deref in GetCanonicalSwiftType.

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -587,6 +587,11 @@ public:
 
   ~SwiftASTContext();
 
+#ifndef NDEBUG
+  /// Provided only for unit tests.
+  SwiftASTContext();
+#endif
+
   const std::string &GetDescription() const;
 
   // PluginInterface functions

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -895,6 +895,12 @@ static std::string GetClangModulesCacheProperty() {
   return std::string(path);
 }
 
+#ifndef NDEBUG
+SwiftASTContext::SwiftASTContext() : m_typeref_typesystem(this) {
+  llvm::dbgs() << "Initialized mock SwiftASTContext\n";
+}
+#endif
+
 SwiftASTContext::SwiftASTContext(std::string description, llvm::Triple triple,
                                  Target *target)
     : TypeSystemSwift(), m_typeref_typesystem(this),

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -44,12 +44,13 @@ swift::Type GetSwiftType(CompilerType type) {
 }
 
 swift::CanType GetCanonicalSwiftType(CompilerType type) {
+  swift::Type swift_type = nullptr;
   auto *ts = type.GetTypeSystem();
   if (auto *tr = llvm::dyn_cast_or_null<TypeSystemSwiftTypeRef>(ts))
-    return tr->GetSwiftType(type)->getCanonicalType();
+    swift_type = tr->GetSwiftType(type);
   if (auto *ast = llvm::dyn_cast_or_null<SwiftASTContext>(ts))
-    return ast->GetSwiftType(type)->getCanonicalType();
-  return swift::CanType();
+    swift_type = ast->GetSwiftType(type);
+  return swift_type ? swift_type->getCanonicalType() : swift::CanType();
 }
 
 static lldb::addr_t

--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -61,6 +61,8 @@ struct TestSwiftASTContext : public testing::Test {
 };
 
 struct SwiftASTContextTester : public SwiftASTContext {
+  SwiftASTContextTester() : SwiftASTContext() {}
+
   static std::string GetResourceDir(llvm::StringRef platform_sdk_path,
                                     std::string swift_dir,
                                     std::string swift_stdlib_os_dir,
@@ -186,4 +188,15 @@ TEST_F(TestSwiftASTContext, ResourceDir) {
   // Local builds.
   swift_dir = path::parent_path(abs_paths[9]);
   EXPECT_EQ(GetResourceDir("x86_64-apple-macosx", macosx_sdk), swift_dir);
+}
+
+TEST_F(TestSwiftASTContext, IsNonTriviallyManagedReferenceType) {
+#ifndef NDEBUG
+  // The mock constructor is only available in asserts mode.
+  SwiftASTContext::NonTriviallyManagedReferenceStrategy strategy;
+  SwiftASTContext context;
+  CompilerType t(&context, nullptr);
+  EXPECT_FALSE(SwiftASTContext::IsNonTriviallyManagedReferenceType(t, strategy,
+                                                                   nullptr));
+#endif
 }


### PR DESCRIPTION
<rdar://problem/64347693>

(cherry picked from commit 5fa7d8e179225801f681229b695a7bc5db0f974f)