### PR TITLE
lldb: Add test for generic struct with bound enum fields

### DIFF
--- a/lldb/test/API/lang/swift/generic_struct_with_optional/Makefile
+++ b/lldb/test/API/lang/swift/generic_struct_with_optional/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/generic_struct_with_optional/TestGenericStructWithOptional.py
+++ b/lldb/test/API/lang/swift/generic_struct_with_optional/TestGenericStructWithOptional.py
@@ -1,0 +1,5 @@
+import lldbsuite.test.lldbinline as lldbinline
+from lldbsuite.test.decorators import *
+
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,
+    skipUnlessDarwin])

--- a/lldb/test/API/lang/swift/generic_struct_with_optional/main.swift
+++ b/lldb/test/API/lang/swift/generic_struct_with_optional/main.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum CustomError {
+  case err1
+}
+
+struct StructWithGenericContents<A, B> {
+  var field1 : A
+  var field2 : B
+}
+
+let EmptyData = Foundation.Data()
+
+let OptionalEmptyData = Swift.Optional<Foundation.Data>.some(EmptyData)
+
+let StructWithGenericEnumContents = StructWithGenericContents(field1: OptionalEmptyData, field2: CustomError.err1)
+
+func onError(_ handler: (StructWithGenericContents<Foundation.Data?, CustomError>) -> Void) {
+  handler(StructWithGenericEnumContents)
+}
+
+onError({e in
+  print(e) //% self.expect("expr -O -- e", substrs=["StructWithGenericContents<Optional<Data>, CustomError>"])
+  print(e) //% self.expect("frame var -d run-target -- e", substrs=["field1 = 0 bytes", "field2 = err1"])
+}) 


### PR DESCRIPTION
This exercises remote mirrors support for reflecting info about the same
type of structure which lldb failed to inspect in rdar://58650732.