### PR TITLE
Remove the transitional -toolchain-stdlib-rpath option from Makefile.…

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -726,7 +726,7 @@ VPATHSOURCES=$(patsubst %,$(VPATH)/%,$(SWIFT_SOURCES))
 ifeq "$(OS)" "Darwin"
 $(EXE): $(MODULENAME).swiftmodule $(OBJECTS)
 	@echo "### Linking" $(EXE)
-	$(SWIFTC) -toolchain-stdlib-rpath $(LD_EXTRAS) \
+	$(SWIFTC) $(LD_EXTRAS) \
 	  $(patsubst $<,-Xlinker -add_ast_path -Xlinker $(BUILDDIR)/$<,$^) \
 	  $(patsubst -g,,$(SWIFTFLAGS)) -o "$(EXE)"
 ifneq "$(CODESIGN)" ""
@@ -822,7 +822,6 @@ ifeq "$(USESWIFTDRIVER)" "1"
 #----------------------------------------------------------------------
 ifeq "$(OS)" "Darwin"
 DYLIB_SWIFT_FLAGS=  \
-	 -toolchain-stdlib-rpath \
 	 -Xlinker -dylib \
 	 -Xlinker -add_ast_path -Xlinker $(DYLIB_NAME).swiftmodule \
 	 -Xlinker -install_name -Xlinker @executable_path/$(shell basename $@) \
@@ -833,11 +832,11 @@ endif
 $(DYLIB_FILENAME) : $(DYLIB_OBJECTS)
 	@echo "### Linking dynamic library $(DYLIB_NAME)"
 ifneq "$(EXCLUDE_WRAPPED_SWIFTMODULE)" ""
-	$(SWIFTC) $(patsubst -g,,$(SWIFTFLAGS)) -toolchain-stdlib-rpath \
+	$(SWIFTC) $(patsubst -g,,$(SWIFTFLAGS)) \
             -emit-library $(DYLIB_SWIFT_FLAGS) -o $@ \
             $(patsubst %.swiftmodule.o,,$^)
 else
-	$(SWIFTC) $(patsubst -g,,$(SWIFTFLAGS)) -toolchain-stdlib-rpath \
+	$(SWIFTC) $(patsubst -g,,$(SWIFTFLAGS)) \
             -emit-library $(DYLIB_SWIFT_FLAGS) -o $@ $^
 endif
 ifneq "$(CODESIGN)" ""

--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -34,6 +34,7 @@ if(LLDB_TEST_SWIFT)
   set(LLDB_SWIFT_LIBS ${SWIFT_LIBRARY_DIR}/swift CACHE STRING "Path to swift libraries")
   set(SWIFT_TEST_ARGS
     --swift-compiler ${LLDB_SWIFTC}
+    # Prefer the just-built stdlib over the system one.
     --inferior-env "DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/macosx\\\""
     --inferior-env "LD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/${CMAKE_SYSTEM_PROCESSOR}\\\""
     --inferior-env "SIMCTL_CHILD_DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/macosx\\\""

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/Makefile
@@ -12,8 +12,7 @@ ifneq "$(CODESIGN)" ""
 endif
 
 lib%.dylib: %.swift
-	$(SWIFTC) -g -Onone $^ -emit-library -module-name $(shell basename $< .swift) -emit-module -Xlinker -install_name -Xlinker @executable_path/$@ -Xcc -I$(SRCDIR) -Xcc -I$(SRCDIR)/$(shell basename $< .swift) $(SWIFTFLAGS) -emit-objc-header-path $(shell basename $< .swift).h \
-           -toolchain-stdlib-rpath
+	$(SWIFTC) -g -Onone $^ -emit-library -module-name $(shell basename $< .swift) -emit-module -Xlinker -install_name -Xlinker @executable_path/$@ -Xcc -I$(SRCDIR) -Xcc -I$(SRCDIR)/$(shell basename $< .swift) $(SWIFTFLAGS) -emit-objc-header-path $(shell basename $< .swift).h
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif

--- a/lldb/test/API/lang/swift/clangimporter/static_archive/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/static_archive/Makefile
@@ -13,8 +13,7 @@ include Makefile.rules
 a.out: main.o
 	$(SWIFTC) $(SWIFTFLAGS) $< -lFoo -lBar -L$(shell pwd) -o $@ \
 	    -Xlinker -add_ast_path -Xlinker $(shell pwd)/Foo.swiftmodule \
-	    -Xlinker -add_ast_path -Xlinker $(shell pwd)/Bar.swiftmodule \
-	    -toolchain-stdlib-rpath
+	    -Xlinker -add_ast_path -Xlinker $(shell pwd)/Bar.swiftmodule
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif

--- a/lldb/test/API/lang/swift/debug_prefix_map/Makefile
+++ b/lldb/test/API/lang/swift/debug_prefix_map/Makefile
@@ -11,7 +11,7 @@ a.out: main.swift
 	# be able to find the source files.
 	mkdir $(BUILDDIR)/srcroot
 	cp $^ $(BUILDDIR)/srcroot
-	$(SWIFTC) srcroot/main.swift -debug-prefix-map $(BUILDDIR)=. -o $@ $(SWIFTFLAGS) -toolchain-stdlib-rpath
+	$(SWIFTC) srcroot/main.swift -debug-prefix-map $(BUILDDIR)=. -o $@ $(SWIFTFLAGS)
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif

--- a/lldb/test/API/lang/swift/deployment_target/Makefile
+++ b/lldb/test/API/lang/swift/deployment_target/Makefile
@@ -5,8 +5,7 @@ include Makefile.rules
 # This test only works on macOS 10.11+.
 
 a.out: main.swift libNewerTarget.dylib
-	$(SWIFTC) -target x86_64-apple-macosx10.10 -g -Onone $^ -lNewerTarget -L$(shell pwd) -o $@ $(SWIFTFLAGS) -I$(shell pwd) -Xfrontend -disable-target-os-checking \
-         -toolchain-stdlib-rpath
+	$(SWIFTC) -target x86_64-apple-macosx10.10 -g -Onone $^ -lNewerTarget -L$(shell pwd) -o $@ $(SWIFTFLAGS) -I$(shell pwd) -Xfrontend -disable-target-os-checking
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif
@@ -18,8 +17,7 @@ ifneq "$(CODESIGN)" ""
 endif
 
 lib%.dylib: %.swift
-	$(SWIFTC) -target x86_64-apple-macosx10.11 -g -Onone $^ -emit-library -module-name $(shell basename $< .swift) -emit-module -Xlinker -install_name -Xlinker @executable_path/$@ \
-	     -toolchain-stdlib-rpath
+	$(SWIFTC) -target x86_64-apple-macosx10.11 -g -Onone $^ -emit-library -module-name $(shell basename $< .swift) -emit-module -Xlinker -install_name -Xlinker @executable_path/$@
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif

--- a/lldb/test/API/lang/swift/missing_sdk/Makefile
+++ b/lldb/test/API/lang/swift/missing_sdk/Makefile
@@ -8,7 +8,7 @@ fakesdk:
 SWIFTFLAGS := $(subst $(SDKROOT),$(shell pwd)/fakesdk,$(SWIFTFLAGS))
 
 a.out: $(SWIFT_SOURCES) fakesdk
-	$(SWIFTC) $< $(SWIFTFLAGS) -o "$(EXE)" -toolchain-stdlib-rpath
+	$(SWIFTC) $< $(SWIFTFLAGS) -o "$(EXE)"
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif

--- a/lldb/test/API/lang/swift/po/val_types/main.swift
+++ b/lldb/test/API/lang/swift/po/val_types/main.swift
@@ -35,7 +35,7 @@ func main() {
   var dm = DefaultMirror()
   var cm = CustomMirror()
   var cs = CustomSummary()
-  var patatino = "foo"
+  var patatino = "foo" //% self.expect("image list")
   print("yay I am done!") //% self.expect("po dm", substrs=['a', 'b', '12', '24'])
   //% self.expect("po cm", substrs=['c', '36'])
   //% self.expect("po cm", substrs=['12', '24'], matching=False)

--- a/lldb/test/API/lang/swift/resilience/Makefile
+++ b/lldb/test/API/lang/swift/resilience/Makefile
@@ -5,7 +5,7 @@ include Makefile.rules
 
 libmod.%.dylib: mod.%.swift
 	ln -sf $< mod.swift
-	$(SWIFTC) $(SWIFTFLAGS) -emit-module -module-name mod mod.swift -emit-library -o $@ -Xlinker -install_name -Xlinker @executable_path/libmod.$*.dylib -toolchain-stdlib-rpath -###
+	$(SWIFTC) $(SWIFTFLAGS) -emit-module -module-name mod mod.swift -emit-library -o $@ -Xlinker -install_name -Xlinker @executable_path/libmod.$*.dylib -###
 	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		DYLIB_NAME=mod \

--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -128,7 +128,6 @@ def use_support_substitutions(config):
     swift_driver_args = []
     if platform.system() in ['Darwin']:
         swift_args += ['-sdk', sdk_path]
-        swift_driver_args += ['-toolchain-stdlib-rpath']
     tools = [
         ToolSubst(
             '%target-swiftc', command=config.swiftc,

--- a/lldb/test/Shell/lit-lldb-init.in
+++ b/lldb/test/Shell/lit-lldb-init.in
@@ -1,4 +1,5 @@
 # LLDB init file for the LIT tests.
+# Prefer the just-built standard library over the system one.
 env DYLD_LIBRARY_PATH='@LLDB_SWIFT_LIBS@/macosx' LD_LIBRARY_PATH='@LLDB_SWIFT_LIBS@/@CMAKE_SYSTEM_PROCESSOR@' SIMCTL_CHILD_DYLD_LIBRARY_PATH='@LLDB_SWIFT_LIBS@/macosx'
 settings set symbols.enable-external-lookup false
 settings set plugin.process.gdb-remote.packet-timeout 60


### PR DESCRIPTION
…rules

This option was needed to support deploying an ABI-stable stdlib to a
pre-stable-ABI OS and has no observable effect on macOS versions after
10.14 outside of adding an ineffective load command to the binary.

<rdar://problem/64169273>

(cherry picked from commit ba5aa8d7d35f48efc6521e31dddb4b4087ccb78c)