### PR TITLE
Reenable ASTSignature.c test

### DIFF
--- a/clang/test/Modules/ASTSignature.c
+++ b/clang/test/Modules/ASTSignature.c
@@ -12,8 +12,6 @@
 // RUN: llvm-bcanalyzer --dump --disable-histogram %t2.pcm > %t2.dump
 // RUN: cat %t1.dump %t2.dump | FileCheck %s
 
-// UNSUPPORTED: true
-
 #include "my_header_2.h"
 
 my_int var = 42;


### PR DESCRIPTION
The test was originally not working because of differences in the `OPTIONS_BLOCK` between here and upstream. I recently changed the test upstream to make it work in both codebases.