### PR TITLE
Remove the caching from DWARFImporterDelegate::lookupValue() 

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -1312,7 +1312,7 @@ protected:
   bool m_initialized_clang_importer_options = false;
   bool m_reported_fatal_error = false;
 
-  // Whether this is a scratch or a module AST context.
+  /// Whether this is a scratch or a module AST context.
   bool m_is_scratch_context = false;
 
   Status m_fatal_errors;

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -1675,7 +1675,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
     //
     // This step is skipped for modules that don't have any Swift
     // debug info. (We assume that a module without a .swift_ast
-    // section has not debuggable Swift code). This skips looking
+    // section has no debuggable Swift code). This skips looking
     // through all the shared cache dylibs when they don't have debug
     // info.
     if (found_swift_modules) {
@@ -2882,9 +2882,6 @@ private:
 class SwiftDWARFImporterDelegate : public swift::DWARFImporterDelegate {
   SwiftASTContext &m_swift_ast_ctx;
   using ModuleAndName = std::pair<const char *, const char *>;
-  /// Caches successful lookups for the scratch context.
-  llvm::DenseMap<ModuleAndName, llvm::SmallVector<clang::QualType, 1>>
-      m_decl_cache;
   std::string m_description;
 
   /// Used to filter out types with mismatching kinds.
@@ -3094,11 +3091,12 @@ public:
         auto *swift_ast_ctx = static_cast<SwiftASTContext *>(&*ts);
         auto *dwarf_imp = static_cast<SwiftDWARFImporterDelegate *>(
             swift_ast_ctx->GetDWARFImporterDelegate());
-        if (!dwarf_imp)
+        if (!dwarf_imp || dwarf_imp == this)
           continue;
-        auto it = dwarf_imp->m_decl_cache.find(
-            {module_cs.GetCString(), name_cs.GetCString()});
-        if (it == dwarf_imp->m_decl_cache.end())
+
+        llvm::SmallVector<clang::Decl *, 2> module_results;
+        dwarf_imp->lookupValue(name, kind, inModule, module_results);
+        if (!module_results.size())
           continue;
 
         auto *from_clang_importer = swift_ast_ctx->GetClangImporter();
@@ -3106,15 +3104,19 @@ public:
           continue;
         auto &from_ctx = from_clang_importer->getClangASTContext();
         auto &to_ctx = clang_importer->getClangASTContext();
-        for (clang::QualType qual_type : it->second)
+        for (clang::Decl *decl : module_results) {
+          clang::QualType qual_type;
+          if (auto *interface = llvm::dyn_cast<clang::ObjCInterfaceDecl>(decl))
+            qual_type = {interface->getTypeForDecl(), 0};
+          if (auto *type = llvm::dyn_cast<clang::TypeDecl>(decl))
+            qual_type = {type->getTypeForDecl(), 0};
           importType(qual_type, from_ctx, to_ctx, kind, results);
+        }
+        // Cut the search short after we found the first result.
+        if (results.size())
+          break;
       }
-      LOG_PRINTF(LIBLLDB_LOG_TYPES, "%d types found in cache.", results.size());
-
-      // TODO: Otherwise, the correct thing to do is to invoke
-      //       search() on all modules. In practice, however, this is
-      //       prohibitively expensive, so we need to do something
-      //       more targeted.
+      LOG_PRINTF(LIBLLDB_LOG_TYPES, "%d types collected.", results.size());
       return;
     }
 
@@ -3141,11 +3143,6 @@ public:
 
       clang::QualType qual_type = ClangUtil::GetQualType(compiler_type);
       importType(qual_type, from_ctx, to_ctx, kind, results);
-
-      // If this is a module context, cache the result for the scratch context.
-      if (m_swift_ast_ctx.GetModule())
-        m_decl_cache[{module_cs.GetCString(), name_cs.GetCString()}].push_back(
-            qual_type);
 
       return true;
     });

--- a/lldb/test/API/lang/swift/dwarfimporter/from_dylib/Foo.h
+++ b/lldb/test/API/lang/swift/dwarfimporter/from_dylib/Foo.h
@@ -1,0 +1,4 @@
+struct FromDylib {
+  int i;
+};
+

--- a/lldb/test/API/lang/swift/dwarfimporter/from_dylib/Foo.swift
+++ b/lldb/test/API/lang/swift/dwarfimporter/from_dylib/Foo.swift
@@ -1,0 +1,9 @@
+import CFoo
+
+public struct WrappingFromDylib {
+  let s : FromDylib = FromDylib(i: 23)
+}
+
+private let anchor = WrappingFromDylib()
+
+public func foo() {}

--- a/lldb/test/API/lang/swift/dwarfimporter/from_dylib/Makefile
+++ b/lldb/test/API/lang/swift/dwarfimporter/from_dylib/Makefile
@@ -1,0 +1,10 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
+LD_EXTRAS = -L$(BUILDDIR) -lFoo
+
+all: libFoo.dylib $(EXE)
+
+include Makefile.rules
+
+libFoo.dylib: Foo.swift
+	$(MAKE) MAKE_DSYM=NO VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all

--- a/lldb/test/API/lang/swift/dwarfimporter/from_dylib/TestSwiftDWARFImporterFromDylib.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/from_dylib/TestSwiftDWARFImporterFromDylib.py
@@ -1,0 +1,21 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import os
+
+class TestSwiftDWARFImporterC(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    # This test needs a working Remote Mirrors implementation.
+    @skipIf(oslist=['linux', 'windows'])
+    def test_dwarf_importer(self):
+        self.build()
+        #os.remove(self.getBuildArtifact('Foo.swiftmodule'))
+        lldbutil.run_to_source_breakpoint(self, 'break here',
+                                          lldb.SBFileSpec('main.swift'))
+        # This type can only be imported into Swift via DWARFImporter
+        # and is not visible from the main module at all.
+        self.expect("expr -- WrappingFromDylib()", substrs=['23'])

--- a/lldb/test/API/lang/swift/dwarfimporter/from_dylib/dylib.mk
+++ b/lldb/test/API/lang/swift/dwarfimporter/from_dylib/dylib.mk
@@ -1,0 +1,6 @@
+DYLIB_ONLY := YES
+DYLIB_NAME := Foo
+DYLIB_SWIFT_SOURCES := Foo.swift
+SWIFTFLAGS_EXTRAS = -I$(SRCDIR)
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/dwarfimporter/from_dylib/main.swift
+++ b/lldb/test/API/lang/swift/dwarfimporter/from_dylib/main.swift
@@ -1,0 +1,3 @@
+import Foo
+
+foo() // break here

--- a/lldb/test/API/lang/swift/dwarfimporter/from_dylib/module.modulemap
+++ b/lldb/test/API/lang/swift/dwarfimporter/from_dylib/module.modulemap
@@ -1,0 +1,1 @@
+module CFoo { header "Foo.h" }

--- a/lldb/test/API/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
@@ -49,7 +49,7 @@ class TestSwiftDWARFImporter_Swift(lldbtest.TestBase):
                 self.assertTrue('from debug info' in line, line)
                 response += 1
             elif found == 2 and response == 1 and 'SwiftDWARFImporterDelegate' in line:
-                self.assertTrue('found in cache' in line, line)
+                self.assertTrue('types collected' in line, line)
                 response += 1
-        self.assertEqual(found, 2)
-        self.assertEqual(response, 2)
+        self.assertEqual(found, 3)
+        self.assertEqual(response, 1)

--- a/lldb/test/API/lang/swift/nsarray_code_running_formatter/TestSwiftNSArrayCodeRunningFormatter.py
+++ b/lldb/test/API/lang/swift/nsarray_code_running_formatter/TestSwiftNSArrayCodeRunningFormatter.py
@@ -13,7 +13,4 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipUnlessDarwin,
-expectedFailureAll(bugnumber="rdar://60396797",
-                   setting=('symbols.use-swift-clangimporter', 'false'))
-])
+                          decorators=[swiftTest,skipUnlessDarwin])

--- a/lldb/test/API/lang/swift/objc_runtime_ivars/TestObjCIvarDiscovery.py
+++ b/lldb/test/API/lang/swift/objc_runtime_ivars/TestObjCIvarDiscovery.py
@@ -26,8 +26,6 @@ class TestObjCIVarDiscovery(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
-    @expectedFailureAll(bugnumber="rdar://60396797",
-                        setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin
     @skipIf(debug_info=no_match("dsym"))
     def test_nodbg(self):
@@ -35,8 +33,6 @@ class TestObjCIVarDiscovery(TestBase):
         shutil.rmtree(self.getBuildArtifact("aTestFramework.framework/Versions/A/aTestFramework.dSYM"))
         self.do_test(False)
 
-    @expectedFailureAll(bugnumber="rdar://60396797",
-                        setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin
     @skipIf(debug_info=no_match("dsym"))
     def test_dbg(self):

--- a/lldb/test/API/lang/swift/swiftieformatting/TestSwiftieFormatting.py
+++ b/lldb/test/API/lang/swift/swiftieformatting/TestSwiftieFormatting.py
@@ -27,8 +27,6 @@ class TestSwiftieFormatting(TestBase):
     def setUp(self):
         TestBase.setUp(self)
 
-    @expectedFailureAll(bugnumber="rdar://60396797",
-                        setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin
     @swiftTest
     def test_swiftie_formatting(self):


### PR DESCRIPTION
and instead forward all requests from the expression context to the
individual module contexts. This allows for finding types that were
not previously loaded into a module context, such as types are first
referenced by a user expression.

<rdar://problem/64169273>