### PR TITLE
Fixup SwiftASTContext for lldb for LLVM upstream inclusiveness changes.

### DIFF
--- a/lldb/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/lldb/include/lldb/Target/SwiftLanguageRuntime.h
@@ -333,7 +333,7 @@ public:
   static bool IsSwiftClassName(const char *name);
   /// Determines wether \c variable is the "self" object.
   static bool IsSelf(Variable &variable);
-  bool IsWhitelistedRuntimeValue(ConstString name) override;
+  bool IsAllowedRuntimeValue(ConstString name) override;
 
   lldb::SyntheticChildrenSP
   GetBridgedSyntheticChildProvider(ValueObject &valobj);

--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -2489,7 +2489,7 @@ void SwiftASTContext::InitializeSearchPathOptions(
       XcodeSDK::Info info;
       info.type = XcodeSDK::GetSDKTypeForTriple(triple);
       XcodeSDK sdk(info);
-      sdk_path = HostInfo::GetXcodeSDKPath(sdk);
+      sdk_path = HostInfo::GetXcodeSDKPath(sdk).str();
     }
     if (sdk_path.empty()) {
       // This fallback is questionable. Perhaps it should be removed.

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1749,7 +1749,7 @@ SwiftLanguageRuntimeImpl::GetBitAlignment(CompilerType type) {
   return {};
 }
 
-bool SwiftLanguageRuntime::IsWhitelistedRuntimeValue(ConstString name) {
+bool SwiftLanguageRuntime::IsAllowedRuntimeValue(ConstString name) {
   return name.GetStringRef() == "self";
 }
 


### PR DESCRIPTION
Also, a fix for StringRef -> std::string conversion.