### PR TITLE
Un-XFAIL two tests fixed by recent DWARFImporter changes in 212faae.

### DIFF
--- a/lldb/test/API/lang/swift/tagged_pointer/TestSwiftTaggedPointer.py
+++ b/lldb/test/API/lang/swift/tagged_pointer/TestSwiftTaggedPointer.py
@@ -15,7 +15,4 @@ from lldbsuite.test.decorators import *
 # This test depends on NSObject, so it is not available on non-Darwin
 # platforms.
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipUnlessDarwin,
-        expectedFailureAll(bugnumber="rdar://60396797",
-                           setting=('symbols.use-swift-clangimporter', 'false'))
-])
+                          decorators=[swiftTest,skipUnlessDarwin])

--- a/lldb/test/API/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
+++ b/lldb/test/API/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
@@ -27,8 +27,6 @@ class TestDictionaryNSObjectAnyObject(TestBase):
     def setUp(self):
         TestBase.setUp(self)
 
-    @expectedFailureAll(bugnumber="rdar://60396797",
-                        setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin
     @swiftTest
     def test_dictionary_nsobject_any_object(self):


### PR DESCRIPTION
(cherry picked from commit 532d9cfebfff94403ed106a3db15f7f126840013)

 Conflicts:
	lldb/test/API/lang/swift/tagged_pointer/TestSwiftTaggedPointer.py
	lldb/test/API/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py