### PR TITLE
Strip out -Werror arguments when constructing ClangImporter.  …

### DIFF
--- a/lldb/source/Symbol/SwiftASTContext.cpp
+++ b/lldb/source/Symbol/SwiftASTContext.cpp
@@ -1464,6 +1464,8 @@ void SwiftASTContext::AddExtraClangArgs(std::vector<std::string> ExtraArgs) {
         clang_argument == "-working-directory")
       continue;
 
+    auto clear_arg = llvm::make_scope_exit([&] { clang_argument.clear(); });
+
     // Enable uniquing for -D and -U options.
     bool is_macro = (clang_argument.size() >= 2 && clang_argument[0] == '-' &&
                      (clang_argument[1] == 'D' || clang_argument[1] == 'U'));
@@ -1471,15 +1473,18 @@ void SwiftASTContext::AddExtraClangArgs(std::vector<std::string> ExtraArgs) {
 
     // Consume any -working-directory arguments.
     StringRef cwd(clang_argument);
-    if (cwd.consume_front("-working-directory"))
+    if (cwd.consume_front("-working-directory")) {
       cur_working_dir = cwd;
-    else {
-      // Otherwise add the argument to the list.
-      if (!is_macro)
-        ApplyWorkingDir(clang_argument, cur_working_dir);
-      AddClangArgument(clang_argument.str(), unique);
+      continue;
     }
-    clang_argument.clear();
+    // Drop -Werror; it would only cause trouble in the debugger.
+    if (clang_argument.startswith("-Werror")) {
+      continue;
+    }
+    // Otherwise add the argument to the list.
+    if (!is_macro)
+      ApplyWorkingDir(clang_argument, cur_working_dir);
+    AddClangArgument(clang_argument.str(), unique);
   }
 }
 

--- a/lldb/test/API/lang/swift/clangimporter/Werror/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/Makefile
@@ -7,10 +7,8 @@ all: libDylib.dylib a.out
 include Makefile.rules
 
 libDylib.dylib: dylib.swift
-	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
-		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
-		BASENAME=$(shell basename $< .swift) \
-		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
+	$(MAKE) BASENAME=$(shell basename $< .swift) \
+		-f $(SRCDIR)/dylib.mk all
 
 clean::
 	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o

--- a/lldb/test/API/lang/swift/clangimporter/Werror/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/Makefile
@@ -1,0 +1,17 @@
+SWIFT_OBJC_INTEROP := 1
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -Xcc -DCONFLICT=1 -Xcc -Werror -I. -L. -lDylib
+
+all: libDylib.dylib a.out
+
+include Makefile.rules
+
+libDylib.dylib: dylib.swift
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=$(shell basename $< .swift) \
+		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
+
+clean::
+	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o
+

--- a/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
@@ -1,0 +1,40 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftW(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+    NO_DEBUG_INFO_TEST = True
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    # Don't run ClangImporter tests if Clangimporter is disabled.
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """This tests that -Werror is removed from ClangImporter options by
+           introducing two conflicting macro definitions in idfferent dylibs.
+        """
+        self.build()
+        target,  _, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec('dylib.swift'))
+        # Register shlib so it can run on-device.
+        self.registerSharedLibrariesWithTarget(target, ['Dylib'])
+
+        # Turn on logging.
+        log = self.getBuildArtifact("types.log")
+        self.expect("log enable lldb types -f "+log)
+        
+        self.expect("p foo", DATA_TYPES_DISPLAYED_CORRECTLY, substrs=["42"])
+        sanity = 0
+        logfile = open(log, "r")
+        for line in logfile:
+            self.assertFalse("-Werror" in line)
+            if "-DCONFLICT" in line:
+                sanity += 1
+        # We see it twice, once in the module, once in the expression context.
+        self.assertEqual(sanity, 2)

--- a/lldb/test/API/lang/swift/clangimporter/Werror/dylib.mk
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/dylib.mk
@@ -1,0 +1,7 @@
+SWIFT_OBJC_INTEROP := 1
+DYLIB_SWIFT_SOURCES := dylib.swift
+DYLIB_NAME := Dylib
+
+SWIFTFLAGS_EXTRAS = -Xcc -DCONFLICT=0
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/Werror/dylib.swift
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/dylib.swift
@@ -1,0 +1,9 @@
+func use<T>(_ t: T) {}
+
+public class Foo {
+  public init() {}
+  public func f() {
+    let foo = 42
+    use(foo) // break here
+  }
+}

--- a/lldb/test/API/lang/swift/clangimporter/Werror/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/main.swift
@@ -1,0 +1,4 @@
+import Dylib
+
+let foo = Foo()
+foo.f()

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/Makefile
@@ -7,10 +7,8 @@ all: libDylib.dylib a.out
 include Makefile.rules
 
 libDylib.dylib: dylib.swift
-	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
-		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
-		BASENAME=$(shell basename $< .swift) \
-		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
+	$(MAKE) BASENAME=$(shell basename $< .swift) \
+		-f $(SRCDIR)/dylib.mk all
 
 clean::
 	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -41,26 +41,14 @@ class TestSwiftDedupMacros(TestBase):
         """
         self.build()
             
-        exe_name = "a.out"
-        exe = self.getBuildArtifact(exe_name)
-
-        # Create the target.
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
+        target,  _, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec('dylib.swift'))
 
         self.registerSharedLibrariesWithTarget(target, ['Dylib'])
 
-        # Set the breakpoints.
-        foo_breakpoint = target.BreakpointCreateBySourceRegex(
-            'break here', lldb.SBFileSpec('dylib.swift'))
-
-        process = target.LaunchSimple(None, None, os.getcwd())
-
         # Turn on logging.
-        command_result = lldb.SBCommandReturnObject()
-        interpreter = self.dbg.GetCommandInterpreter()
         log = self.getBuildArtifact("types.log")
-        interpreter.HandleCommand("log enable lldb types -f "+log, command_result)
+        self.expect("log enable lldb types -f "+log)
         
         self.expect("p foo", DATA_TYPES_DISPLAYED_CORRECTLY, substrs=["42"])
         debug = 0
@@ -77,7 +65,7 @@ class TestSwiftDedupMacros(TestBase):
                 space_with_space += 1
             if "-UNDEBUG" in line:
                 ndebug += 1
-        self.assertTrue(debug == 1)
-        self.assertTrue(space == 1)
-        self.assertTrue(space_with_space == 0)
-        self.assertTrue(ndebug == 1)
+        self.assertEqual(debug, 1)
+        self.assertEqual(space, 1)
+        self.assertEqual(space_with_space, 0)
+        self.assertEqual(ndebug, 1)

--- a/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
+++ b/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
@@ -29,9 +29,9 @@ class TestSwiftExpressionObjCContext(TestBase):
     def test(self):
         self.build()
 
-        # Register shlib so it can run on-device.
         target,  _, _, _ = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec('main.m'))
+        # Register shlib so it can run on-device.
         self.registerSharedLibrariesWithTarget(target, ['Foo'])
 
         # This is expected to fail because we can't yet import ObjC


### PR DESCRIPTION
They only cause trouble in the debugger and never help.

<rdar://problem/64810678>