### PR TITLE
debugserver: Return a nullptr in GetPlatformString()

### DIFF
--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
@@ -668,7 +668,7 @@ const char *MachProcess::GetPlatformString(unsigned char platform) {
   case PLATFORM_DRIVERKIT:
     return "driverkit";
   }
-  return "";
+  return nullptr;
 }
 
 // Given an address, read the mach-o header and load commands out of memory to


### PR DESCRIPTION
This un-breaks the testsuite after https://reviews.llvm.org/D82616

(cherry picked from commit 278874f07f7315e0f7fda3202597e7ab2e94ed1a)