### PR TITLE
Cherry-pick "[lldb/Symbol] Make TypeSystemSwift::GetTypeFromMangledTypename virtual (NFC)"

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -176,6 +176,8 @@ public:
       lldb::opaque_compiler_type_t type, Stream *s,
       bool print_help_if_available, bool print_extensions_if_available,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) = 0;
+  virtual CompilerType
+  GetTypeFromMangledTypename(ConstString mangled_typename) = 0;
 
   /// Unavailable hardcoded functions that don't make sense for Swift.
   /// \{
@@ -280,7 +282,8 @@ public:
   swift::CanType GetCanonicalSwiftType(CompilerType compiler_type);
   swift::Type GetSwiftType(CompilerType compiler_type);
   CompilerType ReconstructType(CompilerType type);
-  CompilerType GetTypeFromMangledTypename(ConstString mangled_typename);
+  CompilerType
+  GetTypeFromMangledTypename(ConstString mangled_typename) override;
 
   // PluginInterface functions
   ConstString GetPluginName() override;
@@ -758,7 +761,8 @@ public:
   /// components up in Swift modules.
   swift::TypeBase *ReconstructType(ConstString mangled_typename);
   swift::TypeBase *ReconstructType(ConstString mangled_typename, Status &error);
-  CompilerType GetTypeFromMangledTypename(ConstString mangled_typename);
+  CompilerType
+  GetTypeFromMangledTypename(ConstString mangled_typename) override;
 
   // Retrieve the Swift.AnyObject type.
   CompilerType GetAnyObjectType();


### PR DESCRIPTION
lldb on swift/master-next is currently broken, it should be fixed with this.

@medismailben 