### PR TITLE
[lldb/test] Rework TestSwiftDeploymentTarget to not hardcode x86_64.

### DIFF
--- a/lldb/test/API/lang/swift/deployment_target/Makefile
+++ b/lldb/test/API/lang/swift/deployment_target/Makefile
@@ -2,10 +2,12 @@ all: a.out dlopen_module
 
 include Makefile.rules
 
+ARCH := x86_64
+
 # This test only works on macOS 10.11+.
 
 a.out: main.swift libNewerTarget.dylib
-	$(SWIFTC) -target x86_64-apple-macosx10.10 -g -Onone $^ -lNewerTarget -L$(shell pwd) -o $@ $(SWIFTFLAGS) -I$(shell pwd) -Xfrontend -disable-target-os-checking \
+	$(SWIFTC) -target $(ARCH)-apple-macosx10.10 -g -Onone $^ -lNewerTarget -L$(shell pwd) -o $@ $(SWIFTFLAGS) -I$(shell pwd) -Xfrontend -disable-target-os-checking \
          -toolchain-stdlib-rpath
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
@@ -18,7 +20,7 @@ ifneq "$(CODESIGN)" ""
 endif
 
 lib%.dylib: %.swift
-	$(SWIFTC) -target x86_64-apple-macosx10.11 -g -Onone $^ -emit-library -module-name $(shell basename $< .swift) -emit-module -Xlinker -install_name -Xlinker @executable_path/$@ \
+	$(SWIFTC) -target $(ARCH)-apple-macosx10.11 -g -Onone $^ -emit-library -module-name $(shell basename $< .swift) -emit-module -Xlinker -install_name -Xlinker @executable_path/$@ \
 	     -toolchain-stdlib-rpath
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"


### PR DESCRIPTION
This is preparation/generalization work for Apple Silicon.