### PR TITLE
[lldb/test] Float80 is an architecture feature, not an OS one.

### DIFF
--- a/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
+++ b/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
@@ -161,10 +161,7 @@ class TestSwiftTypes(TestBase):
                 'Double',
                 'float64',
                 'value = 2.5'])
-        float80_unsupported_platforms = ["ios"]
-        float80_unsupported_archs = ["ppc64le"]
-        if self.getPlatform() not in float80_unsupported_platforms \
-        and platform.machine() not in float80_unsupported_archs:
+        if "x86_64" in platform.machine() :
             self.expect(
                 "frame variable --raw float80",
                 substrs=[

--- a/lldb/test/API/lang/swift/variables/swift/main.swift
+++ b/lldb/test/API/lang/swift/variables/swift/main.swift
@@ -29,7 +29,7 @@ func main() -> Int {
     
     var float32 = Float32(1.25)
     var float64 = 2.5
-#if !os(iOS) && !(os(Linux) && arch(powerpc64le))
+#if arch(x86_64)
     var float80 = Float80(1.0625)
 #endif
     var float = Float(3.75)


### PR DESCRIPTION
This commit generalizes the test for Apple Silicon.