### PR TITLE
[lldb] Remove deprecated check for LLDB_REPRODUCER_DISABLE_CAPTURE

### DIFF
--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -812,14 +812,6 @@ llvm::Optional<int> InitializeReproducer(opt::InputArgList &input_args) {
   bool auto_generate = input_args.hasArg(OPT_auto_generate);
   auto *capture_path = input_args.getLastArg(OPT_capture_path);
 
-  // BEGIN SWIFT
-  if (!getenv("LLDB_REPRODUCER_DISABLE_CAPTURE")) {
-    // Always enable capture unless explicitly disabled by the
-    // LLDB_REPRODUCER_DISABLE_CAPTURE environment variable.
-    capture = true;
-  }
-  // END SWIFT
-
   if (auto_generate && !capture) {
     WithColor::warning()
         << "-reproducer-auto-generate specified without -capture\n";


### PR DESCRIPTION
This is controlled by LLDB_CAPTURE_REPRODUCER since
c37ea5793e3458bedae48f9355b2abdafbd68c93. I must have forgotten to
remove this check when cherrypicking that change.