### PR TITLE
[lldb] Fix that SIGWINCH crashes IOHandlerEditline when we are not us…

### DIFF
--- a/lldb/source/Core/IOHandler.cpp
+++ b/lldb/source/Core/IOHandler.cpp
@@ -289,7 +289,8 @@ void IOHandlerEditline::Deactivate() {
 
 void IOHandlerEditline::TerminalSizeChanged() {
 #if LLDB_ENABLE_LIBEDIT
-  m_editline_up->TerminalSizeChanged();
+  if (m_editline_up)
+    m_editline_up->TerminalSizeChanged();
 #endif
 }
 

--- a/lldb/test/API/iohandler/resize/TestIOHandlerResizeNoEditline.py
+++ b/lldb/test/API/iohandler/resize/TestIOHandlerResizeNoEditline.py
@@ -1,0 +1,21 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+class TestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @no_debug_info_test
+    def test_resize_no_editline(self):
+        """ Tests terminal resizing if the editline isn't used. """
+        dbg = lldb.SBDebugger.Create(False)
+        # Set the input handle to some stream so that we don't start the
+        # editline interface.
+        dbg.SetInputFileHandle(io.BytesIO(b""), True)
+        opts = lldb.SBCommandInterpreterRunOptions()
+        # Launch the command interpreter now.
+        dbg.RunCommandInterpreter(True, True, opts, 0, False, False)
+        # Try resizing the terminal which shouldn't crash.
+        dbg.SetTerminalWidth(47)


### PR DESCRIPTION
…ing the editline backend

Summary:
TerminalSizeChanged is called from our SIGWINCH signal handler but the
IOHandlerEditline currently doesn't check if we are actually using the real
editline backend. If we're not using the real editline backend, `m_editline_up`
won't be set and `IOHandlerEditline::TerminalSizeChanged` will access
the empty unique_ptr. In a real use case we don't use the editline backend
when we for example read input from a file. We also create some temporary
IOHandlerEditline's during LLDB startup it seems that are also treated
as non-interactive (apparently to read startup commands).

This patch just adds a nullptr check for`m_editline_up` as we do in the rest of
IOHandlerEditline.

Fixes rdar://problem/63921950

Reviewers: labath, friss

Reviewed By: friss

Subscribers: abidh, JDevlieghere

Differential Revision: https://reviews.llvm.org/D81729

(cherry picked from commit be18df3d23fe21fa622ec45fa09eddb3af3eef6b)