### PR TITLE
[lldb] Fix TestBridging.test under ASan

### DIFF
--- a/lldb/test/Shell/Reproducer/Swift/Inputs/Bridging.in
+++ b/lldb/test/Shell/Reproducer/Swift/Inputs/Bridging.in
@@ -1,4 +1,4 @@
-breakpoint set -f Bridging.swift -l 2
+breakpoint set -f Bridging.swift -l 3
 run
 bt
 p let $bar = Foo(i: 95126)

--- a/lldb/test/Shell/Reproducer/Swift/Inputs/Bridging.swift
+++ b/lldb/test/Shell/Reproducer/Swift/Inputs/Bridging.swift
@@ -1,5 +1,6 @@
 func main() {
-  let foo = Foo(i: 42)
+  Int x = 41 // Make sure we use the Swift Standard Library
+  let foo = Foo(i: x)
 }
 
 main()


### PR DESCRIPTION
When the inferior doesn't use the Swift Standard Library, we import it
when evaluation the expression which causes the sanitizer runtime to be
loaded too late.