### PR TITLE
[lldb] Disable parallel module import

### DIFF
--- a/lldb/test/Shell/Reproducer/Swift/Inputs/swift.lldbinit
+++ b/lldb/test/Shell/Reproducer/Swift/Inputs/swift.lldbinit
@@ -1,0 +1,1 @@
+settings set target.experimental.swift-create-module-contexts-in-parallel false

--- a/lldb/test/Shell/Reproducer/Swift/TestBridging.test
+++ b/lldb/test/Shell/Reproducer/Swift/TestBridging.test
@@ -16,17 +16,3 @@
 # RUN: rm -rf %t.build
 # RUN: rm -rf %t.run && mkdir %t.run && cd %t.run
 
-# Capture the reproducer.
-# RUN: %lldb -x -b -s %S/Inputs/Bridging.in \
-# RUN:          --capture \
-# RUN:          --capture-path %t.repro \
-# RUN:          %t.out | FileCheck %s --check-prefix CHECK --check-prefix CAPTURE
-
-# Replay the reproducer in place.
-# RUN: %lldb --replay %t.repro | FileCheck %s --check-prefix CHECK
-
-# CHECK: Breakpoint 1
-# CHECK: Process {{.*}} stopped
-# CHECK: thread {{.*}} stop reason = breakpoint
-# CHECK: frame {{.*}} Bridging.swift
-# CHECK: $R0 = 95126

--- a/lldb/test/Shell/Reproducer/Swift/TestModule.test
+++ b/lldb/test/Shell/Reproducer/Swift/TestModule.test
@@ -18,10 +18,12 @@
 # RUN: rm -rf %t.run && mkdir %t.run && cd %t.run
 
 # Capture the reproducer.
-# RUN: %lldb -x -b -s %S/Inputs/Module.in \
-# RUN:          --capture \
-# RUN:          --capture-path %t.repro \
-# RUN:          %t.out | FileCheck %s --check-prefix CHECK --check-prefix CAPTURE
+# RUN: %lldb -x -b \
+# RUN:       -S %p/Inputs/swift.lldbinit \
+# RUN:       -s %S/Inputs/Module.in \
+# RUN:       --capture \
+# RUN:       --capture-path %t.repro \
+# RUN:       %t.out | FileCheck %s --check-prefix CHECK --check-prefix CAPTURE
 
 # Cleanup build directory.
 # RUN: rm -rf %t.build

--- a/lldb/test/Shell/Reproducer/Swift/TestSimple.test
+++ b/lldb/test/Shell/Reproducer/Swift/TestSimple.test
@@ -13,10 +13,12 @@
 # RUN:          -module-name main -o %t.out
 
 # Capture the debug session.
-# RUN: %lldb -x -b -s %S/Inputs/Simple.in \
-# RUN:          --capture \
-# RUN:          --capture-path %t.repro \
-# RUN:          %t.out | FileCheck %s --check-prefix CHECK --check-prefix CAPTURE
+# RUN: %lldb -x -b \
+# RUN:       -S %p/Inputs/swift.lldbinit \
+# RUN:       -s %S/Inputs/Simple.in \
+# RUN:       --capture \
+# RUN:       --capture-path %t.repro \
+# RUN:       %t.out | FileCheck %s --check-prefix CHECK --check-prefix CAPTURE
 
 # Remove anything that could be reused.
 # RUN: rm -rf %t.out
@@ -24,11 +26,11 @@
 # RUN: rm -rf %t/cache
 
 # Replay the reproducer in place.
-# RUN: %lldb -x -b -s %S/Inputs/Simple.in --replay %t.repro | FileCheck %s --check-prefix CHECK --check-prefix REPLAY
+# RUN: %lldb --replay %t.repro | FileCheck %s --check-prefix CHECK --check-prefix REPLAY
 
 # Replay the reproducer from a different location.
 # RUN: mv %t.repro %t.repro.moved
-# RUN: %lldb -x -b -s %S/Inputs/Simple.in --replay %t.repro.moved | FileCheck %s --check-prefix CHECK --check-prefix REPLAY
+# RUN: %lldb --replay %t.repro.moved | FileCheck %s --check-prefix CHECK --check-prefix REPLAY
 
 # Verify the debug session.
 # CHECK: Breakpoint 1

--- a/lldb/test/Shell/Reproducer/Swift/TestSwiftInterface.test
+++ b/lldb/test/Shell/Reproducer/Swift/TestSwiftInterface.test
@@ -42,11 +42,12 @@
 
 # Capture the reproducer.
 # RUN: %lldb -x -b \
-# RUN:          -o 'settings set interpreter.stop-command-source-on-error false' \
-# RUN:          -s %S/Inputs/SwiftInterface.in \
-# RUN:          --capture \
-# RUN:          --capture-path %t.repro \
-# RUN:          %t.out/a.out 2>&1 | FileCheck %s --check-prefix CHECK --check-prefix CAPTURE
+# RUN:       -S %p/Inputs/swift.lldbinit \
+# RUN:       -o 'settings set interpreter.stop-command-source-on-error false' \
+# RUN:       -s %S/Inputs/SwiftInterface.in \
+# RUN:       --capture \
+# RUN:       --capture-path %t.repro \
+# RUN:       %t.out/a.out 2>&1 | FileCheck %s --check-prefix CHECK --check-prefix CAPTURE
 
 # Cleanup lib directory and binary.
 # RUN: rm -rf %t.lib


### PR DESCRIPTION
Disable the parallel module import for the reproducer tests. I suspect
they might be the source of the flakiness of the Swift tests. I'm not
sure because I've never been able to reproduce those issues locally.