### PR TITLE
Use CMAKE_OSX_SYSROOT instead of the environment variable SYSROOT

### DIFF
--- a/lldb/tools/debugserver/source/CMakeLists.txt
+++ b/lldb/tools/debugserver/source/CMakeLists.txt
@@ -129,7 +129,7 @@ if(LLDB_USE_ENTITLEMENTS)
   endif()
 endif()
 
-if($ENV{SDKROOT} MATCHES ".Internal.sdk$")
+if(${CMAKE_OSX_SYSROOT} MATCHES ".Internal.sdk$")
   message(STATUS "LLDB debugserver energy support is enabled")
   add_definitions(-DLLDB_ENERGY)
   set(ENERGY_LIBRARY -lpmenergy -lpmsample)


### PR DESCRIPTION
to detect energy support in debugserver.  The way that Swift
build-script is invoked the former may be overridden manually.

<rdar://problem/63840635>

(cherry picked from commit 60c07fd016a3a5f2050828f92257e1e5d33a485b)