### PR TITLE
[tensorflow] enable optimizations in the repl

### DIFF
--- a/lldb/test/Shell/SwiftREPL/OptimizationEnabled.test
+++ b/lldb/test/Shell/SwiftREPL/OptimizationEnabled.test
@@ -1,0 +1,14 @@
+// SWIFT_ENABLE_TENSORFLOW
+// Checks that optimization is enabled by default in the REPL.
+
+:log enable lldb expr
+print("Hello World")
+
+// EXCLUDE-FROM-INPUT
+// All lines below this are excluded from the input to the REPL, so that they don't trigger a false
+// positive FileCheck match.
+
+// CHECK: SILOptions OptMode 2
+// CHECK: Running SIL optimization passes
+
+// RUN: sed '/EXCLUDE-FROM-INPUT/Q' %s | %lldb --repl | FileCheck %s


### PR DESCRIPTION
A recent merge from `swift/master` branch accidentally turned off optimizations, which we rely on in Jupyter. (https://github.com/apple/llvm-project/commit/1995d9c1076d60644ce90ef13e59dd000844c556#diff-53dbe0dcced6042719e37ff119551ca9)

This PR turns optimizations back on and adds a test.

I was not able to check for `!DICompileUnit(language: DW_LANG_Swift, {{.*}}isOptimized: true` in the test, because `isOptimized` is `true` regardless of whether Swift optimizations run or not. (I'm not sure why.) So I added some new log messages and checked for those instead.