### PR TITLE
[lldb] Make TestIOHandlerResizeNoEditline pass with Python 2

### DIFF
--- a/lldb/test/API/iohandler/resize/TestIOHandlerResizeNoEditline.py
+++ b/lldb/test/API/iohandler/resize/TestIOHandlerResizeNoEditline.py
@@ -13,7 +13,7 @@ class TestCase(TestBase):
         dbg = lldb.SBDebugger.Create(False)
         # Set the input handle to some stream so that we don't start the
         # editline interface.
-        dbg.SetInputFileHandle(io.BytesIO(b""), True)
+        dbg.SetInputFileHandle(open("input_file"), True)
         opts = lldb.SBCommandInterpreterRunOptions()
         # Launch the command interpreter now.
         dbg.RunCommandInterpreter(True, True, opts, 0, False, False)


### PR DESCRIPTION
io.BytesIO seems to produce a stream in Python 2 which isn't recognized
as a file object in the SWIG API, so this test fails for Python 2 (and I assume
also an old SWIG version needs to be involved).

Instead just open an empty input file which is a file object in all Python
versions to make this test pass everywhere.

(cherry picked from commit de0175d04bc3679c7bd8dc64520e790bf38f30b0)