### PR TITLE
Cherry-pick [lldb] Fix missing characters when autocompleting LLDB commands in REPL

### DIFF
--- a/lldb/source/Expression/REPL.cpp
+++ b/lldb/source/Expression/REPL.cpp
@@ -452,6 +452,10 @@ void REPL::IOHandlerComplete(IOHandler &io_handler,
     debugger.GetCommandInterpreter().HandleCompletion(sub_request);
     StringList matches, descriptions;
     sub_result.GetMatches(matches);
+    // Prepend command prefix that was excluded in the completion request.
+    if (request.GetCursorIndex() == 0)
+      for (auto &match : matches)
+        match.insert(0, 1, ':');
     sub_result.GetDescriptions(descriptions);
     request.AddCompletions(matches, descriptions);
     return;


### PR DESCRIPTION
LLDB change for https://github.com/apple/llvm-project/pull/1421

Summary:

When tabbing to complete LLDB commands in REPL, characters would at best be
missing but at worst cause the REPL to crash due to out of range string access.
This patch appends the command character to the completion results to fulfill
the assumption that all matches are prefixed by the request's cursor argument
prefix.

Bug report for the Swift REPL
https://bugs.swift.org/browse/SR-12867

Reviewers: teemperor

Reviewed By: teemperor

Subscribers: lldb-commits

Tags: #lldb

Differential Revision: https://reviews.llvm.org/D82835

(cherry picked from commit 3faec833760fa7ab6e3180378da8c8fb4abbdb11)