### PR TITLE
[lldb] Stop passing -sil-merge-partial-modules

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -740,7 +740,6 @@ $(MODULENAME).swiftmodule: $(OBJECTS) $(DYLIB_OBJECTS)
 	$(SWIFT_FE) $(SWIFT_FEFLAGS) $(SWIFT_HFLAGS) -merge-modules \
 	  -emit-module $(patsubst %.swift,%.partial.swiftmodule,$(SWIFT_SOURCES) $(DYLIB_SWIFT_SOURCES)) \
 	  -emit-module-interface-path $(BUILDDIR)/$(MODULENAME).swiftinterface \
-	  -sil-merge-partial-modules \
 	  -disable-diagnostic-passes -disable-sil-perf-optzns \
 	  -module-name $(MODULENAME) \
 	  -o $(BUILDDIR)/$@

--- a/lldb/test/Shell/Swift/RemoteASTImport.test
+++ b/lldb/test/Shell/Swift/RemoteASTImport.test
@@ -16,7 +16,7 @@
 # RUN: %target-swift-frontend -serialize-debugging-options \
 # RUN:          -module-cache-path %t/cache \
 # RUN:          -merge-modules -emit-module \
-# RUN:          -parse-as-library -sil-merge-partial-modules \
+# RUN:          -parse-as-library \
 # RUN:          -disable-diagnostic-passes -disable-sil-perf-optzns \
 # RUN:          -module-name Library Library.part.swiftmodule \
 # RUN:          -o Library.swiftmodule -I%t
@@ -33,7 +33,7 @@
 # RUN: %target-swift-frontend -serialize-debugging-options  -merge-modules \
 # RUN:          -module-cache-path %t/cache \
 # RUN:          -emit-module RemoteASTImport.part.swiftmodule \
-# RUN:          -parse-as-library -sil-merge-partial-modules \
+# RUN:          -parse-as-library \
 # RUN:          -disable-diagnostic-passes -disable-sil-perf-optzns \
 # RUN:          -import-objc-header %S/Inputs/BridgingHeader.h \
 # RUN:          -I%t -Xcc -DSYNTAX_ERROR=1 \


### PR DESCRIPTION
This flag is being removed in https://github.com/apple/swift/pull/32777.