### PR TITLE
Reduce number of redundant args for ClangImporter

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -218,6 +218,8 @@ public:
   /// Add a list of Clang arguments to the ClangImporter options and
   /// apply the working directory to any relative paths.
   void AddExtraClangArgs(std::vector<std::string> ExtraArgs);
+  static void AddExtraClangArgs(const std::vector<std::string>& source,
+                                std::vector<std::string>& dest);
 
   /// Add the target's swift-extra-clang-flags to the ClangImporter options.
   void AddUserClangArgs(TargetProperties &props);

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -124,7 +124,7 @@ class TestSwiftRewriteClangPaths(TestBase):
             self.assertEqual(found_iquote, 2)
             self.assertEqual(found_i1, 2)
             self.assertEqual(found_i2, 2)
-            self.assertEqual(found_f, 4)
+            self.assertEqual(found_f, 2)
             self.assertEqual(found_rel, 0)
             self.assertEqual(found_abs, 1)
             self.assertEqual(found_ovl, 2)

--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -214,3 +214,32 @@ TEST_F(TestSwiftASTContext, SwiftFriendlyTriple) {
                 llvm::Triple("aarch64_32-apple-watchos")),
             llvm::Triple("arm64_32-apple-watchos"));
 }
+
+namespace {
+  const std::vector<std::string> duplicated_flags = {
+    "-DMACRO1", "-D", "MACRO1", "-UMACRO2", "-U", "MACRO2",
+    "-I/path1", "-I", "/path1", "-F/path2", "-F", "/path2",
+    "-fmodule-map-file=/path3", "-fmodule-map-file=/path3",
+    "-F/path2", "-F", "/path2", "-I/path1", "-I", "/path1",
+    "-UMACRO2", "-U", "MACRO2", "-DMACRO1", "-D", "MACRO1",
+  };
+  const std::vector<std::string> uniqued_flags = {
+    "-DMACRO1", "-UMACRO2", "-I/path1", "-F/path2", "-fmodule-map-file=/path3"
+  };
+} // namespace
+
+TEST(ClangArgs, UniquingCollisionWithExistingFlags) {
+  const std::vector<std::string> source = duplicated_flags;
+  std::vector<std::string> dest = uniqued_flags;
+  SwiftASTContext::AddExtraClangArgs(source, dest);
+
+  EXPECT_EQ(dest, uniqued_flags);
+}
+
+TEST(ClangArgs, UniquingCollisionWithAddedFlags) {
+  const std::vector<std::string> source = duplicated_flags;
+  std::vector<std::string> dest;
+  SwiftASTContext::AddExtraClangArgs(source, dest);
+
+  EXPECT_EQ(dest, uniqued_flags);
+}


### PR DESCRIPTION
This PR is a follow-up to this thread: https://forums.swift.org/t/lldb-performance-with-clang-modules-and-swift/38160

I've tried to keep diff as small as possible, and for more intrusive, but also more reliable solutions I'd propose to add flags categorization (along with uniquing for categories that allow it) to [ClangImporterOptions](https://github.com/apple/swift/blob/master/include/swift/ClangImporter/ClangImporterOptions.h#L30)