### PR TITLE
Require SwiftASTContextReader to be valid at all times

### DIFF
--- a/lldb/include/lldb/Core/SwiftASTContextReader.h
+++ b/lldb/include/lldb/Core/SwiftASTContextReader.h
@@ -91,17 +91,26 @@ struct ScopedSharedMutexReader {
 /// or even separate scratch contexts for each lldb::Module. But it
 /// will only do this if no client holds on to a read lock on \b
 /// m_scratch_typesystem_lock.
-struct SwiftASTContextReader : ScopedSharedMutexReader {
-  SwiftASTContextForExpressions *m_ptr = nullptr;
-  SwiftASTContextReader() : ScopedSharedMutexReader(nullptr) {}
-  SwiftASTContextReader(SharedMutex &mutex, SwiftASTContextForExpressions *ctx)
-      : ScopedSharedMutexReader(&mutex), m_ptr(ctx) {}
+class SwiftASTContextReader : ScopedSharedMutexReader {
+  SwiftASTContextForExpressions *m_ptr;
+
+public:
+  SwiftASTContextReader(SharedMutex &mutex, SwiftASTContextForExpressions &ctx)
+      : ScopedSharedMutexReader(&mutex), m_ptr(&ctx) {
+    assert(m_ptr && "invalid context");
+  }
+
   SwiftASTContextReader(const SwiftASTContextReader &copy)
       : ScopedSharedMutexReader(copy.m_mutex), m_ptr(copy.m_ptr) {}
-  SwiftASTContextForExpressions *get() { return m_ptr; }
-  operator bool() const { return m_ptr; }
-  SwiftASTContextForExpressions *operator->() { return m_ptr; }
-  SwiftASTContextForExpressions &operator*() { return *m_ptr; }
+
+  SwiftASTContextForExpressions *get() {
+    assert(m_ptr && "invalid context");
+    return m_ptr;
+  }
+
+  SwiftASTContextForExpressions *operator->() { return get(); }
+
+  SwiftASTContextForExpressions &operator*() { return *get(); }
 };
 
 /// An RAII object that just acquires the reader lock.

--- a/lldb/include/lldb/Core/ValueObject.h
+++ b/lldb/include/lldb/Core/ValueObject.h
@@ -584,7 +584,7 @@ public:
 
   virtual bool HasSyntheticValue();
 
-  SwiftASTContextReader GetScratchSwiftASTContext();
+  llvm::Optional<SwiftASTContextReader> GetScratchSwiftASTContext();
 
   virtual bool IsSynthetic() { return false; }
 

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1127,7 +1127,7 @@ public:
     return m_scratch_typesystem_lock;
   }
 
-  SwiftASTContextReader
+  llvm::Optional<SwiftASTContextReader>
   GetScratchSwiftASTContext(Status &error, ExecutionContextScope &exe_scope,
                             bool create_on_demand = true);
 

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -1697,10 +1697,10 @@ LanguageType ValueObject::GetObjectRuntimeLanguage() {
   return lldb::eLanguageTypeUnknown;
 }
 
-SwiftASTContextReader ValueObject::GetScratchSwiftASTContext() {
+llvm::Optional<SwiftASTContextReader> ValueObject::GetScratchSwiftASTContext() {
   lldb::TargetSP target_sp(GetTargetSP());
   if (!target_sp)
-    return {};
+    return llvm::None;
   Status error;
   ExecutionContext ctx = GetExecutionContextRef().Lock(false);
   auto *exe_scope = ctx.GetBestExecutionContextScope();

--- a/lldb/source/Core/ValueObjectDynamicValue.cpp
+++ b/lldb/source/Core/ValueObjectDynamicValue.cpp
@@ -433,5 +433,7 @@ bool ValueObjectDynamicValue::DynamicValueTypeInfoNeedsUpdate() {
     return false;
 
   auto *cached_ctx = m_value.GetCompilerType().GetTypeSystem();
-  return cached_ctx == GetScratchSwiftASTContext().get();
+  llvm::Optional<SwiftASTContextReader> scratch_ctx =
+      GetScratchSwiftASTContext();
+  return scratch_ctx ? (cached_ctx == scratch_ctx->get()) : !cached_ctx;
 }

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -927,9 +927,9 @@ public:
 
     if (m_type.GetMinimumLanguage() == lldb::eLanguageTypeSwift) {
       Status status;
-      auto type_system =
-          target_sp->GetScratchSwiftASTContext(status, *exe_scope).get();
-      if (type_system == nullptr) {
+      llvm::Optional<SwiftASTContextReader> maybe_type_system =
+          target_sp->GetScratchSwiftASTContext(status, *exe_scope);
+      if (!maybe_type_system) {
         err.SetErrorStringWithFormat("Couldn't dematerialize a result variable: "
                                      "couldn't get the corresponding type "
                                      "system: %s", status.AsCString());

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -128,8 +128,11 @@ SwiftExpressionParser::SwiftExpressionParser(
 
   if (target_sp) {
     Status error;
-    m_swift_ast_context = std::make_unique<SwiftASTContextReader>(
-        target_sp->GetScratchSwiftASTContext(error, *exe_scope, true));
+    llvm::Optional<SwiftASTContextReader> scratch_ctx =
+        target_sp->GetScratchSwiftASTContext(error, *exe_scope, true);
+    if (scratch_ctx)
+      m_swift_ast_context =
+          std::make_unique<SwiftASTContextReader>(scratch_ctx.getValue());
   }
 }
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -195,11 +195,13 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
   // Make sure the target's SwiftASTContext has been setup before doing any
   // Swift name lookups.
-  auto swift_ast_ctx = m_target->GetScratchSwiftASTContext(err, *frame);
-  if (!swift_ast_ctx) {
+  llvm::Optional<SwiftASTContextReader> maybe_swift_ast_ctx =
+      m_target->GetScratchSwiftASTContext(err, *frame);
+  if (!maybe_swift_ast_ctx) {
     LLDB_LOG(log, "  [SUE::SC] NULL Swift AST Context");
     return;
   }
+  SwiftASTContext *swift_ast_ctx = maybe_swift_ast_ctx->get();
 
   if (!swift_ast_ctx->GetClangImporter()) {
     LLDB_LOG(log, "  [SUE::SC] Swift AST Context has no Clang importer");

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -294,13 +294,13 @@ HashedCollectionConfig::StorageObjectAtAddress(
   // same address.
   Status error;
   ExecutionContextScope *exe_scope = exe_ctx.GetBestExecutionContextScope();
-  auto reader =
+  llvm::Optional<SwiftASTContextReader> reader =
     process_sp->GetTarget().GetScratchSwiftASTContext(error, *exe_scope);
-  SwiftASTContext *ast_ctx = reader.get();
-  if (!ast_ctx)
+  if (!reader)
     return nullptr;
   if (error.Fail())
     return nullptr;
+  SwiftASTContext *ast_ctx = reader->get();
 
   CompilerType rawStorage_type =
       ast_ctx->GetTypeFromMangledTypename(m_nativeStorageRoot_mangled);
@@ -445,10 +445,10 @@ NativeHashedStorageHandler::NativeHashedStorageHandler(
     m_value_stride = value_type_stride ? *value_type_stride : 0;
     if (TypeSystemSwift *swift_ast =
             llvm::dyn_cast_or_null<TypeSystemSwift>(key_type.GetTypeSystem())) {
-      auto scratch_ctx_reader = nativeStorage_sp->GetScratchSwiftASTContext();
-      auto scratch_ctx = scratch_ctx_reader.get();
-      if (!scratch_ctx)
+      llvm::Optional<SwiftASTContextReader> scratch_ctx_reader = nativeStorage_sp->GetScratchSwiftASTContext();
+      if (!scratch_ctx_reader)
         return;
+      SwiftASTContext *scratch_ctx = scratch_ctx_reader->get();
       auto *runtime = SwiftLanguageRuntime::Get(m_process);
       if (!runtime)
         return;

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1013,9 +1013,11 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
             if (target) {
               const bool create_on_demand = false;
               Status error;
-              auto ast_ctx = target->GetScratchSwiftASTContext(
-                  error, *exe_scope, create_on_demand);
-              if (ast_ctx) {
+              llvm::Optional<SwiftASTContextReader> maybe_ast_ctx =
+                  target->GetScratchSwiftASTContext(error, *exe_scope,
+                                                    create_on_demand);
+              if (maybe_ast_ctx) {
+                SwiftASTContext *ast_ctx = maybe_ast_ctx->get();
                 ConstString cs_input{input};
                 Mangled mangled(cs_input);
                 if (mangled.GuessLanguage() == eLanguageTypeSwift) {
@@ -1071,9 +1073,11 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
             Target *target = exe_scope->CalculateTarget().get();
             const bool create_on_demand = false;
             Status error;
-            auto ast_ctx = target->GetScratchSwiftASTContext(error, *exe_scope,
-                                                             create_on_demand);
-            if (ast_ctx) {
+            llvm::Optional<SwiftASTContextReader> maybe_ast_ctx =
+                target->GetScratchSwiftASTContext(error, *exe_scope,
+                                                  create_on_demand);
+            if (maybe_ast_ctx) {
+              SwiftASTContext *ast_ctx = maybe_ast_ctx->get();
               auto iter = ast_ctx->GetModuleCache().begin(),
                    end = ast_ctx->GetModuleCache().end();
 

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -945,8 +945,10 @@ void SwiftLanguageRuntime::FindFunctionPointersInCall(
       Status error;
       Target &target = frame.GetThread()->GetProcess()->GetTarget();
       ExecutionContext exe_ctx(frame);
-      auto swift_ast = target.GetScratchSwiftASTContext(error, frame);
-      if (swift_ast) {
+      llvm::Optional<SwiftASTContextReader> maybe_swift_ast =
+          target.GetScratchSwiftASTContext(error, frame);
+      if (maybe_swift_ast) {
+        SwiftASTContext *swift_ast = maybe_swift_ast->get();
         CompilerType function_type = swift_ast->GetTypeFromMangledTypename(
             mangled_name.GetMangledName());
         if (error.Success()) {
@@ -1152,9 +1154,11 @@ SwiftLanguageRuntime::CalculateErrorValue(StackFrameSP frame_sp,
   if (!exe_scope)
     return error_valobj_sp;
 
-  auto ast_context = target->GetScratchSwiftASTContext(error, *frame_sp);
-  if (!ast_context || error.Fail())
+  llvm::Optional<SwiftASTContextReader> maybe_ast_context =
+      target->GetScratchSwiftASTContext(error, *frame_sp);
+  if (!maybe_ast_context || error.Fail())
     return error_valobj_sp;
+  SwiftASTContext *ast_context = maybe_ast_context->get();
 
   lldb::DataBufferSP buffer(new lldb_private::DataBufferHeap(
       arg0->GetScalar().GetBytes(), arg0->GetScalar().GetByteSize()));
@@ -1483,9 +1487,9 @@ SwiftLanguageRuntimeImpl::GetBridgedSyntheticChildProvider(
   ProjectionSyntheticChildren::TypeProjectionUP type_projection(
       new ProjectionSyntheticChildren::TypeProjectionUP::element_type());
 
-  if (auto swift_ast_ctx = valobj.GetScratchSwiftASTContext()) {
+  if (auto maybe_swift_ast_ctx = valobj.GetScratchSwiftASTContext()) {
     CompilerType swift_type =
-        swift_ast_ctx->GetTypeFromMangledTypename(type_name);
+        maybe_swift_ast_ctx->get()->GetTypeFromMangledTypename(type_name);
 
     if (swift_type.IsValid()) {
       ExecutionContext exe_ctx(m_process);

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -513,18 +513,20 @@ SwiftLanguageRuntime::MetadataPromise::FulfillTypePromise(Status *error) {
   if (m_compiler_type.hasValue())
     return m_compiler_type.getValue();
 
-  auto swift_ast_ctx = m_for_object_sp->GetScratchSwiftASTContext();
-  if (!swift_ast_ctx) {
+  llvm::Optional<SwiftASTContextReader> maybe_swift_ast_ctx =
+      m_for_object_sp->GetScratchSwiftASTContext();
+  if (!maybe_swift_ast_ctx) {
     error->SetErrorString("couldn't get Swift scratch context");
     return CompilerType();
   }
+  SwiftASTContext *swift_ast_ctx = maybe_swift_ast_ctx->get();
   auto &remote_ast = m_swift_runtime.GetRemoteASTContext(*swift_ast_ctx);
   swift::remoteAST::Result<swift::Type> result =
       remote_ast.getTypeForRemoteTypeMetadata(
           swift::remote::RemoteAddress(m_metadata_location));
 
   if (result) {
-    m_compiler_type = {swift_ast_ctx.get(), result.getValue().getPointer()};
+    m_compiler_type = {swift_ast_ctx, result.getValue().getPointer()};
     if (log)
       log->Printf("[MetadataPromise] result is type %s",
                   m_compiler_type->GetTypeName().AsCString());
@@ -543,10 +545,13 @@ SwiftLanguageRuntime::MetadataPromise::FulfillTypePromise(Status *error) {
 SwiftLanguageRuntime::MetadataPromiseSP
 SwiftLanguageRuntimeImpl::GetMetadataPromise(lldb::addr_t addr,
                                              ValueObject &for_object) {
-  auto swift_ast_ctx = for_object.GetScratchSwiftASTContext();
-  if (!swift_ast_ctx || swift_ast_ctx->HasFatalErrors())
+  llvm::Optional<SwiftASTContextReader> maybe_swift_ast_ctx =
+      for_object.GetScratchSwiftASTContext();
+  if (!maybe_swift_ast_ctx)
     return nullptr;
-
+  SwiftASTContext *swift_ast_ctx = maybe_swift_ast_ctx->get();
+  if (swift_ast_ctx->HasFatalErrors())
+    return nullptr;
   if (addr == 0 || addr == LLDB_INVALID_ADDRESS)
     return nullptr;
 
@@ -1038,9 +1043,11 @@ SwiftLanguageRuntimeImpl::DoArchetypeBindingForType(StackFrame &stack_frame,
   auto &target = m_process.GetTarget();
   assert(IsScratchContextLocked(target) &&
          "Swift scratch context not locked ahead of archetype binding");
-  auto scratch_ctx = target.GetScratchSwiftASTContext(error, stack_frame);
-  if (!scratch_ctx)
+  llvm::Optional<SwiftASTContextReader> maybe_scratch_ctx =
+      target.GetScratchSwiftASTContext(error, stack_frame);
+  if (!maybe_scratch_ctx)
     return base_type;
+  SwiftASTContext *scratch_ctx = maybe_scratch_ctx->get();
   base_type = scratch_ctx->ImportType(base_type, error);
 
   if (base_type.GetTypeInfo() & lldb::eTypeIsSwift) {
@@ -1425,11 +1432,13 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_ClangType(
   // Import the remangled dynamic name into the scratch context.
   assert(IsScratchContextLocked(in_value.GetTargetSP()) &&
          "Swift scratch context not locked ahead of dynamic type resolution");
-  auto scratch_ctx = in_value.GetScratchSwiftASTContext();
-  if (!scratch_ctx)
+  llvm::Optional<SwiftASTContextReader> maybe_scratch_ctx =
+      in_value.GetScratchSwiftASTContext();
+  if (!maybe_scratch_ctx)
     return false;
   CompilerType swift_type =
-      scratch_ctx->GetTypeFromMangledTypename(ConstString(remangled));
+      maybe_scratch_ctx->get()->GetTypeFromMangledTypename(
+          ConstString(remangled));
 
   // Roll back the ObjC dynamic type resolution.
   if (!swift_type)
@@ -1483,9 +1492,11 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress(
   // use the scratch context where such operations are legal and safe.
   assert(IsScratchContextLocked(in_value.GetTargetSP()) &&
          "Swift scratch context not locked ahead of dynamic type resolution");
-  auto scratch_ctx = in_value.GetScratchSwiftASTContext();
-  if (!scratch_ctx)
+  llvm::Optional<SwiftASTContextReader> maybe_scratch_ctx =
+      in_value.GetScratchSwiftASTContext();
+  if (!maybe_scratch_ctx)
     return false;
+  SwiftASTContextForExpressions *scratch_ctx = maybe_scratch_ctx->get();
 
   auto retry_once = [&]() {
     // Retry exactly once using the per-module fallback scratch context.


### PR DESCRIPTION
Prior to this patch, it was possible to construct an invalid
SwiftASTContextReader (e.g. via default-init). This led to subtle bugs:
in rdar://65276251 for example, an invalid SwiftASTContextReader was
assigned into an llvm::Optional, and subsequent code crashed because it
assumed that the loaded llvm::Optional contained a valid instance.

Make it so that SwiftASTContextReader is valid at all times.

rdar://65276251