### PR TITLE
Add missing validity-check for SwiftASTContextReader

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -634,8 +634,9 @@ llvm::Optional<uint64_t> SwiftLanguageRuntimeImpl::GetMemberVariableOffset(
 
   llvm::Optional<SwiftASTContextReader> scratch_ctx;
   if (instance) {
-    scratch_ctx = instance->GetScratchSwiftASTContext();
-    if (!scratch_ctx)
+    if (SwiftASTContextReader reader = instance->GetScratchSwiftASTContext())
+      scratch_ctx = reader;
+    else
       return llvm::None;
   }
 


### PR DESCRIPTION
This is a narrower version of
https://github.com/apple/llvm-project/pull/1440 spun off for 5.3.

I've kept 'scratch_ctx' wrapped in an Optional to minimize the necessary
source changes. Simply removing the Optional triggers a subsequent
assert because the context lock is not taken (even though the context
reader is invalid).

rdar://65276251