### PR TITLE
NFC: Refactor clang extra args addition

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -215,10 +215,6 @@ public:
 
   bool AddModuleSearchPath(llvm::StringRef path);
 
-  bool AddClangArgument(std::string arg, bool unique = true);
-
-  bool AddClangArgumentPair(llvm::StringRef arg1, llvm::StringRef arg2);
-
   /// Add a list of Clang arguments to the ClangImporter options and
   /// apply the working directory to any relative paths.
   void AddExtraClangArgs(std::vector<std::string> ExtraArgs);


### PR DESCRIPTION
* Removing unused `AddClangArgumentPair` method
* Replacing linear quadratic complexity for flags uniquing with linear
* Inlining `AddClangArgument` method (not used anywhere outside `SwiftASTContext.cpp`)
* Generalized flags uniquing mechanism for easier expanding unique flags list