### PR TITLE
Target: correct binding variable type (NFC)

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -639,7 +639,7 @@ llvm::Optional<uint64_t> SwiftLanguageRuntimeImpl::GetMemberVariableOffset(
 
   llvm::Optional<SwiftASTContextReader> scratch_ctx;
   if (instance) {
-    if (SwiftASTContextReader reader = instance->GetScratchSwiftASTContext())
+    if (const auto& reader = instance->GetScratchSwiftASTContext())
       scratch_ctx = reader;
     else
       return llvm::None;


### PR DESCRIPTION
The returned type for `GetScratchSwiftASTContext` is
`llvm::Optional<SwiftASTContextReader>` which cannot be unwrapped.  Use
`auto` and a reference binding rather than the copy-constructor and
unbound type.  This repairs the build with MSVC.