### PR TITLE
Revert #1442 on swift/master

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -639,9 +639,8 @@ llvm::Optional<uint64_t> SwiftLanguageRuntimeImpl::GetMemberVariableOffset(
 
   llvm::Optional<SwiftASTContextReader> scratch_ctx;
   if (instance) {
-    if (SwiftASTContextReader reader = instance->GetScratchSwiftASTContext())
-      scratch_ctx = reader;
-    else
+    scratch_ctx = instance->GetScratchSwiftASTContext();
+    if (!scratch_ctx)
       return llvm::None;
   }
 


### PR DESCRIPTION
This reverts PR #1442 on swift/master, where a working implementation has already landed as #1440. The 5.3-specific variant is causing build errors:

```
17:14:59 FAILED: source/Target/CMakeFiles/lldbTarget.dir/SwiftLanguageRuntimeDynamicTypeResolution.cpp.o 
17:14:59 /usr/local/bin/sccache /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++  -DGTEST_HAS_RTTI=0 -DHAVE_ROUND -DLLDB_CONFIGURATION_RELEASE -DLLDB_USE_OS_LOG -D_DEBUG -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Isource/Target -I/Users/buildnode/jenkins/workspace/swift-PR-osx/branch-master/llvm-project/lldb/source/Target -Isource -I/Users/buildnode/jenkins/workspace/swift-PR-osx/branch-master/llvm-project/lldb/include -Iinclude -I/Users/buildnode/jenkins/workspace/swift-PR-osx/branch-master/llvm-project/llvm/include -I/Users/buildnode/jenkins/workspace/swift-PR-osx/branch-master/buildbot_incremental/llvm-macosx-x86_64/include -I/Users/buildnode/jenkins/workspace/swift-PR-osx/branch-master/llvm-project/clang/include -I/Users/buildnode/jenkins/workspace/swift-PR-osx/branch-master/buildbot_incremental/llvm-macosx-x86_64/tools/clang/include -I/Users/buildnode/jenkins/workspace/swift-PR-osx/branch-master/buildbot_incremental/swift-macosx-x86_64/include -I/Users/buildnode/jenkins/workspace/swift-PR-osx/branch-master/swift/include -I/Users/buildnode/jenkins/workspace/swift-PR-osx/branch-master/llvm-project/lldb/source -I/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.16.sdk/usr/include/python2.7 -I/Users/buildnode/jenkins/workspace/swift-PR-osx/branch-master/llvm-project/lldb/tools/clang/include -I../clang/include -I/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.16.sdk/usr/include/libxml2 -I/Users/buildnode/jenkins/workspace/swift-PR-osx/branch-master/llvm-project/lldb/source/. -Wno-unknown-warning-option -Werror=unguarded-availability-new -arch x86_64  -fno-stack-protector -fPIC -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -w -fdiagnostics-color -Wno-deprecated-declarations -Wno-unknown-pragmas -Wno-strict-aliasing -Wno-deprecated-register -Wno-vla-extension -O3  -isysroot /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.16.sdk -mmacosx-version-min=10.11   -UNDEBUG  -fno-exceptions -fno-rtti -std=c++14 -MD -MT source/Target/CMakeFiles/lldbTarget.dir/SwiftLanguageRuntimeDynamicTypeResolution.cpp.o -MF source/Target/CMakeFiles/lldbTarget.dir/SwiftLanguageRuntimeDynamicTypeResolution.cpp.o.d -o source/Target/CMakeFiles/lldbTarget.dir/SwiftLanguageRuntimeDynamicTypeResolution.cpp.o -c /Users/buildnode/jenkins/workspace/swift-PR-osx/branch-master/llvm-project/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
17:14:59 
/Users/buildnode/jenkins/workspace/swift-PR-osx/branch-master/llvm-project/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp:642:31: error: no viable conversion from 'llvm::Optional<SwiftASTContextReader>' to 'lldb_private::SwiftASTContextReader'
17:14:59     if (SwiftASTContextReader reader = instance->GetScratchSwiftASTContext())
17:14:59                               ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
17:14:59 /Users/buildnode/jenkins/workspace/swift-PR-osx/branch-master/llvm-project/lldb/include/lldb/Core/SwiftASTContextReader.h:103:3: note: candidate constructor not viable: no known conversion from 'llvm::Optional<SwiftASTContextReader>' to 'const lldb_private::SwiftASTContextReader &' for 1st argument
17:14:59   SwiftASTContextReader(const SwiftASTContextReader &copy)
17:14:59   ^
17:14:59 1 error generated.
```