### PR TITLE
Disable loading scalars as addresses when materializing an entity variable (swift/release/5.3)

### DIFF
--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -492,10 +492,7 @@ public:
       const bool is_dynamic_class_type =
           m_is_generic &&
           (valobj_type.GetTypeClass() == lldb::eTypeClassClass);
-      const bool scalar_is_load_address = m_is_generic; // this is the only
-                                                          // time we're dealing
-                                                          // with dynamic values
-
+      const bool scalar_is_load_address = false;
       // if the dynamic type is a class, bypass the GetAddressOf() optimization
       // as it doesn't do the right thing
       lldb::addr_t addr_of_valobj =

--- a/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
+++ b/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
@@ -24,7 +24,6 @@ class TestClassConstrainedProtocol(TestBase):
         self.do_self_test("Break here for weak self")
 
     @swiftTest
-    @expectedFailureAll(oslist=["linux"], bugnumber="rdar://31822722")
     def test_extension_self (self):
         """Test that we can reconstruct self in method of a class constrained protocol."""
         self.build()

--- a/lldb/test/API/lang/swift/expression/protocol_extension_self/Makefile
+++ b/lldb/test/API/lang/swift/expression/protocol_extension_self/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
+++ b/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
@@ -1,0 +1,18 @@
+
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class TestSwiftProtocolExtensionSelf(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    def test(self):
+        """Test that the generic self in a protocol extension works in the expression evaluator.
+        """
+        self.build()
+
+        lldbutil.run_to_source_breakpoint(self, "break here",
+                                          lldb.SBFileSpec('main.swift'))
+        self.expect("e f", substrs=[' = 12345'])

--- a/lldb/test/API/lang/swift/expression/protocol_extension_self/main.swift
+++ b/lldb/test/API/lang/swift/expression/protocol_extension_self/main.swift
@@ -1,0 +1,13 @@
+class C : CP {
+  let f: Int = 12345
+}
+
+protocol CP : class {}
+
+extension CP {
+  func foo() {
+    print(self)  // break here
+  }
+}
+
+C().foo()


### PR DESCRIPTION
@adrian-prantl 