### PR TITLE
Rename SerializedModuleLoader to match Swift compiler's new API.

### DIFF
--- a/lldb/include/lldb/Core/SwiftForward.h
+++ b/lldb/include/lldb/Core/SwiftForward.h
@@ -49,7 +49,7 @@ class NominalType;
 class NominalTypeDecl;
 class ProtocolDecl;
 class SearchPathOptions;
-class SerializedModuleLoader;
+class ImplicitSerializedModuleLoader;
 class ParseableInterfaceModuleLoader;
 class SILModule;
 class SILOptions;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3364,7 +3364,7 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
 
   // 3. Create and install the serialized module loader.
   std::unique_ptr<swift::ModuleLoader> serialized_module_loader_ap(
-      swift::SerializedModuleLoader::create(
+      swift::ImplicitSerializedModuleLoader::create(
           *m_ast_context_ap, m_dependency_tracker.get(), loading_mode));
   if (serialized_module_loader_ap)
     m_ast_context_ap->addModuleLoader(std::move(serialized_module_loader_ap));


### PR DESCRIPTION
https://github.com/apple/swift/pull/32903 makes some changes to the module loader structure, including a renaming of `SerializedModuleLoader` to `ImplicitSerializedModuleLoader`. This PR is a required companion to that change. 