### PR TITLE
lldb: repair the Windows build after #1447

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -48,7 +48,7 @@ class IRGenOptions;
 class NominalTypeDecl;
 class SearchPathOptions;
 class SILModule;
-class TBDGenOptions;
+struct TBDGenOptions;
 class VarDecl;
 class ModuleDecl;
 class SourceFile;


### PR DESCRIPTION
`TBDGenOptions` was forward declared as a `class` rather than `struct`.
The type mismatch causes a link failure as the type information is
encoded into the decorated name under the Microsoft ABI.  Switch the
forward declaration to match.