### PR TITLE
Patch in upstreamed support for tuple hashing

### DIFF
--- a/llvm/include/llvm/ADT/Hashing.h
+++ b/llvm/include/llvm/ADT/Hashing.h
@@ -121,9 +121,6 @@ hash_code hash_value(const std::tuple<Ts...> &arg);
 template <typename T>
 hash_code hash_value(const std::basic_string<T> &arg);
 
-/// \brief Compute a hash_code for a tuple.
-template <typename ...Ts>
-hash_code hash_value(const std::tuple<Ts...> &arg);
 
 /// Override the execution seed with a fixed value.
 ///
@@ -678,33 +675,6 @@ hash_code hash_value(const std::tuple<Ts...> &arg) {
 template <typename T>
 hash_code hash_value(const std::basic_string<T> &arg) {
   return hash_combine_range(arg.begin(), arg.end());
-}
-
-template<unsigned ...Indices>
-struct UnsignedConstantIndexSet { };
-
-template<unsigned I, unsigned N, unsigned ...Indices>
-struct MakeUnsignedConstantIndexSet {
-  typedef typename MakeUnsignedConstantIndexSet<I+1, N, Indices..., I>::Type
-    Type;
-};
-
-template<unsigned N, unsigned ...Indices>
-struct MakeUnsignedConstantIndexSet<N, N, Indices...> {
-  typedef UnsignedConstantIndexSet<Indices...> Type;
-};
-
-template <typename ...Ts, unsigned ...Indices>
-hash_code hash_value_tuple_helper(const std::tuple<Ts...> &arg,
-                                  UnsignedConstantIndexSet<Indices...> indices) {
-  return hash_combine(hash_value(std::get<Indices>(arg))...);
-}
-
-template <typename ...Ts>
-hash_code hash_value(const std::tuple<Ts...> &arg) {
-  return hash_value_tuple_helper(
-           arg, 
-           typename MakeUnsignedConstantIndexSet<0, sizeof...(Ts)>::Type());
 }
 
 } // namespace llvm

--- a/llvm/include/llvm/ADT/Hashing.h
+++ b/llvm/include/llvm/ADT/Hashing.h
@@ -113,6 +113,10 @@ template <typename T> hash_code hash_value(const T *ptr);
 template <typename T, typename U>
 hash_code hash_value(const std::pair<T, U> &arg);
 
+/// Compute a hash_code for a tuple.
+template <typename... Ts>
+hash_code hash_value(const std::tuple<Ts...> &arg);
+
 /// Compute a hash_code for a standard string.
 template <typename T>
 hash_code hash_value(const std::basic_string<T> &arg);
@@ -647,6 +651,26 @@ template <typename T> hash_code hash_value(const T *ptr) {
 template <typename T, typename U>
 hash_code hash_value(const std::pair<T, U> &arg) {
   return hash_combine(arg.first, arg.second);
+}
+
+// Implementation details for the hash_value overload for std::tuple<...>(...).
+namespace hashing {
+namespace detail {
+
+template <typename... Ts, std::size_t... Indices>
+hash_code hash_value_tuple_helper(const std::tuple<Ts...> &arg,
+                                  std::index_sequence<Indices...> indices) {
+  return hash_combine(std::get<Indices>(arg)...);
+}
+
+} // namespace detail
+} // namespace hashing
+
+template <typename... Ts>
+hash_code hash_value(const std::tuple<Ts...> &arg) {
+  // TODO: Use std::apply when LLVM starts using C++17.
+  return ::llvm::hashing::detail::hash_value_tuple_helper(
+      arg, typename std::index_sequence_for<Ts...>());
 }
 
 // Declared and documented above, but defined here so that any of the hashing

--- a/llvm/unittests/ADT/HashingTest.cpp
+++ b/llvm/unittests/ADT/HashingTest.cpp
@@ -101,6 +101,17 @@ TEST(HashingTest, HashValueStdPair) {
             hash_value(std::make_pair(obj1, std::make_pair(obj2, obj3))));
 }
 
+TEST(HashingTest, HashValueStdTuple) {
+  EXPECT_EQ(hash_combine(), hash_value(std::make_tuple()));
+  EXPECT_EQ(hash_combine(42), hash_value(std::make_tuple(42)));
+  EXPECT_EQ(hash_combine(42, 'c'), hash_value(std::make_tuple(42, 'c')));
+
+  EXPECT_NE(hash_combine(43, 42), hash_value(std::make_tuple(42, 43)));
+  EXPECT_NE(hash_combine(42, 43), hash_value(std::make_tuple(42ull, 43ull)));
+  EXPECT_NE(hash_combine(42, 43), hash_value(std::make_tuple(42, 43ull)));
+  EXPECT_NE(hash_combine(42, 43), hash_value(std::make_tuple(42ull, 43)));
+}
+
 TEST(HashingTest, HashValueStdString) {
   std::string s = "Hello World!";
   EXPECT_EQ(hash_combine_range(s.c_str(), s.c_str() + s.size()), hash_value(s));


### PR DESCRIPTION
[D83887](https://reviews.llvm.org/D83887) will land support for tuple hashing in LLVM. The previous implementation will not be needed any more and will lead to a compile error.

This change updates the `apple/master` branch proactively to prevent the automerger from breaking. This should be merged as a single squashed commit. 