### PR TITLE
[master-next] lldb: repair the Windows build after #1447

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -51,7 +51,7 @@ class IRGenOptions;
 class NominalTypeDecl;
 class SearchPathOptions;
 class SILModule;
-class TBDGenOptions;
+struct TBDGenOptions;
 class VarDecl;
 class ModuleDecl;
 class SourceFile;


### PR DESCRIPTION
master-next cherry-pick of https://github.com/apple/llvm-project/pull/1470/.