### PR TITLE
Move SwiftASTContext & TypeSystemSwift* into Plugins/TypeSystem/Swift

### DIFF
--- a/lldb/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/lldb/include/lldb/Target/SwiftLanguageRuntime.h
@@ -13,23 +13,20 @@
 #ifndef liblldb_SwiftLanguageRuntime_h_
 #define liblldb_SwiftLanguageRuntime_h_
 
-// C Includes
-// C++ Includes
-#include <mutex>
-#include <tuple>
-#include <vector>
-// Other libraries and framework includes
-// Project includes
 #include "Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "lldb/Breakpoint/BreakpointPrecondition.h"
 #include "lldb/Core/PluginInterface.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/LanguageRuntime.h"
 #include "lldb/lldb-private.h"
 
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Casting.h"
+
+#include <mutex>
+#include <tuple>
+#include <vector>
 
 namespace swift {
 namespace remote {

--- a/lldb/source/API/SystemInitializerFull.cpp
+++ b/lldb/source/API/SystemInitializerFull.cpp
@@ -17,6 +17,14 @@
 #include "lldb/Utility/Timer.h"
 #include "llvm/Support/TargetSelect.h"
 
+// BEGIN SWIFT
+#include "Plugins/ExpressionParser/Swift/SwiftREPL.h"
+#include "Plugins/InstrumentationRuntime/SwiftRuntimeReporting/SwiftRuntimeReporting.h"
+#include "Plugins/Language/Swift/SwiftLanguage.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
+#include "lldb/Target/SwiftLanguageRuntime.h"
+// END SWIFT
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wglobal-constructors"
 #include "llvm/ExecutionEngine/MCJIT.h"

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -54,7 +54,7 @@
 #include "Plugins/Language/ObjC/ObjCLanguage.h"
 
 #ifdef LLDB_ENABLE_SWIFT
-#include "lldb/Symbol/SwiftASTContext.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
 #endif // LLDB_ENABLE_SWIFT
 

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -52,7 +52,7 @@
 #include "lldb/lldb-private-types.h"
 
 // BEGIN SWIFT
-#include "lldb/Symbol/SwiftASTContext.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 // END SWIFT
 
 #include "llvm/Support/Compiler.h"

--- a/lldb/source/Core/ValueObjectDynamicValue.cpp
+++ b/lldb/source/Core/ValueObjectDynamicValue.cpp
@@ -10,7 +10,6 @@
 #include "lldb/Core/Value.h"
 #include "lldb/Core/ValueObject.h"
 #include "lldb/Symbol/CompilerType.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Symbol/Type.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/LanguageRuntime.h"
@@ -22,6 +21,8 @@
 #include "lldb/Utility/Scalar.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/lldb-types.h"
+
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 
 #include <string.h>
 namespace lldb_private {

--- a/lldb/source/Core/ValueObjectVariable.cpp
+++ b/lldb/source/Core/ValueObjectVariable.cpp
@@ -16,7 +16,6 @@
 #include "lldb/Symbol/Declaration.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/ObjectFile.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Symbol/SymbolContext.h"
 #include "lldb/Symbol/SymbolContextScope.h"
 #include "lldb/Symbol/Type.h"
@@ -32,6 +31,8 @@
 #include "lldb/Utility/Status.h"
 #include "lldb/lldb-private-enumerations.h"
 #include "lldb/lldb-types.h"
+
+#include "Plugins/TypeSystem/Swift/TypeSystemSwift.h"
 
 #include "llvm/ADT/StringRef.h"
 

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -12,7 +12,6 @@
 #include "lldb/Core/ValueObjectVariable.h"
 #include "lldb/Expression/ExpressionVariable.h"
 #include "lldb/Symbol/Symbol.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Symbol/Type.h"
 #include "lldb/Symbol/Variable.h"
 #include "lldb/Target/ExecutionContext.h"
@@ -23,6 +22,8 @@
 #include "lldb/Target/Thread.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/RegisterValue.h"
+
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 
 #include <memory>
 

--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -30,7 +30,6 @@
 #include "lldb/Symbol/Block.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/ObjectFile.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Symbol/SymbolVendor.h"
 #include "lldb/Symbol/Type.h"
 #include "lldb/Symbol/TypeSystem.h"
@@ -44,6 +43,8 @@
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/StreamString.h"
+
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 
 using namespace lldb_private;
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.cpp
@@ -18,7 +18,7 @@
 #include "lldb/Utility/StreamString.h"
 
 #ifdef LLDB_ENABLE_SWIFT
-#include "lldb/Symbol/SwiftASTContext.h" // Needed for llvm::isa<SwiftASTContext>(...)
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h" // Needed for llvm::isa<SwiftASTContext>(...)
 #include "lldb/Symbol/TypeSystem.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Pattern.h"

--- a/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
@@ -26,6 +26,7 @@ add_lldb_library(lldbPluginExpressionParserSwift PLUGIN
     lldbSymbol
     lldbTarget
     lldbUtility
+    lldbPluginTypeSystemSwift
     swiftAST
     swiftBasic
     swiftClangImporter

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -12,9 +12,9 @@
 
 #include "SwiftASTManipulator.h"
 
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "lldb/Expression/ExpressionParser.h"
 #include "lldb/Expression/ExpressionSourceCode.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/Log.h"

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -9,7 +9,7 @@
 #include "SwiftExpressionSourceCode.h"
 
 #include "Plugins/ExpressionParser/Swift/SwiftASTManipulator.h"
-#include "lldb/Symbol/SwiftASTContext.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "lldb/Target/Language.h"
 #include "lldb/Target/Platform.h"
 #include "lldb/Target/Target.h"

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
@@ -12,13 +12,10 @@
 
 #include "SwiftPersistentExpressionState.h"
 #include "SwiftExpressionVariable.h"
+
 #include "lldb/Expression/IRExecutionUnit.h"
-
 #include "lldb/Core/Value.h"
-
-#include "lldb/Symbol/SwiftASTContext.h" // Needed for llvm::isa<SwiftASTContext>(...)
 #include "lldb/Symbol/TypeSystem.h"
-
 #include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/StreamString.h"

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -14,6 +14,7 @@
 
 #include "SwiftExpressionVariable.h"
 
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
@@ -25,7 +26,6 @@
 #include "lldb/Interpreter/CommandInterpreter.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
 #include "lldb/Symbol/ObjectFile.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Symbol/SymbolVendor.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/Target.h"

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.h
@@ -13,9 +13,8 @@
 #ifndef liblldb_SwiftREPL_h_
 #define liblldb_SwiftREPL_h_
 
-#include "lldb/Symbol/SwiftASTContext.h"
-#include "lldb/Utility/Status.h"
 #include "lldb/Expression/REPL.h"
+#include "lldb/Utility/Status.h"
 #include "lldb/lldb-public.h"
 
 #include <string>
@@ -24,6 +23,7 @@
 namespace lldb_private {
 
 class IRExecutionUnit;
+class SwiftASTContextForExpressions;
 
 //----------------------------------------------------------------------
 /// @class SwiftREPL SwiftREPL.h "lldb/Expression/SwiftREPL.h"

--- a/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
@@ -24,7 +24,8 @@
 #include "lldb/Target/Thread.h"
 #include "lldb/Utility/RegularExpression.h"
 #ifdef LLDB_ENABLE_SWIFT
-#include "lldb/Symbol/SwiftASTContext.h"
+#include "Plugins/Process/Utility/HistoryThread.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/ClangImporter/ClangImporter.h"

--- a/lldb/source/Plugins/Language/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/Swift/CMakeLists.txt
@@ -23,6 +23,7 @@ add_lldb_library(lldbPluginSwiftLanguage PLUGIN
     lldbTarget
     lldbUtility
     lldbPluginObjCLanguage
+    lldbPluginTypeSystemSwift
     swiftAST
     swiftClangImporter
     clangAST

--- a/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -13,9 +13,9 @@
 #include "SwiftArray.h"
 
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
 #include "lldb/Target/Target.h"

--- a/lldb/source/Plugins/Language/Swift/SwiftDictionary.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftDictionary.cpp
@@ -13,8 +13,8 @@
 #include "SwiftDictionary.h"
 
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
 

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -14,9 +14,9 @@
 
 #include "Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
 #include "lldb/Utility/DataBufferHeap.h"

--- a/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
@@ -13,9 +13,9 @@
 #include "SwiftOptionSet.h"
 
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "lldb/Core/ValueObject.h"
 #include "lldb/Symbol/CompilerType.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Utility/StreamString.h"
 
 #include "swift/AST/Decl.h"

--- a/lldb/source/Plugins/Language/Swift/SwiftOptional.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptional.cpp
@@ -11,10 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "SwiftOptional.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "lldb/DataFormatters/DataVisualization.h"
 #include "lldb/DataFormatters/TypeSummary.h"
 #include "lldb/DataFormatters/ValueObjectPrinter.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
 #include "lldb/Utility/DataBufferHeap.h"

--- a/lldb/source/Plugins/Language/Swift/SwiftSet.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftSet.cpp
@@ -13,8 +13,8 @@
 #include "SwiftSet.h"
 
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
 

--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
@@ -1,7 +1,7 @@
 #include "SwiftUnsafeTypes.h"
 
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "lldb/DataFormatters/TypeSynthetic.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/Logging.h"

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -26,11 +26,11 @@
 #include "clang/AST/DeclObjC.h"
 
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/ObjectFile.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Symbol/SymbolVendor.h"
 #include "lldb/Symbol/Type.h"
 #include "lldb/Symbol/TypeMap.h"

--- a/lldb/source/Plugins/TypeSystem/CMakeLists.txt
+++ b/lldb/source/Plugins/TypeSystem/CMakeLists.txt
@@ -1,1 +1,5 @@
 add_subdirectory(Clang)
+
+if (LLDB_ENABLE_SWIFT_SUPPORT)
+  add_subdirectory(Swift)
+endif()

--- a/lldb/source/Plugins/TypeSystem/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/TypeSystem/Swift/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_lldb_library(lldbPluginTypeSystemSwift PLUGIN
+  TypeSystemSwift.cpp
+  TypeSystemSwiftTypeRef.cpp
+  SwiftASTContext.cpp
+
+  LINK_LIBS
+    lldbCore
+    lldbSymbol
+    lldbTarget
+    lldbUtility
+
+  LINK_COMPONENTS
+    Support
+)

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "lldb/Symbol/SwiftASTContext.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 
 // C++ Includes
 #include <mutex> // std::once
@@ -94,7 +94,6 @@
 #include "lldb/Core/DumpDataExtractor.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/ModuleSpec.h"
-#include "lldb/Core/PluginManager.h"
 #include "lldb/Core/Section.h"
 #include "lldb/Core/StreamFile.h"
 #include "lldb/Core/ThreadSafeDenseMap.h"
@@ -948,16 +947,6 @@ SwiftASTContext::~SwiftASTContext() {
 const std::string &SwiftASTContext::GetDescription() const {
   return m_description;
 }
-
-ConstString SwiftASTContext::GetPluginNameStatic() {
-  return ConstString("swift");
-}
-
-ConstString SwiftASTContext::GetPluginName() {
-  return TypeSystemClang::GetPluginNameStatic();
-}
-
-uint32_t SwiftASTContext::GetPluginVersion() { return 1; }
 
 namespace {
 struct SDKTypeMinVersion {
@@ -2255,36 +2244,6 @@ void SwiftASTContext::EnumerateSupportedLanguages(
   languages_for_expressions.insert(
       s_supported_languages_for_expressions.begin(),
       s_supported_languages_for_expressions.end());
-}
-
-static lldb::TypeSystemSP CreateTypeSystemInstance(lldb::LanguageType language,
-                                                   Module *module,
-                                                   Target *target,
-                                                   const char *extra_options) {
-  // This should be called with either a target or a module.
-  if (module) {
-    assert(!target);
-    assert(StringRef(extra_options).empty());
-    return SwiftASTContext::CreateInstance(language, *module);
-  } else if (target) {
-    assert(!module);
-    return SwiftASTContext::CreateInstance(language, *target, extra_options);
-  }
-  llvm_unreachable("Neither type nor module given to CreateTypeSystemInstance");
-}
-
-void SwiftASTContext::Initialize() {
-  LanguageSet swift;
-  SwiftLanguageRuntime::Initialize();
-  swift.Insert(lldb::eLanguageTypeSwift);
-  PluginManager::RegisterPlugin(GetPluginNameStatic(),
-                                "swift AST context plug-in",
-                                CreateTypeSystemInstance, swift, swift);
-}
-
-void SwiftASTContext::Terminate() {
-  PluginManager::UnregisterPlugin(CreateTypeSystemInstance);
-  SwiftLanguageRuntime::Terminate();
 }
 
 bool SwiftASTContext::SupportsLanguage(lldb::LanguageType language) {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -14,32 +14,14 @@
 #define liblldb_SwiftASTContext_h_
 
 #include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
+#include "Plugins/TypeSystem/Swift/TypeSystemSwift.h"
+#include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
 #include "lldb/Core/SwiftForward.h"
 #include "lldb/Core/ThreadSafeDenseMap.h"
 #include "lldb/Core/ThreadSafeDenseSet.h"
-#include "lldb/Symbol/CompilerType.h"
-#include "lldb/Symbol/SymbolFile.h"
-#include "lldb/Symbol/TypeSystem.h"
-#include "lldb/Utility/ConstString.h"
-#include "lldb/lldb-private.h"
-
 #include "lldb/Utility/Either.h"
-#include "lldb/Utility/Status.h"
-
-#include "llvm/ADT/Optional.h"
-#include "llvm/Support/Threading.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Target/TargetOptions.h"
-
-// FIXME: needed only for the DenseMap.
-#include "clang/Basic/Module.h"
-#include "clang/APINotes/APINotesManager.h"
-
-#include <map>
-#include <set>
-
-namespace llvm {
-class LLVMContext;
-}
 
 namespace swift {
 enum class IRGenDebugInfoLevel : unsigned;
@@ -81,6 +63,10 @@ class APINotesManager;
 }
 } // namespace clang
 
+namespace llvm {
+class LLVMContext;
+}
+
 class DWARFASTParser;
 class SwiftEnumDescriptor;
 
@@ -91,437 +77,6 @@ class SwiftASTContext;
 class ClangExternalASTSourceCallbacks;
 
 CompilerType ToCompilerType(swift::Type qual_type);
-
-/// The implementation of lldb::Type's m_payload field for TypeSystemSwift.
-class TypePayloadSwift {
-  /// Layout: bit 1 ... IsFixedValueBuffer.
-  Type::Payload m_payload = 0;
-
-  static constexpr unsigned FixedValueBufferBit = 1;
-
-public:
-  TypePayloadSwift() = default;
-  explicit TypePayloadSwift(bool is_fixed_value_buffer);
-  explicit TypePayloadSwift(Type::Payload opaque_payload)
-      : m_payload(opaque_payload) {}
-  operator Type::Payload() { return m_payload; }
-
-  /// \return whether this is a Swift fixed-size buffer. Resilient variables in
-  /// fixed-size buffers may be indirect depending on the runtime size of the
-  /// type. This is more a property of the value than of its type.
-  bool IsFixedValueBuffer() {
-    return Flags(m_payload).Test(FixedValueBufferBit);
-  }
-  void SetIsFixedValueBuffer(bool is_fixed_value_buffer) {
-    m_payload = is_fixed_value_buffer
-                    ? Flags(m_payload).Set(FixedValueBufferBit)
-                    : Flags(m_payload).Clear(FixedValueBufferBit);
-  }
-};
-
-/// Abstract base class for all Swift TypeSystems.
-///
-/// Swift CompilerTypes are either a mangled name or a Swift AST
-/// type. If the typesystem is a TypeSystemSwiftTypeRef, they are
-/// mangled names.
-///
-/// \verbatim
-///                      TypeSystem (abstract)
-///                            │
-///                            ↓
-///                      TypeSystemSwift (abstract)
-///                        │         │
-///                        ↓         ↓
-///    TypeSystemSwiftTypeRef ⟷ SwiftASTContext (deprecated)
-///                                  │
-///                                  ↓
-///                               SwiftASTContextForExpressions
-///
-/// \endverbatim
-class TypeSystemSwift : public TypeSystem {
-  /// LLVM RTTI support.
-  static char ID;
-
-public:
-  /// LLVM RTTI support.
-  /// \{
-  bool isA(const void *ClassID) const override { return ClassID == &ID; }
-  static bool classof(const TypeSystem *ts) { return ts->isA(&ID); }
-  /// \}
-
-  TypeSystemSwift();
-
-  virtual lldb::TypeSP GetCachedType(ConstString mangled) = 0;
-  virtual void SetCachedType(ConstString mangled,
-                             const lldb::TypeSP &type_sp) = 0;
-  virtual bool IsImportedType(lldb::opaque_compiler_type_t type,
-                              CompilerType *original_type) = 0;
-  virtual CompilerType GetErrorType() = 0;
-  virtual CompilerType GetReferentType(lldb::opaque_compiler_type_t type) = 0;
-  static CompilerType GetInstanceType(CompilerType ct);
-  virtual CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) = 0;
-  enum class TypeAllocationStrategy { eInline, ePointer, eDynamic, eUnknown };
-  virtual TypeAllocationStrategy
-  GetAllocationStrategy(lldb::opaque_compiler_type_t type) = 0;
-  struct TupleElement {
-    ConstString element_name;
-    CompilerType element_type;
-  };
-  virtual CompilerType
-  CreateTupleType(const std::vector<TupleElement> &elements) = 0;
-  virtual void DumpTypeDescription(
-      lldb::opaque_compiler_type_t type, bool print_help_if_available,
-      bool print_extensions_if_available,
-      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) = 0;
-  virtual void DumpTypeDescription(
-      lldb::opaque_compiler_type_t type, Stream *s,
-      bool print_help_if_available, bool print_extensions_if_available,
-      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) = 0;
-  virtual CompilerType
-  GetTypeFromMangledTypename(ConstString mangled_typename) = 0;
-
-  /// Unavailable hardcoded functions that don't make sense for Swift.
-  /// \{
-  ConstString DeclContextGetName(void *opaque_decl_ctx) override { return {}; }
-  ConstString DeclContextGetScopeQualifiedName(void *opaque_decl_ctx) override {
-    return {};
-  }
-  bool
-  DeclContextIsClassMethod(void *opaque_decl_ctx,
-                           lldb::LanguageType *language_ptr,
-                           bool *is_instance_method_ptr,
-                           ConstString *language_object_name_ptr) override {
-    return false;
-  }
-  bool IsRuntimeGeneratedType(lldb::opaque_compiler_type_t type) override {
-    return false;
-  }
-  bool IsCharType(lldb::opaque_compiler_type_t type) override { return false; }
-  bool IsCompleteType(lldb::opaque_compiler_type_t type) override {
-    return true;
-  }
-  bool IsConst(lldb::opaque_compiler_type_t type) override { return false; }
-  bool IsCStringType(lldb::opaque_compiler_type_t type,
-                     uint32_t &length) override {
-    return false;
-  }
-  bool IsVectorType(lldb::opaque_compiler_type_t type,
-                    CompilerType *element_type, uint64_t *size) override {
-    return false;
-  }
-  uint32_t IsHomogeneousAggregate(lldb::opaque_compiler_type_t type,
-                                  CompilerType *base_type_ptr) override {
-    return 0;
-  }
-  bool IsBlockPointerType(lldb::opaque_compiler_type_t type,
-                          CompilerType *function_pointer_type_ptr) override {
-    return false;
-  }
-  bool IsPolymorphicClass(lldb::opaque_compiler_type_t type) override {
-    return false;
-  }
-  bool IsBeingDefined(lldb::opaque_compiler_type_t type) override {
-    return false;
-  }
-  bool CanPassInRegisters(const CompilerType &type) override {
-    // FIXME: Implement this. There was an abort() here to figure out which
-    // tests where hitting this code. At least TestSwiftReturns and
-    // TestSwiftStepping were failing because of this Darwin.
-    return false;
-  }
-  unsigned GetTypeQualifiers(lldb::opaque_compiler_type_t type) override {
-    return 0;
-  }
-  CompilerType
-  GetTypeForDecl(lldb::opaque_compiler_type_t opaque_decl) override {
-    llvm_unreachable("GetTypeForDecl not implemented");
-  }
-  CompilerType GetBasicTypeFromAST(lldb::BasicType basic_type) override {
-    return {};
-  }
-  const llvm::fltSemantics &GetFloatTypeSemantics(size_t byte_size) override {
-    // See: https://reviews.llvm.org/D67239. At this time of writing this API
-    // is only used by DumpDataExtractor for the C type system.
-    llvm_unreachable("GetFloatTypeSemantics not implemented.");
-  }
-  lldb::BasicType
-  GetBasicTypeEnumeration(lldb::opaque_compiler_type_t type) override {
-    return lldb::eBasicTypeInvalid;
-  }
-  uint32_t
-  GetNumVirtualBaseClasses(lldb::opaque_compiler_type_t opaque_type) override {
-    return 0;
-  }
-  CompilerType
-  GetVirtualBaseClassAtIndex(lldb::opaque_compiler_type_t opaque_type,
-                             size_t idx, uint32_t *bit_offset_ptr) override {
-    return {};
-  }
-  /// \}
-protected:
-  /// Used in the logs.
-  std::string m_description;
-};
-
-/// A Swift TypeSystem that does not own a swift::ASTContext.
-class TypeSystemSwiftTypeRef : public TypeSystemSwift {
-  /// LLVM RTTI support.
-  static char ID;
-
-public:
-  /// LLVM RTTI support.
-  /// \{
-  bool isA(const void *ClassID) const override {
-    return ClassID == &ID || TypeSystemSwift::isA(ClassID);
-  }
-  static bool classof(const TypeSystem *ts) { return ts->isA(&ID); }
-  /// \}
-
-  TypeSystemSwiftTypeRef(SwiftASTContext *swift_ast_context);
-
-  Module *GetModule() const;
-  swift::CanType GetCanonicalSwiftType(CompilerType compiler_type);
-  swift::Type GetSwiftType(CompilerType compiler_type);
-  CompilerType ReconstructType(CompilerType type);
-  CompilerType
-  GetTypeFromMangledTypename(ConstString mangled_typename) override;
-
-  // PluginInterface functions
-  ConstString GetPluginName() override;
-  uint32_t GetPluginVersion() override;
-
-  bool SupportsLanguage(lldb::LanguageType language) override;
-  Status IsCompatible() override;
-
-  void DiagnoseWarnings(Process &process, Module &module) const override;
-  DWARFASTParser *GetDWARFParser() override;
-  // CompilerDecl functions
-  ConstString DeclGetName(void *opaque_decl) override {
-    return ConstString("");
-  }
-
-  // CompilerDeclContext functions
-  std::vector<CompilerDecl>
-  DeclContextFindDeclByName(void *opaque_decl_ctx, ConstString name,
-                            const bool ignore_imported_decls) override {
-    return {};
-  }
-
-  bool DeclContextIsContainedInLookup(void *opaque_decl_ctx,
-                                      void *other_opaque_decl_ctx) override {
-    if (opaque_decl_ctx == other_opaque_decl_ctx)
-      return true;
-    return false;
-  }
-
-  // Tests
-#ifndef NDEBUG
-  bool Verify(lldb::opaque_compiler_type_t type) override;
-#endif
-  bool IsArrayType(lldb::opaque_compiler_type_t type,
-                   CompilerType *element_type, uint64_t *size,
-                   bool *is_incomplete) override;
-  bool IsAggregateType(lldb::opaque_compiler_type_t type) override;
-  bool IsDefined(lldb::opaque_compiler_type_t type) override;
-  bool IsFloatingPointType(lldb::opaque_compiler_type_t type, uint32_t &count,
-                           bool &is_complex) override;
-  bool IsFunctionType(lldb::opaque_compiler_type_t type,
-                      bool *is_variadic_ptr) override;
-  size_t
-  GetNumberOfFunctionArguments(lldb::opaque_compiler_type_t type) override;
-  CompilerType GetFunctionArgumentAtIndex(lldb::opaque_compiler_type_t type,
-                                          const size_t index) override;
-  bool IsFunctionPointerType(lldb::opaque_compiler_type_t type) override;
-  bool IsIntegerType(lldb::opaque_compiler_type_t type,
-                     bool &is_signed) override;
-  bool IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
-                             CompilerType *target_type, // Can pass NULL
-                             bool check_cplusplus, bool check_objc) override;
-  bool IsPointerType(lldb::opaque_compiler_type_t type,
-                     CompilerType *pointee_type) override;
-  bool IsScalarType(lldb::opaque_compiler_type_t type) override;
-  bool IsVoidType(lldb::opaque_compiler_type_t type) override;
-  // Type Completion
-  bool GetCompleteType(lldb::opaque_compiler_type_t type) override;
-  // AST related queries
-  uint32_t GetPointerByteSize() override;
-  // Accessors
-  ConstString GetTypeName(lldb::opaque_compiler_type_t type) override;
-  ConstString GetDisplayTypeName(lldb::opaque_compiler_type_t type,
-                                 const SymbolContext *sc) override;
-  ConstString GetMangledTypeName(lldb::opaque_compiler_type_t type) override;
-  uint32_t GetTypeInfo(lldb::opaque_compiler_type_t type,
-                       CompilerType *pointee_or_element_clang_type) override;
-  lldb::LanguageType
-  GetMinimumLanguage(lldb::opaque_compiler_type_t type) override;
-  lldb::TypeClass GetTypeClass(lldb::opaque_compiler_type_t type) override;
-
-  // Creating related types
-  CompilerType GetArrayElementType(lldb::opaque_compiler_type_t type,
-                                   uint64_t *stride) override;
-  CompilerType GetCanonicalType(lldb::opaque_compiler_type_t type) override;
-  int GetFunctionArgumentCount(lldb::opaque_compiler_type_t type) override;
-  CompilerType GetFunctionArgumentTypeAtIndex(lldb::opaque_compiler_type_t type,
-                                              size_t idx) override;
-  CompilerType
-  GetFunctionReturnType(lldb::opaque_compiler_type_t type) override;
-  size_t GetNumMemberFunctions(lldb::opaque_compiler_type_t type) override;
-  TypeMemberFunctionImpl
-  GetMemberFunctionAtIndex(lldb::opaque_compiler_type_t type,
-                           size_t idx) override;
-  CompilerType GetPointeeType(lldb::opaque_compiler_type_t type) override;
-  CompilerType GetPointerType(lldb::opaque_compiler_type_t type) override;
-
-  // Exploring the type
-  llvm::Optional<uint64_t>
-  GetBitSize(lldb::opaque_compiler_type_t type,
-             ExecutionContextScope *exe_scope) override;
-  llvm::Optional<uint64_t>
-  GetByteStride(lldb::opaque_compiler_type_t type,
-                ExecutionContextScope *exe_scope) override;
-  lldb::Encoding GetEncoding(lldb::opaque_compiler_type_t type,
-                             uint64_t &count) override;
-  lldb::Format GetFormat(lldb::opaque_compiler_type_t type) override;
-  uint32_t GetNumChildren(lldb::opaque_compiler_type_t type,
-                          bool omit_empty_base_classes,
-                          const ExecutionContext *exe_ctx) override;
-  uint32_t GetNumFields(lldb::opaque_compiler_type_t type) override;
-  CompilerType GetFieldAtIndex(lldb::opaque_compiler_type_t type, size_t idx,
-                               std::string &name, uint64_t *bit_offset_ptr,
-                               uint32_t *bitfield_bit_size_ptr,
-                               bool *is_bitfield_ptr) override;
-  CompilerType GetChildCompilerTypeAtIndex(
-      lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
-      bool transparent_pointers, bool omit_empty_base_classes,
-      bool ignore_array_bounds, std::string &child_name,
-      uint32_t &child_byte_size, int32_t &child_byte_offset,
-      uint32_t &child_bitfield_bit_size, uint32_t &child_bitfield_bit_offset,
-      bool &child_is_base_class, bool &child_is_deref_of_parent,
-      ValueObject *valobj, uint64_t &language_flags) override;
-  uint32_t GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
-                                   const char *name,
-                                   bool omit_empty_base_classes) override;
-  size_t
-  GetIndexOfChildMemberWithName(lldb::opaque_compiler_type_t type,
-                                const char *name, bool omit_empty_base_classes,
-                                std::vector<uint32_t> &child_indexes) override;
-  size_t GetNumTemplateArguments(lldb::opaque_compiler_type_t type) override;
-  CompilerType GetTypeForFormatters(lldb::opaque_compiler_type_t type) override;
-  LazyBool ShouldPrintAsOneLiner(lldb::opaque_compiler_type_t type,
-                                 ValueObject *valobj) override;
-  bool IsMeaninglessWithoutDynamicResolution(
-      lldb::opaque_compiler_type_t type) override;
-
-  // Dumping types
-#ifndef NDEBUG
-  /// Convenience LLVM-style dump method for use in the debugger only.
-  LLVM_DUMP_METHOD virtual void
-  dump(lldb::opaque_compiler_type_t type) const override;
-#endif
-
-  void DumpValue(lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
-                 Stream *s, lldb::Format format, const DataExtractor &data,
-                 lldb::offset_t data_offset, size_t data_byte_size,
-                 uint32_t bitfield_bit_size, uint32_t bitfield_bit_offset,
-                 bool show_types, bool show_summary, bool verbose,
-                 uint32_t depth) override;
-
-  bool DumpTypeValue(lldb::opaque_compiler_type_t type, Stream *s,
-                     lldb::Format format, const DataExtractor &data,
-                     lldb::offset_t data_offset, size_t data_byte_size,
-                     uint32_t bitfield_bit_size, uint32_t bitfield_bit_offset,
-                     ExecutionContextScope *exe_scope,
-                     bool is_base_class) override;
-
-  void DumpTypeDescription(
-      lldb::opaque_compiler_type_t type,
-      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
-  void DumpTypeDescription(
-      lldb::opaque_compiler_type_t type, Stream *s,
-      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
-  void DumpSummary(lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
-                   Stream *s, const DataExtractor &data,
-                   lldb::offset_t data_offset, size_t data_byte_size) override;
-  bool IsPointerOrReferenceType(lldb::opaque_compiler_type_t type,
-                                CompilerType *pointee_type) override;
-  llvm::Optional<size_t>
-  GetTypeBitAlign(lldb::opaque_compiler_type_t type,
-                  ExecutionContextScope *exe_scope) override;
-  CompilerType GetBuiltinTypeForEncodingAndBitSize(lldb::Encoding encoding,
-                                                   size_t bit_size) override {
-    return CompilerType();
-  }
-  bool IsTypedefType(lldb::opaque_compiler_type_t type) override;
-  CompilerType GetTypedefedType(lldb::opaque_compiler_type_t type) override;
-  CompilerType
-  GetFullyUnqualifiedType(lldb::opaque_compiler_type_t type) override;
-  CompilerType GetNonReferenceType(lldb::opaque_compiler_type_t type) override;
-  CompilerType
-  GetLValueReferenceType(lldb::opaque_compiler_type_t type) override;
-  CompilerType
-  GetRValueReferenceType(lldb::opaque_compiler_type_t type) override;
-  uint32_t GetNumDirectBaseClasses(lldb::opaque_compiler_type_t type) override;
-  CompilerType GetDirectBaseClassAtIndex(lldb::opaque_compiler_type_t type,
-                                         size_t idx,
-                                         uint32_t *bit_offset_ptr) override;
-  bool IsReferenceType(lldb::opaque_compiler_type_t type,
-                       CompilerType *pointee_type, bool *is_rvalue) override;
-  bool
-  ShouldTreatScalarValueAsAddress(lldb::opaque_compiler_type_t type) override;
-
-  // Swift-specific methods.
-  lldb::TypeSP GetCachedType(ConstString mangled) override;
-  void SetCachedType(ConstString mangled, const lldb::TypeSP &type_sp) override;
-  bool IsImportedType(lldb::opaque_compiler_type_t type,
-                      CompilerType *original_type) override;
-  CompilerType GetErrorType() override;
-  CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
-  CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) override;
-  TypeAllocationStrategy
-  GetAllocationStrategy(lldb::opaque_compiler_type_t type) override;
-  CompilerType
-  CreateTupleType(const std::vector<TupleElement> &elements) override;
-  void DumpTypeDescription(
-      lldb::opaque_compiler_type_t type, bool print_help_if_available,
-      bool print_extensions_if_available,
-      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
-  void DumpTypeDescription(
-      lldb::opaque_compiler_type_t type, Stream *s,
-      bool print_help_if_available, bool print_extensions_if_available,
-      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
-
-private:
-  /// Helper that creates an AST type from \p type.
-  void *ReconstructType(lldb::opaque_compiler_type_t type);
-  /// Cast \p opaque_type as a mangled name.
-  const char *AsMangledName(lldb::opaque_compiler_type_t opaque_type);
-
-  /// Wrap \p node as \p Global(TypeMangling(node)), remangle the type
-  /// and create a CompilerType from it.
-  CompilerType RemangleAsType(swift::Demangle::Demangler &Dem,
-                              swift::Demangle::NodePointer node);
-
-  /// Demangle the mangled name of the canonical type of \p type and
-  /// drill into the Global(TypeMangling(Type())).
-  ///
-  /// \return the child of Type or a nullptr.
-  swift::Demangle::NodePointer
-  DemangleCanonicalType(swift::Demangle::Demangler &Dem,
-                        lldb::opaque_compiler_type_t type);
-
-  /// Return an APINotes manager for the module with module id \id.
-  /// APINotes are used to get at the SDK swiftification annotations.
-  clang::api_notes::APINotesManager *
-  GetAPINotesManager(ClangExternalASTSourceCallbacks *source, unsigned id);
-
-  /// The sibling SwiftASTContext.
-  SwiftASTContext *m_swift_ast_context = nullptr;
-
-  /// The APINotesManager responsible for each Clang module.
-  llvm::DenseMap<clang::Module *,
-                 std::unique_ptr<clang::api_notes::APINotesManager>>
-      m_apinotes_manager;
-};
 
 /// This "middle" class between TypeSystemSwiftTypeRef and
 /// SwiftASTContextForExpressions will eventually go away, as more and
@@ -598,13 +153,6 @@ public:
 
   const std::string &GetDescription() const;
 
-  // PluginInterface functions
-  ConstString GetPluginName() override;
-
-  uint32_t GetPluginVersion() override;
-
-  static ConstString GetPluginNameStatic();
-
   /// Create a SwiftASTContext from a Module.  This context is used
   /// for frame variable and uses ClangImporter options specific to
   /// this lldb::Module.  The optional target is necessary when
@@ -623,10 +171,6 @@ public:
   static void EnumerateSupportedLanguages(
       std::set<lldb::LanguageType> &languages_for_types,
       std::set<lldb::LanguageType> &languages_for_expressions);
-
-  static void Initialize();
-
-  static void Terminate();
 
   bool SupportsLanguage(lldb::LanguageType language) override;
 
@@ -1205,12 +749,10 @@ public:
   /// Retrieves the modules that need to be implicitly imported in a given
   /// execution scope. This includes the modules imported by both the compile
   /// unit as well as any imports from previous expression evaluations.
-  static bool
-  GetImplicitImports(SwiftASTContext &swift_ast_context, SymbolContext &sc,
-                     ExecutionContextScope &exe_scope,
-                     lldb::StackFrameWP &stack_frame_wp,
-                     llvm::SmallVectorImpl<swift::ModuleDecl *> &modules,
-                     Status &error);
+  static bool GetImplicitImports(
+      SwiftASTContext &swift_ast_context, SymbolContext &sc,
+      ExecutionContextScope &exe_scope, lldb::StackFrameWP &stack_frame_wp,
+      llvm::SmallVectorImpl<swift::ModuleDecl *> &modules, Status &error);
 
   /// Cache the user's imports from a SourceFile in a given execution scope such
   /// that they are carried over into future expression evaluations.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -1,0 +1,60 @@
+//===-- TypeSystemSwift.cpp ==---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "Plugins/TypeSystem/Swift/TypeSystemSwift.h"
+
+#include "lldb/Core/PluginManager.h"
+#include "lldb/Target/SwiftLanguageRuntime.h"
+
+LLDB_PLUGIN_DEFINE(TypeSystemSwift)
+
+using namespace lldb_private;
+
+static lldb::TypeSystemSP CreateTypeSystemInstance(lldb::LanguageType language,
+                                                   Module *module,
+                                                   Target *target,
+                                                   const char *extra_options) {
+  // This should be called with either a target or a module.
+  if (module) {
+    assert(!target);
+    assert(StringRef(extra_options).empty());
+    return SwiftASTContext::CreateInstance(language, *module);
+  } else if (target) {
+    assert(!module);
+    return SwiftASTContext::CreateInstance(language, *target, extra_options);
+  }
+  llvm_unreachable("Neither type nor module given to CreateTypeSystemInstance");
+}
+
+void TypeSystemSwift::Initialize() {
+  LanguageSet swift;
+  SwiftLanguageRuntime::Initialize();
+  swift.Insert(lldb::eLanguageTypeSwift);
+  PluginManager::RegisterPlugin(GetPluginNameStatic(),
+                                "Swift type system and AST context plug-in",
+                                CreateTypeSystemInstance, swift, swift);
+}
+
+void TypeSystemSwift::Terminate() {
+  PluginManager::UnregisterPlugin(CreateTypeSystemInstance);
+  SwiftLanguageRuntime::Terminate();
+}
+
+ConstString TypeSystemSwift::GetPluginNameStatic() {
+  return ConstString("swift");
+}
+
+ConstString TypeSystemSwift::GetPluginName() {
+  return TypeSystemSwift::GetPluginNameStatic();
+}
+
+uint32_t TypeSystemSwift::GetPluginVersion() { return 1; }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -1,0 +1,207 @@
+//===-- TypeSystemSwift.h ---------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_TypeSystemSwift_h_
+#define liblldb_TypeSystemSwift_h_
+
+#include "lldb/Symbol/CompilerType.h"
+#include "lldb/Symbol/SymbolFile.h"
+#include "lldb/Symbol/Type.h"
+#include "lldb/Symbol/TypeSystem.h"
+#include "lldb/Utility/ConstString.h"
+#include "lldb/Utility/Flags.h"
+#include "lldb/lldb-private.h"
+
+namespace lldb_private {
+
+/// The implementation of lldb::Type's m_payload field for TypeSystemSwift.
+class TypePayloadSwift {
+  /// Layout: bit 1 ... IsFixedValueBuffer.
+  Type::Payload m_payload = 0;
+
+  static constexpr unsigned FixedValueBufferBit = 1;
+
+public:
+  TypePayloadSwift() = default;
+  explicit TypePayloadSwift(bool is_fixed_value_buffer);
+  explicit TypePayloadSwift(Type::Payload opaque_payload)
+      : m_payload(opaque_payload) {}
+  operator Type::Payload() { return m_payload; }
+
+  /// \return whether this is a Swift fixed-size buffer. Resilient variables in
+  /// fixed-size buffers may be indirect depending on the runtime size of the
+  /// type. This is more a property of the value than of its type.
+  bool IsFixedValueBuffer() {
+    return Flags(m_payload).Test(FixedValueBufferBit);
+  }
+  void SetIsFixedValueBuffer(bool is_fixed_value_buffer) {
+    m_payload = is_fixed_value_buffer
+                    ? Flags(m_payload).Set(FixedValueBufferBit)
+                    : Flags(m_payload).Clear(FixedValueBufferBit);
+  }
+};
+
+/// Abstract base class for all Swift TypeSystems.
+///
+/// Swift CompilerTypes are either a mangled name or a Swift AST
+/// type. If the typesystem is a TypeSystemSwiftTypeRef, they are
+/// mangled names.
+///
+/// \verbatim
+///                      TypeSystem (abstract)
+///                            │
+///                            ↓
+///                      TypeSystemSwift (abstract)
+///                        │         │
+///                        ↓         ↓
+///    TypeSystemSwiftTypeRef ⟷ SwiftASTContext (deprecated)
+///                                  │
+///                                  ↓
+///                               SwiftASTContextForExpressions
+///
+/// \endverbatim
+class TypeSystemSwift : public TypeSystem {
+  /// LLVM RTTI support.
+  static char ID;
+
+public:
+  /// LLVM RTTI support.
+  /// \{
+  bool isA(const void *ClassID) const override { return ClassID == &ID; }
+  static bool classof(const TypeSystem *ts) { return ts->isA(&ID); }
+  /// \}
+
+  TypeSystemSwift();
+
+  /// PluginInterface functions.
+  /// \{
+  static void Initialize();
+  static void Terminate();
+  ConstString GetPluginName() override;
+  uint32_t GetPluginVersion() override;
+  static ConstString GetPluginNameStatic();
+  /// \}
+
+  virtual lldb::TypeSP GetCachedType(ConstString mangled) = 0;
+  virtual void SetCachedType(ConstString mangled,
+                             const lldb::TypeSP &type_sp) = 0;
+  virtual bool IsImportedType(lldb::opaque_compiler_type_t type,
+                              CompilerType *original_type) = 0;
+  virtual CompilerType GetErrorType() = 0;
+  virtual CompilerType GetReferentType(lldb::opaque_compiler_type_t type) = 0;
+  static CompilerType GetInstanceType(CompilerType ct);
+  virtual CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) = 0;
+  enum class TypeAllocationStrategy { eInline, ePointer, eDynamic, eUnknown };
+  virtual TypeAllocationStrategy
+  GetAllocationStrategy(lldb::opaque_compiler_type_t type) = 0;
+  struct TupleElement {
+    ConstString element_name;
+    CompilerType element_type;
+  };
+  virtual CompilerType
+  CreateTupleType(const std::vector<TupleElement> &elements) = 0;
+  virtual void DumpTypeDescription(
+      lldb::opaque_compiler_type_t type, bool print_help_if_available,
+      bool print_extensions_if_available,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) = 0;
+  virtual void DumpTypeDescription(
+      lldb::opaque_compiler_type_t type, Stream *s,
+      bool print_help_if_available, bool print_extensions_if_available,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) = 0;
+  virtual CompilerType
+  GetTypeFromMangledTypename(ConstString mangled_typename) = 0;
+
+  /// Unavailable hardcoded functions that don't make sense for Swift.
+  /// \{
+  ConstString DeclContextGetName(void *opaque_decl_ctx) override { return {}; }
+  ConstString DeclContextGetScopeQualifiedName(void *opaque_decl_ctx) override {
+    return {};
+  }
+  bool
+  DeclContextIsClassMethod(void *opaque_decl_ctx,
+                           lldb::LanguageType *language_ptr,
+                           bool *is_instance_method_ptr,
+                           ConstString *language_object_name_ptr) override {
+    return false;
+  }
+  bool IsRuntimeGeneratedType(lldb::opaque_compiler_type_t type) override {
+    return false;
+  }
+  bool IsCharType(lldb::opaque_compiler_type_t type) override { return false; }
+  bool IsCompleteType(lldb::opaque_compiler_type_t type) override {
+    return true;
+  }
+  bool IsConst(lldb::opaque_compiler_type_t type) override { return false; }
+  bool IsCStringType(lldb::opaque_compiler_type_t type,
+                     uint32_t &length) override {
+    return false;
+  }
+  bool IsVectorType(lldb::opaque_compiler_type_t type,
+                    CompilerType *element_type, uint64_t *size) override {
+    return false;
+  }
+  uint32_t IsHomogeneousAggregate(lldb::opaque_compiler_type_t type,
+                                  CompilerType *base_type_ptr) override {
+    return 0;
+  }
+  bool IsBlockPointerType(lldb::opaque_compiler_type_t type,
+                          CompilerType *function_pointer_type_ptr) override {
+    return false;
+  }
+  bool IsPolymorphicClass(lldb::opaque_compiler_type_t type) override {
+    return false;
+  }
+  bool IsBeingDefined(lldb::opaque_compiler_type_t type) override {
+    return false;
+  }
+  bool CanPassInRegisters(const CompilerType &type) override {
+    // FIXME: Implement this. There was an abort() here to figure out which
+    // tests where hitting this code. At least TestSwiftReturns and
+    // TestSwiftStepping were failing because of this Darwin.
+    return false;
+  }
+  unsigned GetTypeQualifiers(lldb::opaque_compiler_type_t type) override {
+    return 0;
+  }
+  CompilerType
+  GetTypeForDecl(lldb::opaque_compiler_type_t opaque_decl) override {
+    llvm_unreachable("GetTypeForDecl not implemented");
+  }
+  CompilerType GetBasicTypeFromAST(lldb::BasicType basic_type) override {
+    return {};
+  }
+  const llvm::fltSemantics &GetFloatTypeSemantics(size_t byte_size) override {
+    // See: https://reviews.llvm.org/D67239. At this time of writing this API
+    // is only used by DumpDataExtractor for the C type system.
+    llvm_unreachable("GetFloatTypeSemantics not implemented.");
+  }
+  lldb::BasicType
+  GetBasicTypeEnumeration(lldb::opaque_compiler_type_t type) override {
+    return lldb::eBasicTypeInvalid;
+  }
+  uint32_t
+  GetNumVirtualBaseClasses(lldb::opaque_compiler_type_t opaque_type) override {
+    return 0;
+  }
+  CompilerType
+  GetVirtualBaseClassAtIndex(lldb::opaque_compiler_type_t opaque_type,
+                             size_t idx, uint32_t *bit_offset_ptr) override {
+    return {};
+  }
+  /// \}
+protected:
+  /// Used in the logs.
+  std::string m_description;
+};
+
+} // namespace lldb_private
+#endif

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "lldb/Symbol/SwiftASTContext.h"
+#include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
 
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/TypeList.h"

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -1,0 +1,292 @@
+//===-- TypeSystemSwiftTypeRef.h --------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_TypeSystemSwiftTypeRef_h_
+#define liblldb_TypeSystemSwiftTypeRef_h_
+
+#include "Plugins/TypeSystem/Swift/TypeSystemSwift.h"
+#include "lldb/Core/SwiftForward.h"
+
+#include "swift/AST/Type.h"
+#include "swift/Demangling/Demangle.h"
+#include "swift/Demangling/Demangler.h"
+
+// FIXME: needed only for the DenseMap.
+#include "clang/APINotes/APINotesManager.h"
+#include "clang/Basic/Module.h"
+
+namespace lldb_private {
+class SwiftASTContext;
+class ClangExternalASTSourceCallbacks;
+
+/// A Swift TypeSystem that does not own a swift::ASTContext.
+class TypeSystemSwiftTypeRef : public TypeSystemSwift {
+  /// LLVM RTTI support.
+  static char ID;
+
+public:
+  /// LLVM RTTI support.
+  /// \{
+  bool isA(const void *ClassID) const override {
+    return ClassID == &ID || TypeSystemSwift::isA(ClassID);
+  }
+  static bool classof(const TypeSystem *ts) { return ts->isA(&ID); }
+  /// \}
+
+  TypeSystemSwiftTypeRef(SwiftASTContext *swift_ast_context);
+
+  Module *GetModule() const;
+  swift::CanType GetCanonicalSwiftType(CompilerType compiler_type);
+  swift::Type GetSwiftType(CompilerType compiler_type);
+  CompilerType ReconstructType(CompilerType type);
+  CompilerType
+  GetTypeFromMangledTypename(ConstString mangled_typename) override;
+
+  // PluginInterface functions
+  ConstString GetPluginName() override;
+  uint32_t GetPluginVersion() override;
+
+  bool SupportsLanguage(lldb::LanguageType language) override;
+  Status IsCompatible() override;
+
+  void DiagnoseWarnings(Process &process, Module &module) const override;
+  DWARFASTParser *GetDWARFParser() override;
+  // CompilerDecl functions
+  ConstString DeclGetName(void *opaque_decl) override {
+    return ConstString("");
+  }
+
+  // CompilerDeclContext functions
+  std::vector<CompilerDecl>
+  DeclContextFindDeclByName(void *opaque_decl_ctx, ConstString name,
+                            const bool ignore_imported_decls) override {
+    return {};
+  }
+
+  bool DeclContextIsContainedInLookup(void *opaque_decl_ctx,
+                                      void *other_opaque_decl_ctx) override {
+    if (opaque_decl_ctx == other_opaque_decl_ctx)
+      return true;
+    return false;
+  }
+
+  // Tests
+#ifndef NDEBUG
+  bool Verify(lldb::opaque_compiler_type_t type) override;
+#endif
+  bool IsArrayType(lldb::opaque_compiler_type_t type,
+                   CompilerType *element_type, uint64_t *size,
+                   bool *is_incomplete) override;
+  bool IsAggregateType(lldb::opaque_compiler_type_t type) override;
+  bool IsDefined(lldb::opaque_compiler_type_t type) override;
+  bool IsFloatingPointType(lldb::opaque_compiler_type_t type, uint32_t &count,
+                           bool &is_complex) override;
+  bool IsFunctionType(lldb::opaque_compiler_type_t type,
+                      bool *is_variadic_ptr) override;
+  size_t
+  GetNumberOfFunctionArguments(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetFunctionArgumentAtIndex(lldb::opaque_compiler_type_t type,
+                                          const size_t index) override;
+  bool IsFunctionPointerType(lldb::opaque_compiler_type_t type) override;
+  bool IsIntegerType(lldb::opaque_compiler_type_t type,
+                     bool &is_signed) override;
+  bool IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
+                             CompilerType *target_type, // Can pass NULL
+                             bool check_cplusplus, bool check_objc) override;
+  bool IsPointerType(lldb::opaque_compiler_type_t type,
+                     CompilerType *pointee_type) override;
+  bool IsScalarType(lldb::opaque_compiler_type_t type) override;
+  bool IsVoidType(lldb::opaque_compiler_type_t type) override;
+  // Type Completion
+  bool GetCompleteType(lldb::opaque_compiler_type_t type) override;
+  // AST related queries
+  uint32_t GetPointerByteSize() override;
+  // Accessors
+  ConstString GetTypeName(lldb::opaque_compiler_type_t type) override;
+  ConstString GetDisplayTypeName(lldb::opaque_compiler_type_t type,
+                                 const SymbolContext *sc) override;
+  ConstString GetMangledTypeName(lldb::opaque_compiler_type_t type) override;
+  uint32_t GetTypeInfo(lldb::opaque_compiler_type_t type,
+                       CompilerType *pointee_or_element_clang_type) override;
+  lldb::LanguageType
+  GetMinimumLanguage(lldb::opaque_compiler_type_t type) override;
+  lldb::TypeClass GetTypeClass(lldb::opaque_compiler_type_t type) override;
+
+  // Creating related types
+  CompilerType GetArrayElementType(lldb::opaque_compiler_type_t type,
+                                   uint64_t *stride) override;
+  CompilerType GetCanonicalType(lldb::opaque_compiler_type_t type) override;
+  int GetFunctionArgumentCount(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetFunctionArgumentTypeAtIndex(lldb::opaque_compiler_type_t type,
+                                              size_t idx) override;
+  CompilerType
+  GetFunctionReturnType(lldb::opaque_compiler_type_t type) override;
+  size_t GetNumMemberFunctions(lldb::opaque_compiler_type_t type) override;
+  TypeMemberFunctionImpl
+  GetMemberFunctionAtIndex(lldb::opaque_compiler_type_t type,
+                           size_t idx) override;
+  CompilerType GetPointeeType(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetPointerType(lldb::opaque_compiler_type_t type) override;
+
+  // Exploring the type
+  llvm::Optional<uint64_t>
+  GetBitSize(lldb::opaque_compiler_type_t type,
+             ExecutionContextScope *exe_scope) override;
+  llvm::Optional<uint64_t>
+  GetByteStride(lldb::opaque_compiler_type_t type,
+                ExecutionContextScope *exe_scope) override;
+  lldb::Encoding GetEncoding(lldb::opaque_compiler_type_t type,
+                             uint64_t &count) override;
+  lldb::Format GetFormat(lldb::opaque_compiler_type_t type) override;
+  uint32_t GetNumChildren(lldb::opaque_compiler_type_t type,
+                          bool omit_empty_base_classes,
+                          const ExecutionContext *exe_ctx) override;
+  uint32_t GetNumFields(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetFieldAtIndex(lldb::opaque_compiler_type_t type, size_t idx,
+                               std::string &name, uint64_t *bit_offset_ptr,
+                               uint32_t *bitfield_bit_size_ptr,
+                               bool *is_bitfield_ptr) override;
+  CompilerType GetChildCompilerTypeAtIndex(
+      lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
+      bool transparent_pointers, bool omit_empty_base_classes,
+      bool ignore_array_bounds, std::string &child_name,
+      uint32_t &child_byte_size, int32_t &child_byte_offset,
+      uint32_t &child_bitfield_bit_size, uint32_t &child_bitfield_bit_offset,
+      bool &child_is_base_class, bool &child_is_deref_of_parent,
+      ValueObject *valobj, uint64_t &language_flags) override;
+  uint32_t GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
+                                   const char *name,
+                                   bool omit_empty_base_classes) override;
+  size_t
+  GetIndexOfChildMemberWithName(lldb::opaque_compiler_type_t type,
+                                const char *name, bool omit_empty_base_classes,
+                                std::vector<uint32_t> &child_indexes) override;
+  size_t GetNumTemplateArguments(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetTypeForFormatters(lldb::opaque_compiler_type_t type) override;
+  LazyBool ShouldPrintAsOneLiner(lldb::opaque_compiler_type_t type,
+                                 ValueObject *valobj) override;
+  bool IsMeaninglessWithoutDynamicResolution(
+      lldb::opaque_compiler_type_t type) override;
+
+  // Dumping types
+#ifndef NDEBUG
+  /// Convenience LLVM-style dump method for use in the debugger only.
+  LLVM_DUMP_METHOD virtual void
+  dump(lldb::opaque_compiler_type_t type) const override;
+#endif
+
+  void DumpValue(lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
+                 Stream *s, lldb::Format format, const DataExtractor &data,
+                 lldb::offset_t data_offset, size_t data_byte_size,
+                 uint32_t bitfield_bit_size, uint32_t bitfield_bit_offset,
+                 bool show_types, bool show_summary, bool verbose,
+                 uint32_t depth) override;
+
+  bool DumpTypeValue(lldb::opaque_compiler_type_t type, Stream *s,
+                     lldb::Format format, const DataExtractor &data,
+                     lldb::offset_t data_offset, size_t data_byte_size,
+                     uint32_t bitfield_bit_size, uint32_t bitfield_bit_offset,
+                     ExecutionContextScope *exe_scope,
+                     bool is_base_class) override;
+
+  void DumpTypeDescription(
+      lldb::opaque_compiler_type_t type,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
+  void DumpTypeDescription(
+      lldb::opaque_compiler_type_t type, Stream *s,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
+  void DumpSummary(lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
+                   Stream *s, const DataExtractor &data,
+                   lldb::offset_t data_offset, size_t data_byte_size) override;
+  bool IsPointerOrReferenceType(lldb::opaque_compiler_type_t type,
+                                CompilerType *pointee_type) override;
+  llvm::Optional<size_t>
+  GetTypeBitAlign(lldb::opaque_compiler_type_t type,
+                  ExecutionContextScope *exe_scope) override;
+  CompilerType GetBuiltinTypeForEncodingAndBitSize(lldb::Encoding encoding,
+                                                   size_t bit_size) override {
+    return CompilerType();
+  }
+  bool IsTypedefType(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetTypedefedType(lldb::opaque_compiler_type_t type) override;
+  CompilerType
+  GetFullyUnqualifiedType(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetNonReferenceType(lldb::opaque_compiler_type_t type) override;
+  CompilerType
+  GetLValueReferenceType(lldb::opaque_compiler_type_t type) override;
+  CompilerType
+  GetRValueReferenceType(lldb::opaque_compiler_type_t type) override;
+  uint32_t GetNumDirectBaseClasses(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetDirectBaseClassAtIndex(lldb::opaque_compiler_type_t type,
+                                         size_t idx,
+                                         uint32_t *bit_offset_ptr) override;
+  bool IsReferenceType(lldb::opaque_compiler_type_t type,
+                       CompilerType *pointee_type, bool *is_rvalue) override;
+  bool
+  ShouldTreatScalarValueAsAddress(lldb::opaque_compiler_type_t type) override;
+
+  // Swift-specific methods.
+  lldb::TypeSP GetCachedType(ConstString mangled) override;
+  void SetCachedType(ConstString mangled, const lldb::TypeSP &type_sp) override;
+  bool IsImportedType(lldb::opaque_compiler_type_t type,
+                      CompilerType *original_type) override;
+  CompilerType GetErrorType() override;
+  CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) override;
+  TypeAllocationStrategy
+  GetAllocationStrategy(lldb::opaque_compiler_type_t type) override;
+  CompilerType
+  CreateTupleType(const std::vector<TupleElement> &elements) override;
+  void DumpTypeDescription(
+      lldb::opaque_compiler_type_t type, bool print_help_if_available,
+      bool print_extensions_if_available,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
+  void DumpTypeDescription(
+      lldb::opaque_compiler_type_t type, Stream *s,
+      bool print_help_if_available, bool print_extensions_if_available,
+      lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
+
+private:
+  /// Helper that creates an AST type from \p type.
+  void *ReconstructType(lldb::opaque_compiler_type_t type);
+  /// Cast \p opaque_type as a mangled name.
+  const char *AsMangledName(lldb::opaque_compiler_type_t opaque_type);
+
+  /// Wrap \p node as \p Global(TypeMangling(node)), remangle the type
+  /// and create a CompilerType from it.
+  CompilerType RemangleAsType(swift::Demangle::Demangler &Dem,
+                              swift::Demangle::NodePointer node);
+
+  /// Demangle the mangled name of the canonical type of \p type and
+  /// drill into the Global(TypeMangling(Type())).
+  ///
+  /// \return the child of Type or a nullptr.
+  swift::Demangle::NodePointer
+  DemangleCanonicalType(swift::Demangle::Demangler &Dem,
+                        lldb::opaque_compiler_type_t type);
+
+  /// Return an APINotes manager for the module with module id \id.
+  /// APINotes are used to get at the SDK swiftification annotations.
+  clang::api_notes::APINotesManager *
+  GetAPINotesManager(ClangExternalASTSourceCallbacks *source, unsigned id);
+
+  /// The sibling SwiftASTContext.
+  SwiftASTContext *m_swift_ast_context = nullptr;
+
+  /// The APINotesManager responsible for each Clang module.
+  llvm::DenseMap<clang::Module *,
+                 std::unique_ptr<clang::api_notes::APINotesManager>>
+      m_apinotes_manager;
+};
+
+} // namespace lldb_private
+#endif

--- a/lldb/source/Symbol/CMakeLists.txt
+++ b/lldb/source/Symbol/CMakeLists.txt
@@ -4,10 +4,6 @@ if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
   set(PLATFORM_SOURCES LocateSymbolFileMacOSX.cpp)
 endif()
 
-set(SWIFT_SOURCES
-    SwiftASTContext.cpp
-    TypeSystemSwiftTypeRef.cpp
-)
 set(SWIFT_LIBS
     swiftAST
     swiftASTSectionImporter

--- a/lldb/source/Target/ABI.cpp
+++ b/lldb/source/Target/ABI.cpp
@@ -13,12 +13,13 @@
 #include "lldb/Expression/ExpressionVariable.h"
 #include "lldb/Symbol/CompilerType.h"
 #include "lldb/Symbol/TypeSystem.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Target/Thread.h"
 #include "lldb/Utility/Log.h"
 #include "llvm/Support/TargetRegistry.h"
 #include <cctype>
+
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 
 using namespace lldb;
 using namespace lldb_private;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -67,7 +67,7 @@
 #include <mutex>
 
 #ifdef LLDB_ENABLE_SWIFT
-#include "lldb/Symbol/SwiftASTContext.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #endif // LLDB_ENABLE_SWIFT
 
 using namespace lldb;

--- a/lldb/source/Target/ThreadPlanCallFunction.cpp
+++ b/lldb/source/Target/ThreadPlanCallFunction.cpp
@@ -13,7 +13,6 @@
 #include "lldb/Core/DumpRegisterValue.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Symbol/ObjectFile.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Target/ABI.h"
 #include "lldb/Target/LanguageRuntime.h"
 #include "lldb/Target/Process.h"

--- a/lldb/source/Target/ThreadPlanStepOut.cpp
+++ b/lldb/source/Target/ThreadPlanStepOut.cpp
@@ -13,7 +13,6 @@
 #include "lldb/Symbol/Block.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/Function.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Symbol/Symbol.h"
 #include "lldb/Symbol/Type.h"
 #include "lldb/Symbol/VariableList.h"

--- a/lldb/unittests/Symbol/CMakeLists.txt
+++ b/lldb/unittests/Symbol/CMakeLists.txt
@@ -27,6 +27,7 @@ add_lldb_unittest(SymbolTests
     lldbPluginSymbolFileDWARF
     lldbPluginSymbolFileSymtab
     lldbPluginTypeSystemClang
+    lldbPluginTypeSystemSwift
     LLVMTestingSupport
   )
 

--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -14,7 +14,7 @@
 
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
-#include "lldb/Symbol/SwiftASTContext.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 
 using namespace lldb;
 using namespace lldb_private;

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -12,7 +12,8 @@
 
 #include "gtest/gtest.h"
 
-#include "lldb/Symbol/SwiftASTContext.h"
+#include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
+#include "llvm/ADT/StringRef.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Demangling/Demangler.h"
 #include "swift/Strings.h"


### PR DESCRIPTION
to mirror a similar move spearheaded by the Clang typesystem.

(cherry picked from commit 9161b3cb453064096ccb92d181d996154d24ada7)

 Conflicts:
	lldb/source/API/SystemInitializerFull.cpp
	lldb/source/Core/Module.cpp
	lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.cpp
	lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
	lldb/source/Plugins/Language/Swift/SwiftDictionary.cpp
	lldb/source/Plugins/Language/Swift/SwiftSet.cpp
	lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
	lldb/source/Target/Target.cpp
	lldb/unittests/Symbol/CMakeLists.txt