### PR TITLE
Wrapping reference to SwiftASTContext with #ifndef NDEBUG

### DIFF
--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -61,7 +61,9 @@ struct TestSwiftASTContext : public testing::Test {
 };
 
 struct SwiftASTContextTester : public SwiftASTContext {
+  #ifndef NDEBUG
   SwiftASTContextTester() : SwiftASTContext() {}
+  #endif
 
   static std::string GetResourceDir(llvm::StringRef platform_sdk_path,
                                     std::string swift_dir,

--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -62,7 +62,7 @@ struct TestSwiftASTContext : public testing::Test {
 
 struct SwiftASTContextTester : public SwiftASTContext {
   #ifndef NDEBUG
-  SwiftASTContextTester() : SwiftASTContext() {}
+    SwiftASTContextTester() : SwiftASTContext() {}
   #endif
 
   static std::string GetResourceDir(llvm::StringRef platform_sdk_path,


### PR DESCRIPTION
Wrapping reference to SwiftASTContext with #ifndef NDEBUG/#endif because it was only defined in that case per: https://github.com/apple/llvm-project/commit/5fa7d8e179225801f681229b695a7bc5db0f974f.   Without this, running the full lldb testsuite seems to fail on this test.