### PR TITLE
Implement TypeSystemSwiftTypeRef::getCanonicalType() (NFC)

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -1037,13 +1037,12 @@ bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
   // dynamic archetype (and hence its size). Everything follows naturally
   // as the elements are laid out in a contigous buffer without padding.
   CompilerType simd_type = valobj.GetCompilerType().GetCanonicalType();
-  void *type_buffer = reinterpret_cast<void *>(simd_type.GetOpaqueQualType());
   llvm::Optional<uint64_t> opt_type_size = simd_type.GetByteSize(nullptr);
   if (!opt_type_size)
     return false;
   uint64_t type_size = *opt_type_size;
 
-  auto swift_type = reinterpret_cast<::swift::TypeBase *>(type_buffer);
+  ::swift::TypeBase *swift_type = GetSwiftType(simd_type).getPointer();
   auto bound_type = dyn_cast<::swift::BoundGenericType>(swift_type);
   if (!bound_type)
     return false;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5537,14 +5537,6 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
   return swift_flags;
 }
 
-lldb::LanguageType
-SwiftASTContext::GetMinimumLanguage(opaque_compiler_type_t type) {
-  if (!type)
-    return lldb::eLanguageTypeC;
-
-  return lldb::eLanguageTypeSwift;
-}
-
 lldb::TypeClass SwiftASTContext::GetTypeClass(opaque_compiler_type_t type) {
   VALID_OR_RETURN(lldb::eTypeClassInvalid);
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5546,18 +5546,11 @@ lldb::TypeClass SwiftASTContext::GetTypeClass(opaque_compiler_type_t type) {
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
   const swift::TypeKind type_kind = swift_can_type->getKind();
   switch (type_kind) {
-  case swift::TypeKind::Error:
-    return lldb::eTypeClassOther;
   case swift::TypeKind::BuiltinInteger:
-    return lldb::eTypeClassBuiltin;
   case swift::TypeKind::BuiltinFloat:
-    return lldb::eTypeClassBuiltin;
   case swift::TypeKind::BuiltinRawPointer:
-    return lldb::eTypeClassBuiltin;
   case swift::TypeKind::BuiltinNativeObject:
-    return lldb::eTypeClassBuiltin;
   case swift::TypeKind::BuiltinUnsafeValueBuffer:
-    return lldb::eTypeClassBuiltin;
   case swift::TypeKind::BuiltinBridgeObject:
     return lldb::eTypeClassBuiltin;
   case swift::TypeKind::BuiltinVector:
@@ -5569,56 +5562,39 @@ lldb::TypeClass SwiftASTContext::GetTypeClass(opaque_compiler_type_t type) {
   case swift::TypeKind::WeakStorage:
     return ToCompilerType(swift_can_type->getReferenceStorageReferent())
         .GetTypeClass();
-  case swift::TypeKind::GenericTypeParam:
-    return lldb::eTypeClassOther;
-  case swift::TypeKind::DependentMember:
-    return lldb::eTypeClassOther;
   case swift::TypeKind::Enum:
+  case swift::TypeKind::BoundGenericEnum:
     return lldb::eTypeClassUnion;
   case swift::TypeKind::Struct:
+  case swift::TypeKind::BoundGenericStruct:
     return lldb::eTypeClassStruct;
   case swift::TypeKind::Class:
+  case swift::TypeKind::BoundGenericClass:
     return lldb::eTypeClassClass;
+  case swift::TypeKind::GenericTypeParam:
+  case swift::TypeKind::DependentMember:
   case swift::TypeKind::Protocol:
-    return lldb::eTypeClassOther;
+  case swift::TypeKind::ProtocolComposition:
   case swift::TypeKind::Metatype:
-    return lldb::eTypeClassOther;
   case swift::TypeKind::Module:
-    return lldb::eTypeClassOther;
   case swift::TypeKind::PrimaryArchetype:
   case swift::TypeKind::OpenedArchetype:
   case swift::TypeKind::NestedArchetype:
+  case swift::TypeKind::UnboundGeneric:
+  case swift::TypeKind::TypeVariable:
+  case swift::TypeKind::ExistentialMetatype:
+  case swift::TypeKind::SILBox:
+  case swift::TypeKind::DynamicSelf:
+  case swift::TypeKind::SILBlockStorage:
+  case swift::TypeKind::Unresolved:
+  case swift::TypeKind::Error:
     return lldb::eTypeClassOther;
   case swift::TypeKind::Function:
-    return lldb::eTypeClassFunction;
   case swift::TypeKind::GenericFunction:
-    return lldb::eTypeClassFunction;
-  case swift::TypeKind::ProtocolComposition:
-    return lldb::eTypeClassOther;
-  case swift::TypeKind::LValue:
-    return lldb::eTypeClassReference;
-  case swift::TypeKind::UnboundGeneric:
-    return lldb::eTypeClassOther;
-  case swift::TypeKind::BoundGenericClass:
-    return lldb::eTypeClassClass;
-  case swift::TypeKind::BoundGenericEnum:
-    return lldb::eTypeClassUnion;
-  case swift::TypeKind::BoundGenericStruct:
-    return lldb::eTypeClassStruct;
-  case swift::TypeKind::TypeVariable:
-    return lldb::eTypeClassOther;
-  case swift::TypeKind::ExistentialMetatype:
-    return lldb::eTypeClassOther;
-  case swift::TypeKind::DynamicSelf:
-    return lldb::eTypeClassOther;
-  case swift::TypeKind::SILBox:
-    return lldb::eTypeClassOther;
   case swift::TypeKind::SILFunction:
     return lldb::eTypeClassFunction;
-  case swift::TypeKind::SILBlockStorage:
-    return lldb::eTypeClassOther;
-  case swift::TypeKind::Unresolved:
-    return lldb::eTypeClassOther;
+  case swift::TypeKind::LValue:
+    return lldb::eTypeClassReference;
 
   case swift::TypeKind::Optional:
   case swift::TypeKind::TypeAlias:

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -218,7 +218,7 @@ swift::Type SwiftASTContext::GetSwiftType(opaque_compiler_type_t opaque_type) {
 
 swift::CanType
 SwiftASTContext::GetCanonicalSwiftType(opaque_compiler_type_t opaque_type) {
-  assert(opaque_type && *reinterpret_cast<const char *>(opaque_type) != '$' &&
+  assert(!opaque_type || *reinterpret_cast<const char *>(opaque_type) != '$' &&
          "wrong type system");
   return lldb_private::GetCanonicalSwiftType(CompilerType(this, opaque_type));
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -531,9 +531,6 @@ public:
   uint32_t GetTypeInfo(lldb::opaque_compiler_type_t type,
                        CompilerType *pointee_or_element_clang_type) override;
 
-  lldb::LanguageType
-  GetMinimumLanguage(lldb::opaque_compiler_type_t type) override;
-
   lldb::TypeClass GetTypeClass(lldb::opaque_compiler_type_t type) override;
 
   // Creating related types

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -170,6 +170,8 @@ public:
   }
   lldb::LanguageType
   GetMinimumLanguage(lldb::opaque_compiler_type_t type) override {
+    assert(type && "CompilerType::GetMinimumLanguage() is not supposed to "
+                   "forward calls with NULL types ");
     return lldb::eLanguageTypeSwift;
   }
   unsigned GetTypeQualifiers(lldb::opaque_compiler_type_t type) override {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -168,6 +168,10 @@ public:
     // TestSwiftStepping were failing because of this Darwin.
     return false;
   }
+  lldb::LanguageType
+  GetMinimumLanguage(lldb::opaque_compiler_type_t type) override {
+    return lldb::eLanguageTypeSwift;
+  }
   unsigned GetTypeQualifiers(lldb::opaque_compiler_type_t type) override {
     return 0;
   }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1459,10 +1459,6 @@ uint32_t TypeSystemSwiftTypeRef::GetTypeInfo(
   VALIDATE_AND_RETURN(impl, GetTypeInfo, type,
                       (ReconstructType(type), nullptr));
 }
-lldb::LanguageType
-TypeSystemSwiftTypeRef::GetMinimumLanguage(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetMinimumLanguage(ReconstructType(type));
-}
 lldb::TypeClass
 TypeSystemSwiftTypeRef::GetTypeClass(opaque_compiler_type_t type) {
   return m_swift_ast_context->GetTypeClass(ReconstructType(type));

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -755,7 +755,7 @@ static uint32_t collectTypeInfo(Module *M, swift::Demangle::Demangler &Dem,
         else if (node->getText() == swift::BUILTIN_TYPE_NAME_BRIDGEOBJECT)
           swift_flags |=
               eTypeHasChildren | eTypeIsPointer | eTypeIsScalar | eTypeIsObjC;
-        else if (node->getText() == swift::BUILTIN_TYPE_NAME_VEC)
+        else if (node->getText().startswith(swift::BUILTIN_TYPE_NAME_VEC))
           swift_flags |= eTypeHasChildren | eTypeIsVector;
       }
       break;
@@ -1461,7 +1461,31 @@ uint32_t TypeSystemSwiftTypeRef::GetTypeInfo(
 }
 lldb::TypeClass
 TypeSystemSwiftTypeRef::GetTypeClass(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetTypeClass(ReconstructType(type));
+  auto impl = [&]() {
+    uint32_t flags = GetTypeInfo(type, nullptr);
+    // The ordering is significant since GetTypeInfo() returns many flags.
+    if ((flags & eTypeIsScalar))
+      return eTypeClassBuiltin;
+    if ((flags & eTypeIsVector))
+      return eTypeClassVector;
+    if ((flags & eTypeIsTuple))
+      return eTypeClassArray;
+    if ((flags & eTypeIsEnumeration))
+      return eTypeClassUnion;
+    if ((flags & eTypeIsProtocol))
+      return eTypeClassOther;
+    if ((flags & eTypeIsStructUnion))
+      return eTypeClassStruct;
+    if ((flags & eTypeIsClass))
+      return eTypeClassClass;
+    if ((flags & eTypeIsReference))
+      return eTypeClassReference;
+    // This only works because we excluded all other options.
+    if ((flags & eTypeIsPointer))
+      return eTypeClassFunction;
+    return eTypeClassOther;
+  };
+  VALIDATE_AND_RETURN(impl, GetTypeClass, type, (ReconstructType(type)));
 }
 
 // Creating related types

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1502,7 +1502,15 @@ TypeSystemSwiftTypeRef::GetArrayElementType(opaque_compiler_type_t type,
 }
 CompilerType
 TypeSystemSwiftTypeRef::GetCanonicalType(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetCanonicalType(ReconstructType(type));
+  auto impl = [&]() {
+    using namespace swift::Demangle;
+    Demangler Dem;
+    NodePointer canonical =
+        GetCanonicalDemangleTree(GetModule(), Dem, AsMangledName(type));
+    ConstString mangled(mangleNode(canonical));
+    return GetTypeFromMangledTypename(mangled);
+  };
+  VALIDATE_AND_RETURN(impl, GetCanonicalType, type, (ReconstructType(type)));
 }
 int TypeSystemSwiftTypeRef::GetFunctionArgumentCount(
     opaque_compiler_type_t type) {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -110,8 +110,6 @@ public:
   ConstString GetMangledTypeName(lldb::opaque_compiler_type_t type) override;
   uint32_t GetTypeInfo(lldb::opaque_compiler_type_t type,
                        CompilerType *pointee_or_element_clang_type) override;
-  lldb::LanguageType
-  GetMinimumLanguage(lldb::opaque_compiler_type_t type) override;
   lldb::TypeClass GetTypeClass(lldb::opaque_compiler_type_t type) override;
 
   // Creating related types

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -346,3 +346,14 @@ TEST_F(TestTypeSystemSwiftTypeRef, ScalarAddress) {
     ASSERT_TRUE(c.ShouldTreatScalarValueAsAddress());
   }
 }
+
+TEST_F(TestTypeSystemSwiftTypeRef, LanguageVersion) {
+  using namespace swift::Demangle;
+  Demangler dem;
+  NodeBuilder b(dem);
+  {
+    NodePointer int_node = b.GlobalTypeMangling(b.IntType());
+    CompilerType int_type = GetCompilerType(b.Mangle(int_node));
+    ASSERT_EQ(int_type.GetMinimumLanguage(), lldb::eLanguageTypeSwift);
+  }
+}


### PR DESCRIPTION
Also includes a now necessary drive-by fix to an unsound type cast in
SIMDVector_SummaryProvider.