### PR TITLE
[lldb] Fix compile error due implicit StringRef -> std::string conversion

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -1273,7 +1273,7 @@ OptionalClangModuleID TypeSystemClang::GetOrCreateClangModule(
   if (!created)
     return ast_source->GetIDForModule(module);
 
-  module->APINotesFile = apinotes;
+  module->APINotesFile = std::string(apinotes);
   return ast_source->RegisterModule(module);
 }
 


### PR DESCRIPTION
This was failing with:
```
lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:1276:24: error: no viable overloaded '='
  module->APINotesFile = apinotes;
  ~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~
include/c++/v1/string:877:19: note: candidate function not viable: no known conversion from 'llvm::StringRef' to 'const std::__1::basic_string<char>' for 1st argument
    basic_string& operator=(const basic_string& __str);
                  ^
```