### PR TITLE
[lldb] Fix that Swift uses the DisplayName in the FormatManager (cherry-pick swift/master-rebranch)

### DIFF
--- a/lldb/source/DataFormatters/FormatManager.cpp
+++ b/lldb/source/DataFormatters/FormatManager.cpp
@@ -18,6 +18,10 @@
 #include "lldb/Target/Language.h"
 #include "lldb/Utility/Log.h"
 
+// BEGIN SWIFT
+#include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
+// END SWIFT
+
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::formatters;
@@ -192,14 +196,21 @@ void FormatManager::GetPossibleMatches(
     entries.push_back(
         {type_name, did_strip_ptr, did_strip_ref, did_strip_typedef});
 
-    const SymbolContext *sc = nullptr;
-    if (valobj.GetFrameSP())
-      sc = &valobj.GetFrameSP()->GetSymbolContext(eSymbolContextFunction);
+// BEGIN SWIFT
+    TypeSystem *ts = compiler_type.GetTypeSystem();
+    if (ts && !llvm::isa<TypeSystemClang>(ts)) {
+// END SWIFT
+      const SymbolContext *sc = nullptr;
+      if (valobj.GetFrameSP())
+        sc = &valobj.GetFrameSP()->GetSymbolContext(eSymbolContextFunction);
 
-    ConstString display_type_name(compiler_type.GetTypeName());
-    if (display_type_name != type_name)
-      entries.push_back({display_type_name, did_strip_ptr,
-                         did_strip_ref, did_strip_typedef});
+      ConstString display_type_name(compiler_type.GetDisplayTypeName(sc));
+      if (display_type_name != type_name)
+        entries.push_back({display_type_name, reason, did_strip_ptr,
+                           did_strip_ref, did_strip_typedef});
+// BEGIN SWIFT
+    }
+// END SWIFT
   }
 
   for (bool is_rvalue_ref = true, j = true;


### PR DESCRIPTION
In llvm.org the FormatManager currently has the bug that it uses only the
TypeName when deciding which format to use. This bug is currently actually
required to make it possible to support C++'s concept of display names where
inline namespaces are hidden.

To give some more context:
The FormatManager prefers taking a summary provider for a type if the
summary provider is *not* using a regex to match the type name. Upstream
there is a non-regex summary provider for `std::string` and a regex summary
provider for `std::__[num]::string`.

The DisplayTypeName for libc++'s `std::__1::string` is `std::string`. As that
matches the non-regex summary provider for `std::string`, the FormatManager will
always prefer that summary provider over `std::__[num]::string`. However,
`std::string` is a libstdc++ summary provider while `std::__[num]::string` is
the correct libc++ provider. There is no way to tell LLDB that the libc++
summary provider is correct at the moment, so that's why llvm.org isn't using
the DisplayTypeName in the format manager.

Meanwhile in Swift, DisplayTypeName has to be used as some summary providers
etc. match only the DisplayTypeName. That's why only using TypeName there
is breaking tests.

As using the DisplayTypeName breaks C++ and not using the DisplayTypeName
breaks Swift, the current hack we came up with is to only add the DisplayTypeName
to the list of strings the FormatManager searches if the type we are trying
to format is Swift (or not a Clang type).

Clearly this should be fixed upstream but I didn't get around to do that yet.

This was originally fixed in the swift/master branch for stable/20200108
by commit dee0a4cae53095420ad8ed50901261df6d19be46 which was just a merge
commit for the actual patch that split up TypeName and DisplayTypeName in
llvm.org. That's also why that patch escaped the usual detection mechanisms
for these situations.

Fixes rdar://64913211

(cherry picked from commit 766db6824d6c8f8061c1477be474c955db5296d7)