### PR TITLE
[lldb/Reproducers] Always record the current working directory

### DIFF
--- a/lldb/include/lldb/Utility/Reproducer.h
+++ b/lldb/include/lldb/Utility/Reproducer.h
@@ -99,7 +99,7 @@ public:
     return m_collector;
   }
 
-  void recordInterestingDirectory(const llvm::Twine &dir);
+  void RecordInterestingDirectory(const llvm::Twine &dir);
 
   void Keep() override {
     auto mapping = GetRoot().CopyByAppendingPathComponent(Info::file);

--- a/lldb/include/lldb/Utility/Reproducer.h
+++ b/lldb/include/lldb/Utility/Reproducer.h
@@ -11,6 +11,7 @@
 
 #include "lldb/Utility/FileSpec.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileCollector.h"
 #include "llvm/Support/YAMLTraits.h"
@@ -149,6 +150,7 @@ public:
   }
 
   void Update(llvm::StringRef path) { m_cwd = std::string(path); }
+  llvm::StringRef GetWorkingDirectory() { return m_cwd; }
 
   struct Info {
     static const char *name;

--- a/lldb/source/API/SBReproducer.cpp
+++ b/lldb/source/API/SBReproducer.cpp
@@ -234,7 +234,10 @@ const char *SBReproducer::GetPath() {
 
 void SBReproducer::SetWorkingDirectory(const char *path) {
   if (auto *g = lldb_private::repro::Reproducer::Instance().GetGenerator()) {
-    g->GetOrCreate<WorkingDirectoryProvider>().Update(path);
+    auto &wp = g->GetOrCreate<repro::WorkingDirectoryProvider>();
+    wp.Update(path);
+    auto &fp = g->GetOrCreate<repro::FileProvider>();
+    fp.RecordInterestingDirectory(wp.GetWorkingDirectory());
   }
 }
 

--- a/lldb/source/Initialization/SystemInitializerCommon.cpp
+++ b/lldb/source/Initialization/SystemInitializerCommon.cpp
@@ -94,6 +94,8 @@ llvm::Error SystemInitializerCommon::Initialize() {
     vp.SetVersion(lldb_private::GetVersion());
     repro::FileProvider &fp = g->GetOrCreate<repro::FileProvider>();
     FileSystem::Initialize(fp.GetFileCollector());
+    repro::WorkingDirectoryProvider &wp = g->GetOrCreate<repro::WorkingDirectoryProvider>();
+    fp.RecordInterestingDirectory(wp.GetWorkingDirectory());
   } else {
     FileSystem::Initialize();
   }

--- a/lldb/source/Plugins/SymbolVendor/MacOSX/SymbolVendorMacOSX.cpp
+++ b/lldb/source/Plugins/SymbolVendor/MacOSX/SymbolVendorMacOSX.cpp
@@ -299,7 +299,7 @@ SymbolVendorMacOSX::CreateInstance(const lldb::ModuleSP &module_sp,
           if (repro::Generator *g =
                   repro::Reproducer::Instance().GetGenerator()) {
             repro::FileProvider &fp = g->GetOrCreate<repro::FileProvider>();
-            fp.recordInterestingDirectory(dsym_root);
+            fp.RecordInterestingDirectory(dsym_root);
           }
         }
         return symbol_vendor;

--- a/lldb/source/Utility/Reproducer.cpp
+++ b/lldb/source/Utility/Reproducer.cpp
@@ -299,7 +299,7 @@ void WorkingDirectoryProvider::Keep() {
   os << m_cwd << "\n";
 }
 
-void FileProvider::recordInterestingDirectory(const llvm::Twine &dir) {
+void FileProvider::RecordInterestingDirectory(const llvm::Twine &dir) {
   if (m_collector)
     m_collector->addDirectory(dir);
 }

--- a/lldb/test/Shell/Reproducer/TestWorkingDir.test
+++ b/lldb/test/Shell/Reproducer/TestWorkingDir.test
@@ -15,3 +15,13 @@
 
 # RUN: cat %t.repro/cwd.txt | FileCheck %t.check
 # RUN: %lldb --replay %t.repro | FileCheck %t.check
+
+# Make sure the current working directory is recorded even when it's not
+# referenced.
+
+# RUN: rm -rf %t.repro
+# RUN: mkdir -p %t/probably_unique
+# RUN: cd %t/probably_unique
+# RUN: %lldb -x -b -o 'reproducer generate' --capture --capture-path %t.repro
+# RUN: cat %t.repro/cwd.txt | FileCheck %s
+# CHECK: probably_unique


### PR DESCRIPTION
Setting the current working directory in the VFS will fail if the given
path doesn't exist in the YAML mapping or on disk.