### PR TITLE
[lldb] Re-add nullptr check to IRForTarget::RewriteObjCConstString lo…

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
@@ -433,7 +433,7 @@ bool IRForTarget::RewriteObjCConstString(llvm::GlobalVariable *ns_str,
         m_execution_unit.FindSymbol(g_CFStringCreateWithBytes_str, 
                                     missing_weak);
     if (CFStringCreateWithBytes_addr == LLDB_INVALID_ADDRESS || missing_weak) {
-        log->PutCString("Couldn't find CFStringCreateWithBytes in the target");
+      LLDB_LOG(log, "Couldn't find CFStringCreateWithBytes in the target");
 
       m_error_stream.Printf("Error [IRForTarget]: Rewriting an Objective-C "
                             "constant string requires "


### PR DESCRIPTION
…g statement

The nullptr check here was removed in 4ef50a33b12825593a82ca8ea97158b7b71b348e
when I replaced (nearly) all log->Print to LLDB_LOG calls (which automatically
check for this stuff). But it seems this one call escaped my sed call.

Currently working on a test that can cover this code path but we can revert
this until I have found one.

(cherry picked from commit e2d8aa6bf774ef29e134c40f886c55557bb5f970)