### PR TITLE
[lldb/interpreter] Add ability to save lldb session to a file

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandInterpreter.h
+++ b/lldb/include/lldb/Interpreter/CommandInterpreter.h
@@ -20,6 +20,7 @@
 #include "lldb/Utility/CompletionRequest.h"
 #include "lldb/Utility/Event.h"
 #include "lldb/Utility/Log.h"
+#include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/StringList.h"
 #include "lldb/lldb-forward.h"
 #include "lldb/lldb-private.h"
@@ -485,8 +486,10 @@ public:
   bool GetExpandRegexAliases() const;
 
   bool GetPromptOnQuit() const;
-
   void SetPromptOnQuit(bool enable);
+
+  bool GetSaveSessionOnQuit() const;
+  void SetSaveSessionOnQuit(bool enable);
 
   bool GetEchoCommands() const;
   void SetEchoCommands(bool enable);
@@ -525,6 +528,18 @@ public:
                CommandInterpreterRunOptions *options = nullptr);
 
   bool GetSpaceReplPrompts() const;
+
+  /// Save the current debugger session transcript to a file on disk.
+  /// \param output_file
+  ///     The file path to which the session transcript will be written. Since
+  ///     the argument is optional, an arbitrary temporary file will be create
+  ///     when no argument is passed.
+  /// \param result
+  ///     This is used to pass function output and error messages.
+  /// \return \b true if the session transcript was successfully written to
+  /// disk, \b false otherwise.
+  bool SaveTranscript(CommandReturnObject &result,
+                      llvm::Optional<std::string> output_file = llvm::None);
 
 protected:
   friend class Debugger;
@@ -621,6 +636,8 @@ private:
   llvm::Optional<int> m_quit_exit_code;
   // If the driver is accepts custom exit codes for the 'quit' command.
   bool m_allow_exit_code = false;
+
+  StreamString m_transcript_stream;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Commands/CMakeLists.txt
+++ b/lldb/source/Commands/CMakeLists.txt
@@ -13,6 +13,7 @@ add_lldb_library(lldbCommands
   CommandObjectFrame.cpp
   CommandObjectGUI.cpp
   CommandObjectHelp.cpp
+  CommandObjectLanguage.cpp
   CommandObjectLog.cpp
   CommandObjectMemory.cpp
   CommandObjectMultiword.cpp
@@ -22,6 +23,7 @@ add_lldb_library(lldbCommands
   CommandObjectQuit.cpp
   CommandObjectRegister.cpp
   CommandObjectReproducer.cpp
+  CommandObjectSession.cpp
   CommandObjectSettings.cpp
   CommandObjectSource.cpp
   CommandObjectStats.cpp
@@ -31,7 +33,6 @@ add_lldb_library(lldbCommands
   CommandObjectVersion.cpp
   CommandObjectWatchpoint.cpp
   CommandObjectWatchpointCommand.cpp
-  CommandObjectLanguage.cpp
 
   LINK_LIBS
     lldbBase

--- a/lldb/source/Commands/CommandObjectQuit.cpp
+++ b/lldb/source/Commands/CommandObjectQuit.cpp
@@ -103,5 +103,10 @@ bool CommandObjectQuit::DoExecute(Args &command, CommandReturnObject &result) {
       CommandInterpreter::eBroadcastBitQuitCommandReceived;
   m_interpreter.BroadcastEvent(event_type);
   result.SetStatus(eReturnStatusQuit);
+
+
+  if (m_interpreter.GetSaveSessionOnQuit())
+    m_interpreter.SaveTranscript(result);
+
   return true;
 }

--- a/lldb/source/Commands/CommandObjectQuit.cpp
+++ b/lldb/source/Commands/CommandObjectQuit.cpp
@@ -104,7 +104,6 @@ bool CommandObjectQuit::DoExecute(Args &command, CommandReturnObject &result) {
   m_interpreter.BroadcastEvent(event_type);
   result.SetStatus(eReturnStatusQuit);
 
-
   if (m_interpreter.GetSaveSessionOnQuit())
     m_interpreter.SaveTranscript(result);
 

--- a/lldb/source/Commands/CommandObjectSession.cpp
+++ b/lldb/source/Commands/CommandObjectSession.cpp
@@ -1,0 +1,53 @@
+#include "CommandObjectSession.h"
+#include "lldb/Interpreter/CommandInterpreter.h"
+#include "lldb/Interpreter/CommandReturnObject.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+class CommandObjectSessionSave : public CommandObjectParsed {
+public:
+  CommandObjectSessionSave(CommandInterpreter &interpreter)
+      : CommandObjectParsed(interpreter, "session save",
+                            "Save the current session transcripts to a file.\n"
+                            "If no file if specified, transcripts will be "
+                            "saved to a temporary file.",
+                            "session save [file]") {
+    CommandArgumentEntry arg1;
+    arg1.emplace_back(eArgTypePath, eArgRepeatOptional);
+    m_arguments.push_back(arg1);
+  }
+
+  ~CommandObjectSessionSave() override = default;
+
+  void
+  HandleArgumentCompletion(CompletionRequest &request,
+                           OptionElementVector &opt_element_vector) override {
+    CommandCompletions::InvokeCommonCompletionCallbacks(
+        GetCommandInterpreter(), CommandCompletions::eDiskFileCompletion,
+        request, nullptr);
+  }
+
+protected:
+  bool DoExecute(Args &args, CommandReturnObject &result) override {
+    llvm::StringRef file_path;
+
+    if (!args.empty())
+      file_path = args[0].ref();
+
+    if (m_interpreter.SaveTranscript(result, file_path.str()))
+      result.SetStatus(eReturnStatusSuccessFinishNoResult);
+    else
+      result.SetStatus(eReturnStatusFailed);
+    return result.Succeeded();
+  }
+};
+
+CommandObjectSession::CommandObjectSession(CommandInterpreter &interpreter)
+    : CommandObjectMultiword(interpreter, "session",
+                             "Commands controlling LLDB session.",
+                             "session <subcommand> [<command-options>]") {
+  LoadSubCommand("save",
+                 CommandObjectSP(new CommandObjectSessionSave(interpreter)));
+  //  TODO: Move 'history' subcommand from CommandObjectCommands.
+}

--- a/lldb/source/Commands/CommandObjectSession.h
+++ b/lldb/source/Commands/CommandObjectSession.h
@@ -1,0 +1,23 @@
+//===-- CommandObjectSession.h ----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_COMMANDS_COMMANDOBJECTSESSION_H
+#define LLDB_SOURCE_COMMANDS_COMMANDOBJECTSESSION_H
+
+#include "lldb/Interpreter/CommandObjectMultiword.h"
+
+namespace lldb_private {
+
+class CommandObjectSession : public CommandObjectMultiword {
+public:
+  CommandObjectSession(CommandInterpreter &interpreter);
+};
+
+} // namespace lldb_private
+
+#endif // LLDB_SOURCE_COMMANDS_COMMANDOBJECTSESSION_H

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -2938,7 +2938,8 @@ bool CommandInterpreter::SaveTranscript(
     return error_out("Unable to write to destination file",
                      "Bytes written do not match transcript size.");
 
-  result.AppendMessageWithFormat("Session's transcripts saved to %s\n", output_file->c_str());
+  result.AppendMessageWithFormat("Session's transcripts saved to %s\n",
+                                 output_file->c_str());
 
   return true;
 }

--- a/lldb/source/Interpreter/InterpreterProperties.td
+++ b/lldb/source/Interpreter/InterpreterProperties.td
@@ -9,6 +9,10 @@ let Definition = "interpreter" in {
     Global,
     DefaultTrue,
     Desc<"If true, LLDB will prompt you before quitting if there are any live processes being debugged. If false, LLDB will quit without asking in any case.">;
+  def SaveSessionOnQuit: Property<"save-session-on-quit", "Boolean">,
+    Global,
+    DefaultFalse,
+    Desc<"If true, LLDB will save the session's transcripts before quitting.">;
   def StopCmdSourceOnError: Property<"stop-command-source-on-error", "Boolean">,
     Global,
     DefaultTrue,

--- a/lldb/test/API/commands/session/save/TestSessionSave.py
+++ b/lldb/test/API/commands/session/save/TestSessionSave.py
@@ -1,0 +1,74 @@
+"""
+Test the session save feature
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class SessionSaveTestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def raw_transcript_builder(self, cmd, res):
+        raw = "(lldb) " + cmd + "\n"
+        if res.GetOutputSize():
+          raw += res.GetOutput()
+        if res.GetErrorSize():
+          raw += res.GetError()
+        return raw
+
+
+    @skipIfWindows
+    @skipIfReproducer
+    @no_debug_info_test
+    def test_session_save(self):
+        raw = ""
+        interpreter = self.dbg.GetCommandInterpreter()
+
+        settings = [
+          'settings set interpreter.echo-commands true',
+          'settings set interpreter.echo-comment-commands true',
+          'settings set interpreter.stop-command-source-on-error false'
+        ]
+
+        for setting in settings:
+          interpreter.HandleCommand(setting, lldb.SBCommandReturnObject())
+
+        inputs = [
+          '# This is a comment',  # Comment
+          'help session',         # Valid command
+          'Lorem ipsum'           # Invalid command
+        ]
+
+        for cmd in inputs:
+          res = lldb.SBCommandReturnObject()
+          interpreter.HandleCommand(cmd, res)
+          raw += self.raw_transcript_builder(cmd, res)
+
+        self.assertTrue(interpreter.HasCommands())
+        self.assertTrue(len(raw) != 0)
+
+        # Check for error
+        cmd = 'session save /root/file'
+        interpreter.HandleCommand(cmd, res)
+        self.assertFalse(res.Succeeded())
+        raw += self.raw_transcript_builder(cmd, res)
+
+        import tempfile
+        tf = tempfile.NamedTemporaryFile()
+        output_file = tf.name
+
+        res = lldb.SBCommandReturnObject()
+        interpreter.HandleCommand('session save ' + output_file, res)
+        self.assertTrue(res.Succeeded())
+        raw += self.raw_transcript_builder(cmd, res)
+
+        with open(output_file, "r") as file:
+          content = file.read()
+          # Exclude last line, since session won't record it's own output
+          lines = raw.splitlines()[:-1]
+          for line in lines:
+            self.assertIn(line, content)


### PR DESCRIPTION
This patch introduce a new feature that allows the users to save their
debugging session's transcript (commands + outputs) to a file.

It differs from the reproducers since it doesn't require to capture a
session preemptively and replay the reproducer file in lldb.
The user can choose the save its session manually using the session save
command or automatically by setting the interpreter.save-session-on-quit
on their init file.

To do so, the patch adds a Stream object to the CommandInterpreter that
will hold the input command from the IOHandler and the CommandReturnObject
output and error. This way, that stream object accumulates passively all
the interactions throughout the session and will save them to disk on demand.

The user can specify a file path where the session's transcript will be
saved. However, it is optional, and when it is not provided, lldb will
create a temporary file name according to the session date and time.

rdar://63347792

Differential Revision: https://reviews.llvm.org/D82155

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>