### PR TITLE
Make lit TestRunner.py work in Python 3

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1171,7 +1171,7 @@ def applySubstitutions(script, substitutions, recursion_limit=None):
             # short-lived, since the set of substitutions is fairly small, and
             # since thrashing has such bad consequences, not bounding the cache
             # seems reasonable.
-            ln = _caching_re_compile(a).sub(b, ln)
+            ln = _caching_re_compile(a).sub(str(b), ln)
 
         # Strip the trailing newline and any extra whitespace.
         return ln.strip()


### PR DESCRIPTION
Summary: In Python3 SubstituteCaptures are no longer converted to String implicitly behind the scenes. Converting explicitly makes the TestRunner to work in Python3.

Reviewers: gribozavr2, compnerd

Reviewed By: gribozavr2

Subscribers: tbkka, delcypher, llvm-commits

Tags: #llvm

Differential Revision: https://reviews.llvm.org/D81361

(cherry picked from commit b49d47f6a0f5bbf293e26d8b918cb46d80f2102f)