### PR TITLE
[lldb] Cleanup CommandObject registration (NFC)

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -476,55 +476,40 @@ const char *CommandInterpreter::ProcessEmbeddedScriptCommands(const char *arg) {
   return arg;
 }
 
+#define REGISTER_COMMAND_OBJECT(NAME, CLASS)                                   \
+  m_command_dict[NAME] = std::make_shared<CLASS>(*this);
+
 void CommandInterpreter::LoadCommandDictionary() {
   static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
   Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
 
-  lldb::ScriptLanguage script_language = m_debugger.GetScriptLanguage();
-
-  m_command_dict["apropos"] = CommandObjectSP(new CommandObjectApropos(*this));
-  m_command_dict["breakpoint"] =
-      CommandObjectSP(new CommandObjectMultiwordBreakpoint(*this));
-  m_command_dict["command"] =
-      CommandObjectSP(new CommandObjectMultiwordCommands(*this));
-  m_command_dict["disassemble"] =
-      CommandObjectSP(new CommandObjectDisassemble(*this));
-  m_command_dict["expression"] =
-      CommandObjectSP(new CommandObjectExpression(*this));
-  m_command_dict["frame"] =
-      CommandObjectSP(new CommandObjectMultiwordFrame(*this));
-  m_command_dict["gui"] = CommandObjectSP(new CommandObjectGUI(*this));
-  m_command_dict["help"] = CommandObjectSP(new CommandObjectHelp(*this));
-  m_command_dict["log"] = CommandObjectSP(new CommandObjectLog(*this));
-  m_command_dict["memory"] = CommandObjectSP(new CommandObjectMemory(*this));
-  m_command_dict["platform"] =
-      CommandObjectSP(new CommandObjectPlatform(*this));
-  m_command_dict["plugin"] = CommandObjectSP(new CommandObjectPlugin(*this));
-  m_command_dict["process"] =
-      CommandObjectSP(new CommandObjectMultiwordProcess(*this));
-  m_command_dict["quit"] = CommandObjectSP(new CommandObjectQuit(*this));
-  m_command_dict["register"] =
-      CommandObjectSP(new CommandObjectRegister(*this));
-  m_command_dict["reproducer"] =
-      CommandObjectSP(new CommandObjectReproducer(*this));
-  m_command_dict["script"] =
-      CommandObjectSP(new CommandObjectScript(*this, script_language));
-  m_command_dict["session"] = std::make_shared<CommandObjectSession>(*this);
-  m_command_dict["settings"] =
-      CommandObjectSP(new CommandObjectMultiwordSettings(*this));
-  m_command_dict["source"] =
-      CommandObjectSP(new CommandObjectMultiwordSource(*this));
-  m_command_dict["statistics"] = CommandObjectSP(new CommandObjectStats(*this));
-  m_command_dict["target"] =
-      CommandObjectSP(new CommandObjectMultiwordTarget(*this));
-  m_command_dict["thread"] =
-      CommandObjectSP(new CommandObjectMultiwordThread(*this));
-  m_command_dict["type"] = CommandObjectSP(new CommandObjectType(*this));
-  m_command_dict["version"] = CommandObjectSP(new CommandObjectVersion(*this));
-  m_command_dict["watchpoint"] =
-      CommandObjectSP(new CommandObjectMultiwordWatchpoint(*this));
-  m_command_dict["language"] =
-      CommandObjectSP(new CommandObjectLanguage(*this));
+  REGISTER_COMMAND_OBJECT("apropos", CommandObjectApropos);
+  REGISTER_COMMAND_OBJECT("breakpoint", CommandObjectMultiwordBreakpoint);
+  REGISTER_COMMAND_OBJECT("command", CommandObjectMultiwordCommands);
+  REGISTER_COMMAND_OBJECT("disassemble", CommandObjectDisassemble);
+  REGISTER_COMMAND_OBJECT("expression", CommandObjectExpression);
+  REGISTER_COMMAND_OBJECT("frame", CommandObjectMultiwordFrame);
+  REGISTER_COMMAND_OBJECT("gui", CommandObjectGUI);
+  REGISTER_COMMAND_OBJECT("help", CommandObjectHelp);
+  REGISTER_COMMAND_OBJECT("log", CommandObjectLog);
+  REGISTER_COMMAND_OBJECT("memory", CommandObjectMemory);
+  REGISTER_COMMAND_OBJECT("platform", CommandObjectPlatform);
+  REGISTER_COMMAND_OBJECT("plugin", CommandObjectPlugin);
+  REGISTER_COMMAND_OBJECT("process", CommandObjectMultiwordProcess);
+  REGISTER_COMMAND_OBJECT("quit", CommandObjectQuit);
+  REGISTER_COMMAND_OBJECT("register", CommandObjectRegister);
+  REGISTER_COMMAND_OBJECT("reproducer", CommandObjectReproducer);
+  REGISTER_COMMAND_OBJECT("script", CommandObjectScript);
+  REGISTER_COMMAND_OBJECT("settings", CommandObjectMultiwordSettings);
+  REGISTER_COMMAND_OBJECT("session", CommandObjectSession);
+  REGISTER_COMMAND_OBJECT("source", CommandObjectMultiwordSource);
+  REGISTER_COMMAND_OBJECT("statistics", CommandObjectStats);
+  REGISTER_COMMAND_OBJECT("target", CommandObjectMultiwordTarget);
+  REGISTER_COMMAND_OBJECT("thread", CommandObjectMultiwordThread);
+  REGISTER_COMMAND_OBJECT("type", CommandObjectType);
+  REGISTER_COMMAND_OBJECT("version", CommandObjectVersion);
+  REGISTER_COMMAND_OBJECT("watchpoint", CommandObjectMultiwordWatchpoint);
+  REGISTER_COMMAND_OBJECT("language", CommandObjectLanguage);
 
   // clang-format off
   const char *break_regexes[][2] = {

--- a/lldb/source/Interpreter/CommandObjectScript.cpp
+++ b/lldb/source/Interpreter/CommandObjectScript.cpp
@@ -20,8 +20,7 @@ using namespace lldb_private;
 
 // CommandObjectScript
 
-CommandObjectScript::CommandObjectScript(CommandInterpreter &interpreter,
-                                         ScriptLanguage script_lang)
+CommandObjectScript::CommandObjectScript(CommandInterpreter &interpreter)
     : CommandObjectRaw(
           interpreter, "script",
           "Invoke the script interpreter with provided code and display any "

--- a/lldb/source/Interpreter/CommandObjectScript.h
+++ b/lldb/source/Interpreter/CommandObjectScript.h
@@ -13,13 +13,9 @@
 
 namespace lldb_private {
 
-// CommandObjectScript
-
 class CommandObjectScript : public CommandObjectRaw {
 public:
-  CommandObjectScript(CommandInterpreter &interpreter,
-                      lldb::ScriptLanguage script_lang);
-
+  CommandObjectScript(CommandInterpreter &interpreter);
   ~CommandObjectScript() override;
 
 protected:


### PR DESCRIPTION
 - Remove the spurious argument to `CommandObjectScript`.
 - Use make_shared instead of bare `new`.
 - Move code duplication behind a macro.

Differential revision: https://reviews.llvm.org/D84336

(cherry picked from commit 2419ded61d977c043be945f004e6324812a5a3e2)