### PR TITLE
Cherry-Pick: Rename SerializedModuleLoader to match Swift compiler's new API.

### DIFF
--- a/lldb/include/lldb/Core/SwiftForward.h
+++ b/lldb/include/lldb/Core/SwiftForward.h
@@ -49,7 +49,7 @@ class NominalType;
 class NominalTypeDecl;
 class ProtocolDecl;
 class SearchPathOptions;
-class SerializedModuleLoader;
+class ImplicitSerializedModuleLoader;
 class ParseableInterfaceModuleLoader;
 class SILModule;
 class SILOptions;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3325,7 +3325,7 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
 
   // 3. Create and install the serialized module loader.
   std::unique_ptr<swift::ModuleLoader> serialized_module_loader_ap(
-      swift::SerializedModuleLoader::create(
+      swift::ImplicitSerializedModuleLoader::create(
           *m_ast_context_ap, m_dependency_tracker.get(), loading_mode));
   if (serialized_module_loader_ap)
     m_ast_context_ap->addModuleLoader(std::move(serialized_module_loader_ap));


### PR DESCRIPTION
Reviewed in: https://github.com/apple/llvm-project/pull/1465