### PR TITLE
[lldb] Fix LLDB_DEFAULT_TEST_ARCH for standalone builds

### DIFF
--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -13,10 +13,10 @@ function(add_python_test_target name test_script args comment)
   add_dependencies(${name} lldb-test-deps)
 endfunction()
 
-# The default architecture with which to compile test executables is the default LLVM target
-# architecture, which itself defaults to the host architecture.
-string(TOLOWER "${LLVM_TARGET_ARCH}" LLDB_DEFAULT_TEST_ARCH)
-if( LLDB_DEFAULT_TEST_ARCH STREQUAL "host" )
+# The default architecture with which to compile test executables is the
+# default LLVM target architecture, which itself defaults to the host
+# architecture.
+if(NOT LLDB_DEFAULT_TEST_ARCH)
   string(REGEX MATCH "^[^-]*" LLDB_DEFAULT_TEST_ARCH ${LLVM_HOST_TRIPLE})
 endif ()
 


### PR DESCRIPTION
LLVM_TARGET_ARCH is not exported by LLVM so we can't use it from
standalone builds. Default to the architecture in LLVM_HOST_TRIPLE when
no LLDB_DEFAULT_TEST_ARCH was specified.

(cherry picked from commit 8acaceb14c6c6f91996beb27742119844c04292f)