### PR TITLE
template function match

### DIFF
--- a/llvm/include/llvm/ADT/Hashing.h
+++ b/llvm/include/llvm/ADT/Hashing.h
@@ -348,6 +348,7 @@ inline uint64_t get_execution_seed() {
 // support user-defined types which happen to satisfy this property.
 template <typename T> struct is_hashable_data
   : std::integral_constant<bool, ((is_integral_or_enum<T>::value ||
+                                   std::is_same<T, hash_code>::value ||
                                    std::is_pointer<T>::value) &&
                                   64 % sizeof(T) == 0)> {};
 

--- a/llvm/include/llvm/ADT/Hashing.h
+++ b/llvm/include/llvm/ADT/Hashing.h
@@ -102,12 +102,12 @@ public:
 /// differing argument types even if they would implicit promote to a common
 /// type without changing the value.
 template <typename T>
-std::enable_if_t<is_integral_or_enum<T>::value, hash_code> hash_value(T value);
+std::enable_if_t<is_integral_or_enum<T>::value, hash_code> hash_value(T &value);
 
 /// Compute a hash_code for a pointer's address.
 ///
 /// N.B.: This hashes the *address*. Not the value and not the type.
-template <typename T> hash_code hash_value(const T *ptr);
+template <typename T> hash_code hash_value(const T &ptr);
 
 /// Compute a hash_code for a pair of objects.
 template <typename T, typename U>
@@ -631,7 +631,7 @@ inline hash_code hash_integer_value(uint64_t value) {
 // Declared and documented above, but defined here so that any of the hashing
 // infrastructure is available.
 template <typename T>
-std::enable_if_t<is_integral_or_enum<T>::value, hash_code> hash_value(T value) {
+std::enable_if_t<is_integral_or_enum<T>::value, hash_code> hash_value(T &value) {
   return ::llvm::hashing::detail::hash_integer_value(
       static_cast<uint64_t>(value));
 }


### PR DESCRIPTION
(sci) Abaels-MBP:llvm-macosx-x86_64 abaelhe$ /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ -v
Apple clang version 11.0.3 (clang-1103.0.32.62)
Target: x86_64-apple-darwin19.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
(sci) Abaels-MBP:llvm-macosx-x86_64 abaelhe$ /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++  -DGTEST_HAS_RTTI=0 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Ilib/Support -I/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/lib/Support -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/libxml2 -Iinclude -I/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include -Wno-unknown-warning-option -Werror=unguarded-availability-new -fno-stack-protector -g -fPIC -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wcovered-switch-default -Wno-class-memaccess -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wstring-conversion -fdiagnostics-color -std=c++14 -O2 -DNDEBUG -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -mmacosx-version-min=10.9   -std=c++14  -fno-exceptions -fno-rtti -MD -MT lib/Support/CMakeFiles/LLVMSupport.dir/APFloat.cpp.o -MF lib/Support/CMakeFiles/LLVMSupport.dir/APFloat.cpp.o.d -o lib/Support/CMakeFiles/LLVMSupport.dir/APFloat.cpp.o -c /Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/lib/Support/APFloat.cpp
In file included from /Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/lib/Support/APFloat.cpp:14:
In file included from /Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/APFloat.h:20:
In file included from /Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/ArrayRef.h:12:
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/Hashing.h:373:10: error: no matching function for call to 'hash_value'
  return llvm::hash_value(value);
         ^~~~~~~~~~~~~~~~
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/Hashing.h:554:63: note: in instantiation of function template specialization
      'llvm::hashing::detail::get_hashable_data<llvm::hash_code>' requested here
    buffer_ptr = combine_data(length, buffer_ptr, buffer_end, get_hashable_data(arg));
                                                              ^
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/Hashing.h:557:12: note: in instantiation of function template specialization
      'llvm::hashing::detail::hash_combine_recursive_helper::combine<llvm::hash_code>' requested here
    return combine(length, buffer_ptr, buffer_end, args...);
           ^
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/Hashing.h:557:12: note: in instantiation of function template specialization
      'llvm::hashing::detail::hash_combine_recursive_helper::combine<int, llvm::hash_code>' requested here
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/Hashing.h:557:12: note: in instantiation of function template specialization
      'llvm::hashing::detail::hash_combine_recursive_helper::combine<unsigned int, int, llvm::hash_code>' requested here
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/Hashing.h:557:12: note: in instantiation of function template specialization
      'llvm::hashing::detail::hash_combine_recursive_helper::combine<unsigned char, unsigned int, int, llvm::hash_code>' requested here
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/Hashing.h:602:17: note: in instantiation of function template specialization
      'llvm::hashing::detail::hash_combine_recursive_helper::combine<unsigned char, unsigned char, unsigned int, int, llvm::hash_code>' requested here
  return helper.combine(0, helper.buffer, helper.buffer + 64, args...);
                ^
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/lib/Support/APFloat.cpp:2858:10: note: in instantiation of function template specialization
      'llvm::hash_combine<unsigned char, unsigned char, unsigned int, int, llvm::hash_code>' requested here
  return hash_combine((uint8_t)Arg.category, (uint8_t)Arg.sign,
         ^
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/APInt.h:2278:11: note: candidate function not viable: no known conversion
      from 'const llvm::hash_code' to 'const llvm::APInt' for 1st argument
hash_code hash_value(const APInt &Arg);
          ^
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/Hashing.h:105:1: note: candidate template ignored: requirement
      'is_integral_or_enum<llvm::hash_code>::value' was not satisfied [with T = llvm::hash_code]
hash_value(T value);
^
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/Hashing.h:110:33: note: candidate template ignored: could not match
      'const T *' against 'llvm::hash_code'
template <typename T> hash_code hash_value(const T *ptr);
                                ^
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/Hashing.h:114:11: note: candidate template ignored: could not match
      'pair<type-parameter-0-0, type-parameter-0-1>' against 'const llvm::hash_code'
hash_code hash_value(const std::pair<T, U> &arg);
          ^
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/Hashing.h:118:11: note: candidate template ignored: could not match
      'basic_string<type-parameter-0-0, char_traits<type-parameter-0-0>, allocator<type-parameter-0-0> >' against 'const llvm::hash_code'
hash_code hash_value(const std::basic_string<T> &arg);
          ^
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/Hashing.h:554:63: error: no matching function for call to
      'get_hashable_data'
    buffer_ptr = combine_data(length, buffer_ptr, buffer_end, get_hashable_data(arg));
                                                              ^~~~~~~~~~~~~~~~~
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/Hashing.h:602:17: note: in instantiation of function template specialization
      'llvm::hashing::detail::hash_combine_recursive_helper::combine<llvm::hash_code, llvm::hash_code>' requested here
  return helper.combine(0, helper.buffer, helper.buffer + 64, args...);
                ^
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/lib/Support/APFloat.cpp:4344:12: note: in instantiation of function template specialization
      'llvm::hash_combine<llvm::hash_code, llvm::hash_code>' requested here
    return hash_combine(hash_value(Arg.Floats[0]), hash_value(Arg.Floats[1]));
           ^
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/Hashing.h:364:1: note: candidate template ignored: requirement
      'is_hashable_data<llvm::hash_code>::value' was not satisfied [with T = llvm::hash_code]
get_hashable_data(const T &value) {
^
/Users/abaelhe/workspace/APPLE/swift-master/llvm-project/llvm/include/llvm/ADT/Hashing.h:372:1: note: candidate template ignored: substitution failure
      [with T = llvm::hash_code]
get_hashable_data(const T &value) {
^
2 errors generated.