### PR TITLE
debugserver: Support ios simulator load command disambiguation in qPr…

### DIFF
--- a/lldb/tools/debugserver/source/DNB.cpp
+++ b/lldb/tools/debugserver/source/DNB.cpp
@@ -1393,7 +1393,10 @@ const char *DNBGetDeploymentInfo(nub_process_t pid,
                                  uint32_t& patch_version) {
   MachProcessSP procSP;
   if (GetProcessSP(pid, procSP)) {
-    // FIXME: This doesn't correct for older ios simulator and macCatalyst.
+    // FIXME: This doesn't return the correct result when xctest (a
+    // macOS binary) is loaded with the macCatalyst dyld platform
+    // override. The image info corrects for this, but qProcessInfo
+    // will return what is in the binary.
     auto info = procSP->GetDeploymentInfo(lc, load_command_address);
     major_version = info.major_version;
     minor_version = info.minor_version;

--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.h
@@ -236,9 +236,6 @@ public:
     operator bool() { return platform > 0; }
     /// The Mach-O platform type;
     unsigned char platform = 0;
-    /// Pre-LC_BUILD_VERSION files don't disambiguate between ios and ios
-    /// simulator.
-    bool maybe_simulator = false;
     uint32_t major_version = 0;
     uint32_t minor_version = 0;
     uint32_t patch_version = 0;


### PR DESCRIPTION
…ocessInfo

This patch basically moves the disambiguation code from a place where
it was complicated to implement straight to where the load command is
parsed, which has the neat side affect of actually supporting all call
sites!

rdar://problem/66011909

Differential Revision: https://reviews.llvm.org/D84480

(cherry picked from commit 58d84eb534252747115b358c890a1b79c65d4ad4)