### PR TITLE
debugserver: Support ios simulator load command disambiguation in qPr…

### DIFF
--- a/lldb/tools/debugserver/source/DNB.cpp
+++ b/lldb/tools/debugserver/source/DNB.cpp
@@ -1392,7 +1392,10 @@ const char *DNBGetDeploymentInfo(nub_process_t pid,
                                  uint32_t& patch_version) {
   MachProcessSP procSP;
   if (GetProcessSP(pid, procSP)) {
-    // FIXME: This doesn't correct for older ios simulator and macCatalyst.
+    // FIXME: This doesn't return the correct result when xctest (a
+    // macOS binary) is loaded with the macCatalyst dyld platform
+    // override. The image info corrects for this, but qProcessInfo
+    // will return what is in the binary.
     auto info = procSP->GetDeploymentInfo(lc, load_command_address);
     major_version = info.major_version;
     minor_version = info.minor_version;

--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.h
@@ -236,9 +236,6 @@ public:
     operator bool() { return platform > 0; }
     /// The Mach-O platform type;
     unsigned char platform = 0;
-    /// Pre-LC_BUILD_VERSION files don't disambiguate between ios and ios
-    /// simulator.
-    bool maybe_simulator = false;
     uint32_t major_version = 0;
     uint32_t minor_version = 0;
     uint32_t patch_version = 0;

--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
@@ -613,7 +613,28 @@ MachProcess::GetDeploymentInfo(const struct load_command &lc,
     info.major_version = vers_cmd.version >> 16;
     info.minor_version = (vers_cmd.version >> 8) & 0xffu;
     info.patch_version = vers_cmd.version & 0xffu;
-    info.maybe_simulator = true;
+
+    // Disambiguate legacy simulator platforms.
+#if (defined(__x86_64__) || defined(__i386__))
+    // If we are running on Intel macOS, it is safe to assume this is
+    // really a back-deploying simulator binary.
+    switch (info.platform) {
+    case PLATFORM_IOS:
+      info.platform = PLATFORM_IOSSIMULATOR;
+      break;
+    case PLATFORM_TVOS:
+      info.platform = PLATFORM_TVOSSIMULATOR;
+      break;
+    case PLATFORM_WATCHOS:
+      info.platform = PLATFORM_WATCHOSSIMULATOR;
+      break;
+    }
+#else
+    // On an Apple Silicon macOS host, there is no ambiguity. The only
+    // binaries that use legacy load commands are back-deploying
+    // native iOS binaries. All simulator binaries use the newer,
+    // unambiguous LC_BUILD_VERSION load commands.
+#endif
   };
   switch (cmd) {
   case LC_VERSION_MIN_IPHONEOS:
@@ -774,34 +795,6 @@ bool MachProcess::GetMachOInformationFromMemory(
         uuid_copy(inf.uuid, uuidcmd.uuid);
     }
     if (DeploymentInfo deployment_info = GetDeploymentInfo(lc, load_cmds_p)) {
-      // Simulator support. If the platform is ambiguous, use the dyld info.
-      if (deployment_info.maybe_simulator) {
-        // If dyld doesn't return a platform, use a heuristic.
-#if (defined(__x86_64__) || defined(__i386__))
-        // If we are running on Intel macOS, it is safe to assume
-        // this is really a back-deploying simulator binary.
-        if (deployment_info.maybe_simulator) {
-          switch (deployment_info.platform) {
-          case PLATFORM_IOS:
-            deployment_info.platform = PLATFORM_IOSSIMULATOR;
-            break;
-          case PLATFORM_TVOS:
-            deployment_info.platform = PLATFORM_TVOSSIMULATOR;
-            break;
-          case PLATFORM_WATCHOS:
-            deployment_info.platform = PLATFORM_WATCHOSSIMULATOR;
-            break;
-          }
-#else
-        // On an Apple Silicon macOS host, there is no
-        // ambiguity. The only binaries that use legacy load
-        // commands are back-deploying native iOS binaries. All
-        // simulator binaries use the newer, unambiguous
-        // LC_BUILD_VERSION load commands.
-        deployment_info.maybe_simulator = false;
-#endif
-        }
-      }
       const char *lc_platform = GetPlatformString(deployment_info.platform);
       // macCatalyst support.
       //


### PR DESCRIPTION
…ocessInfo

This patch basically moves the disambiguation code from a place where
it was complicated to implement straight to where the load command is
parsed, which has the neat side affect of actually supporting all call
sites!

rdar://problem/66011909

Differential Revision: https://reviews.llvm.org/D84480

(cherry picked from commit 58d84eb534252747115b358c890a1b79c65d4ad4)

 Conflicts:
	lldb/tools/debugserver/source/MacOSX/MachProcess.mm