### PR TITLE
[ASTImporter] Modify ImportDefiniton for ObjCInterfaceDecl so that we always the ImportDeclContext one we start the definition

### DIFF
--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -4758,11 +4758,10 @@ Error ASTNodeImporter::ImportDefinition(
       return ToImplOrErr.takeError();
   }
 
-  if (shouldForceImportDeclContext(Kind)) {
-    // Import all of the members of this class.
-    if (Error Err = ImportDeclContext(From, /*ForceImport=*/true))
-      return Err;
-  }
+  // Import all of the members of this class.
+  if (Error Err = ImportDeclContext(From, /*ForceImport=*/true))
+    return Err;
+
   return Error::success();
 }
 

--- a/lldb/test/API/lang/objc/bitfield_ivars/TestBitfieldIvars.py
+++ b/lldb/test/API/lang/objc/bitfield_ivars/TestBitfieldIvars.py
@@ -14,9 +14,8 @@ class TestBitfieldIvars(TestBase):
         lldbutil.run_to_source_breakpoint(self, "// break here", lldb.SBFileSpec("main.m"))
 
         self.expect_expr("chb->hb->field1", result_type="unsigned int", result_value="0")
-
-        ## FIXME field2 should have a value of 1
-        self.expect("expr chb->hb->field2", matching=False, substrs = ["= 1"]) # this must happen second
+        ## This should happen second
+        self.expect_expr("chb->hb->field2", result_type="unsigned int", result_value="1")
 
         self.expect_expr("hb2->field1", result_type="unsigned int", result_value="10")
         self.expect_expr("hb2->field2", result_type="unsigned int", result_value="3")


### PR DESCRIPTION
Once we start the definition of an ObjCInterfaceDecl we won't attempt to ImportDeclContext
later on. Unlike RecordDecl case which uses DefinitionCompleter to force completeDefinition
we don't seem to have a similar mechanism for ObjCInterfaceDecl.

This fix was needed due to a bug we see in LLDB expression parsing where an initial expression
cause an ObjCInterfaceDecl to be defined and subsequent expressions during import do not call
ImportDeclContext and we can end up in a situation where ivars are imported out of order and not all ivars are imported.

Differential Revision: https://reviews.llvm.org/D83972

(cherry picked from commit 0db2934b0fa9e00ac98e2cb168adba96f6bcd0da)