### PR TITLE
[lldb] Fix llvm-lit in standalone builds

### DIFF
--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -216,6 +216,9 @@ add_dependencies(check-lldb-reproducers check-lldb-reproducers-capture)
 if(LLDB_BUILT_STANDALONE)
   # This has to happen *AFTER* add_lit_testsuite.
   if (EXISTS ${LLVM_MAIN_SRC_DIR}/utils/llvm-lit)
+    # LLVM's make_paths_relative uses Python3_EXECUTABLE which isn't set in a
+    # standalone LLDB build.
+    set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
     add_subdirectory(${LLVM_MAIN_SRC_DIR}/utils/llvm-lit ${CMAKE_CURRENT_BINARY_DIR}/llvm-lit)
   endif()
 endif()


### PR DESCRIPTION
LLVM's make_paths_relative uses Python3_EXECUTABLE which isn't set in
standalone LLDB builds.

(cherry picked from commit 6587ff77ea7aea508dde4ff68bf89e301756a52c)