### PR TITLE
[lldb] Add SBCommandInterpreterRunOptions to LLDB.h

### DIFF
--- a/lldb/include/lldb/API/LLDB.h
+++ b/lldb/include/lldb/API/LLDB.h
@@ -17,6 +17,7 @@
 #include "lldb/API/SBBreakpointName.h"
 #include "lldb/API/SBBroadcaster.h"
 #include "lldb/API/SBCommandInterpreter.h"
+#include "lldb/API/SBCommandInterpreterRunOptions.h"
 #include "lldb/API/SBCommandReturnObject.h"
 #include "lldb/API/SBCommunication.h"
 #include "lldb/API/SBCompileUnit.h"


### PR DESCRIPTION
(cherry picked from commit b6635b5b15cb1c160776493a982302a854df332e)