### PR TITLE
debguserver's type sniffer to only treat .app things that end in .app

### DIFF
--- a/lldb/tools/debugserver/source/debugserver.cpp
+++ b/lldb/tools/debugserver/source/debugserver.cpp
@@ -156,6 +156,20 @@ RNBRunLoopMode RNBRunLoopGetStartModeFromRemote(RNBRemote *remote) {
   return eRNBRunLoopModeExit;
 }
 
+// Check the name to see if it ends with .app
+static bool is_dot_app (const char *app_name) {
+  size_t len = strlen(app_name);
+  if (len < 4)
+    return false;
+  
+  if (app_name[len - 4] == '.' &&
+      app_name[len - 3] == 'a' && 
+      app_name[len - 2] == 'p' &&
+      app_name[len - 1] == 'p')
+    return true;
+  return false;
+}
+
 // This run loop mode will wait for the process to launch and hit its
 // entry point. It will currently ignore all events except for the
 // process state changed event, where it watches for the process stopped
@@ -200,17 +214,17 @@ RNBRunLoopMode RNBRunLoopLaunchInferior(RNBRemote *remote,
 
 #if defined WITH_FBS
     // Check if we have an app bundle, if so launch using BackBoard Services.
-    if (strstr(inferior_argv[0], ".app")) {
+    if (is_dot_app(inferior_argv[0])) {
       launch_flavor = eLaunchFlavorFBS;
     }
 #elif defined WITH_BKS
     // Check if we have an app bundle, if so launch using BackBoard Services.
-    if (strstr(inferior_argv[0], ".app")) {
+    if (is_dot_app(inferior_argv[0])) {
       launch_flavor = eLaunchFlavorBKS;
     }
 #elif defined WITH_SPRINGBOARD
     // Check if we have an app bundle, if so launch using SpringBoard.
-    if (strstr(inferior_argv[0], ".app")) {
+    if (is_dot_app(inferior_argv[0])) {
       launch_flavor = eLaunchFlavorSpringBoard;
     }
 #endif
@@ -1498,17 +1512,17 @@ int main(int argc, char *argv[]) {
 
 #if defined WITH_FBS
           // Check if we have an app bundle, if so launch using SpringBoard.
-          if (waitfor_pid_name.find(".app") != std::string::npos) {
+          if (is_dot_app(waitfor_pid_name.c_str())) {
             launch_flavor = eLaunchFlavorFBS;
           }
 #elif defined WITH_BKS
           // Check if we have an app bundle, if so launch using SpringBoard.
-          if (waitfor_pid_name.find(".app") != std::string::npos) {
+          if (is_dot_app(waitfor_pid_name.c_str())) {
             launch_flavor = eLaunchFlavorBKS;
           }
 #elif defined WITH_SPRINGBOARD
           // Check if we have an app bundle, if so launch using SpringBoard.
-          if (waitfor_pid_name.find(".app") != std::string::npos) {
+          if (is_dot_app(waitfor_pid_name.c_str())) {
             launch_flavor = eLaunchFlavorSpringBoard;
           }
 #endif


### PR DESCRIPTION
debguserver's type sniffer to only treat .app things that end in .app

On an iOS device, if debugserver is left to figure out how to launch
the binary provided, it looks at the filename to see if it contains
".app" and asks FrontBoard to launch it.  However, if this is actually
a command line app with the characters ".app" in the name, it would
end up trying to launch that via the FrontBoard calls even though it
needed to be launched via posix_spawn.  For instance, a command line
program called com.application.tester.

Jim suggested this patch where we only send binaries that end in ".app"
to FrontBoard.

Often debugsever is invoked with a --launch command line argument to
specify the launch method, and none of this code is hit in that
instance.

<rdar://problem/65297100>

(cherry picked from commit abf546dd4f8326b821244b67eaa79ada7757d877)