### PR TITLE
[lldb/Test] Reduce code duplication by importing subprocess globally

### DIFF
--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -6,6 +6,7 @@ import os
 import platform
 import shlex
 import shutil
+import subprocess
 
 import lit.formats
 
@@ -33,7 +34,6 @@ def mkdir_p(path):
 
 
 def find_sanitizer_runtime(name):
-  import subprocess
   resource_dir = subprocess.check_output(
       [config.cmake_cxx_compiler,
        '-print-resource-dir']).decode('utf-8').strip()
@@ -60,7 +60,6 @@ def find_python_interpreter():
     return copied_python
 
   # Find the "real" python binary.
-  import shutil, subprocess
   real_python = subprocess.check_output([
       config.python_executable,
       os.path.join(os.path.dirname(os.path.realpath(__file__)),


### PR DESCRIPTION
Import the subprocess module once instead of doing it inline which is
error prone and leads to needless code duplication.

(cherry picked from commit 162e9f72ac57342a0ea12036576d6212720cc93f)