### PR TITLE
Make sure the Swift REPL is initialized with host OS availablity.

### DIFF
--- a/lldb/test/Shell/SwiftREPL/Availability.test
+++ b/lldb/test/Shell/SwiftREPL/Availability.test
@@ -1,0 +1,14 @@
+// -*- mode: swift; -*-
+// Test that the REPL is launched with the current OS as availability target.
+// REQUIRES: system-darwin
+
+// RUN: mkdir -p %t.dir
+// RUN: echo '@available(macOS '>%t.dir/NewModule.swift
+// RUN: sw_vers | grep ProductVersion | cut -d : -f 2 >>%t.dir/NewModule.swift
+// RUN: echo ', *) public let message = "Hello"' >>%t.dir/NewModule.swift
+// RUN: %target-swiftc -module-name NewModule -emit-module -emit-library -o %t.dir/libNewModule%target-shared-library-suffix %t.dir/NewModule.swift
+
+// RUN: %lldb --repl="-I%t.dir -L%t.dir -lNewModule" --repl-language swift < %s | FileCheck %s
+import NewModule
+message
+// CHECK: $R0{{.*}}Hello


### PR DESCRIPTION
This is fixed by unifying the code that updates the ArchSpec after
finding a fat binary with how it is done for a lean binary.

<rdar://problem/66024437>

This is for the 5.3 branch only. I will prepare a separate patch to make a similar change on llvm.org.