### PR TITLE
[lldb] Create a symlink to the Python interpreter used by LLDB.

### DIFF
--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -134,6 +134,7 @@ endif()
 
 if(PYTHON_RPATH)
   set_property(TARGET liblldb APPEND PROPERTY INSTALL_RPATH "${PYTHON_RPATH}")
+  set_property(TARGET liblldb APPEND PROPERTY BUILD_RPATH "${PYTHON_RPATH}")
 endif()
 
 if (MSVC)


### PR DESCRIPTION
This was Swift knows where to find the right interpreter in their tests.