### PR TITLE
build: always add support for assembly targets on Darwin

### DIFF
--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
@@ -109,7 +109,7 @@ endfunction()
 function(add_asm_sources output)
   set(${output} ${ARGN} PARENT_SCOPE)
   # Xcode will try to compile asm files as C ('clang -x c'), and that will fail.
-  if (${CMAKE_GENERATOR} STREQUAL "Xcode")
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     enable_language(ASM)
   else()
     # Pass ASM file directly to the C++ compiler.


### PR DESCRIPTION
When attempting to build compiler-rt on a developer transition kit, the
build would fail due to `.S` files not being handled properly by the
Ninja generator.  Rather than conditionalising on Xcode, conditionalise
to Darwin.  Because we know that the system compiler is clang based, it
will always properly handle the pre-processing based on the extension.

Differential Revision: https://reviews.llvm.org/D84333

(cherry picked from commit d8e8e32d85f1cbde2a6b67af010fba3c3a3c86e9)