### PR TITLE
TypeSystem: extend the triple sanitization for Swift

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2307,14 +2307,23 @@ llvm::Triple SwiftASTContext::GetTriple() const {
   return llvm::Triple(m_compiler_invocation_ap->getTargetTriple());
 }
 
-/// Conditions a triple string to be safe for use with Swift.  Right
-/// now this just strips the Haswell marker off the CPU name.
+/// Conditions a triple string to be safe for use with Swift.
+///
+/// This strips the Haswell marker off the CPU name (for Apple targets).
+///
+/// It also add the GNU environment for Linux.  Although this is technically
+/// incorrect, as the `*-unknown-linux` environment represents the bare-metal
+/// environment, because Swift is currently hosted only, we can get away with
+/// it.
 ///
 /// TODO: Make Swift more robust.
-static std::string GetSwiftFriendlyTriple(StringRef triple) {
-  if (triple.consume_front("x86_64h"))
-    return std::string("x86_64") + triple.str();
-  return triple.str();
+static std::string GetSwiftFriendlyTriple(llvm::Triple triple) {
+  if (triple.getArchName() == "x86_64h")
+    triple.setArch(llvm::Triple::x86_64);
+  if (triple.isOSLinux() &&
+      triple.getEnvironment() == llvm::Triple::UnknownEnvironment)
+    triple.setEnvironment(llvm::Triple::GNU);
+  return triple.normalize();
 }
 
 bool SwiftASTContext::SetTriple(const llvm::Triple triple, Module *module) {
@@ -2332,7 +2341,7 @@ bool SwiftASTContext::SetTriple(const llvm::Triple triple, Module *module) {
   }
 
   const unsigned unspecified = 0;
-  std::string adjusted_triple = GetSwiftFriendlyTriple(triple.str());
+  std::string adjusted_triple = GetSwiftFriendlyTriple(triple);
   // If the OS version is unspecified, do fancy things.
   if (triple.getOSMajorVersion() == unspecified) {
     // If a triple is "<arch>-apple-darwin" change it to be


### PR DESCRIPTION
The triple as computed from the executable by lldb is `x86_64--linux`.
While this is sufficient for many uses, it is insufficient for Swift
which requires a matching triple.

`x86_64--linux` is morally equivalent to `x86_64-unknown-linux` which is
easily achieved through normalization.  However, this is insufficient on
its own.  This new triple is morally equivalent to
`x86_64-unknown-linux-none-elf`: a freestanding environment, that is, it
is a bare-metal target.  Unlike the Darwin environments, the environment
on Linux is important as that identifies the libc (GNU = glibc, uclibc =
µlibc, musl = musl).  Furthermore, it contains extended ABI information,
e.g. `gnueabi` vs `gnueabihf` which indicates glibc + EABI + soft float
vs hard float (`-meabi`, `-mfloat-abi=soft`/`mflot-abi=hard`) which are
incompatible targets.

Fortunately, triple normalization is a very common process in clang and
the API on `llvm::Triple` allows us to do this as explicit operations.
The previous approach explicitly replaced the arch name spelling of
`x86_64h` which is the Haswell slice with the generic `x86_64`
architecture to handle Darwin targets.  Because the Haswell slice only
enables better code generation and is ABI compatible (though not
executable across previous generations), this difference does not
matter.  Re-apply this change in terms of `llvm::Triple`.

This code now assumes that the Linux environment is `gnu` which is
woefully inadequate but given that the REPL currently is not meant to
execute on android (which uses `android` or `androideabi` for the
environment and the bionic libc) and Swift is currently hosted only, it
is a stop gap until this can be addressed more thoroughly.

This change is sufficient to enable unification of the Swift resource
directory layout across Darwin and non-Darwin targets.