### PR TITLE
[lldb] [testsuite] TestGdbRemoteLibrariesSvr4Support: Fix symlinked b…

### DIFF
--- a/lldb/test/API/tools/lldb-server/libraries-svr4/TestGdbRemoteLibrariesSvr4Support.py
+++ b/lldb/test/API/tools/lldb-server/libraries-svr4/TestGdbRemoteLibrariesSvr4Support.py
@@ -103,7 +103,7 @@ class TestGdbRemoteLibrariesSvr4Support(gdbremote_testcase.GdbRemoteTestCaseBase
             name = child.attrib.get("name")
             libraries_svr4_names.append(os.path.realpath(name))
         for lib in self.get_expected_libs():
-            self.assertIn(self.getBuildDir() + "/" + lib, libraries_svr4_names)
+            self.assertIn(os.path.realpath(self.getBuildDir() + "/" + lib), libraries_svr4_names)
 
     @llgs_test
     @skipUnlessPlatform(["linux", "android", "netbsd"])


### PR DESCRIPTION
…uilddir

When I have symlinked builddir on Fedora 31 x86_64 I get:

	FAIL: test_libraries_svr4_libs_present (TestGdbRemoteLibrariesSvr4Support.TestGdbRemoteLibrariesSvr4Support)
	----------------------------------------------------------------------
	...
	  File "lldb/packages/Python/lldbsuite/test/tools/lldb-server/libraries-svr4/TestGdbRemoteLibrariesSvr4Support.py", line 106, in
	libraries_svr4_libs_present
	    self.assertIn(self.getBuildDir() + "/" + lib, libraries_svr4_names)
	AssertionError:
	'/home/jkratoch/redhat/llvm-monorepo-clangassertsymlink/lldb-test-build.noindex/tools/lldb-server/libraries-svr4/TestGdbRemoteLibrariesSvr4Support.test_libraries_svr4_libs_present/libsvr4lib_a.so' not found in ['/home/jkratoch/redhat/llvm-monorepo/lldb/packages/Python/lldbsuite/test/tools/lldb-server/libraries-svr4/linux-vdso.so.1', '/quad/home/jkratoch/redhat/llvm-monorepo-clangassertsymlink/lldb-test-build.noindex/tools/lldb-server/libraries-svr4/TestGdbRemoteLibrariesSvr4Support.test_libraries_svr4_libs_present/libsvr4lib_a.so', '/quad/home/jkratoch/redhat/llvm-monorepo-clangassertsymlink/lldb-test-build.noindex/tools/lldb-server/libraries-svr4/TestGdbRemoteLibrariesSvr4Support.test_libraries_svr4_libs_present/libsvr4lib_b".so', '/usr/lib64/libdl-2.30.so', '/usr/lib64/libstdc++.so.6.0.27', '/usr/lib64/libm-2.30.so', '/usr/lib64/libgcc_s-9-20190827.so.1', '/usr/lib64/libc-2.30.so', '/usr/lib64/ld-2.30.so']
	Config=x86_64-/quad/home/jkratoch/redhat/llvm-monorepo-clangassertsymlink/bin/clang-11
	----------------------------------------------------------------------

Differential Revision: https://reviews.llvm.org/D74295

(cherry picked from commit 420a51806850a20ebf4144699457de84513f6abc)