### PR TITLE
Revert "macOS 11 support: add a temporary macOS 10.16 -> macOS 11 tri…

### DIFF
--- a/llvm/lib/Support/Triple.cpp
+++ b/llvm/lib/Support/Triple.cpp
@@ -1069,12 +1069,6 @@ void Triple::getOSVersion(unsigned &Major, unsigned &Minor,
     OSName.consume_front("macos");
 
   parseVersionFromName(OSName, Major, Minor, Micro);
-  if (getOS() == MacOSX && Major == 10 && Minor == 16 && Micro == 0) {
-    // macOS 10.16 is canonicalized to macOS 11.
-    Major = 11;
-    Minor = 0;
-    Micro = 0;
-  }
 }
 
 bool Triple::getMacOSXVersion(unsigned &Major, unsigned &Minor,

--- a/llvm/unittests/ADT/TripleTest.cpp
+++ b/llvm/unittests/ADT/TripleTest.cpp
@@ -1235,8 +1235,8 @@ TEST(TripleTest, getOSVersion) {
   T = Triple("x86_64-apple-macos10.16");
   EXPECT_TRUE(T.isMacOSX());
   T.getMacOSXVersion(Major, Minor, Micro);
-  EXPECT_EQ((unsigned)11, Major);
-  EXPECT_EQ((unsigned)0, Minor);
+  EXPECT_EQ((unsigned)10, Major);
+  EXPECT_EQ((unsigned)16, Minor);
   EXPECT_EQ((unsigned)0, Micro);
 
   T = Triple("x86_64-apple-darwin20");


### PR DESCRIPTION
…ple canonicalization to unblock swift CI that uses modules from Beta 1"

This reverts commit 9fd29837db792952a7fb282cb7298a5662ba00a8.