### PR TITLE
[lldb/Test] Fix skipTestIfFn for fucntions that return a value

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -137,7 +137,7 @@ def skipTestIfFn(expected_fn, bugnumber=None):
             if reason is not None:
                 self.skipTest(reason)
             else:
-                func(*args, **kwargs)
+                return func(*args, **kwargs)
         return wrapper
 
     # Some decorators can be called both with no arguments (e.g. @expectedFailureWindows)


### PR DESCRIPTION
Sometimes the decorator is used on a common function rather than the
test method, which can return a value. This fails with decorators that
use skipTestIfFn under the hood.

(cherry picked from commit d6a5cce0e7d65562f081569a61595e53cdb8d5d0)