### PR TITLE
[SelectionDAG] Fix lowering of vector geps

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -3790,8 +3790,6 @@ void SelectionDAGBuilder::visitGetElementPtr(const User &I) {
   SDValue N = getValue(Op0);
   SDLoc dl = getCurSDLoc();
   auto &TLI = DAG.getTargetLoweringInfo();
-  MVT PtrTy = TLI.getPointerTy(DAG.getDataLayout(), AS);
-  MVT PtrMemTy = TLI.getPointerMemTy(DAG.getDataLayout(), AS);
 
   // Normalize Vector GEP - all scalar operands should be converted to the
   // splat vector.
@@ -3915,6 +3913,13 @@ void SelectionDAGBuilder::visitGetElementPtr(const User &I) {
       N = DAG.getNode(ISD::ADD, dl,
                       N.getValueType(), N, IdxN);
     }
+  }
+
+  MVT PtrTy = TLI.getPointerTy(DAG.getDataLayout(), AS);
+  MVT PtrMemTy = TLI.getPointerMemTy(DAG.getDataLayout(), AS);
+  if (IsVectorGEP) {
+    PtrTy = MVT::getVectorVT(PtrTy, VectorElementCount);
+    PtrMemTy = MVT::getVectorVT(PtrMemTy, VectorElementCount);
   }
 
   if (PtrMemTy != PtrTy && !cast<GEPOperator>(I).isInBounds())

--- a/llvm/test/CodeGen/AArch64/vector-gep.ll
+++ b/llvm/test/CodeGen/AArch64/vector-gep.ll
@@ -1,0 +1,21 @@
+; RUN: llc < %s -mtriple=arm64_32-apple-watchos2.0.0 --aarch64-neon-syntax=generic | FileCheck %s
+
+target datalayout = "e-m:o-p:32:32-i64:64-i128:128-n32:64-S128"
+target triple = "arm64_32-apple-watchos2.0.0"
+
+; CHECK-LABEL: lCPI0_0:
+; CHECK-NEXT:    .quad 36
+; CHECK-NEXT:    .quad 4804
+
+define <2 x i8*> @vector_gep(<2 x i8*> %0) {
+; CHECK-LABEL: vector_gep:
+; CHECK:         adrp x[[REG8:[123]?[0-9]]], lCPI0_0@PAGE
+; CHECK:         ldr q[[REG1:[0-9]+]], [x[[REG8]], lCPI0_0@PAGEOFF]
+; CHECK:         add v[[REG0:[0-9]+]].2d, v[[REG0]].2d, v[[REG1]].2d
+; CHECK:         movi v[[REG1]].2d, #0x000000ffffffff
+; CHECK:         and v[[REG0]].16b, v[[REG0]].16b, v[[REG1]].16b
+; CHECK:         ret
+entry:
+  %1 = getelementptr i8, <2 x i8*> %0, <2 x i32> <i32 36, i32 4804>
+  ret <2 x i8*> %1
+}


### PR DESCRIPTION
This fixes an assertion failure that was being triggered in
SelectionDAG::getZeroExtendInReg(), where it was trying to extend the <2xi32>
to i64 (which should have been <2xi64>).

Fixes: rdar://66016901

Differential Revision: https://reviews.llvm.org/D84884

This is a cherry-pick of: afae6d97fa55984003321245ec6ceb5af9cc5856