### PR TITLE
[lldb/Host] Upstream macOS TCC code

### DIFF
--- a/lldb/source/Host/macosx/objcxx/Host.mm
+++ b/lldb/source/Host/macosx/objcxx/Host.mm
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Host/Host.h"
+#include "PosixSpawnResponsible.h"
 
 #include <AvailabilityMacros.h>
 #include <TargetConditionals.h>
@@ -1081,6 +1082,29 @@ static Status LaunchProcessPosixSpawn(const char *exe_path,
              "error: {0}, ::posix_spawnattr_setflags ( &attr, flags={1:x} )",
              error, flags);
     return error;
+  }
+
+  bool is_graphical = true;
+
+#if TARGET_OS_OSX
+  SecuritySessionId session_id;
+  SessionAttributeBits session_attributes;
+  OSStatus status =
+      SessionGetInfo(callerSecuritySession, &session_id, &session_attributes);
+  if (status == errSessionSuccess)
+    is_graphical = session_attributes & sessionHasGraphicAccess;
+#endif
+
+  //  When lldb is ran through a graphical session, this makes the debuggee
+  //  process responsible for the TCC prompts. Otherwise, lldb will use the
+  //  launching process privileges.
+  if (is_graphical && launch_info.GetFlags().Test(eLaunchFlagDebug)) {
+    error.SetError(setup_posix_spawn_responsible_flag(&attr), eErrorTypePOSIX);
+    if (error.Fail()) {
+      LLDB_LOG(log, "error: {0}, setup_posix_spawn_responsible_flag(&attr)",
+               error);
+      return error;
+    }
   }
 
   const char *tmp_argv[2];

--- a/lldb/source/Host/macosx/objcxx/PosixSpawnResponsible.h
+++ b/lldb/source/Host/macosx/objcxx/PosixSpawnResponsible.h
@@ -1,0 +1,46 @@
+//===-- PosixSpawnResponsible.h ---------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_HOST_POSIXSPAWNRESPONSIBLE_H
+#define LLDB_HOST_POSIXSPAWNRESPONSIBLE_H
+
+#include <spawn.h>
+
+#if __has_include(<responsibility.h>)
+#include <dispatch/dispatch.h>
+#include <dlfcn.h>
+#include <responsibility.h>
+
+// Older SDKs  have responsibility.h but not this particular function. Let's
+// include the prototype here.
+errno_t responsibility_spawnattrs_setdisclaim(posix_spawnattr_t *attrs,
+                                              bool disclaim);
+
+#endif
+
+static inline int setup_posix_spawn_responsible_flag(posix_spawnattr_t *attr) {
+  if (@available(macOS 10.14, *)) {
+#if __has_include(<responsibility.h>)
+    static __typeof__(responsibility_spawnattrs_setdisclaim)
+        *responsibility_spawnattrs_setdisclaim_ptr;
+    static dispatch_once_t pred;
+    dispatch_once(&pred, ^{
+      responsibility_spawnattrs_setdisclaim_ptr =
+#ifdef __cplusplus
+          reinterpret_cast<__typeof__(&responsibility_spawnattrs_setdisclaim)>
+#endif
+          (dlsym(RTLD_DEFAULT, "responsibility_spawnattrs_setdisclaim"));
+    });
+    if (responsibility_spawnattrs_setdisclaim_ptr)
+      return responsibility_spawnattrs_setdisclaim_ptr(attr, true);
+#endif
+  }
+  return 0;
+}
+
+#endif // LLDB_HOST_POSIXSPAWNRESPONSIBLE_H


### PR DESCRIPTION
Upstream the code for dealing with TCC introduced in macOS Mojave. This
will make the debuggee instead of the debugger responsible for the
privileges it needs.

Differential revision: https://reviews.llvm.org/D85217

(cherry picked from commit 041c7b84a4b925476d1e21ed302786033bb6035f)