### PR TITLE
[lldb/Test] Add missing stdio.h includes

### DIFF
--- a/lldb/test/API/commands/target/basic/a.c
+++ b/lldb/test/API/commands/target/basic/a.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 int main(int argc, const char* argv[])
 {
     int *null_ptr = 0;

--- a/lldb/test/API/lang/c/global_variables/main.c
+++ b/lldb/test/API/lang/c/global_variables/main.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 int g_common_1; // Not initialized on purpose to cause it to be undefined external in .o file
 int g_file_global_int = 42;
 static const int g_file_static_int = 2;


### PR DESCRIPTION
Fixes error: implicit declaration of function 'printf' is invalid in C99
[-Werror,-Wimplicit-function-declaration]

(cherry picked from commit bb33f925a673f3bb9793d2157c9d3d46d9ad7f25)