### PR TITLE
[lldb/Test] Skip tests that try to get the remote environment

### DIFF
--- a/lldb/test/API/python_api/sbenvironment/TestSBEnvironment.py
+++ b/lldb/test/API/python_api/sbenvironment/TestSBEnvironment.py
@@ -31,6 +31,7 @@ class SBEnvironmentAPICase(TestBase):
 
 
     @add_test_categories(['pyapi'])
+    @skipIfRemote # Remote environment not supported.
     def test_platform_environment(self):
         env = self.dbg.GetSelectedPlatform().GetEnvironment()
         # We assume at least PATH is set
@@ -62,6 +63,7 @@ class SBEnvironmentAPICase(TestBase):
 
 
     @add_test_categories(['pyapi'])
+    @skipIfRemote # Remote environment not supported.
     def test_target_environment(self):
         env = self.dbg.GetSelectedTarget().GetEnvironment()
         # There is no target, so env should be empty

--- a/lldb/test/API/python_api/sbplatform/TestSBPlatform.py
+++ b/lldb/test/API/python_api/sbplatform/TestSBPlatform.py
@@ -9,6 +9,7 @@ class SBPlatformAPICase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @add_test_categories(['pyapi'])
+    @skipIfRemote # Remote environment not supported.
     def test_run(self):
         self.build()
         plat = lldb.SBPlatform.GetHostPlatform()


### PR DESCRIPTION
We don't support getting the remote environment. The gdb remote protocol
has no packet for that.

(cherry picked from commit ba3d84d82b750296c11e843365aa85962a561ad4)