### PR TITLE
[lldb/Test] Add @skipIfRemote decorator to TestProcessList.py

### DIFF
--- a/lldb/test/API/commands/platform/process/list/TestProcessList.py
+++ b/lldb/test/API/commands/platform/process/list/TestProcessList.py
@@ -18,6 +18,7 @@ class ProcessListTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipIfWindows  # https://bugs.llvm.org/show_bug.cgi?id=43702
+    @skipIfRemote   # rdar://problem/66542336
     def test_process_list_with_args(self):
         """Test process list show process args"""
         self.build()


### PR DESCRIPTION
lldb-platform contains a very minimal support for the qfProcessInfo
packet, only allowing the simplest query to get most of the testsuite
running, and returning very little information about the matched
processes.

(cherry picked from commit e8b7edafc3dd0ab85903eebdfdb3bb7cc2d66743)