### PR TITLE
[lldb] Make UBSan tests remote ready

### DIFF
--- a/lldb/test/API/functionalities/ubsan/basic/TestUbsanBasic.py
+++ b/lldb/test/API/functionalities/ubsan/basic/TestUbsanBasic.py
@@ -27,9 +27,9 @@ class UbsanBasicTestCase(TestBase):
     def ubsan_tests(self):
         # Load the test
         exe = self.getBuildArtifact("a.out")
-        self.expect(
-            "file " + exe,
-            patterns=["Current executable set to .*a.out"])
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+        self.registerSanitizerLibrariesWithTarget(target)
 
         self.runCmd("run")
 

--- a/lldb/test/API/functionalities/ubsan/user-expression/TestUbsanUserExpression.py
+++ b/lldb/test/API/functionalities/ubsan/user-expression/TestUbsanUserExpression.py
@@ -25,9 +25,9 @@ class UbsanUserExpressionTestCase(TestBase):
     def ubsan_tests(self):
         # Load the test
         exe = self.getBuildArtifact("a.out")
-        self.expect(
-            "file " + exe,
-            patterns=["Current executable set to .*a.out"])
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+        self.registerSanitizerLibrariesWithTarget(target)
 
         self.runCmd("breakpoint set -f main.c -l %d" % self.line_breakpoint)
 


### PR DESCRIPTION
Add missing call to registerSanitizerLibrariesWithTarget.

(cherry picked from commit 3a538de653607b7602a870d63b13dd51638c1424)