### PR TITLE
[lldb] Fix bug in skipIfRosetta decorator

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -553,10 +553,9 @@ def skipIfNoSBHeaders(func):
 def skipIfRosetta(bugnumber):
     """Skip a test when running the testsuite on macOS under the Rosetta translation layer."""
     def is_running_rosetta(self):
-        if not lldbplatformutil.getPlatform() in ['darwin', 'macosx']:
-            return "not on macOS"
-        if (platform.uname()[5] == "arm") and (self.getArchitecture() == "x86_64"):
-            return "skipped under Rosetta"
+        if lldbplatformutil.getPlatform() in ['darwin', 'macosx']:
+            if (platform.uname()[5] == "arm") and (self.getArchitecture() == "x86_64"):
+                return "skipped under Rosetta"
         return None
     return skipTestIfFn(is_running_rosetta)
 


### PR DESCRIPTION
Currently, the skipIfRosetta decorator will skip tests with the message
"not on macOS" on all platforms that are not `darwin` or `macosx`.
Instead, it should only check the platform and architecture when running
on these platforms.

This triggers for example when running the test suite on device.

Differential revision: https://reviews.llvm.org/D85388

(cherry picked from commit 4fccdd5c85d05b3b03d029f533762e233259573c)