### PR TITLE
Use new libReflection API when reading ELF files

### DIFF
--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -21,6 +21,10 @@
 #include "lldb/lldb-private.h"
 #include "llvm/Support/VersionTuple.h"
 
+namespace swift {
+class SwiftObjectFileFormat;
+enum ReflectionSectionKind : uint8_t;
+}
 namespace lldb_private {
 
 class ObjectFileJITDelegate {
@@ -649,6 +653,9 @@ public:
 
   /// Creates a plugin-specific call frame info
   virtual std::unique_ptr<CallFrameInfo> CreateCallFrameInfo();
+
+  virtual llvm::StringRef
+  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section);
 
 protected:
   // Member variables.

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -40,6 +40,7 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/MipsABIFlags.h"
+#include "swift/ABI/ObjectFile.h"
 
 #define CASE_AND_STREAM(s, def, width)                                         \
   case def:                                                                    \
@@ -3392,4 +3393,10 @@ ObjectFileELF::GetLoadableData(Target &target) {
     loadables.push_back(loadable);
   }
   return loadables;
+}
+
+llvm::StringRef ObjectFileELF::GetReflectionSectionIdentifier(
+    swift::ReflectionSectionKind section) {
+  swift::SwiftObjectFileFormatELF file_format_elf;
+  return file_format_elf.getSectionName(section);
 }

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -395,6 +395,9 @@ private:
   /// .gnu_debugdata section or \c nullptr if an error occured or if there's no
   /// section with that name.
   std::shared_ptr<ObjectFileELF> GetGnuDebugDataObjectFile();
+
+  llvm::StringRef
+  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section);
 };
 
 #endif // liblldb_ObjectFileELF_h_

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -47,6 +47,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 
 #include "ObjectFileMachO.h"
+#include "swift/ABI/ObjectFile.h"
 
 #if defined(__APPLE__) &&                                                      \
     (defined(__arm__) || defined(__arm64__) || defined(__aarch64__))
@@ -6512,4 +6513,10 @@ bool ObjectFileMachO::SaveCore(const lldb::ProcessSP &process_sp,
                  // this process
   }
   return false;
+}
+
+llvm::StringRef ObjectFileMachO::GetReflectionSectionIdentifier(
+    swift::ReflectionSectionKind section) {
+  swift::SwiftObjectFileFormatMachO file_format_mach_o;
+  return file_format_mach_o.getSectionName(section);
 }

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
@@ -207,6 +207,9 @@ protected:
 
   bool SectionIsLoadable(const lldb_private::Section *section);
 
+  llvm::StringRef
+  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section);
+
   llvm::MachO::mach_header m_header;
   static lldb_private::ConstString GetSegmentNameTEXT();
   static lldb_private::ConstString GetSegmentNameDATA();

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -33,6 +33,8 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 
+#include "swift/ABI/ObjectFile.h"
+
 #define IMAGE_DOS_SIGNATURE 0x5A4D    // MZ
 #define IMAGE_NT_SIGNATURE 0x00004550 // PE00
 #define OPT_HEADER_MAGIC_PE32 0x010b
@@ -1264,3 +1266,9 @@ ObjectFile::Strata ObjectFilePECOFF::CalculateStrata() { return eStrataUser; }
 ConstString ObjectFilePECOFF::GetPluginName() { return GetPluginNameStatic(); }
 
 uint32_t ObjectFilePECOFF::GetPluginVersion() { return 1; }
+
+llvm::StringRef ObjectFilePECOFF::GetReflectionSectionIdentifier(
+    swift::ReflectionSectionKind section) {
+  swift::SwiftObjectFileFormatCOFF file_format_coff;
+  return file_format_coff.getSectionName(section);
+}

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
@@ -286,6 +286,9 @@ protected:
   static lldb::SectionType GetSectionType(llvm::StringRef sect_name,
                                           const section_header_t &sect);
 
+  llvm::StringRef
+  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section);
+
   typedef std::vector<section_header_t> SectionHeaderColl;
   typedef SectionHeaderColl::iterator SectionHeaderCollIter;
   typedef SectionHeaderColl::const_iterator SectionHeaderCollConstIter;

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -747,3 +747,9 @@ void llvm::format_provider<ObjectFile::Strata>::format(
     break;
   }
 }
+
+llvm::StringRef ObjectFile::GetReflectionSectionIdentifier(
+    swift::ReflectionSectionKind section) {
+  assert("Base class's GetReflectionSectionIdentifier should not be called");
+  return "";
+}

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -43,6 +43,7 @@
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/Memory.h"
 
 // FIXME: we should not need this
 #include "Plugins/Language/Swift/SwiftFormatters.h"
@@ -318,13 +319,26 @@ static bool HasReflectionInfo(ObjectFile *obj_file) {
     return false;
   };
 
+  StringRef field_md = obj_file->GetReflectionSectionIdentifier(
+      swift::ReflectionSectionKind::fieldmd);
+  StringRef assocty = obj_file->GetReflectionSectionIdentifier(
+      swift::ReflectionSectionKind::assocty);
+  StringRef builtin = obj_file->GetReflectionSectionIdentifier(
+      swift::ReflectionSectionKind::builtin);
+  StringRef capture = obj_file->GetReflectionSectionIdentifier(
+      swift::ReflectionSectionKind::capture);
+  StringRef typeref = obj_file->GetReflectionSectionIdentifier(
+      swift::ReflectionSectionKind::typeref);
+  StringRef reflstr = obj_file->GetReflectionSectionIdentifier(
+      swift::ReflectionSectionKind::reflstr);
+
   bool hasReflectionSection = false;
-  hasReflectionSection |= findSectionInObject("__swift5_fieldmd");
-  hasReflectionSection |= findSectionInObject("__swift5_assocty");
-  hasReflectionSection |= findSectionInObject("__swift5_builtin");
-  hasReflectionSection |= findSectionInObject("__swift5_capture");
-  hasReflectionSection |= findSectionInObject("__swift5_typeref");
-  hasReflectionSection |= findSectionInObject("__swift5_reflstr");
+  hasReflectionSection |= findSectionInObject(field_md);
+  hasReflectionSection |= findSectionInObject(assocty);
+  hasReflectionSection |= findSectionInObject(builtin);
+  hasReflectionSection |= findSectionInObject(capture);
+  hasReflectionSection |= findSectionInObject(typeref);
+  hasReflectionSection |= findSectionInObject(reflstr);
   return hasReflectionSection;
 }
 
@@ -460,8 +474,6 @@ bool SwiftLanguageRuntimeImpl::AddModuleToReflectionContext(
   auto *obj_file = module_sp->GetObjectFile();
   if (!obj_file)
     return false;
-  if (obj_file->GetPluginName().GetStringRef().equals("elf"))
-    return false;
   Address start_address = obj_file->GetBaseAddress();
   auto load_ptr = static_cast<uintptr_t>(
       start_address.GetLoadAddress(&(m_process.GetTarget())));
@@ -472,8 +484,20 @@ bool SwiftLanguageRuntimeImpl::AddModuleToReflectionContext(
                     obj_file->GetFileSpec().GetFilename().GetCString());
     return false;
   }
-  if (HasReflectionInfo(obj_file))
-    m_reflection_ctx->addImage(swift::remote::RemoteAddress(load_ptr));
+  if (HasReflectionInfo(obj_file)) {
+    // When dealing with ELF, we need to pass in the contents of the on-disk
+    // file, since the Section Header Table is not present in the child process
+    if (obj_file->GetPluginName().GetStringRef().equals("elf")) {
+      DataExtractor extractor;
+      auto size = obj_file->GetData(0, obj_file->GetByteSize(), extractor);
+      const uint8_t *file_data = extractor.GetDataStart();
+      llvm::sys::MemoryBlock file_buffer((void *)file_data, size);
+      m_reflection_ctx->readELF(swift::remote::RemoteAddress(load_ptr),
+          llvm::Optional<llvm::sys::MemoryBlock>(file_buffer));
+    } else {
+      m_reflection_ctx->addImage(swift::remote::RemoteAddress(load_ptr));
+    }
+  }
   return true;
 }
 

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
@@ -41,7 +41,7 @@ class TestLibraryResilient(TestBase):
         return info
 
     @swiftTest
-    @expectedFailureOS(no_match(["macosx"])) # Requires Remote Mirrors support
+    @expectedFailureAll(oslist=["windows"]) # Requires Remote Mirrors support
     def test_implementation_only_import_library(self):
         """Test `@_implementationOnly import` in a resilient library used by the main executable
         
@@ -63,7 +63,7 @@ class TestLibraryResilient(TestBase):
         self.expect("e container.wrapped", substrs=["(SomeLibraryCore.TwoInts)", "(first = 2, second = 3)"])
 
     @swiftTest
-    @expectedFailureOS(no_match(["macosx"])) # Requires Remote Mirrors support
+    @expectedFailureAll(oslist=["windows"]) # Requires Remote Mirrors support
     def test_implementation_only_import_library_no_library_module(self):
         """Test `@_implementationOnly import` in a resilient library used by the main executable, after removing the implementation-only library's swiftmodule
         

--- a/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -102,7 +102,7 @@ class TestMainExecutable(TestBase):
         self.runCmd("settings set symbols.use-swift-dwarfimporter true")
 
     @swiftTest
-    @expectedFailureOS(no_match(["macosx"])) # Requires Remote Mirrors support
+    @expectedFailureAll(oslist=["windows"])
     def test_implementation_only_import_main_executable_resilient(self):
         """Test `@_implementationOnly import` in the main executable with a resilient library
         

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
@@ -30,14 +30,12 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureAll(oslist=["linux"],bugnumber="rdar://49662256")
     def test_swift_interface(self):
         """Test that we load and handle modules that only have textual .swiftinterface files"""
         self.build()
         self.do_test()
 
     @swiftTest
-    @expectedFailureAll(oslist=["linux"],bugnumber="rdar://49662256")
     def test_swift_interface_fallback(self):
         """Test that we fall back to load from the .swiftinterface file if the .swiftmodule is invalid"""
         self.build()

--- a/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
@@ -30,14 +30,12 @@ class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureAll(oslist=["linux"],bugnumber="rdar://49662256")
     def test_swift_interface(self):
         """Test that we load and handle modules that only have textual .swiftinterface files"""
         self.build()
         self.do_test()
 
     @swiftTest
-    @expectedFailureAll(oslist=["linux"],bugnumber="rdar://49662256")
     def test_swift_interface_fallback(self):
         """Test that we fall back to load from the .swiftinterface file if the .swiftmodule is invalid"""
         self.build()


### PR DESCRIPTION
This PR uses the updated `readELF` API (implemented in https://github.com/apple/swift/pull/33321) when setting up reflection from ELF files.

Also depends on https://github.com/apple/swift/pull/33358.

@adrian-prantl @vedantk 