### PR TITLE
[lldb] Use target.GetLaunchInfo() instead of creating an empty one.

### DIFF
--- a/lldb/test/API/commands/disassemble/basic/TestFrameDisassemble.py
+++ b/lldb/test/API/commands/disassemble/basic/TestFrameDisassemble.py
@@ -41,7 +41,7 @@ class FrameDisassembleTestCase(TestBase):
         # environment variables, add them using SetArguments or
         # SetEnvironmentEntries
 
-        launch_info = lldb.SBLaunchInfo(None)
+        launch_info = target.GetLaunchInfo()
         process = target.Launch(launch_info, error)
         self.assertTrue(process, PROCESS_IS_VALID)
 

--- a/lldb/test/API/commands/frame/language/TestGuessLanguage.py
+++ b/lldb/test/API/commands/frame/language/TestGuessLanguage.py
@@ -53,7 +53,7 @@ class TestFrameGuessLanguage(TestBase):
         # environment variables, add them using SetArguments or
         # SetEnvironmentEntries
 
-        launch_info = lldb.SBLaunchInfo(None)
+        launch_info = target.GetLaunchInfo()
         process = target.Launch(launch_info, error)
         self.assertTrue(process, PROCESS_IS_VALID)
 

--- a/lldb/test/API/commands/frame/var/TestFrameVar.py
+++ b/lldb/test/API/commands/frame/var/TestFrameVar.py
@@ -42,7 +42,7 @@ class TestFrameVar(TestBase):
         # environment variables, add them using SetArguments or
         # SetEnvironmentEntries
 
-        launch_info = lldb.SBLaunchInfo(None)
+        launch_info = target.GetLaunchInfo()
         process = target.Launch(launch_info, error)
         self.assertTrue(process, PROCESS_IS_VALID)
 

--- a/lldb/test/API/commands/target/auto-install-main-executable/TestAutoInstallMainExecutable.py
+++ b/lldb/test/API/commands/target/auto-install-main-executable/TestAutoInstallMainExecutable.py
@@ -66,7 +66,7 @@ class TestAutoInstallMainExecutable(gdbremote_testcase.GdbRemoteTestCaseBase):
 
         # Disable the auto install.
         self.runCmd("settings set target.auto-install-main-executable false")
-        self.expect("settings show target.auto-install-main-executable", 
+        self.expect("settings show target.auto-install-main-executable",
             substrs=["target.auto-install-main-executable (boolean) = false"])
 
         self.runCmd("platform select %s"%configuration.lldb_platform_name)
@@ -80,7 +80,7 @@ class TestAutoInstallMainExecutable(gdbremote_testcase.GdbRemoteTestCaseBase):
         target = new_debugger.GetSelectedTarget()
         breakpoint = target.BreakpointCreateByName("main")
 
-        launch_info = lldb.SBLaunchInfo(None)
+        launch_info = taget.GetLaunchInfo()
         error = lldb.SBError()
         process = target.Launch(launch_info, error)
         self.assertTrue(process, PROCESS_IS_VALID)

--- a/lldb/test/API/functionalities/breakpoint/address_breakpoints/TestAddressBreakpoints.py
+++ b/lldb/test/API/functionalities/breakpoint/address_breakpoints/TestAddressBreakpoints.py
@@ -56,6 +56,7 @@ class AddressBreakpointTestCase(TestBase):
         launch_info = lldb.SBLaunchInfo(None)
         flags = launch_info.GetLaunchFlags()
         flags &= ~lldb.eLaunchFlagDisableASLR
+        flags &= lldb.eLaunchFlagInheritTCCFromParent
         launch_info.SetLaunchFlags(flags)
 
         error = lldb.SBError()

--- a/lldb/test/API/functionalities/breakpoint/auto_continue/TestBreakpointAutoContinue.py
+++ b/lldb/test/API/functionalities/breakpoint/auto_continue/TestBreakpointAutoContinue.py
@@ -46,7 +46,7 @@ class BreakpointAutoContinue(TestBase):
 
     def launch_it (self, expected_state):
         error = lldb.SBError()
-        launch_info = lldb.SBLaunchInfo(None)
+        launch_info = self.target.GetLaunchInfo()
         launch_info.SetWorkingDirectory(self.get_process_working_directory())
 
         process = self.target.Launch(launch_info, error)

--- a/lldb/test/API/functionalities/signal/TestSendSignal.py
+++ b/lldb/test/API/functionalities/signal/TestSendSignal.py
@@ -47,7 +47,7 @@ class SendSignalTestCase(TestBase):
                         VALID_BREAKPOINT_LOCATION)
 
         # Now launch the process, no arguments & do not stop at entry point.
-        launch_info = lldb.SBLaunchInfo([exe])
+        launch_info = target.GetLaunchInfo()
         launch_info.SetWorkingDirectory(self.get_process_working_directory())
 
         process_listener = lldb.SBListener("signal_test_listener")

--- a/lldb/test/API/functionalities/tail_call_frames/sbapi_support/TestTailCallFrameSBAPI.py
+++ b/lldb/test/API/functionalities/tail_call_frames/sbapi_support/TestTailCallFrameSBAPI.py
@@ -31,7 +31,7 @@ class TestTailCallFrameSBAPI(TestBase):
                         VALID_BREAKPOINT)
 
         error = lldb.SBError()
-        launch_info = lldb.SBLaunchInfo(None)
+        launch_info = target.GetLaunchInfo()
         process = target.Launch(launch_info, error)
         self.assertTrue(process, PROCESS_IS_VALID)
 

--- a/lldb/test/API/functionalities/tail_call_frames/thread_step_out_or_return/TestSteppingOutWithArtificialFrames.py
+++ b/lldb/test/API/functionalities/tail_call_frames/thread_step_out_or_return/TestSteppingOutWithArtificialFrames.py
@@ -29,7 +29,7 @@ class TestArtificialFrameThreadStepOut1(TestBase):
                         VALID_BREAKPOINT)
 
         error = lldb.SBError()
-        launch_info = lldb.SBLaunchInfo(None)
+        launch_info = target.GetLaunchInfo()
         process = target.Launch(launch_info, error)
         self.assertTrue(process, PROCESS_IS_VALID)
 

--- a/lldb/test/API/macosx/thread-names/TestInterruptThreadNames.py
+++ b/lldb/test/API/macosx/thread-names/TestInterruptThreadNames.py
@@ -23,7 +23,7 @@ class TestInterruptThreadNames(TestBase):
         target = self.dbg.CreateTarget(exe)
         self.assertTrue(target, VALID_TARGET)
 
-        launch_info = lldb.SBLaunchInfo(None)
+        launch_info = target.GetLaunchInfo()
         error = lldb.SBError()
         self.dbg.SetAsync(True)
         process = target.Launch(launch_info, error)

--- a/lldb/test/API/python_api/process/TestProcessAPI.py
+++ b/lldb/test/API/python_api/process/TestProcessAPI.py
@@ -339,7 +339,7 @@ class ProcessAPITestCase(TestBase):
         self.assertTrue(target, VALID_TARGET)
 
         # Launch the process and stop at the entry point.
-        launch_info = lldb.SBLaunchInfo(None)
+        launch_info = target.GetLaunchInfo()
         launch_info.SetWorkingDirectory(self.get_process_working_directory())
         launch_flags = launch_info.GetLaunchFlags()
         launch_flags |= lldb.eLaunchFlagStopAtEntry

--- a/lldb/test/API/python_api/process/io/TestProcessIO.py
+++ b/lldb/test/API/python_api/process/io/TestProcessIO.py
@@ -135,7 +135,7 @@ class ProcessIOTestCase(TestBase):
     def create_target(self):
         '''Create the target and launch info that will be used by all tests'''
         self.target = self.dbg.CreateTarget(self.exe)
-        self.launch_info = lldb.SBLaunchInfo([self.exe])
+        self.launch_info = self.target.GetLaunchInfo()
         self.launch_info.SetWorkingDirectory(
             self.get_process_working_directory())
 


### PR DESCRIPTION
Update tests that were creating an empty LaunchInfo instead of using the
one coming from the target. This ensures target properties are honored.

(cherry picked from commit 86aa8e6363c7e00f211de62ccb3236556e9841df)