### PR TITLE
[lldb] Skip TestSimulatorPlatform with out-of-tree debugserver

### DIFF
--- a/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
+++ b/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
@@ -55,6 +55,7 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipUnlessDarwin
     @skipIfDarwinEmbedded
     @apple_simulator_test('iphone')
+    @skipIfOutOfTreeDebugserver
     def test_ios(self):
         """Test running an iOS simulator binary"""
         self.run_with(arch=self.getArchitecture(),
@@ -64,6 +65,7 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipUnlessDarwin
     @skipIfDarwinEmbedded
     @apple_simulator_test('appletv')
+    @skipIfOutOfTreeDebugserver
     def test_tvos(self):
         """Test running an tvOS simulator binary"""
         self.run_with(arch=self.getArchitecture(),
@@ -75,6 +77,7 @@ class TestSimulatorPlatformLaunching(TestBase):
     @apple_simulator_test('watch')
     @skipIfDarwin # rdar://problem/64552748
     @skipIf(archs=['arm64','arm64e'])
+    @skipIfOutOfTreeDebugserver
     def test_watchos_i386(self):
         """Test running a 32-bit watchOS simulator binary"""
         self.run_with(arch='i386',
@@ -86,6 +89,7 @@ class TestSimulatorPlatformLaunching(TestBase):
     @apple_simulator_test('watch')
     @skipIfDarwin # rdar://problem/64552748
     @skipIf(archs=['i386','x86_64'])
+    @skipIfOutOfTreeDebugserver
     def test_watchos_armv7k(self):
         """Test running a 32-bit watchOS simulator binary"""
         self.run_with(arch='armv7k',
@@ -101,9 +105,10 @@ class TestSimulatorPlatformLaunching(TestBase):
     # and ios-simulator.  When targeting a simulator on Apple Silicon
     # macOS, however, these legacy load commands are never generated.
     #
-        
+
     @skipUnlessDarwin
     @skipIfDarwinEmbedded
+    @skipIfOutOfTreeDebugserver
     def test_lc_version_min_macosx(self):
         """Test running a back-deploying non-simulator MacOS X binary"""
         self.run_with(arch=self.getArchitecture(),
@@ -113,6 +118,7 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipIfDarwinEmbedded
     @apple_simulator_test('iphone')
     @skipIf(archs=['arm64','arm64e'])
+    @skipIfOutOfTreeDebugserver
     def test_lc_version_min_iphoneos(self):
         """Test running a back-deploying iOS simulator binary
            with a legacy iOS load command"""
@@ -124,6 +130,7 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipIfDarwinEmbedded
     @apple_simulator_test('iphone')
     @skipIf(archs=['arm64','arm64e'])
+    @skipIfOutOfTreeDebugserver
     def test_ios_backdeploy_x86(self):
         """Test running a back-deploying iOS simulator binary
            with a legacy iOS load command"""
@@ -135,6 +142,7 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipIfDarwinEmbedded
     @apple_simulator_test('iphone')
     @skipIf(archs=['i386','x86_64'])
+    @skipIfOutOfTreeDebugserver
     def test_ios_backdeploy_apple_silicon(self):
         """Test running a back-deploying iOS simulator binary"""
         self.run_with(arch=self.getArchitecture(),
@@ -145,6 +153,7 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipIfDarwinEmbedded
     @apple_simulator_test('appletv')
     @skipIf(archs=['arm64','arm64e'])
+    @skipIfOutOfTreeDebugserver
     def test_lc_version_min_tvos(self):
         """Test running a back-deploying tvOS simulator binary
            with a legacy tvOS load command"""
@@ -156,6 +165,7 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipIfDarwinEmbedded
     @apple_simulator_test('appletv')
     @skipIf(archs=['i386','x86_64'])
+    @skipIfOutOfTreeDebugserver
     def test_tvos_backdeploy_apple_silicon(self):
         """Test running a back-deploying tvOS simulator binary"""
         self.run_with(arch=self.getArchitecture(),
@@ -167,6 +177,7 @@ class TestSimulatorPlatformLaunching(TestBase):
     @apple_simulator_test('watch')
     @skipIf(archs=['arm64','arm64e'])
     @skipIfDarwin # rdar://problem/64552748
+    @skipIfOutOfTreeDebugserver
     def test_lc_version_min_watchos(self):
         """Test running a back-deploying watchOS simulator binary
            with a legacy watchOS load command"""
@@ -179,6 +190,7 @@ class TestSimulatorPlatformLaunching(TestBase):
     @apple_simulator_test('watch')
     @skipIf(archs=['arm64','arm64e'])
     @skipIfDarwin # rdar://problem/64552748
+    @skipIfOutOfTreeDebugserver
     def test_watchos_backdeploy_apple_silicon(self):
         """Test running a back-deploying watchOS simulator binary"""
         self.run_with(arch='armv7k',


### PR DESCRIPTION
(cherry picked from commit 3162c6aa4587d5161008d2b9729b5f2873b0fff9)