### PR TITLE
SwiftASTContext: allow deserializing @_implementationOnly dependencies to avoid crashing

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -930,6 +930,10 @@ SwiftASTContext::SwiftASTContext(std::string description, llvm::Triple triple,
   ir_gen_opts.OutputKind = swift::IRGenOutputKind::Module;
   ir_gen_opts.UseJIT = true;
   ir_gen_opts.DWARFVersion = swift::DWARFVersion;
+  // Allow deserializing @_implementationOnly dependencies
+  // to avoid crashing due to module recovery issues.
+  swift::LangOptions &lang_opts = m_compiler_invocation_ap->getLangOptions();
+  lang_opts.AllowDeserializingImplementationOnly = true;
 }
 
 SwiftASTContext::~SwiftASTContext() {

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
@@ -75,8 +75,8 @@ class TestLibraryIndirect(TestBase):
             "\n    value = (first = 2, second = 3)\n  }\n  other = 10\n}",
             "(Int) simple = 1"])
         self.expect("e container", substrs=["(SomeLibrary.ContainsTwoInts)", "other = 10"])
-        self.expect("e container.wrapped", substrs=["(SomeLibrary.BoxedTwoInts)", "0x", "{}"])
-        self.expect("e container.wrapped.value", error=True, substrs=["value of type 'BoxedTwoInts' has no member 'value'"])
+        self.expect("e container.wrapped", substrs=["(SomeLibrary.BoxedTwoInts)", "0x", "value = (first = 2, second = 3)"])
+        self.expect("e container.wrapped.value", substrs=["(SomeLibraryCore.TwoInts)", "(first = 2, second = 3)"])
 
     @swiftTest
     def test_implementation_only_import_library_no_library_module(self):

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
@@ -60,7 +60,7 @@ class TestLibraryResilient(TestBase):
             "(SomeLibrary.ContainsTwoInts) container = {\n  wrapped = (first = 2, second = 3)\n  other = 10\n}",
             "(Int) simple = 1"])
         self.expect("e container", substrs=["(SomeLibrary.ContainsTwoInts)", "other = 10"])
-        self.expect("e container.wrapped", error=True, substrs=["value of type 'ContainsTwoInts' has no member 'wrapped'"])
+        self.expect("e container.wrapped", substrs=["(SomeLibraryCore.TwoInts)", "(first = 2, second = 3)"])
 
     @swiftTest
     @expectedFailureOS(no_match(["macosx"])) # Requires Remote Mirrors support

--- a/lldb/test/API/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
+++ b/lldb/test/API/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
@@ -24,8 +24,6 @@ class TestSwiftObjCOptionalType(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
-    @expectedFailureAll(bugnumber="rdar://60396797",
-                        setting=('symbols.use-swift-clangimporter', 'false'))
     @swiftTest
     @skipUnlessDarwin
     def test_swift_objc_optional_type(self):


### PR DESCRIPTION
rdar://65570721