### PR TITLE
66802226 5.3

### DIFF
--- a/lldb/include/lldb/Symbol/SwiftASTContext.h
+++ b/lldb/include/lldb/Symbol/SwiftASTContext.h
@@ -749,6 +749,11 @@ public:
   bool SetTriple(const llvm::Triple triple,
                  lldb_private::Module *module = nullptr);
 
+  /// Condition a triple to be safe for use with Swift.  Swift is
+  /// really peculiar about what CPU types it thinks it has standard
+  /// libraries for.
+  static llvm::Triple GetSwiftFriendlyTriple(llvm::Triple triple);
+
   CompilerType GetCompilerType(swift::TypeBase *swift_type);
   CompilerType GetCompilerType(ConstString mangled_name);
   swift::Type GetSwiftType(CompilerType compiler_type);

--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -197,3 +197,18 @@ TEST_F(TestSwiftASTContext, IsNonTriviallyManagedReferenceType) {
                                                                    nullptr));
 #endif
 }
+
+TEST_F(TestSwiftASTContext, SwiftFriendlyTriple) {
+  EXPECT_EQ(SwiftASTContext::GetSwiftFriendlyTriple(
+                llvm::Triple("x86_64-apple-macosx")),
+            llvm::Triple("x86_64-apple-macosx"));
+  EXPECT_EQ(SwiftASTContext::GetSwiftFriendlyTriple(
+                llvm::Triple("x86_64h-apple-macosx")),
+            llvm::Triple("x86_64-apple-macosx"));
+  EXPECT_EQ(SwiftASTContext::GetSwiftFriendlyTriple(
+                llvm::Triple("aarch64-apple-macosx")),
+            llvm::Triple("arm64-apple-macosx"));
+  EXPECT_EQ(SwiftASTContext::GetSwiftFriendlyTriple(
+                llvm::Triple("aarch64_32-apple-watchos")),
+            llvm::Triple("arm64_32-apple-watchos"));
+}


### PR DESCRIPTION
Unfortunately Swift is really peculiar about the CPU type when looking
for the standard library. This fixes the Swift REPL on Apple Silicon.

rdar://problem/66802226

This is a less-strict variant of https://github.com/apple/llvm-project/pull/1630 in the sense that it doesn't look at the Vendor.