### PR TITLE
Canonicalize aarch64 to arm64 before passing it to the Swift compiler.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2307,23 +2307,27 @@ llvm::Triple SwiftASTContext::GetTriple() const {
   return llvm::Triple(m_compiler_invocation_ap->getTargetTriple());
 }
 
-/// Conditions a triple string to be safe for use with Swift.
-///
-/// This strips the Haswell marker off the CPU name (for Apple targets).
-///
-/// It also add the GNU environment for Linux.  Although this is technically
-/// incorrect, as the `*-unknown-linux` environment represents the bare-metal
-/// environment, because Swift is currently hosted only, we can get away with
-/// it.
-///
-/// TODO: Make Swift more robust.
-static std::string GetSwiftFriendlyTriple(llvm::Triple triple) {
-  if (triple.getArchName() == "x86_64h")
-    triple.setArch(llvm::Triple::x86_64);
-  if (triple.isOSLinux() &&
-      triple.getEnvironment() == llvm::Triple::UnknownEnvironment)
-    triple.setEnvironment(llvm::Triple::GNU);
-  return triple.normalize();
+llvm::Triple SwiftASTContext::GetSwiftFriendlyTriple(llvm::Triple triple) {
+  if (triple.getVendor() != llvm::Triple::Apple) {
+    // Add the GNU environment for Linux.  Although this is
+    // technically incorrect, as the `*-unknown-linux` environment
+    // represents the bare-metal environment, because Swift is
+    // currently hosted only, we can get away with it.
+    if (triple.isOSLinux() &&
+        triple.getEnvironment() == llvm::Triple::UnknownEnvironment)
+      triple.setEnvironment(llvm::Triple::GNU);
+    triple.normalize();
+    return triple;
+  }
+
+  StringRef arch_name = triple.getArchName();
+  if (arch_name == "x86_64h")
+    triple.setArchName("x86_64");
+  else if (arch_name == "aarch64")
+    triple.setArchName("arm64");
+  else if (arch_name == "aarch64_32")
+    triple.setArchName("arm64_32");
+  return triple;
 }
 
 bool SwiftASTContext::SetTriple(const llvm::Triple triple, Module *module) {
@@ -2341,18 +2345,15 @@ bool SwiftASTContext::SetTriple(const llvm::Triple triple, Module *module) {
   }
 
   const unsigned unspecified = 0;
-  std::string adjusted_triple = GetSwiftFriendlyTriple(triple);
+  llvm::Triple adjusted_triple = GetSwiftFriendlyTriple(triple);
   // If the OS version is unspecified, do fancy things.
   if (triple.getOSMajorVersion() == unspecified) {
     // If a triple is "<arch>-apple-darwin" change it to be
     // "<arch>-apple-macosx" otherwise the major and minor OS
     // version we append below would be wrong.
     if (triple.getVendor() == llvm::Triple::VendorType::Apple &&
-        triple.getOS() == llvm::Triple::OSType::Darwin) {
-      llvm::Triple mac_triple(adjusted_triple);
-      mac_triple.setOS(llvm::Triple::OSType::MacOSX);
-      adjusted_triple = mac_triple.str();
-    }
+        triple.getOS() == llvm::Triple::OSType::Darwin)
+      adjusted_triple.setOS(llvm::Triple::OSType::MacOSX);
 
     // Append the min OS to the triple if we have a target
     ModuleSP module_sp;
@@ -2367,12 +2368,9 @@ bool SwiftASTContext::SetTriple(const llvm::Triple triple, Module *module) {
 
     if (module) {
       if (ObjectFile *objfile = module->GetObjectFile())
-        if (llvm::VersionTuple version = objfile->GetMinimumOSVersion()) {
-          llvm::Triple vers_triple(adjusted_triple);
-          vers_triple.setOSName(vers_triple.getOSName().str() +
-                                version.getAsString());
-          adjusted_triple = vers_triple.str();
-        }
+        if (llvm::VersionTuple version = objfile->GetMinimumOSVersion())
+          adjusted_triple.setOSName(adjusted_triple.getOSName().str() +
+                                    version.getAsString());
     }
   }
   if (llvm::Triple(triple).getOS() == llvm::Triple::UnknownOS) {
@@ -2381,15 +2379,14 @@ bool SwiftASTContext::SetTriple(const llvm::Triple triple, Module *module) {
     return false;
   }
   LOG_PRINTF(LIBLLDB_LOG_TYPES, "(\"%s\") setting to \"%s\"",
-             triple.str().c_str(), adjusted_triple.c_str());
+             triple.str().c_str(), adjusted_triple.str().c_str());
 
-  llvm::Triple adjusted_llvm_triple(adjusted_triple);
-  m_compiler_invocation_ap->setTargetTriple(adjusted_llvm_triple);
+  m_compiler_invocation_ap->setTargetTriple(adjusted_triple);
 
-  assert(GetTriple() == adjusted_llvm_triple);
+  assert(GetTriple() == adjusted_triple);
   assert(!m_ast_context_ap ||
          (llvm::Triple(m_ast_context_ap->LangOpts.Target.getTriple()) ==
-          adjusted_llvm_triple));
+          adjusted_triple));
 
   // Every time the triple is changed the LangOpts must be updated
   // too, because Swift default-initializes the EnableObjCInterop

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -329,6 +329,11 @@ public:
   bool SetTriple(const llvm::Triple triple,
                  lldb_private::Module *module = nullptr);
 
+  /// Condition a triple to be safe for use with Swift.  Swift is
+  /// really peculiar about what CPU types it thinks it has standard
+  /// libraries for.
+  static llvm::Triple GetSwiftFriendlyTriple(llvm::Triple triple);
+
   CompilerType GetCompilerType(swift::TypeBase *swift_type);
   CompilerType GetCompilerType(ConstString mangled_name);
   swift::Type GetSwiftType(CompilerType compiler_type);

--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -200,3 +200,21 @@ TEST_F(TestSwiftASTContext, IsNonTriviallyManagedReferenceType) {
                                                                    nullptr));
 #endif
 }
+
+TEST_F(TestSwiftASTContext, SwiftFriendlyTriple) {
+  EXPECT_EQ(SwiftASTContext::GetSwiftFriendlyTriple(
+                llvm::Triple("x86_64-apple-macosx")),
+            llvm::Triple("x86_64-apple-macosx"));
+  EXPECT_EQ(SwiftASTContext::GetSwiftFriendlyTriple(
+                llvm::Triple("x86_64h-apple-macosx")),
+            llvm::Triple("x86_64-apple-macosx"));
+  EXPECT_EQ(SwiftASTContext::GetSwiftFriendlyTriple(
+                llvm::Triple("aarch64-apple-macosx")),
+            llvm::Triple("arm64-apple-macosx"));
+  EXPECT_EQ(SwiftASTContext::GetSwiftFriendlyTriple(
+                llvm::Triple("aarch64_32-apple-watchos")),
+            llvm::Triple("arm64_32-apple-watchos"));
+  EXPECT_EQ(SwiftASTContext::GetSwiftFriendlyTriple(
+                llvm::Triple("aarch64-unknown-linux")),
+            llvm::Triple("aarch64-unknown-linux-gnu"));
+}


### PR DESCRIPTION
Unfortunately Swift is really peculiar about the CPU type when looking
for the standard library. This fixes the Swift REPL on Apple Silicon.

<rdar://problem/66802226>