### PR TITLE
[lldb] Enable inheriting TCC permissions in lldb-test

### DIFF
--- a/lldb/tools/lldb-test/lldb-test.cpp
+++ b/lldb/tools/lldb-test/lldb-test.cpp
@@ -1102,6 +1102,9 @@ int main(int argc, const char *argv[]) {
   Dbg->GetCommandInterpreter().HandleCommand(
       "settings set plugin.process.gdb-remote.packet-timeout 60",
       /*add_to_history*/ eLazyBoolNo, Result);
+  Dbg->GetCommandInterpreter().HandleCommand(
+      "settings set target.inherit-tcc true",
+      /*add_to_history*/ eLazyBoolNo, Result);
 
   if (!opts::Log.empty())
     Dbg->EnableLog("lldb", {"all"}, opts::Log, 0, errs());


### PR DESCRIPTION
Like the rest of the test suite, also set the target.inherit-tcc option
to true in lldb-test.

(cherry picked from commit 61afdf0ab43f1aec93d3d482cd3d1d95c537aefe)