### PR TITLE
[lldb/formatter] Add Swift.Unsafe[Mutable][Raw]Pointer data formatter

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -261,16 +261,6 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       swift_category_sp,
       lldb_private::formatters::swift::SwiftBasicTypeSyntheticFrontEndCreator,
       "Swift.UWord", ConstString("Swift.UWord"), basic_synth_flags);
-  AddCXXSynthetic(
-      swift_category_sp,
-      lldb_private::formatters::swift::SwiftBasicTypeSyntheticFrontEndCreator,
-      "Swift.UnsafePointer", ConstString("^Swift.UnsafePointer<.+>$"),
-      basic_synth_flags, true);
-  AddCXXSynthetic(
-      swift_category_sp,
-      lldb_private::formatters::swift::SwiftBasicTypeSyntheticFrontEndCreator,
-      "Swift.UnsafeMutablePointer",
-      ConstString("^Swift.UnsafeMutablePointer<.+>$"), basic_synth_flags, true);
 
   AddFormat(swift_category_sp, lldb::eFormatPointer,
             ConstString("Swift.OpaquePointer"), format_flags, false);
@@ -330,9 +320,9 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
 
   AddCXXSummary(
       swift_category_sp,
-      lldb_private::formatters::swift::UnsafeBufferPointerSummaryProvider,
-      "Swift.Unsafe[Mutable][Raw]BufferPointer",
-      ConstString("^Swift.Unsafe(Mutable)?(Raw)?BufferPointer(<.+>)?$"),
+      lldb_private::formatters::swift::UnsafeTypeSummaryProvider,
+      "Swift.Unsafe[Mutable][Raw][Buffer]Pointer",
+      ConstString("^Swift.Unsafe(Mutable)?(Raw)?(Buffer)?Pointer(<.+>)?$"),
       summary_flags, true);
 
   DictionaryConfig::Get()
@@ -394,10 +384,9 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
 
   AddCXXSynthetic(
       swift_category_sp,
-      lldb_private::formatters::swift::
-          UnsafeBufferPointerSyntheticFrontEndCreator,
-      "Swift.Unsafe[Mutable][Raw]BufferPointer",
-      ConstString("^Swift.Unsafe(Mutable)?(Raw)?BufferPointer(<.+>)?$"),
+      lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEndCreator,
+      "Swift.Unsafe[Mutable][Raw][Buffer]Pointer",
+      ConstString("^Swift.Unsafe(Mutable)?(Raw)?(Buffer)?Pointer(<.+>)?$"),
       synth_flags, true);
 
   DictionaryConfig::Get()

--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
@@ -1,4 +1,5 @@
 #include "SwiftUnsafeTypes.h"
+#include "SwiftBasicTypes.h"
 
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "lldb/DataFormatters/TypeSynthetic.h"
@@ -15,24 +16,33 @@ namespace {
 
 class SwiftUnsafeType {
 public:
+  enum class UnsafePointerKind {
+    eSwiftUnsafePointer,
+    eSwiftUnsafeRawPointer,
+    eSwiftUnsafeBufferPointer,
+    eSwiftUnsafeRawBufferPointer,
+  };
+
   static std::unique_ptr<SwiftUnsafeType> Create(ValueObject &valobj);
   size_t GetCount() const { return m_count; }
   addr_t GetStartAddress() const { return m_start_addr; }
   CompilerType GetElementType() const { return m_elem_type; }
+  UnsafePointerKind GetKind() const { return m_kind; }
   virtual bool Update() = 0;
 
 protected:
-  SwiftUnsafeType(ValueObject &valobj);
+  SwiftUnsafeType(ValueObject &valobj, UnsafePointerKind kind);
   addr_t GetAddress(llvm::StringRef child_name);
 
   ValueObject &m_valobj;
+  const UnsafePointerKind m_kind;
   size_t m_count;
   addr_t m_start_addr;
   CompilerType m_elem_type;
 };
 
-SwiftUnsafeType::SwiftUnsafeType(ValueObject &valobj)
-    : m_valobj(*valobj.GetNonSyntheticValue().get()) {}
+SwiftUnsafeType::SwiftUnsafeType(ValueObject &valobj, UnsafePointerKind kind)
+    : m_valobj(*valobj.GetNonSyntheticValue().get()), m_kind(kind) {}
 
 lldb::addr_t SwiftUnsafeType::GetAddress(llvm::StringRef child_name) {
   ConstString name(child_name);
@@ -64,7 +74,8 @@ lldb::addr_t SwiftUnsafeType::GetAddress(llvm::StringRef child_name) {
     return false;
   }
 
-  auto type_system = llvm::dyn_cast<SwiftASTContext>(type.GetTypeSystem());
+  auto *type_system =
+      llvm::dyn_cast_or_null<TypeSystemSwift>(type.GetTypeSystem());
   if (!type_system) {
     LLDB_LOG(GetLogIfAllCategoriesSet(LIBLLDB_LOG_DATAFORMATTERS),
              "{0}: Couldn't get {1} type system.", __FUNCTION__,
@@ -72,7 +83,8 @@ lldb::addr_t SwiftUnsafeType::GetAddress(llvm::StringRef child_name) {
     return false;
   }
 
-  CompilerType argument_type = type_system->GetGenericArgumentType(type, 0);
+  CompilerType argument_type =
+      type_system->GetGenericArgumentType(type.GetOpaqueQualType(), 0);
 
   if (argument_type.IsValid())
     m_elem_type = argument_type;
@@ -97,7 +109,7 @@ public:
 };
 
 SwiftUnsafeBufferPointer::SwiftUnsafeBufferPointer(ValueObject &valobj)
-    : SwiftUnsafeType(valobj) {}
+    : SwiftUnsafeType(valobj, UnsafePointerKind::eSwiftUnsafeBufferPointer) {}
 
 bool SwiftUnsafeBufferPointer::Update() {
   if (!m_valobj.GetNumChildren())
@@ -183,7 +195,8 @@ private:
 };
 
 SwiftUnsafeRawBufferPointer::SwiftUnsafeRawBufferPointer(ValueObject &valobj)
-    : SwiftUnsafeType(valobj) {}
+    : SwiftUnsafeType(valobj, UnsafePointerKind::eSwiftUnsafeRawBufferPointer) {
+}
 
 bool SwiftUnsafeRawBufferPointer::Update() {
   if (!m_valobj.GetNumChildren())
@@ -231,7 +244,8 @@ bool SwiftUnsafeRawBufferPointer::Update() {
       return false;
     }
 
-    auto type_system = llvm::dyn_cast<TypeSystemSwift>(type.GetTypeSystem());
+    auto *type_system =
+        llvm::dyn_cast_or_null<TypeSystemSwift>(type.GetTypeSystem());
     if (!type_system) {
       LLDB_LOG(GetLogIfAllCategoriesSet(LIBLLDB_LOG_DATAFORMATTERS),
                "{0}: Couldn't get {1} type system.", __FUNCTION__,
@@ -263,6 +277,71 @@ bool SwiftUnsafeRawBufferPointer::Update() {
   return true;
 }
 
+class SwiftUnsafePointer final : public SwiftUnsafeType {
+public:
+  SwiftUnsafePointer(ValueObject &valobj, UnsafePointerKind kind);
+  bool Update() override;
+};
+
+SwiftUnsafePointer::SwiftUnsafePointer(ValueObject &valobj,
+                                       UnsafePointerKind kind)
+    : SwiftUnsafeType(valobj, kind) {}
+
+bool SwiftUnsafePointer::Update() {
+  if (!m_valobj.GetNumChildren())
+    return false;
+
+  // Here is the layout of Swift's Unsafe[Mutable]Pointer.
+  //
+  // ▿ Unsafe[Raw]Pointer
+  //   ▿ _rawValue : Int
+  //       - pointerValue : Int
+  //
+
+  CompilerType type = m_valobj.GetCompilerType();
+  if (!type.IsValid()) {
+    LLDB_LOG(GetLogIfAllCategoriesSet(LIBLLDB_LOG_DATAFORMATTERS),
+             "{0}: Couldn't get the compiler type for the "
+             "'Swift.UnsafePointer' ValueObject.",
+             __FUNCTION__, type.GetTypeName());
+    return false;
+  }
+
+  auto *type_system =
+      llvm::dyn_cast_or_null<TypeSystemSwift>(type.GetTypeSystem());
+  if (!type_system) {
+    LLDB_LOG(GetLogIfAllCategoriesSet(LIBLLDB_LOG_DATAFORMATTERS),
+             "{0}: Couldn't get {1} type system.", __FUNCTION__,
+             type.GetTypeName());
+    return nullptr;
+  }
+
+  CompilerType argument_type =
+      type_system->GetGenericArgumentType(type.GetOpaqueQualType(), 0);
+
+  if (argument_type.IsValid())
+    m_elem_type = argument_type;
+
+  ValueObjectSP pointer_value_sp(m_valobj.GetChildAtIndex(0, true));
+  if (!pointer_value_sp) {
+    LLDB_LOG(GetLogIfAllCategoriesSet(LIBLLDB_LOG_DATAFORMATTERS),
+             "{0}: Couldn't unwrap the 'Swift.Int' ValueObject named "
+             "'pointerValue'.",
+             __FUNCTION__);
+    return false;
+  }
+
+  addr_t addr = pointer_value_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
+
+  if (!addr || addr == LLDB_INVALID_ADDRESS)
+    return false;
+
+  m_start_addr = addr;
+  m_count = (m_elem_type.IsValid()) ? 1 : 0;
+
+  return true;
+}
+
 std::unique_ptr<SwiftUnsafeType> SwiftUnsafeType::Create(ValueObject &valobj) {
   CompilerType type = valobj.GetCompilerType();
   if (!type.IsValid()) {
@@ -281,7 +360,8 @@ std::unique_ptr<SwiftUnsafeType> SwiftUnsafeType::Create(ValueObject &valobj) {
       return nullptr;
     }
 
-    auto type_system = llvm::dyn_cast<TypeSystemSwift>(type.GetTypeSystem());
+    auto *type_system =
+        llvm::dyn_cast_or_null<TypeSystemSwift>(type.GetTypeSystem());
     if (!type_system) {
       LLDB_LOG(GetLogIfAllCategoriesSet(LIBLLDB_LOG_DATAFORMATTERS),
                "{0}: Couldn't get {1} type system.", __FUNCTION__,
@@ -303,28 +383,42 @@ std::unique_ptr<SwiftUnsafeType> SwiftUnsafeType::Create(ValueObject &valobj) {
 
   llvm::StringRef valobj_type_name(type.GetTypeName().GetCString());
   bool is_raw = valobj_type_name.contains("Raw");
-  if (is_raw)
+  bool is_buffer_ptr = valobj_type_name.contains("BufferPointer");
+  UnsafePointerKind kind =
+      static_cast<UnsafePointerKind>(is_buffer_ptr << 1 | is_raw);
+
+  switch (kind) {
+  case UnsafePointerKind::eSwiftUnsafePointer:
+  case UnsafePointerKind::eSwiftUnsafeRawPointer:
+    return std::make_unique<SwiftUnsafePointer>(valobj, kind);
+  case UnsafePointerKind::eSwiftUnsafeBufferPointer:
+    return std::make_unique<SwiftUnsafeBufferPointer>(valobj);
+  case UnsafePointerKind::eSwiftUnsafeRawBufferPointer:
     return std::make_unique<SwiftUnsafeRawBufferPointer>(valobj);
-  return std::make_unique<SwiftUnsafeBufferPointer>(valobj);
+  }
 }
 
 } // namespace
 
-bool lldb_private::formatters::swift::UnsafeBufferPointerSummaryProvider(
+bool lldb_private::formatters::swift::UnsafeTypeSummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-
-  size_t count = 0;
-  addr_t addr = LLDB_INVALID_ADDRESS;
-
   std::unique_ptr<SwiftUnsafeType> unsafe_ptr = SwiftUnsafeType::Create(valobj);
 
   if (!unsafe_ptr || !unsafe_ptr->Update())
     return false;
-  count = unsafe_ptr->GetCount();
-  addr = unsafe_ptr->GetStartAddress();
+  size_t count = unsafe_ptr->GetCount();
+  addr_t addr = unsafe_ptr->GetStartAddress();
 
-  stream.Printf("%zu %s (0x%" PRIx64 ")", count,
-                (count == 1) ? "value" : "values", addr);
+  auto is_buffer_ptr = [](SwiftUnsafeType::UnsafePointerKind kind) {
+    return static_cast<int>(kind) & (1 << 1);
+  };
+
+  // Hide the number of children if not BufferPointer type.
+  if (!is_buffer_ptr(unsafe_ptr->GetKind()))
+    stream.Printf("0x%" PRIx64, addr);
+  else
+    stream.Printf("%zu %s (0x%" PRIx64 ")", count,
+                  (count == 1) ? "value" : "values", addr);
 
   return true;
 }
@@ -332,9 +426,9 @@ bool lldb_private::formatters::swift::UnsafeBufferPointerSummaryProvider(
 namespace lldb_private {
 namespace formatters {
 namespace swift {
-class UnsafeBufferPointerSyntheticFrontEnd : public SyntheticChildrenFrontEnd {
+class UnsafeTypeSyntheticFrontEnd : public SwiftBasicTypeSyntheticFrontEnd {
 public:
-  UnsafeBufferPointerSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp);
+  UnsafeTypeSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp);
 
   virtual size_t CalculateNumChildren();
 
@@ -346,7 +440,7 @@ public:
 
   virtual size_t GetIndexOfChildWithName(ConstString name);
 
-  virtual ~UnsafeBufferPointerSyntheticFrontEnd() = default;
+  virtual ~UnsafeTypeSyntheticFrontEnd() = default;
 
 private:
   ExecutionContextRef m_exe_ctx_ref;
@@ -362,9 +456,9 @@ private:
 } // namespace formatters
 } // namespace lldb_private
 
-lldb_private::formatters::swift::UnsafeBufferPointerSyntheticFrontEnd::
-    UnsafeBufferPointerSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp)
-    : SyntheticChildrenFrontEnd(*valobj_sp.get()) {
+lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::
+    UnsafeTypeSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp)
+    : SwiftBasicTypeSyntheticFrontEnd(*valobj_sp.get()) {
 
   ProcessSP process_sp = valobj_sp->GetProcessSP();
   if (!process_sp)
@@ -382,13 +476,14 @@ lldb_private::formatters::swift::UnsafeBufferPointerSyntheticFrontEnd::
     Update();
 }
 
-size_t lldb_private::formatters::swift::UnsafeBufferPointerSyntheticFrontEnd::
+size_t lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::
     CalculateNumChildren() {
   return m_unsafe_ptr->GetCount();
 }
 
-lldb::ValueObjectSP lldb_private::formatters::swift::
-    UnsafeBufferPointerSyntheticFrontEnd::GetChildAtIndex(size_t idx) {
+lldb::ValueObjectSP
+lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::GetChildAtIndex(
+    size_t idx) {
   const size_t num_children = CalculateNumChildren();
 
   if (idx >= num_children || idx >= m_children.size())
@@ -397,8 +492,7 @@ lldb::ValueObjectSP lldb_private::formatters::swift::
   return m_children[idx];
 }
 
-bool lldb_private::formatters::swift::UnsafeBufferPointerSyntheticFrontEnd::
-    Update() {
+bool lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::Update() {
   m_children.clear();
   ValueObjectSP valobj_sp = m_backend.GetSP();
   if (!valobj_sp)
@@ -447,20 +541,20 @@ bool lldb_private::formatters::swift::UnsafeBufferPointerSyntheticFrontEnd::
   return m_children.size() == num_children;
 }
 
-bool lldb_private::formatters::swift::UnsafeBufferPointerSyntheticFrontEnd::
+bool lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::
     MightHaveChildren() {
   return m_unsafe_ptr->GetCount();
 }
 
-size_t lldb_private::formatters::swift::UnsafeBufferPointerSyntheticFrontEnd::
+size_t lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   return UINT32_MAX;
 }
 
 SyntheticChildrenFrontEnd *
-lldb_private::formatters::swift::UnsafeBufferPointerSyntheticFrontEndCreator(
+lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEndCreator(
     CXXSyntheticChildren *, lldb::ValueObjectSP valobj_sp) {
   if (!valobj_sp)
     return nullptr;
-  return (new UnsafeBufferPointerSyntheticFrontEnd(valobj_sp));
+  return (new UnsafeTypeSyntheticFrontEnd(valobj_sp));
 }

--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.h
@@ -20,12 +20,11 @@ namespace lldb_private {
 namespace formatters {
 namespace swift {
 
-bool UnsafeBufferPointerSummaryProvider(ValueObject &valobj, Stream &stream,
-                                        const TypeSummaryOptions &);
+bool UnsafeTypeSummaryProvider(ValueObject &valobj, Stream &stream,
+                               const TypeSummaryOptions &);
 
 SyntheticChildrenFrontEnd *
-UnsafeBufferPointerSyntheticFrontEndCreator(CXXSyntheticChildren *,
-                                            lldb::ValueObjectSP);
+UnsafeTypeSyntheticFrontEndCreator(CXXSyntheticChildren *, lldb::ValueObjectSP);
 
 }; // namespace swift
 }; // namespace formatters

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -624,7 +624,7 @@ public:
                                    size_t idx);
   static CompilerType GetGenericArgumentType(CompilerType ct, size_t idx);
   CompilerType GetGenericArgumentType(lldb::opaque_compiler_type_t type,
-                                      size_t idx);
+                                      size_t idx) override;
 
   CompilerType GetTypeForFormatters(lldb::opaque_compiler_type_t type) override;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -119,6 +119,8 @@ public:
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) = 0;
   virtual CompilerType
   GetTypeFromMangledTypename(ConstString mangled_typename) = 0;
+  virtual CompilerType GetGenericArgumentType(lldb::opaque_compiler_type_t type,
+                                              size_t idx) = 0;
 
   /// Unavailable hardcoded functions that don't make sense for Swift.
   /// \{

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -924,6 +924,13 @@ CompilerType TypeSystemSwiftTypeRef::GetTypeFromMangledTypename(
   return {this, (opaque_compiler_type_t)mangled_typename.AsCString()};
 }
 
+CompilerType
+TypeSystemSwiftTypeRef::GetGenericArgumentType(opaque_compiler_type_t type,
+                                               size_t idx) {
+  return m_swift_ast_context->GetGenericArgumentType(ReconstructType(type),
+                                                     idx);
+}
+
 lldb::TypeSP TypeSystemSwiftTypeRef::GetCachedType(ConstString mangled) {
   return m_swift_ast_context->GetCachedType(mangled);
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -51,6 +51,9 @@ public:
   CompilerType
   GetTypeFromMangledTypename(ConstString mangled_typename) override;
 
+  CompilerType GetGenericArgumentType(lldb::opaque_compiler_type_t type,
+                                      size_t idx) override;
+
   // PluginInterface functions
   ConstString GetPluginName() override;
   uint32_t GetPluginVersion() override;

--- a/lldb/test/API/functionalities/data-formatter/swift-unsafe/main.swift
+++ b/lldb/test/API/functionalities/data-formatter/swift-unsafe/main.swift
@@ -69,7 +69,28 @@ func main() {
     //%            ])
   }
 
-  let colors = [ColorCode.RGB(155,219,255), ColorCode.Hex(0x4545ff)]
+  var colors = [ColorCode.RGB(155,219,255), ColorCode.Hex(0x4545ff)]
+
+  let unsafe_ptr = UnsafePointer(&colors[0])
+  //% self.expect("frame variable -d run-target unsafe_ptr",
+  //%            patterns=[
+  //%            '\(UnsafePointer<(.*)\.ColorCode>\) unsafe_ptr = 0[xX][0-9a-fA-F]+ {',
+  //%            '\[0\] = RGB {',
+  //%            'RGB = \(0 = 155, 1 = 219, 2 = 255\)'
+  //%            ])
+
+  var unsafe_mutable_ptr = UnsafeMutablePointer(&colors[1])
+  //% self.expect("frame variable -d run-target unsafe_mutable_ptr",
+  //%            patterns=[
+  //%            '\(UnsafeMutablePointer<(.*)\.ColorCode>\) unsafe_mutable_ptr = 0[xX][0-9a-fA-F]+ {',
+  //%            '\[0\] = Hex \(Hex = 4539903\)'
+  //%            ])
+
+  let unsafe_raw_ptr = UnsafeRawPointer(&colors[0])
+  //% self.expect("frame variable -d run-target unsafe_raw_ptr",
+  //%            patterns=[
+  //%            '\(UnsafeRawPointer\) unsafe_raw_ptr = 0[xX][0-9a-fA-F]+'
+  //%            ])
 
   colors.withUnsafeBufferPointer {
     let buf = $0


### PR DESCRIPTION
This patch adds support for Swift's Unsafe[Mutable]Pointer and
UnsafeRaw[Mutable]Pointer data formatting.

Since the 2 types have a similar layout, this patch makes use of the
SwiftUnsafeType factory to create a single helper class for the 2 types.

This commit also removes the old basic summary provider to these 2 types.

rdar://64410428

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>