### PR TITLE
[lldb] Fix the last remaining tests not inheriting TCC permissions

### DIFF
--- a/lldb/test/API/commands/expression/weak_symbols/TestWeakSymbols.py
+++ b/lldb/test/API/commands/expression/weak_symbols/TestWeakSymbols.py
@@ -34,20 +34,21 @@ class TestWeakSymbolsInExpressions(TestBase):
             correct_value = 10
         else:
             correct_value = 20
-            
+
         # Note, I'm adding the "; 10" at the end of the expression to work around
         # the bug that expressions with no result currently return False for Success()...
         expr = "if (&" + weak_varname + " != NULL) { present_weak_int = 10; } else { present_weak_int = 20;}; 10"
         result = self.frame.EvaluateExpression(expr)
         self.assertSuccess(result.GetError(), "absent_weak_int expr failed")
         self.assertEqual(value.GetValueAsSigned(), correct_value, "Didn't change present_weak_int correctly.")
-        
+
     def do_test(self):
         hidden_dir = os.path.join(self.getBuildDir(), "hidden")
         hidden_dylib = os.path.join(hidden_dir, "libdylib.dylib")
 
         launch_info = lldb.SBLaunchInfo(None)
         launch_info.SetWorkingDirectory(self.getBuildDir())
+        launch_info.SetLaunchFlags(lldb.eLaunchFlagInheritTCCFromParent)
         # We have to point to the hidden directory to pick up the
         # version of the dylib without the weak symbols:
         env_expr = self.platformContext.shlib_environment_var + "=" + hidden_dir
@@ -63,7 +64,7 @@ class TestWeakSymbolsInExpressions(TestBase):
         # search paths, and then run @import to introduce it into the expression
         # context:
         self.dbg.HandleCommand("settings set target.clang-module-search-paths " + self.getSourceDir())
-        
+
         self.frame = thread.frames[0]
         self.assertTrue(self.frame.IsValid(), "Got a good frame")
         options = lldb.SBExpressionOptions()
@@ -73,7 +74,7 @@ class TestWeakSymbolsInExpressions(TestBase):
         # Now run an expression that references an absent weak symbol:
         self.run_weak_var_check("absent_weak_int", False)
         self.run_weak_var_check("absent_weak_function", False)
-        
+
         # Make sure we can do the same thing with present weak symbols
         self.run_weak_var_check("present_weak_int", True)
         self.run_weak_var_check("present_weak_function", True)

--- a/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
@@ -52,6 +52,7 @@ class ModuleLoadedNotifysTestCase(TestBase):
             True
 
         error = lldb.SBError()
+        flags = lldb.eLaunchFlagInheritTCCFromParent
         process = target.Launch(listener,
                                 None,      # argv
                                 None,      # envp
@@ -59,7 +60,7 @@ class ModuleLoadedNotifysTestCase(TestBase):
                                 None,      # stdout_path
                                 None,      # stderr_path
                                 None,      # working directory
-                                0,         # launch flags
+                                flags,     # launch flags
                                 False,     # Stop at entry
                                 error)     # error
 

--- a/lldb/test/API/lang/objc/exceptions/TestObjCExceptions.py
+++ b/lldb/test/API/lang/objc/exceptions/TestObjCExceptions.py
@@ -23,6 +23,7 @@ class ObjCExceptionsTestCase(TestBase):
         self.assertTrue(target, VALID_TARGET)
 
         launch_info = lldb.SBLaunchInfo(["a.out", "0"])
+        launch_info.SetLaunchFlags(lldb.eLaunchFlagInheritTCCFromParent)
         lldbutil.run_to_name_breakpoint(self, "objc_exception_throw", launch_info=launch_info)
 
         self.expect("thread list",

--- a/lldb/test/API/types/AbstractBase.py
+++ b/lldb/test/API/types/AbstractBase.py
@@ -151,6 +151,10 @@ class GenericTester(TestBase):
         # This test uses a #include of "basic_type.cpp" so we need to enable
         # always setting inlined breakpoints.
         self.runCmd('settings set target.inline-breakpoint-strategy always')
+
+        # Inherit TCC permissions. We can leave this set.
+        self.runCmd('settings set target.inherit-tcc true')
+
         # And add hooks to restore the settings during tearDown().
         self.addTearDownHook(lambda: self.runCmd(
             "settings set target.inline-breakpoint-strategy headers"))


### PR DESCRIPTION
After this patch all test should have the inferior inheriting the TCC
permissions from its parent.

(cherry picked from commit 254e0abf5be2e98cb7f1fa52617b71f4b94b11a4)