### PR TITLE
Implemement TypeSystemSwiftTypeRef::GetBitSize() (NFC) 

### DIFF
--- a/lldb/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/lldb/include/lldb/Target/SwiftLanguageRuntime.h
@@ -249,7 +249,8 @@ public:
                                                    Status *error = nullptr);
 
   /// Ask Remote Mirrors for the size of a Swift type.
-  llvm::Optional<uint64_t> GetBitSize(CompilerType type);
+  llvm::Optional<uint64_t> GetBitSize(CompilerType type,
+                                      ExecutionContextScope *exe_scope);
 
   /// Ask Remote mirrors for the stride of a Swift type.
   llvm::Optional<uint64_t> GetByteStride(CompilerType type);

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -1037,7 +1037,9 @@ bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
   // dynamic archetype (and hence its size). Everything follows naturally
   // as the elements are laid out in a contigous buffer without padding.
   CompilerType simd_type = valobj.GetCompilerType().GetCanonicalType();
-  llvm::Optional<uint64_t> opt_type_size = simd_type.GetByteSize(nullptr);
+  ExecutionContext exe_ctx = valobj.GetExecutionContextRef().Lock(true);
+  llvm::Optional<uint64_t> opt_type_size =
+    simd_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
   if (!opt_type_size)
     return false;
   uint64_t type_size = *opt_type_size;
@@ -1053,7 +1055,8 @@ bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
   auto swift_arg_type = generic_args[0];
   CompilerType arg_type = ToCompilerType(swift_arg_type);
 
-  llvm::Optional<uint64_t> opt_arg_size = arg_type.GetByteSize(nullptr);
+  llvm::Optional<uint64_t> opt_arg_size =
+      arg_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
   if (!opt_arg_size)
     return false;
   uint64_t arg_size = *opt_arg_size;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -7808,6 +7808,21 @@ bool SwiftASTContext::IsImportedType(opaque_compiler_type_t type,
   return success;
 }
 
+std::string SwiftASTContext::GetSwiftName(const clang::Decl *clang_decl,
+                                          TypeSystemClang &clang_typesystem) {
+  if (auto name_decl = llvm::dyn_cast<clang::NamedDecl>(clang_decl))
+    return ImportName(name_decl);
+  return {};
+}
+
+std::string SwiftASTContext::ImportName(const clang::NamedDecl *clang_decl) {
+  if (auto clang_importer = GetClangImporter()) {
+    swift::DeclName imported_name = clang_importer->importName(clang_decl, {});
+    return imported_name.getBaseName().userFacingName().str();
+  }
+  return clang_decl->getName().str();
+}
+
 void SwiftASTContext::DumpSummary(opaque_compiler_type_t type,
                                   ExecutionContext *exe_ctx, Stream *s,
                                   const lldb_private::DataExtractor &data,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4571,17 +4571,17 @@ CompilerType SwiftASTContext::ImportType(CompilerType &type, Status &error) {
   // CompilerType to match this to the version of the type we got from
   // the mangled name in the original swift::ASTContext.
   ConstString mangled_name(type.GetMangledTypeName());
-  if (mangled_name) {
-    swift::TypeBase *our_type_base =
-        m_mangled_name_to_type_map.lookup(mangled_name.GetCString());
-    if (our_type_base)
-      return ToCompilerType({our_type_base});
-    else {
-      CompilerType our_type(GetTypeFromMangledTypename(mangled_name));
-      if (error.Success())
-        return our_type;
-    }
-  }
+  if (!mangled_name)
+    return {};
+  if (llvm::isa<TypeSystemSwiftTypeRef>(ts))
+    return m_typeref_typesystem.GetTypeFromMangledTypename(mangled_name);
+  swift::TypeBase *our_type_base =
+      m_mangled_name_to_type_map.lookup(mangled_name.GetCString());
+  if (our_type_base)
+    return ToCompilerType({our_type_base});
+  CompilerType our_type(GetTypeFromMangledTypename(mangled_name));
+  if (error.Success())
+    return our_type;
   return {};
 }
 
@@ -5960,7 +5960,7 @@ SwiftASTContext::GetBitSize(opaque_compiler_type_t type,
   if (!exe_scope)
     return {};
   if (auto *runtime = SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
-    return runtime->GetBitSize({this, type});
+    return runtime->GetBitSize({this, type}, exe_scope);
   return {};
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -249,7 +249,7 @@ public:
 
   void CacheModule(swift::ModuleDecl *module);
 
-  Module *GetModule() const { return m_module; }
+  Module *GetModule() const override { return m_module; }
 
   // Call this after the search paths are set up, it will find the module given
   // by module, load the module into the AST context, and also load any

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -61,6 +61,7 @@ namespace clang {
 namespace api_notes {
 class APINotesManager;
 }
+class NamedDecl;
 } // namespace clang
 
 namespace llvm {
@@ -316,6 +317,13 @@ public:
   /// Import and Swiftify a Clang type.
   /// \return Returns an invalid type if unsuccessful.
   CompilerType ImportClangType(CompilerType clang_type);
+
+  /// Use ClangImporter to determine the swiftified name of \p
+  /// clang_decl.
+  std::string GetSwiftName(const clang::Decl *clang_decl,
+                           TypeSystemClang &clang_typesystem) override;
+  /// Use \p ClangImporter to swiftify the decl's name.
+  std::string ImportName(const clang::NamedDecl *clang_decl);
 
   static SwiftASTContext *GetSwiftASTContext(swift::ASTContext *ast);
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -15,11 +15,13 @@
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
 #include <lldb/lldb-enumerations.h>
+#include <llvm/ADT/StringRef.h>
 
 LLDB_PLUGIN_DEFINE(TypeSystemSwift)
 
 using namespace lldb;
 using namespace lldb_private;
+using llvm::StringRef;
 
 /// TypeSystem Plugin functionality.
 /// \{

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -41,10 +41,15 @@ static lldb::TypeSystemSP CreateTypeSystemInstance(lldb::LanguageType language,
   llvm_unreachable("Neither type nor module given to CreateTypeSystemInstance");
 }
 
-void TypeSystemSwift::Initialize() {
+LanguageSet TypeSystemSwift::GetSupportedLanguagesForTypes() {
   LanguageSet swift;
-  SwiftLanguageRuntime::Initialize();
   swift.Insert(lldb::eLanguageTypeSwift);
+  return swift;
+}
+
+void TypeSystemSwift::Initialize() {
+  SwiftLanguageRuntime::Initialize();
+  LanguageSet swift = GetSupportedLanguagesForTypes();
   PluginManager::RegisterPlugin(GetPluginNameStatic(),
                                 "Swift type system and AST context plug-in",
                                 CreateTypeSystemInstance, swift, swift);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -91,6 +91,7 @@ public:
   static ConstString GetPluginNameStatic();
   /// \}
 
+  virtual Module *GetModule() const = 0;
   virtual lldb::TypeSP GetCachedType(ConstString mangled) = 0;
   virtual void SetCachedType(ConstString mangled,
                              const lldb::TypeSP &type_sp) = 0;
@@ -117,6 +118,8 @@ public:
       lldb::opaque_compiler_type_t type, Stream *s,
       bool print_help_if_available, bool print_extensions_if_available,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) = 0;
+
+  /// Create a CompilerType from a mangled Swift type name.
   virtual CompilerType
   GetTypeFromMangledTypename(ConstString mangled_typename) = 0;
   virtual CompilerType GetGenericArgumentType(lldb::opaque_compiler_type_t type,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -91,6 +91,7 @@ public:
   static ConstString GetPluginNameStatic();
   /// \}
 
+  static LanguageSet GetSupportedLanguagesForTypes();
   virtual Module *GetModule() const = 0;
   virtual lldb::TypeSP GetCachedType(ConstString mangled) = 0;
   virtual void SetCachedType(ConstString mangled,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -21,7 +21,12 @@
 #include "lldb/Utility/Flags.h"
 #include "lldb/lldb-private.h"
 
+namespace clang {
+class Decl;
+}
+
 namespace lldb_private {
+class TypeSystemClang;
 
 /// The implementation of lldb::Type's m_payload field for TypeSystemSwift.
 class TypePayloadSwift {
@@ -125,6 +130,11 @@ public:
   GetTypeFromMangledTypename(ConstString mangled_typename) = 0;
   virtual CompilerType GetGenericArgumentType(lldb::opaque_compiler_type_t type,
                                               size_t idx) = 0;
+
+  /// Use API notes or ClangImporter to determine the swiftified name
+  /// of \p clang_decl.
+  virtual std::string GetSwiftName(const clang::Decl *clang_decl,
+                                   TypeSystemClang &clang_typesystem) = 0;
 
   /// Unavailable hardcoded functions that don't make sense for Swift.
   /// \{

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -436,7 +436,7 @@ std::string ExtractSwiftName(
 std::string
 TypeSystemSwiftTypeRef::GetSwiftName(const clang::Decl *clang_decl,
                                      TypeSystemClang &clang_typesystem) {
-  auto *named_decl = dyn_cast_or_null<const clang::NamedDecl>(clang_decl);
+  auto *named_decl = llvm::dyn_cast_or_null<const clang::NamedDecl>(clang_decl);
   if (!named_decl)
     return {};
   StringRef default_name = named_decl->getName();

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -89,12 +89,40 @@ GetClangTypeNode(CompilerType clang_type, swift::Demangle::Demangler &Dem) {
   return structure;
 }
 
+/// \return the child of the \p Type node.
+static swift::Demangle::NodePointer GetType(swift::Demangle::Demangler &Dem,
+                                            swift::Demangle::NodePointer n) {
+  using namespace swift::Demangle;
+  if (!n || n->getKind() != Node::Kind::Global || !n->hasChildren())
+    return nullptr;
+  n = n->getFirstChild();
+  if (!n || n->getKind() != Node::Kind::TypeMangling || !n->hasChildren())
+    return nullptr;
+  n = n->getFirstChild();
+  if (!n || n->getKind() != Node::Kind::Type || !n->hasChildren())
+    return nullptr;
+  n = n->getFirstChild();
+  return n;
+}
+
+/// Demangle a mangled type name and return the child of the \p Type node.
+static swift::Demangle::NodePointer
+GetDemangledType(swift::Demangle::Demangler &Dem, StringRef name) {
+  NodePointer n = Dem.demangleSymbol(name);
+  return GetType(Dem, n);
+}
+
 /// Resolve a type alias node and return a demangle tree for the
 /// resolved type. If the type alias resolves to a Clang type, return
 /// a Clang CompilerType.
+///
+/// \param prefer_clang_types if this is true, type aliases in the
+///                           __C module are resolved as Clang types.
+///
 static std::pair<swift::Demangle::NodePointer, CompilerType>
 ResolveTypeAlias(lldb_private::Module *M, swift::Demangle::Demangler &Dem,
-                 swift::Demangle::NodePointer node) {
+                 swift::Demangle::NodePointer node,
+                 bool prefer_clang_types = false) {
   // Try to look this up as a Swift type alias. For each *Swift*
   // type alias there is a debug info entry that has the mangled
   // name as name and the aliased type as a type.
@@ -104,11 +132,13 @@ ResolveTypeAlias(lldb_private::Module *M, swift::Demangle::Demangler &Dem,
               "No module. Couldn't resolve type alias %s", mangled.AsCString());
     return {{}, {}};
   }
-  llvm::DenseSet<lldb_private::SymbolFile *> searched_symbol_files;
   TypeList types;
-  M->FindTypes({mangled}, false, 1, searched_symbol_files, types);
-  if (types.Empty()) {
-    // No Swift type found -- this could be a Clang typdef.  This
+  if (!prefer_clang_types) {
+    llvm::DenseSet<lldb_private::SymbolFile *> searched_symbol_files;
+    M->FindTypes({mangled}, false, 1, searched_symbol_files, types);
+  }
+  if (prefer_clang_types || types.Empty()) {
+    // No Swift type found -- this could be a Clang typedef.  This
     // check is not done earlier because a Clang typedef that points
     // to a builtin type, e.g., "typedef unsigned uint32_t", could
     // end up pointing to a *Swift* type!
@@ -120,7 +150,7 @@ ResolveTypeAlias(lldb_private::Module *M, swift::Demangle::Demangler &Dem,
           LookupClangForwardType(*M, node->getChild(1)->getText());
       if (!clang_type)
         return {{}, {}};
-      return {{}, clang_type};
+      return {{}, clang_type.GetCanonicalType()};
     }
 
     LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
@@ -142,13 +172,7 @@ ResolveTypeAlias(lldb_private::Module *M, swift::Demangle::Demangler &Dem,
               "Found non-Swift type alias %s", mangled.AsCString());
     return {{}, {}};
   }
-  NodePointer n = Dem.demangleSymbol(desugared_name.GetStringRef());
-  if (n && n->getKind() == Node::Kind::Global && n->hasChildren())
-    n = n->getFirstChild();
-  if (n && n->getKind() == Node::Kind::TypeMangling && n->hasChildren())
-    n = n->getFirstChild();
-  if (n && n->getKind() == Node::Kind::Type && n->hasChildren())
-    n = n->getFirstChild();
+  NodePointer n = GetDemangledType(Dem, desugared_name.GetStringRef());
   if (!n) {
     LLDB_LOG(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
              "Unrecognized demangling %s", desugared_name.AsCString());
@@ -270,7 +294,7 @@ GetCanonicalNode(lldb_private::Module *M, swift::Demangle::Demangler &Dem,
   case Node::Kind::TypeAlias: {
     auto node_clangtype = ResolveTypeAlias(M, Dem, node);
     if (CompilerType clang_type = node_clangtype.second)
-      return getCanonicalNode(GetClangTypeNode(clang_type.GetCanonicalType(), Dem));
+      return getCanonicalNode(GetClangTypeNode(clang_type, Dem));
     if (node_clangtype.first)
       return getCanonicalNode(node_clangtype.first);
     return node;
@@ -397,26 +421,79 @@ static swift::Demangle::NodePointer Desugar(swift::Demangle::Demangler &Dem,
   return desugared;
 }
 
-using GetAPINotesManagerFn = std::function<clang::api_notes::APINotesManager *(
-    ClangExternalASTSourceCallbacks *source, unsigned id)>;
-using GetClangImporterFn = std::function<swift::ClangImporter *()>;
+/// Helper for \p GetSwiftName.
+static template <typename ContextInfo>
+std::string ExtractSwiftName(
+    clang::api_notes::APINotesReader::VersionedInfo<ContextInfo> info) {
+  if (auto version = info.getSelected()) {
+    ContextInfo context_info = info[*version].second;
+    if (!context_info.SwiftName.empty())
+      return context_info.SwiftName;
+  }
+  return {};
+};
 
-/// Replace all "__C" module names with their actual Clang module names.
-static swift::Demangle::NodePointer
-GetNodeForPrinting(const std::string &m_description, lldb_private::Module &M,
-                   GetAPINotesManagerFn get_apinotes_manager,
-                   GetClangImporterFn get_clangimporter,
-                   swift::Demangle::Demangler &Dem,
-                   swift::Demangle::NodePointer node,
-                   bool resolve_objc_module,
-                   bool desugar = true) {
+std::string
+TypeSystemSwiftTypeRef::GetSwiftName(const clang::Decl *clang_decl,
+                                     TypeSystemClang &clang_typesystem) {
+  auto *named_decl = dyn_cast_or_null<const clang::NamedDecl>(clang_decl);
+  if (!named_decl)
+    return {};
+  StringRef default_name = named_decl->getName();
+  unsigned id = clang_decl->getOwningModuleID();
+  if (!id)
+    return default_name.str();
+  auto *ast_source = llvm::dyn_cast_or_null<ClangExternalASTSourceCallbacks>(
+      clang_typesystem.getASTContext().getExternalSource());
+  auto *apinotes_manager = GetAPINotesManager(ast_source, id);
+  if (!apinotes_manager)
+    return default_name.str();
+
+  // Read the Swift name from the API notes.
+  for (auto reader : apinotes_manager->getCurrentModuleReaders()) {
+    std::string swift_name;
+    // The order is significant since some of these decl kinds are also TagDecls.
+    if (llvm::isa<clang::TypedefNameDecl>(clang_decl))
+      swift_name = ExtractSwiftName(reader->lookupTypedef(default_name));
+    else if (llvm::isa<clang::EnumConstantDecl>(clang_decl))
+      swift_name = ExtractSwiftName(reader->lookupEnumConstant(default_name));
+    else if (llvm::isa<clang::ObjCInterfaceDecl>(clang_decl))
+      swift_name = ExtractSwiftName(reader->lookupObjCClassInfo(default_name));
+    else if (llvm::isa<clang::ObjCProtocolDecl>(clang_decl))
+      swift_name =
+          ExtractSwiftName(reader->lookupObjCProtocolInfo(default_name));
+    else if (llvm::isa<clang::TagDecl>(clang_decl))
+      swift_name = ExtractSwiftName(reader->lookupTag(default_name));
+    else
+      assert(false && "unhandled clang decl kind");
+    if (!swift_name.empty())
+      return swift_name;
+  }
+  // Else we must go through ClangImporter to apply the automatic
+  // swiftification rules.
+  //
+  // TODO: Separate ClangImporter::ImportDecl into a freestanding
+  // class, so we don't need a SwiftASTContext for this!
+  return m_swift_ast_context->ImportName(named_decl);
+}
+
+/// Determine whether \p node is an Objective-C type and return its name.
+static StringRef GetObjCTypeName(swift::Demangle::NodePointer node) {
+  if (node && node->getNumChildren() == 2 && node->getChild(0)->hasText() &&
+      node->getChild(0)->getText() == swift::MANGLING_MODULE_OBJC &&
+      node->getChild(1)->hasText())
+    return node->getChild(1)->getText();
+  return {};
+}
+
+swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetNodeForPrintingImpl(
+    swift::Demangle::Demangler &Dem, swift::Demangle::NodePointer node,
+    bool resolve_objc_module, bool desugar) {
   if (!node)
     return node;
   using namespace swift::Demangle;
   auto getNodeForPrinting = [&](NodePointer node) -> NodePointer {
-    return GetNodeForPrinting(m_description, M, get_apinotes_manager,
-                              get_clangimporter, Dem, node, resolve_objc_module,
-                              desugar);
+    return GetNodeForPrintingImpl(Dem, node, resolve_objc_module, desugar);
   };
 
   NodePointer canonical = nullptr;
@@ -425,14 +502,17 @@ GetNodeForPrinting(const std::string &m_description, lldb_private::Module &M,
   case Node::Kind::Class:
   case Node::Kind::Structure:
   case Node::Kind::TypeAlias: {
-    if (node->getNumChildren() != 2 || !node->getChild(0)->hasText() ||
-        node->getChild(0)->getText() != swift::MANGLING_MODULE_OBJC ||
-        !node->getChild(1)->hasText())
-      break;
+    StringRef ident = GetObjCTypeName(node);
+    if (ident.empty())
+      return node;
 
-    // This is an imported Objective-C type; look it up in the debug info.
-    StringRef ident = node->getChild(1)->getText();
-    TypeSP clang_type = LookupClangType(M, ident);
+    auto *Module = GetModule();
+    if (!Module)
+      return node;
+
+    // This is an imported Objective-C type; look it up in the
+    // debug info.
+    TypeSP clang_type = LookupClangType(*Module, ident);
     if (!clang_type)
       return node;
 
@@ -458,15 +538,16 @@ GetNodeForPrinting(const std::string &m_description, lldb_private::Module &M,
         Dem.createNode(Node::Kind::Module, toplevel_module);
     renamed->addChild(module, Dem);
 
-    // This is unfortunate performance-wise, but only ClangImporter
-    // knows how to translate a clang::Decl's name into a Swift name.
-
     // This order is significant, because of `typedef tag`.
     swift::ClangTypeKind kinds[] = {swift::ClangTypeKind::Typedef,
                                     swift::ClangTypeKind::Tag,
                                     swift::ClangTypeKind::ObjCProtocol};
     clang::NamedDecl *clang_decl = nullptr;
     CompilerType compiler_type = clang_type->GetForwardCompilerType();
+    auto *clang_ts =
+        llvm::dyn_cast_or_null<TypeSystemClang>(compiler_type.GetTypeSystem());
+    if (!clang_ts)
+      break;
     clang::QualType qual_type = ClangUtil::GetQualType(compiler_type);
     for (auto kind : kinds) {
       clang_decl = llvm::dyn_cast_or_null<clang::NamedDecl>(
@@ -477,69 +558,7 @@ GetNodeForPrinting(const std::string &m_description, lldb_private::Module &M,
     if (!clang_decl)
       break;
 
-    // Read the Swift name from the APINotes.
-    std::string swift_name = std::string(ident);
-    if (unsigned id = clang_decl->getOwningModuleID()) {
-      auto *clang_typesystem = llvm::dyn_cast_or_null<TypeSystemClang>(
-          compiler_type.GetTypeSystem());
-      if (!clang_typesystem)
-        break;
-      auto *ast_source =
-          llvm::dyn_cast_or_null<ClangExternalASTSourceCallbacks>(
-              clang_typesystem->getASTContext().getExternalSource());
-      if (auto *apinotes_manager = get_apinotes_manager(ast_source, id)) {
-        for (auto reader : apinotes_manager->getCurrentModuleReaders()) {
-          if (llvm::isa<clang::TypedefNameDecl>(clang_decl)) {
-            auto info = reader->lookupTypedef(ident);
-            if (auto version = info.getSelected()) {
-              clang::api_notes::TypedefInfo typedef_info =
-                  info[*version].second;
-              if (!typedef_info.SwiftName.empty())
-                swift_name = typedef_info.SwiftName;
-              break;
-            }
-          }
-          if (llvm::isa<clang::TagDecl>(clang_decl)) {
-            auto info = reader->lookupTag(ident);
-            if (auto version = info.getSelected()) {
-              clang::api_notes::TagInfo tag_info = info[*version].second;
-              if (!tag_info.SwiftName.empty())
-                swift_name = tag_info.SwiftName;
-              break;
-            }
-          }
-          auto extract_context_info =
-              [&](clang::api_notes::APINotesReader::VersionedInfo<
-                  clang::api_notes::ObjCContextInfo>
-                      info) -> bool {
-            if (auto version = info.getSelected()) {
-              clang::api_notes::ObjCContextInfo context_info =
-                  info[*version].second;
-              if (!context_info.SwiftName.empty())
-                swift_name = context_info.SwiftName;
-              return true;
-            }
-            return false;
-          };
-          if (llvm::isa<clang::ObjCInterfaceDecl>(clang_decl)) {
-            auto info = reader->lookupObjCClassInfo(ident);
-            if (extract_context_info(info))
-              break;
-          }
-          if (llvm::isa<clang::ObjCProtocolDecl>(clang_decl)) {
-            auto info = reader->lookupObjCProtocolInfo(ident);
-            if (extract_context_info(info))
-              break;
-          }
-        }
-      }
-    }
-      
-    auto clang_importer = get_clangimporter();
-    if (!clang_importer)
-      break;
-    //swift::DeclName imported_name = clang_importer->importName(clang_decl, {});
-    //imported_name.getBaseName().userFacingName()
+    std::string swift_name = GetSwiftName(clang_decl, *clang_ts);
     NodePointer identifier = Dem.createNode(Node::Kind::Identifier, swift_name);
     renamed->addChild(identifier, Dem);
     return renamed;
@@ -655,17 +674,12 @@ GetNodeForPrinting(const std::string &m_description, lldb_private::Module &M,
 
 /// Return the demangle tree representation with all "__C" module
 /// names with their actual Clang module names.
-static swift::Demangle::NodePointer GetDemangleTreeForPrinting(
-    const std::string &m_description, lldb_private::Module *Module,
-    GetAPINotesManagerFn get_apinotes_manager,
-    GetClangImporterFn get_clangimporter, swift::Demangle::Demangler &Dem,
-    const char *mangled_name, bool resolve_objc_module) {
+swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetDemangleTreeForPrinting(
+    swift::Demangle::Demangler &Dem, const char *mangled_name,
+     bool resolve_objc_module) {
   NodePointer node = Dem.demangleSymbol(mangled_name);
-  if (!Module)
-    return node;
   NodePointer canonical =
-      GetNodeForPrinting(m_description, *Module, get_apinotes_manager,
-                         get_clangimporter, Dem, node, resolve_objc_module);
+      GetNodeForPrintingImpl(Dem, node, resolve_objc_module);
   return canonical;
 }
 
@@ -871,7 +885,7 @@ static uint32_t collectTypeInfo(Module *M, swift::Demangle::Demangler &Dem,
       // swift_flags |= eTypeIsTypedef;
       auto node_clangtype = ResolveTypeAlias(M, Dem, node);
       if (CompilerType clang_type = node_clangtype.second) {
-        collect_clang_type(clang_type.GetCanonicalType());
+        collect_clang_type(clang_type);
         return swift_flags;
       }
       swift_flags |= collectTypeInfo(M, Dem, node_clangtype.first, generic_walk);
@@ -890,6 +904,42 @@ static uint32_t collectTypeInfo(Module *M, swift::Demangle::Demangler &Dem,
     swift_flags |= collectTypeInfo(M, Dem, node->getChild(i), generic_walk);
 
   return swift_flags;
+}
+
+/// Return a pair of modulename, type name for the outermost nominal type.
+llvm::Optional<std::pair<StringRef, StringRef>>
+GetNominal(swift::Demangle::Demangler &Dem, swift::Demangle::NodePointer node) {
+  if (!node)
+    return {};
+  using namespace swift::Demangle;
+  switch (node->getKind()) {
+    case Node::Kind::Structure:
+    case Node::Kind::Class:
+    case Node::Kind::Enum:
+    case Node::Kind::Protocol:
+    case Node::Kind::ProtocolList:
+    case Node::Kind::ProtocolListWithClass:
+    case Node::Kind::ProtocolListWithAnyObject:
+    case Node::Kind::BoundGenericClass:
+    case Node::Kind::BoundGenericEnum:
+    case Node::Kind::BoundGenericStructure:
+    case Node::Kind::BoundGenericProtocol:
+    case Node::Kind::BoundGenericOtherNominalType:
+    case Node::Kind::BoundGenericTypeAlias: {
+    if (node->getNumChildren() != 2)
+      return {};
+    auto *m = node->getChild(0);
+    if (!m || m->getKind() != Node::Kind::Module || !m->hasText())
+      return {};
+    auto *n = node->getChild(1);
+    if (!n || n->getKind() != Node::Kind::Identifier || !n->hasText())
+      return {};
+    return {{m->getText(), n->getText()}};
+  }
+  default:
+    break;
+  }
+  return {};
 }
 
 CompilerType TypeSystemSwift::GetInstanceType(CompilerType compiler_type) {
@@ -1205,19 +1255,7 @@ swift::Demangle::NodePointer TypeSystemSwiftTypeRef::DemangleCanonicalType(
   using namespace swift::Demangle;
   NodePointer node =
       GetCanonicalDemangleTree(GetModule(), Dem, AsMangledName(opaque_type));
-
-  if (!node || node->getNumChildren() != 1 ||
-      node->getKind() != Node::Kind::Global)
-    return nullptr;
-  node = node->getFirstChild();
-  if (node->getNumChildren() != 1 ||
-      node->getKind() != Node::Kind::TypeMangling)
-    return nullptr;
-  node = node->getFirstChild();
-  if (node->getNumChildren() != 1 || node->getKind() != Node::Kind::Type)
-    return nullptr;
-  node = node->getFirstChild();
-  return node;
+  return GetType(Dem, node);
 }
 
 bool TypeSystemSwiftTypeRef::IsArrayType(opaque_compiler_type_t type,
@@ -1448,13 +1486,8 @@ ConstString TypeSystemSwiftTypeRef::GetTypeName(opaque_compiler_type_t type) {
   auto impl = [&]() {
     using namespace swift::Demangle;
     Demangler Dem;
-    NodePointer print_node = GetDemangleTreeForPrinting(
-        m_description, GetModule(),
-        [&](ClangExternalASTSourceCallbacks *source, unsigned id) {
-          return GetAPINotesManager(source, id);
-        },
-        [&]() { return m_swift_ast_context->GetClangImporter(); }, Dem,
-        AsMangledName(type), true);
+    NodePointer print_node =
+        GetDemangleTreeForPrinting(Dem, AsMangledName(type), true);
     std::string remangled = mangleNode(print_node);
     return ConstString(SwiftLanguageRuntime::DemangleSymbolAsString(
         remangled, SwiftLanguageRuntime::eTypeName));
@@ -1467,13 +1500,8 @@ TypeSystemSwiftTypeRef::GetDisplayTypeName(opaque_compiler_type_t type,
   auto impl = [&]() {
     using namespace swift::Demangle;
     Demangler Dem;
-    NodePointer print_node = GetDemangleTreeForPrinting(
-        m_description, GetModule(),
-        [&](ClangExternalASTSourceCallbacks *source, unsigned id) {
-          return GetAPINotesManager(source, id);
-        },
-        [&]() { return m_swift_ast_context->GetClangImporter(); }, Dem,
-        AsMangledName(type), false);
+    NodePointer print_node =
+        GetDemangleTreeForPrinting(Dem, AsMangledName(type), false);
     std::string remangled = mangleNode(print_node);
     return ConstString(SwiftLanguageRuntime::DemangleSymbolAsString(
         remangled, SwiftLanguageRuntime::eDisplayTypeName, sc));
@@ -1619,15 +1647,60 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
     // Bug-for-bug compatibility. See comment in SwiftASTContext::GetBitSize().
     if (IsFunctionType(type, nullptr))
       return GetPointerByteSize() * 8;
-    if (!exe_scope)
+
+    // Clang types can be resolved even without a process.
+    if (CompilerType clang_type = GetAsClangTypeOrNull(type)) {
+      // Swift doesn't know pointers: return the size of the object
+      // pointer instead of the underlying object.
+      if (Flags(clang_type.GetTypeInfo()).AllSet(eTypeIsObjC | eTypeIsClass))
+        return GetPointerByteSize() * 8;
+      return clang_type.GetBitSize(exe_scope);
+    }
+    if (!exe_scope) {
+      LLDB_LOGF(
+          GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
+          "Couldn't compute size of type %s without an execution context.",
+          AsMangledName(type));
       return {};
+    }
     if (auto *runtime =
             SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
       return runtime->GetBitSize({this, type}, exe_scope);
+
+    // If there is no process, we can still try to get the static size
+    // information out of DWARF. Because it is stored in the Type
+    // object we need to look that up by name again.
+    if (auto *M = GetModule()) {
+      swift::Demangle::Demangler Dem;
+      auto node = GetDemangledType(Dem, AsMangledName(type));
+      if (auto module_type = GetNominal(Dem, node)) {
+        // DW_AT_linkage_name is not part of the accelerator table, so
+        // we need to search by module+name.
+        ConstString module(module_type->first);
+        ConstString type(module_type->second);
+        llvm::SmallVector<CompilerContext, 2> decl_context;
+        decl_context.push_back({CompilerContextKind::Module, module});
+        decl_context.push_back({CompilerContextKind::AnyType, type});
+        llvm::DenseSet<SymbolFile *> searched_symbol_files;
+        TypeMap types;
+        M->FindTypes(decl_context,
+                     TypeSystemSwift::GetSupportedLanguagesForTypes(),
+                     searched_symbol_files, types);
+        if (!types.Empty())
+          if (auto type = types.GetTypeAtIndex(0))
+            return type->GetByteSize(nullptr);
+      }
+    }
+    LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
+              "Couldn't compute size of type %s without a process.",
+              AsMangledName(type));
     return {};
   };
-  VALIDATE_AND_RETURN(impl, GetBitSize, type,
-                      (ReconstructType(type), exe_scope));
+  if (exe_scope && exe_scope->CalculateProcess())
+    VALIDATE_AND_RETURN(impl, GetBitSize, type,
+                        (ReconstructType(type), exe_scope));
+  else
+    return impl();
 }
 llvm::Optional<uint64_t>
 TypeSystemSwiftTypeRef::GetByteStride(opaque_compiler_type_t type,
@@ -1705,10 +1778,47 @@ bool TypeSystemSwiftTypeRef::IsMeaninglessWithoutDynamicResolution(
   return m_swift_ast_context->IsMeaninglessWithoutDynamicResolution(
       ReconstructType(type));
 }
+
+CompilerType TypeSystemSwiftTypeRef::GetAsClangTypeOrNull(
+    lldb::opaque_compiler_type_t type) {
+  CompilerType clang_type;
+  using namespace swift::Demangle;
+  Demangler Dem;
+  NodePointer node = GetDemangledType(Dem, AsMangledName(type));
+  // Directly resolve Clang typedefs into Clang types.  Imported
+  // type aliases that point to Clang type that are also Swift builtins, like
+  // Swift.Int, otherwise would resolved to Swift types.
+  if (node && node->getKind() == Node::Kind::TypeAlias &&
+      node->getNumChildren() == 2 && node->getChild(0)->hasText() &&
+      node->getChild(0)->getText() == swift::MANGLING_MODULE_OBJC &&
+      node->getChild(1)->hasText()) {
+    auto node_clangtype = ResolveTypeAlias(GetModule(), Dem, node,
+                                           /*prefer_clang_types*/ true);
+    if (clang_type = node_clangtype.second)
+      return clang_type;
+  }
+  IsImportedType(type, &clang_type);
+  return clang_type;
+}
+
 bool TypeSystemSwiftTypeRef::IsImportedType(opaque_compiler_type_t type,
                                             CompilerType *original_type) {
-  return m_swift_ast_context->IsImportedType(ReconstructType(type),
-                                             original_type);
+  auto impl = [&]() -> bool {
+    using namespace swift::Demangle;
+    Demangler Dem;
+    NodePointer node = DemangleCanonicalType(Dem, type);
+
+    // This is an imported Objective-C type; look it up in the debug info.
+    StringRef ident = GetObjCTypeName(node);
+    if (ident.empty())
+      return {};
+    if (original_type && GetModule())
+      if (TypeSP clang_type = LookupClangType(*GetModule(), ident))
+        *original_type = clang_type->GetForwardCompilerType();
+    return true;
+  };
+  VALIDATE_AND_RETURN(impl, IsImportedType, type,
+                      (ReconstructType(type), nullptr));
 }
 CompilerType TypeSystemSwiftTypeRef::GetErrorType() {
   return m_swift_ast_context->GetErrorType();

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -67,7 +67,7 @@ static TypeSP LookupClangType(Module &M, StringRef name) {
 }
 
 /// Find a Clang type by name in module \p M.
-static CompilerType LookupClangForwardType(Module &M, StringRef name) {
+CompilerType LookupClangForwardType(Module &M, StringRef name) {
   if (TypeSP type = LookupClangType(M, name))
     return type->GetForwardCompilerType();
   return {};
@@ -275,6 +275,16 @@ GetCanonicalNode(lldb_private::Module *M, swift::Demangle::Demangler &Dem,
       return getCanonicalNode(node_clangtype.first);
     return node;
   }
+  case Node::Kind::DynamicSelf: {
+    // Substitute the static type for dynamic self.
+    assert(node->getNumChildren() == 1);
+    if (node->getNumChildren() != 1)
+      return node;
+    NodePointer type = node->getChild(0);
+    if (type->getKind() != Node::Kind::Type || type->getNumChildren() != 1)
+      return node;
+    return getCanonicalNode(type->getChild(0));
+  }
   default:
     break;
   }
@@ -294,10 +304,9 @@ GetCanonicalNode(lldb_private::Module *M, swift::Demangle::Demangler &Dem,
 
 /// Return the demangle tree representation of this type's canonical
 /// (type aliases resolved) type.
-static swift::Demangle::NodePointer
-GetCanonicalDemangleTree(lldb_private::Module *Module,
-                         swift::Demangle::Demangler &Dem,
-                         const char *mangled_name) {
+swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetCanonicalDemangleTree(
+    lldb_private::Module *Module, swift::Demangle::Demangler &Dem,
+    StringRef mangled_name) {
   NodePointer node = Dem.demangleSymbol(mangled_name);
   NodePointer canonical = GetCanonicalNode(Module, Dem, node);
   return canonical;
@@ -986,7 +995,11 @@ bool TypeSystemSwiftTypeRef::Verify(opaque_compiler_type_t type) {
 
 #include <regex>
 namespace {
-template <typename T> bool Equivalent(T l, T r) { return l == r; }
+template <typename T> bool Equivalent(T l, T r) {
+  if (l != r)
+    llvm::dbgs() <<  l << " != " << r << "\n";
+  return l == r;
+}
 
 /// Specialization for GetTypeInfo().
 template <> bool Equivalent<uint32_t>(uint32_t l, uint32_t r) {
@@ -1120,7 +1133,23 @@ template <> bool Equivalent<ConstString>(ConstString l, ConstString r) {
   }
   return l == r;
 }
+
+/// Version taylored to GetBitSize & friends.
+template <>
+bool Equivalent<llvm::Optional<uint64_t>>(llvm::Optional<uint64_t> l,
+                                          llvm::Optional<uint64_t> r) {
+  if (l == r)
+    return true;
+  // There are situations where SwiftASTContext incorrectly returns
+  // all Clang-imported members of structs as having a size of 0, we
+  // thus assume that a larger number is "better".
+  if (l.hasValue() && r.hasValue() && *l > *r)
+    return true;
+  llvm::dbgs() << l << " != " << r << "\n";
+  return false;
 }
+
+} // namespace
 #endif
 
 // This can be removed once the transition is complete.
@@ -1149,6 +1178,7 @@ template <> bool Equivalent<ConstString>(ConstString l, ConstString r) {
            "TypeSystemSwiftTypeRef diverges from SwiftASTContext");            \
     return result;                                                             \
   } while (0)
+
 #else
 #define VALIDATE_AND_RETURN_STATIC(IMPL, REFERENCE) return IMPL()
 #define VALIDATE_AND_RETURN(IMPL, REFERENCE, TYPE, ARGS) return IMPL()
@@ -1173,8 +1203,6 @@ TypeSystemSwiftTypeRef::RemangleAsType(swift::Demangle::Demangler &Dem,
 swift::Demangle::NodePointer TypeSystemSwiftTypeRef::DemangleCanonicalType(
     swift::Demangle::Demangler &Dem, opaque_compiler_type_t opaque_type) {
   using namespace swift::Demangle;
-  if (!opaque_type)
-    return nullptr;
   NodePointer node =
       GetCanonicalDemangleTree(GetModule(), Dem, AsMangledName(opaque_type));
 
@@ -1587,7 +1615,19 @@ TypeSystemSwiftTypeRef::GetPointerType(opaque_compiler_type_t type) {
 llvm::Optional<uint64_t>
 TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
                                    ExecutionContextScope *exe_scope) {
-  return m_swift_ast_context->GetBitSize(ReconstructType(type), exe_scope);
+  auto impl = [&]() -> llvm::Optional<uint64_t> {
+    // Bug-for-bug compatibility. See comment in SwiftASTContext::GetBitSize().
+    if (IsFunctionType(type, nullptr))
+      return GetPointerByteSize() * 8;
+    if (!exe_scope)
+      return {};
+    if (auto *runtime =
+            SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
+      return runtime->GetBitSize({this, type}, exe_scope);
+    return {};
+  };
+  VALIDATE_AND_RETURN(impl, GetBitSize, type,
+                      (ReconstructType(type), exe_scope));
 }
 llvm::Optional<uint64_t>
 TypeSystemSwiftTypeRef::GetByteStride(opaque_compiler_type_t type,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -17,12 +17,18 @@
 #include "lldb/Core/SwiftForward.h"
 
 #include "swift/AST/Type.h"
-#include "swift/Demangling/Demangle.h"
-#include "swift/Demangling/Demangler.h"
 
 // FIXME: needed only for the DenseMap.
 #include "clang/APINotes/APINotesManager.h"
 #include "clang/Basic/Module.h"
+
+namespace swift {
+namespace Demangle {
+class Node;
+using NodePointer = Node *;
+class Demangler;
+} // namespace Demangle
+} // namespace swift
 
 namespace lldb_private {
 class SwiftASTContext;
@@ -44,7 +50,7 @@ public:
 
   TypeSystemSwiftTypeRef(SwiftASTContext *swift_ast_context);
 
-  Module *GetModule() const;
+  Module *GetModule() const override;
   swift::CanType GetCanonicalSwiftType(CompilerType compiler_type);
   swift::Type GetSwiftType(CompilerType compiler_type);
   CompilerType ReconstructType(CompilerType type);
@@ -248,16 +254,22 @@ public:
       bool print_help_if_available, bool print_extensions_if_available,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
 
-private:
-  /// Helper that creates an AST type from \p type.
-  void *ReconstructType(lldb::opaque_compiler_type_t type);
-  /// Cast \p opaque_type as a mangled name.
-  const char *AsMangledName(lldb::opaque_compiler_type_t opaque_type);
+  /// Return the canonicalized Demangle tree for a Swift mangled type name.
+  static swift::Demangle::NodePointer
+  GetCanonicalDemangleTree(lldb_private::Module *Module,
+                           swift::Demangle::Demangler &Dem,
+                           llvm::StringRef mangled_name);
 
   /// Wrap \p node as \p Global(TypeMangling(node)), remangle the type
   /// and create a CompilerType from it.
   CompilerType RemangleAsType(swift::Demangle::Demangler &Dem,
                               swift::Demangle::NodePointer node);
+
+private:
+  /// Helper that creates an AST type from \p type.
+  void *ReconstructType(lldb::opaque_compiler_type_t type);
+  /// Cast \p opaque_type as a mangled name.
+  const char *AsMangledName(lldb::opaque_compiler_type_t type);
 
   /// Demangle the mangled name of the canonical type of \p type and
   /// drill into the Global(TypeMangling(Type())).

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -31,8 +31,8 @@ class Demangler;
 } // namespace swift
 
 namespace lldb_private {
-class SwiftASTContext;
 class ClangExternalASTSourceCallbacks;
+class SwiftASTContext;
 
 /// A Swift TypeSystem that does not own a swift::ASTContext.
 class TypeSystemSwiftTypeRef : public TypeSystemSwift {
@@ -238,6 +238,9 @@ public:
   void SetCachedType(ConstString mangled, const lldb::TypeSP &type_sp) override;
   bool IsImportedType(lldb::opaque_compiler_type_t type,
                       CompilerType *original_type) override;
+  /// Like \p IsImportedType(), but even returns Clang types that are also Swift
+  /// builtins (int <-> Swift.Int) as Clang types.
+  CompilerType GetAsClangTypeOrNull(lldb::opaque_compiler_type_t type);
   CompilerType GetErrorType() override;
   CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
   CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) override;
@@ -260,6 +263,10 @@ public:
                            swift::Demangle::Demangler &Dem,
                            llvm::StringRef mangled_name);
 
+  /// Use API notes to determine the swiftified name of \p clang_decl.
+  std::string GetSwiftName(const clang::Decl *clang_decl,
+                           TypeSystemClang &clang_typesystem) override;
+
   /// Wrap \p node as \p Global(TypeMangling(node)), remangle the type
   /// and create a CompilerType from it.
   CompilerType RemangleAsType(swift::Demangle::Demangler &Dem,
@@ -279,6 +286,21 @@ private:
   DemangleCanonicalType(swift::Demangle::Demangler &Dem,
                         lldb::opaque_compiler_type_t type);
 
+  /// Replace all "__C" module names with their actual Clang module
+  /// names.  This is the recursion step of \p
+  /// GetDemangleTreeForPrinting(). Don't call it directly.
+  swift::Demangle::NodePointer
+  GetNodeForPrintingImpl(swift::Demangle::Demangler &Dem,
+                         swift::Demangle::NodePointer node,
+                         bool resolve_objc_module, bool desugar = true);
+
+  /// Return the demangle tree representation with all "__C" module
+  /// names with their actual Clang module names.
+  swift::Demangle::NodePointer
+  GetDemangleTreeForPrinting(swift::Demangle::Demangler &Dem,
+                             const char *mangled_name,
+                             bool resolve_objc_module);
+
   /// Return an APINotes manager for the module with module id \id.
   /// APINotes are used to get at the SDK swiftification annotations.
   clang::api_notes::APINotesManager *
@@ -291,7 +313,7 @@ private:
   llvm::DenseMap<clang::Module *,
                  std::unique_ptr<clang::api_notes::APINotesManager>>
       m_apinotes_manager;
-};
+  };
 
 } // namespace lldb_private
 #endif

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -259,7 +259,8 @@ public:
     return {};
   }
 
-  llvm::Optional<uint64_t> GetBitSize(CompilerType type) {
+  llvm::Optional<uint64_t> GetBitSize(CompilerType type,
+                                      ExecutionContextScope *exe_scope) {
     STUB_LOG();
     return {};
   }
@@ -2107,8 +2108,10 @@ SwiftLanguageRuntime::GetConcreteType(ExecutionContextScope *exe_scope,
   FORWARD(GetConcreteType, exe_scope, abstract_type_name);
 }
 
-llvm::Optional<uint64_t> SwiftLanguageRuntime::GetBitSize(CompilerType type) {
-  FORWARD(GetBitSize, type);
+llvm::Optional<uint64_t>
+SwiftLanguageRuntime::GetBitSize(CompilerType type,
+                                 ExecutionContextScope *exe_scope) {
+  FORWARD(GetBitSize, type, exe_scope);
 }
 
 llvm::Optional<uint64_t>

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -442,9 +442,19 @@ public:
     target.ReadCStringFromMemory(addr, &storage[0], storage.size(), error);
     if (error.Success()) {
       dest.assign(&storage[0]);
-      if (log)
-        log->Printf("[MemoryReader] memory read returned data: %s",
-                    dest.c_str());
+      if (log) {
+        StreamString stream;
+        for (auto c : dest) {
+          if (c >= 32 && c <= 127) {
+            stream << c;
+          } else {
+            stream << "\\0";
+            stream.PutHex8(c);
+          }
+        }
+        log->Printf("[MemoryReader] memory read returned data: \"%s\"",
+                    stream.GetData());
+      }
       return true;
     } else {
       if (log)
@@ -617,13 +627,100 @@ public:
   }
 };
 
+class LLDBTypeInfoProvider : public swift::remote::TypeInfoProvider {
+  SwiftLanguageRuntimeImpl &m_runtime;
+  TypeSystemSwift &m_typesystem;
+
+public:
+  LLDBTypeInfoProvider(SwiftLanguageRuntimeImpl &runtime,
+                       TypeSystemSwift &typesystem)
+      : m_runtime(runtime), m_typesystem(typesystem) {}
+
+  const swift::reflection::TypeInfo *
+  getTypeInfo(llvm::StringRef mangledName) override {
+    if (auto ti = m_runtime.lookupClangTypeInfo(mangledName))
+      return *ti;
+
+    Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
+    if (log)
+      log->Printf("[LLDBTypeInfoProvider] Looking up debug type info for %s",
+                  mangledName.str().c_str());
+
+    // Materialize a Clang type from the debug info.
+    assert(swift::Demangle::getManglingPrefixLength(mangledName) == 0);
+    std::string wrapped;
+    // The mangled name passed in is bare. Add global prefix ($s) and type (D).
+    llvm::raw_string_ostream(wrapped) << "$s" << mangledName << 'D';
+#ifndef NDEBUG
+    {
+      // Check that our hardcoded mangling wrapper is still up-to-date.
+      swift::Demangle::Context dem;
+      auto node = dem.demangleSymbolAsNode(wrapped);
+      assert(node && node->getKind() == swift::Demangle::Node::Kind::Global);
+      assert(node->getNumChildren() == 1);
+      node = node->getChild(0);
+      assert(node->getKind() == swift::Demangle::Node::Kind::TypeMangling);
+      assert(node->getNumChildren() == 1);
+      node = node->getChild(0);
+      assert(node->getKind() == swift::Demangle::Node::Kind::Type);
+      assert(node->getNumChildren() == 1);
+      node = node->getChild(0);
+      assert(node->getKind() != swift::Demangle::Node::Kind::Type);
+    }
+#endif
+    ConstString mangled(wrapped);
+    CompilerType swift_type = m_typesystem.GetTypeFromMangledTypename(mangled);
+
+    CompilerType clang_type;
+    if (!m_typesystem.IsImportedType(swift_type.GetOpaqueQualType(),
+                                     &clang_type)) {
+      if (log)
+        log->Printf("[LLDBTypeInfoProvider] Could not find clang debug type info for %s",
+                    mangledName.str().c_str());
+      return nullptr;
+    }
+
+    // Build a TypeInfo for the Clang type.
+    auto size = clang_type.GetByteSize(nullptr);
+    auto bit_align = clang_type.GetTypeBitAlign(nullptr);
+    return m_runtime.emplaceClangTypeInfo(mangledName, size, bit_align);
+  }
+};
+
 } // namespace
+
+llvm::Optional<const swift::reflection::TypeInfo *>
+SwiftLanguageRuntimeImpl::lookupClangTypeInfo(llvm::StringRef mangled_name) {
+  std::lock_guard<std::recursive_mutex> locker(m_clang_type_info_mutex);
+  auto it = m_clang_type_info.find(mangled_name);
+  if (it != m_clang_type_info.end()) {
+    if (it->second)
+      return &*it->second;
+    return nullptr;
+  }
+  return {};
+}
+const swift::reflection::TypeInfo *
+SwiftLanguageRuntimeImpl::emplaceClangTypeInfo(
+    llvm::StringRef mangled_name, llvm::Optional<uint64_t> byte_size,
+    llvm::Optional<size_t> bit_align) {
+  std::lock_guard<std::recursive_mutex> locker(m_clang_type_info_mutex);
+  if (!byte_size || !bit_align) {
+    m_clang_type_info.insert({mangled_name, llvm::None});
+    return nullptr;
+  }
+  auto it_b = m_clang_type_info.insert(
+      {mangled_name,
+       swift::reflection::TypeInfo(swift::reflection::TypeInfoKind::Builtin,
+                                   *byte_size, *bit_align * 8, 0, 0, true)});
+  return &*it_b.first->second;
+}
 
 llvm::Optional<uint64_t> SwiftLanguageRuntimeImpl::GetMemberVariableOffset(
     CompilerType instance_type, ValueObject *instance, ConstString member_name,
     Status *error) {
   if (!instance_type.IsValid())
-    return llvm::None;
+    return {};
 
   Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
   // Using the module context for RemoteAST is cheaper bit only safe
@@ -635,13 +732,13 @@ llvm::Optional<uint64_t> SwiftLanguageRuntimeImpl::GetMemberVariableOffset(
   auto *module_ctx =
       llvm::dyn_cast_or_null<SwiftASTContext>(instance_type.GetTypeSystem());
   if (!module_ctx || module_ctx->HasFatalErrors())
-    return llvm::None;
+    return {};
 
   llvm::Optional<SwiftASTContextReader> scratch_ctx;
   if (instance) {
     scratch_ctx = instance->GetScratchSwiftASTContext();
     if (!scratch_ctx)
-      return llvm::None;
+      return {};
   }
 
   auto *remote_ast = &GetRemoteASTContext(*module_ctx);
@@ -740,9 +837,10 @@ llvm::Optional<uint64_t> SwiftLanguageRuntimeImpl::GetMemberVariableOffset(
   }
 
   // Try remote mirrors.
-  const swift::reflection::TypeInfo *type_info = GetTypeInfo(instance_type);
+  const swift::reflection::TypeInfo *type_info =
+      GetTypeInfo(instance_type, nullptr);
   if (!type_info)
-    return llvm::None;
+    return {};
   auto record_type_info =
       llvm::dyn_cast<swift::reflection::RecordTypeInfo>(type_info);
   if (record_type_info) {
@@ -754,7 +852,7 @@ llvm::Optional<uint64_t> SwiftLanguageRuntimeImpl::GetMemberVariableOffset(
           tuple_idx >= record_type_info->getNumFields()) {
         if (error)
           error->SetErrorString("tuple index out of bounds");
-        return llvm::None;
+        return {};
       }
       return record_type_info->getFields()[tuple_idx].Offset;
     }
@@ -769,9 +867,15 @@ llvm::Optional<uint64_t> SwiftLanguageRuntimeImpl::GetMemberVariableOffset(
   lldb::addr_t pointer = instance->GetPointerValue();
   auto *reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
-    return llvm::None;
+    return {};
 
-  auto class_instance_type_info = reflection_ctx->getInstanceTypeInfo(pointer);
+  auto *ts =
+      llvm::dyn_cast_or_null<TypeSystemSwift>(instance_type.GetTypeSystem());
+  if (!ts)
+    return {};
+  LLDBTypeInfoProvider provider(*this, *ts);
+  auto class_instance_type_info =
+      reflection_ctx->getInstanceTypeInfo(pointer, &provider);
   if (class_instance_type_info) {
     auto class_type_info = llvm::dyn_cast<swift::reflection::RecordTypeInfo>(
         class_instance_type_info);
@@ -782,7 +886,7 @@ llvm::Optional<uint64_t> SwiftLanguageRuntimeImpl::GetMemberVariableOffset(
       }
     }
   }
-  return llvm::None;
+  return {};
 }
 
 bool SwiftLanguageRuntime::IsSelf(Variable &variable) {
@@ -1001,7 +1105,31 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Protocol(
   return true;
 }
 
-SwiftLanguageRuntime::MetadataPromiseSP
+llvm::Optional<lldb::addr_t>
+SwiftLanguageRuntimeImpl::GetTypeMetadataForTypeNameAndFrame(
+    StringRef mdvar_name, StackFrame &frame) {
+  VariableList *var_list = frame.GetVariableList(false);
+  if (!var_list)
+    return {};
+
+  VariableSP var_sp(var_list->FindVariable(ConstString(mdvar_name)));
+  if (!var_sp)
+    return {};
+
+  ValueObjectSP metadata_ptr_var_sp(
+      frame.GetValueObjectForFrameVariable(var_sp, lldb::eNoDynamicValues));
+  if (!metadata_ptr_var_sp ||
+      metadata_ptr_var_sp->UpdateValueIfNeeded() == false)
+    return {};
+
+  lldb::addr_t metadata_location(metadata_ptr_var_sp->GetValueAsUnsigned(0));
+  if (metadata_location == 0 || metadata_location == LLDB_INVALID_ADDRESS)
+    return {};
+
+  return metadata_location;
+}
+
+  SwiftLanguageRuntime::MetadataPromiseSP
 SwiftLanguageRuntimeImpl::GetPromiseForTypeNameAndFrame(const char *type_name,
                                                         StackFrame *frame) {
   if (!frame || !type_name || !type_name[0])
@@ -1027,22 +1155,117 @@ SwiftLanguageRuntimeImpl::GetPromiseForTypeNameAndFrame(const char *type_name,
   lldb::addr_t metadata_location(metadata_ptr_var_sp->GetValueAsUnsigned(0));
   if (metadata_location == 0 || metadata_location == LLDB_INVALID_ADDRESS)
     return nullptr;
-
   return GetMetadataPromise(metadata_location, *metadata_ptr_var_sp);
+}
+
+static void
+ForEachGenericParameter(swift::Demangle::NodePointer node,
+                        std::function<void(unsigned, unsigned)> callback) {
+  if (!node)
+    return;
+
+  using namespace swift::Demangle;
+  switch (node->getKind()) {
+  case Node::Kind::DependentGenericParamType: {
+    if (node->getNumChildren() != 2)
+      return;
+    NodePointer depth_node = node->getChild(0);
+    NodePointer index_node = node->getChild(1);
+    if (!depth_node || !depth_node->hasIndex() || !index_node ||
+        !index_node->hasIndex())
+      return;
+    callback(depth_node->getIndex(), index_node->getIndex());
+    break;
+  }
+  default:
+    // Visit the child nodes.
+    for (unsigned i = 0; i < node->getNumChildren(); ++i)
+      ForEachGenericParameter(node->getChild(i), callback);
+  }
+}
+
+CompilerType SwiftLanguageRuntimeImpl::DoArchetypeBindingForTypeRef(
+    StackFrame &stack_frame, TypeSystemSwiftTypeRef &ts,
+    ConstString mangled_name) {
+  auto *reflection_ctx = GetReflectionContext();
+  if (!reflection_ctx)
+    return ts.GetTypeFromMangledTypename(mangled_name);
+
+  swift::Demangle::Demangler Dem;
+  swift::Demangle::NodePointer canonical =
+      TypeSystemSwiftTypeRef::GetCanonicalDemangleTree(
+          ts.GetModule(), Dem, mangled_name.GetStringRef());
+
+  // Build the list of type substitutions.
+  swift::reflection::GenericArgumentMap substitutions;
+  ForEachGenericParameter(canonical, [&](unsigned depth, unsigned index) {
+    if (substitutions.count({depth, index}))
+      return;
+    StreamString mdvar_name;
+    mdvar_name.Printf(u8"$\u03C4_%d_%d", depth, index);
+
+    llvm::Optional<lldb::addr_t> metadata_location =
+        GetTypeMetadataForTypeNameAndFrame(mdvar_name.GetString(), stack_frame);
+    if (!metadata_location)
+      return;
+
+    const swift::reflection::TypeRef *type_ref =
+        reflection_ctx->readTypeFromMetadata(*metadata_location);
+    substitutions.insert({{depth, index}, type_ref});
+  });
+
+  // Nothing to do if there are no type parameters.
+  if (substitutions.empty())
+    return ts.GetTypeFromMangledTypename(ConstString(mangleNode(canonical)));
+
+  // Build a TypeRef from the demangle tree.
+  const swift::reflection::TypeRef *type_ref =
+      swift::Demangle::decodeMangledType(reflection_ctx->getBuilder(),
+                                         canonical);
+
+  // Apply the substitutions.
+  const swift::reflection::TypeRef *bound_type_ref =
+      type_ref->subst(reflection_ctx->getBuilder(), substitutions);
+  swift::Demangle::NodePointer node = bound_type_ref->getDemangling(Dem);
+  CompilerType bound_type = ts.RemangleAsType(Dem, node);
+
+  // Import the type into the scratch context. Subsequent conversions
+  // to Swift types must be performed in the scratch context, since
+  // the bound type may combine types from different
+  // lldb::Modules. Contrary to the AstContext variant of this
+  // function, we don't want to do this earlier, because the
+  // canonicalization in GetCanonicalDemangleTree() must be performed in
+  // the original context as to resolve type aliases correctly.
+  Status error;
+  auto &target = m_process.GetTarget();
+  if (auto scratch_ctx = target.GetScratchSwiftASTContext(error, stack_frame))
+    bound_type = scratch_ctx->get()->ImportType(bound_type, error);
+  
+  LLDB_LOG(
+      GetLogIfAnyCategoriesSet(LIBLLDB_LOG_EXPRESSIONS | LIBLLDB_LOG_TYPES),
+      "Bound {0} -> {1}.", mangled_name, bound_type.GetMangledTypeName());
+  return bound_type;
 }
 
 CompilerType
 SwiftLanguageRuntimeImpl::DoArchetypeBindingForType(StackFrame &stack_frame,
                                                     CompilerType base_type) {
+  auto &target = m_process.GetTarget();
+  assert(IsScratchContextLocked(target) &&
+         "Swift scratch context not locked ahead of archetype binding");
+
+  // If this is a TypeRef type, bind that.
   auto sc = stack_frame.GetSymbolContext(lldb::eSymbolContextEverything);
+  if (auto *ts = llvm::dyn_cast_or_null<TypeSystemSwiftTypeRef>(
+          base_type.GetTypeSystem()))
+    return DoArchetypeBindingForTypeRef(stack_frame, *ts,
+                                        base_type.GetMangledTypeName());
+
   Status error;
   // A failing Clang import in a module context permanently damages
   // that module context.  Binding archetypes can trigger an import of
   // another module, so switch to a scratch context where such an
   // operation is safe.
-  auto &target = m_process.GetTarget();
-  assert(IsScratchContextLocked(target) &&
-         "Swift scratch context not locked ahead of archetype binding");
   llvm::Optional<SwiftASTContextReader> maybe_scratch_ctx =
       target.GetScratchSwiftASTContext(error, stack_frame);
   if (!maybe_scratch_ctx)
@@ -1714,49 +1937,92 @@ lldb::addr_t SwiftLanguageRuntime::FixupAddress(lldb::addr_t addr,
   return addr;
 }
 
-const swift::reflection::TypeInfo *
-SwiftLanguageRuntimeImpl::GetTypeInfo(CompilerType type) {
+const swift::reflection::TypeRef *
+SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type, Module *module) {
+  // Demangle the mangled name.
+  swift::Demangle::Demangler Dem;
+  ConstString mangled_name = type.GetMangledTypeName();
+  auto *ts = llvm::dyn_cast_or_null<TypeSystemSwift>(type.GetTypeSystem());
+  if (!ts)
+    return nullptr;
+  swift::Demangle::NodePointer node =
+      TypeSystemSwiftTypeRef::GetCanonicalDemangleTree(
+          module ? module : ts->GetModule(), Dem, mangled_name.GetStringRef());
+  if (!node)
+    return nullptr;
+
+  // Build a TypeRef.
   auto *reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return nullptr;
 
-  swift::CanType swift_can_type(GetCanonicalSwiftType(type));
-  CompilerType can_type = ToCompilerType(swift_can_type);
-  ConstString mangled_name(can_type.GetMangledTypeName());
-  StringRef mangled_no_prefix =
-      swift::Demangle::dropSwiftManglingPrefix(mangled_name.GetStringRef());
-  swift::Demangle::Demangler Dem;
-  auto demangled = Dem.demangleType(mangled_no_prefix);
-  auto *type_ref = swift::Demangle::decodeMangledType(
-      reflection_ctx->getBuilder(), demangled).getType();
+  const swift::reflection::TypeRef *type_ref =
+      swift::Demangle::decodeMangledType(reflection_ctx->getBuilder(), node);
+  return type_ref;
+}
+
+const swift::reflection::TypeInfo *
+SwiftLanguageRuntimeImpl::GetTypeInfo(CompilerType type,
+                                      ExecutionContextScope *exe_scope) {
+  auto *ts = llvm::dyn_cast_or_null<TypeSystemSwift>(type.GetTypeSystem());
+  if (!ts)
+    return nullptr;
+
+  // Resolve all generic type parameters in the type for the current
+  // frame.  Archetype binding has to happen in the scratch context,
+  // so we lock it while we are in this function.
+  std::unique_ptr<SwiftASTContextLock> lock;
+  if (exe_scope)
+    if (StackFrame *frame = exe_scope->CalculateStackFrame().get()) {
+      ExecutionContext exe_ctx;
+      // FIXME: Should be
+      // frame->CalculateExecutionContext(exe_ctx);
+      // but all the other functions currently get this wrong, too!
+      m_process.GetTarget().CalculateExecutionContext(exe_ctx);
+      lock = std::make_unique<SwiftASTContextLock>(&exe_ctx);
+      type = DoArchetypeBindingForType(*frame, type);
+    }
+
+  // DoArchetypeBindingForType imports the type into the scratch
+  // context, but we need to resolve (any DWARF links in) the typeref
+  // in the original module.
+  const swift::reflection::TypeRef *type_ref =
+      GetTypeRef(type, ts->GetModule());
   if (!type_ref)
     return nullptr;
-  return reflection_ctx->getBuilder().getTypeConverter().getTypeInfo(type_ref);
+
+  auto *reflection_ctx = GetReflectionContext();
+  if (!reflection_ctx)
+    return nullptr;
+
+  LLDBTypeInfoProvider provider(*this, *ts);
+  return reflection_ctx->getTypeInfo(type_ref, &provider);
 }
 
 bool SwiftLanguageRuntimeImpl::IsStoredInlineInBuffer(CompilerType type) {
-  if (auto *type_info = GetTypeInfo(type))
+  if (auto *type_info = GetTypeInfo(type, nullptr))
     return type_info->isBitwiseTakable() && type_info->getSize() <= 24;
   return true;
 }
 
 llvm::Optional<uint64_t>
-SwiftLanguageRuntimeImpl::GetBitSize(CompilerType type) {
-  if (auto *type_info = GetTypeInfo(type))
+SwiftLanguageRuntimeImpl::GetBitSize(CompilerType type,
+                                     ExecutionContextScope *exe_scope) {
+  if (auto *type_info = GetTypeInfo(type, exe_scope))
     return type_info->getSize() * 8;
   return {};
 }
 
 llvm::Optional<uint64_t>
 SwiftLanguageRuntimeImpl::GetByteStride(CompilerType type) {
-  if (auto *type_info = GetTypeInfo(type))
+  if (auto *type_info = GetTypeInfo(type, nullptr))
     return type_info->getStride();
   return {};
 }
 
 llvm::Optional<size_t>
 SwiftLanguageRuntimeImpl::GetBitAlignment(CompilerType type) {
-  if (auto *type_info = GetTypeInfo(type))
+  if (auto *type_info = GetTypeInfo(type, nullptr))
     return type_info->getAlignment();
   return {};
 }

--- a/lldb/source/Target/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Target/SwiftLanguageRuntimeImpl.h
@@ -136,16 +136,16 @@ public:
 protected:
   /// Use the reflection context to build a TypeRef object.
   ///
-  ///\param module can be used to specify a module to look up DWARF
+  /// \param module can be used to specify a module to look up DWARF
   /// type references (such as type aliases and Clang types)
   /// in. Module only needs to be specified when it is different from
   /// \c type.GetTypeSystem().GetModule(). The only situation where it
   /// is necessary to specify the module explicitly is if a type has
   /// been imported into the scratch context. This is always the
   /// module of the outermost type. Even for bound generic types,
-  /// we're only interested in the module the BGS came from, the bound
-  /// generic parameters can be resolved from their type metadata
-  /// alone.
+  /// we're only interested in the module the bound generic type came
+  /// from, the bound generic parameters can be resolved from their
+  /// type metadata alone.
   const swift::reflection::TypeRef *GetTypeRef(CompilerType type,
                                                Module *module = nullptr);
 

--- a/lldb/source/Target/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Target/SwiftLanguageRuntimeImpl.h
@@ -15,6 +15,12 @@
 
 #include "lldb/Target/SwiftLanguageRuntime.h"
 
+namespace swift {
+namespace reflection {
+class TypeRef;
+}
+} // namespace swift
+
 namespace lldb_private {
 class Process;
 
@@ -64,11 +70,21 @@ public:
                                  ValueObject &static_value);
 
   /// Ask Remote Mirrors for the type info about a Swift type.
-  const swift::reflection::TypeInfo *GetTypeInfo(CompilerType type);
+  const swift::reflection::TypeInfo *
+  GetTypeInfo(CompilerType type, ExecutionContextScope *exe_scope);
+
+  llvm::Optional<const swift::reflection::TypeInfo *>
+  lookupClangTypeInfo(llvm::StringRef mangled_name);
+  const swift::reflection::TypeInfo *
+  emplaceClangTypeInfo(llvm::StringRef mangled_name,
+                       llvm::Optional<uint64_t> byte_size,
+                       llvm::Optional<size_t> bit_align);
+
   bool IsStoredInlineInBuffer(CompilerType type);
 
   /// Ask Remote Mirrors for the size of a Swift type.
-  llvm::Optional<uint64_t> GetBitSize(CompilerType type);
+  llvm::Optional<uint64_t> GetBitSize(CompilerType type,
+                                      ExecutionContextScope *exe_scope);
 
   /// Ask Remote mirrors for the stride of a Swift type.
   llvm::Optional<uint64_t> GetByteStride(CompilerType type);
@@ -82,6 +98,10 @@ public:
                                                    ValueObject *instance,
                                                    ConstString member_name,
                                                    Status *error);
+
+  CompilerType DoArchetypeBindingForTypeRef(StackFrame &stack_frame,
+                                            TypeSystemSwiftTypeRef &ts,
+                                            ConstString mangled_name);
 
   CompilerType DoArchetypeBindingForType(StackFrame &stack_frame,
                                          CompilerType base_type);
@@ -114,6 +134,21 @@ public:
   bool IsABIStable();
 
 protected:
+  /// Use the reflection context to build a TypeRef object.
+  ///
+  ///\param module can be used to specify a module to look up DWARF
+  /// type references (such as type aliases and Clang types)
+  /// in. Module only needs to be specified when it is different from
+  /// \c type.GetTypeSystem().GetModule(). The only situation where it
+  /// is necessary to specify the module explicitly is if a type has
+  /// been imported into the scratch context. This is always the
+  /// module of the outermost type. Even for bound generic types,
+  /// we're only interested in the module the BGS came from, the bound
+  /// generic parameters can be resolved from their type metadata
+  /// alone.
+  const swift::reflection::TypeRef *GetTypeRef(CompilerType type,
+                                               Module *module = nullptr);
+
   // Classes that inherit from SwiftLanguageRuntime can see and modify these
   Value::ValueType GetValueType(Value::ValueType static_value_type,
                                 CompilerType static_type,
@@ -149,6 +184,10 @@ protected:
 
   SwiftLanguageRuntime::MetadataPromiseSP
   GetPromiseForTypeNameAndFrame(const char *type_name, StackFrame *frame);
+
+  llvm::Optional<lldb::addr_t>
+  GetTypeMetadataForTypeNameAndFrame(llvm::StringRef mdvar_name,
+                                     StackFrame &frame);
 
   const CompilerType &GetBoxMetadataType();
 
@@ -237,6 +276,10 @@ private:
   /// \return true on success.
   bool AddModuleToReflectionContext(const lldb::ModuleSP &module_sp);
   /// \}
+
+  llvm::StringMap<llvm::Optional<swift::reflection::TypeInfo>>
+      m_clang_type_info;
+  std::recursive_mutex m_clang_type_info_mutex;
 
   /// Swift native NSError isa.
   llvm::Optional<lldb::addr_t> m_SwiftNativeNSErrorISA;

--- a/lldb/test/API/lang/swift/enum_objc/main.swift
+++ b/lldb/test/API/lang/swift/enum_objc/main.swift
@@ -14,3 +14,4 @@ func test()
 }
 
 _ = test()
+print("this is needed to load the stdlib")

--- a/lldb/test/API/lang/swift/system_framework/main.swift
+++ b/lldb/test/API/lang/swift/system_framework/main.swift
@@ -2,5 +2,5 @@ import ApplicationServices
 
 func stop() {}
 
-let a = ATSFSSpec()
+let a = ATSGlyphIdealMetrics()
 stop() // break here

--- a/lldb/test/Shell/Reproducer/Swift/TestBridging.test
+++ b/lldb/test/Shell/Reproducer/Swift/TestBridging.test
@@ -1,4 +1,4 @@
-# UNSUPPORTED: system-windows, system-freebsd
+# UNSUPPORTED: system-windows, system-freebsd, system-linux
 
 # This tests replaying a Swift reproducer with bridging.
 

--- a/lldb/test/Shell/Swift/Inputs/No.swiftmodule.swift
+++ b/lldb/test/Shell/Swift/Inputs/No.swiftmodule.swift
@@ -13,7 +13,7 @@ func f<T>(_ t: T) {
   let string = "hello"             // CHECK-DAG: (String) string = "hello"
   let tuple = (0, 1)               // CHECK-DAG: (Int, Int) tuple = (0 = 0, 1 = 1)
   let strct = s()                  // CHECK-DAG: strct = {}{{$}}
-  let strct2 = S2()                // CHECK-DAG: strct2 = <extracting data from value failed>
+  let strct2 = S2()                // CHECK-DAG: strct2 = {}{{$}}
   let generic = t                  // CHECK-DAG: (Int) generic = 23
   let generic_tuple = (t, t)       // CHECK-DAG: generic_tuple = (0 = 23, 1 = 23)
   print(number)

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -431,3 +431,22 @@ TEST_F(TestTypeSystemSwiftTypeRef, TypeClass) {
     ASSERT_EQ(t.GetTypeClass(), lldb::eTypeClassOther);
   }
 }
+
+TEST_F(TestTypeSystemSwiftTypeRef, ImportedType) {
+  using namespace swift::Demangle;
+  Demangler dem;
+  NodeBuilder b(dem);
+  {
+    NodePointer node = b.GlobalTypeMangling(b.IntType());
+    CompilerType type = GetCompilerType(b.Mangle(node));
+    ASSERT_FALSE(m_swift_ts.IsImportedType(type.GetOpaqueQualType(), nullptr));
+  }
+  {
+    NodePointer node = b.GlobalType(
+        b.Node(Node::Kind::Structure,
+               b.Node(Node::Kind::Module, swift::MANGLING_MODULE_OBJC),
+               b.Node(Node::Kind::Identifier, "NSDecimal")));
+    CompilerType type = GetCompilerType(b.Mangle(node));
+    ASSERT_TRUE(m_swift_ts.IsImportedType(type.GetOpaqueQualType(), nullptr));
+  }
+}


### PR DESCRIPTION
In order to implement GetBitSize, this patch also adds an initial
TypeRef-based implementation of
SwiftLanguageRuntimeImpl::DoArchetypeBinding(). To make
SwiftLanguageRuntimeImpl::GetTypeInfo() work with TypeRefs of
ClangImported non-Objective-C types, a new callback is added to
swift::reflection::MemoryReader, which allos LLDB to provide the
swift::reflection::TypeInfo for a Clang type based on debug
information.

<rdar://problem/55412920>

Needs https://github.com/apple/swift/pull/33417