### PR TITLE
make lldb find python 3.8, for ubuntu20 builds

### DIFF
--- a/lldb/cmake/modules/FindPythonInterpAndLibs.cmake
+++ b/lldb/cmake/modules/FindPythonInterpAndLibs.cmake
@@ -26,8 +26,8 @@ else()
       endif()
     else()
       # SWIFT_ENABLE_TENSORFLOW
-      # Make it so that LLDB can find Python 3.6 or Python 3.7.
-      set(Python_ADDITIONAL_VERSIONS 3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0 2.7 2.6 2.5)
+      # Make it so that LLDB can find Python 3.6+
+      set(Python_ADDITIONAL_VERSIONS 3.8 3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0 2.7 2.6 2.5)
 
       find_package(PythonInterp QUIET)
       find_package(PythonLibs QUIET)


### PR DESCRIPTION
The ubuntu20.04 build for the 0.11updated release is linked to python2 instead of python3, because ubuntu20.04 has python 3.8 and the lldb config file does not known about 3.8.

This is important to fix so that the 0.11 release works on colab if they switch to ubuntu 20.04 while 0.11 is live.

This is a cherry-pick of something already in the tensorflow development branch.

The change will only affect the ubuntu20.04 build.
