### PR TITLE
[lldb] Set the correct include paths in prepare_binding_python.py

### DIFF
--- a/lldb/bindings/python/prepare_binding_python.py
+++ b/lldb/bindings/python/prepare_binding_python.py
@@ -194,6 +194,9 @@ def do_swig_rebuild(options, dependency_file, config_build_dir, settings):
     if options.generate_dependency_file:
         temp_dep_file_path = dependency_file + ".tmp"
 
+    bindings_python_dir = os.path.dirname(os.path.realpath(__file__))
+    bindings_dir = os.path.dirname(bindings_python_dir)
+
     # Build the SWIG args list
     is_darwin = options.target_platform == "Darwin"
     gen_deps = options.generate_dependency_file
@@ -207,7 +210,8 @@ def do_swig_rebuild(options, dependency_file, config_build_dir, settings):
             "-features", "autodoc",
             "-threads",
             "-I" + os.path.normpath(os.path.join(options.src_root, "include")),
-            "-I" + os.path.curdir,
+            "-I" + bindings_dir,
+            "-I" + bindings_python_dir,
             "-D__STDC_LIMIT_MACROS",
             "-D__STDC_CONSTANT_MACROS"
         ]
@@ -418,9 +422,9 @@ def main(options):
             return
 
     # Setup paths used during swig invocation.
-    settings.input_file = os.path.normcase(
-        os.path.join(options.src_root, "bindings", "python.swig"))
     bindings_python_dir = os.path.dirname(os.path.realpath(__file__))
+    settings.input_file = os.path.normcase(
+        os.path.join(bindings_python_dir, "python.swig"))
     settings.extensions_file = os.path.normcase(
         os.path.join(bindings_python_dir, "python-extensions.swig"))
     settings.wrapper_file = os.path.normcase(


### PR DESCRIPTION
Now that the SWIG bindings for Python and Lua live in their own
subdirectories, the include directories in prepare_binding_python.py
need to be updated to include both the top level bindings dir as well as
the Python-specific one.