### PR TITLE
[lldb] Fix relative imports and set the appropriate include dirs

### DIFF
--- a/lldb/bindings/lua/CMakeLists.txt
+++ b/lldb/bindings/lua/CMakeLists.txt
@@ -5,6 +5,7 @@ add_custom_command(
   DEPENDS ${SWIG_HEADERS}
   COMMAND ${SWIG_EXECUTABLE}
       ${SWIG_COMMON_FLAGS}
+      -I${CMAKE_CURRENT_SOURCE_DIR}
       -lua
       -w503
       -outdir ${CMAKE_CURRENT_BINARY_DIR}

--- a/lldb/bindings/lua/lua.swig
+++ b/lldb/bindings/lua/lua.swig
@@ -9,13 +9,13 @@
 %module lldb
 
 %include <std_string.i>
-%include "./lua/lua-typemaps.swig"
-%include "./macros.swig"
-%include "./headers.swig"
+%include "lua-typemaps.swig"
+%include "macros.swig"
+%include "headers.swig"
 
 %{
 using namespace lldb_private;
 using namespace lldb;
 %}
 
-%include "./interfaces.swig"
+%include "interfaces.swig"

--- a/lldb/bindings/python/CMakeLists.txt
+++ b/lldb/bindings/python/CMakeLists.txt
@@ -6,6 +6,7 @@ add_custom_command(
   DEPENDS ${SWIG_HEADERS}
   COMMAND ${SWIG_EXECUTABLE}
       ${SWIG_COMMON_FLAGS}
+      -I${CMAKE_CURRENT_SOURCE_DIR}
       -c++
       -shadow
       -python

--- a/lldb/bindings/python/python.swig
+++ b/lldb/bindings/python/python.swig
@@ -111,9 +111,9 @@ def lldb_iter(obj, getsize, getelem):
 %}
 
 %include <std_string.i>
-%include "./python/python-typemaps.swig"
-%include "./macros.swig"
-%include "./headers.swig"
+%include "python-typemaps.swig"
+%include "macros.swig"
+%include "headers.swig"
 
 %{
 #include "../source/Plugins/ScriptInterpreter/Python/PythonDataObjects.h"
@@ -123,9 +123,9 @@ using namespace lldb_private::python;
 using namespace lldb;
 %}
 
-%include "./interfaces.swig"
-%include "./python/python-extensions.swig"
-%include "./python/python-wrapper.swig"
+%include "interfaces.swig"
+%include "python-extensions.swig"
+%include "python-wrapper.swig"
 
 %pythoncode%{
 _initialize = True


### PR DESCRIPTION
After moving python.swig and lua.swig into their respective
subdirectories, the relative paths in these files were out of date. This
fixes that and ensures the appropriate include paths are set in the SWIG
invocation.

Differential revision: https://reviews.llvm.org/D85859

(cherry picked from commit fbfd831ddac2a9dd2e7bcdf179c88de7c9c5f5ae)