### PR TITLE
Remove Linux XFail in TestClassConstrainedProtocol [master-rebranch]

### DIFF
--- a/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
+++ b/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
@@ -24,7 +24,6 @@ class TestClassConstrainedProtocol(TestBase):
         self.do_self_test("Break here for weak self")
 
     @swiftTest
-    @expectedFailureAll(oslist=["linux"], bugnumber="rdar://31822722")
     def test_extension_self (self):
         """Test that we can reconstruct self in method of a class constrained protocol."""
         self.build()


### PR DESCRIPTION
@adrian-prantl This fixes the XFAIL warning:https://ci.swift.org/job/oss-swift-master-rebranch-swift-package-linux-ubuntu-18_04/8/