### PR TITLE
[lldb] Skip TestStepScripted with reproducers

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -878,8 +878,6 @@ def skipUnlessFeature(feature):
 
 def skipIfReproducer(func):
     """Skip this test if the environment is set up to run LLDB with reproducers."""
-    def is_reproducer():
-        if configuration.capture_path or configuration.replay_path:
-            return "reproducers unsupported"
-        return None
-    return skipTestIfFn(is_reproducer)(func)
+    return unittest2.skipIf(
+        configuration.capture_path or configuration.replay_path,
+        "reproducers unsupported")(func)

--- a/lldb/test/API/functionalities/step_scripted/TestStepScripted.py
+++ b/lldb/test/API/functionalities/step_scripted/TestStepScripted.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
+@skipIfReproducer # FIXME: Unexpected packet during (active) replay
 class StepScriptedTestCase(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
@@ -18,14 +19,12 @@ class StepScriptedTestCase(TestBase):
         self.main_source_file = lldb.SBFileSpec("main.c")
         self.runCmd("command script import Steps.py")
 
-    @skipIfReproducer # FIXME: Unexpected packet during (active) replay
     def test_standard_step_out(self):
         """Tests stepping with the scripted thread plan laying over a standard 
         thread plan for stepping out."""
         self.build()
         self.step_out_with_scripted_plan("Steps.StepOut")
 
-    @skipIfReproducer # FIXME: Unexpected packet during (active) replay
     def test_scripted_step_out(self):
         """Tests stepping with the scripted thread plan laying over an another 
         scripted thread plan for stepping out."""
@@ -65,12 +64,10 @@ class StepScriptedTestCase(TestBase):
         # Make sure we didn't let the process run:
         self.assertEqual(stop_id, process.GetStopID(), "Process didn't run")
         
-    @skipIfReproducer # FIXME: Unexpected packet during (active) replay
     def test_checking_variable(self):
         """Test that we can call SBValue API's from a scripted thread plan - using SBAPI's to step"""
         self.do_test_checking_variable(False)
         
-    @skipIfReproducer # FIXME: Unexpected packet during (active) replay
     def test_checking_variable_cli(self):
         """Test that we can call SBValue API's from a scripted thread plan - using cli to step"""
         self.do_test_checking_variable(True)


### PR DESCRIPTION
Some of the test methods were already skipped because of an unexpected
packet. The test started failing after it was expanded. Skip the whole
test with reproducers so we don't have to add the decorator for every
method.

(cherry picked from commit 180d6ed66778ec5b7ee68878005ca1f0498b6d6d)