### PR TITLE
[lldb] Set the launch flags to GetLaunchInfo().GetLaunchFlags()

### DIFF
--- a/lldb/test/API/commands/expression/expr-in-syscall/TestExpressionInSyscall.py
+++ b/lldb/test/API/commands/expression/expr-in-syscall/TestExpressionInSyscall.py
@@ -31,6 +31,7 @@ class ExprSyscallTestCase(TestBase):
         # launch the inferior and don't wait for it to stop
         self.dbg.SetAsync(True)
         error = lldb.SBError()
+        flags = target.GetLaunchInfo().GetLaunchFlags()
         process = target.Launch(listener,
                                 None,      # argv
                                 None,      # envp
@@ -38,7 +39,7 @@ class ExprSyscallTestCase(TestBase):
                                 None,      # stdout_path
                                 None,      # stderr_path
                                 None,      # working directory
-                                0,         # launch flags
+                                flags,     # launch flags
                                 False,     # Stop at entry
                                 error)     # error
 

--- a/lldb/test/API/commands/register/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register/register_command/TestRegisters.py
@@ -284,13 +284,14 @@ class RegisterCommandsTestCase(TestBase):
 
         # Launch the process, stop at the entry point.
         error = lldb.SBError()
+        flags = target.GetLaunchInfo().GetLaunchFlags()
         process = target.Launch(
                 lldb.SBListener(),
                 None, None, # argv, envp
                 None, None, None, # stdin/out/err
                 self.get_process_working_directory(),
-                0, # launch flags
-                True, # stop at entry
+                flags, # launch flags
+                True,  # stop at entry
                 error)
         self.assertSuccess(error, "Launch succeeds")
 

--- a/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
@@ -52,7 +52,7 @@ class ModuleLoadedNotifysTestCase(TestBase):
             True
 
         error = lldb.SBError()
-        flags = lldb.eLaunchFlagInheritTCCFromParent
+        flags = target.GetLaunchInfo().GetLaunchFlags()
         process = target.Launch(listener,
                                 None,      # argv
                                 None,      # envp

--- a/lldb/test/API/python_api/event/TestEvents.py
+++ b/lldb/test/API/python_api/event/TestEvents.py
@@ -50,6 +50,7 @@ class EventAPITestCase(TestBase):
 
         # Now launch the process, and do not stop at the entry point.
         error = lldb.SBError()
+        flags = target.GetLaunchInfo().GetLaunchFlags()
         process = target.Launch(listener,
                                 None,      # argv
                                 None,      # envp
@@ -57,7 +58,7 @@ class EventAPITestCase(TestBase):
                                 None,      # stdout_path
                                 None,      # stderr_path
                                 None,      # working directory
-                                0,         # launch flags
+                                flags,     # launch flags
                                 False,     # Stop at entry
                                 error)     # error
 
@@ -145,6 +146,7 @@ class EventAPITestCase(TestBase):
 
         # Now launch the process, and do not stop at entry point.
         error = lldb.SBError()
+        flags = target.GetLaunchInfo().GetLaunchFlags()
         process = target.Launch(listener,
                                 None,      # argv
                                 None,      # envp
@@ -152,7 +154,7 @@ class EventAPITestCase(TestBase):
                                 None,      # stdout_path
                                 None,      # stderr_path
                                 None,      # working directory
-                                0,         # launch flags
+                                flags,     # launch flags
                                 False,     # Stop at entry
                                 error)     # error
         self.assertTrue(error.Success() and process, PROCESS_IS_VALID)
@@ -224,6 +226,7 @@ class EventAPITestCase(TestBase):
 
         # Now launch the process, and do not stop at the entry point.
         error = lldb.SBError()
+        flags = target.GetLaunchInfo().GetLaunchFlags()
         process = target.Launch(listener,
                                 None,      # argv
                                 None,      # envp
@@ -231,7 +234,7 @@ class EventAPITestCase(TestBase):
                                 None,      # stdout_path
                                 None,      # stderr_path
                                 None,      # working directory
-                                0,         # launch flags
+                                flags,     # launch flags
                                 False,     # Stop at entry
                                 error)     # error
 


### PR DESCRIPTION
Instead of clearing the launch flags, always pass the target's current
launch flags.

(cherry picked from commit 2ddba09e067add1910cc0f39ce9e1e4e0e43bb28)