### PR TITLE
[darwin][driver] fix isMacosxVersionLT minimum supported OS version c…

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.h
+++ b/clang/lib/Driver/ToolChains/Darwin.h
@@ -452,7 +452,11 @@ public:
   bool isMacosxVersionLT(unsigned V0, unsigned V1 = 0, unsigned V2 = 0) const {
     assert(isTargetMacOS() && getTriple().isMacOSX() &&
            "Unexpected call for non OS X target!");
-    VersionTuple MinVers = getTriple().getMinimumSupportedOSVersion();
+    // The effective triple might not be initialized yet, so construct a
+    // pseudo-effective triple to get the minimum supported OS version.
+    VersionTuple MinVers =
+        llvm::Triple(getTriple().getArchName(), "apple", "macos")
+            .getMinimumSupportedOSVersion();
     return (!MinVers.empty() && MinVers > TargetVersion
                 ? MinVers
                 : TargetVersion) < VersionTuple(V0, V1, V2);

--- a/clang/test/Driver/macos-apple-silicon-slice-link-libs-darwin-only.cpp
+++ b/clang/test/Driver/macos-apple-silicon-slice-link-libs-darwin-only.cpp
@@ -1,0 +1,6 @@
+// RUN: %clang -### -arch arm64 -mmacosx-version-min=10.7 %s 2>&1 | FileCheck -check-prefix=ARM64-10_7 %s
+// RUN: %clang -### -arch x86_64 -mmacosx-version-min=10.7 %s 2>&1 | FileCheck -check-prefix=x86_64-10_7 %s
+// REQUIRES: system-darwin
+
+// ARM64-10_7-NOT: -lcrt1.10.6.o
+// x86_64-10_7:    -lcrt1.10.6.o

--- a/clang/test/Driver/macos-apple-silicon-slice-link-libs.cpp
+++ b/clang/test/Driver/macos-apple-silicon-slice-link-libs.cpp
@@ -1,5 +1,6 @@
 // RUN: %clang -### -target arm64-apple-macos10.7 %s 2>&1 | FileCheck -check-prefix=ARM64-10_7 %s
 // RUN: %clang -### -target x86_64-apple-macos10.7 %s 2>&1 | FileCheck -check-prefix=x86_64-10_7 %s
+// RUN: %clang -### -target arm64-apple-darwin6 %s 2>&1 | FileCheck -check-prefix=ARM64-10_7 %s
 
 // RUN: %clang -### -target arm64-apple-macos10.5 %s 2>&1 | FileCheck -check-prefix=ARM64-10_5 %s
 // RUN: %clang -### -target x86_64-apple-macos10.5 %s 2>&1 | FileCheck -check-prefix=x86_64-10_5 %s


### PR DESCRIPTION
…heck

The previous Driver's triple check only worked for -target, but not for -arch -mmacosx-version-min invocations

(cherry picked from commit c2807b2e56c05080354818c221ed4a35abd8a5c8)