### PR TITLE
Increase the Entropy of ModuleManager Map Keys

### DIFF
--- a/clang/include/clang/Serialization/ModuleManager.h
+++ b/clang/include/clang/Serialization/ModuleManager.h
@@ -59,8 +59,50 @@ class ModuleManager {
   // to implement short-circuiting logic when running DFS over the dependencies.
   SmallVector<ModuleFile *, 2> Roots;
 
+  /// An \c EntryKey is a thin wrapper around a \c FileEntry that implements
+  /// a richer notion of identity.
+  ///
+  /// A plain \c FileEntry has its identity tied to inode numbers. When the
+  /// module cache regenerates a PCM, some filesystem allocators may reuse
+  /// inode numbers for distinct modules, which can cause the cache to return
+  /// mismatched entries. An \c EntryKey ensures that the size and modification
+  /// time are taken into account when determining the identity of a key, which
+  /// significantly decreases - but does not eliminate - the chance of
+  /// a collision.
+  struct EntryKey {
+    const FileEntry *Entry;
+
+    struct Info {
+      static inline EntryKey getEmptyKey() {
+        return EntryKey{llvm::DenseMapInfo<const FileEntry *>::getEmptyKey()};
+      }
+      static inline EntryKey getTombstoneKey() {
+        return EntryKey{
+            llvm::DenseMapInfo<const FileEntry *>::getTombstoneKey()};
+      }
+      static unsigned getHashValue(const EntryKey &Val) {
+        return llvm::DenseMapInfo<const FileEntry *>::getHashValue(Val.Entry);
+      }
+      static bool isEqual(const EntryKey &LHS, const EntryKey &RHS) {
+        if (LHS.Entry == getEmptyKey().Entry ||
+            LHS.Entry == getTombstoneKey().Entry ||
+            RHS.Entry == getEmptyKey().Entry ||
+            RHS.Entry == getTombstoneKey().Entry) {
+          return LHS.Entry == RHS.Entry;
+        }
+        if (LHS.Entry == nullptr || RHS.Entry == nullptr) {
+          return LHS.Entry == RHS.Entry;
+        }
+        return LHS.Entry == RHS.Entry &&
+               LHS.Entry->getSize() == RHS.Entry->getSize() &&
+               LHS.Entry->getModificationTime() ==
+                   RHS.Entry->getModificationTime();
+      }
+    };
+  };
+
   /// All loaded modules, indexed by name.
-  llvm::DenseMap<const FileEntry *, ModuleFile *> Modules;
+  llvm::DenseMap<EntryKey, ModuleFile *, EntryKey::Info> Modules;
 
   /// FileManager that handles translating between filenames and
   /// FileEntry *.
@@ -76,7 +118,7 @@ class ModuleManager {
   const HeaderSearch &HeaderSearchInfo;
 
   /// A lookup of in-memory (virtual file) buffers
-  llvm::DenseMap<const FileEntry *, std::unique_ptr<llvm::MemoryBuffer>>
+  llvm::DenseMap<EntryKey, std::unique_ptr<llvm::MemoryBuffer>, EntryKey::Info>
       InMemoryBuffers;
 
   /// The visitation order.


### PR DESCRIPTION
The ModuleManager's use of FileEntry nodes as the keys for its map of
loaded modules is less than ideal. Uniqueness for FileEntry nodes is
maintained by FileManager, which in turn uses inode numbers on hosts
that support that. When coupled with the module cache's proclivity for
turning over and deleting stale PCMs, this means entries for different
module files can wind up reusing the same underlying inode. When this
happens, subsequent accesses to the Modules map will disagree on the
ModuleFile associated with a given file.

It's fine to use the file management utilities to guarantee the presence
of module data, but we need a better source of key material that is
invariant with respect to these OS-level details. Using file paths alone
is a similarly frought solution because the ASTWriter performs a custom
canonicalization step (that is not equivalent to path canonicalization)
that renders keys from loaded AST cores useless for looking up cached
entries.

To mitigate the effects of inode reuse, increase the entropy of the key
material by incorporating the modtime and size. This ultimately
decreases the likelihood that a PCM that is swapped on disk will confuse
the cache, but it does not eliminate the possibility of collisions.

rdar://48443680