### PR TITLE
Update .gitignore for clangd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ autoconf/autom4te.cache
 .vs
 # clangd index
 .clangd
+.cache


### PR DESCRIPTION
The clangd cache is now stored in a `.cache` directory ([D78501](https://reviews.llvm.org/D78501)).

I've already updated this for `apple/master` in https://github.com/apple/swift/pull/32944.