### PR TITLE
[lldb] Remove stride parameter from SwiftASTContext::GetArrayElementType

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5612,7 +5612,6 @@ lldb::TypeClass SwiftASTContext::GetTypeClass(opaque_compiler_type_t type) {
 
 CompilerType
 SwiftASTContext::GetArrayElementType(opaque_compiler_type_t type,
-                                     uint64_t *stride,
                                      ExecutionContextScope *exe_scope) {
   VALID_OR_RETURN(CompilerType());
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -535,7 +535,6 @@ public:
   // Creating related types
 
   CompilerType GetArrayElementType(lldb::opaque_compiler_type_t type,
-                                   uint64_t *stride,
                                    ExecutionContextScope *exe_scope) override;
 
   CompilerType GetCanonicalType(lldb::opaque_compiler_type_t type) override;


### PR DESCRIPTION
'stride' was removed upstream in D84299 .