### PR TITLE
Enables Linux tests with old rdars

### DIFF
--- a/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
+++ b/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
@@ -29,7 +29,6 @@ class TestSwiftGenericExpressions(lldbtest.TestBase):
         self.main_source = "main.swift"
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
-    @skipIfLinux # <rdar://problem/30783388> test crashing sometimes when run on linux
     @swiftTest
     def test_generic_expressions(self):
         """Test expressions in generic contexts"""

--- a/lldb/test/API/lang/swift/generic_extension/TestSwiftGenericExtension.py
+++ b/lldb/test/API/lang/swift/generic_extension/TestSwiftGenericExtension.py
@@ -13,5 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipIfLinux  # <rdar://problem/30899355> 
+                          decorators=[swiftTest
     ])

--- a/lldb/test/API/lang/swift/partially_generic_func/class/TestSwiftPartiallyGenericFuncClass.py
+++ b/lldb/test/API/lang/swift/partially_generic_func/class/TestSwiftPartiallyGenericFuncClass.py
@@ -13,6 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(), decorators=[
-    swiftTest,
-    skipIfLinux  # <rdar://problem/30952527>
+    swiftTest
     ])

--- a/lldb/test/API/lang/swift/return/TestSwiftReturns.py
+++ b/lldb/test/API/lang/swift/return/TestSwiftReturns.py
@@ -27,7 +27,6 @@ class TestSwiftReturns(TestBase):
 
     @swiftTest
     @skipIfDarwin # rdar://problem/48924409
-    @skipIfLinux  # bugs.swift.org/SR-841
     @expectedFailureAll(
         oslist=["ios"],
         archs=["arm64"],
@@ -40,7 +39,6 @@ class TestSwiftReturns(TestBase):
         self.do_test()
 
     @swiftTest
-    @skipIfLinux  # bugs.swift.org/SR-841
     @expectedFailureAll(
         oslist=["ios"],
         archs=["arm64"],

--- a/lldb/test/API/lang/swift/type_metadata/TestSwiftTypeMetadata.py
+++ b/lldb/test/API/lang/swift/type_metadata/TestSwiftTypeMetadata.py
@@ -24,7 +24,6 @@ class SwiftTypeMetadataTest(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @skipIfLinux # <rdar://problem/30783388> test crashing sometimes when run on linux
     def test_swift_type_metadata(self):
         """Test that LLDB can effectively use the type metadata to reconstruct dynamic types for Swift"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/array/TestSwiftArrayType.py
+++ b/lldb/test/API/lang/swift/variables/array/TestSwiftArrayType.py
@@ -30,7 +30,6 @@ class TestSwiftArrayType(lldbtest.TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @swiftTest
-    @skipIf(bugnumber='rdar://30663811', oslist=['linux'])
     def test_array(self):
         """Check formatting for Swift.Array<T>"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
+++ b/lldb/test/API/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
@@ -25,14 +25,12 @@ class TestIndirectEnumVariables(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @skipIf(bugnumber='rdar://27568868', oslist=['linux'])
     def test_indirect_cases_variables(self):
         """Tests that indirect Enum variables display correctly when cases are indirect"""
         self.build()
         self.do_test("indirect case break here")
 
     @swiftTest
-    @skipIf(bugnumber='rdar://27568868', oslist=['linux'])
     def test_indirect_enum_variables(self):
         """Tests that indirect Enum variables display correctly when enum is indirect"""
         self.build()


### PR DESCRIPTION
This PR enables linux tests with rdars which are disabled but passing.

@adrian-prantl @vedantk 