### PR TITLE
[lldb] Remove XFAIL from now passing TestPtrRefs/TestPtreRefsObjC

### DIFF
--- a/lldb/test/API/functionalities/ptr_refs/TestPtrRefs.py
+++ b/lldb/test/API/functionalities/ptr_refs/TestPtrRefs.py
@@ -15,7 +15,6 @@ class TestPtrRefs(TestBase):
 
     @skipIfAsan # The output looks different under ASAN.
     @skipUnlessDarwin
-    @expectedFailureAll(oslist=["macosx"], debug_info=["dwarf", "gmodules"], bugnumber="llvm.org/pr45112")
     def test_ptr_refs(self):
         """Test format string functionality."""
         self.build()

--- a/lldb/test/API/lang/objc/ptr_refs/TestPtrRefsObjC.py
+++ b/lldb/test/API/lang/objc/ptr_refs/TestPtrRefsObjC.py
@@ -15,7 +15,6 @@ class TestPtrRefsObjC(TestBase):
 
     @skipIfAsan # The output looks different under ASAN.
     @skipUnlessDarwin
-    @expectedFailureAll(oslist=["macosx"], debug_info=["dwarf", "gmodules"], bugnumber="llvm.org/pr45112")
     def test_ptr_refs(self):
         """Test the ptr_refs tool on Darwin with Objective-C"""
         self.build()


### PR DESCRIPTION
8fcfe2862fd4fde4793e232cfeebe6c5540c80a5 and
0cceb54366b406649fdfe7bb11b133ab96f3cd70 fixed those tests.

(cherry picked from commit 7208cb1ac43e4be806bcb91c622fc1f8641e010b)