### PR TITLE
Swift: Fix the Windows build

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
@@ -313,7 +313,7 @@ bool SwiftUnsafePointer::Update() {
     LLDB_LOG(GetLogIfAllCategoriesSet(LIBLLDB_LOG_DATAFORMATTERS),
              "{0}: Couldn't get {1} type system.", __FUNCTION__,
              type.GetTypeName());
-    return nullptr;
+    return false;
   }
 
   CompilerType argument_type =


### PR DESCRIPTION
The implicit conversion from `nullptr_t` to `bool` is not permitted on Windows.

```
lldb\source\Plugins\Language\Swift\SwiftUnsafeTypes.cpp(316,12): error: cannot initialize return object of type 'bool' with an rvalue of type 'nullptr_t'
    return nullptr;
           ^~~~~~~
```

Explicit return a `false` instead.

(cherry picked from commit a13459550e48f25328760f4ed9cd0fe28fbf9bb2)