### PR TITLE
[lldb] Fix a broken path for swig bindings

### DIFF
--- a/lldb/bindings/prepare_bindings.py
+++ b/lldb/bindings/prepare_bindings.py
@@ -270,7 +270,7 @@ def main(args):
 
     # Check if the swig file exists.
     swig_path = os.path.normcase(
-        os.path.join(options.src_root, "bindings", "python.swig"))
+        os.path.join(options.src_root, "bindings", "python", "python.swig"))
     if not os.path.isfile(swig_path):
         logging.error("swig file not found at '%s'", swig_path)
         sys.exit(-3)


### PR DESCRIPTION
Evidently python.swig was moved from x/python.swig to
x/python/python.swig and this usage was not accounted for in the commit.
Fix it here.