### PR TITLE
Target: explicitly convert `StringRef` to `std::string`

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -333,12 +333,12 @@ static bool HasReflectionInfo(ObjectFile *obj_file) {
       swift::ReflectionSectionKind::reflstr);
 
   bool hasReflectionSection = false;
-  hasReflectionSection |= findSectionInObject(field_md);
-  hasReflectionSection |= findSectionInObject(assocty);
-  hasReflectionSection |= findSectionInObject(builtin);
-  hasReflectionSection |= findSectionInObject(capture);
-  hasReflectionSection |= findSectionInObject(typeref);
-  hasReflectionSection |= findSectionInObject(reflstr);
+  hasReflectionSection |= findSectionInObject(field_md.str());
+  hasReflectionSection |= findSectionInObject(assocty.str());
+  hasReflectionSection |= findSectionInObject(builtin.str());
+  hasReflectionSection |= findSectionInObject(capture.str());
+  hasReflectionSection |= findSectionInObject(typeref.str());
+  hasReflectionSection |= findSectionInObject(reflstr.str());
   return hasReflectionSection;
 }
 


### PR DESCRIPTION
This has changed in upstream LLVM and `StringRef` is no longer
implicitly convertible to `std::string`.  Adjust the invocation to allow
the rebranched lldb to build.

(cherry picked from commit 54722a7aa9511a4c582fe51103cfde3f6780ba92)