### PR TITLE
Convert std::string to StringRef

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -310,7 +310,7 @@ public:
 };
 
 static bool HasReflectionInfo(ObjectFile *obj_file) {
-  auto findSectionInObject = [&](std::string name) {
+  auto findSectionInObject = [&](StringRef name) {
     ConstString section_name(name);
     SectionSP section_sp =
         obj_file->GetSectionList()->FindSectionByName(section_name);


### PR DESCRIPTION
The implicit conversion operator from StringRef to std::string has been
deleted upstream, so this addresses the build breakage.