### PR TITLE
[lldb] Fix compile error due implicit StringRef -> std::string conver…

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -1273,7 +1273,7 @@ OptionalClangModuleID TypeSystemClang::GetOrCreateClangModule(
   if (!created)
     return ast_source->GetIDForModule(module);
 
-  module->APINotesFile = apinotes;
+  module->APINotesFile = std::string(apinotes);
   return ast_source->RegisterModule(module);
 }
 


### PR DESCRIPTION
…sion

This was failing with:
```
lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:1276:24: error: no viable overloaded '='
  module->APINotesFile = apinotes;
  ~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~
include/c++/v1/string:877:19: note: candidate function not viable: no known conversion from 'llvm::StringRef' to 'const std::__1::basic_string<char>' for 1st argument
    basic_string& operator=(const basic_string& __str);
                  ^
```

(cherry picked from commit 5206ce51aa2491020db27106048ecf352305d775)

cherry-picking this into apple/master as d4a9e87c30b0575b4f5f838e241c3e491b66eb6a did cherry-pick the breaking change here too.