### PR TITLE
[lldb/interpreter] Add Swift REPL init file support

### DIFF
--- a/lldb/docs/man/lldb.rst
+++ b/lldb/docs/man/lldb.rst
@@ -306,11 +306,15 @@ CONFIGURATION FILES
 :program:`lldb` reads things like settings, aliases and commands from the
 .lldbinit file.
 
-First, it will read the application specific init file whose name is
-~/.lldbinit followed by a "-" and the name of the current program. This would
-be ~/.lldbinit-lldb for the command line :program:`lldb` and ~/.lldbinit-Xcode
-for Xcode. If there is no application specific init file, the global
-~/.lldbinit is read.
+First, :program:`lldb` will try to read the application specific init file
+whose name is ~/.lldbinit followed by a "-" and the name of the current
+program. This would be ~/.lldbinit-lldb for the command line :program:`lldb`
+and ~/.lldbinit-Xcode for Xcode. If there is no application specific init
+file, :program:`lldb` will look for an init file in the home directory.
+If launched with a `REPL`_ option, it will first look for a REPL configuration
+file, specific to the REPL language. If this file doesn't exist, or :program:`lldb`
+wasn't launch with `REPL`_, meaning there is neither a REPL init file nor an
+application specific init file, `lldb` will fallback to the global ~/.lldbinit.
 
 Secondly, it will look for an .lldbinit file in the current working directory.
 For security reasons, :program:`lldb` will print a warning and not source this

--- a/lldb/include/lldb/API/SBCommandInterpreter.h
+++ b/lldb/include/lldb/API/SBCommandInterpreter.h
@@ -146,6 +146,8 @@ public:
                              const char *auto_repeat_command);
 
   void SourceInitFileInHomeDirectory(lldb::SBCommandReturnObject &result);
+  void SourceInitFileInHomeDirectory(lldb::SBCommandReturnObject &result,
+                                     bool is_repl);
 
   void
   SourceInitFileInCurrentWorkingDirectory(lldb::SBCommandReturnObject &result);

--- a/lldb/include/lldb/Interpreter/CommandInterpreter.h
+++ b/lldb/include/lldb/Interpreter/CommandInterpreter.h
@@ -256,7 +256,7 @@ public:
   }
 
   void SourceInitFileCwd(CommandReturnObject &result);
-  void SourceInitFileHome(CommandReturnObject &result);
+  void SourceInitFileHome(CommandReturnObject &result, bool is_repl = false);
 
   bool AddCommand(llvm::StringRef name, const lldb::CommandObjectSP &cmd_sp,
                   bool can_replace);

--- a/lldb/source/API/SBCommandInterpreter.cpp
+++ b/lldb/source/API/SBCommandInterpreter.cpp
@@ -478,6 +478,24 @@ void SBCommandInterpreter::SourceInitFileInHomeDirectory(
   }
 }
 
+void SBCommandInterpreter::SourceInitFileInHomeDirectory(
+    SBCommandReturnObject &result, bool is_repl) {
+  LLDB_RECORD_METHOD(void, SBCommandInterpreter, SourceInitFileInHomeDirectory,
+                     (lldb::SBCommandReturnObject &, bool), result, is_repl);
+
+  result.Clear();
+  if (IsValid()) {
+    TargetSP target_sp(m_opaque_ptr->GetDebugger().GetSelectedTarget());
+    std::unique_lock<std::recursive_mutex> lock;
+    if (target_sp)
+      lock = std::unique_lock<std::recursive_mutex>(target_sp->GetAPIMutex());
+    m_opaque_ptr->SourceInitFileHome(result.ref(), is_repl);
+  } else {
+    result->AppendError("SBCommandInterpreter is not valid");
+    result->SetStatus(eReturnStatusFailed);
+  }
+}
+
 void SBCommandInterpreter::SourceInitFileInCurrentWorkingDirectory(
     SBCommandReturnObject &result) {
   LLDB_RECORD_METHOD(void, SBCommandInterpreter,
@@ -806,6 +824,9 @@ template <> void RegisterMethods<SBCommandInterpreter>(Registry &R) {
   LLDB_REGISTER_METHOD(void, SBCommandInterpreter,
                        SourceInitFileInHomeDirectory,
                        (lldb::SBCommandReturnObject &));
+  LLDB_REGISTER_METHOD(void, SBCommandInterpreter,
+                       SourceInitFileInHomeDirectory,
+                       (lldb::SBCommandReturnObject &, bool));
   LLDB_REGISTER_METHOD(void, SBCommandInterpreter,
                        SourceInitFileInCurrentWorkingDirectory,
                        (lldb::SBCommandReturnObject &));

--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -220,7 +220,7 @@ SBDebugger SBDebugger::Create(bool source_init_files,
     interp.get()->SkipLLDBInitFiles(false);
     interp.get()->SkipAppInitFiles(false);
     SBCommandReturnObject result;
-    interp.SourceInitFileInHomeDirectory(result);
+    interp.SourceInitFileInHomeDirectory(result, false);
   } else {
     interp.get()->SkipLLDBInitFiles(true);
     interp.get()->SkipAppInitFiles(true);

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -2093,6 +2093,22 @@ static void GetHomeInitFile(llvm::SmallVectorImpl<char> &init_file,
   FileSystem::Instance().Resolve(init_file);
 }
 
+static void GetHomeREPLInitFile(llvm::SmallVectorImpl<char> &init_file,
+                                LanguageType language) {
+  std::string init_file_name;
+
+  switch (language) {
+  // TODO: Add support for a language used with a REPL.
+  default:
+    return;
+  }
+
+  llvm::sys::path::home_directory(init_file);
+  llvm::sys::path::append(init_file, init_file_name);
+
+  FileSystem::Instance().Resolve(init_file);
+}
+
 static void GetCwdInitFile(llvm::SmallVectorImpl<char> &init_file) {
   llvm::StringRef s = ".lldbinit";
   init_file.assign(s.begin(), s.end());
@@ -2167,15 +2183,27 @@ void CommandInterpreter::SourceInitFileCwd(CommandReturnObject &result) {
 
 /// We will first see if there is an application specific ".lldbinit" file
 /// whose name is "~/.lldbinit" followed by a "-" and the name of the program.
-/// If this file doesn't exist, we fall back to just the "~/.lldbinit" file.
-void CommandInterpreter::SourceInitFileHome(CommandReturnObject &result) {
+/// If this file doesn't exist, we fall back to the REPL init file or the
+/// default home init file in "~/.lldbinit".
+void CommandInterpreter::SourceInitFileHome(CommandReturnObject &result,
+                                            bool is_repl) {
   if (m_skip_lldbinit_files) {
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
     return;
   }
 
   llvm::SmallString<128> init_file;
-  GetHomeInitFile(init_file);
+
+  if (is_repl) {
+    LanguageType language = {};
+    TargetSP target_sp = GetDebugger().GetSelectedTarget();
+    if (target_sp)
+      language = target_sp->GetLanguage();
+    GetHomeREPLInitFile(init_file, language);
+  }
+
+  if (init_file.empty())
+    GetHomeInitFile(init_file);
 
   if (!m_skip_app_init_files) {
     llvm::StringRef program_name =

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -67,6 +67,7 @@
 #include "lldb/Interpreter/Property.h"
 #include "lldb/Utility/Args.h"
 
+#include "lldb/Target/Language.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/StopInfo.h"
 #include "lldb/Target/TargetList.h"
@@ -2098,7 +2099,9 @@ static void GetHomeREPLInitFile(llvm::SmallVectorImpl<char> &init_file,
   std::string init_file_name;
 
   switch (language) {
-  // TODO: Add support for a language used with a REPL.
+  case eLanguageTypeSwift:
+    init_file_name = ".lldbinit-swift-repl";
+    break;
   default:
     return;
   }
@@ -2195,7 +2198,7 @@ void CommandInterpreter::SourceInitFileHome(CommandReturnObject &result,
   llvm::SmallString<128> init_file;
 
   if (is_repl) {
-    LanguageType language = {};
+    LanguageType language = eLanguageTypeSwift;
     TargetSP target_sp = GetDebugger().GetSelectedTarget();
     if (target_sp)
       language = target_sp->GetLanguage();

--- a/lldb/test/Shell/SwiftREPL/InitFile.test
+++ b/lldb/test/Shell/SwiftREPL/InitFile.test
@@ -1,0 +1,15 @@
+// Test that the Swift REPL init file works.
+// REQUIRES: system-darwin
+
+// RUN: if [ -f ~/.lldbinit ]; then mv ~/.lldbinit ~/.lldbinit.old; fi
+// RUN: echo 'br set -f main.c -l 123' > ~/.lldbinit
+// RUN: echo 'br set -f swift-repl.c -l 456' > ~/.lldbinit-swift-repl
+// RUN: %lldb-init --repl < %s 2>&1 | FileCheck %s
+
+:br list
+// CHECK: Current breakpoints
+// CHECK-NEXT: file = 'swift-repl.c', line = 456, exact_match = 0, locations = 0 (pending)
+
+
+// RUN: rm ~/.lldbinit-swift-repl
+// RUN: if [ -f ~/.lldbinit.old ]; then mv ~/.lldbinit.old ~/.lldbinit; fi

--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -493,7 +493,7 @@ int Driver::MainLoop() {
   // Before we handle any options from the command line, we parse the
   // .lldbinit file in the user's home directory.
   SBCommandReturnObject result;
-  sb_interpreter.SourceInitFileInHomeDirectory(result);
+  sb_interpreter.SourceInitFileInHomeDirectory(result, m_option_data.m_repl);
   if (m_option_data.m_debug_mode) {
     result.PutError(m_debugger.GetErrorFile());
     result.PutOutput(m_debugger.GetOutputFile());

--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -491,7 +491,7 @@ int Driver::MainLoop() {
   SBCommandInterpreter sb_interpreter = m_debugger.GetCommandInterpreter();
 
   // Before we handle any options from the command line, we parse the
-  // .lldbinit file in the user's home directory.
+  // REPL init file or the default file in the user's home directory.
   SBCommandReturnObject result;
   sb_interpreter.SourceInitFileInHomeDirectory(result, m_option_data.m_repl);
   if (m_option_data.m_debug_mode) {


### PR DESCRIPTION
Some users complained that when using the Swift REPL (LLDB launched with
`--repl` option), it would try to read their home init file, which can cause
unintended behaviour.

To solve this issue, this patch introduces a new, more specific, Swift
REPL init file, conveniently name `.lldbinit-swift-repl`. If the user
creates this file in his home directory, and launches LLDB in REPL mode,
it will override the default init file.

This behaviour only applies when REPL mode is enabled.

rdar://65836048

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>