### PR TITLE
[lldb] Store the Apple SDK in dotest's configuration.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -117,6 +117,9 @@ lldb_platform_name = None
 lldb_platform_url = None
 lldb_platform_working_dir = None
 
+# Apple SDK
+apple_sdk = None
+
 # The base directory in which the tests are being built.
 test_build_dir = None
 

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -428,6 +428,8 @@ def parseOptionsAndInitTestdirs():
         configuration.lldb_platform_url = args.lldb_platform_url
     if args.lldb_platform_working_dir:
         configuration.lldb_platform_working_dir = args.lldb_platform_working_dir
+    if args.apple_sdk:
+        configuration.apple_sdk = args.apple_sdk
     if args.test_build_dir:
         configuration.test_build_dir = args.test_build_dir
     if args.lldb_module_cache_dir:

--- a/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
@@ -129,17 +129,28 @@ def getDarwinOSTriples():
 
 def getPlatform():
     """Returns the target platform which the tests are running on."""
-    triple = lldb.selected_platform.GetTriple()
-    if triple is None:
-      # It might be an unconnected remote platform.
-      return ''
+    # Use the Apple SDK to determine the platform if set.
+    if configuration.apple_sdk:
+        platform = configuration.apple_sdk
+        dot = platform.find('.')
+        if dot != -1:
+            platform = platform[:dot]
+        if platform == 'iphoneos':
+            platform = 'ios'
+        return platform
 
-    platform = triple.split('-')[2]
-    if platform.startswith('freebsd'):
-        platform = 'freebsd'
-    elif platform.startswith('netbsd'):
-        platform = 'netbsd'
-    return platform
+    # Use the triple to determine the platform if set.
+    triple = lldb.selected_platform.GetTriple()
+    if triple:
+        platform = triple.split('-')[2]
+        if platform.startswith('freebsd'):
+            platform = 'freebsd'
+        elif platform.startswith('netbsd'):
+            platform = 'netbsd'
+        return platform
+
+    # It still might be an unconnected remote platform.
+    return ''
 
 
 def platformIsDarwin():


### PR DESCRIPTION
This didn't made it into the PR https://github.com/apple/llvm-project/pull/1686 (but that PR added code that depends on this the apple_sdk introduced here).

This patch stores the --apple-sdk argument in the dotest configuration.
When it's set, use it instead of the triple to determine the current
platform.

Differential revision: https://reviews.llvm.org/D85537

(cherry picked from commit f1d525734f86ac4b1a7bf80f3a82291864026de0)