### PR TITLE
[lldb] Make packetlog_get_dylib_info returns the last full response

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -1439,7 +1439,8 @@ def packetlog_get_process_info(log):
     return process_info
 
 def packetlog_get_dylib_info(log):
-    """parse a gdb-remote packet log file and extract the *last* response to jGetLoadedDynamicLibrariesInfos"""
+    """parse a gdb-remote packet log file and extract the *last* complete
+    (=> fetch_all_solibs=true) response to jGetLoadedDynamicLibrariesInfos"""
     import json
     dylib_info = None
     with open(log, "r") as logfile:
@@ -1453,7 +1454,7 @@ def packetlog_get_dylib_info(log):
                 # Unescape '}'.
                 dylib_info = json.loads(line.replace('}]','}')[:-4])
                 expect_dylib_info_response = False
-            if 'send packet: $jGetLoadedDynamicLibrariesInfos:{' in line:
+            if 'send packet: $jGetLoadedDynamicLibrariesInfos:{"fetch_all_solibs":true}' in line:
                 expect_dylib_info_response = True
 
     return dylib_info


### PR DESCRIPTION
Backporting this as the MacCatalyst is also failing on the branch here.

Original summary: 
In sanitized builds the last packet this function finds for the
TestMacCatalyst and TestPlatformSimulator tests is for the asan runtime.

```
 <  69> send packet: $jGetLoadedDynamicLibrariesInfos:{"solib_addresses":[4296048640]}]#3a <
 715> read packet: ${"images":[{"load_address":4296048640,"mod_date":0,"pathname":
 "/Users/buildslave/jenkins/workspace/lldb-cmake-sanitized/host-compiler/lib/clang/12.0.0/lib/darwin/libclang_rt.asan_osx_dynamic.dylib",
 "uuid":"8E38A2CD-753F-3E0F-8EB0-F4BD5788A5CA",
 "min_version_os_name":"macosx","min_version_os_sdk":"10.9",
 "mach_header":{"magic":4277009103,"cputype":16777223,"cpusubtype":3,"filetype":6,
 "flags":43090053}],"segments":[{"name":"__TEXT","vmaddr":0,"vmsize":565248,"fileoff":0,
 "filesize":565248,"maxprot":5}],{"name":"__DATA","vmaddr":565248,"vmsize":13152256,"fileoff":565248,
 "filesize":20480,"maxprot":3}],{"name":"__LINKEDIT","vmaddr":13717504,"vmsize":438272,"fileoff":585728,
 "filesize":435008,"maxprot":1}]]}]]}]#00
```

This just fetches the last package which has fetch_all_solibs and we know
it will contain the image of our test executable to get the tests running again.

(cherry picked from commit 46ed27ff1b1cd74742511d73a4a43afa97455fe2)