### PR TITLE
[Constants] Handle FNeg in getWithOperands.

### DIFF
--- a/clang/test/CodeGen/constantexpr-fneg.c
+++ b/clang/test/CodeGen/constantexpr-fneg.c
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -emit-llvm-bc -disable-llvm-passes -o %t.bc %s
+// RUN: llvm-dis %t.bc -o - | FileCheck %s
+
+// Test case for PR45426. Make sure we do not crash while writing bitcode
+// containing a simplify-able fneg constant expression. Check that the created
+// bitcode file can be disassembled and has the constant expressions simplified.
+//
+// CHECK-LABEL define i32 @main()
+// CHECK:      entry:
+// CHECK-NEXT:   %retval = alloca i32
+// CHECK-NEXT:   store i32 0, i32* %retval
+// CHECK-NEXT:   [[LV:%.*]] = load float*, float** @c
+// CHECK-NEXT:   store float 1.000000e+00, float* [[LV]], align 4
+// CHECK-NEXT:   ret i32 -1
+
+int a[], b;
+float *c;
+int main() {
+  return -(*c = &b != a);
+}

--- a/llvm/lib/IR/Constants.cpp
+++ b/llvm/lib/IR/Constants.cpp
@@ -1316,6 +1316,8 @@ Constant *ConstantExpr::getWithOperands(ArrayRef<Constant *> Ops, Type *Ty,
                                         OnlyIfReducedTy);
   case Instruction::ExtractValue:
     return ConstantExpr::getExtractValue(Ops[0], getIndices(), OnlyIfReducedTy);
+  case Instruction::FNeg:
+    return ConstantExpr::getFNeg(Ops[0]);
   case Instruction::ShuffleVector:
     return ConstantExpr::getShuffleVector(Ops[0], Ops[1], Ops[2],
                                           OnlyIfReducedTy);


### PR DESCRIPTION
Currently ConstantExpr::getWithOperands does not handle FNeg and
subsequently treats FNeg as binary operator, leading to an assertion
failure or segmentation fault if built without assertions.

Originally I reproduced this with llvm-dis on a bitcode file, which I
unfortunately cannot share and also cannot really reduce.

But PR45426 describes the same issue and has a reproducer with Clang, so
I'll go with that.

Reviewed By: aprantl

Differential Revision: https://reviews.llvm.org/D86274

(Cherry-picked from bc72a3ab949e14b990c080985fc1e74475f1e7d2)