### PR TITLE
[lldb] Only check for --apple-sdk argument on Darwin

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -428,7 +428,7 @@ def parseOptionsAndInitTestdirs():
         configuration.lldb_platform_url = args.lldb_platform_url
     if args.lldb_platform_working_dir:
         configuration.lldb_platform_working_dir = args.lldb_platform_working_dir
-    if args.apple_sdk:
+    if platform_system == 'Darwin'  and args.apple_sdk:
         configuration.apple_sdk = args.apple_sdk
     if args.test_build_dir:
         configuration.test_build_dir = args.test_build_dir


### PR DESCRIPTION
This was missing on the stable branch and breaks all API tests on Linux