### PR TITLE
[lldb] Fix build after bb894b97821a

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -118,6 +118,7 @@
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/LLDBAssert.h"
 #include "lldb/Utility/Log.h"
+#include "lldb/Utility/ReproducerProvider.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/XcodeSDK.h"
 #include "llvm/ADT/ScopeExit.h"


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/bb894b97821a creates a new
ReproducerProvider.h header; include it to provide the needed types.