### PR TITLE
[lldb] Return empty string from getExtraMakeArgs when not implemented

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -25,6 +25,7 @@ class Builder:
         Helper function to return extra argumentsfor the make system. This
         method is meant to be overridden by platform specific builders.
         """
+        return ""
 
     def getArchCFlags(self, architecture):
         """Returns the ARCH_CFLAGS for the make system."""


### PR DESCRIPTION
No return statement means the method returns None which breaks a list
comprehension down the line that expects a str instance.

(cherry picked from commit a6eb70c052da767aef6b041d0db20bdf3a9e06b5)