### PR TITLE
Fix GetTypeInfo for changes to decodeMangledType in Swift.

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1729,7 +1729,7 @@ SwiftLanguageRuntimeImpl::GetTypeInfo(CompilerType type) {
   swift::Demangle::Demangler Dem;
   auto demangled = Dem.demangleType(mangled_no_prefix);
   auto *type_ref = swift::Demangle::decodeMangledType(
-      reflection_ctx->getBuilder(), demangled);
+      reflection_ctx->getBuilder(), demangled).getType();
   if (!type_ref)
     return nullptr;
   return reflection_ctx->getBuilder().getTypeConverter().getTypeInfo(type_ref);


### PR DESCRIPTION
Small fix to go along with https://github.com/apple/swift/pull/33585 in Swift.