### PR TITLE
[lldb] Move Xcode SDK helper functions into lldbutil

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -4,27 +4,10 @@ import subprocess
 
 from .builder import Builder
 from lldbsuite.test import configuration
+import lldbsuite.test.lldbutil as lldbutil
 
 REMOTE_PLATFORM_NAME_RE = re.compile(r"^remote-(.+)$")
 SIMULATOR_PLATFORM_RE = re.compile(r"^(.+)-simulator$")
-
-
-def get_sdk(os, env):
-    if os == "ios":
-        if env == "simulator":
-            return "iphonesimulator"
-        if env == "macabi":
-            return "macosx"
-        return "iphoneos"
-    elif os == "tvos":
-        if env == "simulator":
-            return "appletvsimulator"
-        return "appletvos"
-    elif os == "watchos":
-        if env == "simulator":
-            return "watchsimulator"
-        return "watchos"
-    return os
 
 
 def get_os_env_from_platform(platform):
@@ -92,13 +75,11 @@ class BuilderDarwin(Builder):
             return ""
 
         # Get the SDK from the os and env.
-        sdk = get_sdk(os, env)
+        sdk = lldbutil.get_xcode_sdk(os, env)
         if not sdk:
             return ""
 
-        version = subprocess.check_output(
-            ["xcrun", "--sdk", sdk,
-             "--show-sdk-version"]).rstrip().decode('utf-8')
+        version = lldbutil.get_xcode_sdk_version(sdk)
         if not version:
             return ""
 

--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -12,6 +12,7 @@ import errno
 import os
 import re
 import sys
+import subprocess
 
 # Third-party modules
 from six import StringIO as SixStringIO
@@ -52,6 +53,40 @@ def mkdir_p(path):
             raise
     if not os.path.isdir(path):
         raise OSError(errno.ENOTDIR, "%s is not a directory"%path)
+
+
+# ============================
+# Dealing with SDK and triples
+# ============================
+
+def get_xcode_sdk(os, env):
+    if os == "ios":
+        if env == "simulator":
+            return "iphonesimulator"
+        if env == "macabi":
+            return "macosx"
+        return "iphoneos"
+    elif os == "tvos":
+        if env == "simulator":
+            return "appletvsimulator"
+        return "appletvos"
+    elif os == "watchos":
+        if env == "simulator":
+            return "watchsimulator"
+        return "watchos"
+    return os
+
+
+def get_xcode_sdk_version(sdk):
+    return subprocess.check_output(
+        ['xcrun', '--sdk', sdk, '--show-sdk-version']).rstrip().decode('utf-8')
+
+
+def get_xcode_sdk_root(sdk):
+    return subprocess.check_output(['xcrun', '--sdk', sdk, '--show-sdk-path'
+                                    ]).rstrip().decode('utf-8')
+
+
 # ===================================================
 # Disassembly for an SBFunction or an SBSymbol object
 # ===================================================

--- a/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
+++ b/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
@@ -43,8 +43,7 @@ class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
         # Launch the process using simctl
         self.assertIsNotNone(deviceUDID)
         exe_name = 'test_simulator_platform_{}'.format(platform)
-        sdkroot = subprocess.check_output(['xcrun', '--show-sdk-path', '--sdk',
-                                           sdk]).decode("utf-8")
+        sdkroot = lldbutil.get_xcode_sdk_root(sdk)
         self.build(dictionary={ 'EXE': exe_name, 'SDKROOT': sdkroot.strip(),
                                 'ARCH': arch })
         exe_path = self.getBuildArtifact(exe_name)


### PR DESCRIPTION
This allows the logic to be reused by both the builders and the tests.

(cherry picked from commit a3fc61c80f89ea709a1128caa2de2723fe307c81)