### PR TITLE
[Sanitizer] Fix demangling for Swift symbol names

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp
@@ -78,13 +78,6 @@ static void InitializeSwiftDemangler() {
 // Attempts to demangle a Swift name. The demangler will return nullptr if a
 // non-Swift name is passed in.
 const char *DemangleSwift(const char *name) {
-  if (!name) return nullptr;
-
-  // Check if we are dealing with a Swift mangled name first.
-  if (name[0] != '_' || name[1] != 'T') {
-    return nullptr;
-  }
-
   if (swift_demangle_f)
     return swift_demangle_f(name, internal_strlen(name), 0, 0, 0);
 


### PR DESCRIPTION
The Swift symbol name prefix has changed from `_T0` to `_$s` as
documented here [1].  This prevents Swift names from properly being
symbolicated when using the in-process LLVM symbolizer.  The best way to
fix this seems to be to avoid the duplication of "Is this a Swift symbol
name?" here.  We can simply remove this check as `swift_demangle`
already returns null for non-Swift names [2,3].

The check was included in the initial support for Swift name demangling
to avoid superfluous calls to `dlsym()` [4].  A subsequent commit
changed this logic to retrieve the `swift_demangle` function pointer
eagerly during sanitizer initialization, but did not remove the check
[5].

[1] https://github.com/apple/swift/blob/master/docs/ABI/Mangling.rst
[2] https://github.com/apple/swift/blob/b5a8b518eae54cea997f3b0954760fc7858829f6/include/swift/Demangling/Demangle.h#L643
[3] https://github.com/apple/swift/blob/b5a8b518eae54cea997f3b0954760fc7858829f6/stdlib/public/runtime/Demangle.cpp#L656
[4] https://reviews.llvm.org/D19135
[5] https://reviews.llvm.org/D20015

rdar://62753845

Reviewed By: kubamracek

Differential Revision: https://reviews.llvm.org/D81705

(cherry picked from commit 71a6a41f1c55c43c07942e49ef8ecdabd95f8b61)