### PR TITLE
Support: add workaround for newer MSVC toolchains

### DIFF
--- a/llvm/include/llvm/Support/type_traits.h
+++ b/llvm/include/llvm/Support/type_traits.h
@@ -186,6 +186,13 @@ template <typename T>
 class is_trivially_copyable<T*> : public std::true_type {
 };
 
+// Workaround the resolution to DR1734
+#if _MSVC_STL_UPDATE-0l > 202002l
+template <>
+class is_trivially_copyable<std::pair<void *, size_t>> : public std::true_type {
+};
+#endif
+
 
 } // end namespace llvm
 


### PR DESCRIPTION
The MSVC toolchain implemented a resolution to DR1734, which results in
`llvm::is_trivially_copyable` to not match with
`std::is_trivially_copyable`.  This is the minimal change that will
match the ABI and allow building LLVM with a newer MSVC toolchain.