### PR TITLE
[lldb] Fix "no matching std::pair constructor" on Ubuntu 16.04 (NFC)

### DIFF
--- a/lldb/unittests/Symbol/PostfixExpressionTest.cpp
+++ b/lldb/unittests/Symbol/PostfixExpressionTest.cpp
@@ -111,7 +111,7 @@ ParseFPOAndStringify(llvm::StringRef prog) {
       ParseFPOProgram(prog, alloc);
   std::vector<std::pair<std::string, std::string>> result;
   for (const auto &p : parsed)
-    result.emplace_back(p.first, ASTPrinter::Print(p.second));
+    result.emplace_back(p.first.str(), ASTPrinter::Print(p.second));
   return result;
 }
 


### PR DESCRIPTION
Fixes error: no matching constructor for initialization of
'std::pair<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >'
with older toolchain (clang/libcxx) on Ubuntu 16.04. The issue is the
StringRef-to-std::string conversion.

(cherry picked from commit 7f717b6d1f65f8474e8633b040a16c55f0ad6b96)