### PR TITLE
[lldb/interpreter] Add Swift REPL init file support

### DIFF
--- a/lldb/docs/man/lldb.rst
+++ b/lldb/docs/man/lldb.rst
@@ -312,9 +312,11 @@ program. This would be ~/.lldbinit-lldb for the command line :program:`lldb`
 and ~/.lldbinit-Xcode for Xcode. If there is no application specific init
 file, :program:`lldb` will look for an init file in the home directory.
 If launched with a `REPL`_ option, it will first look for a REPL configuration
-file, specific to the REPL language. If this file doesn't exist, or :program:`lldb`
-wasn't launch with `REPL`_, meaning there is neither a REPL init file nor an
-application specific init file, `lldb` will fallback to the global ~/.lldbinit.
+file, specific to the REPL language. The init file should be named as follow:
+`.lldbinit-<language>-repl` (i.e. `.lldbinit-swift-repl`). If this file doesn't
+exist, or :program:`lldb` wasn't launch with `REPL`_, meaning there is neither
+a REPL init file nor an application specific init file, `lldb` will fallback to
+the global ~/.lldbinit.
 
 Secondly, it will look for an .lldbinit file in the current working directory.
 For security reasons, :program:`lldb` will print a warning and not source this

--- a/lldb/include/lldb/Host/FileSystem.h
+++ b/lldb/include/lldb/Host/FileSystem.h
@@ -154,6 +154,10 @@ public:
   /// Call into the Host to see if it can help find the file.
   bool ResolveExecutableLocation(FileSpec &file_spec);
 
+  /// Get the user home directory.
+  bool GetHomeDirectory(llvm::SmallVectorImpl<char> &path) const;
+  bool GetHomeDirectory(FileSpec &file_spec) const;
+
   enum EnumerateDirectoryResult {
     /// Enumerate next entry in the current directory.
     eEnumerateDirectoryResultNext,

--- a/lldb/source/API/SBHostOS.cpp
+++ b/lldb/source/API/SBHostOS.cpp
@@ -96,14 +96,13 @@ SBFileSpec SBHostOS::GetUserHomeDirectory() {
   LLDB_RECORD_STATIC_METHOD_NO_ARGS(lldb::SBFileSpec, SBHostOS,
                                     GetUserHomeDirectory);
 
-  SBFileSpec sb_fspec;
-
-  llvm::SmallString<64> home_dir_path;
-  llvm::sys::path::home_directory(home_dir_path);
-  FileSpec homedir(home_dir_path.c_str());
+  FileSpec homedir;
+  FileSystem::Instance().GetHomeDirectory(homedir);
   FileSystem::Instance().Resolve(homedir);
 
+  SBFileSpec sb_fspec;
   sb_fspec.SetFileSpec(homedir);
+
   return LLDB_RECORD_RESULT(sb_fspec);
 }
 

--- a/lldb/source/Host/common/Editline.cpp
+++ b/lldb/source/Host/common/Editline.cpp
@@ -207,7 +207,7 @@ private:
     // Compute the history path lazily.
     if (m_path.empty() && m_history && !m_prefix.empty()) {
       llvm::SmallString<128> lldb_history_file;
-      llvm::sys::path::home_directory(lldb_history_file);
+      FileSystem::Instance().GetHomeDirectory(lldb_history_file);
       llvm::sys::path::append(lldb_history_file, ".lldb");
 
       // LLDB stores its history in ~/.lldb/. If for some reason this directory

--- a/lldb/source/Host/common/FileSystem.cpp
+++ b/lldb/source/Host/common/FileSystem.cpp
@@ -360,6 +360,18 @@ bool FileSystem::ResolveExecutableLocation(FileSpec &file_spec) {
   return true;
 }
 
+bool FileSystem::GetHomeDirectory(SmallVectorImpl<char> &path) const {
+  return llvm::sys::path::home_directory(path);
+}
+
+bool FileSystem::GetHomeDirectory(FileSpec &file_spec) const {
+  SmallString<128> home_dir;
+  if (!GetHomeDirectory(home_dir))
+    return false;
+  file_spec.SetPath(home_dir);
+  return true;
+}
+
 static int OpenWithFS(const FileSystem &fs, const char *path, int flags,
                       int mode) {
   return const_cast<FileSystem &>(fs).Open(path, flags, mode);

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -2087,7 +2087,7 @@ static void GetHomeInitFile(llvm::SmallVectorImpl<char> &init_file,
     init_file_name.append(suffix.str());
   }
 
-  llvm::sys::path::home_directory(init_file);
+  FileSystem::Instance().GetHomeDirectory(init_file);
   llvm::sys::path::append(init_file, init_file_name);
 
   FileSystem::Instance().Resolve(init_file);
@@ -2103,7 +2103,7 @@ static void GetHomeREPLInitFile(llvm::SmallVectorImpl<char> &init_file,
     return;
   }
 
-  llvm::sys::path::home_directory(init_file);
+  FileSystem::Instance().GetHomeDirectory(init_file);
   llvm::sys::path::append(init_file, init_file_name);
 
   FileSystem::Instance().Resolve(init_file);

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -2094,9 +2094,12 @@ static void GetHomeInitFile(llvm::SmallVectorImpl<char> &init_file,
   FileSystem::Instance().Resolve(init_file);
 }
 
-static void GetHomeREPLInitFile(llvm::SmallVectorImpl<char> &init_file,
-                                LanguageType language) {
-  if (language == LanguageType::eLanguageTypeUnknown)
+static void GetHomeREPLInitFile(llvm::SmallVectorImpl<char> &init_file) {
+  LanguageSet repl_languages = Language::GetLanguagesSupportingREPLs();
+  LanguageType language = eLanguageTypeUnknown;
+  if (auto main_repl_language = repl_languages.GetSingularLanguage())
+    language = *main_repl_language;
+  else
     return;
 
   std::string init_file_name =
@@ -2194,13 +2197,8 @@ void CommandInterpreter::SourceInitFileHome(CommandReturnObject &result,
 
   llvm::SmallString<128> init_file;
 
-  if (is_repl) {
-    LanguageType language = {};
-    TargetSP target_sp = GetDebugger().GetSelectedTarget();
-    if (target_sp)
-      language = target_sp->GetLanguage();
-    GetHomeREPLInitFile(init_file, language);
-  }
+  if (is_repl)
+    GetHomeREPLInitFile(init_file);
 
   if (init_file.empty())
     GetHomeInitFile(init_file);

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -67,6 +67,7 @@
 #include "lldb/Interpreter/Property.h"
 #include "lldb/Utility/Args.h"
 
+#include "lldb/Target/Language.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/StopInfo.h"
 #include "lldb/Target/TargetList.h"
@@ -2095,17 +2096,16 @@ static void GetHomeInitFile(llvm::SmallVectorImpl<char> &init_file,
 
 static void GetHomeREPLInitFile(llvm::SmallVectorImpl<char> &init_file,
                                 LanguageType language) {
-  std::string init_file_name;
-
-  switch (language) {
-  // TODO: Add support for a language used with a REPL.
-  default:
+  if (language == LanguageType::eLanguageTypeUnknown)
     return;
-  }
 
+  std::string init_file_name =
+      (llvm::Twine(".lldbinit-") +
+       llvm::Twine(Language::GetNameForLanguageType(language)) +
+       llvm::Twine("-repl"))
+          .str();
   FileSystem::Instance().GetHomeDirectory(init_file);
   llvm::sys::path::append(init_file, init_file_name);
-
   FileSystem::Instance().Resolve(init_file);
 }
 

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -85,7 +85,7 @@ PlatformProperties::PlatformProperties() {
     return;
 
   llvm::SmallString<64> user_home_dir;
-  if (!llvm::sys::path::home_directory(user_home_dir))
+  if (!FileSystem::Instance().GetHomeDirectory(user_home_dir))
     return;
 
   module_cache_dir = FileSpec(user_home_dir.c_str());

--- a/lldb/test/Shell/SwiftREPL/InitFile.test
+++ b/lldb/test/Shell/SwiftREPL/InitFile.test
@@ -1,0 +1,11 @@
+// Test that the Swift REPL init file works.
+// REQUIRES: system-darwin
+// RUN: export HOME=%t
+// RUN: mkdir -p %t
+// RUN: echo 'br set -f main.c -l 123' > ~/.lldbinit
+// RUN: echo 'br set -f swift-repl.c -l 456' > ~/.lldbinit-swift-repl
+// RUN: %lldb-init --repl < %s 2>&1 | FileCheck %s
+
+:br list
+// CHECK: Current breakpoints
+// CHECK-NEXT: file = 'swift-repl.c', line = 456, exact_match = 0, locations = 0 (pending)

--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -491,7 +491,7 @@ int Driver::MainLoop() {
   SBCommandInterpreter sb_interpreter = m_debugger.GetCommandInterpreter();
 
   // Before we handle any options from the command line, we parse the
-  // .lldbinit file in the user's home directory.
+  // REPL init file or the default file in the user's home directory.
   SBCommandReturnObject result;
   sb_interpreter.SourceInitFileInHomeDirectory(result, m_option_data.m_repl);
   if (m_option_data.m_debug_mode) {


### PR DESCRIPTION
Some users complained that when using the Swift REPL (LLDB launched with
`--repl` option), it would try to read their home init file, which can cause
unintended behaviour.

To solve this issue, this patch introduces a new, more specific, Swift
REPL init file, conveniently named `.lldbinit-swift-repl`. If the user
creates this file in his home directory, and launches LLDB in REPL mode,
it will override the default init file.

This behaviour only applies when REPL mode is enabled.

rdar://65836048

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>