### PR TITLE
Perform an Extra Consistency Check When Searching The ModuleManager's Cache For Implicit Modules

### DIFF
--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -59,7 +59,7 @@ ModuleFile *ModuleManager::lookupByModuleName(StringRef Name) const {
 }
 
 ModuleFile *ModuleManager::lookup(const FileEntry *File) const {
-  auto Known = Modules.find(EntryKey{File});
+  auto Known = Modules.find(File);
   if (Known == Modules.end())
     return nullptr;
 
@@ -72,7 +72,7 @@ ModuleManager::lookupBuffer(StringRef Name) {
                                /*CacheFailure=*/false);
   if (!Entry)
     return nullptr;
-  return std::move(InMemoryBuffers[EntryKey{*Entry}]);
+  return std::move(InMemoryBuffers[*Entry]);
 }
 
 static bool checkSignature(ASTFileSignature Signature,
@@ -133,7 +133,7 @@ ModuleManager::addModule(StringRef FileName, ModuleKind Type,
   }
 
   // Check whether we already loaded this module, before
-  if (ModuleFile *ModuleEntry = Modules.lookup(EntryKey{Entry})) {
+  if (ModuleFile *ModuleEntry = Modules.lookup(Entry)) {
     // Check the stored signature.
     if (checkSignature(ModuleEntry->Signature, ExpectedSignature, ErrorStr))
       return OutOfDate;
@@ -208,7 +208,7 @@ ModuleManager::addModule(StringRef FileName, ModuleKind Type,
     return OutOfDate;
 
   // We're keeping this module.  Store it everywhere.
-  Module = Modules[EntryKey{Entry}] = NewModule.get();
+  Module = Modules[Entry] = NewModule.get();
 
   updateModuleImports(*NewModule, ImportedBy, ImportLoc);
 
@@ -255,7 +255,7 @@ void ModuleManager::removeModules(ModuleIterator First, ModuleMap *modMap) {
 
   // Delete the modules and erase them from the various structures.
   for (ModuleIterator victim = First; victim != Last; ++victim) {
-    Modules.erase(EntryKey{victim->File});
+    Modules.erase(victim->File);
 
     if (modMap) {
       StringRef ModuleName = victim->ModuleName;
@@ -274,7 +274,7 @@ ModuleManager::addInMemoryBuffer(StringRef FileName,
                                  std::unique_ptr<llvm::MemoryBuffer> Buffer) {
   const FileEntry *Entry =
       FileMgr.getVirtualFile(FileName, Buffer->getBufferSize(), 0);
-  InMemoryBuffers[EntryKey{Entry}] = std::move(Buffer);
+  InMemoryBuffers[Entry] = std::move(Buffer);
 }
 
 ModuleManager::VisitState *ModuleManager::allocateVisitState() {


### PR DESCRIPTION
This reverts out the failed approach in #1651 which did nothing to address the symptoms of inode reuse. The patch on top of this provides an alternative approach: For implicit module builds check the name that we expect an entry to be filed under in the Modules cache actually matches the one we're asked to look for. Note that we can only do this for implicit module builds because the paths that these files are looked up under are fully under the control of Clang. For explicit module builds, this consistency check *will* fail on OSes that use different path forms than the *NIXes (e.g. Windows) because of canonicalization issues.

rdar://48443680