### PR TITLE
[master-rebranch] Fix GetTypeInfo for changes to decodeMangledType in Swift.

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1728,7 +1728,7 @@ SwiftLanguageRuntimeImpl::GetTypeInfo(CompilerType type) {
   swift::Demangle::Demangler Dem;
   auto demangled = Dem.demangleType(mangled_no_prefix);
   auto *type_ref = swift::Demangle::decodeMangledType(
-      reflection_ctx->getBuilder(), demangled);
+      reflection_ctx->getBuilder(), demangled).getType();
   if (!type_ref)
     return nullptr;
   return reflection_ctx->getBuilder().getTypeConverter().getTypeInfo(type_ref);


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/llvm-project/pull/1702/ for master-rebranch.

This fix is needed for the change in https://github.com/apple/swift/pull/33585 on swift's master branch to land in swift's master-rebanch branch (the gated auto-merger is failing because of this).

Swift master -> master-rebanch merge PR here: https://github.com/apple/swift/pull/33717