### PR TITLE
Fix GetTypeInfo for changes to decodeMangledType in Swift.

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1728,7 +1728,7 @@ SwiftLanguageRuntimeImpl::GetTypeInfo(CompilerType type) {
   swift::Demangle::Demangler Dem;
   auto demangled = Dem.demangleType(mangled_no_prefix);
   auto *type_ref = swift::Demangle::decodeMangledType(
-      reflection_ctx->getBuilder(), demangled);
+      reflection_ctx->getBuilder(), demangled).getType();
   if (!type_ref)
     return nullptr;
   return reflection_ctx->getBuilder().getTypeConverter().getTypeInfo(type_ref);


### PR DESCRIPTION
Cherry pick #1702 to `swift/master-next`