### PR TITLE
[lldb/formatter] Format single valued OptionSets w/o brackets

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
@@ -168,6 +168,8 @@ bool lldb_private::formatters::swift::SwiftOptionSetSummaryProvider::
     for (auto val_name : *m_cases) {
       llvm::APInt case_value = val_name.first;
       // Print single valued sets without using enclosing brackets.
+      // `WouldEvenConsiderFormatting` can't opt out early because it
+      // has only the type, but needs the value for this case.
       if (case_value == value) {
         ss << '.' << val_name.second;
         dest.assign(ss.GetData());

--- a/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
@@ -180,7 +180,6 @@ bool lldb_private::formatters::swift::SwiftOptionSetSummaryProvider::
       if ((case_value & value) == case_value) {
         // hey a case matched!!
         any_match = true;
-
         if (first_match) {
           ss.Printf("[.%s", val_name.second.AsCString());
           first_match = false;

--- a/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
@@ -174,6 +174,14 @@ bool lldb_private::formatters::swift::SwiftOptionSetSummaryProvider::
       if ((case_value & value) == case_value) {
         // hey a case matched!!
         any_match = true;
+
+        // Print single valued sets without enclosing in brackets.
+        if (first_match && case_value == value) {
+          ss.Printf(".%s", val_name.second.AsCString());
+          dest.assign(ss.GetData());
+          return true;
+        }
+
         if (first_match) {
           ss.Printf("[.%s", val_name.second.AsCString());
           first_match = false;

--- a/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
@@ -167,6 +167,12 @@ bool lldb_private::formatters::swift::SwiftOptionSetSummaryProvider::
 
     for (auto val_name : *m_cases) {
       llvm::APInt case_value = val_name.first;
+      // Print single valued sets without using enclosing brackets.
+      if (case_value == value) {
+        ss << '.' << val_name.second;
+        dest.assign(ss.GetData());
+        return true;
+      }
       // Don't display the zero case in an option set unless it's the
       // only value.
       if (case_value == 0 && value != 0)
@@ -174,13 +180,6 @@ bool lldb_private::formatters::swift::SwiftOptionSetSummaryProvider::
       if ((case_value & value) == case_value) {
         // hey a case matched!!
         any_match = true;
-
-        // Print single valued sets without enclosing in brackets.
-        if (first_match && case_value == value) {
-          ss.Printf(".%s", val_name.second.AsCString());
-          dest.assign(ss.GetData());
-          return true;
-        }
 
         if (first_match) {
           ss.Printf("[.%s", val_name.second.AsCString());

--- a/lldb/test/API/lang/swift/optionset/main.swift
+++ b/lldb/test/API/lang/swift/optionset/main.swift
@@ -28,14 +28,19 @@ func use<T>(_ t: T) {}
 func main() {
   var user_option = Options(rawValue: 123456)
   var computed_option = ComputedOptions(rawValue: 789)
+  var sdk_option_single_valued: NSBinarySearchingOptions = .insertionIndex
   var sdk_option_exhaustive: NSBinarySearchingOptions = [.firstEqual, .insertionIndex]
   var sdk_option_nonexhaustive = NSBinarySearchingOptions(rawValue: 257)
   var sdk_option_nonevalid = NSBinarySearchingOptions(rawValue: 12)
   use((user_option, computed_option, // break here
+      sdk_option_single_valued,
       sdk_option_exhaustive, sdk_option_nonexhaustive,
-      sdk_option_nonevalid)) //%self.expect('frame variable user_option', substrs=['rawValue = 123456'])
+      sdk_option_nonevalid))
+  //%self.expect('frame variable user_option', substrs=['rawValue = 123456'])
   //%self.expect('frame variable computed_option', substrs=['storedValue', '789'])
   //%self.expect('expression user_option', substrs=['rawValue = 123456'])
+  //%self.expect('frame variable sdk_option_single_valued', substrs=['.insertionIndex'])
+  //%self.expect('frame variable sdk_option_single_valued', matching=False, substrs=['[.insertionIndex]'])
   //%self.expect('frame variable sdk_option_exhaustive', substrs=['[.firstEqual, .insertionIndex]'])
   //%self.expect('expression sdk_option_exhaustive', substrs=['[.firstEqual, .insertionIndex]'])
   //%self.expect('frame variable sdk_option_nonexhaustive', substrs=['[.firstEqual, 0x1]'])

--- a/lldb/test/API/lang/swift/optionset/main.swift
+++ b/lldb/test/API/lang/swift/optionset/main.swift
@@ -41,6 +41,8 @@ func main() {
   //%self.expect('expression user_option', substrs=['rawValue = 123456'])
   //%self.expect('frame variable sdk_option_single_valued', substrs=['.insertionIndex'])
   //%self.expect('frame variable sdk_option_single_valued', matching=False, substrs=['['])
+  //%self.expect('expression sdk_option_single_valued', substrs=['.insertionIndex'])
+  //%self.expect('expression sdk_option_single_valued', matching=False, substrs=['['])
   //%self.expect('frame variable sdk_option_exhaustive', substrs=['[.firstEqual, .insertionIndex]'])
   //%self.expect('expression sdk_option_exhaustive', substrs=['[.firstEqual, .insertionIndex]'])
   //%self.expect('frame variable sdk_option_nonexhaustive', substrs=['[.firstEqual, 0x1]'])

--- a/lldb/test/API/lang/swift/optionset/main.swift
+++ b/lldb/test/API/lang/swift/optionset/main.swift
@@ -40,7 +40,7 @@ func main() {
   //%self.expect('frame variable computed_option', substrs=['storedValue', '789'])
   //%self.expect('expression user_option', substrs=['rawValue = 123456'])
   //%self.expect('frame variable sdk_option_single_valued', substrs=['.insertionIndex'])
-  //%self.expect('frame variable sdk_option_single_valued', matching=False, substrs=['[.insertionIndex]'])
+  //%self.expect('frame variable sdk_option_single_valued', matching=False, substrs=['['])
   //%self.expect('frame variable sdk_option_exhaustive', substrs=['[.firstEqual, .insertionIndex]'])
   //%self.expect('expression sdk_option_exhaustive', substrs=['[.firstEqual, .insertionIndex]'])
   //%self.expect('frame variable sdk_option_nonexhaustive', substrs=['[.firstEqual, 0x1]'])

--- a/lldb/test/Shell/Swift/Inputs/No.swiftmodule-ObjC.swift
+++ b/lldb/test/Shell/Swift/Inputs/No.swiftmodule-ObjC.swift
@@ -13,10 +13,9 @@ func f() {
   // The Objective-C runtime recognizes this as a tagged pointer.
   // CHECK-DAG: (NSNumber) inlined = {{.*}}Int64(42)
   let inlined = NSNumber(value: 42)
-  // FIXME: The dataformatters wrongly think this is an OptionSet.
-  // CHECK-DAG: (CMYK) enumerator = [.yellow]
+  // CHECK-DAG: (CMYK) enumerator = .yellow
   let enumerator = yellow
-  // CHECK-DAG: (FourColors) typedef = [.cyan]
+  // CHECK-DAG: (FourColors) typedef = .cyan
   let typedef = FourColors(0)
   let union = Union(i: 23)
   // CHECK-DAG: (OBJCSTUFF_MyString) renamed = {{.*}} "with swift_name"


### PR DESCRIPTION
Special case formatting of single valued option sets to print the case name without square brackets.

For example, instead producing `[.yellow]`, the output will be `.yellow`.

rdar://54106278