### PR TITLE
[NFC] Remove dead use of ModuleDecl::AccessPathTy

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1092,8 +1092,6 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
                   [&ast_ctx, input, name_parts,
                    &results](swift::ModuleDecl *module) -> void {
 
-                swift::ModuleDecl::AccessPathTy access_path;
-
                 for (auto imported_module : swift::namelookup::getAllImports(module)) {
                   auto module = imported_module.importedModule;
                   TypesOrDecls local_results;


### PR DESCRIPTION
An unused variable referenced `swift::ModuleDecl::AccessPathTy`, which I’m trying to remove in apple/swift#33716.