### PR TITLE
SwiftASTContext: Remove redundant type check in GetTypeName

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5317,10 +5317,6 @@ ConstString SwiftASTContext::GetTypeName(opaque_compiler_type_t type) {
                   swift::dyn_cast<swift::SyntaxSugarType>(type.getPointer())) {
             return syntax_sugar_type->getSinglyDesugaredType();
           }
-          if (swift::DictionaryType *dictionary_type =
-                  swift::dyn_cast<swift::DictionaryType>(type.getPointer())) {
-            return dictionary_type->getSinglyDesugaredType();
-          }
           return type;
         });
 


### PR DESCRIPTION
Removes a `dyn_cast` to `DictionaryType` as it immediately follows a `dyn_cast` to its supertype (`SyntaxSugarType`).

The removed code is dead if the preceding cast to `SyntaxSugarType` succeeds. In the case where the preceding cast fails, this code will always fail too.

The git history of this code goes back to an initial import, it's unclear why Dictionary alone was special cased.