### PR TITLE
[lldb/Target] Add custom interpreter option to `platform shell`

### DIFF
--- a/lldb/bindings/interface/SBPlatform.i
+++ b/lldb/bindings/interface/SBPlatform.i
@@ -45,6 +45,7 @@ public:
 class SBPlatformShellCommand
 {
 public:
+    SBPlatformShellCommand (const char *shell, const char *shell_command);
     SBPlatformShellCommand (const char *shell_command);
 
     SBPlatformShellCommand (const SBPlatformShellCommand &rhs);
@@ -53,6 +54,12 @@ public:
 
     void
     Clear();
+
+    const char *
+    GetShell();
+
+    void
+    SetShell(const char *shell_interpreter);
 
     const char *
     GetCommand();

--- a/lldb/include/lldb/API/SBPlatform.h
+++ b/lldb/include/lldb/API/SBPlatform.h
@@ -51,6 +51,7 @@ protected:
 
 class LLDB_API SBPlatformShellCommand {
 public:
+  SBPlatformShellCommand(const char *shell, const char *shell_command);
   SBPlatformShellCommand(const char *shell_command);
 
   SBPlatformShellCommand(const SBPlatformShellCommand &rhs);
@@ -60,6 +61,10 @@ public:
   ~SBPlatformShellCommand();
 
   void Clear();
+
+  const char *GetShell();
+
+  void SetShell(const char *shell);
 
   const char *GetCommand();
 

--- a/lldb/include/lldb/Host/Host.h
+++ b/lldb/include/lldb/Host/Host.h
@@ -196,19 +196,34 @@ public:
   static Status ShellExpandArguments(ProcessLaunchInfo &launch_info);
 
   /// Run a shell command.
-  /// \arg command  shouldn't be NULL
+  /// \arg command  shouldn't be empty
   /// \arg working_dir Pass empty FileSpec to use the current working directory
   /// \arg status_ptr  Pass NULL if you don't want the process exit status
   /// \arg signo_ptr   Pass NULL if you don't want the signal that caused the
   ///                  process to exit
   /// \arg command_output  Pass NULL if you don't want the command output
   /// \arg hide_stderr if this is false, redirect stderr to stdout
-  /// TODO: Convert this function to take a StringRef.
-  static Status RunShellCommand(const char *command,
+  static Status RunShellCommand(llvm::StringRef command,
                                 const FileSpec &working_dir, int *status_ptr,
                                 int *signo_ptr, std::string *command_output,
                                 const Timeout<std::micro> &timeout,
-                                bool run_in_default_shell = true,
+                                bool run_in_shell = true,
+                                bool hide_stderr = false);
+
+  /// Run a shell command.
+  /// \arg shell  Pass an empty string if you want to use the default shell
+  /// interpreter \arg command \arg working_dir  Pass empty FileSpec to use the
+  /// current working directory \arg status_ptr   Pass NULL if you don't want
+  /// the process exit status \arg signo_ptr    Pass NULL if you don't want the
+  /// signal that caused
+  ///                   the process to exit
+  /// \arg command_output  Pass NULL if you don't want the command output
+  /// \arg hide_stderr  If this is \b false, redirect stderr to stdout
+  static Status RunShellCommand(llvm::StringRef shell, llvm::StringRef command,
+                                const FileSpec &working_dir, int *status_ptr,
+                                int *signo_ptr, std::string *command_output,
+                                const Timeout<std::micro> &timeout,
+                                bool run_in_shell = true,
                                 bool hide_stderr = false);
 
   /// Run a shell command.
@@ -222,7 +237,23 @@ public:
                                 int *status_ptr, int *signo_ptr,
                                 std::string *command_output,
                                 const Timeout<std::micro> &timeout,
-                                bool run_in_default_shell = true,
+                                bool run_in_shell = true,
+                                bool hide_stderr = false);
+
+  /// Run a shell command.
+  /// \arg shell            Pass an empty string if you want to use the default
+  /// shell interpreter \arg command \arg working_dir Pass empty FileSpec to use
+  /// the current working directory \arg status_ptr    Pass NULL if you don't
+  /// want the process exit status \arg signo_ptr     Pass NULL if you don't
+  /// want the signal that caused the
+  ///               process to exit
+  /// \arg command_output  Pass NULL if you don't want the command output
+  /// \arg hide_stderr If this is \b false, redirect stderr to stdout
+  static Status RunShellCommand(llvm::StringRef shell, const Args &args,
+                                const FileSpec &working_dir, int *status_ptr,
+                                int *signo_ptr, std::string *command_output,
+                                const Timeout<std::micro> &timeout,
+                                bool run_in_shell = true,
                                 bool hide_stderr = false);
 
   static bool OpenFileInExternalEditor(const FileSpec &file_spec,

--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -618,7 +618,18 @@ public:
   }
 
   virtual lldb_private::Status RunShellCommand(
-      const char *command,         // Shouldn't be nullptr
+      llvm::StringRef command,
+      const FileSpec &working_dir, // Pass empty FileSpec to use the current
+                                   // working directory
+      int *status_ptr, // Pass nullptr if you don't want the process exit status
+      int *signo_ptr,  // Pass nullptr if you don't want the signal that caused
+                       // the process to exit
+      std::string
+          *command_output, // Pass nullptr if you don't want the command output
+      const Timeout<std::micro> &timeout);
+
+  virtual lldb_private::Status RunShellCommand(
+      llvm::StringRef shell, llvm::StringRef command,
       const FileSpec &working_dir, // Pass empty FileSpec to use the current
                                    // working directory
       int *status_ptr, // Pass nullptr if you don't want the process exit status

--- a/lldb/include/lldb/Target/RemoteAwarePlatform.h
+++ b/lldb/include/lldb/Target/RemoteAwarePlatform.h
@@ -68,9 +68,14 @@ public:
   bool GetRemoteOSKernelDescription(std::string &s) override;
   ArchSpec GetRemoteSystemArchitecture() override;
 
-  Status RunShellCommand(const char *command, const FileSpec &working_dir,
+  Status RunShellCommand(llvm::StringRef command, const FileSpec &working_dir,
                          int *status_ptr, int *signo_ptr,
                          std::string *command_output,
+                         const Timeout<std::micro> &timeout) override;
+
+  Status RunShellCommand(llvm::StringRef interpreter, llvm::StringRef command,
+                         const FileSpec &working_dir, int *status_ptr,
+                         int *signo_ptr, std::string *command_output,
                          const Timeout<std::micro> &timeout) override;
 
   const char *GetHostname() override;

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -628,6 +628,8 @@ let Command = "platform shell" in {
     Desc<"Run the commands on the host shell when enabled.">;
   def platform_shell_timeout : Option<"timeout", "t">, Arg<"Value">,
     Desc<"Seconds to wait for the remote host to finish running the command.">;
+  def platform_shell_interpreter : Option<"shell", "s">, Arg<"Path">,
+    Desc<"Shell interpreter path. This is the binary used to run the command.">;
 }
 
 let Command = "process attach" in {

--- a/lldb/source/Host/common/Host.cpp
+++ b/lldb/source/Host/common/Host.cpp
@@ -466,14 +466,24 @@ MonitorShellCommand(std::shared_ptr<ShellInfo> shell_info, lldb::pid_t pid,
   return true;
 }
 
-Status Host::RunShellCommand(const char *command, const FileSpec &working_dir,
-                             int *status_ptr, int *signo_ptr,
-                             std::string *command_output_ptr,
+Status Host::RunShellCommand(llvm::StringRef command,
+                             const FileSpec &working_dir, int *status_ptr,
+                             int *signo_ptr, std::string *command_output_ptr,
                              const Timeout<std::micro> &timeout,
-                             bool run_in_default_shell,
-                             bool hide_stderr) {
-  return RunShellCommand(Args(command), working_dir, status_ptr, signo_ptr,
-                         command_output_ptr, timeout, run_in_default_shell,
+                             bool run_in_shell, bool hide_stderr) {
+  return RunShellCommand(llvm::StringRef(), Args(command), working_dir,
+                         status_ptr, signo_ptr, command_output_ptr, timeout,
+                         run_in_shell, hide_stderr);
+}
+
+Status Host::RunShellCommand(llvm::StringRef shell_path,
+                             llvm::StringRef command,
+                             const FileSpec &working_dir, int *status_ptr,
+                             int *signo_ptr, std::string *command_output_ptr,
+                             const Timeout<std::micro> &timeout,
+                             bool run_in_shell, bool hide_stderr) {
+  return RunShellCommand(shell_path, Args(command), working_dir, status_ptr,
+                         signo_ptr, command_output_ptr, timeout, run_in_shell,
                          hide_stderr);
 }
 
@@ -481,14 +491,27 @@ Status Host::RunShellCommand(const Args &args, const FileSpec &working_dir,
                              int *status_ptr, int *signo_ptr,
                              std::string *command_output_ptr,
                              const Timeout<std::micro> &timeout,
-                             bool run_in_default_shell,
-                             bool hide_stderr) {
+                             bool run_in_shell, bool hide_stderr) {
+  return RunShellCommand(llvm::StringRef(), args, working_dir, status_ptr,
+                         signo_ptr, command_output_ptr, timeout, run_in_shell,
+                         hide_stderr);
+}
+
+Status Host::RunShellCommand(llvm::StringRef shell_path, const Args &args,
+                             const FileSpec &working_dir, int *status_ptr,
+                             int *signo_ptr, std::string *command_output_ptr,
+                             const Timeout<std::micro> &timeout,
+                             bool run_in_shell, bool hide_stderr) {
   Status error;
   ProcessLaunchInfo launch_info;
   launch_info.SetArchitecture(HostInfo::GetArchitecture());
-  if (run_in_default_shell) {
+  if (run_in_shell) {
     // Run the command in a shell
-    launch_info.SetShell(HostInfo::GetDefaultShell());
+    FileSpec shell = HostInfo::GetDefaultShell();
+    if (!shell_path.empty())
+      shell.SetPath(shell_path);
+
+    launch_info.SetShell(shell);
     launch_info.GetArguments().AppendArguments(args);
     const bool localhost = true;
     const bool will_debug = false;

--- a/lldb/source/Host/macosx/objcxx/Host.mm
+++ b/lldb/source/Host/macosx/objcxx/Host.mm
@@ -1323,11 +1323,11 @@ Status Host::ShellExpandArguments(ProcessLaunchInfo &launch_info) {
         launch_info.SetWorkingDirectory(working_dir);
       }
     }
-    bool run_in_default_shell = true;
+    bool run_in_shell = true;
     bool hide_stderr = true;
-    Status e = RunShellCommand(expand_command, cwd, &status, nullptr, &output,
-                               std::chrono::seconds(10), run_in_default_shell,
-                               hide_stderr);
+    Status e =
+        RunShellCommand(expand_command, cwd, &status, nullptr, &output,
+                        std::chrono::seconds(10), run_in_shell, hide_stderr);
 
     if (e.Fail())
       return e;

--- a/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.cpp
+++ b/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.cpp
@@ -706,7 +706,7 @@ bool PlatformRemoteGDBServer::GetFileExists(const FileSpec &file_spec) {
 }
 
 Status PlatformRemoteGDBServer::RunShellCommand(
-    const char *command, // Shouldn't be NULL
+    llvm::StringRef shell, llvm::StringRef command,
     const FileSpec &
         working_dir, // Pass empty FileSpec to use the current working directory
     int *status_ptr, // Pass NULL if you don't want the process exit status

--- a/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.h
+++ b/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.h
@@ -137,7 +137,7 @@ public:
   Status Unlink(const FileSpec &path) override;
 
   Status RunShellCommand(
-      const char *command,         // Shouldn't be NULL
+      llvm::StringRef shell, llvm::StringRef command,
       const FileSpec &working_dir, // Pass empty FileSpec to use the current
                                    // working directory
       int *status_ptr, // Pass NULL if you don't want the process exit status

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -2816,7 +2816,7 @@ lldb::addr_t GDBRemoteCommunicationClient::GetShlibInfoAddr() {
 }
 
 lldb_private::Status GDBRemoteCommunicationClient::RunShellCommand(
-    const char *command, // Shouldn't be NULL
+    llvm::StringRef command,
     const FileSpec &
         working_dir, // Pass empty FileSpec to use the current working directory
     int *status_ptr, // Pass NULL if you don't want the process exit status
@@ -2827,7 +2827,7 @@ lldb_private::Status GDBRemoteCommunicationClient::RunShellCommand(
     const Timeout<std::micro> &timeout) {
   lldb_private::StreamString stream;
   stream.PutCString("qPlatform_shell:");
-  stream.PutBytesAsRawHex8(command, strlen(command));
+  stream.PutBytesAsRawHex8(command.data(), command.size());
   stream.PutChar(',');
   uint32_t timeout_sec = UINT32_MAX;
   if (timeout) {

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
@@ -396,7 +396,7 @@ public:
   bool GetFileExists(const FileSpec &file_spec);
 
   Status RunShellCommand(
-      const char *command,         // Shouldn't be nullptr
+      llvm::StringRef command,
       const FileSpec &working_dir, // Pass empty FileSpec to use the current
                                    // working directory
       int *status_ptr, // Pass nullptr if you don't want the process exit status

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -1319,7 +1319,23 @@ MmapArgList Platform::GetMmapArgumentList(const ArchSpec &arch, addr_t addr,
 }
 
 lldb_private::Status Platform::RunShellCommand(
-    const char *command, // Shouldn't be nullptr
+    llvm::StringRef command,
+    const FileSpec &
+        working_dir, // Pass empty FileSpec to use the current working directory
+    int *status_ptr, // Pass nullptr if you don't want the process exit status
+    int *signo_ptr, // Pass nullptr if you don't want the signal that caused the
+                    // process to exit
+    std::string
+        *command_output, // Pass nullptr if you don't want the command output
+    const Timeout<std::micro> &timeout) {
+  return RunShellCommand(llvm::StringRef(), command, working_dir, status_ptr,
+                         signo_ptr, command_output, timeout);
+}
+
+lldb_private::Status Platform::RunShellCommand(
+    llvm::StringRef shell,   // Pass empty if you want to use the default
+                             // shell interpreter
+    llvm::StringRef command, // Shouldn't be empty
     const FileSpec &
         working_dir, // Pass empty FileSpec to use the current working directory
     int *status_ptr, // Pass nullptr if you don't want the process exit status
@@ -1329,8 +1345,8 @@ lldb_private::Status Platform::RunShellCommand(
         *command_output, // Pass nullptr if you don't want the command output
     const Timeout<std::micro> &timeout) {
   if (IsHost())
-    return Host::RunShellCommand(command, working_dir, status_ptr, signo_ptr,
-                                 command_output, timeout);
+    return Host::RunShellCommand(shell, command, working_dir, status_ptr,
+                                 signo_ptr, command_output, timeout);
   else
     return Status("unimplemented");
 }

--- a/lldb/source/Target/RemoteAwarePlatform.cpp
+++ b/lldb/source/Target/RemoteAwarePlatform.cpp
@@ -171,15 +171,24 @@ Status RemoteAwarePlatform::ResolveExecutable(
 }
 
 Status RemoteAwarePlatform::RunShellCommand(
-    const char *command, const FileSpec &working_dir, int *status_ptr,
+    llvm::StringRef command, const FileSpec &working_dir, int *status_ptr,
     int *signo_ptr, std::string *command_output,
     const Timeout<std::micro> &timeout) {
+  return RunShellCommand(llvm::StringRef(), command, working_dir, status_ptr,
+                         signo_ptr, command_output, timeout);
+}
+
+Status RemoteAwarePlatform::RunShellCommand(
+    llvm::StringRef shell, llvm::StringRef command, const FileSpec &working_dir,
+    int *status_ptr, int *signo_ptr, std::string *command_output,
+    const Timeout<std::micro> &timeout) {
   if (IsHost())
-    return Host::RunShellCommand(command, working_dir, status_ptr, signo_ptr,
-                                 command_output, timeout);
+    return Host::RunShellCommand(shell, command, working_dir, status_ptr,
+                                 signo_ptr, command_output, timeout);
   if (m_remote_platform_sp)
-    return m_remote_platform_sp->RunShellCommand(
-        command, working_dir, status_ptr, signo_ptr, command_output, timeout);
+    return m_remote_platform_sp->RunShellCommand(shell, command, working_dir,
+                                                 status_ptr, signo_ptr,
+                                                 command_output, timeout);
   return Status("unable to run a remote command without a platform");
 }
 

--- a/lldb/test/API/commands/platform/basic/Makefile
+++ b/lldb/test/API/commands/platform/basic/Makefile
@@ -1,0 +1,5 @@
+C_SOURCES := myshell.c
+CFLAGS_EXTRAS := -g0 # No debug info.
+MAKE_DSYM := NO
+
+include Makefile.rules

--- a/lldb/test/API/commands/platform/basic/TestPlatformCommand.py
+++ b/lldb/test/API/commands/platform/basic/TestPlatformCommand.py
@@ -13,6 +13,7 @@ from lldbsuite.test import lldbutil
 class PlatformCommandTestCase(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
+    NO_DEBUG_INFO_TESTCASE = True
 
     @no_debug_info_test
     def test_help_platform(self):
@@ -92,3 +93,11 @@ class PlatformCommandTestCase(TestBase):
                     "error: timed out waiting for shell command to complete"])
         self.expect("shell -t 1 --  sleep 3", error=True, substrs=[
                     "error: timed out waiting for shell command to complete"])
+
+    @no_debug_info_test
+    def test_host_shell_interpreter(self):
+        """ Test the host platform shell with a different interpreter """
+        self.build()
+        exe = self.getBuildArtifact('a.out')
+        self.expect("platform shell -h -s " + exe + " -- 'echo $0'",
+                    substrs=['SUCCESS', 'a.out'])

--- a/lldb/test/API/commands/platform/basic/TestPlatformPython.py
+++ b/lldb/test/API/commands/platform/basic/TestPlatformPython.py
@@ -79,3 +79,20 @@ class PlatformPythonTestCase(TestBase):
             self.assertEqual(
                 desc_data.GetType(), lldb.eStructuredDataTypeString,
                 'Platform description is a string')
+
+    @add_test_categories(['pyapi'])
+    @no_debug_info_test
+    def test_shell_interpreter(self):
+        """ Test a shell with a custom interpreter """
+        platform = self.dbg.GetSelectedPlatform()
+        self.assertTrue(platform.IsValid())
+
+        sh_cmd = lldb.SBPlatformShellCommand('/bin/zsh', 'echo $0')
+        self.assertIn('/bin/zsh', sh_cmd.GetShell())
+        self.assertIn('echo $0', sh_cmd.GetCommand())
+
+        self.build()
+        sh_cmd.SetShell(self.getBuildArtifact('a.out'))
+        err = platform.Run(sh_cmd)
+        self.assertTrue(err.Success())
+        self.assertIn("SUCCESS", sh_cmd.GetOutput())

--- a/lldb/test/API/commands/platform/basic/myshell.c
+++ b/lldb/test/API/commands/platform/basic/myshell.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(int argc, char *argv[]) {
+  if (argc < 3) {
+    fprintf(stderr, "ERROR: Too few arguments (count: %d).\n", argc - 1);
+    exit(1);
+  }
+
+#ifdef WIN32
+  char *cmd_opt = "/C";
+#else
+  char *cmd_opt = "-c";
+#endif
+
+  if (strncmp(argv[1], cmd_opt, 2)) {
+    fprintf(stderr, "ERROR: Missing shell command option ('%s').\n", cmd_opt);
+    exit(1);
+  }
+
+  printf("SUCCESS: %s\n", argv[0]);
+  return 0;
+}

--- a/lldb/test/API/commands/platform/basic/myshell.c
+++ b/lldb/test/API/commands/platform/basic/myshell.c
@@ -8,7 +8,7 @@ int main(int argc, char *argv[]) {
     exit(1);
   }
 
-#ifdef WIN32
+#if defined(_WIN32) || defined(_WIN64)
   char *cmd_opt = "/C";
 #else
   char *cmd_opt = "-c";


### PR DESCRIPTION
This patch adds the ability to use a custom interpreter with the
`platform shell` command. If the user set the `-s|--shell` option
with the path to a binary, lldb passes it down to the platform's
`RunShellProcess` method and set it as the shell to use in
`ProcessLaunchInfo to run commands.

Note that not all the Platforms support running shell commands with
custom interpreters (i.e. RemoteGDBServer is only expected to use the
default shell).

This patch also makes some refactoring and cleanups, like swapping
CString for StringRef when possible and updating `SBPlatformShellCommand`
with new methods and a new constructor.

rdar://67759256

Differential Revision: https://reviews.llvm.org/D86667

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>