### PR TITLE
[lldb/formatter] Format single valued OptionSets w/o brackets

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
@@ -167,6 +167,14 @@ bool lldb_private::formatters::swift::SwiftOptionSetSummaryProvider::
 
     for (auto val_name : *m_cases) {
       llvm::APInt case_value = val_name.first;
+      // Print single valued sets without using enclosing brackets.
+      // `WouldEvenConsiderFormatting` can't opt out early because it
+      // has only the type, but needs the value for this case.
+      if (case_value == value) {
+        ss << '.' << val_name.second;
+        dest.assign(ss.GetData());
+        return true;
+      }
       // Don't display the zero case in an option set unless it's the
       // only value.
       if (case_value == 0 && value != 0)

--- a/lldb/test/API/lang/swift/optionset/main.swift
+++ b/lldb/test/API/lang/swift/optionset/main.swift
@@ -28,14 +28,21 @@ func use<T>(_ t: T) {}
 func main() {
   var user_option = Options(rawValue: 123456)
   var computed_option = ComputedOptions(rawValue: 789)
+  var sdk_option_single_valued: NSBinarySearchingOptions = .insertionIndex
   var sdk_option_exhaustive: NSBinarySearchingOptions = [.firstEqual, .insertionIndex]
   var sdk_option_nonexhaustive = NSBinarySearchingOptions(rawValue: 257)
   var sdk_option_nonevalid = NSBinarySearchingOptions(rawValue: 12)
   use((user_option, computed_option, // break here
+      sdk_option_single_valued,
       sdk_option_exhaustive, sdk_option_nonexhaustive,
-      sdk_option_nonevalid)) //%self.expect('frame variable user_option', substrs=['rawValue = 123456'])
+      sdk_option_nonevalid))
+  //%self.expect('frame variable user_option', substrs=['rawValue = 123456'])
   //%self.expect('frame variable computed_option', substrs=['storedValue', '789'])
   //%self.expect('expression user_option', substrs=['rawValue = 123456'])
+  //%self.expect('frame variable sdk_option_single_valued', substrs=['.insertionIndex'])
+  //%self.expect('frame variable sdk_option_single_valued', matching=False, substrs=['['])
+  //%self.expect('expression sdk_option_single_valued', substrs=['.insertionIndex'])
+  //%self.expect('expression sdk_option_single_valued', matching=False, substrs=['['])
   //%self.expect('frame variable sdk_option_exhaustive', substrs=['[.firstEqual, .insertionIndex]'])
   //%self.expect('expression sdk_option_exhaustive', substrs=['[.firstEqual, .insertionIndex]'])
   //%self.expect('frame variable sdk_option_nonexhaustive', substrs=['[.firstEqual, 0x1]'])

--- a/lldb/test/Shell/Swift/Inputs/No.swiftmodule-ObjC.swift
+++ b/lldb/test/Shell/Swift/Inputs/No.swiftmodule-ObjC.swift
@@ -13,10 +13,9 @@ func f() {
   // The Objective-C runtime recognizes this as a tagged pointer.
   // CHECK-DAG: (NSNumber) inlined = {{.*}}Int64(42)
   let inlined = NSNumber(value: 42)
-  // FIXME: The dataformatters wrongly think this is an OptionSet.
-  // CHECK-DAG: (CMYK) enumerator = [.yellow]
+  // CHECK-DAG: (CMYK) enumerator = .yellow
   let enumerator = yellow
-  // CHECK-DAG: (FourColors) typedef = [.cyan]
+  // CHECK-DAG: (FourColors) typedef = .cyan
   let typedef = FourColors(0)
   let union = Union(i: 23)
   // CHECK-DAG: (OBJCSTUFF_MyString) renamed = {{.*}} "with swift_name"


### PR DESCRIPTION
Special case formatting of single valued option sets to print the case name without square brackets.

For example, instead producing `[.yellow]`, the output will be `.yellow`.

rdar://54106278

Cherrypick of https://github.com/apple/llvm-project/pull/1728