### PR TITLE
[lldb/interpreter] Improve REPL init file compatibility

### DIFF
--- a/lldb/docs/man/lldb.rst
+++ b/lldb/docs/man/lldb.rst
@@ -311,9 +311,11 @@ program. This would be ~/.lldbinit-lldb for the command line :program:`lldb`
 and ~/.lldbinit-Xcode for Xcode. If there is no application specific init
 file, :program:`lldb` will look for an init file in the home directory.
 If launched with a `REPL`_ option, it will first look for a REPL configuration
-file, specific to the REPL language. If this file doesn't exist, or :program:`lldb`
-wasn't launch with `REPL`_, meaning there is neither a REPL init file nor an
-application specific init file, `lldb` will fallback to the global ~/.lldbinit.
+file, specific to the REPL language. The init file should be named as follow:
+`.lldbinit-<language>-repl` (i.e. `.lldbinit-swift-repl`). If this file doesn't
+exist, or :program:`lldb` wasn't launch with `REPL`_, meaning there is neither
+a REPL init file nor an application specific init file, `lldb` will fallback to
+the global ~/.lldbinit.
 
 Secondly, it will look for an .lldbinit file in the current working directory.
 For security reasons, :program:`lldb` will print a warning and not source this

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -67,6 +67,7 @@
 #include "lldb/Interpreter/Property.h"
 #include "lldb/Utility/Args.h"
 
+#include "lldb/Target/Language.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/StopInfo.h"
 #include "lldb/Target/TargetList.h"
@@ -2090,17 +2091,16 @@ static void GetHomeInitFile(llvm::SmallVectorImpl<char> &init_file,
 
 static void GetHomeREPLInitFile(llvm::SmallVectorImpl<char> &init_file,
                                 LanguageType language) {
-  std::string init_file_name;
-
-  switch (language) {
-  // TODO: Add support for a language used with a REPL.
-  default:
+  if (language == LanguageType::eLanguageTypeUnknown)
     return;
-  }
 
-  llvm::sys::path::home_directory(init_file);
+  std::string init_file_name =
+      (llvm::Twine(".lldbinit-") +
+       llvm::Twine(Language::GetNameForLanguageType(language)) +
+       llvm::Twine("-repl"))
+          .str();
+  FileSystem::Instance().GetHomeDirectory(init_file);
   llvm::sys::path::append(init_file, init_file_name);
-
   FileSystem::Instance().Resolve(init_file);
 }
 

--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -491,7 +491,7 @@ int Driver::MainLoop() {
   SBCommandInterpreter sb_interpreter = m_debugger.GetCommandInterpreter();
 
   // Before we handle any options from the command line, we parse the
-  // .lldbinit file in the user's home directory.
+  // REPL init file or the default file in the user's home directory.
   SBCommandReturnObject result;
   sb_interpreter.SourceInitFileInHomeDirectory(result, m_option_data.m_repl);
   if (m_option_data.m_debug_mode) {


### PR DESCRIPTION
This patch changes the command interpreter sourcing logic for the REPL
init file. Instead of looking for a arbitrary file name, it standardizes
the REPL init file name to match to following scheme:

                          `.lldbinit-<language>-repl`

This will make the naming more homogenous and the sourcing logic future-proof.

rdar://65836048

Differential Revision: https://reviews.llvm.org/D86987

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>