### PR TITLE
[lldb] Don't crash when LLDB can't extract the tsan report

### DIFF
--- a/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
@@ -809,7 +809,9 @@ bool InstrumentationRuntimeTSan::NotifyBreakpointHit(
 
   StructuredData::ObjectSP report =
       instance->RetrieveReportData(context->exe_ctx_ref);
-  std::string stop_reason_description;
+  std::string stop_reason_description =
+      "unknown thread sanitizer fault (unable to extract thread sanitizer "
+      "report)";
   if (report) {
     std::string issue_description = instance->FormatDescription(report);
     report->GetAsDictionary()->AddStringItem("description", issue_description);


### PR DESCRIPTION
Right now all tsan tests are crashing on Linux. The tests were already marked as
expected failures, but since commit 20ce8affce85d added an assert that every
StopInfo needs a non-empty stop description the tests actually started crash
(which is even with an expectedFailure a failed test).

The reason for that is that we never had any stop description when hitting tsan
errors on Linux. Before the assert that just made the test fail, but now the
empty description is hitting the assert. This patch just adds a generic stop
description mentioning tsan to prevent that we hit that assert on platforms
where we don't support extracting the tsan report.

Reviewed By: friss

Differential Revision: https://reviews.llvm.org/D86593

(cherry picked from commit 1c5a0cb1c3bffdae0d73acf8a23e31646b35c596)