### PR TITLE
[lldb/Interpreter] Fix language detection for the REPL InitFile

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -2089,9 +2089,12 @@ static void GetHomeInitFile(llvm::SmallVectorImpl<char> &init_file,
   FileSystem::Instance().Resolve(init_file);
 }
 
-static void GetHomeREPLInitFile(llvm::SmallVectorImpl<char> &init_file,
-                                LanguageType language) {
-  if (language == LanguageType::eLanguageTypeUnknown)
+static void GetHomeREPLInitFile(llvm::SmallVectorImpl<char> &init_file) {
+  LanguageSet repl_languages = Language::GetLanguagesSupportingREPLs();
+  LanguageType language = eLanguageTypeUnknown;
+  if (auto main_repl_language = repl_languages.GetSingularLanguage())
+    language = *main_repl_language;
+  else
     return;
 
   std::string init_file_name =
@@ -2189,13 +2192,8 @@ void CommandInterpreter::SourceInitFileHome(CommandReturnObject &result,
 
   llvm::SmallString<128> init_file;
 
-  if (is_repl) {
-    LanguageType language = {};
-    TargetSP target_sp = GetDebugger().GetSelectedTarget();
-    if (target_sp)
-      language = target_sp->GetLanguage();
-    GetHomeREPLInitFile(init_file, language);
-  }
+  if (is_repl)
+    GetHomeREPLInitFile(init_file);
 
   if (init_file.empty())
     GetHomeInitFile(init_file);


### PR DESCRIPTION
Previously, before loading the REPL language-specific init file, lldb
checked the selected target language in which case it returned an unknown
language type with the REPL target.

Instead, the patch calls `Language::GetLanguagesSupportingREPLs` and
look for the first element of that set. In case lldb was not configured
with a REPL language, then, it will just stop sourcing the REPL init
file and fallback to the original logic (continuing with the default
init file).

rdar://65836048

Differential Revision: https://reviews.llvm.org/D87076

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>