### PR TITLE
[lldb] Provide GetHomeDirectory wrapper in Host::FileSystem (NFC)

### DIFF
--- a/lldb/include/lldb/Host/FileSystem.h
+++ b/lldb/include/lldb/Host/FileSystem.h
@@ -154,6 +154,10 @@ public:
   /// Call into the Host to see if it can help find the file.
   bool ResolveExecutableLocation(FileSpec &file_spec);
 
+  /// Get the user home directory.
+  bool GetHomeDirectory(llvm::SmallVectorImpl<char> &path) const;
+  bool GetHomeDirectory(FileSpec &file_spec) const;
+
   enum EnumerateDirectoryResult {
     /// Enumerate next entry in the current directory.
     eEnumerateDirectoryResultNext,

--- a/lldb/source/API/SBHostOS.cpp
+++ b/lldb/source/API/SBHostOS.cpp
@@ -91,14 +91,13 @@ SBFileSpec SBHostOS::GetUserHomeDirectory() {
   LLDB_RECORD_STATIC_METHOD_NO_ARGS(lldb::SBFileSpec, SBHostOS,
                                     GetUserHomeDirectory);
 
-  SBFileSpec sb_fspec;
-
-  llvm::SmallString<64> home_dir_path;
-  llvm::sys::path::home_directory(home_dir_path);
-  FileSpec homedir(home_dir_path.c_str());
+  FileSpec homedir;
+  FileSystem::Instance().GetHomeDirectory(homedir);
   FileSystem::Instance().Resolve(homedir);
 
+  SBFileSpec sb_fspec;
   sb_fspec.SetFileSpec(homedir);
+
   return LLDB_RECORD_RESULT(sb_fspec);
 }
 

--- a/lldb/source/Host/common/Editline.cpp
+++ b/lldb/source/Host/common/Editline.cpp
@@ -207,7 +207,7 @@ private:
     // Compute the history path lazily.
     if (m_path.empty() && m_history && !m_prefix.empty()) {
       llvm::SmallString<128> lldb_history_file;
-      llvm::sys::path::home_directory(lldb_history_file);
+      FileSystem::Instance().GetHomeDirectory(lldb_history_file);
       llvm::sys::path::append(lldb_history_file, ".lldb");
 
       // LLDB stores its history in ~/.lldb/. If for some reason this directory

--- a/lldb/source/Host/common/FileSystem.cpp
+++ b/lldb/source/Host/common/FileSystem.cpp
@@ -360,6 +360,18 @@ bool FileSystem::ResolveExecutableLocation(FileSpec &file_spec) {
   return true;
 }
 
+bool FileSystem::GetHomeDirectory(SmallVectorImpl<char> &path) const {
+  return llvm::sys::path::home_directory(path);
+}
+
+bool FileSystem::GetHomeDirectory(FileSpec &file_spec) const {
+  SmallString<128> home_dir;
+  if (!GetHomeDirectory(home_dir))
+    return false;
+  file_spec.SetPath(home_dir);
+  return true;
+}
+
 static int OpenWithFS(const FileSystem &fs, const char *path, int flags,
                       int mode) {
   return const_cast<FileSystem &>(fs).Open(path, flags, mode);

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -2083,7 +2083,7 @@ static void GetHomeInitFile(llvm::SmallVectorImpl<char> &init_file,
     init_file_name.append(suffix.str());
   }
 
-  llvm::sys::path::home_directory(init_file);
+  FileSystem::Instance().GetHomeDirectory(init_file);
   llvm::sys::path::append(init_file, init_file_name);
 
   FileSystem::Instance().Resolve(init_file);

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -85,7 +85,7 @@ PlatformProperties::PlatformProperties() {
     return;
 
   llvm::SmallString<64> user_home_dir;
-  if (!llvm::sys::path::home_directory(user_home_dir))
+  if (!FileSystem::Instance().GetHomeDirectory(user_home_dir))
     return;
 
   module_cache_dir = FileSpec(user_home_dir.c_str());


### PR DESCRIPTION
Provider a wrapper around llvm::sys::path::home_directory in the
FileSystem class. This will make it possible for the reproducers to
intercept the call in a central place.

(cherry picked from commit 921c1b7df37d6f5353ed5fdffa117dcda0c941ba)

Backported as a 040f52c098b846ab19c3516f2e7a44db5f2cd4d5 (which was backported) calls this function and otherwise the branch doesn't compile.