### PR TITLE
[IRGen] Fix an assert when __attribute__((used)) is used on an ObjC m…

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1961,7 +1961,7 @@ void CodeGenModule::SetFunctionAttributes(GlobalDecl GD, llvm::Function *F,
 }
 
 void CodeGenModule::addUsedGlobal(llvm::GlobalValue *GV) {
-  assert(!GV->isDeclaration() &&
+  assert((isa<llvm::Function>(GV) || !GV->isDeclaration()) &&
          "Only globals with definition can force usage.");
   LLVMUsed.emplace_back(GV);
 }

--- a/clang/test/CodeGenObjC/attr-used-on-method.m
+++ b/clang/test/CodeGenObjC/attr-used-on-method.m
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -triple x86_64-apple-macosx10.10 %s -S -emit-llvm -o - | FileCheck %s
+
+// CHECK: @llvm.used =
+// CHECK-SAME: @"\01-[X m]"
+
+// CHECK: define internal void @"\01-[X m]"(
+
+@interface X @end
+@implementation X
+-(void) m __attribute__((used)) {}
+@end


### PR DESCRIPTION
…ethod

This assert doesn't really make sense for functions in general, since they
start life as declarations, and there isn't really any reason to require them
to be defined before attributes are applied to them.

rdar://67895846