### PR TITLE
[SwiftASTContext] Deeply desugar types in GetTypeName

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5315,7 +5315,7 @@ ConstString SwiftASTContext::GetTypeName(opaque_compiler_type_t type) {
         swift_type.transform([](swift::Type type) -> swift::Type {
           if (swift::SyntaxSugarType *syntax_sugar_type =
                   swift::dyn_cast<swift::SyntaxSugarType>(type.getPointer())) {
-            return syntax_sugar_type->getSinglyDesugaredType();
+            return syntax_sugar_type->getDesugaredType();
           }
           if (swift::DictionaryType *dictionary_type =
                   swift::dyn_cast<swift::DictionaryType>(type.getPointer())) {


### PR DESCRIPTION
In `SwiftASTContext::GetTypeName`, change desugaring to be deep instead of shallow. This applies to `SyntaxSugarType` instances.

rdar://63652334