### PR TITLE
[TypeSystemSwiftTypeRef] Implement IsPointerOrReferenceType

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1759,9 +1759,8 @@ void TypeSystemSwiftTypeRef::DumpSummary(opaque_compiler_type_t type,
 bool TypeSystemSwiftTypeRef::IsPointerOrReferenceType(
     opaque_compiler_type_t type, CompilerType *pointee_type) {
   auto impl = [&]() {
-    return
-      IsPointerType(type, pointee_type) ||
-      IsReferenceType(type, pointee_type, nullptr);
+    return IsPointerType(type, pointee_type) ||
+           IsReferenceType(type, pointee_type, nullptr);
   };
   VALIDATE_AND_RETURN(impl, IsPointerOrReferenceType, type,
                       (ReconstructType(type), pointee_type));

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1758,8 +1758,13 @@ void TypeSystemSwiftTypeRef::DumpSummary(opaque_compiler_type_t type,
 }
 bool TypeSystemSwiftTypeRef::IsPointerOrReferenceType(
     opaque_compiler_type_t type, CompilerType *pointee_type) {
-  return m_swift_ast_context->IsPointerOrReferenceType(ReconstructType(type),
-                                                       pointee_type);
+  auto impl = [&]() {
+    return
+      IsPointerType(type, pointee_type) ||
+      IsReferenceType(type, pointee_type, nullptr);
+  };
+  VALIDATE_AND_RETURN(impl, IsPointerOrReferenceType, type,
+                      (ReconstructType(type), pointee_type));
 }
 llvm::Optional<size_t>
 TypeSystemSwiftTypeRef::GetTypeBitAlign(opaque_compiler_type_t type,

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -205,6 +205,7 @@ TEST_F(TestTypeSystemSwiftTypeRef, Pointer) {
                                         swift::BUILTIN_TYPE_NAME_RAWPOINTER));
     CompilerType p = GetCompilerType(b.Mangle(n));
     ASSERT_TRUE(p.IsPointerType(nullptr));
+    ASSERT_TRUE(p.IsPointerOrReferenceType(nullptr));
   }
   {
     NodePointer n =
@@ -212,18 +213,21 @@ TEST_F(TestTypeSystemSwiftTypeRef, Pointer) {
                             swift::BUILTIN_TYPE_NAME_UNSAFEVALUEBUFFER));
     CompilerType p = GetCompilerType(b.Mangle(n));
     ASSERT_TRUE(p.IsPointerType(nullptr));
+    ASSERT_TRUE(p.IsPointerOrReferenceType(nullptr));
   }
   {
     NodePointer n = b.GlobalType(b.Node(Node::Kind::BuiltinTypeName,
                                         swift::BUILTIN_TYPE_NAME_NATIVEOBJECT));
     CompilerType p = GetCompilerType(b.Mangle(n));
     ASSERT_TRUE(p.IsPointerType(nullptr));
+    ASSERT_TRUE(p.IsPointerOrReferenceType(nullptr));
   }
   {
     NodePointer n = b.GlobalType(b.Node(Node::Kind::BuiltinTypeName,
                                         swift::BUILTIN_TYPE_NAME_BRIDGEOBJECT));
     CompilerType p = GetCompilerType(b.Mangle(n));
     ASSERT_TRUE(p.IsPointerType(nullptr));
+    ASSERT_TRUE(p.IsPointerOrReferenceType(nullptr));
   }
 }
 
@@ -246,9 +250,11 @@ TEST_F(TestTypeSystemSwiftTypeRef, Reference) {
     NodePointer n = b.GlobalType(b.Node(Node::Kind::InOut, b.IntType()));
     CompilerType ref = GetCompilerType(b.Mangle(n));
     ASSERT_TRUE(ref.IsReferenceType(nullptr, nullptr));
+    ASSERT_TRUE(ref.IsPointerOrReferenceType(nullptr));
     CompilerType pointee;
     bool is_rvalue = true;
     ASSERT_TRUE(ref.IsReferenceType(&pointee, &is_rvalue));
+    ASSERT_TRUE(ref.IsPointerOrReferenceType(&pointee));
     NodePointer int_node = b.GlobalTypeMangling(b.IntType());
     CompilerType int_type = GetCompilerType(b.Mangle(int_node));
     ASSERT_EQ(int_type, pointee);


### PR DESCRIPTION
Implement `TypeSystemSwiftTypeRef::IsPointerOrReferenceType` in terms of `IsPointerType` and `IsReferenceType` which are already implemented.

This is a simple implementation but could have some negative performance for reference types, since `DemangleCanonicalType` will be called twice in that case. 

rdar://68171429