### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -129,7 +129,7 @@ endif()
 # BEGIN Swift Mods
 if(swift IN_LIST LLVM_EXTERNAL_PROJECTS)
   add_lldb_test_dependency(
-    swift
+    swift-frontend
     repl_swift)
 endif()
 # END Swift Mods


### PR DESCRIPTION
Fix dependency; the `swift` target is no longer created in the Swift build, it has been renamed to `swift-frontend`.