### PR TITLE
Create ${swig_target}-scripts target instead of lldb-python-scripts

### DIFF
--- a/lldb/CMakeLists.txt
+++ b/lldb/CMakeLists.txt
@@ -95,7 +95,7 @@ if (LLDB_ENABLE_PYTHON)
     set(lldb_python_target_dir "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${LLDB_PYTHON_RELATIVE_PATH}/lldb")
   endif()
   get_target_property(lldb_python_bindings_dir swig_wrapper_python BINARY_DIR)
-  finish_swig_python("finish_swig_python" "${lldb_python_bindings_dir}" "${lldb_python_target_dir}")
+  finish_swig_python("lldb-python" "${lldb_python_bindings_dir}" "${lldb_python_target_dir}")
 endif()
 
 option(LLDB_INCLUDE_TESTS "Generate build targets for the LLDB unit tests." ${LLVM_INCLUDE_TESTS})

--- a/lldb/bindings/python/CMakeLists.txt
+++ b/lldb/bindings/python/CMakeLists.txt
@@ -163,7 +163,7 @@ function(finish_swig_python swig_target lldb_python_bindings_dir lldb_python_tar
     string(REPLACE ${CMAKE_CFG_INTDIR} "\$\{CMAKE_INSTALL_CONFIG_NAME\}" LLDB_PYTHON_INSTALL_PATH ${LLDB_PYTHON_INSTALL_PATH})
     string(REPLACE ${CMAKE_CFG_INTDIR} "\$\{CMAKE_INSTALL_CONFIG_NAME\}" lldb_python_target_dir ${lldb_python_target_dir})
   endif()
-  set(python_scripts_target "lldb-python-scripts")
+  set(python_scripts_target "${swig_target}-scripts")
   set(python_scripts_install_target "install-${python_scripts_target}")
   add_custom_target(${python_scripts_target})
   add_dependencies(${python_scripts_target} ${swig_target})


### PR DESCRIPTION
This addresses the issue raised here https://reviews.llvm.org/rG02bf5632a94da6c3570df002804f8d3f79c11bfc
The `finish_swig_python` function might be called more than once so we need to create the distribution
component target based on the swig target.

Differential Revision: https://reviews.llvm.org/D86402

(cherry picked from commit 52381938bcc8547316d79a4721281da7f934d9b8)