### PR TITLE
Rename DoArchetypeBinding -> BindGenericTypeParameters (NFC)

### DIFF
--- a/lldb/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/lldb/include/lldb/Target/SwiftLanguageRuntime.h
@@ -234,7 +234,11 @@ public:
       const SymbolContext &sc,
       llvm::DenseMap<ArchetypePath, llvm::StringRef> &dict);
 
-  CompilerType DoArchetypeBindingForType(StackFrame &stack_frame,
+  /// Using the generic type parameters of \p stack_frame return a
+  /// version of \p base_type that replaces all generic type
+  /// parameters with bound generic types. If a generic type parameter
+  /// cannot be resolved, the input type is returned.
+  CompilerType BindGenericTypeParameters(StackFrame &stack_frame,
                                          CompilerType base_type);
 
   bool IsStoredInlineInBuffer(CompilerType type) override;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -506,9 +506,8 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
   auto *swift_runtime =
       SwiftLanguageRuntime::Get(stack_frame_sp->GetThread()->GetProcess());
   auto *stack_frame = stack_frame_sp.get();
-  imported_self_type =
-      swift_runtime->DoArchetypeBindingForType(*stack_frame,
-                                               imported_self_type);
+  imported_self_type = swift_runtime->BindGenericTypeParameters(
+      *stack_frame, imported_self_type);
 
   // This might be a referenced type, in which case we really want to
   // extend the referent:
@@ -636,7 +635,7 @@ static void AddVariableInfo(
   // Resolve all archetypes in the variable type.
   if (stack_frame_sp)
     if (language_runtime)
-      target_type = language_runtime->DoArchetypeBindingForType(*stack_frame_sp,
+      target_type = language_runtime->BindGenericTypeParameters(*stack_frame_sp,
                                                                 target_type);
 
   // If we couldn't fully realize the type, then we aren't going
@@ -970,7 +969,7 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
           auto *swift_runtime = SwiftLanguageRuntime::Get(
               stack_frame_sp->GetThread()->GetProcess());
           if (swift_runtime) {
-            actual_type = swift_runtime->DoArchetypeBindingForType(
+            actual_type = swift_runtime->BindGenericTypeParameters(
                 *stack_frame_sp, actual_type);
           }
         }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5184,8 +5184,8 @@ bool SwiftASTContext::IsGenericType(const CompilerType &compiler_type) {
   return false;
 }
 
-static CompilerType BindAllArchetypes(CompilerType type,
-                                      ExecutionContextScope *exe_scope) {
+static CompilerType
+BindGenericTypeParameters(CompilerType type, ExecutionContextScope *exe_scope) {
   if (!exe_scope)
     return type;
   auto *frame = exe_scope->CalculateStackFrame().get();
@@ -5194,7 +5194,7 @@ static CompilerType BindAllArchetypes(CompilerType type,
     return type;
   ExecutionContext exe_ctx;
   exe_scope->CalculateExecutionContext(exe_ctx);
-  if (auto bound = runtime->DoArchetypeBindingForType(*frame, type))
+  if (auto bound = runtime->BindGenericTypeParameters(*frame, type))
     return bound;
   return type;
 }
@@ -5928,7 +5928,7 @@ SwiftASTContext::GetBitSize(opaque_compiler_type_t type,
     ExecutionContext exe_ctx;
     exe_scope->CalculateExecutionContext(exe_ctx);
     auto swift_scratch_ctx_lock = SwiftASTContextLock(&exe_ctx);
-    CompilerType bound_type = BindAllArchetypes({this, type}, exe_scope);
+    CompilerType bound_type = BindGenericTypeParameters({this, type}, exe_scope);
 
     // Check that the type has been bound successfully -- and if not,
     // log the event and bail out to avoid an infinite loop.
@@ -5978,7 +5978,7 @@ SwiftASTContext::GetByteStride(opaque_compiler_type_t type,
     ExecutionContext exe_ctx;
     exe_scope->CalculateExecutionContext(exe_ctx);
     auto swift_scratch_ctx_lock = SwiftASTContextLock(&exe_ctx);
-    CompilerType bound_type = BindAllArchetypes({this, type}, exe_scope);
+    CompilerType bound_type = BindGenericTypeParameters({this, type}, exe_scope);
     // Note thay the bound type may be in a different AST context.
     return bound_type.GetByteStride(exe_scope);
   }
@@ -6011,7 +6011,7 @@ SwiftASTContext::GetTypeBitAlign(opaque_compiler_type_t type,
     ExecutionContext exe_ctx;
     exe_scope->CalculateExecutionContext(exe_ctx);
     auto swift_scratch_ctx_lock = SwiftASTContextLock(&exe_ctx);
-    CompilerType bound_type = BindAllArchetypes({this, type}, exe_scope);
+    CompilerType bound_type = BindGenericTypeParameters({this, type}, exe_scope);
     // Note thay the bound type may be in a different AST context.
     return bound_type.GetTypeBitAlign(exe_scope);
   }

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -247,7 +247,7 @@ public:
 
   void ReleaseAssociatedRemoteASTContext(swift::ASTContext *ctx) {}
 
-  CompilerType DoArchetypeBindingForType(StackFrame &stack_frame,
+  CompilerType BindGenericTypeParameters(StackFrame &stack_frame,
                                          CompilerType base_type) {
     STUB_LOG();
     return {};
@@ -757,7 +757,7 @@ static bool GetObjectDescription_ObjectCopy(SwiftLanguageRuntimeImpl *runtime,
       llvm::dyn_cast_or_null<TypeSystemSwift>(static_type.GetTypeSystem());
   if (swift_ast_ctx) {
     SwiftASTContextLock lock(GetSwiftExeCtx(object));
-    static_type = runtime->DoArchetypeBindingForType(*frame_sp, static_type);
+    static_type = runtime->BindGenericTypeParameters(*frame_sp, static_type);
   }
 
   auto stride = 0;
@@ -2097,9 +2097,9 @@ void SwiftLanguageRuntime::ReleaseAssociatedRemoteASTContext(
 }
 
 CompilerType
-SwiftLanguageRuntime::DoArchetypeBindingForType(StackFrame &stack_frame,
+SwiftLanguageRuntime::BindGenericTypeParameters(StackFrame &stack_frame,
                                                 CompilerType base_type) {
-  FORWARD(DoArchetypeBindingForType, stack_frame, base_type);
+  FORWARD(BindGenericTypeParameters, stack_frame, base_type);
 }
 
 CompilerType

--- a/lldb/source/Target/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Target/SwiftLanguageRuntimeImpl.h
@@ -99,11 +99,13 @@ public:
                                                    ConstString member_name,
                                                    Status *error);
 
-  CompilerType DoArchetypeBindingForTypeRef(StackFrame &stack_frame,
-                                            TypeSystemSwiftTypeRef &ts,
-                                            ConstString mangled_name);
+  /// Like \p BindGenericTypeParameters but for TypeSystemSwiftTypeRef.
+  CompilerType BindGenericTypeParameters(StackFrame &stack_frame,
+                                         TypeSystemSwiftTypeRef &ts,
+                                         ConstString mangled_name);
 
-  CompilerType DoArchetypeBindingForType(StackFrame &stack_frame,
+  /// \see SwiftLanguageRuntime::BindGenericTypeParameters().
+  CompilerType BindGenericTypeParameters(StackFrame &stack_frame,
                                          CompilerType base_type);
 
   CompilerType GetConcreteType(ExecutionContextScope *exe_scope,


### PR DESCRIPTION
When this function was introduced, it actually bound Archetypes, but
now the new name is a much more accurate and less confusing
description of what this function really does.