### PR TITLE
TypeSystem: repair the build on Windows

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -422,8 +422,8 @@ static swift::Demangle::NodePointer Desugar(swift::Demangle::Demangler &Dem,
 }
 
 /// Helper for \p GetSwiftName.
-static template <typename ContextInfo>
-std::string ExtractSwiftName(
+template <typename ContextInfo>
+static std::string ExtractSwiftName(
     clang::api_notes::APINotesReader::VersionedInfo<ContextInfo> info) {
   if (auto version = info.getSelected()) {
     ContextInfo context_info = info[*version].second;


### PR DESCRIPTION
The `static` attribute was in the wrong location and MSVC objected to it.  This repairs the windows builder.