### PR TITLE
[lldb] Fix latent compiler warnings

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -1001,10 +1001,10 @@ void PrintMatrix(Stream &stream,
                  int num_columns, int num_rows) {
   // Print each row.
   stream.Printf("\n[ ");
-  for (unsigned J = 0; J < num_rows; ++J) {
+  for (int J = 0; J < num_rows; ++J) {
     // Join the J-th row's elements with commas.
     std::vector<std::string> row;
-    for (unsigned I = 0; I < num_columns; ++I)
+    for (int I = 0; I < num_columns; ++I)
       row.emplace_back(std::move(matrix[I][J]));
     std::string joined = llvm::join(row, ", ");
 
@@ -1069,14 +1069,14 @@ bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
   ConstString full_type_name = simd_type.GetTypeName();
   llvm::StringRef type_name = full_type_name.GetStringRef();
   uint64_t num_elements = type_size / arg_size;
-  int generic_pos = type_name.find("<");
+  auto generic_pos = type_name.find("<");
   if (generic_pos != llvm::StringRef::npos)
     type_name = type_name.slice(0, generic_pos);
   if (type_name == "Swift.SIMD3")
     num_elements = 3;
 
   std::vector<std::string> elem_vector;
-  for (int i = 0; i < num_elements; ++i) {
+  for (uint64_t i = 0; i < num_elements; ++i) {
     DataExtractor elem_extractor(storage_buf, i * arg_size, arg_size);
     auto simd_elem = ValueObject::CreateValueObjectFromData(
         "simd_elem", elem_extractor, valobj.GetExecutionContextRef(), arg_type);

--- a/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
@@ -97,8 +97,6 @@ void lldb_private::formatters::swift::SwiftOptionSetSummaryProvider::
       return;
   }
 
-  SwiftASTContext *swift_ast_ctx =
-      llvm::dyn_cast_or_null<SwiftASTContext>(m_type.GetTypeSystem());
   auto iter = enum_decl->enumerator_begin(), end = enum_decl->enumerator_end();
   for (; iter != end; ++iter) {
     clang::EnumConstantDecl *case_decl = *iter;

--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
@@ -30,6 +30,8 @@ public:
   UnsafePointerKind GetKind() const { return m_kind; }
   virtual bool Update() = 0;
 
+  virtual ~SwiftUnsafeType() = default;
+
 protected:
   SwiftUnsafeType(ValueObject &valobj, UnsafePointerKind kind);
   addr_t GetAddress(llvm::StringRef child_name);
@@ -531,7 +533,7 @@ bool lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::Update() {
 
     for (size_t i = 0; i < num_children; i++) {
       StreamString idx_name;
-      idx_name.Printf("[%" PRIu64 "]", i);
+      idx_name.Printf("[%zu]", i);
       DataExtractor data(buffer_data, i * m_element_stride, m_element_stride);
       m_children.push_back(CreateValueObjectFromData(
           idx_name.GetString(), data, m_exe_ctx_ref, element_type));

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -394,7 +394,7 @@ private:
   std::shared_ptr<ObjectFileELF> GetGnuDebugDataObjectFile();
 
   llvm::StringRef
-  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section);
+  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section) override;
 };
 
 #endif // LLDB_SOURCE_PLUGINS_OBJECTFILE_ELF_OBJECTFILEELF_H

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
@@ -208,7 +208,7 @@ protected:
   bool SectionIsLoadable(const lldb_private::Section *section);
 
   llvm::StringRef
-  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section);
+  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section) override;
 
   llvm::MachO::mach_header m_header;
   static lldb_private::ConstString GetSegmentNameTEXT();

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
@@ -287,7 +287,7 @@ protected:
                                           const section_header_t &sect);
 
   llvm::StringRef
-  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section);
+  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section) override;
 
   typedef std::vector<section_header_t> SectionHeaderColl;
   typedef SectionHeaderColl::iterator SectionHeaderCollIter;

--- a/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
@@ -83,8 +83,8 @@ void ManualDWARFIndex::Index() {
   // done indexing to make sure we don't pull in all DWARF dies, but we need
   // to wait until all compile units have been indexed in case a DIE in one
   // compile unit refers to another and the indexes accesses those DIEs.
-  for (int i=0; i<units_to_index.size(); ++i)
-     extract_fn(i);
+  for (size_t i = 0; i < units_to_index.size(); ++i)
+    extract_fn(i);
   // This call can deadlock because we are sometimes holding the module lock.
   //  for (size_t i = 0; i < units_to_index.size(); ++i)
   //    pool.async(extract_fn, i);

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1262,8 +1262,6 @@ static const char *getImportFailureString(swift::serialization::Status status) {
   case swift::serialization::Status::TargetTooNew:
     return "The module file was built for a target newer than the current "
            "target.";
-  default:
-    return "An unknown error occurred.";
   }
 }
 
@@ -2976,8 +2974,6 @@ class SwiftDWARFImporterDelegate : public swift::DWARFImporterDelegate {
       // Not implemented since Objective-C protocols aren't yet
       // described in DWARF.
       return true;
-    default:
-      return true;
     }
   }
 
@@ -3192,7 +3188,7 @@ public:
         if (results.size())
           break;
       }
-      LOG_PRINTF(LIBLLDB_LOG_TYPES, "%d types collected.", results.size());
+      LOG_PRINTF(LIBLLDB_LOG_TYPES, "%zu types collected.", results.size());
       return;
     }
 
@@ -3223,7 +3219,7 @@ public:
       return true;
     });
 
-    LOG_PRINTF(LIBLLDB_LOG_TYPES, "%d types from debug info.", results.size());
+    LOG_PRINTF(LIBLLDB_LOG_TYPES, "%zu types from debug info.", results.size());
   }
 };
 } // namespace lldb_private
@@ -3552,8 +3548,7 @@ swift::ModuleDecl *SwiftASTContext::GetModule(const SourceModule &module,
   }
 
   if (!module_decl) {
-    LOG_PRINTF(LIBLLDB_LOG_TYPES, "failed with no error",
-               module.path.front().GetCString());
+    LOG_PRINTF(LIBLLDB_LOG_TYPES, "failed with no error");
 
     error.SetErrorStringWithFormat(
         "failed to get module \"%s\" from AST context",
@@ -6839,7 +6834,7 @@ static llvm::Optional<uint64_t> GetInstanceVariableOffset_Metadata(
   llvm::Optional<uint64_t> offset = runtime->GetMemberVariableOffset(
       type, valobj, ConstString(ivar_name), &error);
   if (offset)
-    LOG_PRINTF(LIBLLDB_LOG_TYPES, "for %s: %lu", ivar_name.str().c_str(),
+    LOG_PRINTF(LIBLLDB_LOG_TYPES, "for %s: %llu", ivar_name.str().c_str(),
                *offset);
   else
     LOG_PRINTF(LIBLLDB_LOG_TYPES, "resolver failure: %s", error.AsCString());
@@ -8139,10 +8134,16 @@ static void DescribeFileUnit(Stream &s, swift::FileUnit *file_unit) {
       switch (source_file->Kind) {
       case swift::SourceFileKind::Library:
         s.PutCString("Library");
+        break;
       case swift::SourceFileKind::Main:
         s.PutCString("Main");
+        break;
       case swift::SourceFileKind::SIL:
         s.PutCString("SIL");
+        break;
+      case swift::SourceFileKind::Interface:
+        s.PutCString("Interface");
+        break;
       }
     }
   } break;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -361,9 +361,10 @@ public:
   swift::ClangImporter *GetClangImporter();
   swift::DWARFImporterDelegate *GetDWARFImporterDelegate();
 
-  CompilerType CreateTupleType(const std::vector<TupleElement> &elements);
+  CompilerType
+  CreateTupleType(const std::vector<TupleElement> &elements) override;
 
-  CompilerType GetErrorType();
+  CompilerType GetErrorType() override;
 
   bool HasErrors();
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -116,6 +116,7 @@ public:
   };
   virtual CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) = 0;
+  using TypeSystem::DumpTypeDescription;
   virtual void DumpTypeDescription(
       lldb::opaque_compiler_type_t type, bool print_help_if_available,
       bool print_extensions_if_available,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -586,15 +586,16 @@ swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetNodeForPrintingImpl(
     NodePointer args_ty = Dem.createNode(Node::Kind::Type);
     NodePointer args_tuple = Dem.createNode(Node::Kind::Tuple);
     for (NodePointer child : *node) {
-      if (child->getKind() == Node::Kind::ImplParameter)
+      if (child->getKind() == Node::Kind::ImplParameter) {
         for (NodePointer type : *node)
           if (type->getKind() == Node::Kind::Type &&
               type->getNumChildren() == 1)
             rett->addChild(type->getChild(0), Dem);
-      else if (child->getKind() == Node::Kind::ImplResult)
+      } else if (child->getKind() == Node::Kind::ImplResult) {
         for (NodePointer type : *node)
           if (type->getKind() == Node::Kind::Type)
             rett->addChild(type, Dem);
+      }
     }
     args_ty->addChild(args_tuple, Dem);
     args->addChild(args_ty, Dem);
@@ -759,7 +760,6 @@ static uint32_t collectTypeInfo(Module *M, swift::Demangle::Demangler &Dem,
       // Bug-for-bug-compatibility. Not sure if this is correct.
       swift_flags |= eTypeIsPointer | eTypeHasValue;
       return swift_flags;
-      LLVM_FALLTHROUGH;
     case Node::Kind::BoundGenericFunction:
       swift_flags |= eTypeIsGeneric | eTypeIsBound;
       LLVM_FALLTHROUGH;
@@ -1792,7 +1792,7 @@ CompilerType TypeSystemSwiftTypeRef::GetAsClangTypeOrNull(
       node->getChild(1)->hasText()) {
     auto node_clangtype = ResolveTypeAlias(GetModule(), Dem, node,
                                            /*prefer_clang_types*/ true);
-    if (clang_type = node_clangtype.second)
+    if (clang_type == node_clangtype.second)
       return clang_type;
   }
   IsImportedType(type, &clang_type);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1779,7 +1779,6 @@ bool TypeSystemSwiftTypeRef::IsMeaninglessWithoutDynamicResolution(
 
 CompilerType TypeSystemSwiftTypeRef::GetAsClangTypeOrNull(
     lldb::opaque_compiler_type_t type) {
-  CompilerType clang_type;
   using namespace swift::Demangle;
   Demangler Dem;
   NodePointer node = GetDemangledType(Dem, AsMangledName(type));
@@ -1792,9 +1791,10 @@ CompilerType TypeSystemSwiftTypeRef::GetAsClangTypeOrNull(
       node->getChild(1)->hasText()) {
     auto node_clangtype = ResolveTypeAlias(GetModule(), Dem, node,
                                            /*prefer_clang_types*/ true);
-    if (clang_type == node_clangtype.second)
-      return clang_type;
+    if (node_clangtype.second)
+      return node_clangtype.second;
   }
+  CompilerType clang_type;
   IsImportedType(type, &clang_type);
   return clang_type;
 }

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -755,6 +755,7 @@ void llvm::format_provider<ObjectFile::Strata>::format(
 
 llvm::StringRef ObjectFile::GetReflectionSectionIdentifier(
     swift::ReflectionSectionKind section) {
-  assert("Base class's GetReflectionSectionIdentifier should not be called");
+  assert(false &&
+         "Base class's GetReflectionSectionIdentifier should not be called");
   return "";
 }

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -400,7 +400,7 @@ void SwiftLanguageRuntimeImpl::SetupExclusivity() {
   Log *log(GetLogIfAnyCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
   if (log)
     log->Printf(
-        "SwiftLanguageRuntime: _swift_disableExclusivityChecking = %lu",
+        "SwiftLanguageRuntime: _swift_disableExclusivityChecking = %llu",
         m_dynamic_exclusivity_flag_addr ? *m_dynamic_exclusivity_flag_addr : 0);
 }
 
@@ -575,6 +575,10 @@ static bool GetObjectDescription_ResultVariable(Process &process, Stream &str,
       log->Printf(
           "[GetObjectDescription_ResultVariable] eExpressionStoppedForDebug");
       break;
+    case eExpressionThreadVanished:
+      log->Printf(
+          "[GetObjectDescription_ResultVariable] eExpressionThreadVanished");
+      break;
     }
   }
 
@@ -681,6 +685,10 @@ static bool GetObjectDescription_ObjectReference(Process &process, Stream &str,
     case eExpressionStoppedForDebug:
       log->Printf(
           "[GetObjectDescription_ObjectReference] eExpressionStoppedForDebug");
+      break;
+    case eExpressionThreadVanished:
+      log->Printf(
+          "[GetObjectDescription_ObjectReference] eExpressionThreadVanished");
       break;
     }
   }
@@ -839,6 +847,10 @@ static bool GetObjectDescription_ObjectCopy(SwiftLanguageRuntimeImpl *runtime,
     case eExpressionStoppedForDebug:
       log->Printf(
           "[GetObjectDescription_ObjectCopy] eExpressionStoppedForDebug");
+      break;
+    case eExpressionThreadVanished:
+      log->Printf(
+          "[GetObjectDescription_ObjectCopy] eExpressionThreadVanished");
       break;
     }
   }

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -949,7 +949,7 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Class(
   auto metadata_address = remote_ast.getHeapMetadataForObject(instance_address);
   if (!metadata_address) {
     if (log) {
-      log->Printf("could not read heap metadata for object at %lu: %s\n",
+      log->Printf("could not read heap metadata for object at %llu: %s\n",
                   class_metadata_ptr,
                   metadata_address.getFailure().render().c_str());
     }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2211,7 +2211,7 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
   auto type_system_or_err = m_scratch_type_system_map.GetTypeSystemForLanguage(
       language, this, create_on_demand, compiler_options);
   if (!type_system_or_err)
-    return std::move(type_system_or_err.takeError());
+    return type_system_or_err.takeError();
 
 #ifdef LLDB_ENABLE_SWIFT
   if (language == eLanguageTypeSwift) {
@@ -2249,7 +2249,7 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
           type_system_or_err = m_scratch_type_system_map.GetTypeSystemForLanguage(
               language, this, create_on_demand, compiler_options);
           if (!type_system_or_err)
-            return std::move(type_system_or_err.takeError());
+            return type_system_or_err.takeError();
 
           if (auto *new_swift_ast_ctx =
                   llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(

--- a/lldb/source/Target/ThreadPlanCallFunction.cpp
+++ b/lldb/source/Target/ThreadPlanCallFunction.cpp
@@ -496,8 +496,8 @@ bool ThreadPlanCallFunction::BreakpointsExplainStop() {
 #ifdef LLDB_ENABLE_SWIFT
       ConstString persistent_variable_name(
           persistent_state->GetNextPersistentVariableName(/*is_error*/ true));
-      if (m_return_valobj_sp = SwiftLanguageRuntime::CalculateErrorValue(
-              frame_sp, persistent_variable_name)) {
+      if ((m_return_valobj_sp = SwiftLanguageRuntime::CalculateErrorValue(
+               frame_sp, persistent_variable_name))) {
 
         DataExtractor data;
         Status data_error;


### PR DESCRIPTION
This fixes warnings identified using the `LLVM_ENABLE_WARNINGS` fix in https://reviews.llvm.org/D87243.

This is a follow up to the removal of unused code in https://github.com/apple/llvm-project/pull/1749.