### PR TITLE
add support for python 3.8 lldb build

### DIFF
--- a/lldb/cmake/modules/FindPythonInterpAndLibs.cmake
+++ b/lldb/cmake/modules/FindPythonInterpAndLibs.cmake
@@ -80,7 +80,7 @@ else()
     else()
       # SWIFT_ENABLE_TENSORFLOW
       # Make it so that LLDB can find Python 3.6+
-      set(Python_ADDITIONAL_VERSIONS 3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0 2.7 2.6 2.5)
+      set(Python_ADDITIONAL_VERSIONS 3.8 3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0 2.7 2.6 2.5)
 
       find_package(PythonInterp QUIET)
       find_package(PythonLibs QUIET)


### PR DESCRIPTION
Ubuntu 20.04 has python 3.8, so we need LLDB to compile with python 3.8 for swift-jupyter to work on Ubuntu 20.04.