### PR TITLE
[lldb/API] Add Breakpoint::SerializeToStructuredData to SBAPI

### DIFF
--- a/lldb/bindings/interface/SBBreakpoint.i
+++ b/lldb/bindings/interface/SBBreakpoint.i
@@ -234,6 +234,8 @@ public:
     SBError
     AddLocation(SBAddress &address);
 
+    SBStructuredData SBBreakpoint::SerializeToStructuredData();
+
     static bool
     EventIsBreakpointEvent (const lldb::SBEvent &event);
 

--- a/lldb/include/lldb/API/SBBreakpoint.h
+++ b/lldb/include/lldb/API/SBBreakpoint.h
@@ -140,7 +140,9 @@ public:
   // Can only be called from a ScriptedBreakpointResolver...
   SBError
   AddLocation(SBAddress &address);
-  
+
+  SBStructuredData SerializeToStructuredData();
+
 private:
   friend class SBBreakpointList;
   friend class SBBreakpointLocation;

--- a/lldb/source/API/SBBreakpoint.cpp
+++ b/lldb/source/API/SBBreakpoint.cpp
@@ -575,7 +575,22 @@ SBError SBBreakpoint::AddLocation(SBAddress &address) {
   return LLDB_RECORD_RESULT(error);
 }
 
-void SBBreakpoint ::SetCallback(SBBreakpointHitCallback callback, void *baton) {
+SBStructuredData SBBreakpoint::SerializeToStructuredData() {
+  LLDB_RECORD_METHOD_NO_ARGS(lldb::SBStructuredData, SBBreakpoint,
+                             SerializeToStructuredData);
+
+  SBStructuredData data;
+  BreakpointSP bkpt_sp = GetSP();
+
+  if (!bkpt_sp)
+    return LLDB_RECORD_RESULT(data);
+
+  StructuredData::ObjectSP bkpt_dict = bkpt_sp->SerializeToStructuredData();
+  data.m_impl_up->SetObjectSP(bkpt_dict);
+  return LLDB_RECORD_RESULT(data);
+}
+
+void SBBreakpoint::SetCallback(SBBreakpointHitCallback callback, void *baton) {
   LLDB_RECORD_DUMMY(void, SBBreakpoint, SetCallback,
                     (lldb::SBBreakpointHitCallback, void *), callback, baton);
 
@@ -1017,6 +1032,8 @@ void RegisterMethods<SBBreakpoint>(Registry &R) {
                        (lldb::SBStream &, bool));
   LLDB_REGISTER_METHOD(lldb::SBError, SBBreakpoint, AddLocation,
                        (lldb::SBAddress &));
+  LLDB_REGISTER_METHOD(lldb::SBStructuredData, SBBreakpoint,
+                       SerializeToStructuredData, ());
   LLDB_REGISTER_METHOD(void, SBBreakpoint, SetScriptCallbackFunction,
                        (const char *));
   LLDB_REGISTER_METHOD(lldb::SBError, SBBreakpoint, SetScriptCallbackFunction,


### PR DESCRIPTION
This patch adds a way to fetch breakpoint metadatas as a serialized
`Structured` Data format (JSON). This can be used by IDEs to update
their UI when a breakpoint is set or modified from the console.

rdar://11013798

Differential Revision: https://reviews.llvm.org/D87491

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>