### PR TITLE
Sema: add support for `__attribute__((__swift_objc_members__))`

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2158,12 +2158,6 @@ def SwiftBridgedTypedef : Attr {
   let Documentation = [SwiftBridgedTypedefDocs];
 }
 
-def SwiftObjCMembers : Attr {
-  let Spellings = [GNU<"swift_objc_members">];
-  let Subjects = SubjectList<[ObjCInterface], ErrorDiag>;
-  let Documentation = [SwiftObjCMembersDocs];
-}
-
 def SwiftName : InheritableAttr {
   let Spellings = [GCC<"swift_name">];
   let Args = [StringArgument<"Name">];
@@ -2227,6 +2221,12 @@ def SwiftVersionedRemoval : Attr {
       return static_cast<attr::Kind>(getRawKind());
     }
   }];
+}
+
+def SwiftObjCMembers : Attr {
+  let Spellings = [GNU<"swift_objc_members">];
+  let Subjects = SubjectList<[ObjCInterface], ErrorDiag>;
+  let Documentation = [SwiftObjCMembersDocs];
 }
 
 def SwiftError : InheritableAttr {

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -3635,6 +3635,16 @@ Swift.
   }];
 }
 
+def SwiftObjCMembersDocs : Documentation {
+  let Category = SwiftDocs;
+  let Heading = "swift_objc_members";
+  let Content = [{
+This attribute indicates that Swift subclasses and members of Swift extensions
+of this class will be implicitly marked with the ``@objcMembers`` Swift
+attribute, exposing them back to Objective-C.
+  }];
+}
+
 def SwiftErrorDocs : Documentation {
   let Category = SwiftDocs;
   let Heading = "swift_error";
@@ -3721,13 +3731,6 @@ def SwiftBridgedTypedefDocs : Documentation {
   let Category = SwiftDocs;
   let Content = [{
 The ``swift_bridged_typedef`` attribute indicates that, when the typedef to which the attribute appertains is imported into Swift, it should refer to the bridged Swift type (e.g., Swift's ``String``) rather than the Objective-C type as written (e.g., ``NSString``).
-  }];
-}
-
-def SwiftObjCMembersDocs : Documentation {
-  let Category = SwiftDocs;
-  let Content = [{
-The ``swift_objc_members`` attribute maps to the Swift ``@objcMembers`` attribute, which indicates that Swift members of this class, its subclasses, and all of the extensions thereof, will implicitly be exposed back to Objective-C.
   }];
 }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -7876,9 +7876,6 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case ParsedAttr::AT_SwiftBridgedTypedef:
     handleSimpleAttribute<SwiftBridgedTypedefAttr>(S, D, AL);
     break;
-  case ParsedAttr::AT_SwiftObjCMembers:
-    handleSimpleAttribute<SwiftObjCMembersAttr>(S, D, AL);
-    break;
   case ParsedAttr::AT_SwiftNewtype:
     handleSwiftNewtypeAttr(S, D, AL);
     break;
@@ -7886,6 +7883,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   // Swift attributes.
   case ParsedAttr::AT_SwiftError:
     handleSwiftError(S, D, AL);
+    break;
+  case ParsedAttr::AT_SwiftObjCMembers:
+    handleSimpleAttribute<SwiftObjCMembersAttr>(S, D, AL);
     break;
 
   // XRay attributes.

--- a/clang/test/SemaObjC/attr-swift_objc_members.m
+++ b/clang/test/SemaObjC/attr-swift_objc_members.m
@@ -1,17 +1,24 @@
 // RUN: %clang_cc1 -verify -fsyntax-only %s
 
 #if !__has_attribute(swift_objc_members)
-#  error Cannot query presence of swift_objc_members attribute.
+#error cannot verify presence of swift_objc_members attribute
 #endif
 
-__attribute__((swift_objc_members))
-__attribute__((objc_root_class))
-@interface A
+__attribute__((__swift_objc_members__))
+__attribute__((__objc_root_class__))
+@interface I
 @end
 
-__attribute__((swift_objc_members)) // expected-error{{'swift_objc_members' attribute only applies to Objective-C interfaces}}
+__attribute__((swift_objc_members))
 @protocol P
 @end
+// expected-error@-3 {{'swift_objc_members' attribute only applies to Objective-C interfaces}}
 
-__attribute__((swift_objc_members)) // expected-error{{'swift_objc_members' attribute only applies to Objective-C interfaces}}
-extern void foo(void);
+__attribute__((swift_objc_members))
+extern void f(void);
+// expected-error@-2 {{'swift_objc_members' attribute only applies to Objective-C interfaces}}
+
+// expected-error@+1 {{'__swift_objc_members__' attribute takes no arguments}}
+__attribute__((__swift_objc_members__("J")))
+@interface J
+@end


### PR DESCRIPTION
This adds the `__swift_objc_members__` attribute to the semantic
analysis.  It allows for annotating ObjC interfaces to provide Swift
semantics indicating that the types derived from this interface will be
back-bridged to Objective-C to allow interoperability with Objective-C
and Swift.

This is based on the work of the original changes in
https://github.com/llvm/llvm-project-staging/commit/8afaf3aad2af43cfedca7a24cd817848c4e95c0c