### PR TITLE
Clang Driver: Use Apple ld64's new @response-file support.

### DIFF
--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -196,6 +196,9 @@ public:
 
   // Accessors
 
+  /// Temporary for Darwin::Linker
+  const llvm::opt::ArgList &getArgs_DO_NOT_USE() const { return Args; }
+
   const Driver &getDriver() const { return D; }
   llvm::vfs::FileSystem &getVFS() const;
   const llvm::Triple &getTriple() const { return Triple; }

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -937,7 +937,22 @@ Tool *MachO::getTool(Action::ActionClass AC) const {
   }
 }
 
-Tool *MachO::buildLinker() const { return new tools::darwin::Linker(*this); }
+Tool *MachO::buildLinker() const {
+  // Determine whether to use an @responsefile or the old -filelist mechanism.
+  bool UseAtFile = false;
+  unsigned Version[5] = {0, 0, 0, 0, 0};
+  if (Arg *A =
+          getArgs_DO_NOT_USE().getLastArg(options::OPT_mlinker_version_EQ)) {
+    // We don't need to diagnose a parse error here, it'll be caught in
+    // ConstructJob.
+    if (Driver::GetReleaseVersion(A->getValue(), Version)) {
+      if (Version[0] >= 607)
+        UseAtFile = true;
+    }
+  }
+
+  return new tools::darwin::Linker(*this, UseAtFile);
+}
 
 Tool *MachO::buildAssembler() const {
   return new tools::darwin::Assembler(*this);

--- a/clang/lib/Driver/ToolChains/Darwin.h
+++ b/clang/lib/Driver/ToolChains/Darwin.h
@@ -69,9 +69,10 @@ class LLVM_LIBRARY_VISIBILITY Linker : public MachOTool {
                    const InputInfoList &Inputs) const;
 
 public:
-  Linker(const ToolChain &TC)
-      : MachOTool("darwin::Linker", "linker", TC, RF_FileList,
-                  llvm::sys::WEM_UTF8, "-filelist") {}
+  Linker(const ToolChain &TC, bool UseAtFile)
+      : MachOTool("darwin::Linker", "linker", TC,
+                  UseAtFile ? RF_Full : RF_FileList, llvm::sys::WEM_UTF8,
+                  UseAtFile ? "@" : "-filelist") {}
 
   bool hasIntegratedCPP() const override { return false; }
   bool isLinkJob() const override { return true; }


### PR DESCRIPTION
In XCode 12, ld64 got support for @files, in addition to the old
-filelist mechanism. Response files allow passing all command-line
arguments to the linker via a file, rather than just filenames, and is
therefore preferred.

Because of the way response-file support is currently implemented as
part of the Tool class in Clang, this change requires an ugly backdoor
function to access Args. A follow-up commit fixes this, but I've
ordered this change first, for easier backportability.

I've added no tests here, because unfortunately, there don't appear to
be _any_ response-file emission automated tests, and I don't see an
obvious way to add them. I've tested that this change works as
expected locally.

Differential Revision: https://reviews.llvm.org/D82777

(cherry picked from commit 381df1653c927efa9dac86c24a9db2b98f270de0)