### PR TITLE
Sema: add support for `__attribute__((__swift_bridged_typedef__))`

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2151,13 +2151,6 @@ def SwiftBridge : Attr {
   let Documentation = [SwiftBridgeDocs];
 }
 
-def SwiftBridgedTypedef : Attr {
-  let Spellings = [GNU<"swift_bridged_typedef">];
-  let Subjects = SubjectList<[TypedefName], ErrorDiag, "typedefs">;
-  let Args = [];
-  let Documentation = [SwiftBridgedTypedefDocs];
-}
-
 def SwiftName : InheritableAttr {
   let Spellings = [GCC<"swift_name">];
   let Args = [StringArgument<"Name">];
@@ -2221,6 +2214,12 @@ def SwiftVersionedRemoval : Attr {
       return static_cast<attr::Kind>(getRawKind());
     }
   }];
+}
+
+def SwiftBridgedTypedef : InheritableAttr {
+  let Spellings = [GNU<"swift_bridged_typedef">];
+  let Subjects = SubjectList<[TypedefName], ErrorDiag>;
+  let Documentation = [SwiftBridgedTypedefDocs];
 }
 
 def SwiftObjCMembers : Attr {

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -3635,6 +3635,27 @@ Swift.
   }];
 }
 
+def SwiftBridgedTypedefDocs : Documentation {
+  let Category = SwiftDocs;
+  let Heading = "swift_bridged";
+  let Content = [{
+The ``swift_bridged_typedef`` attribute indicates that when the typedef to which
+the attribute appertains is imported into Swift, it should refer to the bridged
+Swift type (e.g. Swift's ``String``) rather than the Objective-C type as written
+(e.g. ``NSString``).
+
+  .. code-block:: c
+
+    @interface NSString;
+    typedef NSString *AliasedString __attribute__((__swift_bridged_typedef__));
+
+    extern void acceptsAliasedString(AliasedString _Nonnull parameter);
+
+In this case, the function ``acceptsAliasedString`` will be imported into Swift
+as a function which accepts a ``String`` type parameter.
+  }];
+}
+
 def SwiftObjCMembersDocs : Documentation {
   let Category = SwiftDocs;
   let Heading = "swift_objc_members";
@@ -3725,13 +3746,6 @@ def SwiftBridgeDocs : Documentation {
   let Category = SwiftDocs;
   let Content = [{
 The ``swift_bridge`` attribute indicates that the type to which the attribute appertains is bridged to the named Swift type. 
-  }];
-}
-
-def SwiftBridgedTypedefDocs : Documentation {
-  let Category = SwiftDocs;
-  let Content = [{
-The ``swift_bridged_typedef`` attribute indicates that, when the typedef to which the attribute appertains is imported into Swift, it should refer to the bridged Swift type (e.g., Swift's ``String``) rather than the Objective-C type as written (e.g., ``NSString``).
   }];
 }
 

--- a/clang/test/AST/attr-swift_bridged_typedef.m
+++ b/clang/test/AST/attr-swift_bridged_typedef.m
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -fsyntax-only -ast-dump %s | FileCheck %s
+
+typedef struct T TBridged __attribute((__swift_bridged_typedef__));
+// CHECK: TypedefDecl {{.*}} TBridged 'struct T'
+// CHECK: SwiftBridgedTypedefAttr
+
+typedef struct T TBridged;
+// CHECK: TypedefDecl {{.*}} TBridged 'struct T'
+// CHECK: SwiftBridgedTypedefAttr

--- a/clang/test/AST/attr-swift_bridged_typedef.mm
+++ b/clang/test/AST/attr-swift_bridged_typedef.mm
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -fsyntax-only %s -ast-dump | FileCheck %s
+
+@interface NSString
+@end
+
+using NSStringAlias __attribute__((__swift_bridged_typedef__)) = NSString *;
+// CHECK: TypeAliasDecl {{.*}} NSStringAlias 'NSString *'
+// CHECK: SwiftBridgedTypedefAttr

--- a/clang/test/SemaObjC/attr-swift.m
+++ b/clang/test/SemaObjC/attr-swift.m
@@ -155,11 +155,3 @@ void badSetter1(void) __attribute__((swift_name("getter:bad1())"))); // expected
 Point3D badGetter2(Point3D point) __attribute__((swift_name("getter:bad2(_:))"))); // expected-warning{{parameter of 'swift_name' attribute must be a Swift function name string}}
 
 void badSetter2(Point3D point) __attribute__((swift_name("setter:bad2(self:))"))); // expected-warning{{parameter of 'swift_name' attribute must be a Swift function name string}}
-
-// --- swift_bridged_typedef ---
-@interface NSString
-@end
-
-typedef NSString *NSMyAmazingStringAlias __attribute__((swift_bridged_typedef));
-
-struct __attribute__((swift_bridged_typedef)) NotATypedef { }; // expected-error{{'swift_bridged_typedef' attribute only applies to typedefs}}

--- a/clang/test/SemaObjC/attr-swift_bridged_typedef.m
+++ b/clang/test/SemaObjC/attr-swift_bridged_typedef.m
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -verify -fsyntax-only %s
+
+@interface NSString
+@end
+
+typedef NSString *NSStringAlias __attribute__((__swift_bridged_typedef__));
+
+typedef int IntAlias __attribute__((__swift_bridged_typedef__));
+
+struct __attribute__((swift_bridged_typedef)) S {};
+// expected-error@-1 {{'swift_bridged_typedef' attribute only applies to typedefs}}
+
+typedef unsigned char UnsignedChar __attribute__((__swift_bridged_typedef__("UnsignedChar")));
+// expected-error@-1 {{'__swift_bridged_typedef__' attribute takes no arguments}}


### PR DESCRIPTION
Extend the semantic attributes that clang processes for Swift to include
`swift_bridged_typedef`.  This attribute enables typedefs to be bridged
into Swift with a bridged name.

This is based on the work of the original changes in
https://github.com/llvm/llvm-project-staging/commit/8afaf3aad2af43cfedca7a24cd817848c4e95c0c