### PR TITLE
[TypeSystemSwiftTypeRef] Implement GetErrorType

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1823,24 +1823,28 @@ CompilerType TypeSystemSwiftTypeRef::GetErrorType() {
   auto impl = [&]() {
     using namespace swift::Demangle;
     Demangler Dem;
-    llvm::ArrayRef<NodePointer> nodes = {
-        Dem.createNode(Node::Kind::Type),
-        Dem.createNode(Node::Kind::ProtocolList),
-        Dem.createNode(Node::Kind::TypeList),
-        Dem.createNode(Node::Kind::Type),
-        Dem.createNode(Node::Kind::Protocol),
-    };
-    for (int i = 1; i < nodes.size(); ++i)
-      nodes[i - 1]->addChild(nodes[i], Dem);
+    auto *error_type = Dem.createNode(Node::Kind::Type);
+    auto *parent = error_type;
+    NodePointer node;
+    node = Dem.createNode(Node::Kind::ProtocolList);
+    parent->addChild(node, Dem);
+    parent = node;
+    node = Dem.createNode(Node::Kind::TypeList);
+    parent->addChild(node, Dem);
+    parent = node;
+    node = Dem.createNode(Node::Kind::Type);
+    parent->addChild(node, Dem);
+    parent = node;
+    node = Dem.createNode(Node::Kind::Protocol);
+    parent->addChild(node, Dem);
+    parent = node;
 
-    auto *error_type = nodes.back();
-    auto *module =
-        Dem.createNodeWithAllocatedText(Node::Kind::Module, swift::STDLIB_NAME);
-    auto *identifier =
-        Dem.createNodeWithAllocatedText(Node::Kind::Identifier, "Error");
-    error_type->addChild(module, Dem);
-    error_type->addChild(identifier, Dem);
-    return RemangleAsType(Dem, nodes[0]);
+    parent->addChild(
+        Dem.createNodeWithAllocatedText(Node::Kind::Module, swift::STDLIB_NAME),
+        Dem);
+    parent->addChild(Dem.createNode(Node::Kind::Identifier, "Error"), Dem);
+
+    return RemangleAsType(Dem, error_type);
   };
   VALIDATE_AND_RETURN_STATIC(impl, GetErrorType);
 }

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -438,6 +438,10 @@ TEST_F(TestTypeSystemSwiftTypeRef, TypeClass) {
   }
 }
 
+TEST_F(TestTypeSystemSwiftTypeRef, MangledTypeName) {
+  ASSERT_EQ(m_swift_ts.GetErrorType().GetMangledTypeName(), "$ss5Error_pD");
+}
+
 TEST_F(TestTypeSystemSwiftTypeRef, ImportedType) {
   using namespace swift::Demangle;
   Demangler dem;


### PR DESCRIPTION
Implement `TypeSystemSwiftTypeRef::GetErrorType` by constructing in code the following demangle node tree:

```
kind=Type
  kind=ProtocolList
    kind=TypeList
      kind=Type
        kind=Protocol
          kind=Module, text="Swift"
          kind=Identifier, text="Error"
```

This construction is then passed through `RemangleAsType`.

rdar://68171395