### PR TITLE
[TypeSystemSwiftTypeRef] Implement GetPointerType

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -136,6 +136,7 @@ public:
   GetMemberFunctionAtIndex(lldb::opaque_compiler_type_t type,
                            size_t idx) override;
   CompilerType GetPointeeType(lldb::opaque_compiler_type_t type) override;
+  /// Predicate for BuiltinRawPointer. Other types result in an invalid type.
   CompilerType GetPointerType(lldb::opaque_compiler_type_t type) override;
 
   // Exploring the type


### PR DESCRIPTION
Implement `GetPointerType` by matching the implementation of  [`SwiftASTContext::GetPointerType`](https://github.com/apple/llvm-project/blob/8cc39e1ced992440136e661dc22fb40eb4a91d36/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp#L5871-L5881).

rdar://68171356