### PR TITLE
Sema: add support for `__attribute__((__swift_bridge__))`

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2143,14 +2143,6 @@ def Regparm : TypeAttr {
   let ASTNode = 0;
 }
 
-def SwiftBridge : Attr {
-  let Spellings = [GNU<"swift_bridge">];
-  let Subjects = SubjectList<[Tag, TypedefName, ObjCInterface, ObjCProtocol],
-                             ErrorDiag, "ExpectedType">;
-  let Args = [StringArgument<"SwiftType">];
-  let Documentation = [SwiftBridgeDocs];
-}
-
 def SwiftName : InheritableAttr {
   let Spellings = [GCC<"swift_name">];
   let Args = [StringArgument<"Name">];
@@ -2214,6 +2206,14 @@ def SwiftVersionedRemoval : Attr {
       return static_cast<attr::Kind>(getRawKind());
     }
   }];
+}
+
+def SwiftBridge : InheritableAttr {
+  let Spellings = [GNU<"swift_bridge">];
+  let Args = [StringArgument<"SwiftType">];
+  let Subjects = SubjectList<[Tag, TypedefName, ObjCInterface, ObjCProtocol],
+                             ErrorDiag>;
+  let Documentation = [SwiftBridgeDocs];
 }
 
 def SwiftBridgedTypedef : InheritableAttr {

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -3635,6 +3635,30 @@ Swift.
   }];
 }
 
+def SwiftBridgeDocs : Documentation {
+  let Category = SwiftDocs;
+  let Heading = "swift_bridge";
+  let Content = [{
+The ``swift_bridge`` attribute indicates that the declaration to which the
+attribute appertains is bridged to the named Swift type.
+
+  .. code-block:: c
+
+    __attribute__((__objc_root__))
+    @interface Base
+    - (instancetype)init;
+    @end
+
+    __attribute__((__swift_bridge__("BridgedI")))
+    @interface I : Base
+    @end
+
+In this example, the Objective-C interface ``I`` will be made available to Swift
+with the name ``BridgedI``.  It would be possible for the compiler to refer to
+``I`` still in order to bridge the type back to Objective-C.
+  }];
+}
+
 def SwiftBridgedTypedefDocs : Documentation {
   let Category = SwiftDocs;
   let Heading = "swift_bridged";
@@ -3739,13 +3763,6 @@ where clause is one of the following:
     inbranch
     notinbranch
 
-  }];
-}
-
-def SwiftBridgeDocs : Documentation {
-  let Category = SwiftDocs;
-  let Content = [{
-The ``swift_bridge`` attribute indicates that the type to which the attribute appertains is bridged to the named Swift type. 
   }];
 }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5799,20 +5799,20 @@ static void handleSwiftName(Sema &S, Decl *D, const ParsedAttr &Attr) {
   D->addAttr(::new (S.Context) SwiftNameAttr(S.Context, Attr, Name));
 }
 
-static void handleSwiftBridgeAttr(Sema &S, Decl *D, const ParsedAttr &Attr) {
+static void handleSwiftBridge(Sema &S, Decl *D, const ParsedAttr &AL) {
   // Make sure that there is a string literal as the annotation's single
   // argument.
-  StringRef Str;
-  if (!S.checkStringLiteralArgumentAttr(Attr, 0, Str))
+  StringRef BT;
+  if (!S.checkStringLiteralArgumentAttr(AL, 0, BT))
     return;
 
   // Don't duplicate annotations that are already set.
   if (D->hasAttr<SwiftBridgeAttr>()) {
-    S.Diag(Attr.getLoc(), diag::warn_duplicate_attribute) << Attr.getAttrName();
+    S.Diag(AL.getLoc(), diag::warn_duplicate_attribute) << AL;
     return;
   }
 
-  D->addAttr(::new (S.Context) SwiftBridgeAttr(S.Context, Attr, Str));
+  D->addAttr(::new (S.Context) SwiftBridgeAttr(S.Context, AL, BT));
 }
 
 static void handleSwiftNewtypeAttr(Sema &S, Decl *D, const ParsedAttr &Attr) {
@@ -7871,7 +7871,7 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
     handleSwiftName(S, D, AL);
     break;
   case ParsedAttr::AT_SwiftBridge:
-    handleSwiftBridgeAttr(S, D, AL);
+    handleSwiftBridge(S, D, AL);
     break;
   case ParsedAttr::AT_SwiftBridgedTypedef:
     handleSimpleAttribute<SwiftBridgedTypedefAttr>(S, D, AL);

--- a/clang/test/AST/attr-swift_bridge.m
+++ b/clang/test/AST/attr-swift_bridge.m
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -fsyntax-only -ast-dump %s | FileCheck %s
+
+struct __attribute__((__swift_bridge__("BridgedS"))) S;
+// CHECK: RecordDecl {{.*}} struct S
+// CHECK: SwiftBridgeAttr {{.*}} "BridgedS"
+
+struct S {
+};
+
+// CHECK: RecordDecl {{.*}} struct S definition
+// CHECK: SwiftBridgeAttr {{.*}} Inherited "BridgedS"

--- a/clang/test/SemaObjC/attr-swift_bridge.m
+++ b/clang/test/SemaObjC/attr-swift_bridge.m
@@ -1,0 +1,33 @@
+// RUN: %clang_cc1 -verify -fsyntax-only %s
+
+// expected-error@+1 {{'__swift_bridge__' attribute takes one argument}}
+__attribute__((__swift_bridge__))
+@interface I
+@end
+
+// expected-error@+1 {{'__swift_bridge__' attribute requires a string}}
+__attribute__((__swift_bridge__(1)))
+@interface J
+@end
+
+// expected-error@+1 {{'__swift_bridge__' attribute takes one argument}}
+__attribute__((__swift_bridge__("K", 1)))
+@interface K
+@end
+
+@interface L
+// expected-error@+1 {{'__swift_bridge__' attribute only applies to tag types, typedefs, Objective-C interfaces, and Objective-C protocols}}
+- (void)method __attribute__((__swift_bridge__("method")));
+@end
+
+__attribute__((__swift_bridge__("Array")))
+@interface NSArray
+@end
+
+__attribute__((__swift_bridge__("ProtocolP")))
+@protocol P
+@end
+
+typedef NSArray *NSArrayAlias __attribute__((__swift_bridge__("ArrayAlias")));
+
+struct __attribute__((__swift_bridge__("StructT"))) T {};


### PR DESCRIPTION
This extends semantic analysis of attributes for Swift interoperability
by introducing the `swift_bridge` attribute.  This attribute enables
bridging Objective-C types to Swift specific types.

This is based on the work of the original changes in
https://github.com/llvm/llvm-project-staging/commit/8afaf3aad2af43cfedca7a24cd817848c4e95c0c