### PR TITLE
Don't enforce a strict order in test that does type lookup

### DIFF
--- a/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
+++ b/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
@@ -28,7 +28,6 @@ class TestSwiftTypeLookup(TestBase):
         TestBase.setUp(self)
 
     @swiftTest
-    @skipIf(bugnumber="rdar://problem/67082900")
     def test_swift_type_lookup(self):
         """Test the ability to look for type definitions at the command line"""
         self.build()
@@ -108,7 +107,8 @@ class TestSwiftTypeLookup(TestBase):
                 'func foo',
                 'Int',
                 'Double'],
-            matching=True)
+            matching=True,
+            ordered=False)
         self.expect(
             'type lookup --show-help -- print',
             substrs=[


### PR DESCRIPTION
<rdar://problem/67082900>