### PR TITLE
Don't enforce a strict order in test that does type lookup

### DIFF
--- a/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
+++ b/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
@@ -107,7 +107,8 @@ class TestSwiftTypeLookup(TestBase):
                 'func foo',
                 'Int',
                 'Double'],
-            matching=True)
+            matching=True,
+            ordered=False)
         self.expect(
             'type lookup --show-help -- print',
             substrs=[


### PR DESCRIPTION
<rdar://problem/67082900>

(cherry picked from commit d54e1a178533072c4b68a6bedf6f32ed653a7147)

https://github.com/apple/llvm-project/pull/1811