### PR TITLE
[NFC] Update import filtering code to match Swift.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -8286,9 +8286,14 @@ bool SwiftASTContext::CacheUserImports(SwiftASTContext &swift_ast_context,
   llvm::SmallString<1> m_description;
   llvm::SmallVector<swift::ModuleDecl::ImportedModule, 2> parsed_imports;
 
-  swift::ModuleDecl::ImportFilter import_filter;
-  import_filter |= swift::ModuleDecl::ImportFilterKind::Public;
-  import_filter |= swift::ModuleDecl::ImportFilterKind::Private;
+  swift::ModuleDecl::ImportFilter import_filter {
+      swift::ModuleDecl::ImportFilterKind::Public,
+      swift::ModuleDecl::ImportFilterKind::Private,
+      swift::ModuleDecl::ImportFilterKind::ImplementationOnly,
+      swift::ModuleDecl::ImportFilterKind::SPIAccessControl,
+      swift::ModuleDecl::ImportFilterKind::ShadowedBySeparateOverlay
+  };
+
   source_file.getImportedModules(parsed_imports, import_filter);
 
   auto *persistent_expression_state =

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -8287,11 +8287,11 @@ bool SwiftASTContext::CacheUserImports(SwiftASTContext &swift_ast_context,
   llvm::SmallVector<swift::ModuleDecl::ImportedModule, 2> parsed_imports;
 
   swift::ModuleDecl::ImportFilter import_filter {
-      swift::ModuleDecl::ImportFilterKind::Public,
-      swift::ModuleDecl::ImportFilterKind::Private,
+      swift::ModuleDecl::ImportFilterKind::Exported,
+      swift::ModuleDecl::ImportFilterKind::Default,
       swift::ModuleDecl::ImportFilterKind::ImplementationOnly,
       swift::ModuleDecl::ImportFilterKind::SPIAccessControl,
-      swift::ModuleDecl::ImportFilterKind::ShadowedBySeparateOverlay
+      swift::ModuleDecl::ImportFilterKind::ShadowedByCrossImportOverlay
   };
 
   source_file.getImportedModules(parsed_imports, import_filter);


### PR DESCRIPTION
Matching Swift PR https://github.com/apple/swift/pull/33986 where a couple of enum cases are renamed.

I don't think there's any reason to not cache all kinds of imports, so I've added the rest as well.