### PR TITLE
Sema: introduce `__attribute__((__swift_name__))`

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -3735,20 +3735,22 @@ def SwiftNameDocs : Documentation {
   let Category = SwiftDocs;
   let Heading = "swift_name";
   let Content = [{
-The ``swift_name`` attribute provides the spelling for the transformed name when
-the interface is imported into the Swift language.
+The ``swift_name`` attribute provides the name of the declaration in Swift.  f
+this attribute is absent, the name is transformed according to the algorithm
+built into the Swift compiler.
 
-The argument is the single string representation of the Swift function name.
-The name may be a compound Swift name.  For a type, enum constant, property, or
-variable declaration, the name must be a simple or qualified identifier.
+The argument is a string literal that contains the Swift name of the function,
+variable, or type. When renaming a function, the name may be a compound Swift
+name.  For a type, enum constant, property, or variable declaration, the name
+must be a simple or qualified identifier.
 
   .. code-block:: c
 
-    @interface I
-    - (void) methodWithInt:(int)i __attribute__((__swift_name__("I.method(int:)")))
+    @interface URL
+    - (void) initWithString:(NSString *)s __attribute__((__swift_name__("URL.init(_:)")))
     @end
 
-    void __attribute__((__swift_name__("function()"))) f(void) {
+    void __attribute__((__swift_name__("squareRoot()"))) sqrt(double v) {
     }
   }];
 }

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -4042,13 +4042,15 @@ def warn_attr_swift_name_function
   : Warning<"%0 attribute argument must be a string literal specifying a Swift function name">,
     InGroup<SwiftNameAttribute>;
 def warn_attr_swift_name_invalid_identifier
-  : Warning<"%0 attribute has invalid identifier for %select{base|context|parameter}1 name">,
+  : Warning<"%0 attribute has invalid identifier for the %select{base|context|parameter}1 name">,
     InGroup<SwiftNameAttribute>;
 def warn_attr_swift_name_decl_kind
   : Warning<"%0 attribute cannot be applied to this declaration">,
     InGroup<SwiftNameAttribute>;
 def warn_attr_swift_name_subscript_invalid_parameter
-  : Warning<"%0 attribute for 'subscript' must %select{be a getter or setter|have at least one parameter|have a 'self:' parameter}1">,
+  : Warning<"%0 attribute for 'subscript' must %select{be a getter or setter|"
+        "have at least one parameter|"
+        "have a 'self:' parameter}1">,
     InGroup<SwiftNameAttribute>;
 def warn_attr_swift_name_missing_parameters
   : Warning<"%0 attribute is missing parameter label clause">,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1841,18 +1841,9 @@ public:
     }
   };
 
-  /// Do a check to make sure \p Name looks like a legal swift_name
-  /// attribute for the decl \p D. Raise a diagnostic if the name is invalid
-  /// for the given declaration.
-  ///
-  /// For a function, this will validate a compound Swift name,
-  /// e.g. <code>init(foo:bar:baz:)</code> or <code>controllerForName(_:)</code>,
-  /// and the function will output the number of parameter names, and whether
-  /// this is a single-arg initializer.
-  ///
-  /// For a type, enum constant, property, or variable declaration, this will
-  /// validate either a simple identifier, or a qualified
-  /// <code>context.identifier</code> name.
+  /// Do a check to make sure \p Name looks like a legal argument for the
+  /// swift_name attribute applied to decl \p D.  Raise a diagnostic if the name
+  /// is invalid for the given declaration.
   ///
   /// \p AL is used to provide caret diagnostics in case of a malformed name.
   ///

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -2592,6 +2592,9 @@ static bool mergeDeclAttribute(Sema &S, NamedDecl *D,
     return false;
   } else if (const auto *MA = dyn_cast<MinSizeAttr>(Attr))
     NewAttr = S.mergeMinSizeAttr(D, *MA);
+  else if (const auto *SNA = dyn_cast<SwiftNameAttr>(Attr))
+    NewAttr = S.mergeSwiftNameAttr(D, *SNA, SNA->getName(),
+                                   AMK == Sema::AMK_Override);
   else if (const auto *OA = dyn_cast<OptimizeNoneAttr>(Attr))
     NewAttr = S.mergeOptimizeNoneAttr(D, *OA);
   else if (const auto *SNA = dyn_cast<SwiftNameAttr>(Attr))

--- a/clang/test/SemaObjC/attr-swift_name.m
+++ b/clang/test/SemaObjC/attr-swift_name.m
@@ -58,9 +58,9 @@ __attribute__((__swift_name__("IClass")))
 + (instancetype)trailingColon SWIFT_NAME("foo:");
 // expected-warning@-1 {{'__swift_name__' attribute argument must be a string literal specifying a Swift function name}}
 + (instancetype)initialIgnore:(int)value SWIFT_NAME("_(value:)");
-// expected-warning@-1 {{'__swift_name__' attribute has invalid identifier for base name}}
+// expected-warning@-1 {{'__swift_name__' attribute has invalid identifier for the base name}}
 + (instancetype)middleOmitted:(int)value SWIFT_NAME("i(:)");
-// expected-warning@-1 {{'__swift_name__' attribute has invalid identifier for parameter name}}
+// expected-warning@-1 {{'__swift_name__' attribute has invalid identifier for the parameter name}}
 
 @property(strong) id someProp SWIFT_NAME("prop");
 @end
@@ -69,7 +69,7 @@ enum SWIFT_NAME("E") E {
   value1,
   value2,
   value3 SWIFT_NAME("three"),
-  value4 SWIFT_NAME("four()"), // expected-warning {{'__swift_name__' attribute has invalid identifier for base name}}
+  value4 SWIFT_NAME("four()"), // expected-warning {{'__swift_name__' attribute has invalid identifier for the base name}}
 };
 
 struct SWIFT_NAME("TStruct") SStruct {


### PR DESCRIPTION
This introduces the new `swift_name` attribute that allows annotating
APIs with an alternate spelling for Swift.  This is used as part of the
importing mechanism to allow interfaces to be imported with a new name
into Swift.  It takes a parameter which is the Swift function name.
This parameter is validated to check if it matches the possible
transformed signature in Swift.

This is based on the work of the original changes in
https://github.com/llvm/llvm-project-staging/commit/8afaf3aad2af43cfedca7a24cd817848c4e95c0c

Differential Revision: https://reviews.llvm.org/D87534
Reviewed By: Aaron Ballman, Dmitri Gribenko

Pre-apply late review comments.