### PR TITLE
Revert "[lldb] XFAIL TestMemoryHistory on Linux"

### DIFF
--- a/lldb/test/API/functionalities/asan/TestMemoryHistory.py
+++ b/lldb/test/API/functionalities/asan/TestMemoryHistory.py
@@ -15,9 +15,6 @@ class AsanTestCase(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
-    @expectedFailureAll(
-        oslist=["linux"],
-        bugnumber="non-core functionality, need to reenable and fix later (DES 2014.11.07)")
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
     @expectedFailureNetBSD
     @skipUnlessAddressSanitizer


### PR DESCRIPTION
This reverts commit 7518006d75accd21325747430d6bced66b2c5ada.

This test apparently works on the Swift CI ubuntu bot, so it shouldn't be
XFAIL'd on Linux.

(cherry picked from commit ef7d22a98683ce98b6a2c4d0818d2d9978d42861)

Fixes rdar://69081937