### PR TITLE
[lldb] Remove unused source range limiting (downstream)

### DIFF
--- a/lldb/include/lldb/Expression/IRExecutionUnit.h
+++ b/lldb/include/lldb/Expression/IRExecutionUnit.h
@@ -102,10 +102,7 @@ public:
 
   lldb::ModuleSP GetJITModule();
 
-  lldb::ModuleSP CreateJITModule(const char *name,
-                                 const FileSpec *limit_file_ptr = NULL,
-                                 uint32_t limit_start_line = 0,
-                                 uint32_t limit_end_line = 0);
+  lldb::ModuleSP CreateJITModule(const char *name);
 
   /// Accessor for the mutex that guards LLVM::getGlobalContext()
   static std::recursive_mutex &GetLLVMGlobalContextMutex();

--- a/lldb/include/lldb/Symbol/SymbolFile.h
+++ b/lldb/include/lldb/Symbol/SymbolFile.h
@@ -314,13 +314,6 @@ public:
   virtual std::vector<lldb::DataBufferSP>
   GetASTData(lldb::LanguageType language);
 
-  // Used for the REPL to limit source file ranges that are valid within "file".
-  // Since
-  // breakpoint setting call fall through, we need to stop the fall through from
-  // happening
-  virtual bool SetLimitSourceFileRange(const FileSpec &file,
-                                       uint32_t first_line, uint32_t last_line);
-
   struct RegisterInfoResolver {
     virtual ~RegisterInfoResolver(); // anchor
 
@@ -343,15 +336,6 @@ public:
   virtual void Dump(Stream &s);
 
 protected:
-  class SourceRange {
-  public:
-    SourceRange(const FileSpec &f, uint32_t first, uint32_t last)
-        : file(f), first_line(first), last_line(last) {}
-    FileSpec file;
-    uint32_t first_line;
-    uint32_t last_line;
-  };
-
   void AssertModuleLock();
   virtual uint32_t CalculateNumCompileUnits() = 0;
   virtual lldb::CompUnitSP ParseCompileUnitAtIndex(uint32_t idx) = 0;
@@ -368,7 +352,6 @@ protected:
   Symtab *m_symtab = nullptr;
   uint32_t m_abilities;
   bool m_calculated_abilities;
-  std::vector<SourceRange> m_limit_source_ranges;
 
 private:
   SymbolFile(const SymbolFile &) = delete;

--- a/lldb/source/Expression/IRExecutionUnit.cpp
+++ b/lldb/source/Expression/IRExecutionUnit.cpp
@@ -1353,10 +1353,7 @@ lldb::ModuleSP IRExecutionUnit::GetJITModule() {
   return m_jit_module_wp.lock();
 }
 
-lldb::ModuleSP IRExecutionUnit::CreateJITModule(const char *name,
-                                                const FileSpec *limit_file_ptr,
-                                                uint32_t limit_start_line,
-                                                uint32_t limit_end_line) {
+lldb::ModuleSP IRExecutionUnit::CreateJITModule(const char *name) {
   lldb::ModuleSP jit_module_sp(m_jit_module_wp.lock());
   if (jit_module_sp)
     return jit_module_sp;
@@ -1386,11 +1383,6 @@ lldb::ModuleSP IRExecutionUnit::CreateJITModule(const char *name,
       FileSpec jit_file;
       jit_file.GetFilename() = const_name;
       jit_module_sp->SetFileSpecAndObjectName(jit_file, ConstString());
-
-      if (limit_file_ptr)
-        if (SymbolFile *symbol_file = jit_module_sp->GetSymbolFile())
-          symbol_file->SetLimitSourceFileRange(
-              *limit_file_ptr, limit_start_line, limit_end_line);
 
       target->GetImages().Append(jit_module_sp);
       return jit_module_sp;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -438,19 +438,7 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
     StreamString jit_module_name;
     jit_module_name.Printf("%s%u", FunctionName(),
                            m_options.GetExpressionNumber());
-    const char *limit_file = m_options.GetPoundLineFilePath();
-    FileSpec limit_file_spec;
-    uint32_t limit_start_line = 0;
-    uint32_t limit_end_line = 0;
-    if (limit_file) {
-      limit_file_spec.SetFile(limit_file, FileSpec::Style::native);
-      limit_start_line = m_options.GetPoundLineLine();
-      limit_end_line = limit_start_line +
-                       std::count(m_expr_text.begin(), m_expr_text.end(), '\n');
-    }
-    m_execution_unit_sp->CreateJITModule(jit_module_name.GetString().data(),
-                                         limit_file ? &limit_file_spec : NULL,
-                                         limit_start_line, limit_end_line);
+    m_execution_unit_sp->CreateJITModule(jit_module_name.GetString().data());
   }
 
   if (jit_error.Success()) {

--- a/lldb/source/Symbol/SymbolFile.cpp
+++ b/lldb/source/Symbol/SymbolFile.cpp
@@ -111,16 +111,6 @@ bool SymbolFile::ForceInlineSourceFileCheck() {
   return m_objfile_sp->GetType() == ObjectFile::eTypeJIT;
 }
 
-bool SymbolFile::SetLimitSourceFileRange(const FileSpec &file,
-                                         uint32_t first_line,
-                                         uint32_t last_line) {
-  if (file && first_line <= last_line) {
-    m_limit_source_ranges.push_back(SourceRange(file, first_line, last_line));
-    return true;
-  }
-  return false;
-}
-
 std::vector<lldb::DataBufferSP>
 SymbolFile::GetASTData(lldb::LanguageType language) {
   // SymbolFile subclasses must add this functionality


### PR DESCRIPTION
Seeing that `m_limit_source_ranges` was not being read, this removes it and the related downstream-only code.