### PR TITLE
[am] Add three new automerger edges

### DIFF
--- a/apple-llvm-config/am/am-config.json
+++ b/apple-llvm-config/am/am-config.json
@@ -26,5 +26,20 @@
   "target": "swift/main",
   "upstream": "apple/stable/20200714",
   "test_commits_in_bundle": true
+},
+{
+  "target": "apple/master",
+  "upstream": "apple/main",
+  "test-command": "true"
+},
+{
+  "target": "swift/master-next",
+  "upstream": "swift/next",
+  "test-command": "true"
+},
+{
+  "target": "swift/master",
+  "upstream": "swift/main",
+  "test-command": "true"
 }
 ]


### PR DESCRIPTION
Temporary automergers (basically, forwarders) from the new renamed
branches to the old branches.

  1. `apple/main` -> `apple/master`
  2. `swift/next` -> `swift/master-next`
  3. `swift/main` -> `swift/master`

These should go away in two weeks.