### PR TITLE
UnXFAIL DwarfImporter tests fixed by Swift debug info change

### DIFF
--- a/lldb/test/API/lang/swift/array_tuple_resilient/TestSwiftArrayTupleResilient.py
+++ b/lldb/test/API/lang/swift/array_tuple_resilient/TestSwiftArrayTupleResilient.py
@@ -2,7 +2,4 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipUnlessDarwin,
-    expectedFailureAll(archs=['arm64_32'], bugnumber="<rdar://problem/58065423>")
-                                                           , expectedFailureAll(bugnumber="rdar://60396797",
-                        setting=('symbols.use-swift-clangimporter', 'false'))
-])
+    expectedFailureAll(archs=['arm64_32'], bugnumber="<rdar://problem/58065423>")])

--- a/lldb/test/API/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
@@ -14,7 +14,4 @@ from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
                           decorators=[swiftTest,skipUnlessDarwin,
-                            expectedFailureAll(archs=['arm64_32'], bugnumber="<rdar://problem/58065423>")
-                   ,        expectedFailureAll(bugnumber="rdar://60396797",
-                           setting=('symbols.use-swift-clangimporter', 'false'))
-])
+                            expectedFailureAll(archs=['arm64_32'], bugnumber="<rdar://problem/58065423>")])

--- a/lldb/test/API/lang/swift/objc_inherited_ivars/TestSwiftAtObjCIvars.py
+++ b/lldb/test/API/lang/swift/objc_inherited_ivars/TestSwiftAtObjCIvars.py
@@ -33,8 +33,6 @@ class TestSwiftAtObjCIvars(TestBase):
         lldbutil.check_variable(self, x, False, value='12')
         lldbutil.check_variable(self, y, False, '"12"')
 
-    @expectedFailureAll(bugnumber="rdar://60396797",
-                        setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin
     @swiftTest
     def test_swift_at_objc_ivars(self):

--- a/lldb/test/API/lang/swift/unknown_reference/TestSwiftUnknownReference.py
+++ b/lldb/test/API/lang/swift/unknown_reference/TestSwiftUnknownReference.py
@@ -29,9 +29,6 @@ class TestSwiftUnknownReference(lldbtest.TestBase):
         lldbutil.check_variable(self, m_string, summary='"world"')
 
     
-    @expectedFailureAll(bugnumber="rdar://60396797",
-                        oslist=lldbplatform.darwin_all,
-                        setting=('symbols.use-swift-clangimporter', 'false'))
     @swiftTest
     def test_unknown_objc_ref(self):
         """Test unknown references to Objective-C objects."""

--- a/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
+++ b/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
@@ -33,9 +33,6 @@ class TestSwiftUnknownSelf(lldbtest.TestBase):
         self.expect("fr v self", substrs=["hello", "world"])
 
 
-    @expectedFailureAll(bugnumber="rdar://60396797",
-                        oslist=lldbplatform.darwin_all,
-                        setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(bugnumber="SR-10216", archs=['ppc64le'])
     @swiftTest
     def test_unknown_self_objc_ref(self):


### PR DESCRIPTION
that adds Clang module breadcrumbs for imports of Swift overlays.
<rdar://problem/60396797>

(cherry picked from commit fb1ce81d63dff2b331270984e4da3c6b9fadc2d9)


https://github.com/apple/llvm-project/pull/1836