### PR TITLE
Fix reporting the lack of global variables in "target var".

### DIFF
--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -922,6 +922,7 @@ protected:
         CompileUnit *comp_unit = nullptr;
         if (frame) {
           SymbolContext sc = frame->GetSymbolContext(eSymbolContextCompUnit);
+          comp_unit = sc.comp_unit;
           if (sc.comp_unit) {
             const bool can_create = true;
             VariableListSP comp_unit_varlist_sp(

--- a/lldb/test/API/functionalities/target_var/no_vars/Makefile
+++ b/lldb/test/API/functionalities/target_var/no_vars/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/target_var/no_vars/TestTargetVarNoVars.py
+++ b/lldb/test/API/functionalities/target_var/no_vars/TestTargetVarNoVars.py
@@ -1,0 +1,21 @@
+"""
+Test that target var with no variables returns a correct error
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestTargetVarNoVars(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_target_var_no_vars(self):
+        self.build()
+        lldbutil.run_to_name_breakpoint(self, 'main')
+        self.expect("target variable", substrs=['no global variables in current compile unit', 'main.c'], error=True)
+

--- a/lldb/test/API/functionalities/target_var/no_vars/main.c
+++ b/lldb/test/API/functionalities/target_var/no_vars/main.c
@@ -1,0 +1,5 @@
+int
+main(int argc, char **argv)
+{
+  return argc;
+}


### PR DESCRIPTION
There was a little thinko which meant when stopped in a frame with
debug information but whose CU didn't have any global variables we
report:

no debug info for frame <N>

This patch fixes that error message to say the intended:

no global variables in current compile unit

<rdar://problem/69086361>

(cherry picked from commit 94b0d836a105116220052313df5a58473f706cdf)