### PR TITLE
[LLDB] Add a defensive check for member__f_

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
@@ -155,6 +155,9 @@ CPPLanguageRuntime::FindLibCppStdFunctionCallableInfo(
         member__f_ = sub_member__f_;
   }
 
+  if (!member__f_)
+    return optional_info;
+
   lldb::addr_t member__f_pointer_value = member__f_->GetValueAsUnsigned(0);
 
   optional_info.member__f_pointer_value = member__f_pointer_value;


### PR DESCRIPTION
I only have a crash log and was not able to come up with a test case for this.

rdar://problem/69403150
(cherry picked from commit a079f619b5a1959af8af37cabdea27ae542903db)