### PR TITLE
Add missing NodeType enums

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -1380,6 +1380,8 @@ const char *AArch64TargetLowering::getTargetNodeName(unsigned Opcode) const {
   case AArch64ISD::FIRST_NUMBER:
     break;
     MAKE_CASE(AArch64ISD::CALL)
+    MAKE_CASE(AArch64ISD::AUTH_CALL)
+    MAKE_CASE(AArch64ISD::AUTH_TC_RETURN)
     MAKE_CASE(AArch64ISD::ADRP)
     MAKE_CASE(AArch64ISD::ADR)
     MAKE_CASE(AArch64ISD::ADDlow)


### PR DESCRIPTION
Add enum values from AArch64ISelLowering.h that resolve the error:
```
third_party/unsupported_toolchains/swift/src/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp:1379:11: error: enumeration values 'AUTH_CALL' and 'AUTH_TC_RETURN' not handled in switch [-Werror,-Wswitch]
  switch ((AArch64ISD::NodeType)Opcode) {
          ^
```