### PR TITLE
Add support for firmware/standalone LC_NOTE "main bin spec" corefiles

### DIFF
--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -91,6 +91,17 @@ public:
     eStrataJIT
   };
 
+  /// If we have a corefile binary hint, this enum
+  /// specifies the binary type which we can use to
+  /// select the correct DynamicLoader plugin.
+  enum BinaryType {
+    eBinaryTypeInvalid = 0,
+    eBinaryTypeUnknown,
+    eBinaryTypeKernel,    /// kernel binary
+    eBinaryTypeUser,      /// user process binary
+    eBinaryTypeStandalone /// standalone binary / firmware
+  };
+
   struct LoadableData {
     lldb::addr_t Dest;
     llvm::ArrayRef<uint8_t> Contents;
@@ -500,12 +511,17 @@ public:
   ///   If the uuid of the binary is specified, this will be set.
   ///   If no UUID is available, will be cleared.
   ///
+  /// \param[out] type
+  ///   Return the type of the binary, which will dictate which
+  ///   DynamicLoader plugin should be used.
+  ///
   /// \return
   ///   Returns true if either address or uuid has been set.
-  virtual bool GetCorefileMainBinaryInfo (lldb::addr_t &address, UUID &uuid) {
-      address = LLDB_INVALID_ADDRESS;
-      uuid.Clear();
-      return false;
+  virtual bool GetCorefileMainBinaryInfo(lldb::addr_t &address, UUID &uuid,
+                                         ObjectFile::BinaryType &type) {
+    address = LLDB_INVALID_ADDRESS;
+    uuid.Clear();
+    return false;
   }
 
   virtual lldb::RegisterContextSP

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
@@ -112,7 +112,9 @@ public:
 
   std::string GetIdentifierString() override;
 
-  bool GetCorefileMainBinaryInfo (lldb::addr_t &address, lldb_private::UUID &uuid) override;
+  bool GetCorefileMainBinaryInfo(lldb::addr_t &address,
+                                 lldb_private::UUID &uuid,
+                                 ObjectFile::BinaryType &type) override;
 
   lldb::RegisterContextSP
   GetThreadContextAtIndex(uint32_t idx, lldb_private::Thread &thread) override;

--- a/lldb/test/API/macosx/lc-note/firmware-corefile/Makefile
+++ b/lldb/test/API/macosx/lc-note/firmware-corefile/Makefile
@@ -1,0 +1,14 @@
+MAKE_DSYM := NO
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -Wl,-random_uuid
+
+all: a.out b.out create-empty-corefile
+
+create-empty-corefile:
+	$(MAKE) -f $(MAKEFILE_RULES) EXE=create-empty-corefile \
+		C_SOURCES=create-empty-corefile.c
+
+b.out:
+	$(MAKE)  VPATH=$(SRCDIR)/$* -I $(SRCDIR) -f $(SRCDIR)/bout.mk
+
+include Makefile.rules

--- a/lldb/test/API/macosx/lc-note/firmware-corefile/TestFirmwareCorefiles.py
+++ b/lldb/test/API/macosx/lc-note/firmware-corefile/TestFirmwareCorefiles.py
@@ -1,0 +1,133 @@
+"""Test that corefiles with LC_NOTE "kern ver str" and "main bin spec" load commands works."""
+
+
+
+import os
+import re
+import subprocess
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestFirmwareCorefiles(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @skipIf(debug_info=no_match(["dsym"]), bugnumber="This test is looking explicitly for a dSYM")
+    @skipIf(archs=no_match(['x86_64']))
+    @skipUnlessDarwin
+    def test_lc_note(self):
+        self.build()
+        self.aout_exe = self.getBuildArtifact("a.out")
+        self.bout_exe = self.getBuildArtifact("b.out")
+        self.create_corefile = self.getBuildArtifact("create-empty-corefile")
+        self.dsym_for_uuid = self.getBuildArtifact("dsym-for-uuid.sh")
+        self.aout_corefile = self.getBuildArtifact("aout.core")
+        self.bout_corefile = self.getBuildArtifact("bout.core")
+
+        ## We can hook in our dsym-for-uuid shell script to lldb with this env
+        ## var instead of requiring a defaults write.
+        os.environ['LLDB_APPLE_DSYMFORUUID_EXECUTABLE'] = self.dsym_for_uuid
+        self.addTearDownHook(lambda: os.environ.pop('LLDB_APPLE_DSYMFORUUID_EXECUTABLE', None))
+
+        dwarfdump_uuid_regex = re.compile(
+            'UUID: ([-0-9a-fA-F]+) \(([^\(]+)\) .*')
+        dwarfdump_cmd_output = subprocess.check_output(
+                ('/usr/bin/dwarfdump --uuid "%s"' % self.aout_exe), shell=True).decode("utf-8")
+        aout_uuid = None
+        for line in dwarfdump_cmd_output.splitlines():
+            match = dwarfdump_uuid_regex.search(line)
+            if match:
+                aout_uuid = match.group(1)
+        self.assertNotEqual(aout_uuid, None, "Could not get uuid of built a.out")
+
+        dwarfdump_cmd_output = subprocess.check_output(
+                ('/usr/bin/dwarfdump --uuid "%s"' % self.bout_exe), shell=True).decode("utf-8")
+        bout_uuid = None
+        for line in dwarfdump_cmd_output.splitlines():
+            match = dwarfdump_uuid_regex.search(line)
+            if match:
+                bout_uuid = match.group(1)
+        self.assertNotEqual(bout_uuid, None, "Could not get uuid of built b.out")
+
+        ###  Create our dsym-for-uuid shell script which returns self.aout_exe
+        ###  or self.bout_exe, depending on the UUID on the command line.
+        shell_cmds = [
+                '#! /bin/sh',
+                '# the last argument is the uuid',
+                'while [ $# -gt 1 ]',
+                'do',
+                '  shift',
+                'done',
+                'ret=0',
+                'echo "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>"',
+                'echo "<!DOCTYPE plist PUBLIC \\"-//Apple//DTD PLIST 1.0//EN\\" \\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\\">"',
+                'echo "<plist version=\\"1.0\\">"',
+                '',
+                'if [ "$1" != "%s" -a "$1" != "%s" ]' % (aout_uuid, bout_uuid),
+                'then',
+                '  echo "<key>DBGError</key><string>not found</string>"',
+                '  echo "</plist>"', 
+                '  exit 1',
+                'fi',
+                'if [ "$1" = "%s" ]' % aout_uuid,
+                'then',
+                '  uuid=%s' % aout_uuid,
+                '  bin=%s' % self.aout_exe,
+                '  dsym=%s.dSYM/Contents/Resources/DWARF/%s' % (self.aout_exe, os.path.basename(self.aout_exe)),
+                'else',
+                '  uuid=%s' % bout_uuid,
+                '  bin=%s' % self.bout_exe,
+                '  dsym=%s.dSYM/Contents/Resources/DWARF/%s' % (self.bout_exe, os.path.basename(self.bout_exe)),
+                'fi',
+                'echo "<dict><key>$uuid</key><dict>"',
+                '',
+                'echo "<key>DBGArchitecture</key><string>x86_64</string>"',
+                'echo "<key>DBGDSYMPath</key><string>$dsym</string>"',
+                'echo "<key>DBGSymbolRichExecutable</key><string>$bin</string>"',
+                'echo "</dict></dict></plist>"',
+                'exit $ret'
+                ]
+
+        with open(self.dsym_for_uuid, "w") as writer:
+            for l in shell_cmds:
+                writer.write(l + '\n')
+
+        os.chmod(self.dsym_for_uuid, 0o755)
+
+        ### Create our corefile
+        retcode = call(self.create_corefile + " version-string " + self.aout_corefile + " " + self.aout_exe, shell=True)
+        retcode = call(self.create_corefile + " main-bin-spec " + self.bout_corefile + " " + self.bout_exe, shell=True)
+
+        ### Now run lldb on the corefile
+        ### which will give us a UUID
+        ### which we call dsym-for-uuid.sh with
+        ### which gives us a binary and dSYM
+        ### which lldb should load!
+
+        # First, try the "kern ver str" corefile
+        self.target = self.dbg.CreateTarget('')
+        err = lldb.SBError()
+        self.process = self.target.LoadCore(self.aout_corefile)
+        self.assertEqual(self.process.IsValid(), True)
+        if self.TraceOn():
+            self.runCmd("image list")
+        self.assertEqual(self.target.GetNumModules(), 1)
+        fspec = self.target.GetModuleAtIndex(0).GetFileSpec()
+        filepath = fspec.GetDirectory() + "/" + fspec.GetFilename()
+        self.assertEqual(filepath, self.aout_exe)
+
+
+        # Second, try the "main bin spec" corefile
+        self.target = self.dbg.CreateTarget('')
+        self.process = self.target.LoadCore(self.bout_corefile)
+        self.assertEqual(self.process.IsValid(), True)
+        if self.TraceOn():
+            self.runCmd("image list")
+        self.assertEqual(self.target.GetNumModules(), 1)
+        fspec = self.target.GetModuleAtIndex(0).GetFileSpec()
+        filepath = fspec.GetDirectory() + "/" + fspec.GetFilename()
+        self.assertEqual(filepath, self.bout_exe)

--- a/lldb/test/API/macosx/lc-note/firmware-corefile/bout.mk
+++ b/lldb/test/API/macosx/lc-note/firmware-corefile/bout.mk
@@ -1,0 +1,10 @@
+MAKE_DSYM := NO
+
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -Wl,-random_uuid
+
+EXE := b.out
+
+all: b.out 
+
+include Makefile.rules

--- a/lldb/test/API/macosx/lc-note/firmware-corefile/create-empty-corefile.cpp
+++ b/lldb/test/API/macosx/lc-note/firmware-corefile/create-empty-corefile.cpp
@@ -1,0 +1,347 @@
+#include <mach-o/loader.h>
+#include <mach/thread_status.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <uuid/uuid.h>
+#include <vector>
+
+// Create an empty corefile with a "kern ver str" LC_NOTE
+// or a "main bin spec" LC_NOTE..
+// If an existing binary is given as a 3rd argument on the cmd line,
+// the UUID from that binary will be encoded in the corefile.
+// Otherwise a pre-set UUID will be put in the corefile that
+// is created.
+
+struct main_bin_spec_payload {
+  uint32_t version;
+  uint32_t type;
+  uint64_t address;
+  uuid_t uuid;
+  uint32_t log2_pagesize;
+  uint32_t unused;
+};
+
+union uint32_buf {
+  uint8_t bytebuf[4];
+  uint32_t val;
+};
+
+union uint64_buf {
+  uint8_t bytebuf[8];
+  uint64_t val;
+};
+
+void add_uint64(std::vector<uint8_t> &buf, uint64_t val) {
+  uint64_buf conv;
+  conv.val = val;
+  for (int i = 0; i < 8; i++)
+    buf.push_back(conv.bytebuf[i]);
+}
+
+void add_uint32(std::vector<uint8_t> &buf, uint32_t val) {
+  uint32_buf conv;
+  conv.val = val;
+  for (int i = 0; i < 4; i++)
+    buf.push_back(conv.bytebuf[i]);
+}
+
+std::vector<uint8_t> x86_lc_thread_load_command() {
+  std::vector<uint8_t> data;
+  add_uint32(data, LC_THREAD);                // thread_command.cmd
+  add_uint32(data, 184);                      // thread_command.cmdsize
+  add_uint32(data, x86_THREAD_STATE64);       // thread_command.flavor
+  add_uint32(data, x86_THREAD_STATE64_COUNT); // thread_command.count
+  add_uint64(data, 0x0000000000000000);       // rax
+  add_uint64(data, 0x0000000000000400);       // rbx
+  add_uint64(data, 0x0000000000000000);       // rcx
+  add_uint64(data, 0x0000000000000000);       // rdx
+  add_uint64(data, 0x0000000000000000);       // rdi
+  add_uint64(data, 0x0000000000000000);       // rsi
+  add_uint64(data, 0xffffff9246e2ba20);       // rbp
+  add_uint64(data, 0xffffff9246e2ba10);       // rsp
+  add_uint64(data, 0x0000000000000000);       // r8
+  add_uint64(data, 0x0000000000000000);       // r9
+  add_uint64(data, 0x0000000000000000);       // r10
+  add_uint64(data, 0x0000000000000000);       // r11
+  add_uint64(data, 0xffffff7f96ce5fe1);       // r12
+  add_uint64(data, 0x0000000000000000);       // r13
+  add_uint64(data, 0x0000000000000000);       // r14
+  add_uint64(data, 0xffffff9246e2bac0);       // r15
+  add_uint64(data, 0xffffff8015a8f6d0);       // rip
+  add_uint64(data, 0x0000000000011111);       // rflags
+  add_uint64(data, 0x0000000000022222);       // cs
+  add_uint64(data, 0x0000000000033333);       // fs
+  add_uint64(data, 0x0000000000044444);       // gs
+  return data;
+}
+
+void add_lc_note_kern_ver_str_load_command(
+    std::vector<std::vector<uint8_t>> &loadcmds, std::vector<uint8_t> &payload,
+    int payload_file_offset, std::string uuid) {
+  std::string ident = "EFI UUID=";
+  ident += uuid;
+  std::vector<uint8_t> loadcmd_data;
+
+  add_uint32(loadcmd_data, LC_NOTE); // note_command.cmd
+  add_uint32(loadcmd_data, 40);      // note_command.cmdsize
+  char lc_note_name[16];
+  memset(lc_note_name, 0, 16);
+  strcpy(lc_note_name, "kern ver str");
+
+  // lc_note.data_owner
+  for (int i = 0; i < 16; i++)
+    loadcmd_data.push_back(lc_note_name[i]);
+
+  // we start writing the payload at payload_file_offset to leave
+  // room at the start for the header & the load commands.
+  uint64_t current_payload_offset = payload.size() + payload_file_offset;
+
+  add_uint64(loadcmd_data, current_payload_offset); // note_command.offset
+  add_uint64(loadcmd_data, 4 + ident.size() + 1);   // note_command.size
+
+  loadcmds.push_back(loadcmd_data);
+
+  add_uint32(payload, 1); // kerneL_version_string.version
+  for (int i = 0; i < ident.size() + 1; i++) {
+    payload.push_back(ident[i]);
+  }
+}
+
+void add_lc_note_main_bin_spec_load_command(
+    std::vector<std::vector<uint8_t>> &loadcmds, std::vector<uint8_t> &payload,
+    int payload_file_offset, std::string uuidstr) {
+  std::vector<uint8_t> loadcmd_data;
+
+  add_uint32(loadcmd_data, LC_NOTE); // note_command.cmd
+  add_uint32(loadcmd_data, 40);      // note_command.cmdsize
+  char lc_note_name[16];
+  memset(lc_note_name, 0, 16);
+  strcpy(lc_note_name, "main bin spec");
+
+  // lc_note.data_owner
+  for (int i = 0; i < 16; i++)
+    loadcmd_data.push_back(lc_note_name[i]);
+
+  // we start writing the payload at payload_file_offset to leave
+  // room at the start for the header & the load commands.
+  uint64_t current_payload_offset = payload.size() + payload_file_offset;
+
+  add_uint64(loadcmd_data, current_payload_offset); // note_command.offset
+  add_uint64(loadcmd_data,
+             sizeof(struct main_bin_spec_payload)); // note_command.size
+
+  loadcmds.push_back(loadcmd_data);
+
+  // Now write the "main bin spec" payload.
+  add_uint32(payload, 1);          // version
+  add_uint32(payload, 3);          // type == 3 [ firmware, standalone,e tc ]
+  add_uint64(payload, UINT64_MAX); // load address unknown/unspecified
+  uuid_t uuid;
+  uuid_parse(uuidstr.c_str(), uuid);
+  for (int i = 0; i < sizeof(uuid_t); i++)
+    payload.push_back(uuid[i]);
+  add_uint32(payload, 0); // log2_pagesize unspecified
+  add_uint32(payload, 0); // unused
+}
+
+void add_lc_segment(std::vector<std::vector<uint8_t>> &loadcmds,
+                    std::vector<uint8_t> &payload, int payload_file_offset) {
+  std::vector<uint8_t> loadcmd_data;
+  struct segment_command_64 seg;
+  seg.cmd = LC_SEGMENT_64;
+  seg.cmdsize = sizeof(struct segment_command_64); // no sections
+  memset(seg.segname, 0, 16);
+  seg.vmaddr = 0xffffff7f96400000;
+  seg.vmsize = 4096;
+  seg.fileoff = payload.size() + payload_file_offset;
+  seg.filesize = 0;
+  seg.maxprot = 1;
+  seg.initprot = 1;
+  seg.nsects = 0;
+  seg.flags = 0;
+
+  uint8_t *p = (uint8_t *)&seg;
+  for (int i = 0; i < sizeof(struct segment_command_64); i++) {
+    loadcmd_data.push_back(*(p + i));
+  }
+  loadcmds.push_back(loadcmd_data);
+}
+
+std::string get_uuid_from_binary(const char *fn) {
+  FILE *f = fopen(fn, "r");
+  if (f == nullptr) {
+    fprintf(stderr, "Unable to open binary '%s' to get uuid\n", fn);
+    exit(1);
+  }
+  uint32_t num_of_load_cmds = 0;
+  uint32_t size_of_load_cmds = 0;
+  std::string uuid;
+  off_t file_offset = 0;
+
+  uint8_t magic[4];
+  if (::fread(magic, 1, 4, f) != 4) {
+    fprintf(stderr, "Failed to read magic number from input file %s\n", fn);
+    exit(1);
+  }
+  uint8_t magic_32_be[] = {0xfe, 0xed, 0xfa, 0xce};
+  uint8_t magic_32_le[] = {0xce, 0xfa, 0xed, 0xfe};
+  uint8_t magic_64_be[] = {0xfe, 0xed, 0xfa, 0xcf};
+  uint8_t magic_64_le[] = {0xcf, 0xfa, 0xed, 0xfe};
+
+  if (memcmp(magic, magic_32_be, 4) == 0 ||
+      memcmp(magic, magic_64_be, 4) == 0) {
+    fprintf(stderr, "big endian corefiles not supported\n");
+    exit(1);
+  }
+
+  ::fseeko(f, 0, SEEK_SET);
+  if (memcmp(magic, magic_32_le, 4) == 0) {
+    struct mach_header mh;
+    if (::fread(&mh, 1, sizeof(mh), f) != sizeof(mh)) {
+      fprintf(stderr, "error reading mach header from input file\n");
+      exit(1);
+    }
+    if (mh.cputype != CPU_TYPE_X86_64) {
+      fprintf(stderr,
+              "This tool creates an x86_64 corefile but "
+              "the supplied binary '%s' is cputype 0x%x\n",
+              fn, (uint32_t)mh.cputype);
+      exit(1);
+    }
+    num_of_load_cmds = mh.ncmds;
+    size_of_load_cmds = mh.sizeofcmds;
+    file_offset += sizeof(struct mach_header);
+  } else {
+    struct mach_header_64 mh;
+    if (::fread(&mh, 1, sizeof(mh), f) != sizeof(mh)) {
+      fprintf(stderr, "error reading mach header from input file\n");
+      exit(1);
+    }
+    if (mh.cputype != CPU_TYPE_X86_64) {
+      fprintf(stderr,
+              "This tool creates an x86_64 corefile but "
+              "the supplied binary '%s' is cputype 0x%x\n",
+              fn, (uint32_t)mh.cputype);
+      exit(1);
+    }
+    num_of_load_cmds = mh.ncmds;
+    size_of_load_cmds = mh.sizeofcmds;
+    file_offset += sizeof(struct mach_header_64);
+  }
+
+  off_t load_cmds_offset = file_offset;
+
+  for (int i = 0; i < num_of_load_cmds &&
+                  (file_offset - load_cmds_offset) < size_of_load_cmds;
+       i++) {
+    ::fseeko(f, file_offset, SEEK_SET);
+    uint32_t cmd;
+    uint32_t cmdsize;
+    ::fread(&cmd, sizeof(uint32_t), 1, f);
+    ::fread(&cmdsize, sizeof(uint32_t), 1, f);
+    if (cmd == LC_UUID) {
+      struct uuid_command uuidcmd;
+      ::fseeko(f, file_offset, SEEK_SET);
+      if (::fread(&uuidcmd, 1, sizeof(uuidcmd), f) != sizeof(uuidcmd)) {
+        fprintf(stderr, "Unable to read LC_UUID load command.\n");
+        exit(1);
+      }
+      uuid_string_t uuidstr;
+      uuid_unparse(uuidcmd.uuid, uuidstr);
+      uuid = uuidstr;
+      break;
+    }
+    file_offset += cmdsize;
+  }
+  return uuid;
+}
+
+int main(int argc, char **argv) {
+  if (argc != 4) {
+    fprintf(stderr, "usage: create-empty-corefile version-string|main-bin-spec "
+                    "<output-core-name> <binary-to-copy-uuid-from>\n");
+    fprintf(
+        stderr,
+        "Create a Mach-O corefile with an either LC_NOTE 'kern ver str' or \n");
+    fprintf(stderr, "an LC_NOTE 'main bin spec' load command without an "
+                    "address specified, depending on\n");
+    fprintf(stderr, "whether the 1st arg is version-string or main-bin-spec\n");
+    exit(1);
+  }
+  if (strcmp(argv[1], "version-string") != 0 &&
+      strcmp(argv[1], "main-bin-spec") != 0) {
+    fprintf(stderr, "arg1 was not version-string or main-bin-spec\n");
+    exit(1);
+  }
+
+  std::string uuid = get_uuid_from_binary(argv[3]);
+
+  // An array of load commands (in the form of byte arrays)
+  std::vector<std::vector<uint8_t>> load_commands;
+
+  // An array of corefile contents (page data, lc_note data, etc)
+  std::vector<uint8_t> payload;
+
+  // First add all the load commands / payload so we can figure out how large
+  // the load commands will actually be.
+  load_commands.push_back(x86_lc_thread_load_command());
+  if (strcmp(argv[1], "version-string") == 0)
+    add_lc_note_kern_ver_str_load_command(load_commands, payload, 0, uuid);
+  else
+    add_lc_note_main_bin_spec_load_command(load_commands, payload, 0, uuid);
+  add_lc_segment(load_commands, payload, 0);
+
+  int size_of_load_commands = 0;
+  for (const auto &lc : load_commands)
+    size_of_load_commands += lc.size();
+
+  int header_and_load_cmd_room =
+      sizeof(struct mach_header_64) + size_of_load_commands;
+
+  // Erase the load commands / payload now that we know how much space is
+  // needed, redo it.
+  load_commands.clear();
+  payload.clear();
+
+  load_commands.push_back(x86_lc_thread_load_command());
+
+  if (strcmp(argv[1], "version-string") == 0)
+    add_lc_note_kern_ver_str_load_command(load_commands, payload,
+                                          header_and_load_cmd_room, uuid);
+  else
+    add_lc_note_main_bin_spec_load_command(load_commands, payload,
+                                           header_and_load_cmd_room, uuid);
+
+  add_lc_segment(load_commands, payload, header_and_load_cmd_room);
+
+  struct mach_header_64 mh;
+  mh.magic = MH_MAGIC_64;
+  mh.cputype = CPU_TYPE_X86_64;
+
+  mh.cpusubtype = CPU_SUBTYPE_X86_64_ALL;
+  mh.filetype = MH_CORE;
+  mh.ncmds = load_commands.size();
+  mh.sizeofcmds = size_of_load_commands;
+  mh.flags = 0;
+  mh.reserved = 0;
+
+  FILE *f = fopen(argv[2], "w");
+
+  if (f == nullptr) {
+    fprintf(stderr, "Unable to open file %s for writing\n", argv[2]);
+    exit(1);
+  }
+
+  fwrite(&mh, sizeof(struct mach_header_64), 1, f);
+
+  for (const auto &lc : load_commands)
+    fwrite(lc.data(), lc.size(), 1, f);
+
+  fseek(f, header_and_load_cmd_room, SEEK_SET);
+
+  fwrite(payload.data(), payload.size(), 1, f);
+
+  fclose(f);
+}

--- a/lldb/test/API/macosx/lc-note/firmware-corefile/main.c
+++ b/lldb/test/API/macosx/lc-note/firmware-corefile/main.c
@@ -1,0 +1,2 @@
+#include <stdio.h>
+int main () { puts ("this is the lc-note test program."); }


### PR DESCRIPTION
Add support for firmware/standalone LC_NOTE "main bin spec" corefiles

When a Mach-O corefile has an LC_NOTE "main bin spec" for a
standalone binary / firmware, with only a UUID and no load
address, try to locate the binary and dSYM by UUID and if
found, load it at offset 0 for the user.

Add a test case that tests a firmware/standalone corefile
with both the "kern ver str" and "main bin spec" LC_NOTEs.

<rdar://problem/68193804>

Differential Revision: https://reviews.llvm.org/D88282

(cherry picked from commit 1bec6eb3f5cba594698bae5b2789744e0c8ee5f2)