### PR TITLE
Once we've found a firmware binary and loaded it, don't search more

### DIFF
--- a/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
+++ b/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
@@ -398,6 +398,7 @@ Status ProcessMachCore::DoLoadCore() {
           added_module.Append(module_sp, false);
           GetTarget().ModulesDidLoad(added_module);
           m_dyld_plugin_name = DynamicLoaderDarwinKernel::GetPluginNameStatic();
+          found_main_binary_definitively = true;
         }
       }
     }


### PR DESCRIPTION
Once we've found a firmware binary and loaded it, don't search more

Add the flag in ProcessMachCore::DoLoadCore that stops additional
searches for the binaries when we have an LC_NOTE identifying the
firmware/standalone binary as the correct one & we have loaded it
successfully.

(cherry picked from commit 6e54918db7f4dad0d5a6fbff140009ed6f151d2c)