### PR TITLE
[lldb] Stub Swift type system implementations of GetPointerType

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5876,13 +5876,7 @@ CompilerType SwiftASTContext::GetPointeeType(opaque_compiler_type_t type) {
 
 CompilerType SwiftASTContext::GetPointerType(opaque_compiler_type_t type) {
   VALID_OR_RETURN(CompilerType());
-
-  if (type) {
-    swift::Type swift_type(GetSwiftType({this, type}));
-    const swift::TypeKind type_kind = swift_type->getKind();
-    if (type_kind == swift::TypeKind::BuiltinRawPointer)
-      return ToCompilerType({swift_type});
-  }
+  assert(false && "GetPointerType is unimplemented for Swift types");
   return {};
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1636,9 +1636,14 @@ CompilerType
 TypeSystemSwiftTypeRef::GetPointeeType(opaque_compiler_type_t type) {
   return m_swift_ast_context->GetPointeeType(ReconstructType(type));
 }
+
 CompilerType
 TypeSystemSwiftTypeRef::GetPointerType(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetPointerType(ReconstructType(type));
+  auto impl = [&]() -> CompilerType {
+    assert(false && "GetPointerType is unimplemented for Swift types");
+    return {};
+  };
+  VALIDATE_AND_RETURN(impl, GetPointerType, type, (ReconstructType(type)));
 }
 
 // Exploring the type


### PR DESCRIPTION
Following discussion in https://github.com/apple/llvm-project/pull/1809, this stubs out the current and not useful implementation of `GetPointerType` for Swift types (`SwiftASTContext` and `TypeSystemSwiftTypeRef`).

The existing implementation of `SwiftASTContext::GetPointerType` is a pass through for `Builtin.RawPointer`. This doesn't match the semantics of `TypeSystemClang::GetPointerType`. To match Clang, Swift type systems should probably return `UnsafePointer<T>` for a given type `T`. Or it could be `UnsafeMutablePointer<T>`, or one of the other possible alternatives.

It appears `GetPointerType` is not being called for Swift types, and so instead of speculating what the implementation should do, this change stubs out the implementation. When the time comes that `GetPointerType` is called for Swift types, we can implement it at that time within those known requirements.

rdar://68171356