### PR TITLE
[lldb] Stop unconditionally emitting "could not resolve type"

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -8080,12 +8080,13 @@ void SwiftASTContext::DumpTypeDescription(opaque_compiler_type_t type,
       }
     } break;
     }
-
-    if (buf.size() > 0) {
-      s->Write(buf.data(), buf.size());
-    }
   }
-  s->Printf("<could not resolve type>");
+
+  if (buf.size() > 0) {
+    s->Write(buf.data(), buf.size());
+  } else {
+    s->Printf("<could not resolve type>");
+  }
 }
 
 TypeSP SwiftASTContext::GetCachedType(ConstString mangled) {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -7915,8 +7915,7 @@ void SwiftASTContext::DumpTypeDescription(opaque_compiler_type_t type,
                                           bool print_help_if_available,
                                           bool print_extensions_if_available,
                                           lldb::DescriptionLevel level) {
-  llvm::SmallVector<char, 1024> buf;
-  llvm::raw_svector_ostream llvm_ostrm(buf);
+  const auto initial_written_bytes = s->GetWrittenBytes();
 
   if (type) {
     swift::CanType swift_can_type(GetCanonicalSwiftType(type));
@@ -8082,11 +8081,8 @@ void SwiftASTContext::DumpTypeDescription(opaque_compiler_type_t type,
     }
   }
 
-  if (buf.size() > 0) {
-    s->Write(buf.data(), buf.size());
-  } else {
+  if (s->GetWrittenBytes() == initial_written_bytes)
     s->Printf("<could not resolve type>");
-  }
 }
 
 TypeSP SwiftASTContext::GetCachedType(ConstString mangled) {

--- a/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
+++ b/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
@@ -56,6 +56,12 @@ class TestSwiftTypeLookup(TestBase):
                 'func bar()',
                 'var b'])
 
+        # Regression test. Ensure "<could not resolve type>" is not output.
+        self.expect(
+            "type lookup String",
+            matching=False,
+            substrs=["<could not resolve type>"])
+
         # check that specifiers are honored
         # self.expect('type lookup class Cla1', substrs=['class Cla1 {'])
         # self.expect('type lookup struct Cla1', substrs=['class Cla1 {'], matching=False, error=True)


### PR DESCRIPTION
I noticed that `type lookup <swift-type>` always concluded its output with `<could not resolve type>`, even after all the expected output. In https://github.com/apple/llvm-project/pull/898 it appears this message is being output for all calls to `DumpTypeDescription`. This changes it to only emit `<could not resolve type>` if no type information is otherwise produced.