### PR TITLE
Cherrypick: [NFC] Update ImportFilterKinds to match rename in Swift.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -8293,9 +8293,14 @@ bool SwiftASTContext::CacheUserImports(SwiftASTContext &swift_ast_context,
   llvm::SmallString<1> m_description;
   llvm::SmallVector<swift::ModuleDecl::ImportedModule, 2> parsed_imports;
 
-  swift::ModuleDecl::ImportFilter import_filter;
-  import_filter |= swift::ModuleDecl::ImportFilterKind::Public;
-  import_filter |= swift::ModuleDecl::ImportFilterKind::Private;
+  swift::ModuleDecl::ImportFilter import_filter {
+      swift::ModuleDecl::ImportFilterKind::Exported,
+      swift::ModuleDecl::ImportFilterKind::Default,
+      swift::ModuleDecl::ImportFilterKind::ImplementationOnly,
+      swift::ModuleDecl::ImportFilterKind::SPIAccessControl,
+      swift::ModuleDecl::ImportFilterKind::ShadowedByCrossImportOverlay
+  };
+
   source_file.getImportedModules(parsed_imports, import_filter);
 
   auto *persistent_expression_state =


### PR DESCRIPTION
https://github.com/apple/llvm-project/pull/1819 Never was cherry picked into swift/next. This fixes the swift/next build.