### PR TITLE
[lldb][swift] Fix building with disabled swift support

### DIFF
--- a/lldb/source/API/SystemInitializerFull.cpp
+++ b/lldb/source/API/SystemInitializerFull.cpp
@@ -17,13 +17,13 @@
 #include "lldb/Utility/Timer.h"
 #include "llvm/Support/TargetSelect.h"
 
-// BEGIN SWIFT
+#ifdef LLDB_ENABLE_SWIFT
 #include "Plugins/ExpressionParser/Swift/SwiftREPL.h"
 #include "Plugins/InstrumentationRuntime/SwiftRuntimeReporting/SwiftRuntimeReporting.h"
 #include "Plugins/Language/Swift/SwiftLanguage.h"
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
-// END SWIFT
+#endif //LLDB_ENABLE_SWIFT
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wglobal-constructors"

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -51,9 +51,9 @@
 #include "lldb/Utility/StreamString.h"
 #include "lldb/lldb-private-types.h"
 
-// BEGIN SWIFT
+#ifdef LLDB_ENABLE_SWIFT
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
-// END SWIFT
+#endif //LLDB_ENABLE_SWIFT
 
 #include "llvm/Support/Compiler.h"
 

--- a/lldb/source/Core/ValueObjectDynamicValue.cpp
+++ b/lldb/source/Core/ValueObjectDynamicValue.cpp
@@ -22,7 +22,9 @@
 #include "lldb/Utility/Status.h"
 #include "lldb/lldb-types.h"
 
+#ifdef LLDB_ENABLE_SWIFT
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
+#endif // LLDB_ENABLE_SWIFT
 
 #include <string.h>
 namespace lldb_private {

--- a/lldb/source/Expression/IRExecutionUnit.cpp
+++ b/lldb/source/Expression/IRExecutionUnit.cpp
@@ -25,7 +25,6 @@
 #include "lldb/Symbol/SymbolVendor.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/LanguageRuntime.h"
-#include "lldb/Target/SwiftLanguageRuntime.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/DataExtractor.h"
@@ -34,6 +33,10 @@
 
 #include "lldb/../../source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.h"
 #include "lldb/../../source/Plugins/ObjectFile/JIT/ObjectFileJIT.h"
+
+#ifdef LLDB_ENABLE_SWIFT
+#include "lldb/Target/SwiftLanguageRuntime.h"
+#endif //LLDB_ENABLE_SWIFT
 
 using namespace lldb_private;
 

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -23,7 +23,9 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/RegisterValue.h"
 
+#ifdef LLDB_ENABLE_SWIFT
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
+#endif //LLDB_ENABLE_SWIFT
 
 #include <memory>
 

--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -44,7 +44,9 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/StreamString.h"
 
+#ifdef LLDB_ENABLE_SWIFT
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
+#endif //LLDB_ENABLE_SWIFT
 
 using namespace lldb_private;
 

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -40,7 +40,10 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/MipsABIFlags.h"
+
+#ifdef LLDB_ENABLE_SWIFT
 #include "swift/ABI/ObjectFile.h"
+#endif //LLDB_ENABLE_SWIFT
 
 #define CASE_AND_STREAM(s, def, width)                                         \
   case def:                                                                    \
@@ -3407,6 +3410,10 @@ ObjectFileELF::GetLoadableData(Target &target) {
 
 llvm::StringRef ObjectFileELF::GetReflectionSectionIdentifier(
     swift::ReflectionSectionKind section) {
+#ifdef LLDB_ENABLE_SWIFT
   swift::SwiftObjectFileFormatELF file_format_elf;
   return file_format_elf.getSectionName(section);
+#else
+  llvm_unreachable("Swift support disabled");
+#endif //LLDB_ENABLE_SWIFT
 }

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -27,7 +27,6 @@
 #include "lldb/Target/Platform.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/SectionLoadList.h"
-#include "lldb/Target/SwiftLanguageRuntime.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Target/Thread.h"
 #include "lldb/Target/ThreadList.h"
@@ -47,7 +46,10 @@
 #include "llvm/Support/MemoryBuffer.h"
 
 #include "ObjectFileMachO.h"
+#ifdef LLDB_ENABLE_SWIFT
 #include "swift/ABI/ObjectFile.h"
+#include "lldb/Target/SwiftLanguageRuntime.h"
+#endif //LLDB_ENABLE_SWIFT
 
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
@@ -6474,6 +6476,10 @@ bool ObjectFileMachO::SaveCore(const lldb::ProcessSP &process_sp,
 
 llvm::StringRef ObjectFileMachO::GetReflectionSectionIdentifier(
     swift::ReflectionSectionKind section) {
+#ifdef LLDB_ENABLE_SWIFT
   swift::SwiftObjectFileFormatMachO file_format_mach_o;
   return file_format_mach_o.getSectionName(section);
+#else
+  llvm_unreachable("Swift support disabled");
+#endif //LLDB_ENABLE_SWIFT
 }

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -33,7 +33,9 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 
+#ifdef LLDB_ENABLE_SWIFT
 #include "swift/ABI/ObjectFile.h"
+#endif //LLDB_ENABLE_SWIFT
 
 #define IMAGE_DOS_SIGNATURE 0x5A4D    // MZ
 #define IMAGE_NT_SIGNATURE 0x00004550 // PE00
@@ -1257,6 +1259,10 @@ uint32_t ObjectFilePECOFF::GetPluginVersion() { return 1; }
 
 llvm::StringRef ObjectFilePECOFF::GetReflectionSectionIdentifier(
     swift::ReflectionSectionKind section) {
+#ifdef LLDB_ENABLE_SWIFT
   swift::SwiftObjectFileFormatCOFF file_format_coff;
   return file_format_coff.getSectionName(section);
+#else
+  llvm_unreachable("Swift support disabled");
+#endif //LLDB_ENABLE_SWIFT
 }

--- a/lldb/source/Target/ABI.cpp
+++ b/lldb/source/Target/ABI.cpp
@@ -19,7 +19,9 @@
 #include "llvm/Support/TargetRegistry.h"
 #include <cctype>
 
+#ifdef LLDB_ENABLE_SWIFT
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
+#endif //LLDB_ENABLE_SWIFT
 
 using namespace lldb;
 using namespace lldb_private;

--- a/lldb/source/Target/ThreadPlanCallFunction.cpp
+++ b/lldb/source/Target/ThreadPlanCallFunction.cpp
@@ -18,7 +18,6 @@
 #include "lldb/Target/Process.h"
 #include "lldb/Target/RegisterContext.h"
 #include "lldb/Target/StopInfo.h"
-#include "lldb/Target/SwiftLanguageRuntime.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Target/Thread.h"
 #include "lldb/Target/ThreadPlanRunToAddress.h"
@@ -26,6 +25,10 @@
 #include "lldb/Utility/Stream.h"
 
 #include <memory>
+
+#ifdef LLDB_ENABLE_SWIFT
+#include "lldb/Target/SwiftLanguageRuntime.h"
+#endif //LLDB_ENABLE_SWIFT
 
 using namespace lldb;
 using namespace lldb_private;

--- a/lldb/source/Target/ThreadPlanStepOut.cpp
+++ b/lldb/source/Target/ThreadPlanStepOut.cpp
@@ -20,13 +20,16 @@
 #include "lldb/Target/Process.h"
 #include "lldb/Target/RegisterContext.h"
 #include "lldb/Target/StopInfo.h"
-#include "lldb/Target/SwiftLanguageRuntime.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Target/ThreadPlanStepOverRange.h"
 #include "lldb/Target/ThreadPlanStepThrough.h"
 #include "lldb/Utility/Log.h"
 
 #include <memory>
+
+#ifdef LLDB_ENABLE_SWIFT
+#include "lldb/Target/SwiftLanguageRuntime.h"
+#endif // LLDB_ENABLE_SWIFT
 
 using namespace lldb;
 using namespace lldb_private;

--- a/lldb/unittests/Symbol/CMakeLists.txt
+++ b/lldb/unittests/Symbol/CMakeLists.txt
@@ -2,9 +2,13 @@ set(SWIFT_SOURCES
   TestSwiftASTContext.cpp
   TestTypeSystemSwiftTypeRef.cpp
 )
+set(SWIFT_LIBS
+  lldbPluginTypeSystemSwift
+)
 set(LLVM_OPTIONAL_SOURCES ${SWIFT_SOURCES})
 if (NOT LLDB_ENABLE_SWIFT_SUPPORT)
   unset(SWIFT_SOURCES)
+  unset(SWIFT_LIBS)
 endif()
 
 add_lldb_unittest(SymbolTests
@@ -27,7 +31,7 @@ add_lldb_unittest(SymbolTests
     lldbPluginSymbolFileDWARF
     lldbPluginSymbolFileSymtab
     lldbPluginTypeSystemClang
-    lldbPluginTypeSystemSwift
+    ${SWIFT_LIBS}
     LLVMTestingSupport
   )
 


### PR DESCRIPTION
This adds the missing ifdefs for code that only compiles/links with an
enabled Swift plugin. Also moves a few Swift includes that were embedded in
the normal include list to their own section at the end (to prevent automerger
issues).