### PR TITLE
[lldb][swift] Only run Swift API tests when Swift support is enabled

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -626,6 +626,9 @@ def skipUnlessTargetAndroid(func):
 def swiftTest(func):
     """Decorate the item as a Swift test (Darwin/Linux only, no i386)."""
     def is_not_swift_compatible(self):
+        swift_enabled_error = _get_bool_config_skip_if_decorator("swift")(func)
+        if swift_enabled_error:
+            return swift_enabled_error
         if self.getDebugInfo() == "gmodules":
             return "skipping (gmodules only makes sense for clang tests)"
 

--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -702,6 +702,12 @@ SBStructuredData SBDebugger::GetBuildConfiguration() {
       "A boolean value that indicates if lua support is enabled in LLDB");
   AddLLVMTargets(*config_up);
 
+#ifdef LLDB_ENABLE_SWIFT
+  AddBoolConfigEntry(
+      *config_up, "swift", true,
+      "A boolean value that indicates if Swift support is enabled in LLDB");
+#endif // LLDB_ENABLE_SWIFT
+
   SBStructuredData data;
   data.m_impl_up->SetObjectSP(std::move(config_up));
   return LLDB_RECORD_RESULT(data);


### PR DESCRIPTION
Disabling Swift support in LLDB doesn't prevent the test suite from running
the Swift tests (which then end up failing instead of being marked as
unsupported). This adds swift to the SBDebugger configuration and then checks
that Swift is enabled when running Swift API tests.