### PR TITLE
[lldb][swift] Only run Swift Shell tests when Swift support is enabled

### DIFF
--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -174,6 +174,12 @@ llvm_canonicalize_cmake_booleans(
   LLVM_ENABLE_SHARED_LIBS
   LLDB_IS_64_BITS)
 
+# BEGIN SWIFT
+llvm_canonicalize_cmake_booleans(
+  LLDB_ENABLE_SWIFT_SUPPORT
+)
+# END SWIFT
+
 # Configure the individual test suites.
 add_subdirectory(API)
 add_subdirectory(Shell)

--- a/lldb/test/Shell/Reproducer/Swift/TestBridging.test
+++ b/lldb/test/Shell/Reproducer/Swift/TestBridging.test
@@ -1,4 +1,5 @@
 # UNSUPPORTED: system-windows, system-freebsd, system-linux
+# REQUIRES: swift
 
 # This tests replaying a Swift reproducer with bridging.
 

--- a/lldb/test/Shell/Reproducer/Swift/TestModule.test
+++ b/lldb/test/Shell/Reproducer/Swift/TestModule.test
@@ -1,4 +1,5 @@
 # UNSUPPORTED: system-windows, system-freebsd
+# REQUIRES: swift
 
 # This tests replaying a Swift reproducer with bridging.
 

--- a/lldb/test/Shell/Reproducer/Swift/TestSimple.test
+++ b/lldb/test/Shell/Reproducer/Swift/TestSimple.test
@@ -1,4 +1,5 @@
 # UNSUPPORTED: system-windows, system-freebsd
+# REQUIRES: swift
 
 # This tests replaying a simple reproducer.
 

--- a/lldb/test/Shell/Reproducer/Swift/TestSwiftInterface.test
+++ b/lldb/test/Shell/Reproducer/Swift/TestSwiftInterface.test
@@ -1,6 +1,7 @@
 # Test that reproducers can deal with .swiftinterface files.
 
 # REQUIRES: system-darwin
+# REQUIRES: swift
 #
 # rdar://problem/55564275
 # XFAIL: *

--- a/lldb/test/Shell/Swift/DeserializationFailure.test
+++ b/lldb/test/Shell/Swift/DeserializationFailure.test
@@ -1,4 +1,5 @@
 # REQUIRES: system-darwin
+# REQUIRES: swift
 # Tests that error messages from deserializing Swift modules are
 # printed to the error stream. Architecturally it is not possible to
 # write this as a dotest.py test.

--- a/lldb/test/Shell/Swift/DynamicTyperesolutionConflict.test
+++ b/lldb/test/Shell/Swift/DynamicTyperesolutionConflict.test
@@ -1,5 +1,6 @@
 # REQUIRES: system-darwin
 # REQUIRES: rdar50667488
+# REQUIRES: swift
 
 # This testcase causes the scratch context to get destroyed by a
 # conflict that is triggered via dynamic type resolution. The conflict

--- a/lldb/test/Shell/Swift/MissingVFSOverlay.test
+++ b/lldb/test/Shell/Swift/MissingVFSOverlay.test
@@ -1,5 +1,6 @@
 # Test that error messages from constructing ClangImporter
 # are surfaced to the user.
+# REQUIRES: swift
 
 # RUN: rm -rf %t && mkdir %t && cd %t
 # RUN: cp %p/../../API/lang/swift/deserialization_failure/Inputs/main.swift %t/main.swift

--- a/lldb/test/Shell/Swift/No.swiftmodule-ObjC.test
+++ b/lldb/test/Shell/Swift/No.swiftmodule-ObjC.test
@@ -1,4 +1,5 @@
 # REQUIRES: system-darwin
+# REQUIRES: swift
 # This tests debugging without the presence of a .swiftmodule.
 
 # RUN: rm -rf %t && mkdir %t && cd %t

--- a/lldb/test/Shell/Swift/No.swiftmodule.test
+++ b/lldb/test/Shell/Swift/No.swiftmodule.test
@@ -1,4 +1,5 @@
 # This tests debugging without the presence of a .swiftmodule.
+# REQUIRES: swift
 
 # RUN: rm -rf %t && mkdir %t && cd %t
 #

--- a/lldb/test/Shell/Swift/RemoteASTImport.test
+++ b/lldb/test/Shell/Swift/RemoteASTImport.test
@@ -1,4 +1,5 @@
 # REQUIRES: system-darwin
+# REQUIRES: swift
 
 # This tests that RemoteAST querying the dynamic type of a variable
 # doesn't import any modules into a module SwiftASTContext that

--- a/lldb/test/Shell/Swift/astcontext_error.test
+++ b/lldb/test/Shell/Swift/astcontext_error.test
@@ -1,3 +1,4 @@
+# REQUIRES: swift
 # RUN: rm -rf %t && mkdir %t && cd %t
 # RUN: %target-swiftc -g %S/Inputs/ContextError.swift
 # RUN: %lldb ContextError -s %s | FileCheck %S/Inputs/ContextError.swift

--- a/lldb/test/Shell/Swift/cond-breakpoint.test
+++ b/lldb/test/Shell/Swift/cond-breakpoint.test
@@ -1,3 +1,4 @@
+# REQUIRES: swift
 # RUN: rm -rf %t && mkdir %t && cd %t
 # RUN: %target-swiftc -g %S/Inputs/main.swift -o a.out
 # RUN: %lldb a.out -b -s %s 2>&1 | FileCheck %s

--- a/lldb/test/Shell/Swift/global.test
+++ b/lldb/test/Shell/Swift/global.test
@@ -1,3 +1,5 @@
+# REQUIRES: swift
+
 # RUN: rm -rf %t && mkdir %t && cd %t
 # RUN: %target-swiftc -g \
 # RUN:          -module-cache-path %t/cache %S/Inputs/Global.swift \

--- a/lldb/test/Shell/Swift/runtime-initialization.test
+++ b/lldb/test/Shell/Swift/runtime-initialization.test
@@ -1,3 +1,4 @@
+# REQUIRES: swift
 # RUN: rm -rf %t && mkdir %t
 # RUN: %target-swiftc -g \
 # RUN:          -module-cache-path %t/cache %S/Inputs/RuntimeInit.swift \

--- a/lldb/test/Shell/SwiftREPL/Basic.test
+++ b/lldb/test/Shell/SwiftREPL/Basic.test
@@ -1,4 +1,5 @@
 // Basic sanity checking of the REPL.
+// REQUIRES: swift
 
 // RUN: %lldb --repl --repl-language swift | FileCheck %s --check-prefix=SWIFT
 // SWIFT: Welcome to {{.*}}Swift

--- a/lldb/test/Shell/SwiftREPL/BreakpointSimple.test
+++ b/lldb/test/Shell/SwiftREPL/BreakpointSimple.test
@@ -1,5 +1,5 @@
 // Test that we can set breakpoints in the REPL.
-
+// REQUIRES: swift
 // RUN: %lldb --repl < %s | FileCheck %s
 
 func foo() -> Int {

--- a/lldb/test/Shell/SwiftREPL/CFString.test
+++ b/lldb/test/Shell/SwiftREPL/CFString.test
@@ -1,5 +1,6 @@
 // Test that CFString works in the REPL.
 // REQUIRES: system-darwin
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 // CHECK: Welcome to {{.*}}Swift

--- a/lldb/test/Shell/SwiftREPL/Class.test
+++ b/lldb/test/Shell/SwiftREPL/Class.test
@@ -1,4 +1,5 @@
 // Test that we can define and use a basic class.
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/ComputedProperties.test
+++ b/lldb/test/Shell/SwiftREPL/ComputedProperties.test
@@ -1,4 +1,5 @@
 // Check that we print computed properties correctly.
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/CrashArgs.test
+++ b/lldb/test/Shell/SwiftREPL/CrashArgs.test
@@ -1,4 +1,5 @@
 // Make sure we don't crash if we pass args to the repl.
+// REQUIRES: swift
 
 // RUN: %lldb --repl="-some-argument" | FileCheck %s --check-prefix=SWIFT
 // SWIFT: Welcome to {{.*}}Swift

--- a/lldb/test/Shell/SwiftREPL/Deadlock.test
+++ b/lldb/test/Shell/SwiftREPL/Deadlock.test
@@ -1,3 +1,5 @@
+// REQUIRES: swift
+
 // RUN: %lldb --repl < %s | FileCheck %s
 
 // From https://bugs.swift.org/browse/SR-7114
@@ -5,11 +7,11 @@
 
 let a = 9007199254740991.0
 // CHECK: a: Double = 9007199254740991
-(a * a - a * a).squareRoot() 
+(a * a - a * a).squareRoot()
 // CHECK: (Double) = {
 // CHECK-NEXT:  _value = 0
 // CHECK-NEXT: }
 (a * a).addingProduct(-a, a).squareRoot()
 // CHECK: (Double) = {
-// CHECK-NEXT:  _value = NaN 
+// CHECK-NEXT:  _value = NaN
 // CHECK-NEXT: }

--- a/lldb/test/Shell/SwiftREPL/DeferredNSArray.test
+++ b/lldb/test/Shell/SwiftREPL/DeferredNSArray.test
@@ -1,5 +1,6 @@
 // Test that NSDeferredArray data formatter works.
 // REQUIRES: system-darwin
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/DeploymentTarget.test
+++ b/lldb/test/Shell/SwiftREPL/DeploymentTarget.test
@@ -1,5 +1,6 @@
 // Test that the REPL can call a *really* new function.
 // REQUIRES: system-darwin
+// REQUIRES: swift
 
 // RUN: echo -n "@available(macOS " >%t.swift
 // RUN: python -c 'from __future__ import print_function; import platform; print(platform.mac_ver()[0],end="")' >>%t.swift

--- a/lldb/test/Shell/SwiftREPL/Dict.test
+++ b/lldb/test/Shell/SwiftREPL/Dict.test
@@ -1,4 +1,5 @@
 // Test that the dictionary data formatter works in the REPL.
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=DICT
 

--- a/lldb/test/Shell/SwiftREPL/DictBridging.test
+++ b/lldb/test/Shell/SwiftREPL/DictBridging.test
@@ -1,6 +1,8 @@
 // -*- mode: swift; -*-
 // Test formatters on bridged dictionaries in the REPL.
 // REQUIRES: system-darwin
+// REQUIRES: swift
+
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=DICT
 
 import Foundation

--- a/lldb/test/Shell/SwiftREPL/ErrorReturn.test
+++ b/lldb/test/Shell/SwiftREPL/ErrorReturn.test
@@ -1,6 +1,7 @@
 // XFAIL: powerpc64le
 // SR-10212
 // Test that we can handle errors.
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/ErrorReturnObjC.test
+++ b/lldb/test/Shell/SwiftREPL/ErrorReturnObjC.test
@@ -2,6 +2,7 @@
 // types when they're stored in REPL-defined globals.
 
 // REQUIRES: system-darwin
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/ExclusivityREPL.test
+++ b/lldb/test/Shell/SwiftREPL/ExclusivityREPL.test
@@ -1,4 +1,5 @@
 // Runtime checks for exclusive access should be enabled in the REPL.
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s 2>&1 | FileCheck %s
 // CHECK: modification requires exclusive access

--- a/lldb/test/Shell/SwiftREPL/FoundationTypes.test
+++ b/lldb/test/Shell/SwiftREPL/FoundationTypes.test
@@ -2,6 +2,7 @@
 // types when they're stored in REPL-defined globals.
 
 // REQUIRES: system-darwin
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/FrameworkPath.test
+++ b/lldb/test/Shell/SwiftREPL/FrameworkPath.test
@@ -1,5 +1,6 @@
 // Test target.swift-framework-search-paths works in the REPL.
 // REQUIRES: system-darwin
+// REQUIRES: swift
 
 // RUN: %lldb -O "settings set target.swift-framework-search-paths %S/Inputs/Frameworks" --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/GLKIT.test
+++ b/lldb/test/Shell/SwiftREPL/GLKIT.test
@@ -1,5 +1,6 @@
 // Test formatters for Accelerate/simd.
 // REQUIRES: system-darwin
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/GenericTypealias.test
+++ b/lldb/test/Shell/SwiftREPL/GenericTypealias.test
@@ -1,4 +1,6 @@
 // Test that generic typealiases are reconstructed correctly.
+// REQUIRES: swift
+
 // RUN: %lldb --repl < %s | FileCheck %s
 
 class Tinky<T> {

--- a/lldb/test/Shell/SwiftREPL/Generics.test
+++ b/lldb/test/Shell/SwiftREPL/Generics.test
@@ -1,4 +1,5 @@
 // Test that generics work in the REPL.
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/ImportCocoa.test
+++ b/lldb/test/Shell/SwiftREPL/ImportCocoa.test
@@ -1,5 +1,6 @@
 // Test that importing Cocoa works.
 // REQUIRES: system-darwin
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s 2>&1 | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/ImportDispatch.test
+++ b/lldb/test/Shell/SwiftREPL/ImportDispatch.test
@@ -1,5 +1,6 @@
 // Test that importing Dispatch works.
 // REQUIRES: system-darwin
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s 2>&1 | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/ImportError.test
+++ b/lldb/test/Shell/SwiftREPL/ImportError.test
@@ -1,4 +1,5 @@
 // Test that importing non-existing module fails.
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s 2>&1 | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/ImportFoundation.test
+++ b/lldb/test/Shell/SwiftREPL/ImportFoundation.test
@@ -1,5 +1,6 @@
 // Test that type lookup chooses the right language.
 // REQUIRES: system-darwin
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/InitFile.test
+++ b/lldb/test/Shell/SwiftREPL/InitFile.test
@@ -1,5 +1,7 @@
 // Test that the Swift REPL init file works.
 // REQUIRES: system-darwin
+// REQUIRES: swift
+
 // RUN: export HOME=%t
 // RUN: mkdir -p %t
 // RUN: echo 'br set -f main.c -l 123' > ~/.lldbinit

--- a/lldb/test/Shell/SwiftREPL/LookupAfterImport.test
+++ b/lldb/test/Shell/SwiftREPL/LookupAfterImport.test
@@ -1,5 +1,6 @@
 // Make sure we properly load in new extension members after an import.
 // rdar://64040436
+// REQUIRES: swift
 
 // RUN: rm -rf %t
 // RUN: mkdir %t

--- a/lldb/test/Shell/SwiftREPL/MetatypeRepl.test
+++ b/lldb/test/Shell/SwiftREPL/MetatypeRepl.test
@@ -1,3 +1,5 @@
+// REQUIRES: swift
+
 // RUN: %lldb --repl < %s | FileCheck %s
 
 let x = [Double.self]

--- a/lldb/test/Shell/SwiftREPL/NSObjectSubclass.test
+++ b/lldb/test/Shell/SwiftREPL/NSObjectSubclass.test
@@ -1,5 +1,6 @@
 // Test that the REPL allows defining subclasses of NSObject.
 // REQUIRES: system-darwin
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/NSString.test
+++ b/lldb/test/Shell/SwiftREPL/NSString.test
@@ -1,5 +1,6 @@
 // Test that NSString works in the REPL.
 // REQUIRES: system-darwin
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=NSSTRING
 

--- a/lldb/test/Shell/SwiftREPL/OpenClass.test
+++ b/lldb/test/Shell/SwiftREPL/OpenClass.test
@@ -1,4 +1,5 @@
 // RUN: %lldb --repl < %s 2>&1 | FileCheck %s
+// REQUIRES: swift
 
 class Foo {
   // Don't make any of these 'open'.

--- a/lldb/test/Shell/SwiftREPL/Optional.test
+++ b/lldb/test/Shell/SwiftREPL/Optional.test
@@ -1,4 +1,5 @@
 // RUN: %lldb --repl < %s | FileCheck %s
+// REQUIRES: swift
 
 enum Patatino {
   case first

--- a/lldb/test/Shell/SwiftREPL/OptionalUnowned.test
+++ b/lldb/test/Shell/SwiftREPL/OptionalUnowned.test
@@ -1,3 +1,5 @@
+// REQUIRES: swift
+
 // RUN: %lldb --repl < %s | FileCheck %s
 
 class C

--- a/lldb/test/Shell/SwiftREPL/OptionalWithDynamicType.test
+++ b/lldb/test/Shell/SwiftREPL/OptionalWithDynamicType.test
@@ -2,6 +2,7 @@
 // optional.
 
 // REQUIRES: system-darwin
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s 2>&1 | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/PropertyWrapperPrivate.test
+++ b/lldb/test/Shell/SwiftREPL/PropertyWrapperPrivate.test
@@ -1,5 +1,6 @@
 // Test that we don't crash when SILGen(ing) property wrappers
 // [private].
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/PropertyWrapperPublic.test
+++ b/lldb/test/Shell/SwiftREPL/PropertyWrapperPublic.test
@@ -1,5 +1,6 @@
 // Test that we don't crash when SILGen(ing) property wrappers
 // [public].
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/PropertyWrapperTopLevel.test
+++ b/lldb/test/Shell/SwiftREPL/PropertyWrapperTopLevel.test
@@ -1,3 +1,5 @@
+// REQUIRES: swift
+
 // RUN: %lldb --repl < %s 2>&1 | FileCheck %s
 
 @propertyWrapper struct A<T> {

--- a/lldb/test/Shell/SwiftREPL/RecursiveClass.test
+++ b/lldb/test/Shell/SwiftREPL/RecursiveClass.test
@@ -1,4 +1,5 @@
 // Test that recursive class instances work in the REPL.
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/Redefinition.test
+++ b/lldb/test/Shell/SwiftREPL/Redefinition.test
@@ -1,4 +1,5 @@
 // Test that we can set breakpoints in the REPL.
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/RedirectInput.test
+++ b/lldb/test/Shell/SwiftREPL/RedirectInput.test
@@ -1,4 +1,5 @@
 // Test that input can be redirected from A.swift
+// REQUIRES: swift
 
 // RUN: mkdir -p %t
 // RUN: cp %S/Inputs/A.swift %t/A.swift

--- a/lldb/test/Shell/SwiftREPL/RedirectInputNoSuchFile.test
+++ b/lldb/test/Shell/SwiftREPL/RedirectInputNoSuchFile.test
@@ -1,4 +1,5 @@
 // Test that input can't be redirected from non-existent file A.swift
+// REQUIRES: swift
 
 // RUN: mkdir -p %t
 // RUN: cd %t

--- a/lldb/test/Shell/SwiftREPL/RedirectInputUnreadable.test
+++ b/lldb/test/Shell/SwiftREPL/RedirectInputUnreadable.test
@@ -1,4 +1,5 @@
 // Test that input can't be redirected from unreadable A.swift
+// REQUIRES: swift
 
 // RUN: mkdir -p %t
 // RUN: cp %S/Inputs/A.swift %t/A.swift

--- a/lldb/test/Shell/SwiftREPL/ResilientArray.test
+++ b/lldb/test/Shell/SwiftREPL/ResilientArray.test
@@ -1,4 +1,6 @@
 // REQUIRES: system-darwin
+// REQUIRES: swift
+
 // RUN: %lldb --repl < %s | FileCheck %s
 
 import Foundation

--- a/lldb/test/Shell/SwiftREPL/ResilientDict.test
+++ b/lldb/test/Shell/SwiftREPL/ResilientDict.test
@@ -1,4 +1,6 @@
 // REQUIRES: system-darwin
+// REQUIRES: swift
+
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=DICT
 
 // The dictionary order isn't deterministic, so print the dictionary
@@ -6,14 +8,14 @@
 
 import Foundation
 
-let x : [URL:Int] = [URL(string: "https://github.com")!: 4, URL(string: "https://apple.com")!: 23] 
+let x : [URL:Int] = [URL(string: "https://github.com")!: 4, URL(string: "https://apple.com")!: 23]
 // DICT-LABEL: {{x}}: [URL : Int] = 2 key/value pairs {
 // DICT:      [{{[0-1]}}] = {
 // DICT:         key = "https://apple.com"
 // DICT-NEXT:    value = 23
 // DICT-NEXT:  }
 
-let y : [URL:Int] = [URL(string: "https://github.com")!: 4, URL(string: "https://apple.com")!: 23] 
+let y : [URL:Int] = [URL(string: "https://github.com")!: 4, URL(string: "https://apple.com")!: 23]
 // DICT-LABEL: {{y}}: [URL : Int] = 2 key/value pairs {
 // DICT:       [{{[0-1]}}] = {
 // DICT:          key = "https://github.com"

--- a/lldb/test/Shell/SwiftREPL/SIMD.test
+++ b/lldb/test/Shell/SwiftREPL/SIMD.test
@@ -1,5 +1,6 @@
 // Test formatters for SIMD.
 // REQUIRES: system-darwin
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/SetBridging.test
+++ b/lldb/test/Shell/SwiftREPL/SetBridging.test
@@ -1,6 +1,8 @@
 // -*- mode: swift; -*-
 // Test formatters on bridged sets in the REPL.
 // REQUIRES: system-darwin
+// REQUIRES: swift
+
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=SET
 
 import Foundation

--- a/lldb/test/Shell/SwiftREPL/SimpleExpressions.test
+++ b/lldb/test/Shell/SwiftREPL/SimpleExpressions.test
@@ -1,5 +1,6 @@
 // Test that we can define and use basic functions/expressions in the REPL.
 // Note: All of this should work on all supported platforms.
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/SleepREPL.test
+++ b/lldb/test/Shell/SwiftREPL/SleepREPL.test
@@ -1,5 +1,6 @@
 // Test that we can sleep in the repl
 // REQUIRES: system-darwin
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=SLEEP
 

--- a/lldb/test/Shell/SwiftREPL/String.test
+++ b/lldb/test/Shell/SwiftREPL/String.test
@@ -1,5 +1,6 @@
 // Test that String works in the REPL.
 // REQUIRES: system-darwin
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=STRING
 

--- a/lldb/test/Shell/SwiftREPL/Struct.test
+++ b/lldb/test/Shell/SwiftREPL/Struct.test
@@ -1,4 +1,5 @@
 // Test that we can define and use structs in the REPL.
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/Subclassing.test
+++ b/lldb/test/Shell/SwiftREPL/Subclassing.test
@@ -1,4 +1,5 @@
 // Test that subclassing works in the repl.
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/SwiftInterface.test
+++ b/lldb/test/Shell/SwiftREPL/SwiftInterface.test
@@ -1,4 +1,5 @@
 // Test that .swiftinterface files can be loaded via the repl.
+// REQUIRES: swift
 
 // RUN: rm -rf %t
 // RUN: mkdir %t

--- a/lldb/test/Shell/SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
+++ b/lldb/test/Shell/SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
@@ -3,6 +3,7 @@
 // Note: It intentionally does not check the only-interface or prefer-interface
 // modes as this also causes the Swift stdlib to be loaded via its module
 // interface file, which slows down this test considerably.
+// REQUIRES: swift
 
 // RUN: rm -rf %t && mkdir %t
 

--- a/lldb/test/Shell/SwiftREPL/SwiftTypeLookup.test
+++ b/lldb/test/Shell/SwiftREPL/SwiftTypeLookup.test
@@ -1,4 +1,5 @@
 // Test that we don't crash when looking up types.
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=TYPE
 

--- a/lldb/test/Shell/SwiftREPL/UninitVariables.test
+++ b/lldb/test/Shell/SwiftREPL/UninitVariables.test
@@ -1,4 +1,5 @@
 // Document the way we handle uninitialized variables.
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/ZeroSizeStruct.test
+++ b/lldb/test/Shell/SwiftREPL/ZeroSizeStruct.test
@@ -1,4 +1,5 @@
 // Test that we can define and use zero-sized struct in the repl.
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/enum-singlecase.test
+++ b/lldb/test/Shell/SwiftREPL/enum-singlecase.test
@@ -1,4 +1,5 @@
 // RUN: %lldb --repl < %s 2>&1 | FileCheck %s
+// REQUIRES: swift
 
 enum Foo: String {
   case patatino

--- a/lldb/test/Shell/SwiftREPL/one-char-string.test
+++ b/lldb/test/Shell/SwiftREPL/one-char-string.test
@@ -1,5 +1,6 @@
 // rdar://30147367
 // Make sure that single character strings are displayed correctly.
+// REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=STRING
 

--- a/lldb/test/Shell/lit.cfg.py
+++ b/lldb/test/Shell/lit.cfg.py
@@ -121,6 +121,9 @@ if config.lldb_enable_python:
 if config.lldb_enable_lua:
     config.available_features.add('lua')
 
+if config.lldb_enable_swift:
+    config.available_features.add('swift')
+
 if config.lldb_enable_lzma:
     config.available_features.add('lzma')
 

--- a/lldb/test/Shell/lit.site.cfg.py.in
+++ b/lldb/test/Shell/lit.site.cfg.py.in
@@ -16,6 +16,7 @@ config.lldb_lit_tools_dir = r"@LLDB_LIT_TOOLS_DIR@"
 config.target_triple = "@TARGET_TRIPLE@"
 config.python_executable = "@Python3_EXECUTABLE@"
 config.swiftc = "@LLDB_SWIFTC@"
+config.lldb_enable_swift = @LLDB_ENABLE_SWIFT_SUPPORT@
 config.have_zlib = @LLVM_ENABLE_ZLIB@
 config.lldb_enable_lzma = @LLDB_ENABLE_LZMA@
 config.host_triple = "@LLVM_HOST_TRIPLE@"


### PR DESCRIPTION
Disabling Swift support in LLDB doesn't prevent the test suite from running
the Swift tests (which then end up failing instead of being marked as
unsupported). This adds a lit feature for Swift and adds the REQUIRES to all
Swift tests to mark them as unsupported if Swift is disabled.