### PR TITLE
[Verification] Permit swifterror in arg buffer.

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3006,13 +3006,16 @@ void Verifier::visitCallBase(CallBase &Call) {
                "swifterror argument for call has mismatched alloca", AI, Call);
         continue;
       }
-      auto ArgI = dyn_cast<Argument>(SwiftErrorArg);
-      Assert(ArgI,
-             "swifterror argument should come from an alloca or parameter",
-             SwiftErrorArg, Call);
-      Assert(ArgI->hasSwiftErrorAttr(),
-             "swifterror argument for call has mismatched parameter", ArgI,
-             Call);
+      if (auto *ArgI = dyn_cast<Argument>(SwiftErrorArg)) {
+        Assert(ArgI->hasSwiftErrorAttr(),
+               "swifterror argument for call has mismatched parameter", ArgI,
+               Call);
+      } else {
+        auto *GEP = dyn_cast<GetElementPtrInst>(SwiftErrorArg);
+        Assert(GEP,
+               "swifterror argument for call has mismatched parameter", ArgI,
+               Call);
+      }
     }
 
     if (Attrs.hasParamAttribute(i, Attribute::ImmArg)) {


### PR DESCRIPTION
Previously, a swifterror was only allowed to come from either an alloca or a parameter.  The async calling convention requires that the error be a field in the swift.context parameter, so here a swifterror is allowed to be a gep into the swift.context parameter as well.