### PR TITLE
Implement TypeSystemSwiftTypeRef::GetTypeBitAlign()

### DIFF
--- a/lldb/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/lldb/include/lldb/Target/SwiftLanguageRuntime.h
@@ -260,7 +260,8 @@ public:
   llvm::Optional<uint64_t> GetByteStride(CompilerType type);
 
   /// Ask Remote mirrors for the alignment of a Swift type.
-  llvm::Optional<size_t> GetBitAlignment(CompilerType type);
+  llvm::Optional<size_t> GetBitAlignment(CompilerType type,
+                                         ExecutionContextScope *exe_scope);
 
   /// Release the RemoteASTContext associated with the given swift::ASTContext.
   /// Note that a RemoteASTContext must be destroyed before its associated

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -6054,6 +6054,8 @@ SwiftASTContext::GetTypeBitAlign(opaque_compiler_type_t type,
     exe_scope->CalculateExecutionContext(exe_ctx);
     auto swift_scratch_ctx_lock = SwiftASTContextLock(&exe_ctx);
     CompilerType bound_type = BindGenericTypeParameters({this, type}, exe_scope);
+    if (bound_type.GetOpaqueQualType() == type)
+      return {};
     // Note thay the bound type may be in a different AST context.
     return bound_type.GetTypeBitAlign(exe_scope);
   }
@@ -6061,13 +6063,13 @@ SwiftASTContext::GetTypeBitAlign(opaque_compiler_type_t type,
   const swift::irgen::FixedTypeInfo *fixed_type_info =
       GetSwiftFixedTypeInfo(type);
   if (fixed_type_info)
-    return fixed_type_info->getFixedAlignment().getValue();
+    return fixed_type_info->getFixedAlignment().getValue() * 8;
 
   // Ask the dynamic type system.
   if (!exe_scope)
     return {};
   if (auto *runtime = SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
-    return runtime->GetBitAlignment({this, type});
+    return runtime->GetBitAlignment({this, type}, exe_scope);
   return {};
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -278,6 +278,9 @@ private:
   /// Cast \p opaque_type as a mangled name.
   const char *AsMangledName(lldb::opaque_compiler_type_t type);
 
+  /// Lookup a type in the debug info.
+  lldb::TypeSP LookupTypeInModule(lldb::opaque_compiler_type_t type);
+
   /// Demangle the mangled name of the canonical type of \p type and
   /// drill into the Global(TypeMangling(Type())).
   ///

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -270,7 +270,8 @@ public:
     return {};
   }
 
-  llvm::Optional<size_t> GetBitAlignment(CompilerType type) {
+  llvm::Optional<size_t> GetBitAlignment(CompilerType type,
+                                         ExecutionContextScope *exe_scope) {
     STUB_LOG();
     return {};
   }
@@ -2131,8 +2132,9 @@ SwiftLanguageRuntime::GetByteStride(CompilerType type) {
 }
 
 llvm::Optional<size_t>
-SwiftLanguageRuntime::GetBitAlignment(CompilerType type) {
-  FORWARD(GetBitAlignment, type);
+SwiftLanguageRuntime::GetBitAlignment(CompilerType type,
+                                      ExecutionContextScope *exe_scope) {
+  FORWARD(GetBitAlignment, type, exe_scope);
 }
 
 bool SwiftLanguageRuntime::IsValidErrorValue(ValueObject &in_value) {

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2181,9 +2181,10 @@ SwiftLanguageRuntimeImpl::GetByteStride(CompilerType type) {
 }
 
 llvm::Optional<size_t>
-SwiftLanguageRuntimeImpl::GetBitAlignment(CompilerType type) {
-  if (auto *type_info = GetTypeInfo(type, nullptr))
-    return type_info->getAlignment();
+SwiftLanguageRuntimeImpl::GetBitAlignment(CompilerType type,
+                                          ExecutionContextScope *exe_scope) {
+  if (auto *type_info = GetTypeInfo(type, exe_scope))
+    return type_info->getAlignment() * 8;
   return {};
 }
 

--- a/lldb/source/Target/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Target/SwiftLanguageRuntimeImpl.h
@@ -92,7 +92,8 @@ public:
   llvm::Optional<uint64_t> GetByteStride(CompilerType type);
 
   /// Ask Remote mirrors for the alignment of a Swift type.
-  llvm::Optional<size_t> GetBitAlignment(CompilerType type);
+  llvm::Optional<size_t> GetBitAlignment(CompilerType type,
+                                         ExecutionContextScope *exe_scope);
 
   SwiftLanguageRuntime::MetadataPromiseSP
   GetMetadataPromise(lldb::addr_t addr, ValueObject &for_object);

--- a/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
+++ b/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
@@ -76,5 +76,14 @@ class TestSwiftExpressionsInClassFunctions(TestBase):
             self.check_expression("i", str(i), False)
             if i == 6:
               self.check_expression("self", "a.H<Int>")
+              frame = threads[0].GetFrameAtIndex(0)
+              lldbutil.check_variable(self, frame.FindVariable("self"),
+                                      use_dynamic=True,
+                                      # FIXME: This should be '@thick a.H<Swift.Int>.Type'
+                                      # but valobj.GetDynamicValue(lldb.eDynamicCanRunTarget)
+                                      # doesn't seem to do its job.
+                                      # rdar://problem/69889462
+                                      typename='@thin a.H<τ_0_0>.Type')
+
             self.runCmd("continue")
 


### PR DESCRIPTION
- Thicken generic metatypes in BindGenericTypeParameters(). 
  <rdar://problem/69765047>
- Implement TypeSystemSwiftTypeRef::GetTypeBitAlign() (NFC) 
  <rdar://problem/68171432>