### PR TITLE
[lldb] Hoist --swift-compiler argument out of LLDB_TEST_COMMON_ARGS

### DIFF
--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -32,13 +32,11 @@ option(LLDB_TEST_SWIFT "Use in-tree swift when testing lldb" On)
 if(LLDB_TEST_SWIFT)
   set(LLDB_SWIFTC ${SWIFT_BINARY_DIR}/bin/swiftc CACHE STRING "Path to swift compiler")
   set(LLDB_SWIFT_LIBS ${SWIFT_LIBRARY_DIR}/swift CACHE STRING "Path to swift libraries")
+  # Prefer the just-built stdlib over the system one.
   set(SWIFT_TEST_ARGS
-    --swift-compiler ${LLDB_SWIFTC}
-    # Prefer the just-built stdlib over the system one.
     --inferior-env "DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/macosx\\\""
     --inferior-env "LD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/${CMAKE_SYSTEM_PROCESSOR}\\\""
-    --inferior-env "SIMCTL_CHILD_DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/macosx\\\""
-  )
+    --inferior-env "SIMCTL_CHILD_DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/macosx\\\"")
 endif()
 # END - Swift Mods
 

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -194,6 +194,9 @@ if is_configured('lldb_executable'):
 if is_configured('test_compiler'):
   dotest_cmd += ['--compiler', config.test_compiler]
 
+if is_configured('test_swift_compiler'):
+  dotest_cmd += ['--swift-compiler', config.test_swift_compiler]
+
 if is_configured('dsymutil'):
   dotest_cmd += ['--dsymutil', config.dsymutil]
 

--- a/lldb/test/API/lit.site.cfg.py.in
+++ b/lldb/test/API/lit.site.cfg.py.in
@@ -29,6 +29,7 @@ config.enabled_plugins = []
 config.lldb_executable = '@LLDB_TEST_EXECUTABLE@'
 config.test_arch = '@LLDB_TEST_ARCH@'
 config.test_compiler = '@LLDB_TEST_COMPILER@'
+config.test_swift_compiler = '@LLDB_SWIFTC@'
 config.dsymutil = '@LLDB_TEST_DSYMUTIL@'
 config.filecheck = '@LLDB_TEST_FILECHECK@'
 config.yaml2obj = '@LLDB_TEST_YAML2OBJ@'


### PR DESCRIPTION
Store the swift compiler for testing in the lit config instead of
passing it through the LLDB_TEST_COMMON_ARGS  so that we can configure
it in lit.site.cfg.py if we so desire.