### PR TITLE
[lldb] Reimplement and implement GetPointerType

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5886,10 +5886,11 @@ CompilerType SwiftASTContext::GetPointerType(opaque_compiler_type_t type) {
   VALID_OR_RETURN(CompilerType());
 
   if (type) {
-    swift::Type swift_type(GetSwiftType({this, type}));
-    const swift::TypeKind type_kind = swift_type->getKind();
-    if (type_kind == swift::TypeKind::BuiltinRawPointer)
-      return ToCompilerType({swift_type});
+    auto swift_type = GetSwiftType({this, type});
+    auto pointer_type =
+        swift_type->wrapInPointer(swift::PointerTypeKind::PTK_UnsafePointer);
+    if (pointer_type)
+      return ToCompilerType(pointer_type);
   }
   return {};
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1672,19 +1672,6 @@ TypeSystemSwiftTypeRef::GetPointeeType(opaque_compiler_type_t type) {
 CompilerType
 TypeSystemSwiftTypeRef::GetPointerType(opaque_compiler_type_t type) {
   auto impl = [&]() -> CompilerType {
-    /*
-      kind=Type
-        kind=BoundGenericStructure
-          kind=Type
-            kind=Structure
-              kind=Module, text="Swift"
-              kind=Identifier, text="UnsafePointer"
-          kind=TypeList
-            kind=Type
-              kind=Structure
-                kind=Module, text="Swift"
-                kind=Identifier, text="Int"
-     */
     using namespace swift::Demangle;
     Demangler dem;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -90,8 +90,7 @@ GetClangTypeNode(CompilerType clang_type, swift::Demangle::Demangler &dem) {
 }
 
 /// \return the child of the \p Type node.
-static swift::Demangle::NodePointer GetType(swift::Demangle::Demangler &dem,
-                                            swift::Demangle::NodePointer n) {
+static NodePointer GetType(swift::Demangle::NodePointer n) {
   using namespace swift::Demangle;
   if (!n || n->getKind() != Node::Kind::Global || !n->hasChildren())
     return nullptr;
@@ -109,7 +108,7 @@ static swift::Demangle::NodePointer GetType(swift::Demangle::Demangler &dem,
 static swift::Demangle::NodePointer
 GetDemangledType(swift::Demangle::Demangler &dem, StringRef name) {
   NodePointer n = dem.demangleSymbol(name);
-  return GetType(dem, n);
+  return GetType(n);
 }
 
 /// Resolve a type alias node and return a demangle tree for the
@@ -1291,7 +1290,7 @@ swift::Demangle::NodePointer TypeSystemSwiftTypeRef::DemangleCanonicalType(
   using namespace swift::Demangle;
   NodePointer node =
       GetCanonicalDemangleTree(GetModule(), dem, AsMangledName(opaque_type));
-  return GetType(dem, node);
+  return GetType(node);
 }
 
 bool TypeSystemSwiftTypeRef::IsArrayType(opaque_compiler_type_t type,
@@ -1669,9 +1668,62 @@ CompilerType
 TypeSystemSwiftTypeRef::GetPointeeType(opaque_compiler_type_t type) {
   return m_swift_ast_context->GetPointeeType(ReconstructType(type));
 }
+
 CompilerType
 TypeSystemSwiftTypeRef::GetPointerType(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetPointerType(ReconstructType(type));
+  auto impl = [&]() -> CompilerType {
+    /*
+      kind=Type
+        kind=BoundGenericStructure
+          kind=Type
+            kind=Structure
+              kind=Module, text="Swift"
+              kind=Identifier, text="UnsafePointer"
+          kind=TypeList
+            kind=Type
+              kind=Structure
+                kind=Module, text="Swift"
+                kind=Identifier, text="Int"
+     */
+    using namespace swift::Demangle;
+    Demangler dem;
+
+    auto *pointee_type = GetType(dem.demangleSymbol(AsMangledName(type)));
+
+    auto *pointer_type = dem.createNode(Node::Kind::Type);
+    auto *BGS = dem.createNode(Node::Kind::BoundGenericStructure);
+    pointer_type->addChild(BGS, dem);
+
+    NodePointer parent;
+    NodePointer child;
+
+    // Construct the first (Type) branch of BoundGenericStructure.
+    parent = BGS;
+    child = dem.createNode(Node::Kind::Type);
+    parent->addChild(child, dem);
+    parent = child;
+    child = dem.createNode(Node::Kind::Structure);
+    parent->addChild(child, dem);
+    parent = child;
+    parent->addChild(
+        dem.createNodeWithAllocatedText(Node::Kind::Module, swift::STDLIB_NAME),
+        dem);
+    parent->addChild(dem.createNode(Node::Kind::Identifier, "UnsafePointer"),
+                     dem);
+
+    // Construct the second (TypeList) branch of BoundGenericStructure.
+    parent = BGS;
+    child = dem.createNode(Node::Kind::TypeList);
+    parent->addChild(child, dem);
+    parent = child;
+    child = dem.createNode(Node::Kind::Type);
+    parent->addChild(child, dem);
+    parent = child;
+    parent->addChild(pointee_type, dem);
+
+    return RemangleAsType(dem, pointer_type);
+  };
+  VALIDATE_AND_RETURN(impl, GetPointerType, type, (ReconstructType(type)));
 }
 
 // Exploring the type

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1675,7 +1675,7 @@ TypeSystemSwiftTypeRef::GetPointerType(opaque_compiler_type_t type) {
     using namespace swift::Demangle;
     Demangler dem;
 
-    auto *pointee_type = GetType(dem.demangleSymbol(AsMangledName(type)));
+    auto *pointee_type = GetDemangledType(dem, AsMangledName(type));
 
     auto *pointer_type = dem.createNode(Node::Kind::Type);
     auto *BGS = dem.createNode(Node::Kind::BoundGenericStructure);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1675,38 +1675,35 @@ TypeSystemSwiftTypeRef::GetPointerType(opaque_compiler_type_t type) {
     using namespace swift::Demangle;
     Demangler dem;
 
+    // The type that will be wrapped in UnsafePointer.
     auto *pointee_type = GetDemangledType(dem, AsMangledName(type));
-
+    // The UnsafePointer type.
     auto *pointer_type = dem.createNode(Node::Kind::Type);
-    auto *BGS = dem.createNode(Node::Kind::BoundGenericStructure);
-    pointer_type->addChild(BGS, dem);
 
-    NodePointer parent;
-    NodePointer child;
+    auto *bgs = dem.createNode(Node::Kind::BoundGenericStructure);
+    pointer_type->addChild(bgs, dem);
 
-    // Construct the first (Type) branch of BoundGenericStructure.
-    parent = BGS;
-    child = dem.createNode(Node::Kind::Type);
-    parent->addChild(child, dem);
-    parent = child;
-    child = dem.createNode(Node::Kind::Structure);
-    parent->addChild(child, dem);
-    parent = child;
-    parent->addChild(
-        dem.createNodeWithAllocatedText(Node::Kind::Module, swift::STDLIB_NAME),
-        dem);
-    parent->addChild(dem.createNode(Node::Kind::Identifier, "UnsafePointer"),
-                     dem);
+    // Construct the first branch of BoundGenericStructure.
+    {
+      auto *type = dem.createNode(Node::Kind::Type);
+      bgs->addChild(type, dem);
+      auto *structure = dem.createNode(Node::Kind::Structure);
+      type->addChild(structure, dem);
+      structure->addChild(dem.createNodeWithAllocatedText(Node::Kind::Module,
+                                                          swift::STDLIB_NAME),
+                          dem);
+      structure->addChild(
+          dem.createNode(Node::Kind::Identifier, "UnsafePointer"), dem);
+    }
 
-    // Construct the second (TypeList) branch of BoundGenericStructure.
-    parent = BGS;
-    child = dem.createNode(Node::Kind::TypeList);
-    parent->addChild(child, dem);
-    parent = child;
-    child = dem.createNode(Node::Kind::Type);
-    parent->addChild(child, dem);
-    parent = child;
-    parent->addChild(pointee_type, dem);
+    // Construct the second branch of BoundGenericStructure.
+    {
+      auto *typelist = dem.createNode(Node::Kind::TypeList);
+      bgs->addChild(typelist, dem);
+      auto *type = dem.createNode(Node::Kind::Type);
+      typelist->addChild(type, dem);
+      type->addChild(pointee_type, dem);
+    }
 
     return RemangleAsType(dem, pointer_type);
   };


### PR DESCRIPTION
Reimplement `SwiftASTContext::GetPointerType` to return the given type wrapped in `UnsafePointer<T>`. Also implement `TypeSystemSwiftTypeRef::GetPointerType` with a matching demangle-based implementation that also wraps in `UnsafePointer`.

Given a variable `x: Int`, here is some output:

```
(lldb) script print(lldb.frame.vars["x"][0].AddressOf())
(UnsafePointer<Int>) &x = 0x7ffeefbff728 {
  [0] = 23
}
(lldb) script print(lldb.frame.vars["x"][0].AddressOf().type)
@frozen struct UnsafePointer<Pointee> : Swift._Pointer {
...
```

rdar://68171356