### PR TITLE
[lldb] Fix bug in fallback logic for finding the resource directory.

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
@@ -137,14 +137,12 @@ bool lldb_private::ComputeClangResourceDirectory(FileSpec &lldb_shlib_spec,
         FileSystem::Instance().Resolve(file_spec);
         return true;
       }
-      raw_path = lldb_shlib_spec.GetPath();
     }
-    raw_path.resize(rev_it - r_end);
-  } else {
-    raw_path.resize(rev_it - r_end);
   }
 
   // Fall back to the Clang resource directory inside the framework.
+  raw_path = lldb_shlib_spec.GetPath();
+  raw_path.resize(rev_it - r_end);
   raw_path.append("LLDB.framework/Resources/Clang");
   file_spec.GetDirectory().SetString(raw_path.c_str());
   FileSystem::Instance().Resolve(file_spec);


### PR DESCRIPTION
Both of the if-clauses modify the raw_path variable and only one of them
was resetting the variable for the fallback. Avoid future bugs like that
by always resetting the variable.

Differential revision: https://reviews.llvm.org/D88704

(cherry picked from commit 07c112574a324318a02ef29901a0d5aa1fd95144)