### PR TITLE
[lldb] Remove unused version defines

### DIFF
--- a/lldb/source/lldb.cpp
+++ b/lldb/source/lldb.cpp
@@ -66,19 +66,19 @@ const char *lldb_private::GetVersion() {
     auto const swift_version = swift::version::getSwiftFullVersion();
     g_version_str += "\n" + swift_version;
 #else
-   // getSwiftFullVersion() also prints clang and llvm versions, no
-   // need to print them again. We keep this code here to not diverge
-   // too much from upstream.
-   std::string clang_rev(clang::getClangRevision());
-   if (clang_rev.length() > 0) {
-     g_version_str += "\n  clang revision ";
-     g_version_str += clang_rev;
-   }
-   std::string llvm_rev(clang::getLLVMRevision());
-   if (llvm_rev.length() > 0) {
-     g_version_str += "\n  llvm revision ";
-     g_version_str += llvm_rev;
-   }
+    // getSwiftFullVersion() also prints clang and llvm versions, no
+    // need to print them again. We keep this code here to not diverge
+    // too much from upstream.
+    std::string clang_rev(clang::getClangRevision());
+    if (clang_rev.length() > 0) {
+      g_version_str += "\n  clang revision ";
+      g_version_str += clang_rev;
+    }
+    std::string llvm_rev(clang::getLLVMRevision());
+    if (llvm_rev.length() > 0) {
+      g_version_str += "\n  llvm revision ";
+      g_version_str += llvm_rev;
+    }
 #endif // LLDB_ENABLE_SWIFT
   }
   return g_version_str.c_str();

--- a/lldb/source/lldb.cpp
+++ b/lldb/source/lldb.cpp
@@ -36,16 +36,6 @@ static const char *GetLLDBRepository() {
 #endif
 }
 
-#if LLDB_IS_BUILDBOT_BUILD
-static std::string GetBuildDate() {
-#if defined(LLDB_BUILD_DATE)
-  return std::string(LLDB_BUILD_DATE);
-#else
-  return std::string();
-#endif
-}
-#endif
-
 #define QUOTE(str) #str
 #define EXPAND_AND_QUOTE(str) QUOTE(str)
 
@@ -71,34 +61,11 @@ const char *lldb_private::GetVersion() {
       }
       g_version_str += ")";
     }
-    
-#if LLDB_IS_BUILDBOT_BUILD
-    std::string build_date = GetBuildDate();
-    if(!build_date.empty())
-      g_version_str += " (buildbot " + build_date + ")";
-#endif
 
 #ifdef LLDB_ENABLE_SWIFT
     auto const swift_version = swift::version::getSwiftFullVersion();
     g_version_str += "\n" + swift_version;
 #endif // LLDB_ENABLE_SWIFT
-
-    // getSwiftFullVersion() also prints clang and llvm versions, no
-    // need to print them again. We keep this code here to not diverge
-    // too much from upstream.
-#undef LLDB_UPSTREAM
-#ifdef LLDB_UPSTREAM
-    std::string clang_rev(clang::getClangRevision());
-    if (clang_rev.length() > 0) {
-      g_version_str += "\n  clang revision ";
-      g_version_str += clang_rev;
-    }
-    std::string llvm_rev(clang::getLLVMRevision());
-    if (llvm_rev.length() > 0) {
-      g_version_str += "\n  llvm revision ";
-      g_version_str += llvm_rev;
-    }
-#endif // LLDB_UPSTREAM
   }
   return g_version_str.c_str();
 }

--- a/lldb/source/lldb.cpp
+++ b/lldb/source/lldb.cpp
@@ -65,6 +65,20 @@ const char *lldb_private::GetVersion() {
 #ifdef LLDB_ENABLE_SWIFT
     auto const swift_version = swift::version::getSwiftFullVersion();
     g_version_str += "\n" + swift_version;
+#else
+   // getSwiftFullVersion() also prints clang and llvm versions, no
+   // need to print them again. We keep this code here to not diverge
+   // too much from upstream.
+   std::string clang_rev(clang::getClangRevision());
+   if (clang_rev.length() > 0) {
+     g_version_str += "\n  clang revision ";
+     g_version_str += clang_rev;
+   }
+   std::string llvm_rev(clang::getLLVMRevision());
+   if (llvm_rev.length() > 0) {
+     g_version_str += "\n  llvm revision ";
+     g_version_str += llvm_rev;
+   }
 #endif // LLDB_ENABLE_SWIFT
   }
   return g_version_str.c_str();


### PR DESCRIPTION
Removes unused compiler defines, and related code.

* `LLDB_IS_BUILDBOT_BUILD`
* `LLDB_BUILD_DATE`

This eliminates some downstream diff from llvm.org. See also https://github.com/apple/swift/pull/34212

This also removes the "fake" `LLDB_UPSTREAM` definition, which is the inverse of `LLDB_ENABLE_SWIFT`. Instead, that block of code is an `#else` branch.