### PR TITLE
[clang][Index] Add guard to IndexUnitReader module name reading

### DIFF
--- a/clang/lib/Index/IndexUnitReader.cpp
+++ b/clang/lib/Index/IndexUnitReader.cpp
@@ -378,10 +378,10 @@ void IndexUnitReaderImpl::constructFilePath(SmallVectorImpl<char> &PathBuf,
 }
 
 StringRef IndexUnitReaderImpl::getModuleName(int ModuleIndex) {
-  if (ModuleIndex < 0)
+  if (ModuleIndex < 0 || ModuleNamesBuffer.empty())
     return StringRef();
   auto &ModInfo = Modules[ModuleIndex];
-  return StringRef(ModuleNamesBuffer.data()+ModInfo.NameOffset, ModInfo.NameSize);
+  return ModuleNamesBuffer.substr(ModInfo.NameOffset, ModInfo.NameSize);
 }
 
 


### PR DESCRIPTION
Check that ModuleNamesBuffer is valid before attempting to read strings
from it to avoid possible segfaults. Wasn't able to come up with a test
case, but this does happen based on reported crashes.

Also use StringRef.substr, which returns an empty string if the index is
out of bounds, for even further safety.

Resolves rdar://69809414