### PR TITLE
[lldb][swift] Add missing swiftTest decorators

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbplaygroundrepl.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplaygroundrepl.py
@@ -129,6 +129,7 @@ class PlaygroundREPLTest(TestBase):
         error = self.get_stream_data(result)
         print("Crash Error: {}".format(error))
 
+    @swiftTest
     def test_playgrounds(self):
         # Build
         self.build_all()

--- a/lldb/test/API/commands/help/TestHelp.py
+++ b/lldb/test/API/commands/help/TestHelp.py
@@ -81,6 +81,7 @@ class HelpCommandTestCase(TestBase):
                     substrs=['arm', 'i386', 'x86_64'])
 
     @no_debug_info_test
+    @swiftTest # Checks for the Swift version number in the output
     def test_help_version(self):
         """Test 'help version' and 'version' commands."""
         self.expect("help version",

--- a/lldb/test/API/functionalities/mtc/swift-property/TestMTCSwiftProperty.py
+++ b/lldb/test/API/functionalities/mtc/swift-property/TestMTCSwiftProperty.py
@@ -19,6 +19,7 @@ class MTCSwiftPropertyTestCase(TestBase):
     @expectedFailureAll(bugnumber="rdar://60396797",
                         setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin
+    @swiftTest
     def test(self):
         self.mtc_dylib_path = findMainThreadCheckerDylib()
         self.assertTrue(self.mtc_dylib_path != "")

--- a/lldb/test/API/functionalities/mtc/swift/TestMTCSwift.py
+++ b/lldb/test/API/functionalities/mtc/swift/TestMTCSwift.py
@@ -19,6 +19,7 @@ class MTCSwiftTestCase(TestBase):
     @expectedFailureAll(bugnumber="rdar://60396797",
                         setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin
+    @swiftTest
     def test(self):
         self.mtc_dylib_path = findMainThreadCheckerDylib()
         self.assertTrue(self.mtc_dylib_path != "")

--- a/lldb/test/API/lang/swift/availability/TestAvailability.py
+++ b/lldb/test/API/lang/swift/availability/TestAvailability.py
@@ -41,6 +41,7 @@ class TestAvailability(TestBase):
         # Call super's setUp().
         TestBase.setUp(self)
 
+    @swiftTest
     @skipIf(oslist=['linux', 'windows'])
     def testAvailability(self):
         platform_name = lldbplatformutil.getPlatform()

--- a/lldb/test/API/lang/swift/completion/TestSwiftREPLCompletion.py
+++ b/lldb/test/API/lang/swift/completion/TestSwiftREPLCompletion.py
@@ -12,6 +12,7 @@ class SwiftCompletionTest(PExpectTest):
     # under ASAN on a loaded machine..
     @skipIfAsan
     @skipUnlessDarwin
+    @swiftTest
     def test_basic_completion(self):
 
         self.launch(extra_args=["--repl"], executable=None, dimensions=(100,500))
@@ -41,6 +42,7 @@ class SwiftCompletionTest(PExpectTest):
     # under ASAN on a loaded machine..
     @skipIfAsan
     @skipIf(oslist=['windows'])
+    @swiftTest
     def test_lldb_command_completion(self):
 
         self.launch(extra_args=["--repl"], executable=None, dimensions=(100,500))

--- a/lldb/test/API/lang/swift/delayed_parsing_crash/TestDelayedParsingCrash.py
+++ b/lldb/test/API/lang/swift/delayed_parsing_crash/TestDelayedParsingCrash.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals())
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/deserialization_failure/TestSwiftDeserializationFailure.py
+++ b/lldb/test/API/lang/swift/deserialization_failure/TestSwiftDeserializationFailure.py
@@ -37,6 +37,7 @@ class TestSwiftDeserializationFailure(TestBase):
         # FIXME: this is formatted incorrectly.
         self.expect("fr var t", substrs=["(T)"]) #, "world"])
 
+    @swiftTest
     @skipIf(oslist=['windows'])
     @skipIf(debug_info=no_match(["dwarf"]))
     @expectedFailureAll(archs=["arm64", "arm64e", 'arm64_32'], bugnumber="<rdar://problem/58096919>")
@@ -47,6 +48,7 @@ class TestSwiftDeserializationFailure(TestBase):
         target, process, _, _ = lldbutil.run_to_name_breakpoint(self, 'main')
         self.run_tests(target, process)
 
+    @swiftTest
     @skipIf(oslist=['windows'])
     @skipIf(debug_info=no_match(["dwarf"]))
     @expectedFailureAll(archs=["arm64", "arm64e", 'arm64_32'], bugnumber="<rdar://problem/58096919>")

--- a/lldb/test/API/lang/swift/enum_associated/TestEnumAssociated.py
+++ b/lldb/test/API/lang/swift/enum_associated/TestEnumAssociated.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals())
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/expression/errors/TestExpressionErrors.py
+++ b/lldb/test/API/lang/swift/expression/errors/TestExpressionErrors.py
@@ -24,6 +24,7 @@ class TestExpressionErrors(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
+    @swiftTest
     def test_CanThrowError(self):
         """Tests that swift expressions resolve scoped variables correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/missing_sdk/TestMissingSDK.py
+++ b/lldb/test/API/lang/swift/missing_sdk/TestMissingSDK.py
@@ -19,6 +19,7 @@ class TestMissingSDK(TestBase):
         # Call super's setUp().
         TestBase.setUp(self)
 
+    @swiftTest
     @skipIf(oslist=['windows'])
     @skipIfDarwinEmbedded # swift crash inspecting swift stdlib with little other swift loaded <rdar://problem/55079456> 
     def testMissingSDK(self):

--- a/lldb/test/API/lang/swift/objc_runtime_ivars/TestObjCIvarDiscovery.py
+++ b/lldb/test/API/lang/swift/objc_runtime_ivars/TestObjCIvarDiscovery.py
@@ -28,6 +28,7 @@ class TestObjCIVarDiscovery(TestBase):
 
     @skipUnlessDarwin
     @skipIf(debug_info=no_match("dsym"))
+    @swiftTest
     def test_nodbg(self):
         self.build()
         shutil.rmtree(self.getBuildArtifact("aTestFramework.framework/Versions/A/aTestFramework.dSYM"))
@@ -35,6 +36,7 @@ class TestObjCIVarDiscovery(TestBase):
 
     @skipUnlessDarwin
     @skipIf(debug_info=no_match("dsym"))
+    @swiftTest
     def test_dbg(self):
         self.build()
         self.do_test(True)

--- a/lldb/test/API/lang/swift/private_import/TestSwiftPrivateImport.py
+++ b/lldb/test/API/lang/swift/private_import/TestSwiftPrivateImport.py
@@ -11,6 +11,7 @@ class TestSwiftPrivateImport(TestBase):
         TestBase.setUp(self)
 
     @skipUnlessDarwin
+    @swiftTest
     def test_private_import(self):
         """Test a library with a private import for which there is no debug info"""
         invisible_swift = self.getBuildArtifact("Invisible.swift")

--- a/lldb/test/API/lang/swift/protocol_extension_two/TestProtocolExtensionTwo.py
+++ b/lldb/test/API/lang/swift/protocol_extension_two/TestProtocolExtensionTwo.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals())
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/repl/array/TestREPLArray.py
+++ b/lldb/test/API/repl/array/TestREPLArray.py
@@ -1,4 +1,5 @@
 import lldbsuite.test.lldbinrepl as lldbinrepl
 import lldbsuite.test.lldbtest as lldbtest
+from lldbsuite.test.decorators import *
 
-lldbinrepl.MakeREPLTest(__file__, globals(), [])
+lldbinrepl.MakeREPLTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/repl/cpp_exceptions/TestCPPExceptionsInREPL.py
+++ b/lldb/test/API/repl/cpp_exceptions/TestCPPExceptionsInREPL.py
@@ -26,6 +26,7 @@ class TestREPLExceptions(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @decorators.skipUnlessDarwin
+    @decorators.swiftTest
     def test_set_repl_mode_exceptions(self):
         """ Test that SetREPLMode turns off trapping exceptions."""
         self.build()
@@ -33,6 +34,7 @@ class TestREPLExceptions(TestBase):
         self.do_repl_mode_test()
 
     @decorators.skipUnlessDarwin
+    @decorators.swiftTest
     def test_repl_exceptions(self):
         """ Test the lldb --repl turns off trapping exceptions."""
         self.build()


### PR DESCRIPTION
The swiftTest decorator should be on all Swift tests to make sure they are only
run in configurations where Swift is supported. Otherwise these tests are still
run and will fail when the Swift plugin is disabled.