### PR TITLE
Add a Transform() utility for rewriting demangle trees. (NFC)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -257,6 +257,14 @@ public:
       bool print_help_if_available, bool print_extensions_if_available,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
 
+  /// Recursively transform the demangle tree starting a \p node by
+  /// doing a post-order traversal and replacing each node with
+  /// fn(node).
+  static swift::Demangle::NodePointer Transform(
+      swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
+      std::function<swift::Demangle::NodePointer(swift::Demangle::NodePointer)>
+          fn);
+
   /// Return the canonicalized Demangle tree for a Swift mangled type name.
   static swift::Demangle::NodePointer
   GetCanonicalDemangleTree(lldb_private::Module *Module,


### PR DESCRIPTION
Transform() recursively transforms a demangle tree by doing a
post-order traversal and replacing each node with fn(node).

In most cases this utility will do less work than the ad-hoc
implementation it is replacing because we now only recreate nodes that
actually changed.