### PR TITLE
[AST] Fix crashes caused by redeclarations in hidden prototypes

### DIFF
--- a/clang/lib/AST/DeclObjC.cpp
+++ b/clang/lib/AST/DeclObjC.cpp
@@ -949,7 +949,8 @@ ObjCMethodDecl *ObjCMethodDecl::getNextRedeclarationImpl() {
   if (!Redecl && isRedeclaration()) {
     // This is the last redeclaration, go back to the first method.
     return cast<ObjCContainerDecl>(CtxD)->getMethod(getSelector(),
-                                                    isInstanceMethod());
+                                                    isInstanceMethod(),
+                                                    /*AllowHidden=*/true);
   }
 
   return Redecl ? Redecl : this;
@@ -982,7 +983,8 @@ ObjCMethodDecl *ObjCMethodDecl::getCanonicalDecl() {
   if (isRedeclaration()) {
     // It is possible that we have not done deserializing the ObjCMethod yet.
     ObjCMethodDecl *MD =
-        cast<ObjCContainerDecl>(CtxD)->getMethod(Sel, isInstanceMethod());
+        cast<ObjCContainerDecl>(CtxD)->getMethod(Sel, isInstanceMethod(),
+                                                 /*AllowHidden=*/true);
     return MD ? MD : this;
   }
 
@@ -1299,8 +1301,9 @@ void ObjCMethodDecl::getOverriddenMethods(
   const ObjCMethodDecl *Method = this;
 
   if (Method->isRedeclaration()) {
-    Method = cast<ObjCContainerDecl>(Method->getDeclContext())->
-                   getMethod(Method->getSelector(), Method->isInstanceMethod());
+    Method = cast<ObjCContainerDecl>(Method->getDeclContext())
+                 ->getMethod(Method->getSelector(), Method->isInstanceMethod(),
+                             /*AllowHidden=*/true);
   }
 
   if (Method->isOverriding()) {

--- a/clang/test/Index/Inputs/hidden-redecls-sub.h
+++ b/clang/test/Index/Inputs/hidden-redecls-sub.h
@@ -1,0 +1,7 @@
+@protocol P1
+- (void)p1_method;
+- (void)p1_method;
+@end
+
+@interface Foo (SubP1) <P1>
+@end

--- a/clang/test/Index/Inputs/hidden-redecls.h
+++ b/clang/test/Index/Inputs/hidden-redecls.h
@@ -1,0 +1,3 @@
+@interface Foo
+- (void)parent_method;
+@end

--- a/clang/test/Index/Inputs/module.map
+++ b/clang/test/Index/Inputs/module.map
@@ -20,3 +20,11 @@ module PreambleWithImplicitImport {
     export *
   }
 }
+
+module hidden_redecls {
+  header "hidden-redecls.h"
+
+  explicit module sub {
+    header "hidden-redecls-sub.h"
+  }
+}

--- a/clang/test/Index/hidden-redecls.m
+++ b/clang/test/Index/hidden-redecls.m
@@ -1,0 +1,12 @@
+@import hidden_redecls;
+
+@interface Foo (Top)
+- (void)top_method;
+@end
+
+// p1_method in protocol P1 is hidden since module_redecls.sub hasn't been
+// imported yet. Check it is still indexed.
+
+// RUN: c-index-test -index-file-full %s -isystem %S/Inputs -fmodules -target x86_64-apple-macosx10.7 | FileCheck %s
+// CHECK: [indexDeclaration]: kind: objc-instance-method | name: p1_method | {{.*}} | loc: {{.*}}hidden-redecls-sub.h:2:9 | {{.*}} | isRedecl: 0
+// CHECK: [indexDeclaration]: kind: objc-instance-method | name: p1_method | {{.*}} | loc: {{.*}}hidden-redecls-sub.h:3:9 | {{.*}} | isRedecl: 1


### PR DESCRIPTION
ObjCContainerDecl.getMethod returns a nullptr by default when the
container is a hidden prototype. Callsites where the method is being
looked up on the redeclaration's own container should skip this check
since they (rightly) expect a valid method to be found.

Resolves rdar://69444243

Reviewed By: akyrtzi

Differential Revision: https://reviews.llvm.org/D89024

Cherry-pick from fbb499ef255b77c5a3300543de88956b13e706b7