### PR TITLE
Factor out dynamic self transform

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -324,16 +324,6 @@ GetCanonicalNode(lldb_private::Module *M, swift::Demangle::Demangler &dem,
         return node_clangtype.first;
       return node;
     }
-    case Node::Kind::DynamicSelf: {
-      // Substitute the static type for dynamic self.
-      assert(node->getNumChildren() == 1);
-      if (node->getNumChildren() != 1)
-        return node;
-      NodePointer type = node->getChild(0);
-      if (type->getKind() != Node::Kind::Type || type->getNumChildren() != 1)
-        return node;
-      return type->getChild(0);
-    }
     default:
       break;
     }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -260,6 +260,7 @@ public:
   /// Recursively transform the demangle tree starting a \p node by
   /// doing a post-order traversal and replacing each node with
   /// fn(node).
+  /// The NodePointer passed to \p fn is guaranteed to be non-null.
   static swift::Demangle::NodePointer Transform(
       swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
       std::function<swift::Demangle::NodePointer(swift::Demangle::NodePointer)>

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -257,6 +257,14 @@ public:
       bool print_help_if_available, bool print_extensions_if_available,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
 
+  /// Recursively transform the demangle tree starting a \p node by
+  /// doing a post-order traversal and replacing each node with
+  /// fn(node).
+  static swift::Demangle::NodePointer Transform(
+      swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
+      std::function<swift::Demangle::NodePointer(swift::Demangle::NodePointer)>
+          fn);
+
   /// Return the canonicalized Demangle tree for a Swift mangled type name.
   static swift::Demangle::NodePointer
   GetCanonicalDemangleTree(lldb_private::Module *Module,


### PR DESCRIPTION
Remove the dynamic self replacement from canonicalization 
where it doesn't belong and move it directly into
BindGenericTypeParameters, where it is the only desirable
transformation and full canonicalization is actually
counterproductive.

A subsequent patch will enable the TypeRef typesystem in the
expression evaluator. This is a prerequisite for that to work.