### PR TITLE
[lldb] Update to match apple/swift#33935

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1189,7 +1189,8 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
   swift::ImplicitImportInfo importInfo;
   importInfo.StdlibKind = swift::ImplicitStdlibKind::Stdlib;
   for (auto *module : additional_imports)
-    importInfo.AdditionalModules.emplace_back(module, /*exported*/ false);
+    importInfo.AdditionalImports.emplace_back(swift::ImportedModule(module),
+                                              swift::ImportOptions());
 
   auto module_id = ast_context->getIdentifier(expr_name_buf);
   auto &module = *swift::ModuleDecl::create(module_id, *ast_context,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -8314,7 +8314,7 @@ bool SwiftASTContext::CacheUserImports(SwiftASTContext &swift_ast_context,
                                        swift::SourceFile &source_file,
                                        Status &error) {
   llvm::SmallString<1> m_description;
-  llvm::SmallVector<swift::ModuleDecl::ImportedModule, 2> parsed_imports;
+  llvm::SmallVector<swift::ImportedModule, 2> parsed_imports;
 
   swift::ModuleDecl::ImportFilter import_filter {
       swift::ModuleDecl::ImportFilterKind::Exported,


### PR DESCRIPTION
apple/swift#33935 refactors some types that LLDB uses to implicitly import modules when compiling expressions. This PR updates this code to match.