### PR TITLE
[lldb] Add SBModule::GarbageCollectAllocatedModules and clear modules…

### DIFF
--- a/lldb/bindings/interface/SBModule.i
+++ b/lldb/bindings/interface/SBModule.i
@@ -353,6 +353,17 @@ public:
     static uint32_t
     GetNumberAllocatedModules();
 
+    %feature("docstring", "
+    Removes all modules which are no longer needed by any part of LLDB from
+    the module cache.
+
+    This is an implementation detail exposed for testing and should not be
+    relied upon. Use SBDebugger::MemoryPressureDetected instead to reduce
+    LLDB's memory consumption during execution.
+    ") GarbageCollectAllocatedModules;
+    static void
+    GarbageCollectAllocatedModules();
+
     STRING_EXTENSION(SBModule)
 
 #ifdef SWIGPYTHON

--- a/lldb/include/lldb/API/SBModule.h
+++ b/lldb/include/lldb/API/SBModule.h
@@ -291,6 +291,9 @@ public:
   /// Get the number of global modules.
   static uint32_t GetNumberAllocatedModules();
 
+  /// Remove any global modules which are no longer needed.
+  static void GarbageCollectAllocatedModules();
+
 private:
   friend class SBAddress;
   friend class SBFrame;

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1029,6 +1029,17 @@ class Base(unittest2.TestCase):
         lldb.SBDebugger.Destroy(self.dbg)
         del self.dbg
 
+        # All modules should be orphaned now so that they can be cleared from
+        # the shared module cache.
+        lldb.SBModule.GarbageCollectAllocatedModules()
+
+        # Modules are not orphaned during reproducer replay because they're
+        # leaked on purpose.
+        if not configuration.is_reproducer():
+            # Assert that the global module cache is empty.
+            self.assertEqual(lldb.SBModule.GetNumberAllocatedModules(), 0)
+
+
     # =========================================================
     # Various callbacks to allow introspection of test progress
     # =========================================================
@@ -1984,13 +1995,9 @@ class TestBase(Base):
         for target in targets:
             self.dbg.DeleteTarget(target)
 
-        # Modules are not orphaned during reproducer replay because they're
-        # leaked on purpose.
         if not configuration.is_reproducer():
             # Assert that all targets are deleted.
-            assert self.dbg.GetNumTargets() == 0
-            # Assert that the global module cache is empty.
-            assert lldb.SBModule.GetNumberAllocatedModules() == 0
+            self.assertEqual(self.dbg.GetNumTargets(), 0)
 
         # Do this last, to make sure it's in reverse order from how we setup.
         Base.tearDown(self)

--- a/lldb/source/API/SBModule.cpp
+++ b/lldb/source/API/SBModule.cpp
@@ -690,6 +690,13 @@ uint32_t SBModule::GetNumberAllocatedModules() {
   return Module::GetNumberAllocatedModules();
 }
 
+void SBModule::GarbageCollectAllocatedModules() {
+  LLDB_RECORD_STATIC_METHOD_NO_ARGS(void, SBModule,
+                                    GarbageCollectAllocatedModules);
+  const bool mandatory = false;
+  ModuleList::RemoveOrphanSharedModules(mandatory);
+}
+
 namespace lldb_private {
 namespace repro {
 


### PR DESCRIPTION
… after each test run

Right now the only places in the SB API where lldb:: ModuleSP instances are
destroyed are in SBDebugger::MemoryPressureDetected (where it's just attempted
but not guaranteed) and in SBDebugger::DeleteTarget (which will be removed in
D83933). Tests that directly create an lldb::ModuleSP and never create a target
therefore currently leak lldb::Module instances. This triggers the sanity checks
in lldbtest that make sure that the global module list is empty after a test.

This patch adds SBModule::GarbageCollectAllocatedModules as an explicit way to
clean orphaned lldb::ModuleSP instances. Also we now start calling this method
at the end of each test run and move the sanity check behind that call to make
this work. This way even tests that don't create targets can pass the sanity
check.

This fixes TestUnicodeSymbols.py when D83865 is applied (which makes that the
sanity checks actually fail the test).

Reviewed By: JDevlieghere

Differential Revision: https://reviews.llvm.org/D83876

(cherry picked from commit c2f9454a16e45e1df09d8ebed6dadbc0da264442)