### PR TITLE
[lldb] Fix that C++ base name is only calculated when Swift plugin is…

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -681,13 +681,11 @@ Module::LookupInfo::LookupInfo(ConstString name,
            language == eLanguageTypeSwift) &&
           swift_method.IsValid())
         basename = swift_method.GetBasename();
-      else if ((language == eLanguageTypeUnknown ||
-                Language::LanguageIsCPlusPlus(language) ||
-                Language::LanguageIsC(language) ||
-                language == eLanguageTypeObjC_plus_plus) &&
-               cpp_method.IsValid())
-        basename = cpp_method.GetBasename();
 #endif // LLDB_ENABLE_SWIFT
+      if ((language == eLanguageTypeUnknown ||
+           Language::LanguageIsCFamily(language)) &&
+           cpp_method.IsValid())
+        basename = cpp_method.GetBasename();
 
       if (basename.empty()) {
         if (CPlusPlusLanguage::ExtractContextAndIdentifier(name_cstr, context,


### PR DESCRIPTION
… enabled

In 41c6ab25afbb6dda179c8d995f1935aa60b9b64b I put the C++ GetBasename() call
in Module::LookupInfo behind the LLDB_ENABLE_SWIFT as it appeard to be
introduced by a downstream Swift change. However our downstream change
actually changed
```
  basename = cpp_method.GetBasename();
```
into
```
  if (swift)
    /*swift stuff*/
  else if (c++)
    basename = cpp_method.GetBasename();
```

By putting both if and the else behind LLDB_ENABLE_SWIFT this actually broke
LLDB's ability to set C++ breakpoints by function name when LLDB_ENABLE_SWIFT
wasn't set (which in turn broke the TestCPPBreakpointLocations test).

This patch moves `#ifdef LLDB_ENABLE_SWIFT` only around the Swift-specific
part and leaves the basename calculation enabled independently of Swift.

I also removed the unnecessary `else` as we can't have a method that has
both a language value of Swift and C++, so those branches are anyway mutually
exlusive and comparing the `language` enum value is cheap.

(cherry picked from commit c24d7bfb8a119076c00d2ece3136e76d2c29c34c)