### PR TITLE
[lldb] Handle alternative output in TestAbortExitCode

### DIFF
--- a/lldb/test/Shell/Process/TestAbortExitCode.test
+++ b/lldb/test/Shell/Process/TestAbortExitCode.test
@@ -3,4 +3,4 @@ UNSUPPORTED: system-windows
 RUN: %clang_host %p/Inputs/abort.c -o %t
 RUN: %lldb %t -o run -o continue | FileCheck %s
 
-CHECK: status = 6 (0x00000006)
+CHECK: {{status = 6 \(0x00000006\)|status = 0 \(0x00000000\) Terminated due to signal 6}}


### PR DESCRIPTION
On macOS, this test can instead return `status = 0 (0x00000000) Terminated due to signal 6`. This updates the `CHECK` accordingly.

Differential Revision: https://reviews.llvm.org/D89273

(cherry picked from commit a52cc9b4be362b12ca261000b723374d4b772a45)