### PR TITLE
[repl_swift] Delete codesigning override

### DIFF
--- a/lldb/tools/repl/swift/CMakeLists.txt
+++ b/lldb/tools/repl/swift/CMakeLists.txt
@@ -1,10 +1,3 @@
-# Only set LLVM_CODESIGNING_IDENTITY for building on Apple hosts for Apple
-# targets
-if (CMAKE_HOST_APPLE AND APPLE)
-  # Override locally, so the repl is ad-hoc signed.
-  set(LLVM_CODESIGNING_IDENTITY "-")
-endif()
-
 # Requires system-provided Swift libs.
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14.4)
 


### PR DESCRIPTION
The OSS package build reports `lldb-macosx-arm64/bin/repl_swift: is already signed`.

It looks like the codesigning override for repl_swift is causing the binary to be signed twice.