### PR TITLE
TypeSystem: silence a number of uncovered switch warnings

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4425,6 +4425,9 @@ static SwiftASTContext::TypeOrDecl DeclToTypeOrDecl(swift::ASTContext *ast,
     case swift::DeclKind::Accessor:
     case swift::DeclKind::PoundDiagnostic:
       break;
+
+    default:
+      break;
     }
   }
   return CompilerType();
@@ -5561,6 +5564,9 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
 
   case swift::TypeKind::SILToken:
     break;
+
+  default:
+    break;
   }
   return swift_flags;
 }
@@ -5657,6 +5663,9 @@ lldb::TypeClass SwiftASTContext::GetTypeClass(opaque_compiler_type_t type) {
     break;
 
   case swift::TypeKind::SILToken:
+    break;
+
+  default:
     break;
   }
 
@@ -6164,6 +6173,9 @@ lldb::Encoding SwiftASTContext::GetEncoding(opaque_compiler_type_t type,
 
   case swift::TypeKind::SILToken:
     break;
+
+  default:
+    break;
   }
   count = 0;
   return lldb::eEncodingInvalid;
@@ -6249,6 +6261,9 @@ lldb::Format SwiftASTContext::GetFormat(opaque_compiler_type_t type) {
     break;
 
   case swift::TypeKind::SILToken:
+    break;
+
+  default:
     break;
   }
   // We don't know hot to display this type.
@@ -6361,6 +6376,9 @@ uint32_t SwiftASTContext::GetNumChildren(opaque_compiler_type_t type,
     break;
 
   case swift::TypeKind::SILToken:
+    break;
+
+  default:
     break;
   }
 
@@ -6476,6 +6494,9 @@ uint32_t SwiftASTContext::GetNumFields(opaque_compiler_type_t type) {
     break;
 
   case swift::TypeKind::SILToken:
+    break;
+
+  default:
     break;
   }
 
@@ -6762,6 +6783,9 @@ CompilerType SwiftASTContext::GetFieldAtIndex(opaque_compiler_type_t type,
 
   case swift::TypeKind::SILToken:
     break;
+
+  default:
+    break;
   }
 
   return CompilerType();
@@ -6837,6 +6861,9 @@ uint32_t SwiftASTContext::GetNumPointeeChildren(opaque_compiler_type_t type) {
     break;
 
   case swift::TypeKind::SILToken:
+    break;
+
+  default:
     break;
   }
 
@@ -7201,6 +7228,9 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
 
   case swift::TypeKind::SILToken:
     break;
+
+  default:
+    break;
   }
   return CompilerType();
 }
@@ -7416,6 +7446,9 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
       break;
 
     case swift::TypeKind::SILToken:
+      break;
+
+    default:
       break;
     }
   }
@@ -7800,6 +7833,9 @@ bool SwiftASTContext::DumpTypeValue(
     break;
 
   case swift::TypeKind::SILToken:
+    break;
+
+  default:
     break;
   }
 


### PR DESCRIPTION
This silences a number of uncovered switch warnings from MSVC when
building lldb.