### PR TITLE
Revert "[repl_swift] Delete codesigning override"

### DIFF
--- a/lldb/tools/repl/swift/CMakeLists.txt
+++ b/lldb/tools/repl/swift/CMakeLists.txt
@@ -1,3 +1,10 @@
+# Only set LLVM_CODESIGNING_IDENTITY for building on Apple hosts for Apple
+# targets
+if (CMAKE_HOST_APPLE AND APPLE)
+  # Override locally, so the repl is ad-hoc signed.
+  set(LLVM_CODESIGNING_IDENTITY "-")
+endif()
+
 # Requires system-provided Swift libs.
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14.4)
 


### PR DESCRIPTION
Reverts apple/llvm-project#1945

It looks like it's necessary to add a codesigning entitlement to repl_swift after all.