### PR TITLE
Move initialization of Variable::m_loc_is_const_data into constructor…

### DIFF
--- a/lldb/include/lldb/Symbol/Variable.h
+++ b/lldb/include/lldb/Symbol/Variable.h
@@ -33,7 +33,8 @@ public:
            const lldb::SymbolFileTypeSP &symfile_type_sp, lldb::ValueType scope,
            SymbolContextScope *owner_scope, const RangeList &scope_range,
            Declaration *decl, const DWARFExpression &location, bool external,
-           bool artificial, bool static_member = false);
+           bool artificial, bool location_is_constant_data,
+           bool static_member = false);
 
   virtual ~Variable();
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -3430,9 +3430,7 @@ VariableSP SymbolFileDWARF::ParseVariableDIE(const SymbolContext &sc,
         var_sp = std::make_shared<Variable>(
             die.GetID(), name, mangled, type_sp, scope, symbol_context_scope,
             scope_ranges, &decl, location, is_external, is_artificial,
-            is_static_member);
-
-        var_sp->SetLocationIsConstantValueData(location_is_const_value_data);
+            location_is_const_value_data, is_static_member);
       } else {
         // Not ready to parse this variable yet. It might be a global or static
         // variable that is in a function scope and the function in the symbol

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -812,8 +812,7 @@ VariableSP SymbolFileNativePDB::CreateGlobalVariable(PdbGlobalSymId var_id) {
   VariableSP var_sp = std::make_shared<Variable>(
       toOpaqueUid(var_id), name.str().c_str(), global_name.c_str(), type_sp,
       scope, comp_unit.get(), ranges, &decl, location, is_external, false,
-      false);
-  var_sp->SetLocationIsConstantValueData(false);
+      false, false);
 
   return var_sp;
 }
@@ -840,8 +839,7 @@ SymbolFileNativePDB::CreateConstantSymbol(PdbGlobalSymId var_id,
   VariableSP var_sp = std::make_shared<Variable>(
       toOpaqueUid(var_id), constant.Name.str().c_str(), global_name.c_str(),
       type_sp, eValueTypeVariableGlobal, module.get(), ranges, &decl, location,
-      false, false, false);
-  var_sp->SetLocationIsConstantValueData(true);
+      false, false, true, false);
   return var_sp;
 }
 
@@ -1346,7 +1344,7 @@ VariableSP SymbolFileNativePDB::CreateLocalVariable(PdbCompilandSymId scope_id,
   VariableSP var_sp = std::make_shared<Variable>(
       toOpaqueUid(var_id), name.c_str(), name.c_str(), sftype, var_scope,
       comp_unit_sp.get(), *var_info.ranges, &decl, *var_info.location, false,
-      false, false);
+      false, false, false);
 
   if (!is_param)
     m_ast->GetOrCreateVariableDecl(scope_id, var_id);

--- a/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
@@ -1020,8 +1020,8 @@ VariableSP SymbolFilePDB::ParseVariableForPDBData(
 
   var_sp = std::make_shared<Variable>(
       var_uid, var_name.c_str(), mangled_cstr, type_sp, scope, context_scope,
-      ranges, &decl, location, is_external, is_artificial, is_static_member);
-  var_sp->SetLocationIsConstantValueData(is_constant);
+      ranges, &decl, location, is_external, is_artificial, is_constant,
+      is_static_member);
 
   m_variables.insert(std::make_pair(var_uid, var_sp));
   return var_sp;

--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -40,12 +40,13 @@ Variable::Variable(lldb::user_id_t uid, const char *name, const char *mangled,
                    ValueType scope, SymbolContextScope *context,
                    const RangeList &scope_range, Declaration *decl_ptr,
                    const DWARFExpression &location, bool external,
-                   bool artificial, bool static_member)
+                   bool artificial, bool location_is_constant_data,
+                   bool static_member)
     : UserID(uid), m_name(name), m_mangled(ConstString(mangled)),
       m_symfile_type_sp(symfile_type_sp), m_scope(scope),
       m_owner_scope(context), m_scope_range(scope_range),
       m_declaration(decl_ptr), m_location(location), m_external(external),
-      m_artificial(artificial), m_loc_is_const_data(false),
+      m_artificial(artificial), m_loc_is_const_data(location_is_constant_data),
       m_static_member(static_member) {}
 
 Variable::~Variable() {}


### PR DESCRIPTION
… (NFC)

This makes it symmetric with all other flags and makes it easier to
not forget to initialize it.

https://reviews.llvm.org/D89351
(cherry picked from commit 9b1c06c0e84a9cc763e12b289becb5fc3c9d01ea)

 Conflicts:
	lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp