### PR TITLE
Add accessors. (NFC)

### DIFF
--- a/lldb/include/lldb/Symbol/Type.h
+++ b/lldb/include/lldb/Symbol/Type.h
@@ -56,6 +56,7 @@ public:
   Type *operator->() { return GetType(); }
 
   Type *GetType();
+  SymbolFile &GetSymbolFile() const { return m_symbol_file; }
 
 protected:
   SymbolFile &m_symbol_file;

--- a/lldb/include/lldb/Symbol/Variable.h
+++ b/lldb/include/lldb/Symbol/Variable.h
@@ -65,6 +65,8 @@ public:
 
   lldb::ValueType GetScope() const { return m_scope; }
 
+  const RangeList &GetScopeRange() const { return m_scope_range; }
+
   bool IsExternal() const { return m_external; }
 
   bool IsArtificial() const { return m_artificial; }


### PR DESCRIPTION
There's a place in swift-lldb where it is useful to create a copy of
an lldb_private::Variable. Adding these two accessors makes this
possible.

(cherry picked from commit ec2c2ad2a2dddf24b052625b5ff434704ea43e24)