### PR TITLE
Make sure the Swift REPL is initialized with host OS availablity. 

### DIFF
--- a/lldb/source/Target/TargetList.cpp
+++ b/lldb/source/Target/TargetList.cpp
@@ -254,7 +254,8 @@ Status TargetList::CreateTargetInternal(
   // If we have a valid architecture, make sure the current platform is
   // compatible with that architecture.
   if (!prefer_platform_arch && arch.IsValid()) {
-    if (!platform_sp->IsCompatibleArchitecture(arch, false, nullptr)) {
+    ArchSpec compatible_arch;
+    if (!platform_sp->IsCompatibleArchitecture(arch, false, &compatible_arch)) {
       platform_sp = Platform::GetPlatformForArchitecture(arch, &platform_arch);
       if (!is_dummy_target && platform_sp)
         debugger.GetPlatformList().SetSelectedPlatform(platform_sp);

--- a/lldb/test/Shell/SwiftREPL/Availability.test
+++ b/lldb/test/Shell/SwiftREPL/Availability.test
@@ -1,0 +1,14 @@
+// -*- mode: swift; -*-
+// Test that the REPL is launched with the current OS as availability target.
+// REQUIRES: system-darwin
+
+// RUN: mkdir -p %t.dir
+// RUN: echo '@available(macOS '>%t.dir/NewModule.swift
+// RUN: sw_vers | grep ProductVersion | cut -d : -f 2 >>%t.dir/NewModule.swift
+// RUN: echo ', *) public let message = "Hello"' >>%t.dir/NewModule.swift
+// RUN: %target-swiftc -module-name NewModule -emit-module -emit-library -o %t.dir/libNewModule%target-shared-library-suffix %t.dir/NewModule.swift
+
+// RUN: %lldb --repl="-I%t.dir -L%t.dir -lNewModule" --repl-language swift < %s | FileCheck %s
+import NewModule
+message
+// CHECK: $R0{{.*}}Hello


### PR DESCRIPTION
This is fixed by unifying the code that updates the ArchSpec after
finding a fat binary with how it is done for a lean binary.

<rdar://problem/66024437>

(cherry picked from commit 9f22fa52c9dfc98c96b6a9fdad0c7b3b7759820e)

 Conflicts:
	lldb/source/Target/TargetList.cpp

(cherry picked from commit 4e85bc43b731d0329643f49e3df05c5cba45bd1e)
https://github.com/apple/llvm-project/pull/1963