### PR TITLE
Use the dynamic type of self in the expression evaluator.

### DIFF
--- a/lldb/include/lldb/Symbol/Type.h
+++ b/lldb/include/lldb/Symbol/Type.h
@@ -56,6 +56,7 @@ public:
   Type *operator->() { return GetType(); }
 
   Type *GetType();
+  SymbolFile &GetSymbolFile() const { return m_symbol_file; }
 
 protected:
   SymbolFile &m_symbol_file;

--- a/lldb/include/lldb/Symbol/Variable.h
+++ b/lldb/include/lldb/Symbol/Variable.h
@@ -65,6 +65,8 @@ public:
 
   lldb::ValueType GetScope() const { return m_scope; }
 
+  const RangeList &GetScopeRange() const { return m_scope_range; }
+
   bool IsExternal() const { return m_external; }
 
   bool IsArtificial() const { return m_artificial; }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -15,6 +15,7 @@
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "lldb/Expression/ExpressionParser.h"
 #include "lldb/Expression/ExpressionSourceCode.h"
+#include "lldb/Target/SwiftLanguageRuntime.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/Log.h"
@@ -1019,11 +1020,6 @@ GetPatternBindingForVarDecl(swift::VarDecl *var_decl,
           containing_context, var_decl->getLoc());
 
   return pattern_binding;
-}
-
-static inline swift::Type GetSwiftType(CompilerType type) {
-  return swift::Type(
-      reinterpret_cast<swift::TypeBase *>(type.GetOpaqueQualType()));
 }
 
 bool SwiftASTManipulator::AddExternalVariables(

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -175,6 +175,8 @@ public:
 
   bool SupportsLanguage(lldb::LanguageType language) override;
 
+  SwiftASTContext *GetSwiftASTContext() override { return this; }
+
   Status IsCompatible() override;
 
   swift::SourceManager &GetSourceManager();

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -27,6 +27,7 @@ class Decl;
 
 namespace lldb_private {
 class TypeSystemClang;
+class SwiftASTContext;
 
 /// The implementation of lldb::Type's m_payload field for TypeSystemSwift.
 class TypePayloadSwift {
@@ -97,6 +98,7 @@ public:
   /// \}
 
   static LanguageSet GetSupportedLanguagesForTypes();
+  virtual SwiftASTContext *GetSwiftASTContext() = 0;
   virtual Module *GetModule() const = 0;
   virtual lldb::TypeSP GetCachedType(ConstString mangled) = 0;
   virtual void SetCachedType(ConstString mangled,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/TypeList.h"
@@ -52,23 +53,39 @@ static ConstString GetTypeAlias(swift::Demangle::Demangler &dem,
   return ConstString(mangleNode(global));
 }
 
-/// Find a Clang type by name in module \p M.
-static TypeSP LookupClangType(Module &M, StringRef name) {
-  llvm::SmallVector<CompilerContext, 2> decl_context;
-  decl_context.push_back({CompilerContextKind::AnyModule, ConstString()});
-  decl_context.push_back({CompilerContextKind::AnyType, ConstString(name)});
-  llvm::DenseSet<SymbolFile *> searched_symbol_files;
-  TypeMap clang_types;
-  M.FindTypes(decl_context, TypeSystemClang::GetSupportedLanguagesForTypes(),
-              searched_symbol_files, clang_types);
-  if (clang_types.Empty())
+/// Find a Clang type by name in the modules in \p module_holder.
+static TypeSP LookupClangType(SwiftASTContext *module_holder, StringRef name) {
+  auto lookup = [](Module &M, StringRef name) -> TypeSP {
+    llvm::SmallVector<CompilerContext, 2> decl_context;
+    decl_context.push_back({CompilerContextKind::AnyModule, ConstString()});
+    decl_context.push_back({CompilerContextKind::AnyType, ConstString(name)});
+    llvm::DenseSet<SymbolFile *> searched_symbol_files;
+    TypeMap clang_types;
+    M.FindTypes(decl_context, TypeSystemClang::GetSupportedLanguagesForTypes(),
+                searched_symbol_files, clang_types);
+    if (clang_types.Empty())
+      return {};
+    return clang_types.GetTypeAtIndex(0);
+  };
+  if (!module_holder)
     return {};
-  return clang_types.GetTypeAtIndex(0);
+  if (auto *M = module_holder->GetModule())
+    return lookup(*M, name);
+  TargetSP target_sp = module_holder->GetTarget().lock();
+  if (!target_sp)
+    return {};
+  TypeSP result;
+  target_sp->GetImages().ForEach([&](const ModuleSP &module) -> bool {
+    result = lookup(const_cast<Module &>(*module), name);
+    return !result;
+  });
+  return result;
 }
 
 /// Find a Clang type by name in module \p M.
-CompilerType LookupClangForwardType(Module &M, StringRef name) {
-  if (TypeSP type = LookupClangType(M, name))
+static CompilerType LookupClangForwardType(SwiftASTContext *module_holder,
+                                           StringRef name) {
+  if (TypeSP type = LookupClangType(module_holder, name))
     return type->GetForwardCompilerType();
   return {};
 }
@@ -119,22 +136,28 @@ GetDemangledType(swift::Demangle::Demangler &dem, StringRef name) {
 ///                           __C module are resolved as Clang types.
 ///
 static std::pair<swift::Demangle::NodePointer, CompilerType>
-ResolveTypeAlias(lldb_private::Module *M, swift::Demangle::Demangler &dem,
+ResolveTypeAlias(SwiftASTContext *module_holder,
+                 swift::Demangle::Demangler &dem,
                  swift::Demangle::NodePointer node,
                  bool prefer_clang_types = false) {
   // Try to look this up as a Swift type alias. For each *Swift*
   // type alias there is a debug info entry that has the mangled
   // name as name and the aliased type as a type.
   ConstString mangled = GetTypeAlias(dem, node);
-  if (!M) {
-    LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
-              "No module. Couldn't resolve type alias %s", mangled.AsCString());
-    return {{}, {}};
-  }
   TypeList types;
   if (!prefer_clang_types) {
-    llvm::DenseSet<lldb_private::SymbolFile *> searched_symbol_files;
-    M->FindTypes({mangled}, false, 1, searched_symbol_files, types);
+    llvm::DenseSet<SymbolFile *> searched_symbol_files;
+    if (auto *M = module_holder->GetModule())
+      M->FindTypes({mangled}, false, 1, searched_symbol_files, types);
+    else if (TargetSP target_sp = module_holder->GetTarget().lock())
+      target_sp->GetImages().FindTypes(nullptr, {mangled},
+                                       false, 1, searched_symbol_files, types);
+    else {
+      LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
+                "No module. Couldn't resolve type alias %s",
+                mangled.AsCString());
+      return {{}, {}};
+    }
   }
   if (prefer_clang_types || types.Empty()) {
     // No Swift type found -- this could be a Clang typedef.  This
@@ -146,7 +169,7 @@ ResolveTypeAlias(lldb_private::Module *M, swift::Demangle::Demangler &dem,
         node->getChild(1)->hasText()) {
       // Resolve the typedef within the Clang debug info.
       auto clang_type =
-          LookupClangForwardType(*M, node->getChild(1)->getText());
+          LookupClangForwardType(module_holder, node->getChild(1)->getText());
       if (!clang_type)
         return {{}, {}};
       return {{}, clang_type.GetCanonicalType()};
@@ -214,7 +237,8 @@ swift::Demangle::NodePointer TypeSystemSwiftTypeRef::Transform(
 /// Iteratively resolve all type aliases in \p node by looking up their
 /// desugared types in the debug info of module \p M.
 static swift::Demangle::NodePointer
-GetCanonicalNode(lldb_private::Module *M, swift::Demangle::Demangler &dem,
+GetCanonicalNode(SwiftASTContext *module_holder,
+                 swift::Demangle::Demangler &dem,
                  swift::Demangle::NodePointer node) {
   using namespace swift::Demangle;
   return TypeSystemSwiftTypeRef::Transform(dem, node, [&](NodePointer node) {
@@ -317,7 +341,7 @@ GetCanonicalNode(lldb_private::Module *M, swift::Demangle::Demangler &dem,
 
     case Node::Kind::BoundGenericTypeAlias:
     case Node::Kind::TypeAlias: {
-      auto node_clangtype = ResolveTypeAlias(M, dem, node);
+      auto node_clangtype = ResolveTypeAlias(module_holder, dem, node);
       if (CompilerType clang_type = node_clangtype.second)
         return GetClangTypeNode(clang_type, dem);
       if (node_clangtype.first)
@@ -334,10 +358,10 @@ GetCanonicalNode(lldb_private::Module *M, swift::Demangle::Demangler &dem,
 /// Return the demangle tree representation of this type's canonical
 /// (type aliases resolved) type.
 swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetCanonicalDemangleTree(
-    lldb_private::Module *Module, swift::Demangle::Demangler &dem,
+    SwiftASTContext *module_holder, swift::Demangle::Demangler &dem,
     StringRef mangled_name) {
   NodePointer node = dem.demangleSymbol(mangled_name);
-  NodePointer canonical = GetCanonicalNode(Module, dem, node);
+  NodePointer canonical = GetCanonicalNode(module_holder, dem, node);
   return canonical;
 }
 
@@ -504,7 +528,7 @@ TypeSystemSwiftTypeRef::GetSwiftified(swift::Demangle::Demangler &dem,
 
   // This is an imported Objective-C type; look it up in the
   // debug info.
-  TypeSP clang_type = LookupClangType(*Module, ident);
+  TypeSP clang_type = LookupClangType(m_swift_ast_context, ident);
   if (!clang_type)
     return node;
 
@@ -680,7 +704,8 @@ swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetDemangleTreeForPrinting(
 /// determine whether a node is generic or not, it needs to visit all
 /// nodes. The \p generic_walk argument specifies that the primary
 /// attributes have been collected and that we only look for generics.
-static uint32_t collectTypeInfo(Module *M, swift::Demangle::Demangler &dem,
+static uint32_t collectTypeInfo(SwiftASTContext *module_holder,
+                                swift::Demangle::Demangler &dem,
                                 swift::Demangle::NodePointer node,
                                 bool generic_walk = false) {
   if (!node)
@@ -724,6 +749,7 @@ static uint32_t collectTypeInfo(Module *M, swift::Demangle::Demangler &dem,
     }
   else
     switch (node->getKind()) {
+
     case Node::Kind::SugaredOptional:
       swift_flags |= eTypeIsGeneric | eTypeIsBound | eTypeHasChildren |
                      eTypeHasValue | eTypeIsEnumeration;
@@ -793,7 +819,8 @@ static uint32_t collectTypeInfo(Module *M, swift::Demangle::Demangler &dem,
       if (node->getNumChildren() != 2)
         break;
       // Bug-for-bug compatibility.
-      if (!(collectTypeInfo(M, dem, node->getChild(1)) & eTypeIsGenericTypeParam))
+      if (!(collectTypeInfo(module_holder, dem, node->getChild(1)) &
+            eTypeIsGenericTypeParam))
         swift_flags |= eTypeHasValue | eTypeHasChildren;
       auto module = node->getChild(0);
       if (module->hasText() &&
@@ -827,10 +854,9 @@ static uint32_t collectTypeInfo(Module *M, swift::Demangle::Demangler &dem,
         if (ident->getKind() != Node::Kind::Identifier || !ident->hasText())
           break;
 
-        if (!M)
-          break;
         // Look up the Clang type in DWARF.
-        CompilerType clang_type = LookupClangForwardType(*M, ident->getText());
+        CompilerType clang_type =
+            LookupClangForwardType(module_holder, ident->getText());
         collect_clang_type(clang_type.GetCanonicalType());
         return swift_flags;
       }
@@ -879,12 +905,14 @@ static uint32_t collectTypeInfo(Module *M, swift::Demangle::Demangler &dem,
     case Node::Kind::TypeAlias: {
       // Bug-for-bug compatibility.
       // swift_flags |= eTypeIsTypedef;
-      auto node_clangtype = ResolveTypeAlias(M, dem, node);
+      auto node_clangtype =
+          ResolveTypeAlias(module_holder, dem, node);
       if (CompilerType clang_type = node_clangtype.second) {
         collect_clang_type(clang_type);
         return swift_flags;
       }
-      swift_flags |= collectTypeInfo(M, dem, node_clangtype.first, generic_walk);
+      swift_flags |= collectTypeInfo(module_holder, dem, node_clangtype.first,
+                                     generic_walk);
       return swift_flags;
     }
     default:
@@ -897,7 +925,7 @@ static uint32_t collectTypeInfo(Module *M, swift::Demangle::Demangler &dem,
 
   // Visit the child nodes.
   for (unsigned i = 0; i < node->getNumChildren(); ++i)
-    swift_flags |= collectTypeInfo(M, dem, node->getChild(i), generic_walk);
+    swift_flags |= collectTypeInfo(module_holder, dem, node->getChild(i), generic_walk);
 
   return swift_flags;
 }
@@ -1276,8 +1304,8 @@ TypeSystemSwiftTypeRef::RemangleAsType(swift::Demangle::Demangler &dem,
 swift::Demangle::NodePointer TypeSystemSwiftTypeRef::DemangleCanonicalType(
     swift::Demangle::Demangler &dem, opaque_compiler_type_t opaque_type) {
   using namespace swift::Demangle;
-  NodePointer node =
-      GetCanonicalDemangleTree(GetModule(), dem, AsMangledName(opaque_type));
+  NodePointer node = GetCanonicalDemangleTree(m_swift_ast_context, dem,
+                                              AsMangledName(opaque_type));
   return GetType(node);
 }
 
@@ -1538,7 +1566,7 @@ uint32_t TypeSystemSwiftTypeRef::GetTypeInfo(
     using namespace swift::Demangle;
     Demangler dem;
     NodePointer node = dem.demangleSymbol(AsMangledName(type));
-    return collectTypeInfo(GetModule(), dem, node);
+    return collectTypeInfo(m_swift_ast_context, dem, node);
   };
   VALIDATE_AND_RETURN(impl, GetTypeInfo, type,
                       (ReconstructType(type), nullptr));
@@ -1593,7 +1621,7 @@ TypeSystemSwiftTypeRef::GetCanonicalType(opaque_compiler_type_t type) {
     using namespace swift::Demangle;
     Demangler dem;
     NodePointer canonical =
-        GetCanonicalDemangleTree(GetModule(), dem, AsMangledName(type));
+        GetCanonicalDemangleTree(m_swift_ast_context, dem, AsMangledName(type));
     ConstString mangled(mangleNode(canonical));
     return GetTypeFromMangledTypename(mangled);
   };
@@ -1831,7 +1859,7 @@ CompilerType TypeSystemSwiftTypeRef::GetAsClangTypeOrNull(
       node->getNumChildren() == 2 && node->getChild(0)->hasText() &&
       node->getChild(0)->getText() == swift::MANGLING_MODULE_OBJC &&
       node->getChild(1)->hasText()) {
-    auto node_clangtype = ResolveTypeAlias(GetModule(), dem, node,
+    auto node_clangtype = ResolveTypeAlias(m_swift_ast_context, dem, node,
                                            /*prefer_clang_types*/ true);
     if (node_clangtype.second)
       return node_clangtype.second;
@@ -1853,7 +1881,7 @@ bool TypeSystemSwiftTypeRef::IsImportedType(opaque_compiler_type_t type,
     if (ident.empty())
       return {};
     if (original_type && GetModule())
-      if (TypeSP clang_type = LookupClangType(*GetModule(), ident))
+      if (TypeSP clang_type = LookupClangType(m_swift_ast_context, ident))
         *original_type = clang_type->GetForwardCompilerType();
     return true;
   };

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1250,19 +1250,6 @@ bool Equivalent<llvm::Optional<uint64_t>>(llvm::Optional<uint64_t> l,
   return false;
 }
 
-/// Version taylored to GetTypeBitAlign.
-template <>
-bool Equivalent<llvm::Optional<size_t>>(llvm::Optional<size_t> l,
-                                        llvm::Optional<size_t> r) {
-  if (l == r)
-    return true;
-  // Assume that any value is "better" than none.
-  if (l.hasValue() && !r.hasValue())
-    return true;
-  llvm::dbgs() << l << " != " << r << "\n";
-  return false;
-}
-
 } // namespace
 #endif
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -49,6 +49,7 @@ public:
   /// \}
 
   TypeSystemSwiftTypeRef(SwiftASTContext *swift_ast_context);
+  SwiftASTContext *GetSwiftASTContext() override { return m_swift_ast_context; }
 
   Module *GetModule() const override;
   swift::CanType GetCanonicalSwiftType(CompilerType compiler_type);
@@ -268,7 +269,7 @@ public:
 
   /// Return the canonicalized Demangle tree for a Swift mangled type name.
   static swift::Demangle::NodePointer
-  GetCanonicalDemangleTree(lldb_private::Module *Module,
+  GetCanonicalDemangleTree(SwiftASTContext *module_holder,
                            swift::Demangle::Demangler &dem,
                            llvm::StringRef mangled_name);
 

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2141,6 +2141,9 @@ SwiftLanguageRuntimeImpl::GetTypeInfo(CompilerType type,
   if (!ts)
     return nullptr;
 
+  // Resolve all type aliases.
+  type = type.GetCanonicalType();
+  
   // Resolve all generic type parameters in the type for the current
   // frame.  Archetype binding has to happen in the scratch context,
   // so we lock it while we are in this function.

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2106,7 +2106,8 @@ lldb::addr_t SwiftLanguageRuntime::FixupAddress(lldb::addr_t addr,
 }
 
 const swift::reflection::TypeRef *
-SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type, Module *module) {
+SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type,
+                                     SwiftASTContext *module_holder) {
   // Demangle the mangled name.
   swift::Demangle::Demangler dem;
   ConstString mangled_name = type.GetMangledTypeName();
@@ -2115,7 +2116,8 @@ SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type, Module *module) {
     return nullptr;
   swift::Demangle::NodePointer node =
       TypeSystemSwiftTypeRef::GetCanonicalDemangleTree(
-          module ? module : ts->GetModule(), dem, mangled_name.GetStringRef());
+          module_holder ? module_holder : ts->GetSwiftASTContext(), dem,
+          mangled_name.GetStringRef());
   if (!node)
     return nullptr;
 
@@ -2158,7 +2160,7 @@ SwiftLanguageRuntimeImpl::GetTypeInfo(CompilerType type,
   // context, but we need to resolve (any DWARF links in) the typeref
   // in the original module.
   const swift::reflection::TypeRef *type_ref =
-      GetTypeRef(type, ts->GetModule());
+      GetTypeRef(type, ts->GetSwiftASTContext());
   if (!type_ref)
     return nullptr;
 

--- a/lldb/source/Target/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Target/SwiftLanguageRuntimeImpl.h
@@ -148,19 +148,8 @@ public:
 
 protected:
   /// Use the reflection context to build a TypeRef object.
-  ///
-  /// \param module can be used to specify a module to look up DWARF
-  /// type references (such as type aliases and Clang types)
-  /// in. Module only needs to be specified when it is different from
-  /// \c type.GetTypeSystem().GetModule(). The only situation where it
-  /// is necessary to specify the module explicitly is if a type has
-  /// been imported into the scratch context. This is always the
-  /// module of the outermost type. Even for bound generic types,
-  /// we're only interested in the module the bound generic type came
-  /// from, the bound generic parameters can be resolved from their
-  /// type metadata alone.
   const swift::reflection::TypeRef *GetTypeRef(CompilerType type,
-                                               Module *module = nullptr);
+                                               SwiftASTContext *module_holder);
 
   /// If \p instance points to a Swift object, retrieve its
   /// RecordTypeInfo pass it to the callback \p fn. Repeat the process

--- a/lldb/test/API/lang/swift/generic_class/Makefile
+++ b/lldb/test/API/lang/swift/generic_class/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -O
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/generic_class/TestSwiftGenericClass.py
+++ b/lldb/test/API/lang/swift/generic_class/TestSwiftGenericClass.py
@@ -1,0 +1,21 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class SwiftGenericClassTest(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def test(self):
+        """Tests that a generic class type can be resolved from the instance metadata alone"""
+        self.build()
+        (target, process, thread, breakpoint) = lldbutil.run_to_source_breakpoint(self, 
+                "break here", lldb.SBFileSpec("main.swift"))
+
+        self.expect("frame variable -d run self",
+                    substrs=["a.F<Int>", "23", "42", "128", "256"])
+        self.expect("expr -d run -- self",
+                    substrs=["a.F<Int>", "23", "42", "128", "256"])

--- a/lldb/test/API/lang/swift/generic_class/main.swift
+++ b/lldb/test/API/lang/swift/generic_class/main.swift
@@ -1,0 +1,25 @@
+public class F<A> {
+  let a : A
+  var b = 42
+  var c = 128
+  var d = 256
+  public init(_ val : A) { a = val }
+}
+
+protocol P {
+  func method()
+}
+extension F : P {
+  @inline(never) func method() {
+    print("break here \(b)")
+  }
+}
+
+// Defeat type specialization.
+@inline(never) func getF() -> P {
+  return F<Int>(23)
+}
+
+let obj = getF()
+obj.method()
+


### PR DESCRIPTION
This allows LLDB to resolve generic self types even if no type
parameters are present (for example, because they were optimized out)
because class objects and other entities carry all their dynamic type
information in the *object*.

rdar://problem/69020595