### PR TITLE
[lldb] Add swiftTest decorator to TestSwiftGenericClass.py

### DIFF
--- a/lldb/test/API/lang/swift/generic_class/TestSwiftGenericClass.py
+++ b/lldb/test/API/lang/swift/generic_class/TestSwiftGenericClass.py
@@ -9,6 +9,7 @@ class SwiftGenericClassTest(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
+    @swiftTest
     def test(self):
         """Tests that a generic class type can be resolved from the instance metadata alone"""
         self.build()


### PR DESCRIPTION
Otherwise this test will run in build configurations without the Swift plugin.

(cherry picked from commit 8fd632727edbab1ee4372faaed6bcb821f9c3e06)