### PR TITLE
[lldb][swift] Remove mydir calculation from lldbplaygroundrepl

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbplaygroundrepl.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplaygroundrepl.py
@@ -24,8 +24,6 @@ else:
 
 class PlaygroundREPLTest(TestBase):
 
-    mydir = TestBase.compute_mydir(__file__)
-
     @decorators.skipUnlessDarwin
     @decorators.swiftTest
     @decorators.skipIf(


### PR DESCRIPTION
Calling compute_mydir on a path outside the test/API leads to bogus results
and since commit fcb0d8163a4f3 will also trigger a sanity assert. Also this
isn't an actual test but only the base test for actual tests, so the mydir
value here should be anyway unused.