### PR TITLE
[PM/CC1] Add -f[no-]split-cold-code CC1 option to toggle splitting

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -290,6 +290,10 @@ def warn_alias_with_section : Warning<
   "as the %select{aliasee|resolver}2">,
   InGroup<IgnoredAttributes>;
 
+def warn_fe_ignored_opt_split_cold_code : Warning<
+  "'%0' has no effect when %select{optimizing for minimum size|optimizations are disabled}1">,
+  InGroup<IgnoredAttributes>;
+
 let CategoryName = "Instrumentation Issue" in {
 def warn_profile_data_out_of_date : Warning<
   "profile data may be out of date: of %0 function%s0, %1 %plural{1:has|:have}1"

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -63,6 +63,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MD5.h"
 #include "llvm/Support/TimeProfiler.h"
+#include "llvm/Transforms/IPO/HotColdSplitting.h"
 
 using namespace clang;
 using namespace CodeGen;
@@ -1692,6 +1693,9 @@ void CodeGenModule::SetLLVMFunctionAttributesForDefinition(const Decl *D,
 
     if (D->hasAttr<MinSizeAttr>())
       B.addAttribute(llvm::Attribute::MinSize);
+
+    if (CodeGenOpts.SplitColdCode)
+      B.addAttribute(llvm::getHotColdSplittingAttrKind());
   }
 
   F->addAttributes(llvm::AttributeList::FunctionIndex, B);

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1546,15 +1546,6 @@ static bool ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args, InputKind IK,
 
   Opts.DefaultFunctionAttrs = Args.getAllArgValues(OPT_default_function_attr);
 
-  // -f[no-]split-cold-code
-  // This may only be enabled when optimizing, and when small code size
-  // increases are tolerable.
-  //
-  // swift-clang: Enable hot/cold splitting by default.
-  Opts.SplitColdCode =
-      (Opts.OptimizationLevel > 0) && (Opts.OptimizeSize != 2) &&
-      Args.hasFlag(OPT_fsplit_cold_code, OPT_fno_split_cold_code, true);
-
   Opts.PassPlugins = Args.getAllArgValues(OPT_fpass_plugin_EQ);
 
   Opts.SymbolPartition =
@@ -1565,6 +1556,17 @@ static bool ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args, InputKind IK,
       Args.hasFlag(OPT_AAPCSBitfieldWidth, OPT_ForceNoAAPCSBitfieldWidth, true);
 
   Opts.PassByValueIsNoAlias = Args.hasArg(OPT_fpass_by_value_is_noalias);
+
+  // -f[no-]split-cold-code
+  // This may only be enabled when optimizing, and when small code size
+  // increases are tolerable.
+  Opts.SplitColdCode =
+      (Opts.OptimizationLevel > 0) && (Opts.OptimizeSize != 2) &&
+      Args.hasFlag(OPT_fsplit_cold_code, OPT_fno_split_cold_code, false);
+  if (Arg *A = Args.getLastArg(OPT_fsplit_cold_code))
+    if (!Opts.SplitColdCode)
+      Diags.Report(diag::warn_fe_ignored_opt_split_cold_code)
+          << A->getAsString(Args) << (Opts.OptimizeSize != 2);
 
   return Success;
 }

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1562,7 +1562,7 @@ static bool ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args, InputKind IK,
   // increases are tolerable.
   Opts.SplitColdCode =
       (Opts.OptimizationLevel > 0) && (Opts.OptimizeSize != 2) &&
-      Args.hasFlag(OPT_fsplit_cold_code, OPT_fno_split_cold_code, false);
+      Args.hasFlag(OPT_fsplit_cold_code, OPT_fno_split_cold_code, true);
   if (Arg *A = Args.getLastArg(OPT_fsplit_cold_code))
     if (!Opts.SplitColdCode)
       Diags.Report(diag::warn_fe_ignored_opt_split_cold_code)

--- a/clang/test/CodeGen/split-cold-code.c
+++ b/clang/test/CodeGen/split-cold-code.c
@@ -7,9 +7,11 @@
 // RUN: %clang_cc1 -Oz -fsplit-cold-code -mllvm -debug-pass=Structure \
 // RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=NO-SPLIT %s
 //
-// No splitting by default, even at -O3.
+// ## Begin Apple modification
+// Split by default at -O3.
 // RUN: %clang_cc1 -O3 -mllvm -debug-pass=Structure \
-// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=NO-SPLIT %s
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=SPLIT %s
+// ## End Apple modification
 //
 // No splitting when it's explicitly disabled.
 // RUN: %clang_cc1 -O3 -fno-split-cold-code -mllvm -debug-pass=Structure \
@@ -40,9 +42,11 @@
 // RUN: %clang_cc1 -Oz -fsplit-cold-code -fexperimental-new-pass-manager -fdebug-pass-manager \
 // RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=NO-SPLIT %s
 //
-// No splitting by default, even at -O3.
+// ## Begin Apple modification
+// Split by default at -O3.
 // RUN: %clang_cc1 -O3 -fexperimental-new-pass-manager -fdebug-pass-manager \
-// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=NO-SPLIT %s
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=SPLIT %s
+// ## End Apple modification
 //
 // No splitting when it's explicitly disabled.
 // RUN: %clang_cc1 -O3 -fno-split-cold-code -fexperimental-new-pass-manager -fdebug-pass-manager \

--- a/clang/test/CodeGen/split-cold-code.c
+++ b/clang/test/CodeGen/split-cold-code.c
@@ -1,81 +1,73 @@
 // === Old PM ===
 // No splitting at -O0.
 // RUN: %clang_cc1 -O0 -fsplit-cold-code -mllvm -debug-pass=Structure \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-NO-SPLIT %s
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=NO-SPLIT %s
 //
 // No splitting at -Oz.
 // RUN: %clang_cc1 -Oz -fsplit-cold-code -mllvm -debug-pass=Structure \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-NO-SPLIT %s
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=NO-SPLIT %s
 //
-// Split by default.
+// No splitting by default, even at -O3.
 // RUN: %clang_cc1 -O3 -mllvm -debug-pass=Structure \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-SPLIT %s
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=NO-SPLIT %s
 //
 // No splitting when it's explicitly disabled.
 // RUN: %clang_cc1 -O3 -fno-split-cold-code -mllvm -debug-pass=Structure \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-NO-SPLIT %s
-//
-// No splitting when LLVM passes are disabled.
-// RUN: %clang_cc1 -O3 -fsplit-cold-code -disable-llvm-passes -mllvm -debug-pass=Structure \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-NO-SPLIT %s
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=NO-SPLIT %s
 //
 // Split at -O1.
 // RUN: %clang_cc1 -O1 -fsplit-cold-code -mllvm -debug-pass=Structure \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-SPLIT %s
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=SPLIT %s
 //
 // Split at -Os.
 // RUN: %clang_cc1 -Os -fsplit-cold-code -mllvm -debug-pass=Structure \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-SPLIT %s
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=SPLIT %s
 //
 // Split at -O2.
 // RUN: %clang_cc1 -O2 -fsplit-cold-code -mllvm -debug-pass=Structure \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-SPLIT %s
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=SPLIT %s
 //
 // Split at -O3.
 // RUN: %clang_cc1 -O3 -fsplit-cold-code -mllvm -debug-pass=Structure \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-SPLIT %s
-
-// OLDPM-NO-SPLIT-NOT: Hot Cold Split
-
-// OLDPM-SPLIT: Hot Cold Split
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=SPLIT %s
 
 // === New PM (ditto) ===
 // No splitting at -O0.
 // RUN: %clang_cc1 -O0 -fsplit-cold-code -fexperimental-new-pass-manager -fdebug-pass-manager \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-NO-SPLIT %s
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=NO-SPLIT %s
 //
 // No splitting at -Oz.
 // RUN: %clang_cc1 -Oz -fsplit-cold-code -fexperimental-new-pass-manager -fdebug-pass-manager \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-NO-SPLIT %s
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=NO-SPLIT %s
 //
-// Split by default.
+// No splitting by default, even at -O3.
 // RUN: %clang_cc1 -O3 -fexperimental-new-pass-manager -fdebug-pass-manager \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-SPLIT %s
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=NO-SPLIT %s
 //
 // No splitting when it's explicitly disabled.
 // RUN: %clang_cc1 -O3 -fno-split-cold-code -fexperimental-new-pass-manager -fdebug-pass-manager \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-NO-SPLIT %s
-//
-// No splitting when LLVM passes are disabled.
-// RUN: %clang_cc1 -O3 -fsplit-cold-code -disable-llvm-passes -fexperimental-new-pass-manager -fdebug-pass-manager \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-NO-SPLIT %s
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=NO-SPLIT %s
 //
 // Split at -O1.
 // RUN: %clang_cc1 -O1 -fsplit-cold-code -fexperimental-new-pass-manager -fdebug-pass-manager \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-SPLIT %s
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=SPLIT %s
 //
 // Split at -Os.
 // RUN: %clang_cc1 -Os -fsplit-cold-code -fexperimental-new-pass-manager -fdebug-pass-manager \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-SPLIT %s
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=SPLIT %s
 //
 // Split at -O2.
 // RUN: %clang_cc1 -O2 -fsplit-cold-code -fexperimental-new-pass-manager -fdebug-pass-manager \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-SPLIT %s
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=SPLIT %s
 //
 // Split at -O3.
 // RUN: %clang_cc1 -O3 -fsplit-cold-code -fexperimental-new-pass-manager -fdebug-pass-manager \
-// RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-SPLIT %s
+// RUN:   -emit-llvm -o - %s 2>&1 | FileCheck --check-prefix=SPLIT %s
 
-// NEWPM-NO-SPLIT-NOT: HotColdSplit
+// NO-SPLIT-NOT: "hot-cold-split"
 
-// NEWPM-SPLIT: HotColdSplit
+// SPLIT: define {{.*}} @foo() [[ATTR:#[0-9]+]]
+// SPLIT: attributes [[ATTR]] = { {{.*}} "hot-cold-split"
+
+__attribute__((used))
+void foo() {}

--- a/clang/test/Frontend/split-cold-code.c
+++ b/clang/test/Frontend/split-cold-code.c
@@ -1,0 +1,5 @@
+// RUN: %clang_cc1 -O0 -fsplit-cold-code %s 2>&1 | FileCheck %s --check-prefix=O0
+// O0: warning: '-fsplit-cold-code' has no effect when optimizations are disabled
+
+// RUN: %clang_cc1 -Oz -fsplit-cold-code %s 2>&1 | FileCheck %s --check-prefix=Oz
+// Oz: warning: '-fsplit-cold-code' has no effect when optimizing for minimum size

--- a/llvm/include/llvm/Transforms/IPO/HotColdSplitting.h
+++ b/llvm/include/llvm/Transforms/IPO/HotColdSplitting.h
@@ -12,6 +12,7 @@
 #ifndef LLVM_TRANSFORMS_IPO_HOTCOLDSPLITTING_H
 #define LLVM_TRANSFORMS_IPO_HOTCOLDSPLITTING_H
 
+#include "llvm/ADT/StringRef.h"
 #include "llvm/IR/PassManager.h"
 
 namespace llvm {
@@ -24,6 +25,9 @@ class OptimizationRemarkEmitter;
 class AssumptionCache;
 class DominatorTree;
 class CodeExtractorAnalysisCache;
+
+/// Get the attribute kind used to mark functions for hot/cold splitting.
+StringRef getHotColdSplittingAttrKind();
 
 /// A sequence of basic blocks.
 ///

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -298,7 +298,6 @@ PipelineTuningOptions::PipelineTuningOptions() {
 }
 
 extern cl::opt<bool> EnableConstraintElimination;
-extern cl::opt<bool> EnableHotColdSplit;
 extern cl::opt<bool> EnableOrderFileInstrumentation;
 
 extern cl::opt<bool> FlattenedProfileUsed;
@@ -1236,7 +1235,7 @@ ModulePassManager PassBuilder::buildModuleOptimizationPipeline(
   // Split out cold code. Splitting is done late to avoid hiding context from
   // other optimizations and inadvertently regressing performance. The tradeoff
   // is that this has a higher code size cost than splitting early.
-  if ((EnableHotColdSplit || SplitColdCode) && !LTOPreLink)
+  if (!LTOPreLink)
     MPM.addPass(HotColdSplittingPass());
 
   // LoopSink pass sinks instructions hoisted by LICM, which serves as a
@@ -1625,8 +1624,7 @@ PassBuilder::buildLTODefaultPipeline(OptimizationLevel Level, bool DebugLogging,
 
   // Enable splitting late in the FullLTO post-link pipeline. This is done in
   // the same stage in the old pass manager (\ref addLateLTOOptimizationPasses).
-  if (EnableHotColdSplit || SplitColdCode)
-    MPM.addPass(HotColdSplittingPass());
+  MPM.addPass(HotColdSplittingPass());
 
   // Add late LTO optimization passes.
   // Delete basic blocks, which optimization passes may have killed.

--- a/llvm/lib/Transforms/IPO/HotColdSplitting.cpp
+++ b/llvm/lib/Transforms/IPO/HotColdSplitting.cpp
@@ -73,6 +73,7 @@
 #include <string>
 
 #define DEBUG_TYPE "hotcoldsplit"
+#define PASS_NAME "Hot Cold Splitting"
 
 STATISTIC(NumColdRegionsFound, "Number of cold regions found.");
 STATISTIC(NumColdRegionsOutlined, "Number of cold regions outlined.");
@@ -196,6 +197,8 @@ public:
   }
 
   bool runOnModule(Module &M) override;
+
+  StringRef getPassName() const override { return PASS_NAME; }
 };
 
 } // end anonymous namespace
@@ -217,6 +220,9 @@ bool HotColdSplitting::isFunctionCold(const Function &F) const {
 // Returns false if the function should not be considered for hot-cold split
 // optimization.
 bool HotColdSplitting::shouldOutlineFrom(const Function &F) const {
+  if (!F.hasFnAttribute(getHotColdSplittingAttrKind()))
+    return false;
+
   if (F.hasFnAttribute(Attribute::AlwaysInline))
     return false;
 
@@ -785,13 +791,17 @@ HotColdSplittingPass::run(Module &M, ModuleAnalysisManager &AM) {
 }
 
 char HotColdSplittingLegacyPass::ID = 0;
-INITIALIZE_PASS_BEGIN(HotColdSplittingLegacyPass, "hotcoldsplit",
-                      "Hot Cold Splitting", false, false)
+INITIALIZE_PASS_BEGIN(HotColdSplittingLegacyPass, "hotcoldsplit", PASS_NAME,
+                      false, false)
 INITIALIZE_PASS_DEPENDENCY(ProfileSummaryInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(BlockFrequencyInfoWrapperPass)
-INITIALIZE_PASS_END(HotColdSplittingLegacyPass, "hotcoldsplit",
-                    "Hot Cold Splitting", false, false)
+INITIALIZE_PASS_END(HotColdSplittingLegacyPass, "hotcoldsplit", PASS_NAME,
+                    false, false)
 
 ModulePass *llvm::createHotColdSplittingPass() {
   return new HotColdSplittingLegacyPass();
+}
+
+StringRef llvm::getHotColdSplittingAttrKind() {
+  return "hot-cold-split";
 }

--- a/llvm/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/llvm/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -104,9 +104,6 @@ static cl::opt<bool>
     EnablePerformThinLTO("perform-thinlto", cl::init(false), cl::Hidden,
                          cl::desc("Enable performing ThinLTO."));
 
-cl::opt<bool> EnableHotColdSplit("hot-cold-split", cl::init(false),
-    cl::ZeroOrMore, cl::desc("Enable hot-cold splitting pass"));
-
 static cl::opt<bool> UseLoopVersioningLICM(
     "enable-loop-versioning-licm", cl::init(false), cl::Hidden,
     cl::desc("Enable the experimental Loop Versioning LICM pass"));
@@ -866,8 +863,7 @@ void PassManagerBuilder::populateModulePassManager(
 
   // See comment in the new PM for justification of scheduling splitting at
   // this stage (\ref buildModuleSimplificationPipeline).
-  if ((EnableHotColdSplit || SplitColdCode) &&
-      !(PrepareForLTO || PrepareForThinLTO))
+  if (!(PrepareForLTO || PrepareForThinLTO))
     MPM.add(createHotColdSplittingPass());
 
   if (MergeFunctions)
@@ -1091,8 +1087,7 @@ void PassManagerBuilder::addLateLTOOptimizationPasses(
     legacy::PassManagerBase &PM) {
   // See comment in the new PM for justification of scheduling splitting at
   // this stage (\ref buildLTODefaultPipeline).
-  if (EnableHotColdSplit || SplitColdCode)
-    PM.add(createHotColdSplittingPass());
+  PM.add(createHotColdSplittingPass());
 
   // Delete basic blocks, which optimization passes may have killed.
   PM.add(createCFGSimplificationPass());

--- a/llvm/test/CodeGen/AMDGPU/opt-pipeline.ll
+++ b/llvm/test/CodeGen/AMDGPU/opt-pipeline.ll
@@ -280,6 +280,13 @@
 ; GCN-O1-NEXT:       Warn about non-applied transformations
 ; GCN-O1-NEXT:       Alignment from assumptions
 ; GCN-O1-NEXT:     Strip Unused Function Prototypes
+; GCN-O1-NEXT:     Hot Cold Splitting
+; GCN-O1-NEXT:       FunctionPass Manager
+; GCN-O1-NEXT:         Dominator Tree Construction
+; GCN-O1-NEXT:         Natural Loop Information
+; GCN-O1-NEXT:         Post-Dominator Tree Construction
+; GCN-O1-NEXT:         Branch Probability Analysis
+; GCN-O1-NEXT:         Block Frequency Analysis
 ; GCN-O1-NEXT:     Call Graph Profile
 ; GCN-O1-NEXT:       FunctionPass Manager
 ; GCN-O1-NEXT:         Dominator Tree Construction
@@ -639,6 +646,13 @@
 ; GCN-O2-NEXT:     Strip Unused Function Prototypes
 ; GCN-O2-NEXT:     Dead Global Elimination
 ; GCN-O2-NEXT:     Merge Duplicate Global Constants
+; GCN-O2-NEXT:     Hot Cold Splitting
+; GCN-O2-NEXT:       FunctionPass Manager
+; GCN-O2-NEXT:         Dominator Tree Construction
+; GCN-O2-NEXT:         Natural Loop Information
+; GCN-O2-NEXT:         Post-Dominator Tree Construction
+; GCN-O2-NEXT:         Branch Probability Analysis
+; GCN-O2-NEXT:         Block Frequency Analysis
 ; GCN-O2-NEXT:     Call Graph Profile
 ; GCN-O2-NEXT:       FunctionPass Manager
 ; GCN-O2-NEXT:         Dominator Tree Construction
@@ -1003,6 +1017,13 @@
 ; GCN-O3-NEXT:     Strip Unused Function Prototypes
 ; GCN-O3-NEXT:     Dead Global Elimination
 ; GCN-O3-NEXT:     Merge Duplicate Global Constants
+; GCN-O3-NEXT:     Hot Cold Splitting
+; GCN-O3-NEXT:       FunctionPass Manager
+; GCN-O3-NEXT:         Dominator Tree Construction
+; GCN-O3-NEXT:         Natural Loop Information
+; GCN-O3-NEXT:         Post-Dominator Tree Construction
+; GCN-O3-NEXT:         Branch Probability Analysis
+; GCN-O3-NEXT:         Block Frequency Analysis
 ; GCN-O3-NEXT:     Call Graph Profile
 ; GCN-O3-NEXT:       FunctionPass Manager
 ; GCN-O3-NEXT:         Dominator Tree Construction

--- a/llvm/test/Other/X86/lto-hot-cold-split.ll
+++ b/llvm/test/Other/X86/lto-hot-cold-split.ll
@@ -1,6 +1,6 @@
 ; RUN: opt -module-summary %s -o %t.bc
-; RUN: llvm-lto -hot-cold-split=true -thinlto-action=run %t.bc -debug-pass=Structure 2>&1 | FileCheck %s -check-prefix=OLDPM-ANYLTO-POSTLINK-Os
-; RUN: llvm-lto -hot-cold-split=true %t.bc -debug-pass=Structure 2>&1 | FileCheck %s -check-prefix=OLDPM-ANYLTO-POSTLINK-Os
+; RUN: llvm-lto -thinlto-action=run %t.bc -debug-pass=Structure 2>&1 | FileCheck %s -check-prefix=OLDPM-ANYLTO-POSTLINK-Os
+; RUN: llvm-lto %t.bc -debug-pass=Structure 2>&1 | FileCheck %s -check-prefix=OLDPM-ANYLTO-POSTLINK-Os
 
 ; REQUIRES: asserts
 

--- a/llvm/test/Other/new-pm-defaults.ll
+++ b/llvm/test/Other/new-pm-defaults.ll
@@ -10,23 +10,27 @@
 ; RUN: opt -disable-verify -debug-pass-manager \
 ; RUN:     -passes='default<O1>' -S %s 2>&1 \
 ; RUN:     | FileCheck %s --check-prefix=CHECK-O --check-prefix=CHECK-O1 \
-; RUN:      --check-prefix=%llvmcheckext
+; RUN:      --check-prefix=%llvmcheckext --check-prefix=CHECK-O-NOPRELINK
 ; RUN: opt -disable-verify -debug-pass-manager \
 ; RUN:     -passes='default<O2>' -S  %s 2>&1 \
 ; RUN:     | FileCheck %s --check-prefix=CHECK-O --check-prefix=CHECK-O2 \
-; RUN:      --check-prefix=CHECK-O23SZ --check-prefix=%llvmcheckext
+; RUN:      --check-prefix=CHECK-O23SZ --check-prefix=%llvmcheckext \
+; RUN:      --check-prefix=CHECK-O-NOPRELINK
 ; RUN: opt -disable-verify -debug-pass-manager \
 ; RUN:     -passes='default<O3>' -S  %s 2>&1 \
 ; RUN:     | FileCheck %s --check-prefix=CHECK-O --check-prefix=CHECK-O3 \
-; RUN:      --check-prefix=CHECK-O23SZ --check-prefix=%llvmcheckext
+; RUN:      --check-prefix=CHECK-O23SZ --check-prefix=%llvmcheckext \
+; RUN:      --check-prefix=CHECK-O-NOPRELINK
 ; RUN: opt -disable-verify -debug-pass-manager \
 ; RUN:     -passes='default<Os>' -S %s 2>&1 \
 ; RUN:     | FileCheck %s --check-prefix=CHECK-O --check-prefix=CHECK-Os \
-; RUN:      --check-prefix=CHECK-O23SZ --check-prefix=%llvmcheckext
+; RUN:      --check-prefix=CHECK-O23SZ --check-prefix=%llvmcheckext \
+; RUN:      --check-prefix=CHECK-O-NOPRELINK
 ; RUN: opt -disable-verify -debug-pass-manager \
 ; RUN:     -passes='default<Oz>' -S %s 2>&1 \
 ; RUN:     | FileCheck %s --check-prefix=CHECK-O --check-prefix=CHECK-Oz \
-; RUN:     --check-prefix=CHECK-O23SZ --check-prefix=%llvmcheckext
+; RUN:     --check-prefix=CHECK-O23SZ --check-prefix=%llvmcheckext \
+; RUN:     --check-prefix=CHECK-O-NOPRELINK
 ; RUN: opt -disable-verify -debug-pass-manager \
 ; RUN:     -passes='lto-pre-link<O2>' -S %s 2>&1 \
 ; RUN:     | FileCheck %s --check-prefix=CHECK-O --check-prefix=CHECK-O2 \
@@ -38,43 +42,50 @@
 ; RUN:     -passes='default<O3>' -S  %s 2>&1 \
 ; RUN:     | FileCheck %s --check-prefix=CHECK-O --check-prefix=CHECK-O3 \
 ; RUN:     --check-prefix=%llvmcheckext \
-; RUN:     --check-prefix=CHECK-EP-PEEPHOLE --check-prefix=CHECK-O23SZ
+; RUN:     --check-prefix=CHECK-EP-PEEPHOLE --check-prefix=CHECK-O23SZ \
+; RUN:     --check-prefix=CHECK-O-NOPRELINK
 ; RUN: opt -disable-verify -debug-pass-manager \
 ; RUN:     -passes-ep-late-loop-optimizations='no-op-loop' \
 ; RUN:     -passes='default<O3>' -S  %s 2>&1 \
 ; RUN:     | FileCheck %s --check-prefix=CHECK-O --check-prefix=CHECK-O3 \
 ; RUN:     --check-prefix=%llvmcheckext \
-; RUN:     --check-prefix=CHECK-EP-LOOP-LATE --check-prefix=CHECK-O23SZ
+; RUN:     --check-prefix=CHECK-EP-LOOP-LATE --check-prefix=CHECK-O23SZ \
+; RUN:     --check-prefix=CHECK-O-NOPRELINK
 ; RUN: opt -disable-verify -debug-pass-manager \
 ; RUN:     -passes-ep-loop-optimizer-end='no-op-loop' \
 ; RUN:     -passes='default<O3>' -S  %s 2>&1 \
 ; RUN:     | FileCheck %s --check-prefix=CHECK-O --check-prefix=CHECK-O3 \
 ; RUN:     --check-prefix=%llvmcheckext \
-; RUN:     --check-prefix=CHECK-EP-LOOP-END --check-prefix=CHECK-O23SZ
+; RUN:     --check-prefix=CHECK-EP-LOOP-END --check-prefix=CHECK-O23SZ \
+; RUN:     --check-prefix=CHECK-O-NOPRELINK
 ; RUN: opt -disable-verify -debug-pass-manager \
 ; RUN:     -passes-ep-scalar-optimizer-late='no-op-function' \
 ; RUN:     -passes='default<O3>' -S  %s 2>&1 \
 ; RUN:     | FileCheck %s --check-prefix=CHECK-O --check-prefix=CHECK-O3 \
 ; RUN:     --check-prefix=%llvmcheckext \
-; RUN:     --check-prefix=CHECK-EP-SCALAR-LATE --check-prefix=CHECK-O23SZ
+; RUN:     --check-prefix=CHECK-EP-SCALAR-LATE --check-prefix=CHECK-O23SZ \
+; RUN:     --check-prefix=CHECK-O-NOPRELINK
 ; RUN: opt -disable-verify -debug-pass-manager \
 ; RUN:     -passes-ep-cgscc-optimizer-late='no-op-cgscc' \
 ; RUN:     -passes='default<O3>' -S  %s 2>&1 \
 ; RUN:     | FileCheck %s --check-prefix=CHECK-O --check-prefix=CHECK-O3 \
 ; RUN:     --check-prefix=%llvmcheckext \
-; RUN:     --check-prefix=CHECK-EP-CGSCC-LATE --check-prefix=CHECK-O23SZ
+; RUN:     --check-prefix=CHECK-EP-CGSCC-LATE --check-prefix=CHECK-O23SZ \
+; RUN:     --check-prefix=CHECK-O-NOPRELINK
 ; RUN: opt -disable-verify -debug-pass-manager \
 ; RUN:     -passes-ep-vectorizer-start='no-op-function' \
 ; RUN:     -passes='default<O3>' -S  %s 2>&1 \
 ; RUN:     | FileCheck %s --check-prefix=CHECK-O --check-prefix=CHECK-O3 \
 ; RUN:     --check-prefix=%llvmcheckext \
-; RUN:     --check-prefix=CHECK-EP-VECTORIZER-START --check-prefix=CHECK-O23SZ
+; RUN:     --check-prefix=CHECK-EP-VECTORIZER-START --check-prefix=CHECK-O23SZ \
+; RUN:     --check-prefix=CHECK-O-NOPRELINK
 ; RUN: opt -disable-verify -debug-pass-manager \
 ; RUN:     -passes-ep-pipeline-start='no-op-module' \
 ; RUN:     -passes='default<O3>' -S  %s 2>&1 \
 ; RUN:     | FileCheck %s --check-prefix=CHECK-O --check-prefix=CHECK-O3 \
 ; RUN:     --check-prefix=%llvmcheckext \
-; RUN:     --check-prefix=CHECK-EP-PIPELINE-START --check-prefix=CHECK-O23SZ
+; RUN:     --check-prefix=CHECK-EP-PIPELINE-START --check-prefix=CHECK-O23SZ \
+; RUN:     --check-prefix=CHECK-O-NOPRELINK
 ; RUN: opt -disable-verify -debug-pass-manager \
 ; RUN:     -passes-ep-pipeline-start='no-op-module' \
 ; RUN:     -passes='lto-pre-link<O3>' -S  %s 2>&1 \
@@ -86,7 +97,8 @@
 ; RUN:     -passes='default<O3>' -S  %s 2>&1 \
 ; RUN:     | FileCheck %s --check-prefix=CHECK-O --check-prefix=CHECK-O3 \
 ; RUN:     --check-prefix=%llvmcheckext \
-; RUN:     --check-prefix=CHECK-EP-OPTIMIZER-LAST --check-prefix=CHECK-O23SZ
+; RUN:     --check-prefix=CHECK-EP-OPTIMIZER-LAST --check-prefix=CHECK-O23SZ \
+; RUN:     --check-prefix=CHECK-O-NOPRELINK
 
 ; CHECK-O: Starting llvm::Module pass manager run.
 ; CHECK-O-NEXT: Running pass: ForceFunctionAttrsPass
@@ -223,6 +235,7 @@
 ; CHECK-O2-LTO-NOT: Running pass: EliminateAvailableExternallyPass
 ; CHECK-O: Running pass: ReversePostOrderFunctionAttrsPass
 ; CHECK-O-NEXT: Running pass: RequireAnalysisPass<{{.*}}GlobalsAA
+; CHECK-O-NOPRELINK-NEXT: Running pass: HotColdSplittingPass
 ; CHECK-O-NEXT: Starting llvm::Function pass manager run.
 ; CHECK-O-NEXT: Running pass: Float2IntPass
 ; CHECK-O-NEXT: Running pass: LowerConstantIntrinsicsPass on foo

--- a/llvm/test/Other/new-pm-lto-defaults.ll
+++ b/llvm/test/Other/new-pm-lto-defaults.ll
@@ -98,6 +98,7 @@
 ; CHECK-O2-NEXT: Running pass: CrossDSOCFIPass
 ; CHECK-O2-NEXT: Running pass: LowerTypeTestsPass
 ; CHECK-O-NEXT: Running pass: LowerTypeTestsPass
+; CHECK-O2-NEXT: Running pass: HotColdSplittingPass
 ; CHECK-O2-NEXT: Running pass: SimplifyCFGPass
 ; CHECK-O2-NEXT: Running pass: EliminateAvailableExternallyPass
 ; CHECK-O2-NEXT: Running pass: GlobalDCEPass

--- a/llvm/test/Other/new-pm-pgo.ll
+++ b/llvm/test/Other/new-pm-pgo.ll
@@ -1,9 +1,8 @@
 ; RUN: opt -debug-pass-manager -passes='default<O2>' -pgo-kind=pgo-instr-gen-pipeline -profile-file='temp' %s 2>&1 |FileCheck %s --check-prefixes=GEN
 ; RUN: llvm-profdata merge %S/Inputs/new-pm-pgo.proftext -o %t.profdata
-; RUN: opt -debug-pass-manager -passes='default<O2>' -pgo-kind=pgo-instr-use-pipeline -profile-file='%t.profdata' %s 2>&1 |FileCheck %s --check-prefixes=USE
+; RUN: opt -debug-pass-manager -passes='default<O2>' -pgo-kind=pgo-instr-use-pipeline -profile-file='%t.profdata' %s 2>&1 |FileCheck %s --check-prefixes=USE,USE-NOPRELINK
 ; RUN: opt -debug-pass-manager -passes='thinlto-pre-link<O2>' -pgo-kind=pgo-instr-use-pipeline -profile-file='%t.profdata' %s 2>&1 |FileCheck %s --check-prefixes=USE
 ; RUN: opt -debug-pass-manager -passes='thinlto<O2>' -pgo-kind=pgo-instr-use-pipeline -profile-file='%t.profdata' %s 2>&1 |FileCheck %s --check-prefixes=USE_POST_LINK
-; RUN: opt -debug-pass-manager -passes='default<O2>' -hot-cold-split -pgo-kind=pgo-instr-use-pipeline -profile-file='%t.profdata' %s 2>&1 |FileCheck %s --check-prefixes=USE --check-prefixes=SPLIT
 ; RUN: opt -debug-pass-manager -passes='default<O2>' -pgo-kind=pgo-sample-use-pipeline -profile-file='%S/Inputs/new-pm-pgo.prof' %s 2>&1 \
 ; RUN:     |FileCheck %s --check-prefixes=SAMPLE_USE,SAMPLE_USE_O
 ; RUN: opt -debug-pass-manager -passes='thinlto-pre-link<O2>' -pgo-kind=pgo-sample-use-pipeline -profile-file='%S/Inputs/new-pm-pgo.prof' %s 2>&1 \
@@ -31,7 +30,7 @@
 ; SAMPLE_USE_POST_LINK: Running pass: PGOIndirectCallPromotion
 ; SAMPLE_USE_PRE_LINK-NOT: Running pass: PGOIndirectCallPromotion
 ; SAMPLE_GEN: Running pass: AddDiscriminatorsPass
-; SPLIT: Running pass: HotColdSplittingPass
+; USE-NOPRELINK: Running pass: HotColdSplittingPass
 
 define void @foo() {
   ret void

--- a/llvm/test/Other/new-pm-thinlto-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-defaults.ll
@@ -194,6 +194,7 @@
 ; CHECK-POSTLINK-O-NEXT: Running pass: EliminateAvailableExternallyPass
 ; CHECK-POSTLINK-O-NEXT: Running pass: ReversePostOrderFunctionAttrsPass
 ; CHECK-POSTLINK-O-NEXT: Running pass: RequireAnalysisPass<{{.*}}GlobalsAA
+; CHECK-POSTLINK-O-NEXT: Running pass: HotColdSplittingPass
 ; CHECK-POSTLINK-O-NEXT: Starting llvm::Function pass manager run.
 ; CHECK-POSTLINK-O-NEXT: Running pass: Float2IntPass
 ; CHECK-POSTLINK-O-NEXT: Running pass: LowerConstantIntrinsicsPass

--- a/llvm/test/Other/new-pm-thinlto-postlink-pgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-postlink-pgo-defaults.ll
@@ -165,6 +165,7 @@
 ; CHECK-O-NEXT: Running pass: EliminateAvailableExternallyPass
 ; CHECK-O-NEXT: Running pass: ReversePostOrderFunctionAttrsPass
 ; CHECK-O-NEXT: Running pass: RequireAnalysisPass<{{.*}}GlobalsAA
+; CHECK-O-NEXT: Running pass: HotColdSplittingPass
 ; CHECK-O-NEXT: Starting {{.*}}Function pass manager run.
 ; CHECK-O-NEXT: Running pass: Float2IntPass
 ; CHECK-O-NEXT: Running pass: LowerConstantIntrinsicsPass

--- a/llvm/test/Other/new-pm-thinlto-postlink-samplepgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-postlink-samplepgo-defaults.ll
@@ -176,6 +176,7 @@
 ; CHECK-O-NEXT: Running pass: EliminateAvailableExternallyPass
 ; CHECK-O-NEXT: Running pass: ReversePostOrderFunctionAttrsPass
 ; CHECK-O-NEXT: Running pass: RequireAnalysisPass<{{.*}}GlobalsAA
+; CHECK-O-NEXT: Running pass: HotColdSplittingPass
 ; CHECK-O-NEXT: Starting {{.*}}Function pass manager run.
 ; CHECK-O-NEXT: Running pass: Float2IntPass
 ; CHECK-O-NEXT: Running pass: LowerConstantIntrinsicsPass

--- a/llvm/test/Other/opt-O2-pipeline.ll
+++ b/llvm/test/Other/opt-O2-pipeline.ll
@@ -286,6 +286,13 @@
 ; CHECK-NEXT:     Strip Unused Function Prototypes
 ; CHECK-NEXT:     Dead Global Elimination
 ; CHECK-NEXT:     Merge Duplicate Global Constants
+; CHECK-NEXT:     Hot Cold Splitting
+; CHECK-NEXT:       FunctionPass Manager
+; CHECK-NEXT:         Dominator Tree Construction
+; CHECK-NEXT:         Natural Loop Information
+; CHECK-NEXT:         Post-Dominator Tree Construction
+; CHECK-NEXT:         Branch Probability Analysis
+; CHECK-NEXT:         Block Frequency Analysis
 ; CHECK-NEXT:     Call Graph Profile
 ; CHECK-NEXT:       FunctionPass Manager
 ; CHECK-NEXT:         Dominator Tree Construction

--- a/llvm/test/Other/opt-O3-pipeline-enable-matrix.ll
+++ b/llvm/test/Other/opt-O3-pipeline-enable-matrix.ll
@@ -298,6 +298,13 @@
 ; CHECK-NEXT:     Strip Unused Function Prototypes
 ; CHECK-NEXT:     Dead Global Elimination
 ; CHECK-NEXT:     Merge Duplicate Global Constants
+; CHECK-NEXT:     Hot Cold Splitting
+; CHECK-NEXT:       FunctionPass Manager
+; CHECK-NEXT:         Dominator Tree Construction
+; CHECK-NEXT:         Natural Loop Information
+; CHECK-NEXT:         Post-Dominator Tree Construction
+; CHECK-NEXT:         Branch Probability Analysis
+; CHECK-NEXT:         Block Frequency Analysis
 ; CHECK-NEXT:     Call Graph Profile
 ; CHECK-NEXT:       FunctionPass Manager
 ; CHECK-NEXT:         Dominator Tree Construction

--- a/llvm/test/Other/opt-O3-pipeline.ll
+++ b/llvm/test/Other/opt-O3-pipeline.ll
@@ -291,6 +291,13 @@
 ; CHECK-NEXT:     Strip Unused Function Prototypes
 ; CHECK-NEXT:     Dead Global Elimination
 ; CHECK-NEXT:     Merge Duplicate Global Constants
+; CHECK-NEXT:     Hot Cold Splitting
+; CHECK-NEXT:       FunctionPass Manager
+; CHECK-NEXT:         Dominator Tree Construction
+; CHECK-NEXT:         Natural Loop Information
+; CHECK-NEXT:         Post-Dominator Tree Construction
+; CHECK-NEXT:         Branch Probability Analysis
+; CHECK-NEXT:         Block Frequency Analysis
 ; CHECK-NEXT:     Call Graph Profile
 ; CHECK-NEXT:       FunctionPass Manager
 ; CHECK-NEXT:         Dominator Tree Construction

--- a/llvm/test/Other/opt-Os-pipeline.ll
+++ b/llvm/test/Other/opt-Os-pipeline.ll
@@ -272,6 +272,13 @@
 ; CHECK-NEXT:     Strip Unused Function Prototypes
 ; CHECK-NEXT:     Dead Global Elimination
 ; CHECK-NEXT:     Merge Duplicate Global Constants
+; CHECK-NEXT:     Hot Cold Splitting
+; CHECK-NEXT:       FunctionPass Manager
+; CHECK-NEXT:         Dominator Tree Construction
+; CHECK-NEXT:         Natural Loop Information
+; CHECK-NEXT:         Post-Dominator Tree Construction
+; CHECK-NEXT:         Branch Probability Analysis
+; CHECK-NEXT:         Block Frequency Analysis
 ; CHECK-NEXT:     Call Graph Profile
 ; CHECK-NEXT:       FunctionPass Manager
 ; CHECK-NEXT:         Dominator Tree Construction

--- a/llvm/test/Other/opt-hot-cold-split.ll
+++ b/llvm/test/Other/opt-hot-cold-split.ll
@@ -1,8 +1,8 @@
-; RUN: opt -mtriple=x86_64-- -Os -hot-cold-split=true -debug-pass=Structure -enable-new-pm=0 < %s -o /dev/null 2>&1 | FileCheck %s -check-prefix=DEFAULT-Os
-; RUN: opt -mtriple=x86_64-- -hot-cold-split=true -passes='lto-pre-link<Os>' -debug-pass-manager < %s -o /dev/null 2>&1 | FileCheck %s -check-prefix=LTO-PRELINK-Os
-; RUN: opt -mtriple=x86_64-- -hot-cold-split=true -passes='thinlto-pre-link<Os>' -debug-pass-manager < %s -o /dev/null 2>&1 | FileCheck %s -check-prefix=THINLTO-PRELINK-Os
-; RUN: opt -mtriple=x86_64-- -hot-cold-split=true -passes='lto<Os>' -debug-pass-manager < %s -o /dev/null 2>&1 | FileCheck %s -check-prefix=LTO-POSTLINK-Os
-; RUN: opt -mtriple=x86_64-- -hot-cold-split=true -passes='thinlto<Os>' -debug-pass-manager < %s -o /dev/null 2>&1 | FileCheck %s -check-prefix=THINLTO-POSTLINK-Os
+; RUN: opt -mtriple=x86_64-- -Os -debug-pass=Structure -enable-new-pm=0 < %s -o /dev/null 2>&1 | FileCheck %s -check-prefix=DEFAULT-Os
+; RUN: opt -mtriple=x86_64-- -passes='lto-pre-link<Os>' -debug-pass-manager < %s -o /dev/null 2>&1 | FileCheck %s -check-prefix=LTO-PRELINK-Os
+; RUN: opt -mtriple=x86_64-- -passes='thinlto-pre-link<Os>' -debug-pass-manager < %s -o /dev/null 2>&1 | FileCheck %s -check-prefix=THINLTO-PRELINK-Os
+; RUN: opt -mtriple=x86_64-- -passes='lto<Os>' -debug-pass-manager < %s -o /dev/null 2>&1 | FileCheck %s -check-prefix=LTO-POSTLINK-Os
+; RUN: opt -mtriple=x86_64-- -passes='thinlto<Os>' -debug-pass-manager < %s -o /dev/null 2>&1 | FileCheck %s -check-prefix=THINLTO-POSTLINK-Os
 
 ; REQUIRES: asserts
 

--- a/llvm/test/Other/pass-pipelines.ll
+++ b/llvm/test/Other/pass-pipelines.ll
@@ -11,11 +11,6 @@
 ; RUN:     -pgo-kind=pgo-instr-use-pipeline -profile-file='%t.profdata' \
 ; RUN:     -O2 %s 2>&1 \
 ; RUN:     | FileCheck %s --check-prefix=CHECK-O2 --check-prefix=PGOUSE
-; RUN: opt -enable-new-pm=0 -disable-output -disable-verify -debug-pass=Structure \
-; RUN:     -pgo-kind=pgo-instr-use-pipeline -profile-file='%t.profdata' \
-; RUN:     -hot-cold-split \
-; RUN:     -O2 %s 2>&1 \
-; RUN:     | FileCheck %s --check-prefix=CHECK-O2 --check-prefix=PGOUSE --check-prefix=SPLIT
 ;
 ; In the first pipeline there should just be a function pass manager, no other
 ; pass managers.
@@ -101,7 +96,7 @@
 ; the runtime unrolling though.
 ; CHECK-O2: Loop Pass Manager
 ; CHECK-O2-NEXT: Loop Invariant Code Motion
-; SPLIT: Hot Cold Splitting
+; CHECK-O2: Hot Cold Splitting
 ; CHECK-O2: FunctionPass Manager
 ; CHECK-O2: Loop Pass Manager
 ; CHECK-O2-NEXT: Loop Sink

--- a/llvm/test/Transforms/CodeExtractor/extract-assume.ll
+++ b/llvm/test/Transforms/CodeExtractor/extract-assume.ll
@@ -9,7 +9,7 @@
 
 declare void @fun2(i32) #0
 
-define void @fun(i32 %x) {
+define void @fun(i32 %x) "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.else
 

--- a/llvm/test/Transforms/HotColdSplit/X86/do-not-split.ll
+++ b/llvm/test/Transforms/HotColdSplit/X86/do-not-split.ll
@@ -9,7 +9,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; The cold region is too small to split.
 ; CHECK-LABEL: @foo
 ; CHECK-NOT: foo.cold.1
-define void @foo() {
+define void @foo() "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.end
 
@@ -23,7 +23,7 @@ if.end:                                           ; preds = %entry
 ; The cold region is still too small to split.
 ; CHECK-LABEL: @bar
 ; CHECK-NOT: bar.cold.1
-define void @bar() {
+define void @bar() "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.end
 
@@ -38,7 +38,7 @@ if.end:                                           ; preds = %entry
 ; Make sure we don't try to outline the entire function.
 ; CHECK-LABEL: @fun
 ; CHECK-NOT: fun.cold.1
-define void @fun() {
+define void @fun() "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.end
 
@@ -54,7 +54,7 @@ if.end:                                           ; preds = %entry
 ; entry block is cold.
 ; CHECK: define void @cold_entry_block() [[COLD_ATTR:#[0-9]+]]
 ; CHECK-NOT: cold_entry_block.cold.1
-define void @cold_entry_block() {
+define void @cold_entry_block() "hot-cold-split" {
 entry:
   call void @sink()
   ret void
@@ -63,7 +63,7 @@ entry:
 ; Do not split `noinline` functions.
 ; CHECK-LABEL: @noinline_func
 ; CHECK-NOT: noinline_func.cold.1
-define void @noinline_func() noinline {
+define void @noinline_func() noinline "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.end
 
@@ -78,7 +78,7 @@ if.end:                                           ; preds = %entry
 ; Do not split `alwaysinline` functions.
 ; CHECK-LABEL: @alwaysinline_func
 ; CHECK-NOT: alwaysinline_func.cold.1
-define void @alwaysinline_func() alwaysinline {
+define void @alwaysinline_func() alwaysinline "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.end
 
@@ -93,7 +93,7 @@ if.end:                                           ; preds = %entry
 ; Don't outline infinite loops.
 ; CHECK-LABEL: @infinite_loop
 ; CHECK-NOT: infinite_loop.cold.1
-define void @infinite_loop() {
+define void @infinite_loop() "hot-cold-split" {
 entry:
   br label %loop
 
@@ -105,7 +105,7 @@ loop:
 ; Don't count debug intrinsics towards the outlining threshold.
 ; CHECK-LABEL: @dont_count_debug_intrinsics
 ; CHECK-NOT: dont_count_debug_intrinsics.cold.1
-define void @dont_count_debug_intrinsics(i32 %arg1) !dbg !6 {
+define void @dont_count_debug_intrinsics(i32 %arg1) "hot-cold-split" !dbg !6 {
 entry:
   %var = add i32 0, 0, !dbg !11
   br i1 undef, label %if.then, label %if.end
@@ -122,7 +122,7 @@ if.end:                                           ; preds = %entry
 
 ; CHECK-LABEL: @sanitize_address
 ; CHECK-NOT: sanitize_address.cold.1
-define void @sanitize_address() sanitize_address {
+define void @sanitize_address() sanitize_address "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.end
 
@@ -136,7 +136,7 @@ if.end:                                           ; preds = %entry
 
 ; CHECK-LABEL: @sanitize_hwaddress
 ; CHECK-NOT: sanitize_hwaddress.cold.1
-define void @sanitize_hwaddress() sanitize_hwaddress {
+define void @sanitize_hwaddress() sanitize_hwaddress "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.end
 
@@ -150,7 +150,7 @@ if.end:                                           ; preds = %entry
 
 ; CHECK-LABEL: @sanitize_thread
 ; CHECK-NOT: sanitize_thread.cold.1
-define void @sanitize_thread() sanitize_thread {
+define void @sanitize_thread() sanitize_thread "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.end
 
@@ -164,7 +164,7 @@ if.end:                                           ; preds = %entry
 
 ; CHECK-LABEL: @sanitize_memory
 ; CHECK-NOT: sanitize_memory.cold.1
-define void @sanitize_memory() sanitize_memory {
+define void @sanitize_memory() sanitize_memory "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.end
 
@@ -180,7 +180,7 @@ declare void @llvm.trap() cold noreturn
 
 ; CHECK-LABEL: @nosanitize_call
 ; CHECK-NOT: nosanitize_call.cold.1
-define void @nosanitize_call() sanitize_memory {
+define void @nosanitize_call() sanitize_memory "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.end
 

--- a/llvm/test/Transforms/HotColdSplit/addr-taken.ll
+++ b/llvm/test/Transforms/HotColdSplit/addr-taken.ll
@@ -4,12 +4,12 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-apple-macosx10.14.0"
 
 ; CHECK: define {{.*}} @foo{{.*}}#[[outlined_func_attr:[0-9]+]]
-define void @foo() noreturn cold {
+define void @foo() noreturn cold "hot-cold-split" {
   unreachable
 }
 
 ; CHECK: define {{.*}} @bar.cold.1{{.*}}#[[outlined_func_attr]]
-define void @bar() {
+define void @bar() "hot-cold-split" {
   br i1 undef, label %normal, label %exit
 
 normal:

--- a/llvm/test/Transforms/HotColdSplit/apply-noreturn-bonus.ll
+++ b/llvm/test/Transforms/HotColdSplit/apply-noreturn-bonus.ll
@@ -3,7 +3,7 @@
 
 declare void @sink() cold
 
-define void @foo(i32 %arg) {
+define void @foo(i32 %arg) "hot-cold-split" {
 entry:
   br i1 undef, label %cold1, label %exit
 

--- a/llvm/test/Transforms/HotColdSplit/apply-penalty-for-inputs.ll
+++ b/llvm/test/Transforms/HotColdSplit/apply-penalty-for-inputs.ll
@@ -5,7 +5,7 @@ declare void @sink(i32*, i32, i32) cold
 
 @g = global i32 0
 
-define void @foo(i32 %arg) {
+define void @foo(i32 %arg) "hot-cold-split" {
   %local = load i32, i32* @g
   br i1 undef, label %cold, label %exit
 

--- a/llvm/test/Transforms/HotColdSplit/apply-penalty-for-inputs.ll
+++ b/llvm/test/Transforms/HotColdSplit/apply-penalty-for-inputs.ll
@@ -21,7 +21,7 @@ exit:
   ret void
 }
 
-define void @bar(i32* %p1, i32 %p2, i32 %p3) {
+define void @bar(i32* %p1, i32 %p2, i32 %p3) "hot-cold-split" {
   br i1 undef, label %cold, label %exit
 
 cold:

--- a/llvm/test/Transforms/HotColdSplit/apply-penalty-for-outputs.ll
+++ b/llvm/test/Transforms/HotColdSplit/apply-penalty-for-outputs.ll
@@ -5,7 +5,7 @@ declare void @sink() cold
 
 @g = global i32 0
 
-define i32 @foo(i32 %arg) {
+define i32 @foo(i32 %arg) "hot-cold-split" {
 entry:
   br i1 undef, label %cold, label %exit
 

--- a/llvm/test/Transforms/HotColdSplit/apply-successor-penalty.ll
+++ b/llvm/test/Transforms/HotColdSplit/apply-successor-penalty.ll
@@ -4,7 +4,7 @@
 declare void @sink() cold
 
 ; CHECK-LABEL: Outlining in one_non_region_successor
-define void @one_non_region_successor(i32 %arg) {
+define void @one_non_region_successor(i32 %arg) "hot-cold-split" {
 entry:
   br i1 undef, label %cold1, label %exit
 
@@ -30,7 +30,7 @@ exit:
 }
 
 ; CHECK-LABEL: Outlining in two_non_region_successor
-define void @two_non_region_successors(i32 %arg) {
+define void @two_non_region_successors(i32 %arg) "hot-cold-split" {
 entry:
   br i1 undef, label %cold1, label %exit1
 

--- a/llvm/test/Transforms/HotColdSplit/assumption-cache-invalidation.ll
+++ b/llvm/test/Transforms/HotColdSplit/assumption-cache-invalidation.ll
@@ -21,7 +21,7 @@ target triple = "aarch64"
 ; CHECK: %1 = icmp eq i64 %0, 0
 ; CHECK-NOT: call void @llvm.assume
 
-define void @f() {
+define void @f() "hot-cold-split" {
 entry:
   %0 = getelementptr inbounds %a, %a* null, i64 0, i32 1
   br label %label

--- a/llvm/test/Transforms/HotColdSplit/coldentrycount.ll
+++ b/llvm/test/Transforms/HotColdSplit/coldentrycount.ll
@@ -10,7 +10,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; CHECK: define {{.*}} @fun{{.*}} ![[HOTPROF:[0-9]+]] {{.*}}section_prefix ![[LIKELY:[0-9]+]]
 ; CHECK: call void @fun.cold.1
 
-define void @fun() !prof !14 {
+define void @fun() "hot-cold-split" !prof !14 {
 entry:
   br i1 undef, label %if.then, label %if.else
 

--- a/llvm/test/Transforms/HotColdSplit/delete-use-without-def-dbg-val.ll
+++ b/llvm/test/Transforms/HotColdSplit/delete-use-without-def-dbg-val.ll
@@ -9,7 +9,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; CHECK-LABEL: define {{.*}}@foo.cold
 ; CHECK-NOT: call {{.*}}llvm.dbg.value
 
-define void @foo() !dbg !6 {
+define void @foo() "hot-cold-split" !dbg !6 {
 entry:
   br i1 undef, label %if.then, label %if.end
 

--- a/llvm/test/Transforms/HotColdSplit/duplicate-phi-preds-crash.ll
+++ b/llvm/test/Transforms/HotColdSplit/duplicate-phi-preds-crash.ll
@@ -18,7 +18,7 @@ declare void @sink() cold
 ; CHECK: call {{.*}}@realloc2.cold.1(i64 %size, i8* %ptr, i8** %retval.0.ce.loc)
 ; CHECK-LABEL: cleanup:
 ; CHECK-NEXT: phi i8* [ null, %if.then ], [ %call, %if.end ], [ %retval.0.ce.reload, %codeRepl ]
-define i8* @realloc2(i8* %ptr, i64 %size) {
+define i8* @realloc2(i8* %ptr, i64 %size) "hot-cold-split" {
 entry:
   %0 = add i64 %size, -1
   %1 = icmp ugt i64 %0, 184549375

--- a/llvm/test/Transforms/HotColdSplit/eh-pads.ll
+++ b/llvm/test/Transforms/HotColdSplit/eh-pads.ll
@@ -6,7 +6,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; CHECK-LABEL: define {{.*}}@foo(
 ; CHECK: landingpad
 ; CHECK: sideeffect(i32 2)
-define void @foo(i32 %cond) personality i8 0 {
+define void @foo(i32 %cond) "hot-cold-split" personality i8 0 {
 entry:
   invoke void @llvm.donothing() to label %normal unwind label %exception
 
@@ -30,7 +30,7 @@ normal:
 ;
 ; CHECK-LABEL: define {{.*}}@bar(
 ; CHECK: landingpad
-define void @bar(i32 %cond) personality i8 0 {
+define void @bar(i32 %cond) "hot-cold-split" personality i8 0 {
 entry:
   br i1 undef, label %exit, label %continue
 
@@ -54,7 +54,7 @@ normal:
   ret void
 }
 
-define void @baz() personality i8 0 {
+define void @baz() "hot-cold-split" personality i8 0 {
 entry:
   br i1 undef, label %exit, label %cold1
 

--- a/llvm/test/Transforms/HotColdSplit/eh-typeid-for.ll
+++ b/llvm/test/Transforms/HotColdSplit/eh-typeid-for.ll
@@ -6,7 +6,7 @@
 
 ; CHECK-LABEL: @fun
 ; CHECK-NOT: call {{.*}}@fun.cold.1
-define void @fun() {
+define void @fun() "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.else
 

--- a/llvm/test/Transforms/HotColdSplit/forward-dfs-reaches-marked-block.ll
+++ b/llvm/test/Transforms/HotColdSplit/forward-dfs-reaches-marked-block.ll
@@ -5,7 +5,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 
 ; CHECK-LABEL: define {{.*}}@fun
 ; CHECK: call {{.*}}@fun.cold.1(
-define void @fun() {
+define void @fun() "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.else
 

--- a/llvm/test/Transforms/HotColdSplit/lifetime-markers-on-inputs-1.ll
+++ b/llvm/test/Transforms/HotColdSplit/lifetime-markers-on-inputs-1.ll
@@ -9,7 +9,7 @@ declare void @use(i8*)
 declare void @cold_use2(i8*, i8*) cold
 
 ; CHECK-LABEL: define {{.*}}@foo(
-define void @foo() {
+define void @foo() "hot-cold-split" {
 entry:
   %local1 = alloca i256
   %local2 = alloca i256

--- a/llvm/test/Transforms/HotColdSplit/lifetime-markers-on-inputs-2.ll
+++ b/llvm/test/Transforms/HotColdSplit/lifetime-markers-on-inputs-2.ll
@@ -34,7 +34,7 @@ declare void @use(i8*)
 ;          \      /
 ;            exit
 ;          (lt.end)
-define void @only_lifetime_start_is_cold() {
+define void @only_lifetime_start_is_cold() "hot-cold-split" {
 ; CHECK-LABEL: @only_lifetime_start_is_cold(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[LOCAL1:%.*]] = alloca i256, align 8
@@ -42,7 +42,7 @@ define void @only_lifetime_start_is_cold() {
 ; CHECK-NEXT:    br i1 undef, label [[CODEREPL:%.*]], label [[NO_EXTRACT1:%.*]]
 ; CHECK:       codeRepl:
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0i256(i64 -1, i256* [[LOCAL1]])
-; CHECK-NEXT:    [[TARGETBLOCK:%.*]] = call i1 @only_lifetime_start_is_cold.cold.1(i8* [[LOCAL1_CAST]]) [[ATTR3:#.*]]
+; CHECK-NEXT:    [[TARGETBLOCK:%.*]] = call i1 @only_lifetime_start_is_cold.cold.1(i8* [[LOCAL1_CAST]]) [[ATTR4:#.*]]
 ; CHECK-NEXT:    br i1 [[TARGETBLOCK]], label [[NO_EXTRACT1]], label [[EXIT:%.*]]
 ; CHECK:       no-extract1:
 ; CHECK-NEXT:    br label [[EXIT]]
@@ -94,7 +94,7 @@ exit:
 ;    (lt.end)
 ;        \         /
 ;            exit
-define void @only_lifetime_end_is_cold() {
+define void @only_lifetime_end_is_cold() "hot-cold-split" {
 ; CHECK-LABEL: @only_lifetime_end_is_cold(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[LOCAL1:%.*]] = alloca i256, align 8
@@ -105,7 +105,7 @@ define void @only_lifetime_end_is_cold() {
 ; CHECK-NEXT:    call void @llvm.lifetime.end.p0i8(i64 1, i8* [[LOCAL1_CAST]])
 ; CHECK-NEXT:    br label [[EXIT:%.*]]
 ; CHECK:       codeRepl:
-; CHECK-NEXT:    call void @only_lifetime_end_is_cold.cold.1(i8* [[LOCAL1_CAST]]) [[ATTR3]]
+; CHECK-NEXT:    call void @only_lifetime_end_is_cold.cold.1(i8* [[LOCAL1_CAST]]) [[ATTR4]]
 ; CHECK-NEXT:    br label [[EXIT]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret void
@@ -134,7 +134,7 @@ exit:
 
 ; In this CFG, splitting will extract the blocks extract{1,2,3}. Lifting the
 ; lifetime.end marker would be a miscompile.
-define void @do_not_lift_lifetime_end() {
+define void @do_not_lift_lifetime_end() "hot-cold-split" {
 ; CHECK-LABEL: @do_not_lift_lifetime_end(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[LOCAL1:%.*]] = alloca i256, align 8
@@ -145,7 +145,7 @@ define void @do_not_lift_lifetime_end() {
 ; CHECK-NEXT:    call void @use(i8* [[LOCAL1_CAST]])
 ; CHECK-NEXT:    br i1 undef, label [[EXIT:%.*]], label [[CODEREPL:%.*]]
 ; CHECK:       codeRepl:
-; CHECK-NEXT:    [[TARGETBLOCK:%.*]] = call i1 @do_not_lift_lifetime_end.cold.1(i8* [[LOCAL1_CAST]]) [[ATTR3]]
+; CHECK-NEXT:    [[TARGETBLOCK:%.*]] = call i1 @do_not_lift_lifetime_end.cold.1(i8* [[LOCAL1_CAST]]) [[ATTR4]]
 ; CHECK-NEXT:    br i1 [[TARGETBLOCK]], label [[HEADER]], label [[EXIT]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret void

--- a/llvm/test/Transforms/HotColdSplit/mark-the-whole-func-cold.ll
+++ b/llvm/test/Transforms/HotColdSplit/mark-the-whole-func-cold.ll
@@ -24,7 +24,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; CHECK: define {{.*}}@_Z3fooii{{.*}}#[[outlined_func_attr:[0-9]+]]
 ; CHECK-NOT: _Z3fooii.cold
 ; CHECK: attributes #[[outlined_func_attr]] = { {{.*}}minsize
-define void @_Z3fooii(i32, i32) {
+define void @_Z3fooii(i32, i32) "hot-cold-split" {
   %3 = alloca i32, align 4
   %4 = alloca i32, align 4
   store i32 %0, i32* %3, align 4

--- a/llvm/test/Transforms/HotColdSplit/minsize.ll
+++ b/llvm/test/Transforms/HotColdSplit/minsize.ll
@@ -5,7 +5,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 
 ; CHECK-LABEL: @fun
 ; CHECK: call void @fun.cold.1
-define void @fun() {
+define void @fun() "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.else
 
@@ -18,7 +18,7 @@ if.else:
 }
 
 ; CHECK: define {{.*}} @foo{{.*}}#[[outlined_func_attr:[0-9]+]]
-define void @foo() cold {
+define void @foo() cold "hot-cold-split" {
   ret void
 }
 

--- a/llvm/test/Transforms/HotColdSplit/multiple-exits.ll
+++ b/llvm/test/Transforms/HotColdSplit/multiple-exits.ll
@@ -32,7 +32,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; CHECK: call {{.*}}@sideeffect(i32 1)
 ; CHECK: [[return]]:
 ; CHECK-NEXT: ret void
-define void @foo(i32 %cond) {
+define void @foo(i32 %cond) "hot-cold-split" {
 entry:
   %tobool = icmp eq i32 %cond, 0
   br i1 %tobool, label %exit1, label %if.then

--- a/llvm/test/Transforms/HotColdSplit/noreturn.ll
+++ b/llvm/test/Transforms/HotColdSplit/noreturn.ll
@@ -10,7 +10,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 
 ; CHECK-LABEL: define {{.*}}@foo(
 ; CHECK-NOT: foo.cold.1
-define void @foo(i32, %struct.__jmp_buf_tag*) {
+define void @foo(i32, %struct.__jmp_buf_tag*) "hot-cold-split" {
   %3 = icmp eq i32 %0, 0
   tail call void @_Z10sideeffectv()
   br i1 %3, label %5, label %4
@@ -45,7 +45,7 @@ define void @xpc_objc_main(i32) noreturn {
 
 ; CHECK-LABEL: define {{.*}}@bar(
 ; CHECK: call {{.*}}@bar.cold.1(
-define void @bar(i32) {
+define void @bar(i32) "hot-cold-split" {
   %2 = icmp eq i32 %0, 0
   tail call void @_Z10sideeffectv()
   br i1 %2, label %sink, label %exit
@@ -63,7 +63,7 @@ exit:
 
 ; CHECK-LABEL: define {{.*}}@baz(
 ; CHECK: call {{.*}}@baz.cold.1(
-define void @baz(i32, %struct.__jmp_buf_tag*) {
+define void @baz(i32, %struct.__jmp_buf_tag*) "hot-cold-split" {
   %3 = icmp eq i32 %0, 0
   tail call void @_Z10sideeffectv()
   br i1 %3, label %5, label %4

--- a/llvm/test/Transforms/HotColdSplit/outline-cold-asm.ll
+++ b/llvm/test/Transforms/HotColdSplit/outline-cold-asm.ll
@@ -9,7 +9,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; CHECK-LABEL: define {{.*}}@fun.cold.1(
 ; CHECK: asm ""
 
-define void @fun() {
+define void @fun() "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.else
 

--- a/llvm/test/Transforms/HotColdSplit/outline-disjoint-diamonds.ll
+++ b/llvm/test/Transforms/HotColdSplit/outline-disjoint-diamonds.ll
@@ -5,7 +5,7 @@
 ; CHECK-NEXT: ret void
 ; CHECK: call {{.*}}@fun.cold.1(
 ; CHECK-NEXT: ret void
-define void @fun() {
+define void @fun() "hot-cold-split" {
 entry:
   br i1 undef, label %A.then, label %A.else
 

--- a/llvm/test/Transforms/HotColdSplit/outline-if-then-else.ll
+++ b/llvm/test/Transforms/HotColdSplit/outline-if-then-else.ll
@@ -24,7 +24,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; CHECK-NEXT: call void @foo.cold.1
 ; CHECK-LABEL: if.end2:
 ; CHECK: call void @sideeffect(i32 2)
-define void @foo(i32 %cond) {
+define void @foo(i32 %cond) "hot-cold-split" {
 entry:
   %cond.addr = alloca i32
   store i32 %cond, i32* %cond.addr

--- a/llvm/test/Transforms/HotColdSplit/outline-multiple-entry-region.ll
+++ b/llvm/test/Transforms/HotColdSplit/outline-multiple-entry-region.ll
@@ -34,7 +34,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; CHECK: call void @_Z4sinkv
 ; CHECK: call void @_Z10sideeffecti(i32 3)
 
-define void @_Z3fooii(i32, i32) {
+define void @_Z3fooii(i32, i32) "hot-cold-split" {
   %3 = alloca i32, align 4
   %4 = alloca i32, align 4
   store i32 %0, i32* %3, align 4

--- a/llvm/test/Transforms/HotColdSplit/outline-while-loop.ll
+++ b/llvm/test/Transforms/HotColdSplit/outline-while-loop.ll
@@ -24,7 +24,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; CHECK-NEXT: call void @foo.cold.1
 ; CHECK-LABEL: if.end:
 ; CHECK: call void @sideeffect(i32 1)
-define void @foo(i32 %cond) {
+define void @foo(i32 %cond) "hot-cold-split" {
 entry:
   %tobool = icmp eq i32 %cond, 0
   br i1 %tobool, label %if.end, label %while.cond.preheader
@@ -62,7 +62,7 @@ if.end:                                           ; preds = %entry
 ; CHECK-NEXT: call void @while_loop_after_sink.cold.1
 ; CHECK-LABEL: if.end:
 ; CHECK: call void @sideeffect(i32 1)
-define void @while_loop_after_sink(i32 %cond) {
+define void @while_loop_after_sink(i32 %cond) "hot-cold-split" {
 entry:
   %tobool = icmp eq i32 %cond, 0
   br i1 %tobool, label %if.end, label %sink

--- a/llvm/test/Transforms/HotColdSplit/phi-with-distinct-outlined-values.ll
+++ b/llvm/test/Transforms/HotColdSplit/phi-with-distinct-outlined-values.ll
@@ -11,7 +11,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; CHECK: %p.ce = phi i32 [ 1, %coldbb ], [ 3, %coldbb2 ]
 ; CHECK-NEXT: store i32 %p.ce, i32* %p.ce.out 
 
-define void @foo(i32 %cond) {
+define void @foo(i32 %cond) "hot-cold-split" {
 entry:
   %tobool = icmp eq i32 %cond, 0
   br i1 %tobool, label %if.end, label %coldbb

--- a/llvm/test/Transforms/HotColdSplit/region-overlap.ll
+++ b/llvm/test/Transforms/HotColdSplit/region-overlap.ll
@@ -24,7 +24,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; CHECK-LABEL: define {{.*}}@_Z3fooii
 ; CHECK: call {{.*}}@_Z3fooii.cold.1
 ; CHECK-NOT: _Z3fooii.cold
-define void @_Z3fooii(i32, i32) {
+define void @_Z3fooii(i32, i32) "hot-cold-split" {
   %3 = alloca i32, align 4
   %4 = alloca i32, align 4
   store i32 %0, i32* %3, align 4

--- a/llvm/test/Transforms/HotColdSplit/resume.ll
+++ b/llvm/test/Transforms/HotColdSplit/resume.ll
@@ -10,7 +10,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 
 declare void @sink() cold
 
-define i32 @foo() personality i8 0 {
+define i32 @foo() "hot-cold-split" personality i8 0 {
 entry:
   br i1 undef, label %pre-resume-eh, label %normal
 

--- a/llvm/test/Transforms/HotColdSplit/retain-section.ll
+++ b/llvm/test/Transforms/HotColdSplit/retain-section.ll
@@ -7,7 +7,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 
 ; CHECK-LABEL: @fun
 ; CHECK: call void @fun.cold.1{{.*}}
-define void @fun() section ".text.cold" {
+define void @fun() "hot-cold-split" section ".text.cold" {
 entry:
   br i1 undef, label %if.then, label %if.else
 

--- a/llvm/test/Transforms/HotColdSplit/section-splitting-custom.ll
+++ b/llvm/test/Transforms/HotColdSplit/section-splitting-custom.ll
@@ -15,7 +15,7 @@
 ; CHECK: define {{.*}}@fun.cold.1{{.*}} [[cold_attr:#[0-9]+]] section "__cold_custom"
 ; CHECK: attributes [[cold_attr]] = { {{.*}}noreturn
 
-define void @fun() {
+define void @fun() "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.else
 

--- a/llvm/test/Transforms/HotColdSplit/section-splitting-default.ll
+++ b/llvm/test/Transforms/HotColdSplit/section-splitting-default.ll
@@ -14,7 +14,7 @@
 ; CHECK: define {{.*}}@fun.cold.1{{.*}} [[cold_attr:#[0-9]+]] section "__llvm_cold"
 ; CHECK: attributes [[cold_attr]] = { {{.*}}noreturn
 
-define void @fun() {
+define void @fun() "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.else
 

--- a/llvm/test/Transforms/HotColdSplit/split-cold-2.ll
+++ b/llvm/test/Transforms/HotColdSplit/split-cold-2.ll
@@ -12,7 +12,7 @@
 ; CHECK: define {{.*}}@fun.cold.1{{.*}} [[cold_attr:#[0-9]+]]
 ; CHECK: attributes [[cold_attr]] = { {{.*}}noreturn
 
-define void @fun() {
+define void @fun() "hot-cold-split" {
 entry:
   br i1 undef, label %if.then, label %if.else
 

--- a/llvm/test/Transforms/HotColdSplit/split-out-dbg-label.ll
+++ b/llvm/test/Transforms/HotColdSplit/split-out-dbg-label.ll
@@ -18,7 +18,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; CHECK: [[LINE]] = !DILocation(line: 1, column: 1, scope: [[SCOPE]]
 ; CHECK: [[LABEL]] = !DILabel(scope: [[SCOPE]], name: "bye", file: [[FILE]], line: 28
 
-define void @foo(i32 %arg1) !dbg !6 {
+define void @foo(i32 %arg1) "hot-cold-split" !dbg !6 {
 entry:
   %var = add i32 0, 0, !dbg !11
   br i1 undef, label %if.then, label %if.end

--- a/llvm/test/Transforms/HotColdSplit/split-out-dbg-val-of-arg.ll
+++ b/llvm/test/Transforms/HotColdSplit/split-out-dbg-val-of-arg.ll
@@ -6,7 +6,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; CHECK-LABEL: define {{.*}}@foo.cold
 ; CHECK-NOT: llvm.dbg.value
 
-define void @foo(i32 %arg1) !dbg !6 {
+define void @foo(i32 %arg1) "hot-cold-split" !dbg !6 {
 entry:
   %var = add i32 0, 0, !dbg !11
   br i1 undef, label %if.then, label %if.end

--- a/llvm/test/Transforms/HotColdSplit/split-phis-in-exit-blocks.ll
+++ b/llvm/test/Transforms/HotColdSplit/split-phis-in-exit-blocks.ll
@@ -28,7 +28,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; CHECK: call {{.*}}@sideeffect(i32 3)
 ; CHECK: call {{.*}}@sideeffect(i32 4)
 ; CHECK: call {{.*}}@sideeffect(i32 5)
-define void @pluto() {
+define void @pluto() "hot-cold-split" {
 bb:
   switch i8 undef, label %bb1 [
     i8 0, label %bb7

--- a/llvm/test/Transforms/HotColdSplit/stale-assume-in-original-func.ll
+++ b/llvm/test/Transforms/HotColdSplit/stale-assume-in-original-func.ll
@@ -12,7 +12,7 @@
 ; CHECK-NOT: llvm.assume
 ; CHECK: }
 
-define void @foo(i1 %cond) {
+define void @foo(i1 %cond) "hot-cold-split" {
 entry:
   br i1 %cond, label %cold, label %cont
 

--- a/llvm/test/Transforms/HotColdSplit/succ-block-with-self-edge.ll
+++ b/llvm/test/Transforms/HotColdSplit/succ-block-with-self-edge.ll
@@ -7,7 +7,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; CHECK: call {{.*}}@exit_block_with_same_incoming_vals.cold.1(
 ; CHECK-NOT: br i1 undef
 ; CHECK: phi i32 [ 0, %entry ], [ %p.ce.reload, %codeRepl ]
-define void @exit_block_with_same_incoming_vals(i32 %cond) {
+define void @exit_block_with_same_incoming_vals(i32 %cond) "hot-cold-split" {
 entry:
   %tobool = icmp eq i32 %cond, 0
   br i1 %tobool, label %if.end, label %coldbb
@@ -30,7 +30,7 @@ if.end:
 ; CHECK: call {{.*}}@exit_block_with_distinct_incoming_vals.cold.1(
 ; CHECK-NOT: br i1 undef
 ; CHECK: phi i32 [ 0, %entry ], [ %p.ce.reload, %codeRepl ]
-define void @exit_block_with_distinct_incoming_vals(i32 %cond) {
+define void @exit_block_with_distinct_incoming_vals(i32 %cond) "hot-cold-split" {
 entry:
   %tobool = icmp eq i32 %cond, 0
   br i1 %tobool, label %if.end, label %coldbb

--- a/llvm/test/Transforms/HotColdSplit/swifterror.ll
+++ b/llvm/test/Transforms/HotColdSplit/swifterror.ll
@@ -9,7 +9,7 @@ declare void @sink() cold
 
 ; CHECK-LABEL: define {{.*}}@in_arg(
 ; CHECK: call void @in_arg.cold.1(%swift_error** swifterror
-define void @in_arg(%swift_error** swifterror %error_ptr_ref) {
+define void @in_arg(%swift_error** swifterror %error_ptr_ref) "hot-cold-split" {
   br i1 undef, label %cold, label %exit
 
 cold:
@@ -23,7 +23,7 @@ exit:
 
 ; CHECK-LABEL: define {{.*}}@in_alloca(
 ; CHECK: call void @in_alloca.cold.1(%swift_error** swifterror
-define void @in_alloca() {
+define void @in_alloca() "hot-cold-split" {
   %err = alloca swifterror %swift_error*
   br i1 undef, label %cold, label %exit
 

--- a/llvm/test/Transforms/HotColdSplit/transfer-debug-info.ll
+++ b/llvm/test/Transforms/HotColdSplit/transfer-debug-info.ll
@@ -37,7 +37,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; - Line locations in @foo.cold.1 point to the new scope for @foo.cold.1
 ; CHECK: [[LINE1]] = !DILocation(line: 1, column: 1, scope: [[NEWSCOPE]])
 
-define void @foo(i32 %arg1) !dbg !6 {
+define void @foo(i32 %arg1) "hot-cold-split" !dbg !6 {
 entry:
   %var = add i32 0, 0, !dbg !11
   br i1 undef, label %if.then, label %if.end

--- a/llvm/test/Transforms/HotColdSplit/unwind.ll
+++ b/llvm/test/Transforms/HotColdSplit/unwind.ll
@@ -11,7 +11,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 
 ; CHECK-NOT: noreturn
 
-define i32 @foo() personality i8 0 {
+define i32 @foo() "hot-cold-split" personality i8 0 {
 entry:
   invoke void @llvm.donothing() to label %normal unwind label %exception
 

--- a/llvm/test/Transforms/HotColdSplit/update-split-loop-metadata.ll
+++ b/llvm/test/Transforms/HotColdSplit/update-split-loop-metadata.ll
@@ -14,7 +14,7 @@ target triple = "x86_64-apple-macosx10.14.0"
 ; CHECK: [[LOOP_MD]] = distinct !{[[LOOP_MD]], [[LINE:![0-9]+]], [[LINE]]}
 ; CHECK: [[LINE]] = !DILocation(line: 1, column: 1, scope: [[SCOPE]])
 
-define void @basic(i32* %p, i32 %k) !dbg !6 {
+define void @basic(i32* %p, i32 %k) "hot-cold-split" !dbg !6 {
 entry:
   %cmp3 = icmp slt i32 0, %k
   br i1 %cmp3, label %for.body.lr.ph, label %for.end

--- a/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/generated_funcs.ll
+++ b/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/generated_funcs.ll
@@ -2,7 +2,7 @@
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-apple-macosx10.14.0"
 
-define void @foo(i32) {
+define void @foo(i32) "hot-cold-split" {
   %2 = icmp eq i32 %0, 0
   tail call void @_Z10sideeffectv()
   br i1 %2, label %sink, label %exit
@@ -16,7 +16,7 @@ exit:
   ret void
 }
 
-define void @bar(i32) {
+define void @bar(i32) "hot-cold-split" {
   %2 = icmp eq i32 %0, 0
   tail call void @_Z10sideeffectv()
   br i1 %2, label %sink, label %exit

--- a/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/generated_funcs.ll.generated.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/generated_funcs.ll.generated.expected
@@ -3,7 +3,7 @@
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-apple-macosx10.14.0"
 
-define void @foo(i32) {
+define void @foo(i32) "hot-cold-split" {
   %2 = icmp eq i32 %0, 0
   tail call void @_Z10sideeffectv()
   br i1 %2, label %sink, label %exit
@@ -17,7 +17,7 @@ exit:
   ret void
 }
 
-define void @bar(i32) {
+define void @bar(i32) "hot-cold-split" {
   %2 = icmp eq i32 %0, 0
   tail call void @_Z10sideeffectv()
   br i1 %2, label %sink, label %exit
@@ -38,7 +38,7 @@ declare void @_Z10sideeffectv()
 ; CHECK-NEXT:    tail call void @_Z10sideeffectv()
 ; CHECK-NEXT:    br i1 [[TMP2]], label [[CODEREPL:%.*]], label [[EXIT:%.*]]
 ; CHECK:       codeRepl:
-; CHECK-NEXT:    call void @foo.cold.1() [[ATTR2:#.*]]
+; CHECK-NEXT:    call void @foo.cold.1() [[ATTR3:#.*]]
 ; CHECK-NEXT:    ret void
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret void
@@ -49,7 +49,7 @@ declare void @_Z10sideeffectv()
 ; CHECK-NEXT:    tail call void @_Z10sideeffectv()
 ; CHECK-NEXT:    br i1 [[TMP2]], label [[CODEREPL:%.*]], label [[EXIT:%.*]]
 ; CHECK:       codeRepl:
-; CHECK-NEXT:    call void @bar.cold.1() [[ATTR2]]
+; CHECK-NEXT:    call void @bar.cold.1() [[ATTR3]]
 ; CHECK-NEXT:    ret void
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret void

--- a/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/generated_funcs.ll.nogenerated.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/generated_funcs.ll.nogenerated.expected
@@ -3,13 +3,13 @@
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-apple-macosx10.14.0"
 
-define void @foo(i32) {
+define void @foo(i32) "hot-cold-split" {
 ; CHECK-LABEL: @foo(
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq i32 [[TMP0:%.*]], 0
 ; CHECK-NEXT:    tail call void @_Z10sideeffectv()
 ; CHECK-NEXT:    br i1 [[TMP2]], label [[CODEREPL:%.*]], label [[EXIT:%.*]]
 ; CHECK:       codeRepl:
-; CHECK-NEXT:    call void @foo.cold.1() [[ATTR2:#.*]]
+; CHECK-NEXT:    call void @foo.cold.1() [[ATTR3:#.*]]
 ; CHECK-NEXT:    ret void
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret void
@@ -27,13 +27,13 @@ exit:
   ret void
 }
 
-define void @bar(i32) {
+define void @bar(i32) "hot-cold-split" {
 ; CHECK-LABEL: @bar(
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq i32 [[TMP0:%.*]], 0
 ; CHECK-NEXT:    tail call void @_Z10sideeffectv()
 ; CHECK-NEXT:    br i1 [[TMP2]], label [[CODEREPL:%.*]], label [[EXIT:%.*]]
 ; CHECK:       codeRepl:
-; CHECK-NEXT:    call void @bar.cold.1() [[ATTR2]]
+; CHECK-NEXT:    call void @bar.cold.1() [[ATTR3]]
 ; CHECK-NEXT:    ret void
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret void


### PR DESCRIPTION
This patch adds -f[no-]split-cold-code CC1 options to clang. This allows
the splitting pass to be toggled on/off. The current method of passing
`-mllvm -hot-cold-split=true` to clang isn't ideal as it may not compose
correctly (say, with `-O0` or `-Oz`).

To implement the -fsplit-cold-code option, an attribute is applied to
functions to indicate that they may be considered for splitting. This
removes some complexity from the old/new PM pipeline builders, and
behaves as expected when LTO is enabled.

Co-authored by: Saleem Abdulrasool <compnerd@compnerd.org>