### PR TITLE
[test] Update ptrauth-thunks.cpp for codegen change

### DIFF
--- a/clang/test/CodeGenCXX/ptrauth-thunks.cpp
+++ b/clang/test/CodeGenCXX/ptrauth-thunks.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple arm64-apple-ios -fptrauth-calls -emit-llvm -std=c++11 %s -o - -O1 | FileCheck %s
+// RUN: %clang_cc1 -triple arm64-apple-ios -fptrauth-calls -emit-llvm -std=c++11 %s -o - | FileCheck %s
 
 namespace Test1 {
   struct B1 {
@@ -22,6 +22,9 @@ namespace Test1 {
 }
 
 // CHECK-LABEL: define linkonce_odr void @_ZTv0_n24_N5Test11DD0Ev(%"struct.Test1::D"* %this)
-// CHECK: %[[BitcastThis:.*]] = bitcast %"struct.Test1::D"* %this to i64*
-// CHECK: %[[SignedVTable:.*]] = load i64, i64* %[[BitcastThis]], align 8
-// CHECK: %[[VTable:.*]] = call i64 @llvm.ptrauth.auth.i64(i64 %[[SignedVTable]], i32 2, i64 0)
+// CHECK: %[[This:.*]] = load %"struct.Test1::D"*
+// CHECK: %[[BitcastThis:.*]] = bitcast %"struct.Test1::D"* %[[This]] to i8*
+// CHECK: %[[BitcastThis2:.*]] = bitcast i8* %[[BitcastThis]] to i8**
+// CHECK: %[[SignedVTable:.*]] = load i8*, i8** %[[BitcastThis2]], align 8
+// CHECK: %[[SignedVTableAsInt:.*]] = ptrtoint i8* %[[SignedVTable]] to i64
+// CHECK: %[[VTable:.*]] = call i64 @llvm.ptrauth.auth.i64(i64 %[[SignedVTableAsInt]], i32 2, i64 0)


### PR DESCRIPTION
For some reason, we bitcast a 'this' pointer to 'i8**' instead of to
'i64*' before performing a ptrauth.auth operation.

I'm not sure whether this is due to a clang IRGen change, or due to a change to
some llvm pass that runs at -O1. (Perhaps -O1 can be dropped from the test?)
