### PR TITLE
Implement TypeSystemSwiftTypeRef::IsErrorType()

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -486,7 +486,7 @@ public:
   static bool IsGenericType(const CompilerType &compiler_type);
 
   /// Whether this is the Swift error type.
-  bool IsErrorType(lldb::opaque_compiler_type_t type);
+  bool IsErrorType(lldb::opaque_compiler_type_t type) override;
 
   static bool IsFullyRealized(const CompilerType &compiler_type);
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -105,6 +105,8 @@ public:
                              const lldb::TypeSP &type_sp) = 0;
   virtual bool IsImportedType(lldb::opaque_compiler_type_t type,
                               CompilerType *original_type) = 0;
+  /// Whether this is the Swift error type.
+  virtual bool IsErrorType(lldb::opaque_compiler_type_t type) = 0;
   virtual CompilerType GetErrorType() = 0;
   virtual CompilerType GetReferentType(lldb::opaque_compiler_type_t type) = 0;
   static CompilerType GetInstanceType(CompilerType ct);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -241,6 +241,7 @@ public:
   /// Like \p IsImportedType(), but even returns Clang types that are also Swift
   /// builtins (int <-> Swift.Int) as Clang types.
   CompilerType GetAsClangTypeOrNull(lldb::opaque_compiler_type_t type);
+  bool IsErrorType(lldb::opaque_compiler_type_t type) override;
   CompilerType GetErrorType() override;
   CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
   CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) override;

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -478,8 +478,10 @@ TEST_F(TestTypeSystemSwiftTypeRef, TypeClass) {
   }
 }
 
-TEST_F(TestTypeSystemSwiftTypeRef, MangledTypeName) {
-  ASSERT_EQ(m_swift_ts.GetErrorType().GetMangledTypeName(), "$ss5Error_pD");
+TEST_F(TestTypeSystemSwiftTypeRef, ErrorType) {
+  CompilerType error_type = m_swift_ts.GetErrorType();
+  ASSERT_EQ(error_type.GetMangledTypeName(), "$ss5Error_pD");
+  ASSERT_TRUE(m_swift_ts.IsErrorType(error_type.GetOpaqueQualType()));
 }
 
 TEST_F(TestTypeSystemSwiftTypeRef, ImportedType) {


### PR DESCRIPTION
(cherry picked from commit 2bb0ce859ad3a370d728e9f8680f2b99f7b133b3)

https://github.com/apple/llvm-project/pull/1985