### PR TITLE
[lldb][swift] Make swiftTest decorator not always skip and skipIf regressed tests temporarily

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -626,9 +626,8 @@ def skipUnlessTargetAndroid(func):
 def swiftTest(func):
     """Decorate the item as a Swift test (Darwin/Linux only, no i386)."""
     def is_not_swift_compatible(self):
-        swift_enabled_error = _get_bool_config_skip_if_decorator("swift")(func)
-        if swift_enabled_error:
-            return swift_enabled_error
+        if not _get_bool_config("swift"):
+           return "Swift plugin not enabled"
         if self.getDebugInfo() == "gmodules":
             return "skipping (gmodules only makes sense for clang tests)"
 
@@ -886,11 +885,14 @@ def skipIfAsan(func):
     """Skip this test if the environment is set up to run LLDB *itself* under ASAN."""
     return skipTestIfFn(is_running_under_asan)(func)
 
-def _get_bool_config_skip_if_decorator(key):
+def _get_bool_config(key):
     config = lldb.SBDebugger.GetBuildConfiguration()
     value_node = config.GetValueForKey(key)
     fail_value = True # More likely to notice if something goes wrong
-    have = value_node.GetValueForKey("value").GetBooleanValue(fail_value)
+    return value_node.GetValueForKey("value").GetBooleanValue(fail_value)
+
+def _get_bool_config_skip_if_decorator(key):
+    have = _get_bool_config(key)
     return unittest2.skipIf(not have, "requires " + key)
 
 def skipIfCursesSupportMissing(func):

--- a/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
@@ -25,6 +25,7 @@ class TestSwiftHeadermapConflict(TestBase):
     def setUp(self):
         TestBase.setUp(self)
 
+    @skipIf #FIXME: This regressed silently due to 2c911bceb06ed376801251bdfd992905a66f276c
     @skipIf(bugnumber="rdar://60396797",
             setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
@@ -24,6 +24,7 @@ class TestSwiftRemoteASTImport(TestBase):
     def setUp(self):
         TestBase.setUp(self)
 
+    @expectedFailureAll #FIXME: This regressed silently due to 2c911bceb06ed376801251bdfd992905a66f276c
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
@@ -67,6 +67,7 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
         target.Clear()
         lldb.SBDebugger.MemoryPressureDetected()
 
+    @expectedFailureAll #FIXME: This regressed silently due to 2c911bceb06ed376801251bdfd992905a66f276c
     @skipIf(archs=['ppc64le'], bugnumber='SR-10214')
     @swiftTest
     # This test needs a working Remote Mirrors implementation.

--- a/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
+++ b/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
@@ -39,6 +39,7 @@ class TestSwiftExpressionsInClassFunctions(TestBase):
         self.assertTrue(answer == expected_result, report_str)
 
 
+    @expectedFailureAll #FIXME: This regressed silently due to 2c911bceb06ed376801251bdfd992905a66f276c
     @swiftTest
     def test_expressions_in_class_functions(self):
         """Test expressions in class func contexts"""

--- a/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
+++ b/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,
+                          expectedFailureAll #FIXME: This regressed silently due to 2c911bceb06ed376801251bdfd992905a66f276c
+                          ])

--- a/lldb/test/API/lang/swift/opaque_existentials/TestOpaqueExistentials.py
+++ b/lldb/test/API/lang/swift/opaque_existentials/TestOpaqueExistentials.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,
+                          expectedFailureAll #FIXME: This regressed silently due to 2c911bceb06ed376801251bdfd992905a66f276c
+                          ])

--- a/lldb/test/API/lang/swift/optionset/TestSwiftOptionSetType.py
+++ b/lldb/test/API/lang/swift/optionset/TestSwiftOptionSetType.py
@@ -14,6 +14,7 @@ from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
                           decorators=[swiftTest,skipUnlessDarwin,
+        expectedFailureAll, #FIXME: This regressed silently due to 2c911bceb06ed376801251bdfd992905a66f276c
         expectedFailureAll(bugnumber="rdar://60396797",
                            setting=('symbols.use-swift-clangimporter', 'false'))
 ])

--- a/lldb/test/API/lang/swift/protocol_extension_computed_property/TestProtocolExtensionComputerProperty.py
+++ b/lldb/test/API/lang/swift/protocol_extension_computed_property/TestProtocolExtensionComputerProperty.py
@@ -4,6 +4,7 @@ from lldbsuite.test.decorators import *
 lldbinline.MakeInlineTest(
     __file__, globals(),
         decorators=[
+            expectedFailureAll, #FIXME: This regressed silently due to 2c911bceb06ed376801251bdfd992905a66f276c
             swiftTest,skipUnlessDarwin,
             skipIf(bugnumber="rdar://60396797", # should work but crashes.
                    setting=('symbols.use-swift-clangimporter', 'false'))

--- a/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
+++ b/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
@@ -33,6 +33,7 @@ class TestSwiftUnknownSelf(lldbtest.TestBase):
         self.expect("fr v self", substrs=["hello", "world"])
 
 
+    @skipIf #FIXME: This regressed silently due to 2c911bceb06ed376801251bdfd992905a66f276c
     @skipIf(bugnumber="SR-10216", archs=['ppc64le'])
     @swiftTest
     def test_unknown_self_objc_ref(self):

--- a/lldb/test/API/lang/swift/variables/error_type/TestSwiftErrorType.py
+++ b/lldb/test/API/lang/swift/variables/error_type/TestSwiftErrorType.py
@@ -12,4 +12,7 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[
+#FIXME: This regressed silently due to 2c911bceb06ed376801251bdfd992905a66f276c
+                          expectedFailureAll,
+                          swiftTest])

--- a/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
+++ b/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
@@ -23,6 +23,7 @@ class TestSwiftProtocolTypes(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
+    @expectedFailureAll #FIXME: This regressed silently due to 2c911bceb06ed376801251bdfd992905a66f276c
     @swiftTest
     def test_swift_protocol_types(self):
         """Test support for protocol types"""


### PR DESCRIPTION
_get_bool_config_skip_if_decorator returns a decorator, but the
is_not_swift_compatible function is supposed to return a bool. The skipTestIfFn
is supposed to create the decorator from the function we define.

As _get_bool_config_skip_if_decorator's return value is just interpreted as True,
this ends up causing that we skip all Swift tests all the time.

This just adds a _get_bool_config() function that actually returns a bool.
We could probably also solve this by doing a function composition of the
returned decorator and the decorator we create from our local function, but
just having a bool seems less likely to break.

Also re-enables and skipIf's the tests that are crashing/failing since the commit landed for now.