### PR TITLE
[llvm] Make obj2yaml and yaml2obj LLVM utilities instead of tools

### DIFF
--- a/llvm/tools/obj2yaml/CMakeLists.txt
+++ b/llvm/tools/obj2yaml/CMakeLists.txt
@@ -7,7 +7,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_llvm_tool(obj2yaml
+add_llvm_utility(obj2yaml
   obj2yaml.cpp
   coff2yaml.cpp
   dwarf2yaml.cpp

--- a/llvm/tools/yaml2obj/CMakeLists.txt
+++ b/llvm/tools/yaml2obj/CMakeLists.txt
@@ -3,6 +3,6 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_llvm_tool(yaml2obj
+add_llvm_utility(yaml2obj
   yaml2obj.cpp
   )


### PR DESCRIPTION
For testing purposes I need a way to build and install FileCheck and
yaml2obj. I had to choose between making FileCheck an LLVM tool and
making obj2yaml and yaml2obj utilities. I think the distinction is
rather arbitrary but my understanding is that tools are things meant for
the toolchain while utilities are more used for things like testing,
which is the case here.

The functional difference is that these tools now end up in the
${LLVM_UTILS_INSTALL_DIR}, which defaults to the ${LLVM_TOOLS_INSTALL_DIR}.
Unless you specified a different value or you added obj2yaml and
yaml2obj to ${LLVM_TOOLCHAIN_TOOLS}, this patch shouldn't change
anything.

Differential revision: https://reviews.llvm.org/D89357

(cherry picked from commit 97b8e2c1f063529125a8d1604d2745878c016061)