### PR TITLE
TypeSystem: Avoid the ISO646 spelling of the logical operators

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -401,9 +401,9 @@ template <> struct less<swift::ClusteredBitVector> {
     for (; iL >= 0 && iR >= 0; --iL, --iR) {
       bool bL = lhs[iL];
       bool bR = rhs[iR];
-      if (bL and not bR)
+      if (bL && !bR)
         return false;
-      if (bR and not bL)
+      if (bR && !bL)
         return true;
     }
     return false;


### PR DESCRIPTION
Avoid the use of the ISO646 logical operator spelling.  This enables the removal of the use of the `ciso646` header which can cause some issues when building Swift.