### PR TITLE
[cmake] Unconditionally set the force flag when codesigning

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -1841,9 +1841,10 @@ function(llvm_codesign name)
       set(ARG_BUNDLE_PATH $<TARGET_FILE:${name}>)
     endif()
 
-    if(ARG_FORCE)
-      set(force_flag "-f")
-    endif()
+    # ld64 now always codesigns the binaries it creates. Apply the force arg
+    # unconditionally so that we can - for example - add entitlements to the
+    # targets that need it.
+    set(force_flag "-f")
 
     add_custom_command(
       TARGET ${name} POST_BUILD


### PR DESCRIPTION
The Darwin linker now defaults to ad hoc signing binaries when targeting
Apple Silicon. This creates a problem when configuring targets that must
be built with entitlements: we either need to add -Wl,-no_adhoc_codesign
when building the target, or sign with the force flag set to allow
replacing a pre-existing signature.

Unconditionally force-signing is the more convenient solution. This
doesn't require a ld64 version check, and it's a much less invasive
cmake change.

Patch by Fred Riss!

rdar://70237254

Differential Revision: https://reviews.llvm.org/D89343

(cherry picked from commit 24c1660ac5d7813072b429eee7a9531338e53aea)
