### PR TITLE
Remove ISO646 include

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -400,9 +400,9 @@ template <> struct less<swift::ClusteredBitVector> {
     for (; iL >= 0 && iR >= 0; --iL, --iR) {
       bool bL = lhs[iL];
       bool bR = rhs[iR];
-      if (bL and not bR)
+      if (bL && !bR)
         return false;
-      if (bR and not bL)
+      if (bR && !bL)
         return true;
     }
     return false;

--- a/llvm/include/llvm/Support/Threading.h
+++ b/llvm/include/llvm/Support/Threading.h
@@ -19,7 +19,11 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Config/llvm-config.h" // for LLVM_ON_UNIX
 #include "llvm/Support/Compiler.h"
+// SWIFT_ENABLE_TENSORFLOW
+#if 0
 #include <ciso646> // So we can check the C++ standard lib macros.
+#endif
+// SWIFT_ENABLE_TENSORFLOW END
 #include <functional>
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
Cherry-pick #2001 and remove the ISO646 include. 

When building the standard library, this interferes with `Builtin` definitions of `and`, `or`, and `xor`, causing build errors like this:
```
Bool.swift:61:17: error: module 'Builtin' has no member named 'xor_Int1'
    return Bool(Builtin.xor_Int1(value._value, true._value))
```