### PR TITLE
Add override to fix -Winconsistent-missing-override warning.

### DIFF
--- a/lldb/include/lldb/Target/ThreadPlanPython.h
+++ b/lldb/include/lldb/Target/ThreadPlanPython.h
@@ -47,7 +47,7 @@ public:
 
   bool StopOthers() override { return m_stop_others; }
 
-  void SetStopOthers(bool new_value) { m_stop_others = new_value; }
+  void SetStopOthers(bool new_value) override { m_stop_others = new_value; }
 
   void DidPush() override;
 


### PR DESCRIPTION
(cherry picked from commit b529c5270c99e0ca18e3cbd9a5f50eb0970e560a)