### PR TITLE
Use the use_dynamic option to determine whether to dynamically resolve

### DIFF
--- a/lldb/test/API/lang/swift/availability/TestAvailability.py
+++ b/lldb/test/API/lang/swift/availability/TestAvailability.py
@@ -140,5 +140,5 @@ print("in top_level") // break_7
 
         for breakpoint in breakpoints:
             threads = lldbutil.continue_to_breakpoint(process, breakpoint)
-            self.expect("p f()", "can call")
+            self.expect("expr -d no-run-target -- f()", "can call")
 

--- a/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
+++ b/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
@@ -42,7 +42,9 @@ class TestSwiftGenericExpressions(lldbtest.TestBase):
         self.do_ivar_test()
 
     def check_expression(self, expression, expected_result, use_summary=True):
-        value = self.frame().EvaluateExpression(expression)
+        opts = lldb.SBExpressionOptions()
+        opts.SetFetchDynamicValue(lldb.eDynamicCanRunTarget)
+        value = self.frame().EvaluateExpression(expression, opts)
         self.assertTrue(value.IsValid(), expression + "returned a valid value")
 
         self.assertTrue(value.GetError().Success(), "expression failed")

--- a/lldb/test/API/lang/swift/expression/generic_protocol_extension/main.swift
+++ b/lldb/test/API/lang/swift/expression/generic_protocol_extension/main.swift
@@ -20,7 +20,7 @@ class C<T> : P {
 
 extension P {
   func f() -> Int {
-    return v //% self.expect("p self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["a.C"])
+    return v //% self.expect("expr -d run-target -- self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["a.C"])
   }
 }
 

--- a/lldb/test/API/lang/swift/expression/mutating_struct_extension/main.swift
+++ b/lldb/test/API/lang/swift/expression/mutating_struct_extension/main.swift
@@ -14,7 +14,7 @@ extension Array
 {
     mutating func doGenericStuff()
     {
-        print("generic stuff") //% self.expect("expr 2+3", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["5"])
+        print("generic stuff") //% self.expect("expr -d run-target -- 2+3", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["5"])
     }
 }
 

--- a/lldb/test/API/lang/swift/generic_extension/main.swift
+++ b/lldb/test/API/lang/swift/generic_extension/main.swift
@@ -11,7 +11,7 @@
 // -----------------------------------------------------------------------------
 extension Array {
     func test() {
-        print("PATPAT") //% self.expect("p self", substrs=['[0] = 1', '[1] = 2', '[2] = 3'])
+        print("PATPAT") //% self.expect("expr -d run-target -- self", substrs=['[0] = 1', '[1] = 2', '[2] = 3'])
         return //% self.expect("frame variable -d run -- self", substrs=['[0] = 1', '[1] = 2', '[2] = 3'])
     }
 }

--- a/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_apply/main.swift
+++ b/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_apply/main.swift
@@ -14,7 +14,7 @@ func apply<Type>(_ T : Type, fn: (Type) -> Type) -> Type { return fn(T) }
 public func f<Type>(_ value : Type)
 {
   apply(value) { arg in
-    return arg //% self.expect('po arg', substrs=['3735928559'])
+    return arg //% self.expect('expr -o -d run -- arg', substrs=['3735928559'])
      //% self.expect('expr -d run -- arg', substrs=['Int', '3735928559'])
       //% self.expect('fr var -d run -- arg', substrs=['Int', '3735928559'])
   }

--- a/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_array/main.swift
+++ b/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_array/main.swift
@@ -13,7 +13,7 @@ public struct Q<T> {
   let x: T
 }
 public func foo<T>(_ arg: [Q<T>]) {
-  print(arg) //% self.expect('po arg', substrs=['x : 3735928559'])
+  print(arg) //% self.expect('expr -o -d run -- arg', substrs=['x : 3735928559'])
   //% self.expect('expr -d run -- arg', substrs=['x = 3735928559'])
   //% self.expect('frame var -d run -- arg', substrs=['x = 3735928559'])
 }

--- a/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_flatmap/main.swift
+++ b/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_flatmap/main.swift
@@ -34,13 +34,13 @@ struct FlatMapper<Type>
         ]
         
         let _ = tuples.flatMap { tuple in
-            return tuple //% self.expect('po tuple', substrs=['originalIndex : 0', 'filteredIndex : 0', 'name : "Coffee"', 'ID : "1"'])
+            return tuple //% self.expect('expr -o -d run -- tuple', substrs=['originalIndex : 0', 'filteredIndex : 0', 'name : "Coffee"', 'ID : "1"'])
             //% self.expect('expr -d run -- tuple', substrs=['originalIndex = 0', 'filteredIndex = 0', 'name = "Coffee"', 'ID = "1"'])
             //% self.expect('frame var -d run -- tuple', substrs=['originalIndex = 0', 'filteredIndex = 0', 'name = "Coffee"', 'ID = "1"'])
         }
         
        let _ = values.flatMap { value in
-            return value //% self.expect('po value', substrs=['name : "Coffee"', 'ID : "1"'])
+            return value //% self.expect('expr -o -d run -- value', substrs=['name : "Coffee"', 'ID : "1"'])
             //% self.expect('expr -d run -- value', substrs=['name = "Coffee"', 'ID = "1"'])
             //% self.expect('frame var -d run -- value', substrs=['name = "Coffee"', 'ID = "1"'])
         }

--- a/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
+++ b/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
@@ -101,7 +101,7 @@ class TestSwiftProtocolTypes(TestBase):
                              'x = 1.25', 'y = 2.5'])
 
         self.expect("expression --raw-output --show-types -- loc3dCB",
-                    substrs=['PointUtils & AnyObject) $R',
+                    substrs=['PointUtils & Swift.AnyObject) $R',
                              '(Builtin.RawPointer) instance = 0x',
                              '(Builtin.RawPointer) witness_table_PointUtils = 0x'])
 

--- a/lldb/test/API/lang/swift/variables/uninitialized/main.swift
+++ b/lldb/test/API/lang/swift/variables/uninitialized/main.swift
@@ -23,7 +23,7 @@ struct A<T> {
         let c = cs[0]
 
         let k1 = b(t:c)
-        let k2 = b(t:c) //% self.expect("expression -- c", "Unreadable variable is ignored", substrs = ["= 3"])
+        let k2 = b(t:c) //% self.expect("expr -d run -- c", "Unreadable variable is ignored", substrs = ["= 3"])
         let k3 = b(t:c)
 
         if let maybeT = process(i : adict.count, k1:k1, k2:k2, k3:k3) {


### PR DESCRIPTION
self in Swift expressions.

This is a more principled approach over always dynamically resolving
all types and fixes a regression hidden by the recent @swiftTest
decorator bug.

(cherry picked from commit d1bfc99b848f097e85e8f90d9bd0956dc69e2d89)