### PR TITLE
[lldb] Don't strip LLDB.framework on install

### DIFF
--- a/lldb/cmake/caches/Apple-lldb-macOS.cmake
+++ b/lldb/cmake/caches/Apple-lldb-macOS.cmake
@@ -2,6 +2,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/Apple-lldb-base.cmake)
 
 set(LLDB_BUILD_FRAMEWORK ON CACHE BOOL "")
 set(LLDB_NO_INSTALL_DEFAULT_RPATH ON CACHE BOOL "")
+set(LLDB_SKIP_STRIP ON CACHE BOOL "")
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.11 CACHE STRING "")
 
 # Default install location on the enduser machine. On the build machine, use the


### PR DESCRIPTION
The framework build will run dsymutil after LLDB.framework is installed.

(cherry picked from commit c565f09f4b0d908f51aaf4a841285f39ef93bc8c)