### PR TITLE
[lldb][swift] Make swiftTest decorator not always skip

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -623,9 +623,8 @@ def skipUnlessTargetAndroid(func):
 def swiftTest(func):
     """Decorate the item as a Swift test (Darwin/Linux only, no i386)."""
     def is_not_swift_compatible(self):
-        swift_enabled_error = _get_bool_config_skip_if_decorator("swift")(func)
-        if swift_enabled_error:
-            return swift_enabled_error
+        if not _get_bool_config("swift"):
+           return "Swift plugin not enabled"
         if self.getDebugInfo() == "gmodules":
             return "skipping (gmodules only makes sense for clang tests)"
 
@@ -883,11 +882,14 @@ def skipIfAsan(func):
     """Skip this test if the environment is set up to run LLDB *itself* under ASAN."""
     return skipTestIfFn(is_running_under_asan)(func)
 
-def _get_bool_config_skip_if_decorator(key):
+def _get_bool_config(key):
     config = lldb.SBDebugger.GetBuildConfiguration()
     value_node = config.GetValueForKey(key)
     fail_value = True # More likely to notice if something goes wrong
-    have = value_node.GetValueForKey("value").GetBooleanValue(fail_value)
+    return value_node.GetValueForKey("value").GetBooleanValue(fail_value)
+
+def _get_bool_config_skip_if_decorator(key):
+    have = _get_bool_config(key)
     return unittest2.skipIf(not have, "requires " + key)
 
 def skipIfCursesSupportMissing(func):


### PR DESCRIPTION
_get_bool_config_skip_if_decorator returns a decorator, but the
is_not_swift_compatible function is supposed to return a bool. The skipTestIfFn
is supposed to create the decorator from the function we define.

As _get_bool_config_skip_if_decorator's return value is just interpreted as True,
this ends up causing that we skip all Swift tests all the time.

This just adds a _get_bool_config() function that actually returns a bool.
We could probably also solve this by doing a function composition of the
returned decorator and the decorator we create from our local function, but
just having a bool seems less likely to break.

(cherry picked from commit 386224aa218ced4bd417a3936cc1033ec59758df)