### PR TITLE
[lldb][swift] Use dynamic types as a fallback in AddVariableInfo

### DIFF
--- a/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
+++ b/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,
-                          expectedFailureAll #FIXME: This regressed silently due to 2c911bceb06ed376801251bdfd992905a66f276c
-                          ])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/opaque_existentials/TestOpaqueExistentials.py
+++ b/lldb/test/API/lang/swift/opaque_existentials/TestOpaqueExistentials.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,
-                          expectedFailureAll #FIXME: This regressed silently due to 2c911bceb06ed376801251bdfd992905a66f276c
-                          ])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
+++ b/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
@@ -33,7 +33,6 @@ class TestSwiftUnknownSelf(lldbtest.TestBase):
         self.expect("fr v self", substrs=["hello", "world"])
 
 
-    @skipIf #FIXME: This regressed silently due to 2c911bceb06ed376801251bdfd992905a66f276c
     @skipIf(bugnumber="SR-10216", archs=['ppc64le'])
     @swiftTest
     def test_unknown_self_objc_ref(self):

--- a/lldb/test/API/lang/swift/variables/error_type/TestSwiftErrorType.py
+++ b/lldb/test/API/lang/swift/variables/error_type/TestSwiftErrorType.py
@@ -12,7 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[
-#FIXME: This regressed silently due to 2c911bceb06ed376801251bdfd992905a66f276c
-                          expectedFailureAll,
-                          swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])


### PR DESCRIPTION
Since commit eaceb46661c6833f11fa98659223652f6d549f4a AddVariableInfo is
always using the dynamic type if requested. The dynamic types appear
to not always be usable and caused a few tests to fail(1), but as the swiftTest
decorator was always skipping all Swift tests since commit
2c911bceb06ed376801251bdfd992905a66f276c this wasn't discovered before landing.

This patch restores the old behaviour where possible by first trying the
non-dynamic type and falling back to the dynamic type in case the non-dynamic
type can't be fully realized.

(1) All the failures seem to be related to us reading corrupt data from memory
when using the dynamic type in the expression parser. The dynamic types itself
appear to be perfectly fine, so it's not clear why the new behaviour doesn't work.