### PR TITLE
[profile] Suppress spurious 'expected profile to require unlock' warning

### DIFF
--- a/compiler-rt/lib/profile/InstrProfilingFile.c
+++ b/compiler-rt/lib/profile/InstrProfilingFile.c
@@ -685,7 +685,8 @@ static void initializeProfileForContinuousMode(void) {
         FileOffsetToCounters);
   }
 
-  unlockProfile(&ProfileRequiresUnlock, File);
+  if (ProfileRequiresUnlock)
+    unlockProfile(&ProfileRequiresUnlock, File);
 #endif // defined(__Fuchsia__) || defined(_WIN32)
 }
 

--- a/compiler-rt/test/profile/ContinuousSyncMode/multiple-DSOs.c
+++ b/compiler-rt/test/profile/ContinuousSyncMode/multiple-DSOs.c
@@ -5,7 +5,7 @@
 // RUN: %clang_pgogen -dynamiclib -o %t.dso1.dylib %t.dso1.c
 // RUN: %clang_pgogen -dynamiclib -o %t.dso2.dylib %t.dso2.c
 // RUN: %clang_pgogen -o %t.exe %s %t.dso1.dylib %t.dso2.dylib
-// RUN: env LLVM_PROFILE_FILE="%c%t.profraw" %run %t.exe
+// RUN: env LLVM_PROFILE_FILE="%c%t.profraw" %run %t.exe 2>&1 | count 0
 // RUN: llvm-profdata show --counts --all-functions %t.profraw | FileCheck %s
 
 // CHECK-LABEL: Counters:


### PR DESCRIPTION
In %c (continuous sync) mode, avoid attempting to unlock an
already-unlocked profile.

The profile is only locked when profile merging is enabled.

(cherry picked from commit a77a739abcfa1c5734d374e1afb51cebdb6f36bd)
