### PR TITLE
Add a TypeSystemSwiftTypeRef::GetTupleElementName() method.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -257,6 +257,10 @@ public:
       bool print_help_if_available, bool print_extensions_if_available,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
 
+  /// Return the nth tuple element's name, if it has one.
+  std::string GetTupleElementName(lldb::opaque_compiler_type_t type,
+                                  size_t idx);
+
   /// Recursively transform the demangle tree starting a \p node by
   /// doing a post-order traversal and replacing each node with
   /// fn(node).

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -402,6 +402,20 @@ TEST_F(TestTypeSystemSwiftTypeRef, Tuple) {
     ASSERT_EQ(float_int_tuple.GetMangledTypeName(),
               "$ss0019BuiltinFPIEEE_CJEEdV1f_s0016BuiltinInt_gCJAcV1itD");
   }
+  {
+    NodePointer n = b.GlobalType(
+        b.Node(Node::Kind::Tuple,
+               b.Node(Node::Kind::TupleElement,
+                      b.Node(Node::Kind::TupleElementName, "x"), b.IntType()),
+               b.Node(Node::Kind::TupleElement, b.IntType()),
+               b.Node(Node::Kind::TupleElement,
+                      b.Node(Node::Kind::TupleElementName, "z"), b.IntType())));
+    CompilerType t = GetCompilerType(b.Mangle(n));
+    lldb::opaque_compiler_type_t o = t.GetOpaqueQualType();
+    ASSERT_EQ(m_swift_ts.GetTupleElementName(o, 0), "x");
+    ASSERT_EQ(m_swift_ts.GetTupleElementName(o, 1), "1");
+    ASSERT_EQ(m_swift_ts.GetTupleElementName(o, 2), "z");
+  }
 }
 
 TEST_F(TestTypeSystemSwiftTypeRef, TypeClass) {


### PR DESCRIPTION
(cherry picked from commit adb23f810fc2d07a98cb6fc7f2f2d0be3ddd4239)