### PR TITLE
[lldb] Enable cmake policy CMP0077 for option()

### DIFF
--- a/lldb/CMakeLists.txt
+++ b/lldb/CMakeLists.txt
@@ -7,6 +7,10 @@ if(POLICY CMP0075)
   cmake_policy(SET CMP0075 NEW)
 endif()
 
+if(POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif()
+
 # Add path for custom modules.
 set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}


### PR DESCRIPTION
In lldb, explicitly set the "option() honors normal variables" CMake policy. This applies for
standalone lldb builds and matches what llvm, clang, etc do. This prevents potentially unwanted
clearing of variables like `LLVM_ENABLE_WARNINGS`, and also prevents unnecessary build warnings.

See: https://cmake.org/cmake/help/latest/policy/CMP0077.html

Differential Revision: https://reviews.llvm.org/D89614

(cherry picked from commit ae4fe1984f0e47259b5e476a73749185cc24e1ac)