### PR TITLE
[DebugInfo] Fix legacy ZExt emission when FromBits >= 64 (PR47927)

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
@@ -558,7 +558,7 @@ void DwarfExpression::addExpression(DIExpressionCursor &&ExprCursor,
           if (Encoding == dwarf::DW_ATE_signed)
             emitLegacySExt(PrevConvertOp->getArg(0));
           else if (Encoding == dwarf::DW_ATE_unsigned)
-            emitLegacyZExt(PrevConvertOp->getArg(0));
+            emitLegacyZExt(PrevConvertOp->getArg(0), BitSize);
           PrevConvertOp = None;
         } else {
           PrevConvertOp = Op;
@@ -650,11 +650,17 @@ void DwarfExpression::emitLegacySExt(unsigned FromBits) {
   emitOp(dwarf::DW_OP_or);
 }
 
-void DwarfExpression::emitLegacyZExt(unsigned FromBits) {
-  // (X & (1 << FromBits - 1))
-  emitOp(dwarf::DW_OP_constu);
-  emitUnsigned((1ULL << FromBits) - 1);
-  emitOp(dwarf::DW_OP_and);
+void DwarfExpression::emitLegacyZExt(unsigned FromBits, unsigned ToBits) {
+  if (FromBits < 64) {
+    // X & ((1 << FromBits) - 1)
+    emitOp(dwarf::DW_OP_constu);
+    emitUnsigned((1ULL << FromBits) - 1);
+    emitOp(dwarf::DW_OP_and);
+  } else {
+    addOpPiece(FromBits, 0);
+    emitOp(dwarf::DW_OP_lit0);
+    addOpPiece(ToBits - FromBits, FromBits);
+  }
 }
 
 void DwarfExpression::addWasmLocation(unsigned Index, uint64_t Offset) {

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.h
@@ -351,7 +351,7 @@ public:
   void addFragmentOffset(const DIExpression *Expr);
 
   void emitLegacySExt(unsigned FromBits);
-  void emitLegacyZExt(unsigned FromBits);
+  void emitLegacyZExt(unsigned FromBits, unsigned ToBits);
 
   /// Emit location information expressed via WebAssembly location + offset
   /// The Index is an identifier for locals, globals or operand stack.

--- a/llvm/test/DebugInfo/X86/legacy-zext.ll
+++ b/llvm/test/DebugInfo/X86/legacy-zext.ll
@@ -1,0 +1,32 @@
+; RUN: llc -filetype=obj -o - %s | llvm-dwarfdump - | FileCheck %s
+
+; CHECK: DW_AT_location (DW_OP_breg5 RDI+0, DW_OP_piece 0x8, DW_OP_lit0, DW_OP_bit_piece 0x40 0x40)
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @t(i64 %x) !dbg !6 {
+  call void @llvm.dbg.value(metadata i64 %x, metadata !9,
+                            metadata !DIExpression(DW_OP_LLVM_convert, 64, DW_ATE_unsigned,
+                                                   DW_OP_LLVM_convert, 128, DW_ATE_unsigned)), !dbg !11
+  ret void, !dbg !11
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+!llvm.dbg.cu = !{!0}
+!llvm.debugify = !{!3, !4}
+!llvm.module.flags = !{!5}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "debugify", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2)
+!1 = !DIFile(filename: "legacy-zext.ll", directory: "/")
+!2 = !{}
+!3 = !{i64 2}
+!4 = !{i64 1}
+!5 = !{i64 2, !"Debug Info Version", i32 3}
+!6 = distinct !DISubprogram(name: "t", linkageName: "t", scope: null, file: !1, line: 1, type: !7, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !8)
+!7 = !DISubroutineType(types: !2)
+!8 = !{!9}
+!9 = !DILocalVariable(name: "1", scope: !6, file: !1, line: 1, type: !10)
+!10 = !DIBasicType(name: "ty128", size: 128, encoding: DW_ATE_unsigned)
+!11 = !DILocation(line: 1, column: 1, scope: !6)


### PR DESCRIPTION
Fix an out-of-bounds shift in emitLegacyZExt by using a slightly more
complicated dwarf expression to create the zext mask.

This addresses a UBSan diagnostic seen when compiling compiler-rt
(llvm.org/PR47927).

rdar://70307714

Differential Revision: https://reviews.llvm.org/D89838

(cherry picked from commit 99053462216cf835eb3ae063942c618d9609de87)
