### PR TITLE
Add support for builtin and pointer types to GetClangTypeNode()

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -25,6 +25,7 @@
 
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/Basic/Version.h"
+#include "swift/../../lib/ClangImporter/ClangAdapter.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Demangling/Demangler.h"
 #include "swift/Strings.h"
@@ -90,20 +91,85 @@ static CompilerType LookupClangForwardType(SwiftASTContext *module_holder,
   return {};
 }
 
+/// Return a demangle tree for an UnsafePointer<Pointee>.
+static swift::Demangle::NodePointer
+GetPointerTo(swift::Demangle::Demangler &dem,
+             swift::Demangle::NodePointer pointee) {
+  using namespace swift::Demangle;
+  auto *bgs = dem.createNode(Node::Kind::BoundGenericStructure);
+  // Construct the first branch of BoundGenericStructure.
+  {
+    auto *type = dem.createNode(Node::Kind::Type);
+    auto *structure = dem.createNode(Node::Kind::Structure);
+    structure->addChild(
+        dem.createNodeWithAllocatedText(Node::Kind::Module, swift::STDLIB_NAME),
+        dem);
+    structure->addChild(dem.createNode(Node::Kind::Identifier, "UnsafePointer"),
+                        dem);
+    type->addChild(structure, dem);
+    bgs->addChild(type, dem);
+  }
+
+  // Construct the second branch of BoundGenericStructure.
+  {
+    auto *typelist = dem.createNode(Node::Kind::TypeList);
+    auto *type = dem.createNode(Node::Kind::Type);
+    typelist->addChild(type, dem);
+    type->addChild(pointee, dem);
+    bgs->addChild(typelist, dem);
+  }
+  return bgs;
+}
+
 /// Return a demangle tree leaf node representing \p clang_type.
 static swift::Demangle::NodePointer
 GetClangTypeNode(CompilerType clang_type, swift::Demangle::Demangler &dem) {
   using namespace swift::Demangle;
-  clang::QualType qual_type = ClangUtil::GetQualType(clang_type);
-  NodePointer structure = dem.createNode(
-      qual_type->isClassType() ? Node::Kind::Class : Node::Kind::Structure);
-  NodePointer module = dem.createNodeWithAllocatedText(
-      Node::Kind::Module, swift::MANGLING_MODULE_OBJC);
+  Node::Kind kind;
+  llvm::StringRef swift_name;
+  llvm::StringRef module_name = swift::MANGLING_MODULE_OBJC;
+  CompilerType pointee;
+  if (clang_type.IsPointerType(&pointee))
+    clang_type = pointee;
+    
+  switch (clang_type.GetTypeClass()) {
+  case eTypeClassClass:
+  case eTypeClassObjCObjectPointer:
+    // Objective-C objects are first-class entities, not pointers.
+    kind = Node::Kind::Class;
+    pointee = {};
+    break;
+  case eTypeClassBuiltin: 
+    kind = Node::Kind::Structure;
+    // Ask ClangImporter about the builtin type's Swift name.
+    if (auto *ts = llvm::cast<TypeSystemClang>(clang_type.GetTypeSystem())) {
+      if (clang_type == ts->GetPointerSizedIntType(true)) {
+        swift_name = "Int";
+        break;
+      }
+      if (clang_type == ts->GetPointerSizedIntType(false)) {
+        swift_name = "UInt";
+        break;
+      }
+      swift_name = swift::importer::getClangTypeNameForOmission(
+                       ts->getASTContext(), ClangUtil::GetQualType(clang_type))
+                       .Name;
+      module_name = swift::STDLIB_NAME;
+    }
+    break;
+  default:
+    kind = Node::Kind::Structure;
+  }
+  NodePointer structure = dem.createNode(kind);
+  NodePointer module =
+      dem.createNodeWithAllocatedText(Node::Kind::Module, module_name);
   structure->addChild(module, dem);
   NodePointer identifier = dem.createNodeWithAllocatedText(
-      Node::Kind::Module, clang_type.GetTypeName().GetStringRef());
+      Node::Kind::Identifier, swift_name.empty()
+                                  ? clang_type.GetTypeName().GetStringRef()
+                                  : swift_name);
   structure->addChild(identifier, dem);
-  return structure;
+  return pointee ? GetPointerTo(dem, structure) : structure;
 }
 
 /// \return the child of the \p Type node.
@@ -1740,7 +1806,6 @@ CompilerType
 TypeSystemSwiftTypeRef::GetPointeeType(opaque_compiler_type_t type) {
   return m_swift_ast_context->GetPointeeType(ReconstructType(type));
 }
-
 CompilerType
 TypeSystemSwiftTypeRef::GetPointerType(opaque_compiler_type_t type) {
   auto impl = [&]() -> CompilerType {
@@ -1752,31 +1817,8 @@ TypeSystemSwiftTypeRef::GetPointerType(opaque_compiler_type_t type) {
     // The UnsafePointer type.
     auto *pointer_type = dem.createNode(Node::Kind::Type);
 
-    auto *bgs = dem.createNode(Node::Kind::BoundGenericStructure);
+    auto *bgs = GetPointerTo(dem, pointee_type);
     pointer_type->addChild(bgs, dem);
-
-    // Construct the first branch of BoundGenericStructure.
-    {
-      auto *type = dem.createNode(Node::Kind::Type);
-      bgs->addChild(type, dem);
-      auto *structure = dem.createNode(Node::Kind::Structure);
-      type->addChild(structure, dem);
-      structure->addChild(dem.createNodeWithAllocatedText(Node::Kind::Module,
-                                                          swift::STDLIB_NAME),
-                          dem);
-      structure->addChild(
-          dem.createNode(Node::Kind::Identifier, "UnsafePointer"), dem);
-    }
-
-    // Construct the second branch of BoundGenericStructure.
-    {
-      auto *typelist = dem.createNode(Node::Kind::TypeList);
-      bgs->addChild(typelist, dem);
-      auto *type = dem.createNode(Node::Kind::Type);
-      typelist->addChild(type, dem);
-      type->addChild(pointee_type, dem);
-    }
-
     return RemangleAsType(dem, pointer_type);
   };
   VALIDATE_AND_RETURN(impl, GetPointerType, type, (ReconstructType(type)));


### PR DESCRIPTION
This is a prerequisite for TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex().

(cherry picked from commit 685cf71e9570e61e77acdd9ed1d120534bcf92a5)