### PR TITLE
Increase timeout to find a dSYM in macos DownloadObjectAndSymbolFile

### DIFF
--- a/lldb/source/Symbol/LocateSymbolFileMacOSX.cpp
+++ b/lldb/source/Symbol/LocateSymbolFileMacOSX.cpp
@@ -621,7 +621,7 @@ bool Symbols::DownloadObjectAndSymbolFile(ModuleSpec &module_spec,
             &signo,          // Signal int *
             &command_output, // Command output
             std::chrono::seconds(
-               120), // Large timeout to allow for long dsym download times
+               640), // Large timeout to allow for long dsym download times
             false);  // Don't run in a shell (we don't need shell expansion)
         if (error.Success() && exit_status == 0 && !command_output.empty()) {
           CFCData data(CFDataCreateWithBytesNoCopy(


### PR DESCRIPTION
Increase timeout to find a dSYM in macos DownloadObjectAndSymbolFile

With a large dSYM over a slow home connection, the two minute timeout
would sometimes be exceeded, and we haven't seen instances of a
long timeout causing people any problems, so we're bumping it up.

640 seconds ought to be enough for anyone.

<rdar://problem/67759526>

(cherry picked from commit af5504edd6815d085de8aa66efcd7150d6315a51)