### PR TITLE
Use !hasLocalLinkage instead of listing the symbol types

### DIFF
--- a/lldb/source/Expression/IRExecutionUnit.cpp
+++ b/lldb/source/Expression/IRExecutionUnit.cpp
@@ -328,8 +328,7 @@ void IRExecutionUnit::GetRunnableInfo(Status &error, lldb::addr_t &func_addr,
     if (function.isDeclaration() || function.hasPrivateLinkage())
       continue;
 
-    const bool external =
-        function.hasExternalLinkage() || function.hasLinkOnceODRLinkage();
+    const bool external = !function.hasLocalLinkage();
 
     void *fun_ptr = m_execution_engine_up->getPointerToFunction(&function);
 


### PR DESCRIPTION
we should be exporting one by one.

Differential Revision: https://reviews.llvm.org/D78972

(cherry picked from commit c8c07b76b2cf2ada8e7ec132f7f57b97d76743cf)