### PR TITLE
[lldb] Add missing ^ achor for summary provider regex

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -521,27 +521,27 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
 
   AddCXXSummary(swift_category_sp,
                 lldb_private::formatters::swift::Range_SummaryProvider,
-                "Swift.Range summary provider", ConstString("Swift.Range<.+>$"),
+                "Swift.Range summary provider", ConstString("^Swift.Range<.+>$"),
                 summary_flags, true);
   AddCXXSummary(swift_category_sp,
                 lldb_private::formatters::swift::CountableRange_SummaryProvider,
                 "Swift.CountableRange summary provider",
-                ConstString("Swift.CountableRange<.+>$"), summary_flags, true);
+                ConstString("^Swift.CountableRange<.+>$"), summary_flags, true);
   AddCXXSummary(swift_category_sp,
                 lldb_private::formatters::swift::ClosedRange_SummaryProvider,
                 "Swift.ClosedRange summary provider",
-                ConstString("Swift.ClosedRange<.+>$"), summary_flags, true);
+                ConstString("^Swift.ClosedRange<.+>$"), summary_flags, true);
   AddCXXSummary(
       swift_category_sp,
       lldb_private::formatters::swift::CountableClosedRange_SummaryProvider,
       "Swift.CountableClosedRange summary provider",
-      ConstString("Swift.CountableClosedRange<.+>$"), summary_flags, true);
+      ConstString("^Swift.CountableClosedRange<.+>$"), summary_flags, true);
 
   AddCXXSummary(
       swift_category_sp,
       lldb_private::formatters::swift::StridedRangeGenerator_SummaryProvider,
       "Swift.StridedRangeGenerator summary provider",
-      ConstString("Swift.StridedRangeGenerator<.+>$"), summary_flags, true);
+      ConstString("^Swift.StridedRangeGenerator<.+>$"), summary_flags, true);
 
   TypeSummaryImpl::Flags simd_summary_flags;
   simd_summary_flags.SetCascades(true)

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -541,7 +541,7 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       swift_category_sp,
       lldb_private::formatters::swift::StridedRangeGenerator_SummaryProvider,
       "Swift.StridedRangeGenerator summary provider",
-      ConstString("^Swift.StridedRangeGenerator<.+>$"), summary_flags, true);
+      ConstString("Swift.StridedRangeGenerator<.+>$"), summary_flags, true);
 
   TypeSummaryImpl::Flags simd_summary_flags;
   simd_summary_flags.SetCascades(true)


### PR DESCRIPTION
From the output of `type summary list`, I noticed these regex were missing a `^`. This change adds the missing beginning of string anchor. Without this, if a library were to be named with a Swift suffix (say `HTTPSwift`), then if it defined its own `Range` generic type, then the `Swift.Range` provider would be applied. Certainly not a likely case, but it's an easy fix.