### PR TITLE
[lldb] Pass SwiftOptionalSummaryProvider flags to base constructor

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftOptional.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptional.h
@@ -78,8 +78,7 @@ protected:
 namespace swift {
 struct SwiftOptionalSummaryProvider : public TypeSummaryImpl {
   SwiftOptionalSummaryProvider(const TypeSummaryImpl::Flags &flags)
-      : TypeSummaryImpl(TypeSummaryImpl::Kind::eInternal,
-                        TypeSummaryImpl::Flags()) {}
+      : TypeSummaryImpl(TypeSummaryImpl::Kind::eInternal, flags) {}
 
   virtual ~SwiftOptionalSummaryProvider() {}
 


### PR DESCRIPTION
`SwiftOptionalSummaryProvider`'s flags were not being passed to the base class constructor (`TypeSummaryImpl`).