### PR TITLE
Implement TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex()

### DIFF
--- a/lldb/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/lldb/include/lldb/Target/SwiftLanguageRuntime.h
@@ -252,6 +252,20 @@ public:
                                                    llvm::StringRef member_name,
                                                    Status *error = nullptr);
 
+  /// Ask Remote Mirrors about the children of a composite type.
+  llvm::Optional<unsigned> GetNumChildren(CompilerType type,
+                                          ValueObject *valobj);
+
+  /// Ask Remote Mirrors about a child of a composite type.
+  CompilerType GetChildCompilerTypeAtIndex(
+      CompilerType type, size_t idx, bool transparent_pointers,
+      bool omit_empty_base_classes, bool ignore_array_bounds,
+      std::string &child_name, uint32_t &child_byte_size,
+      int32_t &child_byte_offset, uint32_t &child_bitfield_bit_size,
+      uint32_t &child_bitfield_bit_offset, bool &child_is_base_class,
+      bool &child_is_deref_of_parent, ValueObject *valobj,
+      uint64_t &language_flags);
+
   /// Ask Remote Mirrors for the size of a Swift type.
   llvm::Optional<uint64_t> GetBitSize(CompilerType type,
                                       ExecutionContextScope *exe_scope);

--- a/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
@@ -31,6 +31,7 @@ using namespace lldb_private::formatters::swift;
 /// If this is a Clang enum wrapped in a Swift type, return the clang::EnumDecl.
 static std::pair<clang::EnumDecl *, TypeSystemClang *>
 GetAsEnumDecl(CompilerType swift_type) {
+  swift_type = swift_type.GetCanonicalType();
   if (!swift_type)
     return {nullptr, nullptr};
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2296,7 +2296,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
   }
 
   return swift_ast_sp;
-  }
+}
 
 void SwiftASTContext::EnumerateSupportedLanguages(
     std::set<lldb::LanguageType> &languages_for_types,
@@ -6546,14 +6546,21 @@ GetExistentialTypeChild(swift::ASTContext *swift_ast_ctx, CompilerType type,
   // The instance for a class-bound existential.
   if (idx == 0 && protocol_info.m_is_class_only) {
     CompilerType class_type;
-    if (protocol_info.m_superclass) {
+    // FIXME: Remove this comment once the TypeSystemSwiftTyperef
+    // transition is complete.
+    //
+    // There is not enough data available to support this in
+    // TypeSystemSwiftTypeRef, but there is also notuser-visible
+    // feature affected by this apart from the --raw-types output, so
+    // this was removed to match TypeSystemSwiftTyperef:
+    /* if (protocol_info.m_superclass) {
       class_type = protocol_info.m_superclass;
-    } else {
+      } else */ {
       auto raw_pointer = swift_ast_ctx->TheRawPointerType;
       class_type = ToCompilerType(raw_pointer.getPointer());
     }
 
-    return {class_type, "instance"};
+    return {class_type, "object"};
   }
 
   // The instance for an error existential.
@@ -6567,7 +6574,7 @@ GetExistentialTypeChild(swift::ASTContext *swift_ast_ctx, CompilerType type,
     // The metatype for a non-class, non-error existential.
     auto any_metatype =
         swift::ExistentialMetatypeType::get(swift_ast_ctx->TheAnyType);
-    return {ToCompilerType(any_metatype), "instance_type"};
+    return {ToCompilerType(any_metatype), "metadata"};
   }
 
   // A witness table. Figure out which protocol it corresponds to.
@@ -6582,8 +6589,7 @@ GetExistentialTypeChild(swift::ASTContext *swift_ast_ctx, CompilerType type,
       continue;
 
     if (witness_table_idx == 0) {
-      llvm::raw_string_ostream(name)
-          << "witness_table_" << proto->getBaseName().userFacingName();
+      name = "wtable";
       break;
     }
     --witness_table_idx;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -7825,7 +7825,7 @@ bool SwiftASTContext::IsImportedType(opaque_compiler_type_t type,
 
   if (!type)
     return false;
-  if (swift::CanType swift_can_type = GetCanonicalSwiftType(type)) {
+  if (swift::Type swift_can_type = GetSwiftType(type)) {
     do {
       swift::NominalType *nominal_type =
           swift_can_type->getAs<swift::NominalType>();

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1981,7 +1981,7 @@ bool TypeSystemSwiftTypeRef::IsImportedType(opaque_compiler_type_t type,
   auto impl = [&]() -> bool {
     using namespace swift::Demangle;
     Demangler dem;
-    NodePointer node = DemangleCanonicalType(dem, type);
+    NodePointer node = GetDemangledType(dem, AsMangledName(type));
 
     // This is an imported Objective-C type; look it up in the debug info.
     StringRef ident = GetObjCTypeName(node);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -43,6 +43,61 @@ char TypeSystemSwiftTypeRef::ID;
 
 TypeSystemSwift::TypeSystemSwift() : TypeSystem() {}
 
+/// Determine wether this demangle tree contains an unresolved type alias.
+static bool ContainsUnresolvedTypeAlias(swift::Demangle::NodePointer node) {
+  if (!node)
+    return false;
+
+  if (node->getKind() == swift::Demangle::Node::Kind::TypeAlias)
+    return true;
+
+  for (swift::Demangle::NodePointer child : *node)
+    if (ContainsUnresolvedTypeAlias(child))
+      return true;
+
+  return false;
+}
+
+swift::Demangle::NodePointer
+TypeSystemSwiftTypeRef::CanonicalizeSugar(swift::Demangle::Demangler &dem,
+                                          swift::Demangle::NodePointer node) {
+  return TypeSystemSwiftTypeRef::Transform(dem, node, [&](NodePointer n) {
+    if ((n->getKind() != Node::Kind::BoundGenericEnum &&
+         n->getKind() != Node::Kind::BoundGenericStructure) ||
+        n->getNumChildren() != 2)
+      return n;
+    NodePointer type = n->getChild(0);
+    if (!type || type->getNumChildren() != 1)
+      return n;
+    NodePointer payload = n->getChild(1);
+    if (!payload || payload->getKind() != Node::Kind::TypeList ||
+        !payload->hasChildren())
+      return n;
+
+    NodePointer e = type->getChild(0);
+    if (!e || e->getNumChildren() != 2)
+      return n;
+    NodePointer module = e->getChild(0);
+    NodePointer ident = e->getChild(1);
+    if (!module || module->getKind() != Node::Kind::Module ||
+        !module->hasText() || module->getText() != swift::STDLIB_NAME ||
+        !ident || ident->getKind() != Node::Kind::Identifier ||
+        !ident->hasText())
+      return n;
+    auto kind = llvm::StringSwitch<Node::Kind>(ident->getText())
+                    .Case("Array", Node::Kind::SugaredArray)
+                    .Case("Dictionary", Node::Kind::SugaredDictionary)
+                    .Case("Optional", Node::Kind::SugaredOptional)
+                    .Default(Node::Kind::Type);
+    if (kind == Node::Kind::Type)
+      return n;
+    NodePointer sugared = dem.createNode(kind);
+    for (NodePointer child : *payload)
+      sugared->addChild(child, dem);
+    return sugared;
+  });
+}
+
 /// Create a mangled name for a type alias node.
 static ConstString GetTypeAlias(swift::Demangle::Demangler &dem,
                                 swift::Demangle::NodePointer node) {
@@ -123,53 +178,107 @@ GetPointerTo(swift::Demangle::Demangler &dem,
 
 /// Return a demangle tree leaf node representing \p clang_type.
 static swift::Demangle::NodePointer
-GetClangTypeNode(CompilerType clang_type, swift::Demangle::Demangler &dem) {
+GetClangTypeNode(CompilerType clang_type, swift::Demangle::Demangler &dem,
+                 SwiftASTContext *swift_ast_context) {
+  using namespace swift;
   using namespace swift::Demangle;
-  Node::Kind kind;
+  Node::Kind kind = Node::Kind::Structure;
   llvm::StringRef swift_name;
   llvm::StringRef module_name = swift::MANGLING_MODULE_OBJC;
   CompilerType pointee;
   if (clang_type.IsPointerType(&pointee))
     clang_type = pointee;
-    
+  llvm::StringRef clang_name = clang_type.GetTypeName().GetStringRef();
+  // FIXME: Create a higher-level entry point for this by generalizing ClangAdapter.
+  struct Adapter {
+    struct Context {
+      swift::ASTContext *AST;
+      llvm::StringRef getSwiftName(swift::KnownFoundationEntity entity) {
+        if (AST)
+          return AST->getSwiftName(entity);
+        return "<error: no Swift context>";
+      }
+      Context(swift::ASTContext *ctx) : AST(ctx){};
+    } SwiftContext;
+    Adapter(swift::ASTContext *ctx) : SwiftContext(ctx){};
+  } Impl(swift_ast_context ? swift_ast_context->GetASTContext() : nullptr);
+#define MAP_TYPE(C_TYPE_NAME, C_TYPE_KIND, C_TYPE_BITWIDTH, SWIFT_MODULE_NAME, \
+                 SWIFT_TYPE_NAME, CAN_BE_MISSING, C_NAME_MAPPING)              \
+  if (clang_name.equals(C_TYPE_NAME)) {                                        \
+    module_name = (SWIFT_MODULE_NAME);                                         \
+    swift_name = (SWIFT_TYPE_NAME);                                            \
+  } else
+#include "swift/../../lib/ClangImporter/MappedTypes.def"
+#undef MAP_TYPE
+  // The last dangling else in the macro is for this switch.
   switch (clang_type.GetTypeClass()) {
   case eTypeClassClass:
   case eTypeClassObjCObjectPointer:
+  case eTypeClassObjCInterface:
+    // Special cases for CF-bridged classes. (Better way to do this by
+    // inspecting the clang:Type?)
+    if (clang_name != "NSNumber" && clang_name != "NSValue")
+      kind = Node::Kind::Class;
     // Objective-C objects are first-class entities, not pointers.
-    kind = Node::Kind::Class;
     pointee = {};
     break;
   case eTypeClassBuiltin: 
     kind = Node::Kind::Structure;
     // Ask ClangImporter about the builtin type's Swift name.
     if (auto *ts = llvm::cast<TypeSystemClang>(clang_type.GetTypeSystem())) {
-      if (clang_type == ts->GetPointerSizedIntType(true)) {
+      if (clang_type == ts->GetPointerSizedIntType(true))
         swift_name = "Int";
-        break;
-      }
-      if (clang_type == ts->GetPointerSizedIntType(false)) {
+      else if (clang_type == ts->GetPointerSizedIntType(false))
         swift_name = "UInt";
-        break;
-      }
-      swift_name = swift::importer::getClangTypeNameForOmission(
-                       ts->getASTContext(), ClangUtil::GetQualType(clang_type))
-                       .Name;
+      else
+        swift_name =
+            swift::importer::getClangTypeNameForOmission(
+                ts->getASTContext(), ClangUtil::GetQualType(clang_type))
+                .Name;
       module_name = swift::STDLIB_NAME;
     }
     break;
-  default:
-    kind = Node::Kind::Structure;
+  case eTypeClassArray: {
+    // Ideally we would refactor ClangImporter::ImportType to use an
+    // abstract TypeBuilder and reuse it here.
+    auto *array_type = llvm::dyn_cast<clang::ConstantArrayType>(
+        ClangUtil::GetQualType(clang_type).getTypePtr());
+    if (!array_type)
+      break;
+    auto elem_type = array_type->getElementType();
+    auto size = array_type->getSize().getZExtValue();
+    if (size > 4096)
+      break;
+    auto *tuple = dem.createNode(Node::Kind::Tuple);
+    NodePointer element_type = GetClangTypeNode(
+        {clang_type.GetTypeSystem(), elem_type.getAsOpaquePtr()}, dem,
+        swift_ast_context);
+    for (unsigned i = 0; i < size; ++i) {
+      NodePointer tuple_element = dem.createNode(Node::Kind::TupleElement);
+      NodePointer type = dem.createNode(Node::Kind::Type);
+      type->addChild(element_type, dem);
+      tuple_element->addChild(type, dem);
+      tuple->addChild(tuple_element, dem);
+    }
+    return tuple;
   }
-  NodePointer structure = dem.createNode(kind);
+  case eTypeClassTypedef:
+    kind = Node::Kind::TypeAlias;
+    pointee = {};
+    break;
+  default:
+    break;
+  }
   NodePointer module =
       dem.createNodeWithAllocatedText(Node::Kind::Module, module_name);
-  structure->addChild(module, dem);
   NodePointer identifier = dem.createNodeWithAllocatedText(
       Node::Kind::Identifier, swift_name.empty()
-                                  ? clang_type.GetTypeName().GetStringRef()
+                                  ? clang_name
                                   : swift_name);
-  structure->addChild(identifier, dem);
-  return pointee ? GetPointerTo(dem, structure) : structure;
+  NodePointer nominal = dem.createNode(kind);
+  nominal->addChild(module, dem);
+  nominal->addChild(identifier, dem);
+  return pointee ? GetPointerTo(dem, nominal) : nominal;
 }
 
 /// \return the child of the \p Type node.
@@ -269,28 +378,39 @@ ResolveTypeAlias(SwiftASTContext *module_holder,
   return {n, {}};
 }
 
-std::string
-TypeSystemSwiftTypeRef::GetTupleElementName(lldb::opaque_compiler_type_t type,
-                                            size_t idx) {
+llvm::Optional<TypeSystemSwift::TupleElement>
+TypeSystemSwiftTypeRef::GetTupleElement(lldb::opaque_compiler_type_t type,
+                                        size_t idx) {
+  TupleElement result;
   using namespace swift::Demangle;
   Demangler dem;
   NodePointer node = TypeSystemSwiftTypeRef::DemangleCanonicalType(dem, type);
   if (!node || node->getKind() != Node::Kind::Tuple)
-    return "";
+    return {};
   if (node->getNumChildren() < idx)
-    return "";
+    return {};
   NodePointer child = node->getChild(idx);
   if (child->getNumChildren() != 1 &&
       child->getKind() != Node::Kind::TupleElement)
-    return "";
-  for (NodePointer name : *child) {
-    if (name->getKind() != Node::Kind::TupleElementName)
-      continue;
-    return name->getText().str();
+    return {};
+  for (NodePointer n : *child) {
+    switch (n->getKind()) {
+    case Node::Kind::Type:
+      result.element_type = RemangleAsType(dem, n);
+      break;
+    case Node::Kind::TupleElementName:
+      result.element_name = ConstString(n->getText());
+      break;
+    default:
+      break;
+    }
   }
-  std::string name;
-  llvm::raw_string_ostream(name) << idx;
-  return name;
+  if (!result.element_name) {
+    std::string name;
+    llvm::raw_string_ostream(name) << idx;
+    result.element_name = ConstString(name);
+  }
+  return result;
 }
 
 swift::Demangle::NodePointer TypeSystemSwiftTypeRef::Transform(
@@ -433,7 +553,7 @@ GetCanonicalNode(SwiftASTContext *module_holder,
     case Node::Kind::TypeAlias: {
       auto node_clangtype = ResolveTypeAlias(module_holder, dem, node);
       if (CompilerType clang_type = node_clangtype.second)
-        return GetClangTypeNode(clang_type, dem);
+        return GetClangTypeNode(clang_type, dem, module_holder);
       if (node_clangtype.first)
         return node_clangtype.first;
       return node;
@@ -834,6 +954,12 @@ static uint32_t collectTypeInfo(SwiftASTContext *module_holder,
     if ((type_class & eTypeClassEnumeration)) {
       swift_flags &= ~eTypeIsStructUnion;
       swift_flags |= eTypeIsEnumeration | eTypeHasChildren | eTypeHasValue;
+      return;
+    }
+    if ((type_class & eTypeClassBuiltin)) {
+      swift_flags &= ~eTypeIsStructUnion;
+      swift_flags |= collectTypeInfo(
+          module_holder, dem, GetClangTypeNode(clang_type, dem, module_holder));
       return;
     }
   };
@@ -1276,11 +1402,60 @@ template <> bool Equivalent<uint32_t>(uint32_t l, uint32_t r) {
   return l == r;
 }
 
+/// Determine wether this demangle tree contains a sugar () node.
+static bool ContainsSugaredParen(swift::Demangle::NodePointer node) {
+  if (!node)
+    return false;
+
+  if (node->getKind() == swift::Demangle::Node::Kind::SugaredParen)
+    return true;
+
+  for (swift::Demangle::NodePointer child : *node)
+    if (ContainsSugaredParen(child))
+      return true;
+
+  return false;
+}
+  
 /// Compare two swift types from different type systems by comparing their
 /// (canonicalized) mangled name.
 template <> bool Equivalent<CompilerType>(CompilerType l, CompilerType r) {
-  return l.GetMangledTypeName() == r.GetMangledTypeName();
-} // namespace
+  ConstString lhs = l.GetMangledTypeName();
+  ConstString rhs = r.GetMangledTypeName();
+  if (lhs != rhs) {
+    // Failure. Dump it for easier debugging.
+    llvm::dbgs() << "TypeSystemSwiftTypeRef diverges from SwiftASTContext: "
+                 << lhs.GetStringRef() << " != " << rhs.GetStringRef() << "\n";
+  }
+  if (lhs == ConstString("$sSiD") && rhs == ConstString("$sSuD"))
+    return true;
+  // Ignore missing sugar.
+  swift::Demangle::Demangler dem;
+  auto l_node = GetDemangledType(dem, lhs.GetStringRef());
+  auto r_node = GetDemangledType(dem, rhs.GetStringRef());
+  if (ContainsUnresolvedTypeAlias(r_node) ||
+      ContainsGenericTypeParameter(r_node) || ContainsSugaredParen(r_node))
+    return true;
+  if (swift::Demangle::mangleNode(
+          TypeSystemSwiftTypeRef::CanonicalizeSugar(dem, l_node)) ==
+      swift::Demangle::mangleNode(
+          TypeSystemSwiftTypeRef::CanonicalizeSugar(dem, r_node)))
+    return true;
+
+  // SwiftASTContext hardcodes some less-precise types.
+  if (rhs.GetStringRef().equals("$sBpD"))
+    return true;
+
+  // If the type is a Clang-imported type ignore mismatches. Since we
+  // don't have any visibility into Swift overlays of SDK modules we
+  // can only present the underlying Clang type. However, we can
+  // still swiftify that type later for printing.
+  if (auto *ts =
+          llvm::dyn_cast_or_null<TypeSystemSwiftTypeRef>(l.GetTypeSystem()))
+    if (ts->IsImportedType(l.GetOpaqueQualType(), nullptr))
+      return true;
+  return lhs == rhs;
+}
 /// This one is particularly taylored for GetTypeName() and
 /// GetDisplayTypeName().
 ///
@@ -1391,15 +1566,21 @@ TypeSystemSwiftTypeRef::RemangleAsType(swift::Demangle::Demangler &dem,
                                        swift::Demangle::NodePointer node) {
   if (!node)
     return {};
-  assert(node->getKind() == Node::Kind::Type && "expected type node");
 
   using namespace swift::Demangle;
+  assert(node->getKind() == Node::Kind::Type && "expected type node");
   auto global = dem.createNode(Node::Kind::Global);
   auto type_mangling = dem.createNode(Node::Kind::TypeMangling);
-  global->addChild(type_mangling, dem);
   type_mangling->addChild(node, dem);
+  global->addChild(type_mangling, dem);
   ConstString mangled_element(mangleNode(global));
   return GetTypeFromMangledTypename(mangled_element);
+}
+
+CompilerType TypeSystemSwiftTypeRef::RemangleAsSwiftifiedType(
+    swift::Demangle::Demangler &Dem, swift::Demangle::NodePointer node) {
+  // DELETE THIS
+  return RemangleAsType(Dem, GetNodeForPrintingImpl(Dem, node, true));
 }
 
 swift::Demangle::NodePointer TypeSystemSwiftTypeRef::DemangleCanonicalType(
@@ -1669,6 +1850,12 @@ uint32_t TypeSystemSwiftTypeRef::GetTypeInfo(
     NodePointer node = dem.demangleSymbol(AsMangledName(type));
     return collectTypeInfo(m_swift_ast_context, dem, node);
   };
+#ifndef NDEBUG
+  // This type has special behavior hardcoded in the Swift frontend
+  // that we can't reproduce here.
+  if (StringRef(AsMangledName(type)).equals("$sSo18NSNotificationNameaD"))
+    return impl();
+#endif
   VALIDATE_AND_RETURN(impl, GetTypeInfo, type,
                       (ReconstructType(type), nullptr));
 }
@@ -1715,21 +1902,6 @@ TypeSystemSwiftTypeRef::GetArrayElementType(opaque_compiler_type_t type,
   };
   VALIDATE_AND_RETURN(impl, GetArrayElementType, type,
                       (ReconstructType(type), nullptr, exe_scope));
-}
-
-/// Determine wether this demangle tree contains an unresolved type alias.
-static bool ContainsUnresolvedTypeAlias(swift::Demangle::NodePointer node) {
-  if (!node)
-    return false;
-
-  if (node->getKind() == swift::Demangle::Node::Kind::TypeAlias)
-    return true;
-
-  for (swift::Demangle::NodePointer child : *node)
-    if (ContainsUnresolvedTypeAlias(child))
-      return true;
-
-  return false;
 }
 
 CompilerType
@@ -1907,6 +2079,19 @@ CompilerType TypeSystemSwiftTypeRef::GetFieldAtIndex(
       ReconstructType(type), idx, name, bit_offset_ptr, bitfield_bit_size_ptr,
       is_bitfield_ptr);
 }
+
+static swift::Demangle::NodePointer
+GetClangTypeTypeNode(TypeSystemSwiftTypeRef &ts,
+                     swift::Demangle::Demangler &dem, CompilerType clang_type,
+                     SwiftASTContext *swift_ast_context) {
+  assert(llvm::isa<TypeSystemClang>(clang_type.GetTypeSystem()) &&
+         "expected a clang type");
+  using namespace swift::Demangle;
+  NodePointer type = dem.createNode(Node::Kind::Type);
+  type->addChild(GetClangTypeNode(clang_type, dem, swift_ast_context), dem);
+  return type;
+}
+
 CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
     opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
     bool transparent_pointers, bool omit_empty_base_classes,
@@ -1915,12 +2100,179 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
     uint32_t &child_bitfield_bit_size, uint32_t &child_bitfield_bit_offset,
     bool &child_is_base_class, bool &child_is_deref_of_parent,
     ValueObject *valobj, uint64_t &language_flags) {
-  return m_swift_ast_context->GetChildCompilerTypeAtIndex(
-      ReconstructType(type), exe_ctx, idx, transparent_pointers,
-      omit_empty_base_classes, ignore_array_bounds, child_name, child_byte_size,
-      child_byte_offset, child_bitfield_bit_size, child_bitfield_bit_offset,
-      child_is_base_class, child_is_deref_of_parent, valobj, language_flags);
+  auto fallback = [&]() -> CompilerType {
+    LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
+              "Had to engage SwiftASTContext fallback for type %s.",
+              AsMangledName(type));
+    return m_swift_ast_context->GetChildCompilerTypeAtIndex(
+        ReconstructType(type), exe_ctx, idx, transparent_pointers,
+        omit_empty_base_classes, ignore_array_bounds, child_name,
+        child_byte_size, child_byte_offset, child_bitfield_bit_size,
+        child_bitfield_bit_offset, child_is_base_class,
+        child_is_deref_of_parent, valobj, language_flags);
+  };
+  auto impl = [&]() -> CompilerType {
+    ExecutionContextScope *exe_scope = nullptr;
+    if (exe_ctx)
+      exe_scope = exe_ctx->GetBestExecutionContextScope();
+    if (exe_scope) {
+      if (auto *runtime =
+            SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
+        if (CompilerType result = runtime->GetChildCompilerTypeAtIndex(
+                {this, type}, idx, transparent_pointers,
+                omit_empty_base_classes, ignore_array_bounds, child_name,
+                child_byte_size, child_byte_offset, child_bitfield_bit_size,
+                child_bitfield_bit_offset, child_is_base_class,
+                child_is_deref_of_parent, valobj, language_flags)) {
+          // This type is treated specially by ClangImporter.  It's really a
+          // typedef to NSString *, but ClangImporter introduces an extra
+          // layer of indirection that we simulate here.
+          if (llvm::StringRef(AsMangledName(type))
+                  .endswith("sSo18NSNotificationNameaD"))
+            return GetTypeFromMangledTypename(ConstString("$sSo8NSStringCD"));
+          // FIXME: Private discriminators come out in a different format.
+          if (result.GetMangledTypeName().GetStringRef().count('$') > 1)
+            return fallback();
+          return result;
+        }
+    }
+    // Clang types can be resolved even without a process.
+    bool is_signed;
+    if (CompilerType clang_type = GetAsClangTypeOrNull(type)) {
+      if (clang_type.IsEnumerationType(is_signed) && idx == 0)
+        // C enums get imported into Swift as structs with a "rawValue" field.
+        if (auto *ts =
+                llvm::dyn_cast<TypeSystemClang>(clang_type.GetTypeSystem()))
+          if (clang::EnumDecl *enum_decl = ts->GetAsEnumDecl(clang_type)) {
+            swift::Demangle::Demangler dem;
+            CompilerType raw_value =
+                CompilerType(ts, enum_decl->getIntegerType().getAsOpaquePtr());
+            child_name = "rawValue";
+            auto bit_size = raw_value.GetBitSize(
+                exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr);
+            child_byte_size = bit_size.getValueOr(0) / 8;
+            child_byte_offset = 0;
+            child_bitfield_bit_size = 0;
+            child_bitfield_bit_offset = 0;
+            child_is_base_class = false;
+            child_is_deref_of_parent = false;
+            language_flags = 0;
+            return RemangleAsType(dem,
+                                  GetClangTypeTypeNode(*this, dem, raw_value,
+                                                       m_swift_ast_context));
+          }
+      // Otherwise defer to TypeSystemClang.
+      //
+      // Swift skips bitfields when counting children. Unfortunately
+      // this means we need to do this inefficient linear search here.
+      CompilerType clang_child_type;
+      for (size_t clang_idx = 0, swift_idx = 0; swift_idx <= idx; ++clang_idx) {
+        child_bitfield_bit_size = 0;
+        child_bitfield_bit_offset = 0;
+        clang_child_type = clang_type.GetChildCompilerTypeAtIndex(
+            exe_ctx, clang_idx, transparent_pointers, omit_empty_base_classes,
+            ignore_array_bounds, child_name, child_byte_size, child_byte_offset,
+            child_bitfield_bit_size, child_bitfield_bit_offset,
+            child_is_base_class, child_is_deref_of_parent, valobj,
+            language_flags);
+        if (!child_bitfield_bit_size && !child_bitfield_bit_offset)
+          ++swift_idx;
+        // FIXME: Why is this necessary?
+        if (clang_child_type.IsTypedefType() &&
+            clang_child_type.GetTypeName() ==
+                clang_child_type.GetTypedefedType().GetTypeName())
+          clang_child_type = clang_child_type.GetTypedefedType();
+      }
+      if (clang_child_type) {
+        std::string prefix;
+        swift::Demangle::Demangler dem;
+        swift::Demangle::NodePointer node = GetClangTypeTypeNode(
+            *this, dem, clang_child_type, m_swift_ast_context);
+        switch (node->getChild(0)->getKind()) {
+        case swift::Demangle::Node::Kind::Class:
+            prefix = "ObjectiveC.";
+          break;
+        default:
+          break;
+        }
+        child_name = prefix + child_name;
+        return RemangleAsType(dem, node);
+      }
+    }
+    // FIXME: SwiftASTContext can sometimes find more Clang types because it
+    // imports Clang modules from source. We should be able to replicate this
+    // and remove this fallback.
+    return fallback();
+
+    if (!exe_scope)
+      LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
+                "Cannot compute the children of type %s without an execution "
+                "context.",
+                AsMangledName(type));
+    else
+      LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
+                "Couldn't compute size of type %s without a process.",
+                AsMangledName(type));
+    return {};
+  };
+  // Skip validation when there is no process, because then we also
+  // don't have a runtime.
+  if (!exe_ctx)
+    return impl();
+  ExecutionContextScope *exe_scope = exe_ctx->GetBestExecutionContextScope();
+  if (!exe_scope)
+    return impl();
+  auto *runtime = SwiftLanguageRuntime::Get(exe_scope->CalculateProcess());
+  if (!runtime)
+    return impl();
+  // FIXME:
+  // No point comparing the results if the reflection data has more
+  // information.  There's a nasty chicken & egg problem buried here:
+  // Because the API deals out an index into a list of children we
+  // can't mix&match between the two typesystems if there is such a
+  // divergence. We'll need to replace all calls at once.
+  if (m_swift_ast_context->GetNumFields(ReconstructType(type)) <
+      runtime->GetNumChildren({this, type}, valobj).getValueOr(0))
+    return fallback();
+
+#ifndef NDEBUG
+  std::string ast_child_name;
+  uint32_t ast_child_byte_size;
+  int32_t ast_child_byte_offset;
+  uint32_t ast_child_bitfield_bit_size;
+  uint32_t ast_child_bitfield_bit_offset;
+  bool ast_child_is_base_class;
+  bool ast_child_is_deref_of_parent;
+  uint64_t ast_language_flags;
+  auto defer = llvm::make_scope_exit([&] {
+    llvm::StringRef suffix(ast_child_name);
+    if (suffix.consume_front("__ObjC."))
+      ast_child_name = suffix.str();
+    assert(
+        (llvm::StringRef(child_name).contains('.') ||
+         Equivalent(child_name, ast_child_name)) &&
+        (Equivalent(llvm::Optional<uint64_t>(child_byte_size),
+                    llvm::Optional<uint64_t>(ast_child_byte_size)) ||
+         ast_language_flags) &&
+        Equivalent(llvm::Optional<uint64_t>(child_byte_offset),
+                   llvm::Optional<uint64_t>(ast_child_byte_offset)) &&
+        Equivalent(child_bitfield_bit_offset, ast_child_bitfield_bit_offset) &&
+        Equivalent(child_bitfield_bit_size, ast_child_bitfield_bit_size) &&
+        Equivalent(child_is_base_class, ast_child_is_base_class) &&
+        Equivalent(child_is_deref_of_parent, ast_child_is_deref_of_parent) &&
+        Equivalent(language_flags, ast_language_flags) &&
+        "TypeSystemSwiftTypeRef diverges from SwiftASTContext");
+  });
+#endif
+  VALIDATE_AND_RETURN(
+      impl, GetChildCompilerTypeAtIndex, type,
+      (ReconstructType(type), exe_ctx, idx, transparent_pointers,
+       omit_empty_base_classes, ignore_array_bounds, ast_child_name,
+       ast_child_byte_size, ast_child_byte_offset, ast_child_bitfield_bit_size,
+       ast_child_bitfield_bit_offset, ast_child_is_base_class,
+       ast_child_is_deref_of_parent, valobj, ast_language_flags));
 }
+
 uint32_t
 TypeSystemSwiftTypeRef::GetIndexOfChildWithName(opaque_compiler_type_t type,
                                                 const char *name,
@@ -1992,8 +2344,39 @@ bool TypeSystemSwiftTypeRef::IsImportedType(opaque_compiler_type_t type,
         *original_type = clang_type->GetForwardCompilerType();
     return true;
   };
+  // Dont compare the results if there is no ClangImporter in the SwiftASTContext.
+  const auto &props = ModuleList::GetGlobalModuleListProperties();
+  if (!props.GetUseSwiftClangImporter())
+    return impl();
+
   VALIDATE_AND_RETURN(impl, IsImportedType, type,
                       (ReconstructType(type), nullptr));
+}
+
+bool TypeSystemSwiftTypeRef::IsExistentialType(
+    lldb::opaque_compiler_type_t type) {
+  using namespace swift::Demangle;
+  Demangler dem;
+  NodePointer node = DemangleCanonicalType(dem, type);
+  if (!node || node->getNumChildren() != 1)
+    return false;
+  switch (node->getKind()) {
+  case Node::Kind::Protocol:
+  case Node::Kind::ProtocolList:
+    return true;
+  default:
+    return false;
+  }
+}
+
+CompilerType TypeSystemSwiftTypeRef::GetRawPointerType() {
+    using namespace swift::Demangle;
+    Demangler dem;
+    NodePointer raw_ptr = dem.createNode(Node::Kind::BuiltinTypeName,
+                                         swift::BUILTIN_TYPE_NAME_RAWPOINTER);
+    NodePointer node = dem.createNode(Node::Kind::Type);
+    node->addChild(raw_ptr, dem);
+    return RemangleAsType(dem, node);
 }
 
 CompilerType TypeSystemSwiftTypeRef::GetErrorType() {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -258,9 +258,15 @@ public:
       bool print_help_if_available, bool print_extensions_if_available,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
 
-  /// Return the nth tuple element's name, if it has one.
-  std::string GetTupleElementName(lldb::opaque_compiler_type_t type,
-                                  size_t idx);
+
+  /// Return the nth tuple element's type and name, if it has one.
+  llvm::Optional<TupleElement>
+  GetTupleElement(lldb::opaque_compiler_type_t type, size_t idx);
+
+  /// Get the Swift raw pointer type.
+  CompilerType GetRawPointerType();
+  /// Determine whether \p type is a protocol.
+  bool IsExistentialType(lldb::opaque_compiler_type_t type);
 
   /// Recursively transform the demangle tree starting a \p node by
   /// doing a post-order traversal and replacing each node with
@@ -270,6 +276,11 @@ public:
       swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
       std::function<swift::Demangle::NodePointer(swift::Demangle::NodePointer)>
           fn);
+
+  /// Canonicalize Array, Dictionary and Optional to their sugared form.
+  static swift::Demangle::NodePointer
+  CanonicalizeSugar(swift::Demangle::Demangler &dem,
+                    swift::Demangle::NodePointer node);
 
   /// Return the canonicalized Demangle tree for a Swift mangled type name.
   static swift::Demangle::NodePointer
@@ -285,6 +296,12 @@ public:
   /// and create a CompilerType from it.
   CompilerType RemangleAsType(swift::Demangle::Demangler &dem,
                               swift::Demangle::NodePointer node);
+
+  /// Create a CompilerType after applying Swiftification. This is
+  /// meant to be used for a demenagle tree generated from a \p
+  /// swift::reflection::TypeRef.
+  CompilerType RemangleAsSwiftifiedType(swift::Demangle::Demangler &Dem,
+                                        swift::Demangle::NodePointer node);
 
 private:
   /// Helper that creates an AST type from \p type.

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -213,6 +213,23 @@ public:
     return {};
   }
 
+  bool IsTaggedPointer(lldb::addr_t addr, CompilerType type) {
+    STUB_LOG();
+    return false;
+  }
+
+  std::pair<lldb::addr_t, bool> FixupPointerValue(lldb::addr_t addr,
+                                                  CompilerType type) {
+    STUB_LOG();
+    return {addr, false};
+  }
+
+  lldb::addr_t FixupAddress(lldb::addr_t addr, CompilerType type,
+                            Status &error) {
+    STUB_LOG();
+    return addr;
+  }
+
   SwiftLanguageRuntime::MetadataPromiseSP
   GetMetadataPromise(lldb::addr_t addr, ValueObject &for_object) {
     STUB_LOG();
@@ -230,6 +247,24 @@ public:
                                                    ValueObject *instance,
                                                    llvm::StringRef member_name,
                                                    Status *error) {
+    STUB_LOG();
+    return {};
+  }
+
+  llvm::Optional<unsigned> GetNumChildren(CompilerType type,
+                                          ValueObject *valobj) {
+    STUB_LOG();
+    return {};
+  }
+
+  CompilerType GetChildCompilerTypeAtIndex(
+      CompilerType type, size_t idx, bool transparent_pointers,
+      bool omit_empty_base_classes, bool ignore_array_bounds,
+      std::string &child_name, uint32_t &child_byte_size,
+      int32_t &child_byte_offset, uint32_t &child_bitfield_bit_size,
+      uint32_t &child_bitfield_bit_offset, bool &child_is_base_class,
+      bool &child_is_deref_of_parent, ValueObject *valobj,
+      uint64_t &language_flags) {
     STUB_LOG();
     return {};
   }
@@ -2072,6 +2107,22 @@ SwiftLanguageRuntime::FixUpDynamicType(const TypeAndOrName &type_and_or_name,
   FORWARD(FixUpDynamicType, type_and_or_name, static_value);
 }
 
+bool SwiftLanguageRuntime::IsTaggedPointer(lldb::addr_t addr,
+                                           CompilerType type) {
+  FORWARD(IsTaggedPointer, addr, type);
+}
+
+std::pair<lldb::addr_t, bool>
+SwiftLanguageRuntime::FixupPointerValue(lldb::addr_t addr, CompilerType type) {
+  FORWARD(FixupPointerValue, addr, type);
+}
+
+lldb::addr_t SwiftLanguageRuntime::FixupAddress(lldb::addr_t addr,
+                                                CompilerType type,
+                                                Status &error) {
+  FORWARD(FixupAddress, addr, type, error);
+}
+
 SwiftLanguageRuntime::MetadataPromiseSP
 SwiftLanguageRuntime::GetMetadataPromise(lldb::addr_t addr,
                                          ValueObject &for_object) {
@@ -2086,6 +2137,27 @@ llvm::Optional<uint64_t> SwiftLanguageRuntime::GetMemberVariableOffset(
     CompilerType instance_type, ValueObject *instance,
     llvm::StringRef member_name, Status *error) {
   FORWARD(GetMemberVariableOffset, instance_type, instance, member_name, error);
+}
+
+llvm::Optional<unsigned>
+SwiftLanguageRuntime::GetNumChildren(CompilerType type, ValueObject *valobj) {
+  FORWARD(GetNumChildren, type, valobj);
+}
+
+CompilerType SwiftLanguageRuntime::GetChildCompilerTypeAtIndex(
+    CompilerType type, size_t idx, bool transparent_pointers,
+    bool omit_empty_base_classes, bool ignore_array_bounds,
+    std::string &child_name, uint32_t &child_byte_size,
+    int32_t &child_byte_offset, uint32_t &child_bitfield_bit_size,
+    uint32_t &child_bitfield_bit_offset, bool &child_is_base_class,
+    bool &child_is_deref_of_parent, ValueObject *valobj,
+    uint64_t &language_flags) {
+  FORWARD(GetChildCompilerTypeAtIndex, type, idx, transparent_pointers,
+          omit_empty_base_classes, ignore_array_bounds, child_name,
+          child_byte_size, child_byte_offset,
+          child_bitfield_bit_size, child_bitfield_bit_offset,
+          child_is_base_class, child_is_deref_of_parent, valobj,
+          language_flags);
 }
 
 bool SwiftLanguageRuntime::GetObjectDescription(Stream &str,

--- a/lldb/test/API/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
@@ -77,6 +77,7 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('main.swift'))
+        self.expect("expr union", substrs=["(DoubleLongUnion)", "long_val = 42"])
         lldbutil.check_variable(self,
                                 target.FindFirstGlobalVariable("pureSwift"),
                                 value="42")

--- a/lldb/test/API/lang/swift/enum_tagged/main.swift
+++ b/lldb/test/API/lang/swift/enum_tagged/main.swift
@@ -37,7 +37,7 @@ struct A {
 
 let x = A(x: 42)
 let y = A(y: 39)
-print("!")  //%self.expect("frame var -d run-target -- x", substrs=['(xx = 42)'])
-            //%self.expect("expr -d run-target -- x", substrs=['(xx = 42)'])
-            //%self.expect("frame var -d run-target -- y", substrs=['(yy = 39)'])
-            //%self.expect("expr -d run-target -- y", substrs=['(yy = 39)'])
+print("!")  //% self.expect("frame var -d run-target -- x", substrs=['(xx = 42)'])
+            //% self.expect("expr -d run-target -- x", substrs=['(xx = 42)'])
+            //% self.expect("frame var -d run-target -- y", substrs=['(yy = 39)'])
+            //% self.expect("expr -d run-target -- y", substrs=['(yy = 39)'])

--- a/lldb/test/API/lang/swift/foundation_value_types/notification/main.swift
+++ b/lldb/test/API/lang/swift/foundation_value_types/notification/main.swift
@@ -13,11 +13,11 @@ import Foundation
 
 func main() {
   var notification = Notification(name: Notification.Name(rawValue: "MyNotification"), object: nil, userInfo: [:])
-  print("done!") //% self.expect("frame variable notification", substrs=['name = "MyNotification"', 'object = nil', 'userInfo = 0 key/value pairs'])
-   //% self.expect("expression -d run -- notification", substrs=['name = "MyNotification"', 'object = nil', 'userInfo = 0 key/value pairs'])
+  print("done!") //% self.expect("frame variable -d run -- notification", substrs=['name = ', '"MyNotification"', 'object = nil', 'userInfo = 0 key/value pairs'])
+   //% self.expect("expression -d run -- notification", substrs=['name = ', '"MyNotification"', 'object = nil', 'userInfo = 0 key/value pairs'])
 }
 
 var g_notification = Notification(name: Notification.Name(rawValue: "MyNotification"), object: nil, userInfo: [:])
 
-main() //% self.expect("target variable g_notification", substrs=['name = "MyNotification"', 'object = nil', 'userInfo = 0 key/value pairs'])
-       //% self.expect("expression -d run -- g_notification", substrs=['name = "MyNotification"', 'object = nil', 'userInfo = 0 key/value pairs'])
+main() //% self.expect("target variable -d run g_notification", substrs=['name = ', '"MyNotification"', 'object = nil', 'userInfo = 0 key/value pairs'])
+       //% self.expect("expression -d run -- g_notification", substrs=['name = ', '"MyNotification"', 'object = nil', 'userInfo = 0 key/value pairs'])

--- a/lldb/test/API/lang/swift/generic_self/main.swift
+++ b/lldb/test/API/lang/swift/generic_self/main.swift
@@ -38,7 +38,6 @@ struct S<T> {
     stop()
     //% self.expect('expr -d run -- self', substrs=['(a.S<Int>)','a = 12'])
     //% self.expect('fr v -d run -- self', substrs=['(a.S<Int>)','a = 12'])
-    //% self.expect('fr v -d no-dynamic-values -- self', substrs=['(a.S<T>)','000c'])
     stop()
   }
 }

--- a/lldb/test/API/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
+++ b/lldb/test/API/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
@@ -45,4 +45,4 @@ class TestSwiftCGImportedTypes(TestBase):
         self.assertTrue(
             x_native.IsValid(),
             "Got valid native from cgrect.origin.x")
-        self.assertTrue(x_native.GetValue() == "10", "Value of x is correct")
+        self.assertEquals(x_native.GetValue(), "10", "Value of x is correct")

--- a/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
+++ b/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
@@ -28,6 +28,7 @@ class TestSwiftReferenceStorageTypes(TestBase):
         TestBase.setUp(self)
 
     @decorators.skipIf(archs=['ppc64le']) #SR-10215
+    @skipIfLinux # rdar://problem/71506440
     @swiftTest
     def test_swift_reference_storage_types(self):
         """Test weak, unowned and unmanaged types"""

--- a/lldb/test/API/lang/swift/unknown_reference/main.swift
+++ b/lldb/test/API/lang/swift/unknown_reference/main.swift
@@ -40,6 +40,7 @@ struct S {
   unowned var objc_ref : ObjCClass
 
   func f() {
+    use(self.objc_ref)
     use(self.pure_ref) // break here
   }
 }
@@ -48,4 +49,3 @@ let pure = PureClass()
 let objc = ObjCClass()
 
 S(pure_ref: pure, objc_ref: objc).f()
-

--- a/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
+++ b/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
@@ -65,21 +65,21 @@ class TestSwiftProtocolTypes(TestBase):
                              '(Builtin.RawPointer) payload_data_0 = 0x',
                              '(Builtin.RawPointer) payload_data_1 = 0x',
                              '(Builtin.RawPointer) payload_data_2 = 0x',
-                             '(Any.Type) instance_type = 0x',
-                             '(Builtin.RawPointer) witness_table_PointUtils = 0x'])
-
+                             '(Any.Type) metadata = 0x',
+                             '(Builtin.RawPointer) wtable = 0x'])
+ 
         self.expect("frame variable --dynamic-type run-target loc2d",
                     substrs=['Point2D) loc2d =',
                              'x = 1.25', 'y = 2.5'])
-
+ 
         self.expect("frame variable --raw-output --show-types loc3d",
                     substrs=['PointUtils) loc3d =',
                              '(Builtin.RawPointer) payload_data_0 = 0x',
                              '(Builtin.RawPointer) payload_data_1 = 0x',
                              '(Builtin.RawPointer) payload_data_2 = 0x',
-                             '(Any.Type) instance_type = 0x',
-                             '(Builtin.RawPointer) witness_table_PointUtils = 0x'])
-
+                             '(Any.Type) metadata = 0x',
+                             '(Builtin.RawPointer) wtable = 0x'])
+ 
         self.expect(
             "frame variable --dynamic-type run-target loc3d",
             substrs=[
@@ -87,32 +87,33 @@ class TestSwiftProtocolTypes(TestBase):
                 'x = 1.25',
                 'y = 2.5',
                 'z = 1.25'])
-
+ 
         self.expect("expression --raw-output --show-types -- loc2d",
                     substrs=['PointUtils) $R',
                              '(Builtin.RawPointer) payload_data_0 = 0x',
                              '(Builtin.RawPointer) payload_data_1 = 0x',
                              '(Builtin.RawPointer) payload_data_2 = 0x',
-                             '(Any.Type) instance_type = 0x',
-                             '(Builtin.RawPointer) witness_table_PointUtils = 0x'])
-
+                             '(Any.Type) metadata = 0x',
+                             '(Builtin.RawPointer) wtable = 0x'])
+ 
         self.expect("expression --dynamic-type run-target -- loc2d",
                     substrs=['Point2D) $R',
                              'x = 1.25', 'y = 2.5'])
-
+ 
         self.expect("expression --raw-output --show-types -- loc3dCB",
                     substrs=['PointUtils & Swift.AnyObject) $R',
-                             '(Builtin.RawPointer) instance = 0x',
-                             '(Builtin.RawPointer) witness_table_PointUtils = 0x'])
-
+                             '(Builtin.RawPointer) object = 0x',
+                             '(Builtin.RawPointer) wtable = 0x'])
+ 
         self.expect("expression --dynamic-type run-target -- loc3dCB",
                     substrs=['Point3D) $R', 'x = 1.25', 'y = 2.5', 'z = 1.25'])
 
         self.expect("expression --raw-output --show-types -- loc3dSuper",
                     substrs=['(a.PointSuperclass & a.PointUtils) $R',
-                             '(a.PointSuperclass) instance = 0x',
-                             '(Swift.Int) superData = ',
-                             '(Builtin.RawPointer) witness_table_PointUtils = 0x'])
+#                             Only supported by SwiftASTContext and of little usefulness.
+#                             '(a.PointSuperclass) object = 0x',
+#                             '(Swift.Int) superData = ',
+                             '(Builtin.RawPointer) wtable = 0x'])
 
         self.expect("expression --dynamic-type run-target -- loc3dSuper",
                     substrs=['Point3D) $R', 'x = 1.25', 'y = 2.5', 'z = 1.25'])

--- a/lldb/test/Shell/Swift/Inputs/No.swiftmodule-ObjC.swift
+++ b/lldb/test/Shell/Swift/Inputs/No.swiftmodule-ObjC.swift
@@ -7,7 +7,7 @@ func f() {
   // CHECK-DAG: (size_t) ctype = 1024
   let ctype = size_t(1024)
   // This works as a Clang type via the Objective-C runtime.
-  // CHECK-DAG: (ObjCClass) object = 0x{{[0-9a-f]+}} {
+  // CHECK-DAG: object = 0x{{[0-9a-f]+}} Int32(1234)
   // FIXME: (ObjCClass) object = {{.*}}Hello from Objective-C!
   let object = ObjCClass()
   // The Objective-C runtime recognizes this as a tagged pointer.

--- a/lldb/test/Shell/Swift/No.swiftmodule-ObjC.test
+++ b/lldb/test/Shell/Swift/No.swiftmodule-ObjC.test
@@ -14,7 +14,7 @@
 
 breakpoint set -p "break here"
 run
-frame variable -d no-dynamic
+frame variable -d run
 frame variable object
 # FIXME: (fails creating the expression context)  frame variable -O object
 target var globalFloat

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -455,9 +455,12 @@ TEST_F(TestTypeSystemSwiftTypeRef, Tuple) {
                       b.Node(Node::Kind::TupleElementName, "z"), b.IntType())));
     CompilerType t = GetCompilerType(b.Mangle(n));
     lldb::opaque_compiler_type_t o = t.GetOpaqueQualType();
-    ASSERT_EQ(m_swift_ts.GetTupleElementName(o, 0), "x");
-    ASSERT_EQ(m_swift_ts.GetTupleElementName(o, 1), "1");
-    ASSERT_EQ(m_swift_ts.GetTupleElementName(o, 2), "z");
+    ASSERT_EQ(m_swift_ts.GetTupleElement(o, 0)->element_name.GetStringRef(), "x");
+    ASSERT_EQ(m_swift_ts.GetTupleElement(o, 1)->element_name.GetStringRef(), "1");
+    ASSERT_EQ(m_swift_ts.GetTupleElement(o, 2)->element_name.GetStringRef(), "z");
+    CompilerType int_type =
+        GetCompilerType(b.Mangle(b.GlobalTypeMangling(b.IntType())));
+    ASSERT_EQ(m_swift_ts.GetTupleElement(o, 2)->element_type, int_type);
   }
 }
 
@@ -556,4 +559,8 @@ TEST_F(TestTypeSystemSwiftTypeRef, ImportedType) {
     CompilerType type = GetCompilerType(b.Mangle(node));
     ASSERT_TRUE(m_swift_ts.IsImportedType(type.GetOpaqueQualType(), nullptr));
   }
+}
+
+TEST_F(TestTypeSystemSwiftTypeRef, RawPointer) {
+  ASSERT_EQ(m_swift_ts.GetRawPointerType().GetMangledTypeName(), "$sBpD");
 }


### PR DESCRIPTION
This patch is large, but hopefully we will be able to reuse most of the code for all other type query methods.