### PR TITLE
[lldb] Remove StridedRangeGenerator summary provider

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -581,29 +581,6 @@ bool lldb_private::formatters::swift::CountableClosedRange_SummaryProvider(
   return RangeFamily_SummaryProvider(valobj, stream, options, false);
 }
 
-bool lldb_private::formatters::swift::StridedRangeGenerator_SummaryProvider(
-    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  static ConstString g__bounds("_bounds");
-  static ConstString g__stride("_stride");
-
-  ValueObjectSP bounds_sp(valobj.GetChildMemberWithName(g__bounds, true));
-  ValueObjectSP stride_sp(valobj.GetChildMemberWithName(g__stride, true));
-
-  if (!bounds_sp || !stride_sp)
-    return false;
-
-  auto bounds_summary = bounds_sp->GetSummaryAsCString();
-  auto stride_summary = stride_sp->GetValueAsCString();
-
-  if (!bounds_summary || !bounds_summary[0] || !stride_summary ||
-      !stride_summary[0])
-    return false;
-
-  stream.Printf("(%s).by(%s)", bounds_summary, stride_summary);
-
-  return true;
-}
-
 bool lldb_private::formatters::swift::BuiltinObjC_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
   stream.Printf("0x%" PRIx64 " ", valobj.GetValueAsUnsigned(0));

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -88,9 +88,6 @@ bool ClosedRange_SummaryProvider(ValueObject &valobj, Stream &stream,
 bool CountableClosedRange_SummaryProvider(ValueObject &valobj, Stream &stream,
                                           const TypeSummaryOptions &options);
 
-bool StridedRangeGenerator_SummaryProvider(ValueObject &valobj, Stream &stream,
-                                           const TypeSummaryOptions &options);
-
 bool SIMDVector_SummaryProvider(ValueObject &valobj, Stream &stream,
                                 const TypeSummaryOptions &options);
 

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -537,12 +537,6 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       "Swift.CountableClosedRange summary provider",
       ConstString("Swift.CountableClosedRange<.+>$"), summary_flags, true);
 
-  AddCXXSummary(
-      swift_category_sp,
-      lldb_private::formatters::swift::StridedRangeGenerator_SummaryProvider,
-      "Swift.StridedRangeGenerator summary provider",
-      ConstString("Swift.StridedRangeGenerator<.+>$"), summary_flags, true);
-
   TypeSummaryImpl::Flags simd_summary_flags;
   simd_summary_flags.SetCascades(true)
       .SetDontShowChildren(true)


### PR DESCRIPTION
`StridedRangeGenerator` no longer exists in Swift.