### PR TITLE
[lldb] Remove NativeArray and replace with ContiguousArray

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -363,17 +363,15 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
 
   ExecutionContext exe_ctx(valobj.GetExecutionContextRef());
   ExecutionContextScope *exe_scope = exe_ctx.GetBestExecutionContextScope();
-  if (valobj_typename.startswith("Swift.NativeArray<")) {
+  if (valobj_typename.startswith("Swift.ContiguousArray<")) {
     // Swift.NativeArray
-    static ConstString g_buffer("_buffer");
-    static ConstString g_base("base");
-    static ConstString g_storage("storage");
-    static ConstString g_some("Some");
+    static ConstString g__buffer("_buffer");
+    static ConstString g__storage("_storage");
 
-    ValueObjectSP some_sp(valobj.GetNonSyntheticValue()->GetChildAtNamePath(
-        {g_buffer, g_base, g_storage, g_some}));
+    ValueObjectSP storage_sp(valobj.GetNonSyntheticValue()->GetChildAtNamePath(
+        {g__buffer, g__storage}));
 
-    if (!some_sp)
+    if (!storage_sp)
       return nullptr;
 
     CompilerType elem_type(
@@ -381,7 +379,7 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
 
     auto handler = std::unique_ptr<SwiftArrayBufferHandler>(
         new SwiftArrayNativeBufferHandler(
-            *some_sp, some_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS),
+            *storage_sp, storage_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS),
             elem_type));
     if (handler && handler->IsValid())
       return handler;
@@ -453,8 +451,6 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
           new SwiftArrayEmptyBufferHandler(elem_type));
     }
   }
-
-  return nullptr;
 }
 
 bool lldb_private::formatters::swift::Array_SummaryProvider(

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -290,8 +290,8 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                 ConstString("Swift._NSSwiftArray"), summary_flags, false);
   AddCXXSummary(swift_category_sp,
                 lldb_private::formatters::swift::Array_SummaryProvider,
-                "Swift.Array summary provider",
-                ConstString("^Swift.NativeArray<.+>$"), summary_flags, true);
+                "Swift.ContiguousArray summary provider",
+                ConstString("^Swift.ContiguousArray<.+>$"), summary_flags, true);
   AddCXXSummary(swift_category_sp,
                 lldb_private::formatters::swift::Array_SummaryProvider,
                 "Swift.ArraySlice summary provider",
@@ -346,8 +346,8 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   AddCXXSynthetic(
       swift_category_sp,
       lldb_private::formatters::swift::ArraySyntheticFrontEndCreator,
-      "Swift.Array synthetic children", ConstString("^Swift.NativeArray<.+>$"),
-      synth_flags, true);
+      "Swift.ContiguousArray synthetic children",
+      ConstString("^Swift.ContiguousArray<.+>$"), synth_flags, true);
   AddCXXSynthetic(
       swift_category_sp,
       lldb_private::formatters::swift::ArraySyntheticFrontEndCreator,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5040,7 +5040,7 @@ bool SwiftASTContext::IsArrayType(opaque_compiler_type_t type,
     swift::StructDecl *struct_decl = struct_type->getDecl();
     llvm::StringRef name = struct_decl->getName().get();
     // This is sketchy, but it matches the behavior of GetArrayElementType().
-    if (name != "Array" && name != "NativeArray" && name != "ArraySlice")
+    if (name != "Array" && name != "ContiguousArray" && name != "ArraySlice")
       return false;
     if (!struct_decl->getModuleContext()->isStdlibModule())
       return false;
@@ -5665,7 +5665,7 @@ SwiftASTContext::GetArrayElementType(opaque_compiler_type_t type,
     swift::CanType swift_type(GetCanonicalSwiftType(type));
     // There are a couple of structs that mean "Array" in Swift:
     // Array<T>
-    // NativeArray<T>
+    // ContiguousArray<T>
     // Slice<T>
     // Treat them as arrays for convenience sake.
     swift::BoundGenericStructType *boundGenericStructType(
@@ -5675,7 +5675,7 @@ SwiftASTContext::GetArrayElementType(opaque_compiler_type_t type,
       swift::StructDecl *decl = boundGenericStructType->getDecl();
       if (args.size() == 1 && decl->getModuleContext()->isStdlibModule()) {
         const char *declname = decl->getName().get();
-        if (0 == strcmp(declname, "NativeArray") ||
+        if (0 == strcmp(declname, "ContiguousArray") ||
             0 == strcmp(declname, "Array") ||
             0 == strcmp(declname, "ArraySlice")) {
           assert(GetASTContext() == &args[0].getPointer()->getASTContext());

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1433,7 +1433,7 @@ bool TypeSystemSwiftTypeRef::IsArrayType(opaque_compiler_type_t type,
         node->getChild(1)->getKind() != Node::Kind::Identifier ||
         !node->getChild(1)->hasText() ||
         (node->getChild(1)->getText() != "Array" &&
-         node->getChild(1)->getText() != "NativeArray" &&
+         node->getChild(1)->getText() != "ContiguousArray" &&
          node->getChild(1)->getText() != "ArraySlice"))
       return false;
 

--- a/lldb/test/API/lang/swift/stdlib/ContiguousArray/TestContiguousArray.py
+++ b/lldb/test/API/lang/swift/stdlib/ContiguousArray/TestContiguousArray.py
@@ -20,9 +20,6 @@ class TestContiguousArray(lldbtest.TestBase):
         lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
 
-        self.expect("frame variable --dynamic-type run-target",
-                    startstr="""(ContiguousArray<a.Class>) array = {
-  _buffer = {
-    _storage = 1 value {
-      [0] = 0x""")
-
+        self.expect("frame variable",
+                    startstr="""(ContiguousArray<a.Class>) array = 1 value {
+  [0] = 0x""")


### PR DESCRIPTION
`NativeArray` was renamed to `ContiguousArray` in b666651e3fe2a55416aef9aca69e5406cc7f9e21 (in 2014). This updates lldb to be aware of `ContiguousArray`.

This updates the type summary provider to support `ContiguousArray`. Given:

```swift
var array: ContiguousArray<Int> = [1, 2, 3]
```

Before this change:

```
(lldb) v array
(ContiguousArray<Int>) array = {
  _buffer = {
    _storage = 3 values {
      [0] = 0x0000000000000001
      [1] = 0x0000000000000001
      [2] = 0x0000000000000001
    }
  }
}
```

After this change:

```
(lldb) v array
(ContiguousArray<Int>) array = 3 values {
  [0] = 1
  [1] = 2
  [2] = 3
}
```
