### PR TITLE
[lldb] Fix invalid expect() calls in tests

### DIFF
--- a/lldb/test/API/functionalities/asan/swift/TestAsanSwift.py
+++ b/lldb/test/API/functionalities/asan/swift/TestAsanSwift.py
@@ -93,7 +93,7 @@ class AsanSwiftTestCase(lldbtest.TestBase):
         for i in range(0, thread.GetNumFrames()):
             frame = thread.GetFrameAtIndex(i)
             if frame.GetFunctionName() == "main":
-                self.expect("frame select %d" % i, "at main.swift")
+                self.expect("frame select %d" % i, substrs=["at main.swift"])
                 break
 
         self.expect(

--- a/lldb/test/API/lang/swift/availability/TestAvailability.py
+++ b/lldb/test/API/lang/swift/availability/TestAvailability.py
@@ -140,4 +140,4 @@ print("in top_level") // break_7
 
         for breakpoint in breakpoints:
             threads = lldbutil.continue_to_breakpoint(process, breakpoint)
-            self.expect("expr -d no-run-target -- f()", substrs=["can call"])
+            self.runCmd("expr -d no-run-target -- f()", msg="can call")

--- a/lldb/test/API/lang/swift/availability/TestAvailability.py
+++ b/lldb/test/API/lang/swift/availability/TestAvailability.py
@@ -140,5 +140,4 @@ print("in top_level") // break_7
 
         for breakpoint in breakpoints:
             threads = lldbutil.continue_to_breakpoint(process, breakpoint)
-            self.expect("expr -d no-run-target -- f()", "can call")
-
+            self.expect("expr -d no-run-target -- f()", substrs=["can call"])

--- a/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
+++ b/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
@@ -22,7 +22,7 @@ class TestSwiftRewriteClangPaths(TestBase):
         self.runCmd('log enable lldb types -f "%s"' % log)
         target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(
             self, 'main')
-        self.expect("p 1", "1")
+        self.expect("p 1", substrs=["1"])
 
         # Scan through the types log.
         logfile = open(log, "r")

--- a/lldb/test/API/lang/swift/objc_runtime_ivars/TestObjCIvarDiscovery.py
+++ b/lldb/test/API/lang/swift/objc_runtime_ivars/TestObjCIvarDiscovery.py
@@ -73,11 +73,11 @@ class TestObjCIVarDiscovery(TestBase):
 
         if dbg:
             self.expect(
-                "image list", "Contents/Resources/DWARF/aTestFramework")
+                "image list", substrs=["Contents/Resources/DWARF/aTestFramework"])
         else:
             self.expect(
                 "image list",
-                "Contents/Resources/DWARF/aTestFramework",
+                substrs=["Contents/Resources/DWARF/aTestFramework"],
                 matching=False)
 
         self.runCmd("frame variable -d run --show-types --ptr-depth=1")

--- a/lldb/test/API/lang/swift/variables/uninitialized/main.swift
+++ b/lldb/test/API/lang/swift/variables/uninitialized/main.swift
@@ -16,14 +16,14 @@ struct A<T> {
     }
 
     mutating func a() -> T? {
-        var adict : [String: Any]  //% self.expect("frame variable adict", "Frame variable of an uninitialized dict returns")
+        var adict : [String: Any]  //% self.expect("frame variable adict", substrs=["Frame variable of an uninitialized dict returns"])
         adict = [String: Any]() 
         adict["key1"] = 1.0
         var t : T? = nil
         let c = cs[0]
 
         let k1 = b(t:c)
-        let k2 = b(t:c) //% self.expect("expr -d run -- c", "Unreadable variable is ignored", substrs = ["= 3"])
+        let k2 = b(t:c) //% self.expect("expr -d run -- c", "Unreadable variable is ignored", substrs=["= 3"])
         let k3 = b(t:c)
 
         if let maybeT = process(i : adict.count, k1:k1, k2:k2, k3:k3) {

--- a/lldb/test/API/lang/swift/variables/uninitialized/main.swift
+++ b/lldb/test/API/lang/swift/variables/uninitialized/main.swift
@@ -16,7 +16,7 @@ struct A<T> {
     }
 
     mutating func a() -> T? {
-        var adict : [String: Any]  //% self.expect("frame variable adict", substrs=["Frame variable of an uninitialized dict returns"])
+        var adict : [String: Any]  //% self.expect("frame variable adict", endstr=" adict = {}")
         adict = [String: Any]() 
         adict["key1"] = 1.0
         var t : T? = nil

--- a/lldb/test/API/lang/swift/variables/uninitialized/main.swift
+++ b/lldb/test/API/lang/swift/variables/uninitialized/main.swift
@@ -16,7 +16,7 @@ struct A<T> {
     }
 
     mutating func a() -> T? {
-        var adict : [String: Any]  //% self.runCmd("frame variable adict", "Frame variable of an uninitialized dict returns")
+        var adict : [String: Any]  //% self.runCmd("frame variable adict", msg="Frame variable of an uninitialized dict returns")
         adict = [String: Any]() 
         adict["key1"] = 1.0
         var t : T? = nil

--- a/lldb/test/API/lang/swift/variables/uninitialized/main.swift
+++ b/lldb/test/API/lang/swift/variables/uninitialized/main.swift
@@ -16,7 +16,7 @@ struct A<T> {
     }
 
     mutating func a() -> T? {
-        var adict : [String: Any]  //% self.expect("frame variable adict", endstr=" adict = {}")
+        var adict : [String: Any]  //% self.runCmd("frame variable adict", "Frame variable of an uninitialized dict returns")
         adict = [String: Any]() 
         adict["key1"] = 1.0
         var t : T? = nil


### PR DESCRIPTION
These were identified by https://github.com/apple/llvm-project/pull/2085 which imports https://reviews.llvm.org/D88792 ("Catch invalid calls to `expect()`").