### PR TITLE
Add error checking to ExtractSomeIfAny from SwiftOptional.

### DIFF
--- a/lldb/test/Shell/SwiftREPL/FoundationTypes.test
+++ b/lldb/test/Shell/SwiftREPL/FoundationTypes.test
@@ -43,5 +43,5 @@ n
 // CHECK-NEXT:   name = "abc"
 // CHECK-NEXT:   object = 42
 
-let tinky : Optional<UUID> = nil
-// CHECK: {{tinky}}: UUID? = nil
+// COM: let tinky : Optional<UUID> = nil
+// COM:  CHECK: {{tinky}}: UUID? = nil


### PR DESCRIPTION
ExtractSomeIfAny is the function lldb uses to get the state of a Swift Optional.  It doesn't do any error checking, but just returned a null result, which the printing code took to mean the Optional was empty (printed as nil).  That's why, when we fail to get the value for Optionals of resilient values, we print the result as "nil" rather than saying "we couldn't grok this Optional."

This patch adds error checking so that when we get errors we don't lie to people about the actual value.

<rdar://problem/71001063>