### PR TITLE
APINotes: add APINotesYAMLCompiler

### DIFF
--- a/clang/include/clang/APINotes/APINotesReader.h
+++ b/clang/include/clang/APINotes/APINotesReader.h
@@ -59,11 +59,11 @@ public:
 
   /// Retrieve the name of the module for which this reader is providing API
   /// notes.
-  StringRef getModuleName() const;
+  llvm::StringRef getModuleName() const;
 
   /// Retrieve the size and modification time of the source file from
   /// which this API notes file was created, if known.
-  Optional<std::pair<off_t, time_t>> getSourceFileSizeAndModTime() const;
+  llvm::Optional<std::pair<off_t, time_t>> getSourceFileSizeAndModTime() const;
 
   /// Retrieve the module options
   ModuleOptions getModuleOptions() const;
@@ -74,7 +74,7 @@ public:
   template<typename T>
   class VersionedInfo {
     /// The complete set of results.
-    SmallVector<std::pair<VersionTuple, T>, 1> Results;
+    llvm::SmallVector<std::pair<llvm::VersionTuple, T>, 1> Results;
 
     /// The index of the result that is the "selected" set based on the desired
     /// Swift version, or \c Results.size() if nothing matched.
@@ -87,7 +87,7 @@ public:
     /// Form a versioned info set given the desired version and a set of
     /// results.
     VersionedInfo(llvm::VersionTuple version,
-                  SmallVector<std::pair<llvm::VersionTuple, T>, 1> results);
+                  llvm::SmallVector<std::pair<llvm::VersionTuple, T>, 1> results);
 
     /// Determine whether there is a result that should be applied directly
     /// to the AST.
@@ -100,8 +100,8 @@ public:
     }
 
     /// Retrieve the selected index in the result set.
-    Optional<unsigned> getSelected() const {
-      if (Selected == Results.size()) return None;
+    llvm::Optional<unsigned> getSelected() const {
+      if (Selected == Results.size()) return llvm::None;
       return Selected;
     }
 
@@ -123,28 +123,28 @@ public:
   /// \param name The name of the class we're looking for.
   ///
   /// \returns The ID, if known.
-  Optional<ContextID> lookupObjCClassID(StringRef name);
+  llvm::Optional<ContextID> lookupObjCClassID(llvm::StringRef name);
 
   /// Look for information regarding the given Objective-C class.
   ///
   /// \param name The name of the class we're looking for.
   ///
   /// \returns The information about the class, if known.
-  VersionedInfo<ObjCContextInfo> lookupObjCClassInfo(StringRef name);
+  VersionedInfo<ObjCContextInfo> lookupObjCClassInfo(llvm::StringRef name);
 
   /// Look for the context ID of the given Objective-C protocol.
   ///
   /// \param name The name of the protocol we're looking for.
   ///
   /// \returns The ID of the protocol, if known.
-  Optional<ContextID> lookupObjCProtocolID(StringRef name);
+  llvm::Optional<ContextID> lookupObjCProtocolID(llvm::StringRef name);
 
   /// Look for information regarding the given Objective-C protocol.
   ///
   /// \param name The name of the protocol we're looking for.
   ///
   /// \returns The information about the protocol, if known.
-  VersionedInfo<ObjCContextInfo> lookupObjCProtocolInfo(StringRef name);
+  VersionedInfo<ObjCContextInfo> lookupObjCProtocolInfo(llvm::StringRef name);
 
   /// Look for information regarding the given Objective-C property in
   /// the given context.
@@ -156,7 +156,7 @@ public:
   ///
   /// \returns Information about the property, if known.
   VersionedInfo<ObjCPropertyInfo> lookupObjCProperty(ContextID contextID,
-                                                     StringRef name,
+                                                     llvm::StringRef name,
                                                      bool isInstance);
 
   /// Look for information regarding the given Objective-C method in
@@ -176,21 +176,21 @@ public:
   /// \param name The name of the global variable.
   ///
   /// \returns information about the global variable, if known.
-  VersionedInfo<GlobalVariableInfo> lookupGlobalVariable(StringRef name);
+  VersionedInfo<GlobalVariableInfo> lookupGlobalVariable(llvm::StringRef name);
 
   /// Look for information regarding the given global function.
   ///
   /// \param name The name of the global function.
   ///
   /// \returns information about the global function, if known.
-  VersionedInfo<GlobalFunctionInfo> lookupGlobalFunction(StringRef name);
+  VersionedInfo<GlobalFunctionInfo> lookupGlobalFunction(llvm::StringRef name);
 
   /// Look for information regarding the given enumerator.
   ///
   /// \param name The name of the enumerator.
   ///
   /// \returns information about the enumerator, if known.
-  VersionedInfo<EnumConstantInfo> lookupEnumConstant(StringRef name);
+  VersionedInfo<EnumConstantInfo> lookupEnumConstant(llvm::StringRef name);
 
   /// Look for information regarding the given tag
   /// (struct/union/enum/C++ class).
@@ -198,14 +198,14 @@ public:
   /// \param name The name of the tag.
   ///
   /// \returns information about the tag, if known.
-  VersionedInfo<TagInfo> lookupTag(StringRef name);
+  VersionedInfo<TagInfo> lookupTag(llvm::StringRef name);
 
   /// Look for information regarding the given typedef.
   ///
   /// \param name The name of the typedef.
   ///
   /// \returns information about the typedef, if known.
-  VersionedInfo<TypedefInfo> lookupTypedef(StringRef name);
+  VersionedInfo<TypedefInfo> lookupTypedef(llvm::StringRef name);
 };
 
 } // end namespace api_notes

--- a/clang/include/clang/APINotes/APINotesWriter.h
+++ b/clang/include/clang/APINotes/APINotesWriter.h
@@ -38,7 +38,7 @@ class APINotesWriter {
 public:
   /// Create a new API notes writer with the given module name and
   /// (optional) source file.
-  APINotesWriter(StringRef moduleName, const FileEntry *sourceFile);
+  APINotesWriter(llvm::StringRef moduleName, const FileEntry *sourceFile);
   ~APINotesWriter();
 
   APINotesWriter(const APINotesWriter &) = delete;
@@ -55,7 +55,7 @@ public:
   ///
   /// \returns the ID of the class or protocol, which can be used to add
   /// properties and methods to the class/protocol.
-  ContextID addObjCContext(StringRef name, bool isClass,
+  ContextID addObjCContext(llvm::StringRef name, bool isClass,
                            const ObjCContextInfo &info,
                            llvm::VersionTuple swiftVersion);
 
@@ -64,7 +64,7 @@ public:
   /// \param contextID The context in which this property resides.
   /// \param name The name of this property.
   /// \param info Information about this property.
-  void addObjCProperty(ContextID contextID, StringRef name,
+  void addObjCProperty(ContextID contextID, llvm::StringRef name,
                        bool isInstanceProperty,
                        const ObjCPropertyInfo &info,
                        llvm::VersionTuple swiftVersion);
@@ -84,35 +84,35 @@ public:
   ///
   /// \param name The name of this global variable.
   /// \param info Information about this global variable.
-  void addGlobalVariable(StringRef name, const GlobalVariableInfo &info,
+  void addGlobalVariable(llvm::StringRef name, const GlobalVariableInfo &info,
                          llvm::VersionTuple swiftVersion);
 
   /// Add information about a global function.
   ///
   /// \param name The name of this global function.
   /// \param info Information about this global function.
-  void addGlobalFunction(StringRef name, const GlobalFunctionInfo &info,
+  void addGlobalFunction(llvm::StringRef name, const GlobalFunctionInfo &info,
                          llvm::VersionTuple swiftVersion);
 
   /// Add information about an enumerator.
   ///
   /// \param name The name of this enumerator.
   /// \param info Information about this enumerator.
-  void addEnumConstant(StringRef name, const EnumConstantInfo &info,
+  void addEnumConstant(llvm::StringRef name, const EnumConstantInfo &info,
                        llvm::VersionTuple swiftVersion);
 
   /// Add information about a tag (struct/union/enum/C++ class).
   ///
   /// \param name The name of this tag.
   /// \param info Information about this tag.
-  void addTag(StringRef name, const TagInfo &info,
+  void addTag(llvm::StringRef name, const TagInfo &info,
               llvm::VersionTuple swiftVersion);
 
   /// Add information about a typedef.
   ///
   /// \param name The name of this typedef.
   /// \param info Information about this typedef.
-  void addTypedef(StringRef name, const TypedefInfo &info,
+  void addTypedef(llvm::StringRef name, const TypedefInfo &info,
                   llvm::VersionTuple swiftVersion);
 
   /// Add module options

--- a/clang/include/clang/APINotes/APINotesYAMLCompiler.h
+++ b/clang/include/clang/APINotes/APINotesYAMLCompiler.h
@@ -1,49 +1,49 @@
-//=== APINotesYAMLCompiler.h - API Notes YAML to binary compiler *- C++ -*-===//
+//===-- APINotesYAMLCompiler.h - API Notes YAML Format Reader ---*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
-//
-//===----------------------------------------------------------------------===//
-//
-// This file reads sidecar API notes specified in YAML format.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_CLANG_API_NOTES_YAML_COMPILER_H
-#define LLVM_CLANG_API_NOTES_YAML_COMPILER_H
+#ifndef LLVM_CLANG_APINOTES_APINOTESYAMLCOMPILER_H
+#define LLVM_CLANG_APINOTES_APINOTESYAMLCOMPILER_H
+
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace clang {
+namespace api_notes {
+/// Parses the APINotes YAML content and writes the representation back to the
+/// specified stream.  This provides a means of testing the YAML processing of
+/// the APINotes format.
+bool parseAndDumpAPINotes(llvm::StringRef YI, llvm::raw_ostream &OS);
+} // namespace api_notes
+} // namespace clang
+
 #include "llvm/Support/SourceMgr.h"
-#include <memory>
 
 namespace llvm {
-  class raw_ostream;
-  class MemoryBuffer;
+class MemoryBuffer;
 }
 
 namespace clang {
-
 class FileEntry;
 
 namespace api_notes {
+enum class ActionType {
+  None,
+  YAMLToBinary,
+  BinaryToYAML,
+  Dump,
+};
 
-  enum class ActionType {
-    None,
-    YAMLToBinary,
-    BinaryToYAML,
-    Dump,
-  };
+/// Converts API notes from YAML format to binary format.
+bool compileAPINotes(llvm::StringRef yamlInput, const FileEntry *sourceFile,
+                     llvm::raw_ostream &os,
+                     llvm::SourceMgr::DiagHandlerTy diagHandler = nullptr,
+                     void *diagHandlerCtxt = nullptr);
+}
+}
 
-  /// Converts API notes from YAML format to binary format.
-  bool compileAPINotes(llvm::StringRef yamlInput,
-                       const FileEntry *sourceFile,
-                       llvm::raw_ostream &os,
-                       llvm::SourceMgr::DiagHandlerTy diagHandler = nullptr,
-                       void *diagHandlerCtxt = nullptr);
-
-  bool parseAndDumpAPINotes(llvm::StringRef yamlInput);
-} // end namespace api_notes
-} // end namespace clang
-
-#endif // LLVM_CLANG_API_NOTES_YAML_COMPILER_H
+#endif

--- a/clang/lib/APINotes/APINotesReader.cpp
+++ b/clang/lib/APINotes/APINotesReader.cpp
@@ -527,7 +527,7 @@ namespace {
 
       uint8_t payload = *data++;
       if (payload > 0) {
-        info.SwiftWrapper = static_cast<SwiftWrapperKind>((payload & 0x3) - 1);
+        info.SwiftWrapper = static_cast<SwiftNewTypeKind>((payload & 0x3) - 1);
       }
 
       readCommonTypeInfo(data, info);

--- a/clang/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/clang/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -1,26 +1,29 @@
-//===--- APINotesYAMLCompiler.cpp - API Notes YAML format reader *- C++ -*-===//
+//===-- APINotesYAMLCompiler.cpp - API Notes YAML Format Reader -*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
-//
-//===----------------------------------------------------------------------===//
-//
-// This file reads API notes specified in YAML format.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// The types defined locally are designed to represent the YAML state, which
+// adds an additional bit of state: e.g. a tri-state boolean attribute (yes, no,
+// not applied) becomes a tri-state boolean + present.  As a result, while these
+// enumerations appear to be redefining constants from the attributes table
+// data, they are distinct.
+//
+
 #include "clang/APINotes/APINotesYAMLCompiler.h"
-#include "clang/APINotes/APINotesReader.h"
 #include "clang/APINotes/Types.h"
-#include "clang/APINotes/APINotesWriter.h"
-#include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/StringSet.h"
-#include "llvm/Support/SourceMgr.h"
+#include "clang/Basic/LLVM.h"
+#include "clang/Basic/Specifiers.h"
+#include "llvm/ADT/Optional.h"
 #include "llvm/Support/VersionTuple.h"
 #include "llvm/Support/YAMLParser.h"
 #include "llvm/Support/YAMLTraits.h"
-#include <algorithm>
+#include <vector>
+using namespace clang;
+using namespace api_notes;
 
 /*
  
@@ -135,490 +138,587 @@ Each global variable definition is of the following form:
 
 */
 
-using llvm::StringRef;
-using namespace clang;
 namespace {
-  enum class APIAvailability {
-    Available = 0,
-    OSX,
-    IOS,
-    None,
-    NonSwift,
-  };
+enum class APIAvailability {
+  Available = 0,
+  OSX,
+  IOS,
+  None,
+  NonSwift,
+};
+} // namespace
 
-  enum class MethodKind {
-    Class,
-    Instance,
-  };
+namespace llvm {
+namespace yaml {
+template <> struct ScalarEnumerationTraits<APIAvailability> {
+  static void enumeration(IO &IO, APIAvailability &AA) {
+    IO.enumCase(AA, "OSX", APIAvailability::OSX);
+    IO.enumCase(AA, "iOS", APIAvailability::IOS);
+    IO.enumCase(AA, "none", APIAvailability::None);
+    IO.enumCase(AA, "nonswift", APIAvailability::NonSwift);
+    IO.enumCase(AA, "available", APIAvailability::Available);
+  }
+};
+} // namespace yaml
+} // namespace llvm
 
-  /// Old attribute deprecated in favor of SwiftName.
-  enum class FactoryAsInitKind {
-    /// Infer based on name and type (the default).
-    Infer,
-    /// Treat as a class method.
-    AsClassMethod,
-    /// Treat as an initializer.
-    AsInitializer
-  };
-  
-  /// Syntactic sugar for EnumExtensibility and FlagEnum
-  enum class EnumConvenienceAliasKind {
-    /// EnumExtensibility: none, FlagEnum: false
-    None,
-    /// EnumExtensibility: open, FlagEnum: false
-    CFEnum,
-    /// EnumExtensibility: open, FlagEnum: true
-    CFOptions,
-    /// EnumExtensibility: closed, FlagEnum: false
-    CFClosedEnum
-  };
+namespace {
+enum class MethodKind {
+  Class,
+  Instance,
+};
+} // namespace
 
-  struct AvailabilityItem {
-    APIAvailability Mode = APIAvailability::Available;
-    StringRef Msg;
-    AvailabilityItem() : Mode(APIAvailability::Available), Msg("") {}
-  };
+namespace llvm {
+namespace yaml {
+template <> struct ScalarEnumerationTraits<MethodKind> {
+  static void enumeration(IO &IO, MethodKind &MK) {
+    IO.enumCase(MK, "Class", MethodKind::Class);
+    IO.enumCase(MK, "Instance", MethodKind::Instance);
+  }
+};
+} // namespace yaml
+} // namespace llvm
 
-  static llvm::Optional<NullabilityKind> AbsentNullability = llvm::None;
-  static llvm::Optional<NullabilityKind> DefaultNullability =
-    NullabilityKind::NonNull;
-  typedef std::vector<clang::NullabilityKind> NullabilitySeq;
+namespace {
+struct Param {
+  unsigned Position;
+  Optional<bool> NoEscape = false;
+  Optional<NullabilityKind> Nullability;
+  Optional<RetainCountConventionKind> RetainCountConvention;
+  StringRef Type;
+};
 
-  struct Param {
-    unsigned Position;
-    Optional<bool> NoEscape = false;
-    Optional<NullabilityKind> Nullability;
-    Optional<api_notes::RetainCountConventionKind> RetainCountConvention;
-    StringRef Type;
-  };
-  typedef std::vector<Param> ParamsSeq;
+typedef std::vector<Param> ParamsSeq;
+} // namespace
 
-  struct Method {
-    StringRef Selector;
-    MethodKind Kind;
-    ParamsSeq Params;
-    NullabilitySeq Nullability;
-    Optional<NullabilityKind> NullabilityOfRet;
-    Optional<api_notes::RetainCountConventionKind> RetainCountConvention;
-    AvailabilityItem Availability;
-    Optional<bool> SwiftPrivate;
-    StringRef SwiftName;
-    FactoryAsInitKind FactoryAsInit = FactoryAsInitKind::Infer;
-    bool DesignatedInit = false;
-    bool Required = false;
-    StringRef ResultType;
-  };
-  typedef std::vector<Method> MethodsSeq;
-
-  struct Property {
-    StringRef Name;
-    llvm::Optional<MethodKind> Kind;
-    llvm::Optional<NullabilityKind> Nullability;
-    AvailabilityItem Availability;
-    Optional<bool> SwiftPrivate;
-    StringRef SwiftName;
-    Optional<bool> SwiftImportAsAccessors;
-    StringRef Type;
-  };
-  typedef std::vector<Property> PropertiesSeq;
-
-  struct Class {
-    StringRef Name;
-    bool AuditedForNullability = false;
-    AvailabilityItem Availability;
-    Optional<bool> SwiftPrivate;
-    StringRef SwiftName;
-    Optional<StringRef> SwiftBridge;
-    Optional<StringRef> NSErrorDomain;
-    Optional<bool> SwiftImportAsNonGeneric;
-    Optional<bool> SwiftObjCMembers;
-    MethodsSeq Methods;
-    PropertiesSeq Properties;
-  };
-  typedef std::vector<Class> ClassesSeq;
-
-  struct Function {
-    StringRef Name;
-    ParamsSeq Params;
-    NullabilitySeq Nullability;
-    Optional<NullabilityKind> NullabilityOfRet;
-    Optional<api_notes::RetainCountConventionKind> RetainCountConvention;
-    AvailabilityItem Availability;
-    Optional<bool> SwiftPrivate;
-    StringRef SwiftName;
-    StringRef Type;
-    StringRef ResultType;
-  };
-  typedef std::vector<Function> FunctionsSeq;
-
-  struct GlobalVariable {
-    StringRef Name;
-    llvm::Optional<NullabilityKind> Nullability;
-    AvailabilityItem Availability;
-    Optional<bool> SwiftPrivate;
-    StringRef SwiftName;
-    StringRef Type;
-  };
-  typedef std::vector<GlobalVariable> GlobalVariablesSeq;
-
-  struct EnumConstant {
-    StringRef Name;
-    AvailabilityItem Availability;
-    Optional<bool> SwiftPrivate;
-    StringRef SwiftName;
-  };
-  typedef std::vector<EnumConstant> EnumConstantsSeq;
-
-  struct Tag {
-    StringRef Name;
-    AvailabilityItem Availability;
-    StringRef SwiftName;
-    Optional<bool> SwiftPrivate;
-    Optional<StringRef> SwiftBridge;
-    Optional<StringRef> NSErrorDomain;
-    Optional<api_notes::EnumExtensibilityKind> EnumExtensibility;
-    Optional<bool> FlagEnum;
-    Optional<EnumConvenienceAliasKind> EnumConvenienceKind;
-  };
-  typedef std::vector<Tag> TagsSeq;
-
-  struct Typedef {
-    StringRef Name;
-    AvailabilityItem Availability;
-    StringRef SwiftName;
-    Optional<bool> SwiftPrivate;
-    Optional<StringRef> SwiftBridge;
-    Optional<StringRef> NSErrorDomain;
-    Optional<api_notes::SwiftWrapperKind> SwiftWrapper;
-  };
-  typedef std::vector<Typedef> TypedefsSeq;
-
-  struct TopLevelItems {
-    ClassesSeq Classes;
-    ClassesSeq Protocols;
-    FunctionsSeq Functions;
-    GlobalVariablesSeq Globals;
-    EnumConstantsSeq EnumConstants;
-    TagsSeq Tags;
-    TypedefsSeq Typedefs;
-  };
-
-  struct Versioned {
-    VersionTuple Version;
-    TopLevelItems Items;
-  };
-
-  typedef std::vector<Versioned> VersionedSeq;
-
-  struct Module {
-    StringRef Name;
-    AvailabilityItem Availability;
-    TopLevelItems TopLevel;
-    VersionedSeq SwiftVersions;
-
-    llvm::Optional<bool> SwiftInferImportAsMember = {llvm::None};
-
-    LLVM_ATTRIBUTE_DEPRECATED(
-      void dump() LLVM_ATTRIBUTE_USED,
-      "only for use within the debugger");
-  };
-}
-
-LLVM_YAML_IS_FLOW_SEQUENCE_VECTOR(clang::NullabilityKind)
-LLVM_YAML_IS_SEQUENCE_VECTOR(Method)
-LLVM_YAML_IS_SEQUENCE_VECTOR(Property)
 LLVM_YAML_IS_SEQUENCE_VECTOR(Param)
+LLVM_YAML_IS_FLOW_SEQUENCE_VECTOR(NullabilityKind)
+
+namespace llvm {
+namespace yaml {
+template <> struct ScalarEnumerationTraits<NullabilityKind> {
+  static void enumeration(IO &IO, NullabilityKind &NK) {
+    IO.enumCase(NK, "Nonnull", NullabilityKind::NonNull);
+    IO.enumCase(NK, "Optional", NullabilityKind::Nullable);
+    IO.enumCase(NK, "Unspecified", NullabilityKind::Unspecified);
+    // TODO: Mapping this to it's own value would allow for better cross
+    // checking. Also the default should be Unknown.
+    IO.enumCase(NK, "Scalar", NullabilityKind::Unspecified);
+
+    // Aliases for compatibility with existing APINotes.
+    IO.enumCase(NK, "N", NullabilityKind::NonNull);
+    IO.enumCase(NK, "O", NullabilityKind::Nullable);
+    IO.enumCase(NK, "U", NullabilityKind::Unspecified);
+    IO.enumCase(NK, "S", NullabilityKind::Unspecified);
+  }
+};
+
+template <> struct ScalarEnumerationTraits<RetainCountConventionKind> {
+  static void enumeration(IO &IO, RetainCountConventionKind &RCCK) {
+    IO.enumCase(RCCK, "none", RetainCountConventionKind::None);
+    IO.enumCase(RCCK, "CFReturnsRetained",
+                RetainCountConventionKind::CFReturnsRetained);
+    IO.enumCase(RCCK, "CFReturnsNotRetained",
+                RetainCountConventionKind::CFReturnsNotRetained);
+    IO.enumCase(RCCK, "NSReturnsRetained",
+                RetainCountConventionKind::NSReturnsRetained);
+    IO.enumCase(RCCK, "NSReturnsNotRetained",
+                RetainCountConventionKind::NSReturnsNotRetained);
+  }
+};
+
+template <> struct MappingTraits<Param> {
+  static void mapping(IO &IO, Param &P) {
+    IO.mapRequired("Position", P.Position);
+    IO.mapOptional("Nullability", P.Nullability, llvm::None);
+    IO.mapOptional("RetainCountConvention", P.RetainCountConvention);
+    IO.mapOptional("NoEscape", P.NoEscape);
+    IO.mapOptional("Type", P.Type, StringRef(""));
+  }
+};
+} // namespace yaml
+} // namespace llvm
+
+namespace {
+typedef std::vector<NullabilityKind> NullabilitySeq;
+
+struct AvailabilityItem {
+  APIAvailability Mode = APIAvailability::Available;
+  StringRef Msg;
+};
+
+/// Old attribute deprecated in favor of SwiftName.
+enum class FactoryAsInitKind {
+  /// Infer based on name and type (the default).
+  Infer,
+  /// Treat as a class method.
+  AsClassMethod,
+  /// Treat as an initializer.
+  AsInitializer,
+};
+
+struct Method {
+  StringRef Selector;
+  MethodKind Kind;
+  ParamsSeq Params;
+  NullabilitySeq Nullability;
+  Optional<NullabilityKind> NullabilityOfRet;
+  Optional<RetainCountConventionKind> RetainCountConvention;
+  AvailabilityItem Availability;
+  Optional<bool> SwiftPrivate;
+  StringRef SwiftName;
+  FactoryAsInitKind FactoryAsInit = FactoryAsInitKind::Infer;
+  bool DesignatedInit = false;
+  bool Required = false;
+  StringRef ResultType;
+};
+
+typedef std::vector<Method> MethodsSeq;
+} // namespace
+
+LLVM_YAML_IS_SEQUENCE_VECTOR(Method)
+
+namespace llvm {
+namespace yaml {
+template <> struct ScalarEnumerationTraits<FactoryAsInitKind> {
+  static void enumeration(IO &IO, FactoryAsInitKind &FIK) {
+    IO.enumCase(FIK, "A", FactoryAsInitKind::Infer);
+    IO.enumCase(FIK, "C", FactoryAsInitKind::AsClassMethod);
+    IO.enumCase(FIK, "I", FactoryAsInitKind::AsInitializer);
+  }
+};
+
+template <> struct MappingTraits<Method> {
+  static void mapping(IO &IO, Method &M) {
+    IO.mapRequired("Selector", M.Selector);
+    IO.mapRequired("MethodKind", M.Kind);
+    IO.mapOptional("Parameters", M.Params);
+    IO.mapOptional("Nullability", M.Nullability);
+    IO.mapOptional("NullabilityOfRet", M.NullabilityOfRet, llvm::None);
+    IO.mapOptional("RetainCountConvention", M.RetainCountConvention);
+    IO.mapOptional("Availability", M.Availability.Mode,
+                   APIAvailability::Available);
+    IO.mapOptional("AvailabilityMsg", M.Availability.Msg, StringRef(""));
+    IO.mapOptional("SwiftPrivate", M.SwiftPrivate);
+    IO.mapOptional("SwiftName", M.SwiftName, StringRef(""));
+    IO.mapOptional("FactoryAsInit", M.FactoryAsInit, FactoryAsInitKind::Infer);
+    IO.mapOptional("DesignatedInit", M.DesignatedInit, false);
+    IO.mapOptional("Required", M.Required, false);
+    IO.mapOptional("ResultType", M.ResultType, StringRef(""));
+  }
+};
+} // namespace yaml
+} // namespace llvm
+
+namespace {
+struct Property {
+  StringRef Name;
+  llvm::Optional<MethodKind> Kind;
+  llvm::Optional<NullabilityKind> Nullability;
+  AvailabilityItem Availability;
+  Optional<bool> SwiftPrivate;
+  StringRef SwiftName;
+  Optional<bool> SwiftImportAsAccessors;
+  StringRef Type;
+};
+
+typedef std::vector<Property> PropertiesSeq;
+} // namespace
+
+LLVM_YAML_IS_SEQUENCE_VECTOR(Property)
+
+namespace llvm {
+namespace yaml {
+template <> struct MappingTraits<Property> {
+  static void mapping(IO &IO, Property &P) {
+    IO.mapRequired("Name", P.Name);
+    IO.mapOptional("PropertyKind", P.Kind);
+    IO.mapOptional("Nullability", P.Nullability, llvm::None);
+    IO.mapOptional("Availability", P.Availability.Mode,
+                   APIAvailability::Available);
+    IO.mapOptional("AvailabilityMsg", P.Availability.Msg, StringRef(""));
+    IO.mapOptional("SwiftPrivate", P.SwiftPrivate);
+    IO.mapOptional("SwiftName", P.SwiftName, StringRef(""));
+    IO.mapOptional("SwiftImportAsAccessors", P.SwiftImportAsAccessors);
+    IO.mapOptional("Type", P.Type, StringRef(""));
+  }
+};
+} // namespace yaml
+} // namespace llvm
+
+namespace {
+struct Class {
+  StringRef Name;
+  bool AuditedForNullability = false;
+  AvailabilityItem Availability;
+  Optional<bool> SwiftPrivate;
+  StringRef SwiftName;
+  Optional<StringRef> SwiftBridge;
+  Optional<StringRef> NSErrorDomain;
+  Optional<bool> SwiftImportAsNonGeneric;
+  Optional<bool> SwiftObjCMembers;
+  MethodsSeq Methods;
+  PropertiesSeq Properties;
+};
+
+typedef std::vector<Class> ClassesSeq;
+} // namespace
+
 LLVM_YAML_IS_SEQUENCE_VECTOR(Class)
+
+namespace llvm {
+namespace yaml {
+template <> struct MappingTraits<Class> {
+  static void mapping(IO &IO, Class &C) {
+    IO.mapRequired("Name", C.Name);
+    IO.mapOptional("AuditedForNullability", C.AuditedForNullability, false);
+    IO.mapOptional("Availability", C.Availability.Mode,
+                   APIAvailability::Available);
+    IO.mapOptional("AvailabilityMsg", C.Availability.Msg, StringRef(""));
+    IO.mapOptional("SwiftPrivate", C.SwiftPrivate);
+    IO.mapOptional("SwiftName", C.SwiftName, StringRef(""));
+    IO.mapOptional("SwiftBridge", C.SwiftBridge);
+    IO.mapOptional("NSErrorDomain", C.NSErrorDomain);
+    IO.mapOptional("SwiftImportAsNonGeneric", C.SwiftImportAsNonGeneric);
+    IO.mapOptional("SwiftObjCMembers", C.SwiftObjCMembers);
+    IO.mapOptional("Methods", C.Methods);
+    IO.mapOptional("Properties", C.Properties);
+  }
+};
+} // namespace yaml
+} // namespace llvm
+
+namespace {
+struct Function {
+  StringRef Name;
+  ParamsSeq Params;
+  NullabilitySeq Nullability;
+  Optional<NullabilityKind> NullabilityOfRet;
+  Optional<api_notes::RetainCountConventionKind> RetainCountConvention;
+  AvailabilityItem Availability;
+  Optional<bool> SwiftPrivate;
+  StringRef SwiftName;
+  StringRef Type;
+  StringRef ResultType;
+};
+
+typedef std::vector<Function> FunctionsSeq;
+} // namespace
+
 LLVM_YAML_IS_SEQUENCE_VECTOR(Function)
+
+namespace llvm {
+namespace yaml {
+template <> struct MappingTraits<Function> {
+  static void mapping(IO &IO, Function &F) {
+    IO.mapRequired("Name", F.Name);
+    IO.mapOptional("Parameters", F.Params);
+    IO.mapOptional("Nullability", F.Nullability);
+    IO.mapOptional("NullabilityOfRet", F.NullabilityOfRet, llvm::None);
+    IO.mapOptional("RetainCountConvention", F.RetainCountConvention);
+    IO.mapOptional("Availability", F.Availability.Mode,
+                   APIAvailability::Available);
+    IO.mapOptional("AvailabilityMsg", F.Availability.Msg, StringRef(""));
+    IO.mapOptional("SwiftPrivate", F.SwiftPrivate);
+    IO.mapOptional("SwiftName", F.SwiftName, StringRef(""));
+    IO.mapOptional("ResultType", F.ResultType, StringRef(""));
+  }
+};
+} // namespace yaml
+} // namespace llvm
+
+namespace {
+struct GlobalVariable {
+  StringRef Name;
+  llvm::Optional<NullabilityKind> Nullability;
+  AvailabilityItem Availability;
+  Optional<bool> SwiftPrivate;
+  StringRef SwiftName;
+  StringRef Type;
+};
+
+typedef std::vector<GlobalVariable> GlobalVariablesSeq;
+} // namespace
+
 LLVM_YAML_IS_SEQUENCE_VECTOR(GlobalVariable)
+
+namespace llvm {
+namespace yaml {
+template <> struct MappingTraits<GlobalVariable> {
+  static void mapping(IO &IO, GlobalVariable &GV) {
+    IO.mapRequired("Name", GV.Name);
+    IO.mapOptional("Nullability", GV.Nullability, llvm::None);
+    IO.mapOptional("Availability", GV.Availability.Mode,
+                   APIAvailability::Available);
+    IO.mapOptional("AvailabilityMsg", GV.Availability.Msg, StringRef(""));
+    IO.mapOptional("SwiftPrivate", GV.SwiftPrivate);
+    IO.mapOptional("SwiftName", GV.SwiftName, StringRef(""));
+    IO.mapOptional("Type", GV.Type, StringRef(""));
+  }
+};
+} // namespace yaml
+} // namespace llvm
+
+namespace {
+struct EnumConstant {
+  StringRef Name;
+  AvailabilityItem Availability;
+  Optional<bool> SwiftPrivate;
+  StringRef SwiftName;
+};
+
+typedef std::vector<EnumConstant> EnumConstantsSeq;
+} // namespace
+
 LLVM_YAML_IS_SEQUENCE_VECTOR(EnumConstant)
+
+namespace llvm {
+namespace yaml {
+template <> struct MappingTraits<EnumConstant> {
+  static void mapping(IO &IO, EnumConstant &EC) {
+    IO.mapRequired("Name", EC.Name);
+    IO.mapOptional("Availability", EC.Availability.Mode,
+                   APIAvailability::Available);
+    IO.mapOptional("AvailabilityMsg", EC.Availability.Msg, StringRef(""));
+    IO.mapOptional("SwiftPrivate", EC.SwiftPrivate);
+    IO.mapOptional("SwiftName", EC.SwiftName, StringRef(""));
+  }
+};
+} // namespace yaml
+} // namespace llvm
+
+namespace {
+/// Syntactic sugar for EnumExtensibility and FlagEnum
+enum class EnumConvenienceAliasKind {
+  /// EnumExtensibility: none, FlagEnum: false
+  None,
+  /// EnumExtensibility: open, FlagEnum: false
+  CFEnum,
+  /// EnumExtensibility: open, FlagEnum: true
+  CFOptions,
+  /// EnumExtensibility: closed, FlagEnum: false
+  CFClosedEnum
+};
+} // namespace
+
+namespace llvm {
+namespace yaml {
+template <> struct ScalarEnumerationTraits<EnumConvenienceAliasKind> {
+  static void enumeration(IO &IO, EnumConvenienceAliasKind &ECAK) {
+    IO.enumCase(ECAK, "none", EnumConvenienceAliasKind::None);
+    IO.enumCase(ECAK, "CFEnum", EnumConvenienceAliasKind::CFEnum);
+    IO.enumCase(ECAK, "NSEnum", EnumConvenienceAliasKind::CFEnum);
+    IO.enumCase(ECAK, "CFOptions", EnumConvenienceAliasKind::CFOptions);
+    IO.enumCase(ECAK, "NSOptions", EnumConvenienceAliasKind::CFOptions);
+    IO.enumCase(ECAK, "CFClosedEnum", EnumConvenienceAliasKind::CFClosedEnum);
+    IO.enumCase(ECAK, "NSClosedEnum", EnumConvenienceAliasKind::CFClosedEnum);
+  }
+};
+} // namespace yaml
+} // namespace llvm
+
+namespace {
+struct Tag {
+  StringRef Name;
+  AvailabilityItem Availability;
+  StringRef SwiftName;
+  Optional<bool> SwiftPrivate;
+  Optional<StringRef> SwiftBridge;
+  Optional<StringRef> NSErrorDomain;
+  Optional<EnumExtensibilityKind> EnumExtensibility;
+  Optional<bool> FlagEnum;
+  Optional<EnumConvenienceAliasKind> EnumConvenienceKind;
+};
+
+typedef std::vector<Tag> TagsSeq;
+} // namespace
+
 LLVM_YAML_IS_SEQUENCE_VECTOR(Tag)
+
+namespace llvm {
+namespace yaml {
+template <> struct ScalarEnumerationTraits<EnumExtensibilityKind> {
+  static void enumeration(IO &IO, EnumExtensibilityKind &EEK) {
+    IO.enumCase(EEK, "none", EnumExtensibilityKind::None);
+    IO.enumCase(EEK, "open", EnumExtensibilityKind::Open);
+    IO.enumCase(EEK, "closed", EnumExtensibilityKind::Closed);
+  }
+};
+
+template <> struct MappingTraits<Tag> {
+  static void mapping(IO &IO, Tag &T) {
+    IO.mapRequired("Name", T.Name);
+    IO.mapOptional("Availability", T.Availability.Mode,
+                   APIAvailability::Available);
+    IO.mapOptional("AvailabilityMsg", T.Availability.Msg, StringRef(""));
+    IO.mapOptional("SwiftPrivate", T.SwiftPrivate);
+    IO.mapOptional("SwiftName", T.SwiftName, StringRef(""));
+    IO.mapOptional("SwiftBridge", T.SwiftBridge);
+    IO.mapOptional("NSErrorDomain", T.NSErrorDomain);
+    IO.mapOptional("EnumExtensibility", T.EnumExtensibility);
+    IO.mapOptional("FlagEnum", T.FlagEnum);
+    IO.mapOptional("EnumKind", T.EnumConvenienceKind);
+  }
+};
+} // namespace yaml
+} // namespace llvm
+
+namespace {
+struct Typedef {
+  StringRef Name;
+  AvailabilityItem Availability;
+  StringRef SwiftName;
+  Optional<bool> SwiftPrivate;
+  Optional<StringRef> SwiftBridge;
+  Optional<StringRef> NSErrorDomain;
+  Optional<SwiftNewTypeKind> SwiftType;
+};
+
+typedef std::vector<Typedef> TypedefsSeq;
+} // namespace
+
 LLVM_YAML_IS_SEQUENCE_VECTOR(Typedef)
+
+namespace llvm {
+namespace yaml {
+template <> struct ScalarEnumerationTraits<SwiftNewTypeKind> {
+  static void enumeration(IO &IO, SwiftNewTypeKind &SWK) {
+    IO.enumCase(SWK, "none", SwiftNewTypeKind::None);
+    IO.enumCase(SWK, "struct", SwiftNewTypeKind::Struct);
+    IO.enumCase(SWK, "enum", SwiftNewTypeKind::Enum);
+  }
+};
+
+template <> struct MappingTraits<Typedef> {
+  static void mapping(IO &IO, Typedef &T) {
+    IO.mapRequired("Name", T.Name);
+    IO.mapOptional("Availability", T.Availability.Mode,
+                   APIAvailability::Available);
+    IO.mapOptional("AvailabilityMsg", T.Availability.Msg, StringRef(""));
+    IO.mapOptional("SwiftPrivate", T.SwiftPrivate);
+    IO.mapOptional("SwiftName", T.SwiftName, StringRef(""));
+    IO.mapOptional("SwiftBridge", T.SwiftBridge);
+    IO.mapOptional("NSErrorDomain", T.NSErrorDomain);
+    IO.mapOptional("SwiftWrapper", T.SwiftType);
+  }
+};
+} // namespace yaml
+} // namespace llvm
+
+namespace {
+struct TopLevelItems {
+  ClassesSeq Classes;
+  ClassesSeq Protocols;
+  FunctionsSeq Functions;
+  GlobalVariablesSeq Globals;
+  EnumConstantsSeq EnumConstants;
+  TagsSeq Tags;
+  TypedefsSeq Typedefs;
+};
+} // namespace
+
+namespace llvm {
+namespace yaml {
+static void mapTopLevelItems(IO &IO, TopLevelItems &TLI) {
+  IO.mapOptional("Classes", TLI.Classes);
+  IO.mapOptional("Protocols", TLI.Protocols);
+  IO.mapOptional("Functions", TLI.Functions);
+  IO.mapOptional("Globals", TLI.Globals);
+  IO.mapOptional("Enumerators", TLI.EnumConstants);
+  IO.mapOptional("Tags", TLI.Tags);
+  IO.mapOptional("Typedefs", TLI.Typedefs);
+}
+} // namespace yaml
+} // namespace llvm
+
+namespace {
+struct Versioned {
+  VersionTuple Version;
+  TopLevelItems Items;
+};
+
+typedef std::vector<Versioned> VersionedSeq;
+} // namespace
+
 LLVM_YAML_IS_SEQUENCE_VECTOR(Versioned)
 
 namespace llvm {
-  namespace yaml {
-
-    template <>
-    struct ScalarEnumerationTraits<NullabilityKind > {
-      static void enumeration(IO &io, NullabilityKind  &value) {
-        io.enumCase(value, "N", NullabilityKind::NonNull);
-        io.enumCase(value, "O", NullabilityKind::Nullable);
-        io.enumCase(value, "U", NullabilityKind::Unspecified);
-        // TODO: Mapping this to it's own value would allow for better cross
-        // checking. Also the default should be Unknown.
-        io.enumCase(value, "S", NullabilityKind::Unspecified);
-      }
-    };
-
-    template <>
-    struct ScalarEnumerationTraits<FactoryAsInitKind> {
-      static void enumeration(IO &io, FactoryAsInitKind  &value) {
-        io.enumCase(value, "A", FactoryAsInitKind::Infer);
-        io.enumCase(value, "C", FactoryAsInitKind::AsClassMethod);
-        io.enumCase(value, "I", FactoryAsInitKind::AsInitializer);
-      }
-    };
-
-    template <>
-    struct ScalarEnumerationTraits<MethodKind> {
-      static void enumeration(IO &io, MethodKind &value) {
-        io.enumCase(value, "Class",    MethodKind::Class);
-        io.enumCase(value, "Instance", MethodKind::Instance);
-      }
-    };
-
-    template <>
-    struct ScalarEnumerationTraits<APIAvailability> {
-      static void enumeration(IO &io, APIAvailability &value) {
-        io.enumCase(value, "OSX",       APIAvailability::OSX);
-        io.enumCase(value, "iOS",       APIAvailability::IOS);
-        io.enumCase(value, "none",      APIAvailability::None);
-        io.enumCase(value, "nonswift",  APIAvailability::NonSwift);
-        io.enumCase(value, "available", APIAvailability::Available);
-      }
-    };
-
-    template<>
-    struct ScalarEnumerationTraits<api_notes::SwiftWrapperKind> {
-      static void enumeration(IO &io, api_notes::SwiftWrapperKind &value) {
-        io.enumCase(value, "none",      api_notes::SwiftWrapperKind::None);
-        io.enumCase(value, "struct",    api_notes::SwiftWrapperKind::Struct);
-        io.enumCase(value, "enum",      api_notes::SwiftWrapperKind::Enum);
-      }
-    };
-
-    template<>
-    struct ScalarEnumerationTraits<api_notes::EnumExtensibilityKind> {
-      static void enumeration(IO &io, api_notes::EnumExtensibilityKind &value) {
-        io.enumCase(value, "none",   api_notes::EnumExtensibilityKind::None);
-        io.enumCase(value, "open",   api_notes::EnumExtensibilityKind::Open);
-        io.enumCase(value, "closed", api_notes::EnumExtensibilityKind::Closed);
-      }
-    };
-
-    template<>
-    struct ScalarEnumerationTraits<EnumConvenienceAliasKind> {
-      static void enumeration(IO &io, EnumConvenienceAliasKind &value) {
-        io.enumCase(value, "none",      EnumConvenienceAliasKind::None);
-        io.enumCase(value, "CFEnum",    EnumConvenienceAliasKind::CFEnum);
-        io.enumCase(value, "NSEnum",    EnumConvenienceAliasKind::CFEnum);
-        io.enumCase(value, "CFOptions", EnumConvenienceAliasKind::CFOptions);
-        io.enumCase(value, "NSOptions", EnumConvenienceAliasKind::CFOptions);
-        io.enumCase(value, "CFClosedEnum",
-                    EnumConvenienceAliasKind::CFClosedEnum);
-        io.enumCase(value, "NSClosedEnum",
-                    EnumConvenienceAliasKind::CFClosedEnum);
-      }
-    };
-
-    template<>
-    struct ScalarEnumerationTraits<api_notes::RetainCountConventionKind> {
-      static void enumeration(IO &io,
-                              api_notes::RetainCountConventionKind &value) {
-        using api_notes::RetainCountConventionKind;
-        io.enumCase(value, "none", RetainCountConventionKind::None);
-        io.enumCase(value, "CFReturnsRetained",
-                    RetainCountConventionKind::CFReturnsRetained);
-        io.enumCase(value, "CFReturnsNotRetained",
-                    RetainCountConventionKind::CFReturnsNotRetained);
-        io.enumCase(value, "NSReturnsRetained",
-                    RetainCountConventionKind::NSReturnsRetained);
-        io.enumCase(value, "NSReturnsNotRetained",
-                    RetainCountConventionKind::NSReturnsNotRetained);
-      }
-    };
-
-    template <>
-    struct MappingTraits<Param> {
-      static void mapping(IO &io, Param& p) {
-        io.mapRequired("Position",              p.Position);
-        io.mapOptional("Nullability",           p.Nullability, 
-                                                AbsentNullability);
-        io.mapOptional("RetainCountConvention", p.RetainCountConvention);
-        io.mapOptional("NoEscape",              p.NoEscape);
-        io.mapOptional("Type",                  p.Type, StringRef(""));
-      }
-    };
-
-    template <>
-    struct MappingTraits<Property> {
-      static void mapping(IO &io, Property& p) {
-        io.mapRequired("Name",            p.Name);
-        io.mapOptional("PropertyKind",    p.Kind);
-        io.mapOptional("Nullability",     p.Nullability, 
-                                          AbsentNullability);
-        io.mapOptional("Availability",    p.Availability.Mode);
-        io.mapOptional("AvailabilityMsg", p.Availability.Msg);
-        io.mapOptional("SwiftPrivate",    p.SwiftPrivate);
-        io.mapOptional("SwiftName",       p.SwiftName);
-        io.mapOptional("SwiftImportAsAccessors", p.SwiftImportAsAccessors);
-        io.mapOptional("Type",            p.Type, StringRef(""));
-      }
-    };
-
-    template <>
-    struct MappingTraits<Method> {
-      static void mapping(IO &io, Method& m) {
-        io.mapRequired("Selector",              m.Selector);
-        io.mapRequired("MethodKind",            m.Kind);
-        io.mapOptional("Parameters",            m.Params);
-        io.mapOptional("Nullability",           m.Nullability);
-        io.mapOptional("NullabilityOfRet",      m.NullabilityOfRet,
-                                                AbsentNullability);
-        io.mapOptional("RetainCountConvention", m.RetainCountConvention);
-        io.mapOptional("Availability",          m.Availability.Mode);
-        io.mapOptional("AvailabilityMsg",       m.Availability.Msg);
-        io.mapOptional("SwiftPrivate",          m.SwiftPrivate);
-        io.mapOptional("SwiftName",             m.SwiftName);
-        io.mapOptional("FactoryAsInit",         m.FactoryAsInit,
-                                                FactoryAsInitKind::Infer);
-        io.mapOptional("DesignatedInit",        m.DesignatedInit, false);
-        io.mapOptional("Required",              m.Required, false);
-        io.mapOptional("ResultType",            m.ResultType, StringRef(""));
-      }
-    };
-
-    template <>
-    struct MappingTraits<Class> {
-      static void mapping(IO &io, Class& c) {
-        io.mapRequired("Name",                  c.Name);
-        io.mapOptional("AuditedForNullability", c.AuditedForNullability, false);
-        io.mapOptional("Availability",          c.Availability.Mode);
-        io.mapOptional("AvailabilityMsg",       c.Availability.Msg);
-        io.mapOptional("SwiftPrivate",          c.SwiftPrivate);
-        io.mapOptional("SwiftName",             c.SwiftName);
-        io.mapOptional("SwiftBridge",           c.SwiftBridge);
-        io.mapOptional("NSErrorDomain",         c.NSErrorDomain);
-        io.mapOptional("SwiftImportAsNonGeneric", c.SwiftImportAsNonGeneric);
-        io.mapOptional("SwiftObjCMembers",      c.SwiftObjCMembers);
-        io.mapOptional("Methods",               c.Methods);
-        io.mapOptional("Properties",            c.Properties);
-      }
-    };
-
-    template <>
-    struct MappingTraits<Function> {
-      static void mapping(IO &io, Function& f) {
-        io.mapRequired("Name",                  f.Name);
-        io.mapOptional("Parameters",            f.Params);
-        io.mapOptional("Nullability",           f.Nullability);
-        io.mapOptional("NullabilityOfRet",      f.NullabilityOfRet,
-                                                AbsentNullability);
-        io.mapOptional("RetainCountConvention", f.RetainCountConvention);
-        io.mapOptional("Availability",          f.Availability.Mode);
-        io.mapOptional("AvailabilityMsg",       f.Availability.Msg);
-        io.mapOptional("SwiftPrivate",          f.SwiftPrivate);
-        io.mapOptional("SwiftName",             f.SwiftName);
-        io.mapOptional("ResultType",            f.ResultType, StringRef(""));
-      }
-    };
-
-    template <>
-    struct MappingTraits<GlobalVariable> {
-      static void mapping(IO &io, GlobalVariable& v) {
-        io.mapRequired("Name",            v.Name);
-        io.mapOptional("Nullability",     v.Nullability,
-                                          AbsentNullability);
-        io.mapOptional("Availability",    v.Availability.Mode);
-        io.mapOptional("AvailabilityMsg", v.Availability.Msg);
-        io.mapOptional("SwiftPrivate",    v.SwiftPrivate);
-        io.mapOptional("SwiftName",       v.SwiftName);
-        io.mapOptional("Type",            v.Type, StringRef(""));
-      }
-    };
-
-    template <>
-    struct MappingTraits<EnumConstant> {
-      static void mapping(IO &io, EnumConstant& v) {
-        io.mapRequired("Name",            v.Name);
-        io.mapOptional("Availability",    v.Availability.Mode);
-        io.mapOptional("AvailabilityMsg", v.Availability.Msg);
-        io.mapOptional("SwiftPrivate",    v.SwiftPrivate);
-        io.mapOptional("SwiftName",       v.SwiftName);
-      }
-    };
-
-    template <>
-    struct MappingTraits<Tag> {
-      static void mapping(IO &io, Tag& t) {
-        io.mapRequired("Name",                  t.Name);
-        io.mapOptional("Availability",          t.Availability.Mode);
-        io.mapOptional("AvailabilityMsg",       t.Availability.Msg);
-        io.mapOptional("SwiftPrivate",          t.SwiftPrivate);
-        io.mapOptional("SwiftName",             t.SwiftName);
-        io.mapOptional("SwiftBridge",           t.SwiftBridge);
-        io.mapOptional("NSErrorDomain",         t.NSErrorDomain);
-        io.mapOptional("EnumExtensibility",     t.EnumExtensibility);
-        io.mapOptional("FlagEnum",              t.FlagEnum);
-        io.mapOptional("EnumKind",              t.EnumConvenienceKind);
-      }
-    };
-
-    template <>
-    struct MappingTraits<Typedef> {
-      static void mapping(IO &io, Typedef& t) {
-        io.mapRequired("Name",                  t.Name);
-        io.mapOptional("Availability",          t.Availability.Mode);
-        io.mapOptional("AvailabilityMsg",       t.Availability.Msg);
-        io.mapOptional("SwiftPrivate",          t.SwiftPrivate);
-        io.mapOptional("SwiftName",             t.SwiftName);
-        io.mapOptional("SwiftBridge",           t.SwiftBridge);
-        io.mapOptional("NSErrorDomain",         t.NSErrorDomain);
-        io.mapOptional("SwiftWrapper",         t.SwiftWrapper);
-      }
-    };
-
-    static void mapTopLevelItems(IO &io, TopLevelItems &i) {
-      io.mapOptional("Classes",         i.Classes);
-      io.mapOptional("Protocols",       i.Protocols);
-      io.mapOptional("Functions",       i.Functions);
-      io.mapOptional("Globals",         i.Globals);
-      io.mapOptional("Enumerators",     i.EnumConstants);
-      io.mapOptional("Tags",            i.Tags);
-      io.mapOptional("Typedefs",        i.Typedefs);
-    }
-
-    template <>
-    struct MappingTraits<Versioned> {
-      static void mapping(IO &io, Versioned& v) {
-        io.mapRequired("Version", v.Version);
-        mapTopLevelItems(io, v.Items);
-      }
-    };
-
-    template <>
-    struct MappingTraits<Module> {
-      static void mapping(IO &io, Module& m) {
-        io.mapRequired("Name",            m.Name);
-        io.mapOptional("Availability",    m.Availability.Mode);
-        io.mapOptional("AvailabilityMsg", m.Availability.Msg);
-        io.mapOptional("SwiftInferImportAsMember", m.SwiftInferImportAsMember);
-
-        mapTopLevelItems(io, m.TopLevel);
-
-        io.mapOptional("SwiftVersions",  m.SwiftVersions);
-      }
-    };
+namespace yaml {
+template <> struct MappingTraits<Versioned> {
+  static void mapping(IO &IO, Versioned &V) {
+    IO.mapRequired("Version", V.Version);
+    mapTopLevelItems(IO, V.Items);
   }
-}
+};
+} // namespace yaml
+} // namespace llvm
 
-using llvm::yaml::Input;
-using llvm::yaml::Output;
+namespace {
+struct Module {
+  StringRef Name;
+  AvailabilityItem Availability;
+  TopLevelItems TopLevel;
+  VersionedSeq SwiftVersions;
+
+  llvm::Optional<bool> SwiftInferImportAsMember = {llvm::None};
+
+  LLVM_DUMP_METHOD void dump() /*const*/;
+};
+} // namespace
+
+namespace llvm {
+namespace yaml {
+template <> struct MappingTraits<Module> {
+  static void mapping(IO &IO, Module &M) {
+    IO.mapRequired("Name", M.Name);
+    IO.mapOptional("Availability", M.Availability.Mode,
+                   APIAvailability::Available);
+    IO.mapOptional("AvailabilityMsg", M.Availability.Msg, StringRef(""));
+    IO.mapOptional("SwiftInferImportAsMember", M.SwiftInferImportAsMember);
+    mapTopLevelItems(IO, M.TopLevel);
+    IO.mapOptional("SwiftVersions", M.SwiftVersions);
+  }
+};
+} // namespace yaml
+} // namespace llvm
 
 void Module::dump() {
-  Output yout(llvm::errs());
-  yout << *this;
+  llvm::yaml::Output OS(llvm::errs());
+  OS << *this;
 }
 
-static bool parseAPINotes(StringRef yamlInput, Module &module,
-                          llvm::SourceMgr::DiagHandlerTy diagHandler,
-                          void *diagHandlerCtxt) {
-  Input yin(yamlInput, nullptr, diagHandler, diagHandlerCtxt);
-  yin >> module;
-
-  return static_cast<bool>(yin.error());
+namespace {
+bool parseAPINotes(StringRef YI, Module &M, llvm::SourceMgr::DiagHandlerTy Diag,
+                   void *DiagContext) {
+  llvm::yaml::Input IS(YI, nullptr, Diag, DiagContext);
+  IS >> M;
+  return static_cast<bool>(IS.error());
 }
+} // namespace
+
+bool clang::api_notes::parseAndDumpAPINotes(StringRef YI,
+                                            llvm::raw_ostream &OS) {
+  Module M;
+  if (parseAPINotes(YI, M, nullptr, nullptr))
+    return true;
+
+  llvm::yaml::Output YOS(OS);
+  YOS << M;
+
+  return false;
+}
+
+#include "clang/APINotes/APINotesReader.h"
+#include "clang/APINotes/Types.h"
+#include "clang/APINotes/APINotesWriter.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/VersionTuple.h"
+#include "llvm/Support/YAMLParser.h"
+#include "llvm/Support/YAMLTraits.h"
+#include <algorithm>
 
 namespace {
   using namespace api_notes;
@@ -703,7 +803,7 @@ namespace {
         outInfo.addTypeInfo(0, *nullabilityOfRet);
         audited = true;
       } else if (audited) {
-        outInfo.addTypeInfo(0, *DefaultNullability);
+        outInfo.addTypeInfo(0, NullabilityKind::NonNull);
       }
       if (audited) {
         outInfo.NullabilityAudited = audited;
@@ -791,7 +891,7 @@ namespace {
         return;
 
       if (cl.AuditedForNullability)
-        cInfo.setDefaultNullability(*DefaultNullability);
+        cInfo.setDefaultNullability(NullabilityKind::NonNull);
       if (cl.SwiftImportAsNonGeneric)
         cInfo.setSwiftImportAsNonGeneric(*cl.SwiftImportAsNonGeneric);
       if (cl.SwiftObjCMembers)
@@ -1008,7 +1108,7 @@ namespace {
         TypedefInfo typedefInfo;
         if (convertCommonType(t, typedefInfo, t.Name))
           continue;
-        typedefInfo.SwiftWrapper = t.SwiftWrapper;
+        typedefInfo.SwiftWrapper = t.SwiftType;
 
         Writer->addTypedef(t.Name, typedefInfo, swiftVersion);
       }
@@ -1051,18 +1151,6 @@ static bool compile(const Module &module,
 
   YAMLConverter c(module, sourceFile, os, diagHandler, diagHandlerCtxt);
   return c.convertModule();
-}
-
-bool api_notes::parseAndDumpAPINotes(StringRef yamlInput)  {
-  Module module;
-
-  if (parseAPINotes(yamlInput, module, nullptr, nullptr))
-    return true;
-
-  Output yout(llvm::outs());
-  yout << module;
-
-  return false;
 }
 
 /// Simple diagnostic handler that prints diagnostics to standard error.

--- a/clang/lib/APINotes/CMakeLists.txt
+++ b/clang/lib/APINotes/CMakeLists.txt
@@ -1,8 +1,7 @@
 set(LLVM_LINK_COMPONENTS
   BitReader
   BitstreamReader
-  Support
-  )
+  Support)
 
 add_clang_library(clangAPINotes
   APINotesManager.cpp
@@ -12,5 +11,5 @@ add_clang_library(clangAPINotes
   Types.cpp
 
   LINK_LIBS
-  clangBasic
+    clangBasic
 )

--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -677,7 +677,7 @@ static void ProcessAPINotes(Sema &S, TypedefNameDecl *D,
                             const api_notes::TypedefInfo &info,
                             VersionedInfoMetadata metadata) {
   // swift_wrapper
-  using SwiftWrapperKind = api_notes::SwiftWrapperKind;
+  using SwiftWrapperKind = api_notes::SwiftNewTypeKind;
 
   if (auto swiftWrapper = info.SwiftWrapper) {
     handleAPINotedAttribute<SwiftNewTypeAttr>(S, D,

--- a/clang/test/APINotes/Inputs/Frameworks/Simple.framework/Headers/Simple.apinotes
+++ b/clang/test/APINotes/Inputs/Frameworks/Simple.framework/Headers/Simple.apinotes
@@ -1,0 +1,28 @@
+Name:            SimpleKit
+Classes:
+  - Name:            I
+    Properties:
+      - Name:            nonnullProperty
+        PropertyKind:    Class
+        Nullability:     N
+      - Name:            nonnullNewProperty
+        PropertyKind:    Class
+        Nullability:     Nonnull
+      - Name:            optionalProperty
+        PropertyKind:    Class
+        Nullability:     O
+      - Name:            optionalNewProperty
+        PropertyKind:    Class
+        Nullability:     Optional
+      - Name:            unspecifiedProperty
+        PropertyKind:    Instance
+        Nullability:     U
+      - Name:            unspecifiedNewProperty
+        PropertyKind:    Instance
+        Nullability:     Unspecified
+      - Name:            scalarProperty
+        PropertyKind:    Instance
+        Nullability:     S
+      - Name:            scalarNewProperty
+        PropertyKind:    Instance
+        Nullability:     Scalar

--- a/clang/test/APINotes/Inputs/Frameworks/Simple.framework/Headers/Simple.h
+++ b/clang/test/APINotes/Inputs/Frameworks/Simple.framework/Headers/Simple.h
@@ -1,0 +1,19 @@
+#ifndef SIMPLE_H
+#define SIMPLE_H
+
+__attribute__((__objc_root__))
+@interface I
+@property(class, nonatomic, readonly) id nonnullProperty;
+@property(class, nonatomic, readonly) id nonnullNewProperty;
+
+@property(class, nonatomic, readonly) id optionalProperty;
+@property(class, nonatomic, readonly) id optionalNewProperty;
+
+@property(nonatomic, readonly) id unspecifiedProperty;
+@property(nonatomic, readonly) id unspecifiedNewProperty;
+
+@property(nonatomic, readonly) id scalarProperty;
+@property(nonatomic, readonly) id scalarNewProperty;
+@end
+
+#endif

--- a/clang/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.apinotes
+++ b/clang/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.apinotes
@@ -1,48 +1,48 @@
-Name: SimpleKit
-Tags:
-- Name: RenamedAgainInAPINotesA
-  SwiftName: SuccessfullyRenamedA
-- Name: RenamedAgainInAPINotesB
-  SwiftName: SuccessfullyRenamedB
-Functions:
-- Name: getCFOwnedToUnowned
-  RetainCountConvention: CFReturnsNotRetained
-- Name: getCFUnownedToOwned
-  RetainCountConvention: CFReturnsRetained
-- Name: getCFOwnedToNone
-  RetainCountConvention: none
-- Name: getObjCOwnedToUnowned
-  RetainCountConvention: NSReturnsNotRetained
-- Name: getObjCUnownedToOwned
-  RetainCountConvention: NSReturnsRetained
-- Name: indirectGetCFOwnedToUnowned
-  Parameters:
-  - Position: 0
-    RetainCountConvention: CFReturnsNotRetained
-- Name: indirectGetCFUnownedToOwned
-  Parameters:
-  - Position: 0
-    RetainCountConvention: CFReturnsRetained
-- Name: indirectGetCFOwnedToNone
-  Parameters:
-  - Position: 0
-    RetainCountConvention: none
-- Name: indirectGetCFNoneToOwned
-  Parameters:
-  - Position: 0
-    RetainCountConvention: CFReturnsNotRetained
-- Name: getCFAuditedToUnowned_DUMP
-  RetainCountConvention: CFReturnsNotRetained
-- Name: getCFAuditedToOwned_DUMP
-  RetainCountConvention: CFReturnsRetained
-- Name: getCFAuditedToNone_DUMP
-  RetainCountConvention: none
+Name:            SimpleKit
 Classes:
-- Name: MethodTest
-  Methods:
-  - Selector: getOwnedToUnowned
-    MethodKind: Instance
+  - Name:            MethodTest
+    Methods:
+      - Selector:        getOwnedToUnowned
+        MethodKind:      Instance
+        RetainCountConvention: NSReturnsNotRetained
+      - Selector:        getUnownedToOwned
+        MethodKind:      Instance
+        RetainCountConvention: NSReturnsRetained
+Functions:
+  - Name:            getCFOwnedToUnowned
+    RetainCountConvention: CFReturnsNotRetained
+  - Name:            getCFUnownedToOwned
+    RetainCountConvention: CFReturnsRetained
+  - Name:            getCFOwnedToNone
+    RetainCountConvention: none
+  - Name:            getObjCOwnedToUnowned
     RetainCountConvention: NSReturnsNotRetained
-  - Selector: getUnownedToOwned
-    MethodKind: Instance
+  - Name:            getObjCUnownedToOwned
     RetainCountConvention: NSReturnsRetained
+  - Name:            indirectGetCFOwnedToUnowned
+    Parameters:
+      - Position:        0
+        RetainCountConvention: CFReturnsNotRetained
+  - Name:            indirectGetCFUnownedToOwned
+    Parameters:
+      - Position:        0
+        RetainCountConvention: CFReturnsRetained
+  - Name:            indirectGetCFOwnedToNone
+    Parameters:
+      - Position:        0
+        RetainCountConvention: none
+  - Name:            indirectGetCFNoneToOwned
+    Parameters:
+      - Position:        0
+        RetainCountConvention: CFReturnsNotRetained
+  - Name:            getCFAuditedToUnowned_DUMP
+    RetainCountConvention: CFReturnsNotRetained
+  - Name:            getCFAuditedToOwned_DUMP
+    RetainCountConvention: CFReturnsRetained
+  - Name:            getCFAuditedToNone_DUMP
+    RetainCountConvention: none
+Tags:
+  - Name:            RenamedAgainInAPINotesA
+    SwiftName:       SuccessfullyRenamedA
+  - Name:            RenamedAgainInAPINotesB
+    SwiftName:       SuccessfullyRenamedB

--- a/clang/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.h
+++ b/clang/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.h
@@ -1,20 +1,20 @@
 struct RenamedAgainInAPINotesA {
   int field;
-} __attribute__((swift_name("bad")));
+} __attribute__((__swift_name__("bad")));
 
-struct __attribute__((swift_name("bad"))) RenamedAgainInAPINotesB {
+struct __attribute__((__swift_name__("bad"))) RenamedAgainInAPINotesB {
   int field;
 };
 
-void *getCFOwnedToUnowned(void) __attribute__((cf_returns_retained));
-void *getCFUnownedToOwned(void) __attribute__((cf_returns_not_retained));
-void *getCFOwnedToNone(void) __attribute__((cf_returns_retained));
-id getObjCOwnedToUnowned(void) __attribute__((ns_returns_retained));
-id getObjCUnownedToOwned(void) __attribute__((ns_returns_not_retained));
+void *getCFOwnedToUnowned(void) __attribute__((__cf_returns_retained__));
+void *getCFUnownedToOwned(void) __attribute__((__cf_returns_not_retained__));
+void *getCFOwnedToNone(void) __attribute__((__cf_returns_retained__));
+id getObjCOwnedToUnowned(void) __attribute__((__ns_returns_retained__));
+id getObjCUnownedToOwned(void) __attribute__((__ns_returns_not_retained__));
 
-int indirectGetCFOwnedToUnowned(void **out __attribute__((cf_returns_retained)));
-int indirectGetCFUnownedToOwned(void **out __attribute__((cf_returns_not_retained)));
-int indirectGetCFOwnedToNone(void **out __attribute__((cf_returns_retained)));
+int indirectGetCFOwnedToUnowned(void **out __attribute__((__cf_returns_retained__)));
+int indirectGetCFUnownedToOwned(void **out __attribute__((__cf_returns_not_retained__)));
+int indirectGetCFOwnedToNone(void **out __attribute__((__cf_returns_retained__)));
 int indirectGetCFNoneToOwned(void **out);
 
 #pragma clang arc_cf_code_audited begin
@@ -24,6 +24,6 @@ void *getCFAuditedToNone_DUMP(void);
 #pragma clang arc_cf_code_audited end
 
 @interface MethodTest
-- (id)getOwnedToUnowned __attribute__((ns_returns_retained));
-- (id)getUnownedToOwned __attribute__((ns_returns_not_retained));
+- (id)getOwnedToUnowned __attribute__((__ns_returns_retained__));
+- (id)getUnownedToOwned __attribute__((__ns_returns_not_retained__));
 @end

--- a/clang/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/module.modulemap
+++ b/clang/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/module.modulemap
@@ -1,0 +1,5 @@
+framework module SimpleKit {
+  umbrella header "SimpleKit.h"
+  export *
+  module * { export * }
+}

--- a/clang/test/APINotes/yaml-roundtrip-2.test
+++ b/clang/test/APINotes/yaml-roundtrip-2.test
@@ -1,0 +1,11 @@
+RUN: apinotes-test %S/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.apinotes > %t.result
+RUN: not diff --ed %t.result %S/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.apinotes | FileCheck %s
+
+The `--ed` parameter to `diff` is not implemented in the builtin diff, assume
+that we have a GNU compatible diff when we have a shell.
+REQUIRES: shell
+
+We expect only the document markers to be emitted
+
+CHECK: 50d
+CHECK: 1d

--- a/clang/test/APINotes/yaml-roundtrip.test
+++ b/clang/test/APINotes/yaml-roundtrip.test
@@ -1,0 +1,26 @@
+RUN: apinotes-test %S/Inputs/Frameworks/Simple.framework/Headers/Simple.apinotes > %t.result
+RUN: not diff --strip-trailing-cr %S/Inputs/Frameworks/Simple.framework/Headers/Simple.apinotes %t.result | FileCheck %s
+
+We expect only the nullability to be different as it is canonicalized during the
+roudtrip.
+
+CHECK:      7c8
+CHECK-NEXT: <         Nullability:     N
+CHECK-NEXT: ---
+CHECK-NEXT: >         Nullability:     Nonnull
+CHECK-NEXT: 13c14
+CHECK-NEXT: <         Nullability:     O
+CHECK-NEXT: ---
+CHECK-NEXT: >         Nullability:     Optional
+CHECK-NEXT: 19c20
+CHECK-NEXT: <         Nullability:     U
+CHECK-NEXT: ---
+CHECK-NEXT: >         Nullability:     Unspecified
+CHECK-NEXT: 25c26
+CHECK-NEXT: <         Nullability:     S
+CHECK-NEXT: ---
+CHECK-NEXT: >         Nullability:     Unspecified
+CHECK-NEXT: 28c29,30
+CHECK-NEXT: <         Nullability:     Scalar
+CHECK-NEXT: ---
+CHECK-NEXT: >         Nullability:     Unspecified

--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -58,6 +58,7 @@ if(CLANG_TEST_USE_VG)
 endif ()
 
 list(APPEND CLANG_TEST_DEPS
+  apinotes-test
   c-index-test
   clang
   clang-resource-headers

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -63,7 +63,8 @@ config.substitutions.append(('%PATH%', config.environment['PATH']))
 tool_dirs = [config.clang_tools_dir, config.llvm_tools_dir]
 
 tools = [
-    'c-index-test', 'clang-diff', 'clang-format', 'clang-tblgen', 'opt', 'llvm-ifs',
+    'apinotes-test', 'c-index-test', 'clang-diff', 'clang-format',
+    'clang-tblgen', 'opt', 'llvm-ifs',
     ToolSubst('%clang_extdef_map', command=FindTool(
         'clang-extdef-mapping'), unresolved='ignore'),
 ]

--- a/clang/tools/CMakeLists.txt
+++ b/clang/tools/CMakeLists.txt
@@ -2,6 +2,7 @@ create_subdirectory_options(CLANG TOOL)
 
 add_clang_subdirectory(diagtool)
 add_clang_subdirectory(driver)
+add_clang_subdirectory(apinotes-test)
 add_clang_subdirectory(clang-diff)
 add_clang_subdirectory(clang-format)
 add_clang_subdirectory(clang-format-vs)

--- a/clang/tools/apinotes-test/APINotesTest.cpp
+++ b/clang/tools/apinotes-test/APINotesTest.cpp
@@ -1,0 +1,53 @@
+//===-- APINotesTest.cpp - API Notes Testing Tool ------------------ C++ --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/APINotes/APINotesYAMLCompiler.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Signals.h"
+#include "llvm/Support/ToolOutputFile.h"
+#include "llvm/Support/WithColor.h"
+
+static llvm::cl::list<std::string> APINotes(llvm::cl::Positional,
+                                            llvm::cl::desc("[<apinotes> ...]"),
+                                            llvm::cl::Required);
+
+static llvm::cl::opt<std::string>
+    OutputFileName("o", llvm::cl::desc("output filename"),
+                   llvm::cl::value_desc("filename"), llvm::cl::init("-"));
+
+int main(int argc, const char **argv) {
+  const bool DisableCrashReporting = true;
+  llvm::sys::PrintStackTraceOnErrorSignal(argv[0], DisableCrashReporting);
+  llvm::cl::ParseCommandLineOptions(argc, argv);
+
+  auto Error = [](const llvm::Twine &Msg) {
+    llvm::WithColor::error(llvm::errs(), "apinotes-test") << Msg << '\n';
+  };
+
+  std::error_code EC;
+  auto Out = std::make_unique<llvm::ToolOutputFile>(OutputFileName, EC,
+                                                    llvm::sys::fs::OF_None);
+  if (EC) {
+    Error("failed to open '" + OutputFileName + "': " + EC.message());
+    return EXIT_FAILURE;
+  }
+
+  for (const std::string &Notes : APINotes) {
+    llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> NotesOrError =
+        llvm::MemoryBuffer::getFileOrSTDIN(Notes);
+    if (std::error_code EC = NotesOrError.getError()) {
+      llvm::errs() << EC.message() << '\n';
+      return EXIT_FAILURE;
+    }
+
+    clang::api_notes::parseAndDumpAPINotes((*NotesOrError)->getBuffer(),
+                                           Out->os());
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/clang/tools/apinotes-test/CMakeLists.txt
+++ b/clang/tools/apinotes-test/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(LLVM_LINK_COMPONENTS
+  Support)
+add_clang_executable(apinotes-test
+  APINotesTest.cpp)
+clang_target_link_libraries(apinotes-test PRIVATE
+  clangAPINotes)


### PR DESCRIPTION
This adds the skeleton of the YAML Compiler for APINotes.  This change
only adds the YAML IO model for the API Notes along with a new testing
tool `apinotes-test` which can be used to verify that can round trip the
YAML content properly.  It provides the basis for the future work which
will add a binary serialization and deserialization format to the data
model.