### PR TITLE
Wrap constructor in #ifndef NDEBUG

### DIFF
--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -61,7 +61,9 @@ struct TestSwiftASTContext : public testing::Test {
 };
 
 struct SwiftASTContextTester : public SwiftASTContext {
-  SwiftASTContextTester() : SwiftASTContext() {}
+  #ifndef NDEBUG
+    SwiftASTContextTester() : SwiftASTContext() {}
+  #endif
 
   static std::string GetResourceDir(llvm::StringRef platform_sdk_path,
                                     std::string swift_dir,


### PR DESCRIPTION
After [5165064](https://github.com/apple/llvm-project/commit/51650649d9b62bfd025fdf674368584bddf4841a), `TestSwiftASTContext` fails when `-NDEBUG` is set because the constructor is wrapped in `#ifndef NDEBUG`. This change wraps the use of the constructor as well.

Resolves the failure:
```
/home/michellecasbon/release_0.12/llvm-project/lldb/unittests/Symbol/TestSwiftASTContext.cpp:64:29: error:
      no matching constructor for initialization of
      'lldb_private::SwiftASTContext'
  SwiftASTContextTester() : SwiftASTContext() {}
                            ^
/home/michellecasbon/release_0.12/llvm-project/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h:146:3: note:
      candidate constructor not viable: requires single argument 'rhs', but no
      arguments were provided
  SwiftASTContext(const SwiftASTContext &rhs) = delete;
  ^
/home/michellecasbon/release_0.12/llvm-project/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h:143:3: note:
      candidate constructor not viable: requires at least 2 arguments, but 0 were
      provided
  SwiftASTContext(std::string description, llvm::Triple triple,
  ^
1 error generated.
```