### PR TITLE
[TargetList] Simplify dummy target creation

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -440,6 +440,7 @@ class Target : public std::enable_shared_from_this<Target>,
                public ModuleList::Notifier {
 public:
   friend class TargetList;
+  friend class Debugger;
 
   /// Broadcaster event bits definitions.
   enum {

--- a/lldb/include/lldb/Target/TargetList.h
+++ b/lldb/include/lldb/Target/TargetList.h
@@ -183,28 +183,21 @@ protected:
   typedef std::vector<lldb::TargetSP> collection;
   // Member variables.
   collection m_target_list;
-  lldb::TargetSP m_dummy_target_sp;
   mutable std::recursive_mutex m_target_list_mutex;
   uint32_t m_selected_target_idx;
 
 private:
-  lldb::TargetSP GetDummyTarget(lldb_private::Debugger &debugger);
-
-  Status CreateDummyTarget(Debugger &debugger,
-                           llvm::StringRef specified_arch_name,
-                           lldb::TargetSP &target_sp);
-
   Status CreateTargetInternal(Debugger &debugger, llvm::StringRef user_exe_path,
                               llvm::StringRef triple_str,
                               LoadDependentFiles load_dependent_files,
                               const OptionGroupPlatform *platform_options,
-                              lldb::TargetSP &target_sp, bool is_dummy_target);
+                              lldb::TargetSP &target_sp);
 
   Status CreateTargetInternal(Debugger &debugger, llvm::StringRef user_exe_path,
                               const ArchSpec &arch,
                               LoadDependentFiles get_dependent_modules,
                               lldb::PlatformSP &platform_sp,
-                              lldb::TargetSP &target_sp, bool is_dummy_target);
+                              lldb::TargetSP &target_sp);
 
   TargetList(const TargetList &) = delete;
   const TargetList &operator=(const TargetList &) = delete;

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -678,7 +678,16 @@ Debugger::Debugger(lldb::LogOutputCallback log_callback, void *baton)
   assert(default_platform_sp);
   m_platform_list.Append(default_platform_sp, true);
 
-  m_dummy_target_sp = m_target_list.GetDummyTarget(*this);
+  // Create the dummy target.
+  {
+    ArchSpec arch(Target::GetDefaultArchitecture());
+    if (!arch.IsValid())
+      arch = HostInfo::GetArchitecture();
+    assert(arch.IsValid() && "No valid default or host archspec");
+    const bool is_dummy_target = true;
+    m_dummy_target_sp.reset(
+        new Target(*this, arch, default_platform_sp, is_dummy_target));
+  }
   assert(m_dummy_target_sp.get() && "Couldn't construct dummy target?");
 
   m_collection_sp->Initialize(g_debugger_properties);


### PR DESCRIPTION
Factor out dummy target creation from CreateTargetInternal.

This makes it impossible for dummy target creation to accidentally fail
due to too-strict checking in one of the CreateTargetInternal overloads.

Testing: check-lldb

rdar://70630655

Differential Revision: https://reviews.llvm.org/D90872

(cherry picked from commit 16e5a347e70b4c819ff440dddd2320457cc2c8ca)
