### PR TITLE
Disable tests with invalid `SwiftShims` references 

### DIFF
--- a/lldb/test/API/lang/swift/closure_shortcuts/TestClosureShortcuts.py
+++ b/lldb/test/API/lang/swift/closure_shortcuts/TestClosureShortcuts.py
@@ -12,5 +12,9 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest])
+# SWIFT_ENABLE_TENSORFLOW
+# TODO(TF-1348): Resolve the SwiftShims incompatibility when clangimporter is
+#   disabled.
+# lldbinline.MakeInlineTest(__file__, globals(),
+#                           decorators=[swiftTest])
+# SWIFT_ENABLE_TENSORFLOW END

--- a/lldb/test/API/lang/swift/expression/simple/TestSimpleExpressions.py
+++ b/lldb/test/API/lang/swift/expression/simple/TestSimpleExpressions.py
@@ -160,8 +160,12 @@ class TestSimpleSwiftExpressions(TestBase):
             '"Five: \(is_five) " + "Six: \(is_six)"',
             '"Five: 5 Six: 6"')
 
-        # Next let's try some simple array accesses:
-        self.check_expression("an_int_array[0]", "5", use_summary=False)
+        # SWIFT_ENABLE_TENSORFLOW
+        # TODO(TF-1348): Resolve the SwiftShims incompatibility when
+        #   clangimporter is disabled.
+        # # Next let's try some simple array accesses:
+        # self.check_expression("an_int_array[0]", "5", use_summary=False)
+        # SWIFT_ENABLE_TENSORFLOW END
 
         # Test expression with read-only variables:
         self.check_expression("b_struct.b_read_only == 5", "true")

--- a/lldb/test/API/lang/swift/expression/simple/main.swift
+++ b/lldb/test/API/lang/swift/expression/simple/main.swift
@@ -105,8 +105,12 @@ func main () -> Void
     var eleven_by_dict = str_int_dict["five"]! + str_int_dict["six"]! // Dict breakpoint
     var eleven_str = int_str_dict[11]
 
-    var an_int_array : Array<Int64> = [is_five, is_six, is_eleven]
-    an_int_array.append(13)
+    // SWIFT_ENABLE_TENSORFLOW
+    // TODO(TF-1348): Resolve the SwiftShims incompatibility when
+    //   clangimporter is disabled.
+    // var an_int_array : Array<Int64> = [is_five, is_six, is_eleven]
+    // an_int_array.append(13)
+    // SWIFT_ENABLE_TENSORFLOW END
 
     var b_struct = B(b_int:5)
     b_struct.b_int = b_struct.b_read_only


### PR DESCRIPTION
Disables `lldb-api :: lang/swift/closure_shortcuts/TestClosureShortcuts.py` and a portion of 
`lldb-api :: lang/swift/expression/simple/TestSimpleExpressions.py`.

These tests throw a deserialization error when run with the `dotest-args=--setting symbols.use-swift-clangimporter=false` option.

```
*** DESERIALIZATION FAILURE (please include this section in any bug report) ***
could not deserialize type for '_storage': top-level value not found
Cross-reference to module 'SwiftShims'
... _SwiftArrayBodyStorage
```

Re-enabling tracked by [TF-1348](https://bugs.swift.org/browse/TF-1348).