### PR TITLE
[ScheduleDAGRRList] Pacify overload mismatch in std::min.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGRRList.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGRRList.cpp
@@ -1841,7 +1841,8 @@ static SUnit *popFromQueueImpl(std::vector<SUnit *> &Q, SF &Picker) {
   unsigned BestIdx = 0;
   // Only compute the cost for the first 1000 items in the queue, to avoid
   // excessive compile-times for very large queues.
-  for (unsigned I = 1, E = std::min(Q.size(), 1000ul); I != E; I++)
+  for (unsigned I = 1, E = std::min(Q.size(), (decltype(Q.size()))1000); I != E;
+       I++)
     if (Picker(Q[BestIdx], Q[I]))
       BestIdx = I;
   SUnit *V = Q[BestIdx];


### PR DESCRIPTION
On systems where size() doesn't return unsigned long, this leads to an
overloading mismatch. Convert the constant to whatever type is used for
Q.size() on the system.