### PR TITLE
[WIP] [lldb] Set up basic support for generic expressions

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -62,19 +62,21 @@ public:
   typedef std::shared_ptr<VariableMetadata> VariableMetadataSP;
 
   struct VariableInfo {
+    CompilerType GetStaticType() const { return m_static_type; }
     CompilerType GetType() const { return m_type; }
     swift::Identifier GetName() const { return m_name; }
     swift::VarDecl *GetDecl() const { return m_decl; }
     swift::VarDecl::Introducer GetVarIntroducer() const;
     bool GetIsCaptureList() const;
 
-    VariableInfo() : m_type(), m_name(), m_metadata() {}
+    VariableInfo() : m_static_type(), m_type(), m_name(), m_metadata() {}
 
-    VariableInfo(CompilerType &type, swift::Identifier name,
+    VariableInfo(CompilerType &static_type,
+                 CompilerType &type, swift::Identifier name,
                  VariableMetadataSP metadata, 
                  swift::VarDecl::Introducer introducer, 
                  bool is_capture_list = false)
-        : m_type(type), m_name(name), m_var_introducer(introducer),
+        : m_static_type(static_type), m_type(type), m_name(name), m_var_introducer(introducer),
           m_is_capture_list(is_capture_list), m_metadata(metadata) {}
 
     template <class T> bool MetadataIs() const {
@@ -88,6 +90,7 @@ public:
     friend class SwiftASTManipulator;
 
   protected:
+    CompilerType m_static_type;
     CompilerType m_type;
     swift::Identifier m_name;
     swift::VarDecl *m_decl = nullptr;
@@ -155,7 +158,8 @@ public:
                                       CompilerType &type,
                                       VariableMetadataSP &metadata_sp);
 
-  bool AddExternalVariables(llvm::MutableArrayRef<VariableInfo> variables);
+  bool AddExternalVariables(
+      llvm::MutableArrayRef<VariableInfo> variables, bool force_use_wrapped_function = false);
 
   bool RewriteResult();
 
@@ -175,6 +179,8 @@ public:
                                         bool make_private = true);
 
   bool FixupResultAfterTypeChecking(Status &error);
+
+  void SetupGenericParameters();
 
   static const char *GetArgumentName() { return "$__lldb_arg"; }
   static const char *GetResultName() { return "$__lldb_result"; }


### PR DESCRIPTION
Possible solution for https://bugs.swift.org/browse/SR-12397

This PR sets up for evaluating expressions involving generic types.

## Approach

Instead of only having `$__lldb_expr`, have two functions `$__lldb_expr` and `$__lldb_wrapped_expr`. Pass in all the previously generic variables in the environemnt as generics once more as arguments to `$__lldb_wrapped_expr`.

Example for illustration:

```
func f<T>(_ foo: T) {
    let test = foo != nil // breakpoint here
    print(test)
}
let x: Int? = nil
f(x)
```

For the example above, this setup would would look like:

```
func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {
  @LLDBDebuggerFunction
  func $__lldb_wrapped_expr<T>(_ $__lldb_arg : UnsafeMutablePointer<Any>, foo: T) {
    // user expression here, along with error handling, etc.
  }
  $__lldb_wrapped_expr($__lldb_arg, foo: foo)
}

```

This will correctly print `true` for the expression `foo != nil`.
Also, it might be relevant that the initial approach that LLDB took with generic arguments looks pretty similar to this, although the generic arguments used to be placed inside `WrapExpression` (https://github.com/apple/llvm-project/commit/bd28bd5a3b139d1f4cd3301bde71ef62185f61b8 - look at SwiftASTManipulator.cpp, lines 320-342).

## Problem

The biggest problem with this approach is that it won't use the substituted type when that's more convenient. For example:
```
(lldb) e foo
(T) $R0 = 0x010000000000000000
(lldb) e foo as! Int?
(Int?) $R0 = nil
```

While beforehand, this would be the output:
```
(lldb) e foo
(Int?) $R0 = nil
```

I'm hoping there's some clean solution to this.

There are also some parts missing with this PR, requirements are ignored, evaluation inside classes is ignored, setting up more than one variable per generic type is broken for now, and I think the code could be a lot cleaner. All of this should be straightforward to fix, but I wanted to gather some feedback on this approach before going forward.

@vedantk, @adrian-prantl what do you think?