### PR TITLE
[lldb] Re-enable TestSwiftStaticArchiveTwoSwiftmodules

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
+++ b/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
@@ -25,7 +25,6 @@ class TestSwiftStaticArchiveTwoSwiftmodules(TestBase):
         TestBase.setUp(self)
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
-    @skipIfDarwin # 'rdar://68891755'
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin
     @swiftTest


### PR DESCRIPTION
Fixed by https://github.com/apple/llvm-project/pull/2019