### PR TITLE
[lldb] Fix build after removal of eValueTypeVector

### DIFF
--- a/lldb/source/Core/ValueObjectVariable.cpp
+++ b/lldb/source/Core/ValueObjectVariable.cpp
@@ -256,7 +256,6 @@ bool ValueObjectVariable::UpdateValue() {
         break;
       case Value::eValueTypeLoadAddress:
       case Value::eValueTypeScalar:
-      case Value::eValueTypeVector:
         SetAddressTypeOfChildren(eAddressTypeLoad);
         break;
       }


### PR DESCRIPTION
This was removed in 5d64574301836c4c17127794121d49a62d24f803 and but that
commit didn't remove the usage in some code that is part of a downstream patch.