### PR TITLE
The AssertRecognizer used the module from a frames SC without checkin…

### DIFF
--- a/lldb/source/Target/AssertFrameRecognizer.cpp
+++ b/lldb/source/Target/AssertFrameRecognizer.cpp
@@ -130,7 +130,8 @@ AssertFrameRecognizer::RecognizeFrame(lldb::StackFrameSP frame_sp) {
     SymbolContext sym_ctx =
         prev_frame_sp->GetSymbolContext(eSymbolContextEverything);
 
-    if (!sym_ctx.module_sp->GetFileSpec().FileEquals(location.module_spec))
+    if (!sym_ctx.module_sp ||
+        !sym_ctx.module_sp->GetFileSpec().FileEquals(location.module_spec))
       continue;
 
     ConstString func_name = sym_ctx.GetFunctionName();


### PR DESCRIPTION
…g it was non-null.

I only have a crash report for this.  I could reproduce it with a slightly older
lldb by running an expression that called pthread_kill, but we started making modules
for our expression JIT code, so that no longer triggers the bug.  I can't think of another
good way to test it but the fix is obvious.

(cherry picked from commit 5a4b2e1541f399c146a4ef5cf8f6aaf8b258a77b)