### PR TITLE
[lldb] Make `process connect` behave the same in sync and async mode.

### DIFF
--- a/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.cpp
+++ b/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.cpp
@@ -832,18 +832,6 @@ std::string PlatformRemoteGDBServer::MakeUrl(const char *scheme,
   return std::string(result.GetString());
 }
 
-lldb::ProcessSP PlatformRemoteGDBServer::ConnectProcess(
-    llvm::StringRef connect_url, llvm::StringRef plugin_name,
-    lldb_private::Debugger &debugger, lldb_private::Target *target,
-    lldb_private::Status &error) {
-  if (!IsRemote() || !IsConnected()) {
-    error.SetErrorString("Not connected to remote gdb server");
-    return nullptr;
-  }
-  return Platform::ConnectProcess(connect_url, plugin_name, debugger, target,
-                                  error);
-}
-
 size_t PlatformRemoteGDBServer::ConnectToWaitingProcesses(Debugger &debugger,
                                                           Status &error) {
   std::vector<std::string> connection_urls;

--- a/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.h
+++ b/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.h
@@ -151,12 +151,6 @@ public:
 
   const lldb::UnixSignalsSP &GetRemoteUnixSignals() override;
 
-  lldb::ProcessSP ConnectProcess(llvm::StringRef connect_url,
-                                 llvm::StringRef plugin_name,
-                                 lldb_private::Debugger &debugger,
-                                 lldb_private::Target *target,
-                                 lldb_private::Status &error) override;
-
   size_t ConnectToWaitingProcesses(lldb_private::Debugger &debugger,
                                    lldb_private::Status &error) override;
 

--- a/lldb/test/Shell/Commands/command-process-connect.test
+++ b/lldb/test/Shell/Commands/command-process-connect.test
@@ -1,0 +1,9 @@
+# Synchronous
+# RUN: %lldb -o 'platform select remote-gdb-server' -o 'process connect connect://localhost:4321' 2>&1 | FileCheck %s
+
+# Asynchronous
+# RUN: echo -e 'platform select remote-gdb-server\nprocess connect connect://localhost:4321' | %lldb 2>&1 | FileCheck %s
+
+# CHECK: Platform: remote-gdb-server
+# CHECK: Connected: no
+# CHECK: error: Failed to connect port


### PR DESCRIPTION
I think the check for whether the process is connected is totally bogus
in the first place, but on the off-chance that's it's not, we should
behave the same in synchronous and asynchronous mode.

(cherry picked from commit 6c0cd5676e0a0feaf836e0399023a6e21224467b)