### PR TITLE
[lldb] Split out failing portion of Swift TestNSError

### DIFF
--- a/lldb/test/API/lang/swift/nserror/TestNSError.py
+++ b/lldb/test/API/lang/swift/nserror/TestNSError.py
@@ -32,7 +32,7 @@ class SwiftNSErrorTest(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @expectedFailureAll(bugnumber="rdar://71549869")
+    @skipIf(bugnumber="rdar://71549869")
     def test_swift_nserror_fails(self):
         """Tests that Swift displays NSError correctly"""
         self.build()


### PR DESCRIPTION
TestNSError partially succeeds, but the `userInfo` dictionary is treated as `id` instead of its dynamic type of `NSDictionary`. This causes its value to be printed as just a pointer. This change splits the test so that NSError is still partially tested, but the broken `userInfo` expectation is marked as an expected fail.