### PR TITLE
Cherry-pick commits for -fallow-pcm-with-compiler-errors change

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4262,6 +4262,8 @@ def fno_validate_pch : Flag<["-"], "fno-validate-pch">,
   HelpText<"Disable validation of precompiled headers">;
 def fallow_pch_with_errors : Flag<["-"], "fallow-pch-with-compiler-errors">,
   HelpText<"Accept a PCH file that was created with compiler errors">;
+def fallow_pcm_with_errors : Flag<["-"], "fallow-pcm-with-compiler-errors">,
+  HelpText<"Accept a PCM file that was created with compiler errors">;
 def dump_deserialized_pch_decls : Flag<["-"], "dump-deserialized-decls">,
   HelpText<"Dump declarations that are deserialized from PCH, for testing">;
 def error_on_deserialized_pch_decl : Separate<["-"], "error-on-deserialized-decl">,

--- a/clang/include/clang/Frontend/ASTUnit.h
+++ b/clang/include/clang/Frontend/ASTUnit.h
@@ -694,7 +694,7 @@ public:
       const FileSystemOptions &FileSystemOpts, bool UseDebugInfo = false,
       bool OnlyLocalDecls = false, ArrayRef<RemappedFile> RemappedFiles = None,
       CaptureDiagsKind CaptureDiagnostics = CaptureDiagsKind::None,
-      bool AllowPCHWithCompilerErrors = false,
+      bool AllowASTWithCompilerErrors = false,
       bool UserFilesAreVolatile = false);
 
 private:

--- a/clang/include/clang/Frontend/FrontendActions.h
+++ b/clang/include/clang/Frontend/FrontendActions.h
@@ -117,6 +117,8 @@ protected:
   }
 
   bool hasASTFileSupport() const override { return false; }
+
+  bool shouldEraseOutputFiles() override;
 };
 
 class GenerateInterfaceStubsAction : public ASTFrontendAction {

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -303,6 +303,9 @@ public:
   /// When using -emit-module, treat the modulemap as a system module.
   unsigned IsSystemModule : 1;
 
+  unsigned IndexIgnoreSystemSymbols : 1;
+  unsigned IndexRecordCodegenName : 1;
+
   /// Output (and read) PCM files regardless of compiler errors.
   unsigned AllowPCMWithCompilerErrors : 1;
 
@@ -378,8 +381,6 @@ public:
   std::string ARCMTMigrateReportOut;
 
   std::string IndexStorePath;
-  unsigned IndexIgnoreSystemSymbols : 1;
-  unsigned IndexRecordCodegenName : 1;
 
   /// The input files and their types.
   SmallVector<FrontendInputFile, 0> Inputs;

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -303,6 +303,9 @@ public:
   /// When using -emit-module, treat the modulemap as a system module.
   unsigned IsSystemModule : 1;
 
+  /// Output (and read) PCM files regardless of compiler errors.
+  unsigned AllowPCMWithCompilerErrors : 1;
+
   CodeCompleteOptions CodeCompleteOpts;
 
   /// Specifies the output format of the AST.
@@ -463,7 +466,7 @@ public:
         BuildingImplicitModule(false), ModulesEmbedAllFiles(false),
         IncludeTimestamps(true), UseTemporary(true),
         IndexIgnoreSystemSymbols(false), IndexRecordCodegenName(false),
-        TimeTraceGranularity(500) {}
+        AllowPCMWithCompilerErrors(false), TimeTraceGranularity(500) {}
 
   /// getInputKindForExtension - Return the appropriate input kind for a file
   /// extension. For example, "c" would return Language::C.

--- a/clang/lib/Frontend/ASTUnit.cpp
+++ b/clang/lib/Frontend/ASTUnit.cpp
@@ -758,7 +758,7 @@ std::unique_ptr<ASTUnit> ASTUnit::LoadFromASTFile(
     WhatToLoad ToLoad, IntrusiveRefCntPtr<DiagnosticsEngine> Diags,
     const FileSystemOptions &FileSystemOpts, bool UseDebugInfo,
     bool OnlyLocalDecls, ArrayRef<RemappedFile> RemappedFiles,
-    CaptureDiagsKind CaptureDiagnostics, bool AllowPCHWithCompilerErrors,
+    CaptureDiagsKind CaptureDiagnostics, bool AllowASTWithCompilerErrors,
     bool UserFilesAreVolatile) {
   std::unique_ptr<ASTUnit> AST(new ASTUnit(true));
 
@@ -818,7 +818,7 @@ std::unique_ptr<ASTUnit> ASTUnit::LoadFromASTFile(
   AST->Reader = new ASTReader(
       PP, *AST->ModuleCache, AST->Ctx.get(), PCHContainerRdr, {},
       /*isysroot=*/"",
-      /*DisableValidation=*/disableValid, AllowPCHWithCompilerErrors);
+      /*DisableValidation=*/disableValid, AllowASTWithCompilerErrors);
 
   AST->Reader->setListener(std::make_unique<ASTInfoCollector>(
       *AST->PP, AST->Ctx.get(), *AST->HSOpts, *AST->PPOpts, *AST->LangOpts,

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1551,7 +1551,9 @@ void CompilerInstance::createASTReader() {
   HeaderSearchOptions &HSOpts = getHeaderSearchOpts();
   std::string Sysroot = HSOpts.Sysroot;
   const PreprocessorOptions &PPOpts = getPreprocessorOpts();
+  const FrontendOptions &FEOpts = getFrontendOpts();
   std::unique_ptr<llvm::Timer> ReadTimer;
+
   if (FrontendTimerGroup)
     ReadTimer = std::make_unique<llvm::Timer>("reading_modules",
                                                 "Reading modules",
@@ -1560,7 +1562,7 @@ void CompilerInstance::createASTReader() {
       getPreprocessor(), getModuleCache(), &getASTContext(),
       getPCHContainerReader(), getFrontendOpts().ModuleFileExtensions,
       Sysroot.empty() ? "" : Sysroot.c_str(), PPOpts.DisablePCHValidation,
-      /*AllowASTWithCompilerErrors=*/false,
+      /*AllowASTWithCompilerErrors=*/FEOpts.AllowPCMWithCompilerErrors,
       /*AllowConfigurationMismatch=*/false, HSOpts.ModulesValidateSystemHeaders,
       HSOpts.ValidateASTInputFilesContent,
       getFrontendOpts().UseGlobalModuleIndex, std::move(ReadTimer));

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2023,6 +2023,7 @@ static InputKind ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   Opts.IncludeTimestamps = !Args.hasArg(OPT_fno_pch_timestamp);
   Opts.UseTemporary = !Args.hasArg(OPT_fno_temp_file);
   Opts.IsSystemModule = Args.hasArg(OPT_fsystem_module);
+  Opts.AllowPCMWithCompilerErrors = Args.hasArg(OPT_fallow_pcm_with_errors);
 
   if (Opts.ProgramAction != frontend::GenerateModule && Opts.IsSystemModule)
     Diags.Report(diag::err_drv_argument_only_allowed_with) << "-fsystem-module"
@@ -3652,7 +3653,8 @@ static void ParsePreprocessorArgs(PreprocessorOptions &Opts, ArgList &Args,
   Opts.UsePredefines = !Args.hasArg(OPT_undef);
   Opts.DetailedRecord = Args.hasArg(OPT_detailed_preprocessing_record);
   Opts.DisablePCHValidation = Args.hasArg(OPT_fno_validate_pch);
-  Opts.AllowPCHWithCompilerErrors = Args.hasArg(OPT_fallow_pch_with_errors);
+  Opts.AllowPCHWithCompilerErrors =
+      Args.hasArg(OPT_fallow_pch_with_errors, OPT_fallow_pcm_with_errors);
 
   Opts.DumpDeserializedPCHDecls = Args.hasArg(OPT_dump_deserialized_pch_decls);
   for (const auto *A : Args.filtered(OPT_error_on_deserialized_pch_decl))

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -177,7 +177,8 @@ GenerateModuleAction::CreateASTConsumer(CompilerInstance &CI,
   Consumers.push_back(std::make_unique<PCHGenerator>(
       CI.getPreprocessor(), CI.getModuleCache(), OutputFile, Sysroot, Buffer,
       CI.getFrontendOpts().ModuleFileExtensions,
-      /*AllowASTWithErrors=*/false,
+      /*AllowASTWithErrors=*/
+      +CI.getFrontendOpts().AllowPCMWithCompilerErrors,
       /*IncludeTimestamps=*/
       +CI.getFrontendOpts().BuildingImplicitModule,
       /*ShouldCacheASTInMemory=*/
@@ -185,6 +186,11 @@ GenerateModuleAction::CreateASTConsumer(CompilerInstance &CI,
   Consumers.push_back(CI.getPCHContainerWriter().CreatePCHContainerGenerator(
       CI, std::string(InFile), OutputFile, std::move(OS), Buffer));
   return std::make_unique<MultiplexConsumer>(std::move(Consumers));
+}
+
+bool GenerateModuleAction::shouldEraseOutputFiles() {
+  return !getCompilerInstance().getFrontendOpts().AllowPCMWithCompilerErrors &&
+         ASTFrontendAction::shouldEraseOutputFiles();
 }
 
 bool GenerateModuleFromModuleMapAction::BeginSourceFileAction(
@@ -338,7 +344,7 @@ void VerifyPCHAction::ExecuteAction() {
       CI.getPCHContainerReader(), CI.getFrontendOpts().ModuleFileExtensions,
       Sysroot.empty() ? "" : Sysroot.c_str(),
       /*DisableValidation*/ false,
-      /*AllowPCHWithCompilerErrors*/ false,
+      /*AllowASTWithCompilerErrors*/ false,
       /*AllowConfigurationMismatch*/ true,
       /*ValidateSystemInputs*/ true));
 

--- a/clang/test/Modules/Inputs/error.h
+++ b/clang/test/Modules/Inputs/error.h
@@ -1,0 +1,8 @@
+@import undefined
+
+@interface Error
+- (int)method;
+undefined
+@end
+
+undefined

--- a/clang/test/Modules/Inputs/module.map
+++ b/clang/test/Modules/Inputs/module.map
@@ -2,16 +2,16 @@ module c_library [extern_c] { module inner { header "c-header.h" } }
 module cxx_library { header "cxx-header.h" requires cplusplus }
 module c_library_bad [extern_c] { header "c-header-bad.h" }
 module diamond_top { header "diamond_top.h" }
-module diamond_left {
-  header "diamond_left.h"
+module diamond_left { 
+  header "diamond_left.h" 
   export diamond_top
 }
-module diamond_right {
-  header "diamond_right.h"
+module diamond_right { 
+  header "diamond_right.h" 
   export diamond_top
 }
-module diamond_bottom {
-  header "diamond_bottom.h"
+module diamond_bottom { 
+  header "diamond_bottom.h" 
   export *
 }
 module irgen { header "irgen.h" }
@@ -24,47 +24,47 @@ module lookup_left_cxx { header "lookup_left.hpp" }
 module lookup_right_cxx { header "lookup_right.hpp" }
 module module_private_left { header "module_private_left.h" }
 module module_private_right { header "module_private_right.h" }
-module macros_top {
-  header "macros_top.h"
+module macros_top { 
+  header "macros_top.h" 
   explicit module b { header "macros_top_b.h" }
   explicit module c { header "macros_top_c.h" }
 }
-module macros_left {
-  header "macros_left.h"
+module macros_left { 
+  header "macros_left.h" 
   export *
 }
-module macros_right {
-  header "macros_right.h"
+module macros_right { 
+  header "macros_right.h" 
   export *
   explicit module undef {
     header "macros_right_undef.h"
   }
 }
-module macros_bottom {
-  header "macros_bottom.h"
+module macros_bottom { 
+  header "macros_bottom.h" 
   export *
 }
 module macros { header "macros.h" }
 module macros_other { header "macros_other.h" }
 module category_top { header "category_top.h" }
-module category_left {
-  header "category_left.h"
+module category_left { 
+  header "category_left.h" 
   export category_top
 
   explicit module sub {
     header "category_left_sub.h"
   }
 }
-module category_right {
-  header "category_right.h"
+module category_right { 
+  header "category_right.h" 
   export category_top
 
   explicit module sub {
     header "category_right_sub.h"
   }
 }
-module category_bottom {
-  header "category_bottom.h"
+module category_bottom { 
+  header "category_bottom.h" 
   export category_left
   export category_right
 }
@@ -84,52 +84,52 @@ module decldef {
   explicit module Def { header "def.h" }
 }
 
-module redecl_merge_top {
+module redecl_merge_top { 
   header "redecl-merge-top.h"
   explicit module Explicit { header "redecl-merge-top-explicit.h" }
   exclude header "nonexistent.h"
 }
-module redecl_merge_left {
-  header "redecl-merge-left.h"
+module redecl_merge_left { 
+  header "redecl-merge-left.h" 
   export *
 }
-module redecl_merge_left_left {
-  header "redecl-merge-left-left.h"
+module redecl_merge_left_left { 
+  header "redecl-merge-left-left.h" 
   export *
 }
-module redecl_merge_right {
-  header "redecl-merge-right.h"
+module redecl_merge_right { 
+  header "redecl-merge-right.h" 
   export *
 }
-module redecl_merge_bottom {
+module redecl_merge_bottom { 
   explicit module prefix {
     header "redecl-merge-bottom-prefix.h"
   }
 
-  header "redecl-merge-bottom.h"
+  header "redecl-merge-bottom.h" 
   export *
 }
-module namespaces_top {
+module namespaces_top { 
   header "namespaces-top.h"
   export *
 }
-module namespaces_left {
+module namespaces_left { 
   header "namespaces-left.h"
   export *
 }
-module namespaces_right {
+module namespaces_right { 
   header "namespaces-right.h"
   export *
 }
-module templates_top {
+module templates_top { 
   header "templates-top.h"
   export *
 }
-module templates_left {
+module templates_left { 
   header "templates-left.h"
   export *
 }
-module templates_right {
+module templates_right { 
   header "templates-right.h"
   export *
 }
@@ -159,7 +159,7 @@ module import_decl {
   header "import-decl.h"
 }
 
-framework module * {
+framework module * { 
   exclude NotAModule
 }
 

--- a/clang/test/Modules/Inputs/module.map
+++ b/clang/test/Modules/Inputs/module.map
@@ -2,16 +2,16 @@ module c_library [extern_c] { module inner { header "c-header.h" } }
 module cxx_library { header "cxx-header.h" requires cplusplus }
 module c_library_bad [extern_c] { header "c-header-bad.h" }
 module diamond_top { header "diamond_top.h" }
-module diamond_left { 
-  header "diamond_left.h" 
+module diamond_left {
+  header "diamond_left.h"
   export diamond_top
 }
-module diamond_right { 
-  header "diamond_right.h" 
+module diamond_right {
+  header "diamond_right.h"
   export diamond_top
 }
-module diamond_bottom { 
-  header "diamond_bottom.h" 
+module diamond_bottom {
+  header "diamond_bottom.h"
   export *
 }
 module irgen { header "irgen.h" }
@@ -24,47 +24,47 @@ module lookup_left_cxx { header "lookup_left.hpp" }
 module lookup_right_cxx { header "lookup_right.hpp" }
 module module_private_left { header "module_private_left.h" }
 module module_private_right { header "module_private_right.h" }
-module macros_top { 
-  header "macros_top.h" 
+module macros_top {
+  header "macros_top.h"
   explicit module b { header "macros_top_b.h" }
   explicit module c { header "macros_top_c.h" }
 }
-module macros_left { 
-  header "macros_left.h" 
+module macros_left {
+  header "macros_left.h"
   export *
 }
-module macros_right { 
-  header "macros_right.h" 
+module macros_right {
+  header "macros_right.h"
   export *
   explicit module undef {
     header "macros_right_undef.h"
   }
 }
-module macros_bottom { 
-  header "macros_bottom.h" 
+module macros_bottom {
+  header "macros_bottom.h"
   export *
 }
 module macros { header "macros.h" }
 module macros_other { header "macros_other.h" }
 module category_top { header "category_top.h" }
-module category_left { 
-  header "category_left.h" 
+module category_left {
+  header "category_left.h"
   export category_top
 
   explicit module sub {
     header "category_left_sub.h"
   }
 }
-module category_right { 
-  header "category_right.h" 
+module category_right {
+  header "category_right.h"
   export category_top
 
   explicit module sub {
     header "category_right_sub.h"
   }
 }
-module category_bottom { 
-  header "category_bottom.h" 
+module category_bottom {
+  header "category_bottom.h"
   export category_left
   export category_right
 }
@@ -84,52 +84,52 @@ module decldef {
   explicit module Def { header "def.h" }
 }
 
-module redecl_merge_top { 
+module redecl_merge_top {
   header "redecl-merge-top.h"
   explicit module Explicit { header "redecl-merge-top-explicit.h" }
   exclude header "nonexistent.h"
 }
-module redecl_merge_left { 
-  header "redecl-merge-left.h" 
+module redecl_merge_left {
+  header "redecl-merge-left.h"
   export *
 }
-module redecl_merge_left_left { 
-  header "redecl-merge-left-left.h" 
+module redecl_merge_left_left {
+  header "redecl-merge-left-left.h"
   export *
 }
-module redecl_merge_right { 
-  header "redecl-merge-right.h" 
+module redecl_merge_right {
+  header "redecl-merge-right.h"
   export *
 }
-module redecl_merge_bottom { 
+module redecl_merge_bottom {
   explicit module prefix {
     header "redecl-merge-bottom-prefix.h"
   }
 
-  header "redecl-merge-bottom.h" 
+  header "redecl-merge-bottom.h"
   export *
 }
-module namespaces_top { 
+module namespaces_top {
   header "namespaces-top.h"
   export *
 }
-module namespaces_left { 
+module namespaces_left {
   header "namespaces-left.h"
   export *
 }
-module namespaces_right { 
+module namespaces_right {
   header "namespaces-right.h"
   export *
 }
-module templates_top { 
+module templates_top {
   header "templates-top.h"
   export *
 }
-module templates_left { 
+module templates_left {
   header "templates-left.h"
   export *
 }
-module templates_right { 
+module templates_right {
   header "templates-right.h"
   export *
 }
@@ -159,7 +159,7 @@ module import_decl {
   header "import-decl.h"
 }
 
-framework module * { 
+framework module * {
   exclude NotAModule
 }
 
@@ -484,3 +484,5 @@ module objc_redef_indirect {
   header "objc_redef_indirect.h"
   export *
 }
+
+module error { header "error.h" }

--- a/clang/test/Modules/load-module-with-errors.m
+++ b/clang/test/Modules/load-module-with-errors.m
@@ -1,0 +1,25 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+
+// Write out a module with errors make sure it can be read
+// RUN: %clang_cc1 -fmodules -fallow-pcm-with-compiler-errors \
+// RUN:   -fmodules-cache-path=%t -x objective-c -emit-module \
+// RUN:   -fmodule-name=error %S/Inputs/module.map
+// RUN: %clang_cc1 -fmodules -fallow-pcm-with-compiler-errors \
+// RUN:   -fmodules-cache-path=%t -x objective-c -I %S/Inputs \
+// RUN:   -fimplicit-module-maps -ast-print %s | FileCheck %s
+
+// allow-pcm-with-compiler-errors should also allow errors in PCH
+// RUN: %clang_cc1 -fallow-pcm-with-compiler-errors -x c++ -emit-pch \
+// RUN:   -o %t/check.pch %S/Inputs/error.h
+
+@import error;
+
+void test(id x) {
+  [x method];
+}
+
+// CHECK: @interface Error
+// CHECK-NEXT: - (int)method;
+// CHECK-NEXT: @end
+// CHECK: void test(id x)

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -302,7 +302,7 @@ static bool printSourceSymbolsFromModule(StringRef modulePath,
       std::string(modulePath), *pchRdr, ASTUnit::LoadASTOnly, Diags,
       FileSystemOpts, /*UseDebugInfo=*/false,
       /*OnlyLocalDecls=*/true, None, CaptureDiagsKind::None,
-      /*AllowPCHWithCompilerErrors=*/true,
+      /*AllowASTWithCompilerErrors=*/true,
       /*UserFilesAreVolatile=*/false);
   if (!AU) {
     errs() << "failed to create TU for: " << modulePath << '\n';

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -3474,7 +3474,7 @@ enum CXErrorCode clang_createTranslationUnit2(CXIndex CIdx,
       ast_filename, CXXIdx->getPCHContainerOperations()->getRawReader(),
       ASTUnit::LoadEverything, Diags, FileSystemOpts, /*UseDebugInfo=*/false,
       CXXIdx->getOnlyLocalDecls(), None, CaptureDiagsKind::All,
-      /*AllowPCHWithCompilerErrors=*/true,
+      /*AllowASTWithCompilerErrors=*/true,
       /*UserFilesAreVolatile=*/true);
   *out_TU = MakeCXTranslationUnit(CXXIdx, std::move(AU));
   return *out_TU ? CXError_Success : CXError_Failure;


### PR DESCRIPTION
Grab the main commit and couple cleanups for allowing output of modules despite compiler errors.