### PR TITLE
[lldb] Cleanup unreadable test temp file

### DIFF
--- a/lldb/test/Shell/SwiftREPL/RedirectInputUnreadable.test
+++ b/lldb/test/Shell/SwiftREPL/RedirectInputUnreadable.test
@@ -9,3 +9,4 @@
 
 < A.swift
 // LLDB: could not read file at path 'A.swift'
+// RUN: rm -f A.swift

--- a/lldb/test/Shell/SwiftREPL/RedirectInputUnreadable.test
+++ b/lldb/test/Shell/SwiftREPL/RedirectInputUnreadable.test
@@ -9,4 +9,4 @@
 
 < A.swift
 // LLDB: could not read file at path 'A.swift'
-// RUN: rm -f A.swift
+// RUN: rm -f %t/A.swift


### PR DESCRIPTION
This test creates a file that has its write perm removed, which can cause later issues. This change removes the temp file after at the end of the test.