### PR TITLE
[lldb] Add test to check that we can resolve self even if there are no references to it in a dynamic context

### DIFF
--- a/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/Makefile
+++ b/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/TestDefaultProtocolExtensionNoSelfReference.py
+++ b/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/TestDefaultProtocolExtensionNoSelfReference.py
@@ -1,0 +1,23 @@
+"""
+Test that we can resolve "self" even if there are no references to it in a dynamic context
+"""
+
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class TestDefaultProtocolExtensionNoSelfReference(TestBase):
+    mydir = TestBase.compute_mydir(__file__)
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    @swiftTest
+    def test_protocol_default_extension_no_self_reference(self):
+        """
+        Test that we can resolve "self" even if there are no references to it in a dynamic context
+        """
+        self.build()
+
+        lldbutil.run_to_source_breakpoint(self, 'break here', lldb.SBFileSpec('main.swift'))
+        self.expect('e -d no-run-target -- self', substrs=["(a.C) $R0 = 0x"])

--- a/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/main.swift
+++ b/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/main.swift
@@ -1,0 +1,15 @@
+class C : Foo {
+}
+
+protocol Foo: class {
+  func foo()
+}
+
+extension Foo {
+  func foo() {
+    print(777) // break here
+  }
+}
+
+let c = C()
+c.foo()


### PR DESCRIPTION
Depends on https://github.com/apple/swift/pull/34835.

@adrian-prantl @vedantk 