### PR TITLE
Add back cross-compilation support for Swift.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -31,6 +31,10 @@ class Builder:
         """Returns the ARCH_CFLAGS for the make system."""
         return ""
 
+    def getSwiftTargetFlags(self, architecture):
+        """Returns TARGET_SWIFTFLAGS for the make system."""
+        return ""
+
     def getMake(self, test_subdir, test_name):
         """Returns the invocation for GNU make.
         The first argument is a tuple of the relative path to the testcase
@@ -145,6 +149,7 @@ class Builder:
                 "all",
                 self.getArchCFlags(architecture),
                 self.getArchSpec(architecture),
+                self.getSwiftTargetFlags(architecture),
                 self.getCCSpec(compiler),
                 self.getExtraMakeArgs(),
                 self.getSDKRootSpec(),
@@ -171,6 +176,7 @@ class Builder:
                 "MAKE_DSYM=NO",
                 self.getArchCFlags(architecture),
                 self.getArchSpec(architecture),
+                self.getSwiftTargetFlags(architecture),
                 self.getCCSpec(compiler),
                 self.getExtraMakeArgs(),
                 self.getSDKRootSpec(),
@@ -196,6 +202,7 @@ class Builder:
                 "MAKE_DSYM=NO", "MAKE_DWO=YES",
                 self.getArchCFlags(architecture),
                 self.getArchSpec(architecture),
+                self.getSwiftTargetFlags(architecture),
                 self.getCCSpec(compiler),
                 self.getExtraMakeArgs(),
                 self.getSDKRootSpec(),
@@ -221,6 +228,7 @@ class Builder:
                 "MAKE_DSYM=NO", "MAKE_GMODULES=YES",
                 self.getArchCFlags(architecture),
                 self.getArchSpec(architecture),
+                self.getSwiftTargetFlags(architecture),
                 self.getCCSpec(compiler),
                 self.getExtraMakeArgs(),
                 self.getSDKRootSpec(),

--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -97,6 +97,18 @@ class BuilderDarwin(Builder):
 
         return "ARCH_CFLAGS=\"-target {} {}\"".format(triple, version_min)
 
+    def getSwiftTargetFlags(self, arch):
+        if not arch:
+            arch = configuration.arch
+        if not arch:
+            return ""
+        vendor, os, version, env = get_triple()
+        if not vendor or not os or not version or not env:
+            return ""
+        flags = 'TARGET_SWIFTFLAGS="-target {}-{}-{}{}{}"'.format(
+            arch, vendor, os, version, (("-"+env) if env else ""))
+        return flags
+
     def buildDsym(self,
                   sender=None,
                   architecture=None,
@@ -111,13 +123,13 @@ class BuilderDarwin(Builder):
                 "MAKE_DSYM=YES",
                 self.getArchCFlags(architecture),
                 self.getArchSpec(architecture),
+                self.getSwiftTargetFlags(architecture),
                 self.getCCSpec(compiler),
                 self.getExtraMakeArgs(),
                 self.getSDKRootSpec(),
                 self.getModuleCacheSpec(), "all",
                 self.getCmdLine(dictionary)
             ])
-
         self.runBuildCommands(commands, sender=sender)
 
         # True signifies that we can handle building dsym.

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -262,8 +262,10 @@ ifndef NO_TEST_COMMON_H
 endif
 
 CFLAGS += $(NO_LIMIT_DEBUG_INFO_FLAGS) $(ARCH_CFLAGS)
-SWIFTFLAGS += $(ARCH_SWIFTFLAGS)
 SWIFTFLAGS += $(SWIFTFLAGS_EXTRAS)
+ifeq "$(findstring -target,$(SWIFTFLAGS))" ""
+  SWIFTFLAGS += $(TARGET_SWIFTFLAGS)
+endif
 
 # Swift bridging headers.
 ifneq "$(SWIFT_BRIDGING_HEADER)" ""

--- a/lldb/test/API/lang/swift/playgrounds/TestPlaygrounds.py
+++ b/lldb/test/API/lang/swift/playgrounds/TestPlaygrounds.py
@@ -72,7 +72,7 @@ class TestSwiftPlaygrounds(TestBase):
     def test_cross_module_extension(self):
         """Test that playgrounds work"""
         self.build(dictionary={
-            'ARCH_SWIFTFLAGS':
+            'TARGET_SWIFTFLAGS':
             '-target {}'.format(self.get_build_triple()),
         })
         self.do_test(True)


### PR DESCRIPTION
We accidentally lost this when we refactored Makefile.rules.

rdar://71107152