### PR TITLE
Add back cross-compilation support for Swift.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -31,6 +31,10 @@ class Builder:
         """Returns the ARCH_CFLAGS for the make system."""
         return ""
 
+    def getSwiftTargetFlags(self, architecture):
+        """Returns TARGET_SWIFTFLAGS for the make system."""
+        return ""
+
     def getMake(self, test_subdir, test_name):
         """Returns the invocation for GNU make.
         The first argument is a tuple of the relative path to the testcase
@@ -141,6 +145,7 @@ class Builder:
                 "all",
                 self.getArchCFlags(architecture),
                 self.getArchSpec(architecture),
+                self.getSwiftTargetFlags(architecture),
                 self.getCCSpec(compiler),
                 self.getExtraMakeArgs(),
                 self.getSDKRootSpec(),
@@ -167,6 +172,7 @@ class Builder:
                 "MAKE_DSYM=NO",
                 self.getArchCFlags(architecture),
                 self.getArchSpec(architecture),
+                self.getSwiftTargetFlags(architecture),
                 self.getCCSpec(compiler),
                 self.getExtraMakeArgs(),
                 self.getSDKRootSpec(),
@@ -192,6 +198,7 @@ class Builder:
                 "MAKE_DSYM=NO", "MAKE_DWO=YES",
                 self.getArchCFlags(architecture),
                 self.getArchSpec(architecture),
+                self.getSwiftTargetFlags(architecture),
                 self.getCCSpec(compiler),
                 self.getExtraMakeArgs(),
                 self.getSDKRootSpec(),
@@ -217,6 +224,7 @@ class Builder:
                 "MAKE_DSYM=NO", "MAKE_GMODULES=YES",
                 self.getArchCFlags(architecture),
                 self.getArchSpec(architecture),
+                self.getSwiftTargetFlags(architecture),
                 self.getCCSpec(compiler),
                 self.getExtraMakeArgs(),
                 self.getSDKRootSpec(),

--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -101,6 +101,18 @@ class BuilderDarwin(Builder):
 
         return "ARCH_CFLAGS=\"-target {} {}\"".format(triple, version_min)
 
+    def getSwiftTargetFlags(self, arch):
+        if not arch:
+            arch = configuration.arch
+        if not arch:
+            return ""
+        vendor, os, version, env = get_triple()
+        if not vendor or not os or not version or not env:
+            return ""
+        flags = 'TARGET_SWIFTFLAGS="-target {}-{}-{}{}{}"'.format(
+            arch, vendor, os, version, (("-"+env) if env else ""))
+        return flags
+
     def buildDsym(self,
                   sender=None,
                   architecture=None,
@@ -115,13 +127,13 @@ class BuilderDarwin(Builder):
                 "MAKE_DSYM=YES",
                 self.getArchCFlags(architecture),
                 self.getArchSpec(architecture),
+                self.getSwiftTargetFlags(architecture),
                 self.getCCSpec(compiler),
                 self.getExtraMakeArgs(),
                 self.getSDKRootSpec(),
                 self.getModuleCacheSpec(), "all",
                 self.getCmdLine(dictionary)
             ])
-
         self.runBuildCommands(commands, sender=sender)
 
         # True signifies that we can handle building dsym.

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -260,8 +260,10 @@ ifndef NO_TEST_COMMON_H
 endif
 
 CFLAGS += $(NO_LIMIT_DEBUG_INFO_FLAGS) $(ARCH_CFLAGS)
-SWIFTFLAGS += $(ARCH_SWIFTFLAGS)
 SWIFTFLAGS += $(SWIFTFLAGS_EXTRAS)
+ifeq "$(findstring -target,$(SWIFTFLAGS))" ""
+  SWIFTFLAGS += $(TARGET_SWIFTFLAGS)
+endif
 
 # Swift bridging headers.
 ifneq "$(SWIFT_BRIDGING_HEADER)" ""


### PR DESCRIPTION
We accidentally lost this when we refactored Makefile.rules.

rdar://71107152
(cherry picked from commit 5d41f1e1a59d7d68f61125c95f47e4c7daf69b26)