### PR TITLE
[CodeGen] Make sure pointer authentication function attributes are added to function definitions

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -1810,14 +1810,6 @@ void CodeGenModule::getDefaultFunctionAttributes(StringRef Name,
       FuncAttrs.addAttribute("stackrealign");
     if (CodeGenOpts.Backchain)
       FuncAttrs.addAttribute("backchain");
-    if (CodeGenOpts.PointerAuth.ReturnAddresses)
-      FuncAttrs.addAttribute("ptrauth-returns");
-    if (CodeGenOpts.PointerAuth.FunctionPointers)
-      FuncAttrs.addAttribute("ptrauth-calls");
-    if (CodeGenOpts.PointerAuth.IndirectGotos)
-      FuncAttrs.addAttribute("ptrauth-indirect-gotos");
-    if (CodeGenOpts.PointerAuth.AuthTraps)
-      FuncAttrs.addAttribute("ptrauth-auth-traps");
     if (CodeGenOpts.EnableSegmentedStacks)
       FuncAttrs.addAttribute("split-stack");
 

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -791,6 +791,17 @@ void CodeGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
           FD->getBody()->getStmtClass() == Stmt::CoroutineBodyStmtClass)
         SanOpts.Mask &= ~SanitizerKind::Null;
 
+  // Add pointer authentication attributes.
+  const CodeGenOptions &CodeGenOpts = CGM.getCodeGenOpts();
+  if (CodeGenOpts.PointerAuth.ReturnAddresses)
+    Fn->addFnAttr("ptrauth-returns");
+  if (CodeGenOpts.PointerAuth.FunctionPointers)
+    Fn->addFnAttr("ptrauth-calls");
+  if (CodeGenOpts.PointerAuth.IndirectGotos)
+    Fn->addFnAttr("ptrauth-indirect-gotos");
+  if (CodeGenOpts.PointerAuth.AuthTraps)
+    Fn->addFnAttr("ptrauth-auth-traps");
+
   // Apply xray attributes to the function (as a string, for now)
   bool AlwaysXRayAttr = false;
   if (const auto *XRayAttr = D ? D->getAttr<XRayInstrumentAttr>() : nullptr) {

--- a/clang/test/CodeGenCXX/ptrauth.cpp
+++ b/clang/test/CodeGenCXX/ptrauth.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -triple arm64-apple-ios -fptrauth-calls -fptrauth-returns -fptrauth-intrinsics -emit-llvm -std=c++11 -fexceptions -fcxx-exceptions -o - %s | FileCheck %s
+
+void foo1();
+
+void test_terminate() noexcept {
+  foo1();
+}
+
+// CHECK: define void @_ZSt9terminatev() #[[ATTR4:.*]] {
+
+namespace std {
+  void terminate() noexcept {
+  }
+}
+
+// CHECK: attributes #[[ATTR4]] = {{{.*}}"ptrauth-calls" "ptrauth-returns"{{.*}}}


### PR DESCRIPTION
The pointer authentication attributes weren't being added to the definition of std::terminate when its declaration was added to the IR as a runtime function before its definition was emitted. In that case, getDefaultFunctionAttributes doesn't get called.

rdar://problem/71053329