### PR TITLE
[lldb] Don't reject empty or unnamed template parameter packs

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -243,6 +243,77 @@ def which(program):
                 return exe_file
     return None
 
+class ValueCheck:
+    def __init__(self, name=None, value=None, type=None, summary=None,
+                 children=None):
+        """
+        :param name: The name that the SBValue should have. None if the summary
+                     should not be checked.
+        :param summary: The summary that the SBValue should have. None if the
+                        summary should not be checked.
+        :param value: The value that the SBValue should have. None if the value
+                      should not be checked.
+        :param type: The type that the SBValue result should have. None if the
+                     type should not be checked.
+        :param children: A list of ValueChecks that need to match the children
+                         of this SBValue. None if children shouldn't be checked.
+                         The order of checks is the order of the checks in the
+                         list. The number of checks has to match the number of
+                         children.
+        """
+        self.expect_name = name
+        self.expect_value = value
+        self.expect_type = type
+        self.expect_summary = summary
+        self.children = children
+
+    def check_value(self, test_base, val, error_msg=None):
+        """
+        Checks that the given value matches the currently set properties
+        of this ValueCheck. If a match failed, the given TestBase will
+        be used to emit an error. A custom error message can be specified
+        that will be used to describe failed check for this SBValue (but
+        not errors in the child values).
+        """
+
+        this_error_msg = error_msg if error_msg else ""
+        this_error_msg += "\nChecking SBValue: " + str(val)
+
+        test_base.assertSuccess(val.GetError())
+
+        if self.expect_name:
+            test_base.assertEqual(self.expect_name, val.GetName(),
+                                  this_error_msg)
+        if self.expect_value:
+            test_base.assertEqual(self.expect_value, val.GetValue(),
+                                  this_error_msg)
+        if self.expect_type:
+            test_base.assertEqual(self.expect_type, val.GetDisplayTypeName(),
+                                  this_error_msg)
+        if self.expect_summary:
+            test_base.assertEqual(self.expect_summary, val.GetSummary(),
+                                  this_error_msg)
+        if self.children is not None:
+            self.check_value_children(test_base, val, error_msg)
+
+    def check_value_children(self, test_base, val, error_msg=None):
+        """
+        Checks that the children of a SBValue match a certain structure and
+        have certain properties.
+
+        :param test_base: The current test's TestBase object.
+        :param val: The SBValue to check.
+        """
+
+        this_error_msg = error_msg if error_msg else ""
+        this_error_msg += "\nChecking SBValue: " + str(val)
+
+        test_base.assertEqual(len(self.children), val.GetNumChildren(), this_error_msg)
+
+        for i in range(0, val.GetNumChildren()):
+            expected_child = self.children[i]
+            actual_child = val.GetChildAtIndex(i)
+            expected_child.check_value(test_base, actual_child, error_msg)
 
 class recording(SixStringIO):
     """
@@ -2419,6 +2490,7 @@ FileCheck output:
             result_summary=None,
             result_value=None,
             result_type=None,
+            result_children=None
             ):
         """
         Evaluates the given expression and verifies the result.
@@ -2426,6 +2498,8 @@ FileCheck output:
         :param result_summary: The summary that the expression should have. None if the summary should not be checked.
         :param result_value: The value that the expression should have. None if the value should not be checked.
         :param result_type: The type that the expression result should have. None if the type should not be checked.
+        :param result_children: The expected children of the expression result
+                                as a list of ValueChecks. None if the children shouldn't be checked.
         """
         self.assertTrue(expr.strip() == expr, "Expression contains trailing/leading whitespace: '" + expr + "'")
 
@@ -2444,16 +2518,9 @@ FileCheck output:
         else:
             eval_result = self.target().EvaluateExpression(expr, options)
 
-        self.assertSuccess(eval_result.GetError())
-
-        if result_type:
-            self.assertEqual(result_type, eval_result.GetDisplayTypeName())
-
-        if result_value:
-            self.assertEqual(result_value, eval_result.GetValue())
-
-        if result_summary:
-            self.assertEqual(result_summary, eval_result.GetSummary())
+        value_check = ValueCheck(type=result_type, value=result_value,
+                                 summary=result_summary, children=result_children)
+        value_check.check_value(self, eval_result, str(eval_result))
 
     def invoke(self, obj, name, trace=False):
         """Use reflection to call a method dynamically with no argument."""

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -1945,8 +1945,6 @@ bool DWARFASTParserClang::ParseTemplateParameterInfos(
       break;
     }
   }
-  if (template_param_infos.args.empty())
-    return false;
   return template_param_infos.args.size() == template_param_infos.names.size();
 }
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -333,10 +333,11 @@ public:
   class TemplateParameterInfos {
   public:
     bool IsValid() const {
-      if (args.empty())
+      // Having a pack name but no packed args doesn't make sense, so mark
+      // these template parameters as invalid.
+      if (pack_name && !packed_args)
         return false;
       return args.size() == names.size() &&
-        ((bool)pack_name == (bool)packed_args) &&
         (!packed_args || !packed_args->packed_args);
     }
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/map/TestDataFormatterLibccMap.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/map/TestDataFormatterLibccMap.py
@@ -19,6 +19,11 @@ class LibcxxMapDataFormatterTestCase(TestBase):
         ns = 'ndk' if lldbplatformutil.target_is_android() else ''
         self.namespace = 'std'
 
+    def check_pair(self, first_value, second_value):
+        pair_children = [ValueCheck(name="first", value=first_value),
+                         ValueCheck(name="second", value=second_value)]
+        return ValueCheck(children=pair_children)
+
     @add_test_categories(["libc++"])
     def test_with_run_command(self):
         """Test that that file and class static variables display correctly."""
@@ -51,10 +56,8 @@ class LibcxxMapDataFormatterTestCase(TestBase):
         self.addTearDownHook(cleanup)
 
         ns = self.namespace
-        self.expect('p ii',
-                    substrs=['%s::map' % ns,
-                             'size=0',
-                             '{}'])
+        self.expect_expr("ii", result_summary="size=0", result_children=[])
+
         self.expect('frame var ii',
                     substrs=['%s::map' % ns,
                              'size=0',
@@ -62,14 +65,10 @@ class LibcxxMapDataFormatterTestCase(TestBase):
 
         lldbutil.continue_to_breakpoint(self.process(), bkpt)
 
-        self.expect('p ii',
-                    substrs=['%s::map' % ns, 'size=2',
-                             '[0] = ',
-                             'first = 0',
-                             'second = 0',
-                             '[1] = ',
-                             'first = 1',
-                             'second = 1'])
+        self.expect_expr("ii", result_summary="size=2", result_children=[
+            self.check_pair("0", "0"),
+            self.check_pair("1", "1")
+        ])
 
         self.expect('frame variable ii',
                     substrs=['%s::map' % ns, 'size=2',

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/vector/TestDataFormatterLibcxxVector.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/vector/TestDataFormatterLibcxxVector.py
@@ -26,16 +26,15 @@ class LibcxxVectorDataFormatterTestCase(TestBase):
                              '[6] = 1234567',
                              '}'])
 
-        self.expect("p " + var_name,
-                    substrs=['$', 'size=7',
-                             '[0] = 1',
-                             '[1] = 12',
-                             '[2] = 123',
-                             '[3] = 1234',
-                             '[4] = 12345',
-                             '[5] = 123456',
-                             '[6] = 1234567',
-                             '}'])
+        self.expect_expr(var_name, result_summary="size=7", result_children=[
+            ValueCheck(value="1"),
+            ValueCheck(value="12"),
+            ValueCheck(value="123"),
+            ValueCheck(value="1234"),
+            ValueCheck(value="12345"),
+            ValueCheck(value="123456"),
+            ValueCheck(value="1234567"),
+        ])
 
         # check access-by-index
         self.expect("frame variable " + var_name + "[0]",

--- a/lldb/test/API/lang/cpp/class-template-non-type-parameter-pack/Makefile
+++ b/lldb/test/API/lang/cpp/class-template-non-type-parameter-pack/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/lang/cpp/class-template-non-type-parameter-pack/TestClassTemplateNonTypeParameterPack.py
+++ b/lldb/test/API/lang/cpp/class-template-non-type-parameter-pack/TestClassTemplateNonTypeParameterPack.py
@@ -1,0 +1,76 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+class TestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @no_debug_info_test
+    def test(self):
+        self.build()
+        self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+
+        self.expect_expr("emptyNonTypePack", result_type="NonTypePack<>",
+            result_children=[ValueCheck(name="a", type="int")])
+        self.expect_expr("oneElemNonTypePack", result_type="NonTypePack<1>",
+            result_children=[ValueCheck(name="a", type="int")])
+        self.expect_expr("twoElemNonTypePack", result_type="NonTypePack<1, 2>",
+            result_children=[ValueCheck(name="a", type="int")])
+
+
+        self.expect_expr("emptyAnonNonTypePack", result_type="AnonNonTypePack<>",
+            result_children=[ValueCheck(name="b", type="int")])
+        self.expect_expr("oneElemAnonNonTypePack", result_type="AnonNonTypePack<1>",
+            result_children=[ValueCheck(name="b", type="int")])
+        self.expect_expr("twoElemAnonNonTypePack", result_type="AnonNonTypePack<1, 2>",
+            result_children=[ValueCheck(name="b", type="int")])
+
+
+        self.expect_expr("emptyAnonNonTypePackAfterTypeParam", result_type="AnonNonTypePackAfterTypeParam<int>",
+            result_children=[ValueCheck(name="c", type="int")])
+        self.expect_expr("oneElemAnonNonTypePackAfterTypeParam", result_type="AnonNonTypePackAfterTypeParam<int, 1>",
+            result_children=[ValueCheck(name="c", type="int")])
+
+
+
+        self.expect_expr("emptyAnonNonTypePackAfterAnonTypeParam", result_type="AnonNonTypePackAfterAnonTypeParam<int>",
+            result_children=[ValueCheck(name="d", type="float")])
+        self.expect_expr("oneElemAnonNonTypePackAfterAnonTypeParam", result_type="AnonNonTypePackAfterAnonTypeParam<int, 1>",
+            result_children=[ValueCheck(name="d", type="float")])
+
+
+        self.expect_expr("emptyNonTypePackAfterAnonTypeParam", result_type="NonTypePackAfterAnonTypeParam<int>",
+            result_children=[ValueCheck(name="e", type="int")])
+        self.expect_expr("oneElemNonTypePackAfterAnonTypeParam", result_type="NonTypePackAfterAnonTypeParam<int, 1>",
+            result_children=[ValueCheck(name="e", type="int")])
+
+
+        self.expect_expr("emptyNonTypePackAfterTypeParam", result_type="NonTypePackAfterTypeParam<int>",
+            result_children=[ValueCheck(name="f", type="int")])
+        self.expect_expr("oneElemNonTypePackAfterTypeParam", result_type="NonTypePackAfterTypeParam<int, 1>",
+            result_children=[ValueCheck(name="f", type="int")])
+
+        self.expect_expr("emptyAnonNonTypePackAfterNonTypeParam", result_type="AnonNonTypePackAfterNonTypeParam<1>",
+            result_children=[ValueCheck(name="g", type="int")])
+        self.expect_expr("oneElemAnonNonTypePackAfterNonTypeParam", result_type="AnonNonTypePackAfterNonTypeParam<1, 2>",
+            result_children=[ValueCheck(name="g", type="int")])
+
+
+        self.expect_expr("emptyAnonNonTypePackAfterAnonNonTypeParam", result_type="AnonNonTypePackAfterAnonNonTypeParam<1>",
+            result_children=[ValueCheck(name="h", type="float")])
+        self.expect_expr("oneElemAnonNonTypePackAfterAnonNonTypeParam", result_type="AnonNonTypePackAfterAnonNonTypeParam<1, 2>",
+            result_children=[ValueCheck(name="h", type="float")])
+
+
+        self.expect_expr("emptyNonTypePackAfterAnonNonTypeParam", result_type="NonTypePackAfterAnonNonTypeParam<1>",
+            result_children=[ValueCheck(name="i", type="int")])
+        self.expect_expr("oneElemNonTypePackAfterAnonNonTypeParam", result_type="NonTypePackAfterAnonNonTypeParam<1, 2>",
+            result_children=[ValueCheck(name="i", type="int")])
+
+
+        self.expect_expr("emptyNonTypePackAfterNonTypeParam", result_type="NonTypePackAfterNonTypeParam<1>",
+            result_children=[ValueCheck(name="j", type="int")])
+        self.expect_expr("oneElemNonTypePackAfterNonTypeParam", result_type="NonTypePackAfterNonTypeParam<1, 2>",
+            result_children=[ValueCheck(name="j", type="int")])

--- a/lldb/test/API/lang/cpp/class-template-non-type-parameter-pack/main.cpp
+++ b/lldb/test/API/lang/cpp/class-template-non-type-parameter-pack/main.cpp
@@ -1,0 +1,69 @@
+// Named type parameter pack.
+template <int... Is>
+struct NonTypePack { int a; };
+NonTypePack<> emptyNonTypePack;
+NonTypePack<1> oneElemNonTypePack;
+NonTypePack<1, 2> twoElemNonTypePack;
+
+// Unnamed type parameter pack.
+template <int... >
+struct AnonNonTypePack { int b; };
+AnonNonTypePack<> emptyAnonNonTypePack;
+AnonNonTypePack<1> oneElemAnonNonTypePack;
+AnonNonTypePack<1, 2> twoElemAnonNonTypePack;
+
+// Test type parameter packs combined with non-pack type template parameters.
+
+// Unnamed non-type parameter pack behind a named type parameter.
+template <typename T, int... >
+struct AnonNonTypePackAfterTypeParam { T c; };
+AnonNonTypePackAfterTypeParam<int> emptyAnonNonTypePackAfterTypeParam;
+AnonNonTypePackAfterTypeParam<int, 1> oneElemAnonNonTypePackAfterTypeParam;
+
+// Unnamed non-type parameter pack behind an unnamed type parameter.
+template <typename, int... >
+struct AnonNonTypePackAfterAnonTypeParam { float d; };
+AnonNonTypePackAfterAnonTypeParam<int> emptyAnonNonTypePackAfterAnonTypeParam;
+AnonNonTypePackAfterAnonTypeParam<int, 1> oneElemAnonNonTypePackAfterAnonTypeParam;
+
+// Named non-type parameter pack behind an unnamed type parameter.
+template <typename, int... Is>
+struct NonTypePackAfterAnonTypeParam { int e; };
+NonTypePackAfterAnonTypeParam<int> emptyNonTypePackAfterAnonTypeParam;
+NonTypePackAfterAnonTypeParam<int, 1> oneElemNonTypePackAfterAnonTypeParam;
+
+// Named non-type parameter pack behind a named type parameter.
+template <typename T, int... Is>
+struct NonTypePackAfterTypeParam { int f; };
+NonTypePackAfterTypeParam<int> emptyNonTypePackAfterTypeParam;
+NonTypePackAfterTypeParam<int, 1> oneElemNonTypePackAfterTypeParam;
+
+// Test non-type parameter packs combined with non-pack non-type template parameters.
+
+// Unnamed non-type parameter pack behind a named non-type parameter.
+template <int I, int... >
+struct AnonNonTypePackAfterNonTypeParam { int g; };
+AnonNonTypePackAfterNonTypeParam<1> emptyAnonNonTypePackAfterNonTypeParam;
+AnonNonTypePackAfterNonTypeParam<1, 2> oneElemAnonNonTypePackAfterNonTypeParam;
+
+// Unnamed non-type parameter pack behind an unnamed non-type parameter.
+template <int, int... >
+struct AnonNonTypePackAfterAnonNonTypeParam { float h; };
+AnonNonTypePackAfterAnonNonTypeParam<1> emptyAnonNonTypePackAfterAnonNonTypeParam;
+AnonNonTypePackAfterAnonNonTypeParam<1, 2> oneElemAnonNonTypePackAfterAnonNonTypeParam;
+
+// Named non-type parameter pack behind an unnamed non-type parameter.
+template <int, int... Is>
+struct NonTypePackAfterAnonNonTypeParam { int i; };
+NonTypePackAfterAnonNonTypeParam<1> emptyNonTypePackAfterAnonNonTypeParam;
+NonTypePackAfterAnonNonTypeParam<1, 2> oneElemNonTypePackAfterAnonNonTypeParam;
+
+// Named non-type parameter pack behind an unnamed non-type parameter.
+template <int I, int... Is>
+struct NonTypePackAfterNonTypeParam { int j; };
+NonTypePackAfterNonTypeParam<1> emptyNonTypePackAfterNonTypeParam;
+NonTypePackAfterNonTypeParam<1, 2> oneElemNonTypePackAfterNonTypeParam;
+
+int main() {
+  return 0; // break here
+}

--- a/lldb/test/API/lang/cpp/class-template-type-parameter-pack/Makefile
+++ b/lldb/test/API/lang/cpp/class-template-type-parameter-pack/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/lang/cpp/class-template-type-parameter-pack/TestClassTemplateTypeParameterPack.py
+++ b/lldb/test/API/lang/cpp/class-template-type-parameter-pack/TestClassTemplateTypeParameterPack.py
@@ -1,0 +1,76 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+class TestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @no_debug_info_test
+    def test(self):
+        self.build()
+        self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+
+        self.expect_expr("emptyTypePack", result_type="TypePack<>",
+            result_children=[ValueCheck(name="a", type="int")])
+        self.expect_expr("oneElemTypePack", result_type="TypePack<int>",
+            result_children=[ValueCheck(name="a", type="int")])
+        self.expect_expr("twoElemTypePack", result_type="TypePack<int, float>",
+            result_children=[ValueCheck(name="a", type="int")])
+
+
+        self.expect_expr("emptyAnonTypePack", result_type="AnonTypePack<>",
+            result_children=[ValueCheck(name="b", type="int")])
+        self.expect_expr("oneElemAnonTypePack", result_type="AnonTypePack<int>",
+            result_children=[ValueCheck(name="b", type="int")])
+        self.expect_expr("twoElemAnonTypePack", result_type="AnonTypePack<int, float>",
+            result_children=[ValueCheck(name="b", type="int")])
+
+
+        self.expect_expr("emptyAnonTypePackAfterTypeParam", result_type="AnonTypePackAfterTypeParam<int>",
+            result_children=[ValueCheck(name="c", type="int")])
+        self.expect_expr("oneElemAnonTypePackAfterTypeParam", result_type="AnonTypePackAfterTypeParam<int, float>",
+            result_children=[ValueCheck(name="c", type="int")])
+
+
+
+        self.expect_expr("emptyAnonTypePackAfterAnonTypeParam", result_type="AnonTypePackAfterAnonTypeParam<int>",
+            result_children=[ValueCheck(name="d", type="float")])
+        self.expect_expr("oneElemAnonTypePackAfterAnonTypeParam", result_type="AnonTypePackAfterAnonTypeParam<int, float>",
+            result_children=[ValueCheck(name="d", type="float")])
+
+
+        self.expect_expr("emptyTypePackAfterAnonTypeParam", result_type="TypePackAfterAnonTypeParam<int>",
+            result_children=[ValueCheck(name="e", type="int")])
+        self.expect_expr("oneElemTypePackAfterAnonTypeParam", result_type="TypePackAfterAnonTypeParam<int, float>",
+            result_children=[ValueCheck(name="e", type="int")])
+
+
+        self.expect_expr("emptyTypePackAfterTypeParam", result_type="TypePackAfterTypeParam<int>",
+            result_children=[ValueCheck(name="f", type="int")])
+        self.expect_expr("oneElemTypePackAfterTypeParam", result_type="TypePackAfterTypeParam<int, float>",
+            result_children=[ValueCheck(name="f", type="int")])
+
+        self.expect_expr("emptyAnonTypePackAfterNonTypeParam", result_type="AnonTypePackAfterNonTypeParam<1>",
+            result_children=[ValueCheck(name="g", type="int")])
+        self.expect_expr("oneElemAnonTypePackAfterNonTypeParam", result_type="AnonTypePackAfterNonTypeParam<1, int>",
+            result_children=[ValueCheck(name="g", type="int")])
+
+
+        self.expect_expr("emptyAnonTypePackAfterAnonNonTypeParam", result_type="AnonTypePackAfterAnonNonTypeParam<1>",
+            result_children=[ValueCheck(name="h", type="float")])
+        self.expect_expr("oneElemAnonTypePackAfterAnonNonTypeParam", result_type="AnonTypePackAfterAnonNonTypeParam<1, int>",
+            result_children=[ValueCheck(name="h", type="float")])
+
+
+        self.expect_expr("emptyTypePackAfterAnonNonTypeParam", result_type="TypePackAfterAnonNonTypeParam<1>",
+            result_children=[ValueCheck(name="i", type="int")])
+        self.expect_expr("oneElemTypePackAfterAnonNonTypeParam", result_type="TypePackAfterAnonNonTypeParam<1, int>",
+            result_children=[ValueCheck(name="i", type="int")])
+
+
+        self.expect_expr("emptyTypePackAfterNonTypeParam", result_type="TypePackAfterNonTypeParam<1>",
+            result_children=[ValueCheck(name="j", type="int")])
+        self.expect_expr("oneElemTypePackAfterNonTypeParam", result_type="TypePackAfterNonTypeParam<1, int>",
+            result_children=[ValueCheck(name="j", type="int")])

--- a/lldb/test/API/lang/cpp/class-template-type-parameter-pack/main.cpp
+++ b/lldb/test/API/lang/cpp/class-template-type-parameter-pack/main.cpp
@@ -1,0 +1,69 @@
+// Named type parameter pack.
+template <typename... Is>
+struct TypePack { int a; };
+TypePack<> emptyTypePack;
+TypePack<int> oneElemTypePack;
+TypePack<int, float> twoElemTypePack;
+
+// Unnamed type parameter pack.
+template <typename... >
+struct AnonTypePack { int b; };
+AnonTypePack<> emptyAnonTypePack;
+AnonTypePack<int> oneElemAnonTypePack;
+AnonTypePack<int, float> twoElemAnonTypePack;
+
+// Test type parameter packs combined with non-pack type template parameters.
+
+// Unnamed type parameter pack behind a named type parameter.
+template <typename T, typename... >
+struct AnonTypePackAfterTypeParam { T c; };
+AnonTypePackAfterTypeParam<int> emptyAnonTypePackAfterTypeParam;
+AnonTypePackAfterTypeParam<int, float> oneElemAnonTypePackAfterTypeParam;
+
+// Unnamed type parameter pack behind an unnamed type parameter.
+template <typename, typename... >
+struct AnonTypePackAfterAnonTypeParam { float d; };
+AnonTypePackAfterAnonTypeParam<int> emptyAnonTypePackAfterAnonTypeParam;
+AnonTypePackAfterAnonTypeParam<int, float> oneElemAnonTypePackAfterAnonTypeParam;
+
+// Named type parameter pack behind an unnamed type parameter.
+template <typename, typename... Ts>
+struct TypePackAfterAnonTypeParam { int e; };
+TypePackAfterAnonTypeParam<int> emptyTypePackAfterAnonTypeParam;
+TypePackAfterAnonTypeParam<int, float> oneElemTypePackAfterAnonTypeParam;
+
+// Named type parameter pack behind a named type parameter.
+template <typename T, typename... Ts>
+struct TypePackAfterTypeParam { int f; };
+TypePackAfterTypeParam<int> emptyTypePackAfterTypeParam;
+TypePackAfterTypeParam<int, float> oneElemTypePackAfterTypeParam;
+
+// Test type parameter packs combined with non-pack non-type template parameters.
+
+// Unnamed type parameter pack behind a named type parameter.
+template <int I, typename... >
+struct AnonTypePackAfterNonTypeParam { int g; };
+AnonTypePackAfterNonTypeParam<1> emptyAnonTypePackAfterNonTypeParam;
+AnonTypePackAfterNonTypeParam<1, int> oneElemAnonTypePackAfterNonTypeParam;
+
+// Unnamed type parameter pack behind an unnamed type parameter.
+template <int, typename... >
+struct AnonTypePackAfterAnonNonTypeParam { float h; };
+AnonTypePackAfterAnonNonTypeParam<1> emptyAnonTypePackAfterAnonNonTypeParam;
+AnonTypePackAfterAnonNonTypeParam<1, int> oneElemAnonTypePackAfterAnonNonTypeParam;
+
+// Named type parameter pack behind an unnamed type parameter.
+template <int, typename... Ts>
+struct TypePackAfterAnonNonTypeParam { int i; };
+TypePackAfterAnonNonTypeParam<1> emptyTypePackAfterAnonNonTypeParam;
+TypePackAfterAnonNonTypeParam<1, int> oneElemTypePackAfterAnonNonTypeParam;
+
+// Named type parameter pack behind an unnamed type parameter.
+template <int I, typename... Ts>
+struct TypePackAfterNonTypeParam { int j; };
+TypePackAfterNonTypeParam<1> emptyTypePackAfterNonTypeParam;
+TypePackAfterNonTypeParam<1, int> oneElemTypePackAfterNonTypeParam;
+
+int main() {
+  return 0; // break here
+}

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -516,6 +516,12 @@ TEST_F(TestTypeSystemClang, TemplateArguments) {
   }
 }
 
+TEST_F(TestTypeSystemClang, OnlyPackName) {
+  TypeSystemClang::TemplateParameterInfos infos;
+  infos.pack_name = "A";
+  EXPECT_FALSE(infos.IsValid());
+}
+
 static QualType makeConstInt(clang::ASTContext &ctxt) {
   QualType result(ctxt.IntTy);
   result.addConst();


### PR DESCRIPTION
We currently reject all templates that have either zero args or that have a
parameter pack without a name. Both cases are actually allowed in C++, so
rejecting them leads to LLDB instead falling back to a dummy 'void' type. This
leads to all kind of errors later on (most notable, variables that have such
template types appear to be missing as we can't have 'void' variables and
inheriting from such a template type will cause Clang to hit some asserts when
finding that the base class is 'void').

This just removes the too strict tests and adds a few tests for this stuff (+
some combinations of these tests with preceding template parameters).

Things that I left for follow-up patches:
* All the possible interactions with template-template arguments which seem like a whole new source of possible bugs.
* Function templates which completely lack sanity checks.
* Variable templates are not implemented.
* Alias templates are not implemented too.
* The rather strange checks that just make sure that the separate list of
  template arg names and values always have the same length. I believe those
  ought to be asserts, but my current plan is to move both those things into a
  single list that can't end up in this inconsistent state.

Reviewed By: JDevlieghere, shafik

Differential Revision: https://reviews.llvm.org/D92425

(cherry picked from commit c526426f5cba5308782ea4f86822047ee2ee3818)