### PR TITLE
Partially revert '[MachO] Update embedded part of ObjectFileMachO for…

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -3467,10 +3467,11 @@ size_t ObjectFileMachO::ParseSymtab() {
                           sym[sym_idx].GetMangled().SetValue(
                               const_symbol_name, symbol_name_is_mangled);
                           if (is_gsym && is_debug) {
-                            const char *gsym_name = sym[sym_idx]
-                                                        .GetMangled()
-                                                        .GetName()
-                                                        .GetCString();
+                            const char *gsym_name =
+                                sym[sym_idx]
+                                    .GetMangled()
+                                    .GetName(Mangled::ePreferMangled)
+                                    .GetCString();
                             if (gsym_name)
                               N_GSYM_name_to_sym_idx[gsym_name] = sym_idx;
                           }
@@ -3550,8 +3551,10 @@ size_t ObjectFileMachO::ParseSymtab() {
                             bool found_it = false;
                             for (auto pos = range.first; pos != range.second;
                                  ++pos) {
-                              if (sym[sym_idx].GetMangled().GetName() ==
-                                  sym[pos->second].GetMangled().GetName()) {
+                              if (sym[sym_idx].GetMangled().GetName(
+                                      Mangled::ePreferMangled) ==
+                                  sym[pos->second].GetMangled().GetName(
+                                      Mangled::ePreferMangled)) {
                                 m_nlist_idx_to_sym_idx[nlist_idx] = pos->second;
                                 // We just need the flags from the linker
                                 // symbol, so put these flags
@@ -3591,8 +3594,10 @@ size_t ObjectFileMachO::ParseSymtab() {
                             bool found_it = false;
                             for (auto pos = range.first; pos != range.second;
                                  ++pos) {
-                              if (sym[sym_idx].GetMangled().GetName() ==
-                                  sym[pos->second].GetMangled().GetName()) {
+                              if (sym[sym_idx].GetMangled().GetName(
+                                      Mangled::ePreferMangled) ==
+                                  sym[pos->second].GetMangled().GetName(
+                                      Mangled::ePreferMangled)) {
                                 m_nlist_idx_to_sym_idx[nlist_idx] = pos->second;
                                 // We just need the flags from the linker
                                 // symbol, so put these flags
@@ -3610,10 +3615,11 @@ size_t ObjectFileMachO::ParseSymtab() {
                             if (found_it)
                               continue;
                           } else {
-                            const char *gsym_name = sym[sym_idx]
-                                                        .GetMangled()
-                                                        .GetName()
-                                                        .GetCString();
+                            const char *gsym_name =
+                                sym[sym_idx]
+                                    .GetMangled()
+                                    .GetName(Mangled::ePreferMangled)
+                                    .GetCString();
                             if (gsym_name) {
                               // Combine N_GSYM stab entries with the non
                               // stab symbol
@@ -4334,8 +4340,10 @@ size_t ObjectFileMachO::ParseSymtab() {
       }
 
       if (is_gsym) {
-        const char *gsym_name =
-            sym[sym_idx].GetMangled().GetName().GetCString();
+        const char *gsym_name = sym[sym_idx]
+                                    .GetMangled()
+                                    .GetName(Mangled::ePreferMangled)
+                                    .GetCString();
         if (gsym_name)
           N_GSYM_name_to_sym_idx[gsym_name] = sym_idx;
       }
@@ -4399,8 +4407,9 @@ size_t ObjectFileMachO::ParseSymtab() {
           if (range.first != range.second) {
             for (ValueToSymbolIndexMap::const_iterator pos = range.first;
                  pos != range.second; ++pos) {
-              if (sym[sym_idx].GetMangled().GetName() ==
-                  sym[pos->second].GetMangled().GetName()) {
+              if (sym[sym_idx].GetMangled().GetName(Mangled::ePreferMangled) ==
+                  sym[pos->second].GetMangled().GetName(
+                      Mangled::ePreferMangled)) {
                 m_nlist_idx_to_sym_idx[nlist_idx] = pos->second;
                 // We just need the flags from the linker symbol, so put these
                 // flags into the N_FUN flags to avoid duplicate symbols in the
@@ -4433,8 +4442,9 @@ size_t ObjectFileMachO::ParseSymtab() {
           if (range.first != range.second) {
             for (ValueToSymbolIndexMap::const_iterator pos = range.first;
                  pos != range.second; ++pos) {
-              if (sym[sym_idx].GetMangled().GetName() ==
-                  sym[pos->second].GetMangled().GetName()) {
+              if (sym[sym_idx].GetMangled().GetName(Mangled::ePreferMangled) ==
+                  sym[pos->second].GetMangled().GetName(
+                      Mangled::ePreferMangled)) {
                 m_nlist_idx_to_sym_idx[nlist_idx] = pos->second;
                 // We just need the flags from the linker symbol, so put these
                 // flags into the N_STSYM flags to avoid duplicate symbols in
@@ -4447,8 +4457,10 @@ size_t ObjectFileMachO::ParseSymtab() {
             }
           } else {
             // Combine N_GSYM stab entries with the non stab symbol.
-            const char *gsym_name =
-                sym[sym_idx].GetMangled().GetName().GetCString();
+            const char *gsym_name = sym[sym_idx]
+                                        .GetMangled()
+                                        .GetName(Mangled::ePreferMangled)
+                                        .GetCString();
             if (gsym_name) {
               ConstNameToSymbolIndexMap::const_iterator pos =
                   N_GSYM_name_to_sym_idx.find(gsym_name);


### PR DESCRIPTION
… Mangled API change'

Commit f3aa9e36d91b7b0f4f24f7a3b13cf80c11356e5e fixed the embedded OS
build by removing all passed args for `GetName`/`GetDemangledName`. The motivation
for this was that these arguments were apparently removed in
commit 22b044877d239c40c9a932d1ea47d489c507000f. However, only `GetName`'s language
argument was removed but the mangling preference argument was *not* removed
(and unfortunately had a default argument). So when that commit removed all
the args it didn't just fix the build but it also changed all the mangling
preferences to 'demangled' for all `GetName` calls.

Also some `GetName` calls were outside the TARGET_OS_EMBEDDED ifdef, so
this change ended up breaking the following tests on macOS:

  lldb-api :: lang/objc/objc-static-method-stripped/TestObjCStaticMethodStripped.py
  lldb-api :: lang/objc/objc-super/TestObjCSuper.py

From what I can see f3aa9e36d91b7 removed 12 ePreferMangled args and this patch
re-adds 12 args with roughly the same line numbers, so this *should* restore the
old behaviour and also keep the embedded build working. On the other hand,
ObjectFileMachO::ParseSymtab is a very successful attempt at writing
the longest possible function within LLVM, so this fix is partly based
on the engineering principle known as "hoping for the best".

(cherry picked from commit ffb3fd8f1846de97d10cfca249567eb282cec980)