### PR TITLE
[lldb] Return the original path when tilde expansion fails.

### DIFF
--- a/lldb/source/Utility/TildeExpressionResolver.cpp
+++ b/lldb/source/Utility/TildeExpressionResolver.cpp
@@ -75,9 +75,8 @@ bool StandardTildeExpressionResolver::ResolvePartial(StringRef Expr,
 
 bool TildeExpressionResolver::ResolveFullPath(
     StringRef Expr, llvm::SmallVectorImpl<char> &Output) {
-  Output.clear();
   if (!Expr.startswith("~")) {
-    Output.append(Expr.begin(), Expr.end());
+    Output.assign(Expr.begin(), Expr.end());
     return false;
   }
 
@@ -85,8 +84,10 @@ bool TildeExpressionResolver::ResolveFullPath(
   StringRef Left =
       Expr.take_until([](char c) { return path::is_separator(c); });
 
-  if (!ResolveExact(Left, Output))
+  if (!ResolveExact(Left, Output)) {
+    Output.assign(Expr.begin(), Expr.end());
     return false;
+  }
 
   Output.append(Expr.begin() + Left.size(), Expr.end());
   return true;

--- a/lldb/unittests/Utility/TildeExpressionResolverTest.cpp
+++ b/lldb/unittests/Utility/TildeExpressionResolverTest.cpp
@@ -31,6 +31,9 @@ TEST(TildeExpressionResolver, ResolveFullPath) {
   EXPECT_EQ("/lars", Result);
 
   ASSERT_FALSE(Resolver.ResolveFullPath("~Jaso", Result));
+  EXPECT_EQ("~Jaso", Result);
   ASSERT_FALSE(Resolver.ResolveFullPath("", Result));
+  EXPECT_EQ("", Result);
   ASSERT_FALSE(Resolver.ResolveFullPath("Jason", Result));
+  EXPECT_EQ("Jason", Result);
 }


### PR DESCRIPTION
Differential revision: https://reviews.llvm.org/D92513

(cherry picked from commit dcdd231df6c7b6f4a635fe7941c1f87955328183)