### PR TITLE
[lldb] Treat remote macOS debugging like any other remote darwin plat…

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/CMakeLists.txt
+++ b/lldb/source/Plugins/Platform/MacOSX/CMakeLists.txt
@@ -10,11 +10,12 @@ list(APPEND PLUGIN_PLATFORM_MACOSX_SOURCES
   PlatformDarwin.cpp
   PlatformDarwinKernel.cpp
   PlatformMacOSX.cpp
-  PlatformRemoteiOS.cpp
+  PlatformRemoteAppleBridge.cpp
   PlatformRemoteAppleTV.cpp
   PlatformRemoteAppleWatch.cpp
   PlatformRemoteDarwinDevice.cpp
-  PlatformRemoteAppleBridge.cpp
+  PlatformRemoteMacOSX.cpp
+  PlatformRemoteiOS.cpp
   )
 
 list(APPEND PLUGIN_PLATFORM_MACOSX_DARWIN_ONLY_SOURCES

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PlatformMacOSX.h"
+#include "PlatformRemoteMacOSX.h"
 #include "PlatformRemoteiOS.h"
 #if defined(__APPLE__)
 #include "PlatformAppleSimulator.h"
@@ -44,6 +45,7 @@ static uint32_t g_initialize_count = 0;
 void PlatformMacOSX::Initialize() {
   PlatformDarwin::Initialize();
   PlatformRemoteiOS::Initialize();
+  PlatformRemoteMacOSX::Initialize();
 #if defined(__APPLE__)
   PlatformAppleSimulator::Initialize();
   PlatformDarwinKernel::Initialize();
@@ -54,12 +56,12 @@ void PlatformMacOSX::Initialize() {
 
   if (g_initialize_count++ == 0) {
 #if defined(__APPLE__)
-    PlatformSP default_platform_sp(new PlatformMacOSX(true));
+    PlatformSP default_platform_sp(new PlatformMacOSX());
     default_platform_sp->SetSystemArchitecture(HostInfo::GetArchitecture());
     Platform::SetHostPlatform(default_platform_sp);
 #endif
-    PluginManager::RegisterPlugin(PlatformMacOSX::GetPluginNameStatic(false),
-                                  PlatformMacOSX::GetDescriptionStatic(false),
+    PluginManager::RegisterPlugin(PlatformMacOSX::GetPluginNameStatic(),
+                                  PlatformMacOSX::GetDescriptionStatic(),
                                   PlatformMacOSX::CreateInstance);
   }
 }
@@ -78,98 +80,28 @@ void PlatformMacOSX::Terminate() {
   PlatformDarwinKernel::Terminate();
   PlatformAppleSimulator::Terminate();
 #endif
+  PlatformRemoteMacOSX::Initialize();
   PlatformRemoteiOS::Terminate();
   PlatformDarwin::Terminate();
 }
 
+lldb_private::ConstString PlatformMacOSX::GetPluginNameStatic() {
+  static ConstString g_host_name(Platform::GetHostPlatformName());
+  return g_host_name;
+}
+
+const char *PlatformMacOSX::GetDescriptionStatic() {
+  return "Local Mac OS X user platform plug-in.";
+}
+
 PlatformSP PlatformMacOSX::CreateInstance(bool force, const ArchSpec *arch) {
-  Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_PLATFORM));
-  if (log) {
-    const char *arch_name;
-    if (arch && arch->GetArchitectureName())
-      arch_name = arch->GetArchitectureName();
-    else
-      arch_name = "<null>";
-
-    const char *triple_cstr =
-        arch ? arch->GetTriple().getTriple().c_str() : "<null>";
-
-    LLDB_LOGF(log, "PlatformMacOSX::%s(force=%s, arch={%s,%s})", __FUNCTION__,
-              force ? "true" : "false", arch_name, triple_cstr);
-  }
-
   // The only time we create an instance is when we are creating a remote
-  // macosx platform
-  const bool is_host = false;
-
-  bool create = force;
-  if (!create && arch && arch->IsValid()) {
-    const llvm::Triple &triple = arch->GetTriple();
-    switch (triple.getVendor()) {
-    case llvm::Triple::Apple:
-      create = true;
-      break;
-
-#if defined(__APPLE__)
-    // Only accept "unknown" for vendor if the host is Apple and it "unknown"
-    // wasn't specified (it was just returned because it was NOT specified)
-    case llvm::Triple::UnknownVendor:
-      create = !arch->TripleVendorWasSpecified();
-      break;
-#endif
-    default:
-      break;
-    }
-
-    if (create) {
-      switch (triple.getOS()) {
-      case llvm::Triple::Darwin: // Deprecated, but still support Darwin for
-                                 // historical reasons
-      case llvm::Triple::MacOSX:
-        break;
-#if defined(__APPLE__)
-      // Only accept "vendor" for vendor if the host is Apple and it "unknown"
-      // wasn't specified (it was just returned because it was NOT specified)
-      case llvm::Triple::UnknownOS:
-        create = !arch->TripleOSWasSpecified();
-        break;
-#endif
-      default:
-        create = false;
-        break;
-      }
-    }
-  }
-  if (create) {
-    LLDB_LOGF(log, "PlatformMacOSX::%s() creating platform", __FUNCTION__);
-    return PlatformSP(new PlatformMacOSX(is_host));
-  }
-
-  LLDB_LOGF(log, "PlatformMacOSX::%s() aborting creation of platform",
-            __FUNCTION__);
-
+  // macosx platform which is handled by PlatformRemoteMacOSX.
   return PlatformSP();
 }
 
-lldb_private::ConstString PlatformMacOSX::GetPluginNameStatic(bool is_host) {
-  if (is_host) {
-    static ConstString g_host_name(Platform::GetHostPlatformName());
-    return g_host_name;
-  } else {
-    static ConstString g_remote_name("remote-macosx");
-    return g_remote_name;
-  }
-}
-
-const char *PlatformMacOSX::GetDescriptionStatic(bool is_host) {
-  if (is_host)
-    return "Local Mac OS X user platform plug-in.";
-  else
-    return "Remote Mac OS X user platform plug-in.";
-}
-
 /// Default Constructor
-PlatformMacOSX::PlatformMacOSX(bool is_host) : PlatformDarwin(is_host) {}
+PlatformMacOSX::PlatformMacOSX() : PlatformDarwin(true) {}
 
 /// Destructor.
 ///
@@ -210,67 +142,6 @@ ConstString PlatformMacOSX::GetSDKDirectory(lldb_private::Target &target) {
   }
 
   return {};
-}
-
-Status PlatformMacOSX::GetSymbolFile(const FileSpec &platform_file,
-                                     const UUID *uuid_ptr,
-                                     FileSpec &local_file) {
-  if (IsRemote()) {
-    if (m_remote_platform_sp)
-      return m_remote_platform_sp->GetFileWithUUID(platform_file, uuid_ptr,
-                                                   local_file);
-  }
-
-  // Default to the local case
-  local_file = platform_file;
-  return Status();
-}
-
-lldb_private::Status
-PlatformMacOSX::GetFileWithUUID(const lldb_private::FileSpec &platform_file,
-                                const lldb_private::UUID *uuid_ptr,
-                                lldb_private::FileSpec &local_file) {
-  if (IsRemote() && m_remote_platform_sp) {
-    std::string local_os_build;
-#if !defined(__linux__)
-    HostInfo::GetOSBuildString(local_os_build);
-#endif
-    std::string remote_os_build;
-    m_remote_platform_sp->GetOSBuildString(remote_os_build);
-    if (local_os_build == remote_os_build) {
-      // same OS version: the local file is good enough
-      local_file = platform_file;
-      return Status();
-    } else {
-      // try to find the file in the cache
-      std::string cache_path(GetLocalCacheDirectory());
-      std::string module_path(platform_file.GetPath());
-      cache_path.append(module_path);
-      FileSpec module_cache_spec(cache_path);
-      if (FileSystem::Instance().Exists(module_cache_spec)) {
-        local_file = module_cache_spec;
-        return Status();
-      }
-      // bring in the remote module file
-      FileSpec module_cache_folder =
-          module_cache_spec.CopyByRemovingLastPathComponent();
-      // try to make the local directory first
-      Status err(
-          llvm::sys::fs::create_directory(module_cache_folder.GetPath()));
-      if (err.Fail())
-        return err;
-      err = GetFile(platform_file, module_cache_spec);
-      if (err.Fail())
-        return err;
-      if (FileSystem::Instance().Exists(module_cache_spec)) {
-        local_file = module_cache_spec;
-        return Status();
-      } else
-        return Status("unable to obtain valid module file");
-    }
-  }
-  local_file = platform_file;
-  return Status();
 }
 
 bool PlatformMacOSX::GetSupportedArchitectureAtIndex(uint32_t idx,

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.h
@@ -13,7 +13,7 @@
 
 class PlatformMacOSX : public PlatformDarwin {
 public:
-  PlatformMacOSX(bool is_host);
+  PlatformMacOSX();
 
   ~PlatformMacOSX() override;
 
@@ -25,13 +25,13 @@ public:
 
   static void Terminate();
 
-  static lldb_private::ConstString GetPluginNameStatic(bool is_host);
+  static lldb_private::ConstString GetPluginNameStatic();
 
-  static const char *GetDescriptionStatic(bool is_host);
+  static const char *GetDescriptionStatic();
 
   // lldb_private::PluginInterface functions
   lldb_private::ConstString GetPluginName() override {
-    return GetPluginNameStatic(IsHost());
+    return GetPluginNameStatic();
   }
 
   uint32_t GetPluginVersion() override { return 1; }
@@ -43,25 +43,13 @@ public:
                   lldb::ModuleSP *old_module_sp_ptr,
                   bool *did_create_ptr) override;
 
-  const char *GetDescription() override {
-    return GetDescriptionStatic(IsHost());
-  }
-
-  lldb_private::Status
-  GetSymbolFile(const lldb_private::FileSpec &platform_file,
-                const lldb_private::UUID *uuid_ptr,
-                lldb_private::FileSpec &local_file);
+  const char *GetDescription() override { return GetDescriptionStatic(); }
 
   lldb_private::Status
   GetFile(const lldb_private::FileSpec &source,
           const lldb_private::FileSpec &destination) override {
     return PlatformDarwin::GetFile(source, destination);
   }
-
-  lldb_private::Status
-  GetFileWithUUID(const lldb_private::FileSpec &platform_file,
-                  const lldb_private::UUID *uuid_ptr,
-                  lldb_private::FileSpec &local_file) override;
 
   bool GetSupportedArchitectureAtIndex(uint32_t idx,
                                        lldb_private::ArchSpec &arch) override;

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteMacOSX.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteMacOSX.cpp
@@ -1,0 +1,219 @@
+//===-- PlatformRemoteMacOSX.cpp -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "PlatformRemoteMacOSX.h"
+
+#include "lldb/Breakpoint/BreakpointLocation.h"
+#include "lldb/Core/Module.h"
+#include "lldb/Core/ModuleList.h"
+#include "lldb/Core/ModuleSpec.h"
+#include "lldb/Core/PluginManager.h"
+#include "lldb/Host/Host.h"
+#include "lldb/Host/HostInfo.h"
+#include "lldb/Target/Process.h"
+#include "lldb/Target/Target.h"
+#include "lldb/Utility/ArchSpec.h"
+#include "lldb/Utility/FileSpec.h"
+#include "lldb/Utility/Log.h"
+#include "lldb/Utility/StreamString.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+/// Default Constructor
+PlatformRemoteMacOSX::PlatformRemoteMacOSX() : PlatformRemoteDarwinDevice() {}
+
+// Static Variables
+static uint32_t g_initialize_count = 0;
+
+// Static Functions
+void PlatformRemoteMacOSX::Initialize() {
+  PlatformDarwin::Initialize();
+
+  if (g_initialize_count++ == 0) {
+    PluginManager::RegisterPlugin(PlatformRemoteMacOSX::GetPluginNameStatic(),
+                                  PlatformRemoteMacOSX::GetDescriptionStatic(),
+                                  PlatformRemoteMacOSX::CreateInstance);
+  }
+}
+
+void PlatformRemoteMacOSX::Terminate() {
+  if (g_initialize_count > 0) {
+    if (--g_initialize_count == 0) {
+      PluginManager::UnregisterPlugin(PlatformRemoteMacOSX::CreateInstance);
+    }
+  }
+
+  PlatformDarwin::Terminate();
+}
+
+PlatformSP PlatformRemoteMacOSX::CreateInstance(bool force,
+                                                const ArchSpec *arch) {
+  Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_PLATFORM));
+  if (log) {
+    const char *arch_name;
+    if (arch && arch->GetArchitectureName())
+      arch_name = arch->GetArchitectureName();
+    else
+      arch_name = "<null>";
+
+    const char *triple_cstr =
+        arch ? arch->GetTriple().getTriple().c_str() : "<null>";
+
+    LLDB_LOGF(log, "PlatformMacOSX::%s(force=%s, arch={%s,%s})", __FUNCTION__,
+              force ? "true" : "false", arch_name, triple_cstr);
+  }
+
+  bool create = force;
+  if (!create && arch && arch->IsValid()) {
+    const llvm::Triple &triple = arch->GetTriple();
+    switch (triple.getVendor()) {
+    case llvm::Triple::Apple:
+      create = true;
+      break;
+
+#if defined(__APPLE__)
+    // Only accept "unknown" for vendor if the host is Apple and it "unknown"
+    // wasn't specified (it was just returned because it was NOT specified)
+    case llvm::Triple::UnknownVendor:
+      create = !arch->TripleVendorWasSpecified();
+      break;
+#endif
+    default:
+      break;
+    }
+
+    if (create) {
+      switch (triple.getOS()) {
+      case llvm::Triple::Darwin: // Deprecated, but still support Darwin for
+                                 // historical reasons
+      case llvm::Triple::MacOSX:
+        break;
+#if defined(__APPLE__)
+      // Only accept "vendor" for vendor if the host is Apple and it "unknown"
+      // wasn't specified (it was just returned because it was NOT specified)
+      case llvm::Triple::UnknownOS:
+        create = !arch->TripleOSWasSpecified();
+        break;
+#endif
+      default:
+        create = false;
+        break;
+      }
+    }
+  }
+
+  if (create) {
+    LLDB_LOGF(log, "PlatformRemoteMacOSX::%s() creating platform",
+              __FUNCTION__);
+    return std::make_shared<PlatformRemoteMacOSX>();
+  }
+
+  LLDB_LOGF(log, "PlatformRemoteMacOSX::%s() aborting creation of platform",
+            __FUNCTION__);
+
+  return PlatformSP();
+}
+
+bool PlatformRemoteMacOSX::GetSupportedArchitectureAtIndex(uint32_t idx,
+                                                           ArchSpec &arch) {
+  // macOS for ARM64 support both native and translated x86_64 processes
+  if (!m_num_arm_arches || idx < m_num_arm_arches) {
+    bool res = ARMGetSupportedArchitectureAtIndex(idx, arch);
+    if (res)
+      return true;
+    if (!m_num_arm_arches)
+      m_num_arm_arches = idx;
+  }
+
+  // We can't use x86GetSupportedArchitectureAtIndex() because it uses
+  // the system architecture for some of its return values and also
+  // has a 32bits variant.
+  if (idx == m_num_arm_arches) {
+    arch.SetTriple("x86_64-apple-macosx");
+    return true;
+  } else if (idx == m_num_arm_arches + 1) {
+    arch.SetTriple("x86_64-apple-ios-macabi");
+    return true;
+  } else if (idx == m_num_arm_arches + 2) {
+    arch.SetTriple("arm64-apple-ios");
+    return true;
+  } else if (idx == m_num_arm_arches + 3) {
+    arch.SetTriple("arm64e-apple-ios");
+    return true;
+  }
+
+  return false;
+}
+
+lldb_private::Status PlatformRemoteMacOSX::GetFileWithUUID(
+    const lldb_private::FileSpec &platform_file,
+    const lldb_private::UUID *uuid_ptr, lldb_private::FileSpec &local_file) {
+  if (m_remote_platform_sp) {
+    std::string local_os_build;
+#if !defined(__linux__)
+    HostInfo::GetOSBuildString(local_os_build);
+#endif
+    std::string remote_os_build;
+    m_remote_platform_sp->GetOSBuildString(remote_os_build);
+    if (local_os_build == remote_os_build) {
+      // same OS version: the local file is good enough
+      local_file = platform_file;
+      return Status();
+    } else {
+      // try to find the file in the cache
+      std::string cache_path(GetLocalCacheDirectory());
+      std::string module_path(platform_file.GetPath());
+      cache_path.append(module_path);
+      FileSpec module_cache_spec(cache_path);
+      if (FileSystem::Instance().Exists(module_cache_spec)) {
+        local_file = module_cache_spec;
+        return Status();
+      }
+      // bring in the remote module file
+      FileSpec module_cache_folder =
+          module_cache_spec.CopyByRemovingLastPathComponent();
+      // try to make the local directory first
+      Status err(
+          llvm::sys::fs::create_directory(module_cache_folder.GetPath()));
+      if (err.Fail())
+        return err;
+      err = GetFile(platform_file, module_cache_spec);
+      if (err.Fail())
+        return err;
+      if (FileSystem::Instance().Exists(module_cache_spec)) {
+        local_file = module_cache_spec;
+        return Status();
+      } else
+        return Status("unable to obtain valid module file");
+    }
+  }
+  local_file = platform_file;
+  return Status();
+}
+
+lldb_private::ConstString PlatformRemoteMacOSX::GetPluginNameStatic() {
+  static ConstString g_name("remote-macosx");
+  return g_name;
+}
+
+const char *PlatformRemoteMacOSX::GetDescriptionStatic() {
+  return "Remote Mac OS X user platform plug-in.";
+}
+
+llvm::StringRef PlatformRemoteMacOSX::GetDeviceSupportDirectoryName() {
+  return "macOS DeviceSupport";
+}
+
+llvm::StringRef PlatformRemoteMacOSX::GetPlatformName() {
+  return "MacOSX.platform";
+}

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteMacOSX.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteMacOSX.h
@@ -1,0 +1,60 @@
+//===-- PlatformRemoteMacOSX.h ---------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_PLATFORM_MACOSX_PLATFORMREMOTEMACOSX_H
+#define LLDB_SOURCE_PLUGINS_PLATFORM_MACOSX_PLATFORMREMOTEMACOSX_H
+
+#include <string>
+
+#include "lldb/Utility/FileSpec.h"
+
+#include "llvm/Support/FileSystem.h"
+
+#include "PlatformMacOSX.h"
+#include "PlatformRemoteDarwinDevice.h"
+
+class PlatformRemoteMacOSX : public virtual PlatformRemoteDarwinDevice {
+public:
+  PlatformRemoteMacOSX();
+
+  static lldb::PlatformSP CreateInstance(bool force,
+                                         const lldb_private::ArchSpec *arch);
+
+  static void Initialize();
+
+  static void Terminate();
+
+  static lldb_private::ConstString GetPluginNameStatic();
+
+  static const char *GetDescriptionStatic();
+
+  lldb_private::ConstString GetPluginName() override {
+    return GetPluginNameStatic();
+  }
+
+  uint32_t GetPluginVersion() override { return 1; }
+
+  const char *GetDescription() override { return GetDescriptionStatic(); }
+
+  lldb_private::Status
+  GetFileWithUUID(const lldb_private::FileSpec &platform_file,
+                  const lldb_private::UUID *uuid_ptr,
+                  lldb_private::FileSpec &local_file) override;
+
+  bool GetSupportedArchitectureAtIndex(uint32_t idx,
+                                       lldb_private::ArchSpec &arch) override;
+
+protected:
+  llvm::StringRef GetDeviceSupportDirectoryName() override;
+  llvm::StringRef GetPlatformName() override;
+
+private:
+  uint32_t m_num_arm_arches = 0;
+};
+
+#endif // LLDB_SOURCE_PLUGINS_PLATFORM_MACOSX_PLATFORMREMOTEMACOSX_H

--- a/lldb/test/API/commands/platform/sdk/Makefile
+++ b/lldb/test/API/commands/platform/sdk/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/commands/platform/sdk/TestPlatformSDK.py
+++ b/lldb/test/API/commands/platform/sdk/TestPlatformSDK.py
@@ -1,0 +1,115 @@
+import lldb
+
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+import os
+import platform
+import shutil
+import time
+import socket
+
+
+class PlatformSDKTestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+    NO_DEBUG_INFO_TESTCASE = True
+
+    # The port used by debugserver.
+    PORT = 54637
+
+    # The number of attempts.
+    ATTEMPTS = 10
+
+    # Time given to the binary to launch and to debugserver to attach to it for
+    # every attempt. We'll wait a maximum of 10 times 2 seconds while the
+    # inferior will wait 10 times 10 seconds.
+    TIMEOUT = 2
+
+    def no_debugserver(self):
+        if os.getenv('LLDB_DEBUGSERVER_PATH') is None:
+            return 'no debugserver'
+        return None
+
+    def port_not_available(self):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        if s.connect_ex(('127.0.0.1', self.PORT)) == 0:
+            return '{} not available'.format(self.PORT)
+        return None
+
+    @no_debug_info_test
+    @skipUnlessDarwin
+    @expectedFailureIfFn(no_debugserver)
+    @expectedFailureIfFn(port_not_available)
+    def test_macos_sdk(self):
+        self.build()
+
+        exe = self.getBuildArtifact('a.out')
+        token = self.getBuildArtifact('token')
+
+        # Remove the old token.
+        try:
+            os.remove(token)
+        except:
+            pass
+
+        # Create a fake 'SDK' directory.
+        test_home = os.path.join(self.getBuildDir(), 'fake_home.noindex')
+        macos_version = platform.mac_ver()[0]
+        sdk_dir = os.path.join(test_home, 'Library', 'Developer', 'Xcode',
+                               'macOS DeviceSupport', macos_version)
+        symbols_dir = os.path.join(sdk_dir, 'Symbols')
+        lldbutil.mkdir_p(symbols_dir)
+
+        # Save the current home directory and restore it afterwards.
+        old_home = os.getenv('HOME')
+
+        def cleanup():
+            if not old_home:
+                del os.environ['HOME']
+            else:
+                os.environ['HOME'] = old_home
+
+        self.addTearDownHook(cleanup)
+        os.environ['HOME'] = test_home
+
+        # Launch our test binary.
+        inferior = self.spawnSubprocess(exe, [token])
+        pid = inferior.pid
+
+        # Wait for the binary to launch.
+        lldbutil.wait_for_file_on_target(self, token)
+
+        # Move the binary into the 'SDK'.
+        rel_exe_path = os.path.relpath(exe, '/')
+        exe_sdk_path = os.path.join(symbols_dir, rel_exe_path)
+        lldbutil.mkdir_p(os.path.dirname(exe_sdk_path))
+        shutil.move(exe, exe_sdk_path)
+
+        # Attach to it with debugserver.
+        debugserver = os.getenv('LLDB_DEBUGSERVER_PATH')
+        debugserver_args = [
+            'localhost:{}'.format(self.PORT), '--attach={}'.format(pid)
+        ]
+        self.spawnSubprocess(debugserver, debugserver_args)
+
+        # Select the platform.
+        self.expect('platform select remote-macosx', substrs=[sdk_dir])
+
+        # Connect to debugserver
+        interpreter = self.dbg.GetCommandInterpreter()
+        connected = False
+        for i in range(self.ATTEMPTS):
+            result = lldb.SBCommandReturnObject()
+            interpreter.HandleCommand('gdb-remote {}'.format(self.PORT),
+                                      result)
+            connected = result.Succeeded()
+            if connected:
+                break
+            time.sleep(self.TIMEOUT)
+
+        self.assertTrue(connected, "could not connect to debugserver")
+
+        # Make sure the image was loaded from the 'SDK'.
+        self.expect('image list', substrs=[exe_sdk_path])

--- a/lldb/test/API/commands/platform/sdk/main.c
+++ b/lldb/test/API/commands/platform/sdk/main.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+  FILE *f = fopen(argv[1], "wx");
+  if (f) {
+    fputs("\n", f);
+    fflush(f);
+    fclose(f);
+  } else {
+    return 1;
+  }
+
+  pause();
+  return 0;
+}

--- a/lldb/unittests/Process/ProcessEventDataTest.cpp
+++ b/lldb/unittests/Process/ProcessEventDataTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Plugins/Platform/MacOSX/PlatformMacOSX.h"
+#include "Plugins/Platform/MacOSX/PlatformRemoteMacOSX.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
@@ -151,7 +152,7 @@ ThreadSP CreateThread(ProcessSP &process_sp, bool should_stop,
 TEST_F(ProcessEventDataTest, DoOnRemoval) {
   ArchSpec arch("x86_64-apple-macosx-");
 
-  Platform::SetHostPlatform(PlatformMacOSX::CreateInstance(true, &arch));
+  Platform::SetHostPlatform(PlatformRemoteMacOSX::CreateInstance(true, &arch));
 
   DebuggerSP debugger_sp = Debugger::CreateInstance();
   ASSERT_TRUE(debugger_sp);
@@ -191,7 +192,7 @@ TEST_F(ProcessEventDataTest, DoOnRemoval) {
 TEST_F(ProcessEventDataTest, ShouldStop) {
   ArchSpec arch("x86_64-apple-macosx-");
 
-  Platform::SetHostPlatform(PlatformMacOSX::CreateInstance(true, &arch));
+  Platform::SetHostPlatform(PlatformRemoteMacOSX::CreateInstance(true, &arch));
 
   DebuggerSP debugger_sp = Debugger::CreateInstance();
   ASSERT_TRUE(debugger_sp);


### PR DESCRIPTION
…form

Extract remote debugging logic from PlatformMacOSX and move it into
PlatformRemoteMacOSX so it can benefit from all the logic necessary for
remote debugging.

Until now, remote macOS debugging was treated almost identical to local
macOS debugging. By moving in into its own class, we can have it inherit
from PlatformRemoteDarwinDevice and all the functionality it provides,
such as looking at the correct DeviceSupport directory.

rdar://68167374

Differential revision: https://reviews.llvm.org/D92452

(cherry picked from commit dd2054d38a848a75fe84fb68d9c3a97e5ade6753)