### PR TITLE
[lldb] Refactor GetDeviceSupportDirectoryNames and GetPlatformName (NFC)

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteAppleBridge.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteAppleBridge.cpp
@@ -164,15 +164,10 @@ bool PlatformRemoteAppleBridge::GetSupportedArchitectureAtIndex(uint32_t idx,
   return false;
 }
 
-
-void PlatformRemoteAppleBridge::GetDeviceSupportDirectoryNames (std::vector<std::string> &dirnames) 
-{
-    dirnames.clear();
-    dirnames.push_back("BridgeOS DeviceSupport");
+llvm::StringRef PlatformRemoteAppleBridge::GetDeviceSupportDirectoryName() {
+  return "BridgeOS DeviceSupport";
 }
 
-std::string PlatformRemoteAppleBridge::GetPlatformName ()
-{
-    return "BridgeOS.platform";
+llvm::StringRef PlatformRemoteAppleBridge::GetPlatformName() {
+  return "BridgeOS.platform";
 }
-

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteAppleBridge.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteAppleBridge.h
@@ -50,12 +50,8 @@ public:
                                        lldb_private::ArchSpec &arch) override;
 
 protected:
-
-  // lldb_private::PlatformRemoteDarwinDevice functions
-
-  void GetDeviceSupportDirectoryNames (std::vector<std::string> &dirnames) override;
-
-  std::string GetPlatformName () override;
+  llvm::StringRef GetDeviceSupportDirectoryName() override;
+  llvm::StringRef GetPlatformName() override;
 
 private:
   PlatformRemoteAppleBridge(const PlatformRemoteAppleBridge &) = delete;

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteAppleTV.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteAppleTV.cpp
@@ -223,15 +223,10 @@ bool PlatformRemoteAppleTV::GetSupportedArchitectureAtIndex(uint32_t idx,
   return false;
 }
 
-
-void PlatformRemoteAppleTV::GetDeviceSupportDirectoryNames (std::vector<std::string> &dirnames) 
-{
-    dirnames.clear();
-    dirnames.push_back("tvOS DeviceSupport");
+llvm::StringRef PlatformRemoteAppleTV::GetDeviceSupportDirectoryName() {
+  return "tvOS DeviceSupport";
 }
 
-std::string PlatformRemoteAppleTV::GetPlatformName ()
-{
-    return "AppleTVOS.platform";
+llvm::StringRef PlatformRemoteAppleTV::GetPlatformName() {
+  return "AppleTVOS.platform";
 }
-

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteAppleTV.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteAppleTV.h
@@ -50,12 +50,8 @@ public:
                                        lldb_private::ArchSpec &arch) override;
 
 protected:
-
-  // lldb_private::PlatformRemoteDarwinDevice functions
-
-  void GetDeviceSupportDirectoryNames (std::vector<std::string> &dirnames) override;
-
-  std::string GetPlatformName () override;
+  llvm::StringRef GetDeviceSupportDirectoryName() override;
+  llvm::StringRef GetPlatformName() override;
 
 private:
   PlatformRemoteAppleTV(const PlatformRemoteAppleTV &) = delete;

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteAppleWatch.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteAppleWatch.cpp
@@ -298,13 +298,10 @@ bool PlatformRemoteAppleWatch::GetSupportedArchitectureAtIndex(uint32_t idx,
   return false;
 }
 
-void PlatformRemoteAppleWatch::GetDeviceSupportDirectoryNames (std::vector<std::string> &dirnames) 
-{
-    dirnames.clear();
-    dirnames.push_back("watchOS DeviceSupport");
+llvm::StringRef PlatformRemoteAppleWatch::GetDeviceSupportDirectoryName() {
+  return "watchOS DeviceSupport";
 }
 
-std::string PlatformRemoteAppleWatch::GetPlatformName ()
-{
-    return "WatchOS.platform";
+llvm::StringRef PlatformRemoteAppleWatch::GetPlatformName() {
+  return "WatchOS.platform";
 }

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteAppleWatch.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteAppleWatch.h
@@ -53,12 +53,8 @@ public:
                                        lldb_private::ArchSpec &arch) override;
 
 protected:
-
-  // lldb_private::PlatformRemoteDarwinDevice functions
-
-  void GetDeviceSupportDirectoryNames (std::vector<std::string> &dirnames) override;
-
-  std::string GetPlatformName () override;
+  llvm::StringRef GetDeviceSupportDirectoryName() override;
+  llvm::StringRef GetPlatformName() override;
 
 private:
   PlatformRemoteAppleWatch(const PlatformRemoteAppleWatch &) = delete;

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.cpp
@@ -197,42 +197,36 @@ bool PlatformRemoteDarwinDevice::UpdateSDKDirectoryInfosIfNeeded() {
         }
       }
 
-      std::vector<std::string>  device_support_dirnames;
-      GetDeviceSupportDirectoryNames (device_support_dirnames);
-
-      for (std::string &dirname : device_support_dirnames)
-      {
-        const uint32_t num_installed = m_sdk_directory_infos.size();
-        std::string local_sdk_cache_str = "~/Library/Developer/Xcode/";
-        local_sdk_cache_str += dirname;
-        FileSpec local_sdk_cache(local_sdk_cache_str.c_str());
-        FileSystem::Instance().Resolve(local_sdk_cache);
-        if (FileSystem::Instance().Exists(local_sdk_cache)) {
-          if (log) {
-            LLDB_LOGF(
-                log,
-                "PlatformRemoteDarwinDevice::UpdateSDKDirectoryInfosIfNeeded "
-                "searching %s for additional SDKs",
-                local_sdk_cache.GetPath().c_str());
-          }
-            char path[PATH_MAX];
-            if (local_sdk_cache.GetPath(path, sizeof(path))) {
-              FileSystem::Instance().EnumerateDirectory(
-                  path, find_directories, find_files, find_other,
-                  GetContainedFilesIntoVectorOfStringsCallback,
-                  &m_sdk_directory_infos);
-              const uint32_t num_sdk_infos = m_sdk_directory_infos.size();
-              // First try for an exact match of major, minor and update
-              for (uint32_t i = num_installed; i < num_sdk_infos; ++i) {
-                m_sdk_directory_infos[i].user_cached = true;
-                if (log) {
-                  LLDB_LOGF(
-                      log,
-                      "PlatformRemoteDarwinDevice::"
-                      "UpdateSDKDirectoryInfosIfNeeded "
-                      "user SDK directory %s",
-                      m_sdk_directory_infos[i].directory.GetPath().c_str());
-                }
+      const uint32_t num_installed = m_sdk_directory_infos.size();
+      llvm::StringRef dirname = GetDeviceSupportDirectoryName();
+      std::string local_sdk_cache_str = "~/Library/Developer/Xcode/";
+      local_sdk_cache_str += std::string(dirname);
+      FileSpec local_sdk_cache(local_sdk_cache_str.c_str());
+      FileSystem::Instance().Resolve(local_sdk_cache);
+      if (FileSystem::Instance().Exists(local_sdk_cache)) {
+        if (log) {
+          LLDB_LOGF(
+              log,
+              "PlatformRemoteDarwinDevice::UpdateSDKDirectoryInfosIfNeeded "
+              "searching %s for additional SDKs",
+              local_sdk_cache.GetPath().c_str());
+        }
+        char path[PATH_MAX];
+        if (local_sdk_cache.GetPath(path, sizeof(path))) {
+          FileSystem::Instance().EnumerateDirectory(
+              path, find_directories, find_files, find_other,
+              GetContainedFilesIntoVectorOfStringsCallback,
+              &m_sdk_directory_infos);
+          const uint32_t num_sdk_infos = m_sdk_directory_infos.size();
+          // First try for an exact match of major, minor and update
+          for (uint32_t i = num_installed; i < num_sdk_infos; ++i) {
+            m_sdk_directory_infos[i].user_cached = true;
+            if (log) {
+              LLDB_LOGF(log,
+                        "PlatformRemoteDarwinDevice::"
+                        "UpdateSDKDirectoryInfosIfNeeded "
+                        "user SDK directory %s",
+                        m_sdk_directory_infos[i].directory.GetPath().c_str());
             }
           }
         }
@@ -341,7 +335,8 @@ PlatformRemoteDarwinDevice::GetSDKDirectoryForLatestOSVersion() {
 }
 
 const char *PlatformRemoteDarwinDevice::GetDeviceSupportDirectory() {
-  std::string platform_dir = "/Platforms/" + GetPlatformName() + "/DeviceSupport";
+  std::string platform_dir =
+      ("/Platforms/" + GetPlatformName() + "/DeviceSupport").str();
   if (m_device_support_directory.empty()) {
     if (FileSpec fspec = HostInfo::GetXcodeDeveloperDirectory()) {
       m_device_support_directory = fspec.GetPath();

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.h
@@ -97,10 +97,8 @@ protected:
   // UINT32_MAX if that SDK not found.
   uint32_t GetSDKIndexBySDKDirectoryInfo(const SDKDirectoryInfo *sdk_info);
 
-
-  virtual void GetDeviceSupportDirectoryNames (std::vector<std::string> &dirnames) = 0;
-
-  virtual std::string GetPlatformName () = 0;
+  virtual llvm::StringRef GetDeviceSupportDirectoryName() = 0;
+  virtual llvm::StringRef GetPlatformName() = 0;
 
 private:
   PlatformRemoteDarwinDevice(const PlatformRemoteDarwinDevice &) = delete;

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteiOS.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteiOS.cpp
@@ -143,14 +143,10 @@ bool PlatformRemoteiOS::GetSupportedArchitectureAtIndex(uint32_t idx,
   return ARMGetSupportedArchitectureAtIndex(idx, arch);
 }
 
-
-void PlatformRemoteiOS::GetDeviceSupportDirectoryNames (std::vector<std::string> &dirnames) 
-{
-    dirnames.clear();
-    dirnames.push_back("iOS DeviceSupport");
+llvm::StringRef PlatformRemoteiOS::GetDeviceSupportDirectoryName() {
+  return "iOS DeviceSupport";
 }
 
-std::string PlatformRemoteiOS::GetPlatformName ()
-{
-    return "iPhoneOS.platform";
+llvm::StringRef PlatformRemoteiOS::GetPlatformName() {
+  return "iPhoneOS.platform";
 }

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteiOS.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteiOS.h
@@ -49,12 +49,8 @@ public:
                                        lldb_private::ArchSpec &arch) override;
 
 protected:
-
-  // lldb_private::PlatformRemoteDarwinDevice functions
-
-  void GetDeviceSupportDirectoryNames (std::vector<std::string> &dirnames) override;
-
-  std::string GetPlatformName () override;
+  llvm::StringRef GetDeviceSupportDirectoryName() override;
+  llvm::StringRef GetPlatformName() override;
 
 private:
   PlatformRemoteiOS(const PlatformRemoteiOS &) = delete;


### PR DESCRIPTION
Both functions are effectively returning a single string literal. Change
the interface to return a llvm::StringRef instead of populating a vector
of std::strings or returning a std::string respectively.

(cherry picked from commit 173bb3c2eb094920708ab8f61dae2fe22d331773)