### PR TITLE
[lldb] Refactor the Symbolicator initializer

### DIFF
--- a/lldb/examples/python/symbolication.py
+++ b/lldb/examples/python/symbolication.py
@@ -437,18 +437,22 @@ class Image:
 
 class Symbolicator:
 
-    def __init__(self, debugger):
-        """A class the represents the information needed to symbolicate addresses in a program"""
+    def __init__(self, debugger=None, target=None, images=list()):
+        """A class the represents the information needed to symbolicate
+        addresses in a program.
+
+        Do not call this initializer directly, but rather use the factory
+        methods.
+        """
         self.debugger = debugger
-        self.target = None
-        self.images = list()  # a list of images to be used when symbolicating
+        self.target = target
+        self.images = images  # a list of images to be used when symbolicating
         self.addr_mask = 0xffffffffffffffff
 
     @classmethod
     def InitWithSBTarget(cls, target):
-        obj = cls()
-        obj.target = target
-        obj.images = list()
+        """Initialize a new Symbolicator with an existing SBTarget."""
+        obj = cls(target=target)
         triple = target.triple
         if triple:
             arch = triple.split('-')[0]
@@ -458,6 +462,13 @@ class Symbolicator:
         for module in target.modules:
             image = Image.InitWithSBTargetAndSBModule(target, module)
             obj.images.append(image)
+        return obj
+
+    @classmethod
+    def InitWithSBDebugger(cls, debugger, images):
+        """Initialize a new Symbolicator with an existing debugger and list of
+        images. The Symbolicator will create the target."""
+        obj = cls(debugger=debugger, images=images)
         return obj
 
     def __str__(self):


### PR DESCRIPTION
We found out that we have clients relying on the old signature of the
Symbolicator initializer. Make the signature compatible again and
provide a factory method to initialize the class correctly based on
whether you have a target or want the symbolicator to create one for
you.

Differential revision: D92601

(cherry picked from commit 99ea2c461d140c5a6b7da91061daa1cd9b3ec9b9)