### PR TITLE
[cmake] Add python bindings to the Apple-lldb-Linux distribution

### DIFF
--- a/lldb/cmake/caches/Apple-lldb-Linux.cmake
+++ b/lldb/cmake/caches/Apple-lldb-Linux.cmake
@@ -4,6 +4,7 @@ set(LLVM_DISTRIBUTION_COMPONENTS
   lldb
   liblldb
   lldb-argdumper
+  lldb-python-scripts
   lldb-server
   repl_swift
   CACHE STRING "")


### PR DESCRIPTION
I would like [swift-jupyter](https://github.com/google/swift-jupyter) to work with the stock Swift builds on swift.org.

Everything is compatible, except for one thing: swift-jupyter uses the LLDB Python bindings, which are not built into the Swift builds by default.

This change adds the LLDB Python bindings to the build.