### PR TITLE
[lldb] Remove unused RemangleAsSwiftifiedType

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1577,12 +1577,6 @@ TypeSystemSwiftTypeRef::RemangleAsType(swift::Demangle::Demangler &dem,
   return GetTypeFromMangledTypename(mangled_element);
 }
 
-CompilerType TypeSystemSwiftTypeRef::RemangleAsSwiftifiedType(
-    swift::Demangle::Demangler &Dem, swift::Demangle::NodePointer node) {
-  // DELETE THIS
-  return RemangleAsType(Dem, GetNodeForPrintingImpl(Dem, node, true));
-}
-
 swift::Demangle::NodePointer TypeSystemSwiftTypeRef::DemangleCanonicalType(
     swift::Demangle::Demangler &dem, opaque_compiler_type_t opaque_type) {
   using namespace swift::Demangle;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -297,12 +297,6 @@ public:
   CompilerType RemangleAsType(swift::Demangle::Demangler &dem,
                               swift::Demangle::NodePointer node);
 
-  /// Create a CompilerType after applying Swiftification. This is
-  /// meant to be used for a demenagle tree generated from a \p
-  /// swift::reflection::TypeRef.
-  CompilerType RemangleAsSwiftifiedType(swift::Demangle::Demangler &Dem,
-                                        swift::Demangle::NodePointer node);
-
 private:
   /// Helper that creates an AST type from \p type.
   void *ReconstructType(lldb::opaque_compiler_type_t type);

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1089,7 +1089,6 @@ GetTypeFromTypeRef(TypeSystemSwiftTypeRef &ts,
   swift::Demangle::Demangler dem;
   swift::Demangle::NodePointer node = type_ref->getDemangling(dem);
   return ts.RemangleAsType(dem, node);
-  return ts.RemangleAsSwiftifiedType(dem, node);
 }
 
 CompilerType SwiftLanguageRuntimeImpl::GetChildCompilerTypeAtIndex(


### PR DESCRIPTION
Remove `RemangleAsSwiftifiedType`, whose single callsite is actually unreachable code.
