### PR TITLE
[debugserver] Honor the cpu sub type if specified

### DIFF
--- a/lldb/tools/debugserver/source/DNB.cpp
+++ b/lldb/tools/debugserver/source/DNB.cpp
@@ -1723,19 +1723,52 @@ nub_bool_t DNBSetArchitecture(const char *arch) {
   if (arch && arch[0]) {
     if (strcasecmp(arch, "i386") == 0)
       return DNBArchProtocol::SetArchitecture(CPU_TYPE_I386);
-    else if ((strcasecmp(arch, "x86_64") == 0) ||
-             (strcasecmp(arch, "x86_64h") == 0))
-      return DNBArchProtocol::SetArchitecture(CPU_TYPE_X86_64);
-    else if (strstr(arch, "arm64_32") == arch || 
+    else if (strcasecmp(arch, "x86_64") == 0)
+      return DNBArchProtocol::SetArchitecture(CPU_TYPE_X86_64,
+                                              CPU_SUBTYPE_X86_64_ALL);
+    else if (strcasecmp(arch, "x86_64h") == 0)
+      return DNBArchProtocol::SetArchitecture(CPU_TYPE_X86_64,
+                                              CPU_SUBTYPE_X86_64_H);
+    else if (strstr(arch, "arm64_32") == arch ||
              strstr(arch, "aarch64_32") == arch)
       return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM64_32);
     else if (strstr(arch, "arm64e") == arch)
-      return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM64);
-    else if (strstr(arch, "arm64") == arch || strstr(arch, "armv8") == arch ||
-             strstr(arch, "aarch64") == arch)
-      return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM64);
+      return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM64,
+                                              CPU_SUBTYPE_ARM64E);
+    else if (strstr(arch, "arm64") == arch || strstr(arch, "aarch64") == arch)
+      return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM64,
+                                              CPU_SUBTYPE_ARM64_ALL);
+    else if (strstr(arch, "armv8") == arch)
+      return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM64,
+                                              CPU_SUBTYPE_ARM64_V8);
+    else if (strstr(arch, "armv7em") == arch)
+      return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM,
+                                              CPU_SUBTYPE_ARM_V7EM);
+    else if (strstr(arch, "armv7m") == arch)
+      return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM,
+                                              CPU_SUBTYPE_ARM_V7M);
+    else if (strstr(arch, "armv7k") == arch)
+      return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM,
+                                              CPU_SUBTYPE_ARM_V7K);
+    else if (strstr(arch, "armv7s") == arch)
+      return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM,
+                                              CPU_SUBTYPE_ARM_V7S);
+    else if (strstr(arch, "armv7") == arch)
+      return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7);
+    else if (strstr(arch, "armv6m") == arch)
+      return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM,
+                                              CPU_SUBTYPE_ARM_V6M);
+    else if (strstr(arch, "armv6") == arch)
+      return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V6);
+    else if (strstr(arch, "armv5") == arch)
+      return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM,
+                                              CPU_SUBTYPE_ARM_V5TEJ);
+    else if (strstr(arch, "armv4t") == arch)
+      return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM,
+                                              CPU_SUBTYPE_ARM_V4T);
     else if (strstr(arch, "arm") == arch)
-      return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM);
+      return DNBArchProtocol::SetArchitecture(CPU_TYPE_ARM,
+                                              CPU_SUBTYPE_ARM_ALL);
   }
   return false;
 }

--- a/lldb/tools/debugserver/source/DNBArch.cpp
+++ b/lldb/tools/debugserver/source/DNBArch.cpp
@@ -21,6 +21,7 @@
 typedef std::map<uint32_t, DNBArchPluginInfo> CPUPluginInfoMap;
 
 static uint32_t g_current_cpu_type = 0;
+static uint32_t g_current_cpu_subtype = 0;
 CPUPluginInfoMap g_arch_plugins;
 
 static const DNBArchPluginInfo *GetArchInfo() {
@@ -31,15 +32,17 @@ static const DNBArchPluginInfo *GetArchInfo() {
   return NULL;
 }
 
-uint32_t DNBArchProtocol::GetArchitecture() { return g_current_cpu_type; }
+uint32_t DNBArchProtocol::GetCPUType() { return g_current_cpu_type; }
+uint32_t DNBArchProtocol::GetCPUSubType() { return g_current_cpu_subtype; }
 
-bool DNBArchProtocol::SetArchitecture(uint32_t cpu_type) {
+bool DNBArchProtocol::SetArchitecture(uint32_t cpu_type, uint32_t cpu_subtype) {
   g_current_cpu_type = cpu_type;
+  g_current_cpu_subtype = cpu_subtype;
   bool result = g_arch_plugins.find(g_current_cpu_type) != g_arch_plugins.end();
-  DNBLogThreadedIf(
-      LOG_PROCESS,
-      "DNBArchProtocol::SetDefaultArchitecture (cpu_type=0x%8.8x) => %i",
-      cpu_type, result);
+  DNBLogThreadedIf(LOG_PROCESS,
+                   "DNBArchProtocol::SetDefaultArchitecture (cpu_type=0x%8.8x, "
+                   "cpu_subtype=0x%8.8x) => %i",
+                   cpu_type, cpu_subtype, result);
   return result;
 }
 

--- a/lldb/tools/debugserver/source/DNBArch.h
+++ b/lldb/tools/debugserver/source/DNBArch.h
@@ -49,9 +49,10 @@ public:
 
   static void RegisterArchPlugin(const DNBArchPluginInfo &arch_info);
 
-  static uint32_t GetArchitecture();
+  static uint32_t GetCPUType();
+  static uint32_t GetCPUSubType();
 
-  static bool SetArchitecture(uint32_t cpu_type);
+  static bool SetArchitecture(uint32_t cpu_type, uint32_t cpu_subtype = 0);
 
   DNBArchProtocol() : m_save_id(0) {}
 

--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.h
@@ -90,10 +90,10 @@ public:
                                            char const *envp[],
                                            MachProcess *process, DNBError &err);
   static pid_t PosixSpawnChildForPTraceDebugging(
-      const char *path, cpu_type_t cpu_type, char const *argv[],
-      char const *envp[], const char *working_directory, const char *stdin_path,
-      const char *stdout_path, const char *stderr_path, bool no_stdio,
-      MachProcess *process, int disable_aslr, DNBError &err);
+      const char *path, cpu_type_t cpu_type, cpu_subtype_t cpu_subtype,
+      char const *argv[], char const *envp[], const char *working_directory,
+      const char *stdin_path, const char *stdout_path, const char *stderr_path,
+      bool no_stdio, MachProcess *process, int disable_aslr, DNBError &err);
   nub_addr_t GetDYLDAllImageInfosAddress();
   static const void *PrepareForAttach(const char *path,
                                       nub_launch_flavor_t launch_flavor,

--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
@@ -3148,9 +3148,9 @@ pid_t MachProcess::LaunchForDebug(
 
   case eLaunchFlavorPosixSpawn:
     m_pid = MachProcess::PosixSpawnChildForPTraceDebugging(
-        path, DNBArchProtocol::GetArchitecture(), argv, envp, working_directory,
-        stdin_path, stdout_path, stderr_path, no_stdio, this, disable_aslr,
-        launch_err);
+        path, DNBArchProtocol::GetCPUType(), DNBArchProtocol::GetCPUSubType(),
+        argv, envp, working_directory, stdin_path, stdout_path, stderr_path,
+        no_stdio, this, disable_aslr, launch_err);
     break;
 
   default:
@@ -3210,10 +3210,10 @@ pid_t MachProcess::LaunchForDebug(
 }
 
 pid_t MachProcess::PosixSpawnChildForPTraceDebugging(
-    const char *path, cpu_type_t cpu_type, char const *argv[],
-    char const *envp[], const char *working_directory, const char *stdin_path,
-    const char *stdout_path, const char *stderr_path, bool no_stdio,
-    MachProcess *process, int disable_aslr, DNBError &err) {
+    const char *path, cpu_type_t cpu_type, cpu_subtype_t cpu_subtype,
+    char const *argv[], char const *envp[], const char *working_directory,
+    const char *stdin_path, const char *stdout_path, const char *stderr_path,
+    bool no_stdio, MachProcess *process, int disable_aslr, DNBError &err) {
   posix_spawnattr_t attr;
   short flags;
   DNBLogThreadedIf(LOG_PROCESS,
@@ -3256,24 +3256,40 @@ pid_t MachProcess::PosixSpawnChildForPTraceDebugging(
 
 // On SnowLeopard we should set "DYLD_NO_PIE" in the inferior environment....
 
-#if !defined(__arm__)
-
-  // We don't need to do this for ARM, and we really shouldn't now that we
-  // have multiple CPU subtypes and no posix_spawnattr call that allows us
-  // to set which CPU subtype to launch...
   if (cpu_type != 0) {
     size_t ocount = 0;
-    err.SetError(::posix_spawnattr_setbinpref_np(&attr, 1, &cpu_type, &ocount),
-                 DNBError::POSIX);
-    if (err.Fail() || DNBLogCheckLogBit(LOG_PROCESS))
-      err.LogThreaded("::posix_spawnattr_setbinpref_np ( &attr, 1, cpu_type = "
-                      "0x%8.8x, count => %llu )",
-                      cpu_type, (uint64_t)ocount);
+    bool slice_preference_set = false;
 
-    if (err.Fail() != 0 || ocount != 1)
-      return INVALID_NUB_PROCESS;
+    if (cpu_subtype != 0) {
+      if (@available(macOS 10.16, ios 10.14, watchos 7.0, tvos 14.0,
+                     bridgeos 5.0, *)) {
+        err.SetError(posix_spawnattr_setarchpref_np(&attr, 1, &cpu_type,
+                                                    &cpu_subtype, &ocount));
+        slice_preference_set = err.Success();
+        if (err.Fail() || DNBLogCheckLogBit(LOG_PROCESS))
+          err.LogThreaded(
+              "::posix_spawnattr_setarchpref_np ( &attr, 1, cpu_type = "
+              "0x%8.8x, cpu_subtype = 0x%8.8x, count => %llu )",
+              cpu_type, cpu_subtype, (uint64_t)ocount);
+        if (err.Fail() != 0 || ocount != 1)
+          return INVALID_NUB_PROCESS;
+      }
+    }
+
+    if (!slice_preference_set) {
+      err.SetError(
+          ::posix_spawnattr_setbinpref_np(&attr, 1, &cpu_type, &ocount),
+          DNBError::POSIX);
+      if (err.Fail() || DNBLogCheckLogBit(LOG_PROCESS))
+        err.LogThreaded(
+            "::posix_spawnattr_setbinpref_np ( &attr, 1, cpu_type = "
+            "0x%8.8x, count => %llu )",
+            cpu_type, (uint64_t)ocount);
+
+      if (err.Fail() != 0 || ocount != 1)
+        return INVALID_NUB_PROCESS;
+    }
   }
-#endif
 
   PseudoTerminal pty;
 


### PR DESCRIPTION
Use the newly added spawnattr API, posix_spawnattr_setarchpref_np, to
select a slice preferences per cpu and subcpu types, instead of just cpu
with posix_spawnattr_setarchpref_np.

rdar://16094957

Differential revision: https://reviews.llvm.org/D92712

(cherry picked from commit 0db37576c1dddbec1021b50320ae84a9d838742c)
