### PR TITLE
APINotes: add bitcode format schema definitions

### DIFF
--- a/clang/lib/APINotes/APINotesFormat.h
+++ b/clang/lib/APINotes/APINotesFormat.h
@@ -1,51 +1,35 @@
-//===--- APINotesFormat.h - The internals of API notes files ----*- C++ -*-===//
+//===-- APINotesWriter.h - API Notes Writer ---------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-///
-/// \file
-/// \brief Contains various constants and helper types to deal with API notes
-/// files.
-///
-//===----------------------------------------------------------------------===//
-#ifndef LLVM_CLANG_API_NOTES_FORMAT_H
-#define LLVM_CLANG_API_NOTES_FORMAT_H
 
-#include "llvm/ADT/DenseMapInfo.h"
-#include "llvm/ADT/Hashing.h"
+#ifndef LLVM_CLANG_LIB_APINOTES_APINOTESFORMAT_H
+#define LLVM_CLANG_LIB_APINOTES_APINOTESFORMAT_H
+
 #include "llvm/ADT/PointerEmbeddedInt.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/Bitcode/BitcodeConvenience.h"
-#include "llvm/Bitstream/BitCodes.h"
 
 namespace clang {
 namespace api_notes {
-
-using namespace llvm;
-
 /// Magic number for API notes files.
-const unsigned char API_NOTES_SIGNATURE[] = { 0xE2, 0x9C, 0xA8, 0x01 };
+const unsigned char API_NOTES_SIGNATURE[] = {0xE2, 0x9C, 0xA8, 0x01};
 
 /// API notes file major version number.
-///
 const uint16_t VERSION_MAJOR = 0;
 
 /// API notes file minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t VERSION_MINOR = 24;  // EnumExtensibility+FlagEnum
+const uint16_t VERSION_MINOR = 24; // EnumExtensibility + FlagEnum
 
-using IdentifierID = PointerEmbeddedInt<unsigned, 31>;
-using IdentifierIDField = BCVBR<16>;
+using IdentifierID = llvm::PointerEmbeddedInt<unsigned, 31>;
+using IdentifierIDField = llvm::BCVBR<16>;
 
-using SelectorID = PointerEmbeddedInt<unsigned, 31>;
-using SelectorIDField = BCVBR<16>;
-
-using StoredContextID = PointerEmbeddedInt<unsigned, 31>;
+using SelectorID = llvm::PointerEmbeddedInt<unsigned, 31>;
+using SelectorIDField = llvm::BCVBR<16>;
 
 /// The various types of blocks that can occur within a API notes file.
 ///
@@ -102,175 +86,172 @@ enum BlockID {
 };
 
 namespace control_block {
-  // These IDs must \em not be renumbered or reordered without incrementing
-  // VERSION_MAJOR.
-  enum {
-    METADATA = 1,
-    MODULE_NAME = 2,
-    MODULE_OPTIONS = 3,
-    SOURCE_FILE = 4,
-  };
+// These IDs must \em not be renumbered or reordered without incrementing
+// VERSION_MAJOR.
+enum {
+  METADATA = 1,
+  MODULE_NAME = 2,
+  MODULE_OPTIONS = 3,
+  SOURCE_FILE = 4,
+};
 
-  using MetadataLayout = BCRecordLayout<
-    METADATA, // ID
-    BCFixed<16>, // Module format major version
-    BCFixed<16>  // Module format minor version
-  >;
+using MetadataLayout =
+    llvm::BCRecordLayout<METADATA,          // ID
+                         llvm::BCFixed<16>, // Module format major version
+                         llvm::BCFixed<16>  // Module format minor version
+                         >;
 
-  using ModuleNameLayout = BCRecordLayout<
-    MODULE_NAME,
-    BCBlob       // Module name
-  >;
+using ModuleNameLayout = llvm::BCRecordLayout<MODULE_NAME,
+                                              llvm::BCBlob // Module name
+                                              >;
 
-  using ModuleOptionsLayout = BCRecordLayout<
-    MODULE_OPTIONS,
-    BCFixed<1> // SwiftInferImportAsMember
-  >;
+using ModuleOptionsLayout =
+    llvm::BCRecordLayout<MODULE_OPTIONS,
+                         llvm::BCFixed<1> // SwiftInferImportAsMember
+                         >;
 
-  using SourceFileLayout = BCRecordLayout<
-    SOURCE_FILE,
-    BCVBR<16>, // file size
-    BCVBR<16>  // creation time
-  >;
-}
+using SourceFileLayout = llvm::BCRecordLayout<SOURCE_FILE,
+                                              llvm::BCVBR<16>, // file size
+                                              llvm::BCVBR<16>  // creation time
+                                              >;
+} // namespace control_block
 
 namespace identifier_block {
-  enum {
-    IDENTIFIER_DATA = 1,
-  };
+enum {
+  IDENTIFIER_DATA = 1,
+};
 
-  using IdentifierDataLayout = BCRecordLayout<
-    IDENTIFIER_DATA,  // record ID
-    BCVBR<16>,  // table offset within the blob (see below)
-    BCBlob  // map from identifier strings to decl kinds / decl IDs
-  >;
-}
+using IdentifierDataLayout = llvm::BCRecordLayout<
+    IDENTIFIER_DATA, // record ID
+    llvm::BCVBR<16>, // table offset within the blob (see below)
+    llvm::BCBlob     // map from identifier strings to decl kinds / decl IDs
+    >;
+} // namespace identifier_block
 
 namespace objc_context_block {
-  enum {
-    OBJC_CONTEXT_ID_DATA = 1,
-    OBJC_CONTEXT_INFO_DATA = 2,
-  };
+enum {
+  OBJC_CONTEXT_ID_DATA = 1,
+  OBJC_CONTEXT_INFO_DATA = 2,
+};
 
-  using ObjCContextIDLayout = BCRecordLayout<
-    OBJC_CONTEXT_ID_DATA,  // record ID
-    BCVBR<16>,  // table offset within the blob (see below)
-    BCBlob  // map from ObjC class names/protocol (as IDs) to context IDs
-  >;
+using ObjCContextIDLayout =
+    llvm::BCRecordLayout<OBJC_CONTEXT_ID_DATA, // record ID
+                         llvm::BCVBR<16>, // table offset within the blob (see
+                                          // below)
+                         llvm::BCBlob // map from ObjC class names/protocol (as
+                                      // IDs) to context IDs
+                         >;
 
-  using ObjCContextInfoLayout = BCRecordLayout<
-    OBJC_CONTEXT_INFO_DATA,  // record ID
-    BCVBR<16>,  // table offset within the blob (see below)
-    BCBlob      // map from ObjC context IDs to context information.
-  >;
-}
+using ObjCContextInfoLayout = llvm::BCRecordLayout<
+    OBJC_CONTEXT_INFO_DATA, // record ID
+    llvm::BCVBR<16>,        // table offset within the blob (see below)
+    llvm::BCBlob            // map from ObjC context IDs to context information.
+    >;
+} // namespace objc_context_block
 
 namespace objc_property_block {
-  enum {
-    OBJC_PROPERTY_DATA = 1,
-  };
+enum {
+  OBJC_PROPERTY_DATA = 1,
+};
 
-  using ObjCPropertyDataLayout = BCRecordLayout<
-    OBJC_PROPERTY_DATA,  // record ID
-    BCVBR<16>,  // table offset within the blob (see below)
-    BCBlob  // map from ObjC (class name, property name) pairs to ObjC
-            // property information
-  >;
-}
+using ObjCPropertyDataLayout = llvm::BCRecordLayout<
+    OBJC_PROPERTY_DATA, // record ID
+    llvm::BCVBR<16>,    // table offset within the blob (see below)
+    llvm::BCBlob        // map from ObjC (class name, property name) pairs to
+                        // ObjC property information
+    >;
+} // namespace objc_property_block
 
 namespace objc_method_block {
-  enum {
-    OBJC_METHOD_DATA = 1,
-  };
+enum {
+  OBJC_METHOD_DATA = 1,
+};
 
-  using ObjCMethodDataLayout = BCRecordLayout<
-    OBJC_METHOD_DATA,  // record ID
-    BCVBR<16>,  // table offset within the blob (see below)
-    BCBlob  // map from ObjC (class names, selector,
-            // is-instance-method) tuples to ObjC method information
-  >;
-}
+using ObjCMethodDataLayout =
+    llvm::BCRecordLayout<OBJC_METHOD_DATA, // record ID
+                         llvm::BCVBR<16>,  // table offset within the blob (see
+                                           // below)
+                         llvm::BCBlob // map from ObjC (class names, selector,
+                                      // is-instance-method) tuples to ObjC
+                                      // method information
+                         >;
+} // namespace objc_method_block
 
 namespace objc_selector_block {
-  enum {
-    OBJC_SELECTOR_DATA = 1,
-  };
+enum {
+  OBJC_SELECTOR_DATA = 1,
+};
 
-  using ObjCSelectorDataLayout = BCRecordLayout<
-    OBJC_SELECTOR_DATA,  // record ID
-    BCVBR<16>,  // table offset within the blob (see below)
-    BCBlob  // map from (# pieces, identifier IDs) to Objective-C selector ID.
-  >;
-}
+using ObjCSelectorDataLayout =
+    llvm::BCRecordLayout<OBJC_SELECTOR_DATA, // record ID
+                         llvm::BCVBR<16>, // table offset within the blob (see
+                                          // below)
+                         llvm::BCBlob // map from (# pieces, identifier IDs) to
+                                      // Objective-C selector ID.
+                         >;
+} // namespace objc_selector_block
 
 namespace global_variable_block {
-  enum {
-    GLOBAL_VARIABLE_DATA = 1
-  };
+enum { GLOBAL_VARIABLE_DATA = 1 };
 
-  using GlobalVariableDataLayout = BCRecordLayout<
-    GLOBAL_VARIABLE_DATA,  // record ID
-    BCVBR<16>,  // table offset within the blob (see below)
-    BCBlob  // map from name to global variable information
-  >;
-}
+using GlobalVariableDataLayout = llvm::BCRecordLayout<
+    GLOBAL_VARIABLE_DATA, // record ID
+    llvm::BCVBR<16>,      // table offset within the blob (see below)
+    llvm::BCBlob          // map from name to global variable information
+    >;
+} // namespace global_variable_block
 
 namespace global_function_block {
-  enum {
-    GLOBAL_FUNCTION_DATA = 1
-  };
+enum { GLOBAL_FUNCTION_DATA = 1 };
 
-  using GlobalFunctionDataLayout = BCRecordLayout<
-    GLOBAL_FUNCTION_DATA,  // record ID
-    BCVBR<16>,  // table offset within the blob (see below)
-    BCBlob  // map from name to global function information
-  >;
-}
+using GlobalFunctionDataLayout = llvm::BCRecordLayout<
+    GLOBAL_FUNCTION_DATA, // record ID
+    llvm::BCVBR<16>,      // table offset within the blob (see below)
+    llvm::BCBlob          // map from name to global function information
+    >;
+} // namespace global_function_block
 
 namespace tag_block {
-  enum {
-    TAG_DATA = 1
-  };
+enum { TAG_DATA = 1 };
 
-  using TagDataLayout = BCRecordLayout<
-    TAG_DATA,   // record ID
-    BCVBR<16>,  // table offset within the blob (see below)
-    BCBlob      // map from name to tag information
-  >;
-};
+using TagDataLayout =
+    llvm::BCRecordLayout<TAG_DATA,        // record ID
+                         llvm::BCVBR<16>, // table offset within the blob (see
+                                          // below)
+                         llvm::BCBlob     // map from name to tag information
+                         >;
+}; // namespace tag_block
 
 namespace typedef_block {
-  enum {
-    TYPEDEF_DATA = 1
-  };
+enum { TYPEDEF_DATA = 1 };
 
-  using TypedefDataLayout = BCRecordLayout<
-    TYPEDEF_DATA,   // record ID
-    BCVBR<16>,  // table offset within the blob (see below)
-    BCBlob      // map from name to typedef information
-  >;
-};
+using TypedefDataLayout =
+    llvm::BCRecordLayout<TYPEDEF_DATA,    // record ID
+                         llvm::BCVBR<16>, // table offset within the blob (see
+                                          // below)
+                         llvm::BCBlob // map from name to typedef information
+                         >;
+}; // namespace typedef_block
 
 namespace enum_constant_block {
-  enum {
-    ENUM_CONSTANT_DATA = 1
-  };
+enum { ENUM_CONSTANT_DATA = 1 };
 
-  using EnumConstantDataLayout = BCRecordLayout<
-    ENUM_CONSTANT_DATA,  // record ID
-    BCVBR<16>,           // table offset within the blob (see below)
-    BCBlob               // map from name to enumerator information
-  >;
-}
+using EnumConstantDataLayout =
+    llvm::BCRecordLayout<ENUM_CONSTANT_DATA, // record ID
+                         llvm::BCVBR<16>, // table offset within the blob (see
+                                          // below)
+                         llvm::BCBlob // map from name to enumerator information
+                         >;
+} // namespace enum_constant_block
 
 /// A stored Objective-C selector.
 struct StoredObjCSelector {
   unsigned NumPieces;
   llvm::SmallVector<IdentifierID, 2> Identifiers;
 };
+} // namespace api_notes
+} // namespace clang
 
-} // end namespace api_notes
-} // end namespace clang
 
 namespace llvm {
   template<>
@@ -286,7 +267,7 @@ namespace llvm {
       return clang::api_notes::StoredObjCSelector{ 
                UnsignedInfo::getTombstoneKey(), { } };
     }
-    
+
     static unsigned getHashValue(
                       const clang::api_notes::StoredObjCSelector& value) {
       auto hash = llvm::hash_value(value.NumPieces);
@@ -306,4 +287,4 @@ namespace llvm {
   };
 }
 
-#endif // LLVM_CLANG_API_NOTES_FORMAT_H
+#endif

--- a/clang/lib/APINotes/APINotesWriter.cpp
+++ b/clang/lib/APINotes/APINotesWriter.cpp
@@ -204,7 +204,7 @@ static void emitRecordID(llvm::BitstreamWriter &out, unsigned ID,
 
 void APINotesWriter::Implementation::writeBlockInfoBlock(
        llvm::BitstreamWriter &writer) {
-  BCBlockRAII restoreBlock(writer, llvm::bitc::BLOCKINFO_BLOCK_ID, 2);  
+  llvm::BCBlockRAII restoreBlock(writer, llvm::bitc::BLOCKINFO_BLOCK_ID, 2);  
 
   SmallVector<unsigned char, 64> nameBuffer;
 #define BLOCK(X) emitBlockID(writer, X ## _ID, #X, nameBuffer)
@@ -240,7 +240,7 @@ void APINotesWriter::Implementation::writeBlockInfoBlock(
 
 void APINotesWriter::Implementation::writeControlBlock(
        llvm::BitstreamWriter &writer) {
-  BCBlockRAII restoreBlock(writer, CONTROL_BLOCK_ID, 3);
+  llvm::BCBlockRAII restoreBlock(writer, CONTROL_BLOCK_ID, 3);
   control_block::MetadataLayout metadata(writer);
   metadata.emit(ScratchRecord, VERSION_MAJOR, VERSION_MINOR);
 
@@ -299,7 +299,7 @@ namespace {
 
 void APINotesWriter::Implementation::writeIdentifierBlock(
        llvm::BitstreamWriter &writer) {
-  BCBlockRAII restoreBlock(writer, IDENTIFIER_BLOCK_ID, 3);
+  llvm::BCBlockRAII restoreBlock(writer, IDENTIFIER_BLOCK_ID, 3);
 
   if (IdentifierIDs.empty())
     return;
@@ -641,7 +641,7 @@ namespace {
 
 void APINotesWriter::Implementation::writeObjCContextBlock(
        llvm::BitstreamWriter &writer) {
-  BCBlockRAII restoreBlock(writer, OBJC_CONTEXT_BLOCK_ID, 3);
+  llvm::BCBlockRAII restoreBlock(writer, OBJC_CONTEXT_BLOCK_ID, 3);
 
   if (ObjCContexts.empty())
     return;  
@@ -686,7 +686,7 @@ void APINotesWriter::Implementation::writeObjCContextBlock(
 
 void APINotesWriter::Implementation::writeObjCPropertyBlock(
        llvm::BitstreamWriter &writer) {
-  BCBlockRAII restoreBlock(writer, OBJC_PROPERTY_BLOCK_ID, 3);
+  llvm::BCBlockRAII restoreBlock(writer, OBJC_PROPERTY_BLOCK_ID, 3);
 
   if (ObjCProperties.empty())
     return;  
@@ -805,7 +805,7 @@ namespace {
 
 void APINotesWriter::Implementation::writeObjCMethodBlock(
        llvm::BitstreamWriter &writer) {
-  BCBlockRAII restoreBlock(writer, OBJC_METHOD_BLOCK_ID, 3);
+  llvm::BCBlockRAII restoreBlock(writer, OBJC_METHOD_BLOCK_ID, 3);
 
   if (ObjCMethods.empty())
     return;  
@@ -873,7 +873,7 @@ namespace {
 
 void APINotesWriter::Implementation::writeObjCSelectorBlock(
        llvm::BitstreamWriter &writer) {
-  BCBlockRAII restoreBlock(writer, OBJC_SELECTOR_BLOCK_ID, 3);
+  llvm::BCBlockRAII restoreBlock(writer, OBJC_SELECTOR_BLOCK_ID, 3);
 
   if (SelectorIDs.empty())
     return;  
@@ -924,7 +924,7 @@ namespace {
 
 void APINotesWriter::Implementation::writeGlobalVariableBlock(
        llvm::BitstreamWriter &writer) {
-  BCBlockRAII restoreBlock(writer, GLOBAL_VARIABLE_BLOCK_ID, 3);
+  llvm::BCBlockRAII restoreBlock(writer, GLOBAL_VARIABLE_BLOCK_ID, 3);
 
   if (GlobalVariables.empty())
     return;  
@@ -975,7 +975,7 @@ namespace {
 
 void APINotesWriter::Implementation::writeGlobalFunctionBlock(
        llvm::BitstreamWriter &writer) {
-  BCBlockRAII restoreBlock(writer, GLOBAL_FUNCTION_BLOCK_ID, 3);
+  llvm::BCBlockRAII restoreBlock(writer, GLOBAL_FUNCTION_BLOCK_ID, 3);
 
   if (GlobalFunctions.empty())
     return;  
@@ -1026,7 +1026,7 @@ namespace {
 
 void APINotesWriter::Implementation::writeEnumConstantBlock(
        llvm::BitstreamWriter &writer) {
-  BCBlockRAII restoreBlock(writer, ENUM_CONSTANT_BLOCK_ID, 3);
+  llvm::BCBlockRAII restoreBlock(writer, ENUM_CONSTANT_BLOCK_ID, 3);
 
   if (EnumConstants.empty())
     return;  
@@ -1105,7 +1105,7 @@ namespace {
 
 void APINotesWriter::Implementation::writeTagBlock(
        llvm::BitstreamWriter &writer) {
-  BCBlockRAII restoreBlock(writer, TAG_BLOCK_ID, 3);
+  llvm::BCBlockRAII restoreBlock(writer, TAG_BLOCK_ID, 3);
 
   if (Tags.empty())
     return;  
@@ -1155,7 +1155,7 @@ namespace {
 
 void APINotesWriter::Implementation::writeTypedefBlock(
        llvm::BitstreamWriter &writer) {
-  BCBlockRAII restoreBlock(writer, TYPEDEF_BLOCK_ID, 3);
+  llvm::BCBlockRAII restoreBlock(writer, TYPEDEF_BLOCK_ID, 3);
 
   if (Typedefs.empty())
     return;  


### PR DESCRIPTION
This adds the bitcode format schema required for serialization of the
YAML data to a binary format.  APINotes are pre-compiled and re-used in
the binary format from the frontend.  These definitions provide the data
layout representation enabling writing (and eventually) reading of the
data in bitcode format.