### PR TITLE
[lldb] Wire-up TypeSystemSwiftTypeRef::GetNumChildren

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2077,10 +2077,14 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
     // TODO: which of these should be logged on failure?
     if (auto *exe_scope = exe_ctx->GetBestExecutionContextScope())
       if (auto *runtime =
-              SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
+              SwiftLanguageRuntime::Get(exe_scope->CalculateProcess())) {
         if (auto num_children =
                 runtime->GetNumChildren(GetCanonicalType(type), nullptr))
           return *num_children;
+        else
+          return m_swift_ast_context->GetNumChildren(
+              ReconstructType(type), omit_empty_base_classes, exe_ctx);
+      }
 
     return 0;
   };

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1328,7 +1328,7 @@ template <typename T> bool Equivalent(T l, T r) {
 
 /// Specialization for GetTypeInfo().
 template <> bool Equivalent<uint32_t>(uint32_t l, uint32_t r) {
-  if (l < r) {
+  if (l != r) {
     // Failure. Dump it for easier debugging.
     llvm::dbgs() << "TypeSystemSwiftTypeRef diverges from SwiftASTContext:\n";
 #define HANDLE_ENUM_CASE(VAL, CASE) \
@@ -1399,7 +1399,7 @@ template <> bool Equivalent<uint32_t>(uint32_t l, uint32_t r) {
     HANDLE_ENUM_CASE(r, eTypeIsBound);
     llvm::dbgs() << "\n";
   }
-  return l >= r;
+  return l == r;
 }
 
 /// Determine wether this demangle tree contains a sugar () node.
@@ -1508,10 +1508,9 @@ template <> bool Equivalent<ConstString>(ConstString l, ConstString r) {
   return l == r;
 }
 
-/// Version taylored to GetBitSize & friends.
-template <>
-bool Equivalent<llvm::Optional<uint64_t>>(llvm::Optional<uint64_t> l,
-                                          llvm::Optional<uint64_t> r) {
+/// Version tailored to GetBitSize & friends.
+template <typename T>
+bool Equivalent(llvm::Optional<T> l, llvm::Optional<T> r) {
   if (l == r)
     return true;
   // There are situations where SwiftASTContext incorrectly returns
@@ -1524,6 +1523,12 @@ bool Equivalent<llvm::Optional<uint64_t>>(llvm::Optional<uint64_t> l,
     return true;
   llvm::dbgs() << l << " != " << r << "\n";
   return false;
+}
+
+// Introduced for `GetNumChildren`.
+template <typename T>
+bool Equivalent(llvm::Optional<T> l, T r) {
+  return Equivalent(l, llvm::Optional<T>(r));
 }
 
 } // namespace
@@ -2079,10 +2084,13 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
               SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
         if (auto num_children =
                 runtime->GetNumChildren(GetCanonicalType(type), nullptr)) {
-          auto impl = [&]() -> uint32_t { return *num_children; };
-          VALIDATE_AND_RETURN(
-              impl, GetNumChildren, type,
-              (ReconstructType(type), omit_empty_base_classes, exe_ctx));
+          // Use lambda to intercept and unwrap the `Optional` return value.
+          return [&]() {
+            auto impl = [&]() { return num_children; };
+            VALIDATE_AND_RETURN(
+                impl, GetNumChildren, type,
+                (ReconstructType(type), omit_empty_base_classes, exe_ctx));
+          }().getValue();
         }
 
   LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2065,13 +2065,30 @@ lldb::Encoding TypeSystemSwiftTypeRef::GetEncoding(opaque_compiler_type_t type,
 lldb::Format TypeSystemSwiftTypeRef::GetFormat(opaque_compiler_type_t type) {
   return m_swift_ast_context->GetFormat(ReconstructType(type));
 }
+
 uint32_t
 TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
                                        bool omit_empty_base_classes,
                                        const ExecutionContext *exe_ctx) {
-  return m_swift_ast_context->GetNumChildren(ReconstructType(type),
-                                             omit_empty_base_classes, exe_ctx);
+  auto impl = [&]() -> uint32_t {
+    if (!exe_ctx)
+      return 0;
+
+    // TODO: which of these should be logged on failure?
+    if (auto *exe_scope = exe_ctx->GetBestExecutionContextScope())
+      if (auto *runtime =
+              SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
+        if (auto num_children =
+                runtime->GetNumChildren(GetCanonicalType(type), nullptr))
+          return *num_children;
+
+    return 0;
+  };
+  VALIDATE_AND_RETURN(
+      impl, GetNumChildren, type,
+      (ReconstructType(type), omit_empty_base_classes, exe_ctx));
 }
+
 uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type) {
   return m_swift_ast_context->GetNumFields(ReconstructType(type));
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1328,7 +1328,7 @@ template <typename T> bool Equivalent(T l, T r) {
 
 /// Specialization for GetTypeInfo().
 template <> bool Equivalent<uint32_t>(uint32_t l, uint32_t r) {
-  if (l != r) {
+  if (l < r) {
     // Failure. Dump it for easier debugging.
     llvm::dbgs() << "TypeSystemSwiftTypeRef diverges from SwiftASTContext:\n";
 #define HANDLE_ENUM_CASE(VAL, CASE) \
@@ -1399,7 +1399,7 @@ template <> bool Equivalent<uint32_t>(uint32_t l, uint32_t r) {
     HANDLE_ENUM_CASE(r, eTypeIsBound);
     llvm::dbgs() << "\n";
   }
-  return l == r;
+  return l >= r;
 }
 
 /// Determine wether this demangle tree contains a sugar () node.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2071,22 +2071,17 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
                                        bool omit_empty_base_classes,
                                        const ExecutionContext *exe_ctx) {
   auto impl = [&]() -> uint32_t {
-    if (!exe_ctx)
-      return 0;
-
     // TODO: which of these should be logged on failure?
-    if (auto *exe_scope = exe_ctx->GetBestExecutionContextScope())
-      if (auto *runtime =
-              SwiftLanguageRuntime::Get(exe_scope->CalculateProcess())) {
-        if (auto num_children =
-                runtime->GetNumChildren(GetCanonicalType(type), nullptr))
-          return *num_children;
-        else
-          return m_swift_ast_context->GetNumChildren(
-              ReconstructType(type), omit_empty_base_classes, exe_ctx);
-      }
+    if (exe_ctx)
+      if (auto *exe_scope = exe_ctx->GetBestExecutionContextScope())
+        if (auto *runtime =
+                SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
+          if (auto num_children =
+                  runtime->GetNumChildren(GetCanonicalType(type), nullptr))
+            return *num_children;
 
-    return 0;
+    return m_swift_ast_context->GetNumChildren(
+        ReconstructType(type), omit_empty_base_classes, exe_ctx);
   };
   VALIDATE_AND_RETURN(
       impl, GetNumChildren, type,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2073,7 +2073,6 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
   if (IsFunctionType(type, nullptr))
     return 0;
 
-  // TODO: which of these should be logged on failure?
   if (exe_ctx)
     if (auto *exe_scope = exe_ctx->GetBestExecutionContextScope())
       if (auto *runtime =
@@ -2085,6 +2084,10 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
               impl, GetNumChildren, type,
               (ReconstructType(type), omit_empty_base_classes, exe_ctx));
         }
+
+  LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
+            "Using SwiftASTContext::GetNumChildren fallback for type %s",
+            AsMangledName(type));
 
   return m_swift_ast_context->GetNumChildren(
         ReconstructType(type), omit_empty_base_classes, exe_ctx);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2070,6 +2070,8 @@ uint32_t
 TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
                                        bool omit_empty_base_classes,
                                        const ExecutionContext *exe_ctx) {
+  if (IsFunctionType(type, nullptr))
+    return 0;
 
   // TODO: which of these should be logged on failure?
   if (exe_ctx)

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2075,16 +2075,13 @@ uint32_t
 TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
                                        bool omit_empty_base_classes,
                                        const ExecutionContext *exe_ctx) {
-  if (IsFunctionType(type, nullptr))
-    return 0;
-
   if (exe_ctx)
     if (auto *exe_scope = exe_ctx->GetBestExecutionContextScope())
       if (auto *runtime =
               SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
         if (auto num_children =
                 runtime->GetNumChildren(GetCanonicalType(type), nullptr)) {
-          // Use lambda to intercept and unwrap the `Optional` return value.
+          // Use a lambda to intercept and unwrap the `Optional` return value.
           return [&]() {
             auto impl = [&]() { return num_children; };
             VALIDATE_AND_RETURN(

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2070,22 +2070,22 @@ uint32_t
 TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
                                        bool omit_empty_base_classes,
                                        const ExecutionContext *exe_ctx) {
-  auto impl = [&]() -> uint32_t {
-    // TODO: which of these should be logged on failure?
-    if (exe_ctx)
-      if (auto *exe_scope = exe_ctx->GetBestExecutionContextScope())
-        if (auto *runtime =
-                SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
-          if (auto num_children =
-                  runtime->GetNumChildren(GetCanonicalType(type), nullptr))
-            return *num_children;
 
-    return m_swift_ast_context->GetNumChildren(
+  // TODO: which of these should be logged on failure?
+  if (exe_ctx)
+    if (auto *exe_scope = exe_ctx->GetBestExecutionContextScope())
+      if (auto *runtime =
+              SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
+        if (auto num_children =
+                runtime->GetNumChildren(GetCanonicalType(type), nullptr)) {
+          auto impl = [&]() -> uint32_t { return *num_children; };
+          VALIDATE_AND_RETURN(
+              impl, GetNumChildren, type,
+              (ReconstructType(type), omit_empty_base_classes, exe_ctx));
+        }
+
+  return m_swift_ast_context->GetNumChildren(
         ReconstructType(type), omit_empty_base_classes, exe_ctx);
-  };
-  VALIDATE_AND_RETURN(
-      impl, GetNumChildren, type,
-      (ReconstructType(type), omit_empty_base_classes, exe_ctx));
 }
 
 uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type) {

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1012,8 +1012,14 @@ SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
   // Structs and Tuples.
   if (auto *rti =
           llvm::dyn_cast_or_null<swift::reflection::RecordTypeInfo>(ti)) {
-    auto fields = rti->getFields();
-    return fields.size();
+    // `OpaqueExistential` is documented as:
+    //     An existential is a three-word buffer followed by value metadata...
+    // The buffer is exposed by as children named `payload_data_{0,1,2}`, and
+    // 3 is added to the number of fields.
+    if (rti->getRecordKind() ==
+        swift::reflection::RecordKind::OpaqueExistential)
+      return rti->getNumFields() + 3;
+    return rti->getNumFields();
   }
   if (auto *eti = llvm::dyn_cast_or_null<swift::reflection::EnumTypeInfo>(ti)) {
     return eti->getNumPayloadCases();

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1015,6 +1015,9 @@ SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
     auto fields = rti->getFields();
     return fields.size();
   }
+  if (auto *eti = llvm::dyn_cast_or_null<swift::reflection::EnumTypeInfo>(ti)) {
+    return eti->getNumPayloadCases();
+  }
   // FIXME: Implement more cases.
   return {};
 }

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1012,14 +1012,20 @@ SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
   // Structs and Tuples.
   if (auto *rti =
           llvm::dyn_cast_or_null<swift::reflection::RecordTypeInfo>(ti)) {
-    // `OpaqueExistential` is documented as:
-    //     An existential is a three-word buffer followed by value metadata...
-    // The buffer is exposed by as children named `payload_data_{0,1,2}`, and
-    // requires the number of fields to be increased.
-    if (rti->getRecordKind() ==
-        swift::reflection::RecordKind::OpaqueExistential)
+    switch (rti->getRecordKind()) {
+    case swift::reflection::RecordKind::ThickFunction:
+      // There are two fields, `function` and `context`, but they're not exposed
+      // by lldb.
+      return 0;
+    case swift::reflection::RecordKind::OpaqueExistential:
+      // `OpaqueExistential` is documented as:
+      //     An existential is a three-word buffer followed by value metadata...
+      // The buffer is exposed as children named `payload_data_{0,1,2}`, and
+      // the number of fields are increased to match.
       return rti->getNumFields() + 3;
-    return rti->getNumFields();
+    default:
+      return rti->getNumFields();
+    }
   }
   if (auto *eti = llvm::dyn_cast_or_null<swift::reflection::EnumTypeInfo>(ti)) {
     return eti->getNumPayloadCases();

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1015,7 +1015,7 @@ SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
     // `OpaqueExistential` is documented as:
     //     An existential is a three-word buffer followed by value metadata...
     // The buffer is exposed by as children named `payload_data_{0,1,2}`, and
-    // 3 is added to the number of fields.
+    // requires the number of fields to be increased.
     if (rti->getRecordKind() ==
         swift::reflection::RecordKind::OpaqueExistential)
       return rti->getNumFields() + 3;

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
@@ -82,7 +82,7 @@ class TestLibraryResilient(TestBase):
         # This test is deliberately checking what the user will see, rather than
         # the structure provided by the Python API, in order to test the recovery.
         self.expect("fr var", substrs=[
-            "(SomeLibrary.ContainsTwoInts) container = (other = 10)",
+            "(SomeLibrary.ContainsTwoInts) container = {", "other = 10",
             "(Int) simple = 1"])
         self.expect("e container", substrs=["(SomeLibrary.ContainsTwoInts)", "other = 10"])
         self.expect("e container.wrapped", error=True, substrs=["value of type 'ContainsTwoInts' has no member 'wrapped'"])


### PR DESCRIPTION
Make `TypeSystemSwiftTypeRef::GetNumChildren` use reflection via `SwiftLanguageRuntimeImpl` instead of using `SwiftASTContext`.

This required changes to `SwiftLanguageRuntimeImpl::GetNumChildren`, to handle `EnumTypeInfo` and `OpaqueExistential`.

Other notes:
* The `Equivalent` helper was tweaked to allow `GetNumChildren` to use `>=` when validating. This is because `TypeRef`s can, in some cases, expose more children than `SwiftASTContext` (for example when using library evolution and `.swiftinterface` files)
* Function types are hard code to zero to match `SwiftASTContext` (and makes sense). `TypeRef`s for function types can contain a non-zero number of children.

rdar://68171335
