### PR TITLE
Add a defensive nullptr check.

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1720,6 +1720,8 @@ SwiftLanguageRuntimeImpl::BindGenericTypeParameters(StackFrame &stack_frame,
 
     const swift::reflection::TypeRef *type_ref =
         reflection_ctx->readTypeFromMetadata(*metadata_location);
+    if (!type_ref)
+      return;
     substitutions.insert({{depth, index}, type_ref});
   });
 


### PR DESCRIPTION
TypeRef::subst() doesn't accept null type substitutions.
(cherry picked from commit 77cb9f37abdefa4631a9d55f22c2b499787990d1)