### PR TITLE
Add a defensive nullptr check.

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1723,6 +1723,8 @@ SwiftLanguageRuntimeImpl::BindGenericTypeParameters(StackFrame &stack_frame,
 
     const swift::reflection::TypeRef *type_ref =
         reflection_ctx->readTypeFromMetadata(*metadata_location);
+    if (!type_ref)
+      return;
     substitutions.insert({{depth, index}, type_ref});
   });
 


### PR DESCRIPTION
TypeRef::subst() doesn't accept null type substitutions.