### PR TITLE
Make test more resilient against environment changes.

### DIFF
--- a/lldb/test/API/repl/cpp_exceptions/Makefile
+++ b/lldb/test/API/repl/cpp_exceptions/Makefile
@@ -2,7 +2,7 @@ SWIFT_SOURCES := main.swift
 SWIFTFLAGS_EXTRAS = -L$(BUILDDIR) -I$(BUILDDIR) -I$(SRCDIR) -lWrapper
 LD_EXTRAS = -Xlinker -rpath -Xlinker $(BUILDDIR)
 
-all: libWrapper.dylib a.out
+all: sdkroot.txt libWrapper.dylib a.out
 
 include Makefile.rules
 
@@ -17,3 +17,7 @@ libWrapper.dylib: libCppLib.dylib
 	$(MAKE) -f $(MAKEFILE_RULES) \
 		DYLIB_NAME=Wrapper DYLIB_SWIFT_SOURCES=wrapper.swift \
 		SWIFTFLAGS_EXTRAS="-I$(SRCDIR) -L. -lCppLib -module-link-name Wrapper"
+
+# Make sure Makefile and test agree on the SDK.
+sdkroot.txt:
+	echo $(SDKROOT) > $@

--- a/lldb/test/API/repl/cpp_exceptions/TestCPPExceptionsInREPL.py
+++ b/lldb/test/API/repl/cpp_exceptions/TestCPPExceptionsInREPL.py
@@ -46,7 +46,10 @@ class TestREPLExceptions(TestBase):
 
     @decorators.skipIfRemote
     def do_repl_test(self):
-        sdk_root = swift.getSwiftSDKRoot()
+        sdk_root = ""
+        with open(self.getBuildArtifact("sdkroot.txt"), 'r') as f:
+            sdk_root = f.readlines()[0]
+        self.assertGreater(len(sdk_root), 0)
         build_dir = self.getBuildDir()
         repl_args = [lldbtest_config.lldbExec, "-x", "--repl=-enable-objc-interop -sdk %s -L%s -I%s"%(sdk_root, build_dir, build_dir)]
         repl_proc = subprocess.Popen(repl_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=build_dir)


### PR DESCRIPTION
By using the same SDKROOT that the Makefile uses, we can enforce
conistency between Makefile and python code.

rdar://68717622
(cherry picked from commit 579410fed828f1cc12538fcd7c1f56fa73a08236)