### PR TITLE
[lldb][swift] Disable tests that use the system dsymutil by accident

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
+++ b/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
@@ -27,6 +27,7 @@ class TestSwiftStaticArchiveTwoSwiftmodules(TestBase):
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin
+    @skipIf # Makefile uses system dsymutil (which might not work): rdar://72148156
     @swiftTest
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -23,6 +23,7 @@ class TestSwiftDeploymentTarget(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
+    @skipIf # Makefile uses system dsymutil (which might not work): rdar://72148156
     @skipIf(bugnumber="rdar://60396797", # should work but crashes.
             setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin
@@ -37,6 +38,7 @@ class TestSwiftDeploymentTarget(TestBase):
                                           lldb.SBFileSpec('main.swift'))
         self.expect("p f", substrs=['i = 23'])
 
+    @skipIf # Makefile uses system dsymutil (which might not work): rdar://72148156
     @skipIf(bugnumber="rdar://60396797", # should work but crashes.
             setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/missing_sdk/TestMissingSDK.py
+++ b/lldb/test/API/lang/swift/missing_sdk/TestMissingSDK.py
@@ -19,6 +19,7 @@ class TestMissingSDK(TestBase):
         # Call super's setUp().
         TestBase.setUp(self)
 
+    @skipIf # Makefile uses system dsymutil (which might not work): rdar://72148156
     @swiftTest
     @skipIf(oslist=['windows'])
     @skipIfDarwinEmbedded # swift crash inspecting swift stdlib with little other swift loaded <rdar://problem/55079456> 


### PR DESCRIPTION
These tests seem to use the system dsymutil as they just invoke swiftc (which
then runs the dsymutil it finds for us). Some bots seem to have a broken
dsymutil so these tests fail now on those systems.

See rdar://72148156