### PR TITLE
[lldb] Remove is_variadic_ptr from TypeSystemSwift and SwiftASTContext

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5044,8 +5044,7 @@ bool SwiftASTContext::IsAggregateType(opaque_compiler_type_t type) {
   return false;
 }
 
-bool SwiftASTContext::IsFunctionType(opaque_compiler_type_t type,
-                                     bool *is_variadic_ptr) {
+bool SwiftASTContext::IsFunctionType(opaque_compiler_type_t type) {
   if (type) {
     swift::CanType swift_can_type(GetCanonicalSwiftType(type));
     const swift::TypeKind type_kind = swift_can_type->getKind();
@@ -5094,7 +5093,7 @@ SwiftASTContext::GetFunctionArgumentAtIndex(opaque_compiler_type_t type,
 }
 
 bool SwiftASTContext::IsFunctionPointerType(opaque_compiler_type_t type) {
-  return IsFunctionType(type, nullptr); // FIXME: think about this
+  return IsFunctionType(type); // FIXME: think about this
 }
 
 bool SwiftASTContext::IsPointerType(opaque_compiler_type_t type,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -452,8 +452,7 @@ public:
 
   bool IsDefined(lldb::opaque_compiler_type_t type) override;
 
-  bool IsFunctionType(lldb::opaque_compiler_type_t type,
-                      bool *is_variadic_ptr) override;
+  bool IsFunctionType(lldb::opaque_compiler_type_t type) override;
 
   size_t
   GetNumberOfFunctionArguments(lldb::opaque_compiler_type_t type) override;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1668,8 +1668,7 @@ bool TypeSystemSwiftTypeRef::IsDefined(opaque_compiler_type_t type) {
   VALIDATE_AND_RETURN(impl, IsDefined, type, (ReconstructType(type)));
 }
 
-bool TypeSystemSwiftTypeRef::IsFunctionType(opaque_compiler_type_t type,
-                                            bool *is_variadic_ptr) {
+bool TypeSystemSwiftTypeRef::IsFunctionType(opaque_compiler_type_t type) {
   auto impl = [&]() -> bool {
     using namespace swift::Demangle;
     Demangler dem;
@@ -1679,8 +1678,7 @@ bool TypeSystemSwiftTypeRef::IsFunctionType(opaque_compiler_type_t type,
     return node && (node->getKind() == Node::Kind::FunctionType ||
                     node->getKind() == Node::Kind::ImplFunctionType);
   };
-  VALIDATE_AND_RETURN(impl, IsFunctionType, type,
-                      (ReconstructType(type), nullptr));
+  VALIDATE_AND_RETURN(impl, IsFunctionType, type, (ReconstructType(type)));
 }
 size_t TypeSystemSwiftTypeRef::GetNumberOfFunctionArguments(
     opaque_compiler_type_t type) {
@@ -1754,7 +1752,7 @@ TypeSystemSwiftTypeRef::GetFunctionArgumentAtIndex(opaque_compiler_type_t type,
 }
 bool TypeSystemSwiftTypeRef::IsFunctionPointerType(
     opaque_compiler_type_t type) {
-  auto impl = [&]() -> bool { return IsFunctionType(type, nullptr); };
+  auto impl = [&]() -> bool { return IsFunctionType(type); };
   VALIDATE_AND_RETURN(impl, IsFunctionPointerType, type,
                       (ReconstructType(type)));
 }
@@ -1998,7 +1996,7 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
                                    ExecutionContextScope *exe_scope) {
   auto impl = [&]() -> llvm::Optional<uint64_t> {
     // Bug-for-bug compatibility. See comment in SwiftASTContext::GetBitSize().
-    if (IsFunctionType(type, nullptr))
+    if (IsFunctionType(type))
       return GetPointerByteSize() * 8;
 
     // Clang types can be resolved even without a process.
@@ -2311,7 +2309,7 @@ bool TypeSystemSwiftTypeRef::IsMeaninglessWithoutDynamicResolution(
     using namespace swift::Demangle;
     Demangler dem;
     auto *node = DemangleCanonicalType(dem, type);
-    return ContainsGenericTypeParameter(node) && !IsFunctionType(type, nullptr);
+    return ContainsGenericTypeParameter(node) && !IsFunctionType(type);
   };
   VALIDATE_AND_RETURN(impl, IsMeaninglessWithoutDynamicResolution, type,
                       (ReconstructType(type)));

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -98,8 +98,7 @@ public:
                    bool *is_incomplete) override;
   bool IsAggregateType(lldb::opaque_compiler_type_t type) override;
   bool IsDefined(lldb::opaque_compiler_type_t type) override;
-  bool IsFunctionType(lldb::opaque_compiler_type_t type,
-                      bool *is_variadic_ptr) override;
+  bool IsFunctionType(lldb::opaque_compiler_type_t type) override;
   size_t
   GetNumberOfFunctionArguments(lldb::opaque_compiler_type_t type) override;
   CompilerType GetFunctionArgumentAtIndex(lldb::opaque_compiler_type_t type,


### PR DESCRIPTION
This was removed from upstream and needs to be removed from `swift/next`
    usages as well.