### PR TITLE
Revert "[ThreadPlan] Delete unused ThreadPlanStepInRange code, NFC"

### DIFF
--- a/lldb/include/lldb/Target/ThreadPlanStepInRange.h
+++ b/lldb/include/lldb/Target/ThreadPlanStepInRange.h
@@ -26,6 +26,13 @@ public:
                         LazyBool step_in_avoids_code_without_debug_info,
                         LazyBool step_out_avoids_code_without_debug_info);
 
+  ThreadPlanStepInRange(Thread &thread, const AddressRange &range,
+                        const SymbolContext &addr_context,
+                        const char *step_into_function_name,
+                        lldb::RunMode stop_others,
+                        LazyBool step_in_avoids_code_without_debug_info,
+                        LazyBool step_out_avoids_code_without_debug_info);
+
   ~ThreadPlanStepInRange() override;
 
   void GetDescription(Stream *s, lldb::DescriptionLevel level) override;
@@ -73,6 +80,17 @@ protected:
   bool FrameMatchesAvoidCriteria();
 
 private:
+  friend lldb::ThreadPlanSP Thread::QueueThreadPlanForStepOverRange(
+      bool abort_other_plans, const AddressRange &range,
+      const SymbolContext &addr_context, lldb::RunMode stop_others,
+      Status &status, LazyBool avoid_code_without_debug_info);
+  friend lldb::ThreadPlanSP Thread::QueueThreadPlanForStepInRange(
+      bool abort_other_plans, const AddressRange &range,
+      const SymbolContext &addr_context, const char *step_in_target,
+      lldb::RunMode stop_others, Status &status,
+      LazyBool step_in_avoids_code_without_debug_info,
+      LazyBool step_out_avoids_code_without_debug_info);
+
   void SetupAvoidNoDebug(LazyBool step_in_avoids_code_without_debug_info,
                          LazyBool step_out_avoids_code_without_debug_info);
 

--- a/lldb/source/Target/ThreadPlanStepInRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepInRange.cpp
@@ -49,6 +49,22 @@ ThreadPlanStepInRange::ThreadPlanStepInRange(
                     step_out_avoids_code_without_debug_info);
 }
 
+ThreadPlanStepInRange::ThreadPlanStepInRange(
+    Thread &thread, const AddressRange &range,
+    const SymbolContext &addr_context, const char *step_into_target,
+    lldb::RunMode stop_others, LazyBool step_in_avoids_code_without_debug_info,
+    LazyBool step_out_avoids_code_without_debug_info)
+    : ThreadPlanStepRange(ThreadPlan::eKindStepInRange,
+                          "Step Range stepping in", thread, range, addr_context,
+                          stop_others),
+      ThreadPlanShouldStopHere(this), m_step_past_prologue(true),
+      m_virtual_step(false), m_step_into_target(step_into_target) {
+  SetCallbacks();
+  SetFlagsToDefault();
+  SetupAvoidNoDebug(step_in_avoids_code_without_debug_info,
+                    step_out_avoids_code_without_debug_info);
+}
+
 ThreadPlanStepInRange::~ThreadPlanStepInRange() {
   ClearStepInDeepBreakpoints();
 }


### PR DESCRIPTION
This reverts commit 04cd6c62176ce027af2d343044b84ce5d317aee7.

This is unused upstream but used as part of Swift.