### PR TITLE
Ignore DBGArchitecture from dsymForUUID's plist

### DIFF
--- a/lldb/source/Symbol/LocateSymbolFileMacOSX.cpp
+++ b/lldb/source/Symbol/LocateSymbolFileMacOSX.cpp
@@ -342,13 +342,6 @@ static bool GetModuleSpecInfoFromUUIDDictionary(CFDictionaryRef uuid_dict,
       }
     }
 
-    cf_str = (CFStringRef)CFDictionaryGetValue((CFDictionaryRef)uuid_dict,
-                                               CFSTR("DBGArchitecture"));
-    if (cf_str && CFGetTypeID(cf_str) == CFStringGetTypeID()) {
-      if (CFCString::FileSystemRepresentation(cf_str, str))
-        module_spec.GetArchitecture().SetTriple(str.c_str());
-    }
-
     std::string DBGBuildSourcePath;
     std::string DBGSourcePath;
 

--- a/lldb/test/API/macosx/lc-note/firmware-corefile/TestFirmwareCorefiles.py
+++ b/lldb/test/API/macosx/lc-note/firmware-corefile/TestFirmwareCorefiles.py
@@ -85,7 +85,7 @@ class TestFirmwareCorefiles(TestBase):
                 'fi',
                 'echo "<dict><key>$uuid</key><dict>"',
                 '',
-                'echo "<key>DBGArchitecture</key><string>x86_64</string>"',
+                'echo "<key>DBGArchitecture</key><string>i386</string>"',
                 'echo "<key>DBGDSYMPath</key><string>$dsym</string>"',
                 'echo "<key>DBGSymbolRichExecutable</key><string>$bin</string>"',
                 'echo "</dict></dict></plist>"',


### PR DESCRIPTION
Ignore DBGArchitecture from dsymForUUID's plist

When the architecture from the returned plist differs from the
architecture lldb will pick when loading the binary file, lldb will
reject the binary as not matching.  We are working with UUID's in
this case, so an architecture is not disambiguating anything; it
just opens this possibility for failing to load the specified binary.
Stop reading the architecture from the plist.

<rdar://problem/71612561>
Differential revision: https://reviews.llvm.org/D92692

(cherry picked from commit 2cedc44a92337ccc0e8173b4dbf4cfe5650da8cd)