### PR TITLE
🍒/bastille/33e3b07af3ce9595f49c75a8af559bdec5cc19fa+5861234e72c035ad39b5fd843eef78ab4039351e+ac25e8628c443cddd841c6c91d1c9e23e88969e5

### DIFF
--- a/lldb/include/lldb/Utility/ReproducerInstrumentation.h
+++ b/lldb/include/lldb/Utility/ReproducerInstrumentation.h
@@ -841,6 +841,10 @@ public:
 
   bool ShouldCapture() { return m_local_boundary; }
 
+  /// Mark the current thread as a private thread and pretend that everything
+  /// on this thread is behind happening behind the API boundary.
+  static void PrivateThread() { g_global_boundary = true; }
+
 private:
   template <typename T> friend struct replay;
   void UpdateBoundary() {
@@ -868,7 +872,7 @@ private:
   bool m_result_recorded;
 
   /// Whether we're currently across the API boundary.
-  static bool g_global_boundary;
+  static thread_local bool g_global_boundary;
 };
 
 /// To be used as the "Runtime ID" of a constructor. It also invokes the

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -32,6 +32,7 @@
 #include "lldb/Interpreter/CommandReturnObject.h"
 #include "lldb/Target/Thread.h"
 #include "lldb/Target/ThreadPlan.h"
+#include "lldb/Utility/ReproducerInstrumentation.h"
 #include "lldb/Utility/Timer.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
@@ -430,6 +431,7 @@ ScriptInterpreterPythonImpl::Locker::Locker(
     : ScriptInterpreterLocker(),
       m_teardown_session((on_leave & TearDownSession) == TearDownSession),
       m_python_interpreter(py_interpreter) {
+  repro::Recorder::PrivateThread();
   DoAcquireLock();
   if ((on_entry & InitSession) == InitSession) {
     if (!DoInitSession(on_entry, in, out, err)) {

--- a/lldb/source/Utility/ReproducerInstrumentation.cpp
+++ b/lldb/source/Utility/ReproducerInstrumentation.cpp
@@ -227,4 +227,4 @@ llvm::Optional<InstrumentationData> &InstrumentationData::InstanceImpl() {
   return g_instrumentation_data;
 }
 
-bool lldb_private::repro::Recorder::g_global_boundary;
+thread_local bool lldb_private::repro::Recorder::g_global_boundary = false;


### PR DESCRIPTION
- [lldb] Include thread id in the reproducer trace (NFC)
- [lldb] Track the API boundary using a thread_local variable.
- [lldb] Deal gracefully with concurrency in the API instrumentation.
