### PR TITLE
[lldb] Add ReferenceTypeInfo support to SwiftLanguageRuntimeImpl::GetNumChildren

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1082,11 +1082,16 @@ SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
       return {};
 
     auto *reflection_ctx = GetReflectionContext();
-    auto tc = swift::reflection::TypeConverter(reflection_ctx->getBuilder());
+    auto &builder = reflection_ctx->getBuilder();
+    auto tc = swift::reflection::TypeConverter(builder);
     LLDBTypeInfoProvider tip(*this, *ts);
     auto *cti = tc.getClassInstanceTypeInfo(tr, 0, &tip);
     if (auto *rti =
             llvm::dyn_cast_or_null<swift::reflection::RecordTypeInfo>(cti)) {
+      // The superclass, if any, is an extra child.
+      if (builder.lookupSuperclass(tr)) {
+        return rti->getNumFields() + 1;
+      }
       return rti->getNumFields();
     }
 

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1078,7 +1078,7 @@ SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
       break;
     }
 
-    if (tr)
+    if (!tr)
       return {};
 
     auto *reflection_ctx = GetReflectionContext();

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1089,9 +1089,8 @@ SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
     if (auto *rti =
             llvm::dyn_cast_or_null<swift::reflection::RecordTypeInfo>(cti)) {
       // The superclass, if any, is an extra child.
-      if (builder.lookupSuperclass(tr)) {
+      if (builder.lookupSuperclass(tr))
         return rti->getNumFields() + 1;
-      }
       return rti->getNumFields();
     }
 

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -995,6 +995,38 @@ llvm::Optional<uint64_t> SwiftLanguageRuntimeImpl::GetMemberVariableOffset(
   return offset;
 }
 
+static CompilerType GetWeakReferent(TypeSystemSwiftTypeRef &ts,
+                                    CompilerType type) {
+  using namespace swift::Demangle;
+  Demangler dem;
+  auto mangled = type.GetMangledTypeName().GetStringRef();
+  NodePointer n = dem.demangleSymbol(mangled);
+  if (!n || n->getKind() != Node::Kind::Global || !n->hasChildren())
+    return {};
+  n = n->getFirstChild();
+  if (!n || n->getKind() != Node::Kind::TypeMangling || !n->hasChildren())
+    return {};
+  n = n->getFirstChild();
+  if (!n || n->getKind() != Node::Kind::Type || !n->hasChildren())
+    return {};
+  n = n->getFirstChild();
+  if (!n ||
+      (n->getKind() != Node::Kind::Weak &&
+       n->getKind() != Node::Kind::Unowned &&
+       n->getKind() != Node::Kind::Unmanaged) ||
+      !n->hasChildren())
+    return {};
+  n = n->getFirstChild();
+  if (!n || n->getKind() != Node::Kind::Type || !n->hasChildren())
+    return {};
+  // FIXME: We only need to canonicalize this node, not the entire type.
+  n = ts.CanonicalizeSugar(dem, n->getFirstChild());
+  if (!n || n->getKind() != Node::Kind::SugaredOptional || !n->hasChildren())
+    return {};
+  n = n->getFirstChild();
+  return ts.RemangleAsType(dem, n);
+}
+
 llvm::Optional<unsigned>
 SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
                                          ValueObject *valobj) {
@@ -1006,7 +1038,8 @@ SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
   // Try the static type metadata.
   auto frame =
       valobj ? valobj->GetExecutionContextRef().GetFrameSP().get() : nullptr;
-  auto *ti = GetTypeInfo(type, frame);
+  const swift::reflection::TypeRef *tr = nullptr;
+  auto *ti = GetTypeInfo(type, frame, &tr);
   // Structs and Tuples.
   if (auto *rti =
           llvm::dyn_cast_or_null<swift::reflection::RecordTypeInfo>(ti)) {
@@ -1027,6 +1060,37 @@ SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
   }
   if (auto *eti = llvm::dyn_cast_or_null<swift::reflection::EnumTypeInfo>(ti)) {
     return eti->getNumPayloadCases();
+  }
+  // Objects.
+  if (auto *rti =
+      llvm::dyn_cast_or_null<swift::reflection::ReferenceTypeInfo>(ti)) {
+
+    switch (rti->getReferenceKind()) {
+    case swift::reflection::ReferenceKind::Weak:
+    case swift::reflection::ReferenceKind::Unowned:
+    case swift::reflection::ReferenceKind::Unmanaged:
+      // Weak references are implicitly Optionals, so report the one
+      // child of Optional here.
+      if (GetWeakReferent(*ts, type))
+        return 1;
+      break;
+    default:
+      break;
+    }
+
+    if (tr)
+      return {};
+
+    auto *reflection_ctx = GetReflectionContext();
+    auto tc = swift::reflection::TypeConverter(reflection_ctx->getBuilder());
+    LLDBTypeInfoProvider tip(*this, *ts);
+    auto *cti = tc.getClassInstanceTypeInfo(tr, 0, &tip);
+    if (auto *rti =
+            llvm::dyn_cast_or_null<swift::reflection::RecordTypeInfo>(cti)) {
+      return rti->getNumFields();
+    }
+
+    return {};
   }
   // FIXME: Implement more cases.
   return {};
@@ -1060,38 +1124,6 @@ static llvm::StringRef GetBaseName(swift::Demangle::NodePointer node) {
       return GetBaseName(child);
     return {};
   }
-}
-
-static CompilerType GetWeakReferent(TypeSystemSwiftTypeRef &ts,
-                                    CompilerType type) {
-  using namespace swift::Demangle;
-  Demangler dem;
-  auto mangled = type.GetMangledTypeName().GetStringRef();
-  NodePointer n = dem.demangleSymbol(mangled);
-  if (!n || n->getKind() != Node::Kind::Global || !n->hasChildren())
-    return {};
-  n = n->getFirstChild();
-  if (!n || n->getKind() != Node::Kind::TypeMangling || !n->hasChildren())
-    return {};
-  n = n->getFirstChild();
-  if (!n || n->getKind() != Node::Kind::Type || !n->hasChildren())
-    return {};
-  n = n->getFirstChild();
-  if (!n ||
-      (n->getKind() != Node::Kind::Weak &&
-       n->getKind() != Node::Kind::Unowned &&
-       n->getKind() != Node::Kind::Unmanaged) ||
-      !n->hasChildren())
-    return {};
-  n = n->getFirstChild();
-  if (!n || n->getKind() != Node::Kind::Type || !n->hasChildren())
-    return {};
-  // FIXME: We only need to canonicalize this node, not the entire type.
-  n = ts.CanonicalizeSugar(dem, n->getFirstChild());
-  if (!n || n->getKind() != Node::Kind::SugaredOptional || !n->hasChildren())
-    return {};
-  n = n->getFirstChild();
-  return ts.RemangleAsType(dem, n);
 }
 
 static CompilerType
@@ -2508,9 +2540,9 @@ SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type,
   return type_ref;
 }
 
-const swift::reflection::TypeInfo *
-SwiftLanguageRuntimeImpl::GetTypeInfo(CompilerType type,
-                                      ExecutionContextScope *exe_scope) {
+const swift::reflection::TypeInfo *SwiftLanguageRuntimeImpl::GetTypeInfo(
+    CompilerType type, ExecutionContextScope *exe_scope,
+    swift::reflection::TypeRef const **out_tr) {
   auto *ts = llvm::dyn_cast_or_null<TypeSystemSwift>(type.GetTypeSystem());
   if (!ts)
     return nullptr;
@@ -2540,6 +2572,9 @@ SwiftLanguageRuntimeImpl::GetTypeInfo(CompilerType type,
       GetTypeRef(type, ts->GetSwiftASTContext());
   if (!type_ref)
     return nullptr;
+
+  if (out_tr)
+    *out_tr = type_ref;
 
   auto *reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)

--- a/lldb/source/Target/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Target/SwiftLanguageRuntimeImpl.h
@@ -78,7 +78,8 @@ public:
 
   /// Ask Remote Mirrors for the type info about a Swift type.
   const swift::reflection::TypeInfo *
-  GetTypeInfo(CompilerType type, ExecutionContextScope *exe_scope);
+  GetTypeInfo(CompilerType type, ExecutionContextScope *exe_scope,
+              swift::reflection::TypeRef const **out_tr = nullptr);
 
   llvm::Optional<const swift::reflection::TypeInfo *>
   lookupClangTypeInfo(CompilerType clang_type);

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
@@ -112,8 +112,9 @@ class TestLibraryIndirect(TestBase):
         # This test is deliberately checking what the user will see, rather than
         # the structure provided by the Python API, in order to test the recovery.
         self.expect("fr var", substrs=[
-            "(SomeLibrary.ContainsTwoInts) container = (wrapped = 0x",
-            ", other = 10)",
+            "(SomeLibrary.ContainsTwoInts) container = {",
+            "wrapped = 0x",
+            "other = 10",
             "(Int) simple = 1"])
         self.expect("e container", substrs=["(SomeLibrary.ContainsTwoInts)", "(wrapped = 0x", ", other = 10"])
         self.expect("e container.wrapped", substrs=["(SomeLibrary.BoxedTwoInts)", "0x", "{}"])

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
@@ -116,6 +116,6 @@ class TestLibraryIndirect(TestBase):
             "wrapped = 0x",
             "other = 10",
             "(Int) simple = 1"])
-        self.expect("e container", substrs=["(SomeLibrary.ContainsTwoInts)", "(wrapped = 0x", ", other = 10"])
+        self.expect("e container", substrs=["(SomeLibrary.ContainsTwoInts)", "wrapped = 0x", "other = 10"])
         self.expect("e container.wrapped", substrs=["(SomeLibrary.BoxedTwoInts)", "0x", "{}"])
         self.expect("e container.wrapped.value", error=True, substrs=["value of type 'BoxedTwoInts' has no member 'value'"])


### PR DESCRIPTION
(cherry picked from https://github.com/apple/llvm-project/pull/2218)
