### PR TITLE
Add a test for default arguments in the Swift REPL

### DIFF
--- a/lldb/test/Shell/SwiftREPL/DefaultArgument.test
+++ b/lldb/test/Shell/SwiftREPL/DefaultArgument.test
@@ -1,0 +1,8 @@
+// Test that default arguments work in the REPL
+// REQUIRES: swift
+
+// RUN: %lldb --repl < %s | FileCheck %s
+func foo(arg a: Int = 10) -> Int { return a }
+foo()
+// CHECK: $R0: Int = 10
+


### PR DESCRIPTION
The actual code was fixed on llvm.org and merged here with PR #2074.

This is a follow-up test to assure the fix works.