### PR TITLE
[lldb] Avoid enum as unordered_map key in TypeSystemClang

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -9695,14 +9695,15 @@ GetSpecializedASTName(ScratchTypeSystemClang::IsolatedASTKind feature) {
 }
 
 TypeSystemClang &ScratchTypeSystemClang::GetIsolatedAST(
-    ScratchTypeSystemClang::IsolatedASTKind feature) {
+    ScratchTypeSystemClang::IsolatedASTKind feature_enum) {
+  int feature = static_cast<int>(feature_enum);
   auto found_ast = m_isolated_asts.find(feature);
   if (found_ast != m_isolated_asts.end())
     return *found_ast->second;
 
   // Couldn't find the requested sub-AST, so create it now.
   std::unique_ptr<TypeSystemClang> new_ast;
-  new_ast.reset(new SpecializedScratchAST(GetSpecializedASTName(feature),
+  new_ast.reset(new SpecializedScratchAST(GetSpecializedASTName(feature_enum),
                                           m_triple, CreateASTSource()));
   m_isolated_asts[feature] = std::move(new_ast);
   return *m_isolated_asts[feature];

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -1228,7 +1228,7 @@ private:
   /// Map from IsolatedASTKind to their actual TypeSystemClang instance.
   /// This map is lazily filled with sub-ASTs and should be accessed via
   /// `GetSubAST` (which lazily fills this map).
-  std::unordered_map<IsolatedASTKind, std::unique_ptr<TypeSystemClang>>
+  std::unordered_map<int, std::unique_ptr<TypeSystemClang>>
       m_isolated_asts;
 };
 


### PR DESCRIPTION
This apparently doesn't work with the GCC used on Swift CI's Linux bots.