### PR TITLE
[lldb] Implement TypeSystemSwiftTypeRef::IsPossibleDynamicType

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1775,6 +1775,13 @@ bool TypeSystemSwiftTypeRef::IsPossibleDynamicType(opaque_compiler_type_t type,
   if (!type)
     return false;
 
+  // This is a discrepancy with `SwiftASTContext`. The `impl` below correctly
+  // returns true, but `VALIDATE_AND_RETURN` will assert. This hardcoded
+  // handling of `__C.NSNotificationName` can be removed when the
+  // `VALIDATE_AND_RETURN` is removed.
+  if (GetMangledTypeName(type) == "$sSo18NSNotificationNameaD")
+    return true;
+
   auto impl = [&]() {
     using namespace swift::Demangle;
     Demangler dem;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1791,8 +1791,8 @@ bool TypeSystemSwiftTypeRef::IsPossibleDynamicType(opaque_compiler_type_t type,
 
     if (node->getKind() == Node::Kind::TypeAlias) {
       auto resolved = ResolveTypeAlias(m_swift_ast_context, dem, node);
-      if (resolved.first)
-        node = resolved.first;
+      if (auto *n = std::get<swift::Demangle::NodePointer>(resolved))
+        node = n;
     }
 
     switch (node->getKind()) {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1791,6 +1791,17 @@ bool TypeSystemSwiftTypeRef::IsPossibleDynamicType(opaque_compiler_type_t type,
     case Node::Kind::ProtocolListWithAnyObject:
     case Node::Kind::DynamicSelf:
       return true;
+    case Node::Kind::TypeAlias: {
+      if (node->getNumChildren() == 2) {
+        auto *module = node->getFirstChild();
+        auto *identifier = node->getLastChild();
+        return module->getKind() == Node::Kind::Module &&
+               identifier->getKind() == Node::Kind::Identifier &&
+               module->getText() == "Swift" &&
+               identifier->getText() == "AnyObject";
+      }
+      break;
+    }
     case Node::Kind::BuiltinTypeName: {
       if (!node->hasText())
         return false;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1788,6 +1788,7 @@ bool TypeSystemSwiftTypeRef::IsPossibleDynamicType(opaque_compiler_type_t type,
     case Node::Kind::Protocol:
     case Node::Kind::ProtocolList:
     case Node::Kind::ProtocolListWithClass:
+    case Node::Kind::ProtocolListWithAnyObject:
     case Node::Kind::DynamicSelf:
       return true;
     case Node::Kind::BuiltinTypeName: {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1789,6 +1789,7 @@ bool TypeSystemSwiftTypeRef::IsPossibleDynamicType(opaque_compiler_type_t type,
     case Node::Kind::ProtocolList:
     case Node::Kind::ProtocolListWithClass:
     case Node::Kind::ProtocolListWithAnyObject:
+    case Node::Kind::ExistentialMetatype:
     case Node::Kind::DynamicSelf:
       return true;
     case Node::Kind::TypeAlias: {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1764,13 +1764,49 @@ bool TypeSystemSwiftTypeRef::IsFunctionPointerType(
   VALIDATE_AND_RETURN(impl, IsFunctionPointerType, type,
                       (ReconstructType(type)));
 }
+
 bool TypeSystemSwiftTypeRef::IsPossibleDynamicType(opaque_compiler_type_t type,
                                                    CompilerType *target_type,
                                                    bool check_cplusplus,
                                                    bool check_objc) {
-  return m_swift_ast_context->IsPossibleDynamicType(
-      ReconstructType(type), target_type, check_cplusplus, check_objc);
+  if (target_type)
+    target_type->Clear();
+
+  if (!type)
+    return false;
+
+  auto impl = [&]() {
+    using namespace swift::Demangle;
+    Demangler dem;
+    auto *node = DemangleCanonicalType(dem, type);
+    if (!node)
+      return false;
+
+    switch (node->getKind()) {
+    case Node::Kind::Class:
+    case Node::Kind::BoundGenericClass:
+    case Node::Kind::Protocol:
+    case Node::Kind::ProtocolList:
+    case Node::Kind::ProtocolListWithClass:
+    case Node::Kind::DynamicSelf:
+      return true;
+    case Node::Kind::BuiltinTypeName: {
+      if (!node->hasText())
+        return false;
+      auto name = node->getText();
+      return name == swift::BUILTIN_TYPE_NAME_RAWPOINTER ||
+             name == swift::BUILTIN_TYPE_NAME_NATIVEOBJECT ||
+             name == swift::BUILTIN_TYPE_NAME_BRIDGEOBJECT;
+    }
+    default:
+      return ContainsGenericTypeParameter(node);
+    }
+  };
+  VALIDATE_AND_RETURN(
+      impl, IsPossibleDynamicType, type,
+      (ReconstructType(type), nullptr, check_cplusplus, check_objc));
 }
+
 bool TypeSystemSwiftTypeRef::IsPointerType(opaque_compiler_type_t type,
                                            CompilerType *pointee_type) {
   auto impl = [&]() {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1782,6 +1782,12 @@ bool TypeSystemSwiftTypeRef::IsPossibleDynamicType(opaque_compiler_type_t type,
     if (!node)
       return false;
 
+    if (node->getKind() == Node::Kind::TypeAlias) {
+      auto resolved = ResolveTypeAlias(m_swift_ast_context, dem, node);
+      if (resolved.first)
+        node = resolved.first;
+    }
+
     switch (node->getKind()) {
     case Node::Kind::Class:
     case Node::Kind::BoundGenericClass:
@@ -1792,17 +1798,6 @@ bool TypeSystemSwiftTypeRef::IsPossibleDynamicType(opaque_compiler_type_t type,
     case Node::Kind::ExistentialMetatype:
     case Node::Kind::DynamicSelf:
       return true;
-    case Node::Kind::TypeAlias: {
-      if (node->getNumChildren() == 2) {
-        auto *module = node->getFirstChild();
-        auto *identifier = node->getLastChild();
-        return module->getKind() == Node::Kind::Module &&
-               identifier->getKind() == Node::Kind::Identifier &&
-               module->getText() == "Swift" &&
-               identifier->getText() == "AnyObject";
-      }
-      break;
-    }
     case Node::Kind::BuiltinTypeName: {
       if (!node->hasText())
         return false;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1793,7 +1793,7 @@ bool TypeSystemSwiftTypeRef::IsPossibleDynamicType(opaque_compiler_type_t type,
     case Node::Kind::BuiltinTypeName: {
       if (!node->hasText())
         return false;
-      auto name = node->getText();
+      StringRef name = node->getText();
       return name == swift::BUILTIN_TYPE_NAME_RAWPOINTER ||
              name == swift::BUILTIN_TYPE_NAME_NATIVEOBJECT ||
              name == swift::BUILTIN_TYPE_NAME_BRIDGEOBJECT;


### PR DESCRIPTION
Implement `TypeSystemSwiftTypeRef::IsPossibleDynamicType` to match the `SwiftASTContext` implementation.

rdar://68170302
