### PR TITLE
Add an end-to-end test fo function arguments in an async function.

### DIFF
--- a/lldb/test/API/lang/swift/async/async_fnargs/Makefile
+++ b/lldb/test/API/lang/swift/async/async_fnargs/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -Xfrontend -enable-experimental-concurrency
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/async_fnargs/TestSwiftAsyncFnArgs.py
+++ b/lldb/test/API/lang/swift/async/async_fnargs/TestSwiftAsyncFnArgs.py
@@ -1,0 +1,29 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftAsyncFnArgs(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    def test(self):
+        """Test function arguments in async functions"""
+        self.build()
+        src = lldb.SBFileSpec('main.swift')
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'Set breakpoint here', src)
+
+        self.expect("frame var -d run-target -- msg", '"world"')
+
+        # Continue into the second coroutine funclet.
+        bkpt2 = target.BreakpointCreateBySourceRegex("And also here", src, None)
+        self.assertGreater(bkpt2.GetNumLocations(), 0)
+        process.Continue()
+        self.assertEqual(
+             len(lldbutil.get_threads_stopped_at_breakpoint(process, bkpt2)), 1)
+
+        self.expect("frame var -d run-target -- msg", '"world"')

--- a/lldb/test/API/lang/swift/async/async_fnargs/main.swift
+++ b/lldb/test/API/lang/swift/async/async_fnargs/main.swift
@@ -1,0 +1,17 @@
+import Swift
+func use<T>(_ t: T) {}
+
+func sayHello() async {
+  print("hello")
+}
+
+func sayGeneric<T>(_ msg: T) async {
+  print("Set breakpoint here")
+  await sayHello()
+  print(msg) // And also here.
+}
+
+runAsyncAndBlock {
+  await sayHello()
+  await sayGeneric("world")
+}


### PR DESCRIPTION
(cherry picked from commit f302f0c62091d3ac7cfdddcc735927e9b73ea023)