### PR TITLE
[lldb] Lift GetIndexOfChildWithName into TypeSystemSwift base class

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -7438,21 +7438,6 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
   return 0;
 }
 
-/// Get the index of the child of "clang_type" whose name matches. This
-/// function doesn't descend into the children, but only looks one
-/// level deep and name matches can include base class names.
-uint32_t
-SwiftASTContext::GetIndexOfChildWithName(opaque_compiler_type_t type,
-                                         const char *name,
-                                         bool omit_empty_base_classes) {
-  VALID_OR_RETURN(UINT32_MAX);
-
-  std::vector<uint32_t> child_indexes;
-  size_t num_child_indexes = GetIndexOfChildMemberWithName(
-      type, name, omit_empty_base_classes, child_indexes);
-  return num_child_indexes == 1 ? child_indexes.front() : UINT32_MAX;
-}
-
 size_t SwiftASTContext::GetNumTemplateArguments(opaque_compiler_type_t type) {
   if (!type)
     return 0;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -602,12 +602,6 @@ public:
       bool &child_is_base_class, bool &child_is_deref_of_parent,
       ValueObject *valobj, uint64_t &language_flags) override;
 
-  // Lookup a child given a name. This function will match base class names
-  // and member names in "clang_type" only, not descendants.
-  uint32_t GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
-                                   const char *name,
-                                   bool omit_empty_base_classes) override;
-
   // Lookup a child member given a name. This function will match member names
   // only and will descend into "clang_type" children in search for the first
   // member in this class, or any base class that matches "name".

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -101,3 +101,16 @@ bool TypeSystemSwift::ShouldTreatScalarValueAsAddress(
   return Flags(GetTypeInfo(type, nullptr))
       .AnySet(eTypeInstanceIsPointer | eTypeIsReference);
 }
+
+/// Get the index of the child of "clang_type" whose name matches. This function
+/// doesn't descend into the children, but only looks one level deep and name
+/// matches can include base class names.
+uint32_t
+TypeSystemSwift::GetIndexOfChildWithName(opaque_compiler_type_t type,
+                                         const char *name,
+                                         bool omit_empty_base_classes) {
+  std::vector<uint32_t> child_indexes;
+  size_t num_child_indexes = GetIndexOfChildMemberWithName(
+      type, name, omit_empty_base_classes, child_indexes);
+  return num_child_indexes == 1 ? child_indexes.front() : UINT32_MAX;
+}

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -102,9 +102,6 @@ bool TypeSystemSwift::ShouldTreatScalarValueAsAddress(
       .AnySet(eTypeInstanceIsPointer | eTypeIsReference);
 }
 
-/// Get the index of the child of "clang_type" whose name matches. This function
-/// doesn't descend into the children, but only looks one level deep and name
-/// matches can include base class names.
 uint32_t
 TypeSystemSwift::GetIndexOfChildWithName(opaque_compiler_type_t type,
                                          const char *name,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -242,6 +242,13 @@ public:
   }
   bool
   ShouldTreatScalarValueAsAddress(lldb::opaque_compiler_type_t type) override;
+
+  /// Lookup a child given a name. This function will match base class names
+  /// and member names in "clang_type" only, not descendants.
+  uint32_t GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
+                                   const char *name,
+                                   bool omit_empty_base_classes) override;
+
   /// \}
 protected:
   /// Used in the logs.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -244,7 +244,7 @@ public:
   ShouldTreatScalarValueAsAddress(lldb::opaque_compiler_type_t type) override;
 
   /// Lookup a child given a name. This function will match base class names
-  /// and member names in "clang_type" only, not descendants.
+  /// and member names in \p type only, not descendants.
   uint32_t GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
                                    const char *name,
                                    bool omit_empty_base_classes) override;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2306,13 +2306,6 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
        ast_child_is_deref_of_parent, valobj, ast_language_flags));
 }
 
-uint32_t
-TypeSystemSwiftTypeRef::GetIndexOfChildWithName(opaque_compiler_type_t type,
-                                                const char *name,
-                                                bool omit_empty_base_classes) {
-  return m_swift_ast_context->GetIndexOfChildWithName(
-      ReconstructType(type), name, omit_empty_base_classes);
-}
 size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
     opaque_compiler_type_t type, const char *name, bool omit_empty_base_classes,
     std::vector<uint32_t> &child_indexes) {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -165,9 +165,6 @@ public:
       uint32_t &child_bitfield_bit_size, uint32_t &child_bitfield_bit_offset,
       bool &child_is_base_class, bool &child_is_deref_of_parent,
       ValueObject *valobj, uint64_t &language_flags) override;
-  uint32_t GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
-                                   const char *name,
-                                   bool omit_empty_base_classes) override;
   size_t
   GetIndexOfChildMemberWithName(lldb::opaque_compiler_type_t type,
                                 const char *name, bool omit_empty_base_classes,


### PR DESCRIPTION
`GetIndexOfChildWithName` is not specific to any `TypeSystemSwift` subclass. As a wrapper around `GetIndexOfChildMemberWithName`, it can be moved into the base class.

rdar://68171366
