### PR TITLE
[lldb] Print SWIFTC in the Make invocation

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -116,6 +116,16 @@ class Builder:
         else:
             return ""
 
+    def getSwiftCSpec(self):
+        """
+        Helper function to return the key-value string to specify the Swift
+        compiler used for the make system.
+        """
+        if configuration.swiftCompiler:
+            return "SWIFTC=\"{}\"".format(configuration.swiftCompiler)
+        else:
+            return ""
+
     def getSDKRootSpec(self):
         """
         Helper function to return the key-value string to specify the SDK root
@@ -151,6 +161,7 @@ class Builder:
                 self.getArchSpec(architecture),
                 self.getSwiftTargetFlags(architecture),
                 self.getCCSpec(compiler),
+                self.getSwiftCSpec(),
                 self.getExtraMakeArgs(),
                 self.getSDKRootSpec(),
                 self.getModuleCacheSpec(),
@@ -178,6 +189,7 @@ class Builder:
                 self.getArchSpec(architecture),
                 self.getSwiftTargetFlags(architecture),
                 self.getCCSpec(compiler),
+                self.getSwiftCSpec(),
                 self.getExtraMakeArgs(),
                 self.getSDKRootSpec(),
                 self.getModuleCacheSpec(),
@@ -204,6 +216,7 @@ class Builder:
                 self.getArchSpec(architecture),
                 self.getSwiftTargetFlags(architecture),
                 self.getCCSpec(compiler),
+                self.getSwiftCSpec(),
                 self.getExtraMakeArgs(),
                 self.getSDKRootSpec(),
                 self.getModuleCacheSpec(),
@@ -230,6 +243,7 @@ class Builder:
                 self.getArchSpec(architecture),
                 self.getSwiftTargetFlags(architecture),
                 self.getCCSpec(compiler),
+                self.getSwiftCSpec(),
                 self.getExtraMakeArgs(),
                 self.getSDKRootSpec(),
                 self.getModuleCacheSpec(),

--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -125,6 +125,7 @@ class BuilderDarwin(Builder):
                 self.getArchSpec(architecture),
                 self.getSwiftTargetFlags(architecture),
                 self.getCCSpec(compiler),
+                self.getSwiftCSpec(),
                 self.getExtraMakeArgs(),
                 self.getSDKRootSpec(),
                 self.getModuleCacheSpec(), "all",

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -973,8 +973,6 @@ def run_suite():
     # Iterating over all possible architecture and compiler combinations.
     os.environ["ARCH"] = configuration.arch
     os.environ["CC"] = configuration.compiler
-    if configuration.swiftCompiler:
-        os.environ["SWIFTC"] = configuration.swiftCompiler
     configString = "arch=%s compiler=%s" % (configuration.arch,
                                             configuration.compiler)
 

--- a/lldb/test/API/lang/swift/backwards_compatibility/simple/TestSwiftBackwardsCompatibilitySimple.py
+++ b/lldb/test/API/lang/swift/backwards_compatibility/simple/TestSwiftBackwardsCompatibilitySimple.py
@@ -11,6 +11,7 @@
 # ------------------------------------------------------------------------------
 import lldb
 from lldbsuite.test.decorators import *
+from lldbsuite.test import configuration
 import lldbsuite.test.lldbtest as lldbtest
 import lldbsuite.test.lldbutil as lldbutil
 import os
@@ -25,8 +26,8 @@ class TestSwiftBackwardsCompatibilitySimple(lldbtest.TestBase):
     @swiftTest
     @skipIf(compiler="swiftc", compiler_version=['<', '5.0'])
     def test_simple(self):
-        if 'SWIFTC' in os.environ:
-            compiler = os.environ['SWIFTC']
+        if configuration.swiftCompiler:
+            compiler = configuration.swiftCompiler
         else:
             compiler = swift.getSwiftCompiler()
         version = self.getCompilerVersion(compiler)


### PR DESCRIPTION
Don't pass SWIFTC through the environment but rather make it part of the
Make invocation. This makes it possible to reproduce the Make step by
copying the invocation.

rdar://68730409