### PR TITLE
Disable AST type caching for SILFunctionTypes since the mapping isn't 

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4180,7 +4180,7 @@ void SwiftASTContext::CacheDemangledTypeFailure(ConstString name) {
 /// What we should really do is only mangle AST types in DebugInfo, but that
 /// requires some more plumbing on the Swift side to properly handle generic
 /// specializations.
-swift::Type convertSILFunctionTypesToASTFunctionTypes(swift::Type t) {
+static swift::Type ConvertSILFunctionTypesToASTFunctionTypes(swift::Type t) {
   return t.transform([](swift::Type t) -> swift::Type {
     if (auto *silFn = t->getAs<swift::SILFunctionType>())
       return swift::FunctionType::get({}, t->getASTContext().TheEmptyTupleType);
@@ -4300,14 +4300,18 @@ swift::TypeBase *SwiftASTContext::ReconstructType(ConstString mangled_typename,
                    .getPointer();
 
   if (found_type) {
-    found_type =
-        convertSILFunctionTypesToASTFunctionTypes(found_type).getPointer();
-    CacheDemangledType(mangled_typename, found_type);
-    CompilerType result_type = ToCompilerType(found_type);
-    assert(&found_type->getASTContext() == ast_ctx);
+    swift::TypeBase *ast_type =
+        ConvertSILFunctionTypesToASTFunctionTypes(found_type).getPointer();
+    // This transformation is lossy: all SILFunction types are mapped
+    // to the same AST type. We thus cannot cache the result, since
+    // the mapping isn't bijective.
+    if (ast_type == found_type)
+      CacheDemangledType(mangled_typename, ast_type);
+    CompilerType result_type = ToCompilerType(ast_type);
+    assert(&ast_type->getASTContext() == ast_ctx);
     LOG_PRINTF(LIBLLDB_LOG_TYPES, "(\"%s\") -- found %s", mangled_cstr,
                result_type.GetTypeName().GetCString());
-    return found_type;
+    return ast_type;
   }
 
   LOG_PRINTF(LIBLLDB_LOG_TYPES, "(\"%s\") -- not found", mangled_cstr);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1420,6 +1420,12 @@ static bool ContainsSugaredParen(swift::Demangle::NodePointer node) {
 /// Compare two swift types from different type systems by comparing their
 /// (canonicalized) mangled name.
 template <> bool Equivalent<CompilerType>(CompilerType l, CompilerType r) {
+  // See comments in SwiftASTContext::ReconstructType(). For
+  // SILFunctionTypes the mapping isn't bijective.
+  auto *ast_ctx = llvm::cast<SwiftASTContext>(r.GetTypeSystem());
+  if (((void *)ast_ctx->ReconstructType(l.GetMangledTypeName())) ==
+      r.GetOpaqueQualType())
+    return true;
   ConstString lhs = l.GetMangledTypeName();
   ConstString rhs = r.GetMangledTypeName();
   if (lhs == ConstString("$sSiD") && rhs == ConstString("$sSuD"))


### PR DESCRIPTION
bijective, and relax check in TypeSystemSwiftTypeRef to take this fact
into account.

rdar://70552614