### PR TITLE
[lldb] Implement TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName

### DIFF
--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -324,7 +324,7 @@ public:
 
   /// Lookup a child given a name. This function will match base class names and
   /// member member names in "clang_type" only, not descendants.
-  uint32_t GetIndexOfChildWithName(const char *name,
+  uint32_t GetIndexOfChildWithName(const char *name, ExecutionContext *exe_ctx,
                                    bool omit_empty_base_classes) const;
 
   /// Lookup a child member given a name. This function will match member names
@@ -334,7 +334,8 @@ public:
   /// vector<vector<uint32_t>>
   /// so we catch all names that match a given child name, not just the first.
   size_t
-  GetIndexOfChildMemberWithName(const char *name, bool omit_empty_base_classes,
+  GetIndexOfChildMemberWithName(const char *name, ExecutionContext *exe_ctx,
+                                bool omit_empty_base_classes,
                                 std::vector<uint32_t> &child_indexes) const;
 
   size_t GetNumTemplateArguments() const;

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -355,6 +355,7 @@ public:
   // member member names in "clang_type" only, not descendants.
   virtual uint32_t GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
                                            const char *name,
+                                           ExecutionContext *exe_ctx,
                                            bool omit_empty_base_classes) = 0;
 
   // Lookup a child member given a name. This function will match member names
@@ -365,7 +366,8 @@ public:
   // so we catch all names that match a given child name, not just the first.
   virtual size_t
   GetIndexOfChildMemberWithName(lldb::opaque_compiler_type_t type,
-                                const char *name, bool omit_empty_base_classes,
+                                const char *name, ExecutionContext *exe_ctx,
+                                bool omit_empty_base_classes,
                                 std::vector<uint32_t> &child_indexes) = 0;
 
   virtual size_t GetNumTemplateArguments(lldb::opaque_compiler_type_t type);

--- a/lldb/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/lldb/include/lldb/Target/SwiftLanguageRuntime.h
@@ -256,11 +256,9 @@ public:
   llvm::Optional<unsigned> GetNumChildren(CompilerType type,
                                           ValueObject *valobj);
 
-  llvm::Optional<size_t>
-  GetIndexOfChildMemberWithName(CompilerType type, llvm::StringRef name,
-                                ExecutionContext *exe_ctx,
-                                bool omit_empty_base_classes,
-                                llvm::MutableArrayRef<uint32_t> child_indexes);
+  llvm::Optional<size_t> GetIndexOfChildMemberWithName(
+      CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
+      bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes);
 
   /// Ask Remote Mirrors about a child of a composite type.
   CompilerType GetChildCompilerTypeAtIndex(

--- a/lldb/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/lldb/include/lldb/Target/SwiftLanguageRuntime.h
@@ -256,9 +256,11 @@ public:
   llvm::Optional<unsigned> GetNumChildren(CompilerType type,
                                           ValueObject *valobj);
 
-  llvm::Optional<size_t> GetIndexOfChildMemberWithName(
-      CompilerType type, const char *name, ExecutionContext *exe_ctx,
-      bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes);
+  llvm::Optional<size_t>
+  GetIndexOfChildMemberWithName(CompilerType type, llvm::StringRef name,
+                                ExecutionContext *exe_ctx,
+                                bool omit_empty_base_classes,
+                                llvm::MutableArrayRef<uint32_t> child_indexes);
 
   /// Ask Remote Mirrors about a child of a composite type.
   CompilerType GetChildCompilerTypeAtIndex(

--- a/lldb/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/lldb/include/lldb/Target/SwiftLanguageRuntime.h
@@ -256,6 +256,10 @@ public:
   llvm::Optional<unsigned> GetNumChildren(CompilerType type,
                                           ValueObject *valobj);
 
+  llvm::Optional<size_t> GetIndexOfChildMemberWithName(
+      CompilerType type, const char *name, ExecutionContext *exe_ctx,
+      bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes);
+
   /// Ask Remote Mirrors about a child of a composite type.
   CompilerType GetChildCompilerTypeAtIndex(
       CompilerType type, size_t idx, bool transparent_pointers,

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -595,7 +595,8 @@ lldb::ValueObjectSP ValueObject::GetChildAtNamePath(
 
 size_t ValueObject::GetIndexOfChildWithName(ConstString name) {
   bool omit_empty_base_classes = true;
-  return GetCompilerType().GetIndexOfChildWithName(name.GetCString(),
+  ExecutionContext exe_ctx(GetExecutionContextRef());
+  return GetCompilerType().GetIndexOfChildWithName(name.GetCString(), &exe_ctx,
                                                    omit_empty_base_classes);
 }
 
@@ -614,9 +615,10 @@ ValueObjectSP ValueObject::GetChildMemberWithName(ConstString name,
   if (!GetCompilerType().IsValid())
     return ValueObjectSP();
 
+  ExecutionContext exe_ctx(GetExecutionContextRef());
   const size_t num_child_indexes =
       GetCompilerType().GetIndexOfChildMemberWithName(
-          name.GetCString(), omit_empty_base_classes, child_indexes);
+          name.GetCString(), &exe_ctx, omit_empty_base_classes, child_indexes);
   if (num_child_indexes == 0)
     return nullptr;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
@@ -158,8 +158,8 @@ public:
       return UINT32_MAX;
 
     const bool omit_empty_base_classes = false;
-    return m_block_struct_type.GetIndexOfChildWithName(name.AsCString(),
-                                                       omit_empty_base_classes);
+    return m_block_struct_type.GetIndexOfChildWithName(
+        name.AsCString(), nullptr, omit_empty_base_classes);
   }
 
 private:

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -6504,7 +6504,8 @@ static uint32_t GetIndexForRecordChild(const clang::RecordDecl *record_decl,
 
 size_t TypeSystemClang::GetIndexOfChildMemberWithName(
     lldb::opaque_compiler_type_t type, const char *name,
-    bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
+    ExecutionContext *exe_ctx, bool omit_empty_base_classes,
+    std::vector<uint32_t> &child_indexes) {
   if (type && name && name[0]) {
     clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
     const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -6532,7 +6533,7 @@ size_t TypeSystemClang::GetIndexOfChildMemberWithName(
             CompilerType field_type = GetType(field->getType());
             child_indexes.push_back(child_idx);
             if (field_type.GetIndexOfChildMemberWithName(
-                    name, omit_empty_base_classes, child_indexes))
+                    name, exe_ctx, omit_empty_base_classes, child_indexes))
               return child_indexes.size();
             child_indexes.pop_back();
 
@@ -6641,7 +6642,7 @@ size_t TypeSystemClang::GetIndexOfChildMemberWithName(
                   GetType(getASTContext().getObjCInterfaceType(
                       superclass_interface_decl));
               if (superclass_clang_type.GetIndexOfChildMemberWithName(
-                      name, omit_empty_base_classes, child_indexes)) {
+                      name, exe_ctx, omit_empty_base_classes, child_indexes)) {
                 // We did find an ivar in a superclass so just return the
                 // results!
                 return child_indexes.size();
@@ -6661,7 +6662,7 @@ size_t TypeSystemClang::GetIndexOfChildMemberWithName(
           llvm::cast<clang::ObjCObjectPointerType>(qual_type.getTypePtr())
               ->getPointeeType());
       return objc_object_clang_type.GetIndexOfChildMemberWithName(
-          name, omit_empty_base_classes, child_indexes);
+          name, exe_ctx, omit_empty_base_classes, child_indexes);
     } break;
 
     case clang::Type::ConstantArray: {
@@ -6713,7 +6714,7 @@ size_t TypeSystemClang::GetIndexOfChildMemberWithName(
 
       if (pointee_clang_type.IsAggregateType()) {
         return pointee_clang_type.GetIndexOfChildMemberWithName(
-            name, omit_empty_base_classes, child_indexes);
+            name, exe_ctx, omit_empty_base_classes, child_indexes);
       }
     } break;
 
@@ -6722,7 +6723,7 @@ size_t TypeSystemClang::GetIndexOfChildMemberWithName(
 
       if (pointee_clang_type.IsAggregateType()) {
         return pointee_clang_type.GetIndexOfChildMemberWithName(
-            name, omit_empty_base_classes, child_indexes);
+            name, exe_ctx, omit_empty_base_classes, child_indexes);
       }
     } break;
 
@@ -6737,10 +6738,9 @@ size_t TypeSystemClang::GetIndexOfChildMemberWithName(
 // doesn't descend into the children, but only looks one level deep and name
 // matches can include base class names.
 
-uint32_t
-TypeSystemClang::GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
-                                         const char *name,
-                                         bool omit_empty_base_classes) {
+uint32_t TypeSystemClang::GetIndexOfChildWithName(
+    lldb::opaque_compiler_type_t type, const char *name,
+    ExecutionContext *exe_ctx, bool omit_empty_base_classes) {
   if (type && name && name[0]) {
     clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
 
@@ -6842,7 +6842,7 @@ TypeSystemClang::GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
           llvm::cast<clang::ObjCObjectPointerType>(qual_type.getTypePtr())
               ->getPointeeType());
       return pointee_clang_type.GetIndexOfChildWithName(
-          name, omit_empty_base_classes);
+          name, exe_ctx, omit_empty_base_classes);
     } break;
 
     case clang::Type::ConstantArray: {
@@ -6892,7 +6892,7 @@ TypeSystemClang::GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
       CompilerType pointee_type = GetType(reference_type->getPointeeType());
 
       if (pointee_type.IsAggregateType()) {
-        return pointee_type.GetIndexOfChildWithName(name,
+        return pointee_type.GetIndexOfChildWithName(name, exe_ctx,
                                                     omit_empty_base_classes);
       }
     } break;
@@ -6903,7 +6903,7 @@ TypeSystemClang::GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
       CompilerType pointee_type = GetType(pointer_type->getPointeeType());
 
       if (pointee_type.IsAggregateType()) {
-        return pointee_type.GetIndexOfChildWithName(name,
+        return pointee_type.GetIndexOfChildWithName(name, exe_ctx,
                                                     omit_empty_base_classes);
       } else {
         //                    if (parent_name)

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -821,7 +821,7 @@ public:
   // Lookup a child given a name. This function will match base class names and
   // member member names in "clang_type" only, not descendants.
   uint32_t GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
-                                   const char *name,
+                                   const char *name, ExecutionContext *exe_ctx,
                                    bool omit_empty_base_classes) override;
 
   // Lookup a child member given a name. This function will match member names
@@ -832,7 +832,8 @@ public:
   // so we catch all names that match a given child name, not just the first.
   size_t
   GetIndexOfChildMemberWithName(lldb::opaque_compiler_type_t type,
-                                const char *name, bool omit_empty_base_classes,
+                                const char *name, ExecutionContext *exe_ctx,
+                                bool omit_empty_base_classes,
                                 std::vector<uint32_t> &child_indexes) override;
 
   size_t GetNumTemplateArguments(lldb::opaque_compiler_type_t type) override;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -7259,8 +7259,8 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
 // second index 1 is the child index for "m_b" within class A.
 
 size_t SwiftASTContext::GetIndexOfChildMemberWithName(
-    opaque_compiler_type_t type, const char *name, bool omit_empty_base_classes,
-    std::vector<uint32_t> &child_indexes) {
+    opaque_compiler_type_t type, const char *name, ExecutionContext *exe_ctx,
+    bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
   VALID_OR_RETURN(0);
 
   if (type && name && name[0]) {
@@ -7282,7 +7282,7 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
     case swift::TypeKind::UnownedStorage:
     case swift::TypeKind::WeakStorage:
       return ToCompilerType(swift_can_type->getReferenceStorageReferent())
-          .GetIndexOfChildMemberWithName(name, omit_empty_base_classes,
+          .GetIndexOfChildMemberWithName(name, exe_ctx, omit_empty_base_classes,
                                          child_indexes);
     case swift::TypeKind::GenericTypeParam:
     case swift::TypeKind::DependentMember:
@@ -7363,7 +7363,7 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
         CompilerType superclass_type =
             ToCompilerType(superclass_swift_type.getPointer());
         if (superclass_type.GetIndexOfChildMemberWithName(
-                name, omit_empty_base_classes, child_indexes))
+                name, exe_ctx, omit_empty_base_classes, child_indexes))
           return child_indexes.size();
 
         // We didn't find a stored property matching "name" in our
@@ -7409,7 +7409,7 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
 
       if (pointee_clang_type.IsAggregateType()) {
         return pointee_clang_type.GetIndexOfChildMemberWithName(
-            name, omit_empty_base_classes, child_indexes);
+            name, exe_ctx, omit_empty_base_classes, child_indexes);
       }
     } break;
     case swift::TypeKind::UnboundGeneric:

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -610,7 +610,8 @@ public:
   // name, not just the first.
   size_t
   GetIndexOfChildMemberWithName(lldb::opaque_compiler_type_t type,
-                                const char *name, bool omit_empty_base_classes,
+                                const char *name, ExecutionContext *exe_ctx,
+                                bool omit_empty_base_classes,
                                 std::vector<uint32_t> &child_indexes) override;
 
   size_t GetNumTemplateArguments(lldb::opaque_compiler_type_t type) override;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -102,12 +102,11 @@ bool TypeSystemSwift::ShouldTreatScalarValueAsAddress(
       .AnySet(eTypeInstanceIsPointer | eTypeIsReference);
 }
 
-uint32_t
-TypeSystemSwift::GetIndexOfChildWithName(opaque_compiler_type_t type,
-                                         const char *name,
-                                         bool omit_empty_base_classes) {
+uint32_t TypeSystemSwift::GetIndexOfChildWithName(
+    opaque_compiler_type_t type, const char *name, ExecutionContext *exe_ctx,
+    bool omit_empty_base_classes) {
   std::vector<uint32_t> child_indexes;
   size_t num_child_indexes = GetIndexOfChildMemberWithName(
-      type, name, omit_empty_base_classes, child_indexes);
+      type, name, exe_ctx, omit_empty_base_classes, child_indexes);
   return num_child_indexes == 1 ? child_indexes.front() : UINT32_MAX;
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -246,7 +246,7 @@ public:
   /// Lookup a child given a name. This function will match base class names
   /// and member names in \p type only, not descendants.
   uint32_t GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
-                                   const char *name,
+                                   const char *name, ExecutionContext *exe_ctx,
                                    bool omit_empty_base_classes) override;
 
   /// \}

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2365,11 +2365,13 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
 }
 
 size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
-    opaque_compiler_type_t type, const char *name, bool omit_empty_base_classes,
-    std::vector<uint32_t> &child_indexes) {
+    opaque_compiler_type_t type, const char *name, ExecutionContext *exe_ctx,
+    bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
   return m_swift_ast_context->GetIndexOfChildMemberWithName(
-      ReconstructType(type), name, omit_empty_base_classes, child_indexes);
+      ReconstructType(type), name, exe_ctx, omit_empty_base_classes,
+      child_indexes);
 }
+
 size_t
 TypeSystemSwiftTypeRef::GetNumTemplateArguments(opaque_compiler_type_t type) {
   return m_swift_ast_context->GetNumTemplateArguments(ReconstructType(type));

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2345,7 +2345,7 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
   if (m_swift_ast_context->GetNumChildren(ReconstructType(type),
                                           omit_empty_base_classes, exe_ctx) <
       runtime->GetNumChildren({this, type}, valobj).getValueOr(0))
-    return fallback();
+    return impl();
 
 #ifndef NDEBUG
   std::string ast_child_name;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -167,7 +167,8 @@ public:
       ValueObject *valobj, uint64_t &language_flags) override;
   size_t
   GetIndexOfChildMemberWithName(lldb::opaque_compiler_type_t type,
-                                const char *name, bool omit_empty_base_classes,
+                                const char *name, ExecutionContext *exe_ctx,
+                                bool omit_empty_base_classes,
                                 std::vector<uint32_t> &child_indexes) override;
   size_t GetNumTemplateArguments(lldb::opaque_compiler_type_t type) override;
   CompilerType GetTypeForFormatters(lldb::opaque_compiler_type_t type) override;

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -654,11 +654,11 @@ CompilerType CompilerType::GetChildCompilerTypeAtIndex(
 // index 1 is the child index for "m_b" within class A
 
 size_t CompilerType::GetIndexOfChildMemberWithName(
-    const char *name, bool omit_empty_base_classes,
+    const char *name, ExecutionContext *exe_ctx, bool omit_empty_base_classes,
     std::vector<uint32_t> &child_indexes) const {
   if (IsValid() && name && name[0]) {
     return m_type_system->GetIndexOfChildMemberWithName(
-        m_type, name, omit_empty_base_classes, child_indexes);
+        m_type, name, exe_ctx, omit_empty_base_classes, child_indexes);
   }
   return 0;
 }
@@ -714,9 +714,10 @@ bool CompilerType::IsMeaninglessWithoutDynamicResolution() const {
 
 uint32_t
 CompilerType::GetIndexOfChildWithName(const char *name,
+                                      ExecutionContext *exe_ctx,
                                       bool omit_empty_base_classes) const {
   if (IsValid() && name && name[0]) {
-    return m_type_system->GetIndexOfChildWithName(m_type, name,
+    return m_type_system->GetIndexOfChildWithName(m_type, name, exe_ctx,
                                                   omit_empty_base_classes);
   }
   return UINT32_MAX;

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -257,6 +257,13 @@ public:
     return {};
   }
 
+  llvm::Optional<size_t> GetIndexOfChildMemberWithName(
+      CompilerType type, const char *name, ExecutionContext *exe_ctx,
+      bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
+    STUB_LOG();
+    return {};
+  }
+
   CompilerType GetChildCompilerTypeAtIndex(
       CompilerType type, size_t idx, bool transparent_pointers,
       bool omit_empty_base_classes, bool ignore_array_bounds,
@@ -2142,6 +2149,13 @@ llvm::Optional<uint64_t> SwiftLanguageRuntime::GetMemberVariableOffset(
 llvm::Optional<unsigned>
 SwiftLanguageRuntime::GetNumChildren(CompilerType type, ValueObject *valobj) {
   FORWARD(GetNumChildren, type, valobj);
+}
+
+llvm::Optional<size_t> SwiftLanguageRuntime::GetIndexOfChildMemberWithName(
+    CompilerType type, const char *name, ExecutionContext *exe_ctx,
+    bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
+  FORWARD(GetIndexOfChildMemberWithName, type, name, exe_ctx,
+          omit_empty_base_classes, child_indexes);
 }
 
 CompilerType SwiftLanguageRuntime::GetChildCompilerTypeAtIndex(

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -257,9 +257,11 @@ public:
     return {};
   }
 
-  llvm::Optional<size_t> GetIndexOfChildMemberWithName(
-      CompilerType type, const char *name, ExecutionContext *exe_ctx,
-      bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
+  llvm::Optional<size_t>
+  GetIndexOfChildMemberWithName(CompilerType type, llvm::StringRef name,
+                                ExecutionContext *exe_ctx,
+                                bool omit_empty_base_classes,
+                                llvm::MutableArrayRef<uint32_t> child_indexes) {
     STUB_LOG();
     return {};
   }
@@ -2152,8 +2154,9 @@ SwiftLanguageRuntime::GetNumChildren(CompilerType type, ValueObject *valobj) {
 }
 
 llvm::Optional<size_t> SwiftLanguageRuntime::GetIndexOfChildMemberWithName(
-    CompilerType type, const char *name, ExecutionContext *exe_ctx,
-    bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
+    CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
+    bool omit_empty_base_classes,
+    llvm::MutableArrayRef<uint32_t> child_indexes) {
   FORWARD(GetIndexOfChildMemberWithName, type, name, exe_ctx,
           omit_empty_base_classes, child_indexes);
 }

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -257,11 +257,9 @@ public:
     return {};
   }
 
-  llvm::Optional<size_t>
-  GetIndexOfChildMemberWithName(CompilerType type, llvm::StringRef name,
-                                ExecutionContext *exe_ctx,
-                                bool omit_empty_base_classes,
-                                llvm::MutableArrayRef<uint32_t> child_indexes) {
+  llvm::Optional<size_t> GetIndexOfChildMemberWithName(
+      CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
+      bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
     STUB_LOG();
     return {};
   }
@@ -2155,8 +2153,7 @@ SwiftLanguageRuntime::GetNumChildren(CompilerType type, ValueObject *valobj) {
 
 llvm::Optional<size_t> SwiftLanguageRuntime::GetIndexOfChildMemberWithName(
     CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
-    bool omit_empty_base_classes,
-    llvm::MutableArrayRef<uint32_t> child_indexes) {
+    bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
   FORWARD(GetIndexOfChildMemberWithName, type, name, exe_ctx,
           omit_empty_base_classes, child_indexes);
 }

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1143,8 +1143,9 @@ GetTypeFromTypeRef(TypeSystemSwiftTypeRef &ts,
 }
 
 llvm::Optional<size_t> SwiftLanguageRuntimeImpl::GetIndexOfChildMemberWithName(
-    CompilerType type, const char *name, ExecutionContext *exe_ctx,
-    bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
+    CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
+    bool omit_empty_base_classes,
+    llvm::MutableArrayRef<uint32_t> child_indexes) {
   return {};
 }
 

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1144,8 +1144,7 @@ GetTypeFromTypeRef(TypeSystemSwiftTypeRef &ts,
 
 llvm::Optional<size_t> SwiftLanguageRuntimeImpl::GetIndexOfChildMemberWithName(
     CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
-    bool omit_empty_base_classes,
-    llvm::MutableArrayRef<uint32_t> child_indexes) {
+    bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
   return {};
 }
 

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1142,6 +1142,12 @@ GetTypeFromTypeRef(TypeSystemSwiftTypeRef &ts,
   return ts.RemangleAsType(dem, node);
 }
 
+llvm::Optional<size_t> SwiftLanguageRuntimeImpl::GetIndexOfChildMemberWithName(
+    CompilerType type, const char *name, ExecutionContext *exe_ctx,
+    bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
+  return {};
+}
+
 CompilerType SwiftLanguageRuntimeImpl::GetChildCompilerTypeAtIndex(
     CompilerType type, size_t idx, bool transparent_pointers,
     bool omit_empty_base_classes, bool ignore_array_bounds,

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1046,6 +1046,7 @@ SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
   if (auto *rti =
           llvm::dyn_cast_or_null<swift::reflection::RecordTypeInfo>(ti)) {
     switch (rti->getRecordKind()) {
+    case swift::reflection::RecordKind::ExistentialMetatype:
     case swift::reflection::RecordKind::ThickFunction:
       // There are two fields, `function` and `context`, but they're not exposed
       // by lldb.
@@ -1181,6 +1182,7 @@ llvm::Optional<size_t> SwiftLanguageRuntimeImpl::GetIndexOfChildMemberWithName(
     // Structs and Tuples.
     auto *rti = llvm::cast<RecordTypeInfo>(ti);
     switch (rti->getRecordKind()) {
+    case RecordKind::ExistentialMetatype:
     case RecordKind::ThickFunction:
       // There are two fields, `function` and `context`, but they're not exposed
       // by lldb.

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1184,7 +1184,7 @@ llvm::Optional<size_t> SwiftLanguageRuntimeImpl::GetIndexOfChildMemberWithName(
     case RecordKind::ThickFunction:
       // There are two fields, `function` and `context`, but they're not exposed
       // by lldb.
-      return {};
+      return 0;
     case RecordKind::OpaqueExistential:
       // `OpaqueExistential` is documented as:
       //     An existential is a three-word buffer followed by value metadata...

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1223,19 +1223,21 @@ llvm::Optional<size_t> SwiftLanguageRuntimeImpl::GetIndexOfChildMemberWithName(
       auto &builder = reflection_ctx->getBuilder();
       TypeConverter tc(builder);
       LLDBTypeInfoProvider tip(*this, *ts);
-      // The class_tr pointer is used to iterate the class hierarchy, from the
-      // current class, each superclass, and ends on null.
-      auto *class_tr = tr;
-      while (class_tr) {
+      // `current_tr` iterates the class hierarchy, from the current class, each
+      // superclass, and ends on null.
+      auto *current_tr = tr;
+      while (current_tr) {
         auto *record_ti = llvm::cast<RecordTypeInfo>(
             tc.getClassInstanceTypeInfo(tr, 0, &tip));
-        class_tr = builder.lookupSuperclass(class_tr);
-        uint32_t offset = class_tr ? 1 : 0;
+        auto *super_tr = builder.lookupSuperclass(current_tr);
+        uint32_t offset = super_tr ? 1 : 0;
         if (auto size = findFieldWithName(record_ti->getFields(), name,
-                                          child_indexes, offset)) {
+                                          child_indexes, offset))
           return size;
-        }
+        current_tr = super_tr;
+        child_indexes.push_back(0);
       }
+      child_indexes.clear();
       return {};
     }
     }

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1221,15 +1221,18 @@ llvm::Optional<size_t> SwiftLanguageRuntimeImpl::GetIndexOfChildMemberWithName(
       auto &builder = reflection_ctx->getBuilder();
       auto tc = TypeConverter(builder);
       auto tip = LLDBTypeInfoProvider(*this, *ts);
-      auto *class_ti = tc.getClassInstanceTypeInfo(tr, 0, &tip);
-      while (auto *record_ti = llvm::cast_or_null<RecordTypeInfo>(class_ti)) {
-        auto super_tr = builder.lookupSuperclass(tr);
-        uint32_t offset = super_tr ? 1 : 0;
+      // The class_tr pointer is used to iterate the class hierarchy, from the
+      // current class, each superclass, and ends on null.
+      auto *class_tr = tr;
+      while (class_tr) {
+        auto *record_ti = llvm::cast<RecordTypeInfo>(
+            tc.getClassInstanceTypeInfo(tr, 0, &tip));
+        class_tr = builder.lookupSuperclass(class_tr);
+        uint32_t offset = class_tr ? 1 : 0;
         if (auto size = findFieldWithName(record_ti->getFields(), name,
                                           child_indexes, offset)) {
           return size;
         }
-        class_ti = reflection_ctx->getTypeInfo(super_tr, &tip);
       }
       return {};
     }

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1221,8 +1221,8 @@ llvm::Optional<size_t> SwiftLanguageRuntimeImpl::GetIndexOfChildMemberWithName(
     case ReferenceKind::Strong: {
       auto *reflection_ctx = GetReflectionContext();
       auto &builder = reflection_ctx->getBuilder();
-      auto tc = TypeConverter(builder);
-      auto tip = LLDBTypeInfoProvider(*this, *ts);
+      TypeConverter tc(builder);
+      LLDBTypeInfoProvider tip(*this, *ts);
       // The class_tr pointer is used to iterate the class hierarchy, from the
       // current class, each superclass, and ends on null.
       auto *class_tr = tr;

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1213,8 +1213,9 @@ llvm::Optional<size_t> SwiftLanguageRuntimeImpl::GetIndexOfChildMemberWithName(
     case ReferenceKind::Weak:
     case ReferenceKind::Unowned:
     case ReferenceKind::Unmanaged:
-      // TODO: Dereference
-      return {};
+      return GetIndexOfChildMemberWithName(GetWeakReferent(*ts, type), name,
+                                           exe_ctx, omit_empty_base_classes,
+                                           child_indexes);
     case ReferenceKind::Strong: {
       auto *reflection_ctx = GetReflectionContext();
       auto &builder = reflection_ctx->getBuilder();

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1222,9 +1222,11 @@ llvm::Optional<size_t> SwiftLanguageRuntimeImpl::GetIndexOfChildMemberWithName(
       auto tip = LLDBTypeInfoProvider(*this, *ts);
       auto *cti = tc.getClassInstanceTypeInfo(tr, 0, &tip);
       if (auto *rti = llvm::cast_or_null<RecordTypeInfo>(cti)) {
-        if (auto size =
-                findFieldWithName(rti->getFields(), name, child_indexes))
+        uint32_t offset = builder.lookupSuperclass(tr) ? 1 : 0;
+        if (auto size = findFieldWithName(rti->getFields(), name, child_indexes,
+                                          offset)) {
           return size;
+        }
         // TODO: handle base classes.
       }
       return {};

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1192,7 +1192,7 @@ llvm::Optional<size_t> SwiftLanguageRuntimeImpl::GetIndexOfChildMemberWithName(
       // the number of fields are increased to match.
       if (name.startswith("payload_data_")) {
         uint32_t index;
-        if (name.take_back().getAsInteger(10, index) && index <= 2) {
+        if (name.take_back().getAsInteger(10, index) && index < 3) {
           child_indexes.push_back(index);
           return child_indexes.size();
         }

--- a/lldb/source/Target/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Target/SwiftLanguageRuntimeImpl.h
@@ -120,6 +120,10 @@ public:
   llvm::Optional<unsigned> GetNumChildren(CompilerType type,
                                           ValueObject *valobj);
 
+  llvm::Optional<size_t> GetIndexOfChildMemberWithName(
+      CompilerType type, const char *name, ExecutionContext *exe_ctx,
+      bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes);
+
   CompilerType GetChildCompilerTypeAtIndex(
       CompilerType type, size_t idx, bool transparent_pointers,
       bool omit_empty_base_classes, bool ignore_array_bounds,

--- a/lldb/source/Target/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Target/SwiftLanguageRuntimeImpl.h
@@ -120,11 +120,9 @@ public:
   llvm::Optional<unsigned> GetNumChildren(CompilerType type,
                                           ValueObject *valobj);
 
-  llvm::Optional<size_t>
-  GetIndexOfChildMemberWithName(CompilerType type, llvm::StringRef name,
-                                ExecutionContext *exe_ctx,
-                                bool omit_empty_base_classes,
-                                llvm::MutableArrayRef<uint32_t> child_indexes);
+  llvm::Optional<size_t> GetIndexOfChildMemberWithName(
+      CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
+      bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes);
 
   CompilerType GetChildCompilerTypeAtIndex(
       CompilerType type, size_t idx, bool transparent_pointers,

--- a/lldb/source/Target/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Target/SwiftLanguageRuntimeImpl.h
@@ -120,9 +120,11 @@ public:
   llvm::Optional<unsigned> GetNumChildren(CompilerType type,
                                           ValueObject *valobj);
 
-  llvm::Optional<size_t> GetIndexOfChildMemberWithName(
-      CompilerType type, const char *name, ExecutionContext *exe_ctx,
-      bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes);
+  llvm::Optional<size_t>
+  GetIndexOfChildMemberWithName(CompilerType type, llvm::StringRef name,
+                                ExecutionContext *exe_ctx,
+                                bool omit_empty_base_classes,
+                                llvm::MutableArrayRef<uint32_t> child_indexes);
 
   CompilerType GetChildCompilerTypeAtIndex(
       CompilerType type, size_t idx, bool transparent_pointers,

--- a/lldb/test/API/lang/swift/foundation_value_types/notification/TestSwiftFoundationTypeNotification.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/notification/TestSwiftFoundationTypeNotification.py
@@ -14,7 +14,4 @@ from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(
     __file__, globals(), decorators=
-    [skipUnlessDarwin,swiftTest,
-        expectedFailureAll(bugnumber="rdar://60396797",
-                           setting=('symbols.use-swift-clangimporter', 'false'))
-])
+    [skipUnlessDarwin,swiftTest])

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
@@ -119,5 +119,5 @@ class TestLibraryIndirect(TestBase):
             "other = 10",
             "(Int) simple = 1"])
         self.expect("e container", substrs=["(SomeLibrary.ContainsTwoInts)", "wrapped = 0x", "other = 10"])
-        self.expect("e container.wrapped", substrs=["(SomeLibrary.BoxedTwoInts)", "0x", "{}"])
+        self.expect("e container.wrapped", substrs=["(SomeLibrary.BoxedTwoInts)", "value = (first = 2, second = 3)"])
         self.expect("e container.wrapped.value", error=True, substrs=["value of type 'BoxedTwoInts' has no member 'value'"])

--- a/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
@@ -64,7 +64,7 @@ class TestSwiftInterfaceDSYM(TestBase):
         lldbutil.check_variable(self, child_y, False, value="0")
 
         child_x = var.GetChildMemberWithName("x") # MyPoint.x isn't public
-        self.assertFalse(child_x.IsValid())
+        self.assertTrue(child_x.IsValid())
 
         # Expression evaluation using types from the .swiftinterface only
         # dylibs should work too

--- a/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
@@ -63,7 +63,8 @@ class TestSwiftInterfaceDSYM(TestBase):
         child_y = var.GetChildMemberWithName("y") # MyPoint.y is public
         lldbutil.check_variable(self, child_y, False, value="0")
 
-        child_x = var.GetChildMemberWithName("x") # MyPoint.x isn't public
+        # MyPoint.x isn't public, but LLDB can find it through type metadata.
+        child_x = var.GetChildMemberWithName("x")
         self.assertTrue(child_x.IsValid())
 
         # Expression evaluation using types from the .swiftinterface only

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
@@ -128,7 +128,8 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
         child_y = var.GetChildMemberWithName("y") # MyPoint.y is public
         lldbutil.check_variable(self, child_y, False, value="0")
 
-        child_x = var.GetChildMemberWithName("x") # MyPoint.x isn't public
+        # MyPoint.x isn't public, but LLDB can find it through type metadata.
+        child_x = var.GetChildMemberWithName("x")
         self.assertTrue(child_x.IsValid())
 
         # Expression evaluation using types from the .swiftinterface only

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
@@ -129,7 +129,7 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
         lldbutil.check_variable(self, child_y, False, value="0")
 
         child_x = var.GetChildMemberWithName("x") # MyPoint.x isn't public
-        self.assertFalse(child_x.IsValid())
+        self.assertTrue(child_x.IsValid())
 
         # Expression evaluation using types from the .swiftinterface only
         # dylibs should work too

--- a/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
@@ -75,7 +75,7 @@ class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
         lldbutil.check_variable(self, child_y, False, value="0")
 
         child_x = var.GetChildMemberWithName("x") # MyPoint.x isn't public
-        self.assertFalse(child_x.IsValid())
+        self.assertTrue(child_x.IsValid())
 
         # Expression evaluation using types from the .swiftinterface only
         # modules should work too

--- a/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
@@ -74,7 +74,8 @@ class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
         child_y = var.GetChildMemberWithName("y") # MyPoint.y is public
         lldbutil.check_variable(self, child_y, False, value="0")
 
-        child_x = var.GetChildMemberWithName("x") # MyPoint.x isn't public
+        # MyPoint.x isn't public, but LLDB can find it through type metadata.
+        child_x = var.GetChildMemberWithName("x")
         self.assertTrue(child_x.IsValid())
 
         # Expression evaluation using types from the .swiftinterface only

--- a/lldb/test/Shell/Swift/Inputs/No.swiftmodule.swift
+++ b/lldb/test/Shell/Swift/Inputs/No.swiftmodule.swift
@@ -1,6 +1,6 @@
 import NoSwiftmoduleHelper
 
-// The struct could not possibly be resolved with just the mangled type name.
+// The struct is resolved using type metadata and the Swift runtime.
 struct s { let i = 0 }
 
 func useTypeFromOtherModule(x: S2) {
@@ -12,7 +12,7 @@ func f<T>(_ t: T) {
   let array = [1, 2, 3]            // CHECK-DAG: ([Int]) array = 3 values
   let string = "hello"             // CHECK-DAG: (String) string = "hello"
   let tuple = (0, 1)               // CHECK-DAG: (Int, Int) tuple = (0 = 0, 1 = 1)
-  let strct = s()                  // CHECK-DAG: strct = {}{{$}}
+  let strct = s()                  // CHECK-DAG: strct = (i = 0)
   let strct2 = S2()                // CHECK-DAG: strct2 = {}{{$}}
   let generic = t                  // CHECK-DAG: (Int) generic = 23
   let generic_tuple = (t, t)       // CHECK-DAG: generic_tuple = (0 = 23, 1 = 23)


### PR DESCRIPTION
This ports the implementation of `GetIndexOfChildMemberWithName`, from `SwiftASTContext` to `TypeSystemSwiftTypeRef`.

With this change, when compiling with swiftinterfaces, private properties in Swift types are now visible to lldb through the TypeRef metadata contained in the binary. Tests that expected private properties to not be accessible have been updated.

rdar://68171371