### PR TITLE
[Timer] Count number of executed instructions on macOS

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -676,6 +676,12 @@ else()
 endif()
 option(LLVM_ENABLE_PLUGINS "Enable plugin support" ${LLVM_ENABLE_PLUGINS_default})
 
+include(CheckSymbolExists)
+check_symbol_exists(proc_pid_rusage "libproc.h" HAVE_PROC_PID_RUSAGE)
+if(HAVE_PROC_PID_RUSAGE)
+  list(APPEND CMAKE_REQUIRED_LIBRARIES proc)
+endif()
+
 include(HandleLLVMOptions)
 
 if(CMAKE_VERSION VERSION_LESS 3.12)

--- a/llvm/include/llvm/Config/config.h.cmake
+++ b/llvm/include/llvm/Config/config.h.cmake
@@ -347,4 +347,6 @@
 /* Whether Timers signpost passes in Xcode Instruments */
 #cmakedefine01 LLVM_SUPPORT_XCODE_SIGNPOSTS
 
+#cmakedefine HAVE_PROC_PID_RUSAGE 1
+
 #endif

--- a/llvm/include/llvm/Support/Timer.h
+++ b/llvm/include/llvm/Support/Timer.h
@@ -24,12 +24,14 @@ class TimerGroup;
 class raw_ostream;
 
 class TimeRecord {
-  double WallTime;       ///< Wall clock time elapsed in seconds.
-  double UserTime;       ///< User time elapsed.
-  double SystemTime;     ///< System time elapsed.
-  ssize_t MemUsed;       ///< Memory allocated (in bytes).
+  double WallTime;                ///< Wall clock time elapsed in seconds.
+  double UserTime;                ///< User time elapsed.
+  double SystemTime;              ///< System time elapsed.
+  ssize_t MemUsed;                ///< Memory allocated (in bytes).
+  uint64_t InstructionsExecuted;  ///< Number of instructions executed
 public:
-  TimeRecord() : WallTime(0), UserTime(0), SystemTime(0), MemUsed(0) {}
+  TimeRecord() : WallTime(0), UserTime(0), SystemTime(0), MemUsed(0), 
+                 InstructionsExecuted(0) {}
 
   /// Get the current time and memory usage.  If Start is true we get the memory
   /// usage before the time, otherwise we get time before memory usage.  This
@@ -42,6 +44,7 @@ public:
   double getSystemTime() const { return SystemTime; }
   double getWallTime() const { return WallTime; }
   ssize_t getMemUsed() const { return MemUsed; }
+  uint64_t getInstructionsExecuted() const { return InstructionsExecuted; }
 
   bool operator<(const TimeRecord &T) const {
     // Sort by Wall Time elapsed, as it is the only thing really accurate
@@ -49,16 +52,18 @@ public:
   }
 
   void operator+=(const TimeRecord &RHS) {
-    WallTime   += RHS.WallTime;
-    UserTime   += RHS.UserTime;
-    SystemTime += RHS.SystemTime;
-    MemUsed    += RHS.MemUsed;
+    WallTime             += RHS.WallTime;
+    UserTime             += RHS.UserTime;
+    SystemTime           += RHS.SystemTime;
+    MemUsed              += RHS.MemUsed;
+    InstructionsExecuted += RHS.InstructionsExecuted;
   }
   void operator-=(const TimeRecord &RHS) {
-    WallTime   -= RHS.WallTime;
-    UserTime   -= RHS.UserTime;
-    SystemTime -= RHS.SystemTime;
-    MemUsed    -= RHS.MemUsed;
+    WallTime             -= RHS.WallTime;
+    UserTime             -= RHS.UserTime;
+    SystemTime           -= RHS.SystemTime;
+    MemUsed              -= RHS.MemUsed;
+    InstructionsExecuted -= RHS.InstructionsExecuted;
   }
 
   /// Print the current time record to \p OS, with a breakdown showing

--- a/llvm/lib/Support/Timer.cpp
+++ b/llvm/lib/Support/Timer.cpp
@@ -13,6 +13,7 @@
 #include "llvm/Support/Timer.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/Config/config.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Format.h"
@@ -23,6 +24,14 @@
 #include "llvm/Support/YAMLTraits.h"
 #include "llvm/Support/raw_ostream.h"
 #include <limits>
+
+#if HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#ifdef HAVE_PROC_PID_RUSAGE
+#include <libproc.h>
+#endif
 
 using namespace llvm;
 
@@ -115,6 +124,16 @@ static inline size_t getMemUsage() {
   return sys::Process::GetMallocUsage();
 }
 
+static uint64_t getCurInstructionsExecuted() {
+#if defined(HAVE_UNISTD_H) && defined(HAVE_PROC_PID_RUSAGE) && defined(RUSAGE_INFO_V4)
+  struct rusage_info_v4 ru;
+  if (proc_pid_rusage(getpid(), RUSAGE_INFO_V4, (rusage_info_t *)&ru) == 0) {
+    return ru.ri_instructions;
+  }
+#endif
+  return 0;
+}
+
 TimeRecord TimeRecord::getCurrentTime(bool Start) {
   using Seconds = std::chrono::duration<double, std::ratio<1>>;
   TimeRecord Result;
@@ -123,9 +142,11 @@ TimeRecord TimeRecord::getCurrentTime(bool Start) {
 
   if (Start) {
     Result.MemUsed = getMemUsage();
+    Result.InstructionsExecuted = getCurInstructionsExecuted();
     sys::Process::GetTimeUsage(now, user, sys);
   } else {
     sys::Process::GetTimeUsage(now, user, sys);
+    Result.InstructionsExecuted = getCurInstructionsExecuted();
     Result.MemUsed = getMemUsage();
   }
 
@@ -175,6 +196,8 @@ void TimeRecord::print(const TimeRecord &Total, raw_ostream &OS) const {
 
   if (Total.getMemUsed())
     OS << format("%9" PRId64 "  ", (int64_t)getMemUsed());
+  if (Total.getInstructionsExecuted())
+    OS << format("%9" PRId64 "  ", (int64_t)getInstructionsExecuted());
 }
 
 
@@ -333,6 +356,8 @@ void TimerGroup::PrintQueuedTimers(raw_ostream &OS) {
   OS << "   ---Wall Time---";
   if (Total.getMemUsed())
     OS << "  ---Mem---";
+  if (Total.getInstructionsExecuted())
+    OS << "  ---Instr---";
   OS << "  --- Name ---\n";
 
   // Loop through all of the timing data, printing it out.
@@ -426,6 +451,10 @@ const char *TimerGroup::printJSONValues(raw_ostream &OS, const char *delim) {
     if (T.getMemUsed()) {
       OS << delim;
       printJSONValue(OS, R, ".mem", T.getMemUsed());
+    }
+    if (T.getInstructionsExecuted()) {
+      OS << delim;
+      printJSONValue(OS, R, ".instr", T.getInstructionsExecuted()); 
     }
   }
   TimersToPrint.clear();


### PR DESCRIPTION
In an effort to get performance timers for the Swift parser that are as accurate as possible, I found this PR by Graydon (https://github.com/apple/swift/pull/18658) from a couple years ago, adding a performance metric that counts the number of executed instructions on macOS. According to Graydon (and my intuition), this number is a lot less noisy than the time values.

With this PR, I'm trying to taking the measurements a little bit further by recording them with every LLVM `Timer`. This way, we get the measurement for free in every place that LLVM `Timer`s are used (which happens to include measurements for the Swift parser, my original goal).

The code is mostly copy-based from either Graydon's PR or other places in `Timer.h/cpp`. I would appreciate a thorough code review, in particular regarding the implications of my changes to `CMakeList.txt`. 

Also: I'm not sure, if `swift/main` is the correct branch to target, please let me know if I should target a different branch.