### PR TITLE
[lldb] Implement TypeSystemSwiftTypeRef::GetTypeForFormatters

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2439,7 +2439,7 @@ TypeSystemSwiftTypeRef::GetNumTemplateArguments(opaque_compiler_type_t type) {
 
 CompilerType
 TypeSystemSwiftTypeRef::GetTypeForFormatters(opaque_compiler_type_t type) {
-  auto impl = [&]() { return ReconstructType({this, type}); };
+  auto impl = [&]() { return GetCanonicalType(type); };
   VALIDATE_AND_RETURN(impl, GetTypeForFormatters, type,
                       (ReconstructType(type)));
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2439,7 +2439,7 @@ TypeSystemSwiftTypeRef::GetNumTemplateArguments(opaque_compiler_type_t type) {
 
 CompilerType
 TypeSystemSwiftTypeRef::GetTypeForFormatters(opaque_compiler_type_t type) {
-  auto impl = [&]() -> CompilerType { return {this, type}; };
+  auto impl = [&]() { return ReconstructType({this, type}); };
   VALIDATE_AND_RETURN(impl, GetTypeForFormatters, type,
                       (ReconstructType(type)));
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2436,9 +2436,12 @@ size_t
 TypeSystemSwiftTypeRef::GetNumTemplateArguments(opaque_compiler_type_t type) {
   return m_swift_ast_context->GetNumTemplateArguments(ReconstructType(type));
 }
+
 CompilerType
 TypeSystemSwiftTypeRef::GetTypeForFormatters(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetTypeForFormatters(ReconstructType(type));
+  auto impl = [&]() -> CompilerType { return {this, type}; };
+  VALIDATE_AND_RETURN(impl, GetTypeForFormatters, type,
+                      (ReconstructType(type)));
 }
 
 LazyBool

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2785,10 +2785,14 @@ CompilerType
 TypeSystemSwiftTypeRef::GetTypedefedType(opaque_compiler_type_t type) {
   return m_swift_ast_context->GetTypedefedType(ReconstructType(type));
 }
+
 CompilerType
 TypeSystemSwiftTypeRef::GetFullyUnqualifiedType(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetFullyUnqualifiedType(ReconstructType(type));
+  auto impl = [&]() -> CompilerType { return {this, type}; };
+  VALIDATE_AND_RETURN(impl, GetFullyUnqualifiedType, type,
+                      (ReconstructType(type)));
 }
+
 CompilerType
 TypeSystemSwiftTypeRef::GetNonReferenceType(opaque_compiler_type_t type) {
   return m_swift_ast_context->GetNonReferenceType(ReconstructType(type));


### PR DESCRIPTION
Implement `GetTypeForFormatters` and `GetFullyUnqualifiedType` in `TypeSystemSwiftTypeRef`.

rdar://68171380
