### PR TITLE
Include llvm header before using llvm::make_scope_exit.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -35,6 +35,8 @@
 #include "clang/APINotes/APINotesManager.h"
 #include "clang/APINotes/APINotesReader.h"
 
+#include "llvm/ADT/ScopeExit.h"
+
 #include <algorithm>
 #include <sstream>
 


### PR DESCRIPTION
Include llvm header before using llvm::make_scope_exit.