### PR TITLE
Cherry-pick for 20200714: [libcxx] remove checks for __STDCPP_THREADS__ as it is defined by compiler

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -1167,10 +1167,6 @@ _LIBCPP_FUNC_VIS extern "C" void __sanitizer_annotate_contiguous_container(
        _LIBCPP_HAS_NO_THREADS is defined.
 #endif
 
-#if defined(__STDCPP_THREADS__) && defined(_LIBCPP_HAS_NO_THREADS)
-#error _LIBCPP_HAS_NO_THREADS cannot be set when __STDCPP_THREADS__ is set.
-#endif
-
 #if !defined(_LIBCPP_HAS_NO_THREADS) && !defined(__STDCPP_THREADS__)
 #define __STDCPP_THREADS__ 1
 #endif


### PR DESCRIPTION
[libcxx] remove checks for __STDCPP_THREADS__ as it is defined by compiler

Differential Revision: https://reviews.llvm.org/D92349