### PR TITLE
[lldb] Lift DumpValue into TypeSystemSwift (NFC)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -7632,13 +7632,6 @@ LLVM_DUMP_METHOD void SwiftASTContext::dump(opaque_compiler_type_t type) const {
 }
 #endif
 
-void SwiftASTContext::DumpValue(
-    opaque_compiler_type_t type, ExecutionContext *exe_ctx, Stream *s,
-    lldb::Format format, const lldb_private::DataExtractor &data,
-    lldb::offset_t data_byte_offset, size_t data_byte_size,
-    uint32_t bitfield_bit_size, uint32_t bitfield_bit_offset, bool show_types,
-    bool show_summary, bool verbose, uint32_t depth) {}
-
 bool SwiftASTContext::DumpTypeValue(
     opaque_compiler_type_t type, Stream *s, lldb::Format format,
     const lldb_private::DataExtractor &data, lldb::offset_t byte_offset,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -646,13 +646,6 @@ public:
   dump(lldb::opaque_compiler_type_t type) const override;
 #endif
 
-  void DumpValue(lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
-                 Stream *s, lldb::Format format, const DataExtractor &data,
-                 lldb::offset_t data_offset, size_t data_byte_size,
-                 uint32_t bitfield_bit_size, uint32_t bitfield_bit_offset,
-                 bool show_types, bool show_summary, bool verbose,
-                 uint32_t depth) override;
-
   bool DumpTypeValue(lldb::opaque_compiler_type_t type, Stream *s,
                      lldb::Format format, const DataExtractor &data,
                      lldb::offset_t data_offset, size_t data_byte_size,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -72,6 +72,12 @@ uint32_t TypeSystemSwift::GetPluginVersion() { return 1; }
 
 /// \}
 
+void TypeSystemSwift::DumpValue(
+    lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, Stream *s,
+    lldb::Format format, const DataExtractor &data, lldb::offset_t data_offset,
+    size_t data_byte_size, uint32_t bitfield_bit_size,
+    uint32_t bitfield_bit_offset, bool show_types, bool show_summary,
+    bool verbose, uint32_t depth) {}
 
 bool TypeSystemSwift::IsFloatingPointType(opaque_compiler_type_t type,
                                           uint32_t &count, bool &is_complex) {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -149,6 +149,13 @@ public:
   virtual std::string GetSwiftName(const clang::Decl *clang_decl,
                                    TypeSystemClang &clang_typesystem) = 0;
 
+  void DumpValue(lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
+                 Stream *s, lldb::Format format, const DataExtractor &data,
+                 lldb::offset_t data_offset, size_t data_byte_size,
+                 uint32_t bitfield_bit_size, uint32_t bitfield_bit_offset,
+                 bool show_types, bool show_summary, bool verbose,
+                 uint32_t depth) override;
+
   /// Unavailable hardcoded functions that don't make sense for Swift.
   /// \{
   ConstString DeclContextGetName(void *opaque_decl_ctx) override { return {}; }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2681,18 +2681,6 @@ TypeSystemSwiftTypeRef::dump(opaque_compiler_type_t type) const {
 }
 #endif
 
-void TypeSystemSwiftTypeRef::DumpValue(
-    opaque_compiler_type_t type, ExecutionContext *exe_ctx, Stream *s,
-    lldb::Format format, const DataExtractor &data, lldb::offset_t data_offset,
-    size_t data_byte_size, uint32_t bitfield_bit_size,
-    uint32_t bitfield_bit_offset, bool show_types, bool show_summary,
-    bool verbose, uint32_t depth) {
-  return m_swift_ast_context->DumpValue(
-      ReconstructType(type), exe_ctx, s, format, data, data_offset,
-      data_byte_size, bitfield_bit_size, bitfield_bit_offset, show_types,
-      show_summary, verbose, depth);
-}
-
 bool TypeSystemSwiftTypeRef::DumpTypeValue(
     opaque_compiler_type_t type, Stream *s, lldb::Format format,
     const DataExtractor &data, lldb::offset_t data_offset,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -184,13 +184,6 @@ public:
   dump(lldb::opaque_compiler_type_t type) const override;
 #endif
 
-  void DumpValue(lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
-                 Stream *s, lldb::Format format, const DataExtractor &data,
-                 lldb::offset_t data_offset, size_t data_byte_size,
-                 uint32_t bitfield_bit_size, uint32_t bitfield_bit_offset,
-                 bool show_types, bool show_summary, bool verbose,
-                 uint32_t depth) override;
-
   bool DumpTypeValue(lldb::opaque_compiler_type_t type, Stream *s,
                      lldb::Format format, const DataExtractor &data,
                      lldb::offset_t data_offset, size_t data_byte_size,


### PR DESCRIPTION
`SwiftASTContext::DumpValue` has an empty implementation, and `TypeSystemSwiftTypeRef` calls into it. This change lifts the function into the parent `TypeSystemSwift` class.

rdar://68171416
