### PR TITLE
[lldb] Optimize target read from LLDBMemoryReader::readString

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -445,14 +445,11 @@ public:
           "[MemoryReader] asked to read string data at address 0x%" PRIx64,
           address.getAddressData());
 
-    uint32_t read_size = 50 * 1024;
-    std::vector<char> storage(read_size, 0);
     Target &target(m_process.GetTarget());
     Address addr(address.getAddressData());
     Status error;
-    target.ReadCStringFromMemory(addr, &storage[0], storage.size(), error);
+    target.ReadCStringFromMemory(addr, dest, error);
     if (error.Success()) {
-      dest.assign(&storage[0]);
       if (log) {
         StreamString stream;
         for (auto c : dest) {


### PR DESCRIPTION
Improve performance of `LLDBMemoryReader::readString` by removing allocation/construction of a 50KB `std::vector` buffer for every read. Removing the vector also saves time by not doing deallocation/destruction. The fix is to use an overload of  `ReadCStringFromMemory` that uses a smaller, stack allocated buffer.

Using `TestSwiftHashedContainerEnum.py` as a data point, the test runtime comparison is:

Before  | After
------- | ------
76.853s | 7.465s

Note: This is on an iMac Pro 3 GHz 10-Core Intel with 64 GB memory

#### Investigation

Using Instruments Time Profiler, I captured the last 6.23s of a test run. After exploring the trace for a bit, it was clear a lot of time was being spent in Swift reflection. I found that pruning `LLDBMemoryReader::readString` from the trace reduced the overall time to 0.23s, meaning that in aggregate, a full 6s was being spent in `readString`. Next, by focusing on calls made by `readString`, the data showed that 3.9s was spent in vector construction, and 2.3s spent in vector destruction. Looking at the code I was surprised to see that a 50KB `vector<char>` buffer was being allocated/initialized for every string read (which is a frequent part of reflection). I don't know `std::vector`'s implementation details, but constructing a 50KB vector is much slower than a malloc of 50KB (which I tested by changing this code to use a malloc instead), and likewise destructing the vector is slower than a free.