### PR TITLE
[lldb] Implement TypeSystemSwiftTypeRef::DumpTypeValue

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2709,11 +2709,10 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     // `$sSo16ComparisonResultVD`. For now, use `SwiftASTContext` to handle
     // these enum structs.
     auto resolved = ResolveTypeAlias(m_swift_ast_context, dem, node, true);
-    if (auto clang_type = std::get<CompilerType>(resolved)) {
-      bool is_signed;
-      if (!clang_type.IsEnumerationType(is_signed))
+    auto clang_type = std::get<CompilerType>(resolved);
+    bool is_signed;
+    if (!clang_type.IsEnumerationType(is_signed))
         break;
-    }
     LLVM_FALLTHROUGH;
   }
   case Node::Kind::Enum:

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2699,8 +2699,8 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
 
   using namespace swift::Demangle;
   Demangler dem;
-  auto *canonical_type = DemangleCanonicalType(dem, type);
-  auto kind = canonical_type->getKind();
+  auto *node = DemangleCanonicalType(dem, type);
+  auto kind = node->getKind();
 
   switch (kind) {
   case Node::Kind::Structure: {
@@ -2708,7 +2708,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     // In rare instances, a Swift `Structure` wraps an ObjC enum. An example is
     // `$sSo16ComparisonResultVD`. For now, use `SwiftASTContext` to handle
     // these enum structs.
-    auto resolved = ResolveTypeAlias(m_swift_ast_context, dem, canonical_type, true);
+    auto resolved = ResolveTypeAlias(m_swift_ast_context, dem, node, true);
     if (auto clang_type = std::get<CompilerType>(resolved)) {
       bool is_signed;
       if (!clang_type.IsEnumerationType(is_signed))
@@ -2778,14 +2778,12 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     case Node::Kind::Unmanaged:
     case Node::Kind::Unowned:
     case Node::Kind::Weak:
-      return GetReferentType(dem, canonical_type)
+      return GetReferentType(dem, node)
           .DumpTypeValue(s, format, data, data_offset, data_byte_size,
                          bitfield_bit_size, bitfield_bit_offset, exe_scope,
                          is_base_class);
     default:
-      // Temporary
-      llvm::dbgs() << "DumpTypeValue: " << getNodeKindString(kind) << "\n";
-      assert(false && "Unhandled Demangle node kind");
+      return false;
     }
   };
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2781,8 +2781,13 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
           .DumpTypeValue(s, format, data, data_offset, data_byte_size,
                          bitfield_bit_size, bitfield_bit_offset, exe_scope,
                          is_base_class);
-    default:
+    case Node::Kind::Structure:
+    case Node::Kind::BoundGenericStructure:
       return false;
+    default:
+      LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
+                "Using SwiftASTContext::DumpTypeValue fallback for type %s",
+                AsMangledName(type));
     }
   };
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2781,9 +2781,11 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     case Node::Kind::BoundGenericStructure:
       return false;
     default:
+      assert(false && "Unhandled node kind");
       LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
-                "Using SwiftASTContext::DumpTypeValue fallback for type %s",
+                "DumpTypeValue: Unhandled node kind for type %s",
                 AsMangledName(type));
+      return false;
     }
   };
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2721,7 +2721,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     case Node::Kind::Class:
     case Node::Kind::BoundGenericClass:
       if (is_base_class)
-        break;
+        return false;
       LLVM_FALLTHROUGH;
     case Node::Kind::ExistentialMetatype:
     case Node::Kind::Metatype:

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -13,6 +13,7 @@
 #include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 
+#include "lldb/Core/DumpDataExtractor.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/TypeList.h"
 #include "lldb/Symbol/TypeMap.h"
@@ -2578,6 +2579,16 @@ CompilerType TypeSystemSwiftTypeRef::GetErrorType() {
 }
 
 CompilerType
+TypeSystemSwiftTypeRef::GetReferentType(swift::Demangle::Demangler &dem,
+                                        swift::Demangle::NodePointer parent) {
+  assert(parent->hasChildren());
+  auto *node = parent->getFirstChild();
+  if (!node || node->getKind() != Node::Kind::Type || !node->hasChildren())
+    return {this, nullptr};
+  return RemangleAsType(dem, node);
+}
+
+CompilerType
 TypeSystemSwiftTypeRef::GetReferentType(opaque_compiler_type_t type) {
   auto impl = [&]() -> CompilerType {
     using namespace swift::Demangle;
@@ -2588,10 +2599,7 @@ TypeSystemSwiftTypeRef::GetReferentType(opaque_compiler_type_t type) {
          node->getKind() != Node::Kind::Unmanaged) ||
         !node->hasChildren())
       return {this, type};
-    node = node->getFirstChild();
-    if (!node || node->getKind() != Node::Kind::Type || !node->hasChildren())
-      return {this, type};
-    return RemangleAsType(dem, node);
+    GetReferentType(dem, node);
   };
   VALIDATE_AND_RETURN(impl, GetReferentType, type, (ReconstructType(type)));
 }
@@ -2686,9 +2694,109 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     size_t data_byte_size, uint32_t bitfield_bit_size,
     uint32_t bitfield_bit_offset, ExecutionContextScope *exe_scope,
     bool is_base_class) {
-  return m_swift_ast_context->DumpTypeValue(
-      ReconstructType(type), s, format, data, data_offset, data_byte_size,
-      bitfield_bit_size, bitfield_bit_offset, exe_scope, is_base_class);
+  if (!type)
+    return false;
+
+  using namespace swift::Demangle;
+  Demangler dem;
+  auto *canonical_type = DemangleCanonicalType(dem, type);
+  auto kind = canonical_type->getKind();
+
+  switch (kind) {
+  case Node::Kind::Enum:
+  case Node::Kind::BoundGenericEnum:
+    // TODO: To support Enums, an ExecutionContext parameter will have to be
+    // added and callers updated.
+    return m_swift_ast_context->DumpTypeValue(
+        ReconstructType(type), s, format, data, data_offset, data_byte_size,
+        bitfield_bit_size, bitfield_bit_offset, exe_scope, is_base_class);
+  }
+
+  auto impl = [&]() -> bool {
+    switch (kind) {
+    case Node::Kind::Class:
+    case Node::Kind::BoundGenericClass:
+      if (is_base_class)
+        break;
+      LLVM_FALLTHROUGH;
+    case Node::Kind::ExistentialMetatype:
+    case Node::Kind::Metatype:
+      format = eFormatPointer;
+      LLVM_FALLTHROUGH;
+    case Node::Kind::BuiltinTypeName:
+    case Node::Kind::DependentGenericParamType:
+    case Node::Kind::FunctionType:
+    case Node::Kind::ImplFunctionType: {
+      uint32_t item_count = 1;
+      // A few formats, we might need to modify our size and count for
+      // depending on how we are trying to display the value.
+      switch (format) {
+      case eFormatChar:
+      case eFormatCharPrintable:
+      case eFormatCharArray:
+      case eFormatBytes:
+      case eFormatBytesWithASCII:
+        item_count = data_byte_size;
+        data_byte_size = 1;
+        break;
+      case eFormatUnicode16:
+        item_count = data_byte_size / 2;
+        data_byte_size = 2;
+        break;
+      case eFormatUnicode32:
+        item_count = data_byte_size / 4;
+        data_byte_size = 4;
+        break;
+      case eFormatAddressInfo:
+        if (data_byte_size == 0) {
+          data_byte_size = exe_scope->CalculateTarget()
+                               ->GetArchitecture()
+                               .GetAddressByteSize();
+          item_count = 1;
+        }
+        break;
+      default:
+        break;
+      }
+      return DumpDataExtractor(data, s, data_offset, format, data_byte_size,
+                               item_count, UINT32_MAX, LLDB_INVALID_ADDRESS,
+                               bitfield_bit_size, bitfield_bit_offset,
+                               exe_scope);
+    }
+    case Node::Kind::Unmanaged:
+    case Node::Kind::Unowned:
+    case Node::Kind::Weak:
+      return GetReferentType(dem, canonical_type)
+          .DumpTypeValue(s, format, data, data_offset, data_byte_size,
+                         bitfield_bit_size, bitfield_bit_offset, exe_scope,
+                         is_base_class);
+    case Node::Kind::Structure:
+      return false;
+    default:
+      // Temporary
+      llvm::dbgs() << "DumpTypeValue: " << getNodeKindString(kind) << "\n";
+      assert(false && "Unhandled Demangle node kind");
+    }
+  };
+
+  auto result = impl();
+  if (!m_swift_ast_context)
+    return result;
+  auto cmp_type = ReconstructType(type);
+  if (!cmp_type)
+    return result;
+  StreamString cmp_s;
+  bool equivalent =
+      Equivalent(result, m_swift_ast_context->DumpTypeValue(
+                             ReconstructType(type), &cmp_s, format, data,
+                             data_offset, data_byte_size, bitfield_bit_size,
+                             bitfield_bit_offset, exe_scope, is_base_class)) &&
+      Equivalent(ConstString(cmp_s.GetString()),
+                 ConstString(((StreamString *)s)->GetString()));
+  if (!equivalent)
+    llvm::dbgs() << "failing type was " << (const char *)type << "\n";
+  assert(equivalent && "TypeSystemSwiftTypeRef diverges from SwiftASTContext");
+  return result;
 }
 
 void TypeSystemSwiftTypeRef::DumpTypeDescription(opaque_compiler_type_t type,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2781,7 +2781,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     case Node::Kind::BoundGenericStructure:
       return false;
     default:
-      assert(false && "Unhandled node kind");
+      llvm_unreachable("Unhandled node kind");
       LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
                 "DumpTypeValue: Unhandled node kind for type %s",
                 AsMangledName(type));

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2779,24 +2779,18 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     }
   };
 
-  auto result = impl();
-  if (!m_swift_ast_context)
-    return result;
-  auto cmp_type = ReconstructType(type);
-  if (!cmp_type)
-    return result;
-  StreamString cmp_s;
-  bool equivalent =
-      Equivalent(result, m_swift_ast_context->DumpTypeValue(
-                             ReconstructType(type), &cmp_s, format, data,
-                             data_offset, data_byte_size, bitfield_bit_size,
-                             bitfield_bit_offset, exe_scope, is_base_class)) &&
-      Equivalent(ConstString(cmp_s.GetString()),
-                 ConstString(((StreamString *)s)->GetString()));
-  if (!equivalent)
-    llvm::dbgs() << "failing type was " << (const char *)type << "\n";
-  assert(equivalent && "TypeSystemSwiftTypeRef diverges from SwiftASTContext");
-  return result;
+#ifndef NDEBUG
+  StreamString ast_s;
+  auto defer = llvm::make_scope_exit([&] {
+    assert(Equivalent(ConstString(ast_s.GetString()),
+                      ConstString(((StreamString *)s)->GetString())) &&
+           "TypeSystemSwiftTypeRef diverges from SwiftASTContext");
+  });
+#endif
+  VALIDATE_AND_RETURN(impl, DumpTypeValue, type,
+                      (ReconstructType(type), &ast_s, format, data, data_offset,
+                       data_byte_size, bitfield_bit_size, bitfield_bit_offset,
+                       exe_scope, is_base_class));
 }
 
 void TypeSystemSwiftTypeRef::DumpTypeDescription(opaque_compiler_type_t type,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -327,6 +327,9 @@ private:
                              const char *mangled_name,
                              bool resolve_objc_module);
 
+  CompilerType GetReferentType(swift::Demangle::Demangler &dem,
+                               swift::Demangle::NodePointer node);
+
   /// Return an APINotes manager for the module with module id \id.
   /// APINotes are used to get at the SDK swiftification annotations.
   clang::api_notes::APINotesManager *

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -327,9 +327,6 @@ private:
                              const char *mangled_name,
                              bool resolve_objc_module);
 
-  CompilerType GetReferentType(swift::Demangle::Demangler &dem,
-                               swift::Demangle::NodePointer node);
-
   /// Return an APINotes manager for the module with module id \id.
   /// APINotes are used to get at the SDK swiftification annotations.
   clang::api_notes::APINotesManager *


### PR DESCRIPTION
Implement `TypeSystemSwiftTypeRef::DumpTypeValue` to match `SwiftASTContext`.

rdar://68171421
