### PR TITLE
[lldb] Replace an llvm_unreachable with assert in TypeSystemSwiftTypeRef

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2783,7 +2783,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     case Node::Kind::BoundGenericStructure:
       return false;
     default:
-      llvm_unreachable("Unhandled node kind");
+      assert(false && "Unhandled node kind");
       LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
                 "DumpTypeValue: Unhandled node kind for type %s",
                 AsMangledName(type));


### PR DESCRIPTION
Replace `llvm_unreachable` with `assert(false)` in TypeSystemSwiftTypeRef.