### PR TITLE
[lldb] Add enum support to TypeSystemSwiftTypeRef::DumpTypeValue

### DIFF
--- a/lldb/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/lldb/include/lldb/Target/SwiftLanguageRuntime.h
@@ -256,6 +256,10 @@ public:
   llvm::Optional<unsigned> GetNumChildren(CompilerType type,
                                           ValueObject *valobj);
 
+  llvm::Optional<std::string> GetEnumCaseName(CompilerType type,
+                                              const DataExtractor &data,
+                                              ExecutionContext *exe_ctx);
+
   llvm::Optional<size_t> GetIndexOfChildMemberWithName(
       CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
       bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes);

--- a/lldb/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/lldb/include/lldb/Target/SwiftLanguageRuntime.h
@@ -256,6 +256,8 @@ public:
   llvm::Optional<unsigned> GetNumChildren(CompilerType type,
                                           ValueObject *valobj);
 
+  /// Determine the enum case name for the \p data value of the enum \p type.
+  /// This is performed using Swift reflection.
   llvm::Optional<std::string> GetEnumCaseName(CompilerType type,
                                               const DataExtractor &data,
                                               ExecutionContext *exe_ctx);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2786,7 +2786,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     size_t data_byte_size, uint32_t bitfield_bit_size,
     uint32_t bitfield_bit_offset, ExecutionContextScope *exe_scope,
     bool is_base_class) {
-  auto impl = [&]() -> bool {
+  auto impl = [&]() -> llvm::Optional<bool> {
     if (!type)
       return false;
 
@@ -2892,17 +2892,34 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
   };
 
 #ifndef NDEBUG
+  auto result = impl();
+  if (!result) {
+    if (!m_swift_ast_context)
+      return false;
+    // Swift reflection provided no result, fallback to the AST.
+    return m_swift_ast_context->DumpTypeValue(
+        ReconstructType(type), s, format, data, data_offset, data_byte_size,
+        bitfield_bit_size, bitfield_bit_offset, exe_scope, is_base_class);
+  }
+  auto ast_type = ReconstructType(type);
+  if (!ast_type)
+    return false; /* missing .swiftmodule */
   StreamString ast_s;
-  auto defer = llvm::make_scope_exit([&] {
-    assert(Equivalent(ConstString(ast_s.GetString()),
-                      ConstString(((StreamString *)s)->GetString())) &&
-           "TypeSystemSwiftTypeRef diverges from SwiftASTContext");
-  });
+  bool eq_result =
+      Equivalent(result, m_swift_ast_context->DumpTypeValue(
+                             ast_type, &ast_s, format, data, data_offset,
+                             data_byte_size, bitfield_bit_size,
+                             bitfield_bit_offset, exe_scope, is_base_class));
+  bool eq_stream = Equivalent(ConstString(ast_s.GetString()),
+                              ConstString(((StreamString *)s)->GetString()));
+  if (!eq_result || !eq_stream)
+    llvm::dbgs() << "failing type was " << (const char *)type << "\n";
+  assert(eq_result && eq_stream &&
+         "TypeSystemSwiftTypeRef diverges from SwiftASTContext");
+  return *result;
+#else
+  return impl().getValueOr(false);
 #endif
-  VALIDATE_AND_RETURN(impl, DumpTypeValue, type,
-                      (ReconstructType(type), &ast_s, format, data, data_offset,
-                       data_byte_size, bitfield_bit_size, bitfield_bit_offset,
-                       exe_scope, is_base_class));
 }
 
 void TypeSystemSwiftTypeRef::DumpTypeDescription(opaque_compiler_type_t type,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2452,9 +2452,9 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
       ast_child_name = suffix.str();
     assert((llvm::StringRef(child_name).contains('.') ||
             Equivalent(child_name, ast_child_name)));
-    assert((Equivalent(llvm::Optional<uint64_t>(child_byte_size),
-                       llvm::Optional<uint64_t>(ast_child_byte_size)) ||
-            ast_language_flags));
+    assert(ast_language_flags ||
+           (Equivalent(llvm::Optional<uint64_t>(child_byte_size),
+                       llvm::Optional<uint64_t>(ast_child_byte_size))));
     assert(Equivalent(llvm::Optional<uint64_t>(child_byte_offset),
                       llvm::Optional<uint64_t>(ast_child_byte_offset)));
     assert(

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -259,6 +259,13 @@ public:
     return {};
   }
 
+  llvm::Optional<std::string> GetEnumCaseName(CompilerType type,
+                                              const DataExtractor &data,
+                                              ExecutionContext *exe_ctx) {
+    STUB_LOG();
+    return {};
+  }
+
   llvm::Optional<size_t> GetIndexOfChildMemberWithName(
       CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
       bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
@@ -2166,6 +2173,11 @@ llvm::Optional<uint64_t> SwiftLanguageRuntime::GetMemberVariableOffset(
 llvm::Optional<unsigned>
 SwiftLanguageRuntime::GetNumChildren(CompilerType type, ValueObject *valobj) {
   FORWARD(GetNumChildren, type, valobj);
+}
+
+llvm::Optional<std::string> SwiftLanguageRuntime::GetEnumCaseName(
+    CompilerType type, const DataExtractor &data, ExecutionContext *exe_ctx) {
+  FORWARD(GetEnumCaseName, type, data, exe_ctx);
 }
 
 llvm::Optional<size_t> SwiftLanguageRuntime::GetIndexOfChildMemberWithName(

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1256,7 +1256,6 @@ llvm::Optional<std::string> SwiftLanguageRuntimeImpl::GetEnumCaseName(
   using namespace swift::reflection;
   using namespace swift::remote;
   auto *ti = GetTypeInfo(type, exe_ctx->GetFramePtr());
-  assert(ti->getKind() == TypeInfoKind::Enum && "Expected enum type");
   if (ti->getKind() != TypeInfoKind::Enum)
     return {};
 

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -292,7 +292,7 @@ public:
       } else {
         *result = 0;
       }
-      break;
+      return true;
     }
     case DLQ_GetPointerSize: {
       auto result = static_cast<uint8_t *>(outBuffer);
@@ -302,6 +302,15 @@ public:
     case DLQ_GetSizeSize: {
       auto result = static_cast<uint8_t *>(outBuffer);
       *result = m_process.GetAddressByteSize(); // FIXME: sizeof(size_t)
+      return true;
+    }
+    case DLQ_GetLeastValidPointerValue: {
+      auto *result = (uint64_t *)outBuffer;
+      auto &triple = m_process.GetTarget().GetArchitecture().GetTriple();
+      if (triple.isOSDarwin() && triple.isArch64Bit())
+        *result = 0x100000000;
+      else
+        *result = 0x1000;
       return true;
     }
     }

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -390,8 +390,8 @@ public:
                  uint64_t size) override {
     if (m_local_buffer) {
       auto addr = address.getAddressData();
-      if (addr >= m_local_buffer &&
-          addr + size <= m_local_buffer + m_local_buffer_size) {
+      if (addr >= *m_local_buffer &&
+          addr + size <= *m_local_buffer + m_local_buffer_size) {
         // If this crashes, the assumptions stated in
         // GetDynamicTypeAndAddress_Protocol() most likely no longer
         // hold.
@@ -481,7 +481,7 @@ public:
 
   void popLocalBuffer() {
     lldbassert(m_local_buffer);
-    m_local_buffer = 0;
+    m_local_buffer.reset();
     m_local_buffer_size = 0;
   }
 
@@ -489,7 +489,7 @@ private:
   Process &m_process;
   size_t m_max_read_amount;
 
-  uint64_t m_local_buffer = 0;
+  llvm::Optional<uint64_t> m_local_buffer;
   uint64_t m_local_buffer_size = 0;
 };
 

--- a/lldb/source/Target/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Target/SwiftLanguageRuntimeImpl.h
@@ -123,6 +123,10 @@ public:
   llvm::Optional<unsigned> GetNumFields(CompilerType type,
                                         ExecutionContext *exe_ctx);
 
+  llvm::Optional<std::string> GetEnumCaseName(CompilerType type,
+                                              const DataExtractor &data,
+                                              ExecutionContext *exe_ctx);
+
   llvm::Optional<size_t> GetIndexOfChildMemberWithName(
       CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
       bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes);

--- a/lldb/test/API/lang/swift/foundation_value_types/indexpath/TestSwiftFoundationTypeIndexPath.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/indexpath/TestSwiftFoundationTypeIndexPath.py
@@ -13,4 +13,4 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipIf(oslist=['windows'])])
+                          decorators=[swiftTest,skipIf(oslist=['windows', 'linux'])])

--- a/lldb/test/API/lang/swift/foundation_value_types/indexpath/main.swift
+++ b/lldb/test/API/lang/swift/foundation_value_types/indexpath/main.swift
@@ -20,7 +20,7 @@ func main() {
    //% self.expect("frame variable short_path", substrs=['2 indices'])
    //% self.expect("frame variable very_short_path", substrs=['1 index'])   
    //% self.expect("frame variable empty_path", substrs=['0 indices'])
-   // disabled self.expect("expression -d run -- path", substrs=['5 indices'])
+   //% self.expect("expression -d run -- path", substrs=['5 indices'])
 }
 
 main()

--- a/lldb/test/API/lang/swift/foundation_value_types/indexpath/main.swift
+++ b/lldb/test/API/lang/swift/foundation_value_types/indexpath/main.swift
@@ -20,7 +20,7 @@ func main() {
    //% self.expect("frame variable short_path", substrs=['2 indices'])
    //% self.expect("frame variable very_short_path", substrs=['1 index'])   
    //% self.expect("frame variable empty_path", substrs=['0 indices'])
-   //% self.expect("expression -d run -- path", substrs=['5 indices'])
+   // disabled self.expect("expression -d run -- path", substrs=['5 indices'])
 }
 
 main()


### PR DESCRIPTION
Complete the implementation of `TypeSystemSwiftTypeRef::DumpTypeValue` by adding enum support.

rdar://68171421