### PR TITLE
Add func call so we don't instruction-step into the builtin_trap

### DIFF
--- a/lldb/test/API/macosx/builtin-debugtrap/main.cpp
+++ b/lldb/test/API/macosx/builtin-debugtrap/main.cpp
@@ -3,6 +3,7 @@ int global = 0;
 int main()
 {
   global = 5; // Set a breakpoint here
+  puts("");
   __builtin_debugtrap();
   global = 10;
   __builtin_trap();


### PR DESCRIPTION
Add func call so we don't instruction-step into the builtin_trap

The way this test is structured right now, I set a breakpoint on
the instruction before the __builtin_trap.  It hits the breakpoint,
disables the breakpoint, and instruction steps.  This hits the
builtin_trap instruction which debugserver (on arm64) now advances
to the next instruction and reports that address to lldb.  lldb
doesn't recognize this as a proper response to the instruction
step and continues executing until the next trap, and the test fails.

(cherry picked from commit 885eae9d85de4b1b1907ac9b3ecba26565932069)