### PR TITLE
Skip 'g' packet tests when running on darwin; debugserver doesn't impl

### DIFF
--- a/lldb/test/API/tools/lldb-server/register-reading/TestGdbRemoteGPacket.py
+++ b/lldb/test/API/tools/lldb-server/register-reading/TestGdbRemoteGPacket.py
@@ -130,6 +130,7 @@ class TestGdbRemoteGPacket(gdbremote_testcase.GdbRemoteTestCaseBase):
 
     @expectedFailureAll(oslist=["freebsd"], bugnumber="llvm.org/pr48420")
     @expectedFailureNetBSD
+    @skipIfDarwin # g packet not supported
     def test_g_returns_correct_data_with_suffix(self):
         self.build()
         self.set_inferior_startup_launch()
@@ -137,6 +138,7 @@ class TestGdbRemoteGPacket(gdbremote_testcase.GdbRemoteTestCaseBase):
 
     @expectedFailureAll(oslist=["freebsd"], bugnumber="llvm.org/pr48420")
     @expectedFailureNetBSD
+    @skipIfDarwin # g packet not supported
     def test_g_returns_correct_data_no_suffix(self):
         self.build()
         self.set_inferior_startup_launch()


### PR DESCRIPTION
Skip 'g' packet tests when running on darwin; debugserver doesn't impl

Differential Revision: https://reviews.llvm.org/D94754

(cherry picked from commit 10ac9b29a4ca9e75bcbfa9576e3d8ee83cc9cd78)