### PR TITLE
[dsymutil] Compare object modification times using second precision

### DIFF
--- a/llvm/tools/dsymutil/BinaryHolder.cpp
+++ b/llvm/tools/dsymutil/BinaryHolder.cpp
@@ -100,7 +100,8 @@ Error BinaryHolder::ObjectEntry::load(IntrusiveRefCntPtr<vfs::FileSystem> VFS,
     llvm::ErrorOr<vfs::Status> Stat = VFS->status(Filename);
     if (!Stat)
       return errorCodeToError(Stat.getError());
-    if (Timestamp != Stat->getLastModificationTime())
+    if (Timestamp != std::chrono::time_point_cast<std::chrono::seconds>(
+                         Stat->getLastModificationTime()))
       WithColor::warning() << Filename
                            << ": timestamp mismatch between object file ("
                            << Stat->getLastModificationTime()
@@ -192,7 +193,8 @@ BinaryHolder::ArchiveEntry::getObjectEntry(StringRef Filename,
             return ModTimeOrErr.takeError();
 
           if (Timestamp != sys::TimePoint<>() &&
-              Timestamp != ModTimeOrErr.get()) {
+              Timestamp != std::chrono::time_point_cast<std::chrono::seconds>(
+                               ModTimeOrErr.get())) {
             if (Verbose)
               WithColor::warning()
                   << *NameOrErr


### PR DESCRIPTION
The modification time in the debug map is expressed using second
precision, while the modification time returned by the filesystem could
be more precise. Avoid spurious warnings about timestamp mismatches by
truncating the modification time reported by the system to seconds.

(cherry picked from commit f354b87df23799ee0b6c718894140c846eafc82d)
