### PR TITLE
[lldb] Fix compilation of CppModuleConfigurationTest

### DIFF
--- a/lldb/unittests/Expression/CppModuleConfigurationTest.cpp
+++ b/lldb/unittests/Expression/CppModuleConfigurationTest.cpp
@@ -20,11 +20,11 @@ using namespace lldb_private;
 
 namespace {
 struct CppModuleConfigurationTest : public testing::Test {
-  llvm::MemoryBufferRef m_empty_buffer;
+  std::unique_ptr<llvm::MemoryBuffer> m_empty_buffer;
   llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> m_fs;
 
   CppModuleConfigurationTest()
-      : m_empty_buffer("", "<empty buffer>"),
+      : m_empty_buffer(llvm::MemoryBuffer::getMemBuffer("", "<empty buffer>")),
         m_fs(new llvm::vfs::InMemoryFileSystem()) {}
 
   void SetUp() override {
@@ -42,7 +42,7 @@ struct CppModuleConfigurationTest : public testing::Test {
     FileSpecList result;
     for (const std::string &path : paths) {
       result.Append(FileSpec(path, FileSpec::Style::posix));
-      if (!m_fs->addFileNoOwn(path, static_cast<time_t>(0), m_empty_buffer))
+      if (!m_fs->addFileNoOwn(path, static_cast<time_t>(0), m_empty_buffer.get()))
         llvm_unreachable("Invalid test configuration?");
     }
     return result;


### PR DESCRIPTION
901966c21c92a289944602df9c2bbb3f1f4e3350 updated the test but the backport
commit was missing some changes to make the unit test compile (that I forgot to amend
and now block the automerger).