### PR TITLE
[clang] Downgrade err_nserrordomain_invalid_decl to a warning

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9751,6 +9751,8 @@ def err_nsreturns_retained_attribute_mismatch : Error<
   " attributes">;
 def err_nserrordomain_invalid_decl : Error<
   "domain argument %select{|%1 }0does not refer to global constant">;
+def warn_nserrordomain_invalid_decl : Warning<
+  "domain argument %select{|%1 }0does not refer to global constant">;
 def err_nserrordomain_wrong_type : Error<
   "domain argument %0 does not point to an NSString or CFString constant">;
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5545,7 +5545,7 @@ static void handleNSErrorDomain(Sema &S, Decl *D, const ParsedAttr &AL) {
 
   auto *DRE = dyn_cast<DeclRefExpr>(AL.getArgAsExpr(0));
   if (!DRE) {
-    S.Diag(Loc, diag::err_nserrordomain_invalid_decl) << 0;
+    S.Diag(Loc, diag::warn_nserrordomain_invalid_decl) << 0;
     return;
   }
 

--- a/clang/test/Sema/ns_error_enum.m
+++ b/clang/test/Sema/ns_error_enum.m
@@ -74,7 +74,7 @@ typedef NS_ERROR_ENUM(unsigned char, MyErrorEnumInvalid, InvalidDomain) {
 };
 
 typedef NS_ERROR_ENUM(unsigned char, MyErrorEnumInvalid, "domain-string");
-  // expected-error@-1{{domain argument does not refer to global constant}}
+  // expected-warning@-1{{domain argument does not refer to global constant}}
 
 void foo() {}
 typedef NS_ERROR_ENUM(unsigned char, MyErrorEnumInvalidFunction, foo);


### PR DESCRIPTION
Recent changes to the `ns_error_domain` logic requires the error domain
symbol to be defined before enums referring to it. Temporarily downgrade
the `err_nserrordomain_invalid_decl` error to a warning when the decl is
not found until the code affected by this is updated.