### PR TITLE
Change static buffer to be BSS instead of DATA in HandlePacket_qSpeedTest

### DIFF
--- a/lldb/tools/debugserver/source/RNBRemote.cpp
+++ b/lldb/tools/debugserver/source/RNBRemote.cpp
@@ -4578,7 +4578,8 @@ rnb_err_t RNBRemote::HandlePacket_qSpeedTest(const char *p) {
         __FILE__, __LINE__, p,
         "Didn't find response_size value at right offset");
   else if (*end == ';') {
-    static char g_data[4 * 1024 * 1024 + 16] = "data:";
+    static char g_data[4 * 1024 * 1024 + 16];
+    strcpy(g_data, "data:");
     memset(g_data + 5, 'a', response_size);
     g_data[response_size + 5] = '\0';
     return SendPacket(g_data);


### PR DESCRIPTION
Change static buffer to be BSS instead of DATA in HandlePacket_qSpeedTest

Having this 4MB buffer with a compile-time initialized string forced it
into the DATA section and it took up 4MB of space in the binary, which
accounts for like 80% of debugserver's footprint on disk.  Change it to
BSS and strcpy in the initial value at runtime instead.

<rdar://problem/73503892>

(cherry picked from commit ad25bdcb8e4e9459886062d3855a5971af758731)