### PR TITLE
[clang] Only use warn_nserrordomain_invalid_decl for APINotes

### DIFF
--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -357,7 +357,7 @@ static void ProcessAPINotes(Sema &S, Decl *D,
           auto *VD = lookupResult.getAsSingle<VarDecl>();
 
           if (!VD) {
-            S.Diag(D->getLocation(), diag::err_nserrordomain_invalid_decl) << 0;
+            S.Diag(D->getLocation(), diag::warn_nserrordomain_invalid_decl) << 0;
             return nullptr;
           }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5545,7 +5545,7 @@ static void handleNSErrorDomain(Sema &S, Decl *D, const ParsedAttr &AL) {
 
   auto *DRE = dyn_cast<DeclRefExpr>(AL.getArgAsExpr(0));
   if (!DRE) {
-    S.Diag(Loc, diag::warn_nserrordomain_invalid_decl) << 0;
+    S.Diag(Loc, diag::err_nserrordomain_invalid_decl) << 0;
     return;
   }
 

--- a/clang/test/Sema/ns_error_enum.m
+++ b/clang/test/Sema/ns_error_enum.m
@@ -74,7 +74,7 @@ typedef NS_ERROR_ENUM(unsigned char, MyErrorEnumInvalid, InvalidDomain) {
 };
 
 typedef NS_ERROR_ENUM(unsigned char, MyErrorEnumInvalid, "domain-string");
-  // expected-warning@-1{{domain argument does not refer to global constant}}
+  // expected-error@-1{{domain argument does not refer to global constant}}
 
 void foo() {}
 typedef NS_ERROR_ENUM(unsigned char, MyErrorEnumInvalidFunction, foo);


### PR DESCRIPTION
Only warn on an invalid error domain set via APINotes as a temporary workaround until clients are updated.

This is fix for the workaround in #2368.