### PR TITLE
Fix crash when emitting NullReturn guards for functions returning BOOL

### DIFF
--- a/clang/lib/CodeGen/CGObjCMac.cpp
+++ b/clang/lib/CodeGen/CGObjCMac.cpp
@@ -1800,7 +1800,8 @@ struct NullReturnState {
     // If we've got a scalar return, build a phi.
     if (result.isScalar()) {
       // Derive the null-initialization value.
-      llvm::Constant *null = CGF.CGM.EmitNullConstant(resultType);
+      llvm::Value *null =
+          CGF.EmitFromMemory(CGF.CGM.EmitNullConstant(resultType), resultType);
 
       // If no join is necessary, just flow out.
       if (!contBB) return RValue::get(null);

--- a/clang/test/CodeGenObjC/null-check-bool-ret.m
+++ b/clang/test/CodeGenObjC/null-check-bool-ret.m
@@ -1,0 +1,38 @@
+// RUN: %clang_cc1 -triple arm64e-apple-ios15.0.0 -emit-llvm-bc -fobjc-arc -disable-llvm-passes %s -emit-llvm -o - | FileCheck %s
+
+// rdar://73361264
+
+@protocol NSObject
+@end
+
+@interface NSObject <NSObject>
+@end
+
+@interface WidgetTester : NSObject
+@end
+
+@implementation WidgetTester
+
+typedef struct {
+    NSObject* impl;
+} widget_t;
+
+- (_Bool)withWidget:(widget_t)widget {
+    return 0;
+}
+
+- (_Bool)testWidget:(widget_t)widget {
+    return [self withWidget:widget];
+}
+
+@end
+
+// CHECK-LABEL: msgSend.call:
+// CHECK: [[CALL:%[^ ]+]] = call i1 bitcast (i8* (i8*, i8*, ...)* @objc_msgSend to
+// CHECK-NEXT: br label %msgSend.cont
+
+// CHECK-LABEL: msgSend.null-receiver:
+// CHECK: br label %msgSend.cont
+
+// CHECK-LABEL: msgSend.cont:
+// CHECK-NEXT: {{%[^ ]+}} = phi i1 [ [[CALL]], %msgSend.call ], [ false, %msgSend.null-receiver ]


### PR DESCRIPTION
CodeGenModule::EmitNullConstant() creates constants with their "in memory"
type, not their "in vregs" type. The one place where this difference matters is
when the type is _Bool, as that is an i1 when in vregs and an i8 in memory.

Fixes: rdar://73361264

Cherry-picks upstream commit: 1deee5cacbb76578367186d7ff2937b6fa79b827