### PR TITLE
Add a setting to opt out of the TypeRef typesystem. (NFC-ish)

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -58,6 +58,8 @@ public:
   bool GetUseSwiftClangImporter() const;
   bool GetUseSwiftDWARFImporter() const;
   bool SetUseSwiftDWARFImporter(bool new_value);
+  bool GetUseSwiftTypeRefTypeSystem() const;
+  bool SetUseSwiftTypeRefTypeSystem(bool new_value);
   FileSpec GetClangModulesCachePath() const;
   SwiftModuleLoadingMode GetSwiftModuleLoadingMode() const;
   bool SetSwiftModuleLoadingMode(SwiftModuleLoadingMode);

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -16,6 +16,9 @@ let Definition = "modulelist" in {
   def UseSwiftDWARFImporter: Property<"use-swift-dwarfimporter", "Boolean">,
     DefaultTrue,
     Desc<"Reconstruct Clang module dependencies from DWARF when debugging Swift code">;
+  def UseSwiftTypeRefTypeSystem: Property<"use-swift-typeref-typesystem", "Boolean">,
+    DefaultTrue,
+    Desc<"Prefer Swift Remote Mirrors over Remote AST">;
   def SwiftModuleLoadingMode: Property<"swift-module-loading-mode", "Enum">,
     DefaultEnumValue<"eSwiftModuleLoadingModePreferSerialized">,
     EnumValues<"OptionEnumValues(g_swift_module_loading_mode_enums)">,

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -145,6 +145,17 @@ bool ModuleListProperties::SetUseSwiftDWARFImporter(bool new_value) {
     return m_collection_sp->SetPropertyAtIndexAsBoolean(
             nullptr, ePropertyUseSwiftDWARFImporter, new_value);
 }
+
+bool ModuleListProperties::GetUseSwiftTypeRefTypeSystem() const {
+  const uint32_t idx = ePropertyUseSwiftTypeRefTypeSystem;
+  return m_collection_sp->GetPropertyAtIndexAsBoolean(
+      NULL, idx, g_modulelist_properties[idx].default_uint_value != 0);
+}
+
+bool ModuleListProperties::SetUseSwiftTypeRefTypeSystem(bool new_value) {
+    return m_collection_sp->SetPropertyAtIndexAsBoolean(
+            nullptr, ePropertyUseSwiftTypeRefTypeSystem, new_value);
+}
 // END SWIFT
 
 bool ModuleListProperties::SetClangModulesCachePath(const FileSpec &path) {


### PR DESCRIPTION
Since the new typesystem is exercising some not so battle-hardened
code in the Swift compiler, this setting will allow end-users to
reroute all traffic to SwiftASTContext should this become necessary.

rdar://73521306