### PR TITLE
[YAML I/O] Fix bug in emission of empty sequence

### DIFF
--- a/llvm/include/llvm/Support/YAMLTraits.h
+++ b/llvm/include/llvm/Support/YAMLTraits.h
@@ -1586,7 +1586,7 @@ public:
 private:
   void output(StringRef s);
   void outputUpToEndOfLine(StringRef s);
-  void newLineCheck();
+  void newLineCheck(bool EmptySequence = false);
   void outputNewLine();
   void paddedKey(StringRef key);
   void flowKey(StringRef Key);

--- a/llvm/lib/Support/YAMLTraits.cpp
+++ b/llvm/lib/Support/YAMLTraits.cpp
@@ -592,7 +592,7 @@ void Output::endSequence() {
   // If we did not emit anything, we should explicitly emit an empty sequence
   if (StateStack.back() == inSeqFirstElement) {
     Padding = PaddingBeforeContainer;
-    newLineCheck();
+    newLineCheck(/*EmptySequence=*/true);
     output("[]");
     Padding = "\n";
   }
@@ -798,7 +798,7 @@ void Output::outputNewLine() {
 // if seq in middle, use "- " if firstKey, else use "  "
 //
 
-void Output::newLineCheck() {
+void Output::newLineCheck(bool EmptySequence) {
   if (Padding != "\n") {
     output(Padding);
     Padding = {};
@@ -807,7 +807,7 @@ void Output::newLineCheck() {
   outputNewLine();
   Padding = {};
 
-  if (StateStack.size() == 0)
+  if (StateStack.size() == 0 || EmptySequence)
     return;
 
   unsigned Indent = StateStack.size() - 1;
@@ -831,7 +831,6 @@ void Output::newLineCheck() {
   if (OutputDash) {
     output("- ");
   }
-
 }
 
 void Output::paddedKey(StringRef key) {

--- a/llvm/unittests/Support/YAMLIOTest.cpp
+++ b/llvm/unittests/Support/YAMLIOTest.cpp
@@ -2691,12 +2691,23 @@ TEST(YAMLIO, TestEmptyMapWrite) {
 }
 
 TEST(YAMLIO, TestEmptySequenceWrite) {
-  FooBarContainer cont;
-  std::string str;
-  llvm::raw_string_ostream OS(str);
-  Output yout(OS);
-  yout << cont;
-  EXPECT_EQ(OS.str(), "---\nfbs:             []\n...\n");
+  {
+    FooBarContainer cont;
+    std::string str;
+    llvm::raw_string_ostream OS(str);
+    Output yout(OS);
+    yout << cont;
+    EXPECT_EQ(OS.str(), "---\nfbs:             []\n...\n");
+  }
+
+  {
+    FooBarSequence seq;
+    std::string str;
+    llvm::raw_string_ostream OS(str);
+    Output yout(OS);
+    yout << seq;
+    EXPECT_EQ(OS.str(), "---\n[]\n...\n");
+  }
 }
 
 static void TestEscaped(llvm::StringRef Input, llvm::StringRef Expected) {


### PR DESCRIPTION
Don't emit an output dash for an empty sequence. Take emitting a vector
of strings for example:

  std::vector<std::string> Strings = {"foo", "bar"};
  LLVM_YAML_IS_SEQUENCE_VECTOR(std::string)
  yout << Strings;

This emits the following YAML document.

  ---
  - foo
  - bar
  ...

When the vector is empty, this generates the following result:

  ---
  - []
  ...

Although this is valid YAML, it does not match what we meant to emit.
The result is a one-element sequence consisting of an empty list.
Indeed, if we were to try to read this again we get an error:

  YAML:2:4: error: not a mapping
  - []

The problem is the output dash before the empty list. The correct output
would be:

  ---
  []
  ...

This patch fixes that by not emitting the output dash for an empty
sequence.

Differential revision: https://reviews.llvm.org/D95280

(cherry picked from commit f50b8ee71faeb5056df7a950e7427f3047ff9987)
