### PR TITLE
[lldb] Use explicit no-run for TestSwiftProtocolExtensionSelf

### DIFF
--- a/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
+++ b/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
@@ -15,4 +15,6 @@ class TestSwiftProtocolExtensionSelf(TestBase):
 
         lldbutil.run_to_source_breakpoint(self, "break here",
                                           lldb.SBFileSpec('main.swift'))
+        # This should work without dynamic types. For discussion, see:
+        # https://github.com/apple/llvm-project/pull/2382
         self.expect("e -d no-run -- f", substrs=[' = 12345'])

--- a/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
+++ b/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
@@ -15,4 +15,4 @@ class TestSwiftProtocolExtensionSelf(TestBase):
 
         lldbutil.run_to_source_breakpoint(self, "break here",
                                           lldb.SBFileSpec('main.swift'))
-        self.expect("e f", substrs=[' = 12345'])
+        self.expect("e -d no-run -- f", substrs=[' = 12345'])


### PR DESCRIPTION
The lldb test configuration states:

```
# Always disable default dynamic types for testing purposes.
settings = [('target.prefer-dynamic-value', 'no-dynamic-values')]
```

I'm not sure if this is a recent change, but this setting causes this test to fail. By using `-d no-run`, to get the dynamic type, this test once again passes.

rdar://73214601