### PR TITLE
[lldb] Add move_iterator to supported template list

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/CxxModuleHandler.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/CxxModuleHandler.cpp
@@ -33,6 +33,9 @@ CxxModuleHandler::CxxModuleHandler(ASTImporter &importer, ASTContext *target)
       "shared_ptr",
       "unique_ptr",
       "weak_ptr",
+      // iterator
+      "move_iterator",
+      "__wrap_iter",
       // utility
       "allocator",
       "pair",

--- a/lldb/test/API/commands/expression/import-std-module/iterator/Makefile
+++ b/lldb/test/API/commands/expression/import-std-module/iterator/Makefile
@@ -1,0 +1,4 @@
+USE_LIBCPP := 1
+CXX_SOURCES := main.cpp
+CXXFLAGS_EXTRAS := -std=c++11
+include Makefile.rules

--- a/lldb/test/API/commands/expression/import-std-module/iterator/TestIteratorFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/iterator/TestIteratorFromStdModule.py
@@ -1,0 +1,35 @@
+"""
+Tests standard library iterators.
+"""
+
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @add_test_categories(["libc++"])
+    @skipIf(compiler=no_match("clang"))
+    def test(self):
+        self.build()
+
+        lldbutil.run_to_source_breakpoint(self,
+                                          "// Set break point at this line.",
+                                          lldb.SBFileSpec("main.cpp"))
+
+        self.runCmd("settings set target.import-std-module true")
+
+        iter_type = "std::move_iterator<std::__wrap_iter<int *> >"
+
+        self.expect_expr("move_begin", result_type=iter_type)
+        self.expect_expr("move_begin[0]", result_type="int", result_value="1")
+
+        self.expect_expr("move_begin + 3 == move_end", result_value="true")
+
+        self.expect("expr move_begin++")
+        self.expect_expr("move_begin + 2 == move_end", result_value="true")
+        self.expect("expr move_begin--")
+        self.expect_expr("move_begin + 3 == move_end", result_value="true")

--- a/lldb/test/API/commands/expression/import-std-module/iterator/main.cpp
+++ b/lldb/test/API/commands/expression/import-std-module/iterator/main.cpp
@@ -1,0 +1,9 @@
+#include <iterator>
+#include <vector>
+
+int main() {
+  std::vector<int> v{1, 2, 3};
+  auto move_begin = std::make_move_iterator(v.begin());
+  auto move_end = std::make_move_iterator(v.end());
+  return 0; // Set break point at this line.
+}


### PR DESCRIPTION
Identical to previous commits that just add a standard library template to the
supported template list and test it. Adding this rather obscure class to the
template list is mostly caused by the std::deque test unexpectedly referencing
this type when testing against newer libc++ versions on macOS.

Fixes TestQueueFromStdModule and TestQueueFromStdModule on macOS.
Fixes rdar://73213589

(cherry picked from commit e2a1a718bbe406289adb695348d2cf8085dfaf25)