### PR TITLE
[lldb] Tweak C enum declaration for enum_objc portability

### DIFF
--- a/lldb/test/API/lang/swift/enum_objc/enum.h
+++ b/lldb/test/API/lang/swift/enum_objc/enum.h
@@ -1,10 +1,10 @@
-typedef enum __attribute__((enum_extensibility(closed))) ComparisonResult : long ComparisonResult; enum ComparisonResult : long {
+enum __attribute__((enum_extensibility(closed))) ComparisonResult : long {
     OrderedAscending = -1L,
     OrderedSame,
     OrderedDescending
 };
 
-ComparisonResult getReturn(long x) {
+enum ComparisonResult getReturn(long x) {
   switch (x) {
     case 0:
       return OrderedSame;


### PR DESCRIPTION
Apparently specifying the underlying type for an enum (when language permitted) is not always permitted in a forward declaration (such as in a `typedef`), instead it should be only in the actual declaration.

So instead of:

```objc
typedef enum E : long E;
enum E : long {
  // ...
};
```

the more portable way is to write:

```objc
typedef enum E;
enum E : long {
  // ...
};
```

Instead of using compiler conditionals, as is done in macros like `NS_ENUM`, this change removes the `typedef` altogether.

More info here https://github.com/llvm/llvm-project/commit/d6425e2c14370ecb5e2a4be4cfdef65f8ae69bd0.

rdar://73689333