### PR TITLE
[lldb] Use `foo is None` instead of `not foo` in darwin.py

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -43,12 +43,12 @@ def get_triple():
 
     # Get the SDK from the os and env.
     sdk = lldbutil.get_xcode_sdk(os, env)
-    if not sdk:
+    if sdk is None:
         return None, None, None, None
 
     # Get the version from the SDK.
     version = lldbutil.get_xcode_sdk_version(sdk)
-    if not version:
+    if version is None:
         return None, None, None, None
 
     return vendor, os, version, env
@@ -86,7 +86,7 @@ class BuilderDarwin(Builder):
         """Returns the ARCH_CFLAGS for the make system."""
         # Get the triple components.
         vendor, os, version, env = get_triple()
-        if not vendor or not os or not version or not env:
+        if vendor is None or os is None or version is None or env is None:
             return ""
 
         # Construct the triple from its components.


### PR DESCRIPTION
Explicitly compare to None when checking the triple's components so we
don't bail out when one of them is the empty string.

(cherry picked from commit b2545b71d121ac913e56faff3b704f3957f941b7)
