### PR TITLE
Static analyzer cherrypicks 17

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/AssertSideEffectCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/AssertSideEffectCheck.cpp
@@ -117,7 +117,8 @@ void AssertSideEffectCheck::check(const MatchFinder::MatchResult &Result) {
   if (AssertMacroName.empty())
     return;
 
-  diag(Loc, "found %0() with side effect") << AssertMacroName;
+  diag(Loc, "side effect in %0() condition discarded in release builds")
+      << AssertMacroName;
 }
 
 } // namespace bugprone

--- a/clang-tools-extra/clang-tidy/bugprone/AssertSideEffectCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/AssertSideEffectCheck.cpp
@@ -72,7 +72,8 @@ AssertSideEffectCheck::AssertSideEffectCheck(StringRef Name,
                                              ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
       CheckFunctionCalls(Options.get("CheckFunctionCalls", false)),
-      RawAssertList(Options.get("AssertMacros", "assert")) {
+      RawAssertList(Options.get("AssertMacros",
+                                "assert,NSAssert,NSCAssert")) {
   StringRef(RawAssertList).split(AssertMacros, ",", -1, false);
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone-assert-side-effect.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone-assert-side-effect.cpp
@@ -68,47 +68,47 @@ int main() {
   assert(X == 1);
 
   assert(X = 1);
-  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() with side effect [bugprone-assert-side-effect]
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: side effect in assert() condition discarded in release builds [bugprone-assert-side-effect]
   my_assert(X = 1);
-  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found my_assert() with side effect
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: side effect in my_assert() condition discarded in release builds
   convoluted_assert(X = 1);
-  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found convoluted_assert() with side effect
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: side effect in convoluted_assert() condition discarded in release builds
   not_my_assert(X = 1);
 
   assert(++X);
-  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() with side effect
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: side effect in assert() condition discarded in release builds
   assert(!B);
 
   assert(B || true);
 
   assert(freeFunction());
-  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() with side effect
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: side effect in assert() condition discarded in release builds
 
   MyClass mc;
   assert(mc.badFunc(0, 1));
-  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() with side effect
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: side effect in assert() condition discarded in release builds
   assert(mc.goodFunc(0, 1));
 
   MyClass mc2;
   assert(mc2 = mc);
-  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() with side effect
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: side effect in assert() condition discarded in release builds
 
   assert(-mc > 0);
 
   MyClass *mcp;
   assert(mcp = new MyClass);
-  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() with side effect
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: side effect in assert() condition discarded in release builds
 
   assert((delete mcp, false));
-  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() with side effect
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: side effect in assert() condition discarded in release builds
 
   assert((throw 1, false));
-  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() with side effect
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: side effect in assert() condition discarded in release builds
 
   assert2(1 == 2 - 1);
 
   msvc_assert(mc2 = mc);
-  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found msvc_assert() with side effect
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: side effect in msvc_assert() condition discarded in release builds
 
   return 0;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone-assert-side-effect.m
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone-assert-side-effect.m
@@ -1,0 +1,53 @@
+// RUN: %check_clang_tidy %s bugprone-assert-side-effect %t
+
+int abort();
+
+@interface NSObject
+@end
+
+@interface NSString
+@end
+
+@interface NSAssertionHandler
++ (NSAssertionHandler *)currentHandler;
+- handleFailureInMethod:(SEL)cmd object:(NSObject *)obj desc:(NSString *)desc;
+- handleFailureInFunction:(NSString *)desc;
+@end
+
+#ifndef NDEBUG
+#define NSAssert(condition, description, ...)                                    \
+  do {                                                                           \
+    if (__builtin_expect(!(condition), 0)) {                                     \
+      [[NSAssertionHandler currentHandler] handleFailureInMethod:_cmd            \
+                                                          object:self            \
+                                                            desc:(description)]; \
+    }                                                                            \
+  } while (0);
+#define NSCAssert(condition, description, ...)                                     \
+  do {                                                                             \
+    if (__builtin_expect(!(condition), 0)) {                                       \
+      [[NSAssertionHandler currentHandler] handleFailureInFunction:(description)]; \
+    }                                                                              \
+  } while (0);
+#else
+#define NSAssert(condition, description, ...) do {} while (0)
+#define NSCAssert(condition, description, ...) do {} while (0)
+#endif
+
+@interface I : NSObject
+- (void)foo;
+@end
+
+@implementation I
+- (void)foo {
+  int x = 0;
+  NSAssert((++x) == 1, @"Ugh.");
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: side effect in NSAssert() condition discarded in release builds [bugprone-assert-side-effect]
+}
+@end
+
+void foo() {
+  int x = 0;
+  NSCAssert((++x) == 1, @"Ugh.");
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: side effect in NSCAssert() condition discarded in release builds [bugprone-assert-side-effect]
+}

--- a/clang/include/clang/Analysis/PathDiagnostic.h
+++ b/clang/include/clang/Analysis/PathDiagnostic.h
@@ -68,11 +68,11 @@ struct PathDiagnosticConsumerOptions {
   /// Whether to include additional information about macro expansions
   /// with the diagnostics, because otherwise they can be hard to obtain
   /// without re-compiling the program under analysis.
-  bool ShouldDisplayMacroExpansions;
+  bool ShouldDisplayMacroExpansions = false;
 
   /// Whether to include LLVM statistics of the process in the diagnostic.
   /// Useful for profiling the tool on large real-world codebases.
-  bool ShouldSerializeStats;
+  bool ShouldSerializeStats = false;
 
   /// If the consumer intends to produce multiple output files, should it
   /// use randomly generated file names for these files (with the tiny risk of
@@ -82,21 +82,19 @@ struct PathDiagnosticConsumerOptions {
   /// because deterministic mode is always superior when done right, but
   /// for some consumers this mode is experimental and needs to be
   /// off by default.
-  bool ShouldWriteStableReportFilename;
+  bool ShouldWriteStableReportFilename = false;
 
   /// Whether the consumer should treat consumed diagnostics as hard errors.
   /// Useful for breaking your build when issues are found.
-  bool ShouldDisplayWarningsAsErrors;
+  bool ShouldDisplayWarningsAsErrors = false;
 
   /// Whether the consumer should attempt to rewrite the source file
   /// with fix-it hints attached to the diagnostics it consumes.
-  bool ShouldApplyFixIts;
+  bool ShouldApplyFixIts = false;
 
   /// Whether the consumer should present the name of the entity that emitted
   /// the diagnostic (eg., a checker) so that the user knew how to disable it.
-  bool ShouldDisplayDiagnosticName;
-
-  PathDiagnosticConsumerOptions() = delete;
+  bool ShouldDisplayDiagnosticName = false;
 };
 
 class PathDiagnosticConsumer {

--- a/clang/include/clang/StaticAnalyzer/Core/BugReporter/CommonBugCategories.h
+++ b/clang/include/clang/StaticAnalyzer/Core/BugReporter/CommonBugCategories.h
@@ -19,6 +19,7 @@ extern const char *const MemoryRefCount;
 extern const char *const MemoryError;
 extern const char *const UnixAPI;
 extern const char *const CXXObjectLifecycle;
+extern const char *const CXXMoveSemantics;
 extern const char *const SecurityError;
 } // namespace categories
 } // namespace ento

--- a/clang/lib/Analysis/CalledOnceCheck.cpp
+++ b/clang/lib/Analysis/CalledOnceCheck.cpp
@@ -936,8 +936,9 @@ private:
 
   /// Return true if the only parameter of the function is conventional.
   static bool isOnlyParameterConventional(const FunctionDecl *Function) {
-    return Function->getNumParams() == 1 &&
-           hasConventionalSuffix(Function->getName());
+    IdentifierInfo *II = Function->getIdentifier();
+    return Function->getNumParams() == 1 && II &&
+           hasConventionalSuffix(II->getName());
   }
 
   /// Return true/false if 'swift_async' attribute states that the given

--- a/clang/lib/StaticAnalyzer/Checkers/MoveChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MoveChecker.cpp
@@ -202,7 +202,7 @@ public:
   };
 
 private:
-  mutable std::unique_ptr<BugType> BT;
+  BugType BT{this, "Use-after-move", categories::CXXMoveSemantics};
 
   // Check if the given form of potential misuse of a given object
   // should be reported. If so, get it reported. The callback from which
@@ -393,11 +393,6 @@ ExplodedNode *MoveChecker::reportBug(const MemRegion *Region,
                                      MisuseKind MK) const {
   if (ExplodedNode *N = misuseCausesCrash(MK) ? C.generateErrorNode()
                                               : C.generateNonFatalErrorNode()) {
-
-    if (!BT)
-      BT.reset(new BugType(this, "Use-after-move",
-                           "C++ move semantics"));
-
     // Uniqueing report to the same object.
     PathDiagnosticLocation LocUsedForUniqueing;
     const ExplodedNode *MoveNode = getMoveLocation(N, Region, C);
@@ -431,7 +426,7 @@ ExplodedNode *MoveChecker::reportBug(const MemRegion *Region,
     }
 
     auto R = std::make_unique<PathSensitiveBugReport>(
-        *BT, OS.str(), N, LocUsedForUniqueing,
+        BT, OS.str(), N, LocUsedForUniqueing,
         MoveNode->getLocationContext()->getDecl());
     R->addVisitor(std::make_unique<MovedBugVisitor>(*this, Region, RD, MK));
     C.emitReport(std::move(R));

--- a/clang/lib/StaticAnalyzer/Checkers/StdLibraryFunctionsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdLibraryFunctionsChecker.cpp
@@ -742,7 +742,7 @@ bool StdLibraryFunctionsChecker::evalCall(const CallEvent &Call,
   case EvalCallAsPure: {
     ProgramStateRef State = C.getState();
     const LocationContext *LC = C.getLocationContext();
-    const auto *CE = cast_or_null<CallExpr>(Call.getOriginExpr());
+    const auto *CE = cast<CallExpr>(Call.getOriginExpr());
     SVal V = C.getSValBuilder().conjureSymbolVal(
         CE, LC, CE->getType().getCanonicalType(), C.blockCount());
     State = State->BindExpr(CE, LC, V);

--- a/clang/lib/StaticAnalyzer/Core/CommonBugCategories.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CommonBugCategories.cpp
@@ -20,6 +20,7 @@ const char *const MemoryRefCount =
 const char *const MemoryError = "Memory error";
 const char *const UnixAPI = "Unix API";
 const char *const CXXObjectLifecycle = "C++ object lifecycle";
+const char *const CXXMoveSemantics = "C++ move semantics";
 const char *const SecurityError = "Security error";
 } // namespace categories
 } // namespace ento

--- a/clang/test/Analysis/auto-obj-dtors-cfg-output.cpp
+++ b/clang/test/Analysis/auto-obj-dtors-cfg-output.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_analyze_cc1 -std=c++98 -fcxx-exceptions -fexceptions -analyzer-checker=debug.DumpCFG -analyzer-config cfg-rich-constructors=false %s > %t 2>&1
-// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX98,WARNINGS,CXX98-WARNINGS %s
+// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX98,WARNINGS %s
 // RUN: %clang_analyze_cc1 -std=c++98 -fcxx-exceptions -fexceptions -analyzer-checker=debug.DumpCFG -analyzer-config cfg-rich-constructors=true %s > %t 2>&1
 // RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX98,ANALYZER,CXX98-ANALYZER %s
 // RUN: %clang_analyze_cc1 -std=c++11 -fcxx-exceptions -fexceptions -analyzer-checker=debug.DumpCFG -analyzer-config cfg-rich-constructors=false %s > %t 2>&1

--- a/clang/test/Analysis/cfg-rich-constructors.cpp
+++ b/clang/test/Analysis/cfg-rich-constructors.cpp
@@ -1,11 +1,11 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=debug.DumpCFG -triple x86_64-apple-darwin12 -std=c++11 -w %s > %t 2>&1
-// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX11,ELIDE,CXX11-ELIDE %s
+// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX11,CXX11-ELIDE %s
 // RUN: %clang_analyze_cc1 -analyzer-checker=debug.DumpCFG -triple x86_64-apple-darwin12 -std=c++17 -w %s > %t 2>&1
-// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX17,ELIDE,CXX17-ELIDE %s
+// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX17 %s
 // RUN: %clang_analyze_cc1 -analyzer-checker=debug.DumpCFG -triple x86_64-apple-darwin12 -std=c++11 -w -analyzer-config elide-constructors=false %s > %t 2>&1
-// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX11,NOELIDE,CXX11-NOELIDE %s
+// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX11,CXX11-NOELIDE %s
 // RUN: %clang_analyze_cc1 -analyzer-checker=debug.DumpCFG -triple x86_64-apple-darwin12 -std=c++17 -w -analyzer-config elide-constructors=false %s > %t 2>&1
-// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX17,NOELIDE,CXX17-NOELIDE %s
+// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX17 %s
 
 class C {
 public:

--- a/clang/test/Analysis/cfg-rich-constructors.mm
+++ b/clang/test/Analysis/cfg-rich-constructors.mm
@@ -1,11 +1,11 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=debug.DumpCFG -triple x86_64-apple-darwin12 -std=c++11 -w %s > %t 2>&1
-// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX11,ELIDE,CXX11-ELIDE %s
+// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX11,CXX11-ELIDE %s
 // RUN: %clang_analyze_cc1 -analyzer-checker=debug.DumpCFG -triple x86_64-apple-darwin12 -std=c++17 -w %s > %t 2>&1
-// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX17,ELIDE,CXX17-ELIDE %s
+// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX17 %s
 // RUN: %clang_analyze_cc1 -analyzer-checker=debug.DumpCFG -triple x86_64-apple-darwin12 -std=c++11 -w -analyzer-config elide-constructors=false %s > %t 2>&1
-// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX11,NOELIDE,CXX11-NOELIDE %s
+// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX11,CXX11-NOELIDE %s
 // RUN: %clang_analyze_cc1 -analyzer-checker=debug.DumpCFG -triple x86_64-apple-darwin12 -std=c++17 -w -analyzer-config elide-constructors=false %s > %t 2>&1
-// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX17,NOELIDE,CXX17-NOELIDE %s
+// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,CXX17 %s
 
 class D {
 public:

--- a/clang/test/Analysis/cfg.c
+++ b/clang/test/Analysis/cfg.c
@@ -1,5 +1,5 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=debug.DumpCFG -triple x86_64-apple-darwin12 -fheinous-gnu-extensions %s > %t 2>&1
-// RUN: FileCheck --input-file=%t -check-prefixes=CHECK,WARNINGS %s
+// RUN: FileCheck --input-file=%t --check-prefix=CHECK %s
 
 // This file is the C version of cfg.cpp.
 // Tests that are C-specific should go into this file.

--- a/clang/test/Analysis/exploded-graph-rewriter/trimmers.dot
+++ b/clang/test/Analysis/exploded-graph-rewriter/trimmers.dot
@@ -1,17 +1,17 @@
 // RUN: %exploded_graph_rewriter %s \
 // RUN:     | FileCheck %s -check-prefixes=ONE,TWO,THREE,FOUR
 // RUN: %exploded_graph_rewriter -s %s \
-// RUN:     | FileCheck %s -check-prefixes=ONE,TWO,NOTHREE,FOUR
+// RUN:     | FileCheck %s -check-prefixes=ONE,TWO,NOTTHREE,FOUR
 // RUN: %exploded_graph_rewriter --to=0x2 %s \
-// RUN:     | FileCheck %s -check-prefixes=ONE,TWO,NOTHREE,NOFOUR
+// RUN:     | FileCheck %s -check-prefixes=ONE,TWO,NOTTHREE,NOTFOUR
 // RUN: %exploded_graph_rewriter --to 2 %s \
-// RUN:     | FileCheck %s -check-prefixes=ONE,TWO,NOTHREE,NOFOUR
+// RUN:     | FileCheck %s -check-prefixes=ONE,TWO,NOTTHREE,NOTFOUR
 // RUN: %exploded_graph_rewriter --to 2,3 %s \
-// RUN:     | FileCheck %s -check-prefixes=ONE,TWO,THREE,NOFOUR
+// RUN:     | FileCheck %s -check-prefixes=ONE,TWO,THREE,NOTFOUR
 // RUN: %exploded_graph_rewriter --to 4 %s \
 // RUN:     | FileCheck %s -check-prefixes=ONE,TWO,THREE,FOUR
 // RUN: %exploded_graph_rewriter --to 4 -s %s \
-// RUN:     | FileCheck %s -check-prefixes=ONE,TWO,NOTHREE,FOUR
+// RUN:     | FileCheck %s -check-prefixes=ONE,TWO,NOTTHREE,FOUR
 
 Node0x1 [shape=record,label=
  "{{ "state_id": 0, "program_state": null, "program_points": [

--- a/clang/test/Analysis/lit.local.cfg
+++ b/clang/test/Analysis/lit.local.cfg
@@ -1,5 +1,5 @@
 # -*- Python -*- vim: set ft=python ts=4 sw=4 expandtab tw=79:
-
+from lit.llvm.subst import ToolSubst
 import site
 
 # Load the custom analyzer test format, which runs the test again with Z3 if it
@@ -26,3 +26,9 @@ config.substitutions.append(('%normalize_sarif',
 
 if not config.root.clang_staticanalyzer:
     config.unsupported = True
+
+fc = ToolSubst('FileCheck', unresolved='fatal')
+# Insert this first. Then, we'll first update the blank FileCheck command; then,
+# the default substitution of FileCheck will replace it to its full path.
+config.substitutions.insert(0, (fc.regex,
+    'FileCheck --allow-unused-prefixes=false'))

--- a/clang/test/SemaObjCXX/warn-called-once.mm
+++ b/clang/test/SemaObjCXX/warn-called-once.mm
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -verify -fsyntax-only -Wcompletion-handler %s
+
+// expected-no-diagnostics
+
+class HasCtor {
+  HasCtor(void *) {}
+};


### PR DESCRIPTION
Clang Static Analyzer is traditionally kept reasonably fresh on stable branches through continuous cherry-picking.

This batch includes a hotfix for a new analysis-based warning. Also a couple of tiny fixes for clang-tidy.