### PR TITLE
Be more flexible when handling bridged Swift/ObjC CoreFoundation types.

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -889,8 +889,15 @@ std::vector<ConstString> SwiftLanguage::GetPossibleFormattersMatches(
 
   const bool check_cpp = false;
   const bool check_objc = false;
-  bool canBeSwiftDynamic = compiler_type.IsPossibleDynamicType(
-      nullptr, check_cpp, check_objc);
+  bool canBeSwiftDynamic =
+      compiler_type.IsPossibleDynamicType(nullptr, check_cpp, check_objc) ||
+      // Foundation (but really any library) may create new
+      // Objective-C classes at runtime and LLDB's ObjC runtime
+      // implementation doesn't yet get notified about this. As a
+      // workaround we try to interpret ObjC id pointers as Swift
+      // classes to make them available.
+      (compiler_type.GetCanonicalType().GetTypeClass() ==
+       eTypeClassObjCObjectPointer);
 
   if (canBeSwiftDynamic) {
     do {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4795,6 +4795,12 @@ CompilerType SwiftASTContext::GetErrorType() {
   return {};
 }
 
+CompilerType SwiftASTContext::GetObjCObjectType() {
+  // FIXME: ClangImporter::Implementation stores this type, but it's not
+  // exposed.
+  return GetCompilerType(ConstString("$sSo8NSObjectCD"));
+}
+
 SwiftASTContext *SwiftASTContext::GetSwiftASTContext(swift::ASTContext *ast) {
   SwiftASTContext *swift_ast = GetASTMap().Lookup(ast);
   return swift_ast;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -356,6 +356,7 @@ public:
   CreateTupleType(const std::vector<TupleElement> &elements) override;
 
   CompilerType GetErrorType() override;
+  CompilerType GetObjCObjectType() override;
 
   bool HasErrors();
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -116,6 +116,7 @@ public:
   virtual bool IsImportedType(lldb::opaque_compiler_type_t type,
                               CompilerType *original_type) = 0;
   virtual CompilerType GetErrorType() = 0;
+  virtual CompilerType GetObjCObjectType() = 0;
   virtual CompilerType GetReferentType(lldb::opaque_compiler_type_t type) = 0;
   static CompilerType GetInstanceType(CompilerType ct);
   virtual CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) = 0;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2752,6 +2752,23 @@ CompilerType TypeSystemSwiftTypeRef::GetErrorType() {
   VALIDATE_AND_RETURN_STATIC(impl, GetErrorType);
 }
 
+CompilerType TypeSystemSwiftTypeRef::GetObjCObjectType() {
+  auto impl = [&]() {
+    using namespace swift::Demangle;
+    Demangler dem;
+    auto *obj_type = dem.createNode(Node::Kind::Type);
+    NodePointer s = dem.createNode(Node::Kind::Structure);
+    NodePointer m =
+        dem.createNode(Node::Kind::Module, swift::MANGLING_MODULE_OBJC);
+    NodePointer ident = dem.createNode(Node::Kind::Identifier, "NSObject");
+    s->addChild(m, dem);
+    s->addChild(ident, dem);
+    obj_type->addChild(s, dem);
+    return RemangleAsType(dem, obj_type);
+  };
+  VALIDATE_AND_RETURN_STATIC(impl, GetObjCObjectType);
+}
+
 CompilerType
 TypeSystemSwiftTypeRef::GetReferentType(opaque_compiler_type_t type) {
   auto impl = [&]() -> CompilerType {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -233,6 +233,7 @@ public:
   /// builtins (int <-> Swift.Int) as Clang types.
   CompilerType GetAsClangTypeOrNull(lldb::opaque_compiler_type_t type);
   CompilerType GetErrorType() override;
+  CompilerType GetObjCObjectType() override;
   CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
   CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) override;
   TypeAllocationStrategy

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2486,7 +2486,8 @@ static bool CouldHaveDynamicValue(ValueObject &in_value) {
     // disable it.
     return !in_value.IsBaseClass();
   }
-  return var_type.IsPossibleDynamicType(nullptr, false, false);
+  bool check_objc = true;
+  return var_type.IsPossibleDynamicType(nullptr, false, check_objc);
 }
 
 bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress(
@@ -2497,10 +2498,6 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress(
   if (use_dynamic == lldb::eNoDynamicValues)
     return false;
 
-  // Try to import a Clang type into Swift.
-  if (in_value.GetObjectRuntimeLanguage() == eLanguageTypeObjC)
-    return GetDynamicTypeAndAddress_ClangType(
-        in_value, use_dynamic, class_type_or_name, address, value_type);
 
   if (!CouldHaveDynamicValue(in_value))
     return false;
@@ -2509,11 +2506,33 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress(
   // use the scratch context where such operations are legal and safe.
   assert(IsScratchContextLocked(in_value.GetTargetSP()) &&
          "Swift scratch context not locked ahead of dynamic type resolution");
+  CompilerType val_type(in_value.GetCompilerType());
+
   llvm::Optional<SwiftASTContextReader> maybe_scratch_ctx =
       in_value.GetScratchSwiftASTContext();
+
+  // Try to import a Clang type into Swift.
+  if (in_value.GetObjectRuntimeLanguage() == eLanguageTypeObjC) {
+    if (GetDynamicTypeAndAddress_ClangType(
+            in_value, use_dynamic, class_type_or_name, address, value_type))
+      return true;
+    // If the type couldn't be resolved by the Clang runtime:
+    // Foundation, for example, generates new Objective-C classes on
+    // the fly (such as instances of _DictionaryStorage<T1, T2>) and
+    // LLDB's ObjC runtime implementation isn't set up to recognize
+    // these. As a workaround, try to resolve them as Swift types.
+    if (val_type.GetCanonicalType().GetTypeClass() ==
+        eTypeClassObjCObjectPointer)
+      if (maybe_scratch_ctx)
+        if (auto *scratch_ctx = maybe_scratch_ctx->get())
+          val_type = scratch_ctx->GetObjCObjectType();
+  }
+
   if (!maybe_scratch_ctx)
     return false;
   SwiftASTContextForExpressions *scratch_ctx = maybe_scratch_ctx->get();
+  if (!scratch_ctx)
+    return false;
 
   auto retry_once = [&]() {
     // Retry exactly once using the per-module fallback scratch context.
@@ -2536,7 +2555,6 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress(
 
   // Import the type into the scratch context. Any form of dynamic
   // type resolution may trigger a cross-module import.
-  CompilerType val_type(in_value.GetCompilerType());
   Flags type_info(val_type.GetTypeInfo());
   if (!type_info.AnySet(eTypeIsSwift))
     return false;

--- a/lldb/test/Shell/SwiftREPL/DictBridging.test
+++ b/lldb/test/Shell/SwiftREPL/DictBridging.test
@@ -2,7 +2,6 @@
 // Test formatters on bridged dictionaries in the REPL.
 // REQUIRES: system-darwin
 // REQUIRES: swift
-// REQUIRES: rdar73216083
 
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=DICT
 
@@ -68,7 +67,17 @@ let d_objc2 = NSArray(object: [1: 2] as [NSNumber: NSNumber] as NSDictionary)
 let d_objc3 = NSArray(object: [1: 2] as [Int: Int] as NSDictionary)
 // DICT-LABEL: d_objc3: NSArray = 1 element {
 // DICT-NEXT:    [0] = 1 key/value pair {
-// DICT-NEXT:      [0] = (key = 1, value = 2)
+//
+//               Allowing for both multi-line and single-line
+//               formatting, depending on CoreFoundation
+//               implementation:
+//
+// DICT-NOT: }
+// DICT:           [0] =
+// DICT-NOT: }
+// DICT:                 key = 1
+// DICT-NOT: }
+// DICT:                 value = 2
 // DICT-NEXT:    }
 // DICT-NEXT:  }
 

--- a/lldb/test/Shell/SwiftREPL/SetBridging.test
+++ b/lldb/test/Shell/SwiftREPL/SetBridging.test
@@ -2,7 +2,6 @@
 // Test formatters on bridged sets in the REPL.
 // REQUIRES: system-darwin
 // REQUIRES: swift
-// REQUIRES: rdar73216234
 
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=SET
 


### PR DESCRIPTION
Recent versions of CoreFoundation may vend Swift types that aren't
recognized by LLDB's Objective-C runtime implementation. This patch
tries to resolve (id) types in Swift as Swift types when doing dynamic
type resolution.

rdar://73216083