### PR TITLE
Update the interactive REPL startup message

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -264,7 +264,11 @@ lldb::REPLSP SwiftREPL::CreateInstanceFromDebugger(Status &err,
 
   if (isatty(STDIN_FILENO)) {
     std::string swift_full_version(swift::version::getSwiftFullVersion());
-    printf("Welcome to %s.\nType :help for assistance.\n",
+    printf("Welcome to %s.\n"
+           "Enter Swift code at the prompt to run it immediately.\n"
+           "Lines starting with ':' will be interpreted as LLDB commands."
+           " For a complete listing, type ':help'.\n"
+           "To exit the REPL, type ':quit' or use CTRL-D.\n",
            swift_full_version.c_str());
   }
 


### PR DESCRIPTION
The new message:

- Explains how to exit the REPL. This is a common source of confusion for new users.
- Explains that lines starting with `:` are interpreted as LLDB commands and deemphasizes :help. Oftentimes users are confused because :help prints information that isn't relevant to most REPL users, and the prologue message usually gets scrolled offscreen.