### PR TITLE
GlobalISel: check type size before getZExtValue()ing it.

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -840,9 +840,8 @@ void IRTranslator::emitSwitchCase(SwitchCG::CaseBlock &CB,
     // For conditional branch lowering, we might try to do something silly like
     // emit an G_ICMP to compare an existing G_ICMP i1 result with true. If so,
     // just re-use the existing condition vreg.
-    if (CI && CI->getZExtValue() == 1 &&
-        MRI->getType(CondLHS).getSizeInBits() == 1 &&
-        CB.PredInfo.Pred == CmpInst::ICMP_EQ) {
+    if (MRI->getType(CondLHS).getSizeInBits() == 1 && CI &&
+        CI->getZExtValue() == 1 && CB.PredInfo.Pred == CmpInst::ICMP_EQ) {
       Cond = CondLHS;
     } else {
       Register CondRHS = getOrCreateVReg(*CB.CmpRHS);

--- a/llvm/test/CodeGen/AArch64/GlobalISel/huge-switch.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/huge-switch.ll
@@ -1,0 +1,22 @@
+; RUN: llc -mtriple=arm64-apple-ios %s -o - -O0 -global-isel=1 | FileCheck %s
+define void @foo(i512 %in) {
+; CHECK-LABEL: foo:
+; CHECK: cbz
+  switch i512 %in, label %default [
+    i512 3923188584616675477397368389504791510063972152790021570560, label %l1
+    i512 3923188584616675477397368389504791510063972152790021570561, label %l2
+    i512 3923188584616675477397368389504791510063972152790021570562, label %l3
+  ]
+
+default:
+  ret void
+
+l1:
+  ret void
+
+l2:
+  ret void
+
+l3:
+  ret void
+}


### PR DESCRIPTION
Otherwise getZExtValue() asserts.