### PR TITLE
Revert "Print a warning when stopped in a frame LLDB has no plugin for."

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -86,7 +86,6 @@ public:
   bool GetDetachKeepsStopped() const;
   void SetDetachKeepsStopped(bool keep_stopped);
   bool GetWarningsOptimization() const;
-  bool GetWarningsUnsupportedLanguage() const;
   bool GetStopOnExec() const;
   std::chrono::seconds GetUtilityExpressionTimeout() const;
   bool GetOSPluginReportsAllThreads() const;
@@ -394,7 +393,6 @@ public:
   /// Process warning types.
   enum Warnings {
     eWarningsOptimization = 1,
-    eWarningsUnsupportedLanguage = 2,
     eWarningsSwiftImport
   };
 
@@ -1342,12 +1340,6 @@ public:
   ///     The affected Module.
   void PrintWarningCantLoadSwiftModule(const Module &module,
                                        std::string details);
-
-  /// Print a user-visible warning about a function written in a
-  /// language that this version of LLDB doesn't support.
-  ///
-  /// \see PrintWarningOptimization
-  void PrintWarningUnsupportedLanguage(const SymbolContext &sc);
 
   virtual bool GetProcessInfo(ProcessInstanceInfo &info);
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -259,12 +259,6 @@ bool ProcessProperties::GetWarningsOptimization() const {
       nullptr, idx, g_process_properties[idx].default_uint_value != 0);
 }
 
-bool ProcessProperties::GetWarningsUnsupportedLanguage() const {
-  const uint32_t idx = ePropertyWarningUnsupportedLanguage;
-  return m_collection_sp->GetPropertyAtIndexAsBoolean(
-      nullptr, idx, g_process_properties[idx].default_uint_value != 0);
-}
-
 bool ProcessProperties::GetStopOnExec() const {
   const uint32_t idx = ePropertyStopOnExec;
   return m_collection_sp->GetPropertyAtIndexAsBoolean(
@@ -5925,6 +5919,9 @@ void Process::PrintWarning(uint64_t warning_type, const void *repeat_key,
   StreamSP stream_sp = GetTarget().GetDebugger().GetAsyncOutputStream();
   if (!stream_sp)
     return;
+  if (warning_type == eWarningsOptimization && !GetWarningsOptimization()) {
+    return;
+  }
 
   if (repeat_key != nullptr) {
     WarningsCollection::iterator it = m_warnings_issued.find(warning_type);
@@ -5949,11 +5946,8 @@ void Process::PrintWarning(uint64_t warning_type, const void *repeat_key,
 }
 
 void Process::PrintWarningOptimization(const SymbolContext &sc) {
-  if (!GetWarningsOptimization())
-    return;
-  if (!sc.module_sp)
-    return;
-  if (!sc.module_sp->GetFileSpec().GetFilename().IsEmpty() && sc.function &&
+  if (GetWarningsOptimization() && sc.module_sp &&
+      !sc.module_sp->GetFileSpec().GetFilename().IsEmpty() && sc.function &&
       sc.function->GetIsOptimized()) {
     PrintWarning(Process::Warnings::eWarningsOptimization, sc.module_sp.get(),
                  "%s was compiled with optimization - stepping may behave "
@@ -5967,25 +5961,6 @@ void Process::PrintWarningCantLoadSwiftModule(const Module &module,
   PrintWarning(Process::Warnings::eWarningsSwiftImport, (void *)&module,
                "%s: Cannot load Swift type information; %s\n",
                module.GetFileSpec().GetCString(), details.c_str());
-}
-
-void Process::PrintWarningUnsupportedLanguage(const SymbolContext &sc) {
-  if (!GetWarningsUnsupportedLanguage())
-    return;
-  if (!sc.module_sp)
-    return;
-  LanguageType language = sc.GetLanguage();
-  if (language == eLanguageTypeUnknown)
-    return;
-  auto type_system_or_err = sc.module_sp->GetTypeSystemForLanguage(language);
-  if (auto err = type_system_or_err.takeError()) {
-    llvm::consumeError(std::move(err));
-    PrintWarning(Process::Warnings::eWarningsUnsupportedLanguage,
-                 sc.module_sp.get(),
-                 "This version of LLDB has no plugin for the %s language. "
-                 "Inspection of frame variables will be limited.\n",
-                 Language::GetNameForLanguageType(language));
-  }
 }
 
 bool Process::GetProcessInfo(ProcessInstanceInfo &info) {

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -227,9 +227,6 @@ let Definition = "process" in {
   def WarningOptimization: Property<"optimization-warnings", "Boolean">,
     DefaultTrue,
     Desc<"If true, warn when stopped in code that is optimized where stepping and variable availability may not behave as expected.">;
-  def WarningUnsupportedLanguage: Property<"unsupported-language-warnings", "Boolean">,
-    DefaultTrue,
-    Desc<"If true, warn when stopped in code that is written in a source language that LLDB does not support.">;
   def StopOnExec: Property<"stop-on-exec", "Boolean">,
     Global,
     DefaultTrue,

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -326,13 +326,10 @@ void Thread::FrameSelectedCallback(StackFrame *frame) {
   if (!frame)
     return;
 
-  if (frame->HasDebugInformation() &&
-      (GetProcess()->GetWarningsOptimization() ||
-       GetProcess()->GetWarningsUnsupportedLanguage())) {
+  if (frame->HasDebugInformation() && GetProcess()->GetWarningsOptimization()) {
     SymbolContext sc =
         frame->GetSymbolContext(eSymbolContextFunction | eSymbolContextModule);
     GetProcess()->PrintWarningOptimization(sc);
-    GetProcess()->PrintWarningUnsupportedLanguage(sc);
   }
   SymbolContext msc = frame->GetSymbolContext(eSymbolContextModule);
   if (msc.module_sp)

--- a/lldb/test/Shell/Process/Inputs/true.c
+++ b/lldb/test/Shell/Process/Inputs/true.c
@@ -1,3 +1,0 @@
-int main(int argc, char **argv) {
-  return 0;
-}

--- a/lldb/test/Shell/Process/Optimization.test
+++ b/lldb/test/Shell/Process/Optimization.test
@@ -1,6 +1,0 @@
-Test warnings.
-REQUIRES: shell, system-darwin
-RUN: %clang_host -O3 %S/Inputs/true.c -std=c99 -g -o %t.exe
-RUN: %lldb -o "b main" -o r -o q -b %t.exe | FileCheck %s
-
-CHECK: compiled with optimization

--- a/lldb/test/Shell/Process/UnsupportedLanguage.test
+++ b/lldb/test/Shell/Process/UnsupportedLanguage.test
@@ -1,8 +1,0 @@
-Test warnings.
-REQUIRES: shell
-RUN: %clang_host %S/Inputs/true.c -std=c99 -g -c -S -emit-llvm -o - \
-RUN:   | sed -e 's/DW_LANG_C99/DW_LANG_PLI/g' >%t.ll
-RUN: %clang_host %t.ll -g -o %t.exe
-RUN: %lldb -o "b main" -o r -o q -b %t.exe | FileCheck %s
-
-CHECK: This version of LLDB has no plugin for the pli language


### PR DESCRIPTION
This reverts commit 220c17ffd4e1b127bcc02b25980b7934184ee1da.

The idea behind this commit was to print a warning when users try to debug Swift code with a non-Swift debugger (for example accidentally using the non-Swift-enabled system LLDB on Linux to debug a Linux binary). Unfortunately the way the patch is implemented it also prints the same warning when the Swift typesystem fails to initialize, which is very misleading. Until this is fixed, let's revert the patch in the swift-lldb branch.