### PR TITLE
[lldb/test] Catch invalid calls to expect()

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2439,6 +2439,22 @@ FileCheck output:
         set to False, the 'str' is treated as a string to be matched/not-matched
         against the golden input.
         """
+        # Catch cases where `expect` has been miscalled. Specifically, prevent
+        # this easy to make mistake:
+        #     self.expect("lldb command", "some substr")
+        # The `msg` parameter is used only when a failed match occurs. A failed
+        # match can only occur when one of `patterns`, `startstr`, `endstr`, or
+        # `substrs` has been given. Thus, if a `msg` is given, it's an error to
+        # not also provide one of the matcher parameters.
+        if msg and not (patterns or startstr or endstr or substrs or error):
+            assert False, "expect() missing a matcher argument"
+
+        # Check `patterns` and `substrs` are not accidentally given as strings.
+        assert not isinstance(patterns, six.string_types), \
+            "patterns must be a collection of strings"
+        assert not isinstance(substrs, six.string_types), \
+            "substrs must be a collection of strings"
+
         trace = (True if traceAlways else trace)
 
         if exe:

--- a/lldb/test/API/commands/frame/diagnose/bad-reference/TestBadReference.py
+++ b/lldb/test/API/commands/frame/diagnose/bad-reference/TestBadReference.py
@@ -22,4 +22,5 @@ class TestBadReference(TestBase):
         self.runCmd("run", RUN_SUCCEEDED)
         self.expect("thread list", "Thread should be stopped",
                     substrs=['stopped'])
-        self.expect("frame diagnose", "Crash diagnosis was accurate", "f->b")
+        self.expect("frame diagnose", "Crash diagnosis was accurate",
+                    substrs=["f->b"])

--- a/lldb/test/API/commands/frame/diagnose/complicated-expression/TestComplicatedExpression.py
+++ b/lldb/test/API/commands/frame/diagnose/complicated-expression/TestComplicatedExpression.py
@@ -25,4 +25,4 @@ class TestDiagnoseDereferenceArgument(TestBase):
         self.expect(
             "frame diagnose",
             "Crash diagnosis was accurate",
-            "f->b->d")
+            substrs=["f->b->d"])

--- a/lldb/test/API/commands/frame/diagnose/dereference-argument/TestDiagnoseDereferenceArgument.py
+++ b/lldb/test/API/commands/frame/diagnose/dereference-argument/TestDiagnoseDereferenceArgument.py
@@ -25,4 +25,4 @@ class TestDiagnoseDereferenceArgument(TestBase):
         self.expect(
             "frame diagnose",
             "Crash diagnosis was accurate",
-            "f->b->d")
+            substrs=["f->b->d"])

--- a/lldb/test/API/commands/frame/diagnose/dereference-this/TestDiagnoseDereferenceThis.py
+++ b/lldb/test/API/commands/frame/diagnose/dereference-this/TestDiagnoseDereferenceThis.py
@@ -25,4 +25,4 @@ class TestDiagnoseDereferenceThis(TestBase):
         self.expect(
             "frame diagnose",
             "Crash diagnosis was accurate",
-            "this->a")
+            substrs=["this->a"])

--- a/lldb/test/API/commands/frame/diagnose/inheritance/TestDiagnoseInheritance.py
+++ b/lldb/test/API/commands/frame/diagnose/inheritance/TestDiagnoseInheritance.py
@@ -22,4 +22,5 @@ class TestDiagnoseInheritance(TestBase):
         self.runCmd("run", RUN_SUCCEEDED)
         self.expect("thread list", "Thread should be stopped",
                     substrs=['stopped'])
-        self.expect("frame diagnose", "Crash diagnosis was accurate", "d")
+        self.expect("frame diagnose", "Crash diagnosis was accurate",
+                    substrs=["d"])

--- a/lldb/test/API/commands/frame/diagnose/local-variable/TestLocalVariable.py
+++ b/lldb/test/API/commands/frame/diagnose/local-variable/TestLocalVariable.py
@@ -22,4 +22,5 @@ class TestLocalVariable(TestBase):
         self.runCmd("run", RUN_SUCCEEDED)
         self.expect("thread list", "Thread should be stopped",
                     substrs=['stopped'])
-        self.expect("frame diagnose", "Crash diagnosis was accurate", "myInt")
+        self.expect("frame diagnose", "Crash diagnosis was accurate",
+                    substrs=["myInt"])

--- a/lldb/test/API/commands/frame/diagnose/virtual-method-call/TestDiagnoseDereferenceVirtualMethodCall.py
+++ b/lldb/test/API/commands/frame/diagnose/virtual-method-call/TestDiagnoseDereferenceVirtualMethodCall.py
@@ -22,4 +22,5 @@ class TestDiagnoseVirtualMethodCall(TestBase):
         self.runCmd("run", RUN_SUCCEEDED)
         self.expect("thread list", "Thread should be stopped",
                     substrs=['stopped'])
-        self.expect("frame diagnose", "Crash diagnosis was accurate", "foo")
+        self.expect("frame diagnose", "Crash diagnosis was accurate",
+                    substrs=["foo"])

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -461,15 +461,15 @@ class SettingsCommandTestCase(TestBase):
         # if they are provided
         self.runCmd("settings set thread-format    'abc def'   ")
         self.expect("settings show thread-format",
-                    'thread-format (format-string) = "abc def"')
+                    startstr='thread-format (format-string) = "abc def"')
         self.runCmd('settings set thread-format    "abc def"   ')
         self.expect("settings show thread-format",
-                    'thread-format (format-string) = "abc def"')
+                    startstr='thread-format (format-string) = "abc def"')
         # Make sure when no quotes are provided that we maintain any trailing
         # spaces
         self.runCmd('settings set thread-format abc def   ')
         self.expect("settings show thread-format",
-                    'thread-format (format-string) = "abc def   "')
+                    startstr='thread-format (format-string) = "abc def   "')
         self.runCmd('settings clear thread-format')
 
     def test_settings_with_trailing_whitespace(self):

--- a/lldb/test/API/driver/batch_mode/TestBatchMode.py
+++ b/lldb/test/API/driver/batch_mode/TestBatchMode.py
@@ -44,7 +44,7 @@ class DriverBatchModeTest(PExpectTest):
         child.expect_exact('(char *) touch_me_not')
         # Then we should have a live prompt:
         self.expect_prompt()
-        self.expect("frame variable touch_me_not", substrs='(char *) touch_me_not')
+        self.expect("frame variable touch_me_not", substrs=['(char *) touch_me_not'])
 
     @expectedFlakeyFreeBSD("llvm.org/pr25172 fails rarely on the buildbot")
     def test_batch_mode_run_exit(self):

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_by_line_and_column/TestBreakpointByLineAndColumn.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_by_line_and_column/TestBreakpointByLineAndColumn.py
@@ -21,7 +21,7 @@ class BreakpointByLineAndColumnTestCase(TestBase):
         main_c = lldb.SBFileSpec("main.c")
         _, _, _, breakpoint = lldbutil.run_to_line_breakpoint(self,
                                                               main_c, 11, 50)
-        self.expect("fr v did_call", substrs='1')
+        self.expect("fr v did_call", substrs=['1'])
         in_then = False
         for i in range(breakpoint.GetNumLocations()):
             b_loc = breakpoint.GetLocationAtIndex(i).GetAddress().GetLineEntry()
@@ -35,7 +35,7 @@ class BreakpointByLineAndColumnTestCase(TestBase):
         self.build()
         main_c = lldb.SBFileSpec("main.c")
         _, _, _, breakpoint = lldbutil.run_to_line_breakpoint(self, main_c, 11)
-        self.expect("fr v did_call", substrs='0')
+        self.expect("fr v did_call", substrs=['0'])
         in_condition = False
         for i in range(breakpoint.GetNumLocations()):
             b_loc = breakpoint.GetLocationAtIndex(i).GetAddress().GetLineEntry()

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/cmtime/TestDataFormatterCMTime.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/cmtime/TestDataFormatterCMTime.py
@@ -48,6 +48,6 @@ class CMTimeDataFormatterTestCase(TestBase):
         self.expect(
             'frame variable t4',
             substrs=['10 seconds', 'value = 10', 'timescale = 1', 'epoch = 0'])
-        self.expect('frame variable t5', '-oo')
-        self.expect('frame variable t6', '+oo')
-        self.expect('frame variable t7', 'indefinite')
+        self.expect('frame variable t5', substrs=['+oo'])
+        self.expect('frame variable t6', substrs=['-oo'])
+        self.expect('frame variable t7', substrs=['indefinite'])

--- a/lldb/test/API/lang/cpp/constructors/TestCppConstructors.py
+++ b/lldb/test/API/lang/cpp/constructors/TestCppConstructors.py
@@ -19,7 +19,7 @@ class TestCase(TestBase):
         self.expect_expr("ClassWithDeletedDefaultCtor(7).value", result_type="int", result_value="7")
 
         # FIXME: It seems we try to call the non-existent default constructor here which is wrong.
-        self.expect("expr ClassWithDefaultedCtor().foo()", error=True, substrs="Couldn't lookup symbols:")
+        self.expect("expr ClassWithDefaultedCtor().foo()", error=True, substrs=["Couldn't lookup symbols:"])
 
         # FIXME: Calling deleted constructors should fail before linking.
         self.expect("expr ClassWithDeletedCtor(1).value", error=True, substrs=["Couldn't lookup symbols:"])

--- a/lldb/test/API/lang/swift/async/async_fnargs/TestSwiftAsyncFnArgs.py
+++ b/lldb/test/API/lang/swift/async/async_fnargs/TestSwiftAsyncFnArgs.py
@@ -18,7 +18,7 @@ class TestSwiftAsyncFnArgs(lldbtest.TestBase):
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', src)
 
-        self.expect("frame var -d run-target -- msg", '"world"')
+        self.expect("frame var -d run-target -- msg", substrs=['"world"'])
 
         # Continue into the second coroutine funclet.
         bkpt2 = target.BreakpointCreateBySourceRegex("And also here", src, None)
@@ -27,4 +27,4 @@ class TestSwiftAsyncFnArgs(lldbtest.TestBase):
         self.assertEqual(
              len(lldbutil.get_threads_stopped_at_breakpoint(process, bkpt2)), 1)
 
-        self.expect("frame var -d run-target -- msg", '"world"')
+        self.expect("frame var -d run-target -- msg", substrs=['"world"'])

--- a/lldb/test/API/lang/swift/async/async_fnargs/TestSwiftAsyncFnArgs.py
+++ b/lldb/test/API/lang/swift/async/async_fnargs/TestSwiftAsyncFnArgs.py
@@ -11,6 +11,7 @@ class TestSwiftAsyncFnArgs(lldbtest.TestBase):
 
     @swiftTest
     @skipIf(oslist=['windows', 'linux'])
+    @skipIf(bugnumber="rdar://73882785")
     def test(self):
         """Test function arguments in async functions"""
         self.build()

--- a/lldb/test/API/macosx/macCatalyst/TestMacCatalyst.py
+++ b/lldb/test/API/macosx/macCatalyst/TestMacCatalyst.py
@@ -24,8 +24,8 @@ class TestMacCatalyst(TestBase):
         self.expect("image list -t -b",
                     patterns=[self.getArchitecture() +
                               r'.*-apple-ios.*-macabi a\.out'])
-        self.expect("fr v s", "Hello macCatalyst")
-        self.expect("p s", "Hello macCatalyst")
+        self.expect("fr v s", substrs=["Hello macCatalyst"])
+        self.expect("p s", substrs=["Hello macCatalyst"])
         self.check_debugserver(log)
 
     def check_debugserver(self, log):


### PR DESCRIPTION
Add preconditions to `TestBase.expect()` that catch semantically invalid calls
that happen to succeed anyway. This also fixes the broken callsites caught by
these checks.

This prevents the following incorrect calls:

1. `self.expect("lldb command", "some substr")`
2. `self.expect("lldb command", "assert message", "some substr")`

Differential Revision: https://reviews.llvm.org/D88792

(cherry picked from commit 010d7a388b146cafaf4bc0b28b952d5852d62b6a)