### PR TITLE
[clangd] Add a notification that causes clangd to crash

### DIFF
--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -1453,6 +1453,11 @@ void ClangdLSPServer::onMemoryUsage(const NoParams &,
   Reply(std::move(MT));
 }
 
+void ClangdLSPServer::onCrash(const NoParams &) {
+  // We have been requested to crash.
+  exit(1);
+}
+
 void ClangdLSPServer::onAST(const ASTParams &Params,
                             Callback<llvm::Optional<ASTNode>> CB) {
   Server->getAST(Params.textDocument.uri.file(), Params.range, std::move(CB));
@@ -1511,6 +1516,7 @@ ClangdLSPServer::ClangdLSPServer(class Transport &Transp,
   MsgHandler->bind("textDocument/semanticTokens/full", &ClangdLSPServer::onSemanticTokens);
   MsgHandler->bind("textDocument/semanticTokens/full/delta", &ClangdLSPServer::onSemanticTokensDelta);
   MsgHandler->bind("$/memoryUsage", &ClangdLSPServer::onMemoryUsage);
+  MsgHandler->bind("$/crash", &ClangdLSPServer::onCrash);
   if (Opts.FoldingRanges)
     MsgHandler->bind("textDocument/foldingRange", &ClangdLSPServer::onFoldingRange);
   // clang-format on

--- a/clang-tools-extra/clangd/ClangdLSPServer.h
+++ b/clang-tools-extra/clangd/ClangdLSPServer.h
@@ -160,6 +160,9 @@ private:
   /// This is a clangd extension. Provides a json tree representing memory usage
   /// hierarchy.
   void onMemoryUsage(const NoParams &, Callback<MemoryTree>);
+  /// This is a clangd extension. Makes clangd exit with a non-zero exit code
+  /// for testing purposes.
+  void onCrash(const NoParams &);
 
   std::vector<Fix> getFixes(StringRef File, const clangd::Diagnostic &D);
 


### PR DESCRIPTION
This enables users of clangd to test their crash recovery capabilities should clangd crash.

In particular it enables us to re-enable the tests that were disabled in https://github.com/apple/sourcekit-lsp/pull/364 because our existing technique of crashing `clangd` no longer works.

I’d like to upstream this earlier or later but primarily I’d like to get this in so we can re-enable the tests.

Also, I’m not sure if `apple/stable/20210107` is the right branch to target.