### PR TITLE
[lldb] Convert assertTrue(a == b) to assertEqual(a, b)

### DIFF
--- a/lldb/test/API/commands/register/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register/register_command/TestRegisters.py
@@ -222,7 +222,7 @@ class RegisterCommandsTestCase(TestBase):
         self.assertTrue(matched, STOPPED_DUE_TO_SIGNAL)
 
         process = target.GetProcess()
-        self.assertTrue(process.GetState() == lldb.eStateStopped,
+        self.assertEqual(process.GetState(), lldb.eStateStopped,
                         PROCESS_STOPPED)
 
         thread = process.GetThreadAtIndex(0)

--- a/lldb/test/API/commands/watchpoints/watchpoint_events/TestWatchpointEvents.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_events/TestWatchpointEvents.py
@@ -84,7 +84,7 @@ class TestWatchpointEvents (TestBase):
         local_watch.SetCondition(condition)
         self.GetWatchpointEvent(lldb.eWatchpointEventTypeConditionChanged)
 
-        self.assertTrue(local_watch.GetCondition() == condition,
+        self.assertEqual(local_watch.GetCondition(), condition,
                         'make sure watchpoint condition is "' + condition + '"')
 
     def GetWatchpointEvent(self, event_type):

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/TestBreakpointConditions.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/TestBreakpointConditions.py
@@ -133,7 +133,7 @@ class BreakpointConditionsTestCase(TestBase):
 
         # We didn't associate a thread index with the breakpoint, so it should
         # be invalid.
-        self.assertTrue(breakpoint.GetThreadIndex() == lldb.UINT32_MAX,
+        self.assertEqual(breakpoint.GetThreadIndex(), lldb.UINT32_MAX,
                         "The thread index should be invalid")
         # The thread name should be invalid, too.
         self.assertTrue(breakpoint.GetThreadName() is None,
@@ -143,7 +143,7 @@ class BreakpointConditionsTestCase(TestBase):
         # indeed, being set correctly.
         # There's only one thread for the process.
         breakpoint.SetThreadIndex(1)
-        self.assertTrue(breakpoint.GetThreadIndex() == 1,
+        self.assertEqual(breakpoint.GetThreadIndex(), 1,
                         "The thread index has been set correctly")
 
         # Get the breakpoint location from breakpoint after we verified that,
@@ -175,7 +175,7 @@ class BreakpointConditionsTestCase(TestBase):
                         var.GetValue() == '3')
 
         # The hit count for the breakpoint should be 1.
-        self.assertTrue(breakpoint.GetHitCount() == 1)
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         # Test that the condition expression didn't create a result variable:
         options = lldb.SBExpressionOptions()
@@ -217,7 +217,7 @@ class BreakpointConditionsTestCase(TestBase):
             "There should be a thread stopped due to breakpoint condition")
         frame0 = thread.GetFrameAtIndex(0)
         var = frame0.FindValue('val', lldb.eValueTypeVariableArgument)
-        self.assertTrue(frame0.GetLineEntry().GetLine() == self.line1)
+        self.assertEqual(frame0.GetLineEntry().GetLine(), self.line1)
 
         # The hit count for the breakpoint should be 1.
-        self.assertTrue(breakpoint.GetHitCount() == 1)
+        self.assertEqual(breakpoint.GetHitCount(), 1)

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_ignore_count/TestBreakpointIgnoreCount.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_ignore_count/TestBreakpointIgnoreCount.py
@@ -120,7 +120,7 @@ class BreakpointIgnoreCountTestCase(TestBase):
 
         # Set the ignore count on the breakpoint location.
         location.SetIgnoreCount(2)
-        self.assertTrue(location.GetIgnoreCount() == 2,
+        self.assertEqual(location.GetIgnoreCount(), 2,
                         "SetIgnoreCount() works correctly")
 
         # Now launch the process, and do not stop at entry point.
@@ -145,6 +145,6 @@ class BreakpointIgnoreCountTestCase(TestBase):
                         STOPPED_DUE_TO_BREAKPOINT_IGNORE_COUNT)
 
         # The hit count for the breakpoint should be 3.
-        self.assertTrue(breakpoint.GetHitCount() == 3)
+        self.assertEqual(breakpoint.GetHitCount(), 3)
 
         process.Continue()

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_in_delayslot/TestAvoidBreakpointInDelaySlot.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_in_delayslot/TestAvoidBreakpointInDelaySlot.py
@@ -38,9 +38,9 @@ class AvoidBreakpointInDelaySlotAPITestCase(TestBase):
         self.assertTrue(process, PROCESS_IS_VALID)
 
         list = target.FindFunctions('foo', lldb.eFunctionNameTypeAuto)
-        self.assertTrue(list.GetSize() == 1)
+        self.assertEqual(list.GetSize(), 1)
         sc = list.GetContextAtIndex(0)
-        self.assertTrue(sc.GetSymbol().GetName() == "foo")
+        self.assertEqual(sc.GetSymbol().GetName(), "foo")
         function = sc.GetFunction()
         self.assertTrue(function)
         self.function(function, target)
@@ -75,7 +75,7 @@ class AvoidBreakpointInDelaySlotAPITestCase(TestBase):
 
                 # Breakpoint address should be adjusted to the address of
                 # branch instruction.
-                self.assertTrue(branchinstaddress == bpaddr)
+                self.assertEqual(branchinstaddress, bpaddr)
                 i += 1
             else:
                 i += 1

--- a/lldb/test/API/functionalities/breakpoint/serialize/TestBreakpointSerialization.py
+++ b/lldb/test/API/functionalities/breakpoint/serialize/TestBreakpointSerialization.py
@@ -133,7 +133,7 @@ class BreakpointSerialization(TestBase):
 
         num_source_bps = source_bps.GetSize()
         num_copy_bps = copy_bps.GetSize()
-        self.assertTrue(num_source_bps == num_copy_bps, "Didn't get same number of input and output breakpoints - orig: %d copy: %d"%(num_source_bps, num_copy_bps))
+        self.assertEqual(num_source_bps, num_copy_bps, "Didn't get same number of input and output breakpoints - orig: %d copy: %d"%(num_source_bps, num_copy_bps))
 
         for i in range(0, num_source_bps):
             source_bp = source_bps.GetBreakpointAtIndex(i)
@@ -327,12 +327,12 @@ class BreakpointSerialization(TestBase):
 
         error = self.copy_target.BreakpointsCreateFromFile(self.bkpts_file_spec, names_list, copy_bps)
         self.assertTrue(error.Success(), "Failed reading breakpoints from file: %s"%(error.GetCString()))
-        self.assertTrue(copy_bps.GetSize() == 0, "Found breakpoints with a nonexistent name.")
+        self.assertEqual(copy_bps.GetSize(), 0, "Found breakpoints with a nonexistent name.")
 
         names_list.AppendString(good_bkpt_name)
         error = self.copy_target.BreakpointsCreateFromFile(self.bkpts_file_spec, names_list, copy_bps)
         self.assertTrue(error.Success(), "Failed reading breakpoints from file: %s"%(error.GetCString()))
-        self.assertTrue(copy_bps.GetSize() == 1, "Found the matching breakpoint.")
+        self.assertEqual(copy_bps.GetSize(), 1, "Found the matching breakpoint.")
 
     def do_check_extra_args(self):
 

--- a/lldb/test/API/functionalities/conditional_break/TestConditionalBreak.py
+++ b/lldb/test/API/functionalities/conditional_break/TestConditionalBreak.py
@@ -49,7 +49,7 @@ class ConditionalBreakTestCase(TestBase):
         self.assertTrue(process, PROCESS_IS_VALID)
 
         # The stop reason of the thread should be breakpoint.
-        self.assertTrue(process.GetState() == lldb.eStateStopped,
+        self.assertEqual(process.GetState(), lldb.eStateStopped,
                         STOPPED_DUE_TO_BREAKPOINT)
 
         # Find the line number where a's parent frame function is c.
@@ -77,12 +77,12 @@ class ConditionalBreakTestCase(TestBase):
                 frame1 = thread.GetFrameAtIndex(1)
                 name1 = frame1.GetFunction().GetName()
                 # lldbutil.print_stacktrace(thread)
-                self.assertTrue(name0 == "c", "Break on function c()")
+                self.assertEqual(name0, "c", "Break on function c()")
                 if (name1 == "a"):
                     # By design, we know that a() calls c() only from main.c:27.
                     # In reality, similar logic can be used to find out the call
                     # site.
-                    self.assertTrue(frame1.GetLineEntry().GetLine() == line,
+                    self.assertEqual(frame1.GetLineEntry().GetLine(), line,
                                     "Immediate caller a() at main.c:%d" % line)
 
                     # And the local variable 'val' should have a value of (int)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/atomic/TestLibCxxAtomic.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/atomic/TestLibCxxAtomic.py
@@ -56,8 +56,8 @@ class LibCxxAtomicTestCase(TestBase):
         self.assertEqual(i_atomic.GetNumChildren(), 1)
         i = i_atomic.GetChildAtIndex(0)
 
-        self.assertTrue(i.GetValueAsUnsigned(0) == 5, "i == 5")
-        self.assertTrue(s.GetNumChildren() == 2, "s has two children")
+        self.assertEqual(i.GetValueAsUnsigned(0), 5, "i == 5")
+        self.assertEqual(s.GetNumChildren(), 2, "s has two children")
         self.assertTrue(
             s.GetChildAtIndex(0).GetValueAsUnsigned(0) == 1,
             "s.x == 1")

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-synthval/TestDataFormatterSynthVal.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-synthval/TestDataFormatterSynthVal.py
@@ -66,10 +66,10 @@ class DataFormatterSynthValueTestCase(TestBase):
                 "x_val = %s; y_val = %s; z_val = %s; q_val = %s" %
                 (x_val(), y_val(), z_val(), q_val()))
 
-        self.assertFalse(x_val() == 3, "x == 3 before synthetics")
-        self.assertFalse(y_val() == 4, "y == 4 before synthetics")
-        self.assertFalse(z_val() == 7, "z == 7 before synthetics")
-        self.assertFalse(q_val() == 8, "q == 8 before synthetics")
+        self.assertNotEqual(x_val(), 3, "x == 3 before synthetics")
+        self.assertNotEqual(y_val(), 4, "y == 4 before synthetics")
+        self.assertNotEqual(z_val(), 7, "z == 7 before synthetics")
+        self.assertNotEqual(q_val(), 8, "q == 8 before synthetics")
 
         # now set up the synth
         self.runCmd("script from myIntSynthProvider import *")
@@ -82,10 +82,10 @@ class DataFormatterSynthValueTestCase(TestBase):
                 "x_val = %s; y_val = %s; z_val = %s; q_val = %s" %
                 (x_val(), y_val(), z_val(), q_val()))
 
-        self.assertTrue(x_val() == 3, "x != 3 after synthetics")
-        self.assertTrue(y_val() == 4, "y != 4 after synthetics")
-        self.assertTrue(z_val() == 7, "z != 7 after synthetics")
-        self.assertTrue(q_val() == 8, "q != 8 after synthetics")
+        self.assertEqual(x_val(), 3, "x != 3 after synthetics")
+        self.assertEqual(y_val(), 4, "y != 4 after synthetics")
+        self.assertEqual(z_val(), 7, "z != 7 after synthetics")
+        self.assertEqual(q_val(), 8, "q != 8 after synthetics")
 
         self.expect("frame variable x", substrs=['3'])
         self.expect(

--- a/lldb/test/API/functionalities/data-formatter/vector-types/TestVectorTypesFormatting.py
+++ b/lldb/test/API/functionalities/data-formatter/vector-types/TestVectorTypesFormatting.py
@@ -55,17 +55,17 @@ class VectorTypesFormattingTestCase(TestBase):
         if self.TraceOn():
             print(v)
 
-        self.assertTrue(
-            v.GetNumChildren() == 4,
+        self.assertEqual(
+            v.GetNumChildren(), 4,
             "v as float32[] has 4 children")
-        self.assertTrue(v.GetChildAtIndex(0).GetData().float[
-                        0] == 1.25, "child 0 == 1.25")
-        self.assertTrue(v.GetChildAtIndex(1).GetData().float[
-                        0] == 1.25, "child 1 == 1.25")
-        self.assertTrue(v.GetChildAtIndex(2).GetData().float[
-                        0] == 2.50, "child 2 == 2.50")
-        self.assertTrue(v.GetChildAtIndex(3).GetData().float[
-                        0] == 2.50, "child 3 == 2.50")
+        self.assertEqual(v.GetChildAtIndex(0).GetData().float[0], 1.25,
+                         "child 0 == 1.25")
+        self.assertEqual(v.GetChildAtIndex(1).GetData().float[0], 1.25,
+                         "child 1 == 1.25")
+        self.assertEqual(v.GetChildAtIndex(2).GetData().float[0], 2.50,
+                         "child 2 == 2.50")
+        self.assertEqual(v.GetChildAtIndex(3).GetData().float[0], 2.50,
+                         "child 3 == 2.50")
 
         self.expect("expr -f int16_t[] -- v",
                     substrs=['(0, 16288, 0, 16288, 0, 16416, 0, 16416)'])
@@ -78,11 +78,11 @@ class VectorTypesFormattingTestCase(TestBase):
         oldValue = v.GetChildAtIndex(0).GetValue()
         v.SetFormat(lldb.eFormatHex)
         newValue = v.GetChildAtIndex(0).GetValue()
-        self.assertFalse(oldValue == newValue,
-                         "values did not change along with format")
+        self.assertNotEqual(oldValue, newValue,
+                            "values did not change along with format")
 
         v.SetFormat(lldb.eFormatVectorOfFloat32)
         oldValueAgain = v.GetChildAtIndex(0).GetValue()
-        self.assertTrue(
-            oldValue == oldValueAgain,
+        self.assertEqual(
+            oldValue, oldValueAgain,
             "same format but different values")

--- a/lldb/test/API/functionalities/exec/TestExec.py
+++ b/lldb/test/API/functionalities/exec/TestExec.py
@@ -69,12 +69,12 @@ class ExecTestCase(TestBase):
             self.addTearDownHook(cleanup)
 
         # The stop reason of the thread should be breakpoint.
-        self.assertTrue(process.GetState() == lldb.eStateStopped,
+        self.assertEqual(process.GetState(), lldb.eStateStopped,
                         STOPPED_DUE_TO_BREAKPOINT)
 
         threads = lldbutil.get_threads_stopped_at_breakpoint(
         process, breakpoint1)
-        self.assertTrue(len(threads) == 1)
+        self.assertEqual(len(threads), 1)
 
         # We had a deadlock tearing down the TypeSystemMap on exec, but only if some
         # expression had been evaluated.  So make sure we do that here so the teardown
@@ -86,16 +86,16 @@ class ExecTestCase(TestBase):
             value.IsValid(),
             "Expression evaluated successfully")
         int_value = value.GetValueAsSigned()
-        self.assertTrue(int_value == 3, "Expression got the right result.")
+        self.assertEqual(int_value, 3, "Expression got the right result.")
 
         # Run and we should stop due to exec
         process.Continue()
 
         if not skip_exec:
-            self.assertFalse(process.GetState() == lldb.eStateExited,
-                             "Process should not have exited!")
-            self.assertTrue(process.GetState() == lldb.eStateStopped,
-                            "Process should be stopped at __dyld_start")
+            self.assertNotEqual(process.GetState(), lldb.eStateExited,
+                                "Process should not have exited!")
+            self.assertEqual(process.GetState(), lldb.eStateStopped,
+                             "Process should be stopped at __dyld_start")
 
             threads = lldbutil.get_stopped_threads(
                 process, lldb.eStopReasonExec)
@@ -113,5 +113,5 @@ class ExecTestCase(TestBase):
                 print(t)
                 if t.GetStopReason() != lldb.eStopReasonBreakpoint:
                     self.runCmd("bt")
-        self.assertTrue(len(threads) == 1,
+        self.assertEqual(len(threads), 1,
                         "Stopped at breakpoint in exec'ed process.")

--- a/lldb/test/API/functionalities/return-value/TestReturnValue.py
+++ b/lldb/test/API/functionalities/return-value/TestReturnValue.py
@@ -124,7 +124,7 @@ class ReturnValueTestCase(TestBase):
         #self.assertTrue(return_value.IsValid())
         #return_float = float(return_value.GetValue())
 
-        #self.assertTrue(in_float == return_float)
+        #self.assertEqual(in_float, return_float)
 
         if not self.affected_by_radar_34562999() and not self.affected_by_pr44132():
             self.return_and_test_struct_value("return_one_int")

--- a/lldb/test/API/functionalities/tty/TestTerminal.py
+++ b/lldb/test/API/functionalities/tty/TestTerminal.py
@@ -48,4 +48,4 @@ class LaunchInTerminalTestCase(TestBase):
             "Make sure launch happened successfully in a terminal window")
         # Running in synchronous mode our process should have run and already
         # exited by the time target.Launch() returns
-        self.assertTrue(process.GetState() == lldb.eStateExited)
+        self.assertEqual(process.GetState(), lldb.eStateExited)

--- a/lldb/test/API/functionalities/type_get_module/TestTypeGetModule.py
+++ b/lldb/test/API/functionalities/type_get_module/TestTypeGetModule.py
@@ -71,8 +71,8 @@ class TestTypeGetModule(TestBase):
 
         comp_unit = self.find_comp_unit(exe_module, 'compile_unit1.c')
         cu_type = self.find_type(comp_unit.GetTypes(), 'compile_unit1_type')
-        self.assertTrue(exe_module == cu_type.GetModule())
+        self.assertEqual(exe_module, cu_type.GetModule())
         
         comp_unit = self.find_comp_unit(exe_module, 'compile_unit2.c')
         cu_type = self.find_type(comp_unit.GetTypes(), 'compile_unit2_type')
-        self.assertTrue(exe_module == cu_type.GetModule())
+        self.assertEqual(exe_module, cu_type.GetModule())

--- a/lldb/test/API/lang/c/bitfields/TestBitfields.py
+++ b/lldb/test/API/lang/c/bitfields/TestBitfields.py
@@ -213,7 +213,7 @@ class BitfieldsTestCase(TestBase):
             bits.GetNumChildren() == 10,
             "bits.GetNumChildren() == 10")
         test_compiler = self.getCompiler()
-        self.assertTrue(bits.GetByteSize() == 32, "bits.GetByteSize() == 32")
+        self.assertEqual(bits.GetByteSize(), 32, "bits.GetByteSize() == 32")
 
         # Notice the pattern of int(b1.GetValue(), 0).  We pass a base of 0
         # so that the proper radix is determined based on the contents of the

--- a/lldb/test/API/lang/c/stepping/TestStepAndBreakpoints.py
+++ b/lldb/test/API/lang/c/stepping/TestStepAndBreakpoints.py
@@ -166,14 +166,14 @@ class TestCStepping(TestBase):
 
         process.Continue()
 
-        self.assertTrue(thread.GetFrameAtIndex(0).GetFunctionName() == "a")
-        self.assertTrue(thread.GetStopReason() == lldb.eStopReasonPlanComplete)
+        self.assertEqual(thread.GetFrameAtIndex(0).GetFunctionName(), "a")
+        self.assertEqual(thread.GetStopReason(), lldb.eStopReasonPlanComplete)
 
         # And one more time should get us back to main:
         process.Continue()
 
-        self.assertTrue(thread.GetFrameAtIndex(0).GetFunctionName() == "main")
-        self.assertTrue(thread.GetStopReason() == lldb.eStopReasonPlanComplete)
+        self.assertEqual(thread.GetFrameAtIndex(0).GetFunctionName(), "main")
+        self.assertEqual(thread.GetStopReason(), lldb.eStopReasonPlanComplete)
 
         # Now make sure we can call a function, break in the called function,
         # then have "continue" get us back out again:
@@ -238,18 +238,18 @@ class TestCStepping(TestBase):
 
         threads = lldbutil.continue_to_breakpoint(
             process, break_before_complex_1)
-        self.assertTrue(len(threads) == 1)
+        self.assertEqual(len(threads), 1)
         thread = threads[0]
         break_before_complex_1.SetEnabled(False)
 
         thread.StepInto("b")
-        self.assertTrue(thread.GetFrameAtIndex(0).GetFunctionName() == "b")
+        self.assertEqual(thread.GetFrameAtIndex(0).GetFunctionName(), "b")
 
         # Now continue out and stop at the next call to complex.  This time
         # step all the way into complex:
         threads = lldbutil.continue_to_breakpoint(
             process, break_before_complex_2)
-        self.assertTrue(len(threads) == 1)
+        self.assertEqual(len(threads), 1)
         thread = threads[0]
         break_before_complex_2.SetEnabled(False)
 
@@ -261,7 +261,7 @@ class TestCStepping(TestBase):
         # enable breakpoints in a and c and then step targeting b:
         threads = lldbutil.continue_to_breakpoint(
             process, break_before_complex_3)
-        self.assertTrue(len(threads) == 1)
+        self.assertEqual(len(threads), 1)
         thread = threads[0]
         break_before_complex_3.SetEnabled(False)
 
@@ -272,7 +272,7 @@ class TestCStepping(TestBase):
         threads = lldbutil.get_stopped_threads(
             process, lldb.eStopReasonBreakpoint)
 
-        self.assertTrue(len(threads) == 1)
+        self.assertEqual(len(threads), 1)
         thread = threads[0]
         stop_break_id = thread.GetStopReasonDataAtIndex(0)
         self.assertTrue(stop_break_id == break_at_start_of_a.GetID()
@@ -282,15 +282,15 @@ class TestCStepping(TestBase):
         break_at_start_of_c.SetEnabled(False)
 
         process.Continue()
-        self.assertTrue(thread.GetFrameAtIndex(0).GetFunctionName() == "b")
+        self.assertEqual(thread.GetFrameAtIndex(0).GetFunctionName(), "b")
 
         # Now continue out and stop at the next call to complex.  This time
         # enable breakpoints in a and c and then step targeting b:
         threads = lldbutil.continue_to_breakpoint(
             process, break_before_complex_4)
-        self.assertTrue(len(threads) == 1)
+        self.assertEqual(len(threads), 1)
         thread = threads[0]
         break_before_complex_4.SetEnabled(False)
 
         thread.StepInto("NoSuchFunction")
-        self.assertTrue(thread.GetFrameAtIndex(0).GetFunctionName() == "main")
+        self.assertEqual(thread.GetFrameAtIndex(0).GetFunctionName(), "main")

--- a/lldb/test/API/lang/cpp/class_static/TestStaticVariables.py
+++ b/lldb/test/API/lang/cpp/class_static/TestStaticVariables.py
@@ -157,17 +157,17 @@ class StaticVariableTestCase(TestBase):
         # SBFrame.FindValue() should also work.
         val = frame.FindValue("A::g_points", lldb.eValueTypeVariableGlobal)
         self.DebugSBValue(val)
-        self.assertTrue(val.GetName() == 'A::g_points')
+        self.assertEqual(val.GetName(), 'A::g_points')
 
         # Also exercise the "parameter" and "local" scopes while we are at it.
         val = frame.FindValue("argc", lldb.eValueTypeVariableArgument)
         self.DebugSBValue(val)
-        self.assertTrue(val.GetName() == 'argc')
+        self.assertEqual(val.GetName(), 'argc')
 
         val = frame.FindValue("argv", lldb.eValueTypeVariableArgument)
         self.DebugSBValue(val)
-        self.assertTrue(val.GetName() == 'argv')
+        self.assertEqual(val.GetName(), 'argv')
 
         val = frame.FindValue("hello_world", lldb.eValueTypeVariableLocal)
         self.DebugSBValue(val)
-        self.assertTrue(val.GetName() == 'hello_world')
+        self.assertEqual(val.GetName(), 'hello_world')

--- a/lldb/test/API/lang/cpp/class_types/TestClassTypes.py
+++ b/lldb/test/API/lang/cpp/class_types/TestClassTypes.py
@@ -111,7 +111,7 @@ class ClassTypesTestCase(TestBase):
         # startstr = "main.cpp:93")
 
         # We should be stopped on the breakpoint with a hit count of 1.
-        self.assertTrue(breakpoint.GetHitCount() == 1, BREAKPOINT_HIT_ONCE)
+        self.assertEqual(breakpoint.GetHitCount(), 1, BREAKPOINT_HIT_ONCE)
 
         process.Continue()
 

--- a/lldb/test/API/lang/cpp/dynamic-value/TestCppValueCast.py
+++ b/lldb/test/API/lang/cpp/dynamic-value/TestCppValueCast.py
@@ -63,7 +63,7 @@ class CppValueCastTestCase(TestBase):
         process = target.LaunchSimple(
             None, None, self.get_process_working_directory())
 
-        self.assertTrue(process.GetState() == lldb.eStateStopped,
+        self.assertEqual(process.GetState(), lldb.eStateStopped,
                         PROCESS_STOPPED)
 
         # Find DerivedA and DerivedB types.
@@ -78,7 +78,7 @@ class CppValueCastTestCase(TestBase):
         # First stop is for DerivedA instance.
         threads = lldbutil.get_threads_stopped_at_breakpoint(
             process, breakpoint)
-        self.assertTrue(len(threads) == 1)
+        self.assertEqual(len(threads), 1)
         thread = threads[0]
         frame0 = thread.GetFrameAtIndex(0)
 
@@ -103,11 +103,11 @@ class CppValueCastTestCase(TestBase):
                 print(child)
         a_member_val = instanceA.GetChildMemberWithName('m_a_val')
         self.DebugSBValue(a_member_val)
-        self.assertTrue(a_member_val.GetValueAsUnsigned(error, 0) == 10)
+        self.assertEqual(a_member_val.GetValueAsUnsigned(error, 0), 10)
 
         # Second stop is for DerivedB instance.
         threads = lldbutil.continue_to_breakpoint(process, breakpoint)
-        self.assertTrue(len(threads) == 1)
+        self.assertEqual(len(threads), 1)
         thread = threads[0]
         frame0 = thread.GetFrameAtIndex(0)
 
@@ -132,4 +132,4 @@ class CppValueCastTestCase(TestBase):
                 print(child)
         b_member_val = instanceB.GetChildMemberWithName('m_b_val')
         self.DebugSBValue(b_member_val)
-        self.assertTrue(b_member_val.GetValueAsUnsigned(error, 0) == 36)
+        self.assertEqual(b_member_val.GetValueAsUnsigned(error, 0), 36)

--- a/lldb/test/API/lang/cpp/template/TestTemplateArgs.py
+++ b/lldb/test/API/lang/cpp/template/TestTemplateArgs.py
@@ -123,7 +123,7 @@ class TemplateArgsTestCase(TestBase):
         self.assertTrue(
             member.IsValid(),
             'make sure we find a local variabble named "member"')
-        self.assertTrue(member.GetType().GetName() ==
+        self.assertEqual(member.GetType().GetName(),
                         'EnumTemplate<EnumType::Member>')
 
         expr_result = frame.EvaluateExpression("member.getMember()")
@@ -143,7 +143,7 @@ class TemplateArgsTestCase(TestBase):
         self.assertTrue(
             subclass.IsValid(),
             'make sure we find a local variabble named "subclass"')
-        self.assertTrue(subclass.GetType().GetName() ==
+        self.assertEqual(subclass.GetType().GetName(),
                         'EnumTemplate<EnumType::Subclass>')
 
         expr_result = frame.EvaluateExpression("subclass.getMember()")

--- a/lldb/test/API/lang/objc/blocks/TestObjCIvarsInBlocks.py
+++ b/lldb/test/API/lang/objc/blocks/TestObjCIvarsInBlocks.py
@@ -48,7 +48,7 @@ class TestObjCIvarsInBlocks(TestBase):
 
         thread_list = lldbutil.get_threads_stopped_at_breakpoint(
             process, breakpoint)
-        self.assertTrue(len(thread_list) == 1)
+        self.assertEqual(len(thread_list), 1)
         thread = thread_list[0]
 
         frame = thread.GetFrameAtIndex(0)
@@ -113,7 +113,7 @@ class TestObjCIvarsInBlocks(TestBase):
 
         thread_list = lldbutil.get_threads_stopped_at_breakpoint(
             process, breakpoint_two)
-        self.assertTrue(len(thread_list) == 1)
+        self.assertEqual(len(thread_list), 1)
         thread = thread_list[0]
 
         frame = thread.GetFrameAtIndex(0)

--- a/lldb/test/API/lang/objc/foundation/TestObjCMethods.py
+++ b/lldb/test/API/lang/objc/foundation/TestObjCMethods.py
@@ -253,7 +253,7 @@ class FoundationTestCase(TestBase):
         cur_frame = thread.GetFrameAtIndex(0)
 
         line_number = cur_frame.GetLineEntry().GetLine()
-        self.assertTrue(line_number == self.line, "Hit the first breakpoint.")
+        self.assertEqual(line_number, self.line, "Hit the first breakpoint.")
 
         my_var = cur_frame.FindVariable("my")
         self.assertTrue(my_var, "Made a variable object for my")
@@ -320,5 +320,5 @@ class FoundationTestCase(TestBase):
                             "error: found spurious name lookups when evaluating an expression:")
                     num_errors += 1
                     print(line, end='')
-            self.assertTrue(num_errors == 0, "Spurious lookups detected")
+            self.assertEqual(num_errors, 0, "Spurious lookups detected")
             f.close()

--- a/lldb/test/API/lang/objc/foundation/TestObjectDescriptionAPI.py
+++ b/lldb/test/API/lang/objc/foundation/TestObjectDescriptionAPI.py
@@ -46,7 +46,7 @@ class ObjectDescriptionAPITestCase(TestBase):
         # Make sure we hit our breakpoint:
         thread_list = lldbutil.get_threads_stopped_at_breakpoint(
             process, breakpoint)
-        self.assertTrue(len(thread_list) == 1)
+        self.assertEqual(len(thread_list), 1)
 
         thread = thread_list[0]
         frame0 = thread.GetFrameAtIndex(0)
@@ -59,7 +59,7 @@ class ObjectDescriptionAPITestCase(TestBase):
                 print("val:", v)
                 print("object description:", v.GetObjectDescription())
             if v.GetName() == 'my_global_str':
-                self.assertTrue(v.GetObjectDescription() ==
+                self.assertEqual(v.GetObjectDescription(),
                                 'This is a global string')
 
         # But not here!
@@ -70,5 +70,5 @@ class ObjectDescriptionAPITestCase(TestBase):
                 print("val:", v)
                 print("object description:", v.GetObjectDescription())
             if v.GetName() == 'my_global_str':
-                self.assertTrue(v.GetObjectDescription() ==
+                self.assertEqual(v.GetObjectDescription(),
                                 'This is a global string')

--- a/lldb/test/API/lang/objc/foundation/TestSymbolTable.py
+++ b/lldb/test/API/lang/objc/foundation/TestSymbolTable.py
@@ -68,5 +68,5 @@ class FoundationSymtabTestCase(TestBase):
         # At this point, the known_symbols set should have become an empty set.
         # If not, raise an error.
         self.trace("symbols unaccounted for:", expected_symbols)
-        self.assertTrue(len(expected_symbols) == 0,
+        self.assertEqual(len(expected_symbols), 0,
                         "All the known symbols are accounted for")

--- a/lldb/test/API/lang/objc/objc-checker/TestObjCCheckers.py
+++ b/lldb/test/API/lang/objc/objc-checker/TestObjCCheckers.py
@@ -49,12 +49,12 @@ class ObjCCheckerTestCase(TestBase):
         process = target.LaunchSimple(
             None, None, self.get_process_working_directory())
 
-        self.assertTrue(process.GetState() == lldb.eStateStopped,
+        self.assertEqual(process.GetState(), lldb.eStateStopped,
                         PROCESS_STOPPED)
 
         threads = lldbutil.get_threads_stopped_at_breakpoint(
             process, main_bkpt)
-        self.assertTrue(len(threads) == 1)
+        self.assertEqual(len(threads), 1)
         thread = threads[0]
 
         #

--- a/lldb/test/API/lang/objc/objc-class-method/TestObjCClassMethod.py
+++ b/lldb/test/API/lang/objc/objc-class-method/TestObjCClassMethod.py
@@ -47,7 +47,7 @@ class TestObjCClassMethod(TestBase):
         self.assertTrue(
             len(thread_list) != 0,
             "No thread stopped at our breakpoint.")
-        self.assertTrue(len(thread_list) == 1,
+        self.assertEqual(len(thread_list), 1,
                         "More than one thread stopped at our breakpoint.")
 
         # Now make sure we can call a function in the class method we've
@@ -62,4 +62,4 @@ class TestObjCClassMethod(TestBase):
                 print("cmd_value is valid")
                 print("cmd_value has the value %d" % cmd_value.GetValueAsUnsigned())
         self.assertTrue(cmd_value.IsValid())
-        self.assertTrue(cmd_value.GetValueAsUnsigned() == 5)
+        self.assertEqual(cmd_value.GetValueAsUnsigned(), 5)

--- a/lldb/test/API/python_api/disassemble-raw-data/TestDisassembleRawData.py
+++ b/lldb/test/API/python_api/disassemble-raw-data/TestDisassembleRawData.py
@@ -47,13 +47,13 @@ class DisassembleRawDataTestCase(TestBase):
             print("Raw bytes:    ", [hex(x) for x in raw_bytes])
             print("Disassembled%s" % str(inst))
         if re.match("mips", arch):
-            self.assertTrue(inst.GetMnemonic(target) == "move")
-            self.assertTrue(inst.GetOperands(target) ==
+            self.assertEqual(inst.GetMnemonic(target), "move")
+            self.assertEqual(inst.GetOperands(target),
                             '$' + "fp, " + '$' + "sp")
         elif re.match("powerpc64le", arch):
-            self.assertTrue(inst.GetMnemonic(target) == "li")
-            self.assertTrue(inst.GetOperands(target) == "4, 0")
+            self.assertEqual(inst.GetMnemonic(target), "li")
+            self.assertEqual(inst.GetOperands(target), "4, 0")
         else:
-            self.assertTrue(inst.GetMnemonic(target) == "movq")
-            self.assertTrue(inst.GetOperands(target) ==
+            self.assertEqual(inst.GetMnemonic(target), "movq")
+            self.assertEqual(inst.GetOperands(target),
                             '%' + "rsp, " + '%' + "rbp")

--- a/lldb/test/API/python_api/disassemble-raw-data/TestDisassemble_VST1_64.py
+++ b/lldb/test/API/python_api/disassemble-raw-data/TestDisassemble_VST1_64.py
@@ -76,4 +76,4 @@ class Disassemble_VST1_64(TestBase):
             print("Raw bytes:    ", [hex(x) for x in raw_bytes])
             print("Disassembled%s" % str(inst))
 
-        self.assertTrue(inst.GetMnemonic(target) == "vst1.64")
+        self.assertEqual(inst.GetMnemonic(target), "vst1.64")

--- a/lldb/test/API/python_api/event/TestEvents.py
+++ b/lldb/test/API/python_api/event/TestEvents.py
@@ -315,5 +315,5 @@ class EventAPITestCase(TestBase):
         my_thread.join()
 
         # The final judgement. :-)
-        self.assertTrue(self.state == 'stopped',
+        self.assertEqual(self.state, 'stopped',
                         "Both expected state changed events received")

--- a/lldb/test/API/python_api/frame/TestFrames.py
+++ b/lldb/test/API/python_api/frame/TestFrames.py
@@ -38,7 +38,7 @@ class FrameAPITestCase(TestBase):
             None, None, self.get_process_working_directory())
 
         process = target.GetProcess()
-        self.assertTrue(process.GetState() == lldb.eStateStopped,
+        self.assertEqual(process.GetState(), lldb.eStateStopped,
                         PROCESS_STOPPED)
 
         # Keeps track of the number of times 'a' is called where it is within a
@@ -94,8 +94,9 @@ class FrameAPITestCase(TestBase):
                 sp_value = gpr_reg_set.GetChildMemberWithName("sp")
                 self.assertTrue(
                     sp_value, "We should have a valid Stack Pointer.")
-                self.assertTrue(int(sp_value.GetValue(), 0) == frame.GetSP(
-                ), "SP gotten as a value should equal frame's GetSP")
+                self.assertEqual(
+                    int(sp_value.GetValue(), 0), frame.GetSP(),
+                    "SP gotten as a value should equal frame's GetSP")
 
             print("---", file=session)
             process.Continue()
@@ -106,7 +107,7 @@ class FrameAPITestCase(TestBase):
             PROCESS_EXITED)
 
         # Expect to find 'a' on the call stacks two times.
-        self.assertTrue(callsOfA == 2,
+        self.assertEqual(callsOfA, 2,
                         "Expect to find 'a' on the call stacks two times")
         # By design, the 'a' call frame has the following arg vals:
         #     o a((int)val=1, (char)ch='A')
@@ -141,7 +142,7 @@ class FrameAPITestCase(TestBase):
             None, None, self.get_process_working_directory())
 
         process = target.GetProcess()
-        self.assertTrue(process.GetState() == lldb.eStateStopped,
+        self.assertEqual(process.GetState(), lldb.eStateStopped,
                         PROCESS_STOPPED)
 
         thread = lldbutil.get_stopped_thread(
@@ -183,7 +184,7 @@ class FrameAPITestCase(TestBase):
             None, None, self.get_process_working_directory())
 
         process = target.GetProcess()
-        self.assertTrue(process.GetState() == lldb.eStateStopped,
+        self.assertEqual(process.GetState(), lldb.eStateStopped,
                         PROCESS_STOPPED)
 
         thread = lldbutil.get_stopped_thread(

--- a/lldb/test/API/python_api/frame/inlines/TestInlinedFrame.py
+++ b/lldb/test/API/python_api/frame/inlines/TestInlinedFrame.py
@@ -47,7 +47,7 @@ class InlinedFrameAPITestCase(TestBase):
             None, None, self.get_process_working_directory())
 
         process = target.GetProcess()
-        self.assertTrue(process.GetState() == lldb.eStateStopped,
+        self.assertEqual(process.GetState(), lldb.eStateStopped,
                         PROCESS_STOPPED)
 
         import lldbsuite.test.lldbutil as lldbutil
@@ -70,7 +70,7 @@ class InlinedFrameAPITestCase(TestBase):
         frame0 = thread.GetFrameAtIndex(0)
         if frame0.IsInlined():
             filename = frame0.GetLineEntry().GetFileSpec().GetFilename()
-            self.assertTrue(filename == self.source)
+            self.assertEqual(filename, self.source)
             self.expect(
                 stack_traces1, "First stop at %s:%d" %
                 (self.source, self.first_stop), exe=False, substrs=[
@@ -79,7 +79,7 @@ class InlinedFrameAPITestCase(TestBase):
 
             # Expect to break again for the second time.
             process.Continue()
-            self.assertTrue(process.GetState() == lldb.eStateStopped,
+            self.assertEqual(process.GetState(), lldb.eStateStopped,
                             PROCESS_STOPPED)
             stack_traces2 = lldbutil.print_stacktraces(
                 process, string_buffer=True)

--- a/lldb/test/API/python_api/function_symbol/TestDisasmAPI.py
+++ b/lldb/test/API/python_api/function_symbol/TestDisasmAPI.py
@@ -53,7 +53,7 @@ class DisasmAPITestCase(TestBase):
         self.assertTrue(process, PROCESS_IS_VALID)
 
         # Frame #0 should be on self.line1.
-        self.assertTrue(process.GetState() == lldb.eStateStopped)
+        self.assertEqual(process.GetState(), lldb.eStateStopped)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)
         self.assertTrue(
@@ -61,7 +61,7 @@ class DisasmAPITestCase(TestBase):
             "There should be a thread stopped due to breakpoint condition")
         frame0 = thread.GetFrameAtIndex(0)
         lineEntry = frame0.GetLineEntry()
-        self.assertTrue(lineEntry.GetLine() == self.line1)
+        self.assertEqual(lineEntry.GetLine(), self.line1)
 
         address1 = lineEntry.GetStartAddress()
         self.trace("address1:", address1)
@@ -76,7 +76,7 @@ class DisasmAPITestCase(TestBase):
 
         # Continue the inferior, the breakpoint 2 should be hit.
         process.Continue()
-        self.assertTrue(process.GetState() == lldb.eStateStopped)
+        self.assertEqual(process.GetState(), lldb.eStateStopped)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)
         self.assertTrue(
@@ -84,7 +84,7 @@ class DisasmAPITestCase(TestBase):
             "There should be a thread stopped due to breakpoint condition")
         frame0 = thread.GetFrameAtIndex(0)
         lineEntry = frame0.GetLineEntry()
-        self.assertTrue(lineEntry.GetLine() == self.line2)
+        self.assertEqual(lineEntry.GetLine(), self.line2)
 
         # Verify that the symbol and the function has the same address range
         # per function 'a'.

--- a/lldb/test/API/python_api/function_symbol/TestSymbolAPI.py
+++ b/lldb/test/API/python_api/function_symbol/TestSymbolAPI.py
@@ -53,7 +53,7 @@ class SymbolAPITestCase(TestBase):
         self.assertTrue(process, PROCESS_IS_VALID)
 
         # Frame #0 should be on self.line1.
-        self.assertTrue(process.GetState() == lldb.eStateStopped)
+        self.assertEqual(process.GetState(), lldb.eStateStopped)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)
         self.assertTrue(
@@ -62,7 +62,7 @@ class SymbolAPITestCase(TestBase):
         frame0 = thread.GetFrameAtIndex(0)
         symbol_line1 = frame0.GetSymbol()
         # We should have a symbol type of code.
-        self.assertTrue(symbol_line1.GetType() == lldb.eSymbolTypeCode)
+        self.assertEqual(symbol_line1.GetType(), lldb.eSymbolTypeCode)
         addr_line1 = symbol_line1.GetStartAddress()
         # And a section type of code, too.
         self.assertTrue(addr_line1.GetSection().GetSectionType()
@@ -70,7 +70,7 @@ class SymbolAPITestCase(TestBase):
 
         # Continue the inferior, the breakpoint 2 should be hit.
         process.Continue()
-        self.assertTrue(process.GetState() == lldb.eStateStopped)
+        self.assertEqual(process.GetState(), lldb.eStateStopped)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)
         self.assertTrue(
@@ -79,7 +79,7 @@ class SymbolAPITestCase(TestBase):
         frame0 = thread.GetFrameAtIndex(0)
         symbol_line2 = frame0.GetSymbol()
         # We should have a symbol type of code.
-        self.assertTrue(symbol_line2.GetType() == lldb.eSymbolTypeCode)
+        self.assertEqual(symbol_line2.GetType(), lldb.eSymbolTypeCode)
         addr_line2 = symbol_line2.GetStartAddress()
         # And a section type of code, too.
         self.assertTrue(addr_line2.GetSection().GetSectionType()

--- a/lldb/test/API/python_api/lldbutil/frame/TestFrameUtils.py
+++ b/lldb/test/API/python_api/lldbutil/frame/TestFrameUtils.py
@@ -40,7 +40,7 @@ class FrameUtilsTestCase(TestBase):
 
         if not process:
             self.fail("SBTarget.LaunchProcess() failed")
-        self.assertTrue(process.GetState() == lldb.eStateStopped,
+        self.assertEqual(process.GetState(), lldb.eStateStopped,
                         PROCESS_STOPPED)
 
         import lldbsuite.test.lldbutil as lldbutil

--- a/lldb/test/API/python_api/lldbutil/iter/TestLLDBIterator.py
+++ b/lldb/test/API/python_api/lldbutil/iter/TestLLDBIterator.py
@@ -50,7 +50,7 @@ class LLDBIteratorTestCase(TestBase):
         for m in target.module_iter():
             mine.append(m)
 
-        self.assertTrue(len(yours) == len(mine))
+        self.assertEqual(len(yours), len(mine))
         for i in range(len(yours)):
             if self.TraceOn():
                 print("yours[%d]='%s'" % (i, get_description(yours[i])))
@@ -73,7 +73,7 @@ class LLDBIteratorTestCase(TestBase):
         breakpoint = target.BreakpointCreateByLocation("main.cpp", self.line2)
         self.assertTrue(breakpoint, VALID_BREAKPOINT)
 
-        self.assertTrue(target.GetNumBreakpoints() == 2)
+        self.assertEqual(target.GetNumBreakpoints(), 2)
 
         from lldbsuite.test.lldbutil import get_description
         yours = []
@@ -83,12 +83,12 @@ class LLDBIteratorTestCase(TestBase):
         for b in target.breakpoint_iter():
             mine.append(b)
 
-        self.assertTrue(len(yours) == len(mine))
+        self.assertEqual(len(yours), len(mine))
         for i in range(len(yours)):
             if self.TraceOn():
                 print("yours[%d]='%s'" % (i, get_description(yours[i])))
                 print("mine[%d]='%s'" % (i, get_description(mine[i])))
-            self.assertTrue(yours[i] == mine[i],
+            self.assertEqual(yours[i], mine[i],
                             "ID of yours[{0}] and mine[{0}] matches".format(i))
 
     @add_test_categories(['pyapi'])
@@ -119,7 +119,7 @@ class LLDBIteratorTestCase(TestBase):
             if thread.GetStopReason() == lldb.eStopReasonBreakpoint:
                 stopped_due_to_breakpoint = True
             for frame in thread:
-                self.assertTrue(frame.GetThread().GetThreadID() == ID)
+                self.assertEqual(frame.GetThread().GetThreadID(), ID)
                 if self.TraceOn():
                     print(frame)
 

--- a/lldb/test/API/python_api/process/io/TestProcessIO.py
+++ b/lldb/test/API/python_api/process/io/TestProcessIO.py
@@ -201,7 +201,7 @@ class ProcessIOTestCase(TestBase):
         threads = lldbutil.get_threads_stopped_at_breakpoint(
             self.process, self.breakpoint)
 
-        self.assertTrue(len(threads) == 1)
+        self.assertEqual(len(threads), 1)
         self.thread = threads[0]
         self.frame = self.thread.frames[0]
         self.assertTrue(self.frame, "Frame 0 is valid.")
@@ -217,7 +217,7 @@ class ProcessIOTestCase(TestBase):
         # Let process continue so it will exit
         self.process.Continue()
         state = self.process.GetState()
-        self.assertTrue(state == lldb.eStateExited, PROCESS_IS_VALID)
+        self.assertEqual(state, lldb.eStateExited, PROCESS_IS_VALID)
 
     def check_process_output(self, output, error):
             # Since we launched the process without specifying stdin/out/err,

--- a/lldb/test/API/python_api/process/read-mem-cstring/TestReadMemCString.py
+++ b/lldb/test/API/python_api/process/read-mem-cstring/TestReadMemCString.py
@@ -48,11 +48,11 @@ class TestReadMemCString(TestBase):
         # None object.
         empty_str = process.ReadCStringFromMemory(empty_str_addr, 2048, err)
         self.assertTrue(err.Success())
-        self.assertTrue(empty_str == "")
+        self.assertEqual(empty_str, "")
 
         one_letter_string = process.ReadCStringFromMemory(one_letter_str_addr, 2048, err)
         self.assertTrue(err.Success())
-        self.assertTrue(one_letter_string == "1")
+        self.assertEqual(one_letter_string, "1")
 
         invalid_memory_string = process.ReadCStringFromMemory(invalid_memory_str_addr, 2048, err)
         self.assertTrue(err.Fail())

--- a/lldb/test/API/python_api/sbdata/TestSBData.py
+++ b/lldb/test/API/python_api/sbdata/TestSBData.py
@@ -30,16 +30,16 @@ class SBDataAPICase(TestBase):
         data = lldb.SBData()
         data.SetData(error, addr_data, lldb.eByteOrderBig, 4)
         addr = data.GetAddress(error, 0)
-        self.assertTrue(addr == 0x11223344);
+        self.assertEqual(addr, 0x11223344);
         data.SetData(error, addr_data, lldb.eByteOrderBig, 8)
         addr = data.GetAddress(error, 0)
-        self.assertTrue(addr == 0x1122334455667788);
+        self.assertEqual(addr, 0x1122334455667788);
         data.SetData(error, addr_data, lldb.eByteOrderLittle, 4)
         addr = data.GetAddress(error, 0)
-        self.assertTrue(addr == 0x44332211);
+        self.assertEqual(addr, 0x44332211);
         data.SetData(error, addr_data, lldb.eByteOrderLittle, 8)
         addr = data.GetAddress(error, 0)
-        self.assertTrue(addr == 0x8877665544332211);
+        self.assertEqual(addr, 0x8877665544332211);
 
     @add_test_categories(['pyapi'])
     @skipIfReproducer # SBData::SetData is not instrumented.
@@ -146,8 +146,8 @@ class SBDataAPICase(TestBase):
         self.assertTrue(new_foobar.IsValid())
         data = new_foobar.GetData()
 
-        self.assertTrue(data.uint32[0] == 8, 'then foo[1].a == 8')
-        self.assertTrue(data.uint32[1] == 7, 'then foo[1].b == 7')
+        self.assertEqual(data.uint32[0], 8, 'then foo[1].a == 8')
+        self.assertEqual(data.uint32[1], 7, 'then foo[1].b == 7')
         # exploiting that sizeof(uint32) == sizeof(float)
         self.assertTrue(fabs(data.float[2] - 3.14) < 1, 'foo[1].c == 3.14')
 
@@ -218,7 +218,7 @@ class SBDataAPICase(TestBase):
         new_object = barfoo.CreateValueFromData(
             "new_object", data, barfoo.GetType().GetBasicType(
                 lldb.eBasicTypeInt))
-        self.assertTrue(new_object.GetValue() == "1", 'new_object == 1')
+        self.assertEqual(new_object.GetValue(), "1", 'new_object == 1')
 
         if data.GetByteOrder() == lldb.eByteOrderBig:
             data.SetData(
@@ -262,12 +262,12 @@ class SBDataAPICase(TestBase):
         hello_str = "hello!"
         data2 = lldb.SBData.CreateDataFromCString(
             process.GetByteOrder(), process.GetAddressByteSize(), hello_str)
-        self.assertTrue(len(data2.uint8) == len(hello_str))
-        self.assertTrue(data2.uint8[0] == 104, 'h == 104')
-        self.assertTrue(data2.uint8[1] == 101, 'e == 101')
-        self.assertTrue(data2.uint8[2] == 108, 'l == 108')
+        self.assertEqual(len(data2.uint8), len(hello_str))
+        self.assertEqual(data2.uint8[0], 104, 'h == 104')
+        self.assertEqual(data2.uint8[1], 101, 'e == 101')
+        self.assertEqual(data2.uint8[2], 108, 'l == 108')
         self.assert_data(data2.GetUnsignedInt8, 3, 108)  # l
-        self.assertTrue(data2.uint8[4] == 111, 'o == 111')
+        self.assertEqual(data2.uint8[4], 111, 'o == 111')
         self.assert_data(data2.GetUnsignedInt8, 5, 33)  # !
 
         uint_lists = [[1, 2, 3, 4, 5], [int(i) for i in [1, 2, 3, 4, 5]]]
@@ -415,7 +415,7 @@ class SBDataAPICase(TestBase):
         data2 = lldb.SBData()
 
         data2.SetDataFromCString(hello_str)
-        self.assertTrue(len(data2.uint8) == len(hello_str))
+        self.assertEqual(len(data2.uint8), len(hello_str))
         self.assert_data(data2.GetUnsignedInt8, 0, 104)
         self.assert_data(data2.GetUnsignedInt8, 1, 101)
         self.assert_data(data2.GetUnsignedInt8, 2, 108)

--- a/lldb/test/API/python_api/symbol-context/TestSymbolContext.py
+++ b/lldb/test/API/python_api/symbol-context/TestSymbolContext.py
@@ -49,7 +49,7 @@ class SymbolContextAPITestCase(TestBase):
         self.assertTrue(thread.IsValid(),
                         "There should be a thread stopped due to breakpoint")
         frame0 = thread.GetFrameAtIndex(0)
-        self.assertTrue(frame0.GetLineEntry().GetLine() == self.line)
+        self.assertEqual(frame0.GetLineEntry().GetLine(), self.line)
 
         # Now get the SBSymbolContext from this frame.  We want everything. :-)
         context = frame0.GetSymbolContext(lldb.eSymbolContextEverything)
@@ -81,7 +81,7 @@ class SymbolContextAPITestCase(TestBase):
                     "The line entry should have the correct filename",
                     exe=False,
                     substrs=['main.c'])
-        self.assertTrue(lineEntry.GetLine() == self.line,
+        self.assertEqual(lineEntry.GetLine(), self.line,
                         "The line entry's line number should match ")
 
         symbol = context.GetSymbol()

--- a/lldb/test/API/python_api/target/TestTargetAPI.py
+++ b/lldb/test/API/python_api/target/TestTargetAPI.py
@@ -244,11 +244,11 @@ class TargetAPITestCase(TestBase):
         # Make sure we hit our breakpoint:
         thread_list = lldbutil.get_threads_stopped_at_breakpoint(
             process, breakpoint)
-        self.assertTrue(len(thread_list) == 1)
+        self.assertEqual(len(thread_list), 1)
 
         value_list = target.FindGlobalVariables(
             'my_global_var_of_char_type', 3)
-        self.assertTrue(value_list.GetSize() == 1)
+        self.assertEqual(value_list.GetSize(), 1)
         my_global_var = value_list.GetValueAtIndex(0)
         self.DebugSBValue(my_global_var)
         self.assertTrue(my_global_var)
@@ -267,7 +267,7 @@ class TargetAPITestCase(TestBase):
                 if os.path.normpath(m.GetFileSpec().GetDirectory()) == self.getBuildDir() and m.GetFileSpec().GetFilename() == exe_name:
                     value_list = m.FindGlobalVariables(
                         target, 'my_global_var_of_char_type', 3)
-                    self.assertTrue(value_list.GetSize() == 1)
+                    self.assertEqual(value_list.GetSize(), 1)
                     self.assertTrue(
                         value_list.GetValueAtIndex(0).GetValue() == "'X'")
                     break
@@ -296,15 +296,15 @@ class TargetAPITestCase(TestBase):
 
         # Try it with a null name:
         list = target.FindFunctions(None, lldb.eFunctionNameTypeAuto)
-        self.assertTrue(list.GetSize() == 0)
+        self.assertEqual(list.GetSize(), 0)
 
         list = target.FindFunctions('c', lldb.eFunctionNameTypeAuto)
-        self.assertTrue(list.GetSize() == 1)
+        self.assertEqual(list.GetSize(), 1)
 
         for sc in list:
             self.assertTrue(
                 sc.GetModule().GetFileSpec().GetFilename() == exe_name)
-            self.assertTrue(sc.GetSymbol().GetName() == 'c')
+            self.assertEqual(sc.GetSymbol().GetName(), 'c')
 
     def get_description(self):
         """Exercise SBTaget.GetDescription() API."""
@@ -422,7 +422,7 @@ class TargetAPITestCase(TestBase):
         self.assertTrue(process, PROCESS_IS_VALID)
 
         # Frame #0 should be on self.line1.
-        self.assertTrue(process.GetState() == lldb.eStateStopped)
+        self.assertEqual(process.GetState(), lldb.eStateStopped)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)
         self.assertTrue(
@@ -431,13 +431,13 @@ class TargetAPITestCase(TestBase):
         #self.runCmd("process status")
         frame0 = thread.GetFrameAtIndex(0)
         lineEntry = frame0.GetLineEntry()
-        self.assertTrue(lineEntry.GetLine() == self.line1)
+        self.assertEqual(lineEntry.GetLine(), self.line1)
 
         address1 = lineEntry.GetStartAddress()
 
         # Continue the inferior, the breakpoint 2 should be hit.
         process.Continue()
-        self.assertTrue(process.GetState() == lldb.eStateStopped)
+        self.assertEqual(process.GetState(), lldb.eStateStopped)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)
         self.assertTrue(
@@ -446,7 +446,7 @@ class TargetAPITestCase(TestBase):
         #self.runCmd("process status")
         frame0 = thread.GetFrameAtIndex(0)
         lineEntry = frame0.GetLineEntry()
-        self.assertTrue(lineEntry.GetLine() == self.line2)
+        self.assertEqual(lineEntry.GetLine(), self.line2)
 
         address2 = lineEntry.GetStartAddress()
 

--- a/lldb/test/API/python_api/thread/TestThreadAPI.py
+++ b/lldb/test/API/python_api/thread/TestThreadAPI.py
@@ -203,7 +203,7 @@ class ThreadAPITestCase(TestBase):
         self.assertTrue(process, PROCESS_IS_VALID)
 
         # Frame #0 should be on self.step_out_of_malloc.
-        self.assertTrue(process.GetState() == lldb.eStateStopped)
+        self.assertEqual(process.GetState(), lldb.eStateStopped)
         thread = get_stopped_thread(process, lldb.eStopReasonBreakpoint)
         self.assertTrue(
             thread.IsValid(),
@@ -211,7 +211,7 @@ class ThreadAPITestCase(TestBase):
         self.runCmd("thread backtrace")
         frame0 = thread.GetFrameAtIndex(0)
         lineEntry = frame0.GetLineEntry()
-        self.assertTrue(lineEntry.GetLine() == self.step_out_of_malloc)
+        self.assertEqual(lineEntry.GetLine(), self.step_out_of_malloc)
 
         thread.StepOver()
         thread.StepOver()
@@ -222,13 +222,13 @@ class ThreadAPITestCase(TestBase):
         # main2.cpp.
         frame0 = thread.GetFrameAtIndex(0)
         lineEntry = frame0.GetLineEntry()
-        self.assertTrue(thread.GetStopReason() == lldb.eStopReasonPlanComplete)
+        self.assertEqual(thread.GetStopReason(), lldb.eStopReasonPlanComplete)
         # Expected failure with clang as the compiler.
         # rdar://problem/9223880
         #
         # Which has been fixed on the lldb by compensating for inaccurate line
         # table information with r140416.
-        self.assertTrue(lineEntry.GetLine() == self.after_3_step_overs)
+        self.assertEqual(lineEntry.GetLine(), self.after_3_step_overs)
 
     def run_to_address(self, exe_name):
         """Test Python SBThread.RunToAddress() API."""
@@ -249,7 +249,7 @@ class ThreadAPITestCase(TestBase):
         self.assertTrue(process, PROCESS_IS_VALID)
 
         # Frame #0 should be on self.step_out_of_malloc.
-        self.assertTrue(process.GetState() == lldb.eStateStopped)
+        self.assertEqual(process.GetState(), lldb.eStateStopped)
         thread = get_stopped_thread(process, lldb.eStopReasonBreakpoint)
         self.assertTrue(
             thread.IsValid(),
@@ -257,7 +257,7 @@ class ThreadAPITestCase(TestBase):
         self.runCmd("thread backtrace")
         frame0 = thread.GetFrameAtIndex(0)
         lineEntry = frame0.GetLineEntry()
-        self.assertTrue(lineEntry.GetLine() == self.step_out_of_malloc)
+        self.assertEqual(lineEntry.GetLine(), self.step_out_of_malloc)
 
         # Get the start/end addresses for this line entry.
         start_addr = lineEntry.GetStartAddress().GetLoadAddress(target)

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -47,7 +47,7 @@ class TypeAndTypeListTestCase(TestBase):
         self.assertTrue(process, PROCESS_IS_VALID)
 
         # Get Frame #0.
-        self.assertTrue(process.GetState() == lldb.eStateStopped)
+        self.assertEqual(process.GetState(), lldb.eStateStopped)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)
         self.assertTrue(
@@ -113,13 +113,13 @@ class TypeAndTypeListTestCase(TestBase):
         self.DebugSBType(task_head_type)
         self.assertTrue(task_head_type.IsPointerType())
 
-        self.assertTrue(task_head_type == task_pointer_type)
+        self.assertEqual(task_head_type, task_pointer_type)
 
         # Get the pointee type of 'task_head'.
         task_head_pointee_type = task_head_type.GetPointeeType()
         self.DebugSBType(task_head_pointee_type)
 
-        self.assertTrue(task_type == task_head_pointee_type)
+        self.assertEqual(task_type, task_head_pointee_type)
 
         # We'll now get the child member 'id' from 'task_head'.
         id = task_head.GetChildMemberWithName('id')
@@ -130,7 +130,7 @@ class TypeAndTypeListTestCase(TestBase):
         # SBType.GetBasicType() takes an enum 'BasicType'
         # (lldb-enumerations.h).
         int_type = id_type.GetBasicType(lldb.eBasicTypeInt)
-        self.assertTrue(id_type == int_type)
+        self.assertEqual(id_type, int_type)
 
         # Find 'myint_arr' and check the array element type.
         myint_arr = frame0.FindVariable('myint_arr')
@@ -143,7 +143,7 @@ class TypeAndTypeListTestCase(TestBase):
         self.DebugSBType(myint_arr_element_type)
         myint_type = target.FindFirstType('myint')
         self.DebugSBType(myint_type)
-        self.assertTrue(myint_arr_element_type == myint_type)
+        self.assertEqual(myint_arr_element_type, myint_type)
 
         # Test enum methods. Requires DW_AT_enum_class which was added in Dwarf 4.
         if configuration.dwarf_version >= 4:

--- a/lldb/test/API/python_api/value/TestValueAPI.py
+++ b/lldb/test/API/python_api/value/TestValueAPI.py
@@ -46,7 +46,7 @@ class ValueAPITestCase(TestBase):
         self.assertTrue(process, PROCESS_IS_VALID)
 
         # Get Frame #0.
-        self.assertTrue(process.GetState() == lldb.eStateStopped)
+        self.assertEqual(process.GetState(), lldb.eStateStopped)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)
         self.assertTrue(
@@ -79,14 +79,14 @@ class ValueAPITestCase(TestBase):
         list = target.FindGlobalVariables('weekdays', 1)
         weekdays = list.GetValueAtIndex(0)
         self.assertTrue(weekdays, VALID_VARIABLE)
-        self.assertTrue(weekdays.GetNumChildren() == 5, VALID_VARIABLE)
+        self.assertEqual(weekdays.GetNumChildren(), 5, VALID_VARIABLE)
         self.DebugSBValue(weekdays)
 
         # Get global variable 'g_table'.
         list = target.FindGlobalVariables('g_table', 1)
         g_table = list.GetValueAtIndex(0)
         self.assertTrue(g_table, VALID_VARIABLE)
-        self.assertTrue(g_table.GetNumChildren() == 2, VALID_VARIABLE)
+        self.assertEqual(g_table.GetNumChildren(), 2, VALID_VARIABLE)
         self.DebugSBValue(g_table)
 
         fmt = lldbutil.BasicFormatter()
@@ -126,9 +126,9 @@ class ValueAPITestCase(TestBase):
         # Verify the SBValue::GetByteSize() API is working correctly.
         arch = self.getArchitecture()
         if arch == 'i386':
-            self.assertTrue(value.GetByteSize() == 4)
+            self.assertEqual(value.GetByteSize(), 4)
         elif arch == 'x86_64':
-            self.assertTrue(value.GetByteSize() == 8)
+            self.assertEqual(value.GetByteSize(), 8)
 
         # Get child at index 5 => 'Friday'.
         child = value.GetChildAtIndex(5, lldb.eNoDynamicValues, True)

--- a/lldb/test/API/python_api/value/linked_list/TestValueAPILinkedList.py
+++ b/lldb/test/API/python_api/value/linked_list/TestValueAPILinkedList.py
@@ -50,7 +50,7 @@ class ValueAsLinkedListTestCase(TestBase):
         self.assertTrue(process, PROCESS_IS_VALID)
 
         # Get Frame #0.
-        self.assertTrue(process.GetState() == lldb.eStateStopped)
+        self.assertEqual(process.GetState(), lldb.eStateStopped)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)
         self.assertTrue(
@@ -80,7 +80,7 @@ class ValueAsLinkedListTestCase(TestBase):
         # Sanity checks that the we visited all the items (no more, no less).
         if self.TraceOn():
             print("visited IDs:", list)
-        self.assertTrue(visitedIDs == list)
+        self.assertEqual(visitedIDs, list)
 
         # Let's exercise the linked_list_iter() API again, this time supplying
         # our end of list test function.
@@ -111,7 +111,7 @@ class ValueAsLinkedListTestCase(TestBase):
         # Sanity checks that the we visited all the items (no more, no less).
         if self.TraceOn():
             print("visited IDs:", list)
-        self.assertTrue(visitedIDs == list)
+        self.assertEqual(visitedIDs, list)
 
         # Get variable 'empty_task_head'.
         empty_task_head = frame0.FindVariable('empty_task_head')
@@ -125,7 +125,7 @@ class ValueAsLinkedListTestCase(TestBase):
                 print(cvf.format(t))
             list.append(int(t.GetChildMemberWithName("id").GetValue()))
 
-        self.assertTrue(len(list) == 0)
+        self.assertEqual(len(list), 0)
 
         # Get variable 'task_evil'.
         task_evil = frame0.FindVariable('task_evil')
@@ -139,4 +139,4 @@ class ValueAsLinkedListTestCase(TestBase):
                 print(cvf.format(t))
             list.append(int(t.GetChildMemberWithName("id").GetValue()))
 
-        self.assertTrue(len(list) == 3)
+        self.assertEqual(len(list), 3)

--- a/lldb/test/API/python_api/watchpoint/TestSetWatchpoint.py
+++ b/lldb/test/API/python_api/watchpoint/TestSetWatchpoint.py
@@ -49,7 +49,7 @@ class SetWatchpointAPITestCase(TestBase):
 
         # We should be stopped due to the breakpoint.  Get frame #0.
         process = target.GetProcess()
-        self.assertTrue(process.GetState() == lldb.eStateStopped,
+        self.assertEqual(process.GetState(), lldb.eStateStopped,
                         PROCESS_STOPPED)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)

--- a/lldb/test/API/python_api/watchpoint/TestWatchpointIter.py
+++ b/lldb/test/API/python_api/watchpoint/TestWatchpointIter.py
@@ -52,7 +52,7 @@ class WatchpointIteratorTestCase(TestBase):
 
         # We should be stopped due to the breakpoint.  Get frame #0.
         process = target.GetProcess()
-        self.assertTrue(process.GetState() == lldb.eStateStopped,
+        self.assertEqual(process.GetState(), lldb.eStateStopped,
                         PROCESS_STOPPED)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)
@@ -71,7 +71,7 @@ class WatchpointIteratorTestCase(TestBase):
             self.HideStdout()
 
         # There should be only 1 watchpoint location under the target.
-        self.assertTrue(target.GetNumWatchpoints() == 1)
+        self.assertEqual(target.GetNumWatchpoints(), 1)
         self.assertTrue(watchpoint.IsEnabled())
         watch_id = watchpoint.GetID()
         self.assertTrue(watch_id != 0)
@@ -105,7 +105,7 @@ class WatchpointIteratorTestCase(TestBase):
         # Now disable the 'rw' watchpoint.  The program won't stop when it reads
         # 'global' next.
         watchpoint.SetEnabled(False)
-        self.assertTrue(watchpoint.GetHardwareIndex() == -1)
+        self.assertEqual(watchpoint.GetHardwareIndex(), -1)
         self.assertFalse(watchpoint.IsEnabled())
 
         # Continue.  The program does not stop again when the variable is being
@@ -120,6 +120,6 @@ class WatchpointIteratorTestCase(TestBase):
         # Verify some vital statistics and exercise the iterator API.
         for watchpoint in target.watchpoint_iter():
             self.assertTrue(watchpoint)
-            self.assertTrue(watchpoint.GetWatchSize() == 4)
-            self.assertTrue(watchpoint.GetHitCount() == 1)
+            self.assertEqual(watchpoint.GetWatchSize(), 4)
+            self.assertEqual(watchpoint.GetHitCount(), 1)
             print(watchpoint)

--- a/lldb/test/API/python_api/watchpoint/condition/TestWatchpointConditionAPI.py
+++ b/lldb/test/API/python_api/watchpoint/condition/TestWatchpointConditionAPI.py
@@ -54,7 +54,7 @@ class WatchpointConditionAPITestCase(TestBase):
 
         # We should be stopped due to the breakpoint.  Get frame #0.
         process = target.GetProcess()
-        self.assertTrue(process.GetState() == lldb.eStateStopped,
+        self.assertEqual(process.GetState(), lldb.eStateStopped,
                         PROCESS_STOPPED)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)
@@ -92,4 +92,4 @@ class WatchpointConditionAPITestCase(TestBase):
         self.DebugSBValue(value)
 
         # Verify that the condition is met.
-        self.assertTrue(value.GetValueAsUnsigned() == 5)
+        self.assertEqual(value.GetValueAsUnsigned(), 5)

--- a/lldb/test/API/python_api/watchpoint/watchlocation/TestSetWatchlocation.py
+++ b/lldb/test/API/python_api/watchpoint/watchlocation/TestSetWatchlocation.py
@@ -50,7 +50,7 @@ class SetWatchlocationAPITestCase(TestBase):
 
         # We should be stopped due to the breakpoint.  Get frame #0.
         process = target.GetProcess()
-        self.assertTrue(process.GetState() == lldb.eStateStopped,
+        self.assertEqual(process.GetState(), lldb.eStateStopped,
                         PROCESS_STOPPED)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)

--- a/lldb/test/API/python_api/watchpoint/watchlocation/TestTargetWatchAddress.py
+++ b/lldb/test/API/python_api/watchpoint/watchlocation/TestTargetWatchAddress.py
@@ -49,7 +49,7 @@ class TargetWatchAddressAPITestCase(TestBase):
 
         # We should be stopped due to the breakpoint.  Get frame #0.
         process = target.GetProcess()
-        self.assertTrue(process.GetState() == lldb.eStateStopped,
+        self.assertEqual(process.GetState(), lldb.eStateStopped,
                         PROCESS_STOPPED)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)
@@ -124,7 +124,7 @@ class TargetWatchAddressAPITestCase(TestBase):
 
         # We should be stopped due to the breakpoint.  Get frame #0.
         process = target.GetProcess()
-        self.assertTrue(process.GetState() == lldb.eStateStopped,
+        self.assertEqual(process.GetState(), lldb.eStateStopped,
                         PROCESS_STOPPED)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)

--- a/lldb/test/API/terminal/TestSTTYBeforeAndAfter.py
+++ b/lldb/test/API/terminal/TestSTTYBeforeAndAfter.py
@@ -111,4 +111,4 @@ class TestSTTYBeforeAndAfter(TestBase):
             # Every line should compare equal until the first blank line.
             if len(tuple[0]) == 0:
                 break
-            self.assertTrue(tuple[0] == tuple[1])
+            self.assertEqual(tuple[0], tuple[1])

--- a/lldb/test/API/tools/lldb-server/registers-target-xml-reading/TestGdbRemoteTargetXmlPacket.py
+++ b/lldb/test/API/tools/lldb-server/registers-target-xml-reading/TestGdbRemoteTargetXmlPacket.py
@@ -55,7 +55,7 @@ class TestGdbRemoteTargetXmlPacket(gdbremote_testcase.GdbRemoteTestCaseBase):
         self.assertIsNotNone(context)
         q_info_registers = self.parse_register_info_packets(context)
 
-        self.assertTrue(len(target_xml_registers) == len(q_info_registers))
+        self.assertEqual(len(target_xml_registers), len(q_info_registers))
         for register in zip(target_xml_registers, q_info_registers):
             xml_info_reg = register[0]
             q_info_reg = register[1]

--- a/lldb/test/API/tools/lldb-vscode/breakpoint-events/TestVSCode_breakpointEvents.py
+++ b/lldb/test/API/tools/lldb-vscode/breakpoint-events/TestVSCode_breakpointEvents.py
@@ -91,7 +91,7 @@ class TestVSCode_breakpointEvents(lldbvscode_testcase.VSCodeTestCaseBase):
         # We are now stopped at the entry point to the program. Shared
         # libraries are not loaded yet (at least on macOS they aren't) and any
         # breakpoints set in foo.cpp should not be resolved.
-        self.assertTrue(len(self.vscode.breakpoint_events) == 0,
+        self.assertEqual(len(self.vscode.breakpoint_events), 0,
                         "no breakpoint events when stopped at entry point")
 
         # Continue to the breakpoint
@@ -100,17 +100,17 @@ class TestVSCode_breakpointEvents(lldbvscode_testcase.VSCodeTestCaseBase):
         # Make sure we only get an event for the breakpoint we set via a call
         # to self.vscode.request_setBreakpoints(...), not the breakpoint
         # we set with with a LLDB command in preRunCommands.
-        self.assertTrue(len(self.vscode.breakpoint_events) == 1,
+        self.assertEqual(len(self.vscode.breakpoint_events), 1,
                         "make sure we got a breakpoint event")
         event = self.vscode.breakpoint_events[0]
         # Verify the details of the breakpoint changed notification.
         body = event['body']
-        self.assertTrue(body['reason'] == 'changed',
+        self.assertEqual(body['reason'], 'changed',
                 "breakpoint event is says breakpoint is changed")
         breakpoint = body['breakpoint']
-        self.assertTrue(breakpoint['verified'] == True,
+        self.assertTrue(breakpoint['verified'],
                 "breakpoint event is says it is verified")
-        self.assertTrue(breakpoint['id'] == foo_bp_id,
+        self.assertEqual(breakpoint['id'], foo_bp_id,
                 "breakpoint event is for breakpoint %i" % (foo_bp_id))
         self.assertTrue('line' in breakpoint and breakpoint['line'] > 0,
                 "breakpoint event is has a line number")

--- a/lldb/test/API/tools/lldb-vscode/console/TestVSCode_console.py
+++ b/lldb/test/API/tools/lldb-vscode/console/TestVSCode_console.py
@@ -47,7 +47,7 @@ class TestVSCode_console(lldbvscode_testcase.VSCodeTestCaseBase):
         lines = [breakpoint1_line]
         # Set breakpoint in the thread function so we can step the threads
         breakpoint_ids = self.set_source_breakpoints(source, lines)
-        self.assertTrue(len(breakpoint_ids) == len(lines),
+        self.assertEqual(len(breakpoint_ids), len(lines),
                         "expect correct number of breakpoints")
         self.continue_to_breakpoints(breakpoint_ids)
         # Cause a "scopes" to be sent for frame zero which should update the

--- a/lldb/test/API/tools/lldb-vscode/module/TestVSCode_module.py
+++ b/lldb/test/API/tools/lldb-vscode/module/TestVSCode_module.py
@@ -98,8 +98,8 @@ class TestVSCode_module(lldbvscode_testcase.VSCodeTestCaseBase):
         moduleId = self.vscode.get_active_modules()['a.out']['id']
         response = self.vscode.request_getCompileUnits(moduleId)
         self.assertTrue(response['body'])
-        self.assertTrue(len(response['body']['compileUnits']) == 1,
+        self.assertEqual(len(response['body']['compileUnits']), 1,
                         'Only one source file should exist')
-        self.assertTrue(response['body']['compileUnits'][0]['compileUnitPath'] == main_source_path,
+        self.assertEqual(response['body']['compileUnits'][0]['compileUnitPath'], main_source_path,
                         'Real path to main.cpp matches')
 

--- a/lldb/test/API/tools/lldb-vscode/variables/TestVSCode_variables.py
+++ b/lldb/test/API/tools/lldb-vscode/variables/TestVSCode_variables.py
@@ -29,7 +29,7 @@ class TestVSCode_variables(lldbvscode_testcase.VSCodeTestCaseBase):
             for key in verify:
                 verify_value = verify[key]
                 actual_value = actual[key]
-                self.assertTrue(verify_value == actual_value,
+                self.assertEqual(verify_value, actual_value,
                                 '"%s" keys don\'t match (%s != %s)' % (
                                     key, actual_value, verify_value))
         if 'startswith' in verify_dict:
@@ -87,7 +87,7 @@ class TestVSCode_variables(lldbvscode_testcase.VSCodeTestCaseBase):
         lines = [breakpoint1_line]
         # Set breakpoint in the thread function so we can step the threads
         breakpoint_ids = self.set_source_breakpoints(source, lines)
-        self.assertTrue(len(breakpoint_ids) == len(lines),
+        self.assertEqual(len(breakpoint_ids), len(lines),
                         "expect correct number of breakpoints")
         self.continue_to_breakpoints(breakpoint_ids)
         locals = self.vscode.get_local_variables()
@@ -152,7 +152,7 @@ class TestVSCode_variables(lldbvscode_testcase.VSCodeTestCaseBase):
         # Verify setting the start index to a value that is out of range
         # results in an empty list
         response = self.vscode.request_variables(varRef, start=32, count=1)
-        self.assertTrue(len(response['body']['variables']) == 0,
+        self.assertEqual(len(response['body']['variables']), 0,
                         'verify we get no variable back for invalid start')
 
         # Test evaluate
@@ -197,12 +197,12 @@ class TestVSCode_variables(lldbvscode_testcase.VSCodeTestCaseBase):
         # Test setting variables
         self.set_local('argc', 123)
         argc = self.get_local_as_int('argc')
-        self.assertTrue(argc == 123,
+        self.assertEqual(argc, 123,
                         'verify argc was set to 123 (123 != %i)' % (argc))
 
         self.set_local('argv', 0x1234)
         argv = self.get_local_as_int('argv')
-        self.assertTrue(argv == 0x1234,
+        self.assertEqual(argv, 0x1234,
                         'verify argv was set to 0x1234 (0x1234 != %#x)' % (
                             argv))
 
@@ -219,5 +219,5 @@ class TestVSCode_variables(lldbvscode_testcase.VSCodeTestCaseBase):
         self.vscode.request_setVariable(varRef, "x", 111)
         response = self.vscode.request_variables(varRef, start=0, count=1)
         value = response['body']['variables'][0]['value']
-        self.assertTrue(value == '111',
+        self.assertEqual(value, '111',
                         'verify pt.x got set to 111 (111 != %s)' % (value))


### PR DESCRIPTION
Convert `assertTrue(a == b)` to `assertEqual(a, b)` to produce better failure messages.

These were mostly done via regex search & replace, with some manual fixes.

Differential Revision: https://reviews.llvm.org/D95813

(cherry picked from commit 619e2e095fb1cd1e60b745cf1a10af9f67a4cd41)