### PR TITLE
[lldb] Enable import-std-module's fallback mode by default

### DIFF
--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -50,7 +50,7 @@ let Definition = "target" in {
     DefaultTrue,
     Desc<"Automatically load Clang modules referred to by the program.">;
   def ImportStdModule: Property<"import-std-module", "Enum">,
-    DefaultEnumValue<"eImportStdModuleFalse">,
+    DefaultEnumValue<"eImportStdModuleFallback">,
     EnumValues<"OptionEnumValues(g_import_std_module_value_types)">,
     Desc<"Import the 'std' C++ module to improve expression parsing involving "
          " C++ standard library types.">;


### PR DESCRIPTION
This enables the import-std-module setting's fallback mode by default. With
this all expressions are from no on retried with a loaded C++ module if they
fail to parse without.

(cherry picked from commit 7f6e44325b370249c5a9e7e42c5f224c300b433d)