### PR TITLE
[GlobalISel] Check if branches use the same MBB in matchOptBrCondByInvertingCond

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -908,10 +908,11 @@ bool CombinerHelper::matchOptBrCondByInvertingCond(MachineInstr &MI) {
   if (BrCond->getOpcode() != TargetOpcode::G_BRCOND)
     return false;
 
-  // Check that the next block is the conditional branch target.
-  if (!MBB->isLayoutSuccessor(BrCond->getOperand(1).getMBB()))
-    return false;
-  return true;
+  // Check that the next block is the conditional branch target. Also make sure
+  // that it isn't the same as the G_BR's target (otherwise, this will loop.)
+  MachineBasicBlock *BrCondTarget = BrCond->getOperand(1).getMBB();
+  return BrCondTarget != MI.getOperand(0).getMBB() &&
+         MBB->isLayoutSuccessor(BrCondTarget);
 }
 
 void CombinerHelper::applyOptBrCondByInvertingCond(MachineInstr &MI) {

--- a/llvm/test/CodeGen/AArch64/GlobalISel/prelegalizercombiner-br.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/prelegalizercombiner-br.mir
@@ -29,6 +29,7 @@
     ret i32 %retval.0
   }
 
+  define void @dont_combine_same_block() { ret void }
 
 ...
 ---
@@ -86,4 +87,27 @@ body:             |
     $w0 = COPY %10(s32)
     RET_ReallyLR implicit $w0
 
+...
+---
+name:            dont_combine_same_block
+tracksRegLiveness: true
+body:             |
+  ; CHECK-LABEL: name: dont_combine_same_block
+  ; CHECK: bb.0:
+  ; CHECK:   successors: %bb.1(0x80000000)
+  ; CHECK:   liveins: $w0, $w1
+  ; CHECK:   %cond:_(s1) = G_IMPLICIT_DEF
+  ; CHECK:   G_BRCOND %cond(s1), %bb.1
+  ; CHECK:   G_BR %bb.1
+  ; CHECK: bb.1:
+  ; CHECK:   RET_ReallyLR
+  bb.0:
+    liveins: $w0, $w1
+    %cond:_(s1) = G_IMPLICIT_DEF
+
+    ; The G_BRCOND and G_BR have the same target here. Don't change anything.
+    G_BRCOND %cond(s1), %bb.1
+    G_BR %bb.1
+  bb.1:
+    RET_ReallyLR
 ...


### PR DESCRIPTION
If the G_BR + G_BRCOND in this combine use the same MBB, then it will infinite
loop. Don't allow that to happen.

Differential Revision: https://reviews.llvm.org/D95895

(cherry picked from commit 02d4b365bf4f8c2cb56e5612902f6c3bb4316493)

rdar://73842004