### PR TITLE
[lldb/test] Stop recording fundamental return types (NFC)

### DIFF
--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -2416,13 +2416,13 @@ bool SBTarget::IsLoaded(const SBModule &module) const {
 
   TargetSP target_sp(GetSP());
   if (!target_sp)
-    return LLDB_RECORD_RESULT(false);
+    return false;
 
   ModuleSP module_sp(module.GetSP());
   if (!module_sp)
-    return LLDB_RECORD_RESULT(false);
+    return false;
 
-  return LLDB_RECORD_RESULT(module_sp->IsLoadedInTarget(target_sp.get()));
+  return module_sp->IsLoadedInTarget(target_sp.get());
 }
 
 lldb::SBLaunchInfo SBTarget::GetLaunchInfo() const {


### PR DESCRIPTION
It seems that recording fundamental return type is bogus.

This can trigger asserts when running a test with reproducers so this
patch updates the `SBTarget::IsLoaded` test to stop recording them.

Differential Revision: https://reviews.llvm.org/D95686

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>