### PR TITLE
Fix the guaranteed alignment of memory returned by malloc/new on Darwin

### DIFF
--- a/clang/lib/Basic/TargetInfo.cpp
+++ b/clang/lib/Basic/TargetInfo.cpp
@@ -67,9 +67,12 @@ TargetInfo::TargetInfo(const llvm::Triple &T) : TargetOpts(), Triple(T) {
   // From the glibc documentation, on GNU systems, malloc guarantees 16-byte
   // alignment on 64-bit systems and 8-byte alignment on 32-bit systems. See
   // https://www.gnu.org/software/libc/manual/html_node/Malloc-Examples.html.
-  // This alignment guarantee also applies to Windows and Android.
+  // This alignment guarantee also applies to Windows and Android. On Darwin,
+  // the alignment is 16 bytes on both 64-bit and 32-bit systems.
   if (T.isGNUEnvironment() || T.isWindowsMSVCEnvironment() || T.isAndroid())
     NewAlign = Triple.isArch64Bit() ? 128 : Triple.isArch32Bit() ? 64 : 0;
+  else if (T.isOSDarwin())
+    NewAlign = 128;
   else
     NewAlign = 0; // Infer from basic type alignment.
   HalfWidth = 16;

--- a/clang/test/Preprocessor/init-aarch64.c
+++ b/clang/test/Preprocessor/init-aarch64.c
@@ -532,6 +532,9 @@
 // AARCH64-DARWIN: #define __WINT_WIDTH__ 32
 // AARCH64-DARWIN: #define __aarch64__ 1
 
+// RUN: %clang_cc1 -E -dM -triple=aarch64-apple-ios7.0 -x c++ < /dev/null | FileCheck -match-full-lines -check-prefix AARCH64-DARWIN-CXX %s
+// AARCH64-DARWIN-CXX: #define __STDCPP_DEFAULT_NEW_ALIGNMENT__ 16UL
+
 // RUN: %clang_cc1 -E -dM -ffreestanding -triple=aarch64-windows-msvc < /dev/null | FileCheck -match-full-lines -check-prefix AARCH64-MSVC %s
 
 // AARCH64-MSVC: #define _INTEGRAL_MAX_BITS 64

--- a/clang/test/Preprocessor/init-arm.c
+++ b/clang/test/Preprocessor/init-arm.c
@@ -196,6 +196,9 @@
 // ARM:#define __arm 1
 // ARM:#define __arm__ 1
 
+// RUN: %clang_cc1 -E -dM -triple=armv7-apple-ios7.0 -x c++ < /dev/null | FileCheck -match-full-lines -check-prefix ARM-DARWIN-CXX %s
+// ARM-DARWIN-CXX: #define __STDCPP_DEFAULT_NEW_ALIGNMENT__ 16UL
+
 // RUN: %clang_cc1 -dM -ffreestanding -triple arm-none-none -target-abi apcs-gnu -E /dev/null -o - | FileCheck -match-full-lines -check-prefix ARM-APCS-GNU %s
 // ARM-APCS-GNU: #define __INTPTR_TYPE__ int
 // ARM-APCS-GNU: #define __PTRDIFF_TYPE__ int


### PR DESCRIPTION
The guaranteed alignment is 16 bytes on Darwin.

rdar://73431623

Differential Revision: https://reviews.llvm.org/D95910

(cherry picked from commit aade0ec23b5986a9c478c4093d029a5db8a2c012)