### PR TITLE
Avoid a false positive assertion error (NFC in NDEBUG)

### DIFF
--- a/lldb/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/lldb/include/lldb/Target/SwiftLanguageRuntime.h
@@ -123,6 +123,8 @@ public:
 
   void ModulesDidLoad(const ModuleList &module_list) override;
 
+  bool IsSwiftRuntimeInitialized();
+  
   /// Mangling support.
   /// \{
   /// Use these passthrough functions rather than calling into Swift directly,

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -890,34 +890,34 @@ std::vector<ConstString> SwiftLanguage::GetPossibleFormattersMatches(
   const bool check_cpp = false;
   const bool check_objc = false;
   bool canBeSwiftDynamic =
-      compiler_type.IsPossibleDynamicType(nullptr, check_cpp, check_objc) ||
-      // Foundation (but really any library) may create new
-      // Objective-C classes at runtime and LLDB's ObjC runtime
-      // implementation doesn't yet get notified about this. As a
-      // workaround we try to interpret ObjC id pointers as Swift
-      // classes to make them available.
-      (compiler_type.GetCanonicalType().GetTypeClass() ==
-       eTypeClassObjCObjectPointer);
+      compiler_type.IsPossibleDynamicType(nullptr, check_cpp, check_objc);
+  // Foundation (but really any library) may create new
+  // Objective-C classes at runtime and LLDB's ObjC runtime
+  // implementation doesn't yet get notified about this. As a
+  // workaround we try to interpret ObjC id pointers as Swift
+  // classes to make them available.
+  bool canBeObjCSwiftType = (compiler_type.GetCanonicalType().GetTypeClass() ==
+                             eTypeClassObjCObjectPointer);
 
-  if (canBeSwiftDynamic) {
-    do {
-      lldb::ProcessSP process_sp = valobj.GetProcessSP();
-      if (!process_sp)
-        break;
-      auto *runtime = SwiftLanguageRuntime::Get(process_sp);
-      if (runtime == nullptr)
-        break;
-      TypeAndOrName type_and_or_name;
-      Address address;
-      Value::ValueType value_type;
-      if (!runtime->GetDynamicTypeAndAddress(
-              valobj, use_dynamic, type_and_or_name, address, value_type))
-        break;
-      if (ConstString name = type_and_or_name.GetName())
-        result.push_back(name);
-    } while (false);
-  }
-
+  if (!canBeSwiftDynamic && !canBeObjCSwiftType)
+    return result;
+  lldb::ProcessSP process_sp = valobj.GetProcessSP();
+  if (!process_sp)
+    return result;
+  auto *runtime = SwiftLanguageRuntime::Get(process_sp);
+  if (!runtime)
+    return result;
+  // If this condition fires, we're most likely in pure Objective-C program.
+  if (canBeObjCSwiftType && !runtime->IsSwiftRuntimeInitialized())
+    return result;
+  TypeAndOrName type_and_or_name;
+  Address address;
+  Value::ValueType value_type;
+  if (!runtime->GetDynamicTypeAndAddress(valobj, use_dynamic, type_and_or_name,
+                                         address, value_type))
+    return result;
+  if (ConstString name = type_and_or_name.GetName())
+    result.push_back(name);
   return result;
 }
 

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -513,6 +513,8 @@ SwiftLanguageRuntime::SwiftLanguageRuntime(Process *process)
     m_stub = std::make_unique<SwiftLanguageRuntimeStub>(*process);
 }
 
+bool SwiftLanguageRuntime::IsSwiftRuntimeInitialized() { return (bool)m_impl; }
+
 void SwiftLanguageRuntime::ModulesDidLoad(const ModuleList &module_list) {
   assert(m_process && "modules loaded without process");
   if (m_impl) {


### PR DESCRIPTION
The try-to-interpret-objc-objects-as-swift patch triggers an assertion
in the SwiftLanguageRuntime in pure Objective-C programs, which can be
avoided by not calling GetDynamicTypeAndAddress() if no Swift language
runtime has been initialized.

(cherry picked from commit 19c0fb5d57066e1bb0da68962b9570bcc9021ad1)