### PR TITLE
[clang/test] Specify -flegacy-pass-manager in split-cold-code.c

### DIFF
--- a/clang/test/CodeGen/split-cold-code.c
+++ b/clang/test/CodeGen/split-cold-code.c
@@ -1,38 +1,38 @@
 // === Old PM ===
 // No splitting at -O0.
-// RUN: %clang_cc1 -O0 -fsplit-cold-code -mllvm -debug-pass=Structure \
+// RUN: %clang_cc1 -O0 -flegacy-pass-manager -fsplit-cold-code -mllvm -debug-pass=Structure \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-NO-SPLIT %s
 //
 // No splitting at -Oz.
-// RUN: %clang_cc1 -Oz -fsplit-cold-code -mllvm -debug-pass=Structure \
+// RUN: %clang_cc1 -Oz -flegacy-pass-manager -fsplit-cold-code -mllvm -debug-pass=Structure \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-NO-SPLIT %s
 //
 // Split by default.
-// RUN: %clang_cc1 -O3 -mllvm -debug-pass=Structure \
+// RUN: %clang_cc1 -O3 -flegacy-pass-manager -mllvm -debug-pass=Structure \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-SPLIT %s
 //
 // No splitting when it's explicitly disabled.
-// RUN: %clang_cc1 -O3 -fno-split-cold-code -mllvm -debug-pass=Structure \
+// RUN: %clang_cc1 -O3 -flegacy-pass-manager -fno-split-cold-code -mllvm -debug-pass=Structure \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-NO-SPLIT %s
 //
 // No splitting when LLVM passes are disabled.
-// RUN: %clang_cc1 -O3 -fsplit-cold-code -disable-llvm-passes -mllvm -debug-pass=Structure \
+// RUN: %clang_cc1 -O3 -flegacy-pass-manager -fsplit-cold-code -disable-llvm-passes -mllvm -debug-pass=Structure \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-NO-SPLIT %s
 //
 // Split at -O1.
-// RUN: %clang_cc1 -O1 -fsplit-cold-code -mllvm -debug-pass=Structure \
+// RUN: %clang_cc1 -O1 -flegacy-pass-manager -fsplit-cold-code -mllvm -debug-pass=Structure \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-SPLIT %s
 //
 // Split at -Os.
-// RUN: %clang_cc1 -Os -fsplit-cold-code -mllvm -debug-pass=Structure \
+// RUN: %clang_cc1 -Os -flegacy-pass-manager -fsplit-cold-code -mllvm -debug-pass=Structure \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-SPLIT %s
 //
 // Split at -O2.
-// RUN: %clang_cc1 -O2 -fsplit-cold-code -mllvm -debug-pass=Structure \
+// RUN: %clang_cc1 -O2 -flegacy-pass-manager -fsplit-cold-code -mllvm -debug-pass=Structure \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-SPLIT %s
 //
 // Split at -O3.
-// RUN: %clang_cc1 -O3 -fsplit-cold-code -mllvm -debug-pass=Structure \
+// RUN: %clang_cc1 -O3 -flegacy-pass-manager -fsplit-cold-code -mllvm -debug-pass=Structure \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=OLDPM-SPLIT %s
 
 // OLDPM-NO-SPLIT-NOT: Hot Cold Split


### PR DESCRIPTION
Specify -flegacy-pass-manager in RUN lines which assumed that the old PM
was in use by default.

rdar://73983698
