### PR TITLE
[lldb] Convert more assertTrue to assertEqual (NFC)

### DIFF
--- a/lldb/test/API/api/listeners/TestListener.py
+++ b/lldb/test/API/api/listeners/TestListener.py
@@ -73,8 +73,8 @@ class ListenToModuleLoadedEvents (TestBase):
             "It is a breakpoint event.")
         self.assertTrue(lldb.SBBreakpoint.GetBreakpointEventTypeFromEvent(
             event) == lldb.eBreakpointEventTypeAdded, "It is a breakpoint added event.")
-        self.assertTrue(
-            bkpt == lldb.SBBreakpoint.GetBreakpointFromEvent(event),
+        self.assertEqual(
+            bkpt, lldb.SBBreakpoint.GetBreakpointFromEvent(event),
             "It is our breakpoint.")
 
         # Now make sure if we stop listening for events we don't get them:
@@ -118,8 +118,8 @@ class ListenToModuleLoadedEvents (TestBase):
             "It is a breakpoint event.")
         self.assertTrue(lldb.SBBreakpoint.GetBreakpointEventTypeFromEvent(
             event) == lldb.eBreakpointEventTypeAdded, "It is a breakpoint added event.")
-        self.assertTrue(
-            bkpt == lldb.SBBreakpoint.GetBreakpointFromEvent(event),
+        self.assertEqual(
+            bkpt, lldb.SBBreakpoint.GetBreakpointFromEvent(event),
             "It is our breakpoint.")
 
         # Now make sure if we stop listening for events we don't get them:

--- a/lldb/test/API/commands/disassemble/basic/TestFrameDisassemble.py
+++ b/lldb/test/API/commands/disassemble/basic/TestFrameDisassemble.py
@@ -48,8 +48,8 @@ class FrameDisassembleTestCase(TestBase):
         # Did we hit our breakpoint?
         from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
         threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertTrue(
-            len(threads) == 1,
+        self.assertEqual(
+            len(threads), 1,
             "There should be a thread stopped at our breakpoint")
 
         # The hit count for the breakpoint should be 1.

--- a/lldb/test/API/commands/expression/call-restarts/TestCallThatRestarts.py
+++ b/lldb/test/API/commands/expression/call-restarts/TestCallThatRestarts.py
@@ -42,8 +42,8 @@ class ExprCommandThatRestartsTestCase(TestBase):
 
         # Check that we are back where we were before:
         frame = self.thread.GetFrameAtIndex(0)
-        self.assertTrue(
-            self.orig_frame_pc == frame.GetPC(),
+        self.assertEqual(
+            self.orig_frame_pc, frame.GetPC(),
             "Restored the zeroth frame correctly")
 
     def call_function(self):
@@ -147,6 +147,6 @@ class ExprCommandThatRestartsTestCase(TestBase):
             "Continuing after stopping for signal succeeds.")
 
         frame = self.thread.GetFrameAtIndex(0)
-        self.assertTrue(
-            frame.GetPC() == self.orig_frame_pc,
+        self.assertEqual(
+            frame.GetPC(), self.orig_frame_pc,
             "Continuing returned to the place we started.")

--- a/lldb/test/API/commands/expression/call-throws/TestCallThatThrows.py
+++ b/lldb/test/API/commands/expression/call-throws/TestCallThatThrows.py
@@ -30,8 +30,8 @@ class ExprCommandWithThrowTestCase(TestBase):
     def check_after_call(self):
         # Check that we are back where we were before:
         frame = self.thread.GetFrameAtIndex(0)
-        self.assertTrue(
-            self.orig_frame_pc == frame.GetPC(),
+        self.assertEqual(
+            self.orig_frame_pc, frame.GetPC(),
             "Restored the zeroth frame correctly")
 
     def call_function(self):

--- a/lldb/test/API/commands/frame/language/TestGuessLanguage.py
+++ b/lldb/test/API/commands/frame/language/TestGuessLanguage.py
@@ -60,8 +60,8 @@ class TestFrameGuessLanguage(TestBase):
         # Did we hit our breakpoint?
         from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
         threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertTrue(
-            len(threads) == 1,
+        self.assertEqual(
+            len(threads), 1,
             "There should be a thread stopped at our breakpoint")
 
         # The hit count for the breakpoint should be 1.

--- a/lldb/test/API/commands/frame/var/TestFrameVar.py
+++ b/lldb/test/API/commands/frame/var/TestFrameVar.py
@@ -49,8 +49,8 @@ class TestFrameVar(TestBase):
         # Did we hit our breakpoint?
         from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
         threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertTrue(
-            len(threads) == 1,
+        self.assertEqual(
+            len(threads), 1,
             "There should be a thread stopped at our breakpoint")
 
         # The hit count for the breakpoint should be 1.

--- a/lldb/test/API/commands/process/launch-with-shellexpand/TestLaunchWithShellExpand.py
+++ b/lldb/test/API/commands/process/launch-with-shellexpand/TestLaunchWithShellExpand.py
@@ -56,8 +56,8 @@ class LaunchWithShellExpandTestCase(TestBase):
 
         stop_reason = thread.GetStopReason()
 
-        self.assertTrue(
-            stop_reason == lldb.eStopReasonBreakpoint,
+        self.assertEqual(
+            stop_reason, lldb.eStopReasonBreakpoint,
             "Thread in process stopped in 'main' should have a stop reason of eStopReasonBreakpoint")
 
         self.expect_var_path("argv[1]", summary='"file1.txt"')
@@ -87,8 +87,8 @@ class LaunchWithShellExpandTestCase(TestBase):
 
         stop_reason = thread.GetStopReason()
 
-        self.assertTrue(
-            stop_reason == lldb.eStopReasonBreakpoint,
+        self.assertEqual(
+            stop_reason, lldb.eStopReasonBreakpoint,
             "Thread in process stopped in 'main' should have a stop reason of eStopReasonBreakpoint")
 
         self.expect("frame variable argv[1]", substrs=['foo bar'])
@@ -110,8 +110,8 @@ class LaunchWithShellExpandTestCase(TestBase):
 
         stop_reason = thread.GetStopReason()
 
-        self.assertTrue(
-            stop_reason == lldb.eStopReasonBreakpoint,
+        self.assertEqual(
+            stop_reason, lldb.eStopReasonBreakpoint,
             "Thread in process stopped in 'main' should have a stop reason of eStopReasonBreakpoint")
 
         self.expect("frame variable argv[1]", substrs=['foo bar'])

--- a/lldb/test/API/commands/register/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register/register_command/TestRegisters.py
@@ -297,8 +297,8 @@ class RegisterCommandsTestCase(TestBase):
                 error)
         self.assertSuccess(error, "Launch succeeds")
 
-        self.assertTrue(
-            process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            process.GetState(), lldb.eStateStopped,
             PROCESS_STOPPED)
 
         thread = process.GetThreadAtIndex(0)

--- a/lldb/test/API/commands/watchpoints/watchpoint_events/TestWatchpointEvents.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_events/TestWatchpointEvents.py
@@ -96,8 +96,8 @@ class TestWatchpointEvents (TestBase):
             lldb.SBWatchpoint.EventIsWatchpointEvent(event),
             "Event is a watchpoint event.")
         found_type = lldb.SBWatchpoint.GetWatchpointEventTypeFromEvent(event)
-        self.assertTrue(
-            found_type == event_type,
+        self.assertEqual(
+            found_type, event_type,
             "Event is not correct type, expected: %d, found: %d" %
             (event_type,
              found_type))

--- a/lldb/test/API/functionalities/avoids-fd-leak/TestFdLeak.py
+++ b/lldb/test/API/functionalities/avoids-fd-leak/TestFdLeak.py
@@ -45,11 +45,11 @@ class AvoidsFdLeakTestCase(TestBase):
             None, None, self.get_process_working_directory())
         self.assertTrue(process, PROCESS_IS_VALID)
 
-        self.assertTrue(
-            process.GetState() == lldb.eStateExited,
+        self.assertEqual(
+            process.GetState(), lldb.eStateExited,
             "Process should have exited.")
-        self.assertTrue(
-            process.GetExitStatus() == 0,
+        self.assertEqual(
+            process.GetExitStatus(), 0,
             "Process returned non-zero status. Were incorrect file descriptors passed?")
 
     # The check for descriptor leakage needs to be implemented differently
@@ -69,8 +69,8 @@ class AvoidsFdLeakTestCase(TestBase):
         process1 = target.LaunchSimple(
             None, None, self.get_process_working_directory())
         self.assertTrue(process1, PROCESS_IS_VALID)
-        self.assertTrue(
-            process1.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            process1.GetState(), lldb.eStateStopped,
             "Process should have been stopped.")
 
         target2 = self.dbg.CreateTarget(exe)
@@ -78,9 +78,9 @@ class AvoidsFdLeakTestCase(TestBase):
             None, None, self.get_process_working_directory())
         self.assertTrue(process2, PROCESS_IS_VALID)
 
-        self.assertTrue(
-            process2.GetState() == lldb.eStateExited,
+        self.assertEqual(
+            process2.GetState(), lldb.eStateExited,
             "Process should have exited.")
-        self.assertTrue(
-            process2.GetExitStatus() == 0,
+        self.assertEqual(
+            process2.GetExitStatus(), 0,
             "Process returned non-zero status. Were incorrect file descriptors passed?")

--- a/lldb/test/API/functionalities/breakpoint/address_breakpoints/TestAddressBreakpoints.py
+++ b/lldb/test/API/functionalities/breakpoint/address_breakpoints/TestAddressBreakpoints.py
@@ -67,8 +67,8 @@ class AddressBreakpointTestCase(TestBase):
         # Did we hit our breakpoint?
         from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
         threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertTrue(
-            len(threads) == 1,
+        self.assertEqual(
+            len(threads), 1,
             "There should be a thread stopped at our breakpoint")
 
         # The hit count for the breakpoint should be 1.
@@ -84,8 +84,8 @@ class AddressBreakpointTestCase(TestBase):
         self.assertTrue(process, PROCESS_IS_VALID)
 
         thread = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertTrue(
-            len(threads) == 1,
+        self.assertEqual(
+            len(threads), 1,
             "There should be a thread stopped at our breakpoint")
 
         # The hit count for the breakpoint should now be 2.

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_hit_count/TestBreakpointHitCount.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_hit_count/TestBreakpointHitCount.py
@@ -93,8 +93,8 @@ class BreakpointHitCountTestCase(TestBase):
 
         frame0 = thread.GetFrameAtIndex(0)
         location1 = breakpoint.FindLocationByAddress(frame0.GetPC())
-        self.assertTrue(
-            frame0.GetLineEntry().GetLine() == self.a_int_body_line_no,
+        self.assertEqual(
+            frame0.GetLineEntry().GetLine(), self.a_int_body_line_no,
             "Stopped in int a(int)")
         self.assertTrue(location1)
         self.assertEqual(location1.GetHitCount(), 1)
@@ -110,8 +110,8 @@ class BreakpointHitCountTestCase(TestBase):
 
         frame0 = thread.GetFrameAtIndex(0)
         location2 = breakpoint.FindLocationByAddress(frame0.GetPC())
-        self.assertTrue(
-            frame0.GetLineEntry().GetLine() == self.a_float_body_line_no,
+        self.assertEqual(
+            frame0.GetLineEntry().GetLine(), self.a_float_body_line_no,
             "Stopped in float a(float)")
         self.assertTrue(location2)
         self.assertEqual(location2.GetHitCount(), 1)

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_language/TestBreakpointLanguage.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_language/TestBreakpointLanguage.py
@@ -38,8 +38,8 @@ class TestBreakpointLanguage(TestBase):
             lldb.eLanguageTypeC_plus_plus,
             lldb.SBFileSpecList(),
             lldb.SBFileSpecList())
-        self.assertTrue(
-            cpp_bp.GetNumLocations() == 1,
+        self.assertEqual(
+            cpp_bp.GetNumLocations(), 1,
             "Only one C++ symbol matches")
         self.assertTrue(self.check_location_file(cpp_bp, 0, "b.cpp"))
 
@@ -48,8 +48,8 @@ class TestBreakpointLanguage(TestBase):
             lldb.eLanguageTypeC,
             lldb.SBFileSpecList(),
             lldb.SBFileSpecList())
-        self.assertTrue(
-            c_bp.GetNumLocations() == 1,
+        self.assertEqual(
+            c_bp.GetNumLocations(), 1,
             "Only one C symbol matches")
         self.assertTrue(self.check_location_file(c_bp, 0, "a.c"))
 
@@ -58,8 +58,8 @@ class TestBreakpointLanguage(TestBase):
             lldb.eLanguageTypeObjC,
             lldb.SBFileSpecList(),
             lldb.SBFileSpecList())
-        self.assertTrue(
-            objc_bp.GetNumLocations() == 0,
+        self.assertEqual(
+            objc_bp.GetNumLocations(), 0,
             "No ObjC symbol matches")
 
     def test_by_name_breakpoint_language(self):
@@ -80,8 +80,8 @@ class TestBreakpointLanguage(TestBase):
             lldb.eLanguageTypeC_plus_plus,
             lldb.SBFileSpecList(),
             lldb.SBFileSpecList())
-        self.assertTrue(
-            cpp_bp.GetNumLocations() == 1,
+        self.assertEqual(
+            cpp_bp.GetNumLocations(), 1,
             "Only one C++ symbol matches")
         self.assertTrue(self.check_location_file(cpp_bp, 0, "b.cpp"))
 
@@ -91,8 +91,8 @@ class TestBreakpointLanguage(TestBase):
             lldb.eLanguageTypeC_plus_plus,
             lldb.SBFileSpecList(),
             lldb.SBFileSpecList())
-        self.assertTrue(
-            no_cpp_bp.GetNumLocations() == 0,
+        self.assertEqual(
+            no_cpp_bp.GetNumLocations(), 0,
             "And the C one doesn't match")
 
         c_bp = self.target.BreakpointCreateByName(
@@ -101,8 +101,8 @@ class TestBreakpointLanguage(TestBase):
             lldb.eLanguageTypeC,
             lldb.SBFileSpecList(),
             lldb.SBFileSpecList())
-        self.assertTrue(
-            c_bp.GetNumLocations() == 1,
+        self.assertEqual(
+            c_bp.GetNumLocations(), 1,
             "Only one C symbol matches")
         self.assertTrue(self.check_location_file(c_bp, 0, "a.c"))
 
@@ -112,8 +112,8 @@ class TestBreakpointLanguage(TestBase):
             lldb.eLanguageTypeC,
             lldb.SBFileSpecList(),
             lldb.SBFileSpecList())
-        self.assertTrue(
-            no_c_bp.GetNumLocations() == 0,
+        self.assertEqual(
+            no_c_bp.GetNumLocations(), 0,
             "And the C++ one doesn't match")
 
         objc_bp = self.target.BreakpointCreateByName(
@@ -122,6 +122,6 @@ class TestBreakpointLanguage(TestBase):
             lldb.eLanguageTypeObjC,
             lldb.SBFileSpecList(),
             lldb.SBFileSpecList())
-        self.assertTrue(
-            objc_bp.GetNumLocations() == 0,
+        self.assertEqual(
+            objc_bp.GetNumLocations(), 0,
             "No ObjC symbol matches")

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_names/TestBreakpointNames.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_names/TestBreakpointNames.py
@@ -215,7 +215,7 @@ class BreakpointNames(TestBase):
         # Now find it in the dummy target, and make sure these settings took:
         bp_name = lldb.SBBreakpointName(dummy_target, self.bp_name_string)
         # Make sure the name is right:
-        self.assertTrue (bp_name.GetName() == self.bp_name_string, "Wrong bp_name: %s"%(bp_name.GetName()))
+        self.assertEqual(bp_name.GetName(), self.bp_name_string, "Wrong bp_name: %s"%(bp_name.GetName()))
         bp_name.SetOneShot(self.is_one_shot)
         bp_name.SetIgnoreCount(self.ignore_count)
         bp_name.SetCondition(self.condition)

--- a/lldb/test/API/functionalities/breakpoint/source_regexp/TestSourceRegexBreakpoints.py
+++ b/lldb/test/API/functionalities/breakpoint/source_regexp/TestSourceRegexBreakpoints.py
@@ -40,8 +40,8 @@ class TestSourceRegexBreakpoints(TestBase):
         main_break = target.BreakpointCreateBySourceRegex(
             source_regex, lldb.SBFileSpecList(), target_files, func_names)
         num_locations = main_break.GetNumLocations()
-        self.assertTrue(
-            num_locations == 1,
+        self.assertEqual(
+            num_locations, 1,
             "a.c in a_func should give one breakpoint, got %d." %
             (num_locations))
 
@@ -73,8 +73,8 @@ class TestSourceRegexBreakpoints(TestBase):
             source_regex, lldb.SBFileSpecList(), target_files, lldb.SBStringList())
 
         num_locations = main_break.GetNumLocations()
-        self.assertTrue(
-            num_locations == 2,
+        self.assertEqual(
+            num_locations, 2,
             "main.c should have 2 matches, got %d." %
             (num_locations))
 
@@ -85,8 +85,8 @@ class TestSourceRegexBreakpoints(TestBase):
             source_regex, lldb.SBFileSpecList(), target_files, lldb.SBStringList())
 
         num_locations = main_break.GetNumLocations()
-        self.assertTrue(
-            num_locations == 4,
+        self.assertEqual(
+            num_locations, 4,
             "main.c and a.c should have 4 matches, got %d." %
             (num_locations))
 
@@ -97,7 +97,7 @@ class TestSourceRegexBreakpoints(TestBase):
             source_regex, lldb.SBFileSpecList(), target_files, func_names)
 
         num_locations = main_break.GetNumLocations()
-        self.assertTrue(
-            num_locations == 2,
+        self.assertEqual(
+            num_locations, 2,
             "main_func in main.c and a.c should have 2 matches, got %d." %
             (num_locations))

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/atomic/TestLibCxxAtomic.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/atomic/TestLibCxxAtomic.py
@@ -58,11 +58,11 @@ class LibCxxAtomicTestCase(TestBase):
 
         self.assertEqual(i.GetValueAsUnsigned(0), 5, "i == 5")
         self.assertEqual(s.GetNumChildren(), 2, "s has two children")
-        self.assertTrue(
-            s.GetChildAtIndex(0).GetValueAsUnsigned(0) == 1,
+        self.assertEqual(
+            s.GetChildAtIndex(0).GetValueAsUnsigned(0), 1,
             "s.x == 1")
-        self.assertTrue(
-            s.GetChildAtIndex(1).GetValueAsUnsigned(0) == 2,
+        self.assertEqual(
+            s.GetChildAtIndex(1).GetValueAsUnsigned(0), 2,
             "s.y == 2")
 
         # Try printing the child that points to its own parent object.

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/list/TestDataFormatterLibcxxList.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/list/TestDataFormatterLibcxxList.py
@@ -212,9 +212,9 @@ class LibcxxListDataFormatterTestCase(TestBase):
 
         self.runCmd("continue")
 
-        self.assertTrue(
-            countingList.GetChildAtIndex(0).GetValueAsUnsigned(0) == 3141,
+        self.assertEqual(
+            countingList.GetChildAtIndex(0).GetValueAsUnsigned(0), 3141,
             "uniqued list[0] == 3141")
-        self.assertTrue(
-            countingList.GetChildAtIndex(1).GetValueAsUnsigned(0) == 3142,
+        self.assertEqual(
+            countingList.GetChildAtIndex(1).GetValueAsUnsigned(0), 3142,
             "uniqued list[1] == 3142")

--- a/lldb/test/API/functionalities/data-formatter/format-propagation/TestFormatPropagation.py
+++ b/lldb/test/API/functionalities/data-formatter/format-propagation/TestFormatPropagation.py
@@ -58,11 +58,11 @@ class FormatPropagationTestCase(TestBase):
         self.assertEquals(Y.GetValue(), "2", "Y has an invalid value")
         # set the format on the parent
         parent.SetFormat(lldb.eFormatHex)
-        self.assertTrue(
-            X.GetValue() == "0x00000001",
+        self.assertEqual(
+            X.GetValue(), "0x00000001",
             "X has not changed format")
-        self.assertTrue(
-            Y.GetValue() == "0x00000002",
+        self.assertEqual(
+            Y.GetValue(), "0x00000002",
             "Y has not changed format")
         # Step and check if the values make sense still
         self.runCmd("next")
@@ -76,7 +76,7 @@ class FormatPropagationTestCase(TestBase):
         parent.SetFormat(lldb.eFormatDefault)
         X.SetFormat(lldb.eFormatHex)
         Y.SetFormat(lldb.eFormatDefault)
-        self.assertTrue(
-            X.GetValue() == "0x00000004",
+        self.assertEqual(
+            X.GetValue(), "0x00000004",
             "X is not hex as it asked")
         self.assertEquals(Y.GetValue(), "2", "Y is not defaulted")

--- a/lldb/test/API/functionalities/data-formatter/synthupdate/TestSyntheticFilterRecompute.py
+++ b/lldb/test/API/functionalities/data-formatter/synthupdate/TestSyntheticFilterRecompute.py
@@ -55,8 +55,8 @@ class SyntheticFilterRecomputingTestCase(TestBase):
         if self.TraceOn():
             self.runCmd("expr --dynamic-type run-target --ptr-depth 1 -- x")
 
-        self.assertTrue(
-            id_x.GetSummary() == '@"5 elements"',
+        self.assertEqual(
+            id_x.GetSummary(), '@"5 elements"',
             "array does not get correct summary")
 
         self.runCmd("next")
@@ -70,14 +70,14 @@ class SyntheticFilterRecomputingTestCase(TestBase):
         if self.TraceOn():
             self.runCmd("expr --dynamic-type run-target --ptr-depth 1 -- x")
 
-        self.assertTrue(
-            id_x.GetNumChildren() == 7,
+        self.assertEqual(
+            id_x.GetNumChildren(), 7,
             "dictionary does not have 7 children")
         id_x.SetPreferSyntheticValue(False)
-        self.assertFalse(
-            id_x.GetNumChildren() == 7,
+        self.assertNotEqual(
+            id_x.GetNumChildren(), 7,
             "dictionary still looks synthetic")
         id_x.SetPreferSyntheticValue(True)
-        self.assertTrue(
-            id_x.GetSummary() == "7 key/value pairs",
+        self.assertEqual(
+            id_x.GetSummary(), "7 key/value pairs",
             "dictionary does not get correct summary")

--- a/lldb/test/API/functionalities/dynamic_value_child_count/TestDynamicValueChildCount.py
+++ b/lldb/test/API/functionalities/dynamic_value_child_count/TestDynamicValueChildCount.py
@@ -75,6 +75,6 @@ class DynamicValueChildCountTestCase(TestBase):
         self.runCmd("continue")
         self.assertNotEqual(b.GetNumChildren(), 0, "b now has 1 child")
         self.runCmd("continue")
-        self.assertTrue(
-            b.GetNumChildren() == 0,
+        self.assertEqual(
+            b.GetNumChildren(), 0,
             "b didn't go back to 0 children")

--- a/lldb/test/API/functionalities/exec/TestExec.py
+++ b/lldb/test/API/functionalities/exec/TestExec.py
@@ -99,8 +99,8 @@ class ExecTestCase(TestBase):
 
             threads = lldbutil.get_stopped_threads(
                 process, lldb.eStopReasonExec)
-            self.assertTrue(
-                len(threads) == 1,
+            self.assertEqual(
+                len(threads), 1,
                 "We got a thread stopped for exec.")
 
             # Run and we should stop at breakpoint in main after exec

--- a/lldb/test/API/functionalities/inline-stepping/TestInlineStepping.py
+++ b/lldb/test/API/functionalities/inline-stepping/TestInlineStepping.py
@@ -197,8 +197,8 @@ class TestInlineStepping(TestBase):
 
         threads = lldbutil.continue_to_breakpoint(
             self.process, break_2_in_main)
-        self.assertTrue(
-            len(threads) == 1,
+        self.assertEqual(
+            len(threads), 1,
             "Successfully ran to call site of second caller_trivial_1 call.")
         self.thread = threads[0]
 
@@ -215,8 +215,8 @@ class TestInlineStepping(TestBase):
         value = frame.EvaluateExpression("function_to_call()")
         after_line_entry = frame.GetLineEntry()
 
-        self.assertTrue(
-            before_line_entry.GetLine() == after_line_entry.GetLine(),
+        self.assertEqual(
+            before_line_entry.GetLine(), after_line_entry.GetLine(),
             "Line entry before and after function calls are the same.")
 
         # Now make sure stepping OVER in the middle of the stack works, and
@@ -235,8 +235,8 @@ class TestInlineStepping(TestBase):
 
         threads = lldbutil.continue_to_breakpoint(
             self.process, break_3_in_main)
-        self.assertTrue(
-            len(threads) == 1,
+        self.assertEqual(
+            len(threads), 1,
             "Successfully ran to call site of first caller_ref_1 call.")
         self.thread = threads[0]
 

--- a/lldb/test/API/functionalities/memory/read/TestMemoryRead.py
+++ b/lldb/test/API/functionalities/memory/read/TestMemoryRead.py
@@ -66,12 +66,11 @@ class MemoryReadTestCase(TestBase):
         for i in range(4):
             if i == 0:
                 # Verify that the printout for argc is correct.
-                self.assertTrue(
-                    argc == int(
-                        lines[i].split(':')[1].strip(' {}'), 0))
+                self.assertEqual(
+                    argc, int(lines[i].split(':')[1].strip(' {}'), 0))
             addr = int(lines[i].split(':')[0], 0)
             # Verify that the printout for addr is incremented correctly.
-            self.assertEquals(addr, (address + i * 4))
+            self.assertEqual(addr, (address + i * 4))
 
         # (lldb) memory read --format char[] --size 7 --count 1 `&my_string`
         # 0x7fff5fbff990: {abcdefg}
@@ -130,5 +129,5 @@ class MemoryReadTestCase(TestBase):
               objects_read.extend(l.split(':')[1].split())
           # Check that we got back 4 0x0000 etc bytes
           for o in objects_read:
-              self.assertTrue (len(o) == expected_object_length)
+              self.assertEqual(len(o), expected_object_length)
           self.assertEquals(len(objects_read), 4)

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
@@ -30,8 +30,8 @@ class PluginPythonOSPlugin(TestBase):
         registers = frame.GetRegisters().GetValueAtIndex(0)
         reg_value = thread.GetThreadID() + 1
         for reg in registers:
-            self.assertTrue(
-                reg.GetValueAsUnsigned() == reg_value,
+            self.assertEqual(
+                reg.GetValueAsUnsigned(), reg_value,
                 "Verify the registers contains the correct value")
             reg_value = reg_value + 1
 
@@ -171,11 +171,11 @@ class PluginPythonOSPlugin(TestBase):
             "Make sure we get a frame from thread 0x111111111")
         line_entry = frame.GetLineEntry()
 
-        self.assertTrue(
-            line_entry.GetFileSpec().GetFilename() == 'main.c',
+        self.assertEqual(
+            line_entry.GetFileSpec().GetFilename(), 'main.c',
             "Make sure we stopped on line 5 in main.c")
-        self.assertTrue(
-            line_entry.GetLine() == 5,
+        self.assertEqual(
+            line_entry.GetLine(), 5,
             "Make sure we stopped on line 5 in main.c")
 
         # Now single step thread 0x111111111 and make sure it does what we need
@@ -188,8 +188,8 @@ class PluginPythonOSPlugin(TestBase):
             "Make sure we get a frame from thread 0x111111111")
         line_entry = frame.GetLineEntry()
 
-        self.assertTrue(
-            line_entry.GetFileSpec().GetFilename() == 'main.c',
+        self.assertEqual(
+            line_entry.GetFileSpec().GetFilename(), 'main.c',
             "Make sure we stepped from line 5 to line 6 in main.c")
         self.assertEquals(line_entry.GetLine(), 6,
                         "Make sure we stepped from line 5 to line 6 in main.c")

--- a/lldb/test/API/functionalities/signal/TestSendSignal.py
+++ b/lldb/test/API/functionalities/signal/TestSendSignal.py
@@ -92,8 +92,8 @@ class SendSignalTestCase(TestBase):
         self.assertTrue(
             thread.GetStopReasonDataCount() >= 1,
             "There was data in the event.")
-        self.assertTrue(
-            thread.GetStopReasonDataAtIndex(0) == lldbutil.get_signal_number('SIGUSR1'),
+        self.assertEqual(
+            thread.GetStopReasonDataAtIndex(0), lldbutil.get_signal_number('SIGUSR1'),
             "The stop signal was SIGUSR1")
 
     def match_state(self, process_listener, expected_state):

--- a/lldb/test/API/functionalities/step-avoids-no-debug/TestStepNoDebug.py
+++ b/lldb/test/API/functionalities/step-avoids-no-debug/TestStepNoDebug.py
@@ -78,8 +78,8 @@ class StepAvoidsNoDebugTestCase(TestBase):
             "Could not find source pattern " +
             pattern)
         cur_line = self.thread.frames[0].GetLineEntry().GetLine()
-        self.assertTrue(
-            cur_line == target_line,
+        self.assertEqual(
+            cur_line, target_line,
             "Stepped to line %d instead of expected %d with pattern '%s'." %
             (cur_line,
              target_line,

--- a/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
@@ -64,8 +64,8 @@ class ModuleLoadedNotifysTestCase(TestBase):
                                 False,     # Stop at entry
                                 error)     # error
 
-        self.assertTrue(
-            process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            process.GetState(), lldb.eStateStopped,
             PROCESS_STOPPED)
 
         total_solibs_added = 0

--- a/lldb/test/API/functionalities/thread/break_after_join/TestBreakAfterJoin.py
+++ b/lldb/test/API/functionalities/thread/break_after_join/TestBreakAfterJoin.py
@@ -88,6 +88,6 @@ class BreakpointAfterJoinTestCase(TestBase):
             self.runCmd("process status")
 
         # At this point, the inferior process should have exited.
-        self.assertTrue(
-            process.GetState() == lldb.eStateExited,
+        self.assertEqual(
+            process.GetState(), lldb.eStateExited,
             PROCESS_EXITED)

--- a/lldb/test/API/functionalities/thread/create_after_attach/TestCreateAfterAttach.py
+++ b/lldb/test/API/functionalities/thread/create_after_attach/TestCreateAfterAttach.py
@@ -101,6 +101,6 @@ class CreateAfterAttachTestCase(TestBase):
         self.runCmd("continue")
 
         # At this point, the inferior process should have exited.
-        self.assertTrue(
-            process.GetState() == lldb.eStateExited,
+        self.assertEqual(
+            process.GetState(), lldb.eStateExited,
             PROCESS_EXITED)

--- a/lldb/test/API/functionalities/thread/create_during_step/TestCreateDuringStep.py
+++ b/lldb/test/API/functionalities/thread/create_during_step/TestCreateDuringStep.py
@@ -105,8 +105,8 @@ class CreateDuringStepTestCase(TestBase):
         num_threads = process.GetNumThreads()
 
         # Make sure we see only two threads
-        self.assertTrue(
-            num_threads == 2,
+        self.assertEqual(
+            num_threads, 2,
             'Number of expected threads and actual threads do not match.')
 
         # Get the thread objects
@@ -138,8 +138,8 @@ class CreateDuringStepTestCase(TestBase):
         num_threads = process.GetNumThreads()
 
         # Check to see that we increased the number of threads as expected
-        self.assertTrue(
-            num_threads == 3,
+        self.assertEqual(
+            num_threads, 3,
             'Number of expected threads and actual threads do not match after thread exit.')
 
         stop_reason = stepping_thread.GetStopReason()
@@ -149,6 +149,6 @@ class CreateDuringStepTestCase(TestBase):
         self.runCmd("process continue")
 
         # At this point, the inferior process should have exited.
-        self.assertTrue(
-            process.GetState() == lldb.eStateExited,
+        self.assertEqual(
+            process.GetState(), lldb.eStateExited,
             PROCESS_EXITED)

--- a/lldb/test/API/functionalities/thread/exit_during_break/TestExitDuringBreak.py
+++ b/lldb/test/API/functionalities/thread/exit_during_break/TestExitDuringBreak.py
@@ -58,6 +58,6 @@ class ExitDuringBreakpointTestCase(TestBase):
         self.runCmd("continue")
 
         # At this point, the inferior process should have exited.
-        self.assertTrue(
-            process.GetState() == lldb.eStateExited,
+        self.assertEqual(
+            process.GetState(), lldb.eStateExited,
             PROCESS_EXITED)

--- a/lldb/test/API/functionalities/thread/multi_break/TestMultipleBreakpoints.py
+++ b/lldb/test/API/functionalities/thread/multi_break/TestMultipleBreakpoints.py
@@ -85,6 +85,6 @@ class MultipleBreakpointTestCase(TestBase):
         self.runCmd("continue")
 
         # At this point, the inferior process should have exited.
-        self.assertTrue(
-            process.GetState() == lldb.eStateExited,
+        self.assertEqual(
+            process.GetState(), lldb.eStateExited,
             PROCESS_EXITED)

--- a/lldb/test/API/functionalities/thread/thread_specific_break_plus_condition/TestThreadSpecificBpPlusCondition.py
+++ b/lldb/test/API/functionalities/thread/thread_specific_break_plus_condition/TestThreadSpecificBpPlusCondition.py
@@ -69,6 +69,6 @@ class ThreadSpecificBreakPlusConditionTestCase(TestBase):
         process.Continue()
 
         next_stop_state = process.GetState()
-        self.assertTrue(
-            next_stop_state == lldb.eStateExited,
+        self.assertEqual(
+            next_stop_state, lldb.eStateExited,
             "We should have not hit the breakpoint again.")

--- a/lldb/test/API/lang/c/array_types/TestArrayTypes.py
+++ b/lldb/test/API/lang/c/array_types/TestArrayTypes.py
@@ -216,8 +216,8 @@ class ArrayTypesTestCase(TestBase):
         # Last, check that "long_6" has a value type of eValueTypeVariableLocal
         # and "argc" has eValueTypeVariableArgument.
         from lldbsuite.test.lldbutil import value_type_to_str
-        self.assertTrue(
-            variable.GetValueType() == lldb.eValueTypeVariableLocal,
+        self.assertEqual(
+            variable.GetValueType(), lldb.eValueTypeVariableLocal,
             "Variable 'long_6' should have '%s' value type." %
             value_type_to_str(
                 lldb.eValueTypeVariableLocal))

--- a/lldb/test/API/lang/c/bitfields/TestBitfields.py
+++ b/lldb/test/API/lang/c/bitfields/TestBitfields.py
@@ -206,11 +206,11 @@ class BitfieldsTestCase(TestBase):
         frame = thread.GetFrameAtIndex(0)
         bits = frame.FindVariable("bits")
         self.DebugSBValue(bits)
-        self.assertTrue(
-            bits.GetTypeName() == 'Bits',
+        self.assertEqual(
+            bits.GetTypeName(), 'Bits',
             "bits.GetTypeName() == 'Bits'")
-        self.assertTrue(
-            bits.GetNumChildren() == 10,
+        self.assertEqual(
+            bits.GetNumChildren(), 10,
             "bits.GetNumChildren() == 10")
         test_compiler = self.getCompiler()
         self.assertEqual(bits.GetByteSize(), 32, "bits.GetByteSize() == 32")

--- a/lldb/test/API/lang/c/stepping/TestStepAndBreakpoints.py
+++ b/lldb/test/API/lang/c/stepping/TestStepAndBreakpoints.py
@@ -115,14 +115,14 @@ class TestCStepping(TestBase):
         frame.EvaluateExpression("(int) printf (print_string)")
 
         frame = thread.GetFrameAtIndex(0)
-        self.assertTrue(
-            current_line == frame.GetLineEntry().GetLine(),
+        self.assertEqual(
+            current_line, frame.GetLineEntry().GetLine(),
             "The line stayed the same after expression.")
-        self.assertTrue(
-            current_file == frame.GetLineEntry().GetFileSpec(),
+        self.assertEqual(
+            current_file, frame.GetLineEntry().GetFileSpec(),
             "The file stayed the same after expression.")
-        self.assertTrue(
-            thread.GetStopReason() == lldb.eStopReasonBreakpoint,
+        self.assertEqual(
+            thread.GetStopReason(), lldb.eStopReasonBreakpoint,
             "We still say we stopped for a breakpoint.")
         self.assertTrue(thread.GetStopReasonDataAtIndex(0) == current_bp[
                         0] and thread.GetStopReasonDataAtIndex(1) == current_bp[1], "And it is the same breakpoint.")
@@ -132,8 +132,8 @@ class TestCStepping(TestBase):
         stop_id_after_expression = process.GetStopID()
         stop_id_after_including_expressions = process.GetStopID(True)
 
-        self.assertTrue(
-            stop_id_before_expression == stop_id_after_expression,
+        self.assertEqual(
+            stop_id_before_expression, stop_id_after_expression,
             "Expression calling doesn't change stop ID")
 
         self.assertTrue(
@@ -146,14 +146,14 @@ class TestCStepping(TestBase):
         frame.EvaluateExpression("((char *) 0)[0] = 'a'")
 
         frame = thread.GetFrameAtIndex(0)
-        self.assertTrue(
-            current_line == frame.GetLineEntry().GetLine(),
+        self.assertEqual(
+            current_line, frame.GetLineEntry().GetLine(),
             "The line stayed the same after expression.")
-        self.assertTrue(
-            current_file == frame.GetLineEntry().GetFileSpec(),
+        self.assertEqual(
+            current_file, frame.GetLineEntry().GetFileSpec(),
             "The file stayed the same after expression.")
-        self.assertTrue(
-            thread.GetStopReason() == lldb.eStopReasonBreakpoint,
+        self.assertEqual(
+            thread.GetStopReason(), lldb.eStopReasonBreakpoint,
             "We still say we stopped for a breakpoint.")
         self.assertTrue(thread.GetStopReasonDataAtIndex(0) == current_bp[
                         0] and thread.GetStopReasonDataAtIndex(1) == current_bp[1], "And it is the same breakpoint.")
@@ -202,8 +202,8 @@ class TestCStepping(TestBase):
 
         # See that we are still in b:
         func_name = thread.GetFrameAtIndex(0).GetFunctionName()
-        self.assertTrue(
-            func_name == "b",
+        self.assertEqual(
+            func_name, "b",
             "Should be in 'b', were in %s" %
             (func_name))
 

--- a/lldb/test/API/lang/c/unions/TestUnionMembers.py
+++ b/lldb/test/API/lang/c/unions/TestUnionMembers.py
@@ -21,8 +21,8 @@ class TestUnionMembers(TestBase):
         self.process = self.target.LaunchSimple(
             None, None, self.get_process_working_directory())
         self.assertTrue(self.process.IsValid(), PROCESS_IS_VALID)
-        self.assertTrue(
-            self.process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            self.process.GetState(), lldb.eStateStopped,
             PROCESS_STOPPED)
 
         thread = lldbutil.get_stopped_thread(

--- a/lldb/test/API/lang/cpp/breakpoint-commands/TestCPPBreakpointCommands.py
+++ b/lldb/test/API/lang/cpp/breakpoint-commands/TestCPPBreakpointCommands.py
@@ -20,8 +20,8 @@ class CPPBreakpointCommandsTestCase(TestBase):
                                                   self.a_out_module,
                                                   self.nested_comp_unit)
         num_locations = bkpt.GetNumLocations()
-        self.assertTrue(
-            num_locations == expected_num_locations,
+        self.assertEqual(
+            num_locations, expected_num_locations,
             "Wrong number of locations for '%s', expected: %d got: %d" %
             (name,
              expected_num_locations,

--- a/lldb/test/API/lang/cpp/class_static/TestStaticVariables.py
+++ b/lldb/test/API/lang/cpp/class_static/TestStaticVariables.py
@@ -140,12 +140,12 @@ class StaticVariableTestCase(TestBase):
             name = val.GetName()
             self.assertTrue(name in ['g_points', 'A::g_points'])
             if name == 'g_points':
-                self.assertTrue(
-                    val.GetValueType() == lldb.eValueTypeVariableStatic)
+                self.assertEqual(
+                    val.GetValueType(), lldb.eValueTypeVariableStatic)
                 self.assertEqual(val.GetNumChildren(), 2)
             elif name == 'A::g_points':
-                self.assertTrue(
-                    val.GetValueType() == lldb.eValueTypeVariableGlobal)
+                self.assertEqual(
+                    val.GetValueType(), lldb.eValueTypeVariableGlobal)
                 self.assertEqual(val.GetNumChildren(), 2)
                 child1 = val.GetChildAtIndex(1)
                 self.DebugSBValue(child1)

--- a/lldb/test/API/lang/cpp/diamond/TestDiamond.py
+++ b/lldb/test/API/lang/cpp/diamond/TestDiamond.py
@@ -33,8 +33,8 @@ class CPPTestDiamondInheritance(TestBase):
         j1_Derived2_VBase = j1_Derived2.GetChildAtIndex(0)
         j1_Derived1_VBase_m_value = j1_Derived1_VBase.GetChildAtIndex(0)
         j1_Derived2_VBase_m_value = j1_Derived2_VBase.GetChildAtIndex(0)
-        self.assertTrue(
-            j1_Derived1_VBase.GetLoadAddress() == j1_Derived2_VBase.GetLoadAddress(),
+        self.assertEqual(
+            j1_Derived1_VBase.GetLoadAddress(), j1_Derived2_VBase.GetLoadAddress(),
             "ensure virtual base class is the same between Derived1 and Derived2")
         self.assertTrue(j1_Derived1_VBase_m_value.GetValueAsUnsigned(
             1) == j1_Derived2_VBase_m_value.GetValueAsUnsigned(2), "ensure m_value in VBase is the same")

--- a/lldb/test/API/lang/cpp/exceptions/TestCPPExceptionBreakpoints.py
+++ b/lldb/test/API/lang/cpp/exceptions/TestCPPExceptionBreakpoints.py
@@ -46,15 +46,15 @@ class CPPBreakpointTestCase(TestBase):
         stopped_threads = []
         stopped_threads = lldbutil.get_threads_stopped_at_breakpoint(
             process, exception_bkpt)
-        self.assertTrue(
-            len(stopped_threads) == 1,
+        self.assertEqual(
+            len(stopped_threads), 1,
             "Stopped at our exception breakpoint.")
         thread = stopped_threads[0]
         # Make sure our throw function is still above us on the stack:
 
         frame_functions = lldbutil.get_function_names(thread)
-        self.assertTrue(
-            frame_functions.count("throws_exception_on_even(int)") == 1,
+        self.assertEqual(
+            frame_functions.count("throws_exception_on_even(int)"), 1,
             "Our throw function is still on the stack.")
 
         # Okay we hit our exception throw breakpoint, now make sure we get our catch breakpoint.
@@ -70,12 +70,12 @@ class CPPBreakpointTestCase(TestBase):
             thread = stopped_threads[0]
             frame_functions = lldbutil.get_function_names(thread)
 
-        self.assertTrue(
-            frame_functions.count("throws_exception_on_even(int)") == 0,
+        self.assertEqual(
+            frame_functions.count("throws_exception_on_even(int)"), 0,
             "At catch our throw function is off the stack")
-        self.assertTrue(
-            frame_functions.count("intervening_function(int)") == 0,
+        self.assertEqual(
+            frame_functions.count("intervening_function(int)"), 0,
             "At catch our intervening function is off the stack")
-        self.assertTrue(
-            frame_functions.count("catches_exception(int)") == 1,
+        self.assertEqual(
+            frame_functions.count("catches_exception(int)"), 1,
             "At catch our catch function is on the stack")

--- a/lldb/test/API/lang/cpp/global_operators/TestCppGlobalOperators.py
+++ b/lldb/test/API/lang/cpp/global_operators/TestCppGlobalOperators.py
@@ -41,8 +41,8 @@ class TestCppGlobalOperators(TestBase):
         self.assertTrue(process.IsValid(), PROCESS_IS_VALID)
 
         # Get the thread of the process
-        self.assertTrue(
-            process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            process.GetState(), lldb.eStateStopped,
             PROCESS_STOPPED)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)

--- a/lldb/test/API/lang/cpp/gmodules/TestWithModuleDebugging.py
+++ b/lldb/test/API/lang/cpp/gmodules/TestWithModuleDebugging.py
@@ -53,8 +53,8 @@ class TestWithGmodulesDebugInfo(TestBase):
             testValue.GetError().Success(),
             "Test expression value invalid: %s" %
             (testValue.GetError().GetCString()))
-        self.assertTrue(
-            testValue.GetTypeName() == "IntContainer",
+        self.assertEqual(
+            testValue.GetTypeName(), "IntContainer",
             "Test expression type incorrect")
 
         memberValue = testValue.GetChildMemberWithName("storage")
@@ -62,8 +62,8 @@ class TestWithGmodulesDebugInfo(TestBase):
             memberValue.GetError().Success(),
             "Member value missing or invalid: %s" %
             (testValue.GetError().GetCString()))
-        self.assertTrue(
-            memberValue.GetTypeName() == "int",
+        self.assertEqual(
+            memberValue.GetTypeName(), "int",
             "Member type incorrect")
         self.assertEqual(
             42,
@@ -75,8 +75,8 @@ class TestWithGmodulesDebugInfo(TestBase):
             testValue.GetError().Success(),
             "Test expression value invalid: %s" %
             (testValue.GetError().GetCString()))
-        self.assertTrue(
-            testValue.GetTypeName() == "Foo::Bar",
+        self.assertEqual(
+            testValue.GetTypeName(), "Foo::Bar",
             "Test expression type incorrect")
 
         memberValue = testValue.GetChildMemberWithName("i")
@@ -84,8 +84,8 @@ class TestWithGmodulesDebugInfo(TestBase):
             memberValue.GetError().Success(),
             "Member value missing or invalid: %s" %
             (testValue.GetError().GetCString()))
-        self.assertTrue(
-            memberValue.GetTypeName() == "int",
+        self.assertEqual(
+            memberValue.GetTypeName(), "int",
             "Member type incorrect")
         self.assertEqual(
             123,

--- a/lldb/test/API/lang/cpp/limit-debug-info/TestWithLimitDebugInfo.py
+++ b/lldb/test/API/lang/cpp/limit-debug-info/TestWithLimitDebugInfo.py
@@ -36,8 +36,8 @@ class TestWithLimitDebugInfo(TestBase):
         self.assertTrue(process.IsValid(), PROCESS_IS_VALID)
 
         # Get the thread of the process
-        self.assertTrue(
-            process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            process.GetState(), lldb.eStateStopped,
             PROCESS_STOPPED)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)

--- a/lldb/test/API/lang/cpp/member-and-local-vars-with-same-name/TestMembersAndLocalsWithSameName.py
+++ b/lldb/test/API/lang/cpp/member-and-local-vars-with-same-name/TestMembersAndLocalsWithSameName.py
@@ -38,15 +38,15 @@ class TestMembersAndLocalsWithSameName(TestBase):
             None, None, self.get_process_working_directory())
         self.assertTrue(self.process.IsValid(), PROCESS_IS_VALID)
 
-        self.assertTrue(
-            self.process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            self.process.GetState(), lldb.eStateStopped,
             PROCESS_STOPPED)
 
         self._test_globals()
 
         self.process.Continue()
-        self.assertTrue(
-            self.process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            self.process.GetState(), lldb.eStateStopped,
             PROCESS_STOPPED)
         thread = lldbutil.get_stopped_thread(
             self.process, lldb.eStopReasonBreakpoint)
@@ -67,8 +67,8 @@ class TestMembersAndLocalsWithSameName(TestBase):
         self.assertEqual(val.GetValueAsUnsigned(), 34567)
 
         self.process.Continue()
-        self.assertTrue(
-            self.process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            self.process.GetState(), lldb.eStateStopped,
             PROCESS_STOPPED)
         thread = lldbutil.get_stopped_thread(
             self.process, lldb.eStopReasonBreakpoint)
@@ -89,8 +89,8 @@ class TestMembersAndLocalsWithSameName(TestBase):
         self.assertEqual(val.GetValueAsUnsigned(), 10003)
 
         self.process.Continue()
-        self.assertTrue(
-            self.process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            self.process.GetState(), lldb.eStateStopped,
             PROCESS_STOPPED)
         thread = lldbutil.get_stopped_thread(
             self.process, lldb.eStopReasonBreakpoint)
@@ -140,15 +140,15 @@ class TestMembersAndLocalsWithSameName(TestBase):
             None, None, self.get_process_working_directory())
         self.assertTrue(self.process.IsValid(), PROCESS_IS_VALID)
 
-        self.assertTrue(
-            self.process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            self.process.GetState(), lldb.eStateStopped,
             PROCESS_STOPPED)
 
         self._test_globals()
 
         self.process.Continue()
-        self.assertTrue(
-            self.process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            self.process.GetState(), lldb.eStateStopped,
             PROCESS_STOPPED)
         thread = lldbutil.get_stopped_thread(
             self.process, lldb.eStopReasonBreakpoint)
@@ -171,8 +171,8 @@ class TestMembersAndLocalsWithSameName(TestBase):
         self.assertEqual(val.GetValueAsUnsigned(), 34567)
 
         self.process.Continue()
-        self.assertTrue(
-            self.process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            self.process.GetState(), lldb.eStateStopped,
             PROCESS_STOPPED)
         thread = lldbutil.get_stopped_thread(
             self.process, lldb.eStopReasonBreakpoint)
@@ -199,8 +199,8 @@ class TestMembersAndLocalsWithSameName(TestBase):
         self.assertEqual(val.GetValueAsUnsigned(), 1)
 
         self.process.Continue()
-        self.assertTrue(
-            self.process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            self.process.GetState(), lldb.eStateStopped,
             PROCESS_STOPPED)
         thread = lldbutil.get_stopped_thread(
             self.process, lldb.eStopReasonBreakpoint)

--- a/lldb/test/API/lang/cpp/nsimport/TestCppNsImport.py
+++ b/lldb/test/API/lang/cpp/nsimport/TestCppNsImport.py
@@ -47,8 +47,8 @@ class TestCppNsImport(TestBase):
         self.assertTrue(process.IsValid(), PROCESS_IS_VALID)
 
         # Get the thread of the process
-        self.assertTrue(
-            process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            process.GetState(), lldb.eStateStopped,
             PROCESS_STOPPED)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)
@@ -120,8 +120,8 @@ class TestCppNsImport(TestBase):
         process.Continue()
 
         # Get the thread of the process
-        self.assertTrue(
-            process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            process.GetState(), lldb.eStateStopped,
             PROCESS_STOPPED)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)

--- a/lldb/test/API/lang/cpp/template/TestTemplateArgs.py
+++ b/lldb/test/API/lang/cpp/template/TestTemplateArgs.py
@@ -38,8 +38,8 @@ class TemplateArgsTestCase(TestBase):
         self.assertTrue(process, PROCESS_IS_VALID)
 
         # Get the thread of the process
-        self.assertTrue(
-            process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            process.GetState(), lldb.eStateStopped,
             PROCESS_STOPPED)
         thread = lldbutil.get_stopped_thread(
             process, lldb.eStopReasonBreakpoint)
@@ -61,8 +61,8 @@ class TemplateArgsTestCase(TestBase):
             expr_result.IsValid(),
             'got a valid expression result from expression "testpos.getArg()"')
         self.assertEquals(expr_result.GetValue(), "1", "testpos.getArg() == 1")
-        self.assertTrue(
-            expr_result.GetType().GetName() == "int",
+        self.assertEqual(
+            expr_result.GetType().GetName(), "int",
             'expr_result.GetType().GetName() == "int"')
 
         testneg = frame.FindVariable('testneg')
@@ -75,11 +75,11 @@ class TemplateArgsTestCase(TestBase):
         self.assertTrue(
             expr_result.IsValid(),
             'got a valid expression result from expression "testneg.getArg()"')
-        self.assertTrue(
-            expr_result.GetValue() == "-1",
+        self.assertEqual(
+            expr_result.GetValue(), "-1",
             "testneg.getArg() == -1")
-        self.assertTrue(
-            expr_result.GetType().GetName() == "int",
+        self.assertEqual(
+            expr_result.GetType().GetName(), "int",
             'expr_result.GetType().GetName() == "int"')
 
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24489")
@@ -130,11 +130,11 @@ class TemplateArgsTestCase(TestBase):
         self.assertTrue(
             expr_result.IsValid(),
             'got a valid expression result from expression "member.getMember()"')
-        self.assertTrue(
-            expr_result.GetValue() == "123",
+        self.assertEqual(
+            expr_result.GetValue(), "123",
             "member.getMember() == 123")
-        self.assertTrue(
-            expr_result.GetType().GetName() == "int",
+        self.assertEqual(
+            expr_result.GetType().GetName(), "int",
             'expr_result.GetType().GetName() == "int"')
 
         # Make sure "subclass" can be displayed and also used in an expression
@@ -150,9 +150,9 @@ class TemplateArgsTestCase(TestBase):
         self.assertTrue(
             expr_result.IsValid(),
             'got a valid expression result from expression "subclass.getMember()"')
-        self.assertTrue(
-            expr_result.GetValue() == "246",
+        self.assertEqual(
+            expr_result.GetValue(), "246",
             "subclass.getMember() == 246")
-        self.assertTrue(
-            expr_result.GetType().GetName() == "int",
+        self.assertEqual(
+            expr_result.GetType().GetName(), "int",
             'expr_result.GetType().GetName() == "int"')

--- a/lldb/test/API/lang/objc/blocks/TestObjCIvarsInBlocks.py
+++ b/lldb/test/API/lang/objc/blocks/TestObjCIvarsInBlocks.py
@@ -42,8 +42,8 @@ class TestObjCIvarsInBlocks(TestBase):
         process = target.LaunchSimple(
             None, None, self.get_process_working_directory())
         self.assertTrue(process, "Created a process.")
-        self.assertTrue(
-            process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            process.GetState(), lldb.eStateStopped,
             "Stopped it too.")
 
         thread_list = lldbutil.get_threads_stopped_at_breakpoint(
@@ -73,8 +73,8 @@ class TestObjCIvarsInBlocks(TestBase):
         indirect_value = indirect_blocky.GetValueAsSigned(error)
         self.assertTrue(error.Success(), "Got indirect value for blocky_ivar")
 
-        self.assertTrue(
-            direct_value == indirect_value,
+        self.assertEqual(
+            direct_value, indirect_value,
             "Direct and indirect values are equal.")
 
         # Now make sure that we can get at the captured ivar through the expression parser.
@@ -102,13 +102,13 @@ class TestObjCIvarsInBlocks(TestBase):
             error.Success(),
             "Got value from indirect access using the expression parser")
 
-        self.assertTrue(
-            direct_value == indirect_value,
+        self.assertEqual(
+            direct_value, indirect_value,
             "Direct ivar access and indirect through expression parser produce same value.")
 
         process.Continue()
-        self.assertTrue(
-            process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            process.GetState(), lldb.eStateStopped,
             "Stopped at the second breakpoint.")
 
         thread_list = lldbutil.get_threads_stopped_at_breakpoint(
@@ -125,6 +125,6 @@ class TestObjCIvarsInBlocks(TestBase):
 
         ret_value_signed = expr.GetValueAsSigned(error)
         self.trace('ret_value_signed = %i' % (ret_value_signed))
-        self.assertTrue(
-            ret_value_signed == 5,
+        self.assertEqual(
+            ret_value_signed, 5,
             "The local variable in the block was what we expected.")

--- a/lldb/test/API/lang/objc/foundation/TestObjCMethods.py
+++ b/lldb/test/API/lang/objc/foundation/TestObjCMethods.py
@@ -270,8 +270,8 @@ class FoundationTestCase(TestBase):
 
         my_str_value = int(my_str_var.GetValue(), 0)
 
-        self.assertTrue(
-            str_value == my_str_value,
+        self.assertEqual(
+            str_value, my_str_value,
             "Got the correct value for my->str")
 
     def test_expression_lookups_objc(self):

--- a/lldb/test/API/lang/objc/global_ptrs/TestGlobalObjects.py
+++ b/lldb/test/API/lang/objc/global_ptrs/TestGlobalObjects.py
@@ -32,8 +32,8 @@ class TestObjCGlobalVar(TestBase):
         # Before we launch, make an SBValue for our global object pointer:
         g_obj_ptr = target.FindFirstGlobalVariable("g_obj_ptr")
         self.assertTrue(g_obj_ptr.GetError().Success(), "Made the g_obj_ptr")
-        self.assertTrue(
-            g_obj_ptr.GetValueAsUnsigned(10) == 0,
+        self.assertEqual(
+            g_obj_ptr.GetValueAsUnsigned(10), 0,
             "g_obj_ptr is initially null")
 
         # Now launch the process, and do not stop at entry point.

--- a/lldb/test/API/lang/objc/objc-baseclass-sbtype/TestObjCBaseClassSBType.py
+++ b/lldb/test/API/lang/objc/objc-baseclass-sbtype/TestObjCBaseClassSBType.py
@@ -47,11 +47,11 @@ class ObjCDynamicValueTestCase(TestBase):
         var = self.frame().FindVariable("foo")
         var_ptr_type = var.GetType()
         var_pte_type = var_ptr_type.GetPointeeType()
-        self.assertTrue(
-            var_ptr_type.GetNumberOfDirectBaseClasses() == 1,
+        self.assertEqual(
+            var_ptr_type.GetNumberOfDirectBaseClasses(), 1,
             "Foo * has one base class")
-        self.assertTrue(
-            var_pte_type.GetNumberOfDirectBaseClasses() == 1,
+        self.assertEqual(
+            var_pte_type.GetNumberOfDirectBaseClasses(), 1,
             "Foo has one base class")
 
         self.assertTrue(var_ptr_type.GetDirectBaseClassAtIndex(

--- a/lldb/test/API/lang/objc/objc-dyn-sbtype/TestObjCDynamicSBType.py
+++ b/lldb/test/API/lang/objc/objc-dyn-sbtype/TestObjCDynamicSBType.py
@@ -46,34 +46,34 @@ class ObjCDynamicSBTypeTestCase(TestBase):
             "object").GetDynamicValue(lldb.eDynamicCanRunTarget)
         v_base = self.frame().FindVariable(
             "base").GetDynamicValue(lldb.eDynamicCanRunTarget)
-        self.assertTrue(
-            v_object.GetTypeName() == "MyDerivedClass *",
+        self.assertEqual(
+            v_object.GetTypeName(), "MyDerivedClass *",
             "The NSObject is properly type-named")
-        self.assertTrue(
-            v_base.GetTypeName() == "MyDerivedClass *",
+        self.assertEqual(
+            v_base.GetTypeName(), "MyDerivedClass *",
             "The Base is properly type-named")
         object_type = v_object.GetType()
         base_type = v_base.GetType()
-        self.assertTrue(
-            object_type.GetName() == "MyDerivedClass *",
+        self.assertEqual(
+            object_type.GetName(), "MyDerivedClass *",
             "The dynamic SBType for NSObject is for the correct type")
-        self.assertTrue(
-            base_type.GetName() == "MyDerivedClass *",
+        self.assertEqual(
+            base_type.GetName(), "MyDerivedClass *",
             "The dynamic SBType for Base is for the correct type")
         object_pointee_type = object_type.GetPointeeType()
         base_pointee_type = base_type.GetPointeeType()
-        self.assertTrue(
-            object_pointee_type.GetName() == "MyDerivedClass",
+        self.assertEqual(
+            object_pointee_type.GetName(), "MyDerivedClass",
             "The dynamic type for NSObject figures out its pointee type just fine")
-        self.assertTrue(
-            base_pointee_type.GetName() == "MyDerivedClass",
+        self.assertEqual(
+            base_pointee_type.GetName(), "MyDerivedClass",
             "The dynamic type for Base figures out its pointee type just fine")
 
-        self.assertTrue(
-            object_pointee_type.GetDirectBaseClassAtIndex(0).GetName() == "MyBaseClass",
+        self.assertEqual(
+            object_pointee_type.GetDirectBaseClassAtIndex(0).GetName(), "MyBaseClass",
             "The dynamic type for NSObject can go back to its base class")
-        self.assertTrue(
-            base_pointee_type.GetDirectBaseClassAtIndex(0).GetName() == "MyBaseClass",
+        self.assertEqual(
+            base_pointee_type.GetDirectBaseClassAtIndex(0).GetName(), "MyBaseClass",
             "The dynamic type for Base can go back to its base class")
 
         self.assertTrue(object_pointee_type.GetDirectBaseClassAtIndex(0).GetType().GetDirectBaseClassAtIndex(
@@ -81,9 +81,9 @@ class ObjCDynamicSBTypeTestCase(TestBase):
         self.assertTrue(base_pointee_type.GetDirectBaseClassAtIndex(0).GetType().GetDirectBaseClassAtIndex(
             0).GetName() == "NSObject", "The dynamic type for Base can go up the hierarchy")
 
-        self.assertTrue(
-            object_pointee_type.GetNumberOfFields() == 2,
+        self.assertEqual(
+            object_pointee_type.GetNumberOfFields(), 2,
             "The dynamic type for NSObject has 2 fields")
-        self.assertTrue(
-            base_pointee_type.GetNumberOfFields() == 2,
+        self.assertEqual(
+            base_pointee_type.GetNumberOfFields(), 2,
             "The dynamic type for Base has 2 fields")

--- a/lldb/test/API/lang/objc/objc-ivar-offsets/TestObjCIvarOffsets.py
+++ b/lldb/test/API/lang/objc/objc-ivar-offsets/TestObjCIvarOffsets.py
@@ -36,8 +36,8 @@ class TestObjCIvarOffsets(TestBase):
         process = target.LaunchSimple(
             None, None, self.get_process_working_directory())
         self.assertTrue(process, "Created a process.")
-        self.assertTrue(
-            process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            process.GetState(), lldb.eStateStopped,
             "Stopped it too.")
 
         thread_list = lldbutil.get_threads_stopped_at_breakpoint(

--- a/lldb/test/API/lang/objc/objc-ivar-stripped/TestObjCIvarStripped.py
+++ b/lldb/test/API/lang/objc/objc-ivar-stripped/TestObjCIvarStripped.py
@@ -43,8 +43,8 @@ class TestObjCIvarStripped(TestBase):
         process = target.LaunchSimple(
             None, None, self.get_process_working_directory())
         self.assertTrue(process, "Created a process.")
-        self.assertTrue(
-            process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            process.GetState(), lldb.eStateStopped,
             "Stopped it too.")
 
         thread_list = lldbutil.get_threads_stopped_at_breakpoint(

--- a/lldb/test/API/lang/objc/objc-static-method-stripped/TestObjCStaticMethodStripped.py
+++ b/lldb/test/API/lang/objc/objc-static-method-stripped/TestObjCStaticMethodStripped.py
@@ -49,8 +49,8 @@ class TestObjCStaticMethodStripped(TestBase):
         thread_list = lldbutil.get_threads_stopped_at_breakpoint(process, bpt)
 
         # Make sure we stopped at the first breakpoint.
-        self.assertTrue(
-            len(thread_list) != 0,
+        self.assertNotEqual(
+            len(thread_list), 0,
             "No thread stopped at our breakpoint.")
         self.assertEquals(len(thread_list), 1,
                         "More than one thread stopped at our breakpoint.")
@@ -63,14 +63,14 @@ class TestObjCStaticMethodStripped(TestBase):
         cmd_value = frame.EvaluateExpression("(char *) sel_getName (_cmd)")
         self.assertTrue(cmd_value.IsValid())
         sel_name = cmd_value.GetSummary()
-        self.assertTrue(
-            sel_name == "\"doSomethingWithString:\"",
+        self.assertEqual(
+            sel_name, "\"doSomethingWithString:\"",
             "Got the right value for the selector as string.")
 
         cmd_value = frame.EvaluateExpression(
             "[Foo doSomethingElseWithString:string]")
         self.assertTrue(cmd_value.IsValid())
         string_length = cmd_value.GetValueAsUnsigned()
-        self.assertTrue(
-            string_length == 27,
+        self.assertEqual(
+            string_length, 27,
             "Got the right value from another class method on the same class.")

--- a/lldb/test/API/lang/objc/objc-static-method/TestObjCStaticMethod.py
+++ b/lldb/test/API/lang/objc/objc-static-method/TestObjCStaticMethod.py
@@ -44,8 +44,8 @@ class TestObjCStaticMethod(TestBase):
         thread_list = lldbutil.get_threads_stopped_at_breakpoint(process, bpt)
 
         # Make sure we stopped at the first breakpoint.
-        self.assertTrue(
-            len(thread_list) != 0,
+        self.assertNotEqual(
+            len(thread_list), 0,
             "No thread stopped at our breakpoint.")
         self.assertEquals(len(thread_list), 1,
                         "More than one thread stopped at our breakpoint.")
@@ -58,14 +58,14 @@ class TestObjCStaticMethod(TestBase):
         cmd_value = frame.EvaluateExpression("(char *) sel_getName (_cmd)")
         self.assertTrue(cmd_value.IsValid())
         sel_name = cmd_value.GetSummary()
-        self.assertTrue(
-            sel_name == "\"doSomethingWithString:\"",
+        self.assertEqual(
+            sel_name, "\"doSomethingWithString:\"",
             "Got the right value for the selector as string.")
 
         cmd_value = frame.EvaluateExpression(
             "[self doSomethingElseWithString:string]")
         self.assertTrue(cmd_value.IsValid())
         string_length = cmd_value.GetValueAsUnsigned()
-        self.assertTrue(
-            string_length == 27,
+        self.assertEqual(
+            string_length, 27,
             "Got the right value from another class method on the same class.")

--- a/lldb/test/API/lang/objc/objc-stepping/TestObjCStepping.py
+++ b/lldb/test/API/lang/objc/objc-stepping/TestObjCStepping.py
@@ -214,6 +214,6 @@ class TestObjCStepping(TestBase):
 
         thread.StepInto()
         line_number = thread.GetFrameAtIndex(0).GetLineEntry().GetLine()
-        self.assertTrue(
-            line_number == self.stepped_past_nil_line,
+        self.assertEqual(
+            line_number, self.stepped_past_nil_line,
             "Step in over dispatch to nil stepped over.")

--- a/lldb/test/API/lang/objc/single-entry-dictionary/TestObjCSingleEntryDictionary.py
+++ b/lldb/test/API/lang/objc/single-entry-dictionary/TestObjCSingleEntryDictionary.py
@@ -46,15 +46,15 @@ class ObjCSingleEntryDictionaryTestCase(TestBase):
         d1.SetPreferSyntheticValue(True)
         d1.SetPreferDynamicValue(lldb.eDynamicCanRunTarget)
 
-        self.assertTrue(
-            d1.GetNumChildren() == 1,
+        self.assertEqual(
+            d1.GetNumChildren(), 1,
             "dictionary has != 1 child elements")
         pair = d1.GetChildAtIndex(0)
         pair.SetPreferSyntheticValue(True)
         pair.SetPreferDynamicValue(lldb.eDynamicCanRunTarget)
 
-        self.assertTrue(
-            pair.GetNumChildren() == 2,
+        self.assertEqual(
+            pair.GetNumChildren(), 2,
             "pair has != 2 child elements")
 
         key = pair.GetChildMemberWithName("key")
@@ -65,9 +65,9 @@ class ObjCSingleEntryDictionaryTestCase(TestBase):
         value.SetPreferSyntheticValue(True)
         value.SetPreferDynamicValue(lldb.eDynamicCanRunTarget)
 
-        self.assertTrue(
-            key.GetSummary() == '@"key"',
+        self.assertEqual(
+            key.GetSummary(), '@"key"',
             "key doesn't contain key")
-        self.assertTrue(
-            value.GetSummary() == '@"value"',
+        self.assertEqual(
+            value.GetSummary(), '@"value"',
             "value doesn't contain value")

--- a/lldb/test/API/macosx/indirect_symbol/TestIndirectSymbols.py
+++ b/lldb/test/API/macosx/indirect_symbol/TestIndirectSymbols.py
@@ -71,12 +71,12 @@ class TestIndirectFunctions(TestBase):
         # symbol:
 
         threads = lldbutil.continue_to_breakpoint(process, break_indirect)
-        self.assertTrue(
-            len(threads) == 1,
+        self.assertEqual(
+            len(threads), 1,
             "Stopped at breakpoint in indirect function.")
         curr_function = thread.GetFrameAtIndex(0).GetFunctionName()
-        self.assertTrue(
-            curr_function == "call_through_indirect_hidden",
+        self.assertEqual(
+            curr_function, "call_through_indirect_hidden",
             "Stepped into indirect symbols.")
 
         # Delete this breakpoint so it won't get in the way:
@@ -90,8 +90,8 @@ class TestIndirectFunctions(TestBase):
         # symbol:
         thread.StepInto()
         curr_function = thread.GetFrameAtIndex(0).GetFunctionName()
-        self.assertTrue(
-            curr_function == "call_through_indirect_hidden",
+        self.assertEqual(
+            curr_function, "call_through_indirect_hidden",
             "Stepped into indirect symbols.")
 
         # And the last bit is to set a breakpoint on the re-exported symbol and
@@ -104,10 +104,10 @@ class TestIndirectFunctions(TestBase):
         # symbol:
 
         threads = lldbutil.continue_to_breakpoint(process, break_reexported)
-        self.assertTrue(
-            len(threads) == 1,
+        self.assertEqual(
+            len(threads), 1,
             "Stopped at breakpoint in reexported function target.")
         curr_function = thread.GetFrameAtIndex(0).GetFunctionName()
-        self.assertTrue(
-            curr_function == "call_through_indirect_hidden",
+        self.assertEqual(
+            curr_function, "call_through_indirect_hidden",
             "Stepped into indirect symbols.")

--- a/lldb/test/API/macosx/queues/TestQueues.py
+++ b/lldb/test/API/macosx/queues/TestQueues.py
@@ -42,14 +42,14 @@ class TestQueues(TestBase):
 
     def check_running_and_pending_items_on_queue(
             self, queue, expected_running, expected_pending):
-        self.assertTrue(
-            queue.GetNumPendingItems() == expected_pending,
+        self.assertEqual(
+            queue.GetNumPendingItems(), expected_pending,
             "queue %s should have %d pending items, instead has %d pending items" %
             (queue.GetName(),
              expected_pending,
              (queue.GetNumPendingItems())))
-        self.assertTrue(
-            queue.GetNumRunningItems() == expected_running,
+        self.assertEqual(
+            queue.GetNumRunningItems(), expected_running,
             "queue %s should have %d running items, instead has %d running items" %
             (queue.GetName(),
              expected_running,
@@ -72,8 +72,8 @@ class TestQueues(TestBase):
         if (queue.GetNumThreads() != number_threads):
             self.describe_threads()
 
-        self.assertTrue(
-            queue.GetNumThreads() == number_threads,
+        self.assertEqual(
+            queue.GetNumThreads(), number_threads,
             "queue %s should have %d thread executing, but has %d" %
             (queue.GetName(),
              number_threads,
@@ -90,8 +90,8 @@ class TestQueues(TestBase):
             actual_kind_string = "Serial queue"
         if queue.GetKind() == lldb.eQueueKindConcurrent:
             actual_kind_string = "Concurrent queue"
-        self.assertTrue(
-            queue.GetKind() == kind,
+        self.assertEqual(
+            queue.GetKind(), kind,
             "queue %s is expected to be a %s but it is actually a %s" %
             (queue.GetName(),
              expected_kind_string,
@@ -103,22 +103,22 @@ class TestQueues(TestBase):
             self.assertTrue(
                 t.IsValid(), "Queue %s's thread #%d must be valid" %
                 (queue.GetName(), idx))
-            self.assertTrue(
-                t.GetQueueID() == queue.GetQueueID(),
+            self.assertEqual(
+                t.GetQueueID(), queue.GetQueueID(),
                 "Queue %s has a QueueID of %d but its thread #%d has a QueueID of %d" %
                 (queue.GetName(),
                  queue.GetQueueID(),
                  idx,
                  t.GetQueueID()))
-            self.assertTrue(
-                t.GetQueueName() == queue.GetName(),
+            self.assertEqual(
+                t.GetQueueName(), queue.GetName(),
                 "Queue %s has a QueueName of %s but its thread #%d has a QueueName of %s" %
                 (queue.GetName(),
                  queue.GetName(),
                  idx,
                  t.GetQueueName()))
-            self.assertTrue(
-                t.GetQueue().GetQueueID() == queue.GetQueueID(),
+            self.assertEqual(
+                t.GetQueue().GetQueueID(), queue.GetQueueID(),
                 "Thread #%d's Queue's QueueID of %d is not the same as the QueueID of its owning queue %d" %
                 (idx,
                  t.GetQueue().GetQueueID(),
@@ -364,8 +364,8 @@ class TestQueues(TestBase):
             0).IsValid(), "queue 2's pending item #0 is valid")
         self.assertTrue(queue_performer_2.GetPendingItemAtIndex(0).GetAddress().GetSymbol(
         ).GetName() == "doing_the_work_2", "queue 2's pending item #0 should be doing_the_work_2")
-        self.assertTrue(
-            queue_performer_2.GetNumPendingItems() == 9999,
+        self.assertEqual(
+            queue_performer_2.GetNumPendingItems(), 9999,
             "verify that queue 2 still has 9999 pending items")
         self.assertTrue(queue_performer_2.GetPendingItemAtIndex(
             9998).IsValid(), "queue 2's pending item #9998 is valid")

--- a/lldb/test/API/macosx/safe-to-func-call/TestSafeFuncCalls.py
+++ b/lldb/test/API/macosx/safe-to-func-call/TestSafeFuncCalls.py
@@ -49,6 +49,6 @@ class TestSafeFuncCalls(TestBase):
 
         self.assertTrue(main_thread.SafeToCallFunctions(),
                         "It is safe to call functions on the main thread")
-        self.assertTrue(
-            select_thread.SafeToCallFunctions() == False,
+        self.assertEqual(
+            select_thread.SafeToCallFunctions(), False,
             "It is not safe to call functions on the select thread")

--- a/lldb/test/API/macosx/thread-names/TestInterruptThreadNames.py
+++ b/lldb/test/API/macosx/thread-names/TestInterruptThreadNames.py
@@ -126,8 +126,8 @@ class TestInterruptThreadNames(TestBase):
 
 
     def check_number_of_threads(self, process):
-        self.assertTrue(
-            process.GetNumThreads() == 3,
+        self.assertEqual(
+            process.GetNumThreads(), 3,
             "Check that the process has three threads when sitting at the stopper() breakpoint")
 
     def check_expected_threads_present(self, main_thread, second_thread, third_thread):

--- a/lldb/test/API/python_api/event/TestEvents.py
+++ b/lldb/test/API/python_api/event/TestEvents.py
@@ -62,8 +62,8 @@ class EventAPITestCase(TestBase):
                                 False,     # Stop at entry
                                 error)     # error
 
-        self.assertTrue(
-            process.GetState() == lldb.eStateStopped,
+        self.assertEqual(
+            process.GetState(), lldb.eStateStopped,
             PROCESS_STOPPED)
 
         # Create an empty event object.

--- a/lldb/test/API/python_api/formatters/TestFormattersSBAPI.py
+++ b/lldb/test/API/python_api/formatters/TestFormattersSBAPI.py
@@ -128,8 +128,8 @@ class SBFormattersAPITestCase(TestBase):
         filter = lldb.SBTypeFilter(0)
         filter.AppendExpressionPath("A")
         filter.AppendExpressionPath("D")
-        self.assertTrue(
-            filter.GetNumberOfExpressionPaths() == 2,
+        self.assertEqual(
+            filter.GetNumberOfExpressionPaths(), 2,
             "filter with two items does not have two items")
 
         category.AddTypeFilter(lldb.SBTypeNameSpecifier("JustAStruct"), filter)
@@ -180,11 +180,11 @@ class SBFormattersAPITestCase(TestBase):
             foo_var.GetDeclaration().IsValid(),
             'foo declaration is invalid')
 
-        self.assertTrue(
-            foo_var.GetNumChildren() == 2,
+        self.assertEqual(
+            foo_var.GetNumChildren(), 2,
             'synthetic value has wrong number of child items (synth)')
-        self.assertTrue(
-            foo_var.GetChildMemberWithName('X').GetValueAsUnsigned() == 1,
+        self.assertEqual(
+            foo_var.GetChildMemberWithName('X').GetValueAsUnsigned(), 1,
             'foo_synth.X has wrong value (synth)')
         self.assertFalse(
             foo_var.GetChildMemberWithName('B').IsValid(),
@@ -210,14 +210,14 @@ class SBFormattersAPITestCase(TestBase):
         ).GetSelectedThread().GetSelectedFrame().FindVariable('foo')
         self.assertTrue(foo_var.IsValid(), 'could not find foo')
 
-        self.assertTrue(
-            foo_var.GetNumChildren() == 2,
+        self.assertEqual(
+            foo_var.GetNumChildren(), 2,
             'synthetic value has wrong number of child items (filter)')
-        self.assertTrue(
-            foo_var.GetChildMemberWithName('X').GetValueAsUnsigned() == 0,
+        self.assertEqual(
+            foo_var.GetChildMemberWithName('X').GetValueAsUnsigned(), 0,
             'foo_synth.X has wrong value (filter)')
-        self.assertTrue(
-            foo_var.GetChildMemberWithName('A').GetValueAsUnsigned() == 1,
+        self.assertEqual(
+            foo_var.GetChildMemberWithName('A').GetValueAsUnsigned(), 1,
             'foo_synth.A has wrong value (filter)')
 
         self.assertTrue(filter.ReplaceExpressionPathAtIndex(
@@ -240,20 +240,20 @@ class SBFormattersAPITestCase(TestBase):
         foo_var = self.dbg.GetSelectedTarget().GetProcess(
         ).GetSelectedThread().GetSelectedFrame().FindVariable('foo')
         self.assertTrue(foo_var.IsValid(), 'could not find foo')
-        self.assertTrue(
-            foo_var.GetChildMemberWithName('C').GetValueAsUnsigned() == ord('e'),
+        self.assertEqual(
+            foo_var.GetChildMemberWithName('C').GetValueAsUnsigned(), ord('e'),
             'foo_synth.C has wrong value (filter)')
 
         chosen = self.dbg.GetFilterForType(
             lldb.SBTypeNameSpecifier("JustAStruct"))
-        self.assertTrue(
-            chosen.count == 2,
+        self.assertEqual(
+            chosen.count, 2,
             "wrong filter found for JustAStruct")
-        self.assertTrue(
-            chosen.GetExpressionPathAtIndex(0) == 'C',
+        self.assertEqual(
+            chosen.GetExpressionPathAtIndex(0), 'C',
             "wrong item at index 0 for JustAStruct")
-        self.assertTrue(
-            chosen.GetExpressionPathAtIndex(1) == 'F',
+        self.assertEqual(
+            chosen.GetExpressionPathAtIndex(1), 'F',
             "wrong item at index 1 for JustAStruct")
 
         self.assertFalse(
@@ -420,8 +420,8 @@ class SBFormattersAPITestCase(TestBase):
         self.assertTrue(
             summary.IsValid(),
             "no summary found for foo* when one was in place")
-        self.assertTrue(
-            summary.GetData() == "hello static world",
+        self.assertEqual(
+            summary.GetData(), "hello static world",
             "wrong summary found for foo*")
 
         self.expect("frame variable e1", substrs=["I am an empty Empty1 {}"])
@@ -475,8 +475,8 @@ class SBFormattersAPITestCase(TestBase):
         int_vector = frame.FindVariable("int_vector")
         if self.TraceOn():
             print(int_vector)
-        self.assertTrue(
-            int_vector.GetNumChildren() == 0,
+        self.assertEqual(
+            int_vector.GetNumChildren(), 0,
             'synthetic vector is empty')
 
         self.runCmd('settings set target.enable-synthetic-value false')
@@ -495,6 +495,6 @@ class SBFormattersAPITestCase(TestBase):
         int_vector = frame.FindVariable("int_vector")
         if self.TraceOn():
             print(int_vector)
-        self.assertTrue(
-            int_vector.GetNumChildren() == 0,
+        self.assertEqual(
+            int_vector.GetNumChildren(), 0,
             'synthetic vector is still empty')

--- a/lldb/test/API/python_api/frame/TestFrames.py
+++ b/lldb/test/API/python_api/frame/TestFrames.py
@@ -88,8 +88,8 @@ class FrameAPITestCase(TestBase):
                 # instruction as PC.
                 if self.getArchitecture() in ['arm', 'armv7', 'armv7k']:
                     pc_value_int &= ~1
-                self.assertTrue(
-                    pc_value_int == frame.GetPC(),
+                self.assertEqual(
+                    pc_value_int, frame.GetPC(),
                     "PC gotten as a value should equal frame's GetPC")
                 sp_value = gpr_reg_set.GetChildMemberWithName("sp")
                 self.assertTrue(
@@ -102,8 +102,8 @@ class FrameAPITestCase(TestBase):
             process.Continue()
 
         # At this point, the inferior process should have exited.
-        self.assertTrue(
-            process.GetState() == lldb.eStateExited,
+        self.assertEqual(
+            process.GetState(), lldb.eStateExited,
             PROCESS_EXITED)
 
         # Expect to find 'a' on the call stacks two times.

--- a/lldb/test/API/python_api/lldbutil/iter/TestLLDBIterator.py
+++ b/lldb/test/API/python_api/lldbutil/iter/TestLLDBIterator.py
@@ -55,8 +55,8 @@ class LLDBIteratorTestCase(TestBase):
             if self.TraceOn():
                 print("yours[%d]='%s'" % (i, get_description(yours[i])))
                 print("mine[%d]='%s'" % (i, get_description(mine[i])))
-            self.assertTrue(
-                yours[i] == mine[i],
+            self.assertEqual(
+                yours[i], mine[i],
                 "UUID+FileSpec of yours[{0}] and mine[{0}] matches".format(i))
 
     @add_test_categories(['pyapi'])

--- a/lldb/test/API/python_api/objc_type/TestObjCType.py
+++ b/lldb/test/API/python_api/objc_type/TestObjCType.py
@@ -49,12 +49,12 @@ class ObjCSBTypeTestCase(TestBase):
         aBar = self.frame().FindVariable("aBar")
         aBarType = aBar.GetType()
         self.assertTrue(aBarType.IsValid(), "Bar should be a valid data type")
-        self.assertTrue(
-            aBarType.GetName() == "Bar *",
+        self.assertEqual(
+            aBarType.GetName(), "Bar *",
             "Bar has the right name")
 
-        self.assertTrue(
-            aBarType.GetNumberOfDirectBaseClasses() == 1,
+        self.assertEqual(
+            aBarType.GetNumberOfDirectBaseClasses(), 1,
             "Bar has a superclass")
         aFooType = aBarType.GetDirectBaseClassAtIndex(0)
 
@@ -64,6 +64,6 @@ class ObjCSBTypeTestCase(TestBase):
         self.assertEquals(aBarType.GetNumberOfFields(), 1, "Bar has a field")
         aBarField = aBarType.GetFieldAtIndex(0)
 
-        self.assertTrue(
-            aBarField.GetName() == "_iVar",
+        self.assertEqual(
+            aBarField.GetName(), "_iVar",
             "The field has the right name")

--- a/lldb/test/API/python_api/sbdata/TestSBData.py
+++ b/lldb/test/API/python_api/sbdata/TestSBData.py
@@ -430,20 +430,20 @@ class SBDataAPICase(TestBase):
         self.assert_data(data2.GetUnsignedInt64, 24, 4)
         self.assert_data(data2.GetUnsignedInt64, 32, 5)
 
-        self.assertTrue(
-            data2.uint64[0] == 1,
+        self.assertEqual(
+            data2.uint64[0], 1,
             'read_data_helper failure: set data2[0] = 1')
-        self.assertTrue(
-            data2.uint64[1] == 2,
+        self.assertEqual(
+            data2.uint64[1], 2,
             'read_data_helper failure: set data2[1] = 2')
-        self.assertTrue(
-            data2.uint64[2] == 3,
+        self.assertEqual(
+            data2.uint64[2], 3,
             'read_data_helper failure: set data2[2] = 3')
-        self.assertTrue(
-            data2.uint64[3] == 4,
+        self.assertEqual(
+            data2.uint64[3], 4,
             'read_data_helper failure: set data2[3] = 4')
-        self.assertTrue(
-            data2.uint64[4] == 5,
+        self.assertEqual(
+            data2.uint64[4], 5,
             'read_data_helper failure: set data2[4] = 5')
 
         self.assertTrue(
@@ -468,20 +468,20 @@ class SBDataAPICase(TestBase):
         self.assert_data(data2.GetUnsignedInt32, 12, 4)
         self.assert_data(data2.GetUnsignedInt32, 16, 5)
 
-        self.assertTrue(
-            data2.uint32[0] == 1,
+        self.assertEqual(
+            data2.uint32[0], 1,
             'read_data_helper failure: set 32-bit data2[0] = 1')
-        self.assertTrue(
-            data2.uint32[1] == 2,
+        self.assertEqual(
+            data2.uint32[1], 2,
             'read_data_helper failure: set 32-bit data2[1] = 2')
-        self.assertTrue(
-            data2.uint32[2] == 3,
+        self.assertEqual(
+            data2.uint32[2], 3,
             'read_data_helper failure: set 32-bit data2[2] = 3')
-        self.assertTrue(
-            data2.uint32[3] == 4,
+        self.assertEqual(
+            data2.uint32[3], 4,
             'read_data_helper failure: set 32-bit data2[3] = 4')
-        self.assertTrue(
-            data2.uint32[4] == 5,
+        self.assertEqual(
+            data2.uint32[4], 5,
             'read_data_helper failure: set 32-bit data2[4] = 5')
 
         data2.SetDataFromDoubleArray([3.14, 6.28, 2.71])

--- a/lldb/test/API/python_api/sbvalue_persist/TestSBValuePersist.py
+++ b/lldb/test/API/python_api/sbvalue_persist/TestSBValuePersist.py
@@ -57,11 +57,11 @@ class SBValuePersistTestCase(TestBase):
         self.assertTrue(barPersist.IsValid(), "barPersist is not valid")
         self.assertTrue(bazPersist.IsValid(), "bazPersist is not valid")
 
-        self.assertTrue(
-            fooPersist.GetValueAsUnsigned(0) == 10,
+        self.assertEqual(
+            fooPersist.GetValueAsUnsigned(0), 10,
             "fooPersist != 10")
-        self.assertTrue(
-            barPersist.GetPointeeData().sint32[0] == 4,
+        self.assertEqual(
+            barPersist.GetPointeeData().sint32[0], 4,
             "barPersist != 4")
         self.assertEquals(bazPersist.GetSummary(), '"85"', "bazPersist != 85")
 
@@ -71,11 +71,11 @@ class SBValuePersistTestCase(TestBase):
         self.assertTrue(barPersist.IsValid(), "barPersist is not valid")
         self.assertTrue(bazPersist.IsValid(), "bazPersist is not valid")
 
-        self.assertTrue(
-            fooPersist.GetValueAsUnsigned(0) == 10,
+        self.assertEqual(
+            fooPersist.GetValueAsUnsigned(0), 10,
             "fooPersist != 10")
-        self.assertTrue(
-            barPersist.GetPointeeData().sint32[0] == 4,
+        self.assertEqual(
+            barPersist.GetPointeeData().sint32[0], 4,
             "barPersist != 4")
         self.assertEquals(bazPersist.GetSummary(), '"85"', "bazPersist != 85")
 

--- a/lldb/test/API/python_api/signals/TestSignalsAPI.py
+++ b/lldb/test/API/python_api/signals/TestSignalsAPI.py
@@ -48,9 +48,9 @@ class SignalsAPITestCase(TestBase):
         unix_signals.SetShouldNotify(sigint, False)
 
         process.Continue()
-        self.assertTrue(
-            process.state == lldb.eStateExited,
+        self.assertEqual(
+            process.state, lldb.eStateExited,
             "The process should have exited")
-        self.assertTrue(
-            process.GetExitStatus() == 0,
+        self.assertEqual(
+            process.GetExitStatus(), 0,
             "The process should have returned 0")

--- a/lldb/test/API/python_api/target/TestTargetAPI.py
+++ b/lldb/test/API/python_api/target/TestTargetAPI.py
@@ -268,8 +268,8 @@ class TargetAPITestCase(TestBase):
                     value_list = m.FindGlobalVariables(
                         target, 'my_global_var_of_char_type', 3)
                     self.assertEqual(value_list.GetSize(), 1)
-                    self.assertTrue(
-                        value_list.GetValueAtIndex(0).GetValue() == "'X'")
+                    self.assertEqual(
+                        value_list.GetValueAtIndex(0).GetValue(), "'X'")
                     break
 
     def find_compile_units(self, exe):
@@ -283,8 +283,8 @@ class TargetAPITestCase(TestBase):
         list = target.FindCompileUnits(lldb.SBFileSpec(source_name, False))
         # Executable has been built just from one source file 'main.c',
         # so we may check only the first element of list.
-        self.assertTrue(
-            list[0].GetCompileUnit().GetFileSpec().GetFilename() == source_name)
+        self.assertEqual(
+            list[0].GetCompileUnit().GetFileSpec().GetFilename(), source_name)
 
     def find_functions(self, exe_name):
         """Exercise SBTaget.FindFunctions() API."""
@@ -302,8 +302,8 @@ class TargetAPITestCase(TestBase):
         self.assertEqual(list.GetSize(), 1)
 
         for sc in list:
-            self.assertTrue(
-                sc.GetModule().GetFileSpec().GetFilename() == exe_name)
+            self.assertEqual(
+                sc.GetModule().GetFileSpec().GetFilename(), exe_name)
             self.assertEqual(sc.GetSymbol().GetName(), 'c')
 
     def get_description(self):

--- a/lldb/test/API/python_api/thread/TestThreadAPI.py
+++ b/lldb/test/API/python_api/thread/TestThreadAPI.py
@@ -99,8 +99,7 @@ class ThreadAPITestCase(TestBase):
 
         proc_of_thread = thread.GetProcess()
         self.trace("proc_of_thread:", proc_of_thread)
-        self.assertTrue(proc_of_thread.GetProcessID()
-                        == process.GetProcessID())
+        self.assertEqual(proc_of_thread.GetProcessID(), process.GetProcessID())
 
     def get_stop_description(self):
         """Test Python SBThread.GetStopDescription() API."""
@@ -180,8 +179,8 @@ class ThreadAPITestCase(TestBase):
 
         thread.StepOut()
         self.runCmd("thread backtrace")
-        self.assertTrue(
-            thread.GetFrameAtIndex(0).GetLineEntry().GetLine() == self.step_out_of_malloc,
+        self.assertEqual(
+            thread.GetFrameAtIndex(0).GetLineEntry().GetLine(), self.step_out_of_malloc,
             "step out of malloc into function b is successful")
 
     def step_over_3_times(self, exe_name):

--- a/lldb/test/API/python_api/value/TestValueAPI.py
+++ b/lldb/test/API/python_api/value/TestValueAPI.py
@@ -176,11 +176,11 @@ class ValueAPITestCase(TestBase):
         ]:
             self.assertTrue(v)
 
-        self.assertTrue(
-            frame0.FindVariable('uinthex').GetValueAsUnsigned() == 3768803088,
+        self.assertEqual(
+            frame0.FindVariable('uinthex').GetValueAsUnsigned(), 3768803088,
             'unsigned uinthex == 3768803088')
-        self.assertTrue(
-            frame0.FindVariable('sinthex').GetValueAsUnsigned() == 3768803088,
+        self.assertEqual(
+            frame0.FindVariable('sinthex').GetValueAsUnsigned(), 3768803088,
             'unsigned sinthex == 3768803088')
 
         self.assertTrue(

--- a/lldb/test/API/python_api/value/change_values/TestChangeValueAPI.py
+++ b/lldb/test/API/python_api/value/change_values/TestChangeValueAPI.py
@@ -82,8 +82,8 @@ class ChangeValueAPITestCase(TestBase):
         self.assertTrue(result, "Setting val returned True.")
         actual_value = val_value.GetValueAsSigned(error, 0)
         self.assertTrue(error.Success(), "Got a changed value from val")
-        self.assertTrue(
-            actual_value == 12345,
+        self.assertEqual(
+            actual_value, 12345,
             "Got the right changed value from val")
 
         # Now check that we can set a structure element:
@@ -163,8 +163,8 @@ class ChangeValueAPITestCase(TestBase):
         self.assertTrue(result, "Setting sp returned true.")
         actual_value = sp_value.GetValueAsUnsigned(error, 0)
         self.assertTrue(error.Success(), "Got a changed value for sp")
-        self.assertTrue(
-            actual_value == 1,
+        self.assertEqual(
+            actual_value, 1,
             "Got the right changed value for sp.")
 
         # Boundary condition test the SBValue.CreateValueFromExpression() API.

--- a/lldb/test/API/python_api/watchpoint/TestSetWatchpoint.py
+++ b/lldb/test/API/python_api/watchpoint/TestSetWatchpoint.py
@@ -98,8 +98,8 @@ class SetWatchpointAPITestCase(TestBase):
         process.Continue()
 
         # At this point, the inferior process should have exited.
-        self.assertTrue(
-            process.GetState() == lldb.eStateExited,
+        self.assertEqual(
+            process.GetState(), lldb.eStateExited,
             PROCESS_EXITED)
 
         self.dbg.DeleteTarget(target)

--- a/lldb/test/API/python_api/watchpoint/TestWatchpointIter.py
+++ b/lldb/test/API/python_api/watchpoint/TestWatchpointIter.py
@@ -113,8 +113,8 @@ class WatchpointIteratorTestCase(TestBase):
         process.Continue()
 
         # At this point, the inferior process should have exited.
-        self.assertTrue(
-            process.GetState() == lldb.eStateExited,
+        self.assertEqual(
+            process.GetState(), lldb.eStateExited,
             PROCESS_EXITED)
 
         # Verify some vital statistics and exercise the iterator API.


### PR DESCRIPTION
Follow up to D95813, this converts multiline `assertTrue` to `assertEqual`.

Differential Revision: https://reviews.llvm.org/D95899

(cherry picked from commit 0ed758b26041ef4ec57e8511d289fb0b84468775)