### PR TITLE
[ASTReader] Always rebuild a cached module that has errors

### DIFF
--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -2743,9 +2743,15 @@ ASTReader::ReadControlBlock(ModuleFile &F,
       }
 
       bool hasErrors = Record[6];
-      if (hasErrors && !DisableValidation && !AllowASTWithCompilerErrors) {
-        Diag(diag::err_pch_with_compiler_errors);
-        return HadErrors;
+      if (hasErrors && !DisableValidation) {
+        // Always rebuild modules from the cache on an error
+        if (F.Kind == MK_ImplicitModule)
+          return OutOfDate;
+
+        if (!AllowASTWithCompilerErrors) {
+          Diag(diag::err_pch_with_compiler_errors);
+          return HadErrors;
+        }
       }
       if (hasErrors) {
         Diags.ErrorOccurred = true;

--- a/clang/test/Modules/Inputs/error.h
+++ b/clang/test/Modules/Inputs/error.h
@@ -1,8 +1,0 @@
-@import undefined
-
-@interface Error
-- (int)method;
-undefined
-@end
-
-undefined

--- a/clang/test/Modules/Inputs/error/error.h
+++ b/clang/test/Modules/Inputs/error/error.h
@@ -1,0 +1,9 @@
+@import undefined;
+
+@interface Error
+- (int)method;
+- (undefined)method2;
+undefined;
+@end
+
+undefined

--- a/clang/test/Modules/Inputs/error/module.modulemap
+++ b/clang/test/Modules/Inputs/error/module.modulemap
@@ -1,0 +1,3 @@
+module error {
+  header "error.h"
+}

--- a/clang/test/Modules/Inputs/module.map
+++ b/clang/test/Modules/Inputs/module.map
@@ -488,5 +488,3 @@ module objc_redef_indirect {
   header "objc_redef_indirect.h"
   export *
 }
-
-module error { header "error.h" }

--- a/clang/test/Modules/load-module-with-errors.m
+++ b/clang/test/Modules/load-module-with-errors.m
@@ -1,25 +1,68 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
+// RUN: mkdir %t/prebuilt
 
-// Write out a module with errors make sure it can be read
 // RUN: %clang_cc1 -fmodules -fallow-pcm-with-compiler-errors \
-// RUN:   -fmodules-cache-path=%t -x objective-c -emit-module \
-// RUN:   -fmodule-name=error %S/Inputs/module.map
-// RUN: %clang_cc1 -fmodules -fallow-pcm-with-compiler-errors \
-// RUN:   -fmodules-cache-path=%t -x objective-c -I %S/Inputs \
-// RUN:   -fimplicit-module-maps -ast-print %s | FileCheck %s
+// RUN:   -fmodule-name=error -o %t/prebuilt/error.pcm \
+// RUN:   -x objective-c -emit-module %S/Inputs/error/module.modulemap
+
+// RUN: %clang_cc1 -fsyntax-only -fmodules -fallow-pcm-with-compiler-errors \
+// RUN:   -fprebuilt-module-path=%t/prebuilt -fmodules-cache-path=%t \
+// RUN:   -ast-print %s | FileCheck %s
+// RUN: %clang_cc1 -fsyntax-only -fmodules \
+// RUN:   -fprebuilt-module-path=%t/prebuilt -fmodules-cache-path=%t \
+// RUN:   -verify=pcherror %s
+
+// RUN: %clang_cc1 -fsyntax-only -fmodules -fallow-pcm-with-compiler-errors \
+// RUN:   -fmodule-file=error=%t/prebuilt/error.pcm -fmodules-cache-path=%t \
+// RUN:   -ast-print %s | FileCheck %s
+// RUN: %clang_cc1 -fsyntax-only -fmodules \
+// RUN:   -fmodule-file=error=%t/prebuilt/error.pcm -fmodules-cache-path=%t \
+// RUN:   -verify=pcherror %s
+
+// RUN: %clang_cc1 -fsyntax-only -fmodules -fallow-pcm-with-compiler-errors \
+// RUN:   -fmodule-file=%t/prebuilt/error.pcm -fmodules-cache-path=%t \
+// RUN:   -ast-print %s | FileCheck %s
+// RUN: not %clang_cc1 -fsyntax-only -fmodules \
+// RUN:   -fmodule-file=%t/prebuilt/error.pcm -fmodules-cache-path=%t \
+// RUN:   -verify=pcherror %s
+
+// Shouldn't build the cached module (that has errors) when not allowing errors
+// RUN: not %clang_cc1 -fsyntax-only -fmodules \
+// RUN:   -fmodules-cache-path=%t -fimplicit-module-maps -I %S/Inputs/error \
+// RUN:   -x objective-c %s
+// RUN: find %t -name "error-*.pcm" | not grep error
+
+// Should build the cached module when allowing errors
+// RUN: %clang_cc1 -fsyntax-only -fmodules -fallow-pcm-with-compiler-errors \
+// RUN:   -fmodules-cache-path=%t -fimplicit-module-maps -I %S/Inputs/error \
+// RUN:   -x objective-c -verify %s
+// RUN: find %t -name "error-*.pcm" | grep error
+
+// Make sure there is still an error after the module is already in the cache
+// RUN: %clang_cc1 -fsyntax-only -fmodules -fallow-pcm-with-compiler-errors \
+// RUN:   -fmodules-cache-path=%t -fimplicit-module-maps -I %S/Inputs/error \
+// RUN:   -x objective-c -verify %s
+
+// Should rebuild the cached module if it had an error (if it wasn't rebuilt
+// the verify would fail as it would be the PCH error instead)
+// RUN: %clang_cc1 -fsyntax-only -fmodules \
+// RUN:   -fmodules-cache-path=%t -fimplicit-module-maps -I %S/Inputs/error \
+// RUN:   -x objective-c -verify %s
 
 // allow-pcm-with-compiler-errors should also allow errors in PCH
-// RUN: %clang_cc1 -fallow-pcm-with-compiler-errors -x c++ -emit-pch \
-// RUN:   -o %t/check.pch %S/Inputs/error.h
+// RUN: %clang_cc1 -fallow-pcm-with-compiler-errors -x objective-c \
+// RUN:   -o %t/check.pch -emit-pch %S/Inputs/error/error.h
 
-@import error;
+// pcherror-error@* {{PCH file contains compiler errors}}
+@import error; // expected-error {{could not build module 'error'}}
 
-void test(id x) {
+void test(Error *x) {
   [x method];
 }
 
 // CHECK: @interface Error
 // CHECK-NEXT: - (int)method;
+// CHECK-NEXT: - (id)method2;
 // CHECK-NEXT: @end
-// CHECK: void test(id x)
+// CHECK: void test(Error *x)


### PR DESCRIPTION
A module in the cache with an error should just be a cache miss. If
allowing errors (with -fallow-pcm-with-compiler-errors), a rebuild is
needed so that the appropriate diagnostics are output and in case search
paths have changed. If not allowing errors, the module was built
*allowing* errors and thus should be rebuilt regardless.

Reviewed By: akyrtzi

Differential Revision: https://reviews.llvm.org/D95989

Cherry-pick of a2c1054c303f20be006e9ef20739dbb88bd9ae02