### PR TITLE
Always emit variables from a Swift async context as entry values.

### DIFF
--- a/llvm/test/DebugInfo/MIR/X86/swift-async-entryvalues.mir
+++ b/llvm/test/DebugInfo/MIR/X86/swift-async-entryvalues.mir
@@ -1,0 +1,249 @@
+# RUN: llc -run-pass=livedebugvalues -verify-machineinstrs -march=x86-64 -o - %s | FileCheck %s
+#
+# CHECK: DBG_VALUE renamable $r14, 0, {{.*}}, !DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_deref, DW_OP_plus_uconst, 64, DW_OP_plus_uconst, 24, DW_OP_deref), debug-location
+#
+# RUN: llc -O0 -dwarf-version 5 -debugger-tune=lldb -filetype=obj \
+# RUN:   -start-before=livedebugvalues -o - %s \
+# RUN:     | llvm-dwarfdump --name=msg - | FileCheck %s -check-prefixes=CHECK-DWARF
+#
+# CHECK-DWARF:  DW_AT_location	(DW_OP_entry_value(DW_OP_reg14 R14), DW_OP_deref, DW_OP_plus_uconst 0x40, DW_OP_plus_uconst 0x18, DW_OP_deref)
+#
+# This was llvm-extracted from
+#   func use<T>(_ t: T) {}
+#   func forceSplit() async {}
+#   func withGenericArg<T>(_ msg: T) async {
+#     use(msg)
+#   }
+#   @main struct Main {
+#     static func main() async {
+#       await withGenericArg("hello (asynchronously)")
+#     }
+#   }
+
+--- |
+  ; ModuleID = '<stdin>'
+  source_filename = "/tmp/out.mir"
+  target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-apple-macosx11.0.0"
+  
+  %swift.opaque = type opaque
+  %swift.type = type { i64 }
+  %"$s1M14withGenericArgyyxYlF.Frame" = type { %swift.task*, %swift.executor*, %swift.context*, %swift.opaque*, %swift.type*, i8* }
+  %swift.task = type { %swift.refcounted, i8*, i8*, i64, i8*, %swift.context*, i64 }
+  %swift.refcounted = type { %swift.type*, i64 }
+  %swift.executor = type {}
+  %swift.context = type {}
+  %swift.error = type opaque
+  
+  declare hidden swiftcc void @"$s1M3useyyxlF"(%swift.opaque* noalias nocapture, %swift.type*) #0
+  
+  ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+  declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
+  
+  define hidden swiftcc void @"$s1M14withGenericArgyyxYlF.resume.0"(i8* %0, i8* %1, i8* swiftasync %2) !dbg !42 {
+    %4 = bitcast i8* %2 to i8**, !dbg !47
+    %5 = load i8*, i8** %4, align 8, !dbg !47
+    %6 = getelementptr inbounds i8, i8* %5, i32 64
+    %7 = bitcast i8* %6 to %"$s1M14withGenericArgyyxYlF.Frame"*
+    %8 = bitcast %"$s1M14withGenericArgyyxYlF.Frame"* %7 to i8*
+    %9 = getelementptr inbounds %"$s1M14withGenericArgyyxYlF.Frame", %"$s1M14withGenericArgyyxYlF.Frame"* %7, i32 0, i32 0
+    %10 = getelementptr inbounds %"$s1M14withGenericArgyyxYlF.Frame", %"$s1M14withGenericArgyyxYlF.Frame"* %7, i32 0, i32 1
+    %11 = getelementptr inbounds %"$s1M14withGenericArgyyxYlF.Frame", %"$s1M14withGenericArgyyxYlF.Frame"* %7, i32 0, i32 2
+    %12 = getelementptr inbounds %"$s1M14withGenericArgyyxYlF.Frame", %"$s1M14withGenericArgyyxYlF.Frame"* %7, i32 0, i32 5, !dbg !53
+    %13 = load i8*, i8** %12, align 8, !dbg !53
+    %14 = getelementptr inbounds %"$s1M14withGenericArgyyxYlF.Frame", %"$s1M14withGenericArgyyxYlF.Frame"* %7, i32 0, i32 4, !dbg !53
+    %15 = load %swift.type*, %swift.type** %14, align 8, !dbg !53
+    call void @llvm.dbg.declare(metadata i8* %2, metadata !54, metadata !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 64, DW_OP_plus_uconst, 32)), !dbg !58
+    %16 = getelementptr inbounds %"$s1M14withGenericArgyyxYlF.Frame", %"$s1M14withGenericArgyyxYlF.Frame"* %7, i32 0, i32 3, !dbg !53
+    %17 = load %swift.opaque*, %swift.opaque** %16, align 8, !dbg !53
+    call void @llvm.dbg.declare(metadata i8* %2, metadata !59, metadata !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 64, DW_OP_plus_uconst, 24, DW_OP_deref)), !dbg !61
+    %18 = bitcast i8* %0 to %swift.task*, !dbg !53
+    store %swift.task* %18, %swift.task** %9, align 8, !dbg !53
+    %19 = bitcast i8* %1 to %swift.executor*, !dbg !53
+    store %swift.executor* %19, %swift.executor** %10, align 8, !dbg !53
+    %20 = bitcast i8* %2 to i8**, !dbg !62
+    %21 = load i8*, i8** %20, align 8, !dbg !62
+    %22 = bitcast i8* %21 to %swift.context*, !dbg !53
+    store %swift.context* %22, %swift.context** %11, align 8, !dbg !53
+    %23 = load %swift.task*, %swift.task** %9, align 8, !dbg !53
+    call swiftcc void @swift_task_dealloc(%swift.task* %23, i8* %13) #4, !dbg !53
+    call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13), !dbg !53
+    call swiftcc void @"$s1M3useyyxlF"(%swift.opaque* noalias nocapture %17, %swift.type* %15), !dbg !64
+    %24 = load %swift.context*, %swift.context** %11, align 8, !dbg !65
+    %25 = bitcast %swift.context* %24 to <{ %swift.context*, void (%swift.task*, %swift.executor*, %swift.context*)*, %swift.executor*, i32, [4 x i8], %swift.error*, %swift.refcounted*, %swift.opaque*, [8 x i8] }>*, !dbg !65
+    %26 = load %swift.context*, %swift.context** %11, align 8, !dbg !65
+    %27 = bitcast %swift.context* %26 to <{ %swift.context*, void (%swift.task*, %swift.executor*, %swift.context*)*, %swift.executor*, i32, [4 x i8], %swift.error*, %swift.refcounted*, %swift.opaque*, [8 x i8] }>*, !dbg !65
+    %28 = getelementptr inbounds <{ %swift.context*, void (%swift.task*, %swift.executor*, %swift.context*)*, %swift.executor*, i32, [4 x i8], %swift.error*, %swift.refcounted*, %swift.opaque*, [8 x i8] }>, <{ %swift.context*, void (%swift.task*, %swift.executor*, %swift.context*)*, %swift.executor*, i32, [4 x i8], %swift.error*, %swift.refcounted*, %swift.opaque*, [8 x i8] }>* %27, i32 0, i32 1, !dbg !65
+    %29 = load void (%swift.task*, %swift.executor*, %swift.context*)*, void (%swift.task*, %swift.executor*, %swift.context*)** %28, align 8, !dbg !65
+    %30 = load %swift.task*, %swift.task** %9, align 8, !dbg !65
+    %31 = load %swift.executor*, %swift.executor** %10, align 8, !dbg !65
+    %32 = load %swift.context*, %swift.context** %11, align 8, !dbg !65
+    tail call swiftcc void %29(%swift.task* %30, %swift.executor* %31, %swift.context* swiftasync %32), !dbg !65
+    ret void, !dbg !65
+  }
+  
+  ; Function Attrs: argmemonly nounwind
+  declare extern_weak swiftcc void @swift_task_dealloc(%swift.task*, i8*) #2
+  
+  ; Function Attrs: argmemonly nofree nosync nounwind willreturn
+  declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #3
+  
+  attributes #0 = { "frame-pointer"="all" }
+  attributes #1 = { nofree nosync nounwind readnone speculatable willreturn }
+  attributes #2 = { argmemonly nounwind }
+  attributes #3 = { argmemonly nofree nosync nounwind willreturn }
+  attributes #4 = { nounwind }
+  
+  !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7, !8, !9, !10, !11, !12, !13}
+  !llvm.dbg.cu = !{!14}
+  !swift.module.flags = !{!26}
+  !llvm.linker.options = !{!38, !39, !40, !41}
+  
+  !0 = !{i32 2, !"SDK Version", [2 x i32] [i32 11, i32 3]}
+  !1 = !{i32 1, !"Objective-C Version", i32 2}
+  !2 = !{i32 1, !"Objective-C Image Info Version", i32 0}
+  !3 = !{i32 1, !"Objective-C Image Info Section", !"__DATA,__objc_imageinfo,regular,no_dead_strip"}
+  !4 = !{i32 1, !"Objective-C Garbage Collection", i8 0}
+  !5 = !{i32 1, !"Objective-C Class Properties", i32 64}
+  !6 = !{i32 7, !"Dwarf Version", i32 4}
+  !7 = !{i32 2, !"Debug Info Version", i32 3}
+  !8 = !{i32 1, !"wchar_size", i32 4}
+  !9 = !{i32 7, !"PIC Level", i32 2}
+  !10 = !{i32 1, !"Swift Version", i32 7}
+  !11 = !{i32 1, !"Swift ABI Version", i32 7}
+  !12 = !{i32 1, !"Swift Major Version", i8 5}
+  !13 = !{i32 1, !"Swift Minor Version", i8 4}
+  !14 = distinct !DICompileUnit(language: DW_LANG_Swift, file: !15, producer: "Swift version 5.4-dev effective-4.1.50 (LLVM b549c9ecb63c552, Swift 691ead342f707b9)", isOptimized: false, runtimeVersion: 5, emissionKind: FullDebug, enums: !16, imports: !17, sysroot: "/", sdk: "MacOSX.sdk")
+  !15 = !DIFile(filename: "/Volumes/Data/swift/swift/test/DebugInfo/async-args.swift", directory: "/Volumes/Data/swift/llvm-project")
+  !16 = !{}
+  !17 = !{!18, !20, !22, !24}
+  !18 = !DIImportedEntity(tag: DW_TAG_imported_module, scope: !15, entity: !19, file: !15)
+  !19 = !DIModule(scope: null, name: "M", includePath: "/Volumes/Data/swift/swift/test/DebugInfo")
+  !20 = !DIImportedEntity(tag: DW_TAG_imported_module, scope: !15, entity: !21, file: !15)
+  !21 = !DIModule(scope: null, name: "Swift", includePath: "")
+  !22 = !DIImportedEntity(tag: DW_TAG_imported_module, scope: !15, entity: !23, file: !15)
+  !23 = !DIModule(scope: null, name: "_Concurrency", includePath: "")
+  !24 = !DIImportedEntity(tag: DW_TAG_imported_module, scope: !15, entity: !25, file: !15)
+  !25 = !DIModule(scope: null, name: "SwiftOnoneSupport", includePath: "")
+  !26 = !{!"standard-library", i1 false}
+  !38 = !{!"-lswiftSwiftOnoneSupport"}
+  !39 = !{!"-lswiftCore"}
+  !40 = !{!"-lswift_Concurrency"}
+  !41 = !{!"-lobjc"}
+  !42 = distinct !DISubprogram(name: "withGenericArg", linkageName: "$s1M14withGenericArgyyxYlF", scope: !19, file: !15, line: 9, type: !43, scopeLine: 9, spFlags: DISPFlagDefinition, unit: !14, retainedNodes: !16)
+  !43 = !DISubroutineType(types: !44)
+  !44 = !{!45, !46}
+  !45 = !DICompositeType(tag: DW_TAG_structure_type, name: "$sytD", file: !15, elements: !16, runtimeLang: DW_LANG_Swift, identifier: "$sytD")
+  !46 = !DICompositeType(tag: DW_TAG_structure_type, name: "$sxD", file: !15, runtimeLang: DW_LANG_Swift, identifier: "$sxD")
+  !47 = !DILocation(line: 0, scope: !48, inlinedAt: !51)
+  !48 = distinct !DISubprogram(linkageName: "__swift_async_resume_project_context", scope: !19, file: !49, type: !50, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !14, retainedNodes: !16)
+  !49 = !DIFile(filename: "<compiler-generated>", directory: "")
+  !50 = !DISubroutineType(types: null)
+  !51 = distinct !DILocation(line: 21, column: 9, scope: !52)
+  !52 = distinct !DILexicalBlock(scope: !42, file: !15, line: 9, column: 40)
+  !53 = !DILocation(line: 21, column: 9, scope: !52)
+  !54 = !DILocalVariable(name: "$\CF\84_0_0", scope: !42, file: !15, type: !55, flags: DIFlagArtificial)
+  !55 = !DIDerivedType(tag: DW_TAG_typedef, name: "T", scope: !56, file: !49, baseType: !57)
+  !56 = !DIModule(scope: null, name: "Builtin")
+  !57 = !DIDerivedType(tag: DW_TAG_pointer_type, name: "$sBpD", baseType: null, size: 64)
+  !58 = !DILocation(line: 0, scope: !42)
+  !59 = !DILocalVariable(name: "msg", arg: 1, scope: !42, file: !15, line: 9, type: !60)
+  !60 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !46)
+  !61 = !DILocation(line: 9, column: 24, scope: !42)
+  !62 = !DILocation(line: 0, scope: !48, inlinedAt: !63)
+  !63 = distinct !DILocation(line: 21, column: 9, scope: !52)
+  !64 = !DILocation(line: 33, column: 3, scope: !52)
+  !65 = !DILocation(line: 34, column: 1, scope: !52)
+
+...
+---
+name:            '$s1M14withGenericArgyyxYlF.resume.0'
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+registers:       []
+liveins:
+  - { reg: '$rdi', virtual-reg: '' }
+  - { reg: '$rsi', virtual-reg: '' }
+  - { reg: '$r14', virtual-reg: '' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       40
+  offsetAdjustment: -40
+  maxAlignment:    8
+  adjustsStack:    true
+  hasCalls:        true
+  stackProtector:  ''
+  maxCallFrameSize: 0
+  cvBytesOfCalleeSavedRegisters: 8
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:
+  - { id: 0, type: spill-slot, offset: -16, size: 8, alignment: 16, stack-id: default, 
+      callee-saved-register: '$r14', callee-saved-restored: true, debug-info-variable: '', 
+      debug-info-expression: '', debug-info-location: '' }
+stack:
+  - { id: 0, name: '', type: spill-slot, offset: -24, size: 8, alignment: 8, 
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true, 
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+  - { id: 1, name: '', type: spill-slot, offset: -32, size: 8, alignment: 8, 
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true, 
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+  - { id: 2, name: '', type: spill-slot, offset: -40, size: 8, alignment: 8, 
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true, 
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo: {}
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $rdi, $rsi, $r14
+  
+    DBG_VALUE renamable $r14, 0, !59, !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 64, DW_OP_plus_uconst, 24, DW_OP_deref), debug-location !61
+    frame-setup PUSH64r $r14, implicit-def $rsp, implicit $rsp
+    CFI_INSTRUCTION def_cfa_offset 16
+    $rsp = frame-setup SUB64ri8 $rsp, 32, implicit-def dead $eflags
+    CFI_INSTRUCTION def_cfa_offset 48
+    CFI_INSTRUCTION offset $r14, -16
+    DBG_VALUE renamable $r14, 0, !54, !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 64, DW_OP_plus_uconst, 32), debug-location !58
+    $rcx = MOV64rr killed $rsi
+    renamable $rax = MOV64rm renamable $r14, 1, $noreg, 0, $noreg, debug-location !47 :: (load 8 from %ir.4)
+    MOV64mr $rsp, 1, $noreg, 24, $noreg, $rax :: (store 8 into %stack.0)
+    renamable $rsi = MOV64rm renamable $rax, 1, $noreg, 104, $noreg, debug-location !53 :: (load 8 from %ir.12)
+    renamable $rdx = MOV64rm renamable $rax, 1, $noreg, 88, $noreg, debug-location !53 :: (load 8 from %ir.16)
+    MOV64mr $rsp, 1, $noreg, 8, $noreg, $rdx :: (store 8 into %stack.2)
+    renamable $rdx = MOV64rm renamable $rax, 1, $noreg, 96, $noreg, debug-location !53 :: (load 8 from %ir.14)
+    MOV64mr $rsp, 1, $noreg, 16, $noreg, $rdx :: (store 8 into %stack.1)
+    MOV64mr renamable $rax, 1, $noreg, 64, $noreg, killed renamable $rdi, debug-location !53 :: (store 8 into %ir.9)
+    MOV64mr renamable $rax, 1, $noreg, 72, $noreg, killed renamable $rcx, debug-location !53 :: (store 8 into %ir.10)
+    renamable $rcx = MOV64rm killed renamable $r14, 1, $noreg, 0, $noreg, debug-location !62 :: (load 8 from %ir.20)
+    MOV64mr renamable $rax, 1, $noreg, 80, $noreg, killed renamable $rcx, debug-location !53 :: (store 8 into %ir.11)
+    renamable $rdi = MOV64rm renamable $rax, 1, $noreg, 64, $noreg, debug-location !53 :: (load 8 from %ir.9)
+    CALL64pcrel32 @swift_task_dealloc, csr_64, implicit $rsp, implicit $ssp, implicit killed $rdi, implicit killed $rsi, implicit-def $rsp, implicit-def $ssp, debug-location !53
+    $rdi = MOV64rm $rsp, 1, $noreg, 8, $noreg :: (load 8 from %stack.2)
+    $rsi = MOV64rm $rsp, 1, $noreg, 16, $noreg :: (load 8 from %stack.1)
+    CALL64pcrel32 @"$s1M3useyyxlF", csr_64, implicit $rsp, implicit $ssp, implicit killed $rdi, implicit killed $rsi, implicit-def $rsp, implicit-def $ssp, debug-location !64
+    $rcx = MOV64rm $rsp, 1, $noreg, 24, $noreg :: (load 8 from %stack.0)
+    renamable $r14 = MOV64rm renamable $rcx, 1, $noreg, 80, $noreg, debug-location !65 :: (load 8 from %ir.11)
+    renamable $rax = MOV64rm renamable $r14, 1, $noreg, 8, $noreg, debug-location !65 :: (load 8 from %ir.28)
+    renamable $rdi = MOV64rm renamable $rcx, 1, $noreg, 64, $noreg, debug-location !65 :: (load 8 from %ir.9)
+    renamable $rsi = MOV64rm killed renamable $rcx, 1, $noreg, 72, $noreg, debug-location !65 :: (load 8 from %ir.10)
+    CALL64r killed renamable $rax, csr_64, implicit $rsp, implicit $ssp, implicit killed $rdi, implicit killed $rsi, implicit killed $r14, implicit-def $rsp, implicit-def $ssp, debug-location !65
+    $rsp = frame-destroy ADD64ri8 $rsp, 32, implicit-def dead $eflags, debug-location !65
+    $r14 = frame-destroy POP64r implicit-def $rsp, implicit $rsp, debug-location !65
+    RETQ debug-location !65
+
+...


### PR DESCRIPTION
Unfortunately the swiftasync attribute is not yet on LLVM.org.

rdar://70397854