### PR TITLE
[lldb] Ignore utf-8 decode errors

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -517,8 +517,8 @@ def system(commands, **kwargs):
                 "command": shellCommand
             }
             raise cpe
-        output = output + this_output.decode("utf-8")
-        error = error + this_error.decode("utf-8")
+        output = output + this_output.decode("utf-8", "ignore")
+        error = error + this_error.decode("utf-8", "ignore")
     return (output, error)
 
 


### PR DESCRIPTION
This code has already been rewritten upstream, so this only applies to
5.4.