### PR TITLE
[lldb] Fix loose handling of swift type metadata

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1334,8 +1334,10 @@ llvm::Optional<size_t> SwiftLanguageRuntimeImpl::GetIndexOfChildMemberWithName(
       // superclass, and ends on null.
       auto *current_tr = tr;
       while (current_tr) {
-        auto *record_ti = llvm::cast<RecordTypeInfo>(
-            tc.getClassInstanceTypeInfo(tr, 0, &tip));
+        auto *record_ti = llvm::dyn_cast_or_null<RecordTypeInfo>(
+            tc.getClassInstanceTypeInfo(current_tr, 0, &tip));
+        if (!record_ti)
+          break;
         auto *super_tr = builder.lookupSuperclass(current_tr);
         uint32_t offset = super_tr ? 1 : 0;
         if (auto size = findFieldWithName(record_ti->getFields(), name,


### PR DESCRIPTION
This fixes two bugs.

First, use `dyn_cast_or_null` in case `getClassInstanceTypeInfo` returns null. It's not clear to me when it would be null, but we have fallback sources of metadata.

Second, as I was looking into the crash, I noticed that `getClassInstanceTypeInfo` was being called with the same `TypeRef` on every iteration. This change uses the loop variable `current_tr` instead. Without this, the `TypeInfo` would be always be for the instance's class, not any of its superclasses.

rdar://74078912