### PR TITLE
Remove uneeded CopyType from BlockPointerSyntheticFrontEnd 

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
@@ -74,14 +74,12 @@ public:
     const CompilerType reserved_type =
         clang_ast_context->GetBasicType(lldb::eBasicTypeInt);
     const char *const FuncPtr_name("__FuncPtr");
-    const CompilerType FuncPtr_type =
-        clang_ast_importer->CopyType(*clang_ast_context, function_pointer_type);
 
     m_block_struct_type = clang_ast_context->CreateStructForIdentifier(
         ConstString(), {{isa_name, isa_type},
                         {flags_name, flags_type},
                         {reserved_name, reserved_type},
-                        {FuncPtr_name, FuncPtr_type}});
+                        {FuncPtr_name, function_pointer_type}});
   }
 
   ~BlockPointerSyntheticFrontEnd() override = default;

--- a/lldb/test/API/lang/c/blocks/TestBlocks.py
+++ b/lldb/test/API/lang/c/blocks/TestBlocks.py
@@ -20,6 +20,7 @@ class BlocksTestCase(TestBase):
         # Find the line numbers to break at.
         self.lines.append(line_number('main.c', '// Set breakpoint 0 here.'))
         self.lines.append(line_number('main.c', '// Set breakpoint 1 here.'))
+        self.lines.append(line_number('main.c', '// Set breakpoint 2 here.'))
 
     def launch_common(self):
         self.build()
@@ -50,6 +51,10 @@ class BlocksTestCase(TestBase):
         # This should display correctly.
         self.expect("expression (int)neg (-12)", VARIABLES_DISPLAYED_CORRECTLY,
                     substrs=["= 12"])
+
+        self.wait_for_breakpoint()
+
+        self.expect_expr("h(cg)", result_type="int", result_value="42")
 
     @skipUnlessDarwin
     def test_define(self):

--- a/lldb/test/API/lang/c/blocks/main.c
+++ b/lldb/test/API/lang/c/blocks/main.c
@@ -1,5 +1,17 @@
 #include <stdio.h>
 
+struct CG {int x; int y;};
+
+int g(int (^callback)(struct CG)) {
+   struct CG cg = {.x=1,.y=2};
+
+   int z = callback(cg); // Set breakpoint 2 here.
+
+   return z;
+}
+
+int h(struct CG cg){return 42;}
+
 int main()
 {
     int c = 1;
@@ -16,6 +28,13 @@ int main()
 
     printf("%d\n", add(3, 4));
     printf("%d\n", neg(-5)); // Set breakpoint 1 here.
+
+    int (^add_struct)(struct CG) = ^int(struct CG cg)
+    {
+        return cg.x + cg.y;
+    };
+
+    g(add_struct);
 
     return 0;
 }


### PR DESCRIPTION
BlockPointerSyntheticFrontEnd does a CopyType which results in it copying the type back into its own context. This will result in a call to ASTImporterDelegate::setOrigin with &decl->getASTContext() == origin.ctx this can result in an infinite recursion later on in ASTImporter since it will attempt to find the decl in its origin which will be itself.

This fixes: rdar://problem/73618836