### PR TITLE
Add missing nullptr check.

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -2167,6 +2167,8 @@ void coro::salvageDebugInfo(
     } else if (auto *GEPInst = dyn_cast<GetElementPtrInst>(Storage)) {
       Expr = llvm::salvageDebugInfoImpl(*GEPInst, Expr,
                                         /*WithStackValue=*/false);
+      if (!Expr)
+        return;
       Storage = GEPInst->getOperand(0);
     } else if (auto *BCInst = dyn_cast<llvm::BitCastInst>(Storage))
       Storage = BCInst->getOperand(0);

--- a/llvm/test/Transforms/Coroutines/coro-debug.ll
+++ b/llvm/test/Transforms/Coroutines/coro-debug.ll
@@ -13,6 +13,7 @@ entry:
   %coro_hdl = alloca i8*, align 8
   store i32 %x, i32* %x.addr, align 4
   %0 = call token @llvm.coro.id(i32 0, i8* null, i8* bitcast (i8* (i32)* @f to i8*), i8* null), !dbg !16
+  %undef = bitcast i8* undef to [16 x i8]*
   %1 = call i64 @llvm.coro.size.i64(), !dbg !16
   %call = call i8* @malloc(i64 %1), !dbg !16
   %2 = call i8* @llvm.coro.begin(token %0, i8* %call) #7, !dbg !16
@@ -27,6 +28,8 @@ entry:
 
 sw.bb:                                            ; preds = %entry
   %direct = load i32, i32* %x.addr, align 4, !dbg !14
+  %gep = getelementptr inbounds [16 x i8], [16 x i8]* %undef, i32 %direct, !dbg !14
+  call void @llvm.dbg.declare(metadata [16 x i8] *%gep, metadata !27, metadata !13), !dbg !14
   call void @llvm.dbg.declare(metadata i32 %conv, metadata !26, metadata !13), !dbg !14
   call void @llvm.dbg.declare(metadata i32 %direct, metadata !25, metadata !13), !dbg !14
   call void @llvm.dbg.declare(metadata i32* %x.addr, metadata !12, metadata !13), !dbg !14
@@ -132,6 +135,7 @@ attributes #7 = { noduplicate }
 ; These variables were added manually.
 !25 = !DILocalVariable(name: "direct_mem", scope: !6, file: !7, line: 55, type: !11)
 !26 = !DILocalVariable(name: "direct_const", scope: !6, file: !7, line: 55, type: !11)
+!27 = !DILocalVariable(name: "undefined", scope: !6, file: !7, line: 55, type: !11)
 
 ; CHECK: define i8* @f(i32 %x) #0 !dbg ![[ORIG:[0-9]+]]
 ; CHECK: define internal fastcc void @f.resume(%f.Frame* noalias nonnull align 8 dereferenceable(32) %FramePtr) #0 !dbg ![[RESUME:[0-9]+]]


### PR DESCRIPTION
salvageDebugInfoImpl() may fail and return a nullptr.

(cherry picked from commit 19fc8eede484ce50fa0341addeed55af12440dad)