### PR TITLE
[lldb] Fix crash in FormatEntity for mangled-name

### DIFF
--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -1769,7 +1769,7 @@ bool FormatEntity::Format(const Entry &entry, Stream &s,
       return false;
     s.PutCString(name);
 
-    if (sc->block->GetContainingInlinedBlock()) {
+    if (sc->block && sc->block->GetContainingInlinedBlock()) {
       if (const InlineFunctionInfo *inline_info =
               sc->block->GetInlinedFunctionInfo()) {
         s.PutCString(" [inlined] ");


### PR DESCRIPTION
Check a `Block` pointer before dereferencing.

Using `function.mangled-name` led to a crash for a frame where the symbol
context had no block info. In my case, the frame's function was a system frame.

Differential Revision: https://reviews.llvm.org/D96307

(cherry picked from commit 7dc324aafa2b17a4f9a992b9727a3642505053a6)