### PR TITLE
[lldb] Add step target to ThreadPlanStepInRange constructor

### DIFF
--- a/lldb/include/lldb/Target/ThreadPlanStepInRange.h
+++ b/lldb/include/lldb/Target/ThreadPlanStepInRange.h
@@ -22,7 +22,7 @@ class ThreadPlanStepInRange : public ThreadPlanStepRange,
 public:
   ThreadPlanStepInRange(Thread &thread, const AddressRange &range,
                         const SymbolContext &addr_context,
-                        lldb::RunMode stop_others,
+                        const char *step_into_target, lldb::RunMode stop_others,
                         LazyBool step_in_avoids_code_without_debug_info,
                         LazyBool step_out_avoids_code_without_debug_info);
 
@@ -40,10 +40,6 @@ public:
   bool ShouldStop(Event *event_ptr) override;
 
   void SetAvoidRegexp(const char *name);
-
-  void SetStepInTarget(const char *target) {
-    m_step_into_target.SetCString(target);
-  }
 
   static void SetDefaultFlagValue(uint32_t new_value);
 

--- a/lldb/include/lldb/Target/ThreadPlanStepInRange.h
+++ b/lldb/include/lldb/Target/ThreadPlanStepInRange.h
@@ -26,13 +26,6 @@ public:
                         LazyBool step_in_avoids_code_without_debug_info,
                         LazyBool step_out_avoids_code_without_debug_info);
 
-  ThreadPlanStepInRange(Thread &thread, const AddressRange &range,
-                        const SymbolContext &addr_context,
-                        const char *step_into_function_name,
-                        lldb::RunMode stop_others,
-                        LazyBool step_in_avoids_code_without_debug_info,
-                        LazyBool step_out_avoids_code_without_debug_info);
-
   ~ThreadPlanStepInRange() override;
 
   void GetDescription(Stream *s, lldb::DescriptionLevel level) override;

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
@@ -397,8 +397,8 @@ CPPLanguageRuntime::GetStepThroughTrampolinePlan(Thread &thread,
       // We create a ThreadPlan to keep stepping through using the address range
       // of the current function.
       ret_plan_sp = std::make_shared<ThreadPlanStepInRange>(
-          thread, range_of_curr_func, sc, eOnlyThisThread, eLazyBoolYes,
-          eLazyBoolYes);
+          thread, range_of_curr_func, sc, nullptr, eOnlyThisThread,
+          eLazyBoolYes, eLazyBoolYes);
       return ret_plan_sp;
     }
   }

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -1310,16 +1310,10 @@ ThreadPlanSP Thread::QueueThreadPlanForStepInRange(
     lldb::RunMode stop_other_threads, Status &status,
     LazyBool step_in_avoids_code_without_debug_info,
     LazyBool step_out_avoids_code_without_debug_info) {
-  ThreadPlanSP thread_plan_sp(
-      new ThreadPlanStepInRange(*this, range, addr_context, stop_other_threads,
-                                step_in_avoids_code_without_debug_info,
-                                step_out_avoids_code_without_debug_info));
-  ThreadPlanStepInRange *plan =
-      static_cast<ThreadPlanStepInRange *>(thread_plan_sp.get());
-
-  if (step_in_target)
-    plan->SetStepInTarget(step_in_target);
-
+  ThreadPlanSP thread_plan_sp(new ThreadPlanStepInRange(
+      *this, range, addr_context, step_in_target, stop_other_threads,
+      step_in_avoids_code_without_debug_info,
+      step_out_avoids_code_without_debug_info));
   status = QueueThreadPlan(thread_plan_sp, abort_other_plans);
   return thread_plan_sp;
 }

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -1324,16 +1324,13 @@ ThreadPlanSP Thread::QueueThreadPlanForStepInRangeNoShouldStop(
     lldb::RunMode stop_other_threads, Status &status,
     LazyBool step_in_avoids_code_without_debug_info,
     LazyBool step_out_avoids_code_without_debug_info) {
-  ThreadPlanSP thread_plan_sp(
-      new ThreadPlanStepInRange(*this, range, addr_context, stop_other_threads,
-                                step_in_avoids_code_without_debug_info,
-                                step_out_avoids_code_without_debug_info));
+  ThreadPlanSP thread_plan_sp(new ThreadPlanStepInRange(
+      *this, range, addr_context, step_in_target, stop_other_threads,
+      step_in_avoids_code_without_debug_info,
+      step_out_avoids_code_without_debug_info));
+
   ThreadPlanStepInRange *plan =
       static_cast<ThreadPlanStepInRange *>(thread_plan_sp.get());
-
-  if (step_in_target)
-    plan->SetStepInTarget(step_in_target);
-
   plan->ClearShouldStopHereCallbacks();
 
   status = QueueThreadPlan(thread_plan_sp, abort_other_plans);

--- a/lldb/source/Target/ThreadPlanStepInRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepInRange.cpp
@@ -49,22 +49,6 @@ ThreadPlanStepInRange::ThreadPlanStepInRange(
                     step_out_avoids_code_without_debug_info);
 }
 
-ThreadPlanStepInRange::ThreadPlanStepInRange(
-    Thread &thread, const AddressRange &range,
-    const SymbolContext &addr_context, const char *step_into_target,
-    lldb::RunMode stop_others, LazyBool step_in_avoids_code_without_debug_info,
-    LazyBool step_out_avoids_code_without_debug_info)
-    : ThreadPlanStepRange(ThreadPlan::eKindStepInRange,
-                          "Step Range stepping in", thread, range, addr_context,
-                          stop_others),
-      ThreadPlanShouldStopHere(this), m_step_past_prologue(true),
-      m_virtual_step(false), m_step_into_target(step_into_target) {
-  SetCallbacks();
-  SetFlagsToDefault();
-  SetupAvoidNoDebug(step_in_avoids_code_without_debug_info,
-                    step_out_avoids_code_without_debug_info);
-}
-
 ThreadPlanStepInRange::~ThreadPlanStepInRange() {
   ClearStepInDeepBreakpoints();
 }

--- a/lldb/source/Target/ThreadPlanStepInRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepInRange.cpp
@@ -35,14 +35,14 @@ uint32_t ThreadPlanStepInRange::s_default_flag_values =
 
 ThreadPlanStepInRange::ThreadPlanStepInRange(
     Thread &thread, const AddressRange &range,
-    const SymbolContext &addr_context, lldb::RunMode stop_others,
-    LazyBool step_in_avoids_code_without_debug_info,
+    const SymbolContext &addr_context, const char *step_into_target,
+    lldb::RunMode stop_others, LazyBool step_in_avoids_code_without_debug_info,
     LazyBool step_out_avoids_code_without_debug_info)
     : ThreadPlanStepRange(ThreadPlan::eKindStepInRange,
                           "Step Range stepping in", thread, range, addr_context,
                           stop_others),
       ThreadPlanShouldStopHere(this), m_step_past_prologue(true),
-      m_virtual_step(false) {
+      m_virtual_step(false), m_step_into_target(step_into_target) {
   SetCallbacks();
   SetFlagsToDefault();
   SetupAvoidNoDebug(step_in_avoids_code_without_debug_info,


### PR DESCRIPTION
`QueueThreadPlanForStepInRange` accepts a `step_into_target`, but the constructor for
`ThreadPlanStepInRange` does not. Instead, a caller would optionally call
`SetStepInTarget()` in a separate statement.

This change adds `step_into_target` as a constructor argument. This simplifies
construction of `ThreadPlanSP`, by avoiding a subsequent downcast and conditional
assignment. This constructor is already used in downstream repos.

Differential Revision: https://reviews.llvm.org/D96539

(cherry picked from commit a5ab1dc4ad2c02510e363b4dd3c267f9eaf11516)