### PR TITLE
[Index] Add new option to specify the output file to use in the index store unit file rather than using -o

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -591,6 +591,8 @@ def index_ignore_system_symbols : Flag<["-"], "index-ignore-system-symbols">, Fl
   HelpText<"Ignore symbols from system headers">;
 def index_record_codegen_name : Flag<["-"], "index-record-codegen-name">, Flags<[CC1Option]>,
   HelpText<"Record the codegen name for symbols">;
+def index_unit_output_path : Separate<["-"], "index-unit-output-path">, MetaVarName<"<path>">, Flags<[CC1Option]>,
+  HelpText<"Use <path> as the output path for this compilation unit in the index unit file">;
 
 // Make sure all other -ccc- options are rejected.
 def ccc_ : Joined<["-"], "ccc-">, Group<internal_Group>, Flags<[Unsupported]>;

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -378,6 +378,7 @@ public:
   std::string ARCMTMigrateReportOut;
 
   std::string IndexStorePath;
+  std::string IndexUnitOutputPath;
 
   /// The input kind, either specified via -x argument or deduced from the input
   /// file name.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5162,6 +5162,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     Args.AddLastArg(CmdArgs, options::OPT_index_store_path);
     Args.AddLastArg(CmdArgs, options::OPT_index_ignore_system_symbols);
     Args.AddLastArg(CmdArgs, options::OPT_index_record_codegen_name);
+    Args.AddLastArg(CmdArgs, options::OPT_index_unit_output_path);
 
     // If '-o' is passed along with '-fsyntax-only' pass it along the cc1
     // invocation so that the index action knows what the out file is.

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2878,6 +2878,7 @@ static bool ParseFrontendArgsImpl(FrontendOptions &Opts, ArgList &Args,
   }
 
   Opts.IndexStorePath = std::string(Args.getLastArgValue(OPT_index_store_path));
+  Opts.IndexUnitOutputPath = std::string(Args.getLastArgValue(OPT_index_unit_output_path));
   Opts.IndexIgnoreSystemSymbols = Args.hasArg(OPT_index_ignore_system_symbols);
   Opts.IndexRecordCodegenName = Args.hasArg(OPT_index_record_codegen_name);
 

--- a/clang/lib/Index/IndexingAction.cpp
+++ b/clang/lib/Index/IndexingAction.cpp
@@ -639,7 +639,9 @@ void IndexRecordActionBase::finish(CompilerInstance &CI) {
     return;
   }
 
-  std::string OutputFile = CI.getFrontendOpts().OutputFile;
+  std::string OutputFile = CI.getFrontendOpts().IndexUnitOutputPath;
+  if (OutputFile.empty())
+    OutputFile = CI.getFrontendOpts().OutputFile;
   if (OutputFile.empty()) {
     OutputFile = std::string(CI.getFrontendOpts().Inputs[0].getFile());
     OutputFile += ".o";

--- a/clang/test/Index/Store/relative-out-path.c
+++ b/clang/test/Index/Store/relative-out-path.c
@@ -16,4 +16,20 @@
 // CHECK:      outfile.o[[OUT_HASH:.*$]]
 // CHECK-NEXT: outfile.o[[OUT_HASH]]
 
+// Repeat with custom unit output path:
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %clang %s -index-store-path %t/idx1 -c -o %t/outfile1.o -index-unit-output-path %t/custom.o
+// RUN: cd %t
+// RUN: %clang %s -index-store-path %t/idx2 -c -o outfile2.o -index-unit-output-path custom.o
+// RUN: cd ..
+// RUN: %clang %s -index-store-path %t/idx3 -fsyntax-only -o outfile3.o -working-directory=%t -index-unit-output-path custom.o
+// RUN: diff -r -u %t/idx2 %t/idx3
+
+// RUN: find %t/idx1 -name '*custom.o*' > %t/hashes.txt
+// RUN: find %t/idx3 -name '*custom.o*' >> %t/hashes.txt
+// RUN: FileCheck %s --input-file=%t/hashes.txt --check-prefix=CUSTOM
+// CUSTOM:      custom.o[[OUT_HASH:.*$]]
+// CUSTOM-NEXT: custom.o[[OUT_HASH]]
+
 void foo();

--- a/clang/test/Index/Store/unit-with-explicit-output-path.c
+++ b/clang/test/Index/Store/unit-with-explicit-output-path.c
@@ -1,0 +1,46 @@
+#include "print-unit.h"
+#include "syshead.h"
+
+void foo(int i);
+
+// RUN: rm -rf %t
+// RUN: %clang_cc1 -I %S/Inputs -isystem %S/Inputs/sys -index-store-path %t/idx %s -triple x86_64-apple-macosx10.8
+// RUN: c-index-test core -print-unit %t/idx | FileCheck --check-prefixes=DEFAULT,ALL %s
+// RUN: %clang_cc1 -I %S/Inputs -isystem %S/Inputs/sys -index-store-path %t/idx_opt1 %s -triple x86_64-apple-macosx10.8 -o %t/unit-with-explicit-output-path.o
+// RUN: c-index-test core -print-unit %t/idx_opt1 | FileCheck %s -check-prefixes=OUT,ALL
+// RUN: %clang_cc1 -I %S/Inputs -isystem %S/Inputs/sys -index-store-path %t/idx_opt2 %s -triple x86_64-apple-macosx10.8 -index-unit-output-path custom-unit.o
+// RUN: c-index-test core -print-unit %t/idx_opt2 | FileCheck %s -check-prefixes=UNITOUT,ALL
+
+// DEFAULT: unit-with-explicit-output-path.c.o
+// OUT: unit-with-explicit-output-path.o
+// UNITOUT: custom-unit.o
+// ALL: provider: clang-
+// ALL: is-system: 0
+// ALL: has-main: 1
+// ALL: main-path: {{.*}}{{/|\\}}unit-with-explicit-output-path.c
+// DEFAULT: out-file: {{.*}}{{/|\\}}unit-with-explicit-output-path.c.o
+// OUT: out-file: {{.*}}{{/|\\}}unit-with-explicit-output-path.o
+// UNITOUT: out-file: custom-unit.o
+// ALL: target: x86_64-apple-macosx10.8
+// ALL: is-debug: 1
+
+
+// RUN: %clang_cc1 -I %S/Inputs -isystem %S/Inputs/sys -index-store-path %t/idx_same %s -triple x86_64-apple-macosx10.8 -o %t/dir1/out.o -index-unit-output-path %t/custom-unit.o
+// RUN: %clang_cc1 -I %S/Inputs -isystem %S/Inputs/sys -index-store-path %t/idx_same %s -triple x86_64-apple-macosx10.8 -o %t/dir2/out.o -index-unit-output-path %t/custom-unit.o
+// RUN: c-index-test core -print-unit %t/idx_same | FileCheck %s -check-prefixes=SINGLE
+
+// Make sure there's only one unit file produced even though both invocations had different -o paths.
+// SINGLE-NOT: --------
+// SINGLE: custom-unit.o-{{.*}}
+// SINGLE-NEXT: --------
+// SINGLE-NOT: --------
+
+// RUN: %clang_cc1 -I %S/Inputs -isystem %S/Inputs/sys -index-store-path %t/idx_same %s -triple x86_64-apple-macosx10.8 -o %t/dir2/out.o -index-unit-output-path %t/custom-unit2.o
+// RUN: c-index-test core -print-unit %t/idx_same | FileCheck %s -check-prefixes=TWOUNITS
+
+// Make sure there are two unit files now, as we had a different unit output path.
+
+// TWOUNITS: custom-unit.o-{{.*}}
+// TWOUNITS-NEXT: --------
+// TWOUNITS: custom-unit2.o-{{.*}}
+// TWOUNITS-NEXT: --------

--- a/clang/tools/driver/CMakeLists.txt
+++ b/clang/tools/driver/CMakeLists.txt
@@ -119,3 +119,26 @@ if(CLANG_ORDER_FILE AND
     set_target_properties(clang PROPERTIES LINK_DEPENDS ${CLANG_ORDER_FILE})
   endif()
 endif()
+
+# Add features.json file into usr/share/clang
+set(features_file_src "${CMAKE_CURRENT_SOURCE_DIR}/features.json")
+set(features_file_dest "${CMAKE_BINARY_DIR}/share/clang/features.json")
+
+add_custom_command(OUTPUT ${features_file_dest}
+                   COMMAND ${CMAKE_COMMAND} -E make_directory
+                     ${CMAKE_BINARY_DIR}/share/clang
+                   COMMAND ${CMAKE_COMMAND} -E copy
+                     ${features_file_src}
+                     ${features_file_dest}
+                   DEPENDS ${features_file_src})
+
+add_custom_target(clang-features-file DEPENDS ${features_file_dest})
+add_dependencies(clang clang-features-file)
+install(FILES ${features_file_dest}
+        DESTINATION "share/clang"
+        COMPONENT clang)
+if(NOT LLVM_ENABLE_IDE)
+  add_llvm_install_targets("install-features-file"
+                           DEPENDS clang-features-file
+                           COMPONENT clang)
+endif()

--- a/clang/tools/driver/features.json
+++ b/clang/tools/driver/features.json
@@ -1,0 +1,13 @@
+{
+  "features": [
+    {
+      "name": "index-unit-output-path"
+    },
+    {
+      "name": "vfs-directory-remap"
+    },
+    {
+      "name": "allow-pcm-with-compiler-errors"
+    }
+  ]
+}


### PR DESCRIPTION
- **[Index] Add new option to specify the output file to use for/record in the index store unit file rather than using -o.**
    The -o path was used to identify the index data associated with a particular compilation unit. Because the whole path is considered this meant that separate build directories could never share index data, even if they differed in ways that didn't affect the index data (such as ASANified vs non-ASANified builds). With the new option to explicitly pass the output file to use for the index store, the same path can be used in both builds, allowing index data to be reused.
- **[CMake] Add a features.json file to make it easier for build systems to determine what features a given toolchain supports.** 
    The only available method to check for features at the moment is through version checks or setting up appropriate inputs/environments to run clang and infer their support from the output. This is error-prone/tedious and in the case of version checks, and doesn't work well for locally built compilers. features.json is intended to communicate to build systems that a new feature and its associated flags are available, in order to assist with transitional periods where not all supported toolchains may have the feature. It is not intended to be a comprehensive report of all available features.  It's installed to usr/share/clang/features.json and currently lists the new `-index-unit-output-path` option and the new 'directory-remap' type supported in the -ivfsoverly yaml.

Resolves  rdar://problem/72387110.