### PR TITLE
[lldb] Let TestPExpectTest test the right test class

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbpexpect.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbpexpect.py
@@ -53,11 +53,12 @@ class PExpectTest(TestBase):
 
     def expect(self, cmd, substrs=None):
         self.assertNotIn('\n', cmd)
-        self.child.sendline(cmd)
         # If 'substrs' is a string then this code would just check that every
         # character of the string is in the output.
         assert not isinstance(substrs, six.string_types), \
             "substrs must be a collection of strings"
+
+        self.child.sendline(cmd)
         if substrs is not None:
             for s in substrs:
                 self.child.expect_exact(s)

--- a/lldb/test/API/test_utils/TestPExpectTest.py
+++ b/lldb/test/API/test_utils/TestPExpectTest.py
@@ -2,14 +2,9 @@
 Test the PExpectTest test functions.
 """
 
+from lldbsuite.test.lldbpexpect import *
 
-import lldb
-import lldbsuite.test.lldbutil as lldbutil
-from lldbsuite.test.lldbtest import *
-from textwrap import dedent
-
-
-class TestPExpectTestCase(TestBase):
+class TestPExpectTestCase(PExpectTest):
 
     mydir = TestBase.compute_mydir(__file__)
     NO_DEBUG_INFO_TESTCASE = True


### PR DESCRIPTION
This test supposed to check the test base we are using for pexpect tests, but instead it used the normal TestBase
class we use for all other tests. TestBase already had the substrs type check since D88792 so this
test was passing because of that.

This just changes the test base of the test to the pexpect one so that the `expect` calls find their intended
target function. Also moves the check to the very start so that we can check the argument without
actually having to start a terminal and all that jazz.

(I found this by accident as D88792 got somehow reverted in a downstream branch so this test started
failing).

Reviewed By: JDevlieghere

Differential Revision: https://reviews.llvm.org/D96556

(cherry picked from commit 0c118831a37a058f5ff196a4be3c4d5b1cf25e63)