### PR TITLE
Cherry-pick the implementation of atomic_is_lock_free in compiler-rt

### DIFF
--- a/compiler-rt/lib/builtins/atomic.c
+++ b/compiler-rt/lib/builtins/atomic.c
@@ -36,6 +36,8 @@
 #pragma redefine_extname __atomic_exchange_c SYMBOL_NAME(__atomic_exchange)
 #pragma redefine_extname __atomic_compare_exchange_c SYMBOL_NAME(              \
     __atomic_compare_exchange)
+#pragma redefine_extname __atomic_is_lock_free_c SYMBOL_NAME(                  \
+    __atomic_is_lock_free)
 
 /// Number of locks.  This allocates one page on 32-bit platforms, two on
 /// 64-bit.  This can be specified externally if a different trade between
@@ -156,6 +158,14 @@ static __inline Lock *lock_for_pointer(void *ptr) {
       break;                                                                   \
     }                                                                          \
   } while (0)
+
+/// Whether atomic operations for the given size (and alignment) are lock-free.
+bool __atomic_is_lock_free_c(size_t size, void *ptr) {
+#define LOCK_FREE_ACTION(type) return true;
+  LOCK_FREE_CASES(ptr);
+#undef LOCK_FREE_ACTION
+  return false;
+}
 
 /// An atomic load operation.  This is atomic with respect to the source
 /// pointer only.


### PR DESCRIPTION
This function is called by the __atomic_is_lock_free() builtin if the value
cannot be resolved to true at compile time. Lack of this function is
causing the non-lockfree atomics tests in libc++ to not be run (see D91911)

This function is also added in D85044, but that review also adds support
for using lock-free atomics in more cases, whereas this is a minimal change
that just adds __atomic_is_lock_free() for the implementation of atomic.c.

This is a cherry-pick of 00530dee5d1295dc20ebafdd9a8a79662f41513e.

Reviewed By: ldionne

Differential Revision: https://reviews.llvm.org/D92302