### PR TITLE
[lldb] Resolve two compiler warnings

### DIFF
--- a/lldb/source/Core/ValueObjectChild.cpp
+++ b/lldb/source/Core/ValueObjectChild.cpp
@@ -238,9 +238,6 @@ bool ValueObjectChild::UpdateValue() {
             m_value.GetScalar() = scalar;
           }
           break;
-        default:
-          m_error.SetErrorString("parent has invalid value.");
-          break;
         }
       }
 

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -280,7 +280,9 @@ public:
   bool queryDataLayout(DataLayoutQueryType type, void *inBuffer,
                        void *outBuffer) override {
     switch (type) {
-    // FIXME: add support for case DLQ_GetPtrAuthMask:
+    // FIXME: add support for case DLQ_GetPtrAuthMask rdar://70729149
+    case DLQ_GetPtrAuthMask:
+      return false;
     case DLQ_GetObjCReservedLowBits: {
       auto *result = static_cast<uint8_t *>(outBuffer);
       auto &triple = m_process.GetTarget().GetArchitecture().GetTriple();
@@ -314,8 +316,6 @@ public:
       return true;
     }
     }
-
-    return false;
   }
 
   swift::remote::RemoteAddress


### PR DESCRIPTION
Resolves two warnings:

1. A `default` on a fully covered switch
2. A missing `case` in a switch statement with no `default`