### PR TITLE
[lldb] Improve error message for modules with dots or dashes

### DIFF
--- a/lldb/test/Shell/ScriptInterpreter/Python/command_import.test
+++ b/lldb/test/Shell/ScriptInterpreter/Python/command_import.test
@@ -1,0 +1,20 @@
+# REQUIRES: python
+
+# RUN: rm -rf %t && mkdir -p %t
+# RUN: echo "print('Rene Magritte')" >> %t/foo.py
+# RUN: echo "print('Jan van Eyck')" >> %t/foo-bar.py
+# RUN: echo "print('Pieter Bruegel the Elder')" >> %t/foo.bar.py
+# RUN: echo "print('Pieter Bruegel the Younger')" >> %t/foo.bar
+
+# RUN: %lldb --script-language python -o 'command script import %t/foo.py' 2>&1 | FileCheck %s --check-prefix MAGRITTE
+# MAGRITTE: Rene Magritte
+
+# RUN: %lldb --script-language python -o 'command script import %t/foo-bar.py' 2>&1 | FileCheck %s --check-prefix VANEYCK
+# VANEYCK-NOT: Jan van Eyck
+# VANEYCK: module importing failed: Python discourages dashes in module names: foo-bar
+
+# RUN: %lldb --script-language python -o 'command script import %t/foo.bar.py' 2>&1 | FileCheck %s --check-prefix BRUEGEL
+# RUN: %lldb --script-language python -o 'command script import %t/foo.bar' 2>&1 | FileCheck %s --check-prefix BRUEGEL
+# BRUEGEL-NOT: Pieter Bruegel the Elder
+# BRUEGEL-NOT: Pieter Bruegel the Younger
+# BRUEGEL: module importing failed: Python does not allow dots in module names: foo.bar


### PR DESCRIPTION
LLDB does not like to import Python files with dashes or dots in their
name. While the former are technically allowed, it is discouraged. Dots
are allowed for subpackages but not in module names. This patch improves
the user experience by printing a useful error.

Before this patch:

  error: module importing failed: SyntaxError('invalid syntax',
  ('<string>', 1, 11, 'import foo-bar\n'))

After this patch:

  error: module importing failed: Python discourages dashes in module
  names: foo-bar

rdar://74263511

[1] https://www.python.org/dev/peps/pep-0008/#package-and-module-names

Differential revision: https://reviews.llvm.org/D96833

(cherry picked from commit d6e80578fc5e5199d5783671bd0c8ce1050925f9)
