### PR TITLE
SwiftAsync: switch to temporary register for this parameter.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64CallingConvention.td
+++ b/llvm/lib/Target/AArch64/AArch64CallingConvention.td
@@ -70,7 +70,7 @@ def CC_AArch64_AAPCS : CallingConv<[
   CCIfSwiftError<CCIfType<[i64], CCAssignToRegWithShadow<[X21], [W21]>>>,
 
   // Pass SwiftAsync in a callee saved register.
-  CCIfSwiftAsync<CCIfType<[i64], CCAssignToRegWithShadow<[X22], [W22]>>>,
+  CCIfSwiftAsync<CCIfType<[i64], CCAssignToRegWithShadow<[X9], [W9]>>>,
 
   CCIfConsecutiveRegs<CCCustom<"CC_AArch64_Custom_Block">>,
 
@@ -206,7 +206,7 @@ def CC_AArch64_DarwinPCS : CallingConv<[
   CCIfSwiftError<CCIfType<[i64], CCAssignToRegWithShadow<[X21], [W21]>>>,
 
   // Pass SwiftAsync in a callee saved register.
-  CCIfSwiftAsync<CCIfType<[i64], CCAssignToRegWithShadow<[X22], [W22]>>>,
+  CCIfSwiftAsync<CCIfType<[i64], CCAssignToRegWithShadow<[X9], [W9]>>>,
 
   CCIfConsecutiveRegs<CCCustom<"CC_AArch64_Custom_Block">>,
 

--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -1227,7 +1227,7 @@ void AArch64FrameLowering::emitPrologue(MachineFunction &MF,
       bool HaveInitialContext = Attrs.hasAttrSomewhere(Attribute::SwiftAsync);
 
       BuildMI(MBB, MBBI, DL, TII->get(AArch64::StoreSwiftAsyncContext))
-          .addUse(HaveInitialContext ? AArch64::X22 : AArch64::XZR)
+          .addUse(HaveInitialContext ? AArch64::X9 : AArch64::XZR)
           .addUse(AArch64::SP)
           .addImm(FPOffset - 8)
           .setMIFlags(MachineInstr::FrameSetup);

--- a/llvm/lib/Target/X86/X86CallingConv.td
+++ b/llvm/lib/Target/X86/X86CallingConv.td
@@ -519,7 +519,7 @@ def CC_X86_64_C : CallingConv<[
   CCIfSwiftError<CCIfType<[i64], CCAssignToReg<[R12]>>>,
 
   // Pass SwiftSelf in a callee saved register.
-  CCIfSwiftAsync<CCIfType<[i64], CCAssignToReg<[R14]>>>,
+  CCIfSwiftAsync<CCIfType<[i64], CCAssignToReg<[R11]>>>,
 
   // For Swift Calling Conventions, pass sret in %rax.
   CCIfCC<"CallingConv::Swift",

--- a/llvm/lib/Target/X86/X86FrameLowering.cpp
+++ b/llvm/lib/Target/X86/X86FrameLowering.cpp
@@ -1476,10 +1476,10 @@ void X86FrameLowering::emitPrologue(MachineFunction &MF,
         const auto &Attrs = MF.getFunction().getAttributes();
 
         if (Attrs.hasAttrSomewhere(Attribute::SwiftAsync)) {
-          // We have an initial context in r14, store it just before the frame
+          // We have an initial context in r11, store it just before the frame
           // pointer.
           BuildMI(MBB, MBBI, DL, TII.get(X86::PUSH64r))
-              .addReg(X86::R14)
+              .addReg(X86::R11)
               .setMIFlag(MachineInstr::FrameSetup);
         } else {
           // No initial context, store null so that there's no pointer that

--- a/llvm/test/CodeGen/AArch64/swift-async-reg.ll
+++ b/llvm/test/CodeGen/AArch64/swift-async-reg.ll
@@ -4,14 +4,14 @@
 
 define i8* @argument(i8* swiftasync %in) {
 ; CHECK-LABEL: argument:
-; CHECK: mov x0, x22
+; CHECK: mov x0, x9
 
   ret i8* %in
 }
 
 define void @call(i8* %in) {
 ; CHECK-LABEL: call:
-; CHECK: mov x22, x0
+; CHECK: mov x9, x0
 
   call i8* @argument(i8* swiftasync %in)
   ret void

--- a/llvm/test/CodeGen/AArch64/swift-async.ll
+++ b/llvm/test/CodeGen/AArch64/swift-async.ll
@@ -3,7 +3,7 @@
 ; RUN: llc -mtriple=arm64e-apple-ios %s -o - | FileCheck %s --check-prefixes=CHECK-AUTH,CHECK
 
 ; Important details in prologue:
-;   * x22 is stored just below x29
+;   * x9 is stored just below x29
 ;   * Enough stack space is allocated for everything
 define void @simple(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK-LABEL: simple:
@@ -11,10 +11,10 @@ define void @simple(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK: sub sp, sp, #32
 ; CHECK: stp x29, x30, [sp, #16]
 
-; CHECK-NOAUTH: str x22, [sp, #8]
+; CHECK-NOAUTH: str x9, [sp, #8]
 ; CHECK-AUTH: add x16, sp, #8
 ; CHECK-AUTH: movk x16, #49946, lsl #48
-; CHECK-AUTH: mov x17, x22
+; CHECK-AUTH: mov x17, x9
 ; CHECK-AUTH: pacdb x17, x16
 ; CHECK-AUTH: str x17, [sp, #8]
 
@@ -39,10 +39,10 @@ define void @more_csrs(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK: stp x24, x23, [sp, #8]
 ; CHECK: stp x29, x30, [sp, #32]
 
-; CHECK-NOAUTH: str x22, [sp, #24]
+; CHECK-NOAUTH: str x9, [sp, #24]
 ; CHECK-AUTH: add x16, sp, #24
 ; CHECK-AUTH: movk x16, #49946, lsl #48
-; CHECK-AUTH: mov x17, x22
+; CHECK-AUTH: mov x17, x9
 ; CHECK-AUTH: pacdb x17, x16
 ; CHECK-AUTH: str x17, [sp, #24]
 
@@ -69,10 +69,10 @@ define void @locals(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK: sub sp, sp, #64
 ; CHECK: stp x29, x30, [sp, #48]
 
-; CHECK-NOAUTH: str x22, [sp, #40]
+; CHECK-NOAUTH: str x9, [sp, #40]
 ; CHECK-AUTH: add x16, sp, #40
 ; CHECK-AUTH: movk x16, #49946, lsl #48
-; CHECK-AUTH: mov x17, x22
+; CHECK-AUTH: mov x17, x9
 ; CHECK-AUTH: pacdb x17, x16
 ; CHECK-AUTH: str x17, [sp, #40]
 
@@ -97,11 +97,11 @@ define void @locals(i8* swiftasync %ctx) "frame-pointer"="all" {
 define void @use_input_context(i8* swiftasync %ctx, i8** %ptr) "frame-pointer"="all" {
 ; CHECK-LABEL: use_input_context:
 
-; CHECK-NOAUTH: str x22, [sp
-; CHECK-AUTH: mov x17, x22
+; CHECK-NOAUTH: str x9, [sp
+; CHECK-AUTH: mov x17, x9
 
-; CHECK-NOT: x22
-; CHECK: str x22, [x0]
+; CHECK-NOT: x9
+; CHECK: str x9, [x0]
 
   store i8* %ctx, i8** %ptr
   ret void
@@ -142,7 +142,7 @@ define void @large_frame(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK: sub sp, sp, #48
 ; CHECK: stp x28, x27, [sp, #8]
 ; CHECK: stp x29, x30, [sp, #32]
-; CHECK-NOAUTH: str x22, [sp, #24]
+; CHECK-NOAUTH: str x9, [sp, #24]
 ; CHECK: add x29, sp, #32
 ; CHECK: sub sp, sp, #1024
 ; [...]

--- a/llvm/test/CodeGen/X86/swift-async-reg.ll
+++ b/llvm/test/CodeGen/X86/swift-async-reg.ll
@@ -3,14 +3,14 @@
 
 define i8* @argument(i8* swiftasync %in) {
 ; CHECK-LABEL: argument:
-; CHECK: movq %r14, %rax
+; CHECK: movq %r11, %rax
 
   ret i8* %in
 }
 
 define void @call(i8* %in) {
 ; CHECK-LABEL: call:
-; CHECK: movq %rdi, %r14
+; CHECK: movq %rdi, %r11
 
   call i8* @argument(i8* swiftasync %in)
   ret void

--- a/llvm/test/CodeGen/X86/swift-async.ll
+++ b/llvm/test/CodeGen/X86/swift-async.ll
@@ -6,7 +6,7 @@ define void @simple(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK-LABEL: simple:
 ; CHECK: btsq    $60, %rbp
 ; CHECK: pushq   %rbp
-; CHECK: pushq   %r14
+; CHECK: pushq   %r11
 ; CHECK: leaq    8(%rsp), %rbp
 ; CHECK: pushq
 ; [...]
@@ -28,7 +28,7 @@ define void @more_csrs(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK: btsq    $60, %rbp
 ; CHECK: pushq   %rbp
 ; CHECK: .cfi_offset %rbp, -16
-; CHECK: pushq   %r14
+; CHECK: pushq   %r11
 ; CHECK: leaq    8(%rsp), %rbp
 ; CHECK: subq    $8, %rsp
 ; CHECK: pushq   %r15
@@ -51,7 +51,7 @@ define void @locals(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK: pushq   %rbp
 ; CHECK: .cfi_def_cfa_offset 16
 ; CHECK: .cfi_offset %rbp, -16
-; CHECK: pushq   %r14
+; CHECK: pushq   %r11
 ; CHECK: leaq    8(%rsp), %rbp
 ; CHECK: .cfi_def_cfa_register %rbp
 ; CHECK: subq    $56, %rsp
@@ -72,7 +72,7 @@ define void @locals(i8* swiftasync %ctx) "frame-pointer"="all" {
 
 define void @use_input_context(i8* swiftasync %ctx, i8** %ptr) "frame-pointer"="all" {
 ; CHECK-LABEL: use_input_context:
-; CHECK: movq    %r14, (%rdi)
+; CHECK: movq    %r11, (%rdi)
 
   store i8* %ctx, i8** %ptr
   ret void


### PR DESCRIPTION
The async functions use tail calls as the primary call mechanism, so the
concept of returning the parameter for use in the caller doesn't really apply.
In fact, restoring the callee-saved registers will clobber the value we're
attempting to pass in this case.