### PR TITLE
[lldb] Disable x86-multithread-write.test with reproducers

### DIFF
--- a/lldb/test/Shell/Register/x86-multithread-write.test
+++ b/lldb/test/Shell/Register/x86-multithread-write.test
@@ -1,6 +1,7 @@
 # XFAIL: system-windows
 # REQUIRES: native && (target-x86 || target-x86_64)
 # UNSUPPORTED: system-debugserver
+# UNSUPPORTED: lldb-repro
 # RUN: %clangxx_host %p/Inputs/x86-multithread-write.cpp -o %t -pthread
 # RUN: %lldb -b -s %s %t | FileCheck %s
 


### PR DESCRIPTION
This test is failing on GreenDragon. Disabling it until I have bandwidth
to investigate why the register values are different during replay.

(cherry picked from commit 876e7714dc73e651c5841af1b38b54fa350b6331)
