### PR TITLE
[clang] bump VERSION_MAJOR

### DIFF
--- a/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/clang/include/clang/Serialization/ASTBitCodes.h
@@ -41,7 +41,7 @@ namespace serialization {
 /// Version 4 of AST files also requires that the version control branch and
 /// revision match exactly, since there is no backward compatibility of
 /// AST files at this time.
-const unsigned VERSION_MAJOR = 11;
+const unsigned VERSION_MAJOR = 12;
 
 /// AST file minor version number supported by this version of
 /// Clang.


### PR DESCRIPTION
Somewhat speculative, see https://reviews.llvm.org/D96816#2572431

(cherry picked from commit 063236646849564094f5fcfc947ad36dba0efedb)