### PR TITLE
[lldb] Check that files exists before handing them off to FileCollector

### DIFF
--- a/lldb/source/Utility/Reproducer.cpp
+++ b/lldb/source/Utility/Reproducer.cpp
@@ -374,7 +374,7 @@ static llvm::Error addPaths(StringRef path,
   SmallVector<StringRef, 0> paths;
   (*buffer)->getBuffer().split(paths, '\0');
   for (StringRef p : paths) {
-    if (!p.empty())
+    if (!p.empty() && llvm::sys::fs::exists(p))
       callback(p);
   }
 


### PR DESCRIPTION
The FileCollector asserts that paths passed to addDirectory are indeed
directories. For that to work, the file needs to actually exist. In the
downstream Swift fork we have tests that remove files during testing,
which resulted in this assertion getting triggered.

(cherry picked from commit 31fa76fd24adea755e4368674a59385d2c5b0cc7)
