### PR TITLE
LanguageRuntime can provide an UnwindPlan for special occasions

### DIFF
--- a/lldb/include/lldb/Target/LanguageRuntime.h
+++ b/lldb/include/lldb/Target/LanguageRuntime.h
@@ -173,7 +173,30 @@ public:
   virtual bool isA(const void *ClassID) const { return ClassID == &ID; }
   static char ID;
 
+  /// A language runtime may be able to provide a special UnwindPlan for
+  /// the frame represented by the register contents \a regctx when that
+  /// frame is not following the normal ABI conventions.
+  /// Instead of using the normal UnwindPlan for the function, we will use
+  /// this special UnwindPlan for this one backtrace.
+  /// One example of this would be a language that has asynchronous functions,
+  /// functions that may not be currently-executing, while waiting on other
+  /// asynchronous calls they made, but are part of a logical backtrace that
+  /// we want to show the developer because that's how they think of the
+  /// program flow.
+  static lldb::UnwindPlanSP
+  GetRuntimeUnwindPlan(lldb_private::Thread &thread,
+                       lldb_private::RegisterContext *regctx);
+
 protected:
+  // The static GetRuntimeUnwindPlan method above is only implemented in the
+  // base class; subclasses may override this protected member if they can
+  // provide one of these UnwindPlans.
+  virtual lldb::UnwindPlanSP
+  GetRuntimeUnwindPlan(lldb::ProcessSP process_sp,
+                       lldb_private::RegisterContext *regctx) {
+    return lldb::UnwindPlanSP();
+  }
+
   LanguageRuntime(Process *process);
 };
 

--- a/lldb/source/Target/LanguageRuntime.cpp
+++ b/lldb/source/Target/LanguageRuntime.cpp
@@ -259,6 +259,21 @@ BreakpointSP LanguageRuntime::CreateExceptionBreakpoint(
   return exc_breakpt_sp;
 }
 
+UnwindPlanSP LanguageRuntime::GetRuntimeUnwindPlan(Thread &thread,
+                                                   RegisterContext *regctx) {
+  ProcessSP process_sp = thread.GetProcess();
+  if (!process_sp.get())
+    return UnwindPlanSP();
+  for (const lldb::LanguageType lang_type : Language::GetSupportedLanguages()) {
+    if (LanguageRuntime *runtime = process_sp->GetLanguageRuntime(lang_type)) {
+      UnwindPlanSP plan_sp = runtime->GetRuntimeUnwindPlan(process_sp, regctx);
+      if (plan_sp.get())
+        return plan_sp;
+    }
+  }
+  return UnwindPlanSP();
+}
+
 void LanguageRuntime::InitializeCommands(CommandObject *parent) {
   if (!parent)
     return;


### PR DESCRIPTION
LanguageRuntime can provide an UnwindPlan for special occasions

Add a facility in the LanguageRuntime to provide a special
UnwindPlan based on the register values in a RegisterContext,
instead of using the return-pc to find a function and use its
normal UnwindPlans.

Needed when the runtime has special stack frames that we want
to show the user, but aren't actually on the real stack.
Specifically for Swift asynchronous functions.

With feedback from Greg Clayton, Jonas Devlieghere, Dave Lee

<rdar://problem/70398009>

Differential Revision: https://reviews.llvm.org/D96839

(cherry picked from commit d82ecb0ac72261189ec3a5dccd3ad55aeafe07b4)