### PR TITLE
[lldb][swift] Prevent infinite recursion between ValueObjectDynamic and LoadLibraryUsingPaths

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3962,6 +3962,21 @@ bool SwiftASTContext::LoadLibraryUsingPaths(
       uniqued_paths.push_back(library_search_dir);
   }
 
+  detail::SwiftLibraryLookupRequest library_request;
+  library_request.library_name = library_fullname;
+  library_request.search_paths = uniqued_paths;
+  library_request.check_rpath = check_rpath;
+  library_request.process_uid = process.GetUniqueID();
+
+  // If this library failed to load before, don't try to load it again.
+  // This is partly done for performance reasons, but also trying to load a
+  // library might change the process state. This in turn could then invalidate
+  // ValueObjects which then in turn try to resolve types their types again
+  // which would bring us back here trying to load the required library. This
+  // cache prevents this recursion. See also rdar://74454500
+  if (failed_library_loads.count(library_request) != 0)
+    return false;
+
   FileSpec library_spec(library_fullname);
   FileSpec found_library;
   uint32_t token = LLDB_INVALID_IMAGE_TOKEN;
@@ -3996,6 +4011,8 @@ bool SwiftASTContext::LoadLibraryUsingPaths(
                                library_fullname.c_str(),
                                load_image_error.AsCString());
   }
+
+  failed_library_loads.insert(library_request);
   return false;
 }
 


### PR DESCRIPTION
There is currently a possible infinite recursion in ValueObjectDynamic that
happens when a library consistently fails to be loaded for some reason.

The recursion starts here:

    CompilerType ValueObjectDynamicValue::GetCompilerTypeImpl() {
      const bool success = UpdateValueIfNeeded(false);

UpdateValueIfNeeded brings us here:

    bool ValueObject::UpdateValueIfNeeded(bool update_format) {
      if (NeedsUpdating()) {
        m_update_point.SetUpdated();
        [...]
        if (IsInScope()) {
          [...]
          bool success = UpdateValue();
          if (success) {
            UpdateChildrenAddressType();

UpdateChildrenAddressType brings us to this (with valobj being our ValueObjectDynamicValue):

    void ValueObjectVariable::DoUpdateChildrenAddressType(ValueObject &valobj) {
      Value::ValueType value_type = valobj.GetValue().GetValueType();
      ExecutionContext exe_ctx(GetExecutionContextRef());
      Process *process = exe_ctx.GetProcessPtr();
      const bool process_is_alive = process && process->IsAlive();
      const uint32_t type_info = valobj.GetCompilerType().GetTypeInfo();

In the last line we call GetCompilerType and that brings us back to the start
as that calls GetCompilerTypeImpl.

So usually the `if (NeedsUpdating()) ... SetUpdated()` would prevent the recursion,
but when a failing to load library this check is broken.

The reason for that is that `UpdateValue` implementation in Swift
might lead to a call to `Platform::LoadImageUsingPaths` which in turn ends
up executing code in the target process via this function call chain:

    lldb_private::ValueObjectDynamicValue::UpdateValue
      lldb_private::SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress
        lldb_private::ValueObject::GetScratchSwiftASTContext
          lldb_private::Target::GetScratchSwiftASTContext
            lldb_private::SwiftASTContext::GetCompileUnitImports
              LoadOneModule
                lldb_private::SwiftASTContext::LoadModule
                  swift::ModuleDecl::collectLinkLibraries
                    swift::ClangModuleUnit::collectLinkLibraries
                      lldb_private::SwiftASTContext::LoadLibraryUsingPaths
                        lldb_private::Platform::LoadImageUsingPaths
                          PlatformPOSIX::DoLoadImage
                             lldb_private::FunctionCaller::ExecuteFunction
                               lldb_private::Process::RunThreadPlan

As executing code will modify the process state, our ValueObjectDynamic is
getting invalidated which causes `NeedsUpdating()` to return true.

We do call `UpdateValue` in `UpdateValueIfNeeded` which means we now have
the following behaviour (see the comments in the code):

    bool ValueObject::UpdateValueIfNeeded(bool update_format) {
      if (NeedsUpdating()) {
        m_update_point.SetUpdated(); // We mark the object as updated.
                                     // NeedsUpdating() is now false.
        [...]
        if (IsInScope()) {
          [...]
          bool success = UpdateValue(); // We update and load a library. This
                                        // executes codes and invalidates the
                                        // ValueObject.
                                        // NeedsUpdating() is now true.
          if (success) {
            UpdateChildrenAddressType(); // This calls UpdateValueIfNeeded.
                                         // However as NeedsUpdating() is true,
                                         // we just get sent back here.

Usually `LoadLibraryUsingPaths` is not unconditionally executing code
as it will early-exit if it sees that a library already has been loaded. This
seems to usually prevent the recursion described as not executing any code
will also not invalidate the ValueObject. However, if the library fails
to load the current implementation will just keep retrying to load the library
and execute code in the process. This leads to the ValueObject continuously
being invalidated and we have our infinite recursion.

This patch fixes the issue by introducing a cache for failed library lookups.
This way the first time we fail to load a function we just early-exit in the
same fashion as we do for successfully loaded libraries.

Fixes rdar://74454500