### PR TITLE
[lldb] Add initial support for async step in

### DIFF
--- a/lldb/source/Target/ThreadPlanStepThrough.cpp
+++ b/lldb/source/Target/ThreadPlanStepThrough.cpp
@@ -135,12 +135,6 @@ bool ThreadPlanStepThrough::ValidatePlan(Stream *error) {
     return false;
   }
 
-  if (m_backstop_bkpt_id == LLDB_INVALID_BREAK_ID) {
-    if (error)
-      error->PutCString("Could not create backstop breakpoint.");
-    return false;
-  }
-
   if (!m_sub_plan_sp.get()) {
     if (error)
       error->PutCString("Does not have a subplan.");


### PR DESCRIPTION
This is an initial implementation of stepping into swift async functions.

This introduces a composite thread plan, `ThreadPlanStepInAsync`, which contains the logic need for stepping into an async function. This includes:

1. Determining if the function begins with an async context switch, which is like a trampoline via `swift_task_switch`
2. Setting a breakpoint on the target of `swift_task_switch`
3. Allowing the calling thread to continue, and not stay stopped

For the purposes of stepping, there are two types of swift async functions, those that begin with a `swift_task_switch` "prolog", and those which contain the immediate function body. For async functions that start with a task switch, `ThreadPlanStepInAsync` pushes a step in plan, and for those that contain the immediate function body, no further action is required.

In follow ups, the active thread plan stack will be disassociated with the current thread, and two things will be done:

1. The disassociated thread plan stacks will be queries to determine which thread plan to restore on the active thread when the breakpoint hits
2. The disassociated thread plans will be keyed by the AsyncContext, and this will be used to ensure the breakpoint is conditional on the async context known at the time of step in