### PR TITLE
[libClang][Dependency] Return an error message when `-cc1` arguments are not provided

### DIFF
--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -218,6 +218,7 @@ clang_experimental_DependencyScannerWorker_getFileDependencies_v0(
     for (int i = 2; i < argc; ++i)
       Compilation.push_back(argv[i]);
   else {
+    *error = "The dependency scanner requires using -cc1 compilation arguments. See  clang_Driver_getExternalActionsForCommand_v0 in Driver.h for more information."
     return nullptr; // TODO: Run the driver to get -cc1 args.
   }
 


### PR DESCRIPTION
- Return a message indicating that the arguments received cannot be used to find dependencies using `clang_experimental_DependencyScannerWorker_getFileDependencies_v0`

I'm working on generating the cc1 parameters automatically but for now I thought was a good idea to return a error message when they are not provided.

