### PR TITLE
[lldb] Reinstate support for LLDB_VERSION_STRING

### DIFF
--- a/lldb/source/lldb.cpp
+++ b/lldb/source/lldb.cpp
@@ -6,14 +6,25 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "VCSVersion.inc"
 #include "lldb/lldb-private.h"
+#include "clang/Basic/Version.h"
 
 using namespace lldb;
 using namespace lldb_private;
 
-#include "clang/Basic/Version.h"
+// LLDB_VERSION_STRING is set through a define so unlike the other defines
+// expanded with CMake, it lacks the double quotes.
+#define QUOTE(str) #str
+#define EXPAND_AND_QUOTE(str) QUOTE(str)
 
-#include "VCSVersion.inc"
+static const char *GetLLDBVersion() {
+#ifdef LLDB_VERSION_STRING
+  return EXPAND_AND_QUOTE(LLDB_VERSION_STRING);
+#else
+  return "lldb version " CLANG_VERSION_STRING;
+#endif
+}
 
 static const char *GetLLDBRevision() {
 #ifdef LLDB_REVISION
@@ -34,11 +45,10 @@ static const char *GetLLDBRepository() {
 const char *lldb_private::GetVersion() {
   static std::string g_version_str;
   if (g_version_str.empty()) {
-    g_version_str += "lldb version ";
-    g_version_str += CLANG_VERSION_STRING;
-
+    const char *lldb_version = GetLLDBVersion();
     const char *lldb_repo = GetLLDBRepository();
     const char *lldb_rev = GetLLDBRevision();
+    g_version_str += lldb_version;
     if (lldb_repo || lldb_rev) {
       g_version_str += " (";
       if (lldb_repo)


### PR DESCRIPTION
Reinstate support for specifying -DLLDB_VERSION_STRING="best-lldb"
which seems to have gotten accidentally removed in the past.

rdar://38983903

Differential revision: https://reviews.llvm.org/D97235

(cherry picked from commit 5d2850161e8cc14254a615911b0277d0050575d6)