### PR TITLE
Revert "Module: Use FileEntryRef and DirectoryEntryRef in Umbrella, H…

### DIFF
--- a/clang/include/clang/Basic/DirectoryEntry.h
+++ b/clang/include/clang/Basic/DirectoryEntry.h
@@ -62,26 +62,7 @@ public:
   bool isSameRef(DirectoryEntryRef RHS) const { return ME == RHS.ME; }
 
   DirectoryEntryRef() = delete;
-  DirectoryEntryRef(const MapEntry &ME) : ME(&ME) {}
-
-  /// Allow DirectoryEntryRef to degrade into 'const DirectoryEntry*' to
-  /// facilitate incremental adoption.
-  ///
-  /// The goal is to avoid code churn due to dances like the following:
-  /// \code
-  /// // Old code.
-  /// lvalue = rvalue;
-  ///
-  /// // Temporary code from an incremental patch.
-  /// lvalue = &rvalue.getDirectoryEntry();
-  ///
-  /// // Final code.
-  /// lvalue = rvalue;
-  /// \endcode
-  ///
-  /// FIXME: Once DirectoryEntryRef is "everywhere" and DirectoryEntry::getName
-  /// has been deleted, delete this implicit conversion.
-  operator const DirectoryEntry *() const { return &getDirEntry(); }
+  DirectoryEntryRef(MapEntry &ME) : ME(&ME) {}
 
 private:
   friend class FileMgr::MapEntryOptionalStorage<DirectoryEntryRef>;
@@ -222,77 +203,5 @@ template <> struct DenseMapInfo<clang::DirectoryEntryRef> {
 };
 
 } // end namespace llvm
-
-namespace clang {
-
-/// Wrapper around Optional<DirectoryEntryRef> that degrades to 'const
-/// DirectoryEntry*', facilitating incremental patches to propagate
-/// DirectoryEntryRef.
-///
-/// This class can be used as return value or field where it's convenient for
-/// an Optional<DirectoryEntryRef> to degrade to a 'const DirectoryEntry*'. The
-/// purpose is to avoid code churn due to dances like the following:
-/// \code
-/// // Old code.
-/// lvalue = rvalue;
-///
-/// // Temporary code from an incremental patch.
-/// Optional<DirectoryEntryRef> MaybeF = rvalue;
-/// lvalue = MaybeF ? &MaybeF.getDirectoryEntry() : nullptr;
-///
-/// // Final code.
-/// lvalue = rvalue;
-/// \endcode
-///
-/// FIXME: Once DirectoryEntryRef is "everywhere" and DirectoryEntry::LastRef
-/// and DirectoryEntry::getName have been deleted, delete this class and
-/// replace instances with Optional<DirectoryEntryRef>.
-class OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr
-    : public Optional<DirectoryEntryRef> {
-public:
-  OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr() = default;
-  OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr(
-      OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr &&) = default;
-  OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr(
-      const OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr &) = default;
-  OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr &
-  operator=(OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr &&) = default;
-  OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr &
-  operator=(const OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr &) = default;
-
-  OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr(llvm::NoneType) {}
-  OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr(DirectoryEntryRef Ref)
-      : Optional<DirectoryEntryRef>(Ref) {}
-  OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr(Optional<DirectoryEntryRef> MaybeRef)
-      : Optional<DirectoryEntryRef>(MaybeRef) {}
-
-  OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr &operator=(llvm::NoneType) {
-    Optional<DirectoryEntryRef>::operator=(None);
-    return *this;
-  }
-  OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr &operator=(DirectoryEntryRef Ref) {
-    Optional<DirectoryEntryRef>::operator=(Ref);
-    return *this;
-  }
-  OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr &
-  operator=(Optional<DirectoryEntryRef> MaybeRef) {
-    Optional<DirectoryEntryRef>::operator=(MaybeRef);
-    return *this;
-  }
-
-  /// Degrade to 'const DirectoryEntry *' to allow  DirectoryEntry::LastRef and
-  /// DirectoryEntry::getName have been deleted, delete this class and replace
-  /// instances with Optional<DirectoryEntryRef>
-  operator const DirectoryEntry *() const {
-    return hasValue() ? &getValue().getDirEntry() : nullptr;
-  }
-};
-
-static_assert(std::is_trivially_copyable<
-                  OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr>::value,
-              "OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr should be "
-              "trivially copyable");
-
-} // end namespace clang
 
 #endif // LLVM_CLANG_BASIC_DIRECTORYENTRY_H

--- a/clang/include/clang/Basic/Module.h
+++ b/clang/include/clang/Basic/Module.h
@@ -133,9 +133,7 @@ public:
   std::string PresumedModuleMapFile;
 
   /// The umbrella header or directory.
-  llvm::PointerUnion<const FileEntryRef::MapEntry *,
-                     const DirectoryEntryRef::MapEntry *>
-      Umbrella;
+  llvm::PointerUnion<const FileEntry *, const DirectoryEntry *> Umbrella;
 
   /// The module signature.
   ASTFileSignature Signature;
@@ -197,9 +195,9 @@ public:
   struct Header {
     std::string NameAsWritten;
     std::string PathRelativeToRootModuleDirectory;
-    OptionalFileEntryRefDegradesToFileEntryPtr Entry;
+    const FileEntry *Entry;
 
-    explicit operator bool() { return Entry != None; }
+    explicit operator bool() { return Entry; }
   };
 
   /// Information about a directory name as found in the module map
@@ -207,9 +205,9 @@ public:
   struct DirectoryName {
     std::string NameAsWritten;
     std::string PathRelativeToRootModuleDirectory;
-    OptionalDirectoryEntryRefDegradesToDirectoryEntryPtr Entry;
+    const DirectoryEntry *Entry;
 
-    explicit operator bool() { return Entry != None; }
+    explicit operator bool() { return Entry; }
   };
 
   /// The headers that are part of this module.
@@ -557,16 +555,16 @@ public:
   /// Retrieve the header that serves as the umbrella header for this
   /// module.
   Header getUmbrellaHeader() const {
-    if (auto *ME = Umbrella.dyn_cast<const FileEntryRef::MapEntry *>())
+    if (auto *FE = Umbrella.dyn_cast<const FileEntry *>())
       return Header{UmbrellaAsWritten, UmbrellaRelativeToRootModuleDirectory,
-                    FileEntryRef(*ME)};
+                    FE};
     return Header{};
   }
 
   /// Determine whether this module has an umbrella directory that is
   /// not based on an umbrella header.
   bool hasUmbrellaDir() const {
-    return Umbrella && Umbrella.is<const DirectoryEntryRef::MapEntry *>();
+    return Umbrella && Umbrella.is<const DirectoryEntry *>();
   }
 
   /// Add a top-level header associated with this module.

--- a/clang/include/clang/Lex/ModuleMap.h
+++ b/clang/include/clang/Lex/ModuleMap.h
@@ -14,7 +14,6 @@
 #ifndef LLVM_CLANG_LEX_MODULEMAP_H
 #define LLVM_CLANG_LEX_MODULEMAP_H
 
-#include "clang/Basic/FileEntry.h"
 #include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/Module.h"
@@ -38,6 +37,7 @@ namespace clang {
 
 class DiagnosticsEngine;
 class DirectoryEntry;
+class FileEntry;
 class FileManager;
 class HeaderSearch;
 class SourceManager;
@@ -659,13 +659,13 @@ public:
 
   /// Sets the umbrella header of the given module to the given
   /// header.
-  void setUmbrellaHeader(Module *Mod, FileEntryRef UmbrellaHeader,
+  void setUmbrellaHeader(Module *Mod, const FileEntry *UmbrellaHeader,
                          Twine NameAsWritten,
                          Twine PathRelativeToRootModuleDirectory);
 
   /// Sets the umbrella directory of the given module to the given
   /// directory.
-  void setUmbrellaDir(Module *Mod, DirectoryEntryRef UmbrellaDir,
+  void setUmbrellaDir(Module *Mod, const DirectoryEntry *UmbrellaDir,
                       Twine NameAsWritten,
                       Twine PathRelativeToRootModuleDirectory);
 

--- a/clang/lib/Basic/Module.cpp
+++ b/clang/lib/Basic/Module.cpp
@@ -253,11 +253,8 @@ Module::DirectoryName Module::getUmbrellaDir() const {
   if (Header U = getUmbrellaHeader())
     return {"", "", U.Entry->getDir()};
 
-  if (auto *ME = Umbrella.dyn_cast<const DirectoryEntryRef::MapEntry *>())
-    return {UmbrellaAsWritten, UmbrellaRelativeToRootModuleDirectory,
-            DirectoryEntryRef(*ME)};
-
-  return {"", "", None};
+  return {UmbrellaAsWritten, UmbrellaRelativeToRootModuleDirectory,
+          Umbrella.dyn_cast<const DirectoryEntry *>()};
 }
 
 void Module::addTopHeader(const FileEntry *File) {

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -304,7 +304,8 @@ bool GenerateHeaderModuleAction::BeginSourceFileAction(
         << Name;
       continue;
     }
-    Headers.push_back({std::string(Name), std::string(Name), *FE});
+    Headers.push_back({std::string(Name), std::string(Name),
+                       &FE->getFileEntry});
   }
   HS.getModuleMap().createHeaderModule(CI.getLangOpts().CurrentModule, Headers);
 

--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -300,7 +300,7 @@ bool ModuleMap::resolveAsBuiltinHeader(
   // supplied by Clang. Find that builtin header.
   SmallString<128> Path;
   llvm::sys::path::append(Path, BuiltinIncludeDir->getName(), Header.FileName);
-  auto File = SourceMgr.getFileManager().getOptionalFileRef(Path);
+  auto File = SourceMgr.getFileManager().getFile(Path);
   if (!File)
     return false;
 
@@ -1021,7 +1021,7 @@ Module *ModuleMap::inferFrameworkModule(const DirectoryEntry *FrameworkDir,
   // Look for an umbrella header.
   SmallString<128> UmbrellaName = StringRef(FrameworkDir->getName());
   llvm::sys::path::append(UmbrellaName, "Headers", ModuleName + ".h");
-  auto UmbrellaHeader = FileMgr.getOptionalFileRef(UmbrellaName);
+  auto UmbrellaHeader = FileMgr.getFile(UmbrellaName);
 
   // FIXME: If there's no umbrella header, we could probably scan the
   // framework to load *everything*. But, it's not clear that this is a good
@@ -1133,15 +1133,15 @@ Module *ModuleMap::createShadowedModule(StringRef Name, bool IsFramework,
   return Result;
 }
 
-void ModuleMap::setUmbrellaHeader(Module *Mod, FileEntryRef UmbrellaHeader,
+void ModuleMap::setUmbrellaHeader(Module *Mod, const FileEntry *UmbrellaHeader,
                                   Twine NameAsWritten,
                                   Twine PathRelativeToRootModuleDirectory) {
   Headers[UmbrellaHeader].push_back(KnownHeader(Mod, NormalHeader));
-  Mod->Umbrella = &UmbrellaHeader.getMapEntry();
+  Mod->Umbrella = UmbrellaHeader;
   Mod->UmbrellaAsWritten = NameAsWritten.str();
   Mod->UmbrellaRelativeToRootModuleDirectory =
       PathRelativeToRootModuleDirectory.str();
-  UmbrellaDirs[UmbrellaHeader.getDir()] = Mod;
+  UmbrellaDirs[UmbrellaHeader->getDir()] = Mod;
 
   // Notify callbacks that we just added a new header.
   for (const auto &Cb : Callbacks)
@@ -1151,7 +1151,7 @@ void ModuleMap::setUmbrellaHeader(Module *Mod, FileEntryRef UmbrellaHeader,
 void ModuleMap::setUmbrellaDir(Module *Mod, DirectoryEntryRef UmbrellaDir,
                                Twine NameAsWritten,
                                Twine PathRelativeToRootModuleDirectory) {
-  Mod->Umbrella = &UmbrellaDir.getMapEntry();
+  Mod->Umbrella = UmbrellaDir;
   Mod->UmbrellaAsWritten = NameAsWritten.str();
   Mod->UmbrellaRelativeToRootModuleDirectory =
       PathRelativeToRootModuleDirectory.str();
@@ -2438,15 +2438,15 @@ void ModuleMapParser::parseUmbrellaDirDecl(SourceLocation UmbrellaLoc) {
   }
 
   // Look for this file.
-  Optional<DirectoryEntryRef> Dir;
+  const DirectoryEntry *Dir = nullptr;
   if (llvm::sys::path::is_absolute(DirName)) {
-    if (auto D = SourceMgr.getFileManager().getOptionalDirectoryRef(DirName))
+    if (auto D = SourceMgr.getFileManager().getDirectory(DirName))
       Dir = *D;
   } else {
     SmallString<128> PathName;
     PathName = Directory->getName();
     llvm::sys::path::append(PathName, DirName);
-    if (auto D = SourceMgr.getFileManager().getOptionalDirectoryRef(PathName))
+    if (auto D = SourceMgr.getFileManager().getDirectory(PathName))
       Dir = *D;
   }
 
@@ -2467,7 +2467,7 @@ void ModuleMapParser::parseUmbrellaDirDecl(SourceLocation UmbrellaLoc) {
         SourceMgr.getFileManager().getVirtualFileSystem();
     for (llvm::vfs::recursive_directory_iterator I(FS, Dir->getName(), EC), E;
          I != E && !EC; I.increment(EC)) {
-      if (auto FE = SourceMgr.getFileManager().getOptionalFileRef(I->path())) {
+      if (auto FE = SourceMgr.getFileManager().getFile(I->path())) {
         Module::Header Header = {"", std::string(I->path()), *FE};
         Headers.push_back(std::move(Header));
       }
@@ -2481,7 +2481,7 @@ void ModuleMapParser::parseUmbrellaDirDecl(SourceLocation UmbrellaLoc) {
     return;
   }
 
-  if (Module *OwningModule = Map.UmbrellaDirs[*Dir]) {
+  if (Module *OwningModule = Map.UmbrellaDirs[Dir]) {
     Diags.Report(UmbrellaLoc, diag::err_mmap_umbrella_clash)
       << OwningModule->getFullModuleName();
     HadError = true;
@@ -2489,7 +2489,7 @@ void ModuleMapParser::parseUmbrellaDirDecl(SourceLocation UmbrellaLoc) {
   }
 
   // Record this umbrella directory.
-  Map.setUmbrellaDir(ActiveModule, *Dir, DirNameAsWritten, DirName);
+  Map.setUmbrellaDir(ActiveModule, Dir, DirNameAsWritten, DirName);
 }
 
 /// Parse a module export declaration.

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -1916,7 +1916,7 @@ HeaderFileInfoTrait::ReadData(internal_key_ref key, const unsigned char *d,
     // going to use this information to rebuild the module, so it doesn't make
     // a lot of difference.
     Module::Header H = {std::string(key.Filename), "",
-                        *FileMgr.getOptionalFileRef(Filename)};
+                        *FileMgr.getFile(Filename)};
     ModMap.addHeader(Mod, H, HeaderRole, /*Imported*/true);
     HFI.isModuleHeader |= !(HeaderRole & ModuleMap::TextualHeader);
   }
@@ -5611,7 +5611,7 @@ ASTReader::ReadSubmoduleBlock(ModuleFile &F, unsigned ClientLoadCapabilities) {
     case SUBMODULE_UMBRELLA_HEADER: {
       std::string Filename = std::string(Blob);
       ResolveImportedPath(F, Filename);
-      if (auto Umbrella = PP.getFileManager().getOptionalFileRef(Filename)) {
+      if (auto Umbrella = PP.getFileManager().getFile(Filename)) {
         if (!CurrentModule->getUmbrellaHeader())
           // FIXME: NameAsWritten
           ModMap.setUmbrellaHeader(CurrentModule, *Umbrella, Blob, "");
@@ -5645,8 +5645,7 @@ ASTReader::ReadSubmoduleBlock(ModuleFile &F, unsigned ClientLoadCapabilities) {
     case SUBMODULE_UMBRELLA_DIR: {
       std::string Dirname = std::string(Blob);
       ResolveImportedPath(F, Dirname);
-      if (auto Umbrella =
-              PP.getFileManager().getOptionalDirectoryRef(Dirname)) {
+      if (auto Umbrella = PP.getFileManager().getDirectory(Dirname)) {
         if (!CurrentModule->getUmbrellaDir())
           // FIXME: NameAsWritten
           ModMap.setUmbrellaDir(CurrentModule, *Umbrella, Blob, "");


### PR DESCRIPTION
…eader, and DirectoryName, NFC"

This reverts commit 32c501dd88b62787d3a5ffda7aabcf4650dbe3cd. Hit a case
where this causes a behaviour change, perhaps the same root cause that
triggered the revert of a40db5502b2515a6f2f1676b5d7a655ae0f41179 in
7799ef7121aa7d59f4bd95cdf70035de724ead6f.

https://reviews.llvm.org/D90497#2582166

Conflicts:
	clang/include/clang/Basic/Module.h
	clang/include/clang/Lex/ModuleMap.h
	clang/lib/Basic/Module.cpp
	clang/lib/Frontend/FrontendActions.cpp
	clang/lib/Lex/ModuleMap.cpp
	clang/lib/Serialization/ASTReader.cpp

Conflicts due to out-of-tree Header::PathRelativeToRootModuleDirectory.