### PR TITLE
[lldb] Add deref support and tests to shared_ptr synthetic

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.h
@@ -105,10 +105,6 @@ public:
 
 private:
   ValueObject *m_cntrl;
-  lldb::ValueObjectSP m_count_sp;
-  lldb::ValueObjectSP m_weak_count_sp;
-  uint8_t m_ptr_size;
-  lldb::ByteOrder m_byte_order;
 };
 
 class LibcxxUniquePtrSyntheticFrontEnd : public SyntheticChildrenFrontEnd {

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/shared_ptr/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/shared_ptr/Makefile
@@ -1,0 +1,6 @@
+CXX_SOURCES := main.cpp
+
+USE_LIBCPP := 1
+
+CXXFLAGS_EXTRAS := -std=c++14
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/shared_ptr/TestDataFormatterLibcxxSharedPtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/shared_ptr/TestDataFormatterLibcxxSharedPtr.py
@@ -1,0 +1,88 @@
+"""
+Test lldb data formatter for libc++ std::shared_ptr.
+"""
+
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @add_test_categories(["libc++"])
+    def test_shared_ptr_variables(self):
+        """Test `frame variable` output for `std::shared_ptr` types."""
+        self.build()
+
+        lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.cpp")
+        )
+
+        valobj = self.expect_var_path(
+            "sp_empty",
+            type="std::shared_ptr<int>",
+            summary="nullptr",
+            children=[ValueCheck(name="__ptr_")],
+        )
+        self.assertEqual(
+            valobj.child[0].GetValueAsUnsigned(lldb.LLDB_INVALID_ADDRESS), 0
+        )
+
+        self.expect(
+            "frame variable *sp_empty", substrs=["(int) *sp_empty = <parent is NULL>"]
+        )
+
+        valobj = self.expect_var_path(
+            "sp_int",
+            type="std::shared_ptr<int>",
+            children=[ValueCheck(name="__ptr_")],
+        )
+        self.assertRegex(valobj.summary, r"^10( strong=1)? weak=1$")
+        self.assertNotEqual(valobj.child[0].unsigned, 0)
+
+        valobj = self.expect_var_path(
+            "sp_int_ref",
+            type="std::shared_ptr<int> &",
+            children=[ValueCheck(name="__ptr_")],
+        )
+        self.assertRegex(valobj.summary, r"^10( strong=1)? weak=1$")
+        self.assertNotEqual(valobj.child[0].unsigned, 0)
+
+        valobj = self.expect_var_path(
+            "sp_int_ref_ref",
+            type="std::shared_ptr<int> &&",
+            children=[ValueCheck(name="__ptr_")],
+        )
+        self.assertRegex(valobj.summary, r"^10( strong=1)? weak=1$")
+        self.assertNotEqual(valobj.child[0].unsigned, 0)
+
+        valobj = self.expect_var_path(
+            "sp_str",
+            type="std::shared_ptr<std::basic_string<char, std::char_traits<char>, std::allocator<char> > >",
+            children=[ValueCheck(name="__ptr_", summary='"hello"')],
+        )
+        self.assertRegex(valobj.summary, r'^"hello"( strong=1)? weak=1$')
+
+        valobj = self.expect_var_path("sp_user", type="std::shared_ptr<User>")
+        self.assertRegex(
+            valobj.summary,
+            "^std(::__1)?::shared_ptr<User>::element_type @ 0x0*[1-9a-f][0-9a-f]+( strong=1)? weak=1",
+        )
+        self.assertNotEqual(valobj.child[0].unsigned, 0)
+
+        valobj = self.expect_var_path(
+            "*sp_user",
+            type="User",
+            children=[
+                ValueCheck(name="id", value="30"),
+                ValueCheck(name="name", summary='"steph"'),
+            ],
+        )
+        self.assertEqual(str(valobj), '(User) *__ptr_ = (id = 30, name = "steph")')
+
+        self.expect_var_path("sp_user->id", type="int", value="30")
+        self.expect_var_path("sp_user->name", type="std::string", summary='"steph"')

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/shared_ptr/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/shared_ptr/main.cpp
@@ -1,0 +1,18 @@
+#include <memory>
+#include <string>
+
+struct User {
+  int id = 30;
+  std::string name = "steph";
+};
+
+int main() {
+  std::shared_ptr<int> sp_empty;
+  std::shared_ptr<int> sp_int = std::make_shared<int>(10);
+  std::shared_ptr<std::string> sp_str = std::make_shared<std::string>("hello");
+  std::shared_ptr<int> &sp_int_ref = sp_int;
+  std::shared_ptr<int> &&sp_int_ref_ref = std::make_shared<int>(10);
+  std::shared_ptr<User> sp_user = std::make_shared<User>();
+
+  return 0; // break here
+}


### PR DESCRIPTION
Add `frame variable` dereference suppport to libc++ `std::shared_ptr`.

This change allows for commands like `v *thing_sp` and `v thing_sp->m_id`. These
commands now work the same way they do with raw pointers. This is done by adding an
unaccounted for child member named `$$dereference$$`.

Also, add API tests for `std::shared_ptr`, previously there were none.

Differential Revision: https://reviews.llvm.org/D97165

(cherry picked from commit 0ac42fd26d738b2d7b2811fc995bd7cacf994144)