### PR TITLE
Recommit: SwiftAsync: switch back to normally callee-saved register for context

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64CallingConvention.td
+++ b/llvm/lib/Target/AArch64/AArch64CallingConvention.td
@@ -69,8 +69,9 @@ def CC_AArch64_AAPCS : CallingConv<[
   // A SwiftError is passed in X21.
   CCIfSwiftError<CCIfType<[i64], CCAssignToRegWithShadow<[X21], [W21]>>>,
 
-  // Pass SwiftAsync in a callee saved register.
-  CCIfSwiftAsync<CCIfType<[i64], CCAssignToRegWithShadow<[X9], [W9]>>>,
+  // Pass SwiftAsync in an otherwise callee saved register so that it will be
+  // preserved for normal function calls.
+  CCIfSwiftAsync<CCIfType<[i64], CCAssignToRegWithShadow<[X22], [W22]>>>,
 
   CCIfConsecutiveRegs<CCCustom<"CC_AArch64_Custom_Block">>,
 
@@ -205,8 +206,9 @@ def CC_AArch64_DarwinPCS : CallingConv<[
   // A SwiftError is passed in X21.
   CCIfSwiftError<CCIfType<[i64], CCAssignToRegWithShadow<[X21], [W21]>>>,
 
-  // Pass SwiftAsync in a callee saved register.
-  CCIfSwiftAsync<CCIfType<[i64], CCAssignToRegWithShadow<[X9], [W9]>>>,
+  // Pass SwiftAsync in an otherwise callee saved register so that it will be
+  // preserved for normal function calls.
+  CCIfSwiftAsync<CCIfType<[i64], CCAssignToRegWithShadow<[X22], [W22]>>>,
 
   CCIfConsecutiveRegs<CCCustom<"CC_AArch64_Custom_Block">>,
 
@@ -418,6 +420,9 @@ def CSR_AArch64_SVE_AAPCS : CalleeSavedRegs<(add (sequence "Z%u", 8, 23),
                                                  X19, X20, X21, X22, X23, X24,
                                                  X25, X26, X27, X28, LR, FP)>;
 
+def CSR_AArch64_AAPCS_SwiftAsync
+    : CalleeSavedRegs<(sub CSR_AArch64_AAPCS, X22)>;
+
 // Constructors and destructors return 'this' in the iOS 64-bit C++ ABI; since
 // 'this' and the pointer return value are both passed in X0 in these cases,
 // this can be partially modelled by treating X0 as a callee-saved register;
@@ -469,6 +474,9 @@ def CSR_Darwin_AArch64_AAPCS_ThisReturn
 
 def CSR_Darwin_AArch64_AAPCS_SwiftError
     : CalleeSavedRegs<(sub CSR_Darwin_AArch64_AAPCS, X21)>;
+
+def CSR_Darwin_AArch64_AAPCS_SwiftAsync
+    : CalleeSavedRegs<(sub CSR_Darwin_AArch64_AAPCS, X22)>;
 
 // The function used by Darwin to obtain the address of a thread-local variable
 // guarantees more than a normal AAPCS function. x16 and x17 are used on the

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
@@ -100,6 +100,10 @@ AArch64RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
       MF->getFunction().getAttributes().hasAttrSomewhere(
           Attribute::SwiftError))
     return CSR_AArch64_AAPCS_SwiftError_SaveList;
+  if (MF->getFunction().getAttributes().hasAttrSomewhere(
+          Attribute::SwiftAsync) ||
+      MF->getFunction().getCallingConv() == CallingConv::SwiftTail)
+    return CSR_AArch64_AAPCS_SwiftAsync_SaveList;
   if (MF->getFunction().getCallingConv() == CallingConv::PreserveMost)
     return CSR_AArch64_RT_MostRegs_SaveList;
   if (MF->getFunction().getCallingConv() == CallingConv::Win64)
@@ -134,6 +138,10 @@ AArch64RegisterInfo::getDarwinCalleeSavedRegs(const MachineFunction *MF) const {
       MF->getFunction().getAttributes().hasAttrSomewhere(
           Attribute::SwiftError))
     return CSR_Darwin_AArch64_AAPCS_SwiftError_SaveList;
+  if (MF->getFunction().getAttributes().hasAttrSomewhere(
+          Attribute::SwiftAsync) ||
+      MF->getFunction().getCallingConv() == CallingConv::SwiftTail)
+    return CSR_Darwin_AArch64_AAPCS_SwiftAsync_SaveList;
   if (MF->getFunction().getCallingConv() == CallingConv::PreserveMost)
     return CSR_Darwin_AArch64_RT_MostRegs_SaveList;
   return CSR_Darwin_AArch64_AAPCS_SaveList;
@@ -199,6 +207,10 @@ AArch64RegisterInfo::getDarwinCallPreservedMask(const MachineFunction &MF,
           ->supportSwiftError() &&
       MF.getFunction().getAttributes().hasAttrSomewhere(Attribute::SwiftError))
     return CSR_Darwin_AArch64_AAPCS_SwiftError_RegMask;
+  if (MF.getFunction().getAttributes().hasAttrSomewhere(
+          Attribute::SwiftAsync) ||
+      MF.getFunction().getCallingConv() == CallingConv::SwiftTail)
+    return CSR_Darwin_AArch64_AAPCS_SwiftAsync_RegMask;
   if (CC == CallingConv::PreserveMost)
     return CSR_Darwin_AArch64_RT_MostRegs_RegMask;
   return CSR_Darwin_AArch64_AAPCS_RegMask;
@@ -233,6 +245,13 @@ AArch64RegisterInfo::getCallPreservedMask(const MachineFunction &MF,
       MF.getFunction().getAttributes().hasAttrSomewhere(Attribute::SwiftError))
     return SCS ? CSR_AArch64_AAPCS_SwiftError_SCS_RegMask
                : CSR_AArch64_AAPCS_SwiftError_RegMask;
+  if (MF.getFunction().getAttributes().hasAttrSomewhere(
+          Attribute::SwiftAsync) ||
+      MF.getFunction().getCallingConv() == CallingConv::SwiftTail) {
+    if (SCS)
+      report_fatal_error("ShadowCallStack attribute not supported with swiftasync");
+    return CSR_AArch64_AAPCS_SwiftAsync_RegMask;
+  }
   if (CC == CallingConv::PreserveMost)
     return SCS ? CSR_AArch64_RT_MostRegs_SCS_RegMask
                : CSR_AArch64_RT_MostRegs_RegMask;

--- a/llvm/lib/Target/X86/X86CallingConv.td
+++ b/llvm/lib/Target/X86/X86CallingConv.td
@@ -518,8 +518,9 @@ def CC_X86_64_C : CallingConv<[
   // A SwiftError is passed in R12.
   CCIfSwiftError<CCIfType<[i64], CCAssignToReg<[R12]>>>,
 
-  // Pass SwiftSelf in a callee saved register.
-  CCIfSwiftAsync<CCIfType<[i64], CCAssignToReg<[R11]>>>,
+  // Pass SwiftAsync in an otherwise callee saved register so that calls to
+  // normal functions don't need to save it somewhere.
+  CCIfSwiftAsync<CCIfType<[i64], CCAssignToReg<[R14]>>>,
 
   // For Swift Calling Conventions, pass sret in %rax.
   CCIfCC<"CallingConv::Swift",
@@ -1083,6 +1084,7 @@ def CSR_32 : CalleeSavedRegs<(add ESI, EDI, EBX, EBP)>;
 def CSR_64 : CalleeSavedRegs<(add RBX, R12, R13, R14, R15, RBP)>;
 
 def CSR_64_SwiftError : CalleeSavedRegs<(sub CSR_64, R12)>;
+def CSR_64_SwiftAsync : CalleeSavedRegs<(sub CSR_64, R14)>;
 
 def CSR_32EHRet : CalleeSavedRegs<(add EAX, EDX, CSR_32)>;
 def CSR_64EHRet : CalleeSavedRegs<(add RAX, RDX, CSR_64)>;
@@ -1093,6 +1095,7 @@ def CSR_Win64 : CalleeSavedRegs<(add CSR_Win64_NoSSE,
                                      (sequence "XMM%u", 6, 15))>;
 
 def CSR_Win64_SwiftError : CalleeSavedRegs<(sub CSR_Win64, R12)>;
+def CSR_Win64_SwiftAsync : CalleeSavedRegs<(sub CSR_Win64, R14)>;
 
 // The function used by Darwin to obtain the address of a thread-local variable
 // uses rdi to pass a single parameter and rax for the return value. All other

--- a/llvm/lib/Target/X86/X86FrameLowering.cpp
+++ b/llvm/lib/Target/X86/X86FrameLowering.cpp
@@ -1479,7 +1479,7 @@ void X86FrameLowering::emitPrologue(MachineFunction &MF,
           // We have an initial context in r11, store it just before the frame
           // pointer.
           BuildMI(MBB, MBBI, DL, TII.get(X86::PUSH64r))
-              .addReg(X86::R11)
+              .addReg(X86::R14)
               .setMIFlag(MachineInstr::FrameSetup);
         } else {
           // No initial context, store null so that there's no pointer that

--- a/llvm/lib/Target/X86/X86RegisterInfo.cpp
+++ b/llvm/lib/Target/X86/X86RegisterInfo.cpp
@@ -382,6 +382,11 @@ X86RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
       return IsWin64 ? CSR_Win64_SwiftError_SaveList
                      : CSR_64_SwiftError_SaveList;
 
+    if (F.getAttributes().hasAttrSomewhere(Attribute::SwiftAsync) ||
+        F.getCallingConv() == CallingConv::SwiftTail)
+      return IsWin64 ? CSR_Win64_SwiftError_SaveList
+                     : CSR_64_SwiftAsync_SaveList;
+
     if (IsWin64)
       return HasSSE ? CSR_Win64_SaveList : CSR_Win64_NoSSE_SaveList;
     if (CallsEHReturn)
@@ -497,6 +502,11 @@ X86RegisterInfo::getCallPreservedMask(const MachineFunction &MF,
                      F.getAttributes().hasAttrSomewhere(Attribute::SwiftError);
     if (IsSwiftCC)
       return IsWin64 ? CSR_Win64_SwiftError_RegMask : CSR_64_SwiftError_RegMask;
+
+    if (F.getAttributes().hasAttrSomewhere(Attribute::SwiftAsync) ||
+        F.getCallingConv() == CallingConv::SwiftTail)
+      return IsWin64 ? CSR_Win64_SwiftAsync_RegMask : CSR_64_SwiftAsync_RegMask;
+
     return IsWin64 ? CSR_Win64_RegMask : CSR_64_RegMask;
   }
 

--- a/llvm/test/CodeGen/AArch64/swift-async-reg.ll
+++ b/llvm/test/CodeGen/AArch64/swift-async-reg.ll
@@ -4,14 +4,14 @@
 
 define i8* @argument(i8* swiftasync %in) {
 ; CHECK-LABEL: argument:
-; CHECK: mov x0, x9
+; CHECK: mov x0, x22
 
   ret i8* %in
 }
 
 define void @call(i8* %in) {
 ; CHECK-LABEL: call:
-; CHECK: mov x9, x0
+; CHECK: mov x22, x0
 
   call i8* @argument(i8* swiftasync %in)
   ret void

--- a/llvm/test/CodeGen/AArch64/swift-async.ll
+++ b/llvm/test/CodeGen/AArch64/swift-async.ll
@@ -3,7 +3,7 @@
 ; RUN: llc -mtriple=arm64e-apple-ios %s -o - | FileCheck %s --check-prefixes=CHECK-AUTH,CHECK
 
 ; Important details in prologue:
-;   * x9 is stored just below x29
+;   * x22 is stored just below x29
 ;   * Enough stack space is allocated for everything
 define void @simple(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK-LABEL: simple:
@@ -11,10 +11,10 @@ define void @simple(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK: sub sp, sp, #32
 ; CHECK: stp x29, x30, [sp, #16]
 
-; CHECK-NOAUTH: str x9, [sp, #8]
+; CHECK-NOAUTH: str x22, [sp, #8]
 ; CHECK-AUTH: add x16, sp, #8
 ; CHECK-AUTH: movk x16, #49946, lsl #48
-; CHECK-AUTH: mov x17, x9
+; CHECK-AUTH: mov x17, x22
 ; CHECK-AUTH: pacdb x17, x16
 ; CHECK-AUTH: str x17, [sp, #8]
 
@@ -35,30 +35,27 @@ define void @simple(i8* swiftasync %ctx) "frame-pointer"="all" {
 define void @more_csrs(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK-LABEL: more_csrs:
 ; CHECK: orr x29, x29, #0x100000000000000
-; CHECK: sub sp, sp, #48
-; CHECK: stp x24, x23, [sp, #8]
-; CHECK: stp x29, x30, [sp, #32]
+; CHECK: str x23, [sp, #-32]!
+; CHECK: stp x29, x30, [sp, #16]
 
-; CHECK-NOAUTH: str x9, [sp, #24]
-; CHECK-AUTH: add x16, sp, #24
+; CHECK-NOAUTH: str x22, [sp, #8]
+; CHECK-AUTH: add x16, sp, #8
 ; CHECK-AUTH: movk x16, #49946, lsl #48
-; CHECK-AUTH: mov x17, x9
+; CHECK-AUTH: mov x17, x22
 ; CHECK-AUTH: pacdb x17, x16
-; CHECK-AUTH: str x17, [sp, #24]
+; CHECK-AUTH: str x17, [sp, #8]
 
-; CHECK: add x29, sp, #32
+; CHECK: add x29, sp, #16
 ; CHECK: .cfi_def_cfa w29, 16
 ; CHECK: .cfi_offset w30, -8
 ; CHECK: .cfi_offset w29, -16
 ; CHECK: .cfi_offset w23, -32
-; CHECK: .cfi_offset w24, -40
 
 ; [...]
 
-; CHECK: ldp x29, x30, [sp, #32]
-; CHECK: ldp x24, x23, [sp, #8]
+; CHECK: ldp x29, x30, [sp, #16]
+; CHECK: ldr x23, [sp], #32
 ; CHECK: and x29, x29, #0xefffffffffffffff
-; CHECK: add sp, sp, #48
   call void asm sideeffect "", "~{x23}"()
   ret void
 }
@@ -69,10 +66,10 @@ define void @locals(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK: sub sp, sp, #64
 ; CHECK: stp x29, x30, [sp, #48]
 
-; CHECK-NOAUTH: str x9, [sp, #40]
+; CHECK-NOAUTH: str x22, [sp, #40]
 ; CHECK-AUTH: add x16, sp, #40
 ; CHECK-AUTH: movk x16, #49946, lsl #48
-; CHECK-AUTH: mov x17, x9
+; CHECK-AUTH: mov x17, x22
 ; CHECK-AUTH: pacdb x17, x16
 ; CHECK-AUTH: str x17, [sp, #40]
 
@@ -97,11 +94,11 @@ define void @locals(i8* swiftasync %ctx) "frame-pointer"="all" {
 define void @use_input_context(i8* swiftasync %ctx, i8** %ptr) "frame-pointer"="all" {
 ; CHECK-LABEL: use_input_context:
 
-; CHECK-NOAUTH: str x9, [sp
-; CHECK-AUTH: mov x17, x9
+; CHECK-NOAUTH: str x22, [sp
+; CHECK-AUTH: mov x17, x22
 
-; CHECK-NOT: x9
-; CHECK: str x9, [x0]
+; CHECK-NOT: x22
+; CHECK: str x22, [x0]
 
   store i8* %ctx, i8** %ptr
   ret void
@@ -139,21 +136,39 @@ define void @simple_fp_elim(i8* swiftasync %ctx) "frame-pointer"="non-leaf" {
 
 define void @large_frame(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK-LABEL: large_frame:
-; CHECK: sub sp, sp, #48
-; CHECK: stp x28, x27, [sp, #8]
-; CHECK: stp x29, x30, [sp, #32]
-; CHECK-NOAUTH: str x9, [sp, #24]
-; CHECK: add x29, sp, #32
+; CHECK: str x28, [sp, #-32]!
+; CHECK: stp x29, x30, [sp, #16]
+; CHECK-NOAUTH: str x22, [sp, #8]
+; CHECK: add x29, sp, #16
 ; CHECK: sub sp, sp, #1024
 ; [...]
 ; CHECK: add sp, sp, #1024
-; CHECK: ldp x29, x30, [sp, #32]
-; CHECK: ldp x28, x27, [sp, #8]
-; CHECK: add sp, sp, #48
+; CHECK: ldp x29, x30, [sp, #16]
+; CHECK: ldr x28, [sp], #32
 ; CHECK: ret
   %var = alloca i8, i32 1024
   ret void
 }
 
+; Important point is that there is just one 8-byte gap in the CSR region (right
+; now just above d8) to realign the stack.
+define void @two_unpaired_csrs(i8* swiftasync) "frame-pointer"="all" {
+; CHECK-LABEL: two_unpaired_csrs:
+; CHECK: str d8, [sp, #-48]!
+; CHECK: str x19, [sp, #16]
+; CHECK: stp x29, x30, [sp, #32]
+; CHECK-NOAUTH: str x22, [sp, #24]
+; CHECK: add x29, sp, #32
+
+; CHECK: .cfi_def_cfa w29, 16
+; CHECK: .cfi_offset w30, -8
+; CHECK: .cfi_offset w29, -16
+; CHECK: .cfi_offset w19, -32
+; CHECK: .cfi_offset b8, -48
+
+  call void asm "","~{x19},~{d8}"()
+  call void @bar(i32* undef)
+  ret void
+}
 declare void @bar(i32*)
 declare i8** @llvm.swift.async.context.addr()

--- a/llvm/test/CodeGen/AArch64/swifttail-async.ll
+++ b/llvm/test/CodeGen/AArch64/swifttail-async.ll
@@ -1,0 +1,29 @@
+; RUN: llc -mtriple=arm64-apple-ios %s -o - | FileCheck %s
+
+
+declare swifttailcc void @swifttail_callee()
+define swifttailcc void @swifttail() {
+; CHECK-LABEL: swifttail:
+; CHECK-NOT: ld{{.*}}x22
+  call void asm "","~{x22}"()
+  tail call swifttailcc void @swifttail_callee()
+  ret void
+}
+
+define void @has_swiftasync(i8* swiftasync %in) {
+; CHECK-LABEL: has_swiftasync:
+; CHECK-NOT: ld{{.*}}x22
+  call void asm "","~{x22}"()
+  ret void
+}
+
+; It's impossible to get a tail call from a function without a swiftasync
+; parameter to one with unless the CC is swifttailcc. So it doesn't matter
+; whether x22 is callee-saved in this case.
+define void @calls_swiftasync() {
+; CHECK-LABEL: calls_swiftasync:
+; CHECK-NOT: b _has_swiftasync
+  call void asm "","~{x22}"()
+  tail call void @has_swiftasync(i8* swiftasync null)
+  ret void
+}

--- a/llvm/test/CodeGen/X86/swift-async-reg.ll
+++ b/llvm/test/CodeGen/X86/swift-async-reg.ll
@@ -3,14 +3,14 @@
 
 define i8* @argument(i8* swiftasync %in) {
 ; CHECK-LABEL: argument:
-; CHECK: movq %r11, %rax
+; CHECK: movq %r14, %rax
 
   ret i8* %in
 }
 
 define void @call(i8* %in) {
 ; CHECK-LABEL: call:
-; CHECK: movq %rdi, %r11
+; CHECK: movq %rdi, %r14
 
   call i8* @argument(i8* swiftasync %in)
   ret void

--- a/llvm/test/CodeGen/X86/swift-async.ll
+++ b/llvm/test/CodeGen/X86/swift-async.ll
@@ -6,7 +6,7 @@ define void @simple(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK-LABEL: simple:
 ; CHECK: btsq    $60, %rbp
 ; CHECK: pushq   %rbp
-; CHECK: pushq   %r11
+; CHECK: pushq   %r14
 ; CHECK: leaq    8(%rsp), %rbp
 ; CHECK: pushq
 ; [...]
@@ -28,7 +28,7 @@ define void @more_csrs(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK: btsq    $60, %rbp
 ; CHECK: pushq   %rbp
 ; CHECK: .cfi_offset %rbp, -16
-; CHECK: pushq   %r11
+; CHECK: pushq   %r14
 ; CHECK: leaq    8(%rsp), %rbp
 ; CHECK: subq    $8, %rsp
 ; CHECK: pushq   %r15
@@ -51,7 +51,7 @@ define void @locals(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK: pushq   %rbp
 ; CHECK: .cfi_def_cfa_offset 16
 ; CHECK: .cfi_offset %rbp, -16
-; CHECK: pushq   %r11
+; CHECK: pushq   %r14
 ; CHECK: leaq    8(%rsp), %rbp
 ; CHECK: .cfi_def_cfa_register %rbp
 ; CHECK: subq    $56, %rsp
@@ -72,7 +72,7 @@ define void @locals(i8* swiftasync %ctx) "frame-pointer"="all" {
 
 define void @use_input_context(i8* swiftasync %ctx, i8** %ptr) "frame-pointer"="all" {
 ; CHECK-LABEL: use_input_context:
-; CHECK: movq    %r11, (%rdi)
+; CHECK: movq    %r14, (%rdi)
 
   store i8* %ctx, i8** %ptr
   ret void

--- a/llvm/test/CodeGen/X86/swifttail-async.ll
+++ b/llvm/test/CodeGen/X86/swifttail-async.ll
@@ -1,0 +1,29 @@
+; RUN: llc -mtriple=x86_64-apple-darwin %s -o - | FileCheck %s
+
+
+declare swifttailcc void @swifttail_callee()
+define swifttailcc void @swifttail() {
+; CHECK-LABEL: swifttail:
+; CHECK-NOT: popq %r14
+  call void asm "","~{r14}"()
+  tail call swifttailcc void @swifttail_callee()
+  ret void
+}
+
+define void @has_swiftasync(i8* swiftasync %in) {
+; CHECK-LABEL: has_swiftasync:
+; CHECK-NOT: popq %r14
+  call void asm "","~{r14}"()
+  ret void
+}
+
+; It's impossible to get a tail call from a function without a swiftasync
+; parameter to one with unless the CC is swifttailcc. So it doesn't matter
+; whether r14 is callee-saved in this case.
+define void @calls_swiftasync() {
+; CHECK-LABEL: calls_swiftasync:
+; CHECK-NOT: jmpq _has_swiftasync
+  call void asm "","~{r14}"()
+  tail call void @has_swiftasync(i8* swiftasync null)
+  ret void
+}


### PR DESCRIPTION
We prefer a callee-saved register so that the context doesn't have to be moved into one whenever a swiftasync function makes a call to a normal one.

Also, the previous r11 on x86 is the linker scratch register, which isn't good.

Recommit info:

  * There was a bug in AArch64FrameLowering that caused a build-time crash on some arm64_32 bots. That's fixed in this version.
  * Execution time tests took a while to work through stale build-artefacts since this is an ABI change, causing transitional failures. These will probably happen again but should sort themselves out eventually.