### PR TITLE
[lldb][swift] Fix use after free in SwiftDWARFImporterDelegate::importType

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -56,6 +56,7 @@
 #include "swift/Serialization/Validation.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/DeclObjC.h"
+#include "clang/Basic/SourceManager.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Basic/TargetOptions.h"
 #include "clang/Driver/Driver.h"
@@ -3055,10 +3056,10 @@ class SwiftDWARFImporterDelegate : public swift::DWARFImporterDelegate {
                   clang::ASTContext &to_ctx,
                   llvm::Optional<swift::ClangTypeKind> kind,
                   llvm::SmallVectorImpl<clang::Decl *> &results) {
-    clang::FileSystemOptions file_system_options;
-    clang::FileManager file_manager(
-        file_system_options, FileSystem::Instance().GetVirtualFileSystem());
-    clang::ASTImporter importer(to_ctx, file_manager, from_ctx, file_manager,
+    clang::ASTImporter importer(to_ctx,
+                                to_ctx.getSourceManager().getFileManager(),
+                                from_ctx,
+                                from_ctx.getSourceManager().getFileManager(),
                                 false);
     llvm::Expected<clang::QualType> clang_type(importer.Import(qual_type));
     if (!clang_type) {


### PR DESCRIPTION
The FileManager stores the names of the file entries. When importing any
Decl in this method we end up storing the file name in the temporary FileManager
that we delete at the end of the method.
Once we try to import a second type and we run into an ASTImporter error,
Clang will try to print a diagnostic and use the file name that was stored
in the already free'd FileManager from the previous `importType` call.

Fixes the crash in rdar://73587632