### PR TITLE
[lldb] Fix #if to #ifdef in Driver (NFC)

### DIFF
--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -824,7 +824,7 @@ llvm::Optional<int> InitializeReproducer(llvm::StringRef argv0,
   }
 
   // BEGIN SWIFT
-#if TARGET_OS_IPHONE
+#ifdef TARGET_OS_IPHONE
   bool capture = input_args.hasArg(OPT_capture);
 #else
   bool capture = true;


### PR DESCRIPTION
This resolves the below compilation error, as triggered by `-Wundef-prefix=TARGET_OS_`.

```
swift-project/llvm-project/lldb/tools/driver/Driver.cpp:827:5: error: 'TARGET_OS_IPHONE' is not defined, evaluates to 0 [-Werror,-Wundef-prefix=TARGET_OS_]
#if TARGET_OS_IPHONE
    ^
1 error generated.
```