### PR TITLE
[lldb/Core] Change large function threshold variable into a setting.

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -246,6 +246,8 @@ public:
 
   const FormatEntity::Entry *GetFrameFormatUnique() const;
 
+  uint32_t GetStopDisassemblyMaxSize() const;
+
   const FormatEntity::Entry *GetThreadFormat() const;
 
   const FormatEntity::Entry *GetThreadStopFormat() const;

--- a/lldb/source/Commands/CommandObjectDisassemble.cpp
+++ b/lldb/source/Commands/CommandObjectDisassemble.cpp
@@ -23,7 +23,6 @@
 
 static constexpr unsigned default_disasm_byte_size = 32;
 static constexpr unsigned default_disasm_num_ins = 4;
-static constexpr unsigned large_function_threshold = 8000;
 
 using namespace lldb;
 using namespace lldb_private;
@@ -223,7 +222,7 @@ CommandObjectDisassemble::~CommandObjectDisassemble() = default;
 llvm::Error CommandObjectDisassemble::CheckRangeSize(const AddressRange &range,
                                                      llvm::StringRef what) {
   if (m_options.num_instructions > 0 || m_options.force ||
-      range.GetByteSize() < large_function_threshold)
+      range.GetByteSize() < GetDebugger().GetStopDisassemblyMaxSize())
     return llvm::Error::success();
   StreamString msg;
   msg << "Not disassembling " << what << " because it is very large ";

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -51,6 +51,10 @@ let Definition = "debugger" in {
     DefaultEnumValue<"Debugger::eStopDisassemblyTypeNoDebugInfo">,
     EnumValues<"OptionEnumValues(g_show_disassembly_enum_values)">,
     Desc<"Control when to display disassembly when displaying a stopped context.">;
+  def StopDisassemblyMaxSize: Property<"stop-disassembly-max-size", "UInt64">,
+    Global,
+    DefaultUnsignedValue<32000>,
+    Desc<"The size limit to use when disassembling large functions (default: 32KB).">;
   def StopLineCountAfter: Property<"stop-line-count-after", "SInt64">,
     Global,
     DefaultUnsignedValue<3>,

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -258,6 +258,12 @@ const FormatEntity::Entry *Debugger::GetFrameFormatUnique() const {
   return m_collection_sp->GetPropertyAtIndexAsFormatEntity(nullptr, idx);
 }
 
+uint32_t Debugger::GetStopDisassemblyMaxSize() const {
+  const uint32_t idx = ePropertyStopDisassemblyMaxSize;
+  return m_collection_sp->GetPropertyAtIndexAsUInt64(
+      nullptr, idx, g_debugger_properties[idx].default_uint_value);
+}
+
 bool Debugger::GetNotifyVoid() const {
   const uint32_t idx = ePropertyNotiftVoid;
   return m_collection_sp->GetPropertyAtIndexAsBoolean(

--- a/lldb/test/Shell/Commands/command-disassemble-process.yaml
+++ b/lldb/test/Shell/Commands/command-disassemble-process.yaml
@@ -10,6 +10,7 @@
 # RUN:   | FileCheck %s
 
 # RUN: %lldb -c %t %T/command-disassemble-process.big.exe \
+# RUN:   -o "settings set stop-disassembly-max-size 8000" \
 # RUN:   -o disassemble -o exit 2>&1 | FileCheck %s --check-prefix=BIG
 
 # CHECK:       (lldb) disassemble

--- a/lldb/test/Shell/Commands/command-disassemble.s
+++ b/lldb/test/Shell/Commands/command-disassemble.s
@@ -2,6 +2,7 @@
 
 # RUN: llvm-mc -filetype=obj -triple x86_64-pc-linux %s -o %t
 # RUN: %lldb %t -o "settings set interpreter.stop-command-source-on-error false" \
+# RUN:   -o "settings set stop-disassembly-max-size 8000" \
 # RUN:   -s %S/Inputs/command-disassemble.lldbinit -o exit 2>&1 | FileCheck %s
 
 # CHECK:      (lldb) disassemble


### PR DESCRIPTION
This patch replaces the static large function threshold variable with a
global debugger setting (`stop-disassembly-max-size`).

The default threshold is now set to 32KB (instead of 8KB) and can be modified.

rdar://74726362

Differential Revision: https://reviews.llvm.org/D97486

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>