### PR TITLE
Don't compare results for equivalence if type reconstruction failed.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1593,6 +1593,8 @@ bool Equivalent(llvm::Optional<T> l, T r) {
     auto result = IMPL();                                                      \
     if (!m_swift_ast_context)                                                  \
       return result;                                                           \
+    if ((TYPE) && !ReconstructType(TYPE))                                      \
+      return result;                                                           \
     bool equivalent =                                                          \
         !ReconstructType(TYPE) /* missing .swiftmodule */ ||                   \
         (Equivalent(result, m_swift_ast_context->REFERENCE ARGS));             \


### PR DESCRIPTION
rdar://74880491