### PR TITLE
Don't compare results for equivalence if type reconstruction failed. …

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1592,6 +1592,8 @@ bool Equivalent(llvm::Optional<T> l, T r) {
     auto result = IMPL();                                                      \
     if (!m_swift_ast_context)                                                  \
       return result;                                                           \
+    if ((TYPE) && !ReconstructType(TYPE))                                      \
+      return result;                                                           \
     bool equivalent =                                                          \
         !ReconstructType(TYPE) /* missing .swiftmodule */ ||                   \
         (Equivalent(result, m_swift_ast_context->REFERENCE ARGS));             \


### PR DESCRIPTION
…(NFC)

rdar://74880491
(cherry picked from commit 4eb7594aef4dcfbbfd91595124c78bea65c26970)

https://github.com/apple/llvm-project/pull/2592