### PR TITLE
Promote scalars to load addresses when dereferencing them. 

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -1064,10 +1064,12 @@ bool DWARFExpression::Evaluate(
           return false;
         }
         stack.back().GetScalar() = load_Addr;
-        stack.back().SetValueType(Value::eValueTypeLoadAddress);
-        // Fall through to load address code below...
+        // Fall through to load address promotion code below.
       } LLVM_FALLTHROUGH;
       case Value::eValueTypeScalar:
+        // Promote Scalar to LoadAddress and fall through.
+        stack.back().SetValueType(Value::eValueTypeLoadAddress);
+        LLVM_FALLTHROUGH;
       case Value::eValueTypeLoadAddress:
         if (exe_ctx) {
           if (process) {

--- a/lldb/unittests/Expression/DWARFExpressionTest.cpp
+++ b/lldb/unittests/Expression/DWARFExpressionTest.cpp
@@ -41,6 +41,8 @@ static llvm::Expected<Scalar> Evaluate(llvm::ArrayRef<uint8_t> expr,
   switch (result.GetValueType()) {
   case Value::eValueTypeScalar:
     return result.GetScalar();
+  case Value::eValueTypeLoadAddress:
+    return LLDB_INVALID_ADDRESS;
   case Value::eValueTypeHostAddress: {
     // Convert small buffers to scalars to simplify the tests.
     DataBufferHeap &buf = result.GetBuffer();
@@ -344,6 +346,12 @@ TEST_F(DWARFExpressionMockProcessTest, DW_OP_deref) {
   ASSERT_TRUE(process_sp);
 
   ExecutionContext exe_ctx(process_sp);
-  EXPECT_THAT_EXPECTED(Evaluate({DW_OP_lit4, DW_OP_deref}, {}, {}, &exe_ctx),
+  // Implicit location: *0x4.
+  EXPECT_THAT_EXPECTED(Evaluate({DW_OP_lit4, DW_OP_deref, DW_OP_stack_value},
+                                {}, {}, &exe_ctx),
                        llvm::HasValue(GetScalar(32, 0x07060504, false)));
+  // Memory location: *(*0x4).
+  // Evaluate returns LLDB_INVALID_ADDRESS for all load addresses.
+  EXPECT_THAT_EXPECTED(Evaluate({DW_OP_lit4, DW_OP_deref}, {}, {}, &exe_ctx),
+                       llvm::HasValue(Scalar(LLDB_INVALID_ADDRESS)));
 }


### PR DESCRIPTION
This is a follow-up to 188b0747c1664d962e94f00b5e3caac529fa1e26. This
is a very narrow fix to a more general problem. LLDB should be better
at distinguishing between implict and memory location descriptions.

rdar://74902042
(cherry picked from commit 14ccba26bd4d4f78cf5ec2ca8bb55c95913a3ec5)

 Conflicts:
	lldb/source/Expression/DWARFExpression.cpp
	lldb/unittests/Expression/DWARFExpressionTest.cpp