### PR TITLE
[lldb] Fix swift::Demangle namespace use

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
@@ -15,7 +15,6 @@
 
 #include "swift/ABI/Task.h"
 #include "swift/Demangling/Demangle.h"
-#include "swift/Demangling/Demangler.h"
 #include "lldb/Symbol/Block.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/VariableList.h"
@@ -54,20 +53,21 @@ enum class ThunkAction {
 
 } // namespace
 
-static NodePointer
-childAtPath(NodePointer node,
+static swift::Demangle::NodePointer
+childAtPath(swift::Demangle::NodePointer node,
             llvm::ArrayRef<swift::Demangle::Node::Kind> path) {
   if (path.empty())
     return node;
 
   auto current_step = path.front();
-  for (NodePointer child : *node)
+  for (auto *child : *node)
     if (child->getKind() == current_step)
       return childAtPath(child, path.drop_front());
   return nullptr;
 }
 
-static bool hasChild(NodePointer node, swift::Demangle::Node::Kind kind) {
+static bool hasChild(swift::Demangle::NodePointer node,
+                     swift::Demangle::Node::Kind kind) {
   return childAtPath(node, {kind});
 }
 


### PR DESCRIPTION
`swift/Demangling/Demangler.h` contains `using namespace swift::Demangler` ([link]( https://github.com/apple/swift/blob/f1e532cf9265524268856fbfb1c0eca583a7182a/include/swift/Demangling/Demangler.h#L27)).

This allowed some lldb code to depend on that. This change fixes things by either by referencing the `swift::Demangle` namespace, by using `auto`, or by adding a missing `using namespace swift::Demangle`.