### PR TITLE
[lldb/Interpreter] Make OptionGroupPythonClassWithDict options non-required

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandHistory.h
+++ b/lldb/include/lldb/Interpreter/CommandHistory.h
@@ -20,9 +20,9 @@ namespace lldb_private {
 
 class CommandHistory {
 public:
-  CommandHistory();
+  CommandHistory() = default;
 
-  ~CommandHistory();
+  ~CommandHistory() = default;
 
   size_t GetSize() const;
 

--- a/lldb/include/lldb/Interpreter/CommandObject.h
+++ b/lldb/include/lldb/Interpreter/CommandObject.h
@@ -113,7 +113,7 @@ public:
     llvm::StringRef help = "", llvm::StringRef syntax = "",
                 uint32_t flags = 0);
 
-  virtual ~CommandObject();
+  virtual ~CommandObject() = default;
 
   static const char *
   GetArgumentTypeAsCString(const lldb::CommandArgumentType arg_type);

--- a/lldb/include/lldb/Interpreter/CommandReturnObject.h
+++ b/lldb/include/lldb/Interpreter/CommandReturnObject.h
@@ -26,7 +26,7 @@ class CommandReturnObject {
 public:
   CommandReturnObject(bool colors);
 
-  ~CommandReturnObject();
+  ~CommandReturnObject() = default;
 
   llvm::StringRef GetOutputData() {
     lldb::StreamSP stream_sp(m_out_stream.GetStreamAtIndex(eStreamStringIndex));

--- a/lldb/include/lldb/Interpreter/OptionGroupArchitecture.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupArchitecture.h
@@ -18,9 +18,9 @@ namespace lldb_private {
 
 class OptionGroupArchitecture : public OptionGroup {
 public:
-  OptionGroupArchitecture();
+  OptionGroupArchitecture() = default;
 
-  ~OptionGroupArchitecture() override;
+  ~OptionGroupArchitecture() override = default;
 
   llvm::ArrayRef<OptionDefinition> GetDefinitions() override;
 

--- a/lldb/include/lldb/Interpreter/OptionGroupBoolean.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupBoolean.h
@@ -33,7 +33,6 @@ public:
 
   Status SetOptionValue(uint32_t option_idx, llvm::StringRef option_value,
                         ExecutionContext *execution_context) override;
-  Status SetOptionValue(uint32_t, const char *, ExecutionContext *) = delete;
 
   void OptionParsingStarting(ExecutionContext *execution_context) override;
 

--- a/lldb/include/lldb/Interpreter/OptionGroupBoolean.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupBoolean.h
@@ -25,7 +25,7 @@ public:
                      const char *usage_text, bool default_value,
                      bool no_argument_toggle_default);
 
-  ~OptionGroupBoolean() override;
+  ~OptionGroupBoolean() override = default;
 
   llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
     return llvm::ArrayRef<OptionDefinition>(&m_option_definition, 1);

--- a/lldb/include/lldb/Interpreter/OptionGroupFile.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupFile.h
@@ -24,7 +24,7 @@ public:
                   lldb::CommandArgumentType argument_type,
                   const char *usage_text);
 
-  ~OptionGroupFile() override;
+  ~OptionGroupFile() override = default;
 
   llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
     return llvm::ArrayRef<OptionDefinition>(&m_option_definition, 1);

--- a/lldb/include/lldb/Interpreter/OptionGroupFile.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupFile.h
@@ -32,7 +32,6 @@ public:
 
   Status SetOptionValue(uint32_t option_idx, llvm::StringRef option_value,
                         ExecutionContext *execution_context) override;
-  Status SetOptionValue(uint32_t, const char *, ExecutionContext *) = delete;
 
   void OptionParsingStarting(ExecutionContext *execution_context) override;
 
@@ -63,7 +62,6 @@ public:
 
   Status SetOptionValue(uint32_t option_idx, llvm::StringRef option_value,
                         ExecutionContext *execution_context) override;
-  Status SetOptionValue(uint32_t, const char *, ExecutionContext *) = delete;
 
   void OptionParsingStarting(ExecutionContext *execution_context) override;
 

--- a/lldb/include/lldb/Interpreter/OptionGroupFormat.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupFormat.h
@@ -32,13 +32,12 @@ public:
       uint64_t default_count =
           UINT64_MAX); // Pass UINT64_MAX to disable the "--count" option
 
-  ~OptionGroupFormat() override;
+  ~OptionGroupFormat() override = default;
 
   llvm::ArrayRef<OptionDefinition> GetDefinitions() override;
 
   Status SetOptionValue(uint32_t option_idx, llvm::StringRef option_value,
                         ExecutionContext *execution_context) override;
-  Status SetOptionValue(uint32_t, const char *, ExecutionContext *) = delete;
 
   void OptionParsingStarting(ExecutionContext *execution_context) override;
 

--- a/lldb/include/lldb/Interpreter/OptionGroupOutputFile.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupOutputFile.h
@@ -20,13 +20,12 @@ class OptionGroupOutputFile : public OptionGroup {
 public:
   OptionGroupOutputFile();
 
-  ~OptionGroupOutputFile() override;
+  ~OptionGroupOutputFile() override = default;
 
   llvm::ArrayRef<OptionDefinition> GetDefinitions() override;
 
   Status SetOptionValue(uint32_t option_idx, llvm::StringRef option_value,
                         ExecutionContext *execution_context) override;
-  Status SetOptionValue(uint32_t, const char *, ExecutionContext *) = delete;
 
   void OptionParsingStarting(ExecutionContext *execution_context) override;
 

--- a/lldb/include/lldb/Interpreter/OptionGroupPythonClassWithDict.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupPythonClassWithDict.h
@@ -37,7 +37,6 @@ public:
 
   Status SetOptionValue(uint32_t option_idx, llvm::StringRef option_value,
                         ExecutionContext *execution_context) override;
-  Status SetOptionValue(uint32_t, const char *, ExecutionContext *) = delete;
 
   void OptionParsingStarting(ExecutionContext *execution_context) override;
   Status OptionParsingFinished(ExecutionContext *execution_context) override;

--- a/lldb/include/lldb/Interpreter/OptionGroupPythonClassWithDict.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupPythonClassWithDict.h
@@ -29,7 +29,7 @@ public:
                                  int key_option = 'k', 
                                  int value_option = 'v');
                       
-  ~OptionGroupPythonClassWithDict() override;
+  ~OptionGroupPythonClassWithDict() override = default;
 
   llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
     return llvm::ArrayRef<OptionDefinition>(m_option_definition);

--- a/lldb/include/lldb/Interpreter/OptionGroupPythonClassWithDict.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupPythonClassWithDict.h
@@ -1,4 +1,4 @@
-//===-- OptionGroupPythonClassWithDict.h -------------------------------------*- C++ -*-===//
+//===-- OptionGroupPythonClassWithDict.h ------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,9 +9,10 @@
 #ifndef LLDB_INTERPRETER_OPTIONGROUPPYTHONCLASSWITHDICT_H
 #define LLDB_INTERPRETER_OPTIONGROUPPYTHONCLASSWITHDICT_H
 
-#include "lldb/lldb-types.h"
 #include "lldb/Interpreter/Options.h"
+#include "lldb/Utility/Flags.h"
 #include "lldb/Utility/StructuredData.h"
+#include "lldb/lldb-types.h"
 
 namespace lldb_private {
 
@@ -23,12 +24,20 @@ namespace lldb_private {
 // StructuredData::Dictionary is constructed with those pairs.
 class OptionGroupPythonClassWithDict : public OptionGroup {
 public:
-  OptionGroupPythonClassWithDict(const char *class_use,
-                                 bool is_class = true,
-                                 int class_option = 'C',
-                                 int key_option = 'k', 
-                                 int value_option = 'v');
-                      
+  enum OptionKind {
+    eScriptClass    = 1 << 0,
+    eDictKey        = 1 << 1,
+    eDictValue      = 1 << 2,
+    ePythonFunction = 1 << 3,
+    eAllOptions     = (eScriptClass | eDictKey | eDictValue | ePythonFunction)
+  };
+
+  OptionGroupPythonClassWithDict(const char *class_use, bool is_class = true,
+                                 int class_option = 'C', int key_option = 'k',
+                                 int value_option = 'v',
+                                 uint16_t required_options = eScriptClass |
+                                                             ePythonFunction);
+
   ~OptionGroupPythonClassWithDict() override = default;
 
   llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
@@ -55,6 +64,7 @@ protected:
   std::string m_class_usage_text, m_key_usage_text, m_value_usage_text;
   bool m_is_class;
   OptionDefinition m_option_definition[4];
+  Flags m_required_options;
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Interpreter/OptionGroupString.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupString.h
@@ -22,7 +22,7 @@ public:
                     lldb::CommandArgumentType argument_type,
                     const char *usage_text, const char *default_value);
 
-  ~OptionGroupString() override;
+  ~OptionGroupString() override = default;
 
   llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
     return llvm::ArrayRef<OptionDefinition>(&m_option_definition, 1);

--- a/lldb/include/lldb/Interpreter/OptionGroupString.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupString.h
@@ -30,7 +30,6 @@ public:
 
   Status SetOptionValue(uint32_t option_idx, llvm::StringRef option_value,
                         ExecutionContext *execution_context) override;
-  Status SetOptionValue(uint32_t, const char *, ExecutionContext *) = delete;
 
   void OptionParsingStarting(ExecutionContext *execution_context) override;
 

--- a/lldb/include/lldb/Interpreter/OptionGroupUInt64.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupUInt64.h
@@ -23,7 +23,7 @@ public:
                     lldb::CommandArgumentType argument_type,
                     const char *usage_text, uint64_t default_value);
 
-  ~OptionGroupUInt64() override;
+  ~OptionGroupUInt64() override = default;
 
   llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
     return llvm::ArrayRef<OptionDefinition>(&m_option_definition, 1);

--- a/lldb/include/lldb/Interpreter/OptionGroupUInt64.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupUInt64.h
@@ -31,7 +31,6 @@ public:
 
   Status SetOptionValue(uint32_t option_idx, llvm::StringRef option_value,
                         ExecutionContext *execution_context) override;
-  Status SetOptionValue(uint32_t, const char *, ExecutionContext *) = delete;
 
   void OptionParsingStarting(ExecutionContext *execution_context) override;
 

--- a/lldb/include/lldb/Interpreter/OptionGroupUUID.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupUUID.h
@@ -26,7 +26,6 @@ public:
 
   Status SetOptionValue(uint32_t option_idx, llvm::StringRef option_value,
                         ExecutionContext *execution_context) override;
-  Status SetOptionValue(uint32_t, const char *, ExecutionContext *) = delete;
 
   void OptionParsingStarting(ExecutionContext *execution_context) override;
 

--- a/lldb/include/lldb/Interpreter/OptionGroupUUID.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupUUID.h
@@ -18,9 +18,9 @@ namespace lldb_private {
 
 class OptionGroupUUID : public OptionGroup {
 public:
-  OptionGroupUUID();
+  OptionGroupUUID() = default;
 
-  ~OptionGroupUUID() override;
+  ~OptionGroupUUID() override = default;
 
   llvm::ArrayRef<OptionDefinition> GetDefinitions() override;
 

--- a/lldb/include/lldb/Interpreter/OptionGroupValueObjectDisplay.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupValueObjectDisplay.h
@@ -26,7 +26,6 @@ public:
 
   Status SetOptionValue(uint32_t option_idx, llvm::StringRef option_value,
                         ExecutionContext *execution_context) override;
-  Status SetOptionValue(uint32_t, const char *, ExecutionContext *) = delete;
 
   void OptionParsingStarting(ExecutionContext *execution_context) override;
 

--- a/lldb/include/lldb/Interpreter/OptionGroupValueObjectDisplay.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupValueObjectDisplay.h
@@ -18,9 +18,9 @@ namespace lldb_private {
 
 class OptionGroupValueObjectDisplay : public OptionGroup {
 public:
-  OptionGroupValueObjectDisplay();
+  OptionGroupValueObjectDisplay() = default;
 
-  ~OptionGroupValueObjectDisplay() override;
+  ~OptionGroupValueObjectDisplay() override = default;
 
   llvm::ArrayRef<OptionDefinition> GetDefinitions() override;
 

--- a/lldb/include/lldb/Interpreter/OptionGroupVariable.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupVariable.h
@@ -20,7 +20,7 @@ class OptionGroupVariable : public OptionGroup {
 public:
   OptionGroupVariable(bool show_frame_options);
 
-  ~OptionGroupVariable() override;
+  ~OptionGroupVariable() override = default;
 
   llvm::ArrayRef<OptionDefinition> GetDefinitions() override;
 

--- a/lldb/include/lldb/Interpreter/OptionGroupVariable.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupVariable.h
@@ -26,7 +26,6 @@ public:
 
   Status SetOptionValue(uint32_t option_idx, llvm::StringRef option_value,
                         ExecutionContext *execution_context) override;
-  Status SetOptionValue(uint32_t, const char *, ExecutionContext *) = delete;
 
   void OptionParsingStarting(ExecutionContext *execution_context) override;
 

--- a/lldb/include/lldb/Interpreter/OptionGroupWatchpoint.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupWatchpoint.h
@@ -17,9 +17,9 @@ namespace lldb_private {
 
 class OptionGroupWatchpoint : public OptionGroup {
 public:
-  OptionGroupWatchpoint();
+  OptionGroupWatchpoint() = default;
 
-  ~OptionGroupWatchpoint() override;
+  ~OptionGroupWatchpoint() override = default;
 
   static bool IsWatchSizeSupported(uint32_t watch_size);
 

--- a/lldb/include/lldb/Interpreter/OptionGroupWatchpoint.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupWatchpoint.h
@@ -27,7 +27,6 @@ public:
 
   Status SetOptionValue(uint32_t option_idx, llvm::StringRef option_value,
                         ExecutionContext *execution_context) override;
-  Status SetOptionValue(uint32_t, const char *, ExecutionContext *) = delete;
 
   void OptionParsingStarting(ExecutionContext *execution_context) override;
 

--- a/lldb/include/lldb/Interpreter/OptionValueArch.h
+++ b/lldb/include/lldb/Interpreter/OptionValueArch.h
@@ -17,7 +17,7 @@ namespace lldb_private {
 
 class OptionValueArch : public OptionValue {
 public:
-  OptionValueArch() : OptionValue(), m_current_value(), m_default_value() {}
+  OptionValueArch() = default;
 
   OptionValueArch(const char *triple)
       : OptionValue(), m_current_value(triple), m_default_value() {
@@ -31,7 +31,7 @@ public:
       : OptionValue(), m_current_value(current_value),
         m_default_value(default_value) {}
 
-  ~OptionValueArch() override {}
+  ~OptionValueArch() override = default;
 
   // Virtual subclass pure virtual overrides
 

--- a/lldb/include/lldb/Interpreter/OptionValueArgs.h
+++ b/lldb/include/lldb/Interpreter/OptionValueArgs.h
@@ -19,7 +19,7 @@ public:
       : OptionValueArray(
             OptionValue::ConvertTypeToMask(OptionValue::eTypeString)) {}
 
-  ~OptionValueArgs() override {}
+  ~OptionValueArgs() override = default;
 
   size_t GetArgs(Args &args);
 

--- a/lldb/include/lldb/Interpreter/OptionValueArray.h
+++ b/lldb/include/lldb/Interpreter/OptionValueArray.h
@@ -20,7 +20,7 @@ public:
   OptionValueArray(uint32_t type_mask = UINT32_MAX, bool raw_value_dump = false)
       : m_type_mask(type_mask), m_values(), m_raw_value_dump(raw_value_dump) {}
 
-  ~OptionValueArray() override {}
+  ~OptionValueArray() override = default;
 
   // Virtual subclass pure virtual overrides
 

--- a/lldb/include/lldb/Interpreter/OptionValueBoolean.h
+++ b/lldb/include/lldb/Interpreter/OptionValueBoolean.h
@@ -21,7 +21,7 @@ public:
       : OptionValue(), m_current_value(current_value),
         m_default_value(default_value) {}
 
-  ~OptionValueBoolean() override {}
+  ~OptionValueBoolean() override = default;
 
   // Virtual subclass pure virtual overrides
 

--- a/lldb/include/lldb/Interpreter/OptionValueChar.h
+++ b/lldb/include/lldb/Interpreter/OptionValueChar.h
@@ -22,7 +22,7 @@ public:
       : OptionValue(), m_current_value(current_value),
         m_default_value(default_value) {}
 
-  ~OptionValueChar() override {}
+  ~OptionValueChar() override = default;
 
   // Virtual subclass pure virtual overrides
 

--- a/lldb/include/lldb/Interpreter/OptionValueDictionary.h
+++ b/lldb/include/lldb/Interpreter/OptionValueDictionary.h
@@ -22,7 +22,7 @@ public:
       : OptionValue(), m_type_mask(type_mask), m_values(),
         m_raw_value_dump(raw_value_dump) {}
 
-  ~OptionValueDictionary() override {}
+  ~OptionValueDictionary() override = default;
 
   // Virtual subclass pure virtual overrides
 

--- a/lldb/include/lldb/Interpreter/OptionValueEnumeration.h
+++ b/lldb/include/lldb/Interpreter/OptionValueEnumeration.h
@@ -31,7 +31,7 @@ public:
 
   OptionValueEnumeration(const OptionEnumValues &enumerators, enum_type value);
 
-  ~OptionValueEnumeration() override;
+  ~OptionValueEnumeration() override = default;
 
   // Virtual subclass pure virtual overrides
 

--- a/lldb/include/lldb/Interpreter/OptionValueFileColonLine.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFileColonLine.h
@@ -21,7 +21,7 @@ public:
   OptionValueFileColonLine();
   OptionValueFileColonLine(const llvm::StringRef input);
 
-  ~OptionValueFileColonLine() override {}
+  ~OptionValueFileColonLine() override = default;
 
   OptionValue::Type GetType() const override { return eTypeFileLineColumn; }
 

--- a/lldb/include/lldb/Interpreter/OptionValueFileSpec.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFileSpec.h
@@ -25,7 +25,7 @@ public:
   OptionValueFileSpec(const FileSpec &current_value,
                       const FileSpec &default_value, bool resolve = true);
 
-  ~OptionValueFileSpec() override {}
+  ~OptionValueFileSpec() override = default;
 
   // Virtual subclass pure virtual overrides
 

--- a/lldb/include/lldb/Interpreter/OptionValueFileSpecList.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFileSpecList.h
@@ -18,12 +18,12 @@ namespace lldb_private {
 
 class OptionValueFileSpecList : public OptionValue {
 public:
-  OptionValueFileSpecList() : OptionValue(), m_current_value() {}
+  OptionValueFileSpecList() = default;
 
   OptionValueFileSpecList(const FileSpecList &current_value)
       : OptionValue(), m_current_value(current_value) {}
 
-  ~OptionValueFileSpecList() override {}
+  ~OptionValueFileSpecList() override = default;
 
   // Virtual subclass pure virtual overrides
 

--- a/lldb/include/lldb/Interpreter/OptionValueFormat.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFormat.h
@@ -22,7 +22,7 @@ public:
       : OptionValue(), m_current_value(current_value),
         m_default_value(default_value) {}
 
-  ~OptionValueFormat() override {}
+  ~OptionValueFormat() override = default;
 
   // Virtual subclass pure virtual overrides
 

--- a/lldb/include/lldb/Interpreter/OptionValueFormatEntity.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFormatEntity.h
@@ -18,7 +18,7 @@ class OptionValueFormatEntity : public OptionValue {
 public:
   OptionValueFormatEntity(const char *default_format);
 
-  ~OptionValueFormatEntity() override {}
+  ~OptionValueFormatEntity() override = default;
 
   // Virtual subclass pure virtual overrides
 

--- a/lldb/include/lldb/Interpreter/OptionValueLanguage.h
+++ b/lldb/include/lldb/Interpreter/OptionValueLanguage.h
@@ -25,7 +25,7 @@ public:
       : OptionValue(), m_current_value(current_value),
         m_default_value(default_value) {}
 
-  ~OptionValueLanguage() override {}
+  ~OptionValueLanguage() override = default;
 
   // Virtual subclass pure virtual overrides
 

--- a/lldb/include/lldb/Interpreter/OptionValuePathMappings.h
+++ b/lldb/include/lldb/Interpreter/OptionValuePathMappings.h
@@ -19,7 +19,7 @@ public:
   OptionValuePathMappings(bool notify_changes)
       : OptionValue(), m_path_mappings(), m_notify_changes(notify_changes) {}
 
-  ~OptionValuePathMappings() override {}
+  ~OptionValuePathMappings() override = default;
 
   // Virtual subclass pure virtual overrides
 

--- a/lldb/include/lldb/Interpreter/OptionValueProperties.h
+++ b/lldb/include/lldb/Interpreter/OptionValueProperties.h
@@ -23,8 +23,7 @@ class OptionValueProperties
     : public OptionValue,
       public std::enable_shared_from_this<OptionValueProperties> {
 public:
-  OptionValueProperties()
-      : OptionValue(), m_name(), m_properties(), m_name_to_index() {}
+  OptionValueProperties() = default;
 
   OptionValueProperties(ConstString name);
 

--- a/lldb/include/lldb/Interpreter/OptionValueSInt64.h
+++ b/lldb/include/lldb/Interpreter/OptionValueSInt64.h
@@ -16,9 +16,7 @@ namespace lldb_private {
 
 class OptionValueSInt64 : public OptionValue {
 public:
-  OptionValueSInt64()
-      : OptionValue(), m_current_value(0), m_default_value(0),
-        m_min_value(INT64_MIN), m_max_value(INT64_MAX) {}
+  OptionValueSInt64() = default;
 
   OptionValueSInt64(int64_t value)
       : OptionValue(), m_current_value(value), m_default_value(value),
@@ -29,12 +27,9 @@ public:
         m_default_value(default_value), m_min_value(INT64_MIN),
         m_max_value(INT64_MAX) {}
 
-  OptionValueSInt64(const OptionValueSInt64 &rhs)
-      : OptionValue(rhs), m_current_value(rhs.m_current_value),
-        m_default_value(rhs.m_default_value), m_min_value(rhs.m_min_value),
-        m_max_value(rhs.m_max_value) {}
+  OptionValueSInt64(const OptionValueSInt64 &rhs) = default;
 
-  ~OptionValueSInt64() override {}
+  ~OptionValueSInt64() override = default;
 
   // Virtual subclass pure virtual overrides
 
@@ -93,10 +88,10 @@ public:
   int64_t GetMaximumValue() const { return m_max_value; }
 
 protected:
-  int64_t m_current_value;
-  int64_t m_default_value;
-  int64_t m_min_value;
-  int64_t m_max_value;
+  int64_t m_current_value = 0;
+  int64_t m_default_value = 0;
+  int64_t m_min_value = INT64_MIN;
+  int64_t m_max_value = INT64_MAX;
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Interpreter/OptionValueString.h
+++ b/lldb/include/lldb/Interpreter/OptionValueString.h
@@ -109,7 +109,6 @@ public:
   const char *GetDefaultValue() const { return m_default_value.c_str(); }
   llvm::StringRef GetDefaultValueAsRef() const { return m_default_value; }
 
-  Status SetCurrentValue(const char *) = delete;
   Status SetCurrentValue(llvm::StringRef value);
 
   Status AppendToCurrentValue(const char *value);

--- a/lldb/include/lldb/Interpreter/OptionValueString.h
+++ b/lldb/include/lldb/Interpreter/OptionValueString.h
@@ -23,9 +23,7 @@ public:
 
   enum Options { eOptionEncodeCharacterEscapeSequences = (1u << 0) };
 
-  OptionValueString()
-      : OptionValue(), m_current_value(), m_default_value(), m_options(),
-        m_validator(), m_validator_baton() {}
+  OptionValueString() = default;
 
   OptionValueString(ValidatorCallback validator, void *baton = nullptr)
       : OptionValue(), m_current_value(), m_default_value(), m_options(),
@@ -128,8 +126,8 @@ protected:
   std::string m_current_value;
   std::string m_default_value;
   Flags m_options;
-  ValidatorCallback m_validator;
-  void *m_validator_baton;
+  ValidatorCallback m_validator = nullptr;
+  void *m_validator_baton = nullptr;
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Interpreter/OptionValueUInt64.h
+++ b/lldb/include/lldb/Interpreter/OptionValueUInt64.h
@@ -31,7 +31,6 @@ public:
   // inside of a lldb::OptionValueSP object if all goes well. If the string
   // isn't a uint64_t value or any other error occurs, return an empty
   // lldb::OptionValueSP and fill error in with the correct stuff.
-  static lldb::OptionValueSP Create(const char *, Status &) = delete;
   static lldb::OptionValueSP Create(llvm::StringRef value_str, Status &error);
   // Virtual subclass pure virtual overrides
 

--- a/lldb/include/lldb/Interpreter/OptionValueUInt64.h
+++ b/lldb/include/lldb/Interpreter/OptionValueUInt64.h
@@ -16,7 +16,7 @@ namespace lldb_private {
 
 class OptionValueUInt64 : public OptionValue {
 public:
-  OptionValueUInt64() : OptionValue(), m_current_value(0), m_default_value(0) {}
+  OptionValueUInt64() = default;
 
   OptionValueUInt64(uint64_t value)
       : OptionValue(), m_current_value(value), m_default_value(value) {}
@@ -25,7 +25,7 @@ public:
       : OptionValue(), m_current_value(current_value),
         m_default_value(default_value) {}
 
-  ~OptionValueUInt64() override {}
+  ~OptionValueUInt64() override = default;
 
   // Decode a uint64_t from "value_cstr" return a OptionValueUInt64 object
   // inside of a lldb::OptionValueSP object if all goes well. If the string
@@ -71,8 +71,8 @@ public:
   void SetDefaultValue(uint64_t value) { m_default_value = value; }
 
 protected:
-  uint64_t m_current_value;
-  uint64_t m_default_value;
+  uint64_t m_current_value = 0;
+  uint64_t m_default_value = 0;
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Interpreter/OptionValueUUID.h
+++ b/lldb/include/lldb/Interpreter/OptionValueUUID.h
@@ -16,11 +16,11 @@ namespace lldb_private {
 
 class OptionValueUUID : public OptionValue {
 public:
-  OptionValueUUID() : OptionValue(), m_uuid() {}
+  OptionValueUUID() = default;
 
   OptionValueUUID(const UUID &uuid) : OptionValue(), m_uuid(uuid) {}
 
-  ~OptionValueUUID() override {}
+  ~OptionValueUUID() override = default;
 
   // Virtual subclass pure virtual overrides
 

--- a/lldb/include/lldb/Interpreter/ScriptInterpreter.h
+++ b/lldb/include/lldb/Interpreter/ScriptInterpreter.h
@@ -85,7 +85,7 @@ public:
 
   ScriptInterpreter(Debugger &debugger, lldb::ScriptLanguage script_lang);
 
-  ~ScriptInterpreter() override;
+  ~ScriptInterpreter() override = default;
 
   struct ExecuteScriptOptions {
   public:

--- a/lldb/source/Interpreter/CommandHistory.cpp
+++ b/lldb/source/Interpreter/CommandHistory.cpp
@@ -13,10 +13,6 @@
 using namespace lldb;
 using namespace lldb_private;
 
-CommandHistory::CommandHistory() : m_mutex(), m_history() {}
-
-CommandHistory::~CommandHistory() {}
-
 size_t CommandHistory::GetSize() const {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   return m_history.size();

--- a/lldb/source/Interpreter/CommandObject.cpp
+++ b/lldb/source/Interpreter/CommandObject.cpp
@@ -49,8 +49,6 @@ CommandObject::CommandObject(CommandInterpreter &interpreter,
   m_cmd_syntax = std::string(syntax);
 }
 
-CommandObject::~CommandObject() {}
-
 Debugger &CommandObject::GetDebugger() { return m_interpreter.GetDebugger(); }
 
 llvm::StringRef CommandObject::GetHelp() { return m_cmd_help_short; }

--- a/lldb/source/Interpreter/CommandReturnObject.cpp
+++ b/lldb/source/Interpreter/CommandReturnObject.cpp
@@ -45,8 +45,6 @@ CommandReturnObject::CommandReturnObject(bool colors)
       m_status(eReturnStatusStarted), m_did_change_process_state(false),
       m_interactive(true) {}
 
-CommandReturnObject::~CommandReturnObject() {}
-
 void CommandReturnObject::AppendErrorWithFormat(const char *format, ...) {
   if (!format)
     return;

--- a/lldb/source/Interpreter/OptionGroupArchitecture.cpp
+++ b/lldb/source/Interpreter/OptionGroupArchitecture.cpp
@@ -13,10 +13,6 @@
 using namespace lldb;
 using namespace lldb_private;
 
-OptionGroupArchitecture::OptionGroupArchitecture() : m_arch_str() {}
-
-OptionGroupArchitecture::~OptionGroupArchitecture() {}
-
 static constexpr OptionDefinition g_option_table[] = {
     {LLDB_OPT_SET_1, false, "arch", 'a', OptionParser::eRequiredArgument,
      nullptr, {}, 0, eArgTypeArchitecture,

--- a/lldb/source/Interpreter/OptionGroupBoolean.cpp
+++ b/lldb/source/Interpreter/OptionGroupBoolean.cpp
@@ -33,8 +33,6 @@ OptionGroupBoolean::OptionGroupBoolean(uint32_t usage_mask, bool required,
   m_option_definition.usage_text = usage_text;
 }
 
-OptionGroupBoolean::~OptionGroupBoolean() {}
-
 Status OptionGroupBoolean::SetOptionValue(uint32_t option_idx,
                                           llvm::StringRef option_value,
                                           ExecutionContext *execution_context) {

--- a/lldb/source/Interpreter/OptionGroupFile.cpp
+++ b/lldb/source/Interpreter/OptionGroupFile.cpp
@@ -31,8 +31,6 @@ OptionGroupFile::OptionGroupFile(uint32_t usage_mask, bool required,
   m_option_definition.usage_text = usage_text;
 }
 
-OptionGroupFile::~OptionGroupFile() {}
-
 Status OptionGroupFile::SetOptionValue(uint32_t option_idx,
                                        llvm::StringRef option_arg,
                                        ExecutionContext *execution_context) {

--- a/lldb/source/Interpreter/OptionGroupFormat.cpp
+++ b/lldb/source/Interpreter/OptionGroupFormat.cpp
@@ -24,8 +24,6 @@ OptionGroupFormat::OptionGroupFormat(lldb::Format default_format,
       m_count(default_count, default_count), m_prev_gdb_format('x'),
       m_prev_gdb_size('w') {}
 
-OptionGroupFormat::~OptionGroupFormat() {}
-
 static constexpr OptionDefinition g_option_table[] = {
     {LLDB_OPT_SET_1, false, "format", 'f', OptionParser::eRequiredArgument,
      nullptr, {}, 0, eArgTypeFormat,

--- a/lldb/source/Interpreter/OptionGroupOutputFile.cpp
+++ b/lldb/source/Interpreter/OptionGroupOutputFile.cpp
@@ -16,8 +16,6 @@ using namespace lldb_private;
 OptionGroupOutputFile::OptionGroupOutputFile()
     : m_file(), m_append(false, false) {}
 
-OptionGroupOutputFile::~OptionGroupOutputFile() {}
-
 static const uint32_t SHORT_OPTION_APND = 0x61706e64; // 'apnd'
 
 static constexpr OptionDefinition g_option_table[] = {

--- a/lldb/source/Interpreter/OptionGroupPythonClassWithDict.cpp
+++ b/lldb/source/Interpreter/OptionGroupPythonClassWithDict.cpp
@@ -81,8 +81,6 @@ OptionGroupPythonClassWithDict::OptionGroupPythonClassWithDict
 
 }
 
-OptionGroupPythonClassWithDict::~OptionGroupPythonClassWithDict() {}
-
 Status OptionGroupPythonClassWithDict::SetOptionValue(
     uint32_t option_idx,
     llvm::StringRef option_arg,

--- a/lldb/source/Interpreter/OptionGroupPythonClassWithDict.cpp
+++ b/lldb/source/Interpreter/OptionGroupPythonClassWithDict.cpp
@@ -13,12 +13,10 @@
 using namespace lldb;
 using namespace lldb_private;
 
-OptionGroupPythonClassWithDict::OptionGroupPythonClassWithDict
-    (const char *class_use,
-     bool is_class,
-     int class_option,
-     int key_option, 
-     int value_option) : OptionGroup(), m_is_class(is_class) {
+OptionGroupPythonClassWithDict::OptionGroupPythonClassWithDict(
+    const char *class_use, bool is_class, int class_option, int key_option,
+    int value_option, uint16_t required_options)
+    : m_is_class(is_class), m_required_options(required_options) {
   m_key_usage_text.assign("The key for a key/value pair passed to the "
                           "implementation of a ");
   m_key_usage_text.append(class_use);
@@ -36,7 +34,7 @@ OptionGroupPythonClassWithDict::OptionGroupPythonClassWithDict
   m_class_usage_text.append(".");
   
   m_option_definition[0].usage_mask = LLDB_OPT_SET_1;
-  m_option_definition[0].required = true;
+  m_option_definition[0].required = m_required_options.Test(eScriptClass);
   m_option_definition[0].long_option = "script-class";
   m_option_definition[0].short_option = class_option;
   m_option_definition[0].validator = nullptr;
@@ -47,7 +45,7 @@ OptionGroupPythonClassWithDict::OptionGroupPythonClassWithDict
   m_option_definition[0].usage_text = m_class_usage_text.data();
 
   m_option_definition[1].usage_mask = LLDB_OPT_SET_2;
-  m_option_definition[1].required = false;
+  m_option_definition[1].required = m_required_options.Test(eDictKey);
   m_option_definition[1].long_option = "structured-data-key";
   m_option_definition[1].short_option = key_option;
   m_option_definition[1].validator = nullptr;
@@ -58,7 +56,7 @@ OptionGroupPythonClassWithDict::OptionGroupPythonClassWithDict
   m_option_definition[1].usage_text = m_key_usage_text.data();
 
   m_option_definition[2].usage_mask = LLDB_OPT_SET_2;
-  m_option_definition[2].required = false;
+  m_option_definition[2].required = m_required_options.Test(eDictValue);
   m_option_definition[2].long_option = "structured-data-value";
   m_option_definition[2].short_option = value_option;
   m_option_definition[2].validator = nullptr;
@@ -69,7 +67,7 @@ OptionGroupPythonClassWithDict::OptionGroupPythonClassWithDict
   m_option_definition[2].usage_text = m_value_usage_text.data();
   
   m_option_definition[3].usage_mask = LLDB_OPT_SET_3;
-  m_option_definition[3].required = true;
+  m_option_definition[3].required = m_required_options.Test(ePythonFunction);
   m_option_definition[3].long_option = "python-function";
   m_option_definition[3].short_option = class_option;
   m_option_definition[3].validator = nullptr;
@@ -78,7 +76,6 @@ OptionGroupPythonClassWithDict::OptionGroupPythonClassWithDict
   m_option_definition[3].completion_type = 0;
   m_option_definition[3].argument_type = eArgTypePythonFunction;
   m_option_definition[3].usage_text = m_class_usage_text.data();
-
 }
 
 Status OptionGroupPythonClassWithDict::SetOptionValue(

--- a/lldb/source/Interpreter/OptionGroupString.cpp
+++ b/lldb/source/Interpreter/OptionGroupString.cpp
@@ -32,8 +32,6 @@ OptionGroupString::OptionGroupString(uint32_t usage_mask, bool required,
   m_option_definition.usage_text = usage_text;
 }
 
-OptionGroupString::~OptionGroupString() {}
-
 Status OptionGroupString::SetOptionValue(uint32_t option_idx,
                                          llvm::StringRef option_arg,
                                          ExecutionContext *execution_context) {

--- a/lldb/source/Interpreter/OptionGroupUInt64.cpp
+++ b/lldb/source/Interpreter/OptionGroupUInt64.cpp
@@ -32,8 +32,6 @@ OptionGroupUInt64::OptionGroupUInt64(uint32_t usage_mask, bool required,
   m_option_definition.usage_text = usage_text;
 }
 
-OptionGroupUInt64::~OptionGroupUInt64() {}
-
 Status OptionGroupUInt64::SetOptionValue(uint32_t option_idx,
                                          llvm::StringRef option_arg,
                                          ExecutionContext *execution_context) {

--- a/lldb/source/Interpreter/OptionGroupUUID.cpp
+++ b/lldb/source/Interpreter/OptionGroupUUID.cpp
@@ -13,10 +13,6 @@
 using namespace lldb;
 using namespace lldb_private;
 
-OptionGroupUUID::OptionGroupUUID() : m_uuid() {}
-
-OptionGroupUUID::~OptionGroupUUID() {}
-
 static constexpr OptionDefinition g_option_table[] = {
     {LLDB_OPT_SET_1, false, "uuid", 'u', OptionParser::eRequiredArgument,
      nullptr, {}, 0, eArgTypeModuleUUID, "A module UUID value."},

--- a/lldb/source/Interpreter/OptionGroupValueObjectDisplay.cpp
+++ b/lldb/source/Interpreter/OptionGroupValueObjectDisplay.cpp
@@ -19,10 +19,6 @@
 using namespace lldb;
 using namespace lldb_private;
 
-OptionGroupValueObjectDisplay::OptionGroupValueObjectDisplay() {}
-
-OptionGroupValueObjectDisplay::~OptionGroupValueObjectDisplay() {}
-
 static const OptionDefinition g_option_table[] = {
     {LLDB_OPT_SET_1, false, "dynamic-type", 'd',
      OptionParser::eRequiredArgument, nullptr, GetDynamicValueTypes(), 0,

--- a/lldb/source/Interpreter/OptionGroupVariable.cpp
+++ b/lldb/source/Interpreter/OptionGroupVariable.cpp
@@ -70,8 +70,6 @@ OptionGroupVariable::OptionGroupVariable(bool show_frame_options)
     : OptionGroup(), include_frame_options(show_frame_options),
       summary(ValidateNamedSummary), summary_string(ValidateSummaryString) {}
 
-OptionGroupVariable::~OptionGroupVariable() {}
-
 Status
 OptionGroupVariable::SetOptionValue(uint32_t option_idx,
                                     llvm::StringRef option_arg,

--- a/lldb/source/Interpreter/OptionGroupWatchpoint.cpp
+++ b/lldb/source/Interpreter/OptionGroupWatchpoint.cpp
@@ -74,10 +74,6 @@ bool OptionGroupWatchpoint::IsWatchSizeSupported(uint32_t watch_size) {
   return false;
 }
 
-OptionGroupWatchpoint::OptionGroupWatchpoint() : OptionGroup() {}
-
-OptionGroupWatchpoint::~OptionGroupWatchpoint() {}
-
 Status
 OptionGroupWatchpoint::SetOptionValue(uint32_t option_idx,
                                       llvm::StringRef option_arg,

--- a/lldb/source/Interpreter/OptionValueEnumeration.cpp
+++ b/lldb/source/Interpreter/OptionValueEnumeration.cpp
@@ -20,8 +20,6 @@ OptionValueEnumeration::OptionValueEnumeration(
   SetEnumerations(enumerators);
 }
 
-OptionValueEnumeration::~OptionValueEnumeration() {}
-
 void OptionValueEnumeration::DumpValue(const ExecutionContext *exe_ctx,
                                        Stream &strm, uint32_t dump_mask) {
   if (dump_mask & eDumpOptionType)

--- a/lldb/source/Interpreter/Options.cpp
+++ b/lldb/source/Interpreter/Options.cpp
@@ -27,7 +27,7 @@ using namespace lldb_private;
 // Options
 Options::Options() : m_getopt_table() { BuildValidOptionSets(); }
 
-Options::~Options() {}
+Options::~Options() = default;
 
 void Options::NotifyOptionParsingStarting(ExecutionContext *execution_context) {
   m_seen_options.clear();

--- a/lldb/source/Interpreter/ScriptInterpreter.cpp
+++ b/lldb/source/Interpreter/ScriptInterpreter.cpp
@@ -30,8 +30,6 @@ ScriptInterpreter::ScriptInterpreter(Debugger &debugger,
                                      lldb::ScriptLanguage script_lang)
     : m_debugger(debugger), m_script_lang(script_lang) {}
 
-ScriptInterpreter::~ScriptInterpreter() {}
-
 void ScriptInterpreter::CollectDataForBreakpointCommandCallback(
     std::vector<BreakpointOptions *> &bp_options_vec,
     CommandReturnObject &result) {


### PR DESCRIPTION
When using `OptionGroupPythonClassWithDict` options in an `OptionGroup`
with other `Options`, it can happen that the combinaison of some options
of each group makes the command invalid.

To solve that issue, this patch adds a bitmask argument to the
`OptionGroupPythonClassWithDict` constuctor that is used to mark each
option as required (or not).

If the `required_options` bitmask isn't passed to the constructor, the
class will keep its default behaviour, making the `--script-class` and
`--python-function` required.

rdar://65508855

Differential Revision: https://reviews.llvm.org/D97910

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>