### PR TITLE
[Index] Don't hash the DeclarationName of a NamedDecl if it's empty, …

### DIFF
--- a/clang/lib/Index/IndexRecordHasher.cpp
+++ b/clang/lib/Index/IndexRecordHasher.cpp
@@ -262,7 +262,8 @@ hash_code IndexRecordHasher::hash(CanQualType CT) {
 }
 
 hash_code IndexRecordHasher::hash(DeclarationName Name) {
-  assert(!Name.isEmpty());
+  if (Name.isEmpty())
+    return INITIAL_HASH;
   // Measurements for using cache or not here, showed significant slowdown when
   // using the cache for all DeclarationNames when parsing Cocoa, and minor
   // improvement or no difference for a couple of C++ single translation unit

--- a/clang/test/Index/Store/crash-msguid-hash.cpp
+++ b/clang/test/Index/Store/crash-msguid-hash.cpp
@@ -1,0 +1,25 @@
+// RUN: rm -rf %t
+// RUN: %clang_cc1 %s -std=c++1z -index-store-path %t/idx -fms-extensions
+// Should not crash.
+
+class VirtualBase
+{
+public:
+   VirtualBase() noexcept {}
+   virtual ~VirtualBase() noexcept {}
+};
+
+template< class MostDerivedInterface, const _GUID& MostDerivedInterfaceIID = __uuidof( MostDerivedInterface )  >
+class TGuidHolder : public VirtualBase
+{
+};
+
+struct  __declspec(uuid("12345678-1234-5678-ABCD-12345678ABCD")) GUIDInterfaceClass {};
+
+class Widget : public TGuidHolder< GUIDInterfaceClass >
+{
+public:
+   Widget();
+   ~Widget() noexcept {}
+};
+


### PR DESCRIPTION
…as MSGuid declarations have an empty name