### PR TITLE
Add UnwindPlans that can follow an AsyncContext chain

### DIFF
--- a/lldb/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/lldb/include/lldb/Target/SwiftLanguageRuntime.h
@@ -387,6 +387,11 @@ public:
 
   static AppleObjCRuntimeV2 *GetObjCRuntime(lldb_private::Process &process);
 protected:
+  lldb::UnwindPlanSP
+  GetRuntimeUnwindPlan(lldb::ProcessSP process_sp,
+                       lldb_private::RegisterContext *regctx,
+                       bool &behaves_like_zeroth_frame) override;
+
   bool GetTargetOfPartialApply(SymbolContext &curr_sc, ConstString &apply_name,
                                SymbolContext &sc);
   AppleObjCRuntimeV2 *GetObjCRuntime();

--- a/lldb/test/API/lang/swift/async/unwind/sayhello/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/sayhello/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -Xfrontend -enable-experimental-concurrency
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/sayhello/TestSwiftAsyncUnwind.py
+++ b/lldb/test/API/lang/swift/async/unwind/sayhello/TestSwiftAsyncUnwind.py
@@ -1,0 +1,33 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftAsyncUnwind(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    @skipIf(oslist=['windows', 'linux'])
+    def test(self):
+        """Test async unwind"""
+        self.build()
+        src = lldb.SBFileSpec('main.swift')
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', src)
+
+        self.assertTrue("sayolleH" in thread.GetFrameAtIndex(0).GetFunctionName(), 
+                "Redundantly confirm that we're stopped in sayolleH()")
+
+        if self.TraceOn():
+           self.runCmd("bt all")
+
+        self.assertTrue("sayHello" in thread.GetFrameAtIndex(1).GetFunctionName())
+        self.assertTrue("sayGeneric" in thread.GetFrameAtIndex(2).GetFunctionName())
+
+        # Check that we can only get 2 registers for frames that unwound 
+        # with an AsyncContext.
+        self.assertEqual(thread.GetFrameAtIndex(1).GetRegisters().GetSize(), 3)
+        self.assertEqual(thread.GetFrameAtIndex(2).GetRegisters().GetSize(), 3)

--- a/lldb/test/API/lang/swift/async/unwind/sayhello/main.swift
+++ b/lldb/test/API/lang/swift/async/unwind/sayhello/main.swift
@@ -1,0 +1,26 @@
+import Swift
+
+func sayolleH(str : String) async {
+  var str = "in sayolleH"
+  print("\(str) before calls")
+  print(str.reversed()) // break here
+}
+
+func sayHello() async {
+  var str = "in hello"
+  print("\(str) before calls")
+  await sayolleH(str:"hello")
+  print("\(str) after calls")
+}
+
+func sayGeneric<T>(_ msg: T) async {
+  var str = "in generic"
+  print("\(str) before calls - arg \(msg)")
+  await sayHello()
+  print("\(str) after calls - arg \(msg)")
+}
+
+runAsyncAndBlock {
+  await sayGeneric("world")
+  await sayHello()
+}


### PR DESCRIPTION
Add UnwindPlans that can follow an AsyncContext chain

Building on top of already-landed generic lldb changes to
support calling into the LanguageRuntimes to fetch an UnwindPlan
that can follow the AsyncContext chain and provide a logical
backtrace including both currently-executing stack frames and
async stack frames.

<rdar://problem/70398009>