### PR TITLE
[lldb][swift] Also cache successful library loads in SwiftASTContext

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -864,8 +864,10 @@ protected:
   lldb_private::Process *m_process = nullptr;
   Module *m_module = nullptr;
   std::string m_platform_sdk_path;
-  /// All previously failed library loads in LoadLibraryUsingPaths.
-  std::unordered_set<detail::SwiftLibraryLookupRequest> failed_library_loads;
+  /// All previously library loads in LoadLibraryUsingPaths with their
+  /// respective result (true = loaded, false = failed to load).
+  std::unordered_map<detail::SwiftLibraryLookupRequest, bool>
+      library_load_cache;
 
   typedef std::map<Module *, std::vector<lldb::DataBufferSP>> ASTFileDataMap;
   ASTFileDataMap m_ast_file_data_map;


### PR DESCRIPTION
d2ab0e5bb0029df2257e25a1d6c2a1a4f1bc19a2 added a cache that prevents that
the SwiftASTContext retries failed library loads. There is already a cache
that is supposed to prevent retrying successful library loads by searching
the loaded image list of the target process for the ModuleSpec we try to load.

That positive load cache however doesn't seem to account for cases where
the loaded library file ends up being versioned and the requested file is
just link to that versioned shared library. For example, a request to load
`libz.dylib` might end up loading `libz.1.dylib`, but we only look for
`libz.dylib` in the current implementation of the positive cache.

This causes that we end up calling the library loading backend far too often
which turns out to be a fairly expensive operation (every library load
needs to execute a utility function that calls dlopen in the target).

This just expands the negative cache implementation to also cover successful
library loads so that we no longet have to rely on the loaded ModuleSpecs
to match the one that we are trying to load.