### PR TITLE
[lldb][swift] Don't search all images in SwiftASTContext::LoadLibrary UsingPaths

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3938,11 +3938,8 @@ bool SwiftASTContext::LoadLibraryUsingPaths(
 
   ModuleSpec module_spec;
   module_spec.GetFileSpec().GetFilename().SetCString(library_fullname.c_str());
-  lldb_private::ModuleList matching_module_list;
 
-  process.GetTarget().GetImages().FindModules(module_spec,
-                                              matching_module_list);
-  if (!matching_module_list.IsEmpty()) {
+  if (process.GetTarget().GetImages().FindFirstModule(module_spec)) {
     LOG_PRINTF(LIBLLDB_LOG_TYPES, "Skipping module %s as it is already loaded.",
                library_fullname.c_str());
     return true;


### PR DESCRIPTION
We only want to check if there is already a matching module but not which modules
actually match our ModuleSpec. Use the proper method that will return once if
finds the first match. This saves us from checking all loaded modules for every
library.