### PR TITLE
[lldb][swift] Fix inverted cache check in DynamicValueTypeInfoNeedsUpdate

### DIFF
--- a/lldb/source/Core/ValueObjectDynamicValue.cpp
+++ b/lldb/source/Core/ValueObjectDynamicValue.cpp
@@ -443,7 +443,10 @@ bool ValueObjectDynamicValue::DynamicValueTypeInfoNeedsUpdate() {
   auto *cached_ctx = m_value.GetCompilerType().GetTypeSystem();
   llvm::Optional<SwiftASTContextReader> scratch_ctx =
       GetScratchSwiftASTContext();
-  return scratch_ctx ? (cached_ctx == scratch_ctx->get()) : !cached_ctx;
+
+  if (!scratch_ctx || !cached_ctx)
+    return true;
+  return cached_ctx != scratch_ctx->get();
 #else // !LLDB_ENABLE_SWIFT
   return false;
 #endif // LLDB_ENABLE_SWIFT


### PR DESCRIPTION
This function returns true if the ValueObject should be updated. The current
implementation checks whether the current CompilerType is inside the current
scratch AST. If the type is in the scratch AST then the ValueObject is marked
as out of date and will be updated.

From what I can see this check is inverted. It was added as part of a patch
that implemented recreating the scratch AST (8c9ffb1adc49b39dac6cd7c54a0b6be)
and the idea seems to be that the CompilerType should be re-evaluated in case
the current type is in a no longer existing or outdated scratch AST. The current
implementation however is checking the opposite (the ValueObject is marked
as out of date if its type is in the current scratch AST).

From what I can see we create CompilerTypes in the scratch AST so this
check is essentially always marking a ValueObjectDynamic as out-of-date.