### PR TITLE
[ubsan] support print_module_map flag in standalone mode

### DIFF
--- a/compiler-rt/lib/ubsan/ubsan_diag.cpp
+++ b/compiler-rt/lib/ubsan/ubsan_diag.cpp
@@ -388,6 +388,10 @@ ScopedReport::ScopedReport(ReportOptions Opts, Location SummaryLoc,
 ScopedReport::~ScopedReport() {
   MaybePrintStackTrace(Opts.pc, Opts.bp);
   MaybeReportErrorSummary(SummaryLoc, Type);
+
+  if (common_flags()->print_module_map >= 2)
+    DumpProcessMap();
+
   if (flags()->halt_on_error)
     Die();
 }

--- a/compiler-rt/lib/ubsan/ubsan_init.cpp
+++ b/compiler-rt/lib/ubsan/ubsan_init.cpp
@@ -33,6 +33,11 @@ static void CommonInit() {
   InitializeSuppressions();
 }
 
+static void UbsanDie() {
+  if (common_flags()->print_module_map >= 1)
+    DumpProcessMap();
+}
+
 static void CommonStandaloneInit() {
   SanitizerToolName = GetSanititizerToolName();
   CacheBinaryName();
@@ -42,6 +47,10 @@ static void CommonStandaloneInit() {
   AndroidLogInit();
   InitializeCoverage(common_flags()->coverage, common_flags()->coverage_dir);
   CommonInit();
+
+  // Only add die callback when running in standalone mode to avoid printing
+  // the same information from multiple sanitizers' output
+  AddDieCallback(UbsanDie);
   Symbolizer::LateInitialize();
 }
 

--- a/compiler-rt/test/sanitizer_common/TestCases/Darwin/print-module-map.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Darwin/print-module-map.cpp
@@ -1,0 +1,40 @@
+// Checks that module map does not print at 0, prints once after aborting with 1,
+// and prints once before and after aborting with 2
+
+// RUN: %clangxx -DUSING_%tool_name %s -o %t -w
+
+// RUN: %env_tool_opts="print_module_map=0" not %run %t 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-MM0
+// RUN: %env_tool_opts="print_module_map=1" not %run %t 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-MM1
+// RUN: %env_tool_opts="print_module_map=2" not %run %t 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-MM2
+
+// tsan support pending rdar://67747473
+// XFAIL: tsan
+
+// FIXME: Add linux support.
+// XFAIL: msan && linux
+
+// FIXME: Add lsan support.
+// XFAIL: lsan
+
+int global;
+
+int main() {
+#if defined(USING_ubsan)
+  int value = 5;
+  int computation = value / 0; // Division by zero.
+#else
+  volatile int *a = new int[100];
+  delete[] a;
+  global = a[0]; // use-after-free: triggers ASan/TSan report.
+#endif
+  return 0;
+}
+
+// CHECK: SUMMARY:
+// CHECK-MM0-NOT: Process module map:
+// CHECK-MM1-NOT: Process module map:
+// CHECK-MM2: Process module map:
+// CHECK: ABORTING
+// CHECK-MM0-NOT: Process module map:
+// CHECK-MM1-NEXT: Process module map:
+// CHECK-MM2-NEXT: Process module map:


### PR DESCRIPTION
Currently, `print_module_map` is only respected for ubsan if it is ran in tandem with asan. This patch adds support for this flag in standalone mode. I copied the pattern used to implement this for asan.

Also added a common `print_module_map` lit test for Darwin only. Since the print messages are different per platform, we need to write a regex test to cover them. This test is coming in a separate patch

rdar://56135732

Reviewed By: vitalybuka, vsk, delcypher

Differential Revision: https://reviews.llvm.org/D97746

(cherry picked from commit 9059903f2d33098e2c0e7074604da6845e31c436)