### PR TITLE
🍒/ganymede/080ded7445cc670cf2628e660690a06503d226d7+c2d2adbce9299e562abd00b8f3139933beb97e17

### DIFF
--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -129,11 +129,6 @@ if is_configured('shared_libs'):
     lit_config.warning("unable to inject shared library path on '{}'".format(
         platform.system()))
 
-# Propagate LLDB_CAPTURE_REPRODUCER
-if 'LLDB_CAPTURE_REPRODUCER' in os.environ:
-  config.environment['LLDB_CAPTURE_REPRODUCER'] = os.environ[
-      'LLDB_CAPTURE_REPRODUCER']
-
 # Support running the test suite under the lldb-repro wrapper. This makes it
 # possible to capture a test suite run and then rerun all the test from the
 # just captured reproducer.
@@ -259,3 +254,12 @@ config.test_format = lldbtest.LLDBTest(dotest_cmd)
 if 'FREEBSD_LEGACY_PLUGIN' in os.environ:
   config.environment['FREEBSD_LEGACY_PLUGIN'] = os.environ[
       'FREEBSD_LEGACY_PLUGIN']
+
+# Propagate LLDB_CAPTURE_REPRODUCER
+if 'LLDB_CAPTURE_REPRODUCER' in os.environ:
+  config.environment['LLDB_CAPTURE_REPRODUCER'] = os.environ[
+      'LLDB_CAPTURE_REPRODUCER']
+
+# Propagate XDG_CACHE_HOME
+if 'XDG_CACHE_HOME' in os.environ:
+  config.environment['XDG_CACHE_HOME'] = os.environ['XDG_CACHE_HOME']

--- a/lldb/test/Shell/lit.cfg.py
+++ b/lldb/test/Shell/lit.cfg.py
@@ -45,6 +45,7 @@ llvm_config.with_system_environment([
     'LLDB_CAPTURE_REPRODUCER',
     'TEMP',
     'TMP',
+    'XDG_CACHE_HOME',
 ])
 
 # Support running the test suite under the lldb-repro wrapper. This makes it

--- a/lldb/test/Shell/lit.cfg.py
+++ b/lldb/test/Shell/lit.cfg.py
@@ -38,10 +38,14 @@ config.test_source_root = os.path.dirname(__file__)
 # test_exec_root: The root path where tests should be run.
 config.test_exec_root = os.path.join(config.lldb_obj_root, 'test')
 
-# Propagate reproducer environment vars.
-if 'LLDB_CAPTURE_REPRODUCER' in os.environ:
-  config.environment['LLDB_CAPTURE_REPRODUCER'] = os.environ[
-      'LLDB_CAPTURE_REPRODUCER']
+# Propagate environment vars.
+llvm_config.with_system_environment([
+    'FREEBSD_LEGACY_PLUGIN',
+    'HOME',
+    'LLDB_CAPTURE_REPRODUCER',
+    'TEMP',
+    'TMP',
+])
 
 # Support running the test suite under the lldb-repro wrapper. This makes it
 # possible to capture a test suite run and then rerun all the test from the
@@ -136,6 +140,3 @@ if platform.system() == 'NetBSD' and os.geteuid() != 0:
         can_set_dbregs = False
 if can_set_dbregs:
     config.available_features.add('dbregs-set')
-
-# pass control variable through
-llvm_config.with_system_environment('FREEBSD_LEGACY_PLUGIN')

--- a/lldb/test/Unit/lit.cfg.py
+++ b/lldb/test/Unit/lit.cfg.py
@@ -28,6 +28,7 @@ llvm_config.with_system_environment([
     'PATH',
     'TEMP',
     'TMP',
+    'XDG_CACHE_HOME',
 ])
 llvm_config.with_environment('PATH',
                              os.path.dirname(sys.executable),

--- a/lldb/test/Unit/lit.cfg.py
+++ b/lldb/test/Unit/lit.cfg.py
@@ -23,8 +23,15 @@ config.test_exec_root = config.test_source_root
 # it needs to be able to find it at runtime.  This is fine if Python is on your
 # system PATH, but if it's not, then this unit test executable will fail to run.
 # We can solve this by forcing the Python directory onto the system path here.
-llvm_config.with_system_environment('PATH')
-llvm_config.with_environment('PATH', os.path.dirname(sys.executable), append_path=True)
+llvm_config.with_system_environment([
+    'HOME',
+    'PATH',
+    'TEMP',
+    'TMP',
+])
+llvm_config.with_environment('PATH',
+                             os.path.dirname(sys.executable),
+                             append_path=True)
 
 # testFormat: The test format to use to interpret tests.
 config.test_format = lit.formats.GoogleTest(config.llvm_build_mode, 'Tests')


### PR DESCRIPTION
- [lldb] Use lit.with_system_environment to propagate env variables
- [lldb] Propagate XDG_CACHE_HOME environment variable to tests
