### PR TITLE
[cmake] Enable -Werror=return-type

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -731,6 +731,10 @@ if (LLVM_ENABLE_WARNINGS AND (LLVM_COMPILER_IS_GCC_COMPATIBLE OR CLANG_CL))
 
   # Enable -Wstring-conversion to catch misuse of string literals.
   add_flag_if_supported("-Wstring-conversion" STRING_CONVERSION_FLAG)
+
+  # Enable -Werror=return-type if available, to catch functions that contain
+  # control paths that do not return a value.
+  add_flag_if_supported("-Werror=return-type" WERROR_RETURN_TYPE)
 endif (LLVM_ENABLE_WARNINGS AND (LLVM_COMPILER_IS_GCC_COMPATIBLE OR CLANG_CL))
 
 if (LLVM_COMPILER_IS_GCC_COMPATIBLE AND NOT LLVM_ENABLE_WARNINGS)


### PR DESCRIPTION
Turn `-Wreturn-type` into an error.

This is currently used by libcxx, libcxxabi, and libunwind, and would be a good default
for all of llvm. I'm not aware of any cases where this shouldn't be an error. This
ensures different build configs, merges, and downstream branches catch issues sooner.

Differential Revision: https://reviews.llvm.org/D98224

(cherry picked from commit ce94a161651d0edd313d0fa65571eb53d3a34d13)