### PR TITLE
Log in SetPrivateState when unwind logging enabled

### DIFF
--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1519,8 +1519,8 @@ void Process::SetPrivateState(StateType new_state) {
   if (m_finalizing)
     return;
 
-  Log *log(lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_STATE |
-                                                  LIBLLDB_LOG_PROCESS));
+  Log *log(lldb_private::GetLogIfAnyCategoriesSet(
+      LIBLLDB_LOG_STATE | LIBLLDB_LOG_PROCESS | LIBLLDB_LOG_UNWIND));
   bool state_changed = false;
 
   LLDB_LOGF(log, "Process::SetPrivateState (%s)", StateAsCString(new_state));


### PR DESCRIPTION
Log in SetPrivateState when unwind logging enabled

It is easier to read the unwind logging when you can see
when the inferior resumes / stops and we're doing new unwinds.

(cherry picked from commit ea659ea101a56a08c73be65ab62c3e180e37ca38)