### PR TITLE
Don't create a swift async unwind plan when in a function prologue

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -2345,8 +2345,9 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
   Address pc;
   pc.SetLoadAddress(regctx->GetPC(), &target);
   SymbolContext sc;
-  if (pc.IsValid() && pc.CalculateSymbolContext(
-                          &sc, eSymbolContextFunction | eSymbolContextSymbol)) {
+  if (pc.IsValid()) {
+    pc.CalculateSymbolContext(&sc,
+                              eSymbolContextFunction | eSymbolContextSymbol);
     if (sc.function) {
       Address func_start_addr = sc.function->GetAddressRange().GetBaseAddress();
       AddressRange prologue_range(func_start_addr,
@@ -2354,9 +2355,7 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
       if (prologue_range.ContainsLoadAddress(pc, &target)) {
         return UnwindPlanSP();
       }
-    }
-
-    if (sc.symbol) {
+    } else if (sc.symbol) {
       Address func_start_addr = sc.symbol->GetAddress();
       AddressRange prologue_range(func_start_addr,
                                   sc.symbol->GetPrologueByteSize());

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -2299,7 +2299,8 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
                                            RegisterContext *regctx,
                                            bool &behaves_like_zeroth_frame) {
 
-  ArchSpec arch = process_sp->GetTarget().GetArchitecture();
+  Target &target(process_sp->GetTarget());
+  ArchSpec arch = target.GetArchitecture();
   uint32_t async_context_regnum;
   uint32_t fp_regnum;
   uint32_t pc_regnum;
@@ -2333,6 +2334,36 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
       }
     }
     return UnwindPlanSP();
+  }
+
+  // If we're in the prologue of a function, don't provide a Swift async
+  // unwind plan.  We can be tricked by unmodified caller-registers that
+  // make this look like an async frame when this is a standard ABI function
+  // call, and the parent is the async frame.
+  // This assumes that the frame pointer register will be modified in the
+  // prologue.
+  Address pc;
+  pc.SetLoadAddress(regctx->GetPC(), &target);
+  SymbolContext sc;
+  if (pc.IsValid() && pc.CalculateSymbolContext(
+                          &sc, eSymbolContextFunction | eSymbolContextSymbol)) {
+    if (sc.function) {
+      Address func_start_addr = sc.function->GetAddressRange().GetBaseAddress();
+      AddressRange prologue_range(func_start_addr,
+                                  sc.function->GetPrologueByteSize());
+      if (prologue_range.ContainsLoadAddress(pc, &target)) {
+        return UnwindPlanSP();
+      }
+    }
+
+    if (sc.symbol) {
+      Address func_start_addr = sc.symbol->GetAddress();
+      AddressRange prologue_range(func_start_addr,
+                                  sc.symbol->GetPrologueByteSize());
+      if (prologue_range.ContainsLoadAddress(pc, &target)) {
+        return UnwindPlanSP();
+      }
+    }
   }
 
   addr_t saved_fp = LLDB_INVALID_ADDRESS;


### PR DESCRIPTION
Don't create a swift async unwind plan when in a function prologue

If a swift async function does a standard ABI function call into
a normal function, at the start, we will still have the caller's
async register values (e.g. deref frame pointer shows us an
AsyncContext address with high-nibble flags set).

This patch changes SwiftLanguageRuntime to detect when we are in the
middle of a function prologue, and not return an async unwind plan
in that case.