### PR TITLE
[lldb] Add work around handling of recursive_mutex lock failures

### DIFF
--- a/lldb/test/API/lldbtest.py
+++ b/lldb/test/API/lldbtest.py
@@ -112,7 +112,7 @@ class LLDBTest(TestFormat):
             'recursive_mutex lock failed' in err and
             exitCode != 0
         ):
-            return lit.Test.PASS, output
+            return lit.Test.FLAKYPASS, output
 
         if exitCode:
             if 'XPASS:' in out or 'XPASS:' in err:

--- a/lldb/test/API/lldbtest.py
+++ b/lldb/test/API/lldbtest.py
@@ -101,6 +101,19 @@ class LLDBTest(TestFormat):
         if timeoutInfo:
             return lit.Test.TIMEOUT, output
 
+        # Temporary fix to a flaky CI error. See rdar://52221547
+        # After unit tests have finished, a race during lldb shutdown can
+        # result in this innocuous and trouble causing failure:
+        #
+        # libc++abi.dylib: terminating with uncaught exception of type \
+        # std::__1::system_error: recursive_mutex lock failed: Invalid argument
+        if (
+            'RESULT: PASSED' in err and
+            'recursive_mutex lock failed' in err and
+            exitCode != 0
+        ):
+            return lit.Test.PASS, output
+
         if exitCode:
             if 'XPASS:' in out or 'XPASS:' in err:
                 return lit.Test.XPASS, output


### PR DESCRIPTION
A known flaky failure causes swift-lldb tests to be marked as failing, even when they pass. This adds special handling to prevent the unwanted CI failures.

The test failure manifests in a non-zero exit code, and `stderr` contains this output:

> libc++abi.dylib: terminating with uncaught exception of type std::__1::system_error: recursive_mutex lock failed: Invalid argument

This failure is known to happen during lldb shutdown, and thus happens after the tests have run. If the test output contains `RESULT: PASSED`, that means the test has succeeded.

This change checks for these conditions and marks the test as a `FLAKYPASS` to prevent the false negative CI failures.

rdar://52221547