### PR TITLE
Cherry-pick recent changes to LLVM swift async stuff

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64CallingConvention.td
+++ b/llvm/lib/Target/AArch64/AArch64CallingConvention.td
@@ -420,8 +420,8 @@ def CSR_AArch64_SVE_AAPCS : CalleeSavedRegs<(add (sequence "Z%u", 8, 23),
                                                  X19, X20, X21, X22, X23, X24,
                                                  X25, X26, X27, X28, LR, FP)>;
 
-def CSR_AArch64_AAPCS_SwiftAsync
-    : CalleeSavedRegs<(sub CSR_AArch64_AAPCS, X22)>;
+def CSR_AArch64_AAPCS_SwiftTail
+    : CalleeSavedRegs<(sub CSR_AArch64_AAPCS, X20, X22)>;
 
 // Constructors and destructors return 'this' in the iOS 64-bit C++ ABI; since
 // 'this' and the pointer return value are both passed in X0 in these cases,
@@ -475,8 +475,8 @@ def CSR_Darwin_AArch64_AAPCS_ThisReturn
 def CSR_Darwin_AArch64_AAPCS_SwiftError
     : CalleeSavedRegs<(sub CSR_Darwin_AArch64_AAPCS, X21)>;
 
-def CSR_Darwin_AArch64_AAPCS_SwiftAsync
-    : CalleeSavedRegs<(sub CSR_Darwin_AArch64_AAPCS, X22)>;
+def CSR_Darwin_AArch64_AAPCS_SwiftTail
+    : CalleeSavedRegs<(sub CSR_Darwin_AArch64_AAPCS, X20, X22)>;
 
 // The function used by Darwin to obtain the address of a thread-local variable
 // guarantees more than a normal AAPCS function. x16 and x17 are used on the

--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -47,8 +47,9 @@
 // | callee-saved gpr registers        | <--.
 // |                                   |    | On Darwin platforms these
 // |- - - - - - - - - - - - - - - - - -|    | callee saves are swapped,
-// |                                   |    | (frame record first)
-// | prev_fp, prev_lr                  | <--'
+// | prev_lr                           |    | (frame record first)
+// | prev_fp                           | <--'
+// | async context if needed           |
 // | (a.k.a. "frame record")           |
 // |-----------------------------------| <- fp(=x29)
 // |                                   |

--- a/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp
@@ -4065,7 +4065,7 @@ void AArch64DAGToDAGISel::Select(SDNode *Node) {
       return;
     }
 
-    case Intrinsic::swift_async_context_addr:
+    case Intrinsic::swift_async_context_addr: {
       SDLoc DL(Node);
       CurDAG->SelectNodeTo(Node, AArch64::SUBXri, MVT::i64,
                            CurDAG->getCopyFromReg(CurDAG->getEntryNode(), DL,
@@ -4076,6 +4076,7 @@ void AArch64DAGToDAGISel::Select(SDNode *Node) {
       MF.getFrameInfo().setFrameAddressIsTaken(true);
       MF.getInfo<AArch64FunctionInfo>()->setHasSwiftAsyncContext(true);
       return;
+    }
     }
     break;
   }

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -2469,8 +2469,14 @@ bool AArch64InstrInfo::getMemOpInfo(unsigned Opcode, TypeSize &Scale,
   case AArch64::LDRDui:
   case AArch64::STRXui:
   case AArch64::STRDui:
-  case AArch64::StoreSwiftAsyncContext:
     Scale = TypeSize::Fixed(8);
+    Width = 8;
+    MinOffset = 0;
+    MaxOffset = 4095;
+    break;
+  case AArch64::StoreSwiftAsyncContext:
+    // Store is an STRXui, but there might be an ADDXri in the expansion too.
+    Scale = TypeSize::Fixed(1);
     Width = 8;
     MinOffset = 0;
     MaxOffset = 4095;

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
@@ -103,7 +103,7 @@ AArch64RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
   if (MF->getFunction().getAttributes().hasAttrSomewhere(
           Attribute::SwiftAsync) ||
       MF->getFunction().getCallingConv() == CallingConv::SwiftTail)
-    return CSR_AArch64_AAPCS_SwiftAsync_SaveList;
+    return CSR_AArch64_AAPCS_SwiftTail_SaveList;
   if (MF->getFunction().getCallingConv() == CallingConv::PreserveMost)
     return CSR_AArch64_RT_MostRegs_SaveList;
   if (MF->getFunction().getCallingConv() == CallingConv::Win64)
@@ -141,7 +141,7 @@ AArch64RegisterInfo::getDarwinCalleeSavedRegs(const MachineFunction *MF) const {
   if (MF->getFunction().getAttributes().hasAttrSomewhere(
           Attribute::SwiftAsync) ||
       MF->getFunction().getCallingConv() == CallingConv::SwiftTail)
-    return CSR_Darwin_AArch64_AAPCS_SwiftAsync_SaveList;
+    return CSR_Darwin_AArch64_AAPCS_SwiftTail_SaveList;
   if (MF->getFunction().getCallingConv() == CallingConv::PreserveMost)
     return CSR_Darwin_AArch64_RT_MostRegs_SaveList;
   return CSR_Darwin_AArch64_AAPCS_SaveList;
@@ -209,8 +209,8 @@ AArch64RegisterInfo::getDarwinCallPreservedMask(const MachineFunction &MF,
     return CSR_Darwin_AArch64_AAPCS_SwiftError_RegMask;
   if (MF.getFunction().getAttributes().hasAttrSomewhere(
           Attribute::SwiftAsync) ||
-      MF.getFunction().getCallingConv() == CallingConv::SwiftTail)
-    return CSR_Darwin_AArch64_AAPCS_SwiftAsync_RegMask;
+      CC == CallingConv::SwiftTail)
+    return CSR_Darwin_AArch64_AAPCS_SwiftTail_RegMask;
   if (CC == CallingConv::PreserveMost)
     return CSR_Darwin_AArch64_RT_MostRegs_RegMask;
   return CSR_Darwin_AArch64_AAPCS_RegMask;
@@ -247,10 +247,10 @@ AArch64RegisterInfo::getCallPreservedMask(const MachineFunction &MF,
                : CSR_AArch64_AAPCS_SwiftError_RegMask;
   if (MF.getFunction().getAttributes().hasAttrSomewhere(
           Attribute::SwiftAsync) ||
-      MF.getFunction().getCallingConv() == CallingConv::SwiftTail) {
+      CC == CallingConv::SwiftTail) {
     if (SCS)
-      report_fatal_error("ShadowCallStack attribute not supported with swiftasync");
-    return CSR_AArch64_AAPCS_SwiftAsync_RegMask;
+      report_fatal_error("ShadowCallStack attribute not supported with swifttail");
+    return CSR_AArch64_AAPCS_SwiftTail_RegMask;
   }
   if (CC == CallingConv::PreserveMost)
     return SCS ? CSR_AArch64_RT_MostRegs_SCS_RegMask

--- a/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
@@ -5001,11 +5001,13 @@ bool AArch64InstructionSelector::selectIntrinsic(MachineInstr &I,
     return true;
   }
   case Intrinsic::swift_async_context_addr:
-    MIRBuilder
-        .buildInstr(AArch64::SUBXri, {I.getOperand(0).getReg()},
-                    {Register(AArch64::FP)})
-        .addImm(8)
-        .addImm(0);
+    auto MIB = MIRBuilder
+                   .buildInstr(AArch64::SUBXri, {I.getOperand(0).getReg()},
+                               {Register(AArch64::FP)})
+                   .addImm(8)
+                   .addImm(0);
+    constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+
     MF->getFrameInfo().setFrameAddressIsTaken(true);
     MF->getInfo<AArch64FunctionInfo>()->setHasSwiftAsyncContext(true);
     I.eraseFromParent();

--- a/llvm/lib/Target/ARM/ARMFrameLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMFrameLowering.cpp
@@ -158,7 +158,7 @@ static int getArgumentStackToRestore(MachineFunction &MF,
   }
   ARMFunctionInfo *AFI = MF.getInfo<ARMFunctionInfo>();
 
-  unsigned ArgumentPopSize = 0;
+  int ArgumentPopSize = 0;
   if (IsTailCallReturn) {
     MachineOperand &StackAdjust = MBBI->getOperand(1);
 

--- a/llvm/lib/Target/X86/X86CallingConv.td
+++ b/llvm/lib/Target/X86/X86CallingConv.td
@@ -1084,7 +1084,7 @@ def CSR_32 : CalleeSavedRegs<(add ESI, EDI, EBX, EBP)>;
 def CSR_64 : CalleeSavedRegs<(add RBX, R12, R13, R14, R15, RBP)>;
 
 def CSR_64_SwiftError : CalleeSavedRegs<(sub CSR_64, R12)>;
-def CSR_64_SwiftAsync : CalleeSavedRegs<(sub CSR_64, R14)>;
+def CSR_64_SwiftTail : CalleeSavedRegs<(sub CSR_64, R13, R14)>;
 
 def CSR_32EHRet : CalleeSavedRegs<(add EAX, EDX, CSR_32)>;
 def CSR_64EHRet : CalleeSavedRegs<(add RAX, RDX, CSR_64)>;
@@ -1095,7 +1095,7 @@ def CSR_Win64 : CalleeSavedRegs<(add CSR_Win64_NoSSE,
                                      (sequence "XMM%u", 6, 15))>;
 
 def CSR_Win64_SwiftError : CalleeSavedRegs<(sub CSR_Win64, R12)>;
-def CSR_Win64_SwiftAsync : CalleeSavedRegs<(sub CSR_Win64, R14)>;
+def CSR_Win64_SwiftTail : CalleeSavedRegs<(sub CSR_Win64, R13, R14)>;
 
 // The function used by Darwin to obtain the address of a thread-local variable
 // uses rdi to pass a single parameter and rax for the return value. All other

--- a/llvm/lib/Target/X86/X86FastISel.cpp
+++ b/llvm/lib/Target/X86/X86FastISel.cpp
@@ -1181,6 +1181,7 @@ bool X86FastISel::X86SelectRet(const Instruction *I) {
   if (CC != CallingConv::C &&
       CC != CallingConv::Fast &&
       CC != CallingConv::Tail &&
+      CC != CallingConv::SwiftTail &&
       CC != CallingConv::X86_FastCall &&
       CC != CallingConv::X86_StdCall &&
       CC != CallingConv::X86_ThisCall &&
@@ -1195,7 +1196,7 @@ bool X86FastISel::X86SelectRet(const Instruction *I) {
   // fastcc with -tailcallopt is intended to provide a guaranteed
   // tail call optimization. Fastisel doesn't know how to do that.
   if ((CC == CallingConv::Fast && TM.Options.GuaranteedTailCallOpt) ||
-      CC == CallingConv::Tail)
+      CC == CallingConv::Tail || CC == CallingConv::SwiftTail)
     return false;
 
   // Let SDISel handle vararg functions.
@@ -3181,7 +3182,8 @@ static unsigned computeBytesPoppedByCalleeForSRet(const X86Subtarget *Subtarget,
   if (Subtarget->getTargetTriple().isOSMSVCRT())
     return 0;
   if (CC == CallingConv::Fast || CC == CallingConv::GHC ||
-      CC == CallingConv::HiPE || CC == CallingConv::Tail)
+      CC == CallingConv::HiPE || CC == CallingConv::Tail ||
+      CC == CallingConv::SwiftTail)
     return 0;
 
   if (CB)

--- a/llvm/lib/Target/X86/X86RegisterInfo.cpp
+++ b/llvm/lib/Target/X86/X86RegisterInfo.cpp
@@ -349,6 +349,8 @@ X86RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
     if (!HasSSE)
       return CSR_Win64_NoSSE_SaveList;
     return CSR_Win64_SaveList;
+  case CallingConv::SwiftTail:
+    return IsWin64 ? CSR_Win64_SwiftTail_SaveList : CSR_64_SwiftTail_SaveList;
   case CallingConv::X86_64_SysV:
     if (CallsEHReturn)
       return CSR_64EHRet_SaveList;
@@ -384,8 +386,8 @@ X86RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
 
     if (F.getAttributes().hasAttrSomewhere(Attribute::SwiftAsync) ||
         F.getCallingConv() == CallingConv::SwiftTail)
-      return IsWin64 ? CSR_Win64_SwiftError_SaveList
-                     : CSR_64_SwiftAsync_SaveList;
+      return IsWin64 ? CSR_Win64_SwiftTail_SaveList
+                     : CSR_64_SwiftTail_SaveList;
 
     if (IsWin64)
       return HasSSE ? CSR_Win64_SaveList : CSR_Win64_NoSSE_SaveList;
@@ -470,6 +472,8 @@ X86RegisterInfo::getCallPreservedMask(const MachineFunction &MF,
     break;
   case CallingConv::Win64:
     return CSR_Win64_RegMask;
+  case CallingConv::SwiftTail:
+    return IsWin64 ? CSR_Win64_SwiftTail_RegMask : CSR_64_SwiftTail_RegMask;
   case CallingConv::X86_64_SysV:
     return CSR_64_RegMask;
   case CallingConv::X86_INTR:
@@ -503,9 +507,8 @@ X86RegisterInfo::getCallPreservedMask(const MachineFunction &MF,
     if (IsSwiftCC)
       return IsWin64 ? CSR_Win64_SwiftError_RegMask : CSR_64_SwiftError_RegMask;
 
-    if (F.getAttributes().hasAttrSomewhere(Attribute::SwiftAsync) ||
-        F.getCallingConv() == CallingConv::SwiftTail)
-      return IsWin64 ? CSR_Win64_SwiftAsync_RegMask : CSR_64_SwiftAsync_RegMask;
+    if (F.getAttributes().hasAttrSomewhere(Attribute::SwiftAsync))
+      return IsWin64 ? CSR_Win64_SwiftTail_RegMask : CSR_64_SwiftTail_RegMask;
 
     return IsWin64 ? CSR_Win64_RegMask : CSR_64_RegMask;
   }

--- a/llvm/test/Bitcode/attributes.ll
+++ b/llvm/test/Bitcode/attributes.ll
@@ -422,6 +422,12 @@ define void @f71() hot
   ret void
 }
 
+; CHECK: define void @f72(i8* swiftasync %0)
+define void @f72(i8* swiftasync %0)
+{
+  ret void;
+}
+
 ; CHECK: attributes #0 = { noreturn }
 ; CHECK: attributes #1 = { nounwind }
 ; CHECK: attributes #2 = { readnone }

--- a/llvm/test/Bitcode/compatibility.ll
+++ b/llvm/test/Bitcode/compatibility.ll
@@ -552,6 +552,12 @@ declare void @f.param.dereferenceable(i8* dereferenceable(4))
 ; CHECK: declare void @f.param.dereferenceable(i8* dereferenceable(4))
 declare void @f.param.dereferenceable_or_null(i8* dereferenceable_or_null(4))
 ; CHECK: declare void @f.param.dereferenceable_or_null(i8* dereferenceable_or_null(4))
+declare void @f.param.swiftself(i8* swiftself)
+; CHECK: declare void @f.param.swiftself(i8* swiftself)
+declare void @f.param.swiftasync(i8* swiftasync)
+; CHECK: declare void @f.param.swiftasync(i8* swiftasync)
+declare void @f.param.swifterror(i8** swifterror)
+; CHECK: declare void @f.param.swifterror(i8** swifterror)
 
 ; Functions -- unnamed_addr and local_unnamed_addr
 declare void @f.unnamed_addr() unnamed_addr

--- a/llvm/test/CodeGen/AArch64/swift-async-unwind.ll
+++ b/llvm/test/CodeGen/AArch64/swift-async-unwind.ll
@@ -1,0 +1,13 @@
+; RUN: llc -mtriple=arm64-apple-ios %s -filetype=obj -o - | llvm-objdump --unwind-info - | FileCheck %s
+
+; Swift asynchronous context is incompatible with the compact unwind encoding
+; that currently exists and assumes callee-saved registers are right next to FP
+; in a particular order. This isn't a problem now because C++ exceptions aren't
+; allowed to unwind through Swift code, but at least make sure the compact info
+; says to use DWARF correctly.
+
+; CHECK: compact encoding: 0x03000000
+define void @foo(i8* swiftasync %in) "frame-pointer"="all" {
+  call void asm sideeffect "", "~{x23}"()
+  ret void
+}

--- a/llvm/test/CodeGen/AArch64/swift-async.ll
+++ b/llvm/test/CodeGen/AArch64/swift-async.ll
@@ -5,7 +5,7 @@
 ; Important details in prologue:
 ;   * x22 is stored just below x29
 ;   * Enough stack space is allocated for everything
-define void @simple(i8* swiftasync %ctx) "frame-pointer"="all" {
+define swifttailcc void @simple(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK-LABEL: simple:
 ; CHECK: orr x29, x29, #0x100000000000000
 ; CHECK: sub sp, sp, #32
@@ -32,7 +32,7 @@ define void @simple(i8* swiftasync %ctx) "frame-pointer"="all" {
   ret void
 }
 
-define void @more_csrs(i8* swiftasync %ctx) "frame-pointer"="all" {
+define swifttailcc void @more_csrs(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK-LABEL: more_csrs:
 ; CHECK: orr x29, x29, #0x100000000000000
 ; CHECK: str x23, [sp, #-32]!
@@ -60,7 +60,7 @@ define void @more_csrs(i8* swiftasync %ctx) "frame-pointer"="all" {
   ret void
 }
 
-define void @locals(i8* swiftasync %ctx) "frame-pointer"="all" {
+define swifttailcc void @locals(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK-LABEL: locals:
 ; CHECK: orr x29, x29, #0x100000000000000
 ; CHECK: sub sp, sp, #64
@@ -91,7 +91,7 @@ define void @locals(i8* swiftasync %ctx) "frame-pointer"="all" {
   ret void
 }
 
-define void @use_input_context(i8* swiftasync %ctx, i8** %ptr) "frame-pointer"="all" {
+define swifttailcc void @use_input_context(i8* swiftasync %ctx, i8** %ptr) "frame-pointer"="all" {
 ; CHECK-LABEL: use_input_context:
 
 ; CHECK-NOAUTH: str x22, [sp
@@ -104,7 +104,7 @@ define void @use_input_context(i8* swiftasync %ctx, i8** %ptr) "frame-pointer"="
   ret void
 }
 
-define i8** @context_in_func() "frame-pointer"="non-leaf" {
+define swifttailcc i8** @context_in_func() "frame-pointer"="non-leaf" {
 ; CHECK-LABEL: context_in_func:
 
 ; CHECK-NOAUTH: str xzr, [sp, #8]
@@ -118,7 +118,7 @@ define i8** @context_in_func() "frame-pointer"="non-leaf" {
   ret i8** %ptr
 }
 
-define void @write_frame_context(i8* swiftasync %ctx, i8* %newctx) "frame-pointer"="non-leaf" {
+define swifttailcc void @write_frame_context(i8* swiftasync %ctx, i8* %newctx) "frame-pointer"="non-leaf" {
 ; CHECK-LABEL: write_frame_context:
 ; CHECK: sub x[[ADDR:[0-9]+]], x29, #8
 ; CHECK: str x0, [x[[ADDR]]]
@@ -127,14 +127,14 @@ define void @write_frame_context(i8* swiftasync %ctx, i8* %newctx) "frame-pointe
   ret void
 }
 
-define void @simple_fp_elim(i8* swiftasync %ctx) "frame-pointer"="non-leaf" {
+define swifttailcc void @simple_fp_elim(i8* swiftasync %ctx) "frame-pointer"="non-leaf" {
 ; CHECK-LABEL: simple_fp_elim:
 ; CHECK-NOT: orr x29, x29, #0x100000000000000
 
   ret void
 }
 
-define void @large_frame(i8* swiftasync %ctx) "frame-pointer"="all" {
+define swifttailcc void @large_frame(i8* swiftasync %ctx) "frame-pointer"="all" {
 ; CHECK-LABEL: large_frame:
 ; CHECK: str x28, [sp, #-32]!
 ; CHECK: stp x29, x30, [sp, #16]
@@ -170,5 +170,6 @@ define void @two_unpaired_csrs(i8* swiftasync) "frame-pointer"="all" {
   call void @bar(i32* undef)
   ret void
 }
-declare void @bar(i32*)
+
+declare swifttailcc void @bar(i32*)
 declare i8** @llvm.swift.async.context.addr()

--- a/llvm/test/CodeGen/AArch64/swifttail-async.ll
+++ b/llvm/test/CodeGen/AArch64/swifttail-async.ll
@@ -27,3 +27,10 @@ define void @calls_swiftasync() {
   tail call void @has_swiftasync(i8* swiftasync null)
   ret void
 }
+
+define swifttailcc void @no_preserve_swiftself() {
+; CHECK-LABEL: no_preserve_swiftself:
+; CHECK-NOT: ld{{.*}}x20
+  call void asm "","~{x20}"()
+  ret void
+}

--- a/llvm/test/CodeGen/AArch64/swifttail-call.ll
+++ b/llvm/test/CodeGen/AArch64/swifttail-call.ll
@@ -158,7 +158,7 @@ define { double, [2 x double] } @test_mismatched_insert() {
 
 define void @fromC_totail() {
 ; COMMON-LABEL: fromC_totail:
-; COMMON: sub sp, sp, #32
+; COMMON: sub sp, sp, #48
 
 ; COMMON-NOT: sub sp,
 ; COMMON: mov w[[TMP:[0-9]+]], #42
@@ -176,7 +176,7 @@ define void @fromC_totail() {
 
 define void @fromC_totail_noreservedframe(i32 %len) {
 ; COMMON-LABEL: fromC_totail_noreservedframe:
-; COMMON: stp x29, x30, [sp, #-32]!
+; COMMON: stp x29, x30, [sp, #-48]!
 
 ; COMMON: mov w[[TMP:[0-9]+]], #42
   ; Note stack is subtracted here to allocate space for arg
@@ -217,4 +217,14 @@ define swifttailcc void @fromtail_toC() {
   call void @Ccallee_stack8([8 x i64] undef, i64 42)
   call void @Ccallee_stack8([8 x i64] undef, i64 42)
   ret void
+}
+
+declare swifttailcc i8* @SwiftSelf(i8 * swiftasync %context, i8* swiftself %closure)
+define swiftcc i8* @CallSwiftSelf(i8* swiftself %closure, i8* %context) {
+; CHECK-LABEL: CallSwiftSelf:
+; CHECK: stp x20
+  ;call void asm "","~{r13}"() ; We get a push r13 but why not with the call
+  ; below?
+  %res = call swifttailcc i8* @SwiftSelf(i8 * swiftasync %context, i8* swiftself %closure)
+  ret i8* %res
 }

--- a/llvm/test/CodeGen/X86/swifttail-async.ll
+++ b/llvm/test/CodeGen/X86/swifttail-async.ll
@@ -27,3 +27,20 @@ define void @calls_swiftasync() {
   tail call void @has_swiftasync(i8* swiftasync null)
   ret void
 }
+
+define swifttailcc void @no_preserve_swiftself() {
+; CHECK-LABEL: no_preserve_swiftself:
+; CHECK-NOT: popq %r13
+  call void asm "","~{r13}"()
+  ret void
+}
+
+declare swifttailcc i8* @SwiftSelf(i8 * swiftasync %context, i8* swiftself %closure)
+define swiftcc i8* @CallSwiftSelf(i8* swiftself %closure, i8* %context) {
+; CHECK-LABEL: CallSwiftSelf:
+; CHECK: pushq %r13
+  ;call void asm "","~{r13}"() ; We get a push r13 but why not with the call
+  ; below?
+  %res = call swifttailcc i8* @SwiftSelf(i8 * swiftasync %context, i8* swiftself %closure)
+  ret i8* %res
+}

--- a/llvm/test/CodeGen/X86/tailcall-swifttailcc.ll
+++ b/llvm/test/CodeGen/X86/tailcall-swifttailcc.ll
@@ -45,3 +45,19 @@ define dso_local swifttailcc i32 @noret() nounwind {
   tail call swifttailcc void @does_not_return()
   unreachable
 }
+
+define dso_local swifttailcc void @void_test(i32, i32, i32, i32) {
+; CHECK-LABEL: void_test:
+; CHECK:    jmp void_test
+  entry:
+   musttail call swifttailcc void @void_test( i32 %0, i32 %1, i32 %2, i32 %3)
+   ret void
+}
+
+define dso_local swifttailcc i1 @i1test(i32, i32, i32, i32) {
+; CHECK-LABEL: i1test:
+; CHECK:    jmp i1test
+  entry:
+  %4 = musttail call swifttailcc i1 @i1test( i32 %0, i32 %1, i32 %2, i32 %3)
+  ret i1 %4
+}

--- a/llvm/test/Verifier/swiftasync.ll
+++ b/llvm/test/Verifier/swiftasync.ll
@@ -1,0 +1,4 @@
+; RUN: not llvm-as %s -o /dev/null 2>&1 | FileCheck %s
+
+declare void @a(i32* swiftasync %a, i32* swiftasync %b)
+; CHECK: Cannot have multiple 'swiftasync' parameters!

--- a/llvm/utils/emacs/llvm-mode.el
+++ b/llvm/utils/emacs/llvm-mode.el
@@ -55,7 +55,7 @@
 
          ;; Calling conventions
          "ccc" "fastcc" "coldcc" "webkit_jscc" "anyregcc" "preserve_mostcc" "preserve_allcc"
-         "cxx_fast_tlscc" "swiftcc"
+         "cxx_fast_tlscc" "swiftcc" "swifttailcc" "tailcc"
 
          "atomic" "volatile" "personality" "prologue" "section") 'symbols) . font-lock-keyword-face)
    ;; Arithmetic and Logical Operators

--- a/llvm/utils/vim/syntax/llvm.vim
+++ b/llvm/utils/vim/syntax/llvm.vim
@@ -153,6 +153,8 @@ syn keyword llvmKeyword
       \ sspstrong
       \ strictfp
       \ swiftcc
+      \ swifterror
+      \ swifttailcc
       \ swiftself
       \ tail
       \ target


### PR DESCRIPTION
    * Fix addressing-mode range for StoreSwiftAsyncContext
      * Constrain GISel instruction correctly.
      * Rename calling conv in .td
      * Base preserved mask on CC of callee, not caller.
      * Fix x86 FastISel
      * Change type of pop size to int (NFC since unsigned wrap is fine).