### PR TITLE
Fix title underline length

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -12137,7 +12137,7 @@ other aggressive transformations, so the value returned may not be that
 of the obvious source-language caller.
 
 '``llvm.swift.async.context.addr``' Intrinsic
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Syntax:
 """""""


### PR DESCRIPTION
    llvm-project/llvm/docs/LangRef.rst:12140: WARNING: Title underline too short.

    '``llvm.swift.async.context.addr``' Intrinsic
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^