### PR TITLE
[VFS] Fix Wreturn-type gcc warning (NFC)

### DIFF
--- a/llvm/include/llvm/Support/VirtualFileSystem.h
+++ b/llvm/include/llvm/Support/VirtualFileSystem.h
@@ -678,6 +678,7 @@ public:
       case EK_Directory:
         return false;
       }
+      llvm_unreachable("invalid entry kind");
     }
   };
 


### PR DESCRIPTION
GCC warning:
```
In file included from /llvm-project/llvm/lib/Support/VirtualFileSystem.cpp:13:
/llvm-project/llvm/include/llvm/Support/VirtualFileSystem.h: In static member function ‘static bool llvm::vfs::RedirectingFileSystem::RemapEntry::classof(const llvm::vfs::RedirectingFileSystem::Entry*)’:
/llvm-project/llvm/include/llvm/Support/VirtualFileSystem.h:681:5: warning: control reaches end of non-void function [-Wreturn-type]
  681 |     }
      |     ^
```

(cherry picked from commit 8178a55b25704e150edf4c595a4283bc757c8fb8)