### PR TITLE
[lldb/Platform] Skip very slow xcrun queries for simulator platforms, NFC

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
@@ -505,6 +505,16 @@ uint32_t PlatformAppleSimulator::FindProcesses(
   return process_infos.size();
 }
 
+/// Whether to skip creating a simulator platform.
+static bool shouldSkipSimulatorPlatform(bool force, const ArchSpec *arch) {
+  // If the arch is known not to specify a simulator environment, skip creating
+  // the simulator platform (we can create it later if there's a matching arch).
+  // This avoids very slow xcrun queries for non-simulator archs (the slowness
+  // is due to xcrun not caching negative queries (rdar://74882205)).
+  return !force && arch && arch->IsValid() &&
+         !arch->TripleEnvironmentWasSpecified();
+}
+
 static llvm::StringRef GetXcodeSDKDir(std::string preferred,
                                       std::string secondary) {
   llvm::StringRef sdk;
@@ -530,6 +540,8 @@ struct PlatformiOSSimulator {
   }
 
   static PlatformSP CreateInstance(bool force, const ArchSpec *arch) {
+    if (shouldSkipSimulatorPlatform(force, arch))
+      return nullptr;
     llvm::StringRef sdk;
     sdk = HostInfo::GetXcodeSDKPath(XcodeSDK("iPhoneSimulator.Internal.sdk"));
     if (sdk.empty())
@@ -578,6 +590,8 @@ struct PlatformAppleTVSimulator {
   }
 
   static PlatformSP CreateInstance(bool force, const ArchSpec *arch) {
+    if (shouldSkipSimulatorPlatform(force, arch))
+      return nullptr;
     return PlatformAppleSimulator::CreateInstance(
         "PlatformAppleTVSimulator", g_tvos_description,
         ConstString(g_tvos_plugin_name),
@@ -619,6 +633,8 @@ struct PlatformAppleWatchSimulator {
   }
 
   static PlatformSP CreateInstance(bool force, const ArchSpec *arch) {
+    if (shouldSkipSimulatorPlatform(force, arch))
+      return nullptr;
     return PlatformAppleSimulator::CreateInstance(
         "PlatformAppleWatchSimulator", g_watchos_description,
         ConstString(g_watchos_plugin_name),


### PR DESCRIPTION
GetXcodeSDK() consistently takes over 1 second to complete if the
queried SDK is missing, because `xcrun` doesn't cache negative lookups.

Because there are multiple simulator platforms, this can add 4+ seconds
to `lldb -b some_object_file.o`.

To work around this, skip the call to GetXcodeSDK() when setting up
simulator platforms if the specified arch doesn't have what looks like a
simulator triple.

Some other ways to fix this:
- Fix caching in xcrun (rdar://74882205)
- Test for arch compat before calling SomePlatform::CreateInstance() (much
  larger change)

Differential Revision: https://reviews.llvm.org/D98272

(cherry picked from commit ac29c35207a506eedaaea8a4196b83facbf978da)
