### PR TITLE
[lldb] Swift async: Hopefully correct unwinder

### DIFF
--- a/lldb/include/lldb/Symbol/UnwindPlan.h
+++ b/lldb/include/lldb/Symbol/UnwindPlan.h
@@ -360,6 +360,9 @@ public:
 
     bool SetRegisterLocationToSame(uint32_t reg_num, bool must_replace);
 
+    bool SetRegisterLocationToIsDWARFExpression(uint32_t reg_num,
+                                                const uint8_t *opcodes,
+                                                uint32_t len, bool can_replace);
     // When this UnspecifiedRegistersAreUndefined mode is
     // set, any register that is not specified by this Row will
     // be described as Undefined.

--- a/lldb/source/Symbol/UnwindPlan.cpp
+++ b/lldb/source/Symbol/UnwindPlan.cpp
@@ -352,6 +352,18 @@ bool UnwindPlan::Row::SetRegisterLocationToSame(uint32_t reg_num,
   return true;
 }
 
+bool UnwindPlan::Row::SetRegisterLocationToIsDWARFExpression(
+    uint32_t reg_num, const uint8_t *opcodes, uint32_t len, bool can_replace) {
+  if (!can_replace &&
+      m_register_locations.find(reg_num) != m_register_locations.end())
+    return false;
+  RegisterLocation reg_loc;
+  reg_loc.SetIsDWARFExpression(opcodes, len);
+  m_register_locations[reg_num] = reg_loc;
+  return true;
+}
+
+
 bool UnwindPlan::Row::operator==(const UnwindPlan::Row &rhs) const {
   return m_offset == rhs.m_offset && m_cfa_value == rhs.m_cfa_value &&
          m_afa_value == rhs.m_afa_value &&

--- a/lldb/test/API/lang/swift/async/unwind/backtrace_locals/TestSwiftAsyncBacktraceLocals.py
+++ b/lldb/test/API/lang/swift/async/unwind/backtrace_locals/TestSwiftAsyncBacktraceLocals.py
@@ -11,6 +11,7 @@ class TestSwiftAsyncBacktraceLocals(lldbtest.TestBase):
 
     @swiftTest
     @skipIf(oslist=['windows', 'linux'])
+    @skipIf(archs=no_match(["arm64", "arm64e", "arm64_32", "x86_64"]))
     def test(self):
         """Test async unwind"""
         self.build()
@@ -23,19 +24,39 @@ class TestSwiftAsyncBacktraceLocals(lldbtest.TestBase):
         
         if self.TraceOn():
            self.runCmd("bt all")
-           
+
+        # cfa[n] contains the CFA for the fibonacci(n) call.
+        cfa = [ None for _ in range(11) ]
+
+        # Continue 10 times, hitting all the initial calls to the fibonacci()
+        # function with decreasing arguments.
         for n in range(10):
             lldbutil.continue_to_breakpoint(process, start_bkpt)
+            # The top frame is fibonacci(10-n)
             for f in range(n+1):
-               frame = thread.GetFrameAtIndex(f)
-               self.assertIn("fibonacci", frame.GetFunctionName(), 
-                             "Redundantly confirm that we're stopped in fibonacci()")
-               if f == 0:
-                   # Get arguments (arguments, locals, statics, in_scope_only)
-                   args = frame.GetVariables(True, False, False, True)
-                   self.assertEqual(len(args), 1, "Found one argument")
-                   self.assertEqual(args[0].GetName(), "n", "Found n argument")
-                   self.assertEqual(args[0].GetValue(), str(10-n), "n has correct value")
+                frame = thread.GetFrameAtIndex(f)
+                # The selected frame is fibonacci(10-n+f)
+                fibonacci_number = 10-n+f
+                self.assertIn("fibonacci", frame.GetFunctionName(),
+                              "Redundantly confirm that we're stopped in fibonacci()")
+                if not cfa[fibonacci_number]:
+                    cfa[fibonacci_number] = frame.GetCFA()
+                else:
+                    self.assertEqual(cfa[fibonacci_number], frame.GetCFA(),
+                                     "Stable CFA for the first 10 recursions")
+                # Get arguments (arguments, locals, statics, in_scope_only)
+                args = frame.GetVariables(True, False, False, True)
+                self.assertEqual(len(args), 1, "Found one argument")
+                self.assertEqual(args[0].GetName(), "n", "Found n argument")
+                self.assertEqual(args[0].GetValue(), str(fibonacci_number), "n has correct value")
+                if f != 0:
+                    # The PC of a logical frame is stored in its "callee"
+                    # AsyncContext as the second pointer field.
+                    error = lldb.SBError()
+                    ret_addr = process.ReadPointerFromMemory(cfa[fibonacci_number-1] + target.addr_size, error)
+                    self.assertTrue(error.Success(), "Managed to read context memory")
+                    self.assertEqual(ret_addr, frame.GetPC())
+
             self.assertIn("Main.main", thread.GetFrameAtIndex(n+1).GetFunctionName())
 
         lldbutil.continue_to_breakpoint(process, end_bkpt)
@@ -44,6 +65,13 @@ class TestSwiftAsyncBacktraceLocals(lldbtest.TestBase):
         self.assertEqual(len(args), 1, "Found one argument")
         self.assertEqual(args[0].GetName(), "n", "Found n argument")
         self.assertEqual(args[0].GetValue(), str(1), "n has correct value")
+        # Callers have n values from 2 to 10
+        for n in range(1,9):
+            frame = thread.GetFrameAtIndex(n)
+            args = frame.GetVariables(True, False, False, True)
+            self.assertEqual(len(args), 1, "Found one argument")
+            self.assertEqual(args[0].GetName(), "n", "Found n argument")
+            self.assertEqual(args[0].GetValue(), str(n+1), "n has correct value")
 
         lldbutil.continue_to_breakpoint(process, end_bkpt)
         frame = thread.GetFrameAtIndex(0)
@@ -51,3 +79,10 @@ class TestSwiftAsyncBacktraceLocals(lldbtest.TestBase):
         self.assertEqual(len(args), 1, "Found one argument")
         self.assertEqual(args[0].GetName(), "n", "Found n argument")
         self.assertEqual(args[0].GetValue(), str(0), "n has correct value")
+        # Callers have n values from 2 to 10
+        for n in range(1,9):
+            frame = thread.GetFrameAtIndex(n)
+            args = frame.GetVariables(True, False, False, True)
+            self.assertEqual(len(args), 1, "Found one argument")
+            self.assertEqual(args[0].GetName(), "n", "Found n argument")
+            self.assertEqual(args[0].GetValue(), str(n+1), "n has correct value")

--- a/lldb/test/API/lang/swift/async/unwind/backtrace_locals/main.swift
+++ b/lldb/test/API/lang/swift/async/unwind/backtrace_locals/main.swift
@@ -4,6 +4,7 @@ func fibonacci(_ n: Int) async -> Int {
     }
     let n_1 = await fibonacci(n - 1)
     let n_2 = await fibonacci(n - 2)
+    print(n, n_1, n_2)
     return n_1 + n_2
 }
 


### PR DESCRIPTION
The unwinder situation for async frames is tricky because the ABI is
not completely uniform. Most coroutines take a context register as
argument and need to dereference it to get their actualy async
context. Unfortunately this is not true when you are the first
coroutine extracted from an async function, in this case you take your
context directly.

Accounting for the above disparity is not easy because lower frames
might need to know about the semantic applied to the frame above them
and that's not something the unwinder traditionally does. In this
patch, we use a dummy register as a marker to signal that to our
parent frame.