### PR TITLE
[LLDB] Fix `Wunused-result` warning

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -2843,7 +2843,9 @@ void CommandInterpreter::IOHandlerInputComplete(IOHandler &io_handler,
   StartHandlingCommand();
 
   OverrideExecutionContext(m_debugger.GetSelectedExecutionContext());
-  llvm::make_scope_exit([this]() { RestoreExecutionContext(); });
+  auto finalize = llvm::make_scope_exit([this]() {
+    RestoreExecutionContext();
+  });
 
   lldb_private::CommandReturnObject result(m_debugger.GetUseColor());
   HandleCommand(line.c_str(), eLazyBoolCalculate, result);


### PR DESCRIPTION
(cherry picked from commit 5a63045fe78834937785ed5081052e083a98077f)