### PR TITLE
[lldb] Disable Stepper/TestSwiftBenchmarkOnone

### DIFF
--- a/lldb/test/Shell/Stepper/TestSwiftBenchmarkOnone.1.test
+++ b/lldb/test/Shell/Stepper/TestSwiftBenchmarkOnone.1.test
@@ -1,4 +1,5 @@
 # REQUIRES: swift_Benchmark_Onone
+# REQUIRES: rdar75336700
 #
 # The test has regressed, tracked by: rdar://73760364
 # XFAIL: *


### PR DESCRIPTION
This XFAIL test has started unexpectedly passing. Disabling it to not block CI.