### PR TITLE
[asan] disable no-fd test on darwin

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/no-fd.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/no-fd.cpp
@@ -10,6 +10,9 @@
 // lld - see https://bugs.llvm.org/show_bug.cgi?id=45076.
 // UNSUPPORTED: android, powerpc
 
+// Deflake this test before reinabling for darwin (rdar://74992832)
+// UNSUPPORTED: darwin
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
If a log message is triggered between execv and child, this test fails.
In the meantime, disable the test to unblock CI

rdar://74992832

Reviewed By: delcypher

Differential Revision: https://reviews.llvm.org/D98453

(cherry picked from commit 03afd5cea48509cb8d5f10bf1a863bf47c3ef9c2)