### PR TITLE
arm64e: authenticate LR against the correct SP when tail calling.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.h
@@ -61,6 +61,10 @@ public:
                               MutableArrayRef<CalleeSavedInfo> CSI,
                               const TargetRegisterInfo *TRI) const override;
 
+  void insertAuthLR(MachineBasicBlock &MBB,
+                    int64_t ArgumentStackToRestore,
+                    DebugLoc DL) const;
+
   /// Can this function use the red zone for local allocations.
   bool canUseRedZone(const MachineFunction &MF) const;
 

--- a/llvm/test/CodeGen/AArch64/swifttail-ptrauth.ll
+++ b/llvm/test/CodeGen/AArch64/swifttail-ptrauth.ll
@@ -1,0 +1,49 @@
+; RUN: llc -verify-machineinstrs < %s -mtriple=arm64e-apple-macosx | FileCheck %s
+
+declare swifttailcc void @callee_stack0()
+declare swifttailcc void @callee_stack8([8 x i64], i64)
+declare swifttailcc void @callee_stack16([8 x i64], i64, i64)
+declare extern_weak swifttailcc void @callee_weak()
+
+define swifttailcc void @caller_to0_from0() "ptrauth-returns" "frame-pointer"="all" nounwind {
+; CHECK-LABEL: caller_to0_from0:
+; CHECK: stp x29, x30, [sp, #-16]!
+; [...]
+; CHECK: ldp x29, x30, [sp], #16
+; CHECK-NEXT: autibsp
+; CHECK-NOT: add sp
+; CHECK-NOT: sub sp
+  musttail call swifttailcc void @callee_stack0()
+  ret void
+
+}
+
+define swifttailcc void @caller_to0_from8([8 x i64], i64) "ptrauth-returns" "frame-pointer"="all" {
+; CHECK-LABEL: caller_to0_from8:
+; CHECK: stp x29, x30, [sp, #-16]!
+; [...]
+; CHECK: ldp x29, x30, [sp], #16
+; CHECK-NEXT: autibsp
+; CHECK: add sp, sp, #16
+
+  musttail call swifttailcc void @callee_stack0()
+  ret void
+
+}
+
+define swifttailcc void @caller_to8_from0() "ptrauth-returns" "frame-pointer"="all" {
+; CHECK-LABEL: caller_to8_from0:
+; CHECK: stp x29, x30, [sp, #-32]!
+; [...]
+; CHECK: ldp x29, x30, [sp], #16
+; CHECK-NEXT: add x16, sp, #16
+; CHECK-NEXT: autib x30, x16
+; CHECK-NOT: add sp
+; CHECK-NOT: sub sp
+
+; Key point is that we don't move sp then autibsp because that leaves live
+; arguments below sp, potentially outside the redzone.
+  musttail call swifttailcc void @callee_stack8([8 x i64] undef, i64 42)
+  ret void
+
+}


### PR DESCRIPTION
With a guaranteed tail calling convention, SP can be different on function exit compared to entry. This means the natural AUTIBSP instruction no longer has the correct discriminator.

To fix this, we try to put SP back to where it was on entry before executing. If that's not possible because it would expose live function arguments outside the red-zone then we find a temporary register and use AUTIB instead.