### PR TITLE
Add withExtendedLifetime to a few lldb tests.

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Dylib.swift
+++ b/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Dylib.swift
@@ -7,5 +7,6 @@ public class Foo : NSObject {
     // When evaluating "input" here, RemoteAST will try to get its
     // dynamic type.
     print("break here")
+    withExtendedLifetime(input) {}
   }
 }

--- a/lldb/test/API/lang/swift/clangimporter/remoteast_import/Library.swift
+++ b/lldb/test/API/lang/swift/clangimporter/remoteast_import/Library.swift
@@ -8,5 +8,6 @@ public final class Foo : NSObject {
     // dynamic type.  This must *not* trigger an import of the "main"
     // module in the Library module context.
     print("break here")
+    withExtendedLifetime(input) {}
   }
 }

--- a/lldb/test/API/lang/swift/variables/bridged_string/main.swift
+++ b/lldb/test/API/lang/swift/variables/bridged_string/main.swift
@@ -20,6 +20,7 @@ func main()
 	let s5 = "abc" as NSString
 	let s6 = String(s5)
 	print(s1) // Set breakpoint here
+        withExtendedLifetime((s2, s3, s4, s5, s6)) {}
 }
 
 main()

--- a/lldb/test/Shell/Stepper/TestSwiftBenchmarkOnone.1.test
+++ b/lldb/test/Shell/Stepper/TestSwiftBenchmarkOnone.1.test
@@ -1,7 +1,8 @@
 # REQUIRES: swift_Benchmark_Onone
 #
 # The test has regressed, tracked by: rdar://73760364
-# XFAIL: *
+# The regression only appears when compiling with -disable-copy-propagation.
+# REQUIRES: rdar73760364
 #
 # - Don't capture a reproducer (it can easily exceed 1GB).
 # - Skip `po` testing for now (until we can un-XFAIL `frame var` testing).

--- a/lldb/test/Shell/Swift/Inputs/Library.swift
+++ b/lldb/test/Shell/Swift/Inputs/Library.swift
@@ -8,5 +8,6 @@ public final class Foo : NSObject {
     // dynamic type.  This must *not* trigger an import of the "main"
     // module in the Library module context.
     print("break here")
+    withExtendedLifetime(input) {}
   }
 }


### PR DESCRIPTION
Required for landing Swift PR:
Enable mandatory copy propagation (shortens -Onone lifetimes) #36408
https://github.com/apple/swift/pull/36408