### PR TITLE
  SwiftAsync: only change callee-saved registers for `swifttailcc`.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
@@ -100,9 +100,7 @@ AArch64RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
       MF->getFunction().getAttributes().hasAttrSomewhere(
           Attribute::SwiftError))
     return CSR_AArch64_AAPCS_SwiftError_SaveList;
-  if (MF->getFunction().getAttributes().hasAttrSomewhere(
-          Attribute::SwiftAsync) ||
-      MF->getFunction().getCallingConv() == CallingConv::SwiftTail)
+  if (MF->getFunction().getCallingConv() == CallingConv::SwiftTail)
     return CSR_AArch64_AAPCS_SwiftTail_SaveList;
   if (MF->getFunction().getCallingConv() == CallingConv::PreserveMost)
     return CSR_AArch64_RT_MostRegs_SaveList;
@@ -138,9 +136,7 @@ AArch64RegisterInfo::getDarwinCalleeSavedRegs(const MachineFunction *MF) const {
       MF->getFunction().getAttributes().hasAttrSomewhere(
           Attribute::SwiftError))
     return CSR_Darwin_AArch64_AAPCS_SwiftError_SaveList;
-  if (MF->getFunction().getAttributes().hasAttrSomewhere(
-          Attribute::SwiftAsync) ||
-      MF->getFunction().getCallingConv() == CallingConv::SwiftTail)
+  if (MF->getFunction().getCallingConv() == CallingConv::SwiftTail)
     return CSR_Darwin_AArch64_AAPCS_SwiftTail_SaveList;
   if (MF->getFunction().getCallingConv() == CallingConv::PreserveMost)
     return CSR_Darwin_AArch64_RT_MostRegs_SaveList;
@@ -207,9 +203,7 @@ AArch64RegisterInfo::getDarwinCallPreservedMask(const MachineFunction &MF,
           ->supportSwiftError() &&
       MF.getFunction().getAttributes().hasAttrSomewhere(Attribute::SwiftError))
     return CSR_Darwin_AArch64_AAPCS_SwiftError_RegMask;
-  if (MF.getFunction().getAttributes().hasAttrSomewhere(
-          Attribute::SwiftAsync) ||
-      CC == CallingConv::SwiftTail)
+  if (CC == CallingConv::SwiftTail)
     return CSR_Darwin_AArch64_AAPCS_SwiftTail_RegMask;
   if (CC == CallingConv::PreserveMost)
     return CSR_Darwin_AArch64_RT_MostRegs_RegMask;
@@ -245,9 +239,7 @@ AArch64RegisterInfo::getCallPreservedMask(const MachineFunction &MF,
       MF.getFunction().getAttributes().hasAttrSomewhere(Attribute::SwiftError))
     return SCS ? CSR_AArch64_AAPCS_SwiftError_SCS_RegMask
                : CSR_AArch64_AAPCS_SwiftError_RegMask;
-  if (MF.getFunction().getAttributes().hasAttrSomewhere(
-          Attribute::SwiftAsync) ||
-      CC == CallingConv::SwiftTail) {
+  if (CC == CallingConv::SwiftTail) {
     if (SCS)
       report_fatal_error("ShadowCallStack attribute not supported with swifttail");
     return CSR_AArch64_AAPCS_SwiftTail_RegMask;

--- a/llvm/lib/Target/X86/X86RegisterInfo.cpp
+++ b/llvm/lib/Target/X86/X86RegisterInfo.cpp
@@ -384,11 +384,6 @@ X86RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
       return IsWin64 ? CSR_Win64_SwiftError_SaveList
                      : CSR_64_SwiftError_SaveList;
 
-    if (F.getAttributes().hasAttrSomewhere(Attribute::SwiftAsync) ||
-        F.getCallingConv() == CallingConv::SwiftTail)
-      return IsWin64 ? CSR_Win64_SwiftTail_SaveList
-                     : CSR_64_SwiftTail_SaveList;
-
     if (IsWin64)
       return HasSSE ? CSR_Win64_SaveList : CSR_Win64_NoSSE_SaveList;
     if (CallsEHReturn)
@@ -506,9 +501,6 @@ X86RegisterInfo::getCallPreservedMask(const MachineFunction &MF,
                      F.getAttributes().hasAttrSomewhere(Attribute::SwiftError);
     if (IsSwiftCC)
       return IsWin64 ? CSR_Win64_SwiftError_RegMask : CSR_64_SwiftError_RegMask;
-
-    if (F.getAttributes().hasAttrSomewhere(Attribute::SwiftAsync))
-      return IsWin64 ? CSR_Win64_SwiftTail_RegMask : CSR_64_SwiftTail_RegMask;
 
     return IsWin64 ? CSR_Win64_RegMask : CSR_64_RegMask;
   }

--- a/llvm/test/CodeGen/AArch64/swifttail-async.ll
+++ b/llvm/test/CodeGen/AArch64/swifttail-async.ll
@@ -12,7 +12,7 @@ define swifttailcc void @swifttail() {
 
 define void @has_swiftasync(i8* swiftasync %in) {
 ; CHECK-LABEL: has_swiftasync:
-; CHECK-NOT: ld{{.*}}x22
+; CHECK: ld{{.*}}x22
   call void asm "","~{x22}"()
   ret void
 }

--- a/llvm/test/CodeGen/X86/swifttail-async.ll
+++ b/llvm/test/CodeGen/X86/swifttail-async.ll
@@ -12,7 +12,7 @@ define swifttailcc void @swifttail() {
 
 define void @has_swiftasync(i8* swiftasync %in) {
 ; CHECK-LABEL: has_swiftasync:
-; CHECK-NOT: popq %r14
+; CHECK: popq %r14
   call void asm "","~{r14}"()
   ret void
 }


### PR DESCRIPTION
We had decided that any function taking a `swiftasync` parameter reduced the set of callee-saved registers because I thought at the time it was needed to adopt `swiftasync` before `swifttailcc`. This isn't so, it's just a slight optimization, and a confusing one at that. So remove that special case.