### PR TITLE
Delay requesting a scratch context in BindGenericTypeParameters() 

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1952,13 +1952,11 @@ SwiftLanguageRuntimeImpl::BindGenericTypeParameters(StackFrame &stack_frame,
   using namespace swift::Demangle;
 
   Status error;
-  auto &target = m_process.GetTarget();
-  auto scratch_ctx = target.GetScratchSwiftASTContext(error, stack_frame);
   auto *reflection_ctx = GetReflectionContext();
-  if (!scratch_ctx || !reflection_ctx) {
+  if (!reflection_ctx) {
     LLDB_LOG(
         GetLogIfAnyCategoriesSet(LIBLLDB_LOG_EXPRESSIONS | LIBLLDB_LOG_TYPES),
-        "No scratch/reflection context available.");
+        "No reflection context available.");
     return ts.GetTypeFromMangledTypename(mangled_name);
   }
 
@@ -2029,6 +2027,14 @@ SwiftLanguageRuntimeImpl::BindGenericTypeParameters(StackFrame &stack_frame,
   // function, we don't want to do this earlier, because the
   // canonicalization in GetCanonicalDemangleTree() must be performed in
   // the original context as to resolve type aliases correctly.
+  auto &target = m_process.GetTarget();
+  auto scratch_ctx = target.GetScratchSwiftASTContext(error, stack_frame);
+  if (!scratch_ctx) {
+    LLDB_LOG(
+        GetLogIfAnyCategoriesSet(LIBLLDB_LOG_EXPRESSIONS | LIBLLDB_LOG_TYPES),
+        "No scratch context available.");
+    return ts.GetTypeFromMangledTypename(mangled_name);
+  }
   bound_type = scratch_ctx->get()->ImportType(bound_type, error);
   
   LLDB_LOG(


### PR DESCRIPTION
until we know that the type is actually generic. As we recentyly
discovered, requesting an already-created scratch context is actually
a surprisingly expensive operation, so we shouldn't do it unless we
know that we actually need it.

rdar://75372262