### PR TITLE
Cache the results of SwiftASTContext::GetCompileUnitImports()

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -8320,8 +8320,8 @@ bool SwiftASTContext::GetImplicitImports(
     llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
         &modules,
     Status &error) {
-  if (!GetCompileUnitImports(swift_ast_context, sc, stack_frame_wp, modules,
-                             error)) {
+  if (!swift_ast_context.GetCompileUnitImports(sc, stack_frame_wp, &modules,
+                                               error)) {
     return false;
   }
 
@@ -8392,23 +8392,37 @@ bool SwiftASTContext::CacheUserImports(SwiftASTContext &swift_ast_context,
   return true;
 }
 
+namespace {
+struct CUSignature : public std::pair<Module *, lldb::user_id_t> {
+  CUSignature(CompileUnit &compile_unit)
+      : std::pair<Module *, lldb::user_id_t>(compile_unit.GetModule().get(),
+                                             compile_unit.GetID()) {}
+};
+} // namespace
+
 bool SwiftASTContext::GetCompileUnitImports(
-    SwiftASTContext &swift_ast_context, SymbolContext &sc,
-    lldb::StackFrameWP &stack_frame_wp,
+    SymbolContext &sc, lldb::StackFrameWP &stack_frame_wp,
     llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
-        &modules,
+        *modules,
     Status &error) {
+  CompileUnit *compile_unit = sc.comp_unit;
+  if (compile_unit)
+    if (m_cu_imports.insert(CUSignature(*compile_unit)).second)
+      // List of imports isn't requested and we already processes this CU?
+      if (!modules)
+        return true;
+
   // Import the Swift standard library and its dependencies.
   SourceModule swift_module;
   swift_module.path.emplace_back("Swift");
   auto *stdlib =
-      LoadOneModule(swift_module, swift_ast_context, stack_frame_wp, error);
+      LoadOneModule(swift_module, *this, stack_frame_wp, error);
   if (!stdlib)
     return false;
 
-  modules.emplace_back(swift::ImportedModule(stdlib));
+  if (modules)
+    modules->emplace_back(swift::ImportedModule(stdlib));
 
-  CompileUnit *compile_unit = sc.comp_unit;
   if (!compile_unit || compile_unit->GetLanguage() != lldb::eLanguageTypeSwift)
     return true;
 
@@ -8423,11 +8437,12 @@ bool SwiftASTContext::GetCompileUnitImports(
       continue;
 
     auto *loaded_module =
-        LoadOneModule(module, swift_ast_context, stack_frame_wp, error);
+        LoadOneModule(module, *this, stack_frame_wp, error);
     if (!loaded_module)
       return false;
 
-    modules.emplace_back(swift::ImportedModule(loaded_module));
+    if (modules)
+      modules->emplace_back(swift::ImportedModule(loaded_module));
   }
   return true;
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -774,13 +774,19 @@ public:
                                lldb::StackFrameWP &stack_frame_wp,
                                swift::SourceFile &source_file, Status &error);
 
-  /// Retrieve the modules imported by the compilation unit.
-  static bool GetCompileUnitImports(
-      SwiftASTContext &swift_ast_context, SymbolContext &sc,
-      lldb::StackFrameWP &stack_frame_wp,
+  /// Retrieve/import the modules imported by the compilation unit.
+  bool GetCompileUnitImports(
+      SymbolContext &sc, lldb::StackFrameWP &stack_frame_wp,
       llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
-          &modules,
+          *modules,
       Status &error);
+
+  /// Perform all the implicit imports for the current frame.
+  void PerformCompileUnitImports(SymbolContext &sc,
+                                 lldb::StackFrameWP &stack_frame_wp,
+                                 Status &error) {
+    GetCompileUnitImports(sc, stack_frame_wp, nullptr, error);
+  }
 
 protected:
   /// This map uses the string value of ConstStrings as the key, and the
@@ -868,6 +874,8 @@ protected:
   /// respective result (true = loaded, false = failed to load).
   std::unordered_map<detail::SwiftLibraryLookupRequest, bool>
       library_load_cache;
+  /// A cache for GetCompileUnitImports();
+  llvm::DenseSet<std::pair<Module *, lldb::user_id_t>> m_cu_imports;
 
   typedef std::map<Module *, std::vector<lldb::DataBufferSP>> ASTFileDataMap;
   ASTFileDataMap m_ast_file_data_map;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2557,10 +2557,7 @@ llvm::Optional<SwiftASTContextReader> Target::GetScratchSwiftASTContext(
       !swift_ast_ctx->HasFatalErrors()) {
     StackFrameWP frame_wp(frame_sp);
     SymbolContext sc = frame_sp->GetSymbolContext(lldb::eSymbolContextEverything);
-    llvm::SmallVector<swift::AttributedImport<swift::ImportedModule>, 16>
-        modules;
-    swift_ast_ctx->GetCompileUnitImports(*swift_ast_ctx, sc, frame_wp, modules,
-                                         error);
+    swift_ast_ctx->PerformCompileUnitImports(sc, frame_wp, error);
   }
 
   if (!swift_ast_ctx)


### PR DESCRIPTION
Every time a scratch context is requested, a call to
GetCompileUnitImports() is made, which is both expensive and
redundant. This patch adds a cache that keeps track of compile units
for which the imports were already performed. This results in a
measurable performance improvement on the LLDB test suite.

rdar://75381959

The results are very noisy, so please take this with a grain of salt.
Before:
```
Tests Times:
--------------------------------------------------------------------------
[   Range   ] :: [               Percentage               ] :: [ Count ]
--------------------------------------------------------------------------
[150s,160s) :: [                                        ] :: [  1/355]
[140s,150s) :: [                                        ] :: [  0/355]
[130s,140s) :: [                                        ] :: [  0/355]
[120s,130s) :: [                                        ] :: [  0/355]
[110s,120s) :: [                                        ] :: [  0/355]
[100s,110s) :: [                                        ] :: [  0/355]
[ 90s,100s) :: [                                        ] :: [  0/355]
[ 80s, 90s) :: [                                        ] :: [  0/355]
[ 70s, 80s) :: [                                        ] :: [  1/355]
[ 60s, 70s) :: [                                        ] :: [  0/355]
[ 50s, 60s) :: [                                        ] :: [  7/355]
[ 40s, 50s) :: [                                        ] :: [  2/355]
[ 30s, 40s) :: [*                                       ] :: [ 11/355]
[ 20s, 30s) :: [****                                    ] :: [ 40/355]
[ 10s, 20s) :: [*****                                   ] :: [ 51/355]
[  0s, 10s) :: [***************************             ] :: [242/355]
--------------------------------------------------------------------------
```

After:

```
Tests Times:
--------------------------------------------------------------------------
[   Range   ] :: [               Percentage               ] :: [ Count ]
--------------------------------------------------------------------------
[140s,150s) :: [                                        ] :: [  1/355]
[130s,140s) :: [                                        ] :: [  0/355]
[120s,130s) :: [                                        ] :: [  0/355]
[110s,120s) :: [                                        ] :: [  0/355]
[100s,110s) :: [                                        ] :: [  0/355]
[ 90s,100s) :: [                                        ] :: [  0/355]
[ 80s, 90s) :: [                                        ] :: [  0/355]
[ 70s, 80s) :: [                                        ] :: [  1/355]
[ 60s, 70s) :: [                                        ] :: [  0/355]
[ 50s, 60s) :: [                                        ] :: [  3/355]
[ 40s, 50s) :: [                                        ] :: [  5/355]
[ 30s, 40s) :: [                                        ] :: [  7/355]
[ 20s, 30s) :: [****                                    ] :: [ 42/355]
[ 10s, 20s) :: [*****                                   ] :: [ 50/355]
[  0s, 10s) :: [***************************             ] :: [246/355]
--------------------------------------------------------------------------
```