### PR TITLE
[asan] disable MallocNanoZone for no fd test on darwin

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/no-fd.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/no-fd.cpp
@@ -1,6 +1,11 @@
 // RUN: %clangxx_asan -std=c++11 -O0 %s -o %t
-// RUN: %run %t 2>&1 | FileCheck %s
-// RUN: %env_asan_opts=debug=1,verbosity=2 %run %t 2>&1 | FileCheck %s
+
+// MallocNanoZone=0 disables initialization of the Nano MallocZone on Darwin.
+// Initialization of this zone can interfere with this test because the zone
+// might log which opens another file descriptor,
+// e.g. failing to setup the zone due to ASan taking the memory region it wants.
+// RUN: env MallocNanoZone=0 %run %t 2>&1 | FileCheck %s
+// RUN: env MallocNanoZone=0 %env_asan_opts=debug=1,verbosity=2 %run %t 2>&1 | FileCheck %s
 
 // Test ASan initialization
 
@@ -9,9 +14,6 @@
 // versions of Android. On PPC with ASLR turned on, this fails when linked with
 // lld - see https://bugs.llvm.org/show_bug.cgi?id=45076.
 // UNSUPPORTED: android, powerpc
-
-// Deflake this test before reinabling for darwin (rdar://74992832)
-// UNSUPPORTED: darwin
 
 #include <assert.h>
 #include <stdio.h>


### PR DESCRIPTION
On Darwin, MallocNanoZone may log after execv, which messes up this test.
Disable MallocNanoZone for this test since we don't use it anyway with asan.

This environment variable should only affect Darwin and not change behavior on other platforms.

rdar://74992832

Reviewed By: delcypher

Differential Revision: https://reviews.llvm.org/D98735

(cherry picked from commit c2f3b2f90eadeb6a8fb8fd5314f3c5d101451260)