### PR TITLE
Cherry-pick to swift/main: Merge pull request #2692 from varungandhi-apple/vg-apple/stable

### DIFF
--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -788,10 +788,11 @@ public:
     case CC_PreserveAll:
     case CC_X86_64SysV:
     case CC_Swift:
-    case CC_SwiftAsync:
     case CC_X86RegCall:
     case CC_OpenCLKernel:
       return CCCR_OK;
+    case CC_SwiftAsync:
+      return CCCR_Error;
     default:
       return CCCR_Warning;
     }

--- a/clang/test/CodeGen/swift-call-conv.c
+++ b/clang/test/CodeGen/swift-call-conv.c
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -triple aarch64-unknown-windows-msvc -emit-llvm %s -o - | FileCheck %s
-// RUN: %clang_cc1 -triple x86_64-unknown-windows-msvc -emit-llvm %s -o - | FileCheck %s
 
 // REQUIRES: aarch64-registered-target,arm-registered-target,x86-registered-target
 

--- a/clang/test/Sema/attr-swiftcall.c
+++ b/clang/test/Sema/attr-swiftcall.c
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -triple x86_64-apple-darwin10 -fsyntax-only -verify %s
-// RUN: %clang_cc1 -triple x86_64-unknown-windows -fsyntax-only -verify %s
 
 #define SWIFTCALL __attribute__((swiftcall))
 #define SWIFTASYNCCALL __attribute__((swiftasynccall))


### PR DESCRIPTION
Temporarily mark swiftasync unsupported for x86_64 Windows

(cherry picked from commit 73e4a098f0277759276684e47b8fc5c3f4396ae9)