### PR TITLE
[swift] Update lldb for new option to ModuleInterfaceCheckerImpl.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3369,7 +3369,8 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
   m_ast_context_ap->addModuleInterfaceChecker(
     std::make_unique<swift::ModuleInterfaceCheckerImpl>(*m_ast_context_ap,
       moduleCachePath, prebuiltModuleCachePath,
-      swift::ModuleInterfaceLoaderOptions()));
+      swift::ModuleInterfaceLoaderOptions(),
+      swift::RequireOSSAModules_t(GetSILOptions())));
 
   // 2. Create and install the module interface loader.
   //


### PR DESCRIPTION
We need to specify whether or not we require ossa modules which can change the
behavior of the debugger. We just propagate the value already being specified
(which should be the default value).