### PR TITLE
Static analyzer cherrypicks 20

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/BugReporter/CommonBugCategories.h
+++ b/clang/include/clang/StaticAnalyzer/Core/BugReporter/CommonBugCategories.h
@@ -21,6 +21,7 @@ extern const char *const UnixAPI;
 extern const char *const CXXObjectLifecycle;
 extern const char *const CXXMoveSemantics;
 extern const char *const SecurityError;
+extern const char *const UnusedCode;
 } // namespace categories
 } // namespace ento
 } // namespace clang

--- a/clang/lib/StaticAnalyzer/Checkers/DeadStoresChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/DeadStoresChecker.cpp
@@ -260,8 +260,8 @@ public:
         break;
     }
 
-    BR.EmitBasicReport(AC->getDecl(), Checker, BugType, "Dead store", os.str(),
-                       L, R, Fixits);
+    BR.EmitBasicReport(AC->getDecl(), Checker, BugType, categories::UnusedCode,
+                       os.str(), L, R, Fixits);
   }
 
   void CheckVarDecl(const VarDecl *VD, const Expr *Ex, const Expr *Val,

--- a/clang/lib/StaticAnalyzer/Checkers/UnreachableCodeChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UnreachableCodeChecker.cpp
@@ -169,7 +169,7 @@ void UnreachableCodeChecker::checkEndAnalysis(ExplodedGraph &G,
     if (SM.isInSystemHeader(SL) || SM.isInExternCSystemHeader(SL))
       continue;
 
-    B.EmitBasicReport(D, this, "Unreachable code", "Dead code",
+    B.EmitBasicReport(D, this, "Unreachable code", categories::UnusedCode,
                       "This statement is never executed", DL, SR);
   }
 }

--- a/clang/lib/StaticAnalyzer/Core/CommonBugCategories.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CommonBugCategories.cpp
@@ -22,6 +22,7 @@ const char *const UnixAPI = "Unix API";
 const char *const CXXObjectLifecycle = "C++ object lifecycle";
 const char *const CXXMoveSemantics = "C++ move semantics";
 const char *const SecurityError = "Security error";
+const char *const UnusedCode = "Unused code";
 } // namespace categories
 } // namespace ento
 } // namespace clang

--- a/clang/test/Analysis/Inputs/expected-plists/edges-new.mm.plist
+++ b/clang/test/Analysis/Inputs/expected-plists/edges-new.mm.plist
@@ -2368,7 +2368,7 @@
     </dict>
    </array>
    <key>description</key><string>Value stored to &apos;x&apos; is never read</string>
-   <key>category</key><string>Dead store</string>
+   <key>category</key><string>Unused code</string>
    <key>type</key><string>Dead increment</string>
    <key>check_name</key><string>deadcode.DeadStores</string>
    <!-- This hash is experimental and going to change! -->
@@ -11409,7 +11409,7 @@
     </dict>
    </array>
    <key>description</key><string>Value stored to &apos;foo&apos; during its initialization is never read</string>
-   <key>category</key><string>Dead store</string>
+   <key>category</key><string>Unused code</string>
    <key>type</key><string>Dead initialization</string>
    <key>check_name</key><string>deadcode.DeadStores</string>
    <!-- This hash is experimental and going to change! -->

--- a/clang/test/Analysis/Inputs/expected-plists/objc-arc.m.plist
+++ b/clang/test/Analysis/Inputs/expected-plists/objc-arc.m.plist
@@ -382,7 +382,7 @@
     </dict>
    </array>
    <key>description</key><string>Value stored to &apos;x&apos; during its initialization is never read</string>
-   <key>category</key><string>Dead store</string>
+   <key>category</key><string>Unused code</string>
    <key>type</key><string>Dead initialization</string>
    <key>check_name</key><string>deadcode.DeadStores</string>
    <!-- This hash is experimental and going to change! -->
@@ -450,7 +450,7 @@
     </dict>
    </array>
    <key>description</key><string>Value stored to &apos;obj1&apos; during its initialization is never read</string>
-   <key>category</key><string>Dead store</string>
+   <key>category</key><string>Unused code</string>
    <key>type</key><string>Dead initialization</string>
    <key>check_name</key><string>deadcode.DeadStores</string>
    <!-- This hash is experimental and going to change! -->
@@ -518,7 +518,7 @@
     </dict>
    </array>
    <key>description</key><string>Value stored to &apos;obj4&apos; during its initialization is never read</string>
-   <key>category</key><string>Dead store</string>
+   <key>category</key><string>Unused code</string>
    <key>type</key><string>Dead initialization</string>
    <key>check_name</key><string>deadcode.DeadStores</string>
    <!-- This hash is experimental and going to change! -->
@@ -586,7 +586,7 @@
     </dict>
    </array>
    <key>description</key><string>Value stored to &apos;obj5&apos; during its initialization is never read</string>
-   <key>category</key><string>Dead store</string>
+   <key>category</key><string>Unused code</string>
    <key>type</key><string>Dead initialization</string>
    <key>check_name</key><string>deadcode.DeadStores</string>
    <!-- This hash is experimental and going to change! -->
@@ -654,7 +654,7 @@
     </dict>
    </array>
    <key>description</key><string>Value stored to &apos;obj6&apos; during its initialization is never read</string>
-   <key>category</key><string>Dead store</string>
+   <key>category</key><string>Unused code</string>
    <key>type</key><string>Dead initialization</string>
    <key>check_name</key><string>deadcode.DeadStores</string>
    <!-- This hash is experimental and going to change! -->
@@ -1064,7 +1064,7 @@
     </dict>
    </array>
    <key>description</key><string>Value stored to &apos;cf1&apos; during its initialization is never read</string>
-   <key>category</key><string>Dead store</string>
+   <key>category</key><string>Unused code</string>
    <key>type</key><string>Dead initialization</string>
    <key>check_name</key><string>deadcode.DeadStores</string>
    <!-- This hash is experimental and going to change! -->
@@ -1132,7 +1132,7 @@
     </dict>
    </array>
    <key>description</key><string>Value stored to &apos;cf2&apos; during its initialization is never read</string>
-   <key>category</key><string>Dead store</string>
+   <key>category</key><string>Unused code</string>
    <key>type</key><string>Dead initialization</string>
    <key>check_name</key><string>deadcode.DeadStores</string>
    <!-- This hash is experimental and going to change! -->
@@ -1200,7 +1200,7 @@
     </dict>
    </array>
    <key>description</key><string>Value stored to &apos;cf3&apos; during its initialization is never read</string>
-   <key>category</key><string>Dead store</string>
+   <key>category</key><string>Unused code</string>
    <key>type</key><string>Dead initialization</string>
    <key>check_name</key><string>deadcode.DeadStores</string>
    <!-- This hash is experimental and going to change! -->
@@ -1268,7 +1268,7 @@
     </dict>
    </array>
    <key>description</key><string>Value stored to &apos;cf4&apos; during its initialization is never read</string>
-   <key>category</key><string>Dead store</string>
+   <key>category</key><string>Unused code</string>
    <key>type</key><string>Dead initialization</string>
    <key>check_name</key><string>deadcode.DeadStores</string>
    <!-- This hash is experimental and going to change! -->

--- a/clang/test/Analysis/Inputs/expected-plists/plist-output.m.plist
+++ b/clang/test/Analysis/Inputs/expected-plists/plist-output.m.plist
@@ -2169,7 +2169,7 @@
     </dict>
    </array>
    <key>description</key><string>Value stored to &apos;foo&apos; during its initialization is never read</string>
-   <key>category</key><string>Dead store</string>
+   <key>category</key><string>Unused code</string>
    <key>type</key><string>Dead initialization</string>
    <key>check_name</key><string>deadcode.DeadStores</string>
    <!-- This hash is experimental and going to change! -->
@@ -5654,7 +5654,7 @@
     </dict>
    </array>
    <key>description</key><string>Value stored to &apos;x&apos; is never read</string>
-   <key>category</key><string>Dead store</string>
+   <key>category</key><string>Unused code</string>
    <key>type</key><string>Dead increment</string>
    <key>check_name</key><string>deadcode.DeadStores</string>
    <!-- This hash is experimental and going to change! -->

--- a/clang/test/SemaObjC/warn-called-once.m
+++ b/clang/test/SemaObjC/warn-called-once.m
@@ -1130,4 +1130,32 @@ void suppression_3(int cond, void (^callback)(void) CALLED_ONCE) {
   }
 }
 
+- (void)test_escape_before_branch:(int)cond
+                   withCompletion:(void (^)(void))handler {
+  if (cond) {
+    filler();
+  }
+
+  void (^copiedHandler)(void) = ^{
+    handler();
+  };
+
+  if (cond) {
+    // no-warning
+    handler();
+  } else {
+    copiedHandler();
+  }
+}
+
+- (void)test_escape_after_branch:(int)cond
+                  withCompletion:(void (^)(void))handler {
+  if (cond) {
+    // no-warning
+    handler();
+  }
+
+  escape(handler);
+}
+
 @end


### PR DESCRIPTION
Clang Static Analyzer is traditionally kept reasonably fresh on stable branches through continuous cherry-picking.

This PR also includes a patch for a recently introduced analysis-based warning, `-Wcompletion-handler`.