### PR TITLE
[coro] Use swift mangling for resume functions

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -1586,8 +1586,23 @@ static void splitAsyncCoroutine(Function &F, coro::Shape &Shape,
     auto *Suspend = cast<CoroSuspendAsyncInst>(Shape.CoroSuspends[Idx]);
 
     // Create the clone declaration.
+    auto resumeNameSuffix = ".resume.";
+    auto projectionFunctionName =
+        Suspend->getAsyncContextProjectionFunction()->getName();
+    bool useSwiftMangling = false;
+    if (projectionFunctionName.equals("__swift_async_resume_project_context")) {
+      resumeNameSuffix = "TQ";
+      useSwiftMangling = true;
+    } else if (projectionFunctionName.equals(
+                   "__swift_async_resume_get_context")) {
+      resumeNameSuffix = "TY";
+      useSwiftMangling = true;
+    }
     auto *Continuation = createCloneDeclaration(
-        F, Shape, ".resume." + Twine(Idx), NextF, Suspend);
+        F, Shape,
+        useSwiftMangling ? resumeNameSuffix + Twine(Idx) + "_"
+                         : resumeNameSuffix + Twine(Idx),
+        NextF, Suspend);
     Clones.push_back(Continuation);
 
     // Insert a branch to a new return block immediately before the suspend

--- a/llvm/test/Transforms/Coroutines/coro-split-swift-async.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-swift-async.ll
@@ -16,7 +16,7 @@
 ; dbg.declare and not stashed into an alloca. They will get lowered to
 ; an entry value in the backend.
 
-; CHECK: define internal swiftcc void @"$s1a1fyS2iYF.resume.0"(i8* %0, i8* %1, i8* swiftasync %2)
+; CHECK: define internal swiftcc void @"$s1a1fyS2iYFTY0_"(i8* %0, i8* %1, i8* swiftasync %2)
 ; CHECK: entryresume.0:
 ; CHECK-NEXT:   call void @llvm.dbg.declare(metadata i8* %2, metadata ![[X:[0-9]+]], metadata !DIExpression(DW_OP_plus_uconst, 64, DW_OP_plus_uconst, 24))
 ; CHECK: ![[X]] = !DILocalVariable(name: "x",


### PR DESCRIPTION
The resume partial functions generated for swift suspend points will now
use a Swift mangling suffix.

Await resume partial functions will use the suffix 'TQ'[0-9]+'_' (e.g "...TQ0_")
and suspend resume partial functions will use the suffix 'TY'[0-9]+'_'
(e.g "...TY1_").