### PR TITLE
Resolve merge error in sanitizer_linux_libcdep.cpp

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp
@@ -704,7 +704,7 @@ static int AddModuleSegments(const char *module_name, dl_phdr_info *info,
     return 0;
   LoadedModule cur_module;
   bool instrumented = IsModuleInstrumented(info);
-  cur_module.set(module_name.data(), info->dlpi_addr, instrumented);
+  cur_module.set(module_name, info->dlpi_addr, instrumented);
   for (int i = 0; i < (int)info->dlpi_phnum; i++) {
     const Elf_Phdr *phdr = &info->dlpi_phdr[i];
     if (phdr->p_type == PT_LOAD) {


### PR DESCRIPTION
This seems to be a merge error when merging f5e6182ce6cd1 into apple/main
that accidentially left the `.data()` call in to preserve the downstream
additional argument. The `.data()` is now causing compilation errors as
`module_name` is just a C-string after f5e6182ce6cd1 .