### PR TITLE
[asan] specify c++ version in tests to fix compile error

### DIFF
--- a/compiler-rt/test/asan/TestCases/asan_update_allocation.cpp
+++ b/compiler-rt/test/asan/TestCases/asan_update_allocation.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx_asan -O0 %s -o %t
+// RUN: %clangxx_asan -O0 %s --std=c++11 -o %t
 
 // RUN: not %run %t 10 0 2>&1 | FileCheck %s --check-prefix=CHECK-%os --check-prefixes=CHECK,T0
 // RUN: not %run %t 10000000 0 2>&1 | FileCheck %s --check-prefixes=CHECK,T0

--- a/compiler-rt/test/asan/TestCases/lsan_crash.cpp
+++ b/compiler-rt/test/asan/TestCases/lsan_crash.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx_asan -O2 %s -o %t && %run %t
+// RUN: %clangxx_asan -O2 %s --std=c++11 -o %t && %run %t
 
 #include <atomic>
 #include <memory>


### PR DESCRIPTION
If we don't specify the c++ version in these tests, it could cause compile errors because the compiler could default to an older c++

rdar://75247244

Reviewed By: vitalybuka

Differential Revision: https://reviews.llvm.org/D98913

(cherry picked from commit 6ca178cd78a99d682d0be43eff1a808c1bcf47e6)