### PR TITLE
When on the first insn of live func, don't return a swift unwind plan

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -2355,14 +2355,16 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
       Address func_start_addr = sc.function->GetAddressRange().GetBaseAddress();
       AddressRange prologue_range(func_start_addr,
                                   sc.function->GetPrologueByteSize());
-      if (prologue_range.ContainsLoadAddress(pc, &target)) {
+      if (prologue_range.ContainsLoadAddress(pc, &target) ||
+          func_start_addr == pc) {
         return UnwindPlanSP();
       }
     } else if (sc.symbol) {
       Address func_start_addr = sc.symbol->GetAddress();
       AddressRange prologue_range(func_start_addr,
                                   sc.symbol->GetPrologueByteSize());
-      if (prologue_range.ContainsLoadAddress(pc, &target)) {
+      if (prologue_range.ContainsLoadAddress(pc, &target) ||
+          func_start_addr == pc) {
         return UnwindPlanSP();
       }
     }


### PR DESCRIPTION
When on the first insn of live func, don't return a swift unwind plan

We don't return a swift async unwind plan when we're in a live
function (can fetch all registers)'s prologue.  But we only know
prologue ranges when we have debug info today -- so special case
when we are on the first instruction of a live function, to treat
that as being in the prologue as well.