### PR TITLE
🍒/ganymede/0c090a96821b3b35cd68fadf9cc3fa7402285fe7+8248dd91d7f042893d4a605e98d19cb1b89a44d4+683590a203004df0e395824be6f2408a952a424e+eb26afbafe8b6fb115aac7f5e7ba80edc32138ab

### DIFF
--- a/lldb/test/API/.lit_test_times.txt
+++ b/lldb/test/API/.lit_test_times.txt
@@ -1,1 +1,0 @@
-2.777875e+00 functionalities/load_lazy/TestLoadUsingLazyBind.py

--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -188,3 +188,25 @@ if (CMAKE_GENERATOR STREQUAL "Xcode")
     ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS lldb-test-deps)
 endif()
+
+# Targets for running the test suite on the different Apple simulators.
+add_lit_testsuite(check-lldb-simulator-ios
+  "Running lldb test suite on the iOS simulator"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  PARAMS "lldb-run-with-simulator=ios"
+  EXCLUDE_FROM_CHECK_ALL
+  DEPENDS lldb-test-deps)
+
+add_lit_testsuite(check-lldb-simulator-watchos
+  "Running lldb test suite on the watchOS simulator"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  PARAMS "lldb-run-with-simulator=watchos"
+  EXCLUDE_FROM_CHECK_ALL
+  DEPENDS lldb-test-deps)
+
+add_lit_testsuite(check-lldb-simulator-tvos
+  "Running lldb test suite on the tvOS simulator"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  PARAMS "lldb-run-with-simulator=tvos"
+  EXCLUDE_FROM_CHECK_ALL
+  DEPENDS lldb-test-deps)

--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -1,3 +1,10 @@
+add_custom_target(lldb-api-test-deps)
+add_dependencies(lldb-api-test-deps lldb-test-deps)
+
+add_lit_testsuites(LLDB-API
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDS lldb-api-test-deps)
+
 function(add_python_test_target name test_script args comment)
   set(PYTHON_TEST_COMMAND
     ${Python3_EXECUTABLE}
@@ -174,20 +181,11 @@ string(REPLACE ${CMAKE_CFG_INTDIR} ${dotest_args_replacement} LLDB_TEST_FILECHEC
 string(REPLACE ${CMAKE_CFG_INTDIR} ${dotest_args_replacement} LLDB_TEST_YAML2OBJ "${LLDB_TEST_YAML2OBJ}")
 string(REPLACE ${CMAKE_CFG_INTDIR} ${dotest_args_replacement} LLDB_TEST_SERVER "${LLDB_TEST_SERVER}")
 
-# Configure the API test suite.
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
   MAIN_CONFIG
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py)
-
-if (CMAKE_GENERATOR STREQUAL "Xcode")
-  # Xcode does not get the auto-generated targets. We need to create
-  # check-lldb-api manually.
-  add_lit_testsuite(check-lldb-api "Running lldb api test suite"
-    ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS lldb-test-deps)
-endif()
 
 # Targets for running the test suite on the different Apple simulators.
 add_lit_testsuite(check-lldb-simulator-ios
@@ -195,18 +193,23 @@ add_lit_testsuite(check-lldb-simulator-ios
   ${CMAKE_CURRENT_BINARY_DIR}
   PARAMS "lldb-run-with-simulator=ios"
   EXCLUDE_FROM_CHECK_ALL
-  DEPENDS lldb-test-deps)
+  DEPENDS lldb-api-test-deps)
 
 add_lit_testsuite(check-lldb-simulator-watchos
   "Running lldb test suite on the watchOS simulator"
   ${CMAKE_CURRENT_BINARY_DIR}
   PARAMS "lldb-run-with-simulator=watchos"
   EXCLUDE_FROM_CHECK_ALL
-  DEPENDS lldb-test-deps)
+  DEPENDS lldb-api-test-deps)
 
 add_lit_testsuite(check-lldb-simulator-tvos
   "Running lldb test suite on the tvOS simulator"
   ${CMAKE_CURRENT_BINARY_DIR}
   PARAMS "lldb-run-with-simulator=tvos"
   EXCLUDE_FROM_CHECK_ALL
-  DEPENDS lldb-test-deps)
+  DEPENDS lldb-api-test-deps)
+
+add_lit_testsuite(check-lldb-api "Running lldb api test suite"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  EXCLUDE_FROM_CHECK_ALL
+  DEPENDS lldb-api-test-deps)

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -17,10 +17,10 @@ config.name = 'lldb-api'
 config.suffixes = ['.py']
 
 # test_source_root: The root path where tests are located.
-# test_exec_root: The root path where tests should be run.
 config.test_source_root = os.path.dirname(__file__)
-config.test_exec_root = config.test_source_root
 
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.lldb_obj_root, 'test', 'API')
 
 def mkdir_p(path):
   import errno

--- a/lldb/test/API/lit.site.cfg.py.in
+++ b/lldb/test/API/lit.site.cfg.py.in
@@ -1,6 +1,5 @@
 @LIT_SITE_CFG_IN_HEADER@
 
-config.test_exec_root = "@LLDB_BINARY_DIR@"
 config.llvm_src_root = "@LLVM_SOURCE_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"

--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -181,19 +181,13 @@ configure_lit_site_cfg(
   MAIN_CONFIG
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py)
 
-add_lit_testsuites(LLDB
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  DEPENDS lldb-test-deps)
-
-add_lit_testsuite(check-lldb-lit "Running lldb lit test suite"
+add_lit_testsuite(check-lldb "Running lldb lit test suite"
   ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS lldb-test-deps)
-set_target_properties(check-lldb-lit PROPERTIES FOLDER "lldb tests")
-
-add_custom_target(check-lldb)
-add_dependencies(check-lldb lldb-test-deps)
-set_target_properties(check-lldb PROPERTIES FOLDER "lldb misc")
-add_dependencies(check-lldb check-lldb-lit)
+  DEPENDS
+    lldb-api-test-deps
+    lldb-shell-test-deps
+    lldb-unit-test-deps)
+set_target_properties(check-lldb PROPERTIES FOLDER "lldb tests")
 
 # Add a lit test suite that runs the API & shell test while capturing a
 # reproducer.

--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -216,29 +216,6 @@ add_lit_testsuite(check-lldb-reproducers
   DEPENDS lldb-test-deps)
 add_dependencies(check-lldb-reproducers check-lldb-reproducers-capture)
 
-# Targets for running the test suite on the different Apple simulators.
-add_lit_testsuite(check-lldb-simulator-ios
-  "Running lldb test suite on the iOS simulator"
-  ${CMAKE_CURRENT_BINARY_DIR}/API
-  PARAMS "lldb-run-with-simulator=ios"
-  EXCLUDE_FROM_CHECK_ALL
-  DEPENDS lldb-test-deps)
-
-add_lit_testsuite(check-lldb-simulator-watchos
-  "Running lldb test suite on the watchOS simulator"
-  ${CMAKE_CURRENT_BINARY_DIR}/API
-  PARAMS "lldb-run-with-simulator=watchos"
-  EXCLUDE_FROM_CHECK_ALL
-  DEPENDS lldb-test-deps)
-
-add_lit_testsuite(check-lldb-simulator-tvos
-  "Running lldb test suite on the tvOS simulator"
-  ${CMAKE_CURRENT_BINARY_DIR}/API
-  PARAMS "lldb-run-with-simulator=tvos"
-  EXCLUDE_FROM_CHECK_ALL
-  DEPENDS lldb-test-deps)
-
-
 if(LLDB_BUILT_STANDALONE)
   # This has to happen *AFTER* add_lit_testsuite.
   if (EXISTS ${LLVM_MAIN_SRC_DIR}/utils/llvm-lit)

--- a/lldb/test/Shell/CMakeLists.txt
+++ b/lldb/test/Shell/CMakeLists.txt
@@ -1,4 +1,10 @@
-# Configure the Shell test suite.
+add_custom_target(lldb-shell-test-deps)
+add_dependencies(lldb-shell-test-deps lldb-test-deps)
+
+add_lit_testsuites(LLDB-SHELL
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDS lldb-shell-test-deps)
+
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
@@ -8,10 +14,7 @@ configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit-lldb-init.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit-lldb-init)
 
-if (CMAKE_GENERATOR STREQUAL "Xcode")
-  # Xcode does not get the auto-generated targets. We need to create
-  # check-lldb-shell manually.
-  add_lit_testsuite(check-lldb-shell "Running lldb shell test suite"
-    ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS lldb-test-deps)
-endif()
+add_lit_testsuite(check-lldb-shell "Running lldb shell test suite"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  EXCLUDE_FROM_CHECK_ALL
+  DEPENDS lldb-shell-test-deps)

--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -11,7 +11,7 @@ from lit.llvm.subst import ToolSubst
 
 
 def _get_lldb_init_path(config):
-    return os.path.join(config.test_exec_root, 'Shell', 'lit-lldb-init')
+    return os.path.join(config.test_exec_root, 'lit-lldb-init')
 
 
 def _disallow(config, execName):

--- a/lldb/test/Shell/lit.cfg.py
+++ b/lldb/test/Shell/lit.cfg.py
@@ -36,7 +36,7 @@ config.excludes = ['Inputs', 'CMakeLists.txt', 'README.txt', 'LICENSE.txt']
 config.test_source_root = os.path.dirname(__file__)
 
 # test_exec_root: The root path where tests should be run.
-config.test_exec_root = os.path.join(config.lldb_obj_root, 'test')
+config.test_exec_root = os.path.join(config.lldb_obj_root, 'test', 'Shell')
 
 # Propagate environment vars.
 llvm_config.with_system_environment([

--- a/lldb/test/Unit/CMakeLists.txt
+++ b/lldb/test/Unit/CMakeLists.txt
@@ -1,7 +1,17 @@
-# Configure the Unit test suite.
+add_custom_target(lldb-unit-test-deps)
+add_dependencies(lldb-unit-test-deps lldb-test-deps)
+
+add_lit_testsuites(LLDB-UNIT
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDS lldb-unit-test-deps)
+
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
   MAIN_CONFIG
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py)
 
+add_lit_testsuite(check-lldb-unit "Running lldb unit test suite"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  EXCLUDE_FROM_CHECK_ALL
+  DEPENDS lldb-unit-test-deps)

--- a/lldb/test/Unit/lit.site.cfg.py.in
+++ b/lldb/test/Unit/lit.site.cfg.py.in
@@ -1,6 +1,5 @@
 @LIT_SITE_CFG_IN_HEADER@
 
-config.test_exec_root = "@LLDB_BINARY_DIR@"
 config.llvm_src_root = "@LLVM_SOURCE_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"

--- a/lldb/test/lit.site.cfg.py.in
+++ b/lldb/test/lit.site.cfg.py.in
@@ -1,6 +1,5 @@
 @LIT_SITE_CFG_IN_HEADER@
 
-config.test_exec_root = "@LLDB_BINARY_DIR@"
 config.llvm_src_root = "@LLVM_SOURCE_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"

--- a/lldb/unittests/CMakeLists.txt
+++ b/lldb/unittests/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_custom_target(LLDBUnitTests)
 set_target_properties(LLDBUnitTests PROPERTIES FOLDER "lldb tests")
-add_dependencies(lldb-test-deps LLDBUnitTests)
+
+add_dependencies(lldb-unit-test-deps LLDBUnitTests)
 
 include_directories(${LLDB_SOURCE_ROOT})
 include_directories(${LLDB_PROJECT_ROOT}/unittests)


### PR DESCRIPTION
- [lldb] Move Apple simulators test targets under API
- [lldb] Fix test_exec_root of API tests
- [lldb] config.test_exec_root is set by lit.cfg.py
- Re-land "[lldb] Make the API, Shell and Unit tests independent lit test suites"
