### PR TITLE
[dsymutil] Only look for ThinLTO suffixes if we failed to find symbol.

### DIFF
--- a/llvm/tools/dsymutil/MachODebugMapParser.cpp
+++ b/llvm/tools/dsymutil/MachODebugMapParser.cpp
@@ -463,13 +463,15 @@ void MachODebugMapParser::handleStabSymbolTableEntry(uint32_t StringIndex,
   }
 
   // ThinLTO adds a unique suffix to exported private symbols.
-  for (auto Iter = CurrentObjectAddresses.begin();
-       Iter != CurrentObjectAddresses.end(); ++Iter) {
-    llvm::StringRef SymbolName = Iter->getKey();
-    auto Pos = SymbolName.rfind(".llvm.");
-    if (Pos != llvm::StringRef::npos && SymbolName.substr(0, Pos) == Name) {
-      ObjectSymIt = Iter;
-      break;
+  if (ObjectSymIt == CurrentObjectAddresses.end()) {
+    for (auto Iter = CurrentObjectAddresses.begin();
+         Iter != CurrentObjectAddresses.end(); ++Iter) {
+      llvm::StringRef SymbolName = Iter->getKey();
+      auto Pos = SymbolName.rfind(".llvm.");
+      if (Pos != llvm::StringRef::npos && SymbolName.substr(0, Pos) == Name) {
+        ObjectSymIt = Iter;
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
Only look for symbols with the ThinLTO suffix if we fail to find the
symbol.

(cherry picked from commit 1c9b83edaf93376c59b40f49bb8842ad679bea68)
