### PR TITLE
[lldb] Update async step-in implementation

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -2258,7 +2258,7 @@ void PruneThreadPlans();
 
   void SynchronizeThreadPlans();
 
-  lldb::ThreadPlanSP FindDetachedPlanExplainingStop(Event *event_ptr);
+  lldb::ThreadPlanSP FindDetachedPlanExplainingStop(Thread &thread, Event *event_ptr);
 
   /// Find the thread plan stack associated with thread with \a tid.
   ///

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -2256,6 +2256,10 @@ bool PruneThreadPlansForTID(lldb::tid_t tid);
 /// Prune ThreadPlanStacks for all unreported threads.
 void PruneThreadPlans();
 
+  void SynchronizeThreadPlans();
+
+  lldb::ThreadPlanSP FindDetachedPlanExplainingStop(Event *event_ptr);
+
   /// Find the thread plan stack associated with thread with \a tid.
   ///
   /// \param[in] tid
@@ -2796,6 +2800,7 @@ protected:
                                      /// threads in m_thread_list, as well as
                                      /// threads we knew existed, but haven't
                                      /// determined that they have died yet.
+  std::vector<ThreadPlanStack> m_async_thread_plans;
   ThreadList m_extended_thread_list; ///< Owner for extended threads that may be
                                      ///generated, cleared on natural stops
   uint32_t m_extended_thread_stop_id; ///< The natural stop id when

--- a/lldb/include/lldb/Target/ThreadPlan.h
+++ b/lldb/include/lldb/Target/ThreadPlan.h
@@ -513,7 +513,7 @@ public:
   void SetTID(lldb::tid_t tid) { m_tid = tid; }
 
   friend lldb::ThreadPlanSP
-  Process::FindDetachedPlanExplainingStop(Event *event_ptr);
+  Process::FindDetachedPlanExplainingStop(Thread &thread, Event *event_ptr);
 
 protected:
   // Classes that inherit from ThreadPlan can see and modify these

--- a/lldb/include/lldb/Target/ThreadPlan.h
+++ b/lldb/include/lldb/Target/ThreadPlan.h
@@ -507,7 +507,6 @@ public:
       return m_iteration_count;
   }
 
-  bool IsTID(lldb::tid_t tid) { return tid == m_tid; }
   bool HasTID() { return m_tid != LLDB_INVALID_THREAD_ID; }
   void ClearTID() { m_tid = LLDB_INVALID_THREAD_ID; }
   lldb::tid_t GetTID() { return m_tid; }

--- a/lldb/include/lldb/Target/ThreadPlan.h
+++ b/lldb/include/lldb/Target/ThreadPlan.h
@@ -507,6 +507,15 @@ public:
       return m_iteration_count;
   }
 
+  bool IsTID(lldb::tid_t tid) { return tid == m_tid; }
+  bool HasTID() { return m_tid != LLDB_INVALID_THREAD_ID; }
+  void ClearTID() { m_tid = LLDB_INVALID_THREAD_ID; }
+  lldb::tid_t GetTID() { return m_tid; }
+  void SetTID(lldb::tid_t tid) { m_tid = tid; }
+
+  friend lldb::ThreadPlanSP
+  Process::FindDetachedPlanExplainingStop(Event *event_ptr);
+
 protected:
   // Classes that inherit from ThreadPlan can see and modify these
 

--- a/lldb/include/lldb/Target/ThreadPlanStack.h
+++ b/lldb/include/lldb/Target/ThreadPlanStack.h
@@ -159,12 +159,13 @@ public:
 
   // rename to ...?
   std::vector<ThreadPlanStack> CleanUp() {
-    std::vector<lldb::tid_t> invalidated_tids;
+    llvm::SmallVector<lldb::tid_t, 2> invalidated_tids;
     for (auto &pair : m_plans_list)
       if (pair.second.GetTID() != pair.first)
         invalidated_tids.push_back(pair.first);
 
     std::vector<ThreadPlanStack> detached_stacks;
+    detached_stacks.reserve(invalidated_tids.size());
     for (auto tid : invalidated_tids) {
       auto it = m_plans_list.find(tid);
       auto stack = std::move(it->second);

--- a/lldb/include/lldb/Target/ThreadPlanStack.h
+++ b/lldb/include/lldb/Target/ThreadPlanStack.h
@@ -151,21 +151,18 @@ public:
 
   // rename to Reactivate?
   void Activate(ThreadPlanStack &&stack) {
-    if (m_plans_list.find(stack.GetTID()) == m_plans_list.end()) {
+    if (m_plans_list.find(stack.GetTID()) == m_plans_list.end())
       m_plans_list.emplace(stack.GetTID(), std::move(stack));
-    } else {
+    else
       m_plans_list.at(stack.GetTID()) = std::move(stack);
-    }
   }
 
   // rename to ...?
   std::vector<ThreadPlanStack> CleanUp() {
     std::vector<lldb::tid_t> invalidated_tids;
-    for (auto &pair : m_plans_list) {
-      if (!pair.second.IsTID(pair.first)) {
+    for (auto &pair : m_plans_list)
+      if (!pair.second.IsTID(pair.first))
         invalidated_tids.push_back(pair.first);
-      }
-    }
 
     std::vector<ThreadPlanStack> detached_stacks;
     for (auto tid : invalidated_tids) {

--- a/lldb/include/lldb/Target/ThreadPlanStack.h
+++ b/lldb/include/lldb/Target/ThreadPlanStack.h
@@ -161,7 +161,7 @@ public:
   std::vector<ThreadPlanStack> CleanUp() {
     std::vector<lldb::tid_t> invalidated_tids;
     for (auto &pair : m_plans_list)
-      if (!pair.second.IsTID(pair.first))
+      if (pair.second.GetTID() != pair.first)
         invalidated_tids.push_back(pair.first);
 
     std::vector<ThreadPlanStack> detached_stacks;

--- a/lldb/include/lldb/Target/ThreadPlanStack.h
+++ b/lldb/include/lldb/Target/ThreadPlanStack.h
@@ -95,6 +95,10 @@ public:
 
   void WillResume();
 
+  bool IsTID(lldb::tid_t tid);
+  lldb::tid_t GetTID();
+  void SetTID(lldb::tid_t tid);
+
 private:
   const PlanStack &GetStackOfKind(ThreadPlanStack::StackKind kind) const;
 
@@ -145,8 +149,36 @@ public:
       return &result->second;
   }
 
+  // rename to Reactivate?
+  void Activate(ThreadPlanStack &&stack) {
+    if (m_plans_list.find(stack.GetTID()) == m_plans_list.end()) {
+      m_plans_list.emplace(stack.GetTID(), std::move(stack));
+    } else {
+      m_plans_list.at(stack.GetTID()) = std::move(stack);
+    }
+  }
+
+  // rename to ...?
+  std::vector<ThreadPlanStack> CleanUp() {
+    std::vector<lldb::tid_t> invalidated_tids;
+    for (auto &pair : m_plans_list) {
+      if (!pair.second.IsTID(pair.first)) {
+        invalidated_tids.push_back(pair.first);
+      }
+    }
+
+    std::vector<ThreadPlanStack> detached_stacks;
+    for (auto tid : invalidated_tids) {
+      auto it = m_plans_list.find(tid);
+      auto stack = std::move(it->second);
+      m_plans_list.erase(it);
+      detached_stacks.emplace_back(std::move(stack));
+    }
+    return detached_stacks;
+  }
+
   void Clear() {
-    for (auto plan : m_plans_list)
+    for (auto &plan : m_plans_list)
       plan.second.ThreadDestroyed(nullptr);
     m_plans_list.clear();
   }

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1434,9 +1434,8 @@ void Process::UpdateThreadListIfNeeded() {
 }
 
 void Process::SynchronizeThreadPlans() {
-  for (auto &stack : m_thread_plans.CleanUp()) {
+  for (auto &stack : m_thread_plans.CleanUp())
     m_async_thread_plans.emplace_back(std::move(stack));
-  }
 }
 
 ThreadPlanSP Process::FindDetachedPlanExplainingStop(Event *event_ptr) {

--- a/lldb/source/Target/StackFrameList.cpp
+++ b/lldb/source/Target/StackFrameList.cpp
@@ -739,10 +739,8 @@ StackFrameSP StackFrameList::GetFrameWithStackID(const StackID &stack_id) {
           std::find_if(begin, end, [&](StackFrameSP frame_sp) {
             return frame_sp->GetStackID() == stack_id;
           });
-      if (pos != end) {
-        if ((*pos)->GetStackID() == stack_id)
-          return *pos;
-      }
+      if (pos != end)
+        return *pos;
     }
     do {
       frame_sp = GetFrameAtIndex(frame_idx);

--- a/lldb/source/Target/StackFrameList.cpp
+++ b/lldb/source/Target/StackFrameList.cpp
@@ -725,23 +725,20 @@ StackFrameList::GetFrameWithConcreteFrameIndex(uint32_t unwind_idx) {
   return frame_sp;
 }
 
-static bool CompareStackID(const StackFrameSP &stack_sp,
-                           const StackID &stack_id) {
-  return stack_sp->GetStackID() < stack_id;
-}
-
 StackFrameSP StackFrameList::GetFrameWithStackID(const StackID &stack_id) {
   StackFrameSP frame_sp;
 
   if (stack_id.IsValid()) {
     std::lock_guard<std::recursive_mutex> guard(m_mutex);
     uint32_t frame_idx = 0;
-    // Do a binary search in case the stack frame is already in our cache
+    // Do a search in case the stack frame is already in our cache.
     collection::const_iterator begin = m_frames.begin();
     collection::const_iterator end = m_frames.end();
     if (begin != end) {
       collection::const_iterator pos =
-          std::lower_bound(begin, end, stack_id, CompareStackID);
+          std::find_if(begin, end, [&](StackFrameSP frame_sp) {
+            return frame_sp->GetStackID() == stack_id;
+          });
       if (pos != end) {
         if ((*pos)->GetStackID() == stack_id)
           return *pos;

--- a/lldb/source/Target/StackID.cpp
+++ b/lldb/source/Target/StackID.cpp
@@ -61,6 +61,11 @@ bool lldb_private::operator<(const StackID &lhs, const StackID &rhs) {
   const lldb::addr_t lhs_cfa = lhs.GetCallFrameAddress();
   const lldb::addr_t rhs_cfa = rhs.GetCallFrameAddress();
 
+  // Check for async -> sync comparison. (stack: high, heap: low)
+  if (lhs_cfa - rhs_cfa >= 0x00007ff000000000ULL) {
+    return true;
+  }
+
   // FIXME: We are assuming that the stacks grow downward in memory.  That's not
   // necessary, but true on
   // all the machines we care about at present.  If this changes, we'll have to

--- a/lldb/source/Target/StackID.cpp
+++ b/lldb/source/Target/StackID.cpp
@@ -61,10 +61,12 @@ bool lldb_private::operator<(const StackID &lhs, const StackID &rhs) {
   const lldb::addr_t lhs_cfa = lhs.GetCallFrameAddress();
   const lldb::addr_t rhs_cfa = rhs.GetCallFrameAddress();
 
-  // Check for async -> sync comparison. (stack: high, heap: low)
-  if (lhs_cfa - rhs_cfa >= 0x00007ff000000000ULL) {
+  // FIXME: rdar://76119439
+  // This heuristic is a *temporary* fallback while proper fixes are
+  // determined. The heuristic assumes the CFA of async functions is a low
+  // (heap) address, and for normal functions it's a high (stack) address.
+  if (lhs_cfa - rhs_cfa >= 0x00007ff000000000ULL)
     return true;
-  }
 
   // FIXME: We are assuming that the stacks grow downward in memory.  That's not
   // necessary, but true on

--- a/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
@@ -79,6 +79,8 @@ static bool IsSwiftAsyncFunctionSymbol(swift::Demangle::NodePointer node) {
   using namespace swift::Demangle;
   if (!node || node->getKind() != Node::Kind::Global)
     return false;
+  if (hasChild(node, Node::Kind::AsyncSuspendResumePartialFunction))
+    return false;
   return childAtPath(node,
                      {Node::Kind::Function, Node::Kind::Type,
                       Node::Kind::FunctionType, Node::Kind::AsyncAnnotation}) ||

--- a/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
@@ -191,15 +191,13 @@ public:
       return false;
     }
 
-    if (sc.line_entry.IsValid() && sc.line_entry.line == 0) {
+    if (sc.line_entry.IsValid() && sc.line_entry.line == 0)
       // Compiler generated function, need to step in.
       return true;
-    }
 
     // TEMPORARY HACK WORKAROUND
-    if (!sc.symbol || !sc.comp_unit) {
+    if (!sc.symbol || !sc.comp_unit)
       return false;
-    }
     auto fn_start = sc.symbol->GetFileAddress();
     auto fn_end = sc.symbol->GetFileAddress() + sc.symbol->GetByteSize();
     int line_entry_count = 0;
@@ -207,18 +205,15 @@ public:
       for (uint32_t i = 0; i < line_table->GetSize(); ++i) {
         LineEntry line_entry;
         if (line_table->GetLineEntryAtIndex(i, line_entry)) {
-          if (!line_entry.IsValid() || line_entry.line == 0) {
+          if (!line_entry.IsValid() || line_entry.line == 0)
             continue;
-          }
 
           auto line_start = line_entry.range.GetBaseAddress().GetFileAddress();
-          if (line_start >= fn_start && line_start < fn_end) {
-            if (++line_entry_count > 1) {
+          if (line_start >= fn_start && line_start < fn_end)
+            if (++line_entry_count > 1)
               // This is an async function with a proper body of code, no step
               // into `swift_task_switch` required.
               return false;
-            }
-          }
         }
       }
     }
@@ -230,9 +225,8 @@ public:
       : ThreadPlan(eKindGeneric, "step-in-async", thread, eVoteNoOpinion,
                    eVoteNoOpinion) {
     assert(sc.function);
-    if (!sc.function) {
+    if (!sc.function)
       return;
-    }
 
     m_step_in_plan_sp = std::make_shared<ThreadPlanStepInRange>(
         thread, sc.function->GetAddressRange(), sc, "swift_task_switch",
@@ -240,9 +234,8 @@ public:
   }
 
   void DidPush() override {
-    if (m_step_in_plan_sp) {
+    if (m_step_in_plan_sp)
       PushPlan(m_step_in_plan_sp);
-    }
   }
 
   bool ValidatePlan(Stream *error) override { return (bool)m_step_in_plan_sp; }
@@ -253,20 +246,17 @@ public:
   }
 
   bool DoPlanExplainsStop(Event *event) override {
-    if (!HasTID()) {
+    if (!HasTID())
       return false;
-    }
-    if (!m_async_breakpoint_sp) {
+    if (!m_async_breakpoint_sp)
       return false;
-    }
 
     return m_breakpoint_async_context == m_initial_async_context;
   }
 
   bool ShouldStop(Event *event) override {
-    if (!m_async_breakpoint_sp) {
+    if (!m_async_breakpoint_sp)
       return false;
-    }
 
     if (m_breakpoint_async_context == m_initial_async_context) {
       SetPlanComplete();
@@ -276,13 +266,11 @@ public:
   }
 
   bool MischiefManaged() override {
-    if (IsPlanComplete()) {
+    if (IsPlanComplete())
       return true;
-    }
 
-    if (!m_step_in_plan_sp->IsPlanComplete()) {
+    if (!m_step_in_plan_sp->IsPlanComplete())
       return false;
-    }
 
     if (!m_step_in_plan_sp->PlanSucceeded()) {
       // If the step in fails, then this plan fails.
@@ -330,9 +318,8 @@ private:
     auto resume_fn_reg = reg_ctx->ConvertRegisterKindToRegisterNumber(
         RegisterKind::eRegisterKindGeneric, resume_fn_regnum);
     auto resume_fn_ptr = reg_ctx->ReadRegisterAsUnsigned(resume_fn_reg, 0);
-    if (!resume_fn_ptr) {
+    if (!resume_fn_ptr)
       return {};
-    }
 
     auto &target = thread.GetProcess()->GetTarget();
     auto breakpoint_sp = target.CreateBreakpoint(resume_fn_ptr, true, false);

--- a/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
@@ -336,20 +336,34 @@ private:
 
   static uint64_t GetAsyncContext(lldb::StackFrameSP frame_sp) {
     auto reg_ctx_sp = frame_sp->GetRegisterContext();
+
+    int async_ctx_regnum = 0;
     auto arch = reg_ctx_sp->CalculateTarget()->GetArchitecture();
-    int async_context_regnum = 0;
     if (arch.GetMachine() == llvm::Triple::x86_64) {
-      async_context_regnum = dwarf_r14_x86_64;
+      async_ctx_regnum = dwarf_r14_x86_64;
     } else if (arch.GetMachine() == llvm::Triple::aarch64) {
-      async_context_regnum = arm64_dwarf::x22;
+      async_ctx_regnum = arm64_dwarf::x22;
     } else {
       assert(false && "swift async supports only x86_64 and arm64");
       return 0;
     }
 
-    auto async_context_reg = reg_ctx_sp->ConvertRegisterKindToRegisterNumber(
-        RegisterKind::eRegisterKindDWARF, async_context_regnum);
-    return reg_ctx_sp->ReadRegisterAsUnsigned(async_context_reg, 23);
+    auto async_ctx_reg = reg_ctx_sp->ConvertRegisterKindToRegisterNumber(
+        RegisterKind::eRegisterKindDWARF, async_ctx_regnum);
+    auto async_ctx = reg_ctx_sp->ReadRegisterAsUnsigned(async_ctx_reg, 23);
+
+    auto sc = frame_sp->GetSymbolContext(eSymbolContextSymbol);
+    auto mangled_name = sc.symbol->GetMangled().GetMangledName().GetStringRef();
+    bool indirect_context =
+        SwiftLanguageRuntime::IsSwiftAsyncAwaitResumePartialFunctionSymbol(
+            mangled_name);
+
+    if (!indirect_context)
+      return async_ctx;
+
+    auto process_sp = frame_sp->CalculateProcess();
+    Status error;
+    return process_sp->ReadPointerFromMemory(async_ctx, error);
   }
 
   ThreadPlanSP m_step_in_plan_sp;

--- a/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
@@ -344,6 +344,7 @@ private:
       async_context_regnum = arm64_dwarf::x22;
     } else {
       assert(false && "swift async supports only x86_64 and arm64");
+      return 0;
     }
 
     auto async_context_reg = reg_ctx_sp->ConvertRegisterKindToRegisterNumber(

--- a/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
@@ -188,11 +188,6 @@ static ThunkAction GetThunkAction(ThunkKind kind) {
 class ThreadPlanStepInAsync : public ThreadPlan {
 public:
   static bool NeedsStep(SymbolContext &sc) {
-    if (sc.symbol->GetAddressRef().GetOffset() != 0) {
-      // Async step is only applicable at the start of a function.
-      return false;
-    }
-
     if (sc.line_entry.IsValid() && sc.line_entry.line == 0)
       // Compiler generated function, need to step in.
       return true;

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -811,7 +811,7 @@ bool Thread::ShouldStop(Event *event_ptr) {
 
   // Call this after ShouldStopSynchronous.
   ThreadPlan *current_plan;
-  if (auto plan = GetProcess()->FindDetachedPlanExplainingStop(event_ptr))
+  if (auto plan = GetProcess()->FindDetachedPlanExplainingStop(*this, event_ptr))
     current_plan = plan.get();
   else
     current_plan = GetCurrentPlan();

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -811,13 +811,12 @@ bool Thread::ShouldStop(Event *event_ptr) {
 
   // Call this after ShouldStopSynchronous.
   ThreadPlan *current_plan;
-  if (auto plan = GetProcess()->FindDetachedPlanExplainingStop(event_ptr)) {
+  if (auto plan = GetProcess()->FindDetachedPlanExplainingStop(event_ptr))
     current_plan = plan.get();
-  } else {
+  else
     current_plan = GetCurrentPlan();
-  }
 
-  // The top most plan always gets to do the trace log...
+  // The top most plan always gets to do the trace log…
   current_plan->DoTraceLog();
 
   // If we've already been restarted, don't query the plans since the state

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -747,8 +747,6 @@ void Thread::DidResume() { SetResumeSignal(LLDB_INVALID_SIGNAL_NUMBER); }
 void Thread::DidStop() { SetState(eStateStopped); }
 
 bool Thread::ShouldStop(Event *event_ptr) {
-  ThreadPlan *current_plan = GetCurrentPlan();
-
   bool should_stop = true;
 
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_STEP));
@@ -799,9 +797,6 @@ bool Thread::ShouldStop(Event *event_ptr) {
     LLDB_LOGF(log, "Plan stack initial state:\n%s", s.GetData());
   }
 
-  // The top most plan always gets to do the trace log...
-  current_plan->DoTraceLog();
-
   // First query the stop info's ShouldStopSynchronous.  This handles
   // "synchronous" stop reasons, for example the breakpoint command on internal
   // breakpoints.  If a synchronous stop reason says we should not stop, then
@@ -813,6 +808,17 @@ bool Thread::ShouldStop(Event *event_ptr) {
                    "stop, returning ShouldStop of false.");
     return false;
   }
+
+  // Call this after ShouldStopSynchronous.
+  ThreadPlan *current_plan;
+  if (auto plan = GetProcess()->FindDetachedPlanExplainingStop(event_ptr)) {
+    current_plan = plan.get();
+  } else {
+    current_plan = GetCurrentPlan();
+  }
+
+  // The top most plan always gets to do the trace log...
+  current_plan->DoTraceLog();
 
   // If we've already been restarted, don't query the plans since the state
   // they would examine is not current.

--- a/lldb/source/Target/ThreadPlanStack.cpp
+++ b/lldb/source/Target/ThreadPlanStack.cpp
@@ -384,9 +384,8 @@ bool ThreadPlanStack::IsTID(lldb::tid_t tid) {
 lldb::tid_t ThreadPlanStack::GetTID() { return GetCurrentPlan()->GetTID(); }
 
 void ThreadPlanStack::SetTID(lldb::tid_t tid) {
-  for (auto plan_sp : m_plans) {
+  for (auto plan_sp : m_plans)
     plan_sp->SetTID(tid);
-  }
 }
 
 const ThreadPlanStack::PlanStack &

--- a/lldb/source/Target/ThreadPlanStack.cpp
+++ b/lldb/source/Target/ThreadPlanStack.cpp
@@ -377,10 +377,6 @@ void ThreadPlanStack::WillResume() {
   m_discarded_plans.clear();
 }
 
-bool ThreadPlanStack::IsTID(lldb::tid_t tid) {
-  return GetCurrentPlan()->IsTID(tid);
-}
-
 lldb::tid_t ThreadPlanStack::GetTID() { return GetCurrentPlan()->GetTID(); }
 
 void ThreadPlanStack::SetTID(lldb::tid_t tid) {

--- a/lldb/source/Target/ThreadPlanStack.cpp
+++ b/lldb/source/Target/ThreadPlanStack.cpp
@@ -377,6 +377,18 @@ void ThreadPlanStack::WillResume() {
   m_discarded_plans.clear();
 }
 
+bool ThreadPlanStack::IsTID(lldb::tid_t tid) {
+  return GetCurrentPlan()->IsTID(tid);
+}
+
+lldb::tid_t ThreadPlanStack::GetTID() { return GetCurrentPlan()->GetTID(); }
+
+void ThreadPlanStack::SetTID(lldb::tid_t tid) {
+  for (auto plan_sp : m_plans) {
+    plan_sp->SetTID(tid);
+  }
+}
+
 const ThreadPlanStack::PlanStack &
 ThreadPlanStack::GetStackOfKind(ThreadPlanStack::StackKind kind) const {
   switch (kind) {

--- a/lldb/test/API/lang/swift/async/stepping/step-in/Makefile
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -Xfrontend -enable-experimental-concurrency -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/stepping/step-in/TestSwiftStepInAsync.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/TestSwiftStepInAsync.py
@@ -1,0 +1,60 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    @skipIf(oslist=['windows', 'linux'])
+    def test(self):
+        """Test step-in to async functions"""
+        self.build()
+        src = lldb.SBFileSpec('main.swift')
+        _, process, _, _ = lldbutil.run_to_source_breakpoint(self, 'await', src)
+
+	# When run with debug info enabled builds, this prevents stepping from
+	# stopping in Swift Concurrency runtime functions.
+        self.runCmd("settings set target.process.thread.step-avoid-regexp swift_task_")
+
+        # All thread actions are done on the currently selected thread.
+        thread = process.GetSelectedThread
+
+        num_async_steps = 0
+        while True:
+            stop_reason = thread().stop_reason
+            if stop_reason == lldb.eStopReasonNone:
+                break
+            elif stop_reason == lldb.eStopReasonPlanComplete:
+                # Run until the next `await` breakpoint.
+                process.Continue()
+            elif stop_reason == lldb.eStopReasonBreakpoint:
+                caller_before = thread().frames[0].function.name
+                line_before = thread().frames[0].line_entry.line
+                thread().StepInto()
+                caller_after = thread().frames[1].function.name
+                line_after = thread().frames[0].line_entry.line
+
+		# Breakpoints on lines with an `await` may result in more than
+		# one breakpoint location. Specifically a location before an
+		# async function is called, and then a location on the resume
+		# function. In this case, running `step` on these lines will
+		# move execution forward within the same function, _not_ step
+		# into a new function.
+                #
+		# As this test is for stepping into async functions, when the
+		# step-in keeps execution on the same or next line -- not a
+		# different function, then it can be ignored. rdar://76116620
+                if line_after in (line_before, line_before + 1):
+		    # When stepping stops at breakpoint, don't continue.
+                    if thread().stop_reason != lldb.eStopReasonBreakpoint:
+                        process.Continue()
+                    continue
+
+                self.assertEqual(caller_after, caller_before)
+                num_async_steps += 1
+
+        self.assertEqual(num_async_steps, 6)

--- a/lldb/test/API/lang/swift/async/stepping/step-in/main.swift
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/main.swift
@@ -1,0 +1,19 @@
+@MainActor func stringNum(_ i: Int) async -> String {
+  let x = await randInt(i)
+  let y = await randInt(i)
+  return String(x + y)
+}
+
+@MainActor func randInt(_ i: Int) async -> Int {
+  return Int.random(in: 1...i)
+}
+
+func use<T>(_ t: T...) {}
+
+@main struct Main {
+  static func main() async {
+    let a = await stringNum(30)
+    let b = await stringNum(41)
+    use(a, b)
+  }
+}


### PR DESCRIPTION
This followup to #2537 is to support the following:

1. The new async unwinding implemented across a few other commits (see #2617 #2645 #2663)
2. The initial implementation set a breakpoint on the async resume function, but the breakpoint was not conditional and would stop even if another async task (ie "thread") was the caller. This change implements the conditional breakpoint
3. Handle the updated `swift_task_switch` ABI changes (see https://github.com/apple/swift/pull/36437)

Conditional breakpoints need some explanation. This change introduces a new mode for thread plans which has been discussed with @jimingham. As of this change, thread plans are no longer bound to a thread, they can be detached from an initial thread, and connected to a new thread. This is to support Swift Concurrency, where stepping into an async function can not assume that function will be called on the same thread, and cannot assume the state of the OS native stack.

To support this, the `Process` now manages new list of thread plans that have been detached from a thread (`m_async_thread_plans`), and has supporting code to move thread plans back and forth between `m_thread_plans` and `m_async_thread_plans`.

The new function `FindDetachedPlanExplainingStop` is used to determine if a detached thread plan explains a current stop, and if so that thread plan is attached to the current thread, in order to continue carrying out its work.
