### PR TITLE
Temporarily allow lit to be executed with python2

### DIFF
--- a/llvm/utils/lit/lit/Test.py
+++ b/llvm/utils/lit/lit/Test.py
@@ -214,7 +214,7 @@ class TestSuite:
         if os.path.exists(test_times_file):
             with open(test_times_file, 'r') as time_file:
                 for line in time_file:
-                    time, path = line.split(maxsplit=1)
+                    time, path = line.split(None, 1)
                     self.test_times[path.strip('\n')] = float(time)
 
     def getSourcePath(self, components):


### PR DESCRIPTION
A few projects still need to be updated to use python3 to invoke lit,
this PR would allow the automerger from `apple/stable/20210107` to
`swift/main` to complete successfully in the mean time.

Addresses rdar://75848017