### PR TITLE
Remove runAsyncAndBlock

### DIFF
--- a/lldb/test/API/lang/swift/async/async_fnargs/Makefile
+++ b/lldb/test/API/lang/swift/async/async_fnargs/Makefile
@@ -1,3 +1,3 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -Xfrontend -enable-experimental-concurrency
+SWIFTFLAGS_EXTRAS := -Xfrontend -enable-experimental-concurrency -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/async_fnargs/main.swift
+++ b/lldb/test/API/lang/swift/async/async_fnargs/main.swift
@@ -11,7 +11,9 @@ func sayGeneric<T>(_ msg: T) async {
   print(msg) // And also here.
 }
 
-runAsyncAndBlock {
-  await sayHello()
-  await sayGeneric("world")
+@main struct Main {
+  static func main() async {
+    await sayHello()
+    await sayGeneric("world")
+  }
 }

--- a/lldb/test/API/lang/swift/async/unwind/sayhello/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/sayhello/Makefile
@@ -1,3 +1,3 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -Xfrontend -enable-experimental-concurrency
+SWIFTFLAGS_EXTRAS := -Xfrontend -enable-experimental-concurrency -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/sayhello/main.swift
+++ b/lldb/test/API/lang/swift/async/unwind/sayhello/main.swift
@@ -20,7 +20,9 @@ func sayGeneric<T>(_ msg: T) async {
   print("\(str) after calls - arg \(msg)")
 }
 
-runAsyncAndBlock {
-  await sayGeneric("world")
-  await sayHello()
+@main struct Main {
+  static func main() async {
+    await sayGeneric("world")
+    await sayHello()
+  }
 }


### PR DESCRIPTION
This patch removes the call to `runAsyncAndBlock` and replaces it with the
the async-main construct since we're trying to delete `runAsyncAndBlock`.

Part of: rdar://73906556