### PR TITLE
[lldb][swift] Ignore -- flag in swift-extra-clang-flags

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1485,6 +1485,15 @@ void SwiftASTContext::AddExtraClangArgs(const std::vector<std::string>& source,
     if (clang_argument.startswith("-Werror"))
       continue;
 
+    // Drop `--`. This might be coming from the user-provided setting
+    // swift-extra-clang-flags (where users sometimes think a -- is necessary
+    // to separate the flags from the settings name). `--` indicates to Clang
+    // that all following arguments are file names instead of flags, so this
+    // should never be passed to Clang (which would otherwise either crash or
+    // cause Clang to look for files with the name '-Wflag-name`).
+    if (clang_argument == "--")
+      continue;
+
     if (clang_argument.empty())
       continue;
 

--- a/lldb/test/API/lang/swift/clangimporter/extra_clang_flags/TestSwiftExtraClangFlags.py
+++ b/lldb/test/API/lang/swift/clangimporter/extra_clang_flags/TestSwiftExtraClangFlags.py
@@ -59,3 +59,22 @@ class TestSwiftExtraClangFlags(TestBase):
                                           lldb.SBFileSpec('main.swift'))
         self.expect("frame var foo", "sanity check", substrs=['(Foo)'])
         self.expect("expr FromOverlay(i: 23)", substrs=['(FromOverlay)', '23'])
+
+    # Don't run ClangImporter tests if Clangimporter is disabled.
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipIf(oslist=['windows'])
+    @swiftTest
+    def test_invalid_extra_clang_flags(self):
+        """
+        Test that LLDB ignores specific invalid arguments in
+        swift-extra-clang-flags.
+        """
+        self.build()
+        self.addTearDownHook(
+            lambda: self.runCmd("settings clear target.swift-extra-clang-flags"))
+
+        self.expect('settings set target.swift-extra-clang-flags -- -v')
+
+        lldbutil.run_to_source_breakpoint(self, "break here",
+                                          lldb.SBFileSpec('main.swift'))
+        self.expect("frame var foo", substrs=['(Foo)'])

--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -248,3 +248,13 @@ TEST(ClangArgs, UniquingCollisionWithAddedFlags) {
 
   EXPECT_EQ(dest, uniqued_flags);
 }
+
+TEST(ClangArgs, DoubleDash) {
+  // -v with all currently ignored arguments following.
+  const std::vector<std::string> source{"-v", "--", "-Werror", ""};
+  std::vector<std::string> dest;
+  SwiftASTContext::AddExtraClangArgs(source, dest);
+
+  // Check that all ignored arguments got removed.
+  EXPECT_EQ(dest, std::vector<std::string>({"-v"}));
+}


### PR DESCRIPTION
`--` indicates to Clang that all following arguments are file names (even when
they match a Clang compiler flag). This leads to the confusion situation
where LLDB users can run `settings set target.swift-extra-clang-flags -- -v`
and completely break the embedded Clang instance (that now tries to open the
file `-v`).

Fixes rdar://58457122

Previously created here but that PR got deleted https://github.com/apple/llvm-project/pull/2405