### PR TITLE
Add optional verification to check that tail calls from swifttail->swiftail are marked musttail.

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3316,7 +3316,24 @@ static AttrBuilder getParameterABIAttributes(int I, AttributeList Attrs) {
   return Copy;
 }
 
+static cl::opt<bool>
+EnableSwiftTailCCMustTailCheck("enable-swifttailcc-musttail-check",
+cl::init(false), cl::desc("Check that tail calls from swifttailcc functions to"
+                          " swifttailcc functions are marked musttail."));
+
 void Verifier::verifyMustTailCall(CallInst &CI) {
+  if (!CI.isMustTailCall()) {
+    if (EnableSwiftTailCCMustTailCheck &&
+        CI.getCallingConv() == CallingConv::SwiftTail &&
+        CI.getCaller()->getCallingConv() == CallingConv::SwiftTail &&
+        isa_and_nonnull<ReturnInst>(CI.getNextNode())) {
+      Assert(
+        false, "tail call from swifttail->swiftail should be marked musttail",
+        &CI);
+    }
+    return;
+  }
+
   Assert(!CI.isInlineAsm(), "cannot use musttail call with inline asm", &CI);
 
   Function *F = CI.getParent()->getParent();
@@ -3401,9 +3418,7 @@ void Verifier::verifyMustTailCall(CallInst &CI) {
 
 void Verifier::visitCallInst(CallInst &CI) {
   visitCallBase(CI);
-
-  if (CI.isMustTailCall())
-    verifyMustTailCall(CI);
+  verifyMustTailCall(CI);
 }
 
 void Verifier::visitInvokeInst(InvokeInst &II) {

--- a/llvm/lib/Transforms/IPO/MergeFunctions.cpp
+++ b/llvm/lib/Transforms/IPO/MergeFunctions.cpp
@@ -713,7 +713,11 @@ void MergeFunctions::writeThunk(Function *F, Function *G) {
 
   CallInst *CI = Builder.CreateCall(F, Args);
   ReturnInst *RI = nullptr;
-  CI->setTailCall();
+  bool isSwiftTailCall =
+   F->getCallingConv() == CallingConv::SwiftTail &&
+   G->getCallingConv() == CallingConv::SwiftTail;
+  CI->setTailCallKind(
+    isSwiftTailCall ? llvm::CallInst::TCK_MustTail : llvm::CallInst::TCK_Tail);
   CI->setCallingConv(F->getCallingConv());
   CI->setAttributes(F->getAttributes());
   if (H->getReturnType()->isVoidTy()) {


### PR DESCRIPTION
Fixes rdar://75899279 and rdar://76024125