### PR TITLE
Improve LiveDebugValues for arm64 Swift async variables.

### DIFF
--- a/llvm/test/DebugInfo/MIR/AArch64/swift-async.mir
+++ b/llvm/test/DebugInfo/MIR/AArch64/swift-async.mir
@@ -1,0 +1,366 @@
+# RUN: llc -mtriple arm64-apple-macos11 -O0 -start-before=livedebugvalues -filetype=obj -o - %s \
+# RUN:     | llvm-dwarfdump  --name  'n' - | FileCheck %s
+# CHECK: DW_TAG_formal_parameter
+# CHECK:   DW_AT_location (DW_OP_entry_value(DW_OP_reg22 W22), DW_OP_deref, DW_OP_plus_uconst 0x18, DW_OP_plus_uconst 0x8)
+# CHECK:  DW_AT_name	("n")
+--- |
+  ; ModuleID = '/tmp/t1.ll'
+  source_filename = "/tmp/fib.ll"
+  target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+  target triple = "arm64-apple-macosx16.0.0"
+  
+  %swift.async_func_pointer = type <{ i32, i32 }>
+  %"$s3fib9fibonacciyS2iYF.Frame" = type { %swift.context*, i64, i64, i64, i64, i8*, i64, i8* }
+  %swift.context = type {}
+  
+  @"$s3fib9fibonacciyS2iYFTu" = external hidden global %swift.async_func_pointer, section "__TEXT,__const", align 8
+  
+  ; Function Attrs: cold noreturn nounwind
+  declare void @llvm.trap() #0
+  
+  ; Function Attrs: argmemonly nofree nosync nounwind willreturn
+  declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
+  
+  ; Function Attrs: argmemonly nofree nosync nounwind willreturn
+  declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
+  
+  ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+  declare void @llvm.dbg.declare(metadata, metadata, metadata) #2
+  
+  ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+  declare { i64, i1 } @llvm.ssub.with.overflow.i64(i64, i64) #2
+  
+  ; Function Attrs: nofree nosync nounwind readnone willreturn
+  declare i1 @llvm.expect.i1(i1, i1) #3
+  
+  ; Function Attrs: argmemonly nounwind
+  declare extern_weak swiftcc i8* @swift_task_alloc(i64) #4
+  
+  ; Function Attrs: nounwind readnone
+  declare i8** @llvm.swift.async.context.addr() #5
+  
+  ; Function Attrs: argmemonly nounwind
+  declare extern_weak swiftcc void @swift_task_dealloc(i8*) #4
+  
+  define hidden swifttailcc void @"$s3fib9fibonacciyS2iYFTQ0_"(i8* swiftasync %0, i64 %1) #6 !dbg !59 {
+  entryresume.0:
+    call void @llvm.dbg.declare(metadata i8* %0, metadata !64, metadata !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24, DW_OP_plus_uconst, 24)), !dbg !66
+    call void @llvm.dbg.declare(metadata i8* %0, metadata !67, metadata !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24, DW_OP_plus_uconst, 16)), !dbg !68
+    call void @llvm.dbg.declare(metadata i8* %0, metadata !69, metadata !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24, DW_OP_plus_uconst, 8)), !dbg !70
+    %2 = bitcast i8* %0 to i8**, !dbg !71
+    %3 = load i8*, i8** %2, align 8, !dbg !71
+    %4 = call i8** @llvm.swift.async.context.addr() #7, !dbg !71
+    store i8* %3, i8** %4, align 8, !dbg !71
+    %async.ctx.frameptr1 = getelementptr inbounds i8, i8* %3, i32 24
+    %FramePtr = bitcast i8* %async.ctx.frameptr1 to %"$s3fib9fibonacciyS2iYF.Frame"*
+    %vFrame = bitcast %"$s3fib9fibonacciyS2iYF.Frame"* %FramePtr to i8*
+    %5 = getelementptr inbounds %"$s3fib9fibonacciyS2iYF.Frame", %"$s3fib9fibonacciyS2iYF.Frame"* %FramePtr, i32 0, i32 0
+    %n.debug = getelementptr inbounds %"$s3fib9fibonacciyS2iYF.Frame", %"$s3fib9fibonacciyS2iYF.Frame"* %FramePtr, i32 0, i32 1
+    %n_1.debug = getelementptr inbounds %"$s3fib9fibonacciyS2iYF.Frame", %"$s3fib9fibonacciyS2iYF.Frame"* %FramePtr, i32 0, i32 2
+    %n_2.debug = getelementptr inbounds %"$s3fib9fibonacciyS2iYF.Frame", %"$s3fib9fibonacciyS2iYF.Frame"* %FramePtr, i32 0, i32 3
+    %.reload.addr14 = getelementptr inbounds %"$s3fib9fibonacciyS2iYF.Frame", %"$s3fib9fibonacciyS2iYF.Frame"* %FramePtr, i32 0, i32 5, !dbg !76
+    %.reload15 = load i8*, i8** %.reload.addr14, align 8, !dbg !76
+    %.reload.addr11 = getelementptr inbounds %"$s3fib9fibonacciyS2iYF.Frame", %"$s3fib9fibonacciyS2iYF.Frame"* %FramePtr, i32 0, i32 4, !dbg !76
+    %.reload12 = load i64, i64* %.reload.addr11, align 8, !dbg !76
+    %6 = bitcast i8* %0 to i8**, !dbg !77
+    %7 = load i8*, i8** %6, align 8, !dbg !77
+    %8 = call i8** @llvm.swift.async.context.addr() #7, !dbg !77
+    store i8* %7, i8** %8, align 8, !dbg !77
+    %9 = bitcast i8* %7 to %swift.context*, !dbg !76
+    store %swift.context* %9, %swift.context** %5, align 8, !dbg !76
+    %.spill.addr16 = getelementptr inbounds %"$s3fib9fibonacciyS2iYF.Frame", %"$s3fib9fibonacciyS2iYF.Frame"* %FramePtr, i32 0, i32 6, !dbg !76
+    store i64 %1, i64* %.spill.addr16, align 8, !dbg !76
+    call swiftcc void @swift_task_dealloc(i8* %.reload15) #7, !dbg !76
+    call void @llvm.lifetime.end.p0i8(i64 -1, i8* %.reload15), !dbg !76
+    store i64 %1, i64* %n_1.debug, align 8, !dbg !79
+    call void asm sideeffect "", "r"(i64* %n_1.debug), !dbg !80
+    %10 = call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 %.reload12, i64 2), !dbg !82
+    %11 = extractvalue { i64, i1 } %10, 0, !dbg !82
+    %12 = extractvalue { i64, i1 } %10, 1, !dbg !82
+    %13 = call i1 @llvm.expect.i1(i1 %12, i1 false), !dbg !82
+    br i1 %13, label %29, label %CoroSuspend3, !dbg !82
+  
+  CoroSuspend3:                                     ; preds = %entryresume.0
+    %14 = load i32, i32* getelementptr inbounds (%swift.async_func_pointer, %swift.async_func_pointer* @"$s3fib9fibonacciyS2iYFTu", i32 0, i32 0), align 8, !dbg !83
+    %15 = sext i32 %14 to i64, !dbg !83
+    %16 = add i64 ptrtoint (%swift.async_func_pointer* @"$s3fib9fibonacciyS2iYFTu" to i64), %15, !dbg !83
+    %17 = inttoptr i64 %16 to i8*, !dbg !83
+    %18 = bitcast i8* %17 to void (%swift.context*, i64)*, !dbg !83
+    %19 = load i32, i32* getelementptr inbounds (%swift.async_func_pointer, %swift.async_func_pointer* @"$s3fib9fibonacciyS2iYFTu", i32 0, i32 1), align 8, !dbg !83
+    %20 = zext i32 %19 to i64, !dbg !83
+    %21 = call swiftcc i8* @swift_task_alloc(i64 %20) #7, !dbg !83
+    %.spill.addr19 = getelementptr inbounds %"$s3fib9fibonacciyS2iYF.Frame", %"$s3fib9fibonacciyS2iYF.Frame"* %FramePtr, i32 0, i32 7, !dbg !83
+    store i8* %21, i8** %.spill.addr19, align 8, !dbg !83
+    call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21), !dbg !83
+    %22 = bitcast i8* %21 to <{ %swift.context*, void (%swift.context*)*, i32 }>*, !dbg !83
+    %23 = load %swift.context*, %swift.context** %5, align 8, !dbg !83
+    %24 = getelementptr inbounds <{ %swift.context*, void (%swift.context*)*, i32 }>, <{ %swift.context*, void (%swift.context*)*, i32 }>* %22, i32 0, i32 0, !dbg !83
+    store %swift.context* %23, %swift.context** %24, align 8, !dbg !83
+    %25 = bitcast i8* bitcast (void (i8*, i64)* @"$s3fib9fibonacciyS2iYFTQ1_" to i8*) to void (%swift.context*)*, !dbg !83
+    %26 = getelementptr inbounds <{ %swift.context*, void (%swift.context*)*, i32 }>, <{ %swift.context*, void (%swift.context*)*, i32 }>* %22, i32 0, i32 1, !dbg !83
+    store void (%swift.context*)* %25, void (%swift.context*)** %26, align 8, !dbg !83
+    %27 = bitcast i8* %21 to %swift.context*, !dbg !83
+    %28 = bitcast void (%swift.context*, i64)* %18 to i8*, !dbg !83
+    musttail call swifttailcc void %18(%swift.context* swiftasync %27, i64 %11) #7, !dbg !84
+    ret void, !dbg !84
+  
+  29:                                               ; preds = %entryresume.0
+    call void @llvm.trap(), !dbg !87
+    unreachable, !dbg !87
+  }
+  
+  declare hidden swifttailcc void @"$s3fib9fibonacciyS2iYFTQ1_"(i8* swiftasync, i64) #6
+  
+  attributes #0 = { cold noreturn nounwind }
+  attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+  attributes #2 = { nofree nosync nounwind readnone speculatable willreturn }
+  attributes #3 = { nofree nosync nounwind readnone willreturn }
+  attributes #4 = { argmemonly nounwind }
+  attributes #5 = { nounwind readnone }
+  attributes #6 = { "frame-pointer"="non-leaf" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="apple-a12" "target-features"="+aes,+crc,+crypto,+fp-armv8,+fullfp16,+lse,+neon,+ras,+rcpc,+rdm,+sha2,+v8.3a,+zcm,+zcz" "unsafe-fp-math"="false" "use-soft-float"="false" }
+  attributes #7 = { nounwind }
+  
+  !llvm.dbg.cu = !{!0}
+  !swift.module.flags = !{!12}
+  !llvm.asan.globals = !{!13, !14, !15, !16, !17, !18, !19, !20, !21, !22, !23, !24, !25, !26, !27, !28, !29, !30, !31, !32, !33, !34, !35, !36, !37}
+  !llvm.module.flags = !{!38, !39, !40, !41, !42, !43, !44, !45, !46, !47, !48, !49, !50, !51, !52, !53, !54}
+  ;!llvm.linker.options = !{!55, !56, !57, !58}
+  
+  !0 = distinct !DICompileUnit(language: DW_LANG_Swift, file: !1, producer: "Swift version 5.5-dev (LLVM 6cafa2dc0b8de57, Swift 9c8f32517768a78)", isOptimized: false, runtimeVersion: 5, emissionKind: FullDebug, enums: !2, imports: !3)
+  !1 = !DIFile(filename: "/Volumes/Data/swift/llvm-project/../llvm-project/lldb/test/API/lang/swift/async/unwind/backtrace_locals/main.swift", directory: "/Volumes/Data/swift/llvm-project")
+  !2 = !{}
+  !3 = !{!4, !6, !8, !10}
+  !4 = !DIImportedEntity(tag: DW_TAG_imported_module, scope: !1, entity: !5, file: !1)
+  !5 = !DIModule(scope: null, name: "fib", includePath: "/Volumes/Data/swift/llvm-project/../llvm-project/lldb/test/API/lang/swift/async/unwind/backtrace_locals")
+  !6 = !DIImportedEntity(tag: DW_TAG_imported_module, scope: !1, entity: !7, file: !1)
+  !7 = !DIModule(scope: null, name: "Swift", includePath: "/Volumes/Data/swift/_build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/macosx/Swift.swiftmodule/arm64-apple-macos.swiftmodule")
+  !8 = !DIImportedEntity(tag: DW_TAG_imported_module, scope: !1, entity: !9, file: !1)
+  !9 = !DIModule(scope: null, name: "_Concurrency", includePath: "/Volumes/Data/swift/_build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/macosx/_Concurrency.swiftmodule/arm64-apple-macos.swiftmodule")
+  !10 = !DIImportedEntity(tag: DW_TAG_imported_module, scope: !1, entity: !11, file: !1)
+  !11 = !DIModule(scope: null, name: "SwiftOnoneSupport", includePath: "/Volumes/Data/swift/_build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/macosx/SwiftOnoneSupport.swiftmodule/arm64-apple-macos.swiftmodule")
+  !12 = !{!"standard-library", i1 false}
+  !13 = distinct !{null, null, null, i1 false, i1 true}
+  !14 = !{%swift.async_func_pointer* @"$s3fib9fibonacciyS2iYFTu", null, null, i1 false, i1 true}
+  !15 = distinct !{null, null, null, i1 false, i1 true}
+  !16 = distinct !{null, null, null, i1 false, i1 true}
+  !17 = distinct !{null, null, null, i1 false, i1 true}
+  !18 = distinct !{null, null, null, i1 false, i1 true}
+  !19 = distinct !{null, null, null, i1 false, i1 true}
+  !20 = distinct !{null, null, null, i1 false, i1 true}
+  !21 = distinct !{null, null, null, i1 false, i1 true}
+  !22 = distinct !{null, null, null, i1 false, i1 true}
+  !23 = distinct !{null, null, null, i1 false, i1 true}
+  !24 = distinct !{null, null, null, i1 false, i1 true}
+  !25 = distinct !{null, null, null, i1 false, i1 true}
+  !26 = distinct !{null, null, null, i1 false, i1 true}
+  !27 = distinct !{null, null, null, i1 false, i1 true}
+  !28 = distinct !{null, null, null, i1 false, i1 true}
+  !29 = distinct !{null, null, null, i1 false, i1 true}
+  !30 = distinct !{null, null, null, i1 false, i1 true}
+  !31 = distinct !{null, null, null, i1 false, i1 true}
+  !32 = distinct !{null, null, null, i1 false, i1 true}
+  !33 = distinct !{null, null, null, i1 false, i1 true}
+  !34 = distinct !{null, null, null, i1 false, i1 true}
+  !35 = distinct !{null, null, null, i1 false, i1 true}
+  !36 = distinct !{null, null, null, i1 false, i1 true}
+  !37 = distinct !{null, null, null, i1 false, i1 true}
+  !38 = !{i32 1, !"Objective-C Version", i32 2}
+  !39 = !{i32 1, !"Objective-C Image Info Version", i32 0}
+  !40 = !{i32 1, !"Objective-C Image Info Section", !"__DATA,__objc_imageinfo,regular,no_dead_strip"}
+  !41 = !{i32 1, !"Objective-C Garbage Collection", i8 0}
+  !42 = !{i32 1, !"Objective-C Class Properties", i32 64}
+  !43 = !{i32 7, !"Dwarf Version", i32 4}
+  !44 = !{i32 2, !"Debug Info Version", i32 3}
+  !45 = !{i32 1, !"wchar_size", i32 4}
+  !46 = !{i32 1, !"branch-target-enforcement", i32 0}
+  !47 = !{i32 1, !"sign-return-address", i32 0}
+  !48 = !{i32 1, !"sign-return-address-all", i32 0}
+  !49 = !{i32 1, !"sign-return-address-with-bkey", i32 0}
+  !50 = !{i32 7, !"PIC Level", i32 2}
+  !51 = !{i32 1, !"Swift Version", i32 7}
+  !52 = !{i32 1, !"Swift ABI Version", i32 7}
+  !53 = !{i32 1, !"Swift Major Version", i8 5}
+  !54 = !{i32 1, !"Swift Minor Version", i8 5}
+  !55 = !{!"-lswiftSwiftOnoneSupport"}
+  !56 = !{!"-lswiftCore"}
+  !57 = !{!"-lswift_Concurrency"}
+  !58 = !{!"-lobjc"}
+  !59 = distinct !DISubprogram(name: "fibonacci", linkageName: "$s3fib9fibonacciyS2iYFTQ0_", scope: !5, file: !1, line: 19, type: !60, scopeLine: 23, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+  !60 = !DISubroutineType(types: !61)
+  !61 = !{!62, !62}
+  !62 = !DICompositeType(tag: DW_TAG_structure_type, name: "Int", scope: !7, file: !63, size: 64, elements: !2, runtimeLang: DW_LANG_Swift, identifier: "$sSiD")
+  !63 = !DIFile(filename: "_build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/macosx/Swift.swiftmodule/arm64-apple-macos.swiftmodule", directory: "/Volumes/Data/swift")
+  !64 = !DILocalVariable(name: "n_2", scope: !59, file: !1, line: 24, type: !65)
+  !65 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !62)
+  !66 = !DILocation(line: 24, column: 9, scope: !59)
+  !67 = !DILocalVariable(name: "n_1", scope: !59, file: !1, line: 23, type: !65)
+  !68 = !DILocation(line: 23, column: 9, scope: !59)
+  !69 = !DILocalVariable(name: "n", arg: 1, scope: !59, file: !1, line: 19, type: !65)
+  !70 = !DILocation(line: 19, column: 16, scope: !59)
+  !71 = !DILocation(line: 0, scope: !72, inlinedAt: !75)
+  !72 = distinct !DISubprogram(linkageName: "__swift_async_resume_project_context", scope: !5, file: !73, type: !74, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+  !73 = !DIFile(filename: "<compiler-generated>", directory: "")
+  !74 = !DISubroutineType(types: null)
+  !75 = distinct !DILocation(line: 23, column: 21, scope: !59)
+  !76 = !DILocation(line: 23, column: 21, scope: !59)
+  !77 = !DILocation(line: 0, scope: !72, inlinedAt: !78)
+  !78 = distinct !DILocation(line: 23, column: 21, scope: !59)
+  !79 = !DILocation(line: 0, scope: !59)
+  !80 = !DILocation(line: 0, scope: !81)
+  !81 = !DILexicalBlockFile(scope: !59, file: !73, discriminator: 0)
+  !82 = !DILocation(line: 24, column: 33, scope: !59)
+  !83 = !DILocation(line: 24, column: 21, scope: !59)
+  !84 = !DILocation(line: 0, scope: !85, inlinedAt: !86)
+  !85 = distinct !DISubprogram(linkageName: "__swift_suspend_dispatch_2.3", scope: !5, file: !73, type: !74, flags: DIFlagArtificial, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !0, retainedNodes: !2)
+  !86 = distinct !DILocation(line: 24, column: 21, scope: !59)
+  !87 = !DILocation(line: 0, scope: !88, inlinedAt: !82)
+  !88 = distinct !DISubprogram(name: "Swift runtime failure: arithmetic overflow", scope: !5, file: !1, type: !74, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+
+...
+---
+name:            '$s3fib9fibonacciyS2iYFTQ0_'
+alignment:       4
+exposesReturnsTwice: false
+legalized:       true
+regBankSelected: true
+selected:        true
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+registers:       []
+liveins:
+  - { reg: '$x22', virtual-reg: '' }
+  - { reg: '$x0', virtual-reg: '' }
+frameInfo:
+  isFrameAddressTaken: true
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       80
+  offsetAdjustment: 0
+  maxAlignment:    8
+  adjustsStack:    true
+  hasCalls:        true
+  stackProtector:  ''
+  maxCallFrameSize: 0
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:
+  - { id: 0, name: '', type: spill-slot, offset: -32, size: 8, alignment: 8, 
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true, 
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+  - { id: 1, name: '', type: spill-slot, offset: -40, size: 8, alignment: 8, 
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true, 
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+  - { id: 2, name: '', type: spill-slot, offset: -48, size: 8, alignment: 8, 
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true, 
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+  - { id: 3, name: '', type: spill-slot, offset: -56, size: 8, alignment: 8, 
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true, 
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+  - { id: 4, name: '', type: spill-slot, offset: -64, size: 8, alignment: 8, 
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true, 
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+  - { id: 5, name: '', type: spill-slot, offset: -72, size: 8, alignment: 8, 
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true, 
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+  - { id: 6, name: '', type: spill-slot, offset: -80, size: 8, alignment: 8, 
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true, 
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+  - { id: 7, name: '', type: spill-slot, offset: -8, size: 8, alignment: 8, 
+      stack-id: default, callee-saved-register: '$lr', callee-saved-restored: true, 
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+  - { id: 8, name: '', type: spill-slot, offset: -16, size: 8, alignment: 8, 
+      stack-id: default, callee-saved-register: '$fp', callee-saved-restored: true, 
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+  - { id: 9, name: '', type: spill-slot, offset: -24, size: 8, alignment: 8, 
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true, 
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  hasRedZone:      false
+body:             |
+  bb.0.entryresume.0:
+    successors: %bb.2(0x40000000), %bb.1(0x40000000)
+    liveins: $x0, $x22, $lr
+  
+    $fp = frame-setup ORRXri $fp, 4352
+    $sp = frame-setup SUBXri $sp, 80, 0
+    frame-setup STPXi killed $fp, killed $lr, $sp, 8 :: (store 8 into %stack.8), (store 8 into %stack.7)
+    frame-setup STRXui $x22, $sp, 7
+    $fp = frame-setup ADDXri $sp, 64, 0
+    frame-setup CFI_INSTRUCTION def_cfa $w29, 16
+    frame-setup CFI_INSTRUCTION offset $w30, -8
+    frame-setup CFI_INSTRUCTION offset $w29, -16
+    $x8 = ORRXrs $xzr, killed $x0, 0
+    STRXui $x8, $sp, 3 :: (store 8 into %stack.3)
+    $x9 = ADRP target-flags(aarch64-page) @"$s3fib9fibonacciyS2iYFTu", debug-location !79
+    renamable $x9 = ADDXri $x9, target-flags(aarch64-pageoff, aarch64-nc) @"$s3fib9fibonacciyS2iYFTu", 0, debug-location !79
+    STRXui killed $x9, $sp, 1 :: (store 8 into %stack.5)
+    DBG_VALUE $x22, 0, !64, !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24, DW_OP_plus_uconst, 24), debug-location !66
+    DBG_VALUE $x22, 0, !67, !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24, DW_OP_plus_uconst, 16), debug-location !68
+    DBG_VALUE $x22, 0, !69, !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24, DW_OP_plus_uconst, 8), debug-location !70
+    renamable $x9 = LDRXui renamable $x22, 0, debug-location !71 :: (load 8 from %ir.2)
+    STRXui $x9, $sp, 2 :: (store 8 into %stack.4)
+    renamable $x10 = SUBXri $fp, 8, 0, debug-location !71
+    STRXui renamable $x9, killed renamable $x10, 0, debug-location !71 :: (store 8 into %ir.4)
+    renamable $x10 = ADDXri renamable $x9, 40, 0
+    STRXui $x10, $sp, 4 :: (store 8 into %stack.2)
+    renamable $x0 = LDRXui renamable $x9, 8, debug-location !76 :: (load 8 from %ir..reload.addr14)
+    renamable $x10 = LDRXui renamable $x9, 7, debug-location !76 :: (load 8 from %ir..reload.addr11)
+    STURXi $x10, $fp, -24 :: (store 8 into %stack.1)
+    renamable $x10 = LDRXui killed renamable $x22, 0, debug-location !77 :: (load 8 from %ir.6)
+    renamable $x11 = SUBXri $fp, 8, 0, debug-location !77
+    STRXui renamable $x10, killed renamable $x11, 0, debug-location !77 :: (store 8 into %ir.8)
+    STRXui killed renamable $x10, renamable $x9, 3, debug-location !76 :: (store 8 into %ir.5)
+    STRXui renamable $x8, renamable $x9, 9, debug-location !76 :: (store 8 into %ir..spill.addr16)
+    BL @swift_task_dealloc, csr_darwin_aarch64_aapcs, implicit-def dead $lr, implicit $sp, implicit killed $x0, debug-location !76
+    $x10 = LDRXui $sp, 2 :: (load 8 from %stack.4)
+    $x0 = LDRXui $sp, 3 :: (load 8 from %stack.3)
+    $x9 = LDRXui $sp, 4 :: (load 8 from %stack.2)
+    $x8 = LDURXi $fp, -24 :: (load 8 from %stack.1)
+    STRXui killed renamable $x0, renamable $x10, 5, debug-location !79 :: (store 8 into %ir.n_1.debug)
+    INLINEASM &"", 1 /* sideeffect attdialect */, 1441801 /* reguse:GPR64common */, killed renamable $x9, debug-location !80
+    renamable $x8 = SUBSXri killed renamable $x8, 2, 0, implicit-def $nzcv, debug-location !82
+    STURXi killed $x8, $fp, -16 :: (store 8 into %stack.0)
+    renamable $w8 = CSINCWr $wzr, $wzr, 7, implicit killed $nzcv, debug-location !82
+    TBNZW killed renamable $w8, 0, %bb.2, debug-location !82
+  
+  bb.1.CoroSuspend3:
+    $x8 = LDRXui $sp, 1 :: (load 8 from %stack.5)
+    renamable $x10 = ADRP target-flags(aarch64-page) @"$s3fib9fibonacciyS2iYFTu", debug-location !79
+    $x9 = ADRP target-flags(aarch64-page) @"$s3fib9fibonacciyS2iYFTu", debug-location !79
+    renamable $x9 = ADDXri $x9, target-flags(aarch64-pageoff, aarch64-nc) @"$s3fib9fibonacciyS2iYFTu", 0, debug-location !79
+    renamable $x10 = LDRSWui killed renamable $x10, target-flags(aarch64-pageoff, aarch64-nc) @"$s3fib9fibonacciyS2iYFTu", debug-location !83 :: (dereferenceable load 4 from `i32* getelementptr inbounds (%swift.async_func_pointer, %swift.async_func_pointer* @"$s3fib9fibonacciyS2iYFTu", i32 0, i32 0)`, align 8)
+    $x0 = ADDXrs killed renamable $x9, killed renamable $x10, 0, debug-location !83
+    STRXui $x0, $sp, 0 :: (store 8 into %stack.6)
+    renamable $w8 = LDRWui killed renamable $x8, 1, debug-location !83 :: (dereferenceable load 4 from `i32* getelementptr inbounds (%swift.async_func_pointer, %swift.async_func_pointer* @"$s3fib9fibonacciyS2iYFTu", i32 0, i32 1)`, align 8)
+    $x0 = ORRXrs $xzr, undef $x8, 0, implicit killed $w8, debug-location !83
+    BL @swift_task_alloc, csr_darwin_aarch64_aapcs, implicit-def dead $lr, implicit $sp, implicit killed $x0, implicit-def $x0, debug-location !83
+    $x8 = LDRXui $sp, 2 :: (load 8 from %stack.4)
+    $x1 = LDRXui $sp, 0 :: (load 8 from %stack.6)
+    $x22 = ORRXrs $xzr, $x0, 0, debug-location !83
+    $x0 = LDURXi $fp, -16 :: (load 8 from %stack.0)
+    STRXui renamable $x22, renamable $x8, 10, debug-location !83 :: (store 8 into %ir..spill.addr19)
+    renamable $x8 = LDRXui killed renamable $x8, 3, debug-location !83 :: (load 8 from %ir.5)
+    STRXui killed renamable $x8, renamable $x22, 0, debug-location !83 :: (store 8 into %ir.24)
+    $x8 = ADRP target-flags(aarch64-page) @"$s3fib9fibonacciyS2iYFTQ1_", debug-location !79
+    renamable $x8 = ADDXri $x8, target-flags(aarch64-pageoff, aarch64-nc) @"$s3fib9fibonacciyS2iYFTQ1_", 0, debug-location !79
+    STRXui killed renamable $x8, renamable $x22, 1, debug-location !83 :: (store 8 into %ir.26)
+    $fp, $lr = frame-destroy LDPXi $sp, 8, debug-location !84 :: (load 8 from %stack.8), (load 8 from %stack.7)
+    $fp = frame-destroy ANDXri $fp, 4350, debug-location !84
+    $sp = frame-destroy ADDXri $sp, 80, 0, debug-location !84
+    TCRETURNri killed renamable $x1, 0, csr_darwin_aarch64_aapcs_swifttail, implicit $sp, implicit killed $x22, implicit killed $x0, debug-location !84
+  
+  bb.2 (%ir-block.29):
+    BRK 1, debug-location !87
+
+...


### PR DESCRIPTION
This patch contains two bugfixes:
1. iterate over the MachineRefInfo's livein values instead of the MBB
2. move all DBG_VALUEs that point into an asyn context to the very beginning of the first basic block

rdar://75904857