### PR TITLE
[lldb] Skip ResilientArray and ResilientDict

### DIFF
--- a/lldb/test/Shell/SwiftREPL/ResilientArray.test
+++ b/lldb/test/Shell/SwiftREPL/ResilientArray.test
@@ -3,7 +3,7 @@
 
 // RUN: %lldb --repl < %s | FileCheck %s
 // rdar://76105456
-// XFAIL: *
+// UNSUPPORTED: *
 import Foundation
 
 let x : [URL] = [URL(string: "https://github.com")!, URL(string: "https://apple.com")!]

--- a/lldb/test/Shell/SwiftREPL/ResilientDict.test
+++ b/lldb/test/Shell/SwiftREPL/ResilientDict.test
@@ -4,7 +4,7 @@
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=DICT
 
 // rdar://76105456
-// XFAIL: *
+// UNSUPPORTED: *
 
 // The dictionary order isn't deterministic, so print the dictionary
 // once per element.


### PR DESCRIPTION
Skip instead of XFAIL these tests as they fail on Catalina but pass on
Big Sur.

rdar://76127919