### PR TITLE
[lldb] UNSUPPORTED -> REQUIRES

### DIFF
--- a/lldb/test/Shell/SwiftREPL/ResilientArray.test
+++ b/lldb/test/Shell/SwiftREPL/ResilientArray.test
@@ -2,8 +2,10 @@
 // REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
+
 // rdar://76105456
-// UNSUPPORTED: *
+// REQUIRES: radar76105456
+
 import Foundation
 
 let x : [URL] = [URL(string: "https://github.com")!, URL(string: "https://apple.com")!]

--- a/lldb/test/Shell/SwiftREPL/ResilientDict.test
+++ b/lldb/test/Shell/SwiftREPL/ResilientDict.test
@@ -4,7 +4,7 @@
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=DICT
 
 // rdar://76105456
-// UNSUPPORTED: *
+// REQUIRES: radar76105456
 
 // The dictionary order isn't deterministic, so print the dictionary
 // once per element.


### PR DESCRIPTION
Lit supports `XFAIL: *` but apparently not `UNSUPPORTED: *`, so use use
REQUIRES instead.