### PR TITLE
Reject Objective-C types in SwiftLanguage::GetPossibleFormattersMatch…

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -884,6 +884,15 @@ std::vector<ConstString> SwiftLanguage::GetPossibleFormattersMatches(
   if (use_dynamic == lldb::eNoDynamicValues)
     return result;
 
+  // There is no point in attempting to format Clang types here, since
+  // FormatManager will try to format all Swift types also as
+  // Objective-C types and vice versa.  Due to the incomplete
+  // ClangImporter implementation for C++, continuing here for
+  // Objective-C++ types can actually lead to crashes that can be
+  // avoided by just formatting those types as Objective-C types.
+  if (valobj.GetObjectRuntimeLanguage() == eLanguageTypeObjC)
+    return result;
+
   SwiftASTContextLock scratch_ctx_lock(&valobj.GetExecutionContextRef());
   CompilerType compiler_type(valobj.GetCompilerType());
 


### PR DESCRIPTION
…es()

This mostly NFC commit avoids redundant work when formatting
Objective-C(++) types, especially in Objective-C contexts.  LLDB tries
to format all Objective-C and Swift types in both languages. However
the formatting of Objective-C types in Swift effectively just wraps
the Objective-C type and the end result is the same as if we just
formatted the type as Objective-C to begin with.

Due to the incomplete ClangImporter implementation for C++ this this
could also lead to crashes that can be avoided by just formatting ObjC
types as Objective-C.

rdar://75030678
(cherry picked from commit 9a9c31161d2a4081dfcb4e8268826065e0f2debd)