### PR TITLE
Always resolve bind generic types in the expression evaluator.

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -446,15 +446,14 @@ public:
 /// An invalid CompilerType is returned on error.
 static CompilerType GetSwiftTypeForVariableValueObject(
     lldb::ValueObjectSP valobj_sp, lldb::StackFrameSP &stack_frame_sp,
-    SwiftLanguageRuntime *runtime, bool use_dynamic_value) {
+    SwiftLanguageRuntime *runtime) {
   // Check that the passed ValueObject is valid.
   if (!valobj_sp || valobj_sp->GetError().Fail())
     return CompilerType();
   CompilerType result = valobj_sp->GetCompilerType();
   if (!result.IsValid())
     return CompilerType();
-  if (use_dynamic_value)
-    result = runtime->BindGenericTypeParameters(*stack_frame_sp, result);
+  result = runtime->BindGenericTypeParameters(*stack_frame_sp, result);
   if (!result.GetTypeSystem()->SupportsLanguage(lldb::eLanguageTypeSwift))
     return CompilerType();
   return result;
@@ -474,8 +473,8 @@ static CompilerType ResolveVariable(
                                                      lldb::eNoDynamicValues);
   const bool use_dynamic_value = use_dynamic > lldb::eNoDynamicValues;
 
-  CompilerType var_type = GetSwiftTypeForVariableValueObject(
-      valobj_sp, stack_frame_sp, runtime, use_dynamic_value);
+  CompilerType var_type =
+      GetSwiftTypeForVariableValueObject(valobj_sp, stack_frame_sp, runtime);
 
   if (!var_type.IsValid())
     return {};
@@ -484,8 +483,7 @@ static CompilerType ResolveVariable(
   // the dynamic type.
   if (!SwiftASTContext::IsFullyRealized(var_type) && use_dynamic_value) {
     var_type = GetSwiftTypeForVariableValueObject(
-        valobj_sp->GetDynamicValue(use_dynamic), stack_frame_sp, runtime,
-        use_dynamic_value);
+        valobj_sp->GetDynamicValue(use_dynamic), stack_frame_sp, runtime);
     if (!var_type.IsValid())
       return {};
   }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1013,6 +1013,7 @@ static uint32_t collectTypeInfo(SwiftASTContext *module_holder,
     case Node::Kind::BoundGenericFunction:
       swift_flags |= eTypeIsGeneric | eTypeIsBound;
       LLVM_FALLTHROUGH;
+    case Node::Kind::NoEscapeFunctionType:
     case Node::Kind::FunctionType:
       swift_flags |= eTypeIsPointer | eTypeHasValue;
       break;
@@ -1745,6 +1746,7 @@ size_t TypeSystemSwiftTypeRef::GetNumberOfFunctionArguments(
     Demangler dem;
     NodePointer node = DemangleCanonicalType(dem, type);
     if (!node || (node->getKind() != Node::Kind::FunctionType &&
+                  node->getKind() != Node::Kind::NoEscapeFunctionType &&
                   node->getKind() != Node::Kind::ImplFunctionType))
       return 0;
     unsigned num_args = 0;
@@ -1774,6 +1776,7 @@ TypeSystemSwiftTypeRef::GetFunctionArgumentAtIndex(opaque_compiler_type_t type,
     Demangler dem;
     NodePointer node = DemangleCanonicalType(dem, type);
     if (!node || (node->getKind() != Node::Kind::FunctionType &&
+                  node->getKind() != Node::Kind::NoEscapeFunctionType &&
                   node->getKind() != Node::Kind::ImplFunctionType))
       return {};
     unsigned num_args = 0;
@@ -2053,6 +2056,7 @@ TypeSystemSwiftTypeRef::GetFunctionReturnType(opaque_compiler_type_t type) {
     Demangler dem;
     NodePointer node = DemangleCanonicalType(dem, type);
     if (!node || (node->getKind() != Node::Kind::FunctionType &&
+                  node->getKind() != Node::Kind::NoEscapeFunctionType &&
                   node->getKind() != Node::Kind::ImplFunctionType))
       return {};
     for (NodePointer child : *node) {
@@ -2223,6 +2227,7 @@ lldb::Encoding TypeSystemSwiftTypeRef::GetEncoding(opaque_compiler_type_t type,
     case Node::Kind::Class:
     case Node::Kind::BoundGenericClass:
     case Node::Kind::FunctionType:
+    case Node::Kind::NoEscapeFunctionType:
     case Node::Kind::ImplFunctionType:
     case Node::Kind::DependentGenericParamType:
     case Node::Kind::Function:
@@ -2889,6 +2894,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     case Node::Kind::BuiltinTypeName:
     case Node::Kind::DependentGenericParamType:
     case Node::Kind::FunctionType:
+    case Node::Kind::NoEscapeFunctionType:
     case Node::Kind::ImplFunctionType: {
       uint32_t item_count = 1;
       // A few formats, we might need to modify our size and count for

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1732,6 +1732,7 @@ bool TypeSystemSwiftTypeRef::IsFunctionType(opaque_compiler_type_t type) {
     // Note: There are a number of other candidates, and this list may need
     // updating. Ex: `NoEscapeFunctionType`, `ThinFunctionType`, etc.
     return node && (node->getKind() == Node::Kind::FunctionType ||
+                    node->getKind() == Node::Kind::NoEscapeFunctionType ||
                     node->getKind() == Node::Kind::ImplFunctionType);
   };
   VALIDATE_AND_RETURN(impl, IsFunctionType, type, (ReconstructType(type)),

--- a/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
+++ b/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
@@ -21,13 +21,13 @@ class TestClassConstrainedProtocol(TestBase):
     def test_extension_weak_self(self):
         """Test that we can reconstruct weak self captured in a class constrained protocol."""
         self.build()
-        self.do_self_test("Break here for weak self", needs_dynamic=True)
+        self.do_self_test("Break here for weak self", needs_dynamic=False)
 
     @swiftTest
     def test_extension_self (self):
         """Test that we can reconstruct self in method of a class constrained protocol."""
         self.build()
-        self.do_self_test("Break here in class protocol", needs_dynamic=True)
+        self.do_self_test("Break here in class protocol", needs_dynamic=False)
 
     @swiftTest
     def test_method_weak_self(self):

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -138,6 +138,17 @@ TEST_F(TestTypeSystemSwiftTypeRef, Function) {
     ASSERT_EQ(impl_void_void.GetNumberOfFunctionArguments(), 0UL);
   }
   {
+    NodePointer n = b.GlobalType(
+        b.Node(Node::Kind::NoEscapeFunctionType,
+               b.Node(Node::Kind::ArgumentTuple,
+                      b.Node(Node::Kind::Type, b.Node(Node::Kind::Tuple))),
+               b.Node(Node::Kind::ReturnType,
+                      b.Node(Node::Kind::Type, b.Node(Node::Kind::Tuple)))));
+    CompilerType impl_void_void = GetCompilerType(b.Mangle(n));
+    ASSERT_TRUE(impl_void_void.IsFunctionType());
+    ASSERT_EQ(impl_void_void.GetNumberOfFunctionArguments(), 0UL);
+  }
+  {
     NodePointer n = b.GlobalType(b.Node(
         Node::Kind::ImplFunctionType, b.Node(Node::Kind::ImplEscaping),
         b.Node(Node::Kind::ImplConvention, "@callee_guaranteed"),

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -144,9 +144,10 @@ TEST_F(TestTypeSystemSwiftTypeRef, Function) {
                       b.Node(Node::Kind::Type, b.Node(Node::Kind::Tuple))),
                b.Node(Node::Kind::ReturnType,
                       b.Node(Node::Kind::Type, b.Node(Node::Kind::Tuple)))));
-    CompilerType impl_void_void = GetCompilerType(b.Mangle(n));
-    ASSERT_TRUE(impl_void_void.IsFunctionType());
-    ASSERT_EQ(impl_void_void.GetNumberOfFunctionArguments(), 0UL);
+    CompilerType ne_void_void = GetCompilerType(b.Mangle(n));
+    ASSERT_TRUE(ne_void_void.IsFunctionType());
+    ASSERT_TRUE(ne_void_void.IsFunctionPointerType());
+    ASSERT_EQ(ne_void_void.GetNumberOfFunctionArguments(), 0UL);
   }
   {
     NodePointer n = b.GlobalType(b.Node(


### PR DESCRIPTION
It makes really no sense for generic types to not be bound in the
expression evaluator. The desired end-state is to divorce generic type
binding from dynamic type resolution. Instead, we'll add a
--bind-generic-types option to frame/target variable that is on by
default (not included in this patch).

rdar://76148477