### PR TITLE
Cherry-pick #2790 from apple/stable/20210107 to swift/main

### DIFF
--- a/llvm/lib/Target/X86/X86CallingConv.td
+++ b/llvm/lib/Target/X86/X86CallingConv.td
@@ -862,6 +862,10 @@ def CC_X86_32_C : CallingConv<[
   // The 'nest' parameter, if any, is passed in ECX.
   CCIfNest<CCAssignToReg<[ECX]>>,
 
+  // On swifttailcc pass swiftself in ECX.
+  CCIfCC<"CallingConv::SwiftTail",
+         CCIfSwiftSelf<CCIfType<[i32], CCAssignToReg<[ECX]>>>>,
+
   // The first 3 integer arguments, if marked 'inreg' and if the call is not
   // a vararg call, are passed in integer registers.
   CCIfNotVarArg<CCIfInReg<CCIfType<[i32], CCAssignToReg<[EAX, EDX, ECX]>>>>,

--- a/llvm/lib/Target/X86/X86RegisterInfo.cpp
+++ b/llvm/lib/Target/X86/X86RegisterInfo.cpp
@@ -350,6 +350,8 @@ X86RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
       return CSR_Win64_NoSSE_SaveList;
     return CSR_Win64_SaveList;
   case CallingConv::SwiftTail:
+    if (!Is64Bit)
+      return CSR_32_SaveList;
     return IsWin64 ? CSR_Win64_SwiftTail_SaveList : CSR_64_SwiftTail_SaveList;
   case CallingConv::X86_64_SysV:
     if (CallsEHReturn)
@@ -468,6 +470,8 @@ X86RegisterInfo::getCallPreservedMask(const MachineFunction &MF,
   case CallingConv::Win64:
     return CSR_Win64_RegMask;
   case CallingConv::SwiftTail:
+    if (!Is64Bit)
+      return CSR_32_RegMask;
     return IsWin64 ? CSR_Win64_SwiftTail_RegMask : CSR_64_SwiftTail_RegMask;
   case CallingConv::X86_64_SysV:
     return CSR_64_RegMask;

--- a/llvm/test/CodeGen/X86/swifttail-async-i386.ll
+++ b/llvm/test/CodeGen/X86/swifttail-async-i386.ll
@@ -1,0 +1,22 @@
+; RUN: llc -mtriple=i386-apple-darwin %s -o - | FileCheck %s
+
+declare void @clobber()
+
+declare swifttailcc void @swifttail_callee()
+define swifttailcc void @swifttail() {
+; CHECK-LABEL: swifttail:
+; CHECK-NOT: %rbx
+  call void @clobber()
+  tail call swifttailcc void @swifttail_callee()
+  ret void
+}
+
+declare swifttailcc void @swiftself(i8* swiftself)
+
+define swifttailcc void @swifttail2(i8* %arg) {
+; CHECK-LABEL: swifttail2:
+; CHECK: movl {{.*}}, %ecx
+; CHECK: jmp _swiftself
+  tail call swifttailcc void @swiftself(i8* swiftself %arg)
+  ret void
+}


### PR DESCRIPTION
X86: swifttailcc pass swiftself in ECX
X86: swiftailcc fix csr save list and register mask on i386

(cherry picked from commit d3e945a40791db98dd859088cb3c8a0bac500150)