### PR TITLE
Cherry-pick Python3 changes to apple/stable/20210107

### DIFF
--- a/llvm/utils/lit/lit.py
+++ b/llvm/utils/lit/lit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from lit.main import main
 

--- a/llvm/utils/lit/lit/cl_arguments.py
+++ b/llvm/utils/lit/lit/cl_arguments.py
@@ -31,7 +31,7 @@ def parse_args():
             metavar="N",
             help="Number of workers used for testing",
             type=_positive_int,
-            default=lit.util.detectCPUs())
+            default=lit.util.usable_core_count())
     parser.add_argument("--config-prefix",
             dest="configPrefix",
             metavar="NAME",

--- a/llvm/utils/lit/lit/run.py
+++ b/llvm/utils/lit/lit/run.py
@@ -110,7 +110,7 @@ class Run(object):
     # threads counts toward the current process limit. Try to raise the (soft)
     # process limit so that tests don't fail due to resource exhaustion.
     def _increase_process_limit(self):
-        ncpus = lit.util.detectCPUs()
+        ncpus = lit.util.usable_core_count()
         desired_limit = self.workers * ncpus * 2 # the 2 is a safety factor
 
         # Importing the resource module will likely fail on Windows.


### PR DESCRIPTION
These changes were missing since we branched after they were merged, which is annoying for developers at their desks as they need to use `python3 path/to/lit.py` explicitly.