### PR TITLE
[tsan] Fix aarch64-*-linux after D86377

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_platform_posix.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_platform_posix.cpp
@@ -99,7 +99,7 @@ void CheckAndProtect() {
     Die();
   }
 
-#if defined(__aarch64__) && !HAS_48_BIT_ADDRESS_SPACE
+#if defined(__aarch64__) && defined(__APPLE__) && !HAS_48_BIT_ADDRESS_SPACE
   ProtectRange(HeapMemEnd(), ShadowBeg());
   ProtectRange(ShadowEnd(), MetaShadowBeg());
   ProtectRange(MetaShadowEnd(), TraceMemBeg());


### PR DESCRIPTION
All check-tsan tests fail on aarch64-*-linux because HeapMemEnd() > ShadowBeg()
for the following code path:
```
 #if defined(__aarch64__) && !HAS_48_BIT_ADDRESS_SPACE
   ProtectRange(HeapMemEnd(), ShadowBeg());
```

Restore the behavior before D86377 for aarch64-*-linux.