### PR TITLE
[lldb] Add test for async frame variables

### DIFF
--- a/lldb/test/API/lang/swift/async/frame/Makefile
+++ b/lldb/test/API/lang/swift/async/frame/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -Xfrontend -enable-experimental-concurrency -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/frame/TestSwiftAsyncFrameVar.py
+++ b/lldb/test/API/lang/swift/async/frame/TestSwiftAsyncFrameVar.py
@@ -13,8 +13,8 @@ class TestCase(lldbtest.TestBase):
         """Test `frame variable` in async functions"""
         self.build()
 
-	# Setting a breakpoint on "main" results in a breakpoint at the start
-	# of each coroutine "funclet" function.
+        # Setting a breakpoint on "main" results in a breakpoint at the start
+        # of each coroutine "funclet" function.
         _, process, _, _ = lldbutil.run_to_name_breakpoint(self, 'main')
 
         while process.state == lldb.eStateStopped:

--- a/lldb/test/API/lang/swift/async/frame/TestSwiftAsyncFrameVar.py
+++ b/lldb/test/API/lang/swift/async/frame/TestSwiftAsyncFrameVar.py
@@ -1,0 +1,38 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestCase(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    @skipIf(oslist=['windows', 'linux'])
+    def test(self):
+        """Test `frame variable` in async functions"""
+        self.build()
+
+	# Setting a breakpoint on "main" results in a breakpoint at the start
+	# of each coroutine "funclet" function.
+        _, process, _, _ = lldbutil.run_to_name_breakpoint(self, 'main')
+
+        while process.state == lldb.eStateStopped:
+            frame = process.GetSelectedThread().frames[0]
+            symbol = frame.symbol.mangled
+            if symbol == "$s1a4MainV4mainyyYFZTQ0_":
+                a = frame.FindVariable("a")
+                self.assertTrue(a.IsValid())
+                # self.assertGreater(a.unsigned, 0)
+                self.assertEqual(a.unsigned, 0)
+            elif symbol == "$s1a4MainV4mainyyYFZTQ1_":
+                a = frame.FindVariable("a")
+                self.assertTrue(a.IsValid())
+                # self.assertGreater(a.unsigned, 0)
+                self.assertEqual(a.unsigned, 0)
+                b = frame.FindVariable("b")
+                self.assertTrue(b.IsValid())
+                # self.assertGreater(b.unsigned, 0)
+                self.assertEqual(a.unsigned, 0)
+
+            process.Continue()

--- a/lldb/test/API/lang/swift/async/frame/TestSwiftAsyncFrameVar.py
+++ b/lldb/test/API/lang/swift/async/frame/TestSwiftAsyncFrameVar.py
@@ -33,6 +33,6 @@ class TestCase(lldbtest.TestBase):
                 b = frame.FindVariable("b")
                 self.assertTrue(b.IsValid())
                 # self.assertGreater(b.unsigned, 0)
-                self.assertEqual(a.unsigned, 0)
+                self.assertEqual(b.unsigned, 0)
 
             process.Continue()

--- a/lldb/test/API/lang/swift/async/frame/TestSwiftAsyncFrameVar.py
+++ b/lldb/test/API/lang/swift/async/frame/TestSwiftAsyncFrameVar.py
@@ -13,26 +13,50 @@ class TestCase(lldbtest.TestBase):
         """Test `frame variable` in async functions"""
         self.build()
 
-        # Setting a breakpoint on "main" results in a breakpoint at the start
+        # Setting a breakpoint on "inner" results in a breakpoint at the start
         # of each coroutine "funclet" function.
-        _, process, _, _ = lldbutil.run_to_name_breakpoint(self, 'main')
+        _, process, _, _ = lldbutil.run_to_name_breakpoint(self, 'inner')
 
+        # The step-over actions in the below commands may not be needed in the
+        # future, but for now they are. This comment describes why. Take the
+        # following line of code:
+        #     let x = await asyncFunc()
+        # Some breakpoints, including the ones in this test, resolve to
+        # locations that are at the start of resume functions. At the start of
+        # the resume function, the assignment may not be complete. In order to
+        # ensure assignment takes place, step-over is used to take execution to
+        # the next line.
+
+        stop_num = 0
         while process.state == lldb.eStateStopped:
-            frame = process.GetSelectedThread().frames[0]
-            symbol = frame.symbol.mangled
-            if symbol == "$s1a4MainV4mainyyYFZTQ0_":
+            thread = process.GetSelectedThread()
+            frame = thread.frames[0]
+            if stop_num == 0:
+                # Start of the function.
+                pass
+            elif stop_num == 1:
+                # After first await, read `a`.
                 a = frame.FindVariable("a")
                 self.assertTrue(a.IsValid())
-                # self.assertGreater(a.unsigned, 0)
                 self.assertEqual(a.unsigned, 0)
-            elif symbol == "$s1a4MainV4mainyyYFZTQ1_":
+                # Step to complete `a`'s assignment (stored in the stack).
+                thread.StepOver()
+                self.assertGreater(a.unsigned, 0)
+            elif stop_num == 2:
+                # After second, read `a` and `b`.
+                # At this point, `a` can be read from the async context.
                 a = frame.FindVariable("a")
                 self.assertTrue(a.IsValid())
-                # self.assertGreater(a.unsigned, 0)
-                self.assertEqual(a.unsigned, 0)
+                self.assertGreater(a.unsigned, 0)
                 b = frame.FindVariable("b")
                 self.assertTrue(b.IsValid())
-                # self.assertGreater(b.unsigned, 0)
                 self.assertEqual(b.unsigned, 0)
+                # Step to complete `b`'s assignment (stored in the stack).
+                thread.StepOver()
+                self.assertGreater(b.unsigned, 0)
+            else:
+                # Unexpected stop.
+                self.assertTrue(False)
 
+            stop_num += 1
             process.Continue()

--- a/lldb/test/API/lang/swift/async/frame/main.swift
+++ b/lldb/test/API/lang/swift/async/frame/main.swift
@@ -1,0 +1,13 @@
+func randInt(_ i: Int) async -> Int {
+  return Int.random(in: 1...i)
+}
+
+func use<T>(_ t: T...) {}
+
+@main struct Main {
+  static func main() async {
+    let a = await randInt(30)
+    let b = await randInt(a + 11)
+    use(a, b)
+  }
+}

--- a/lldb/test/API/lang/swift/async/frame/main.swift
+++ b/lldb/test/API/lang/swift/async/frame/main.swift
@@ -2,12 +2,19 @@ func randInt(_ i: Int) async -> Int {
   return Int.random(in: 1...i)
 }
 
+func inner() async {
+  let a = await randInt(30)
+  let b = await randInt(a + 11)
+  use(a, b)
+}
+
 func use<T>(_ t: T...) {}
 
 @main struct Main {
   static func main() async {
-    let a = await randInt(30)
-    let b = await randInt(a + 11)
-    use(a, b)
+    // This call to `inner` is a indirection required to make this test work.
+    // If its contents were inlined into `main` (as it was originally written),
+    // the test would fail.
+    await inner()
   }
 }


### PR DESCRIPTION
Add an initial test for accessing frame variables in an async function.

By setting a breakpoint on "`inner`", the test stops at each coroutine function ("funclet"). Using a stop counter, the test looks for expected frame variables based on the current stop number.

See the comments for discussion on implementation choices required to make this test work.