### PR TITLE
<rdar://75704162> Kind of weird "completion handler is never used" warnings on initializers that take a completion handler

### DIFF
--- a/clang/lib/Analysis/CalledOnceCheck.cpp
+++ b/clang/lib/Analysis/CalledOnceCheck.cpp
@@ -1011,11 +1011,16 @@ private:
     return llvm::None;
   }
 
+  /// Return true if the specified selector represents init method.
+  static bool isInitMethod(Selector MethodSelector) {
+    return MethodSelector.getMethodFamily() == OMF_init;
+  }
+
   /// Return true if the specified selector piece matches conventions.
   static bool isConventionalSelectorPiece(Selector MethodSelector,
                                           unsigned PieceIndex,
                                           QualType PieceType) {
-    if (!isConventional(PieceType)) {
+    if (!isConventional(PieceType) || isInitMethod(MethodSelector)) {
       return false;
     }
 

--- a/clang/test/SemaObjC/warn-called-once.m
+++ b/clang/test/SemaObjC/warn-called-once.m
@@ -13,6 +13,7 @@
 @protocol NSObject
 @end
 @interface NSObject <NSObject>
+- (instancetype)init;
 - (id)copy;
 - (id)class;
 - autorelease;
@@ -1233,6 +1234,15 @@ static inline void DefferedCallback(DeferredBlock *inBlock) { (*inBlock)(); }
 
   // We still can warn about double call even in this case.
   handler(); // expected-warning{{completion handler is called twice}}
+}
+
+- (void)initWithAdditions:(int)cond
+           withCompletion:(void (^)(void))handler {
+  self = [self init];
+  if (self) {
+    escape(handler);
+  }
+  // no-warning
 }
 
 @end


### PR DESCRIPTION
This pull-request cherry-picks a low risk fix for a new analysis-based warning -Wcompletion-handler.
It removes `init` methods from being recognized as `completionHandler` methods, so this fix can only decrease the number of warnings.

rdar://75704162

Differential Revision: https://reviews.llvm.org/D99601

(cherry picked from commit 77f1e096e8a0a0f37a4c5f8a0bacc7c60f44f0a1)