### PR TITLE
[lldb] Disable tests failing on Amazon Linux 2

### DIFF
--- a/lldb/test/API/lang/swift/completion/TestSwiftREPLCompletion.py
+++ b/lldb/test/API/lang/swift/completion/TestSwiftREPLCompletion.py
@@ -13,6 +13,7 @@ class SwiftCompletionTest(PExpectTest):
     @skipIfAsan
     @skipUnlessDarwin
     @swiftTest
+    @skipIf(bugnumber="rdar://76540680")
     def test_basic_completion(self):
 
         self.launch(extra_args=["--repl"], executable=None, dimensions=(100,500))
@@ -43,6 +44,7 @@ class SwiftCompletionTest(PExpectTest):
     @skipIfAsan
     @skipIf(oslist=['windows'])
     @swiftTest
+    @skipIf(bugnumber="rdar://76540680")
     def test_lldb_command_completion(self):
 
         self.launch(extra_args=["--repl"], executable=None, dimensions=(100,500))

--- a/lldb/test/Shell/Reproducer/Swift/TestModule.test
+++ b/lldb/test/Shell/Reproducer/Swift/TestModule.test
@@ -1,5 +1,6 @@
 # UNSUPPORTED: system-windows, system-freebsd
 # REQUIRES: swift
+# REQUIRES: rdar76540680
 
 # This tests replaying a Swift reproducer with bridging.
 

--- a/lldb/test/Shell/Reproducer/Swift/TestSimple.test
+++ b/lldb/test/Shell/Reproducer/Swift/TestSimple.test
@@ -1,5 +1,6 @@
 # UNSUPPORTED: system-windows, system-freebsd
 # REQUIRES: swift
+# REQUIRES: rdar76540680
 
 # This tests replaying a simple reproducer.
 


### PR DESCRIPTION
Jenkins URL: https://ci.swift.org/job/oss-swift-package-amazon-linux-2/1331

********************
Failed Tests (3):
  lldb-api :: lang/swift/completion/TestSwiftREPLCompletion.py
  lldb-shell :: Reproducer/Swift/TestModule.test
  lldb-shell :: Reproducer/Swift/TestSimple.test

rdar://76540680