### PR TITLE
[lldb] Remove suggestion to run with '-d run-target'

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -680,12 +680,8 @@ static llvm::Optional<llvm::Error> AddVariableInfo(
     // Not realizing self is a fatal error for an expression and the
     // Swift compiler error alone is not particularly useful.
     if (is_self)
-      return make_error<StringError>(
-          inconvertibleErrorCode(),
-          llvm::Twine("Couldn't realize type of self.") +
-              (use_dynamic
-                   ? ""
-                   : " Try evaluating the expression with -d run-target"));
+      return make_error<StringError>(inconvertibleErrorCode(),
+                                     "Couldn't realize type of self.");
     return {};
   }
 


### PR DESCRIPTION
Stop suggesting running with '-d run-target'. This no longer has any
effect, since we now always bind generic types in the expression
evaluator.

rdar://76517425