### PR TITLE
[lldb] Fix 'r' and 'run' aliases on Apple Silicon

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -422,24 +422,20 @@ void CommandInterpreter::Initialize() {
   cmd_obj_sp = GetCommandSPExact("process launch");
   if (cmd_obj_sp) {
     alias_arguments_vector_sp = std::make_shared<OptionArgVector>();
-#if defined(__arm__) || defined(__arm64__) || defined(__aarch64__)
+#if defined(__APPLE__)
+#if defined(TARGET_OS_IPHONE)
     AddAlias("r", cmd_obj_sp, "--");
     AddAlias("run", cmd_obj_sp, "--");
 #else
-#if defined(__APPLE__)
-    std::string shell_option;
-    shell_option.append("--shell-expand-args");
-    shell_option.append(" true");
-    shell_option.append(" --");
     AddAlias("r", cmd_obj_sp, "--shell-expand-args true --");
     AddAlias("run", cmd_obj_sp, "--shell-expand-args true --");
+#endif
 #else
     StreamString defaultshell;
     defaultshell.Printf("--shell=%s --",
                         HostInfo::GetDefaultShell().GetPath().c_str());
     AddAlias("r", cmd_obj_sp, defaultshell.GetString());
     AddAlias("run", cmd_obj_sp, defaultshell.GetString());
-#endif
 #endif
   }
 

--- a/lldb/test/Shell/Host/TestCustomShell.test
+++ b/lldb/test/Shell/Host/TestCustomShell.test
@@ -1,7 +1,5 @@
-# This test applies to POSIX.
-# UNSUPPORTED: system-windows
-
 # FIXME: ShellExpandArguments is unimplemented on the following targets.
+# UNSUPPORTED: system-windows
 # UNSUPPORTED: system-linux
 # XFAIL: system-freebsd
 # XFAIL: system-netbsd


### PR DESCRIPTION
The 'r' and 'run' aliases were different based on the target
architecture. I suspect the intention was to disable shell expansion on
embedded devices. This fixes TestCustomShell.test on AS.

(cherry picked from commit 4d3a061c32ee5c4fb88be389a4dd7fd71fc9fa9c)
