### PR TITLE
[lldb] Factor out common Swift Async Context utilities

### DIFF
--- a/lldb/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/lldb/include/lldb/Target/SwiftLanguageRuntime.h
@@ -132,7 +132,7 @@ public:
   /// Return true if name is a Swift async function symbol.
   static bool IsSwiftAsyncFunctionSymbol(llvm::StringRef name);
 
-  /// Return the async context address using the register specific to the target.
+  /// Return the async context address using the target's specific register.
   static lldb::addr_t GetAsyncContext(RegisterContext *regctx);
 
   static bool

--- a/lldb/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/lldb/include/lldb/Target/SwiftLanguageRuntime.h
@@ -132,6 +132,9 @@ public:
   /// Return true if name is a Swift async function symbol.
   static bool IsSwiftAsyncFunctionSymbol(llvm::StringRef name);
 
+  /// Return the async context address using the register specific to the target.
+  static lldb::addr_t GetAsyncContext(RegisterContext *regctx);
+
   static bool
   IsSwiftAsyncAwaitResumePartialFunctionSymbol(llvm::StringRef name);
 

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -2290,25 +2290,31 @@ void SwiftLanguageRuntime::DidFinishExecutingUserExpression(
 
 bool SwiftLanguageRuntime::IsABIStable() { FORWARD(IsABIStable); }
 
-struct AsyncUnwindRegisters {
+// The target specific register numbers (eh_frame/dwarf) used for async
+// unwinding.
+struct AsyncUnwindRegisterNumbers {
   uint32_t async_ctx_regnum;
   uint32_t fp_regnum;
   uint32_t pc_regnum;
+  // A register to use as a marker to indicate how the async context is passed
+  // to the function (indirectly, or not). This needs to be communicated to the
+  // frames below us as they need to react differently. There is no good way to
+  // expose this, so we set another dummy register to communicate this state.
   uint32_t dummy_regnum;
 };
 
-static llvm::Optional<AsyncUnwindRegisters>
-GetAsyncUnwindRegisters(llvm::Triple::ArchType triple) {
+static llvm::Optional<AsyncUnwindRegisterNumbers>
+GetAsyncUnwindRegisterNumbers(llvm::Triple::ArchType triple) {
   switch (triple) {
   case llvm::Triple::x86_64:
-    return (AsyncUnwindRegisters){
+    return (AsyncUnwindRegisterNumbers){
         .async_ctx_regnum = dwarf_r14_x86_64,
         .fp_regnum = dwarf_rbp_x86_64,
         .pc_regnum = dwarf_rip_x86_64,
         .dummy_regnum = dwarf_r15_x86_64,
     };
   case llvm::Triple::aarch64:
-    return (AsyncUnwindRegisters){
+    return (AsyncUnwindRegisterNumbers){
         .async_ctx_regnum = arm64_dwarf::x22,
         .fp_regnum = arm64_dwarf::fp,
         .pc_regnum = arm64_dwarf::pc,
@@ -2325,9 +2331,9 @@ lldb::addr_t SwiftLanguageRuntime::GetAsyncContext(RegisterContext *regctx) {
     return LLDB_INVALID_ADDRESS;
 
   auto arch = regctx->CalculateTarget()->GetArchitecture();
-  if (auto registers = GetAsyncUnwindRegisters(arch.GetMachine())) {
+  if (auto regnums = GetAsyncUnwindRegisterNumbers(arch.GetMachine())) {
     auto reg = regctx->ConvertRegisterKindToRegisterNumber(
-        RegisterKind::eRegisterKindDWARF, registers->async_ctx_regnum);
+        RegisterKind::eRegisterKindDWARF, regnums->async_ctx_regnum);
     return regctx->ReadRegisterAsUnsigned(reg, LLDB_INVALID_ADDRESS);
   }
 
@@ -2344,8 +2350,9 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
 
   Target &target(process_sp->GetTarget());
   auto arch = target.GetArchitecture();
-  auto registers = GetAsyncUnwindRegisters(arch.GetMachine());
-  if (!registers)
+  llvm::Optional<AsyncUnwindRegisterNumbers> regnums =
+      GetAsyncUnwindRegisterNumbers(arch.GetMachine());
+  if (!regnums)
     return UnwindPlanSP();
 
   // If we can't fetch the fp reg, and we *can* fetch the async
@@ -2437,7 +2444,7 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
   else if (arch.GetMachine() == llvm::Triple::aarch64)
     expr = g_cfa_dwarf_expression_arm64;
   else
-    llvm_unreachable("Unsupported architexture");
+    llvm_unreachable("Unsupported architecture");
 
   row->GetCFAValue().SetIsDWARFExpression(expr, expr_size);
   // The coroutine funclets split from an async function have 2 different ABIs:
@@ -2459,12 +2466,12 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
     // array minus one. This skips the last deref for this use.
     assert(expr[expr_size - 1] == llvm::dwarf::DW_OP_deref &&
            "Should skip a deref");
-    row->SetRegisterLocationToIsDWARFExpression(registers->async_ctx_regnum,
+    row->SetRegisterLocationToIsDWARFExpression(regnums->async_ctx_regnum,
                                                 expr, expr_size - 1, false);
   } else {
     // In the first part of a split async function, the context is passed
     // directly, so we can use the CFA value directly.
-    row->SetRegisterLocationToIsCFAPlusOffset(registers->async_ctx_regnum, 0,
+    row->SetRegisterLocationToIsCFAPlusOffset(regnums->async_ctx_regnum, 0,
                                               false);
     // The fact that we are in this case needs to be communicated to the frames
     // below us as they need to react differently. There is no good way to
@@ -2473,10 +2480,10 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
         llvm::dwarf::DW_OP_const1u, 0
     };
     row->SetRegisterLocationToIsDWARFExpression(
-        registers->dummy_regnum, g_dummy_dwarf_expression,
+        regnums->dummy_regnum, g_dummy_dwarf_expression,
         sizeof(g_dummy_dwarf_expression), false);
   }
-  row->SetRegisterLocationToAtCFAPlusOffset(registers->pc_regnum, ptr_size,
+  row->SetRegisterLocationToAtCFAPlusOffset(regnums->pc_regnum, ptr_size,
                                             false);
 
   row->SetUnspecifiedRegistersAreUndefined(true);
@@ -2501,19 +2508,20 @@ GetFollowAsyncContextUnwindPlan(RegisterContext *regctx, ArchSpec &arch,
   const int32_t ptr_size = 8;
   row->SetOffset(0);
 
-  auto registers = GetAsyncUnwindRegisters(arch.GetMachine());
-  if (!registers)
+  llvm::Optional<AsyncUnwindRegisterNumbers> regnums =
+      GetAsyncUnwindRegisterNumbers(arch.GetMachine());
+  if (!regnums)
     return UnwindPlanSP();
 
   // In the general case, the async register setup by the frame above us
   // should be dereferenced twice to get our context, except when the frame
   // above us is an async frame on the OS stack that takes its context directly
   // (see discussion in GetRuntimeUnwindPlan()). The availability of
-  // dummy_regnum is used as a marked for this situation.
-  if (regctx->ReadRegisterAsUnsigned(registers->dummy_regnum, (uint64_t)-1ll) !=
+  // dummy_regnum is used as a marker for this situation.
+  if (regctx->ReadRegisterAsUnsigned(regnums->dummy_regnum, (uint64_t)-1ll) !=
       (uint64_t)-1ll) {
-    row->GetCFAValue().SetIsRegisterDereferenced(registers->async_ctx_regnum);
-    row->SetRegisterLocationToSame(registers->async_ctx_regnum, false);
+    row->GetCFAValue().SetIsRegisterDereferenced(regnums->async_ctx_regnum);
+    row->SetRegisterLocationToSame(regnums->async_ctx_regnum, false);
   } else {
     static const uint8_t async_dwarf_expression_x86_64[] = {
         llvm::dwarf::DW_OP_regx, dwarf_r14_x86_64, // DW_OP_regx, reg
@@ -2545,10 +2553,10 @@ GetFollowAsyncContextUnwindPlan(RegisterContext *regctx, ArchSpec &arch,
            "Should skip a deref");
     row->GetCFAValue().SetIsDWARFExpression(expression, expr_size);
     row->SetRegisterLocationToIsDWARFExpression(
-        registers->async_ctx_regnum, expression, expr_size - 1, false);
+        regnums->async_ctx_regnum, expression, expr_size - 1, false);
   }
 
-  row->SetRegisterLocationToAtCFAPlusOffset(registers->pc_regnum, ptr_size,
+  row->SetRegisterLocationToAtCFAPlusOffset(regnums->pc_regnum, ptr_size,
                                             false);
 
   row->SetUnspecifiedRegistersAreUndefined(true);

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -2290,18 +2290,21 @@ void SwiftLanguageRuntime::DidFinishExecutingUserExpression(
 
 bool SwiftLanguageRuntime::IsABIStable() { FORWARD(IsABIStable); }
 
-// The target specific register numbers (eh_frame/dwarf) used for async
-// unwinding.
+namespace {
+/// The target specific register numbers used for async unwinding.
+///
+/// For UnwindPlans, these use eh_frame / dwarf register numbering.
 struct AsyncUnwindRegisterNumbers {
   uint32_t async_ctx_regnum;
   uint32_t fp_regnum;
   uint32_t pc_regnum;
-  // A register to use as a marker to indicate how the async context is passed
-  // to the function (indirectly, or not). This needs to be communicated to the
-  // frames below us as they need to react differently. There is no good way to
-  // expose this, so we set another dummy register to communicate this state.
+  /// A register to use as a marker to indicate how the async context is passed
+  /// to the function (indirectly, or not). This needs to be communicated to the
+  /// frames below us as they need to react differently. There is no good way to
+  /// expose this, so we set another dummy register to communicate this state.
   uint32_t dummy_regnum;
 };
+} // namespace
 
 static llvm::Optional<AsyncUnwindRegisterNumbers>
 GetAsyncUnwindRegisterNumbers(llvm::Triple::ArchType triple) {

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -2324,7 +2324,6 @@ GetAsyncUnwindRegisterNumbers(llvm::Triple::ArchType triple) {
         .dummy_regnum = arm64_dwarf::x23,
     };
   default:
-    assert(false && "swift async supports only x86_64 and arm64");
     return {};
   }
 }
@@ -2340,6 +2339,7 @@ lldb::addr_t SwiftLanguageRuntime::GetAsyncContext(RegisterContext *regctx) {
     return regctx->ReadRegisterAsUnsigned(reg, LLDB_INVALID_ADDRESS);
   }
 
+  assert(false && "swift async supports only x86_64 and arm64");
   return LLDB_INVALID_ADDRESS;
 }
 

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -2469,8 +2469,8 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
     // array minus one. This skips the last deref for this use.
     assert(expr[expr_size - 1] == llvm::dwarf::DW_OP_deref &&
            "Should skip a deref");
-    row->SetRegisterLocationToIsDWARFExpression(regnums->async_ctx_regnum,
-                                                expr, expr_size - 1, false);
+    row->SetRegisterLocationToIsDWARFExpression(regnums->async_ctx_regnum, expr,
+                                                expr_size - 1, false);
   } else {
     // In the first part of a split async function, the context is passed
     // directly, so we can use the CFA value directly.

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -2309,20 +2309,22 @@ struct AsyncUnwindRegisterNumbers {
 static llvm::Optional<AsyncUnwindRegisterNumbers>
 GetAsyncUnwindRegisterNumbers(llvm::Triple::ArchType triple) {
   switch (triple) {
-  case llvm::Triple::x86_64:
-    return (AsyncUnwindRegisterNumbers){
-        .async_ctx_regnum = dwarf_r14_x86_64,
-        .fp_regnum = dwarf_rbp_x86_64,
-        .pc_regnum = dwarf_rip_x86_64,
-        .dummy_regnum = dwarf_r15_x86_64,
-    };
-  case llvm::Triple::aarch64:
-    return (AsyncUnwindRegisterNumbers){
-        .async_ctx_regnum = arm64_dwarf::x22,
-        .fp_regnum = arm64_dwarf::fp,
-        .pc_regnum = arm64_dwarf::pc,
-        .dummy_regnum = arm64_dwarf::x23,
-    };
+  case llvm::Triple::x86_64: {
+    AsyncUnwindRegisterNumbers regnums;
+    regnums.async_ctx_regnum = dwarf_r14_x86_64;
+    regnums.fp_regnum = dwarf_rbp_x86_64;
+    regnums.pc_regnum = dwarf_rip_x86_64;
+    regnums.dummy_regnum = dwarf_r15_x86_64;
+    return regnums;
+  }
+  case llvm::Triple::aarch64: {
+    AsyncUnwindRegisterNumbers regnums;
+    regnums.async_ctx_regnum = arm64_dwarf::x22;
+    regnums.fp_regnum = arm64_dwarf::fp;
+    regnums.pc_regnum = arm64_dwarf::pc;
+    regnums.dummy_regnum = arm64_dwarf::x23;
+    return regnums;
+  }
   default:
     return {};
   }

--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -2290,6 +2290,50 @@ void SwiftLanguageRuntime::DidFinishExecutingUserExpression(
 
 bool SwiftLanguageRuntime::IsABIStable() { FORWARD(IsABIStable); }
 
+struct AsyncUnwindRegisters {
+  uint32_t async_ctx_regnum;
+  uint32_t fp_regnum;
+  uint32_t pc_regnum;
+  uint32_t dummy_regnum;
+};
+
+static llvm::Optional<AsyncUnwindRegisters>
+GetAsyncUnwindRegisters(llvm::Triple::ArchType triple) {
+  switch (triple) {
+  case llvm::Triple::x86_64:
+    return (AsyncUnwindRegisters){
+        .async_ctx_regnum = dwarf_r14_x86_64,
+        .fp_regnum = dwarf_rbp_x86_64,
+        .pc_regnum = dwarf_rip_x86_64,
+        .dummy_regnum = dwarf_r15_x86_64,
+    };
+  case llvm::Triple::aarch64:
+    return (AsyncUnwindRegisters){
+        .async_ctx_regnum = arm64_dwarf::x22,
+        .fp_regnum = arm64_dwarf::fp,
+        .pc_regnum = arm64_dwarf::pc,
+        .dummy_regnum = arm64_dwarf::x23,
+    };
+  default:
+    assert(false && "swift async supports only x86_64 and arm64");
+    return {};
+  }
+}
+
+lldb::addr_t SwiftLanguageRuntime::GetAsyncContext(RegisterContext *regctx) {
+  if (!regctx)
+    return LLDB_INVALID_ADDRESS;
+
+  auto arch = regctx->CalculateTarget()->GetArchitecture();
+  if (auto registers = GetAsyncUnwindRegisters(arch.GetMachine())) {
+    auto reg = regctx->ConvertRegisterKindToRegisterNumber(
+        RegisterKind::eRegisterKindDWARF, registers->async_ctx_regnum);
+    return regctx->ReadRegisterAsUnsigned(reg, LLDB_INVALID_ADDRESS);
+  }
+
+  return LLDB_INVALID_ADDRESS;
+}
+
 // Examine the register state and detect the transition from a real
 // stack frame to an AsyncContext frame, or a frame in the middle of
 // the AsyncContext chain, and return an UnwindPlan for these situations.
@@ -2299,43 +2343,19 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
                                            bool &behaves_like_zeroth_frame) {
 
   Target &target(process_sp->GetTarget());
-  ArchSpec arch = target.GetArchitecture();
-  uint32_t async_context_regnum;
-  uint32_t fp_regnum;
-  uint32_t pc_regnum;
-  uint32_t dummy_regnum;
-
-  if (arch.GetMachine() == llvm::Triple::x86_64) {
-    async_context_regnum = dwarf_r14_x86_64;
-    fp_regnum = dwarf_rbp_x86_64;
-    pc_regnum = dwarf_rip_x86_64;
-    dummy_regnum = dwarf_r15_x86_64;
-  } else if (arch.GetMachine() == llvm::Triple::aarch64) {
-    async_context_regnum = arm64_dwarf::x22;
-    fp_regnum = arm64_dwarf::fp;
-    pc_regnum = arm64_dwarf::pc;
-    dummy_regnum = arm64_dwarf::x23;
-  } else {
+  auto arch = target.GetArchitecture();
+  auto registers = GetAsyncUnwindRegisters(arch.GetMachine());
+  if (!registers)
     return UnwindPlanSP();
-  }
 
   // If we can't fetch the fp reg, and we *can* fetch the async
   // context register, then we're in the middle of the AsyncContext
   // chain, return an UnwindPlan for that.
   addr_t fp = regctx->GetFP(LLDB_INVALID_ADDRESS);
   if (fp == LLDB_INVALID_ADDRESS) {
-    const RegisterInfo *reg_info =
-        regctx->GetRegisterInfo(eRegisterKindDWARF, async_context_regnum);
-    if (reg_info) {
-      RegisterValue val;
-      if (regctx->ReadRegister(reg_info, val)) {
-        addr_t async_context_addr = val.GetAsUInt64(LLDB_INVALID_ADDRESS);
-        if (async_context_addr != LLDB_INVALID_ADDRESS) {
-          return GetFollowAsyncContextUnwindPlan(regctx, arch,
-                                                 behaves_like_zeroth_frame);
-        }
-      }
-    }
+    if (GetAsyncContext(regctx) != LLDB_INVALID_ADDRESS)
+      return GetFollowAsyncContextUnwindPlan(regctx, arch,
+                                             behaves_like_zeroth_frame);
     return UnwindPlanSP();
   }
 
@@ -2426,7 +2446,7 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
   //  - Async await resume partial functions take their context indirectly, it
   //    needs to be dereferenced to get the actual function's context.
   // The debug info for locals reflects this difference, so our unwinding of the
-  // context reister needs to reflect it too.
+  // context register needs to reflect it too.
   bool indirect_context = IsSwiftAsyncAwaitResumePartialFunctionSymbol(
       sc.symbol->GetMangled().GetMangledName().GetStringRef());
 
@@ -2439,24 +2459,25 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
     // array minus one. This skips the last deref for this use.
     assert(expr[expr_size - 1] == llvm::dwarf::DW_OP_deref &&
            "Should skip a deref");
-    row->SetRegisterLocationToIsDWARFExpression(async_context_regnum, expr,
-                                                expr_size - 1, false);
+    row->SetRegisterLocationToIsDWARFExpression(registers->async_ctx_regnum,
+                                                expr, expr_size - 1, false);
   } else {
     // In the first part of a split async function, the context is passed
     // directly, so we can use the CFA value directly.
-    row->SetRegisterLocationToIsCFAPlusOffset(async_context_regnum, 0, false);
+    row->SetRegisterLocationToIsCFAPlusOffset(registers->async_ctx_regnum, 0,
+                                              false);
     // The fact that we are in this case needs to be communicated to the frames
     // below us as they need to react differently. There is no good way to
     // expose this, so we set another dummy register to communicate this state.
     static const uint8_t g_dummy_dwarf_expression[] = {
         llvm::dwarf::DW_OP_const1u, 0
     };
-    row->SetRegisterLocationToIsDWARFExpression(dummy_regnum,
-                                                g_dummy_dwarf_expression,
-                                                sizeof(g_dummy_dwarf_expression),
-                                                false);
+    row->SetRegisterLocationToIsDWARFExpression(
+        registers->dummy_regnum, g_dummy_dwarf_expression,
+        sizeof(g_dummy_dwarf_expression), false);
   }
-  row->SetRegisterLocationToAtCFAPlusOffset(pc_regnum, ptr_size, false);
+  row->SetRegisterLocationToAtCFAPlusOffset(registers->pc_regnum, ptr_size,
+                                            false);
 
   row->SetUnspecifiedRegistersAreUndefined(true);
 
@@ -2480,34 +2501,19 @@ GetFollowAsyncContextUnwindPlan(RegisterContext *regctx, ArchSpec &arch,
   const int32_t ptr_size = 8;
   row->SetOffset(0);
 
-  uint32_t async_context_regnum;
-  uint32_t fp_regnum;
-  uint32_t pc_regnum;
-  uint32_t dummy_regnum;
-
-  if (arch.GetMachine() == llvm::Triple::x86_64) {
-    async_context_regnum = dwarf_r14_x86_64;
-    fp_regnum = dwarf_rbp_x86_64;
-    pc_regnum = dwarf_rip_x86_64;
-    dummy_regnum = dwarf_r15_x86_64;
-  } else if (arch.GetMachine() == llvm::Triple::aarch64) {
-    async_context_regnum = arm64_dwarf::x22;
-    fp_regnum = arm64_dwarf::fp;
-    pc_regnum = arm64_dwarf::pc;
-    dummy_regnum = arm64_dwarf::x23;
-  } else {
+  auto registers = GetAsyncUnwindRegisters(arch.GetMachine());
+  if (!registers)
     return UnwindPlanSP();
-  }
 
   // In the general case, the async register setup by the frame above us
   // should be dereferenced twice to get our context, except when the frame
   // above us is an async frame on the OS stack that takes its context directly
   // (see discussion in GetRuntimeUnwindPlan()). The availability of
   // dummy_regnum is used as a marked for this situation.
-  if (regctx->ReadRegisterAsUnsigned(dummy_regnum, (uint64_t)-1ll) !=
+  if (regctx->ReadRegisterAsUnsigned(registers->dummy_regnum, (uint64_t)-1ll) !=
       (uint64_t)-1ll) {
-    row->GetCFAValue().SetIsRegisterDereferenced(async_context_regnum);
-    row->SetRegisterLocationToSame(async_context_regnum, false);
+    row->GetCFAValue().SetIsRegisterDereferenced(registers->async_ctx_regnum);
+    row->SetRegisterLocationToSame(registers->async_ctx_regnum, false);
   } else {
     static const uint8_t async_dwarf_expression_x86_64[] = {
         llvm::dwarf::DW_OP_regx, dwarf_r14_x86_64, // DW_OP_regx, reg
@@ -2539,10 +2545,11 @@ GetFollowAsyncContextUnwindPlan(RegisterContext *regctx, ArchSpec &arch,
            "Should skip a deref");
     row->GetCFAValue().SetIsDWARFExpression(expression, expr_size);
     row->SetRegisterLocationToIsDWARFExpression(
-        async_context_regnum, expression, expr_size - 1, false);
+        registers->async_ctx_regnum, expression, expr_size - 1, false);
   }
 
-  row->SetRegisterLocationToAtCFAPlusOffset(pc_regnum, ptr_size, false);
+  row->SetRegisterLocationToAtCFAPlusOffset(registers->pc_regnum, ptr_size,
+                                            false);
 
   row->SetUnspecifiedRegistersAreUndefined(true);
 

--- a/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
@@ -383,21 +383,7 @@ private:
 
   static lldb::addr_t GetAsyncContext(lldb::StackFrameSP frame_sp) {
     auto reg_ctx_sp = frame_sp->GetRegisterContext();
-
-    int async_ctx_regnum = 0;
-    auto arch = reg_ctx_sp->CalculateTarget()->GetArchitecture();
-    if (arch.GetMachine() == llvm::Triple::x86_64) {
-      async_ctx_regnum = dwarf_r14_x86_64;
-    } else if (arch.GetMachine() == llvm::Triple::aarch64) {
-      async_ctx_regnum = arm64_dwarf::x22;
-    } else {
-      assert(false && "swift async supports only x86_64 and arm64");
-      return 0;
-    }
-
-    auto async_ctx_reg = reg_ctx_sp->ConvertRegisterKindToRegisterNumber(
-        RegisterKind::eRegisterKindDWARF, async_ctx_regnum);
-    return reg_ctx_sp->ReadRegisterAsUnsigned(async_ctx_reg, 0);
+    return SwiftLanguageRuntime::GetAsyncContext(reg_ctx_sp.get());
   }
 
   ThreadPlanSP m_step_in_plan_sp;


### PR DESCRIPTION
(cherry picked from https://github.com/apple/llvm-project/pull/2789, https://github.com/apple/llvm-project/pull/2802, and https://github.com/apple/llvm-project/pull/2807)