### PR TITLE
[clang][FileManager] Support empty file name in getVirtualFileRef for…

### DIFF
--- a/clang/lib/Basic/FileManager.cpp
+++ b/clang/lib/Basic/FileManager.cpp
@@ -384,9 +384,12 @@ FileEntryRef FileManager::getVirtualFileRef(StringRef Filename, off_t Size,
 
   // Now that all ancestors of Filename are in the cache, the
   // following call is guaranteed to find the DirectoryEntry from the
-  // cache.
-  auto DirInfo = expectedToOptional(
-      getDirectoryFromFile(*this, Filename, /*CacheFailure=*/true));
+  // cache. A virtual file can also have an empty filename, that could come
+  // from a source location preprocessor directive with an empty filename as
+  // an example, so we need to pretend it has a name to ensure a valid directory
+  // entry can be returned.
+  auto DirInfo = expectedToOptional(getDirectoryFromFile(
+      *this, Filename.empty() ? "." : Filename, /*CacheFailure=*/true));
   assert(DirInfo &&
          "The directory of a virtual file should already be in the cache.");
 

--- a/clang/test/Misc/serialized-diags-empty-filename.c
+++ b/clang/test/Misc/serialized-diags-empty-filename.c
@@ -1,0 +1,8 @@
+// RUN: rm -f %t.diag
+// RUN: not %clang -c %s --serialize-diagnostics %t.diag
+// RUN: c-index-test -read-diagnostics %t.diag 2>&1 | FileCheck %s
+
+# 1 "" 1
+void 1();
+
+// CHECK: :1:6: error:


### PR DESCRIPTION
… serialized diagnostics

After https://reviews.llvm.org/D90484 libclang is unable to read a serialized diagnostic file
which contains a diagnostic which came from a file with an empty filename. The reason being is
that the serialized diagnostic reader is creating a virtual file for the "" filename, which now
fails after the changes in https://reviews.llvm.org/D90484. This patch restores the previous
behavior in getVirtualFileRef by allowing it to construct a file entry ref with an empty name by
pretending its name is "." so that the directory entry can be created.

Differential Revision: https://reviews.llvm.org/D100428

(cherry picked from commit c1554f32e3b3fafab64698fdb5b806b1bda4aa8a)