### PR TITLE
Mark armv6m compat with armv7em; match armv7em being compat with armv6m

### DIFF
--- a/lldb/source/Utility/ArchSpec.cpp
+++ b/lldb/source/Utility/ArchSpec.cpp
@@ -1113,11 +1113,13 @@ static bool cores_match(const ArchSpec::Core core1, const ArchSpec::Core core2,
     if (!enforce_exact_match) {
       if (core2 == ArchSpec::eCore_arm_generic)
         return true;
-      try_inverse = false;
+      if (core2 == ArchSpec::eCore_arm_armv7em)
+        return true;
       if (core2 == ArchSpec::eCore_arm_armv7)
         return true;
       if (core2 == ArchSpec::eCore_arm_armv6m)
         return true;
+      try_inverse = false;
     }
     break;
 


### PR DESCRIPTION
Mark armv6m compat with armv7em; match armv7em being compat with armv6m

armv7em and armv6m in ArchSpec cores_match() will return true.
There was a small bug where the reverse order would not return true.

rdar://76387176
(cherry picked from commit 01ad95ff2a7cc127eddf3832693bbd5c6c54f9ef)