### PR TITLE
[lldb] Disable TestSwiftReferenceStorageTypes.py on Linux

### DIFF
--- a/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
+++ b/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
@@ -29,6 +29,7 @@ class TestSwiftReferenceStorageTypes(TestBase):
 
     @decorators.skipIf(archs=['ppc64le']) #SR-10215
     @swiftTest
+    @skipIf(oslist=["linux"], bugnumber="rdar://76592966")
     def test_swift_reference_storage_types(self):
         """Test weak, unowned and unmanaged types"""
         self.build()


### PR DESCRIPTION
This is failing on Ubuntu 16.04 and Ubuntu 18.04.

https://ci.swift.org/view/LLDB/job/oss-lldb-incremental-linux-ubuntu-16_04/
https://ci.swift.org/view/LLDB/job/oss-lldb-incremental-linux-ubuntu-18_04/

rdar://76592966