### PR TITLE
[ASTReader] Only mark module out of date if not already compiled

### DIFF
--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -2744,9 +2744,10 @@ ASTReader::ReadControlBlock(ModuleFile &F,
 
       bool hasErrors = Record[6];
       if (hasErrors && !DisableValidation) {
-        // If requested by the caller, mark modules on error as out-of-date.
-        if (F.Kind == MK_ImplicitModule &&
-            (ClientLoadCapabilities & ARR_TreatModuleWithErrorsAsOutOfDate))
+        // If requested by the caller and the module hasn't already been read
+        // or compiled, mark modules on error as out-of-date.
+        if ((ClientLoadCapabilities & ARR_TreatModuleWithErrorsAsOutOfDate) &&
+            !ModuleMgr.getModuleCache().isPCMFinal(F.FileName))
           return OutOfDate;
 
         if (!AllowASTWithCompilerErrors) {

--- a/clang/test/Modules/Inputs/error/error.h
+++ b/clang/test/Modules/Inputs/error/error.h
@@ -1,3 +1,5 @@
+#pragma mark mark
+
 @import undefined;
 
 @interface Error

--- a/clang/test/Modules/Inputs/error/module.modulemap
+++ b/clang/test/Modules/Inputs/error/module.modulemap
@@ -1,3 +1,13 @@
 module error {
   header "error.h"
 }
+
+module use_error_a {
+  header "use_error_a.h"
+  export error
+}
+
+module use_error_b {
+  header "use_error_b.h"
+  export error
+}

--- a/clang/test/Modules/Inputs/error/use_error_a.h
+++ b/clang/test/Modules/Inputs/error/use_error_a.h
@@ -1,0 +1,3 @@
+@import error;
+
+void funca(Error *a);

--- a/clang/test/Modules/Inputs/error/use_error_b.h
+++ b/clang/test/Modules/Inputs/error/use_error_b.h
@@ -1,0 +1,3 @@
+@import error;
+
+void funcb(Error *b);


### PR DESCRIPTION
If a module contains errors (ie. it was built with
-fallow-pcm-with-compiler-errors and had errors) and was from the module
cache, it is marked as out of date - see
a2c1054c303f20be006e9ef20739dbb88bd9ae02.

When a module is imported multiple times in the one compile, this caused
it to be recompiled each time - removing the existing buffer from the
module cache and replacing it. This results in various errors further
down the line.

Instead, only mark the module as out of date if it isn't already
finalized in the module cache.

Reviewed By: akyrtzi

Differential Revision: https://reviews.llvm.org/D100619