### PR TITLE
X86: enable proper frame lowering for swift async on Win64

### DIFF
--- a/llvm/test/CodeGen/X86/swift-async-win64.ll
+++ b/llvm/test/CodeGen/X86/swift-async-win64.ll
@@ -1,0 +1,110 @@
+; RUN: llc -mtriple=x86_64-unknown-windows-msvc %s -o - | FileCheck %s
+; RUN: llc -mtriple=i686-windows-msvc %s -o - | FileCheck %s --check-prefix=CHECK-32
+
+define void @simple(i8* swiftasync %ctx) "frame-pointer"="all" {
+; CHECK-LABEL: simple:
+; CHECK: btsq    $60, %rbp
+; CHECK: pushq   %rbp
+; CHECK: pushq   %r14
+; CHECK: leaq    8(%rsp), %rbp
+
+; [...]
+
+; CHECK: addq    $16, %rsp
+; CHECK: popq    %rbp
+; CHECK: btrq    $60, %rbp
+; CHECK: retq
+
+; CHECK-32-LABEL: simple:
+; CHECK-32: movl 8(%ebp), [[TMP:%.*]]
+; CHECK-32: movl [[TMP]], {{.*}}(%ebp)
+
+  ret void
+}
+
+define void @more_csrs(i8* swiftasync %ctx) "frame-pointer"="all" {
+; CHECK-LABEL: more_csrs:
+; CHECK: btsq    $60, %rbp
+; CHECK: pushq   %rbp
+; CHECK: .seh_pushreg %rbp
+; CHECK: pushq   %r14
+; CHECK: .seh_pushreg %r14
+; CHECK: leaq    8(%rsp), %rbp
+; CHECK: subq    $8, %rsp
+; CHECK: pushq   %r15
+; CHECK: .seh_pushreg %r15
+
+; [...]
+
+; CHECK: popq    %r15
+; CHECK: addq    $16, %rsp
+; CHECK: popq    %rbp
+; CHECK: btrq    $60, %rbp
+; CHECK: retq
+  call void asm sideeffect "", "~{r15}"()
+  ret void
+}
+
+define void @locals(i8* swiftasync %ctx) "frame-pointer"="all" {
+; CHECK-LABEL: locals:
+; CHECK: btsq    $60, %rbp
+; CHECK: pushq   %rbp
+; CHECK: .seh_pushreg %rbp
+; CHECK: pushq   %r14
+; CHECK: .seh_pushreg %r14
+; CHECK: leaq    8(%rsp), %rbp
+; CHECK: subq    $88, %rsp
+
+; CHECK: leaq    -48(%rbp), %rcx
+; CHECK: callq   bar
+
+; CHECK: addq    $80, %rsp
+; CHECK: addq    $16, %rsp
+; CHECK: popq    %rbp
+; CHECK: btrq    $60, %rbp
+; CHECK: retq
+
+  %var = alloca i32, i32 10
+  call void @bar(i32* %var)
+  ret void
+}
+
+define void @use_input_context(i8* swiftasync %ctx, i8** %ptr) "frame-pointer"="all" {
+; CHECK-LABEL: use_input_context:
+; CHECK: movq    %r14, (%rcx)
+
+  store i8* %ctx, i8** %ptr
+  ret void
+}
+
+define i8** @context_in_func() "frame-pointer"="non-leaf" {
+; CHECK-LABEL: context_in_func:
+; CHECK: leaq    -8(%rbp), %rax
+
+; CHECK-32-LABEL: context_in_func
+; CHECK-32: movl %esp, %eax
+
+  %ptr = call i8** @llvm.swift.async.context.addr()
+  ret i8** %ptr
+}
+
+define void @write_frame_context(i8* swiftasync %ctx, i8* %newctx) "frame-pointer"="non-leaf" {
+; CHECK-LABEL: write_frame_context:
+; CHECK: movq    %rbp, [[TMP:%.*]]
+; CHECK: subq    $8, [[TMP]]
+; CHECK: movq    %rcx, ([[TMP]])
+
+  %ptr = call i8** @llvm.swift.async.context.addr()
+  store i8* %newctx, i8** %ptr
+  ret void
+}
+
+define void @simple_fp_elim(i8* swiftasync %ctx) "frame-pointer"="non-leaf" {
+; CHECK-LABEL: simple_fp_elim:
+; CHECK-NOT: btsq
+
+  ret void
+}
+
+declare void @bar(i32*)
+declare i8** @llvm.swift.async.context.addr()

--- a/llvm/test/CodeGen/X86/swifttail-async-win64.ll
+++ b/llvm/test/CodeGen/X86/swifttail-async-win64.ll
@@ -1,0 +1,46 @@
+; RUN: llc -mtriple x86_64-unknown-windows-msvc %s -o - | FileCheck %s
+
+
+declare swifttailcc void @swifttail_callee()
+define swifttailcc void @swifttail() {
+; CHECK-LABEL: swifttail:
+; CHECK-NOT: popq %r14
+  call void asm "","~{r14}"()
+  tail call swifttailcc void @swifttail_callee()
+  ret void
+}
+
+define void @has_swiftasync(i8* swiftasync %in) {
+; CHECK-LABEL: has_swiftasync:
+; CHECK: popq %r14
+  call void asm "","~{r14}"()
+  ret void
+}
+
+; It's impossible to get a tail call from a function without a swiftasync
+; parameter to one with unless the CC is swifttailcc. So it doesn't matter
+; whether r14 is callee-saved in this case.
+define void @calls_swiftasync() {
+; CHECK-LABEL: calls_swiftasync:
+; CHECK-NOT: jmpq _has_swiftasync
+  call void asm "","~{r14}"()
+  tail call void @has_swiftasync(i8* swiftasync null)
+  ret void
+}
+
+define swifttailcc void @no_preserve_swiftself() {
+; CHECK-LABEL: no_preserve_swiftself:
+; CHECK-NOT: popq %r13
+  call void asm "","~{r13}"()
+  ret void
+}
+
+declare swifttailcc i8* @SwiftSelf(i8 * swiftasync %context, i8* swiftself %closure)
+define swiftcc i8* @CallSwiftSelf(i8* swiftself %closure, i8* %context) {
+; CHECK-LABEL: CallSwiftSelf:
+; CHECK: pushq %r13
+  ;call void asm "","~{r13}"() ; We get a push r13 but why not with the call
+  ; below?
+  %res = call swifttailcc i8* @SwiftSelf(i8 * swiftasync %context, i8* swiftself %closure)
+  ret i8* %res
+}


### PR DESCRIPTION
The Swift asynchronous calling convention requires some additional setup
on the frame.  In particular, the swift async register needs to be
spilled relative to the frame pointer, which we now accommodate.  This
may require some further refinement due to frame setup restrictions on
Windows, but this initial approach should be sufficient to move towards
a working asynchronous support.