### PR TITLE
[lldb] Support "absolute memory address" images in crashlog.py

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -452,9 +452,9 @@ class JSONCrashLogParser:
             img_uuid = uuid.UUID(json_image['uuid'])
             low = int(json_image['base'])
             high = int(0)
-            name = json_image['name']
-            path = json_image['path']
-            version = ""
+            name = json_image['name'] if 'name' in json_image else ''
+            path = json_image['path'] if 'path' in json_image else ''
+            version = ''
             darwin_image = self.crashlog.DarwinImage(low, high, name, version,
                                                      img_uuid, path,
                                                      self.verbose)


### PR DESCRIPTION
The binary image list contains the following entry when a frame is not
found in any know binary image:

  {
    "size" : 0,
    "source" : "A",
    "base" : 0,
    "uuid" : "00000000-0000-0000-0000-000000000000"
  }

Note that this object is missing the name and path keys. This patch
makes the JSON parser resilient against their absence.

(cherry picked from commit 2cbd3b04feaaaff7fab4c6500476839a23180886)
