### PR TITLE
[lldb] Exclude "resume partial" prefix from demangled display name

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeNames.cpp
@@ -655,6 +655,7 @@ SwiftLanguageRuntime::DemangleSymbolAsString(StringRef symbol, DemangleMode mode
   switch (mode) {
   case eSimplified:
     options = swift::Demangle::DemangleOptions::SimplifiedUIDemangleOptions();
+    options.ShowAsyncResumePartial = false;
     break;
   case eTypeName:
     options.DisplayModuleNames = true;

--- a/lldb/test/API/lang/swift/async/stepping/step-in/TestSwiftStepInAsync.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/TestSwiftStepInAsync.py
@@ -32,10 +32,10 @@ class TestCase(lldbtest.TestBase):
                 # Run until the next `await` breakpoint.
                 process.Continue()
             elif stop_reason == lldb.eStopReasonBreakpoint:
-                caller_before = thread().frames[0].function.name
+                caller_before = thread().frames[0].function.GetDisplayName()
                 line_before = thread().frames[0].line_entry.line
                 thread().StepInto()
-                caller_after = thread().frames[1].function.name
+                caller_after = thread().frames[1].function.GetDisplayName()
                 line_after = thread().frames[0].line_entry.line
 
 		# Breakpoints on lines with an `await` may result in more than
@@ -54,10 +54,7 @@ class TestCase(lldbtest.TestBase):
                         process.Continue()
                     continue
 
-                # The entry function is missing this prefix dedicating resume functions.
-                prefix = re.compile(r'^\([0-9]+\) (await|suspend) resume partial function for ')
-                self.assertEqual(prefix.sub('', caller_after),
-                                 prefix.sub('', caller_before))
+                self.assertEqual(caller_after, caller_before)
                 num_async_steps += 1
 
         self.assertGreater(num_async_steps, 0)


### PR DESCRIPTION
When generating a display name for async resume partial functions, use the top-level function name. This primary purpose of this change is to display frames in backtraces using the function names found in source code. This will match developer expectations.

For demonstration, instead of a backtrace like this:

```
asyncHelper() at main.swift:2
(1) await resume partial function for static Main.main() at main.swift:13
```

with this change the backtrace will be:

```
asyncHelper() at main.swift:2
static Main.main() at main.swift:13
```

Depends on https://github.com/apple/swift/pull/36978