### PR TITLE
Make sure PHIElimination doesn't copy debug locations across basic bl… 

### DIFF
--- a/llvm/lib/CodeGen/PHIElimination.cpp
+++ b/llvm/lib/CodeGen/PHIElimination.cpp
@@ -476,9 +476,10 @@ void PHIElimination::LowerPHINode(MachineBasicBlock &MBB,
           if (DefMI->isImplicitDef())
             ImpDefs.insert(DefMI);
       } else {
-        NewSrcInstr =
-            TII->createPHISourceCopy(opBlock, InsertPos, MPhi->getDebugLoc(),
-                                     SrcReg, SrcSubReg, IncomingReg);
+        // Delete the debug location, since the copy is inserted into a
+        // different basic block.
+        NewSrcInstr = TII->createPHISourceCopy(opBlock, InsertPos, nullptr,
+                                               SrcReg, SrcSubReg, IncomingReg);
       }
     }
 

--- a/llvm/test/CodeGen/AArch64/PHIElimination-debugloc.mir
+++ b/llvm/test/CodeGen/AArch64/PHIElimination-debugloc.mir
@@ -1,0 +1,41 @@
+# RUN: llc -mtriple=aarch64-linux-gnu -verify-machineinstrs -o - %s \
+# RUN:   -run-pass=livevars,phi-node-elimination,twoaddressinstruction \
+# RUN:   -no-phi-elim-live-out-early-exit=1 -phi-elim-split-all-critical-edges=1 \
+# RUN: | FileCheck %s
+
+--- |
+  define void @test() !dbg !7 {
+  entry:
+    ret void, !dbg !14
+  }
+  !llvm.dbg.cu = !{!0}
+  !llvm.module.flags = !{!3, !4}
+
+  !0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "Adrian", emissionKind: FullDebug)
+  !1 = !DIFile(filename: "/tmp/t.c", directory: "/")
+  !2 = !{}
+  !3 = !{i32 2, !"Dwarf Version", i32 2}
+  !4 = !{i32 2, !"Debug Info Version", i32 4}
+  !5 = !{i32 1, !"PIC Level", i32 2}
+  !7 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 1, type: !8, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: true, unit: !0)
+  !8 = !DISubroutineType(types: !{})
+  !14 = !DILocation(line: 1, column: 0, scope: !7)
+
+---
+name: test
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $nzcv, $wzr
+    Bcc 8, %bb.2, implicit $nzcv
+
+  ; CHECK-LABEL: bb.1:
+  bb.1:
+    %x:gpr32 = COPY $wzr
+  ; Test that the debug location is not copied into bb1!
+  ; CHECK: %3:gpr32 = COPY killed %x{{$}}
+  ; CHECK-LABEL: bb.2:
+  bb.2:
+    %y:gpr32 = PHI %x:gpr32, %bb.1, undef %undef:gpr32, %bb.0, debug-location !14
+    $wzr = COPY %y:gpr32
+...


### PR DESCRIPTION
…ocks.

PHIElimination may insert copy instructions in multiple basic
blocks. Moving debug locations across basic block boundaries would be
misleading as illustrated by the test case.

rdar://75463656

Differential Revision: https://reviews.llvm.org/D100886

(cherry picked from commit 81cad0be687e3db027b6035e2193a805eb1b6ced)