### PR TITLE
[lldb] Include thread name in crashlog.py output

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -418,11 +418,15 @@ class JSONCrashLogParser:
             self.parse_images(self.data['usedImages'])
             self.parse_threads(self.data['threads'])
             thread = self.crashlog.threads[self.crashlog.crashed_thread_idx]
-            thread.reason = self.parse_crash_reason(self.data['exception'])
+            reason = self.parse_crash_reason(self.data['exception'])
+            if thread.reason:
+                thread.reason = '{} {}'.format(thread.reason, reason)
+            else:
+                thread.reason = reason
         except (KeyError, ValueError, TypeError) as e:
-           raise CrashLogParseException(
-               'Failed to parse JSON crashlog: {}: {}'.format(
-                   type(e).__name__, e))
+            raise CrashLogParseException(
+                'Failed to parse JSON crashlog: {}: {}'.format(
+                    type(e).__name__, e))
 
         return self.crashlog
 
@@ -480,6 +484,8 @@ class JSONCrashLogParser:
         idx = 0
         for json_thread in json_threads:
             thread = self.crashlog.Thread(idx, False)
+            if 'name' in json_thread:
+                thread.reason = json_thread['name']
             if json_thread.get('triggered', False):
                 self.crashlog.crashed_thread_idx = idx
                 self.registers = self.parse_thread_registers(

--- a/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/Inputs/a.out.ips
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/Inputs/a.out.ips
@@ -40,6 +40,7 @@
   {
     "triggered": true,
     "id": 6152004,
+    "name": "Crashing Thread Name",
     "threadState": {
       "r13": {
         "value": 0

--- a/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/json.test
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/json.test
@@ -3,7 +3,7 @@
 # RUN: python %S/patch-crashlog.py --binary %t.out --crashlog %t.crash --offsets '{"main":20, "bar":9, "foo":16}' --json
 # RUN: %lldb %t.out -o 'command script import lldb.macosx.crashlog' -o 'crashlog %t.crash' 2>&1 | FileCheck %s
 
-# CHECK: Thread[0] EXC_BAD_ACCESS (SIGSEGV) (KERN_INVALID_ADDRESS at 0x0000000000000000)
+# CHECK: Thread[0] Crashing Thread Name EXC_BAD_ACCESS (SIGSEGV) (KERN_INVALID_ADDRESS at 0x0000000000000000)
 # CHECK: [  0] {{.*}}out`foo + 16 at test.c
 # CHECK: [  1] {{.*}}out`bar + 8 at test.c
 # CHECK: [  2] {{.*}}out`main + 19 at test.c


### PR DESCRIPTION
Update the JSON parser to include the thread name in the Thread object.

rdar://76677320
(cherry picked from commit a62cbd9a0211d08bace8794b435996890feb44d4)
