### PR TITLE
lldb/Instrumentation: NFC-ish use GetFrameCodeAddressForSymbolication()

### DIFF
--- a/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
@@ -210,18 +210,13 @@ InstrumentationRuntimeMainThreadChecker::RetrieveReportData(
   StackFrameSP responsible_frame;
   for (unsigned I = 0; I < thread_sp->GetStackFrameCount(); ++I) {
     StackFrameSP frame = thread_sp->GetStackFrameAtIndex(I);
-    Address addr = frame->GetFrameCodeAddress();
+    Address addr = frame->GetFrameCodeAddressForSymbolication();
     if (addr.GetModule() == runtime_module_sp) // Skip PCs from the runtime.
       continue;
 
     // The first non-runtime frame is responsible for the bug.
     if (!responsible_frame)
       responsible_frame = frame;
-
-    // First frame in stacktrace should point to a real PC, not return address.
-    if (I != 0 && trace->GetSize() == 0) {
-      addr.Slide(-1);
-    }
 
     lldb::addr_t PC = addr.GetLoadAddress(&target);
     trace->AddItem(StructuredData::ObjectSP(new StructuredData::Integer(PC)));
@@ -365,8 +360,11 @@ InstrumentationRuntimeMainThreadChecker::GetBacktracesFromExtendedStopInfo(
       info->GetObjectForDotSeparatedPath("tid");
   tid_t tid = thread_id_obj ? thread_id_obj->GetIntegerValue() : 0;
 
-  HistoryThread *history_thread = new HistoryThread(*process_sp, tid, PCs);
-  ThreadSP new_thread_sp(history_thread);
+  // We gather symbolication addresses above, so no need for HistoryThread to
+  // try to infer the call addresses.
+  bool pcs_are_call_addresses = true;
+  ThreadSP new_thread_sp = std::make_shared<HistoryThread>(
+      *process_sp, tid, PCs, pcs_are_call_addresses);
 
   // Save this in the Process' ExtendedThreadList so a strong pointer retains
   // the object


### PR DESCRIPTION
A couple of our Instrumentation runtimes were gathering backtraces,
storing it in a StructuredData array and later creating a HistoryThread
using this data. By deafult HistoryThread will consider the history PCs
as return addresses and thus will substract 1 from them to go to the
call address.

This is usually correct, but it's also wasteful as when we gather the
backtraces ourselves, we have much better information to decide how
to backtrace and symbolicate. This patch uses the new
GetFrameCodeAddressForSymbolication() to gather the PCs that should
be used for symbolication and configures the HistoryThread to just
use those PCs as-is.

(The MTC plugin was actaully applying a -1 itself and then the
HistoryThread would do it again, so this actaully fixes a bug there.)

rdar://77027680

Differential Revision: https://reviews.llvm.org/D101094

(cherry picked from commit 91e90cf622074633009788a220a354043a609dee)