### PR TITLE
Add previous formatting commit to .git-blame-ignore-revs (NFC)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -40,3 +40,6 @@ d8f0e6caa91e230a486c948ab643174e40bdf215
 
 # Wiped out some non-ascii characters that snuck into the copyright.
 5b08a8a43254ed30bd953e869b0fd9fc1e8b82d0
+
+# reformat of swift-lldb master-next
+505de57baa751dbb8bbd3019df5105ec70d0f5c3


### PR DESCRIPTION
This formatting commit 505de57baa751dbb8bbd3019df5105ec70d0f5c3 is missing from the list of commits to ignore.