### PR TITLE
[lldb] Update register state parsing for JSON crashlogs

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -97,7 +97,7 @@ class CrashLog(symbolication.Symbolicator):
             if self.registers:
                 print("%s  Registers:" % (prefix))
                 for reg in self.registers.keys():
-                    print("%s    %-5s = %#16.16x" % (prefix, reg, self.registers[reg]))
+                    print("%s    %-8s = %#16.16x" % (prefix, reg, self.registers[reg]))
 
         def dump_symbolicated(self, crash_log, options):
             this_thread_crashed = self.app_specific_backtrace
@@ -156,6 +156,10 @@ class CrashLog(symbolication.Symbolicator):
                         symbolicated_frame_address_idx += 1
                 else:
                     print(frame)
+            if self.registers:
+                print()
+                for reg in self.registers.keys():
+                    print("    %-8s = %#16.16x" % (reg, self.registers[reg]))
 
         def add_ident(self, ident):
             if ident not in self.idents:
@@ -482,7 +486,7 @@ class JSONCrashLogParser:
             thread = self.crashlog.Thread(idx, False)
             if json_thread.get('triggered', False):
                 self.crashlog.crashed_thread_idx = idx
-                self.registers = self.parse_thread_registers(
+                thread.registers = self.parse_thread_registers(
                     json_thread['threadState'])
             thread.queue = json_thread.get('queue')
             self.parse_frames(thread, json_thread.get('frames', []))
@@ -490,19 +494,13 @@ class JSONCrashLogParser:
             idx += 1
 
     def parse_thread_registers(self, json_thread_state):
-        idx = 0
         registers = dict()
-        for json_reg in json_thread_state.get('x', []):
-            key = str('x{}'.format(idx))
-            value = int(json_reg['value'])
-            registers[key] = value
-            idx += 1
-
-        for register in ['lr', 'cpsr', 'fp', 'sp', 'esr', 'pc']:
-            if register in json_thread_state:
-                json_reg = json_thread_state[register]
-                registers[register] = int(json_reg['value'])
-
+        for key, state in json_thread_state.items():
+            try:
+               value = int(state['value'])
+               registers[key] = value
+            except (TypeError, ValueError):
+               pass
         return registers
 
 

--- a/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/json.test
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/json.test
@@ -7,3 +7,4 @@
 # CHECK: [  0] {{.*}}out`foo + 16 at test.c
 # CHECK: [  1] {{.*}}out`bar + 8 at test.c
 # CHECK: [  2] {{.*}}out`main + 19 at test.c
+# CHECK: rbp = 0x00007ffeec22a530

--- a/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/text.test
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/text.test
@@ -7,3 +7,4 @@
 # CHECK: [  0] {{.*}}out`foo + 16 at test.c
 # CHECK: [  1] {{.*}}out`bar + 8 at test.c
 # CHECK: [  2] {{.*}}out`main + 19 at test.c
+# CHECK: rbp = 0x00007ffee42d8020


### PR DESCRIPTION
 - The register encoding state in the JSON crashlog format changes.
   Update the parser accordingly.
 - Print the register state when printing the symbolicated thread.

(cherry picked from commit 91d3f73937b603b168a2be40f57a81efcc37da86)
