### PR TITLE
[cmake] Configure policy CMP0116

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -15,6 +15,12 @@ if(POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif()
 
+# CMP0116: Ninja generators transform `DEPFILE`s from `add_custom_command()`
+# New in CMake 3.20. https://cmake.org/cmake/help/latest/policy/CMP0116.html
+if(POLICY CMP0116)
+  cmake_policy(SET CMP0116 OLD)
+endif()
+
 if(NOT DEFINED LLVM_VERSION_MAJOR)
   set(LLVM_VERSION_MAJOR 12)
 endif()


### PR DESCRIPTION
Using `cmake` >=3.20 results in many warnings about this new policy. This change silences the warnings by explicitly declaring use of the "OLD" behavior.

This policy currently affects only one place: the `tablegen()` function in `TableGen.cmake`.

Differential Revision: https://reviews.llvm.org/D101083

(cherry picked from commit 638d84b60b7e7b7fa9099939ab4de2ec1e0c52c3)