### PR TITLE
[lldb] Fix one regex case of _regexp-list

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -823,8 +823,8 @@ void CommandInterpreter::LoadCommandDictionary() {
         list_regex_cmd_up->AddRegexCommand(
             "^-([[:digit:]]+)[[:space:]]*$",
             "source list --reverse --count %1") &&
-        list_regex_cmd_up->AddRegexCommand("^([^.]+)\\.([^.]+)$",
-                                           "source list --file \"%1.%2\"") &&
+        list_regex_cmd_up->AddRegexCommand("^([^.]+\\.[^.[:space:]]+)[[:space:]]*$",
+                                           "source list --file \"%1\"") &&
         list_regex_cmd_up->AddRegexCommand("^(.+)$",
                                            "source list --name \"%1\"") &&
         list_regex_cmd_up->AddRegexCommand("^$", "source list")) {


### PR DESCRIPTION
Without command autocompletion, the input can have a trailing space. The
trailing space has been included in the filename, which results in an error
message. This change prevents the trailing space from being captured in the
filename.

This change also uses a single capture rather than two.

(cherry picked from https://github.com/apple/llvm-project/pull/2881)
