### PR TITLE
[lldb] Exit Swift unwind when symbol context fails

### DIFF
--- a/lldb/source/Target/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntime.cpp
@@ -2201,25 +2201,26 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
   Address pc;
   pc.SetLoadAddress(regctx->GetPC(), &target);
   SymbolContext sc;
-  if (pc.IsValid()) {
-    pc.CalculateSymbolContext(&sc,
-                              eSymbolContextFunction | eSymbolContextSymbol);
-    if (sc.function) {
-      Address func_start_addr = sc.function->GetAddressRange().GetBaseAddress();
-      AddressRange prologue_range(func_start_addr,
-                                  sc.function->GetPrologueByteSize());
-      if (prologue_range.ContainsLoadAddress(pc, &target) ||
-          func_start_addr == pc) {
-        return UnwindPlanSP();
-      }
-    } else if (sc.symbol) {
-      Address func_start_addr = sc.symbol->GetAddress();
-      AddressRange prologue_range(func_start_addr,
-                                  sc.symbol->GetPrologueByteSize());
-      if (prologue_range.ContainsLoadAddress(pc, &target) ||
-          func_start_addr == pc) {
-        return UnwindPlanSP();
-      }
+  if (pc.IsValid())
+    if (!pc.CalculateSymbolContext(&sc, eSymbolContextFunction |
+                                            eSymbolContextSymbol))
+      return UnwindPlanSP();
+
+  if (sc.function) {
+    Address func_start_addr = sc.function->GetAddressRange().GetBaseAddress();
+    AddressRange prologue_range(func_start_addr,
+                                sc.function->GetPrologueByteSize());
+    if (prologue_range.ContainsLoadAddress(pc, &target) ||
+        func_start_addr == pc) {
+      return UnwindPlanSP();
+    }
+  } else if (sc.symbol) {
+    Address func_start_addr = sc.symbol->GetAddress();
+    AddressRange prologue_range(func_start_addr,
+                                sc.symbol->GetPrologueByteSize());
+    if (prologue_range.ContainsLoadAddress(pc, &target) ||
+        func_start_addr == pc) {
+      return UnwindPlanSP();
     }
   }
 


### PR DESCRIPTION
Exit early from `GetRuntimeUnwindPlan` when `CalculateSymbolContext` does not succeed.

Best viewed with ignoring whitespace changes https://github.com/apple/llvm-project/pull/2889/files?w=1

This is a fix to the symptom not the cause, but prevents crashes without any (known) affects on behavior. Notably, backtraces still work as expected.

When the symbol context can't be calculated, later in this function this expression crashes because `sc.symbol` is null.

```cpp
bool indirect_context = IsSwiftAsyncAwaitResumePartialFunctionSymbol(
    sc.symbol->GetMangled().GetMangledName().GetStringRef());
```

rdar://76798331