### PR TITLE
[lldb] Fix bug where memory read --outfile is not truncating the file

### DIFF
--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -767,10 +767,11 @@ protected:
     std::string path = outfile_spec.GetPath();
     if (outfile_spec) {
 
-      auto open_options = File::eOpenOptionWrite | File::eOpenOptionCanCreate;
+      File::OpenOptions open_options =
+          File::eOpenOptionWrite | File::eOpenOptionCanCreate;
       const bool append = m_outfile_options.GetAppend().GetCurrentValue();
-      if (append)
-        open_options |= File::eOpenOptionAppend;
+      open_options |=
+          append ? File::eOpenOptionAppend : File::eOpenOptionTruncate;
 
       auto outfile = FileSystem::Instance().Open(outfile_spec, open_options);
 


### PR DESCRIPTION
The memory read --outfile command should truncate the output when unless
--append-outfile. Fix the bug and add a test.

rdar://76062318

Differential revision: https://reviews.llvm.org/D99890

(cherry picked from commit 710651c61dcdb2f969811b9a8c7efb425b5e2918)
