### PR TITLE
[lldb] Implement TypeSystemSwiftTypeRef::GetNumTemplateArguments

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2616,8 +2616,37 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
 
 size_t
 TypeSystemSwiftTypeRef::GetNumTemplateArguments(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetNumTemplateArguments(ReconstructType(type));
+  auto impl = [&]() -> size_t {
+    using namespace swift::Demangle;
+    Demangler dem;
+    NodePointer node = DemangleCanonicalType(dem, type);
+
+    if (!node)
+      return 0;
+
+    switch (node->getKind()) {
+    case Node::Kind::BoundGenericClass:
+    case Node::Kind::BoundGenericEnum:
+    case Node::Kind::BoundGenericStructure:
+    case Node::Kind::BoundGenericProtocol:
+    case Node::Kind::BoundGenericOtherNominalType:
+    case Node::Kind::BoundGenericTypeAlias:
+    case Node::Kind::BoundGenericFunction: {
+      if (node->getNumChildren() > 1) {
+        NodePointer child = node->getChild(1);
+        if (child && child->getKind() == Node::Kind::TypeList)
+          return child->getNumChildren();
+      }
+    } break;
+    default:
+      break;
+    }
+    return 0;
+  };
+  VALIDATE_AND_RETURN(impl, GetNumTemplateArguments, type,
+                      (ReconstructType(type)), (ReconstructType(type)));
 }
+
 CompilerType
 TypeSystemSwiftTypeRef::GetTypeForFormatters(opaque_compiler_type_t type) {
   return m_swift_ast_context->GetTypeForFormatters(ReconstructType(type));

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -577,3 +577,65 @@ TEST_F(TestTypeSystemSwiftTypeRef, ImportedType) {
 TEST_F(TestTypeSystemSwiftTypeRef, RawPointer) {
   ASSERT_EQ(m_swift_ts.GetRawPointerType().GetMangledTypeName(), "$sBpD");
 }
+
+TEST_F(TestTypeSystemSwiftTypeRef, GetNumTemplateArguments) {
+  using namespace swift::Demangle;
+  Demangler dem;
+  NodeBuilder b(dem);
+  {
+    NodePointer n = b.GlobalType(b.Node(
+        Node::Kind::BoundGenericClass,
+        b.Node(Node::Kind::Type,
+               b.Node(Node::Kind::Class, b.Node(Node::Kind::Module, "module"),
+                      b.Node(Node::Kind::Identifier, "Foo"))),
+        b.Node(Node::Kind::TypeList,
+               b.Node(Node::Kind::Type,
+                      b.Node(Node::Kind::DependentGenericParamType,
+                             b.NodeWithIndex(Node::Kind::Index, 0),
+                             b.NodeWithIndex(Node::Kind::Index, 0))),
+               b.Node(Node::Kind::Type,
+                      b.Node(Node::Kind::DependentGenericParamType,
+                             b.NodeWithIndex(Node::Kind::Index, 0),
+                             b.NodeWithIndex(Node::Kind::Index, 1))),
+               b.Node(Node::Kind::Type,
+                      b.Node(Node::Kind::DependentGenericParamType,
+                             b.NodeWithIndex(Node::Kind::Index, 0),
+                             b.NodeWithIndex(Node::Kind::Index, 2))))));
+    CompilerType t = GetCompilerType(b.Mangle(n));
+    ASSERT_EQ(t.GetNumTemplateArguments(), 3);
+  }
+
+  {
+    NodePointer n = b.GlobalType(b.Node(
+        Node::Kind::BoundGenericStructure,
+        b.Node(Node::Kind::Type,
+               b.Node(Node::Kind::Structure, b.Node(Node::Kind::Module, "module"),
+                      b.Node(Node::Kind::Identifier, "Foo"))),
+        b.Node(Node::Kind::TypeList,
+               b.Node(Node::Kind::Type,
+                      b.Node(Node::Kind::DependentGenericParamType,
+                             b.NodeWithIndex(Node::Kind::Index, 0),
+                             b.NodeWithIndex(Node::Kind::Index, 0))),
+               b.Node(Node::Kind::Type,
+                      b.Node(Node::Kind::DependentGenericParamType,
+                             b.NodeWithIndex(Node::Kind::Index, 0),
+                             b.NodeWithIndex(Node::Kind::Index, 1))))));
+    CompilerType t = GetCompilerType(b.Mangle(n));
+    ASSERT_EQ(t.GetNumTemplateArguments(), 2);
+  }
+
+  {
+    NodePointer n = b.GlobalType(b.Node(
+        Node::Kind::BoundGenericEnum,
+        b.Node(Node::Kind::Type,
+               b.Node(Node::Kind::Enum, b.Node(Node::Kind::Module, "module"),
+                      b.Node(Node::Kind::Identifier, "Foo"))),
+        b.Node(Node::Kind::TypeList,
+               b.Node(Node::Kind::Type,
+                      b.Node(Node::Kind::DependentGenericParamType,
+                             b.NodeWithIndex(Node::Kind::Index, 0),
+                             b.NodeWithIndex(Node::Kind::Index, 0))))));
+    CompilerType t = GetCompilerType(b.Mangle(n));
+    ASSERT_EQ(t.GetNumTemplateArguments(), 1);
+  }
+}


### PR DESCRIPTION
This follows the same behavior as `SwiftASTContext::GetNumTemplateArguments`, which only returns the number of template arguments of generic types and not generic functions.

rdar://68171376