### PR TITLE
[clang] Don't crash when loading invalid VFS for the module dep colle…

### DIFF
--- a/clang/test/VFS/broken-vfs-module-dep.c
+++ b/clang/test/VFS/broken-vfs-module-dep.c
@@ -1,0 +1,7 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: not %clang_cc1 -module-dependency-dir %t -ivfsoverlay %S/Inputs/invalid-yaml.yaml %s 2>&1 | FileCheck %s
+
+// CHECK: error: Unexpected token
+// CHECK: error: Unexpected token
+// CHECK: 1 error generated

--- a/llvm/lib/Support/VirtualFileSystem.cpp
+++ b/llvm/lib/Support/VirtualFileSystem.cpp
@@ -2127,6 +2127,8 @@ void vfs::collectVFSFromYAML(std::unique_ptr<MemoryBuffer> Buffer,
   std::unique_ptr<RedirectingFileSystem> VFS = RedirectingFileSystem::create(
       std::move(Buffer), DiagHandler, YAMLFilePath, DiagContext,
       std::move(ExternalFS));
+  if (!VFS)
+    return;
   ErrorOr<RedirectingFileSystem::LookupResult> RootResult =
       VFS->lookupPath("/");
   if (!RootResult)


### PR DESCRIPTION
…ctor

The VFS is null when it's invalid so return early in collectVFSFromYAML.