### PR TITLE
[lldb] Use SBStructuredData default ctor instead of StructuredDataImpl* ctor

### DIFF
--- a/lldb/source/API/SBFrame.cpp
+++ b/lldb/source/API/SBFrame.cpp
@@ -1220,7 +1220,7 @@ lldb::SBStructuredData SBFrame::GetLanguageSpecificData() const {
       if (auto *data = runtime->GetLanguageSpecificData(*frame))
         return {data};
 
-  return nullptr;
+  return {};
 }
 
 // BEGIN SWIFT


### PR DESCRIPTION
Use `SBStructuredData()` instead of `SBStructuredData(StructuredDataImpl *)` as the latter causes a crash later when using the copy assignment operator.

Fixes the bug introduced in https://github.com/apple/llvm-project/pull/2867

rdar://77283279