### PR TITLE
[clang][driver][darwin] use the deployment target version as the SDK …

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -2764,8 +2764,16 @@ void Darwin::addPlatformVersionArgs(const llvm::opt::ArgList &Args,
       }
       CmdArgs.push_back(Args.MakeArgString(SDKVersion.getAsString()));
     } else {
-      // Use a blank SDK version if it's not present.
-      CmdArgs.push_back("0.0.0");
+      // Use an SDK version that's matching the deployment target if the SDK
+      // version is missing. This is preferred over an empty SDK version (0.0.0)
+      // as the system's runtime might expect the linked binary to contain a
+      // valid SDK version in order for the binary to work correctly. It's
+      // reasonable to use the deployment target version as a proxy for the
+      // SDK version because older SDKs don't guarantee support for deployment
+      // targets newer than the SDK versions, so that rules out using some
+      // predetermined older SDK version, which leaves the deployment target
+      // version as the only reasonable choice.
+      CmdArgs.push_back(Args.MakeArgString(TargetVersion.getAsString()));
     }
   };
   EmitPlatformVersionArg(getOSTargetVersion(), TargetPlatform,

--- a/clang/test/Driver/darwin-ld-platform-version-macos.c
+++ b/clang/test/Driver/darwin-ld-platform-version-macos.c
@@ -48,4 +48,7 @@
 // RUN: %clang -target x86_64-apple-macos10.13 -mlinker-version=520 \
 // RUN:   -### %t.o 2>&1 \
 // RUN:   | FileCheck --check-prefix=NOSDK %s
-// NOSDK: "-platform_version" "macos" "10.13.0" "0.0.0"
+// RUN: %clang -target x86_64-apple-darwin17 -mlinker-version=520 \
+// RUN:   -### %t.o 2>&1 \
+// RUN:   | FileCheck --check-prefix=NOSDK %s
+// NOSDK: "-platform_version" "macos" "10.13.0" "10.13.0"


### PR DESCRIPTION
…version

when passing -platform_version to the linker

The use of a valid SDK version is preferred over an empty SDK version
(0.0.0) as the system's runtime might expect the linked binary to contain
a valid SDK version in order for the binary to work correctly

rdar://66795188
(cherry picked from commit 8fc5f07fc0aee95ff9f79e91035d115690177dc1)