### PR TITLE
[lldb] Implement TypeSystemSwiftTypeRef::GetLValueReferenceType and TypeSystemSwiftTypeRef::GetRValueReferenceType

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5897,10 +5897,6 @@ SwiftASTContext::GetMemberFunctionAtIndex(opaque_compiler_type_t type,
 
 CompilerType
 SwiftASTContext::GetLValueReferenceType(opaque_compiler_type_t type) {
-  VALID_OR_RETURN(CompilerType());
-
-  if (type)
-    return ToCompilerType({swift::LValueType::get(GetSwiftType(type))});
   return {};
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3101,11 +3101,17 @@ TypeSystemSwiftTypeRef::GetNonReferenceType(opaque_compiler_type_t type) {
 }
 CompilerType
 TypeSystemSwiftTypeRef::GetLValueReferenceType(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetLValueReferenceType(ReconstructType(type));
+    auto impl = []() { return CompilerType(); };
+
+  VALIDATE_AND_RETURN(impl, GetLValueReferenceType, type,
+                      (ReconstructType(type)), (ReconstructType(type)));
 }
 CompilerType
 TypeSystemSwiftTypeRef::GetRValueReferenceType(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetRValueReferenceType(ReconstructType(type));
+  auto impl = []() { return CompilerType(); };
+
+  VALIDATE_AND_RETURN(impl, GetRValueReferenceType, type,
+                      (ReconstructType(type)), (ReconstructType(type)));
 }
 uint32_t
 TypeSystemSwiftTypeRef::GetNumDirectBaseClasses(opaque_compiler_type_t type) {

--- a/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Target/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -415,7 +415,7 @@ public:
     Target &target(m_process.GetTarget());
     Address addr(address.getAddressData());
     Status error;
-    if (size > target.ReadMemory(addr, dest, size, error, true)) {
+    if (size > target.ReadMemory(addr, dest, size, error)) {
       LLDB_LOGV(log, "[MemoryReader] memory read returned fewer bytes than asked for");
       return false;
     }
@@ -2728,7 +2728,7 @@ lldb::addr_t SwiftLanguageRuntimeImpl::FixupAddress(lldb::addr_t addr,
     Target &target = m_process.GetTarget();
     size_t ptr_size = m_process.GetAddressByteSize();
     lldb::addr_t refd_addr = LLDB_INVALID_ADDRESS;
-    target.ReadMemory(addr, &refd_addr, ptr_size, error, true);
+    target.ReadMemory(addr, &refd_addr, ptr_size, error);
     if (error.Success()) {
       bool extra_deref;
       std::tie(refd_addr, extra_deref) = FixupPointerValue(refd_addr, type);


### PR DESCRIPTION
Although Swift doesn't have a notion of lvalues, the compiler does have an internal representation of lvalues, which is what SwiftASTContext embeds a type in. We can't use this in TypeSystemSwiftTypeRef though, since no equivalent exists in the demangling nodes. Therefore we now return invalid nodes for both `GetLValueReferenceType` and `GetRValueReferenceType` in `TypeSystemSwiftTypeRef` and `SwiftASTContext`.

rdar://68171437
rdar://68171436