### PR TITLE
[lldb] Implement TypeSystemSwiftTypeRef::GetInstanceType

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2814,8 +2814,34 @@ TypeSystemSwiftTypeRef::GetReferentType(opaque_compiler_type_t type) {
 
 CompilerType
 TypeSystemSwiftTypeRef::GetInstanceType(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetInstanceType(ReconstructType(type));
+  auto impl = [&]() -> CompilerType {
+    using namespace swift::Demangle;
+    Demangler dem;
+    NodePointer node = DemangleCanonicalType(dem, type);
+
+    if (!node)
+      return {};
+    if (ContainsUnresolvedTypeAlias(node)) {
+      // If we couldn't resolve all type aliases, we might be in a REPL session
+      // where getting to the debug information necessary for resolving that
+      // type alias isn't possible, or the user might have defined the
+      // type alias in the REPL. In these cases, fallback to asking the AST
+      // for the canonical type.
+      return m_swift_ast_context->GetInstanceType(ReconstructType(type));
+    }
+
+    if (node->getKind() == Node::Kind::Metatype) {
+      for (NodePointer child : *node)
+        if (child->getKind() == Node::Kind::Type)
+          return RemangleAsType(dem, child);
+      return {};
+    }
+    return {this, type};
+  };
+  VALIDATE_AND_RETURN(impl, GetInstanceType, type, (ReconstructType(type)),
+                      (ReconstructType(type)));
 }
+
 TypeSystemSwift::TypeAllocationStrategy
 TypeSystemSwiftTypeRef::GetAllocationStrategy(opaque_compiler_type_t type) {
   return m_swift_ast_context->GetAllocationStrategy(ReconstructType(type));

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -639,3 +639,32 @@ TEST_F(TestTypeSystemSwiftTypeRef, GetNumTemplateArguments) {
     ASSERT_EQ(t.GetNumTemplateArguments(), 1);
   }
 }
+
+TEST_F(TestTypeSystemSwiftTypeRef, GetInstanceType) {
+  using namespace swift::Demangle;
+  Demangler dem;
+  NodeBuilder b(dem);
+  {
+    NodePointer n = b.GlobalType(
+            b.Node(Node::Kind::Metatype,
+              b.Node(Node::Kind::MetatypeRepresentation, "@thin"),
+              b.Node(Node::Kind::Type,
+                b.Node(Node::Kind::Structure,
+                  b.Node(Node::Kind::Module, "Swift"),
+                  b.Node(Node::Kind::Identifier, "String")))));
+
+    CompilerType t = GetCompilerType(b.Mangle(n));
+    CompilerType instance_type = m_swift_ts.GetInstanceType(t.GetOpaqueQualType());
+    ASSERT_EQ(instance_type.GetMangledTypeName(), "$sSSD");
+  };
+  {
+    NodePointer n = b.GlobalType(
+        b.Node(Node::Kind::Structure,
+          b.Node(Node::Kind::Module, "Swift"),
+          b.Node(Node::Kind::Identifier, "String")));
+
+    CompilerType t = GetCompilerType(b.Mangle(n));
+    CompilerType instance_type = m_swift_ts.GetInstanceType(t.GetOpaqueQualType());
+    ASSERT_EQ(instance_type.GetMangledTypeName(), "$sSSD");
+  };
+};


### PR DESCRIPTION
Essentially, we check if the type of the current node is a `Metatype`, and, if so, extract it's first child, which should be the type we're interested in.

Here's `SwiftASTContext::GetInstanceType` for context:

```
CompilerType SwiftASTContext::GetInstanceType(opaque_compiler_type_t type) {
  if (!type)
    return {};

  swift::CanType swift_can_type(GetCanonicalSwiftType(type));
  assert((&swift_can_type->getASTContext() == GetASTContext()) &&
         "input type belongs to different SwiftASTContext");
  auto metatype_type = swift::dyn_cast<swift::AnyMetatypeType>(swift_can_type);
  if (metatype_type)
    return ToCompilerType({metatype_type.getInstanceType().getPointer()});

  return ToCompilerType({GetSwiftType(type)});
}
```

rdar://68171400