### PR TITLE
[lldb] Implement TypeSystemSwiftTypeRef::GetLValueReferenceType and TypeSystemSwiftTypeRef::GetRValueReferenceType (swift/next)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5870,10 +5870,6 @@ SwiftASTContext::GetMemberFunctionAtIndex(opaque_compiler_type_t type,
 
 CompilerType
 SwiftASTContext::GetLValueReferenceType(opaque_compiler_type_t type) {
-  VALID_OR_RETURN(CompilerType());
-
-  if (type)
-    return ToCompilerType({swift::LValueType::get(GetSwiftType(type))});
   return {};
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3100,11 +3100,17 @@ TypeSystemSwiftTypeRef::GetNonReferenceType(opaque_compiler_type_t type) {
 }
 CompilerType
 TypeSystemSwiftTypeRef::GetLValueReferenceType(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetLValueReferenceType(ReconstructType(type));
+    auto impl = []() { return CompilerType(); };
+
+  VALIDATE_AND_RETURN(impl, GetLValueReferenceType, type,
+                      (ReconstructType(type)), (ReconstructType(type)));
 }
 CompilerType
 TypeSystemSwiftTypeRef::GetRValueReferenceType(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetRValueReferenceType(ReconstructType(type));
+  auto impl = []() { return CompilerType(); };
+
+  VALIDATE_AND_RETURN(impl, GetRValueReferenceType, type,
+                      (ReconstructType(type)), (ReconstructType(type)));
 }
 uint32_t
 TypeSystemSwiftTypeRef::GetNumDirectBaseClasses(opaque_compiler_type_t type) {


### PR DESCRIPTION
Implement TypeSystemSwiftTypeRef::GetLValueReferenceType and TypeSystemSwiftTypeRef::GetRValueReferenceType

(cherry picked from commit f6e2ba85f5fadd1a753b28adba4a84005400bb3f)