### PR TITLE
Only run typesystem validation assertions when runnign the LLDB

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -55,14 +55,18 @@ class ModuleListProperties : public Properties {
 public:
   ModuleListProperties();
 
+  // BEGIN SWIFT
   bool GetUseSwiftClangImporter() const;
   bool GetUseSwiftDWARFImporter() const;
   bool SetUseSwiftDWARFImporter(bool new_value);
   bool GetUseSwiftTypeRefTypeSystem() const;
   bool SetUseSwiftTypeRefTypeSystem(bool new_value);
-  FileSpec GetClangModulesCachePath() const;
+  bool GetSwiftValidateTypeSystem() const;
   SwiftModuleLoadingMode GetSwiftModuleLoadingMode() const;
   bool SetSwiftModuleLoadingMode(SwiftModuleLoadingMode);
+  // END SWIFT
+
+  FileSpec GetClangModulesCachePath() const;
   bool SetClangModulesCachePath(const FileSpec &path);
   bool GetEnableExternalLookup() const;
   bool SetEnableExternalLookup(bool new_value);

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -789,6 +789,10 @@ class Base(unittest2.TestCase):
 
             'settings set symbols.clang-modules-cache-path "{}"'.format(
                 configuration.lldb_module_cache_dir),
+
+            # Enable expensive validations in TypeSystemSwiftTypeRef.
+            'settings set symbols.swift-validate-typesystem true',
+
             "settings set use-color false",
         ]
 

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -19,6 +19,9 @@ let Definition = "modulelist" in {
   def UseSwiftTypeRefTypeSystem: Property<"use-swift-typeref-typesystem", "Boolean">,
     DefaultTrue,
     Desc<"Prefer Swift Remote Mirrors over Remote AST">;
+  def SwiftValidateTypeSystem: Property<"swift-validate-typesystem", "Boolean">,
+    DefaultFalse,
+    Desc<"Validate all Swift typesystem queries. Used for testing an asserts-enabled LLDB only.">;
   def SwiftModuleLoadingMode: Property<"swift-module-loading-mode", "Enum">,
     DefaultEnumValue<"eSwiftModuleLoadingModePreferSerialized">,
     EnumValues<"OptionEnumValues(g_swift_module_loading_mode_enums)">,

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -132,50 +132,54 @@ FileSpec ModuleListProperties::GetClangModulesCachePath() const {
 bool ModuleListProperties::GetUseSwiftClangImporter() const {
   const uint32_t idx = ePropertyUseSwiftClangImporter;
   return m_collection_sp->GetPropertyAtIndexAsBoolean(
-      NULL, idx, g_modulelist_properties[idx].default_uint_value != 0);
+      nullptr, idx, g_modulelist_properties[idx].default_uint_value != 0);
 }
 
 bool ModuleListProperties::GetUseSwiftDWARFImporter() const {
   const uint32_t idx = ePropertyUseSwiftDWARFImporter;
   return m_collection_sp->GetPropertyAtIndexAsBoolean(
-      NULL, idx, g_modulelist_properties[idx].default_uint_value != 0);
+      nullptr, idx, g_modulelist_properties[idx].default_uint_value != 0);
 }
 
 bool ModuleListProperties::SetUseSwiftDWARFImporter(bool new_value) {
-    return m_collection_sp->SetPropertyAtIndexAsBoolean(
-            nullptr, ePropertyUseSwiftDWARFImporter, new_value);
+  return m_collection_sp->SetPropertyAtIndexAsBoolean(
+      nullptr, ePropertyUseSwiftDWARFImporter, new_value);
 }
 
 bool ModuleListProperties::GetUseSwiftTypeRefTypeSystem() const {
   const uint32_t idx = ePropertyUseSwiftTypeRefTypeSystem;
   return m_collection_sp->GetPropertyAtIndexAsBoolean(
-      NULL, idx, g_modulelist_properties[idx].default_uint_value != 0);
+      nullptr, idx, g_modulelist_properties[idx].default_uint_value != 0);
+}
+
+bool ModuleListProperties::GetSwiftValidateTypeSystem() const {
+  const uint32_t idx = ePropertySwiftValidateTypeSystem;
+  return m_collection_sp->GetPropertyAtIndexAsBoolean(
+      nullptr, idx, g_modulelist_properties[idx].default_uint_value != 0);
 }
 
 bool ModuleListProperties::SetUseSwiftTypeRefTypeSystem(bool new_value) {
-    return m_collection_sp->SetPropertyAtIndexAsBoolean(
-            nullptr, ePropertyUseSwiftTypeRefTypeSystem, new_value);
+  return m_collection_sp->SetPropertyAtIndexAsBoolean(
+      nullptr, ePropertyUseSwiftTypeRefTypeSystem, new_value);
 }
-// END SWIFT
 
 bool ModuleListProperties::SetClangModulesCachePath(const FileSpec &path) {
   return m_collection_sp->SetPropertyAtIndexAsFileSpec(
       nullptr, ePropertyClangModulesCachePath, path);
 }
 
-// BEGIN SWIFT
 SwiftModuleLoadingMode ModuleListProperties::GetSwiftModuleLoadingMode() const {
   const uint32_t idx = ePropertySwiftModuleLoadingMode;
   return (SwiftModuleLoadingMode)
       m_collection_sp->GetPropertyAtIndexAsEnumeration(
           nullptr, idx, g_modulelist_properties[idx].default_uint_value);
 }
-// END SWIFT
 
 bool ModuleListProperties::SetSwiftModuleLoadingMode(SwiftModuleLoadingMode mode) {
   return m_collection_sp->SetPropertyAtIndexAsEnumeration(
       nullptr, ePropertySwiftModuleLoadingMode, mode);
 }
+// END SWIFT
 
 void ModuleListProperties::UpdateSymlinkMappings() {
   FileSpecList list = m_collection_sp

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1580,6 +1580,9 @@ bool Equivalent(llvm::Optional<T> l, T r) {
   do {                                                                         \
     FALLBACK(REFERENCE, ());                                                   \
     auto result = IMPL();                                                      \
+    if (!ModuleList::GetGlobalModuleListProperties()                           \
+             .GetSwiftValidateTypeSystem())                                    \
+      return result;                                                           \
     if (!m_swift_ast_context)                                                  \
       return result;                                                           \
     assert((result == m_swift_ast_context->REFERENCE()) &&                     \
@@ -1591,6 +1594,9 @@ bool Equivalent(llvm::Optional<T> l, T r) {
   do {                                                                         \
     FALLBACK(REFERENCE, FALLBACK_ARGS);                                        \
     auto result = IMPL();                                                      \
+    if (!ModuleList::GetGlobalModuleListProperties()                           \
+             .GetSwiftValidateTypeSystem())                                    \
+      return result;                                                           \
     if (!m_swift_ast_context)                                                  \
       return result;                                                           \
     bool equivalent =                                                          \
@@ -2507,6 +2513,9 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
   bool ast_child_is_deref_of_parent;
   uint64_t ast_language_flags;
   auto defer = llvm::make_scope_exit([&] {
+    if (!ModuleList::GetGlobalModuleListProperties()
+             .GetSwiftValidateTypeSystem())
+      return;
     llvm::StringRef suffix(ast_child_name);
     if (suffix.consume_front("__ObjC."))
       ast_child_name = suffix.str();

--- a/lldb/test/Shell/lit-lldb-init.in
+++ b/lldb/test/Shell/lit-lldb-init.in
@@ -7,3 +7,4 @@ settings set interpreter.echo-comment-commands false
 settings set symbols.clang-modules-cache-path "@LLDB_TEST_MODULE_CACHE_LLDB@"
 settings set target.auto-apply-fixits false
 settings set target.inherit-tcc true
+settings set symbols.swift-validate-typesystem true


### PR DESCRIPTION
testsuite.  There are still a lot of false positives and we don't want
to burden users running nightly builds with these assertions.

(cherry picked from commit 1df9a603603abf5c32b547ef4d10af6f0070f480)

 Conflicts:
	lldb/include/lldb/Core/ModuleList.h
	lldb/test/Shell/lit-lldb-init.in