### PR TITLE
[lldb] Invert dependency between SwiftLanguageRuntime and ObjectFile plugins

### DIFF
--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -21,10 +21,6 @@
 #include "lldb/lldb-private.h"
 #include "llvm/Support/VersionTuple.h"
 
-namespace swift {
-class SwiftObjectFileFormat;
-enum ReflectionSectionKind : uint8_t;
-}
 namespace lldb_private {
 
 class ObjectFileJITDelegate {
@@ -669,9 +665,6 @@ public:
 
   /// Creates a plugin-specific call frame info
   virtual std::unique_ptr<CallFrameInfo> CreateCallFrameInfo();
-
-  virtual llvm::StringRef
-  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section);
 
 protected:
   // Member variables.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/CMakeLists.txt
@@ -16,4 +16,7 @@ add_lldb_library(lldbPluginSwiftLanguageRuntime PLUGIN
     lldbPluginExpressionParserClang
     lldbPluginProcessUtility
     lldbPluginSwiftLanguage
+    lldbPluginObjectFileELF
+    lldbPluginObjectFileMachO
+    lldbPluginObjectFilePECOFF
 )

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -41,10 +41,6 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/MipsABIFlags.h"
 
-#ifdef LLDB_ENABLE_SWIFT
-#include "swift/ABI/ObjectFile.h"
-#endif //LLDB_ENABLE_SWIFT
-
 #define CASE_AND_STREAM(s, def, width)                                         \
   case def:                                                                    \
     s->Printf("%-*s", width, #def);                                            \
@@ -3403,14 +3399,4 @@ ObjectFileELF::GetLoadableData(Target &target) {
     loadables.push_back(loadable);
   }
   return loadables;
-}
-
-llvm::StringRef ObjectFileELF::GetReflectionSectionIdentifier(
-    swift::ReflectionSectionKind section) {
-#ifdef LLDB_ENABLE_SWIFT
-  swift::SwiftObjectFileFormatELF file_format_elf;
-  return file_format_elf.getSectionName(section);
-#else
-  llvm_unreachable("Swift support disabled");
-#endif //LLDB_ENABLE_SWIFT
 }

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -392,9 +392,6 @@ private:
   /// .gnu_debugdata section or \c nullptr if an error occured or if there's no
   /// section with that name.
   std::shared_ptr<ObjectFileELF> GetGnuDebugDataObjectFile();
-
-  llvm::StringRef
-  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section) override;
 };
 
 #endif // LLDB_SOURCE_PLUGINS_OBJECTFILE_ELF_OBJECTFILEELF_H

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -46,10 +46,6 @@
 #include "llvm/Support/MemoryBuffer.h"
 
 #include "ObjectFileMachO.h"
-#ifdef LLDB_ENABLE_SWIFT
-#include "swift/ABI/ObjectFile.h"
-#include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
-#endif //LLDB_ENABLE_SWIFT
 
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
@@ -6463,14 +6459,4 @@ bool ObjectFileMachO::SaveCore(const lldb::ProcessSP &process_sp,
                  // this process
   }
   return false;
-}
-
-llvm::StringRef ObjectFileMachO::GetReflectionSectionIdentifier(
-    swift::ReflectionSectionKind section) {
-#ifdef LLDB_ENABLE_SWIFT
-  swift::SwiftObjectFileFormatMachO file_format_mach_o;
-  return file_format_mach_o.getSectionName(section);
-#else
-  llvm_unreachable("Swift support disabled");
-#endif //LLDB_ENABLE_SWIFT
 }

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
@@ -209,9 +209,6 @@ protected:
 
   bool SectionIsLoadable(const lldb_private::Section *section);
 
-  llvm::StringRef
-  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section) override;
-
   llvm::MachO::mach_header m_header;
   static lldb_private::ConstString GetSegmentNameTEXT();
   static lldb_private::ConstString GetSegmentNameDATA();

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -1213,13 +1213,3 @@ ObjectFile::Strata ObjectFilePECOFF::CalculateStrata() { return eStrataUser; }
 ConstString ObjectFilePECOFF::GetPluginName() { return GetPluginNameStatic(); }
 
 uint32_t ObjectFilePECOFF::GetPluginVersion() { return 1; }
-
-llvm::StringRef ObjectFilePECOFF::GetReflectionSectionIdentifier(
-    swift::ReflectionSectionKind section) {
-#ifdef LLDB_ENABLE_SWIFT
-  swift::SwiftObjectFileFormatCOFF file_format_coff;
-  return file_format_coff.getSectionName(section);
-#else
-  llvm_unreachable("Swift support disabled");
-#endif //LLDB_ENABLE_SWIFT
-}

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
@@ -286,9 +286,6 @@ protected:
   static lldb::SectionType GetSectionType(llvm::StringRef sect_name,
                                           const section_header_t &sect);
 
-  llvm::StringRef
-  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section) override;
-
   typedef std::vector<section_header_t> SectionHeaderColl;
   typedef SectionHeaderColl::iterator SectionHeaderCollIter;
   typedef SectionHeaderColl::const_iterator SectionHeaderCollConstIter;

--- a/lldb/source/Plugins/TypeSystem/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/TypeSystem/Swift/CMakeLists.txt
@@ -9,6 +9,14 @@ add_lldb_library(lldbPluginTypeSystemSwift PLUGIN
     lldbTarget
     lldbUtility
 
+    swiftAST
+    swiftASTSectionImporter
+    swiftBasic
+    swiftClangImporter
+    swiftFrontend
+    swiftSIL
+    swiftSerialization
+
   LINK_COMPONENTS
     Support
 )

--- a/lldb/source/Symbol/CMakeLists.txt
+++ b/lldb/source/Symbol/CMakeLists.txt
@@ -4,21 +4,6 @@ if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
   set(PLATFORM_SOURCES LocateSymbolFileMacOSX.cpp)
 endif()
 
-set(SWIFT_LIBS
-    swiftAST
-    swiftASTSectionImporter
-    swiftBasic
-    swiftClangImporter
-    swiftFrontend
-    swiftSIL
-    swiftSerialization
-)
-list(APPEND LLVM_OPTIONAL_SOURCES ${SWIFT_SOURCES})
-if (NOT LLDB_ENABLE_SWIFT_SUPPORT)
-  unset(SWIFT_SOURCES)
-  unset(SWIFT_LIBS)
-endif()
-
 add_lldb_library(lldbSymbol
   ArmUnwindInfo.cpp
   Block.cpp
@@ -51,7 +36,6 @@ add_lldb_library(lldbSymbol
   Variable.cpp
   VariableList.cpp
 
-  ${SWIFT_SOURCES}
   ${PLATFORM_SOURCES}
 
   LINK_LIBS
@@ -65,11 +49,10 @@ add_lldb_library(lldbSymbol
     lldbUtility
     lldbPluginObjCLanguage
     lldbPluginPlatformMacOSX
-    ${SWIFT_LIBS}
 
   LINK_COMPONENTS
     Support
   )
-if(CMAKE_CXX_COMPILER_ID STREQUAL Clang AND NOT SWIFT_COMPILER_IS_MSVC_LIKE)
+if(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
   target_compile_options(lldbSymbol PRIVATE -Wno-dollar-in-identifier-extension)
 endif()

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -726,10 +726,3 @@ void llvm::format_provider<ObjectFile::Strata>::format(
     break;
   }
 }
-
-llvm::StringRef ObjectFile::GetReflectionSectionIdentifier(
-    swift::ReflectionSectionKind section) {
-  assert(false &&
-         "Base class's GetReflectionSectionIdentifier should not be called");
-  return "";
-}


### PR DESCRIPTION
The motivation behind this change is that ObjectFile and its derived
classes don't need to know about swift directly. SwiftLanguageRuntime
on the other hand has direct knowledge of swift so it should be able to
make the decision it needs to with the ObjectFile it has.

cc @JDevlieghere @adrian-prantl

If you'd like this on other branches just tell me which and I will open PRs for those too.