### PR TITLE
[lldb] Implement TypeSystemSwiftTypeRef::IsTypedefType and TypeSystemSwiftTypeRef::GetTypedefedType

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3148,13 +3148,40 @@ TypeSystemSwiftTypeRef::GetTypeBitAlign(opaque_compiler_type_t type,
             AsMangledName(type));
   return {};
 }
+
 bool TypeSystemSwiftTypeRef::IsTypedefType(opaque_compiler_type_t type) {
-  return m_swift_ast_context->IsTypedefType(ReconstructType(type));
+  auto impl = [&]() {
+    using namespace swift::Demangle;
+    Demangler dem;
+    NodePointer node = GetDemangledType(dem, AsMangledName(type));
+    return node && node->getKind() == Node::Kind::TypeAlias;
+  };
+
+  VALIDATE_AND_RETURN(impl, IsTypedefType, type, (ReconstructType(type)),
+                      (ReconstructType(type)));
 }
+
 CompilerType
 TypeSystemSwiftTypeRef::GetTypedefedType(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetTypedefedType(ReconstructType(type));
+  auto impl = [&]() -> CompilerType {
+    using namespace swift::Demangle;
+    Demangler dem;
+    NodePointer node = GetDemangledType(dem, AsMangledName(type));
+    if (!node || node->getKind() != Node::Kind::TypeAlias)
+      return {};
+    auto pair = ResolveTypeAlias(m_swift_ast_context, dem, node);
+    if (NodePointer resolved = std::get<swift::Demangle::NodePointer>(pair)) {
+      NodePointer type_node = dem.createNode(Node::Kind::Type);
+      type_node->addChild(resolved, dem);
+      return RemangleAsType(dem, type_node);
+    }
+    return std::get<CompilerType>(pair);
+  };
+
+  VALIDATE_AND_RETURN(impl, GetTypedefedType, type, (ReconstructType(type)),
+                      (ReconstructType(type)));
 }
+
 CompilerType
 TypeSystemSwiftTypeRef::GetFullyUnqualifiedType(opaque_compiler_type_t type) {
   return m_swift_ast_context->GetFullyUnqualifiedType(ReconstructType(type));

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -646,25 +646,47 @@ TEST_F(TestTypeSystemSwiftTypeRef, GetInstanceType) {
   NodeBuilder b(dem);
   {
     NodePointer n = b.GlobalType(
-            b.Node(Node::Kind::Metatype,
-              b.Node(Node::Kind::MetatypeRepresentation, "@thin"),
-              b.Node(Node::Kind::Type,
-                b.Node(Node::Kind::Structure,
-                  b.Node(Node::Kind::Module, "Swift"),
-                  b.Node(Node::Kind::Identifier, "String")))));
+        b.Node(Node::Kind::Metatype,
+               b.Node(Node::Kind::MetatypeRepresentation, "@thin"),
+               b.Node(Node::Kind::Type,
+                      b.Node(Node::Kind::Structure,
+                             b.Node(Node::Kind::Module, "Swift"),
+                             b.Node(Node::Kind::Identifier, "String")))));
 
     CompilerType t = GetCompilerType(b.Mangle(n));
-    CompilerType instance_type = m_swift_ts.GetInstanceType(t.GetOpaqueQualType());
+    CompilerType instance_type =
+        m_swift_ts.GetInstanceType(t.GetOpaqueQualType());
     ASSERT_EQ(instance_type.GetMangledTypeName(), "$sSSD");
   };
   {
     NodePointer n = b.GlobalType(
-        b.Node(Node::Kind::Structure,
-          b.Node(Node::Kind::Module, "Swift"),
-          b.Node(Node::Kind::Identifier, "String")));
+        b.Node(Node::Kind::Structure, b.Node(Node::Kind::Module, "Swift"),
+               b.Node(Node::Kind::Identifier, "String")));
 
     CompilerType t = GetCompilerType(b.Mangle(n));
-    CompilerType instance_type = m_swift_ts.GetInstanceType(t.GetOpaqueQualType());
+    CompilerType instance_type =
+        m_swift_ts.GetInstanceType(t.GetOpaqueQualType());
     ASSERT_EQ(instance_type.GetMangledTypeName(), "$sSSD");
   };
 };
+
+TEST_F(TestTypeSystemSwiftTypeRef, IsTypedefType) {
+  using namespace swift::Demangle;
+  Demangler dem;
+  NodeBuilder b(dem);
+  {
+    NodePointer n = b.GlobalType(
+        b.Node(Node::Kind::TypeAlias, b.Node(Node::Kind::Module, "module"),
+               b.Node(Node::Kind::Identifier, "Alias")));
+    CompilerType t = GetCompilerType(b.Mangle(n));
+    ASSERT_TRUE(t.IsTypedefType());
+  };
+  {
+    NodePointer n = b.GlobalType(
+        b.Node(Node::Kind::Structure, b.Node(Node::Kind::Module, "module"),
+               b.Node(Node::Kind::Identifier, "SomeNotAliasedType")));
+    CompilerType t = GetCompilerType(b.Mangle(n));
+    ASSERT_FALSE(t.IsTypedefType());
+  };
+};
+


### PR DESCRIPTION
@adrian-prantl since we need debug info to resolve a typedef, is it possible to unit test `TypeSystemSwiftTypeRef::GetTypedefedType`?

rdar://68171433
rdar://68171443