### PR TITLE
[lldb] Fix invalid use of mutating keyword in generated expressions

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -186,8 +186,9 @@ do {
         func_decorator = "final class";
       else
         func_decorator = "static";
-    } else if (is_class && !weak_self) {
-      func_decorator = "final";
+    } else if (is_class) {
+      if (!weak_self)
+        func_decorator = "final";
     } else {
       func_decorator = "mutating";
     }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -186,9 +186,8 @@ do {
         func_decorator = "final class";
       else
         func_decorator = "static";
-    } else if (is_class) {
-      if (!weak_self)
-        func_decorator = "final";
+    } else if (is_class && !weak_self) {
+      func_decorator = "final";
     } else {
       func_decorator = "mutating";
     }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -144,9 +144,13 @@ findSwiftSelf(StackFrame &frame, lldb::VariableSP self_var_sp) {
     info.is_metatype = true;
   }
 
+  info.swift_type = GetSwiftType(info.type).getPointer();
+  if (auto dyn_self =
+      llvm::dyn_cast_or_null<swift::DynamicSelfType>(info.swift_type))
+    info.swift_type = dyn_self->getSelfType().getPointer();
+
   // 5) If the adjusted type isn't equal to the type according to the runtime,
   // switch it to the latter type.
-  info.swift_type = GetSwiftType(info.type).getPointer();
   if (info.swift_type && (info.swift_type != info.type.GetOpaqueQualType()))
     info.type = ToCompilerType(info.swift_type);
 


### PR DESCRIPTION
Prevent conditional logic from falling through to adding the `mutating` keyword when evaluating Swift expressions inside of a a function whose `self` type is a dynamic `Self`.

After determining the type of self, resolve instances of `DynamicSelfType` to their self type. This allows consumers to properly determine when a type is a class, for example, which is not possible when using the dynamic self directly.
