### PR TITLE
lit: revert 134b103fc0f3a995d76398bf4b029d72bebe8162

### DIFF
--- a/llvm/utils/lit/lit/util.py
+++ b/llvm/utils/lit/lit/util.py
@@ -119,12 +119,6 @@ def usable_core_count():
         n = len(os.sched_getaffinity(0))
     except AttributeError:
         n = os.cpu_count() or 1
-
-    # On Windows, with more than 32 processes, process creation often fails with
-    # "Too many open files".  FIXME: Check if there's a better fix.
-    if platform.system() == 'Windows':
-        return min(n, 32)
-
     return n
 
 


### PR DESCRIPTION
Revert the 32-process cap on Windows.  When testing with Swift, we found
that there was a time reduction for testing with the higher load.  This
should hopefully not matter much in practice.  In the case that the
original problem with python remains with a high subprocess count, we
can easily revert this change.

(cherry picked from commit d319005a3746a7661c8c9a3302266b6ff7cf61be)