### PR TITLE
[lldb] Disable TestSwiftStepping on linux-aarch64

### DIFF
--- a/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
+++ b/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
@@ -25,6 +25,7 @@ class TestSwiftStepping(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @expectedFailureAll(oslist=['linux'], archs=['aarch64'], bugnumber="rdar://77785062")
     def test_swift_stepping(self):
         """Tests that we can step reliably in swift code."""
         self.build()


### PR DESCRIPTION
This test is currently failing, because lldb is breaking at the wrong line. To unblock building on linux-aarch64, we temporarily disable this test.

rdar://77785062