### PR TITLE
[lldb] Fix misleading indentation in ABISysV_x86_64.cpp

### DIFF
--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -70,6 +70,8 @@ option(LLDB_SKIP_STRIP "Whether to skip stripping of binaries when installing ll
 option(LLDB_ENABLE_SWIFT_SUPPORT "Enable swift support" ON)
 option(LLDB_USE_STATIC_BINDINGS "Use the static Python bindings." OFF)
 option(LLDB_ENABLE_WERROR "Fail and stop if a warning is triggered." ${LLVM_ENABLE_WERROR})
+check_cxx_compiler_flag("-Wmisleading-indentation" CXX_SUPPORTS_MISLEADING_INDENTATION)
+append_if(CXX_SUPPORTS_MISLEADING_INDENTATION "-Werror=misleading-indentation" CMAKE_CXX_FLAGS)
 if(LLDB_ENABLE_SWIFT_SUPPORT)
   add_definitions( -DLLDB_ENABLE_SWIFT )
 endif()

--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -70,8 +70,6 @@ option(LLDB_SKIP_STRIP "Whether to skip stripping of binaries when installing ll
 option(LLDB_ENABLE_SWIFT_SUPPORT "Enable swift support" ON)
 option(LLDB_USE_STATIC_BINDINGS "Use the static Python bindings." OFF)
 option(LLDB_ENABLE_WERROR "Fail and stop if a warning is triggered." ${LLVM_ENABLE_WERROR})
-check_cxx_compiler_flag("-Wmisleading-indentation" CXX_SUPPORTS_MISLEADING_INDENTATION)
-append_if(CXX_SUPPORTS_MISLEADING_INDENTATION "-Werror=misleading-indentation" CMAKE_CXX_FLAGS)
 if(LLDB_ENABLE_SWIFT_SUPPORT)
   add_definitions( -DLLDB_ENABLE_SWIFT )
 endif()

--- a/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
@@ -1147,14 +1147,14 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectImpl(
         }
 
         if (!already_copied) {
-        // These two tests are just sanity checks.  If I somehow get the type
-        // calculation wrong above it is better to just return nothing than to
-        // assert or crash.
-        if (!copy_from_extractor)
-          return return_valobj_sp;
-        if (copy_from_offset + field_byte_width >
-            copy_from_extractor->GetByteSize())
-          return return_valobj_sp;
+          // These two tests are just sanity checks.  If I somehow get the type
+          // calculation wrong above it is better to just return nothing than to
+          // assert or crash.
+          if (!copy_from_extractor)
+            return return_valobj_sp;
+          if (copy_from_offset + field_byte_width >
+              copy_from_extractor->GetByteSize())
+            return return_valobj_sp;
 
           copy_from_extractor->CopyByteOrderedData(
               copy_from_offset, field_byte_width,


### PR DESCRIPTION
Pre-emptive fix for [eventual use of](https://reviews.llvm.org/D102092) `-Wmisleading-indentation`.

See also https://github.com/apple/llvm-project/pull/2928.

(cherry picked from https://github.com/apple/llvm-project/pull/2935)
