### PR TITLE
[lldb] Add null checks to childAtPath helper function

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -60,12 +60,12 @@ enum class ThunkAction {
 static swift::Demangle::NodePointer
 childAtPath(swift::Demangle::NodePointer node,
             llvm::ArrayRef<swift::Demangle::Node::Kind> path) {
-  if (path.empty())
+  if (!node || path.empty())
     return node;
 
   auto current_step = path.front();
   for (auto *child : *node)
-    if (child->getKind() == current_step)
+    if (child && child->getKind() == current_step)
       return childAtPath(child, path.drop_front());
   return nullptr;
 }

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -60,7 +60,7 @@ enum class ThunkAction {
 static swift::Demangle::NodePointer
 childAtPath(swift::Demangle::NodePointer node,
             llvm::ArrayRef<swift::Demangle::Node::Kind> path) {
-  if (!node || !node->hasChildren() || path.empty())
+  if (!node || path.empty())
     return node;
 
   auto current_step = path.front();

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -60,7 +60,7 @@ enum class ThunkAction {
 static swift::Demangle::NodePointer
 childAtPath(swift::Demangle::NodePointer node,
             llvm::ArrayRef<swift::Demangle::Node::Kind> path) {
-  if (!node || path.empty())
+  if (!node || !node->hasChildren() || path.empty())
     return node;
 
   auto current_step = path.front();


### PR DESCRIPTION
Add conservative null checks to avoid expected input data.

rdar://77286761

(cherry picked from https://github.com/apple/llvm-project/pull/2944)
