### PR TITLE
[lldb] Skip TestSwiftReferenceStorageTypes on Linux when the architecture is AArch64 (swift/next)

### DIFF
--- a/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
+++ b/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
@@ -29,6 +29,7 @@ class TestSwiftReferenceStorageTypes(TestBase):
 
     @decorators.skipIf(archs=['ppc64le']) #SR-10215
     @swiftTest
+    @skipIf(oslist=["linux"], archs=['aarch64'], bugnumber="rdar://76592966")
     def test_swift_reference_storage_types(self):
         """Test weak, unowned and unmanaged types"""
         self.build()


### PR DESCRIPTION
(cherry picked from commit 109dde625a47ecfde7eea0b63c685c2f8d6d8fa5)