### PR TITLE
Use CXX_SOURCES and point to the right source file.

### DIFF
--- a/lldb/test/API/lang/cpp/break-on-initializers/Makefile
+++ b/lldb/test/API/lang/cpp/break-on-initializers/Makefile
@@ -1,4 +1,4 @@
-C_SOURCES := main.c
+CXX_SOURCES := main.cpp
 CXXFLAGS_EXTRAS := -std=c++11
 
 include Makefile.rules


### PR DESCRIPTION
Copy paste error, but the test still built on macOS.  Weird.
It failed on debian linux with an error about -fno-limit-debug-info
not being a supported flag???  Not sure how this goof would cause
that error, but let's see if it did...

(cherry picked from commit 98feb08e449f179c3c5ccc6878c31cf16c160b06)

---------

This fixes the respective test on the stable branch.