### PR TITLE
Cache the results of SwiftASTContext::GetCompileUnitImports()

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -8308,8 +8308,8 @@ bool SwiftASTContext::GetImplicitImports(
     llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
         &modules,
     Status &error) {
-  if (!GetCompileUnitImports(swift_ast_context, sc, stack_frame_wp, modules,
-                             error)) {
+  if (!swift_ast_context.GetCompileUnitImports(sc, stack_frame_wp, modules,
+                                               error)) {
     return false;
   }
 
@@ -8381,22 +8381,54 @@ bool SwiftASTContext::CacheUserImports(SwiftASTContext &swift_ast_context,
 }
 
 bool SwiftASTContext::GetCompileUnitImports(
-    SwiftASTContext &swift_ast_context, SymbolContext &sc,
-    lldb::StackFrameWP &stack_frame_wp,
+    SymbolContext &sc, lldb::StackFrameWP &stack_frame_wp,
     llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
         &modules,
     Status &error) {
+  return GetCompileUnitImportsImpl(sc, stack_frame_wp, &modules, error);
+}
+
+void SwiftASTContext::PerformCompileUnitImports(
+    SymbolContext &sc, lldb::StackFrameWP &stack_frame_wp, Status &error) {
+  GetCompileUnitImportsImpl(sc, stack_frame_wp, nullptr, error);
+}
+
+static std::pair<Module *, lldb::user_id_t>
+GetCUSignature(CompileUnit &compile_unit) {
+  return {compile_unit.GetModule().get(), compile_unit.GetID()};
+}
+
+bool SwiftASTContext::GetCompileUnitImportsImpl(
+    SymbolContext &sc, lldb::StackFrameWP &stack_frame_wp,
+    llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
+        *modules,
+    Status &error) {
+  CompileUnit *compile_unit = sc.comp_unit;
+  if (compile_unit)
+    // Check the cache if this compile unit's imports were previously
+    // requested.  If the caller didn't request the list of imported
+    // modules then there is nothing left to do for subsequent
+    // GetCompileUnitImportsImpl() calls as the previously loaded
+    // modules should still be loaded.  The fact the we
+    // unconditionally return true does not matter because the only
+    // way to get here is through void PerformCompileUnitImports(),
+    // which discards the return value.
+    if (!m_cu_imports.insert(GetCUSignature(*compile_unit)).second)
+      // List of imports isn't requested and we already processed this CU?
+      if (!modules)
+        return true;
+
   // Import the Swift standard library and its dependencies.
   SourceModule swift_module;
   swift_module.path.emplace_back("Swift");
   auto *stdlib =
-      LoadOneModule(swift_module, swift_ast_context, stack_frame_wp, error);
+      LoadOneModule(swift_module, *this, stack_frame_wp, error);
   if (!stdlib)
     return false;
 
-  modules.emplace_back(swift::ImportedModule(stdlib));
+  if (modules)
+    modules->emplace_back(swift::ImportedModule(stdlib));
 
-  CompileUnit *compile_unit = sc.comp_unit;
   if (!compile_unit || compile_unit->GetLanguage() != lldb::eLanguageTypeSwift)
     return true;
 
@@ -8411,11 +8443,12 @@ bool SwiftASTContext::GetCompileUnitImports(
       continue;
 
     auto *loaded_module =
-        LoadOneModule(module, swift_ast_context, stack_frame_wp, error);
+        LoadOneModule(module, *this, stack_frame_wp, error);
     if (!loaded_module)
       return false;
 
-    modules.emplace_back(swift::ImportedModule(loaded_module));
+    if (modules)
+      modules->emplace_back(swift::ImportedModule(loaded_module));
   }
   return true;
 }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2502,10 +2502,7 @@ llvm::Optional<SwiftASTContextReader> Target::GetScratchSwiftASTContext(
       !swift_ast_ctx->HasFatalErrors()) {
     StackFrameWP frame_wp(frame_sp);
     SymbolContext sc = frame_sp->GetSymbolContext(lldb::eSymbolContextEverything);
-    llvm::SmallVector<swift::AttributedImport<swift::ImportedModule>, 16>
-        modules;
-    swift_ast_ctx->GetCompileUnitImports(*swift_ast_ctx, sc, frame_wp, modules,
-                                         error);
+    swift_ast_ctx->PerformCompileUnitImports(sc, frame_wp, error);
   }
 
   if (!swift_ast_ctx)


### PR DESCRIPTION
Every time a scratch context is requested, a call to
GetCompileUnitImports() is made, which is both expensive and
redundant. This patch adds a cache that keeps track of compile units
for which the imports were already performed. This results in a
measurable performance improvement on the LLDB test suite.

rdar://75381959
(cherry picked from commit 7b1707adbe47125f8c255eff27e20ed761cb8602)

 Conflicts:
	lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h