### PR TITLE
Get more info if lldbutil.run_to_XXX_breakpoint doesn't hit the break…

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -878,7 +878,19 @@ def run_to_breakpoint_do_run(test, target, bkpt, launch_info = None,
     test.assertFalse(error.Fail(),
                      "Process launch failed: %s" % (error.GetCString()))
 
-    test.assertEqual(process.GetState(), lldb.eStateStopped)
+    if process.GetState() == lldb.eStateRunning:
+        # If we get here with eStateRunning, it means we missed the
+        # initial breakpoint. Figure out where the process is
+        # so we can report that:
+        error = lldb.SBError()
+        error = process.Stop()
+        if not error.Success():
+            test.fail("Failed to stop: %s"%(error.GetCString()))
+
+        error_string = "Failed to hit initial breakpoint:\n%s\n"%(print_stacktraces(process, True))
+        test.fail(error_string)
+
+    test.assertEqual(process.GetState(), lldb.eStateStopped, error_string)
 
     # Frame #0 should be at our breakpoint.
     threads = get_threads_stopped_at_breakpoint(


### PR DESCRIPTION
…point.

We interrupt the process.  If that fails, we report the error.  If it
stops the process successfully, we print the stacktraces for all the
threads in the inferior so we can see whether it overshot the breakpoint,
or stalled before getting to it, etc...

The bots are showing a failure in TestSwiftDeploymentTarget.py.  The error is that the process state in lldbutil.run_to_source_breakpoint is "eStateRunning".  I can't repro the problem, so I need to get more info
from the merge bot about where the process actually is.