### PR TITLE
[lldb] Rename test classes to correct name (swift/next)

### DIFF
--- a/lldb/test/API/lang/swift/tagged_pointer/TestSwiftTaggedPointer.py
+++ b/lldb/test/API/lang/swift/tagged_pointer/TestSwiftTaggedPointer.py
@@ -4,7 +4,7 @@ import lldbsuite.test.lldbtest as lldbtest
 import lldbsuite.test.lldbutil as lldbutil
 import unittest2
 
-class TestSwiftAnyType(lldbtest.TestBase):
+class TestSwiftTaggedPointer(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 

--- a/lldb/test/API/lang/swift/union/TestSwiftCUnion.py
+++ b/lldb/test/API/lang/swift/union/TestSwiftCUnion.py
@@ -6,7 +6,7 @@ import os
 import unittest2
 
 
-class TestSwiftAnyType(lldbtest.TestBase):
+class TestSwiftCUnion(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 


### PR DESCRIPTION
(cherry picked from commit 780850cc4d8c5c1d341aa861d3e19b9c00a91306)