### PR TITLE
Revert "Add an "interrupt timeout" to Process, and pipe that through …

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -93,7 +93,6 @@ public:
   bool GetWarningsUnsupportedLanguage() const;
   bool GetStopOnExec() const;
   std::chrono::seconds GetUtilityExpressionTimeout() const;
-  std::chrono::seconds GetInterruptTimeout() const;
   bool GetOSPluginReportsAllThreads() const;
   void SetOSPluginReportsAllThreads(bool does_report);
   bool GetSteppingRunsAllThreads() const;

--- a/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.cpp
+++ b/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.cpp
@@ -736,8 +736,8 @@ const UnixSignalsSP &PlatformRemoteGDBServer::GetRemoteUnixSignals() {
   m_remote_signals_sp = UnixSignals::Create(GetRemoteSystemArchitecture());
 
   StringExtractorGDBRemote response;
-  auto result =
-      m_gdb_client.SendPacketAndWaitForResponse("jSignalsInfo", response);
+  auto result = m_gdb_client.SendPacketAndWaitForResponse("jSignalsInfo",
+                                                          response, false);
 
   if (result != decltype(result)::Success ||
       response.GetResponseType() != response.eResponse)

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteClientBase.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteClientBase.cpp
@@ -20,10 +20,7 @@ using namespace lldb_private;
 using namespace lldb_private::process_gdb_remote;
 using namespace std::chrono;
 
-// When we've sent a continue packet and are waiting for the target to stop,
-// we wake up the wait with this interval to make sure the stub hasn't gone
-// away while we were waiting.
-static const seconds kWakeupInterval(5);
+static const seconds kInterruptTimeout(5);
 
 /////////////////////////
 // GDBRemoteClientBase //
@@ -38,8 +35,7 @@ GDBRemoteClientBase::GDBRemoteClientBase(const char *comm_name,
 
 StateType GDBRemoteClientBase::SendContinuePacketAndWaitForResponse(
     ContinueDelegate &delegate, const UnixSignals &signals,
-    llvm::StringRef payload, std::chrono::seconds interrupt_timeout,
-    StringExtractorGDBRemote &response) {
+    llvm::StringRef payload, StringExtractorGDBRemote &response) {
   Log *log(ProcessGDBRemoteLog::GetLogIfAllCategoriesSet(GDBR_LOG_PROCESS));
   response.Clear();
 
@@ -52,34 +48,16 @@ StateType GDBRemoteClientBase::SendContinuePacketAndWaitForResponse(
   if (!cont_lock)
     return eStateInvalid;
   OnRunPacketSent(true);
-  // The main ReadPacket loop wakes up at computed_timeout intervals, just to 
-  // check that the connection hasn't dropped.  When we wake up we also check
-  // whether there is an interrupt request that has reached its endpoint.
-  // If we want a shorter interrupt timeout that kWakeupInterval, we need to 
-  // choose the shorter interval for the wake up as well.
-  std::chrono::seconds computed_timeout = std::min(interrupt_timeout, 
-                                                   kWakeupInterval);
+
   for (;;) {
-    PacketResult read_result = ReadPacket(response, computed_timeout, false);
+    PacketResult read_result = ReadPacket(response, kInterruptTimeout, false);
     switch (read_result) {
     case PacketResult::ErrorReplyTimeout: {
       std::lock_guard<std::mutex> lock(m_mutex);
-      if (m_async_count == 0) {
+      if (m_async_count == 0)
         continue;
-      }
-      auto cur_time = steady_clock::now();
-      if (cur_time >= m_interrupt_endpoint)
+      if (steady_clock::now() >= m_interrupt_time + kInterruptTimeout)
         return eStateInvalid;
-      else {
-        // We woke up and found an interrupt is in flight, but we haven't
-        // exceeded the interrupt wait time.  So reset the wait time to the
-        // time left till the interrupt timeout.  But don't wait longer
-        // than our wakeup timeout.
-        auto new_wait = m_interrupt_endpoint - cur_time;
-        computed_timeout = std::min(kWakeupInterval,
-            std::chrono::duration_cast<std::chrono::seconds>(new_wait));
-        continue;
-      }
       break;
     }
     case PacketResult::Success:
@@ -155,9 +133,8 @@ StateType GDBRemoteClientBase::SendContinuePacketAndWaitForResponse(
   }
 }
 
-bool GDBRemoteClientBase::SendAsyncSignal(
-    int signo, std::chrono::seconds interrupt_timeout) {
-  Lock lock(*this, interrupt_timeout);
+bool GDBRemoteClientBase::SendAsyncSignal(int signo) {
+  Lock lock(*this, true);
   if (!lock || !lock.DidInterrupt())
     return false;
 
@@ -167,26 +144,25 @@ bool GDBRemoteClientBase::SendAsyncSignal(
   return true;
 }
 
-bool GDBRemoteClientBase::Interrupt(std::chrono::seconds interrupt_timeout) {
-  Lock lock(*this, interrupt_timeout);
+bool GDBRemoteClientBase::Interrupt() {
+  Lock lock(*this, true);
   if (!lock.DidInterrupt())
     return false;
   m_should_stop = true;
   return true;
 }
-
 GDBRemoteCommunication::PacketResult
 GDBRemoteClientBase::SendPacketAndWaitForResponse(
     llvm::StringRef payload, StringExtractorGDBRemote &response,
-    std::chrono::seconds interrupt_timeout) {
-  Lock lock(*this, interrupt_timeout);
+    bool send_async) {
+  Lock lock(*this, send_async);
   if (!lock) {
     if (Log *log =
             ProcessGDBRemoteLog::GetLogIfAllCategoriesSet(GDBR_LOG_PROCESS))
       LLDB_LOGF(log,
                 "GDBRemoteClientBase::%s failed to get mutex, not sending "
-                "packet '%.*s'",
-                __FUNCTION__, int(payload.size()), payload.data());
+                "packet '%.*s' (send_async=%d)",
+                __FUNCTION__, int(payload.size()), payload.data(), send_async);
     return PacketResult::ErrorSendFailed;
   }
 
@@ -196,16 +172,16 @@ GDBRemoteClientBase::SendPacketAndWaitForResponse(
 GDBRemoteCommunication::PacketResult
 GDBRemoteClientBase::SendPacketAndReceiveResponseWithOutputSupport(
     llvm::StringRef payload, StringExtractorGDBRemote &response,
-    std::chrono::seconds interrupt_timeout,
+    bool send_async,
     llvm::function_ref<void(llvm::StringRef)> output_callback) {
-  Lock lock(*this, interrupt_timeout);
+  Lock lock(*this, send_async);
   if (!lock) {
     if (Log *log =
             ProcessGDBRemoteLog::GetLogIfAllCategoriesSet(GDBR_LOG_PROCESS))
       LLDB_LOGF(log,
                 "GDBRemoteClientBase::%s failed to get mutex, not sending "
-                "packet '%.*s'",
-                __FUNCTION__, int(payload.size()), payload.data());
+                "packet '%.*s' (send_async=%d)",
+                __FUNCTION__, int(payload.size()), payload.data(), send_async);
     return PacketResult::ErrorSendFailed;
   }
 
@@ -246,14 +222,13 @@ GDBRemoteClientBase::SendPacketAndWaitForResponseNoLock(
   return packet_result;
 }
 
-bool GDBRemoteClientBase::SendvContPacket(
-    llvm::StringRef payload, std::chrono::seconds interrupt_timeout,
-    StringExtractorGDBRemote &response) {
+bool GDBRemoteClientBase::SendvContPacket(llvm::StringRef payload,
+                                          StringExtractorGDBRemote &response) {
   Log *log(ProcessGDBRemoteLog::GetLogIfAllCategoriesSet(GDBR_LOG_PROCESS));
   LLDB_LOGF(log, "GDBRemoteCommunicationClient::%s ()", __FUNCTION__);
 
   // we want to lock down packet sending while we continue
-  Lock lock(*this, interrupt_timeout);
+  Lock lock(*this, true);
 
   LLDB_LOGF(log,
             "GDBRemoteCommunicationClient::%s () sending vCont packet: %.*s",
@@ -361,20 +336,18 @@ GDBRemoteClientBase::ContinueLock::lock() {
 // GDBRemoteClientBase::Lock //
 ///////////////////////////////
 
-GDBRemoteClientBase::Lock::Lock(GDBRemoteClientBase &comm,
-                                std::chrono::seconds interrupt_timeout)
+GDBRemoteClientBase::Lock::Lock(GDBRemoteClientBase &comm, bool interrupt)
     : m_async_lock(comm.m_async_mutex, std::defer_lock), m_comm(comm),
-      m_interrupt_timeout(interrupt_timeout), m_acquired(false),
-      m_did_interrupt(false) {
-  SyncWithContinueThread();
+      m_acquired(false), m_did_interrupt(false) {
+  SyncWithContinueThread(interrupt);
   if (m_acquired)
     m_async_lock.lock();
 }
 
-void GDBRemoteClientBase::Lock::SyncWithContinueThread() {
+void GDBRemoteClientBase::Lock::SyncWithContinueThread(bool interrupt) {
   Log *log(ProcessGDBRemoteLog::GetLogIfAllCategoriesSet(GDBR_LOG_PROCESS));
   std::unique_lock<std::mutex> lock(m_comm.m_mutex);
-  if (m_comm.m_is_running && m_interrupt_timeout == std::chrono::seconds(0))
+  if (m_comm.m_is_running && !interrupt)
     return; // We were asked to avoid interrupting the sender. Lock is not
             // acquired.
 
@@ -392,9 +365,9 @@ void GDBRemoteClientBase::Lock::SyncWithContinueThread() {
                        "interrupt packet");
         return;
       }
-      m_comm.m_interrupt_endpoint = steady_clock::now() + m_interrupt_timeout;
       if (log)
         log->PutCString("GDBRemoteClientBase::Lock::Lock sent packet: \\x03");
+      m_comm.m_interrupt_time = steady_clock::now();
     }
     m_comm.m_cv.wait(lock, [this] { return !m_comm.m_is_running; });
     m_did_interrupt = true;

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -218,7 +218,7 @@ bool GDBRemoteCommunicationClient::QueryNoAckModeSupported() {
     ScopedTimeout timeout(*this, std::max(GetPacketTimeout(), seconds(6)));
 
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse("QStartNoAckMode", response) ==
+    if (SendPacketAndWaitForResponse("QStartNoAckMode", response, false) ==
         PacketResult::Success) {
       if (response.IsOKResponse()) {
         m_send_acks = false;
@@ -235,8 +235,8 @@ void GDBRemoteCommunicationClient::GetListThreadsInStopReplySupported() {
     m_supports_threads_in_stop_reply = eLazyBoolNo;
 
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse("QListThreadsInStopReply", response) ==
-        PacketResult::Success) {
+    if (SendPacketAndWaitForResponse("QListThreadsInStopReply", response,
+                                     false) == PacketResult::Success) {
       if (response.IsOKResponse())
         m_supports_threads_in_stop_reply = eLazyBoolYes;
     }
@@ -248,8 +248,8 @@ bool GDBRemoteCommunicationClient::GetVAttachOrWaitSupported() {
     m_attach_or_wait_reply = eLazyBoolNo;
 
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse("qVAttachOrWaitSupported", response) ==
-        PacketResult::Success) {
+    if (SendPacketAndWaitForResponse("qVAttachOrWaitSupported", response,
+                                     false) == PacketResult::Success) {
       if (response.IsOKResponse())
         m_attach_or_wait_reply = eLazyBoolYes;
     }
@@ -262,8 +262,8 @@ bool GDBRemoteCommunicationClient::GetSyncThreadStateSupported() {
     m_prepare_for_reg_writing_reply = eLazyBoolNo;
 
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse("qSyncThreadStateSupported", response) ==
-        PacketResult::Success) {
+    if (SendPacketAndWaitForResponse("qSyncThreadStateSupported", response,
+                                     false) == PacketResult::Success) {
       if (response.IsOKResponse())
         m_prepare_for_reg_writing_reply = eLazyBoolYes;
     }
@@ -355,7 +355,8 @@ void GDBRemoteCommunicationClient::GetRemoteQSupported() {
   }
 
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(packet.GetString(), response) ==
+  if (SendPacketAndWaitForResponse(packet.GetString(), response,
+                                   /*send_async=*/false) ==
       PacketResult::Success) {
     const char *response_cstr = response.GetStringRef().data();
 
@@ -452,8 +453,8 @@ bool GDBRemoteCommunicationClient::GetThreadSuffixSupported() {
   if (m_supports_thread_suffix == eLazyBoolCalculate) {
     StringExtractorGDBRemote response;
     m_supports_thread_suffix = eLazyBoolNo;
-    if (SendPacketAndWaitForResponse("QThreadSuffixSupported", response) ==
-        PacketResult::Success) {
+    if (SendPacketAndWaitForResponse("QThreadSuffixSupported", response,
+                                     false) == PacketResult::Success) {
       if (response.IsOKResponse())
         m_supports_thread_suffix = eLazyBoolYes;
     }
@@ -469,7 +470,7 @@ bool GDBRemoteCommunicationClient::GetVContSupported(char flavor) {
     m_supports_vCont_C = eLazyBoolNo;
     m_supports_vCont_s = eLazyBoolNo;
     m_supports_vCont_S = eLazyBoolNo;
-    if (SendPacketAndWaitForResponse("vCont?", response) ==
+    if (SendPacketAndWaitForResponse("vCont?", response, false) ==
         PacketResult::Success) {
       const char *response_cstr = response.GetStringRef().data();
       if (::strstr(response_cstr, ";c"))
@@ -521,9 +522,9 @@ bool GDBRemoteCommunicationClient::GetVContSupported(char flavor) {
 
 GDBRemoteCommunication::PacketResult
 GDBRemoteCommunicationClient::SendThreadSpecificPacketAndWaitForResponse(
-    lldb::tid_t tid, StreamString &&payload,
-    StringExtractorGDBRemote &response) {
-  Lock lock(*this);
+    lldb::tid_t tid, StreamString &&payload, StringExtractorGDBRemote &response,
+    bool send_async) {
+  Lock lock(*this, send_async);
   if (!lock) {
     if (Log *log = ProcessGDBRemoteLog::GetLogIfAnyCategoryIsSet(
             GDBR_LOG_PROCESS | GDBR_LOG_PACKETS))
@@ -560,7 +561,7 @@ LazyBool GDBRemoteCommunicationClient::GetThreadPacketSupported(
   payload.PutCString(packetStr);
   StringExtractorGDBRemote response;
   if (SendThreadSpecificPacketAndWaitForResponse(
-          tid, std::move(payload), response) == PacketResult::Success &&
+          tid, std::move(payload), response, false) == PacketResult::Success &&
       response.IsNormalResponse()) {
     return eLazyBoolYes;
   }
@@ -574,7 +575,7 @@ StructuredData::ObjectSP GDBRemoteCommunicationClient::GetThreadsInfo() {
   if (m_supports_jThreadsInfo) {
     StringExtractorGDBRemote response;
     response.SetResponseValidatorToJSON();
-    if (SendPacketAndWaitForResponse("jThreadsInfo", response) ==
+    if (SendPacketAndWaitForResponse("jThreadsInfo", response, false) ==
         PacketResult::Success) {
       if (response.IsUnsupportedResponse()) {
         m_supports_jThreadsInfo = false;
@@ -591,7 +592,7 @@ bool GDBRemoteCommunicationClient::GetThreadExtendedInfoSupported() {
   if (m_supports_jThreadExtendedInfo == eLazyBoolCalculate) {
     StringExtractorGDBRemote response;
     m_supports_jThreadExtendedInfo = eLazyBoolNo;
-    if (SendPacketAndWaitForResponse("jThreadExtendedInfo:", response) ==
+    if (SendPacketAndWaitForResponse("jThreadExtendedInfo:", response, false) ==
         PacketResult::Success) {
       if (response.IsOKResponse()) {
         m_supports_jThreadExtendedInfo = eLazyBoolYes;
@@ -607,7 +608,7 @@ void GDBRemoteCommunicationClient::EnableErrorStringInPacket() {
     // We try to enable error strings in remote packets but if we fail, we just
     // work in the older way.
     m_supports_error_string_reply = eLazyBoolNo;
-    if (SendPacketAndWaitForResponse("QEnableErrorStrings", response) ==
+    if (SendPacketAndWaitForResponse("QEnableErrorStrings", response, false) ==
         PacketResult::Success) {
       if (response.IsOKResponse()) {
         m_supports_error_string_reply = eLazyBoolYes;
@@ -621,7 +622,8 @@ bool GDBRemoteCommunicationClient::GetLoadedDynamicLibrariesInfosSupported() {
     StringExtractorGDBRemote response;
     m_supports_jLoadedDynamicLibrariesInfos = eLazyBoolNo;
     if (SendPacketAndWaitForResponse("jGetLoadedDynamicLibrariesInfos:",
-                                     response) == PacketResult::Success) {
+                                     response,
+                                     false) == PacketResult::Success) {
       if (response.IsOKResponse()) {
         m_supports_jLoadedDynamicLibrariesInfos = eLazyBoolYes;
       }
@@ -634,7 +636,7 @@ bool GDBRemoteCommunicationClient::GetSharedCacheInfoSupported() {
   if (m_supports_jGetSharedCacheInfo == eLazyBoolCalculate) {
     StringExtractorGDBRemote response;
     m_supports_jGetSharedCacheInfo = eLazyBoolNo;
-    if (SendPacketAndWaitForResponse("jGetSharedCacheInfo:", response) ==
+    if (SendPacketAndWaitForResponse("jGetSharedCacheInfo:", response, false) ==
         PacketResult::Success) {
       if (response.IsOKResponse()) {
         m_supports_jGetSharedCacheInfo = eLazyBoolYes;
@@ -650,7 +652,7 @@ bool GDBRemoteCommunicationClient::GetxPacketSupported() {
     m_supports_x = eLazyBoolNo;
     char packet[256];
     snprintf(packet, sizeof(packet), "x0,0");
-    if (SendPacketAndWaitForResponse(packet, response) ==
+    if (SendPacketAndWaitForResponse(packet, response, false) ==
         PacketResult::Success) {
       if (response.IsOKResponse())
         m_supports_x = eLazyBoolYes;
@@ -662,7 +664,7 @@ bool GDBRemoteCommunicationClient::GetxPacketSupported() {
 GDBRemoteCommunicationClient::PacketResult
 GDBRemoteCommunicationClient::SendPacketsAndConcatenateResponses(
     const char *payload_prefix, std::string &response_string) {
-  Lock lock(*this);
+  Lock lock(*this, false);
   if (!lock) {
     Log *log(ProcessGDBRemoteLog::GetLogIfAnyCategoryIsSet(GDBR_LOG_PROCESS |
                                                            GDBR_LOG_PACKETS));
@@ -723,7 +725,8 @@ lldb::pid_t GDBRemoteCommunicationClient::GetCurrentProcessID(bool allow_lazy) {
     // the thread id, which newer debugserver and lldb-gdbserver stubs return
     // correctly.
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse("qC", response) == PacketResult::Success) {
+    if (SendPacketAndWaitForResponse("qC", response, false) ==
+        PacketResult::Success) {
       if (response.GetChar() == 'Q') {
         if (response.GetChar() == 'C') {
           m_curr_pid = response.GetHexMaxU32(false, LLDB_INVALID_PROCESS_ID);
@@ -756,7 +759,7 @@ lldb::pid_t GDBRemoteCommunicationClient::GetCurrentProcessID(bool allow_lazy) {
 bool GDBRemoteCommunicationClient::GetLaunchSuccess(std::string &error_str) {
   error_str.clear();
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse("qLaunchSuccess", response) ==
+  if (SendPacketAndWaitForResponse("qLaunchSuccess", response, false) ==
       PacketResult::Success) {
     if (response.IsOKResponse())
       return true;
@@ -810,7 +813,7 @@ int GDBRemoteCommunicationClient::SendArgumentsPacket(
     }
 
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse(packet.GetString(), response) ==
+    if (SendPacketAndWaitForResponse(packet.GetString(), response, false) ==
         PacketResult::Success) {
       if (response.IsOKResponse())
         return 0;
@@ -860,7 +863,7 @@ int GDBRemoteCommunicationClient::SendEnvironmentPacket(
       if (m_supports_QEnvironmentHexEncoded) {
         packet.PutCString("QEnvironmentHexEncoded:");
         packet.PutBytesAsRawHex8(name_equal_value, strlen(name_equal_value));
-        if (SendPacketAndWaitForResponse(packet.GetString(), response) ==
+        if (SendPacketAndWaitForResponse(packet.GetString(), response, false) ==
             PacketResult::Success) {
           if (response.IsOKResponse())
             return 0;
@@ -874,7 +877,7 @@ int GDBRemoteCommunicationClient::SendEnvironmentPacket(
 
     } else if (m_supports_QEnvironment) {
       packet.Printf("QEnvironment:%s", name_equal_value);
-      if (SendPacketAndWaitForResponse(packet.GetString(), response) ==
+      if (SendPacketAndWaitForResponse(packet.GetString(), response, false) ==
           PacketResult::Success) {
         if (response.IsOKResponse())
           return 0;
@@ -894,7 +897,7 @@ int GDBRemoteCommunicationClient::SendLaunchArchPacket(char const *arch) {
     StreamString packet;
     packet.Printf("QLaunchArch:%s", arch);
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse(packet.GetString(), response) ==
+    if (SendPacketAndWaitForResponse(packet.GetString(), response, false) ==
         PacketResult::Success) {
       if (response.IsOKResponse())
         return 0;
@@ -912,7 +915,7 @@ int GDBRemoteCommunicationClient::SendLaunchEventDataPacket(
     StreamString packet;
     packet.Printf("QSetProcessEvent:%s", data);
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse(packet.GetString(), response) ==
+    if (SendPacketAndWaitForResponse(packet.GetString(), response, false) ==
         PacketResult::Success) {
       if (response.IsOKResponse()) {
         if (was_supported)
@@ -997,7 +1000,7 @@ bool GDBRemoteCommunicationClient::GetGDBServerVersion() {
     m_qGDBServerVersion_is_valid = eLazyBoolNo;
 
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse("qGDBServerVersion", response) ==
+    if (SendPacketAndWaitForResponse("qGDBServerVersion", response, false) ==
         PacketResult::Success) {
       if (response.IsNormalResponse()) {
         llvm::StringRef name, value;
@@ -1089,7 +1092,7 @@ void GDBRemoteCommunicationClient::MaybeEnableCompression(
   if (avail_type != CompressionType::None) {
     StringExtractorGDBRemote response;
     std::string packet = "QEnableCompression:type:" + avail_name + ";";
-    if (SendPacketAndWaitForResponse(packet, response) !=
+    if (SendPacketAndWaitForResponse(packet, response, false) !=
         PacketResult::Success)
       return;
 
@@ -1115,7 +1118,8 @@ uint32_t GDBRemoteCommunicationClient::GetGDBServerProgramVersion() {
 
 bool GDBRemoteCommunicationClient::GetDefaultThreadId(lldb::tid_t &tid) {
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse("qC", response) != PacketResult::Success)
+  if (SendPacketAndWaitForResponse("qC", response, false) !=
+      PacketResult::Success)
     return false;
 
   if (!response.IsNormalResponse())
@@ -1150,7 +1154,7 @@ bool GDBRemoteCommunicationClient::GetHostInfo(bool force) {
     ScopedTimeout timeout(*this, seconds(10));
     m_qHostInfo_is_valid = eLazyBoolNo;
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse("qHostInfo", response) ==
+    if (SendPacketAndWaitForResponse("qHostInfo", response, false) ==
         PacketResult::Success) {
       if (response.IsNormalResponse()) {
         llvm::StringRef name;
@@ -1340,7 +1344,7 @@ int GDBRemoteCommunicationClient::SendAttach(
         ::snprintf(packet, sizeof(packet), "vAttach;%" PRIx64, pid);
     UNUSED_IF_ASSERT_DISABLED(packet_len);
     assert(packet_len < (int)sizeof(packet));
-    if (SendPacketAndWaitForResponse(packet, response) ==
+    if (SendPacketAndWaitForResponse(packet, response, false) ==
         PacketResult::Success) {
       if (response.IsErrorResponse())
         return response.GetError();
@@ -1356,7 +1360,7 @@ int GDBRemoteCommunicationClient::SendStdinNotification(const char *data,
   packet.PutCString("I");
   packet.PutBytesAsRawHex8(data, data_len);
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(packet.GetString(), response) ==
+  if (SendPacketAndWaitForResponse(packet.GetString(), response, false) ==
       PacketResult::Success) {
     return 0;
   }
@@ -1389,7 +1393,7 @@ addr_t GDBRemoteCommunicationClient::AllocateMemory(size_t size,
     assert(packet_len < (int)sizeof(packet));
     UNUSED_IF_ASSERT_DISABLED(packet_len);
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse(packet, response) ==
+    if (SendPacketAndWaitForResponse(packet, response, false) ==
         PacketResult::Success) {
       if (response.IsUnsupportedResponse())
         m_supports_alloc_dealloc_memory = eLazyBoolNo;
@@ -1411,7 +1415,7 @@ bool GDBRemoteCommunicationClient::DeallocateMemory(addr_t addr) {
     assert(packet_len < (int)sizeof(packet));
     UNUSED_IF_ASSERT_DISABLED(packet_len);
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse(packet, response) ==
+    if (SendPacketAndWaitForResponse(packet, response, false) ==
         PacketResult::Success) {
       if (response.IsUnsupportedResponse())
         m_supports_alloc_dealloc_memory = eLazyBoolNo;
@@ -1435,7 +1439,7 @@ Status GDBRemoteCommunicationClient::Detach(bool keep_stopped) {
       assert(packet_len < (int)sizeof(packet));
       UNUSED_IF_ASSERT_DISABLED(packet_len);
       StringExtractorGDBRemote response;
-      if (SendPacketAndWaitForResponse(packet, response) ==
+      if (SendPacketAndWaitForResponse(packet, response, false) ==
               PacketResult::Success &&
           response.IsOKResponse()) {
         m_supports_detach_stay_stopped = eLazyBoolYes;
@@ -1449,13 +1453,15 @@ Status GDBRemoteCommunicationClient::Detach(bool keep_stopped) {
       return error;
     } else {
       StringExtractorGDBRemote response;
-      PacketResult packet_result = SendPacketAndWaitForResponse("D1", response);
+      PacketResult packet_result =
+          SendPacketAndWaitForResponse("D1", response, false);
       if (packet_result != PacketResult::Success)
         error.SetErrorString("Sending extended disconnect packet failed.");
     }
   } else {
     StringExtractorGDBRemote response;
-    PacketResult packet_result = SendPacketAndWaitForResponse("D", response);
+    PacketResult packet_result =
+        SendPacketAndWaitForResponse("D", response, false);
     if (packet_result != PacketResult::Success)
       error.SetErrorString("Sending disconnect packet failed.");
   }
@@ -1475,7 +1481,7 @@ Status GDBRemoteCommunicationClient::GetMemoryRegionInfo(
     assert(packet_len < (int)sizeof(packet));
     UNUSED_IF_ASSERT_DISABLED(packet_len);
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse(packet, response) ==
+    if (SendPacketAndWaitForResponse(packet, response, false) ==
             PacketResult::Success &&
         response.GetResponseType() == StringExtractorGDBRemote::eResponse) {
       llvm::StringRef name;
@@ -1712,8 +1718,8 @@ Status GDBRemoteCommunicationClient::GetWatchpointSupportInfo(uint32_t &num) {
   num = 0;
   if (m_supports_watchpoint_support_info != eLazyBoolNo) {
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse("qWatchpointSupportInfo:", response) ==
-        PacketResult::Success) {
+    if (SendPacketAndWaitForResponse("qWatchpointSupportInfo:", response,
+                                     false) == PacketResult::Success) {
       m_supports_watchpoint_support_info = eLazyBoolYes;
       llvm::StringRef name;
       llvm::StringRef value;
@@ -1781,7 +1787,7 @@ int GDBRemoteCommunicationClient::SetSTDIN(const FileSpec &file_spec) {
     packet.PutStringAsRawHex8(path);
 
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse(packet.GetString(), response) ==
+    if (SendPacketAndWaitForResponse(packet.GetString(), response, false) ==
         PacketResult::Success) {
       if (response.IsOKResponse())
         return 0;
@@ -1801,7 +1807,7 @@ int GDBRemoteCommunicationClient::SetSTDOUT(const FileSpec &file_spec) {
     packet.PutStringAsRawHex8(path);
 
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse(packet.GetString(), response) ==
+    if (SendPacketAndWaitForResponse(packet.GetString(), response, false) ==
         PacketResult::Success) {
       if (response.IsOKResponse())
         return 0;
@@ -1821,7 +1827,7 @@ int GDBRemoteCommunicationClient::SetSTDERR(const FileSpec &file_spec) {
     packet.PutStringAsRawHex8(path);
 
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse(packet.GetString(), response) ==
+    if (SendPacketAndWaitForResponse(packet.GetString(), response, false) ==
         PacketResult::Success) {
       if (response.IsOKResponse())
         return 0;
@@ -1835,7 +1841,7 @@ int GDBRemoteCommunicationClient::SetSTDERR(const FileSpec &file_spec) {
 
 bool GDBRemoteCommunicationClient::GetWorkingDir(FileSpec &working_dir) {
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse("qGetWorkingDir", response) ==
+  if (SendPacketAndWaitForResponse("qGetWorkingDir", response, false) ==
       PacketResult::Success) {
     if (response.IsUnsupportedResponse())
       return false;
@@ -1857,7 +1863,7 @@ int GDBRemoteCommunicationClient::SetWorkingDir(const FileSpec &working_dir) {
     packet.PutStringAsRawHex8(path);
 
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse(packet.GetString(), response) ==
+    if (SendPacketAndWaitForResponse(packet.GetString(), response, false) ==
         PacketResult::Success) {
       if (response.IsOKResponse())
         return 0;
@@ -1876,7 +1882,8 @@ int GDBRemoteCommunicationClient::SetDisableASLR(bool enable) {
   assert(packet_len < (int)sizeof(packet));
   UNUSED_IF_ASSERT_DISABLED(packet_len);
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(packet, response) == PacketResult::Success) {
+  if (SendPacketAndWaitForResponse(packet, response, false) ==
+      PacketResult::Success) {
     if (response.IsOKResponse())
       return 0;
     uint8_t error = response.GetError();
@@ -1893,7 +1900,8 @@ int GDBRemoteCommunicationClient::SetDetachOnError(bool enable) {
   assert(packet_len < (int)sizeof(packet));
   UNUSED_IF_ASSERT_DISABLED(packet_len);
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(packet, response) == PacketResult::Success) {
+  if (SendPacketAndWaitForResponse(packet, response, false) ==
+      PacketResult::Success) {
     if (response.IsOKResponse())
       return 0;
     uint8_t error = response.GetError();
@@ -2011,7 +2019,7 @@ bool GDBRemoteCommunicationClient::GetProcessInfo(
     assert(packet_len < (int)sizeof(packet));
     UNUSED_IF_ASSERT_DISABLED(packet_len);
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse(packet, response) ==
+    if (SendPacketAndWaitForResponse(packet, response, false) ==
         PacketResult::Success) {
       return DecodeProcessInfoResponse(response, process_info);
     } else {
@@ -2036,7 +2044,7 @@ bool GDBRemoteCommunicationClient::GetCurrentProcessInfo(bool allow_lazy) {
   GetHostInfo();
 
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse("qProcessInfo", response) ==
+  if (SendPacketAndWaitForResponse("qProcessInfo", response, false) ==
       PacketResult::Success) {
     if (response.IsNormalResponse()) {
       llvm::StringRef name;
@@ -2232,7 +2240,7 @@ uint32_t GDBRemoteCommunicationClient::FindProcesses(
     // Increase timeout as the first qfProcessInfo packet takes a long time on
     // Android. The value of 1min was arrived at empirically.
     ScopedTimeout timeout(*this, minutes(1));
-    if (SendPacketAndWaitForResponse(packet.GetString(), response) ==
+    if (SendPacketAndWaitForResponse(packet.GetString(), response, false) ==
         PacketResult::Success) {
       do {
         ProcessInstanceInfo process_info;
@@ -2240,7 +2248,7 @@ uint32_t GDBRemoteCommunicationClient::FindProcesses(
           break;
         process_infos.push_back(process_info);
         response = StringExtractorGDBRemote();
-      } while (SendPacketAndWaitForResponse("qsProcessInfo", response) ==
+      } while (SendPacketAndWaitForResponse("qsProcessInfo", response, false) ==
                PacketResult::Success);
     } else {
       m_supports_qfProcessInfo = false;
@@ -2259,7 +2267,7 @@ bool GDBRemoteCommunicationClient::GetUserName(uint32_t uid,
     assert(packet_len < (int)sizeof(packet));
     UNUSED_IF_ASSERT_DISABLED(packet_len);
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse(packet, response) ==
+    if (SendPacketAndWaitForResponse(packet, response, false) ==
         PacketResult::Success) {
       if (response.IsNormalResponse()) {
         // Make sure we parsed the right number of characters. The response is
@@ -2286,7 +2294,7 @@ bool GDBRemoteCommunicationClient::GetGroupName(uint32_t gid,
     assert(packet_len < (int)sizeof(packet));
     UNUSED_IF_ASSERT_DISABLED(packet_len);
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse(packet, response) ==
+    if (SendPacketAndWaitForResponse(packet, response, false) ==
         PacketResult::Success) {
       if (response.IsNormalResponse()) {
         // Make sure we parsed the right number of characters. The response is
@@ -2314,7 +2322,8 @@ bool GDBRemoteCommunicationClient::SetNonStopMode(const bool enable) {
 
   StringExtractorGDBRemote response;
   // Send to target
-  if (SendPacketAndWaitForResponse(packet, response) == PacketResult::Success)
+  if (SendPacketAndWaitForResponse(packet, response, false) ==
+      PacketResult::Success)
     if (response.IsOKResponse())
       return true;
 
@@ -2386,7 +2395,7 @@ void GDBRemoteCommunicationClient::TestPacketSpeed(const uint32_t num_packets,
         for (i = 0; i < num_packets; ++i) {
           const auto packet_start_time = steady_clock::now();
           StringExtractorGDBRemote response;
-          SendPacketAndWaitForResponse(packet.GetString(), response);
+          SendPacketAndWaitForResponse(packet.GetString(), response, false);
           const auto packet_end_time = steady_clock::now();
           packet_times.push_back(packet_end_time - packet_start_time);
         }
@@ -2440,7 +2449,7 @@ void GDBRemoteCommunicationClient::TestPacketSpeed(const uint32_t num_packets,
         uint32_t packet_count = 0;
         while (bytes_read < recv_amount) {
           StringExtractorGDBRemote response;
-          SendPacketAndWaitForResponse(packet.GetString(), response);
+          SendPacketAndWaitForResponse(packet.GetString(), response, false);
           bytes_read += recv_size;
           ++packet_count;
         }
@@ -2494,7 +2503,7 @@ bool GDBRemoteCommunicationClient::SendSpeedTestPacket(uint32_t send_size,
   }
 
   StringExtractorGDBRemote response;
-  return SendPacketAndWaitForResponse(packet.GetString(), response) ==
+  return SendPacketAndWaitForResponse(packet.GetString(), response, false) ==
          PacketResult::Success;
 }
 
@@ -2524,7 +2533,7 @@ bool GDBRemoteCommunicationClient::LaunchGDBServer(
   // give the process a few seconds to startup
   ScopedTimeout timeout(*this, seconds(10));
 
-  if (SendPacketAndWaitForResponse(stream.GetString(), response) ==
+  if (SendPacketAndWaitForResponse(stream.GetString(), response, false) ==
       PacketResult::Success) {
     llvm::StringRef name;
     llvm::StringRef value;
@@ -2548,7 +2557,7 @@ size_t GDBRemoteCommunicationClient::QueryGDBServer(
   connection_urls.clear();
 
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse("qQueryGDBServer", response) !=
+  if (SendPacketAndWaitForResponse("qQueryGDBServer", response, false) !=
       PacketResult::Success)
     return 0;
 
@@ -2587,7 +2596,7 @@ bool GDBRemoteCommunicationClient::KillSpawnedProcess(lldb::pid_t pid) {
   stream.Printf("qKillSpawnedProcess:%" PRId64, pid);
 
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(stream.GetString(), response) ==
+  if (SendPacketAndWaitForResponse(stream.GetString(), response, false) ==
       PacketResult::Success) {
     if (response.IsOKResponse())
       return true;
@@ -2608,7 +2617,8 @@ bool GDBRemoteCommunicationClient::SetCurrentThread(uint64_t tid) {
   assert(packet_len + 1 < (int)sizeof(packet));
   UNUSED_IF_ASSERT_DISABLED(packet_len);
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(packet, response) == PacketResult::Success) {
+  if (SendPacketAndWaitForResponse(packet, response, false) ==
+      PacketResult::Success) {
     if (response.IsOKResponse()) {
       m_curr_tid = tid;
       return true;
@@ -2643,7 +2653,8 @@ bool GDBRemoteCommunicationClient::SetCurrentThreadForRun(uint64_t tid) {
   assert(packet_len + 1 < (int)sizeof(packet));
   UNUSED_IF_ASSERT_DISABLED(packet_len);
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(packet, response) == PacketResult::Success) {
+  if (SendPacketAndWaitForResponse(packet, response, false) ==
+      PacketResult::Success) {
     if (response.IsOKResponse()) {
       m_curr_tid_run = tid;
       return true;
@@ -2666,7 +2677,8 @@ bool GDBRemoteCommunicationClient::SetCurrentThreadForRun(uint64_t tid) {
 
 bool GDBRemoteCommunicationClient::GetStopReply(
     StringExtractorGDBRemote &response) {
-  if (SendPacketAndWaitForResponse("?", response) == PacketResult::Success)
+  if (SendPacketAndWaitForResponse("?", response, false) ==
+      PacketResult::Success)
     return response.IsNormalResponse();
   return false;
 }
@@ -2679,7 +2691,7 @@ bool GDBRemoteCommunicationClient::GetThreadStopInfo(
         ::snprintf(packet, sizeof(packet), "qThreadStopInfo%" PRIx64, tid);
     assert(packet_len < (int)sizeof(packet));
     UNUSED_IF_ASSERT_DISABLED(packet_len);
-    if (SendPacketAndWaitForResponse(packet, response) ==
+    if (SendPacketAndWaitForResponse(packet, response, false) ==
         PacketResult::Success) {
       if (response.IsUnsupportedResponse())
         m_supports_qThreadStopInfo = false;
@@ -2695,8 +2707,7 @@ bool GDBRemoteCommunicationClient::GetThreadStopInfo(
 }
 
 uint8_t GDBRemoteCommunicationClient::SendGDBStoppointTypePacket(
-    GDBStoppointType type, bool insert, addr_t addr, uint32_t length,
-    std::chrono::seconds timeout) {
+    GDBStoppointType type, bool insert, addr_t addr, uint32_t length) {
   Log *log(GetLogIfAnyCategoriesSet(LIBLLDB_LOG_BREAKPOINTS));
   LLDB_LOGF(log, "GDBRemoteCommunicationClient::%s() %s at addr = 0x%" PRIx64,
             __FUNCTION__, insert ? "add" : "remove", addr);
@@ -2717,7 +2728,7 @@ uint8_t GDBRemoteCommunicationClient::SendGDBStoppointTypePacket(
   // or "" (unsupported)
   response.SetResponseValidatorToOKErrorNotSupported();
   // Try to send the breakpoint packet, and check that it was correctly sent
-  if (SendPacketAndWaitForResponse(packet, response, timeout) ==
+  if (SendPacketAndWaitForResponse(packet, response, true) ==
       PacketResult::Success) {
     // Receive and OK packet when the breakpoint successfully placed
     if (response.IsOKResponse())
@@ -2759,7 +2770,7 @@ size_t GDBRemoteCommunicationClient::GetCurrentThreadIDs(
     std::vector<lldb::tid_t> &thread_ids, bool &sequence_mutex_unavailable) {
   thread_ids.clear();
 
-  Lock lock(*this);
+  Lock lock(*this, false);
   if (lock) {
     sequence_mutex_unavailable = false;
     StringExtractorGDBRemote response;
@@ -2809,7 +2820,7 @@ size_t GDBRemoteCommunicationClient::GetCurrentThreadIDs(
 
 lldb::addr_t GDBRemoteCommunicationClient::GetShlibInfoAddr() {
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse("qShlibInfoAddr", response) !=
+  if (SendPacketAndWaitForResponse("qShlibInfoAddr", response, false) !=
           PacketResult::Success ||
       !response.IsNormalResponse())
     return LLDB_INVALID_ADDRESS;
@@ -2842,7 +2853,7 @@ lldb_private::Status GDBRemoteCommunicationClient::RunShellCommand(
     stream.PutStringAsRawHex8(path);
   }
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(stream.GetString(), response) ==
+  if (SendPacketAndWaitForResponse(stream.GetString(), response, false) ==
       PacketResult::Success) {
     if (response.GetChar() != 'F')
       return Status("malformed reply");
@@ -2880,7 +2891,8 @@ Status GDBRemoteCommunicationClient::MakeDirectory(const FileSpec &file_spec,
   llvm::StringRef packet = stream.GetString();
   StringExtractorGDBRemote response;
 
-  if (SendPacketAndWaitForResponse(packet, response) != PacketResult::Success)
+  if (SendPacketAndWaitForResponse(packet, response, false) !=
+      PacketResult::Success)
     return Status("failed to send '%s' packet", packet.str().c_str());
 
   if (response.GetChar() != 'F')
@@ -2901,7 +2913,8 @@ GDBRemoteCommunicationClient::SetFilePermissions(const FileSpec &file_spec,
   llvm::StringRef packet = stream.GetString();
   StringExtractorGDBRemote response;
 
-  if (SendPacketAndWaitForResponse(packet, response) != PacketResult::Success)
+  if (SendPacketAndWaitForResponse(packet, response, false) !=
+      PacketResult::Success)
     return Status("failed to send '%s' packet", stream.GetData());
 
   if (response.GetChar() != 'F')
@@ -2943,7 +2956,7 @@ GDBRemoteCommunicationClient::OpenFile(const lldb_private::FileSpec &file_spec,
   stream.PutChar(',');
   stream.PutHex32(mode);
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(stream.GetString(), response) ==
+  if (SendPacketAndWaitForResponse(stream.GetString(), response, false) ==
       PacketResult::Success) {
     return ParseHostIOPacketResponse(response, UINT64_MAX, error);
   }
@@ -2955,7 +2968,7 @@ bool GDBRemoteCommunicationClient::CloseFile(lldb::user_id_t fd,
   lldb_private::StreamString stream;
   stream.Printf("vFile:close:%i", (int)fd);
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(stream.GetString(), response) ==
+  if (SendPacketAndWaitForResponse(stream.GetString(), response, false) ==
       PacketResult::Success) {
     return ParseHostIOPacketResponse(response, -1, error) == 0;
   }
@@ -2970,7 +2983,7 @@ lldb::user_id_t GDBRemoteCommunicationClient::GetFileSize(
   stream.PutCString("vFile:size:");
   stream.PutStringAsRawHex8(path);
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(stream.GetString(), response) ==
+  if (SendPacketAndWaitForResponse(stream.GetString(), response, false) ==
       PacketResult::Success) {
     if (response.GetChar() != 'F')
       return UINT64_MAX;
@@ -2988,7 +3001,7 @@ void GDBRemoteCommunicationClient::AutoCompleteDiskFileOrDirectory(
   stream.PutChar(',');
   stream.PutStringAsRawHex8(request.GetCursorArgumentPrefix());
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(stream.GetString(), response) ==
+  if (SendPacketAndWaitForResponse(stream.GetString(), response, false) ==
       PacketResult::Success) {
     StreamString strm;
     char ch = response.GetChar();
@@ -3014,7 +3027,7 @@ GDBRemoteCommunicationClient::GetFilePermissions(const FileSpec &file_spec,
   stream.PutCString("vFile:mode:");
   stream.PutStringAsRawHex8(path);
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(stream.GetString(), response) ==
+  if (SendPacketAndWaitForResponse(stream.GetString(), response, false) ==
       PacketResult::Success) {
     if (response.GetChar() != 'F') {
       error.SetErrorStringWithFormat("invalid response to '%s' packet",
@@ -3049,7 +3062,7 @@ uint64_t GDBRemoteCommunicationClient::ReadFile(lldb::user_id_t fd,
   stream.Printf("vFile:pread:%i,%" PRId64 ",%" PRId64, (int)fd, dst_len,
                 offset);
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(stream.GetString(), response) ==
+  if (SendPacketAndWaitForResponse(stream.GetString(), response, false) ==
       PacketResult::Success) {
     if (response.GetChar() != 'F')
       return 0;
@@ -3083,7 +3096,7 @@ uint64_t GDBRemoteCommunicationClient::WriteFile(lldb::user_id_t fd,
   stream.Printf("vFile:pwrite:%i,%" PRId64 ",", (int)fd, offset);
   stream.PutEscapedBytes(src, src_len);
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(stream.GetString(), response) ==
+  if (SendPacketAndWaitForResponse(stream.GetString(), response, false) ==
       PacketResult::Success) {
     if (response.GetChar() != 'F') {
       error.SetErrorStringWithFormat("write file failed");
@@ -3118,7 +3131,7 @@ Status GDBRemoteCommunicationClient::CreateSymlink(const FileSpec &src,
   stream.PutChar(',');
   stream.PutStringAsRawHex8(src_path);
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(stream.GetString(), response) ==
+  if (SendPacketAndWaitForResponse(stream.GetString(), response, false) ==
       PacketResult::Success) {
     if (response.GetChar() == 'F') {
       uint32_t result = response.GetU32(UINT32_MAX);
@@ -3149,7 +3162,7 @@ Status GDBRemoteCommunicationClient::Unlink(const FileSpec &file_spec) {
   // so we follow suit here
   stream.PutStringAsRawHex8(path);
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(stream.GetString(), response) ==
+  if (SendPacketAndWaitForResponse(stream.GetString(), response, false) ==
       PacketResult::Success) {
     if (response.GetChar() == 'F') {
       uint32_t result = response.GetU32(UINT32_MAX);
@@ -3179,7 +3192,7 @@ bool GDBRemoteCommunicationClient::GetFileExists(
   stream.PutCString("vFile:exists:");
   stream.PutStringAsRawHex8(path);
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(stream.GetString(), response) ==
+  if (SendPacketAndWaitForResponse(stream.GetString(), response, false) ==
       PacketResult::Success) {
     if (response.GetChar() != 'F')
       return false;
@@ -3198,7 +3211,7 @@ bool GDBRemoteCommunicationClient::CalculateMD5(
   stream.PutCString("vFile:MD5:");
   stream.PutStringAsRawHex8(path);
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(stream.GetString(), response) ==
+  if (SendPacketAndWaitForResponse(stream.GetString(), response, false) ==
       PacketResult::Success) {
     if (response.GetChar() != 'F')
       return false;
@@ -3245,7 +3258,7 @@ DataBufferSP GDBRemoteCommunicationClient::ReadRegister(lldb::tid_t tid,
   payload.Printf("p%x", reg);
   StringExtractorGDBRemote response;
   if (SendThreadSpecificPacketAndWaitForResponse(
-          tid, std::move(payload), response) != PacketResult::Success ||
+          tid, std::move(payload), response, false) != PacketResult::Success ||
       !response.IsNormalResponse())
     return nullptr;
 
@@ -3260,7 +3273,7 @@ DataBufferSP GDBRemoteCommunicationClient::ReadAllRegisters(lldb::tid_t tid) {
   payload.PutChar('g');
   StringExtractorGDBRemote response;
   if (SendThreadSpecificPacketAndWaitForResponse(
-          tid, std::move(payload), response) != PacketResult::Success ||
+          tid, std::move(payload), response, false) != PacketResult::Success ||
       !response.IsNormalResponse())
     return nullptr;
 
@@ -3279,8 +3292,9 @@ bool GDBRemoteCommunicationClient::WriteRegister(lldb::tid_t tid,
                             endian::InlHostByteOrder(),
                             endian::InlHostByteOrder());
   StringExtractorGDBRemote response;
-  return SendThreadSpecificPacketAndWaitForResponse(
-             tid, std::move(payload), response) == PacketResult::Success &&
+  return SendThreadSpecificPacketAndWaitForResponse(tid, std::move(payload),
+                                                    response, false) ==
+             PacketResult::Success &&
          response.IsOKResponse();
 }
 
@@ -3292,8 +3306,9 @@ bool GDBRemoteCommunicationClient::WriteAllRegisters(
                             endian::InlHostByteOrder(),
                             endian::InlHostByteOrder());
   StringExtractorGDBRemote response;
-  return SendThreadSpecificPacketAndWaitForResponse(
-             tid, std::move(payload), response) == PacketResult::Success &&
+  return SendThreadSpecificPacketAndWaitForResponse(tid, std::move(payload),
+                                                    response, false) ==
+             PacketResult::Success &&
          response.IsOKResponse();
 }
 
@@ -3308,7 +3323,7 @@ bool GDBRemoteCommunicationClient::SaveRegisterState(lldb::tid_t tid,
   payload.PutCString("QSaveRegisterState");
   StringExtractorGDBRemote response;
   if (SendThreadSpecificPacketAndWaitForResponse(
-          tid, std::move(payload), response) != PacketResult::Success)
+          tid, std::move(payload), response, false) != PacketResult::Success)
     return false;
 
   if (response.IsUnsupportedResponse())
@@ -3334,7 +3349,7 @@ bool GDBRemoteCommunicationClient::RestoreRegisterState(lldb::tid_t tid,
   payload.Printf("QRestoreRegisterState:%u", save_id);
   StringExtractorGDBRemote response;
   if (SendThreadSpecificPacketAndWaitForResponse(
-          tid, std::move(payload), response) != PacketResult::Success)
+          tid, std::move(payload), response, false) != PacketResult::Success)
     return false;
 
   if (response.IsOKResponse())
@@ -3352,16 +3367,14 @@ bool GDBRemoteCommunicationClient::SyncThreadState(lldb::tid_t tid) {
   StreamString packet;
   StringExtractorGDBRemote response;
   packet.Printf("QSyncThreadState:%4.4" PRIx64 ";", tid);
-  return SendPacketAndWaitForResponse(packet.GetString(), response) ==
+  return SendPacketAndWaitForResponse(packet.GetString(), response, false) ==
              GDBRemoteCommunication::PacketResult::Success &&
          response.IsOKResponse();
 }
 
 lldb::user_id_t
-GDBRemoteCommunicationClient::SendStartTracePacket(
-    const TraceOptions &options,
-    std::chrono::seconds timeout,
-    Status &error) {
+GDBRemoteCommunicationClient::SendStartTracePacket(const TraceOptions &options,
+                                                   Status &error) {
   Log *log(ProcessGDBRemoteLog::GetLogIfAllCategoriesSet(GDBR_LOG_PROCESS));
   lldb::user_id_t ret_uid = LLDB_INVALID_UID;
 
@@ -3386,7 +3399,7 @@ GDBRemoteCommunicationClient::SendStartTracePacket(
 
   StringExtractorGDBRemote response;
   if (SendPacketAndWaitForResponse(escaped_packet.GetString(), response,
-                                   timeout) ==
+                                   true) ==
       GDBRemoteCommunication::PacketResult::Success) {
     if (!response.IsNormalResponse()) {
       error = response.GetStatus();
@@ -3404,8 +3417,7 @@ GDBRemoteCommunicationClient::SendStartTracePacket(
 
 Status
 GDBRemoteCommunicationClient::SendStopTracePacket(lldb::user_id_t uid,
-                                                  lldb::tid_t thread_id,
-                                                  std::chrono::seconds timeout) {
+                                                  lldb::tid_t thread_id) {
   Log *log(ProcessGDBRemoteLog::GetLogIfAllCategoriesSet(GDBR_LOG_PROCESS));
   StringExtractorGDBRemote response;
   Status error;
@@ -3425,7 +3437,7 @@ GDBRemoteCommunicationClient::SendStopTracePacket(lldb::user_id_t uid,
   escaped_packet.PutEscapedBytes(json_string.GetData(), json_string.GetSize());
 
   if (SendPacketAndWaitForResponse(escaped_packet.GetString(), response,
-                                   timeout) ==
+                                   true) ==
       GDBRemoteCommunication::PacketResult::Success) {
     if (!response.IsOKResponse()) {
       error = response.GetStatus();
@@ -3442,27 +3454,24 @@ GDBRemoteCommunicationClient::SendStopTracePacket(lldb::user_id_t uid,
 
 Status GDBRemoteCommunicationClient::SendGetDataPacket(
     lldb::user_id_t uid, lldb::tid_t thread_id,
-    llvm::MutableArrayRef<uint8_t> &buffer,
-    std::chrono::seconds timeout, size_t offset) {
+    llvm::MutableArrayRef<uint8_t> &buffer, size_t offset) {
 
   StreamGDBRemote escaped_packet;
   escaped_packet.PutCString("jTraceBufferRead:");
-  return SendGetTraceDataPacket(escaped_packet, uid, thread_id, buffer, timeout, offset);
+  return SendGetTraceDataPacket(escaped_packet, uid, thread_id, buffer, offset);
 }
 
 Status GDBRemoteCommunicationClient::SendGetMetaDataPacket(
     lldb::user_id_t uid, lldb::tid_t thread_id,
-    llvm::MutableArrayRef<uint8_t> &buffer,
-    std::chrono::seconds timeout, size_t offset) {
+    llvm::MutableArrayRef<uint8_t> &buffer, size_t offset) {
 
   StreamGDBRemote escaped_packet;
   escaped_packet.PutCString("jTraceMetaRead:");
-  return SendGetTraceDataPacket(escaped_packet, uid, thread_id, buffer,
-                                timeout, offset);
+  return SendGetTraceDataPacket(escaped_packet, uid, thread_id, buffer, offset);
 }
 
 llvm::Expected<TraceTypeInfo>
-GDBRemoteCommunicationClient::SendGetSupportedTraceType(std::chrono::seconds timeout) {
+GDBRemoteCommunicationClient::SendGetSupportedTraceType() {
   Log *log(ProcessGDBRemoteLog::GetLogIfAllCategoriesSet(GDBR_LOG_PROCESS));
 
   StreamGDBRemote escaped_packet;
@@ -3470,7 +3479,7 @@ GDBRemoteCommunicationClient::SendGetSupportedTraceType(std::chrono::seconds tim
 
   StringExtractorGDBRemote response;
   if (SendPacketAndWaitForResponse(escaped_packet.GetString(), response,
-                                   timeout) ==
+                                   true) ==
       GDBRemoteCommunication::PacketResult::Success) {
     if (response.IsErrorResponse())
       return response.GetStatus().ToError();
@@ -3492,8 +3501,7 @@ GDBRemoteCommunicationClient::SendGetSupportedTraceType(std::chrono::seconds tim
 
 Status
 GDBRemoteCommunicationClient::SendGetTraceConfigPacket(lldb::user_id_t uid,
-                                                       TraceOptions &options,
-                                                       std::chrono::seconds timeout) {
+                                                       TraceOptions &options) {
   Log *log(ProcessGDBRemoteLog::GetLogIfAllCategoriesSet(GDBR_LOG_PROCESS));
   StringExtractorGDBRemote response;
   Status error;
@@ -3512,7 +3520,7 @@ GDBRemoteCommunicationClient::SendGetTraceConfigPacket(lldb::user_id_t uid,
   escaped_packet.PutEscapedBytes(json_string.GetData(), json_string.GetSize());
 
   if (SendPacketAndWaitForResponse(escaped_packet.GetString(), response,
-                                   timeout) ==
+                                   true) ==
       GDBRemoteCommunication::PacketResult::Success) {
     if (response.IsNormalResponse()) {
       uint64_t type = std::numeric_limits<uint64_t>::max();
@@ -3564,8 +3572,7 @@ GDBRemoteCommunicationClient::SendGetTraceConfigPacket(lldb::user_id_t uid,
 
 Status GDBRemoteCommunicationClient::SendGetTraceDataPacket(
     StreamGDBRemote &packet, lldb::user_id_t uid, lldb::tid_t thread_id,
-    llvm::MutableArrayRef<uint8_t> &buffer, std::chrono::seconds timeout,
-    size_t offset) {
+    llvm::MutableArrayRef<uint8_t> &buffer, size_t offset) {
   Log *log(ProcessGDBRemoteLog::GetLogIfAllCategoriesSet(GDBR_LOG_PROCESS));
   Status error;
 
@@ -3583,8 +3590,7 @@ Status GDBRemoteCommunicationClient::SendGetTraceDataPacket(
 
   packet.PutEscapedBytes(json_string.GetData(), json_string.GetSize());
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(packet.GetString(), response,
-                                   timeout) ==
+  if (SendPacketAndWaitForResponse(packet.GetString(), response, true) ==
       GDBRemoteCommunication::PacketResult::Success) {
     if (response.IsNormalResponse()) {
       size_t filled_size = response.GetHexBytesAvail(buffer);
@@ -3604,8 +3610,8 @@ Status GDBRemoteCommunicationClient::SendGetTraceDataPacket(
 
 llvm::Optional<QOffsets> GDBRemoteCommunicationClient::GetQOffsets() {
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse("qOffsets", response) !=
-      PacketResult::Success)
+  if (SendPacketAndWaitForResponse(
+          "qOffsets", response, /*send_async=*/false) != PacketResult::Success)
     return llvm::None;
   if (!response.IsNormalResponse())
     return llvm::None;
@@ -3660,7 +3666,7 @@ bool GDBRemoteCommunicationClient::GetModuleInfo(
   packet.PutStringAsRawHex8(triple);
 
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(packet.GetString(), response) !=
+  if (SendPacketAndWaitForResponse(packet.GetString(), response, false) !=
       PacketResult::Success)
     return false;
 
@@ -3767,7 +3773,7 @@ GDBRemoteCommunicationClient::GetModulesInfo(
   ScopedTimeout timeout(*this, std::chrono::seconds(10));
 
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(payload.GetString(), response) !=
+  if (SendPacketAndWaitForResponse(payload.GetString(), response, false) !=
           PacketResult::Success ||
       response.IsErrorResponse())
     return llvm::None;
@@ -3826,7 +3832,7 @@ bool GDBRemoteCommunicationClient::ReadExtFeature(
            << "," << std::hex << size;
 
     GDBRemoteCommunication::PacketResult res =
-        SendPacketAndWaitForResponse(packet.str(), chunk);
+        SendPacketAndWaitForResponse(packet.str(), chunk, false);
 
     if (res != GDBRemoteCommunication::PacketResult::Success) {
       err.SetErrorString("Error sending $qXfer packet");
@@ -3915,7 +3921,7 @@ void GDBRemoteCommunicationClient::ServeSymbolLookups(
   bool first_qsymbol_query = true;
 
   if (m_supports_qSymbol && !m_qSymbol_requests_done) {
-    Lock lock(*this);
+    Lock lock(*this, false);
     if (lock) {
       StreamString packet;
       packet.PutCString("qSymbol::");
@@ -4043,8 +4049,9 @@ GDBRemoteCommunicationClient::GetSupportedStructuredDataPlugins() {
 
     // Poll it now.
     StringExtractorGDBRemote response;
-    if (SendPacketAndWaitForResponse("qStructuredDataPlugins", response) ==
-        PacketResult::Success) {
+    const bool send_async = false;
+    if (SendPacketAndWaitForResponse("qStructuredDataPlugins", response,
+                                     send_async) == PacketResult::Success) {
       m_supported_async_json_packets_sp =
           StructuredData::ParseJSON(std::string(response.GetStringRef()));
       if (m_supported_async_json_packets_sp &&
@@ -4088,7 +4095,7 @@ Status GDBRemoteCommunicationClient::SendSignalsToIgnore(
   std::string packet = formatv("QPassSignals:{0:$[;]@(x-2)}", range).str();
 
   StringExtractorGDBRemote response;
-  auto send_status = SendPacketAndWaitForResponse(packet, response);
+  auto send_status = SendPacketAndWaitForResponse(packet, response, false);
 
   if (send_status != GDBRemoteCommunication::PacketResult::Success)
     return Status("Sending QPassSignals packet failed");
@@ -4127,8 +4134,10 @@ Status GDBRemoteCommunicationClient::ConfigureRemoteStructuredData(
   stream.Flush();
 
   // Send the packet.
+  const bool send_async = false;
   StringExtractorGDBRemote response;
-  auto result = SendPacketAndWaitForResponse(stream.GetString(), response);
+  auto result =
+      SendPacketAndWaitForResponse(stream.GetString(), response, send_async);
   if (result == PacketResult::Success) {
     // We failed if the config result comes back other than OK.
     if (strcmp(response.GetStringRef().data(), "OK") == 0) {

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
@@ -319,8 +319,7 @@ public:
       GDBStoppointType type, // Type of breakpoint or watchpoint
       bool insert,           // Insert or remove?
       lldb::addr_t addr,     // Address of breakpoint or watchpoint
-      uint32_t length,       // Byte Size of breakpoint or watchpoint
-      std::chrono::seconds interrupt_timeout); // Time to wait for an interrupt
+      uint32_t length);      // Byte Size of breakpoint or watchpoint
 
   bool SetNonStopMode(const bool enable);
 
@@ -507,27 +506,21 @@ public:
                                 const StructuredData::ObjectSP &config_sp);
 
   lldb::user_id_t SendStartTracePacket(const TraceOptions &options,
-                                       std::chrono::seconds interrupt_timeout,
                                        Status &error);
 
-  Status SendStopTracePacket(lldb::user_id_t uid, lldb::tid_t thread_id,
-                             std::chrono::seconds interrupt_timeout);
+  Status SendStopTracePacket(lldb::user_id_t uid, lldb::tid_t thread_id);
 
   Status SendGetDataPacket(lldb::user_id_t uid, lldb::tid_t thread_id,
                            llvm::MutableArrayRef<uint8_t> &buffer,
-                           std::chrono::seconds interrupt_timeout,
                            size_t offset = 0);
 
   Status SendGetMetaDataPacket(lldb::user_id_t uid, lldb::tid_t thread_id,
                                llvm::MutableArrayRef<uint8_t> &buffer,
-                               std::chrono::seconds interrupt_timeout,
                                size_t offset = 0);
 
-  Status SendGetTraceConfigPacket(lldb::user_id_t uid, TraceOptions &options,
-                                  std::chrono::seconds interrupt_timeout);
+  Status SendGetTraceConfigPacket(lldb::user_id_t uid, TraceOptions &options);
 
-  llvm::Expected<TraceTypeInfo> SendGetSupportedTraceType(
-      std::chrono::seconds interrupt_timeout);
+  llvm::Expected<TraceTypeInfo> SendGetSupportedTraceType();
 
 protected:
   LazyBool m_supports_not_sending_acks;
@@ -619,12 +612,11 @@ protected:
 
   PacketResult SendThreadSpecificPacketAndWaitForResponse(
       lldb::tid_t tid, StreamString &&payload,
-      StringExtractorGDBRemote &response);
+      StringExtractorGDBRemote &response, bool send_async);
 
   Status SendGetTraceDataPacket(StreamGDBRemote &packet, lldb::user_id_t uid,
                                 lldb::tid_t thread_id,
                                 llvm::MutableArrayRef<uint8_t> &buffer,
-                                std::chrono::seconds timeout,
                                 size_t offset);
 
   Status LoadQXferMemoryMap();

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteRegisterContext.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteRegisterContext.cpp
@@ -348,7 +348,7 @@ bool GDBRemoteRegisterContext::WriteRegisterBytes(const RegisterInfo *reg_info,
                                reg_info->byte_size,        // dst length
                                m_reg_data.GetByteOrder())) // dst byte order
   {
-    GDBRemoteClientBase::Lock lock(gdb_comm);
+    GDBRemoteClientBase::Lock lock(gdb_comm, false);
     if (lock) {
       if (m_write_all_at_once) {
         // Invalidate all register values
@@ -483,7 +483,7 @@ bool GDBRemoteRegisterContext::ReadAllRegisterValues(
   const bool use_g_packet =
       !gdb_comm.AvoidGPackets((ProcessGDBRemote *)process);
 
-  GDBRemoteClientBase::Lock lock(gdb_comm);
+  GDBRemoteClientBase::Lock lock(gdb_comm, false);
   if (lock) {
     if (gdb_comm.SyncThreadState(m_thread.GetProtocolID()))
       InvalidateAllRegisters();
@@ -549,7 +549,7 @@ bool GDBRemoteRegisterContext::WriteAllRegisterValues(
   const bool use_g_packet =
       !gdb_comm.AvoidGPackets((ProcessGDBRemote *)process);
 
-  GDBRemoteClientBase::Lock lock(gdb_comm);
+  GDBRemoteClientBase::Lock lock(gdb_comm, false);
   if (lock) {
     // The data_sp contains the G response packet.
     if (use_g_packet) {

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -461,7 +461,7 @@ void ProcessGDBRemote::BuildDynamicRegisterInfo(bool force) {
     assert(packet_len < (int)sizeof(packet));
     UNUSED_IF_ASSERT_DISABLED(packet_len);
     StringExtractorGDBRemote response;
-    if (m_gdb_comm.SendPacketAndWaitForResponse(packet, response) ==
+    if (m_gdb_comm.SendPacketAndWaitForResponse(packet, response, false) ==
         GDBRemoteCommunication::PacketResult::Success) {
       response_type = response.GetResponseType();
       if (response_type == StringExtractorGDBRemote::eResponse) {
@@ -1011,7 +1011,7 @@ Status ProcessGDBRemote::ConnectToDebugserver(llvm::StringRef connect_url) {
   for (size_t idx = 0; idx < num_cmds; idx++) {
     StringExtractorGDBRemote response;
     m_gdb_comm.SendPacketAndWaitForResponse(
-        GetExtraStartupCommands().GetArgumentAtIndex(idx), response);
+        GetExtraStartupCommands().GetArgumentAtIndex(idx), response, false);
   }
   return error;
 }
@@ -1201,32 +1201,32 @@ Status ProcessGDBRemote::DoAttachToProcessWithName(
 
 lldb::user_id_t ProcessGDBRemote::StartTrace(const TraceOptions &options,
                                              Status &error) {
-  return m_gdb_comm.SendStartTracePacket(options, GetInterruptTimeout(), error);
+  return m_gdb_comm.SendStartTracePacket(options, error);
 }
 
 Status ProcessGDBRemote::StopTrace(lldb::user_id_t uid, lldb::tid_t thread_id) {
-  return m_gdb_comm.SendStopTracePacket(uid, thread_id, GetInterruptTimeout());
+  return m_gdb_comm.SendStopTracePacket(uid, thread_id);
 }
 
 Status ProcessGDBRemote::GetData(lldb::user_id_t uid, lldb::tid_t thread_id,
                                  llvm::MutableArrayRef<uint8_t> &buffer,
                                  size_t offset) {
-  return m_gdb_comm.SendGetDataPacket(uid, thread_id, buffer, GetInterruptTimeout(), offset);
+  return m_gdb_comm.SendGetDataPacket(uid, thread_id, buffer, offset);
 }
 
 Status ProcessGDBRemote::GetMetaData(lldb::user_id_t uid, lldb::tid_t thread_id,
                                      llvm::MutableArrayRef<uint8_t> &buffer,
                                      size_t offset) {
-  return m_gdb_comm.SendGetMetaDataPacket(uid, thread_id, buffer, GetInterruptTimeout(), offset);
+  return m_gdb_comm.SendGetMetaDataPacket(uid, thread_id, buffer, offset);
 }
 
 Status ProcessGDBRemote::GetTraceConfig(lldb::user_id_t uid,
                                         TraceOptions &options) {
-  return m_gdb_comm.SendGetTraceConfigPacket(uid, options, GetInterruptTimeout());
+  return m_gdb_comm.SendGetTraceConfigPacket(uid, options);
 }
 
 llvm::Expected<TraceTypeInfo> ProcessGDBRemote::GetSupportedTraceType() {
-  return m_gdb_comm.SendGetSupportedTraceType(GetInterruptTimeout());
+  return m_gdb_comm.SendGetSupportedTraceType();
 }
 
 void ProcessGDBRemote::DidExit() {
@@ -1471,7 +1471,7 @@ void ProcessGDBRemote::HandleStopReplySequence() {
   while (true) {
     // Send vStopped
     StringExtractorGDBRemote response;
-    m_gdb_comm.SendPacketAndWaitForResponse("vStopped", response);
+    m_gdb_comm.SendPacketAndWaitForResponse("vStopped", response, false);
 
     // OK represents end of signal list
     if (response.IsOKResponse())
@@ -2391,7 +2391,7 @@ Status ProcessGDBRemote::DoHalt(bool &caused_stop) {
     // file handle and debugserver will go away, and we can be done...
     m_gdb_comm.Disconnect();
   } else
-    caused_stop = m_gdb_comm.Interrupt(GetInterruptTimeout());
+    caused_stop = m_gdb_comm.Interrupt();
   return error;
 }
 
@@ -2540,11 +2540,11 @@ Status ProcessGDBRemote::DoDestroy() {
   if (m_gdb_comm.IsConnected()) {
     if (m_public_state.GetValue() != eStateAttaching) {
       StringExtractorGDBRemote response;
+      bool send_async = true;
       GDBRemoteCommunication::ScopedTimeout(m_gdb_comm,
                                             std::chrono::seconds(3));
 
-      if (m_gdb_comm.SendPacketAndWaitForResponse("k", response,
-                                                  GetInterruptTimeout()) ==
+      if (m_gdb_comm.SendPacketAndWaitForResponse("k", response, send_async) ==
           GDBRemoteCommunication::PacketResult::Success) {
         char packet_cmd = response.GetChar(0);
 
@@ -2708,8 +2708,7 @@ size_t ProcessGDBRemote::DoReadMemory(addr_t addr, void *buf, size_t size,
   assert(packet_len + 1 < (int)sizeof(packet));
   UNUSED_IF_ASSERT_DISABLED(packet_len);
   StringExtractorGDBRemote response;
-  if (m_gdb_comm.SendPacketAndWaitForResponse(packet, response,
-                                              GetInterruptTimeout()) ==
+  if (m_gdb_comm.SendPacketAndWaitForResponse(packet, response, true) ==
       GDBRemoteCommunication::PacketResult::Success) {
     if (response.IsNormalResponse()) {
       error.Clear();
@@ -2835,7 +2834,7 @@ Status ProcessGDBRemote::FlashErase(lldb::addr_t addr, size_t size) {
 
   StringExtractorGDBRemote response;
   if (m_gdb_comm.SendPacketAndWaitForResponse(packet.GetString(), response,
-                                              GetInterruptTimeout()) ==
+                                              true) ==
       GDBRemoteCommunication::PacketResult::Success) {
     if (response.IsOKResponse()) {
       m_erased_flash_ranges.Insert(range, true);
@@ -2864,8 +2863,7 @@ Status ProcessGDBRemote::FlashDone() {
   if (m_erased_flash_ranges.IsEmpty())
     return status;
   StringExtractorGDBRemote response;
-  if (m_gdb_comm.SendPacketAndWaitForResponse("vFlashDone", response,
-                                              GetInterruptTimeout()) ==
+  if (m_gdb_comm.SendPacketAndWaitForResponse("vFlashDone", response, true) ==
       GDBRemoteCommunication::PacketResult::Success) {
     if (response.IsOKResponse()) {
       m_erased_flash_ranges.Clear();
@@ -2926,7 +2924,7 @@ size_t ProcessGDBRemote::DoWriteMemory(addr_t addr, const void *buf,
   }
   StringExtractorGDBRemote response;
   if (m_gdb_comm.SendPacketAndWaitForResponse(packet.GetString(), response,
-                                              GetInterruptTimeout()) ==
+                                              true) ==
       GDBRemoteCommunication::PacketResult::Success) {
     if (response.IsOKResponse()) {
       error.Clear();
@@ -3102,7 +3100,7 @@ Status ProcessGDBRemote::EnableBreakpointSite(BreakpointSite *bp_site) {
       (!bp_site->HardwareRequired())) {
     // Try to send off a software breakpoint packet ($Z0)
     uint8_t error_no = m_gdb_comm.SendGDBStoppointTypePacket(
-        eBreakpointSoftware, true, addr, bp_op_size, GetInterruptTimeout());
+        eBreakpointSoftware, true, addr, bp_op_size);
     if (error_no == 0) {
       // The breakpoint was placed successfully
       bp_site->SetEnabled(true);
@@ -3142,7 +3140,7 @@ Status ProcessGDBRemote::EnableBreakpointSite(BreakpointSite *bp_site) {
   if (m_gdb_comm.SupportsGDBStoppointPacket(eBreakpointHardware)) {
     // Try to send off a hardware breakpoint packet ($Z1)
     uint8_t error_no = m_gdb_comm.SendGDBStoppointTypePacket(
-        eBreakpointHardware, true, addr, bp_op_size, GetInterruptTimeout());
+        eBreakpointHardware, true, addr, bp_op_size);
     if (error_no == 0) {
       // The breakpoint was placed successfully
       bp_site->SetEnabled(true);
@@ -3206,15 +3204,13 @@ Status ProcessGDBRemote::DisableBreakpointSite(BreakpointSite *bp_site) {
 
     case BreakpointSite::eHardware:
       if (m_gdb_comm.SendGDBStoppointTypePacket(eBreakpointHardware, false,
-                                                addr, bp_op_size,
-                                                GetInterruptTimeout()))
+                                                addr, bp_op_size))
         error.SetErrorToGenericError();
       break;
 
     case BreakpointSite::eExternal: {
       if (m_gdb_comm.SendGDBStoppointTypePacket(eBreakpointSoftware, false,
-                                                addr, bp_op_size,
-                                                GetInterruptTimeout()))
+                                                addr, bp_op_size))
         error.SetErrorToGenericError();
     } break;
     }
@@ -3270,8 +3266,7 @@ Status ProcessGDBRemote::EnableWatchpoint(Watchpoint *wp, bool notify) {
     // Pass down an appropriate z/Z packet...
     if (m_gdb_comm.SupportsGDBStoppointPacket(type)) {
       if (m_gdb_comm.SendGDBStoppointTypePacket(type, true, addr,
-                                                wp->GetByteSize(),
-                                                GetInterruptTimeout()) == 0) {
+                                                wp->GetByteSize()) == 0) {
         wp->SetEnabled(true, notify);
         return error;
       } else
@@ -3317,8 +3312,7 @@ Status ProcessGDBRemote::DisableWatchpoint(Watchpoint *wp, bool notify) {
       GDBStoppointType type = GetGDBStoppointType(wp);
       // Pass down an appropriate z/Z packet...
       if (m_gdb_comm.SendGDBStoppointTypePacket(type, false, addr,
-                                                wp->GetByteSize(),
-                                                GetInterruptTimeout()) == 0) {
+                                                wp->GetByteSize()) == 0) {
         wp->SetEnabled(false, notify);
         return error;
       } else
@@ -3343,7 +3337,7 @@ Status ProcessGDBRemote::DoSignal(int signo) {
   Log *log(ProcessGDBRemoteLog::GetLogIfAllCategoriesSet(GDBR_LOG_PROCESS));
   LLDB_LOGF(log, "ProcessGDBRemote::DoSignal (signal = %d)", signo);
 
-  if (!m_gdb_comm.SendAsyncSignal(signo, GetInterruptTimeout()))
+  if (!m_gdb_comm.SendAsyncSignal(signo))
     error.SetErrorStringWithFormat("failed to send signal %i", signo);
   return error;
 }
@@ -3721,7 +3715,7 @@ thread_result_t ProcessGDBRemote::AsyncThread(void *arg) {
               // send the vCont packet
               if (!process->GetGDBRemote().SendvContPacket(
                       llvm::StringRef(continue_cstr, continue_cstr_len),
-                      process->GetInterruptTimeout(), response)) {
+                      response)) {
                 // Something went wrong
                 done = true;
                 break;
@@ -3733,7 +3727,6 @@ thread_result_t ProcessGDBRemote::AsyncThread(void *arg) {
                   process->GetGDBRemote().SendContinuePacketAndWaitForResponse(
                       *process, *process->GetUnixSignals(),
                       llvm::StringRef(continue_cstr, continue_cstr_len),
-                      process->GetInterruptTimeout(),
                       response);
 
               // We need to immediately clear the thread ID list so we are sure
@@ -4028,7 +4021,8 @@ ProcessGDBRemote::GetExtendedInfoForThread(lldb::tid_t tid) {
 
     StringExtractorGDBRemote response;
     response.SetResponseValidatorToJSON();
-    if (m_gdb_comm.SendPacketAndWaitForResponse(packet.GetString(), response) ==
+    if (m_gdb_comm.SendPacketAndWaitForResponse(packet.GetString(), response,
+                                                false) ==
         GDBRemoteCommunication::PacketResult::Success) {
       StringExtractorGDBRemote::ResponseType response_type =
           response.GetResponseType();
@@ -4100,7 +4094,8 @@ ProcessGDBRemote::GetLoadedDynamicLibrariesInfos_sender(
 
     StringExtractorGDBRemote response;
     response.SetResponseValidatorToJSON();
-    if (m_gdb_comm.SendPacketAndWaitForResponse(packet.GetString(), response) ==
+    if (m_gdb_comm.SendPacketAndWaitForResponse(packet.GetString(), response,
+                                                false) ==
         GDBRemoteCommunication::PacketResult::Success) {
       StringExtractorGDBRemote::ResponseType response_type =
           response.GetResponseType();
@@ -4133,7 +4128,8 @@ StructuredData::ObjectSP ProcessGDBRemote::GetSharedCacheInfo() {
 
     StringExtractorGDBRemote response;
     response.SetResponseValidatorToJSON();
-    if (m_gdb_comm.SendPacketAndWaitForResponse(packet.GetString(), response) ==
+    if (m_gdb_comm.SendPacketAndWaitForResponse(packet.GetString(), response,
+                                                false) ==
         GDBRemoteCommunication::PacketResult::Success) {
       StringExtractorGDBRemote::ResponseType response_type =
           response.GetResponseType();
@@ -4899,7 +4895,8 @@ Status ProcessGDBRemote::GetFileLoadAddress(const FileSpec &file,
   packet.PutStringAsRawHex8(file_path);
 
   StringExtractorGDBRemote response;
-  if (m_gdb_comm.SendPacketAndWaitForResponse(packet.GetString(), response) !=
+  if (m_gdb_comm.SendPacketAndWaitForResponse(packet.GetString(), response,
+                                              false) !=
       GDBRemoteCommunication::PacketResult::Success)
     return Status("Sending qFileLoadAddress packet failed");
 
@@ -5276,9 +5273,10 @@ public:
     if (process) {
       for (size_t i = 0; i < argc; ++i) {
         const char *packet_cstr = command.GetArgumentAtIndex(0);
+        bool send_async = true;
         StringExtractorGDBRemote response;
         process->GetGDBRemote().SendPacketAndWaitForResponse(
-            packet_cstr, response, process->GetInterruptTimeout());
+            packet_cstr, response, send_async);
         result.SetStatus(eReturnStatusSuccessFinishResult);
         Stream &output_strm = result.GetOutputStream();
         output_strm.Printf("  packet: %s\n", packet_cstr);
@@ -5327,10 +5325,11 @@ public:
       packet.PutCString("qRcmd,");
       packet.PutBytesAsRawHex8(command.data(), command.size());
 
+      bool send_async = true;
       StringExtractorGDBRemote response;
       Stream &output_strm = result.GetOutputStream();
       process->GetGDBRemote().SendPacketAndReceiveResponseWithOutputSupport(
-          packet.GetString(), response, process->GetInterruptTimeout(),
+          packet.GetString(), response, send_async,
           [&output_strm](llvm::StringRef output) { output_strm << output; });
       result.SetStatus(eReturnStatusSuccessFinishResult);
       output_strm.Printf("  packet: %s\n", packet.GetData());

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -290,13 +290,6 @@ std::chrono::seconds ProcessProperties::GetUtilityExpressionTimeout() const {
   return std::chrono::seconds(value);
 }
 
-std::chrono::seconds ProcessProperties::GetInterruptTimeout() const {
-  const uint32_t idx = ePropertyInterruptTimeout;
-  uint64_t value = m_collection_sp->GetPropertyAtIndexAsUInt64(
-      nullptr, idx, g_process_properties[idx].default_uint_value);
-  return std::chrono::seconds(value);
-}
-
 bool ProcessProperties::GetSteppingRunsAllThreads() const {
   const uint32_t idx = ePropertySteppingRunsAllThreads;
   return m_collection_sp->GetPropertyAtIndexAsBoolean(
@@ -1493,8 +1486,8 @@ Status Process::ResumeSynchronous(Stream *stream) {
 
   Status error = PrivateResume();
   if (error.Success()) {
-    StateType state = WaitForProcessToStop(GetInterruptTimeout(), nullptr, true,
-                                           listener_sp, stream);
+    StateType state =
+        WaitForProcessToStop(llvm::None, nullptr, true, listener_sp, stream);
     const bool must_be_alive =
         false; // eStateExited is ok, so this must be false
     if (!StateIsStoppedState(state, must_be_alive))
@@ -3237,10 +3230,9 @@ Status Process::Halt(bool clear_thread_plans, bool use_run_lock) {
     return Status();
   }
 
-  // Wait for the process halt timeout seconds for the process to stop.
-  StateType state =
-      WaitForProcessToStop(GetInterruptTimeout(), &event_sp, true,
-                           halt_listener_sp, nullptr, use_run_lock);
+  // Wait for 10 second for the process to stop.
+  StateType state = WaitForProcessToStop(
+      seconds(10), &event_sp, true, halt_listener_sp, nullptr, use_run_lock);
   RestoreProcessEvents();
 
   if (state == eStateInvalid || !event_sp) {
@@ -3271,8 +3263,8 @@ Status Process::StopForDestroyOrDetach(lldb::EventSP &exit_event_sp) {
     SendAsyncInterrupt();
 
     // Consume the interrupt event.
-    StateType state = WaitForProcessToStop(GetInterruptTimeout(),
-                                           &exit_event_sp, true, listener_sp);
+    StateType state =
+        WaitForProcessToStop(seconds(10), &exit_event_sp, true, listener_sp);
 
     RestoreProcessEvents();
 

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -230,9 +230,6 @@ let Definition = "process" in {
   def UtilityExpressionTimeout: Property<"utility-expression-timeout", "UInt64">,
     DefaultUnsignedValue<15>,
     Desc<"The time in seconds to wait for LLDB-internal utility expressions.">;
-  def InterruptTimeout: Property<"interrupt-timeout", "UInt64">,
-    DefaultUnsignedValue<20>,
-    Desc<"The time in seconds to wait for an interrupt succeed in stopping the target.">;
   def SteppingRunsAllThreads: Property<"run-all-threads", "Boolean">,
     DefaultFalse,
     Desc<"If true, stepping operations will run all threads.  This is equivalent to setting the run-mode option to 'all-threads'.">;

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteClientBaseTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteClientBaseTest.cpp
@@ -55,8 +55,6 @@ public:
   }
 
 protected:
-  // We don't have a process to get the interrupt timeout from, so make one up.
-  static std::chrono::seconds g_timeout;
   TestClient client;
   MockServer server;
   MockDelegate delegate;
@@ -64,8 +62,7 @@ protected:
 
   StateType SendCPacket(StringExtractorGDBRemote &response) {
     return client.SendContinuePacketAndWaitForResponse(delegate, LinuxSignals(),
-                                                       "c", g_timeout, 
-                                                       response);
+                                                       "c", response);
   }
 
   void WaitForRunEvent() {
@@ -74,8 +71,6 @@ protected:
         &client, TestClient::eBroadcastBitRunPacketSent, event_sp, llvm::None);
   }
 };
-
-std::chrono::seconds GDBRemoteClientBaseTest::g_timeout(10);
 
 } // end anonymous namespace
 
@@ -108,7 +103,7 @@ TEST_F(GDBRemoteClientBaseTest, SendContinueAndAsyncSignal) {
   StringExtractorGDBRemote continue_response, response;
 
   // SendAsyncSignal should do nothing when we are not running.
-  ASSERT_FALSE(client.SendAsyncSignal(0x47, g_timeout));
+  ASSERT_FALSE(client.SendAsyncSignal(0x47));
 
   // Continue. After the run packet is sent, send an async signal.
   std::future<StateType> continue_state = std::async(
@@ -117,9 +112,8 @@ TEST_F(GDBRemoteClientBaseTest, SendContinueAndAsyncSignal) {
   ASSERT_EQ("c", response.GetStringRef());
   WaitForRunEvent();
 
-  std::future<bool> async_result = std::async(std::launch::async, [&] {
-    return client.SendAsyncSignal(0x47, g_timeout);
-  });
+  std::future<bool> async_result = std::async(
+      std::launch::async, [&] { return client.SendAsyncSignal(0x47); });
 
   // First we'll get interrupted.
   ASSERT_EQ(PacketResult::Success, server.GetPacket(response));
@@ -139,6 +133,7 @@ TEST_F(GDBRemoteClientBaseTest, SendContinueAndAsyncSignal) {
 
 TEST_F(GDBRemoteClientBaseTest, SendContinueAndAsyncPacket) {
   StringExtractorGDBRemote continue_response, async_response, response;
+  const bool send_async = true;
 
   // Continue. After the run packet is sent, send an async packet.
   std::future<StateType> continue_state = std::async(
@@ -148,12 +143,13 @@ TEST_F(GDBRemoteClientBaseTest, SendContinueAndAsyncPacket) {
   WaitForRunEvent();
 
   // Sending without async enabled should fail.
-  ASSERT_EQ(PacketResult::ErrorSendFailed,
-            client.SendPacketAndWaitForResponse("qTest1", response));
+  ASSERT_EQ(
+      PacketResult::ErrorSendFailed,
+      client.SendPacketAndWaitForResponse("qTest1", response, !send_async));
 
   std::future<PacketResult> async_result = std::async(std::launch::async, [&] {
     return client.SendPacketAndWaitForResponse("qTest2", async_response,
-                                               g_timeout);
+                                               send_async);
   });
 
   // First we'll get interrupted.
@@ -182,7 +178,7 @@ TEST_F(GDBRemoteClientBaseTest, SendContinueAndInterrupt) {
   StringExtractorGDBRemote continue_response, response;
 
   // Interrupt should do nothing when we're not running.
-  ASSERT_FALSE(client.Interrupt(g_timeout));
+  ASSERT_FALSE(client.Interrupt());
 
   // Continue. After the run packet is sent, send an interrupt.
   std::future<StateType> continue_state = std::async(
@@ -191,8 +187,8 @@ TEST_F(GDBRemoteClientBaseTest, SendContinueAndInterrupt) {
   ASSERT_EQ("c", response.GetStringRef());
   WaitForRunEvent();
 
-  std::future<bool> async_result = std::async(
-      std::launch::async, [&] { return client.Interrupt(g_timeout); });
+  std::future<bool> async_result =
+      std::async(std::launch::async, [&] { return client.Interrupt(); });
 
   // We get interrupted.
   ASSERT_EQ(PacketResult::Success, server.GetPacket(response));
@@ -215,8 +211,8 @@ TEST_F(GDBRemoteClientBaseTest, SendContinueAndLateInterrupt) {
   ASSERT_EQ("c", response.GetStringRef());
   WaitForRunEvent();
 
-  std::future<bool> async_result = std::async(
-      std::launch::async, [&] { return client.Interrupt(g_timeout); });
+  std::future<bool> async_result =
+      std::async(std::launch::async, [&] { return client.Interrupt(); });
 
   // However, the target stops due to a different reason than the original
   // interrupt.
@@ -237,9 +233,10 @@ TEST_F(GDBRemoteClientBaseTest, SendContinueAndLateInterrupt) {
 
 TEST_F(GDBRemoteClientBaseTest, SendContinueAndInterrupt2PacketBug) {
   StringExtractorGDBRemote continue_response, async_response, response;
+  const bool send_async = true;
 
   // Interrupt should do nothing when we're not running.
-  ASSERT_FALSE(client.Interrupt(g_timeout));
+  ASSERT_FALSE(client.Interrupt());
 
   // Continue. After the run packet is sent, send an async signal.
   std::future<StateType> continue_state = std::async(
@@ -248,8 +245,8 @@ TEST_F(GDBRemoteClientBaseTest, SendContinueAndInterrupt2PacketBug) {
   ASSERT_EQ("c", response.GetStringRef());
   WaitForRunEvent();
 
-  std::future<bool> interrupt_result = std::async(
-      std::launch::async, [&] { return client.Interrupt(g_timeout); });
+  std::future<bool> interrupt_result =
+      std::async(std::launch::async, [&] { return client.Interrupt(); });
 
   // We get interrupted. We'll send two packets to simulate a buggy stub.
   ASSERT_EQ(PacketResult::Success, server.GetPacket(response));
@@ -264,7 +261,8 @@ TEST_F(GDBRemoteClientBaseTest, SendContinueAndInterrupt2PacketBug) {
 
   // Packet stream should remain synchronized.
   std::future<PacketResult> send_result = std::async(std::launch::async, [&] {
-    return client.SendPacketAndWaitForResponse("qTest", async_response);
+    return client.SendPacketAndWaitForResponse("qTest", async_response,
+                                               !send_async);
   });
   ASSERT_EQ(PacketResult::Success, server.GetPacket(response));
   ASSERT_EQ("qTest", response.GetStringRef());
@@ -330,8 +328,8 @@ TEST_F(GDBRemoteClientBaseTest, InterruptNoResponse) {
   ASSERT_EQ("c", response.GetStringRef());
   WaitForRunEvent();
 
-  std::future<bool> async_result = std::async(
-      std::launch::async, [&] { return client.Interrupt(g_timeout); });
+  std::future<bool> async_result =
+      std::async(std::launch::async, [&] { return client.Interrupt(); });
 
   // We get interrupted, but we don't send a stop packet.
   ASSERT_EQ(PacketResult::Success, server.GetPacket(response));
@@ -354,7 +352,7 @@ TEST_F(GDBRemoteClientBaseTest, SendPacketAndReceiveResponseWithOutputSupport) {
   ASSERT_EQ(PacketResult::Success, server.SendPacket("OK"));
 
   PacketResult result = client.SendPacketAndReceiveResponseWithOutputSupport(
-      "qRcmd,test", response, g_timeout,
+      "qRcmd,test", response, true,
       [&command_output](llvm::StringRef output) { command_output << output; });
 
   ASSERT_EQ(PacketResult::Success, result);

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
@@ -386,7 +386,7 @@ TEST_F(GDBRemoteCommunicationClientTest, SendTraceSupportedTypePacket) {
   std::string error_message;
   auto callback = [&] {
     if (llvm::Expected<TraceTypeInfo> trace_type_or_err =
-        client.SendGetSupportedTraceType(std::chrono::seconds(10))) {
+            client.SendGetSupportedTraceType()) {
       trace_type = *trace_type_or_err;
       error_message = "";
       return true;
@@ -458,7 +458,7 @@ TEST_F(GDBRemoteCommunicationClientTest, SendStartTracePacket) {
   options.setTraceParams(custom_params);
 
   std::future<lldb::user_id_t> result = std::async(std::launch::async, [&] {
-    return client.SendStartTracePacket(options, std::chrono::seconds(10), error);
+    return client.SendStartTracePacket(options, error);
   });
 
   // Since the line is exceeding 80 characters.
@@ -472,9 +472,7 @@ TEST_F(GDBRemoteCommunicationClientTest, SendStartTracePacket) {
 
   error.Clear();
   result = std::async(std::launch::async, [&] {
-    return client.SendStartTracePacket(options,
-                                       std::chrono::seconds(10),
-                                       error);
+    return client.SendStartTracePacket(options, error);
   });
 
   HandlePacket(server, (expected_packet1 + expected_packet2), "E23");
@@ -487,8 +485,7 @@ TEST_F(GDBRemoteCommunicationClientTest, SendStopTracePacket) {
   lldb::user_id_t trace_id = 3;
 
   std::future<Status> result = std::async(std::launch::async, [&] {
-    return client.SendStopTracePacket(trace_id, thread_id,
-                                      std::chrono::seconds(10));
+    return client.SendStopTracePacket(trace_id, thread_id);
   });
 
   const char *expected_packet = R"(jTraceStop:{"threadid":35,"traceid":3})";
@@ -496,7 +493,7 @@ TEST_F(GDBRemoteCommunicationClientTest, SendStopTracePacket) {
   ASSERT_TRUE(result.get().Success());
 
   result = std::async(std::launch::async, [&] {
-    return client.SendStopTracePacket(trace_id, thread_id, std::chrono::seconds(10));
+    return client.SendStopTracePacket(trace_id, thread_id);
   });
 
   HandlePacket(server, expected_packet, "E23");
@@ -512,8 +509,7 @@ TEST_F(GDBRemoteCommunicationClientTest, SendGetDataPacket) {
   size_t offset = 0;
 
   std::future<Status> result = std::async(std::launch::async, [&] {
-    return client.SendGetDataPacket(trace_id, thread_id, buffer,
-                                    std::chrono::seconds(10), offset);
+    return client.SendGetDataPacket(trace_id, thread_id, buffer, offset);
   });
 
   std::string expected_packet1 =
@@ -528,8 +524,7 @@ TEST_F(GDBRemoteCommunicationClientTest, SendGetDataPacket) {
 
   llvm::MutableArrayRef<uint8_t> buffer2(buf, 32);
   result = std::async(std::launch::async, [&] {
-    return client.SendGetDataPacket(trace_id, thread_id, buffer2,
-                                    std::chrono::seconds(10), offset);
+    return client.SendGetDataPacket(trace_id, thread_id, buffer2, offset);
   });
 
   HandlePacket(server, expected_packet1+expected_packet2, "E23");
@@ -546,8 +541,7 @@ TEST_F(GDBRemoteCommunicationClientTest, SendGetMetaDataPacket) {
   size_t offset = 0;
 
   std::future<Status> result = std::async(std::launch::async, [&] {
-    return client.SendGetMetaDataPacket(trace_id, thread_id, buffer,
-                                        std::chrono::seconds(10), offset);
+    return client.SendGetMetaDataPacket(trace_id, thread_id, buffer, offset);
   });
 
   std::string expected_packet1 =
@@ -562,9 +556,7 @@ TEST_F(GDBRemoteCommunicationClientTest, SendGetMetaDataPacket) {
 
   llvm::MutableArrayRef<uint8_t> buffer2(buf, 32);
   result = std::async(std::launch::async, [&] {
-    return client.SendGetMetaDataPacket(trace_id, thread_id, buffer2,
-                                        std::chrono::seconds(10),
-                                        offset);
+    return client.SendGetMetaDataPacket(trace_id, thread_id, buffer2, offset);
   });
 
   HandlePacket(server, expected_packet1+expected_packet2, "E23");
@@ -579,8 +571,7 @@ TEST_F(GDBRemoteCommunicationClientTest, SendGetTraceConfigPacket) {
   options.setThreadID(thread_id);
 
   std::future<Status> result = std::async(std::launch::async, [&] {
-    return client.SendGetTraceConfigPacket(trace_id, options,
-                                           std::chrono::seconds(10));
+    return client.SendGetTraceConfigPacket(trace_id, options);
   });
 
   const char *expected_packet =
@@ -609,8 +600,7 @@ TEST_F(GDBRemoteCommunicationClientTest, SendGetTraceConfigPacket) {
 
   // Checking error response.
   std::future<Status> result2 = std::async(std::launch::async, [&] {
-    return client.SendGetTraceConfigPacket(trace_id, options,
-                                           std::chrono::seconds(10));
+    return client.SendGetTraceConfigPacket(trace_id, options);
   });
 
   HandlePacket(server, expected_packet, "E23");
@@ -618,8 +608,7 @@ TEST_F(GDBRemoteCommunicationClientTest, SendGetTraceConfigPacket) {
 
   // Wrong JSON as response.
   std::future<Status> result3 = std::async(std::launch::async, [&] {
-    return client.SendGetTraceConfigPacket(trace_id, options,
-                                           std::chrono::seconds(10));
+    return client.SendGetTraceConfigPacket(trace_id, options);
   });
 
   std::string incorrect_json1 =
@@ -631,8 +620,7 @@ TEST_F(GDBRemoteCommunicationClientTest, SendGetTraceConfigPacket) {
 
   // Wrong JSON as custom_params.
   std::future<Status> result4 = std::async(std::launch::async, [&] {
-    return client.SendGetTraceConfigPacket(trace_id, options,
-                                           std::chrono::seconds(10));
+    return client.SendGetTraceConfigPacket(trace_id, options);
   });
 
   std::string incorrect_custom_params1 =

--- a/lldb/unittests/tools/lldb-server/tests/TestClient.cpp
+++ b/lldb/unittests/tools/lldb-server/tests/TestClient.cpp
@@ -193,7 +193,7 @@ Error TestClient::SendMessage(StringRef message, std::string &response_string,
                               PacketResult expected_result) {
   StringExtractorGDBRemote response;
   GTEST_LOG_(INFO) << "Send Packet: " << message.str();
-  PacketResult result = SendPacketAndWaitForResponse(message, response);
+  PacketResult result = SendPacketAndWaitForResponse(message, response, false);
   response.GetEscapedBinaryData(response_string);
   GTEST_LOG_(INFO) << "Read Packet: " << response_string;
   if (result != expected_result)


### PR DESCRIPTION
…the"

This reverts commit d82650fd1790813837bde056b2066bd4206e5d99.

This interrupt timeout seems to cause us to every so often miss a stop
reply packet.  Revert till I can figure out how that could happen.