### PR TITLE
[lldb/API] Use a valid LineEntry object in SBCompileUnit::FindLineEntryIndex

### DIFF
--- a/lldb/source/API/SBCompileUnit.cpp
+++ b/lldb/source/API/SBCompileUnit.cpp
@@ -108,9 +108,10 @@ uint32_t SBCompileUnit::FindLineEntryIndex(uint32_t start_idx, uint32_t line,
     else
       file_spec = m_opaque_ptr->GetPrimaryFile();
 
+    LineEntry line_entry;
     index = m_opaque_ptr->FindLineEntry(
         start_idx, line, inline_file_spec ? inline_file_spec->get() : nullptr,
-        exact, nullptr);
+        exact, &line_entry);
   }
 
   return index;

--- a/lldb/test/API/functionalities/find-line-entry/Makefile
+++ b/lldb/test/API/functionalities/find-line-entry/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/find-line-entry/TestFindLineEntry.py
+++ b/lldb/test/API/functionalities/find-line-entry/TestFindLineEntry.py
@@ -1,0 +1,33 @@
+"""
+Test that SBCompileUnit::FindLineEntryIndex works correctly.
+"""
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+
+class FindLineEntry(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def test_compile_unit_find_line_entry_index(self):
+        """ Test the CompileUnit LineEntryIndex lookup API """
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+        self.target = self.dbg.CreateTarget(exe)
+        self.assertTrue(self.target.IsValid(), "Target is not valid")
+
+        self.file = lldb.SBFileSpec("main.c")
+        sc_list = self.target.FindCompileUnits(self.file)
+        self.assertEqual(len(sc_list), 1)
+        cu = sc_list[0].GetCompileUnit()
+        self.assertTrue(cu.IsValid(), "CompileUnit is not valid")
+
+        # First look for valid line
+        self.line = line_number("main.c", "int change_me")
+        self.assertNotEqual(cu.FindLineEntryIndex(0, self.line, self.file),
+                            lldb.LLDB_INVALID_LINE_NUMBER)
+
+        # Then look for a line out of bound
+        self.assertEqual(cu.FindLineEntryIndex(0, 42, self.file),
+                            lldb.LLDB_INVALID_LINE_NUMBER)

--- a/lldb/test/API/functionalities/find-line-entry/main.c
+++ b/lldb/test/API/functionalities/find-line-entry/main.c
@@ -1,0 +1,7 @@
+int main() {
+  int change_me = 0;
+  for (int i = 0; i < 2; i++) {
+    change_me++;
+  }
+  return 0;
+}


### PR DESCRIPTION
This patch updates `SBCompileUnit::FindLineEntryIndex` to pass a valid
`LineEntry` pointer to `CompileUnit::FindLineEntry`.

This caused `LineTable::FindLineEntryIndexByFileIndexImpl` to return its
`best_match` initial value (UINT32_MAX).

rdar://78115426

Differential Revision: https://reviews.llvm.org/D102658

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>