### PR TITLE
Fix coro-debug-O2.ll

### DIFF
--- a/llvm/test/Transforms/Coroutines/coro-debug-O2.ll
+++ b/llvm/test/Transforms/Coroutines/coro-debug-O2.ll
@@ -4,6 +4,7 @@
 
 ; CHECK-LABEL: define internal fastcc void @f.resume({{.*}})
 ; CHECK:       entry.resume:
+; CHECK:        call void @llvm.dbg.declare(
 ; CHECK:        call void @llvm.dbg.declare(metadata %f.Frame* %FramePtr, metadata ![[PROMISEVAR_RESUME:[0-9]+]], metadata !DIExpression(
 ;
 ; CHECK: ![[PROMISEVAR_RESUME]] = !DILocalVariable(name: "__promise"


### PR DESCRIPTION
There are differences in the orders in which debug instructions are emitted in coro::salvageDebugInfo between github.com/apple and llvm.org.