### PR TITLE
Override EndSourceFile in WrappingIndexRecordAction

### DIFF
--- a/clang/lib/Index/IndexingAction.cpp
+++ b/clang/lib/Index/IndexingAction.cpp
@@ -672,6 +672,10 @@ protected:
     return std::make_unique<MultiplexConsumer>(std::move(Consumers));
   }
 
+  void EndSourceFile() override {
+    FrontendAction::EndSourceFile();
+  }
+
   void EndSourceFileAction() override {
     // Invoke wrapped action's method.
     WrapperFrontendAction::EndSourceFileAction();


### PR DESCRIPTION
92f9852fc99b0a18e8d1329341f36f1708343f05 caused index tests to fail. This commit is an attempt to restore the behavior prior to that.