### PR TITLE
Annotate this argument with alignment

### DIFF
--- a/clang/test/CodeGenCXX/ptrauth-apple-kext-indirect-call-2.cpp
+++ b/clang/test/CodeGenCXX/ptrauth-apple-kext-indirect-call-2.cpp
@@ -100,6 +100,6 @@ void FUNC4(Derived4* p) {
 // CHECK: %[[T5:[0-9]+]] = load void (%struct.Derived4*)*, void (%struct.Derived4*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint void (%struct.Derived4*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 426)
-// CHECK: call void %[[T5]](%struct.Derived4* nonnull dereferenceable(8) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call void %[[T5]](%struct.Derived4* nonnull align {{[0-9]+}} dereferenceable(8) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
   p->abc();
 }

--- a/clang/test/CodeGenCXX/ptrauth-apple-kext-indirect-call.cpp
+++ b/clang/test/CodeGenCXX/ptrauth-apple-kext-indirect-call.cpp
@@ -38,5 +38,5 @@ void f(SubTempl<int>* t) {
 }
 
 // CHECK: getelementptr inbounds (void (%struct.Templ*)*, void (%struct.Templ*)** bitcast ({ [5 x i8*] }* @_ZTV5TemplIiE to void (%struct.Templ*)**), i64 2)
-// CHECK: define internal void @_ZN5TemplIiE1fEv(%struct.Templ* nonnull dereferenceable(8) %this)
-// CHECK: define internal void @_ZN5TemplIiE1gEv(%struct.Templ* nonnull dereferenceable(8) %this)
+// CHECK: define internal void @_ZN5TemplIiE1fEv(%struct.Templ* nonnull align {{[0-9]+}} dereferenceable(8) %this)
+// CHECK: define internal void @_ZN5TemplIiE1gEv(%struct.Templ* nonnull align {{[0-9]+}} dereferenceable(8) %this)

--- a/clang/test/CodeGenCXX/ptrauth-apple-kext-indirect-virtual-dtor-call.cpp
+++ b/clang/test/CodeGenCXX/ptrauth-apple-kext-indirect-virtual-dtor-call.cpp
@@ -14,11 +14,11 @@ void DELETE(B1 *pb1) {
 // CHECK-LABEL: define void @_ZN2B1D0Ev
 // CHECK: [[T1:%.*]] = load %struct.B1* (%struct.B1*)*, %struct.B1* (%struct.B1*)** getelementptr inbounds (%struct.B1* (%struct.B1*)*, %struct.B1* (%struct.B1*)** bitcast ({ [5 x i8*] }* @_ZTV2B1 to %struct.B1* (%struct.B1*)**), i64 2)
 // CHECK-NEXT: [[B1:%.*]] = call i64 @llvm.ptrauth.blend.i64(i64 ptrtoint (%struct.B1* (%struct.B1*)** getelementptr inbounds (%struct.B1* (%struct.B1*)*, %struct.B1* (%struct.B1*)** bitcast ({ [5 x i8*] }* @_ZTV2B1 to %struct.B1* (%struct.B1*)**), i64 2) to i64), i64 14635)
-// CHECK-NEXT: call %struct.B1* [[T1]](%struct.B1* nonnull dereferenceable(8) [[T2:%.*]]) [ "ptrauth"(i32 0, i64 [[B1]]) ]
+// CHECK-NEXT: call %struct.B1* [[T1]](%struct.B1* nonnull align 8 dereferenceable(8) [[T2:%.*]]) [ "ptrauth"(i32 0, i64 [[B1]]) ]
 // CHECK-LABEL: define void @_Z6DELETEP2B1
 // CHECK: [[T3:%.*]] = load %struct.B1* (%struct.B1*)*, %struct.B1* (%struct.B1*)** getelementptr inbounds (%struct.B1* (%struct.B1*)*, %struct.B1* (%struct.B1*)** bitcast ({ [5 x i8*] }* @_ZTV2B1 to %struct.B1* (%struct.B1*)**), i64 2)
 // CHECK-NEXT: [[B3:%.*]] = call i64 @llvm.ptrauth.blend.i64(i64 ptrtoint (%struct.B1* (%struct.B1*)** getelementptr inbounds (%struct.B1* (%struct.B1*)*, %struct.B1* (%struct.B1*)** bitcast ({ [5 x i8*] }* @_ZTV2B1 to %struct.B1* (%struct.B1*)**), i64 2) to i64), i64 14635)
-// CHECK-NEXT:  call %struct.B1* [[T3]](%struct.B1* nonnull dereferenceable(8) [[T4:%.*]]) [ "ptrauth"(i32 0, i64 [[B3]])
+// CHECK-NEXT:  call %struct.B1* [[T3]](%struct.B1* nonnull align 8 dereferenceable(8) [[T4:%.*]]) [ "ptrauth"(i32 0, i64 [[B3]])
 
 template<class T>
 struct Templ {
@@ -45,6 +45,6 @@ void f(SubTempl<int>* t) {
 }
 
 // CHECK: getelementptr inbounds (%struct.Templ* (%struct.Templ*)*, %struct.Templ* (%struct.Templ*)** bitcast ({ [7 x i8*] }* @_ZTV5TemplIiE to %struct.Templ* (%struct.Templ*)**), i64 2)
-// CHECK: declare void @_ZN5TemplIiED0Ev(%struct.Templ* nonnull dereferenceable(8))
-// CHECK: define internal void @_ZN5TemplIiE1fEv(%struct.Templ* nonnull dereferenceable(8) %this)
-// CHECK: define internal void @_ZN5TemplIiE1gEv(%struct.Templ* nonnull dereferenceable(8) %this)
+// CHECK: declare void @_ZN5TemplIiED0Ev(%struct.Templ* nonnull align 8 dereferenceable(8))
+// CHECK: define internal void @_ZN5TemplIiE1fEv(%struct.Templ* nonnull align 8 dereferenceable(8) %this)
+// CHECK: define internal void @_ZN5TemplIiE1gEv(%struct.Templ* nonnull align 8 dereferenceable(8) %this)

--- a/clang/test/CodeGenCXX/ptrauth-member-function-pointer.cpp
+++ b/clang/test/CodeGenCXX/ptrauth-member-function-pointer.cpp
@@ -120,7 +120,7 @@ typedef void (Derived0::*MethodTy1)();
 // CHECK-NEXT: %[[V5:.*]] = load void (%[[STRUCT_BASE0]]*)*, void (%[[STRUCT_BASE0]]*)** %[[VFN]], align 8
 // CHECK-NEXT: %[[V6:.*]] = ptrtoint void (%[[STRUCT_BASE0]]*)** %[[VFN]] to i64
 // CHECK-NEXT: %[[V7:.*]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[V6]], i64 55600)
-// CHECK-NEXT: musttail call void %[[V5]](%[[STRUCT_BASE0]]* nonnull dereferenceable(8) %[[V0]]) [ "ptrauth"(i32 0, i64 %[[V7]]) ]
+// CHECK-NEXT: musttail call void %[[V5]](%[[STRUCT_BASE0]]* nonnull align {{[0-9]+}} dereferenceable(8) %[[V0]]) [ "ptrauth"(i32 0, i64 %[[V7]]) ]
 // CHECK-NEXT: ret void
 
 // CHECK: define linkonce_odr hidden void @_ZN5Base08virtual3Ev_vfpthunk_(%[[STRUCT_BASE0]]* %{{.*}}) {{.*}}align 2
@@ -148,7 +148,7 @@ typedef void (Derived0::*MethodTy1)();
 // CHECK-NEXT: %[[V7:.*]] = load void (%[[STRUCT_BASE0]]*, i32, ...)*, void (%[[STRUCT_BASE0]]*, i32, ...)** %[[VFN]], align 8
 // CHECK-NEXT: %[[V8:.*]] = ptrtoint void (%[[STRUCT_BASE0]]*, i32, ...)** %[[VFN]] to i64
 // CHECK-NEXT: %[[V9:.*]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[V8]], i64 7464)
-// CHECK-NEXT: musttail call void (%[[STRUCT_BASE0]]*, i32, ...) %[[V7]](%[[STRUCT_BASE0]]* nonnull dereferenceable(8) %[[V1]], i32 %[[V2]], ...) [ "ptrauth"(i32 0, i64 %[[V9]]) ]
+// CHECK-NEXT: musttail call void (%[[STRUCT_BASE0]]*, i32, ...) %[[V7]](%[[STRUCT_BASE0]]* nonnull align {{[0-9]+}} dereferenceable(8) %[[V1]], i32 %[[V2]], ...) [ "ptrauth"(i32 0, i64 %[[V9]]) ]
 // CHECK-NEXT: ret void
 
 // CHECK: define linkonce_odr hidden void @_ZN8Derived08virtual6Ev_vfpthunk_(%[[STRUCT_DERIVED0]]* %{{.*}}){{.*}} align 2
@@ -162,14 +162,14 @@ typedef void (Derived0::*MethodTy1)();
 // Check that the return value of the musttail call isn't copied to a temporary.
 
 // CHECK: define linkonce_odr hidden [2 x i64] @_ZN8Derived010return_aggEv_vfpthunk_(%[[STRUCT_DERIVED0]]* %{{.*}})
-// CHECK: %[[CALL:.*]] = musttail call [2 x i64] %{{.*}}(%[[STRUCT_DERIVED0]]* nonnull dereferenceable(8) %{{.*}}) [ "ptrauth"(i32 0, i64 %{{.*}}) ]
+// CHECK: %[[CALL:.*]] = musttail call [2 x i64] %{{.*}}(%[[STRUCT_DERIVED0]]* nonnull align {{[0-9]+}} dereferenceable(8) %{{.*}}) [ "ptrauth"(i32 0, i64 %{{.*}}) ]
 // CHECK-NEXT: ret [2 x i64] %[[CALL]]
 
 // Check that the sret pointer passed to the caller is forwarded to the musttail
 // call.
 
 // CHECK: define linkonce_odr hidden void @_ZN8Derived04sretEv_vfpthunk_(%[[STRUCT_A1]]* noalias sret(%struct.A1) align 4 %[[AGG_RESULT:.*]], %[[STRUCT_DERIVED0]]* %{{.*}})
-// CHECK: musttail call void %{{.*}}(%[[STRUCT_A1]]* sret(%struct.A1) align 4 %[[AGG_RESULT]], %[[STRUCT_DERIVED0]]* nonnull dereferenceable(8) %{{.*}}) [ "ptrauth"(i32 0, i64 %{{.*}}) ]
+// CHECK: musttail call void %{{.*}}(%[[STRUCT_A1]]* sret(%struct.A1) align 4 %[[AGG_RESULT]], %[[STRUCT_DERIVED0]]* nonnull align {{[0-9]+}} dereferenceable(8) %{{.*}}) [ "ptrauth"(i32 0, i64 %{{.*}}) ]
 // CHECK-NEXT: ret void
 
 // Check that the thunk function doesn't destruct the trivial_abi argument.
@@ -270,7 +270,7 @@ void test0() {
 
 // CHECK: %[[V14:.*]] = phi void (%[[STRUCT_BASE0]]*)* [ %[[MEMPTR_VIRTUALFN]], {{.*}} ], [ %[[MEMPTR_NONVIRTUALFN]], {{.*}} ]
 // CHECK: %[[V15:.*]] = phi i64 [ 0, {{.*}} ], [ [[TYPEDISC0]], {{.*}} ]
-// CHECK: call void %[[V14]](%[[STRUCT_BASE0]]* nonnull dereferenceable(8) %[[THIS_ADJUSTED]]) [ "ptrauth"(i32 0, i64 %[[V15]]) ]
+// CHECK: call void %[[V14]](%[[STRUCT_BASE0]]* nonnull align {{[0-9]+}} dereferenceable(8) %[[THIS_ADJUSTED]]) [ "ptrauth"(i32 0, i64 %[[V15]]) ]
 // CHECK: ret void
 
 void test1(Base0 *a0, MethodTy0 a1) {

--- a/clang/test/CodeGenCXX/ptrauth-qualifier-struct.cpp
+++ b/clang/test/CodeGenCXX/ptrauth-qualifier-struct.cpp
@@ -52,7 +52,7 @@ void testMoveConstructor(SA a) {
 // CHECK: define void @_Z18testCopyAssignment2SA(%[[STRUCT_SA]]*
 // CHECK: call nonnull align 8 dereferenceable(16) %[[STRUCT_SA]]* @_ZN2SAaSERKS_(
 
-// CHECK: define linkonce_odr nonnull align 8 dereferenceable(16) %[[STRUCT_SA:.*]]* @_ZN2SAaSERKS_(%[[STRUCT_SA]]* nonnull dereferenceable(16) %[[THIS:.*]], %[[STRUCT_SA]]* nonnull align 8 dereferenceable(16) %0)
+// CHECK: define linkonce_odr nonnull align 8 dereferenceable(16) %[[STRUCT_SA:.*]]* @_ZN2SAaSERKS_(%[[STRUCT_SA]]* nonnull align 8 dereferenceable(16) %[[THIS:.*]], %[[STRUCT_SA]]* nonnull align 8 dereferenceable(16) %0)
 // CHECK: %[[THIS_ADDR:.*]] = alloca %[[STRUCT_SA]]*, align 8
 // CHECK: %[[_ADDR:.*]] = alloca %[[STRUCT_SA]]*, align 8
 // CHECK: store %[[STRUCT_SA]]* %[[THIS]], %[[STRUCT_SA]]** %[[THIS_ADDR]], align 8
@@ -77,7 +77,7 @@ void testCopyAssignment(SA a) {
 // CHECK: define void @_Z18testMoveAssignment2SA(%[[STRUCT_SA]]*
 // CHECK: call nonnull align 8 dereferenceable(16) %[[STRUCT_SA]]* @_ZN2SAaSEOS_(
 
-// CHECK: define linkonce_odr nonnull align 8 dereferenceable(16) %[[STRUCT_SA:.*]]* @_ZN2SAaSEOS_(%[[STRUCT_SA]]* nonnull dereferenceable(16) %[[THIS:.*]], %[[STRUCT_SA]]* nonnull align 8 dereferenceable(16) %0)
+// CHECK: define linkonce_odr nonnull align 8 dereferenceable(16) %[[STRUCT_SA:.*]]* @_ZN2SAaSEOS_(%[[STRUCT_SA]]* nonnull align 8 dereferenceable(16) %[[THIS:.*]], %[[STRUCT_SA]]* nonnull align 8 dereferenceable(16) %0)
 // CHECK: %[[THIS_ADDR:.*]] = alloca %[[STRUCT_SA]]*, align 8
 // CHECK: %[[_ADDR:.*]] = alloca %[[STRUCT_SA]]*, align 8
 // CHECK: store %[[STRUCT_SA]]* %[[THIS]], %[[STRUCT_SA]]** %[[THIS_ADDR]], align 8
@@ -129,7 +129,7 @@ void testMoveAssignment(SI a) {
   t = static_cast<SI &&>(a);
 }
 
-// CHECK: define linkonce_odr %[[STRUCT_SA:.*]]* @_ZN2SAC2ERKS_(%[[STRUCT_SA]]* nonnull dereferenceable(16) %[[THIS:.*]], %[[STRUCT_SA]]* nonnull align 8 dereferenceable(16) %0)
+// CHECK: define linkonce_odr %[[STRUCT_SA:.*]]* @_ZN2SAC2ERKS_(%[[STRUCT_SA]]* nonnull align 8 dereferenceable(16) %[[THIS:.*]], %[[STRUCT_SA]]* nonnull align 8 dereferenceable(16) %0)
 // CHECK: %[[RETVAL:.*]] = alloca %[[STRUCT_SA]]*, align 8
 // CHECK: %[[THIS_ADDR:.*]] = alloca %[[STRUCT_SA]]*, align 8
 // CHECK: %[[_ADDR:.*]] = alloca %[[STRUCT_SA]]*, align 8
@@ -148,7 +148,7 @@ void testMoveAssignment(SI a) {
 // CHECK: %[[V8:.*]] = ptrtoint i32* %[[V2]] to i64
 // CHECK: %[[V9:.*]] = call i64 @llvm.ptrauth.resign.i64(i64 %[[V8]], i32 1, i64 %[[V4]], i32 1, i64 %[[V6]])
 
-// CHECK: define linkonce_odr %[[STRUCT_SA:.*]]* @_ZN2SAC2EOS_(%[[STRUCT_SA]]* nonnull dereferenceable(16) %[[THIS:.*]], %[[STRUCT_SA]]* nonnull align 8 dereferenceable(16) %0)
+// CHECK: define linkonce_odr %[[STRUCT_SA:.*]]* @_ZN2SAC2EOS_(%[[STRUCT_SA]]* nonnull align 8 dereferenceable(16) %[[THIS:.*]], %[[STRUCT_SA]]* nonnull align 8 dereferenceable(16) %0)
 // CHECK: %[[RETVAL:.*]] = alloca %[[STRUCT_SA]]*, align 8
 // CHECK: %[[THIS_ADDR:.*]] = alloca %[[STRUCT_SA]]*, align 8
 // CHECK: %[[_ADDR:.*]] = alloca %[[STRUCT_SA]]*, align 8

--- a/clang/test/CodeGenCXX/ptrauth-virtual-function.cpp
+++ b/clang/test/CodeGenCXX/ptrauth-virtual-function.cpp
@@ -216,7 +216,7 @@ V1::~V1() {
 // CHECK: %[[T5:[0-9]+]] = load void (%class.B0*)*, void (%class.B0*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint void (%class.B0*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 53119)
-// CHECK: call void %[[T5]](%class.B0* nonnull dereferenceable(12) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call void %[[T5]](%class.B0* nonnull align {{[0-9]+}} dereferenceable(12) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testB0m0(B0 *a) {
   a->m0();
@@ -231,7 +231,7 @@ void testB0m0(B0 *a) {
 // CHECK: %[[T5:[0-9]+]] = load %struct.S1* (%class.B0*)*, %struct.S1* (%class.B0*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint %struct.S1* (%class.B0*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 15165)
-// CHECK: call %struct.S1* %[[T5]](%class.B0* nonnull dereferenceable(12) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call %struct.S1* %[[T5]](%class.B0* nonnull align {{[0-9]+}} dereferenceable(12) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testB0m1(B0 *a) {
   a->m1();
@@ -246,7 +246,7 @@ void testB0m1(B0 *a) {
 // CHECK: %[[T5:[0-9]+]] = load void (%class.B0*)*, void (%class.B0*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint void (%class.B0*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 43073)
-// CHECK: call void %[[T5]](%class.B0* nonnull dereferenceable(12) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call void %[[T5]](%class.B0* nonnull align {{[0-9]+}} dereferenceable(12) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testB0m2(B0 *a) {
   a->m2();
@@ -261,7 +261,7 @@ void testB0m2(B0 *a) {
 // CHECK: %[[T5:[0-9]+]] = load void (%class.D0*)*, void (%class.D0*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint void (%class.D0*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 53119)
-// CHECK: call void %[[T5]](%class.D0* nonnull dereferenceable(16) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call void %[[T5]](%class.D0* nonnull align {{[0-9]+}} dereferenceable(16) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testD0m0(D0 *a) {
   a->m0();
@@ -276,7 +276,7 @@ void testD0m0(D0 *a) {
 // CHECK: %[[T5:[0-9]+]] = load %struct.S2* (%class.D0*)*, %struct.S2* (%class.D0*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint %struct.S2* (%class.D0*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 35045)
-// CHECK: call %struct.S2* %[[T5]](%class.D0* nonnull dereferenceable(16) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call %struct.S2* %[[T5]](%class.D0* nonnull align {{[0-9]+}} dereferenceable(16) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testD0m1(D0 *a) {
   a->m1();
@@ -291,7 +291,7 @@ void testD0m1(D0 *a) {
 // CHECK: %[[T5:[0-9]+]] = load void (%class.B0*)*, void (%class.B0*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint void (%class.B0*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 43073)
-// CHECK: call void %[[T5]](%class.B0* nonnull dereferenceable(12) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call void %[[T5]](%class.B0* nonnull align {{[0-9]+}} dereferenceable(12) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testD0m2(D0 *a) {
   a->m2();
@@ -306,7 +306,7 @@ void testD0m2(D0 *a) {
 // CHECK: %[[T5:[0-9]+]] = load void (%class.D0*)*, void (%class.D0*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint void (%class.D0*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 10565)
-// CHECK: call void %[[T5]](%class.D0* nonnull dereferenceable(16) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call void %[[T5]](%class.D0* nonnull align {{[0-9]+}} dereferenceable(16) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testD0m3(D0 *a) {
   a->m3();
@@ -322,7 +322,7 @@ void testD0m3(D0 *a) {
 // CHECK: %[[T5:[0-9]+]] = load void (%class.D1*)*, void (%class.D1*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint void (%class.D1*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 53119)
-// CHECK: call void %[[T5]](%class.D1* nonnull dereferenceable(16) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call void %[[T5]](%class.D1* nonnull align {{[0-9]+}} dereferenceable(16) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testD1m0(D1 *a) {
   a->m0();
@@ -337,7 +337,7 @@ void testD1m0(D1 *a) {
 // CHECK: %[[T5:[0-9]+]] = load %struct.S2* (%class.D1*)*, %struct.S2* (%class.D1*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint %struct.S2* (%class.D1*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 52864)
-// CHECK: call %struct.S2* %[[T5]](%class.D1* nonnull dereferenceable(16) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call %struct.S2* %[[T5]](%class.D1* nonnull align {{[0-9]+}} dereferenceable(16) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testD1m1(D1 *a) {
   a->m1();
@@ -352,7 +352,7 @@ void testD1m1(D1 *a) {
 // CHECK: %[[T5:[0-9]+]] = load void (%class.B0*)*, void (%class.B0*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint void (%class.B0*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 43073)
-// CHECK: call void %[[T5]](%class.B0* nonnull dereferenceable(12) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call void %[[T5]](%class.B0* nonnull align {{[0-9]+}} dereferenceable(12) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testD1m2(D1 *a) {
   a->m2();
@@ -368,7 +368,7 @@ void testD1m2(D1 *a) {
 // CHECK: %[[T5:[0-9]+]] = load void (%class.D2*)*, void (%class.D2*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint void (%class.D2*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 53119)
-// CHECK: call void %[[T5]](%class.D2* nonnull dereferenceable(36) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call void %[[T5]](%class.D2* nonnull align {{[0-9]+}} dereferenceable(36) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testD2m0(D2 *a) {
   a->m0();
@@ -383,21 +383,21 @@ void testD2m0(D2 *a) {
 // CHECK: %[[T5:[0-9]+]] = load %struct.S2* (%class.D2*)*, %struct.S2* (%class.D2*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint %struct.S2* (%class.D2*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 35045)
-// CHECK: call %struct.S2* %[[T5]](%class.D2* nonnull dereferenceable(36) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call %struct.S2* %[[T5]](%class.D2* nonnull align {{[0-9]+}} dereferenceable(36) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testD2m1(D2 *a) {
   a->m1();
 }
 
 // CHECK-LABEL: define void @_Z10testD2m2D0P2D2(
-// CHECK: call void @_ZN2B02m2Ev(%class.B0* nonnull dereferenceable(12) %{{.*}}){{$}}
+// CHECK: call void @_ZN2B02m2Ev(%class.B0* nonnull align {{[0-9]+}} dereferenceable(12) %{{.*}}){{$}}
 
 void testD2m2D0(D2 *a) {
   a->D0::m2();
 }
 
 // CHECK-LABEL: define void @_Z10testD2m2D1P2D2(
-// CHECK: call void @_ZN2B02m2Ev(%class.B0* nonnull dereferenceable(12) %{{.*}}){{$}}
+// CHECK: call void @_ZN2B02m2Ev(%class.B0* nonnull align {{[0-9]+}} dereferenceable(12) %{{.*}}){{$}}
 
 void testD2m2D1(D2 *a) {
   a->D1::m2();
@@ -412,7 +412,7 @@ void testD2m2D1(D2 *a) {
 // CHECK: %[[T5:[0-9]+]] = load void (%class.D2*)*, void (%class.D2*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint void (%class.D2*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 10565)
-// CHECK: call void %[[T5]](%class.D2* nonnull dereferenceable(36) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call void %[[T5]](%class.D2* nonnull align {{[0-9]+}} dereferenceable(36) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testD2m3(D2 *a) {
   a->m3();
@@ -427,7 +427,7 @@ void testD2m3(D2 *a) {
 // CHECK: %[[T5:[0-9]+]] = load void (%class.D3*)*, void (%class.D3*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint void (%class.D3*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 44578)
-// CHECK: call void %[[T5]](%class.D3* nonnull dereferenceable(32) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call void %[[T5]](%class.D3* nonnull align {{[0-9]+}} dereferenceable(32) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testD3m0(D3 *a) {
   a->m0();
@@ -442,7 +442,7 @@ void testD3m0(D3 *a) {
 // CHECK: %[[T5:[0-9]+]] = load %struct.S2* (%class.D3*)*, %struct.S2* (%class.D3*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint %struct.S2* (%class.D3*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 30766)
-// CHECK: call %struct.S2* %[[T5]](%class.D3* nonnull dereferenceable(32) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call %struct.S2* %[[T5]](%class.D3* nonnull align {{[0-9]+}} dereferenceable(32) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testD3m1(D3 *a) {
   a->m1();
@@ -457,7 +457,7 @@ void testD3m1(D3 *a) {
 // CHECK: %[[T5:[0-9]+]] = load void (%class.B0*)*, void (%class.B0*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint void (%class.B0*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 43073)
-// CHECK: call void %[[T5]](%class.B0* nonnull dereferenceable(12) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call void %[[T5]](%class.B0* nonnull align {{[0-9]+}} dereferenceable(12) %{{.*}}) [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testD3m2(D3 *a) {
   a->m2();
@@ -473,7 +473,7 @@ void testD3m2(D3 *a) {
 // CHECK: %[[T5:[0-9]+]] = load void (%class.D3*)*, void (%class.D3*)** %[[VFN]]
 // CHECK: %[[T6:[0-9]+]] = ptrtoint void (%class.D3*)** %[[VFN]] to i64
 // CHECK: %[[T7:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 62452)
-// CHECK: call void %[[T5]](%class.D3* nonnull dereferenceable(32) %{{.*}}) #{{.*}} [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: call void %[[T5]](%class.D3* nonnull align {{[0-9]+}} dereferenceable(32) %{{.*}}) #{{.*}} [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testD3Destructor0(D3 *a) {
   delete a;
@@ -498,7 +498,7 @@ void testD3Destructor0(D3 *a) {
 // CHECK: %[[T12:[0-9]+]] = load %class.D3* (%class.D3*)*, %class.D3* (%class.D3*)** %[[VFN]]
 // CHECK: %[[T13:[0-9]+]] = ptrtoint %class.D3* (%class.D3*)** %[[VFN]] to i64
 // CHECK: %[[T14:[0-9]+]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T13]], i64 57279)
-// CHECK: %call = call %class.D3* %[[T12]](%class.D3* nonnull dereferenceable(32) %{{.*}}) #{{.*}} [ "ptrauth"(i32 0, i64 %[[T14]]) ]
+// CHECK: %call = call %class.D3* %[[T12]](%class.D3* nonnull align {{[0-9]+}} dereferenceable(32) %{{.*}}) #{{.*}} [ "ptrauth"(i32 0, i64 %[[T14]]) ]
 // CHECK: call void @_ZdlPv(i8* %[[T7]])
 
 void testD3Destructor1(D3 *a) {
@@ -515,7 +515,7 @@ void testD3Destructor1(D3 *a) {
 // CHECK: %[[T5:.*]] = load %class.D3* (%class.D3*)*, %class.D3* (%class.D3*)** %[[VFN]]
 // CHECK: %[[T6:.*]] = ptrtoint %class.D3* (%class.D3*)** %[[VFN]] to i64
 // CHECK: %[[T7:.*]] = call i64 @llvm.ptrauth.blend.i64(i64 %[[T6]], i64 57279)
-// CHECK: %call = call %class.D3* %[[T5]](%class.D3* nonnull dereferenceable(32) %{{.*}}) #{{.*}} [ "ptrauth"(i32 0, i64 %[[T7]]) ]
+// CHECK: %call = call %class.D3* %[[T5]](%class.D3* nonnull align {{[0-9]+}} dereferenceable(32) %{{.*}}) #{{.*}} [ "ptrauth"(i32 0, i64 %[[T7]]) ]
 
 void testD3Destructor2(D3 *a) {
   a->~D3();

--- a/clang/test/CodeGenObjCXX/ptrauth-property-object-reference.mm
+++ b/clang/test/CodeGenObjCXX/ptrauth-property-object-reference.mm
@@ -35,7 +35,7 @@ struct TCPPObject
 // CHECK: [[TWO:%.*]] = load %struct.TCPPObject*, %struct.TCPPObject** [[ADDR:%.*]], align 8
 // CHECK: [[THREE:%.*]] = load %struct.TCPPObject*, %struct.TCPPObject** [[ADDR1:%.*]], align 8
 // CHECK: [[CALL:%.*]] = call i32 @_Z7DEFAULTv()
-// CHECK:  call %struct.TCPPObject* @_ZN10TCPPObjectC1ERKS_i(%struct.TCPPObject* nonnull dereferenceable(256) [[TWO]], %struct.TCPPObject* nonnull align {{[0-9]+}} dereferenceable({{[0-9]+}}) [[THREE]], i32 [[CALL]])
+// CHECK:  call %struct.TCPPObject* @_ZN10TCPPObjectC1ERKS_i(%struct.TCPPObject* nonnull align {{[0-9]+}} dereferenceable(256) [[TWO]], %struct.TCPPObject* nonnull align {{[0-9]+}} dereferenceable({{[0-9]+}}) [[THREE]], i32 [[CALL]])
 // CHECK:  ret void
 
 // CHECK: define internal void @"\01-[MyDocument MyProperty]"(
@@ -48,7 +48,7 @@ struct TCPPObject
 // CHECK-LABEL: define internal void @__assign_helper_atomic_property_(%struct.TCPPObject* %0, %struct.TCPPObject* %1) #
 // CHECK: [[THREE:%.*]] = load %struct.TCPPObject*, %struct.TCPPObject** [[ADDR1:%.*]], align 8
 // CHECK: [[TWO:%.*]] = load %struct.TCPPObject*, %struct.TCPPObject** [[ADDR:%.*]], align 8
-// CHECK: [[CALL:%.*]] = call nonnull align {{[0-9]+}} dereferenceable({{[0-9]+}}) %struct.TCPPObject* @_ZN10TCPPObjectaSERKS_(%struct.TCPPObject* nonnull dereferenceable(256) [[TWO]], %struct.TCPPObject* nonnull align {{[0-9]+}} dereferenceable({{[0-9]+}}) [[THREE]])
+// CHECK: [[CALL:%.*]] = call nonnull align {{[0-9]+}} dereferenceable({{[0-9]+}}) %struct.TCPPObject* @_ZN10TCPPObjectaSERKS_(%struct.TCPPObject* nonnull align {{[0-9]+}} dereferenceable(256) [[TWO]], %struct.TCPPObject* nonnull align {{[0-9]+}} dereferenceable({{[0-9]+}}) [[THREE]])
 // CHECK:  ret void
 
 // CHECK: define internal void @"\01-[MyDocument setMyProperty:]"(

--- a/clang/test/CodeGenObjCXX/ptrauth-struct-cxx-abi.mm
+++ b/clang/test/CodeGenObjCXX/ptrauth-struct-cxx-abi.mm
@@ -19,7 +19,7 @@ struct AddrDiscStrong1 {
 // Check that AddrDiscStrong0 is destructed in the callee.
 
 // CHECK: define void @_Z24testParamAddrDiscStrong015AddrDiscStrong0(%[[STRUCT_ADDRDISCSTRONG0]]* %[[A:.*]])
-// CHECK: call %[[STRUCT_ADDRDISCSTRONG0]]* @_ZN15AddrDiscStrong0D1Ev(%[[STRUCT_ADDRDISCSTRONG0]]* nonnull dereferenceable(16) %[[A]])
+// CHECK: call %[[STRUCT_ADDRDISCSTRONG0]]* @_ZN15AddrDiscStrong0D1Ev(%[[STRUCT_ADDRDISCSTRONG0]]* nonnull align {{[0-9]+}} dereferenceable(16) %[[A]])
 // CHECK: ret void
 
 // CHECK: define linkonce_odr %[[STRUCT_ADDRDISCSTRONG0]]* @_ZN15AddrDiscStrong0D1Ev(


### PR DESCRIPTION
clang started annotating `this` with alignment after 16d03818412415c56efcd482d18c0cbdf712524c.