### PR TITLE
Bitcode-ABI: set the swiftasync bitcode encoding to what got committed upstream

### DIFF
--- a/llvm/include/llvm/Bitcode/LLVMBitCodes.h
+++ b/llvm/include/llvm/Bitcode/LLVMBitCodes.h
@@ -656,7 +656,7 @@ enum AttributeKindCodes {
   ATTR_KIND_MUSTPROGRESS = 70,
   ATTR_KIND_NO_CALLBACK = 71,
   ATTR_KIND_HOT = 72,
-  ATTR_KIND_SWIFT_ASYNC = 73,
+  ATTR_KIND_SWIFT_ASYNC = 75,
 };
 
 enum ComdatSelectionKindCodes {


### PR DESCRIPTION
swifttailcc already has the same definition it ended up with in OSS (20).