### PR TITLE
[debugserver] Add platform cache support to improve performance.

### DIFF
--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.h
@@ -252,6 +252,7 @@ public:
                                      struct mach_o_information &inf);
   JSONGenerator::ObjectSP FormatDynamicLibrariesIntoJSON(
       const std::vector<struct binary_image_information> &image_infos);
+  uint32_t GetPlatform();
   /// Get the runtime platform from DYLD via SPI.
   uint32_t GetProcessPlatformViaDYLDSPI();
   /// Use the dyld SPI present in macOS 10.12, iOS 10, tvOS 10,
@@ -375,6 +376,7 @@ private:
 
   pid_t m_pid;           // Process ID of child process
   cpu_type_t m_cpu_type; // The CPU type of this process
+  uint32_t m_platform;   // The platform of this process
   int m_child_stdin;
   int m_child_stdout;
   int m_child_stderr;

--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
@@ -701,7 +701,7 @@ MachProcess::GetDeploymentInfo(const struct load_command &lc,
   // DYLD_FORCE_PLATFORM=6. In that case, force the platform to
   // macCatalyst and use the macCatalyst version of the host OS
   // instead of the macOS deployment target.
-  if (is_executable && GetProcessPlatformViaDYLDSPI() == PLATFORM_MACCATALYST) {
+  if (is_executable && GetPlatform() == PLATFORM_MACCATALYST) {
     info.platform = PLATFORM_MACCATALYST;
     std::string catalyst_version = GetMacCatalystVersionString();
     const char *major = catalyst_version.c_str();
@@ -1103,6 +1103,12 @@ struct dyld_process_cache_info {
   bool privateCache;
 };
 
+uint32_t MachProcess::GetPlatform() {
+  if (m_platform == 0)
+    m_platform = MachProcess::GetProcessPlatformViaDYLDSPI();
+  return m_platform;
+}
+
 uint32_t MachProcess::GetProcessPlatformViaDYLDSPI() {
   kern_return_t kern_ret;
   uint32_t platform = 0;
@@ -1158,7 +1164,7 @@ MachProcess::GetAllLoadedLibrariesInfos(nub_process_t pid) {
 
     std::vector<struct binary_image_information> image_infos;
     GetAllLoadedBinariesViaDYLDSPI(image_infos);
-    uint32_t platform = GetProcessPlatformViaDYLDSPI();
+    uint32_t platform = GetPlatform();
     const size_t image_count = image_infos.size();
     for (size_t i = 0; i < image_count; i++) {
       GetMachOInformationFromMemory(platform,
@@ -1189,7 +1195,7 @@ JSONGenerator::ObjectSP MachProcess::GetLibrariesInfoForAddresses(
 
     std::vector<struct binary_image_information> all_image_infos;
     GetAllLoadedBinariesViaDYLDSPI(all_image_infos);
-    uint32_t platform = GetProcessPlatformViaDYLDSPI();
+    uint32_t platform = GetPlatform();
 
     std::vector<struct binary_image_information> image_infos;
     const size_t macho_addresses_count = macho_addresses.size();
@@ -1355,6 +1361,7 @@ void MachProcess::Clear(bool detaching) {
   // Clear any cached thread list while the pid and task are still valid
 
   m_task.Clear();
+  m_platform = 0;
   // Now clear out all member variables
   m_pid = INVALID_NUB_PROCESS;
   if (!detaching)
@@ -1646,6 +1653,7 @@ bool MachProcess::Detach() {
 
   // NULL our task out as we have already restored all exception ports
   m_task.Clear();
+  m_platform = 0;
 
   // Clear out any notion of the process we once were
   const bool detaching = true;


### PR DESCRIPTION
The dyld SPI used by debugserver (_dyld_process_info_create) has become
much slower in macOS BigSur 11.3 causing a significant performance
regression when attaching. This commit mitigates that by caching the
result when calling the SPI to compute the platform.

Differential revision: https://reviews.llvm.org/D102833

(cherry picked from commit 8dd106028b1533f0de03a1ffb4ea0dce40b5a2ff)