### PR TITLE
[lldb] Skip TestSwiftReferenceStorageTypes on Linux (swift/next)

### DIFF
--- a/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
+++ b/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
@@ -29,7 +29,7 @@ class TestSwiftReferenceStorageTypes(TestBase):
 
     @decorators.skipIf(archs=['ppc64le']) #SR-10215
     @swiftTest
-    @skipIf(oslist=["linux"], archs=['aarch64'], bugnumber="rdar://76592966")
+    @skipIf(oslist=["linux"], bugnumber="rdar://76592966")
     def test_swift_reference_storage_types(self):
         """Test weak, unowned and unmanaged types"""
         self.build()


### PR DESCRIPTION
(cherry picked from commit 09492f4b1ff40f353a08b05731fc2a90106966ce)