### PR TITLE
[lldb] Fix TypeSystemSwiftTypeRef::GetTypedefedType maybe retuning clang compiler types.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3182,12 +3182,15 @@ TypeSystemSwiftTypeRef::GetTypedefedType(opaque_compiler_type_t type) {
     if (!node || node->getKind() != Node::Kind::TypeAlias)
       return {};
     auto pair = ResolveTypeAlias(m_swift_ast_context, dem, node);
+    NodePointer type_node = dem.createNode(Node::Kind::Type);
     if (NodePointer resolved = std::get<swift::Demangle::NodePointer>(pair)) {
-      NodePointer type_node = dem.createNode(Node::Kind::Type);
       type_node->addChild(resolved, dem);
-      return RemangleAsType(dem, type_node);
+    } else {
+      NodePointer clang_node = GetClangTypeNode(std::get<CompilerType>(pair),
+                                                dem, m_swift_ast_context);
+      type_node->addChild(clang_node, dem);
     }
-    return std::get<CompilerType>(pair);
+    return RemangleAsType(dem, type_node);
   };
 #ifndef NDEBUG
   // We skip validation when dealing with a builtin type since builtins are


### PR DESCRIPTION
On `TypeSystemSwiftTypeRef::GetTypedefedType` we sometimes returned a `CompilerType` whose type system is `TypeSystemClang`. This patch makes it so we always return a `CompilerType` with `TypeSystemSwiftTypeRef` as the type system.