### PR TITLE
Sprinkle scoped timer support all over the Swift language binding.

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1,4 +1,4 @@
-//===-- SwiftExpressionParser.cpp -------------------------------*- C++ -*-===//
+//===-- SwiftExpressionParser.cpp ---------------------------------------*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -39,6 +39,7 @@
 #include "lldb/Target/Thread.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/Stream.h"
+#include "lldb/Utility/Timer.h"
 
 #include "llvm-c/Analysis.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -254,6 +255,7 @@ public:
   bool lookupAdditions(swift::DeclBaseName Name, swift::DeclContext *DC,
                        swift::SourceLoc Loc, bool IsTypeLookup,
                        ResultVector &RV) override {
+    LLDB_SCOPED_TIMER();
     static unsigned counter = 0;
     unsigned count = counter++;
 
@@ -397,6 +399,7 @@ public:
   bool lookupAdditions(swift::DeclBaseName Name, swift::DeclContext *DC,
                        swift::SourceLoc Loc, bool IsTypeLookup,
                        ResultVector &RV) override {
+    LLDB_SCOPED_TIMER();
     static unsigned counter = 0;
     unsigned count = counter++;
 
@@ -447,6 +450,7 @@ public:
 static CompilerType GetSwiftTypeForVariableValueObject(
     lldb::ValueObjectSP valobj_sp, lldb::StackFrameSP &stack_frame_sp,
     SwiftLanguageRuntime *runtime) {
+  LLDB_SCOPED_TIMER();
   // Check that the passed ValueObject is valid.
   if (!valobj_sp || valobj_sp->GetError().Fail())
     return {};
@@ -470,6 +474,7 @@ static CompilerType GetSwiftTypeForVariableValueObject(
 static CompilerType ResolveVariable(
     lldb::VariableSP variable_sp, lldb::StackFrameSP &stack_frame_sp,
     SwiftLanguageRuntime * runtime, lldb::DynamicValueType use_dynamic) {
+  LLDB_SCOPED_TIMER();
   lldb::ValueObjectSP valobj_sp =
       stack_frame_sp->GetValueObjectForFrameVariable(variable_sp,
                                                      lldb::eNoDynamicValues);
@@ -496,6 +501,8 @@ static void AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
                                SwiftASTContextForExpressions &swift_ast_context,
                                SwiftASTManipulator &manipulator,
                                lldb::DynamicValueType use_dynamic) {
+  LLDB_SCOPED_TIMER();
+
   // First emit the typealias for "$__lldb_context".
   if (!block)
     return;
@@ -640,6 +647,8 @@ static llvm::Optional<llvm::Error> AddVariableInfo(
     llvm::SmallDenseSet<const char *, 8> &processed_variables,
     llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables,
     lldb::DynamicValueType use_dynamic) {
+  LLDB_SCOPED_TIMER();
+
   StringRef name = variable_sp->GetUnqualifiedName().GetStringRef();
   const char *name_cstr = name.data();
   assert(StringRef(name_cstr) == name && "missing null terminator");
@@ -735,6 +744,7 @@ static llvm::Optional<llvm::Error> RegisterAllVariables(
     SwiftASTContextForExpressions &ast_context,
     llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables,
     lldb::DynamicValueType use_dynamic) {
+  LLDB_SCOPED_TIMER();
   if (!sc.block && !sc.function)
     return {};
 
@@ -804,7 +814,8 @@ static void ResolveSpecialNames(
     llvm::SmallVectorImpl<swift::Identifier> &special_names,
     llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
-
+  LLDB_SCOPED_TIMER();
+  
   if (!sc.target_sp)
     return;
 
@@ -1007,6 +1018,7 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
                     lldb::StackFrameWP &stack_frame_wp,
                     DiagnosticManager &diagnostic_manager, Log *log,
                     bool repl) {
+  LLDB_SCOPED_TIMER();
   uint64_t offset = 0;
   bool needs_init = false;
 
@@ -1212,6 +1224,7 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
     ExecutionContextScope &exe_scope, const EvaluateExpressionOptions &options,
     bool repl, bool playground) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
+  LLDB_SCOPED_TIMER();
 
   auto should_disable_objc_runtime = [&]() {
     lldb::StackFrameSP this_frame_sp(stack_frame_wp.lock());
@@ -1441,6 +1454,7 @@ bool SwiftExpressionParser::Complete(CompletionRequest &request, unsigned line,
 unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
                                       uint32_t first_line, uint32_t last_line) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
+  LLDB_SCOPED_TIMER();
 
   SwiftExpressionParser::SILVariableMap variable_map;
   auto *swift_ast_ctx = m_swift_ast_context->get();
@@ -1807,6 +1821,7 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
 static bool FindFunctionInModule(ConstString &mangled_name,
                                  llvm::Module *module, const char *orig_name,
                                  bool exact) {
+  LLDB_SCOPED_TIMER();
   swift::Demangle::Context demangle_ctx;
   for (llvm::Module::iterator fi = module->getFunctionList().begin(),
                               fe = module->getFunctionList().end();
@@ -1860,6 +1875,7 @@ Status SwiftExpressionParser::PrepareForExecution(
     lldb::addr_t &func_addr, lldb::addr_t &func_end,
     lldb::IRExecutionUnitSP &execution_unit_sp, ExecutionContext &exe_ctx,
     bool &can_interpret, ExecutionPolicy execution_policy) {
+  LLDB_SCOPED_TIMER();
   Status err;
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
 
@@ -1919,6 +1935,7 @@ Status SwiftExpressionParser::PrepareForExecution(
 
 bool SwiftExpressionParser::RewriteExpression(
     DiagnosticManager &diagnostic_manager) {
+  LLDB_SCOPED_TIMER();
   // There isn't a Swift equivalent to clang::Rewriter, so we'll just
   // use that.
   auto *swift_ast_ctx = m_swift_ast_context->get();

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -32,6 +32,7 @@
 #include "lldb/Symbol/VariableList.h"
 #include "lldb/Utility/LLDBAssert.h"
 #include "lldb/Utility/Log.h"
+#include "lldb/Utility/Timer.h"
 
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
@@ -160,6 +161,7 @@ findSwiftSelf(StackFrame &frame, lldb::VariableSP self_var_sp) {
 void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
   LLDB_LOG(log, "SwiftUserExpression::ScanContext()");
+  LLDB_SCOPED_TIMER();
 
   m_target = exe_ctx.GetTargetPtr();
   if (!m_target) {
@@ -275,6 +277,7 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
                                 bool keep_result_in_memory,
                                 bool generate_debug_info) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
+  LLDB_SCOPED_TIMER();
 
   Status err;
 
@@ -506,6 +509,7 @@ bool SwiftUserExpression::AddArguments(ExecutionContext &exe_ctx,
 
 lldb::ExpressionVariableSP SwiftUserExpression::GetResultAfterDematerialization(
     ExecutionContextScope *exe_scope) {
+  LLDB_SCOPED_TIMER();
   lldb::ExpressionVariableSP in_result_sp = m_result_delegate.GetVariable();
   lldb::ExpressionVariableSP in_error_sp = m_error_delegate.GetVariable();
 

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -18,6 +18,7 @@
 #include "lldb/Target/Process.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/Status.h"
+#include "lldb/Utility/Timer.h"
 #include "swift/AST/Types.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "llvm/ADT/Optional.h"
@@ -96,6 +97,7 @@ bool lldb_private::formatters::swift::StringGuts_SummaryProvider(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &summary_options,
     StringPrinter::ReadStringAndDumpToStreamOptions read_options) {
+  LLDB_SCOPED_TIMER();
 
   static ConstString g__object("_object");
   static ConstString g__storage("_storage");
@@ -379,6 +381,8 @@ bool lldb_private::formatters::swift::StaticString_SummaryProvider(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &summary_options,
     StringPrinter::ReadStringAndDumpToStreamOptions read_options) {
+  LLDB_SCOPED_TIMER();
+
   static ConstString g__startPtrOrData("_startPtrOrData");
   static ConstString g__byteSize("_utf8CodeUnitCount");
   static ConstString g__flags("_flags");
@@ -433,6 +437,7 @@ bool lldb_private::formatters::swift::SwiftSharedString_SummaryProvider_2(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &summary_options,
     StringPrinter::ReadStringAndDumpToStreamOptions read_options) {
+  LLDB_SCOPED_TIMER();
   ProcessSP process(valobj.GetProcessSP());
   if (!process)
     return false;
@@ -461,6 +466,7 @@ bool lldb_private::formatters::swift::SwiftSharedString_SummaryProvider_2(
 
 bool lldb_private::formatters::swift::SwiftStringStorage_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
+  LLDB_SCOPED_TIMER();
   ProcessSP process(valobj.GetProcessSP());
   if (!process)
     return false;
@@ -531,6 +537,7 @@ bool lldb_private::formatters::swift::DarwinBoolean_SummaryProvider(
 static bool RangeFamily_SummaryProvider(ValueObject &valobj, Stream &stream,
                                         const TypeSummaryOptions &options,
                                         bool isHalfOpen) {
+  LLDB_SCOPED_TIMER();
   static ConstString g_lowerBound("lowerBound");
   static ConstString g_upperBound("upperBound");
 
@@ -665,6 +672,7 @@ lldb_private::formatters::swift::EnumSyntheticFrontEndCreator(
 
 bool lldb_private::formatters::swift::ObjC_Selector_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
+  LLDB_SCOPED_TIMER();
   static ConstString g_ptr("ptr");
   static ConstString g__rawValue("_rawValue");
 
@@ -811,6 +819,7 @@ bool PrintTypePreservingNSNumber(DataBufferSP buffer_sp, ProcessSP process_sp,
 
 bool lldb_private::formatters::swift::TypePreservingNSNumber_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
+  LLDB_SCOPED_TIMER();
   lldb::addr_t ptr_value(valobj.GetValueAsUnsigned(LLDB_INVALID_ADDRESS));
   if (ptr_value == LLDB_INVALID_ADDRESS)
     return false;
@@ -995,6 +1004,8 @@ void PrintMatrix(Stream &stream,
 
 bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
+  LLDB_SCOPED_TIMER();
+
   // SIMD vector contains an inner member `_storage` which is an opaque
   // container. Given SIMD is always in the form SIMDX<Type> where X is a
   // positive integer, we can calculate the number of elements and the
@@ -1064,6 +1075,8 @@ bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
 
 bool lldb_private::formatters::swift::LegacySIMD_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
+  LLDB_SCOPED_TIMER();
+
   Status error;
   ProcessSP process_sp(valobj.GetProcessSP());
   if (!process_sp)
@@ -1148,6 +1161,8 @@ bool lldb_private::formatters::swift::LegacySIMD_SummaryProvider(
 
 bool lldb_private::formatters::swift::GLKit_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
+  LLDB_SCOPED_TIMER();
+
   // Get the type name without the "GLKit." prefix.
   ConstString full_type_name = valobj.GetTypeName();
   llvm::StringRef type_name = full_type_name.GetStringRef();

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -32,6 +32,7 @@
 #include "lldb/Target/RegisterContext.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/OptionParsing.h"
+#include "lldb/Utility/Timer.h"
 
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/Decl.h"
@@ -418,6 +419,8 @@ SwiftLanguageRuntimeImpl::GetReflectionContext() {
 }
 
 void SwiftLanguageRuntimeImpl::SetupReflection() {
+  LLDB_SCOPED_TIMER();
+ 
   // SetupABIBit() iterates of the Target's images and thus needs to
   // acquire that ModuleList's lock. We need to acquire this before
   // locking m_add_module_mutex, since ModulesDidLoad can also be
@@ -2175,7 +2178,8 @@ UnwindPlanSP
 SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
                                            RegisterContext *regctx,
                                            bool &behaves_like_zeroth_frame) {
-
+  LLDB_SCOPED_TIMER();
+ 
   Target &target(process_sp->GetTarget());
   auto arch = target.GetArchitecture();
   llvm::Optional<AsyncUnwindRegisterNumbers> regnums =
@@ -2332,7 +2336,8 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
 static UnwindPlanSP
 GetFollowAsyncContextUnwindPlan(RegisterContext *regctx, ArchSpec &arch,
                                 bool &behaves_like_zeroth_frame) {
-
+  LLDB_SCOPED_TIMER();
+ 
   UnwindPlan::RowSP row(new UnwindPlan::Row);
   const int32_t ptr_size = 8;
   row->SetOffset(0);

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2509,6 +2509,7 @@ Target::CreateUtilityFunction(std::string expression, std::string name,
 llvm::Optional<SwiftASTContextReader> Target::GetScratchSwiftASTContext(
     Status &error, ExecutionContextScope &exe_scope, bool create_on_demand) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_TARGET));
+  LLDB_SCOPED_TIMER();
 
   Module *lldb_module = nullptr;
   if (m_use_scratch_typesystem_per_module)


### PR DESCRIPTION
The scoped timers translate into Signposts on Darwin and should make
performance tracking much easier.

rdar://76070796