### PR TITLE
[lldb] Disable flaky test Shell/Reproducer/Swift/TestBridging.test

### DIFF
--- a/lldb/test/Shell/Reproducer/Swift/TestBridging.test
+++ b/lldb/test/Shell/Reproducer/Swift/TestBridging.test
@@ -1,6 +1,9 @@
 # UNSUPPORTED: system-windows, system-freebsd, system-linux
 # REQUIRES: swift
 
+# Failing non-deterministically in CI.
+# REQUIRES: rdar78319322
+
 # This tests replaying a Swift reproducer with bridging.
 
 # Start clean.


### PR DESCRIPTION
This has been failing non-deterministically in CI.

rdar://78319322