### PR TITLE
[lldb] Disable 'DisplayDebuggerGeneratedModule' when generating a display string from TypeSystemSwiftTypeRef (swift/next)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -668,6 +668,7 @@ SwiftLanguageRuntime::DemangleSymbolAsString(StringRef symbol, DemangleMode mode
     options.QualifyEntities = true;
     options.DisplayModuleNames = true;
     options.DisplayLocalNameContexts = false;
+    options.DisplayDebuggerGeneratedModule = false;
     break;    
   }
 


### PR DESCRIPTION
(cherry picked from commit 1b515d2b1b22253b95949f979fb3783e86e13e67)