### PR TITLE
[lldb] Skip compiler type equivalence when lhs's type system is clang (swift/next)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3224,12 +3224,15 @@ TypeSystemSwiftTypeRef::GetTypedefedType(opaque_compiler_type_t type) {
     if (!node || node->getKind() != Node::Kind::TypeAlias)
       return {};
     auto pair = ResolveTypeAlias(m_swift_ast_context, dem, node);
+    NodePointer type_node = dem.createNode(Node::Kind::Type);
     if (NodePointer resolved = std::get<swift::Demangle::NodePointer>(pair)) {
-      NodePointer type_node = dem.createNode(Node::Kind::Type);
       type_node->addChild(resolved, dem);
-      return RemangleAsType(dem, type_node);
+    } else {
+      NodePointer clang_node = GetClangTypeNode(std::get<CompilerType>(pair),
+                                                dem, m_swift_ast_context);
+      type_node->addChild(clang_node, dem);
     }
-    return std::get<CompilerType>(pair);
+    return RemangleAsType(dem, type_node);
   };
 #ifndef NDEBUG
   // We skip validation when dealing with a builtin type since builtins are


### PR DESCRIPTION
(cherry picked from commit 1bd931e3c978320cd0966a2c0f92507a670a5505)