### PR TITLE
[lldb] Make TypeSystemSwiftTypeRef typedef functions consider BoundGenericTypeAlias nodes (swift/next)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3186,7 +3186,8 @@ bool TypeSystemSwiftTypeRef::IsTypedefType(opaque_compiler_type_t type) {
     using namespace swift::Demangle;
     Demangler dem;
     NodePointer node = GetDemangledType(dem, AsMangledName(type));
-    return node && node->getKind() == Node::Kind::TypeAlias;
+    return node && (node->getKind() == Node::Kind::TypeAlias ||
+                    node->getKind() == Node::Kind::BoundGenericTypeAlias);
   };
 
 #ifndef NDEBUG
@@ -3221,7 +3222,8 @@ TypeSystemSwiftTypeRef::GetTypedefedType(opaque_compiler_type_t type) {
     using namespace swift::Demangle;
     Demangler dem;
     NodePointer node = GetDemangledType(dem, AsMangledName(type));
-    if (!node || node->getKind() != Node::Kind::TypeAlias)
+    if (!node || (node->getKind() != Node::Kind::TypeAlias &&
+                  node->getKind() != Node::Kind::BoundGenericTypeAlias))
       return {};
     auto pair = ResolveTypeAlias(m_swift_ast_context, dem, node);
     if (NodePointer resolved = std::get<swift::Demangle::NodePointer>(pair)) {

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -688,5 +688,20 @@ TEST_F(TestTypeSystemSwiftTypeRef, IsTypedefType) {
     CompilerType t = GetCompilerType(b.Mangle(n));
     ASSERT_FALSE(t.IsTypedefType());
   };
-};
+  {
+    NodePointer n = b.GlobalType(
+        b.Node(Node::Kind::BoundGenericTypeAlias,
+               b.Node(Node::Kind::Type,
+                      b.Node(Node::Kind::TypeAlias,
+                             b.Node(Node::Kind::Module, "module"),
+                             b.Node(Node::Kind::Identifier, "SomeType"))),
+               b.Node(Node::Kind::TypeList,
+                      b.Node(Node::Kind::Type,
+                             b.Node(Node::Kind::Structure,
+                                    b.Node(Node::Kind::Module, "Swift"),
+                                    b.Node(Node::Kind::Identifier, "Int"))))));
+    CompilerType t = GetCompilerType(b.Mangle(n));
+    ASSERT_TRUE(t.IsTypedefType());
+  };
+}
 


### PR DESCRIPTION
(cherry picked from commit 67f4fcf86a048450a8d93ae595cb1e6fcf5a6d7b)