### PR TITLE
Special-case Pattern Binding Decls Created by LLDB

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -432,7 +432,7 @@ swift::Stmt *SwiftASTManipulator::ConvertExpressionToTmpReturnVarAccess(
                                           result_loc_info.tmp_var_decl);
 
   const auto static_spelling_kind = swift::StaticSpellingKind::KeywordStatic;
-  result_loc_info.binding_decl = swift::PatternBindingDecl::createImplicit(
+  result_loc_info.binding_decl = swift::PatternBindingDecl::createForDebugger(
       ast_context, static_spelling_kind, var_pattern, expr, new_decl_context);
   result_loc_info.binding_decl->setStatic(false);
 
@@ -445,8 +445,12 @@ swift::Stmt *SwiftASTManipulator::ConvertExpressionToTmpReturnVarAccess(
     body.push_back(result_loc_info.return_stmt);
   }
 
+  swift::SourceLoc brace_end = result_loc_info.orig_expr->getEndLoc();
+  if (brace_end.isInvalid()) {
+    brace_end = source_loc;
+  }
   auto *body_stmt = swift::BraceStmt::create(
-      ast_context, source_loc, llvm::ArrayRef<swift::ASTNode>(body), source_loc,
+      ast_context, source_loc, llvm::ArrayRef<swift::ASTNode>(body), brace_end,
       true);
 
   // Default construct a label info that contains nothing for the 'do'

--- a/lldb/test/API/lang/swift/expression/scopes/main.swift
+++ b/lldb/test/API/lang/swift/expression/scopes/main.swift
@@ -131,6 +131,9 @@ func main () -> Void
     var my_b = B()
 
     my_b.method()
+
+    let my_c = [1, 2, 3].map { x in x }
+    print(my_c)
 }
 
 main()


### PR DESCRIPTION
When LLDB wraps a user-defined expression in the REPL, it takes something like this
```
<expr>
```

and turns it into (very very abstractly)

```
var result
do {
  result = <expr>
}
print(result)
```

In the process, it creates an implicit pattern binding and an implicit do block. Of these, only the implicit do is considered by ASTScope lookup to be relevant. This presents a problem when `<expr>` is or contains a closure, as the parameters of that closure are defined within a scope that will never be expanded. Thus,

```
> [42].map { x in x } // <- cannot find 'x' in scope
```

This patch provides the LLDB half of the fix wherein we consume the
infrastructure in the Swift half and readjust the source locations of
the implicit braced block so ASTScope is happy to look up variables
defined in its body.

rdar://78256873