### PR TITLE
[lldb] Add CFunctionPointer case to TypeSystemSwiftTypeRef::DumpTypeValue

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2990,6 +2990,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     case Node::Kind::DependentGenericParamType:
     case Node::Kind::FunctionType:
     case Node::Kind::NoEscapeFunctionType:
+    case Node::Kind::CFunctionPointer:
     case Node::Kind::ImplFunctionType: {
       uint32_t item_count = 1;
       // A few formats, we might need to modify our size and count for


### PR DESCRIPTION
(cherry picked from commit 8ca0adc7525d1f55dc88e6273a9bf64fbda5221e)