### PR TITLE
After removing overlays from Swift repo we are started seeing followi…

### DIFF
--- a/lldb/test/API/lang/swift/foundation_value_types/indexpath/TestSwiftFoundationTypeIndexPath.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/indexpath/TestSwiftFoundationTypeIndexPath.py
@@ -13,4 +13,4 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipIf(oslist=['windows', 'linux'])])
+                          decorators=[swiftTest,skipIf(oslist=['macosx', 'windows', 'linux'])])

--- a/lldb/test/API/lang/swift/foundation_value_types/indexpath/TestSwiftFoundationTypeIndexPath.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/indexpath/TestSwiftFoundationTypeIndexPath.py
@@ -13,4 +13,4 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipIf(oslist=['macosx', 'windows', 'linux'])])
+                          decorators=[swiftTest,skipIf(oslist=['windows', 'linux']), expectedFailureAll(oslist=['macosx'], bugnumber='rdar://79052960')])

--- a/lldb/test/Shell/SwiftREPL/FoundationTypes.test
+++ b/lldb/test/Shell/SwiftREPL/FoundationTypes.test
@@ -3,7 +3,8 @@
 
 // REQUIRES: system-darwin
 // REQUIRES: swift
-// REQUIRES: rdar79052960
+// XFAIL: system-darwin
+// rdar://79052960
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/FoundationTypes.test
+++ b/lldb/test/Shell/SwiftREPL/FoundationTypes.test
@@ -3,6 +3,7 @@
 
 // REQUIRES: system-darwin
 // REQUIRES: swift
+// REQUIRES: rdar79052960
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/ResilientArray.test
+++ b/lldb/test/Shell/SwiftREPL/ResilientArray.test
@@ -1,5 +1,6 @@
 // REQUIRES: system-darwin
 // REQUIRES: swift
+// REQUIRES: rdar79053073
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/ResilientArray.test
+++ b/lldb/test/Shell/SwiftREPL/ResilientArray.test
@@ -1,6 +1,7 @@
 // REQUIRES: system-darwin
 // REQUIRES: swift
-// REQUIRES: rdar79053073
+// XFAIL: system-darwin
+// rdar://79053073
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/ResilientDict.test
+++ b/lldb/test/Shell/SwiftREPL/ResilientDict.test
@@ -1,6 +1,7 @@
 // REQUIRES: system-darwin
 // REQUIRES: swift
-// REQUIRES: rdar79053148
+// XFAIL: system-darwin
+// rdar://79053148
 
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=DICT
 

--- a/lldb/test/Shell/SwiftREPL/ResilientDict.test
+++ b/lldb/test/Shell/SwiftREPL/ResilientDict.test
@@ -1,5 +1,6 @@
 // REQUIRES: system-darwin
 // REQUIRES: swift
+// REQUIRES: rdar79053148
 
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=DICT
 


### PR DESCRIPTION
…ng failures

* lldb-api :: lang/swift/foundation_value_types/indexpath/TestSwiftFoundationTypeIndexPath.py
* lldb-shell :: SwiftREPL/FoundationTypes.test
* lldb-shell :: SwiftREPL/ResilientArray.test
* lldb-shell :: SwiftREPL/ResilientDict.test