### PR TITLE
[LLDB][NFC] Remove parameter names from forward declarations from hand written expressions used in heap.py

### DIFF
--- a/lldb/examples/darwin/heap_find/heap.py
+++ b/lldb/examples/darwin/heap_find/heap.py
@@ -36,7 +36,7 @@ typedef uintptr_t vm_address_t;
 typedef natural_t task_t;
 typedef int kern_return_t;
 #define KERN_SUCCESS 0
-typedef void (*range_callback_t)(task_t task, void *baton, unsigned type, uintptr_t ptr_addr, uintptr_t ptr_size);
+typedef void (*range_callback_t)(task_t, void *, unsigned, uintptr_t, uintptr_t);
 '''
     if options.search_vm_regions:
         expr += '''
@@ -120,8 +120,8 @@ typedef struct vm_range_t {
     vm_address_t	address;
     vm_size_t		size;
 } vm_range_t;
-typedef kern_return_t (*memory_reader_t)(task_t task, vm_address_t remote_address, vm_size_t size, void **local_memory);
-typedef void (*vm_range_recorder_t)(task_t task, void *baton, unsigned type, vm_range_t *range, unsigned size);
+typedef kern_return_t (*memory_reader_t)(task_t, vm_address_t, vm_size_t, void **);
+typedef void (*vm_range_recorder_t)(task_t, void *, unsigned, vm_range_t *, unsigned);
 typedef struct malloc_introspection_t {
     kern_return_t (*enumerator)(task_t task, void *, unsigned type_mask, vm_address_t zone_address, memory_reader_t reader, vm_range_recorder_t recorder); /* enumerates all the malloc pointers in use */
 } malloc_introspection_t;
@@ -130,7 +130,7 @@ typedef struct malloc_zone_t {
     struct malloc_introspection_t	*introspect;
 } malloc_zone_t;
 kern_return_t malloc_get_all_zones(task_t task, memory_reader_t reader, vm_address_t **addresses, unsigned *count);
-memory_reader_t task_peek = [](task_t task, vm_address_t remote_address, vm_size_t size, void **local_memory) -> kern_return_t {
+memory_reader_t task_peek = [](task_t, vm_address_t remote_address, vm_size_t, void **local_memory) -> kern_return_t {
     *local_memory = (void*) remote_address;
     return KERN_SUCCESS;
 };


### PR DESCRIPTION
heap.py has a lot of large hand written expressions and each name in the
expression will be looked up by clang during expression parsing. For
function parameters this will be in Sema::ActOnParamDeclarator(...) in order to
catch redeclarations of parameters. The names are not needed and we have seen
some rare cases where since we don't have symbols we end up in
SymbolContext::FindBestGlobalDataSymbol(...) which may conflict with other global
symbols.

There may be a way to make this lookup smarter to avoid these cases but it is
not clear how well tested this path is and how much work it would be to fix it.
So we will go with this fix while we investigate more.

Ref: rdar://78265641
(cherry picked from commit ae1a699554cfa01d9fb307a964c3a9f71831a62e)