### PR TITLE
[lldb] Fix missing 'return' in ValueObject::GetMangledTypename

### DIFF
--- a/lldb/include/lldb/Core/ValueObject.h
+++ b/lldb/include/lldb/Core/ValueObject.h
@@ -364,7 +364,7 @@ public:
 
   // Subclasses can implement the functions below.
   virtual ConstString GetMangledTypeName() {
-    GetCompilerType().GetMangledTypeName();
+    return GetCompilerType().GetMangledTypeName();
   }
 
   virtual ConstString GetTypeName() { return GetCompilerType().GetTypeName(); }


### PR DESCRIPTION
This was accidentially dropped when my getter inline got automerged in
3ca5ea4a7d778c0865e27c621944ae8ac9a53b84 .