### PR TITLE
[clang][ObjC] allow the use of NSAttributedString * argument type wit…

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3508,7 +3508,7 @@ static void handleFormatAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   } else if (Kind == NSStringFormat) {
     // FIXME: do we need to check if the type is NSString*?  What are the
     // semantics?
-    if (!isNSStringType(Ty, S.Context)) {
+    if (!isNSStringType(Ty, S.Context, /*AllowNSAttributedString=*/true)) {
       S.Diag(AL.getLoc(), diag::err_format_attribute_not)
         << "an NSString" << IdxExpr->getSourceRange()
         << getFunctionOrMethodParamRange(D, ArgIdx);

--- a/clang/test/SemaObjC/format-strings-objc.m
+++ b/clang/test/SemaObjC/format-strings-objc.m
@@ -34,6 +34,11 @@ typedef float CGFloat;
 @interface NSConstantString : NSSimpleCString @end
 extern void *_NSConstantStringClassReference;
 
+@interface NSAttributedString : NSObject
++(instancetype)stringWithFormat:(NSAttributedString *)fmt, ...
+    __attribute__((format(__NSString__, 1, 2)));
+@end
+
 typedef const struct __CFString * CFStringRef;
 extern void CFStringCreateWithFormat(CFStringRef format, ...) __attribute__((format(CFString, 1, 2)));
 #define CFSTR(cStr)  ((CFStringRef) __builtin___CFStringMakeConstantString ("" cStr ""))
@@ -332,6 +337,9 @@ const char *rd23622446(const char *format) {
                          value:(nullable NSString *)value
                          table:(nullable NSString *)tableName
     __attribute__((format_arg(1)));
+
+- (NSAttributedString *)someMethod2:(NSString *)key
+    __attribute__((format_arg(1)));
 @end
 
 void useLocalizedStringForKey(NSBundle *bndl) {
@@ -356,4 +364,9 @@ void useLocalizedStringForKey(NSBundle *bndl) {
               [bndl someRandomMethod:@"flerp"
                                value:0
                                table:0], 42]; // expected-warning{{data argument not used by format string}}
+
+  [NSAttributedString stringWithFormat:
+              [bndl someMethod2: @"test"], 5]; // expected-warning{{data argument not used by format string}}
+  [NSAttributedString stringWithFormat:
+              [bndl someMethod2: @"%f"], 42]; // expected-warning{{format specifies type 'double' but the argument has type 'int'}}
 }


### PR DESCRIPTION
…h format attribute

This is useful for APIs that want to accept an attributed NSString as their format string

rdar://79163229