### PR TITLE
Backport changes for race conditions in DirectoryWatcher

### DIFF
--- a/clang/lib/DirectoryWatcher/windows/DirectoryWatcher-windows.cpp
+++ b/clang/lib/DirectoryWatcher/windows/DirectoryWatcher-windows.cpp
@@ -133,6 +133,9 @@ DirectoryWatcherWindows::~DirectoryWatcherWindows() {
 }
 
 void DirectoryWatcherWindows::InitialScan() {
+  std::unique_lock<std::mutex> lock(Mutex);
+  Ready.wait(lock, [this] { return this->WatcherActive; });
+
   Callback(getAsFileEvents(scanDirectory(Path.data())), /*IsInitial=*/true);
 }
 


### PR DESCRIPTION
This is backporting some changes from upstream for the DirectoryWatcher implementation on Windows.  This only impacts the Windows target.