### PR TITLE
[X86] Default to -x86-pad-for-align=false to drop assembler differenc…

### DIFF
--- a/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
@@ -109,7 +109,7 @@ cl::opt<unsigned> X86PadMaxPrefixSize(
     cl::desc("Maximum number of prefixes to use for padding"));
 
 cl::opt<bool> X86PadForAlign(
-    "x86-pad-for-align", cl::init(true), cl::Hidden,
+    "x86-pad-for-align", cl::init(false), cl::Hidden,
     cl::desc("Pad previous instructions to implement align directives"));
 
 cl::opt<bool> X86PadForBranchAlign(
@@ -957,6 +957,9 @@ void X86AsmBackend::finishLayout(MCAssembler const &Asm,
   if (!X86PadForAlign && !X86PadForBranchAlign)
     return;
 
+  // The processed regions are delimitered by LabeledFragments. -g may have more
+  // MCSymbols and therefore different relaxation results. X86PadForAlign is
+  // disabled by default to eliminate the -g vs non -g difference.
   DenseSet<MCFragment *> LabeledFragments;
   for (const MCSymbol &S : Asm.symbols())
     LabeledFragments.insert(S.getFragment(false));

--- a/llvm/test/MC/X86/Inputs/pad-align-with-debug.s
+++ b/llvm/test/MC/X86/Inputs/pad-align-with-debug.s
@@ -1,0 +1,45 @@
+# See PR48742.
+    .text
+    .p2align 4
+foo:
+    .file 1 "foo.c"
+    movq    %rdi, %rax
+    .p2align 4,,10
+    .p2align 3
+L1:
+    movzbl  (%rax), %edx
+    cmpb    $10, %dl
+    je  L4
+L2:
+    cmpb    $100, %dl
+    je  L5
+    cmpb    $200, %dl
+    je  L5
+    cmpb    $300, %dl
+    jne L5
+    .p2align 4,,10
+    .p2align 3
+L3:
+    movq    %rax, %rdx
+    incq    %rax
+    cmpb    $30, (%rax)
+    jne L3
+    leaq    2(%rdx), %rax
+    movzbl  (%rax), %edx
+    .loc 1 1234 5
+    cmpb    $90, %dl
+    jne L2
+    .p2align 4,,10
+    .p2align 3
+L4:
+    cmpb    $99, 4(%rax)
+    je L7
+L5:
+    incq    %rax
+    jmp L1
+    .p2align 4,,10
+    .p2align 3
+L6:
+    ret
+L7:
+    ret

--- a/llvm/test/MC/X86/Inputs/pad-align-without-debug.s
+++ b/llvm/test/MC/X86/Inputs/pad-align-without-debug.s
@@ -1,0 +1,43 @@
+# See PR48742.
+    .text
+    .p2align 4
+foo:
+    movq    %rdi, %rax
+    .p2align 4,,10
+    .p2align 3
+L1:
+    movzbl  (%rax), %edx
+    cmpb    $10, %dl
+    je L4
+L2:
+    cmpb    $100, %dl
+    je  L5
+    cmpb    $200, %dl
+    je  L5
+    cmpb    $300, %dl
+    jne L5
+    .p2align 4,,10
+    .p2align 3
+L3:
+    movq    %rax, %rdx
+    incq    %rax
+    cmpb    $30, (%rax)
+    jne L3
+    leaq    2(%rdx), %rax
+    movzbl  (%rax), %edx
+    cmpb    $90, %dl
+    jne L2
+    .p2align 4,,10
+    .p2align 3
+L4:
+    cmpb    $99, 4(%rax)
+    je L7
+L5:
+    incq    %rax
+    jmp L1
+    .p2align 4,,10
+    .p2align 3
+L6:
+    ret
+L7:
+    ret

--- a/llvm/test/MC/X86/align-via-padding-corner.s
+++ b/llvm/test/MC/X86/align-via-padding-corner.s
@@ -1,4 +1,4 @@
-  # RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-pc-linux-gnu %s -x86-pad-max-prefix-size=5 | llvm-objdump -d - | FileCheck %s
+  # RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-pc-linux-gnu %s -x86-pad-max-prefix-size=5 -x86-pad-for-align=1 | llvm-objdump -d - | FileCheck %s
 
 
   # The first test check the correctness cornercase - can't add prefixes on a

--- a/llvm/test/MC/X86/align-via-padding.s
+++ b/llvm/test/MC/X86/align-via-padding.s
@@ -1,4 +1,4 @@
-# RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-pc-linux-gnu %s -x86-pad-max-prefix-size=5 | llvm-objdump -d --section=.text - | FileCheck %s
+# RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-pc-linux-gnu %s -x86-pad-max-prefix-size=5 -x86-pad-for-align=1 | llvm-objdump -d - | FileCheck %s
 
 # This test file highlights the interactions between prefix padding and
 # relaxation padding.

--- a/llvm/test/MC/X86/align-via-relaxation.s
+++ b/llvm/test/MC/X86/align-via-relaxation.s
@@ -1,4 +1,5 @@
-# RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-pc-linux-gnu -x86-pad-max-prefix-size=0 %s | llvm-objdump -d --section=.text - | FileCheck %s
+# RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-pc-linux-gnu -x86-pad-max-prefix-size=0 %s | llvm-objdump -d - | FileCheck %s --check-prefix=NOPAD
+# RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-pc-linux-gnu -x86-pad-max-prefix-size=0 -x86-pad-for-align=1 %s | llvm-objdump -d - | FileCheck %s
 
 # This test exercises only the padding via relaxation logic.  The  interaction
 # etween prefix padding and relaxation logic can be seen in align-via-padding.s
@@ -6,6 +7,19 @@
   .file "test.c"
   .text
   .section  .text
+
+# NOPAD-LABEL: <.text>:
+# NOPAD-NEXT:     0: eb 1f           jmp 0x21 <foo>
+# NOPAD-NEXT:     2: eb 1d           jmp 0x21 <foo>
+# NOPAD-NEXT:     4: eb 1b           jmp 0x21 <foo>
+# NOPAD-NEXT:     6: eb 19           jmp 0x21 <foo>
+# NOPAD-NEXT:     8: eb 17           jmp 0x21 <foo>
+# NOPAD-NEXT:     a: eb 15           jmp 0x21 <foo>
+# NOPAD-NEXT:     c: eb 13           jmp 0x21 <foo>
+# NOPAD-NEXT:     e: 66 66 66 66 66 66 2e 0f 1f 84 00 00 00 00 00  nopw    %cs:(%rax,%rax)
+# NOPAD-NEXT:    1d: 0f 1f 00        nopl (%rax)
+# NOPAD-NEXT:    20: cc              int3
+
   # Demonstrate that we can relax instructions to provide padding, not
   # just insert nops.  jmps are being used for ease of demonstration.
   # CHECK: .text

--- a/llvm/test/MC/X86/pad-for-align-debug.s
+++ b/llvm/test/MC/X86/pad-for-align-debug.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-apple-macos -x86-pad-for-align=true %S/Inputs/pad-align-with-debug.s | llvm-objdump -d - | FileCheck --check-prefix=CHECK --check-prefix=DEBUG %s
 # RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-apple-macos -x86-pad-for-align=true %S/Inputs/pad-align-without-debug.s | llvm-objdump -d - | FileCheck --check-prefix=CHECK --check-prefix=NODEBUG %s
-# RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-apple-macos -x86-pad-for-align=false %S/Inputs/pad-align-without-debug.s | llvm-objdump -d - | FileCheck --check-prefix=NOPAD %s
-# RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-apple-macos -x86-pad-for-align=false %S/Inputs/pad-align-with-debug.s | llvm-objdump -d - | FileCheck --check-prefix=NOPAD %s
+# RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-apple-macos %S/Inputs/pad-align-without-debug.s | llvm-objdump -d - | FileCheck --check-prefix=DEFAULT %s
+# RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-apple-macos %S/Inputs/pad-align-with-debug.s | llvm-objdump -d - | FileCheck --check-prefix=DEFAULT %s
 
 ; Test case to show that -x86-pad-for-align causes binary differences in the
 ; presence of debug locations. Inputs/pad-align-with-debug.s and
@@ -51,31 +51,31 @@
 ; CHECK-NEXT:      50: c3                               retq
 ; CHECK-NEXT:      51: c3                               retq
 
-; NOPAD:            0: 48 89 f8                         movq    %rdi, %rax
-; NOPAD-NEXT:       3: 0f 1f 44 00 00                   nopl    (%rax,%rax)
-; NOPAD-NEXT:       8: 0f b6 10                         movzbl  (%rax), %edx
-; NOPAD-NEXT:       b: 80 fa 0a                         cmpb    $10, %dl
-; NOPAD-NEXT:       e: 74 30                            je  0x40 <foo+0x40>
-; NOPAD-NEXT:      10: 80 fa 64                         cmpb    $100, %dl
-; NOPAD-NEXT:      13: 74 31                            je  0x46 <foo+0x46>
-; NOPAD-NEXT:      15: 80 fa c8                         cmpb    $-56, %dl
-; NOPAD-NEXT:      18: 74 2c                            je  0x46 <foo+0x46>
-; NOPAD-NEXT:      1a: 80 fa 2c                         cmpb    $44, %dl
-; NOPAD-NEXT:      1d: 75 27                            jne 0x46 <foo+0x46>
-; NOPAD-NEXT:      1f: 90                               nop
-; NOPAD-NEXT:      20: 48 89 c2                         movq    %rax, %rdx
-; NOPAD-NEXT:      23: 48 ff c0                         incq    %rax
-; NOPAD-NEXT:      26: 80 38 1e                         cmpb    $30, (%rax)
-; NOPAD-NEXT:      29: 75 f5                            jne 0x20 <foo+0x20>
-; NOPAD-NEXT:      2b: 48 8d 42 02                      leaq    2(%rdx), %rax
-; NOPAD-NEXT:      2f: 0f b6 10                         movzbl  (%rax), %edx
-; NOPAD-NEXT:      32: 80 fa 5a                         cmpb    $90, %dl
-; NOPAD-NEXT:      35: 75 d9                            jne 0x10 <foo+0x10>
-; NOPAD-NEXT:      37: 66 0f 1f 84 00 00 00 00 00       nopw    (%rax,%rax)
-; NOPAD-NEXT:      40: 80 78 04 63                      cmpb    $99, 4(%rax)
-; NOPAD-NEXT:      44: 74 0b                            je  0x51 <foo+0x51>
-; NOPAD-NEXT:      46: 48 ff c0                         incq    %rax
-; NOPAD-NEXT:      49: eb bd                            jmp 0x8 <foo+0x8>
-; NOPAD-NEXT:      4b: 0f 1f 44 00 00                   nopl    (%rax,%rax)
-; NOPAD-NEXT:      50: c3                               retq
-; NOPAD-NEXT:      51: c3                               retq
+; DEFAULT:            0: 48 89 f8                         movq    %rdi, %rax
+; DEFAULT-NEXT:       3: 0f 1f 44 00 00                   nopl    (%rax,%rax)
+; DEFAULT-NEXT:       8: 0f b6 10                         movzbl  (%rax), %edx
+; DEFAULT-NEXT:       b: 80 fa 0a                         cmpb    $10, %dl
+; DEFAULT-NEXT:       e: 74 30                            je  0x40 <foo+0x40>
+; DEFAULT-NEXT:      10: 80 fa 64                         cmpb    $100, %dl
+; DEFAULT-NEXT:      13: 74 31                            je  0x46 <foo+0x46>
+; DEFAULT-NEXT:      15: 80 fa c8                         cmpb    $-56, %dl
+; DEFAULT-NEXT:      18: 74 2c                            je  0x46 <foo+0x46>
+; DEFAULT-NEXT:      1a: 80 fa 2c                         cmpb    $44, %dl
+; DEFAULT-NEXT:      1d: 75 27                            jne 0x46 <foo+0x46>
+; DEFAULT-NEXT:      1f: 90                               nop
+; DEFAULT-NEXT:      20: 48 89 c2                         movq    %rax, %rdx
+; DEFAULT-NEXT:      23: 48 ff c0                         incq    %rax
+; DEFAULT-NEXT:      26: 80 38 1e                         cmpb    $30, (%rax)
+; DEFAULT-NEXT:      29: 75 f5                            jne 0x20 <foo+0x20>
+; DEFAULT-NEXT:      2b: 48 8d 42 02                      leaq    2(%rdx), %rax
+; DEFAULT-NEXT:      2f: 0f b6 10                         movzbl  (%rax), %edx
+; DEFAULT-NEXT:      32: 80 fa 5a                         cmpb    $90, %dl
+; DEFAULT-NEXT:      35: 75 d9                            jne 0x10 <foo+0x10>
+; DEFAULT-NEXT:      37: 66 0f 1f 84 00 00 00 00 00       nopw    (%rax,%rax)
+; DEFAULT-NEXT:      40: 80 78 04 63                      cmpb    $99, 4(%rax)
+; DEFAULT-NEXT:      44: 74 0b                            je  0x51 <foo+0x51>
+; DEFAULT-NEXT:      46: 48 ff c0                         incq    %rax
+; DEFAULT-NEXT:      49: eb bd                            jmp 0x8 <foo+0x8>
+; DEFAULT-NEXT:      4b: 0f 1f 44 00 00                   nopl    (%rax,%rax)
+; DEFAULT-NEXT:      50: c3                               retq
+; DEFAULT-NEXT:      51: c3                               retq

--- a/llvm/test/MC/X86/pad-for-align-debug.s
+++ b/llvm/test/MC/X86/pad-for-align-debug.s
@@ -1,0 +1,81 @@
+# RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-apple-macos -x86-pad-for-align=true %S/Inputs/pad-align-with-debug.s | llvm-objdump -d - | FileCheck --check-prefix=CHECK --check-prefix=DEBUG %s
+# RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-apple-macos -x86-pad-for-align=true %S/Inputs/pad-align-without-debug.s | llvm-objdump -d - | FileCheck --check-prefix=CHECK --check-prefix=NODEBUG %s
+# RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-apple-macos -x86-pad-for-align=false %S/Inputs/pad-align-without-debug.s | llvm-objdump -d - | FileCheck --check-prefix=NOPAD %s
+# RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-apple-macos -x86-pad-for-align=false %S/Inputs/pad-align-with-debug.s | llvm-objdump -d - | FileCheck --check-prefix=NOPAD %s
+
+; Test case to show that -x86-pad-for-align causes binary differences in the
+; presence of debug locations. Inputs/pad-align-with-debug.s and
+; Inputs/pad-align-without-debug.s are equivalent, modulo a single .loc, which
+; cause the difference in the binary below. This should be fixed, before
+; x86-pad-for-align=true becomes the default.
+
+; Also see PR48742.
+
+
+; CHECK-LABEL: 0000000000000000 <foo>:
+; CHECK:            0: 48 89 f8                         movq    %rdi, %rax
+; CHECK-NEXT:       3: 0f 1f 44 00 00                   nopl    (%rax,%rax)
+; CHECK-NEXT:       8: 0f b6 10                         movzbl  (%rax), %edx
+; CHECK-NEXT:       b: 80 fa 0a                         cmpb    $10, %dl
+; CHECK-NEXT:       e: 74 30                            je  0x40 <foo+0x40>
+; CHECK-NEXT:      10: 80 fa 64                         cmpb    $100, %dl
+; CHECK-NEXT:      13: 74 31                            je  0x46 <foo+0x46>
+; CHECK-NEXT:      15: 80 fa c8                         cmpb    $-56, %dl
+; CHECK-NEXT:      18: 74 2c                            je  0x46 <foo+0x46>
+; CHECK-NEXT:      1a: 80 fa 2c                         cmpb    $44, %dl
+; CHECK-NEXT:      1d: 75 27                            jne 0x46 <foo+0x46>
+; CHECK-NEXT:      1f: 90                               nop
+; CHECK-NEXT:      20: 48 89 c2                         movq    %rax, %rdx
+; CHECK-NEXT:      23: 48 ff c0                         incq    %rax
+; CHECK-NEXT:      26: 80 38 1e                         cmpb    $30, (%rax)
+
+; DEBUG-NEXT:      29: 75 f5                            jne 0x20 <foo+0x20>
+; DEBUG-NEXT:      2b: 48 8d 42 02                      leaq    2(%rdx), %rax
+; DEBUG-NEXT:      2f: 0f b6 10                         movzbl  (%rax), %edx
+; DEBUG-NEXT:      32: 80 fa 5a                         cmpb    $90, %dl
+; DEBUG-NEXT:      35: 0f 85 d5 ff ff ff                jne 0x10 <foo+0x10>
+; DEBUG-NEXT:      3b: 0f 1f 44 00 00                   nopl    (%rax,%rax)
+
+; NODEBUG-NEXT:      29: 0f 85 f1 ff ff ff              jne 0x20 <foo+0x20>
+; NODEBUG-NEXT:      2f: 48 8d 42 02                    leaq    2(%rdx), %rax
+; NODEBUG-NEXT:      33: 0f b6 10                       movzbl  (%rax), %edx
+; NODEBUG-NEXT:      36: 80 fa 5a                       cmpb    $90, %dl
+; NODEBUG-NEXT:      39: 0f 85 d1 ff ff ff              jne 0x10 <foo+0x10>
+; NODEBUG-NEXT:      3f: 90                             nop
+
+; CHECK-NEXT:      40: 80 78 04 63                      cmpb    $99, 4(%rax)
+; CHECK-NEXT:      44: 74 0b                            je  0x51 <foo+0x51>
+; CHECK-NEXT:      46: 48 ff c0                         incq    %rax
+; CHECK-NEXT:      49: e9 ba ff ff ff                   jmp 0x8 <foo+0x8>
+; CHECK-NEXT:      4e: 66 90                            nop
+; CHECK-NEXT:      50: c3                               retq
+; CHECK-NEXT:      51: c3                               retq
+
+; NOPAD:            0: 48 89 f8                         movq    %rdi, %rax
+; NOPAD-NEXT:       3: 0f 1f 44 00 00                   nopl    (%rax,%rax)
+; NOPAD-NEXT:       8: 0f b6 10                         movzbl  (%rax), %edx
+; NOPAD-NEXT:       b: 80 fa 0a                         cmpb    $10, %dl
+; NOPAD-NEXT:       e: 74 30                            je  0x40 <foo+0x40>
+; NOPAD-NEXT:      10: 80 fa 64                         cmpb    $100, %dl
+; NOPAD-NEXT:      13: 74 31                            je  0x46 <foo+0x46>
+; NOPAD-NEXT:      15: 80 fa c8                         cmpb    $-56, %dl
+; NOPAD-NEXT:      18: 74 2c                            je  0x46 <foo+0x46>
+; NOPAD-NEXT:      1a: 80 fa 2c                         cmpb    $44, %dl
+; NOPAD-NEXT:      1d: 75 27                            jne 0x46 <foo+0x46>
+; NOPAD-NEXT:      1f: 90                               nop
+; NOPAD-NEXT:      20: 48 89 c2                         movq    %rax, %rdx
+; NOPAD-NEXT:      23: 48 ff c0                         incq    %rax
+; NOPAD-NEXT:      26: 80 38 1e                         cmpb    $30, (%rax)
+; NOPAD-NEXT:      29: 75 f5                            jne 0x20 <foo+0x20>
+; NOPAD-NEXT:      2b: 48 8d 42 02                      leaq    2(%rdx), %rax
+; NOPAD-NEXT:      2f: 0f b6 10                         movzbl  (%rax), %edx
+; NOPAD-NEXT:      32: 80 fa 5a                         cmpb    $90, %dl
+; NOPAD-NEXT:      35: 75 d9                            jne 0x10 <foo+0x10>
+; NOPAD-NEXT:      37: 66 0f 1f 84 00 00 00 00 00       nopw    (%rax,%rax)
+; NOPAD-NEXT:      40: 80 78 04 63                      cmpb    $99, 4(%rax)
+; NOPAD-NEXT:      44: 74 0b                            je  0x51 <foo+0x51>
+; NOPAD-NEXT:      46: 48 ff c0                         incq    %rax
+; NOPAD-NEXT:      49: eb bd                            jmp 0x8 <foo+0x8>
+; NOPAD-NEXT:      4b: 0f 1f 44 00 00                   nopl    (%rax,%rax)
+; NOPAD-NEXT:      50: c3                               retq
+; NOPAD-NEXT:      51: c3                               retq

--- a/llvm/test/MC/X86/prefix-padding-32.s
+++ b/llvm/test/MC/X86/prefix-padding-32.s
@@ -1,4 +1,4 @@
-# RUN: llvm-mc -filetype=obj -triple i386-pc-linux-gnu %s -x86-pad-max-prefix-size=15 | llvm-objdump -d --section=.text - | FileCheck %s
+# RUN: llvm-mc -filetype=obj -triple i386-pc-linux-gnu %s -x86-pad-max-prefix-size=15 -x86-pad-for-align=1 | llvm-objdump -d - | FileCheck %s
 
 # Check prefix padding generation for all cases on 32 bit x86.
 

--- a/llvm/test/MC/X86/prefix-padding-64.s
+++ b/llvm/test/MC/X86/prefix-padding-64.s
@@ -1,4 +1,4 @@
-# RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-pc-linux-gnu %s -x86-pad-max-prefix-size=15 | llvm-objdump -d --section=.text - | FileCheck %s
+# RUN: llvm-mc -mcpu=skylake -filetype=obj -triple x86_64-pc-linux-gnu %s -x86-pad-max-prefix-size=15 -x86-pad-for-align=1 | llvm-objdump -d - | FileCheck %s
 
 # Check prefix padding generation for all cases on 64 bit x86.
 


### PR DESCRIPTION
…e with or w/o -g

Fix PR48742: the D75203 assembler optimization locates MCRelaxableFragment's
within two MCSymbol's and relaxes some MCRelaxableFragment's to reduce the size
of a MCAlignFragment.  A -g build has more MCSymbol's and therefore may have
different assembler output (e.g. a MCRelaxableFragment (jmp) may have 5 bytes
with -O1 while 2 bytes with -O1 -g).

`.p2align 4, 0x90` is common due to loops. For a larger program, with a
lot of temporary labels, the assembly output difference is somewhat
destined. The cost seems to overweigh the benefits so we default to
-x86-pad-for-align=false until the heuristic is improved.

Reviewed By: skan

Differential Revision: https://reviews.llvm.org/D94542

(cherry-picked from a048ce13e32daa255d26533c00da8abd0b67e819)