### PR TITLE
[lldb] Check that swift types are valid before accessing them

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -891,6 +891,10 @@ bool SwiftASTManipulator::FixupResultAfterTypeChecking(Status &error) {
 
   swift::VarDecl *result_var =
       AddExternalVariable(result_var_name, return_ast_type, metadata_sp);
+  if (!result_var) {
+    error.SetErrorString("Could not add external result variable.");
+    return false;
+  }
 
   result_var->overwriteAccess(swift::AccessLevel::Public);
   result_var->overwriteSetterAccess(swift::AccessLevel::Public);
@@ -934,6 +938,11 @@ bool SwiftASTManipulator::FixupResultAfterTypeChecking(Status &error) {
 
             swift::VarDecl *error_var = AddExternalVariable(
                 error_var_name, error_ast_type, error_metadata_sp);
+
+            if (!error_var) {
+              error.SetErrorString("Could not add external error variable.");
+              return false;
+            }
 
             error_var->overwriteAccess(swift::AccessLevel::Public);
             error_var->overwriteSetterAccess(
@@ -1025,6 +1034,9 @@ bool SwiftASTManipulator::AddExternalVariables(
     swift::Identifier name = variable.m_name;
     swift::Type var_type = GetSwiftType(variable.m_type);
 
+    if (!var_type)
+      return false;
+
     // If the type is an inout or lvalue type (happens if this is an argument)
     // strip that part off:
 
@@ -1113,6 +1125,10 @@ bool SwiftASTManipulator::AddExternalVariables(
       if (!referent_type)
         continue;
 
+      swift::Type swift_referent_type = GetSwiftType(referent_type);
+      if (!swift_referent_type) 
+        continue;
+      
       // One tricky bit here is that this var may be an argument to the function
       // whose context we are
       // emulating, and that argument might be of "inout" type.  We need to
@@ -1122,7 +1138,7 @@ bool SwiftASTManipulator::AddExternalVariables(
       // it is inout or not, so we don't have to do anything more to get this to
       // work.
       swift::Type var_type =
-          GetSwiftType(referent_type)->getWithoutSpecifierType();
+          swift_referent_type->getWithoutSpecifierType();
       if (is_self) {
         // Another tricky bit is that the Metatype types we get have the
         // "Representation" already attached (i.e.
@@ -1310,6 +1326,9 @@ swift::ValueDecl *SwiftASTManipulator::MakeGlobalTypealias(
       swift::TypeAliasDecl(swift::SourceLoc(), swift::SourceLoc(), name,
                            swift::SourceLoc(), nullptr, &m_source_file);
   swift::Type underlying_type = GetSwiftType(type);
+  if (!underlying_type)
+    return nullptr;
+
   type_alias_decl->setUnderlyingType(underlying_type);
   type_alias_decl->markAsDebuggerAlias(true);
   type_alias_decl->setImplicit(true);

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1059,15 +1059,24 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
     } else {
       CompilerType actual_type = variable.GetType();
       // Desugar '$lldb_context', etc.
-      auto transformed_type = GetSwiftType(actual_type).transform(
-        [](swift::Type t) -> swift::Type {
-          if (auto *aliasTy = swift::dyn_cast<swift::TypeAliasType>(t.getPointer())) {
-            if (aliasTy && aliasTy->getDecl()->isDebuggerAlias()) {
-              return aliasTy->getSinglyDesugaredType();
+      swift::Type actual_swift_type = GetSwiftType(actual_type);
+      if (!actual_swift_type)
+        return llvm::None;
+
+      auto transformed_type =
+          actual_swift_type.transform([](swift::Type t) -> swift::Type {
+            if (auto *aliasTy =
+                    swift::dyn_cast<swift::TypeAliasType>(t.getPointer())) {
+              if (aliasTy && aliasTy->getDecl()->isDebuggerAlias()) {
+                return aliasTy->getSinglyDesugaredType();
+              }
             }
-          }
-          return t;
-      });
+            return t;
+          });
+
+      if (!transformed_type)
+        return llvm::None;
+
       actual_type =
           ToCompilerType(transformed_type->mapTypeOutOfContext().getPointer());
       auto *swift_ast_ctx =
@@ -1407,8 +1416,9 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
                          *code_manipulator, options.GetUseDynamic());
 
       // Register all local variables so that lookups to them resolve.
-      if (auto error = RegisterAllVariables(sc, stack_frame_sp, *swift_ast_context,
-                                            local_variables, options.GetUseDynamic()))
+      if (auto error =
+              RegisterAllVariables(sc, stack_frame_sp, *swift_ast_context,
+                                   local_variables, options.GetUseDynamic()))
         return std::move(*error);
     }
 
@@ -1423,7 +1433,9 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
     ResolveSpecialNames(sc, exe_scope, *swift_ast_context, special_names,
                         local_variables);
 
-    code_manipulator->AddExternalVariables(local_variables);
+    if (!code_manipulator->AddExternalVariables(local_variables))
+      return make_error<StringError>(inconvertibleErrorCode(),
+                                     "Could not add external variables.");
 
     stack_frame_sp.reset();
   }


### PR DESCRIPTION
Check that the `swift::Type` is valid, before using its '->` operator.

rdar://77390710
https://bugs.swift.org/browse/SR-14556