### PR TITLE
Improve error handling in llvm-dwarfdump.

### DIFF
--- a/llvm/test/DebugInfo/dwarfdump-invalid.test
+++ b/llvm/test/DebugInfo/dwarfdump-invalid.test
@@ -1,6 +1,8 @@
 ; Verify that llvm-dwarfdump doesn't crash on broken input files.
 
-RUN: not llvm-dwarfdump %p/Inputs/invalid.elf 2>&1 | FileCheck %s --check-prefix=INVALID-ELF
-RUN: not llvm-dwarfdump %p/Inputs/invalid.elf.2 2>&1 | FileCheck %s --check-prefix=INVALID-ELF
-RUN: not llvm-dwarfdump %p/Inputs/invalid.elf.3 2>&1 | FileCheck %s --check-prefix=INVALID-ELF
-INVALID-ELF: Invalid data was encountered while parsing the file
+RUN: not llvm-dwarfdump %p/Inputs/invalid.elf 2>&1 | FileCheck %s --check-prefix=INVALID-ELF1
+RUN: not llvm-dwarfdump %p/Inputs/invalid.elf.2 2>&1 | FileCheck %s --check-prefix=INVALID-ELF2
+RUN: not llvm-dwarfdump %p/Inputs/invalid.elf.3 2>&1 | FileCheck %s --check-prefix=INVALID-ELF3
+INVALID-ELF1: section header table goes past the end of the file
+INVALID-ELF2: Invalid ELF data
+INVALID-ELF3: Invalid ELF class

--- a/llvm/test/tools/llvm-dwarfdump/X86/lc_malformed.test
+++ b/llvm/test/tools/llvm-dwarfdump/X86/lc_malformed.test
@@ -1,0 +1,39 @@
+# RUN: yaml2obj %s | not llvm-dwarfdump --uuid - 2>&1 | FileCheck %s
+# CHECK: load command 0 filesize field in LC_SEGMENT_64 greater than vmsize field
+
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x01000007
+  cpusubtype:      0x00000003
+  filetype:        0x00000001
+  ncmds:           1
+  sizeofcmds:      24
+  flags:           0x00002000
+  reserved:        0x00000000
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         232
+    segname:         ''
+    vmaddr:          0
+    vmsize:          80
+    fileoff:         384
+    filesize:        81
+    maxprot:         7
+    initprot:        7
+    nsects:          1
+    flags:           0
+    Sections:
+      - sectname:        __text
+        segname:         __TEXT
+        addr:            0x0000000000000000
+        size:            15
+        offset:          0x00000180
+        align:           4
+        reloff:          0x00000000
+        nreloc:          0
+        flags:           0x80000400
+        reserved1:       0x00000000
+        reserved2:       0x00000000
+        reserved3:       0x00000000
+...

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -257,11 +257,15 @@ static cl::extrahelp
 /// @}
 //===----------------------------------------------------------------------===//
 
-static void error(StringRef Prefix, std::error_code EC) {
-  if (!EC)
+static void error(StringRef Prefix, Error Err) {
+  if (!Err)
     return;
-  WithColor::error() << Prefix << ": " << EC.message() << "\n";
+  WithColor::error() << Prefix << ": " << toString(std::move(Err)) << "\n";
   exit(1);
+}
+
+static void error(StringRef Prefix, std::error_code EC) {
+  error(Prefix, errorCodeToError(EC));
 }
 
 static DIDumpOptions getDumpOpts(DWARFContext &C) {
@@ -502,13 +506,13 @@ static bool handleArchive(StringRef Filename, Archive &Arch,
   Error Err = Error::success();
   for (auto Child : Arch.children(Err)) {
     auto BuffOrErr = Child.getMemoryBufferRef();
-    error(Filename, errorToErrorCode(BuffOrErr.takeError()));
+    error(Filename, BuffOrErr.takeError());
     auto NameOrErr = Child.getName();
-    error(Filename, errorToErrorCode(NameOrErr.takeError()));
+    error(Filename, NameOrErr.takeError());
     std::string Name = (Filename + "(" + NameOrErr.get() + ")").str();
     Result &= handleBuffer(Name, BuffOrErr.get(), HandleObj, OS);
   }
-  error(Filename, errorToErrorCode(std::move(Err)));
+  error(Filename, std::move(Err));
 
   return Result;
 }
@@ -516,7 +520,7 @@ static bool handleArchive(StringRef Filename, Archive &Arch,
 static bool handleBuffer(StringRef Filename, MemoryBufferRef Buffer,
                          HandlerFn HandleObj, raw_ostream &OS) {
   Expected<std::unique_ptr<Binary>> BinOrErr = object::createBinary(Buffer);
-  error(Filename, errorToErrorCode(BinOrErr.takeError()));
+  error(Filename, BinOrErr.takeError());
 
   bool Result = true;
   auto RecoverableErrorHandler = [&](Error E) {
@@ -547,7 +551,7 @@ static bool handleBuffer(StringRef Filename, MemoryBufferRef Buffer,
       } else
         consumeError(MachOOrErr.takeError());
       if (auto ArchiveOrErr = ObjForArch.getAsArchive()) {
-        error(ObjName, errorToErrorCode(ArchiveOrErr.takeError()));
+        error(ObjName, ArchiveOrErr.takeError());
         if (!handleArchive(ObjName, *ArchiveOrErr.get(), HandleObj, OS))
           Result = false;
         continue;


### PR DESCRIPTION
Without this patch we're only showing a generic error message derived
from the error code to the end user.

rdar://79378794

Differential Revision: https://reviews.llvm.org/D104483

(cherry picked from commit 072f5180f2d33a3323a164fe19a7a477e93073a9)