### PR TITLE
Add support for the NSMutableDictionary variant: "__NSFrozenDictionaryM"

### DIFF
--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -410,6 +410,7 @@ bool lldb_private::formatters::NSDictionarySummaryProvider(
   static const ConstString g_DictionaryM("__NSDictionaryM");
   static const ConstString g_DictionaryMLegacy("__NSDictionaryM_Legacy");
   static const ConstString g_DictionaryMImmutable("__NSDictionaryM_Immutable");
+  static const ConstString g_DictionaryMFrozen("__NSFrozenDictionaryM");
   static const ConstString g_Dictionary1("__NSSingleEntryDictionaryI");
   static const ConstString g_Dictionary0("__NSDictionary0");
   static const ConstString g_DictionaryCF("__CFDictionary");
@@ -427,7 +428,8 @@ bool lldb_private::formatters::NSDictionarySummaryProvider(
       return false;
 
     value &= (is_64bit ? ~0xFC00000000000000UL : ~0xFC000000U);
-  } else if (class_name == g_DictionaryM || class_name == g_DictionaryMLegacy) {
+  } else if (class_name == g_DictionaryM || class_name == g_DictionaryMLegacy 
+             || class_name == g_DictionaryMFrozen) {
     AppleObjCRuntime *apple_runtime =
     llvm::dyn_cast_or_null<AppleObjCRuntime>(runtime);
     Status error;
@@ -509,6 +511,7 @@ lldb_private::formatters::NSDictionarySyntheticFrontEndCreator(
   static const ConstString g_DictionaryM("__NSDictionaryM");
   static const ConstString g_Dictionary1("__NSSingleEntryDictionaryI");
   static const ConstString g_DictionaryImmutable("__NSDictionaryM_Immutable");
+  static const ConstString g_DictionaryMFrozen("__NSFrozenDictionaryM");
   static const ConstString g_DictionaryMLegacy("__NSDictionaryM_Legacy");
   static const ConstString g_Dictionary0("__NSDictionary0");
   static const ConstString g_DictionaryCF("__CFDictionary");
@@ -520,7 +523,7 @@ lldb_private::formatters::NSDictionarySyntheticFrontEndCreator(
 
   if (class_name == g_DictionaryI) {
     return (new NSDictionaryISyntheticFrontEnd(valobj_sp));
-  } else if (class_name == g_DictionaryM) {
+  } else if (class_name == g_DictionaryM || class_name == g_DictionaryMFrozen) {
     if (runtime->GetFoundationVersion() >= 1437) {
       return (new Foundation1437::NSDictionaryMSyntheticFrontEnd(valobj_sp));
     } else if (runtime->GetFoundationVersion() >= 1428) {

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSContainer.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSContainer.py
@@ -20,7 +20,7 @@ class ObjCDataFormatterNSContainer(ObjCDataFormatterTestCase):
 
     def nscontainers_data_formatter_commands(self):
         self.expect(
-            'frame variable newArray nsDictionary newDictionary nscfDictionary cfDictionaryRef newMutableDictionary newMutableDictionaryRef cfarray_ref mutable_array_ref',
+            'frame variable newArray nsDictionary newDictionary nscfDictionary cfDictionaryRef newMutableDictionary copyDictionary newMutableDictionaryRef cfarray_ref mutable_array_ref',
             substrs=[
                 '(NSArray *) newArray = ',
                 ' @"50 elements"',
@@ -34,6 +34,8 @@ class ObjCDataFormatterNSContainer(ObjCDataFormatterTestCase):
                 ' 2 key/value pairs',
                 '(NSDictionary *) newMutableDictionary = ',
                 ' 21 key/value pairs',
+                '(NSMutableDictionary *) copyDictionary = ',
+                ' 21 key/value pairs',
                 '(CFMutableDictionaryRef) newMutableDictionaryRef = ',
                 ' 21 key/value pairs',
                 '(CFArrayRef) cfarray_ref = ',
@@ -42,6 +44,9 @@ class ObjCDataFormatterNSContainer(ObjCDataFormatterTestCase):
                 ' @"11 elements"',
             ])
 
+        self.expect('frame var -d run-target copyDictionary[10]',
+                    substrs=['@"bar9"', '@"foo"'])
+        
         self.expect(
             'frame variable -d run-target *nscfDictionary',
             patterns=[

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/main.m
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/main.m
@@ -476,6 +476,10 @@ int main(int argc, const char *argv[]) {
   [newMutableDictionary setObject:@"foo" forKey:@"bar19"];
   [newMutableDictionary setObject:@"foo" forKey:@"bar20"];
 
+  /* Copying an NSMutableDictionary makes a different member of the
+     class cluster, so let's also make a copy of this one: */
+  NSMutableDictionary *copyDictionary = [newMutableDictionary copy];
+
   CFMutableDictionaryRef newMutableDictionaryRef = CFDictionaryCreateMutableCopy(kCFAllocatorDefault, 0, newMutableDictionary);
 
   id cfKeys[4] = {@"foo", @"bar", @"baz", @"quux"};


### PR DESCRIPTION
This was an oversight of the commit: bb93483c119b92c1ec2b7a58505e21b9dce6a333 that
added support for the Frozen variants.  Also added a test case for the way that
currently produces one of these variants (a copy).

(cherry picked from commit 4eabb12057616f360b2329f63c0379eced3135b4)

Frozen & Mutable dictionaries have the same storage, so all we needed to do was recognize the new type and treat it the same way as the Mutable dictionary.