### PR TITLE
[lldb] handle relative working directories in swiftmodule debug info

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -142,7 +142,7 @@
     if (HasFatalErrors()) {                                                    \
       return;                                                                  \
     }                                                                          \
-  } while (0);                                                                 
+  } while (0);
 #define VALID_OR_RETURN_CHECK_TYPE(type, value)                                \
   do {                                                                         \
     if (HasFatalErrors() || !type) {                                           \
@@ -1414,29 +1414,6 @@ bool ConsumeIncludeOption(StringRef &arg, StringRef &prefix) {
   return false;
 }
 
-/// Turn relative paths in clang options into absolute paths based on
-/// \c cur_working_dir.
-template <typename SmallString>
-void ApplyWorkingDir(SmallString &clang_argument, StringRef cur_working_dir) {
-  StringRef arg = clang_argument.str();
-  StringRef prefix;
-  if (ConsumeIncludeOption(arg, prefix)) {
-    // Ignore the option part of a double-arg include option.
-    if (arg.empty())
-      return;
-  } else if (arg.startswith("-")) {
-    // Assume this is a compiler arg and not a path starting with "-".
-    return;
-  }
-  // There is most probably a path in arg now.
-  if (!llvm::sys::path::is_relative(arg))
-    return;
-  SmallString rel_path = arg;
-  clang_argument = prefix;
-  llvm::sys::path::append(clang_argument, cur_working_dir, rel_path);
-  llvm::sys::path::remove_dots(clang_argument);
-}
-
 std::array<StringRef, 2> macro_flags = { "-D", "-U" };
 std::array<StringRef, 5> multi_arg_flags =
     { "-D", "-U", "-I", "-F", "-working-directory" };
@@ -1527,6 +1504,31 @@ void SwiftASTContext::AddUserClangArgs(TargetProperties &props) {
   for (const auto &arg : args.entries())
     user_clang_flags.push_back(arg.ref().str());
   AddExtraClangArgs(user_clang_flags);
+}
+
+/// Turn relative paths in clang options into absolute paths based on
+/// \c cur_working_dir.
+void SwiftASTContext::ApplyWorkingDir(
+    llvm::SmallVectorImpl<char> &clang_argument, StringRef cur_working_dir) {
+  StringRef arg = StringRef(clang_argument.data(), clang_argument.size());
+  StringRef prefix;
+  if (ConsumeIncludeOption(arg, prefix)) {
+    // Ignore the option part of a double-arg include option.
+    if (arg.empty())
+      return;
+  } else if (arg.startswith("-")) {
+    // Assume this is a compiler arg and not a path starting with "-".
+    return;
+  }
+  // There is most probably a path in arg now.
+  if (!llvm::sys::path::is_relative(arg))
+    return;
+
+  llvm::SmallString<128> joined_path;
+  llvm::sys::path::append(joined_path, cur_working_dir, arg);
+  llvm::sys::path::remove_dots(joined_path);
+  clang_argument.resize(prefix.size());
+  clang_argument.append(joined_path.begin(), joined_path.end());
 }
 
 void SwiftASTContext::RemapClangImporterOptions(
@@ -4592,7 +4594,7 @@ llvm::Optional<SwiftASTContext::TypeOrDecl>
 SwiftASTContext::FindTypeOrDecl(const char *name,
                                 swift::ModuleDecl *swift_module) {
   VALID_OR_RETURN(llvm::Optional<SwiftASTContext::TypeOrDecl>());
- 
+
   TypesOrDecls search_results;
 
   FindTypesOrDecls(name, swift_module, search_results, false);
@@ -5772,7 +5774,7 @@ SwiftASTContext::GetArrayElementType(opaque_compiler_type_t type,
       }
     }
   }
-  
+
   return element_type;
 }
 
@@ -5847,7 +5849,7 @@ size_t SwiftASTContext::GetNumMemberFunctions(opaque_compiler_type_t type) {
       }
     }
   }
-  
+
   return num_functions;
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -20,6 +20,7 @@
 #include "lldb/Core/ThreadSafeDenseMap.h"
 #include "lldb/Core/ThreadSafeDenseSet.h"
 #include "lldb/Utility/Either.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Target/TargetOptions.h"
 
@@ -166,7 +167,7 @@ public:
                   Target *target = nullptr);
 
   SwiftASTContext(const SwiftASTContext &rhs) = delete;
-  
+
   TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() override {
     return m_typeref_typesystem;
   }
@@ -551,6 +552,9 @@ public:
   static bool IsNonTriviallyManagedReferenceType(
       const CompilerType &type, NonTriviallyManagedReferenceStrategy &strategy,
       CompilerType *underlying_type = nullptr);
+
+  static void ApplyWorkingDir(llvm::SmallVectorImpl<char> &clang_argument,
+                              llvm::StringRef cur_working_dir);
 
   // AST related queries
 
@@ -981,4 +985,5 @@ private:
 };
 
 } // namespace lldb_private
+
 #endif // #ifndef liblldb_SwiftASTContext_h_


### PR DESCRIPTION
This change makes it possible to use relative working directories. Prior
to this change the `path::append` will put a / between the `clang_argument`
and the `cur_working_dir`, which will not correctly resolve if
`cur_working_dir` is relative. This change joins the path components
separately then concatenates with the `clang_argument`.