### PR TITLE
[compiler-rt] fix two asan tests (unpoison-alternate-stack.cpp, zero_page_pc.cpp)

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/unpoison-alternate-stack.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/unpoison-alternate-stack.cpp
@@ -6,10 +6,6 @@
 // RUN: %clangxx_asan -std=c++20 -fexceptions -O0 %s -o %t -pthread
 // RUN: %run %t
 
-// XFAIL: ios && !iossim
-// longjmp from signal handler is unportable.
-// XFAIL: solaris
-
 #include <algorithm>
 #include <cassert>
 #include <cerrno>

--- a/compiler-rt/test/asan/TestCases/zero_page_pc.cpp
+++ b/compiler-rt/test/asan/TestCases/zero_page_pc.cpp
@@ -1,9 +1,17 @@
 // Check that ASan correctly detects SEGV on the zero page.
 // RUN: %clangxx_asan %s -o %t && not %run %t 2>&1 | FileCheck %s
 
+#if __has_feature(ptrauth_calls)
+#  include <ptrauth.h>
+#endif
+
 typedef void void_f();
 int main() {
   void_f *func = (void_f *)0x4;
+#if __has_feature(ptrauth_calls)
+  func = ptrauth_sign_unauthenticated(
+      func, ptrauth_key_function_pointer, 0);
+#endif
   func();
   // x86 reports the SEGV with both address=4 and pc=4.
   // On PowerPC64 ELFv1, the pointer is taken to be a function-descriptor


### PR DESCRIPTION
This is a test only change. Cherry picking fixes for these two test cases for our CI.