### PR TITLE
[5.5] use SymbolGraphOptions when getting swift::ASTContext

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -54,6 +54,7 @@
 #include "swift/SIL/SILModule.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "swift/Serialization/Validation.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/Basic/SourceManager.h"
@@ -2524,6 +2525,10 @@ swift::TypeCheckerOptions &SwiftASTContext::GetTypeCheckerOptions() {
   return GetCompilerInvocation().getTypeCheckerOptions();
 }
 
+swift::symbolgraphgen::SymbolGraphOptions &SwiftASTContext::GetSymbolGraphOptions() {
+  return GetCompilerInvocation().getSymbolGraphOptions();
+}
+
 swift::DiagnosticEngine &SwiftASTContext::GetDiagnosticEngine() {
   if (!m_diagnostic_engine_ap) {
     m_diagnostic_engine_ap.reset(
@@ -3310,7 +3315,7 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
   LLDB_SCOPED_TIMER();
   m_ast_context_ap.reset(swift::ASTContext::get(
       GetLanguageOptions(), GetTypeCheckerOptions(), GetSearchPathOptions(),
-      GetClangImporterOptions(),
+      GetClangImporterOptions(), GetSymbolGraphOptions(),
       GetSourceManager(), GetDiagnosticEngine()));
   m_diagnostic_consumer_ap.reset(new StoringDiagnosticConsumer(*this));
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -16,6 +16,7 @@
 #include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 #include "Plugins/TypeSystem/Swift/TypeSystemSwift.h"
 #include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "lldb/Core/SwiftForward.h"
 #include "lldb/Core/ThreadSafeDenseMap.h"
 #include "lldb/Core/ThreadSafeDenseSet.h"
@@ -208,6 +209,8 @@ public:
   swift::SourceManager &GetSourceManager();
 
   swift::LangOptions &GetLanguageOptions();
+
+  swift::symbolgraphgen::SymbolGraphOptions &GetSymbolGraphOptions();
 
   swift::TypeCheckerOptions &GetTypeCheckerOptions();
 


### PR DESCRIPTION
As part of https://github.com/apple/swift/pull/38071, the use of Swift's ASTContext needs to be updated in LLDB to handle the addition of the symbol-graph options.