### PR TITLE
arm64_32: only use 4-byte stack slot for tail call pointer args

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -5482,7 +5482,8 @@ AArch64TargetLowering::LowerCall(CallLoweringInfo &CLI,
       // common case. It should also work for fundamental types too.
       uint32_t BEAlign = 0;
       unsigned OpSize;
-      if (VA.getLocInfo() == CCValAssign::Indirect)
+      if (VA.getLocInfo() == CCValAssign::Indirect ||
+          VA.getLocInfo() == CCValAssign::Trunc)
         OpSize = VA.getLocVT().getFixedSizeInBits();
       else
         OpSize = Flags.isByVal() ? Flags.getByValSize() * 8

--- a/llvm/test/CodeGen/AArch64/swifttail-arm64_32.ll
+++ b/llvm/test/CodeGen/AArch64/swifttail-arm64_32.ll
@@ -1,0 +1,10 @@
+; RUN: llc -mtriple=arm64_32-apple-watchos %s -o - | FileCheck %s
+
+declare swifttailcc void @pointer_align_callee([8 x i64], i32, i32, i32, i8*)
+define swifttailcc void @pointer_align_caller(i8* swiftasync %as, i8* %in) "frame-pointer"="all" {
+; CHECK-LABEL: pointer_align_caller:
+; CHECK: b _pointer_align_callee
+  alloca i32
+  musttail call swifttailcc void @pointer_align_callee([8 x i64] undef, i32 0, i32 1, i32 2, i8* %in)
+  ret void
+}


### PR DESCRIPTION
We're currently allocating 8-byte (overlapping) slots for pointers on arm64_32 which confusess PrologEpilogEmitter later on. This calculates the size correctly.

Only arm64_32 ever uses the `Trunc` option so there should be no risk of side-effects.