### PR TITLE
Fix incorrect test.

### DIFF
--- a/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -45,11 +45,8 @@ class TestSwiftDeploymentTarget(TestBase):
     @swiftTest
     def test_swift_deployment_target_dlopen(self):
         self.build()
-        # Create the target
-        target = self.dbg.CreateTarget(self.getBuildArtifact("dlopen_module"))
-        self.assertTrue(target, VALID_TARGET)
-
-        (_, _, self.thread, _) = lldbutil.run_to_source_breakpoint(self,
-            'break here', lldb.SBFileSpec('NewerTarget.swift'))
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('NewerTarget.swift'),
+            exe_name="dlopen_module")
         self.expect("p self", substrs=['i = 23'])
 


### PR DESCRIPTION
According to the comment the test is supposed to run against the
"dlopen_module" target, but instead it creates that target and then
runs the test against a second default "a.out" target.

(cherry picked from commit b8b264ffbfc9e8fcedd2ca42b3ca464866ad9a47)