### PR TITLE
Save and restore previous terminal after setting the terminal for checking if terminal supports colors

### DIFF
--- a/llvm/lib/Support/Unix/Process.inc
+++ b/llvm/lib/Support/Unix/Process.inc
@@ -332,6 +332,7 @@ static bool terminalHasColors(int fd) {
   // First, acquire a global lock because these C routines are thread hostile.
   std::lock_guard<std::mutex> G(*TermColorMutex);
 
+  struct term *previous_term = set_curterm(nullptr);
   int errret = 0;
   if (setupterm(nullptr, fd, &errret) != 0)
     // Regardless of why, if we can't get terminfo, we shouldn't try to print
@@ -355,7 +356,7 @@ static bool terminalHasColors(int fd) {
 
   // Now extract the structure allocated by setupterm and free its memory
   // through a really silly dance.
-  struct term *termp = set_curterm(nullptr);
+  struct term *termp = set_curterm(previous_term);
   (void)del_curterm(termp); // Drop any errors here.
 
   // Return true if we found a color capabilities for the current terminal.


### PR DESCRIPTION
The call to "set_curterm" inside the "terminalHasColors" function breaks
the EditLine configuration on some Linux distributions, causing certain
characters that have functions bound to them to not show up and
backspace to stop deleting characters (only visually). This patch
ensures that term struct is restored after the routine for cheking if
terminal supports colors is done, which fixes the aforementioned issue.

Reviewed By: labath

Differential Revision: https://reviews.llvm.org/D95230

(cherry picked from commit 075de2d8a7567a6a39e8477407960aa2545b68c2)

@adrian-prantl this is a patch I made back in March to fix an issue where certain characters wouldn't show up in the REPL on Linux, but I forgot to cherry-pick it from llvm.org 🤦‍♂️