### PR TITLE
AArch64: use 4-byte slots for arm64_32 pointers in a tail call

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -5864,7 +5864,8 @@ AArch64TargetLowering::LowerCall(CallLoweringInfo &CLI,
       // common case. It should also work for fundamental types too.
       uint32_t BEAlign = 0;
       unsigned OpSize;
-      if (VA.getLocInfo() == CCValAssign::Indirect)
+      if (VA.getLocInfo() == CCValAssign::Indirect ||
+          VA.getLocInfo() == CCValAssign::Trunc)
         OpSize = VA.getLocVT().getFixedSizeInBits();
       else
         OpSize = Flags.isByVal() ? Flags.getByValSize() * 8

--- a/llvm/test/CodeGen/AArch64/swifttail-arm64_32.ll
+++ b/llvm/test/CodeGen/AArch64/swifttail-arm64_32.ll
@@ -1,0 +1,16 @@
+; RUN: llc -mtriple=arm64_32-apple-watchos %s -o - | FileCheck %s
+
+declare swifttailcc void @pointer_align_callee([8 x i64], i32, i32, i32, i8*)
+define swifttailcc void @pointer_align_caller(i8* swiftasync %as, i8* %in) "frame-pointer"="all" {
+; CHECK-LABEL: pointer_align_caller:
+; CHECK: sub sp, sp, #48
+; CHECK: mov [[TWO:w[0-9]+]], #2
+; CHECK: mov [[ZERO_ONE:x[0-9]+]], #4294967296
+; CHECK: stp [[TWO]], w0, [x29, #24]
+; CHECK: str [[ZERO_ONE]], [x29, #16]
+; CHECK: add sp, sp, #32
+; CHECK: b _pointer_align_callee
+  alloca i32
+  musttail call swifttailcc void @pointer_align_callee([8 x i64] undef, i32 0, i32 1, i32 2, i8* %in)
+  ret void
+}


### PR DESCRIPTION
Cherry-picking from 7802f62b3f2c18aa689e315460539736e1c81974.