### PR TITLE
[Support] Get correct number of physical cores on Apple Silicon

### DIFF
--- a/llvm/lib/Support/Host.cpp
+++ b/llvm/lib/Support/Host.cpp
@@ -1309,7 +1309,7 @@ int computeHostNumPhysicalCores() {
 }
 #elif defined(__linux__) && defined(__s390x__)
 int computeHostNumPhysicalCores() { return sysconf(_SC_NPROCESSORS_ONLN); }
-#elif defined(__APPLE__) && defined(__x86_64__)
+#elif defined(__APPLE__)
 #include <sys/param.h>
 #include <sys/sysctl.h>
 


### PR DESCRIPTION
Fix a bug that `computeHostNumPhysicalCores` is fallback to default
unknown when building for Apple Silicon macs.

rdar://80533675

Reviewed By: arphaman

Differential Revision: https://reviews.llvm.org/D106012