### PR TITLE
[debugserver] Un-conditionalize code guarded by macOS 10.10 checks

### DIFF
--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
@@ -2715,10 +2715,6 @@ MachProcess::GetGenealogyImageInfo(size_t idx) {
 
 bool MachProcess::GetOSVersionNumbers(uint64_t *major, uint64_t *minor,
                                       uint64_t *patch) {
-#if defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) &&                  \
-    (__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101000)
-  return false;
-#else
   NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 
   NSOperatingSystemVersion vers =
@@ -2733,7 +2729,6 @@ bool MachProcess::GetOSVersionNumbers(uint64_t *major, uint64_t *minor,
   [pool drain];
 
   return true;
-#endif
 }
 
 std::string MachProcess::GetMacCatalystVersionString() {

--- a/lldb/tools/debugserver/source/RNBRemote.cpp
+++ b/lldb/tools/debugserver/source/RNBRemote.cpp
@@ -148,8 +148,6 @@ uint64_t decode_uint64(const char *p, int base, char **end = nullptr,
 extern void ASLLogCallback(void *baton, uint32_t flags, const char *format,
                            va_list args);
 
-#if defined(__APPLE__) &&                                                      \
-    (__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 101000)
 // from System.framework/Versions/B/PrivateHeaders/sys/codesign.h
 extern "C" {
 #define CS_OPS_STATUS 0       /* return status */
@@ -164,7 +162,6 @@ typedef uint32_t csr_config_t;
 #define CSR_ALLOW_TASK_FOR_PID (1 << 2)
 int csr_check(csr_config_t mask);
 }
-#endif
 
 RNBRemote::RNBRemote()
     : m_ctx(), m_comm(), m_arch(), m_continue_thread(-1), m_thread(-1),


### PR DESCRIPTION
We've been requiring macOS 10.11 since 2018 so there's no point in
keeping code for 10.10 around.

(cherry picked from commit b5a84e214d49c56d13dc1fb76273f575e6752c68)