### PR TITLE
[Sema] Fix ptrauth test failure

### DIFF
--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -66,7 +66,7 @@ namespace {
       //   cv-unqualified non-class, non-array type, the type of the
       //   expression is adjusted to T prior to any further analysis.
       if (!S.Context.getLangOpts().ObjC && !DestType->isRecordType() &&
-          !DestType->isArrayType()) {
+          !DestType->isArrayType() && !DestType.getPointerAuth()) {
         DestType = DestType.getUnqualifiedType();
       }
 


### PR DESCRIPTION
Opt out of the unqualified type logic for casting([expr.type]/8.2.2),
if the type has pointer auth qualifiers as we never allow casting to
authenticated types.