### PR TITLE
[Support] Turn on SupportTest for Apple Silicon

### DIFF
--- a/llvm/unittests/Support/Host.cpp
+++ b/llvm/unittests/Support/Host.cpp
@@ -39,7 +39,7 @@ protected:
     // physical cores, which is currently only supported/tested on
     // some systems.
     return (Host.isOSWindows() && llvm_is_multithreaded()) ||
-           (Host.isX86() && (Host.isOSDarwin() || Host.isOSLinux())) ||
+           Host.isOSDarwin() || (Host.isX86() && Host.isOSLinux()) ||
            (Host.isPPC64() && Host.isOSLinux()) ||
            (Host.isSystemZ() && (Host.isOSLinux() || Host.isOSzOS()));
   }


### PR DESCRIPTION
Follow up for D106012, turn on unittest for Host on Apple Silicon.

Reviewed By: dexonsmith

Differential Revision: https://reviews.llvm.org/D106020