### PR TITLE
[lldb] Call DestroyImpl for eStateInvalid

### DIFF
--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -665,10 +665,10 @@ void Process::Finalize() {
   case eStateStepping:
   case eStateCrashed:
   case eStateSuspended:
+  case eStateInvalid:
     DestroyImpl(false);
     break;
 
-  case eStateInvalid:
   case eStateUnloaded:
   case eStateDetached:
   case eStateExited:


### PR DESCRIPTION
The process ends up in eStateInvalid when you attempt to interrupt a
GDBRemoteProcess and it doesn't return in time. When that happens we
really should be calling Destroy because otherwise we might end up in a
situation where we receive a packet while or after we've torn down the
main process.