### PR TITLE
Revert "[lldb] Use CompileUnit::ResolveSymbolContext in SymbolFileDWARF"

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2017,7 +2017,7 @@ uint32_t SymbolFileDWARF::ResolveSymbolContext(
               uint32_t line_idx = line_table->FindLineEntryIndexByFileIndex(
                   0, file_idx, src_location_spec, &sc.line_entry);
               found_line = sc.line_entry.line;
-              found_column - sc.line_entry.column;
+              found_column = sc.line_entry.column;
 
               while (line_idx != UINT32_MAX) {
                 sc.function = nullptr;
@@ -2034,7 +2034,8 @@ uint32_t SymbolFileDWARF::ResolveSymbolContext(
 
                 SourceLocationSpec found_location_spec(
                     file_spec, found_line, found_column,
-                    /*check_inlines=*/false, /*exact=*/true) sc_list.Append(sc);
+                    /*check_inlines=*/false, /*exact=*/true);
+                sc_list.Append(sc);
                 line_idx = line_table->FindLineEntryIndexByFileIndex(
                     line_idx + 1, file_idx, found_location_spec,
                     &sc.line_entry);

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -1974,6 +1974,8 @@ uint32_t SymbolFileDWARF::ResolveSymbolContext(
     const SourceLocationSpec &src_location_spec,
     SymbolContextItem resolve_scope, SymbolContextList &sc_list) {
   std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
+  const FileSpec &file_spec = src_location_spec.GetFileSpec();
+  const uint32_t line = src_location_spec.GetLine().getValueOr(0);
   const bool check_inlines = src_location_spec.GetCheckInlines();
   const uint32_t prev_size = sc_list.GetSize();
   if (resolve_scope & eSymbolContextCompUnit) {
@@ -1986,7 +1988,71 @@ uint32_t SymbolFileDWARF::ResolveSymbolContext(
       bool file_spec_matches_cu_file_spec = FileSpec::Match(
           src_location_spec.GetFileSpec(), dc_cu->GetPrimaryFile());
       if (check_inlines || file_spec_matches_cu_file_spec) {
-        dc_cu->ResolveSymbolContext(src_location_spec, resolve_scope, sc_list);
+        SymbolContext sc(m_objfile_sp->GetModule());
+        sc.comp_unit = dc_cu;
+        uint32_t file_idx = UINT32_MAX;
+
+        // If we are looking for inline functions only and we don't find it
+        // in the support files, we are done.
+        if (check_inlines) {
+          file_idx =
+              sc.comp_unit->GetSupportFiles().FindFileIndex(1, file_spec, true);
+          if (file_idx == UINT32_MAX)
+            continue;
+        }
+
+        if (line != 0) {
+          LineTable *line_table = sc.comp_unit->GetLineTable();
+
+          if (line_table != nullptr && line != 0) {
+            // We will have already looked up the file index if we are
+            // searching for inline entries.
+            if (!check_inlines)
+              file_idx = sc.comp_unit->GetSupportFiles().FindFileIndex(
+                  1, file_spec, true);
+
+            if (file_idx != UINT32_MAX) {
+              uint32_t found_line;
+              uint16_t found_column;
+              uint32_t line_idx = line_table->FindLineEntryIndexByFileIndex(
+                  0, file_idx, src_location_spec, &sc.line_entry);
+              found_line = sc.line_entry.line;
+              found_column - sc.line_entry.column;
+
+              while (line_idx != UINT32_MAX) {
+                sc.function = nullptr;
+                sc.block = nullptr;
+                if (resolve_scope &
+                    (eSymbolContextFunction | eSymbolContextBlock)) {
+                  const lldb::addr_t file_vm_addr =
+                      sc.line_entry.range.GetBaseAddress().GetFileAddress();
+                  if (file_vm_addr != LLDB_INVALID_ADDRESS) {
+                    ResolveFunctionAndBlock(
+                        file_vm_addr, resolve_scope & eSymbolContextBlock, sc);
+                  }
+                }
+
+                SourceLocationSpec found_location_spec(
+                    file_spec, found_line, found_column,
+                    /*check_inlines=*/false, /*exact=*/true) sc_list.Append(sc);
+                line_idx = line_table->FindLineEntryIndexByFileIndex(
+                    line_idx + 1, file_idx, found_location_spec,
+                    &sc.line_entry);
+              }
+            }
+          } else if (file_spec_matches_cu_file_spec && !check_inlines) {
+            // only append the context if we aren't looking for inline call
+            // sites by file and line and if the file spec matches that of
+            // the compile unit
+            sc_list.Append(sc);
+          }
+        } else if (file_spec_matches_cu_file_spec && !check_inlines) {
+          // only append the context if we aren't looking for inline call
+          // sites by file and line and if the file spec matches that of
+          // the compile unit
+          sc_list.Append(sc);
+        }
+
         if (!check_inlines)
           break;
       }

--- a/lldb/source/Symbol/CompileUnit.cpp
+++ b/lldb/source/Symbol/CompileUnit.cpp
@@ -254,6 +254,17 @@ void CompileUnit::ResolveSymbolContext(
   if (!file_spec_matches_cu_file_spec && !check_inlines)
     return;
 
+  uint32_t file_idx =
+      GetSupportFiles().FindFileIndex(0, file_spec, true);
+  while (file_idx != UINT32_MAX) {
+    file_indexes.push_back(file_idx);
+    file_idx = GetSupportFiles().FindFileIndex(file_idx + 1, file_spec, true);
+  }
+
+  const size_t num_file_indexes = file_indexes.size();
+  if (num_file_indexes == 0)
+    return;
+
   SymbolContext sc(GetModule());
   sc.comp_unit = this;
 
@@ -266,25 +277,10 @@ void CompileUnit::ResolveSymbolContext(
     return;
   }
 
-  uint32_t file_idx =
-      GetSupportFiles().FindFileIndex(0, file_spec, true);
-  while (file_idx != UINT32_MAX) {
-    file_indexes.push_back(file_idx);
-    file_idx = GetSupportFiles().FindFileIndex(file_idx + 1, file_spec, true);
-  }
-
-  const size_t num_file_indexes = file_indexes.size();
-  if (num_file_indexes == 0)
-    return;
-
   LineTable *line_table = sc.comp_unit->GetLineTable();
 
-  if (line_table == nullptr) {
-    if (file_spec_matches_cu_file_spec && !check_inlines) {
-      sc_list.Append(sc);
-    }
+  if (line_table == nullptr)
     return;
-  }
 
   uint32_t line_idx;
   LineEntry line_entry;


### PR DESCRIPTION
Cherry-picks that commit + the build fix.