### PR TITLE
[am] Drop apple/main and rename swift/next to next

### DIFF
--- a/apple-llvm-config/am/am-config.json
+++ b/apple-llvm-config/am/am-config.json
@@ -1,12 +1,7 @@
 [
 {
-  "target": "apple/main",
+  "target": "next",
   "upstream": "llvm.org/main"
-},
-{
-  "target": "swift/next",
-  "upstream": "apple/main",
-  "test-command": "true"
 },
 {
   "target": "swift/rebranch",


### PR DESCRIPTION
Updating the config after the branch renaming.

 - `apple/main` has been merged into `swift/next`
 - `swift/next` has been renamed to `next`.