### PR TITLE
Fix a bug in OptimizedStructLayout when filling gaps before

### DIFF
--- a/llvm/unittests/Support/OptimizedStructLayoutTest.cpp
+++ b/llvm/unittests/Support/OptimizedStructLayoutTest.cpp
@@ -130,3 +130,20 @@ TEST(OptimizedStructLayoutTest, GardenPath) {
     .flexible(2, 2, 48)
     .verify(50, 4);
 }
+
+// PR 51131
+TEST(OptimizedStructLayoutTest, HighAlignment) {
+  // Handle the case where a flexible field has such a high alignment
+  // requirement that aligning LastEnd to it gives an offset past the
+  // end of the gap before the next fixed-alignment field.
+  LayoutTest()
+    .fixed(8, 8, 0)
+    .fixed(8, 8, 8)
+    .fixed(64, 64, 64)
+    .flexible(1, 1, 16)
+    .flexible(1, 1, 17)
+    .flexible(4, 128, 128)
+    .flexible(1, 1, 18)
+    .flexible(1, 1, 19)
+    .verify(132, 128);
+}


### PR DESCRIPTION
fixed fields with highly-aligned flexible fields.

The code was not considering the possibility that aligning
the current offset to the alignment of a queue might push
us past the end of the gap.  Subtracting the offsets to
figure out the maximum field size for the gap then overflowed,
making us think that we had nearly unbounded space to fill.

Fixes PR 51131.

(cherry picked from commit 326a5a2658d81db46a78b184fe42e522ef170f32)