### PR TITLE
[lldb] Change some Swift REPL intro text

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -100,6 +100,7 @@ lldb::REPLSP SwiftREPL::CreateInstanceFromTarget(Status &err, Target &target,
 lldb::REPLSP SwiftREPL::CreateInstanceFromDebugger(Status &err,
                                                    Debugger &debugger,
                                                    const char *repl_options) {
+  printf("Starting the Swift REPL...\n");
   const char *bp_name = "repl_main";
 
   FileSpec repl_executable = HostInfo::GetSupportExeDir();
@@ -262,9 +263,8 @@ lldb::REPLSP SwiftREPL::CreateInstanceFromDebugger(Status &err,
   // Disable the cleanup, since we have a valid repl session now.
   cleanup.release();
 
-  std::string swift_full_version(swift::version::getSwiftFullVersion());
-  printf("Welcome to %s.\nType :help for assistance.\n",
-         swift_full_version.c_str());
+  printf("You are now in an interactive environment powered by the LLDB debugger where you can type, run, and debug Swift code.\n\n");
+  printf("Type \x1B[1m:help\x1B[0m for debugger assistance. Type \x1B[1m:exit\x1B[0m to quit.\n");
 
   return repl_sp;
 }

--- a/lldb/test/Shell/SwiftREPL/CFString.test
+++ b/lldb/test/Shell/SwiftREPL/CFString.test
@@ -3,7 +3,7 @@
 // REQUIRES: swift
 
 // RUN: %lldb --repl < %s | FileCheck %s
-// CHECK: Welcome to {{.*}}Swift
+// CHECK: You are now in an interactive environment
 
 import Foundation
 

--- a/lldb/test/Shell/SwiftREPL/ComputedProperties.test
+++ b/lldb/test/Shell/SwiftREPL/ComputedProperties.test
@@ -12,7 +12,7 @@ var x : Int {
   }
 }
 
-// CHECK: Welcome to {{.*}}Swift
+// CHECK: You are now in an interactive environment
 // CHECK: Type :help
 // CHECK: {{x}}: Int
 

--- a/lldb/test/Shell/SwiftREPL/UninitVariables.test
+++ b/lldb/test/Shell/SwiftREPL/UninitVariables.test
@@ -4,7 +4,7 @@
 // RUN: %lldb --repl < %s | FileCheck %s
 
 var x : Int
-// CHECK: Welcome to {{.*}}Swift
+// CHECK: You are now in an interactive environment
 // CHECK: Type :help
 // CHECK: {{x}}: Int = 0
 x = 42


### PR DESCRIPTION
> Note: This PR is for a pitch discussion and building a test toolchain. Do not merge – thanks!

Print a "starting up" message as it might take a long time for
everything to load, especially with cold module caches.

Clarify that :help is for help with debugger commands, not the
Swift language.

Tell people how to exit in case they don't know the EOF escape.

Remove the version print as that will be now be handled with
the `swift` command.

See https://forums.swift.org/t/command-line-ux-enhancements-for-swift/50670 for more context.