### PR TITLE
[lldb] Force live memory from LLDBMemoryReader

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -413,8 +413,15 @@ public:
     Target &target(m_process.GetTarget());
     Address addr(address.getAddressData());
     Status error;
-    if (size > target.ReadMemory(addr, dest, size, error)) {
-      LLDB_LOGV(log, "[MemoryReader] memory read returned fewer bytes than asked for");
+
+    // We disable reads from the file-cache since if the image we're reading
+    // from is part of the shared cache, offsets we read from the file-cache may
+    // be wrong.
+    if (size > target.ReadMemory(addr, dest, size, error,
+                                 true /* force_live_memory */)) {
+      LLDB_LOGV(
+          log,
+          "[MemoryReader] memory read returned fewer bytes than asked for");
       return false;
     }
     if (error.Fail()) {


### PR DESCRIPTION
This is a temporary, safe solution for a bug caused by a bad
interaction between the filecache optimization and the shared
cache, which causes offsets read from the filecache to be
potentially wrong.

This patch is safe, as it causes all memory reads to come from the inferior, which always has the correct memory.