### PR TITLE
[Compiler-rt] Fix running ASan/TSan unit tests under macOS 12.0.

### DIFF
--- a/compiler-rt/unittests/lit.common.unit.cfg.py
+++ b/compiler-rt/unittests/lit.common.unit.cfg.py
@@ -46,6 +46,10 @@ if config.host_os == 'Darwin':
   # 64-bit Darwin. Using more scales badly and hogs the system due to
   # inefficient handling of large mmap'd regions (terabytes) by the kernel.
   lit_config.parallelism_groups["shadow-memory"] = 3
+  # Disable libmalloc nanoallocator due to crashes running on macOS 12.0.
+  #
+  # rdar://80086125
+  config.environment['MallocNanoZone'] = '0'
 
   # The test config gets pickled and sent to multiprocessing workers, and that
   # only works for code if it is stored at the top level of some module.


### PR DESCRIPTION
On macOS the unit tests currently rely on libmalloc being used for
allocations (due to no functioning interceptors) but also having the
ASan/TSan allocator initialized in the same process.

This leads to crashes with the macOS 12.0 libmalloc nano allocator so
disable use of the allocator while running unit tests as a workaround.

rdar://80086125

Differential Revision: https://reviews.llvm.org/D107412

(cherry picked from commit b4121b335c48979716520f36445e6b01bef523cf)