### PR TITLE
[lldb] Only warn about 'auto' types in the log instead of stderr

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -1157,10 +1157,20 @@ CompilerType TypeSystemClang::GetBuiltinTypeForDWARFEncodingAndBitSize(
   // to fix any issues we run into.
   if (!type_name.empty()) {
     std::string type_name_str = type_name.str();
-    Host::SystemLog(Host::eSystemLogError,
-                    "error: need to add support for DW_TAG_base_type '%s' "
-                    "encoded with DW_ATE = 0x%x, bit_size = %u\n",
-                    type_name_str.c_str(), dw_ate, bit_size);
+    // GCC and newer Clang versions emit 'auto' types. This isn't supported yet,
+    // but we should also not spam the stderr with warnings, so instead log
+    // these special types. See rdar://71352569
+    if (type_name_str == "auto") {
+      Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
+      LLDB_LOGF(log, "error: need to add support for DW_TAG_base_type '%s' "
+               "encoded with DW_ATE = 0x%x, bit_size = %u\n",
+               type_name_str.c_str(), dw_ate, bit_size);
+    } else {
+      Host::SystemLog(Host::eSystemLogError,
+                      "error: need to add support for DW_TAG_base_type '%s' "
+                      "encoded with DW_ATE = 0x%x, bit_size = %u\n",
+                      type_name_str.c_str(), dw_ate, bit_size);
+    }
   } else {
     Host::SystemLog(Host::eSystemLogError, "error: need to add support for "
                                            "DW_TAG_base_type encoded with "

--- a/lldb/test/Shell/Expr/Inputs/auto.cpp
+++ b/lldb/test/Shell/Expr/Inputs/auto.cpp
@@ -1,0 +1,12 @@
+struct Foo {
+  auto i();
+};
+
+auto Foo::i() {
+  return 1;
+}
+
+int main() {
+  Foo f;
+  f.i();
+}

--- a/lldb/test/Shell/Expr/TestAutoErr.test
+++ b/lldb/test/Shell/Expr/TestAutoErr.test
@@ -1,0 +1,14 @@
+# RUN: %clangxx_host %p/Inputs/auto.cpp -std=c++14 -g -o %t
+
+# Test for emitted 'auto' types: rdar://71352569
+
+# The warning shouldn't appear in the stderr output.
+# RUN: %lldb -o "expr Foo f"  %t -b 2>&1 | FileCheck --check-prefix=NO_OUT %s
+# But the warning should be in the log.
+# We add the log enable command here as an argument as the channel names
+# matches the word 'LLDB' and our sanity check substitution will kick in and
+# warn us about using the word 'LLDB' instead of '%lldb" in a run invocation.
+# RUN: %lldb -s %p/enable_log -o "expr Foo f" %t -b | FileCheck %s
+
+# CHECK: error: need to add support for DW_TAG_base_type 'auto'
+# NO_OUT-NOT: error: need to add support for DW_TAG_base_type 'auto'

--- a/lldb/test/Shell/Expr/enable_log
+++ b/lldb/test/Shell/Expr/enable_log
@@ -1,0 +1,1 @@
+log enable lldb types


### PR DESCRIPTION
Stop-gap fix that hides the 'auto' warnings that Clang emits. This commit
should *not* be cherry-picked to any newer branches.

See rdar://71352569

(cherry picked from commit 5c676ba8323df648e3713bedc45479061b3b0355)

Note: Wasn't intended to be cherry-picked, but stop-gap is still needed.