### PR TITLE
Support async function calls in the expression evaluator and REPL.

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1738,7 +1738,7 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   }
 
   runSILDiagnosticPasses(*sil_module);
-  runSILOwnershipEliminatorPass(*sil_module);
+  runSILLoweringPasses(*sil_module);
 
   if (log) {
     std::string s;

--- a/lldb/test/API/lang/swift/playgrounds/Concurrency.swift
+++ b/lldb/test/API/lang/swift/playgrounds/Concurrency.swift
@@ -1,0 +1,23 @@
+import _Concurrency
+import Darwin
+// Test that the pass pipeline is set up to support concurrency.
+var i: Int = 0
+
+if #available(macOS 12, iOS 15, watchOS 8, tvOS 15, *) {
+
+  actor Actor {
+    func f() -> Int { return 42 }
+  }
+
+  let queue = Actor()
+  async {
+    i = await queue.f()
+  }
+
+} else {
+  // Still make the test pass if we don't have concurrency.
+  i = 42
+}
+
+while (i == 0) { sleep(1) }
+i - 19

--- a/lldb/test/API/lang/swift/playgrounds/TestPlaygrounds.py
+++ b/lldb/test/API/lang/swift/playgrounds/TestPlaygrounds.py
@@ -68,6 +68,7 @@ class TestSwiftPlaygrounds(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(debug_info=decorators.no_match("dsym"))
     def test_cross_module_extension(self):
         """Test that playgrounds work"""
@@ -123,9 +124,7 @@ class TestSwiftPlaygrounds(TestBase):
         options.SetPlaygroundTransformEnabled()
 
         self.frame().EvaluateExpression(contents, options)
-
         ret = self.frame().EvaluateExpression("get_output()")
-
         playground_output = ret.GetSummary()
         if not force_target:
             # This is expected to fail because the deployment target
@@ -139,3 +138,13 @@ class TestSwiftPlaygrounds(TestBase):
         self.assertTrue("b=\\'5\\'" in playground_output)
         self.assertTrue("=\\'8\\'" in playground_output)
         self.assertTrue("=\\'11\\'" in playground_output)
+
+        # Test concurrency
+        contents = "error"
+        with open('Concurrency.swift', 'r') as contents_file:
+            contents = contents_file.read()
+        res = self.frame().EvaluateExpression(contents, options)
+        ret = self.frame().EvaluateExpression("get_output()")
+        playground_output = ret.GetSummary()
+        self.assertTrue(playground_output is not None)
+        self.assertTrue("=\\'23\\'" in playground_output)


### PR DESCRIPTION
Async function calls require a new SIL pass (LowerHopToActor) that
wasn't previously part of ther expression evaluator's pass
pipeline. To avoid such a problem in the future, this patch replaces
LLDB's ad-hoc SIL lowering pipeline with the "official" SIL lowering
pass pipeline which currently consists of

  LowerHopToActor (New!)
  OwnershipModelEliminator (Previously also manually scheduled by LLDB)
  IRGenPrepare (New, removes poundAssert, staticReport, and lowers condFailMessage)
  AddressLowering (New, for SIL opaque values, currently no effect since not enabled)

rdar://79408099
(cherry picked from commit 1fa5bf9a45786e5aa66b5145b5e0723a6ccfb976)