### PR TITLE
[Compiler-RT] On Apple Platforms switch to always emitting full debug info

### DIFF
--- a/compiler-rt/CMakeLists.txt
+++ b/compiler-rt/CMakeLists.txt
@@ -413,6 +413,13 @@ if(MSVC)
     string(REGEX REPLACE "(^| )/Z[i7I]($| )" " /Z7 "
            "${var_to_update}" "${${var_to_update}}")
   endforeach()
+elseif(APPLE)
+  # On Apple platforms use full debug info (i.e. not `-gline-tables-only`)
+  # for all build types so that the runtime can be debugged.
+  if(NOT COMPILER_RT_HAS_G_FLAG)
+    message(FATAL_ERROR "-g is not supported by host compiler")
+  endif()
+  list(APPEND SANITIZER_COMMON_CFLAGS -g)
 elseif(COMPILER_RT_HAS_GLINE_TABLES_ONLY_FLAG AND NOT COMPILER_RT_DEBUG)
   list(APPEND SANITIZER_COMMON_CFLAGS -gline-tables-only)
 elseif(COMPILER_RT_HAS_G_FLAG)


### PR DESCRIPTION
Previously the build used `-gline-tables-only` when `COMPILER_RT_DEBUG`
was off (default) and `-g` when `COMPILER_RT_DEBUG` was on. The end
result of this meant that the release build of the Sanitizer runtimes
were difficult to debug (e.g. information about variables and function
arguments were missing).

Presumably the reason for preferring `-gline-tables-only` for release
builds was to save space. However, for Apple platforms this doesn't
matter because debug info lives in separate `.dSYM` files (which aren't
shipped) rather than in the shipped `.dylib` files.

Now on Apple platforms we always emit full debug info if the compiler
supports it and we emit a fatal error if `-g` isn't supported.

rdar://79223184

Differential Revision: https://reviews.llvm.org/D107501

(cherry picked from commit fb0a929512c25bd9859498cde7d1c6c73f550d61)