### PR TITLE
[20210726][CMake] Add the new clang features file to the distribution

### DIFF
--- a/clang/cmake/caches/Apple-stage2.cmake
+++ b/clang/cmake/caches/Apple-stage2.cmake
@@ -76,6 +76,7 @@ set(LLVM_DISTRIBUTION_COMPONENTS
   clang-resource-headers
   cxx-headers
   Remarks
+  clang-features-file
   ${LLVM_TOOLCHAIN_TOOLS}
   ${LLVM_TOOLCHAIN_UTILITIES}
   CACHE STRING "")


### PR DESCRIPTION
Cherry-pick https://github.com/apple/llvm-project/pull/3150

-----

clang-features-file was added to the install but not the distribution.
It's intended to communicate to build systems that a new feature and
associated flags are available, so should be added to the distribution.

Resolves rdar://72387110