### PR TITLE
Reland "[lldb/DWARF] Only match mangled name in full-name function lo…

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.cpp
@@ -41,7 +41,7 @@ bool DWARFIndex::ProcessFunctionDIE(
     return true;
 
   // In case of a full match, we just insert everything we find.
-  if (name_type_mask & eFunctionNameTypeFull)
+  if (name_type_mask & eFunctionNameTypeFull && die.GetMangledName() == name)
     return callback(die);
 
   // If looking for ObjC selectors, we need to also check if the name is a

--- a/lldb/test/API/lang/cpp/printf/TestPrintf.py
+++ b/lldb/test/API/lang/cpp/printf/TestPrintf.py
@@ -5,4 +5,4 @@ lldbinline.MakeInlineTest(
     __file__, globals(), [
         decorators.expectedFailureAll(
             bugnumber="llvm.org/PR36715",
-            oslist=lldbplatformutil.getDarwinOSTriples()+['windows'])])
+            oslist=['windows'])])

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/find-basic-function.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/find-basic-function.cpp
@@ -10,6 +10,10 @@
 // RUN:   FileCheck --check-prefix=FULL %s
 // RUN: lldb-test symbols --name=_Z3fooi --find=function --function-flags=full %t | \
 // RUN:   FileCheck --check-prefix=FULL-MANGLED %s
+// RUN: lldb-test symbols --name=_ZN3bar3baz3fooEv --find=function --function-flags=full %t | \
+// RUN:   FileCheck --check-prefix=FULL-MANGLED-NAMESPACE %s
+// RUN: lldb-test symbols --name=_ZN4sbar3fooEi --find=function --function-flags=full %t | \
+// RUN:   FileCheck --check-prefix=FULL-MANGLED-METHOD %s
 // RUN: lldb-test symbols --name=foo --context=context --find=function --function-flags=base %t | \
 // RUN:   FileCheck --check-prefix=CONTEXT %s
 // RUN: lldb-test symbols --name=not_there --find=function %t | \
@@ -21,9 +25,13 @@
 // RUN: lldb-test symbols --name=foo --find=function --function-flags=method %t | \
 // RUN:   FileCheck --check-prefix=METHOD %s
 // RUN: lldb-test symbols --name=foo --find=function --function-flags=full %t | \
-// RUN:   FileCheck --check-prefix=FULL-INDEXED %s
+// RUN:   FileCheck --check-prefix=FULL %s
 // RUN: lldb-test symbols --name=_Z3fooi --find=function --function-flags=full %t | \
 // RUN:   FileCheck --check-prefix=FULL-MANGLED %s
+// RUN: lldb-test symbols --name=_ZN3bar3baz3fooEv --find=function --function-flags=full %t | \
+// RUN:   FileCheck --check-prefix=FULL-MANGLED-NAMESPACE %s
+// RUN: lldb-test symbols --name=_ZN4sbar3fooEi --find=function --function-flags=full %t | \
+// RUN:   FileCheck --check-prefix=FULL-MANGLED-METHOD %s
 // RUN: lldb-test symbols --name=foo --context=context --find=function --function-flags=base %t | \
 // RUN:   FileCheck --check-prefix=CONTEXT %s
 // RUN: lldb-test symbols --name=not_there --find=function %t | \
@@ -37,9 +45,13 @@
 // RUN: lldb-test symbols --name=foo --find=function --function-flags=method %t | \
 // RUN:   FileCheck --check-prefix=METHOD %s
 // RUN: lldb-test symbols --name=foo --find=function --function-flags=full %t | \
-// RUN:   FileCheck --check-prefix=FULL-INDEXED %s
+// RUN:   FileCheck --check-prefix=FULL %s
 // RUN: lldb-test symbols --name=_Z3fooi --find=function --function-flags=full %t | \
 // RUN:   FileCheck --check-prefix=FULL-MANGLED %s
+// RUN: lldb-test symbols --name=_ZN3bar3baz3fooEv --find=function --function-flags=full %t | \
+// RUN:   FileCheck --check-prefix=FULL-MANGLED-NAMESPACE %s
+// RUN: lldb-test symbols --name=_ZN4sbar3fooEi --find=function --function-flags=full %t | \
+// RUN:   FileCheck --check-prefix=FULL-MANGLED-METHOD %s
 // RUN: lldb-test symbols --name=foo --context=context --find=function --function-flags=base %t | \
 // RUN:   FileCheck --check-prefix=CONTEXT %s
 // RUN: lldb-test symbols --name=not_there --find=function %t | \
@@ -58,19 +70,16 @@
 // METHOD-DAG: name = "sbar::foo(int)", mangled = "_ZN4sbar3fooEi"
 // METHOD-DAG: name = "ffbar()::sbaz::foo()", mangled = "_ZZ5ffbarvEN4sbaz3fooEv"
 
-// FULL-INDEXED: Found 7 functions:
-// FULL-INDEXED-DAG: name = "foo()", mangled = "_Z3foov"
-// FULL-INDEXED-DAG: name = "foo(int)", mangled = "_Z3fooi"
-// FULL-INDEXED-DAG: name = "bar::foo()", mangled = "_ZN3bar3fooEv"
-// FULL-INDEXED-DAG: name = "bar::baz::foo()", mangled = "_ZN3bar3baz3fooEv"
-// FULL-INDEXED-DAG: name = "sbar::foo()", mangled = "_ZN4sbar3fooEv"
-// FULL-INDEXED-DAG: name = "sbar::foo(int)", mangled = "_ZN4sbar3fooEi"
-// FULL-INDEXED-DAG: name = "ffbar()::sbaz::foo()", mangled = "_ZZ5ffbarvEN4sbaz3fooEv"
-
 // FULL: Found 0 functions:
 
 // FULL-MANGLED: Found 1 functions:
 // FULL-MANGLED-DAG: name = "foo(int)", mangled = "_Z3fooi"
+
+// FULL-MANGLED-NAMESPACE: Found 1 functions:
+// FULL-MANGLED-NAMESPACE-DAG: name = "bar::baz::foo()", mangled = "_ZN3bar3baz3fooEv"
+
+// FULL-MANGLED-METHOD: Found 1 functions:
+// FULL-MANGLED-METHOD-DAG: name = "sbar::foo(int)", mangled = "_ZN4sbar3fooEi"
 
 // CONTEXT: Found 1 functions:
 // CONTEXT-DAG: name = "bar::foo()", mangled = "_ZN3bar3fooEv"


### PR DESCRIPTION
…okup (with accelerators)"

Summary:

In the spirit of https://reviews.llvm.org/D70846, we only return functions with
matching mangled name from Apple/DebugNamesDWARFIndex::GetFunction if
eFunctionNameTypeFull is requested.

This speeds up lookup in the presence of large amount of class methods of the
same name (a typical examples would be constructors of templates with many
instantiations or overloaded operators).

Reviewers: labath, teemperor

Reviewed By: labath, teemperor

Subscribers: aprantl, arphaman, lldb-commits

Tags: #lldb

Differential Revision: https://reviews.llvm.org/D73191

(cherry picked from commit f968bd77bbcf142afdb74750e53485b044de3e5f)