### PR TITLE
Make lldb build

### DIFF
--- a/lldb/include/lldb/Core/JITSection.h
+++ b/lldb/include/lldb/Core/JITSection.h
@@ -42,7 +42,7 @@ public:
 
   // LLVM RTTI support
   static char ID;
-  virtual bool isA(const void *ClassID) const {
+  bool isA(const void *ClassID) const override {
     return ClassID == &ID || Section::isA(ClassID);
   }
   static bool classof(const Section *obj) { return obj->isA(&ID); }

--- a/lldb/include/lldb/Target/ThreadPlanStack.h
+++ b/lldb/include/lldb/Target/ThreadPlanStack.h
@@ -95,7 +95,9 @@ public:
   /// generated.
   void ClearThreadCache();
 
-  bool IsTID(lldb::tid_t tid);
+  bool IsTID(lldb::tid_t tid) {
+    return GetTID() == tid;
+  }
   lldb::tid_t GetTID();
   void SetTID(lldb::tid_t tid);
 
@@ -115,6 +117,9 @@ private:
                                           // completed plan checkpoints.
   std::unordered_map<size_t, PlanStack> m_completed_plan_store;
   mutable std::recursive_mutex m_stack_mutex;
+  
+  // ThreadPlanStacks shouldn't be copied.
+  ThreadPlanStack(ThreadPlanStack &rhs) = delete;
 };
 
 class ThreadPlanStackMap {
@@ -128,15 +133,34 @@ public:
 
   void AddThread(Thread &thread) {
     lldb::tid_t tid = thread.GetID();
-    m_plans_list.emplace(tid, thread);
+    std::shared_ptr<ThreadPlanStack> new_elem_sp(new ThreadPlanStack(thread));
+    m_plans_sp_container.push_back(new_elem_sp);
+    m_plans_list.emplace(tid, new_elem_sp.get());
   }
 
   bool RemoveTID(lldb::tid_t tid) {
     auto result = m_plans_list.find(tid);
     if (result == m_plans_list.end())
       return false;
-    result->second.ThreadDestroyed(nullptr);
+    ThreadPlanStack *removed_stack = result->second;
     m_plans_list.erase(result);
+    // Also remove this from the stack storage:
+    PlansStore::iterator end 
+        = m_plans_sp_container.end();
+    PlansStore::iterator iter; 
+    for (iter = m_plans_sp_container.begin();
+         iter != end; iter++) {
+      if ((*iter)->IsTID(tid)) {
+        break;
+      } 
+    }
+    if (iter == end)
+      return false;
+
+    // Finally, tell the stack its thread has been destroyed:
+    removed_stack->ThreadDestroyed(nullptr);
+    // And THEN remove it from the container so it goes away.
+    m_plans_sp_container.erase(iter);
     return true;
   }
 
@@ -145,7 +169,7 @@ public:
     if (result == m_plans_list.end())
       return nullptr;
     else
-      return &result->second;
+      return result->second;
   }
 
   /// Clear the Thread* cache that each ThreadPlan contains.
@@ -154,38 +178,49 @@ public:
   /// generated.
   void ClearThreadCache() {
     for (auto &plan_list : m_plans_list)
-      plan_list.second.ClearThreadCache();
+      plan_list.second->ClearThreadCache();
   }
 
   // rename to Reactivate?
-  void Activate(ThreadPlanStack &&stack) {
+  void Activate(ThreadPlanStack &stack) {
+    // Remove this from the detached plan list:
+    std::vector<ThreadPlanStack *>::iterator end = m_detached_plans.end();    
+    
+    for (std::vector<ThreadPlanStack *>::iterator iter 
+             = m_detached_plans.begin(); iter != end; iter++) {
+      if (*iter == &stack) {
+        m_detached_plans.erase(iter);
+        break;
+      }
+    }
+    
     if (m_plans_list.find(stack.GetTID()) == m_plans_list.end())
-      m_plans_list.emplace(stack.GetTID(), std::move(stack));
+      m_plans_list.emplace(stack.GetTID(), &stack);
     else
-      m_plans_list.at(stack.GetTID()) = std::move(stack);
+      m_plans_list.at(stack.GetTID()) = &stack;
   }
 
-  // rename to ...?
-  std::vector<ThreadPlanStack> CleanUp() {
+  void ScanForDetachedPlanStacks() {
     llvm::SmallVector<lldb::tid_t, 2> invalidated_tids;
     for (auto &pair : m_plans_list)
-      if (pair.second.GetTID() != pair.first)
+      if (pair.second->GetTID() != pair.first)
         invalidated_tids.push_back(pair.first);
 
-    std::vector<ThreadPlanStack> detached_stacks;
-    detached_stacks.reserve(invalidated_tids.size());
     for (auto tid : invalidated_tids) {
       auto it = m_plans_list.find(tid);
-      auto stack = std::move(it->second);
+      ThreadPlanStack *stack = it->second;
       m_plans_list.erase(it);
-      detached_stacks.emplace_back(std::move(stack));
+      m_detached_plans.push_back(stack);
     }
-    return detached_stacks;
   }
 
+  std::vector<ThreadPlanStack *> &GetDetachedPlanStacks() {
+    return m_detached_plans;
+  }
+  
   void Clear() {
     for (auto &plan : m_plans_list)
-      plan.second.ThreadDestroyed(nullptr);
+      plan.second->ThreadDestroyed(nullptr);
     m_plans_list.clear();
   }
 
@@ -202,7 +237,23 @@ public:
 
 private:
   Process &m_process;
-  using PlansList = std::unordered_map<lldb::tid_t, ThreadPlanStack>;
+  // We don't want to make copies of these ThreadPlanStacks, there needs to be
+  // just one of these tracking each piece of work.  But we need to move the
+  // work from "attached to a TID" state to "detached" state, which is most
+  // conveniently done by having separate containers for the two states.
+  // To do that w/o having to spend effort fighting with C++'s desire to invoke
+  // copy constructors, we keep a store for the real object, and then keep
+  // pointers to the objects in the two containers.  The store actually holds
+  // shared_ptrs to the objects, so that the pointers in the containers will stay
+  // valid.
+  
+  // Use a shared pointer rather than unique_ptr here to prevent C++ from trying
+  // to use a copy constructor on the stored type.
+  using PlansStore = std::vector<std::shared_ptr<ThreadPlanStack>>;
+  PlansStore m_plans_sp_container;
+  std::vector<ThreadPlanStack *> m_detached_plans;
+  
+  using PlansList = std::unordered_map<lldb::tid_t, ThreadPlanStack *>;
   PlansList m_plans_list;
 };
 

--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -77,9 +77,7 @@ static ConstString GetDemangledNameWithoutArguments(ConstString mangled,
       if (SwiftLanguageRuntime::MethodName::ExtractFunctionBasenameFromMangled(
               mangled, basename, is_method)) {
         if (basename && basename != mangled) {
-          g_most_recent_mangled_to_name_sans_args.first = mangled;
-          g_most_recent_mangled_to_name_sans_args.second = basename;
-          return (g_most_recent_mangled_to_name_sans_args.second);
+          return basename;
         }
       }
     }

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -313,8 +313,13 @@ CompilerType ValueObject::MaybeCalculateCompleteType() {
 
   // try the modules
   if (TargetSP target_sp = GetTargetSP()) {
+    auto *persistent_state = llvm::cast<ClangPersistentVariables>(
+      target_sp->GetPersistentExpressionStateForLanguage(lldb::eLanguageTypeC));
+    if (!persistent_state)
+      return compiler_type;
+
     if (auto clang_modules_decl_vendor =
-            target_sp->GetClangModulesDeclVendor()) {
+            persistent_state->GetClangModulesDeclVendor()) {
       ConstString key_cs(class_name);
       auto types = clang_modules_decl_vendor->FindTypes(
           key_cs, /*max_matches*/ UINT32_MAX);

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -123,9 +123,9 @@ bool SwiftLanguage::IsTopLevelFunction(Function &function) {
   return false;
 }
 
-std::vector<ConstString>
+std::vector<Language::MethodNameVariant>
 SwiftLanguage::GetMethodNameVariants(ConstString method_name) const {
-  std::vector<ConstString> variant_names;
+  std::vector<Language::MethodNameVariant> variant_names;
 
   // NOTE:  We need to do this because we don't have a proper parser for Swift
   // function name syntax so we try to ensure that if we autocomplete to
@@ -135,7 +135,7 @@ SwiftLanguage::GetMethodNameVariants(ConstString method_name) const {
   ConstString counterpart;
   if (method_name.GetMangledCounterpart(counterpart))
     if (SwiftLanguageRuntime::IsSwiftMangledName(counterpart.GetStringRef()))
-      variant_names.emplace_back(counterpart);
+      variant_names.emplace_back(counterpart, eFunctionNameTypeFull);
   return variant_names;
 }
 

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.h
@@ -34,10 +34,10 @@ public:
 
   bool IsTopLevelFunction(Function &function) override;
 
-  std::vector<ConstString>
+  std::vector<Language::MethodNameVariant>
   GetMethodNameVariants(ConstString method_name) const override;
 
-  virtual lldb::TypeCategoryImplSP GetFormatters() override;
+  lldb::TypeCategoryImplSP GetFormatters() override;
 
   HardcodedFormatters::HardcodedSummaryFinder GetHardcodedSummaries() override;
 

--- a/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
@@ -205,7 +205,9 @@ bool lldb_private::formatters::swift::SwiftOptionSetSummaryProvider::
   if (matched_value != value) {
     // Print the unaccounted-for bits separately.
     llvm::APInt residual = value & ~matched_value;
-    ss << ", 0x" << residual.toString(16, false);
+    llvm::SmallString<24> string;
+    residual.toString(string, 16, false);
+    ss << ", 0x" << string;
   }
   ss << ']';
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -982,7 +982,7 @@ void SwiftLanguageRuntime::FindFunctionPointersInCall(
                 CompilerType clang_void_ptr_type =
                     clang_ctx->GetBasicType(eBasicTypeVoid).GetPointerType();
 
-                input_value.SetValueType(Value::eValueTypeScalar);
+                input_value.SetValueType(Value::ValueType::Scalar);
                 input_value.SetCompilerType(clang_void_ptr_type);
                 argument_values.PushValue(input_value);
 
@@ -1692,8 +1692,8 @@ llvm::Optional<Value> SwiftLanguageRuntime::GetErrorReturnLocationAfterReturn(
 
   Value val;
   if (reg_value.GetScalarValue(val.GetScalar())) {
-    val.SetValueType(Value::eValueTypeScalar);
-    val.SetContext(Value::eContextTypeRegisterInfo,
+    val.SetValueType(Value::ValueType::Scalar);
+    val.SetContext(Value::ContextType::RegisterInfo,
                    const_cast<RegisterInfo *>(reg_info));
     error_val = val;
   }

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1866,7 +1866,7 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Protocol(
 
   if (in_value.GetValueType() == eValueTypeConstResult &&
       in_value.GetValue().GetValueType() ==
-          lldb_private::Value::eValueTypeHostAddress) {
+          lldb_private::Value::ValueType::HostAddress) {
     if (log)
       log->Printf("existential value is a const result");
 
@@ -2431,7 +2431,7 @@ Value::ValueType SwiftLanguageRuntimeImpl::GetValueType(
         return {};
       if (swift_ast_ctx->IsErrorType(static_type.GetOpaqueQualType())) {
         // ErrorType values are always a pointer
-        return Value::eValueTypeLoadAddress;
+        return Value::ValueType::LoadAddress;
       }
 
       if (auto *ts = llvm::dyn_cast_or_null<TypeSystemSwift>(
@@ -2446,7 +2446,7 @@ Value::ValueType SwiftLanguageRuntimeImpl::GetValueType(
           return static_value_type;
         case SwiftASTContext::TypeAllocationStrategy::ePointer: // pointed-to;
                                                                 // in the target
-          return Value::eValueTypeLoadAddress;
+          return Value::ValueType::LoadAddress;
         }
     }
     if (static_type_flags.AllSet(eTypeIsSwift | eTypeIsGenericTypeParam)) {
@@ -2458,14 +2458,14 @@ Value::ValueType SwiftLanguageRuntimeImpl::GetValueType(
       // ObjC classes
       if (dynamic_type_flags.AllClear(eTypeIsPointer | eTypeIsReference |
                                       eTypeInstanceIsPointer))
-        return Value::eValueTypeLoadAddress;
+        return Value::ValueType::LoadAddress;
     }
 
     if (static_type_flags.AllSet(eTypeIsSwift | eTypeIsPointer) &&
         static_type_flags.AllClear(eTypeIsGenericTypeParam)) {
       // FIXME: This branch is not covered by any testcases in the test suite.
       if (is_indirect_enum_case || static_type_flags.AllClear(eTypeIsBuiltIn))
-        return Value::eValueTypeLoadAddress;
+        return Value::ValueType::LoadAddress;
     }
   }
 
@@ -2476,7 +2476,7 @@ Value::ValueType SwiftLanguageRuntimeImpl::GetValueType(
       dynamic_type_flags.AllClear(eTypeIsPointer | eTypeInstanceIsPointer))
     return static_value_type;
   else
-    return Value::eValueTypeScalar;
+    return Value::ValueType::Scalar;
 }
 
 bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_ClangType(

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6945,6 +6945,7 @@ llvm::StringRef ObjectFileMachO::GetReflectionSectionIdentifier(
 #else
   llvm_unreachable("Swift support disabled");
 #endif //LLDB_ENABLE_SWIFT
+}
 
 ObjectFileMachO::MachOCorefileAllImageInfos
 ObjectFileMachO::GetCorefileAllImageInfos() {

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -51,7 +51,9 @@ static llvm::StringRef GetTypedefName(const DWARFDIE &die) {
   DWARFDIE type_die = die.GetAttributeValueAsReferenceDIE(DW_AT_type);
   if (!type_die.IsValid())
     return {};
-  return llvm::StringRef::withNullAsEmpty(type_die.GetName());
+  if (!type_die.GetName())
+    return {};
+  return llvm::StringRef(type_die.GetName());
 }
 
 lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,

--- a/lldb/source/Symbol/Symtab.cpp
+++ b/lldb/source/Symbol/Symtab.cpp
@@ -339,9 +339,9 @@ void Symtab::InitNameIndexes() {
                                                        is_method)) {
               if (basename && basename != mangled_name) {
                 if (is_method)
-                  m_method_to_index.Append(basename, value);
+                  method_to_index.Append(basename, value);
                 else
-                  m_basename_to_index.Append(basename, value);
+                  basename_to_index.Append(basename, value);
               }
             }
           }

--- a/lldb/source/Target/ThreadPlanStack.cpp
+++ b/lldb/source/Target/ThreadPlanStack.cpp
@@ -452,8 +452,8 @@ void ThreadPlanStackMap::DumpPlans(Stream &strm,
       index_id = thread_sp->GetIndexID();
 
     if (condense_if_trivial) {
-      if (!elem.second.AnyPlans() && !elem.second.AnyCompletedPlans() &&
-          !elem.second.AnyDiscardedPlans()) {
+      if (!elem.second->AnyPlans() && !elem.second->AnyCompletedPlans() &&
+          !elem.second->AnyDiscardedPlans()) {
         strm.Printf("thread #%u: tid = 0x%4.4" PRIx64 "\n", index_id, tid);
         strm.IndentMore();
         strm.Indent();
@@ -466,7 +466,7 @@ void ThreadPlanStackMap::DumpPlans(Stream &strm,
     strm.Indent();
     strm.Printf("thread #%u: tid = 0x%4.4" PRIx64 ":\n", index_id, tid);
 
-    elem.second.DumpThreadPlans(strm, desc_level, internal);
+    elem.second->DumpThreadPlans(strm, desc_level, internal);
   }
 }
 

--- a/lldb/source/Target/ThreadPlanStepInRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepInRange.cpp
@@ -351,7 +351,7 @@ bool ThreadPlanStepInRange::StepInDeepBreakpointExplainsStop(
       for (size_t i = 0; i < num_owners; i++) {
         BreakpointLocationSP owner_loc_sp(bp_site_sp->GetOwnerAtIndex(i));
         Breakpoint &owner_bp(owner_loc_sp->GetBreakpoint());
-        if (owner_loc_sp->ValidForThisThread(&GetThread()) &&
+        if (owner_loc_sp->ValidForThisThread(GetThread()) &&
             !owner_bp.IsInternal()) {
           explains_stop = false;
           break;


### PR DESCRIPTION
The lldb build on this branch is currently broken.

This is a pair of patches that fix that.

The first patch deals conflicts between the way ThreadPlanStack's were held in ThreadPlanStackMaps and the way we were moving stacks around to support swift async stepping.  This is a preliminary version of this patch, it needs to be refactored and half go to llvm.org and half is swift specific.  But that might take a bit (the patch is poorly motivated in the llvm.org sources), and without the patch we don't build, so...  I also know this patch works, as I applied it to the release/5.5 branch and the test suite ran cleanly.

The second patch is a grab bag of little fixes for things that had changed on the llvm.org side & needed updating in the swift support.

With these two patches, lldb builds, but it doesn't run the tests successfully.  We're getting some reproducer error at startup.

