### PR TITLE
rdar://81632946 [libclang][deps] Accept only driver invocations, don't modify them

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -30,6 +30,24 @@ namespace dependencies {
 
 class DependencyScanningWorkerFilesystem;
 
+/// Compilation database that holds and reports a single compile command.
+class SingleCommandCompilationDatabase : public CompilationDatabase {
+  CompileCommand Command;
+
+public:
+  SingleCommandCompilationDatabase(CompileCommand Cmd)
+      : Command(std::move(Cmd)) {}
+
+  std::vector<CompileCommand>
+  getCompileCommands(StringRef FilePath) const override {
+    return {Command};
+  }
+
+  std::vector<CompileCommand> getAllCompileCommands() const override {
+    return {Command};
+  }
+};
+
 class DependencyConsumer {
 public:
   virtual ~DependencyConsumer() {}

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -85,6 +85,11 @@ public:
                                   const CompilationDatabase &CDB,
                                   DependencyConsumer &Consumer);
 
+  /// Run the dependency scanning tool for a given clang driver invocation, and
+  /// report the discovered dependencies to the provided consumer.
+  ///
+  /// \returns A \c StringError with the diagnostic output if clang errors
+  /// occurred, success otherwise.
   llvm::Error
   computeDependenciesForClangInvocation(StringRef WorkingDirectory,
                                         ArrayRef<std::string> Arguments,

--- a/clang/test/Index/Core/scan-deps.m
+++ b/clang/test/Index/Core/scan-deps.m
@@ -1,10 +1,3 @@
-// RUN: rm -rf %t.mcp
-// RUN: echo %S > %t.result
-// RUN: c-index-test core --scan-deps %S -- %clang -cc1 -I %S/Inputs/module \
-// RUN:     -fmodules -fmodules-cache-path=%t.mcp -fimplicit-module-maps \
-// RUN:     -o FoE.o -x objective-c %s >> %t.result
-// RUN: cat %t.result | sed 's/\\/\//g' | FileCheck %s
-
 // Use driver arguments.
 // RUN: rm -rf %t.mcp
 // RUN: echo %S > %t.result

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -201,24 +201,6 @@ llvm::cl::opt<bool> Verbose("v", llvm::cl::Optional,
 
 } // end anonymous namespace
 
-class SingleCommandCompilationDatabase : public tooling::CompilationDatabase {
-public:
-  SingleCommandCompilationDatabase(tooling::CompileCommand Cmd)
-      : Command(std::move(Cmd)) {}
-
-  std::vector<tooling::CompileCommand>
-  getCompileCommands(StringRef FilePath) const override {
-    return {Command};
-  }
-
-  std::vector<tooling::CompileCommand> getAllCompileCommands() const override {
-    return {Command};
-  }
-
-private:
-  tooling::CompileCommand Command;
-};
-
 /// Takes the result of a dependency scan and prints error / dependency files
 /// based on the result.
 ///

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -221,23 +221,7 @@ getFileDependencies(CXDependencyScannerWorker W, int argc,
 
   DependencyScanningWorker *Worker = unwrap(W);
 
-  std::vector<std::string> Compilation;
-  if (StringRef(argv[1]) == "-cc1")
-    for (int i = 2; i < argc; ++i)
-      Compilation.push_back(argv[i]);
-  else {
-    // Run the driver to get -cc1 args.
-    ArrayRef<const char *> CArgs = llvm::makeArrayRef(argv, argv+argc);
-    IntrusiveRefCntPtr<DiagnosticsEngine>
-    Diags(CompilerInstance::createDiagnostics(new DiagnosticOptions));
-    auto CI = createInvocationFromCommandLine(CArgs, Diags, /*VFS=*/nullptr,
-      /*ShouldRecoverOnErrors=*/false, &Compilation);
-    if (!CI) {
-      if (error)
-        *error = cxstring::createRef("failed creating 'cc1' arguments");
-      return nullptr;
-    }
-  }
+  std::vector<std::string> Compilation{argv, argv + argc};
 
   if (Worker->getFormat() == ScanningOutputFormat::Full)
     return getFullDependencies(Worker, Compilation, WorkingDirectory, MDC,


### PR DESCRIPTION
The way libclang dependency scanner handles command-lines differs from what `clang-scan-deps` does.

The `clang-scan-deps` command-line tool only accepts driver arguments (from a compilation database), while libclang supports both driver and **cc1** command-lines. This PR removes the support for cc1 command-lines from libclang (the `getFileDependencies` function in `CDependencies.cpp`), unifying the API. There are no clients that rely on cc1 support. (Relying on cc1 invocations would be pretty dangerous in general, since it has breaking changes between releases.)

This change to `getFileDependencies` means `DependencyScanningWorker::computeDependenciesForClangInvocation` now receives driver command-line, making it possible to just forward to `DependencyScanningWorker::computeDependencies`.

There's a subtle aspect of this patch that solves rdar://81632946. The code that was used to convert the driver invocation to cc1 invocation in `getFileDependencies` injected the `-fsyntax-only` flag, which can override flags like `-emit-pch`. This means the information about PCH compilations didn't reach the dependency scanner library, breaking PCH support that was tested to work with `clang-scan-deps`.

The upstream cherry-pick will be removed once the commit makes it through the automerger.