### PR TITLE
Rework the ThreadPlanStackMap class so we can move ThreadPlanStacks

### DIFF
--- a/lldb/include/lldb/Target/ThreadPlanStack.h
+++ b/lldb/include/lldb/Target/ThreadPlanStack.h
@@ -149,8 +149,8 @@ public:
     ThreadPlanStack *removed_stack = result->second;
     m_plans_list.erase(result);
     // Now find it in the stack storage:
-    PlansStore::iterator end = m_plans_up_container.end();
-    PlansStore::iterator iter = std::find_if(m_plans_up_container.begin(), end,
+    auto end = m_plans_up_container.end();
+    auto iter = std::find_if(m_plans_up_container.begin(), end,
         [&] (std::unique_ptr<ThreadPlanStack> &stack) {
           return stack->IsTID(tid);
         });
@@ -184,9 +184,8 @@ public:
   // rename to Reactivate?
   void Activate(ThreadPlanStack &stack) {
     // Remove this from the detached plan list:
-    std::vector<ThreadPlanStack *>::iterator end = m_detached_plans.end();    
-    std::vector<ThreadPlanStack *>::iterator iter 
-        = std::find_if(m_detached_plans.begin(), end, 
+    auto end = m_detached_plans.end();    
+    auto iter = std::find_if(m_detached_plans.begin(), end, 
         [&] (ThreadPlanStack *elem) {
           return elem == &stack; });
     if (iter != end)
@@ -212,6 +211,11 @@ public:
     }
   }
 
+  // This gets the vector of pointers to thread plans that aren't
+  // currently running on a thread.  This is generally for thread
+  // plans that represent asynchronous operations waiting to be
+  // scheduled.
+  // The vector will never have null ThreadPlanStacks in it.
   std::vector<ThreadPlanStack *> &GetDetachedPlanStacks() {
     return m_detached_plans;
   }

--- a/lldb/source/Target/ThreadPlanStack.cpp
+++ b/lldb/source/Target/ThreadPlanStack.cpp
@@ -452,8 +452,8 @@ void ThreadPlanStackMap::DumpPlans(Stream &strm,
       index_id = thread_sp->GetIndexID();
 
     if (condense_if_trivial) {
-      if (!elem.second.AnyPlans() && !elem.second.AnyCompletedPlans() &&
-          !elem.second.AnyDiscardedPlans()) {
+      if (!elem.second->AnyPlans() && !elem.second->AnyCompletedPlans() &&
+          !elem.second->AnyDiscardedPlans()) {
         strm.Printf("thread #%u: tid = 0x%4.4" PRIx64 "\n", index_id, tid);
         strm.IndentMore();
         strm.Indent();
@@ -466,7 +466,7 @@ void ThreadPlanStackMap::DumpPlans(Stream &strm,
     strm.Indent();
     strm.Printf("thread #%u: tid = 0x%4.4" PRIx64 ":\n", index_id, tid);
 
-    elem.second.DumpThreadPlans(strm, desc_level, internal);
+    elem.second->DumpThreadPlans(strm, desc_level, internal);
   }
 }
 


### PR DESCRIPTION
Supporting swift async requires we move non-copyable ThreadPlanStacks from the TID->Plans map to the "Detached plan" vector.  That's easier to do if we keep the stacks in a central store, and use references in the organizing containers.

This version of the patch uses unique_ptr's - I was getting "no copy constructor" build failures with an earlier version that used UP's but this version is fine.

I wanted folks to get a change to look at this.  I also had "no copy constructor" failures when the "organizing containers" were ThreadPlanStack &'s rather than ThreadPlanStack *'s.  I'm going to try converting them back - since we never put nullptr elements into the organizing containers so that's more correct.  Otherwise I'll add a comment to the effect that these will never be null.

If that works, I'll update the patch with that fix, but I wanted to give folks a chance to look at the other changes.