### PR TITLE
[20210726][CMake] Rename install features file target

### DIFF
--- a/clang/tools/driver/CMakeLists.txt
+++ b/clang/tools/driver/CMakeLists.txt
@@ -138,7 +138,7 @@ install(FILES ${features_file_dest}
         DESTINATION "share/clang"
         COMPONENT clang)
 if(NOT LLVM_ENABLE_IDE)
-  add_llvm_install_targets("install-features-file"
+  add_llvm_install_targets("install-clang-features-file"
                            DEPENDS clang-features-file
                            COMPONENT clang)
 endif()

--- a/clang/tools/driver/CMakeLists.txt
+++ b/clang/tools/driver/CMakeLists.txt
@@ -136,9 +136,9 @@ add_custom_target(clang-features-file DEPENDS ${features_file_dest})
 add_dependencies(clang clang-features-file)
 install(FILES ${features_file_dest}
         DESTINATION "share/clang"
-        COMPONENT clang)
+        COMPONENT clang-features-file)
 if(NOT LLVM_ENABLE_IDE)
   add_llvm_install_targets("install-clang-features-file"
                            DEPENDS clang-features-file
-                           COMPONENT clang)
+                           COMPONENT clang-features-file)
 endif()


### PR DESCRIPTION
Cherry-picks https://github.com/apple/llvm-project/pull/3173

-----

llvm_distribution_add_targets expects the install target to have the
same name as the target to be distributed but prefixed with `install-`.
Rename `install-feature-file` to `install-clang-feature-file` to match
the distributed target name.