### PR TITLE
Update copy of code in UpdateValue from DoUpdateChildrenAddressType

### DIFF
--- a/lldb/source/Core/ValueObjectVariable.cpp
+++ b/lldb/source/Core/ValueObjectVariable.cpp
@@ -220,6 +220,8 @@ bool ValueObjectVariable::UpdateValue() {
           (type_info & (lldb::eTypeIsPointer | lldb::eTypeIsReference)) != 0;
 
       switch (value_type) {
+      case Value::ValueType::Invalid:
+        break;
       case Value::ValueType::FileAddress:
         // If this type is a pointer, then its children will be considered load
         // addresses if the pointer or reference is dereferenced, but only if


### PR DESCRIPTION
Update copy of code in UpdateValue from DoUpdateChildrenAddressType

The swift version of ValueObjectVariable.cpp has a copy of the
code in ValueObjectVariable::DoUpdateChildrenAddressType in
ValueObjectVariable::UpdateValue, and the copied bit of code
didn't pick up an update.