### PR TITLE
AArch64: don't form indexed paired ops if base reg overlaps operands.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64LoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/AArch64/AArch64LoadStoreOptimizer.cpp
@@ -1613,8 +1613,8 @@ AArch64LoadStoreOpt::findMatchingInsn(MachineBasicBlock::iterator I,
           // If the stored value and the address of the second instruction is
           // the same, it needs to be using the updated register and therefore
           // it must not be folded.
-          bool IsMIRegTheSame =
-              getLdStRegOp(MI).getReg() == getLdStBaseOp(MI).getReg();
+          bool IsMIRegTheSame = TRI->regsOverlap(getLdStRegOp(MI).getReg(),
+                                                 getLdStBaseOp(MI).getReg());
           if (IsOutOfBounds || IsBaseRegUsed || IsBaseRegModified ||
               IsMIRegTheSame) {
             LiveRegUnits::accumulateUsedDefed(MI, ModifiedRegUnits,

--- a/llvm/test/CodeGen/AArch64/ldrpre-ldr-merge.mir
+++ b/llvm/test/CodeGen/AArch64/ldrpre-ldr-merge.mir
@@ -14,13 +14,13 @@ body:             |
     liveins: $w0, $w1, $x1
     ; CHECK-LABEL: name: 1-ldrwpre-ldrwui-merge
     ; CHECK: liveins: $w0, $w1, $x1
-    ; CHECK: early-clobber $x1, renamable $w0, renamable $w1 = LDPWpre renamable $x1, 5 :: (load (s32))
-    ; CHECK: STPWi renamable $w0, renamable $w1, renamable $x1, 0 :: (store (s32))
+    ; CHECK: early-clobber $x1, renamable $w0, renamable $w2 = LDPWpre renamable $x1, 5 :: (load (s32))
+    ; CHECK: STPWi renamable $w0, renamable $w2, renamable $x1, 0 :: (store (s32))
     ; CHECK: RET undef $lr
     early-clobber renamable $x1, renamable $w0 = LDRWpre killed renamable $x1, 20 :: (load (s32))
-    renamable $w1 = LDRWui renamable $x1, 1 :: (load (s32))
+    renamable $w2 = LDRWui renamable $x1, 1 :: (load (s32))
     STRWui killed renamable $w0, renamable $x1, 0 :: (store (s32))
-    STRWui killed renamable $w1, renamable $x1, 1 :: (store (s32))
+    STRWui killed renamable $w2, renamable $x1, 1 :: (store (s32))
     RET undef $lr
 ...
 

--- a/llvm/test/CodeGen/AArch64/strpre-str-merge.mir
+++ b/llvm/test/CodeGen/AArch64/strpre-str-merge.mir
@@ -451,3 +451,30 @@ body:             |
     RET undef $lr, implicit $x0
 
 ...
+
+---
+name:            17-strwpre-strwui-same-reg-no-merge
+alignment:       4
+tracksRegLiveness: true
+liveins:
+  - { reg: '$x0' }
+  - { reg: '$x1' }
+  - { reg: '$x2' }
+frameInfo:
+  maxAlignment:    1
+  maxCallFrameSize: 0
+machineFunctionInfo:
+  hasRedZone:      false
+body:             |
+  bb.0.entry:
+    liveins: $x0, $x1, $x2
+    ; CHECK-LABEL: name: 17-strwpre-strwui-same-reg-no-merge
+    ; CHECK: liveins: $x0, $x1, $x2
+    ; CHECK: early-clobber renamable $x0 = STRWpre renamable $w1, renamable $x0, 24, implicit $w0, implicit-def $w0 :: (store (s32))
+    ; CHECK: STRWui renamable $w0, renamable $x0, 1 :: (store (s32))
+    ; CHECK: RET undef $lr, implicit $x0
+    early-clobber renamable $x0 = STRWpre killed renamable $w1, killed renamable $x0, 24 :: (store (s32))
+    STRWui renamable $w0, renamable $x0, 1 :: (store (s32))
+    RET undef $lr, implicit $x0
+
+...


### PR DESCRIPTION
The registers involved might not be identical, but can still overlap (e.g.
"str w0, [x0, #4]!").

(cherry picked from commit 3d41ef68e7eecef5fbb4ed43be91b44b583c7158)