### PR TITLE
[AArch64][GlobalISel] Fix constraining LDXPX intrinsic selection.

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
@@ -5042,6 +5042,7 @@ bool AArch64InstructionSelector::selectIntrinsicWithSideEffects(
         {I.getOperand(0).getReg(), I.getOperand(1).getReg()},
         {I.getOperand(3)});
     NewI.cloneMemRefs(I);
+    constrainSelectedInstRegOperands(*NewI, TII, TRI, RBI);
     break;
   }
   case Intrinsic::trap:


### PR DESCRIPTION
Causes a fallback because of lack of regclasses on vregs, unless its without
asserts, where we end up crashing later in codegen.

(cherry picked from commit a11d9a1f480ff83f98c550a6139637ff69c9c07c)