### PR TITLE
[Sema][ObjC] Allow conversions between pointers to ObjC pointers and pointers to structs

### DIFF
--- a/clang/lib/Sema/SemaExprObjC.cpp
+++ b/clang/lib/Sema/SemaExprObjC.cpp
@@ -4449,9 +4449,14 @@ Sema::CheckObjCConversion(SourceRange castRange, QualType castType,
   // Allow casts between pointers to lifetime types (e.g., __strong id*)
   // and pointers to void (e.g., cv void *). Casting from void* to lifetime*
   // must be explicit.
-  if (exprACTC == ACTC_indirectRetainable && castACTC == ACTC_voidPtr)
+  // Allow conversions between pointers to lifetime types and coreFoundation
+  // pointers too, but only when the conversions are explicit.
+  if (exprACTC == ACTC_indirectRetainable &&
+      (castACTC == ACTC_voidPtr ||
+       (castACTC == ACTC_coreFoundation && isCast(CCK))))
     return ACR_okay;
-  if (castACTC == ACTC_indirectRetainable && exprACTC == ACTC_voidPtr &&
+  if (castACTC == ACTC_indirectRetainable &&
+      (exprACTC == ACTC_voidPtr || exprACTC == ACTC_coreFoundation) &&
       isCast(CCK))
     return ACR_okay;
 

--- a/clang/test/SemaObjC/arc-type-conversion.m
+++ b/clang/test/SemaObjC/arc-type-conversion.m
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -fobjc-arc -fobjc-runtime-has-weak -verify -fblocks %s
+// RUN: %clang_cc1 -fsyntax-only -fobjc-arc -fobjc-runtime-has-weak -verify -fblocks -Wno-incompatible-pointer-types %s
 
 typedef const void * CFTypeRef;
 CFTypeRef CFBridgingRetain(id X);
@@ -95,4 +95,15 @@ void ownership_transfer_in_cast(void *vp, Block *pblk) {
 void conversion_in_conditional(id a, void* b) {
   id c = 1 ? a : b; // expected-error {{operands to conditional of types 'id' and 'void *' are incompatible in ARC mode}}
   id d = 1 ? b : a; // expected-error {{operands to conditional of types 'void *' and 'id' are incompatible in ARC mode}}
+}
+
+void conversion_pointer_to_id(__strong id *x) {
+  struct S {
+    int a[2];
+  } s, *p;
+
+  x = (__strong id *)&s;
+  x = &s; // expected-error {{implicit conversion of a non-Objective-C pointer type 'struct S *' to '__strong id *' is disallowed with ARC}}
+  p = (struct S *)x;
+  p = x; // expected-error {{implicit conversion of an indirect pointer to an Objective-C pointer to 'struct S *' is disallowed with ARC}}
 }


### PR DESCRIPTION
clang was just being conservative and trying to prevent users from
messing up the qualifier on the inner pointer type. Lifting this
restriction enables using some of the libc++ templates with ObjC pointer
arguments, which clang currently rejects.

rdar://79018677

Differential Revision: https://reviews.llvm.org/D107021

(cherry picked from commit cc4bfd7f59d5a0024ada2a5c2a6f46d53290882b)