### PR TITLE
[clang][deps] Fix failing test

### DIFF
--- a/clang/test/Index/Core/scan-deps.m
+++ b/clang/test/Index/Core/scan-deps.m
@@ -20,7 +20,7 @@
 // CHECK-NEXT:       [[PREFIX]]/Inputs/module/SubModA.h
 // CHECK-NEXT:       [[PREFIX]]/Inputs/module/SubSubModA.h
 // CHECK-NEXT:       [[PREFIX]]/Inputs/module/module.modulemap
-// CHECK-NEXT:     build-args: {{.*}} -emit-module {{.*}} -fmodule-name=ModA -fno-implicit-modules {{.*}}
+// CHECK-NEXT:     build-args: {{.*}} -emit-module {{.*}} -fmodule-name=ModA {{.*}} -fno-implicit-modules {{.*}}
 // CHECK-NEXT: dependencies:
 // CHECK-NEXT:   context-hash: [[HASH_TU:[A-Z0-9]+]]
 // CHECK-NEXT:   module-deps:


### PR DESCRIPTION
After 6da811fd5c7158eecaf25f0e417131f2e7dfb35f, the generated command-lines changed a bit and an extra argument appeared between `-fmodule-name` and `-fno-implicit-modules`. This commit fixes that by allowing extra arguments in that spot.