### PR TITLE
[5.5][llvm-cov] Check path emptyness in path-equivalence after removing dots.

### DIFF
--- a/llvm/tools/llvm-cov/CodeCoverage.cpp
+++ b/llvm/tools/llvm-cov/CodeCoverage.cpp
@@ -445,7 +445,7 @@ void CodeCoverageTool::remapPathNames(const CoverageMapping &Coverage) {
     SmallString<128> NativePath;
     sys::path::native(Path, NativePath);
     sys::path::remove_dots(NativePath, true);
-    if (!sys::path::is_separator(NativePath.back()))
+    if (!NativePath.empty() && !sys::path::is_separator(NativePath.back()))
       NativePath += sys::path::get_separator();
     return NativePath.c_str();
   };


### PR DESCRIPTION
(cherry picked from commit dd388ba3e0b0a5f06565d0bcb6e1aebb5daac065)

Without this when using `-coverage-prefix-map` to remove absolute paths from your binaries, you can get a crash remapping those to the true paths with llvm-cov.