### PR TITLE
Only scan Swift compile units when scanning for the Swift SDK 

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1769,9 +1769,11 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
       // Force parsing of the CUs to extract the SDK info.
       XcodeSDK sdk;
       if (SymbolFile *sym_file = module.GetSymbolFile())
-        for (unsigned i = 0; i < sym_file->GetNumCompileUnits(); ++i)
-          sdk.Merge(
-              sym_file->ParseXcodeSDK(*sym_file->GetCompileUnitAtIndex(i)));
+        for (unsigned i = 0; i < sym_file->GetNumCompileUnits(); ++i) {
+          auto &cu = *sym_file->GetCompileUnitAtIndex(i);
+          if (cu.GetLanguage() == lldb::eLanguageTypeSwift)
+            sdk.Merge(sym_file->ParseXcodeSDK(cu));
+        }
 
       std::string sdk_path = HostInfo::GetXcodeSDKPath(sdk).str();
       LOG_PRINTF(LIBLLDB_LOG_TYPES, "Host SDK path for sdk %s is %s.",

--- a/lldb/test/API/lang/swift/xcode_sdk/Makefile
+++ b/lldb/test/API/lang/swift/xcode_sdk/Makefile
@@ -1,4 +1,13 @@
 SWIFT_SOURCES := main.swift
 SWIFTFLAGS_EXTRAS := -Xfrontend -no-serialize-debugging-options
+SWIFT_BRIDGING_HEADER := bridging-header.h
+LD_EXTRAS := ignored.o
+
+all: ignored.o $(EXE)
+
+# Artificially inject a wrong SDK into a C file to test that it is ebing ignored.
+ignored.o: ignored.c
+	$(CC) -target $(ARCH)-apple-macos  -c $< -o $@ \
+	  -isysroot $(shell xcrun --sdk iphonesimulator --show-sdk-path)
 
 include Makefile.rules

--- a/lldb/test/API/lang/swift/xcode_sdk/TestSwiftXcodeSDK.py
+++ b/lldb/test/API/lang/swift/xcode_sdk/TestSwiftXcodeSDK.py
@@ -35,7 +35,7 @@ class TestSwiftXcodeSDK(lldbtest.TestBase):
         lldbutil.run_to_name_breakpoint(self, 'main')
 
         self.expect("p 1")
-        self.check_log(log, ".sdk")
+        self.check_log(log, "MacOSX")
 
     @swiftTest
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/xcode_sdk/bridging-header.h
+++ b/lldb/test/API/lang/swift/xcode_sdk/bridging-header.h
@@ -1,0 +1,1 @@
+void c_function();

--- a/lldb/test/API/lang/swift/xcode_sdk/ignored.c
+++ b/lldb/test/API/lang/swift/xcode_sdk/ignored.c
@@ -1,0 +1,1 @@
+void c_function() {}

--- a/lldb/test/API/lang/swift/xcode_sdk/main.swift
+++ b/lldb/test/API/lang/swift/xcode_sdk/main.swift
@@ -1,1 +1,2 @@
+c_function()
 print("I have loaded Swift successfully - break here")


### PR DESCRIPTION
While generally being a sensible thing to do, this works around an
edge case where system C libraries that were compiled against a
different SDK are messing up the Swift SDK configuration.

rdar://76071920