### PR TITLE
Update all stale license headers. NFC

### DIFF
--- a/clang/include/clang-c/Refactor.h
+++ b/clang/include/clang-c/Refactor.h
@@ -1,9 +1,9 @@
 /*==-- clang-c/Refactor.h - Refactoring Public C Interface --------*- C -*-===*\
 |*                                                                            *|
-|*                     The LLVM Compiler Infrastructure                       *|
-|*                                                                            *|
-|* This file is distributed under the University of Illinois Open Source      *|
-|* License. See LICENSE.TXT for details.                                      *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
 |*                                                                            *|
 |*===----------------------------------------------------------------------===*|
 |*                                                                            *|

--- a/clang/include/clang/APINotes/APINotesManager.h
+++ b/clang/include/clang/APINotes/APINotesManager.h
@@ -1,9 +1,8 @@
 //===--- APINotesManager.h - Manage API Notes Files -------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/include/clang/APINotes/APINotesOptions.h
+++ b/clang/include/clang/APINotes/APINotesOptions.h
@@ -1,9 +1,8 @@
 //===--- APINotesOptions.h --------------------------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/include/clang/APINotes/APINotesReader.h
+++ b/clang/include/clang/APINotes/APINotesReader.h
@@ -1,9 +1,8 @@
 //===--- APINotesReader.h - API Notes Reader ----------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/include/clang/APINotes/APINotesWriter.h
+++ b/clang/include/clang/APINotes/APINotesWriter.h
@@ -1,9 +1,8 @@
 //===--- APINotesWriter.h - API Notes Writer ----------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/include/clang/AST/DependentASTVisitor.h
+++ b/clang/include/clang/AST/DependentASTVisitor.h
@@ -1,9 +1,8 @@
 //===--- DependentASTVisitor.h - Helper for dependent nodes -----*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/include/clang/Basic/SourceMgrAdapter.h
+++ b/clang/include/clang/Basic/SourceMgrAdapter.h
@@ -1,9 +1,8 @@
 //=== SourceMgrAdapter.h - SourceMgr to SourceManager Adapter ---*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/include/clang/Edit/RefactoringFixits.h
+++ b/clang/include/clang/Edit/RefactoringFixits.h
@@ -1,9 +1,8 @@
 //===--- RefactoringFixits.h - Fixit producers for refactorings -*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Index/IndexDataStore.h
+++ b/clang/include/clang/Index/IndexDataStore.h
@@ -1,9 +1,8 @@
 //===--- IndexDataStore.h - Index data store info -------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Index/IndexDataStoreSymbolUtils.h
+++ b/clang/include/clang/Index/IndexDataStoreSymbolUtils.h
@@ -1,9 +1,8 @@
 //===--- IndexDataStoreSymbolUtils.h - Utilities for indexstore symbols ---===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Index/IndexRecordReader.h
+++ b/clang/include/clang/Index/IndexRecordReader.h
@@ -1,9 +1,8 @@
 //===--- IndexRecordReader.h - Index record deserialization ---------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Index/IndexRecordWriter.h
+++ b/clang/include/clang/Index/IndexRecordWriter.h
@@ -1,9 +1,8 @@
 //===--- IndexRecordWriter.h - Index record serialization -----------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Index/IndexUnitReader.h
+++ b/clang/include/clang/Index/IndexUnitReader.h
@@ -1,9 +1,8 @@
 //===--- IndexUnitReader.h - Index unit deserialization -------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Index/IndexUnitWriter.h
+++ b/clang/include/clang/Index/IndexUnitWriter.h
@@ -1,9 +1,8 @@
 //===--- IndexUnitWriter.h - Index unit serialization ---------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Tooling/Refactor/IndexerQuery.h
+++ b/clang/include/clang/Tooling/Refactor/IndexerQuery.h
@@ -1,9 +1,8 @@
 //===--- IndexerQuery.h - A set of indexer query interfaces ---------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/include/clang/Tooling/Refactor/RefactoringActionFinder.h
+++ b/clang/include/clang/Tooling/Refactor/RefactoringActionFinder.h
@@ -1,9 +1,8 @@
 //===--- RefactoringActionFinder.h - Clang refactoring library ------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 ///

--- a/clang/include/clang/Tooling/Refactor/RefactoringActions.def
+++ b/clang/include/clang/Tooling/Refactor/RefactoringActions.def
@@ -1,9 +1,8 @@
 //===--- RefactoringActions.def - The list of refactoring actions  --------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Tooling/Refactor/RefactoringActions.h
+++ b/clang/include/clang/Tooling/Refactor/RefactoringActions.h
@@ -1,9 +1,8 @@
 //===--- RefactoringActions.h - Clang refactoring library -----------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 ///

--- a/clang/include/clang/Tooling/Refactor/RefactoringOperation.h
+++ b/clang/include/clang/Tooling/Refactor/RefactoringOperation.h
@@ -1,9 +1,8 @@
 //===--- RefactoringOperations.h - Defines a refactoring operation --------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Tooling/Refactor/RefactoringOperationState.h
+++ b/clang/include/clang/Tooling/Refactor/RefactoringOperationState.h
@@ -1,9 +1,8 @@
 //===--- RefactoringOperationState.h - Serializable operation state -------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/include/clang/Tooling/Refactor/RefactoringOptionSet.h
+++ b/clang/include/clang/Tooling/Refactor/RefactoringOptionSet.h
@@ -1,9 +1,8 @@
 //===--- RefactoringOptionSet.h - A container for the refactoring options -===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Tooling/Refactor/RefactoringOptions.h
+++ b/clang/include/clang/Tooling/Refactor/RefactoringOptions.h
@@ -1,9 +1,8 @@
 //===--- RefactoringOptions.h - A set of all the refactoring options ------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/include/clang/Tooling/Refactor/RefactoringReplacement.h
+++ b/clang/include/clang/Tooling/Refactor/RefactoringReplacement.h
@@ -1,9 +1,8 @@
 //===--- RefactoringReplacement.h - ------------------------*- C++ -*------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Tooling/Refactor/RenameIndexedFile.h
+++ b/clang/include/clang/Tooling/Refactor/RenameIndexedFile.h
@@ -1,9 +1,8 @@
 //===--- RenameIndexedFile.h - -----------------------------*- C++ -*------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Tooling/Refactor/RenamedSymbol.h
+++ b/clang/include/clang/Tooling/Refactor/RenamedSymbol.h
@@ -1,9 +1,8 @@
 //===--- RenamedSymbol.h - ---------------------------------*- C++ -*------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Tooling/Refactor/RenamingOperation.h
+++ b/clang/include/clang/Tooling/Refactor/RenamingOperation.h
@@ -1,9 +1,8 @@
 //===--- RenamingOperation.h - -----------------------------*- C++ -*------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Tooling/Refactor/SymbolName.h
+++ b/clang/include/clang/Tooling/Refactor/SymbolName.h
@@ -1,9 +1,8 @@
 //===--- SymbolName.h - Clang refactoring library ----------*- C++ -*------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Tooling/Refactor/SymbolOccurrenceFinder.h
+++ b/clang/include/clang/Tooling/Refactor/SymbolOccurrenceFinder.h
@@ -1,9 +1,8 @@
 //===--- SymbolOccurrenceFinder.h - Clang refactoring library -------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 ///

--- a/clang/include/clang/Tooling/Refactor/SymbolOperation.h
+++ b/clang/include/clang/Tooling/Refactor/SymbolOperation.h
@@ -1,9 +1,8 @@
 //===--- SymbolOperation.h - -------------------------------*- C++ -*------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Tooling/Refactor/USRFinder.h
+++ b/clang/include/clang/Tooling/Refactor/USRFinder.h
@@ -1,9 +1,8 @@
 //===--- USRFinder.h - Clang refactoring library --------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 ///

--- a/clang/include/indexstore/IndexStoreCXX.h
+++ b/clang/include/indexstore/IndexStoreCXX.h
@@ -1,9 +1,8 @@
 //===--- IndexStoreCXX.h - C++ wrapper for the Index Store C API. ---------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/include/indexstore/indexstore.h
+++ b/clang/include/indexstore/indexstore.h
@@ -1,9 +1,9 @@
 /*===-- indexstore/indexstore.h - Index Store C API ----------------- C -*-===*\
 |*                                                                            *|
-|*                     The LLVM Compiler Infrastructure                       *|
-|*                                                                            *|
-|* This file is distributed under the University of Illinois Open Source      *|
-|* License. See LICENSE.TXT for details.                                      *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
 |*                                                                            *|
 |*===----------------------------------------------------------------------===*|
 |*                                                                            *|

--- a/clang/lib/APINotes/APINotesManager.cpp
+++ b/clang/lib/APINotes/APINotesManager.cpp
@@ -1,9 +1,8 @@
 //===--- APINotesManager.cpp - Manage API Notes Files ---------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/lib/APINotes/APINotesReader.cpp
+++ b/clang/lib/APINotes/APINotesReader.cpp
@@ -1,9 +1,8 @@
 //===--- APINotesReader.cpp - Side Car Reader --------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/lib/APINotes/APINotesWriter.cpp
+++ b/clang/lib/APINotes/APINotesWriter.cpp
@@ -1,9 +1,8 @@
 //===--- APINotesWriter.cpp - API Notes Writer --------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/lib/APINotes/Types.cpp
+++ b/clang/lib/APINotes/Types.cpp
@@ -1,9 +1,8 @@
 //===--- Types.cpp - API Notes Data Types ----------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/lib/Basic/SourceMgrAdapter.cpp
+++ b/clang/lib/Basic/SourceMgrAdapter.cpp
@@ -1,9 +1,8 @@
 //=== SourceMgrAdapter.cpp - SourceMgr to SourceManager Adapter -----------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/lib/Edit/FillInMissingProtocolStubs.cpp
+++ b/clang/lib/Edit/FillInMissingProtocolStubs.cpp
@@ -1,9 +1,8 @@
 //===--- FillInMissingProtocolStubs.cpp -  --------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/lib/Edit/FillInMissingSwitchEnumCases.cpp
+++ b/clang/lib/Edit/FillInMissingSwitchEnumCases.cpp
@@ -1,9 +1,8 @@
 //===--- FillInMissingSwitchEnumCases.cpp -  ------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Index/BitstreamVisitor.h
+++ b/clang/lib/Index/BitstreamVisitor.h
@@ -1,9 +1,8 @@
 //===--- BitstreamVisitor.h - Helper for reading a bitstream --------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Index/ClangIndexRecordWriter.cpp
+++ b/clang/lib/Index/ClangIndexRecordWriter.cpp
@@ -1,9 +1,8 @@
 //===--- ClangIndexRecordWriter.cpp - Index record serialization ----------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Index/ClangIndexRecordWriter.h
+++ b/clang/lib/Index/ClangIndexRecordWriter.h
@@ -1,9 +1,8 @@
 //===--- ClangIndexRecordWriter.h - Index record serialization ------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Index/IndexDataStoreUtils.cpp
+++ b/clang/lib/Index/IndexDataStoreUtils.cpp
@@ -1,9 +1,8 @@
 //===--- IndexDataStoreUtils.cpp - Functions/constants for the data store -===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Index/IndexDataStoreUtils.h
+++ b/clang/lib/Index/IndexDataStoreUtils.h
@@ -1,9 +1,8 @@
 //===--- IndexDataStoreUtils.h - Functions/constants for the data store ---===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Index/IndexRecordHasher.cpp
+++ b/clang/lib/Index/IndexRecordHasher.cpp
@@ -1,9 +1,8 @@
 //===--- IndexRecordHasher.cpp - Index record hashing ---------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Index/IndexRecordHasher.h
+++ b/clang/lib/Index/IndexRecordHasher.h
@@ -1,9 +1,8 @@
 //===--- IndexRecordHasher.h - Index record hashing -----------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Index/IndexRecordReader.cpp
+++ b/clang/lib/Index/IndexRecordReader.cpp
@@ -1,9 +1,8 @@
 //===--- IndexRecordReader.cpp - Index record deserialization -------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Index/IndexRecordWriter.cpp
+++ b/clang/lib/Index/IndexRecordWriter.cpp
@@ -1,9 +1,8 @@
 //===--- IndexRecordWriter.cpp - Index record serialization ---------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Index/IndexUnitReader.cpp
+++ b/clang/lib/Index/IndexUnitReader.cpp
@@ -1,9 +1,8 @@
 //===--- IndexUnitReader.cpp - Index unit deserialization -----------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Index/IndexUnitWriter.cpp
+++ b/clang/lib/Index/IndexUnitWriter.cpp
@@ -1,9 +1,8 @@
 //===--- IndexUnitWriter.cpp - Index unit serialization -------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/IndexDataStore/IndexDataStore.cpp
+++ b/clang/lib/IndexDataStore/IndexDataStore.cpp
@@ -1,9 +1,8 @@
 //===--- IndexDataStore.cpp - Index data store info -----------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -1,9 +1,8 @@
 //===--- SemaAPINotes.cpp - API Notes Handling ----------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/lib/Tooling/Refactor/ASTSlice.cpp
+++ b/clang/lib/Tooling/Refactor/ASTSlice.cpp
@@ -1,9 +1,8 @@
 //===--- ASTSlice.cpp - Represents a portion of the AST -------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/ASTSlice.h
+++ b/clang/lib/Tooling/Refactor/ASTSlice.h
@@ -1,9 +1,8 @@
 //===--- ASTSlice.h - Represents a portion of the AST ---------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/ASTStateSerialization.cpp
+++ b/clang/lib/Tooling/Refactor/ASTStateSerialization.cpp
@@ -1,9 +1,8 @@
 //===-- ASTStateSerialization.cpp - Persists TU-specific state across TUs -===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/Extract.cpp
+++ b/clang/lib/Tooling/Refactor/Extract.cpp
@@ -1,9 +1,8 @@
 //===--- Extract.cpp -  ---------------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/lib/Tooling/Refactor/ExtractRepeatedExpressionIntoVariable.cpp
+++ b/clang/lib/Tooling/Refactor/ExtractRepeatedExpressionIntoVariable.cpp
@@ -1,9 +1,8 @@
 //===--- ExtractRepeatedExpressionIntoVariable.cpp -  ---------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/lib/Tooling/Refactor/ExtractionUtils.cpp
+++ b/clang/lib/Tooling/Refactor/ExtractionUtils.cpp
@@ -1,9 +1,8 @@
 //===--- ExtractionUtils.cpp - Extraction helper functions ----------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/ExtractionUtils.h
+++ b/clang/lib/Tooling/Refactor/ExtractionUtils.h
@@ -1,9 +1,8 @@
 //===--- ExtractionUtils.h - Extraction helper functions ------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/FillInEnumSwitchCases.cpp
+++ b/clang/lib/Tooling/Refactor/FillInEnumSwitchCases.cpp
@@ -1,9 +1,8 @@
 //===--- FillInEnumSwitchCases.cpp -  -------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/lib/Tooling/Refactor/FillInMissingMethodStubsFromAbstractClasses.cpp
+++ b/clang/lib/Tooling/Refactor/FillInMissingMethodStubsFromAbstractClasses.cpp
@@ -1,9 +1,8 @@
 //===--- FillInMissingMethodStubsFromAbstractClasses.cpp -  ---------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/lib/Tooling/Refactor/FillInMissingProtocolStubs.cpp
+++ b/clang/lib/Tooling/Refactor/FillInMissingProtocolStubs.cpp
@@ -1,9 +1,8 @@
 //===--- FillInMissingProtocolStubs.cpp -  --------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/lib/Tooling/Refactor/IfSwitchConversion.cpp
+++ b/clang/lib/Tooling/Refactor/IfSwitchConversion.cpp
@@ -1,9 +1,8 @@
 //===--- IfSwitchConversion.cpp -  ----------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/lib/Tooling/Refactor/ImplementDeclaredMethods.cpp
+++ b/clang/lib/Tooling/Refactor/ImplementDeclaredMethods.cpp
@@ -1,9 +1,8 @@
 //===--- ImplementDeclaredMethods.cpp -  ----------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/lib/Tooling/Refactor/IndexerQueries.cpp
+++ b/clang/lib/Tooling/Refactor/IndexerQueries.cpp
@@ -1,9 +1,8 @@
 //===--- IndexerQueries.cpp - Indexer queries -----------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/LocalizeObjCStringLiteral.cpp
+++ b/clang/lib/Tooling/Refactor/LocalizeObjCStringLiteral.cpp
@@ -1,9 +1,8 @@
 //===--- LocalizeObjCString.cpp -  ----------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/lib/Tooling/Refactor/RefactoringActionFinder.cpp
+++ b/clang/lib/Tooling/Refactor/RefactoringActionFinder.cpp
@@ -1,9 +1,8 @@
 //===--- RefactoringActionFinder.cpp - Clang refactoring library ----------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 ///

--- a/clang/lib/Tooling/Refactor/RefactoringActions.cpp
+++ b/clang/lib/Tooling/Refactor/RefactoringActions.cpp
@@ -1,9 +1,8 @@
 //===--- RefactoringActions.cpp - Clang refactoring library ---------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 ///

--- a/clang/lib/Tooling/Refactor/RefactoringContinuations.h
+++ b/clang/lib/Tooling/Refactor/RefactoringContinuations.h
@@ -1,9 +1,8 @@
 //===--- RefactoringContinuations.h - Defines refactoring continuations ---===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/RefactoringOperation.cpp
+++ b/clang/lib/Tooling/Refactor/RefactoringOperation.cpp
@@ -1,9 +1,8 @@
 //===--- RefactoringOperation.cpp - Defines a refactoring operation -------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/RefactoringOperations.h
+++ b/clang/lib/Tooling/Refactor/RefactoringOperations.h
@@ -1,9 +1,8 @@
 //===--- RefactoringOperations.h - The supported refactoring operations ---===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/RefactoringOptions.cpp
+++ b/clang/lib/Tooling/Refactor/RefactoringOptions.cpp
@@ -1,9 +1,8 @@
 //===--- RefactoringOptions.cpp - A set of all the refactoring options ----===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/RenameIndexedFile.cpp
+++ b/clang/lib/Tooling/Refactor/RenameIndexedFile.cpp
@@ -1,9 +1,8 @@
 //===--- RenameIndexedFile.cpp - ------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/RenamedSymbol.cpp
+++ b/clang/lib/Tooling/Refactor/RenamedSymbol.cpp
@@ -1,9 +1,8 @@
 //===--- RenamedSymbol.cpp - ----------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/RenamingOperation.cpp
+++ b/clang/lib/Tooling/Refactor/RenamingOperation.cpp
@@ -1,9 +1,8 @@
 //===--- RenamingOperation.cpp - ------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/SourceLocationUtilities.cpp
+++ b/clang/lib/Tooling/Refactor/SourceLocationUtilities.cpp
@@ -1,9 +1,8 @@
 //===--- SourceLocationUtilities.cpp - Source location helper functions ---===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/SourceLocationUtilities.h
+++ b/clang/lib/Tooling/Refactor/SourceLocationUtilities.h
@@ -1,9 +1,8 @@
 //===--- SourceLocationUtilities.h - Source location helper functions -----===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/StmtUtils.cpp
+++ b/clang/lib/Tooling/Refactor/StmtUtils.cpp
@@ -1,9 +1,8 @@
 //===--- StmtUtils.cpp - Statement helper functions -----------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/StmtUtils.h
+++ b/clang/lib/Tooling/Refactor/StmtUtils.h
@@ -1,9 +1,8 @@
 //===--- StmtUtils.h - Statement helper functions -------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/SymbolName.cpp
+++ b/clang/lib/Tooling/Refactor/SymbolName.cpp
@@ -1,9 +1,8 @@
 //===--- SymbolName.cpp - Clang refactoring library -----------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/SymbolOccurrenceFinder.cpp
+++ b/clang/lib/Tooling/Refactor/SymbolOccurrenceFinder.cpp
@@ -1,9 +1,8 @@
 //===--- SymbolOccurrenceFinder.cpp - Clang refactoring library -----------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 ///

--- a/clang/lib/Tooling/Refactor/SymbolOperation.cpp
+++ b/clang/lib/Tooling/Refactor/SymbolOperation.cpp
@@ -1,9 +1,8 @@
 //===--- SymbolOperation.cpp - --------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/SymbolUSRFinder.cpp
+++ b/clang/lib/Tooling/Refactor/SymbolUSRFinder.cpp
@@ -1,9 +1,8 @@
 //===--- SymbolUSRFinder.cpp - Clang refactoring library ------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 ///

--- a/clang/lib/Tooling/Refactor/TypeUtils.cpp
+++ b/clang/lib/Tooling/Refactor/TypeUtils.cpp
@@ -1,9 +1,8 @@
 //===--- TypeUtils.cpp - Type helper functions ----------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/TypeUtils.h
+++ b/clang/lib/Tooling/Refactor/TypeUtils.h
@@ -1,9 +1,8 @@
 //===--- TypeUtils.h - Type helper functions ------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Tooling/Refactor/USRFinder.cpp
+++ b/clang/lib/Tooling/Refactor/USRFinder.cpp
@@ -1,9 +1,8 @@
 //===--- USRFinder.cpp - Clang refactoring library ------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 ///

--- a/clang/tools/IndexStore/IndexStore.cpp
+++ b/clang/tools/IndexStore/IndexStore.cpp
@@ -1,9 +1,8 @@
 //===- IndexStore.cpp - Index store API -----------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/tools/c-index-test/JSONAggregation.cpp
+++ b/clang/tools/c-index-test/JSONAggregation.cpp
@@ -1,9 +1,8 @@
 //===--- JSONAggregation.cpp - Index data aggregation in JSON format ------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/tools/c-index-test/JSONAggregation.h
+++ b/clang/tools/c-index-test/JSONAggregation.h
@@ -1,9 +1,8 @@
 //===--- JSONAggregation.h - Index data aggregation in JSON format --------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/tools/clang-refactor-test/ClangRefactorTest.cpp
+++ b/clang/tools/clang-refactor-test/ClangRefactorTest.cpp
@@ -1,9 +1,8 @@
 //===--- ClangRefactorTest.cpp - ------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/tools/libclang/CRefactor.cpp
+++ b/clang/tools/libclang/CRefactor.cpp
@@ -1,9 +1,8 @@
 //===- CRefactor.cpp - Refactoring API hooks ------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/clang/unittests/libclang/DriverTest.cpp
+++ b/clang/unittests/libclang/DriverTest.cpp
@@ -1,9 +1,8 @@
 //===---- DriverTest.cpp --------------------------------------------------===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/lldb/include/lldb/Utility/Either.h
+++ b/lldb/include/lldb/Utility/Either.h
@@ -1,9 +1,8 @@
 //===-- Either.h -----------------------------------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftDiagnostic.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftDiagnostic.h
@@ -1,9 +1,8 @@
 //===-- SwiftDiagnostic.h -------------------------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftHost.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftHost.cpp
@@ -1,9 +1,8 @@
 //===-- SwiftHost.cpp -------------------------------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftHost.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftHost.h
@@ -1,9 +1,8 @@
 //===-- SwiftHost.h ---------------------------------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/lldb/source/Plugins/InstrumentationRuntime/SwiftRuntimeReporting/SwiftRuntimeReporting.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/SwiftRuntimeReporting/SwiftRuntimeReporting.cpp
@@ -1,9 +1,8 @@
 //===-- SwiftRuntimeReporting.cpp -------------------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/lldb/source/Plugins/InstrumentationRuntime/SwiftRuntimeReporting/SwiftRuntimeReporting.h
+++ b/lldb/source/Plugins/InstrumentationRuntime/SwiftRuntimeReporting/SwiftRuntimeReporting.h
@@ -1,9 +1,8 @@
 //===-- SwiftRuntimeReporting.h ---------------------------------*- C++ -*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/lldb/unittests/Expression/SwiftParserTest.cpp
+++ b/lldb/unittests/Expression/SwiftParserTest.cpp
@@ -1,9 +1,8 @@
 //===-- SwiftParserTest.cpp --------------------------------------*- C++-*-===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/unittests/Bitcode/RecordLayout.cpp
+++ b/llvm/unittests/Bitcode/RecordLayout.cpp
@@ -1,9 +1,8 @@
 //===- llvm/unittest/Bitcode/RecordLayout.cpp - Tests for BCRecordLayout --===//
 //
-//                     The LLVM Compiler Infrastructure
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
It appears the files that don't exist in upstream have the old LLVM license in them.