### PR TITLE
[lldb] Support diagnostic options in Swift REPL

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -936,6 +936,8 @@ protected:
 
   friend class CompilerType;
 
+  void ApplyDiagnosticOptions();
+
   /// Apply a PathMappingList dictionary on all search paths in the
   /// ClangImporterOptions.
   void RemapClangImporterOptions(const PathMappingList &path_map);

--- a/lldb/test/Shell/SwiftREPL/DiagnosticOptions.test
+++ b/lldb/test/Shell/SwiftREPL/DiagnosticOptions.test
@@ -1,0 +1,20 @@
+// Test diagnostic options in REPL
+// REQUIRES: swift
+
+// RUN: %lldb --repl="-debug-diagnostic-names" < %s 2>&1 \
+// RUN: | FileCheck %s --check-prefix=DIAGNOSTIC
+
+// RUN: split-file %s %t.dir
+// RUN: %lldb --repl="-localization-path %t.dir -locale fr" < %s 2>&1 \
+// RUN: | FileCheck %s --check-prefix=LOCALIZED
+
+
+_ = "An unterminated string
+// DIAGNOSTIC: error: unterminated string literal [lex_unterminated_string]{{$}}
+// LOCALIZED: error: chaîne non terminée littérale{{$}}
+:quit
+
+
+//--- fr.yaml
+- id: "lex_unterminated_string"
+  msg: "chaîne non terminée littérale"


### PR DESCRIPTION
Honor some previously ignored diagnostic options like
'-debug-diagnostic-names' and '-locale' by applying them to the
diagnostic engine in the SwiftASTContext.

https://bugs.swift.org/browse/SR-14845