### PR TITLE
[FileCheck] Use StringRef for MatchRegexp to fix crash.

### DIFF
--- a/llvm/lib/FileCheck/FileCheck.cpp
+++ b/llvm/lib/FileCheck/FileCheck.cpp
@@ -1034,7 +1034,8 @@ bool Pattern::parsePattern(StringRef PatternStr, StringRef Prefix,
       bool IsLegacyLineExpr = false;
       StringRef DefName;
       StringRef SubstStr;
-      std::string MatchRegexp;
+      StringRef MatchRegexp;
+      std::string WildcardRegexp;
       size_t SubstInsertIdx = RegExStr.size();
 
       // Parse string variable or legacy @LINE expression.
@@ -1078,7 +1079,7 @@ bool Pattern::parsePattern(StringRef PatternStr, StringRef Prefix,
             return true;
           }
           DefName = Name;
-          MatchRegexp = MatchStr.str();
+          MatchRegexp = MatchStr;
         } else {
           if (IsPseudo) {
             MatchStr = OrigMatchStr;
@@ -1117,7 +1118,8 @@ bool Pattern::parsePattern(StringRef PatternStr, StringRef Prefix,
           SubstStr = MatchStr;
         else {
           ExpressionFormat Format = ExpressionPointer->getFormat();
-          MatchRegexp = cantFail(Format.getWildcardRegex());
+          WildcardRegexp = cantFail(Format.getWildcardRegex());
+          MatchRegexp = WildcardRegexp;
         }
       }
 

--- a/llvm/test/FileCheck/invalid-regex.txt
+++ b/llvm/test/FileCheck/invalid-regex.txt
@@ -1,0 +1,19 @@
+# This file contains invalid regular expressions in variable patterns. Make
+# sure a proper error message is presented
+//------------------------------------------------
+RUN: %ProtectFileCheckOutput \
+RUN: not FileCheck -check-prefix=CHECK-STAR %s < /dev/null 2>&1 | \
+RUN:   FileCheck -check-prefix=ERR-STAR %s
+
+CHECK-STAR: [[BOOM:*]]
+ERR-STAR: error: invalid regex: repetition-operator operand invalid
+
+//------------------------------------------------
+RUN: %ProtectFileCheckOutput \
+RUN: not FileCheck -check-prefix=CHECK-PLUS %s < /dev/null 2>&1 | \
+RUN:   FileCheck -check-prefix=ERR-PLUS %s
+
+CHECK-PLUS: [[BOOM:+]]
+ERR-PLUS: error: invalid regex: repetition-operator operand invalid
+
+//------------------------------------------------


### PR DESCRIPTION
If MatchRegexp is an invalid regex, an error message will be printed
using SourceManager::PrintMessage via AddRegExToRegEx.

PrintMessage relies on the input being a StringRef into a string managed
by SourceManager. At the moment, a StringRef to a std::string
allocated in the caller of AddRegExToRegEx is passed. If the regex is
invalid, this StringRef is passed to PrintMessage, where it will crash,
because it does not point to a string managed via SourceMgr.

This patch fixes the crash by turning MatchRegexp into a StringRef If
we use MatchStr, we directly use that StringRef, which points into a
string from SourceMgr. Otherwise, MatchRegexp gets assigned
Format.getWildcardRegex(), which returns a std::string. To extend the
lifetime, assign it to a std::string variable WildcardRegexp and assign
MatchRegexp to a stringref to WildcardRegexp. WildcardRegexp should
always be valid, so we should never have to print an error message
via the SoureMgr I think.

Fixes PR49319.

Reviewed By: thopre

(cherry-picked from a3d357e504875f4f6c2b3c2674eb84a7b4101cb9)
Differential Revision: https://reviews.llvm.org/D109050