### PR TITLE
[lldb] Adjust parse_frames for unnamed images

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -473,7 +473,8 @@ class JSONCrashLogParser:
         idx = 0
         for json_frame in json_frames:
             image_id = int(json_frame['imageIndex'])
-            ident = self.get_used_image(image_id)['name']
+            json_image = self.get_used_image(image_id)
+            ident = json_image['name'] if 'name' in json_image else ''
             thread.add_ident(ident)
             if ident not in self.crashlog.idents:
                 self.crashlog.idents.append(ident)


### PR DESCRIPTION
Follow up to 2cbd3b04feaaaff7fab4c6500476839a23180886 which added
support for unnamed images but missed the use case in parse_frames.

(cherry picked from commit 05cdd294ab020b42329413ae7ab52d0c5aaf8151)
