### PR TITLE
[lldb/Plugins] Move member template specialization out of class

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptedPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptedPythonInterface.cpp
@@ -35,4 +35,31 @@ ScriptedPythonInterface::GetStatusFromMethod(llvm::StringRef method_name) {
   return error;
 }
 
+template <>
+Status ScriptedPythonInterface::ExtractValueFromPythonObject<Status>(
+    python::PythonObject &p, Status &error) {
+  if (lldb::SBError *sb_error = reinterpret_cast<lldb::SBError *>(
+          LLDBSWIGPython_CastPyObjectToSBError(p.get())))
+    error = m_interpreter.GetStatusFromSBError(*sb_error);
+  else
+    error.SetErrorString("Couldn't cast lldb::SBError to lldb::Status.");
+
+  return error;
+}
+
+template <>
+lldb::DataExtractorSP
+ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::DataExtractorSP>(
+    python::PythonObject &p, Status &error) {
+  lldb::SBData *sb_data = reinterpret_cast<lldb::SBData *>(
+      LLDBSWIGPython_CastPyObjectToSBData(p.get()));
+
+  if (!sb_data) {
+    error.SetErrorString("Couldn't cast lldb::SBError to lldb::Status.");
+    return nullptr;
+  }
+
+  return m_interpreter.GetDataExtractorFromSBData(*sb_data);
+}
+
 #endif

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptedPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptedPythonInterface.h
@@ -33,33 +33,6 @@ protected:
     return p.CreateStructuredObject();
   }
 
-  template <>
-  Status ExtractValueFromPythonObject<Status>(python::PythonObject &p,
-                                              Status &error) {
-    if (lldb::SBError *sb_error = reinterpret_cast<lldb::SBError *>(
-            LLDBSWIGPython_CastPyObjectToSBError(p.get())))
-      error = m_interpreter.GetStatusFromSBError(*sb_error);
-    else
-      error.SetErrorString("Couldn't cast lldb::SBError to lldb::Status.");
-
-    return error;
-  }
-
-  template <>
-  lldb::DataExtractorSP
-  ExtractValueFromPythonObject<lldb::DataExtractorSP>(python::PythonObject &p,
-                                                      Status &error) {
-    lldb::SBData *sb_data = reinterpret_cast<lldb::SBData *>(
-        LLDBSWIGPython_CastPyObjectToSBData(p.get()));
-
-    if (!sb_data) {
-      error.SetErrorString("Couldn't cast lldb::SBError to lldb::Status.");
-      return nullptr;
-    }
-
-    return m_interpreter.GetDataExtractorFromSBData(*sb_data);
-  }
-
   template <typename T = StructuredData::ObjectSP, typename... Args>
   T Dispatch(llvm::StringRef method_name, Status &error, Args... args) {
     using namespace python;
@@ -149,6 +122,16 @@ protected:
   // The lifetime is managed by the ScriptInterpreter
   ScriptInterpreterPythonImpl &m_interpreter;
 };
+
+template <>
+Status ScriptedPythonInterface::ExtractValueFromPythonObject<Status>(
+    python::PythonObject &p, Status &error);
+
+template <>
+lldb::DataExtractorSP
+ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::DataExtractorSP>(
+    python::PythonObject &p, Status &error);
+
 } // namespace lldb_private
 
 #endif // LLDB_ENABLE_PYTHON


### PR DESCRIPTION
This patch should fix the build failure that surfaced when build llvm
with GCC: https://lab.llvm.org/staging/#/builders/16/builds/10450

GCC complained that I explicitely specialized
 `ScriptedPythonInterface::ExtractValueFromPythonObject` in a
in non-namespace scope, which is tolerated by Clang.

To solve this issue, the specialization were declared out of the class
and implemented in the source file.

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>