### PR TITLE
Edit gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 # vim swap files
 .*.sw?
 .sw?
-#OS X specific files.
+# macOS specific files.
 .DS_store
 
 # Ignore the user specified CMake presets in subproject directories.


### PR DESCRIPTION
On June 13, 2016, at WWDC16, OS X was renamed macOS.
But here in the gitignore file this hasn't changed.
Please merge it.