### PR TITLE
Fix `asan/TestCases/Darwin/scrible.cpp` to work on platforms where `l…

### DIFF
--- a/compiler-rt/test/asan/TestCases/Darwin/scribble.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/scribble.cpp
@@ -13,7 +13,14 @@ struct Isa {
 };
 
 struct MyClass {
-  long padding;
+  // User memory and `ChunkHeader` overlap. In particular the `free_context_id`
+  // is stored at the beginning of user memory when it is freed. That part of
+  // user memory is not scribbled and is changed when the memory is freed. This
+  // test relies on `isa` being scribbled or unmodified after memory is freed.
+  // In order for this to work the start of `isa` must come after whatever is in
+  // `ChunkHeader` (currently the 64-bit `free_context_id`). The padding here is
+  // to ensure this is the case.
+  uint64_t padding;
   Isa *isa;
   long data;
 


### PR DESCRIPTION
…ong` is not 64-bits.

Previously the test was failing on platforms where `long` was less than
64-bits wide (e.g. older WatchOS simulators and arm64_32) because the
`padding` field was too small.

The test currently relies on the `my_object->isa` being scribbled or
left unmodified after `my_object` is freed. However, this was not the
case because the `isa` pointer intersected with
`ChunkHeader::free_context_id`.  `free_context_id` starts at the
beginning of user memory but it only initialized once the memory is
freed. This caused the `isa` pointer to change after it was freed
leading to the test crashing.

To fix this the `padding` field has been made explicitly 64-bits wide
(same size as `ChunkHeader::free_context_id`).

rdar://75806757

Differential Revision: https://reviews.llvm.org/D109409

(cherry picked from commit 71841146b6222ef7eea06b9facd94d0e0c29c62b)