### PR TITLE
Add a command-line flag to control the Swift extended async frame info.

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -416,6 +416,11 @@ CODEGENOPT(PassByValueIsNoAlias, 1, 0)
 /// according to the field declaring type width.
 CODEGENOPT(AAPCSBitfieldWidth, 1, 1)
 
+// Whether to emit Swift Async function extended frame information: auto,
+// never, always.
+ENUM_CODEGENOPT(SwiftAsyncFramePointer, SwiftAsyncFramePointerKind, 2,
+                SwiftAsyncFramePointerKind::Auto)
+
 #undef CODEGENOPT
 #undef ENUM_CODEGENOPT
 #undef VALUE_CODEGENOPT

--- a/clang/include/clang/Basic/CodeGenOptions.h
+++ b/clang/include/clang/Basic/CodeGenOptions.h
@@ -135,6 +135,13 @@ public:
     All,         // Keep all frame pointers.
   };
 
+  enum class SwiftAsyncFramePointerKind {
+    Auto, // Choose Swift async extended frame info based on deployment target.
+    Always, // Unconditionally emit Swift async extended frame info.
+    Never,  // Don't emit Swift async extended frame info.
+    Default = Auto,
+  };
+
   enum FiniteLoopsKind {
     Language, // Not specified, use language standard.
     Always,   // All loops are assumed to be finite.

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1185,6 +1185,14 @@ defm pseudo_probe_for_profiling : BoolFOption<"pseudo-probe-for-profiling",
 def forder_file_instrumentation : Flag<["-"], "forder-file-instrumentation">,
     Group<f_Group>, Flags<[CC1Option, CoreOption]>,
     HelpText<"Generate instrumented code to collect order file into default.profraw file (overridden by '=' form of option or LLVM_PROFILE_FILE env var)">;
+def fswift_async_fp_EQ : Joined<["-"], "fswift-async-fp=">,
+    Group<f_Group>, Flags<[CC1Option, CC1AsOption, CoreOption]>, MetaVarName<"<option>">,
+    HelpText<"Control emission of Swift async extended frame info (option: auto, always, never)">,
+    Values<"auto,always,never">,
+    NormalizedValuesScope<"CodeGenOptions::SwiftAsyncFramePointerKind">,
+    NormalizedValues<["Auto", "Always", "Never"]>,
+    MarshallingInfoFlag<"CodeGenOpts.SwiftAsyncFramePointer", "Auto">,
+    AutoNormalizeEnum;
 
 def fapinotes : Flag<["-"], "fapinotes">, Group<f_clang_Group>,
   Flags<[CC1Option]>, HelpText<"Enable external API notes support">;

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -566,6 +566,21 @@ static bool initTargetOptions(DiagnosticsEngine &Diags,
       CodeGenOpts.ValueTrackingVariableLocations;
   Options.XRayOmitFunctionIndex = CodeGenOpts.XRayOmitFunctionIndex;
 
+  switch (CodeGenOpts.getSwiftAsyncFramePointer()) {
+  case CodeGenOptions::SwiftAsyncFramePointerKind::Auto:
+    Options.SwiftAsyncFramePointer =
+        SwiftAsyncFramePointerMode::DeploymentBased;
+    break;
+
+  case CodeGenOptions::SwiftAsyncFramePointerKind::Always:
+    Options.SwiftAsyncFramePointer = SwiftAsyncFramePointerMode::Always;
+    break;
+
+  case CodeGenOptions::SwiftAsyncFramePointerKind::Never:
+    Options.SwiftAsyncFramePointer = SwiftAsyncFramePointerMode::Never;
+    break;
+  }
+
   Options.MCOptions.SplitDwarfFile = CodeGenOpts.SplitDwarfFile;
   Options.MCOptions.MCRelaxAll = CodeGenOpts.RelaxAll;
   Options.MCOptions.MCSaveTempLabels = CodeGenOpts.SaveTempLabels;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5605,6 +5605,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   RenderSCPOptions(TC, Args, CmdArgs);
   RenderTrivialAutoVarInitOptions(D, TC, Args, CmdArgs);
 
+  Args.AddLastArg(CmdArgs, options::OPT_fswift_async_fp_EQ);
+
   // Translate -mstackrealign
   if (Args.hasFlag(options::OPT_mstackrealign, options::OPT_mno_stackrealign,
                    false))

--- a/clang/test/CodeGen/swift-async-extended-fp.c
+++ b/clang/test/CodeGen/swift-async-extended-fp.c
@@ -1,0 +1,40 @@
+// RUN: %clang_cc1 -mframe-pointer=all -triple x86_64-apple-darwin10 -target-cpu core2 -S -o - %s | FileCheck %s --check-prefix=AUTO-X86
+// RUN: %clang_cc1 -mframe-pointer=all -triple x86_64-apple-darwin12 -target-cpu core2 -S -o - %s | FileCheck %s --check-prefix=ALWAYS-X86
+// RUN: %clang_cc1 -fswift-async-fp=never -mframe-pointer=all -triple x86_64-apple-darwin10 -target-cpu core2 -S -o - %s | FileCheck %s --check-prefix=NEVER-X86
+// RUN: %clang_cc1 -fswift-async-fp=never -mframe-pointer=all -triple x86_64-apple-darwin12 -target-cpu core2 -S -o - %s | FileCheck %s --check-prefix=NEVER-X86
+// RUN: %clang_cc1 -fswift-async-fp=auto -mframe-pointer=all -triple x86_64-apple-darwin10 -target-cpu core2 -S -o - %s | FileCheck %s --check-prefix=AUTO-X86
+// RUN: %clang_cc1 -fswift-async-fp=auto -mframe-pointer=all -triple x86_64-apple-darwin12 -target-cpu core2 -S -o - %s | FileCheck %s --check-prefix=ALWAYS-X86
+// RUN: %clang_cc1 -fswift-async-fp=always -mframe-pointer=all -triple x86_64-apple-darwin10 -target-cpu core2 -S -o - %s | FileCheck %s --check-prefix=ALWAYS-X86
+// RUN: %clang_cc1 -fswift-async-fp=always -mframe-pointer=all -triple x86_64-apple-darwin12 -target-cpu core2 -S -o - %s | FileCheck %s --check-prefix=ALWAYS-X86
+
+// RUN: %clang_cc1 -mframe-pointer=all -triple arm64-apple-ios9 -target-cpu cyclone -S -o - %s | FileCheck %s --check-prefix=AUTO-ARM64
+// RUN: %clang_cc1 -mframe-pointer=all -triple arm64-apple-ios15 -target-cpu cyclone -S -o - %s | FileCheck %s --check-prefix=ALWAYS-ARM64
+// RUN: %clang_cc1 -fswift-async-fp=never -mframe-pointer=all -triple arm64-apple-ios9 -target-cpu cyclone -S -o - %s | FileCheck %s --check-prefix=NEVER-ARM64
+// RUN: %clang_cc1 -fswift-async-fp=never -mframe-pointer=all -triple arm64-apple-ios15 -target-cpu cyclone -S -o - %s | FileCheck %s --check-prefix=NEVER-ARM64
+
+// REQUIRES: aarch64-registered-target,x86-registered-target
+
+#define SWIFTASYNCCALL __attribute__((swiftasynccall))
+#define ASYNC_CONTEXT __attribute__((swift_async_context))
+
+SWIFTASYNCCALL void async_context_1(ASYNC_CONTEXT void *ctx) {}
+
+// AUTO-X86: _async_context_1:
+// AUTO-X86:	_swift_async_extendedFramePointerFlags
+
+// ALWAYS-X86: _async_context_1:
+// ALWAYS-X86: btsq	$60
+
+// NEVER-X86: _async_context_1:
+// NEVER-X86-NOT:	_swift_async_extendedFramePointerFlags
+// NEVER-X86-NOT: btsq	$60
+
+// AUTO-ARM64: _async_context_1
+// AUTO-ARM64: _swift_async_extendedFramePointerFlags
+
+// ALWAYS-ARM64: _async_context_1
+// ALWAYS-ARM64: orr x29, x29, #0x1000000000000000
+
+// NEVER-ARM64: _async_context_1:
+// NEVER-ARM64-NOT:	_swift_async_extendedFramePointerFlags
+// NEVER-ARM64-NOT: orr x29, x29, #0x1000000000000000

--- a/llvm/include/llvm/CodeGen/CommandFlags.h
+++ b/llvm/include/llvm/CodeGen/CommandFlags.h
@@ -71,6 +71,8 @@ llvm::FloatABI::ABIType getFloatABIForCalls();
 
 llvm::FPOpFusion::FPOpFusionMode getFuseFPOps();
 
+SwiftAsyncFramePointerMode getSwiftAsyncFramePointer();
+
 bool getDontPlaceZerosInBSS();
 
 bool getEnableGuaranteedTailCallOpt();

--- a/llvm/include/llvm/Target/TargetOptions.h
+++ b/llvm/include/llvm/Target/TargetOptions.h
@@ -119,6 +119,17 @@ namespace llvm {
     DisableWithDiag // Disable the abort but emit a diagnostic on failure.
   };
 
+  /// Indicates when and how the Swift async frame pointer bit should be set.
+  enum class SwiftAsyncFramePointerMode {
+    /// Determine whether to set the bit statically or dynamically based
+    /// on the deployment target.
+    DeploymentBased,
+    /// Always set the bit.
+    Always,
+    /// Never set the bit.
+    Never,
+  };
+
   class TargetOptions {
   public:
     TargetOptions()
@@ -225,6 +236,11 @@ namespace llvm {
     /// EnableGlobalISelAbort - Control abort behaviour when global instruction
     /// selection fails to lower/select an instruction.
     GlobalISelAbortMode GlobalISelAbort = GlobalISelAbortMode::Enable;
+
+    /// Control when and how the Swift async frame pointer bit should
+    /// be set.
+    SwiftAsyncFramePointerMode SwiftAsyncFramePointer =
+        SwiftAsyncFramePointerMode::DeploymentBased;
 
     /// UseInitArray - Use .init_array instead of .ctors for static
     /// constructors.

--- a/llvm/lib/CodeGen/CommandFlags.cpp
+++ b/llvm/lib/CodeGen/CommandFlags.cpp
@@ -64,6 +64,7 @@ CGOPT(DenormalMode::DenormalModeKind, DenormalFP32Math)
 CGOPT(bool, EnableHonorSignDependentRoundingFPMath)
 CGOPT(FloatABI::ABIType, FloatABIForCalls)
 CGOPT(FPOpFusion::FPOpFusionMode, FuseFPOps)
+CGOPT(SwiftAsyncFramePointerMode, SwiftAsyncFramePointer)
 CGOPT(bool, DontPlaceZerosInBSS)
 CGOPT(bool, EnableGuaranteedTailCallOpt)
 CGOPT(bool, DisableTailCalls)
@@ -278,6 +279,18 @@ codegen::RegisterCodeGenFlags::RegisterCodeGenFlags() {
           clEnumValN(FPOpFusion::Strict, "off",
                      "Only fuse FP ops when the result won't be affected.")));
   CGBINDOPT(FuseFPOps);
+
+  static cl::opt<SwiftAsyncFramePointerMode> SwiftAsyncFramePointer(
+      "swift-async-fp",
+      cl::desc("Determine when the Swift async frame pointer should be set"),
+      cl::init(SwiftAsyncFramePointerMode::DeploymentBased),
+      cl::values(clEnumValN(SwiftAsyncFramePointerMode::DeploymentBased, "auto",
+                            "Determine based on deployment target"),
+                 clEnumValN(SwiftAsyncFramePointerMode::Always, "always",
+                            "Always set the bit"),
+                 clEnumValN(SwiftAsyncFramePointerMode::Never, "never",
+                            "Never set the bit")));
+  CGBINDOPT(SwiftAsyncFramePointer);
 
   static cl::opt<bool> DontPlaceZerosInBSS(
       "nozero-initialized-in-bss",
@@ -571,7 +584,7 @@ codegen::InitTargetOptionsFromCodeGenFlags(const Triple &TheTriple) {
   Options.ThreadModel = getThreadModel();
   Options.EABIVersion = getEABIVersion();
   Options.DebuggerTuning = getDebuggerTuningOpt();
-
+  Options.SwiftAsyncFramePointer = getSwiftAsyncFramePointer();
   return Options;
 }
 

--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -1110,22 +1110,32 @@ void AArch64FrameLowering::emitPrologue(MachineFunction &MF,
   // ORR is sufficient, it is assumed a Swift kernel would initialize the TBI
   // bits so that is still true.
   if (HasFP && AFI->hasSwiftAsyncContext()) {
-    if  (Subtarget.swiftAsyncContextIsDynamicallySet()) {
-      // The special symbol below is absolute and has a *value* that can be
-      // combined with the frame pointer to signal an extended frame.
-      BuildMI(MBB, MBBI, DL, TII->get(AArch64::LOADgot), AArch64::X16)
-          .addExternalSymbol("swift_async_extendedFramePointerFlags",
-                             AArch64II::MO_GOT);
-      BuildMI(MBB, MBBI, DL, TII->get(AArch64::ORRXrs), AArch64::FP)
-          .addUse(AArch64::FP)
-          .addUse(AArch64::X16)
-          .addImm(Subtarget.isTargetILP32() ? 32 : 0);
-    } else {
+    switch (MF.getTarget().Options.SwiftAsyncFramePointer) {
+    case SwiftAsyncFramePointerMode::DeploymentBased:
+      if (Subtarget.swiftAsyncContextIsDynamicallySet()) {
+        // The special symbol below is absolute and has a *value* that can be
+        // combined with the frame pointer to signal an extended frame.
+        BuildMI(MBB, MBBI, DL, TII->get(AArch64::LOADgot), AArch64::X16)
+            .addExternalSymbol("swift_async_extendedFramePointerFlags",
+                               AArch64II::MO_GOT);
+        BuildMI(MBB, MBBI, DL, TII->get(AArch64::ORRXrs), AArch64::FP)
+            .addUse(AArch64::FP)
+            .addUse(AArch64::X16)
+            .addImm(Subtarget.isTargetILP32() ? 32 : 0);
+        break;
+      }
+      LLVM_FALLTHROUGH;
+
+    case SwiftAsyncFramePointerMode::Always:
       // ORR x29, x29, #0x1000_0000_0000_0000
       BuildMI(MBB, MBBI, DL, TII->get(AArch64::ORRXri), AArch64::FP)
           .addUse(AArch64::FP)
           .addImm(0x1100)
           .setMIFlag(MachineInstr::FrameSetup);
+      break;
+
+    case SwiftAsyncFramePointerMode::Never:
+      break;
     }
   }
 

--- a/llvm/lib/Target/X86/X86FrameLowering.cpp
+++ b/llvm/lib/Target/X86/X86FrameLowering.cpp
@@ -1342,22 +1342,32 @@ void X86FrameLowering::emitPrologue(MachineFunction &MF,
   unsigned StackProbeSize = STI.getTargetLowering()->getStackProbeSize(MF);
 
   if (HasFP && X86FI->hasSwiftAsyncContext()) {
-    if (STI.swiftAsyncContextIsDynamicallySet()) {
-      // The special symbol below is absolute and has a *value* suitable to be
-      // combined with the frame pointer directly.
-      BuildMI(MBB, MBBI, DL, TII.get(X86::OR64rm), MachineFramePtr)
-          .addUse(MachineFramePtr)
-          .addUse(X86::RIP)
-          .addImm(1)
-          .addUse(X86::NoRegister)
-          .addExternalSymbol("swift_async_extendedFramePointerFlags",
-                             X86II::MO_GOTPCREL)
-          .addUse(X86::NoRegister);
-    } else {
+    switch (MF.getTarget().Options.SwiftAsyncFramePointer) {
+    case SwiftAsyncFramePointerMode::DeploymentBased:
+      if (STI.swiftAsyncContextIsDynamicallySet()) {
+        // The special symbol below is absolute and has a *value* suitable to be
+        // combined with the frame pointer directly.
+        BuildMI(MBB, MBBI, DL, TII.get(X86::OR64rm), MachineFramePtr)
+            .addUse(MachineFramePtr)
+            .addUse(X86::RIP)
+            .addImm(1)
+            .addUse(X86::NoRegister)
+            .addExternalSymbol("swift_async_extendedFramePointerFlags",
+                               X86II::MO_GOTPCREL)
+            .addUse(X86::NoRegister);
+        break;
+      }
+      LLVM_FALLTHROUGH;
+
+    case SwiftAsyncFramePointerMode::Always:
       BuildMI(MBB, MBBI, DL, TII.get(X86::BTS64ri8), MachineFramePtr)
           .addUse(MachineFramePtr)
           .addImm(60)
           .setMIFlag(MachineInstr::FrameSetup);
+      break;
+
+    case SwiftAsyncFramePointerMode::Never:
+      break;
     }
   }
 

--- a/llvm/test/CodeGen/AArch64/swift-dynamic-async-frame.ll
+++ b/llvm/test/CodeGen/AArch64/swift-dynamic-async-frame.ll
@@ -1,5 +1,8 @@
 ; RUN: llc -mtriple arm64-apple-ios15.0.0 %s -o - | FileCheck %s --check-prefix=CHECK-STATIC
+; RUN: llc -mtriple arm64-apple-ios15.0.0 -swift-async-fp=auto %s -o - | FileCheck %s --check-prefix=CHECK-STATIC
+; RUN: llc -mtriple arm64-apple-ios14.9.0 -swift-async-fp=always %s -o - | FileCheck %s --check-prefix=CHECK-STATIC
 ; RUN: llc -mtriple arm64-apple-ios14.9.0 %s -o - | FileCheck %s --check-prefix=CHECK-DYNAMIC
+; RUN: llc -mtriple arm64-apple-ios14.9.0 -swift-async-fp=auto %s -o - | FileCheck %s --check-prefix=CHECK-DYNAMIC
 ; RUN: llc -mtriple arm64-apple-tvos15.0.0 %s -o - | FileCheck %s --check-prefix=CHECK-STATIC
 ; RUN: llc -mtriple arm64-apple-tvos14.9.0 %s -o - | FileCheck %s --check-prefix=CHECK-DYNAMIC
 ; RUN: llc -mtriple arm64-apple-macosx12.0.0 %s -o - | FileCheck %s --check-prefix=CHECK-STATIC

--- a/llvm/test/CodeGen/X86/swift-dynamic-async-frame.ll
+++ b/llvm/test/CodeGen/X86/swift-dynamic-async-frame.ll
@@ -1,5 +1,9 @@
 ; RUN: llc -mtriple x86_64-apple-macosx12.0.0 %s -o - | FileCheck %s --check-prefix=CHECK-STATIC
+; RUN: llc -mtriple x86_64-apple-macosx12.0.0 -swift-async-fp=always %s -o - | FileCheck %s --check-prefix=CHECK-STATIC
+; RUN: llc -mtriple x86_64-apple-macosx12.0.0 -swift-async-fp=auto %s -o - | FileCheck %s --check-prefix=CHECK-STATIC
+; RUN: llc -mtriple x86_64-apple-macosx11.9.0 -swift-async-fp=always %s -o - | FileCheck %s --check-prefix=CHECK-STATIC
 ; RUN: llc -mtriple x86_64-apple-macosx11.9.0 %s -o - | FileCheck %s --check-prefix=CHECK-DYNAMIC
+; RUN: llc -mtriple x86_64-apple-macosx11.9.0 -swift-async-fp=auto %s -o - | FileCheck %s --check-prefix=CHECK-DYNAMIC
 
 ; CHECK-STATIC-LABEL: foo:
 ; CHECK-STATIC: btsq $60, %rbp


### PR DESCRIPTION
Introduce a new command-line flag `-swift-async-fp={auto|always|never}`
that controls how code generation sets the Swift extended async frame
info bit. There are three possibilities:

* `auto`: the default, which determines how to set the bit based on
deployment target, either statically or dynamically via
`swift_async_extendedFramePointerFlags`.
* `always`: always set the bit statically, regardless of deployment
target.
* `never`: never set the bit, regardless of deployment target.

Patch by Doug Gregor <dgregor@apple.com>

Differential Revision: https://reviews.llvm.org/D109392