### PR TITLE
Remove unnecessary assertion and add a testcase.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2317,9 +2317,8 @@ lldb::Encoding TypeSystemSwiftTypeRef::GetEncoding(opaque_compiler_type_t type,
       return referent_type.GetEncoding(count);
     }
     default:
-      assert(false && "Unhandled node kind");
       LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
-                "GetEncoding: Unhandled node kind for type %s",
+                "No encoding for type %s",
                 AsMangledName(type));
       break;
     }

--- a/lldb/test/API/lang/swift/enum_as_value/Makefile
+++ b/lldb/test/API/lang/swift/enum_as_value/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/enum_as_value/TestSwiftEnumAsValue.py
+++ b/lldb/test/API/lang/swift/enum_as_value/TestSwiftEnumAsValue.py
@@ -1,0 +1,22 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftAnyType(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    def test_any_type(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
+
+        frame = thread.frames[0]
+        var_e = frame.FindVariable("e")
+        # We don't have an encoding for enums.
+        self.assertEqual(var_e.GetValueAsSigned(0xdead), 0xdead)
+        self.assertEqual(var_e.GetValue(), 'B')

--- a/lldb/test/API/lang/swift/enum_as_value/main.swift
+++ b/lldb/test/API/lang/swift/enum_as_value/main.swift
@@ -1,0 +1,10 @@
+enum E {
+case A
+case B
+}
+func main(_ e: E) {
+    print(e) // Set breakpoint here
+}
+
+main(.B)
+


### PR DESCRIPTION
TypeSystemSwiftTypeRef::GetEncoding() had an assert(false) in the
default path of the switch because we had no test coverage for
it. This patch adds test coverage and removes the assert.

Xcode is calling GetValueAsUnsigned() on enum locals, which we found
out thanks to this assertion.

Fixes https://bugs.swift.org/browse/SR-15127.