### PR TITLE
[5.5] Revert "[llvm-cov] reset executation count to 0 after wrapped segment"

### DIFF
--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -794,7 +794,6 @@ LineCoverageStats::LineCoverageStats(
     ExecutionCount = WrappedSegment->Count;
   if (!MinRegionCount)
     return;
-  ExecutionCount = 0;
   for (const auto *LS : LineSegments)
     if (isStartOfRegion(LS))
       ExecutionCount = std::max(ExecutionCount, LS->Count);

--- a/llvm/test/tools/llvm-cov/Inputs/instrprof-comdat.h
+++ b/llvm/test/tools/llvm-cov/Inputs/instrprof-comdat.h
@@ -12,7 +12,7 @@ template <class T> T FOO<T>::DoIt(T ti) { // HEADER: [[@LINE]]|  2|template
   for (T I = 0; I < ti; I++) {            // HEADER: [[@LINE]]| 22|  for (T
     t += I;                               // HEADER: [[@LINE]]| 20|   t += I;
     if (I > ti / 2)                       // HEADER: [[@LINE]]| 20|   if (I > ti
-      t -= 1;                             // HEADER: [[@LINE]]|  8|     t -= 1;
+      t -= 1;                             // HEADER: [[@LINE]]| 20|     t -= 1;
   }                                       // HEADER: [[@LINE]]| 20| }
                                           // HEADER: [[@LINE]]|  2|
   return t;                               // HEADER: [[@LINE]]|  2|  return t;

--- a/llvm/test/tools/llvm-cov/branch-logical-mixed.cpp
+++ b/llvm/test/tools/llvm-cov/branch-logical-mixed.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
 
 // REPORT: Name                        Regions    Miss   Cover     Lines    Miss   Cover  Branches    Miss   Cover
 // REPORT-NEXT: ---
-// REPORT-NEXT: _Z4funcii                        77       9  88.31%        68       10  85.29%        80      32  60.00%
+// REPORT-NEXT: _Z4funcii                        77       9  88.31%        68       3  95.59%        80      32  60.00%
 // REPORT-NEXT: main                              1       0 100.00%         5       0 100.00%         0       0   0.00%
 // REPORT-NEXT: ---
-// REPORT-NEXT: TOTAL                            78       9  88.46%        73       10  86.30%        80      32  60.00%
+// REPORT-NEXT: TOTAL                            78       9  88.46%        73       3  95.89%        80      32  60.00%

--- a/llvm/test/tools/llvm-cov/branch-noShowBranch.test
+++ b/llvm/test/tools/llvm-cov/branch-noShowBranch.test
@@ -20,6 +20,6 @@
 // REPORT-NOT: do_fallthrough                    9       0 100.00%        12       0 100.00%         6       0 100.00%
 // REPORT-NOT: main                              1       0 100.00%        16       0 100.00%         0       0   0.00%
 // REPORT-NOT: c-general.c:static_func           4       0 100.00%         4       0 100.00%         2       0 100.00%
-// REPORT: TOTAL                           197      24  87.82%       234       13  94.44%
+// REPORT: TOTAL                           197      24  87.82%       234       8  96.58%
 // REPORT-NOT: TOTAL                           197      24  87.82%       234       13  94.44%       174      38  78.16%
 

--- a/llvm/test/tools/llvm-cov/ignore-filename-regex.test
+++ b/llvm/test/tools/llvm-cov/ignore-filename-regex.test
@@ -22,7 +22,7 @@ REPORT_IGNORE_DIR-NOT: {{.*}}extra{{[/\\]}}dec.h{{.*}}
 REPORT_IGNORE_DIR-NOT: {{.*}}extra{{[/\\]}}inc.h{{.*}}
 REPORT_IGNORE_DIR: {{.*}}abs.h{{.*}}
 REPORT_IGNORE_DIR: {{.*}}main.cc{{.*}}
-REPORT_IGNORE_DIR: {{^}}TOTAL 5{{.*}}90.00%{{$}}
+REPORT_IGNORE_DIR: {{^}}TOTAL 5{{.*}}100.00%{{$}}
 
 # Ignore all files from "extra" directory even when SOURCES specified.
 RUN: llvm-cov report -instr-profile %S/Inputs/sources_specified/main.profdata \
@@ -35,7 +35,7 @@ REPORT_IGNORE_DIR_WITH_SOURCES-NOT: {{.*}}extra{{[/\\]}}dec.h{{.*}}
 REPORT_IGNORE_DIR_WITH_SOURCES-NOT: {{.*}}extra{{[/\\]}}inc.h{{.*}}
 REPORT_IGNORE_DIR_WITH_SOURCES-NOT: {{.*}}main.cc{{.*}}
 REPORT_IGNORE_DIR_WITH_SOURCES: {{.*}}abs.h{{.*}}
-REPORT_IGNORE_DIR_WITH_SOURCES: {{^}}TOTAL 4{{.*}}80.00%{{$}}
+REPORT_IGNORE_DIR_WITH_SOURCES: {{^}}TOTAL 4{{.*}}100.00%{{$}}
 
 ########################
 # Test "show" command.

--- a/llvm/unittests/ProfileData/CoverageMappingTest.cpp
+++ b/llvm/unittests/ProfileData/CoverageMappingTest.cpp
@@ -675,7 +675,7 @@ TEST_P(CoverageMappingTest, test_line_coverage_iterator) {
   CoverageData Data = LoadedCoverage->getCoverageForFile("file1");
 
   unsigned Line = 0;
-  unsigned LineCounts[] = {20, 20, 20, 20, 10, 10, 10, 10, 10, 0, 0};
+  unsigned LineCounts[] = {20, 20, 20, 20, 30, 10, 10, 10, 10, 0, 0};
   for (const auto &LCS : getLineCoverageStats(Data)) {
     ASSERT_EQ(Line + 1, LCS.getLine());
     errs() << "Line: " << Line + 1 << ", count = " << LCS.getExecutionCount() << "\n";


### PR DESCRIPTION
This was discovered to break Swift's code coverage analysis, but wasn't
picked after being reverted upstream.

More info: https://reviews.llvm.org/D85036 https://bugs.llvm.org/show_bug.cgi?id=49297

Differential Revision: https://reviews.llvm.org/D98084

(cherry picked from commit 8d5c3ae357b5f78a004427c39934f6881ae41544)