### PR TITLE
[5.5] Revert "[VFS] Fix inconsistencies between relative paths and fallthrough in the RedirectingFileSystem"

### DIFF
--- a/llvm/include/llvm/Support/VirtualFileSystem.h
+++ b/llvm/include/llvm/Support/VirtualFileSystem.h
@@ -734,7 +734,9 @@ private:
   friend class RedirectingFSDirIterImpl;
   friend class RedirectingFileSystemParser;
 
-  bool shouldUseExternalFS() const { return IsFallthrough; }
+  bool shouldUseExternalFS() const {
+    return ExternalFSValidWD && IsFallthrough;
+  }
 
   /// Canonicalize path by removing ".", "..", "./", components. This is
   /// a VFS request, do not bother about symlinks in the path components
@@ -761,6 +763,9 @@ private:
 
   /// The current working directory of the file system.
   std::string WorkingDirectory;
+
+  /// Whether the current working directory is valid for the external FS.
+  bool ExternalFSValidWD = false;
 
   /// The file system to use for external references.
   IntrusiveRefCntPtr<FileSystem> ExternalFS;
@@ -813,7 +818,7 @@ public:
   /// Looks up \p Path in \c Roots and returns a LookupResult giving the
   /// matched entry and, if the entry was a FileEntry or DirectoryRemapEntry,
   /// the path it redirects to in the external file system.
-  ErrorOr<LookupResult> lookupPath(StringRef Path) const;
+  ErrorOr<LookupResult> lookupPath(const Twine &Path) const;
 
   /// Parses \p Buffer, which is expected to be in YAML format and
   /// returns a virtual file system representing its contents.

--- a/llvm/unittests/Support/VirtualFileSystemTest.cpp
+++ b/llvm/unittests/Support/VirtualFileSystemTest.cpp
@@ -2373,8 +2373,7 @@ TEST_F(VFSFromYAMLTest, WorkingDirectoryFallthroughInvalid) {
   EXPECT_TRUE(Status->exists());
 
   Status = FS->status("foo/a");
-  ASSERT_FALSE(Status.getError());
-  EXPECT_TRUE(Status->exists());
+  ASSERT_TRUE(Status.getError());
 }
 
 TEST_F(VFSFromYAMLTest, VirtualWorkingDirectory) {


### PR DESCRIPTION
This fixes https://bugs.swift.org/browse/SR-15123 where `#fileID` and
friends, and error messages, when using a vfsoverlay would always be
absolute paths even when the file paths to the invocation were relative.

This likely isn't the right long term fix, but is likely the safest fix
for now.

This reverts 0be9ca7c0f9a733f846bb6bc4e8e36d46b518162