### PR TITLE
Target: explicitly handle `.swift1_autolink_entries`

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -761,6 +761,8 @@ static MCSection *selectExplicitSectionGlobal(
   StringRef Group = "";
   bool IsComdat = false;
   unsigned Flags = getELFSectionFlags(Kind);
+  if (SectionName == ".swift1_autolink_entries")
+    Flags |= ELF::SHF_EXCLUDE;
   if (const Comdat *C = getELFComdat(GO)) {
     Group = C->getName();
     IsComdat = C->getSelectionKind() == Comdat::Any;

--- a/llvm/lib/Target/TargetLoweringObjectFile.cpp
+++ b/llvm/lib/Target/TargetLoweringObjectFile.cpp
@@ -215,6 +215,9 @@ SectionKind TargetLoweringObjectFile::getKindForGlobal(const GlobalObject *GO,
   // Global variables require more detailed analysis.
   const auto *GVar = cast<GlobalVariable>(GO);
 
+  if (GVar->getSection() == ".swift1_autolink_entries")
+    return SectionKind::getMetadata();
+
   // Handle thread-local data first.
   if (GVar->isThreadLocal()) {
     if (isSuitableForBSS(GVar) && !TM.Options.NoZerosInBSS) {


### PR DESCRIPTION
This is being applied downstream as the section is not a standard
section and this is Swift centric.  The longer term solution here is to
drop support for gold as a linker as we have done for the BFD linker.
With the use of LLD, we can use a LLVM extension to inject linker
options into ELF.  This has a corresponding change to Swift to remove
the previous ELF specific gadget to discard the metadata.

rdar://82640394