### PR TITLE
Copy an info diagnostic's fixits to previous error one if same location

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2816,6 +2816,26 @@ public:
         break;
       }
 
+      // Swift may insert note diagnostics after an error diagnostic with fixits
+      // related to that error. Check if the latest inserted diagnostic is an
+      // error one, and that the diagnostic being processed is a note one that
+      // points to the same error, and if so, copy the fixits from the note
+      // diagnostic to the error one. There may be subsequent notes with fixits
+      // related to the same error, but we only copy the first one as the fixits
+      // are mutually exclusive (for example, one may suggest inserting a '?'
+      // and the next may suggest inserting '!')
+      if (!m_raw_diagnostics.empty() &&
+          info.Kind == swift::DiagnosticKind::Note) {
+        auto &last_diagnostic = m_raw_diagnostics.back();
+        if (last_diagnostic.kind == swift::DiagnosticKind::Error &&
+            last_diagnostic.fixits.empty() &&
+            last_diagnostic.bufferID == bufferID &&
+            last_diagnostic.column == line_col.second &&
+            last_diagnostic.line == line_col.first)
+          last_diagnostic.fixits.insert(last_diagnostic.fixits.end(),
+                                        info.FixIts.begin(), info.FixIts.end());
+      }
+
       // Translate ranges.
       llvm::SmallVector<llvm::SMRange, 2> ranges;
       for (auto R : info.Ranges)

--- a/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
+++ b/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
@@ -65,9 +65,16 @@ class TestSwiftFixIts(TestBase):
         options = lldb.SBExpressionOptions()
         options.SetAutoApplyFixIts(False)
 
-        # First make sure the expression fails with no fixits:
+        # First make sure the expressions fail with no fixits:
         value = frame.EvaluateExpression(
             "var $tmp : Int = does_have.could_be!!", options)
+        self.assertTrue(value.GetError().Fail())
+        self.assertTrue(
+            value.GetError().GetError() != 0x1001,
+            'Failure was not "no return type"')
+
+        value = frame.EvaluateExpression(
+                "var $tmp2 = wrapper.wrapped", options)
         self.assertTrue(value.GetError().Fail())
         self.assertTrue(
             value.GetError().GetError() != 0x1001,
@@ -83,8 +90,13 @@ class TestSwiftFixIts(TestBase):
             value.GetError().GetError() == 0x1001,
             'This error is "no return type"')
 
-        # Check that the expression was correct:
+        # Check that the expressions were correct:
         tmp_value = frame.EvaluateExpression("$tmp == 100")
         self.assertTrue(tmp_value.GetError().Success())
         self.assertTrue(tmp_value.GetSummary() == 'true')
-
+        
+        value = frame.EvaluateExpression(
+                "var $tmp2 = wrapper.wrapped", options)
+        tmp_value = frame.EvaluateExpression("$tmp2 == 7")
+        self.assertTrue(tmp_value.GetError().Success())
+        self.assertTrue(tmp_value.GetSummary() == 'true')

--- a/lldb/test/API/lang/swift/fixits/main.swift
+++ b/lldb/test/API/lang/swift/fixits/main.swift
@@ -10,6 +10,10 @@
 //
 // -----------------------------------------------------------------------------
 
+class Wrapper {
+  let wrapped = 7
+}
+
 class HasOptional
 {
     var could_be : Int?
@@ -38,7 +42,7 @@ class HasOptional
 func main() -> Int 
 {
     let does_have = HasOptional(input: 100)
-
+    let wrapper: Wrapper? = Wrapper()
     print ("\(does_have.returnIt()): break here to test fixits.")
     return 0
 }


### PR DESCRIPTION
Swift may insert note diagnostics after an error diagnostic with fixits
related to that error. Check if the lastest inserted diagnostic is an
error one, and that the diagnostic being processed is a note one that
points to the same error, and if so, copy the fixits from the note
diagnostic to the error one. There may be subsequent notes with fixits
related to the same error, but we only copy the first one as the fixits
are mutually exclusive (for example, one may suggest inserting a '?'
and the next may suggest inserting '!'