### PR TITLE
[lldb] Remove SBExecutionContext::reset (NFC)

### DIFF
--- a/lldb/include/lldb/API/SBExecutionContext.h
+++ b/lldb/include/lldb/API/SBExecutionContext.h
@@ -50,8 +50,6 @@ public:
   SBFrame GetFrame() const;
 
 protected:
-  void reset(lldb::ExecutionContextRefSP &event_sp);
-
   lldb_private::ExecutionContextRef *get() const;
 
 private:


### PR DESCRIPTION
This is a protected function that's not implemented.

(cherry picked from commit c96d45700f6d3cb2b8d1972bb8de03522b3ff8d7)
