### PR TITLE
[lldb] Name UnsafePointer's single child 'pointee'

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/swift-unsafe/main.swift
+++ b/lldb/test/API/functionalities/data-formatter/swift-unsafe/main.swift
@@ -75,7 +75,12 @@ func main() {
   //% self.expect("frame variable -d run-target unsafe_ptr",
   //%            patterns=[
   //%            '\(UnsafePointer<(.*)\.ColorCode>\) unsafe_ptr = 0[xX][0-9a-fA-F]+ {',
-  //%            '\[0\] = RGB {',
+  //%            'pointee = RGB {',
+  //%            'RGB = \(0 = 155, 1 = 219, 2 = 255\)'
+  //%            ])
+  //% self.expect("frame variable -d run-target unsafe_ptr.pointee",
+  //%            patterns=[
+  //%            'pointee = RGB {',
   //%            'RGB = \(0 = 155, 1 = 219, 2 = 255\)'
   //%            ])
 
@@ -83,7 +88,11 @@ func main() {
   //% self.expect("frame variable -d run-target unsafe_mutable_ptr",
   //%            patterns=[
   //%            '\(UnsafeMutablePointer<(.*)\.ColorCode>\) unsafe_mutable_ptr = 0[xX][0-9a-fA-F]+ {',
-  //%            '\[0\] = Hex \(Hex = 4539903\)'
+  //%            'pointee = Hex \(Hex = 4539903\)'
+  //%            ])
+  //% self.expect("frame variable -d run-target unsafe_mutable_ptr.pointee",
+  //%            patterns=[
+  //%            'pointee = Hex \(Hex = 4539903\)'
   //%            ])
 
   let unsafe_raw_ptr = UnsafeRawPointer(&colors[0])


### PR DESCRIPTION
Currently, the builtin formatter for `UnsafePointer` and `UnsafeMutablePointer` provide a single child, which is named `[0]`. This changes that child to be named `pointee`. This has two advantages:

First, it enables `v ptr.pointee` to work, which matches `p ptr.pointee`. This is typically how unsafe pointers access their contents, not via subscript.

Second, it avoids a behavior that looks like a bug to the user. For example:

```swift
let ptr = UnsafeMutablePointer<Int>.allocate(capacity: 2)
ptr[0] = 41
ptr[1] = 23
print(ptr) // break here
```

On that last line, running `v ptr` produces:

```swift
(lldb) v ptr
(UnsafeMutablePointer<Int>) ptr = 0x100404080 {
  [0] = 41
}
```

Both `UnsafePointer` and `UnsafeMutablePointer` will only ever print the single child. A user may think their data is wrong, when it's in fact correct (because they aren't shown the second value). Or, they might think lldb has a bug, when in fact printing a single child expected behavior. Unless I have missed something, `Unsafe(Mutable)?Pointer` does not capture state that would indicate it was created with a specific capacity, that information is "erased". If a capacity were available at runtime, lldb could print all of the children.

Note that with this change `v ptr[0]` still succeeds, so that behavior is maintained. Also note that `v ptr[1]` does not currently work regardless of whether it's valid. This is because the provider reports only 1 child. The work around is to run `p ptr[1]`.

After this change, the above `v` command prints:

```swift
(lldb) v ptr
(UnsafeMutablePointer<Int>) ptr = 0x100404080 {
  pointee = 41
}
```

rdar://83155374