### PR TITLE
Rebranch: Turn on swiftasync for i386.

### DIFF
--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -353,12 +353,11 @@ public:
     case CC_C:
     case CC_PreserveMost:
     case CC_Swift:
+    case CC_SwiftAsync:
     case CC_X86Pascal:
     case CC_IntelOclBicc:
     case CC_OpenCLKernel:
       return CCCR_OK;
-    case CC_SwiftAsync:
-      return CCCR_Error;
     default:
       return CCCR_Warning;
     }

--- a/clang/test/CodeGen/swift-async-call-conv.c
+++ b/clang/test/CodeGen/swift-async-call-conv.c
@@ -3,12 +3,14 @@
 // RUN: %clang_cc1 -triple armv7-apple-darwin9 -emit-llvm -o - %s | FileCheck %s
 // RUN: %clang_cc1 -triple armv7s-apple-ios9 -emit-llvm -o - %s | FileCheck %s
 // RUN: %clang_cc1 -triple armv7k-apple-ios9 -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple i386-apple-watchos2 -emit-llvm -o - %s | FileCheck %s
 
 // RUN: %clang_cc1 -x c++ -triple x86_64-apple-darwin10 -target-cpu core2 -emit-llvm -o - %s | FileCheck %s --check-prefix=CHECK --check-prefix=CPPONLY
 // RUN: %clang_cc1 -x c++ -triple arm64-apple-ios9 -target-cpu cyclone -emit-llvm -o - %s | FileCheck %s --check-prefix=CHECK --check-prefix=CPPONLY
 // RUN: %clang_cc1 -x c++ -triple armv7-apple-darwin9 -emit-llvm -o - %s | FileCheck %s --check-prefix=CHECK --check-prefix=CPPONLY
 // RUN: %clang_cc1 -x c++ -triple armv7s-apple-ios9 -emit-llvm -o - %s | FileCheck %s --check-prefix=CHECK --check-prefix=CPPONLY
 // RUN: %clang_cc1 -x c++ -triple armv7k-apple-ios9 -emit-llvm -o - %s | FileCheck %s --check-prefix=CHECK --check-prefix=CPPONLY
+// RUN: %clang_cc1 -x c++ -triple i386-apple-watchos2 -emit-llvm -o - %s | FileCheck %s --check-prefix=CHECK --check-prefix=CPPONLY
 
 // Test tail call behavior when a swiftasynccall function is called
 // from another swiftasynccall function.


### PR DESCRIPTION
Cherry-picking the cherry-pick PR: https://github.com/apple/llvm-project/pull/2797/
rdar://83249830

This patch is necessary to allow concurrency to run on the i386 watchOS simulator.

(cherry picked from commit 8c462e79b60e82a758b6aa1587dc156d30c6d850)

It was reverted in bcbe5a8cdbb3f3e949c565236ca181486d69f815,
due to LLVM-side issues, but those should be fixed with
apple/llvm-project PRs #2788 and #2790.
