### PR TITLE
[LLDB][Swift] Use the new mangleNode() return type correctly.

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2068,7 +2068,10 @@ SwiftLanguageRuntimeImpl::BindGenericTypeParameters(StackFrame &stack_frame,
 
   // Nothing to do if there are no type parameters.
   auto get_canonical = [&]() {
-    return ts.GetTypeFromMangledTypename(ConstString(mangleNode(canonical)));
+    auto mangling = mangleNode(canonical);
+    if (!mangling.isSuccess())
+      return CompilerType();
+    return ts.GetTypeFromMangledTypename(ConstString(mangling.result()));
   };
   if (substitutions.empty())
     return get_canonical();
@@ -2531,7 +2534,10 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_ClangType(
     c->addChild(factory.createNode(Node::Kind::Identifier, dyn_name), factory);
     cty->addChild(c, factory);
 
-    remangled = mangleNode(global);
+    auto mangling = mangleNode(global);
+    if (!mangling.isSuccess())
+      return false;
+    remangled = mangling.result();
   }
 
   // Import the remangled dynamic name into the scratch context.

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -88,7 +88,7 @@ public:
     return GlobalTypeMangling(Node(Node::Kind::Type, type));
   }
 
-  std::string Mangle(NodePointer node) { return mangleNode(node); }
+  std::string Mangle(NodePointer node) { return mangleNode(node).result(); }
 };
 
 TEST_F(TestTypeSystemSwiftTypeRef, Array) {


### PR DESCRIPTION
The return type of `mangleNode()` is changing to allow the remanglers to report errors to the caller.  Change the LLDB plugin to account for that, and try to handle errors more reasonably (previously they would have resulted in program termination).

See also https://github.com/apple/swift/pull/39187

(This is a cherry pick of apple/llvm-project#3235.)

rdar://79725187