### PR TITLE
Restore HotColdSplit pass manager customization - 🍒 5295edef5ccbfc642…

### DIFF
--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -1109,7 +1109,7 @@ PassBuilder::buildModuleOptimizationPipeline(OptimizationLevel Level,
   // Split out cold code. Splitting is done late to avoid hiding context from
   // other optimizations and inadvertently regressing performance. The tradeoff
   // is that this has a higher code size cost than splitting early.
-  if (EnableHotColdSplit && !LTOPreLink)
+  if ((EnableHotColdSplit || SplitColdCode) && !LTOPreLink)
     MPM.addPass(HotColdSplittingPass());
 
   // Search the code for similar regions of code. If enough similar regions can
@@ -1578,7 +1578,7 @@ PassBuilder::buildLTODefaultPipeline(OptimizationLevel Level,
 
   // Enable splitting late in the FullLTO post-link pipeline. This is done in
   // the same stage in the old pass manager (\ref addLateLTOOptimizationPasses).
-  if (EnableHotColdSplit)
+  if (EnableHotColdSplit || SplitColdCode)
     MPM.addPass(HotColdSplittingPass());
 
   // Add late LTO optimization passes.


### PR DESCRIPTION
…d1730ee7eb6ba611e972475

These were originally added in:
4538539bcc1d029ac3b8e974ba9edea1bc2d3551

And subsequently dropped in:
4223c94fac065e1a7da5a42988ea76851cf1cbae

Breaking:
clang/test/CodeGen/split-cold-code.c

rdar://83249619