### PR TITLE
[lldb] Show fix-it applied even if expression didn't evaluate succesfully

### DIFF
--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -438,9 +438,8 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
   // We only tell you about the FixIt if we applied it.  The compiler errors
   // will suggest the FixIt if it parsed.
   if (!m_fixed_expression.empty() && target.GetEnableNotifyAboutFixIts()) {
-    if (success == eExpressionCompleted)
-      error_stream.Printf("  Fix-it applied, fixed expression was: \n    %s\n",
-                          m_fixed_expression.c_str());
+    error_stream.Printf("  Fix-it applied, fixed expression was: \n    %s\n",
+                        m_fixed_expression.c_str());
   }
 
   if (result_valobj_sp) {

--- a/lldb/test/API/commands/expression/fixits/main.cpp
+++ b/lldb/test/API/commands/expression/fixits/main.cpp
@@ -17,6 +17,7 @@ main()
 {
   struct MyStruct my_struct = {10, {20, 30}};
   struct MyStruct *my_pointer = &my_struct;
+  struct MyStruct *null_pointer = nullptr;
   printf ("Stop here to evaluate expressions: %d %d %p\n", my_pointer->first, my_pointer->second.a, my_pointer);
   return 0;
 }


### PR DESCRIPTION
If we applied a fix-it before evaluating an expression and that
expression didn't evaluate correctly, we should still tell users about
the fix-it we applied since that may be the reason why it didn't work
correctly.

Differential Revision: https://reviews.llvm.org/D109908

(cherry picked from commit fbaf36721783c3bcbd45f81294e6980eaef165e4)