### PR TITLE
[LLDB][Swift] Use the new mangleNode() return type correctly.

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2039,7 +2039,10 @@ SwiftLanguageRuntimeImpl::BindGenericTypeParameters(StackFrame &stack_frame,
 
   // Nothing to do if there are no type parameters.
   auto get_canonical = [&]() {
-    return ts.GetTypeFromMangledTypename(ConstString(mangleNode(canonical)));
+    auto mangling = mangleNode(canonical);
+    if (!mangling.isSuccess())
+      return CompilerType();
+    return ts.GetTypeFromMangledTypename(ConstString(mangling.result()));
   };
   if (substitutions.empty())
     return get_canonical();
@@ -2502,7 +2505,10 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_ClangType(
     c->addChild(factory.createNode(Node::Kind::Identifier, dyn_name), factory);
     cty->addChild(c, factory);
 
-    remangled = mangleNode(global);
+    auto mangling = mangleNode(global);
+    if (!mangling.isSuccess())
+      return false;
+    remangled = mangling.result();
   }
 
   // Import the remangled dynamic name into the scratch context.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -139,14 +139,15 @@ TypeSystemSwiftTypeRef::GetBaseName(swift::Demangle::NodePointer node) {
 }
 
 /// Create a mangled name for a type alias node.
-static ConstString GetTypeAlias(swift::Demangle::Demangler &dem,
-                                swift::Demangle::NodePointer node) {
+static swift::Demangle::ManglingErrorOr<std::string>
+GetTypeAlias(swift::Demangle::Demangler &dem,
+             swift::Demangle::NodePointer node) {
   using namespace swift::Demangle;
   auto global = dem.createNode(Node::Kind::Global);
   auto type_mangling = dem.createNode(Node::Kind::TypeMangling);
   global->addChild(type_mangling, dem);
   type_mangling->addChild(node, dem);
-  return ConstString(mangleNode(global));
+  return mangleNode(global);
 }
 
 /// Find a Clang type by name in the modules in \p module_holder.
@@ -360,7 +361,14 @@ ResolveTypeAlias(SwiftASTContext *module_holder,
   // Try to look this up as a Swift type alias. For each *Swift*
   // type alias there is a debug info entry that has the mangled
   // name as name and the aliased type as a type.
-  ConstString mangled = GetTypeAlias(dem, node);
+  auto mangling = GetTypeAlias(dem, node);
+  if (!mangling.isSuccess()) {
+    LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
+              "Failed while mangling type alias (%d:%u)", mangling.error().code,
+              mangling.error().line);
+    return {{}, {}};
+  }
+  ConstString mangled(mangling.result());
   TypeList types;
   if (!prefer_clang_types) {
     llvm::DenseSet<SymbolFile *> searched_symbol_files;
@@ -1365,7 +1373,10 @@ bool TypeSystemSwiftTypeRef::Verify(opaque_compiler_type_t type) {
   using namespace swift::Demangle;
   Demangler dem;
   NodePointer node = dem.demangleSymbol(str);
-  std::string remangled = mangleNode(node);
+  auto mangling = mangleNode(node);
+  if (!mangling.isSuccess())
+    return false;
+  std::string remangled = mangling.result();
   return remangled == std::string(str);
 }
 
@@ -1509,10 +1520,14 @@ template <> bool Equivalent<CompilerType>(CompilerType l, CompilerType r) {
   if (ContainsUnresolvedTypeAlias(r_node) ||
       ContainsGenericTypeParameter(r_node) || ContainsSugaredParen(r_node))
     return true;
-  if (swift::Demangle::mangleNode(StripPrivateIDs(
-          dem, TypeSystemSwiftTypeRef::CanonicalizeSugar(dem, l_node))) ==
-      swift::Demangle::mangleNode(StripPrivateIDs(
-          dem, TypeSystemSwiftTypeRef::CanonicalizeSugar(dem, r_node))))
+  auto l_mangling = swift::Demangle::mangleNode(StripPrivateIDs(
+      dem, TypeSystemSwiftTypeRef::CanonicalizeSugar(dem, l_node)));
+  auto r_mangling = swift::Demangle::mangleNode(StripPrivateIDs(
+      dem, TypeSystemSwiftTypeRef::CanonicalizeSugar(dem, r_node)));
+  if (!l_mangling.isSuccess() || !r_mangling.isSuccess())
+    return false;
+
+  if (l_mangling.result() == r_mangling.result())
     return true;
 
   // SwiftASTContext hardcodes some less-precise types.
@@ -1678,7 +1693,10 @@ TypeSystemSwiftTypeRef::RemangleAsType(swift::Demangle::Demangler &dem,
   auto type_mangling = dem.createNode(Node::Kind::TypeMangling);
   type_mangling->addChild(node, dem);
   global->addChild(type_mangling, dem);
-  ConstString mangled_element(mangleNode(global));
+  auto mangling = mangleNode(global);
+  if (!mangling.isSuccess())
+    return {};
+  ConstString mangled_element(mangling.result());
   return GetTypeFromMangledTypename(mangled_element);
 }
 
@@ -1985,7 +2003,16 @@ ConstString TypeSystemSwiftTypeRef::GetTypeName(opaque_compiler_type_t type) {
     Demangler dem;
     NodePointer print_node =
         GetDemangleTreeForPrinting(dem, AsMangledName(type), true);
-    std::string remangled = mangleNode(print_node);
+    auto mangling = mangleNode(print_node);
+    std::string remangled;
+    if (mangling.isSuccess())
+      remangled = mangling.result();
+    else {
+      std::ostringstream buf;
+      buf << "<mangling error " << mangling.error().code << ":"
+          << mangling.error().line << ">";
+      remangled = buf.str();
+    }
     return ConstString(SwiftLanguageRuntime::DemangleSymbolAsString(
         remangled, SwiftLanguageRuntime::eTypeName));
   };
@@ -2001,7 +2028,16 @@ TypeSystemSwiftTypeRef::GetDisplayTypeName(opaque_compiler_type_t type,
     Demangler dem;
     NodePointer print_node =
         GetDemangleTreeForPrinting(dem, AsMangledName(type), false);
-    std::string remangled = mangleNode(print_node);
+    auto mangling = mangleNode(print_node);
+    std::string remangled;
+    if (mangling.isSuccess())
+      remangled = mangling.result();
+    else {
+      std::ostringstream buf;
+      buf << "<mangling error " << mangling.error().code << ":"
+          << mangling.error().line << ">";
+      remangled = buf.str();
+    }
     return ConstString(SwiftLanguageRuntime::DemangleSymbolAsString(
         remangled, SwiftLanguageRuntime::eDisplayTypeName, sc));
   };
@@ -2085,7 +2121,10 @@ TypeSystemSwiftTypeRef::GetCanonicalType(opaque_compiler_type_t type) {
       CompilerType ast_type = ReconstructType({this, type}).GetCanonicalType();
       return GetTypeFromMangledTypename(ast_type.GetMangledTypeName());
     }
-    ConstString mangled(mangleNode(canonical));
+    auto mangling = mangleNode(canonical);
+    if (!mangling.isSuccess())
+      return CompilerType();
+    ConstString mangled(mangling.result());
     return GetTypeFromMangledTypename(mangled);
   };
   VALIDATE_AND_RETURN(impl, GetCanonicalType, type, (ReconstructType(type)),

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -88,7 +88,7 @@ public:
     return GlobalTypeMangling(Node(Node::Kind::Type, type));
   }
 
-  std::string Mangle(NodePointer node) { return mangleNode(node); }
+  std::string Mangle(NodePointer node) { return mangleNode(node).result(); }
 };
 
 TEST_F(TestTypeSystemSwiftTypeRef, Array) {


### PR DESCRIPTION
The return type of `mangleNode()` is changing to allow the remanglers to
report errors to the caller.  Change the LLDB plugin to account for that,
and try to handle errors more reasonably (previously they would have
resulted in program termination).

See also https://github.com/apple/swift/pull/39187

rdar://79725187