### PR TITLE
[lldb] Copy the system debugserver in LLDB.framework

### DIFF
--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -124,10 +124,17 @@ if(CMAKE_HOST_APPLE)
 
   if(LLDB_USE_SYSTEM_DEBUGSERVER)
     lldb_find_system_debugserver(system_debugserver_path)
-    add_custom_target(debugserver
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different
-      ${system_debugserver_path} ${LLVM_RUNTIME_OUTPUT_INTDIR}
-      COMMENT "Copying the system debugserver to LLDB's binaries directory for testing.")
+    if(LLDB_BUILD_FRAMEWORK)
+      add_custom_target(debugserver
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${system_debugserver_path} $<TARGET_FILE_DIR:liblldb>/Resources
+        COMMENT "Copying the system debugserver to LLDB.framework's resource directory for testing.")
+    else()
+      add_custom_target(debugserver
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${system_debugserver_path} ${LLVM_RUNTIME_OUTPUT_INTDIR}
+        COMMENT "Copying the system debugserver to LLDB's binaries directory for testing.")
+    endif()
     message(STATUS "LLDB tests use out-of-tree debugserver: ${system_debugserver_path}")
     list(APPEND LLDB_TEST_COMMON_ARGS --out-of-tree-debugserver)
     add_lldb_test_dependency(debugserver)


### PR DESCRIPTION
When using the system debugserver for testing, copy the binary in the
LLDB.framework Resource directory instead of the build's bin directory.

rdar://82998263
(cherry picked from commit c6288759296f808a2f7304bbd1bd5b18974e4ccc)
