### PR TITLE
[cmake][compiler-rt] Explicitly pass CMAKE_MT to `runtimes` external project

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -428,6 +428,7 @@ ${error} Set RUNTIMES_BUILD_ALLOW_DARWIN to allow a single darwin triple.")
                                         -DCMAKE_ASM_COMPILER_WORKS=ON
                                         ${RUNTIMES_CMAKE_ARGS}
                              PASSTHROUGH_PREFIXES LLVM_ENABLE_RUNTIMES
+                                                  CMAKE_MT
                                                   ${ARG_PREFIXES}
                              EXTRA_TARGETS ${extra_targets}
                                            ${test_targets}


### PR DESCRIPTION
Since CMake 3.20 `CMAKE_MT` detection changed, making it necessary to adjust the value
of this var for some systems manually (e.g. Swift on Windows sets mt tool explicitly at the moment).

Unfortunately, `CMAKE_MT` defined for llvm is not propagated to external projects automatically,
and `runtimes` project appears misconfigured.

To fix that behavior we could use passthrough mechanics of llvm_ExternalProject_Add, and
pass existing CMAKE_MT value down the chain.