### PR TITLE
SwiftASTContext: s/module.sym_file.GetTypeSystem/module.GetTypeSystem/

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2250,14 +2250,8 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
         if (!HasSwiftModules(*module_sp))
           return;
 
-        SymbolFile *sym_file = module_sp->GetSymbolFile();
-        if (!sym_file)
-          return;
-
-        Status sym_file_error;
-
         auto type_system_or_err =
-            sym_file->GetTypeSystemForLanguage(lldb::eLanguageTypeSwift);
+            module_sp->GetTypeSystemForLanguage(lldb::eLanguageTypeSwift);
         if (!type_system_or_err) {
           llvm::consumeError(type_system_or_err.takeError());
           return;


### PR DESCRIPTION
This is an NFC change:
- SymbolFile::GetTypeSystemForLanguage() forwards to
  m_objfile_sp->GetModule()->GetTypeSystemForLanguage()
- SymbolFileDWARF::GetTypeSystemForLanguage() forwards to
    debug_map_symfile->GetTypeSystemForLanguage();
  or
    m_objfile_sp->GetModule()->GetTypeSystemForLanguage()
- SymbolFileDWARFDebugMap: forwards to SymbolFile
- SymbolFilePDB::GetTypeSystemForLanguage()
      m_objfile_sp->GetModule()->GetTypeSystemForLanguage()