### PR TITLE
[lldb] Fix TestImportStdModule on some setups by testing minmax inste…

### DIFF
--- a/lldb/test/API/commands/expression/import-std-module/basic/TestImportStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/basic/TestImportStdModule.py
@@ -24,6 +24,8 @@ class ImportStdModule(TestBase):
         self.runCmd("settings set target.import-std-module true")
         # Calling some normal std functions that return non-template types.
         self.expect_expr("std::abs(-42)", result_type="int", result_value="42")
+        self.expect_expr("std::minmax<int>(1, 2).first", result_type="const int",
+            result_value="1")
         self.expect_expr("std::div(2, 1).quot",
                          result_type="int",
                          result_value="2")
@@ -50,7 +52,7 @@ class ImportStdModule(TestBase):
         self.runCmd("settings set target.import-std-module true")
         # These languages don't support C++ modules, so they shouldn't
         # be able to evaluate the expression.
-        self.expect("expr -l C -- std::abs(-42)", error=True)
-        self.expect("expr -l C99 -- std::abs(-42)", error=True)
-        self.expect("expr -l C11 -- std::abs(-42)", error=True)
-        self.expect("expr -l ObjC -- std::abs(-42)", error=True)
+        self.expect("expr -l C -- std::minmax<int>(1, 2).first", error=True)
+        self.expect("expr -l C99 -- std::minmax<int>(1, 2).first", error=True)
+        self.expect("expr -l C11 -- std::minmax<int>(1, 2).first", error=True)
+        self.expect("expr -l ObjC -- std::minmax<int>(1, 2).first", error=True)


### PR DESCRIPTION
…ad of abs

Some downstream forks of LLDB change parts of the test setup in a way that
causes lldb to somehow resolve `std::abs` (probably to `::abs`). This patch
changes the tested function here to be `std::minmax` which (hopefully) doesn't
have any identically named functions that LLDB could find and call. Just to be
extra safe this also explicitly specified the template arguments so that in
case there is a `minmax` non-template function we still don't end up calling it
from this test.

(cherry picked from commit f939a32e5c483686af16561211d77c06a5579011)