### PR TITLE
[lldb] Toggle the reproducer default in the driver

### DIFF
--- a/lldb/test/Shell/Reproducer/TestDriverOptions.test
+++ b/lldb/test/Shell/Reproducer/TestDriverOptions.test
@@ -10,13 +10,12 @@
 #
 # RUN: %lldb --capture --capture-path %t.repro -b -o 'reproducer status' 2>&1 | FileCheck %s --check-prefix NO-WARNING --check-prefix STATUS-CAPTURE
 # RUN: %lldb --capture -b -o 'reproducer status' 2>&1 | FileCheck %s --check-prefix NO-WARNING --check-prefix STATUS-CAPTURE
-# BEGIN SWIFT-LLDB CHANGE (--capture does not need to be specified, as it's on by default)
-# RUN: %lldb --capture-path %t.repro -b -o 'reproducer status' 2>&1 | FileCheck %s --check-prefix NO-WARNING --check-prefix STATUS-CAPTURE --check-prefix NOAUTOGEN
-# RUN: %lldb --capture-path %t.repro -b -o 'reproducer status' --reproducer-generate-on-exit  2>&1
-# END SWIFT-LLDB-CHANGE
-
+# RUN: %lldb --capture-path %t.repro -b -o 'reproducer status' 2>&1 | FileCheck %s --check-prefix WARNING --check-prefix STATUS-CAPTURE --check-prefix NOAUTOGEN
+# RUN: %lldb --capture-path %t.repro -b -o 'reproducer status' --reproducer-generate-on-exit  2>&1 | FileCheck %s --check-prefix WARNING2
+#
 # NO-WARNING-NOT: warning: -capture-path specified without -capture
 # WARNING: warning: -capture-path specified without -capture
+# WARNING2: warning: -reproducer-generate-on-exit specified without -capture
 # STATUS-CAPTURE: Reproducer is in capture mode.
 # NOAUTOGEN-NOT: Auto generate
 

--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -826,14 +826,7 @@ static llvm::Optional<int> InitializeReproducer(llvm::StringRef argv0,
     return 0;
   }
 
-  // BEGIN SWIFT
-#if TARGET_OS_IPHONE
   bool capture = input_args.hasArg(OPT_capture);
-#else
-  bool repl = input_args.hasArg(OPT_repl) || input_args.hasArg(OPT_repl_);
-  bool capture = !repl || input_args.hasArg(OPT_capture);
-#endif
-  // END SWIFT
   bool generate_on_exit = input_args.hasArg(OPT_generate_on_exit);
   auto *capture_path = input_args.getLastArg(OPT_capture_path);
 


### PR DESCRIPTION
Turn off reproducer-capture-by default. See lldb-dev [0] for more
context.

[0] https://lists.llvm.org/pipermail/lldb-dev/2021-September/017045.html