### PR TITLE
[rdar://83635806] don't run frexp tests on ios for now

### DIFF
--- a/compiler-rt/test/asan/TestCases/frexp_interceptor.cpp
+++ b/compiler-rt/test/asan/TestCases/frexp_interceptor.cpp
@@ -3,7 +3,7 @@
 // Test the frexp() interceptor.
 // we are choosing not to cherry pick the fix for this test to this branch rdar://81224953
 // fix is this commit: https://github.com/apple/llvm-project/commit/cfa4d112da8d
-// XFAIL: ios && !iossim
+// UNSUPPORTED: ios
 
 #include <math.h>
 #include <stdio.h>


### PR DESCRIPTION
Since the fix was landed in main but not cherry picked in this branch,
disable the test instead of xfail since it's causing some downstream ci failures