### PR TITLE
Support debugging Swift dylibs that were loaded after SwiftASTContext

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1949,7 +1949,7 @@ static lldb::ModuleSP GetUnitTestModule(lldb_private::ModuleList &modules) {
 /// Scan a newly added lldb::Module fdor Swift modules and report any errors in
 /// its module SwiftASTContext to Target.
 static void
-ProcessModule(ModuleSP &&module_sp, std::string m_description,
+ProcessModule(ModuleSP module_sp, std::string m_description,
               bool use_all_compiler_flags, Target &target,
               std::vector<std::string> &module_search_paths,
               std::vector<std::pair<std::string, bool>> &framework_search_paths,
@@ -5069,6 +5069,37 @@ void SwiftASTContext::PrintDiagnostics(DiagnosticManager &diagnostic_manager,
 
 void SwiftASTContext::ModulesDidLoad(ModuleList &module_list) {
   ClearModuleDependentCaches();
+
+  // Scan the new modules for Swift contents and try to import it if
+  // safe, otherwise poison this context.
+  TargetSP target_sp = GetTarget().lock();
+  if (!target_sp)
+    return;
+
+  bool use_all_compiler_flags = target_sp->GetUseAllCompilerFlags();
+  unsigned num_images = module_list.GetSize();
+  for (size_t mi = 0; mi != num_images; ++mi) {
+    std::vector<std::string> module_search_paths;
+    std::vector<std::pair<std::string, bool>> framework_search_paths;
+    std::vector<std::string> extra_clang_args;
+    lldb::ModuleSP module_sp = module_list.GetModuleAtIndex(mi);
+    ProcessModule(module_sp, m_description, use_all_compiler_flags, *target_sp,
+                  module_search_paths, framework_search_paths,
+                  extra_clang_args);
+    // If the use-all-compiler-flags setting is enabled, the expression
+    // context is supposed to merge all search paths form all dylibs.
+    if (use_all_compiler_flags && !extra_clang_args.empty()) {
+      // We cannot reconfigure ClangImporter after its creation.
+      // Instead poison the SwiftASTContext so it gets recreated.
+      m_fatal_errors.SetErrorStringWithFormat(
+          "New Swift image added: %s",
+          module_sp->GetFileSpec().GetPath().c_str());
+    }
+
+    // Scan the dylib for .swiftast sections.
+    std::vector<std::string> module_names;
+    RegisterSectionModules(*module_sp, module_names);
+  }
 }
 
 void SwiftASTContext::ClearModuleDependentCaches() {

--- a/lldb/test/API/lang/swift/late_dylib/Makefile
+++ b/lldb/test/API/lang/swift/late_dylib/Makefile
@@ -1,0 +1,21 @@
+# This Makefile recursively calls itself, hence the ?=.
+EXE ?= a.out
+C_SOURCES ?= loader.c
+all: dylib $(EXE)
+
+include Makefile.rules
+
+.PHONY: dylib
+dylib:
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		-f $(SRCDIR)/Makefile \
+		DYLIB_FILENAME=dylib.dylib \
+		DYLIB_SWIFT_SOURCES=dylib.swift \
+		DYLIB_NAME=dylib \
+		DYLIB_ONLY=YES \
+		C_SOURCES= \
+		LD_EXTRAS="-lSwiftCore -Xlinker -exported_symbol -Xlinker _f" \
+		dylib.dylib
+

--- a/lldb/test/API/lang/swift/late_dylib/TestSwiftLateDylib.py
+++ b/lldb/test/API/lang/swift/late_dylib/TestSwiftLateDylib.py
@@ -1,0 +1,21 @@
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftLateDylib(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @skipUnlessDarwin
+    @swiftTest
+    @skipIfDarwinEmbedded 
+    def test(self):
+        """Test that a late loaded Swift dylib is debuggable"""
+        self.build()
+        target, process, _, _ = lldbutil.run_to_name_breakpoint(self, "main")
+        # Initialize SwiftASTContext before loading the dylib.
+        self.expect("expr -l Swift -- 0")
+        bkpt = target.BreakpointCreateByLocation(lldb.SBFileSpec('dylib.swift'), 7)
+        lldbutil.continue_to_breakpoint(process, bkpt)
+        self.expect("v x", substrs=['Hello from the Dylib'])
+        self.expect("expr x", substrs=['Hello from the Dylib'])

--- a/lldb/test/API/lang/swift/late_dylib/dylib.swift
+++ b/lldb/test/API/lang/swift/late_dylib/dylib.swift
@@ -1,0 +1,8 @@
+struct FromDylib {
+    let msg = "Hello from the Dylib!"
+}
+
+@_silgen_name("f") public func f() {
+  let x = FromDylib()
+  print(x) // line 7
+}

--- a/lldb/test/API/lang/swift/late_dylib/loader.c
+++ b/lldb/test/API/lang/swift/late_dylib/loader.c
@@ -1,0 +1,12 @@
+#include <dlfcn.h>
+#include <stdio.h>
+#include <string.h>
+#include <libgen.h>
+
+int main(int argc, const char **argv) {
+  char *dylib_name = strcat(dirname(argv[0]),"/dylib.dylib");
+  void *dylib = dlopen(dylib_name, RTLD_NOW);
+  void (*f)() = dlsym(dylib, "f");
+  f();
+  return 0;
+}

--- a/lldb/test/API/lang/swift/late_dylib_clangdeps/ClangMod.h
+++ b/lldb/test/API/lang/swift/late_dylib_clangdeps/ClangMod.h
@@ -1,0 +1,3 @@
+struct FromClang {
+  int x;
+};

--- a/lldb/test/API/lang/swift/late_dylib_clangdeps/Makefile
+++ b/lldb/test/API/lang/swift/late_dylib_clangdeps/Makefile
@@ -1,0 +1,22 @@
+# This Makefile recursively calls itself, hence the ?=.
+EXE ?= a.out
+C_SOURCES ?= loader.c
+all: dylib $(EXE)
+
+include Makefile.rules
+
+.PHONY: dylib
+dylib:
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		-f $(SRCDIR)/Makefile \
+		DYLIB_FILENAME=dylib.dylib \
+		DYLIB_SWIFT_SOURCES=dylib.swift \
+		DYLIB_NAME=dylib \
+		DYLIB_ONLY=YES \
+		SWIFTFLAGS_EXTRAS="-Xcc -I$(SRCDIR)" \
+		C_SOURCES= \
+		LD_EXTRAS="-lSwiftCore -Xlinker -exported_symbol -Xlinker _f" \
+		dylib.dylib
+

--- a/lldb/test/API/lang/swift/late_dylib_clangdeps/TestSwiftLateDylibClangDeps.py
+++ b/lldb/test/API/lang/swift/late_dylib_clangdeps/TestSwiftLateDylibClangDeps.py
@@ -1,0 +1,21 @@
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftLateDylibClangDeps(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @skipUnlessDarwin
+    @swiftTest
+    @skipIfDarwinEmbedded 
+    def test(self):
+        """Test that a late loaded Swift dylib with Clang dependencies is debuggable"""
+        self.build()
+        target, process, _, _ = lldbutil.run_to_name_breakpoint(self, "main")
+        # Initialize SwiftASTContext before loading the dylib.
+        self.expect("expr -l Swift -- 0")
+        bkpt = target.BreakpointCreateByLocation(lldb.SBFileSpec('dylib.swift'), 5)
+        lldbutil.continue_to_breakpoint(process, bkpt)
+        self.expect("v x", substrs=['42'])
+        self.expect("expr x", substrs=['42'])

--- a/lldb/test/API/lang/swift/late_dylib_clangdeps/dylib.swift
+++ b/lldb/test/API/lang/swift/late_dylib_clangdeps/dylib.swift
@@ -1,0 +1,6 @@
+import ClangMod
+
+@_silgen_name("f") public func f() {
+  let x = FromClang(x: 42)
+  print(x) // line 5
+}

--- a/lldb/test/API/lang/swift/late_dylib_clangdeps/loader.c
+++ b/lldb/test/API/lang/swift/late_dylib_clangdeps/loader.c
@@ -1,0 +1,12 @@
+#include <dlfcn.h>
+#include <stdio.h>
+#include <string.h>
+#include <libgen.h>
+
+int main(int argc, const char **argv) {
+  char *dylib_name = strcat(dirname(argv[0]),"/dylib.dylib");
+  void *dylib = dlopen(dylib_name, RTLD_NOW);
+  void (*f)() = dlsym(dylib, "f");
+  f();
+  return 0;
+}

--- a/lldb/test/API/lang/swift/late_dylib_clangdeps/module.modulemap
+++ b/lldb/test/API/lang/swift/late_dylib_clangdeps/module.modulemap
@@ -1,0 +1,3 @@
+module ClangMod {
+  header "ClangMod.h"
+}


### PR DESCRIPTION
… was initialized.

This patch extends the ModulesDidLoad callback to register .swiftast
sections in the new dylib and posons the context if necessary to force
a reinitialization.

rdar://81135636