### PR TITLE
[VectorCombine] Discard ScalarizationResult state in early exit.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -822,6 +822,12 @@ public:
   /// freeze.
   bool isSafeWithFreeze() const { return Status == StatusTy::SafeWithFreeze; }
 
+  /// Reset the state of Unsafe and clear ToFreze if set.
+  void discard() {
+    ToFreeze = nullptr;
+    Status = StatusTy::Unsafe;
+  }
+
   /// Freeze the ToFreeze and update the use in \p User to use it.
   void freeze(IRBuilder<> &Builder, Instruction &UserI) {
     assert(isSafeWithFreeze() &&
@@ -1006,6 +1012,7 @@ bool VectorCombine::scalarizeLoadExtract(Instruction &I) {
     auto ScalarIdx = canScalarizeAccess(FixedVT, UI->getOperand(1), &I, AC, DT);
     if (!ScalarIdx.isSafe()) {
       // TODO: Freeze index if it is safe to do so.
+      ScalarIdx.discard();
       return false;
     }
 


### PR DESCRIPTION
ScalarizationResult's destructor makes sure ToFreeze is not ignored if
set. Currently, scalarizeLoadExtract has an early exit if the index is
not safe directly. But when it is SafeWithFreeze, we need to discard the
state first, otherwise we hit the assert in the destructor.

Fixes PR51992.

(cherry-picked from e2f6290e06be63149af770197b772248369ac038)