### PR TITLE
[lldb] Load system's libswiftCore and honor explicit settings on REPL

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -195,6 +195,7 @@ lldb::REPLSP SwiftREPL::CreateInstanceFromDebugger(Status &err,
     launch_info.SetExecutableFile(exe_module_sp->GetPlatformFileSpec(), true);
   }
 
+  launch_info.GetEnvironment() = target_sp->GetTargetEnvironment();
   debugger.SetAsyncExecution(false);
   err = target_sp->Launch(launch_info, nullptr);
   debugger.SetAsyncExecution(true);

--- a/lldb/tools/repl/swift/main.c
+++ b/lldb/tools/repl/swift/main.c
@@ -57,7 +57,9 @@ int main() {
 #endif
 #ifdef __APPLE__
   // Force loading of libswiftCore.dylib, which is not linked at build time.
-  dlopen("@rpath/libswiftCore.dylib", RTLD_LAZY);
+  // We load the system's libswiftCore, but this is overriden on tests to 
+  // use the just built one by setting DYLD_LIBRARY_PATH.
+  dlopen("/usr/lib/swift/libswiftCore.dylib", RTLD_LAZY);
 #elif defined(__linux__)
   dlopen("libswiftCore.so", RTLD_LAZY);
 #elif defined(_WIN32)


### PR DESCRIPTION
We change the dummy to load the system's version of libswiftCore because
dyld fails to override an image with @rpath correctly. We also pass the
current environment to the REPL so any explicit settings work on the
repl as we..