### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/lldb/bindings/python/CMakeLists.txt
+++ b/lldb/bindings/python/CMakeLists.txt
@@ -5,7 +5,7 @@ add_custom_command(
   DEPENDS ${SWIG_INTERFACES}
   DEPENDS ${SWIG_HEADERS}
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/prepare_binding_python.py
-  COMMAND ${PYTHON_EXECUTABLE} ${LLDB_SOURCE_DIR}/bindings/prepare_bindings.py
+  COMMAND ${Python3_EXECUTABLE} ${LLDB_SOURCE_DIR}/bindings/prepare_bindings.py
       ${framework_arg}
       --srcRoot=${LLDB_SOURCE_DIR}
       --targetDir=${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
Fix the python executable.  The python interpreter is `Python3_EXECUTABLE` after the merge.  We were relying on the shebang to get the python which could pick up the wrong version.