### PR TITLE
[lldb] Add missing serialization status strings

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1272,7 +1272,8 @@ static const char *getImportFailureString(swift::serialization::Status status) {
     return "The module file was built with a different SDK than the one in use "
            "to build the client.";
   case swift::serialization::Status::RevisionIncompatible:
-    return "The precise revision version doesn't match.";
+    return "The resilient module file was built by a different version of the "
+           "compiler.";
   }
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1268,6 +1268,11 @@ static const char *getImportFailureString(swift::serialization::Status status) {
   case swift::serialization::Status::TargetTooNew:
     return "The module file was built for a target newer than the current "
            "target.";
+  case swift::serialization::Status::SDKMismatch:
+    return "The module file was built with a different SDK than the one in use "
+           "to build the client.";
+  case swift::serialization::Status::RevisionIncompatible:
+    return "The precise revision version doesn't match.";
   }
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1272,8 +1272,8 @@ static const char *getImportFailureString(swift::serialization::Status status) {
     return "The module file was built with a different SDK than the one in use "
            "to build the client.";
   case swift::serialization::Status::RevisionIncompatible:
-    return "The resilient module file was built by a different version of the "
-           "compiler.";
+    return "The module file was built with library evolution enabled by a "
+           "different version of the compiler.";
   }
 }
 


### PR DESCRIPTION
Update `getImportFailureString` to handle `SDKMismatch` and `RevisionIncompatible`. Without these cases, the function triggers `-Wreturn-type` with the message "non-void function does not return a value in all control paths". This could lead to crashes.