### PR TITLE
Add the --relative-to-command-file to "command source" so you can

### DIFF
--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -533,6 +533,10 @@ let Command = "source" in {
     Desc<"If true, stop executing commands on continue.">;
   def source_silent_run : Option<"silent-run", "s">, Arg<"Boolean">,
     Desc<"If true don't echo commands while executing.">;
+  def cmd_relative_to_command_file : Option<"relative-to-command-file", "C">,
+    Desc<"Resolve non-absolute paths relative to the location of the "
+    "current command file. This argument can only be used when the command is "
+    "being sourced from a file.">;
 }
 
 let Command = "alias" in {

--- a/lldb/test/API/commands/command/source/TestCommandSource.py
+++ b/lldb/test/API/commands/command/source/TestCommandSource.py
@@ -21,7 +21,18 @@ class CommandSourceTestCase(TestBase):
         # Sourcing .lldb in the current working directory, which in turn imports
         # the "my" package that defines the date() function.
         self.runCmd("command source .lldb")
+        self.check_results()
+        
+    @no_debug_info_test
+    def test_command_source_relative(self):
+        """Test that lldb command "command source" works correctly with relative paths."""
 
+        # Sourcing .lldb in the current working directory, which in turn imports
+        # the "my" package that defines the date() function.
+        self.runCmd("command source commands2.txt")
+        self.check_results()
+        
+    def check_results(self, failure=False):
         # Python should evaluate "my.date()" successfully.
         command_interpreter = self.dbg.GetCommandInterpreter()
         self.assertTrue(command_interpreter, VALID_COMMAND_INTERPRETER)
@@ -29,6 +40,18 @@ class CommandSourceTestCase(TestBase):
         command_interpreter.HandleCommand("script my.date()", result)
 
         import datetime
-        self.expect(result.GetOutput(), "script my.date() runs successfully",
-                    exe=False,
-                    substrs=[str(datetime.date.today())])
+        if failure:
+            self.expect(result.GetOutput(), "script my.date() runs successfully",
+                        exe=False, error=True)
+        else: 
+            self.expect(result.GetOutput(), "script my.date() runs successfully",
+                        exe=False,
+                        substrs=[str(datetime.date.today())])
+        
+    @no_debug_info_test
+    def test_command_source_relative_error(self):
+        """Test that 'command source -C' gives an error for a relative path"""
+        source_dir = self.getSourceDir()
+        result = lldb.SBCommandReturnObject()
+        self.runCmd("command source --stop-on-error 1 not-relative.txt")
+        self.check_results(failure=True)

--- a/lldb/test/API/commands/command/source/commands2.txt
+++ b/lldb/test/API/commands/command/source/commands2.txt
@@ -1,0 +1,1 @@
+command source -C subdir/subcmds.txt

--- a/lldb/test/API/commands/command/source/not-relative.txt
+++ b/lldb/test/API/commands/command/source/not-relative.txt
@@ -1,0 +1,2 @@
+command source -C /tmp/somefile.txt
+script import my

--- a/lldb/test/API/commands/command/source/subdir/subcmds.txt
+++ b/lldb/test/API/commands/command/source/subdir/subcmds.txt
@@ -1,0 +1,1 @@
+command source -C ../commands.txt


### PR DESCRIPTION
have linked command files in a source tree and get to them all from
one main command file.

Differential Revision: https://reviews.llvm.org/D110601

(cherry picked from commit 3bf3b96629e8dfc55d01ba0cb05ca01a467017fa)