### PR TITLE
Make "process attach -c" work correctly, and add a test for it.

### DIFF
--- a/lldb/test/API/commands/process/attach/TestProcessAttach.py
+++ b/lldb/test/API/commands/process/attach/TestProcessAttach.py
@@ -43,6 +43,23 @@ class ProcessAttachTestCase(TestBase):
         process = target.GetProcess()
         self.assertTrue(process, PROCESS_IS_VALID)
 
+    @skipIfiOSSimulator
+    def test_attach_to_process_by_id_autocontinue(self):
+        """Test attach by process id"""
+        self.build()
+        exe = self.getBuildArtifact(exe_name)
+
+        # Spawn a new process
+        popen = self.spawnSubprocess(exe)
+
+        self.runCmd("process attach -c -p " + str(popen.pid))
+
+        target = self.dbg.GetSelectedTarget()
+
+        process = target.GetProcess()
+        self.assertTrue(process, PROCESS_IS_VALID)
+        self.assertTrue(process.GetState(), lldb.eStateRunning)
+
     @skipIfReproducer # FIXME: Unexpected packet during (active) replay
     @skipIfWindows # This is flakey on Windows AND when it fails, it hangs: llvm.org/pr48806
     def test_attach_to_process_from_different_dir_by_id(self):


### PR DESCRIPTION
The issue here was that we were not updating the interpreter's
execution context when calling HandleCommand to continue the process.
Since we had just created the process, it wasn't in the interpreter's
execution context so HandleCommand failed at CheckRequirements.  The
patch fixes that by passing the process execution context directly
to HandleCommand.

Differential Revision: https://reviews.llvm.org/D110787

(cherry picked from commit 2303391d1f543f4e57f9ed0fc68bad2d4cf890dc)