### PR TITLE
Deserialize search path options in ProcessModule (NFCi)  …

### DIFF
--- a/lldb/test/Shell/Swift/astcontext_error.test
+++ b/lldb/test/Shell/Swift/astcontext_error.test
@@ -3,6 +3,7 @@
 # RUN: %target-swiftc -g %S/Inputs/ContextError.swift
 # RUN: %lldb ContextError -s %s | FileCheck %S/Inputs/ContextError.swift
 
+# Test that re-running a process doesn't emit bogus warnings.
 br set -p "here"
 run
 run


### PR DESCRIPTION
That patch is one step towards removing the need for a separate
SwiftASTContext per lldb::Module. It moves the parsing of the headers
of modules found in Swift AST sections directly into ProcessModule()
since all that ProcessModule() needs is the search path options from
the serialized swift::CompilerInvocation in the module.

Right now this means that the compiler invocations are deserialized
twice, but this should be a cheap operation.

rdar://81717792