### PR TITLE
Optimize schema and encoding of BlockRef

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/CASObjectFormat/Encoding.h
+++ b/llvm/include/llvm/ExecutionEngine/CASObjectFormat/Encoding.h
@@ -1,0 +1,124 @@
+//===- llvm/ExecutionEngine/CASObjectFormat/Encoding.h ----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_CASOBJECTFORMAT_ENCODING_H
+#define LLVM_EXECUTIONENGINE_CASOBJECTFORMAT_ENCODING_H
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Error.h"
+#include <numeric>
+#include <type_traits>
+
+namespace llvm {
+namespace casobjectformat {
+namespace encoding {
+
+template <class T, std::enable_if_t<std::is_integral<T>::value &&
+                                        std::numeric_limits<T>::is_signed,
+                                    bool> = true>
+static std::make_unsigned_t<T> rotateSign(T SV) {
+  using UT = std::make_unsigned_t<T>;
+  if (SV == std::numeric_limits<T>::min())
+    return std::numeric_limits<UT>::max();
+  UT UV = (UT(SV < 0 ? -SV - 1 : SV) << 1) | UT(SV < 0);
+  return UV;
+}
+
+template <class T, std::enable_if_t<std::is_integral<T>::value &&
+                                        !std::numeric_limits<T>::is_signed,
+                                    bool> = true>
+static std::make_signed_t<T> unrotateSign(T UV) {
+  using ST = std::make_signed_t<T>;
+  if (UV == std::numeric_limits<T>::max())
+    return std::numeric_limits<ST>::min();
+  ST SV = UV & 1 ? -ST(UV >> 1) - 1 : UV >> 1;
+  return SV;
+}
+
+template <class T, std::enable_if_t<std::is_integral<T>::value &&
+                                        !std::numeric_limits<T>::is_signed,
+                                    bool> = true>
+static void writeVBR8(T UV, SmallVectorImpl<char> &Data) {
+  const unsigned TotalBits = sizeof(T) * 8;
+  unsigned WrittenBits = 0;
+  do {
+    const unsigned RemainingBits = TotalBits - WrittenBits;
+    const bool IsLastByte = RemainingBits <= 8;
+    const unsigned BitsToWrite = IsLastByte ? RemainingBits : 7;
+    unsigned char Byte = UV;
+    UV >>= BitsToWrite;
+    if (UV) {
+      assert(!IsLastByte);
+      Byte |= 0x80U;
+    } else if (!IsLastByte) {
+      Byte &= 0x7FU;
+    }
+    Data.push_back(Byte);
+    WrittenBits += BitsToWrite;
+  } while (UV);
+}
+
+template <class T, std::enable_if_t<std::is_integral<T>::value &&
+                                        std::numeric_limits<T>::is_signed,
+                                    bool> = true>
+static void writeVBR8(T SV, SmallVectorImpl<char> &Data) {
+  writeVBR8(rotateSign(SV), Data);
+}
+
+template <class T, std::enable_if_t<std::is_integral<T>::value &&
+                                        !std::numeric_limits<T>::is_signed,
+                                    bool> = true>
+static Error consumeVBR8(StringRef &Data, T &UV) {
+  const unsigned TotalBits = sizeof(T) * 8;
+  unsigned ReadBits = 0;
+  T ReadUV = 0U;
+  while (TotalBits > ReadBits) {
+    if (Data.empty())
+      return createStringError(inconvertibleErrorCode(), "vbr8 missing bytes");
+    const unsigned RemainingBits = TotalBits - ReadBits;
+    const bool IsLastByte = RemainingBits <= 8;
+    const unsigned BitsToRead = IsLastByte ? RemainingBits : 7;
+    const T Byte = Data[0];
+    Data = Data.drop_front();
+
+    ReadUV |= (IsLastByte ? Byte : Byte & 0x7FU) << ReadBits;
+    ReadBits += BitsToRead;
+
+    if (IsLastByte || !(Byte & 0x80U)) {
+      UV = ReadUV;
+      return Error::success();
+    }
+  }
+  // Should be unreachable.
+  llvm::report_fatal_error(
+      createStringError(inconvertibleErrorCode(), "vbr8 not finished"));
+}
+
+template <class T, std::enable_if_t<std::is_integral<T>::value &&
+                                        std::numeric_limits<T>::is_signed,
+                                    bool> = true>
+static Error consumeVBR8(StringRef &Data, T &SV) {
+  std::make_unsigned_t<T> UV;
+  if (Error E = consumeVBR8(Data, UV))
+    return E;
+  SV = unrotateSign(UV);
+  return Error::success();
+}
+
+template <class T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
+static Expected<StringRef> readVBR8(StringRef Data, T &V) {
+  if (Error E = consumeVBR8(Data, V))
+    return std::move(E);
+  return Data;
+}
+
+} // namespace encoding
+} // end namespace casobjectformat
+} // end namespace llvm
+
+#endif // LLVM_EXECUTIONENGINE_CASOBJECTFORMAT_ENCODING_H

--- a/llvm/include/llvm/ExecutionEngine/CASObjectFormat/ObjectFileSchema.h
+++ b/llvm/include/llvm/ExecutionEngine/CASObjectFormat/ObjectFileSchema.h
@@ -340,7 +340,7 @@ public:
   FixupList getFixups() const { return FixupList(getData()); }
 
   static Expected<FixupListRef> create(ObjectFileSchema &Schema,
-                                       ArrayRef<const jitlink::Edge *> Edges);
+                                       ArrayRef<Fixup> Fixups);
 
 private:
   explicit FixupListRef(LeafRefT Ref) : LeafRefT(Ref) {}
@@ -728,9 +728,9 @@ public:
     return createImpl(Schema, Section, Data, None, None, None);
   }
   static Expected<BlockRef> create(ObjectFileSchema &Schema, SectionRef Section,
-                                   BlockDataRef Data, FixupListRef Fixups,
-                                   TargetInfoListRef TargetInfo,
-                                   TargetListRef Targets) {
+                                   BlockDataRef Data, ArrayRef<Fixup> Fixups,
+                                   ArrayRef<TargetInfo> TargetInfo,
+                                   ArrayRef<TargetRef> Targets) {
     return createImpl(Schema, Section, Data, Fixups, TargetInfo, Targets);
   }
 
@@ -748,9 +748,9 @@ private:
 
   static Expected<BlockRef> createImpl(ObjectFileSchema &Schema,
                                        SectionRef Section, BlockDataRef Data,
-                                       Optional<FixupListRef> Fixups,
-                                       Optional<TargetInfoListRef> TargetInfo,
-                                       Optional<TargetListRef> Targets);
+                                       ArrayRef<Fixup> Fixups,
+                                       ArrayRef<TargetInfo> TargetInfo,
+                                       ArrayRef<TargetRef> Targets);
 };
 
 /// A symbol.

--- a/llvm/include/llvm/ExecutionEngine/CASObjectFormat/ObjectFileSchema.h
+++ b/llvm/include/llvm/ExecutionEngine/CASObjectFormat/ObjectFileSchema.h
@@ -717,15 +717,21 @@ public:
   /// definition has an abstract backedge.
   bool isSymbolTemplate() const;
 
-  uint64_t getOffset() const;
+  uint64_t getOffset() const { return Offset; }
 
   Flags getFlags() const {
     return Flags(getDeadStrip(), getScope(), getMerge());
   }
 
-  DeadStripKind getDeadStrip() const { return (DeadStripKind)getData()[8]; }
-  ScopeKind getScope() const { return (ScopeKind)getData()[9]; }
-  MergeKind getMerge() const { return (MergeKind)getData()[10]; }
+  DeadStripKind getDeadStrip() const {
+    return (DeadStripKind)(((unsigned char)getData()[0] >> 6) & 0x3);
+  }
+  ScopeKind getScope() const {
+    return (ScopeKind)(((unsigned char)getData()[0] >> 4) & 0x3);
+  }
+  MergeKind getMerge() const {
+    return (MergeKind)(((unsigned char)getData()[0] >> 2) & 0x3);
+  }
 
   cas::CASID getDefinitionID() const { return getReference(1); }
   Optional<cas::CASID> getNameID() const {
@@ -761,7 +767,9 @@ public:
              GetDefinitionRef);
 
 private:
-  explicit SymbolRef(SpecificRefT Ref) : SpecificRefT(Ref) {}
+  uint64_t Offset;
+  explicit SymbolRef(SpecificRefT Ref, uint64_t Offset)
+      : SpecificRefT(Ref), Offset(Offset) {}
 };
 
 /// A symbol table.

--- a/llvm/lib/CAS/BuiltinCAS.cpp
+++ b/llvm/lib/CAS/BuiltinCAS.cpp
@@ -442,6 +442,7 @@ static void printTree(raw_ostream &OS, ArrayRef<NamedTreeEntry> SortedEntries,
 }
 
 CASID BuiltinCAS::ObjectContentReference::getReference(size_t I) const {
+  assert(I < getNumReferences() && "Reference out of range");
   return CASID(
       bufferAsRawHash(ReferenceBlock.substr(I * NumHashBytes, NumHashBytes)));
 }

--- a/llvm/unittests/ExecutionEngine/CASObjectFormat/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/CASObjectFormat/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_llvm_unittest(CASObjectFormatTests
+  EncodingTest.cpp
   FixupListTest.cpp
   ObjectFileSchemaTest.cpp
   TargetInfoListTest.cpp

--- a/llvm/unittests/ExecutionEngine/CASObjectFormat/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/CASObjectFormat/CMakeLists.txt
@@ -9,6 +9,7 @@ add_llvm_unittest(CASObjectFormatTests
   FixupListTest.cpp
   ObjectFileSchemaTest.cpp
   TargetInfoListTest.cpp
+  TargetListTest.cpp
   )
 
 target_link_libraries(CASObjectFormatTests PRIVATE LLVMTestingSupport)

--- a/llvm/unittests/ExecutionEngine/CASObjectFormat/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/CASObjectFormat/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_unittest(CASObjectFormatTests
   FixupListTest.cpp
   ObjectFileSchemaTest.cpp
+  TargetInfoListTest.cpp
   )
 
 target_link_libraries(CASObjectFormatTests PRIVATE LLVMTestingSupport)

--- a/llvm/unittests/ExecutionEngine/CASObjectFormat/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/CASObjectFormat/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_llvm_unittest(CASObjectFormatTests
+  FixupListTest.cpp
   ObjectFileSchemaTest.cpp
   )
 

--- a/llvm/unittests/ExecutionEngine/CASObjectFormat/EncodingTest.cpp
+++ b/llvm/unittests/ExecutionEngine/CASObjectFormat/EncodingTest.cpp
@@ -1,0 +1,231 @@
+//===- EncodingTest.cpp - Unit tests for CASObjectFormat encoding ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/CASObjectFormat/Encoding.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::casobjectformat;
+using namespace llvm::casobjectformat::encoding;
+
+template <class T> static Expected<T> makeRoundTripVBR8(T V) {
+  SmallVector<char> Data;
+  writeVBR8(V, Data);
+
+  T RoundTripV;
+  StringRef Remaining(Data.begin(), Data.size());
+  if (Error E = consumeVBR8(Remaining, RoundTripV))
+    return std::move(E);
+  if (!Remaining.empty())
+    return createStringError(inconvertibleErrorCode(),
+                             "data left over; got: " + Twine(RoundTripV));
+  return RoundTripV;
+}
+
+template <class T> static size_t getSizeVBR8(T V) {
+  SmallVector<char> Data;
+  writeVBR8(V, Data);
+  return Data.size();
+}
+
+namespace {
+
+TEST(EncodingTest, rotateSign) {
+  // Check int.
+  EXPECT_EQ(0U, rotateSign(0));
+  EXPECT_EQ(2U, rotateSign(1));
+  EXPECT_EQ(4U, rotateSign(2));
+  EXPECT_EQ(6U, rotateSign(3));
+  EXPECT_EQ(UINT_MAX - 1U, rotateSign(INT_MAX - 0));
+  EXPECT_EQ(UINT_MAX - 3U, rotateSign(INT_MAX - 1));
+  EXPECT_EQ(UINT_MAX - 5U, rotateSign(INT_MAX - 2));
+  EXPECT_EQ(UINT_MAX - 7U, rotateSign(INT_MAX - 3));
+
+  EXPECT_EQ(1U, rotateSign(-1));
+  EXPECT_EQ(3U, rotateSign(-2));
+  EXPECT_EQ(5U, rotateSign(-3));
+  EXPECT_EQ(7U, rotateSign(-4));
+  EXPECT_EQ(UINT_MAX - 0U, rotateSign(INT_MIN + 0));
+  EXPECT_EQ(UINT_MAX - 2U, rotateSign(INT_MIN + 1));
+  EXPECT_EQ(UINT_MAX - 4U, rotateSign(INT_MIN + 2));
+  EXPECT_EQ(UINT_MAX - 6U, rotateSign(INT_MIN + 3));
+
+  // Check long long.
+  EXPECT_EQ(0ULL, rotateSign(0LL));
+  EXPECT_EQ(2ULL, rotateSign(1LL));
+  EXPECT_EQ(4ULL, rotateSign(2LL));
+  EXPECT_EQ(6ULL, rotateSign(3LL));
+  EXPECT_EQ(ULLONG_MAX - 1ULL, rotateSign(LLONG_MAX - 0LL));
+  EXPECT_EQ(ULLONG_MAX - 3ULL, rotateSign(LLONG_MAX - 1LL));
+  EXPECT_EQ(ULLONG_MAX - 5ULL, rotateSign(LLONG_MAX - 2LL));
+  EXPECT_EQ(ULLONG_MAX - 7ULL, rotateSign(LLONG_MAX - 3LL));
+
+  EXPECT_EQ(1ULL, rotateSign(-1LL));
+  EXPECT_EQ(3ULL, rotateSign(-2LL));
+  EXPECT_EQ(5ULL, rotateSign(-3LL));
+  EXPECT_EQ(7ULL, rotateSign(-4LL));
+  EXPECT_EQ(ULLONG_MAX - 0ULL, rotateSign(LLONG_MIN + 0LL));
+  EXPECT_EQ(ULLONG_MAX - 2ULL, rotateSign(LLONG_MIN + 1LL));
+  EXPECT_EQ(ULLONG_MAX - 4ULL, rotateSign(LLONG_MIN + 2LL));
+  EXPECT_EQ(ULLONG_MAX - 6ULL, rotateSign(LLONG_MIN + 3LL));
+
+  // Check char.
+  EXPECT_EQ(0U, rotateSign(char(0)));
+  EXPECT_EQ(2U, rotateSign(char(1)));
+  EXPECT_EQ(4U, rotateSign(char(2)));
+  EXPECT_EQ(6U, rotateSign(char(3)));
+  EXPECT_EQ(UCHAR_MAX - 1U, rotateSign(char(CHAR_MAX - 0)));
+  EXPECT_EQ(UCHAR_MAX - 3U, rotateSign(char(CHAR_MAX - 1)));
+  EXPECT_EQ(UCHAR_MAX - 5U, rotateSign(char(CHAR_MAX - 2)));
+  EXPECT_EQ(UCHAR_MAX - 7U, rotateSign(char(CHAR_MAX - 3)));
+
+  EXPECT_EQ(1U, rotateSign(char(-1LL)));
+  EXPECT_EQ(3U, rotateSign(char(-2LL)));
+  EXPECT_EQ(5U, rotateSign(char(-3LL)));
+  EXPECT_EQ(7U, rotateSign(char(-4LL)));
+  EXPECT_EQ(UCHAR_MAX - 0U, rotateSign(char(CHAR_MIN + 0LL)));
+  EXPECT_EQ(UCHAR_MAX - 2U, rotateSign(char(CHAR_MIN + 1LL)));
+  EXPECT_EQ(UCHAR_MAX - 4U, rotateSign(char(CHAR_MIN + 2LL)));
+  EXPECT_EQ(UCHAR_MAX - 6U, rotateSign(char(CHAR_MIN + 3LL)));
+}
+
+TEST(EncodingTest, unrotateSign) {
+  // Check int.
+  EXPECT_EQ(0, unrotateSign(0U));
+  EXPECT_EQ(1, unrotateSign(2U));
+  EXPECT_EQ(2, unrotateSign(4U));
+  EXPECT_EQ(3, unrotateSign(6U));
+  EXPECT_EQ(INT_MAX - 0, unrotateSign(UINT_MAX - 1U));
+  EXPECT_EQ(INT_MAX - 1, unrotateSign(UINT_MAX - 3U));
+  EXPECT_EQ(INT_MAX - 2, unrotateSign(UINT_MAX - 5U));
+  EXPECT_EQ(INT_MAX - 3, unrotateSign(UINT_MAX - 7U));
+
+  EXPECT_EQ(-1, unrotateSign(1U));
+  EXPECT_EQ(-2, unrotateSign(3U));
+  EXPECT_EQ(-3, unrotateSign(5U));
+  EXPECT_EQ(-4, unrotateSign(7U));
+  EXPECT_EQ(INT_MIN + 0, unrotateSign(UINT_MAX - 0U));
+  EXPECT_EQ(INT_MIN + 1, unrotateSign(UINT_MAX - 2U));
+  EXPECT_EQ(INT_MIN + 2, unrotateSign(UINT_MAX - 4U));
+  EXPECT_EQ(INT_MIN + 3, unrotateSign(UINT_MAX - 6U));
+
+  // Check long long.
+  EXPECT_EQ(0LL, unrotateSign(0ULL));
+  EXPECT_EQ(1LL, unrotateSign(2ULL));
+  EXPECT_EQ(2LL, unrotateSign(4ULL));
+  EXPECT_EQ(3LL, unrotateSign(6ULL));
+  EXPECT_EQ(LLONG_MAX - 0LL, unrotateSign(ULLONG_MAX - 1ULL));
+  EXPECT_EQ(LLONG_MAX - 1LL, unrotateSign(ULLONG_MAX - 3ULL));
+  EXPECT_EQ(LLONG_MAX - 2LL, unrotateSign(ULLONG_MAX - 5ULL));
+  EXPECT_EQ(LLONG_MAX - 3LL, unrotateSign(ULLONG_MAX - 7ULL));
+
+  EXPECT_EQ(-1LL, unrotateSign(1ULL));
+  EXPECT_EQ(-2LL, unrotateSign(3ULL));
+  EXPECT_EQ(-3LL, unrotateSign(5ULL));
+  EXPECT_EQ(-4LL, unrotateSign(7ULL));
+  EXPECT_EQ(LLONG_MIN + 0LL, unrotateSign(ULLONG_MAX - 0ULL));
+  EXPECT_EQ(LLONG_MIN + 1LL, unrotateSign(ULLONG_MAX - 2ULL));
+  EXPECT_EQ(LLONG_MIN + 2LL, unrotateSign(ULLONG_MAX - 4ULL));
+  EXPECT_EQ(LLONG_MIN + 3LL, unrotateSign(ULLONG_MAX - 6ULL));
+
+  // Check char.
+  EXPECT_EQ(char(0), unrotateSign(0U));
+  EXPECT_EQ(char(1), unrotateSign(2U));
+  EXPECT_EQ(char(2), unrotateSign(4U));
+  EXPECT_EQ(char(3), unrotateSign(6U));
+  EXPECT_EQ(char(CHAR_MAX - 0), unrotateSign(UCHAR_MAX - 1U));
+  EXPECT_EQ(char(CHAR_MAX - 1), unrotateSign(UCHAR_MAX - 3U));
+  EXPECT_EQ(char(CHAR_MAX - 2), unrotateSign(UCHAR_MAX - 5U));
+  EXPECT_EQ(char(CHAR_MAX - 3), unrotateSign(UCHAR_MAX - 7U));
+
+  EXPECT_EQ(char(-1LL), unrotateSign(1U));
+  EXPECT_EQ(char(-2LL), unrotateSign(3U));
+  EXPECT_EQ(char(-3LL), unrotateSign(5U));
+  EXPECT_EQ(char(-4LL), unrotateSign(7U));
+  EXPECT_EQ(char(CHAR_MIN + 0LL), unrotateSign(UCHAR_MAX - 0U));
+  EXPECT_EQ(char(CHAR_MIN + 1LL), unrotateSign(UCHAR_MAX - 2U));
+  EXPECT_EQ(char(CHAR_MIN + 2LL), unrotateSign(UCHAR_MAX - 4U));
+  EXPECT_EQ(char(CHAR_MIN + 3LL), unrotateSign(UCHAR_MAX - 6U));
+}
+
+TEST(EncodingTest, VBR8) {
+  for (unsigned V : {0U, 1U, 2U, 3U}) {
+    unsigned MaxV = UINT_MAX - V;
+    EXPECT_THAT_EXPECTED(makeRoundTripVBR8(V), HasValue(V));
+    EXPECT_THAT_EXPECTED(makeRoundTripVBR8(MaxV), HasValue(MaxV));
+  }
+  for (unsigned long long V : {0U, 1U, 2U, 3U}) {
+    unsigned long long MaxV = ULLONG_MAX - V;
+    EXPECT_THAT_EXPECTED(makeRoundTripVBR8(V), HasValue(V));
+    EXPECT_THAT_EXPECTED(makeRoundTripVBR8(MaxV), HasValue(MaxV));
+  }
+  for (unsigned char V : {0U, 1U, 2U, 3U}) {
+    unsigned char MaxV = UCHAR_MAX - V;
+    EXPECT_THAT_EXPECTED(makeRoundTripVBR8(V), HasValue(V));
+    EXPECT_THAT_EXPECTED(makeRoundTripVBR8(MaxV), HasValue(MaxV));
+  }
+  for (int V : {0, 1, 2, 3}) {
+    int MinV = INT_MIN + V;
+    int MaxV = INT_MAX - V;
+    EXPECT_THAT_EXPECTED(makeRoundTripVBR8(V), HasValue(V));
+    EXPECT_THAT_EXPECTED(makeRoundTripVBR8(MaxV), HasValue(MaxV));
+    EXPECT_THAT_EXPECTED(makeRoundTripVBR8(MinV), HasValue(MinV));
+  }
+  for (long long V : {0, 1, 2, 3}) {
+    long long MinV = LLONG_MIN + V;
+    long long MaxV = LLONG_MAX - V;
+    EXPECT_THAT_EXPECTED(makeRoundTripVBR8(V), HasValue(V));
+    EXPECT_THAT_EXPECTED(makeRoundTripVBR8(MaxV), HasValue(MaxV));
+    EXPECT_THAT_EXPECTED(makeRoundTripVBR8(MinV), HasValue(MinV));
+  }
+  for (char V : {0, 1, 2, 3}) {
+    char MinV = CHAR_MIN + V;
+    char MaxV = CHAR_MAX - V;
+    EXPECT_THAT_EXPECTED(makeRoundTripVBR8(V), HasValue(V));
+    EXPECT_THAT_EXPECTED(makeRoundTripVBR8(MaxV), HasValue(MaxV));
+    EXPECT_THAT_EXPECTED(makeRoundTripVBR8(MinV), HasValue(MinV));
+  }
+}
+
+TEST(EncodingTest, VBR8Size) {
+  // Check unsigned.
+  EXPECT_EQ(1U, getSizeVBR8(0U));
+  EXPECT_EQ(1U, getSizeVBR8(1U));
+  EXPECT_EQ(1U, getSizeVBR8((1U << 7) - 1U));
+  EXPECT_EQ(2U, getSizeVBR8((1U << 7)));
+  EXPECT_EQ(2U, getSizeVBR8((1U << 14) - 1U));
+  EXPECT_EQ(3U, getSizeVBR8((1U << 14)));
+  EXPECT_EQ(4U, getSizeVBR8((1U << 28) - 1U));
+  EXPECT_EQ(5U, getSizeVBR8((1U << 28)));
+  EXPECT_EQ(5U, getSizeVBR8(UINT_MAX));
+
+  // Spot-check int.
+  EXPECT_EQ(1U, getSizeVBR8(0));
+  EXPECT_EQ(1U, getSizeVBR8(1));
+  EXPECT_EQ(1U, getSizeVBR8(63));
+  EXPECT_EQ(2U, getSizeVBR8(64));
+  EXPECT_EQ(1U, getSizeVBR8(-1));
+  EXPECT_EQ(1U, getSizeVBR8(-2));
+  EXPECT_EQ(1U, getSizeVBR8(-64));
+  EXPECT_EQ(2U, getSizeVBR8(-65));
+
+  // Check limits of unsigned long long.
+  EXPECT_EQ(8U, getSizeVBR8(ULLONG_MAX >> 8));
+  EXPECT_EQ(9U, getSizeVBR8(ULLONG_MAX >> 7));
+  EXPECT_EQ(9U, getSizeVBR8(ULLONG_MAX));
+
+  // Check char.
+  EXPECT_EQ(1U, getSizeVBR8(char(0)));
+  EXPECT_EQ(1U, getSizeVBR8(char(1)));
+  EXPECT_EQ(1U, getSizeVBR8(char(127)));
+  EXPECT_EQ(1U, getSizeVBR8(char(-1)));
+  EXPECT_EQ(1U, getSizeVBR8(char(-128)));
+}
+
+} // end namespace

--- a/llvm/unittests/ExecutionEngine/CASObjectFormat/FixupListTest.cpp
+++ b/llvm/unittests/ExecutionEngine/CASObjectFormat/FixupListTest.cpp
@@ -1,0 +1,78 @@
+//===- FixupListTest.cpp - Unit tests for FixupList object file schema ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ExecutionEngine/CASObjectFormat/ObjectFileSchema.h"
+#include "llvm/Support/Endian.h"
+#include "llvm/Support/Memory.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::casobjectformat;
+
+namespace {
+
+TEST(FixupListTest, Empty) {
+  EXPECT_EQ(FixupList().begin(), FixupList().end());
+
+#if !defined(NDEBUG) && GTEST_HAS_DEATH_TEST
+  EXPECT_DEATH(++FixupList().begin(), "past the end");
+  EXPECT_DEATH(++FixupList().end(), "past the end");
+#endif
+}
+
+TEST(FixupListTest, Single) {
+  SmallString<128> Data;
+  auto makeList = [&Data](Fixup &&F) {
+    Data.clear();
+    FixupList::encode(makeArrayRef(F), Data);
+    return FixupList(Data);
+  };
+
+  {
+    FixupList FL = makeList(Fixup{jitlink::Edge::Kind(0), 0U});
+    EXPECT_NE(FL.begin(), FL.end());
+    EXPECT_EQ(jitlink::Edge::Kind(0), FL.begin()->Kind);
+    EXPECT_EQ(0U, FL.begin()->Offset);
+    EXPECT_EQ(1, std::distance(FL.begin(), FL.end()));
+#if !defined(NDEBUG) && GTEST_HAS_DEATH_TEST
+    EXPECT_DEATH(++++FL.begin(), "past the end");
+    EXPECT_DEATH(++FL.end(), "past the end");
+#endif
+  }
+
+  {
+    FixupList FL = makeList(Fixup{jitlink::Edge::Kind(127), 12345678U});
+    EXPECT_NE(FL.begin(), FL.end());
+    EXPECT_EQ(jitlink::Edge::Kind(127), FL.begin()->Kind);
+    EXPECT_EQ(12345678U, FL.begin()->Offset);
+    EXPECT_EQ(1, std::distance(FL.begin(), FL.end()));
+#if !defined(NDEBUG) && GTEST_HAS_DEATH_TEST
+    EXPECT_DEATH(++++FL.begin(), "past the end");
+    EXPECT_DEATH(++FL.end(), "past the end");
+#endif
+  }
+}
+
+TEST(FixupListTest, Multiple) {
+  Fixup Input[] = {
+      {jitlink::Edge::Kind(0), 0U},      {jitlink::Edge::Kind(1), 0U},
+      {jitlink::Edge::Kind(0), 1U},      {jitlink::Edge::Kind(1), 5U},
+      {jitlink::Edge::Kind(0), 876543U}, {jitlink::Edge::Kind(1), 555555U},
+      {jitlink::Edge::Kind(20), 0U},     {jitlink::Edge::Kind(127), 0U},
+      {jitlink::Edge::Kind(20), 17U},    {jitlink::Edge::Kind(127), 12345678U},
+  };
+
+  SmallString<128> Data;
+  FixupList::encode(Input, Data);
+  FixupList FL(Data);
+  SmallVector<Fixup, 16> Output(FL.begin(), FL.end());
+  EXPECT_EQ(makeArrayRef(Input), makeArrayRef(Output));
+}
+
+} // end namespace

--- a/llvm/unittests/ExecutionEngine/CASObjectFormat/ObjectFileSchemaTest.cpp
+++ b/llvm/unittests/ExecutionEngine/CASObjectFormat/ObjectFileSchemaTest.cpp
@@ -420,23 +420,23 @@ TEST(CASObjectFormatTests, BlockWithEdges) {
       expectedToOptional(BlockRef::create(Schema, B, createTarget));
   ASSERT_TRUE(Block);
   EXPECT_TRUE(Block->hasEdges());
-  Optional<TargetInfoListRef> TargetInfoList = cantFail(Block->getTargetInfo());
+  TargetInfoList TIs = cantFail(Block->getTargetInfo());
   FixupList Fixups = cantFail(Block->getFixups());
   Optional<TargetListRef> TargetList = cantFail(Block->getTargets());
   ASSERT_EQ(std::extent<decltype(AddOrder)>::value,
             size_t(std::distance(Fixups.begin(), Fixups.end())));
   ASSERT_EQ(std::extent<decltype(AddOrder)>::value,
-            TargetInfoList->getNumEdges());
+            size_t(std::distance(TIs.begin(), TIs.end())));
   ASSERT_EQ(3u, TargetList->getNumTargets());
 
   // Check the fixups and targets, in sorted order.
   FixupList::iterator F = Fixups.begin();
+  TargetInfoList::iterator TI = TIs.begin();
   for (size_t I = 0, E = std::extent<decltype(AddOrder)>::value; I != E;
-       ++I, ++F) {
-    size_t TargetIndex = TargetInfoList->getTargetIndex(I);
-    ASSERT_LT(TargetIndex, TargetList->getNumTargets());
+       ++I, ++F, ++TI) {
+    ASSERT_LT(TI->Index, TargetList->getNumTargets());
     Optional<TargetRef> Target =
-        expectedToOptional(TargetList->getTarget(TargetIndex));
+        expectedToOptional(TargetList->getTarget(TI->Index));
     ASSERT_TRUE(Target);
     TargetRef ExpectedTarget = *CreatedSymbols.lookup(Targets[I]);
 
@@ -444,7 +444,7 @@ TEST(CASObjectFormatTests, BlockWithEdges) {
     EXPECT_EQ(Kinds[I], F->Kind);
     EXPECT_EQ(Offsets[I], F->Offset);
     EXPECT_EQ(ExpectedTarget.getID(), Target->getID());
-    EXPECT_EQ(Addends[I], TargetInfoList->getAddend(I));
+    EXPECT_EQ(Addends[I], TI->Addend);
   }
 }
 

--- a/llvm/unittests/ExecutionEngine/CASObjectFormat/ObjectFileSchemaTest.cpp
+++ b/llvm/unittests/ExecutionEngine/CASObjectFormat/ObjectFileSchemaTest.cpp
@@ -422,21 +422,20 @@ TEST(CASObjectFormatTests, BlockWithEdges) {
   EXPECT_TRUE(Block->hasEdges());
   TargetInfoList TIs = cantFail(Block->getTargetInfo());
   FixupList Fixups = cantFail(Block->getFixups());
-  Optional<TargetListRef> TargetList = cantFail(Block->getTargets());
+  TargetList BlockTargets = cantFail(Block->getTargets());
   ASSERT_EQ(std::extent<decltype(AddOrder)>::value,
             size_t(std::distance(Fixups.begin(), Fixups.end())));
   ASSERT_EQ(std::extent<decltype(AddOrder)>::value,
             size_t(std::distance(TIs.begin(), TIs.end())));
-  ASSERT_EQ(3u, TargetList->getNumTargets());
+  ASSERT_EQ(3u, BlockTargets.size());
 
   // Check the fixups and targets, in sorted order.
   FixupList::iterator F = Fixups.begin();
   TargetInfoList::iterator TI = TIs.begin();
   for (size_t I = 0, E = std::extent<decltype(AddOrder)>::value; I != E;
        ++I, ++F, ++TI) {
-    ASSERT_LT(TI->Index, TargetList->getNumTargets());
-    Optional<TargetRef> Target =
-        expectedToOptional(TargetList->getTarget(TI->Index));
+    ASSERT_LT(TI->Index, BlockTargets.size());
+    Optional<TargetRef> Target = expectedToOptional(BlockTargets[TI->Index]);
     ASSERT_TRUE(Target);
     TargetRef ExpectedTarget = *CreatedSymbols.lookup(Targets[I]);
 

--- a/llvm/unittests/ExecutionEngine/CASObjectFormat/ObjectFileSchemaTest.cpp
+++ b/llvm/unittests/ExecutionEngine/CASObjectFormat/ObjectFileSchemaTest.cpp
@@ -421,15 +421,18 @@ TEST(CASObjectFormatTests, BlockWithEdges) {
   ASSERT_TRUE(Block);
   EXPECT_TRUE(Block->hasEdges());
   Optional<TargetInfoListRef> TargetInfoList = cantFail(Block->getTargetInfo());
-  Optional<FixupListRef> FixupList = cantFail(Block->getFixups());
+  FixupList Fixups = cantFail(Block->getFixups());
   Optional<TargetListRef> TargetList = cantFail(Block->getTargets());
-  ASSERT_EQ(std::extent<decltype(AddOrder)>::value, FixupList->getNumEdges());
+  ASSERT_EQ(std::extent<decltype(AddOrder)>::value,
+            size_t(std::distance(Fixups.begin(), Fixups.end())));
   ASSERT_EQ(std::extent<decltype(AddOrder)>::value,
             TargetInfoList->getNumEdges());
   ASSERT_EQ(3u, TargetList->getNumTargets());
 
   // Check the fixups and targets, in sorted order.
-  for (size_t I = 0, E = std::extent<decltype(AddOrder)>::value; I != E; ++I) {
+  FixupList::iterator F = Fixups.begin();
+  for (size_t I = 0, E = std::extent<decltype(AddOrder)>::value; I != E;
+       ++I, ++F) {
     size_t TargetIndex = TargetInfoList->getTargetIndex(I);
     ASSERT_LT(TargetIndex, TargetList->getNumTargets());
     Optional<TargetRef> Target =
@@ -438,8 +441,8 @@ TEST(CASObjectFormatTests, BlockWithEdges) {
     TargetRef ExpectedTarget = *CreatedSymbols.lookup(Targets[I]);
 
     // These are easy to test.
-    EXPECT_EQ(Kinds[I], FixupList->getFixupKind(I));
-    EXPECT_EQ(Offsets[I], FixupList->getFixupOffset(I));
+    EXPECT_EQ(Kinds[I], F->Kind);
+    EXPECT_EQ(Offsets[I], F->Offset);
     EXPECT_EQ(ExpectedTarget.getID(), Target->getID());
     EXPECT_EQ(Addends[I], TargetInfoList->getAddend(I));
   }

--- a/llvm/unittests/ExecutionEngine/CASObjectFormat/TargetInfoListTest.cpp
+++ b/llvm/unittests/ExecutionEngine/CASObjectFormat/TargetInfoListTest.cpp
@@ -1,0 +1,76 @@
+//===- TargetInfoListTest.cpp - Unit tests for TargetInfoList -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ExecutionEngine/CASObjectFormat/ObjectFileSchema.h"
+#include "llvm/Support/Endian.h"
+#include "llvm/Support/Memory.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::casobjectformat;
+
+namespace {
+
+TEST(TargetInfoListTest, Empty) {
+  EXPECT_EQ(TargetInfoList().begin(), TargetInfoList().end());
+
+#if !defined(NDEBUG) && GTEST_HAS_DEATH_TEST
+  EXPECT_DEATH(++TargetInfoList().begin(), "past the end");
+  EXPECT_DEATH(++TargetInfoList().end(), "past the end");
+#endif
+}
+
+TEST(TargetInfoListTest, Single) {
+  SmallString<128> Data;
+  auto makeList = [&Data](TargetInfo &&F) {
+    Data.clear();
+    TargetInfoList::encode(makeArrayRef(F), Data);
+    return TargetInfoList(Data);
+  };
+
+  {
+    TargetInfoList TIL = makeList(TargetInfo{0, 0U});
+    EXPECT_NE(TIL.begin(), TIL.end());
+    EXPECT_EQ(0, TIL.begin()->Addend);
+    EXPECT_EQ(0U, TIL.begin()->Index);
+    EXPECT_EQ(1, std::distance(TIL.begin(), TIL.end()));
+#if !defined(NDEBUG) && GTEST_HAS_DEATH_TEST
+    EXPECT_DEATH(++++TIL.begin(), "past the end");
+    EXPECT_DEATH(++TIL.end(), "past the end");
+#endif
+  }
+
+  {
+    TargetInfoList TIL = makeList(TargetInfo{7777777, 0U});
+    EXPECT_NE(TIL.begin(), TIL.end());
+    EXPECT_EQ(7777777, TIL.begin()->Addend);
+    EXPECT_EQ(0U, TIL.begin()->Index);
+    EXPECT_EQ(1, std::distance(TIL.begin(), TIL.end()));
+#if !defined(NDEBUG) && GTEST_HAS_DEATH_TEST
+    EXPECT_DEATH(++++TIL.begin(), "past the end");
+    EXPECT_DEATH(++TIL.end(), "past the end");
+#endif
+  }
+}
+
+TEST(TargetInfoListTest, Multiple) {
+  TargetInfo Input[] = {
+      {0, 0U},  {1, 1U},       {0, 2U},         {1, 3U},        {0, 7U},
+      {1, 13U}, {-20, 12U},    {-7777777, 11U}, {20, 5U},       {7777777, 10U},
+      {20, 4U}, {7777777, 9U}, {-20, 6U},       {-7777777, 8U},
+  };
+
+  SmallString<128> Data;
+  TargetInfoList::encode(Input, Data);
+  TargetInfoList TIL(Data);
+  SmallVector<TargetInfo, 16> Output(TIL.begin(), TIL.end());
+  EXPECT_EQ(makeArrayRef(Input), makeArrayRef(Output));
+}
+
+} // end namespace

--- a/llvm/unittests/ExecutionEngine/CASObjectFormat/TargetInfoListTest.cpp
+++ b/llvm/unittests/ExecutionEngine/CASObjectFormat/TargetInfoListTest.cpp
@@ -66,6 +66,7 @@ TEST(TargetInfoListTest, Multiple) {
       {20, 4U}, {7777777, 9U}, {-20, 6U},       {-7777777, 8U},
   };
 
+  // Then check iteration.
   SmallString<128> Data;
   TargetInfoList::encode(Input, Data);
   TargetInfoList TIL(Data);

--- a/llvm/unittests/ExecutionEngine/CASObjectFormat/TargetListTest.cpp
+++ b/llvm/unittests/ExecutionEngine/CASObjectFormat/TargetListTest.cpp
@@ -1,0 +1,150 @@
+//===- TargetListTest.cpp - Unit tests for TargetList ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ExecutionEngine/CASObjectFormat/ObjectFileSchema.h"
+#include "llvm/Support/Endian.h"
+#include "llvm/Support/Memory.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::casobjectformat;
+
+namespace {
+
+class TargetListTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    G.emplace("graph", Triple("x86_64-apple-darwin"), 8, support::little,
+              jitlink::getGenericEdgeKindName);
+    Section = &G->createSection("section", sys::Memory::MF_EXEC);
+    Z = &G->createZeroFillBlock(*Section, 256, 0, 256, 0);
+    ExternalS = &G->addExternalSymbol("External", 0, jitlink::Linkage::Strong);
+    DefinedS =
+        &G->addDefinedSymbol(*Z, 0, "Defined", 0, jitlink::Linkage::Strong,
+                             jitlink::Scope::Default, false, false);
+
+    // Prepare dependencies in the CAS.
+    CAS = cas::createInMemoryCAS();
+    Schema.emplace(*CAS);
+
+    // Create ExternalS.
+    CreatedExternalS =
+        expectedToOptional(IndirectSymbolRef::create(*Schema, *ExternalS));
+    ASSERT_TRUE(CreatedExternalS);
+
+    // Create the block and symbol for DefinedS.
+    ZeroBlock = expectedToOptional(
+        BlockRef::create(*Schema, *Z,
+                         [](const jitlink::Symbol &S, jitlink::Edge::Kind,
+                            bool IsFromData, jitlink::Edge::AddendT &,
+                            Optional<StringRef> &) -> Expected<TargetRef> {
+                           return createStringError(inconvertibleErrorCode(),
+                                                    "expected leaf block");
+                         }));
+    ASSERT_TRUE(ZeroBlock);
+    CreatedDefinedS = expectedToOptional(SymbolRef::create(
+        *Schema, *DefinedS,
+        [&](const jitlink::Block &B) -> Expected<SymbolDefinitionRef> {
+          assert(&B == Z);
+          return ZeroBlock->getAsSymbolDefinition();
+        }));
+    ASSERT_TRUE(CreatedDefinedS);
+
+    CreatedAbstractBackedgeS =
+        expectedToOptional(IndirectSymbolRef::createAbstractBackedge(*Schema));
+    ASSERT_TRUE(CreatedAbstractBackedgeS);
+  }
+  void TearDown() override {
+    CreatedAbstractBackedgeS.reset();
+    CreatedDefinedS.reset();
+    ZeroBlock.reset();
+    CreatedExternalS.reset();
+    Schema.reset();
+    CAS.reset();
+    Section = nullptr;
+    Z = nullptr;
+    ExternalS = nullptr;
+    DefinedS = nullptr;
+    G.reset();
+  }
+
+  Optional<jitlink::LinkGraph> G;
+  jitlink::Section *Section = nullptr;
+  jitlink::Block *Z = nullptr;
+  jitlink::Symbol *ExternalS = nullptr;
+  jitlink::Symbol *DefinedS = nullptr;
+  std::unique_ptr<cas::CASDB> CAS;
+  Optional<ObjectFileSchema> Schema;
+  Optional<IndirectSymbolRef> CreatedExternalS;
+  Optional<BlockRef> ZeroBlock;
+  Optional<SymbolRef> CreatedDefinedS;
+  Optional<IndirectSymbolRef> CreatedAbstractBackedgeS;
+};
+
+TEST_F(TargetListTest, empty) {
+  EXPECT_TRUE(TargetList().empty());
+  EXPECT_EQ(0U, TargetList().size());
+  EXPECT_FALSE(TargetList().hasAbstractBackedge());
+
+#if !defined(NDEBUG) && GTEST_HAS_DEATH_TEST
+  EXPECT_DEATH(expectedToOptional(TargetList()[0]), "past the end");
+#endif
+}
+
+TEST_F(TargetListTest, symbols) {
+  TargetRef Input[] = {
+      CreatedExternalS->getAsTarget(),
+      CreatedDefinedS->getAsTarget(),
+  };
+
+  // Create a list.
+  Optional<TargetListRef> ListRef =
+      expectedToOptional(TargetListRef::create(*Schema, Input));
+  ASSERT_TRUE(ListRef);
+  TargetList List = ListRef->getTargets();
+
+  // Check the content.
+  ASSERT_FALSE(List.empty());
+  ASSERT_EQ(std::extent<decltype(Input)>::value, List.size());
+  EXPECT_FALSE(List.hasAbstractBackedge());
+  for (size_t I = 0, E = List.size(); I != E; ++I) {
+    Optional<TargetRef> Ref = expectedToOptional(List[I]);
+    ASSERT_TRUE(Ref);
+    ASSERT_EQ(Input[I].getID(), Ref->getID());
+    ASSERT_EQ(Input[I].getKindString(), Ref->getKindString());
+  }
+}
+
+TEST_F(TargetListTest, symbolsWithAbstractBackedge) {
+  TargetRef Input[] = {
+      CreatedExternalS->getAsTarget(),
+      CreatedDefinedS->getAsTarget(),
+      CreatedAbstractBackedgeS->getAsTarget(),
+  };
+
+  // Create a list.
+  Optional<TargetListRef> ListRef =
+      expectedToOptional(TargetListRef::create(*Schema, Input));
+  ASSERT_TRUE(ListRef);
+  EXPECT_TRUE(ListRef->hasAbstractBackedge());
+  TargetList List = ListRef->getTargets();
+
+  // Check the content.
+  ASSERT_FALSE(List.empty());
+  ASSERT_EQ(std::extent<decltype(Input)>::value, List.size());
+  EXPECT_TRUE(List.hasAbstractBackedge());
+  for (size_t I = 0, E = List.size(); I != E; ++I) {
+    Optional<TargetRef> Ref = expectedToOptional(List[I]);
+    ASSERT_TRUE(Ref);
+    ASSERT_EQ(Input[I].getID(), Ref->getID());
+    ASSERT_EQ(Input[I].getKindString(), Ref->getKindString());
+  }
+}
+
+} // end namespace


### PR DESCRIPTION
Have a look at the individual commits for details. This is a series of NFC prep commits (refactoring and adding unit tests for various components), followed by the meat in dfa33eaaf1303d201b6646b408082974e7360de5 which actually changes the encoding.

I've also thought through (and documented next to `CompileUnitRef`) some changes to the schema that might help us get further.