### PR TITLE
Reland "[lldb] Use CompileUnit::ResolveSymbolContext in SymbolFileDWARF"

### DIFF
--- a/lldb/source/Symbol/CompileUnit.cpp
+++ b/lldb/source/Symbol/CompileUnit.cpp
@@ -254,17 +254,6 @@ void CompileUnit::ResolveSymbolContext(
   if (!file_spec_matches_cu_file_spec && !check_inlines)
     return;
 
-  uint32_t file_idx =
-      GetSupportFiles().FindFileIndex(0, file_spec, true);
-  while (file_idx != UINT32_MAX) {
-    file_indexes.push_back(file_idx);
-    file_idx = GetSupportFiles().FindFileIndex(file_idx + 1, file_spec, true);
-  }
-
-  const size_t num_file_indexes = file_indexes.size();
-  if (num_file_indexes == 0)
-    return;
-
   SymbolContext sc(GetModule());
   sc.comp_unit = this;
 
@@ -277,10 +266,25 @@ void CompileUnit::ResolveSymbolContext(
     return;
   }
 
+  uint32_t file_idx =
+      GetSupportFiles().FindFileIndex(0, file_spec, true);
+  while (file_idx != UINT32_MAX) {
+    file_indexes.push_back(file_idx);
+    file_idx = GetSupportFiles().FindFileIndex(file_idx + 1, file_spec, true);
+  }
+
+  const size_t num_file_indexes = file_indexes.size();
+  if (num_file_indexes == 0)
+    return;
+
   LineTable *line_table = sc.comp_unit->GetLineTable();
 
-  if (line_table == nullptr)
+  if (line_table == nullptr) {
+    if (file_spec_matches_cu_file_spec && !check_inlines) {
+      sc_list.Append(sc);
+    }
     return;
+  }
 
   uint32_t line_idx;
   LineEntry line_entry;


### PR DESCRIPTION
This patch relands changes introduced in b7c987be79a73e479472e157f20197082e936506
and aligns it with llvm.org.

This should also fix the test failure in `dwarf5-debug_line-file-index.s`.

rdar://83444992

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>