### PR TITLE
[lldb] Improve meta data stripping from JSON crashlogs

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -415,8 +415,14 @@ class JSONCrashLogParser:
         with open(self.path, 'r') as f:
             buffer = f.read()
 
-        # First line is meta-data.
-        buffer = buffer[buffer.index('\n') + 1:]
+        # Skip the first line if it contains meta data.
+        head, _, tail = buffer.partition('\n')
+        try:
+            metadata = json.loads(head)
+            if 'app_name' in metadata and 'app_version' in metadata:
+                buffer = tail
+        except ValueError:
+            pass
 
         try:
             self.data = json.loads(buffer)

--- a/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/json.test
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/json.test
@@ -1,7 +1,12 @@
 # RUN: %clang_host -g %S/Inputs/test.c -o %t.out
+
 # RUN: cp %S/Inputs/a.out.ips %t.crash
 # RUN: python %S/patch-crashlog.py --binary %t.out --crashlog %t.crash --offsets '{"main":20, "bar":9, "foo":16}' --json
 # RUN: %lldb %t.out -o 'command script import lldb.macosx.crashlog' -o 'crashlog %t.crash' 2>&1 | FileCheck %s
+
+# RUN: cp %S/Inputs/a.out.ips %t.nometadata.crash
+# RUN: python %S/patch-crashlog.py --binary %t.out --crashlog %t.nometadata.crash --offsets '{"main":20, "bar":9, "foo":16}' --json --no-metadata
+# RUN: %lldb %t.out -o 'command script import lldb.macosx.crashlog' -o 'crashlog %t.nometadata.crash' 2>&1 | FileCheck %s
 
 # CHECK: Thread[0] Crashing Thread Name EXC_BAD_ACCESS (SIGSEGV) (KERN_INVALID_ADDRESS at 0x0000000000000000)
 # CHECK: [  0] {{.*}}out`foo + 16 at test.c

--- a/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/patch-crashlog.py
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/patch-crashlog.py
@@ -49,6 +49,9 @@ class CrashLogPatcher:
                     self.data = self.data.replace(
                         "@{}@".format(symbol), str(representation(patch_addr)))
 
+    def remove_metadata(self):
+        self.data= self.data[self.data.index('\n') + 1:]
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Crashlog Patcher')
@@ -56,6 +59,7 @@ if __name__ == '__main__':
     parser.add_argument('--crashlog', required=True)
     parser.add_argument('--offsets', required=True)
     parser.add_argument('--json', default=False, action='store_true')
+    parser.add_argument('--no-metadata', default=False, action='store_true')
     args = parser.parse_args()
 
     offsets = json.loads(args.offsets)
@@ -67,6 +71,9 @@ if __name__ == '__main__':
     p.patch_executable()
     p.patch_uuid()
     p.patch_addresses()
+
+    if args.no_metadata:
+        p.remove_metadata()
 
     with open(args.crashlog, 'w') as file:
         file.write(p.data)


### PR DESCRIPTION
JSON crashlogs normally start with a single line of meta data that we
strip unconditionally. Some producers started omitting the meta data
which tripped up crashlog. Be more resilient by only removing the first
line when we know it really is meta data.

rdar://82641662
(cherry picked from commit 730fca46fc87dad09040cb0b27ede10ae2c7c9d7)
