### PR TITLE
[lldb] Add new Swift log channel

### DIFF
--- a/lldb/include/lldb/Utility/Logging.h
+++ b/lldb/include/lldb/Utility/Logging.h
@@ -62,7 +62,9 @@ Log *GetLogIfAllCategoriesSet(uint32_t mask);
 
 Log *GetLogIfAnyCategoriesSet(uint32_t mask);
 
+#ifdef LLDB_ENABLE_SWIFT
 Log *GetSwiftHealthLog();
+#endif
 
 void InitializeLldbChannel();
 

--- a/lldb/include/lldb/Utility/Logging.h
+++ b/lldb/include/lldb/Utility/Logging.h
@@ -50,7 +50,9 @@
    LIBLLDB_LOG_STATE | LIBLLDB_LOG_SYMBOLS | LIBLLDB_LOG_TARGET |              \
    LIBLLDB_LOG_COMMANDS)
 
+#ifdef LLDB_ENABLE_SWIFT
 #define LIBLLDB_SWIFT_LOG_HEALTH (1u << 1)
+#endif
 
 namespace lldb_private {
 

--- a/lldb/include/lldb/Utility/Logging.h
+++ b/lldb/include/lldb/Utility/Logging.h
@@ -50,6 +50,8 @@
    LIBLLDB_LOG_STATE | LIBLLDB_LOG_SYMBOLS | LIBLLDB_LOG_TARGET |              \
    LIBLLDB_LOG_COMMANDS)
 
+#define LIBLLDB_SWIFT_LOG_HEALTH (1u << 1)
+
 namespace lldb_private {
 
 class Log;
@@ -57,6 +59,8 @@ class Log;
 Log *GetLogIfAllCategoriesSet(uint32_t mask);
 
 Log *GetLogIfAnyCategoriesSet(uint32_t mask);
+
+Log *GetSwiftHealthLog();
 
 void InitializeLldbChannel();
 

--- a/lldb/source/Utility/Logging.cpp
+++ b/lldb/source/Utility/Logging.cpp
@@ -49,10 +49,16 @@ static constexpr Log::Category g_categories[] = {
   {{"watch"}, {"log watchpoint related activities"}, LIBLLDB_LOG_WATCHPOINTS},
 };
 
+static constexpr Log::Category g_swift_categories[] = {
+  {{"health"}, {"log all messages related to lldb Swift operational health"}, LIBLLDB_SWIFT_LOG_HEALTH},
+};
+
 static Log::Channel g_log_channel(g_categories, LIBLLDB_LOG_DEFAULT);
+static Log::Channel g_swift_log_channel(g_swift_categories, LIBLLDB_SWIFT_LOG_HEALTH);
 
 void lldb_private::InitializeLldbChannel() {
   Log::Register("lldb", g_log_channel);
+  Log::Register("swift", g_swift_log_channel);
 }
 
 Log *lldb_private::GetLogIfAllCategoriesSet(uint32_t mask) {
@@ -61,4 +67,8 @@ Log *lldb_private::GetLogIfAllCategoriesSet(uint32_t mask) {
 
 Log *lldb_private::GetLogIfAnyCategoriesSet(uint32_t mask) {
   return g_log_channel.GetLogIfAny(mask);
+}
+
+Log *lldb_private::GetSwiftHealthLog() {
+  return g_swift_log_channel.GetLogIfAny(LIBLLDB_SWIFT_LOG_HEALTH);
 }

--- a/lldb/source/Utility/Logging.cpp
+++ b/lldb/source/Utility/Logging.cpp
@@ -49,16 +49,23 @@ static constexpr Log::Category g_categories[] = {
   {{"watch"}, {"log watchpoint related activities"}, LIBLLDB_LOG_WATCHPOINTS},
 };
 
+static Log::Channel g_log_channel(g_categories, LIBLLDB_LOG_DEFAULT);
+
+#ifdef LLDB_ENABLE_SWIFT
+
 static constexpr Log::Category g_swift_categories[] = {
   {{"health"}, {"log all messages related to lldb Swift operational health"}, LIBLLDB_SWIFT_LOG_HEALTH},
 };
 
-static Log::Channel g_log_channel(g_categories, LIBLLDB_LOG_DEFAULT);
 static Log::Channel g_swift_log_channel(g_swift_categories, LIBLLDB_SWIFT_LOG_HEALTH);
+
+#endif
 
 void lldb_private::InitializeLldbChannel() {
   Log::Register("lldb", g_log_channel);
+#ifdef LLDB_ENABLE_SWIFT
   Log::Register("swift", g_swift_log_channel);
+#endif
 }
 
 Log *lldb_private::GetLogIfAllCategoriesSet(uint32_t mask) {
@@ -69,6 +76,8 @@ Log *lldb_private::GetLogIfAnyCategoriesSet(uint32_t mask) {
   return g_log_channel.GetLogIfAny(mask);
 }
 
+#ifdef LLDB_ENABLE_SWIFT
 Log *lldb_private::GetSwiftHealthLog() {
   return g_swift_log_channel.GetLogIfAny(LIBLLDB_SWIFT_LOG_HEALTH);
 }
+#endif


### PR DESCRIPTION
This adds a new log channel named "swift", which has a single category named "health". The purpose of this new log channel is to provide an always enabled log, which will be used to capture key information (yet low volume) related to lldb's ability to debug a swift target/process. These logs will either be written to a temp file, or memory buffer.

The requirements of this new log can't be satisfied by defining a new category in the existing "lldb" channel, because there is a single log stream per channel. This means when a user enables their own logging, ex `log enable lldb types`, this would have the side effect of disabling or redirecting the always enabled log.

This new channel is expected to be low volume, and doesn't seem to need multiple categories. Because of this, the API to access it takes no arguments: `GetSwiftHealthLog()`.