### PR TITLE
[lldb] Implement GetGenericArgumentType and IsTupleType on tss-typeref

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -349,7 +349,10 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
         swift_runtime->GetMetadataPromise(argmetadata_ptr, valobj));
     if (promise_sp)
       if (CompilerType type = promise_sp->FulfillTypePromise())
-        argument_type = SwiftASTContext::GetGenericArgumentType(type, 0);
+        if (TypeSystemSwift *type_system =
+                llvm::dyn_cast<TypeSystemSwift>(type.GetTypeSystem()))
+          argument_type =
+              type_system->GetGenericArgumentType(type.GetOpaqueQualType(), 0);
 
     if (!argument_type.IsValid())
       return nullptr;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4962,6 +4962,13 @@ SwiftASTContext::CreateTupleType(const std::vector<TupleElement> &elements) {
   }
 }
 
+bool SwiftASTContext::IsTupleType(lldb::opaque_compiler_type_t type) {
+  VALID_OR_RETURN(false);
+
+  auto swift_type = GetSwiftType(type);
+  return llvm::isa<::swift::TupleType>(swift_type);
+}
+
 CompilerType SwiftASTContext::GetErrorType() {
   VALID_OR_RETURN(CompilerType());
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -395,6 +395,7 @@ public:
 
   CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) override;
+  bool IsTupleType(lldb::opaque_compiler_type_t type) override;
 
   CompilerType GetErrorType() override;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -126,9 +126,14 @@ public:
   struct TupleElement {
     ConstString element_name;
     CompilerType element_type;
+    
+    TupleElement() = default;
+    TupleElement(ConstString name, CompilerType type)
+        : element_name(name), element_type(type) {}
   };
   virtual CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) = 0;
+  virtual bool IsTupleType(lldb::opaque_compiler_type_t type) = 0;
   using TypeSystem::DumpTypeDescription;
   virtual void DumpTypeDescription(
       lldb::opaque_compiler_type_t type, bool print_help_if_available,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -240,6 +240,7 @@ public:
   GetAllocationStrategy(lldb::opaque_compiler_type_t type) override;
   CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) override;
+  bool IsTupleType(lldb::opaque_compiler_type_t type) override;
   void DumpTypeDescription(
       lldb::opaque_compiler_type_t type, bool print_help_if_available,
       bool print_extensions_if_available,

--- a/lldb/test/Shell/SwiftREPL/ResilientDict.test
+++ b/lldb/test/Shell/SwiftREPL/ResilientDict.test
@@ -1,9 +1,6 @@
 // REQUIRES: system-darwin
 // REQUIRES: swift
 
-// rdar://82038873
-// XFAIL: *
-
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=DICT
 
 // The dictionary order isn't deterministic, so print the dictionary
@@ -12,14 +9,14 @@
 import Foundation
 
 let x : [URL:Int] = [URL(string: "https://github.com")!: 4, URL(string: "https://apple.com")!: 23]
-// DICT-LABEL: {{x}}: [URL : Int] = 2 key/value pairs {
+// DICT-LABEL: {{x}}: [Foundation.URL : Int] = 2 key/value pairs {
 // DICT:      [{{[0-1]}}] = {
 // DICT:         key = "https://apple.com"
 // DICT-NEXT:    value = 23
 // DICT-NEXT:  }
 
 let y : [URL:Int] = [URL(string: "https://github.com")!: 4, URL(string: "https://apple.com")!: 23]
-// DICT-LABEL: {{y}}: [URL : Int] = 2 key/value pairs {
+// DICT-LABEL: {{y}}: [Foundation.URL : Int] = 2 key/value pairs {
 // DICT:       [{{[0-1]}}] = {
 // DICT:          key = "https://github.com"
 // DICT-NEXT:     value = 4


### PR DESCRIPTION
Implement GetGenericArgumentType and IsTupleType on
TypeSystemSwiftTypeRef, and replace direct calls to SwiftASTContext's
versions of those functions with type system unaware ones.

rdar://82038873
rdar://79053148