### PR TITLE
[lldb] Find public Objective-C class when reconstructing type

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2844,14 +2844,9 @@ bool TypeSystemSwiftTypeRef::IsImportedType(opaque_compiler_type_t type,
     return true;
   };
   FALLBACK(IsImportedType, (ReconstructType(type), original_type));
-  // Dont compare the results if there is no ClangImporter in the SwiftASTContext.
-  const auto &props = ModuleList::GetGlobalModuleListProperties();
-  if (!props.GetUseSwiftClangImporter())
-    return impl();
-
-  VALIDATE_AND_RETURN(impl, IsImportedType, type,
-                      (ReconstructType(type), nullptr),
-                      (ReconstructType(type), original_type));
+  // We can't validate the result because ReconstructType may call this
+  // function, causing an infinite loop.
+  return impl();
 }
 
 bool TypeSystemSwiftTypeRef::IsExistentialType(


### PR DESCRIPTION
When reconstructing a private Objective-C type, walk up the
type hierarchy until a type importable from Swift is found or
until we run out of types.

(cherry picked from commit 33bf8f72eedce37ddc5f4b3e2aaf29a2242f083d)