### PR TITLE
[lldb] Consider local decls when getting base name of a node

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -278,6 +278,9 @@ public:
                            swift::Demangle::Demangler &dem,
                            llvm::StringRef mangled_name);
 
+  /// Return the base name of the topmost nominal type.
+  static llvm::StringRef GetBaseName(swift::Demangle::NodePointer node);
+
   /// Use API notes to determine the swiftified name of \p clang_decl.
   std::string GetSwiftName(const clang::Decl *clang_decl,
                            TypeSystemClang &clang_typesystem) override;

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -705,3 +705,31 @@ TEST_F(TestTypeSystemSwiftTypeRef, IsTypedefType) {
   };
 }
 
+TEST_F(TestTypeSystemSwiftTypeRef, GetBaseName) {
+  using namespace swift::Demangle;
+  Demangler dem;
+  NodeBuilder b(dem);
+  {
+    NodePointer n = 
+            b.Node(Node::Kind::Class,
+              b.Node(Node::Kind::Function,
+                b.Node(Node::Kind::Module, "a"),
+                b.Node(Node::Kind::Identifier, "main"),
+                b.Node(Node::Kind::Type,
+                  b.Node(Node::Kind::FunctionType,
+                    b.Node(Node::Kind::ArgumentTuple,
+                      b.Node(Node::Kind::Type,
+                        b.Node(Node::Kind::Tuple)))),
+                  b.Node(Node::Kind::ReturnType,
+                    b.Node(Node::Kind::Type,
+                      b.Node(Node::Kind::Structure,
+                        b.Node(Node::Kind::Module, "Swift"),
+                        b.Node(Node::Kind::Identifier, "Int")))))),
+          b.Node(Node::Kind::LocalDeclName,
+            b.NodeWithIndex(Node::Kind::Number, 0),
+            b.Node(Node::Kind::Identifier, "Base")));
+    auto name = TypeSystemSwiftTypeRef::GetBaseName(n);
+    ASSERT_EQ(name, "Base");
+  }
+}
+


### PR DESCRIPTION
(cherry picked from commit cf7cb6b6dea8e81ccefbc60b7f760796ea671960)