### PR TITLE
[lldb] Implement GetGenericArgumentType and IsTupleType on tss-typeref

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -349,7 +349,10 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
         swift_runtime->GetMetadataPromise(argmetadata_ptr, valobj));
     if (promise_sp)
       if (CompilerType type = promise_sp->FulfillTypePromise())
-        argument_type = SwiftASTContext::GetGenericArgumentType(type, 0);
+        if (TypeSystemSwift *type_system =
+                llvm::dyn_cast<TypeSystemSwift>(type.GetTypeSystem()))
+          argument_type =
+              type_system->GetGenericArgumentType(type.GetOpaqueQualType(), 0);
 
     if (!argument_type.IsValid())
       return nullptr;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4973,6 +4973,13 @@ SwiftASTContext::CreateTupleType(const std::vector<TupleElement> &elements) {
   }
 }
 
+bool SwiftASTContext::IsTupleType(lldb::opaque_compiler_type_t type) {
+  VALID_OR_RETURN(false);
+
+  auto swift_type = GetSwiftType(type);
+  return llvm::isa<::swift::TupleType>(swift_type);
+}
+
 CompilerType SwiftASTContext::GetErrorType() {
   VALID_OR_RETURN(CompilerType());
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -395,6 +395,7 @@ public:
 
   CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) override;
+  bool IsTupleType(lldb::opaque_compiler_type_t type) override;
 
   CompilerType GetErrorType() override;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -125,9 +125,14 @@ public:
   struct TupleElement {
     ConstString element_name;
     CompilerType element_type;
+    
+    TupleElement() = default;
+    TupleElement(ConstString name, CompilerType type)
+        : element_name(name), element_type(type) {}
   };
   virtual CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) = 0;
+  virtual bool IsTupleType(lldb::opaque_compiler_type_t type) = 0;
   using TypeSystem::DumpTypeDescription;
   virtual void DumpTypeDescription(
       lldb::opaque_compiler_type_t type, bool print_help_if_available,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1321,13 +1321,6 @@ CompilerType TypeSystemSwiftTypeRef::GetTypeFromMangledTypename(
   return {this, (opaque_compiler_type_t)mangled_typename.AsCString()};
 }
 
-CompilerType
-TypeSystemSwiftTypeRef::GetGenericArgumentType(opaque_compiler_type_t type,
-                                               size_t idx) {
-  return m_swift_ast_context->GetGenericArgumentType(ReconstructType(type),
-                                                     idx);
-}
-
 lldb::TypeSP TypeSystemSwiftTypeRef::GetCachedType(ConstString mangled) {
   return m_swift_ast_context->GetCachedType(mangled);
 }
@@ -3051,10 +3044,21 @@ CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
     auto result = impl();
     if (!m_swift_ast_context)
       return result;
+    std::vector<TupleElement> ast_elements;
+    std::transform(elements.begin(), elements.end(),
+                   std::back_inserter(ast_elements), [&](TupleElement element) {
+                     return TupleElement(element.element_name,
+                                         ReconstructType(element.element_type));
+                   });
     bool equivalent =
-        Equivalent(result, m_swift_ast_context->CreateTupleType(elements));
-    if (!equivalent)
+        Equivalent(result, m_swift_ast_context->CreateTupleType(ast_elements));
+    if (!equivalent) {
+      result.dump();
+      auto a = m_swift_ast_context->CreateTupleType(elements);
+      llvm::dbgs() << "AST type: " << a.GetMangledTypeName() << "\n";
       llvm::dbgs() << "failing tuple type\n";
+    }
+
     assert(equivalent &&
            "TypeSystemSwiftTypeRef diverges from SwiftASTContext");
     return result;
@@ -3062,6 +3066,17 @@ CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
 #else
   return impl();
 #endif
+}
+
+bool TypeSystemSwiftTypeRef::IsTupleType(lldb::opaque_compiler_type_t type) {
+  auto impl = [&] {
+    using namespace swift::Demangle;
+    Demangler dem;
+    NodePointer node = GetDemangledType(dem, AsMangledName(type));
+    return node->getKind() == Node::Kind::Tuple;
+  };
+  VALIDATE_AND_RETURN(impl, IsTupleType, type, (ReconstructType(type)), (ReconstructType(type)));
+  return false;
 }
 
 void TypeSystemSwiftTypeRef::DumpTypeDescription(
@@ -3492,4 +3507,37 @@ bool TypeSystemSwiftTypeRef::IsReferenceType(opaque_compiler_type_t type,
   VALIDATE_AND_RETURN(impl, IsReferenceType, type,
                       (ReconstructType(type), nullptr, nullptr),
                       (ReconstructType(type), pointee_type, is_rvalue));
+}
+
+CompilerType
+TypeSystemSwiftTypeRef::GetGenericArgumentType(opaque_compiler_type_t type,
+                                               size_t idx) {
+  auto impl = [&]() -> CompilerType {
+    Demangler dem;
+    NodePointer node = DemangleCanonicalType(dem, type);
+    if (!node || node->getNumChildren() != 2)
+      return {};
+
+    if (node->getKind() != Node::Kind::BoundGenericClass &&
+        node->getKind() != Node::Kind::BoundGenericStructure &&
+        node->getKind() != Node::Kind::BoundGenericEnum &&
+        node->getKind() != Node::Kind::BoundGenericFunction &&
+        node->getKind() != Node::Kind::BoundGenericProtocol &&
+        node->getKind() != Node::Kind::BoundGenericTypeAlias &&
+        node->getKind() != Node::Kind::BoundGenericProtocol)
+      return {};
+
+    NodePointer type_list = node->getChild(1);
+    if (!type_list || type_list->getNumChildren() <= idx)
+      return {};
+
+    NodePointer generic_argument_type = type_list->getChild(idx);
+    if (!generic_argument_type)
+      return {};
+
+    return RemangleAsType(dem, generic_argument_type);
+  };
+
+  VALIDATE_AND_RETURN(impl, GetGenericArgumentType, type, (ReconstructType(type), idx),
+    (ReconstructType(type), idx));
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -239,6 +239,7 @@ public:
   GetAllocationStrategy(lldb::opaque_compiler_type_t type) override;
   CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) override;
+  bool IsTupleType(lldb::opaque_compiler_type_t type) override;
   void DumpTypeDescription(
       lldb::opaque_compiler_type_t type, bool print_help_if_available,
       bool print_extensions_if_available,

--- a/lldb/test/Shell/SwiftREPL/ResilientDict.test
+++ b/lldb/test/Shell/SwiftREPL/ResilientDict.test
@@ -9,14 +9,14 @@
 import Foundation
 
 let x : [URL:Int] = [URL(string: "https://github.com")!: 4, URL(string: "https://apple.com")!: 23]
-// DICT-LABEL: {{x}}: [URL : Int] = 2 key/value pairs {
+// DICT-LABEL: {{x}}: [Foundation.URL : Int] = 2 key/value pairs {
 // DICT:      [{{[0-1]}}] = {
 // DICT:         key = "https://apple.com"
 // DICT-NEXT:    value = 23
 // DICT-NEXT:  }
 
 let y : [URL:Int] = [URL(string: "https://github.com")!: 4, URL(string: "https://apple.com")!: 23]
-// DICT-LABEL: {{y}}: [URL : Int] = 2 key/value pairs {
+// DICT-LABEL: {{y}}: [Foundation.URL : Int] = 2 key/value pairs {
 // DICT:       [{{[0-1]}}] = {
 // DICT:          key = "https://github.com"
 // DICT-NEXT:     value = 4


### PR DESCRIPTION
Implement GetGenericArgumentType and IsTupleType on
TypeSystemSwiftTypeRef, and replace direct calls to SwiftASTContext's
versions of those functions with type system unaware ones.

(cherry picked from commit c92a7f7505a3e76327ccd8f7054ee2ea5ed31fd3)