### PR TITLE
Implement a warning that detects Swift compile units that were compil…

### DIFF
--- a/lldb/include/lldb/Symbol/SymbolFile.h
+++ b/lldb/include/lldb/Symbol/SymbolFile.h
@@ -131,6 +131,9 @@ public:
 
   Symtab *GetSymtab();
 
+  virtual llvm::VersionTuple GetProducerVersion(CompileUnit &comp_unit) {
+    return {};
+  }
   virtual lldb::LanguageType ParseLanguage(CompileUnit &comp_unit) = 0;
   /// Return the Xcode SDK comp_unit was compiled against.
   virtual XcodeSDK ParseXcodeSDK(CompileUnit &comp_unit) { return {}; }

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -93,6 +93,9 @@ public:
   void SetDetachKeepsStopped(bool keep_stopped);
   bool GetWarningsOptimization() const;
   bool GetWarningsUnsupportedLanguage() const;
+#ifdef LLDB_ENABLE_SWIFT
+  bool GetWarningsToolchainMismatch() const;
+#endif
   bool GetStopOnExec() const;
   std::chrono::seconds GetUtilityExpressionTimeout() const;
   std::chrono::seconds GetInterruptTimeout() const;
@@ -371,7 +374,8 @@ public:
   enum Warnings {
     eWarningsOptimization = 1,
     eWarningsUnsupportedLanguage = 2,
-    eWarningsSwiftImport
+    eWarningsSwiftImport,
+    eWarningsToolchainMismatch
   };
 
   typedef Range<lldb::addr_t, lldb::addr_t> LoadRange;
@@ -1329,6 +1333,7 @@ public:
   ///     pre-computed.
   void PrintWarningOptimization(const SymbolContext &sc);
 
+#ifdef LLDB_ENABLE_SWIFT
   /// Prints a async warning message to the user one time per Process
   /// for a Module whose Swift AST sections couldn't be loaded because
   /// they aren't buildable on the current machine.
@@ -1338,6 +1343,11 @@ public:
   void PrintWarningCantLoadSwiftModule(const Module &module,
                                        std::string details);
 
+  /// Print a user-visible warning about Swift CUs compiled with a
+  /// different Swift compiler than the one embedded in LLDB.
+  void PrintWarningToolchainMismatch(const SymbolContext &sc);
+#endif
+  
   /// Print a user-visible warning about a function written in a
   /// language that this version of LLDB doesn't support.
   ///

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -854,6 +854,16 @@ bool SymbolFileDWARF::FixupAddress(Address &addr) {
   // This is a normal DWARF file, no address fixups need to happen
   return true;
 }
+
+llvm::VersionTuple SymbolFileDWARF::GetProducerVersion(CompileUnit &comp_unit) {
+  std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
+  DWARFUnit *dwarf_cu = GetDWARFCompileUnit(&comp_unit);
+  if (dwarf_cu)
+    return dwarf_cu->GetProducerVersion();
+  else
+    return {};
+}
+
 lldb::LanguageType SymbolFileDWARF::ParseLanguage(CompileUnit &comp_unit) {
   std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
   DWARFUnit *dwarf_cu = GetDWARFCompileUnit(&comp_unit);

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
@@ -108,6 +108,8 @@ public:
   void InitializeObject() override;
 
   // Compile Unit function calls
+  llvm::VersionTuple
+  GetProducerVersion(lldb_private::CompileUnit &comp_unit) override;
 
   lldb::LanguageType
   ParseLanguage(lldb_private::CompileUnit &comp_unit) override;

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -621,6 +621,15 @@ size_t SymbolFileDWARFDebugMap::GetCompUnitInfosForModule(
   return cu_infos.size();
 }
 
+llvm::VersionTuple
+SymbolFileDWARFDebugMap::GetProducerVersion(CompileUnit &comp_unit) {
+  std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
+  SymbolFileDWARF *oso_dwarf = GetSymbolFile(comp_unit);
+  if (oso_dwarf)
+    return oso_dwarf->GetProducerVersion(comp_unit);
+  return {};
+}
+
 lldb::LanguageType
 SymbolFileDWARFDebugMap::ParseLanguage(CompileUnit &comp_unit) {
   std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.h
@@ -56,6 +56,8 @@ public:
   void InitializeObject() override;
 
   // Compile Unit function calls
+  llvm::VersionTuple
+  GetProducerVersion(lldb_private::CompileUnit &comp_unit) override;
   lldb::LanguageType
   ParseLanguage(lldb_private::CompileUnit &comp_unit) override;
   lldb_private::XcodeSDK

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -238,6 +238,9 @@ let Definition = "process" in {
   def WarningUnsupportedLanguage: Property<"unsupported-language-warnings", "Boolean">,
     DefaultTrue,
     Desc<"If true, warn when stopped in code that is written in a source language that LLDB does not support.">;
+  def WarningToolchainMismatch: Property<"toolchain-mismatch-warnings", "Boolean">,
+    DefaultTrue,
+    Desc<"If true, warn when stopped in code that was compiled by a Swift compiler different from the one embedded in LLDB.">;
   def StopOnExec: Property<"stop-on-exec", "Boolean">,
     Global,
     DefaultTrue,

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -321,11 +321,18 @@ void Thread::FrameSelectedCallback(StackFrame *frame) {
 
   if (frame->HasDebugInformation() &&
       (GetProcess()->GetWarningsOptimization() ||
-       GetProcess()->GetWarningsUnsupportedLanguage())) {
+       GetProcess()->GetWarningsUnsupportedLanguage()
+#ifdef LLDB_ENABLE_SWIFT
+       || GetProcess()->GetWarningsToolchainMismatch())
+#endif
+      ) {
     SymbolContext sc =
         frame->GetSymbolContext(eSymbolContextFunction | eSymbolContextModule);
     GetProcess()->PrintWarningOptimization(sc);
     GetProcess()->PrintWarningUnsupportedLanguage(sc);
+#ifdef LLDB_ENABLE_SWIFT
+    GetProcess()->PrintWarningToolchainMismatch(sc);
+#endif
   }
   SymbolContext msc = frame->GetSymbolContext(eSymbolContextModule);
   if (msc.module_sp)

--- a/lldb/test/Shell/Swift/ToolchainMismatch.test
+++ b/lldb/test/Shell/Swift/ToolchainMismatch.test
@@ -1,0 +1,38 @@
+# REQUIRES: swift
+
+# Tests that a warning is printed when stopped in a Swift frame
+# compiled by a different Swift compiler than the one embedded in LLDB.
+
+# RUN: rm -rf %t && mkdir %t && cd %t
+# RUN: %target-swiftc -g \
+# RUN:          -module-cache-path %t/cache %S/Inputs/main.swift \
+# RUN:          -module-name main -o %t/a.ll -emit-ir
+# RUN: sed -i -e 's/producer: "[^"]*Swift [^"]*"/producer: "Future Swift (swiftlang-9999.8.7.6)"/g' %t/a.ll
+# RUN: %clang_host -c %t/a.ll -o %t/a.o
+# RUN: llvm-dwarfdump -r 0 %t/a.o | grep -q swiftlang-9999
+# RUN: %target-swiftc \
+# RUN:          -module-cache-path %t/cache \
+# RUN:          %t/a.o -o %t/a.out
+# RUN: %lldb %t/a.out -s %s 2>&1 | FileCheck %s
+
+# Sanity check: Swift
+# RUN: %target-swiftc -g \
+# RUN:          -module-cache-path %t/cache %S/Inputs/main.swift \
+# RUN:          -module-name main -o %t/good.out
+# RUN: %lldb %t/good.out -s %s 2>&1 | FileCheck %s --check-prefix=SANITY
+
+# Sanity check: Clang
+# RUN: %clang_host -g \
+# RUN:          %S/../Driver/Inputs/hello.cpp \
+# RUN:          -o %t/clang.out
+# RUN: %lldb %t/clang.out -s %s 2>&1 | FileCheck %s --check-prefix=SANITY
+
+b main
+run
+quit
+
+# The {{ }} avoids accidentally matching the input script!
+# CHECK: {{a\.out}} was compiled with a Swift compiler from a different toolchain.
+# CHECK: stop reason{{ = }}breakpoint
+# SANITY-NOT: {{a\.out}} was compiled with a Swift compiler from a different toolchain.
+# SANITY: stop reason{{ = }}breakpoint


### PR DESCRIPTION
…ed with

a different Swift compiler than the one that is embedded in LLDB.

rdar://82982242
(cherry picked from commit 58c5b073c9e41fda9c329253e58d7da2078e8056)