### PR TITLE
[llvm-cas-object-format] Convert object files from blob in CAS

### DIFF
--- a/llvm/test/tools/llvm-cas-object-format/Inputs/main.ll
+++ b/llvm/test/tools/llvm-cas-object-format/Inputs/main.ll
@@ -1,0 +1,13 @@
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx12.0.0"
+
+define i32 @_foo() #0 {
+  ret i32 0
+}
+
+define i32 @main() #0 {
+  %1 = call i32 @_foo()
+  ret i32 %1
+}
+
+attributes #0 = { noinline nounwind optnone }

--- a/llvm/test/tools/llvm-cas-object-format/Inputs/test.ll
+++ b/llvm/test/tools/llvm-cas-object-format/Inputs/test.ll
@@ -1,0 +1,8 @@
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx11.0.0"
+
+define i32 @_test() #0 {
+  ret i32 0
+}
+
+attributes #0 = { noinline optnone }

--- a/llvm/test/tools/llvm-cas-object-format/glob.test
+++ b/llvm/test/tools/llvm-cas-object-format/glob.test
@@ -1,0 +1,15 @@
+RUN: rm -rf %t && mkdir -p %t
+RUN: llc %S/Inputs/main.ll --filetype=obj -o %t/main.o
+RUN: llc %S/Inputs/test.ll --filetype=obj -o %t/test.o
+
+RUN: llvm-cas-object-format --cas %t/cas %t/main.o %t/test.o --just-blobs | tail -n 1 | cut -f 3 -d ' ' > %t/blob.id
+
+RUN: llvm-cas-object-format --cas %t/cas %t/main.o --object-stats | FileCheck %s --check-prefix=CHECK-ONE-CU
+RUN: llvm-cas-object-format --cas %t/cas --ingest-cas @%t/blob.id --cas-glob "**/main.o" --object-stats | FileCheck %s --check-prefix=CHECK-ONE-CU
+
+RUN: llvm-cas-object-format --cas %t/cas --ingest-cas @%t/blob.id | tail -n 1 | cut -f 3 -d ' ' > %t/cas.id
+RUN: llvm-cas-object-format --cas %t/cas --analysis-only @%t/cas.id --object-stats | FileCheck %s --check-prefix=CHECK-TWO-CU
+RUN: llvm-cas-object-format --cas %t/cas --analysis-only @%t/cas.id --cas-glob "**/main.o" --object-stats | FileCheck %s --check-prefix=CHECK-ONE-CU
+
+CHECK-ONE-CU: cas.o:compile-unit 1
+CHECK-TWO-CU: cas.o:compile-unit 2

--- a/llvm/test/tools/llvm-cas-object-format/input-kind.test
+++ b/llvm/test/tools/llvm-cas-object-format/input-kind.test
@@ -1,0 +1,9 @@
+RUN: rm -rf %t && mkdir -p %t
+RUN: llc %S/Inputs/main.ll --filetype=obj -o %t/main.o
+
+RUN: llvm-cas-object-format --cas %t/cas %t/main.o --just-blobs | tail -n 1 | cut -f 3 -d ' ' > %t/blob.id
+
+RUN: llvm-cas-object-format --cas %t/cas %t/main.o --object-stats > %t/output_1.txt
+RUN: llvm-cas-object-format --cas %t/cas --ingest-cas @%t/blob.id --object-stats > %t/output_2.txt
+
+RUN: diff %t/output_1.txt %t/output_2.txt


### PR DESCRIPTION
Add an option to `llvm-cas-object-format` so it can convert object files
that are already stored as blobs in the CAS database.