### PR TITLE
Add a new flag `-fobjc-sign-class-ro`

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -421,6 +421,9 @@ CODEGENOPT(AAPCSBitfieldWidth, 1, 1)
 ENUM_CODEGENOPT(SwiftAsyncFramePointer, SwiftAsyncFramePointerKind, 2,
                 SwiftAsyncFramePointerKind::Always)
 
+/// Whether to sign Objective-C class_ro_t pointers in objc_class structs
+CODEGENOPT(ObjCSignClassROPointers, 1, 0)
+
 #undef CODEGENOPT
 #undef ENUM_CODEGENOPT
 #undef VALUE_CODEGENOPT

--- a/clang/include/clang/Basic/PointerAuthOptions.h
+++ b/clang/include/clang/Basic/PointerAuthOptions.h
@@ -181,6 +181,9 @@ struct PointerAuthOptions {
   /// The ABI for Objective-C method lists.
   PointerAuthSchema ObjCMethodListFunctionPointers;
 
+  /// The ABI for Objective-C class_ro_t pointers.
+  PointerAuthSchema ObjCClassROPointers;
+
   /// The ABI for C++ virtual table pointers (the pointer to the table
   /// itself) as installed in an actual class instance.
   PointerAuthSchema CXXVTablePointers;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2144,6 +2144,9 @@ def fobjc_disable_direct_methods_for_testing :
   Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Ignore attribute objc_direct so that direct methods can be tested">,
   MarshallingInfoFlag<"LangOpts->ObjCDisableDirectMethodsForTesting">;
+def fobjc_sign_class_ro : Flag<["-"], "fobjc-sign-class-ro">, Group<f_Group>, Flags<[CC1Option]>,
+  HelpText<"Sign the class_ro_t pointer in Objective-C class structures emitted by the compiler">;
+def fno_objc_sign_class_ro : Flag<["-"], "fno-objc-sign-class-ro">, Group<f_Group>, Flags<[CC1Option]>;
 
 def fomit_frame_pointer : Flag<["-"], "fomit-frame-pointer">, Group<f_Group>;
 def fopenmp : Flag<["-"], "fopenmp">, Group<f_Group>, Flags<[CC1Option, NoArgumentUnused]>,

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -2603,6 +2603,17 @@ Darwin::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
     }
   }
 
+  // For macOS, we enable `class_ro_t` pointer signing by default, because
+  // the Objective-C runtime will ignore the extra bits in the pointer if
+  // it doesn't understand them.  For iOS, however, it is only on by default
+  // as of iOS 16; before then, it will be *off* by default.
+  if (!DAL->hasArgNoClaim(options::OPT_fobjc_sign_class_ro,
+                          options::OPT_fno_objc_sign_class_ro)) {
+    if (!isTargetIOSBased() || !isIPhoneOSVersionLT(16, 0)) {
+      DAL->AddFlagArg(nullptr, Opts.getOption(options::OPT_fobjc_sign_class_ro));
+    }
+  }
+
   if (!Args.getLastArg(options::OPT_stdlib_EQ) &&
       GetCXXStdlibType(Args) == ToolChain::CST_Libcxx)
     DAL->AddJoinedArg(nullptr, Opts.getOption(options::OPT_stdlib_EQ),

--- a/clang/test/CodeGenObjC/ptrauth-class-ro.m
+++ b/clang/test/CodeGenObjC/ptrauth-class-ro.m
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -fptrauth-calls -fobjc-sign-class-ro -fobjc-arc -fobjc-runtime=ios-7 -triple arm64-apple-ios -emit-llvm -o - %s | FileCheck %s
+
+// CHECK: @"OBJC_CLASS_$_Foo" = global %struct._class_t { %struct._class_t* @"OBJC_METACLASS_$_Foo", %struct._class_t* null, %struct._objc_cache* @_objc_empty_cache, i8* (i8*, i8*)** null, %struct._class_ro_t* bitcast ({ i8*, i32, i64, i64 }* @"_OBJC_CLASS_RO_$_Foo.ptrauth" to %struct._class_ro_t*) }, section "__DATA, __objc_data", align 8
+// CHECK: @"OBJC_METACLASS_$_Foo" = global %struct._class_t { %struct._class_t* @"OBJC_METACLASS_$_Foo", %struct._class_t* @"OBJC_CLASS_$_Foo", %struct._objc_cache* @_objc_empty_cache, i8* (i8*, i8*)** null, %struct._class_ro_t* bitcast ({ i8*, i32, i64, i64 }* @"_OBJC_METACLASS_RO_$_Foo.ptrauth" to %struct._class_ro_t*) }, section "__DATA, __objc_data", align 8
+// CHECK: @"_OBJC_CLASS_RO_$_Foo.ptrauth" = private constant { i8*, i32, i64, i64 } { i8* bitcast (%struct._class_ro_t* @"_OBJC_CLASS_RO_$_Foo" to i8*), i32 2, i64 ptrtoint (%struct._class_ro_t** getelementptr inbounds (%struct._class_t, %struct._class_t* @"OBJC_CLASS_$_Foo", i32 0, i32 4) to i64), i64 25080 }, section "llvm.ptrauth", align 8
+// CHECK: @"_OBJC_METACLASS_RO_$_Foo.ptrauth" = private constant { i8*, i32, i64, i64 } { i8* bitcast (%struct._class_ro_t* @"_OBJC_METACLASS_RO_$_Foo" to i8*), i32 2, i64 ptrtoint (%struct._class_ro_t** getelementptr inbounds (%struct._class_t, %struct._class_t* @"OBJC_METACLASS_$_Foo", i32 0, i32 4) to i64), i64 25080 }, section "llvm.ptrauth", align 8
+
+// CHECK: {i32, 1, !"Objective-C Enforce ClassRO Pointer Signing", i32 16}
+
+@interface C
+- (void) m0;
+@end
+
+@implementation C
+- (void)m0 {}
+@end
+
+void test_sign_class_ro(C *c) {
+  [c m0];
+}

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -6780,6 +6780,11 @@ following key-value pairs:
        If present, its value must be 6. This flag requires that the
        ``Objective-C Garbage Collection`` flag have the value 2.
 
+   * - ``Objective-C Enforce ClassRO Pointer Signing``
+     - **[Optional]** --- Specifies that the Objective-C runtime should enforce
+       pointer signing for ``class_ro_t`` pointers in ``objc_class`` structs.
+       Value values are 0, for disabled, and 16, for enabled.
+
 Some important flag interactions:
 
 -  If a module with ``Objective-C Garbage Collection`` set to 0 is

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -85,7 +85,8 @@ static void GetObjCImageInfo(Module &M, unsigned &Version, unsigned &Flags,
                Key == "Objective-C GC Only" ||
                Key == "Objective-C Is Simulated" ||
                Key == "Objective-C Class Properties" ||
-               Key == "Objective-C Image Swift Version") {
+               Key == "Objective-C Image Swift Version" ||
+               Key == "Objective-C Enforce ClassRO Pointer Signing") {
       Flags |= mdconst::extract<ConstantInt>(MFE.Val)->getZExtValue();
     } else if (Key == "Objective-C Image Info Section") {
       Section = cast<MDString>(MFE.Val)->getString();


### PR DESCRIPTION
Introduce a new flag `-fobjc-sign-class-ro` that controls whether or not Objective-C `class_ro_t` pointers in `objc_class` structs are pointer signed on ARM64e, and that also enables pointer signing enforcement in the runtime for that field.

rdar://83979731