### PR TITLE
[llvm-cas-object-format] Fix a use-after-free bug due to scope

### DIFF
--- a/llvm/tools/llvm-cas-object-format/llvm-cas-object-format.cpp
+++ b/llvm/tools/llvm-cas-object-format/llvm-cas-object-format.cpp
@@ -103,6 +103,8 @@ int main(int argc, char *argv[]) {
   StringMap<CASID> Files;
   SmallVector<CASID> SummaryIDs;
   SharedStream OS(outs());
+  BumpPtrAllocator Alloc;
+  StringSaver Saver(Alloc);
   std::mutex Lock;
   auto ingestAsyc = [&](StringRef InputFile, MemoryBufferRef FileContent) {
     Pool.async([&, InputFile, FileContent]() {
@@ -132,8 +134,6 @@ int main(int argc, char *argv[]) {
 
     case IngestFromCASTree: {
       auto ID = ExitOnErr(CAS->parseCASID(IF));
-      BumpPtrAllocator Alloc;
-      StringSaver Saver(Alloc);
       SmallVector<NamedTreeEntry> Stack;
       Stack.emplace_back(ID, TreeEntry::Tree, "/");
       Optional<GlobPattern> GlobP;


### PR DESCRIPTION
Move the BumpPointerAllocator to the correct scope to avoid use after
free error.