### PR TITLE
[Preprocessor] Elide empty line(s) at start of file.

### DIFF
--- a/clang/lib/Frontend/PrintPreprocessedOutput.cpp
+++ b/clang/lib/Frontend/PrintPreprocessedOutput.cpp
@@ -293,7 +293,7 @@ bool PrintPPOutputPPCallbacks::MoveToLine(unsigned LineNo,
       WriteLineInfo(LineNo, nullptr, 0);
     }
     StartedNewLine = true;
-  } else if (!StartedNewLine) {
+  } else if (EmittedTokensOnThisLine) {
     // If we are not on the correct line and don't need to be line-correct,
     // at least ensure we start on a new line.
     OS << '\n';

--- a/clang/test/Preprocessor/print_empty_include.c
+++ b/clang/test/Preprocessor/print_empty_include.c
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -E -P %s | count 1
+// Ensure no superfluous newlines are printed
+// llvm.org/PR51616
+
+#include "print_empty_include.h"
+#include "print_empty_include.h"
+
+#define EXPANDED_TO_NOTHING
+EXPANDED_TO_NOTHING
+

--- a/clang/test/Preprocessor/print_empty_include.h
+++ b/clang/test/Preprocessor/print_empty_include.h
@@ -1,0 +1,4 @@
+#if 0
+intentionally empty
+#endif
+

--- a/clang/test/Preprocessor/print_line_track.c
+++ b/clang/test/Preprocessor/print_line_track.c
@@ -3,7 +3,7 @@
  * RUN: %clang_cc1 -E -P %s | grep 'a 3'
  * RUN: %clang_cc1 -E -P %s | grep 'b 16'
  * RUN: %clang_cc1 -E %s | not grep '# 0 '
- * RUN: %clang_cc1 -E -P %s | count 4
+ * RUN: %clang_cc1 -E -P %s | count 2
  * PR1848 PR3437 PR7360
 */
 


### PR DESCRIPTION
In -P mode, PrintPPOutputPPCallbacks::MoveToLine started at least one
newline if current and target line number mismatched. The method is also
called when entering a new file, be it the main file or an include file.
In this situation line numbers always almost mismatch, resulting in a
newline for each occurance even if no tokens have been printed
in-between.

Empty lines at the beginning of the output must be trimmed because it
may be parsed by scripts expecting the result to appear on the first
output line, as done by LibreOffice's configure script.

Fix by only emitting a newline if tokens have been printed so far using
the EmittedTokensOnThisLine flag. Also adding a test case of FileChanged
callbacks occuring with empty include files.

This fixes llvm.org/PR51616

(cherry picked from commit 66e37c99ef5d7da1b17b3bbaa4ef05b633a473f7)