### PR TITLE
[GlobalDCE] Add !llvm.used.conditional support for conditionally used global variables

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/GlobalDCE.h
+++ b/llvm/include/llvm/Transforms/IPO/GlobalDCE.h
@@ -56,6 +56,7 @@ private:
   void UpdateGVDependencies(GlobalValue &GV);
   void MarkLive(GlobalValue &GV,
                 SmallVectorImpl<GlobalValue *> *Updates = nullptr);
+  void PropagateLivenessInGlobalValues();
   bool RemoveUnusedGlobalValue(GlobalValue &GV);
 
   // Dead virtual function elimination.
@@ -65,6 +66,9 @@ private:
   void ScanVTableLoad(Function *Caller, Metadata *TypeId, uint64_t CallOffset);
 
   void ComputeDependencies(Value *V, SmallPtrSetImpl<GlobalValue *> &U);
+
+  GlobalValue *TargetFromConditionalUsedIfLive(MDNode *M);
+  void PropagateLivenessToConditionallyUsed(Module &M);
 };
 
 }

--- a/llvm/include/llvm/Transforms/Utils/ModuleUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/ModuleUtils.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_TRANSFORMS_UTILS_MODULEUTILS_H
 #define LLVM_TRANSFORMS_UTILS_MODULEUTILS_H
 
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include <utility> // for std::pair
@@ -24,6 +25,7 @@ class Module;
 class Function;
 class FunctionCallee;
 class GlobalValue;
+class GlobalVariable;
 class Constant;
 class Value;
 class Type;
@@ -77,6 +79,10 @@ void appendToUsed(Module &M, ArrayRef<GlobalValue *> Values);
 
 /// Adds global values to the llvm.compiler.used list.
 void appendToCompilerUsed(Module &M, ArrayRef<GlobalValue *> Values);
+
+/// Replaces llvm.used or llvm.compiler.used list with a new set of values.
+GlobalVariable *setUsedInitializer(GlobalVariable &V,
+                                   const SmallPtrSetImpl<GlobalValue *> &Init);
 
 /// Filter out potentially dead comdat functions where other entries keep the
 /// entire comdat group alive.

--- a/llvm/lib/Transforms/Utils/ModuleUtils.cpp
+++ b/llvm/lib/Transforms/Utils/ModuleUtils.cpp
@@ -111,6 +111,44 @@ void llvm::appendToCompilerUsed(Module &M, ArrayRef<GlobalValue *> Values) {
   appendToUsedList(M, "llvm.compiler.used", Values);
 }
 
+static int compareNames(Constant *const *A, Constant *const *B) {
+  Value *AStripped = (*A)->stripPointerCasts();
+  Value *BStripped = (*B)->stripPointerCasts();
+  return AStripped->getName().compare(BStripped->getName());
+}
+
+GlobalVariable *
+llvm::setUsedInitializer(GlobalVariable &V,
+                         const SmallPtrSetImpl<GlobalValue *> &Init) {
+  if (Init.empty()) {
+    V.eraseFromParent();
+    return nullptr;
+  }
+
+  // Type of pointer to the array of pointers.
+  PointerType *Int8PtrTy = Type::getInt8PtrTy(V.getContext(), 0);
+
+  SmallVector<Constant *, 8> UsedArray;
+  for (GlobalValue *GV : Init) {
+    Constant *Cast =
+        ConstantExpr::getPointerBitCastOrAddrSpaceCast(GV, Int8PtrTy);
+    UsedArray.push_back(Cast);
+  }
+  // Sort to get deterministic order.
+  array_pod_sort(UsedArray.begin(), UsedArray.end(), compareNames);
+  ArrayType *ATy = ArrayType::get(Int8PtrTy, UsedArray.size());
+
+  Module *M = V.getParent();
+  V.removeFromParent();
+  GlobalVariable *NV =
+      new GlobalVariable(*M, ATy, false, GlobalValue::AppendingLinkage,
+                         ConstantArray::get(ATy, UsedArray), "");
+  NV->takeName(&V);
+  NV->setSection("llvm.metadata");
+  delete &V;
+  return NV;
+}
+
 FunctionCallee
 llvm::declareSanitizerInitFunction(Module &M, StringRef InitName,
                                    ArrayRef<Type *> InitArgTypes) {

--- a/llvm/test/Transforms/GlobalDCE/used.conditional1.ll
+++ b/llvm/test/Transforms/GlobalDCE/used.conditional1.ll
@@ -1,0 +1,41 @@
+; RUN: opt -S -globaldce < %s | FileCheck %s
+
+;
+; (1) a regular dead global referenced in @llvm.used is kept alive
+;
+define internal void @func_marked_as_used() {
+  ; CHECK: @func_marked_as_used
+  ret void
+}
+
+;
+; (2) a dead global referenced in @llvm.used, but marked as conditionally used
+; in !llvm.used.conditional where the condition is alive, is kept alive
+;
+define internal void @func_conditionally_used_and_live() {
+  ; CHECK: @func_conditionally_used_and_live
+  ret void
+}
+
+;
+; (3) a dead global referenced in @llvm.used, but marked as conditionally used
+; in !llvm.used.conditional where the condition is dead, is eliminated
+;
+define internal void @func_conditionally_used_and_dead() {
+  ; CHECK-NOT: @func_conditionally_used_and_dead
+  ret void
+}
+
+@condition_live = internal unnamed_addr constant i64 42
+@condition_dead = internal unnamed_addr constant i64 42
+
+@llvm.used = appending global [4 x i8*] [
+   i8* bitcast (void ()* @func_marked_as_used to i8*),
+   i8* bitcast (i64* @condition_live to i8*),
+   i8* bitcast (void ()* @func_conditionally_used_and_live to i8*),
+   i8* bitcast (void ()* @func_conditionally_used_and_dead to i8*)
+], section "llvm.metadata"
+
+!1 = !{void ()* @func_conditionally_used_and_live, i32 0, !{i64* @condition_live}}
+!2 = !{void ()* @func_conditionally_used_and_dead, i32 0, !{i64* @condition_dead}}
+!llvm.used.conditional = !{!1, !2}

--- a/llvm/test/Transforms/GlobalDCE/used.conditional2.ll
+++ b/llvm/test/Transforms/GlobalDCE/used.conditional2.ll
@@ -1,0 +1,32 @@
+; RUN: opt -S -globaldce < %s | FileCheck %s
+
+;
+; (1) a dead global referenced in @llvm.used, but marked as conditionally used
+; by both @condition_live and @condition_dead, with an *ANY* type, is alive
+;
+define internal void @func_conditionally_by_two_conditions_any() {
+  ; CHECK: @func_conditionally_by_two_conditions_any
+  ret void
+}
+
+;
+; (2) a dead global referenced in @llvm.used, but marked as conditionally used
+; by both @condition_live and @condition_dead, with an *ALL* type, is removed
+;
+define internal void @func_conditionally_by_two_conditions_all() {
+  ; CHECK-NOT: @func_conditionally_by_two_conditions_all
+  ret void
+}
+
+@condition_live = internal unnamed_addr constant i64 42
+@condition_dead = internal unnamed_addr constant i64 42
+
+@llvm.used = appending global [3 x i8*] [
+   i8* bitcast (i64* @condition_live to i8*),
+   i8* bitcast (void ()* @func_conditionally_by_two_conditions_any to i8*),
+   i8* bitcast (void ()* @func_conditionally_by_two_conditions_all to i8*)
+], section "llvm.metadata"
+
+!1 = !{void ()* @func_conditionally_by_two_conditions_any, i32 0, !{ i64* @condition_live, i64* @condition_dead } }
+!2 = !{void ()* @func_conditionally_by_two_conditions_all, i32 1, !{ i64* @condition_live, i64* @condition_dead } }
+!llvm.used.conditional = !{!1, !2}

--- a/llvm/test/Transforms/GlobalDCE/used.conditional3.ll
+++ b/llvm/test/Transforms/GlobalDCE/used.conditional3.ll
@@ -1,0 +1,34 @@
+; RUN: opt -S -globaldce < %s | FileCheck %s
+
+; Test that when performing llvm.used.conditional removals, we discover globals
+; that might trigger other llvm.used.conditional liveness. See the following
+; diagram of dependencies between the globals:
+;
+; @a -\
+;      \ (conditional, see !1, satisfied)
+;       \-> @b -\
+;                \ (regular usage)
+;                 \-> @c -\
+;                          \ (conditional, see !2, satisfied)
+;                           \-> @d
+
+@a = internal unnamed_addr constant i64 42
+@b = internal unnamed_addr constant i64* @c
+@c = internal unnamed_addr constant i64 42
+@d = internal unnamed_addr constant i64 42
+
+; All four, and mainly @d need to stay alive:
+; CHECK: @a = internal unnamed_addr constant i64 42
+; CHECK: @b = internal unnamed_addr constant i64* @c
+; CHECK: @c = internal unnamed_addr constant i64 42
+; CHECK: @d = internal unnamed_addr constant i64 42
+
+@llvm.used = appending global [3 x i8*] [
+  i8* bitcast (i64* @a to i8*),
+  i8* bitcast (i64** @b to i8*),
+  i8* bitcast (i64* @d to i8*)
+], section "llvm.metadata"
+
+!1 = !{i64** @b, i32 0, !{i64* @a}}
+!2 = !{i64* @d, i32 0, !{i64* @c}}
+!llvm.used.conditional = !{!1, !2}

--- a/llvm/test/Transforms/GlobalDCE/used.conditional4.ll
+++ b/llvm/test/Transforms/GlobalDCE/used.conditional4.ll
@@ -1,0 +1,19 @@
+; RUN: opt -S -globaldce < %s | FileCheck %s
+
+; Test !llvm.used.conditional with circular dependencies
+
+@globalA = internal unnamed_addr constant i8* bitcast (i8** @globalB to i8*)
+@globalB = internal unnamed_addr constant i8* bitcast (i8** @globalA to i8*)
+
+; All four, and mainly @d need to stay alive:
+; CHECK-NOT: @globalA
+; CHECK-NOT: @globalB
+
+@llvm.used = appending global [2 x i8*] [
+  i8* bitcast (i8** @globalA to i8*),
+  i8* bitcast (i8** @globalB to i8*)
+], section "llvm.metadata"
+
+!1 = !{i8** @globalA, i32 0, !{i8** @globalB}}
+!2 = !{i8** @globalB, i32 0, !{i8** @globalA}}
+!llvm.used.conditional = !{!1, !2}

--- a/llvm/test/Transforms/GlobalDCE/used.conditional5.ll
+++ b/llvm/test/Transforms/GlobalDCE/used.conditional5.ll
@@ -1,0 +1,17 @@
+; RUN: opt -S -globaldce < %s | FileCheck %s
+
+@target = internal unnamed_addr constant i32 46
+@dep1 = internal unnamed_addr constant i32 732
+
+@llvm.used = appending global [1 x i8*] [
+  i8* bitcast (i32* @target to i8*)
+], section "llvm.metadata"
+
+!0 = !{i32* @target, i32 0, !{i8* bitcast (i32* @dep1 to i8*)}}
+!llvm.used.conditional = !{!0}
+
+; CHECK-NOT: @target
+; CHECK-NOT: @dep1
+; CHECK: !llvm.used.conditional = !{!0}
+; CHECK: !0 = distinct !{null, i32 0, !1}
+; CHECK: !1 = !{i8* undef}

--- a/llvm/test/Verifier/llvm.used.conditional-invalid.ll
+++ b/llvm/test/Verifier/llvm.used.conditional-invalid.ll
@@ -1,0 +1,10 @@
+; RUN: not llvm-as < %s -o /dev/null 2>&1 | FileCheck %s
+
+@a = global i32 42
+@llvm.used = appending global [1 x i32*] [i32* @a], section "llvm.metadata"
+
+@cond = global i32 43
+!1 = !{ i32* @cond, i32 1, !{ i32* @a }, i32 8 }
+!llvm.used.conditional = !{ !1 }
+
+; CHECK: invalid llvm.used.conditional member

--- a/llvm/test/Verifier/llvm.used.conditional-invalid2.ll
+++ b/llvm/test/Verifier/llvm.used.conditional-invalid2.ll
@@ -1,0 +1,10 @@
+; RUN: not llvm-as < %s -o /dev/null 2>&1 | FileCheck %s
+
+@a = global i32 42
+@llvm.used = appending global [1 x i32*] [i32* @a], section "llvm.metadata"
+
+@cond = global i32 43
+!1 = !{ i32* @cond, i32 1, i32* @a }
+!llvm.used.conditional = !{ !1 }
+
+; CHECK: invalid llvm.used.conditional member

--- a/llvm/test/Verifier/llvm.used.conditional-invalid3.ll
+++ b/llvm/test/Verifier/llvm.used.conditional-invalid3.ll
@@ -1,0 +1,10 @@
+; RUN: not llvm-as < %s -o /dev/null 2>&1 | FileCheck %s
+
+@a = global i32 42
+@llvm.used = appending global [1 x i32*] [i32* @a], section "llvm.metadata"
+
+@cond = global i32 43
+!1 = !{ i32* @cond, i32 4, !{ i32* @a } }
+!llvm.used.conditional = !{ !1 }
+
+; CHECK: invalid llvm.used.conditional member

--- a/llvm/test/Verifier/llvm.used.conditional-invalid4.ll
+++ b/llvm/test/Verifier/llvm.used.conditional-invalid4.ll
@@ -1,0 +1,10 @@
+; RUN: not llvm-as < %s -o /dev/null 2>&1 | FileCheck %s
+
+@a = global i32 42
+@llvm.used = appending global [1 x i32*] [i32* @a], section "llvm.metadata"
+
+@cond = global i32 43
+!1 = !{ !1, i32 1, !{ i32* @a } }
+!llvm.used.conditional = !{ !1 }
+
+; CHECK: invalid llvm.used.conditional member

--- a/llvm/test/Verifier/llvm.used.conditional.ll
+++ b/llvm/test/Verifier/llvm.used.conditional.ll
@@ -1,0 +1,9 @@
+; RUN: llvm-as < %s -o /dev/null
+
+@a = global i32 42
+@llvm.used = appending global [1 x i32*] [i32* @a], section "llvm.metadata"
+
+@cond = global i32 43
+!1 = !{ i32* @cond, i32 1, !{ i32* @a } }
+!2 = !{ null,       i32 1, !{ i32* @a } }
+!llvm.used.conditional = !{ !1, !2 }


### PR DESCRIPTION
This PR lands a preview version of !llvm.used.conditional that is not yet merged in upstream LLVM and is being reviewed at <https://reviews.llvm.org/D104496>, but it's important to unblock progress in adopting these changes in Swift. Once upstream LLVM gets !llvm.used.metadata (or a differently-named or differently-implemented) support, which downstream change will be reverted.

Commit message:
> [GlobalDCE] Add !llvm.used.conditional support for conditionally used global variables
>
> As part of the optimization work to emit dead-strippable symbols for Swift and
enable GlobalDCE to remove those symbols when possible, we need to mark some
Swift symbols as conditionally used based on a set of other symbols. Background
info can be found here: https://bugs.swift.org/browse/SR-14509.
> 
> This diff adds a module-level name metadata !llvm.used.conditional, which
contains a list of metadata triplets, that describes the conditions under which
we allow removal of globals even if they are mentioned in @llvm.used. See the
included LangRef changes to details. The implementation is a strict addition,
it does not change any semantics and does not affect IR or passes in any way,
unless !llvm.used.conditional is present in the input IR.