### PR TITLE
[GlobalDCE] Add !vtable_strict_types metadata to inform VFE about non-vptrs in vtable globals

### DIFF
--- a/llvm/docs/TypeMetadata.rst
+++ b/llvm/docs/TypeMetadata.rst
@@ -288,3 +288,11 @@ In addition, all function pointer loads from a vtable marked with the
 calls sites can be correlated with the vtables which they might load from.
 Other parts of the vtable (RTTI, offset-to-top, ...) can still be accessed with
 normal loads.
+
+Additionally, a vtable can have a ``!vtable_strict_types`` metadata attached,
+which if present imposes a stricter rule on the vtable: All virtual function
+pointers in the vtable must have a matching ``!type`` attachment (where the
+offset in the attachment matches the virtual function). Function pointers
+without a ``!type`` attachment are not participating in removal of unused
+function pointers. All virtual call sites that perform loads into such a vtable
+must use a zero offset in the `llvm.type.checked.load` intrinsic call.

--- a/llvm/include/llvm/Transforms/IPO/GlobalDCE.h
+++ b/llvm/include/llvm/Transforms/IPO/GlobalDCE.h
@@ -47,6 +47,12 @@ private:
   DenseMap<Metadata *, SmallSet<std::pair<GlobalVariable *, uint64_t>, 4>>
       TypeIdMap;
 
+  /// VTable -> set of vfuncs in that vtable (that have !type metadata).
+  DenseMap<GlobalVariable *, SmallPtrSet<GlobalValue *, 8>> VFuncMap;
+
+  bool ShouldDependencyStayAliveDueToStrictMetadata(GlobalValue *VTableVal,
+                                                    GlobalValue *VPtr);
+
   // Global variables which are vtables, and which we have enough information
   // about to safely do dead virtual function elimination.
   SmallPtrSet<GlobalValue *, 32> VFESafeVTables;

--- a/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
+++ b/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
@@ -1192,7 +1192,8 @@ void LowerTypeTestsModule::verifyTypeMDNode(GlobalObject *GO, MDNode *Type) {
 
   if (GO->isThreadLocal())
     report_fatal_error("Bit set element may not be thread-local");
-  if (isa<GlobalVariable>(GO) && GO->hasSection())
+  if (isa<GlobalVariable>(GO) && GO->hasSection() &&
+      !GO->hasMetadata("vtable_strict_types"))
     report_fatal_error(
         "A member of a type identifier may not have an explicit section");
 

--- a/llvm/test/Transforms/GlobalDCE/virtual-functions-non-vfunc-entries.ll
+++ b/llvm/test/Transforms/GlobalDCE/virtual-functions-non-vfunc-entries.ll
@@ -1,0 +1,79 @@
+; RUN: opt < %s -globaldce -S | FileCheck %s
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+declare { i8*, i1 } @llvm.type.checked.load(i8*, i32, metadata)
+
+; A vtable that contains a non-nfunc entry, @regular_non_virtual_funcA, but
+; without the !vtable_strict_types attribute, so GlobalDCE will treat the
+; @regular_non_virtual_funcA slot as eligible for VFE, and remove it.
+@vtableA = internal unnamed_addr constant { [3 x i8*] } { [3 x i8*] [
+  i8* bitcast (void ()* @vfunc1_live to i8*),
+  i8* bitcast (void ()* @vfunc2_dead to i8*),
+  i8* bitcast (void ()* @regular_non_virtual_funcA to i8*)
+]}, align 8, !type !0, !type !1, !vcall_visibility !{i64 2}
+!0 = !{i64 0, !"vfunc1.type"}
+!1 = !{i64 8, !"vfunc2.type"}
+
+; CHECK:      @vtableA = internal unnamed_addr constant { [3 x i8*] } { [3 x i8*] [
+; CHECK-SAME:   i8* bitcast (void ()* @vfunc1_live to i8*),
+; CHECK-SAME:   i8* null,
+; CHECK-SAME:   i8* null
+; CHECK-SAME: ] }, align 8, !type !0, !type !1, !vcall_visibility !2
+
+
+; A vtable that contains a non-nfunc entry, @regular_non_virtual_funcB, with a
+; !vtable_strict_types marker which means anything that does not have a matching
+; !type offset should not participate in VFE. GlobalDCE should keep
+; @regular_non_virtual_funcB in the vtable.
+@vtableB = internal unnamed_addr constant { [3 x i8*] } { [3 x i8*] [
+  i8* bitcast (void ()* @vfunc1_live to i8*),
+  i8* bitcast (void ()* @vfunc2_dead to i8*),
+  i8* bitcast (void ()* @regular_non_virtual_funcB to i8*)
+]}, align 8, !type !2, !type !3, !vcall_visibility !{i64 2}, !vtable_strict_types !998
+!2 = !{i64 0, !"vfunc1.type"}
+!3 = !{i64 8, !"vfunc2.type"}
+
+; CHECK:      @vtableB = internal unnamed_addr constant { [3 x i8*] } { [3 x i8*] [
+; CHECK-SAME:   i8* bitcast (void ()* @vfunc1_live to i8*),
+; CHECK-SAME:   i8* null,
+; CHECK-SAME:   i8* bitcast (void ()* @regular_non_virtual_funcB to i8*)
+; CHECK-SAME: ] }, align 8, !type !0, !type !1, !vcall_visibility !2
+
+; (1) vfunc1_live is referenced from @main, stays alive
+define internal void @vfunc1_live() {
+  ; CHECK: define internal void @vfunc1_live(
+  ret void
+}
+
+; (2) vfunc2_dead is never referenced, gets removed and vtable slot is null'd
+define internal void @vfunc2_dead() {
+  ; CHECK-NOT: define internal void @vfunc2_dead(
+  ret void
+}
+
+; (3) regular, non-virtual function that just happens to be referenced from the
+; vtable data structure, but vtable is not marked with !vtable_strict_types, is
+; removed
+define internal void @regular_non_virtual_funcA() {
+  ; CHECK-NOT: define internal void @regular_non_virtual_funcA(
+  ret void
+}
+
+; (4) regular, non-virtual function that just happens to be referenced from the
+; vtable data structure, marked with !vtable_strict_types, should stay alive
+define internal void @regular_non_virtual_funcB() {
+  ; CHECK: define internal void @regular_non_virtual_funcB(
+  ret void
+}
+
+define void @main() {
+  %1 = ptrtoint { [3 x i8*] }* @vtableA to i64 ; to keep @vtableA alive
+  %2 = ptrtoint { [3 x i8*] }* @vtableB to i64 ; to keep @vtableB alive
+  %3 = tail call { i8*, i1 } @llvm.type.checked.load(i8* null, i32 0, metadata !"vfunc1.type")
+  ret void
+}
+
+!998 = !{}
+!999 = !{i32 1, !"Virtual Function Elim", i32 1}
+!llvm.module.flags = !{!999}

--- a/llvm/test/Transforms/GlobalDCE/virtual-functions-sections.ll
+++ b/llvm/test/Transforms/GlobalDCE/virtual-functions-sections.ll
@@ -1,0 +1,32 @@
+; RUN: opt < %s -globaldce -lowertypetests -lowertypetests-summary-action=export -S | FileCheck %s
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+declare { i8*, i1 } @llvm.type.checked.load(i8*, i32, metadata)
+
+@vtable = internal unnamed_addr constant { [2 x i8*] } { [2 x i8*] [
+  i8* bitcast (void ()* @vfunc1_live to i8*),
+  i8* bitcast (void ()* @vfunc2_dead to i8*)
+]}, align 8, !type !0, !type !1, !vcall_visibility !{i64 2}, !vtable_strict_types !998, section "my_custom_section"
+!0 = !{i64 0, !"vfunc1.type"}
+!1 = !{i64 8, !"vfunc2.type"}
+
+define internal void @vfunc1_live() {
+  ; CHECK: define internal void @vfunc1_live(
+  ret void
+}
+
+define internal void @vfunc2_dead() {
+  ; CHECK-NOT: define internal void @vfunc2_dead(
+  ret void
+}
+
+define void @main() {
+  %1 = ptrtoint { [2 x i8*] }* @vtable to i64 ; to keep @vtable alive
+  %2 = tail call { i8*, i1 } @llvm.type.checked.load(i8* null, i32 0, metadata !"vfunc1.type")
+  ret void
+}
+
+!998 = !{}
+!999 = !{i32 1, !"Virtual Function Elim", i32 1}
+!llvm.module.flags = !{!999}


### PR DESCRIPTION
This PR lands a preview version of an LLVM change that is not yet merged upstream and is being reviewed at https://reviews.llvm.org/D108741, but it's important to unblock progress in adopting these changes in Swift. Once upstreamed, this downstream change will be reverted.

Commit message:
> [GlobalDCE] Add !vtable_strict_types metadata to inform VFE about non-vptrs in vtable globals
>
> As part of codesize optimization work for Swift, we'd like to add Virtual
Function Elimination to Swift, very similarly to how GlobalDCE supports C++ VFE.
This PR adds support to GlobalDCE for vtables containing references that are not
virtual functions and should not participate in VFE.
>
> This behavior is triggered by attaching !vtable_strict_types metadata to a
vtable, which then causes GlobalDCE's logic that ignores vtable->vfunc
dependencies to only apply when the vtable slot offset is present in one of the
!type metadata attributes on the vtable. See explanation in TypeMetadata.rst.
