### PR TITLE
Avoid potential infinite recursion.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -6049,8 +6049,8 @@ SwiftASTContext::GetBitSize(opaque_compiler_type_t type,
     // Check that the type has been bound successfully -- and if not,
     // log the event and bail out to avoid an infinite loop.
     swift::CanType swift_bound_type(::GetCanonicalSwiftType(bound_type));
-    if (swift_bound_type->hasTypeParameter()) {
-      LOG_PRINTF(LIBLLDB_LOG_TYPES, "GetBitSize: Can't bind type: %s",
+    if (swift_bound_type && swift_bound_type->hasTypeParameter()) {
+      LOG_PRINTF(LIBLLDB_LOG_TYPES, "Can't bind type: %s",
                  bound_type.GetTypeName().AsCString());
       return {};
     }
@@ -6095,6 +6095,16 @@ SwiftASTContext::GetByteStride(opaque_compiler_type_t type,
     exe_scope->CalculateExecutionContext(exe_ctx);
     auto swift_scratch_ctx_lock = SwiftASTContextLock(&exe_ctx);
     CompilerType bound_type = BindGenericTypeParameters({this, type}, exe_scope);
+
+    // Check that the type has been bound successfully -- and if not,
+    // log the event and bail out to avoid an infinite loop.
+    swift::CanType swift_bound_type(::GetCanonicalSwiftType(bound_type));
+    if (swift_bound_type && swift_bound_type->hasTypeParameter()) {
+      LOG_PRINTF(LIBLLDB_LOG_TYPES, "Can't bind type: %s",
+                 bound_type.GetTypeName().AsCString());
+      return {};
+    }
+
     // Note thay the bound type may be in a different AST context.
     return bound_type.GetByteStride(exe_scope);
   }
@@ -6128,8 +6138,16 @@ SwiftASTContext::GetTypeBitAlign(opaque_compiler_type_t type,
     exe_scope->CalculateExecutionContext(exe_ctx);
     auto swift_scratch_ctx_lock = SwiftASTContextLock(&exe_ctx);
     CompilerType bound_type = BindGenericTypeParameters({this, type}, exe_scope);
-    if (bound_type.GetOpaqueQualType() == type)
+
+    // Check that the type has been bound successfully -- and if not,
+    // log the event and bail out to avoid an infinite loop.
+    swift::CanType swift_bound_type(::GetCanonicalSwiftType(bound_type));
+    if (swift_bound_type && swift_bound_type->hasTypeParameter()) {
+      LOG_PRINTF(LIBLLDB_LOG_TYPES, "Can't bind type: %s",
+                 bound_type.GetTypeName().AsCString());
       return {};
+
+    }
     // Note thay the bound type may be in a different AST context.
     return bound_type.GetTypeBitAlign(exe_scope);
   }


### PR DESCRIPTION
This applies the recursion check from GetBitSize to GetByteStride and GetTypeBitAlign.

rdar://83262793
(cherry picked from commit 234fe54aab6fc66eed996d8cb815379de5649218)