### PR TITLE
Invert the ownership between SwiftASTContext and TypeSystemSwiftTypeR…

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1584,9 +1584,9 @@ bool Module::SetArchitecture(const ArchSpec &new_arch) {
       return true;
     }
 #ifdef LLDB_ENABLE_SWIFT
-    if (auto *swift_ast =
-            llvm::dyn_cast_or_null<SwiftASTContext>(&*type_system_or_err))
-      swift_ast->SetTriple(new_arch.GetTriple());
+    if (auto *ts =
+            llvm::dyn_cast_or_null<TypeSystemSwift>(&*type_system_or_err))
+      ts->SetTriple(new_arch.GetTriple());
 #endif // LLDB_ENABLE_SWIFT
     return true;
   }
@@ -1711,8 +1711,8 @@ void Module::ClearModuleDependentCaches() {
   }
 
 #ifdef LLDB_ENABLE_SWIFT
-  if (auto *swift_ast = llvm::dyn_cast_or_null<SwiftASTContext>(&*type_system_or_err))
-    swift_ast->ClearModuleDependentCaches();
+  if (auto *ts = llvm::dyn_cast_or_null<TypeSystemSwift>(&*type_system_or_err))
+    ts->ClearModuleDependentCaches();
 #endif // LLDB_ENABLE_SWIFT
 }
 

--- a/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
@@ -101,7 +101,10 @@ static std::string TranslateObjCNameToSwiftName(std::string className,
     return "";
   }
 
-  auto *ctx = llvm::dyn_cast_or_null<SwiftASTContext>(&*type_system_or_err);
+  auto *ts = llvm::dyn_cast_or_null<TypeSystemSwift>(&*type_system_or_err);
+  if (!ts)
+    return "";
+  auto *ctx = ts->GetSwiftASTContext();
   if (!ctx)
     return "";
   swift::ClangImporter *imp = ctx->GetClangImporter();

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1872,7 +1872,7 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Protocol(
   }
 
   const swift::reflection::TypeRef *protocol_typeref =
-      GetTypeRef(protocol_type, tss->GetSwiftASTContext());
+      GetTypeRef(protocol_type, &tss->GetTypeSystemSwiftTypeRef());
   if (!protocol_typeref) {
     if (log)
       log->Printf("Could not get protocol typeref");
@@ -2841,7 +2841,7 @@ lldb::addr_t SwiftLanguageRuntimeImpl::FixupAddress(lldb::addr_t addr,
 
 const swift::reflection::TypeRef *
 SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type,
-                                     SwiftASTContext *module_holder) {
+                                     TypeSystemSwiftTypeRef *module_holder) {
   // Demangle the mangled name.
   swift::Demangle::Demangler dem;
   ConstString mangled_name = type.GetMangledTypeName();
@@ -2850,8 +2850,10 @@ SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type,
     return nullptr;
   swift::Demangle::NodePointer node =
       TypeSystemSwiftTypeRef::GetCanonicalDemangleTree(
-          module_holder ? module_holder : ts->GetSwiftASTContext(), dem,
-          mangled_name.GetStringRef());
+          module_holder ? module_holder : &ts->GetTypeSystemSwiftTypeRef(),
+          module_holder ? module_holder->GetSwiftASTContext()
+                        : ts->GetSwiftASTContext(),
+          dem, mangled_name.GetStringRef());
   if (!node)
     return nullptr;
 
@@ -2895,7 +2897,7 @@ SwiftLanguageRuntimeImpl::GetSwiftRuntimeTypeInfo(
   // context, but we need to resolve (any DWARF links in) the typeref
   // in the original module.
   const swift::reflection::TypeRef *type_ref =
-      GetTypeRef(type, ts->GetSwiftASTContext());
+      GetTypeRef(type, &ts->GetTypeSystemSwiftTypeRef());
   if (!type_ref)
     return nullptr;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -182,8 +182,8 @@ protected:
       swift::External<swift::RuntimeTarget<sizeof(uintptr_t)>>>;
 
   /// Use the reflection context to build a TypeRef object.
-  const swift::reflection::TypeRef *GetTypeRef(CompilerType type,
-                                               SwiftASTContext *module_holder);
+  const swift::reflection::TypeRef *
+  GetTypeRef(CompilerType type, TypeSystemSwiftTypeRef *module_holder);
 
   /// Returned by \ref ForEachSuperClassType. Not every user of \p
   /// ForEachSuperClassType needs all of these. By returning this

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -23,17 +23,23 @@ using namespace lldb;
 using namespace lldb_private;
 using llvm::StringRef;
 
+TypeSystemSwift::TypeSystemSwift() : TypeSystem() {}
+
 /// TypeSystem Plugin functionality.
 /// \{
 static lldb::TypeSystemSP CreateTypeSystemInstance(lldb::LanguageType language,
                                                    Module *module,
                                                    Target *target,
                                                    const char *extra_options) {
+  if (language != eLanguageTypeSwift)
+    return {};
+
   // This should be called with either a target or a module.
   if (module) {
     assert(!target);
     assert(StringRef(extra_options).empty());
-    return SwiftASTContext::CreateInstance(language, *module);
+    return std::shared_ptr<TypeSystemSwiftTypeRef>(
+        new TypeSystemSwiftTypeRef(*module));
   } else if (target) {
     assert(!module);
     return SwiftASTContext::CreateInstance(language, *target, extra_options);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -70,9 +70,16 @@ public:
 ///                        │         │
 ///                        ↓         ↓
 ///    TypeSystemSwiftTypeRef ⟷ SwiftASTContext (deprecated)
-///                                  │
-///                                  ↓
-///                               SwiftASTContextForExpressions
+///                              /    │
+///                              ↓    ↓
+///      SwiftASTContextForModules    SwiftASTContextForExpressions
+///          (deprecated)
+///
+///
+/// Memory management:
+///
+/// A per-module TypeSystemSwiftTypeRef owns a lazily initialized SwiftASTContext.
+/// A SwiftASTContextForExpressions owns a  TypeSystemSwiftTypeRef.
 ///
 /// \endverbatim
 class TypeSystemSwift : public TypeSystem {
@@ -108,9 +115,11 @@ public:
   };
 
   static LanguageSet GetSupportedLanguagesForTypes();
-  virtual SwiftASTContext *GetSwiftASTContext() = 0;
+  virtual SwiftASTContext *GetSwiftASTContext() const = 0;
   virtual TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() = 0;
-  virtual Module *GetModule() const = 0;
+  virtual void SetTriple(const llvm::Triple triple) = 0;
+  virtual void ClearModuleDependentCaches() = 0;
+
   virtual lldb::TypeSP GetCachedType(ConstString mangled) = 0;
   virtual void SetCachedType(ConstString mangled,
                              const lldb::TypeSP &type_sp) = 0;
@@ -273,6 +282,8 @@ public:
 protected:
   /// Used in the logs.
   std::string m_description;
+  /// The module this typesystem belongs to if any.
+  Module *m_module = nullptr;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1656,7 +1656,7 @@ void Target::ModulesDidLoad(ModuleList &module_list) {
     auto notify_callback = [&](TypeSystem *type_system) {
 #ifdef LLDB_ENABLE_SWIFT
       auto *swift_ast_ctx =
-          llvm::dyn_cast_or_null<SwiftASTContext>(type_system);
+          llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(type_system);
       if (!swift_ast_ctx)
         return true;
       swift_ast_ctx->ModulesDidLoad(module_list);
@@ -2550,7 +2550,7 @@ llvm::Optional<SwiftASTContextReader> Target::GetScratchSwiftASTContext(
 
     bool fallback = true;
     auto typesystem_sp = SwiftASTContext::CreateInstance(
-        lldb::eLanguageTypeSwift, *lldb_module, this, fallback);
+        lldb::eLanguageTypeSwift, *lldb_module, nullptr, this, fallback);
     auto *swift_ast_ctx =
         llvm::cast<SwiftASTContextForExpressions>(typesystem_sp.get());
     m_scratch_typesystem_for_module.insert({idx, typesystem_sp});

--- a/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
+++ b/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
@@ -28,7 +28,7 @@ class TestSwiftRewriteClangPaths(TestBase):
         logfile = open(log, "r")
         found = 0
         for line in logfile:
-            if line.startswith(' SwiftASTContext("a.out")::RemapClangImporterOptions() -- remapped'):
+            if line.startswith(' SwiftASTContextForModule("a.out")::RemapClangImporterOptions() -- remapped'):
                 if '/LocalSDK/' in line:
                     found += 1
         self.assertEqual(found, 1)

--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -65,6 +65,10 @@ struct SwiftASTContextTester : public SwiftASTContext {
     SwiftASTContextTester() : SwiftASTContext() {}
   #endif
 
+  TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() override {
+    return m_typeref_typesystem;
+  }
+
   static std::string GetResourceDir(llvm::StringRef platform_sdk_path,
                                     std::string swift_dir,
                                     std::string swift_stdlib_os_dir,
@@ -79,6 +83,7 @@ struct SwiftASTContextTester : public SwiftASTContext {
                                          const llvm::Triple &host) {
     return SwiftASTContext::GetSwiftStdlibOSDir(target, host);
   }
+  TypeSystemSwiftTypeRef m_typeref_typesystem;
 };
 
 TEST_F(TestSwiftASTContext, ResourceDir) {
@@ -195,7 +200,7 @@ TEST_F(TestSwiftASTContext, IsNonTriviallyManagedReferenceType) {
 #ifndef NDEBUG
   // The mock constructor is only available in asserts mode.
   SwiftASTContext::NonTriviallyManagedReferenceStrategy strategy;
-  SwiftASTContext context;
+  SwiftASTContextTester context;
   CompilerType t(&context, nullptr);
   EXPECT_FALSE(SwiftASTContext::IsNonTriviallyManagedReferenceType(t, strategy,
                                                                    nullptr));

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -25,7 +25,7 @@ using namespace llvm;
 struct TestTypeSystemSwiftTypeRef : public testing::Test {
   TypeSystemSwiftTypeRef m_swift_ts;
 
-  TestTypeSystemSwiftTypeRef() : m_swift_ts(nullptr) {}
+  TestTypeSystemSwiftTypeRef() : m_swift_ts() {}
   CompilerType GetCompilerType(std::string mangled_name) {
     ConstString internalized(mangled_name);
     return m_swift_ts.GetTypeFromMangledTypename(internalized);


### PR DESCRIPTION
…ef (NFC)

This patch introduces a new subclass SwiftASTContextForModules, which
is now owned by TypeSystemSwiftTypeRef and initialized lazily. The
TypeSystemSwiftTypeRef that corresponds to the scratch context is
still owned by SwiftASTContextForExpressions.

rdar://81717792