### PR TITLE
Invert the ownership between SwiftASTContext and TypeSystemSwiftTypeR…

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1569,9 +1569,9 @@ bool Module::SetArchitecture(const ArchSpec &new_arch) {
       return true;
     }
 #ifdef LLDB_ENABLE_SWIFT
-    if (auto *swift_ast =
-            llvm::dyn_cast_or_null<SwiftASTContext>(&*type_system_or_err))
-      swift_ast->SetTriple(new_arch.GetTriple());
+    if (auto *ts =
+            llvm::dyn_cast_or_null<TypeSystemSwift>(&*type_system_or_err))
+      ts->SetTriple(new_arch.GetTriple());
 #endif // LLDB_ENABLE_SWIFT
     return true;
   }
@@ -1696,8 +1696,8 @@ void Module::ClearModuleDependentCaches() {
   }
 
 #ifdef LLDB_ENABLE_SWIFT
-  if (auto *swift_ast = llvm::dyn_cast_or_null<SwiftASTContext>(&*type_system_or_err))
-    swift_ast->ClearModuleDependentCaches();
+  if (auto *ts = llvm::dyn_cast_or_null<TypeSystemSwift>(&*type_system_or_err))
+    ts->ClearModuleDependentCaches();
 #endif // LLDB_ENABLE_SWIFT
 }
 

--- a/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
@@ -101,7 +101,10 @@ static std::string TranslateObjCNameToSwiftName(std::string className,
     return "";
   }
 
-  auto *ctx = llvm::dyn_cast_or_null<SwiftASTContext>(&*type_system_or_err);
+  auto *ts = llvm::dyn_cast_or_null<TypeSystemSwift>(&*type_system_or_err);
+  if (!ts)
+    return "";
+  auto *ctx = ts->GetSwiftASTContext();
   if (!ctx)
     return "";
   swift::ClangImporter *imp = ctx->GetClangImporter();

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1872,7 +1872,7 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Protocol(
   }
 
   const swift::reflection::TypeRef *protocol_typeref =
-      GetTypeRef(protocol_type, tss->GetSwiftASTContext());
+      GetTypeRef(protocol_type, &tss->GetTypeSystemSwiftTypeRef());
   if (!protocol_typeref) {
     if (log)
       log->Printf("Could not get protocol typeref");
@@ -2841,7 +2841,7 @@ lldb::addr_t SwiftLanguageRuntimeImpl::FixupAddress(lldb::addr_t addr,
 
 const swift::reflection::TypeRef *
 SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type,
-                                     SwiftASTContext *module_holder) {
+                                     TypeSystemSwiftTypeRef *module_holder) {
   // Demangle the mangled name.
   swift::Demangle::Demangler dem;
   ConstString mangled_name = type.GetMangledTypeName();
@@ -2850,8 +2850,10 @@ SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type,
     return nullptr;
   swift::Demangle::NodePointer node =
       TypeSystemSwiftTypeRef::GetCanonicalDemangleTree(
-          module_holder ? module_holder : ts->GetSwiftASTContext(), dem,
-          mangled_name.GetStringRef());
+          module_holder ? module_holder : &ts->GetTypeSystemSwiftTypeRef(),
+          module_holder ? module_holder->GetSwiftASTContext()
+                        : ts->GetSwiftASTContext(),
+          dem, mangled_name.GetStringRef());
   if (!node)
     return nullptr;
 
@@ -2895,7 +2897,7 @@ SwiftLanguageRuntimeImpl::GetSwiftRuntimeTypeInfo(
   // context, but we need to resolve (any DWARF links in) the typeref
   // in the original module.
   const swift::reflection::TypeRef *type_ref =
-      GetTypeRef(type, ts->GetSwiftASTContext());
+      GetTypeRef(type, &ts->GetTypeSystemSwiftTypeRef());
   if (!type_ref)
     return nullptr;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -182,8 +182,8 @@ protected:
       swift::External<swift::RuntimeTarget<sizeof(uintptr_t)>>>;
 
   /// Use the reflection context to build a TypeRef object.
-  const swift::reflection::TypeRef *GetTypeRef(CompilerType type,
-                                               SwiftASTContext *module_holder);
+  const swift::reflection::TypeRef *
+  GetTypeRef(CompilerType type, TypeSystemSwiftTypeRef *module_holder);
 
   /// Returned by \ref ForEachSuperClassType. Not every user of \p
   /// ForEachSuperClassType needs all of these. By returning this

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -187,6 +187,7 @@ using namespace lldb;
 using namespace lldb_private;
 
 char SwiftASTContext::ID;
+char SwiftASTContextForModule::ID;
 char SwiftASTContextForExpressions::ID;
 
 CompilerType lldb_private::ToCompilerType(swift::Type qual_type) {
@@ -200,7 +201,7 @@ TypePayloadSwift::TypePayloadSwift(bool is_fixed_value_buffer) {
 }
 
 CompilerType SwiftASTContext::GetCompilerType(ConstString mangled_name) {
-  return m_typeref_typesystem.GetTypeFromMangledTypename(mangled_name);
+  return GetTypeSystemSwiftTypeRef().GetTypeFromMangledTypename(mangled_name);
 }
 
 CompilerType SwiftASTContext::GetCompilerType(swift::TypeBase *swift_type) {
@@ -216,7 +217,9 @@ swift::Type TypeSystemSwiftTypeRef::GetSwiftType(CompilerType compiler_type) {
   // FIXME: Suboptimal performance, because the ConstString is looked up again.
   ConstString mangled_name(
       reinterpret_cast<const char *>(compiler_type.GetOpaqueQualType()));
-  return ts->m_swift_ast_context->ReconstructType(mangled_name);
+  if (auto *swift_ast_context = ts->GetSwiftASTContext())
+    return swift_ast_context->ReconstructType(mangled_name);
+  return {};
 }
 
 swift::Type SwiftASTContext::GetSwiftType(CompilerType compiler_type) {
@@ -899,14 +902,14 @@ static std::string GetClangModulesCacheProperty() {
 }
 
 #ifndef NDEBUG
-SwiftASTContext::SwiftASTContext() : m_typeref_typesystem(this) {
+SwiftASTContext::SwiftASTContext() {
   llvm::dbgs() << "Initialized mock SwiftASTContext\n";
 }
 #endif
 
 SwiftASTContext::SwiftASTContext(std::string description, llvm::Triple triple,
                                  Target *target)
-    : TypeSystemSwift(), m_typeref_typesystem(this),
+    : TypeSystemSwift(),
       m_compiler_invocation_ap(new swift::CompilerInvocation()) {
   m_description = description;
 
@@ -1613,10 +1616,11 @@ static bool IsDWARFImported(swift::ModuleDecl &module) {
                      });
 }
 
-lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
-                                                   Module &module,
-                                                   Target *target,
-                                                   bool fallback) {
+lldb::TypeSystemSP
+SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
+                                TypeSystemSwiftTypeRef *typeref_typesystem,
+                                Target *target, bool fallback) {
+  assert(((bool)fallback && (bool)target) != (bool)typeref_typesystem);
   if (!SwiftASTContextSupportsLanguage(language))
     return lldb::TypeSystemSP();
 
@@ -1626,6 +1630,8 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
     ss << "SwiftASTContext";
     if (fallback)
       ss << "ForExpressions";
+    else
+      ss << "ForModule";
     ss << '(' << '"';
     module.GetDescription(ss, eDescriptionLevelBrief);
     ss << '"' << ')';
@@ -1688,9 +1694,10 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
   // If there is a target this may be a fallback scratch context.
   assert((!fallback || target) && "fallback context must specify a target");
   std::shared_ptr<SwiftASTContext> swift_ast_sp(
-      fallback ? (new SwiftASTContextForExpressions(m_description, *target))
-               : (new SwiftASTContext(
-                     m_description,
+      fallback ? static_cast<SwiftASTContext *>(
+                     new SwiftASTContextForExpressions(m_description, *target))
+               : static_cast<SwiftASTContext *>(new SwiftASTContextForModule(
+                     *typeref_typesystem, m_description,
                      target ? target->GetArchitecture().GetTriple() : triple,
                      target)));
   bool suppress_config_log = false;
@@ -1922,6 +1929,19 @@ static lldb::ModuleSP GetUnitTestModule(lldb_private::ModuleList &modules) {
   return ModuleSP();
 }
 
+static SwiftASTContext *GetModuleSwiftASTContext(Module &module) {
+  auto type_system_or_err =
+      module.GetTypeSystemForLanguage(lldb::eLanguageTypeSwift);
+  if (!type_system_or_err) {
+    llvm::consumeError(type_system_or_err.takeError());
+    return {};
+  }
+  auto *ts = static_cast<TypeSystemSwift *>(&*type_system_or_err);
+  if (!ts)
+    return {};
+  return ts->GetSwiftASTContext();
+}
+
 /// Scan a newly added lldb::Module for Swift modules and report any errors in
 /// its module SwiftASTContext to Target.
 static void
@@ -2002,16 +2022,7 @@ ProcessModule(ModuleSP module_sp, std::string m_description,
   if (!HasSwiftModules(*module_sp))
     return;
 
-  auto type_system_or_err =
-      module_sp->GetTypeSystemForLanguage(lldb::eLanguageTypeSwift);
-  if (!type_system_or_err) {
-    llvm::consumeError(type_system_or_err.takeError());
-    return;
-  }
-
-  SwiftASTContext *ast_context =
-      llvm::dyn_cast_or_null<SwiftASTContext>(&*type_system_or_err);
-
+  SwiftASTContext *ast_context = GetModuleSwiftASTContext(*module_sp);
   if (!ast_context || ast_context->HasFatalErrors() ||
       !ast_context->GetClangImporter()) {
     // Make sure we warn about this module load failure, the one
@@ -2163,11 +2174,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
       for (size_t mi = 0; mi != num_images; ++mi) {
         auto module_sp = target.GetImages().GetModuleAtIndex(mi);
         pool.async([=] {
-          auto val_or_err =
-              module_sp->GetTypeSystemForLanguage(lldb::eLanguageTypeSwift);
-          if (!val_or_err) {
-            llvm::consumeError(val_or_err.takeError());
-          }
+          GetModuleSwiftASTContext(*module_sp);
         });
       }
       pool.wait();
@@ -2181,15 +2188,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
       if (!HasSwiftModules(*module_sp))
         continue;
 
-      auto type_system_or_err =
-          module_sp->GetTypeSystemForLanguage(lldb::eLanguageTypeSwift);
-      if (!type_system_or_err) {
-        llvm::consumeError(type_system_or_err.takeError());
-        continue;
-      }
-
-      auto *module_swift_ast =
-          llvm::dyn_cast_or_null<SwiftASTContext>(&*type_system_or_err);
+      SwiftASTContext *module_swift_ast = GetModuleSwiftASTContext(*module_sp);
       if (!module_swift_ast || module_swift_ast->HasFatalErrors() ||
           !module_swift_ast->GetClangImporter())
         continue;
@@ -2222,14 +2221,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
     auto get_executable_triple = [&]() -> llvm::Triple {
       if (!exe_module_sp)
         return {};
-      auto type_system_or_err =
-          exe_module_sp->GetTypeSystemForLanguage(lldb::eLanguageTypeSwift);
-      if (!type_system_or_err) {
-        llvm::consumeError(type_system_or_err.takeError());
-        return {};
-      }
-      auto *exe_ast_ctx =
-          llvm::dyn_cast_or_null<SwiftASTContext>(&type_system_or_err.get());
+      auto *exe_ast_ctx = GetModuleSwiftASTContext(*exe_module_sp);
       if (!exe_ast_ctx)
         return {};
       return exe_ast_ctx->GetLanguageOptions().Target;
@@ -3271,7 +3263,7 @@ public:
                        TypeSystemClang::GetSupportedLanguagesForTypes(),
                        searched_symbol_files, clang_types);
     };
-    if (Module *module = m_swift_ast_ctx.GetModule())
+    if (Module *module = m_swift_ast_ctx.GetTypeSystemSwiftTypeRef().GetModule())
       search(*module);
     else if (TargetSP target_sp = m_swift_ast_ctx.GetTarget().lock()) {
       // In a scratch context, check the module's DWARFImporterDelegates first.
@@ -3282,12 +3274,7 @@ public:
       auto images = target_sp->GetImages();
       for (size_t i = 0; i != images.GetSize(); ++i) {
         auto module_sp = images.GetModuleAtIndex(i);
-        auto ts = module_sp->GetTypeSystemForLanguage(lldb::eLanguageTypeSwift);
-        if (!ts) {
-          llvm::consumeError(ts.takeError());
-          continue;
-        }
-        auto *swift_ast_ctx = static_cast<SwiftASTContext *>(&*ts);
+        auto *swift_ast_ctx = GetModuleSwiftASTContext(*module_sp);
         auto *dwarf_imp = static_cast<SwiftDWARFImporterDelegate *>(
             swift_ast_ctx->GetDWARFImporterDelegate());
         if (!dwarf_imp || dwarf_imp == this)
@@ -4346,7 +4333,7 @@ CompilerType SwiftASTContext::GetAsClangType(ConstString mangled_name) {
   // that look like they might be come from Objective-C (or C) as
   // Clang types. LLDB's Objective-C part is very robust against
   // malformed object pointers, so this isn't very risky.
-  Module *module = GetModule();
+  Module *module = GetTypeSystemSwiftTypeRef().GetModule();
   if (!module)
     return {};
   auto type_system_or_err =
@@ -4811,7 +4798,7 @@ CompilerType SwiftASTContext::ImportType(CompilerType &type, Status &error) {
   if (!mangled_name)
     return {};
   if (llvm::isa<TypeSystemSwiftTypeRef>(ts))
-    return m_typeref_typesystem.GetTypeFromMangledTypename(mangled_name);
+    return GetTypeSystemSwiftTypeRef().GetTypeFromMangledTypename(mangled_name);
   swift::TypeBase *our_type_base =
       m_mangled_name_to_type_map.lookup(mangled_name.GetCString());
   if (our_type_base)
@@ -5100,7 +5087,7 @@ void SwiftASTContext::PrintDiagnostics(DiagnosticManager &diagnostic_manager,
   }
 }
 
-void SwiftASTContext::ModulesDidLoad(ModuleList &module_list) {
+void SwiftASTContextForExpressions::ModulesDidLoad(ModuleList &module_list) {
   ClearModuleDependentCaches();
 
   // Scan the new modules for Swift contents and try to import it if
@@ -5562,7 +5549,7 @@ SwiftASTContext::GetAllocationStrategy(opaque_compiler_type_t type) {
 
 CompilerType
 SwiftASTContext::GetTypeRefType(lldb::opaque_compiler_type_t type) {
-  return m_typeref_typesystem.GetTypeFromMangledTypename(
+  return GetTypeSystemSwiftTypeRef().GetTypeFromMangledTypename(
       GetMangledTypeName(type));
 }
 
@@ -8335,6 +8322,7 @@ SwiftASTContextForExpressions::SwiftASTContextForExpressions(
     std::string description, Target &target)
     : SwiftASTContext(std::move(description),
                       target.GetArchitecture().GetTriple(), &target),
+      m_typeref_typesystem(*this),
       m_persistent_state_up(new SwiftPersistentExpressionState) {}
 
 UserExpression *SwiftASTContextForExpressions::GetUserExpression(

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -163,15 +163,13 @@ public:
   /// Provide the global LLVMContext.
   static llvm::LLVMContext &GetGlobalLLVMContext();
 
+protected:
   // Constructors and destructors
   SwiftASTContext(std::string description, llvm::Triple triple,
                   Target *target = nullptr);
+public:
 
   SwiftASTContext(const SwiftASTContext &rhs) = delete;
-
-  TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() override {
-    return m_typeref_typesystem;
-  }
 
   ~SwiftASTContext();
 
@@ -187,10 +185,10 @@ public:
   /// this lldb::Module.  The optional target is necessary when
   /// creating a module-specific scratch context.  If \p fallback is
   /// true, then a SwiftASTContextForExpressions is created.
-  static lldb::TypeSystemSP CreateInstance(lldb::LanguageType language,
-                                           Module &module,
-                                           Target *target = nullptr,
-                                           bool fallback = false);
+  static lldb::TypeSystemSP
+  CreateInstance(lldb::LanguageType language, Module &module,
+                 TypeSystemSwiftTypeRef *typeref_typesystem = nullptr,
+                 Target *target = nullptr, bool fallback = false);
   /// Create a SwiftASTContext from a Target.  This context is global
   /// and used for the expression evaluator.
   static lldb::TypeSystemSP CreateInstance(lldb::LanguageType language,
@@ -203,7 +201,9 @@ public:
 
   bool SupportsLanguage(lldb::LanguageType language) override;
 
-  SwiftASTContext *GetSwiftASTContext() override { return this; }
+  SwiftASTContext *GetSwiftASTContext() const override {
+    return const_cast<SwiftASTContext *>(this);
+  }
 
   Status IsCompatible() override;
 
@@ -281,8 +281,6 @@ public:
   swift::ModuleDecl *GetModule(const FileSpec &module_spec, Status &error);
 
   void CacheModule(swift::ModuleDecl *module);
-
-  Module *GetModule() const override { return m_module; }
 
   // Call this after the search paths are set up, it will find the module given
   // by module, load the module into the AST context, and also load any
@@ -368,8 +366,10 @@ public:
 
   llvm::Triple GetTriple() const;
 
-  bool SetTriple(const llvm::Triple triple,
-                 lldb_private::Module *module = nullptr);
+  bool SetTriple(const llvm::Triple triple, lldb_private::Module *module);
+  void SetTriple(const llvm::Triple triple) override {
+    SetTriple(triple, nullptr);
+  }
 
   /// Condition a triple to be safe for use with Swift.  Swift is
   /// really peculiar about what CPU types it thinks it has standard
@@ -418,9 +418,7 @@ public:
   swift::IRGenOptions &GetIRGenOptions();
   swift::TBDGenOptions &GetTBDGenOptions();
 
-  void ModulesDidLoad(ModuleList &module_list);
-
-  void ClearModuleDependentCaches();
+  void ClearModuleDependentCaches() override;
 
   void LogConfiguration();
 
@@ -846,7 +844,6 @@ protected:
 
   /// Data members.
   /// @{
-  TypeSystemSwiftTypeRef m_typeref_typesystem;
   std::unique_ptr<swift::CompilerInvocation> m_compiler_invocation_ap;
   std::unique_ptr<swift::SourceManager> m_source_manager_up;
   std::unique_ptr<swift::DiagnosticEngine> m_diagnostic_engine_ap;
@@ -884,7 +881,6 @@ protected:
   /// Only if this AST belongs to a target, and an expression has been
   /// evaluated will the target's process pointer be filled in
   lldb_private::Process *m_process = nullptr;
-  Module *m_module = nullptr;
   std::string m_platform_sdk_path;
   /// All previously library loads in LoadLibraryUsingPaths with their
   /// respective result (true = loaded, false = failed to load).
@@ -958,6 +954,35 @@ protected:
                                          const llvm::Triple &host);
 };
 
+/// Deprecated.
+class SwiftASTContextForModule : public SwiftASTContext {
+  // LLVM RTTI support
+  static char ID;
+
+public:
+  /// LLVM RTTI support
+  /// \{
+  bool isA(const void *ClassID) const override {
+    return ClassID == &ID || SwiftASTContext::isA(ClassID);
+  }
+  static bool classof(const TypeSystem *ts) { return ts->isA(&ID); }
+  /// \}
+
+  SwiftASTContextForModule(TypeSystemSwiftTypeRef &typeref_typesystem,
+                           std::string description, llvm::Triple triple,
+                           Target *target)
+      : SwiftASTContext(description, triple, target),
+        m_typeref_typesystem(typeref_typesystem) {}
+  virtual ~SwiftASTContextForModule() {}
+
+  TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() override {
+    return m_typeref_typesystem;
+  }
+
+private:
+  TypeSystemSwiftTypeRef &m_typeref_typesystem;
+};
+
 class SwiftASTContextForExpressions : public SwiftASTContext {
   // LLVM RTTI support
   static char ID;
@@ -972,8 +997,11 @@ public:
   /// \}
 
   SwiftASTContextForExpressions(std::string description, Target &target);
-
   virtual ~SwiftASTContextForExpressions() {}
+
+  TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() override {
+    return m_typeref_typesystem;
+  }
 
   UserExpression *GetUserExpression(llvm::StringRef expr,
                                     llvm::StringRef prefix,
@@ -984,7 +1012,10 @@ public:
 
   PersistentExpressionState *GetPersistentExpressionState() override;
 
+  void ModulesDidLoad(ModuleList &module_list);
+
 private:
+  TypeSystemSwiftTypeRef m_typeref_typesystem;
   std::unique_ptr<SwiftPersistentExpressionState> m_persistent_state_up;
 };
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -23,17 +23,23 @@ using namespace lldb;
 using namespace lldb_private;
 using llvm::StringRef;
 
+TypeSystemSwift::TypeSystemSwift() : TypeSystem() {}
+
 /// TypeSystem Plugin functionality.
 /// \{
 static lldb::TypeSystemSP CreateTypeSystemInstance(lldb::LanguageType language,
                                                    Module *module,
                                                    Target *target,
                                                    const char *extra_options) {
+  if (language != eLanguageTypeSwift)
+    return {};
+
   // This should be called with either a target or a module.
   if (module) {
     assert(!target);
     assert(StringRef(extra_options).empty());
-    return SwiftASTContext::CreateInstance(language, *module);
+    return std::shared_ptr<TypeSystemSwiftTypeRef>(
+        new TypeSystemSwiftTypeRef(*module));
   } else if (target) {
     assert(!module);
     return SwiftASTContext::CreateInstance(language, *target, extra_options);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -49,8 +49,6 @@ using namespace lldb_private;
 char TypeSystemSwift::ID;
 char TypeSystemSwiftTypeRef::ID;
 
-TypeSystemSwift::TypeSystemSwift() : TypeSystem() {}
-
 /// Determine wether this demangle tree contains an unresolved type alias.
 static bool ContainsUnresolvedTypeAlias(swift::Demangle::NodePointer node) {
   if (!node)
@@ -152,7 +150,8 @@ GetTypeAlias(swift::Demangle::Demangler &dem,
 }
 
 /// Find a Clang type by name in the modules in \p module_holder.
-static TypeSP LookupClangType(SwiftASTContext *module_holder, StringRef name) {
+static TypeSP LookupClangType(TypeSystemSwiftTypeRef *module_holder,
+                              SwiftASTContext *target_holder, StringRef name) {
   auto lookup = [](Module &M, StringRef name) -> TypeSP {
     llvm::SmallVector<CompilerContext, 2> decl_context;
     decl_context.push_back({CompilerContextKind::AnyModule, ConstString()});
@@ -169,7 +168,9 @@ static TypeSP LookupClangType(SwiftASTContext *module_holder, StringRef name) {
     return {};
   if (auto *M = module_holder->GetModule())
     return lookup(*M, name);
-  TargetSP target_sp = module_holder->GetTarget().lock();
+  if (!target_holder)
+    return {};
+  TargetSP target_sp = target_holder->GetTarget().lock();
   if (!target_sp)
     return {};
   TypeSP result;
@@ -181,9 +182,10 @@ static TypeSP LookupClangType(SwiftASTContext *module_holder, StringRef name) {
 }
 
 /// Find a Clang type by name in module \p M.
-static CompilerType LookupClangForwardType(SwiftASTContext *module_holder,
-                                           StringRef name) {
-  if (TypeSP type = LookupClangType(module_holder, name))
+static CompilerType
+LookupClangForwardType(TypeSystemSwiftTypeRef *module_holder,
+                       SwiftASTContext *target_holder, StringRef name) {
+  if (TypeSP type = LookupClangType(module_holder, target_holder, name))
     return type->GetForwardCompilerType();
   return {};
 }
@@ -389,11 +391,10 @@ GetNominal(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node) {
 /// \param prefer_clang_types if this is true, type aliases in the
 ///                           __C module are resolved as Clang types.
 ///
-static std::pair<swift::Demangle::NodePointer, CompilerType>
-ResolveTypeAlias(SwiftASTContext *module_holder,
-                 swift::Demangle::Demangler &dem,
-                 swift::Demangle::NodePointer node,
-                 bool prefer_clang_types = false) {
+static std::pair<swift::Demangle::NodePointer, CompilerType> ResolveTypeAlias(
+    TypeSystemSwiftTypeRef *module_holder, SwiftASTContext *target_holder,
+    swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
+    bool prefer_clang_types = false) {
   LLDB_SCOPED_TIMER();
   auto resolve_clang_type = [&]() -> CompilerType {
     auto maybe_module_and_type_names = GetNominal(dem, node);
@@ -405,8 +406,8 @@ ResolveTypeAlias(SwiftASTContext *module_holder,
       return {};
 
     // Resolve the typedef within the Clang debug info.
-    auto clang_type =
-        LookupClangForwardType(module_holder, node->getChild(1)->getText());
+    auto clang_type = LookupClangForwardType(module_holder, target_holder,
+                                             node->getChild(1)->getText());
     if (!clang_type)
       return {};
 
@@ -430,7 +431,7 @@ ResolveTypeAlias(SwiftASTContext *module_holder,
     llvm::DenseSet<SymbolFile *> searched_symbol_files;
     if (auto *M = module_holder->GetModule())
       M->FindTypes({mangled}, false, 1, searched_symbol_files, types);
-    else if (TargetSP target_sp = module_holder->GetTarget().lock())
+    else if (TargetSP target_sp = target_holder->GetTarget().lock())
       target_sp->GetImages().FindTypes(nullptr, {mangled},
                                        false, 1, searched_symbol_files, types);
     else {
@@ -552,10 +553,9 @@ swift::Demangle::NodePointer TypeSystemSwiftTypeRef::Transform(
 
 /// Iteratively resolve all type aliases in \p node by looking up their
 /// desugared types in the debug info of module \p M.
-static swift::Demangle::NodePointer
-GetCanonicalNode(SwiftASTContext *module_holder,
-                 swift::Demangle::Demangler &dem,
-                 swift::Demangle::NodePointer node) {
+static swift::Demangle::NodePointer GetCanonicalNode(
+    TypeSystemSwiftTypeRef *module_holder, SwiftASTContext *target_holder,
+    swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node) {
   using namespace swift::Demangle;
   return TypeSystemSwiftTypeRef::Transform(dem, node, [&](NodePointer node) {
     NodePointer canonical = nullptr;
@@ -657,9 +657,10 @@ GetCanonicalNode(SwiftASTContext *module_holder,
 
     case Node::Kind::BoundGenericTypeAlias:
     case Node::Kind::TypeAlias: {
-      auto node_clangtype = ResolveTypeAlias(module_holder, dem, node);
+      auto node_clangtype =
+          ResolveTypeAlias(module_holder, target_holder, dem, node);
       if (CompilerType clang_type = node_clangtype.second)
-        return GetClangTypeNode(clang_type, dem, module_holder);
+        return GetClangTypeNode(clang_type, dem, target_holder);
       if (node_clangtype.first)
         return node_clangtype.first;
       return node;
@@ -674,11 +675,11 @@ GetCanonicalNode(SwiftASTContext *module_holder,
 /// Return the demangle tree representation of this type's canonical
 /// (type aliases resolved) type.
 swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetCanonicalDemangleTree(
-    SwiftASTContext *module_holder, swift::Demangle::Demangler &dem,
-    StringRef mangled_name) {
+    TypeSystemSwiftTypeRef *module_holder, SwiftASTContext *target_holder,
+    swift::Demangle::Demangler &dem, StringRef mangled_name) {
   LLDB_SCOPED_TIMER();
   auto *node = dem.demangleSymbol(mangled_name);
-  return GetCanonicalNode(module_holder, dem, node);
+  return GetCanonicalNode(module_holder, target_holder, dem, node);
 }
 
 static clang::Decl *GetDeclForTypeAndKind(clang::QualType qual_type,
@@ -823,7 +824,9 @@ TypeSystemSwiftTypeRef::GetSwiftName(const clang::Decl *clang_decl,
   //
   // TODO: Separate ClangImporter::ImportDecl into a freestanding
   // class, so we don't need a SwiftASTContext for this!
-  return m_swift_ast_context->ImportName(named_decl);
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->ImportName(named_decl);
+  return {};
 }
 
 /// Determine whether \p node is an Objective-C type and return its name.
@@ -848,7 +851,7 @@ TypeSystemSwiftTypeRef::GetSwiftified(swift::Demangle::Demangler &dem,
 
   // This is an imported Objective-C type; look it up in the
   // debug info.
-  TypeSP clang_type = LookupClangType(m_swift_ast_context, ident);
+  TypeSP clang_type = LookupClangType(this, GetSwiftASTContext(), ident);
   if (!clang_type)
     return node;
 
@@ -1039,7 +1042,8 @@ static bool ContainsGenericTypeParameter(swift::Demangle::NodePointer node) {
 /// determine whether a node is generic or not, it needs to visit all
 /// nodes. The \p generic_walk argument specifies that the primary
 /// attributes have been collected and that we only look for generics.
-static uint32_t collectTypeInfo(SwiftASTContext *module_holder,
+static uint32_t collectTypeInfo(TypeSystemSwiftTypeRef *module_holder,
+                                SwiftASTContext *swift_ast_context,
                                 swift::Demangle::Demangler &dem,
                                 swift::Demangle::NodePointer node,
                                 bool &unresolved_typealias,
@@ -1073,9 +1077,10 @@ static uint32_t collectTypeInfo(SwiftASTContext *module_holder,
     }
     if ((type_class & eTypeClassBuiltin)) {
       swift_flags &= ~eTypeIsStructUnion;
-      swift_flags |= collectTypeInfo(
-          module_holder, dem, GetClangTypeNode(clang_type, dem, module_holder),
-          unresolved_typealias);
+      swift_flags |=
+          collectTypeInfo(module_holder, swift_ast_context, dem,
+                          GetClangTypeNode(clang_type, dem, swift_ast_context),
+                          unresolved_typealias);
       return;
     }
   };
@@ -1199,8 +1204,8 @@ static uint32_t collectTypeInfo(SwiftASTContext *module_holder,
           break;
 
         // Look up the Clang type in DWARF.
-        CompilerType clang_type =
-            LookupClangForwardType(module_holder, ident->getText());
+        CompilerType clang_type = LookupClangForwardType(
+            module_holder, swift_ast_context, ident->getText());
         collect_clang_type(clang_type.GetCanonicalType());
         return swift_flags;
       }
@@ -1250,7 +1255,7 @@ static uint32_t collectTypeInfo(SwiftASTContext *module_holder,
       // Bug-for-bug compatibility.
       // swift_flags |= eTypeIsTypedef;
       auto node_clangtype =
-          ResolveTypeAlias(module_holder, dem, node);
+          ResolveTypeAlias(module_holder, swift_ast_context, dem, node);
       if (CompilerType clang_type = node_clangtype.second) {
         collect_clang_type(clang_type);
         return swift_flags;
@@ -1260,8 +1265,8 @@ static uint32_t collectTypeInfo(SwiftASTContext *module_holder,
         // then we don't have debug info to resolve it from.
         unresolved_typealias = true;
       }
-      swift_flags |= collectTypeInfo(module_holder, dem, node_clangtype.first,
-                                     generic_walk);
+      swift_flags |= collectTypeInfo(module_holder, swift_ast_context, dem,
+                                     node_clangtype.first, generic_walk);
       return swift_flags;
     }
     default:
@@ -1274,8 +1279,9 @@ static uint32_t collectTypeInfo(SwiftASTContext *module_holder,
 
   // Visit the child nodes.
   for (unsigned i = 0; i < node->getNumChildren(); ++i)
-    swift_flags |= collectTypeInfo(module_holder, dem, node->getChild(i),
-                                   unresolved_typealias, generic_walk);
+    swift_flags |=
+        collectTypeInfo(module_holder, swift_ast_context, dem,
+                        node->getChild(i), unresolved_typealias, generic_walk);
 
   return swift_flags;
 }
@@ -1289,12 +1295,48 @@ CompilerType TypeSystemSwift::GetInstanceType(CompilerType compiler_type) {
   return {};
 }
 
-TypeSystemSwiftTypeRef::TypeSystemSwiftTypeRef(
-    SwiftASTContext *swift_ast_context)
-    : m_swift_ast_context(swift_ast_context) {
-  m_description = "TypeSystemSwiftTypeRef";
+TypeSystemSwiftTypeRef::TypeSystemSwiftTypeRef(Module &module) {
+  m_module = &module;
+  {
+    llvm::raw_string_ostream ss(m_description);
+    ss << "TypeSystemSwiftTypeRef(\"";
+    module.GetDescription(ss, eDescriptionLevelBrief);
+    ss << "\")";
+  }
+  LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
+            "%s::TypeSystemSwiftTypeRef()", m_description.c_str());
 }
 
+TypeSystemSwiftTypeRef::TypeSystemSwiftTypeRef(
+    SwiftASTContextForExpressions &swift_ast_context)
+    : m_swift_ast_context(&swift_ast_context) {
+  m_description = "TypeSystemSwiftTypeRef(ForExpressions)";
+  LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
+            "%sTypeSystemSwiftTypeRef()", m_description.c_str());
+}
+
+SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContext() const {
+  if (!m_swift_ast_context) {
+    if (auto *module = GetModule()) {
+      m_swift_ast_context_sp = SwiftASTContext::CreateInstance(
+          LanguageType::eLanguageTypeSwift, *module,
+          const_cast<TypeSystemSwiftTypeRef *>(this));
+      m_swift_ast_context =
+          llvm::dyn_cast_or_null<SwiftASTContext>(m_swift_ast_context_sp.get());
+    }
+  }
+  return m_swift_ast_context;
+}
+
+void TypeSystemSwiftTypeRef::SetTriple(const llvm::Triple triple) {
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    swift_ast_context->SetTriple(triple);
+}
+
+void TypeSystemSwiftTypeRef::ClearModuleDependentCaches() {
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    swift_ast_context->ClearModuleDependentCaches();
+}
 const char *TypeSystemSwiftTypeRef::AsMangledName(opaque_compiler_type_t type) {
   assert(type && *reinterpret_cast<const char *>(type) == '$' &&
          "wrong type system");
@@ -1309,11 +1351,13 @@ TypeSystemSwiftTypeRef::GetMangledTypeName(opaque_compiler_type_t type) {
 
 void *TypeSystemSwiftTypeRef::ReconstructType(opaque_compiler_type_t type) {
   Status error;
-  return m_swift_ast_context->ReconstructType(GetMangledTypeName(type), error);
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->ReconstructType(GetMangledTypeName(type), error);
+  return {};
 }
 
 CompilerType TypeSystemSwiftTypeRef::ReconstructType(CompilerType type) {
-  return {m_swift_ast_context, ReconstructType(type.GetOpaqueQualType())};
+  return {GetSwiftASTContext(), ReconstructType(type.GetOpaqueQualType())};
 }
 
 CompilerType TypeSystemSwiftTypeRef::GetTypeFromMangledTypename(
@@ -1322,16 +1366,15 @@ CompilerType TypeSystemSwiftTypeRef::GetTypeFromMangledTypename(
 }
 
 lldb::TypeSP TypeSystemSwiftTypeRef::GetCachedType(ConstString mangled) {
-  return m_swift_ast_context->GetCachedType(mangled);
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    swift_ast_context->GetCachedType(mangled);
+  return {};
 }
 
 void TypeSystemSwiftTypeRef::SetCachedType(ConstString mangled,
                                            const lldb::TypeSP &type_sp) {
-  return m_swift_ast_context->SetCachedType(mangled, type_sp);
-}
-
-Module *TypeSystemSwiftTypeRef::GetModule() const {
-  return m_swift_ast_context ? m_swift_ast_context->GetModule() : nullptr;
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    swift_ast_context->SetCachedType(mangled, type_sp);
 }
 
 ConstString TypeSystemSwiftTypeRef::GetPluginName() {
@@ -1343,15 +1386,21 @@ bool TypeSystemSwiftTypeRef::SupportsLanguage(lldb::LanguageType language) {
 }
 
 Status TypeSystemSwiftTypeRef::IsCompatible() {
-  return m_swift_ast_context->IsCompatible();
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return m_swift_ast_context->IsCompatible();
+  return {};
 }
 
 void TypeSystemSwiftTypeRef::DiagnoseWarnings(Process &process,
                                               Module &module) const {
-  m_swift_ast_context->DiagnoseWarnings(process, module);
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    swift_ast_context->DiagnoseWarnings(process, module);
 }
+
 DWARFASTParser *TypeSystemSwiftTypeRef::GetDWARFParser() {
-  return m_swift_ast_context->GetDWARFParser();
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->GetDWARFParser();
+  return {};
 }
 
 TypeSP TypeSystemSwiftTypeRef::LookupTypeInModule(
@@ -1652,8 +1701,11 @@ bool Equivalent(llvm::Optional<T> l, T r) {
 #define FALLBACK(REFERENCE, ARGS)                                              \
   do {                                                                         \
     if (!ModuleList::GetGlobalModuleListProperties()                           \
-             .GetUseSwiftTypeRefTypeSystem())                                  \
-      return m_swift_ast_context->REFERENCE ARGS;                              \
+             .GetUseSwiftTypeRefTypeSystem()) {                                \
+      if (auto *swift_ast_context = GetSwiftASTContext())                      \
+        return swift_ast_context->REFERENCE ARGS;                              \
+      return {};                                                               \
+    }                                                                          \
   } while (0)
 
 #ifndef NDEBUG
@@ -1664,9 +1716,9 @@ bool Equivalent(llvm::Optional<T> l, T r) {
     if (!ModuleList::GetGlobalModuleListProperties()                           \
              .GetSwiftValidateTypeSystem())                                    \
       return result;                                                           \
-    if (!m_swift_ast_context)                                                  \
+    if (!GetSwiftASTContext())                                                 \
       return result;                                                           \
-    assert((result == m_swift_ast_context->REFERENCE()) &&                     \
+    assert((result == GetSwiftASTContext()->REFERENCE()) &&                    \
            "TypeSystemSwiftTypeRef diverges from SwiftASTContext");            \
     return result;                                                             \
   } while (0)
@@ -1678,7 +1730,7 @@ bool Equivalent(llvm::Optional<T> l, T r) {
     if (!ModuleList::GetGlobalModuleListProperties()                           \
              .GetSwiftValidateTypeSystem())                                    \
       return result;                                                           \
-    if (!m_swift_ast_context)                                                  \
+    if (!GetSwiftASTContext())                                                 \
       return result;                                                           \
     if (ShouldSkipValidation(TYPE))                                            \
       return result;                                                           \
@@ -1686,7 +1738,7 @@ bool Equivalent(llvm::Optional<T> l, T r) {
       return result;                                                           \
     bool equivalent =                                                          \
         !ReconstructType(TYPE) /* missing .swiftmodule */ ||                   \
-        (Equivalent(result, m_swift_ast_context->REFERENCE ARGS));             \
+        (Equivalent(result, GetSwiftASTContext()->REFERENCE ARGS));            \
     if (!equivalent)                                                           \
       llvm::dbgs() << "failing type was " << (const char *)TYPE << "\n";       \
     assert(equivalent &&                                                       \
@@ -1930,7 +1982,7 @@ bool TypeSystemSwiftTypeRef::IsPossibleDynamicType(opaque_compiler_type_t type,
       return false;
 
     if (node->getKind() == Node::Kind::TypeAlias) {
-      auto resolved = ResolveTypeAlias(m_swift_ast_context, dem, node);
+      auto resolved = ResolveTypeAlias(this, GetSwiftASTContext(), dem, node);
       if (auto *n = std::get<swift::Demangle::NodePointer>(resolved))
         node = n;
     }
@@ -2006,7 +2058,9 @@ uint32_t TypeSystemSwiftTypeRef::GetPointerByteSize() {
     }
     // An expression context has no module. Since it's for expression
     // evaluation we might as well defer to the SwiftASTContext.
-    return m_swift_ast_context->GetPointerByteSize();
+    if (auto *swift_ast_context = GetSwiftASTContext())
+      return swift_ast_context->GetPointerByteSize();
+    return 0;
   };
   VALIDATE_AND_RETURN_STATIC(impl, GetPointerByteSize);
 }
@@ -2066,13 +2120,13 @@ uint32_t TypeSystemSwiftTypeRef::GetTypeInfo(
     Demangler dem;
     NodePointer node = dem.demangleSymbol(AsMangledName(type));
     bool unresolved_typealias = false;
-    uint32_t flags =
-        collectTypeInfo(m_swift_ast_context, dem, node, unresolved_typealias);
-    if (unresolved_typealias) {
+    uint32_t flags = collectTypeInfo(this, GetSwiftASTContext(), dem, node,
+                                     unresolved_typealias);
+    if (unresolved_typealias && GetSwiftASTContext()) {
       // If this is a typealias defined in the expression evaluator,
       // then we don't have debug info to resolve it from.
-      return m_swift_ast_context->GetTypeInfo(ReconstructType(type),
-                                              pointee_or_element_clang_type);
+      return GetSwiftASTContext()->GetTypeInfo(ReconstructType(type),
+                                               pointee_or_element_clang_type);
     }
     return flags;
   };
@@ -2131,8 +2185,8 @@ TypeSystemSwiftTypeRef::GetCanonicalType(opaque_compiler_type_t type) {
   auto impl = [&]() {
     using namespace swift::Demangle;
     Demangler dem;
-    NodePointer canonical =
-        GetCanonicalDemangleTree(m_swift_ast_context, dem, AsMangledName(type));
+    NodePointer canonical = GetCanonicalDemangleTree(this, GetSwiftASTContext(),
+                                                     dem, AsMangledName(type));
     if (ContainsUnresolvedTypeAlias(canonical)) {
       // If this is a typealias defined in the expression evaluator,
       // then we don't have debug info to resolve it from.
@@ -2195,17 +2249,23 @@ TypeSystemSwiftTypeRef::GetFunctionReturnType(opaque_compiler_type_t type) {
 }
 size_t
 TypeSystemSwiftTypeRef::GetNumMemberFunctions(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetNumMemberFunctions(ReconstructType(type));
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->GetNumMemberFunctions(ReconstructType(type));
+  return {};
 }
 TypeMemberFunctionImpl
 TypeSystemSwiftTypeRef::GetMemberFunctionAtIndex(opaque_compiler_type_t type,
                                                  size_t idx) {
-  return m_swift_ast_context->GetMemberFunctionAtIndex(ReconstructType(type),
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->GetMemberFunctionAtIndex(ReconstructType(type),
                                                        idx);
+  return {};
 }
 CompilerType
 TypeSystemSwiftTypeRef::GetPointeeType(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetPointeeType(ReconstructType(type));
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->GetPointeeType(ReconstructType(type));
+  return {};
 }
 CompilerType
 TypeSystemSwiftTypeRef::GetPointerType(opaque_compiler_type_t type) {
@@ -2259,7 +2319,8 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
       // If this is an expression context, perhaps the type was
       // defined in the expression. In that case we don't have debug
       // info for it, so defer to SwiftASTContext.
-      if (llvm::isa<SwiftASTContextForExpressions>(m_swift_ast_context))
+      if (llvm::isa_and_nonnull<SwiftASTContextForExpressions>(
+              GetSwiftASTContext()))
         return ReconstructType({this, type}).GetBitSize(exe_scope);
       LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
                 "Couldn't compute size of type %s using SwiftLanguageRuntime.",
@@ -2394,7 +2455,9 @@ lldb::Encoding TypeSystemSwiftTypeRef::GetEncoding(opaque_compiler_type_t type,
 
 lldb::Format TypeSystemSwiftTypeRef::GetFormat(opaque_compiler_type_t type) {
   LLDB_SCOPED_TIMER();
-  return m_swift_ast_context->GetFormat(ReconstructType(type));
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->GetFormat(ReconstructType(type));
+  return {};
 }
 
 uint32_t
@@ -2424,8 +2487,10 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
             "Using SwiftASTContext::GetNumChildren fallback for type %s",
             AsMangledName(type));
 
-  return m_swift_ast_context->GetNumChildren(ReconstructType(type),
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->GetNumChildren(ReconstructType(type),
                                              omit_empty_base_classes, exe_ctx);
+  return {};
 }
 
 uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
@@ -2454,7 +2519,9 @@ uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
             "Using SwiftASTContext::GetNumFields fallback for type %s",
             AsMangledName(type));
 
-  return m_swift_ast_context->GetNumFields(ReconstructType(type), exe_ctx);
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->GetNumFields(ReconstructType(type), exe_ctx);
+  return {};
 }
 
 CompilerType TypeSystemSwiftTypeRef::GetFieldAtIndex(
@@ -2462,20 +2529,22 @@ CompilerType TypeSystemSwiftTypeRef::GetFieldAtIndex(
     uint64_t *bit_offset_ptr, uint32_t *bitfield_bit_size_ptr,
     bool *is_bitfield_ptr) {
   LLDB_SCOPED_TIMER();
-  return m_swift_ast_context->GetFieldAtIndex(
-      ReconstructType(type), idx, name, bit_offset_ptr, bitfield_bit_size_ptr,
-      is_bitfield_ptr);
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->GetFieldAtIndex(
+        ReconstructType(type), idx, name, bit_offset_ptr, bitfield_bit_size_ptr,
+        is_bitfield_ptr);
+  return {};
 }
 
 static swift::Demangle::NodePointer
 GetClangTypeTypeNode(TypeSystemSwiftTypeRef &ts,
                      swift::Demangle::Demangler &dem, CompilerType clang_type,
-                     SwiftASTContext *module_holder) {
+                     SwiftASTContext *swift_ast_context) {
   assert(llvm::isa<TypeSystemClang>(clang_type.GetTypeSystem()) &&
          "expected a clang type");
   using namespace swift::Demangle;
   NodePointer type = dem.createNode(Node::Kind::Type);
-  type->addChild(GetClangTypeNode(clang_type, dem, module_holder), dem);
+  type->addChild(GetClangTypeNode(clang_type, dem, swift_ast_context), dem);
   return type;
 }
 
@@ -2500,12 +2569,14 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
     LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
               "Had to engage SwiftASTContext fallback for type %s.",
               AsMangledName(type));
-    return m_swift_ast_context->GetChildCompilerTypeAtIndex(
-        ReconstructType(type), exe_ctx, idx, transparent_pointers,
-        omit_empty_base_classes, ignore_array_bounds, child_name,
-        child_byte_size, child_byte_offset, child_bitfield_bit_size,
-        child_bitfield_bit_offset, child_is_base_class,
-        child_is_deref_of_parent, valobj, language_flags);
+    if (auto *swift_ast_context = GetSwiftASTContext())
+      return swift_ast_context->GetChildCompilerTypeAtIndex(
+          ReconstructType(type), exe_ctx, idx, transparent_pointers,
+          omit_empty_base_classes, ignore_array_bounds, child_name,
+          child_byte_size, child_byte_offset, child_bitfield_bit_size,
+          child_bitfield_bit_offset, child_is_base_class,
+          child_is_deref_of_parent, valobj, language_flags);
+    return {};
   };
   FALLBACK(GetChildCompilerTypeAtIndex,
            (ReconstructType(type), exe_ctx, idx, transparent_pointers,
@@ -2517,9 +2588,10 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
   auto get_ast_num_children = [&]() {
     if (ast_num_children)
       return *ast_num_children;
-    ast_num_children = m_swift_ast_context->GetNumChildren(
-        ReconstructType(type), omit_empty_base_classes, exe_ctx);
-    return *ast_num_children;
+    if (auto *swift_ast_context = GetSwiftASTContext())
+      ast_num_children = swift_ast_context->GetNumChildren(
+          ReconstructType(type), omit_empty_base_classes, exe_ctx);
+    return ast_num_children.getValueOr(0);
   };
   auto impl = [&]() -> CompilerType {
     ExecutionContextScope *exe_scope = nullptr;
@@ -2576,7 +2648,7 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
             language_flags = 0;
             return RemangleAsType(dem,
                                   GetClangTypeTypeNode(*this, dem, raw_value,
-                                                       m_swift_ast_context));
+                                                       GetSwiftASTContext()));
           }
       // Otherwise defer to TypeSystemClang.
       //
@@ -2604,7 +2676,7 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
         std::string prefix;
         swift::Demangle::Demangler dem;
         swift::Demangle::NodePointer node = GetClangTypeTypeNode(
-            *this, dem, clang_child_type, m_swift_ast_context);
+            *this, dem, clang_child_type, GetSwiftASTContext());
         switch (node->getChild(0)->getKind()) {
         case swift::Demangle::Node::Kind::Class:
             prefix = "ObjectiveC.";
@@ -2715,13 +2787,14 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
 #ifndef NDEBUG
         // This block is a custom VALIDATE_AND_RETURN implementation to support
         // checking the return value, plus the by-ref `child_indexes`.
-        if (!m_swift_ast_context)
+        if (!GetSwiftASTContext())
           return *index_size;
         auto ast_type = ReconstructType(type);
         if (!ast_type)
           return *index_size;
         std::vector<uint32_t> ast_child_indexes;
-        auto ast_index_size = m_swift_ast_context->GetIndexOfChildMemberWithName(
+        auto ast_index_size =
+            GetSwiftASTContext()->GetIndexOfChildMemberWithName(
                 ast_type, name, exe_ctx, omit_empty_base_classes,
                 ast_child_indexes);
         // The runtime has more info than the AST. No useful validation can be
@@ -2763,9 +2836,11 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
             "type %s",
             AsMangledName(type));
 
-  return m_swift_ast_context->GetIndexOfChildMemberWithName(
-      ReconstructType(type), name, exe_ctx, omit_empty_base_classes,
-      child_indexes);
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->GetIndexOfChildMemberWithName(
+        ReconstructType(type), name, exe_ctx, omit_empty_base_classes,
+        child_indexes);
+  return {};
 }
 
 size_t
@@ -2857,8 +2932,9 @@ CompilerType TypeSystemSwiftTypeRef::GetAsClangTypeOrNull(
       node->getNumChildren() == 2 && node->getChild(0)->hasText() &&
       node->getChild(0)->getText() == swift::MANGLING_MODULE_OBJC &&
       node->getChild(1)->hasText()) {
-    auto node_clangtype = ResolveTypeAlias(m_swift_ast_context, dem, node,
-                                           /*prefer_clang_types*/ true);
+    auto node_clangtype =
+        ResolveTypeAlias(this, GetSwiftASTContext(), dem, node,
+                         /*prefer_clang_types*/ true);
     if (node_clangtype.second)
       return node_clangtype.second;
   }
@@ -2880,7 +2956,8 @@ bool TypeSystemSwiftTypeRef::IsImportedType(opaque_compiler_type_t type,
     if (ident.empty())
       return {};
     if (original_type)
-      if (TypeSP clang_type = LookupClangType(m_swift_ast_context, ident))
+      if (TypeSP clang_type =
+              LookupClangType(this, GetSwiftASTContext(), ident))
         *original_type = clang_type->GetForwardCompilerType();
     return true;
   };
@@ -2981,7 +3058,9 @@ TypeSystemSwiftTypeRef::GetInstanceType(opaque_compiler_type_t type) {
       // type alias isn't possible, or the user might have defined the
       // type alias in the REPL. In these cases, fallback to asking the AST
       // for the canonical type.
-      return m_swift_ast_context->GetInstanceType(ReconstructType(type));
+      if (auto *swift_ast_context = GetSwiftASTContext())
+        return swift_ast_context->GetInstanceType(ReconstructType(type));
+      return {};
     }
 
     if (node->getKind() == Node::Kind::Metatype) {
@@ -2998,7 +3077,9 @@ TypeSystemSwiftTypeRef::GetInstanceType(opaque_compiler_type_t type) {
 
 TypeSystemSwift::TypeAllocationStrategy
 TypeSystemSwiftTypeRef::GetAllocationStrategy(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetAllocationStrategy(ReconstructType(type));
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->GetAllocationStrategy(ReconstructType(type));
+  return {};
 }
 
 CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
@@ -3038,7 +3119,7 @@ CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
 #ifndef NDEBUG
   {
     auto result = impl();
-    if (!m_swift_ast_context)
+    if (!GetSwiftASTContext())
       return result;
     std::vector<TupleElement> ast_elements;
     std::transform(elements.begin(), elements.end(),
@@ -3047,10 +3128,10 @@ CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
                                          ReconstructType(element.element_type));
                    });
     bool equivalent =
-        Equivalent(result, m_swift_ast_context->CreateTupleType(ast_elements));
+        Equivalent(result, GetSwiftASTContext()->CreateTupleType(ast_elements));
     if (!equivalent) {
       result.dump();
-      auto a = m_swift_ast_context->CreateTupleType(elements);
+      auto a = GetSwiftASTContext()->CreateTupleType(elements);
       llvm::dbgs() << "AST type: " << a.GetMangledTypeName() << "\n";
       llvm::dbgs() << "failing tuple type\n";
     }
@@ -3079,17 +3160,19 @@ void TypeSystemSwiftTypeRef::DumpTypeDescription(
     opaque_compiler_type_t type, bool print_help_if_available,
     bool print_extensions_if_available, lldb::DescriptionLevel level) {
   LLDB_SCOPED_TIMER();
-  return m_swift_ast_context->DumpTypeDescription(
-      ReconstructType(type), print_help_if_available, print_help_if_available,
-      level);
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->DumpTypeDescription(
+        ReconstructType(type), print_help_if_available, print_help_if_available,
+        level);
 }
 void TypeSystemSwiftTypeRef::DumpTypeDescription(
     opaque_compiler_type_t type, Stream *s, bool print_help_if_available,
     bool print_extensions_if_available, lldb::DescriptionLevel level) {
   LLDB_SCOPED_TIMER();
-  return m_swift_ast_context->DumpTypeDescription(
-      ReconstructType(type), s, print_help_if_available,
-      print_extensions_if_available, level);
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->DumpTypeDescription(
+        ReconstructType(type), s, print_help_if_available,
+        print_extensions_if_available, level);
 }
 
 // Dumping types
@@ -3182,7 +3265,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     case Node::Kind::Structure: {
       // In some instances, a swift `structure` wraps an objc enum. The enum
       // case needs to be handled, but structs are no-ops.
-      auto resolved = ResolveTypeAlias(m_swift_ast_context, dem, node, true);
+      auto resolved = ResolveTypeAlias(this, GetSwiftASTContext(), dem, node, true);
       auto clang_type = std::get<CompilerType>(resolved);
       if (!clang_type)
         return false;
@@ -3214,9 +3297,11 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
       // This can happen in two cases:
       // 1. MultiPayloadEnums not currently supported by Swift reflection
       // 2. Some clang imported enums
-      return m_swift_ast_context->DumpTypeValue(
-          ReconstructType(type), s, format, data, data_offset, data_byte_size,
-          bitfield_bit_size, bitfield_bit_offset, exe_scope, is_base_class);
+      if (auto *swift_ast_context = GetSwiftASTContext())
+        return swift_ast_context->DumpTypeValue(
+            ReconstructType(type), s, format, data, data_offset, data_byte_size,
+            bitfield_bit_size, bitfield_bit_offset, exe_scope, is_base_class);
+      return {};
     }
     case Node::Kind::TypeAlias:
     case Node::Kind::BoundGenericTypeAlias: {
@@ -3224,9 +3309,11 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
       // SwiftASTContext couldn't resolve. This happens for ObjC
       // typedefs such as CFString in the REPL. More investigation is
       // needed.
-      return m_swift_ast_context->DumpTypeValue(
-          ReconstructType(type), s, format, data, data_offset, data_byte_size,
-          bitfield_bit_size, bitfield_bit_offset, exe_scope, is_base_class);
+      if (auto *swift_ast_context = GetSwiftASTContext())
+        return swift_ast_context->DumpTypeValue(
+            ReconstructType(type), s, format, data, data_offset, data_byte_size,
+            bitfield_bit_size, bitfield_bit_offset, exe_scope, is_base_class);
+      return {};
     }
     default:
       assert(false && "Unhandled node kind");
@@ -3259,13 +3346,15 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
 void TypeSystemSwiftTypeRef::DumpTypeDescription(opaque_compiler_type_t type,
                                                  lldb::DescriptionLevel level) {
   LLDB_SCOPED_TIMER();
-  return m_swift_ast_context->DumpTypeDescription(ReconstructType(type), level);
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->DumpTypeDescription(ReconstructType(type), level);
 }
 void TypeSystemSwiftTypeRef::DumpTypeDescription(opaque_compiler_type_t type,
                                                  Stream *s,
                                                  lldb::DescriptionLevel level) {
   LLDB_SCOPED_TIMER();
-  return m_swift_ast_context->DumpTypeDescription(ReconstructType(type), s,
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->DumpTypeDescription(ReconstructType(type), s,
                                                   level);
 }
 void TypeSystemSwiftTypeRef::DumpSummary(opaque_compiler_type_t type,
@@ -3274,7 +3363,8 @@ void TypeSystemSwiftTypeRef::DumpSummary(opaque_compiler_type_t type,
                                          lldb::offset_t data_offset,
                                          size_t data_byte_size) {
   LLDB_SCOPED_TIMER();
-  return m_swift_ast_context->DumpSummary(ReconstructType(type), exe_ctx, s,
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->DumpSummary(ReconstructType(type), exe_ctx, s,
                                           data, data_offset, data_byte_size);
 }
 bool TypeSystemSwiftTypeRef::IsPointerOrReferenceType(
@@ -3319,7 +3409,8 @@ TypeSystemSwiftTypeRef::GetTypeBitAlign(opaque_compiler_type_t type,
     // If this is an expression context, perhaps the type was
     // defined in the expression. In that case we don't have debug
     // info for it, so defer to SwiftASTContext.
-    if (llvm::isa<SwiftASTContextForExpressions>(m_swift_ast_context))
+    if (llvm::isa_and_nonnull<SwiftASTContextForExpressions>(
+            GetSwiftASTContext()))
       return ReconstructType({this, type}).GetTypeBitAlign(exe_scope);
   }
 
@@ -3388,13 +3479,13 @@ TypeSystemSwiftTypeRef::GetTypedefedType(opaque_compiler_type_t type) {
     if (!node || (node->getKind() != Node::Kind::TypeAlias &&
                   node->getKind() != Node::Kind::BoundGenericTypeAlias))
       return {};
-    auto pair = ResolveTypeAlias(m_swift_ast_context, dem, node);
+    auto pair = ResolveTypeAlias(this, GetSwiftASTContext(), dem, node);
     NodePointer type_node = dem.createNode(Node::Kind::Type);
     if (NodePointer resolved = std::get<swift::Demangle::NodePointer>(pair)) {
       type_node->addChild(resolved, dem);
     } else {
       NodePointer clang_node = GetClangTypeNode(std::get<CompilerType>(pair),
-                                                dem, m_swift_ast_context);
+                                                dem, GetSwiftASTContext());
       type_node->addChild(clang_node, dem);
     }
     return RemangleAsType(dem, type_node);
@@ -3405,16 +3496,19 @@ TypeSystemSwiftTypeRef::GetTypedefedType(opaque_compiler_type_t type) {
 
 CompilerType
 TypeSystemSwiftTypeRef::GetFullyUnqualifiedType(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetFullyUnqualifiedType(ReconstructType(type));
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->GetFullyUnqualifiedType(ReconstructType(type));
+  return {};
 }
 CompilerType
 TypeSystemSwiftTypeRef::GetNonReferenceType(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetNonReferenceType(ReconstructType(type));
+  if (auto *swift_ast_context = GetSwiftASTContext())
+  return swift_ast_context->GetNonReferenceType(ReconstructType(type));
+  return {};
 }
 CompilerType
 TypeSystemSwiftTypeRef::GetLValueReferenceType(opaque_compiler_type_t type) {
-    auto impl = []() { return CompilerType(); };
-
+  auto impl = []() { return CompilerType(); };
   VALIDATE_AND_RETURN(impl, GetLValueReferenceType, type,
                       (ReconstructType(type)), (ReconstructType(type)));
 }
@@ -3427,12 +3521,16 @@ TypeSystemSwiftTypeRef::GetRValueReferenceType(opaque_compiler_type_t type) {
 }
 uint32_t
 TypeSystemSwiftTypeRef::GetNumDirectBaseClasses(opaque_compiler_type_t type) {
-  return m_swift_ast_context->GetNumDirectBaseClasses(ReconstructType(type));
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->GetNumDirectBaseClasses(ReconstructType(type));
+  return {};
 }
 CompilerType TypeSystemSwiftTypeRef::GetDirectBaseClassAtIndex(
     opaque_compiler_type_t type, size_t idx, uint32_t *bit_offset_ptr) {
-  return m_swift_ast_context->GetDirectBaseClassAtIndex(ReconstructType(type),
+  if (auto *swift_ast_context = GetSwiftASTContext())
+    return swift_ast_context->GetDirectBaseClassAtIndex(ReconstructType(type),
                                                         idx, bit_offset_ptr);
+  return {};
 }
 bool TypeSystemSwiftTypeRef::IsReferenceType(opaque_compiler_type_t type,
                                              CompilerType *pointee_type,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -33,6 +33,7 @@ class Demangler;
 namespace lldb_private {
 class ClangExternalASTSourceCallbacks;
 class SwiftASTContext;
+class SwiftASTContextForExpressions;
 
 /// A Swift TypeSystem that does not own a swift::ASTContext.
 class TypeSystemSwiftTypeRef : public TypeSystemSwift {
@@ -48,11 +49,17 @@ public:
   static bool classof(const TypeSystem *ts) { return ts->isA(&ID); }
   /// \}
 
-  TypeSystemSwiftTypeRef(SwiftASTContext *swift_ast_context);
-  SwiftASTContext *GetSwiftASTContext() override { return m_swift_ast_context; }
+#ifndef NDEBUG
+  /// Provided only for unit tests.
+  TypeSystemSwiftTypeRef() {}
+#endif
+  TypeSystemSwiftTypeRef(Module &module);
+  TypeSystemSwiftTypeRef(SwiftASTContextForExpressions &swift_ast_context);
+  SwiftASTContext *GetSwiftASTContext() const override;
   TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() override { return *this; }
+  void SetTriple(const llvm::Triple triple) override;
+  void ClearModuleDependentCaches() override;
 
-  Module *GetModule() const override;
   swift::CanType GetCanonicalSwiftType(CompilerType compiler_type);
   swift::Type GetSwiftType(CompilerType compiler_type);
   CompilerType ReconstructType(CompilerType type);
@@ -88,6 +95,8 @@ public:
       return true;
     return false;
   }
+
+  Module *GetModule() const { return m_module; }
 
   // Tests
 #ifndef NDEBUG
@@ -274,10 +283,9 @@ public:
                     swift::Demangle::NodePointer node);
 
   /// Return the canonicalized Demangle tree for a Swift mangled type name.
-  static swift::Demangle::NodePointer
-  GetCanonicalDemangleTree(SwiftASTContext *module_holder,
-                           swift::Demangle::Demangler &dem,
-                           llvm::StringRef mangled_name);
+  static swift::Demangle::NodePointer GetCanonicalDemangleTree(
+      TypeSystemSwiftTypeRef *module_holder, SwiftASTContext *target_holder,
+      swift::Demangle::Demangler &dem, llvm::StringRef mangled_name);
 
   /// Return the base name of the topmost nominal type.
   static llvm::StringRef GetBaseName(swift::Demangle::NodePointer node);
@@ -342,7 +350,8 @@ private:
 #endif
 
   /// The sibling SwiftASTContext.
-  SwiftASTContext *m_swift_ast_context = nullptr;
+  mutable lldb::TypeSystemSP m_swift_ast_context_sp;
+  mutable SwiftASTContext *m_swift_ast_context = nullptr;
 
   /// The APINotesManager responsible for each Clang module.
   llvm::DenseMap<clang::Module *,

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1656,7 +1656,7 @@ void Target::ModulesDidLoad(ModuleList &module_list) {
     auto notify_callback = [&](TypeSystem *type_system) {
 #ifdef LLDB_ENABLE_SWIFT
       auto *swift_ast_ctx =
-          llvm::dyn_cast_or_null<SwiftASTContext>(type_system);
+          llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(type_system);
       if (!swift_ast_ctx)
         return true;
       swift_ast_ctx->ModulesDidLoad(module_list);
@@ -2550,7 +2550,7 @@ llvm::Optional<SwiftASTContextReader> Target::GetScratchSwiftASTContext(
 
     bool fallback = true;
     auto typesystem_sp = SwiftASTContext::CreateInstance(
-        lldb::eLanguageTypeSwift, *lldb_module, this, fallback);
+        lldb::eLanguageTypeSwift, *lldb_module, nullptr, this, fallback);
     auto *swift_ast_ctx =
         llvm::cast<SwiftASTContextForExpressions>(typesystem_sp.get());
     m_scratch_typesystem_for_module.insert({idx, typesystem_sp});

--- a/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
+++ b/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
@@ -28,7 +28,7 @@ class TestSwiftRewriteClangPaths(TestBase):
         logfile = open(log, "r")
         found = 0
         for line in logfile:
-            if line.startswith(' SwiftASTContext("a.out")::RemapClangImporterOptions() -- remapped'):
+            if line.startswith(' SwiftASTContextForModule("a.out")::RemapClangImporterOptions() -- remapped'):
                 if '/LocalSDK/' in line:
                     found += 1
         self.assertEqual(found, 1)

--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -65,6 +65,10 @@ struct SwiftASTContextTester : public SwiftASTContext {
     SwiftASTContextTester() : SwiftASTContext() {}
   #endif
 
+  TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() override {
+    return m_typeref_typesystem;
+  }
+
   static std::string GetResourceDir(llvm::StringRef platform_sdk_path,
                                     std::string swift_dir,
                                     std::string swift_stdlib_os_dir,
@@ -79,6 +83,7 @@ struct SwiftASTContextTester : public SwiftASTContext {
                                          const llvm::Triple &host) {
     return SwiftASTContext::GetSwiftStdlibOSDir(target, host);
   }
+  TypeSystemSwiftTypeRef m_typeref_typesystem;
 };
 
 TEST_F(TestSwiftASTContext, ResourceDir) {
@@ -195,7 +200,7 @@ TEST_F(TestSwiftASTContext, IsNonTriviallyManagedReferenceType) {
 #ifndef NDEBUG
   // The mock constructor is only available in asserts mode.
   SwiftASTContext::NonTriviallyManagedReferenceStrategy strategy;
-  SwiftASTContext context;
+  SwiftASTContextTester context;
   CompilerType t(&context, nullptr);
   EXPECT_FALSE(SwiftASTContext::IsNonTriviallyManagedReferenceType(t, strategy,
                                                                    nullptr));

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -25,7 +25,7 @@ using namespace llvm;
 struct TestTypeSystemSwiftTypeRef : public testing::Test {
   TypeSystemSwiftTypeRef m_swift_ts;
 
-  TestTypeSystemSwiftTypeRef() : m_swift_ts(nullptr) {}
+  TestTypeSystemSwiftTypeRef() : m_swift_ts() {}
   CompilerType GetCompilerType(std::string mangled_name) {
     ConstString internalized(mangled_name);
     return m_swift_ts.GetTypeFromMangledTypename(internalized);


### PR DESCRIPTION
…ef (NFC)

This patch introduces a new subclass SwiftASTContextForModules, which
is now owned by TypeSystemSwiftTypeRef and initialized lazily. The
TypeSystemSwiftTypeRef that corresponds to the scratch context is
still owned by SwiftASTContextForExpressions.

rdar://81717792
(cherry picked from commit 83676ae2fcdd222db030f0b7bea16f90c5e84fb4)