### PR TITLE
[lldb] Add basic healthcheck command

### DIFF
--- a/lldb/include/lldb/Utility/Logging.h
+++ b/lldb/include/lldb/Utility/Logging.h
@@ -11,7 +11,9 @@
 
 #include <cstdint>
 
+#ifdef LLDB_ENABLE_SWIFT
 #include "llvm/ADT/StringRef.h"
+#endif
 
 // Log Bits specific to logging in lldb
 #define LIBLLDB_LOG_PROCESS (1u << 1)

--- a/lldb/include/lldb/Utility/Logging.h
+++ b/lldb/include/lldb/Utility/Logging.h
@@ -11,6 +11,8 @@
 
 #include <cstdint>
 
+#include "llvm/ADT/StringRef.h"
+
 // Log Bits specific to logging in lldb
 #define LIBLLDB_LOG_PROCESS (1u << 1)
 #define LIBLLDB_LOG_THREAD (1u << 2)
@@ -64,6 +66,7 @@ Log *GetLogIfAnyCategoriesSet(uint32_t mask);
 
 #ifdef LLDB_ENABLE_SWIFT
 Log *GetSwiftHealthLog();
+llvm::StringRef GetSwiftHealthLogData();
 #endif
 
 void InitializeLldbChannel();

--- a/lldb/source/Commands/CMakeLists.txt
+++ b/lldb/source/Commands/CMakeLists.txt
@@ -12,6 +12,7 @@ add_lldb_library(lldbCommands
   CommandObjectExpression.cpp
   CommandObjectFrame.cpp
   CommandObjectGUI.cpp
+  CommandObjectHealthcheck.cpp
   CommandObjectHelp.cpp
   CommandObjectLanguage.cpp
   CommandObjectLog.cpp

--- a/lldb/source/Commands/CommandObjectHealthcheck.cpp
+++ b/lldb/source/Commands/CommandObjectHealthcheck.cpp
@@ -25,6 +25,7 @@ CommandObjectHealthcheck::CommandObjectHealthcheck(
 
 bool CommandObjectHealthcheck::DoExecute(Args &args,
                                          CommandReturnObject &result) {
+#ifdef LLDB_ENABLE_SWIFT
   std::error_code err;
   llvm::SmallString<128> temp_path;
   int temp_fd = -1;
@@ -49,5 +50,6 @@ bool CommandObjectHealthcheck::DoExecute(Args &args,
 
   result.AppendMessageWithFormat("Health check written to %s\n",
                                  temp_path.c_str());
+#endif
   return true;
 }

--- a/lldb/source/Commands/CommandObjectHealthcheck.cpp
+++ b/lldb/source/Commands/CommandObjectHealthcheck.cpp
@@ -1,0 +1,53 @@
+//===-- CommandObjectHealthcheck.cpp --------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CommandObjectHealthcheck.h"
+
+#include "lldb/Host/HostInfo.h"
+#include "lldb/Interpreter/CommandReturnObject.h"
+#include "lldb/Utility/Log.h"
+#include "lldb/Host/FileSystem.h"
+#include "lldb/lldb-private.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+CommandObjectHealthcheck::CommandObjectHealthcheck(
+    CommandInterpreter &interpreter)
+    : CommandObjectParsed(interpreter, "healthcheck",
+                          "Show the LLDB debugger health check diagnostics.",
+                          "healthcheck") {}
+
+bool CommandObjectHealthcheck::DoExecute(Args &args,
+                                         CommandReturnObject &result) {
+  std::error_code err;
+  llvm::SmallString<128> temp_path;
+  int temp_fd = -1;
+  if (FileSpec temp_file_spec = HostInfo::GetProcessTempDir()) {
+    temp_file_spec.AppendPathComponent("lldb-healthcheck-%%%%%%.log");
+    err = llvm::sys::fs::createUniqueFile(temp_file_spec.GetPath(), temp_fd,
+                                          temp_path);
+  } else {
+    err = llvm::sys::fs::createTemporaryFile("lldb-healthcheck", "log", temp_fd,
+                                             temp_path);
+  }
+
+  if (temp_fd == -1) {
+    result.AppendErrorWithFormat("could not write to temp file %s",
+                                 err.message().c_str());
+    return false;
+  }
+
+  llvm::raw_fd_ostream temp_stream(temp_fd, true, true);
+  llvm::StringRef data = GetSwiftHealthLogData();
+  temp_stream << data;
+
+  result.AppendMessageWithFormat("Health check written to %s\n",
+                                 temp_path.c_str());
+  return true;
+}

--- a/lldb/source/Commands/CommandObjectHealthcheck.h
+++ b/lldb/source/Commands/CommandObjectHealthcheck.h
@@ -1,0 +1,28 @@
+//===-- CommandObjectHealthcheck.h ------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_COMMANDS_COMMANDOBJECTHEALTHCHECK_H
+#define LLDB_SOURCE_COMMANDS_COMMANDOBJECTHEALTHCHECK_H
+
+#include "lldb/Interpreter/CommandObject.h"
+
+namespace lldb_private {
+
+class CommandObjectHealthcheck : public CommandObjectParsed {
+public:
+  CommandObjectHealthcheck(CommandInterpreter &interpreter);
+
+  ~CommandObjectHealthcheck() override = default;
+
+protected:
+  bool DoExecute(Args &args, CommandReturnObject &result) override;
+};
+
+} // namespace lldb_private
+
+#endif // LLDB_SOURCE_COMMANDS_COMMANDOBJECTHEALTHCHECK_H

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -20,6 +20,7 @@
 #include "Commands/CommandObjectFrame.h"
 #include "Commands/CommandObjectGUI.h"
 #include "Commands/CommandObjectHelp.h"
+#include "Commands/CommandObjectHealthcheck.h"
 #include "Commands/CommandObjectLanguage.h"
 #include "Commands/CommandObjectLog.h"
 #include "Commands/CommandObjectMemory.h"
@@ -511,6 +512,7 @@ void CommandInterpreter::LoadCommandDictionary() {
   REGISTER_COMMAND_OBJECT("frame", CommandObjectMultiwordFrame);
   REGISTER_COMMAND_OBJECT("gui", CommandObjectGUI);
   REGISTER_COMMAND_OBJECT("help", CommandObjectHelp);
+  REGISTER_COMMAND_OBJECT("healthcheck", CommandObjectHealthcheck);
   REGISTER_COMMAND_OBJECT("log", CommandObjectLog);
   REGISTER_COMMAND_OBJECT("memory", CommandObjectMemory);
   REGISTER_COMMAND_OBJECT("platform", CommandObjectPlatform);

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -512,7 +512,9 @@ void CommandInterpreter::LoadCommandDictionary() {
   REGISTER_COMMAND_OBJECT("frame", CommandObjectMultiwordFrame);
   REGISTER_COMMAND_OBJECT("gui", CommandObjectGUI);
   REGISTER_COMMAND_OBJECT("help", CommandObjectHelp);
+#ifdef LLDB_ENABLE_SWIFT
   REGISTER_COMMAND_OBJECT("healthcheck", CommandObjectHealthcheck);
+#endif
   REGISTER_COMMAND_OBJECT("log", CommandObjectLog);
   REGISTER_COMMAND_OBJECT("memory", CommandObjectMemory);
   REGISTER_COMMAND_OBJECT("platform", CommandObjectPlatform);

--- a/lldb/source/Utility/Logging.cpp
+++ b/lldb/source/Utility/Logging.cpp
@@ -84,7 +84,13 @@ Log *lldb_private::GetLogIfAnyCategoriesSet(uint32_t mask) {
 }
 
 #ifdef LLDB_ENABLE_SWIFT
+
 Log *lldb_private::GetSwiftHealthLog() {
   return g_swift_log_channel.GetLogIfAny(LIBLLDB_SWIFT_LOG_HEALTH);
 }
+
+llvm::StringRef lldb_private::GetSwiftHealthLogData() {
+  return g_swift_log_buffer;
+}
+
 #endif

--- a/lldb/source/Utility/Logging.cpp
+++ b/lldb/source/Utility/Logging.cpp
@@ -59,12 +59,19 @@ static constexpr Log::Category g_swift_categories[] = {
 
 static Log::Channel g_swift_log_channel(g_swift_categories, LIBLLDB_SWIFT_LOG_HEALTH);
 
+static std::string g_swift_log_buffer;
+
 #endif
 
 void lldb_private::InitializeLldbChannel() {
   Log::Register("lldb", g_log_channel);
 #ifdef LLDB_ENABLE_SWIFT
   Log::Register("swift", g_swift_log_channel);
+
+  llvm::raw_null_ostream error_stream;
+  Log::EnableLogChannel(
+      std::make_shared<llvm::raw_string_ostream>(g_swift_log_buffer),
+      LLDB_LOG_OPTION_THREADSAFE, "swift", {"health"}, error_stream);
 #endif
 }
 


### PR DESCRIPTION
This adds a `healthcheck` command. This initial implementation writes a temp file containing the `swift health` logs. Those logs are captured in a memory buffer that gets enabled during logging initialization.

rdar://82981924