### PR TITLE
[lldb] Remove logging from Platform::~Platform

### DIFF
--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -74,11 +74,9 @@ public:
   /// Default Constructor
   Platform(bool is_host_platform);
 
-  /// Destructor.
-  ///
   /// The destructor is virtual since this class is designed to be inherited
   /// from by the plug-in instance.
-  ~Platform() override;
+  ~Platform() override = default;
 
   static void Initialize();
 

--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -76,7 +76,7 @@ public:
 
   /// The destructor is virtual since this class is designed to be inherited
   /// from by the plug-in instance.
-  ~Platform() override = default;
+  ~Platform() override;
 
   static void Initialize();
 

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -395,6 +395,8 @@ Platform::Platform(bool is_host)
   LLDB_LOGF(log, "%p Platform::Platform()", static_cast<void *>(this));
 }
 
+Platform::~Platform() = default;
+
 void Platform::GetStatus(Stream &strm) {
   std::string s;
   strm.Printf("  Platform: %s\n", GetPluginName().GetCString());

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -395,15 +395,6 @@ Platform::Platform(bool is_host)
   LLDB_LOGF(log, "%p Platform::Platform()", static_cast<void *>(this));
 }
 
-/// Destructor.
-///
-/// The destructor is virtual since this class is designed to be
-/// inherited from by the plug-in instance.
-Platform::~Platform() {
-  Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_OBJECT));
-  LLDB_LOGF(log, "%p Platform::~Platform()", static_cast<void *>(this));
-}
-
 void Platform::GetStatus(Stream &strm) {
   std::string s;
   strm.Printf("  Platform: %s\n", GetPluginName().GetCString());


### PR DESCRIPTION
Platform instances are stored in a function-local static list. However, the
logging code involves locking a function-local static mutex. This only works on
some implementations where the Log mutex is by accident destroyed *after* the
Platform list is destroyed.

This fixes randomly failing tests due to `recursive_mutex lock failed: Invalid
argument`.

Reviewed By: kastiglione

Differential Revision: https://reviews.llvm.org/D111816

(cherry picked from commit e632e900ac1092f581b42fb93662613db9977b5a)