### PR TITLE
[lldb] Add call to registerClangImporterRequestFunctions in SwiftASTContext

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3538,6 +3538,7 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
   registerIDERequestFunctions(m_ast_context_ap->evaluator);
   registerParseRequestFunctions(m_ast_context_ap->evaluator);
   registerTypeCheckerRequestFunctions(m_ast_context_ap->evaluator);
+  registerClangImporterRequestFunctions(m_ast_context_ap->evaluator);
   registerSILGenRequestFunctions(m_ast_context_ap->evaluator);
   registerSILOptimizerRequestFunctions(m_ast_context_ap->evaluator);
   registerTBDGenRequestFunctions(m_ast_context_ap->evaluator);


### PR DESCRIPTION
Add a call to `registerClangImporterRequestFunctions`, whose docs say:

> Clients that form an ASTContext and import any Clang APIs should call this function after forming the ASTContext.
