### PR TITLE
Use Module's FileSpec for limiting binaries to set dyld breakpoint in

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.cpp
@@ -350,7 +350,7 @@ bool DynamicLoaderMacOS::SetNotificationBreakpoint() {
       LazyBool skip_prologue = eLazyBoolNo;
       FileSpecList *source_files = nullptr;
       FileSpecList dyld_filelist;
-      dyld_filelist.Append(dyld_sp->GetObjectFile()->GetFileSpec());
+      dyld_filelist.Append(dyld_sp->GetFileSpec());
 
       Breakpoint *breakpoint =
           m_process->GetTarget()


### PR DESCRIPTION
Use Module's FileSpec for limiting binaries to set dyld breakpoint in

When DynamicLoaderMacOS::SetNotificationBreakpoint sets the breakpoint
for new binaries being loaded/unloaded, it limits the scope of that
breakpoint to just dyld, so we don't re-evaluate the breakpoint for
every new binary loaded.  I wrote this to get the module's ObjectFile
FileSpec in an earlier change, but this is not correct.  If lldb
is debugging a remote system, and it had to read dyld out of memory
from the remote system, it will have no FileSpec on the lldb debugger
host.  We need to grab the Module's FileSpec, which in this case is
actually falling back to the PlatformFileSpec, the binary path on the
target system.

rdar://84199646
(cherry picked from commit 35d710148b98e2ec52056271e7f9103620593b7a)