### PR TITLE
[lldb] Rename 'healthcheck' to 'swift-healthcheck'

### DIFF
--- a/lldb/source/Commands/CommandObjectHealthcheck.cpp
+++ b/lldb/source/Commands/CommandObjectHealthcheck.cpp
@@ -19,9 +19,9 @@ using namespace lldb_private;
 
 CommandObjectHealthcheck::CommandObjectHealthcheck(
     CommandInterpreter &interpreter)
-    : CommandObjectParsed(interpreter, "healthcheck",
+    : CommandObjectParsed(interpreter, "swift-healthcheck",
                           "Show the LLDB debugger health check diagnostics.",
-                          "healthcheck") {}
+                          "swift-healthcheck") {}
 
 bool CommandObjectHealthcheck::DoExecute(Args &args,
                                          CommandReturnObject &result) {

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -513,7 +513,7 @@ void CommandInterpreter::LoadCommandDictionary() {
   REGISTER_COMMAND_OBJECT("gui", CommandObjectGUI);
   REGISTER_COMMAND_OBJECT("help", CommandObjectHelp);
 #ifdef LLDB_ENABLE_SWIFT
-  REGISTER_COMMAND_OBJECT("healthcheck", CommandObjectHealthcheck);
+  REGISTER_COMMAND_OBJECT("swift-healthcheck", CommandObjectHealthcheck);
 #endif
   REGISTER_COMMAND_OBJECT("log", CommandObjectLog);
   REGISTER_COMMAND_OBJECT("memory", CommandObjectMemory);


### PR DESCRIPTION
TestAbbreviation is failing as it expects 'h' to be a shortcut for 'help' which
seems also what users expect. Rename healthcheck to 'swift-healthcheck' for now
to fix this.