### PR TITLE
[lldb] Harden TestCompletion against new settings in 'target.process'

### DIFF
--- a/lldb/test/API/functionalities/completion/TestCompletion.py
+++ b/lldb/test/API/functionalities/completion/TestCompletion.py
@@ -397,7 +397,7 @@ class CommandLineCompletionTestCase(TestBase):
     def test_settings_set_target_process_dot(self):
         """Test that 'settings set target.process.t' completes to 'settings set target.process.thread.'."""
         self.complete_from_to(
-            'settings set target.process.t',
+            'settings set target.process.thr',
             'settings set target.process.thread.')
 
     def test_settings_set_target_process_thread_dot(self):


### PR DESCRIPTION
This test starts failing when people add a setting starting with
`target.process.t` which of course can easily happen. Make it a bit more
resistant by only requiring that `target.process.thr` has a unique completion.

(cherry picked from commit ff4c98c05559e498300bd3ad55272ac2a8d10dbc)