### PR TITLE
[lldb] Duplicate SwiftASTContext::CreateInstance errors to swift health log

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1663,8 +1663,7 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
   LOG_PRINTF(LIBLLDB_LOG_TYPES, "(Module)");
 
   auto logError = [&](const char *message) {
-    LOG_PRINTF(LIBLLDB_LOG_TYPES, "Failed to create module context - %s",
-               message);
+    HEALTH_LOG_PRINTF("Failed to create module context - %s", message);
   };
 
   ArchSpec arch = module.GetArchitecture();


### PR DESCRIPTION
This `logError` lambda logs errors in `SwiftASTContext::CreateInstance`. Of most interest, are diagnostic errors, as called here:

https://github.com/apple/llvm-project/blob/434d67e83d6c4e09cab9737a53487d2bd14788fd/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp#L1880-L1883 

Changing the macro to `HEALTH_LOG_PRINTF` ensures these important log messages are _also_ sent to the `swift log` stream.