### PR TITLE
Move the ownership of DWARFASTParserSwift from SwiftASTContext to Typ…

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
@@ -19,11 +19,11 @@
 class DWARFDebugInfoEntry;
 class DWARFDIECollection;
 
-namespace lldb_private { class SwiftASTContext; }
+namespace lldb_private { class TypeSystemSwiftTypeRef; }
 
 class DWARFASTParserSwift : public DWARFASTParser {
 public:
-  DWARFASTParserSwift(lldb_private::SwiftASTContext &ast);
+  DWARFASTParserSwift(lldb_private::TypeSystemSwiftTypeRef &swift_typesystem);
 
   virtual ~DWARFASTParserSwift();
 
@@ -56,7 +56,7 @@ public:
       lldb_private::CompilerDeclContext decl_context) override {}
 
 protected:
-  lldb_private::SwiftASTContext &m_ast;
+  lldb_private::TypeSystemSwiftTypeRef &m_swift_typesystem;
 };
 
 #endif // SymbolFileDWARF_DWARFASTParserSwift_h_

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -128,7 +128,6 @@
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
 #include "Plugins/Platform/MacOSX/PlatformDarwin.h"
 #include "Plugins/SymbolFile/DWARF/DWARFASTParserClang.h"
-#include "Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 
 #define VALID_OR_RETURN(value)                                                 \
@@ -4491,20 +4490,6 @@ CompilerType SwiftASTContext::GetAnyObjectType() {
   return ToCompilerType({ast->getAnyObjectType()});
 }
 
-CompilerType SwiftASTContext::GetVoidFunctionType() {
-  VALID_OR_RETURN(CompilerType());
-
-  if (!m_void_function_type) {
-    swift::ASTContext *ast = GetASTContext();
-    swift::Type empty_tuple_type(swift::TupleType::getEmpty(*ast));
-    // FIXME: Verify ExtInfo state is correct, not working by accident.
-    swift::FunctionType::ExtInfo info;
-    m_void_function_type =
-        ToCompilerType({swift::FunctionType::get({}, empty_tuple_type, info)});
-  }
-  return m_void_function_type;
-}
-
 static CompilerType ValueDeclToType(swift::ValueDecl *decl,
                                     swift::ASTContext *ast) {
   if (decl) {
@@ -8312,23 +8297,8 @@ void SwiftASTContext::DumpTypeDescription(opaque_compiler_type_t type,
     s->Printf("<could not resolve type>");
 }
 
-TypeSP SwiftASTContext::GetCachedType(ConstString mangled) {
-  TypeSP type_sp;
-  if (m_swift_type_map.Lookup(mangled.GetCString(), type_sp))
-    return type_sp;
-  else
-    return TypeSP();
-}
-
-void SwiftASTContext::SetCachedType(ConstString mangled,
-                                    const TypeSP &type_sp) {
-  m_swift_type_map.Insert(mangled.GetCString(), type_sp);
-}
-
 DWARFASTParser *SwiftASTContext::GetDWARFParser() {
-  if (!m_dwarf_ast_parser_ap)
-    m_dwarf_ast_parser_ap.reset(new DWARFASTParserSwift(*this));
-  return m_dwarf_ast_parser_ap.get();
+  return GetTypeSystemSwiftTypeRef().GetDWARFParser();
 }
 
 std::vector<lldb::DataBufferSP> &

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -18,7 +18,6 @@
 #include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "lldb/Core/SwiftForward.h"
-#include "lldb/Core/ThreadSafeDenseMap.h"
 #include "lldb/Core/ThreadSafeDenseSet.h"
 #include "lldb/Utility/Either.h"
 #include "llvm/ADT/SmallVector.h"
@@ -340,9 +339,6 @@ public:
 
   // Retrieve the Swift.AnyObject type.
   CompilerType GetAnyObjectType();
-
-  // Get a function type that returns nothing and take no parameters
-  CompilerType GetVoidFunctionType();
 
   /// Import and Swiftify a Clang type.
   /// \return Returns an invalid type if unsuccessful.
@@ -761,10 +757,6 @@ public:
 
   CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
 
-  lldb::TypeSP GetCachedType(ConstString mangled) override;
-
-  void SetCachedType(ConstString mangled, const lldb::TypeSP &type_sp) override;
-
   /// Retrieves the modules that need to be implicitly imported in a given
   /// execution scope. This includes the modules imported by both the compile
   /// unit as well as any imports from previous expression evaluations.
@@ -858,7 +850,6 @@ protected:
   llvm::once_flag m_ir_gen_module_once;
   std::unique_ptr<swift::DiagnosticConsumer> m_diagnostic_consumer_ap;
   std::unique_ptr<swift::DependencyTracker> m_dependency_tracker;
-  std::unique_ptr<DWARFASTParser> m_dwarf_ast_parser_ap;
   /// A collection of (not necessarily fatal) error messages that
   /// should be printed by Process::PrintWarningCantLoadSwift().
   std::vector<std::string> m_module_import_warnings;
@@ -910,9 +901,6 @@ protected:
 
   typedef ThreadSafeDenseSet<const char *> SwiftMangledNameSet;
   SwiftMangledNameSet m_negative_type_cache;
-
-  typedef ThreadSafeDenseMap<const char *, lldb::TypeSP> SwiftTypeMap;
-  SwiftTypeMap m_swift_type_map;
 
   /// @}
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -119,9 +119,6 @@ public:
   virtual void SetTriple(const llvm::Triple triple) = 0;
   virtual void ClearModuleDependentCaches() = 0;
 
-  virtual lldb::TypeSP GetCachedType(ConstString mangled) = 0;
-  virtual void SetCachedType(ConstString mangled,
-                             const lldb::TypeSP &type_sp) = 0;
   virtual bool IsImportedType(lldb::opaque_compiler_type_t type,
                               CompilerType *original_type) = 0;
   virtual CompilerType GetErrorType() = 0;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -24,6 +24,7 @@
 
 #include "Plugins/ExpressionParser/Clang/ClangExternalASTSourceCallbacks.h"
 #include "Plugins/ExpressionParser/Clang/ClangUtil.h"
+#include "Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 
 #include "swift/AST/ClangModuleLoader.h"
@@ -1295,6 +1296,12 @@ CompilerType TypeSystemSwift::GetInstanceType(CompilerType compiler_type) {
   return {};
 }
 
+#ifndef NDEBUG
+TypeSystemSwiftTypeRef::TypeSystemSwiftTypeRef() {}
+#endif
+
+TypeSystemSwiftTypeRef::~TypeSystemSwiftTypeRef() {}
+
 TypeSystemSwiftTypeRef::TypeSystemSwiftTypeRef(Module &module) {
   m_module = &module;
   {
@@ -1365,16 +1372,16 @@ CompilerType TypeSystemSwiftTypeRef::GetTypeFromMangledTypename(
   return {this, (opaque_compiler_type_t)mangled_typename.AsCString()};
 }
 
-lldb::TypeSP TypeSystemSwiftTypeRef::GetCachedType(ConstString mangled) {
-  if (auto *swift_ast_context = GetSwiftASTContext())
-    swift_ast_context->GetCachedType(mangled);
+TypeSP TypeSystemSwiftTypeRef::GetCachedType(ConstString mangled) {
+  TypeSP type_sp;
+  if (m_swift_type_map.Lookup(mangled.GetCString(), type_sp))
+    return type_sp;
   return {};
 }
 
 void TypeSystemSwiftTypeRef::SetCachedType(ConstString mangled,
-                                           const lldb::TypeSP &type_sp) {
-  if (auto *swift_ast_context = GetSwiftASTContext())
-    swift_ast_context->SetCachedType(mangled, type_sp);
+                                    const TypeSP &type_sp) {
+  m_swift_type_map.Insert(mangled.GetCString(), type_sp);
 }
 
 ConstString TypeSystemSwiftTypeRef::GetPluginName() {
@@ -1398,9 +1405,9 @@ void TypeSystemSwiftTypeRef::DiagnoseWarnings(Process &process,
 }
 
 DWARFASTParser *TypeSystemSwiftTypeRef::GetDWARFParser() {
-  if (auto *swift_ast_context = GetSwiftASTContext())
-    return swift_ast_context->GetDWARFParser();
-  return {};
+  if (!m_dwarf_ast_parser_up)
+    m_dwarf_ast_parser_up.reset(new DWARFASTParserSwift(*this));
+  return m_dwarf_ast_parser_up.get();
 }
 
 TypeSP TypeSystemSwiftTypeRef::LookupTypeInModule(
@@ -2284,6 +2291,27 @@ TypeSystemSwiftTypeRef::GetPointerType(opaque_compiler_type_t type) {
   };
   VALIDATE_AND_RETURN(impl, GetPointerType, type, (ReconstructType(type)),
                       (ReconstructType(type)));
+}
+
+CompilerType TypeSystemSwiftTypeRef::GetVoidFunctionType() {
+  using namespace swift::Demangle;
+  Demangler dem;
+  NodePointer type = dem.createNode(Node::Kind::Type);
+  NodePointer fnty = dem.createNode(Node::Kind::FunctionType);
+  type->addChild(fnty, dem);
+  NodePointer args = dem.createNode(Node::Kind::ArgumentTuple);
+  fnty->addChild(args, dem);
+  NodePointer args_ty = dem.createNode(Node::Kind::Type);
+  args->addChild(args_ty, dem);
+  NodePointer args_tuple = dem.createNode(Node::Kind::Tuple);
+  args_ty->addChild(args_tuple, dem);
+  NodePointer rett = dem.createNode(Node::Kind::ReturnType);
+  fnty->addChild(rett, dem);
+  NodePointer ret_ty = dem.createNode(Node::Kind::Type);
+  rett->addChild(ret_ty, dem);
+  NodePointer ret_tuple = dem.createNode(Node::Kind::Tuple);
+  ret_ty->addChild(ret_tuple, dem);
+  return RemangleAsType(dem, type);
 }
 
 // Exploring the type

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -15,6 +15,7 @@
 
 #include "Plugins/TypeSystem/Swift/TypeSystemSwift.h"
 #include "lldb/Core/SwiftForward.h"
+#include "lldb/Core/ThreadSafeDenseMap.h"
 
 #include "swift/AST/Type.h"
 
@@ -51,8 +52,9 @@ public:
 
 #ifndef NDEBUG
   /// Provided only for unit tests.
-  TypeSystemSwiftTypeRef() {}
+  TypeSystemSwiftTypeRef();
 #endif
+  ~TypeSystemSwiftTypeRef();
   TypeSystemSwiftTypeRef(Module &module);
   TypeSystemSwiftTypeRef(SwiftASTContextForExpressions &swift_ast_context);
   SwiftASTContext *GetSwiftASTContext() const override;
@@ -146,6 +148,9 @@ public:
   CompilerType GetPointeeType(lldb::opaque_compiler_type_t type) override;
   CompilerType GetPointerType(lldb::opaque_compiler_type_t type) override;
 
+  /// Get a function type that returns nothing and take no parameters.
+  CompilerType GetVoidFunctionType();
+
   // Exploring the type
   llvm::Optional<uint64_t>
   GetBitSize(lldb::opaque_compiler_type_t type,
@@ -234,8 +239,8 @@ public:
                        CompilerType *pointee_type, bool *is_rvalue) override;
 
   // Swift-specific methods.
-  lldb::TypeSP GetCachedType(ConstString mangled) override;
-  void SetCachedType(ConstString mangled, const lldb::TypeSP &type_sp) override;
+  lldb::TypeSP GetCachedType(ConstString mangled);
+  void SetCachedType(ConstString mangled, const lldb::TypeSP &type_sp);
   bool IsImportedType(lldb::opaque_compiler_type_t type,
                       CompilerType *original_type) override;
   /// Like \p IsImportedType(), but even returns Clang types that are also Swift
@@ -352,12 +357,16 @@ private:
   /// The sibling SwiftASTContext.
   mutable lldb::TypeSystemSP m_swift_ast_context_sp;
   mutable SwiftASTContext *m_swift_ast_context = nullptr;
+  std::unique_ptr<DWARFASTParser> m_dwarf_ast_parser_up;
 
   /// The APINotesManager responsible for each Clang module.
   llvm::DenseMap<clang::Module *,
                  std::unique_ptr<clang::api_notes::APINotesManager>>
       m_apinotes_manager;
-  };
+
+  /// All lldb::Type pointers produced by DWARFASTParser Swift go here.
+  ThreadSafeDenseMap<const char *, lldb::TypeSP> m_swift_type_map;
+};
 
 } // namespace lldb_private
 #endif

--- a/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
@@ -35,5 +35,7 @@ class TestSwiftWerror(TestBase):
             self.assertFalse("-Werror" in line)
             if "-DCONFLICT" in line:
                 sanity += 1
-        # We see it twice, once in the module, once in the expression context.
-        self.assertEqual(sanity, 2)
+        # We see it twice in the expression context and once in a Module context.
+        #  -DCONFLICT=0
+        #  -DCONFLICT=1
+        self.assertEqual(sanity, 2+1)

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -64,7 +64,8 @@ class TestSwiftDedupMacros(TestBase):
                 space_with_space += 1
             if "-UNDEBUG" in line:
                 ndebug += 1
-        self.assertEqual(debug, 1)
-        self.assertEqual(space, 1)
+        # One extra in SwiftASTContextPerModule.
+        self.assertEqual(debug, 1+1)
+        self.assertEqual(space, 1+1)
         self.assertEqual(space_with_space, 0)
-        self.assertEqual(ndebug, 1)
+        self.assertEqual(ndebug, 1+1)


### PR DESCRIPTION
…eSystemSwiftTypeRef (NFC)

This has no effect on functionality or performance.

rdar://81717792
(cherry picked from commit dd73dab8a274e8d820d2f630131ef66f71d5e8df)