### PR TITLE
[lldb] Fix nullptr dereference in AppleObjCRuntimeV2

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -2009,6 +2009,11 @@ AppleObjCRuntimeV2::SharedCacheClassInfoExtractor::UpdateISAToDescriptorMap() {
   const uint32_t num_classes = 128 * 1024;
 
   UtilityFunction *get_class_info_code = GetClassInfoUtilityFunction(exe_ctx);
+  if (!get_class_info_code) {
+    // The callee will have already logged a useful error message.
+    return DescriptorMapUpdateResult::Fail();
+  }
+
   FunctionCaller *get_shared_cache_class_info_function =
       get_class_info_code->GetFunctionCaller();
 


### PR DESCRIPTION
Fix a potential nullptr dereference in AppleObjCRuntimeV2 by checking
the result of GetClassInfoUtilityFunction and returning a failure if
it's null.

The DynamicClassInfoExtractor was already doign the right thing, but the
SharedCacheClassInfoExtractor was missing this check.

(cherry picked from commit 957a5e987444d3193575d6ad8afe6c75da00d794)
