### PR TITLE
[lldb/test] Update test/API/functionalities/load_lazy to macOS 12

### DIFF
--- a/lldb/test/API/functionalities/load_lazy/Makefile
+++ b/lldb/test/API/functionalities/load_lazy/Makefile
@@ -5,9 +5,20 @@ all: t2_0 t2_1 t1 a.out
 
 include Makefile.rules
 
+ifeq "$(OS)" "Darwin"
+	# In macOS 12, dyld switched to using chained fixups. As a result, all
+	# symbols are bound at launch and there are no lazy pointers any more.
+	# Since we wish to import/dlopen() a dylib with missing symbols, we need
+	# to use a weak import. This applies to all macOS 12-aligned OS releases,
+	# e.g. iOS 15, etc.
+	LINKFLAGS := "-Wl,-weak-lt2_0"
+else
+	LINKFLAGS := "-lt2_0"
+endif
+
 t1: t2_0
 	$(MAKE) VPATH=$(SRCDIR) -f $(MAKEFILE_RULES) \
-		DYLIB_ONLY=YES DYLIB_C_SOURCES=t1.c DYLIB_NAME=t1 LD_EXTRAS="-L. -lt2_0"
+		DYLIB_ONLY=YES DYLIB_C_SOURCES=t1.c DYLIB_NAME=t1 LD_EXTRAS="-L. $(LINKFLAGS)"
 
 t2_0:
 	$(MAKE) VPATH=$(SRCDIR) -f $(MAKEFILE_RULES) \


### PR DESCRIPTION
In macOS 12, dyld switched to using chained fixups. As a result, all symbols
are bound at launch and there are no lazy pointers any more. Since we wish to
import/dlopen() a dylib with missing symbols, we need to use a weak import.
This applies to all macOS 12-aligned OS releases, e.g. iOS 15, etc.

rdar://81295101

Differential Revision: https://reviews.llvm.org/D112034

(cherry picked from commit 5e004b03f72a17f916b93792eb778dfa9e7a09cc)
