### PR TITLE
Use correct formatting for printing bytes in FoundationValueTypes

### DIFF
--- a/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
@@ -470,7 +470,7 @@ bool lldb_private::formatters::swift::Data_SummaryProvider(
   if (count == 1)
     stream.Printf("1 byte");
   else
-    stream.Printf("%lld bytes", count);
+    stream.Printf("%ld bytes", count);
 
   return true;
 }


### PR DESCRIPTION
It's a long, not a long long