### PR TITLE
[LLDB][NFC] Remove parameter names from forward declarations from hand written expressions used in heap.py part 2

### DIFF
--- a/lldb/examples/darwin/heap_find/heap.py
+++ b/lldb/examples/darwin/heap_find/heap.py
@@ -129,7 +129,7 @@ typedef struct malloc_zone_t {
     void *reserved1[12];
     struct malloc_introspection_t	*introspect;
 } malloc_zone_t;
-kern_return_t malloc_get_all_zones(task_t task, memory_reader_t reader, vm_address_t **addresses, unsigned *count);
+kern_return_t malloc_get_all_zones(task_t, memory_reader_t, vm_address_t **, unsigned *);
 memory_reader_t task_peek = [](task_t, vm_address_t remote_address, vm_size_t, void **local_memory) -> kern_return_t {
     *local_memory = (void*) remote_address;
     return KERN_SUCCESS;


### PR DESCRIPTION
heap.py has a lot of large hand written expressions and each name in the
expression will be looked up by clang during expression parsing. For
function parameters this will be in Sema::ActOnParamDeclarator(...) in order to
catch redeclarations of parameters. The names are not needed and we have seen
some rare cases where since we don't have symbols we end up in
SymbolContext::FindBestGlobalDataSymbol(...) which may conflict with other global
symbols.

There may be a way to make this lookup smarter to avoid these cases but it is
not clear how well tested this path is and how much work it would be to fix it.
So we will go with this fix while we investigate more.

This is a second try at getting all the cases we care about.

Ref: rdar://78265641
(cherry picked from commit 320f65ee65f40fadbd2016036e538e28ae28614c)