### PR TITLE
Add support for caching tablegen

### DIFF
--- a/clang/utils/TableGen/CMakeLists.txt
+++ b/clang/utils/TableGen/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(LLVM_LINK_COMPONENTS Support)
+set(LLVM_LINK_COMPONENTS Support CAS)
 
 add_tablegen(clang-tblgen CLANG
   ASTTableGen.cpp

--- a/clang/utils/TableGen/TableGen.cpp
+++ b/clang/utils/TableGen/TableGen.cpp
@@ -486,7 +486,7 @@ int main(int argc, char **argv) {
 
   llvm_shutdown_obj Y;
 
-  return TableGenMain(argv[0], &ClangTableGenMain);
+  return TableGenMain(makeArrayRef(argv, argc), &ClangTableGenMain);
 }
 
 #ifdef __has_feature

--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -1255,6 +1255,22 @@ if(LLVM_ENABLE_EXPERIMENTAL_CAS_TOKEN_CACHE)
   append_if(SUPPORTS_CAS_TOKEN_CACHE "-fcas-token-cache" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
 endif()
 
+# Do depscan caching in tablegen.
+set(LLVM_ENABLE_EXPERIMENTAL_DEPSCAN_TABLEGEN OFF CACHE BOOL
+  "Use the depscanning in tablegen")
+if(LLVM_ENABLE_EXPERIMENTAL_DEPSCAN_TABLEGEN)
+  list(APPEND LLVM_TABLEGEN_FLAGS "--depscan")
+
+  if(LLVM_ENABLE_PROJECTS_USED)
+    get_filename_component(source_root "${LLVM_MAIN_SRC_DIR}/.." ABSOLUTE)
+  else()
+    set(source_root "${LLVM_MAIN_SRC_DIR}")
+  endif()
+
+  list(APPEND LLVM_TABLEGEN_FLAGS "--depscan-prefix-map=${source_root}=/^source")
+  list(APPEND LLVM_TABLEGEN_FLAGS "--depscan-prefix-map=${CMAKE_BINARY_DIR}=/^build")
+endif()
+
 if(LLVM_INCLUDE_TESTS)
   # Lit test suite requires at least python 3.6
   set(LLVM_MINIMUM_PYTHON_VERSION 3.6)

--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -577,6 +577,16 @@ public:
     return const_cast<Expected<T> *>(this)->get();
   }
 
+  /// Returns \a takeError() after moving the held T (if any) into \p V.
+  template <class OtherT>
+  Error moveInto(
+      OtherT &Value,
+      std::enable_if_t<std::is_assignable<OtherT &, T &&>::value> * = nullptr) {
+    if (*this)
+      Value = std::move(get());
+    return takeError();
+  }
+
   /// Check that this Expected<T> is an error of type ErrT.
   template <typename ErrT> bool errorIsA() const {
     return HasError && (*getErrorStorage())->template isA<ErrT>();

--- a/llvm/include/llvm/Support/Path.h
+++ b/llvm/include/llvm/Support/Path.h
@@ -27,6 +27,14 @@ namespace path {
 
 enum class Style { windows, posix, native };
 
+constexpr Style system_style() {
+#if defined(_WIN32)
+  return Style::windows;
+#else
+  return Style::posix;
+#endif
+}
+
 /// @name Lexical Component Iterator
 /// @{
 

--- a/llvm/include/llvm/Support/PrefixMapper.h
+++ b/llvm/include/llvm/Support/PrefixMapper.h
@@ -1,0 +1,209 @@
+//===- llvm/Support/PrefixMapper.h - Prefix mapping utility -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TABLEGEN_PREFIXMAPPER_H
+#define LLVM_TABLEGEN_PREFIXMAPPER_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/StringSaver.h"
+
+namespace llvm {
+
+namespace vfs {
+class FileSystem;
+} // end namespace vfs
+
+struct MappedPrefix {
+  StringRef Old;
+  StringRef New;
+
+  MappedPrefix getInverse() const { return MappedPrefix{New, Old}; }
+
+  bool operator==(const MappedPrefix &RHS) const {
+    return Old == RHS.Old && New == RHS.New;
+  }
+  bool operator!=(const MappedPrefix &RHS) const { return !(*this == RHS); }
+
+  static Optional<MappedPrefix> getFromJoined(StringRef JoinedMapping);
+
+  static Error transformJoined(ArrayRef<StringRef> Joined,
+                               SmallVectorImpl<MappedPrefix> &Split);
+  static Error transformJoined(ArrayRef<std::string> Joined,
+                               SmallVectorImpl<MappedPrefix> &Split);
+  static void transformJoinedIfValid(ArrayRef<StringRef> Joined,
+                                     SmallVectorImpl<MappedPrefix> &Split);
+  static void transformJoinedIfValid(ArrayRef<std::string> Joined,
+                                     SmallVectorImpl<MappedPrefix> &Split);
+};
+
+/// Remap path prefixes.
+///
+/// FIXME: The StringSaver should be optional. Only APIs returning StringRef
+/// need it, and those could assert/crash if one is not configured.
+class PrefixMapper {
+public:
+  /// Map \p Path, and saving the new (or existing) path in \p NewPath.
+  ///
+  /// \pre \p Path is not a reference into \p NewPath.
+  void map(StringRef Path, SmallVectorImpl<char> &NewPath);
+  void map(StringRef Path, std::string &NewPath);
+
+  /// Map \p Path, returning \a StringSaver::save() for new paths that aren't
+  /// exact matches.
+  StringRef map(StringRef Path);
+
+  /// Map \p Path, returning \a std::string.
+  std::string mapToString(StringRef Path);
+
+  /// Map \p Path in place.
+  void mapInPlace(SmallVectorImpl<char> &Path);
+  void mapInPlace(std::string &Path);
+
+private:
+  /// Map (or unmap) \p Path. On a match, fills \p Storage with the mapped path
+  /// unless it's an exact match.
+  ///
+  /// \pre \p Path is not a reference into \p Storage.
+  Optional<StringRef> mapImpl(StringRef Path, SmallVectorImpl<char> &Storage);
+
+public:
+  void add(const MappedPrefix &MP) { Mappings.push_back(MP); }
+
+  /// A path-based reverse lexicographic sort, putting deeper paths first so
+  /// that deeper paths are prioritized over their parent paths. For example,
+  /// if both the source and build directories are remapped and one is nested
+  /// inside the other, the nested one will come first.
+  ///
+  /// FIXME: Doubtful that this would work correctly on windows, since it's
+  /// case- and separator-sensitive.
+  ///
+  /// FIXME: Should probably be done implicitly, maybe by moving to a std::set
+  /// or std::map.
+  ///
+  /// TODO: Test.
+  void sort();
+
+  template <class RangeT> void addRange(const RangeT &Mappings) {
+    this->Mappings.append(Mappings.begin(), Mappings.end());
+  }
+
+  template <class RangeT> void addInverseRange(const RangeT &Mappings) {
+    for (const MappedPrefix &M : Mappings)
+      add(M.getInverse());
+  }
+
+  ArrayRef<MappedPrefix> getMappings() const { return Mappings; }
+
+  StringSaver &getStringSaver() { return Saver; }
+  sys::path::Style getPathStyle() const { return PathStyle; }
+
+  PrefixMapper(StringSaver &Saver,
+               sys::path::Style PathStyle = sys::path::Style::native)
+      : PathStyle(PathStyle), Saver(Saver) {}
+
+private:
+  sys::path::Style PathStyle;
+  StringSaver &Saver;
+  SmallVector<MappedPrefix> Mappings;
+};
+
+/// Wrapper for \a PrefixMapper that maps using the result of \a
+/// FileSystem::getRealPath(). Returns an error if inputs cannot be found.
+///
+/// FIXME: The StringSaver should be optional. Only APIs returning StringRef
+/// need it, and those could assert/crash if one is not configured.
+class RealPathPrefixMapper {
+public:
+  Error map(StringRef Path, SmallVectorImpl<char> &NewPath);
+  Error map(StringRef Path, std::string &NewPath) {
+    return mapToString(Path).moveInto(NewPath);
+  }
+  Expected<StringRef> map(StringRef Path);
+  Expected<std::string> mapToString(StringRef Path);
+  Error mapInPlace(SmallVectorImpl<char> &Path);
+  Error mapInPlace(std::string &Path);
+
+  void mapOrOriginal(StringRef Path, SmallVectorImpl<char> &NewPath) {
+    if (errorToBool(map(Path, NewPath)))
+      NewPath.assign(Path.begin(), Path.end());
+  }
+  void mapOrOriginal(StringRef Path, std::string &NewPath) {
+    if (errorToBool(map(Path, NewPath)))
+      NewPath.assign(Path.begin(), Path.end());
+  }
+  Optional<StringRef> mapOrNone(StringRef Path) {
+    return expectedToOptional(map(Path));
+  }
+  StringRef mapOrOriginal(StringRef Path) {
+    Optional<StringRef> Mapped = mapOrNone(Path);
+    return Mapped ? *Mapped : Path;
+  }
+  Optional<std::string> mapToStringOrNone(StringRef Path) {
+    return expectedToOptional(mapToString(Path));
+  }
+  void mapInPlaceOrClear(SmallVectorImpl<char> &Path) {
+    if (errorToBool(mapInPlace(Path)))
+      Path.clear();
+  }
+  void mapInPlaceOrClear(std::string &Path) {
+    if (errorToBool(mapInPlace(Path)))
+      Path.clear();
+  }
+
+private:
+  Error getRealPath(StringRef Path, SmallVectorImpl<char> &RealPath);
+  Error makePrefixReal(StringRef &Prefix);
+
+public:
+  ArrayRef<MappedPrefix> getMappings() const { return PM.getMappings(); }
+  sys::path::Style getPathStyle() const { return PM.getPathStyle(); }
+
+  Error add(const MappedPrefix &Mapping);
+
+  template <class RangeT> Error addRange(const RangeT &Mappings) {
+    for (const MappedPrefix &M : Mappings)
+      if (Error E = add(M))
+        return E;
+    return Error::success();
+  }
+
+  template <class RangeT> Error addInverseRange(const RangeT &Mappings) {
+    for (const MappedPrefix &M : Mappings)
+      if (Error E = add(M.getInverse()))
+        return E;
+    return Error::success();
+  }
+
+  template <class RangeT> void addRangeIfValid(const RangeT &Mappings) {
+    for (const MappedPrefix &M : Mappings)
+      consumeError(add(M));
+  }
+
+  template <class RangeT> void addInverseRangeIfValid(const RangeT &Mappings) {
+    for (const MappedPrefix &M : Mappings)
+      consumeError(add(M.getInverse()));
+  }
+
+  void sort() { PM.sort(); }
+
+  RealPathPrefixMapper(IntrusiveRefCntPtr<vfs::FileSystem> FS,
+                       StringSaver &Saver,
+                       sys::path::Style PathStyle = sys::path::Style::native);
+  ~RealPathPrefixMapper();
+
+private:
+  PrefixMapper PM;
+  IntrusiveRefCntPtr<vfs::FileSystem> FS;
+};
+
+} // end namespace llvm
+
+#endif // LLVM_TABLEGEN_PREFIXMAPPER_H

--- a/llvm/include/llvm/TableGen/Main.h
+++ b/llvm/include/llvm/TableGen/Main.h
@@ -13,6 +13,8 @@
 #ifndef LLVM_TABLEGEN_MAIN_H
 #define LLVM_TABLEGEN_MAIN_H
 
+#include "llvm/ADT/ArrayRef.h"
+
 namespace llvm {
 
 class raw_ostream;
@@ -22,6 +24,9 @@ class RecordKeeper;
 /// Returns true on error, false otherwise.
 using TableGenMainFn = bool (raw_ostream &OS, RecordKeeper &Records);
 
+int TableGenMain(ArrayRef<const char *> Args, TableGenMainFn *MainFn);
+
+/// Deprecated. Clients should pass all args to enable caching.
 int TableGenMain(const char *argv0, TableGenMainFn *MainFn);
 
 } // end namespace llvm

--- a/llvm/include/llvm/TableGen/ScanDependencies.h
+++ b/llvm/include/llvm/TableGen/ScanDependencies.h
@@ -1,0 +1,102 @@
+//===- llvm/TableGen/ScanDependencies.h - TableGen scan-deps ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TABLEGEN_SCANDEPENDENCIES_H
+#define LLVM_TABLEGEN_SCANDEPENDENCIES_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/CAS/CASDB.h"
+#include "llvm/Support/Error.h"
+
+namespace llvm {
+
+namespace cas {
+class CachingOnDiskFileSystem;
+} // end namespace cas
+
+class RealPathPrefixMapper;
+struct MappedPrefix;
+
+namespace tablegen {
+
+/// FIXME: Maybe this and \a flattenStrings() could/should go somewhere in
+/// Support? Although it's a pretty simple serialization, not hard to rewrite.
+void splitFlattenedStrings(StringRef Flattened,
+                           SmallVectorImpl<StringRef> &List);
+void flattenStrings(ArrayRef<StringRef> List, SmallVectorImpl<char> &Flattened);
+
+/// Helper for fuzzy-matching include directives in tablegen files. This is a
+/// very lazy lex, matching 'include "..."' even in comments. It does not
+/// descend into the files.
+void scanTextForIncludes(StringRef Input, SmallVectorImpl<StringRef> &Includes);
+
+/// Cached version of the above.
+///
+/// \p ExecID is the Blob for the running executable. It can be used as part of
+/// the key for caching to avoid (fixed) bugs poisoning results.
+Error scanTextForIncludes(cas::CASDB &CAS, cas::CASID ExecID,
+                          const cas::BlobRef &Blob,
+                          SmallVectorImpl<StringRef> &Includes);
+
+/// Match logic from SourceMgr::AddIncludeFile.
+///
+/// FIXME: Take CASFileSystemBase once it adds statusAndFileID().
+Optional<cas::CASID> lookupIncludeID(cas::CachingOnDiskFileSystem &FS,
+                                     ArrayRef<std::string> IncludeDirs,
+                                     StringRef Filename);
+
+/// Helper to access all includes under \p MainFileBlob.
+///
+/// \p ExecID is the Blob for the running executable. It can be used as part of
+/// the key for caching to avoid (fixed) bugs poisoning results.
+Error accessAllIncludes(cas::CachingOnDiskFileSystem &FS, cas::CASID ExecID,
+                        ArrayRef<std::string> IncludeDirs,
+                        const cas::BlobRef &MainFileBlob);
+
+Error createMainFileError(StringRef MainFilename, std::error_code EC);
+
+struct ScanIncludesResult {
+  cas::CASID IncludesTree;
+  cas::BlobRef MainBlob;
+};
+
+/// Scan includes and build a CAS tree. If \p PrefixMappings is not \c None,
+/// remap the includes while building the tree. If \p PM is not \c nullptr
+/// then the \a RealPathPrefixMapper used will be returned there.
+///
+/// \p ExecID is the Blob for the running executable. It can be used as part of
+/// the key for caching to avoid (fixed) bugs poisoning results.
+///
+/// TODO: We should upstream a version of this that doesn't rely on the CAS;
+/// it'd be useful for build systems that want to collect dependencies ahead of
+/// time. Maybe can separate a tool/etc. for that.
+Expected<ScanIncludesResult>
+scanIncludes(cas::CASDB &CAS, cas::CASID ExecID, StringRef MainFilename,
+             ArrayRef<std::string> IncludeDirs,
+             ArrayRef<MappedPrefix> PrefixMappings = None,
+             Optional<RealPathPrefixMapper> *CapturedPM = nullptr);
+
+/// Scan includes and build a CAS tree where their prefixes have been remapped
+/// according to \a PrefixMappings. Also remap the main file and include
+/// directories. Return the includes tree and the main file blob.
+///
+/// \p ExecID is the Blob for the running executable. It can be used as part of
+/// the key for caching to avoid (fixed) bugs poisoning results.
+Expected<ScanIncludesResult>
+scanIncludesAndRemap(cas::CASDB &CAS, cas::CASID ExecID,
+                     std::string &MainFilename,
+                     std::vector<std::string> &IncludeDirs,
+                     ArrayRef<MappedPrefix> PrefixMappings);
+
+} // end namespace tablegen
+} // end namespace llvm
+
+#endif // LLVM_TABLEGEN_SCANDEPENDENCIES_H

--- a/llvm/lib/Frontend/OpenACC/CMakeLists.txt
+++ b/llvm/lib/Frontend/OpenACC/CMakeLists.txt
@@ -7,6 +7,7 @@ add_llvm_component_library(LLVMFrontendOpenACC
 
   DEPENDS
   acc_gen
+  ObjdumpOptsTableGen
 )
 
 target_link_libraries(LLVMFrontendOpenACC LLVMSupport)

--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -178,6 +178,7 @@ add_llvm_component_library(LLVMSupport
   OutputConfig.cpp
   Parallel.cpp
   PluginLoader.cpp
+  PrefixMapper.cpp
   PrettyStackTrace.cpp
   RandomNumberGenerator.cpp
   Regex.cpp

--- a/llvm/lib/Support/Path.cpp
+++ b/llvm/lib/Support/Path.cpp
@@ -37,11 +37,7 @@ namespace {
   using llvm::sys::path::Style;
 
   inline Style real_style(Style style) {
-#ifdef _WIN32
-    return (style == Style::posix) ? Style::posix : Style::windows;
-#else
-    return (style == Style::windows) ? Style::windows : Style::posix;
-#endif
+    return style == Style::native ? llvm::sys::path::system_style() : style;
   }
 
   inline const char *separators(Style style) {

--- a/llvm/lib/Support/PrefixMapper.cpp
+++ b/llvm/lib/Support/PrefixMapper.cpp
@@ -1,0 +1,247 @@
+//===- PrefixMapper.cpp - Prefix mapping utility --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/PrefixMapper.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Support/VirtualFileSystem.h"
+
+using namespace llvm;
+
+Optional<MappedPrefix> MappedPrefix::getFromJoined(StringRef JoinedMapping) {
+  auto Equals = JoinedMapping.find('=');
+  if (Equals == StringRef::npos)
+    return None;
+  StringRef Old = JoinedMapping.substr(0, Equals);
+  StringRef New = JoinedMapping.substr(Equals + 1);
+  return MappedPrefix{Old, New};
+}
+
+template <bool StopOnInvalid, class StringT>
+static Optional<StringRef>
+transformJoinedImpl(ArrayRef<StringT> JoinedMappings,
+                    SmallVectorImpl<MappedPrefix> &Mappings) {
+  size_t OriginalSize = Mappings.size();
+  for (StringRef Joined : JoinedMappings) {
+    if (Optional<MappedPrefix> Split = MappedPrefix::getFromJoined(Joined)) {
+      Mappings.push_back(*Split);
+      continue;
+    }
+    if (!StopOnInvalid)
+      continue;
+    Mappings.resize(OriginalSize);
+    return Joined;
+  }
+  return None;
+}
+
+static Error makeErrorForInvalidJoin(Optional<StringRef> Joined) {
+  if (!Joined)
+    return Error::success();
+  return createStringError(inconvertibleErrorCode(),
+                           "invalid prefix map: '" + *Joined + "'");
+}
+
+Error MappedPrefix::transformJoined(ArrayRef<StringRef> Joined,
+                                    SmallVectorImpl<MappedPrefix> &Split) {
+  return makeErrorForInvalidJoin(
+      transformJoinedImpl</*StopOnInvalid*/ true>(Joined, Split));
+}
+
+Error MappedPrefix::transformJoined(ArrayRef<std::string> Joined,
+                                    SmallVectorImpl<MappedPrefix> &Split) {
+  return makeErrorForInvalidJoin(
+      transformJoinedImpl</*StopOnInvalid*/ true>(Joined, Split));
+}
+
+void MappedPrefix::transformJoinedIfValid(
+    ArrayRef<StringRef> Joined, SmallVectorImpl<MappedPrefix> &Split) {
+  transformJoinedImpl</*StopOnInvalid*/ false>(Joined, Split);
+}
+
+void MappedPrefix::transformJoinedIfValid(
+    ArrayRef<std::string> Joined, SmallVectorImpl<MappedPrefix> &Split) {
+  transformJoinedImpl</*StopOnInvalid*/ false>(Joined, Split);
+}
+
+/// FIXME: Copy/pasted from llvm/lib/Support/Path.cpp.
+static bool startsWith(StringRef Path, StringRef Prefix,
+                       sys::path::Style PathStyle) {
+  if (PathStyle == sys::path::Style::posix ||
+      (PathStyle == sys::path::Style::native &&
+       sys::path::system_style() == sys::path::Style::posix))
+    return Path.startswith(Prefix);
+
+  if (Path.size() < Prefix.size())
+    return false;
+
+  // Windows prefix matching : case and separator insensitive
+  for (size_t I = 0, E = Prefix.size(); I != E; ++I) {
+    bool SepPath = sys::path::is_separator(Path[I], PathStyle);
+    bool SepPrefix = sys::path::is_separator(Prefix[I], PathStyle);
+    if (SepPath != SepPrefix)
+      return false;
+    if (SepPath)
+      continue;
+    if (toLower(Path[I]) != toLower(Prefix[I]))
+      return false;
+  }
+  return true;
+}
+
+Optional<StringRef> PrefixMapper::mapImpl(StringRef Path,
+                                          SmallVectorImpl<char> &Storage) {
+  for (const MappedPrefix &Map : Mappings) {
+    StringRef Old = Map.Old;
+    StringRef New = Map.New;
+    if (!startsWith(Path, Old, PathStyle))
+      continue;
+    StringRef Suffix = Path.drop_front(Old.size());
+    if (Suffix.empty())
+      return New; // Exact match.
+
+    // Don't remap "/old-suffix" with mapping "/old=/new".
+    if (!llvm::sys::path::is_separator(Suffix.front(), PathStyle))
+      continue;
+
+    // Drop the separator, append, and return.
+    Storage.assign(New.begin(), New.end());
+    llvm::sys::path::append(Storage, PathStyle, Suffix.drop_front());
+    return StringRef(Storage.begin(), Storage.size());
+  }
+  return None;
+}
+
+void PrefixMapper::map(StringRef Path, SmallVectorImpl<char> &NewPath) {
+  NewPath.clear();
+  Optional<StringRef> Mapped = mapImpl(Path, NewPath);
+  if (!NewPath.empty())
+    return;
+  if (!Mapped)
+    Mapped = Path;
+  NewPath.assign(Mapped->begin(), Mapped->end());
+}
+
+void PrefixMapper::map(StringRef Path, std::string &NewPath) {
+  NewPath = mapToString(Path);
+}
+
+StringRef PrefixMapper::map(StringRef Path) {
+  SmallString<256> Storage;
+  Optional<StringRef> Mapped = mapImpl(Path, Storage);
+  if (!Mapped)
+    return Path;
+  if (Storage.empty())
+    return *Mapped; // Exact match.
+  return Saver.save(StringRef(Storage));
+}
+
+std::string PrefixMapper::mapToString(StringRef Path) {
+  SmallString<256> Storage;
+  Optional<StringRef> Mapped = mapImpl(Path, Storage);
+  return Mapped ? Mapped->str() : Path.str();
+}
+
+void PrefixMapper::mapInPlace(SmallVectorImpl<char> &Path) {
+  SmallString<256> Storage;
+  Optional<StringRef> Mapped =
+      mapImpl(StringRef(Path.begin(), Path.size()), Storage);
+  if (!Mapped)
+    return;
+  if (Storage.empty())
+    Path.assign(Mapped->begin(), Mapped->end());
+  else
+    Storage.swap(Path);
+}
+
+void PrefixMapper::mapInPlace(std::string &Path) {
+  SmallString<256> Storage;
+  Optional<StringRef> Mapped = mapImpl(Path, Storage);
+  if (!Mapped)
+    return;
+  Path.assign(Mapped->begin(), Mapped->size());
+}
+
+void PrefixMapper::sort() {
+  // FIXME: Only works for posix right now since it doesn't handle case- and
+  // separator-insensitivity.
+  std::stable_sort(Mappings.begin(), Mappings.end(),
+                   [](const MappedPrefix &LHS, const MappedPrefix &RHS) {
+                     return LHS.Old > RHS.Old;
+                   });
+}
+
+RealPathPrefixMapper::RealPathPrefixMapper(
+    IntrusiveRefCntPtr<vfs::FileSystem> FS, StringSaver &Saver,
+    sys::path::Style PathStyle)
+    : PM(Saver, PathStyle), FS(std::move(FS)) {}
+
+RealPathPrefixMapper::~RealPathPrefixMapper() = default;
+
+Error RealPathPrefixMapper::getRealPath(StringRef Path,
+                                        SmallVectorImpl<char> &RealPath) {
+  if (std::error_code EC = FS->getRealPath(Path, RealPath))
+    return createFileError(Path, EC);
+  return Error::success();
+}
+
+Error RealPathPrefixMapper::map(StringRef Path,
+                                SmallVectorImpl<char> &NewPath) {
+  NewPath.clear();
+  if (Error E = getRealPath(Path, NewPath))
+    return E;
+  PM.mapInPlace(NewPath);
+  return Error::success();
+}
+
+Expected<StringRef> RealPathPrefixMapper::map(StringRef Path) {
+  SmallString<256> RealPath;
+  if (Error E = getRealPath(Path, RealPath))
+    return std::move(E);
+  return PM.map(RealPath);
+}
+
+Expected<std::string> RealPathPrefixMapper::mapToString(StringRef Path) {
+  SmallString<256> RealPath;
+  if (Error E = getRealPath(Path, RealPath))
+    return std::move(E);
+  return PM.mapToString(RealPath);
+}
+
+Error RealPathPrefixMapper::mapInPlace(SmallVectorImpl<char> &Path) {
+  SmallString<256> RealPath;
+  if (Error E = getRealPath(StringRef(Path.begin(), Path.size()), RealPath))
+    return E;
+  PM.map(RealPath, Path);
+  return Error::success();
+}
+
+Error RealPathPrefixMapper::mapInPlace(std::string &Path) {
+  SmallString<256> RealPath;
+  if (Error E = getRealPath(Path, RealPath))
+    return E;
+  Path = PM.mapToString(RealPath);
+  return Error::success();
+}
+
+Error RealPathPrefixMapper::makePrefixReal(StringRef &Prefix) {
+  SmallString<256> RealPath;
+  if (Error E = getRealPath(Prefix, RealPath))
+    return E;
+  if (RealPath != Prefix)
+    Prefix = PM.getStringSaver().save(StringRef(RealPath));
+  return Error::success();
+}
+
+Error RealPathPrefixMapper::add(const MappedPrefix &Mapping) {
+  StringRef Old = Mapping.Old;
+  StringRef New = Mapping.New;
+  if (Error E = makePrefixReal(Old))
+    return E;
+  PM.add(MappedPrefix{Old, New});
+  return Error::success();
+}

--- a/llvm/lib/TableGen/CMakeLists.txt
+++ b/llvm/lib/TableGen/CMakeLists.txt
@@ -4,6 +4,7 @@ add_llvm_component_library(LLVMTableGen
   JSONBackend.cpp
   Main.cpp
   Record.cpp
+  ScanDependencies.cpp
   SetTheory.cpp
   StringMatcher.cpp
   TableGenBackend.cpp

--- a/llvm/lib/TableGen/Main.cpp
+++ b/llvm/lib/TableGen/Main.cpp
@@ -160,3 +160,8 @@ int llvm::TableGenMain(const char *argv0, TableGenMainFn *MainFn) {
     return reportError(argv0, Twine(ErrorsPrinted) + " errors.\n");
   return 0;
 }
+
+int llvm::TableGenMain(ArrayRef<const char *> Args, TableGenMainFn *MainFn) {
+  assert(!Args.empty() && "Missing argv0!");
+  return TableGenMain(Args[0], MainFn);
+}

--- a/llvm/lib/TableGen/Main.cpp
+++ b/llvm/lib/TableGen/Main.cpp
@@ -16,18 +16,27 @@
 
 #include "llvm/TableGen/Main.h"
 #include "TGParser.h"
+#include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/CAS/CASFileSystem.h"
+#include "llvm/CAS/CachingOnDiskFileSystem.h"
+#include "llvm/Support/Allocator.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/PrefixMapper.h"
+#include "llvm/Support/StringSaver.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/TableGen/Error.h"
 #include "llvm/TableGen/Record.h"
+#include "llvm/TableGen/ScanDependencies.h"
 #include <algorithm>
 #include <cstdio>
 #include <system_error>
 using namespace llvm;
+using namespace llvm::tablegen;
 
 static cl::opt<std::string>
 OutputFilename("o", cl::desc("Output filename"), cl::value_desc("filename"),
@@ -53,6 +62,12 @@ MacroNames("D", cl::desc("Name of the macro to be defined"),
 static cl::opt<bool>
 WriteIfChanged("write-if-changed", cl::desc("Only write output if it changed"));
 
+static cl::opt<bool> Depscan("depscan",
+                             cl::desc("Use a CAS, depscanning, and caching"));
+static cl::list<std::string>
+    DepscanPrefixMap("depscan-prefix-map",
+                     cl::desc("Prefix mapping for --depscan"));
+
 static cl::opt<bool>
 TimePhases("time-phases", cl::desc("Time phases of parser and backend"));
 
@@ -68,11 +83,11 @@ static int reportError(const char *ProgName, Error E) {
   return 1;
 }
 
-/// Create a dependency file for `-d` option.
-///
-/// This functionality is really only for the benefit of the build system.
-/// It is similar to GCC's `-M*` family of options.
-static Error createDependencyFile(const TGParser &Parser) {
+static SmallVectorImpl<char> *CapturedDepend = nullptr;
+static std::string *CapturedOutput = nullptr;
+
+static Error
+createDependencyFileImpl(function_ref<void(raw_ostream &OS)> Write) {
   if (OutputFilename == "-")
     return createStringError(inconvertibleErrorCode(),
                              "the option -d must be used together with -o");
@@ -82,13 +97,37 @@ static Error createDependencyFile(const TGParser &Parser) {
   if (EC)
     return createStringError(EC, "error opening " + DependFilename + ":" +
                                      EC.message());
-  DepOut.os() << OutputFilename << ":";
-  for (const auto &Dep : Parser.getDependencies()) {
-    DepOut.os() << ' ' << Dep;
-  }
-  DepOut.os() << "\n";
+  Write(DepOut.os());
   DepOut.keep();
   return Error::success();
+}
+
+static PrefixMapper *CreateDependencyFilePM = nullptr;
+
+/// Create a dependency file for `-d` option.
+///
+/// This functionality is really only for the benefit of the build system.
+/// It is similar to GCC's `-M*` family of options.
+template <class StringSetT>
+static Error createDependencyFile(const StringSetT &Dependencies) {
+  return createDependencyFileImpl([&](raw_ostream &OS) {
+    OS << OutputFilename << ":";
+    for (StringRef Dep : Dependencies) {
+      OS << ' '
+         << (CreateDependencyFilePM ? CreateDependencyFilePM->map(Dep) : Dep);
+    }
+    OS << "\n";
+  });
+}
+
+static Error createDependencyFile(const TGParser &Parser) {
+  if (CapturedDepend) {
+    for (StringRef Dep : Parser.getDependencies()) {
+      CapturedDepend->append(Dep.begin(), Dep.end());
+      CapturedDepend->push_back(0);
+    }
+  }
+  return createDependencyFile(Parser.getDependencies());
 }
 
 namespace {
@@ -111,25 +150,52 @@ public:
 void AlreadyReportedError::anchor() {}
 char AlreadyReportedError::ID = 0;
 
-static Error TableGenMainImpl(TableGenMainFn *MainFn) {
+static Error createOutputFile(StringRef Out) {
+  bool WriteFile = true;
+  if (WriteIfChanged) {
+    // Only updates the real output file if there are any differences.
+    // This prevents recompilation of all the files depending on it if there
+    // aren't any.
+    if (auto ExistingOrErr =
+            MemoryBuffer::getFile(OutputFilename, /*IsText=*/true))
+      if (std::move(ExistingOrErr.get())->getBuffer() == Out)
+        WriteFile = false;
+  }
+  if (WriteFile) {
+    std::error_code EC;
+    ToolOutputFile OutFile(OutputFilename, EC, sys::fs::OF_Text);
+    if (EC)
+      return createStringError(EC, "error opening " + OutputFilename + ": " +
+                                       EC.message());
+    OutFile.os() << Out;
+    if (ErrorsPrinted == 0)
+      OutFile.keep();
+  }
+  return Error::success();
+}
+
+static Error
+TableGenMainImpl(TableGenMainFn *MainFn,
+                 std::unique_ptr<MemoryBuffer> MainFile = nullptr) {
   RecordKeeper Records;
 
   if (TimePhases)
     Records.startPhaseTiming();
 
   // Parse the input file.
-
   Records.startTimer("Parse, build records");
-  ErrorOr<std::unique_ptr<MemoryBuffer>> FileOrErr =
-      MemoryBuffer::getFileOrSTDIN(InputFilename, /*IsText=*/true);
-  if (std::error_code EC = FileOrErr.getError())
-    return createStringError(EC, "Could not open input file '" + InputFilename +
-                                     "': " + EC.message());
+  if (!MainFile) {
+    ErrorOr<std::unique_ptr<MemoryBuffer>> FileOrErr =
+        MemoryBuffer::getFileOrSTDIN(InputFilename, /*IsText=*/true);
+    if (std::error_code EC = FileOrErr.getError())
+      return createMainFileError(InputFilename, EC);
+    MainFile = std::move(*FileOrErr);
+  }
 
   Records.saveInputFilename(InputFilename);
 
   // Tell SrcMgr about this buffer, which is what TGParser will pick up.
-  SrcMgr.AddNewSourceBuffer(std::move(*FileOrErr), SMLoc());
+  SrcMgr.AddNewSourceBuffer(std::move(MainFile), SMLoc());
 
   // Record the location of the include directory so that the lexer can find
   // it later.
@@ -160,27 +226,11 @@ static Error TableGenMainImpl(TableGenMainFn *MainFn) {
   }
 
   Records.startTimer("Write output");
-  bool WriteFile = true;
-  if (WriteIfChanged) {
-    // Only updates the real output file if there are any differences.
-    // This prevents recompilation of all the files depending on it if there
-    // aren't any.
-    if (auto ExistingOrErr =
-            MemoryBuffer::getFile(OutputFilename, /*IsText=*/true))
-      if (std::move(ExistingOrErr.get())->getBuffer() == Out.str())
-        WriteFile = false;
-  }
-  if (WriteFile) {
-    std::error_code EC;
-    ToolOutputFile OutFile(OutputFilename, EC, sys::fs::OF_Text);
-    if (EC)
-      return createStringError(EC, "error opening " + OutputFilename + ": " +
-                                       EC.message());
-    OutFile.os() << Out.str();
-    if (ErrorsPrinted == 0)
-      OutFile.keep();
-  }
-  
+  if (Error E = createOutputFile(Out.str()))
+    return E;
+  if (CapturedOutput)
+    *CapturedOutput = std::move(Out.str());
+
   Records.stopTimer();
   Records.stopPhaseTiming();
 
@@ -194,7 +244,304 @@ int llvm::TableGenMain(const char *argv0, TableGenMainFn *MainFn) {
   return reportError(argv0, TableGenMainImpl(MainFn));
 }
 
+namespace {
+struct TableGenCache {
+  std::unique_ptr<cas::CASDB> CAS;
+  Optional<cas::CASID> ExecutableID;
+  Optional<cas::CASID> IncludesTreeID;
+  Optional<cas::CASID> ActionID;
+  Optional<cas::CASID> ResultID;
+  Optional<cas::CASID> MainFileID;
+  std::unique_ptr<MemoryBuffer> MainFile;
+  Optional<std::string> OriginalInputFilename;
+
+  SmallVector<MappedPrefix> PrefixMappings;
+  BumpPtrAllocator Alloc;
+  StringSaver Saver;
+  Optional<RealPathPrefixMapper> PM;
+  Optional<PrefixMapper> InversePM;
+
+  TableGenCache() : Saver(Alloc) {}
+  ~TableGenCache() { CreateDependencyFilePM = nullptr; }
+
+  Expected<cas::CASID> createExecutableBlob(StringRef Argv0);
+  Expected<cas::CASID> createCommandLineBlob(ArrayRef<const char *> Args);
+  Error createAction(ArrayRef<const char *> Args);
+
+  Error lookupCachedResult(ArrayRef<const char *> Args);
+
+  Error computeResult(TableGenMainFn *MainFn);
+  Error replayResult();
+
+  void createPrefixMap(IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS);
+  void createInversePrefixMap();
+};
+} // end namespace
+
+void TableGenCache::createPrefixMap(
+    IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS) {
+  assert(!PM);
+  PM.emplace(std::move(FS), Saver);
+  PM->addRangeIfValid(PrefixMappings);
+}
+
+void TableGenCache::createInversePrefixMap() {
+  InversePM.emplace(Saver);
+  InversePM->addInverseRange(PrefixMappings);
+  CreateDependencyFilePM = &*InversePM;
+}
+
+Expected<cas::CASID> TableGenCache::createExecutableBlob(StringRef Argv0) {
+  ErrorOr<std::unique_ptr<MemoryBuffer>> Buffer = MemoryBuffer::getFile(Argv0);
+  if (!Buffer)
+    return errorCodeToError(Buffer.getError());
+  Expected<cas::BlobRef> Blob = CAS->createBlob((**Buffer).getBuffer());
+  if (!Blob)
+    return Blob.takeError();
+  return *Blob;
+}
+
+Expected<cas::CASID>
+TableGenCache::createCommandLineBlob(ArrayRef<const char *> Args) {
+  SmallString<1024> CommandLine;
+
+  // Use raw_svector_stream since it doesn't buffer.
+  raw_svector_ostream OS(CommandLine);
+  auto serializeArg = [&](StringRef Arg) {
+    OS << Arg;
+    CommandLine.push_back(0);
+  };
+  serializeArg(sys::path::filename(Args[0]));
+  Args = Args.drop_front();
+
+  // Serialize remapped includes.
+  for (StringRef Dir : IncludeDirs) {
+    serializeArg("-I");
+    serializeArg(Dir);
+  }
+
+  // Serialize other args.
+  while (!Args.empty()) {
+    StringRef Arg = Args.front();
+    // Skip known inputs, which are handled specially. Skip known outputs,
+    // which don't affect the result. Skip prefix remapping.
+    if (Arg == "-I" || Arg == "-d" || Arg == "-o" ||
+        Arg == "--depscan-prefix-map") {
+      Args = Args.drop_front(2);
+      continue;
+    }
+    if (Arg.startswith("-I") || Arg.startswith("-d") || Arg.startswith("-o") ||
+        Arg.startswith("--depscan-prefix-map=") || Arg == "--depscan") {
+      Args = Args.drop_front();
+      continue;
+    }
+
+    // Serialize the remapped input.
+    if (OriginalInputFilename && *OriginalInputFilename == Args.front()) {
+      serializeArg(InputFilename);
+      Args = Args.drop_front();
+      continue;
+    }
+
+    serializeArg(Args.front());
+    Args = Args.drop_front();
+  }
+
+  Expected<cas::BlobRef> Blob = CAS->createBlob(CommandLine);
+  if (!Blob)
+    return Blob.takeError();
+  return *Blob;
+}
+
+Error TableGenCache::createAction(ArrayRef<const char *> Args) {
+  Expected<cas::CASID> CommandLineID = createCommandLineBlob(Args);
+  if (!CommandLineID)
+    return CommandLineID.takeError();
+
+  cas::HierarchicalTreeBuilder Builder;
+  Builder.push(*IncludesTreeID, cas::TreeEntry::Tree, "includes");
+  Builder.push(*MainFileID, cas::TreeEntry::Regular, "input");
+  Builder.push(*ExecutableID, cas::TreeEntry::Regular, "executable");
+  Builder.push(*CommandLineID, cas::TreeEntry::Regular, "command-line");
+  Expected<cas::TreeRef> Tree = Builder.create(*CAS);
+  if (!Tree)
+    return Tree.takeError();
+  ActionID = *Tree;
+  return Error::success();
+}
+
+Error TableGenCache::lookupCachedResult(ArrayRef<const char *> Args) {
+  if (Error E =
+          cas::createOnDiskCAS(cas::getDefaultOnDiskCASPath()).moveInto(CAS))
+    return E;
+
+  if (Error E = createExecutableBlob(Args[0]).moveInto(ExecutableID))
+    return E;
+
+  OriginalInputFilename = InputFilename.getValue();
+  Expected<ScanIncludesResult> Scan = scanIncludesAndRemap(
+      *CAS, *ExecutableID, InputFilename, *&IncludeDirs, PrefixMappings);
+  if (!Scan)
+    return Scan.takeError();
+
+  // Save the results of the scan.
+  IncludesTreeID = Scan->IncludesTree;
+  MainFileID = Scan->MainBlob;
+  MainFile =
+      MemoryBuffer::getMemBuffer(Scan->MainBlob.getData(), InputFilename);
+
+  if (Error E = createAction(Args))
+    return E;
+
+  // Not an error for the result to be missing.
+  ResultID = expectedToOptional(CAS->getCachedResult(*ActionID));
+  return Error::success();
+}
+
+namespace {
+struct CapturedDiagnostics {
+  std::string Diags;
+  raw_string_ostream OS;
+
+  static void diagnose(const SMDiagnostic &Diag, void *This_) {
+    auto *This = reinterpret_cast<CapturedDiagnostics *>(This_);
+
+    // Print live.
+    SrcMgr.setDiagHandler(nullptr);
+    SrcMgr.PrintMessage(errs(), Diag);
+
+    // Capture.
+    //
+    // FIXME: Serialize the diagnostic semantically to replay it with colours
+    // and to refer to the sources already in the CAS.
+    SrcMgr.PrintMessage(This->OS, Diag);
+
+    // Put back the handler.
+    SrcMgr.setDiagHandler(&CapturedDiagnostics::diagnose, This);
+  }
+
+  CapturedDiagnostics() : OS(Diags) {}
+};
+} // end namespace
+
+Error TableGenCache::computeResult(TableGenMainFn *MainFn) {
+  if (ResultID)
+    return replayResult();
+
+  std::string CapturedStderr;
+  std::string OutputStorage;
+  SmallString<256> DependStorage;
+
+  CapturedDiagnostics Diags;
+  if (ActionID) {
+    assert(IncludesTreeID && "Expected an input tree...");
+    if (auto FS = cas::createCASFileSystem(*CAS, *IncludesTreeID))
+      SrcMgr.setFileSystem(std::move(*FS));
+    else
+      return FS.takeError();
+
+    CapturedOutput = &OutputStorage;
+    CapturedDepend = &DependStorage;
+    SrcMgr.setDiagHandler(&CapturedDiagnostics::diagnose, &Diags);
+  }
+  auto ResetCaptures = make_scope_exit([&]() {
+    CapturedOutput = nullptr;
+    CapturedDepend = nullptr;
+  });
+
+  // Don't cache failed builds for now.
+  if (Error E = TableGenMainImpl(MainFn, std::move(MainFile)))
+    return E;
+
+  // Caching not turned on.
+  if (!ActionID)
+    return Error::success();
+
+  cas::HierarchicalTreeBuilder Builder;
+  auto addFile = [&](StringRef Name, StringRef Data) -> Error {
+    Expected<cas::CASID> ID = CAS->createBlob(Data);
+    if (!ID)
+      return ID.takeError();
+    Builder.push(*ID, cas::TreeEntry::Regular, Name);
+    return Error::success();
+  };
+
+  if (Error E = addFile("output", *CapturedOutput))
+    return E;
+  if (!DependFilename.empty())
+    if (Error E = addFile("depend", DependStorage))
+      return E;
+  if (!Diags.OS.str().empty())
+    if (Error E = addFile("stderr", Diags.OS.str()))
+      return E;
+
+  Expected<cas::TreeRef> Tree = Builder.create(*CAS);
+  if (!Tree)
+    return Tree.takeError();
+  return CAS->putCachedResult(*ActionID, *Tree);
+}
+
+Error TableGenCache::replayResult() {
+  assert(ResultID && "Need a result!");
+
+  Expected<cas::TreeRef> Tree = CAS->getTree(*ResultID);
+  if (!Tree)
+    return Tree.takeError();
+
+  auto getBlob = [&](StringRef Name, Optional<cas::BlobRef> &Blob) -> Error {
+    Optional<cas::NamedTreeEntry> Entry = Tree->lookup(Name);
+    if (!Entry)
+      return Error::success();
+    Expected<cas::BlobRef> ExpectedBlob = CAS->getBlob(Entry->getID());
+    if (!ExpectedBlob)
+      return ExpectedBlob.takeError();
+    Blob = *ExpectedBlob;
+    return Error::success();
+  };
+  Optional<cas::BlobRef> Output;
+  Optional<cas::BlobRef> Depend;
+  Optional<cas::BlobRef> Stderr;
+  if (Error E = getBlob("output", Output))
+    return E;
+  if (Error E = getBlob("depend", Depend))
+    return E;
+  if (Error E = getBlob("stderr", Stderr))
+    return E;
+  if (!Output)
+    return createStringError(inconvertibleErrorCode(),
+                             "cached result has no output");
+
+  if (Depend) {
+    SmallVector<StringRef> Dependencies;
+    splitFlattenedStrings(Depend->getData(), Dependencies);
+    if (Error E = createDependencyFile(Dependencies))
+      return E;
+  }
+
+  // FIXME: This should replay diagnostics semantically, adding colours as
+  // appropriate. Currently it's low-fidelity.
+  if (Stderr)
+    errs() << Stderr->getData();
+
+  if (Error E = createOutputFile(Output->getData()))
+    return E;
+
+  return Error::success();
+}
+
 int llvm::TableGenMain(ArrayRef<const char *> Args, TableGenMainFn *MainFn) {
   assert(!Args.empty() && "Missing argv0!");
-  return reportError(Args[0], TableGenMainImpl(MainFn));
+  if (!Depscan)
+    return TableGenMain(Args[0], MainFn);
+
+  TableGenCache Cache;
+  if (Error E =
+          MappedPrefix::transformJoined(DepscanPrefixMap, Cache.PrefixMappings))
+    return reportError(Args[0], std::move(E));
+
+  if (Error E = Cache.lookupCachedResult(Args))
+    return reportError(Args[0], std::move(E));
+
+  Error E = Cache.computeResult(MainFn);
+  return reportError(Args[0], std::move(E));
 }

--- a/llvm/lib/TableGen/ScanDependencies.cpp
+++ b/llvm/lib/TableGen/ScanDependencies.cpp
@@ -1,0 +1,265 @@
+//===- ScanDependencies.cpp - TableGen scan-deps implementation -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/TableGen/ScanDependencies.h"
+#include "llvm/CAS/CachingOnDiskFileSystem.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/PrefixMapper.h"
+
+using namespace llvm;
+using namespace llvm::tablegen;
+
+void tablegen::flattenStrings(ArrayRef<StringRef> List,
+                              SmallVectorImpl<char> &Flattened) {
+  for (StringRef Name : List) {
+    Flattened.append(Name.begin(), Name.end());
+    Flattened.push_back(0);
+  }
+}
+
+void tablegen::splitFlattenedStrings(StringRef Flattened,
+                                     SmallVectorImpl<StringRef> &List) {
+  while (!Flattened.empty()) {
+    auto Null = Flattened.find(0);
+    // FIXME: Return an error, or bail out and try uncached?
+    assert(Null != StringRef::npos &&
+           "Expected valid list of null-terminated includes");
+    List.push_back(Flattened.take_front(Null));
+    Flattened = Flattened.drop_front(Null + 1);
+  }
+}
+
+void tablegen::scanTextForIncludes(StringRef Input,
+                                   SmallVectorImpl<StringRef> &Includes) {
+  constexpr StringLiteral Keyword = "include";
+  SmallString<256> ResultToCache;
+  for (auto I = Input.find(Keyword); I != StringRef::npos;
+       I = Input.find(Keyword)) {
+    // Check (non-exhaustively!) if we can skip this match because it's part of
+    // a longer identifier.
+    bool Skip = I > 0 && (isalpha(Input[I - 1]) || isdigit(Input[I - 1]));
+    Input = Input.drop_front(I + Keyword.size());
+    if (Input.size() < 3 || Skip)
+      return;
+    auto Pos = Input.find_first_not_of(" \t\v\r\n");
+    if (Pos == StringRef::npos)
+      return;
+    {
+      auto Q = Input[Pos];
+      Input = Input.drop_front(Pos + 1);
+      if (Q != '"')
+        continue;
+    }
+
+    // Assume that tablegen files don't have escaped quotes in their
+    // filenames.
+    Pos = Input.find_first_of("\r\n\"");
+    if (Pos == StringRef::npos)
+      return;
+    StringRef Name = Input.take_front(Pos);
+    {
+      auto Q = Input[Pos];
+      Input = Input.drop_front(Pos + 1);
+      if (Q != '"')
+        continue;
+    }
+
+    Includes.push_back(Name);
+  }
+}
+
+static Error
+fetchCachedIncludedFiles(cas::CASDB &CAS, cas::CASID ID,
+                         SmallVectorImpl<StringRef> &IncludedFiles) {
+  Expected<cas::BlobRef> ExpectedBlob = CAS.getBlob(ID);
+  if (!ExpectedBlob)
+    return ExpectedBlob.takeError();
+  splitFlattenedStrings(ExpectedBlob->getData(), IncludedFiles);
+  return Error::success();
+}
+
+static Error computeIncludedFiles(cas::CASDB &CAS, cas::CASID Key,
+                                  StringRef Input,
+                                  SmallVectorImpl<StringRef> &IncludedFiles) {
+  SmallString<256> ResultToCache;
+  scanTextForIncludes(Input, IncludedFiles);
+  flattenStrings(IncludedFiles, ResultToCache);
+
+  Expected<cas::BlobRef> ExpectedResult = CAS.createBlob(ResultToCache);
+  if (!ExpectedResult)
+    return ExpectedResult.takeError();
+  if (Error E = CAS.putCachedResult(Key, *ExpectedResult))
+    return E;
+  return Error::success();
+}
+
+Error tablegen::scanTextForIncludes(cas::CASDB &CAS, cas::CASID ExecID,
+                                    const cas::BlobRef &Blob,
+                                    SmallVectorImpl<StringRef> &Includes) {
+  constexpr StringLiteral CacheKeyData = "llvm::tablegen::scanTextForIncludes";
+
+  Expected<cas::NodeRef> Key = CAS.createNode({ExecID, Blob}, CacheKeyData);
+  if (!Key)
+    return Key.takeError();
+
+  if (Optional<cas::CASID> ResultID =
+          expectedToOptional(CAS.getCachedResult(*Key)))
+    return fetchCachedIncludedFiles(CAS, *ResultID, Includes);
+  return computeIncludedFiles(CAS, *Key, Blob.getData(), Includes);
+}
+
+Optional<cas::CASID>
+tablegen::lookupIncludeID(cas::CachingOnDiskFileSystem &FS,
+                          ArrayRef<std::string> IncludeDirs,
+                          StringRef Filename) {
+  SmallString<256> Path;
+  Optional<cas::CASID> ID;
+  if (!FS.statusAndFileID(Filename, ID).getError())
+    return ID;
+  for (StringRef Dir : IncludeDirs) {
+    // Match path logic from SourceMgr::AddIncludeFile.
+    Path.assign(Dir);
+    Path.append(sys::path::get_separator());
+    Path.append(Filename);
+    if (!FS.statusAndFileID(Path, ID).getError())
+      return ID;
+  }
+  return ID;
+}
+
+Error tablegen::accessAllIncludes(cas::CachingOnDiskFileSystem &FS,
+                                  cas::CASID ExecID,
+                                  ArrayRef<std::string> IncludeDirs,
+                                  const cas::BlobRef &MainFileBlob) {
+  cas::CASDB &CAS = FS.getCAS();
+
+  // Helper for adding to the worklist.
+  SmallVector<cas::BlobRef> Worklist = {MainFileBlob};
+  SmallDenseSet<cas::CASID, 16> Seen;
+  Seen.insert(MainFileBlob);
+  auto push = [&Seen, &Worklist, &CAS](cas::CASID ID) -> Error {
+    if (!Seen.insert(ID).second)
+      return Error::success();
+
+    Expected<cas::BlobRef> Blob = CAS.getBlob(ID);
+    if (!Blob)
+      return Blob.takeError();
+    Worklist.push_back(*Blob);
+    return Error::success();
+  };
+
+  // Find an overapproximation of 'include' directives.
+  SmallVector<StringRef> IncludedFiles;
+  while (!Worklist.empty()) {
+    IncludedFiles.clear();
+    if (Error E = scanTextForIncludes(CAS, ExecID, Worklist.pop_back_val(),
+                                      IncludedFiles))
+      return E;
+
+    // Add included files to the worklist. Ignore files not found, since the
+    // fuzzy search above could have found commented out includes.
+    for (StringRef IncludedFile : IncludedFiles)
+      if (Optional<cas::CASID> ID =
+              lookupIncludeID(FS, IncludeDirs, IncludedFile))
+        if (Error E = push(*ID))
+          return E;
+  }
+  return Error::success();
+}
+
+static Expected<cas::BlobRef> openMainFile(cas::CachingOnDiskFileSystem &FS,
+                                           StringRef MainFilename) {
+  cas::CASDB &CAS = FS.getCAS();
+
+  // FIXME: FileSystem should virtualize stdin.
+  if (MainFilename == "-") {
+    // Get stdin, then add it to the CAS.
+    ErrorOr<std::unique_ptr<MemoryBuffer>> MaybeFile = MemoryBuffer::getSTDIN();
+    if (!MaybeFile)
+      return createMainFileError(MainFilename, MaybeFile.getError());
+    return CAS.createBlob((**MaybeFile).getBuffer());
+  }
+
+  Optional<cas::CASID> MainFileID;
+  if (std::error_code EC =
+          FS.statusAndFileID(MainFilename, MainFileID).getError())
+    return createMainFileError(MainFilename, EC);
+  return CAS.getBlob(*MainFileID);
+}
+
+Error tablegen::createMainFileError(StringRef MainFilename,
+                                    std::error_code EC) {
+  assert(EC && "Expected error");
+  return createStringError(EC, "Could not open input file '" + MainFilename +
+                                   "': " + EC.message());
+}
+
+Expected<ScanIncludesResult> tablegen::scanIncludes(
+    cas::CASDB &CAS, cas::CASID ExecID, StringRef MainFilename,
+    ArrayRef<std::string> IncludeDirs, ArrayRef<MappedPrefix> PrefixMappings,
+    Optional<RealPathPrefixMapper> *CapturedPM) {
+  IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS;
+  if (Error E = cas::createCachingOnDiskFileSystem(CAS).moveInto(FS))
+    return std::move(E);
+
+  FS->trackNewAccesses();
+  Expected<cas::BlobRef> MainBlob = openMainFile(*FS, MainFilename);
+  if (!MainBlob)
+    return MainBlob.takeError();
+
+  // Helper for adding to the worklist.
+  if (Error E = accessAllIncludes(*FS, ExecID, IncludeDirs, *MainBlob))
+    return std::move(E);
+
+  BumpPtrAllocator Alloc;
+  StringSaver Saver(Alloc);
+  Optional<RealPathPrefixMapper> LocalPM;
+  Optional<RealPathPrefixMapper> &PM = CapturedPM ? *CapturedPM : LocalPM;
+  if (!PrefixMappings.empty()) {
+    PM.emplace(FS, Saver);
+    if (Error E = PM->addRange(PrefixMappings))
+      return std::move(E);
+    PM->sort();
+  }
+
+  Expected<cas::TreeRef> Tree = FS->createTreeFromNewAccesses(
+      [&](StringRef Path) { return PM ? PM->mapOrOriginal(Path) : Path; });
+  if (!Tree)
+    return Tree.takeError();
+
+  return ScanIncludesResult{*Tree, *MainBlob};
+}
+
+Expected<ScanIncludesResult>
+tablegen::scanIncludesAndRemap(cas::CASDB &CAS, cas::CASID ExecID,
+                               std::string &MainFilename,
+                               std::vector<std::string> &IncludeDirs,
+                               ArrayRef<MappedPrefix> PrefixMappings) {
+  Optional<RealPathPrefixMapper> PM;
+  auto Result =
+      scanIncludes(CAS, ExecID, MainFilename, IncludeDirs, PrefixMappings, &PM);
+  if (!Result)
+    return Result.takeError();
+
+  if (!PM)
+    return Result;
+
+  // Remap the main filename. Since it was already loaded and should be cached
+  // by the filesystem, an error here would be most surprising.
+  if (Error E = PM->mapInPlace(MainFilename))
+    return std::move(E);
+
+  // Remap includes and strip invalid ones. If there have been no includes,
+  // it's possible these will be new accesses, but they won't be needed anyway.
+  // Clear and erase them.
+  for (std::string &Dir : IncludeDirs)
+    PM->mapInPlaceOrClear(Dir);
+  llvm::erase_value(IncludeDirs, "");
+
+  return Result;
+}

--- a/llvm/unittests/Support/CMakeLists.txt
+++ b/llvm/unittests/Support/CMakeLists.txt
@@ -62,6 +62,7 @@ add_llvm_unittest(SupportTests
   OutputBackendTest.cpp
   ParallelTest.cpp
   Path.cpp
+  PrefixMapperTest.cpp
   ProcessTest.cpp
   ProgramTest.cpp
   RegexTest.cpp

--- a/llvm/unittests/Support/ErrorTest.cpp
+++ b/llvm/unittests/Support/ErrorTest.cpp
@@ -1031,4 +1031,71 @@ TEST(Error, SubtypeStringErrorTest) {
             0);
 }
 
+static Error createAnyError() {
+  return errorCodeToError(test_error_code::unspecified);
+}
+
+struct MoveOnlyBox {
+  Optional<int> Box;
+
+  explicit MoveOnlyBox(int I) : Box(I) {}
+  MoveOnlyBox() = default;
+  MoveOnlyBox(MoveOnlyBox &&) = default;
+  MoveOnlyBox &operator=(MoveOnlyBox &&) = default;
+
+  MoveOnlyBox(const MoveOnlyBox &) = delete;
+  MoveOnlyBox &operator=(const MoveOnlyBox &) = delete;
+
+  bool operator==(const MoveOnlyBox &RHS) const {
+    if (bool(Box) != bool(RHS.Box))
+      return false;
+    return Box ? *Box == *RHS.Box : false;
+  }
+};
+
+TEST(Error, moveInto) {
+  // Use MoveOnlyBox as the T in Expected<T>.
+  auto make = [](int I) -> Expected<MoveOnlyBox> { return MoveOnlyBox(I); };
+  auto makeFailure = []() -> Expected<MoveOnlyBox> { return createAnyError(); };
+
+  {
+    MoveOnlyBox V;
+
+    // Failure with no prior value.
+    EXPECT_THAT_ERROR(makeFailure().moveInto(V), Failed());
+    EXPECT_EQ(None, V.Box);
+
+    // Success with no prior value.
+    EXPECT_THAT_ERROR(make(5).moveInto(V), Succeeded());
+    EXPECT_EQ(5, V.Box);
+
+    // Success with an existing value.
+    EXPECT_THAT_ERROR(make(7).moveInto(V), Succeeded());
+    EXPECT_EQ(7, V.Box);
+
+    // Failure with an existing value. Might be nice to assign a
+    // default-constructed value in this case, but for now it's being left
+    // alone.
+    EXPECT_THAT_ERROR(makeFailure().moveInto(V), Failed());
+    EXPECT_EQ(7, V.Box);
+  }
+
+  // Check that this works with optionals too.
+  {
+    // Same cases as above.
+    Optional<MoveOnlyBox> MaybeV;
+    EXPECT_THAT_ERROR(makeFailure().moveInto(MaybeV), Failed());
+    EXPECT_EQ(None, MaybeV);
+
+    EXPECT_THAT_ERROR(make(5).moveInto(MaybeV), Succeeded());
+    EXPECT_EQ(MoveOnlyBox(5), MaybeV);
+
+    EXPECT_THAT_ERROR(make(7).moveInto(MaybeV), Succeeded());
+    EXPECT_EQ(MoveOnlyBox(7), MaybeV);
+
+    EXPECT_THAT_ERROR(makeFailure().moveInto(MaybeV), Failed());
+    EXPECT_EQ(MoveOnlyBox(7), MaybeV);
+  }
+}
+
 } // namespace

--- a/llvm/unittests/Support/PrefixMapperTest.cpp
+++ b/llvm/unittests/Support/PrefixMapperTest.cpp
@@ -1,0 +1,595 @@
+//===- unittests/Support/PrefixMapperTest.cpp - Prefix Mapper tests -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/PrefixMapper.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/Support/VirtualFileSystem.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+namespace llvm {
+static inline void PrintTo(const MappedPrefix &P, std::ostream *OS) {
+  *OS << ::testing::PrintToString(P.Old.str() + "=" + P.New.str());
+}
+} // end namespace llvm
+
+namespace {
+
+TEST(MappedPrefixTest, getInverse) {
+  EXPECT_EQ((MappedPrefix{"b", "a"}), (MappedPrefix{"a", "b"}).getInverse());
+  EXPECT_EQ((MappedPrefix{"a", "b"}), (MappedPrefix{"b", "a"}).getInverse());
+}
+
+TEST(MappedPrefixTest, getFromJoined) {
+  auto split = MappedPrefix::getFromJoined;
+  EXPECT_EQ(None, split(""));
+  EXPECT_EQ(None, split("a"));
+  EXPECT_EQ(None, split("abc"));
+  EXPECT_EQ((MappedPrefix{"", ""}), split("="));
+  EXPECT_EQ((MappedPrefix{"a", ""}), split("a="));
+  EXPECT_EQ((MappedPrefix{"", "b"}), split("=b"));
+  EXPECT_EQ((MappedPrefix{"a", "b"}), split("a=b"));
+  EXPECT_EQ((MappedPrefix{"abc", "def"}), split("abc=def"));
+  EXPECT_EQ((MappedPrefix{"", "="}), split("=="));
+  EXPECT_EQ((MappedPrefix{"a", "b=c"}), split("a=b=c"));
+}
+
+TEST(MappedPrefixTest, transformJoined) {
+  SmallVector<std::string> JoinedStrings = {
+      "=", "a=", "=b", "a=b", "abc=def", "==", "a=b=c",
+  };
+  SmallVector<StringRef> JoinedRefs(JoinedStrings.begin(), JoinedStrings.end());
+
+  MappedPrefix ExpectedSplit[] = {
+      MappedPrefix{"", ""},       MappedPrefix{"a", ""},
+      MappedPrefix{"", "b"},      MappedPrefix{"a", "b"},
+      MappedPrefix{"abc", "def"}, MappedPrefix{"", "="},
+      MappedPrefix{"a", "b=c"},
+  };
+
+  SmallVector<MappedPrefix> ComputedSplit;
+  MappedPrefix::transformJoinedIfValid(JoinedStrings, ComputedSplit);
+  EXPECT_EQ(makeArrayRef(ExpectedSplit), makeArrayRef(ComputedSplit));
+
+  ComputedSplit.clear();
+  MappedPrefix::transformJoinedIfValid(JoinedRefs, ComputedSplit);
+  EXPECT_EQ(makeArrayRef(ExpectedSplit), makeArrayRef(ComputedSplit));
+}
+
+TEST(MappedPrefixTest, transformJoinedError) {
+  SmallVector<std::string> JoinedStrings = {
+      "old=new",
+      "middle",
+      "old-again=new-again",
+      "after",
+  };
+  SmallVector<StringRef> JoinedRefs(JoinedStrings.begin(), JoinedStrings.end());
+
+  SmallVector<MappedPrefix> Split;
+  EXPECT_THAT_ERROR(MappedPrefix::transformJoined(JoinedStrings, Split),
+                    FailedWithMessage("invalid prefix map: 'middle'"));
+  ASSERT_EQ(0u, Split.size());
+  EXPECT_THAT_ERROR(MappedPrefix::transformJoined(JoinedRefs, Split),
+                    FailedWithMessage("invalid prefix map: 'middle'"));
+  ASSERT_EQ(0u, Split.size());
+}
+
+TEST(MappedPrefixTest, transformJoinedIfValid) {
+  SmallVector<std::string> JoinedStrings = {
+      "", "a", "abc", "=", "a=", "=b", "a=b", "abc=def", "==", "a=b=c",
+  };
+  SmallVector<StringRef> JoinedRefs(JoinedStrings.begin(), JoinedStrings.end());
+
+  MappedPrefix ExpectedSplit[] = {
+      MappedPrefix{"", ""},       MappedPrefix{"a", ""},
+      MappedPrefix{"", "b"},      MappedPrefix{"a", "b"},
+      MappedPrefix{"abc", "def"}, MappedPrefix{"", "="},
+      MappedPrefix{"a", "b=c"},
+  };
+
+  SmallVector<MappedPrefix> ComputedSplit;
+  MappedPrefix::transformJoinedIfValid(JoinedStrings, ComputedSplit);
+  EXPECT_EQ(makeArrayRef(ExpectedSplit), makeArrayRef(ComputedSplit));
+
+  ComputedSplit.clear();
+  MappedPrefix::transformJoinedIfValid(JoinedRefs, ComputedSplit);
+  EXPECT_EQ(makeArrayRef(ExpectedSplit), makeArrayRef(ComputedSplit));
+}
+
+TEST(PrefixMapperTest, construct) {
+  BumpPtrAllocator Alloc;
+  StringSaver Saver(Alloc);
+  for (auto PathStyle : {
+           sys::path::Style::posix,
+           sys::path::Style::windows,
+           sys::path::Style::native,
+       })
+    EXPECT_EQ(PathStyle, PrefixMapper(Saver, PathStyle).getPathStyle());
+}
+
+TEST(PrefixMapperTest, add) {
+  BumpPtrAllocator Alloc;
+  StringSaver Saver(Alloc);
+  PrefixMapper PM(Saver, sys::path::Style::posix);
+  PM.add(MappedPrefix{"a", "b"});
+  PM.add(MappedPrefix{"b", "a"});
+  ASSERT_EQ(2u, PM.getMappings().size());
+  ASSERT_EQ((MappedPrefix{"a", "b"}), PM.getMappings().front());
+  ASSERT_EQ((MappedPrefix{"b", "a"}), PM.getMappings().back());
+}
+
+TEST(PrefixMapperTest, addRange) {
+  BumpPtrAllocator Alloc;
+  StringSaver Saver(Alloc);
+  PrefixMapper PM(Saver, sys::path::Style::posix);
+
+  PM.add(MappedPrefix{"/old/before", "/new/before"});
+  MappedPrefix Range[] = {
+      {"/old/1", "/new/1"},
+      {"/old/2", "/new/2"},
+      {"/old/3", "/new/3"},
+  };
+  auto RangeRef = makeArrayRef(Range);
+  PM.addRange(RangeRef);
+  PM.add(MappedPrefix{"/old/after", "/new/after"});
+
+  ASSERT_EQ(2u + RangeRef.size(), PM.getMappings().size());
+  EXPECT_EQ((MappedPrefix{"/old/before", "/new/before"}),
+            PM.getMappings().front());
+  EXPECT_EQ((MappedPrefix{"/old/after", "/new/after"}),
+            PM.getMappings().back());
+  EXPECT_EQ(RangeRef, PM.getMappings().drop_front().drop_back());
+}
+
+static void checkPosix(sys::path::Style PathStyle) {
+  BumpPtrAllocator Alloc;
+  StringSaver Saver(Alloc);
+  PrefixMapper PM(Saver, PathStyle);
+  MappedPrefix Mappings[] = {
+      // Simple mappings.
+      {"/old", "/new"},
+      {"/shorter", "/this/is/longer"},
+      {"/from/longer", "/shorter"},
+      {"relative/old", "relative/new"},
+
+      // Confirm that non-directory matches are skipped correctly.
+      {"/old-almost", "/new-other"},
+
+      // Confirm mappings don't run twice by adding a mapping that would rerun
+      // on "/new".
+      {"/new/reenter-check", "/reentered"},
+  };
+  PM.addRange(makeArrayRef(Mappings));
+
+  // Not caught by anything.
+  EXPECT_EQ("", PM.map(""));
+  EXPECT_EQ("/x", PM.map("/x"));
+  EXPECT_EQ("/new", PM.map("/new"));
+  EXPECT_EQ("/new/nested", PM.map("/new/nested"));
+  EXPECT_EQ("/old-in-prefix", PM.map("/old-in-prefix"));
+
+  // Caught by simple mappings.
+  EXPECT_EQ("/new", PM.map("/old"));
+  EXPECT_EQ("/new/", PM.map("/old/"));
+  EXPECT_EQ("/new/a", PM.map("/old/a"));
+  EXPECT_EQ("/new/../x/y", PM.map("/old/../x/y"));
+  EXPECT_EQ("relative/new", PM.map("relative/old"));
+  EXPECT_EQ("/this/is/longer", PM.map("/shorter"));
+  EXPECT_EQ("/this/is/longer/a", PM.map("/shorter/a"));
+  EXPECT_EQ("/this/is/longer/with/long/nested/file",
+            PM.map("/shorter/with/long/nested/file"));
+  EXPECT_EQ("/shorter", PM.map("/from/longer"));
+  EXPECT_EQ("/shorter/a", PM.map("/from/longer/a"));
+  EXPECT_EQ("/shorter/with/long/nested/file",
+            PM.map("/from/longer/with/long/nested/file"));
+
+  // Check that "/old" doesn't catch "/old-almost".
+  EXPECT_EQ("/new-other", PM.map("/old-almost"));
+  EXPECT_EQ("/new-other/a", PM.map("/old-almost/a"));
+}
+
+TEST(PrefixMapperTest, mapPosix) { checkPosix(sys::path::Style::posix); }
+
+static void checkWindows(sys::path::Style PathStyle) {
+  BumpPtrAllocator Alloc;
+  StringSaver Saver(Alloc);
+  PrefixMapper PM(Saver, PathStyle);
+  MappedPrefix Mappings[] = {
+      // Simple mappings.
+      {"c:\\old", "c:\\new"},
+      {"C:\\UPPER\\old", "c:\\UPPER\\new"},
+      {"c:/forward/old", "C:/forward/new"},
+      {"c:\\shorter", "c:\\this\\is\\longer"},
+      {"c:\\from\\longer", "c:\\shorter"},
+      {"relative\\old", "relative\\new"},
+
+      // Confirm that non-directory matches are remapped correctly.
+      {"c:\\old-almost", "c:\\new-other"},
+
+      // Confirm mappings don't run twice, just the first that matches.
+      {"c:\\new\\reenter-check", "c:\\reentered"},
+  };
+  PM.addRange(makeArrayRef(Mappings));
+
+  // Not caught by anything.
+  EXPECT_EQ("", PM.map(""));
+  EXPECT_EQ("c:\\x", PM.map("c:\\x"));
+  EXPECT_EQ("c:\\new", PM.map("c:\\new"));
+  EXPECT_EQ("c:\\new\\nested", PM.map("c:\\new\\nested"));
+  EXPECT_EQ("c:\\old-in-prefix", PM.map("c:\\old-in-prefix"));
+
+  // Caught by simple mappings.
+  EXPECT_EQ("c:\\new", PM.map("c:\\old"));
+  EXPECT_EQ("c:\\new", PM.map("C:\\old"));
+  EXPECT_EQ("c:\\new\\", PM.map("c:\\old\\"));
+  EXPECT_EQ("c:\\new\\a", PM.map("c:\\old\\a"));
+  EXPECT_EQ("c:\\new\\a", PM.map("C:\\old\\a"));
+  EXPECT_EQ("c:\\new\\..\\x\\y", PM.map("c:\\old\\..\\x\\y"));
+  EXPECT_EQ("c:\\UPPER\\new", PM.map("C:\\UPPER\\old"));
+  EXPECT_EQ("C:/forward/new", PM.map("C:/forward/old"));
+  EXPECT_EQ("C:/forward/new\\x/y", PM.map("C:/forward/old/x/y"));
+  EXPECT_EQ("relative\\new", PM.map("relative\\old"));
+  EXPECT_EQ("c:\\this\\is\\longer", PM.map("c:\\shorter"));
+  EXPECT_EQ("c:\\this\\is\\longer\\a", PM.map("c:\\shorter\\a"));
+  EXPECT_EQ("c:\\this\\is\\longer\\with\\long\\nested\\file",
+            PM.map("c:\\shorter\\with\\long\\nested\\file"));
+  EXPECT_EQ("c:\\shorter", PM.map("c:\\from\\longer"));
+  EXPECT_EQ("c:\\shorter\\a", PM.map("c:\\from\\longer\\a"));
+  EXPECT_EQ("c:\\shorter\\with\\long\\nested\\file",
+            PM.map("c:\\from\\longer\\with\\long\\nested\\file"));
+
+  // Check that "\\old" doesn't catch "\\old-almost".
+  EXPECT_EQ("c:\\new-other", PM.map("c:\\old-almost"));
+  EXPECT_EQ("c:\\new-other\\a", PM.map("c:\\old-almost\\a"));
+}
+
+TEST(PrefixMapperTest, mapWindows) { checkWindows(sys::path::Style::windows); }
+
+TEST(PrefixMapperTest, mapNative) {
+  if (sys::path::system_style() == sys::path::Style::posix)
+    checkPosix(sys::path::Style::native);
+  else
+    checkWindows(sys::path::Style::native);
+}
+
+TEST(PrefixMapperTest, mapTwoArgs) {
+  BumpPtrAllocator Alloc;
+  StringSaver Saver(Alloc);
+  PrefixMapper PM(Saver, sys::path::Style::posix);
+  MappedPrefix Mappings[] = {{"/old", "/new"}};
+  PM.addRange(makeArrayRef(Mappings));
+
+  MappedPrefix Tests[] = {
+      {"/old", "/new"},     {"/old/x/y", "/new/x/y"},
+      {"/old", "/new"},     {"relative/path", "relative/path"},
+      {"/other", "/other"},
+  };
+
+  SmallString<128> OutputV;
+  std::string OutputS;
+  for (MappedPrefix M : Tests) {
+    PM.map(M.Old, OutputV);
+    PM.map(M.Old, OutputS);
+    EXPECT_EQ(M.New, OutputV);
+    EXPECT_EQ(M.New, OutputS);
+  }
+}
+
+TEST(PrefixMapperTest, mapToString) {
+  BumpPtrAllocator Alloc;
+  StringSaver Saver(Alloc);
+  PrefixMapper PM(Saver, sys::path::Style::posix);
+  MappedPrefix Mappings[] = {{"/old", "/new"}};
+  PM.addRange(makeArrayRef(Mappings));
+
+  MappedPrefix Tests[] = {
+      {"/old", "/new"},     {"/old/x/y", "/new/x/y"},
+      {"/old", "/new"},     {"relative/path", "relative/path"},
+      {"/other", "/other"},
+  };
+
+  SmallString<128> Output;
+  for (MappedPrefix M : Tests) {
+    std::string S = PM.mapToString(M.Old);
+    EXPECT_EQ(M.New, S);
+  }
+}
+
+TEST(PrefixMapperTest, mapInPlace) {
+  BumpPtrAllocator Alloc;
+  StringSaver Saver(Alloc);
+  PrefixMapper PM(Saver, sys::path::Style::posix);
+  MappedPrefix Mappings[] = {{"/old", "/new"}};
+  PM.addRange(makeArrayRef(Mappings));
+
+  MappedPrefix Tests[] = {
+      {"/old", "/new"},     {"/old/x/y", "/new/x/y"},
+      {"/old", "/new"},     {"relative/path", "relative/path"},
+      {"/other", "/other"},
+  };
+
+  SmallString<128> V;
+  std::string S;
+  for (MappedPrefix M : Tests) {
+    V = M.Old;
+    S = M.Old.str();
+    PM.mapInPlace(V);
+    PM.mapInPlace(S);
+    EXPECT_EQ(M.New, V);
+    EXPECT_EQ(M.New, S);
+  }
+}
+
+class GetRealPathFileSystem : public vfs::FileSystem {
+public:
+  ErrorOr<vfs::Status> status(const Twine &) override {
+    return make_error_code(std::errc::operation_not_permitted);
+  }
+  vfs::directory_iterator dir_begin(const Twine &,
+                                    std::error_code &EC) override {
+    EC = make_error_code(std::errc::operation_not_permitted);
+    return vfs::directory_iterator();
+  }
+  std::error_code setCurrentWorkingDirectory(const Twine &) override {
+    return make_error_code(std::errc::operation_not_permitted);
+  }
+  ErrorOr<std::string> getCurrentWorkingDirectory() const override {
+    return make_error_code(std::errc::operation_not_permitted);
+  }
+  ErrorOr<std::unique_ptr<vfs::File>> openFileForRead(const Twine &) override {
+    return make_error_code(std::errc::operation_not_permitted);
+  }
+
+  std::error_code getRealPath(const Twine &Path,
+                              SmallVectorImpl<char> &Output) const override {
+    auto I = RealPaths.find(Path.str());
+    if (I == RealPaths.end())
+      return make_error_code(std::errc::no_such_file_or_directory);
+    Output.assign(I->second.begin(), I->second.end());
+    return std::error_code{};
+  }
+
+  StringMap<std::string> RealPaths = {
+      {"relative", "/real/path/1"},
+      {"relative/", "/real/path/1"},
+      {"symlink/to/relative", "/real/path/1"},
+      {"relative/nested", "/real/path/1/nested"},
+      {"symlink/to/relative/nested", "/real/path/1/nested"},
+      {"/real/path/1", "/real/path/1"},
+      {"/real/path/1/", "/real/path/1"},
+      {"/real/path/1/nested", "/real/path/1/nested"},
+      {"/absolute", "/real/path/2"},
+      {"/absolute/", "/real/path/2"},
+      {"/absolute/nested", "/real/path/2/nested"},
+      {"/real/path/2", "/real/path/2"},
+      {"/real/path/2/", "/real/path/2"},
+      {"/real/path/2/nested", "/real/path/2/nested"},
+  };
+};
+
+TEST(RealPathPrefixMapperTest, construct) {
+  BumpPtrAllocator Alloc;
+  StringSaver Saver(Alloc);
+  auto FS = makeIntrusiveRefCnt<GetRealPathFileSystem>();
+
+  for (auto PathStyle : {
+           sys::path::Style::posix,
+           sys::path::Style::windows,
+           sys::path::Style::native,
+       }) {
+    EXPECT_EQ(PathStyle,
+              RealPathPrefixMapper(FS, Saver, PathStyle).getPathStyle());
+  }
+}
+
+TEST(RealPathPrefixMapperTest, add) {
+  BumpPtrAllocator Alloc;
+  StringSaver Saver(Alloc);
+  auto FS = makeIntrusiveRefCnt<GetRealPathFileSystem>();
+  RealPathPrefixMapper PM(FS, Saver);
+
+  EXPECT_THAT_ERROR(PM.add(MappedPrefix{"relative", "/new1"}), Succeeded());
+  EXPECT_THAT_ERROR(PM.add(MappedPrefix{"/absolute", "/new2"}), Succeeded());
+  ASSERT_EQ(2u, PM.getMappings().size());
+  EXPECT_EQ((MappedPrefix{"/real/path/1", "/new1"}), PM.getMappings().front());
+  EXPECT_EQ((MappedPrefix{"/real/path/2", "/new2"}), PM.getMappings().back());
+
+  EXPECT_THAT_ERROR(PM.add(MappedPrefix{"missing", "/new"}), Failed());
+  EXPECT_EQ(2u, PM.getMappings().size());
+}
+
+TEST(RealPathPrefixMapperTest, addRange) {
+  BumpPtrAllocator Alloc;
+  StringSaver Saver(Alloc);
+  auto FS = makeIntrusiveRefCnt<GetRealPathFileSystem>();
+  RealPathPrefixMapper PM(FS, Saver);
+
+  MappedPrefix BadMapping[] = {
+      {"missing", "/new"},
+  };
+  MappedPrefix Mappings[] = {
+      {"relative", "/new1"},
+      {"/absolute", "/new2"},
+  };
+  EXPECT_THAT_ERROR(PM.addRange(makeArrayRef(Mappings)), Succeeded());
+  ASSERT_EQ(2u, PM.getMappings().size());
+  EXPECT_EQ((MappedPrefix{"/real/path/1", "/new1"}), PM.getMappings().front());
+  EXPECT_EQ((MappedPrefix{"/real/path/2", "/new2"}), PM.getMappings().back());
+
+  EXPECT_THAT_ERROR(PM.addRange(makeArrayRef(BadMapping)), Failed());
+  EXPECT_EQ(2u, PM.getMappings().size());
+}
+
+TEST(RealPathPrefixMapperTest, addRangeIfValid) {
+  BumpPtrAllocator Alloc;
+  StringSaver Saver(Alloc);
+  auto FS = makeIntrusiveRefCnt<GetRealPathFileSystem>();
+  RealPathPrefixMapper PM(FS, Saver);
+
+  MappedPrefix Mappings[] = {
+      {"missing-before", "/new"}, {"relative", "/new1"},
+      {"missing", "/new"},        {"/absolute", "/new2"},
+      {"missing-after", "/new"},
+  };
+  PM.addRangeIfValid(makeArrayRef(Mappings));
+  ASSERT_EQ(2u, PM.getMappings().size());
+  EXPECT_EQ((MappedPrefix{"/real/path/1", "/new1"}), PM.getMappings().front());
+  EXPECT_EQ((MappedPrefix{"/real/path/2", "/new2"}), PM.getMappings().back());
+}
+
+TEST(RealPathPrefixMapperTest, addInverseRange) {
+  BumpPtrAllocator Alloc;
+  StringSaver Saver(Alloc);
+  auto FS = makeIntrusiveRefCnt<GetRealPathFileSystem>();
+  RealPathPrefixMapper PM(FS, Saver);
+
+  MappedPrefix BadMapping[] = {
+      {"/new", "missing"},
+  };
+  MappedPrefix Mappings[] = {
+      {"/new1", "relative"},
+      {"/new2", "/absolute"},
+  };
+  EXPECT_THAT_ERROR(PM.addInverseRange(makeArrayRef(Mappings)), Succeeded());
+  ASSERT_EQ(2u, PM.getMappings().size());
+  EXPECT_EQ((MappedPrefix{"/real/path/1", "/new1"}), PM.getMappings().front());
+  EXPECT_EQ((MappedPrefix{"/real/path/2", "/new2"}), PM.getMappings().back());
+
+  EXPECT_THAT_ERROR(PM.addInverseRange(makeArrayRef(BadMapping)), Failed());
+  EXPECT_EQ(2u, PM.getMappings().size());
+}
+
+TEST(RealPathPrefixMapperTest, addInverseRangeIfValid) {
+  BumpPtrAllocator Alloc;
+  StringSaver Saver(Alloc);
+  auto FS = makeIntrusiveRefCnt<GetRealPathFileSystem>();
+  RealPathPrefixMapper PM(FS, Saver);
+
+  MappedPrefix Mappings[] = {
+      {"/new", "missing-before"}, {"/new1", "relative"},
+      {"/new", "missing"},        {"/new2", "/absolute"},
+      {"/new", "missing-after"},
+  };
+  PM.addInverseRangeIfValid(makeArrayRef(Mappings));
+  ASSERT_EQ(2u, PM.getMappings().size());
+  EXPECT_EQ((MappedPrefix{"/real/path/1", "/new1"}), PM.getMappings().front());
+  EXPECT_EQ((MappedPrefix{"/real/path/2", "/new2"}), PM.getMappings().back());
+}
+
+struct MapState {
+  BumpPtrAllocator Alloc;
+  StringSaver Saver;
+  IntrusiveRefCntPtr<GetRealPathFileSystem> FS =
+      makeIntrusiveRefCnt<GetRealPathFileSystem>();
+  RealPathPrefixMapper PM;
+
+  SmallVector<MappedPrefix> Tests = {
+      {"relative", "/new1"},
+      {"relative/nested", "/new1/nested"},
+      {"symlink/to/relative", "/new1"},
+      {"symlink/to/relative/nested", "/new1/nested"},
+      {"/real/path/1", "/new1"},
+      {"/real/path/1/nested", "/new1/nested"},
+      {"/absolute", "/new2"},
+      {"/absolute/nested", "/new2/nested"},
+      {"/real/path/2", "/new2"},
+      {"/real/path/2/nested", "/new2/nested"},
+  };
+  SmallVector<StringRef> FailedTests = {"missing", "/missing", "/relative"};
+  MapState() : Saver(Alloc), PM(FS, Saver) {
+    EXPECT_THAT_ERROR(PM.add(MappedPrefix{"relative", "/new1"}), Succeeded());
+    EXPECT_THAT_ERROR(PM.add(MappedPrefix{"/absolute", "/new2"}), Succeeded());
+  }
+};
+
+TEST(RealPathPrefixMapperTest, map) {
+  MapState State;
+  ASSERT_EQ(2u, State.PM.getMappings().size());
+
+  SmallString<128> NotFoundV;
+  std::string NotFoundS;
+  SmallString<128> FoundV;
+  std::string FoundS;
+  for (StringRef S : State.FailedTests) {
+    FoundV = "";
+    FoundS = "";
+    EXPECT_THAT_EXPECTED(State.PM.map(S), Failed());
+    EXPECT_THAT_EXPECTED(State.PM.mapToString(S), Failed());
+    EXPECT_THAT_ERROR(State.PM.map(S, NotFoundV), Failed());
+    EXPECT_THAT_ERROR(State.PM.map(S, NotFoundS), Failed());
+    EXPECT_EQ("", NotFoundV);
+    EXPECT_EQ("", NotFoundS);
+    EXPECT_EQ(None, State.PM.mapOrNone(S));
+    EXPECT_EQ(None, State.PM.mapToStringOrNone(S));
+    EXPECT_EQ(S, State.PM.mapOrOriginal(S));
+
+    State.PM.mapOrOriginal(S, FoundV);
+    State.PM.mapOrOriginal(S, FoundS);
+    EXPECT_EQ(S, FoundV);
+    EXPECT_EQ(S, FoundS);
+  }
+
+  for (MappedPrefix Map : State.Tests) {
+    EXPECT_THAT_EXPECTED(State.PM.map(Map.Old), HasValue(Map.New));
+    EXPECT_THAT_EXPECTED(State.PM.mapToString(Map.Old), HasValue(Map.New));
+    EXPECT_THAT_ERROR(State.PM.map(Map.Old, FoundV), Succeeded());
+    EXPECT_THAT_ERROR(State.PM.map(Map.Old, FoundS), Succeeded());
+    EXPECT_EQ(Map.New, FoundV);
+    EXPECT_EQ(Map.New, FoundS);
+    EXPECT_EQ(Map.New, State.PM.mapOrNone(Map.Old));
+    EXPECT_EQ(Map.New.str(), State.PM.mapToStringOrNone(Map.Old));
+    EXPECT_EQ(Map.New, State.PM.mapOrOriginal(Map.Old));
+
+    FoundV = "";
+    FoundS = "";
+    State.PM.mapOrOriginal(Map.Old, FoundV);
+    State.PM.mapOrOriginal(Map.Old, FoundS);
+    EXPECT_EQ(Map.New, FoundV);
+    EXPECT_EQ(Map.New, FoundS);
+  }
+}
+
+TEST(RealPathPrefixMapperTest, mapInPlace) {
+  MapState State;
+  ASSERT_EQ(2u, State.PM.getMappings().size());
+
+  std::string FoundS;
+  SmallString<128> FoundV;
+  for (StringRef S : State.FailedTests) {
+    FoundS = S.str();
+    FoundV = S;
+    EXPECT_THAT_ERROR(State.PM.mapInPlace(FoundS), Failed());
+    EXPECT_THAT_ERROR(State.PM.mapInPlace(FoundV), Failed());
+    EXPECT_EQ(S, FoundS);
+    EXPECT_EQ(S, FoundV);
+    State.PM.mapInPlaceOrClear(FoundS);
+    State.PM.mapInPlaceOrClear(FoundV);
+    EXPECT_EQ("", FoundS);
+    EXPECT_EQ("", FoundV);
+  }
+
+  for (MappedPrefix Map : State.Tests) {
+    FoundS = Map.Old.str();
+    FoundV = Map.Old;
+    EXPECT_THAT_ERROR(State.PM.mapInPlace(FoundS), Succeeded());
+    EXPECT_THAT_ERROR(State.PM.mapInPlace(FoundV), Succeeded());
+    EXPECT_EQ(Map.New, FoundS);
+    EXPECT_EQ(Map.New, FoundV);
+
+    FoundS = Map.Old.str();
+    FoundV = Map.Old;
+    State.PM.mapInPlaceOrClear(FoundS);
+    State.PM.mapInPlaceOrClear(FoundV);
+    EXPECT_EQ(Map.New, FoundS);
+    EXPECT_EQ(Map.New, FoundV);
+  }
+}
+
+} // end namespace

--- a/llvm/unittests/TableGen/CMakeLists.txt
+++ b/llvm/unittests/TableGen/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LLVM_LINK_COMPONENTS
   TableGen
   Support
+  CAS
   )
 
 set(LLVM_TARGET_DEFINITIONS Automata.td)
@@ -12,6 +13,11 @@ add_public_tablegen_target(AutomataTestTableGen)
 add_llvm_unittest(TableGenTests DISABLE_LLVM_LINK_LLVM_DYLIB
   CodeExpanderTest.cpp
   AutomataTest.cpp
+  ScanDependenciesTest.cpp
   )
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../utils/TableGen)
-target_link_libraries(TableGenTests PRIVATE LLVMTableGenGlobalISel LLVMTableGen)
+target_link_libraries(TableGenTests PRIVATE
+  LLVMTableGenGlobalISel
+  LLVMTableGen
+  LLVMTestingSupport
+  )

--- a/llvm/unittests/TableGen/ScanDependenciesTest.cpp
+++ b/llvm/unittests/TableGen/ScanDependenciesTest.cpp
@@ -1,0 +1,129 @@
+//===- unittests/TableGen/ScanDependenciesTest.cpp - Test tblgen scandeps -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/TableGen/ScanDependencies.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::tablegen;
+
+namespace {
+
+TEST(ScanDependenciesTest, scanTextForIncludes) {
+  std::pair<StringRef, ArrayRef<StringRef>> Tests[] = {
+      {"", {}},
+      {"include \"file.td\"", {"file.td"}},
+      {"include\"file.td\"", {"file.td"}},
+      {"include\t\"file.td\"", {"file.td"}},
+      {"include\v\"file.td\"", {"file.td"}},
+      {"include\n\"file.td\"", {"file.td"}},
+      {"include\r\"file.td\"", {"file.td"}},
+      {"include \t\v\n\r\"file.td\"", {"file.td"}},
+      {"include \"file.td\"include \"file2.td\"", {"file.td", "file2.td"}},
+      {"include \"file.td\" include \"file2.td\"", {"file.td", "file2.td"}},
+      {"include \"file.td\"\ninclude \"file2.td\"\n", {"file.td", "file2.td"}},
+  };
+  for (auto T : Tests) {
+    SmallVector<StringRef> Includes;
+    scanTextForIncludes(T.first, Includes);
+    EXPECT_EQ(T, std::make_pair(T.first, makeArrayRef(Includes)));
+  }
+}
+
+TEST(ScanDependenciesTest, scanFuzzyIncludesNotStart) {
+  std::pair<StringRef, ArrayRef<StringRef>> Tests[] = {
+      {" include \"file.td\"", {"file.td"}},
+      {"    include \"file.td\"", {"file.td"}},
+      {";include \"file.td\"", {"file.td"}},
+      {"\tinclude \"file.td\"", {"file.td"}},
+      {"\vinclude \"file.td\"", {"file.td"}},
+      {"\ninclude \"file.td\"", {"file.td"}},
+      {"\rinclude \"file.td\"", {"file.td"}},
+      {"after things include \"file.td\"", {"file.td"}},
+      {"after things;include \"file.td\"", {"file.td"}},
+      {"after things\tinclude \"file.td\"", {"file.td"}},
+      {"after things\vinclude \"file.td\"", {"file.td"}},
+      {"after things\ninclude \"file.td\"", {"file.td"}},
+      {"after things\rinclude \"file.td\"", {"file.td"}},
+  };
+  for (auto T : Tests) {
+    SmallVector<StringRef> Includes;
+    scanTextForIncludes(T.first, Includes);
+    EXPECT_EQ(T, std::make_pair(T.first, makeArrayRef(Includes)));
+  }
+}
+
+TEST(ScanDependenciesTest, scanFuzzyIncludesSuffix) {
+  std::pair<StringRef, ArrayRef<StringRef>> Tests[] = {
+      {"include \"file.td\"\n", {"file.td"}},
+      {"include \"file.td\"\r", {"file.td"}},
+      {"include \"file.td\"\t", {"file.td"}},
+      {"include \"file.td\"\v", {"file.td"}},
+      {"include \"file.td\" ", {"file.td"}},
+      {"include \"file.td\"\"", {"file.td"}},
+      {"include \"file.td\"a", {"file.td"}},
+      {"include \"file.td\";", {"file.td"}},
+      {"include \"file.td\"'", {"file.td"}},
+  };
+  for (auto T : Tests) {
+    SmallVector<StringRef> Includes;
+    scanTextForIncludes(T.first, Includes);
+    EXPECT_EQ(T, std::make_pair(T.first, makeArrayRef(Includes)));
+  }
+}
+
+TEST(ScanDependenciesTest, scanFuzzyIncludesWithPrefix) {
+  // Don't recognize 'include' if it's not after an appropriate token?
+  std::pair<StringRef, ArrayRef<StringRef>> Tests[] = {
+      {"prefixinclude \"file.td\"", {}},
+      {"prefix0include \"file.td\"", {}},
+  };
+  for (auto T : Tests) {
+    SmallVector<StringRef> Includes;
+    scanTextForIncludes(T.first, Includes);
+    EXPECT_EQ(T, std::make_pair(T.first, makeArrayRef(Includes)));
+  }
+}
+
+TEST(ScanDependenciesTest, scanFuzzyIncludesComments) {
+  // It'd be nice to skip comments but the current fuzzy scan doesn't bother.
+  std::pair<StringRef, ArrayRef<StringRef>> Tests[] = {
+      {"// include \"file.td\"", {"file.td"}},
+      {"/* include \"file.td\"", {"file.td"}},
+      {"/* include \"file.td\" */", {"file.td"}},
+  };
+  for (auto T : Tests) {
+    SmallVector<StringRef> Includes;
+    scanTextForIncludes(T.first, Includes);
+    EXPECT_EQ(T, std::make_pair(T.first, makeArrayRef(Includes)));
+  }
+}
+
+TEST(ScanDependenciesTest, flattenStrings) {
+  std::pair<ArrayRef<StringRef>, StringRef> Tests[] = {
+      {{}, StringLiteral::withInnerNUL("")},
+      {{""}, StringLiteral::withInnerNUL("\0")},
+      {{"a"}, StringLiteral::withInnerNUL("a\0")},
+      {{"ab"}, StringLiteral::withInnerNUL("ab\0")},
+      {{"\n\n\n"}, StringLiteral::withInnerNUL("\n\n\n\0")},
+      {{"", "ab", "ab", "de", "cd", ""},
+       StringLiteral::withInnerNUL("\0ab\0ab\0de\0cd\0\0")},
+  };
+  for (auto T : Tests) {
+    SmallString<128> Flattened;
+    flattenStrings(T.first, Flattened);
+    EXPECT_EQ(T, std::make_pair(T.first, StringRef(Flattened)));
+
+    SmallVector<StringRef> Split;
+    splitFlattenedStrings(T.second, Split);
+    EXPECT_EQ(T, std::make_pair(makeArrayRef(Split), T.second));
+  }
+}
+
+} // end namespace

--- a/llvm/utils/TableGen/CMakeLists.txt
+++ b/llvm/utils/TableGen/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(GlobalISel)
 
-set(LLVM_LINK_COMPONENTS Support)
+set(LLVM_LINK_COMPONENTS Support CAS)
 
 add_tablegen(llvm-tblgen LLVM
   AsmMatcherEmitter.cpp

--- a/llvm/utils/TableGen/TableGen.cpp
+++ b/llvm/utils/TableGen/TableGen.cpp
@@ -282,7 +282,7 @@ int main(int argc, char **argv) {
   InitLLVM X(argc, argv);
   cl::ParseCommandLineOptions(argc, argv);
 
-  return TableGenMain(argv[0], &LLVMTableGenMain);
+  return TableGenMain(makeArrayRef(argv, argc), &LLVMTableGenMain);
 }
 
 #ifndef __has_feature


### PR DESCRIPTION
In git-log order:
- 63a48d5d2b7b TableGen: Add caching using the CAS
- 8076dd5f1e75 TableGen: Split out a TableGenImpl that does not need Argv0, NFC
- fe64b850352e TableGen: Start passing all args to TableGenMain, NFC
- 20f2319f42c5 Support: Add PrefixMapper and RealPathPrefixMapper
- dedbfc95b56c WIP: Support: Expose sys::path::system_style()
- ac9fd93d489b Support: Add Expected::moveInto and Expected::emplaceInto

Uses the `SourceMgr` change from https://github.com/apple/llvm-project/pull/3402.