### PR TITLE
Temporarily undefine IBAction/IBOutlet ObjC macros in attribute headers

### DIFF
--- a/clang/include/clang/AST/AttrVisitor.h
+++ b/clang/include/clang/AST/AttrVisitor.h
@@ -13,6 +13,11 @@
 #ifndef LLVM_CLANG_AST_ATTRVISITOR_H
 #define LLVM_CLANG_AST_ATTRVISITOR_H
 
+#pragma push_macro("IBAction")
+#pragma push_macro("IBOutlet")
+#undef IBAction
+#undef IBOutlet
+
 #include "clang/AST/Attr.h"
 
 namespace clang {
@@ -71,5 +76,8 @@ class ConstAttrVisitor
                                ParamTys...> {};
 
 } // namespace clang
+
+#pragma pop_macro("IBAction")
+#pragma pop_macro("IBOutlet")
 
 #endif // LLVM_CLANG_AST_ATTRVISITOR_H

--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -13,6 +13,11 @@
 #ifndef LLVM_CLANG_AST_RECURSIVEASTVISITOR_H
 #define LLVM_CLANG_AST_RECURSIVEASTVISITOR_H
 
+#pragma push_macro("IBAction")
+#pragma push_macro("IBOutlet")
+#undef IBAction
+#undef IBOutlet
+
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclarationName.h"
@@ -3698,5 +3703,8 @@ bool RecursiveASTVisitor<Derived>::VisitOMPFilterClause(OMPFilterClause *C) {
 #undef TRY_TO
 
 } // end namespace clang
+
+#pragma pop_macro("IBAction")
+#pragma pop_macro("IBOutlet")
 
 #endif // LLVM_CLANG_AST_RECURSIVEASTVISITOR_H

--- a/clang/include/clang/Basic/AttrKinds.h
+++ b/clang/include/clang/Basic/AttrKinds.h
@@ -14,6 +14,11 @@
 #ifndef LLVM_CLANG_BASIC_ATTRKINDS_H
 #define LLVM_CLANG_BASIC_ATTRKINDS_H
 
+#pragma push_macro("IBAction")
+#pragma push_macro("IBOutlet")
+#undef IBAction
+#undef IBOutlet
+
 namespace clang {
 
 namespace attr {
@@ -29,5 +34,8 @@ enum Kind {
 
 } // end namespace attr
 } // end namespace clang
+
+#pragma pop_macro("IBAction")
+#pragma pop_macro("IBOutlet")
 
 #endif


### PR DESCRIPTION
IBAction and IBOutlet are defined when compiling with ObjC/ObjC++ enabled. This can cause issues due to macro expansion when we look through these header files while compiling in ObjC++ mode. This patch temporarily undefs these macros so that the compiler doesn't try to expand them when looking through these attribute headers. 