### PR TITLE
[lldb] Always set the minimum OS version in the Darwin builder

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -98,7 +98,7 @@ class BuilderDarwin(Builder):
         version_min = ""
         if env == "simulator":
             version_min = "-m{}-simulator-version-min={}".format(os, version)
-        elif os == "macosx":
+        else:
             version_min = "-m{}-version-min={}".format(os, version)
 
         return "ARCH_CFLAGS=\"-target {} {}\"".format(triple, version_min)


### PR DESCRIPTION
(cherry picked from commit 09b95b9dc9afb0c12e7d10faea17ed0cb6920b9f)
