### PR TITLE
[lldb] Pass the target triple when determining the DWARF version

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -20,6 +20,10 @@ class Builder:
         compiler = lldbutil.which(compiler)
         return os.path.abspath(compiler)
 
+    def getTriple(self, arch):
+        """Returns the triple for the given architecture or None."""
+        return None
+
     def getExtraMakeArgs(self):
         """
         Helper function to return extra argumentsfor the make system. This

--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -55,6 +55,13 @@ def get_triple():
 
 
 class BuilderDarwin(Builder):
+    def getTriple(self, arch):
+        vendor, os, version, env = get_triple()
+        components = [arch, vendor, os, version, env]
+        if None in components:
+            return None
+        return '-'.join(components)
+
     def getExtraMakeArgs(self):
         """
         Helper function to return extra argumentsfor the make system. This

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1370,15 +1370,18 @@ class Base(unittest2.TestCase):
             return str(configuration.dwarf_version)
         if 'clang' in self.getCompiler():
             try:
+                triple = builder_module().getTriple(self.getArchitecture())
+                target = ['-target', triple] if triple else []
                 driver_output = check_output(
-                    [self.getCompiler()] + '-g -c -x c - -o - -###'.split(),
+                    [self.getCompiler()] + target + '-g -c -x c - -o - -###'.split(),
                     stderr=STDOUT)
                 driver_output = driver_output.decode("utf-8")
                 for line in driver_output.split(os.linesep):
                     m = re.search('dwarf-version=([0-9])', line)
                     if m:
                         return m.group(1)
-            except: pass
+            except CalledProcessError:
+                pass
         return '0'
 
     def platformIsDarwin(self):


### PR DESCRIPTION
When targeting iOS, the default dwarf version is 2 and not 4. Currently,
the test suite does not pick up on that because it invokes the test
compiler without a target triple. This patch fixes that and now
correctly skips tests that have a dwarf version specified in a skipIf
decorator.

rdar://84530477

Differential revision: https://reviews.llvm.org/D112325

(cherry picked from commit 0f12cf7ebaaf9f2a52be3baef7d25562a5ac15cb)
