### PR TITLE
[lldb/test] Remove XFAIL on TestSwiftStepping.py

### DIFF
--- a/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
+++ b/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
@@ -25,7 +25,6 @@ class TestSwiftStepping(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureAll(oslist=['linux'], archs=['aarch64'], bugnumber="rdar://77785062")
     def test_swift_stepping(self):
         """Tests that we can step reliably in swift code."""
         self.build()


### PR DESCRIPTION
This patch removes the XFAIL decorator for TestSwiftStepping.py when
running on Aarch64 Linux since the test is now passing.

This could have changed following 696c7a51f958e0b72bb5ffbe7edcbd84b8ef0abb.

rdar://84618307

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>