### PR TITLE
[lldb] Move reference related functions to TypeSystemSwift

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -6047,27 +6047,6 @@ SwiftASTContext::GetMemberFunctionAtIndex(opaque_compiler_type_t type,
   return TypeMemberFunctionImpl();
 }
 
-CompilerType
-SwiftASTContext::GetLValueReferenceType(opaque_compiler_type_t type) {
-  return {};
-}
-
-CompilerType
-SwiftASTContext::GetRValueReferenceType(opaque_compiler_type_t type) {
-  return {};
-}
-
-CompilerType SwiftASTContext::GetNonReferenceType(opaque_compiler_type_t type) {
-  VALID_OR_RETURN_CHECK_TYPE(type, CompilerType());
-
-  swift::CanType swift_can_type(GetCanonicalSwiftType(type));
-
-  swift::LValueType *lvalue = swift_can_type->getAs<swift::LValueType>();
-  if (lvalue)
-    return ToCompilerType({lvalue->getObjectType().getPointer()});
-  return {};
-}
-
 CompilerType SwiftASTContext::GetPointeeType(opaque_compiler_type_t type) {
   return {};
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -737,11 +737,7 @@ public:
   std::string GetSuperclassName(const CompilerType &superclass_type);
   CompilerType
   GetFullyUnqualifiedType(lldb::opaque_compiler_type_t type) override;
-  CompilerType GetNonReferenceType(lldb::opaque_compiler_type_t type) override;
-  CompilerType
-  GetLValueReferenceType(lldb::opaque_compiler_type_t type) override;
-  CompilerType
-  GetRValueReferenceType(lldb::opaque_compiler_type_t type) override;
+  
   uint32_t GetNumDirectBaseClasses(lldb::opaque_compiler_type_t type) override;
   CompilerType GetDirectBaseClassAtIndex(lldb::opaque_compiler_type_t type,
                                          size_t idx,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -275,6 +275,20 @@ public:
                                    const char *name, ExecutionContext *exe_ctx,
                                    bool omit_empty_base_classes) override;
 
+  CompilerType
+  GetLValueReferenceType(lldb::opaque_compiler_type_t type) override {
+    return {};
+  }
+
+  CompilerType
+  GetRValueReferenceType(lldb::opaque_compiler_type_t type) override {
+    return {};
+  }
+
+  CompilerType GetNonReferenceType(lldb::opaque_compiler_type_t type) override {
+    return {};
+  }
+
   /// \}
 protected:
   /// Used in the logs.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3534,25 +3534,6 @@ TypeSystemSwiftTypeRef::GetFullyUnqualifiedType(opaque_compiler_type_t type) {
     return swift_ast_context->GetFullyUnqualifiedType(ReconstructType(type));
   return {};
 }
-CompilerType
-TypeSystemSwiftTypeRef::GetNonReferenceType(opaque_compiler_type_t type) {
-  if (auto *swift_ast_context = GetSwiftASTContext())
-  return swift_ast_context->GetNonReferenceType(ReconstructType(type));
-  return {};
-}
-CompilerType
-TypeSystemSwiftTypeRef::GetLValueReferenceType(opaque_compiler_type_t type) {
-  auto impl = []() { return CompilerType(); };
-  VALIDATE_AND_RETURN(impl, GetLValueReferenceType, type,
-                      (ReconstructType(type)), (ReconstructType(type)));
-}
-CompilerType
-TypeSystemSwiftTypeRef::GetRValueReferenceType(opaque_compiler_type_t type) {
-  auto impl = []() { return CompilerType(); };
-
-  VALIDATE_AND_RETURN(impl, GetRValueReferenceType, type,
-                      (ReconstructType(type)), (ReconstructType(type)));
-}
 uint32_t
 TypeSystemSwiftTypeRef::GetNumDirectBaseClasses(opaque_compiler_type_t type) {
   if (auto *swift_ast_context = GetSwiftASTContext())

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -230,11 +230,6 @@ public:
   CompilerType GetTypedefedType(lldb::opaque_compiler_type_t type) override;
   CompilerType
   GetFullyUnqualifiedType(lldb::opaque_compiler_type_t type) override;
-  CompilerType GetNonReferenceType(lldb::opaque_compiler_type_t type) override;
-  CompilerType
-  GetLValueReferenceType(lldb::opaque_compiler_type_t type) override;
-  CompilerType
-  GetRValueReferenceType(lldb::opaque_compiler_type_t type) override;
   uint32_t GetNumDirectBaseClasses(lldb::opaque_compiler_type_t type) override;
   CompilerType GetDirectBaseClassAtIndex(lldb::opaque_compiler_type_t type,
                                          size_t idx,


### PR DESCRIPTION
Swift has no concept of reference types (at least not from a user's
perspective). Both TypeSystemSwiftTypeRef and SwiftASTContext should
return invalid types for reference related queries. Unify their
implementation in TypeSystemSwift.