### PR TITLE
[lldb] Disable swift-create-module-contexts-in-parallel for a few tests

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/pyobjsynthprovider/TestPyObjSynthProvider.py
+++ b/lldb/test/API/functionalities/data-formatter/pyobjsynthprovider/TestPyObjSynthProvider.py
@@ -28,6 +28,7 @@ class PyObjectSynthProviderTestCase(TestBase):
 
     def provider_data_formatter_commands(self):
         """Test that the PythonObjectSyntheticChildProvider helper class works"""
+        self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)
 
         lldbutil.run_break_set_by_file_and_line(

--- a/lldb/test/API/functionalities/data-formatter/pyobjsynthprovider/TestPyObjSynthProvider.py
+++ b/lldb/test/API/functionalities/data-formatter/pyobjsynthprovider/TestPyObjSynthProvider.py
@@ -28,6 +28,7 @@ class PyObjectSynthProviderTestCase(TestBase):
 
     def provider_data_formatter_commands(self):
         """Test that the PythonObjectSyntheticChildProvider helper class works"""
+        # rdar://84688015 SILModule::checkForLeaks can assert when used concurrently.
         self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)
 

--- a/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
@@ -45,6 +45,7 @@ class TestSwiftDynamicTypeResolutionImportConflict(TestBase):
 
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
+        self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.build()
         target, _, _, _ = lldbutil.run_to_source_breakpoint(self, "break here",
                                           lldb.SBFileSpec('main.swift'),

--- a/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
@@ -45,6 +45,7 @@ class TestSwiftDynamicTypeResolutionImportConflict(TestBase):
 
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
+        # rdar://84688015 SILModule::checkForLeaks can assert when used concurrently.
         self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.build()
         target, _, _, _ = lldbutil.run_to_source_breakpoint(self, "break here",

--- a/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
@@ -38,6 +38,7 @@ class TestSwiftHeadermapConflict(TestBase):
         self.runCmd("settings set symbols.use-swift-dwarfimporter false")
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
+        # rdar://84688015 SILModule::checkForLeaks can assert when used concurrently.
         self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.build()
 

--- a/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
@@ -38,6 +38,7 @@ class TestSwiftHeadermapConflict(TestBase):
         self.runCmd("settings set symbols.use-swift-dwarfimporter false")
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
+        self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.build()
 
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
@@ -38,6 +38,7 @@ class TestSwiftMacroConflict(TestBase):
         self.runCmd('settings set symbols.use-swift-dwarfimporter false')
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
+        # rdar://84688015 SILModule::checkForLeaks can assert when used concurrently.
         self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.build()
 
@@ -78,6 +79,7 @@ class TestSwiftMacroConflict(TestBase):
         self.runCmd('settings set symbols.use-swift-dwarfimporter true')
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
+        # rdar://84688015 SILModule::checkForLeaks can assert when used concurrently.
         self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
 
         self.build()

--- a/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
@@ -38,6 +38,7 @@ class TestSwiftMacroConflict(TestBase):
         self.runCmd('settings set symbols.use-swift-dwarfimporter false')
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
+        self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.build()
 
         target, process, _, _ = lldbutil.run_to_source_breakpoint(
@@ -77,6 +78,8 @@ class TestSwiftMacroConflict(TestBase):
         self.runCmd('settings set symbols.use-swift-dwarfimporter true')
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
+        self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
+
         self.build()
 
         target, process, _, _ = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
@@ -37,6 +37,7 @@ class TestSwiftObjCMainConflictingDylibs(TestBase):
 
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
+        self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.build()
         target, process, _, foo_breakpoint = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('Foo.swift'),

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
@@ -37,6 +37,7 @@ class TestSwiftObjCMainConflictingDylibs(TestBase):
 
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
+        # rdar://84688015 SILModule::checkForLeaks can assert when used concurrently.
         self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.build()
         target, process, _, foo_breakpoint = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
@@ -37,6 +37,7 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
 
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
+        self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.build()
 
         target, process, _, bar_breakpoint = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
@@ -37,6 +37,7 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
 
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
+        # rdar://84688015 SILModule::checkForLeaks can assert when used concurrently.
         self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.build()
 

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -60,6 +60,7 @@ class TestSwiftRewriteClangPaths(TestBase):
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
         self.runCmd("settings set symbols.use-swift-dwarfimporter false")
+        self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
 
         botdir = os.path.realpath(self.getBuildArtifact("buildbot"))
         userdir = os.path.realpath(self.getBuildArtifact("user"))

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -60,6 +60,7 @@ class TestSwiftRewriteClangPaths(TestBase):
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
         self.runCmd("settings set symbols.use-swift-dwarfimporter false")
+        # rdar://84688015 SILModule::checkForLeaks can assert when used concurrently.
         self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
 
         botdir = os.path.realpath(self.getBuildArtifact("buildbot"))


### PR DESCRIPTION
Disable `swift-create-module-contexts-in-parallel` to avoid a `SILModule` concurrency bug that happens sometimes in asserts builds. In those cases, `SILModule::checkForLeaks` asserts, but it is a false positive. These settings can eventually be removed for one of two reasons: either when LLDB moves to using a single `SwiftASTContext`, or when rdar:://84688015 resolves the way `checkForLeaks` is implemented.

rdar://84527987