### PR TITLE
[cherry-pick to next] Fix Stable lldb Release Builds

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2756,9 +2756,9 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
   if (get_ast_num_children() <
       runtime->GetNumChildren({this, type}, valobj).getValueOr(0))
     return impl();
+#ifndef NDEBUG
   if (ShouldSkipValidation(type))
     return impl();
-#ifndef NDEBUG
   std::string ast_child_name;
   uint32_t ast_child_byte_size = 0;
   int32_t ast_child_byte_offset = 0;


### PR DESCRIPTION
ShouldSkipValidation is only defined #ifndef NDEBUG so it should only be
called #ifndef NDEBUG

See also: https://github.com/apple/llvm-project/pull/3477