### PR TITLE
[lldb] The os and version are not separate components in the triple

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -54,13 +54,20 @@ def get_triple():
     return vendor, os, version, env
 
 
+def get_triple_str(arch, vendor, os, version, env):
+    if None in [arch, vendor, os, version, env]:
+        return None
+
+    component = [arch, vendor, os + version]
+    if env:
+        components.append(env)
+    return '-'.join(component)
+
+
 class BuilderDarwin(Builder):
     def getTriple(self, arch):
         vendor, os, version, env = get_triple()
-        components = [arch, vendor, os, version, env]
-        if None in components:
-            return None
-        return '-'.join(components)
+        return get_triple_str(arch, vendor, os, version, env)
 
     def getExtraMakeArgs(self):
         """
@@ -95,11 +102,9 @@ class BuilderDarwin(Builder):
         """Returns the ARCH_CFLAGS for the make system."""
         # Get the triple components.
         vendor, os, version, env = get_triple()
-        if vendor is None or os is None or version is None or env is None:
+        triple = get_triple_str(arch, vendor, os, version, env)
+        if not triple:
             return ""
-
-        # Construct the triple from its components.
-        triple = '-'.join([arch, vendor, os, version, env])
 
         # Construct min version argument
         version_min = ""


### PR DESCRIPTION
Create a valid triple in the Darwin builder. Currently it was
incorrectly treating the os and version as two separate components in
the triple.

Differential revision: https://reviews.llvm.org/D112676

(cherry picked from commit 2c350730ca8b75727188139f033a7bd60d9383c7)