### PR TITLE
[clang][driver][darwin] support -target with Mac Catalyst triple with…

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1807,7 +1807,12 @@ std::string getOSVersion(llvm::Triple::OSType OS, const llvm::Triple &Triple,
           << Triple.getOSName();
     break;
   case llvm::Triple::IOS:
-    Triple.getiOSVersion(Major, Minor, Micro);
+    if (Triple.isMacCatalystEnvironment() && !Triple.getOSMajorVersion()) {
+      Major = 13;
+      Minor = 1;
+      Micro = 0;
+    } else
+      Triple.getiOSVersion(Major, Minor, Micro);
     break;
   case llvm::Triple::TvOS:
     Triple.getOSVersion(Major, Minor, Micro);

--- a/clang/test/Driver/darwin-maccatalyst.c
+++ b/clang/test/Driver/darwin-maccatalyst.c
@@ -1,9 +1,12 @@
 // RUN: %clang -target x86_64-apple-ios13.1-macabi -c %s -### 2>&1 | \
 // RUN:   FileCheck --check-prefix=CHECK-VERSION1 %s
+// RUN: %clang -target x86_64-apple-ios-macabi -c %s -### 2>&1 | \
+// RUN:   FileCheck --check-prefix=CHECK-VERSION1 %s
 // RUN: %clang -target x86_64-apple-ios13.0-macabi -c %s -### 2>&1 | \
 // RUN:   FileCheck --check-prefix=CHECK-ERROR %s
 // RUN: %clang -target x86_64-apple-ios12.0-macabi -c %s -### 2>&1 | \
 // RUN:   FileCheck --check-prefix=CHECK-ERROR %s
 
+// CHECK-VERSION1-NOT: error:
 // CHECK-VERSION1: "x86_64-apple-ios13.1.0-macabi"
 // CHECK-ERROR: error: invalid version number in '-target x86_64-apple-ios


### PR DESCRIPTION
…out OS version

Some users might omit the version and assume the compiler will target the initial
Mac Catalyst version.

(cherry picked from commit 3d0d7d8c5b669332f55c0af654b10f510bde1932)