### PR TITLE
[lldb] Run async tests using back-deployment target

### DIFF
--- a/lldb/test/API/lang/swift/async/async_fnargs/TestSwiftAsyncFnArgs.py
+++ b/lldb/test/API/lang/swift/async/async_fnargs/TestSwiftAsyncFnArgs.py
@@ -14,6 +14,18 @@ class TestSwiftAsyncFnArgs(lldbtest.TestBase):
     def test(self):
         """Test function arguments in async functions"""
         self.build()
+        self.do_test()
+
+    @swiftTest
+    @skipIf(oslist=['windows', 'linux'])
+    def test_backdeploy(self):
+        """Test function arguments in async functions"""
+        self.build(dictionary={
+            'TARGET_SWIFTFLAGS': f'-target {self.getArchitecture()}-apple-macos11'
+        })
+        self.do_test()
+
+    def do_test(self):
         src = lldb.SBFileSpec('main.swift')
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', src)

--- a/lldb/test/API/lang/swift/async/expr/TestSwiftAsyncExpressions.py
+++ b/lldb/test/API/lang/swift/async/expr/TestSwiftAsyncExpressions.py
@@ -16,6 +16,20 @@ class TestSwiftAsyncExpressions(lldbtest.TestBase):
     def test_actor(self):
         """Test async unwind"""
         self.build()
+        self.do_test_actor()
+
+    @swiftTest
+    @skipIfWindows
+    @skipIfLinux
+    @skipIf(archs=no_match(["arm64", "arm64e", "arm64_32", "x86_64"]))
+    def test_actor_backdeploy(self):
+        """Test async unwind"""
+        self.build(dictionary={
+            'TARGET_SWIFTFLAGS': f'-target {self.getArchitecture()}-apple-macos11'
+        })
+        self.do_test_actor()
+
+    def do_test_actor(self):
         target, process, thread, main_bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec("main.swift"))
         self.expect("expr n", substrs=["42"])

--- a/lldb/test/API/lang/swift/async/frame/language_specific_data/TestSwiftAsyncLanguageSpecificData.py
+++ b/lldb/test/API/lang/swift/async/frame/language_specific_data/TestSwiftAsyncLanguageSpecificData.py
@@ -12,7 +12,18 @@ class TestCase(lldbtest.TestBase):
     def test(self):
         """Test SBFrame.GetLanguageSpecificData() in async functions"""
         self.build()
+        self.do_test()
 
+    @swiftTest
+    @skipIf(oslist=['windows', 'linux'])
+    def test_backdeploy(self):
+        """Test SBFrame.GetLanguageSpecificData() in async functions"""
+        self.build(dictionary={
+            'TARGET_SWIFTFLAGS': f'-target {self.getArchitecture()}-apple-macos11'
+        })
+        self.do_test()
+
+    def do_test(self):
         # This test uses "main" as a prefix for all functions, so that all will
         # be stopped at. Setting a breakpoint on "main" results in a breakpoint
         # at the start of each coroutine "funclet" function.

--- a/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
+++ b/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
@@ -12,7 +12,18 @@ class TestCase(lldbtest.TestBase):
     def test(self):
         """Test `frame variable` in async functions"""
         self.build()
+        self.do_test()
 
+    @swiftTest
+    @skipIf(oslist=['windows', 'linux'])
+    def test_backdeploy(self):
+        """Test `frame variable` in async functions"""
+        self.build(dictionary={
+            'TARGET_SWIFTFLAGS': f'-target {self.getArchitecture()}-apple-macos11'
+        })
+        self.do_test()
+
+    def do_test(self):
         # Setting a breakpoint on "inner" results in a breakpoint at the start
         # of each coroutine "funclet" function.
         _, process, _, _ = lldbutil.run_to_name_breakpoint(self, 'inner')

--- a/lldb/test/API/lang/swift/async/stepping/step-in/TestSwiftStepInAsync.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/TestSwiftStepInAsync.py
@@ -13,6 +13,18 @@ class TestCase(lldbtest.TestBase):
     def test(self):
         """Test step-in to async functions"""
         self.build()
+        self.do_test()
+
+    @swiftTest
+    @skipIf(oslist=['windows', 'linux'])
+    def test_backdeploy(self):
+        """Test step-in to async functions"""
+        self.build(dictionary={
+            'TARGET_SWIFTFLAGS': f'-target {self.getArchitecture()}-apple-macos11'
+        })
+        self.do_test()
+
+    def do_test(self):
         src = lldb.SBFileSpec('main.swift')
         _, process, _, _ = lldbutil.run_to_source_breakpoint(self, 'await', src)
 

--- a/lldb/test/API/lang/swift/async/unwind/backtrace_locals/TestSwiftAsyncBacktraceLocals.py
+++ b/lldb/test/API/lang/swift/async/unwind/backtrace_locals/TestSwiftAsyncBacktraceLocals.py
@@ -30,9 +30,35 @@ class TestSwiftAsyncBacktraceLocals(lldbtest.TestBase):
     @skipIfWindows
     @skipIfLinux
     @skipIf(archs=no_match(["arm64", "arm64e", "arm64_32", "x86_64"]))
+    def test_backdeploy(self):
+        """Test async unwind"""
+        self.build(dictionary={
+            'TARGET_SWIFTFLAGS': f'-target {self.getArchitecture()}-apple-macos11'
+        })
+        target, process, thread, main_bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'main breakpoint', self.src)
+        self.run_fibo_tests(target, process)
+
+    @swiftTest
+    @skipIfWindows
+    @skipIfLinux
+    @skipIf(archs=no_match(["arm64", "arm64e", "arm64_32", "x86_64"]))
     def test_actor(self):
         """Test async unwind"""
         self.build()
+        target, process, thread, main_bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'main actor breakpoint', self.src)
+        self.run_fibo_tests(target, process)
+
+    @swiftTest
+    @skipIfWindows
+    @skipIfLinux
+    @skipIf(archs=no_match(["arm64", "arm64e", "arm64_32", "x86_64"]))
+    def test_actor_backdeploy(self):
+        """Test async unwind"""
+        self.build(dictionary={
+            'TARGET_SWIFTFLAGS': f'-target {self.getArchitecture()}-apple-macos11'
+        })
         target, process, thread, main_bkpt = lldbutil.run_to_source_breakpoint(
             self, 'main actor breakpoint', self.src)
         self.run_fibo_tests(target, process)

--- a/lldb/test/API/lang/swift/async/unwind/sayhello/TestSwiftAsyncUnwind.py
+++ b/lldb/test/API/lang/swift/async/unwind/sayhello/TestSwiftAsyncUnwind.py
@@ -14,6 +14,18 @@ class TestSwiftAsyncUnwind(lldbtest.TestBase):
     def test(self):
         """Test async unwind"""
         self.build()
+        self.do_test()
+
+    @swiftTest
+    @skipIf(oslist=['windows', 'linux'])
+    def test_backdeploy(self):
+        """Test async unwind"""
+        self.build(dictionary={
+            'TARGET_SWIFTFLAGS': f'-target {self.getArchitecture()}-apple-macos11'
+        })
+        self.do_test()
+
+    def do_test(self):
         src = lldb.SBFileSpec('main.swift')
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', src)


### PR DESCRIPTION
For each of the async tests, extract the test body into a function (in some cases this already existed), and then duplicate each `test*` function to a `*_backdeploy` test. The back-deploy tests build for `macos11`, which is a back deployment target.