### PR TITLE
build: optionalize some clang resource headers

### DIFF
--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -203,20 +203,24 @@ foreach( f ${files} ${cuda_wrapper_files} ${ppc_wrapper_files} ${openmp_wrapper_
 endforeach( f )
 
 # Generate header files and copy them to the build directory
-# Generate arm_neon.h
-clang_generate_header(-gen-arm-neon arm_neon.td arm_neon.h)
-# Generate arm_fp16.h
-clang_generate_header(-gen-arm-fp16 arm_fp16.td arm_fp16.h)
-# Generate arm_sve.h
-clang_generate_header(-gen-arm-sve-header arm_sve.td arm_sve.h)
-# Generate arm_bf16.h
-clang_generate_header(-gen-arm-bf16 arm_bf16.td arm_bf16.h)
-# Generate arm_mve.h
-clang_generate_header(-gen-arm-mve-header arm_mve.td arm_mve.h)
-# Generate arm_cde.h
-clang_generate_header(-gen-arm-cde-header arm_cde.td arm_cde.h)
-# Generate riscv_vector.h
-clang_generate_header(-gen-riscv-vector-header riscv_vector.td riscv_vector.h)
+if(ARM IN_LIST LLVM_TARGETS_TO_BUILD OR AArch64 IN_LIST LLVM_TARGETS_TO_BUILD)
+  # Generate arm_neon.h
+  clang_generate_header(-gen-arm-neon arm_neon.td arm_neon.h)
+  # Generate arm_fp16.h
+  clang_generate_header(-gen-arm-fp16 arm_fp16.td arm_fp16.h)
+  # Generate arm_sve.h
+  clang_generate_header(-gen-arm-sve-header arm_sve.td arm_sve.h)
+  # Generate arm_bf16.h
+  clang_generate_header(-gen-arm-bf16 arm_bf16.td arm_bf16.h)
+  # Generate arm_mve.h
+  clang_generate_header(-gen-arm-mve-header arm_mve.td arm_mve.h)
+  # Generate arm_cde.h
+  clang_generate_header(-gen-arm-cde-header arm_cde.td arm_cde.h)
+endif()
+if(RISCV IN_LIST LLVM_TARGETS_TO_BUILD)
+  # Generate riscv_vector.h
+  clang_generate_header(-gen-riscv-vector-header riscv_vector.td riscv_vector.h)
+endif()
 
 add_custom_target(clang-resource-headers ALL DEPENDS ${out_files})
 set_target_properties(clang-resource-headers PROPERTIES


### PR DESCRIPTION
This makes the RISCV specific resource header `riscv_vector.h` optional.
It also similarly treats some of the ARM NEON headers.  The RISCV header
added 10 MB to the resource directory which was previously 10 MB.  This
header is gratuitously large, and increases the size of the build for a
target which may not be enabled.