### PR TITLE
[CASObjectFormats/NestedV1] Simplify code a bit related to `CompileUnitBuilder::getOrCreateTarget()`

### DIFF
--- a/llvm/include/llvm/CASObjectFormats/NestedV1.h
+++ b/llvm/include/llvm/CASObjectFormats/NestedV1.h
@@ -562,9 +562,7 @@ public:
 
   static Expected<BlockRef>
   create(const ObjectFileSchema &Schema, const jitlink::Block &Block,
-         function_ref<Expected<Optional<TargetRef>>(
-             const jitlink::Symbol &, jitlink::Edge::Kind, bool IsFromData,
-             jitlink::Edge::AddendT &Addend, Optional<StringRef> &SplitContent)>
+         function_ref<Expected<Optional<TargetRef>>(const jitlink::Symbol &)>
              GetTargetRef);
 
   static Expected<BlockRef> create(const ObjectFileSchema &Schema,

--- a/llvm/unittests/CASObjectFormats/NestedV1TargetListTest.cpp
+++ b/llvm/unittests/CASObjectFormats/NestedV1TargetListTest.cpp
@@ -52,9 +52,7 @@ protected:
     ASSERT_THAT_ERROR(
         unwrapExpected(BlockRef::create(
                            *Schema, *Z,
-                           [](const jitlink::Symbol &S, jitlink::Edge::Kind,
-                              bool IsFromData, jitlink::Edge::AddendT &,
-                              Optional<StringRef> &) -> Expected<TargetRef> {
+                           [](const jitlink::Symbol &S) -> Expected<TargetRef> {
                              return createStringError(inconvertibleErrorCode(),
                                                       "expected leaf block");
                            }),


### PR DESCRIPTION
Remove parameters that are no longer used.