### PR TITLE
Change path prefix mapping to use "tree" paths instead of "real" paths

### DIFF
--- a/llvm/include/llvm/Support/PrefixMapper.h
+++ b/llvm/include/llvm/Support/PrefixMapper.h
@@ -105,13 +105,17 @@ public:
   StringSaver &getStringSaver() { return Saver; }
   sys::path::Style getPathStyle() const { return PathStyle; }
 
-  PrefixMapper(StringSaver &Saver,
+  PrefixMapper(sys::path::Style PathStyle = sys::path::Style::native)
+      : PathStyle(PathStyle), Alloc(in_place), Saver(*Alloc) {}
+
+  PrefixMapper(BumpPtrAllocator &Alloc,
                sys::path::Style PathStyle = sys::path::Style::native)
-      : PathStyle(PathStyle), Saver(Saver) {}
+      : PathStyle(PathStyle), Saver(Alloc) {}
 
 private:
   sys::path::Style PathStyle;
-  StringSaver &Saver;
+  Optional<BumpPtrAllocator> Alloc;
+  StringSaver Saver;
   SmallVector<MappedPrefix> Mappings;
 };
 
@@ -198,7 +202,9 @@ public:
   void sort() { PM.sort(); }
 
   RealPathPrefixMapper(IntrusiveRefCntPtr<vfs::FileSystem> FS,
-                       StringSaver &Saver,
+                       sys::path::Style PathStyle = sys::path::Style::native);
+  RealPathPrefixMapper(IntrusiveRefCntPtr<vfs::FileSystem> FS,
+                       BumpPtrAllocator &Alloc,
                        sys::path::Style PathStyle = sys::path::Style::native);
   ~RealPathPrefixMapper();
 

--- a/llvm/include/llvm/Support/VirtualCachedDirectoryEntry.h
+++ b/llvm/include/llvm/Support/VirtualCachedDirectoryEntry.h
@@ -1,0 +1,60 @@
+//===- VirtualCachedDirectoryEntry.h ----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_VIRTUALCACHEDDIRECTORYENTRY_H
+#define LLVM_SUPPORT_VIRTUALCACHEDDIRECTORYENTRY_H
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Path.h"
+
+namespace llvm {
+namespace vfs {
+
+/// Base class for a cached directory entry, exposing details of the filesystem
+/// tree.
+///
+/// TODO: Move more of \a llvm::cas::FileSystemCache::DirectoryEntry to here.
+class CachedDirectoryEntry {
+public:
+  /// The name of this filesystem node.
+  StringRef getName() const { return Name; }
+
+  /// The path to this filesystem node (including the name). The parent path of
+  /// the tree path is guaranteed not to contain symbolic links.
+  ///
+  /// For example, given:
+  ///
+  ///     /a/sym -> b
+  ///     /a/b/c
+  ///     /d
+  ///
+  /// Then directory entries exist with the following tree paths:
+  ///
+  ///     - "/a"
+  ///         - "/a/b"
+  ///             - "/a/b/c"
+  ///         - "/a/sym"
+  ///     - "/d"
+  ///
+  /// The directory entry referred to by "/a/sym/c" will have the tree path
+  /// "/a/b/c".
+  StringRef getTreePath() const { return TreePath; }
+
+  explicit CachedDirectoryEntry(
+      StringRef TreePath, sys::path::Style Style = sys::path::Style::native)
+      : TreePath(TreePath), Name(sys::path::filename(TreePath, Style)) {}
+
+protected:
+  StringRef TreePath;
+  StringRef Name;
+};
+
+} // namespace vfs
+} // namespace llvm
+
+#endif // LLVM_SUPPORT_VIRTUALCACHEDDIRECTORYENTRY_H

--- a/llvm/include/llvm/Support/VirtualFileSystem.h
+++ b/llvm/include/llvm/Support/VirtualFileSystem.h
@@ -20,10 +20,12 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Chrono.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/VirtualCachedDirectoryEntry.h"
 #include <cassert>
 #include <cstdint>
 #include <ctime>
@@ -276,6 +278,46 @@ public:
   /// This returns errc::operation_not_permitted if not implemented by subclass.
   virtual std::error_code getRealPath(const Twine &Path,
                                       SmallVectorImpl<char> &Output) const;
+
+  /// Gets access to the directory entry for \p Path. Among other things, this
+  /// exposes the filesystem tree's actual path to \p Path.
+  ///
+  /// If \p FollowSymlinks and \p Path refers to a symbol link, this returns
+  /// the directory entry for the link's target, evaluated recursively (as if
+  /// calling \a getRealPath()). Otherwise, it returns the entry for the
+  /// symbolic link itself (as if \a getRealPath() had been called only on the
+  /// parent path).
+  ///
+  /// For example, given:
+  ///
+  ///     /a/sym -> b
+  ///     /a/b/c
+  ///
+  /// The following table explains the object returned, and its tree path:
+  ///
+  ///     Path      Follow     NoFollow
+  ///     ====      ======     ========
+  ///     /a/sym    /a/b       /a/sym
+  ///     /a/sym/   /a/b       /a/b
+  ///     /a/sym/c  /a/b/c     /a/b/c
+  ///
+  /// Paths are made absolute before lookup.
+  ///
+  /// FIXME: Make this non-const, since it can do work? (Why is \a
+  /// getRealPath() const?)
+  ///
+  /// FIXME: Add \a getCachedDirectoryEntry(), which is const-qualified and
+  /// never does work?
+  ///
+  /// FIXME: Follow symlinks by default (can make the virtual function end in
+  /// Impl to avoid virtual/default parameter shenanigans)?
+  virtual Expected<const CachedDirectoryEntry *>
+  getDirectoryEntry(const Twine &Path, bool FollowSymlinks) const {
+    // FIXME: Consider providing a defualt imlementation that calls \a
+    // getRealPath() on the parent path and reappending the filename (assuming
+    // it exists).
+    return createFileError(Path, make_error_code(std::errc::not_supported));
+  }
 
   /// Check whether a file exists. Provided for convenience.
   bool exists(const Twine &Path);

--- a/llvm/include/llvm/TableGen/ScanDependencies.h
+++ b/llvm/include/llvm/TableGen/ScanDependencies.h
@@ -22,7 +22,7 @@ namespace cas {
 class CachingOnDiskFileSystem;
 } // end namespace cas
 
-class RealPathPrefixMapper;
+class TreePathPrefixMapper;
 struct MappedPrefix;
 
 namespace tablegen {
@@ -70,7 +70,7 @@ struct ScanIncludesResult {
 
 /// Scan includes and build a CAS tree. If \p PrefixMappings is not \c None,
 /// remap the includes while building the tree. If \p PM is not \c nullptr
-/// then the \a RealPathPrefixMapper used will be returned there.
+/// then the \a TreePathPrefixMapper used will be returned there.
 ///
 /// \p ExecID is the Blob for the running executable. It can be used as part of
 /// the key for caching to avoid (fixed) bugs poisoning results.
@@ -82,7 +82,7 @@ Expected<ScanIncludesResult>
 scanIncludes(cas::CASDB &CAS, cas::CASID ExecID, StringRef MainFilename,
              ArrayRef<std::string> IncludeDirs,
              ArrayRef<MappedPrefix> PrefixMappings = None,
-             Optional<RealPathPrefixMapper> *CapturedPM = nullptr);
+             Optional<TreePathPrefixMapper> *CapturedPM = nullptr);
 
 /// Scan includes and build a CAS tree where their prefixes have been remapped
 /// according to \a PrefixMappings. Also remap the main file and include

--- a/llvm/lib/CAS/CASFileSystem.cpp
+++ b/llvm/lib/CAS/CASFileSystem.cpp
@@ -24,7 +24,7 @@ class CASFileSystem : public CASFileSystemBase {
     FileSystemCache::DirectoryEntry *Entry;
 
     /// Mimics shell behaviour on directory changes. Not necessarily the same
-    /// as \c Entry->getRealPath().
+    /// as \c Entry->getTreePath().
     std::string Path;
   };
 
@@ -126,7 +126,7 @@ Error CASFileSystem::initialize(CASID RootID) {
 
   // Initial working directory is the root.
   WorkingDirectory.Entry = &Cache->getRoot();
-  WorkingDirectory.Path = WorkingDirectory.Entry->getRealPath().str();
+  WorkingDirectory.Path = WorkingDirectory.Entry->getTreePath().str();
 
   // Load the root to confirm it's really a tree.
   return loadDirectory(*WorkingDirectory.Entry);
@@ -153,7 +153,7 @@ Error CASFileSystem::loadDirectory(DirectoryEntry &Parent) {
   if (D.isComplete())
     return Error::success();
 
-  SmallString<128> Path = Parent.getRealPath();
+  SmallString<128> Path = Parent.getTreePath();
   size_t ParentPathSize = Path.size();
   auto makeCachedEntry =
       [&](const NamedTreeEntry &NewEntry) -> DirectoryEntry & {
@@ -327,7 +327,7 @@ CASFileSystem::lookupPath(StringRef Path, bool FollowSymlinks) {
   // FIXME: Need to handle lazy symlinks somehow.
   return Cache->lookupPath(Path, *WorkingDirectory.Entry, RequestDirectoryEntry,
                            RequestSymlinkTarget,
-                           /*PreloadRealPath=*/nullptr, FollowSymlinks,
+                           /*PreloadTreePath=*/nullptr, FollowSymlinks,
                            /*TrackNonRealPathEntries=*/nullptr);
 }
 

--- a/llvm/lib/Support/Error.cpp
+++ b/llvm/lib/Support/Error.cpp
@@ -80,8 +80,11 @@ std::error_code inconvertibleErrorCode() {
 }
 
 std::error_code FileError::convertToErrorCode() const {
-  return std::error_code(static_cast<int>(ErrorErrorCode::FileError),
-                         *ErrorErrorCat);
+  std::error_code NestedEC = Err->convertToErrorCode();
+  if (NestedEC == inconvertibleErrorCode())
+    return std::error_code(static_cast<int>(ErrorErrorCode::FileError),
+                           *ErrorErrorCat);
+  return NestedEC;
 }
 
 Error errorCodeToError(std::error_code EC) {

--- a/llvm/lib/Support/PrefixMapper.cpp
+++ b/llvm/lib/Support/PrefixMapper.cpp
@@ -176,9 +176,13 @@ void PrefixMapper::sort() {
 }
 
 RealPathPrefixMapper::RealPathPrefixMapper(
-    IntrusiveRefCntPtr<vfs::FileSystem> FS, StringSaver &Saver,
+    IntrusiveRefCntPtr<vfs::FileSystem> FS, BumpPtrAllocator &Alloc,
     sys::path::Style PathStyle)
-    : PM(Saver, PathStyle), FS(std::move(FS)) {}
+    : PM(Alloc, PathStyle), FS(std::move(FS)) {}
+
+RealPathPrefixMapper::RealPathPrefixMapper(
+    IntrusiveRefCntPtr<vfs::FileSystem> FS, sys::path::Style PathStyle)
+    : PM(PathStyle), FS(std::move(FS)) {}
 
 RealPathPrefixMapper::~RealPathPrefixMapper() = default;
 

--- a/llvm/lib/TableGen/Main.cpp
+++ b/llvm/lib/TableGen/Main.cpp
@@ -257,11 +257,10 @@ struct TableGenCache {
 
   SmallVector<MappedPrefix> PrefixMappings;
   BumpPtrAllocator Alloc;
-  StringSaver Saver;
   Optional<RealPathPrefixMapper> PM;
   Optional<PrefixMapper> InversePM;
 
-  TableGenCache() : Saver(Alloc) {}
+  TableGenCache() = default;
   ~TableGenCache() { CreateDependencyFilePM = nullptr; }
 
   Expected<cas::CASID> createExecutableBlob(StringRef Argv0);
@@ -281,12 +280,12 @@ struct TableGenCache {
 void TableGenCache::createPrefixMap(
     IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS) {
   assert(!PM);
-  PM.emplace(std::move(FS), Saver);
+  PM.emplace(std::move(FS), Alloc);
   PM->addRangeIfValid(PrefixMappings);
 }
 
 void TableGenCache::createInversePrefixMap() {
-  InversePM.emplace(Saver);
+  InversePM.emplace(Alloc);
   InversePM->addInverseRange(PrefixMappings);
   CreateDependencyFilePM = &*InversePM;
 }

--- a/llvm/lib/TableGen/Main.cpp
+++ b/llvm/lib/TableGen/Main.cpp
@@ -257,7 +257,7 @@ struct TableGenCache {
 
   SmallVector<MappedPrefix> PrefixMappings;
   BumpPtrAllocator Alloc;
-  Optional<RealPathPrefixMapper> PM;
+  Optional<TreePathPrefixMapper> PM;
   Optional<PrefixMapper> InversePM;
 
   TableGenCache() = default;

--- a/llvm/lib/TableGen/ScanDependencies.cpp
+++ b/llvm/lib/TableGen/ScanDependencies.cpp
@@ -216,12 +216,10 @@ Expected<ScanIncludesResult> tablegen::scanIncludes(
   if (Error E = accessAllIncludes(*FS, ExecID, IncludeDirs, *MainBlob))
     return std::move(E);
 
-  BumpPtrAllocator Alloc;
-  StringSaver Saver(Alloc);
   Optional<RealPathPrefixMapper> LocalPM;
   Optional<RealPathPrefixMapper> &PM = CapturedPM ? *CapturedPM : LocalPM;
   if (!PrefixMappings.empty()) {
-    PM.emplace(FS, Saver);
+    PM.emplace(FS);
     if (Error E = PM->addRange(PrefixMappings))
       return std::move(E);
     PM->sort();

--- a/llvm/lib/TableGen/ScanDependencies.cpp
+++ b/llvm/lib/TableGen/ScanDependencies.cpp
@@ -202,7 +202,7 @@ Error tablegen::createMainFileError(StringRef MainFilename,
 Expected<ScanIncludesResult> tablegen::scanIncludes(
     cas::CASDB &CAS, cas::CASID ExecID, StringRef MainFilename,
     ArrayRef<std::string> IncludeDirs, ArrayRef<MappedPrefix> PrefixMappings,
-    Optional<RealPathPrefixMapper> *CapturedPM) {
+    Optional<TreePathPrefixMapper> *CapturedPM) {
   IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS;
   if (Error E = cas::createCachingOnDiskFileSystem(CAS).moveInto(FS))
     return std::move(E);
@@ -216,8 +216,8 @@ Expected<ScanIncludesResult> tablegen::scanIncludes(
   if (Error E = accessAllIncludes(*FS, ExecID, IncludeDirs, *MainBlob))
     return std::move(E);
 
-  Optional<RealPathPrefixMapper> LocalPM;
-  Optional<RealPathPrefixMapper> &PM = CapturedPM ? *CapturedPM : LocalPM;
+  Optional<TreePathPrefixMapper> LocalPM;
+  Optional<TreePathPrefixMapper> &PM = CapturedPM ? *CapturedPM : LocalPM;
   if (!PrefixMappings.empty()) {
     PM.emplace(FS);
     if (Error E = PM->addRange(PrefixMappings))
@@ -238,7 +238,7 @@ tablegen::scanIncludesAndRemap(cas::CASDB &CAS, cas::CASID ExecID,
                                std::string &MainFilename,
                                std::vector<std::string> &IncludeDirs,
                                ArrayRef<MappedPrefix> PrefixMappings) {
-  Optional<RealPathPrefixMapper> PM;
+  Optional<TreePathPrefixMapper> PM;
   auto Result =
       scanIncludes(CAS, ExecID, MainFilename, IncludeDirs, PrefixMappings, &PM);
   if (!Result)

--- a/llvm/unittests/CAS/CMakeLists.txt
+++ b/llvm/unittests/CAS/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LLVM_LINK_COMPONENTS
   Support
   CAS
+  TestingSupport
   )
 
 add_llvm_unittest(CASTests

--- a/llvm/unittests/Support/ErrorTest.cpp
+++ b/llvm/unittests/Support/ErrorTest.cpp
@@ -959,6 +959,33 @@ TEST(Error, FileErrorTest) {
             0);
 }
 
+TEST(Error, FileErrorErrorCode) {
+  for (std::error_code EC : {
+           make_error_code(std::errc::not_supported),
+           make_error_code(std::errc::invalid_argument),
+           make_error_code(std::errc::no_such_file_or_directory),
+       }) {
+    EXPECT_EQ(EC, errorToErrorCode(
+                      createFileError("file.bin", EC)));
+    EXPECT_EQ(EC, errorToErrorCode(
+                      createFileError("file.bin", /*Line=*/5, EC)));
+    EXPECT_EQ(EC, errorToErrorCode(
+                      createFileError("file.bin", errorCodeToError(EC))));
+    EXPECT_EQ(EC, errorToErrorCode(
+                      createFileError("file.bin", /*Line=*/5, errorCodeToError(EC))));
+  }
+
+  // inconvertibleErrorCode() should be wrapped to avoid a fatal error.
+  EXPECT_EQ(
+      "A file error occurred.",
+      errorToErrorCode(createFileError("file.bin", inconvertibleErrorCode()))
+          .message());
+  EXPECT_EQ(
+      "A file error occurred.",
+      errorToErrorCode(createFileError("file.bin", /*Line=*/5, inconvertibleErrorCode()))
+          .message());
+}
+
 enum class test_error_code {
   unspecified = 1,
   error_1,


### PR DESCRIPTION
`RealPathPrefixMapper` didn't actually work, pointed out by https://github.com/apple/llvm-project/pull/3482. Attempt to fix it by using "tree" paths (no-follow-symlink mode).