### PR TITLE
[debugserver] Fix typo in DNBArchImplARM64

### DIFF
--- a/lldb/tools/debugserver/source/MacOSX/arm64/DNBArchImplARM64.cpp
+++ b/lldb/tools/debugserver/source/MacOSX/arm64/DNBArchImplARM64.cpp
@@ -157,9 +157,9 @@ kern_return_t DNBArchMachARM64::GetGPRState(bool force) {
         uint64_t log_pc = arm_thread_state64_get_pc(m_state.context.gpr);
 #else
         uint64_t log_fp = m_state.context.gpr.__fp;
-        uint64_t log_fp = m_state.context.gpr.__lr;
-        uint64_t log_fp = m_state.context.gpr.__sp;
-        uint64_t log_fp = m_state.context.gpr.__pc,
+        uint64_t log_lr = m_state.context.gpr.__lr;
+        uint64_t log_sp = m_state.context.gpr.__sp;
+        uint64_t log_pc = m_state.context.gpr.__pc;
 #endif
     DNBLogThreaded(
         "thread_get_state(0x%4.4x, %u, &gpr, %u) => 0x%8.8x (count = %u) regs"


### PR DESCRIPTION
rdar://85020754
(cherry picked from commit 3120cadac782cd51f88f52dd2e88a20a6aa77b4b)