### PR TITLE
CAS: Use CachedDirectoryEntry in createTreeWithNewAccessors()

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5858,6 +5858,8 @@ def fno_depscan : Flag<["-"], "fno-depscan">,
     Alias<fdepscan_EQ>, AliasArgs<["off"]>;
 
 // CAS prefix map options.
+//
+// FIXME: Add DepscanOption flag.
 def fdepscan_prefix_map_EQ : Joined<["-"], "fdepscan-prefix-map=">,
     Group<f_Group>, MetaVarName<"<old>=<new>">,
     HelpText<"With -fdepscan, seamlessly filter the CAS filesystem to"
@@ -5874,8 +5876,12 @@ def fdepscan_prefix_map_toolchain_EQ :
              " remap it to the given path (see -fdepscan-prefix-map=).">;
 
 // -cc1depscan options.
+//
+// FIXME: Add to their own group; add NoDriverOption and DepscanOption flags.
 def cc1_args : Option<["-"], "cc1-args", KIND_REMAINING_ARGS>,
     HelpText<"pass cc1 options to depscan afterwards">;
+def dump_depscan_tree_EQ : Option<["-"], "dump-depscan-tree=", KIND_JOINED>,
+    HelpText<"emit the CAS identifier for the tree instead of the full -cc1">;
 
 // -cc1 options. These should be available in the driver too, but the driver
 // doesn't currently support most of them. For example, the driver should

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -94,7 +94,8 @@ public:
   llvm::Expected<llvm::cas::TreeRef> getDependencyTreeFromCompilerInvocation(
       std::shared_ptr<CompilerInvocation> Invocation, StringRef CWD,
       DiagnosticConsumer &DiagsConsumer,
-      llvm::function_ref<StringRef(StringRef)> RemapPath = nullptr);
+      llvm::function_ref<StringRef(const llvm::vfs::CachedDirectoryEntry &)>
+          RemapPath = nullptr);
 
   llvm::Expected<llvm::cas::TreeRef>
   getDependencyTreeFromCC1CommandLine(ArrayRef<const char *> Args,

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -198,9 +198,11 @@ llvm::Expected<llvm::cas::TreeRef>
 DependencyScanningTool::getDependencyTreeFromCompilerInvocation(
     std::shared_ptr<CompilerInvocation> Invocation, StringRef CWD,
     DiagnosticConsumer &DiagsConsumer,
-    llvm::function_ref<StringRef(StringRef)> RemapPath) {
+    llvm::function_ref<StringRef(const llvm::vfs::CachedDirectoryEntry &)>
+        RemapPath) {
   llvm::cas::CachingOnDiskFileSystem &FS = Worker.getRealFS();
   FS.trackNewAccesses();
+  FS.setCurrentWorkingDirectory(CWD);
   MakeDependencyTree DepsConsumer(FS);
   Worker.computeDependenciesFromCompilerInvocation(std::move(Invocation), CWD,
                                                    DepsConsumer, DiagsConsumer);

--- a/clang/test/CAS/depscan.c
+++ b/clang/test/CAS/depscan.c
@@ -4,5 +4,6 @@
 // RUN: %clang -cc1depscan -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %s.o 2>&1 | FileCheck %s
 
 // CHECK: "-fcas" "builtin"
+// CHECK: "-fcas-builtin-path" "/^llvm::cas::builtin::default/llvm.cas.builtin.default"
 
 int test() { return 0; }

--- a/clang/tools/driver/driver.cpp
+++ b/clang/tools/driver/driver.cpp
@@ -442,8 +442,8 @@ static void addCC1ScanDepsArgsInline(
   llvm::Expected<llvm::cas::CASID> Root =
       Tool.getDependencyTreeFromCompilerInvocation(
           std::make_shared<CompilerInvocation>(*Invocation), WorkingDirectory,
-          *DiagsConsumer, [&](StringRef Path) {
-            return remapPath(Path, Saver, ComputedMapping);
+          *DiagsConsumer, [&](const llvm::vfs::CachedDirectoryEntry &Entry) {
+            return remapPath(Entry.getTreePath(), Saver, ComputedMapping);
           });
   if (!Root) {
     // FIXME: Use D.Diags somehow...

--- a/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
+++ b/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
@@ -41,8 +41,35 @@ public:
 
   /// Create a tree that represents all stats tracked since the call to \a
   /// trackNewAccesses(). Stops tracking new accesses.
+  ///
+  /// If provided, \p RemapPath is used to adjust paths in the created CAS
+  /// tree.
+  ///
+  /// FIXME: Targets of symbolic links are not currently remapped. For example,
+  /// given:
+  ///
+  ///     /sym1 -> old
+  ///     /old/filename
+  ///     /old/sym2 -> filename
+  ///     /old/sym3 -> /old/filename
+  ///
+  /// If \p RemapPath uses a mapping prefix "/old=/new", then the resulting
+  /// tree will be:
+  ///
+  ///     /sym1 -> old               [broken]
+  ///     /new/filename
+  ///     /new/sym2 -> filename
+  ///     /new/sym3 -> /old/filename [broken]
+  ///
+  /// ... but the correct result would keep /sym1 and /old/sym3 working:
+  ///
+  ///     /sym1 -> new               [broken]
+  ///     /new/filename
+  ///     /new/sym2 -> filename
+  ///     /new/sym3 -> /new/filename [broken]
   virtual Expected<TreeRef> createTreeFromNewAccesses(
-      llvm::function_ref<StringRef(StringRef)> RemapPath = nullptr) = 0;
+      llvm::function_ref<StringRef(const vfs::CachedDirectoryEntry &)>
+          RemapPath = nullptr) = 0;
 
   /// Create a tree that represents all known directories, files, and symlinks.
   virtual Expected<TreeRef> createTreeFromAllAccesses() = 0;

--- a/llvm/lib/TableGen/ScanDependencies.cpp
+++ b/llvm/lib/TableGen/ScanDependencies.cpp
@@ -226,7 +226,10 @@ Expected<ScanIncludesResult> tablegen::scanIncludes(
   }
 
   Expected<cas::TreeRef> Tree = FS->createTreeFromNewAccesses(
-      [&](StringRef Path) { return PM ? PM->mapOrOriginal(Path) : Path; });
+      [&](const vfs::CachedDirectoryEntry &Entry) {
+        return PM ? PM->mapOrOriginal(Entry.getTreePath())
+                  : Entry.getTreePath();
+      });
   if (!Tree)
     return Tree.takeError();
 


### PR DESCRIPTION
Change CachingOnDiskFileSystem to pass back a CachedDirectoryEntry. This
part should be NFC. A future commit will update TreePathPrefixMapper to
split out APIs that take these directly, but...

... I tried to test this and found that `clang -cc1depscan` didn't
handle prefix mapping correctly. Fixed that and it'll be hard to split,
so planning to commit squashed together.