### PR TITLE
[clang] 'unused-but-set-variable' warning should not apply to __block…

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -1941,6 +1941,12 @@ void Sema::DiagnoseUnusedButSetDecl(const VarDecl *VD) {
     }
   }
 
+  // Don't warn about __block Objective-C pointer variables, as they might
+  // be assigned in the block but not used elsewhere for the purpose of lifetime
+  // extension.
+  if (VD->hasAttr<BlocksAttr>() && Ty->isObjCObjectPointerType())
+    return;
+
   auto iter = RefsMinusAssignments.find(VD);
   if (iter == RefsMinusAssignments.end())
     return;

--- a/clang/test/SemaObjC/block-capture-unused-variable.m
+++ b/clang/test/SemaObjC/block-capture-unused-variable.m
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 -fsyntax-only -fobjc-arc -fblocks -verify -Wunused-but-set-variable -Wno-objc-root-class %s
+
+typedef struct dispatch_queue_s *dispatch_queue_t;
+
+typedef void (^dispatch_block_t)(void);
+
+void dispatch_async(dispatch_queue_t queue, dispatch_block_t block);
+
+extern __attribute__((visibility("default"))) struct dispatch_queue_s _dispatch_main_q;
+
+id getFoo();
+
+@protocol P
+
+@end
+
+@interface I
+
+@end
+
+void test() {
+  // no diagnostics
+  __block id x = getFoo();
+  __block id<P> y = x;
+  __block I *z = (I *)x;
+  // diagnose non-block variables
+  id x2 = getFoo(); // expected-warning {{variable 'x2' set but not used}}
+  dispatch_async(&_dispatch_main_q, ^{
+    x = ((void *)0);
+    y = x;
+    z = ((void *)0);
+  });
+  x2 = getFoo();
+}


### PR DESCRIPTION
… objective-c pointers

The __block Objective-C pointers can be set but not used due to a commonly used lifetime extension pattern in Objective-C.

Differential Revision: https://reviews.llvm.org/D112850

(cherry picked from commit a00944ebeab1b0adbce606cde4d2410fcbb3f440)