### PR TITLE
[lldb] Use std::string instead of llvm::Twine in GDBRemoteCommunicationClient

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -1075,9 +1075,8 @@ void GDBRemoteCommunicationClient::MaybeEnableCompression(
 
   if (avail_type != CompressionType::None) {
     StringExtractorGDBRemote response;
-    llvm::Twine packet = "QEnableCompression:type:" + avail_name + ";";
-    if (SendPacketAndWaitForResponse(packet.str(), response) !=
-        PacketResult::Success)
+    std::string packet = "QEnableCompression:type:" + avail_name.str() + ";";
+    if (SendPacketAndWaitForResponse(packet, response) != PacketResult::Success)
       return;
 
     if (response.IsOKResponse()) {


### PR DESCRIPTION
From the documentation:

  A Twine is not intended for use directly and should not be stored, its
  implementation relies on the ability to store pointers to temporary
  stack objects which may be deallocated at the end of a statement.
  Twines should only be used accepted as const references in arguments,
  when an API wishes to accept possibly-concatenated strings.

rdar://84799118

Differential revision: https://reviews.llvm.org/D113314

(cherry picked from commit 6d48e2505c7a68a470e75b61ad504d51db0f8a36)
