### PR TITLE
[Index] Disable ClearASTBeforeBackend when indexing is enabled

### DIFF
--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -177,6 +177,7 @@ CreateFrontendAction(CompilerInstance &CI) {
 #endif
 
   if (!FEOpts.IndexStorePath.empty()) {
+    CI.getCodeGenOpts().ClearASTBeforeBackend = false;
     Act = index::createIndexDataRecordingAction(FEOpts, std::move(Act));
     CI.setGenModuleActionWrapper(&index::createIndexDataRecordingAction);
   }


### PR DESCRIPTION
ClearASTBeforeBackend clears the AST before codegen, but the index data
is written after this point. Disable so the index still has access to
the AST.

Resolves rdar://85076833