### PR TITLE
🍒/FBI/05fbe758906e+ef2efd2553e0+1ab9a2906e19

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -555,12 +555,118 @@ bool PlatformDarwin::x86GetSupportedArchitectureAtIndex(uint32_t idx,
   return false;
 }
 
+static llvm::ArrayRef<const char *> GetCompatibleArchs(ArchSpec::Core core) {
+  switch (core) {
+  default:
+    LLVM_FALLTHROUGH;
+  case ArchSpec::eCore_arm_arm64: {
+    static const char *g_arm64_compatible_archs[] = {
+        "arm64",    "armv7",    "armv7f",   "armv7k",   "armv7s",   "armv7m",
+        "armv7em",  "armv6m",   "armv6",    "armv5",    "armv4",    "arm",
+        "thumbv7",  "thumbv7f", "thumbv7k", "thumbv7s", "thumbv7m", "thumbv7em",
+        "thumbv6m", "thumbv6",  "thumbv5",  "thumbv4t", "thumb",
+    };
+    return {g_arm64_compatible_archs};
+  }
+  case ArchSpec::eCore_arm_armv7: {
+    static const char *g_armv7_compatible_archs[] = {
+        "armv7",   "armv6m",   "armv6",   "armv5",   "armv4",    "arm",
+        "thumbv7", "thumbv6m", "thumbv6", "thumbv5", "thumbv4t", "thumb",
+    };
+    return {g_armv7_compatible_archs};
+  }
+  case ArchSpec::eCore_arm_armv7f: {
+    static const char *g_armv7f_compatible_archs[] = {
+        "armv7f",  "armv7",   "armv6m",   "armv6",   "armv5",
+        "armv4",   "arm",     "thumbv7f", "thumbv7", "thumbv6m",
+        "thumbv6", "thumbv5", "thumbv4t", "thumb",
+    };
+    return {g_armv7f_compatible_archs};
+  }
+  case ArchSpec::eCore_arm_armv7k:
+    static const char *g_armv7k_compatible_archs[] = {
+        "armv7k",  "armv7",   "armv6m",   "armv6",   "armv5",
+        "armv4",   "arm",     "thumbv7k", "thumbv7", "thumbv6m",
+        "thumbv6", "thumbv5", "thumbv4t", "thumb",
+    };
+    return {g_armv7k_compatible_archs};
+  case ArchSpec::eCore_arm_armv7s:
+    static const char *g_armv7s_compatible_archs[] = {
+        "armv7s",  "armv7",   "armv6m",   "armv6",   "armv5",
+        "armv4",   "arm",     "thumbv7s", "thumbv7", "thumbv6m",
+        "thumbv6", "thumbv5", "thumbv4t", "thumb",
+    };
+    return {g_armv7s_compatible_archs};
+  case ArchSpec::eCore_arm_armv7m:
+    static const char *g_armv7m_compatible_archs[] = {
+        "armv7m",  "armv7",   "armv6m",   "armv6",   "armv5",
+        "armv4",   "arm",     "thumbv7m", "thumbv7", "thumbv6m",
+        "thumbv6", "thumbv5", "thumbv4t", "thumb",
+    };
+    return {g_armv7m_compatible_archs};
+  case ArchSpec::eCore_arm_armv7em:
+    static const char *g_armv7em_compatible_archs[] = {
+        "armv7em", "armv7",   "armv6m",    "armv6",   "armv5",
+        "armv4",   "arm",     "thumbv7em", "thumbv7", "thumbv6m",
+        "thumbv6", "thumbv5", "thumbv4t",  "thumb",
+    };
+    return {g_armv7em_compatible_archs};
+  case ArchSpec::eCore_arm_armv6m:
+    static const char *g_armv6m_compatible_archs[] = {
+        "armv6m",   "armv6",   "armv5",   "armv4",    "arm",
+        "thumbv6m", "thumbv6", "thumbv5", "thumbv4t", "thumb",
+    };
+    return {g_armv6m_compatible_archs};
+  case ArchSpec::eCore_arm_armv6:
+    static const char *g_armv6_compatible_archs[] = {
+        "armv6",   "armv5",   "armv4",    "arm",
+        "thumbv6", "thumbv5", "thumbv4t", "thumb",
+    };
+    return {g_armv6_compatible_archs};
+  case ArchSpec::eCore_arm_armv5:
+    static const char *g_armv5_compatible_archs[] = {
+        "armv5", "armv4", "arm", "thumbv5", "thumbv4t", "thumb",
+    };
+    return {g_armv5_compatible_archs};
+  case ArchSpec::eCore_arm_armv4:
+    static const char *g_armv4_compatible_archs[] = {
+        "armv4",
+        "arm",
+        "thumbv4t",
+        "thumb",
+    };
+    return {g_armv4_compatible_archs};
+  }
+  return {};
+}
+
+const char *PlatformDarwin::GetCompatibleArch(ArchSpec::Core core, size_t idx) {
+  llvm::ArrayRef<const char *> compatible_archs = GetCompatibleArchs(core);
+  if (!compatible_archs.data())
+    return nullptr;
+  if (idx < compatible_archs.size())
+    return compatible_archs[idx];
+  return nullptr;
+}
+
 /// The architecture selection rules for arm processors These cpu subtypes have
 /// distinct names (e.g. armv7f) but armv7 binaries run fine on an armv7f
 /// processor.
 bool PlatformDarwin::ARMGetSupportedArchitectureAtIndex(uint32_t idx,
                                                         ArchSpec &arch) {
-  ArchSpec system_arch(GetSystemArchitecture());
+#if TARGET_OS_OSX
+  if (IsHost()) {
+    if (idx == 0) {
+      arch.SetTriple("arm64e-apple-macosx");
+      return true;
+    } else if (idx == 1) {
+      arch.SetTriple("arm64-apple-macosx");
+      return true;
+    }
+    arch.Clear();
+    return false;
+  }
+#endif
 
 #if defined(TARGET_OS_TV) && TARGET_OS_TV == 1
 #define OSNAME "tvos"
@@ -574,570 +680,14 @@ bool PlatformDarwin::ARMGetSupportedArchitectureAtIndex(uint32_t idx,
 #define OSNAME "ios"
 #endif
 
-#if TARGET_OS_OSX
-  if (IsHost()) {
-    if (idx == 0) {
-      arch.SetTriple("arm64e-apple-macosx");
-      return true;
-    } else if (idx == 1) {
-      arch.SetTriple("arm64-apple-macosx");
-      return true;
-    }
-    return false;
-  }
-#endif
-
+  const ArchSpec system_arch = GetSystemArchitecture();
   const ArchSpec::Core system_core = system_arch.GetCore();
-  switch (system_core) {
-  default:
-    switch (idx) {
-    case 0:
-      arch.SetTriple("arm64-apple-" OSNAME);
-      return true;
-    case 1:
-      arch.SetTriple("armv7-apple-" OSNAME);
-      return true;
-    case 2:
-      arch.SetTriple("armv7f-apple-" OSNAME);
-      return true;
-    case 3:
-      arch.SetTriple("armv7k-apple-" OSNAME);
-      return true;
-    case 4:
-      arch.SetTriple("armv7s-apple-" OSNAME);
-      return true;
-    case 5:
-      arch.SetTriple("armv7m-apple-" OSNAME);
-      return true;
-    case 6:
-      arch.SetTriple("armv7em-apple-" OSNAME);
-      return true;
-    case 7:
-      arch.SetTriple("armv6m-apple-" OSNAME);
-      return true;
-    case 8:
-      arch.SetTriple("armv6-apple-" OSNAME);
-      return true;
-    case 9:
-      arch.SetTriple("armv5-apple-" OSNAME);
-      return true;
-    case 10:
-      arch.SetTriple("armv4-apple-" OSNAME);
-      return true;
-    case 11:
-      arch.SetTriple("arm-apple-" OSNAME);
-      return true;
-    case 12:
-      arch.SetTriple("thumbv7-apple-" OSNAME);
-      return true;
-    case 13:
-      arch.SetTriple("thumbv7f-apple-" OSNAME);
-      return true;
-    case 14:
-      arch.SetTriple("thumbv7k-apple-" OSNAME);
-      return true;
-    case 15:
-      arch.SetTriple("thumbv7s-apple-" OSNAME);
-      return true;
-    case 16:
-      arch.SetTriple("thumbv7m-apple-" OSNAME);
-      return true;
-    case 17:
-      arch.SetTriple("thumbv7em-apple-" OSNAME);
-      return true;
-    case 18:
-      arch.SetTriple("thumbv6m-apple-" OSNAME);
-      return true;
-    case 19:
-      arch.SetTriple("thumbv6-apple-" OSNAME);
-      return true;
-    case 20:
-      arch.SetTriple("thumbv5-apple-" OSNAME);
-      return true;
-    case 21:
-      arch.SetTriple("thumbv4t-apple-" OSNAME);
-      return true;
-    case 22:
-      arch.SetTriple("thumb-apple-" OSNAME);
-      return true;
-    default:
-      break;
-    }
-    break;
-
-  case ArchSpec::eCore_arm_arm64:
-    switch (idx) {
-    case 0:
-      arch.SetTriple("arm64-apple-" OSNAME);
-      return true;
-    case 1:
-      arch.SetTriple("armv7s-apple-" OSNAME);
-      return true;
-    case 2:
-      arch.SetTriple("armv7f-apple-" OSNAME);
-      return true;
-    case 3:
-      arch.SetTriple("armv7m-apple-" OSNAME);
-      return true;
-    case 4:
-      arch.SetTriple("armv7em-apple-" OSNAME);
-      return true;
-    case 5:
-      arch.SetTriple("armv7-apple-" OSNAME);
-      return true;
-    case 6:
-      arch.SetTriple("armv6m-apple-" OSNAME);
-      return true;
-    case 7:
-      arch.SetTriple("armv6-apple-" OSNAME);
-      return true;
-    case 8:
-      arch.SetTriple("armv5-apple-" OSNAME);
-      return true;
-    case 9:
-      arch.SetTriple("armv4-apple-" OSNAME);
-      return true;
-    case 10:
-      arch.SetTriple("arm-apple-" OSNAME);
-      return true;
-    case 11:
-      arch.SetTriple("thumbv7-apple-" OSNAME);
-      return true;
-    case 12:
-      arch.SetTriple("thumbv7f-apple-" OSNAME);
-      return true;
-    case 13:
-      arch.SetTriple("thumbv7k-apple-" OSNAME);
-      return true;
-    case 14:
-      arch.SetTriple("thumbv7s-apple-" OSNAME);
-      return true;
-    case 15:
-      arch.SetTriple("thumbv7m-apple-" OSNAME);
-      return true;
-    case 16:
-      arch.SetTriple("thumbv7em-apple-" OSNAME);
-      return true;
-    case 17:
-      arch.SetTriple("thumbv6m-apple-" OSNAME);
-      return true;
-    case 18:
-      arch.SetTriple("thumbv6-apple-" OSNAME);
-      return true;
-    case 19:
-      arch.SetTriple("thumbv5-apple-" OSNAME);
-      return true;
-    case 20:
-      arch.SetTriple("thumbv4t-apple-" OSNAME);
-      return true;
-    case 21:
-      arch.SetTriple("thumb-apple-" OSNAME);
-      return true;
-    default:
-      break;
-    }
-    break;
-
-  case ArchSpec::eCore_arm_armv7f:
-    switch (idx) {
-    case 0:
-      arch.SetTriple("armv7f-apple-" OSNAME);
-      return true;
-    case 1:
-      arch.SetTriple("armv7-apple-" OSNAME);
-      return true;
-    case 2:
-      arch.SetTriple("armv6m-apple-" OSNAME);
-      return true;
-    case 3:
-      arch.SetTriple("armv6-apple-" OSNAME);
-      return true;
-    case 4:
-      arch.SetTriple("armv5-apple-" OSNAME);
-      return true;
-    case 5:
-      arch.SetTriple("armv4-apple-" OSNAME);
-      return true;
-    case 6:
-      arch.SetTriple("arm-apple-" OSNAME);
-      return true;
-    case 7:
-      arch.SetTriple("thumbv7f-apple-" OSNAME);
-      return true;
-    case 8:
-      arch.SetTriple("thumbv7-apple-" OSNAME);
-      return true;
-    case 9:
-      arch.SetTriple("thumbv6m-apple-" OSNAME);
-      return true;
-    case 10:
-      arch.SetTriple("thumbv6-apple-" OSNAME);
-      return true;
-    case 11:
-      arch.SetTriple("thumbv5-apple-" OSNAME);
-      return true;
-    case 12:
-      arch.SetTriple("thumbv4t-apple-" OSNAME);
-      return true;
-    case 13:
-      arch.SetTriple("thumb-apple-" OSNAME);
-      return true;
-    default:
-      break;
-    }
-    break;
-
-  case ArchSpec::eCore_arm_armv7k:
-    switch (idx) {
-    case 0:
-      arch.SetTriple("armv7k-apple-" OSNAME);
-      return true;
-    case 1:
-      arch.SetTriple("armv7-apple-" OSNAME);
-      return true;
-    case 2:
-      arch.SetTriple("armv6m-apple-" OSNAME);
-      return true;
-    case 3:
-      arch.SetTriple("armv6-apple-" OSNAME);
-      return true;
-    case 4:
-      arch.SetTriple("armv5-apple-" OSNAME);
-      return true;
-    case 5:
-      arch.SetTriple("armv4-apple-" OSNAME);
-      return true;
-    case 6:
-      arch.SetTriple("arm-apple-" OSNAME);
-      return true;
-    case 7:
-      arch.SetTriple("thumbv7k-apple-" OSNAME);
-      return true;
-    case 8:
-      arch.SetTriple("thumbv7-apple-" OSNAME);
-      return true;
-    case 9:
-      arch.SetTriple("thumbv6m-apple-" OSNAME);
-      return true;
-    case 10:
-      arch.SetTriple("thumbv6-apple-" OSNAME);
-      return true;
-    case 11:
-      arch.SetTriple("thumbv5-apple-" OSNAME);
-      return true;
-    case 12:
-      arch.SetTriple("thumbv4t-apple-" OSNAME);
-      return true;
-    case 13:
-      arch.SetTriple("thumb-apple-" OSNAME);
-      return true;
-    default:
-      break;
-    }
-    break;
-
-  case ArchSpec::eCore_arm_armv7s:
-    switch (idx) {
-    case 0:
-      arch.SetTriple("armv7s-apple-" OSNAME);
-      return true;
-    case 1:
-      arch.SetTriple("armv7-apple-" OSNAME);
-      return true;
-    case 2:
-      arch.SetTriple("armv6m-apple-" OSNAME);
-      return true;
-    case 3:
-      arch.SetTriple("armv6-apple-" OSNAME);
-      return true;
-    case 4:
-      arch.SetTriple("armv5-apple-" OSNAME);
-      return true;
-    case 5:
-      arch.SetTriple("armv4-apple-" OSNAME);
-      return true;
-    case 6:
-      arch.SetTriple("arm-apple-" OSNAME);
-      return true;
-    case 7:
-      arch.SetTriple("thumbv7s-apple-" OSNAME);
-      return true;
-    case 8:
-      arch.SetTriple("thumbv7-apple-" OSNAME);
-      return true;
-    case 9:
-      arch.SetTriple("thumbv6m-apple-" OSNAME);
-      return true;
-    case 10:
-      arch.SetTriple("thumbv6-apple-" OSNAME);
-      return true;
-    case 11:
-      arch.SetTriple("thumbv5-apple-" OSNAME);
-      return true;
-    case 12:
-      arch.SetTriple("thumbv4t-apple-" OSNAME);
-      return true;
-    case 13:
-      arch.SetTriple("thumb-apple-" OSNAME);
-      return true;
-    default:
-      break;
-    }
-    break;
-
-  case ArchSpec::eCore_arm_armv7m:
-    switch (idx) {
-    case 0:
-      arch.SetTriple("armv7m-apple-" OSNAME);
-      return true;
-    case 1:
-      arch.SetTriple("armv7-apple-" OSNAME);
-      return true;
-    case 2:
-      arch.SetTriple("armv6m-apple-" OSNAME);
-      return true;
-    case 3:
-      arch.SetTriple("armv6-apple-" OSNAME);
-      return true;
-    case 4:
-      arch.SetTriple("armv5-apple-" OSNAME);
-      return true;
-    case 5:
-      arch.SetTriple("armv4-apple-" OSNAME);
-      return true;
-    case 6:
-      arch.SetTriple("arm-apple-" OSNAME);
-      return true;
-    case 7:
-      arch.SetTriple("thumbv7m-apple-" OSNAME);
-      return true;
-    case 8:
-      arch.SetTriple("thumbv7-apple-" OSNAME);
-      return true;
-    case 9:
-      arch.SetTriple("thumbv6m-apple-" OSNAME);
-      return true;
-    case 10:
-      arch.SetTriple("thumbv6-apple-" OSNAME);
-      return true;
-    case 11:
-      arch.SetTriple("thumbv5-apple-" OSNAME);
-      return true;
-    case 12:
-      arch.SetTriple("thumbv4t-apple-" OSNAME);
-      return true;
-    case 13:
-      arch.SetTriple("thumb-apple-" OSNAME);
-      return true;
-    default:
-      break;
-    }
-    break;
-
-  case ArchSpec::eCore_arm_armv7em:
-    switch (idx) {
-    case 0:
-      arch.SetTriple("armv7em-apple-" OSNAME);
-      return true;
-    case 1:
-      arch.SetTriple("armv7-apple-" OSNAME);
-      return true;
-    case 2:
-      arch.SetTriple("armv6m-apple-" OSNAME);
-      return true;
-    case 3:
-      arch.SetTriple("armv6-apple-" OSNAME);
-      return true;
-    case 4:
-      arch.SetTriple("armv5-apple-" OSNAME);
-      return true;
-    case 5:
-      arch.SetTriple("armv4-apple-" OSNAME);
-      return true;
-    case 6:
-      arch.SetTriple("arm-apple-" OSNAME);
-      return true;
-    case 7:
-      arch.SetTriple("thumbv7em-apple-" OSNAME);
-      return true;
-    case 8:
-      arch.SetTriple("thumbv7-apple-" OSNAME);
-      return true;
-    case 9:
-      arch.SetTriple("thumbv6m-apple-" OSNAME);
-      return true;
-    case 10:
-      arch.SetTriple("thumbv6-apple-" OSNAME);
-      return true;
-    case 11:
-      arch.SetTriple("thumbv5-apple-" OSNAME);
-      return true;
-    case 12:
-      arch.SetTriple("thumbv4t-apple-" OSNAME);
-      return true;
-    case 13:
-      arch.SetTriple("thumb-apple-" OSNAME);
-      return true;
-    default:
-      break;
-    }
-    break;
-
-  case ArchSpec::eCore_arm_armv7:
-    switch (idx) {
-    case 0:
-      arch.SetTriple("armv7-apple-" OSNAME);
-      return true;
-    case 1:
-      arch.SetTriple("armv6m-apple-" OSNAME);
-      return true;
-    case 2:
-      arch.SetTriple("armv6-apple-" OSNAME);
-      return true;
-    case 3:
-      arch.SetTriple("armv5-apple-" OSNAME);
-      return true;
-    case 4:
-      arch.SetTriple("armv4-apple-" OSNAME);
-      return true;
-    case 5:
-      arch.SetTriple("arm-apple-" OSNAME);
-      return true;
-    case 6:
-      arch.SetTriple("thumbv7-apple-" OSNAME);
-      return true;
-    case 7:
-      arch.SetTriple("thumbv6m-apple-" OSNAME);
-      return true;
-    case 8:
-      arch.SetTriple("thumbv6-apple-" OSNAME);
-      return true;
-    case 9:
-      arch.SetTriple("thumbv5-apple-" OSNAME);
-      return true;
-    case 10:
-      arch.SetTriple("thumbv4t-apple-" OSNAME);
-      return true;
-    case 11:
-      arch.SetTriple("thumb-apple-" OSNAME);
-      return true;
-    default:
-      break;
-    }
-    break;
-
-  case ArchSpec::eCore_arm_armv6m:
-    switch (idx) {
-    case 0:
-      arch.SetTriple("armv6m-apple-" OSNAME);
-      return true;
-    case 1:
-      arch.SetTriple("armv6-apple-" OSNAME);
-      return true;
-    case 2:
-      arch.SetTriple("armv5-apple-" OSNAME);
-      return true;
-    case 3:
-      arch.SetTriple("armv4-apple-" OSNAME);
-      return true;
-    case 4:
-      arch.SetTriple("arm-apple-" OSNAME);
-      return true;
-    case 5:
-      arch.SetTriple("thumbv6m-apple-" OSNAME);
-      return true;
-    case 6:
-      arch.SetTriple("thumbv6-apple-" OSNAME);
-      return true;
-    case 7:
-      arch.SetTriple("thumbv5-apple-" OSNAME);
-      return true;
-    case 8:
-      arch.SetTriple("thumbv4t-apple-" OSNAME);
-      return true;
-    case 9:
-      arch.SetTriple("thumb-apple-" OSNAME);
-      return true;
-    default:
-      break;
-    }
-    break;
-
-  case ArchSpec::eCore_arm_armv6:
-    switch (idx) {
-    case 0:
-      arch.SetTriple("armv6-apple-" OSNAME);
-      return true;
-    case 1:
-      arch.SetTriple("armv5-apple-" OSNAME);
-      return true;
-    case 2:
-      arch.SetTriple("armv4-apple-" OSNAME);
-      return true;
-    case 3:
-      arch.SetTriple("arm-apple-" OSNAME);
-      return true;
-    case 4:
-      arch.SetTriple("thumbv6-apple-" OSNAME);
-      return true;
-    case 5:
-      arch.SetTriple("thumbv5-apple-" OSNAME);
-      return true;
-    case 6:
-      arch.SetTriple("thumbv4t-apple-" OSNAME);
-      return true;
-    case 7:
-      arch.SetTriple("thumb-apple-" OSNAME);
-      return true;
-    default:
-      break;
-    }
-    break;
-
-  case ArchSpec::eCore_arm_armv5:
-    switch (idx) {
-    case 0:
-      arch.SetTriple("armv5-apple-" OSNAME);
-      return true;
-    case 1:
-      arch.SetTriple("armv4-apple-" OSNAME);
-      return true;
-    case 2:
-      arch.SetTriple("arm-apple-" OSNAME);
-      return true;
-    case 3:
-      arch.SetTriple("thumbv5-apple-" OSNAME);
-      return true;
-    case 4:
-      arch.SetTriple("thumbv4t-apple-" OSNAME);
-      return true;
-    case 5:
-      arch.SetTriple("thumb-apple-" OSNAME);
-      return true;
-    default:
-      break;
-    }
-    break;
-
-  case ArchSpec::eCore_arm_armv4:
-    switch (idx) {
-    case 0:
-      arch.SetTriple("armv4-apple-" OSNAME);
-      return true;
-    case 1:
-      arch.SetTriple("arm-apple-" OSNAME);
-      return true;
-    case 2:
-      arch.SetTriple("thumbv4t-apple-" OSNAME);
-      return true;
-    case 3:
-      arch.SetTriple("thumb-apple-" OSNAME);
-      return true;
-    default:
-      break;
-    }
-    break;
+  if (const char *compatible_arch = GetCompatibleArch(system_core, idx)) {
+    std::string triple =
+        llvm::formatv("{0}-apple-" OSNAME, compatible_arch).str();
+    arch.SetTriple(triple);
   }
+
   arch.Clear();
   return false;
 }

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -583,52 +583,59 @@ static llvm::ArrayRef<const char *> GetCompatibleArchs(ArchSpec::Core core) {
     };
     return {g_armv7f_compatible_archs};
   }
-  case ArchSpec::eCore_arm_armv7k:
+  case ArchSpec::eCore_arm_armv7k: {
     static const char *g_armv7k_compatible_archs[] = {
         "armv7k",  "armv7",   "armv6m",   "armv6",   "armv5",
         "armv4",   "arm",     "thumbv7k", "thumbv7", "thumbv6m",
         "thumbv6", "thumbv5", "thumbv4t", "thumb",
     };
     return {g_armv7k_compatible_archs};
-  case ArchSpec::eCore_arm_armv7s:
+  }
+  case ArchSpec::eCore_arm_armv7s: {
     static const char *g_armv7s_compatible_archs[] = {
         "armv7s",  "armv7",   "armv6m",   "armv6",   "armv5",
         "armv4",   "arm",     "thumbv7s", "thumbv7", "thumbv6m",
         "thumbv6", "thumbv5", "thumbv4t", "thumb",
     };
     return {g_armv7s_compatible_archs};
-  case ArchSpec::eCore_arm_armv7m:
+  }
+  case ArchSpec::eCore_arm_armv7m: {
     static const char *g_armv7m_compatible_archs[] = {
         "armv7m",  "armv7",   "armv6m",   "armv6",   "armv5",
         "armv4",   "arm",     "thumbv7m", "thumbv7", "thumbv6m",
         "thumbv6", "thumbv5", "thumbv4t", "thumb",
     };
     return {g_armv7m_compatible_archs};
-  case ArchSpec::eCore_arm_armv7em:
+  }
+  case ArchSpec::eCore_arm_armv7em: {
     static const char *g_armv7em_compatible_archs[] = {
         "armv7em", "armv7",   "armv6m",    "armv6",   "armv5",
         "armv4",   "arm",     "thumbv7em", "thumbv7", "thumbv6m",
         "thumbv6", "thumbv5", "thumbv4t",  "thumb",
     };
     return {g_armv7em_compatible_archs};
-  case ArchSpec::eCore_arm_armv6m:
+  }
+  case ArchSpec::eCore_arm_armv6m: {
     static const char *g_armv6m_compatible_archs[] = {
         "armv6m",   "armv6",   "armv5",   "armv4",    "arm",
         "thumbv6m", "thumbv6", "thumbv5", "thumbv4t", "thumb",
     };
     return {g_armv6m_compatible_archs};
-  case ArchSpec::eCore_arm_armv6:
+  }
+  case ArchSpec::eCore_arm_armv6: {
     static const char *g_armv6_compatible_archs[] = {
         "armv6",   "armv5",   "armv4",    "arm",
         "thumbv6", "thumbv5", "thumbv4t", "thumb",
     };
     return {g_armv6_compatible_archs};
-  case ArchSpec::eCore_arm_armv5:
+  }
+  case ArchSpec::eCore_arm_armv5: {
     static const char *g_armv5_compatible_archs[] = {
         "armv5", "armv4", "arm", "thumbv5", "thumbv4t", "thumb",
     };
     return {g_armv5_compatible_archs};
-  case ArchSpec::eCore_arm_armv4:
+  }
+  case ArchSpec::eCore_arm_armv4: {
     static const char *g_armv4_compatible_archs[] = {
         "armv4",
         "arm",
@@ -636,6 +643,7 @@ static llvm::ArrayRef<const char *> GetCompatibleArchs(ArchSpec::Core core) {
         "thumb",
     };
     return {g_armv4_compatible_archs};
+  }
   }
   return {};
 }

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -103,6 +103,9 @@ public:
   static lldb_private::FileSpec GetCurrentCommandLineToolsDirectory();
 
 protected:
+  static const char *GetCompatibleArch(lldb_private::ArchSpec::Core core,
+                                       size_t idx);
+
   struct CrashInfoAnnotations {
     uint64_t version;          // unsigned long
     uint64_t message;          // char *

--- a/lldb/tools/debugserver/source/TTYState.cpp
+++ b/lldb/tools/debugserver/source/TTYState.cpp
@@ -39,20 +39,19 @@ bool TTYState::GetTTYState(int fd, bool saveProcessGroup) {
 }
 
 bool TTYState::SetTTYState() const {
-  int result = 0;
   if (IsValid()) {
     if (TFlagsValid())
-      result = fcntl(m_fd, F_SETFL, m_tflags);
+      fcntl(m_fd, F_SETFL, m_tflags);
 
     if (TTYStateValid())
-      result = tcsetattr(m_fd, TCSANOW, &m_ttystate);
+      tcsetattr(m_fd, TCSANOW, &m_ttystate);
 
     if (ProcessGroupValid()) {
       // Save the original signal handler.
       void (*saved_sigttou_callback)(int) = NULL;
       saved_sigttou_callback = (void (*)(int))signal(SIGTTOU, SIG_IGN);
       // Set the process group
-      result = tcsetpgrp(m_fd, m_processGroup);
+      tcsetpgrp(m_fd, m_processGroup);
       // Restore the original signal handler.
       signal(SIGTTOU, saved_sigttou_callback);
     }

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -20,6 +20,7 @@ using namespace lldb_private;
 struct PlatformDarwinTester : public PlatformDarwin {
 public:
   using PlatformDarwin::FindComponentInPath;
+  using PlatformDarwin::GetCompatibleArch;
 };
 
 TEST(PlatformDarwinTest, TestParseVersionBuildDir) {
@@ -65,4 +66,96 @@ TEST(PlatformDarwinTest, FindComponentInPath) {
 
   EXPECT_EQ("",
             PlatformDarwinTester::FindComponentInPath("/path/to/foo", "bar"));
+}
+
+TEST(PlatformDarwinTest, GetCompatibleArchARM64) {
+  const ArchSpec::Core core = ArchSpec::eCore_arm_arm64;
+  EXPECT_STREQ("arm64", PlatformDarwinTester::GetCompatibleArch(core, 0));
+  EXPECT_STREQ("armv7", PlatformDarwinTester::GetCompatibleArch(core, 1));
+  EXPECT_STREQ("armv4", PlatformDarwinTester::GetCompatibleArch(core, 10));
+  EXPECT_STREQ("arm", PlatformDarwinTester::GetCompatibleArch(core, 11));
+  EXPECT_STREQ("thumbv7", PlatformDarwinTester::GetCompatibleArch(core, 12));
+  EXPECT_STREQ("thumbv4t", PlatformDarwinTester::GetCompatibleArch(core, 21));
+  EXPECT_STREQ("thumb", PlatformDarwinTester::GetCompatibleArch(core, 22));
+  EXPECT_EQ(nullptr, PlatformDarwinTester::GetCompatibleArch(core, 23));
+}
+
+TEST(PlatformDarwinTest, GetCompatibleArchARMv7f) {
+  const ArchSpec::Core core = ArchSpec::eCore_arm_armv7f;
+  EXPECT_STREQ("armv7f", PlatformDarwinTester::GetCompatibleArch(core, 0));
+  EXPECT_STREQ("armv7", PlatformDarwinTester::GetCompatibleArch(core, 1));
+  EXPECT_STREQ("arm", PlatformDarwinTester::GetCompatibleArch(core, 6));
+  EXPECT_STREQ("thumbv7f", PlatformDarwinTester::GetCompatibleArch(core, 7));
+}
+
+TEST(PlatformDarwinTest, GetCompatibleArchARMv7k) {
+  const ArchSpec::Core core = ArchSpec::eCore_arm_armv7k;
+  EXPECT_STREQ("armv7k", PlatformDarwinTester::GetCompatibleArch(core, 0));
+  EXPECT_STREQ("armv7", PlatformDarwinTester::GetCompatibleArch(core, 1));
+  EXPECT_STREQ("arm", PlatformDarwinTester::GetCompatibleArch(core, 6));
+  EXPECT_STREQ("thumbv7k", PlatformDarwinTester::GetCompatibleArch(core, 7));
+}
+
+TEST(PlatformDarwinTest, GetCompatibleArchARMv7s) {
+  const ArchSpec::Core core = ArchSpec::eCore_arm_armv7s;
+  EXPECT_STREQ("armv7s", PlatformDarwinTester::GetCompatibleArch(core, 0));
+  EXPECT_STREQ("armv7", PlatformDarwinTester::GetCompatibleArch(core, 1));
+  EXPECT_STREQ("arm", PlatformDarwinTester::GetCompatibleArch(core, 6));
+  EXPECT_STREQ("thumbv7s", PlatformDarwinTester::GetCompatibleArch(core, 7));
+}
+
+TEST(PlatformDarwinTest, GetCompatibleArchARMv7m) {
+  const ArchSpec::Core core = ArchSpec::eCore_arm_armv7m;
+  EXPECT_STREQ("armv7m", PlatformDarwinTester::GetCompatibleArch(core, 0));
+  EXPECT_STREQ("armv7", PlatformDarwinTester::GetCompatibleArch(core, 1));
+  EXPECT_STREQ("arm", PlatformDarwinTester::GetCompatibleArch(core, 6));
+  EXPECT_STREQ("thumbv7m", PlatformDarwinTester::GetCompatibleArch(core, 7));
+}
+
+TEST(PlatformDarwinTest, GetCompatibleArchARMv7em) {
+  const ArchSpec::Core core = ArchSpec::eCore_arm_armv7em;
+  EXPECT_STREQ("armv7em", PlatformDarwinTester::GetCompatibleArch(core, 0));
+  EXPECT_STREQ("armv7", PlatformDarwinTester::GetCompatibleArch(core, 1));
+  EXPECT_STREQ("arm", PlatformDarwinTester::GetCompatibleArch(core, 6));
+  EXPECT_STREQ("thumbv7em", PlatformDarwinTester::GetCompatibleArch(core, 7));
+}
+
+TEST(PlatformDarwinTest, GetCompatibleArchARMv7) {
+  const ArchSpec::Core core = ArchSpec::eCore_arm_armv7;
+  EXPECT_STREQ("armv7", PlatformDarwinTester::GetCompatibleArch(core, 0));
+  EXPECT_STREQ("armv6m", PlatformDarwinTester::GetCompatibleArch(core, 1));
+  EXPECT_STREQ("arm", PlatformDarwinTester::GetCompatibleArch(core, 5));
+  EXPECT_STREQ("thumbv7", PlatformDarwinTester::GetCompatibleArch(core, 6));
+}
+
+TEST(PlatformDarwinTest, GetCompatibleArchARMv6m) {
+  const ArchSpec::Core core = ArchSpec::eCore_arm_armv6m;
+  EXPECT_STREQ("armv6m", PlatformDarwinTester::GetCompatibleArch(core, 0));
+  EXPECT_STREQ("armv6", PlatformDarwinTester::GetCompatibleArch(core, 1));
+  EXPECT_STREQ("arm", PlatformDarwinTester::GetCompatibleArch(core, 4));
+  EXPECT_STREQ("thumbv6m", PlatformDarwinTester::GetCompatibleArch(core, 5));
+}
+
+TEST(PlatformDarwinTest, GetCompatibleArchARMv6) {
+  const ArchSpec::Core core = ArchSpec::eCore_arm_armv6;
+  EXPECT_STREQ("armv6", PlatformDarwinTester::GetCompatibleArch(core, 0));
+  EXPECT_STREQ("armv5", PlatformDarwinTester::GetCompatibleArch(core, 1));
+  EXPECT_STREQ("arm", PlatformDarwinTester::GetCompatibleArch(core, 3));
+  EXPECT_STREQ("thumbv6", PlatformDarwinTester::GetCompatibleArch(core, 4));
+}
+
+TEST(PlatformDarwinTest, GetCompatibleArchARMv5) {
+  const ArchSpec::Core core = ArchSpec::eCore_arm_armv5;
+  EXPECT_STREQ("armv5", PlatformDarwinTester::GetCompatibleArch(core, 0));
+  EXPECT_STREQ("armv4", PlatformDarwinTester::GetCompatibleArch(core, 1));
+  EXPECT_STREQ("arm", PlatformDarwinTester::GetCompatibleArch(core, 2));
+  EXPECT_STREQ("thumbv5", PlatformDarwinTester::GetCompatibleArch(core, 3));
+}
+
+TEST(PlatformDarwinTest, GetCompatibleArchARMv4) {
+  const ArchSpec::Core core = ArchSpec::eCore_arm_armv4;
+  EXPECT_STREQ("armv4", PlatformDarwinTester::GetCompatibleArch(core, 0));
+  EXPECT_STREQ("arm", PlatformDarwinTester::GetCompatibleArch(core, 1));
+  EXPECT_STREQ("thumbv4t", PlatformDarwinTester::GetCompatibleArch(core, 2));
+  EXPECT_STREQ("thumb", PlatformDarwinTester::GetCompatibleArch(core, 3));
 }


### PR DESCRIPTION
- [lldb] Remove nested switches from ARMGetSupportedArchitectureAtIndex (NFC)
- [lldb] Remove 'result' variable which is set but not used (NFC)
- [lldb] Fix C2360: initialization of 'identifier' is skipped by 'case' label
