### PR TITLE
Revert "[lldb] Disable swift-create-module-contexts-in-parallel for a few tests"

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/pyobjsynthprovider/TestPyObjSynthProvider.py
+++ b/lldb/test/API/functionalities/data-formatter/pyobjsynthprovider/TestPyObjSynthProvider.py
@@ -28,8 +28,6 @@ class PyObjectSynthProviderTestCase(TestBase):
 
     def provider_data_formatter_commands(self):
         """Test that the PythonObjectSyntheticChildProvider helper class works"""
-        # rdar://84688015 SILModule::checkForLeaks can assert when used concurrently.
-        self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)
 
         lldbutil.run_break_set_by_file_and_line(

--- a/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
@@ -45,8 +45,6 @@ class TestSwiftDynamicTypeResolutionImportConflict(TestBase):
 
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
-        # rdar://84688015 SILModule::checkForLeaks can assert when used concurrently.
-        self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.build()
         target, _, _, _ = lldbutil.run_to_source_breakpoint(self, "break here",
                                           lldb.SBFileSpec('main.swift'),

--- a/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
@@ -38,8 +38,6 @@ class TestSwiftHeadermapConflict(TestBase):
         self.runCmd("settings set symbols.use-swift-dwarfimporter false")
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
-        # rdar://84688015 SILModule::checkForLeaks can assert when used concurrently.
-        self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.build()
 
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
@@ -38,8 +38,6 @@ class TestSwiftMacroConflict(TestBase):
         self.runCmd('settings set symbols.use-swift-dwarfimporter false')
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
-        # rdar://84688015 SILModule::checkForLeaks can assert when used concurrently.
-        self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.build()
 
         target, process, _, _ = lldbutil.run_to_source_breakpoint(
@@ -79,9 +77,6 @@ class TestSwiftMacroConflict(TestBase):
         self.runCmd('settings set symbols.use-swift-dwarfimporter true')
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
-        # rdar://84688015 SILModule::checkForLeaks can assert when used concurrently.
-        self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
-
         self.build()
 
         target, process, _, _ = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
@@ -37,8 +37,6 @@ class TestSwiftObjCMainConflictingDylibs(TestBase):
 
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
-        # rdar://84688015 SILModule::checkForLeaks can assert when used concurrently.
-        self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.build()
         target, process, _, foo_breakpoint = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('Foo.swift'),

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
@@ -37,8 +37,6 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
 
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
-        # rdar://84688015 SILModule::checkForLeaks can assert when used concurrently.
-        self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
         self.build()
 
         target, process, _, bar_breakpoint = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -60,8 +60,6 @@ class TestSwiftRewriteClangPaths(TestBase):
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
         self.runCmd("settings set symbols.use-swift-dwarfimporter false")
-        # rdar://84688015 SILModule::checkForLeaks can assert when used concurrently.
-        self.runCmd("settings set target.experimental.swift-create-module-contexts-in-parallel false")
 
         botdir = os.path.realpath(self.getBuildArtifact("buildbot"))
         userdir = os.path.realpath(self.getBuildArtifact("user"))


### PR DESCRIPTION
These temporary workarounds can be removed now that a fix (https://github.com/apple/swift/pull/39980) has been merged.

This reverts https://github.com/apple/llvm-project/pull/3474