### PR TITLE
[5.5][Index] Add an async symbol property

### DIFF
--- a/clang/include/clang/Index/IndexSymbol.h
+++ b/clang/include/clang/Index/IndexSymbol.h
@@ -101,7 +101,7 @@ enum class SymbolSubKind : uint8_t {
   SwiftGenericTypeParam,
 };
 
-typedef uint16_t SymbolPropertySet;
+typedef uint32_t SymbolPropertySet;
 /// Set of properties that provide additional info about a symbol.
 enum class SymbolProperty : SymbolPropertySet {
   Generic                       = 1 << 0,
@@ -114,8 +114,10 @@ enum class SymbolProperty : SymbolPropertySet {
   Local                         = 1 << 7,
   /// Symbol is part of a protocol interface.
   ProtocolInterface             = 1 << 8,
+
+  /// Swift-only properties
+  SwiftAsync                    = 1 << 16,
 };
-static const unsigned SymbolPropertyBitNum = 9;
 
 /// Set of roles that are attributed to symbol occurrences.
 ///

--- a/clang/include/indexstore/indexstore.h
+++ b/clang/include/indexstore/indexstore.h
@@ -25,7 +25,7 @@
  * INDEXSTORE_VERSION_MAJOR is intended for "major" source/ABI breaking changes.
  */
 #define INDEXSTORE_VERSION_MAJOR 0
-#define INDEXSTORE_VERSION_MINOR 11
+#define INDEXSTORE_VERSION_MINOR 12
 
 #define INDEXSTORE_VERSION_ENCODE(major, minor) ( \
       ((major) * 10000)                           \
@@ -299,6 +299,8 @@ INDEXSTORE_OPTIONS(uint64_t, indexstore_symbol_property_t) {
   INDEXSTORE_SYMBOL_PROPERTY_GKINSPECTABLE                    = 1 << 6,
   INDEXSTORE_SYMBOL_PROPERTY_LOCAL                            = 1 << 7,
   INDEXSTORE_SYMBOL_PROPERTY_PROTOCOL_INTERFACE               = 1 << 8,
+
+  INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ASYNC                      = 1 << 16,
 };
 
 typedef enum {

--- a/clang/lib/Index/IndexDataStoreUtils.cpp
+++ b/clang/lib/Index/IndexDataStoreUtils.cpp
@@ -227,6 +227,8 @@ SymbolPropertySet index::getSymbolProperties(uint64_t Props) {
     SymbolProperties |= (SymbolPropertySet)SymbolProperty::Local;
   if (Props & INDEXSTORE_SYMBOL_PROPERTY_PROTOCOL_INTERFACE)
     SymbolProperties |= (SymbolPropertySet)SymbolProperty::ProtocolInterface;
+  if (Props & INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ASYNC)
+    SymbolProperties |= (SymbolPropertySet)SymbolProperty::SwiftAsync;
 
   return SymbolProperties;
 }
@@ -458,6 +460,9 @@ indexstore_symbol_property_t index::getIndexStoreProperties(SymbolPropertySet Pr
       break;
     case SymbolProperty::ProtocolInterface:
       storeProp |= INDEXSTORE_SYMBOL_PROPERTY_PROTOCOL_INTERFACE;
+      break;
+    case SymbolProperty::SwiftAsync:
+      storeProp |= INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ASYNC;
       break;
     }
   });

--- a/clang/lib/Index/IndexRecordWriter.cpp
+++ b/clang/lib/Index/IndexRecordWriter.cpp
@@ -128,7 +128,7 @@ static void writeDecls(BitstreamWriter &Stream, ArrayRef<DeclInfo> Decls,
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 5)); // Kind
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 5)); // SubKind
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 5)); // Language
-  Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, SymbolPropertyBitNum)); // Properties
+  Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 9)); // Properties
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, SymbolRoleBitNum)); // Roles
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, SymbolRoleBitNum)); // Related Roles
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // Length of name in block

--- a/clang/lib/Index/IndexSymbol.cpp
+++ b/clang/lib/Index/IndexSymbol.cpp
@@ -588,6 +588,7 @@ void index::applyForEachSymbolProperty(SymbolPropertySet Props,
   APPLY_FOR_PROPERTY(GKInspectable);
   APPLY_FOR_PROPERTY(Local);
   APPLY_FOR_PROPERTY(ProtocolInterface);
+  APPLY_FOR_PROPERTY(SwiftAsync);
 
 #undef APPLY_FOR_PROPERTY
 }
@@ -609,6 +610,7 @@ void index::printSymbolProperties(SymbolPropertySet Props, raw_ostream &OS) {
     case SymbolProperty::GKInspectable: OS << "GKI"; break;
     case SymbolProperty::Local: OS << "local"; break;
     case SymbolProperty::ProtocolInterface: OS << "protocol"; break;
+    case SymbolProperty::SwiftAsync: OS << "swift_async"; break;
     }
   });
 }


### PR DESCRIPTION
Cherry-pick 28d136d2465a7ade9338e78b0c43ba3c06ad2a9b (https://github.com/apple/llvm-project/pull/3452)

Resolves SR-15476

-----

Since this is a Swift-only property, set to a high value to avoid
conflicts with new Clang properties.

Resolves rdar://83780222