### PR TITLE
lldb: link swift's libswift to lldb

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -151,6 +151,40 @@ function(add_lldb_library name)
   endif()
 endfunction(add_lldb_library)
 
+# BEGIN Swift Mods
+function(add_properties_for_swift_modules target)
+  if (BOOTSTRAPPING_MODE)
+    if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+      if(BOOTSTRAPPING_MODE MATCHES "HOSTTOOLS|.*HOSTLIBS")
+        target_link_directories(${target} PRIVATE
+            "${CMAKE_OSX_SYSROOT}/usr/lib/swift"
+            "${LLDB_SWIFT_LIBS}/macosx")
+        set_property(TARGET ${target} APPEND PROPERTY INSTALL_RPATH
+            "/usr/lib/swift")
+      elseif(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
+        target_link_directories(${target} PRIVATE "${LLDB_SWIFT_LIBS}/macosx")
+        set_property(TARGET ${target} APPEND PROPERTY INSTALL_RPATH
+            "${LLDB_SWIFT_LIBS}/macosx")
+      else()
+        message(FATAL_ERROR "Unknown BOOTSTRAPPING_MODE '${BOOTSTRAPPING_MODE}'")
+      endif()
+
+      # Workaround for a linker crash related to autolinking: rdar://77839981
+      set_property(TARGET ${target} APPEND_STRING PROPERTY
+                   LINK_FLAGS " -lobjc ")
+    elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
+      string(REGEX MATCH "^[^-]*" arch ${TARGET_TRIPLE})
+      target_link_libraries(${target} PRIVATE swiftCore-linux-${arch})
+  
+      # TODO: add "${LLDB_SWIFT_LIBS}/linux" to BUILD_RPATH and not INSTALL_RPATH.
+      # This does not work for some reason.
+      set_property(TARGET ${target} APPEND PROPERTY INSTALL_RPATH
+          "${LLDB_SWIFT_LIBS}/linux;$ORIGIN/../lib/swift/linux")
+    endif()
+  endif()
+endfunction()
+# END Swift Mods
+
 function(add_lldb_executable name)
   cmake_parse_arguments(ARG
     "GENERATE_INSTALL"

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -125,6 +125,10 @@ add_lldb_library(liblldb SHARED ${option_framework}
   ${option_install_prefix}
 )
 
+# BEGIN Swift Mods
+add_properties_for_swift_modules(liblldb)
+# END Swift Mods
+
 # lib/pythonX.Y/dist-packages/lldb/_lldb.so is a symlink to lib/liblldb.so,
 # which depends on lib/libLLVM*.so (BUILD_SHARED_LIBS) or lib/libLLVM-10git.so
 # (LLVM_LINK_LLVM_DYLIB). Add an additional rpath $ORIGIN/../../../../lib so

--- a/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
@@ -37,6 +37,7 @@ add_lldb_library(lldbPluginExpressionParserSwift PLUGIN
     swiftSIL
     swiftSILOptimizer
     swiftSerialization
+    swiftCompilerModules
     clangAST
     clangBasic
     clangRewrite

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -39,6 +39,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/InitializeSwiftModules.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "llvm/Support/ConvertUTF.h"
 
@@ -79,6 +80,8 @@ void SwiftLanguage::Initialize() {
   lldb_private::formatters::NSArray_Additionals::GetAdditionalSynthetics()
       .emplace(g_NSArrayClass1,
                lldb_private::formatters::swift::ArraySyntheticFrontEndCreator);
+
+  initializeSwiftModules();
 }
 
 void SwiftLanguage::Terminate() {

--- a/lldb/tools/lldb-test/CMakeLists.txt
+++ b/lldb/tools/lldb-test/CMakeLists.txt
@@ -24,6 +24,10 @@ add_lldb_tool(lldb-test
     Support
   )
 
+# BEGIN Swift Mods
+add_properties_for_swift_modules(lldb-test)
+# END Swift Mods
+
 if(Python3_RPATH)
   set_property(TARGET lldb-test APPEND PROPERTY INSTALL_RPATH "${Python3_RPATH}")
   set_property(TARGET lldb-test APPEND PROPERTY BUILD_RPATH   "${Python3_RPATH}")


### PR DESCRIPTION
This is needed for the swift expression parser once parts of the parser are implemented in swift.
For details on libswift see https://github.com/apple/swift/blob/main/libswift/README.md.