### PR TITLE
clang -fdepscan: Fix when state gets shared to unblock broader use

### DIFF
--- a/clang/include/clang/Driver/CC1DepScanDClient.h
+++ b/clang/include/clang/Driver/CC1DepScanDClient.h
@@ -38,7 +38,7 @@ struct AutoArgEdit {
 
 void addCC1ScanDepsArgs(
     const char *Exec, SmallVectorImpl<const char *> &Argv,
-    const DepscanPrefixMapping &Mapping,
+    const DepscanPrefixMapping &Mapping, StringRef DaemonKey,
     llvm::function_ref<const char *(const Twine &)> SaveArg);
 
 } // namespace cc1depscand

--- a/clang/include/clang/Driver/CC1DepScanDProtocol.h
+++ b/clang/include/clang/Driver/CC1DepScanDProtocol.h
@@ -23,7 +23,7 @@
 namespace clang {
 namespace cc1depscand {
 
-StringRef getBasePath();
+std::string getBasePath(StringRef DaemonKey);
 
 int createSocket();
 int connectToSocket(StringRef BasePath, int Socket);

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5847,15 +5847,46 @@ def fsycl_is_host : Flag<["-"], "fsycl-is-host">,
 def fdepscan_EQ : Joined<["-"], "fdepscan=">,
     Group<f_Group>,
     HelpText<"Scan for dependencies ahead of compiling, generating a"
-             " pruned CAS tree to send to -fcas-fs."
-             " Values are 'daemon', 'inline', or 'off'.">;
+             " pruned CAS tree to send to -fcas-fs. Values are"
+             " 'auto',"
+             " 'daemon' (see -fdepscan-share and -fdepscan-share-parent),"
+             " 'inline', or"
+             " 'off' (default).">;
 def fdepscan : Flag<["-"], "fdepscan">,
-    Group<f_Group>,
-    HelpText<"Turn on -fdepscan. Currently uses 'daemon'.">,
-    Alias<fdepscan_EQ>, AliasArgs<["daemon"]>;
+    Group<f_Group>, HelpText<"Turn on -fdepscan=auto.">,
+    Alias<fdepscan_EQ>, AliasArgs<["auto"]>;
 def fno_depscan : Flag<["-"], "fno-depscan">,
     Group<f_Group>,
     Alias<fdepscan_EQ>, AliasArgs<["off"]>;
+def fdepscan_share_EQ : Joined<["-"], "fdepscan-share=">,
+    Group<f_Group>,
+    HelpText<"If the argument is the name of a command in the process tree,"
+             " share state based on its PID."
+             " E.g., -fdepscan -fdepscan-share=ninja will search for 'ninja'"
+             " in the process tree and share state based on its PID if found."
+             " See also -fdepscan-share-stop.">;
+def fdepscan_share_parent_EQ : Joined<["-"], "fdepscan-share-parent=">,
+    Group<f_Group>,
+    HelpText<"Share state based on the PID of the parent command if the name"
+             " matches."
+             " See also -fdepscan-share-stop.">;
+def fdepscan_share_parent : Joined<["-"], "fdepscan-share-parent">,
+    Group<f_Group>,
+    HelpText<"Share state based on the PID of the parent command."
+             " See also -fdepscan-share-stop.">;
+def fno_depscan_share : Flag<["-"], "fno-depscan-share">,
+    Group<f_Group>,
+    HelpText<"Turn off -fdepscan-share and -fdepscan-share-parent.">;
+def fdepscan_share_stop_EQ : Joined<["-"], "fdepscan-share-stop=">,
+    Group<f_Group>,
+    HelpText<"Stop looking for the command named by -fdepscan-share if a"
+             " process with the name of the provided argument is found first."
+             " Also blocks -fdepscan-share=parent if the parent has this name."
+             " E.g., -fdepscan -fdepscan-share=ninja"
+             " -fdepscan-share-stop=cmake looks for 'ninja' and 'cmake' in the"
+             " process tree; if 'ninja' is found first, state is shared based"
+             " on ninja's PID; if 'cmake' is found first, state is not"
+             " shared.">;
 
 // CAS prefix map options.
 //

--- a/clang/test/CAS/cas-token-cache.c
+++ b/clang/test/CAS/cas-token-cache.c
@@ -1,8 +1,11 @@
 // Test running -fcas-token-cache.
-// TODO: Test should be updated to not depend on a working cache at default location, which is out of test/build directory.
-// Removing the dependency on driver will be great as well.
+//
+// TODO: Test should be updated to not depend on a working cache at default
+// location, which is out of test/build directory.  Removing the dependency on
+// driver will be great as well (-fdepscan should get coverage somewhere else
+// instead).
 
-// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=daemon -Xclang -fcas-token-cache -fsyntax-only -x c %s
+// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=inline -Xclang -fcas-token-cache -fsyntax-only -x c %s
 
 #include "test.h"
 

--- a/clang/test/CAS/fdepscan.c
+++ b/clang/test/CAS/fdepscan.c
@@ -1,0 +1,28 @@
+// Test running -fdepscan.
+//
+// TODO: Test should be updated to not depend on a working cache at default
+// location, which is out of test/build directory.
+
+// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=daemon -fsyntax-only -x c %s
+// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=inline -fsyntax-only -x c %s
+// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=auto -fsyntax-only -x c %s
+// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=off -fsyntax-only -x c %s
+//
+// Check -fdepscan-share-related arguments are claimed.
+// TODO: Check behaviour.
+//
+// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=off \
+// RUN:     -fdepscan-share-parent                                     \
+// RUN:     -fdepscan-share-parent=                                    \
+// RUN:     -fdepscan-share-parent=python                              \
+// RUN:     -fdepscan-share=python                                     \
+// RUN:     -fdepscan-share=                                           \
+// RUN:     -fdepscan-share-stop=python                                \
+// RUN:     -fno-depscan-share                                         \
+// RUN:     -fsyntax-only -x c %s                                      \
+// RUN: | FileCheck %s -allow-empty
+// CHECK-NOT: warning:
+
+#include "test.h"
+
+int func(void);

--- a/clang/tools/driver/driver.cpp
+++ b/clang/tools/driver/driver.cpp
@@ -54,6 +54,15 @@
 #include <memory>
 #include <set>
 #include <system_error>
+
+#if defined(__APPLE__) &&                                                      \
+    __has_include(<libproc.h>) && __has_include(<sys/proc_info.h>)
+#define USE_APPLE_LIBPROC_FOR_DEPSCAN_ANCESTORS
+#include <libproc.h>
+#include <sys/proc_info.h>
+#include <unistd.h>
+#endif
+
 using namespace clang;
 using namespace clang::driver;
 using namespace llvm::opt;
@@ -396,15 +405,157 @@ static void addCC1ScanDepsArgsInline(
   return;
 }
 
+namespace {
+/// FIXME: Move to LLVMSupport; probably llvm/Support/Process.h.
+///
+/// TODO: Get this working on Linux:
+/// - Reading `/proc/[pid]/comm` for the command names.
+/// - Walk up the `ppid` fields in `/proc/[pid]/stat`.
+struct ProcessAncestor {
+  uint64_t PID = ~0ULL;
+  uint64_t PPID = ~0ULL;
+  StringRef Name;
+};
+class ProcessAncestorIterator
+    : public llvm::iterator_facade_base<ProcessAncestorIterator,
+                                        std::forward_iterator_tag,
+                                        const ProcessAncestor> {
+
+public:
+  ProcessAncestorIterator() = default;
+
+  static uint64_t getThisPID();
+  static uint64_t getParentPID();
+
+  static ProcessAncestorIterator getThisBegin() {
+    return ProcessAncestorIterator().setPID(getThisPID());
+  }
+  static ProcessAncestorIterator getParentBegin() {
+    return ProcessAncestorIterator().setPID(getParentPID());
+  }
+
+  const ProcessAncestor &operator*() const { return Ancestor; }
+  ProcessAncestorIterator &operator++() { return setPID(Ancestor.PPID); }
+  bool operator==(const ProcessAncestorIterator &RHS) const {
+    return Ancestor.PID == RHS.Ancestor.PID;
+  }
+
+private:
+  ProcessAncestorIterator &setPID(uint64_t NewPID);
+
+  ProcessAncestor Ancestor;
+#ifdef USE_APPLE_LIBPROC_FOR_DEPSCAN_ANCESTORS
+  proc_bsdinfo ProcInfo;
+#endif
+};
+} // end namespace
+
+uint64_t ProcessAncestorIterator::getThisPID() {
+  // FIXME: Not portable.
+  return ::getpid();
+}
+
+uint64_t ProcessAncestorIterator::getParentPID() {
+  // FIXME: Not portable.
+  return ::getppid();
+}
+
+ProcessAncestorIterator &ProcessAncestorIterator::setPID(uint64_t NewPID) {
+  // Reset state in case NewPID isn't found.
+  Ancestor = ProcessAncestor();
+
+#ifdef USE_APPLE_LIBPROC_FOR_DEPSCAN_ANCESTORS
+  pid_t TypeCorrectPID = NewPID;
+  if (proc_pidinfo(TypeCorrectPID, PROC_PIDTBSDINFO, 0, &ProcInfo,
+                   sizeof(ProcInfo)) != sizeof(ProcInfo))
+    return *this; // Not found or no access.
+
+  Ancestor.PID = NewPID;
+  Ancestor.PPID = ProcInfo.pbi_ppid;
+  Ancestor.Name = StringRef(ProcInfo.pbi_name);
+#else
+  (void)NewPID;
+#endif
+  return *this;
+}
+
+namespace {
+struct DepscanSharing {
+  bool OnlyShareParent = false;
+  Optional<StringRef> Name;
+  Optional<StringRef> Stop;
+};
+} // end namespace;
+
+static Optional<std::string>
+makeDepscanDaemonKey(StringRef Mode, const DepscanSharing &Sharing) {
+  if (Mode == "inline")
+    return None;
+
+  auto makeKey = [](uint64_t PID) { return Twine(PID).str(); };
+
+  if (Sharing.Name) {
+    // Check for fast path, which doesn't need to look up process names:
+    // -fdepscan-share-parent without -fdepscan-share-stop.
+    if (Sharing.Name->empty() && !Sharing.Stop)
+      return makeKey(ProcessAncestorIterator::getParentPID());
+
+    // Check the parent's process name, and then process ancestors.
+    for (ProcessAncestorIterator I = ProcessAncestorIterator::getParentBegin(), IE;
+         I != IE; ++I) {
+      if (I->Name == Sharing.Stop)
+        break;
+      if (Sharing.Name->empty() || I->Name == *Sharing.Name)
+        return makeKey(I->PID);
+      if (Sharing.OnlyShareParent)
+        break;
+    }
+
+    // Fall through if the process to share isn't found.
+  }
+
+  // Still daemonize, but use the PID from this process as the key to avoid
+  // sharing state.
+  if (Mode == "daemon")
+    return makeKey(ProcessAncestorIterator::getThisPID());
+
+  // Mode == "auto".
+  //
+  // TODO: consider returning ThisPID (same as "daemon") once the daemon can
+  // share a CAS instance without sharing filesystem caching. Or maybe delete
+  // "auto" at that point and make "-fdepscan" default to "-fdepscan=daemon".
+  return None;
+}
+
 static void
 CC1ScanDeps(const Arg &A, const char *Exec,
             SmallVectorImpl<const char *> &CC1Args, const Driver &D,
             const ArgList &Args) {
   StringRef Mode = A.getValue();
+
+  // Collect these before returning to ensure they're claimed.
+  DepscanSharing Sharing;
+  if (Arg *A = Args.getLastArg(options::OPT_fdepscan_share_stop_EQ))
+    Sharing.Stop = A->getValue();
+  if (Arg *A = Args.getLastArg(options::OPT_fdepscan_share_EQ,
+                               options::OPT_fdepscan_share_parent,
+                               options::OPT_fdepscan_share_parent_EQ,
+                               options::OPT_fno_depscan_share)) {
+    if (A->getOption().matches(options::OPT_fdepscan_share_EQ) ||
+        A->getOption().matches(options::OPT_fdepscan_share_parent_EQ)) {
+      Sharing.Name = A->getValue();
+      Sharing.OnlyShareParent =
+          A->getOption().matches(options::OPT_fdepscan_share_parent_EQ);
+    } else if (A->getOption().matches(options::OPT_fdepscan_share_parent)) {
+      Sharing.Name = "";
+      Sharing.OnlyShareParent = true;
+    }
+  }
+
   if (Mode == "off")
     return;
 
-  if (Mode != "daemon" && Mode != "inline")
+  if (Mode != "daemon" && Mode != "inline" && Mode != "auto")
     D.Diag(diag::err_drv_invalid_argument_to_option)
       << Mode << A.getOption().getName();
 
@@ -412,10 +563,11 @@ CC1ScanDeps(const Arg &A, const char *Exec,
       parseCASFSAutoPrefixMappings(D, Args);
 
   auto SaveArg = [&Args](const Twine &T) { return Args.MakeArgString(T); };
-  if (Mode == "inline")
-    addCC1ScanDepsArgsInline(Exec, CC1Args, PrefixMapping, SaveArg);
+  if (Optional<std::string> DaemonKey = makeDepscanDaemonKey(Mode, Sharing))
+    cc1depscand::addCC1ScanDepsArgs(Exec, CC1Args, PrefixMapping, *DaemonKey,
+                                    SaveArg);
   else
-    cc1depscand::addCC1ScanDepsArgs(Exec, CC1Args, PrefixMapping, SaveArg);
+    addCC1ScanDepsArgsInline(Exec, CC1Args, PrefixMapping, SaveArg);
 }
 
 int main(int Argc, const char **Argv) {


### PR DESCRIPTION
Stop sharing state whenever the parent PID matches. This fixes two bugs:

- Adding `-fdepscan-prefix-map` to `CMAKE_{C,CXX}_FLAGS` broke CMake
  configuration if sharing by parent PID.

- Using `-fdepscan` on the command-line was error-prone since source
  changes get ignored unless you `killall clang-14`.

Here's how things work now:

- `-fdepscan=daemon` by default doesn't share any state, just has a
  separate daemon per launching process.
    - Add `-fdepscan-share=parent` to restore the previous behaviour.
    - Add `-fdepscan-share=ninja` to search for the nearest `ninja` in
      the process tree and share based on that pid.
    - Add `-fdepscan-share-stop=cmake` to block sharing if `cmake` is
      found first.
- `-fdepscan` aliases the new `-fdepscan=auto`, which only daemonizes if
  it's going to share state.

Note: We should update `-fdepscan=daemon` in a future commit to have all
commands share a single daemon (and CAS instance). Left out for now, but
some notes:

- The PID logic above can be used for sharing a CachingOnDiskFileSystem.
- Need a different daemon for different on-disk `clang`s still.
    - Might be okay to share based on on-disk path, to avoid having to
      ingest the executable into the CAS in each driver instance?
    - But then the daemon needs to know if clang changed on disk since
      it launched. Maybe it's good (and cheap) enough to call
      fs::status() on itself on receiving a new connection. If there's a
      change, it should initiate shutdown, and refuse the connection to
      trigger the launch of a new daemon.
- At that point, probably `auto` can/should be removed and `-fdepscan`
  changed back to aliasing `-fdepscan=daemon`.