### PR TITLE
[lldb] Pass a `nullptr` `CancellationFlag` to the `swift::ASTContext` constructor

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3370,7 +3370,8 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
   m_ast_context_ap.reset(swift::ASTContext::get(
       GetLanguageOptions(), GetTypeCheckerOptions(), GetSILOptions(),
       GetSearchPathOptions(), GetClangImporterOptions(),
-      GetSymbolGraphOptions(), GetSourceManager(), GetDiagnosticEngine()));
+      GetSymbolGraphOptions(), GetSourceManager(), GetDiagnosticEngine(),
+      /*CancellationFlag=*/nullptr));
   m_diagnostic_consumer_ap.reset(new StoringDiagnosticConsumer(*this));
 
   if (getenv("LLDB_SWIFT_DUMP_DIAGS")) {


### PR DESCRIPTION
Companion of https://github.com/apple/swift/pull/40158.