### PR TITLE
A few cleanups for flatv1

### DIFF
--- a/llvm/include/llvm/CASObjectFormats/FlatV1.h
+++ b/llvm/include/llvm/CASObjectFormats/FlatV1.h
@@ -196,28 +196,6 @@ private:
   explicit SectionRef(SpecificRefT Ref) : SpecificRefT(Ref) {}
 };
 
-class EdgeListRef : public SpecificRef<EdgeListRef> {
-  using SpecificRefT = SpecificRef<EdgeListRef>;
-  friend class SpecificRef<EdgeListRef>;
-
-public:
-  static constexpr StringLiteral KindString = "cas.o:edgelist";
-
-  static Expected<EdgeListRef> create(CompileUnitBuilder &CUB,
-                                      ArrayRef<const jitlink::Edge *> Edges);
-  static Expected<EdgeListRef> get(Expected<ObjectFormatNodeRef> Ref);
-  static Expected<EdgeListRef> get(const ObjectFileSchema &Schema,
-                                   cas::CASID ID) {
-    return get(Schema.getNode(ID));
-  }
-
-  Error materialize(LinkGraphBuilder &LGB, jitlink::Block &Parent,
-                    unsigned BlockIdx) const;
-
-private:
-  explicit EdgeListRef(SpecificRefT Ref) : SpecificRefT(Ref) {}
-};
-
 class BlockRef : public SpecificRef<BlockRef> {
   using SpecificRefT = SpecificRef<BlockRef>;
   friend class SpecificRef<BlockRef>;
@@ -336,7 +314,6 @@ public:
       : CAS(Schema.CAS), Schema(Schema), TT(Target), DebugOS(DebugOS) {}
 
   Error createAndReferenceName(StringRef S);
-  Error createAndReferenceEdges(ArrayRef<const jitlink::Edge *> Edges);
   Error createAndReferenceContent(StringRef Content);
 
   Error createSection(const jitlink::Section &S);

--- a/llvm/include/llvm/CASObjectFormats/FlatV1.h
+++ b/llvm/include/llvm/CASObjectFormats/FlatV1.h
@@ -423,7 +423,6 @@ public:
     jitlink::Block *Block;
     Optional<BlockRef> Ref;
     Optional<data::BlockData> Data;
-    Optional<data::FixupList::iterator> CurrentFixup;
     unsigned BlockIdx = 0;
     unsigned Remaining = 0;
   };

--- a/llvm/lib/CASObjectFormats/FlatV1.cpp
+++ b/llvm/lib/CASObjectFormats/FlatV1.cpp
@@ -297,14 +297,14 @@ Expected<SectionRef> SectionRef::get(Expected<ObjectFormatNodeRef> Ref) {
 }
 
 static Error encodeEdge(CompileUnitBuilder &CUB, SmallVectorImpl<char> &Data,
-                        const jitlink::Edge *E, bool ForceDirectIndex = false) {
+                        const jitlink::Edge *E) {
 
   auto SymbolIndex = CUB.getSymbolIndex(E->getTarget());
   if (!SymbolIndex)
     return SymbolIndex.takeError();
 
   unsigned IdxAndHasAddend = *SymbolIndex << 1 | (E->getAddend() != 0);
-  if (!DirectIndexEncode && !ForceDirectIndex)
+  if (!DirectIndexEncode)
     CUB.encodeIndex(IdxAndHasAddend);
   else
     encoding::writeVBR8(IdxAndHasAddend, Data);
@@ -316,10 +316,9 @@ static Error encodeEdge(CompileUnitBuilder &CUB, SmallVectorImpl<char> &Data,
 
 static Error decodeEdge(LinkGraphBuilder &LGB, StringRef &Data,
                         jitlink::Block &Parent, unsigned BlockIdx,
-                        const data::Fixup &Fixup,
-                        bool ForceDirectIndex = false) {
+                        const data::Fixup &Fixup) {
   unsigned SymbolIdx;
-  if (!DirectIndexEncode && !ForceDirectIndex)
+  if (!DirectIndexEncode)
     SymbolIdx = LGB.nextIdxForBlock(BlockIdx);
   else if (auto E = encoding::consumeVBR8(Data, SymbolIdx))
     return E;


### PR DESCRIPTION
- 2ae8bb786efd CAS.o/FlatV1: Avoid storing number of edges twice
- d076e965bf3a CAS.o/FlatV1: Remove dead code for ForceDirectIndex
- f8c0acbabc3a CAS.o/FlatV1: Remove --direct-index-encode, which is not profitable                                                                         - 

Mostly NFC, except for dropping `--direct-index-encode`. Want to remove that since I don't think either of us finds it interesting for collecting data at this point, and it simplifies another PR.