### PR TITLE
CAS.o/FlatV1: Adopt data::TargetInfoList in CompileUnit

### DIFF
--- a/llvm/include/llvm/CASObjectFormats/FlatV1.h
+++ b/llvm/include/llvm/CASObjectFormats/FlatV1.h
@@ -330,8 +330,8 @@ public:
   // Encode the index into compile unit.
   void encodeIndex(unsigned Index);
 
-  // Encode a target info list and return an offset.
-  Error encodeTargetInfo(ArrayRef<const jitlink::Edge *> Edges);
+  // Encode a target info list and return the offset.
+  Expected<size_t> encodeTargetInfo(ArrayRef<const jitlink::Edge *> Edges);
 
 private:
   friend class CompileUnitRef;

--- a/llvm/lib/CASObjectFormats/FlatV1.cpp
+++ b/llvm/lib/CASObjectFormats/FlatV1.cpp
@@ -293,42 +293,69 @@ Expected<SectionRef> SectionRef::get(Expected<ObjectFormatNodeRef> Ref) {
   return SectionRef(*Specific);
 }
 
-static Error encodeEdge(CompileUnitBuilder &CUB, SmallVectorImpl<char> &Data,
+static Error encodeEdge(CompileUnitBuilder &CUB,
+                        SmallVectorImpl<data::TargetInfo> &List,
                         const jitlink::Edge *E) {
-
   auto SymbolIndex = CUB.getSymbolIndex(E->getTarget());
   if (!SymbolIndex)
     return SymbolIndex.takeError();
-
-  unsigned IdxAndHasAddend = *SymbolIndex << 1 | (E->getAddend() != 0);
-  CUB.encodeIndex(IdxAndHasAddend);
-
-  if (E->getAddend() != 0)
-    encoding::writeVBR8(E->getAddend(), Data);
+  List.push_back({E->getAddend(), *SymbolIndex});
   return Error::success();
 }
 
-static Error decodeEdge(LinkGraphBuilder &LGB, StringRef &Data,
-                        jitlink::Block &Parent, unsigned BlockIdx,
-                        const data::Fixup &Fixup) {
-  unsigned SymbolIdx = LGB.nextIdxForBlock(BlockIdx);
+Error CompileUnitBuilder::encodeTargetInfo(
+    ArrayRef<const jitlink::Edge *> Edges) {
+  SmallVector<data::TargetInfo> List;
+  for (const jitlink::Edge *E : Edges)
+    if (Error Err = encodeEdge(*this, List, E))
+      return Err;
 
-  bool HasAddend = SymbolIdx & 1U;
-  auto Symbol = LGB.getSymbol(SymbolIdx >> 1);
+  size_t Start = FlatTargetInfo.size();
+  data::TargetInfoList::encode(List, FlatTargetInfo);
+  size_t Length = FlatTargetInfo.size() - Start;
+  auto &MaybeExisting =
+      TargetInfoPool[StringRef(FlatTargetInfo).take_back(Length)];
+  if (MaybeExisting) {
+    // Truncate FlatTargetInfo again since this is already in the pool.
+    FlatTargetInfo.resize(Start);
+    Start = MaybeExisting - 1;
+  } else {
+    MaybeExisting = Start + 1;
+  }
+
+  // FIXME: Maybe should use uint64_t, or be a different range from CAS object
+  // indexes.
+  assert(Start < UINT_MAX && "Index out of range");
+  encodeIndex(Start);
+  return Error::success();
+}
+
+data::TargetInfoList LinkGraphBuilder::getTargetInfoFrom(unsigned Start) {
+  assert(Start < FlatTargetInfo.size() && "Start out of range");
+  return data::TargetInfoList(StringRef(FlatTargetInfo).drop_front(Start));
+}
+
+static Error decodeEdge(LinkGraphBuilder &LGB, jitlink::Block &Parent,
+                        const data::TargetInfo &TI, const data::Fixup &Fixup) {
+  auto Symbol = LGB.getSymbol(TI.Index);
   if (!Symbol)
     return Symbol.takeError();
 
-  jitlink::Edge::AddendT Addend = 0;
-  if (HasAddend) {
-    if (auto E = encoding::consumeVBR8(Data, Addend))
+  Parent.addEdge(Fixup.Kind, Fixup.Offset, **Symbol, TI.Addend);
+  return Error::success();
+}
+
+static Error decodeEdges(LinkGraphBuilder &LGB, jitlink::Block &Parent,
+                         unsigned BlockIdx, const data::FixupList &FL) {
+  if (FL.empty())
+    return Error::success();
+
+  unsigned TargetInfoStart = LGB.nextIdxForBlock(BlockIdx);
+  data::TargetInfoList TIL(LGB.getTargetInfoFrom(TargetInfoStart));
+  data::TargetInfoList::iterator TI = TIL.begin();
+  for (const data::Fixup &Fixup : FL)
+    if (Error E = decodeEdge(LGB, Parent, *TI++, Fixup))
       return E;
-  }
-  auto BlockInfo = LGB.getBlockInfo(BlockIdx);
-  if (!BlockInfo)
-    return BlockInfo.takeError();
-
-  Parent.addEdge(Fixup.Kind, Fixup.Offset, **Symbol, Addend);
-
   return Error::success();
 }
 
@@ -390,15 +417,12 @@ Expected<BlockRef> BlockRef::create(CompileUnitBuilder &CUB,
     if (auto E = CUB.createAndReferenceContent(BlockData))
       return std::move(E);
   } else {
-    encoding::writeVBR8(BlockData.size(), B->Data);
     B->Data.append(BlockData);
   }
 
-  for (const auto *E : Edges) {
-    // Nest the Edge in block.
-    if (auto Err = encodeEdge(CUB, B->Data, E))
+  if (!Edges.empty())
+    if (auto Err = CUB.encodeTargetInfo(Edges))
       return std::move(Err);
-  }
 
   return get(B->build());
 }
@@ -406,7 +430,6 @@ Expected<BlockRef> BlockRef::create(CompileUnitBuilder &CUB,
 Error BlockRef::materializeBlock(LinkGraphBuilder &LGB,
                                  unsigned BlockIdx) const {
   uint64_t SectionIdx;
-  auto Remaining = getData();
   SectionIdx = LGB.nextIdxForBlock(BlockIdx);
 
   auto SectionInfo = LGB.getSectionInfo(SectionIdx);
@@ -420,21 +443,14 @@ Error BlockRef::materializeBlock(LinkGraphBuilder &LGB,
       return ContentRef.takeError();
     ContentData = ContentRef->getData();
   } else {
-    unsigned ContentSize;
-    if (auto E = encoding::consumeVBR8(Remaining, ContentSize))
-      return E;
-    auto Data = consumeDataOfSize(Remaining, ContentSize);
-    if (!Data)
-      return Data.takeError();
-    ContentData = *Data;
+    ContentData = getData();
   }
 
   auto BlockInfo = LGB.getBlockInfo(BlockIdx);
   if (!BlockInfo)
     return BlockInfo.takeError();
 
-  BlockInfo->Data.emplace(ContentData);
-  auto &Block = *BlockInfo->Data;
+  data::BlockData Block(ContentData);
   auto Address =
       getAlignedAddress(*SectionInfo, Block.getSize(), Block.getAlignment(),
                         Block.getAlignmentOffset());
@@ -447,7 +463,7 @@ Error BlockRef::materializeBlock(LinkGraphBuilder &LGB,
                       Block.getAlignment(), Block.getAlignmentOffset());
 
   BlockInfo->Block = &B;
-  BlockInfo->Remaining = Remaining.size();
+  BlockInfo->Fixups = Block.getFixups();
   return Error::success();
 }
 
@@ -458,17 +474,10 @@ Error BlockRef::materializeEdges(LinkGraphBuilder &LGB,
     return BlockInfo.takeError();
 
   // Nothing remains, no edges.
-  if (!BlockInfo->Remaining)
+  if (BlockInfo->Fixups->empty())
     return Error::success();
 
-  auto Remaining = getData().take_back(BlockInfo->Remaining);
-  for (const data::Fixup &Fixup : BlockInfo->Data->getFixups()) {
-    if (Error Err =
-            decodeEdge(LGB, Remaining, *BlockInfo->Block, BlockIdx, Fixup))
-      return Err;
-  }
-
-  return Error::success();
+  return decodeEdges(LGB, *BlockInfo->Block, BlockIdx, *BlockInfo->Fixups);
 }
 
 Expected<BlockRef> BlockRef::get(Expected<ObjectFormatNodeRef> Ref) {
@@ -844,6 +853,10 @@ Expected<CompileUnitRef> CompileUnitRef::create(const ObjectFileSchema &Schema,
   for (auto Idx : Builder.BlockIndexStarts)
     encoding::writeVBR8(Idx, B->Data);
 
+  /// Write the flat TargetInfoList data.
+  encoding::writeVBR8(Builder.FlatTargetInfo.size(), B->Data);
+  B->Data.append(Builder.FlatTargetInfo);
+
   // Inlined symbols if set.
   if (InlineSymbols)
     B->Data.append(Builder.InlineBuffer);
@@ -913,6 +926,14 @@ Error CompileUnitRef::materialize(LinkGraphBuilder &LGB) const {
       return Err;
     LGB.Blocks[I].BlockIdx = Idx;
   }
+
+  /// Write the flat TargetInfoList data.
+  size_t FlatTargetInfoSize;
+  if (Error Err = encoding::consumeVBR8(Remaining, FlatTargetInfoSize))
+    return Err;
+  if (Error Err = consumeDataOfSize(Remaining, FlatTargetInfoSize)
+                      .moveInto(LGB.FlatTargetInfo))
+    return Err;
 
   if (InlineSymbols)
     LGB.InlineBuffer = Remaining;


### PR DESCRIPTION
This is built on top of https://github.com/apple/llvm-project/pull/3555; I split that out since I think it can/should land whatever happens here.

- 75946ec001ef CAS.o/FlatV1: Adopt data::TargetInfoList in CompileUnit
- 05ac2f507b1a CAS.o/FlatV1: Inline TargetInfoLists that have no addends

The first commit lifts addends out of the block and puts them in the compile unit, and the second one recovers from regressions caused by the former. They're split for ease of review.

My motivation is to make the content of `flatv1::BlockRef` encapsulate (exactly) `data::BlockData` (which maybe could be renamed to `data::Block`...). The other option is to add addends to `data::BlockData`. I think it's important to do one of those two things. The `casobjectformats::data` namespace has easily unit-testable code for the encodings; this also makes them reusable in different schemas, or in different parts of the same schema (e.g., inlined vs. outlined data). A pre-requisite for experimenting with outlining subgraphs in flatv1 is to make the encodings easy to reason about. If the "right" encoding for block data has the addends in it, then we should augment `data::BlockData` (and nestedv1). If it doesn't, then we should take this patch.

Honestly, I'm not sure this patch is the right approach vs. adding Addends to data::BlockData. The stats for Mach-O don't support this direction; it's almost neutral when adding the second commit, but the other direction (changing `data::BlockData`) is simpler. I'd like to see stats for ELF -- both `-ffunction-sections` and `-fno-function-sections` (although we care a lot more about the former, the latter would be good to understand) -- before landing this.