### PR TITLE
[rebranch] Use EnableOSSAModules when calling validateSerializedAST

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1362,7 +1362,7 @@ static bool DeserializeAllCompilerFlags(swift::CompilerInvocation &invocation,
     for (; !buf.empty(); buf = buf.substr(info.bytes)) {
       swift::serialization::ExtendedValidationInfo extended_validation_info;
       info = swift::serialization::validateSerializedAST(
-          buf, /*requiresOSSAModules=*/false, &extended_validation_info);
+          buf, invocation.getSILOptions().EnableOSSAModules, &extended_validation_info);
       bool invalid_ast = info.status != swift::serialization::Status::Valid;
       bool invalid_size = (info.bytes == 0) || (info.bytes > buf.size());
       bool invalid_name = info.name.empty();


### PR DESCRIPTION
I had set this to false rather than use the SIL options due to a misunderstanding in what `loadFromSerializedAST` actually does. Update to match 8a11fcccf2818fbe67d2ef8e8db0fd9077c0e2ee.