### PR TITLE
[modules] Update visibility for merged ObjCProtocolDecl definitions.

### DIFF
--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -1250,6 +1250,13 @@ void ASTDeclReader::ReadObjCDefinitionData(
 
 void ASTDeclReader::MergeDefinitionData(ObjCProtocolDecl *D,
          struct ObjCProtocolDecl::DefinitionData &&NewDD) {
+  struct ObjCProtocolDecl::DefinitionData &DD = D->data();
+  if (DD.Definition != NewDD.Definition) {
+    Reader.MergedDeclContexts.insert(
+        std::make_pair(NewDD.Definition, DD.Definition));
+    Reader.mergeDefinitionVisibility(DD.Definition, NewDD.Definition);
+  }
+
   // FIXME: odr checking?
 }
 

--- a/clang/test/Modules/merge-objc-protocol-visibility.m
+++ b/clang/test/Modules/merge-objc-protocol-visibility.m
@@ -1,0 +1,76 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %clang_cc1 -emit-llvm -o %t/test.bc -F%t/Frameworks %t/test.m -Werror=objc-method-access -DHIDDEN_FIRST=1 \
+// RUN:            -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/modules.cache
+// RUN: %clang_cc1 -emit-llvm -o %t/test.bc -F%t/Frameworks %t/test.m -Werror=objc-method-access -DHIDDEN_FIRST=0 \
+// RUN:            -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/modules.cache
+
+// Test a case when Objective-C protocol is imported both as hidden and as visible.
+
+//--- Frameworks/Foundation.framework/Headers/Foundation.h
+@interface NSObject
+@end
+
+//--- Frameworks/Foundation.framework/Modules/module.modulemap
+framework module Foundation {
+  header "Foundation.h"
+  export *
+}
+
+//--- Frameworks/Common.framework/Headers/Common.h
+#import <Foundation/Foundation.h>
+@protocol Testing;
+@interface Common : NSObject
+- (id<Testing>)getProtocolObj;
+@end
+
+//--- Frameworks/Common.framework/Modules/module.modulemap
+framework module Common {
+  header "Common.h"
+  export *
+}
+
+//--- Frameworks/Regular.framework/Headers/Regular.h
+@protocol Testing
+- (void)protocolMethod;
+@end
+
+//--- Frameworks/Regular.framework/Modules/module.modulemap
+framework module Regular {
+  header "Regular.h"
+  export *
+}
+
+//--- Frameworks/RegularHider.framework/Headers/Visible.h
+// Empty, file required to create a module.
+
+//--- Frameworks/RegularHider.framework/Headers/Hidden.h
+@protocol Testing
+- (void)protocolMethod;
+@end
+
+//--- Frameworks/RegularHider.framework/Modules/module.modulemap
+framework module RegularHider {
+  header "Visible.h"
+  export *
+
+  explicit module Hidden {
+    header "Hidden.h"
+    export *
+  }
+}
+
+//--- test.m
+#import <Common/Common.h>
+
+#if HIDDEN_FIRST
+#import <RegularHider/Visible.h>
+#import <Regular/Regular.h>
+#else
+#import <Regular/Regular.h>
+#import <RegularHider/Visible.h>
+#endif
+
+void test(Common *obj) {
+  [[obj getProtocolObj] protocolMethod];
+}


### PR DESCRIPTION
Merge definition visibility the same way we do for other decls. Without
the fix the added test emits `-Wobjc-method-access` as it cannot find a
visible protocol. Make this warning `-Werror` so the test would fail
when protocol visibility regresses.

rdar://83600696

Differential Revision: https://reviews.llvm.org/D111860

(cherry picked from commit 7ad693a322c1b6765f5d06559c2bd73cc3938aaf)