### PR TITLE
[20211026] Allow __attribute__((swift_attr)) in attribute push pragmas

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2357,6 +2357,7 @@ def SwiftAttr : InheritableAttr {
   let Spellings = [GNU<"swift_attr">];
   let Args = [StringArgument<"Attribute">];
   let Documentation = [SwiftAttrDocs];
+  let PragmaAttributeSupport = 1;
 }
 
 def SwiftBridge : InheritableAttr {

--- a/clang/test/AST/attr-swift_attr.m
+++ b/clang/test/AST/attr-swift_attr.m
@@ -1,8 +1,16 @@
-// RUN: %clang_cc1 -fsyntax-only -ast-dump %s | FileCheck %s
+// RUN: not %clang_cc1 -fsyntax-only -ast-dump %s | FileCheck %s
 
 __attribute__((swift_attr("@actor")))
 @interface View
 @end
 
-// CHECK: InterfaceDecl {{.*}} View
+// CHECK-LABEL: InterfaceDecl {{.*}} View
 // CHECK-NEXT: SwiftAttrAttr {{.*}} "@actor"
+
+#pragma clang attribute push(__attribute__((swift_attr("@sendable"))), apply_to=objc_interface)
+@interface Contact
+@end
+#pragma clang attribute pop
+
+// CHECK-LABEL: InterfaceDecl {{.*}} Contact
+// CHECK-NEXT: SwiftAttrAttr {{.*}} "@sendable"

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -164,6 +164,7 @@
 // CHECK-NEXT: SwiftAsyncContext (SubjectMatchRule_variable_is_parameter)
 // CHECK-NEXT: SwiftAsyncError (SubjectMatchRule_function, SubjectMatchRule_objc_method)
 // CHECK-NEXT: SwiftAsyncName (SubjectMatchRule_objc_method, SubjectMatchRule_function)
+// CHECK-NEXT: SwiftAttr ()
 // CHECK-NEXT: SwiftBridgedTypedef (SubjectMatchRule_type_alias)
 // CHECK-NEXT: SwiftContext (SubjectMatchRule_variable_is_parameter)
 // CHECK-NEXT: SwiftError (SubjectMatchRule_function, SubjectMatchRule_objc_method)


### PR DESCRIPTION
Cherry-picks #3547 to stable/20211026.

> This change does what it says on the tin: it allows SwiftAttr to be used with #pragma clang attribute push to add Swift attributes to large regions of header files. We plan to use this to annotate headers with concurrency information.
> 
> Reviewed at https://reviews.llvm.org/D112773. Fixes rdar://83499885.