### PR TITLE
Make tablegen executables reproducible

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -18,6 +18,10 @@ TODO: add demos for plugins once there are some.
 Some of these are currently `-cc1`-only. Some should stay that way, others just
 need to be "fixed". Some are driver-only (and should remain so).
 
+- `-greproducible`: Make debug info more reproducible. Both `-cc1` and linker.
+    - Avoids writing out Clang's Git revision (maybe it should avoid the
+      version altogether).
+    - Tells the linker not to write object file timestamps in the debug map.
 - `-fcas=builtin`: use the builtin CAS (defaults to in-memory).
     - `-fcas-builtin-path=<path>`: path to on-disk storage for CAS.
     - `-fcas-builtin-path='/^$TMPDIR/<path>'`: "hack" for referencing temp
@@ -136,11 +140,9 @@ options available.
 % (cd "$STAGE2BUILD" &&
    cmake -G Ninja                                   \
      -DLLVM_ENABLE_PROJECTS="clang"                 \
-     -DCMAKE_OSX_SYSROOT="$SDK"                     \
      -DCMAKE_C_COMPILER=$CLANG                      \
      -DCMAKE_CXX_COMPILER=${CLANG}++                \
      -DCMAKE_ASM_COMPILER=$(xcrun -find clang)      \
-     -DLLVM_ENABLE_LIBCXX=ON                        \
      -DLLVM_ENABLE_EXPERIMENTAL_DEPSCAN_TABLEGEN=ON \
      -DLLVM_ENABLE_EXPERIMENTAL_DEPSCAN=ON          \
      -DLLVM_ENABLE_EXPERIMENTAL_CAS_TOKEN_CACHE=ON  \
@@ -164,6 +166,7 @@ options directly.
 % rm -rf "$STAGE2BUILD"
 % mkdir -p "$STAGE2BUILD"
 % CLANGFLAGS=(
+     -greproducible
      -fdepscan -fdepscan-share-parent=ninja -fdepscan-share-stop=cmake
      -fdepscan-prefix-map-sdk=/^sdk
      -fdepscan-prefix-map-toolchain=/^toolchain
@@ -173,14 +176,13 @@ options directly.
      -fcas-token-cache
   )
 % (cd "$STAGE2BUILD" &&
-   cmake -G Ninja                                   \
-     -DLLVM_ENABLE_PROJECTS="clang"                 \
-     -DCMAKE_OSX_SYSROOT="$SDK"                     \
-     -DCMAKE_C_COMPILER=$CLANG                      \
-     -DCMAKE_CXX_COMPILER=${CLANG}++                \
-     -DCMAKE_ASM_COMPILER=$(xcrun -find clang)      \
-     -DLLVM_ENABLE_LIBCXX=ON                        \
-     -DCMAKE_{C,CXX}_FLAGS="$CLANGFLAGS[*]"         \
+   cmake -G Ninja                                               \
+     -DLLVM_ENABLE_PROJECTS="clang"                             \
+     -DCMAKE_C_COMPILER=$CLANG                                  \
+     -DCMAKE_CXX_COMPILER=${CLANG}++                            \
+     -DCMAKE_ASM_COMPILER=$(xcrun -find clang)                  \
+     -DCMAKE_{C,CXX}_FLAGS="$CLANGFLAGS[*]"                     \
+     -DCMAKE_{EXE,SHARED,MODULE}_LINKER_FLAGS="-greproducible"  \
      ../llvm &&
    ninja)
 ```

--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -345,6 +345,9 @@ VALUE_CODEGENOPT(SSPBufferSize, 32, 0)
 /// The kind of generated debug info.
 ENUM_CODEGENOPT(DebugInfo, codegenoptions::DebugInfoKind, 4, codegenoptions::NoDebugInfo)
 
+/// Whether to make debug info reproducible.
+CODEGENOPT(ReproducibleDebugInfo, 1, 0)
+
 /// Whether to generate macro debug info.
 CODEGENOPT(MacroDebugInfo, 1, 0)
 

--- a/clang/include/clang/Driver/Job.h
+++ b/clang/include/clang/Driver/Job.h
@@ -140,6 +140,7 @@ class Command {
 
   /// See Command::setEnvironment
   std::vector<const char *> Environment;
+  std::vector<const char *> EnvironmentDisplay;
 
   /// Information on executable run provided by OS.
   mutable Optional<llvm::sys::ProcessStatistics> ProcStat;
@@ -203,6 +204,9 @@ public:
   /// \remark If the environment remains unset, then the environment
   ///         from the parent process will be used.
   virtual void setEnvironment(llvm::ArrayRef<const char *> NewEnvironment);
+
+  /// Sets the environment to display in `-###`.
+  virtual void setEnvironmentDisplay(llvm::ArrayRef<const char *> Display);
 
   const char *getExecutable() const { return Executable; }
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2931,6 +2931,10 @@ def gcoff : Joined<["-"], "gcoff">, Group<g_Group>, Flags<[Unsupported]>;
 def gxcoff : Joined<["-"], "gxcoff">, Group<g_Group>, Flags<[Unsupported]>;
 def gvms : Joined<["-"], "gvms">, Group<g_Group>, Flags<[Unsupported]>;
 def gtoggle : Flag<["-"], "gtoggle">, Group<g_flags_Group>, Flags<[Unsupported]>;
+defm reproducible : BoolOption<"g", "reproducible",
+  CodeGenOpts<"ReproducibleDebugInfo">, DefaultFalse,
+  PosFlag<SetTrue, [CC1Option], "Tune debug info to be reproducible.">,
+  NegFlag<SetFalse>>, Group<g_flags_Group>;
 def grecord_command_line : Flag<["-"], "grecord-command-line">,
   Group<g_flags_Group>;
 def gno_record_command_line : Flag<["-"], "gno-record-command-line">,

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -562,9 +562,11 @@ void CGDebugInfo::CreateCompileUnit() {
     LangTag = llvm::dwarf::DW_LANG_C89;
   }
 
-  // FIXME: Choose IncludeRevision based on command-line argument. Including
-  // the Git revision is bad for reproducible builds / caching.
-  std::string Producer = getClangFullVersion(/*IncludeRevision=*/false);
+  // Including the Git revision of the producer is really bad for reproducible
+  // builds. Potentially the rest of the version should be skipped as well, but
+  // this is a start.
+  std::string Producer = getClangFullVersion(
+      /*IncludeRevision=*/!CGM.getCodeGenOpts().ReproducibleDebugInfo);
 
   // Figure out which version of the ObjC runtime we have.
   unsigned RuntimeVers = 0;

--- a/clang/lib/Driver/Job.cpp
+++ b/clang/lib/Driver/Job.cpp
@@ -200,6 +200,15 @@ rewriteIncludes(const llvm::ArrayRef<const char *> &Args, size_t Idx,
 
 void Command::Print(raw_ostream &OS, const char *Terminator, bool Quote,
                     CrashReportInfo *CrashInfo) const {
+  // Print the environment to display, if relevant.
+  if (!EnvironmentDisplay.empty()) {
+    OS << " env";
+    for (const char *NameValue : EnvironmentDisplay) {
+      OS << ' ';
+      llvm::sys::printArg(OS, NameValue, /*Quote=*/true);
+    }
+  }
+
   // Always quote the exe.
   OS << ' ';
   llvm::sys::printArg(OS, Executable, /*Quote=*/true);
@@ -299,6 +308,11 @@ void Command::setEnvironment(llvm::ArrayRef<const char *> NewEnvironment) {
   Environment.reserve(NewEnvironment.size() + 1);
   Environment.assign(NewEnvironment.begin(), NewEnvironment.end());
   Environment.push_back(nullptr);
+}
+
+void Command::setEnvironmentDisplay(llvm::ArrayRef<const char *> Display) {
+  EnvironmentDisplay.reserve(Display.size());
+  EnvironmentDisplay.assign(Display.begin(), Display.end());
 }
 
 void Command::PrintFileNames() const {

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6588,12 +6588,21 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   const char *Exec = D.getClangProgramPath();
 
+  // Check if there's a request for reproducible debug info. Pass it through
+  // but also use it.
+  bool GReproducible =
+      Args.hasFlag(options::OPT_greproducible,
+                   options::OPT_gno_reproducible, false);
+  if (GReproducible)
+    CmdArgs.push_back("-greproducible");
+
   // Optionally embed the -cc1 level arguments into the debug info or a
   // section, for build analysis.
   // Also record command line arguments into the debug info if
   // -grecord-gcc-switches options is set on.
   // By default, -gno-record-gcc-switches is set on and no recording.
   auto GRecordSwitches =
+      !GReproducible &&
       Args.hasFlag(options::OPT_grecord_command_line,
                    options::OPT_gno_record_command_line, false);
   auto FRecordSwitches =

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -821,14 +821,13 @@ void darwin::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
   // Set the environment to include ZERO_AR_FLAGS.
   //
-  // FIXME: Add a -freproducible-debug-info command-line option and use that to
-  // trigger this.
-  //
   // FIXME: Add a flag to the linkers to support this without an environment
   // variable, and use that when the linkers are new enough.
   VirtualEnvironment Environment;
-  Environment.set("ZERO_AR_DATE", "1",
-                  [&](StringRef S) { return Args.MakeArgString(S); });
+  if (Args.hasFlag(options::OPT_greproducible,
+                   options::OPT_gno_reproducible, false))
+    Environment.set("ZERO_AR_DATE", "1",
+                    [&](StringRef S) { return Args.MakeArgString(S); });
 
   std::unique_ptr<Command> Cmd = std::make_unique<Command>(
       JA, *this, ResponseSupport, Exec, CmdArgs, Inputs, Output);

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -518,6 +518,90 @@ static void renderRemarksOptions(const ArgList &Args, ArgStringList &CmdArgs,
   }
 }
 
+namespace {
+/// Environment. By default, same as the host application.
+class VirtualEnvironment {
+public:
+  Optional<ArrayRef<const char *>> getEnvironmentIfOverridden() const {
+    if (Environment)
+      return makeArrayRef(*Environment);
+    return None;
+  }
+
+  void set(StringRef Name, StringRef Value,
+           llvm::function_ref<const char *(StringRef)> SaveString);
+
+private:
+  static const char **findName(const char **I, StringRef Name,
+                               Optional<StringRef> &Existing);
+  static const char **getHostEnvironment();
+  void copyHostEnvironment(const char **I = nullptr);
+  Optional<SmallVector<const char *>> Environment;
+};
+} // end namespace
+
+const char **VirtualEnvironment::findName(const char **I, StringRef Name,
+                                          Optional<StringRef> &Existing) {
+  std::string Prefix = (Name + Twine("=")).str();
+  for (; *I; ++I) {
+    StringRef NameValue = *I;
+    if (!NameValue.startswith(Prefix))
+      continue;
+    Existing = NameValue;
+    break;
+  }
+  return I;
+}
+
+extern char **environ;
+const char **VirtualEnvironment::getHostEnvironment() {
+  return const_cast<const char **>(environ);
+}
+
+void VirtualEnvironment::copyHostEnvironment(const char **Hint) {
+  assert(!Environment);
+  const char **B = getHostEnvironment();
+  const char **I = Hint ? Hint : B;
+  while (*I)
+    ++I;
+
+  Environment.emplace();
+
+  // Include room for nullptr plus 1 new variable.
+  Environment->reserve(I - B + 2);
+
+  // Include nullptr.
+  Environment->append(B, I + 1);
+}
+
+/// Set an environment variable.
+///
+/// FIXME: Not portable.
+void VirtualEnvironment::set(
+    StringRef Name, StringRef Value,
+    llvm::function_ref<const char *(StringRef)> SaveString) {
+  const char **B =
+      Environment ? Environment->data() : const_cast<const char **>(environ);
+  Optional<StringRef> Existing;
+  const char **I = findName(B, Name, Existing);
+  if (Existing && Existing->drop_front(Name.size() + 1) == Value)
+    return;
+
+  SmallString<128> Storage;
+  const char *NameValue =
+      SaveString((Name + Twine("=") + Value).toStringRef(Storage));
+
+  // Update the environment block.
+  if (!Environment)
+    copyHostEnvironment(I);
+  if (*I) {
+    (*Environment)[I - B] = NameValue;
+    return;
+  }
+  Environment->back() = NameValue;
+  Environment->push_back(nullptr);
+}
+
 void darwin::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                                   const InputInfo &Output,
                                   const InputInfoList &Inputs,
@@ -723,9 +807,32 @@ void darwin::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                        "-filelist"};
   }
 
+  // Set the environment to include ZERO_AR_FLAGS.
+  //
+  // FIXME: Add a -freproducible-debug-info command-line option and use that to
+  // trigger this.
+  //
+  // FIXME: Add a flag to the linkers to support this without an environment
+  // variable, and use that when the linkers are new enough.
+  VirtualEnvironment Environment;
+  Environment.set("ZERO_AR_DATE", "1",
+                  [&](StringRef S) { return Args.MakeArgString(S); });
+
   std::unique_ptr<Command> Cmd = std::make_unique<Command>(
       JA, *this, ResponseSupport, Exec, CmdArgs, Inputs, Output);
   Cmd->setInputFileList(std::move(InputFileList));
+
+  // Set the environment, if it has been overridden.
+  //
+  // FIXME: If VAR=1 has been overridden, then -### should include it as:
+  //
+  //     % env VAR=1 /usr/bin/ld ...
+  //
+  // But currently nothing gets shown at all.
+  if (Optional<ArrayRef<const char *>> Env =
+          Environment.getEnvironmentIfOverridden())
+    Cmd->setEnvironment(*Env);
+
   C.addCommand(std::move(Cmd));
 }
 

--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -1264,6 +1264,13 @@ if(LLVM_ENABLE_EXPERIMENTAL_DEPSCAN)
     append("-fdepscan-prefix-map-toolchain=/^toolchain" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
     append("-fdepscan-prefix-map=${source_root}=/^source" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
     append("-fdepscan-prefix-map=${CMAKE_BINARY_DIR}=/^build" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+
+    check_c_compiler_flag("-greproducible" SUPPORTS_GREPRODUCIBLE)
+    if(SUPPORTS_GREPRODUCIBLE)
+      append("-greproducible"
+        CMAKE_C_FLAGS CMAKE_CXX_FLAGS
+        CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
- e3e7ad7e44f2 Driver: Set ZERO_AC_DATE=1 on Darwin to make link output reproducible
- 3d4e34e851bb Driver: Show environment in -###
- cb89dd06fcce Clang: Add -greproducible

First commit has the meat, then the others make it testable / add command-line options / etc. Confirmed locally that `llvm-tablegen` is now reproducible even with debug info.

`-greproducible` does two things for now:
- It sets the right environment for ld64 (and lld) to use zeroes in object file timestamps.
- It controls whether debug info includes the Git revision of the producer (this branch used to do this unconditionally).
