### PR TITLE
[20210726][split-file] Default to --no-leading-lines

### DIFF
--- a/lld/test/ELF/linkerscript/overwrite-sections.test
+++ b/lld/test/ELF/linkerscript/overwrite-sections.test
@@ -1,5 +1,5 @@
 # REQUIRES: x86
-# RUN: rm -rf %t && split-file %s %t
+# RUN: rm -rf %t && split-file --leading-lines %s %t
 # RUN: llvm-mc -filetype=obj -triple=x86_64 %t/a.s -o %t/a.o
 
 ## There is no main linker script. OVERWRITE_SECTIONS defines output section

--- a/llvm/test/tools/split-file/basic.test
+++ b/llvm/test/tools/split-file/basic.test
@@ -9,20 +9,20 @@ cc
 //--- end
 
 # RUN: rm -rf %t
-# RUN: split-file %s %t
+# RUN: split-file --leading-lines %s %t
 # RUN: diff %S/Inputs/basic-aa.txt %t/aa
 # RUN: diff %S/Inputs/basic-bb.txt %t/bb
 # RUN: diff %S/Inputs/basic-cc.txt %t/subdir/cc
 # RUN: FileCheck %s --check-prefix=END < %t/end
 
 ## Can be called on a non-empty directory.
-# RUN: split-file %s %t
+# RUN: split-file --leading-lines %s %t
 # RUN: diff %S/Inputs/basic-aa.txt %t/aa
 
 ## Test that we will delete the output if it is a file, so that we can create
 ## a directory.
 # RUN: rm -rf %t && touch %t
-# RUN: split-file %s %t
+# RUN: split-file --leading-lines %s %t
 # RUN: diff %S/Inputs/basic-aa.txt %t/aa
 
 # END: RUN: split-file %s %t

--- a/llvm/tools/split-file/split-file.cpp
+++ b/llvm/tools/split-file/split-file.cpp
@@ -35,8 +35,12 @@ static cl::opt<std::string> input(cl::Positional, cl::desc("filename"),
 static cl::opt<std::string> output(cl::Positional, cl::desc("directory"),
                                    cl::value_desc("directory"), cl::cat(cat));
 
+static cl::opt<bool> leadingLines("leading-lines",
+                                    cl::desc("Preserve line numbers"),
+                                    cl::cat(cat));
+
 static cl::opt<bool> noLeadingLines("no-leading-lines",
-                                    cl::desc("Don't preserve line numbers"),
+                                    cl::desc("Don't preserve line numbers (default)"),
                                     cl::cat(cat));
 
 static StringRef toolName;
@@ -97,9 +101,9 @@ static int handle(MemoryBuffer &inputBuf, StringRef input) {
     Part &cur = res.first->second;
     if (!i.is_at_eof())
       cur.begin = i->data();
-    // If --no-leading-lines is not specified, numEmptyLines is 0. Append
-    // newlines so that the extracted part preserves line numbers.
-    cur.leadingLines = noLeadingLines ? 0 : i.line_number() - 1;
+    // If --leading-lines is specified, numEmptyLines is 0. Append newlines so
+    // that the extracted part preserves line numbers.
+    cur.leadingLines = leadingLines ? i.line_number() - 1 : 0;
 
     lastPart = partName;
   }


### PR DESCRIPTION
Cherry-pick split-file `--no-leading-lines` as default change with the aim to update Swift's `split_file.py` with `split-file` instead.

-----

It turns out that the --leading-lines may be a bad default.
[[#@LINE+-num]] is rarely used.