### PR TITLE
[CASObjectFormats/FlatV1] Fix issue where edges got dropped during round-tripping

### DIFF
--- a/llvm/lib/CASObjectFormats/FlatV1.cpp
+++ b/llvm/lib/CASObjectFormats/FlatV1.cpp
@@ -456,10 +456,8 @@ Error BlockRef::materializeEdges(LinkGraphBuilder &LGB,
   if (!BlockInfo)
     return BlockInfo.takeError();
 
-  // Nothing remains, no edges.
-  if (!BlockInfo->Remaining)
-    return Error::success();
-
+  // There may be edges even if `BlockInfo->Remaining` is zero, if the `addend`s
+  // are zero.
   auto Remaining = getData().take_back(BlockInfo->Remaining);
   for (const data::Fixup &Fixup : BlockInfo->Data->getFixups()) {
     if (Error Err =

--- a/llvm/unittests/CASObjectFormats/FlatV1SchemaTest.cpp
+++ b/llvm/unittests/CASObjectFormats/FlatV1SchemaTest.cpp
@@ -92,6 +92,14 @@ TEST(FlatV1SchemaTest, RoundTrip) {
   G.addDefinedSymbol(DupB, 0, "DupB1", 0, jitlink::Linkage::Strong,
                      jitlink::Scope::Default, false, false);
 
+  {
+    // Create a block with an edge with addend = 0.
+    jitlink::Block &B = G.createContentBlock(Section, BlockContent, 0, 256, 0);
+    B.addEdge(jitlink::Edge::FirstKeepAlive, 0, S1, 0);
+    G.addDefinedSymbol(B, 0, "AddendZeroEdge", 0, jitlink::Linkage::Strong,
+                       jitlink::Scope::Default, false, false);
+  }
+
   std::unique_ptr<jitlink::LinkGraph> RoundTripG;
   {
     // Convert to cas.o.


### PR DESCRIPTION
If a block had edges with `addend=0`, then they would all get dropped during round-tripping.