### PR TITLE
[lldb] Move DumpSummary implementation to TypeSystemSwift

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -8063,12 +8063,6 @@ std::string SwiftASTContext::ImportName(const clang::NamedDecl *clang_decl) {
   return clang_decl->getName().str();
 }
 
-void SwiftASTContext::DumpSummary(opaque_compiler_type_t type,
-                                  ExecutionContext *exe_ctx, Stream *s,
-                                  const lldb_private::DataExtractor &data,
-                                  lldb::offset_t data_byte_offset,
-                                  size_t data_byte_size) {}
-
 void SwiftASTContext::DumpTypeDescription(opaque_compiler_type_t type,
                                           lldb::DescriptionLevel level) {
   StreamFile s(stdout, false);

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -709,12 +709,6 @@ public:
       bool print_help_if_available, bool print_extensions_if_available,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
 
-  // TODO: These methods appear unused. Should they be removed?
-
-  void DumpSummary(lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
-                   Stream *s, const DataExtractor &data,
-                   lldb::offset_t data_offset, size_t data_byte_size) override;
-
   // TODO: Determine if these methods should move to TypeSystemClang.
 
   bool IsPointerOrReferenceType(lldb::opaque_compiler_type_t type,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -293,6 +293,11 @@ public:
     return {};
   }
 
+  // TODO: This method appear unused. Should they be removed?
+  void DumpSummary(lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
+                   Stream *s, const DataExtractor &data,
+                   lldb::offset_t data_offset, size_t data_byte_size) override {
+  }
   /// \}
 protected:
   /// Used in the logs.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3400,16 +3400,6 @@ void TypeSystemSwiftTypeRef::DumpTypeDescription(opaque_compiler_type_t type,
     return swift_ast_context->DumpTypeDescription(ReconstructType(type), s,
                                                   level);
 }
-void TypeSystemSwiftTypeRef::DumpSummary(opaque_compiler_type_t type,
-                                         ExecutionContext *exe_ctx, Stream *s,
-                                         const DataExtractor &data,
-                                         lldb::offset_t data_offset,
-                                         size_t data_byte_size) {
-  LLDB_SCOPED_TIMER();
-  if (auto *swift_ast_context = GetSwiftASTContext())
-    return swift_ast_context->DumpSummary(ReconstructType(type), exe_ctx, s,
-                                          data, data_offset, data_byte_size);
-}
 bool TypeSystemSwiftTypeRef::IsPointerOrReferenceType(
     opaque_compiler_type_t type, CompilerType *pointee_type) {
   auto impl = [&]() {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -213,9 +213,7 @@ public:
   void DumpTypeDescription(
       lldb::opaque_compiler_type_t type, Stream *s,
       lldb::DescriptionLevel level = lldb::eDescriptionLevelFull) override;
-  void DumpSummary(lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
-                   Stream *s, const DataExtractor &data,
-                   lldb::offset_t data_offset, size_t data_byte_size) override;
+
   bool IsPointerOrReferenceType(lldb::opaque_compiler_type_t type,
                                 CompilerType *pointee_type) override;
   llvm::Optional<size_t>


### PR DESCRIPTION
DumpSummary appears to be unused, and it has an empty implementation on
SwiftASTContext. Move it to TypeSystemSwift so it's shared to
TypeSystemSwiftTypeRef as well.

(cherry picked from commit 3c6d4b1e1dd2764f6da8f2c470daaf47c7018277)