### PR TITLE
[lld] Add initial support for `lld` to load and link `CAS.o` objects

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -243,3 +243,12 @@ directory.
     --keep-compact-unwind-alive=false \
     --prefer-indirect-symbol-refs=true
 ```
+
+## lld: Linking CAS.o
+
+`lld` can connect to the builtin CAS and read & link `CAS.o` objects:
+
+```
+% llvm-cas-object-format --cas "$TMPDIR/casfs.default" t1.o t2.o -silent > casid
+% ld64.lld -cas_path "$TMPDIR/casfs.default" @casid -o a.out
+```

--- a/lld/MachO/CMakeLists.txt
+++ b/lld/MachO/CMakeLists.txt
@@ -36,6 +36,7 @@ add_lld_library(lldMachO
   ${LLVM_TARGETS_TO_BUILD}
   BinaryFormat
   BitReader
+  CASObjectFormats
   Core
   DebugInfoDWARF
   LTO

--- a/lld/MachO/Config.h
+++ b/lld/MachO/Config.h
@@ -24,6 +24,15 @@
 
 #include <vector>
 
+namespace llvm {
+namespace cas {
+class CASDB;
+}
+namespace casobjectformats {
+class SchemaPool;
+}
+} // namespace llvm
+
 namespace lld {
 namespace macho {
 
@@ -164,6 +173,9 @@ struct Configuration {
   // so use a vector instead of a map.
   std::vector<SectionAlign> sectionAlignments;
   std::vector<SegmentProtection> segmentProtections;
+
+  std::unique_ptr<llvm::cas::CASDB> CAS;
+  std::unique_ptr<llvm::casobjectformats::SchemaPool> CASSchemas;
 
   llvm::DenseMap<llvm::StringRef, SymbolPriorityEntry> priorities;
   SectionRenameMap sectionRenameMap;

--- a/lld/MachO/InputFiles.h
+++ b/lld/MachO/InputFiles.h
@@ -17,6 +17,7 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/BinaryFormat/MachO.h"
+#include "llvm/CAS/CASDB.h"
 #include "llvm/DebugInfo/DWARF/DWARFUnit.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -32,6 +33,12 @@ namespace MachO {
 class InterfaceFile;
 } // namespace MachO
 class TarWriter;
+namespace casobjectformats {
+class SchemaPool;
+} // namespace casobjectformats
+namespace jitlink {
+class LinkGraph;
+} // namespace jitlink
 } // namespace llvm
 
 namespace lld {
@@ -64,6 +71,7 @@ public:
     DylibKind,
     ArchiveKind,
     BitcodeKind,
+    CASSchemaKind,
   };
 
   virtual ~InputFile() = default;
@@ -84,6 +92,9 @@ public:
 protected:
   InputFile(Kind kind, MemoryBufferRef mb)
       : mb(mb), id(idCount++), fileKind(kind), name(mb.getBufferIdentifier()) {}
+
+  InputFile(Kind kind, StringRef name_)
+      : id(idCount++), fileKind(kind), name(name_) {}
 
   InputFile(Kind, const llvm::MachO::InterfaceFile &);
 
@@ -119,6 +130,22 @@ private:
                         SubsectionMap &);
   void parseDebugInfo();
   void parseDataInCode();
+};
+
+// CAS-schema .o file
+class CASSchemaFile final : public InputFile {
+public:
+  CASSchemaFile(llvm::casobjectformats::SchemaPool &CASSchemas,
+                llvm::cas::CASID ID, StringRef filename);
+  ~CASSchemaFile();
+  static bool classof(const InputFile *f) { return f->kind() == CASSchemaKind; }
+
+  Error parse();
+
+private:
+  llvm::casobjectformats::SchemaPool &CASSchemas;
+  llvm::cas::CASID ID;
+  std::unique_ptr<llvm::jitlink::LinkGraph> linkGraph;
 };
 
 // command-line -sectcreate file

--- a/lld/MachO/Options.td
+++ b/lld/MachO/Options.td
@@ -921,6 +921,10 @@ def cache_path_lto : Separate<["-"], "cache_path_lto">,
     MetaVarName<"<path>">,
     HelpText<"Use <path> as a directory for the incremental LTO cache">,
     Group<grp_rare>;
+def cas_path : Separate<["-"], "cas_path">,
+    MetaVarName<"<path>">,
+    HelpText<"Use <path> as the path to the CAS on disk">,
+    Group<grp_rare>;
 def prune_interval_lto : Separate<["-"], "prune_interval_lto">,
     MetaVarName<"<seconds>">,
     HelpText<"Prune the incremental LTO cache after <seconds> (-1 disables pruning)">,

--- a/lld/MachO/SymbolTable.cpp
+++ b/lld/MachO/SymbolTable.cpp
@@ -56,7 +56,8 @@ Defined *SymbolTable::addDefined(StringRef name, InputFile *file,
   std::tie(s, wasInserted) = insert(name, file);
 
   assert(!isWeakDef || (isa<BitcodeFile>(file) && !isec) ||
-         (isa<ObjFile>(file) && file == isec->getFile()));
+         ((isa<ObjFile>(file) || isa<CASSchemaFile>(file)) &&
+          file == isec->getFile()));
 
   if (!wasInserted) {
     if (auto *defined = dyn_cast<Defined>(s)) {

--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -943,12 +943,12 @@ void SymtabSection::finalizeContents() {
   // Local symbols aren't in the SymbolTable, so we walk the list of object
   // files to gather them.
   for (const InputFile *file : inputFiles) {
-    if (auto *objFile = dyn_cast<ObjFile>(file)) {
-      for (Symbol *sym : objFile->symbols) {
+    if (isa<ObjFile>(file) || isa<CASSchemaFile>(file)) {
+      for (Symbol *sym : file->symbols) {
         if (auto *defined = dyn_cast_or_null<Defined>(sym)) {
           if (!defined->isExternal() && defined->isLive()) {
             StringRef name = defined->getName();
-            if (!name.startswith("l") && !name.startswith("L"))
+            if (!name.empty() && !name.startswith("l") && !name.startswith("L"))
               addSymbol(localSymbols, sym);
           }
         }

--- a/lld/test/MachO/CAS/cpp-globalctordtor.s
+++ b/lld/test/MachO/CAS/cpp-globalctordtor.s
@@ -1,0 +1,149 @@
+// REQUIRES: x86
+// RUN: rm -rf %t; mkdir -p %t
+// RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %s -o %t/test.o
+// RUN: llvm-cas-object-format %t/test.o -cas %t/cas -ingest-schema=flatv1 -silent > %t/casid-flat.txt
+// RUN: llvm-cas-object-format %t/test.o -cas %t/cas -ingest-schema=nestedv1 -silent > %t/casid-nested.txt
+// RUN: %lld -lc++ -lSystem -cas_path %t/cas @%t/casid-flat.txt -o %t/test-flat
+// RUN: %lld -lc++ -lSystem -cas_path %t/cas @%t/casid-nested.txt -o %t/test-nested
+// RUN: llvm-objdump --macho %t/test-flat --full-contents -d -t | \
+// RUN:     FileCheck %s --check-prefix=CHECK --check-prefix=FLAT
+// RUN: llvm-objdump --macho %t/test-nested --full-contents -d -t | \
+// RUN:     FileCheck %s --check-prefix=CHECK --check-prefix=NESTED
+
+// NESTED: __GLOBAL__sub_I_test.cpp:
+// NESTED: callq ___cxx_global_var_init
+
+// CHECK: ___cxx_global_var_init:
+// CHECK: leaq	_mys1(%rip), %rdi
+// CHECK: callq	__ZN3MySC1Ev ## MyS::MyS()
+// CHECK: leaq	__ZN3MySD1Ev(%rip), %rdi ## MyS::~MyS()
+// CHECK: leaq	_mys1(%rip), %rsi
+// CHECK: leaq	__mh_execute_header(%rip), %rdx
+// CHECK: callq	{{.*}} ## symbol stub for: ___cxa_atexit
+
+// FLAT: __GLOBAL__sub_I_test.cpp:
+// FLAT: callq ___cxx_global_var_init
+
+// CHECK: Contents of section __TEXT,__stubs:
+// CHECK: Contents of section __TEXT,__stub_helper:
+// CHECK: Contents of section __DATA_CONST,__got:
+// CHECK: Contents of section __DATA_CONST,__mod_init_func:
+// CHECK: Contents of section __DATA,__la_symbol_ptr:
+// CHECK: Contents of section __DATA,__data:
+// CHECK: Contents of section __DATA,__common:
+
+// CHECK: SYMBOL TABLE:
+
+// FLAT: l     F __TEXT,__text ___cxx_global_var_init
+// FLAT: l     F __TEXT,__text __GLOBAL__sub_I_test.cpp
+// FLAT: l     O __DATA,__data __dyld_private
+// FLAT: l     F __TEXT,__text __ZN3MySC1Ev
+// FLAT: l     F __TEXT,__text __ZN3MySD1Ev
+// FLAT: l     F __TEXT,__text __ZN3MySC2Ev
+// FLAT: l     F __TEXT,__text __ZN3MySD2Ev
+
+// NESTED: l     F __TEXT,__text __GLOBAL__sub_I_test.cpp
+// NESTED: l     F __TEXT,__text ___cxx_global_var_init
+// NESTED: l     O __DATA,__data __dyld_private
+// NESTED: l     F __TEXT,__text __ZN3MySC1Ev
+// NESTED: l     F __TEXT,__text __ZN3MySC2Ev
+// NESTED: l     F __TEXT,__text __ZN3MySD2Ev
+// NESTED: l     F __TEXT,__text __ZN3MySD1Ev
+
+// CHECK: g     F __TEXT,__text _main
+// CHECK: g     O __DATA,__common _mys1
+// CHECK: g     F __TEXT,__text __mh_execute_header
+// CHECK:         *UND* ___cxa_atexit
+// CHECK:         *UND* dyld_stub_binder
+
+## This is assembly output of:
+##
+##  struct MyS {
+##    char c[7];
+##    MyS() {}
+##    ~MyS() {}
+##  };
+##  MyS mys1;
+##  int main() {
+##    return 0;
+##  }
+##
+	.section	__TEXT,__text,regular,pure_instructions
+	.section	__TEXT,__StaticInit,regular,pure_instructions
+	.p2align	4, 0x90                         ## -- Begin function __cxx_global_var_init
+___cxx_global_var_init:                 ## @__cxx_global_var_init
+## %bb.0:                               ## %entry
+	pushq	%rax
+	leaq	_mys1(%rip), %rdi
+	callq	__ZN3MySC1Ev
+	movq	__ZN3MySD1Ev@GOTPCREL(%rip), %rdi
+	leaq	_mys1(%rip), %rsi
+	leaq	___dso_handle(%rip), %rdx
+	callq	___cxa_atexit
+	popq	%rax
+	retq
+                                        ## -- End function
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	__ZN3MySC1Ev                    ## -- Begin function _ZN3MySC1Ev
+	.weak_def_can_be_hidden	__ZN3MySC1Ev
+	.p2align	4, 0x90
+__ZN3MySC1Ev:                           ## @_ZN3MySC1Ev
+## %bb.0:                               ## %entry
+	pushq	%rax
+	movq	%rdi, (%rsp)
+	movq	(%rsp), %rdi
+	callq	__ZN3MySC2Ev
+	popq	%rax
+	retq
+                                        ## -- End function
+	.globl	__ZN3MySD1Ev                    ## -- Begin function _ZN3MySD1Ev
+	.weak_def_can_be_hidden	__ZN3MySD1Ev
+	.p2align	4, 0x90
+__ZN3MySD1Ev:                           ## @_ZN3MySD1Ev
+## %bb.0:                               ## %entry
+	pushq	%rax
+	movq	%rdi, (%rsp)
+	movq	(%rsp), %rdi
+	callq	__ZN3MySD2Ev
+	popq	%rax
+	retq
+                                        ## -- End function
+	.globl	_main                           ## -- Begin function main
+	.p2align	4, 0x90
+_main:                                  ## @main
+## %bb.0:                               ## %entry
+	movl	$0, -4(%rsp)
+	xorl	%eax, %eax
+	retq
+                                        ## -- End function
+	.globl	__ZN3MySC2Ev                    ## -- Begin function _ZN3MySC2Ev
+	.weak_def_can_be_hidden	__ZN3MySC2Ev
+	.p2align	4, 0x90
+__ZN3MySC2Ev:                           ## @_ZN3MySC2Ev
+## %bb.0:                               ## %entry
+	movq	%rdi, -8(%rsp)
+	retq
+                                        ## -- End function
+	.globl	__ZN3MySD2Ev                    ## -- Begin function _ZN3MySD2Ev
+	.weak_def_can_be_hidden	__ZN3MySD2Ev
+	.p2align	4, 0x90
+__ZN3MySD2Ev:                           ## @_ZN3MySD2Ev
+## %bb.0:                               ## %entry
+	movq	%rdi, -8(%rsp)
+	retq
+                                        ## -- End function
+	.section	__TEXT,__StaticInit,regular,pure_instructions
+	.p2align	4, 0x90                         ## -- Begin function _GLOBAL__sub_I_test.cpp
+__GLOBAL__sub_I_test.cpp:               ## @_GLOBAL__sub_I_test.cpp
+## %bb.0:                               ## %entry
+	pushq	%rax
+	callq	___cxx_global_var_init
+	popq	%rax
+	retq
+                                        ## -- End function
+	.globl	_mys1                           ## @mys1
+.zerofill __DATA,__common,_mys1,7,0
+	.section	__DATA,__mod_init_func,mod_init_funcs
+	.p2align	3
+	.quad	__GLOBAL__sub_I_test.cpp
+.subsections_via_symbols

--- a/lld/test/MachO/CAS/cstrings.s
+++ b/lld/test/MachO/CAS/cstrings.s
@@ -1,0 +1,103 @@
+// REQUIRES: x86
+// RUN: rm -rf %t; mkdir -p %t
+// RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %s -o %t/test.o
+// RUN: llvm-cas-object-format %t/test.o -cas %t/cas -ingest-schema=flatv1 -silent > %t/casid-flat.txt
+// RUN: llvm-cas-object-format %t/test.o -cas %t/cas -ingest-schema=nestedv1 -silent > %t/casid-nested.txt
+// RUN: %lld -cas_path %t/cas @%t/casid-flat.txt -o %t/test-flat
+// RUN: %lld -cas_path %t/cas @%t/casid-nested.txt -o %t/test-nested
+// RUN: llvm-objdump --macho %t/test-flat --full-contents -d -t | FileCheck %s
+// RUN: llvm-objdump --macho %t/test-nested --full-contents -d -t | FileCheck %s
+
+// CHECK: _main:
+// CHECK: movq	_svar1(%rip), %rdi
+// CHECK: callq	_puts_stub
+// CHECK: movq	_svar2(%rip), %rdi
+// CHECK: callq	_puts_stub
+// CHECK: movq	_svar3(%rip), %rdi
+// CHECK: callq	_puts_stub
+
+// CHECK: _puts_stub:
+// CHECK: movq	%rdi, -8(%rsp)
+
+// CHECK: Contents of section __TEXT,__cstring:
+// CHECK:  1000003d0 68656c6c 6f00776f 726c6400 2100      hello.world.!.
+// CHECK: Contents of section __DATA,__data:
+// CHECK:  100001000 d0030000 01000000 d6030000 01000000
+// CHECK:  100001010 dc030000 01000000
+
+// CHECK: SYMBOL TABLE:
+// CHECK: 00000001000003c0 l     F __TEXT,__text _puts_stub
+// CHECK: 0000000100000380 g     F __TEXT,__text _main
+// CHECK: 0000000100001000 g     O __DATA,__data _svar1
+// CHECK: 0000000100001008 g     O __DATA,__data _svar2
+// CHECK: 0000000100001010 g     O __DATA,__data _svar3
+
+
+## This is assembly output of:
+##
+##  const char *svar1 = "hello";
+##  const char *svar2 = "world";
+##  const char *svar3 = "!";
+##  static inline void puts_stub(const char *);
+##  int main() {
+##    puts_stub(svar1);
+##    puts_stub(svar2);
+##    puts_stub(svar3);
+##    return 0;
+##  }
+##  static inline void puts_stub(const char *) {}
+##
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_main                           ## -- Begin function main
+	.p2align	4, 0x90
+_main:                                  ## @main
+## %bb.0:                               ## %entry
+	pushq	%rax
+	movl	$0, 4(%rsp)
+	movq	_svar1(%rip), %rdi
+	callq	_puts_stub
+	movq	_svar2(%rip), %rdi
+	callq	_puts_stub
+	movq	_svar3(%rip), %rdi
+	callq	_puts_stub
+	xorl	%eax, %eax
+	popq	%rcx
+	retq
+                                        ## -- End function
+	.p2align	4, 0x90                         ## -- Begin function puts_stub
+_puts_stub:                             ## @puts_stub
+## %bb.0:                               ## %entry
+	movq	%rdi, -8(%rsp)
+	retq
+                                        ## -- End function
+	.section	__TEXT,__cstring,cstring_literals
+L_.str:                                 ## @.str
+	.asciz	"hello"
+
+	.section	__DATA,__data
+	.globl	_svar1                          ## @svar1
+	.p2align	3
+_svar1:
+	.quad	L_.str
+
+	.section	__TEXT,__cstring,cstring_literals
+L_.str.1:                               ## @.str.1
+	.asciz	"world"
+
+	.section	__DATA,__data
+	.globl	_svar2                          ## @svar2
+	.p2align	3
+_svar2:
+	.quad	L_.str.1
+
+	.section	__TEXT,__cstring,cstring_literals
+L_.str.2:                               ## @.str.2
+	.asciz	"!"
+
+	.section	__DATA,__data
+	.globl	_svar3                          ## @svar3
+	.p2align	3
+_svar3:
+	.quad	L_.str.2
+
+.subsections_via_symbols

--- a/lld/test/MachO/CAS/tlv.s
+++ b/lld/test/MachO/CAS/tlv.s
@@ -1,0 +1,65 @@
+// REQUIRES: x86
+// RUN: rm -rf %t; mkdir -p %t
+// RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %s -o %t/test.o
+// RUN: llvm-cas-object-format %t/test.o -cas %t/cas -ingest-schema=flatv1 -silent > %t/casid-flat.txt
+// RUN: llvm-cas-object-format %t/test.o -cas %t/cas -ingest-schema=nestedv1 -silent > %t/casid-nested.txt
+// RUN: %lld -lSystem -cas_path %t/cas @%t/casid-flat.txt -o %t/test-flat
+// RUN: %lld -lSystem -cas_path %t/cas @%t/casid-nested.txt -o %t/test-nested
+// RUN: llvm-objdump --macho %t/test-flat --full-contents -d -t | FileCheck %s
+// RUN: llvm-objdump --macho %t/test-nested --full-contents -d -t | FileCheck %s
+
+// CHECK: _main:
+// CHECK: pushq %rax
+// CHECK: movl  $0, 4(%rsp)
+// CHECK: leaq  _sometlv(%rip), %rdi
+// CHECK: callq *(%rdi)
+// CHECK: movl  $1, (%rax)
+// CHECK: movl  (%rax), %eax
+// CHECK: popq  %rcx
+// CHECK: retq
+
+// CHECK: Contents of section __TEXT,__text:
+// CHECK: Contents of section __DATA,__thread_vars:
+// CHECK: Contents of section __DATA,__thread_bss:
+// CHECK:  100001018 cffaedfe
+
+// CHECK: SYMBOL TABLE:
+// CHECK: 0000000100001018 l     O __DATA,__thread_bss _sometlv$tlv$init
+// CHECK: 00000001000003b0 g     F __TEXT,__text _main
+// CHECK: 0000000100001000 g     O __DATA,__thread_vars _sometlv
+// CHECK: 0000000100000000 g     F __TEXT,__text __mh_execute_header
+// CHECK: 0000000000000000         *UND* dyld_stub_binder
+// CHECK: 0000000000000000         *UND* __tlv_bootstrap
+
+## This is assembly output of:
+##
+## __thread int sometlv;
+## int main() {
+##   sometlv = 1;
+##   return sometlv;
+## }
+##
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_main                           ## -- Begin function main
+	.p2align	4, 0x90
+_main:                                  ## @main
+## %bb.0:                               ## %entry
+	pushq	%rax
+	movl	$0, 4(%rsp)
+	movq	_sometlv@TLVP(%rip), %rdi
+	callq	*(%rdi)
+	movl	$1, (%rax)
+	movl	(%rax), %eax
+	popq	%rcx
+	retq
+                                        ## -- End function
+.tbss _sometlv$tlv$init, 4, 2           ## @sometlv
+
+	.section	__DATA,__thread_vars,thread_local_variables
+	.globl	_sometlv
+_sometlv:
+	.quad	__tlv_bootstrap
+	.quad	0
+	.quad	_sometlv$tlv$init
+
+.subsections_via_symbols

--- a/lld/test/MachO/Inputs/MacOSX.sdk/usr/lib/libc++abi.tbd
+++ b/lld/test/MachO/Inputs/MacOSX.sdk/usr/lib/libc++abi.tbd
@@ -6,5 +6,5 @@ install-name:     '/usr/lib/libc++abi.dylib'
 current-version:  1281
 exports:
   - archs:        [ i386, x86_64, arm64 ]
-    symbols:      [ ___cxa_allocate_exception, ___cxa_begin_catch, ___cxa_end_catch, ___cxa_throw, ___gxx_personality_v0, __ZTIi ]
+    symbols:      [ ___cxa_allocate_exception, ___cxa_begin_catch, ___cxa_end_catch, ___cxa_throw, ___cxa_atexit, ___gxx_personality_v0, __ZTIi ]
 ...

--- a/lld/test/lit.cfg.py
+++ b/lld/test/lit.cfg.py
@@ -40,7 +40,7 @@ llvm_config.use_lld()
 tool_patterns = [
     'llc', 'llvm-as', 'llvm-mc', 'llvm-nm', 'llvm-objdump', 'llvm-pdbutil',
     'llvm-dwarfdump', 'llvm-readelf', 'llvm-readobj', 'obj2yaml', 'yaml2obj',
-    'opt', 'llvm-dis']
+    'opt', 'llvm-dis', 'llvm-cas-object-format']
 
 llvm_config.add_tool_substitutions(tool_patterns)
 

--- a/llvm/include/llvm/CASObjectFormats/SchemaBase.h
+++ b/llvm/include/llvm/CASObjectFormats/SchemaBase.h
@@ -80,6 +80,28 @@ public:
   virtual ~SchemaBase() = default;
 };
 
+/// Creates all the schemas and can be used to retrieve a particular schema
+/// based on a CAS root node. A client should aim to create and maximize re-use
+/// of an instance of this object.
+class SchemaPool {
+public:
+  /// Creates all the schemas up front.
+  explicit SchemaPool(cas::CASDB &CAS);
+
+  /// Look up the schema for the provided root node. Returns \a nullptr if no
+  /// schema was found or it's not actually a root node. The returned \p
+  /// SchemaBase pointer is owned by the \p SchemaPool instance, therefore it
+  /// cannot be used beyond the \p SchemaPool instance's lifetime.
+  ///
+  /// Thread-safe.
+  SchemaBase *getSchemaForRoot(cas::NodeRef Node) const;
+
+  cas::CASDB &getCAS() const { return Schemas.front()->CAS; }
+
+private:
+  SmallVector<std::unique_ptr<SchemaBase>> Schemas;
+};
+
 } // namespace casobjectformats
 } // namespace llvm
 

--- a/llvm/lib/CASObjectFormats/SchemaBase.cpp
+++ b/llvm/lib/CASObjectFormats/SchemaBase.cpp
@@ -7,8 +7,23 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CASObjectFormats/SchemaBase.h"
+#include "llvm/CASObjectFormats/FlatV1.h"
+#include "llvm/CASObjectFormats/NestedV1.h"
 
 using namespace llvm;
 using namespace llvm::casobjectformats;
 
 void SchemaBase::anchor() {}
+
+SchemaPool::SchemaPool(cas::CASDB &CAS) {
+  Schemas.push_back(std::make_unique<flatv1::ObjectFileSchema>(CAS));
+  Schemas.push_back(std::make_unique<nestedv1::ObjectFileSchema>(CAS));
+}
+
+SchemaBase *SchemaPool::getSchemaForRoot(cas::NodeRef Node) const {
+  for (auto &Schema : Schemas) {
+    if (Schema->isRootNode(Node))
+      return Schema.get();
+  }
+  return nullptr;
+}

--- a/llvm/tools/llvm-cas-object-format/llvm-cas-object-format.cpp
+++ b/llvm/tools/llvm-cas-object-format/llvm-cas-object-format.cpp
@@ -254,6 +254,7 @@ struct StatCollector {
   using POTItemHandler = unique_function<void(
       ExitOnError &, function_ref<void(ObjectKindInfo &)>, cas::NodeRef)>;
 
+  // FIXME: Utilize \p SchemaPool.
   nestedv1::ObjectFileSchema NestedV1Schema;
   flatv1::ObjectFileSchema FlatV1Schema;
   SmallVector<std::pair<const SchemaBase *, POTItemHandler>> Schemas;


### PR DESCRIPTION
Adds option `-cas_path` which makes `lld` able to parse & load CASIDs from the command-line instead of .o file paths.
It currently works by loading the CAS object and getting a `jitlink::LinkGraph` from it. `lld` then walks the `LinkGraph` objects.