### PR TITLE
Headers: exclude `#include_next <stdatomic.h>` on MSVC

### DIFF
--- a/clang/lib/Headers/stdatomic.h
+++ b/clang/lib/Headers/stdatomic.h
@@ -12,8 +12,12 @@
 
 /* If we're hosted, fall back to the system's stdatomic.h. FreeBSD, for
  * example, already has a Clang-compatible stdatomic.h header.
+ *
+ * Exclude the MSVC path as well as the MSVC header as of the 14.31.30818
+ * explicitly disallows `stdatomic.h` in the C mode via an `#error`.  Fallback
+ * to the clang resource header until that is fully supported.
  */
-#if __STDC_HOSTED__ && __has_include_next(<stdatomic.h>)
+#if __STDC_HOSTED__ && __has_include_next(<stdatomic.h>) && !defined(_MSC_VER)
 # include_next <stdatomic.h>
 #else
 


### PR DESCRIPTION
The 14.31.30818 toolset has the following in the `stdatomic.h`:
~~~
 #ifndef __cplusplus
 #error <stdatomic.h> is not yet supported when compiling as C, but this is planned for a future release.
 #endif
~~~

This results in clang failing to build existing code which relied on
`stdatomic.h` in C mode on Windows.  Simply fallback to the clang header
until that header is available as a complete implementation.

(cherry picked from commit 1ad7de9e92bc2977698e5f6d6493202b50c912d5)