### PR TITLE
[llvm-cas-object-format] Make FlatV1 schema ingestion deterministic for EH frames

### DIFF
--- a/llvm/test/tools/llvm-cas-object-format/Inputs/main.ll
+++ b/llvm/test/tools/llvm-cas-object-format/Inputs/main.ll
@@ -10,4 +10,4 @@ define i32 @main() #0 {
   ret i32 %1
 }
 
-attributes #0 = { noinline nounwind optnone }
+attributes #0 = { noinline nounwind optnone uwtable }

--- a/llvm/test/tools/llvm-cas-object-format/check-deterministic-flatv1.test
+++ b/llvm/test/tools/llvm-cas-object-format/check-deterministic-flatv1.test
@@ -1,0 +1,5 @@
+RUN: rm -rf %t && mkdir -p %t
+RUN: llc %S/Inputs/main.ll --filetype=obj -o %t/main.o
+
+// Ingest multiple times and check that we got the same CAS ID for all.
+RUN: llvm-cas-object-format --cas %t/cas %t/main.o -silent -ingest-schema=flatv1 -repeat 10


### PR DESCRIPTION
LinkGraph creates an anonymous symbol that covers the full EH frame section
block and no edge points to it. The EH frame splitter may end up creating an
identical symbol (that has an edge pointed to it) which can result in
non-deterministic behavior in `FlatV1` schema ingestion, because the
symbols cannot be ordered in a deterministic manner.

Add a new function `removeRedundantEHFrameSymbol()` which removes this redundant
symbol before we run the EH frame splitter.