### PR TITLE
Revert "Add support for 32-bit reflection contexts."

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -412,7 +412,7 @@ static bool HasReflectionInfo(ObjectFile *obj_file) {
   return hasReflectionSection;
 }
 
-SwiftLanguageRuntimeImpl::ReflectionContextInterface *
+SwiftLanguageRuntimeImpl::NativeReflectionContext *
 SwiftLanguageRuntimeImpl::GetReflectionContext() {
   if (!m_initialized_reflection_ctx)
     SetupReflection();
@@ -438,21 +438,7 @@ void SwiftLanguageRuntimeImpl::SetupReflection() {
   if (m_initialized_reflection_ctx)
     return;
 
-  auto &target = m_process.GetTarget();
-  if (auto exe_module = target.GetExecutableModule()) {
-    auto &triple = exe_module->GetArchitecture().GetTriple();
-    if (triple.isArch64Bit())
-      m_reflection_ctx = ReflectionContextInterface::CreateReflectionContext64(
-          this->GetMemoryReader());
-    else if (triple.isArch32Bit())
-      m_reflection_ctx = ReflectionContextInterface::CreateReflectionContext32(
-          this->GetMemoryReader());
-    else {
-      LLDB_LOGF(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
-                "Could not initialize reflection context for \"%s\"",
-                triple.str().c_str());
-    }
-  }
+  m_reflection_ctx.reset(new NativeReflectionContext(this->GetMemoryReader()));
   m_initialized_reflection_ctx = true;
 
   // Add all defered modules to reflection context that were added to

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -250,142 +250,6 @@ lldb::addr_t SwiftLanguageRuntime::MaybeMaskNonTrivialReferencePointer(
   return addr;
 }
 
-namespace {
-
-/// An implementation of the generic ReflectionContextInterface that
-/// is templatized on target pointer width and specialized to either
-/// 32-bit or 64-bit pointers.
-template <unsigned PointerSize>
-class TargetReflectionContext
-    : public SwiftLanguageRuntimeImpl::ReflectionContextInterface {
-  using ReflectionContext = swift::reflection::ReflectionContext<
-      swift::External<swift::RuntimeTarget<PointerSize>>>;
-  ReflectionContext m_reflection_ctx;
-
-public:
-  TargetReflectionContext(
-      std::shared_ptr<swift::reflection::MemoryReader> reader)
-      : m_reflection_ctx(reader) {}
-
-  bool addImage(
-      llvm::function_ref<std::pair<swift::remote::RemoteRef<void>, uint64_t>(
-          swift::ReflectionSectionKind)>
-          find_section) override {
-    return m_reflection_ctx.addImage(find_section);
-  }
-
-  bool addImage(swift::remote::RemoteAddress image_start) override {
-    return m_reflection_ctx.addImage(image_start);
-  }
-
-  bool readELF(swift::remote::RemoteAddress ImageStart,
-               llvm::Optional<llvm::sys::MemoryBlock> FileBuffer) override {
-    return m_reflection_ctx.readELF(ImageStart, FileBuffer);
-  }
-
-  const swift::reflection::TypeInfo *
-  getTypeInfo(const swift::reflection::TypeRef *type_ref,
-              swift::remote::TypeInfoProvider *provider) override {
-    return m_reflection_ctx.getTypeInfo(type_ref, provider);
-  }
-
-  swift::reflection::MemoryReader &getReader() override {
-    return m_reflection_ctx.getReader();
-  }
-
-  bool ForEachSuperClassType(
-      LLDBTypeInfoProvider *tip, lldb::addr_t pointer,
-      std::function<bool(SwiftLanguageRuntimeImpl::SuperClassType)> fn)
-      override {
-    auto md_ptr = m_reflection_ctx.readMetadataFromInstance(pointer);
-    if (!md_ptr)
-      return false;
-
-    // Class object.
-    LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
-              "found RecordTypeInfo for instance");
-    while (md_ptr && *md_ptr) {
-      // Reading metadata is potentially expensive since (in a remote
-      // debugging scenario it may even incur network traffic) so we
-      // just return closures that the caller can use to query details
-      // if they need them.'
-      auto metadata = *md_ptr;
-      if (fn({[=]() -> const swift::reflection::RecordTypeInfo * {
-                auto *ti = m_reflection_ctx.getMetadataTypeInfo(metadata, tip);
-                return llvm::dyn_cast_or_null<
-                    swift::reflection::RecordTypeInfo>(ti);
-              },
-              [=]() -> const swift::reflection::TypeRef * {
-                return m_reflection_ctx.readTypeFromMetadata(metadata);
-              }}))
-        return true;
-
-      // Continue with the base class.
-      md_ptr = m_reflection_ctx.readSuperClassFromClassMetadata(metadata);
-    }
-    return false;
-  }
-
-  llvm::Optional<std::pair<const swift::reflection::TypeRef *,
-                           swift::reflection::RemoteAddress>>
-  projectExistentialAndUnwrapClass(
-      swift::reflection::RemoteAddress existential_address,
-      const swift::reflection::TypeRef &existential_tr) override {
-    return m_reflection_ctx.projectExistentialAndUnwrapClass(
-        existential_address, existential_tr);
-  }
-
-  const swift::reflection::TypeRef *
-  readTypeFromMetadata(lldb::addr_t metadata_address,
-                       bool skip_artificial_subclasses) override {
-    return m_reflection_ctx.readTypeFromMetadata(metadata_address,
-                                                 skip_artificial_subclasses);
-  }
-
-  const swift::reflection::TypeRef *
-  readTypeFromInstance(lldb::addr_t instance_address,
-                       bool skip_artificial_subclasses) override {
-    auto metadata_address =
-        m_reflection_ctx.readMetadataFromInstance(instance_address);
-    if (!metadata_address) {
-      LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
-                "could not read heap metadata for object at %llu\n",
-                instance_address);
-      return nullptr;
-    }
-
-    return m_reflection_ctx.readTypeFromMetadata(*metadata_address,
-                                                 skip_artificial_subclasses);
-  }
-
-  swift::reflection::TypeRefBuilder &getBuilder() override {
-    return m_reflection_ctx.getBuilder();
-  }
-
-  llvm::Optional<bool> isValueInlinedInExistentialContainer(
-      swift::remote::RemoteAddress existential_address) override {
-    return m_reflection_ctx.isValueInlinedInExistentialContainer(
-        existential_address);
-  }
-};
-
-} // namespace
-
-std::unique_ptr<SwiftLanguageRuntimeImpl::ReflectionContextInterface>
-SwiftLanguageRuntimeImpl::ReflectionContextInterface::CreateReflectionContext32(
-    std::shared_ptr<swift::remote::MemoryReader> reader) {
-  return std::make_unique<TargetReflectionContext<4>>(reader);
-}
-
-std::unique_ptr<SwiftLanguageRuntimeImpl::ReflectionContextInterface>
-SwiftLanguageRuntimeImpl::ReflectionContextInterface::CreateReflectionContext64(
-    std::shared_ptr<swift::remote::MemoryReader> reader) {
-  return std::make_unique<TargetReflectionContext<8>>(reader);
-}
-
-SwiftLanguageRuntimeImpl::ReflectionContextInterface::
-    ~ReflectionContextInterface() {}
-
 const CompilerType &SwiftLanguageRuntimeImpl::GetBoxMetadataType() {
   if (m_box_metadata_type.IsValid())
     return m_box_metadata_type;
@@ -770,8 +634,6 @@ public:
   }
 };
 
-} // namespace
-
 class LLDBTypeInfoProvider : public swift::remote::TypeInfoProvider {
   SwiftLanguageRuntimeImpl &m_runtime;
   TypeSystemSwift &m_typesystem;
@@ -850,8 +712,7 @@ public:
         if (is_bitfield_ptr) {
           Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
           if (log)
-            log->Printf("[LLDBTypeInfoProvider] bitfield support is not yet "
-                        "implemented");
+            log->Printf("[LLDBTypeInfoProvider] bitfield support is not yet implemented");
           continue;
         }
         swift::reflection::FieldInfo field_info = {
@@ -863,6 +724,8 @@ public:
     return m_runtime.emplaceClangTypeInfo(clang_type, size, bit_align, fields);
   }
 };
+
+} // namespace
 
 llvm::Optional<const swift::reflection::TypeInfo *>
 SwiftLanguageRuntimeImpl::lookupClangTypeInfo(CompilerType clang_type) {
@@ -1711,9 +1574,35 @@ bool SwiftLanguageRuntimeImpl::ForEachSuperClassType(
   if (!ts)
     return false;
 
-  LLDBTypeInfoProvider tip(*this, *ts);
   lldb::addr_t pointer = instance.GetPointerValue();
-  return reflection_ctx->ForEachSuperClassType(&tip, pointer, fn);
+  auto md_ptr = reflection_ctx->readMetadataFromInstance(pointer);
+  if (!md_ptr)
+    return false;
+
+  // Class object.
+  LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
+            "found RecordTypeInfo for instance");
+  while (md_ptr && *md_ptr) {
+    // Reading metadata is potentially expensive since (in a remote
+    // debugging scenario it may even incur network traffic) so we
+    // just return closures that the caller can use to query details
+    // if they need them.
+    auto metadata = *md_ptr;
+    if (fn({[=]() -> const swift::reflection::RecordTypeInfo * {
+              LLDBTypeInfoProvider tip(*this, *ts);
+              auto *ti = reflection_ctx->getMetadataTypeInfo(metadata, &tip);
+              return llvm::dyn_cast_or_null<swift::reflection::RecordTypeInfo>(
+                  ti);
+            },
+            [=]() -> const swift::reflection::TypeRef * {
+              return reflection_ctx->readTypeFromMetadata(metadata);
+            }}))
+      return true;
+
+    // Continue with the base class.
+    md_ptr = reflection_ctx->readSuperClassFromClassMetadata(metadata);
+  }
+  return false;
 }
 
 bool SwiftLanguageRuntime::IsSelf(Variable &variable) {
@@ -1784,8 +1673,8 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Class(
     lldb::DynamicValueType use_dynamic, TypeAndOrName &class_type_or_name,
     Address &address) {
   AddressType address_type;
-  lldb::addr_t instance_ptr = in_value.GetPointerValue(&address_type);
-  if (instance_ptr == LLDB_INVALID_ADDRESS || instance_ptr == 0)
+  lldb::addr_t class_metadata_ptr = in_value.GetPointerValue(&address_type);
+  if (class_metadata_ptr == LLDB_INVALID_ADDRESS || class_metadata_ptr == 0)
     return false;
 
   CompilerType static_type = in_value.GetCompilerType();
@@ -1793,7 +1682,7 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Class(
       llvm::dyn_cast_or_null<TypeSystemSwift>(static_type.GetTypeSystem());
   if (!tss)
     return false;
-  address.SetRawAddress(instance_ptr);
+  address.SetRawAddress(class_metadata_ptr);
   auto &ts = tss->GetTypeSystemSwiftTypeRef();
   // Ask the Objective-C runtime about Objective-C types.
   if (tss->IsImportedType(static_type.GetOpaqueQualType(), nullptr))
@@ -1823,7 +1712,19 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Class(
     }
   Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
   auto *reflection_ctx = GetReflectionContext();
-  const auto *typeref = reflection_ctx->readTypeFromInstance(instance_ptr);
+  swift::remote::RemoteAddress instance_address(class_metadata_ptr);
+  auto metadata_address =
+      reflection_ctx->readMetadataFromInstance(class_metadata_ptr);
+  if (!metadata_address) {
+    if (log)
+      log->Printf("could not read heap metadata for object at %llu\n",
+                  class_metadata_ptr);
+    return false;
+  }
+
+  const auto *typeref =
+      reflection_ctx->readTypeFromMetadata(*metadata_address,
+                                           /*skipArtificial=*/false);
   if (!typeref)
     return false;
   swift::Demangle::Demangler dem;
@@ -1832,8 +1733,8 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Class(
 
 #ifndef NDEBUG
   auto &remote_ast = GetRemoteASTContext(scratch_ctx);
-  auto remote_ast_metadata_address = remote_ast.getHeapMetadataForObject(
-      swift::remote::RemoteAddress(instance_ptr));
+  auto remote_ast_metadata_address =
+      remote_ast.getHeapMetadataForObject(instance_address);
   if (remote_ast_metadata_address) {
     auto instance_type = remote_ast.getTypeForRemoteTypeMetadata(
         remote_ast_metadata_address.getValue(),
@@ -1847,8 +1748,9 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Class(
                      << "\n";
     } else {
       if (log) {
-        log->Printf("could not get type metadata: %s\n",
-                    instance_type.getFailure().render().c_str());
+        log->Printf(
+            "could not get type metadata from address %" PRIu64 " : %s\n",
+            *metadata_address, instance_type.getFailure().render().c_str());
       }
     }
   }

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -15,7 +15,6 @@
 
 #include "SwiftLanguageRuntime.h"
 #include "swift/Reflection/TypeLowering.h"
-#include "llvm/Support/Memory.h"
 
 namespace swift {
 namespace reflection {
@@ -25,7 +24,6 @@ class TypeRef;
 
 namespace lldb_private {
 class Process;
-class LLDBTypeInfoProvider;
 
 /// A full LLDB language runtime backed by the Swift runtime library
 /// in the process.
@@ -179,6 +177,15 @@ public:
 
   bool IsABIStable();
 
+protected:
+  using NativeReflectionContext = swift::reflection::ReflectionContext<
+      swift::External<swift::RuntimeTarget<sizeof(uintptr_t)>>>;
+
+  /// Use the reflection context to build a TypeRef object.
+  const swift::reflection::TypeRef *
+  GetTypeRef(CompilerType type, TypeSystemSwiftTypeRef *module_holder,
+             SwiftASTContext *swift_ast_context);
+
   /// Returned by \ref ForEachSuperClassType. Not every user of \p
   /// ForEachSuperClassType needs all of these. By returning this
   /// object we call into the runtime only when needed.
@@ -187,62 +194,6 @@ public:
     std::function<const swift::reflection::RecordTypeInfo *()> get_record_type_info;
     std::function<const swift::reflection::TypeRef *()> get_typeref;
   };
-
-  /// An abstract interface to swift::reflection::ReflectionContext
-  /// objects of varying pointer sizes.  This class encapsulates all
-  /// traffic to ReflectionContext and abstracts the detail that
-  /// ReflectionContext is a template that needs to be specialized for
-  /// a specific pointer width.
-  class ReflectionContextInterface {
-  public:
-    /// Return a 32-bit reflection context.
-    static std::unique_ptr<ReflectionContextInterface>
-    CreateReflectionContext32(
-        std::shared_ptr<swift::remote::MemoryReader> reader);
-
-    /// Return a 64-bit reflection context.
-    static std::unique_ptr<ReflectionContextInterface>
-    CreateReflectionContext64(
-        std::shared_ptr<swift::remote::MemoryReader> reader);
-
-    virtual ~ReflectionContextInterface();
-
-    virtual bool addImage(
-        llvm::function_ref<std::pair<swift::remote::RemoteRef<void>, uint64_t>(
-            swift::ReflectionSectionKind)>
-            find_section);
-    virtual bool addImage(swift::remote::RemoteAddress image_start) = 0;
-    virtual bool readELF(swift::remote::RemoteAddress ImageStart,
-                         llvm::Optional<llvm::sys::MemoryBlock> FileBuffer) = 0;
-    virtual const swift::reflection::TypeInfo *
-    getTypeInfo(const swift::reflection::TypeRef *type_ref,
-                swift::remote::TypeInfoProvider *provider) = 0;
-    virtual swift::remote::MemoryReader &getReader() = 0;
-    virtual bool
-    ForEachSuperClassType(LLDBTypeInfoProvider *tip, lldb::addr_t pointer,
-                          std::function<bool(SuperClassType)> fn) = 0;
-    virtual llvm::Optional<std::pair<const swift::reflection::TypeRef *,
-                                     swift::remote::RemoteAddress>>
-    projectExistentialAndUnwrapClass(
-        swift::remote::RemoteAddress existential_addess,
-        const swift::reflection::TypeRef &existential_tr) = 0;
-    virtual const swift::reflection::TypeRef *
-    readTypeFromMetadata(lldb::addr_t metadata_address,
-                         bool skip_artificial_subclasses = false) = 0;
-    virtual const swift::reflection::TypeRef *
-    readTypeFromInstance(lldb::addr_t instance_address,
-                         bool skip_artificial_subclasses = false) = 0;
-    virtual swift::reflection::TypeRefBuilder &getBuilder() = 0;
-    virtual llvm::Optional<bool> isValueInlinedInExistentialContainer(
-        swift::remote::RemoteAddress existential_address) = 0;
-  };
-
-protected:
-  /// Use the reflection context to build a TypeRef object.
-  const swift::reflection::TypeRef *
-  GetTypeRef(CompilerType type, TypeSystemSwiftTypeRef *module_holder,
-             SwiftASTContext *swift_ast_context);
-
   /// If \p instance points to a Swift object, retrieve its
   /// RecordTypeInfo and pass it to the callback \p fn. Repeat the
   /// process with all superclasses. If \p fn returns \p true, early
@@ -350,7 +301,7 @@ private:
   llvm::Optional<lldb::addr_t> GetDynamicExclusivityFlagAddr();
 
   /// Lazily initialize the reflection context. Return \p nullptr on failure.
-  ReflectionContextInterface *GetReflectionContext();
+  NativeReflectionContext *GetReflectionContext();
 
   /// Lazily initialize and return \p m_SwiftNativeNSErrorISA.
   llvm::Optional<lldb::addr_t> GetSwiftNativeNSErrorISA();
@@ -370,7 +321,7 @@ private:
 
   /// Reflection context.
   /// \{
-  std::unique_ptr<ReflectionContextInterface> m_reflection_ctx;
+  std::unique_ptr<NativeReflectionContext> m_reflection_ctx;
 
   /// Record modules added through ModulesDidLoad, which are to be
   /// added to the reflection context once it's being initialized.


### PR DESCRIPTION
Reverts apple/llvm-project#3590

This regressed the Windows builds: https://ci-external.swift.org/job/oss-swift-windows-x86_64-vs2019/7267/consoleText