### PR TITLE
Plugins: repair the Windows build

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -210,7 +210,7 @@ public:
     virtual bool addImage(
         llvm::function_ref<std::pair<swift::remote::RemoteRef<void>, uint64_t>(
             swift::ReflectionSectionKind)>
-            find_section);
+            find_section) = 0;
     virtual bool addImage(swift::remote::RemoteAddress image_start) = 0;
     virtual bool readELF(swift::remote::RemoteAddress ImageStart,
                          llvm::Optional<llvm::sys::MemoryBlock> FileBuffer) = 0;


### PR DESCRIPTION
The change in #3590 introduced an undefined pure virtual method but did
not mark it as a pure virtual method, resulting in an undefined exported
function.  The Windows build identified this issue.

Patch by Adrian Prantl!

# **DO NOT FILE A PULL REQUEST**

We are in the process of a github migration.  Please do not create a pull request as this could interfere with the process.
