### PR TITLE
Simplify logic to identify dyld_sim in Simulator debugging on macos

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -540,35 +540,18 @@ void DynamicLoaderDarwin::UpdateSpecialBinariesFromNewImageInfos(
   const size_t image_infos_size = image_infos.size();
   for (size_t i = 0; i < image_infos_size; i++) {
     if (image_infos[i].header.filetype == llvm::MachO::MH_DYLINKER) {
-      // In a "simulator" process (an x86 process that is 
-      // ios/tvos/watchos/bridgeos) we will have two dyld modules -- 
+      // In a "simulator" process we will have two dyld modules -- 
       // a "dyld" that we want to keep track of, and a "dyld_sim" which 
-      // we don't need to keep track of here. If the target is an x86 
-      // system and the OS of the dyld binary is ios/tvos/watchos/bridgeos, 
-      // then we are looking at dyld_sym.
+      // we don't need to keep track of here.  dyld_sim will have a non-macosx
+      // OS.
+      if (target_arch.GetTriple().getEnvironment() == llvm::Triple::Simulator &&
+          image_infos[i].os_type != llvm::Triple::OSType::MacOSX) {
+        continue;
+      }
 
-      // debugserver has only recently (late 2016) started sending up the os
-      // type for each binary it sees -- so if we don't have an os type, use a
-      // filename check as our next best guess.
-      if (image_infos[i].os_type == llvm::Triple::OSType::UnknownOS) {
-        if (image_infos[i].file_spec.GetFilename() != g_dyld_sim_filename) {
-          dyld_idx = i;
-        }
-      } else if (target_arch.GetTriple().getArch() == llvm::Triple::x86 ||
-                 target_arch.GetTriple().getArch() == llvm::Triple::x86_64) {
-        if (image_infos[i].os_type != llvm::Triple::OSType::IOS &&
-            image_infos[i].os_type != llvm::Triple::TvOS &&
-            image_infos[i].os_type != llvm::Triple::WatchOS) {
-            // NEED_BRIDGEOS_TRIPLE image_infos[i].os_type != llvm::Triple::BridgeOS) {
-          dyld_idx = i;
-        }
-      }
-      else {
-        // catch-all for any other environment -- trust that dyld is actually
-        // dyld
-        dyld_idx = i;
-      }
-    } else if (image_infos[i].header.filetype == llvm::MachO::MH_EXECUTE) {
+      dyld_idx = i;
+    } 
+    if (image_infos[i].header.filetype == llvm::MachO::MH_EXECUTE) {
       exe_idx = i;
     }
   }


### PR DESCRIPTION
When debugging a Simulator process on macOS (e.g. the iPhone simulator),
the process will have both a dyld, and a dyld_sim present.  The dyld_sim
is an iOS Simulator binary.  The dyld is a macOS binary.  Both are
MH_DYLINKER filetypes.  lldb needs to identify & set a breakpoint in
dyld, so it has to distinguish between these two.

Previously lldb was checking if the inferior target was x86 (indicating
macOS) and the OS of the MH_DYLINKER binary was iOS/watchOS/etc -- if
so, then this is dyld_sim and we should ignore it.  Now with arm64
macOS systems, this check was invalid, and we would set our breakpoint
for new binaries being loaded in dyld_sim, causing binary loading to
be missed by lldb.

This patch uses the Target's ArchSpec triple environment, to see if
this process is a simulator process.  If this is a Simulator process,
then we only recognize a MH_DYLINKER binary with OS type macOS as
being dyld.

This patch also removes some code that handled pre-2016 era debugservers
which didn't give us the OS type for each binary.  This was only being
used on macOS, where we don't need to handle the presence of very old
debugservers.

Differential Revision: https://reviews.llvm.org/D115001
rdar://85907839

(cherry picked from commit fddafa110d8628851a48939fe956864b318e8e53)

# **DO NOT FILE A PULL REQUEST**

We are in the process of a github migration.  Please do not create a pull request as this could interfere with the process.
