### PR TITLE
[lldb] Remove trivial scoped timer from collectTypeInfo

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -977,7 +977,6 @@ static uint32_t collectTypeInfo(TypeSystemSwiftTypeRef *module_holder,
                                 swift::Demangle::NodePointer node,
                                 bool &unresolved_typealias,
                                 bool generic_walk = false) {
-  LLDB_SCOPED_TIMER();
   if (!node)
     return 0;
   uint32_t swift_flags = eTypeIsSwift;


### PR DESCRIPTION
A recent profile shows this function as being fast (trivial) and high firing, and doesn't benefit from timer.

\# calls: 32,921
avg time: 6.57µs
total time: 216.26ms
