### PR TITLE
[lldb] Configure CMake policy CMP0116 for standalone builds

### DIFF
--- a/lldb/cmake/modules/LLDBStandalone.cmake
+++ b/lldb/cmake/modules/LLDBStandalone.cmake
@@ -1,3 +1,9 @@
+# CMP0116: Ninja generators transform `DEPFILE`s from `add_custom_command()`
+# New in CMake 3.20. https://cmake.org/cmake/help/latest/policy/CMP0116.html
+if(POLICY CMP0116)
+  cmake_policy(SET CMP0116 OLD)
+endif()
+
 option(LLVM_INSTALL_TOOLCHAIN_ONLY "Only include toolchain files in the 'install' target." OFF)
 
 find_package(LLVM REQUIRED CONFIG HINTS ${LLVM_DIR} NO_CMAKE_FIND_ROOT_PATH)


### PR DESCRIPTION
Using CMake >=3.20 results in many warnings about this new policy. This change silences the warnings by explicitly declaring use of the "OLD" behavior.

This applies D101083 to LLDBStandalone.cmake.

Differential Revision: https://reviews.llvm.org/D112497

(cherry picked from commit 65dae8b2f20c32632e48922456a305504f4e6fbe)