### PR TITLE
Initialize the Swift CompilerInstance with the triple from the load commands.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -914,8 +914,7 @@ SwiftASTContext::SwiftASTContext() {
 }
 #endif
 
-SwiftASTContext::SwiftASTContext(std::string description, llvm::Triple triple,
-                                 Target *target)
+SwiftASTContext::SwiftASTContext(std::string description, Target *target)
     : TypeSystemSwift(),
       m_compiler_invocation_ap(new swift::CompilerInvocation()) {
   m_description = description;
@@ -935,7 +934,6 @@ SwiftASTContext::SwiftASTContext(std::string description, llvm::Triple triple,
   if (target)
     m_target_wp = target->shared_from_this();
 
-  SetTriple(triple);
   swift::IRGenOptions &ir_gen_opts =
       m_compiler_invocation_ap->getIRGenOptions();
   ir_gen_opts.OutputKind = swift::IRGenOutputKind::Module;
@@ -1715,9 +1713,7 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
       fallback ? static_cast<SwiftASTContext *>(
                      new SwiftASTContextForExpressions(m_description, *target))
                : static_cast<SwiftASTContext *>(new SwiftASTContextForModule(
-                     *typeref_typesystem, m_description,
-                     target ? target->GetArchitecture().GetTriple() : triple,
-                     target)));
+                     *typeref_typesystem, m_description, target)));
   bool suppress_config_log = false;
   auto defer_log = llvm::make_scope_exit([swift_ast_sp, &suppress_config_log] {
     // To avoid spamming the log with useless info, we don't log the
@@ -1734,12 +1730,8 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
   swift_ast_sp->GetLanguageOptions().EnableAccessControl = false;
   swift_ast_sp->GetLanguageOptions().EnableTargetOSChecking = false;
 
-  swift_ast_sp->SetTriple(triple, &module);
-
-  bool set_triple = false;
   bool found_swift_modules = false;
   SymbolFile *sym_file = module.GetSymbolFile();
-  std::string target_triple;
 
   if (sym_file) {
     bool got_serialized_options = false;
@@ -1752,17 +1744,11 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
       swift_ast_sp->m_module_import_warnings.push_back(std::string(error));
     }
 
-    // Some of the bits in the compiler options we keep separately, so
-    // we need to populate them from the serialized options:
     llvm::StringRef serialized_triple =
         swift_ast_sp->GetCompilerInvocation().getTargetTriple();
-    if (serialized_triple.empty()) {
-      LOG_PRINTF(LIBLLDB_LOG_TYPES, "Serialized triple was empty.");
-    } else {
-      LOG_PRINTF(LIBLLDB_LOG_TYPES, "Found serialized triple %s.",
+    if (!serialized_triple.empty()) {
+      LOG_PRINTF(LIBLLDB_LOG_TYPES, "Serialized/default triple would have been %s.",
                  serialized_triple.str().c_str());
-      swift_ast_sp->SetTriple(llvm::Triple(serialized_triple), &module);
-      set_triple = true;
     }
 
     // SDK path setup.
@@ -1802,24 +1788,12 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
     }
   }
 
-  if (!set_triple) {
-    llvm::Triple llvm_triple = swift_ast_sp->GetTriple();
+  // The serialized triple is the triple of the last binary
+  // __swiftast section that was processed. Instead of relying on
+  // the section contents order, we overwrite the triple in the
+  // CompilerInvocation with the triple recovered from the binary.
+  swift_ast_sp->SetTriple(triple, &module);
 
-    // LLVM wants this to be set to iOS or MacOSX; if we're working on
-    // a bare-boards type image, change the triple for LLVM's benefit.
-    if (llvm_triple.getVendor() == llvm::Triple::Apple &&
-        llvm_triple.getOS() == llvm::Triple::UnknownOS) {
-      if (llvm_triple.getArch() == llvm::Triple::arm ||
-          llvm_triple.getArch() == llvm::Triple::thumb) {
-        llvm_triple.setOS(llvm::Triple::IOS);
-      } else {
-        llvm_triple.setOS(llvm::Triple::MacOSX);
-      }
-      swift_ast_sp->SetTriple(llvm_triple, &module);
-    }
-  }
-
-  triple = swift_ast_sp->GetTriple();
   std::string resource_dir = swift_ast_sp->GetResourceDir(triple);
   ConfigureResourceDirs(swift_ast_sp->GetCompilerInvocation(),
                         FileSpec(resource_dir), triple);
@@ -8287,8 +8261,7 @@ SwiftASTContext::GetASTVectorForModule(const Module *module) {
 
 SwiftASTContextForExpressions::SwiftASTContextForExpressions(
     std::string description, Target &target)
-    : SwiftASTContext(std::move(description),
-                      target.GetArchitecture().GetTriple(), &target),
+    : SwiftASTContext(std::move(description), &target),
       m_typeref_typesystem(*this),
       m_persistent_state_up(new SwiftPersistentExpressionState) {}
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -164,8 +164,8 @@ public:
 
 protected:
   // Constructors and destructors
-  SwiftASTContext(std::string description, llvm::Triple triple,
-                  Target *target = nullptr);
+  SwiftASTContext(std::string description, Target *target = nullptr);
+
 public:
 
   SwiftASTContext(const SwiftASTContext &rhs) = delete;
@@ -946,9 +946,8 @@ public:
   /// \}
 
   SwiftASTContextForModule(TypeSystemSwiftTypeRef &typeref_typesystem,
-                           std::string description, llvm::Triple triple,
-                           Target *target)
-      : SwiftASTContext(description, triple, target),
+                           std::string description, Target *target)
+      : SwiftASTContext(description, target),
         m_typeref_typesystem(typeref_typesystem) {}
   virtual ~SwiftASTContextForModule() {}
 

--- a/lldb/test/API/lang/swift/deployment_target/Makefile
+++ b/lldb/test/API/lang/swift/deployment_target/Makefile
@@ -10,6 +10,7 @@ include Makefile.rules
 
 a.out: main.swift libNewerTarget.dylib
 
+
 dlopen_module: dlopen_module.m libNewerTarget.dylib
 	$(MAKE) -f $(MAKEFILE_RULES) \
 		CXX= \

--- a/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -17,6 +17,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 import unittest2
+import os
 
 
 class TestSwiftDeploymentTarget(TestBase):
@@ -32,7 +33,6 @@ class TestSwiftDeploymentTarget(TestBase):
     @swiftTest
     def test_swift_deployment_target(self):
         self.build()
-
         lldbutil.run_to_source_breakpoint(self,
                                           "break here",
                                           lldb.SBFileSpec('main.swift'))
@@ -53,3 +53,27 @@ class TestSwiftDeploymentTarget(TestBase):
         lldbutil.continue_to_breakpoint(process, bkpt)
         self.expect("p self", substrs=['i = 23'])
 
+    @skipUnlessDarwin
+    @skipIfDarwinEmbedded # This test uses macOS triples explicitly.
+    @skipIf(macos_version=["<", "10.11"])
+    @swiftTest
+    def test_swift_deployment_target_from_macho(self):
+        self.build(dictionary={"MAKE_DSYM": "NO"})
+        os.unlink(self.getBuildArtifact("a.swiftmodule"))
+        log = self.getBuildArtifact("types.log")
+        self.runCmd('log enable lldb types -f "%s"' % log)
+        lldbutil.run_to_source_breakpoint(self,
+                                          "break here",
+                                          lldb.SBFileSpec('main.swift'))
+        self.expect("p f", substrs=['i = 23'])
+
+        found_no_ast = False
+        found_triple = False
+        logfile = open(log, "r")
+        for line in logfile:
+            if 'SwiftASTContextForModule("a.out")::DeserializeAllCompilerFlags() -- Found 0 AST file data entries.' in line:
+                found_no_ast = True
+            if 'SwiftASTContextForModule("a.out")::SetTriple("x86_64-apple-macosx10.10.0")' in line:
+                found_triple = True
+        self.assertTrue(found_no_ast)
+        self.assertTrue(found_triple)


### PR DESCRIPTION
The serialized triple is the triple of the last binary __swiftast
section that was processed. Instead of relying on the section contents
order, we overwrite the triple in the CompilerInvocation with the
triple recovered from the binary.

This should fix issues such as thew one reported in https://forums.swift.org/t/lldb-not-honoring-minimum-platform-version-for-spm-packages/53607