### PR TITLE
clang -fdepscan: Move create_directories() call to daemon

### DIFF
--- a/clang/lib/Driver/CC1DepScanDProtocol.cpp
+++ b/clang/lib/Driver/CC1DepScanDProtocol.cpp
@@ -83,12 +83,7 @@ std::string cc1depscand::getBasePath(StringRef DaemonKey) {
   // Construct the path.
   SmallString<128> BasePath;
   llvm::sys::path::system_temp_directory(/*ErasedOnReboot=*/true, BasePath);
-  llvm::sys::path::append(BasePath, "llvm.depscan.daemon");
-
-  // Ignore the error here; let something else report an error lator.
-  (void)llvm::sys::fs::create_directories(BasePath);
-
-  llvm::sys::path::append(BasePath, DaemonKey);
+  llvm::sys::path::append(BasePath, "llvm.depscan.daemon", DaemonKey);
 
   // Ensure null-termination.
   return BasePath.str().str();

--- a/clang/tools/driver/cc1depscand_main.cpp
+++ b/clang/tools/driver/cc1depscand_main.cpp
@@ -365,6 +365,12 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
   (BasePath + ".out").toVector(LogOutPath);
   (BasePath + ".err").toVector(LogErrPath);
 
+  // Create the base directory if necessary.
+  StringRef BaseDir = llvm::sys::path::parent_path(BasePath);
+  if (std::error_code EC = llvm::sys::fs::create_directories(BaseDir))
+    llvm::report_fatal_error("clang -cc1depscand: cannot create basedir: " +
+                             EC.message());
+
   auto openAndReplaceFD = [&](int ReplacedFD, StringRef Path) {
     int FD;
     if (std::error_code EC = llvm::sys::fs::openFile(


### PR DESCRIPTION
Move a `create_directories()` call from the driver to the to daemon.
This call got added as part of the `-fdepscan-share` changes that fixed
the soundness of daemonization.

This speeds up (clean but cached) `ninja clang` from 15.3 seconds:
```
% time ninja clang
[3386/3386] Creating executable symlink bin/clang
ninja clang  62.82s user 86.85s system 977% cpu 15.312 total
```
to 14.6 seconds:
```
% time ninja clang
[3386/3386] Creating executable symlink bin/clang
ninja clang  62.45s user 92.73s system 1067% cpu 14.531 total
```
on my machine (config `-DCMAKE_BUILD_TYPE=Release`).

Unfortunately, there's still a major regression. IIRC, this used to take
~5s (I think `ninja test-depends` was around ~10s).

Note that those old numbers were with `-DLLVM_TARGETS_TO_BUILD=X86`.
Trying that now, I'm seeing ~10.5s:
```
[2386/2386] Creating executable symlink bin/clang
ninja clang  41.98s user 67.63s system 1020% cpu 10.744 total
```
and ~17s for `test-depends`. It's possible my memory is off by a factor
of two, but I think there might still be something to investigate.

I wondered if the same commit was at fault -- that the system calls to
introspect the process chain are too expensive. I tried using
`-fdepscan-share-parent` (without an argument) and removing
`-fdepscan-share-stop` -- this should avoid looking up process names and
blindly share on `ppid()` as before -- but perf didn't improve, so maybe
that's not it. In either case, we shouldn't revert the soundness fix.
Ultimately we should switch to using a single shared daemon per
absolute-path-to-clang that multiplexes between different
`CachingOnDiskFileSystem`s. This is a bit complicated, since the daemon
needs to get out of the way if a new `clang` binary is built. I think we
can handle this by: (a) using a pid file per absolute-path-to-clang and
a separate communication channel that is named by pid; (b) assume clang
has not changed if there's a pre-existing CachingOnDiskFileSystem to
reuse/share; (b) if we need a new FS (because it's a new build), check
if the `clang` binary is the same as the daemon; (c) if it is different,
start initiating shutdown (allowing running jobs to complete but not
accepting new connections) and reject the connection to allow the client
to launch a new daemon.