### PR TITLE
Enable `lld` to cache its linker work

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -276,9 +276,18 @@ Some other use flags to use:
 % ld64.lld -arch x86_64 -platform_version macos 12 12 --fcas-builtin-path "$TMPDIR/casfs.default" --fcas-fs @casid /path/to/dir/main.o -o a.out
 ```
 
+### Caching linker invocations
+
+`ld64.lld` can connect to the builtin CAS and cache its linker work:
+```
+% ld64.lld -arch x86_64 -platform_version macos 12 12 --fcas-builtin-path "$TMPDIR/casfs.default" --fcas-cache-results t.o -o a.out --verbose
+```
+With `--verbose` (or `LLD_VERBOSE=1` as environment variable) it will output to `stderr`
+to indicate whether there was a cache 'hit' or 'miss'.
+
 ### Linking CAS.o
 
-`ld64.lld` can connect to the builtin CAS and read & link `CAS.o` objects:
+`ld64.lld` can read & link `CAS.o` objects:
 
 ```
 % llvm-cas-object-format --cas "$TMPDIR/casfs.default" t1.o t2.o -silent > casid

--- a/DEMO.md
+++ b/DEMO.md
@@ -273,5 +273,5 @@ Some other use flags to use:
 
 ```
 % llvm-cas-object-format --cas "$TMPDIR/casfs.default" t1.o t2.o -silent > casid
-% ld64.lld -cas_path "$TMPDIR/casfs.default" @casid -o a.out
+% ld64.lld --fcas-builtin-path "$TMPDIR/casfs.default" @casid -o a.out
 ```

--- a/DEMO.md
+++ b/DEMO.md
@@ -267,11 +267,20 @@ Some other use flags to use:
 * `--debug`, `--debug-ingest`, `--dump`: Useful debug options (some only work
   with assertion build)
 
-## lld: Linking CAS.o
+## lld/machO
 
-`lld` can connect to the builtin CAS and read & link `CAS.o` objects:
+### Using a CAS filesystem
+
+```
+% llvm-cas -cas "$TMPDIR/casfs.default" --merge /path/to/dir > casid
+% ld64.lld -arch x86_64 -platform_version macos 12 12 --fcas-builtin-path "$TMPDIR/casfs.default" --fcas-fs @casid /path/to/dir/main.o -o a.out
+```
+
+### Linking CAS.o
+
+`ld64.lld` can connect to the builtin CAS and read & link `CAS.o` objects:
 
 ```
 % llvm-cas-object-format --cas "$TMPDIR/casfs.default" t1.o t2.o -silent > casid
-% ld64.lld --fcas-builtin-path "$TMPDIR/casfs.default" @casid -o a.out
+% ld64.lld -arch x86_64 -platform_version macos 12 12 --fcas-builtin-path "$TMPDIR/casfs.default" @casid -o a.out
 ```

--- a/clang/include/clang/Basic/CASOptions.h
+++ b/clang/include/clang/Basic/CASOptions.h
@@ -43,6 +43,10 @@ public:
   /// Transparently enable pre-tokenized files with -fcas.
   bool CASTokenCache = false;
 
+  /// When using -fcas-fs-result-cache, write a CASID for the output file.
+  /// FIXME: Add clang tests for this functionality.
+  bool WriteOutputAsCASID = false;
+
   /// For \a BuiltinCAS, a path on-disk for a persistent backing store. This is
   /// optional, although \a CASFileSystemRootID is unlikely to work.
   std::string BuiltinPath;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5972,6 +5972,11 @@ defm fcas_token_cache : BoolFOption<"cas-token-cache",
     PosFlag<SetTrue, [], "When reading from a CAS, cache tokens.">,
     NegFlag<SetFalse>>;
 
+defm fcasid_output : BoolFOption<"casid-output",
+    CASOpts<"WriteOutputAsCASID">, DefaultFalse,
+    PosFlag<SetTrue, [], "When using -fcas-fs-result-cache, write a CASID for the output file.">,
+    NegFlag<SetFalse>>;
+
 } // let Flags = [CC1Option, NoDriverOption]
 
 def sycl_std_EQ : Joined<["-"], "sycl-std=">, Group<sycl_Group>,

--- a/lld/MachO/CMakeLists.txt
+++ b/lld/MachO/CMakeLists.txt
@@ -15,6 +15,7 @@ add_lld_library(lldMachO
   DriverUtils.cpp
   Dwarf.cpp
   ExportTrie.cpp
+  FileSystem.cpp
   ICF.cpp
   InputFiles.cpp
   InputSection.cpp

--- a/lld/MachO/Config.h
+++ b/lld/MachO/Config.h
@@ -181,6 +181,7 @@ struct Configuration {
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs;
   std::unique_ptr<llvm::cas::CASDB> CAS;
   std::unique_ptr<llvm::casobjectformats::SchemaPool> CASSchemas;
+  bool depScanning = false;
 
   llvm::DenseMap<llvm::StringRef, SymbolPriorityEntry> priorities;
   SectionRenameMap sectionRenameMap;

--- a/lld/MachO/Config.h
+++ b/lld/MachO/Config.h
@@ -12,6 +12,7 @@
 #include "llvm/ADT/CachedHashString.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/BinaryFormat/MachO.h"
@@ -30,6 +31,9 @@ class CASDB;
 }
 namespace casobjectformats {
 class SchemaPool;
+}
+namespace vfs {
+class FileSystem;
 }
 } // namespace llvm
 
@@ -174,6 +178,7 @@ struct Configuration {
   std::vector<SectionAlign> sectionAlignments;
   std::vector<SegmentProtection> segmentProtections;
 
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs;
   std::unique_ptr<llvm::cas::CASDB> CAS;
   std::unique_ptr<llvm::casobjectformats::SchemaPool> CASSchemas;
 

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -8,6 +8,7 @@
 
 #include "Driver.h"
 #include "Config.h"
+#include "FileSystem.h"
 #include "ICF.h"
 #include "InputFiles.h"
 #include "LTO.h"
@@ -25,6 +26,7 @@
 #include "lld/Common/Args.h"
 #include "lld/Common/Driver.h"
 #include "lld/Common/ErrorHandler.h"
+#include "lld/Common/Filesystem.h"
 #include "lld/Common/LLVM.h"
 #include "lld/Common/Memory.h"
 #include "lld/Common/Reproduce.h"
@@ -42,7 +44,6 @@
 #include "llvm/Object/Archive.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Parallel.h"
@@ -50,6 +51,7 @@
 #include "llvm/Support/TarWriter.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/TimeProfiler.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/TextAPI/PackedVersion.h"
 
 #include <algorithm>
@@ -109,10 +111,10 @@ static Optional<std::string> findFramework(StringRef name) {
       // NOTE: we must resolve the symlink before trying the suffixes, because
       // there are no symlinks for the suffixed paths.
       SmallString<260> location;
-      if (!fs::real_path(symlink, location)) {
+      if (!macho::fs::real_path(symlink, location)) {
         // only append suffix if realpath() succeeds
         Twine suffixed = location + suffix;
-        if (fs::exists(suffixed))
+        if (macho::fs::exists(suffixed))
           return suffixed.str();
       }
       // Suffix lookup failed, fall through to the no-suffix case.
@@ -125,10 +127,10 @@ static Optional<std::string> findFramework(StringRef name) {
 }
 
 static bool warnIfNotDirectory(StringRef option, StringRef path) {
-  if (!fs::exists(path)) {
+  if (!macho::fs::exists(path)) {
     warn("directory not found for option -" + option + path);
     return false;
-  } else if (!fs::is_directory(path)) {
+  } else if (!macho::fs::is_directory(path)) {
     warn("option -" + option + path + " references a non-directory path");
     return false;
   }
@@ -149,7 +151,7 @@ getSearchPaths(unsigned optionCode, InputArgList &args,
         SmallString<261> buffer(root);
         path::append(buffer, path);
         // Do not warn about paths that are computed via the syslib roots
-        if (fs::is_directory(buffer)) {
+        if (macho::fs::is_directory(buffer)) {
           paths.push_back(saver.save(buffer.str()));
           found = true;
         }
@@ -167,7 +169,7 @@ getSearchPaths(unsigned optionCode, InputArgList &args,
     for (const StringRef &root : roots) {
       SmallString<261> buffer(root);
       path::append(buffer, path);
-      if (fs::is_directory(buffer))
+      if (macho::fs::is_directory(buffer))
         paths.push_back(saver.save(buffer.str()));
     }
   }
@@ -1203,6 +1205,37 @@ bool macho::link(ArrayRef<const char *> argsArr, bool canExitEarly,
   depTracker =
       make<DependencyTracker>(args.getLastArgValue(OPT_dependency_info));
 
+  // Do CAS and virtual filesystem setup early on so that it is available for
+  // filesystem calls.
+
+  // FIXME: Only supporting the \p BuiltinCAS currently, add same flags and
+  // mechanism as on the clang side to be able to use any kind of CAS.
+  if (args.hasArg(OPT_cas_path)) {
+    StringRef path = args.getLastArgValue(OPT_cas_path);
+    auto CAS = llvm::cas::createOnDiskCAS(path);
+    if (CAS) {
+      config->CAS = std::move(*CAS);
+      config->CASSchemas = std::make_unique<SchemaPool>(*config->CAS);
+    } else {
+      error("error loading CAS at path '" + path +
+            "': " + toString(CAS.takeError()));
+    }
+  }
+  Optional<StringRef> CASFileSystemRootID;
+  if (args.hasArg(OPT_fcas_fs))
+    CASFileSystemRootID = args.getLastArgValue(OPT_fcas_fs);
+  Optional<StringRef> CASFileSystemWorkingDirectory;
+  if (args.hasArg(OPT_fcas_fs_working_directory))
+    CASFileSystemRootID = args.getLastArgValue(OPT_fcas_fs_working_directory);
+  auto fs = lld::createFileSystem(config->CAS.get(), CASFileSystemRootID,
+                                  CASFileSystemWorkingDirectory);
+  if (fs) {
+    config->fs = std::move(*fs);
+  } else {
+    error("error creating file system: " + toString(fs.takeError()));
+    config->fs = llvm::vfs::getRealFileSystem();
+  }
+
   // Must be set before any InputSections and Symbols are created.
   config->deadStrip = args.hasArg(OPT_dead_strip);
 
@@ -1296,20 +1329,6 @@ bool macho::link(ArrayRef<const char *> argsArr, bool canExitEarly,
   config->icfLevel = getICFLevel(args);
   config->dedupLiterals = args.hasArg(OPT_deduplicate_literals) ||
                           config->icfLevel != ICFLevel::none;
-
-  // FIXME: Only supporting the \p BuiltinCAS currently, add same flags and
-  // mechanism as on the clang side to be able to use any kind of CAS.
-  if (args.hasArg(OPT_cas_path)) {
-    StringRef path = args.getLastArgValue(OPT_cas_path);
-    auto CAS = llvm::cas::createOnDiskCAS(path);
-    if (CAS) {
-      config->CAS = std::move(*CAS);
-      config->CASSchemas = std::make_unique<SchemaPool>(*config->CAS);
-    } else {
-      error("error loading CAS at path '" + path +
-            "': " + toString(CAS.takeError()));
-    }
-  }
 
   // FIXME: Add a commandline flag for this too.
   config->zeroModTime = getenv("ZERO_AR_DATE");

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -37,6 +37,8 @@
 #include "llvm/BinaryFormat/MachO.h"
 #include "llvm/BinaryFormat/Magic.h"
 #include "llvm/CAS/CASDB.h"
+#include "llvm/CAS/CASFileSystem.h"
+#include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/CAS/Utils.h"
 #include "llvm/CASObjectFormats/SchemaBase.h"
 #include "llvm/Config/llvm-config.h"
@@ -69,7 +71,7 @@ using namespace lld::macho;
 Configuration *macho::config;
 DependencyTracker *macho::depTracker;
 
-static HeaderFileType getOutputType(const InputArgList &args) {
+HeaderFileType macho::getOutputType(const InputArgList &args) {
   // TODO: -r, -dylinker, -preload...
   Arg *outputArg = args.getLastArg(OPT_bundle, OPT_dylib, OPT_execute);
   if (outputArg == nullptr)
@@ -274,6 +276,27 @@ static std::vector<ArchiveMember> getArchiveMembers(MemoryBufferRef mb) {
   return v;
 }
 
+static void handleFileForDepScanning(MemoryBufferRef mbref) {
+  assert(config->depScanning);
+
+  file_magic magic = identify_magic(mbref.getBuffer());
+
+  switch (magic) {
+  case file_magic::macho_object:
+    // A macho object may contain additional libraries/framework to link with.
+    ObjFile::parseLCLinkerOptions(mbref);
+    break;
+  case file_magic::macho_dynamically_linked_shared_lib:
+  case file_magic::macho_dynamically_linked_shared_lib_stub:
+  case file_magic::tapi_file:
+    // A dylib may have load commands for other dylibs.
+    loadDylib(mbref);
+    break;
+  default:
+    break;
+  }
+}
+
 static DenseMap<StringRef, ArchiveFile *> loadedArchives;
 
 static InputFile *addFile(StringRef path, bool forceLoadArchive,
@@ -282,6 +305,10 @@ static InputFile *addFile(StringRef path, bool forceLoadArchive,
   if (!buffer)
     return nullptr;
   MemoryBufferRef mbref = *buffer;
+  if (config->depScanning) {
+    handleFileForDepScanning(mbref);
+    return nullptr;
+  }
   InputFile *newFile = nullptr;
 
   file_magic magic = identify_magic(mbref.getBuffer());
@@ -464,7 +491,8 @@ static void addFramework(StringRef name, bool isNeeded, bool isWeak,
 
 // Parses LC_LINKER_OPTION contents, which can add additional command line
 // flags.
-void macho::parseLCLinkerOption(InputFile *f, unsigned argc, StringRef data) {
+void macho::parseLCLinkerOption(StringRef inputName, unsigned argc,
+                                StringRef data) {
   SmallVector<const char *, 4> argv;
   size_t offset = 0;
   for (unsigned i = 0; i < argc && offset < data.size(); ++i) {
@@ -472,7 +500,7 @@ void macho::parseLCLinkerOption(InputFile *f, unsigned argc, StringRef data) {
     offset += strlen(data.data() + offset) + 1;
   }
   if (argv.size() != argc || offset > data.size())
-    fatal(toString(f) + ": invalid LC_LINKER_OPTION");
+    fatal(inputName + ": invalid LC_LINKER_OPTION");
 
   MachOOptTable table;
   unsigned missingIndex, missingCount;
@@ -861,6 +889,12 @@ static const char *getReproduceOption(InputArgList &args) {
   return getenv("LLD_REPRODUCE");
 }
 
+static bool isVerboseOptionEnabled(const InputArgList &args) {
+  if (args.hasArg(OPT_verbose))
+    return true;
+  return getenv("LLD_VERBOSE");
+}
+
 static void parseClangOption(StringRef opt, const Twine &msg) {
   std::string err;
   raw_string_ostream os(err);
@@ -1021,6 +1055,12 @@ static void handleSymbolPatterns(InputArgList &args,
     symbolPatterns.insert(arg->getValue());
   for (const Arg *arg : args.filtered(listFileOptionCode)) {
     StringRef path = arg->getValue();
+    if (config->depScanning) {
+      // Register the input path with the caching filesystem.
+      vfs::Status stat;
+      macho::fs::status(path, stat);
+      continue;
+    }
     Optional<MemoryBufferRef> buffer = readFile(path);
     if (!buffer) {
       error("Could not read symbol file: " + path);
@@ -1046,17 +1086,20 @@ void createFiles(const InputArgList &args) {
 
     switch (opt.getID()) {
     case OPT_INPUT: {
-      StringRef path = rerootPath(arg->getValue());
       if (config->CAS) {
-        if (auto optCASID = expectedToOptional(config->CAS->parseCASID(path))) {
+        StringRef casid = arg->getValue();
+        if (auto optCASID =
+                expectedToOptional(config->CAS->parseCASID(casid))) {
+          if (config->depScanning)
+            continue; // we'll record the casid as part of the options.
           if (auto E = addCASTree(*config->CASSchemas, *optCASID)) {
-            error("error walking CAS tree with ID '" + path +
+            error("error walking CAS tree with ID '" + casid +
                   "': " + toString(std::move(E)));
           }
           break;
         }
       }
-      addFile(path, /*forceLoadArchive=*/false);
+      addFile(rerootPath(arg->getValue()), /*forceLoadArchive=*/false);
       break;
     }
     case OPT_needed_library:
@@ -1167,6 +1210,216 @@ static void referenceStubBinder() {
   symtab->addUndefined("dyld_stub_binder", /*file=*/nullptr, /*isWeak=*/false);
 }
 
+static bool shouldCacheResults(InputArgList &args) {
+  const Arg *arg =
+      args.getLastArg(OPT_fcas_cache_results, OPT_fcas_no_cache_results);
+  if (!arg || arg->getOption().getID() == OPT_fcas_no_cache_results)
+    return false;
+  if (!config->CAS) {
+    error("--fcas-cache-results is used but CAS is disabled");
+    return false;
+  }
+  if (args.hasArg(OPT_fcas_fs)) {
+    // FIXME: Need to have a \p CachingOnDiskFileSystem that can track accesses
+    // over a CAS tree, instead of the real filesystem.
+    error("--fcas-cache-results is incompatible with --fcas-fs currently");
+    return false;
+  }
+  if (args.hasArg(OPT_map))
+    warn("-map not supported for caching");
+  if (args.hasArg(OPT_dependency_info))
+    warn("-dependency_info not supported for caching");
+  return true;
+}
+
+static bool link(InputArgList &args, bool canExitEarly, raw_ostream &stdoutOS,
+                 raw_ostream &stderrOS);
+
+static CASID createResultCacheKey(CASDB &CAS, CASID rootID,
+                                  const InputArgList &args) {
+  // Change this when the schema for caching changes. It will ensure creation of
+  // brand new cachets.
+  constexpr unsigned CACHE_FORMAT_VERSION = 1;
+
+  HierarchicalTreeBuilder builder;
+  builder.push(rootID, TreeEntry::Tree, "filesystem");
+  builder.push(cantFail(CAS.createBlob(
+                   createResponseFile(args, /*isForCacheKey=*/true))),
+               TreeEntry::Regular, "arguments");
+  std::string version = getLLDVersion();
+  { raw_string_ostream(version) << '-' << CACHE_FORMAT_VERSION; }
+  builder.push(cantFail(CAS.createBlob(version)), TreeEntry::Regular,
+               "version");
+
+  return cantFail(builder.create(CAS)).getID();
+}
+
+static Error replayResult(CASDB &CAS, CASID resultID) {
+  TimeTraceScope timeScope("Caching: replay result");
+
+  std::unique_ptr<vfs::FileSystem> fs;
+  if (Expected<std::unique_ptr<vfs::FileSystem>> expectedFS =
+          createCASFileSystem(CAS, resultID))
+    fs = std::move(*expectedFS);
+  else
+    return expectedFS.takeError();
+
+  // FIXME: portable? Maybe, since CASFileSystem maybe will always be posix?
+  auto contentOrErr = fs->getBufferForFile("/output");
+  if (!contentOrErr)
+    return errorCodeToError(contentOrErr.getError());
+  std::unique_ptr<MemoryBuffer> content = std::move(*contentOrErr);
+
+  std::unique_ptr<FileOutputBuffer> output;
+  if (auto expectedOutput =
+          FileOutputBuffer::create(config->outputFile, content->getBufferSize(),
+                                   FileOutputBuffer::F_executable))
+    output = std::move(*expectedOutput);
+  else
+    return expectedOutput.takeError();
+  llvm::copy(content->getBuffer(), output->getBufferStart());
+  return output->commit();
+}
+
+static bool linkWithResultCaching(InputArgList &args, bool canExitEarly,
+                                  raw_ostream &stdoutOS,
+                                  raw_ostream &stderrOS) {
+  assert(config->CAS);
+  CASDB &CAS = *config->CAS;
+
+  Optional<CASID> optCacheKey;
+  Optional<TreeRef> rootRef;
+  {
+    TimeTraceScope timeScope("Caching: create key");
+
+    // FIXME: Allow doing input scanning using a CAS-FS. Need to have a \p
+    // CachingOnDiskFileSystem that can track accesses over a CAS tree, instead
+    // of the real filesystem.
+    auto cacheFS = createCachingOnDiskFileSystem(CAS);
+    if (!cacheFS) {
+      error("error creating caching filesystem: " +
+            toString(cacheFS.takeError()));
+      return ::link(args, canExitEarly, stdoutOS, stderrOS);
+    }
+    (*cacheFS)->trackNewAccesses();
+    auto originalFS = std::move(config->fs);
+    config->fs = *cacheFS;
+
+    config->depScanning = true;
+    if (!::link(args, canExitEarly, stdoutOS, stderrOS)) {
+      // We are exiting with an initial set of errors but not all the errors
+      // that would be emitted if \p link() was run normally, but it shouldn't
+      // be an issue in practice. If it is important to get the full set of
+      // errors we could hide the initial set of errors, so they are not emitted
+      // twice, and run \p link() again.
+      return false;
+    }
+    if (!inputFiles.empty())
+      report_fatal_error("dependency scanning added new input file");
+    if (!symtab->getSymbols().empty())
+      report_fatal_error("dependency scanning added new symbol");
+    resetLoadedDylibs();
+    config->depScanning = false;
+    config->fs = std::move(originalFS);
+
+    auto expectedRootRef = (*cacheFS)->createTreeFromAllAccesses();
+    if (!expectedRootRef) {
+      error("error creating CAS tree for inputs: " +
+            toString(expectedRootRef.takeError()));
+      return false;
+    }
+
+    optCacheKey = createResultCacheKey(CAS, *expectedRootRef, args);
+    rootRef = *expectedRootRef;
+  }
+
+  CASID cacheKey = *optCacheKey;
+  Expected<CASID> result = config->CAS->getCachedResult(cacheKey);
+  if (result) {
+    log("Caching: cache hit, result: " +
+        cantFail(CAS.convertCASIDToString(*result)) +
+        ", key: " + cantFail(CAS.convertCASIDToString(cacheKey)));
+    if (Error E = replayResult(CAS, std::move(*result))) {
+      error("error replaying cached result: " + toString(std::move(E)));
+      return false;
+    }
+    return true;
+  }
+
+  {
+    TimeTraceScope timeScope("Caching: link after cache miss");
+
+    log("Caching: cache miss, key: " +
+        cantFail(CAS.convertCASIDToString(cacheKey)));
+    consumeError(result.takeError());
+
+    SmallString<128> workingDirectory;
+    if (std::error_code ec = sys::fs::current_path(workingDirectory)) {
+      report_fatal_error(errorCodeToError(ec));
+    }
+
+    auto rootFS = createCASFileSystem(CAS, *rootRef);
+    if (!rootFS) {
+      error("error creating CASFS for root inputs: " +
+            toString(rootFS.takeError()));
+      return false;
+    }
+    (*rootFS)->setCurrentWorkingDirectory(workingDirectory);
+    // For the normal execution restrict access only to the input files that
+    // were determined to be part of the dependency scanning pass. This ensures
+    // that no input gets used that was not accounted for as part of the
+    // cache-key.
+    config->fs = std::move(*rootFS);
+
+    if (!::link(args, /*canExitEarly=*/false, stdoutOS, stderrOS))
+      return false;
+  }
+
+  {
+    TimeTraceScope timeScope("Caching: cache result");
+
+    // Go back to the real filesystem for handling the output file.
+    config->fs = vfs::getRealFileSystem();
+
+    // Cache the result.
+    // FIXME: Cache and replay the warning diagnostics.
+    // FIXME: Include other outputs, see the warnings emitted in \p
+    // shouldCacheResults().
+
+    // FIXME: Get the memory buffer of the output directly, instead of
+    // round-tripping from disk.
+    Optional<MemoryBufferRef> outBuffer = readFile(config->outputFile);
+    if (!outBuffer) {
+      return false;
+    }
+
+    Expected<BlobRef> blob = CAS.createBlob(outBuffer->getBuffer());
+    if (!blob) {
+      error("error creating CAS blob for output: " +
+            toString(blob.takeError()));
+      return false;
+    }
+
+    HierarchicalTreeBuilder builder;
+    builder.push(*blob, TreeEntry::Executable, "/output");
+    auto resultID = builder.create(CAS);
+    if (!resultID) {
+      error("error creating result CASID: " + toString(resultID.takeError()));
+      return false;
+    }
+
+    if (Error E = CAS.putCachedResult(cacheKey, *resultID)) {
+      error("error storing cached result: " + toString(std::move(E)));
+      return false;
+    }
+
+    log("Caching: cached result: " +
+        cantFail(CAS.convertCASIDToString(*resultID)));
+  }
+
+  return true;
+}
+
 bool macho::link(ArrayRef<const char *> argsArr, bool canExitEarly,
                  raw_ostream &stdoutOS, raw_ostream &stderrOS) {
   lld::stdoutOS = &stdoutOS;
@@ -1184,7 +1437,7 @@ bool macho::link(ArrayRef<const char *> argsArr, bool canExitEarly,
       "too many errors emitted, stopping now "
       "(use --error-limit=0 to see all errors)";
   errorHandler().errorLimit = args::getInteger(args, OPT_error_limit_eq, 20);
-  errorHandler().verbose = args.hasArg(OPT_verbose);
+  errorHandler().verbose = isVerboseOptionEnabled(args);
 
   if (args.hasArg(OPT_help_hidden)) {
     parser.printHelp(argsArr[0], /*showHidden=*/true);
@@ -1204,6 +1457,12 @@ bool macho::link(ArrayRef<const char *> argsArr, bool canExitEarly,
   target = createTargetInfo(args);
   depTracker =
       make<DependencyTracker>(args.getLastArgValue(OPT_dependency_info));
+
+  config->progName = argsArr[0];
+
+  config->outputFile = args.getLastArgValue(OPT_o, "a.out");
+  config->finalOutput =
+      args.getLastArgValue(OPT_final_output, config->outputFile);
 
   // Do CAS and virtual filesystem setup early on so that it is available for
   // filesystem calls.
@@ -1236,9 +1495,6 @@ bool macho::link(ArrayRef<const char *> argsArr, bool canExitEarly,
     config->fs = llvm::vfs::getRealFileSystem();
   }
 
-  // Must be set before any InputSections and Symbols are created.
-  config->deadStrip = args.hasArg(OPT_dead_strip);
-
   config->systemLibraryRoots = getSystemLibraryRoots(args);
   if (const char *path = getReproduceOption(args)) {
     // Note that --reproduce is a debug option so you can ignore it
@@ -1253,6 +1509,27 @@ bool macho::link(ArrayRef<const char *> argsArr, bool canExitEarly,
       error("--reproduce: " + toString(errOrWriter.takeError()));
     }
   }
+
+  config->timeTraceEnabled = args.hasArg(
+      OPT_time_trace, OPT_time_trace_granularity_eq, OPT_time_trace_file_eq);
+  config->timeTraceGranularity =
+      args::getInteger(args, OPT_time_trace_granularity_eq, 500);
+
+  // Initialize time trace profiler.
+  if (config->timeTraceEnabled)
+    timeTraceProfilerInitialize(config->timeTraceGranularity, config->progName);
+
+  if (shouldCacheResults(args))
+    return linkWithResultCaching(args, canExitEarly, stdoutOS, stderrOS);
+
+  return ::link(args, canExitEarly, stdoutOS, stderrOS);
+}
+
+static bool link(InputArgList &args, bool canExitEarly, raw_ostream &stdoutOS,
+                 raw_ostream &stderrOS) {
+
+  // Must be set before any InputSections and Symbols are created.
+  config->deadStrip = args.hasArg(OPT_dead_strip);
 
   if (auto *arg = args.getLastArg(OPT_threads_eq)) {
     StringRef v(arg->getValue());
@@ -1278,9 +1555,6 @@ bool macho::link(ArrayRef<const char *> argsArr, bool canExitEarly,
 
   config->mapFile = args.getLastArgValue(OPT_map);
   config->optimize = args::getInteger(args, OPT_O, 1);
-  config->outputFile = args.getLastArgValue(OPT_o, "a.out");
-  config->finalOutput =
-      args.getLastArgValue(OPT_final_output, config->outputFile);
   config->astPaths = args.getAllArgValues(OPT_add_ast_path);
   config->headerPad = args::getHex(args, OPT_headerpad, /*Default=*/32);
   config->headerPadMaxInstallNames =
@@ -1371,7 +1645,7 @@ bool macho::link(ArrayRef<const char *> argsArr, bool canExitEarly,
 
   config->undefinedSymbolTreatment = getUndefinedSymbolTreatment(args);
 
-  if (config->outputType == MH_EXECUTE)
+  if (config->outputType == MH_EXECUTE && !config->depScanning)
     config->entry = symtab->addUndefined(args.getLastArgValue(OPT_e, "_main"),
                                          /*file=*/nullptr,
                                          /*isWeakRef=*/false);
@@ -1461,22 +1735,22 @@ bool macho::link(ArrayRef<const char *> argsArr, bool canExitEarly,
                  : "\n\t" + join(config->frameworkSearchPaths, "\n\t")));
   }
 
-  config->progName = argsArr[0];
-
-  config->timeTraceEnabled = args.hasArg(
-      OPT_time_trace, OPT_time_trace_granularity_eq, OPT_time_trace_file_eq);
-  config->timeTraceGranularity =
-      args::getInteger(args, OPT_time_trace_granularity_eq, 500);
-
-  // Initialize time trace profiler.
-  if (config->timeTraceEnabled)
-    timeTraceProfilerInitialize(config->timeTraceGranularity, config->progName);
-
   {
     TimeTraceScope timeScope("ExecuteLinker");
 
     initLLVM(); // must be run before any call to addFile()
     createFiles(args);
+
+    if (config->depScanning) {
+      for (const Arg *arg : args.filtered(OPT_sectcreate)) {
+        StringRef fileName = arg->getValue(2);
+        // Register the input path with the caching filesystem.
+        vfs::Status stat;
+        macho::fs::status(fileName, stat);
+      }
+      // Got all inputs, now we can stop.
+      return !errorCount();
+    }
 
     config->isPic = config->outputType == MH_DYLIB ||
                     config->outputType == MH_BUNDLE ||

--- a/lld/MachO/Driver.h
+++ b/lld/MachO/Driver.h
@@ -13,6 +13,7 @@
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/BinaryFormat/MachO.h"
 #include "llvm/Option/OptTable.h"
 #include "llvm/Support/MemoryBuffer.h"
 
@@ -47,15 +48,21 @@ enum {
 #undef OPTION
 };
 
-void parseLCLinkerOption(InputFile *, unsigned argc, StringRef data);
+void parseLCLinkerOption(StringRef inputName, unsigned argc, StringRef data);
 
-std::string createResponseFile(const llvm::opt::InputArgList &args);
+std::string createResponseFile(const llvm::opt::InputArgList &args,
+                               bool isForCacheKey = false);
+
+llvm::MachO::HeaderFileType getOutputType(const llvm::opt::InputArgList &args);
 
 // Check for both libfoo.dylib and libfoo.tbd (in that order).
 llvm::Optional<std::string> resolveDylibPath(llvm::StringRef path);
 
 DylibFile *loadDylib(llvm::MemoryBufferRef mbref, DylibFile *umbrella = nullptr,
                      bool isBundleLoader = false);
+
+/// Called after dependency scanning pass is finished, to reset to initial state for performing a normal link.
+void resetLoadedDylibs();
 
 // Search for all possible combinations of `{root}/{name}.{extension}`.
 // If \p extensions are not specified, then just search for `{root}/{name}`.

--- a/lld/MachO/FileSystem.cpp
+++ b/lld/MachO/FileSystem.cpp
@@ -1,0 +1,35 @@
+//===- FileSystem.cpp -----------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "FileSystem.h"
+#include "Config.h"
+#include "llvm/Support/VirtualFileSystem.h"
+
+using namespace llvm;
+using namespace lld;
+using namespace lld::macho;
+
+bool fs::exists(const Twine &path) { return config->fs->exists(path); }
+
+bool fs::is_directory(const Twine &path) {
+  auto status = config->fs->status(path);
+  return status && status->isDirectory();
+}
+
+std::error_code fs::status(const Twine &path, vfs::Status &result) {
+  auto status = config->fs->status(path);
+  if (!status)
+    return status.getError();
+  result = *status;
+  return std::error_code();
+}
+
+std::error_code fs::real_path(const Twine &path,
+                              llvm::SmallVectorImpl<char> &output) {
+  return config->fs->getRealPath(path, output);
+}

--- a/lld/MachO/FileSystem.h
+++ b/lld/MachO/FileSystem.h
@@ -1,0 +1,42 @@
+//===- FileSystem.h ---------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines a number of functions as they exist in 'llvm/Support/FileSystem.h'
+// but with implementations based on using a virtual filesystem that is setup
+// during configuration.
+//
+// FIXME: Generalize and use for the other linker flavors as well.
+//===----------------------------------------------------------------------===//
+
+#ifndef LLD_MACHO_FILESYSTEM_H
+#define LLD_MACHO_FILESYSTEM_H
+
+#include "lld/Common/LLVM.h"
+#include <system_error>
+
+namespace llvm {
+namespace vfs {
+class Status;
+}
+} // namespace llvm
+
+namespace lld {
+namespace macho {
+namespace fs {
+
+bool exists(const Twine &path);
+bool is_directory(const Twine &path);
+std::error_code status(const Twine &path, llvm::vfs::Status &result);
+std::error_code real_path(const Twine &path,
+                          llvm::SmallVectorImpl<char> &output);
+
+} // namespace fs
+} // namespace macho
+} // namespace lld
+
+#endif

--- a/lld/MachO/InputFiles.cpp
+++ b/lld/MachO/InputFiles.cpp
@@ -771,6 +771,15 @@ void ObjFile::parseLCLinkerOptions(MemoryBufferRef mb) {
 
 ObjFile::ObjFile(MemoryBufferRef mb, uint32_t modTime, StringRef archiveName)
     : InputFile(ObjKind, mb), modTime(modTime) {
+  init(archiveName);
+}
+
+ObjFile::ObjFile(MemoryBufferRef mb, llvm::cas::CASID ID, StringRef archiveName)
+    : InputFile(ObjKind, mb), modTime(0), casID(std::move(ID)) {
+  init(archiveName);
+}
+
+void ObjFile::init(StringRef archiveName) {
   this->archiveName = std::string(archiveName);
   if (target->wordSize == 8)
     parse<LP64>();

--- a/lld/MachO/InputFiles.h
+++ b/lld/MachO/InputFiles.h
@@ -109,16 +109,19 @@ private:
 class ObjFile final : public InputFile {
 public:
   ObjFile(MemoryBufferRef mb, uint32_t modTime, StringRef archiveName);
+  ObjFile(MemoryBufferRef mb, llvm::cas::CASID ID, StringRef archiveName);
   static bool classof(const InputFile *f) { return f->kind() == ObjKind; }
 
   llvm::DWARFUnit *compileUnit = nullptr;
   const uint32_t modTime;
+  const llvm::Optional<llvm::cas::CASID> casID;
   std::vector<ConcatInputSection *> debugSections;
   ArrayRef<llvm::MachO::data_in_code_entry> dataInCodeEntries;
 
   static void parseLCLinkerOptions(MemoryBufferRef mb);
 
 private:
+  void init(StringRef archiveName);
   template <class LP> void parse();
   template <class Section> void parseSections(ArrayRef<Section>);
   template <class LP>

--- a/lld/MachO/InputFiles.h
+++ b/lld/MachO/InputFiles.h
@@ -116,6 +116,8 @@ public:
   std::vector<ConcatInputSection *> debugSections;
   ArrayRef<llvm::MachO::data_in_code_entry> dataInCodeEntries;
 
+  static void parseLCLinkerOptions(MemoryBufferRef mb);
+
 private:
   template <class LP> void parse();
   template <class Section> void parseSections(ArrayRef<Section>);

--- a/lld/MachO/Options.td
+++ b/lld/MachO/Options.td
@@ -74,6 +74,14 @@ def thinlto_cache_policy: Joined<["--"], "thinlto-cache-policy=">,
 def O : JoinedOrSeparate<["-"], "O">,
     HelpText<"Optimize output file size">;
 
+// CAS-related options.
+// FIXME: Include missing CAS options from clang.
+
+def cas_path : Separate<["--"], "fcas-builtin-path">,
+    HelpText<"Path to a persistent on-disk backing store for the builtin CAS.">,
+    MetaVarName<"<path>">,
+    Group<grp_lld>;
+
 // This is a complete Options.td compiled from Apple's ld(1) manpage
 // dated 2018-03-07 and cross checked with ld64 source code in repo
 // https://github.com/apple-opensource/ld64 at git tag "512.4" dated
@@ -920,10 +928,6 @@ def object_path_lto : Separate<["-"], "object_path_lto">,
 def cache_path_lto : Separate<["-"], "cache_path_lto">,
     MetaVarName<"<path>">,
     HelpText<"Use <path> as a directory for the incremental LTO cache">,
-    Group<grp_rare>;
-def cas_path : Separate<["-"], "cas_path">,
-    MetaVarName<"<path>">,
-    HelpText<"Use <path> as the path to the CAS on disk">,
     Group<grp_rare>;
 def prune_interval_lto : Separate<["-"], "prune_interval_lto">,
     MetaVarName<"<seconds>">,

--- a/lld/MachO/Options.td
+++ b/lld/MachO/Options.td
@@ -90,6 +90,13 @@ def fcas_fs_working_directory : Separate<["--"], "fcas-fs-working-directory">,
     MetaVarName<"<dir>">,
     Group<grp_lld>;
 
+def fcas_cache_results: Flag<["--"], "fcas-cache-results">,
+    HelpText<"Use a result cache">,
+    Group<grp_lld>;
+def fcas_no_cache_results: Flag<["--"], "fcas-no-cache-results">,
+    HelpText<"Use a result cache">,
+    Group<grp_lld>;
+
 // This is a complete Options.td compiled from Apple's ld(1) manpage
 // dated 2018-03-07 and cross checked with ld64 source code in repo
 // https://github.com/apple-opensource/ld64 at git tag "512.4" dated

--- a/lld/MachO/Options.td
+++ b/lld/MachO/Options.td
@@ -81,6 +81,14 @@ def cas_path : Separate<["--"], "fcas-builtin-path">,
     HelpText<"Path to a persistent on-disk backing store for the builtin CAS.">,
     MetaVarName<"<path>">,
     Group<grp_lld>;
+def fcas_fs : Separate<["--"], "fcas-fs">,
+    HelpText<"Configure the filesystem to read from the provided CAS tree.">,
+    MetaVarName<"<tree>">,
+    Group<grp_lld>;
+def fcas_fs_working_directory : Separate<["--"], "fcas-fs-working-directory">,
+    HelpText<"Working directory for -fcas-fs (if not the root).">,
+    MetaVarName<"<dir>">,
+    Group<grp_lld>;
 
 // This is a complete Options.td compiled from Apple's ld(1) manpage
 // dated 2018-03-07 and cross checked with ld64 source code in repo

--- a/lld/include/lld/Common/Filesystem.h
+++ b/lld/include/lld/Common/Filesystem.h
@@ -12,9 +12,28 @@
 #include "lld/Common/LLVM.h"
 #include <system_error>
 
+namespace llvm {
+template <typename T> class IntrusiveRefCntPtr;
+
+namespace cas {
+class CASDB;
+}
+
+namespace vfs {
+class FileSystem;
+}
+
+} // namespace llvm
+
 namespace lld {
 void unlinkAsync(StringRef path);
 std::error_code tryCreateFile(StringRef path);
+
+Expected<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>>
+createFileSystem(llvm::cas::CASDB *CAS,
+                 llvm::Optional<StringRef> CASFileSystemRootID,
+                 llvm::Optional<StringRef> CASFileSystemWorkingDirectory);
+
 } // namespace lld
 
 #endif

--- a/lld/test/CMakeLists.txt
+++ b/lld/test/CMakeLists.txt
@@ -31,10 +31,10 @@ set(LLD_TEST_DEPS lld)
 if (NOT LLD_BUILT_STANDALONE)
   list(APPEND LLD_TEST_DEPS
     FileCheck count dsymutil llc llvm-ar llvm-as llvm-bcanalyzer llvm-cas
-    llvm-cas-object-format llvm-config
-    llvm-cvtres llvm-dis llvm-dwarfdump llvm-lib llvm-lipo llvm-mc llvm-nm
-    llvm-objcopy llvm-objdump llvm-otool llvm-pdbutil llvm-profdata llvm-readelf
-    llvm-readobj llvm-strip llvm-symbolizer not obj2yaml opt split-file yaml2obj
+    llvm-cas-object-format llvm-config llvm-cvtres llvm-dis llvm-dwarfdump
+    llvm-lib llvm-libtool-darwin llvm-lipo llvm-mc llvm-nm llvm-objcopy
+    llvm-objdump llvm-otool llvm-pdbutil llvm-profdata llvm-readelf llvm-readobj
+    llvm-strip llvm-symbolizer not obj2yaml opt split-file yaml2obj
     )
 endif()
 

--- a/lld/test/CMakeLists.txt
+++ b/lld/test/CMakeLists.txt
@@ -30,7 +30,8 @@ configure_lit_site_cfg(
 set(LLD_TEST_DEPS lld)
 if (NOT LLD_BUILT_STANDALONE)
   list(APPEND LLD_TEST_DEPS
-    FileCheck count dsymutil llc llvm-ar llvm-as llvm-bcanalyzer llvm-config
+    FileCheck count dsymutil llc llvm-ar llvm-as llvm-bcanalyzer llvm-cas
+    llvm-cas-object-format llvm-config
     llvm-cvtres llvm-dis llvm-dwarfdump llvm-lib llvm-lipo llvm-mc llvm-nm
     llvm-objcopy llvm-objdump llvm-otool llvm-pdbutil llvm-profdata llvm-readelf
     llvm-readobj llvm-strip llvm-symbolizer not obj2yaml opt split-file yaml2obj

--- a/lld/test/MachO/CAS/cache-results.s
+++ b/lld/test/MachO/CAS/cache-results.s
@@ -1,0 +1,136 @@
+// REQUIRES: x86
+// RUN: rm -rf %t; split-file %s %t
+// RUN: mkdir -p %t/alib %t/dlib
+
+// RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/main.s -o %t/main.o
+// RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/t1.s -o %t/t1.o
+// RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/t2.s -o %t/t2.o
+// RUN: llvm-ar rcs %t/alib/libt1.a %t/t1.o
+// RUN: %lld -dylib -o %t/dlib/libt2.dylib %t/t2.o
+
+// Check normal invocation.
+// RUN: %lld %t/main.o -o %t/exe-normal -lt1 -lt2 -L%t/alib -L%t/dlib
+// RUN: llvm-objdump --macho %t/exe-normal -t | FileCheck %s -check-prefix=SYMBOLS
+
+// Check result caching.
+
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN:    | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: diff %t/exe %t/exe-normal
+
+// RUN: rm %t/exe
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN:    | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: diff %t/exe %t/exe-normal
+
+// RUN: touch %t/main.o %t/alib/libt1.a %t/dlib/libt2.dylib
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN:    | FileCheck %s -check-prefix=CACHE-HIT
+
+// Check that changing output executable filename doesn't affect cache key for executables.
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe2 -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN:    | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: diff %t/exe2 %t/exe-normal
+
+// But changing output dylib filename affects cache key.
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose -dylib %t/main.o -o %t/exe1.dylib -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN:    | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose -dylib %t/main.o -o %t/exe2.dylib -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN:    | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: not diff %t/exe1.dylib %t/exe2.dylib
+
+// Check that re-exports in a dylib are handled for dependency scanning (libc++ re-exports libc++abi)
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose -lc++ %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN:    | FileCheck %s -check-prefix=CACHE-MISS
+
+// Change order of search paths.
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt2 -lt1 -L%t/alib -L%t/dlib 2>&1 \
+// RUN:    | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt2 -lt1 -L%t/alib -L%t/dlib 2>&1 \
+// RUN:    | FileCheck %s -check-prefix=CACHE-HIT
+
+// Change .o contents
+// RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/main2.s -o %t/main.o
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN:    | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN:    | FileCheck %s -check-prefix=CACHE-HIT
+
+// Change .a and .dylib contents
+// RUN: llvm-ar rcs %t/alib/libt1.a %t/t2.o
+// RUN: %lld -dylib -o %t/dlib/libt2.dylib %t/t1.o
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN:    | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN:    | FileCheck %s -check-prefix=CACHE-HIT
+
+// Check using relative paths.
+
+// RUN: mv %t/exe %t/exe.bak; cd %t
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose main.o -o exe -lt1 -lt2 -Lalib -Ldlib 2>&1 \
+// RUN:    | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: diff %t/exe %t/exe.bak
+
+// CACHE-MISS:      Caching: cache miss
+// CACHE-MISS-NEXT: Caching: cached result
+
+// CACHE-HIT: Caching: cache hit
+
+// SYMBOLS: F __TEXT,__text _main
+// SYMBOLS: F __TEXT,__text _call1
+// SYMBOLS: *UND* _putchar
+// SYMBOLS: *UND* _call2
+
+//--- main.s
+	.linker_option "-lSystem"
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_main
+	.p2align	4, 0x90
+_main:
+	pushq	%rax
+	movl	$0, 4(%rsp)
+	callq	_call1
+	callq	_call2
+	movl	$10, %edi
+	callq	_putchar
+	xorl	%eax, %eax
+	popq	%rcx
+	retq
+
+.subsections_via_symbols
+
+//--- main2.s
+	.linker_option "-lSystem"
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_main
+	.p2align	4, 0x90
+_main:
+	pushq	%rax
+	movl	$0, 4(%rsp)
+	callq	_call1
+	callq	_call2
+	movl	$11, %edi
+	callq	_putchar
+	xorl	%eax, %eax
+	popq	%rcx
+	retq
+
+.subsections_via_symbols
+
+//--- t1.s
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_call1
+	.p2align	4, 0x90
+_call1:
+	retq
+
+.subsections_via_symbols
+
+//--- t2.s
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_call2
+	.p2align	4, 0x90
+_call2:
+	retq
+
+.subsections_via_symbols

--- a/lld/test/MachO/CAS/cas-fs.s
+++ b/lld/test/MachO/CAS/cas-fs.s
@@ -1,0 +1,82 @@
+// REQUIRES: x86
+// RUN: rm -rf %t; split-file %s %t
+// RUN: mkdir -p %t/alib %t/dlib
+
+// RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/main.s -o %t/main.o
+// RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/t1.s -o %t/t1.o
+// RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/t2.s -o %t/t2.o
+// RUN: llvm-ar rcs %t/alib/libt1.a %t/t1.o
+// RUN: %lld -dylib -o %t/dlib/libt2.dylib %t/t2.o
+
+// Check with normal filesystem access.
+// RUN: %lld -lSystem %t/main.o -o %t/exe1 -lt1 -lt2 -L%t/alib -L%t/dlib
+// RUN: llvm-objdump --macho %t/exe1 -t | FileCheck %s -check-prefix=SYMBOLS
+
+// Check with CAS filesystem.
+
+// RUN: llvm-cas -cas %t/cas --merge > %t/empty.id
+// RUN: not %lld --fcas-builtin-path %t/cas --fcas-fs @%t/empty.id -lSystem %t/main.o -o %t/exe2 -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN:    | FileCheck %s -check-prefix=FAIL-DIR -check-prefix=FAIL-SYSLIB -check-prefix=FAIL-MAIN -check-prefix=FAIL-USERLIB
+
+// RUN: llvm-cas -cas %t/cas --merge %t/main.o > %t/main.o.id
+// RUN: not %lld --fcas-builtin-path %t/cas --fcas-fs @%t/main.o.id -lSystem %t/main.o -o %t/exe2 -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN:    | FileCheck %s -check-prefix=FAIL-DIR -check-prefix=FAIL-SYSLIB -check-prefix=FAIL-USERLIB -check-prefix=FAIL-SYSSYM -check-prefix=FAIL-USERSYM
+
+// RUN: llvm-cas -cas %t/cas --merge %t/main.o %t/alib %t/dlib > %t/o-and-libs.id
+// RUN: not %lld --fcas-builtin-path %t/cas --fcas-fs @%t/o-and-libs.id -lSystem %t/main.o -o %t/exe2 -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN:    | FileCheck %s -check-prefix=FAIL-SYSLIB -check-prefix=FAIL-SYSSYM
+
+// RUN: llvm-cas -cas %t/cas --merge @%t/o-and-libs.id %S/../Inputs/MacOSX.sdk > %t/complete.id
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-fs @%t/complete.id -lSystem %t/main.o -o %t/exe2 -lt1 -lt2 -L%t/alib -L%t/dlib
+// RUN: llvm-objdump --macho %t/exe2 -t | FileCheck %s -check-prefix=SYMBOLS
+
+// FAIL-DIR: error: directory not found for option -L{{.*}}alib
+// FAIL-DIR: error: directory not found for option -L{{.*}}dlib
+// FAIL-SYSLIB: error: library not found for -lSystem
+// FAIL-MAIN: error: cannot open {{.*}}main.o: No such file or directory
+// FAIL-USERLIB: error: library not found for -lt1
+// FAIL-USERLIB: error: library not found for -lt2
+
+// FAIL-SYSSYM: error: undefined symbol: _putchar
+// FAIL-USERSYM: error: undefined symbol: _call2
+// FAIL-USERSYM: error: undefined symbol: _call1
+
+// SYMBOLS: F __TEXT,__text _main
+// SYMBOLS: F __TEXT,__text _call1
+// SYMBOLS: *UND* _putchar
+// SYMBOLS: *UND* _call2
+
+//--- main.s
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_main
+	.p2align	4, 0x90
+_main:
+	pushq	%rax
+	movl	$0, 4(%rsp)
+	callq	_call1
+	callq	_call2
+	movl	$10, %edi
+	callq	_putchar
+	xorl	%eax, %eax
+	popq	%rcx
+	retq
+
+.subsections_via_symbols
+
+//--- t1.s
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_call1
+	.p2align	4, 0x90
+_call1:
+	retq
+
+.subsections_via_symbols
+
+//--- t2.s
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_call2
+	.p2align	4, 0x90
+_call2:
+	retq
+
+.subsections_via_symbols

--- a/lld/test/MachO/CAS/cpp-globalctordtor.s
+++ b/lld/test/MachO/CAS/cpp-globalctordtor.s
@@ -3,8 +3,8 @@
 // RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %s -o %t/test.o
 // RUN: llvm-cas-object-format %t/test.o -cas %t/cas -ingest-schema=flatv1 -silent > %t/casid-flat.txt
 // RUN: llvm-cas-object-format %t/test.o -cas %t/cas -ingest-schema=nestedv1 -silent > %t/casid-nested.txt
-// RUN: %lld -lc++ -lSystem -cas_path %t/cas @%t/casid-flat.txt -o %t/test-flat
-// RUN: %lld -lc++ -lSystem -cas_path %t/cas @%t/casid-nested.txt -o %t/test-nested
+// RUN: %lld -lc++ -lSystem --fcas-builtin-path %t/cas @%t/casid-flat.txt -o %t/test-flat
+// RUN: %lld -lc++ -lSystem --fcas-builtin-path %t/cas @%t/casid-nested.txt -o %t/test-nested
 // RUN: llvm-objdump --macho %t/test-flat --full-contents -d -t | \
 // RUN:     FileCheck %s --check-prefix=CHECK --check-prefix=FLAT
 // RUN: llvm-objdump --macho %t/test-nested --full-contents -d -t | \

--- a/lld/test/MachO/CAS/cstrings.s
+++ b/lld/test/MachO/CAS/cstrings.s
@@ -3,8 +3,8 @@
 // RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %s -o %t/test.o
 // RUN: llvm-cas-object-format %t/test.o -cas %t/cas -ingest-schema=flatv1 -silent > %t/casid-flat.txt
 // RUN: llvm-cas-object-format %t/test.o -cas %t/cas -ingest-schema=nestedv1 -silent > %t/casid-nested.txt
-// RUN: %lld -cas_path %t/cas @%t/casid-flat.txt -o %t/test-flat
-// RUN: %lld -cas_path %t/cas @%t/casid-nested.txt -o %t/test-nested
+// RUN: %lld --fcas-builtin-path %t/cas @%t/casid-flat.txt -o %t/test-flat
+// RUN: %lld --fcas-builtin-path %t/cas @%t/casid-nested.txt -o %t/test-nested
 // RUN: llvm-objdump --macho %t/test-flat --full-contents -d -t | FileCheck %s
 // RUN: llvm-objdump --macho %t/test-nested --full-contents -d -t | FileCheck %s
 

--- a/lld/test/MachO/CAS/embedded-casids.s
+++ b/lld/test/MachO/CAS/embedded-casids.s
@@ -1,0 +1,68 @@
+// REQUIRES: x86
+// RUN: rm -rf %t; split-file %s %t
+// RUN: mkdir -p %t/alib %t/alib.id
+
+// RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/main.s -o %t/main.o
+// RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/t1.s -o %t/t1.o
+// RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/t2.s -o %t/t2.o
+// RUN: llvm-libtool-darwin -static -o %t/alib/libt.a %t/t1.o %t/t2.o
+
+// Check normal invocation.
+// RUN: %lld -lSystem %t/main.o -o %t/exe-normal -lt -L%t/alib
+// RUN: llvm-objdump --macho %t/exe-normal -t | FileCheck %s -check-prefix=SYMBOLS
+
+// Check with embedded CASIDS.
+// RUN: llvm-cas-object-format -cas %t/cas -just-blobs %t/main.o -casid-output %t/main.id.o
+// RUN: %lld --fcas-builtin-path %t/cas -lSystem %t/main.id.o -o %t/exe -lt -L%t/alib
+// RUN: diff %t/exe %t/exe-normal
+
+// RUN: llvm-cas-object-format -cas %t/cas -just-blobs %t/t1.o -casid-output %t/t1.id.o
+// RUN: llvm-cas-object-format -cas %t/cas -just-blobs %t/t2.o -casid-output %t/t2.id.o
+// RUN: llvm-libtool-darwin -fcas builtin -fcas-builtin-path %t/cas -static -o %t/alib.id/libt.a %t/t1.id.o %t/t2.id.o
+// RUN: %lld --fcas-builtin-path %t/cas -lSystem %t/main.id.o -o %t/exe -lt -L%t/alib.id
+// RUN: diff %t/exe %t/exe-normal
+
+// Check with CAS schema.
+// RUN: llvm-cas-object-format -cas %t/cas -ingest-schema=flatv1 %t/main.o -casid-output %t/main.schema.o
+// RUN: %lld --fcas-builtin-path %t/cas -lSystem %t/main.schema.o -o %t/exe-schema -lt -L%t/alib.id
+// RUN: llvm-objdump --macho %t/exe-schema -t | FileCheck %s -check-prefix=SYMBOLS
+
+// SYMBOLS-DAG: F __TEXT,__text _main
+// SYMBOLS-DAG: F __TEXT,__text _call1
+// SYMBOLS-DAG: F __TEXT,__text _call2
+// SYMBOLS: *UND* _putchar
+
+//--- main.s
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_main
+	.p2align	4, 0x90
+_main:
+	pushq	%rax
+	movl	$0, 4(%rsp)
+	callq	_call1
+	callq	_call2
+	movl	$10, %edi
+	callq	_putchar
+	xorl	%eax, %eax
+	popq	%rcx
+	retq
+
+.subsections_via_symbols
+
+//--- t1.s
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_call1
+	.p2align	4, 0x90
+_call1:
+	retq
+
+.subsections_via_symbols
+
+//--- t2.s
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_call2
+	.p2align	4, 0x90
+_call2:
+	retq
+
+.subsections_via_symbols

--- a/lld/test/MachO/CAS/tlv.s
+++ b/lld/test/MachO/CAS/tlv.s
@@ -3,8 +3,8 @@
 // RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %s -o %t/test.o
 // RUN: llvm-cas-object-format %t/test.o -cas %t/cas -ingest-schema=flatv1 -silent > %t/casid-flat.txt
 // RUN: llvm-cas-object-format %t/test.o -cas %t/cas -ingest-schema=nestedv1 -silent > %t/casid-nested.txt
-// RUN: %lld -lSystem -cas_path %t/cas @%t/casid-flat.txt -o %t/test-flat
-// RUN: %lld -lSystem -cas_path %t/cas @%t/casid-nested.txt -o %t/test-nested
+// RUN: %lld -lSystem --fcas-builtin-path %t/cas @%t/casid-flat.txt -o %t/test-flat
+// RUN: %lld -lSystem --fcas-builtin-path %t/cas @%t/casid-nested.txt -o %t/test-nested
 // RUN: llvm-objdump --macho %t/test-flat --full-contents -d -t | FileCheck %s
 // RUN: llvm-objdump --macho %t/test-nested --full-contents -d -t | FileCheck %s
 

--- a/lld/test/MachO/Inputs/MacOSX.sdk/usr/lib/libSystem.tbd
+++ b/lld/test/MachO/Inputs/MacOSX.sdk/usr/lib/libSystem.tbd
@@ -50,7 +50,7 @@ parent-umbrella:
     umbrella:     System
 exports:
   - targets:      [ x86_64-macos, x86_64-maccatalyst, arm64-macos ]
-    symbols:      [ ]
+    symbols:      [ _putchar ]
 --- !tapi-tbd
 tbd-version:      4
 targets:          [ x86_64-macos, x86_64-maccatalyst, arm64-macos ]

--- a/lld/test/lit.cfg.py
+++ b/lld/test/lit.cfg.py
@@ -40,7 +40,7 @@ llvm_config.use_lld()
 tool_patterns = [
     'llc', 'llvm-as', 'llvm-mc', 'llvm-nm', 'llvm-objdump', 'llvm-pdbutil',
     'llvm-dwarfdump', 'llvm-readelf', 'llvm-readobj', 'obj2yaml', 'yaml2obj',
-    'opt', 'llvm-dis', 'llvm-cas-object-format']
+    'opt', 'llvm-dis', 'llvm-cas', 'llvm-cas-object-format']
 
 llvm_config.add_tool_substitutions(tool_patterns)
 

--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -283,7 +283,7 @@ if( LLVM_ENABLE_LLD )
     message(FATAL_ERROR "LLVM_ENABLE_LLD and LLVM_USE_LINKER can't be set at the same time")
   endif()
   # In case of MSVC cmake always invokes the linker directly, so the linker
-  # should be specified by CMAKE_LINKER cmake variable instead of by -fuse-ld
+  # should be specified by CMAKE_LINKER cmake variable instead of by --ld-path
   # compiler option.
   if ( NOT MSVC )
     set(LLVM_USE_LINKER "lld")
@@ -292,13 +292,13 @@ endif()
 
 if( LLVM_USE_LINKER )
   set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
-  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -fuse-ld=${LLVM_USE_LINKER}")
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} --ld-path=${LLVM_USE_LINKER}")
   check_cxx_source_compiles("int main() { return 0; }" CXX_SUPPORTS_CUSTOM_LINKER)
   if ( NOT CXX_SUPPORTS_CUSTOM_LINKER )
-    message(FATAL_ERROR "Host compiler does not support '-fuse-ld=${LLVM_USE_LINKER}'")
+    message(FATAL_ERROR "Host compiler does not support '--ld-path=${LLVM_USE_LINKER}'")
   endif()
   set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
-  append("-fuse-ld=${LLVM_USE_LINKER}"
+  append("--ld-path=${LLVM_USE_LINKER}"
     CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
 endif()
 
@@ -1226,6 +1226,13 @@ endif()
 set(LLVM_ENABLE_EXPERIMENTAL_DEPSCAN OFF CACHE BOOL
   "Use the experimental -fdepscan and related flags")
 set(LLVM_DEPSCAN_MODE "" CACHE STRING "Mode for -fdepscan if used")
+set(LLVM_CAS_BUILTIN_PATH "" CACHE STRING "Path to pass for -fcas-builtin-path")
+set(LLVM_CAS_BUILTIN_PATH_Default "/^llvm::cas::builtin::default/llvm.cas.builtin.default")
+if (LLVM_CAS_BUILTIN_PATH)
+  set(LLVM_CAS_BUILTIN_PATH_Default "${LLVM_CAS_BUILTIN_PATH}")
+endif()
+set(LLVM_CAS_ENABLE_CASID_OBJECT_OUTPUTS OFF CACHE BOOL
+  "When the experimental -fdepscan is enabled also enable writing CASIDs for object files")
 if(LLVM_ENABLE_EXPERIMENTAL_DEPSCAN)
   # Don't daemonize when running the check.
   check_c_compiler_flag("-fdepscan=off" SUPPORTS_DEPSCAN)
@@ -1298,6 +1305,25 @@ if(LLVM_ENABLE_EXPERIMENTAL_DEPSCAN_TABLEGEN)
 
   list(APPEND LLVM_TABLEGEN_FLAGS "--depscan-prefix-map=${source_root}=/^source")
   list(APPEND LLVM_TABLEGEN_FLAGS "--depscan-prefix-map=${CMAKE_BINARY_DIR}=/^build")
+endif()
+
+set(LLVM_ENABLE_EXPERIMENTAL_LINKER_RESULT_CACHE OFF CACHE BOOL
+  "Use the result cache for linker invocations")
+if(LLVM_ENABLE_EXPERIMENTAL_LINKER_RESULT_CACHE)
+  # FIXME: Do check that the linker supports these flags and error out if not.
+  append("-Xlinker --fcas-cache-results -Xlinker --fcas-builtin-path -Xlinker ${LLVM_CAS_BUILTIN_PATH_Default}"
+    CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
+endif()
+
+if (LLVM_CAS_ENABLE_CASID_OBJECT_OUTPUTS)
+  # This needs to be enabled next to the linker becoming CAS-aware, otherwise
+  # compiler flag checks will fail.
+  if(NOT LLVM_ENABLE_EXPERIMENTAL_LINKER_RESULT_CACHE)
+    message(FATAL_ERROR "LLVM_CAS_ENABLE_CASID_OBJECT_OUTPUTS requires a CAS-aware linker")
+  endif()
+  append("-Xclang -fcasid-output" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+  # FIXME: Do check that libtool supports embedded CASIDs and error out if not.
+  append("-fcas builtin -fcas-builtin-path ${LLVM_CAS_BUILTIN_PATH_Default}" CMAKE_STATIC_LINKER_FLAGS)
 endif()
 
 if(LLVM_INCLUDE_TESTS)

--- a/llvm/include/llvm/BinaryFormat/Magic.h
+++ b/llvm/include/llvm/BinaryFormat/Magic.h
@@ -51,6 +51,7 @@ struct file_magic {
     wasm_object,         ///< WebAssembly Object file
     pdb,                 ///< Windows PDB debug info file
     tapi_file,           ///< Text-based Dynamic Library Stub file
+    cas_id,              ///< Embedded CAS ID
   };
 
   bool is_object() const { return V != unknown; }
@@ -73,6 +74,9 @@ file_magic identify_magic(StringRef magic);
 /// @returns errc::success if result has been successfully set, otherwise a
 ///          platform-specific error_code.
 std::error_code identify_magic(const Twine &path, file_magic &result);
+
+constexpr const char *casidObjectMagicPrefix = "CASID:";
+
 } // namespace llvm
 
 #endif

--- a/llvm/include/llvm/CAS/CASOutputBackend.h
+++ b/llvm/include/llvm/CAS/CASOutputBackend.h
@@ -27,8 +27,16 @@ public:
   Expected<std::unique_ptr<vfs::OutputFile>>
   createFileImpl(StringRef ResolvedPath, vfs::OutputConfig Config) override;
 
-  CASOutputBackend(std::shared_ptr<CASDB> CAS);
-  CASOutputBackend(CASDB &CAS);
+  /// \param CASIDOutputBackend if set it will be used to write out the file
+  /// contents as embedded CASID. Can be \p nullptr.
+  CASOutputBackend(
+      std::shared_ptr<CASDB> CAS,
+      IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend);
+  /// \param CASIDOutputBackend if set it will be used to write out the file
+  /// contents as embedded CASID. Can be \p nullptr.
+  CASOutputBackend(
+      CASDB &CAS,
+      IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend);
 
 private:
   ~CASOutputBackend();
@@ -37,6 +45,7 @@ private:
 
   CASDB &CAS;
   std::shared_ptr<CASDB> OwnedCAS;
+  IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend;
 };
 
 } // namespace cas

--- a/llvm/include/llvm/CAS/Utils.h
+++ b/llvm/include/llvm/CAS/Utils.h
@@ -12,12 +12,18 @@
 #include "llvm/Support/Error.h"
 
 namespace llvm {
+class MemoryBufferRef;
+
 namespace cas {
 
 class CASDB;
 class CASID;
 class NamedTreeEntry;
 class TreeRef;
+
+Expected<CASID> readCASIDBuffer(cas::CASDB &CAS, llvm::MemoryBufferRef Buffer);
+
+void writeCASIDBuffer(cas::CASDB &CAS, const CASID &ID, llvm::raw_ostream &OS);
 
 /// Visit each file entry in order, returning an error from \p Callback to stop
 /// early.

--- a/llvm/include/llvm/Object/ArchiveWriter.h
+++ b/llvm/include/llvm/Object/ArchiveWriter.h
@@ -20,11 +20,18 @@ namespace llvm {
 struct NewArchiveMember {
   std::unique_ptr<MemoryBuffer> Buf;
   StringRef MemberName;
+  /// This can be different than \p Buf in the case of getting the contents
+  /// from a CAS ID.
+  StringRef Contents;
   sys::TimePoint<std::chrono::seconds> ModTime;
   unsigned UID = 0, GID = 0, Perms = 0644;
 
   NewArchiveMember() = default;
   NewArchiveMember(MemoryBufferRef BufRef);
+
+  MemoryBufferRef getContentsBufferRef() const {
+    return MemoryBufferRef(Contents, Buf->getBufferIdentifier());
+  }
 
   static Expected<NewArchiveMember>
   getOldMember(const object::Archive::Child &OldMember, bool Deterministic);

--- a/llvm/lib/BinaryFormat/Magic.cpp
+++ b/llvm/lib/BinaryFormat/Magic.cpp
@@ -35,6 +35,8 @@ static bool startswith(StringRef Magic, const char (&S)[N]) {
 file_magic llvm::identify_magic(StringRef Magic) {
   if (Magic.size() < 4)
     return file_magic::unknown;
+  if (Magic.startswith(casidObjectMagicPrefix))
+    return file_magic::cas_id;
   switch ((unsigned char)Magic[0]) {
   case 0x00: {
     // COFF bigobj, CL.exe's LTO object file, or short import library file

--- a/llvm/lib/CAS/CASOutputBackend.cpp
+++ b/llvm/lib/CAS/CASOutputBackend.cpp
@@ -9,6 +9,7 @@
 #include "llvm/CAS/CASOutputBackend.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/CAS/CASDB.h"
+#include "llvm/CAS/Utils.h"
 #include "llvm/Support/AlignOf.h"
 #include "llvm/Support/Allocator.h"
 
@@ -27,20 +28,27 @@ public:
   CASOutputFile(StringRef Path, OnCloseType OnClose)
       : OutputFile(Path), OnClose(std::move(OnClose)) {}
 
+  static bool isNull(const OutputFile &File) {
+    return OutputFile::isNull(File);
+  }
+
 private:
   OnCloseType OnClose;
 };
 } // namespace
 
-CASOutputBackend::CASOutputBackend(std::shared_ptr<CASDB> CAS)
-    : CASOutputBackend(*CAS) {
+CASOutputBackend::CASOutputBackend(
+    std::shared_ptr<CASDB> CAS,
+    IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend)
+    : CASOutputBackend(*CAS, std::move(CASIDOutputBackend)) {
   this->OwnedCAS = std::move(CAS);
 }
 
-CASOutputBackend::CASOutputBackend(CASDB &CAS)
+CASOutputBackend::CASOutputBackend(
+    CASDB &CAS, IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend)
     : StableUniqueEntityAdaptorType(
           sys::path::Style::native /*FIXME: should be posix?*/),
-      CAS(CAS) {}
+      CAS(CAS), CASIDOutputBackend(std::move(CASIDOutputBackend)) {}
 
 CASOutputBackend::~CASOutputBackend() = default;
 
@@ -48,8 +56,34 @@ struct CASOutputBackend::PrivateImpl {
   HierarchicalTreeBuilder Builder;
 };
 
+static Error writeOutputAsCASID(CASDB &CAS, CASID &ID, StringRef ResolvedPath,
+                                llvm::vfs::OutputBackend &CASIDOutputBackend,
+                                vfs::OutputConfig Config) {
+  auto ExpOutFile = CASIDOutputBackend.createFile(ResolvedPath, Config);
+  if (!ExpOutFile)
+    return ExpOutFile.takeError();
+  auto OutFile = std::move(*ExpOutFile);
+  if (CASOutputFile::isNull(*OutFile))
+    return Error::success();
+
+  writeCASIDBuffer(CAS, ID, *OutFile->getOS());
+
+  SmallString<50> Contents;
+  {
+    raw_svector_ostream OS(Contents);
+    writeCASIDBuffer(CAS, ID, OS);
+  }
+  Expected<BlobRef> Blob = CAS.createBlob(Contents);
+  if (!Blob)
+    return Blob.takeError();
+  ID = *Blob;
+
+  return OutFile->close();
+}
+
 Expected<std::unique_ptr<vfs::OutputFile>>
-CASOutputBackend::createFileImpl(StringRef ResolvedPath, vfs::OutputConfig) {
+CASOutputBackend::createFileImpl(StringRef ResolvedPath,
+                                 vfs::OutputConfig Config) {
   if (!Impl)
     Impl = std::make_unique<PrivateImpl>();
 
@@ -58,7 +92,13 @@ CASOutputBackend::createFileImpl(StringRef ResolvedPath, vfs::OutputConfig) {
         Expected<BlobRef> Blob = CAS.createBlob(Bytes);
         if (!Blob)
           return Blob.takeError();
-        Impl->Builder.push(*Blob, TreeEntry::Regular, Path);
+        CASID ID = *Blob;
+        if (CASIDOutputBackend) {
+          if (Error E = writeOutputAsCASID(CAS, ID, Path, *CASIDOutputBackend,
+                                           Config))
+            return E;
+        }
+        Impl->Builder.push(ID, TreeEntry::Regular, Path);
         return Error::success();
       });
 }

--- a/llvm/lib/CAS/CMakeLists.txt
+++ b/llvm/lib/CAS/CMakeLists.txt
@@ -14,5 +14,5 @@ add_llvm_component_library(LLVMCAS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/CAS
 
   LINK_COMPONENTS
-  Support
+  BinaryFormat
 )

--- a/llvm/lib/Object/Binary.cpp
+++ b/llvm/lib/Object/Binary.cpp
@@ -81,7 +81,8 @@ Expected<std::unique_ptr<Binary>> object::createBinary(MemoryBufferRef Buffer,
   case file_magic::windows_resource:
     return WindowsResource::createWindowsResource(Buffer);
   case file_magic::pdb:
-    // PDB does not support the Binary interface.
+  case file_magic::cas_id:
+    // Does not support the Binary interface.
     return errorCodeToError(object_error::invalid_file_type);
   case file_magic::unknown:
   case file_magic::coff_cl_gl_object:

--- a/llvm/lib/Object/ObjectFile.cpp
+++ b/llvm/lib/Object/ObjectFile.cpp
@@ -146,6 +146,7 @@ ObjectFile::createObjectFile(MemoryBufferRef Object, file_magic Type,
   case file_magic::pdb:
   case file_magic::minidump:
   case file_magic::goff_object:
+  case file_magic::cas_id:
     return errorCodeToError(object_error::invalid_file_type);
   case file_magic::tapi_file:
     return errorCodeToError(object_error::invalid_file_type);

--- a/llvm/tools/llvm-ar/llvm-ar.cpp
+++ b/llvm/tools/llvm-ar/llvm-ar.cpp
@@ -672,7 +672,7 @@ static void addChildMember(std::vector<NewArchiveMember> &Members,
     }
   }
   if (FlattenArchive &&
-      identify_magic(NMOrErr->Buf->getBuffer()) == file_magic::archive) {
+      identify_magic(NMOrErr->Contents) == file_magic::archive) {
     Expected<std::string> FileNameOrErr = M.getFullName();
     failIfError(FileNameOrErr.takeError());
     object::Archive &Lib = readLibrary(*FileNameOrErr);
@@ -712,7 +712,7 @@ static void addMember(std::vector<NewArchiveMember> &Members,
   }
 
   if (FlattenArchive &&
-      identify_magic(NMOrErr->Buf->getBuffer()) == file_magic::archive) {
+      identify_magic(NMOrErr->Contents) == file_magic::archive) {
     object::Archive &Lib = readLibrary(FileName);
     // When creating thin archives, only flatten if the member is also thin.
     if (!Thin || Lib.isThin()) {
@@ -879,7 +879,7 @@ static object::Archive::Kind getDefaultForHost() {
 }
 
 static object::Archive::Kind getKindFromMember(const NewArchiveMember &Member) {
-  auto MemBufferRef = Member.Buf->getMemBufferRef();
+  auto MemBufferRef = Member.getContentsBufferRef();
   Expected<std::unique_ptr<object::ObjectFile>> OptionalObject =
       object::ObjectFile::createObjectFile(MemBufferRef);
 

--- a/llvm/tools/llvm-libtool-darwin/CMakeLists.txt
+++ b/llvm/tools/llvm-libtool-darwin/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(LLVM_LINK_COMPONENTS
   BinaryFormat
+  CAS
   Core
   Object
   Support

--- a/llvm/unittests/CAS/CASOutputBackendTest.cpp
+++ b/llvm/unittests/CAS/CASOutputBackendTest.cpp
@@ -35,7 +35,7 @@ TEST(CASOutputBackendTest, createFiles) {
   std::unique_ptr<CASDB> CAS = createInMemoryCAS();
   ASSERT_TRUE(CAS);
 
-  auto Outputs = makeIntrusiveRefCnt<CASOutputBackend>(*CAS);
+  auto Outputs = makeIntrusiveRefCnt<CASOutputBackend>(*CAS, nullptr);
 
   auto make = [&](StringRef Content, StringRef Path) {
     auto O = expectedToPointer(Outputs->createFile(Path));


### PR DESCRIPTION
There are changes beyond `lld` in order to enable writing out embedded CASIDs as objects and archives. Using such functionality we avoid writing out complete object files and archives on disk and make linker caching (and the build in general) more efficient.
However, note that enabling embedded CASIDs would make `lldb` not work since it won't be able to understand such object files.

In the PR there are individual commits that build on top of each other. Note that `lld` has testing coverage for the new functionality but tests for `clang` and `llvm-libtool-darwin` are currently missing.