### PR TITLE
X86 swifttailcc remove invalid check

### DIFF
--- a/llvm/lib/Target/X86/X86RegisterInfo.cpp
+++ b/llvm/lib/Target/X86/X86RegisterInfo.cpp
@@ -391,10 +391,6 @@ X86RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
       return IsWin64 ? CSR_Win64_SwiftError_SaveList
                      : CSR_64_SwiftError_SaveList;
 
-    if (MF->getFunction().getCallingConv() == CallingConv::SwiftTail)
-      return IsWin64 ? CSR_Win64_SwiftTail_SaveList
-                     : CSR_64_SwiftTail_SaveList;
-
     if (IsWin64)
       return HasSSE ? CSR_Win64_SaveList : CSR_Win64_NoSSE_SaveList;
     if (CallsEHReturn)
@@ -514,9 +510,6 @@ X86RegisterInfo::getCallPreservedMask(const MachineFunction &MF,
                      F.getAttributes().hasAttrSomewhere(Attribute::SwiftError);
     if (IsSwiftCC)
       return IsWin64 ? CSR_Win64_SwiftError_RegMask : CSR_64_SwiftError_RegMask;
-
-    if (MF.getFunction().getCallingConv() == CallingConv::SwiftTail)
-      return IsWin64 ? CSR_Win64_SwiftTail_RegMask : CSR_64_SwiftTail_RegMask;
 
     return IsWin64 ? CSR_Win64_RegMask : CSR_64_RegMask;
   }


### PR DESCRIPTION
MF can be caller or callee.

This is a cherry-pick of some of the code of 23eeb5aa5a16e6da41c36d349cd98073ec4c1654.

Upstream LLVM does not have this code i.e it matches the code after this
patch.
Probably things got confused during a merge.