### PR TITLE
clang -fdepscan: Fix option type for -fdepscan-share-parent

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5874,7 +5874,7 @@ def fdepscan_share_parent_EQ : Joined<["-"], "fdepscan-share-parent=">,
     HelpText<"Share state based on the PID of the parent command if the name"
              " matches."
              " See also -fdepscan-share-stop.">;
-def fdepscan_share_parent : Joined<["-"], "fdepscan-share-parent">,
+def fdepscan_share_parent : Flag<["-"], "fdepscan-share-parent">,
     Group<f_Group>,
     HelpText<"Share state based on the PID of the parent command."
              " See also -fdepscan-share-stop.">;

--- a/clang/test/CAS/fdepscan.c
+++ b/clang/test/CAS/fdepscan.c
@@ -22,6 +22,11 @@
 // RUN:     -fsyntax-only -x c %s                                      \
 // RUN: | FileCheck %s -allow-empty
 // CHECK-NOT: warning:
+//
+// RUN: not %clang -target x86_64-apple-macos11 -I %S/Inputs \
+// RUN:     -fdepscan-share-parents 2>&1                     \
+// RUN: | FileCheck %s -check-prefix=BAD-SPELLING
+// BAD-SPELLING: error: unknown argument '-fdepscan-share-parents'
 
 #include "test.h"
 


### PR DESCRIPTION
`-fdepscan-share-parent` should be a Flag, not Joined, since there's no
argument expected. Barely observable, but an option like
`-fdepscan-share-parents` would have been accepted before (giving an
(ignored) value of "s").