### PR TITLE
[lldb] Default to Swift if no REPL language is specified

### DIFF
--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -307,6 +307,15 @@ SBError Driver::ProcessArgs(const opt::InputArgList &args, bool &exiting) {
     m_option_data.m_repl = true;
   }
 
+#ifdef LLDB_ENABLE_SWIFT
+  // For the Swift fork, we want to default to Swift if no REPL language is
+  // specified.
+  if (m_option_data.m_repl &&
+      m_option_data.m_repl_lang == eLanguageTypeUnknown) {
+    m_option_data.m_repl_lang = eLanguageTypeSwift;
+  }
+#endif // LLDB_ENABLE_SWIFT
+
   if (auto *arg = args.getLastArg(OPT_repl_)) {
     m_option_data.m_repl = true;
     if (auto arg_value = arg->getValue())


### PR DESCRIPTION
Now that the REPL supports more than one language, we no longer
automatically pick Swift, because it's not the only supported language.
Change the driver to use Swift if no REPL language is specified.