### PR TITLE
CMake: Suppress warnings from llvm-libtool

### DIFF
--- a/compiler-rt/cmake/Modules/UseLibtool.cmake
+++ b/compiler-rt/cmake/Modules/UseLibtool.cmake
@@ -28,6 +28,12 @@ if(CMAKE_LIBTOOL)
     if(NOT LIBTOOL_VERSION VERSION_LESS "862")
       set(LIBTOOL_NO_WARNING_FLAG "-no_warning_for_no_symbols")
     endif()
+  elseif("${LIBTOOL_V_OUTPUT}" MATCHES "LLVM version ([0-9.]+).*")
+    string(REGEX REPLACE ".*LLVM version ([0-9.]+).*" "\\1" LIBTOOL_VERSION
+      ${LIBTOOL_V_OUTPUT})
+    if(NOT LIBTOOL_VERSION VERSION_LESS "13")
+      set(LIBTOOL_NO_WARNING_FLAG "-no_warning_for_no_symbols")
+    endif()
   endif()
 
   foreach(lang ${languages})

--- a/llvm/cmake/modules/UseLibtool.cmake
+++ b/llvm/cmake/modules/UseLibtool.cmake
@@ -28,6 +28,12 @@ if(CMAKE_LIBTOOL)
     if(NOT LIBTOOL_VERSION VERSION_LESS "862")
       set(LIBTOOL_NO_WARNING_FLAG "-no_warning_for_no_symbols")
     endif()
+  elseif("${LIBTOOL_V_OUTPUT}" MATCHES "LLVM version ([0-9.]+).*")
+    string(REGEX REPLACE ".*LLVM version ([0-9.]+).*" "\\1" LIBTOOL_VERSION
+      ${LIBTOOL_V_OUTPUT})
+    if(NOT LIBTOOL_VERSION VERSION_LESS "13")
+      set(LIBTOOL_NO_WARNING_FLAG "-no_warning_for_no_symbols")
+    endif()
   endif()
 
   foreach(lang ${languages})


### PR DESCRIPTION
cdcb60a820571f7384920fb534ce23e7568bfc03 added warnings for objects with
no symbols and the `-no_warning_for_no_symbols` flag. That commit landed
in LLVM 13.0.0. Update CMake configuration to use the flag.

Differential Revision: https://reviews.llvm.org/D115468