### PR TITLE
[lldb/Target] Refine source display warning for artificial locations (NFC)

### DIFF
--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -1909,14 +1909,13 @@ bool StackFrame::GetStatus(Stream &strm, bool show_frame_info, bool show_source,
             ConstString fn_name = m_sc.GetFunctionName();
 
             if (!fn_name.IsEmpty())
-              strm.Printf("Warning: the current PC is an artificial location "
-                          "in function %s.",
-                          fn_name.AsCString());
-            else
               strm.Printf(
-                  "Warning: the current PC is an artificial location "
-                  "but lldb couldn't associate it with a function in %s.",
-                  m_sc.line_entry.file.GetFilename().GetCString());
+                  "Note: this address is compiler-generated code in function "
+                  "%s that has no source code associated with it.",
+                  fn_name.AsCString());
+            else
+              strm.Printf("Note: this address is compiler-generated code that "
+                          "has no source code associated with it.");
             strm.EOL();
           }
         }

--- a/lldb/test/API/source-manager/TestSourceManager.py
+++ b/lldb/test/API/source-manager/TestSourceManager.py
@@ -281,7 +281,7 @@ class SourceManagerTestCase(TestBase):
 
         self.expect("run", RUN_SUCCEEDED,
                     substrs=['stop reason = breakpoint', '%s:%d' % (src_file,0),
-                             'Warning: the current PC is an artificial ',
-                             'location in function '
-                             ])
+                             'Note: this address is compiler-generated code in '
+                             'function', 'that has no source code associated '
+                             'with it.'])
 


### PR DESCRIPTION
This is a post-review update for D115313, to rephrase source display
warning messages for artificial locations, making them more
understandable for the end-user.

Differential Revision: https://reviews.llvm.org/D115461

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>