### PR TITLE
[lldb/Target] Slide source display for artificial locations at function start

### DIFF
--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -1909,14 +1909,13 @@ bool StackFrame::GetStatus(Stream &strm, bool show_frame_info, bool show_source,
             ConstString fn_name = m_sc.GetFunctionName();
 
             if (!fn_name.IsEmpty())
-              strm.Printf("Warning: the current PC is an artificial location "
-                          "in function %s.",
-                          fn_name.AsCString());
-            else
               strm.Printf(
-                  "Warning: the current PC is an artificial location "
-                  "but lldb couldn't associate it with a function in %s.",
-                  m_sc.line_entry.file.GetFilename().GetCString());
+                  "Note: this address is compiler-generated code in function "
+                  "%s that has no source code associated with it.",
+                  fn_name.AsCString());
+            else
+              strm.Printf("Note: this address is compiler-generated code that "
+                          "has no source code associated with it.");
             strm.EOL();
           }
         }

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -1892,14 +1892,33 @@ bool StackFrame::GetStatus(Stream &strm, bool show_frame_info, bool show_source,
       if (m_sc.comp_unit && m_sc.line_entry.IsValid()) {
         have_debuginfo = true;
         if (source_lines_before > 0 || source_lines_after > 0) {
+          uint32_t start_line = m_sc.line_entry.line;
+          if (!start_line && m_sc.function) {
+            FileSpec source_file;
+            m_sc.function->GetStartLineSourceInfo(source_file, start_line);
+          }
+
           size_t num_lines =
               target->GetSourceManager().DisplaySourceLinesWithLineNumbers(
-                  m_sc.line_entry.file, m_sc.line_entry.line,
-                  m_sc.line_entry.column, source_lines_before,
-                  source_lines_after, "->", &strm);
+                  m_sc.line_entry.file, start_line, m_sc.line_entry.column,
+                  source_lines_before, source_lines_after, "->", &strm);
           if (num_lines != 0)
             have_source = true;
           // TODO: Give here a one time warning if source file is missing.
+          if (!m_sc.line_entry.line) {
+            ConstString fn_name = m_sc.GetFunctionName();
+
+            if (!fn_name.IsEmpty())
+              strm.Printf("Warning: the current PC is an artificial location "
+                          "in function %s.",
+                          fn_name.AsCString());
+            else
+              strm.Printf(
+                  "Warning: the current PC is an artificial location "
+                  "but lldb couldn't associate it with a function in %s.",
+                  m_sc.line_entry.file.GetFilename().GetCString());
+            strm.EOL();
+          }
         }
       }
       switch (disasm_display) {

--- a/lldb/test/API/source-manager/TestSourceManager.py
+++ b/lldb/test/API/source-manager/TestSourceManager.py
@@ -280,7 +280,7 @@ class SourceManagerTestCase(TestBase):
 
         self.expect("run", RUN_SUCCEEDED,
                     substrs=['stop reason = breakpoint', '%s:%d' % (src_file,0),
-                             'Warning: the current PC is an artificial ',
-                             'location in function '
-                             ])
+                             'Note: this address is compiler-generated code in '
+                             'function', 'that has no source code associated '
+                             'with it.'])
 

--- a/lldb/test/API/source-manager/TestSourceManager.py
+++ b/lldb/test/API/source-manager/TestSourceManager.py
@@ -203,7 +203,6 @@ class SourceManagerTestCase(TestBase):
             SOURCE_DISPLAYED_CORRECTLY,
             substrs=['Hello world'])
 
-        
         # The '-b' option shows the line table locations from the debug information
         # that indicates valid places to set source level breakpoints.
 
@@ -269,3 +268,19 @@ class SourceManagerTestCase(TestBase):
                     substrs=['stopped',
                              'main-copy.c:%d' % self.line,
                              'stop reason = breakpoint'])
+
+    def test_artificial_source_location(self):
+        src_file = 'artificial_location.c'
+        d = {'C_SOURCES': src_file }
+        self.build(dictionary=d)
+
+        lldbutil.run_to_source_breakpoint(
+            self, 'main',
+            lldb.SBFileSpec(src_file, False))
+
+        self.expect("run", RUN_SUCCEEDED,
+                    substrs=['stop reason = breakpoint', '%s:%d' % (src_file,0),
+                             'Warning: the current PC is an artificial ',
+                             'location in function '
+                             ])
+

--- a/lldb/test/API/source-manager/artificial_location.c
+++ b/lldb/test/API/source-manager/artificial_location.c
@@ -1,0 +1,6 @@
+int foo() { return 42; }
+
+int main() {
+#line 0
+  return foo();
+}


### PR DESCRIPTION
It can happen that a line entry reports that some source code is located
at line 0. In DWARF, line 0 is a special location which indicates that
code has no 1-1 mapping with source.

When stopping in one of those artificial locations, lldb doesn't know which
line to display and shows the beginning of the file instead.

This patch mitigates this behaviour by checking if the current symbol context
of the line entry has a matching function, in which case, it slides the
source listing to the start of that function.

This patch also shows the user a warning explaining why lldb couldn't
show sources at that location.

rdar://83118425

Differential Revision: https://reviews.llvm.org/D115313

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>