### PR TITLE
[clang] Fix the crash when output file is using absolute path

### DIFF
--- a/clang/test/CAS/fcas-fs-result-cache.c
+++ b/clang/test/CAS/fcas-fs-result-cache.c
@@ -1,0 +1,27 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
+//
+// RUN: %clang -cc1 -triple x86_64-apple-macos11 -fcas builtin \
+// RUN:   -fcas-builtin-path %t/cas -fcas-fs @%t/casid -fcas-fs-result-cache \
+// RUN:   -Rcas-fs-result-cache-hit -emit-obj -o %t/output.o 2>&1 \
+// RUN:   | FileCheck %s --allow-empty --check-prefix=CACHE-MISS
+// RUN: ls %t/output.o && rm %t/output.o
+// RUN: %clang -cc1 -triple x86_64-apple-macos11 -fcas builtin \
+// RUN:   -fcas-builtin-path %t/cas -fcas-fs @%t/casid -fcas-fs-result-cache \
+// RUN:   -Rcas-fs-result-cache-hit -emit-obj -o %t/output.o 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CACHE-HIT
+// RUN: ls %t/output.o && rm %t/output.o
+// RUN: cd %t
+// RUN: %clang -cc1 -triple x86_64-apple-macos11 -fcas builtin \
+// RUN:   -fcas-builtin-path %t/cas -fcas-fs @%t/casid -fcas-fs-result-cache \
+// RUN:   -Rcas-fs-result-cache-hit -emit-obj -o output.o 2>&1 \
+// RUN:   | FileCheck %s --allow-empty --check-prefix=CACHE-MISS
+// RUN: ls %t/output.o && rm %t/output.o
+// RUN: %clang -cc1 -triple x86_64-apple-macos11 -fcas builtin \
+// RUN:   -fcas-builtin-path %t/cas -fcas-fs @%t/casid -fcas-fs-result-cache \
+// RUN:   -Rcas-fs-result-cache-hit -emit-obj -o output.o 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CACHE-HIT
+// RUN: ls %t/output.o
+//
+// CACHE-HIT: remark: result cache hit
+// CACHE-MISS-NOT: remark: result cache hit

--- a/llvm/include/llvm/CAS/CASOutputBackend.h
+++ b/llvm/include/llvm/CAS/CASOutputBackend.h
@@ -31,12 +31,14 @@ public:
   /// contents as embedded CASID. Can be \p nullptr.
   CASOutputBackend(
       std::shared_ptr<CASDB> CAS,
-      IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend);
+      IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend,
+      function_ref<std::string(StringRef)> CASPathRewriter);
   /// \param CASIDOutputBackend if set it will be used to write out the file
   /// contents as embedded CASID. Can be \p nullptr.
   CASOutputBackend(
       CASDB &CAS,
-      IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend);
+      IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend,
+      function_ref<std::string(StringRef)> CASPathRewriter);
 
 private:
   ~CASOutputBackend();
@@ -46,6 +48,7 @@ private:
   CASDB &CAS;
   std::shared_ptr<CASDB> OwnedCAS;
   IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend;
+  function_ref<std::string(StringRef)> CASPathRewriter;
 };
 
 } // namespace cas

--- a/llvm/unittests/CAS/CASOutputBackendTest.cpp
+++ b/llvm/unittests/CAS/CASOutputBackendTest.cpp
@@ -35,7 +35,8 @@ TEST(CASOutputBackendTest, createFiles) {
   std::unique_ptr<CASDB> CAS = createInMemoryCAS();
   ASSERT_TRUE(CAS);
 
-  auto Outputs = makeIntrusiveRefCnt<CASOutputBackend>(*CAS, nullptr);
+  auto Outputs = makeIntrusiveRefCnt<CASOutputBackend>(
+      *CAS, nullptr, [](StringRef Path) { return Path.str(); });
 
   auto make = [&](StringRef Content, StringRef Path) {
     auto O = expectedToPointer(Outputs->createFile(Path));


### PR DESCRIPTION
Fix the problem that clang -fdepscan cannot handle absolute path as
output by not hard code the output path in the CAS. Instead, let
cc1_main to remap the file path using the information in compiler
invocation.

rdar://86215990