### PR TITLE
[lldb] Bump macOS versions to 11 on the TestPlaygrounds test

### DIFF
--- a/lldb/test/API/lang/swift/playgrounds/Contents.swift
+++ b/lldb/test/API/lang/swift/playgrounds/Contents.swift
@@ -17,7 +17,7 @@ let b = 5
 
 a + b
 
-@available(macOS 10.11, iOS 8.0, tvOS 8.0, watchOS 6.0, *) func newAPI() -> Int {
+@available(macOS 11.1, iOS 8.0, tvOS 8.0, watchOS 6.0, *) func newAPI() -> Int {
   return 11
 }
 

--- a/lldb/test/API/lang/swift/playgrounds/TestPlaygrounds.py
+++ b/lldb/test/API/lang/swift/playgrounds/TestPlaygrounds.py
@@ -53,7 +53,7 @@ class TestSwiftPlaygrounds(TestBase):
                 version = '7.0'
             triple = '{}-{}-{}{}'.format(arch, vendor, os, version)
         else:
-            triple = '{}-apple-macosx10.10'.format(platform.machine())
+            triple = '{}-apple-macosx11.0'.format(platform.machine())
         return triple
 
     def get_run_triple(self):


### PR DESCRIPTION
This is necessary since macOS 11 was the first version to support ARM64,
    and the compiler will silently bump up the triple when something < 11 is
    specified.