### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/lldb/source/Version/CMakeLists.txt
+++ b/lldb/source/Version/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 # Configure the VCSVersion.inc file.
 set(vcs_version_inc "${CMAKE_CURRENT_BINARY_DIR}/VCSVersion.inc")
-set(generate_vcs_version_script "${LLVM_CMAKE_DIR}/GenerateVersionFromVCS.cmake")
+set(generate_vcs_version_script "${LLVM_CMAKE_PATH}/GenerateVersionFromVCS.cmake")
 
 find_first_existing_vc_file("${LLDB_SOURCE_DIR}" lldb_vc)
 


### PR DESCRIPTION
Fix the unified build by using `LLVM_CMAKE_PATH` rather than `LLVM_CMAKE_DIR`.  This matches the previous behaviour, and relies on the standalone build defining `LLVM_CMAKE_PATH` through `LLVM_CMAKE_DIR`.