### PR TITLE
[lldb] Check if language is supported before creating a REPL instance

### DIFF
--- a/lldb/include/lldb/Core/PluginManager.h
+++ b/lldb/include/lldb/Core/PluginManager.h
@@ -449,6 +449,8 @@ public:
 
   static REPLCreateInstance GetREPLCreateCallbackAtIndex(uint32_t idx);
 
+  static LanguageSet GetREPLSupportedLanguagesAtIndex(uint32_t idx);
+
   static LanguageSet GetREPLAllTypeSystemSupportedLanguages();
 
   // Some plug-ins might register a DebuggerInitializeCallback callback when

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -1346,6 +1346,12 @@ REPLCreateInstance PluginManager::GetREPLCreateCallbackAtIndex(uint32_t idx) {
   return GetREPLInstances().GetCallbackAtIndex(idx);
 }
 
+LanguageSet PluginManager::GetREPLSupportedLanguagesAtIndex(uint32_t idx) {
+  const auto &instances = GetREPLInstances().GetInstances();
+  return idx < instances.size() ? instances[idx].supported_languages
+                                : LanguageSet();
+}
+
 LanguageSet PluginManager::GetREPLAllTypeSystemSupportedLanguages() {
   const auto &instances = GetREPLInstances().GetInstances();
   LanguageSet all;

--- a/lldb/source/Expression/REPL.cpp
+++ b/lldb/source/Expression/REPL.cpp
@@ -39,7 +39,11 @@ lldb::REPLSP REPL::Create(Status &err, lldb::LanguageType language,
   lldb::REPLSP ret;
 
   while (REPLCreateInstance create_instance =
-             PluginManager::GetREPLCreateCallbackAtIndex(idx++)) {
+             PluginManager::GetREPLCreateCallbackAtIndex(idx)) {
+    LanguageSet supported_languages =
+        PluginManager::GetREPLSupportedLanguagesAtIndex(idx++);
+    if (!supported_languages[language])
+      continue;
     ret = (*create_instance)(err, language, debugger, target, repl_options);
     if (ret) {
       break;

--- a/lldb/test/Shell/REPL/Basic.test
+++ b/lldb/test/Shell/REPL/Basic.test
@@ -1,0 +1,10 @@
+// Basic sanity checking of the REPL.
+
+// RUN: %lldb --repl --repl-language c++ 2>&1 | FileCheck %s --check-prefix=CPP
+// CPP: error: must have a target to create a REPL
+
+// RUN: %lldb --repl --repl-language python 2>&1 | FileCheck %s --check-prefix=PYTHON
+// PYTHON: error: couldn't find a REPL for python
+
+// RUN: not %lldb --repl --repl-language bogus 2>&1 | FileCheck %s --check-prefix=BOGUS
+// BOGUS: error: Unrecognized language name: "bogus"


### PR DESCRIPTION
Currently, we'll try to instantiate a ClangREPL for every known
language. The plugin manager already knows what languages it supports,
so rely on that to only instantiate a REPL when we know the requested
language is supported.

rdar://86439474

Differential revision: https://reviews.llvm.org/D115698

(cherry picked from commit 100863ccd8d41091f90749ba76d91f6dfafdde57)
