### PR TITLE
[llvm] Include LLVM_ENABLE_RUNTIMES in the cross compilation invocation

### DIFF
--- a/llvm/cmake/modules/CrossCompile.cmake
+++ b/llvm/cmake/modules/CrossCompile.cmake
@@ -57,6 +57,8 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
          "${LLVM_ENABLE_PROJECTS}")
   string(REPLACE ";" "$<SEMICOLON>" llvm_external_projects_arg
          "${LLVM_EXTERNAL_PROJECTS}")
+  string(REPLACE ";" "$<SEMICOLON>" llvm_enable_runtimes_arg
+         "${LLVM_ENABLE_RUNTIMES}")
 
   set(external_project_source_dirs)
   foreach(project ${LLVM_EXTERNAL_PROJECTS})
@@ -77,6 +79,7 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
         -DLLVM_TARGET_ARCH="${LLVM_TARGET_ARCH}"
         -DLLVM_ENABLE_PROJECTS="${llvm_enable_projects_arg}"
         -DLLVM_EXTERNAL_PROJECTS="${llvm_external_projects_arg}"
+        -DLLVM_ENABLE_RUNTIMES="${llvm_enable_runtimes_arg}"
         ${external_project_source_dirs}
         -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN="${LLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN}"
         ${build_type_flags} ${linker_flag} ${external_clang_dir}


### PR DESCRIPTION
Forward the LLVM_ENABLE_RUNTIMES cmake variable in the cross compilation
invocation.

Now that passing libcxx must be specified in LLVM_ENABLE_RUNTIMES
instead of LLVM_ENABLE_PROJECTS, the LLDB's sanity check for libcxx
trips up (in the cross compilation case) because the runtimes are not
forwarded. This patch fixes that.

Differential revision: https://reviews.llvm.org/D112855

(cherry picked from commit 80405df30749d9d2002d84bb312ae38edf19a7bf)
