### PR TITLE
[lldb] Make Swift the default language for the 'repl' command

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -397,7 +397,11 @@ void CommandInterpreter::Initialize() {
       po->SetHelpLong("");
     }
 
-    AddAlias("repl", cmd_obj_sp, "--repl -- ");
+#ifdef LLDB_ENABLE_SWIFT
+    // FIXME: Upstream the REPL command together with support for a default
+    // language, similar to what exists for scripting.
+    AddAlias("repl", cmd_obj_sp, "--repl --language swift -- ");
+#endif
 
     CommandAlias *parray_alias =
         AddAlias("parray", cmd_obj_sp, "--element-count %1 --");


### PR DESCRIPTION
The `repl` command only exists in the downstream fork. Make it default
for Swift for now, until we have a mechanism to specify a default REPL
language, similar to how we have a default scripting language.