### PR TITLE
Fix dynamic import of libraries in Xcode playgrounds.

### DIFF
--- a/lldb/include/lldb/Expression/UserExpression.h
+++ b/lldb/include/lldb/Expression/UserExpression.h
@@ -266,10 +266,8 @@ public:
       0x1001; ///< ValueObject::GetError() returns this if there is no result
               /// from the expression.
 
-  const char *GetFixedText() {
-    if (m_fixed_text.empty())
-      return nullptr;
-    return m_fixed_text.c_str();
+  llvm::StringRef GetFixedText() {
+    return m_fixed_text;
   }
 
 protected:

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -708,6 +708,20 @@ ifneq "$(DYLIB_HIDE_SWIFTMODULE)" ""
             -emit-library $(DYLIB_SWIFT_FLAGS) -o $@ \
             $(patsubst %.swiftmodule.o,,$(DYLIB_OBJECTS))
 else
+ifneq "$(FRAMEWORK)" ""
+	mkdir -p $(FRAMEWORK).framework/Versions/A/Headers
+	mkdir -p $(FRAMEWORK).framework/Versions/A/Modules
+	mkdir -p $(FRAMEWORK).framework/Versions/A/Resources
+ifneq "$(MODULENAME)" ""
+	mkdir -p $(FRAMEWORK).framework/Versions/A/Modules/$(MODULENAME).swiftmodule
+	cp -r $(MODULENAME).swiftmodule $(FRAMEWORK).framework/Versions/A/Modules/$(MODULENAME).swiftmodule/$(ARCH).swiftmodule
+endif
+	(cd $(FRAMEWORK).framework/Versions; ln -sf A Current)
+	(cd $(FRAMEWORK).framework/; ln -sf Versions/A/Headers Headers)
+	(cd $(FRAMEWORK).framework/; ln -sf Versions/A/Modules Modules)
+	(cd $(FRAMEWORK).framework/; ln -sf Versions/A/Resources Resources)
+	(cd $(FRAMEWORK).framework/; ln -sf Versions/A/$(FRAMEWORK) $(FRAMEWORK))
+endif
 	$(SWIFTC) $(patsubst -g,,$(SWIFTFLAGS)) \
             -emit-library $(DYLIB_SWIFT_FLAGS) -o $@ $(DYLIB_OBJECTS)
 endif

--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -262,9 +262,7 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
   if (fixed_expression == nullptr)
     fixed_expression = &tmp_fixed_expression;
 
-  const char *fixed_text = user_expression_sp->GetFixedText();
-  if (fixed_text != nullptr)
-    fixed_expression->append(fixed_text);
+  *fixed_expression = user_expression_sp->GetFixedText().str();
 
   // If there is a fixed expression, try to parse it:
   if (!parse_success) {
@@ -293,8 +291,8 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
         } else {
           // The fixed expression also didn't parse. Let's check for any new
           // Fix-Its we could try.
-          if (fixed_expression_sp->GetFixedText()) {
-            *fixed_expression = fixed_expression_sp->GetFixedText();
+          if (!fixed_expression_sp->GetFixedText().empty()) {
+            *fixed_expression = fixed_expression_sp->GetFixedText().str();
           } else {
             // Fixed expression didn't compile without a fixit, don't retry and
             // don't tell the user about it.

--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -264,6 +264,12 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
 
   *fixed_expression = user_expression_sp->GetFixedText().str();
 
+  // Swift Playgrounds disable fixits, but SwiftASTContext may get
+  // poisoned (see SwiftASTContextForExpressions::ModulesDidLoad())
+  // during expression evaluation. When this happens we want to re-run
+  // the same expression with a freshly initialized SwiftASTContext.
+  bool is_replay = !options.GetAutoApplyFixIts() && expr == *fixed_expression;
+
   // If there is a fixed expression, try to parse it:
   if (!parse_success) {
     // Delete the expression that failed to parse before attempting to parse
@@ -271,8 +277,9 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
     user_expression_sp.reset();
 
     execution_results = lldb::eExpressionParseError;
-    if (!fixed_expression->empty() && options.GetAutoApplyFixIts()) {
-      const uint64_t max_fix_retries = options.GetRetriesWithFixIts();
+    if (!fixed_expression->empty() &&
+        (options.GetAutoApplyFixIts() || is_replay)) {
+      const uint64_t max_fix_retries = is_replay ? 1 : options.GetRetriesWithFixIts();
       for (uint64_t i = 0; i < max_fix_retries; ++i) {
         // Try parsing the fixed expression.
         lldb::UserExpressionSP fixed_expression_sp(

--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -271,8 +271,7 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
     user_expression_sp.reset();
 
     execution_results = lldb::eExpressionParseError;
-    if (fixed_expression && !fixed_expression->empty() &&
-        options.GetAutoApplyFixIts()) {
+    if (!fixed_expression->empty() && options.GetAutoApplyFixIts()) {
       const uint64_t max_fix_retries = options.GetRetriesWithFixIts();
       for (uint64_t i = 0; i < max_fix_retries; ++i) {
         // Try parsing the fixed expression.

--- a/lldb/test/API/lang/swift/playgrounds/Dylib.swift
+++ b/lldb/test/API/lang/swift/playgrounds/Dylib.swift
@@ -1,0 +1,2 @@
+
+public func f() -> String { return "Hello from the Dylib!" }

--- a/lldb/test/API/lang/swift/playgrounds/Makefile
+++ b/lldb/test/API/lang/swift/playgrounds/Makefile
@@ -6,7 +6,7 @@ SWIFT_SOURCES = PlaygroundStub.swift
 LD_EXTRAS := -Xlinker -rpath -Xlinker /usr/lib/swift
 LD_EXTRAS += -L. -lPlaygroundsRuntime
 
-PlaygroundStub: libPlaygroundsRuntime.dylib
+PlaygroundStub: libPlaygroundsRuntime.dylib Dylib.framework
 
 include Makefile.rules
 
@@ -15,3 +15,9 @@ libPlaygroundsRuntime.dylib: PlaygroundsRuntime.swift
 		DYLIB_SWIFT_SOURCES=PlaygroundsRuntime.swift \
 		DYLIB_NAME=PlaygroundsRuntime
 
+Dylib.framework: Dylib.swift
+	$(MAKE) -f $(MAKEFILE_RULES) \
+		FRAMEWORK=Dylib \
+		DYLIB_SWIFT_SOURCES=Dylib.swift \
+		DYLIB_NAME=Dylib \
+		SWIFTFLAGS_EXTRAS="-Xcc -DNEW_OPTION_FROM_DYLIB=1"


### PR DESCRIPTION
The Swift expression parser uses the fixit mechanism to force
SwiftASTContext to be reinitialized if it contains fatal
errors. Playgrounds disable fixit application and thus defeated the
mechanism. This became a problem after the late dylib notification was
fixed in 1348ae3. This patch detects
the situation where the fixit is identical to the original expression
and makes one retry even if fixits are disabled.

rdar://85431564