### PR TITLE
[lldb] Workaround ManualDWARFIndex deadlock in GetDwoSymbolFileForCompileUnit

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
@@ -98,11 +98,8 @@ void ManualDWARFIndex::Index() {
   // to wait until all compile units have been indexed in case a DIE in one
   // compile unit refers to another and the indexes accesses those DIEs.
   for (size_t i = 0; i < units_to_index.size(); ++i)
-    extract_fn(i);
-  // This call can deadlock because we are sometimes holding the module lock.
-  //  for (size_t i = 0; i < units_to_index.size(); ++i)
-  //    pool.async(extract_fn, i);
-  //  pool.wait();
+    pool.async(extract_fn, i);
+  pool.wait();
 
   // Now create a task runner that can index each DWARF unit in a
   // separate thread so we can index quickly.

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -1785,6 +1785,10 @@ SymbolFileDWARF::GetDwoSymbolFileForCompileUnit(
   if (!FileSystem::Instance().Exists(dwo_file))
     return nullptr;
 
+  if (dwo_file.GetFileNameExtension() == ".pcm" ||
+      dwo_file.GetFileNameExtension() == ".pch")
+    return nullptr;
+
   const lldb::offset_t file_offset = 0;
   DataBufferSP dwo_file_data_sp;
   lldb::offset_t dwo_file_data_offset = 0;


### PR DESCRIPTION
LLDB has a long-standing deadlock when extracting DWARF compile units,
which we worked around by doing the extracting sequentially instead of
in parallel. Due to a recent upstream change [1] that made loading .dwo
files more lazy, the deadlock moved from the extraction stage to the
parsing stage.

The deadlock in question is caused by GetDwoSymbolFileForCompileUnit,
which follows the `DW_AT_dwo_name` used by gmodules to try to parse a
`.pcm` file for which we already hold the module lock.

As a short-term workaround, I'm filtering out .pcm and .pch files in
GetDwoSymbolFileForCompileUnit. A more structural solution could include
emitting accelerator tables for the JIT object so we don't have to build
a manual index or ensuring that we don't try to reparse a symbol file
that's already in flight.

[1] https://reviews.llvm.org/rGfb09f365ae28920666ddfd466fb09b44b9cb7be1