### PR TITLE
[lldb] Make functions that take SwiftASTContext in TSSTyperef not static

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -257,7 +257,7 @@ public:
   }
 
   void DumpTyperef(CompilerType type, TypeSystemSwiftTypeRef *module_holder,
-                    SwiftASTContext *swift_ast_context, Stream *s) {
+                   Stream *s) {
     STUB_LOG();
   }
 
@@ -2041,10 +2041,9 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(
 }
 
 void SwiftLanguageRuntime::DumpTyperef(CompilerType type,
-                                        TypeSystemSwiftTypeRef *module_holder,
-                                        SwiftASTContext *swift_ast_context,
-                                        Stream *s) {
-  FORWARD(DumpTyperef, type, module_holder, swift_ast_context, s);
+                                       TypeSystemSwiftTypeRef *module_holder,
+                                       Stream *s) {
+  FORWARD(DumpTyperef, type, module_holder, s);
 }
 
 TypeAndOrName

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -151,7 +151,7 @@ public:
                                             const SymbolContext *sc = nullptr);
 
   void DumpTyperef(CompilerType type, TypeSystemSwiftTypeRef *module_holder,
-             SwiftASTContext *swift_ast_context, Stream *s);
+                   Stream *s);
   class MethodName {
   public:
     enum Type {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1947,8 +1947,7 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Protocol(
   }
 
   const swift::reflection::TypeRef *protocol_typeref =
-      GetTypeRef(protocol_type, &tss->GetTypeSystemSwiftTypeRef(),
-                 tss->GetSwiftASTContext());
+      GetTypeRef(protocol_type, &tss->GetTypeSystemSwiftTypeRef());
   if (!protocol_typeref) {
     if (log)
       log->Printf("Could not get protocol typeref");
@@ -2501,12 +2500,11 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_IndirectEnumCase(
 }
 
 void SwiftLanguageRuntimeImpl::DumpTyperef(
-    CompilerType type, TypeSystemSwiftTypeRef *module_holder,
-    SwiftASTContext *swift_ast_context, Stream *s) {
+    CompilerType type, TypeSystemSwiftTypeRef *module_holder, Stream *s) {
   if (!s)
     return;
 
-  const auto *typeref = GetTypeRef(type, module_holder, swift_ast_context);
+  const auto *typeref = GetTypeRef(type, module_holder);
   if (!typeref)
     return;
 
@@ -2960,8 +2958,7 @@ lldb::addr_t SwiftLanguageRuntimeImpl::FixupAddress(lldb::addr_t addr,
 
 const swift::reflection::TypeRef *
 SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type,
-                                     TypeSystemSwiftTypeRef *module_holder,
-                                     SwiftASTContext *swift_ast_context) {
+                                     TypeSystemSwiftTypeRef *module_holder) {
   // Demangle the mangled name.
   swift::Demangle::Demangler dem;
   ConstString mangled_name = type.GetMangledTypeName();
@@ -2969,8 +2966,7 @@ SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type,
   if (!ts)
     return nullptr;
   swift::Demangle::NodePointer node =
-      TypeSystemSwiftTypeRef::GetCanonicalDemangleTree(
-          module_holder, swift_ast_context, dem, mangled_name.GetStringRef());
+      module_holder->GetCanonicalDemangleTree(dem, mangled_name.GetStringRef());
   if (!node)
     return nullptr;
 
@@ -3013,8 +3009,8 @@ SwiftLanguageRuntimeImpl::GetSwiftRuntimeTypeInfo(
   // BindGenericTypeParameters imports the type into the scratch
   // context, but we need to resolve (any DWARF links in) the typeref
   // in the original module.
-  const swift::reflection::TypeRef *type_ref = GetTypeRef(
-      type, &ts->GetTypeSystemSwiftTypeRef(), ts->GetSwiftASTContext());
+  const swift::reflection::TypeRef *type_ref =
+      GetTypeRef(type, &ts->GetTypeSystemSwiftTypeRef());
   if (!type_ref)
     return nullptr;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -180,7 +180,7 @@ public:
   bool IsABIStable();
 
   void DumpTyperef(CompilerType type, TypeSystemSwiftTypeRef *module_holder,
-             SwiftASTContext *swift_ast_context, Stream *s);
+                   Stream *s);
   /// Returned by \ref ForEachSuperClassType. Not every user of \p
   /// ForEachSuperClassType needs all of these. By returning this
   /// object we call into the runtime only when needed.
@@ -242,8 +242,7 @@ public:
 protected:
   /// Use the reflection context to build a TypeRef object.
   const swift::reflection::TypeRef *
-  GetTypeRef(CompilerType type, TypeSystemSwiftTypeRef *module_holder,
-             SwiftASTContext *swift_ast_context);
+  GetTypeRef(CompilerType type, TypeSystemSwiftTypeRef *module_holder);
 
   /// If \p instance points to a Swift object, retrieve its
   /// RecordTypeInfo and pass it to the callback \p fn. Repeat the

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -284,10 +284,9 @@ public:
                     swift::Demangle::NodePointer node);
 
   /// Return the canonicalized Demangle tree for a Swift mangled type name.
-  static swift::Demangle::NodePointer GetCanonicalDemangleTree(
-      TypeSystemSwiftTypeRef *module_holder, SwiftASTContext *target_holder,
-      swift::Demangle::Demangler &dem, llvm::StringRef mangled_name);
-
+  swift::Demangle::NodePointer
+  GetCanonicalDemangleTree(swift::Demangle::Demangler &dem,
+                           llvm::StringRef mangled_name);
   /// Return the base name of the topmost nominal type.
   static llvm::StringRef GetBaseName(swift::Demangle::NodePointer node);
 
@@ -344,6 +343,30 @@ private:
   clang::api_notes::APINotesManager *
   GetAPINotesManager(ClangExternalASTSourceCallbacks *source, unsigned id);
 
+  lldb::TypeSP LookupClangType(llvm::StringRef name);
+
+  CompilerType LookupClangForwardType(llvm::StringRef name);
+
+  std::pair<swift::Demangle::NodePointer, CompilerType>
+  ResolveTypeAlias(swift::Demangle::Demangler &dem,
+                   swift::Demangle::NodePointer node,
+                   bool prefer_clang_types = false);
+
+  swift::Demangle::NodePointer
+  GetCanonicalNode(swift::Demangle::Demangler &dem,
+                   swift::Demangle::NodePointer node);
+
+  uint32_t CollectTypeInfo(swift::Demangle::Demangler &dem,
+                           swift::Demangle::NodePointer node,
+                           bool &unresolved_typealias,
+                           bool generic_walk = false);
+
+  swift::Demangle::NodePointer
+  GetClangTypeNode(CompilerType clang_type, swift::Demangle::Demangler &dem);
+
+  swift::Demangle::NodePointer
+  GetClangTypeTypeNode(swift::Demangle::Demangler &dem,
+                       CompilerType clang_type);
 #ifndef NDEBUG
   /// Check whether the type being dealt with is tricky to validate due to
   /// discrepancies between TypeSystemSwiftTypeRef and SwiftASTContext.


### PR DESCRIPTION
This allows for SwiftASTContext to be initialized only when necessary
(in TypeSystemSwiftTypeRef).

(cherry picked from commit bd47e7c395fd26d7fd2868c8128bf2efa34e383a)