### PR TITLE
[lldb] Log modules using internal and public SDKs

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1771,12 +1771,24 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
 
       // Force parsing of the CUs to extract the SDK info.
       XcodeSDK sdk;
+      bool found_public_sdk = false;
+      bool found_internal_sdk = false;
       if (SymbolFile *sym_file = module.GetSymbolFile())
-        for (unsigned i = 0; i < sym_file->GetNumCompileUnits(); ++i) {
+        for (unsigned i = 0; i < sym_file->GetNumCompileUnits(); ++i)
           if (auto cu_sp = sym_file->GetCompileUnitAtIndex(i))
-            if (cu_sp->GetLanguage() == lldb::eLanguageTypeSwift)
-              sdk.Merge(sym_file->ParseXcodeSDK(*cu_sp));
-        }
+            if (cu_sp->GetLanguage() == lldb::eLanguageTypeSwift) {
+              auto cu_sdk = sym_file->ParseXcodeSDK(*cu_sp);
+              sdk.Merge(cu_sdk);
+              bool is_internal_sdk = cu_sdk.IsAppleInternalSDK();
+              found_public_sdk |= !is_internal_sdk;
+              found_internal_sdk |= is_internal_sdk;
+            }
+
+      if (found_public_sdk && found_internal_sdk)
+        HEALTH_LOG_PRINTF("Unsupported mixing of public and internal SDKs in "
+                          "'%s'. Mixed use of SDKs indicates use of different "
+                          "toolchains, which is not supported.",
+                          module.GetFileSpec().GetFilename().GetCString());
 
       std::string sdk_path = HostInfo::GetXcodeSDKPath(sdk).str();
       LOG_PRINTF(LIBLLDB_LOG_TYPES, "Host SDK path for sdk %s is %s.",


### PR DESCRIPTION
Log when a module (executable or dylib) has been built with a mix of object files from public and internal SDKs. This identifies mixed use _within_ a module (which could happen when linking in a separately built static library). This does not identify mixed SDK use across modules, that could be done as a separate check.

rdar://82982242

(cherry picked from PR https://github.com/apple/llvm-project/pull/3720)