### PR TITLE
plugins: make swiftCompilerModules optional

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
@@ -37,7 +37,6 @@ add_lldb_library(lldbPluginExpressionParserSwift PLUGIN
     swiftSIL
     swiftSILOptimizer
     swiftSerialization
-    swiftCompilerModules
     clangAST
     clangBasic
     clangRewrite
@@ -46,3 +45,7 @@ add_lldb_library(lldbPluginExpressionParserSwift PLUGIN
     Support
     Core
   )
+if(TARGET swiftCompilerModules)
+  target_link_libraries(lldbPluginExpressionParserSwift PRIVATE
+    swiftCompilerModules)
+endif()


### PR DESCRIPTION
This is not always available, and is definitely not yet available on
Windows due to a completely broken build system.  This optionalizes the
dependency to repair the Windows build.