### PR TITLE
swift-lldb cmake: fix a build problem when BOOTSTRAPPING=OFF

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
@@ -2,6 +2,10 @@ if(NOT LLDB_BUILT_STANDALONE)
   set(tablegen_deps intrinsics_gen)
 endif()
 
+if (NOT BOOTSTRAPPING_MODE)
+  add_library(swiftCompilerModules ALIAS swiftCompilerStub)
+endif()
+
 add_lldb_library(lldbPluginExpressionParserSwift PLUGIN
   SwiftASTManipulator.cpp
   SwiftExpressionParser.cpp


### PR DESCRIPTION
Need to add an alias from wiftCompilerModules to swiftCompilerStub