### PR TITLE
lldb: fix the build after #3537

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
@@ -2,7 +2,7 @@ if(NOT LLDB_BUILT_STANDALONE)
   set(tablegen_deps intrinsics_gen)
 endif()
 
-if (NOT BOOTSTRAPPING_MODE)
+if (NOT BOOTSTRAPPING_MODE AND LLDB_BUILT_STANDALONE)
   add_library(swiftCompilerModules ALIAS swiftCompilerStub)
 endif()
 


### PR DESCRIPTION
Fix the unified build; this should repair the CI: https://ci-external.swift.org/job/oss-swift-windows-toolchain-x86_64-vs2019/562/