### PR TITLE
[CMake] Generate a lldbinit file to remap path

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -236,6 +236,31 @@ options directly.
   (cd build && cmake ... && ninja)
 ```
 
+#### Try debugging just built compiler
+
+CMake on a CAS-aware branch creates a .lldbinit file in the build directory
+which helps to map the canonicalized path back to the path on disk:
+
+```
+% lldb -- $COMMAND
+
+(lldb) command source $BUILD_DIR/.lldbinit
+```
+
+or source from lldb commandline:
+
+```
+% lldb --source $BUILD_DIR/.lldbinit -- $COMMAND
+```
+
+or if your CWD is in `$BUILD_DIR`, just run:
+
+```
+% lldb --local-lldbinit -- $COMMAND
+```
+
+You can also manually do that by using `settings set target.source-map` command.
+
 #### Build swift compiler
 
 In order to build swift compiler from `main` branch which is not CAS aware, do:

--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -1272,6 +1272,11 @@ if(LLVM_ENABLE_EXPERIMENTAL_DEPSCAN)
     append("-fdepscan-prefix-map=${source_root}=/^source" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
     append("-fdepscan-prefix-map=${CMAKE_BINARY_DIR}=/^build" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
 
+    # Create a LLDB init file to remap prefix map back to original path.
+    # TODO: Remap SDK and toolchain path.
+    set(lldb_prefix_remap_init_file "${CMAKE_BINARY_DIR}/.lldbinit")
+    file(WRITE ${lldb_prefix_remap_init_file} "settings set target.source-map /^source ${source_root} /^build ${CMAKE_BINARY_DIR}")
+
     check_c_compiler_flag("-greproducible" SUPPORTS_GREPRODUCIBLE)
     if(SUPPORTS_GREPRODUCIBLE)
       append("-greproducible"


### PR DESCRIPTION
Create a .lldbinit file in the build directory that remaps the
canonicalized path used by compiler back to the path on disk.