### PR TITLE
[lldb] Use specified LD_EXTRAS when building TestSwiftCPPExceptionsIn…

### DIFF
--- a/lldb/test/API/repl/cpp_exceptions/Makefile
+++ b/lldb/test/API/repl/cpp_exceptions/Makefile
@@ -16,6 +16,7 @@ libCppLib.dylib: CppLib/CppLib.cpp
 libWrapper.dylib: libCppLib.dylib
 	$(MAKE) -f $(MAKEFILE_RULES) \
 		DYLIB_NAME=Wrapper DYLIB_SWIFT_SOURCES=wrapper.swift \
+		LD_EXTRAS="$(LD_EXTRAS)" \
 		SWIFTFLAGS_EXTRAS="-I$(SRCDIR) -L. -lCppLib -module-link-name Wrapper"
 
 # Make sure Makefile and test agree on the SDK.


### PR DESCRIPTION
…REPL

(cherry picked from commit 8106a567c75e22dc0b6f80f22315a6a46d9e7282)