### PR TITLE
[lldb] Remove some unnecessary scoped timers in TypeSystemSwiftTypeRef

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -342,7 +342,6 @@ static swift::Demangle::NodePointer GetType(swift::Demangle::NodePointer n) {
 /// Demangle a mangled type name and return the child of the \p Type node.
 static swift::Demangle::NodePointer
 GetDemangledType(swift::Demangle::Demangler &dem, StringRef name) {
-  LLDB_SCOPED_TIMER();
   return GetType(dem.demangleSymbol(name));
 }
 
@@ -641,7 +640,6 @@ TypeSystemSwiftTypeRef::GetCanonicalNode(swift::Demangle::Demangler &dem,
 /// (type aliases resolved) type.
 swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetCanonicalDemangleTree(
     swift::Demangle::Demangler &dem, StringRef mangled_name) {
-  LLDB_SCOPED_TIMER();
   auto *node = dem.demangleSymbol(mangled_name);
   return GetCanonicalNode(dem, node);
 }


### PR DESCRIPTION
In Instruments traces, these two timers show to be somewhat high firing, while also having quite short durations.

| Name | Count | Duration | Min Duration | Avg Duration | Std Dev Duration | Max Duration |
| --- | --- | --- | --- | --- | --- | --- | 
| `GetCanonicalDemangleTree` | 4,214 | 224.15 ms | 9.24 µs | 53.19 µs | 61.87 µs | 620.08 µs |
| `GetDemangledType` | 3,849 | 141.02 ms | 8.51 µs | 36.64 µs | 13.83 µs | 142.81 µs |

These don't seem to bring any value, and do add noise and overhead to the trace. For that reason, I think they can be deleted. See also #3637.

(cherry picked from #3743)