### PR TITLE
[lldb] Fix SymbolFile/DWARF/x86/dwp.s

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -3315,9 +3315,11 @@ VariableSP SymbolFileDWARF::ParseVariableDIE(const SymbolContext &sc,
     }
   }
 
+#ifdef LLDB_ENABLE_SWIFT
   if (tag == DW_TAG_variable && mangled &&
       sc.comp_unit->GetLanguage() == eLanguageTypeSwift)
     mangled = nullptr;
+#endif
 
   // Prefer DW_AT_location over DW_AT_const_value. Both can be emitted e.g.
   // for static constexpr member variables -- DW_AT_const_value will be

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/dwp.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/dwp.s
@@ -10,40 +10,40 @@
 # CHECK: (INT3) A = 3
 
 # CHECK-LABEL: image lookup -v -n F1
-# CHECK: CompileUnit: id = {0x00000001}, file = "1.c", language = "<not loaded>"
+# CHECK: CompileUnit: id = {0x00000001}, file = "1.c", language = "{{<not loaded>|unknown}}"
 # CHECK: Function: {{.*}}, name = "F1", range = [0x0000000000000001-0x0000000000000002)
 # CHECK: Variable: {{.*}}, name = "x", type = "int", location = DW_OP_reg1 RDX
 
 # SYMBOLS:      Compile units:
-# SYMBOLS-NEXT: CompileUnit{0x00000000}, language = "<not loaded>", file = '0.c'
+# SYMBOLS-NEXT: CompileUnit{0x00000000}, language = "{{<not loaded>|unknown}}", file = '0.c'
 # SYMBOLS-NEXT:   Variable{{.*}}, name = "A", {{.*}}, location = DW_OP_GNU_addr_index 0x0
 # SYMBOLS-NEXT:   Function{{.*}}, demangled = F0
 # SYMBOLS-NEXT:   Block{{.*}}, ranges = [0x00000000-0x00000001)
 # SYMBOLS-NEXT:     Variable{{.*}}, name = "x", {{.*}}, location = 
 # SYMBOLS-NEXT:       DW_LLE_startx_length   (0x0000000000000001, 0x0000000000000001): DW_OP_reg0 RAX
 # SYMBOLS-EMPTY:
-# SYMBOLS-NEXT: CompileUnit{0x00000001}, language = "<not loaded>", file = '1.c'
+# SYMBOLS-NEXT: CompileUnit{0x00000001}, language = "{{<not loaded>|unknown}}", file = '1.c'
 # SYMBOLS-NEXT:   Variable{{.*}}, name = "A", {{.*}}, location = DW_OP_GNU_addr_index 0x2
 # SYMBOLS-NEXT:   Function{{.*}}, demangled = F1
 # SYMBOLS-NEXT:   Block{{.*}}, ranges = [0x00000001-0x00000002)
 # SYMBOLS-NEXT:     Variable{{.*}}, name = "x", {{.*}}, location = 
 # SYMBOLS-NEXT:       DW_LLE_startx_length   (0x0000000000000003, 0x0000000000000001): DW_OP_reg1 RDX
 # SYMBOLS-EMPTY:
-# SYMBOLS-NEXT: CompileUnit{0x00000002}, language = "<not loaded>", file = '2.c'
+# SYMBOLS-NEXT: CompileUnit{0x00000002}, language = "{{<not loaded>|unknown}}", file = '2.c'
 # SYMBOLS-NEXT:   Variable{{.*}}, name = "A", {{.*}}, location = DW_OP_GNU_addr_index 0x4
 # SYMBOLS-NEXT:   Function{{.*}}, demangled = F2
 # SYMBOLS-NEXT:   Block{{.*}}, ranges = [0x00000002-0x00000003)
 # SYMBOLS-NEXT:     Variable{{.*}}, name = "x", {{.*}}, location = 
 # SYMBOLS-NEXT:       DW_LLE_startx_length   (0x0000000000000005, 0x0000000000000001): DW_OP_reg2 RCX
 # SYMBOLS-EMPTY:
-# SYMBOLS-NEXT: CompileUnit{0x00000003}, language = "<not loaded>", file = '3.c'
+# SYMBOLS-NEXT: CompileUnit{0x00000003}, language = "{{<not loaded>|unknown}}", file = '3.c'
 # SYMBOLS-NEXT:   Variable{{.*}}, name = "A", {{.*}}, location = DW_OP_GNU_addr_index 0x6
 # SYMBOLS-NEXT:   Function{{.*}}, demangled = F3
 # SYMBOLS-NEXT:   Block{{.*}}, ranges = [0x00000003-0x00000004)
 # SYMBOLS-NEXT:     Variable{{.*}}, name = "x", {{.*}}, location = 
 # SYMBOLS-NEXT:       DW_LLE_startx_length   (0x0000000000000007, 0x0000000000000001): DW_OP_reg3 RBX
 # SYMBOLS-EMPTY:
-# SYMBOLS-NEXT: CompileUnit{0x00000004}, language = "<not loaded>", file = ''
+# SYMBOLS-NEXT: CompileUnit{0x00000004}, language = "{{<not loaded>|unknown}}", file = ''
 # SYMBOLS-EMPTY:
 
         .section        .debug_abbrev,"",@progbits


### PR DESCRIPTION
The Swift fork has a call to comp_unit->GetLanguage() which causes the
language to be parsed sooner than upstream. Modify the test accordingly
and put the downstream change between LLDB_ENABLE_SWIFT ifdefs.