### PR TITLE
[lldb] Change ReconstructType positive cache hits logging to verbose

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4434,8 +4434,9 @@ swift::TypeBase *SwiftASTContext::ReconstructType(ConstString mangled_typename,
   llvm::PrettyStackTraceFormat PST("error finding type for %s", mangled_cstr);
   swift::TypeBase *found_type = m_mangled_name_to_type_map.lookup(mangled_cstr);
   if (found_type) {
-    LOG_PRINTF(LIBLLDB_LOG_TYPES, "(\"%s\") -- found in the positive cache",
-               mangled_cstr);
+    LOG_VERBOSE_PRINTF(LIBLLDB_LOG_TYPES,
+                       "(\"%s\") -- found in the positive cache",
+                       mangled_cstr);
     assert(&found_type->getASTContext() == ast_ctx);
     return found_type;
   }


### PR DESCRIPTION
This particular log happens fairly frequently, and provides little debugging value, since the logs will already contain a log saying the type was "found". This changes the log to be emitted only when verbose logging is enabled.