### PR TITLE
[lldb] Don't eagerly load SwiftASTContext from DiagnoseWarnings

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1321,7 +1321,7 @@ Status TypeSystemSwiftTypeRef::IsCompatible() {
 
 void TypeSystemSwiftTypeRef::DiagnoseWarnings(Process &process,
                                               Module &module) const {
-  if (auto *swift_ast_context = GetSwiftASTContext())
+  if (auto *swift_ast_context = GetSwiftASTContextOrNull())
     swift_ast_context->DiagnoseWarnings(process, module);
 }
 

--- a/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
@@ -35,7 +35,6 @@ class TestSwiftWerror(TestBase):
             self.assertFalse("-Werror" in line)
             if "-DCONFLICT" in line:
                 sanity += 1
-        # We see it twice in the expression context and once in a Module context.
-        #  -DCONFLICT=0
-        #  -DCONFLICT=1
-        self.assertEqual(sanity, 2+1)
+        # We see -DCONFLICT twice in the expression context and once in each of
+        # the two Module contexts.
+        self.assertEqual(sanity, 2+2)

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -65,7 +65,7 @@ class TestSwiftDedupMacros(TestBase):
             if "-UNDEBUG" in line:
                 ndebug += 1
         # One extra in SwiftASTContextPerModule.
-        self.assertEqual(debug, 1+1)
-        self.assertEqual(space, 1+1)
+        self.assertEqual(debug, 3)
+        self.assertEqual(space, 3)
         self.assertEqual(space_with_space, 0)
-        self.assertEqual(ndebug, 1+1)
+        self.assertEqual(ndebug, 3)

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -125,12 +125,12 @@ class TestSwiftRewriteClangPaths(TestBase):
         if remap:
             self.assertEqual(errs, 0, "expected no module import error")
             # Counting occurences in the scratch context.
-            self.assertEqual(found_iquote, 1)
-            self.assertEqual(found_i1, 1)
-            self.assertEqual(found_i2, 1)
-            self.assertEqual(found_f, 1)
+            self.assertEqual(found_iquote, 3)
+            self.assertEqual(found_i1, 3)
+            self.assertEqual(found_i2, 3)
+            self.assertEqual(found_f, 3)
             self.assertEqual(found_rel, 0)
             self.assertEqual(found_abs, 1)
-            self.assertEqual(found_ovl, 1)
+            self.assertEqual(found_ovl, 3)
         else:
             self.assertGreater(errs, 0, "expected module import error")

--- a/lldb/test/Shell/Swift/DeserializationFailure.test
+++ b/lldb/test/Shell/Swift/DeserializationFailure.test
@@ -14,6 +14,8 @@
 
 b main
 run
+# Create a SwiftASTContext, to induce error output.
+p 1
 
 # The {{ }} avoids accidentally matching the input script!
 # CHECK: a.out:{{ }}{{.*}}The serialized module is corrupted.

--- a/lldb/test/Shell/Swift/MissingVFSOverlay.test
+++ b/lldb/test/Shell/Swift/MissingVFSOverlay.test
@@ -11,6 +11,8 @@
 
 b main
 run
+# Create a SwiftASTContext, to induce error output.
+p 1
 
 # The {{ }} avoids accidentally matching the input script!
 # CHECK: a.out:{{ }}


### PR DESCRIPTION
The `DiagnoseWarnings` function is called from one place: `Thread::FrameSelectedCallback`. While reviewing an instruments profile of lldb, I did not expect to see `FrameSelectedCallback` triggering `SwiftASTContext` creation.

I don't know of any reason for this to be done eagerly. This changes `TypeSystemSwiftTypeRef::DiagnoseWarnings` to only invoke `SwiftASTContext::DiagnoseWarnings` if an instance of `SwiftASTContext` has already been constructed.