### PR TITLE
[lldb] Filter out redundant log in SwiftASTContext

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4414,6 +4414,8 @@ swift::TypeBase *SwiftASTContext::ReconstructType(ConstString mangled_typename,
     return {};
   }
 
+  LOG_VERBOSE_PRINTF(LIBLLDB_LOG_TYPES, "(\"%s\")", mangled_cstr);
+
   swift::ASTContext *ast_ctx = GetASTContext();
   if (!ast_ctx) {
     LOG_PRINTF(LIBLLDB_LOG_TYPES, "(\"%s\") -- null Swift AST Context",

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4414,8 +4414,6 @@ swift::TypeBase *SwiftASTContext::ReconstructType(ConstString mangled_typename,
     return {};
   }
 
-  LOG_PRINTF(LIBLLDB_LOG_TYPES, "(\"%s\")", mangled_cstr);
-
   swift::ASTContext *ast_ctx = GetASTContext();
   if (!ast_ctx) {
     LOG_PRINTF(LIBLLDB_LOG_TYPES, "(\"%s\") -- null Swift AST Context",


### PR DESCRIPTION
Filter out `types` log noise produced by `SwiftASTContext::ReconstructType`.

When reading through a `types` log (to aid debugging), there are numerous logs from `SwiftASTContext::ReconstructType`. These logs are always in unnecessary pairs:

```
SwiftASTContextForModule("TheApp")::ReconstructType("$sSbD")
SwiftASTContextForModule("TheApp")::ReconstructType("$sSbD") -- found in the positive cache
```

The first line is of little value since there's always a second line showing the result (cached, searching, found, not found, etc).

Since this method is called frequently, the redundant first line adds up and slows down reading through a types log. This change converts the first log line to be printed only under verbose logging. The reason for keeping it around, instead of deleting it, is its historical use:

> The reason why this is logged twice was to have something to help debugging when type reconstruction crashes, but I can't recall using this log output in practice in the last 2 years.

(cherry picked from #3763)