### PR TITLE
Fix format specifier to not trigger an assertion

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -577,7 +577,7 @@ public:
                   std::string &dest) override {
     Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
 
-    LLDB_LOGV(log, "[MemoryReader] asked to read string data at address {0x}",
+    LLDB_LOGV(log, "[MemoryReader] asked to read string data at address {0:x}",
               address.getAddressData());
 
     Target &target(m_process.GetTarget());


### PR DESCRIPTION
(cherry picked from commit be53aca48c843b1e6b4361586ce1b54648d3671b)