### PR TITLE
[lldb] Add missing SeverityForKind return statement

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2930,10 +2930,8 @@ public:
     case swift::DiagnosticKind::Warning:
       return eDiagnosticSeverityWarning;
     case swift::DiagnosticKind::Note:
-      return eDiagnosticSeverityRemark;
     case swift::DiagnosticKind::Remark:
       return eDiagnosticSeverityRemark;
-      break;
     }
 
     llvm_unreachable("Unhandled DiagnosticKind in switch.");

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2932,6 +2932,7 @@ public:
     case swift::DiagnosticKind::Note:
       return eDiagnosticSeverityRemark;
     case swift::DiagnosticKind::Remark:
+      return eDiagnosticSeverityRemark;
       break;
     }
 


### PR DESCRIPTION
This missing return statement will lead to a crash if remark diagnostics are being emitted.

(cherry picked from #3779)