### PR TITLE
[lldb] Add missing SeverityForKind return statement

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2931,6 +2931,7 @@ public:
     case swift::DiagnosticKind::Note:
       return eDiagnosticSeverityRemark;
     case swift::DiagnosticKind::Remark:
+      return eDiagnosticSeverityRemark;
       break;
     }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2929,10 +2929,8 @@ public:
     case swift::DiagnosticKind::Warning:
       return eDiagnosticSeverityWarning;
     case swift::DiagnosticKind::Note:
-      return eDiagnosticSeverityRemark;
     case swift::DiagnosticKind::Remark:
       return eDiagnosticSeverityRemark;
-      break;
     }
 
     llvm_unreachable("Unhandled DiagnosticKind in switch.");


### PR DESCRIPTION
This missing return statement will lead to a crash if remark diagnostics are being emitted.

(cherry picked from #3782)