### PR TITLE
Remove assertion.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3094,7 +3094,6 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
           bitfield_bit_size, bitfield_bit_offset, exe_scope, is_base_class);
     }
     default:
-      assert(false && "Unhandled node kind");
       LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
                 "DumpTypeValue: Unhandled node kind for type %s",
                 AsMangledName(type));


### PR DESCRIPTION
This patch removes an assertion that isn't helpful for end users. The error is still logged as has been fixed properly on the main branch.

https://bugs.swift.org/browse/SR-15677