### PR TITLE
[lldb] Make sure libCppLib.dylib is propery signed

### DIFF
--- a/lldb/test/API/repl/cpp_exceptions/Makefile
+++ b/lldb/test/API/repl/cpp_exceptions/Makefile
@@ -12,6 +12,9 @@ libCppLib.dylib: CppLib/CppLib.cpp
 		DYLIB_NAME=CppLib DYLIB_ONLY=YES CXXFLAGS_EXTRAS=-fPIC \
 		DYLIB_CXX_SOURCES="CppLib/CppLib.cpp CppLib/CppLibWrapper.cpp"
 	install_name_tool -id $@ $@
+ifneq "$(CODESIGN)" ""
+	$(CODESIGN) -f -s - "$@"
+endif
 
 libWrapper.dylib: libCppLib.dylib
 	$(MAKE) -f $(MAKEFILE_RULES) \


### PR DESCRIPTION
rdar://86042324
(cherry picked from commit 990a48b720baea674041032252cc22760b6a0fa9)