### PR TITLE
Fix use-after-free in SwiftLanguageRuntimeImpl::GetChildCompilerTypeA…

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1597,22 +1597,36 @@ CompilerType SwiftLanguageRuntimeImpl::GetChildCompilerTypeAtIndex(
     NodePointer type_node = dem.demangleSymbol(mangled);
     llvm::StringRef type_name = TypeSystemSwiftTypeRef::GetBaseName(
         ts->CanonicalizeSugar(dem, type_node));
+
+    auto *reflection_ctx = GetReflectionContext();
+    if (!reflection_ctx)
+      return {};
+    CompilerType instance_type = valobj->GetCompilerType();
+    auto *instance_ts =
+        llvm::dyn_cast_or_null<TypeSystemSwift>(instance_type.GetTypeSystem());
+    if (!instance_ts)
+      return {};
+
+    // LLDBTypeInfoProvider needs to kept alive until as long as supers gets accessed.
     llvm::SmallVector<SuperClassType, 2> supers;
-    ForEachSuperClassType(*valobj, [&](SuperClassType sc) -> bool {
-      if (!found_start) {
-        // The ValueObject always points to the same class instance,
-        // even when querying base classes. Drop base classes until we
-        // reach the requested type.
-        if (auto *tr = sc.get_typeref()) {
-          NodePointer base_class = tr->getDemangling(dem);
-          if (TypeSystemSwiftTypeRef::GetBaseName(base_class) != type_name)
-            return false;
-          found_start = true;
-        }
-      }
-      supers.push_back(sc);
-      return supers.size() >= 2;
-    });
+    LLDBTypeInfoProvider tip(*this, *instance_ts);
+    lldb::addr_t pointer = valobj->GetPointerValue();
+    reflection_ctx->ForEachSuperClassType(
+        &tip, pointer, [&](SuperClassType sc) -> bool {
+          if (!found_start) {
+            // The ValueObject always points to the same class instance,
+            // even when querying base classes. Drop base classes until we
+            // reach the requested type.
+            if (auto *tr = sc.get_typeref()) {
+              NodePointer base_class = tr->getDemangling(dem);
+              if (TypeSystemSwiftTypeRef::GetBaseName(base_class) != type_name)
+                return false;
+              found_start = true;
+            }
+          }
+          supers.push_back(sc);
+          return supers.size() >= 2;
+        });
 
     if (supers.size() == 0) {
       LLDB_LOGF(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -246,7 +246,7 @@ protected:
   /// If \p instance points to a Swift object, retrieve its
   /// RecordTypeInfo and pass it to the callback \p fn. Repeat the
   /// process with all superclasses. If \p fn returns \p true, early
-  /// exit and return \ptrue. Otherwise return \p false.
+  /// exit and return \p true. Otherwise return \p false.
   bool ForEachSuperClassType(ValueObject &instance,
                              std::function<bool(SuperClassType)> fn);
 


### PR DESCRIPTION
…tIndex()

This function broke the contract with ForEachSuperClass by making a
copy of the returned super classes and then calling into the callbacks
outside of the closure.

rdar://87565969