### PR TITLE
Fix use-after-free in SwiftLanguageRuntimeImpl::GetChildCompilerTypeA…

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -247,7 +247,7 @@ protected:
   /// If \p instance points to a Swift object, retrieve its
   /// RecordTypeInfo and pass it to the callback \p fn. Repeat the
   /// process with all superclasses. If \p fn returns \p true, early
-  /// exit and return \ptrue. Otherwise return \p false.
+  /// exit and return \p true. Otherwise return \p false.
   bool ForEachSuperClassType(ValueObject &instance,
                              std::function<bool(SuperClassType)> fn);
 


### PR DESCRIPTION
…tIndex()

This function broke the contract with ForEachSuperClass by making a
copy of the returned super classes and then calling into the callbacks
outside of the closure.

rdar://87565969
(cherry picked from commit 3e2bc968fef85da193a7999514fb165dd6a4296b)