### PR TITLE
[lldb] Only promote -Wignored-attributes to an error

### DIFF
--- a/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
+++ b/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
@@ -20,7 +20,7 @@ class TestCase(TestBase):
         try:
             self.build(dictionary={
                 "C_SOURCES" : test_file,
-                "CFLAGS_EXTRAS" : "-Werror"
+                "CFLAGS_EXTRAS" : "-Werror=ignored-attributes"
             })
         except BuildError as e:
              # Test source failed to build. Check if it failed because the


### PR DESCRIPTION
Avoid other warnings from failing the test, such as
-Wunused-command-line-argument in the downstream Swift fork.

(cherry picked from commit a10692c734faff9ef28bc725703a0eacea78eeca)
