### PR TITLE
[LLDB] Fix LLDB buildbots break due to --image-base

### DIFF
--- a/lldb/test/Shell/ObjectFile/ELF/basic-info.yaml
+++ b/lldb/test/Shell/ObjectFile/ELF/basic-info.yaml
@@ -1,7 +1,7 @@
 # REQUIRES: lld
 
 # RUN: yaml2obj %s -o %t.o
-# RUN: ld.lld %t.o -o %t -image-base 0x47000
+# RUN: ld.lld %t.o -o %t --image-base 0x47000
 # RUN: lldb-test object-file %t | FileCheck %s
 
 # CHECK: Plugin name: elf

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/debug-types-address-ranges.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/debug-types-address-ranges.s
@@ -7,7 +7,7 @@
 # REQUIRES: lld
 
 # RUN: llvm-mc -dwarf-version=5 -triple x86_64-pc-linux %s -filetype=obj >%t.o
-# RUN: ld.lld %t.o -o %t -image-base=0x47000 -z separate-code
+# RUN: ld.lld %t.o -o %t --image-base=0x47000 -z separate-code
 # RUN: %lldb %t -o "image lookup -a 0x48000 -v" -o exit | FileCheck %s
 
 # CHECK:   CompileUnit: id = {0x00000001}, file = "/tmp/a.cc", language = "c++"


### PR DESCRIPTION
LLDB build were failing due to following two test failures:
lldb-shell :: ObjectFile/ELF/basic-info.yaml
lldb-shell :: SymbolFile/DWARF/x86/debug-types-address-ranges.s

There were caused by commit 6506907a0a1a8a789ad7036ef911f7e31213c9a5

(cherry picked from commit 4c8ea90b252eeead9a6943f67444a229147949fb)
