### PR TITLE
[GlobalISel] Fix SR-15531 regression

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -4815,10 +4815,10 @@ LegalizerHelper::narrowScalarShift(MachineInstr &MI, unsigned TypeIdx,
   const LLT HalfTy = LLT::scalar(NewBitSize);
   const LLT CondTy = LLT::scalar(1);
 
-  if (const MachineInstr *KShiftAmt =
-          getOpcodeDef(TargetOpcode::G_CONSTANT, Amt, MRI)) {
-    return narrowScalarShiftByConstant(
-        MI, KShiftAmt->getOperand(1).getCImm()->getValue(), HalfTy, ShiftAmtTy);
+  if (auto VRegAndVal =
+          getConstantVRegValWithLookThrough(Amt, MRI, true, false)) {
+    return narrowScalarShiftByConstant(MI, VRegAndVal->Value, HalfTy,
+                                       ShiftAmtTy);
   }
 
   // TODO: Expand with known bits.

--- a/llvm/test/CodeGen/AArch64/GlobalISel/arm64-atomic-128.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/arm64-atomic-128.ll
@@ -347,146 +347,86 @@ define void @val_compare_and_swap_monotonic(i128* %p, i128 %oldval, i128 %newval
 define void @atomic_load_relaxed(i64, i64, i128* %p, i128* %p2) {
 ; CHECK-LLSC-O1-LABEL: atomic_load_relaxed:
 ; CHECK-LLSC-O1:       // %bb.0:
-; CHECK-LLSC-O1-NEXT:    mov w8, #64
-; CHECK-LLSC-O1-NEXT:    sub x9, x8, #64
 ; CHECK-LLSC-O1-NEXT:  .LBB4_1: // %atomicrmw.start
 ; CHECK-LLSC-O1-NEXT:    // =>This Inner Loop Header: Depth=1
-; CHECK-LLSC-O1-NEXT:    ldxp x10, x8, [x2]
-; CHECK-LLSC-O1-NEXT:    lsl x8, x8, x9
-; CHECK-LLSC-O1-NEXT:    lsr x11, x8, x9
-; CHECK-LLSC-O1-NEXT:    stxp w12, x10, x11, [x2]
-; CHECK-LLSC-O1-NEXT:    cbnz w12, .LBB4_1
+; CHECK-LLSC-O1-NEXT:    ldxp x9, x8, [x2]
+; CHECK-LLSC-O1-NEXT:    stxp w10, x9, x8, [x2]
+; CHECK-LLSC-O1-NEXT:    cbnz w10, .LBB4_1
 ; CHECK-LLSC-O1-NEXT:  // %bb.2: // %atomicrmw.end
-; CHECK-LLSC-O1-NEXT:    mov v0.d[0], x10
+; CHECK-LLSC-O1-NEXT:    mov v0.d[0], x9
 ; CHECK-LLSC-O1-NEXT:    mov v0.d[1], x8
 ; CHECK-LLSC-O1-NEXT:    str q0, [x3]
 ; CHECK-LLSC-O1-NEXT:    ret
 ;
 ; CHECK-CAS-O1-LABEL: atomic_load_relaxed:
 ; CHECK-CAS-O1:       // %bb.0:
-; CHECK-CAS-O1-NEXT:    mov w8, #64
-; CHECK-CAS-O1-NEXT:    sub x9, x8, #64
 ; CHECK-CAS-O1-NEXT:  .LBB4_1: // %atomicrmw.start
 ; CHECK-CAS-O1-NEXT:    // =>This Inner Loop Header: Depth=1
-; CHECK-CAS-O1-NEXT:    ldxp x10, x8, [x2]
-; CHECK-CAS-O1-NEXT:    lsl x8, x8, x9
-; CHECK-CAS-O1-NEXT:    lsr x11, x8, x9
-; CHECK-CAS-O1-NEXT:    stxp w12, x10, x11, [x2]
-; CHECK-CAS-O1-NEXT:    cbnz w12, .LBB4_1
+; CHECK-CAS-O1-NEXT:    ldxp x9, x8, [x2]
+; CHECK-CAS-O1-NEXT:    stxp w10, x9, x8, [x2]
+; CHECK-CAS-O1-NEXT:    cbnz w10, .LBB4_1
 ; CHECK-CAS-O1-NEXT:  // %bb.2: // %atomicrmw.end
-; CHECK-CAS-O1-NEXT:    mov v0.d[0], x10
+; CHECK-CAS-O1-NEXT:    mov v0.d[0], x9
 ; CHECK-CAS-O1-NEXT:    mov v0.d[1], x8
 ; CHECK-CAS-O1-NEXT:    str q0, [x3]
 ; CHECK-CAS-O1-NEXT:    ret
 ;
 ; CHECK-LLSC-O0-LABEL: atomic_load_relaxed:
 ; CHECK-LLSC-O0:       // %bb.0:
-; CHECK-LLSC-O0-NEXT:    sub sp, sp, #64
-; CHECK-LLSC-O0-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-LLSC-O0-NEXT:    str x2, [sp, #48] // 8-byte Folded Spill
-; CHECK-LLSC-O0-NEXT:    str x3, [sp, #56] // 8-byte Folded Spill
+; CHECK-LLSC-O0-NEXT:    sub sp, sp, #48
+; CHECK-LLSC-O0-NEXT:    .cfi_def_cfa_offset 48
+; CHECK-LLSC-O0-NEXT:    str x2, [sp, #32] // 8-byte Folded Spill
+; CHECK-LLSC-O0-NEXT:    str x3, [sp, #40] // 8-byte Folded Spill
 ; CHECK-LLSC-O0-NEXT:    b .LBB4_1
 ; CHECK-LLSC-O0-NEXT:  .LBB4_1: // %atomicrmw.start
 ; CHECK-LLSC-O0-NEXT:    // =>This Inner Loop Header: Depth=1
-; CHECK-LLSC-O0-NEXT:    ldr x11, [sp, #48] // 8-byte Folded Reload
-; CHECK-LLSC-O0-NEXT:    ldxp x9, x15, [x11]
-; CHECK-LLSC-O0-NEXT:    mov x12, xzr
-; CHECK-LLSC-O0-NEXT:    mov w8, #64
-; CHECK-LLSC-O0-NEXT:    // kill: def $x8 killed $w8
-; CHECK-LLSC-O0-NEXT:    mov w10, #64
-; CHECK-LLSC-O0-NEXT:    // kill: def $x10 killed $w10
-; CHECK-LLSC-O0-NEXT:    str x10, [sp, #8] // 8-byte Folded Spill
-; CHECK-LLSC-O0-NEXT:    subs x16, x10, #64
-; CHECK-LLSC-O0-NEXT:    subs x13, x8, #64
-; CHECK-LLSC-O0-NEXT:    lsl x14, x15, x10
-; CHECK-LLSC-O0-NEXT:    lsr x13, x15, x13
-; CHECK-LLSC-O0-NEXT:    orr x13, x13, x12
-; CHECK-LLSC-O0-NEXT:    lsl x15, x15, x16
-; CHECK-LLSC-O0-NEXT:    subs x16, x10, #64
-; CHECK-LLSC-O0-NEXT:    csel x14, x14, x12, lo
-; CHECK-LLSC-O0-NEXT:    subs x16, x10, #64
-; CHECK-LLSC-O0-NEXT:    csel x13, x13, x15, lo
-; CHECK-LLSC-O0-NEXT:    subs x15, x10, #0
-; CHECK-LLSC-O0-NEXT:    csel x13, x12, x13, eq
-; CHECK-LLSC-O0-NEXT:    orr x9, x9, x14
-; CHECK-LLSC-O0-NEXT:    orr x12, x12, x13
+; CHECK-LLSC-O0-NEXT:    ldr x11, [sp, #32] // 8-byte Folded Reload
+; CHECK-LLSC-O0-NEXT:    ldxp x9, x10, [x11]
+; CHECK-LLSC-O0-NEXT:    mov x8, xzr
+; CHECK-LLSC-O0-NEXT:    orr x9, x9, x8
+; CHECK-LLSC-O0-NEXT:    orr x10, x8, x10
 ; CHECK-LLSC-O0-NEXT:    // implicit-def: $q0
 ; CHECK-LLSC-O0-NEXT:    mov v0.d[0], x9
+; CHECK-LLSC-O0-NEXT:    str q0, [sp] // 16-byte Folded Spill
+; CHECK-LLSC-O0-NEXT:    mov v0.d[1], x10
 ; CHECK-LLSC-O0-NEXT:    str q0, [sp, #16] // 16-byte Folded Spill
-; CHECK-LLSC-O0-NEXT:    mov v0.d[1], x12
-; CHECK-LLSC-O0-NEXT:    str q0, [sp, #32] // 16-byte Folded Spill
-; CHECK-LLSC-O0-NEXT:    subs x13, x10, #64
-; CHECK-LLSC-O0-NEXT:    subs x8, x8, #64
-; CHECK-LLSC-O0-NEXT:    lsl x8, x12, x8
-; CHECK-LLSC-O0-NEXT:    orr x8, x8, x9, lsr #0
-; CHECK-LLSC-O0-NEXT:    lsr x12, x12, x13
-; CHECK-LLSC-O0-NEXT:    subs x13, x10, #64
-; CHECK-LLSC-O0-NEXT:    csel x8, x8, x12, lo
-; CHECK-LLSC-O0-NEXT:    subs x10, x10, #0
-; CHECK-LLSC-O0-NEXT:    csel x10, x9, x8, eq
 ; CHECK-LLSC-O0-NEXT:    stxp w8, x9, x10, [x11]
 ; CHECK-LLSC-O0-NEXT:    cbnz w8, .LBB4_1
 ; CHECK-LLSC-O0-NEXT:    b .LBB4_2
 ; CHECK-LLSC-O0-NEXT:  .LBB4_2: // %atomicrmw.end
-; CHECK-LLSC-O0-NEXT:    ldr q0, [sp, #32] // 16-byte Folded Reload
-; CHECK-LLSC-O0-NEXT:    ldr x8, [sp, #56] // 8-byte Folded Reload
+; CHECK-LLSC-O0-NEXT:    ldr q0, [sp, #16] // 16-byte Folded Reload
+; CHECK-LLSC-O0-NEXT:    ldr x8, [sp, #40] // 8-byte Folded Reload
 ; CHECK-LLSC-O0-NEXT:    str q0, [x8]
-; CHECK-LLSC-O0-NEXT:    add sp, sp, #64
+; CHECK-LLSC-O0-NEXT:    add sp, sp, #48
 ; CHECK-LLSC-O0-NEXT:    ret
 ;
 ; CHECK-CAS-O0-LABEL: atomic_load_relaxed:
 ; CHECK-CAS-O0:       // %bb.0:
-; CHECK-CAS-O0-NEXT:    sub sp, sp, #64
-; CHECK-CAS-O0-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-CAS-O0-NEXT:    str x2, [sp, #48] // 8-byte Folded Spill
-; CHECK-CAS-O0-NEXT:    str x3, [sp, #56] // 8-byte Folded Spill
+; CHECK-CAS-O0-NEXT:    sub sp, sp, #48
+; CHECK-CAS-O0-NEXT:    .cfi_def_cfa_offset 48
+; CHECK-CAS-O0-NEXT:    str x2, [sp, #32] // 8-byte Folded Spill
+; CHECK-CAS-O0-NEXT:    str x3, [sp, #40] // 8-byte Folded Spill
 ; CHECK-CAS-O0-NEXT:    b .LBB4_1
 ; CHECK-CAS-O0-NEXT:  .LBB4_1: // %atomicrmw.start
 ; CHECK-CAS-O0-NEXT:    // =>This Inner Loop Header: Depth=1
-; CHECK-CAS-O0-NEXT:    ldr x11, [sp, #48] // 8-byte Folded Reload
-; CHECK-CAS-O0-NEXT:    ldxp x9, x15, [x11]
-; CHECK-CAS-O0-NEXT:    mov x12, #0
-; CHECK-CAS-O0-NEXT:    mov w8, #64
-; CHECK-CAS-O0-NEXT:    // kill: def $x8 killed $w8
-; CHECK-CAS-O0-NEXT:    mov w10, #64
-; CHECK-CAS-O0-NEXT:    // kill: def $x10 killed $w10
-; CHECK-CAS-O0-NEXT:    str x10, [sp, #8] // 8-byte Folded Spill
-; CHECK-CAS-O0-NEXT:    subs x16, x10, #64
-; CHECK-CAS-O0-NEXT:    subs x13, x8, #64
-; CHECK-CAS-O0-NEXT:    lsl x14, x15, x10
-; CHECK-CAS-O0-NEXT:    lsr x13, x15, x13
-; CHECK-CAS-O0-NEXT:    orr x13, x13, x12
-; CHECK-CAS-O0-NEXT:    lsl x15, x15, x16
-; CHECK-CAS-O0-NEXT:    subs x16, x10, #64
-; CHECK-CAS-O0-NEXT:    csel x14, x14, x12, lo
-; CHECK-CAS-O0-NEXT:    subs x16, x10, #64
-; CHECK-CAS-O0-NEXT:    csel x13, x13, x15, lo
-; CHECK-CAS-O0-NEXT:    subs x15, x10, #0
-; CHECK-CAS-O0-NEXT:    csel x13, x12, x13, eq
-; CHECK-CAS-O0-NEXT:    orr x9, x9, x14
-; CHECK-CAS-O0-NEXT:    orr x12, x12, x13
+; CHECK-CAS-O0-NEXT:    ldr x11, [sp, #32] // 8-byte Folded Reload
+; CHECK-CAS-O0-NEXT:    ldxp x9, x10, [x11]
+; CHECK-CAS-O0-NEXT:    mov x8, #0
+; CHECK-CAS-O0-NEXT:    orr x9, x9, x8
+; CHECK-CAS-O0-NEXT:    orr x10, x8, x10
 ; CHECK-CAS-O0-NEXT:    // implicit-def: $q0
 ; CHECK-CAS-O0-NEXT:    mov v0.d[0], x9
+; CHECK-CAS-O0-NEXT:    str q0, [sp] // 16-byte Folded Spill
+; CHECK-CAS-O0-NEXT:    mov v0.d[1], x10
 ; CHECK-CAS-O0-NEXT:    str q0, [sp, #16] // 16-byte Folded Spill
-; CHECK-CAS-O0-NEXT:    mov v0.d[1], x12
-; CHECK-CAS-O0-NEXT:    str q0, [sp, #32] // 16-byte Folded Spill
-; CHECK-CAS-O0-NEXT:    subs x13, x10, #64
-; CHECK-CAS-O0-NEXT:    subs x8, x8, #64
-; CHECK-CAS-O0-NEXT:    lsl x8, x12, x8
-; CHECK-CAS-O0-NEXT:    orr x8, x8, x9, lsr #0
-; CHECK-CAS-O0-NEXT:    lsr x12, x12, x13
-; CHECK-CAS-O0-NEXT:    subs x13, x10, #64
-; CHECK-CAS-O0-NEXT:    csel x8, x8, x12, lo
-; CHECK-CAS-O0-NEXT:    subs x10, x10, #0
-; CHECK-CAS-O0-NEXT:    csel x10, x9, x8, eq
 ; CHECK-CAS-O0-NEXT:    stxp w8, x9, x10, [x11]
 ; CHECK-CAS-O0-NEXT:    cbnz w8, .LBB4_1
 ; CHECK-CAS-O0-NEXT:    b .LBB4_2
 ; CHECK-CAS-O0-NEXT:  .LBB4_2: // %atomicrmw.end
-; CHECK-CAS-O0-NEXT:    ldr q0, [sp, #32] // 16-byte Folded Reload
-; CHECK-CAS-O0-NEXT:    ldr x8, [sp, #56] // 8-byte Folded Reload
+; CHECK-CAS-O0-NEXT:    ldr q0, [sp, #16] // 16-byte Folded Reload
+; CHECK-CAS-O0-NEXT:    ldr x8, [sp, #40] // 8-byte Folded Reload
 ; CHECK-CAS-O0-NEXT:    str q0, [x8]
-; CHECK-CAS-O0-NEXT:    add sp, sp, #64
+; CHECK-CAS-O0-NEXT:    add sp, sp, #48
 ; CHECK-CAS-O0-NEXT:    ret
 
     %r = load atomic i128, i128* %p monotonic, align 16

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-bswap.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-bswap.mir
@@ -41,4 +41,3 @@ body:             |
     $w0 = COPY %3(s32)
     RET_ReallyLR implicit $w0
 
-...

--- a/llvm/test/CodeGen/AArch64/fold-global-offsets.ll
+++ b/llvm/test/CodeGen/AArch64/fold-global-offsets.ll
@@ -131,11 +131,8 @@ define i32 @f7() {
 ; GISEL-NEXT:    adrp x8, x3+88
 ; GISEL-NEXT:    add x8, x8, :lo12:x3+88
 ; GISEL-NEXT:    mov v0.d[1], x8
-; GISEL-NEXT:    mov w9, #64
 ; GISEL-NEXT:    mov d0, v0.d[1]
-; GISEL-NEXT:    sub x8, x9, #64
-; GISEL-NEXT:    fmov x9, d0
-; GISEL-NEXT:    lsr x8, x9, x8
+; GISEL-NEXT:    fmov x8, d0
 ; GISEL-NEXT:    ldr w0, [x8, #20]
 ; GISEL-NEXT:    ret
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fshl.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fshl.ll
@@ -4707,44 +4707,44 @@ define amdgpu_ps i128 @s_fshl_i128(i128 inreg %lhs, i128 inreg %rhs, i128 inreg 
 ; GFX6-NEXT:    s_and_b64 s[12:13], s[8:9], s[10:11]
 ; GFX6-NEXT:    s_andn2_b64 s[8:9], s[10:11], s[8:9]
 ; GFX6-NEXT:    s_sub_i32 s9, s12, 64
-; GFX6-NEXT:    s_sub_i32 s13, 64, s12
+; GFX6-NEXT:    s_sub_i32 s10, 64, s12
 ; GFX6-NEXT:    s_cmp_lt_u32 s12, 64
-; GFX6-NEXT:    s_cselect_b32 s16, 1, 0
+; GFX6-NEXT:    s_cselect_b32 s18, 1, 0
 ; GFX6-NEXT:    s_cmp_eq_u32 s12, 0
-; GFX6-NEXT:    s_cselect_b32 s17, 1, 0
-; GFX6-NEXT:    s_lshl_b64 s[10:11], s[0:1], s12
-; GFX6-NEXT:    s_lshr_b64 s[14:15], s[0:1], s13
+; GFX6-NEXT:    s_cselect_b32 s19, 1, 0
+; GFX6-NEXT:    s_lshl_b64 s[14:15], s[0:1], s12
+; GFX6-NEXT:    s_lshr_b64 s[16:17], s[0:1], s10
 ; GFX6-NEXT:    s_lshl_b64 s[12:13], s[2:3], s12
-; GFX6-NEXT:    s_or_b64 s[12:13], s[14:15], s[12:13]
+; GFX6-NEXT:    s_or_b64 s[12:13], s[16:17], s[12:13]
 ; GFX6-NEXT:    s_lshl_b64 s[0:1], s[0:1], s9
-; GFX6-NEXT:    s_cmp_lg_u32 s16, 0
-; GFX6-NEXT:    s_cselect_b64 s[10:11], s[10:11], 0
+; GFX6-NEXT:    s_cmp_lg_u32 s18, 0
+; GFX6-NEXT:    s_cselect_b64 s[14:15], s[14:15], 0
 ; GFX6-NEXT:    s_cselect_b64 s[0:1], s[12:13], s[0:1]
-; GFX6-NEXT:    s_cmp_lg_u32 s17, 0
+; GFX6-NEXT:    s_cmp_lg_u32 s19, 0
 ; GFX6-NEXT:    s_cselect_b64 s[2:3], s[2:3], s[0:1]
-; GFX6-NEXT:    s_sub_i32 s9, 64, 1
-; GFX6-NEXT:    s_lshr_b64 s[0:1], s[6:7], 1
-; GFX6-NEXT:    s_lshr_b64 s[4:5], s[4:5], 1
-; GFX6-NEXT:    s_lshl_b64 s[6:7], s[6:7], s9
-; GFX6-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
-; GFX6-NEXT:    s_sub_i32 s14, s8, 64
-; GFX6-NEXT:    s_sub_i32 s12, 64, s8
+; GFX6-NEXT:    s_lshr_b64 s[0:1], s[4:5], 1
+; GFX6-NEXT:    s_lshl_b32 s5, s6, 31
+; GFX6-NEXT:    s_mov_b32 s4, s11
+; GFX6-NEXT:    s_or_b64 s[0:1], s[0:1], s[4:5]
+; GFX6-NEXT:    s_lshr_b64 s[4:5], s[6:7], 1
+; GFX6-NEXT:    s_sub_i32 s12, s8, 64
+; GFX6-NEXT:    s_sub_i32 s10, 64, s8
 ; GFX6-NEXT:    s_cmp_lt_u32 s8, 64
-; GFX6-NEXT:    s_cselect_b32 s15, 1, 0
+; GFX6-NEXT:    s_cselect_b32 s13, 1, 0
 ; GFX6-NEXT:    s_cmp_eq_u32 s8, 0
 ; GFX6-NEXT:    s_cselect_b32 s16, 1, 0
-; GFX6-NEXT:    s_lshr_b64 s[6:7], s[0:1], s8
-; GFX6-NEXT:    s_lshl_b64 s[12:13], s[0:1], s12
-; GFX6-NEXT:    s_lshr_b64 s[8:9], s[4:5], s8
-; GFX6-NEXT:    s_or_b64 s[8:9], s[8:9], s[12:13]
-; GFX6-NEXT:    s_lshr_b64 s[0:1], s[0:1], s14
-; GFX6-NEXT:    s_cmp_lg_u32 s15, 0
-; GFX6-NEXT:    s_cselect_b64 s[0:1], s[8:9], s[0:1]
+; GFX6-NEXT:    s_lshr_b64 s[6:7], s[4:5], s8
+; GFX6-NEXT:    s_lshl_b64 s[10:11], s[4:5], s10
+; GFX6-NEXT:    s_lshr_b64 s[8:9], s[0:1], s8
+; GFX6-NEXT:    s_or_b64 s[8:9], s[8:9], s[10:11]
+; GFX6-NEXT:    s_lshr_b64 s[4:5], s[4:5], s12
+; GFX6-NEXT:    s_cmp_lg_u32 s13, 0
+; GFX6-NEXT:    s_cselect_b64 s[4:5], s[8:9], s[4:5]
 ; GFX6-NEXT:    s_cmp_lg_u32 s16, 0
-; GFX6-NEXT:    s_cselect_b64 s[0:1], s[4:5], s[0:1]
-; GFX6-NEXT:    s_cmp_lg_u32 s15, 0
+; GFX6-NEXT:    s_cselect_b64 s[0:1], s[0:1], s[4:5]
+; GFX6-NEXT:    s_cmp_lg_u32 s13, 0
 ; GFX6-NEXT:    s_cselect_b64 s[4:5], s[6:7], 0
-; GFX6-NEXT:    s_or_b64 s[0:1], s[10:11], s[0:1]
+; GFX6-NEXT:    s_or_b64 s[0:1], s[14:15], s[0:1]
 ; GFX6-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
 ; GFX6-NEXT:    ; return to shader part epilog
 ;
@@ -4754,44 +4754,44 @@ define amdgpu_ps i128 @s_fshl_i128(i128 inreg %lhs, i128 inreg %rhs, i128 inreg 
 ; GFX8-NEXT:    s_and_b64 s[12:13], s[8:9], s[10:11]
 ; GFX8-NEXT:    s_andn2_b64 s[8:9], s[10:11], s[8:9]
 ; GFX8-NEXT:    s_sub_i32 s9, s12, 64
-; GFX8-NEXT:    s_sub_i32 s13, 64, s12
+; GFX8-NEXT:    s_sub_i32 s10, 64, s12
 ; GFX8-NEXT:    s_cmp_lt_u32 s12, 64
-; GFX8-NEXT:    s_cselect_b32 s16, 1, 0
+; GFX8-NEXT:    s_cselect_b32 s18, 1, 0
 ; GFX8-NEXT:    s_cmp_eq_u32 s12, 0
-; GFX8-NEXT:    s_cselect_b32 s17, 1, 0
-; GFX8-NEXT:    s_lshl_b64 s[10:11], s[0:1], s12
-; GFX8-NEXT:    s_lshr_b64 s[14:15], s[0:1], s13
+; GFX8-NEXT:    s_cselect_b32 s19, 1, 0
+; GFX8-NEXT:    s_lshl_b64 s[14:15], s[0:1], s12
+; GFX8-NEXT:    s_lshr_b64 s[16:17], s[0:1], s10
 ; GFX8-NEXT:    s_lshl_b64 s[12:13], s[2:3], s12
-; GFX8-NEXT:    s_or_b64 s[12:13], s[14:15], s[12:13]
+; GFX8-NEXT:    s_or_b64 s[12:13], s[16:17], s[12:13]
 ; GFX8-NEXT:    s_lshl_b64 s[0:1], s[0:1], s9
-; GFX8-NEXT:    s_cmp_lg_u32 s16, 0
-; GFX8-NEXT:    s_cselect_b64 s[10:11], s[10:11], 0
+; GFX8-NEXT:    s_cmp_lg_u32 s18, 0
+; GFX8-NEXT:    s_cselect_b64 s[14:15], s[14:15], 0
 ; GFX8-NEXT:    s_cselect_b64 s[0:1], s[12:13], s[0:1]
-; GFX8-NEXT:    s_cmp_lg_u32 s17, 0
+; GFX8-NEXT:    s_cmp_lg_u32 s19, 0
 ; GFX8-NEXT:    s_cselect_b64 s[2:3], s[2:3], s[0:1]
-; GFX8-NEXT:    s_sub_i32 s9, 64, 1
-; GFX8-NEXT:    s_lshr_b64 s[0:1], s[6:7], 1
-; GFX8-NEXT:    s_lshr_b64 s[4:5], s[4:5], 1
-; GFX8-NEXT:    s_lshl_b64 s[6:7], s[6:7], s9
-; GFX8-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
-; GFX8-NEXT:    s_sub_i32 s14, s8, 64
-; GFX8-NEXT:    s_sub_i32 s12, 64, s8
+; GFX8-NEXT:    s_lshr_b64 s[0:1], s[4:5], 1
+; GFX8-NEXT:    s_lshl_b32 s5, s6, 31
+; GFX8-NEXT:    s_mov_b32 s4, s11
+; GFX8-NEXT:    s_or_b64 s[0:1], s[0:1], s[4:5]
+; GFX8-NEXT:    s_lshr_b64 s[4:5], s[6:7], 1
+; GFX8-NEXT:    s_sub_i32 s12, s8, 64
+; GFX8-NEXT:    s_sub_i32 s10, 64, s8
 ; GFX8-NEXT:    s_cmp_lt_u32 s8, 64
-; GFX8-NEXT:    s_cselect_b32 s15, 1, 0
+; GFX8-NEXT:    s_cselect_b32 s13, 1, 0
 ; GFX8-NEXT:    s_cmp_eq_u32 s8, 0
 ; GFX8-NEXT:    s_cselect_b32 s16, 1, 0
-; GFX8-NEXT:    s_lshr_b64 s[6:7], s[0:1], s8
-; GFX8-NEXT:    s_lshl_b64 s[12:13], s[0:1], s12
-; GFX8-NEXT:    s_lshr_b64 s[8:9], s[4:5], s8
-; GFX8-NEXT:    s_or_b64 s[8:9], s[8:9], s[12:13]
-; GFX8-NEXT:    s_lshr_b64 s[0:1], s[0:1], s14
-; GFX8-NEXT:    s_cmp_lg_u32 s15, 0
-; GFX8-NEXT:    s_cselect_b64 s[0:1], s[8:9], s[0:1]
+; GFX8-NEXT:    s_lshr_b64 s[6:7], s[4:5], s8
+; GFX8-NEXT:    s_lshl_b64 s[10:11], s[4:5], s10
+; GFX8-NEXT:    s_lshr_b64 s[8:9], s[0:1], s8
+; GFX8-NEXT:    s_or_b64 s[8:9], s[8:9], s[10:11]
+; GFX8-NEXT:    s_lshr_b64 s[4:5], s[4:5], s12
+; GFX8-NEXT:    s_cmp_lg_u32 s13, 0
+; GFX8-NEXT:    s_cselect_b64 s[4:5], s[8:9], s[4:5]
 ; GFX8-NEXT:    s_cmp_lg_u32 s16, 0
-; GFX8-NEXT:    s_cselect_b64 s[0:1], s[4:5], s[0:1]
-; GFX8-NEXT:    s_cmp_lg_u32 s15, 0
+; GFX8-NEXT:    s_cselect_b64 s[0:1], s[0:1], s[4:5]
+; GFX8-NEXT:    s_cmp_lg_u32 s13, 0
 ; GFX8-NEXT:    s_cselect_b64 s[4:5], s[6:7], 0
-; GFX8-NEXT:    s_or_b64 s[0:1], s[10:11], s[0:1]
+; GFX8-NEXT:    s_or_b64 s[0:1], s[14:15], s[0:1]
 ; GFX8-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
 ; GFX8-NEXT:    ; return to shader part epilog
 ;
@@ -4801,44 +4801,44 @@ define amdgpu_ps i128 @s_fshl_i128(i128 inreg %lhs, i128 inreg %rhs, i128 inreg 
 ; GFX9-NEXT:    s_and_b64 s[12:13], s[8:9], s[10:11]
 ; GFX9-NEXT:    s_andn2_b64 s[8:9], s[10:11], s[8:9]
 ; GFX9-NEXT:    s_sub_i32 s9, s12, 64
-; GFX9-NEXT:    s_sub_i32 s13, 64, s12
+; GFX9-NEXT:    s_sub_i32 s10, 64, s12
 ; GFX9-NEXT:    s_cmp_lt_u32 s12, 64
-; GFX9-NEXT:    s_cselect_b32 s16, 1, 0
+; GFX9-NEXT:    s_cselect_b32 s18, 1, 0
 ; GFX9-NEXT:    s_cmp_eq_u32 s12, 0
-; GFX9-NEXT:    s_cselect_b32 s17, 1, 0
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[0:1], s12
-; GFX9-NEXT:    s_lshr_b64 s[14:15], s[0:1], s13
+; GFX9-NEXT:    s_cselect_b32 s19, 1, 0
+; GFX9-NEXT:    s_lshl_b64 s[14:15], s[0:1], s12
+; GFX9-NEXT:    s_lshr_b64 s[16:17], s[0:1], s10
 ; GFX9-NEXT:    s_lshl_b64 s[12:13], s[2:3], s12
-; GFX9-NEXT:    s_or_b64 s[12:13], s[14:15], s[12:13]
+; GFX9-NEXT:    s_or_b64 s[12:13], s[16:17], s[12:13]
 ; GFX9-NEXT:    s_lshl_b64 s[0:1], s[0:1], s9
-; GFX9-NEXT:    s_cmp_lg_u32 s16, 0
-; GFX9-NEXT:    s_cselect_b64 s[10:11], s[10:11], 0
+; GFX9-NEXT:    s_cmp_lg_u32 s18, 0
+; GFX9-NEXT:    s_cselect_b64 s[14:15], s[14:15], 0
 ; GFX9-NEXT:    s_cselect_b64 s[0:1], s[12:13], s[0:1]
-; GFX9-NEXT:    s_cmp_lg_u32 s17, 0
+; GFX9-NEXT:    s_cmp_lg_u32 s19, 0
 ; GFX9-NEXT:    s_cselect_b64 s[2:3], s[2:3], s[0:1]
-; GFX9-NEXT:    s_sub_i32 s9, 64, 1
-; GFX9-NEXT:    s_lshr_b64 s[0:1], s[6:7], 1
-; GFX9-NEXT:    s_lshr_b64 s[4:5], s[4:5], 1
-; GFX9-NEXT:    s_lshl_b64 s[6:7], s[6:7], s9
-; GFX9-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
-; GFX9-NEXT:    s_sub_i32 s14, s8, 64
-; GFX9-NEXT:    s_sub_i32 s12, 64, s8
+; GFX9-NEXT:    s_lshr_b64 s[0:1], s[4:5], 1
+; GFX9-NEXT:    s_lshl_b32 s5, s6, 31
+; GFX9-NEXT:    s_mov_b32 s4, s11
+; GFX9-NEXT:    s_or_b64 s[0:1], s[0:1], s[4:5]
+; GFX9-NEXT:    s_lshr_b64 s[4:5], s[6:7], 1
+; GFX9-NEXT:    s_sub_i32 s12, s8, 64
+; GFX9-NEXT:    s_sub_i32 s10, 64, s8
 ; GFX9-NEXT:    s_cmp_lt_u32 s8, 64
-; GFX9-NEXT:    s_cselect_b32 s15, 1, 0
+; GFX9-NEXT:    s_cselect_b32 s13, 1, 0
 ; GFX9-NEXT:    s_cmp_eq_u32 s8, 0
 ; GFX9-NEXT:    s_cselect_b32 s16, 1, 0
-; GFX9-NEXT:    s_lshr_b64 s[6:7], s[0:1], s8
-; GFX9-NEXT:    s_lshl_b64 s[12:13], s[0:1], s12
-; GFX9-NEXT:    s_lshr_b64 s[8:9], s[4:5], s8
-; GFX9-NEXT:    s_or_b64 s[8:9], s[8:9], s[12:13]
-; GFX9-NEXT:    s_lshr_b64 s[0:1], s[0:1], s14
-; GFX9-NEXT:    s_cmp_lg_u32 s15, 0
-; GFX9-NEXT:    s_cselect_b64 s[0:1], s[8:9], s[0:1]
+; GFX9-NEXT:    s_lshr_b64 s[6:7], s[4:5], s8
+; GFX9-NEXT:    s_lshl_b64 s[10:11], s[4:5], s10
+; GFX9-NEXT:    s_lshr_b64 s[8:9], s[0:1], s8
+; GFX9-NEXT:    s_or_b64 s[8:9], s[8:9], s[10:11]
+; GFX9-NEXT:    s_lshr_b64 s[4:5], s[4:5], s12
+; GFX9-NEXT:    s_cmp_lg_u32 s13, 0
+; GFX9-NEXT:    s_cselect_b64 s[4:5], s[8:9], s[4:5]
 ; GFX9-NEXT:    s_cmp_lg_u32 s16, 0
-; GFX9-NEXT:    s_cselect_b64 s[0:1], s[4:5], s[0:1]
-; GFX9-NEXT:    s_cmp_lg_u32 s15, 0
+; GFX9-NEXT:    s_cselect_b64 s[0:1], s[0:1], s[4:5]
+; GFX9-NEXT:    s_cmp_lg_u32 s13, 0
 ; GFX9-NEXT:    s_cselect_b64 s[4:5], s[6:7], 0
-; GFX9-NEXT:    s_or_b64 s[0:1], s[10:11], s[0:1]
+; GFX9-NEXT:    s_or_b64 s[0:1], s[14:15], s[0:1]
 ; GFX9-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
 ; GFX9-NEXT:    ; return to shader part epilog
 ;
@@ -4850,37 +4850,37 @@ define amdgpu_ps i128 @s_fshl_i128(i128 inreg %lhs, i128 inreg %rhs, i128 inreg 
 ; GFX10-NEXT:    s_sub_i32 s9, s12, 64
 ; GFX10-NEXT:    s_sub_i32 s10, 64, s12
 ; GFX10-NEXT:    s_cmp_lt_u32 s12, 64
-; GFX10-NEXT:    s_cselect_b32 s16, 1, 0
+; GFX10-NEXT:    s_cselect_b32 s18, 1, 0
 ; GFX10-NEXT:    s_cmp_eq_u32 s12, 0
-; GFX10-NEXT:    s_cselect_b32 s17, 1, 0
-; GFX10-NEXT:    s_lshl_b64 s[14:15], s[2:3], s12
-; GFX10-NEXT:    s_lshr_b64 s[10:11], s[0:1], s10
+; GFX10-NEXT:    s_cselect_b32 s19, 1, 0
+; GFX10-NEXT:    s_lshl_b64 s[16:17], s[2:3], s12
+; GFX10-NEXT:    s_lshr_b64 s[14:15], s[0:1], s10
 ; GFX10-NEXT:    s_lshl_b64 s[12:13], s[0:1], s12
-; GFX10-NEXT:    s_or_b64 s[10:11], s[10:11], s[14:15]
+; GFX10-NEXT:    s_or_b64 s[14:15], s[14:15], s[16:17]
 ; GFX10-NEXT:    s_lshl_b64 s[0:1], s[0:1], s9
-; GFX10-NEXT:    s_cmp_lg_u32 s16, 0
+; GFX10-NEXT:    s_cmp_lg_u32 s18, 0
 ; GFX10-NEXT:    s_cselect_b64 s[12:13], s[12:13], 0
-; GFX10-NEXT:    s_cselect_b64 s[0:1], s[10:11], s[0:1]
-; GFX10-NEXT:    s_cmp_lg_u32 s17, 0
+; GFX10-NEXT:    s_cselect_b64 s[0:1], s[14:15], s[0:1]
+; GFX10-NEXT:    s_cmp_lg_u32 s19, 0
 ; GFX10-NEXT:    s_cselect_b64 s[2:3], s[2:3], s[0:1]
-; GFX10-NEXT:    s_sub_i32 s9, 64, 1
 ; GFX10-NEXT:    s_lshr_b64 s[0:1], s[4:5], 1
-; GFX10-NEXT:    s_lshl_b64 s[4:5], s[6:7], s9
-; GFX10-NEXT:    s_lshr_b64 s[6:7], s[6:7], 1
-; GFX10-NEXT:    s_or_b64 s[0:1], s[0:1], s[4:5]
+; GFX10-NEXT:    s_lshl_b32 s5, s6, 31
+; GFX10-NEXT:    s_mov_b32 s4, s11
 ; GFX10-NEXT:    s_sub_i32 s14, s8, 64
+; GFX10-NEXT:    s_or_b64 s[0:1], s[0:1], s[4:5]
+; GFX10-NEXT:    s_lshr_b64 s[4:5], s[6:7], 1
 ; GFX10-NEXT:    s_sub_i32 s9, 64, s8
 ; GFX10-NEXT:    s_cmp_lt_u32 s8, 64
 ; GFX10-NEXT:    s_cselect_b32 s15, 1, 0
 ; GFX10-NEXT:    s_cmp_eq_u32 s8, 0
 ; GFX10-NEXT:    s_cselect_b32 s16, 1, 0
-; GFX10-NEXT:    s_lshr_b64 s[4:5], s[0:1], s8
-; GFX10-NEXT:    s_lshl_b64 s[10:11], s[6:7], s9
-; GFX10-NEXT:    s_lshr_b64 s[8:9], s[6:7], s8
-; GFX10-NEXT:    s_or_b64 s[4:5], s[4:5], s[10:11]
-; GFX10-NEXT:    s_lshr_b64 s[6:7], s[6:7], s14
+; GFX10-NEXT:    s_lshr_b64 s[6:7], s[0:1], s8
+; GFX10-NEXT:    s_lshl_b64 s[10:11], s[4:5], s9
+; GFX10-NEXT:    s_lshr_b64 s[8:9], s[4:5], s8
+; GFX10-NEXT:    s_or_b64 s[6:7], s[6:7], s[10:11]
+; GFX10-NEXT:    s_lshr_b64 s[4:5], s[4:5], s14
 ; GFX10-NEXT:    s_cmp_lg_u32 s15, 0
-; GFX10-NEXT:    s_cselect_b64 s[4:5], s[4:5], s[6:7]
+; GFX10-NEXT:    s_cselect_b64 s[4:5], s[6:7], s[4:5]
 ; GFX10-NEXT:    s_cmp_lg_u32 s16, 0
 ; GFX10-NEXT:    s_cselect_b64 s[0:1], s[0:1], s[4:5]
 ; GFX10-NEXT:    s_cmp_lg_u32 s15, 0
@@ -4914,26 +4914,24 @@ define i128 @v_fshl_i128(i128 %lhs, i128 %rhs, i128 %amt) {
 ; GFX6-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc
 ; GFX6-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v14
-; GFX6-NEXT:    s_sub_i32 s4, 64, 1
 ; GFX6-NEXT:    v_cndmask_b32_e32 v12, v0, v2, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v13, v1, v3, vcc
 ; GFX6-NEXT:    v_lshr_b64 v[0:1], v[4:5], 1
-; GFX6-NEXT:    v_lshl_b64 v[2:3], v[6:7], s4
-; GFX6-NEXT:    v_lshr_b64 v[4:5], v[6:7], 1
+; GFX6-NEXT:    v_lshlrev_b32_e32 v2, 31, v6
+; GFX6-NEXT:    v_or_b32_e32 v1, v1, v2
+; GFX6-NEXT:    v_lshr_b64 v[2:3], v[6:7], 1
 ; GFX6-NEXT:    v_sub_i32_e32 v6, vcc, 64, v15
-; GFX6-NEXT:    v_or_b32_e32 v0, v0, v2
-; GFX6-NEXT:    v_or_b32_e32 v1, v1, v3
-; GFX6-NEXT:    v_lshr_b64 v[2:3], v[0:1], v15
-; GFX6-NEXT:    v_lshl_b64 v[6:7], v[4:5], v6
 ; GFX6-NEXT:    v_subrev_i32_e32 v14, vcc, 64, v15
-; GFX6-NEXT:    v_or_b32_e32 v6, v2, v6
-; GFX6-NEXT:    v_or_b32_e32 v7, v3, v7
-; GFX6-NEXT:    v_lshr_b64 v[2:3], v[4:5], v14
+; GFX6-NEXT:    v_lshr_b64 v[4:5], v[0:1], v15
+; GFX6-NEXT:    v_lshl_b64 v[6:7], v[2:3], v6
+; GFX6-NEXT:    v_lshr_b64 v[8:9], v[2:3], v15
+; GFX6-NEXT:    v_lshr_b64 v[2:3], v[2:3], v14
+; GFX6-NEXT:    v_or_b32_e32 v4, v4, v6
 ; GFX6-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v15
-; GFX6-NEXT:    v_lshr_b64 v[8:9], v[4:5], v15
-; GFX6-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc
+; GFX6-NEXT:    v_or_b32_e32 v5, v5, v7
+; GFX6-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc
 ; GFX6-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v15
-; GFX6-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e64 v0, v2, v0, s[4:5]
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, v3, v1, s[4:5]
 ; GFX6-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
@@ -4965,26 +4963,24 @@ define i128 @v_fshl_i128(i128 %lhs, i128 %rhs, i128 %amt) {
 ; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc
 ; GFX8-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v14
-; GFX8-NEXT:    s_sub_i32 s4, 64, 1
 ; GFX8-NEXT:    v_cndmask_b32_e32 v12, v0, v2, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v13, v1, v3, vcc
 ; GFX8-NEXT:    v_lshrrev_b64 v[0:1], 1, v[4:5]
-; GFX8-NEXT:    v_lshlrev_b64 v[2:3], s4, v[6:7]
-; GFX8-NEXT:    v_lshrrev_b64 v[4:5], 1, v[6:7]
+; GFX8-NEXT:    v_lshlrev_b32_e32 v2, 31, v6
+; GFX8-NEXT:    v_or_b32_e32 v1, v1, v2
+; GFX8-NEXT:    v_lshrrev_b64 v[2:3], 1, v[6:7]
 ; GFX8-NEXT:    v_sub_u32_e32 v6, vcc, 64, v15
-; GFX8-NEXT:    v_or_b32_e32 v0, v0, v2
-; GFX8-NEXT:    v_or_b32_e32 v1, v1, v3
-; GFX8-NEXT:    v_lshrrev_b64 v[2:3], v15, v[0:1]
-; GFX8-NEXT:    v_lshlrev_b64 v[6:7], v6, v[4:5]
 ; GFX8-NEXT:    v_subrev_u32_e32 v14, vcc, 64, v15
-; GFX8-NEXT:    v_or_b32_e32 v6, v2, v6
-; GFX8-NEXT:    v_or_b32_e32 v7, v3, v7
-; GFX8-NEXT:    v_lshrrev_b64 v[2:3], v14, v[4:5]
+; GFX8-NEXT:    v_lshrrev_b64 v[4:5], v15, v[0:1]
+; GFX8-NEXT:    v_lshlrev_b64 v[6:7], v6, v[2:3]
+; GFX8-NEXT:    v_lshrrev_b64 v[8:9], v15, v[2:3]
+; GFX8-NEXT:    v_lshrrev_b64 v[2:3], v14, v[2:3]
+; GFX8-NEXT:    v_or_b32_e32 v4, v4, v6
 ; GFX8-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v15
-; GFX8-NEXT:    v_lshrrev_b64 v[8:9], v15, v[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc
+; GFX8-NEXT:    v_or_b32_e32 v5, v5, v7
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc
 ; GFX8-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v15
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e64 v0, v2, v0, s[4:5]
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, v3, v1, s[4:5]
 ; GFX8-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
@@ -5016,26 +5012,24 @@ define i128 @v_fshl_i128(i128 %lhs, i128 %rhs, i128 %amt) {
 ; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc
 ; GFX9-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v14
-; GFX9-NEXT:    s_sub_i32 s4, 64, 1
 ; GFX9-NEXT:    v_cndmask_b32_e32 v12, v0, v2, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v13, v1, v3, vcc
 ; GFX9-NEXT:    v_lshrrev_b64 v[0:1], 1, v[4:5]
-; GFX9-NEXT:    v_lshlrev_b64 v[2:3], s4, v[6:7]
-; GFX9-NEXT:    v_lshrrev_b64 v[4:5], 1, v[6:7]
+; GFX9-NEXT:    v_lshlrev_b32_e32 v2, 31, v6
+; GFX9-NEXT:    v_or_b32_e32 v1, v1, v2
+; GFX9-NEXT:    v_lshrrev_b64 v[2:3], 1, v[6:7]
 ; GFX9-NEXT:    v_sub_u32_e32 v6, 64, v15
-; GFX9-NEXT:    v_or_b32_e32 v0, v0, v2
-; GFX9-NEXT:    v_or_b32_e32 v1, v1, v3
-; GFX9-NEXT:    v_lshrrev_b64 v[2:3], v15, v[0:1]
-; GFX9-NEXT:    v_lshlrev_b64 v[6:7], v6, v[4:5]
 ; GFX9-NEXT:    v_subrev_u32_e32 v14, 64, v15
-; GFX9-NEXT:    v_or_b32_e32 v6, v2, v6
-; GFX9-NEXT:    v_or_b32_e32 v7, v3, v7
-; GFX9-NEXT:    v_lshrrev_b64 v[2:3], v14, v[4:5]
+; GFX9-NEXT:    v_lshrrev_b64 v[4:5], v15, v[0:1]
+; GFX9-NEXT:    v_lshlrev_b64 v[6:7], v6, v[2:3]
+; GFX9-NEXT:    v_lshrrev_b64 v[8:9], v15, v[2:3]
+; GFX9-NEXT:    v_lshrrev_b64 v[2:3], v14, v[2:3]
+; GFX9-NEXT:    v_or_b32_e32 v4, v4, v6
 ; GFX9-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v15
-; GFX9-NEXT:    v_lshrrev_b64 v[8:9], v15, v[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc
+; GFX9-NEXT:    v_or_b32_e32 v5, v5, v7
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc
 ; GFX9-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v15
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, v0, s[4:5]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, v3, v1, s[4:5]
 ; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
@@ -5051,51 +5045,49 @@ define i128 @v_fshl_i128(i128 %lhs, i128 %rhs, i128 %amt) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX10-NEXT:    s_movk_i32 s4, 0x7f
-; GFX10-NEXT:    v_xor_b32_e32 v10, -1, v8
-; GFX10-NEXT:    v_and_b32_e32 v18, s4, v8
-; GFX10-NEXT:    s_sub_i32 s5, 64, 1
 ; GFX10-NEXT:    v_lshrrev_b64 v[4:5], 1, v[4:5]
-; GFX10-NEXT:    v_lshlrev_b64 v[8:9], s5, v[6:7]
-; GFX10-NEXT:    v_and_b32_e32 v19, s4, v10
-; GFX10-NEXT:    v_sub_nc_u32_e32 v11, 64, v18
-; GFX10-NEXT:    v_lshlrev_b64 v[12:13], v18, v[2:3]
+; GFX10-NEXT:    v_and_b32_e32 v18, s4, v8
+; GFX10-NEXT:    v_xor_b32_e32 v8, -1, v8
+; GFX10-NEXT:    v_lshlrev_b32_e32 v12, 31, v6
 ; GFX10-NEXT:    v_lshrrev_b64 v[6:7], 1, v[6:7]
+; GFX10-NEXT:    v_sub_nc_u32_e32 v9, 64, v18
+; GFX10-NEXT:    v_and_b32_e32 v19, s4, v8
+; GFX10-NEXT:    v_lshlrev_b64 v[10:11], v18, v[2:3]
+; GFX10-NEXT:    v_or_b32_e32 v5, v5, v12
 ; GFX10-NEXT:    v_subrev_nc_u32_e32 v20, 64, v18
+; GFX10-NEXT:    v_lshrrev_b64 v[8:9], v9, v[0:1]
 ; GFX10-NEXT:    v_sub_nc_u32_e32 v16, 64, v19
-; GFX10-NEXT:    v_lshrrev_b64 v[10:11], v11, v[0:1]
-; GFX10-NEXT:    v_or_b32_e32 v4, v4, v8
-; GFX10-NEXT:    v_or_b32_e32 v5, v5, v9
-; GFX10-NEXT:    v_lshlrev_b64 v[8:9], v18, v[0:1]
-; GFX10-NEXT:    v_lshlrev_b64 v[16:17], v16, v[6:7]
-; GFX10-NEXT:    v_lshlrev_b64 v[0:1], v20, v[0:1]
-; GFX10-NEXT:    v_or_b32_e32 v12, v10, v12
+; GFX10-NEXT:    v_lshlrev_b64 v[12:13], v18, v[0:1]
 ; GFX10-NEXT:    v_lshrrev_b64 v[14:15], v19, v[4:5]
-; GFX10-NEXT:    v_subrev_nc_u32_e32 v10, 64, v19
+; GFX10-NEXT:    v_lshlrev_b64 v[0:1], v20, v[0:1]
 ; GFX10-NEXT:    v_cmp_gt_u32_e32 vcc_lo, 64, v18
-; GFX10-NEXT:    v_or_b32_e32 v13, v11, v13
+; GFX10-NEXT:    v_or_b32_e32 v10, v8, v10
+; GFX10-NEXT:    v_lshlrev_b64 v[16:17], v16, v[6:7]
+; GFX10-NEXT:    v_subrev_nc_u32_e32 v8, 64, v19
+; GFX10-NEXT:    v_or_b32_e32 v11, v9, v11
 ; GFX10-NEXT:    v_cmp_gt_u32_e64 s4, 64, v19
-; GFX10-NEXT:    v_cmp_eq_u32_e64 s5, 0, v19
-; GFX10-NEXT:    v_lshrrev_b64 v[10:11], v10, v[6:7]
+; GFX10-NEXT:    v_cndmask_b32_e32 v10, v0, v10, vcc_lo
+; GFX10-NEXT:    v_cmp_eq_u32_e64 s6, 0, v18
+; GFX10-NEXT:    v_lshrrev_b64 v[8:9], v8, v[6:7]
 ; GFX10-NEXT:    v_or_b32_e32 v14, v14, v16
 ; GFX10-NEXT:    v_or_b32_e32 v15, v15, v17
-; GFX10-NEXT:    v_cndmask_b32_e32 v12, v0, v12, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v13, v1, v13, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v11, v1, v11, vcc_lo
 ; GFX10-NEXT:    v_lshrrev_b64 v[0:1], v19, v[6:7]
-; GFX10-NEXT:    v_cmp_eq_u32_e64 s6, 0, v18
-; GFX10-NEXT:    v_cndmask_b32_e64 v10, v10, v14, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v11, v15, s4
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, 0, v9, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v8, 0, v8, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v12, v2, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v13, v3, s6
+; GFX10-NEXT:    v_cmp_eq_u32_e64 s5, 0, v19
+; GFX10-NEXT:    v_cndmask_b32_e64 v8, v8, v14, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, v9, v15, s4
+; GFX10-NEXT:    v_cndmask_b32_e32 v12, 0, v12, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v7, 0, v13, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, v10, v2, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, v8, v4, s5
 ; GFX10-NEXT:    v_cndmask_b32_e64 v5, v6, v5, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0, v1, s4
 ; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, v0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v10, v4, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v8, 0, v1, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, v11, v3, s6
+; GFX10-NEXT:    v_or_b32_e32 v0, v12, v4
 ; GFX10-NEXT:    v_or_b32_e32 v1, v7, v5
-; GFX10-NEXT:    v_or_b32_e32 v3, v3, v9
 ; GFX10-NEXT:    v_or_b32_e32 v2, v2, v6
-; GFX10-NEXT:    v_or_b32_e32 v0, v8, v4
+; GFX10-NEXT:    v_or_b32_e32 v3, v3, v8
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
   %result = call i128 @llvm.fshl.i128(i128 %lhs, i128 %rhs, i128 %amt)
   ret i128 %result
@@ -5117,34 +5109,34 @@ define amdgpu_ps <4 x float> @v_fshl_i128_ssv(i128 inreg %lhs, i128 inreg %rhs, 
 ; GFX6-NEXT:    v_or_b32_e32 v3, v1, v3
 ; GFX6-NEXT:    v_lshl_b64 v[0:1], s[0:1], v8
 ; GFX6-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v6
-; GFX6-NEXT:    s_sub_i32 s8, 64, 1
 ; GFX6-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
+; GFX6-NEXT:    s_mov_b32 s8, 0
 ; GFX6-NEXT:    v_cndmask_b32_e32 v8, 0, v4, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v9, 0, v5, vcc
 ; GFX6-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX6-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v6
 ; GFX6-NEXT:    v_mov_b32_e32 v3, s3
-; GFX6-NEXT:    s_lshr_b64 s[2:3], s[4:5], 1
-; GFX6-NEXT:    s_lshl_b64 s[4:5], s[6:7], s8
-; GFX6-NEXT:    s_lshr_b64 s[0:1], s[6:7], 1
+; GFX6-NEXT:    s_lshr_b64 s[0:1], s[4:5], 1
+; GFX6-NEXT:    s_lshl_b32 s9, s6, 31
+; GFX6-NEXT:    s_lshr_b64 s[2:3], s[6:7], 1
 ; GFX6-NEXT:    v_cndmask_b32_e32 v6, v0, v2, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v10, v1, v3, vcc
 ; GFX6-NEXT:    v_sub_i32_e32 v2, vcc, 64, v7
-; GFX6-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
-; GFX6-NEXT:    v_lshr_b64 v[0:1], s[2:3], v7
-; GFX6-NEXT:    v_lshl_b64 v[2:3], s[0:1], v2
+; GFX6-NEXT:    s_or_b64 s[0:1], s[0:1], s[8:9]
+; GFX6-NEXT:    v_lshr_b64 v[0:1], s[0:1], v7
+; GFX6-NEXT:    v_lshl_b64 v[2:3], s[2:3], v2
 ; GFX6-NEXT:    v_subrev_i32_e32 v11, vcc, 64, v7
 ; GFX6-NEXT:    v_or_b32_e32 v2, v0, v2
 ; GFX6-NEXT:    v_or_b32_e32 v3, v1, v3
-; GFX6-NEXT:    v_lshr_b64 v[0:1], s[0:1], v11
+; GFX6-NEXT:    v_lshr_b64 v[0:1], s[2:3], v11
 ; GFX6-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v7
-; GFX6-NEXT:    v_lshr_b64 v[4:5], s[0:1], v7
+; GFX6-NEXT:    v_lshr_b64 v[4:5], s[2:3], v7
 ; GFX6-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX6-NEXT:    v_mov_b32_e32 v2, s2
+; GFX6-NEXT:    v_mov_b32_e32 v2, s0
+; GFX6-NEXT:    v_mov_b32_e32 v3, s1
 ; GFX6-NEXT:    v_cmp_eq_u32_e64 s[0:1], 0, v7
-; GFX6-NEXT:    v_mov_b32_e32 v3, s3
 ; GFX6-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[0:1]
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[0:1]
 ; GFX6-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc
@@ -5170,34 +5162,34 @@ define amdgpu_ps <4 x float> @v_fshl_i128_ssv(i128 inreg %lhs, i128 inreg %rhs, 
 ; GFX8-NEXT:    v_or_b32_e32 v3, v1, v3
 ; GFX8-NEXT:    v_lshlrev_b64 v[0:1], v8, s[0:1]
 ; GFX8-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v6
-; GFX8-NEXT:    s_sub_i32 s8, 64, 1
 ; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
+; GFX8-NEXT:    s_mov_b32 s8, 0
 ; GFX8-NEXT:    v_cndmask_b32_e32 v8, 0, v4, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v9, 0, v5, vcc
 ; GFX8-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX8-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v6
 ; GFX8-NEXT:    v_mov_b32_e32 v3, s3
-; GFX8-NEXT:    s_lshr_b64 s[2:3], s[4:5], 1
-; GFX8-NEXT:    s_lshl_b64 s[4:5], s[6:7], s8
-; GFX8-NEXT:    s_lshr_b64 s[0:1], s[6:7], 1
+; GFX8-NEXT:    s_lshr_b64 s[0:1], s[4:5], 1
+; GFX8-NEXT:    s_lshl_b32 s9, s6, 31
+; GFX8-NEXT:    s_lshr_b64 s[2:3], s[6:7], 1
 ; GFX8-NEXT:    v_cndmask_b32_e32 v6, v0, v2, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v10, v1, v3, vcc
 ; GFX8-NEXT:    v_sub_u32_e32 v2, vcc, 64, v7
-; GFX8-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
-; GFX8-NEXT:    v_lshrrev_b64 v[0:1], v7, s[2:3]
-; GFX8-NEXT:    v_lshlrev_b64 v[2:3], v2, s[0:1]
+; GFX8-NEXT:    s_or_b64 s[0:1], s[0:1], s[8:9]
+; GFX8-NEXT:    v_lshrrev_b64 v[0:1], v7, s[0:1]
+; GFX8-NEXT:    v_lshlrev_b64 v[2:3], v2, s[2:3]
 ; GFX8-NEXT:    v_subrev_u32_e32 v11, vcc, 64, v7
 ; GFX8-NEXT:    v_or_b32_e32 v2, v0, v2
 ; GFX8-NEXT:    v_or_b32_e32 v3, v1, v3
-; GFX8-NEXT:    v_lshrrev_b64 v[0:1], v11, s[0:1]
+; GFX8-NEXT:    v_lshrrev_b64 v[0:1], v11, s[2:3]
 ; GFX8-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v7
-; GFX8-NEXT:    v_lshrrev_b64 v[4:5], v7, s[0:1]
+; GFX8-NEXT:    v_lshrrev_b64 v[4:5], v7, s[2:3]
 ; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX8-NEXT:    v_mov_b32_e32 v2, s2
+; GFX8-NEXT:    v_mov_b32_e32 v2, s0
+; GFX8-NEXT:    v_mov_b32_e32 v3, s1
 ; GFX8-NEXT:    v_cmp_eq_u32_e64 s[0:1], 0, v7
-; GFX8-NEXT:    v_mov_b32_e32 v3, s3
 ; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[0:1]
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[0:1]
 ; GFX8-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc
@@ -5223,34 +5215,34 @@ define amdgpu_ps <4 x float> @v_fshl_i128_ssv(i128 inreg %lhs, i128 inreg %rhs, 
 ; GFX9-NEXT:    v_or_b32_e32 v3, v1, v3
 ; GFX9-NEXT:    v_lshlrev_b64 v[0:1], v8, s[0:1]
 ; GFX9-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v6
-; GFX9-NEXT:    s_sub_i32 s8, 64, 1
 ; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
+; GFX9-NEXT:    s_mov_b32 s8, 0
 ; GFX9-NEXT:    v_cndmask_b32_e32 v8, 0, v4, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v9, 0, v5, vcc
 ; GFX9-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX9-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v6
+; GFX9-NEXT:    s_lshr_b64 s[0:1], s[4:5], 1
+; GFX9-NEXT:    s_lshl_b32 s9, s6, 31
 ; GFX9-NEXT:    v_mov_b32_e32 v3, s3
-; GFX9-NEXT:    s_lshr_b64 s[2:3], s[4:5], 1
-; GFX9-NEXT:    s_lshl_b64 s[4:5], s[6:7], s8
 ; GFX9-NEXT:    v_cndmask_b32_e32 v6, v0, v2, vcc
-; GFX9-NEXT:    s_lshr_b64 s[0:1], s[6:7], 1
-; GFX9-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
+; GFX9-NEXT:    s_lshr_b64 s[2:3], s[6:7], 1
+; GFX9-NEXT:    s_or_b64 s[0:1], s[0:1], s[8:9]
 ; GFX9-NEXT:    v_sub_u32_e32 v2, 64, v7
 ; GFX9-NEXT:    v_cndmask_b32_e32 v10, v1, v3, vcc
-; GFX9-NEXT:    v_lshrrev_b64 v[0:1], v7, s[2:3]
-; GFX9-NEXT:    v_lshlrev_b64 v[2:3], v2, s[0:1]
+; GFX9-NEXT:    v_lshrrev_b64 v[0:1], v7, s[0:1]
+; GFX9-NEXT:    v_lshlrev_b64 v[2:3], v2, s[2:3]
 ; GFX9-NEXT:    v_subrev_u32_e32 v11, 64, v7
 ; GFX9-NEXT:    v_or_b32_e32 v2, v0, v2
 ; GFX9-NEXT:    v_or_b32_e32 v3, v1, v3
-; GFX9-NEXT:    v_lshrrev_b64 v[0:1], v11, s[0:1]
+; GFX9-NEXT:    v_lshrrev_b64 v[0:1], v11, s[2:3]
 ; GFX9-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v7
-; GFX9-NEXT:    v_lshrrev_b64 v[4:5], v7, s[0:1]
+; GFX9-NEXT:    v_lshrrev_b64 v[4:5], v7, s[2:3]
 ; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX9-NEXT:    v_mov_b32_e32 v2, s2
+; GFX9-NEXT:    v_mov_b32_e32 v2, s0
+; GFX9-NEXT:    v_mov_b32_e32 v3, s1
 ; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], 0, v7
-; GFX9-NEXT:    v_mov_b32_e32 v3, s3
 ; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[0:1]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[0:1]
 ; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc
@@ -5263,15 +5255,15 @@ define amdgpu_ps <4 x float> @v_fshl_i128_ssv(i128 inreg %lhs, i128 inreg %rhs, 
 ;
 ; GFX10-LABEL: v_fshl_i128_ssv:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    s_movk_i32 s8, 0x7f
+; GFX10-NEXT:    s_movk_i32 s9, 0x7f
 ; GFX10-NEXT:    v_xor_b32_e32 v4, -1, v0
-; GFX10-NEXT:    v_and_b32_e32 v12, s8, v0
-; GFX10-NEXT:    s_sub_i32 s9, 64, 1
+; GFX10-NEXT:    v_and_b32_e32 v12, s9, v0
+; GFX10-NEXT:    s_mov_b32 s8, 0
 ; GFX10-NEXT:    s_lshr_b64 s[4:5], s[4:5], 1
-; GFX10-NEXT:    v_and_b32_e32 v13, s8, v4
+; GFX10-NEXT:    v_and_b32_e32 v13, s9, v4
 ; GFX10-NEXT:    v_sub_nc_u32_e32 v2, 64, v12
 ; GFX10-NEXT:    v_lshlrev_b64 v[0:1], v12, s[2:3]
-; GFX10-NEXT:    s_lshl_b64 s[8:9], s[6:7], s9
+; GFX10-NEXT:    s_lshl_b32 s9, s6, 31
 ; GFX10-NEXT:    s_lshr_b64 s[6:7], s[6:7], 1
 ; GFX10-NEXT:    s_or_b64 s[8:9], s[4:5], s[8:9]
 ; GFX10-NEXT:    v_lshrrev_b64 v[2:3], v2, s[0:1]
@@ -5335,16 +5327,14 @@ define amdgpu_ps <4 x float> @v_fshl_i128_svs(i128 inreg %lhs, i128 %rhs, i128 i
 ; GFX6-NEXT:    s_cselect_b64 s[6:7], s[6:7], 0
 ; GFX6-NEXT:    s_cselect_b64 s[0:1], s[8:9], s[0:1]
 ; GFX6-NEXT:    s_cmp_lg_u32 s13, 0
-; GFX6-NEXT:    s_cselect_b64 s[0:1], s[2:3], s[0:1]
-; GFX6-NEXT:    s_sub_i32 s2, 64, 1
-; GFX6-NEXT:    v_lshl_b64 v[4:5], v[2:3], s2
 ; GFX6-NEXT:    v_lshr_b64 v[0:1], v[0:1], 1
+; GFX6-NEXT:    s_cselect_b64 s[0:1], s[2:3], s[0:1]
+; GFX6-NEXT:    v_lshlrev_b32_e32 v4, 31, v2
 ; GFX6-NEXT:    v_lshr_b64 v[2:3], v[2:3], 1
 ; GFX6-NEXT:    s_sub_i32 s3, 64, s4
 ; GFX6-NEXT:    s_sub_i32 s2, s4, 64
+; GFX6-NEXT:    v_or_b32_e32 v1, v1, v4
 ; GFX6-NEXT:    s_cmp_lt_u32 s4, 64
-; GFX6-NEXT:    v_or_b32_e32 v0, v0, v4
-; GFX6-NEXT:    v_or_b32_e32 v1, v1, v5
 ; GFX6-NEXT:    s_cselect_b32 s5, 1, 0
 ; GFX6-NEXT:    s_cmp_eq_u32 s4, 0
 ; GFX6-NEXT:    v_lshr_b64 v[4:5], v[0:1], s4
@@ -5392,16 +5382,14 @@ define amdgpu_ps <4 x float> @v_fshl_i128_svs(i128 inreg %lhs, i128 %rhs, i128 i
 ; GFX8-NEXT:    s_cselect_b64 s[6:7], s[6:7], 0
 ; GFX8-NEXT:    s_cselect_b64 s[0:1], s[8:9], s[0:1]
 ; GFX8-NEXT:    s_cmp_lg_u32 s13, 0
-; GFX8-NEXT:    s_cselect_b64 s[0:1], s[2:3], s[0:1]
-; GFX8-NEXT:    s_sub_i32 s2, 64, 1
-; GFX8-NEXT:    v_lshlrev_b64 v[4:5], s2, v[2:3]
 ; GFX8-NEXT:    v_lshrrev_b64 v[0:1], 1, v[0:1]
+; GFX8-NEXT:    s_cselect_b64 s[0:1], s[2:3], s[0:1]
+; GFX8-NEXT:    v_lshlrev_b32_e32 v4, 31, v2
 ; GFX8-NEXT:    v_lshrrev_b64 v[2:3], 1, v[2:3]
 ; GFX8-NEXT:    s_sub_i32 s3, 64, s4
 ; GFX8-NEXT:    s_sub_i32 s2, s4, 64
+; GFX8-NEXT:    v_or_b32_e32 v1, v1, v4
 ; GFX8-NEXT:    s_cmp_lt_u32 s4, 64
-; GFX8-NEXT:    v_or_b32_e32 v0, v0, v4
-; GFX8-NEXT:    v_or_b32_e32 v1, v1, v5
 ; GFX8-NEXT:    s_cselect_b32 s5, 1, 0
 ; GFX8-NEXT:    s_cmp_eq_u32 s4, 0
 ; GFX8-NEXT:    v_lshrrev_b64 v[4:5], s4, v[0:1]
@@ -5449,16 +5437,14 @@ define amdgpu_ps <4 x float> @v_fshl_i128_svs(i128 inreg %lhs, i128 %rhs, i128 i
 ; GFX9-NEXT:    s_cselect_b64 s[6:7], s[6:7], 0
 ; GFX9-NEXT:    s_cselect_b64 s[0:1], s[8:9], s[0:1]
 ; GFX9-NEXT:    s_cmp_lg_u32 s13, 0
-; GFX9-NEXT:    s_cselect_b64 s[0:1], s[2:3], s[0:1]
-; GFX9-NEXT:    s_sub_i32 s2, 64, 1
-; GFX9-NEXT:    v_lshlrev_b64 v[4:5], s2, v[2:3]
 ; GFX9-NEXT:    v_lshrrev_b64 v[0:1], 1, v[0:1]
+; GFX9-NEXT:    s_cselect_b64 s[0:1], s[2:3], s[0:1]
+; GFX9-NEXT:    v_lshlrev_b32_e32 v4, 31, v2
 ; GFX9-NEXT:    v_lshrrev_b64 v[2:3], 1, v[2:3]
 ; GFX9-NEXT:    s_sub_i32 s3, 64, s4
 ; GFX9-NEXT:    s_sub_i32 s2, s4, 64
+; GFX9-NEXT:    v_or_b32_e32 v1, v1, v4
 ; GFX9-NEXT:    s_cmp_lt_u32 s4, 64
-; GFX9-NEXT:    v_or_b32_e32 v0, v0, v4
-; GFX9-NEXT:    v_or_b32_e32 v1, v1, v5
 ; GFX9-NEXT:    s_cselect_b32 s5, 1, 0
 ; GFX9-NEXT:    s_cmp_eq_u32 s4, 0
 ; GFX9-NEXT:    v_lshrrev_b64 v[4:5], s4, v[0:1]
@@ -5495,8 +5481,10 @@ define amdgpu_ps <4 x float> @v_fshl_i128_svs(i128 inreg %lhs, i128 %rhs, i128 i
 ; GFX10-NEXT:    s_sub_i32 s5, s8, 64
 ; GFX10-NEXT:    s_sub_i32 s6, 64, s8
 ; GFX10-NEXT:    s_cmp_lt_u32 s8, 64
+; GFX10-NEXT:    v_lshlrev_b32_e32 v4, 31, v2
 ; GFX10-NEXT:    s_cselect_b32 s12, 1, 0
 ; GFX10-NEXT:    s_cmp_eq_u32 s8, 0
+; GFX10-NEXT:    v_lshrrev_b64 v[2:3], 1, v[2:3]
 ; GFX10-NEXT:    s_cselect_b32 s13, 1, 0
 ; GFX10-NEXT:    s_lshl_b64 s[10:11], s[2:3], s8
 ; GFX10-NEXT:    s_lshr_b64 s[6:7], s[0:1], s6
@@ -5504,29 +5492,25 @@ define amdgpu_ps <4 x float> @v_fshl_i128_svs(i128 inreg %lhs, i128 %rhs, i128 i
 ; GFX10-NEXT:    s_or_b64 s[6:7], s[6:7], s[10:11]
 ; GFX10-NEXT:    s_lshl_b64 s[0:1], s[0:1], s5
 ; GFX10-NEXT:    s_cmp_lg_u32 s12, 0
+; GFX10-NEXT:    v_or_b32_e32 v1, v1, v4
 ; GFX10-NEXT:    s_cselect_b64 s[8:9], s[8:9], 0
 ; GFX10-NEXT:    s_cselect_b64 s[0:1], s[6:7], s[0:1]
 ; GFX10-NEXT:    s_cmp_lg_u32 s13, 0
 ; GFX10-NEXT:    s_cselect_b64 s[2:3], s[2:3], s[0:1]
-; GFX10-NEXT:    s_sub_i32 s0, 64, 1
-; GFX10-NEXT:    v_lshlrev_b64 v[4:5], s0, v[2:3]
-; GFX10-NEXT:    v_lshrrev_b64 v[2:3], 1, v[2:3]
 ; GFX10-NEXT:    s_sub_i32 s0, 64, s4
-; GFX10-NEXT:    v_or_b32_e32 v0, v0, v4
-; GFX10-NEXT:    v_or_b32_e32 v1, v1, v5
+; GFX10-NEXT:    v_lshrrev_b64 v[4:5], s4, v[0:1]
 ; GFX10-NEXT:    v_lshlrev_b64 v[6:7], s0, v[2:3]
 ; GFX10-NEXT:    s_sub_i32 s0, s4, 64
 ; GFX10-NEXT:    s_cmp_lt_u32 s4, 64
 ; GFX10-NEXT:    v_lshrrev_b64 v[8:9], s0, v[2:3]
-; GFX10-NEXT:    v_lshrrev_b64 v[4:5], s4, v[0:1]
 ; GFX10-NEXT:    s_cselect_b32 vcc_lo, 1, 0
 ; GFX10-NEXT:    s_cmp_eq_u32 s4, 0
-; GFX10-NEXT:    v_lshrrev_b64 v[2:3], s4, v[2:3]
-; GFX10-NEXT:    s_cselect_b32 s0, 1, 0
-; GFX10-NEXT:    s_and_b32 s1, 1, vcc_lo
 ; GFX10-NEXT:    v_or_b32_e32 v4, v4, v6
 ; GFX10-NEXT:    v_or_b32_e32 v5, v5, v7
+; GFX10-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX10-NEXT:    s_and_b32 s1, 1, vcc_lo
 ; GFX10-NEXT:    s_and_b32 s0, 1, s0
+; GFX10-NEXT:    v_lshrrev_b64 v[2:3], s4, v[2:3]
 ; GFX10-NEXT:    v_cndmask_b32_e32 v4, v8, v4, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e32 v5, v9, v5, vcc_lo
 ; GFX10-NEXT:    v_cmp_ne_u32_e64 vcc_lo, 0, s0
@@ -5554,47 +5538,47 @@ define amdgpu_ps <4 x float> @v_fshl_i128_vss(i128 %lhs, i128 inreg %rhs, i128 i
 ; GFX6-NEXT:    s_sub_i32 s6, 64, s8
 ; GFX6-NEXT:    s_sub_i32 s5, s8, 64
 ; GFX6-NEXT:    s_cmp_lt_u32 s8, 64
-; GFX6-NEXT:    s_cselect_b32 s7, 1, 0
+; GFX6-NEXT:    s_cselect_b32 s9, 1, 0
 ; GFX6-NEXT:    s_cmp_eq_u32 s8, 0
+; GFX6-NEXT:    s_cselect_b32 s10, 1, 0
 ; GFX6-NEXT:    v_lshr_b64 v[4:5], v[0:1], s6
 ; GFX6-NEXT:    v_lshl_b64 v[6:7], v[2:3], s8
-; GFX6-NEXT:    s_cselect_b32 s9, 1, 0
 ; GFX6-NEXT:    v_lshl_b64 v[8:9], v[0:1], s8
 ; GFX6-NEXT:    v_lshl_b64 v[0:1], v[0:1], s5
-; GFX6-NEXT:    s_and_b32 s5, 1, s7
+; GFX6-NEXT:    s_and_b32 s5, 1, s9
+; GFX6-NEXT:    s_lshl_b32 s9, s2, 31
+; GFX6-NEXT:    s_lshr_b64 s[0:1], s[0:1], 1
+; GFX6-NEXT:    s_mov_b32 s8, s7
 ; GFX6-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s5
+; GFX6-NEXT:    s_and_b32 s5, 1, s10
+; GFX6-NEXT:    s_or_b64 s[0:1], s[0:1], s[8:9]
+; GFX6-NEXT:    s_lshr_b64 s[2:3], s[2:3], 1
+; GFX6-NEXT:    s_sub_i32 s10, s4, 64
+; GFX6-NEXT:    s_sub_i32 s8, 64, s4
+; GFX6-NEXT:    s_cmp_lt_u32 s4, 64
 ; GFX6-NEXT:    v_or_b32_e32 v4, v4, v6
 ; GFX6-NEXT:    v_or_b32_e32 v5, v5, v7
-; GFX6-NEXT:    s_and_b32 s5, 1, s9
+; GFX6-NEXT:    s_cselect_b32 s11, 1, 0
+; GFX6-NEXT:    s_cmp_eq_u32 s4, 0
+; GFX6-NEXT:    s_cselect_b32 s12, 1, 0
 ; GFX6-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v7, 0, v9, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX6-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s5
-; GFX6-NEXT:    s_sub_i32 s5, 64, 1
-; GFX6-NEXT:    s_lshr_b64 s[6:7], s[2:3], 1
-; GFX6-NEXT:    s_lshr_b64 s[0:1], s[0:1], 1
-; GFX6-NEXT:    s_lshl_b64 s[2:3], s[2:3], s5
-; GFX6-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
-; GFX6-NEXT:    s_sub_i32 s10, s4, 64
-; GFX6-NEXT:    s_sub_i32 s8, 64, s4
-; GFX6-NEXT:    s_cmp_lt_u32 s4, 64
-; GFX6-NEXT:    s_cselect_b32 s11, 1, 0
-; GFX6-NEXT:    s_cmp_eq_u32 s4, 0
-; GFX6-NEXT:    s_cselect_b32 s12, 1, 0
-; GFX6-NEXT:    s_lshr_b64 s[2:3], s[6:7], s4
-; GFX6-NEXT:    s_lshl_b64 s[8:9], s[6:7], s8
+; GFX6-NEXT:    s_lshr_b64 s[6:7], s[2:3], s4
+; GFX6-NEXT:    s_lshl_b64 s[8:9], s[2:3], s8
 ; GFX6-NEXT:    s_lshr_b64 s[4:5], s[0:1], s4
 ; GFX6-NEXT:    s_or_b64 s[4:5], s[4:5], s[8:9]
-; GFX6-NEXT:    s_lshr_b64 s[6:7], s[6:7], s10
+; GFX6-NEXT:    s_lshr_b64 s[2:3], s[2:3], s10
 ; GFX6-NEXT:    s_cmp_lg_u32 s11, 0
-; GFX6-NEXT:    s_cselect_b64 s[4:5], s[4:5], s[6:7]
+; GFX6-NEXT:    s_cselect_b64 s[2:3], s[4:5], s[2:3]
 ; GFX6-NEXT:    s_cmp_lg_u32 s12, 0
-; GFX6-NEXT:    s_cselect_b64 s[0:1], s[0:1], s[4:5]
+; GFX6-NEXT:    s_cselect_b64 s[0:1], s[0:1], s[2:3]
 ; GFX6-NEXT:    s_cmp_lg_u32 s11, 0
 ; GFX6-NEXT:    v_cndmask_b32_e32 v2, v0, v2, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v3, v1, v3, vcc
-; GFX6-NEXT:    s_cselect_b64 s[2:3], s[2:3], 0
+; GFX6-NEXT:    s_cselect_b64 s[2:3], s[6:7], 0
 ; GFX6-NEXT:    v_or_b32_e32 v0, s0, v6
 ; GFX6-NEXT:    v_or_b32_e32 v1, s1, v7
 ; GFX6-NEXT:    v_or_b32_e32 v2, s2, v2
@@ -5609,47 +5593,47 @@ define amdgpu_ps <4 x float> @v_fshl_i128_vss(i128 %lhs, i128 inreg %rhs, i128 i
 ; GFX8-NEXT:    s_sub_i32 s6, 64, s8
 ; GFX8-NEXT:    s_sub_i32 s5, s8, 64
 ; GFX8-NEXT:    s_cmp_lt_u32 s8, 64
-; GFX8-NEXT:    s_cselect_b32 s7, 1, 0
+; GFX8-NEXT:    s_cselect_b32 s9, 1, 0
 ; GFX8-NEXT:    s_cmp_eq_u32 s8, 0
+; GFX8-NEXT:    s_cselect_b32 s10, 1, 0
 ; GFX8-NEXT:    v_lshrrev_b64 v[4:5], s6, v[0:1]
 ; GFX8-NEXT:    v_lshlrev_b64 v[6:7], s8, v[2:3]
-; GFX8-NEXT:    s_cselect_b32 s9, 1, 0
 ; GFX8-NEXT:    v_lshlrev_b64 v[8:9], s8, v[0:1]
 ; GFX8-NEXT:    v_lshlrev_b64 v[0:1], s5, v[0:1]
-; GFX8-NEXT:    s_and_b32 s5, 1, s7
+; GFX8-NEXT:    s_and_b32 s5, 1, s9
+; GFX8-NEXT:    s_lshl_b32 s9, s2, 31
+; GFX8-NEXT:    s_lshr_b64 s[0:1], s[0:1], 1
+; GFX8-NEXT:    s_mov_b32 s8, s7
 ; GFX8-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s5
+; GFX8-NEXT:    s_and_b32 s5, 1, s10
+; GFX8-NEXT:    s_or_b64 s[0:1], s[0:1], s[8:9]
+; GFX8-NEXT:    s_lshr_b64 s[2:3], s[2:3], 1
+; GFX8-NEXT:    s_sub_i32 s10, s4, 64
+; GFX8-NEXT:    s_sub_i32 s8, 64, s4
+; GFX8-NEXT:    s_cmp_lt_u32 s4, 64
 ; GFX8-NEXT:    v_or_b32_e32 v4, v4, v6
 ; GFX8-NEXT:    v_or_b32_e32 v5, v5, v7
-; GFX8-NEXT:    s_and_b32 s5, 1, s9
+; GFX8-NEXT:    s_cselect_b32 s11, 1, 0
+; GFX8-NEXT:    s_cmp_eq_u32 s4, 0
+; GFX8-NEXT:    s_cselect_b32 s12, 1, 0
 ; GFX8-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v7, 0, v9, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX8-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s5
-; GFX8-NEXT:    s_sub_i32 s5, 64, 1
-; GFX8-NEXT:    s_lshr_b64 s[6:7], s[2:3], 1
-; GFX8-NEXT:    s_lshr_b64 s[0:1], s[0:1], 1
-; GFX8-NEXT:    s_lshl_b64 s[2:3], s[2:3], s5
-; GFX8-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
-; GFX8-NEXT:    s_sub_i32 s10, s4, 64
-; GFX8-NEXT:    s_sub_i32 s8, 64, s4
-; GFX8-NEXT:    s_cmp_lt_u32 s4, 64
-; GFX8-NEXT:    s_cselect_b32 s11, 1, 0
-; GFX8-NEXT:    s_cmp_eq_u32 s4, 0
-; GFX8-NEXT:    s_cselect_b32 s12, 1, 0
-; GFX8-NEXT:    s_lshr_b64 s[2:3], s[6:7], s4
-; GFX8-NEXT:    s_lshl_b64 s[8:9], s[6:7], s8
+; GFX8-NEXT:    s_lshr_b64 s[6:7], s[2:3], s4
+; GFX8-NEXT:    s_lshl_b64 s[8:9], s[2:3], s8
 ; GFX8-NEXT:    s_lshr_b64 s[4:5], s[0:1], s4
 ; GFX8-NEXT:    s_or_b64 s[4:5], s[4:5], s[8:9]
-; GFX8-NEXT:    s_lshr_b64 s[6:7], s[6:7], s10
+; GFX8-NEXT:    s_lshr_b64 s[2:3], s[2:3], s10
 ; GFX8-NEXT:    s_cmp_lg_u32 s11, 0
-; GFX8-NEXT:    s_cselect_b64 s[4:5], s[4:5], s[6:7]
+; GFX8-NEXT:    s_cselect_b64 s[2:3], s[4:5], s[2:3]
 ; GFX8-NEXT:    s_cmp_lg_u32 s12, 0
-; GFX8-NEXT:    s_cselect_b64 s[0:1], s[0:1], s[4:5]
+; GFX8-NEXT:    s_cselect_b64 s[0:1], s[0:1], s[2:3]
 ; GFX8-NEXT:    s_cmp_lg_u32 s11, 0
 ; GFX8-NEXT:    v_cndmask_b32_e32 v2, v0, v2, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v3, v1, v3, vcc
-; GFX8-NEXT:    s_cselect_b64 s[2:3], s[2:3], 0
+; GFX8-NEXT:    s_cselect_b64 s[2:3], s[6:7], 0
 ; GFX8-NEXT:    v_or_b32_e32 v0, s0, v6
 ; GFX8-NEXT:    v_or_b32_e32 v1, s1, v7
 ; GFX8-NEXT:    v_or_b32_e32 v2, s2, v2
@@ -5664,47 +5648,47 @@ define amdgpu_ps <4 x float> @v_fshl_i128_vss(i128 %lhs, i128 inreg %rhs, i128 i
 ; GFX9-NEXT:    s_sub_i32 s6, 64, s8
 ; GFX9-NEXT:    s_sub_i32 s5, s8, 64
 ; GFX9-NEXT:    s_cmp_lt_u32 s8, 64
-; GFX9-NEXT:    s_cselect_b32 s7, 1, 0
+; GFX9-NEXT:    s_cselect_b32 s9, 1, 0
 ; GFX9-NEXT:    s_cmp_eq_u32 s8, 0
+; GFX9-NEXT:    s_cselect_b32 s10, 1, 0
 ; GFX9-NEXT:    v_lshrrev_b64 v[4:5], s6, v[0:1]
 ; GFX9-NEXT:    v_lshlrev_b64 v[6:7], s8, v[2:3]
-; GFX9-NEXT:    s_cselect_b32 s9, 1, 0
 ; GFX9-NEXT:    v_lshlrev_b64 v[8:9], s8, v[0:1]
 ; GFX9-NEXT:    v_lshlrev_b64 v[0:1], s5, v[0:1]
-; GFX9-NEXT:    s_and_b32 s5, 1, s7
+; GFX9-NEXT:    s_and_b32 s5, 1, s9
+; GFX9-NEXT:    s_lshl_b32 s9, s2, 31
+; GFX9-NEXT:    s_lshr_b64 s[0:1], s[0:1], 1
+; GFX9-NEXT:    s_mov_b32 s8, s7
 ; GFX9-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s5
+; GFX9-NEXT:    s_and_b32 s5, 1, s10
+; GFX9-NEXT:    s_or_b64 s[0:1], s[0:1], s[8:9]
+; GFX9-NEXT:    s_lshr_b64 s[2:3], s[2:3], 1
+; GFX9-NEXT:    s_sub_i32 s10, s4, 64
+; GFX9-NEXT:    s_sub_i32 s8, 64, s4
+; GFX9-NEXT:    s_cmp_lt_u32 s4, 64
 ; GFX9-NEXT:    v_or_b32_e32 v4, v4, v6
 ; GFX9-NEXT:    v_or_b32_e32 v5, v5, v7
-; GFX9-NEXT:    s_and_b32 s5, 1, s9
+; GFX9-NEXT:    s_cselect_b32 s11, 1, 0
+; GFX9-NEXT:    s_cmp_eq_u32 s4, 0
+; GFX9-NEXT:    s_cselect_b32 s12, 1, 0
 ; GFX9-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v7, 0, v9, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
 ; GFX9-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s5
-; GFX9-NEXT:    s_sub_i32 s5, 64, 1
-; GFX9-NEXT:    s_lshr_b64 s[6:7], s[2:3], 1
-; GFX9-NEXT:    s_lshr_b64 s[0:1], s[0:1], 1
-; GFX9-NEXT:    s_lshl_b64 s[2:3], s[2:3], s5
-; GFX9-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
-; GFX9-NEXT:    s_sub_i32 s10, s4, 64
-; GFX9-NEXT:    s_sub_i32 s8, 64, s4
-; GFX9-NEXT:    s_cmp_lt_u32 s4, 64
-; GFX9-NEXT:    s_cselect_b32 s11, 1, 0
-; GFX9-NEXT:    s_cmp_eq_u32 s4, 0
-; GFX9-NEXT:    s_cselect_b32 s12, 1, 0
-; GFX9-NEXT:    s_lshr_b64 s[2:3], s[6:7], s4
-; GFX9-NEXT:    s_lshl_b64 s[8:9], s[6:7], s8
+; GFX9-NEXT:    s_lshr_b64 s[6:7], s[2:3], s4
+; GFX9-NEXT:    s_lshl_b64 s[8:9], s[2:3], s8
 ; GFX9-NEXT:    s_lshr_b64 s[4:5], s[0:1], s4
 ; GFX9-NEXT:    s_or_b64 s[4:5], s[4:5], s[8:9]
-; GFX9-NEXT:    s_lshr_b64 s[6:7], s[6:7], s10
+; GFX9-NEXT:    s_lshr_b64 s[2:3], s[2:3], s10
 ; GFX9-NEXT:    s_cmp_lg_u32 s11, 0
-; GFX9-NEXT:    s_cselect_b64 s[4:5], s[4:5], s[6:7]
+; GFX9-NEXT:    s_cselect_b64 s[2:3], s[4:5], s[2:3]
 ; GFX9-NEXT:    s_cmp_lg_u32 s12, 0
-; GFX9-NEXT:    s_cselect_b64 s[0:1], s[0:1], s[4:5]
+; GFX9-NEXT:    s_cselect_b64 s[0:1], s[0:1], s[2:3]
 ; GFX9-NEXT:    s_cmp_lg_u32 s11, 0
 ; GFX9-NEXT:    v_cndmask_b32_e32 v2, v0, v2, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v3, v1, v3, vcc
-; GFX9-NEXT:    s_cselect_b64 s[2:3], s[2:3], 0
+; GFX9-NEXT:    s_cselect_b64 s[2:3], s[6:7], 0
 ; GFX9-NEXT:    v_or_b32_e32 v0, s0, v6
 ; GFX9-NEXT:    v_or_b32_e32 v1, s1, v7
 ; GFX9-NEXT:    v_or_b32_e32 v2, s2, v2
@@ -5715,7 +5699,7 @@ define amdgpu_ps <4 x float> @v_fshl_i128_vss(i128 %lhs, i128 inreg %rhs, i128 i
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_mov_b64 s[6:7], 0x7f
 ; GFX10-NEXT:    s_and_b64 s[8:9], s[4:5], s[6:7]
-; GFX10-NEXT:    s_andn2_b64 s[6:7], s[6:7], s[4:5]
+; GFX10-NEXT:    s_andn2_b64 s[10:11], s[6:7], s[4:5]
 ; GFX10-NEXT:    s_sub_i32 s4, 64, s8
 ; GFX10-NEXT:    s_sub_i32 s5, s8, 64
 ; GFX10-NEXT:    s_cmp_lt_u32 s8, 64
@@ -5724,43 +5708,43 @@ define amdgpu_ps <4 x float> @v_fshl_i128_vss(i128 %lhs, i128 inreg %rhs, i128 i
 ; GFX10-NEXT:    s_cselect_b32 vcc_lo, 1, 0
 ; GFX10-NEXT:    s_cmp_eq_u32 s8, 0
 ; GFX10-NEXT:    v_lshlrev_b64 v[8:9], s8, v[0:1]
-; GFX10-NEXT:    s_cselect_b32 s7, 1, 0
+; GFX10-NEXT:    s_cselect_b32 s6, 1, 0
 ; GFX10-NEXT:    s_and_b32 s4, 1, vcc_lo
 ; GFX10-NEXT:    v_lshlrev_b64 v[0:1], s5, v[0:1]
 ; GFX10-NEXT:    v_or_b32_e32 v4, v4, v6
 ; GFX10-NEXT:    v_or_b32_e32 v5, v5, v7
 ; GFX10-NEXT:    v_cmp_ne_u32_e64 s4, 0, s4
+; GFX10-NEXT:    s_lshl_b32 s5, s2, 31
 ; GFX10-NEXT:    s_lshr_b64 s[0:1], s[0:1], 1
-; GFX10-NEXT:    s_and_b32 s7, 1, s7
-; GFX10-NEXT:    s_sub_i32 s10, s6, 64
-; GFX10-NEXT:    s_sub_i32 s8, 64, s6
+; GFX10-NEXT:    s_and_b32 s6, 1, s6
+; GFX10-NEXT:    s_lshr_b64 s[2:3], s[2:3], 1
 ; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, v4, s4
 ; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, v5, s4
-; GFX10-NEXT:    s_sub_i32 s4, 64, 1
-; GFX10-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc_lo
-; GFX10-NEXT:    s_lshl_b64 s[4:5], s[2:3], s4
-; GFX10-NEXT:    s_lshr_b64 s[2:3], s[2:3], 1
+; GFX10-NEXT:    s_mov_b32 s4, s7
+; GFX10-NEXT:    s_sub_i32 s11, s10, 64
 ; GFX10-NEXT:    s_or_b64 s[0:1], s[0:1], s[4:5]
-; GFX10-NEXT:    s_cmp_lt_u32 s6, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, 0, v9, vcc_lo
-; GFX10-NEXT:    s_cselect_b32 s11, 1, 0
-; GFX10-NEXT:    s_cmp_eq_u32 s6, 0
-; GFX10-NEXT:    v_cmp_ne_u32_e64 vcc_lo, 0, s7
+; GFX10-NEXT:    s_sub_i32 s7, 64, s10
+; GFX10-NEXT:    s_cmp_lt_u32 s10, 64
+; GFX10-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc_lo
 ; GFX10-NEXT:    s_cselect_b32 s12, 1, 0
-; GFX10-NEXT:    s_lshr_b64 s[4:5], s[0:1], s6
-; GFX10-NEXT:    s_lshl_b64 s[8:9], s[2:3], s8
-; GFX10-NEXT:    s_lshr_b64 s[6:7], s[2:3], s6
-; GFX10-NEXT:    s_or_b64 s[4:5], s[4:5], s[8:9]
-; GFX10-NEXT:    s_lshr_b64 s[2:3], s[2:3], s10
-; GFX10-NEXT:    s_cmp_lg_u32 s11, 0
+; GFX10-NEXT:    s_cmp_eq_u32 s10, 0
+; GFX10-NEXT:    v_cndmask_b32_e32 v7, 0, v9, vcc_lo
+; GFX10-NEXT:    v_cmp_ne_u32_e64 vcc_lo, 0, s6
+; GFX10-NEXT:    s_cselect_b32 s13, 1, 0
+; GFX10-NEXT:    s_lshr_b64 s[4:5], s[0:1], s10
+; GFX10-NEXT:    s_lshl_b64 s[6:7], s[2:3], s7
+; GFX10-NEXT:    s_lshr_b64 s[8:9], s[2:3], s10
+; GFX10-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
+; GFX10-NEXT:    s_lshr_b64 s[2:3], s[2:3], s11
+; GFX10-NEXT:    s_cmp_lg_u32 s12, 0
 ; GFX10-NEXT:    v_cndmask_b32_e32 v2, v0, v2, vcc_lo
 ; GFX10-NEXT:    s_cselect_b64 s[2:3], s[4:5], s[2:3]
-; GFX10-NEXT:    s_cmp_lg_u32 s12, 0
+; GFX10-NEXT:    s_cmp_lg_u32 s13, 0
 ; GFX10-NEXT:    v_cndmask_b32_e32 v3, v1, v3, vcc_lo
 ; GFX10-NEXT:    s_cselect_b64 s[0:1], s[0:1], s[2:3]
-; GFX10-NEXT:    s_cmp_lg_u32 s11, 0
+; GFX10-NEXT:    s_cmp_lg_u32 s12, 0
 ; GFX10-NEXT:    v_or_b32_e32 v0, s0, v6
-; GFX10-NEXT:    s_cselect_b64 s[2:3], s[6:7], 0
+; GFX10-NEXT:    s_cselect_b64 s[2:3], s[8:9], 0
 ; GFX10-NEXT:    v_or_b32_e32 v1, s1, v7
 ; GFX10-NEXT:    v_or_b32_e32 v2, s2, v2
 ; GFX10-NEXT:    v_or_b32_e32 v3, s3, v3
@@ -5773,58 +5757,46 @@ define amdgpu_ps <4 x float> @v_fshl_i128_vss(i128 %lhs, i128 inreg %rhs, i128 i
 define amdgpu_ps i128 @s_fshl_i128_65(i128 inreg %lhs, i128 inreg %rhs) {
 ; GFX6-LABEL: s_fshl_i128_65:
 ; GFX6:       ; %bb.0:
-; GFX6-NEXT:    s_sub_i32 s2, 0x41, 64
-; GFX6-NEXT:    s_sub_i32 s4, 64, 63
-; GFX6-NEXT:    s_mov_b32 s9, 0
-; GFX6-NEXT:    s_lshl_b64 s[2:3], s[0:1], s2
-; GFX6-NEXT:    s_lshr_b32 s8, s7, 31
-; GFX6-NEXT:    s_lshr_b32 s0, s5, 31
-; GFX6-NEXT:    s_mov_b32 s1, s9
-; GFX6-NEXT:    s_lshl_b64 s[4:5], s[6:7], s4
-; GFX6-NEXT:    s_or_b64 s[0:1], s[0:1], s[4:5]
-; GFX6-NEXT:    s_or_b64 s[2:3], s[2:3], s[8:9]
+; GFX6-NEXT:    s_lshl_b64 s[2:3], s[0:1], 1
+; GFX6-NEXT:    s_lshr_b32 s4, s5, 31
+; GFX6-NEXT:    s_mov_b32 s5, 0
+; GFX6-NEXT:    s_lshl_b64 s[0:1], s[6:7], 1
+; GFX6-NEXT:    s_or_b64 s[0:1], s[4:5], s[0:1]
+; GFX6-NEXT:    s_lshr_b32 s4, s7, 31
+; GFX6-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
 ; GFX6-NEXT:    ; return to shader part epilog
 ;
 ; GFX8-LABEL: s_fshl_i128_65:
 ; GFX8:       ; %bb.0:
-; GFX8-NEXT:    s_sub_i32 s2, 0x41, 64
-; GFX8-NEXT:    s_sub_i32 s4, 64, 63
-; GFX8-NEXT:    s_mov_b32 s9, 0
-; GFX8-NEXT:    s_lshl_b64 s[2:3], s[0:1], s2
-; GFX8-NEXT:    s_lshr_b32 s8, s7, 31
-; GFX8-NEXT:    s_lshr_b32 s0, s5, 31
-; GFX8-NEXT:    s_mov_b32 s1, s9
-; GFX8-NEXT:    s_lshl_b64 s[4:5], s[6:7], s4
-; GFX8-NEXT:    s_or_b64 s[0:1], s[0:1], s[4:5]
-; GFX8-NEXT:    s_or_b64 s[2:3], s[2:3], s[8:9]
+; GFX8-NEXT:    s_lshl_b64 s[2:3], s[0:1], 1
+; GFX8-NEXT:    s_lshr_b32 s4, s5, 31
+; GFX8-NEXT:    s_mov_b32 s5, 0
+; GFX8-NEXT:    s_lshl_b64 s[0:1], s[6:7], 1
+; GFX8-NEXT:    s_or_b64 s[0:1], s[4:5], s[0:1]
+; GFX8-NEXT:    s_lshr_b32 s4, s7, 31
+; GFX8-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
 ; GFX8-NEXT:    ; return to shader part epilog
 ;
 ; GFX9-LABEL: s_fshl_i128_65:
 ; GFX9:       ; %bb.0:
-; GFX9-NEXT:    s_sub_i32 s2, 0x41, 64
-; GFX9-NEXT:    s_sub_i32 s4, 64, 63
-; GFX9-NEXT:    s_mov_b32 s9, 0
-; GFX9-NEXT:    s_lshl_b64 s[2:3], s[0:1], s2
-; GFX9-NEXT:    s_lshr_b32 s8, s7, 31
-; GFX9-NEXT:    s_lshr_b32 s0, s5, 31
-; GFX9-NEXT:    s_mov_b32 s1, s9
-; GFX9-NEXT:    s_lshl_b64 s[4:5], s[6:7], s4
-; GFX9-NEXT:    s_or_b64 s[0:1], s[0:1], s[4:5]
-; GFX9-NEXT:    s_or_b64 s[2:3], s[2:3], s[8:9]
+; GFX9-NEXT:    s_lshl_b64 s[2:3], s[0:1], 1
+; GFX9-NEXT:    s_lshr_b32 s4, s5, 31
+; GFX9-NEXT:    s_mov_b32 s5, 0
+; GFX9-NEXT:    s_lshl_b64 s[0:1], s[6:7], 1
+; GFX9-NEXT:    s_or_b64 s[0:1], s[4:5], s[0:1]
+; GFX9-NEXT:    s_lshr_b32 s4, s7, 31
+; GFX9-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
 ; GFX9-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-LABEL: s_fshl_i128_65:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    s_sub_i32 s2, 0x41, 64
-; GFX10-NEXT:    s_sub_i32 s4, 64, 63
-; GFX10-NEXT:    s_mov_b32 s9, 0
-; GFX10-NEXT:    s_lshl_b64 s[2:3], s[0:1], s2
-; GFX10-NEXT:    s_lshr_b32 s0, s5, 31
-; GFX10-NEXT:    s_lshr_b32 s8, s7, 31
-; GFX10-NEXT:    s_mov_b32 s1, s9
-; GFX10-NEXT:    s_lshl_b64 s[4:5], s[6:7], s4
-; GFX10-NEXT:    s_or_b64 s[2:3], s[2:3], s[8:9]
-; GFX10-NEXT:    s_or_b64 s[0:1], s[0:1], s[4:5]
+; GFX10-NEXT:    s_lshr_b32 s2, s5, 31
+; GFX10-NEXT:    s_mov_b32 s3, 0
+; GFX10-NEXT:    s_lshl_b64 s[4:5], s[6:7], 1
+; GFX10-NEXT:    s_lshl_b64 s[8:9], s[0:1], 1
+; GFX10-NEXT:    s_or_b64 s[0:1], s[2:3], s[4:5]
+; GFX10-NEXT:    s_lshr_b32 s2, s7, 31
+; GFX10-NEXT:    s_or_b64 s[2:3], s[8:9], s[2:3]
 ; GFX10-NEXT:    ; return to shader part epilog
   %result = call i128 @llvm.fshl.i128(i128 %lhs, i128 %rhs, i128 65)
   ret i128 %result
@@ -5834,39 +5806,33 @@ define i128 @v_fshl_i128_65(i128 %lhs, i128 %rhs) {
 ; GFX6-LABEL: v_fshl_i128_65:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    s_sub_i32 s4, 0x41, 64
-; GFX6-NEXT:    v_lshl_b64 v[2:3], v[0:1], s4
-; GFX6-NEXT:    s_sub_i32 s4, 64, 63
-; GFX6-NEXT:    v_lshl_b64 v[0:1], v[6:7], s4
+; GFX6-NEXT:    v_lshl_b64 v[2:3], v[0:1], 1
+; GFX6-NEXT:    v_lshl_b64 v[0:1], v[6:7], 1
+; GFX6-NEXT:    v_lshrrev_b32_e32 v4, 31, v5
+; GFX6-NEXT:    v_or_b32_e32 v0, v4, v0
 ; GFX6-NEXT:    v_lshrrev_b32_e32 v4, 31, v7
-; GFX6-NEXT:    v_lshrrev_b32_e32 v5, 31, v5
-; GFX6-NEXT:    v_or_b32_e32 v0, v5, v0
 ; GFX6-NEXT:    v_or_b32_e32 v2, v2, v4
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_fshl_i128_65:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    s_sub_i32 s4, 0x41, 64
-; GFX8-NEXT:    v_lshlrev_b64 v[2:3], s4, v[0:1]
-; GFX8-NEXT:    s_sub_i32 s4, 64, 63
-; GFX8-NEXT:    v_lshlrev_b64 v[0:1], s4, v[6:7]
+; GFX8-NEXT:    v_lshlrev_b64 v[2:3], 1, v[0:1]
+; GFX8-NEXT:    v_lshlrev_b64 v[0:1], 1, v[6:7]
+; GFX8-NEXT:    v_lshrrev_b32_e32 v4, 31, v5
+; GFX8-NEXT:    v_or_b32_e32 v0, v4, v0
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v4, 31, v7
-; GFX8-NEXT:    v_lshrrev_b32_e32 v5, 31, v5
-; GFX8-NEXT:    v_or_b32_e32 v0, v5, v0
 ; GFX8-NEXT:    v_or_b32_e32 v2, v2, v4
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_fshl_i128_65:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    s_sub_i32 s4, 0x41, 64
-; GFX9-NEXT:    v_lshlrev_b64 v[2:3], s4, v[0:1]
-; GFX9-NEXT:    s_sub_i32 s4, 64, 63
-; GFX9-NEXT:    v_lshlrev_b64 v[0:1], s4, v[6:7]
+; GFX9-NEXT:    v_lshlrev_b64 v[2:3], 1, v[0:1]
+; GFX9-NEXT:    v_lshlrev_b64 v[0:1], 1, v[6:7]
+; GFX9-NEXT:    v_lshrrev_b32_e32 v4, 31, v5
+; GFX9-NEXT:    v_or_b32_e32 v0, v4, v0
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v4, 31, v7
-; GFX9-NEXT:    v_lshrrev_b32_e32 v5, 31, v5
-; GFX9-NEXT:    v_or_b32_e32 v0, v5, v0
 ; GFX9-NEXT:    v_or_b32_e32 v2, v2, v4
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5874,10 +5840,8 @@ define i128 @v_fshl_i128_65(i128 %lhs, i128 %rhs) {
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX10-NEXT:    s_sub_i32 s4, 0x41, 64
-; GFX10-NEXT:    s_sub_i32 s5, 64, 63
-; GFX10-NEXT:    v_lshlrev_b64 v[2:3], s4, v[0:1]
-; GFX10-NEXT:    v_lshlrev_b64 v[0:1], s5, v[6:7]
+; GFX10-NEXT:    v_lshlrev_b64 v[2:3], 1, v[0:1]
+; GFX10-NEXT:    v_lshlrev_b64 v[0:1], 1, v[6:7]
 ; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 31, v5
 ; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 31, v7
 ; GFX10-NEXT:    v_or_b32_e32 v0, v4, v0
@@ -5909,27 +5873,27 @@ define amdgpu_ps <2 x i128> @s_fshl_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ; GFX6-NEXT:    s_cselect_b64 s[0:1], s[22:23], s[0:1]
 ; GFX6-NEXT:    s_cmp_lg_u32 s29, 0
 ; GFX6-NEXT:    s_cselect_b64 s[2:3], s[2:3], s[0:1]
-; GFX6-NEXT:    s_sub_i32 s26, 64, 1
-; GFX6-NEXT:    s_lshr_b64 s[0:1], s[10:11], 1
-; GFX6-NEXT:    s_lshr_b64 s[8:9], s[8:9], 1
-; GFX6-NEXT:    s_lshl_b64 s[10:11], s[10:11], s26
-; GFX6-NEXT:    s_or_b64 s[8:9], s[8:9], s[10:11]
-; GFX6-NEXT:    s_sub_i32 s27, s16, 64
+; GFX6-NEXT:    s_lshr_b64 s[0:1], s[8:9], 1
+; GFX6-NEXT:    s_lshl_b32 s9, s10, 31
+; GFX6-NEXT:    s_mov_b32 s8, s19
+; GFX6-NEXT:    s_or_b64 s[0:1], s[0:1], s[8:9]
+; GFX6-NEXT:    s_lshr_b64 s[8:9], s[10:11], 1
+; GFX6-NEXT:    s_sub_i32 s26, s16, 64
 ; GFX6-NEXT:    s_sub_i32 s22, 64, s16
 ; GFX6-NEXT:    s_cmp_lt_u32 s16, 64
-; GFX6-NEXT:    s_cselect_b32 s28, 1, 0
+; GFX6-NEXT:    s_cselect_b32 s27, 1, 0
 ; GFX6-NEXT:    s_cmp_eq_u32 s16, 0
-; GFX6-NEXT:    s_cselect_b32 s29, 1, 0
-; GFX6-NEXT:    s_lshr_b64 s[10:11], s[0:1], s16
-; GFX6-NEXT:    s_lshl_b64 s[22:23], s[0:1], s22
-; GFX6-NEXT:    s_lshr_b64 s[16:17], s[8:9], s16
+; GFX6-NEXT:    s_cselect_b32 s28, 1, 0
+; GFX6-NEXT:    s_lshr_b64 s[10:11], s[8:9], s16
+; GFX6-NEXT:    s_lshl_b64 s[22:23], s[8:9], s22
+; GFX6-NEXT:    s_lshr_b64 s[16:17], s[0:1], s16
 ; GFX6-NEXT:    s_or_b64 s[16:17], s[16:17], s[22:23]
-; GFX6-NEXT:    s_lshr_b64 s[0:1], s[0:1], s27
+; GFX6-NEXT:    s_lshr_b64 s[8:9], s[8:9], s26
+; GFX6-NEXT:    s_cmp_lg_u32 s27, 0
+; GFX6-NEXT:    s_cselect_b64 s[8:9], s[16:17], s[8:9]
 ; GFX6-NEXT:    s_cmp_lg_u32 s28, 0
-; GFX6-NEXT:    s_cselect_b64 s[0:1], s[16:17], s[0:1]
-; GFX6-NEXT:    s_cmp_lg_u32 s29, 0
-; GFX6-NEXT:    s_cselect_b64 s[0:1], s[8:9], s[0:1]
-; GFX6-NEXT:    s_cmp_lg_u32 s28, 0
+; GFX6-NEXT:    s_cselect_b64 s[0:1], s[0:1], s[8:9]
+; GFX6-NEXT:    s_cmp_lg_u32 s27, 0
 ; GFX6-NEXT:    s_cselect_b64 s[8:9], s[10:11], 0
 ; GFX6-NEXT:    s_or_b64 s[2:3], s[2:3], s[8:9]
 ; GFX6-NEXT:    s_and_b64 s[8:9], s[20:21], s[18:19]
@@ -5938,38 +5902,39 @@ define amdgpu_ps <2 x i128> @s_fshl_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ; GFX6-NEXT:    s_sub_i32 s11, s8, 64
 ; GFX6-NEXT:    s_sub_i32 s9, 64, s8
 ; GFX6-NEXT:    s_cmp_lt_u32 s8, 64
-; GFX6-NEXT:    s_cselect_b32 s20, 1, 0
+; GFX6-NEXT:    s_cselect_b32 s18, 1, 0
 ; GFX6-NEXT:    s_cmp_eq_u32 s8, 0
-; GFX6-NEXT:    s_cselect_b32 s21, 1, 0
+; GFX6-NEXT:    s_cselect_b32 s22, 1, 0
 ; GFX6-NEXT:    s_lshl_b64 s[16:17], s[4:5], s8
-; GFX6-NEXT:    s_lshr_b64 s[18:19], s[4:5], s9
+; GFX6-NEXT:    s_lshr_b64 s[20:21], s[4:5], s9
 ; GFX6-NEXT:    s_lshl_b64 s[8:9], s[6:7], s8
-; GFX6-NEXT:    s_or_b64 s[8:9], s[18:19], s[8:9]
+; GFX6-NEXT:    s_or_b64 s[8:9], s[20:21], s[8:9]
 ; GFX6-NEXT:    s_lshl_b64 s[4:5], s[4:5], s11
-; GFX6-NEXT:    s_cmp_lg_u32 s20, 0
-; GFX6-NEXT:    s_cselect_b64 s[16:17], s[16:17], 0
+; GFX6-NEXT:    s_cmp_lg_u32 s18, 0
 ; GFX6-NEXT:    s_cselect_b64 s[4:5], s[8:9], s[4:5]
-; GFX6-NEXT:    s_cmp_lg_u32 s21, 0
+; GFX6-NEXT:    s_cselect_b64 s[16:17], s[16:17], 0
+; GFX6-NEXT:    s_cmp_lg_u32 s22, 0
 ; GFX6-NEXT:    s_cselect_b64 s[6:7], s[6:7], s[4:5]
-; GFX6-NEXT:    s_lshr_b64 s[8:9], s[12:13], 1
-; GFX6-NEXT:    s_lshl_b64 s[12:13], s[14:15], s26
-; GFX6-NEXT:    s_lshr_b64 s[4:5], s[14:15], 1
-; GFX6-NEXT:    s_or_b64 s[8:9], s[8:9], s[12:13]
+; GFX6-NEXT:    s_lshr_b64 s[4:5], s[12:13], 1
+; GFX6-NEXT:    s_lshl_b32 s9, s14, 31
+; GFX6-NEXT:    s_mov_b32 s8, s19
+; GFX6-NEXT:    s_or_b64 s[4:5], s[4:5], s[8:9]
+; GFX6-NEXT:    s_lshr_b64 s[8:9], s[14:15], 1
 ; GFX6-NEXT:    s_sub_i32 s18, s10, 64
 ; GFX6-NEXT:    s_sub_i32 s14, 64, s10
 ; GFX6-NEXT:    s_cmp_lt_u32 s10, 64
 ; GFX6-NEXT:    s_cselect_b32 s19, 1, 0
 ; GFX6-NEXT:    s_cmp_eq_u32 s10, 0
 ; GFX6-NEXT:    s_cselect_b32 s20, 1, 0
-; GFX6-NEXT:    s_lshr_b64 s[12:13], s[4:5], s10
-; GFX6-NEXT:    s_lshl_b64 s[14:15], s[4:5], s14
-; GFX6-NEXT:    s_lshr_b64 s[10:11], s[8:9], s10
+; GFX6-NEXT:    s_lshr_b64 s[12:13], s[8:9], s10
+; GFX6-NEXT:    s_lshl_b64 s[14:15], s[8:9], s14
+; GFX6-NEXT:    s_lshr_b64 s[10:11], s[4:5], s10
 ; GFX6-NEXT:    s_or_b64 s[10:11], s[10:11], s[14:15]
-; GFX6-NEXT:    s_lshr_b64 s[4:5], s[4:5], s18
+; GFX6-NEXT:    s_lshr_b64 s[8:9], s[8:9], s18
 ; GFX6-NEXT:    s_cmp_lg_u32 s19, 0
-; GFX6-NEXT:    s_cselect_b64 s[4:5], s[10:11], s[4:5]
+; GFX6-NEXT:    s_cselect_b64 s[8:9], s[10:11], s[8:9]
 ; GFX6-NEXT:    s_cmp_lg_u32 s20, 0
-; GFX6-NEXT:    s_cselect_b64 s[4:5], s[8:9], s[4:5]
+; GFX6-NEXT:    s_cselect_b64 s[4:5], s[4:5], s[8:9]
 ; GFX6-NEXT:    s_cmp_lg_u32 s19, 0
 ; GFX6-NEXT:    s_cselect_b64 s[8:9], s[12:13], 0
 ; GFX6-NEXT:    s_or_b64 s[4:5], s[16:17], s[4:5]
@@ -5997,27 +5962,27 @@ define amdgpu_ps <2 x i128> @s_fshl_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ; GFX8-NEXT:    s_cselect_b64 s[0:1], s[22:23], s[0:1]
 ; GFX8-NEXT:    s_cmp_lg_u32 s29, 0
 ; GFX8-NEXT:    s_cselect_b64 s[2:3], s[2:3], s[0:1]
-; GFX8-NEXT:    s_sub_i32 s26, 64, 1
-; GFX8-NEXT:    s_lshr_b64 s[0:1], s[10:11], 1
-; GFX8-NEXT:    s_lshr_b64 s[8:9], s[8:9], 1
-; GFX8-NEXT:    s_lshl_b64 s[10:11], s[10:11], s26
-; GFX8-NEXT:    s_or_b64 s[8:9], s[8:9], s[10:11]
-; GFX8-NEXT:    s_sub_i32 s27, s16, 64
+; GFX8-NEXT:    s_lshr_b64 s[0:1], s[8:9], 1
+; GFX8-NEXT:    s_lshl_b32 s9, s10, 31
+; GFX8-NEXT:    s_mov_b32 s8, s19
+; GFX8-NEXT:    s_or_b64 s[0:1], s[0:1], s[8:9]
+; GFX8-NEXT:    s_lshr_b64 s[8:9], s[10:11], 1
+; GFX8-NEXT:    s_sub_i32 s26, s16, 64
 ; GFX8-NEXT:    s_sub_i32 s22, 64, s16
 ; GFX8-NEXT:    s_cmp_lt_u32 s16, 64
-; GFX8-NEXT:    s_cselect_b32 s28, 1, 0
+; GFX8-NEXT:    s_cselect_b32 s27, 1, 0
 ; GFX8-NEXT:    s_cmp_eq_u32 s16, 0
-; GFX8-NEXT:    s_cselect_b32 s29, 1, 0
-; GFX8-NEXT:    s_lshr_b64 s[10:11], s[0:1], s16
-; GFX8-NEXT:    s_lshl_b64 s[22:23], s[0:1], s22
-; GFX8-NEXT:    s_lshr_b64 s[16:17], s[8:9], s16
+; GFX8-NEXT:    s_cselect_b32 s28, 1, 0
+; GFX8-NEXT:    s_lshr_b64 s[10:11], s[8:9], s16
+; GFX8-NEXT:    s_lshl_b64 s[22:23], s[8:9], s22
+; GFX8-NEXT:    s_lshr_b64 s[16:17], s[0:1], s16
 ; GFX8-NEXT:    s_or_b64 s[16:17], s[16:17], s[22:23]
-; GFX8-NEXT:    s_lshr_b64 s[0:1], s[0:1], s27
+; GFX8-NEXT:    s_lshr_b64 s[8:9], s[8:9], s26
+; GFX8-NEXT:    s_cmp_lg_u32 s27, 0
+; GFX8-NEXT:    s_cselect_b64 s[8:9], s[16:17], s[8:9]
 ; GFX8-NEXT:    s_cmp_lg_u32 s28, 0
-; GFX8-NEXT:    s_cselect_b64 s[0:1], s[16:17], s[0:1]
-; GFX8-NEXT:    s_cmp_lg_u32 s29, 0
-; GFX8-NEXT:    s_cselect_b64 s[0:1], s[8:9], s[0:1]
-; GFX8-NEXT:    s_cmp_lg_u32 s28, 0
+; GFX8-NEXT:    s_cselect_b64 s[0:1], s[0:1], s[8:9]
+; GFX8-NEXT:    s_cmp_lg_u32 s27, 0
 ; GFX8-NEXT:    s_cselect_b64 s[8:9], s[10:11], 0
 ; GFX8-NEXT:    s_or_b64 s[2:3], s[2:3], s[8:9]
 ; GFX8-NEXT:    s_and_b64 s[8:9], s[20:21], s[18:19]
@@ -6026,38 +5991,39 @@ define amdgpu_ps <2 x i128> @s_fshl_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ; GFX8-NEXT:    s_sub_i32 s11, s8, 64
 ; GFX8-NEXT:    s_sub_i32 s9, 64, s8
 ; GFX8-NEXT:    s_cmp_lt_u32 s8, 64
-; GFX8-NEXT:    s_cselect_b32 s20, 1, 0
+; GFX8-NEXT:    s_cselect_b32 s18, 1, 0
 ; GFX8-NEXT:    s_cmp_eq_u32 s8, 0
-; GFX8-NEXT:    s_cselect_b32 s21, 1, 0
+; GFX8-NEXT:    s_cselect_b32 s22, 1, 0
 ; GFX8-NEXT:    s_lshl_b64 s[16:17], s[4:5], s8
-; GFX8-NEXT:    s_lshr_b64 s[18:19], s[4:5], s9
+; GFX8-NEXT:    s_lshr_b64 s[20:21], s[4:5], s9
 ; GFX8-NEXT:    s_lshl_b64 s[8:9], s[6:7], s8
-; GFX8-NEXT:    s_or_b64 s[8:9], s[18:19], s[8:9]
+; GFX8-NEXT:    s_or_b64 s[8:9], s[20:21], s[8:9]
 ; GFX8-NEXT:    s_lshl_b64 s[4:5], s[4:5], s11
-; GFX8-NEXT:    s_cmp_lg_u32 s20, 0
-; GFX8-NEXT:    s_cselect_b64 s[16:17], s[16:17], 0
+; GFX8-NEXT:    s_cmp_lg_u32 s18, 0
 ; GFX8-NEXT:    s_cselect_b64 s[4:5], s[8:9], s[4:5]
-; GFX8-NEXT:    s_cmp_lg_u32 s21, 0
+; GFX8-NEXT:    s_cselect_b64 s[16:17], s[16:17], 0
+; GFX8-NEXT:    s_cmp_lg_u32 s22, 0
 ; GFX8-NEXT:    s_cselect_b64 s[6:7], s[6:7], s[4:5]
-; GFX8-NEXT:    s_lshr_b64 s[8:9], s[12:13], 1
-; GFX8-NEXT:    s_lshl_b64 s[12:13], s[14:15], s26
-; GFX8-NEXT:    s_lshr_b64 s[4:5], s[14:15], 1
-; GFX8-NEXT:    s_or_b64 s[8:9], s[8:9], s[12:13]
+; GFX8-NEXT:    s_lshr_b64 s[4:5], s[12:13], 1
+; GFX8-NEXT:    s_lshl_b32 s9, s14, 31
+; GFX8-NEXT:    s_mov_b32 s8, s19
+; GFX8-NEXT:    s_or_b64 s[4:5], s[4:5], s[8:9]
+; GFX8-NEXT:    s_lshr_b64 s[8:9], s[14:15], 1
 ; GFX8-NEXT:    s_sub_i32 s18, s10, 64
 ; GFX8-NEXT:    s_sub_i32 s14, 64, s10
 ; GFX8-NEXT:    s_cmp_lt_u32 s10, 64
 ; GFX8-NEXT:    s_cselect_b32 s19, 1, 0
 ; GFX8-NEXT:    s_cmp_eq_u32 s10, 0
 ; GFX8-NEXT:    s_cselect_b32 s20, 1, 0
-; GFX8-NEXT:    s_lshr_b64 s[12:13], s[4:5], s10
-; GFX8-NEXT:    s_lshl_b64 s[14:15], s[4:5], s14
-; GFX8-NEXT:    s_lshr_b64 s[10:11], s[8:9], s10
+; GFX8-NEXT:    s_lshr_b64 s[12:13], s[8:9], s10
+; GFX8-NEXT:    s_lshl_b64 s[14:15], s[8:9], s14
+; GFX8-NEXT:    s_lshr_b64 s[10:11], s[4:5], s10
 ; GFX8-NEXT:    s_or_b64 s[10:11], s[10:11], s[14:15]
-; GFX8-NEXT:    s_lshr_b64 s[4:5], s[4:5], s18
+; GFX8-NEXT:    s_lshr_b64 s[8:9], s[8:9], s18
 ; GFX8-NEXT:    s_cmp_lg_u32 s19, 0
-; GFX8-NEXT:    s_cselect_b64 s[4:5], s[10:11], s[4:5]
+; GFX8-NEXT:    s_cselect_b64 s[8:9], s[10:11], s[8:9]
 ; GFX8-NEXT:    s_cmp_lg_u32 s20, 0
-; GFX8-NEXT:    s_cselect_b64 s[4:5], s[8:9], s[4:5]
+; GFX8-NEXT:    s_cselect_b64 s[4:5], s[4:5], s[8:9]
 ; GFX8-NEXT:    s_cmp_lg_u32 s19, 0
 ; GFX8-NEXT:    s_cselect_b64 s[8:9], s[12:13], 0
 ; GFX8-NEXT:    s_or_b64 s[4:5], s[16:17], s[4:5]
@@ -6085,27 +6051,27 @@ define amdgpu_ps <2 x i128> @s_fshl_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ; GFX9-NEXT:    s_cselect_b64 s[0:1], s[22:23], s[0:1]
 ; GFX9-NEXT:    s_cmp_lg_u32 s29, 0
 ; GFX9-NEXT:    s_cselect_b64 s[2:3], s[2:3], s[0:1]
-; GFX9-NEXT:    s_sub_i32 s26, 64, 1
-; GFX9-NEXT:    s_lshr_b64 s[0:1], s[10:11], 1
-; GFX9-NEXT:    s_lshr_b64 s[8:9], s[8:9], 1
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[10:11], s26
-; GFX9-NEXT:    s_or_b64 s[8:9], s[8:9], s[10:11]
-; GFX9-NEXT:    s_sub_i32 s27, s16, 64
+; GFX9-NEXT:    s_lshr_b64 s[0:1], s[8:9], 1
+; GFX9-NEXT:    s_lshl_b32 s9, s10, 31
+; GFX9-NEXT:    s_mov_b32 s8, s19
+; GFX9-NEXT:    s_or_b64 s[0:1], s[0:1], s[8:9]
+; GFX9-NEXT:    s_lshr_b64 s[8:9], s[10:11], 1
+; GFX9-NEXT:    s_sub_i32 s26, s16, 64
 ; GFX9-NEXT:    s_sub_i32 s22, 64, s16
 ; GFX9-NEXT:    s_cmp_lt_u32 s16, 64
-; GFX9-NEXT:    s_cselect_b32 s28, 1, 0
+; GFX9-NEXT:    s_cselect_b32 s27, 1, 0
 ; GFX9-NEXT:    s_cmp_eq_u32 s16, 0
-; GFX9-NEXT:    s_cselect_b32 s29, 1, 0
-; GFX9-NEXT:    s_lshr_b64 s[10:11], s[0:1], s16
-; GFX9-NEXT:    s_lshl_b64 s[22:23], s[0:1], s22
-; GFX9-NEXT:    s_lshr_b64 s[16:17], s[8:9], s16
+; GFX9-NEXT:    s_cselect_b32 s28, 1, 0
+; GFX9-NEXT:    s_lshr_b64 s[10:11], s[8:9], s16
+; GFX9-NEXT:    s_lshl_b64 s[22:23], s[8:9], s22
+; GFX9-NEXT:    s_lshr_b64 s[16:17], s[0:1], s16
 ; GFX9-NEXT:    s_or_b64 s[16:17], s[16:17], s[22:23]
-; GFX9-NEXT:    s_lshr_b64 s[0:1], s[0:1], s27
+; GFX9-NEXT:    s_lshr_b64 s[8:9], s[8:9], s26
+; GFX9-NEXT:    s_cmp_lg_u32 s27, 0
+; GFX9-NEXT:    s_cselect_b64 s[8:9], s[16:17], s[8:9]
 ; GFX9-NEXT:    s_cmp_lg_u32 s28, 0
-; GFX9-NEXT:    s_cselect_b64 s[0:1], s[16:17], s[0:1]
-; GFX9-NEXT:    s_cmp_lg_u32 s29, 0
-; GFX9-NEXT:    s_cselect_b64 s[0:1], s[8:9], s[0:1]
-; GFX9-NEXT:    s_cmp_lg_u32 s28, 0
+; GFX9-NEXT:    s_cselect_b64 s[0:1], s[0:1], s[8:9]
+; GFX9-NEXT:    s_cmp_lg_u32 s27, 0
 ; GFX9-NEXT:    s_cselect_b64 s[8:9], s[10:11], 0
 ; GFX9-NEXT:    s_or_b64 s[2:3], s[2:3], s[8:9]
 ; GFX9-NEXT:    s_and_b64 s[8:9], s[20:21], s[18:19]
@@ -6114,38 +6080,39 @@ define amdgpu_ps <2 x i128> @s_fshl_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ; GFX9-NEXT:    s_sub_i32 s11, s8, 64
 ; GFX9-NEXT:    s_sub_i32 s9, 64, s8
 ; GFX9-NEXT:    s_cmp_lt_u32 s8, 64
-; GFX9-NEXT:    s_cselect_b32 s20, 1, 0
+; GFX9-NEXT:    s_cselect_b32 s18, 1, 0
 ; GFX9-NEXT:    s_cmp_eq_u32 s8, 0
-; GFX9-NEXT:    s_cselect_b32 s21, 1, 0
+; GFX9-NEXT:    s_cselect_b32 s22, 1, 0
 ; GFX9-NEXT:    s_lshl_b64 s[16:17], s[4:5], s8
-; GFX9-NEXT:    s_lshr_b64 s[18:19], s[4:5], s9
+; GFX9-NEXT:    s_lshr_b64 s[20:21], s[4:5], s9
 ; GFX9-NEXT:    s_lshl_b64 s[8:9], s[6:7], s8
-; GFX9-NEXT:    s_or_b64 s[8:9], s[18:19], s[8:9]
+; GFX9-NEXT:    s_or_b64 s[8:9], s[20:21], s[8:9]
 ; GFX9-NEXT:    s_lshl_b64 s[4:5], s[4:5], s11
-; GFX9-NEXT:    s_cmp_lg_u32 s20, 0
-; GFX9-NEXT:    s_cselect_b64 s[16:17], s[16:17], 0
+; GFX9-NEXT:    s_cmp_lg_u32 s18, 0
 ; GFX9-NEXT:    s_cselect_b64 s[4:5], s[8:9], s[4:5]
-; GFX9-NEXT:    s_cmp_lg_u32 s21, 0
+; GFX9-NEXT:    s_cselect_b64 s[16:17], s[16:17], 0
+; GFX9-NEXT:    s_cmp_lg_u32 s22, 0
 ; GFX9-NEXT:    s_cselect_b64 s[6:7], s[6:7], s[4:5]
-; GFX9-NEXT:    s_lshr_b64 s[8:9], s[12:13], 1
-; GFX9-NEXT:    s_lshl_b64 s[12:13], s[14:15], s26
-; GFX9-NEXT:    s_lshr_b64 s[4:5], s[14:15], 1
-; GFX9-NEXT:    s_or_b64 s[8:9], s[8:9], s[12:13]
+; GFX9-NEXT:    s_lshr_b64 s[4:5], s[12:13], 1
+; GFX9-NEXT:    s_lshl_b32 s9, s14, 31
+; GFX9-NEXT:    s_mov_b32 s8, s19
+; GFX9-NEXT:    s_or_b64 s[4:5], s[4:5], s[8:9]
+; GFX9-NEXT:    s_lshr_b64 s[8:9], s[14:15], 1
 ; GFX9-NEXT:    s_sub_i32 s18, s10, 64
 ; GFX9-NEXT:    s_sub_i32 s14, 64, s10
 ; GFX9-NEXT:    s_cmp_lt_u32 s10, 64
 ; GFX9-NEXT:    s_cselect_b32 s19, 1, 0
 ; GFX9-NEXT:    s_cmp_eq_u32 s10, 0
 ; GFX9-NEXT:    s_cselect_b32 s20, 1, 0
-; GFX9-NEXT:    s_lshr_b64 s[12:13], s[4:5], s10
-; GFX9-NEXT:    s_lshl_b64 s[14:15], s[4:5], s14
-; GFX9-NEXT:    s_lshr_b64 s[10:11], s[8:9], s10
+; GFX9-NEXT:    s_lshr_b64 s[12:13], s[8:9], s10
+; GFX9-NEXT:    s_lshl_b64 s[14:15], s[8:9], s14
+; GFX9-NEXT:    s_lshr_b64 s[10:11], s[4:5], s10
 ; GFX9-NEXT:    s_or_b64 s[10:11], s[10:11], s[14:15]
-; GFX9-NEXT:    s_lshr_b64 s[4:5], s[4:5], s18
+; GFX9-NEXT:    s_lshr_b64 s[8:9], s[8:9], s18
 ; GFX9-NEXT:    s_cmp_lg_u32 s19, 0
-; GFX9-NEXT:    s_cselect_b64 s[4:5], s[10:11], s[4:5]
+; GFX9-NEXT:    s_cselect_b64 s[8:9], s[10:11], s[8:9]
 ; GFX9-NEXT:    s_cmp_lg_u32 s20, 0
-; GFX9-NEXT:    s_cselect_b64 s[4:5], s[8:9], s[4:5]
+; GFX9-NEXT:    s_cselect_b64 s[4:5], s[4:5], s[8:9]
 ; GFX9-NEXT:    s_cmp_lg_u32 s19, 0
 ; GFX9-NEXT:    s_cselect_b64 s[8:9], s[12:13], 0
 ; GFX9-NEXT:    s_or_b64 s[4:5], s[16:17], s[4:5]
@@ -6173,27 +6140,27 @@ define amdgpu_ps <2 x i128> @s_fshl_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ; GFX10-NEXT:    s_cselect_b64 s[0:1], s[24:25], s[0:1]
 ; GFX10-NEXT:    s_cmp_lg_u32 s29, 0
 ; GFX10-NEXT:    s_cselect_b64 s[2:3], s[2:3], s[0:1]
-; GFX10-NEXT:    s_sub_i32 s26, 64, 1
 ; GFX10-NEXT:    s_lshr_b64 s[0:1], s[8:9], 1
-; GFX10-NEXT:    s_lshl_b64 s[8:9], s[10:11], s26
-; GFX10-NEXT:    s_lshr_b64 s[10:11], s[10:11], 1
+; GFX10-NEXT:    s_lshl_b32 s9, s10, 31
+; GFX10-NEXT:    s_mov_b32 s8, s19
+; GFX10-NEXT:    s_sub_i32 s26, s16, 64
 ; GFX10-NEXT:    s_or_b64 s[0:1], s[0:1], s[8:9]
-; GFX10-NEXT:    s_sub_i32 s27, s16, 64
+; GFX10-NEXT:    s_lshr_b64 s[8:9], s[10:11], 1
 ; GFX10-NEXT:    s_sub_i32 s17, 64, s16
 ; GFX10-NEXT:    s_cmp_lt_u32 s16, 64
-; GFX10-NEXT:    s_cselect_b32 s28, 1, 0
+; GFX10-NEXT:    s_cselect_b32 s27, 1, 0
 ; GFX10-NEXT:    s_cmp_eq_u32 s16, 0
-; GFX10-NEXT:    s_cselect_b32 s29, 1, 0
-; GFX10-NEXT:    s_lshr_b64 s[8:9], s[0:1], s16
-; GFX10-NEXT:    s_lshl_b64 s[24:25], s[10:11], s17
-; GFX10-NEXT:    s_lshr_b64 s[16:17], s[10:11], s16
-; GFX10-NEXT:    s_or_b64 s[8:9], s[8:9], s[24:25]
-; GFX10-NEXT:    s_lshr_b64 s[10:11], s[10:11], s27
+; GFX10-NEXT:    s_cselect_b32 s28, 1, 0
+; GFX10-NEXT:    s_lshr_b64 s[10:11], s[0:1], s16
+; GFX10-NEXT:    s_lshl_b64 s[24:25], s[8:9], s17
+; GFX10-NEXT:    s_lshr_b64 s[16:17], s[8:9], s16
+; GFX10-NEXT:    s_or_b64 s[10:11], s[10:11], s[24:25]
+; GFX10-NEXT:    s_lshr_b64 s[8:9], s[8:9], s26
+; GFX10-NEXT:    s_cmp_lg_u32 s27, 0
+; GFX10-NEXT:    s_cselect_b64 s[8:9], s[10:11], s[8:9]
 ; GFX10-NEXT:    s_cmp_lg_u32 s28, 0
-; GFX10-NEXT:    s_cselect_b64 s[8:9], s[8:9], s[10:11]
-; GFX10-NEXT:    s_cmp_lg_u32 s29, 0
 ; GFX10-NEXT:    s_cselect_b64 s[0:1], s[0:1], s[8:9]
-; GFX10-NEXT:    s_cmp_lg_u32 s28, 0
+; GFX10-NEXT:    s_cmp_lg_u32 s27, 0
 ; GFX10-NEXT:    s_cselect_b64 s[8:9], s[16:17], 0
 ; GFX10-NEXT:    s_andn2_b64 s[10:11], s[18:19], s[20:21]
 ; GFX10-NEXT:    s_or_b64 s[2:3], s[2:3], s[8:9]
@@ -6202,36 +6169,37 @@ define amdgpu_ps <2 x i128> @s_fshl_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ; GFX10-NEXT:    s_sub_i32 s11, s8, 64
 ; GFX10-NEXT:    s_sub_i32 s9, 64, s8
 ; GFX10-NEXT:    s_cmp_lt_u32 s8, 64
-; GFX10-NEXT:    s_cselect_b32 s20, 1, 0
+; GFX10-NEXT:    s_cselect_b32 s18, 1, 0
 ; GFX10-NEXT:    s_cmp_eq_u32 s8, 0
-; GFX10-NEXT:    s_cselect_b32 s21, 1, 0
+; GFX10-NEXT:    s_cselect_b32 s22, 1, 0
 ; GFX10-NEXT:    s_lshr_b64 s[16:17], s[4:5], s9
-; GFX10-NEXT:    s_lshl_b64 s[18:19], s[6:7], s8
+; GFX10-NEXT:    s_lshl_b64 s[20:21], s[6:7], s8
 ; GFX10-NEXT:    s_lshl_b64 s[8:9], s[4:5], s8
-; GFX10-NEXT:    s_or_b64 s[16:17], s[16:17], s[18:19]
+; GFX10-NEXT:    s_or_b64 s[16:17], s[16:17], s[20:21]
 ; GFX10-NEXT:    s_lshl_b64 s[4:5], s[4:5], s11
-; GFX10-NEXT:    s_cmp_lg_u32 s20, 0
+; GFX10-NEXT:    s_cmp_lg_u32 s18, 0
 ; GFX10-NEXT:    s_cselect_b64 s[8:9], s[8:9], 0
 ; GFX10-NEXT:    s_cselect_b64 s[4:5], s[16:17], s[4:5]
-; GFX10-NEXT:    s_cmp_lg_u32 s21, 0
+; GFX10-NEXT:    s_cmp_lg_u32 s22, 0
 ; GFX10-NEXT:    s_cselect_b64 s[6:7], s[6:7], s[4:5]
 ; GFX10-NEXT:    s_lshr_b64 s[4:5], s[12:13], 1
-; GFX10-NEXT:    s_lshl_b64 s[12:13], s[14:15], s26
-; GFX10-NEXT:    s_lshr_b64 s[14:15], s[14:15], 1
-; GFX10-NEXT:    s_or_b64 s[4:5], s[4:5], s[12:13]
+; GFX10-NEXT:    s_lshl_b32 s13, s14, 31
+; GFX10-NEXT:    s_mov_b32 s12, s19
 ; GFX10-NEXT:    s_sub_i32 s18, s10, 64
+; GFX10-NEXT:    s_or_b64 s[4:5], s[4:5], s[12:13]
+; GFX10-NEXT:    s_lshr_b64 s[12:13], s[14:15], 1
 ; GFX10-NEXT:    s_sub_i32 s11, 64, s10
 ; GFX10-NEXT:    s_cmp_lt_u32 s10, 64
 ; GFX10-NEXT:    s_cselect_b32 s19, 1, 0
 ; GFX10-NEXT:    s_cmp_eq_u32 s10, 0
 ; GFX10-NEXT:    s_cselect_b32 s20, 1, 0
-; GFX10-NEXT:    s_lshr_b64 s[12:13], s[4:5], s10
-; GFX10-NEXT:    s_lshl_b64 s[16:17], s[14:15], s11
-; GFX10-NEXT:    s_lshr_b64 s[10:11], s[14:15], s10
-; GFX10-NEXT:    s_or_b64 s[12:13], s[12:13], s[16:17]
-; GFX10-NEXT:    s_lshr_b64 s[14:15], s[14:15], s18
+; GFX10-NEXT:    s_lshr_b64 s[14:15], s[4:5], s10
+; GFX10-NEXT:    s_lshl_b64 s[16:17], s[12:13], s11
+; GFX10-NEXT:    s_lshr_b64 s[10:11], s[12:13], s10
+; GFX10-NEXT:    s_or_b64 s[14:15], s[14:15], s[16:17]
+; GFX10-NEXT:    s_lshr_b64 s[12:13], s[12:13], s18
 ; GFX10-NEXT:    s_cmp_lg_u32 s19, 0
-; GFX10-NEXT:    s_cselect_b64 s[12:13], s[12:13], s[14:15]
+; GFX10-NEXT:    s_cselect_b64 s[12:13], s[14:15], s[12:13]
 ; GFX10-NEXT:    s_cmp_lg_u32 s20, 0
 ; GFX10-NEXT:    s_cselect_b64 s[4:5], s[4:5], s[12:13]
 ; GFX10-NEXT:    s_cmp_lg_u32 s19, 0
@@ -6247,21 +6215,19 @@ define <2 x i128> @v_fshl_v2i128(<2 x i128> %lhs, <2 x i128> %rhs, <2 x i128> %a
 ; GFX6-LABEL: v_fshl_v2i128:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    s_sub_i32 s6, 64, 1
-; GFX6-NEXT:    v_lshl_b64 v[17:18], v[10:11], s6
-; GFX6-NEXT:    v_lshr_b64 v[8:9], v[8:9], 1
-; GFX6-NEXT:    s_movk_i32 s7, 0x7f
-; GFX6-NEXT:    v_and_b32_e32 v23, s7, v16
-; GFX6-NEXT:    v_or_b32_e32 v8, v8, v17
-; GFX6-NEXT:    v_xor_b32_e32 v16, -1, v16
+; GFX6-NEXT:    s_movk_i32 s6, 0x7f
+; GFX6-NEXT:    v_and_b32_e32 v23, s6, v16
 ; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, 64, v23
-; GFX6-NEXT:    v_and_b32_e32 v24, s7, v16
-; GFX6-NEXT:    v_or_b32_e32 v9, v9, v18
 ; GFX6-NEXT:    v_lshr_b64 v[17:18], v[0:1], v17
 ; GFX6-NEXT:    v_lshl_b64 v[21:22], v[2:3], v23
-; GFX6-NEXT:    v_lshr_b64 v[10:11], v[10:11], 1
-; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, 64, v24
+; GFX6-NEXT:    v_xor_b32_e32 v16, -1, v16
+; GFX6-NEXT:    v_lshr_b64 v[8:9], v[8:9], 1
+; GFX6-NEXT:    v_and_b32_e32 v24, s6, v16
 ; GFX6-NEXT:    v_or_b32_e32 v21, v17, v21
+; GFX6-NEXT:    v_lshlrev_b32_e32 v17, 31, v10
+; GFX6-NEXT:    v_lshr_b64 v[10:11], v[10:11], 1
+; GFX6-NEXT:    v_or_b32_e32 v9, v9, v17
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, 64, v24
 ; GFX6-NEXT:    v_or_b32_e32 v22, v18, v22
 ; GFX6-NEXT:    v_lshl_b64 v[16:17], v[10:11], v16
 ; GFX6-NEXT:    v_lshr_b64 v[18:19], v[8:9], v24
@@ -6293,9 +6259,9 @@ define <2 x i128> @v_fshl_v2i128(<2 x i128> %lhs, <2 x i128> %rhs, <2 x i128> %a
 ; GFX6-NEXT:    v_or_b32_e32 v1, v18, v3
 ; GFX6-NEXT:    v_or_b32_e32 v2, v17, v8
 ; GFX6-NEXT:    v_or_b32_e32 v3, v16, v9
-; GFX6-NEXT:    v_and_b32_e32 v16, s7, v20
+; GFX6-NEXT:    v_and_b32_e32 v16, s6, v20
 ; GFX6-NEXT:    v_xor_b32_e32 v8, -1, v20
-; GFX6-NEXT:    v_and_b32_e32 v17, s7, v8
+; GFX6-NEXT:    v_and_b32_e32 v17, s6, v8
 ; GFX6-NEXT:    v_sub_i32_e32 v8, vcc, 64, v16
 ; GFX6-NEXT:    v_lshr_b64 v[8:9], v[4:5], v8
 ; GFX6-NEXT:    v_lshl_b64 v[10:11], v[6:7], v16
@@ -6313,26 +6279,25 @@ define <2 x i128> @v_fshl_v2i128(<2 x i128> %lhs, <2 x i128> %rhs, <2 x i128> %a
 ; GFX6-NEXT:    v_cndmask_b32_e32 v16, v4, v6, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v20, v5, v7, vcc
 ; GFX6-NEXT:    v_lshr_b64 v[4:5], v[12:13], 1
-; GFX6-NEXT:    v_lshl_b64 v[6:7], v[14:15], s6
-; GFX6-NEXT:    v_lshr_b64 v[8:9], v[14:15], 1
+; GFX6-NEXT:    v_lshlrev_b32_e32 v6, 31, v14
+; GFX6-NEXT:    v_or_b32_e32 v5, v5, v6
+; GFX6-NEXT:    v_lshr_b64 v[6:7], v[14:15], 1
 ; GFX6-NEXT:    v_sub_i32_e32 v10, vcc, 64, v17
-; GFX6-NEXT:    v_or_b32_e32 v4, v4, v6
-; GFX6-NEXT:    v_or_b32_e32 v5, v5, v7
-; GFX6-NEXT:    v_lshr_b64 v[6:7], v[4:5], v17
-; GFX6-NEXT:    v_lshl_b64 v[10:11], v[8:9], v10
+; GFX6-NEXT:    v_lshr_b64 v[8:9], v[4:5], v17
+; GFX6-NEXT:    v_lshl_b64 v[10:11], v[6:7], v10
 ; GFX6-NEXT:    v_subrev_i32_e32 v12, vcc, 64, v17
-; GFX6-NEXT:    v_or_b32_e32 v10, v6, v10
-; GFX6-NEXT:    v_or_b32_e32 v11, v7, v11
-; GFX6-NEXT:    v_lshr_b64 v[6:7], v[8:9], v17
-; GFX6-NEXT:    v_lshr_b64 v[8:9], v[8:9], v12
+; GFX6-NEXT:    v_or_b32_e32 v10, v8, v10
+; GFX6-NEXT:    v_or_b32_e32 v11, v9, v11
+; GFX6-NEXT:    v_lshr_b64 v[8:9], v[6:7], v17
+; GFX6-NEXT:    v_lshr_b64 v[6:7], v[6:7], v12
 ; GFX6-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v17
-; GFX6-NEXT:    v_cndmask_b32_e32 v8, v8, v10, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v6, v6, v10, vcc
 ; GFX6-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v17
-; GFX6-NEXT:    v_cndmask_b32_e32 v9, v9, v11, vcc
-; GFX6-NEXT:    v_cndmask_b32_e64 v4, v8, v4, s[4:5]
-; GFX6-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s[4:5]
-; GFX6-NEXT:    v_cndmask_b32_e32 v6, 0, v6, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v7, 0, v7, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v7, v7, v11, vcc
+; GFX6-NEXT:    v_cndmask_b32_e64 v4, v6, v4, s[4:5]
+; GFX6-NEXT:    v_cndmask_b32_e64 v5, v7, v5, s[4:5]
+; GFX6-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v7, 0, v9, vcc
 ; GFX6-NEXT:    v_or_b32_e32 v4, v18, v4
 ; GFX6-NEXT:    v_or_b32_e32 v5, v19, v5
 ; GFX6-NEXT:    v_or_b32_e32 v6, v16, v6
@@ -6342,21 +6307,19 @@ define <2 x i128> @v_fshl_v2i128(<2 x i128> %lhs, <2 x i128> %rhs, <2 x i128> %a
 ; GFX8-LABEL: v_fshl_v2i128:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    s_sub_i32 s6, 64, 1
-; GFX8-NEXT:    v_lshlrev_b64 v[17:18], s6, v[10:11]
-; GFX8-NEXT:    v_lshrrev_b64 v[8:9], 1, v[8:9]
-; GFX8-NEXT:    s_movk_i32 s7, 0x7f
-; GFX8-NEXT:    v_and_b32_e32 v23, s7, v16
-; GFX8-NEXT:    v_or_b32_e32 v8, v8, v17
-; GFX8-NEXT:    v_xor_b32_e32 v16, -1, v16
+; GFX8-NEXT:    s_movk_i32 s6, 0x7f
+; GFX8-NEXT:    v_and_b32_e32 v23, s6, v16
 ; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, 64, v23
-; GFX8-NEXT:    v_and_b32_e32 v24, s7, v16
-; GFX8-NEXT:    v_or_b32_e32 v9, v9, v18
 ; GFX8-NEXT:    v_lshrrev_b64 v[17:18], v17, v[0:1]
 ; GFX8-NEXT:    v_lshlrev_b64 v[21:22], v23, v[2:3]
-; GFX8-NEXT:    v_lshrrev_b64 v[10:11], 1, v[10:11]
-; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, 64, v24
+; GFX8-NEXT:    v_xor_b32_e32 v16, -1, v16
+; GFX8-NEXT:    v_lshrrev_b64 v[8:9], 1, v[8:9]
+; GFX8-NEXT:    v_and_b32_e32 v24, s6, v16
 ; GFX8-NEXT:    v_or_b32_e32 v21, v17, v21
+; GFX8-NEXT:    v_lshlrev_b32_e32 v17, 31, v10
+; GFX8-NEXT:    v_lshrrev_b64 v[10:11], 1, v[10:11]
+; GFX8-NEXT:    v_or_b32_e32 v9, v9, v17
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, 64, v24
 ; GFX8-NEXT:    v_or_b32_e32 v22, v18, v22
 ; GFX8-NEXT:    v_lshlrev_b64 v[16:17], v16, v[10:11]
 ; GFX8-NEXT:    v_lshrrev_b64 v[18:19], v24, v[8:9]
@@ -6388,9 +6351,9 @@ define <2 x i128> @v_fshl_v2i128(<2 x i128> %lhs, <2 x i128> %rhs, <2 x i128> %a
 ; GFX8-NEXT:    v_or_b32_e32 v1, v18, v3
 ; GFX8-NEXT:    v_or_b32_e32 v2, v17, v8
 ; GFX8-NEXT:    v_or_b32_e32 v3, v16, v9
-; GFX8-NEXT:    v_and_b32_e32 v16, s7, v20
+; GFX8-NEXT:    v_and_b32_e32 v16, s6, v20
 ; GFX8-NEXT:    v_xor_b32_e32 v8, -1, v20
-; GFX8-NEXT:    v_and_b32_e32 v17, s7, v8
+; GFX8-NEXT:    v_and_b32_e32 v17, s6, v8
 ; GFX8-NEXT:    v_sub_u32_e32 v8, vcc, 64, v16
 ; GFX8-NEXT:    v_lshrrev_b64 v[8:9], v8, v[4:5]
 ; GFX8-NEXT:    v_lshlrev_b64 v[10:11], v16, v[6:7]
@@ -6408,26 +6371,25 @@ define <2 x i128> @v_fshl_v2i128(<2 x i128> %lhs, <2 x i128> %rhs, <2 x i128> %a
 ; GFX8-NEXT:    v_cndmask_b32_e32 v16, v4, v6, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v20, v5, v7, vcc
 ; GFX8-NEXT:    v_lshrrev_b64 v[4:5], 1, v[12:13]
-; GFX8-NEXT:    v_lshlrev_b64 v[6:7], s6, v[14:15]
-; GFX8-NEXT:    v_lshrrev_b64 v[8:9], 1, v[14:15]
+; GFX8-NEXT:    v_lshlrev_b32_e32 v6, 31, v14
+; GFX8-NEXT:    v_or_b32_e32 v5, v5, v6
+; GFX8-NEXT:    v_lshrrev_b64 v[6:7], 1, v[14:15]
 ; GFX8-NEXT:    v_sub_u32_e32 v10, vcc, 64, v17
-; GFX8-NEXT:    v_or_b32_e32 v4, v4, v6
-; GFX8-NEXT:    v_or_b32_e32 v5, v5, v7
-; GFX8-NEXT:    v_lshrrev_b64 v[6:7], v17, v[4:5]
-; GFX8-NEXT:    v_lshlrev_b64 v[10:11], v10, v[8:9]
+; GFX8-NEXT:    v_lshrrev_b64 v[8:9], v17, v[4:5]
+; GFX8-NEXT:    v_lshlrev_b64 v[10:11], v10, v[6:7]
 ; GFX8-NEXT:    v_subrev_u32_e32 v12, vcc, 64, v17
-; GFX8-NEXT:    v_or_b32_e32 v10, v6, v10
-; GFX8-NEXT:    v_or_b32_e32 v11, v7, v11
-; GFX8-NEXT:    v_lshrrev_b64 v[6:7], v17, v[8:9]
-; GFX8-NEXT:    v_lshrrev_b64 v[8:9], v12, v[8:9]
+; GFX8-NEXT:    v_or_b32_e32 v10, v8, v10
+; GFX8-NEXT:    v_or_b32_e32 v11, v9, v11
+; GFX8-NEXT:    v_lshrrev_b64 v[8:9], v17, v[6:7]
+; GFX8-NEXT:    v_lshrrev_b64 v[6:7], v12, v[6:7]
 ; GFX8-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v17
-; GFX8-NEXT:    v_cndmask_b32_e32 v8, v8, v10, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v6, v6, v10, vcc
 ; GFX8-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v17
-; GFX8-NEXT:    v_cndmask_b32_e32 v9, v9, v11, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v8, v4, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, 0, v6, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v7, 0, v7, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v7, v7, v11, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, v6, v4, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v7, v5, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v7, 0, v9, vcc
 ; GFX8-NEXT:    v_or_b32_e32 v4, v18, v4
 ; GFX8-NEXT:    v_or_b32_e32 v5, v19, v5
 ; GFX8-NEXT:    v_or_b32_e32 v6, v16, v6
@@ -6437,21 +6399,19 @@ define <2 x i128> @v_fshl_v2i128(<2 x i128> %lhs, <2 x i128> %rhs, <2 x i128> %a
 ; GFX9-LABEL: v_fshl_v2i128:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    s_sub_i32 s6, 64, 1
-; GFX9-NEXT:    v_lshlrev_b64 v[17:18], s6, v[10:11]
-; GFX9-NEXT:    v_lshrrev_b64 v[8:9], 1, v[8:9]
-; GFX9-NEXT:    s_movk_i32 s7, 0x7f
-; GFX9-NEXT:    v_and_b32_e32 v23, s7, v16
-; GFX9-NEXT:    v_or_b32_e32 v8, v8, v17
-; GFX9-NEXT:    v_xor_b32_e32 v16, -1, v16
+; GFX9-NEXT:    s_movk_i32 s6, 0x7f
+; GFX9-NEXT:    v_and_b32_e32 v23, s6, v16
 ; GFX9-NEXT:    v_sub_u32_e32 v17, 64, v23
-; GFX9-NEXT:    v_and_b32_e32 v24, s7, v16
-; GFX9-NEXT:    v_or_b32_e32 v9, v9, v18
 ; GFX9-NEXT:    v_lshrrev_b64 v[17:18], v17, v[0:1]
 ; GFX9-NEXT:    v_lshlrev_b64 v[21:22], v23, v[2:3]
-; GFX9-NEXT:    v_lshrrev_b64 v[10:11], 1, v[10:11]
-; GFX9-NEXT:    v_sub_u32_e32 v16, 64, v24
+; GFX9-NEXT:    v_xor_b32_e32 v16, -1, v16
+; GFX9-NEXT:    v_lshrrev_b64 v[8:9], 1, v[8:9]
+; GFX9-NEXT:    v_and_b32_e32 v24, s6, v16
 ; GFX9-NEXT:    v_or_b32_e32 v21, v17, v21
+; GFX9-NEXT:    v_lshlrev_b32_e32 v17, 31, v10
+; GFX9-NEXT:    v_lshrrev_b64 v[10:11], 1, v[10:11]
+; GFX9-NEXT:    v_or_b32_e32 v9, v9, v17
+; GFX9-NEXT:    v_sub_u32_e32 v16, 64, v24
 ; GFX9-NEXT:    v_or_b32_e32 v22, v18, v22
 ; GFX9-NEXT:    v_lshlrev_b64 v[16:17], v16, v[10:11]
 ; GFX9-NEXT:    v_lshrrev_b64 v[18:19], v24, v[8:9]
@@ -6483,9 +6443,9 @@ define <2 x i128> @v_fshl_v2i128(<2 x i128> %lhs, <2 x i128> %rhs, <2 x i128> %a
 ; GFX9-NEXT:    v_or_b32_e32 v1, v18, v3
 ; GFX9-NEXT:    v_or_b32_e32 v2, v17, v8
 ; GFX9-NEXT:    v_or_b32_e32 v3, v16, v9
-; GFX9-NEXT:    v_and_b32_e32 v16, s7, v20
+; GFX9-NEXT:    v_and_b32_e32 v16, s6, v20
 ; GFX9-NEXT:    v_xor_b32_e32 v8, -1, v20
-; GFX9-NEXT:    v_and_b32_e32 v17, s7, v8
+; GFX9-NEXT:    v_and_b32_e32 v17, s6, v8
 ; GFX9-NEXT:    v_sub_u32_e32 v8, 64, v16
 ; GFX9-NEXT:    v_lshrrev_b64 v[8:9], v8, v[4:5]
 ; GFX9-NEXT:    v_lshlrev_b64 v[10:11], v16, v[6:7]
@@ -6503,26 +6463,25 @@ define <2 x i128> @v_fshl_v2i128(<2 x i128> %lhs, <2 x i128> %rhs, <2 x i128> %a
 ; GFX9-NEXT:    v_cndmask_b32_e32 v16, v4, v6, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v20, v5, v7, vcc
 ; GFX9-NEXT:    v_lshrrev_b64 v[4:5], 1, v[12:13]
-; GFX9-NEXT:    v_lshlrev_b64 v[6:7], s6, v[14:15]
-; GFX9-NEXT:    v_lshrrev_b64 v[8:9], 1, v[14:15]
+; GFX9-NEXT:    v_lshlrev_b32_e32 v6, 31, v14
+; GFX9-NEXT:    v_or_b32_e32 v5, v5, v6
+; GFX9-NEXT:    v_lshrrev_b64 v[6:7], 1, v[14:15]
 ; GFX9-NEXT:    v_sub_u32_e32 v10, 64, v17
-; GFX9-NEXT:    v_or_b32_e32 v4, v4, v6
-; GFX9-NEXT:    v_or_b32_e32 v5, v5, v7
-; GFX9-NEXT:    v_lshrrev_b64 v[6:7], v17, v[4:5]
-; GFX9-NEXT:    v_lshlrev_b64 v[10:11], v10, v[8:9]
+; GFX9-NEXT:    v_lshrrev_b64 v[8:9], v17, v[4:5]
+; GFX9-NEXT:    v_lshlrev_b64 v[10:11], v10, v[6:7]
 ; GFX9-NEXT:    v_subrev_u32_e32 v12, 64, v17
-; GFX9-NEXT:    v_or_b32_e32 v10, v6, v10
-; GFX9-NEXT:    v_or_b32_e32 v11, v7, v11
-; GFX9-NEXT:    v_lshrrev_b64 v[6:7], v17, v[8:9]
-; GFX9-NEXT:    v_lshrrev_b64 v[8:9], v12, v[8:9]
+; GFX9-NEXT:    v_or_b32_e32 v10, v8, v10
+; GFX9-NEXT:    v_or_b32_e32 v11, v9, v11
+; GFX9-NEXT:    v_lshrrev_b64 v[8:9], v17, v[6:7]
+; GFX9-NEXT:    v_lshrrev_b64 v[6:7], v12, v[6:7]
 ; GFX9-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v17
-; GFX9-NEXT:    v_cndmask_b32_e32 v8, v8, v10, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v6, v6, v10, vcc
 ; GFX9-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v17
-; GFX9-NEXT:    v_cndmask_b32_e32 v9, v9, v11, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v8, v4, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, 0, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, 0, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v7, v7, v11, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, v6, v4, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, v7, v5, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v7, 0, v9, vcc
 ; GFX9-NEXT:    v_or_b32_e32 v4, v18, v4
 ; GFX9-NEXT:    v_or_b32_e32 v5, v19, v5
 ; GFX9-NEXT:    v_or_b32_e32 v6, v16, v6
@@ -6534,94 +6493,91 @@ define <2 x i128> @v_fshl_v2i128(<2 x i128> %lhs, <2 x i128> %rhs, <2 x i128> %a
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX10-NEXT:    s_movk_i32 s7, 0x7f
-; GFX10-NEXT:    v_xor_b32_e32 v18, -1, v16
-; GFX10-NEXT:    v_and_b32_e32 v27, s7, v16
-; GFX10-NEXT:    s_sub_i32 s8, 64, 1
 ; GFX10-NEXT:    v_lshrrev_b64 v[8:9], 1, v[8:9]
-; GFX10-NEXT:    v_lshlrev_b64 v[16:17], s8, v[10:11]
-; GFX10-NEXT:    v_and_b32_e32 v28, s7, v18
-; GFX10-NEXT:    v_sub_nc_u32_e32 v19, 64, v27
-; GFX10-NEXT:    v_lshlrev_b64 v[21:22], v27, v[2:3]
+; GFX10-NEXT:    v_and_b32_e32 v27, s7, v16
+; GFX10-NEXT:    v_xor_b32_e32 v16, -1, v16
+; GFX10-NEXT:    v_lshlrev_b32_e32 v21, 31, v10
 ; GFX10-NEXT:    v_lshrrev_b64 v[10:11], 1, v[10:11]
+; GFX10-NEXT:    v_sub_nc_u32_e32 v17, 64, v27
+; GFX10-NEXT:    v_and_b32_e32 v28, s7, v16
+; GFX10-NEXT:    v_lshlrev_b64 v[18:19], v27, v[2:3]
+; GFX10-NEXT:    v_or_b32_e32 v9, v9, v21
 ; GFX10-NEXT:    v_subrev_nc_u32_e32 v29, 64, v27
+; GFX10-NEXT:    v_lshrrev_b64 v[16:17], v17, v[0:1]
 ; GFX10-NEXT:    v_sub_nc_u32_e32 v25, 64, v28
-; GFX10-NEXT:    v_lshrrev_b64 v[18:19], v19, v[0:1]
-; GFX10-NEXT:    v_or_b32_e32 v8, v8, v16
-; GFX10-NEXT:    v_or_b32_e32 v9, v9, v17
-; GFX10-NEXT:    v_lshlrev_b64 v[16:17], v27, v[0:1]
-; GFX10-NEXT:    v_lshlrev_b64 v[25:26], v25, v[10:11]
-; GFX10-NEXT:    v_lshlrev_b64 v[0:1], v29, v[0:1]
-; GFX10-NEXT:    v_or_b32_e32 v21, v18, v21
+; GFX10-NEXT:    v_lshlrev_b64 v[21:22], v27, v[0:1]
 ; GFX10-NEXT:    v_lshrrev_b64 v[23:24], v28, v[8:9]
-; GFX10-NEXT:    v_subrev_nc_u32_e32 v18, 64, v28
-; GFX10-NEXT:    v_or_b32_e32 v22, v19, v22
+; GFX10-NEXT:    v_lshlrev_b64 v[0:1], v29, v[0:1]
 ; GFX10-NEXT:    v_cmp_gt_u32_e32 vcc_lo, 64, v27
+; GFX10-NEXT:    v_or_b32_e32 v18, v16, v18
+; GFX10-NEXT:    v_lshlrev_b64 v[25:26], v25, v[10:11]
+; GFX10-NEXT:    v_subrev_nc_u32_e32 v16, 64, v28
+; GFX10-NEXT:    v_or_b32_e32 v19, v17, v19
 ; GFX10-NEXT:    v_cmp_gt_u32_e64 s4, 64, v28
 ; GFX10-NEXT:    v_cmp_eq_u32_e64 s5, 0, v28
-; GFX10-NEXT:    v_lshrrev_b64 v[18:19], v18, v[10:11]
+; GFX10-NEXT:    v_cmp_eq_u32_e64 s6, 0, v27
+; GFX10-NEXT:    v_lshrrev_b64 v[16:17], v16, v[10:11]
 ; GFX10-NEXT:    v_or_b32_e32 v23, v23, v25
 ; GFX10-NEXT:    v_or_b32_e32 v24, v24, v26
-; GFX10-NEXT:    v_cndmask_b32_e32 v22, v1, v22, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_u32_e64 s6, 0, v27
-; GFX10-NEXT:    v_cndmask_b32_e32 v21, v0, v21, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v18, v18, v23, s4
+; GFX10-NEXT:    v_cndmask_b32_e32 v19, v1, v19, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v18, v0, v18, vcc_lo
 ; GFX10-NEXT:    v_lshrrev_b64 v[0:1], v28, v[10:11]
-; GFX10-NEXT:    v_cndmask_b32_e64 v10, v19, v24, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v22, v22, v3, s6
-; GFX10-NEXT:    v_cndmask_b32_e32 v16, 0, v16, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v18, v8, s5
-; GFX10-NEXT:    v_cndmask_b32_e32 v11, 0, v17, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v16, v16, v23, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v10, v17, v24, s4
+; GFX10-NEXT:    v_cndmask_b32_e32 v11, 0, v22, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v22, v19, v3, s6
+; GFX10-NEXT:    v_cndmask_b32_e32 v21, 0, v21, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, v16, v8, s5
 ; GFX10-NEXT:    v_cndmask_b32_e64 v8, v10, v9, s5
+; GFX10-NEXT:    v_and_b32_e32 v23, s7, v20
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, v18, v2, s6
 ; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0, v0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v21, v2, s6
-; GFX10-NEXT:    v_and_b32_e32 v24, s7, v20
-; GFX10-NEXT:    v_or_b32_e32 v0, v16, v3
+; GFX10-NEXT:    v_or_b32_e32 v0, v21, v3
 ; GFX10-NEXT:    v_xor_b32_e32 v3, -1, v20
-; GFX10-NEXT:    v_cndmask_b32_e64 v23, 0, v1, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v24, 0, v1, s4
 ; GFX10-NEXT:    v_or_b32_e32 v1, v11, v8
+; GFX10-NEXT:    v_sub_nc_u32_e32 v10, 64, v23
 ; GFX10-NEXT:    v_or_b32_e32 v2, v2, v9
-; GFX10-NEXT:    v_lshlrev_b64 v[10:11], s8, v[14:15]
 ; GFX10-NEXT:    v_lshrrev_b64 v[8:9], 1, v[12:13]
-; GFX10-NEXT:    v_sub_nc_u32_e32 v16, 64, v24
 ; GFX10-NEXT:    v_and_b32_e32 v25, s7, v3
+; GFX10-NEXT:    v_lshlrev_b32_e32 v16, 31, v14
+; GFX10-NEXT:    v_lshrrev_b64 v[10:11], v10, v[4:5]
+; GFX10-NEXT:    v_lshlrev_b64 v[12:13], v23, v[6:7]
 ; GFX10-NEXT:    v_lshrrev_b64 v[14:15], 1, v[14:15]
-; GFX10-NEXT:    v_subrev_nc_u32_e32 v3, 64, v24
-; GFX10-NEXT:    v_cmp_gt_u32_e32 vcc_lo, 64, v24
-; GFX10-NEXT:    v_lshrrev_b64 v[12:13], v16, v[4:5]
-; GFX10-NEXT:    v_lshlrev_b64 v[16:17], v24, v[6:7]
 ; GFX10-NEXT:    v_sub_nc_u32_e32 v20, 64, v25
-; GFX10-NEXT:    v_or_b32_e32 v8, v8, v10
-; GFX10-NEXT:    v_or_b32_e32 v9, v9, v11
-; GFX10-NEXT:    v_lshlrev_b64 v[10:11], v24, v[4:5]
-; GFX10-NEXT:    v_lshlrev_b64 v[3:4], v3, v[4:5]
-; GFX10-NEXT:    v_or_b32_e32 v16, v12, v16
-; GFX10-NEXT:    v_subrev_nc_u32_e32 v12, 64, v25
+; GFX10-NEXT:    v_or_b32_e32 v9, v9, v16
+; GFX10-NEXT:    v_subrev_nc_u32_e32 v3, 64, v23
+; GFX10-NEXT:    v_lshlrev_b64 v[16:17], v23, v[4:5]
+; GFX10-NEXT:    v_or_b32_e32 v12, v10, v12
+; GFX10-NEXT:    v_subrev_nc_u32_e32 v10, 64, v25
 ; GFX10-NEXT:    v_lshrrev_b64 v[18:19], v25, v[8:9]
 ; GFX10-NEXT:    v_lshlrev_b64 v[20:21], v20, v[14:15]
-; GFX10-NEXT:    v_or_b32_e32 v5, v13, v17
+; GFX10-NEXT:    v_cmp_gt_u32_e32 vcc_lo, 64, v23
+; GFX10-NEXT:    v_lshlrev_b64 v[3:4], v3, v[4:5]
+; GFX10-NEXT:    v_or_b32_e32 v5, v11, v13
+; GFX10-NEXT:    v_lshrrev_b64 v[10:11], v10, v[14:15]
 ; GFX10-NEXT:    v_cmp_gt_u32_e64 s4, 64, v25
-; GFX10-NEXT:    v_lshrrev_b64 v[12:13], v12, v[14:15]
-; GFX10-NEXT:    v_cndmask_b32_e32 v16, v3, v16, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_u32_e64 s6, 0, v24
-; GFX10-NEXT:    v_or_b32_e32 v17, v18, v20
+; GFX10-NEXT:    v_cndmask_b32_e32 v13, 0, v16, vcc_lo
+; GFX10-NEXT:    v_or_b32_e32 v16, v18, v20
 ; GFX10-NEXT:    v_or_b32_e32 v18, v19, v21
+; GFX10-NEXT:    v_cndmask_b32_e32 v12, v3, v12, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e32 v5, v4, v5, vcc_lo
 ; GFX10-NEXT:    v_lshrrev_b64 v[3:4], v25, v[14:15]
+; GFX10-NEXT:    v_cmp_eq_u32_e64 s6, 0, v23
+; GFX10-NEXT:    v_cndmask_b32_e64 v10, v10, v16, s4
 ; GFX10-NEXT:    v_cmp_eq_u32_e64 s5, 0, v25
-; GFX10-NEXT:    v_cndmask_b32_e64 v12, v12, v17, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v13, v13, v18, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v11, v11, v18, s4
+; GFX10-NEXT:    v_cndmask_b32_e32 v14, 0, v17, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v7, v5, v7, s6
-; GFX10-NEXT:    v_cndmask_b32_e32 v10, 0, v10, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v11, 0, v11, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v12, v8, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, v4, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v8, v13, v9, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, v12, v6, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, v10, v8, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v10, 0, v4, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v8, v11, v9, s5
 ; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0, v3, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v16, v6, s6
-; GFX10-NEXT:    v_or_b32_e32 v4, v10, v5
-; GFX10-NEXT:    v_or_b32_e32 v3, v22, v23
-; GFX10-NEXT:    v_or_b32_e32 v5, v11, v8
-; GFX10-NEXT:    v_or_b32_e32 v7, v7, v12
+; GFX10-NEXT:    v_or_b32_e32 v3, v22, v24
+; GFX10-NEXT:    v_or_b32_e32 v4, v13, v5
+; GFX10-NEXT:    v_or_b32_e32 v7, v7, v10
+; GFX10-NEXT:    v_or_b32_e32 v5, v14, v8
 ; GFX10-NEXT:    v_or_b32_e32 v6, v6, v9
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
   %result = call <2 x i128> @llvm.fshl.v2i128(<2 x i128> %lhs, <2 x i128> %rhs, <2 x i128> %amt)

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fshr.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fshr.ll
@@ -4840,25 +4840,25 @@ define <2 x i64> @v_fshr_v2i64(<2 x i64> %lhs, <2 x i64> %rhs, <2 x i64> %amt) {
 define amdgpu_ps i128 @s_fshr_i128(i128 inreg %lhs, i128 inreg %rhs, i128 inreg %amt) {
 ; GFX6-LABEL: s_fshr_i128:
 ; GFX6:       ; %bb.0:
-; GFX6-NEXT:    s_mov_b64 s[10:11], 0x7f
+; GFX6-NEXT:    s_movk_i32 s10, 0x7f
+; GFX6-NEXT:    s_mov_b32 s11, 0
 ; GFX6-NEXT:    s_and_b64 s[12:13], s[8:9], s[10:11]
 ; GFX6-NEXT:    s_andn2_b64 s[8:9], s[10:11], s[8:9]
-; GFX6-NEXT:    s_sub_i32 s9, 64, 1
-; GFX6-NEXT:    s_lshl_b64 s[10:11], s[0:1], 1
-; GFX6-NEXT:    s_lshr_b64 s[0:1], s[0:1], s9
 ; GFX6-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
-; GFX6-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
+; GFX6-NEXT:    s_lshr_b32 s10, s1, 31
+; GFX6-NEXT:    s_lshl_b64 s[14:15], s[0:1], 1
+; GFX6-NEXT:    s_or_b64 s[0:1], s[2:3], s[10:11]
 ; GFX6-NEXT:    s_sub_i32 s13, s8, 64
 ; GFX6-NEXT:    s_sub_i32 s9, 64, s8
 ; GFX6-NEXT:    s_cmp_lt_u32 s8, 64
 ; GFX6-NEXT:    s_cselect_b32 s16, 1, 0
 ; GFX6-NEXT:    s_cmp_eq_u32 s8, 0
 ; GFX6-NEXT:    s_cselect_b32 s17, 1, 0
-; GFX6-NEXT:    s_lshl_b64 s[2:3], s[10:11], s8
-; GFX6-NEXT:    s_lshr_b64 s[14:15], s[10:11], s9
+; GFX6-NEXT:    s_lshl_b64 s[2:3], s[14:15], s8
+; GFX6-NEXT:    s_lshr_b64 s[10:11], s[14:15], s9
 ; GFX6-NEXT:    s_lshl_b64 s[8:9], s[0:1], s8
-; GFX6-NEXT:    s_or_b64 s[8:9], s[14:15], s[8:9]
-; GFX6-NEXT:    s_lshl_b64 s[10:11], s[10:11], s13
+; GFX6-NEXT:    s_or_b64 s[8:9], s[10:11], s[8:9]
+; GFX6-NEXT:    s_lshl_b64 s[10:11], s[14:15], s13
 ; GFX6-NEXT:    s_cmp_lg_u32 s16, 0
 ; GFX6-NEXT:    s_cselect_b64 s[2:3], s[2:3], 0
 ; GFX6-NEXT:    s_cselect_b64 s[8:9], s[8:9], s[10:11]
@@ -4887,25 +4887,25 @@ define amdgpu_ps i128 @s_fshr_i128(i128 inreg %lhs, i128 inreg %rhs, i128 inreg 
 ;
 ; GFX8-LABEL: s_fshr_i128:
 ; GFX8:       ; %bb.0:
-; GFX8-NEXT:    s_mov_b64 s[10:11], 0x7f
+; GFX8-NEXT:    s_movk_i32 s10, 0x7f
+; GFX8-NEXT:    s_mov_b32 s11, 0
 ; GFX8-NEXT:    s_and_b64 s[12:13], s[8:9], s[10:11]
 ; GFX8-NEXT:    s_andn2_b64 s[8:9], s[10:11], s[8:9]
-; GFX8-NEXT:    s_sub_i32 s9, 64, 1
-; GFX8-NEXT:    s_lshl_b64 s[10:11], s[0:1], 1
-; GFX8-NEXT:    s_lshr_b64 s[0:1], s[0:1], s9
 ; GFX8-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
-; GFX8-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
+; GFX8-NEXT:    s_lshr_b32 s10, s1, 31
+; GFX8-NEXT:    s_lshl_b64 s[14:15], s[0:1], 1
+; GFX8-NEXT:    s_or_b64 s[0:1], s[2:3], s[10:11]
 ; GFX8-NEXT:    s_sub_i32 s13, s8, 64
 ; GFX8-NEXT:    s_sub_i32 s9, 64, s8
 ; GFX8-NEXT:    s_cmp_lt_u32 s8, 64
 ; GFX8-NEXT:    s_cselect_b32 s16, 1, 0
 ; GFX8-NEXT:    s_cmp_eq_u32 s8, 0
 ; GFX8-NEXT:    s_cselect_b32 s17, 1, 0
-; GFX8-NEXT:    s_lshl_b64 s[2:3], s[10:11], s8
-; GFX8-NEXT:    s_lshr_b64 s[14:15], s[10:11], s9
+; GFX8-NEXT:    s_lshl_b64 s[2:3], s[14:15], s8
+; GFX8-NEXT:    s_lshr_b64 s[10:11], s[14:15], s9
 ; GFX8-NEXT:    s_lshl_b64 s[8:9], s[0:1], s8
-; GFX8-NEXT:    s_or_b64 s[8:9], s[14:15], s[8:9]
-; GFX8-NEXT:    s_lshl_b64 s[10:11], s[10:11], s13
+; GFX8-NEXT:    s_or_b64 s[8:9], s[10:11], s[8:9]
+; GFX8-NEXT:    s_lshl_b64 s[10:11], s[14:15], s13
 ; GFX8-NEXT:    s_cmp_lg_u32 s16, 0
 ; GFX8-NEXT:    s_cselect_b64 s[2:3], s[2:3], 0
 ; GFX8-NEXT:    s_cselect_b64 s[8:9], s[8:9], s[10:11]
@@ -4934,25 +4934,25 @@ define amdgpu_ps i128 @s_fshr_i128(i128 inreg %lhs, i128 inreg %rhs, i128 inreg 
 ;
 ; GFX9-LABEL: s_fshr_i128:
 ; GFX9:       ; %bb.0:
-; GFX9-NEXT:    s_mov_b64 s[10:11], 0x7f
+; GFX9-NEXT:    s_movk_i32 s10, 0x7f
+; GFX9-NEXT:    s_mov_b32 s11, 0
 ; GFX9-NEXT:    s_and_b64 s[12:13], s[8:9], s[10:11]
 ; GFX9-NEXT:    s_andn2_b64 s[8:9], s[10:11], s[8:9]
-; GFX9-NEXT:    s_sub_i32 s9, 64, 1
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[0:1], 1
-; GFX9-NEXT:    s_lshr_b64 s[0:1], s[0:1], s9
 ; GFX9-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
-; GFX9-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
+; GFX9-NEXT:    s_lshr_b32 s10, s1, 31
+; GFX9-NEXT:    s_lshl_b64 s[14:15], s[0:1], 1
+; GFX9-NEXT:    s_or_b64 s[0:1], s[2:3], s[10:11]
 ; GFX9-NEXT:    s_sub_i32 s13, s8, 64
 ; GFX9-NEXT:    s_sub_i32 s9, 64, s8
 ; GFX9-NEXT:    s_cmp_lt_u32 s8, 64
 ; GFX9-NEXT:    s_cselect_b32 s16, 1, 0
 ; GFX9-NEXT:    s_cmp_eq_u32 s8, 0
 ; GFX9-NEXT:    s_cselect_b32 s17, 1, 0
-; GFX9-NEXT:    s_lshl_b64 s[2:3], s[10:11], s8
-; GFX9-NEXT:    s_lshr_b64 s[14:15], s[10:11], s9
+; GFX9-NEXT:    s_lshl_b64 s[2:3], s[14:15], s8
+; GFX9-NEXT:    s_lshr_b64 s[10:11], s[14:15], s9
 ; GFX9-NEXT:    s_lshl_b64 s[8:9], s[0:1], s8
-; GFX9-NEXT:    s_or_b64 s[8:9], s[14:15], s[8:9]
-; GFX9-NEXT:    s_lshl_b64 s[10:11], s[10:11], s13
+; GFX9-NEXT:    s_or_b64 s[8:9], s[10:11], s[8:9]
+; GFX9-NEXT:    s_lshl_b64 s[10:11], s[14:15], s13
 ; GFX9-NEXT:    s_cmp_lg_u32 s16, 0
 ; GFX9-NEXT:    s_cselect_b64 s[2:3], s[2:3], 0
 ; GFX9-NEXT:    s_cselect_b64 s[8:9], s[8:9], s[10:11]
@@ -4981,14 +4981,14 @@ define amdgpu_ps i128 @s_fshr_i128(i128 inreg %lhs, i128 inreg %rhs, i128 inreg 
 ;
 ; GFX10-LABEL: s_fshr_i128:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    s_mov_b64 s[10:11], 0x7f
+; GFX10-NEXT:    s_movk_i32 s10, 0x7f
+; GFX10-NEXT:    s_mov_b32 s11, 0
 ; GFX10-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
 ; GFX10-NEXT:    s_and_b64 s[12:13], s[8:9], s[10:11]
-; GFX10-NEXT:    s_sub_i32 s13, 64, 1
 ; GFX10-NEXT:    s_andn2_b64 s[8:9], s[10:11], s[8:9]
-; GFX10-NEXT:    s_lshr_b64 s[10:11], s[0:1], s13
+; GFX10-NEXT:    s_lshr_b32 s10, s1, 31
 ; GFX10-NEXT:    s_lshl_b64 s[0:1], s[0:1], 1
-; GFX10-NEXT:    s_or_b64 s[2:3], s[10:11], s[2:3]
+; GFX10-NEXT:    s_or_b64 s[2:3], s[2:3], s[10:11]
 ; GFX10-NEXT:    s_sub_i32 s13, s8, 64
 ; GFX10-NEXT:    s_sub_i32 s9, 64, s8
 ; GFX10-NEXT:    s_cmp_lt_u32 s8, 64
@@ -5036,29 +5036,27 @@ define i128 @v_fshr_i128(i128 %lhs, i128 %rhs, i128 %amt) {
 ; GFX6-NEXT:    s_movk_i32 s4, 0x7f
 ; GFX6-NEXT:    v_and_b32_e32 v14, s4, v8
 ; GFX6-NEXT:    v_xor_b32_e32 v8, -1, v8
-; GFX6-NEXT:    v_and_b32_e32 v15, s4, v8
-; GFX6-NEXT:    s_sub_i32 s4, 64, 1
-; GFX6-NEXT:    v_lshr_b64 v[8:9], v[0:1], s4
 ; GFX6-NEXT:    v_lshl_b64 v[2:3], v[2:3], 1
-; GFX6-NEXT:    v_lshl_b64 v[0:1], v[0:1], 1
-; GFX6-NEXT:    v_or_b32_e32 v2, v8, v2
-; GFX6-NEXT:    v_or_b32_e32 v3, v9, v3
-; GFX6-NEXT:    v_sub_i32_e32 v8, vcc, 64, v15
-; GFX6-NEXT:    v_subrev_i32_e32 v16, vcc, 64, v15
-; GFX6-NEXT:    v_lshr_b64 v[8:9], v[0:1], v8
+; GFX6-NEXT:    v_and_b32_e32 v15, s4, v8
+; GFX6-NEXT:    v_lshl_b64 v[8:9], v[0:1], 1
+; GFX6-NEXT:    v_lshrrev_b32_e32 v0, 31, v1
+; GFX6-NEXT:    v_or_b32_e32 v2, v2, v0
+; GFX6-NEXT:    v_sub_i32_e32 v0, vcc, 64, v15
+; GFX6-NEXT:    v_lshr_b64 v[0:1], v[8:9], v0
 ; GFX6-NEXT:    v_lshl_b64 v[10:11], v[2:3], v15
-; GFX6-NEXT:    v_lshl_b64 v[12:13], v[0:1], v15
-; GFX6-NEXT:    v_lshl_b64 v[0:1], v[0:1], v16
-; GFX6-NEXT:    v_or_b32_e32 v8, v8, v10
+; GFX6-NEXT:    v_subrev_i32_e32 v16, vcc, 64, v15
+; GFX6-NEXT:    v_lshl_b64 v[12:13], v[8:9], v15
+; GFX6-NEXT:    v_or_b32_e32 v10, v0, v10
+; GFX6-NEXT:    v_or_b32_e32 v11, v1, v11
+; GFX6-NEXT:    v_lshl_b64 v[0:1], v[8:9], v16
 ; GFX6-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v15
-; GFX6-NEXT:    v_or_b32_e32 v9, v9, v11
-; GFX6-NEXT:    v_cndmask_b32_e32 v10, 0, v12, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v11, 0, v13, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v12, 0, v12, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v13, 0, v13, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v0, v10, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v1, v1, v11, vcc
 ; GFX6-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v15
-; GFX6-NEXT:    v_cndmask_b32_e32 v12, v0, v2, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v13, v1, v3, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v10, v0, v2, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v11, v1, v3, vcc
 ; GFX6-NEXT:    v_sub_i32_e32 v2, vcc, 64, v14
 ; GFX6-NEXT:    v_lshr_b64 v[0:1], v[4:5], v14
 ; GFX6-NEXT:    v_lshl_b64 v[2:3], v[6:7], v2
@@ -5075,10 +5073,10 @@ define i128 @v_fshr_i128(i128 %lhs, i128 %rhs, i128 %amt) {
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, v1, v5, s[4:5]
 ; GFX6-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v3, 0, v9, vcc
-; GFX6-NEXT:    v_or_b32_e32 v0, v10, v0
-; GFX6-NEXT:    v_or_b32_e32 v1, v11, v1
-; GFX6-NEXT:    v_or_b32_e32 v2, v12, v2
-; GFX6-NEXT:    v_or_b32_e32 v3, v13, v3
+; GFX6-NEXT:    v_or_b32_e32 v0, v12, v0
+; GFX6-NEXT:    v_or_b32_e32 v1, v13, v1
+; GFX6-NEXT:    v_or_b32_e32 v2, v10, v2
+; GFX6-NEXT:    v_or_b32_e32 v3, v11, v3
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_fshr_i128:
@@ -5087,29 +5085,27 @@ define i128 @v_fshr_i128(i128 %lhs, i128 %rhs, i128 %amt) {
 ; GFX8-NEXT:    s_movk_i32 s4, 0x7f
 ; GFX8-NEXT:    v_and_b32_e32 v14, s4, v8
 ; GFX8-NEXT:    v_xor_b32_e32 v8, -1, v8
-; GFX8-NEXT:    v_and_b32_e32 v15, s4, v8
-; GFX8-NEXT:    s_sub_i32 s4, 64, 1
-; GFX8-NEXT:    v_lshrrev_b64 v[8:9], s4, v[0:1]
 ; GFX8-NEXT:    v_lshlrev_b64 v[2:3], 1, v[2:3]
-; GFX8-NEXT:    v_lshlrev_b64 v[0:1], 1, v[0:1]
-; GFX8-NEXT:    v_or_b32_e32 v2, v8, v2
-; GFX8-NEXT:    v_or_b32_e32 v3, v9, v3
-; GFX8-NEXT:    v_sub_u32_e32 v8, vcc, 64, v15
-; GFX8-NEXT:    v_subrev_u32_e32 v16, vcc, 64, v15
-; GFX8-NEXT:    v_lshrrev_b64 v[8:9], v8, v[0:1]
+; GFX8-NEXT:    v_and_b32_e32 v15, s4, v8
+; GFX8-NEXT:    v_lshlrev_b64 v[8:9], 1, v[0:1]
+; GFX8-NEXT:    v_lshrrev_b32_e32 v0, 31, v1
+; GFX8-NEXT:    v_or_b32_e32 v2, v2, v0
+; GFX8-NEXT:    v_sub_u32_e32 v0, vcc, 64, v15
+; GFX8-NEXT:    v_lshrrev_b64 v[0:1], v0, v[8:9]
 ; GFX8-NEXT:    v_lshlrev_b64 v[10:11], v15, v[2:3]
-; GFX8-NEXT:    v_lshlrev_b64 v[12:13], v15, v[0:1]
-; GFX8-NEXT:    v_lshlrev_b64 v[0:1], v16, v[0:1]
-; GFX8-NEXT:    v_or_b32_e32 v8, v8, v10
+; GFX8-NEXT:    v_subrev_u32_e32 v16, vcc, 64, v15
+; GFX8-NEXT:    v_lshlrev_b64 v[12:13], v15, v[8:9]
+; GFX8-NEXT:    v_or_b32_e32 v10, v0, v10
+; GFX8-NEXT:    v_or_b32_e32 v11, v1, v11
+; GFX8-NEXT:    v_lshlrev_b64 v[0:1], v16, v[8:9]
 ; GFX8-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v15
-; GFX8-NEXT:    v_or_b32_e32 v9, v9, v11
-; GFX8-NEXT:    v_cndmask_b32_e32 v10, 0, v12, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v11, 0, v13, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v12, 0, v12, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v13, 0, v13, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v10, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v11, vcc
 ; GFX8-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v15
-; GFX8-NEXT:    v_cndmask_b32_e32 v12, v0, v2, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v13, v1, v3, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v10, v0, v2, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v11, v1, v3, vcc
 ; GFX8-NEXT:    v_sub_u32_e32 v2, vcc, 64, v14
 ; GFX8-NEXT:    v_lshrrev_b64 v[0:1], v14, v[4:5]
 ; GFX8-NEXT:    v_lshlrev_b64 v[2:3], v2, v[6:7]
@@ -5126,10 +5122,10 @@ define i128 @v_fshr_i128(i128 %lhs, i128 %rhs, i128 %amt) {
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v5, s[4:5]
 ; GFX8-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v3, 0, v9, vcc
-; GFX8-NEXT:    v_or_b32_e32 v0, v10, v0
-; GFX8-NEXT:    v_or_b32_e32 v1, v11, v1
-; GFX8-NEXT:    v_or_b32_e32 v2, v12, v2
-; GFX8-NEXT:    v_or_b32_e32 v3, v13, v3
+; GFX8-NEXT:    v_or_b32_e32 v0, v12, v0
+; GFX8-NEXT:    v_or_b32_e32 v1, v13, v1
+; GFX8-NEXT:    v_or_b32_e32 v2, v10, v2
+; GFX8-NEXT:    v_or_b32_e32 v3, v11, v3
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_fshr_i128:
@@ -5138,30 +5134,28 @@ define i128 @v_fshr_i128(i128 %lhs, i128 %rhs, i128 %amt) {
 ; GFX9-NEXT:    s_movk_i32 s4, 0x7f
 ; GFX9-NEXT:    v_and_b32_e32 v14, s4, v8
 ; GFX9-NEXT:    v_xor_b32_e32 v8, -1, v8
-; GFX9-NEXT:    v_and_b32_e32 v15, s4, v8
-; GFX9-NEXT:    s_sub_i32 s4, 64, 1
-; GFX9-NEXT:    v_lshrrev_b64 v[8:9], s4, v[0:1]
 ; GFX9-NEXT:    v_lshlrev_b64 v[2:3], 1, v[2:3]
-; GFX9-NEXT:    v_lshlrev_b64 v[0:1], 1, v[0:1]
-; GFX9-NEXT:    v_or_b32_e32 v2, v8, v2
-; GFX9-NEXT:    v_or_b32_e32 v3, v9, v3
-; GFX9-NEXT:    v_sub_u32_e32 v8, 64, v15
-; GFX9-NEXT:    v_subrev_u32_e32 v16, 64, v15
-; GFX9-NEXT:    v_lshrrev_b64 v[8:9], v8, v[0:1]
+; GFX9-NEXT:    v_and_b32_e32 v15, s4, v8
+; GFX9-NEXT:    v_lshlrev_b64 v[8:9], 1, v[0:1]
+; GFX9-NEXT:    v_lshrrev_b32_e32 v0, 31, v1
+; GFX9-NEXT:    v_or_b32_e32 v2, v2, v0
+; GFX9-NEXT:    v_sub_u32_e32 v0, 64, v15
+; GFX9-NEXT:    v_lshrrev_b64 v[0:1], v0, v[8:9]
 ; GFX9-NEXT:    v_lshlrev_b64 v[10:11], v15, v[2:3]
-; GFX9-NEXT:    v_lshlrev_b64 v[12:13], v15, v[0:1]
-; GFX9-NEXT:    v_lshlrev_b64 v[0:1], v16, v[0:1]
-; GFX9-NEXT:    v_or_b32_e32 v8, v8, v10
+; GFX9-NEXT:    v_subrev_u32_e32 v16, 64, v15
+; GFX9-NEXT:    v_lshlrev_b64 v[12:13], v15, v[8:9]
+; GFX9-NEXT:    v_or_b32_e32 v10, v0, v10
+; GFX9-NEXT:    v_or_b32_e32 v11, v1, v11
+; GFX9-NEXT:    v_lshlrev_b64 v[0:1], v16, v[8:9]
 ; GFX9-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v15
-; GFX9-NEXT:    v_or_b32_e32 v9, v9, v11
-; GFX9-NEXT:    v_cndmask_b32_e32 v10, 0, v12, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, 0, v13, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v12, 0, v12, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v13, 0, v13, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v10, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v11, vcc
 ; GFX9-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v15
-; GFX9-NEXT:    v_cndmask_b32_e32 v12, v0, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v10, v0, v2, vcc
 ; GFX9-NEXT:    v_sub_u32_e32 v2, 64, v14
-; GFX9-NEXT:    v_cndmask_b32_e32 v13, v1, v3, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v11, v1, v3, vcc
 ; GFX9-NEXT:    v_lshrrev_b64 v[0:1], v14, v[4:5]
 ; GFX9-NEXT:    v_lshlrev_b64 v[2:3], v2, v[6:7]
 ; GFX9-NEXT:    v_subrev_u32_e32 v15, 64, v14
@@ -5177,59 +5171,57 @@ define i128 @v_fshr_i128(i128 %lhs, i128 %rhs, i128 %amt) {
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, v5, s[4:5]
 ; GFX9-NEXT:    v_cndmask_b32_e32 v2, 0, v8, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v3, 0, v9, vcc
-; GFX9-NEXT:    v_or_b32_e32 v0, v10, v0
-; GFX9-NEXT:    v_or_b32_e32 v1, v11, v1
-; GFX9-NEXT:    v_or_b32_e32 v2, v12, v2
-; GFX9-NEXT:    v_or_b32_e32 v3, v13, v3
+; GFX9-NEXT:    v_or_b32_e32 v0, v12, v0
+; GFX9-NEXT:    v_or_b32_e32 v1, v13, v1
+; GFX9-NEXT:    v_or_b32_e32 v2, v10, v2
+; GFX9-NEXT:    v_or_b32_e32 v3, v11, v3
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_fshr_i128:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX10-NEXT:    v_xor_b32_e32 v11, -1, v8
-; GFX10-NEXT:    s_sub_i32 s4, 64, 1
-; GFX10-NEXT:    v_lshlrev_b64 v[2:3], 1, v[2:3]
-; GFX10-NEXT:    v_lshrrev_b64 v[9:10], s4, v[0:1]
+; GFX10-NEXT:    v_xor_b32_e32 v9, -1, v8
 ; GFX10-NEXT:    s_movk_i32 s4, 0x7f
-; GFX10-NEXT:    v_lshlrev_b64 v[0:1], 1, v[0:1]
-; GFX10-NEXT:    v_and_b32_e32 v18, s4, v11
+; GFX10-NEXT:    v_lshlrev_b64 v[2:3], 1, v[2:3]
+; GFX10-NEXT:    v_lshrrev_b32_e32 v10, 31, v1
 ; GFX10-NEXT:    v_and_b32_e32 v19, s4, v8
-; GFX10-NEXT:    v_or_b32_e32 v3, v10, v3
-; GFX10-NEXT:    v_or_b32_e32 v2, v9, v2
-; GFX10-NEXT:    v_sub_nc_u32_e32 v10, 64, v18
+; GFX10-NEXT:    v_and_b32_e32 v18, s4, v9
+; GFX10-NEXT:    v_lshlrev_b64 v[0:1], 1, v[0:1]
+; GFX10-NEXT:    v_or_b32_e32 v2, v2, v10
 ; GFX10-NEXT:    v_sub_nc_u32_e32 v16, 64, v19
-; GFX10-NEXT:    v_subrev_nc_u32_e32 v20, 64, v18
-; GFX10-NEXT:    v_lshrrev_b64 v[14:15], v19, v[4:5]
+; GFX10-NEXT:    v_sub_nc_u32_e32 v10, 64, v18
+; GFX10-NEXT:    v_subrev_nc_u32_e32 v21, 64, v18
+; GFX10-NEXT:    v_subrev_nc_u32_e32 v20, 64, v19
 ; GFX10-NEXT:    v_lshlrev_b64 v[8:9], v18, v[2:3]
+; GFX10-NEXT:    v_lshrrev_b64 v[12:13], v19, v[4:5]
 ; GFX10-NEXT:    v_lshrrev_b64 v[10:11], v10, v[0:1]
 ; GFX10-NEXT:    v_lshlrev_b64 v[16:17], v16, v[6:7]
-; GFX10-NEXT:    v_lshlrev_b64 v[12:13], v18, v[0:1]
-; GFX10-NEXT:    v_lshlrev_b64 v[0:1], v20, v[0:1]
+; GFX10-NEXT:    v_lshlrev_b64 v[14:15], v18, v[0:1]
+; GFX10-NEXT:    v_lshlrev_b64 v[0:1], v21, v[0:1]
 ; GFX10-NEXT:    v_cmp_gt_u32_e32 vcc_lo, 64, v18
 ; GFX10-NEXT:    v_cmp_gt_u32_e64 s4, 64, v19
 ; GFX10-NEXT:    v_or_b32_e32 v10, v10, v8
-; GFX10-NEXT:    v_subrev_nc_u32_e32 v8, 64, v19
 ; GFX10-NEXT:    v_or_b32_e32 v11, v11, v9
-; GFX10-NEXT:    v_or_b32_e32 v14, v14, v16
-; GFX10-NEXT:    v_or_b32_e32 v15, v15, v17
+; GFX10-NEXT:    v_lshrrev_b64 v[8:9], v20, v[6:7]
+; GFX10-NEXT:    v_or_b32_e32 v12, v12, v16
+; GFX10-NEXT:    v_or_b32_e32 v13, v13, v17
 ; GFX10-NEXT:    v_cndmask_b32_e32 v10, v0, v10, vcc_lo
-; GFX10-NEXT:    v_lshrrev_b64 v[8:9], v8, v[6:7]
 ; GFX10-NEXT:    v_cndmask_b32_e32 v11, v1, v11, vcc_lo
 ; GFX10-NEXT:    v_lshrrev_b64 v[0:1], v19, v[6:7]
 ; GFX10-NEXT:    v_cmp_eq_u32_e64 s6, 0, v18
+; GFX10-NEXT:    v_cndmask_b32_e64 v8, v8, v12, s4
 ; GFX10-NEXT:    v_cmp_eq_u32_e64 s5, 0, v19
-; GFX10-NEXT:    v_cndmask_b32_e32 v12, 0, v12, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v8, v8, v14, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v9, v15, s4
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, 0, v13, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, v9, v13, s4
+; GFX10-NEXT:    v_cndmask_b32_e32 v14, 0, v14, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v7, 0, v15, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v2, v10, v2, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v11, v3, s6
 ; GFX10-NEXT:    v_cndmask_b32_e64 v4, v8, v4, s5
 ; GFX10-NEXT:    v_cndmask_b32_e64 v5, v6, v5, s5
 ; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, v0, s4
 ; GFX10-NEXT:    v_cndmask_b32_e64 v8, 0, v1, s4
-; GFX10-NEXT:    v_or_b32_e32 v0, v12, v4
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, v11, v3, s6
+; GFX10-NEXT:    v_or_b32_e32 v0, v14, v4
 ; GFX10-NEXT:    v_or_b32_e32 v1, v7, v5
 ; GFX10-NEXT:    v_or_b32_e32 v2, v2, v6
 ; GFX10-NEXT:    v_or_b32_e32 v3, v3, v8
@@ -5244,20 +5236,20 @@ define amdgpu_ps <4 x float> @v_fshr_i128_ssv(i128 inreg %lhs, i128 inreg %rhs, 
 ; GFX6-NEXT:    s_movk_i32 s8, 0x7f
 ; GFX6-NEXT:    v_and_b32_e32 v6, s8, v0
 ; GFX6-NEXT:    v_xor_b32_e32 v0, -1, v0
-; GFX6-NEXT:    s_sub_i32 s10, 64, 1
 ; GFX6-NEXT:    v_and_b32_e32 v7, s8, v0
-; GFX6-NEXT:    s_lshl_b64 s[8:9], s[0:1], 1
-; GFX6-NEXT:    s_lshr_b64 s[0:1], s[0:1], s10
+; GFX6-NEXT:    s_mov_b32 s9, 0
 ; GFX6-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
+; GFX6-NEXT:    s_lshr_b32 s8, s1, 31
+; GFX6-NEXT:    s_lshl_b64 s[10:11], s[0:1], 1
 ; GFX6-NEXT:    v_sub_i32_e32 v0, vcc, 64, v7
-; GFX6-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
-; GFX6-NEXT:    v_lshr_b64 v[0:1], s[8:9], v0
+; GFX6-NEXT:    s_or_b64 s[0:1], s[2:3], s[8:9]
+; GFX6-NEXT:    v_lshr_b64 v[0:1], s[10:11], v0
 ; GFX6-NEXT:    v_lshl_b64 v[2:3], s[0:1], v7
 ; GFX6-NEXT:    v_subrev_i32_e32 v8, vcc, 64, v7
-; GFX6-NEXT:    v_lshl_b64 v[4:5], s[8:9], v7
+; GFX6-NEXT:    v_lshl_b64 v[4:5], s[10:11], v7
 ; GFX6-NEXT:    v_or_b32_e32 v2, v0, v2
 ; GFX6-NEXT:    v_or_b32_e32 v3, v1, v3
-; GFX6-NEXT:    v_lshl_b64 v[0:1], s[8:9], v8
+; GFX6-NEXT:    v_lshl_b64 v[0:1], s[10:11], v8
 ; GFX6-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v7
 ; GFX6-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
@@ -5297,20 +5289,20 @@ define amdgpu_ps <4 x float> @v_fshr_i128_ssv(i128 inreg %lhs, i128 inreg %rhs, 
 ; GFX8-NEXT:    s_movk_i32 s8, 0x7f
 ; GFX8-NEXT:    v_and_b32_e32 v6, s8, v0
 ; GFX8-NEXT:    v_xor_b32_e32 v0, -1, v0
-; GFX8-NEXT:    s_sub_i32 s10, 64, 1
 ; GFX8-NEXT:    v_and_b32_e32 v7, s8, v0
-; GFX8-NEXT:    s_lshl_b64 s[8:9], s[0:1], 1
-; GFX8-NEXT:    s_lshr_b64 s[0:1], s[0:1], s10
+; GFX8-NEXT:    s_mov_b32 s9, 0
 ; GFX8-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
+; GFX8-NEXT:    s_lshr_b32 s8, s1, 31
+; GFX8-NEXT:    s_lshl_b64 s[10:11], s[0:1], 1
 ; GFX8-NEXT:    v_sub_u32_e32 v0, vcc, 64, v7
-; GFX8-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
-; GFX8-NEXT:    v_lshrrev_b64 v[0:1], v0, s[8:9]
+; GFX8-NEXT:    s_or_b64 s[0:1], s[2:3], s[8:9]
+; GFX8-NEXT:    v_lshrrev_b64 v[0:1], v0, s[10:11]
 ; GFX8-NEXT:    v_lshlrev_b64 v[2:3], v7, s[0:1]
 ; GFX8-NEXT:    v_subrev_u32_e32 v8, vcc, 64, v7
-; GFX8-NEXT:    v_lshlrev_b64 v[4:5], v7, s[8:9]
+; GFX8-NEXT:    v_lshlrev_b64 v[4:5], v7, s[10:11]
 ; GFX8-NEXT:    v_or_b32_e32 v2, v0, v2
 ; GFX8-NEXT:    v_or_b32_e32 v3, v1, v3
-; GFX8-NEXT:    v_lshlrev_b64 v[0:1], v8, s[8:9]
+; GFX8-NEXT:    v_lshlrev_b64 v[0:1], v8, s[10:11]
 ; GFX8-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v7
 ; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
@@ -5350,20 +5342,20 @@ define amdgpu_ps <4 x float> @v_fshr_i128_ssv(i128 inreg %lhs, i128 inreg %rhs, 
 ; GFX9-NEXT:    s_movk_i32 s8, 0x7f
 ; GFX9-NEXT:    v_and_b32_e32 v6, s8, v0
 ; GFX9-NEXT:    v_xor_b32_e32 v0, -1, v0
-; GFX9-NEXT:    s_sub_i32 s10, 64, 1
 ; GFX9-NEXT:    v_and_b32_e32 v7, s8, v0
-; GFX9-NEXT:    s_lshl_b64 s[8:9], s[0:1], 1
-; GFX9-NEXT:    s_lshr_b64 s[0:1], s[0:1], s10
+; GFX9-NEXT:    s_mov_b32 s9, 0
 ; GFX9-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
+; GFX9-NEXT:    s_lshr_b32 s8, s1, 31
+; GFX9-NEXT:    s_lshl_b64 s[10:11], s[0:1], 1
 ; GFX9-NEXT:    v_sub_u32_e32 v0, 64, v7
-; GFX9-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
-; GFX9-NEXT:    v_lshrrev_b64 v[0:1], v0, s[8:9]
+; GFX9-NEXT:    s_or_b64 s[0:1], s[2:3], s[8:9]
+; GFX9-NEXT:    v_lshrrev_b64 v[0:1], v0, s[10:11]
 ; GFX9-NEXT:    v_lshlrev_b64 v[2:3], v7, s[0:1]
 ; GFX9-NEXT:    v_subrev_u32_e32 v8, 64, v7
-; GFX9-NEXT:    v_lshlrev_b64 v[4:5], v7, s[8:9]
+; GFX9-NEXT:    v_lshlrev_b64 v[4:5], v7, s[10:11]
 ; GFX9-NEXT:    v_or_b32_e32 v2, v0, v2
 ; GFX9-NEXT:    v_or_b32_e32 v3, v1, v3
-; GFX9-NEXT:    v_lshlrev_b64 v[0:1], v8, s[8:9]
+; GFX9-NEXT:    v_lshlrev_b64 v[0:1], v8, s[10:11]
 ; GFX9-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v7
 ; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
@@ -5402,14 +5394,14 @@ define amdgpu_ps <4 x float> @v_fshr_i128_ssv(i128 inreg %lhs, i128 inreg %rhs, 
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    v_xor_b32_e32 v1, -1, v0
 ; GFX10-NEXT:    s_movk_i32 s10, 0x7f
-; GFX10-NEXT:    s_sub_i32 s8, 64, 1
+; GFX10-NEXT:    s_lshr_b32 s8, s1, 31
 ; GFX10-NEXT:    v_and_b32_e32 v13, s10, v0
-; GFX10-NEXT:    s_lshr_b64 s[8:9], s[0:1], s8
+; GFX10-NEXT:    s_mov_b32 s9, 0
 ; GFX10-NEXT:    v_and_b32_e32 v12, s10, v1
 ; GFX10-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
 ; GFX10-NEXT:    s_lshl_b64 s[0:1], s[0:1], 1
 ; GFX10-NEXT:    v_sub_nc_u32_e32 v8, 64, v13
-; GFX10-NEXT:    s_or_b64 s[8:9], s[8:9], s[2:3]
+; GFX10-NEXT:    s_or_b64 s[8:9], s[2:3], s[8:9]
 ; GFX10-NEXT:    v_sub_nc_u32_e32 v2, 64, v12
 ; GFX10-NEXT:    v_subrev_nc_u32_e32 v10, 64, v12
 ; GFX10-NEXT:    v_lshlrev_b64 v[0:1], v12, s[8:9]
@@ -5454,25 +5446,25 @@ define amdgpu_ps <4 x float> @v_fshr_i128_ssv(i128 inreg %lhs, i128 inreg %rhs, 
 define amdgpu_ps <4 x float> @v_fshr_i128_svs(i128 inreg %lhs, i128 %rhs, i128 inreg %amt) {
 ; GFX6-LABEL: v_fshr_i128_svs:
 ; GFX6:       ; %bb.0:
-; GFX6-NEXT:    s_mov_b64 s[6:7], 0x7f
+; GFX6-NEXT:    s_movk_i32 s6, 0x7f
+; GFX6-NEXT:    s_mov_b32 s7, 0
 ; GFX6-NEXT:    s_and_b64 s[8:9], s[4:5], s[6:7]
 ; GFX6-NEXT:    s_andn2_b64 s[4:5], s[6:7], s[4:5]
-; GFX6-NEXT:    s_sub_i32 s5, 64, 1
-; GFX6-NEXT:    s_lshl_b64 s[6:7], s[0:1], 1
-; GFX6-NEXT:    s_lshr_b64 s[0:1], s[0:1], s5
 ; GFX6-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
-; GFX6-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
+; GFX6-NEXT:    s_lshr_b32 s6, s1, 31
+; GFX6-NEXT:    s_lshl_b64 s[10:11], s[0:1], 1
+; GFX6-NEXT:    s_or_b64 s[0:1], s[2:3], s[6:7]
 ; GFX6-NEXT:    s_sub_i32 s9, s4, 64
 ; GFX6-NEXT:    s_sub_i32 s5, 64, s4
 ; GFX6-NEXT:    s_cmp_lt_u32 s4, 64
 ; GFX6-NEXT:    s_cselect_b32 s12, 1, 0
 ; GFX6-NEXT:    s_cmp_eq_u32 s4, 0
 ; GFX6-NEXT:    s_cselect_b32 s13, 1, 0
-; GFX6-NEXT:    s_lshl_b64 s[2:3], s[6:7], s4
-; GFX6-NEXT:    s_lshr_b64 s[10:11], s[6:7], s5
+; GFX6-NEXT:    s_lshl_b64 s[2:3], s[10:11], s4
+; GFX6-NEXT:    s_lshr_b64 s[6:7], s[10:11], s5
 ; GFX6-NEXT:    s_lshl_b64 s[4:5], s[0:1], s4
-; GFX6-NEXT:    s_or_b64 s[4:5], s[10:11], s[4:5]
-; GFX6-NEXT:    s_lshl_b64 s[6:7], s[6:7], s9
+; GFX6-NEXT:    s_or_b64 s[4:5], s[6:7], s[4:5]
+; GFX6-NEXT:    s_lshl_b64 s[6:7], s[10:11], s9
 ; GFX6-NEXT:    s_cmp_lg_u32 s12, 0
 ; GFX6-NEXT:    s_cselect_b64 s[2:3], s[2:3], 0
 ; GFX6-NEXT:    s_cselect_b64 s[4:5], s[4:5], s[6:7]
@@ -5510,25 +5502,25 @@ define amdgpu_ps <4 x float> @v_fshr_i128_svs(i128 inreg %lhs, i128 %rhs, i128 i
 ;
 ; GFX8-LABEL: v_fshr_i128_svs:
 ; GFX8:       ; %bb.0:
-; GFX8-NEXT:    s_mov_b64 s[6:7], 0x7f
+; GFX8-NEXT:    s_movk_i32 s6, 0x7f
+; GFX8-NEXT:    s_mov_b32 s7, 0
 ; GFX8-NEXT:    s_and_b64 s[8:9], s[4:5], s[6:7]
 ; GFX8-NEXT:    s_andn2_b64 s[4:5], s[6:7], s[4:5]
-; GFX8-NEXT:    s_sub_i32 s5, 64, 1
-; GFX8-NEXT:    s_lshl_b64 s[6:7], s[0:1], 1
-; GFX8-NEXT:    s_lshr_b64 s[0:1], s[0:1], s5
 ; GFX8-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
-; GFX8-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
+; GFX8-NEXT:    s_lshr_b32 s6, s1, 31
+; GFX8-NEXT:    s_lshl_b64 s[10:11], s[0:1], 1
+; GFX8-NEXT:    s_or_b64 s[0:1], s[2:3], s[6:7]
 ; GFX8-NEXT:    s_sub_i32 s9, s4, 64
 ; GFX8-NEXT:    s_sub_i32 s5, 64, s4
 ; GFX8-NEXT:    s_cmp_lt_u32 s4, 64
 ; GFX8-NEXT:    s_cselect_b32 s12, 1, 0
 ; GFX8-NEXT:    s_cmp_eq_u32 s4, 0
 ; GFX8-NEXT:    s_cselect_b32 s13, 1, 0
-; GFX8-NEXT:    s_lshl_b64 s[2:3], s[6:7], s4
-; GFX8-NEXT:    s_lshr_b64 s[10:11], s[6:7], s5
+; GFX8-NEXT:    s_lshl_b64 s[2:3], s[10:11], s4
+; GFX8-NEXT:    s_lshr_b64 s[6:7], s[10:11], s5
 ; GFX8-NEXT:    s_lshl_b64 s[4:5], s[0:1], s4
-; GFX8-NEXT:    s_or_b64 s[4:5], s[10:11], s[4:5]
-; GFX8-NEXT:    s_lshl_b64 s[6:7], s[6:7], s9
+; GFX8-NEXT:    s_or_b64 s[4:5], s[6:7], s[4:5]
+; GFX8-NEXT:    s_lshl_b64 s[6:7], s[10:11], s9
 ; GFX8-NEXT:    s_cmp_lg_u32 s12, 0
 ; GFX8-NEXT:    s_cselect_b64 s[2:3], s[2:3], 0
 ; GFX8-NEXT:    s_cselect_b64 s[4:5], s[4:5], s[6:7]
@@ -5566,25 +5558,25 @@ define amdgpu_ps <4 x float> @v_fshr_i128_svs(i128 inreg %lhs, i128 %rhs, i128 i
 ;
 ; GFX9-LABEL: v_fshr_i128_svs:
 ; GFX9:       ; %bb.0:
-; GFX9-NEXT:    s_mov_b64 s[6:7], 0x7f
+; GFX9-NEXT:    s_movk_i32 s6, 0x7f
+; GFX9-NEXT:    s_mov_b32 s7, 0
 ; GFX9-NEXT:    s_and_b64 s[8:9], s[4:5], s[6:7]
 ; GFX9-NEXT:    s_andn2_b64 s[4:5], s[6:7], s[4:5]
-; GFX9-NEXT:    s_sub_i32 s5, 64, 1
-; GFX9-NEXT:    s_lshl_b64 s[6:7], s[0:1], 1
-; GFX9-NEXT:    s_lshr_b64 s[0:1], s[0:1], s5
 ; GFX9-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
-; GFX9-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
+; GFX9-NEXT:    s_lshr_b32 s6, s1, 31
+; GFX9-NEXT:    s_lshl_b64 s[10:11], s[0:1], 1
+; GFX9-NEXT:    s_or_b64 s[0:1], s[2:3], s[6:7]
 ; GFX9-NEXT:    s_sub_i32 s9, s4, 64
 ; GFX9-NEXT:    s_sub_i32 s5, 64, s4
 ; GFX9-NEXT:    s_cmp_lt_u32 s4, 64
 ; GFX9-NEXT:    s_cselect_b32 s12, 1, 0
 ; GFX9-NEXT:    s_cmp_eq_u32 s4, 0
 ; GFX9-NEXT:    s_cselect_b32 s13, 1, 0
-; GFX9-NEXT:    s_lshl_b64 s[2:3], s[6:7], s4
-; GFX9-NEXT:    s_lshr_b64 s[10:11], s[6:7], s5
+; GFX9-NEXT:    s_lshl_b64 s[2:3], s[10:11], s4
+; GFX9-NEXT:    s_lshr_b64 s[6:7], s[10:11], s5
 ; GFX9-NEXT:    s_lshl_b64 s[4:5], s[0:1], s4
-; GFX9-NEXT:    s_or_b64 s[4:5], s[10:11], s[4:5]
-; GFX9-NEXT:    s_lshl_b64 s[6:7], s[6:7], s9
+; GFX9-NEXT:    s_or_b64 s[4:5], s[6:7], s[4:5]
+; GFX9-NEXT:    s_lshl_b64 s[6:7], s[10:11], s9
 ; GFX9-NEXT:    s_cmp_lg_u32 s12, 0
 ; GFX9-NEXT:    s_cselect_b64 s[2:3], s[2:3], 0
 ; GFX9-NEXT:    s_cselect_b64 s[4:5], s[4:5], s[6:7]
@@ -5622,14 +5614,14 @@ define amdgpu_ps <4 x float> @v_fshr_i128_svs(i128 inreg %lhs, i128 %rhs, i128 i
 ;
 ; GFX10-LABEL: v_fshr_i128_svs:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    s_mov_b64 s[6:7], 0x7f
+; GFX10-NEXT:    s_movk_i32 s6, 0x7f
+; GFX10-NEXT:    s_mov_b32 s7, 0
 ; GFX10-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
 ; GFX10-NEXT:    s_and_b64 s[8:9], s[4:5], s[6:7]
-; GFX10-NEXT:    s_sub_i32 s9, 64, 1
 ; GFX10-NEXT:    s_andn2_b64 s[4:5], s[6:7], s[4:5]
-; GFX10-NEXT:    s_lshr_b64 s[6:7], s[0:1], s9
+; GFX10-NEXT:    s_lshr_b32 s6, s1, 31
 ; GFX10-NEXT:    s_lshl_b64 s[0:1], s[0:1], 1
-; GFX10-NEXT:    s_or_b64 s[2:3], s[6:7], s[2:3]
+; GFX10-NEXT:    s_or_b64 s[2:3], s[2:3], s[6:7]
 ; GFX10-NEXT:    s_sub_i32 s9, s4, 64
 ; GFX10-NEXT:    s_sub_i32 s5, 64, s4
 ; GFX10-NEXT:    s_cmp_lt_u32 s4, 64
@@ -5684,37 +5676,35 @@ define amdgpu_ps <4 x float> @v_fshr_i128_vss(i128 %lhs, i128 inreg %rhs, i128 i
 ; GFX6-NEXT:    s_mov_b64 s[6:7], 0x7f
 ; GFX6-NEXT:    s_and_b64 s[8:9], s[4:5], s[6:7]
 ; GFX6-NEXT:    s_andn2_b64 s[4:5], s[6:7], s[4:5]
-; GFX6-NEXT:    s_sub_i32 s5, 64, 1
-; GFX6-NEXT:    v_lshr_b64 v[4:5], v[0:1], s5
 ; GFX6-NEXT:    v_lshl_b64 v[2:3], v[2:3], 1
 ; GFX6-NEXT:    s_sub_i32 s5, s4, 64
 ; GFX6-NEXT:    s_sub_i32 s6, 64, s4
-; GFX6-NEXT:    v_lshl_b64 v[0:1], v[0:1], 1
+; GFX6-NEXT:    v_lshl_b64 v[4:5], v[0:1], 1
+; GFX6-NEXT:    v_lshrrev_b32_e32 v0, 31, v1
 ; GFX6-NEXT:    s_cmp_lt_u32 s4, 64
+; GFX6-NEXT:    v_or_b32_e32 v2, v2, v0
 ; GFX6-NEXT:    s_cselect_b32 s7, 1, 0
 ; GFX6-NEXT:    s_cmp_eq_u32 s4, 0
-; GFX6-NEXT:    v_or_b32_e32 v2, v4, v2
-; GFX6-NEXT:    v_or_b32_e32 v3, v5, v3
 ; GFX6-NEXT:    s_cselect_b32 s9, 1, 0
+; GFX6-NEXT:    v_lshr_b64 v[0:1], v[4:5], s6
 ; GFX6-NEXT:    v_lshl_b64 v[6:7], v[2:3], s4
-; GFX6-NEXT:    v_lshl_b64 v[8:9], v[0:1], s4
+; GFX6-NEXT:    v_lshl_b64 v[8:9], v[4:5], s4
 ; GFX6-NEXT:    s_and_b32 s4, 1, s7
-; GFX6-NEXT:    v_lshr_b64 v[4:5], v[0:1], s6
 ; GFX6-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s4
 ; GFX6-NEXT:    s_and_b32 s4, 1, s9
 ; GFX6-NEXT:    s_sub_i32 s10, s8, 64
 ; GFX6-NEXT:    s_sub_i32 s9, 64, s8
 ; GFX6-NEXT:    s_cmp_lt_u32 s8, 64
-; GFX6-NEXT:    v_lshl_b64 v[0:1], v[0:1], s5
-; GFX6-NEXT:    v_or_b32_e32 v4, v4, v6
-; GFX6-NEXT:    v_or_b32_e32 v5, v5, v7
+; GFX6-NEXT:    v_or_b32_e32 v6, v0, v6
+; GFX6-NEXT:    v_or_b32_e32 v7, v1, v7
+; GFX6-NEXT:    v_lshl_b64 v[0:1], v[4:5], s5
 ; GFX6-NEXT:    s_cselect_b32 s11, 1, 0
 ; GFX6-NEXT:    s_cmp_eq_u32 s8, 0
 ; GFX6-NEXT:    s_cselect_b32 s12, 1, 0
-; GFX6-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v7, 0, v9, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v5, 0, v9, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v0, v6, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v1, v1, v7, vcc
 ; GFX6-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s4
 ; GFX6-NEXT:    s_lshr_b64 s[4:5], s[2:3], s8
 ; GFX6-NEXT:    s_lshr_b64 s[6:7], s[0:1], s8
@@ -5729,8 +5719,8 @@ define amdgpu_ps <4 x float> @v_fshr_i128_vss(i128 %lhs, i128 inreg %rhs, i128 i
 ; GFX6-NEXT:    v_cndmask_b32_e32 v2, v0, v2, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v3, v1, v3, vcc
 ; GFX6-NEXT:    s_cselect_b64 s[2:3], s[4:5], 0
-; GFX6-NEXT:    v_or_b32_e32 v0, s0, v6
-; GFX6-NEXT:    v_or_b32_e32 v1, s1, v7
+; GFX6-NEXT:    v_or_b32_e32 v0, s0, v4
+; GFX6-NEXT:    v_or_b32_e32 v1, s1, v5
 ; GFX6-NEXT:    v_or_b32_e32 v2, s2, v2
 ; GFX6-NEXT:    v_or_b32_e32 v3, s3, v3
 ; GFX6-NEXT:    ; return to shader part epilog
@@ -5740,37 +5730,35 @@ define amdgpu_ps <4 x float> @v_fshr_i128_vss(i128 %lhs, i128 inreg %rhs, i128 i
 ; GFX8-NEXT:    s_mov_b64 s[6:7], 0x7f
 ; GFX8-NEXT:    s_and_b64 s[8:9], s[4:5], s[6:7]
 ; GFX8-NEXT:    s_andn2_b64 s[4:5], s[6:7], s[4:5]
-; GFX8-NEXT:    s_sub_i32 s5, 64, 1
-; GFX8-NEXT:    v_lshrrev_b64 v[4:5], s5, v[0:1]
 ; GFX8-NEXT:    v_lshlrev_b64 v[2:3], 1, v[2:3]
 ; GFX8-NEXT:    s_sub_i32 s5, s4, 64
 ; GFX8-NEXT:    s_sub_i32 s6, 64, s4
-; GFX8-NEXT:    v_lshlrev_b64 v[0:1], 1, v[0:1]
+; GFX8-NEXT:    v_lshlrev_b64 v[4:5], 1, v[0:1]
+; GFX8-NEXT:    v_lshrrev_b32_e32 v0, 31, v1
 ; GFX8-NEXT:    s_cmp_lt_u32 s4, 64
+; GFX8-NEXT:    v_or_b32_e32 v2, v2, v0
 ; GFX8-NEXT:    s_cselect_b32 s7, 1, 0
 ; GFX8-NEXT:    s_cmp_eq_u32 s4, 0
-; GFX8-NEXT:    v_or_b32_e32 v2, v4, v2
-; GFX8-NEXT:    v_or_b32_e32 v3, v5, v3
 ; GFX8-NEXT:    s_cselect_b32 s9, 1, 0
+; GFX8-NEXT:    v_lshrrev_b64 v[0:1], s6, v[4:5]
 ; GFX8-NEXT:    v_lshlrev_b64 v[6:7], s4, v[2:3]
-; GFX8-NEXT:    v_lshlrev_b64 v[8:9], s4, v[0:1]
+; GFX8-NEXT:    v_lshlrev_b64 v[8:9], s4, v[4:5]
 ; GFX8-NEXT:    s_and_b32 s4, 1, s7
-; GFX8-NEXT:    v_lshrrev_b64 v[4:5], s6, v[0:1]
 ; GFX8-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s4
 ; GFX8-NEXT:    s_and_b32 s4, 1, s9
 ; GFX8-NEXT:    s_sub_i32 s10, s8, 64
 ; GFX8-NEXT:    s_sub_i32 s9, 64, s8
 ; GFX8-NEXT:    s_cmp_lt_u32 s8, 64
-; GFX8-NEXT:    v_lshlrev_b64 v[0:1], s5, v[0:1]
-; GFX8-NEXT:    v_or_b32_e32 v4, v4, v6
-; GFX8-NEXT:    v_or_b32_e32 v5, v5, v7
+; GFX8-NEXT:    v_or_b32_e32 v6, v0, v6
+; GFX8-NEXT:    v_or_b32_e32 v7, v1, v7
+; GFX8-NEXT:    v_lshlrev_b64 v[0:1], s5, v[4:5]
 ; GFX8-NEXT:    s_cselect_b32 s11, 1, 0
 ; GFX8-NEXT:    s_cmp_eq_u32 s8, 0
 ; GFX8-NEXT:    s_cselect_b32 s12, 1, 0
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v7, 0, v9, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v5, 0, v9, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v6, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v7, vcc
 ; GFX8-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s4
 ; GFX8-NEXT:    s_lshr_b64 s[4:5], s[2:3], s8
 ; GFX8-NEXT:    s_lshr_b64 s[6:7], s[0:1], s8
@@ -5785,8 +5773,8 @@ define amdgpu_ps <4 x float> @v_fshr_i128_vss(i128 %lhs, i128 inreg %rhs, i128 i
 ; GFX8-NEXT:    v_cndmask_b32_e32 v2, v0, v2, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v3, v1, v3, vcc
 ; GFX8-NEXT:    s_cselect_b64 s[2:3], s[4:5], 0
-; GFX8-NEXT:    v_or_b32_e32 v0, s0, v6
-; GFX8-NEXT:    v_or_b32_e32 v1, s1, v7
+; GFX8-NEXT:    v_or_b32_e32 v0, s0, v4
+; GFX8-NEXT:    v_or_b32_e32 v1, s1, v5
 ; GFX8-NEXT:    v_or_b32_e32 v2, s2, v2
 ; GFX8-NEXT:    v_or_b32_e32 v3, s3, v3
 ; GFX8-NEXT:    ; return to shader part epilog
@@ -5796,37 +5784,35 @@ define amdgpu_ps <4 x float> @v_fshr_i128_vss(i128 %lhs, i128 inreg %rhs, i128 i
 ; GFX9-NEXT:    s_mov_b64 s[6:7], 0x7f
 ; GFX9-NEXT:    s_and_b64 s[8:9], s[4:5], s[6:7]
 ; GFX9-NEXT:    s_andn2_b64 s[4:5], s[6:7], s[4:5]
-; GFX9-NEXT:    s_sub_i32 s5, 64, 1
-; GFX9-NEXT:    v_lshrrev_b64 v[4:5], s5, v[0:1]
 ; GFX9-NEXT:    v_lshlrev_b64 v[2:3], 1, v[2:3]
 ; GFX9-NEXT:    s_sub_i32 s5, s4, 64
 ; GFX9-NEXT:    s_sub_i32 s6, 64, s4
-; GFX9-NEXT:    v_lshlrev_b64 v[0:1], 1, v[0:1]
+; GFX9-NEXT:    v_lshlrev_b64 v[4:5], 1, v[0:1]
+; GFX9-NEXT:    v_lshrrev_b32_e32 v0, 31, v1
 ; GFX9-NEXT:    s_cmp_lt_u32 s4, 64
+; GFX9-NEXT:    v_or_b32_e32 v2, v2, v0
 ; GFX9-NEXT:    s_cselect_b32 s7, 1, 0
 ; GFX9-NEXT:    s_cmp_eq_u32 s4, 0
-; GFX9-NEXT:    v_or_b32_e32 v2, v4, v2
-; GFX9-NEXT:    v_or_b32_e32 v3, v5, v3
 ; GFX9-NEXT:    s_cselect_b32 s9, 1, 0
+; GFX9-NEXT:    v_lshrrev_b64 v[0:1], s6, v[4:5]
 ; GFX9-NEXT:    v_lshlrev_b64 v[6:7], s4, v[2:3]
-; GFX9-NEXT:    v_lshlrev_b64 v[8:9], s4, v[0:1]
+; GFX9-NEXT:    v_lshlrev_b64 v[8:9], s4, v[4:5]
 ; GFX9-NEXT:    s_and_b32 s4, 1, s7
-; GFX9-NEXT:    v_lshrrev_b64 v[4:5], s6, v[0:1]
 ; GFX9-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s4
 ; GFX9-NEXT:    s_and_b32 s4, 1, s9
 ; GFX9-NEXT:    s_sub_i32 s10, s8, 64
 ; GFX9-NEXT:    s_sub_i32 s9, 64, s8
 ; GFX9-NEXT:    s_cmp_lt_u32 s8, 64
-; GFX9-NEXT:    v_lshlrev_b64 v[0:1], s5, v[0:1]
-; GFX9-NEXT:    v_or_b32_e32 v4, v4, v6
-; GFX9-NEXT:    v_or_b32_e32 v5, v5, v7
+; GFX9-NEXT:    v_or_b32_e32 v6, v0, v6
+; GFX9-NEXT:    v_or_b32_e32 v7, v1, v7
+; GFX9-NEXT:    v_lshlrev_b64 v[0:1], s5, v[4:5]
 ; GFX9-NEXT:    s_cselect_b32 s11, 1, 0
 ; GFX9-NEXT:    s_cmp_eq_u32 s8, 0
 ; GFX9-NEXT:    s_cselect_b32 s12, 1, 0
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, 0, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, 0, v9, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v5, 0, v9, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v6, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v7, vcc
 ; GFX9-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s4
 ; GFX9-NEXT:    s_lshr_b64 s[4:5], s[2:3], s8
 ; GFX9-NEXT:    s_lshr_b64 s[6:7], s[0:1], s8
@@ -5841,29 +5827,27 @@ define amdgpu_ps <4 x float> @v_fshr_i128_vss(i128 %lhs, i128 inreg %rhs, i128 i
 ; GFX9-NEXT:    v_cndmask_b32_e32 v2, v0, v2, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v3, v1, v3, vcc
 ; GFX9-NEXT:    s_cselect_b64 s[2:3], s[4:5], 0
-; GFX9-NEXT:    v_or_b32_e32 v0, s0, v6
-; GFX9-NEXT:    v_or_b32_e32 v1, s1, v7
+; GFX9-NEXT:    v_or_b32_e32 v0, s0, v4
+; GFX9-NEXT:    v_or_b32_e32 v1, s1, v5
 ; GFX9-NEXT:    v_or_b32_e32 v2, s2, v2
 ; GFX9-NEXT:    v_or_b32_e32 v3, s3, v3
 ; GFX9-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-LABEL: v_fshr_i128_vss:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    s_sub_i32 s6, 64, 1
 ; GFX10-NEXT:    v_lshlrev_b64 v[2:3], 1, v[2:3]
-; GFX10-NEXT:    v_lshrrev_b64 v[4:5], s6, v[0:1]
+; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 31, v1
 ; GFX10-NEXT:    s_mov_b64 s[6:7], 0x7f
 ; GFX10-NEXT:    v_lshlrev_b64 v[0:1], 1, v[0:1]
 ; GFX10-NEXT:    s_andn2_b64 s[8:9], s[6:7], s[4:5]
 ; GFX10-NEXT:    s_and_b64 s[6:7], s[4:5], s[6:7]
+; GFX10-NEXT:    v_or_b32_e32 v2, v2, v4
 ; GFX10-NEXT:    s_sub_i32 s4, 64, s8
-; GFX10-NEXT:    v_or_b32_e32 v2, v4, v2
-; GFX10-NEXT:    v_or_b32_e32 v3, v5, v3
 ; GFX10-NEXT:    s_sub_i32 s5, s8, 64
 ; GFX10-NEXT:    s_cmp_lt_u32 s8, 64
 ; GFX10-NEXT:    v_lshrrev_b64 v[4:5], s4, v[0:1]
-; GFX10-NEXT:    s_cselect_b32 vcc_lo, 1, 0
 ; GFX10-NEXT:    v_lshlrev_b64 v[6:7], s8, v[2:3]
+; GFX10-NEXT:    s_cselect_b32 vcc_lo, 1, 0
 ; GFX10-NEXT:    s_cmp_eq_u32 s8, 0
 ; GFX10-NEXT:    v_lshlrev_b64 v[8:9], s8, v[0:1]
 ; GFX10-NEXT:    s_cselect_b32 s7, 1, 0
@@ -5910,58 +5894,50 @@ define amdgpu_ps <4 x float> @v_fshr_i128_vss(i128 %lhs, i128 inreg %rhs, i128 i
 define amdgpu_ps i128 @s_fshr_i128_65(i128 inreg %lhs, i128 inreg %rhs) {
 ; GFX6-LABEL: s_fshr_i128_65:
 ; GFX6:       ; %bb.0:
-; GFX6-NEXT:    s_sub_i32 s3, 64, 63
 ; GFX6-NEXT:    s_mov_b32 s4, 0
 ; GFX6-NEXT:    s_lshl_b32 s5, s0, 31
-; GFX6-NEXT:    s_lshr_b64 s[0:1], s[0:1], s3
 ; GFX6-NEXT:    s_lshl_b32 s3, s2, 31
 ; GFX6-NEXT:    s_mov_b32 s2, s4
-; GFX6-NEXT:    s_or_b64 s[2:3], s[0:1], s[2:3]
-; GFX6-NEXT:    s_sub_i32 s0, 0x41, 64
-; GFX6-NEXT:    s_lshr_b64 s[0:1], s[6:7], s0
+; GFX6-NEXT:    s_lshr_b64 s[0:1], s[0:1], 1
+; GFX6-NEXT:    s_or_b64 s[2:3], s[2:3], s[0:1]
+; GFX6-NEXT:    s_lshr_b64 s[0:1], s[6:7], 1
 ; GFX6-NEXT:    s_or_b64 s[0:1], s[4:5], s[0:1]
 ; GFX6-NEXT:    ; return to shader part epilog
 ;
 ; GFX8-LABEL: s_fshr_i128_65:
 ; GFX8:       ; %bb.0:
-; GFX8-NEXT:    s_sub_i32 s3, 64, 63
 ; GFX8-NEXT:    s_mov_b32 s4, 0
 ; GFX8-NEXT:    s_lshl_b32 s5, s0, 31
-; GFX8-NEXT:    s_lshr_b64 s[0:1], s[0:1], s3
 ; GFX8-NEXT:    s_lshl_b32 s3, s2, 31
 ; GFX8-NEXT:    s_mov_b32 s2, s4
-; GFX8-NEXT:    s_or_b64 s[2:3], s[0:1], s[2:3]
-; GFX8-NEXT:    s_sub_i32 s0, 0x41, 64
-; GFX8-NEXT:    s_lshr_b64 s[0:1], s[6:7], s0
+; GFX8-NEXT:    s_lshr_b64 s[0:1], s[0:1], 1
+; GFX8-NEXT:    s_or_b64 s[2:3], s[2:3], s[0:1]
+; GFX8-NEXT:    s_lshr_b64 s[0:1], s[6:7], 1
 ; GFX8-NEXT:    s_or_b64 s[0:1], s[4:5], s[0:1]
 ; GFX8-NEXT:    ; return to shader part epilog
 ;
 ; GFX9-LABEL: s_fshr_i128_65:
 ; GFX9:       ; %bb.0:
-; GFX9-NEXT:    s_sub_i32 s3, 64, 63
 ; GFX9-NEXT:    s_mov_b32 s4, 0
 ; GFX9-NEXT:    s_lshl_b32 s5, s0, 31
-; GFX9-NEXT:    s_lshr_b64 s[0:1], s[0:1], s3
 ; GFX9-NEXT:    s_lshl_b32 s3, s2, 31
 ; GFX9-NEXT:    s_mov_b32 s2, s4
-; GFX9-NEXT:    s_or_b64 s[2:3], s[0:1], s[2:3]
-; GFX9-NEXT:    s_sub_i32 s0, 0x41, 64
-; GFX9-NEXT:    s_lshr_b64 s[0:1], s[6:7], s0
+; GFX9-NEXT:    s_lshr_b64 s[0:1], s[0:1], 1
+; GFX9-NEXT:    s_or_b64 s[2:3], s[2:3], s[0:1]
+; GFX9-NEXT:    s_lshr_b64 s[0:1], s[6:7], 1
 ; GFX9-NEXT:    s_or_b64 s[0:1], s[4:5], s[0:1]
 ; GFX9-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-LABEL: s_fshr_i128_65:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    s_sub_i32 s3, 64, 63
-; GFX10-NEXT:    s_lshl_b32 s5, s0, 31
-; GFX10-NEXT:    s_lshr_b64 s[8:9], s[0:1], s3
-; GFX10-NEXT:    s_sub_i32 s0, 0x41, 64
 ; GFX10-NEXT:    s_mov_b32 s4, 0
-; GFX10-NEXT:    s_lshr_b64 s[0:1], s[6:7], s0
 ; GFX10-NEXT:    s_lshl_b32 s3, s2, 31
+; GFX10-NEXT:    s_lshl_b32 s5, s0, 31
 ; GFX10-NEXT:    s_mov_b32 s2, s4
-; GFX10-NEXT:    s_or_b64 s[0:1], s[4:5], s[0:1]
-; GFX10-NEXT:    s_or_b64 s[2:3], s[8:9], s[2:3]
+; GFX10-NEXT:    s_lshr_b64 s[8:9], s[0:1], 1
+; GFX10-NEXT:    s_lshr_b64 s[6:7], s[6:7], 1
+; GFX10-NEXT:    s_or_b64 s[2:3], s[2:3], s[8:9]
+; GFX10-NEXT:    s_or_b64 s[0:1], s[4:5], s[6:7]
 ; GFX10-NEXT:    ; return to shader part epilog
   %result = call i128 @llvm.fshr.i128(i128 %lhs, i128 %rhs, i128 65)
   ret i128 %result
@@ -5971,43 +5947,34 @@ define i128 @v_fshr_i128_65(i128 %lhs, i128 %rhs) {
 ; GFX6-LABEL: v_fshr_i128_65:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    s_sub_i32 s4, 64, 63
-; GFX6-NEXT:    v_mov_b32_e32 v4, v2
-; GFX6-NEXT:    v_lshr_b64 v[2:3], v[0:1], s4
-; GFX6-NEXT:    s_sub_i32 s4, 0x41, 64
-; GFX6-NEXT:    v_lshlrev_b32_e32 v5, 31, v0
-; GFX6-NEXT:    v_lshr_b64 v[0:1], v[6:7], s4
-; GFX6-NEXT:    v_lshlrev_b32_e32 v4, 31, v4
-; GFX6-NEXT:    v_or_b32_e32 v3, v3, v4
-; GFX6-NEXT:    v_or_b32_e32 v1, v5, v1
+; GFX6-NEXT:    v_lshlrev_b32_e32 v5, 31, v2
+; GFX6-NEXT:    v_lshr_b64 v[2:3], v[0:1], 1
+; GFX6-NEXT:    v_lshlrev_b32_e32 v4, 31, v0
+; GFX6-NEXT:    v_lshr_b64 v[0:1], v[6:7], 1
+; GFX6-NEXT:    v_or_b32_e32 v3, v5, v3
+; GFX6-NEXT:    v_or_b32_e32 v1, v4, v1
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_fshr_i128_65:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    s_sub_i32 s4, 64, 63
-; GFX8-NEXT:    v_mov_b32_e32 v4, v2
-; GFX8-NEXT:    v_lshrrev_b64 v[2:3], s4, v[0:1]
-; GFX8-NEXT:    s_sub_i32 s4, 0x41, 64
-; GFX8-NEXT:    v_lshlrev_b32_e32 v5, 31, v0
-; GFX8-NEXT:    v_lshrrev_b64 v[0:1], s4, v[6:7]
-; GFX8-NEXT:    v_lshlrev_b32_e32 v4, 31, v4
-; GFX8-NEXT:    v_or_b32_e32 v3, v3, v4
-; GFX8-NEXT:    v_or_b32_e32 v1, v5, v1
+; GFX8-NEXT:    v_lshlrev_b32_e32 v5, 31, v2
+; GFX8-NEXT:    v_lshrrev_b64 v[2:3], 1, v[0:1]
+; GFX8-NEXT:    v_lshlrev_b32_e32 v4, 31, v0
+; GFX8-NEXT:    v_lshrrev_b64 v[0:1], 1, v[6:7]
+; GFX8-NEXT:    v_or_b32_e32 v3, v5, v3
+; GFX8-NEXT:    v_or_b32_e32 v1, v4, v1
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_fshr_i128_65:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    s_sub_i32 s4, 64, 63
-; GFX9-NEXT:    v_mov_b32_e32 v4, v2
-; GFX9-NEXT:    v_lshrrev_b64 v[2:3], s4, v[0:1]
-; GFX9-NEXT:    s_sub_i32 s4, 0x41, 64
-; GFX9-NEXT:    v_lshlrev_b32_e32 v5, 31, v0
-; GFX9-NEXT:    v_lshrrev_b64 v[0:1], s4, v[6:7]
-; GFX9-NEXT:    v_lshlrev_b32_e32 v4, 31, v4
-; GFX9-NEXT:    v_or_b32_e32 v3, v3, v4
-; GFX9-NEXT:    v_or_b32_e32 v1, v5, v1
+; GFX9-NEXT:    v_lshlrev_b32_e32 v5, 31, v2
+; GFX9-NEXT:    v_lshrrev_b64 v[2:3], 1, v[0:1]
+; GFX9-NEXT:    v_lshlrev_b32_e32 v4, 31, v0
+; GFX9-NEXT:    v_lshrrev_b64 v[0:1], 1, v[6:7]
+; GFX9-NEXT:    v_or_b32_e32 v3, v5, v3
+; GFX9-NEXT:    v_or_b32_e32 v1, v4, v1
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_fshr_i128_65:
@@ -6015,14 +5982,12 @@ define i128 @v_fshr_i128_65(i128 %lhs, i128 %rhs) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX10-NEXT:    v_mov_b32_e32 v8, v2
-; GFX10-NEXT:    s_sub_i32 s4, 64, 63
-; GFX10-NEXT:    s_sub_i32 s5, 0x41, 64
-; GFX10-NEXT:    v_lshrrev_b64 v[2:3], s4, v[0:1]
-; GFX10-NEXT:    v_lshrrev_b64 v[4:5], s5, v[6:7]
+; GFX10-NEXT:    v_lshrrev_b64 v[4:5], 1, v[6:7]
+; GFX10-NEXT:    v_lshrrev_b64 v[2:3], 1, v[0:1]
 ; GFX10-NEXT:    v_lshlrev_b32_e32 v9, 31, v0
 ; GFX10-NEXT:    v_lshlrev_b32_e32 v0, 31, v8
 ; GFX10-NEXT:    v_or_b32_e32 v1, v9, v5
-; GFX10-NEXT:    v_or_b32_e32 v3, v3, v0
+; GFX10-NEXT:    v_or_b32_e32 v3, v0, v3
 ; GFX10-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
   %result = call i128 @llvm.fshr.i128(i128 %lhs, i128 %rhs, i128 65)
@@ -6032,36 +5997,37 @@ define i128 @v_fshr_i128_65(i128 %lhs, i128 %rhs) {
 define amdgpu_ps <2 x i128> @s_fshr_v2i128(<2 x i128> inreg %lhs, <2 x i128> inreg %rhs, <2 x i128> inreg %amt) {
 ; GFX6-LABEL: s_fshr_v2i128:
 ; GFX6:       ; %bb.0:
-; GFX6-NEXT:    s_mov_b64 s[18:19], 0x7f
-; GFX6-NEXT:    s_sub_i32 s28, 64, 1
+; GFX6-NEXT:    s_movk_i32 s18, 0x7f
+; GFX6-NEXT:    s_mov_b32 s19, 0
 ; GFX6-NEXT:    s_and_b64 s[22:23], s[16:17], s[18:19]
 ; GFX6-NEXT:    s_andn2_b64 s[16:17], s[18:19], s[16:17]
 ; GFX6-NEXT:    s_lshl_b64 s[24:25], s[0:1], 1
-; GFX6-NEXT:    s_lshr_b64 s[0:1], s[0:1], s28
+; GFX6-NEXT:    s_lshr_b32 s0, s1, 31
 ; GFX6-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
-; GFX6-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
+; GFX6-NEXT:    s_mov_b32 s1, s19
+; GFX6-NEXT:    s_or_b64 s[0:1], s[2:3], s[0:1]
 ; GFX6-NEXT:    s_sub_i32 s23, s16, 64
 ; GFX6-NEXT:    s_sub_i32 s17, 64, s16
 ; GFX6-NEXT:    s_cmp_lt_u32 s16, 64
-; GFX6-NEXT:    s_cselect_b32 s29, 1, 0
+; GFX6-NEXT:    s_cselect_b32 s28, 1, 0
 ; GFX6-NEXT:    s_cmp_eq_u32 s16, 0
-; GFX6-NEXT:    s_cselect_b32 s30, 1, 0
+; GFX6-NEXT:    s_cselect_b32 s29, 1, 0
 ; GFX6-NEXT:    s_lshl_b64 s[2:3], s[24:25], s16
 ; GFX6-NEXT:    s_lshr_b64 s[26:27], s[24:25], s17
 ; GFX6-NEXT:    s_lshl_b64 s[16:17], s[0:1], s16
 ; GFX6-NEXT:    s_or_b64 s[16:17], s[26:27], s[16:17]
 ; GFX6-NEXT:    s_lshl_b64 s[24:25], s[24:25], s23
-; GFX6-NEXT:    s_cmp_lg_u32 s29, 0
+; GFX6-NEXT:    s_cmp_lg_u32 s28, 0
 ; GFX6-NEXT:    s_cselect_b64 s[2:3], s[2:3], 0
 ; GFX6-NEXT:    s_cselect_b64 s[16:17], s[16:17], s[24:25]
-; GFX6-NEXT:    s_cmp_lg_u32 s30, 0
+; GFX6-NEXT:    s_cmp_lg_u32 s29, 0
 ; GFX6-NEXT:    s_cselect_b64 s[16:17], s[0:1], s[16:17]
 ; GFX6-NEXT:    s_sub_i32 s26, s22, 64
 ; GFX6-NEXT:    s_sub_i32 s24, 64, s22
 ; GFX6-NEXT:    s_cmp_lt_u32 s22, 64
 ; GFX6-NEXT:    s_cselect_b32 s27, 1, 0
 ; GFX6-NEXT:    s_cmp_eq_u32 s22, 0
-; GFX6-NEXT:    s_cselect_b32 s29, 1, 0
+; GFX6-NEXT:    s_cselect_b32 s28, 1, 0
 ; GFX6-NEXT:    s_lshr_b64 s[0:1], s[10:11], s22
 ; GFX6-NEXT:    s_lshl_b64 s[24:25], s[10:11], s24
 ; GFX6-NEXT:    s_lshr_b64 s[22:23], s[8:9], s22
@@ -6069,7 +6035,7 @@ define amdgpu_ps <2 x i128> @s_fshr_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ; GFX6-NEXT:    s_lshr_b64 s[10:11], s[10:11], s26
 ; GFX6-NEXT:    s_cmp_lg_u32 s27, 0
 ; GFX6-NEXT:    s_cselect_b64 s[10:11], s[22:23], s[10:11]
-; GFX6-NEXT:    s_cmp_lg_u32 s29, 0
+; GFX6-NEXT:    s_cmp_lg_u32 s28, 0
 ; GFX6-NEXT:    s_cselect_b64 s[8:9], s[8:9], s[10:11]
 ; GFX6-NEXT:    s_cmp_lg_u32 s27, 0
 ; GFX6-NEXT:    s_cselect_b64 s[10:11], s[0:1], 0
@@ -6077,10 +6043,10 @@ define amdgpu_ps <2 x i128> @s_fshr_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ; GFX6-NEXT:    s_or_b64 s[2:3], s[16:17], s[10:11]
 ; GFX6-NEXT:    s_andn2_b64 s[10:11], s[18:19], s[20:21]
 ; GFX6-NEXT:    s_and_b64 s[8:9], s[20:21], s[18:19]
-; GFX6-NEXT:    s_lshl_b64 s[16:17], s[4:5], 1
-; GFX6-NEXT:    s_lshr_b64 s[4:5], s[4:5], s28
 ; GFX6-NEXT:    s_lshl_b64 s[6:7], s[6:7], 1
-; GFX6-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
+; GFX6-NEXT:    s_lshr_b32 s18, s5, 31
+; GFX6-NEXT:    s_lshl_b64 s[16:17], s[4:5], 1
+; GFX6-NEXT:    s_or_b64 s[4:5], s[6:7], s[18:19]
 ; GFX6-NEXT:    s_sub_i32 s9, s10, 64
 ; GFX6-NEXT:    s_sub_i32 s11, 64, s10
 ; GFX6-NEXT:    s_cmp_lt_u32 s10, 64
@@ -6120,36 +6086,37 @@ define amdgpu_ps <2 x i128> @s_fshr_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ;
 ; GFX8-LABEL: s_fshr_v2i128:
 ; GFX8:       ; %bb.0:
-; GFX8-NEXT:    s_mov_b64 s[18:19], 0x7f
-; GFX8-NEXT:    s_sub_i32 s28, 64, 1
+; GFX8-NEXT:    s_movk_i32 s18, 0x7f
+; GFX8-NEXT:    s_mov_b32 s19, 0
 ; GFX8-NEXT:    s_and_b64 s[22:23], s[16:17], s[18:19]
 ; GFX8-NEXT:    s_andn2_b64 s[16:17], s[18:19], s[16:17]
 ; GFX8-NEXT:    s_lshl_b64 s[24:25], s[0:1], 1
-; GFX8-NEXT:    s_lshr_b64 s[0:1], s[0:1], s28
+; GFX8-NEXT:    s_lshr_b32 s0, s1, 31
 ; GFX8-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
-; GFX8-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
+; GFX8-NEXT:    s_mov_b32 s1, s19
+; GFX8-NEXT:    s_or_b64 s[0:1], s[2:3], s[0:1]
 ; GFX8-NEXT:    s_sub_i32 s23, s16, 64
 ; GFX8-NEXT:    s_sub_i32 s17, 64, s16
 ; GFX8-NEXT:    s_cmp_lt_u32 s16, 64
-; GFX8-NEXT:    s_cselect_b32 s29, 1, 0
+; GFX8-NEXT:    s_cselect_b32 s28, 1, 0
 ; GFX8-NEXT:    s_cmp_eq_u32 s16, 0
-; GFX8-NEXT:    s_cselect_b32 s30, 1, 0
+; GFX8-NEXT:    s_cselect_b32 s29, 1, 0
 ; GFX8-NEXT:    s_lshl_b64 s[2:3], s[24:25], s16
 ; GFX8-NEXT:    s_lshr_b64 s[26:27], s[24:25], s17
 ; GFX8-NEXT:    s_lshl_b64 s[16:17], s[0:1], s16
 ; GFX8-NEXT:    s_or_b64 s[16:17], s[26:27], s[16:17]
 ; GFX8-NEXT:    s_lshl_b64 s[24:25], s[24:25], s23
-; GFX8-NEXT:    s_cmp_lg_u32 s29, 0
+; GFX8-NEXT:    s_cmp_lg_u32 s28, 0
 ; GFX8-NEXT:    s_cselect_b64 s[2:3], s[2:3], 0
 ; GFX8-NEXT:    s_cselect_b64 s[16:17], s[16:17], s[24:25]
-; GFX8-NEXT:    s_cmp_lg_u32 s30, 0
+; GFX8-NEXT:    s_cmp_lg_u32 s29, 0
 ; GFX8-NEXT:    s_cselect_b64 s[16:17], s[0:1], s[16:17]
 ; GFX8-NEXT:    s_sub_i32 s26, s22, 64
 ; GFX8-NEXT:    s_sub_i32 s24, 64, s22
 ; GFX8-NEXT:    s_cmp_lt_u32 s22, 64
 ; GFX8-NEXT:    s_cselect_b32 s27, 1, 0
 ; GFX8-NEXT:    s_cmp_eq_u32 s22, 0
-; GFX8-NEXT:    s_cselect_b32 s29, 1, 0
+; GFX8-NEXT:    s_cselect_b32 s28, 1, 0
 ; GFX8-NEXT:    s_lshr_b64 s[0:1], s[10:11], s22
 ; GFX8-NEXT:    s_lshl_b64 s[24:25], s[10:11], s24
 ; GFX8-NEXT:    s_lshr_b64 s[22:23], s[8:9], s22
@@ -6157,7 +6124,7 @@ define amdgpu_ps <2 x i128> @s_fshr_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ; GFX8-NEXT:    s_lshr_b64 s[10:11], s[10:11], s26
 ; GFX8-NEXT:    s_cmp_lg_u32 s27, 0
 ; GFX8-NEXT:    s_cselect_b64 s[10:11], s[22:23], s[10:11]
-; GFX8-NEXT:    s_cmp_lg_u32 s29, 0
+; GFX8-NEXT:    s_cmp_lg_u32 s28, 0
 ; GFX8-NEXT:    s_cselect_b64 s[8:9], s[8:9], s[10:11]
 ; GFX8-NEXT:    s_cmp_lg_u32 s27, 0
 ; GFX8-NEXT:    s_cselect_b64 s[10:11], s[0:1], 0
@@ -6165,10 +6132,10 @@ define amdgpu_ps <2 x i128> @s_fshr_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ; GFX8-NEXT:    s_or_b64 s[2:3], s[16:17], s[10:11]
 ; GFX8-NEXT:    s_andn2_b64 s[10:11], s[18:19], s[20:21]
 ; GFX8-NEXT:    s_and_b64 s[8:9], s[20:21], s[18:19]
-; GFX8-NEXT:    s_lshl_b64 s[16:17], s[4:5], 1
-; GFX8-NEXT:    s_lshr_b64 s[4:5], s[4:5], s28
 ; GFX8-NEXT:    s_lshl_b64 s[6:7], s[6:7], 1
-; GFX8-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
+; GFX8-NEXT:    s_lshr_b32 s18, s5, 31
+; GFX8-NEXT:    s_lshl_b64 s[16:17], s[4:5], 1
+; GFX8-NEXT:    s_or_b64 s[4:5], s[6:7], s[18:19]
 ; GFX8-NEXT:    s_sub_i32 s9, s10, 64
 ; GFX8-NEXT:    s_sub_i32 s11, 64, s10
 ; GFX8-NEXT:    s_cmp_lt_u32 s10, 64
@@ -6208,36 +6175,37 @@ define amdgpu_ps <2 x i128> @s_fshr_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ;
 ; GFX9-LABEL: s_fshr_v2i128:
 ; GFX9:       ; %bb.0:
-; GFX9-NEXT:    s_mov_b64 s[18:19], 0x7f
-; GFX9-NEXT:    s_sub_i32 s28, 64, 1
+; GFX9-NEXT:    s_movk_i32 s18, 0x7f
+; GFX9-NEXT:    s_mov_b32 s19, 0
 ; GFX9-NEXT:    s_and_b64 s[22:23], s[16:17], s[18:19]
 ; GFX9-NEXT:    s_andn2_b64 s[16:17], s[18:19], s[16:17]
 ; GFX9-NEXT:    s_lshl_b64 s[24:25], s[0:1], 1
-; GFX9-NEXT:    s_lshr_b64 s[0:1], s[0:1], s28
+; GFX9-NEXT:    s_lshr_b32 s0, s1, 31
 ; GFX9-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
-; GFX9-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
+; GFX9-NEXT:    s_mov_b32 s1, s19
+; GFX9-NEXT:    s_or_b64 s[0:1], s[2:3], s[0:1]
 ; GFX9-NEXT:    s_sub_i32 s23, s16, 64
 ; GFX9-NEXT:    s_sub_i32 s17, 64, s16
 ; GFX9-NEXT:    s_cmp_lt_u32 s16, 64
-; GFX9-NEXT:    s_cselect_b32 s29, 1, 0
+; GFX9-NEXT:    s_cselect_b32 s28, 1, 0
 ; GFX9-NEXT:    s_cmp_eq_u32 s16, 0
-; GFX9-NEXT:    s_cselect_b32 s30, 1, 0
+; GFX9-NEXT:    s_cselect_b32 s29, 1, 0
 ; GFX9-NEXT:    s_lshl_b64 s[2:3], s[24:25], s16
 ; GFX9-NEXT:    s_lshr_b64 s[26:27], s[24:25], s17
 ; GFX9-NEXT:    s_lshl_b64 s[16:17], s[0:1], s16
 ; GFX9-NEXT:    s_or_b64 s[16:17], s[26:27], s[16:17]
 ; GFX9-NEXT:    s_lshl_b64 s[24:25], s[24:25], s23
-; GFX9-NEXT:    s_cmp_lg_u32 s29, 0
+; GFX9-NEXT:    s_cmp_lg_u32 s28, 0
 ; GFX9-NEXT:    s_cselect_b64 s[2:3], s[2:3], 0
 ; GFX9-NEXT:    s_cselect_b64 s[16:17], s[16:17], s[24:25]
-; GFX9-NEXT:    s_cmp_lg_u32 s30, 0
+; GFX9-NEXT:    s_cmp_lg_u32 s29, 0
 ; GFX9-NEXT:    s_cselect_b64 s[16:17], s[0:1], s[16:17]
 ; GFX9-NEXT:    s_sub_i32 s26, s22, 64
 ; GFX9-NEXT:    s_sub_i32 s24, 64, s22
 ; GFX9-NEXT:    s_cmp_lt_u32 s22, 64
 ; GFX9-NEXT:    s_cselect_b32 s27, 1, 0
 ; GFX9-NEXT:    s_cmp_eq_u32 s22, 0
-; GFX9-NEXT:    s_cselect_b32 s29, 1, 0
+; GFX9-NEXT:    s_cselect_b32 s28, 1, 0
 ; GFX9-NEXT:    s_lshr_b64 s[0:1], s[10:11], s22
 ; GFX9-NEXT:    s_lshl_b64 s[24:25], s[10:11], s24
 ; GFX9-NEXT:    s_lshr_b64 s[22:23], s[8:9], s22
@@ -6245,7 +6213,7 @@ define amdgpu_ps <2 x i128> @s_fshr_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ; GFX9-NEXT:    s_lshr_b64 s[10:11], s[10:11], s26
 ; GFX9-NEXT:    s_cmp_lg_u32 s27, 0
 ; GFX9-NEXT:    s_cselect_b64 s[10:11], s[22:23], s[10:11]
-; GFX9-NEXT:    s_cmp_lg_u32 s29, 0
+; GFX9-NEXT:    s_cmp_lg_u32 s28, 0
 ; GFX9-NEXT:    s_cselect_b64 s[8:9], s[8:9], s[10:11]
 ; GFX9-NEXT:    s_cmp_lg_u32 s27, 0
 ; GFX9-NEXT:    s_cselect_b64 s[10:11], s[0:1], 0
@@ -6253,10 +6221,10 @@ define amdgpu_ps <2 x i128> @s_fshr_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ; GFX9-NEXT:    s_or_b64 s[2:3], s[16:17], s[10:11]
 ; GFX9-NEXT:    s_andn2_b64 s[10:11], s[18:19], s[20:21]
 ; GFX9-NEXT:    s_and_b64 s[8:9], s[20:21], s[18:19]
-; GFX9-NEXT:    s_lshl_b64 s[16:17], s[4:5], 1
-; GFX9-NEXT:    s_lshr_b64 s[4:5], s[4:5], s28
 ; GFX9-NEXT:    s_lshl_b64 s[6:7], s[6:7], 1
-; GFX9-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
+; GFX9-NEXT:    s_lshr_b32 s18, s5, 31
+; GFX9-NEXT:    s_lshl_b64 s[16:17], s[4:5], 1
+; GFX9-NEXT:    s_or_b64 s[4:5], s[6:7], s[18:19]
 ; GFX9-NEXT:    s_sub_i32 s9, s10, 64
 ; GFX9-NEXT:    s_sub_i32 s11, 64, s10
 ; GFX9-NEXT:    s_cmp_lt_u32 s10, 64
@@ -6296,36 +6264,37 @@ define amdgpu_ps <2 x i128> @s_fshr_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ;
 ; GFX10-LABEL: s_fshr_v2i128:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    s_mov_b64 s[18:19], 0x7f
-; GFX10-NEXT:    s_sub_i32 s28, 64, 1
+; GFX10-NEXT:    s_mov_b32 s19, 0
+; GFX10-NEXT:    s_movk_i32 s18, 0x7f
+; GFX10-NEXT:    s_lshr_b32 s24, s1, 31
 ; GFX10-NEXT:    s_and_b64 s[22:23], s[16:17], s[18:19]
 ; GFX10-NEXT:    s_andn2_b64 s[16:17], s[18:19], s[16:17]
-; GFX10-NEXT:    s_lshr_b64 s[24:25], s[0:1], s28
 ; GFX10-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
+; GFX10-NEXT:    s_mov_b32 s25, s19
 ; GFX10-NEXT:    s_lshl_b64 s[0:1], s[0:1], 1
-; GFX10-NEXT:    s_or_b64 s[2:3], s[24:25], s[2:3]
+; GFX10-NEXT:    s_or_b64 s[2:3], s[2:3], s[24:25]
 ; GFX10-NEXT:    s_sub_i32 s23, s16, 64
 ; GFX10-NEXT:    s_sub_i32 s17, 64, s16
 ; GFX10-NEXT:    s_cmp_lt_u32 s16, 64
-; GFX10-NEXT:    s_cselect_b32 s29, 1, 0
+; GFX10-NEXT:    s_cselect_b32 s28, 1, 0
 ; GFX10-NEXT:    s_cmp_eq_u32 s16, 0
-; GFX10-NEXT:    s_cselect_b32 s30, 1, 0
+; GFX10-NEXT:    s_cselect_b32 s29, 1, 0
 ; GFX10-NEXT:    s_lshr_b64 s[24:25], s[0:1], s17
 ; GFX10-NEXT:    s_lshl_b64 s[26:27], s[2:3], s16
 ; GFX10-NEXT:    s_lshl_b64 s[16:17], s[0:1], s16
 ; GFX10-NEXT:    s_or_b64 s[24:25], s[24:25], s[26:27]
 ; GFX10-NEXT:    s_lshl_b64 s[0:1], s[0:1], s23
-; GFX10-NEXT:    s_cmp_lg_u32 s29, 0
+; GFX10-NEXT:    s_cmp_lg_u32 s28, 0
 ; GFX10-NEXT:    s_cselect_b64 s[16:17], s[16:17], 0
 ; GFX10-NEXT:    s_cselect_b64 s[0:1], s[24:25], s[0:1]
-; GFX10-NEXT:    s_cmp_lg_u32 s30, 0
+; GFX10-NEXT:    s_cmp_lg_u32 s29, 0
 ; GFX10-NEXT:    s_cselect_b64 s[2:3], s[2:3], s[0:1]
 ; GFX10-NEXT:    s_sub_i32 s26, s22, 64
 ; GFX10-NEXT:    s_sub_i32 s23, 64, s22
 ; GFX10-NEXT:    s_cmp_lt_u32 s22, 64
 ; GFX10-NEXT:    s_cselect_b32 s27, 1, 0
 ; GFX10-NEXT:    s_cmp_eq_u32 s22, 0
-; GFX10-NEXT:    s_cselect_b32 s29, 1, 0
+; GFX10-NEXT:    s_cselect_b32 s28, 1, 0
 ; GFX10-NEXT:    s_lshr_b64 s[0:1], s[8:9], s22
 ; GFX10-NEXT:    s_lshl_b64 s[24:25], s[10:11], s23
 ; GFX10-NEXT:    s_lshr_b64 s[22:23], s[10:11], s22
@@ -6333,18 +6302,18 @@ define amdgpu_ps <2 x i128> @s_fshr_v2i128(<2 x i128> inreg %lhs, <2 x i128> inr
 ; GFX10-NEXT:    s_lshr_b64 s[10:11], s[10:11], s26
 ; GFX10-NEXT:    s_cmp_lg_u32 s27, 0
 ; GFX10-NEXT:    s_cselect_b64 s[0:1], s[0:1], s[10:11]
-; GFX10-NEXT:    s_cmp_lg_u32 s29, 0
+; GFX10-NEXT:    s_cmp_lg_u32 s28, 0
 ; GFX10-NEXT:    s_cselect_b64 s[0:1], s[8:9], s[0:1]
 ; GFX10-NEXT:    s_cmp_lg_u32 s27, 0
 ; GFX10-NEXT:    s_cselect_b64 s[8:9], s[22:23], 0
 ; GFX10-NEXT:    s_andn2_b64 s[10:11], s[18:19], s[20:21]
-; GFX10-NEXT:    s_or_b64 s[0:1], s[16:17], s[0:1]
-; GFX10-NEXT:    s_lshr_b64 s[16:17], s[4:5], s28
-; GFX10-NEXT:    s_lshl_b64 s[6:7], s[6:7], 1
 ; GFX10-NEXT:    s_or_b64 s[2:3], s[2:3], s[8:9]
 ; GFX10-NEXT:    s_and_b64 s[8:9], s[20:21], s[18:19]
+; GFX10-NEXT:    s_lshr_b32 s18, s5, 31
+; GFX10-NEXT:    s_lshl_b64 s[6:7], s[6:7], 1
+; GFX10-NEXT:    s_or_b64 s[0:1], s[16:17], s[0:1]
 ; GFX10-NEXT:    s_lshl_b64 s[4:5], s[4:5], 1
-; GFX10-NEXT:    s_or_b64 s[6:7], s[16:17], s[6:7]
+; GFX10-NEXT:    s_or_b64 s[6:7], s[6:7], s[18:19]
 ; GFX10-NEXT:    s_sub_i32 s9, s10, 64
 ; GFX10-NEXT:    s_sub_i32 s11, 64, s10
 ; GFX10-NEXT:    s_cmp_lt_u32 s10, 64
@@ -6389,17 +6358,15 @@ define <2 x i128> @v_fshr_v2i128(<2 x i128> %lhs, <2 x i128> %rhs, <2 x i128> %a
 ; GFX6-LABEL: v_fshr_v2i128:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    s_sub_i32 s6, 64, 1
-; GFX6-NEXT:    v_lshr_b64 v[17:18], v[0:1], s6
-; GFX6-NEXT:    v_lshl_b64 v[2:3], v[2:3], 1
-; GFX6-NEXT:    s_movk_i32 s7, 0x7f
-; GFX6-NEXT:    v_or_b32_e32 v2, v17, v2
+; GFX6-NEXT:    s_movk_i32 s6, 0x7f
 ; GFX6-NEXT:    v_xor_b32_e32 v17, -1, v16
-; GFX6-NEXT:    v_and_b32_e32 v23, s7, v17
+; GFX6-NEXT:    v_lshl_b64 v[2:3], v[2:3], 1
+; GFX6-NEXT:    v_and_b32_e32 v23, s6, v17
+; GFX6-NEXT:    v_lshrrev_b32_e32 v17, 31, v1
 ; GFX6-NEXT:    v_lshl_b64 v[0:1], v[0:1], 1
-; GFX6-NEXT:    v_or_b32_e32 v3, v18, v3
+; GFX6-NEXT:    v_or_b32_e32 v2, v2, v17
 ; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, 64, v23
-; GFX6-NEXT:    v_and_b32_e32 v24, s7, v16
+; GFX6-NEXT:    v_and_b32_e32 v24, s6, v16
 ; GFX6-NEXT:    v_lshr_b64 v[17:18], v[0:1], v17
 ; GFX6-NEXT:    v_lshl_b64 v[21:22], v[2:3], v23
 ; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, 64, v24
@@ -6434,67 +6401,64 @@ define <2 x i128> @v_fshr_v2i128(<2 x i128> %lhs, <2 x i128> %rhs, <2 x i128> %a
 ; GFX6-NEXT:    v_or_b32_e32 v0, v25, v2
 ; GFX6-NEXT:    v_or_b32_e32 v2, v17, v8
 ; GFX6-NEXT:    v_xor_b32_e32 v8, -1, v20
+; GFX6-NEXT:    v_lshl_b64 v[6:7], v[6:7], 1
 ; GFX6-NEXT:    v_or_b32_e32 v1, v18, v3
 ; GFX6-NEXT:    v_or_b32_e32 v3, v16, v9
-; GFX6-NEXT:    v_and_b32_e32 v17, s7, v8
-; GFX6-NEXT:    v_lshr_b64 v[8:9], v[4:5], s6
-; GFX6-NEXT:    v_lshl_b64 v[6:7], v[6:7], 1
-; GFX6-NEXT:    v_lshl_b64 v[4:5], v[4:5], 1
-; GFX6-NEXT:    v_or_b32_e32 v6, v8, v6
-; GFX6-NEXT:    v_or_b32_e32 v7, v9, v7
-; GFX6-NEXT:    v_sub_i32_e32 v8, vcc, 64, v17
-; GFX6-NEXT:    v_lshr_b64 v[8:9], v[4:5], v8
+; GFX6-NEXT:    v_and_b32_e32 v17, s6, v8
+; GFX6-NEXT:    v_lshl_b64 v[8:9], v[4:5], 1
+; GFX6-NEXT:    v_lshrrev_b32_e32 v4, 31, v5
+; GFX6-NEXT:    v_or_b32_e32 v6, v6, v4
+; GFX6-NEXT:    v_sub_i32_e32 v4, vcc, 64, v17
+; GFX6-NEXT:    v_lshr_b64 v[4:5], v[8:9], v4
 ; GFX6-NEXT:    v_lshl_b64 v[10:11], v[6:7], v17
 ; GFX6-NEXT:    v_subrev_i32_e32 v18, vcc, 64, v17
-; GFX6-NEXT:    v_or_b32_e32 v10, v8, v10
-; GFX6-NEXT:    v_or_b32_e32 v11, v9, v11
-; GFX6-NEXT:    v_lshl_b64 v[8:9], v[4:5], v17
-; GFX6-NEXT:    v_lshl_b64 v[4:5], v[4:5], v18
+; GFX6-NEXT:    v_or_b32_e32 v10, v4, v10
+; GFX6-NEXT:    v_or_b32_e32 v11, v5, v11
+; GFX6-NEXT:    v_lshl_b64 v[4:5], v[8:9], v17
+; GFX6-NEXT:    v_lshl_b64 v[8:9], v[8:9], v18
 ; GFX6-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v17
-; GFX6-NEXT:    v_and_b32_e32 v16, s7, v20
-; GFX6-NEXT:    v_cndmask_b32_e32 v8, 0, v8, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v9, 0, v9, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v4, v4, v10, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v5, v5, v11, vcc
+; GFX6-NEXT:    v_and_b32_e32 v16, s6, v20
+; GFX6-NEXT:    v_cndmask_b32_e32 v18, 0, v4, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v19, 0, v5, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v4, v8, v10, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v5, v9, v11, vcc
 ; GFX6-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v17
-; GFX6-NEXT:    v_cndmask_b32_e32 v10, v4, v6, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v11, v5, v7, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v8, v4, v6, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v9, v5, v7, vcc
 ; GFX6-NEXT:    v_sub_i32_e32 v6, vcc, 64, v16
 ; GFX6-NEXT:    v_lshr_b64 v[4:5], v[12:13], v16
 ; GFX6-NEXT:    v_lshl_b64 v[6:7], v[14:15], v6
-; GFX6-NEXT:    v_subrev_i32_e32 v17, vcc, 64, v16
-; GFX6-NEXT:    v_or_b32_e32 v18, v4, v6
-; GFX6-NEXT:    v_or_b32_e32 v19, v5, v7
-; GFX6-NEXT:    v_lshr_b64 v[6:7], v[14:15], v17
+; GFX6-NEXT:    v_subrev_i32_e32 v10, vcc, 64, v16
+; GFX6-NEXT:    v_or_b32_e32 v11, v4, v6
+; GFX6-NEXT:    v_or_b32_e32 v17, v5, v7
+; GFX6-NEXT:    v_lshr_b64 v[6:7], v[14:15], v10
 ; GFX6-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v16
 ; GFX6-NEXT:    v_lshr_b64 v[4:5], v[14:15], v16
-; GFX6-NEXT:    v_cndmask_b32_e32 v6, v6, v18, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v6, v6, v11, vcc
 ; GFX6-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v16
-; GFX6-NEXT:    v_cndmask_b32_e32 v7, v7, v19, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v7, v7, v17, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e64 v6, v6, v12, s[4:5]
+; GFX6-NEXT:    v_cndmask_b32_e32 v10, 0, v4, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e64 v7, v7, v13, s[4:5]
-; GFX6-NEXT:    v_cndmask_b32_e32 v12, 0, v4, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v13, 0, v5, vcc
-; GFX6-NEXT:    v_or_b32_e32 v4, v8, v6
-; GFX6-NEXT:    v_or_b32_e32 v5, v9, v7
-; GFX6-NEXT:    v_or_b32_e32 v6, v10, v12
-; GFX6-NEXT:    v_or_b32_e32 v7, v11, v13
+; GFX6-NEXT:    v_cndmask_b32_e32 v11, 0, v5, vcc
+; GFX6-NEXT:    v_or_b32_e32 v4, v18, v6
+; GFX6-NEXT:    v_or_b32_e32 v5, v19, v7
+; GFX6-NEXT:    v_or_b32_e32 v6, v8, v10
+; GFX6-NEXT:    v_or_b32_e32 v7, v9, v11
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_fshr_v2i128:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    s_sub_i32 s6, 64, 1
-; GFX8-NEXT:    v_lshrrev_b64 v[17:18], s6, v[0:1]
-; GFX8-NEXT:    v_lshlrev_b64 v[2:3], 1, v[2:3]
-; GFX8-NEXT:    s_movk_i32 s7, 0x7f
-; GFX8-NEXT:    v_or_b32_e32 v2, v17, v2
+; GFX8-NEXT:    s_movk_i32 s6, 0x7f
 ; GFX8-NEXT:    v_xor_b32_e32 v17, -1, v16
-; GFX8-NEXT:    v_and_b32_e32 v23, s7, v17
+; GFX8-NEXT:    v_lshlrev_b64 v[2:3], 1, v[2:3]
+; GFX8-NEXT:    v_and_b32_e32 v23, s6, v17
+; GFX8-NEXT:    v_lshrrev_b32_e32 v17, 31, v1
 ; GFX8-NEXT:    v_lshlrev_b64 v[0:1], 1, v[0:1]
-; GFX8-NEXT:    v_or_b32_e32 v3, v18, v3
+; GFX8-NEXT:    v_or_b32_e32 v2, v2, v17
 ; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, 64, v23
-; GFX8-NEXT:    v_and_b32_e32 v24, s7, v16
+; GFX8-NEXT:    v_and_b32_e32 v24, s6, v16
 ; GFX8-NEXT:    v_lshrrev_b64 v[17:18], v17, v[0:1]
 ; GFX8-NEXT:    v_lshlrev_b64 v[21:22], v23, v[2:3]
 ; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, 64, v24
@@ -6529,67 +6493,64 @@ define <2 x i128> @v_fshr_v2i128(<2 x i128> %lhs, <2 x i128> %rhs, <2 x i128> %a
 ; GFX8-NEXT:    v_or_b32_e32 v0, v25, v2
 ; GFX8-NEXT:    v_or_b32_e32 v2, v17, v8
 ; GFX8-NEXT:    v_xor_b32_e32 v8, -1, v20
+; GFX8-NEXT:    v_lshlrev_b64 v[6:7], 1, v[6:7]
 ; GFX8-NEXT:    v_or_b32_e32 v1, v18, v3
 ; GFX8-NEXT:    v_or_b32_e32 v3, v16, v9
-; GFX8-NEXT:    v_and_b32_e32 v17, s7, v8
-; GFX8-NEXT:    v_lshrrev_b64 v[8:9], s6, v[4:5]
-; GFX8-NEXT:    v_lshlrev_b64 v[6:7], 1, v[6:7]
-; GFX8-NEXT:    v_lshlrev_b64 v[4:5], 1, v[4:5]
-; GFX8-NEXT:    v_or_b32_e32 v6, v8, v6
-; GFX8-NEXT:    v_or_b32_e32 v7, v9, v7
-; GFX8-NEXT:    v_sub_u32_e32 v8, vcc, 64, v17
-; GFX8-NEXT:    v_lshrrev_b64 v[8:9], v8, v[4:5]
+; GFX8-NEXT:    v_and_b32_e32 v17, s6, v8
+; GFX8-NEXT:    v_lshlrev_b64 v[8:9], 1, v[4:5]
+; GFX8-NEXT:    v_lshrrev_b32_e32 v4, 31, v5
+; GFX8-NEXT:    v_or_b32_e32 v6, v6, v4
+; GFX8-NEXT:    v_sub_u32_e32 v4, vcc, 64, v17
+; GFX8-NEXT:    v_lshrrev_b64 v[4:5], v4, v[8:9]
 ; GFX8-NEXT:    v_lshlrev_b64 v[10:11], v17, v[6:7]
 ; GFX8-NEXT:    v_subrev_u32_e32 v18, vcc, 64, v17
-; GFX8-NEXT:    v_or_b32_e32 v10, v8, v10
-; GFX8-NEXT:    v_or_b32_e32 v11, v9, v11
-; GFX8-NEXT:    v_lshlrev_b64 v[8:9], v17, v[4:5]
-; GFX8-NEXT:    v_lshlrev_b64 v[4:5], v18, v[4:5]
+; GFX8-NEXT:    v_or_b32_e32 v10, v4, v10
+; GFX8-NEXT:    v_or_b32_e32 v11, v5, v11
+; GFX8-NEXT:    v_lshlrev_b64 v[4:5], v17, v[8:9]
+; GFX8-NEXT:    v_lshlrev_b64 v[8:9], v18, v[8:9]
 ; GFX8-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v17
-; GFX8-NEXT:    v_and_b32_e32 v16, s7, v20
-; GFX8-NEXT:    v_cndmask_b32_e32 v8, 0, v8, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v9, 0, v9, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v4, v10, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v5, v11, vcc
+; GFX8-NEXT:    v_and_b32_e32 v16, s6, v20
+; GFX8-NEXT:    v_cndmask_b32_e32 v18, 0, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v19, 0, v5, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v4, v8, v10, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v5, v9, v11, vcc
 ; GFX8-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v17
-; GFX8-NEXT:    v_cndmask_b32_e32 v10, v4, v6, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v11, v5, v7, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v8, v4, v6, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v9, v5, v7, vcc
 ; GFX8-NEXT:    v_sub_u32_e32 v6, vcc, 64, v16
 ; GFX8-NEXT:    v_lshrrev_b64 v[4:5], v16, v[12:13]
 ; GFX8-NEXT:    v_lshlrev_b64 v[6:7], v6, v[14:15]
-; GFX8-NEXT:    v_subrev_u32_e32 v17, vcc, 64, v16
-; GFX8-NEXT:    v_or_b32_e32 v18, v4, v6
-; GFX8-NEXT:    v_or_b32_e32 v19, v5, v7
-; GFX8-NEXT:    v_lshrrev_b64 v[6:7], v17, v[14:15]
+; GFX8-NEXT:    v_subrev_u32_e32 v10, vcc, 64, v16
+; GFX8-NEXT:    v_or_b32_e32 v11, v4, v6
+; GFX8-NEXT:    v_or_b32_e32 v17, v5, v7
+; GFX8-NEXT:    v_lshrrev_b64 v[6:7], v10, v[14:15]
 ; GFX8-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v16
 ; GFX8-NEXT:    v_lshrrev_b64 v[4:5], v16, v[14:15]
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v6, v18, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v6, v6, v11, vcc
 ; GFX8-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v16
-; GFX8-NEXT:    v_cndmask_b32_e32 v7, v7, v19, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v7, v7, v17, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e64 v6, v6, v12, s[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e32 v10, 0, v4, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e64 v7, v7, v13, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e32 v12, 0, v4, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v13, 0, v5, vcc
-; GFX8-NEXT:    v_or_b32_e32 v4, v8, v6
-; GFX8-NEXT:    v_or_b32_e32 v5, v9, v7
-; GFX8-NEXT:    v_or_b32_e32 v6, v10, v12
-; GFX8-NEXT:    v_or_b32_e32 v7, v11, v13
+; GFX8-NEXT:    v_cndmask_b32_e32 v11, 0, v5, vcc
+; GFX8-NEXT:    v_or_b32_e32 v4, v18, v6
+; GFX8-NEXT:    v_or_b32_e32 v5, v19, v7
+; GFX8-NEXT:    v_or_b32_e32 v6, v8, v10
+; GFX8-NEXT:    v_or_b32_e32 v7, v9, v11
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_fshr_v2i128:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    s_sub_i32 s6, 64, 1
-; GFX9-NEXT:    v_lshrrev_b64 v[17:18], s6, v[0:1]
-; GFX9-NEXT:    v_lshlrev_b64 v[2:3], 1, v[2:3]
-; GFX9-NEXT:    s_movk_i32 s7, 0x7f
-; GFX9-NEXT:    v_or_b32_e32 v2, v17, v2
+; GFX9-NEXT:    s_movk_i32 s6, 0x7f
 ; GFX9-NEXT:    v_xor_b32_e32 v17, -1, v16
-; GFX9-NEXT:    v_and_b32_e32 v23, s7, v17
+; GFX9-NEXT:    v_lshlrev_b64 v[2:3], 1, v[2:3]
+; GFX9-NEXT:    v_and_b32_e32 v23, s6, v17
+; GFX9-NEXT:    v_lshrrev_b32_e32 v17, 31, v1
 ; GFX9-NEXT:    v_lshlrev_b64 v[0:1], 1, v[0:1]
-; GFX9-NEXT:    v_or_b32_e32 v3, v18, v3
+; GFX9-NEXT:    v_or_b32_e32 v2, v2, v17
 ; GFX9-NEXT:    v_sub_u32_e32 v17, 64, v23
-; GFX9-NEXT:    v_and_b32_e32 v24, s7, v16
+; GFX9-NEXT:    v_and_b32_e32 v24, s6, v16
 ; GFX9-NEXT:    v_lshrrev_b64 v[17:18], v17, v[0:1]
 ; GFX9-NEXT:    v_lshlrev_b64 v[21:22], v23, v[2:3]
 ; GFX9-NEXT:    v_sub_u32_e32 v16, 64, v24
@@ -6624,119 +6585,114 @@ define <2 x i128> @v_fshr_v2i128(<2 x i128> %lhs, <2 x i128> %rhs, <2 x i128> %a
 ; GFX9-NEXT:    v_or_b32_e32 v0, v25, v2
 ; GFX9-NEXT:    v_or_b32_e32 v2, v17, v8
 ; GFX9-NEXT:    v_xor_b32_e32 v8, -1, v20
-; GFX9-NEXT:    v_or_b32_e32 v1, v18, v3
-; GFX9-NEXT:    v_and_b32_e32 v17, s7, v8
-; GFX9-NEXT:    v_or_b32_e32 v3, v16, v9
-; GFX9-NEXT:    v_lshrrev_b64 v[8:9], s6, v[4:5]
 ; GFX9-NEXT:    v_lshlrev_b64 v[6:7], 1, v[6:7]
-; GFX9-NEXT:    v_lshlrev_b64 v[4:5], 1, v[4:5]
-; GFX9-NEXT:    v_or_b32_e32 v6, v8, v6
-; GFX9-NEXT:    v_or_b32_e32 v7, v9, v7
-; GFX9-NEXT:    v_sub_u32_e32 v8, 64, v17
-; GFX9-NEXT:    v_lshrrev_b64 v[8:9], v8, v[4:5]
+; GFX9-NEXT:    v_or_b32_e32 v1, v18, v3
+; GFX9-NEXT:    v_and_b32_e32 v17, s6, v8
+; GFX9-NEXT:    v_or_b32_e32 v3, v16, v9
+; GFX9-NEXT:    v_lshlrev_b64 v[8:9], 1, v[4:5]
+; GFX9-NEXT:    v_lshrrev_b32_e32 v4, 31, v5
+; GFX9-NEXT:    v_or_b32_e32 v6, v6, v4
+; GFX9-NEXT:    v_sub_u32_e32 v4, 64, v17
+; GFX9-NEXT:    v_lshrrev_b64 v[4:5], v4, v[8:9]
 ; GFX9-NEXT:    v_lshlrev_b64 v[10:11], v17, v[6:7]
 ; GFX9-NEXT:    v_subrev_u32_e32 v18, 64, v17
-; GFX9-NEXT:    v_or_b32_e32 v10, v8, v10
-; GFX9-NEXT:    v_or_b32_e32 v11, v9, v11
-; GFX9-NEXT:    v_lshlrev_b64 v[8:9], v17, v[4:5]
-; GFX9-NEXT:    v_lshlrev_b64 v[4:5], v18, v[4:5]
+; GFX9-NEXT:    v_or_b32_e32 v10, v4, v10
+; GFX9-NEXT:    v_or_b32_e32 v11, v5, v11
+; GFX9-NEXT:    v_lshlrev_b64 v[4:5], v17, v[8:9]
+; GFX9-NEXT:    v_lshlrev_b64 v[8:9], v18, v[8:9]
 ; GFX9-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v17
-; GFX9-NEXT:    v_and_b32_e32 v16, s7, v20
-; GFX9-NEXT:    v_cndmask_b32_e32 v8, 0, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v9, 0, v9, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v4, v10, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v5, v11, vcc
+; GFX9-NEXT:    v_and_b32_e32 v16, s6, v20
+; GFX9-NEXT:    v_cndmask_b32_e32 v18, 0, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v19, 0, v5, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v4, v8, v10, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v5, v9, v11, vcc
 ; GFX9-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v17
-; GFX9-NEXT:    v_cndmask_b32_e32 v10, v4, v6, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v8, v4, v6, vcc
 ; GFX9-NEXT:    v_sub_u32_e32 v6, 64, v16
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v5, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v9, v5, v7, vcc
 ; GFX9-NEXT:    v_lshrrev_b64 v[4:5], v16, v[12:13]
 ; GFX9-NEXT:    v_lshlrev_b64 v[6:7], v6, v[14:15]
-; GFX9-NEXT:    v_subrev_u32_e32 v17, 64, v16
-; GFX9-NEXT:    v_or_b32_e32 v18, v4, v6
-; GFX9-NEXT:    v_or_b32_e32 v19, v5, v7
-; GFX9-NEXT:    v_lshrrev_b64 v[6:7], v17, v[14:15]
+; GFX9-NEXT:    v_subrev_u32_e32 v10, 64, v16
+; GFX9-NEXT:    v_or_b32_e32 v11, v4, v6
+; GFX9-NEXT:    v_or_b32_e32 v17, v5, v7
+; GFX9-NEXT:    v_lshrrev_b64 v[6:7], v10, v[14:15]
 ; GFX9-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v16
 ; GFX9-NEXT:    v_lshrrev_b64 v[4:5], v16, v[14:15]
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v6, v18, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v6, v6, v11, vcc
 ; GFX9-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v16
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v7, v19, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v7, v7, v17, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e64 v6, v6, v12, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e32 v10, 0, v4, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e64 v7, v7, v13, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e32 v12, 0, v4, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v13, 0, v5, vcc
-; GFX9-NEXT:    v_or_b32_e32 v4, v8, v6
-; GFX9-NEXT:    v_or_b32_e32 v5, v9, v7
-; GFX9-NEXT:    v_or_b32_e32 v6, v10, v12
-; GFX9-NEXT:    v_or_b32_e32 v7, v11, v13
+; GFX9-NEXT:    v_cndmask_b32_e32 v11, 0, v5, vcc
+; GFX9-NEXT:    v_or_b32_e32 v4, v18, v6
+; GFX9-NEXT:    v_or_b32_e32 v5, v19, v7
+; GFX9-NEXT:    v_or_b32_e32 v6, v8, v10
+; GFX9-NEXT:    v_or_b32_e32 v7, v9, v11
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_fshr_v2i128:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    s_waitcnt_vscnt null, 0x0
-; GFX10-NEXT:    v_xor_b32_e32 v19, -1, v16
-; GFX10-NEXT:    s_sub_i32 s5, 64, 1
-; GFX10-NEXT:    s_movk_i32 s6, 0x7f
-; GFX10-NEXT:    v_lshrrev_b64 v[17:18], s5, v[0:1]
+; GFX10-NEXT:    v_xor_b32_e32 v17, -1, v16
+; GFX10-NEXT:    s_movk_i32 s5, 0x7f
 ; GFX10-NEXT:    v_lshlrev_b64 v[2:3], 1, v[2:3]
-; GFX10-NEXT:    v_and_b32_e32 v25, s6, v19
-; GFX10-NEXT:    v_lshlrev_b64 v[0:1], 1, v[0:1]
-; GFX10-NEXT:    v_and_b32_e32 v26, s6, v16
+; GFX10-NEXT:    v_and_b32_e32 v26, s5, v16
 ; GFX10-NEXT:    v_lshlrev_b64 v[6:7], 1, v[6:7]
-; GFX10-NEXT:    v_or_b32_e32 v2, v17, v2
-; GFX10-NEXT:    v_or_b32_e32 v3, v18, v3
-; GFX10-NEXT:    v_sub_nc_u32_e32 v17, 64, v25
-; GFX10-NEXT:    v_subrev_nc_u32_e32 v16, 64, v25
-; GFX10-NEXT:    v_sub_nc_u32_e32 v19, 64, v26
-; GFX10-NEXT:    v_lshlrev_b64 v[23:24], v25, v[0:1]
-; GFX10-NEXT:    v_lshlrev_b64 v[21:22], v25, v[2:3]
-; GFX10-NEXT:    v_lshrrev_b64 v[17:18], v17, v[0:1]
-; GFX10-NEXT:    v_lshlrev_b64 v[0:1], v16, v[0:1]
-; GFX10-NEXT:    v_cmp_gt_u32_e32 vcc_lo, 64, v25
+; GFX10-NEXT:    v_and_b32_e32 v25, s5, v17
+; GFX10-NEXT:    v_lshrrev_b32_e32 v17, 31, v1
+; GFX10-NEXT:    v_lshlrev_b64 v[0:1], 1, v[0:1]
 ; GFX10-NEXT:    v_subrev_nc_u32_e32 v27, 64, v26
 ; GFX10-NEXT:    v_cmp_gt_u32_e64 s4, 64, v26
-; GFX10-NEXT:    v_or_b32_e32 v21, v17, v21
-; GFX10-NEXT:    v_or_b32_e32 v22, v18, v22
-; GFX10-NEXT:    v_lshrrev_b64 v[16:17], v26, v[8:9]
-; GFX10-NEXT:    v_lshlrev_b64 v[18:19], v19, v[10:11]
+; GFX10-NEXT:    v_sub_nc_u32_e32 v18, 64, v25
+; GFX10-NEXT:    v_or_b32_e32 v2, v2, v17
+; GFX10-NEXT:    v_subrev_nc_u32_e32 v19, 64, v25
+; GFX10-NEXT:    v_lshlrev_b64 v[23:24], v25, v[0:1]
+; GFX10-NEXT:    v_cmp_gt_u32_e32 vcc_lo, 64, v25
+; GFX10-NEXT:    v_lshrrev_b64 v[17:18], v18, v[0:1]
+; GFX10-NEXT:    v_lshlrev_b64 v[21:22], v25, v[2:3]
+; GFX10-NEXT:    v_lshlrev_b64 v[0:1], v19, v[0:1]
 ; GFX10-NEXT:    v_cndmask_b32_e32 v23, 0, v23, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v21, v0, v21, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v22, v1, v22, vcc_lo
-; GFX10-NEXT:    v_lshrrev_b64 v[0:1], v27, v[10:11]
 ; GFX10-NEXT:    v_cndmask_b32_e32 v24, 0, v24, vcc_lo
+; GFX10-NEXT:    v_or_b32_e32 v22, v18, v22
+; GFX10-NEXT:    v_sub_nc_u32_e32 v18, 64, v26
+; GFX10-NEXT:    v_or_b32_e32 v21, v17, v21
+; GFX10-NEXT:    v_lshrrev_b64 v[16:17], v26, v[8:9]
+; GFX10-NEXT:    v_cndmask_b32_e32 v22, v1, v22, vcc_lo
+; GFX10-NEXT:    v_lshlrev_b64 v[18:19], v18, v[10:11]
+; GFX10-NEXT:    v_cndmask_b32_e32 v21, v0, v21, vcc_lo
+; GFX10-NEXT:    v_lshrrev_b64 v[0:1], v27, v[10:11]
 ; GFX10-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 0, v25
 ; GFX10-NEXT:    v_or_b32_e32 v16, v16, v18
 ; GFX10-NEXT:    v_or_b32_e32 v17, v17, v19
 ; GFX10-NEXT:    v_cndmask_b32_e32 v18, v21, v2, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e32 v22, v22, v3, vcc_lo
-; GFX10-NEXT:    v_lshrrev_b64 v[2:3], v26, v[10:11]
-; GFX10-NEXT:    v_cndmask_b32_e64 v10, v0, v16, s4
-; GFX10-NEXT:    v_xor_b32_e32 v16, -1, v20
 ; GFX10-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 0, v26
-; GFX10-NEXT:    v_cndmask_b32_e64 v11, v1, v17, s4
-; GFX10-NEXT:    v_lshrrev_b64 v[0:1], s5, v[4:5]
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, v16, s4
+; GFX10-NEXT:    v_xor_b32_e32 v16, -1, v20
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, v17, s4
+; GFX10-NEXT:    v_lshrrev_b64 v[2:3], v26, v[10:11]
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc_lo
+; GFX10-NEXT:    v_lshrrev_b32_e32 v8, 31, v5
+; GFX10-NEXT:    v_and_b32_e32 v25, s5, v16
 ; GFX10-NEXT:    v_lshlrev_b64 v[4:5], 1, v[4:5]
-; GFX10-NEXT:    v_and_b32_e32 v25, s6, v16
-; GFX10-NEXT:    v_cndmask_b32_e32 v8, v10, v8, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v16, v11, v9, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s4
-; GFX10-NEXT:    v_or_b32_e32 v6, v0, v6
-; GFX10-NEXT:    v_or_b32_e32 v7, v1, v7
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc_lo
+; GFX10-NEXT:    v_or_b32_e32 v0, v23, v0
+; GFX10-NEXT:    v_or_b32_e32 v6, v6, v8
 ; GFX10-NEXT:    v_sub_nc_u32_e32 v9, 64, v25
-; GFX10-NEXT:    v_or_b32_e32 v0, v23, v8
-; GFX10-NEXT:    v_and_b32_e32 v23, s6, v20
+; GFX10-NEXT:    v_and_b32_e32 v23, s5, v20
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s4
 ; GFX10-NEXT:    v_cndmask_b32_e64 v26, 0, v3, s4
 ; GFX10-NEXT:    v_lshlrev_b64 v[10:11], v25, v[6:7]
 ; GFX10-NEXT:    v_lshrrev_b64 v[8:9], v9, v[4:5]
-; GFX10-NEXT:    v_subrev_nc_u32_e32 v3, 64, v25
 ; GFX10-NEXT:    v_sub_nc_u32_e32 v20, 64, v23
-; GFX10-NEXT:    v_or_b32_e32 v1, v24, v16
+; GFX10-NEXT:    v_subrev_nc_u32_e32 v3, 64, v25
 ; GFX10-NEXT:    v_or_b32_e32 v2, v18, v2
 ; GFX10-NEXT:    v_lshlrev_b64 v[16:17], v25, v[4:5]
+; GFX10-NEXT:    v_lshrrev_b64 v[18:19], v23, v[12:13]
 ; GFX10-NEXT:    v_or_b32_e32 v10, v8, v10
 ; GFX10-NEXT:    v_subrev_nc_u32_e32 v8, 64, v23
-; GFX10-NEXT:    v_lshrrev_b64 v[18:19], v23, v[12:13]
 ; GFX10-NEXT:    v_lshlrev_b64 v[20:21], v20, v[14:15]
 ; GFX10-NEXT:    v_cmp_gt_u32_e32 vcc_lo, 64, v25
 ; GFX10-NEXT:    v_lshlrev_b64 v[3:4], v3, v[4:5]
@@ -6760,11 +6716,12 @@ define <2 x i128> @v_fshr_v2i128(<2 x i128> %lhs, <2 x i128> %rhs, <2 x i128> %a
 ; GFX10-NEXT:    v_cndmask_b32_e64 v10, 0, v4, s4
 ; GFX10-NEXT:    v_cndmask_b32_e64 v8, v9, v13, s5
 ; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0, v3, s4
-; GFX10-NEXT:    v_or_b32_e32 v3, v22, v26
+; GFX10-NEXT:    v_or_b32_e32 v1, v24, v1
 ; GFX10-NEXT:    v_or_b32_e32 v4, v11, v5
-; GFX10-NEXT:    v_or_b32_e32 v7, v7, v10
+; GFX10-NEXT:    v_or_b32_e32 v3, v22, v26
 ; GFX10-NEXT:    v_or_b32_e32 v5, v14, v8
 ; GFX10-NEXT:    v_or_b32_e32 v6, v6, v9
+; GFX10-NEXT:    v_or_b32_e32 v7, v7, v10
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
   %result = call <2 x i128> @llvm.fshr.v2i128(<2 x i128> %lhs, <2 x i128> %rhs, <2 x i128> %amt)
   ret <2 x i128> %result

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/saddsat.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/saddsat.ll
@@ -4797,13 +4797,11 @@ define amdgpu_ps i128 @s_saddsat_i128(i128 inreg %lhs, i128 inreg %rhs) {
 ; GFX6-NEXT:    v_cmp_eq_u64_e64 s[0:1], s[6:7], 0
 ; GFX6-NEXT:    s_ashr_i32 s3, s9, 31
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[0:1]
-; GFX6-NEXT:    s_sub_i32 s0, 0x7f, 64
-; GFX6-NEXT:    s_ashr_i64 s[0:1], s[8:9], s0
-; GFX6-NEXT:    s_add_u32 s0, s0, 0
-; GFX6-NEXT:    s_cselect_b32 s2, 1, 0
-; GFX6-NEXT:    s_and_b32 s2, s2, 1
-; GFX6-NEXT:    s_cmp_lg_u32 s2, 0
-; GFX6-NEXT:    s_addc_u32 s1, s1, 0
+; GFX6-NEXT:    s_add_u32 s0, s3, 0
+; GFX6-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX6-NEXT:    s_and_b32 s1, s1, 1
+; GFX6-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX6-NEXT:    s_addc_u32 s1, s3, 0
 ; GFX6-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX6-NEXT:    s_and_b32 s2, s2, 1
 ; GFX6-NEXT:    s_cmp_lg_u32 s2, 0
@@ -4867,15 +4865,13 @@ define amdgpu_ps i128 @s_saddsat_i128(i128 inreg %lhs, i128 inreg %rhs) {
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[0:1]
 ; GFX8-NEXT:    s_and_b32 s0, 1, s2
 ; GFX8-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, s0
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[0:1]
-; GFX8-NEXT:    s_sub_i32 s0, 0x7f, 64
 ; GFX8-NEXT:    s_ashr_i32 s3, s9, 31
-; GFX8-NEXT:    s_ashr_i64 s[0:1], s[8:9], s0
-; GFX8-NEXT:    s_add_u32 s0, s0, 0
-; GFX8-NEXT:    s_cselect_b32 s2, 1, 0
-; GFX8-NEXT:    s_and_b32 s2, s2, 1
-; GFX8-NEXT:    s_cmp_lg_u32 s2, 0
-; GFX8-NEXT:    s_addc_u32 s1, s1, 0
+; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[0:1]
+; GFX8-NEXT:    s_add_u32 s0, s3, 0
+; GFX8-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX8-NEXT:    s_and_b32 s1, s1, 1
+; GFX8-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX8-NEXT:    s_addc_u32 s1, s3, 0
 ; GFX8-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX8-NEXT:    s_and_b32 s2, s2, 1
 ; GFX8-NEXT:    s_cmp_lg_u32 s2, 0
@@ -4939,15 +4935,13 @@ define amdgpu_ps i128 @s_saddsat_i128(i128 inreg %lhs, i128 inreg %rhs) {
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[0:1]
 ; GFX9-NEXT:    s_and_b32 s0, 1, s2
 ; GFX9-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, s0
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[0:1]
-; GFX9-NEXT:    s_sub_i32 s0, 0x7f, 64
 ; GFX9-NEXT:    s_ashr_i32 s3, s9, 31
-; GFX9-NEXT:    s_ashr_i64 s[0:1], s[8:9], s0
-; GFX9-NEXT:    s_add_u32 s0, s0, 0
-; GFX9-NEXT:    s_cselect_b32 s2, 1, 0
-; GFX9-NEXT:    s_and_b32 s2, s2, 1
-; GFX9-NEXT:    s_cmp_lg_u32 s2, 0
-; GFX9-NEXT:    s_addc_u32 s1, s1, 0
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[0:1]
+; GFX9-NEXT:    s_add_u32 s0, s3, 0
+; GFX9-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX9-NEXT:    s_and_b32 s1, s1, 1
+; GFX9-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX9-NEXT:    s_addc_u32 s1, s3, 0
 ; GFX9-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX9-NEXT:    s_and_b32 s2, s2, 1
 ; GFX9-NEXT:    s_cmp_lg_u32 s2, 0
@@ -5011,25 +5005,23 @@ define amdgpu_ps i128 @s_saddsat_i128(i128 inreg %lhs, i128 inreg %rhs) {
 ; GFX10-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s0
 ; GFX10-NEXT:    s_and_b32 s0, 1, s1
-; GFX10-NEXT:    s_sub_i32 s1, 0x7f, 64
 ; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, s0
 ; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s0
-; GFX10-NEXT:    s_ashr_i64 s[0:1], s[8:9], s1
-; GFX10-NEXT:    s_add_u32 s0, s0, 0
-; GFX10-NEXT:    s_cselect_b32 s2, 1, 0
+; GFX10-NEXT:    s_add_u32 s0, s3, 0
+; GFX10-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX10-NEXT:    s_and_b32 s1, s1, 1
 ; GFX10-NEXT:    v_xor_b32_e32 v0, v1, v0
-; GFX10-NEXT:    s_and_b32 s2, s2, 1
+; GFX10-NEXT:    s_cmp_lg_u32 s1, 0
 ; GFX10-NEXT:    v_mov_b32_e32 v1, s4
-; GFX10-NEXT:    s_cmp_lg_u32 s2, 0
-; GFX10-NEXT:    s_addc_u32 s1, s1, 0
+; GFX10-NEXT:    s_addc_u32 s1, s3, 0
 ; GFX10-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX10-NEXT:    v_and_b32_e32 v0, 1, v0
 ; GFX10-NEXT:    s_and_b32 s2, s2, 1
 ; GFX10-NEXT:    s_cmp_lg_u32 s2, 0
 ; GFX10-NEXT:    s_addc_u32 s2, s3, 0
-; GFX10-NEXT:    s_cselect_b32 s6, 1, 0
+; GFX10-NEXT:    s_cselect_b32 s4, 1, 0
 ; GFX10-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v0
-; GFX10-NEXT:    s_and_b32 s4, s6, 1
+; GFX10-NEXT:    s_and_b32 s4, s4, 1
 ; GFX10-NEXT:    s_cmp_lg_u32 s4, 0
 ; GFX10-NEXT:    s_addc_u32 s3, s3, 0x80000000
 ; GFX10-NEXT:    v_cndmask_b32_e64 v0, v1, s0, vcc_lo
@@ -5056,30 +5048,28 @@ define amdgpu_ps <4 x float> @saddsat_i128_sv(i128 inreg %lhs, i128 %rhs) {
 ; GFX6-NEXT:    v_addc_u32_e32 v4, vcc, v4, v2, vcc
 ; GFX6-NEXT:    v_addc_u32_e32 v5, vcc, v5, v3, vcc
 ; GFX6-NEXT:    v_cmp_gt_u64_e32 vcc, s[0:1], v[0:1]
-; GFX6-NEXT:    s_sub_i32 s0, 0x7f, 64
+; GFX6-NEXT:    v_bfrev_b32_e32 v8, 1
 ; GFX6-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_gt_i64_e32 vcc, s[2:3], v[4:5]
-; GFX6-NEXT:    v_bfrev_b32_e32 v8, 1
 ; GFX6-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_eq_u64_e32 vcc, s[2:3], v[4:5]
 ; GFX6-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
 ; GFX6-NEXT:    v_cmp_gt_i64_e32 vcc, 0, v[2:3]
 ; GFX6-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[2:3]
+; GFX6-NEXT:    v_ashrrev_i32_e32 v3, 31, v5
 ; GFX6-NEXT:    v_cndmask_b32_e64 v2, v7, 0, vcc
-; GFX6-NEXT:    v_xor_b32_e32 v6, v2, v6
-; GFX6-NEXT:    v_ashr_i64 v[2:3], v[4:5], s0
-; GFX6-NEXT:    v_ashrrev_i32_e32 v7, 31, v5
-; GFX6-NEXT:    v_add_i32_e32 v2, vcc, 0, v2
-; GFX6-NEXT:    v_addc_u32_e32 v3, vcc, 0, v3, vcc
-; GFX6-NEXT:    v_addc_u32_e32 v9, vcc, 0, v7, vcc
-; GFX6-NEXT:    v_addc_u32_e32 v7, vcc, v7, v8, vcc
-; GFX6-NEXT:    v_and_b32_e32 v6, 1, v6
-; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
-; GFX6-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
+; GFX6-NEXT:    v_xor_b32_e32 v2, v2, v6
+; GFX6-NEXT:    v_add_i32_e32 v6, vcc, 0, v3
+; GFX6-NEXT:    v_addc_u32_e32 v7, vcc, 0, v3, vcc
+; GFX6-NEXT:    v_addc_u32_e32 v9, vcc, 0, v3, vcc
+; GFX6-NEXT:    v_addc_u32_e32 v3, vcc, v3, v8, vcc
+; GFX6-NEXT:    v_and_b32_e32 v2, 1, v2
+; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v0, v6, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v1, v1, v7, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v2, v4, v9, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v3, v5, v7, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
 ; GFX6-NEXT:    ; return to shader part epilog
 ;
 ; GFX8-LABEL: saddsat_i128_sv:
@@ -5092,30 +5082,28 @@ define amdgpu_ps <4 x float> @saddsat_i128_sv(i128 inreg %lhs, i128 %rhs) {
 ; GFX8-NEXT:    v_addc_u32_e32 v4, vcc, v4, v2, vcc
 ; GFX8-NEXT:    v_addc_u32_e32 v5, vcc, v5, v3, vcc
 ; GFX8-NEXT:    v_cmp_gt_u64_e32 vcc, s[0:1], v[0:1]
-; GFX8-NEXT:    s_sub_i32 s0, 0x7f, 64
+; GFX8-NEXT:    v_bfrev_b32_e32 v8, 1
 ; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; GFX8-NEXT:    v_cmp_gt_i64_e32 vcc, s[2:3], v[4:5]
-; GFX8-NEXT:    v_bfrev_b32_e32 v8, 1
 ; GFX8-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; GFX8-NEXT:    v_cmp_eq_u64_e32 vcc, s[2:3], v[4:5]
 ; GFX8-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
 ; GFX8-NEXT:    v_cmp_gt_i64_e32 vcc, 0, v[2:3]
 ; GFX8-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; GFX8-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[2:3]
+; GFX8-NEXT:    v_ashrrev_i32_e32 v3, 31, v5
 ; GFX8-NEXT:    v_cndmask_b32_e64 v2, v7, 0, vcc
-; GFX8-NEXT:    v_xor_b32_e32 v6, v2, v6
-; GFX8-NEXT:    v_ashrrev_i64 v[2:3], s0, v[4:5]
-; GFX8-NEXT:    v_ashrrev_i32_e32 v7, 31, v5
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 0, v2
-; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, 0, v3, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v9, vcc, 0, v7, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v7, vcc, v7, v8, vcc
-; GFX8-NEXT:    v_and_b32_e32 v6, 1, v6
-; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
+; GFX8-NEXT:    v_xor_b32_e32 v2, v2, v6
+; GFX8-NEXT:    v_add_u32_e32 v6, vcc, 0, v3
+; GFX8-NEXT:    v_addc_u32_e32 v7, vcc, 0, v3, vcc
+; GFX8-NEXT:    v_addc_u32_e32 v9, vcc, 0, v3, vcc
+; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, v3, v8, vcc
+; GFX8-NEXT:    v_and_b32_e32 v2, 1, v2
+; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v6, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v7, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v2, v4, v9, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v5, v7, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
 ; GFX8-NEXT:    ; return to shader part epilog
 ;
 ; GFX9-LABEL: saddsat_i128_sv:
@@ -5128,30 +5116,28 @@ define amdgpu_ps <4 x float> @saddsat_i128_sv(i128 inreg %lhs, i128 %rhs) {
 ; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v4, v2, vcc
 ; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, v5, v3, vcc
 ; GFX9-NEXT:    v_cmp_gt_u64_e32 vcc, s[0:1], v[0:1]
-; GFX9-NEXT:    s_sub_i32 s0, 0x7f, 64
+; GFX9-NEXT:    v_bfrev_b32_e32 v8, 1
 ; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; GFX9-NEXT:    v_cmp_gt_i64_e32 vcc, s[2:3], v[4:5]
-; GFX9-NEXT:    v_bfrev_b32_e32 v8, 1
 ; GFX9-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; GFX9-NEXT:    v_cmp_eq_u64_e32 vcc, s[2:3], v[4:5]
 ; GFX9-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
 ; GFX9-NEXT:    v_cmp_gt_i64_e32 vcc, 0, v[2:3]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; GFX9-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[2:3]
+; GFX9-NEXT:    v_ashrrev_i32_e32 v3, 31, v5
 ; GFX9-NEXT:    v_cndmask_b32_e64 v2, v7, 0, vcc
-; GFX9-NEXT:    v_xor_b32_e32 v6, v2, v6
-; GFX9-NEXT:    v_ashrrev_i64 v[2:3], s0, v[4:5]
-; GFX9-NEXT:    v_ashrrev_i32_e32 v7, 31, v5
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, 0, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v3, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v9, vcc, 0, v7, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, v7, v8, vcc
-; GFX9-NEXT:    v_and_b32_e32 v6, 1, v6
-; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
+; GFX9-NEXT:    v_xor_b32_e32 v2, v2, v6
+; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, 0, v3
+; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v3, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v9, vcc, 0, v3, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v8, vcc
+; GFX9-NEXT:    v_and_b32_e32 v2, 1, v2
+; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v6, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v7, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v2, v4, v9, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v5, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
 ; GFX9-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-LABEL: saddsat_i128_sv:
@@ -5161,7 +5147,6 @@ define amdgpu_ps <4 x float> @saddsat_i128_sv(i128 inreg %lhs, i128 %rhs) {
 ; GFX10-NEXT:    v_add_co_ci_u32_e32 v4, vcc_lo, s2, v2, vcc_lo
 ; GFX10-NEXT:    v_add_co_ci_u32_e32 v5, vcc_lo, s3, v3, vcc_lo
 ; GFX10-NEXT:    v_cmp_gt_u64_e32 vcc_lo, s[0:1], v[0:1]
-; GFX10-NEXT:    s_sub_i32 s0, 0x7f, 64
 ; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc_lo
 ; GFX10-NEXT:    v_cmp_gt_i64_e32 vcc_lo, s[2:3], v[4:5]
 ; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc_lo
@@ -5170,20 +5155,19 @@ define amdgpu_ps <4 x float> @saddsat_i128_sv(i128 inreg %lhs, i128 %rhs) {
 ; GFX10-NEXT:    v_cmp_eq_u64_e32 vcc_lo, s[2:3], v[4:5]
 ; GFX10-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc_lo
 ; GFX10-NEXT:    v_cmp_eq_u64_e32 vcc_lo, 0, v[2:3]
-; GFX10-NEXT:    v_ashrrev_i32_e32 v7, 31, v5
+; GFX10-NEXT:    v_ashrrev_i32_e32 v3, 31, v5
 ; GFX10-NEXT:    v_cndmask_b32_e64 v2, v8, 0, vcc_lo
-; GFX10-NEXT:    v_xor_b32_e32 v6, v2, v6
-; GFX10-NEXT:    v_ashrrev_i64 v[2:3], s0, v[4:5]
-; GFX10-NEXT:    v_and_b32_e32 v6, 1, v6
-; GFX10-NEXT:    v_add_co_u32 v2, vcc_lo, v2, 0
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v3, vcc_lo, 0, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, v6
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v6, vcc_lo, 0, v7, vcc_lo
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v7, vcc_lo, 0x80000000, v7, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v4, v6, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v5, v7, s0
+; GFX10-NEXT:    v_xor_b32_e32 v2, v2, v6
+; GFX10-NEXT:    v_add_co_u32 v6, vcc_lo, v3, 0
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v7, vcc_lo, 0, v3, vcc_lo
+; GFX10-NEXT:    v_and_b32_e32 v2, 1, v2
+; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, v2
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v2, vcc_lo, 0, v3, vcc_lo
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v3, vcc_lo, 0x80000000, v3, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, v6, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, v7, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, v4, v2, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, v5, v3, s0
 ; GFX10-NEXT:    ; return to shader part epilog
   %result = call i128 @llvm.sadd.sat.i128(i128 %lhs, i128 %rhs)
   %cast = bitcast i128 %result to <4 x float>
@@ -5207,24 +5191,22 @@ define amdgpu_ps <4 x float> @saddsat_i128_vs(i128 %lhs, i128 inreg %rhs) {
 ; GFX6-NEXT:    v_bfrev_b32_e32 v8, 1
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_eq_u64_e32 vcc, v[6:7], v[2:3]
-; GFX6-NEXT:    v_ashrrev_i32_e32 v3, 31, v7
 ; GFX6-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[0:1]
 ; GFX6-NEXT:    v_cmp_eq_u64_e64 s[0:1], s[2:3], 0
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[0:1]
-; GFX6-NEXT:    s_sub_i32 s0, 0x7f, 64
-; GFX6-NEXT:    v_xor_b32_e32 v2, v1, v0
-; GFX6-NEXT:    v_ashr_i64 v[0:1], v[6:7], s0
-; GFX6-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX6-NEXT:    v_add_i32_e32 v0, vcc, 0, v0
-; GFX6-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; GFX6-NEXT:    v_addc_u32_e32 v9, vcc, 0, v3, vcc
-; GFX6-NEXT:    v_addc_u32_e32 v3, vcc, v3, v8, vcc
-; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX6-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX6-NEXT:    v_xor_b32_e32 v0, v1, v0
+; GFX6-NEXT:    v_ashrrev_i32_e32 v1, 31, v7
+; GFX6-NEXT:    v_add_i32_e32 v2, vcc, 0, v1
+; GFX6-NEXT:    v_addc_u32_e32 v3, vcc, 0, v1, vcc
+; GFX6-NEXT:    v_addc_u32_e32 v9, vcc, 0, v1, vcc
+; GFX6-NEXT:    v_addc_u32_e32 v8, vcc, v1, v8, vcc
+; GFX6-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v4, v2, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v1, v5, v3, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v2, v6, v9, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v3, v7, v8, vcc
 ; GFX6-NEXT:    ; return to shader part epilog
 ;
 ; GFX8-LABEL: saddsat_i128_vs:
@@ -5249,21 +5231,19 @@ define amdgpu_ps <4 x float> @saddsat_i128_vs(i128 %lhs, i128 inreg %rhs) {
 ; GFX8-NEXT:    s_and_b32 s0, 1, s4
 ; GFX8-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, s0
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[0:1]
-; GFX8-NEXT:    s_sub_i32 s0, 0x7f, 64
-; GFX8-NEXT:    v_xor_b32_e32 v2, v1, v0
-; GFX8-NEXT:    v_ashrrev_i64 v[0:1], s0, v[6:7]
-; GFX8-NEXT:    v_ashrrev_i32_e32 v3, 31, v7
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 0, v0
-; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
+; GFX8-NEXT:    v_xor_b32_e32 v0, v1, v0
+; GFX8-NEXT:    v_ashrrev_i32_e32 v1, 31, v7
+; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 0, v1
+; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, 0, v1, vcc
 ; GFX8-NEXT:    v_bfrev_b32_e32 v8, 1
-; GFX8-NEXT:    v_addc_u32_e32 v9, vcc, 0, v3, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, v3, v8, vcc
-; GFX8-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX8-NEXT:    v_addc_u32_e32 v9, vcc, 0, v1, vcc
+; GFX8-NEXT:    v_addc_u32_e32 v8, vcc, v1, v8, vcc
+; GFX8-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v4, v2, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v3, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v2, v6, v9, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v7, v8, vcc
 ; GFX8-NEXT:    ; return to shader part epilog
 ;
 ; GFX9-LABEL: saddsat_i128_vs:
@@ -5288,21 +5268,19 @@ define amdgpu_ps <4 x float> @saddsat_i128_vs(i128 %lhs, i128 inreg %rhs) {
 ; GFX9-NEXT:    s_and_b32 s0, 1, s4
 ; GFX9-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, s0
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[0:1]
-; GFX9-NEXT:    s_sub_i32 s0, 0x7f, 64
-; GFX9-NEXT:    v_xor_b32_e32 v2, v1, v0
-; GFX9-NEXT:    v_ashrrev_i64 v[0:1], s0, v[6:7]
-; GFX9-NEXT:    v_ashrrev_i32_e32 v3, 31, v7
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, 0, v0
-; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v1, vcc
+; GFX9-NEXT:    v_xor_b32_e32 v0, v1, v0
+; GFX9-NEXT:    v_ashrrev_i32_e32 v1, 31, v7
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, 0, v1
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v1, vcc
 ; GFX9-NEXT:    v_bfrev_b32_e32 v8, 1
-; GFX9-NEXT:    v_addc_co_u32_e32 v9, vcc, 0, v3, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v8, vcc
-; GFX9-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v9, vcc, 0, v1, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v8, vcc, v1, v8, vcc
+; GFX9-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v3, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v2, v6, v9, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v7, v8, vcc
 ; GFX9-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-LABEL: saddsat_i128_vs:
@@ -5322,22 +5300,20 @@ define amdgpu_ps <4 x float> @saddsat_i128_vs(i128 %lhs, i128 inreg %rhs) {
 ; GFX10-NEXT:    v_cmp_lt_i64_e32 vcc_lo, v[6:7], v[2:3]
 ; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc_lo
 ; GFX10-NEXT:    v_cmp_eq_u64_e32 vcc_lo, v[6:7], v[2:3]
-; GFX10-NEXT:    v_ashrrev_i32_e32 v3, 31, v7
 ; GFX10-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v1, v8, 0, s0
-; GFX10-NEXT:    s_sub_i32 s0, 0x7f, 64
-; GFX10-NEXT:    v_xor_b32_e32 v2, v1, v0
-; GFX10-NEXT:    v_ashrrev_i64 v[0:1], s0, v[6:7]
-; GFX10-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX10-NEXT:    v_add_co_u32 v0, vcc_lo, v0, 0
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v1, vcc_lo, 0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, v2
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v2, vcc_lo, 0, v3, vcc_lo
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v3, vcc_lo, 0x80000000, v3, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v6, v2, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v7, v3, s0
+; GFX10-NEXT:    v_xor_b32_e32 v0, v1, v0
+; GFX10-NEXT:    v_ashrrev_i32_e32 v1, 31, v7
+; GFX10-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX10-NEXT:    v_add_co_u32 v2, vcc_lo, v1, 0
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v3, vcc_lo, 0, v1, vcc_lo
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v8, vcc_lo, 0, v1, vcc_lo
+; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, v0
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v9, vcc_lo, 0x80000000, v1, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, v2, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, v3, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, v6, v8, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, v7, v9, s0
 ; GFX10-NEXT:    ; return to shader part epilog
   %result = call i128 @llvm.sadd.sat.i128(i128 %lhs, i128 %rhs)
   %cast = bitcast i128 %result to <4 x float>
@@ -5353,30 +5329,28 @@ define <2 x i128> @v_saddsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX6-NEXT:    v_addc_u32_e32 v16, vcc, v2, v10, vcc
 ; GFX6-NEXT:    v_addc_u32_e32 v17, vcc, v3, v11, vcc
 ; GFX6-NEXT:    v_cmp_lt_u64_e32 vcc, v[8:9], v[0:1]
-; GFX6-NEXT:    s_sub_i32 s4, 0x7f, 64
+; GFX6-NEXT:    v_bfrev_b32_e32 v18, 1
 ; GFX6-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_lt_i64_e32 vcc, v[16:17], v[2:3]
-; GFX6-NEXT:    v_bfrev_b32_e32 v18, 1
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_eq_u64_e32 vcc, v[16:17], v[2:3]
-; GFX6-NEXT:    v_ashrrev_i32_e32 v3, 31, v17
 ; GFX6-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
 ; GFX6-NEXT:    v_cmp_gt_i64_e32 vcc, 0, v[10:11]
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[10:11]
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, v1, 0, vcc
-; GFX6-NEXT:    v_xor_b32_e32 v2, v1, v0
-; GFX6-NEXT:    v_ashr_i64 v[0:1], v[16:17], s4
-; GFX6-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX6-NEXT:    v_add_i32_e32 v0, vcc, 0, v0
-; GFX6-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; GFX6-NEXT:    v_addc_u32_e32 v10, vcc, 0, v3, vcc
-; GFX6-NEXT:    v_addc_u32_e32 v3, vcc, v3, v18, vcc
-; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX6-NEXT:    v_cndmask_b32_e32 v0, v8, v0, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v1, v9, v1, vcc
+; GFX6-NEXT:    v_xor_b32_e32 v0, v1, v0
+; GFX6-NEXT:    v_ashrrev_i32_e32 v1, 31, v17
+; GFX6-NEXT:    v_add_i32_e32 v2, vcc, 0, v1
+; GFX6-NEXT:    v_addc_u32_e32 v3, vcc, 0, v1, vcc
+; GFX6-NEXT:    v_addc_u32_e32 v10, vcc, 0, v1, vcc
+; GFX6-NEXT:    v_addc_u32_e32 v11, vcc, v1, v18, vcc
+; GFX6-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v8, v2, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v1, v9, v3, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v2, v16, v10, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v3, v17, v3, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v3, v17, v11, vcc
 ; GFX6-NEXT:    v_add_i32_e32 v8, vcc, v4, v12
 ; GFX6-NEXT:    v_addc_u32_e32 v9, vcc, v5, v13, vcc
 ; GFX6-NEXT:    v_addc_u32_e32 v10, vcc, v6, v14, vcc
@@ -5386,24 +5360,23 @@ define <2 x i128> @v_saddsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX6-NEXT:    v_cmp_lt_i64_e32 vcc, v[10:11], v[6:7]
 ; GFX6-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_eq_u64_e32 vcc, v[10:11], v[6:7]
-; GFX6-NEXT:    v_ashrrev_i32_e32 v7, 31, v11
 ; GFX6-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
 ; GFX6-NEXT:    v_cmp_gt_i64_e32 vcc, 0, v[14:15]
 ; GFX6-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[14:15]
 ; GFX6-NEXT:    v_cndmask_b32_e64 v5, v5, 0, vcc
-; GFX6-NEXT:    v_xor_b32_e32 v6, v5, v4
-; GFX6-NEXT:    v_ashr_i64 v[4:5], v[10:11], s4
-; GFX6-NEXT:    v_and_b32_e32 v6, 1, v6
-; GFX6-NEXT:    v_add_i32_e32 v4, vcc, 0, v4
-; GFX6-NEXT:    v_addc_u32_e32 v5, vcc, 0, v5, vcc
-; GFX6-NEXT:    v_addc_u32_e32 v12, vcc, 0, v7, vcc
-; GFX6-NEXT:    v_addc_u32_e32 v7, vcc, v7, v18, vcc
-; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
-; GFX6-NEXT:    v_cndmask_b32_e32 v4, v8, v4, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v5, v9, v5, vcc
+; GFX6-NEXT:    v_xor_b32_e32 v4, v5, v4
+; GFX6-NEXT:    v_ashrrev_i32_e32 v5, 31, v11
+; GFX6-NEXT:    v_add_i32_e32 v6, vcc, 0, v5
+; GFX6-NEXT:    v_addc_u32_e32 v7, vcc, 0, v5, vcc
+; GFX6-NEXT:    v_addc_u32_e32 v12, vcc, 0, v5, vcc
+; GFX6-NEXT:    v_addc_u32_e32 v13, vcc, v5, v18, vcc
+; GFX6-NEXT:    v_and_b32_e32 v4, 1, v4
+; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; GFX6-NEXT:    v_cndmask_b32_e32 v4, v8, v6, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v5, v9, v7, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v6, v10, v12, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v7, v11, v7, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v7, v11, v13, vcc
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_saddsat_v2i128:
@@ -5414,30 +5387,28 @@ define <2 x i128> @v_saddsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX8-NEXT:    v_addc_u32_e32 v16, vcc, v2, v10, vcc
 ; GFX8-NEXT:    v_addc_u32_e32 v17, vcc, v3, v11, vcc
 ; GFX8-NEXT:    v_cmp_lt_u64_e32 vcc, v[8:9], v[0:1]
-; GFX8-NEXT:    s_sub_i32 s4, 0x7f, 64
+; GFX8-NEXT:    v_bfrev_b32_e32 v18, 1
 ; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GFX8-NEXT:    v_cmp_lt_i64_e32 vcc, v[16:17], v[2:3]
-; GFX8-NEXT:    v_bfrev_b32_e32 v18, 1
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GFX8-NEXT:    v_cmp_eq_u64_e32 vcc, v[16:17], v[2:3]
-; GFX8-NEXT:    v_ashrrev_i32_e32 v3, 31, v17
 ; GFX8-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
 ; GFX8-NEXT:    v_cmp_gt_i64_e32 vcc, 0, v[10:11]
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GFX8-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[10:11]
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, 0, vcc
-; GFX8-NEXT:    v_xor_b32_e32 v2, v1, v0
-; GFX8-NEXT:    v_ashrrev_i64 v[0:1], s4, v[16:17]
-; GFX8-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 0, v0
-; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v10, vcc, 0, v3, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, v3, v18, vcc
-; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v8, v0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v9, v1, vcc
+; GFX8-NEXT:    v_xor_b32_e32 v0, v1, v0
+; GFX8-NEXT:    v_ashrrev_i32_e32 v1, 31, v17
+; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 0, v1
+; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, 0, v1, vcc
+; GFX8-NEXT:    v_addc_u32_e32 v10, vcc, 0, v1, vcc
+; GFX8-NEXT:    v_addc_u32_e32 v11, vcc, v1, v18, vcc
+; GFX8-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v8, v2, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v9, v3, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v2, v16, v10, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v17, v3, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v17, v11, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v8, vcc, v4, v12
 ; GFX8-NEXT:    v_addc_u32_e32 v9, vcc, v5, v13, vcc
 ; GFX8-NEXT:    v_addc_u32_e32 v10, vcc, v6, v14, vcc
@@ -5447,24 +5418,23 @@ define <2 x i128> @v_saddsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX8-NEXT:    v_cmp_lt_i64_e32 vcc, v[10:11], v[6:7]
 ; GFX8-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GFX8-NEXT:    v_cmp_eq_u64_e32 vcc, v[10:11], v[6:7]
-; GFX8-NEXT:    v_ashrrev_i32_e32 v7, 31, v11
 ; GFX8-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
 ; GFX8-NEXT:    v_cmp_gt_i64_e32 vcc, 0, v[14:15]
 ; GFX8-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GFX8-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[14:15]
 ; GFX8-NEXT:    v_cndmask_b32_e64 v5, v5, 0, vcc
-; GFX8-NEXT:    v_xor_b32_e32 v6, v5, v4
-; GFX8-NEXT:    v_ashrrev_i64 v[4:5], s4, v[10:11]
-; GFX8-NEXT:    v_and_b32_e32 v6, 1, v6
-; GFX8-NEXT:    v_add_u32_e32 v4, vcc, 0, v4
-; GFX8-NEXT:    v_addc_u32_e32 v5, vcc, 0, v5, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v12, vcc, 0, v7, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v7, vcc, v7, v18, vcc
-; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v8, v4, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v9, v5, vcc
+; GFX8-NEXT:    v_xor_b32_e32 v4, v5, v4
+; GFX8-NEXT:    v_ashrrev_i32_e32 v5, 31, v11
+; GFX8-NEXT:    v_add_u32_e32 v6, vcc, 0, v5
+; GFX8-NEXT:    v_addc_u32_e32 v7, vcc, 0, v5, vcc
+; GFX8-NEXT:    v_addc_u32_e32 v12, vcc, 0, v5, vcc
+; GFX8-NEXT:    v_addc_u32_e32 v13, vcc, v5, v18, vcc
+; GFX8-NEXT:    v_and_b32_e32 v4, 1, v4
+; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; GFX8-NEXT:    v_cndmask_b32_e32 v4, v8, v6, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v5, v9, v7, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v6, v10, v12, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v7, v11, v7, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v7, v11, v13, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_saddsat_v2i128:
@@ -5475,30 +5445,28 @@ define <2 x i128> @v_saddsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX9-NEXT:    v_addc_co_u32_e32 v16, vcc, v2, v10, vcc
 ; GFX9-NEXT:    v_addc_co_u32_e32 v17, vcc, v3, v11, vcc
 ; GFX9-NEXT:    v_cmp_lt_u64_e32 vcc, v[8:9], v[0:1]
-; GFX9-NEXT:    s_sub_i32 s4, 0x7f, 64
+; GFX9-NEXT:    v_bfrev_b32_e32 v18, 1
 ; GFX9-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GFX9-NEXT:    v_cmp_lt_i64_e32 vcc, v[16:17], v[2:3]
-; GFX9-NEXT:    v_bfrev_b32_e32 v18, 1
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GFX9-NEXT:    v_cmp_eq_u64_e32 vcc, v[16:17], v[2:3]
-; GFX9-NEXT:    v_ashrrev_i32_e32 v3, 31, v17
 ; GFX9-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
 ; GFX9-NEXT:    v_cmp_gt_i64_e32 vcc, 0, v[10:11]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GFX9-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[10:11]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, 0, vcc
-; GFX9-NEXT:    v_xor_b32_e32 v2, v1, v0
-; GFX9-NEXT:    v_ashrrev_i64 v[0:1], s4, v[16:17]
-; GFX9-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, 0, v0
-; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v1, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v10, vcc, 0, v3, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v18, vcc
-; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v8, v0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v9, v1, vcc
+; GFX9-NEXT:    v_xor_b32_e32 v0, v1, v0
+; GFX9-NEXT:    v_ashrrev_i32_e32 v1, 31, v17
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, 0, v1
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v1, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v10, vcc, 0, v1, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v11, vcc, v1, v18, vcc
+; GFX9-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v8, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v9, v3, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v2, v16, v10, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v17, v3, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v17, v11, vcc
 ; GFX9-NEXT:    v_add_co_u32_e32 v8, vcc, v4, v12
 ; GFX9-NEXT:    v_addc_co_u32_e32 v9, vcc, v5, v13, vcc
 ; GFX9-NEXT:    v_addc_co_u32_e32 v10, vcc, v6, v14, vcc
@@ -5508,24 +5476,23 @@ define <2 x i128> @v_saddsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX9-NEXT:    v_cmp_lt_i64_e32 vcc, v[10:11], v[6:7]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GFX9-NEXT:    v_cmp_eq_u64_e32 vcc, v[10:11], v[6:7]
-; GFX9-NEXT:    v_ashrrev_i32_e32 v7, 31, v11
 ; GFX9-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
 ; GFX9-NEXT:    v_cmp_gt_i64_e32 vcc, 0, v[14:15]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GFX9-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[14:15]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v5, v5, 0, vcc
-; GFX9-NEXT:    v_xor_b32_e32 v6, v5, v4
-; GFX9-NEXT:    v_ashrrev_i64 v[4:5], s4, v[10:11]
-; GFX9-NEXT:    v_and_b32_e32 v6, 1, v6
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, 0, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v12, vcc, 0, v7, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, v7, v18, vcc
-; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v8, v4, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v9, v5, vcc
+; GFX9-NEXT:    v_xor_b32_e32 v4, v5, v4
+; GFX9-NEXT:    v_ashrrev_i32_e32 v5, 31, v11
+; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, 0, v5
+; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v5, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v12, vcc, 0, v5, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v13, vcc, v5, v18, vcc
+; GFX9-NEXT:    v_and_b32_e32 v4, 1, v4
+; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; GFX9-NEXT:    v_cndmask_b32_e32 v4, v8, v6, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v5, v9, v7, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v6, v10, v12, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v11, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v7, v11, v13, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_saddsat_v2i128:
@@ -5533,7 +5500,6 @@ define <2 x i128> @v_saddsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX10-NEXT:    v_add_co_u32 v8, vcc_lo, v0, v8
-; GFX10-NEXT:    s_sub_i32 s6, 0x7f, 64
 ; GFX10-NEXT:    v_add_co_ci_u32_e32 v9, vcc_lo, v1, v9, vcc_lo
 ; GFX10-NEXT:    v_add_co_ci_u32_e32 v16, vcc_lo, v2, v10, vcc_lo
 ; GFX10-NEXT:    v_add_co_ci_u32_e32 v17, vcc_lo, v3, v11, vcc_lo
@@ -5544,49 +5510,47 @@ define <2 x i128> @v_saddsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX10-NEXT:    v_cmp_gt_i64_e32 vcc_lo, 0, v[10:11]
 ; GFX10-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc_lo
 ; GFX10-NEXT:    v_cmp_eq_u64_e32 vcc_lo, v[16:17], v[2:3]
-; GFX10-NEXT:    v_ashrrev_i32_e32 v3, 31, v17
 ; GFX10-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
 ; GFX10-NEXT:    v_cmp_eq_u64_e32 vcc_lo, 0, v[10:11]
 ; GFX10-NEXT:    v_cndmask_b32_e64 v1, v18, 0, vcc_lo
 ; GFX10-NEXT:    v_add_co_u32 v10, vcc_lo, v4, v12
 ; GFX10-NEXT:    v_add_co_ci_u32_e32 v11, vcc_lo, v5, v13, vcc_lo
 ; GFX10-NEXT:    v_add_co_ci_u32_e32 v12, vcc_lo, v6, v14, vcc_lo
-; GFX10-NEXT:    v_xor_b32_e32 v2, v1, v0
+; GFX10-NEXT:    v_xor_b32_e32 v0, v1, v0
 ; GFX10-NEXT:    v_add_co_ci_u32_e32 v13, vcc_lo, v7, v15, vcc_lo
 ; GFX10-NEXT:    v_cmp_lt_u64_e64 s4, v[10:11], v[4:5]
-; GFX10-NEXT:    v_ashrrev_i64 v[0:1], s6, v[16:17]
-; GFX10-NEXT:    v_and_b32_e32 v2, 1, v2
+; GFX10-NEXT:    v_ashrrev_i32_e32 v1, 31, v17
+; GFX10-NEXT:    v_and_b32_e32 v0, 1, v0
 ; GFX10-NEXT:    v_cmp_eq_u64_e64 s5, v[12:13], v[6:7]
 ; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s4
 ; GFX10-NEXT:    v_cmp_lt_i64_e64 s4, v[12:13], v[6:7]
-; GFX10-NEXT:    v_add_co_u32 v0, vcc_lo, v0, 0
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v1, vcc_lo, 0, v1, vcc_lo
+; GFX10-NEXT:    v_add_co_u32 v2, vcc_lo, v1, 0
+; GFX10-NEXT:    v_ashrrev_i32_e32 v7, 31, v13
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v3, vcc_lo, 0, v1, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s4
 ; GFX10-NEXT:    v_cmp_gt_i64_e64 s4, 0, v[14:15]
 ; GFX10-NEXT:    v_cndmask_b32_e64 v18, 0, 1, s4
-; GFX10-NEXT:    v_cmp_ne_u32_e64 s4, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v5, v4, s5
+; GFX10-NEXT:    v_cmp_ne_u32_e64 s4, 0, v0
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v5, v4, s5
 ; GFX10-NEXT:    v_cmp_eq_u64_e64 s5, 0, v[14:15]
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v5, vcc_lo, 0, v3, vcc_lo
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v6, vcc_lo, 0x80000000, v3, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v8, v0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v9, v1, s4
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v5, vcc_lo, 0, v1, vcc_lo
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v6, vcc_lo, 0x80000000, v1, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, v9, v3, s4
 ; GFX10-NEXT:    v_cndmask_b32_e64 v4, v18, 0, s5
-; GFX10-NEXT:    v_xor_b32_e32 v7, v4, v2
-; GFX10-NEXT:    v_ashrrev_i64 v[3:4], s6, v[12:13]
+; GFX10-NEXT:    v_xor_b32_e32 v4, v4, v0
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v8, v2, s4
 ; GFX10-NEXT:    v_cndmask_b32_e64 v2, v16, v5, s4
-; GFX10-NEXT:    v_ashrrev_i32_e32 v5, 31, v13
-; GFX10-NEXT:    v_and_b32_e32 v7, 1, v7
-; GFX10-NEXT:    v_add_co_u32 v8, vcc_lo, v3, 0
+; GFX10-NEXT:    v_and_b32_e32 v3, 1, v4
+; GFX10-NEXT:    v_add_co_u32 v4, vcc_lo, v7, 0
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v5, vcc_lo, 0, v7, vcc_lo
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v8, vcc_lo, 0, v7, vcc_lo
+; GFX10-NEXT:    v_cmp_ne_u32_e64 s5, 0, v3
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v7, vcc_lo, 0x80000000, v7, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v3, v17, v6, s4
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v9, vcc_lo, 0, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_ne_u32_e64 s5, 0, v7
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v7, vcc_lo, 0, v5, vcc_lo
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v14, vcc_lo, 0x80000000, v5, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v10, v8, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v12, v7, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v11, v9, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v13, v14, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, v10, v4, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, v11, v5, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, v12, v8, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, v13, v7, s5
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
   %result = call <2 x i128> @llvm.sadd.sat.v2i128(<2 x i128> %lhs, <2 x i128> %rhs)
   ret <2 x i128> %result
@@ -5620,25 +5584,23 @@ define amdgpu_ps <2 x i128> @s_saddsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX6-NEXT:    v_cmp_eq_u64_e32 vcc, s[16:17], v[0:1]
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[0:1]
 ; GFX6-NEXT:    v_cmp_eq_u64_e64 s[0:1], s[10:11], 0
-; GFX6-NEXT:    s_sub_i32 s10, 0x7f, 64
-; GFX6-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[0:1]
 ; GFX6-NEXT:    s_ashr_i32 s3, s17, 31
-; GFX6-NEXT:    s_ashr_i64 s[0:1], s[16:17], s10
-; GFX6-NEXT:    s_add_u32 s0, s0, 0
-; GFX6-NEXT:    s_cselect_b32 s2, 1, 0
-; GFX6-NEXT:    s_and_b32 s2, s2, 1
-; GFX6-NEXT:    s_cmp_lg_u32 s2, 0
-; GFX6-NEXT:    s_addc_u32 s1, s1, 0
+; GFX6-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[0:1]
+; GFX6-NEXT:    s_add_u32 s0, s3, 0
+; GFX6-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX6-NEXT:    s_and_b32 s1, s1, 1
+; GFX6-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX6-NEXT:    s_addc_u32 s1, s3, 0
 ; GFX6-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX6-NEXT:    s_and_b32 s2, s2, 1
 ; GFX6-NEXT:    s_cmp_lg_u32 s2, 0
 ; GFX6-NEXT:    s_addc_u32 s2, s3, 0
-; GFX6-NEXT:    s_cselect_b32 s18, 1, 0
-; GFX6-NEXT:    s_and_b32 s18, s18, 1
-; GFX6-NEXT:    s_brev_b32 s11, 1
-; GFX6-NEXT:    s_cmp_lg_u32 s18, 0
+; GFX6-NEXT:    s_cselect_b32 s11, 1, 0
+; GFX6-NEXT:    s_and_b32 s11, s11, 1
+; GFX6-NEXT:    s_brev_b32 s10, 1
+; GFX6-NEXT:    s_cmp_lg_u32 s11, 0
 ; GFX6-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
-; GFX6-NEXT:    s_addc_u32 s3, s3, s11
+; GFX6-NEXT:    s_addc_u32 s3, s3, s10
 ; GFX6-NEXT:    v_xor_b32_e32 v0, v1, v0
 ; GFX6-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX6-NEXT:    s_add_u32 s0, s4, s12
@@ -5681,12 +5643,11 @@ define amdgpu_ps <2 x i128> @s_saddsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX6-NEXT:    v_cmp_eq_u64_e64 s[4:5], s[14:15], 0
 ; GFX6-NEXT:    s_ashr_i32 s7, s3, 31
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[4:5]
-; GFX6-NEXT:    s_ashr_i64 s[4:5], s[2:3], s10
-; GFX6-NEXT:    s_add_u32 s4, s4, 0
-; GFX6-NEXT:    s_cselect_b32 s6, 1, 0
-; GFX6-NEXT:    s_and_b32 s6, s6, 1
-; GFX6-NEXT:    s_cmp_lg_u32 s6, 0
-; GFX6-NEXT:    s_addc_u32 s5, s5, 0
+; GFX6-NEXT:    s_add_u32 s4, s7, 0
+; GFX6-NEXT:    s_cselect_b32 s5, 1, 0
+; GFX6-NEXT:    s_and_b32 s5, s5, 1
+; GFX6-NEXT:    s_cmp_lg_u32 s5, 0
+; GFX6-NEXT:    s_addc_u32 s5, s7, 0
 ; GFX6-NEXT:    s_cselect_b32 s6, 1, 0
 ; GFX6-NEXT:    s_and_b32 s6, s6, 1
 ; GFX6-NEXT:    s_cmp_lg_u32 s6, 0
@@ -5699,7 +5660,7 @@ define amdgpu_ps <2 x i128> @s_saddsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX6-NEXT:    v_and_b32_e32 v0, 1, v0
 ; GFX6-NEXT:    v_mov_b32_e32 v3, s0
 ; GFX6-NEXT:    v_mov_b32_e32 v8, s1
-; GFX6-NEXT:    s_addc_u32 s7, s7, s11
+; GFX6-NEXT:    s_addc_u32 s7, s7, s10
 ; GFX6-NEXT:    v_mov_b32_e32 v1, s4
 ; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
 ; GFX6-NEXT:    v_mov_b32_e32 v2, s5
@@ -5754,25 +5715,23 @@ define amdgpu_ps <2 x i128> @s_saddsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[0:1]
 ; GFX8-NEXT:    s_and_b32 s0, 1, s2
 ; GFX8-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, s0
-; GFX8-NEXT:    s_sub_i32 s10, 0x7f, 64
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[0:1]
 ; GFX8-NEXT:    s_ashr_i32 s3, s17, 31
-; GFX8-NEXT:    s_ashr_i64 s[0:1], s[16:17], s10
-; GFX8-NEXT:    s_add_u32 s0, s0, 0
-; GFX8-NEXT:    s_cselect_b32 s2, 1, 0
-; GFX8-NEXT:    s_and_b32 s2, s2, 1
-; GFX8-NEXT:    s_cmp_lg_u32 s2, 0
-; GFX8-NEXT:    s_addc_u32 s1, s1, 0
+; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[0:1]
+; GFX8-NEXT:    s_add_u32 s0, s3, 0
+; GFX8-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX8-NEXT:    s_and_b32 s1, s1, 1
+; GFX8-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX8-NEXT:    s_addc_u32 s1, s3, 0
 ; GFX8-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX8-NEXT:    s_and_b32 s2, s2, 1
 ; GFX8-NEXT:    s_cmp_lg_u32 s2, 0
 ; GFX8-NEXT:    s_addc_u32 s2, s3, 0
-; GFX8-NEXT:    s_cselect_b32 s18, 1, 0
-; GFX8-NEXT:    s_and_b32 s18, s18, 1
-; GFX8-NEXT:    s_brev_b32 s11, 1
-; GFX8-NEXT:    s_cmp_lg_u32 s18, 0
+; GFX8-NEXT:    s_cselect_b32 s11, 1, 0
+; GFX8-NEXT:    s_and_b32 s11, s11, 1
+; GFX8-NEXT:    s_brev_b32 s10, 1
+; GFX8-NEXT:    s_cmp_lg_u32 s11, 0
 ; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX8-NEXT:    s_addc_u32 s3, s3, s11
+; GFX8-NEXT:    s_addc_u32 s3, s3, s10
 ; GFX8-NEXT:    v_xor_b32_e32 v0, v1, v0
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX8-NEXT:    s_add_u32 s0, s4, s12
@@ -5819,14 +5778,13 @@ define amdgpu_ps <2 x i128> @s_saddsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
 ; GFX8-NEXT:    s_and_b32 s4, 1, s6
 ; GFX8-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, s4
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[4:5]
 ; GFX8-NEXT:    s_ashr_i32 s7, s3, 31
-; GFX8-NEXT:    s_ashr_i64 s[4:5], s[2:3], s10
-; GFX8-NEXT:    s_add_u32 s4, s4, 0
-; GFX8-NEXT:    s_cselect_b32 s6, 1, 0
-; GFX8-NEXT:    s_and_b32 s6, s6, 1
-; GFX8-NEXT:    s_cmp_lg_u32 s6, 0
-; GFX8-NEXT:    s_addc_u32 s5, s5, 0
+; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[4:5]
+; GFX8-NEXT:    s_add_u32 s4, s7, 0
+; GFX8-NEXT:    s_cselect_b32 s5, 1, 0
+; GFX8-NEXT:    s_and_b32 s5, s5, 1
+; GFX8-NEXT:    s_cmp_lg_u32 s5, 0
+; GFX8-NEXT:    s_addc_u32 s5, s7, 0
 ; GFX8-NEXT:    s_cselect_b32 s6, 1, 0
 ; GFX8-NEXT:    s_and_b32 s6, s6, 1
 ; GFX8-NEXT:    s_cmp_lg_u32 s6, 0
@@ -5839,7 +5797,7 @@ define amdgpu_ps <2 x i128> @s_saddsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX8-NEXT:    v_and_b32_e32 v0, 1, v0
 ; GFX8-NEXT:    v_mov_b32_e32 v3, s0
 ; GFX8-NEXT:    v_mov_b32_e32 v8, s1
-; GFX8-NEXT:    s_addc_u32 s7, s7, s11
+; GFX8-NEXT:    s_addc_u32 s7, s7, s10
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s4
 ; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
 ; GFX8-NEXT:    v_mov_b32_e32 v2, s5
@@ -5894,25 +5852,23 @@ define amdgpu_ps <2 x i128> @s_saddsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[0:1]
 ; GFX9-NEXT:    s_and_b32 s0, 1, s2
 ; GFX9-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, s0
-; GFX9-NEXT:    s_sub_i32 s10, 0x7f, 64
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[0:1]
 ; GFX9-NEXT:    s_ashr_i32 s3, s17, 31
-; GFX9-NEXT:    s_ashr_i64 s[0:1], s[16:17], s10
-; GFX9-NEXT:    s_add_u32 s0, s0, 0
-; GFX9-NEXT:    s_cselect_b32 s2, 1, 0
-; GFX9-NEXT:    s_and_b32 s2, s2, 1
-; GFX9-NEXT:    s_cmp_lg_u32 s2, 0
-; GFX9-NEXT:    s_addc_u32 s1, s1, 0
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[0:1]
+; GFX9-NEXT:    s_add_u32 s0, s3, 0
+; GFX9-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX9-NEXT:    s_and_b32 s1, s1, 1
+; GFX9-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX9-NEXT:    s_addc_u32 s1, s3, 0
 ; GFX9-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX9-NEXT:    s_and_b32 s2, s2, 1
 ; GFX9-NEXT:    s_cmp_lg_u32 s2, 0
 ; GFX9-NEXT:    s_addc_u32 s2, s3, 0
-; GFX9-NEXT:    s_cselect_b32 s18, 1, 0
-; GFX9-NEXT:    s_and_b32 s18, s18, 1
-; GFX9-NEXT:    s_brev_b32 s11, 1
-; GFX9-NEXT:    s_cmp_lg_u32 s18, 0
+; GFX9-NEXT:    s_cselect_b32 s11, 1, 0
+; GFX9-NEXT:    s_and_b32 s11, s11, 1
+; GFX9-NEXT:    s_brev_b32 s10, 1
+; GFX9-NEXT:    s_cmp_lg_u32 s11, 0
 ; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX9-NEXT:    s_addc_u32 s3, s3, s11
+; GFX9-NEXT:    s_addc_u32 s3, s3, s10
 ; GFX9-NEXT:    v_xor_b32_e32 v0, v1, v0
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX9-NEXT:    s_add_u32 s0, s4, s12
@@ -5959,14 +5915,13 @@ define amdgpu_ps <2 x i128> @s_saddsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
 ; GFX9-NEXT:    s_and_b32 s4, 1, s6
 ; GFX9-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, s4
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[4:5]
 ; GFX9-NEXT:    s_ashr_i32 s7, s3, 31
-; GFX9-NEXT:    s_ashr_i64 s[4:5], s[2:3], s10
-; GFX9-NEXT:    s_add_u32 s4, s4, 0
-; GFX9-NEXT:    s_cselect_b32 s6, 1, 0
-; GFX9-NEXT:    s_and_b32 s6, s6, 1
-; GFX9-NEXT:    s_cmp_lg_u32 s6, 0
-; GFX9-NEXT:    s_addc_u32 s5, s5, 0
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[4:5]
+; GFX9-NEXT:    s_add_u32 s4, s7, 0
+; GFX9-NEXT:    s_cselect_b32 s5, 1, 0
+; GFX9-NEXT:    s_and_b32 s5, s5, 1
+; GFX9-NEXT:    s_cmp_lg_u32 s5, 0
+; GFX9-NEXT:    s_addc_u32 s5, s7, 0
 ; GFX9-NEXT:    s_cselect_b32 s6, 1, 0
 ; GFX9-NEXT:    s_and_b32 s6, s6, 1
 ; GFX9-NEXT:    s_cmp_lg_u32 s6, 0
@@ -5979,7 +5934,7 @@ define amdgpu_ps <2 x i128> @s_saddsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX9-NEXT:    v_and_b32_e32 v0, 1, v0
 ; GFX9-NEXT:    v_mov_b32_e32 v3, s0
 ; GFX9-NEXT:    v_mov_b32_e32 v8, s1
-; GFX9-NEXT:    s_addc_u32 s7, s7, s11
+; GFX9-NEXT:    s_addc_u32 s7, s7, s10
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s4
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
 ; GFX9-NEXT:    v_mov_b32_e32 v2, s5
@@ -6029,32 +5984,30 @@ define amdgpu_ps <2 x i128> @s_saddsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX10-NEXT:    s_cmp_eq_u64 s[10:11], 0
 ; GFX10-NEXT:    v_cmp_ne_u32_e64 vcc_lo, 0, s0
 ; GFX10-NEXT:    s_cselect_b32 s0, 1, 0
-; GFX10-NEXT:    s_sub_i32 s10, 0x7f, 64
-; GFX10-NEXT:    s_and_b32 s0, 1, s0
 ; GFX10-NEXT:    s_ashr_i32 s3, s17, 31
+; GFX10-NEXT:    s_and_b32 s0, 1, s0
+; GFX10-NEXT:    s_brev_b32 s10, 1
 ; GFX10-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s1
 ; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, s0
-; GFX10-NEXT:    s_brev_b32 s11, 1
 ; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s0
-; GFX10-NEXT:    s_ashr_i64 s[0:1], s[16:17], s10
-; GFX10-NEXT:    s_add_u32 s0, s0, 0
-; GFX10-NEXT:    s_cselect_b32 s2, 1, 0
+; GFX10-NEXT:    s_add_u32 s0, s3, 0
+; GFX10-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX10-NEXT:    s_and_b32 s1, s1, 1
 ; GFX10-NEXT:    v_xor_b32_e32 v0, v1, v0
-; GFX10-NEXT:    s_and_b32 s2, s2, 1
+; GFX10-NEXT:    s_cmp_lg_u32 s1, 0
 ; GFX10-NEXT:    v_mov_b32_e32 v1, s8
-; GFX10-NEXT:    s_cmp_lg_u32 s2, 0
-; GFX10-NEXT:    s_addc_u32 s1, s1, 0
+; GFX10-NEXT:    s_addc_u32 s1, s3, 0
 ; GFX10-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX10-NEXT:    v_and_b32_e32 v0, 1, v0
 ; GFX10-NEXT:    s_and_b32 s2, s2, 1
 ; GFX10-NEXT:    s_cmp_lg_u32 s2, 0
 ; GFX10-NEXT:    s_addc_u32 s2, s3, 0
-; GFX10-NEXT:    s_cselect_b32 s18, 1, 0
+; GFX10-NEXT:    s_cselect_b32 s11, 1, 0
 ; GFX10-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v0
-; GFX10-NEXT:    s_and_b32 s18, s18, 1
-; GFX10-NEXT:    s_cmp_lg_u32 s18, 0
-; GFX10-NEXT:    s_addc_u32 s3, s3, s11
+; GFX10-NEXT:    s_and_b32 s11, s11, 1
+; GFX10-NEXT:    s_cmp_lg_u32 s11, 0
+; GFX10-NEXT:    s_addc_u32 s3, s3, s10
 ; GFX10-NEXT:    v_cndmask_b32_e64 v0, v1, s0, vcc_lo
 ; GFX10-NEXT:    s_add_u32 s0, s4, s12
 ; GFX10-NEXT:    s_cselect_b32 s8, 1, 0
@@ -6088,17 +6041,16 @@ define amdgpu_ps <2 x i128> @s_saddsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s4
 ; GFX10-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX10-NEXT:    s_ashr_i32 s5, s9, 31
-; GFX10-NEXT:    s_and_b32 s4, 1, s2
 ; GFX10-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s3
-; GFX10-NEXT:    s_ashr_i64 s[2:3], s[8:9], s10
-; GFX10-NEXT:    v_cmp_ne_u32_e64 s4, 0, s4
-; GFX10-NEXT:    s_add_u32 s2, s2, 0
-; GFX10-NEXT:    s_cselect_b32 s6, 1, 0
-; GFX10-NEXT:    s_and_b32 s6, s6, 1
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v5, 0, s4
-; GFX10-NEXT:    s_cmp_lg_u32 s6, 0
-; GFX10-NEXT:    s_addc_u32 s3, s3, 0
+; GFX10-NEXT:    s_and_b32 s3, 1, s2
+; GFX10-NEXT:    s_add_u32 s2, s5, 0
+; GFX10-NEXT:    v_cmp_ne_u32_e64 s3, 0, s3
+; GFX10-NEXT:    s_cselect_b32 s4, 1, 0
+; GFX10-NEXT:    s_and_b32 s4, s4, 1
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, v5, 0, s3
+; GFX10-NEXT:    s_cmp_lg_u32 s4, 0
+; GFX10-NEXT:    s_addc_u32 s3, s5, 0
 ; GFX10-NEXT:    s_cselect_b32 s4, 1, 0
 ; GFX10-NEXT:    v_xor_b32_e32 v4, v5, v4
 ; GFX10-NEXT:    s_and_b32 s4, s4, 1
@@ -6111,7 +6063,7 @@ define amdgpu_ps <2 x i128> @s_saddsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX10-NEXT:    s_and_b32 s6, s6, 1
 ; GFX10-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v4
 ; GFX10-NEXT:    s_cmp_lg_u32 s6, 0
-; GFX10-NEXT:    s_addc_u32 s1, s5, s11
+; GFX10-NEXT:    s_addc_u32 s1, s5, s10
 ; GFX10-NEXT:    v_cndmask_b32_e64 v4, v5, s2, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v5, v6, s3, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v6, v7, s4, vcc_lo

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/ssubsat.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/ssubsat.ll
@@ -4781,16 +4781,14 @@ define amdgpu_ps i128 @s_ssubsat_i128(i128 inreg %lhs, i128 inreg %rhs) {
 ; GFX6-NEXT:    v_cmp_eq_u64_e32 vcc, s[10:11], v[0:1]
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[0:1]
 ; GFX6-NEXT:    v_cmp_gt_i64_e64 s[0:1], s[6:7], 0
+; GFX6-NEXT:    s_ashr_i32 s3, s11, 31
 ; GFX6-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[0:1]
-; GFX6-NEXT:    s_sub_i32 s0, 0x7f, 64
-; GFX6-NEXT:    s_ashr_i32 s3, s11, 31
-; GFX6-NEXT:    s_ashr_i64 s[0:1], s[10:11], s0
-; GFX6-NEXT:    s_add_u32 s0, s0, 0
-; GFX6-NEXT:    s_cselect_b32 s2, 1, 0
-; GFX6-NEXT:    s_and_b32 s2, s2, 1
-; GFX6-NEXT:    s_cmp_lg_u32 s2, 0
-; GFX6-NEXT:    s_addc_u32 s1, s1, 0
+; GFX6-NEXT:    s_add_u32 s0, s3, 0
+; GFX6-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX6-NEXT:    s_and_b32 s1, s1, 1
+; GFX6-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX6-NEXT:    s_addc_u32 s1, s3, 0
 ; GFX6-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX6-NEXT:    s_and_b32 s2, s2, 1
 ; GFX6-NEXT:    s_cmp_lg_u32 s2, 0
@@ -4857,15 +4855,13 @@ define amdgpu_ps i128 @s_ssubsat_i128(i128 inreg %lhs, i128 inreg %rhs) {
 ; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[0:1]
 ; GFX8-NEXT:    s_and_b32 s0, 1, s2
-; GFX8-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s0
-; GFX8-NEXT:    s_sub_i32 s0, 0x7f, 64
 ; GFX8-NEXT:    s_ashr_i32 s3, s11, 31
-; GFX8-NEXT:    s_ashr_i64 s[0:1], s[10:11], s0
-; GFX8-NEXT:    s_add_u32 s0, s0, 0
-; GFX8-NEXT:    s_cselect_b32 s2, 1, 0
-; GFX8-NEXT:    s_and_b32 s2, s2, 1
-; GFX8-NEXT:    s_cmp_lg_u32 s2, 0
-; GFX8-NEXT:    s_addc_u32 s1, s1, 0
+; GFX8-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s0
+; GFX8-NEXT:    s_add_u32 s0, s3, 0
+; GFX8-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX8-NEXT:    s_and_b32 s1, s1, 1
+; GFX8-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX8-NEXT:    s_addc_u32 s1, s3, 0
 ; GFX8-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX8-NEXT:    s_and_b32 s2, s2, 1
 ; GFX8-NEXT:    s_cmp_lg_u32 s2, 0
@@ -4931,15 +4927,13 @@ define amdgpu_ps i128 @s_ssubsat_i128(i128 inreg %lhs, i128 inreg %rhs) {
 ; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[0:1]
 ; GFX9-NEXT:    s_and_b32 s0, 1, s2
-; GFX9-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s0
-; GFX9-NEXT:    s_sub_i32 s0, 0x7f, 64
 ; GFX9-NEXT:    s_ashr_i32 s3, s11, 31
-; GFX9-NEXT:    s_ashr_i64 s[0:1], s[10:11], s0
-; GFX9-NEXT:    s_add_u32 s0, s0, 0
-; GFX9-NEXT:    s_cselect_b32 s2, 1, 0
-; GFX9-NEXT:    s_and_b32 s2, s2, 1
-; GFX9-NEXT:    s_cmp_lg_u32 s2, 0
-; GFX9-NEXT:    s_addc_u32 s1, s1, 0
+; GFX9-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s0
+; GFX9-NEXT:    s_add_u32 s0, s3, 0
+; GFX9-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX9-NEXT:    s_and_b32 s1, s1, 1
+; GFX9-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX9-NEXT:    s_addc_u32 s1, s3, 0
 ; GFX9-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX9-NEXT:    s_and_b32 s2, s2, 1
 ; GFX9-NEXT:    s_cmp_lg_u32 s2, 0
@@ -4999,21 +4993,19 @@ define amdgpu_ps i128 @s_ssubsat_i128(i128 inreg %lhs, i128 inreg %rhs) {
 ; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s1
 ; GFX10-NEXT:    s_cselect_b32 s1, 1, 0
 ; GFX10-NEXT:    s_ashr_i32 s3, s11, 31
-; GFX10-NEXT:    s_and_b32 s2, 1, s1
 ; GFX10-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s0
 ; GFX10-NEXT:    v_cmp_gt_i64_e64 s0, s[6:7], 0
-; GFX10-NEXT:    v_cmp_ne_u32_e64 vcc_lo, 0, s2
 ; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s0
-; GFX10-NEXT:    s_sub_i32 s0, 0x7f, 64
-; GFX10-NEXT:    s_ashr_i64 s[0:1], s[10:11], s0
-; GFX10-NEXT:    s_add_u32 s0, s0, 0
-; GFX10-NEXT:    s_cselect_b32 s4, 1, 0
+; GFX10-NEXT:    s_and_b32 s0, 1, s1
+; GFX10-NEXT:    v_cmp_ne_u32_e64 vcc_lo, 0, s0
+; GFX10-NEXT:    s_add_u32 s0, s3, 0
+; GFX10-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX10-NEXT:    s_and_b32 s1, s1, 1
 ; GFX10-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc_lo
-; GFX10-NEXT:    s_and_b32 s4, s4, 1
+; GFX10-NEXT:    s_cmp_lg_u32 s1, 0
 ; GFX10-NEXT:    v_mov_b32_e32 v2, s9
-; GFX10-NEXT:    s_cmp_lg_u32 s4, 0
-; GFX10-NEXT:    s_addc_u32 s1, s1, 0
+; GFX10-NEXT:    s_addc_u32 s1, s3, 0
 ; GFX10-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX10-NEXT:    v_xor_b32_e32 v0, v1, v0
 ; GFX10-NEXT:    s_and_b32 s2, s2, 1
@@ -5050,7 +5042,6 @@ define amdgpu_ps <4 x float> @ssubsat_i128_sv(i128 inreg %lhs, i128 %rhs) {
 ; GFX6-NEXT:    v_subb_u32_e32 v6, vcc, v6, v2, vcc
 ; GFX6-NEXT:    v_subb_u32_e32 v7, vcc, v7, v3, vcc
 ; GFX6-NEXT:    v_cmp_gt_u64_e32 vcc, s[0:1], v[4:5]
-; GFX6-NEXT:    s_sub_i32 s0, 0x7f, 64
 ; GFX6-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_gt_i64_e32 vcc, s[2:3], v[6:7]
 ; GFX6-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
@@ -5061,21 +5052,20 @@ define amdgpu_ps <4 x float> @ssubsat_i128_sv(i128 inreg %lhs, i128 %rhs) {
 ; GFX6-NEXT:    v_cmp_lt_i64_e32 vcc, 0, v[2:3]
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[2:3]
-; GFX6-NEXT:    v_ashrrev_i32_e32 v3, 31, v7
 ; GFX6-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
-; GFX6-NEXT:    v_xor_b32_e32 v2, v0, v8
-; GFX6-NEXT:    v_ashr_i64 v[0:1], v[6:7], s0
+; GFX6-NEXT:    v_ashrrev_i32_e32 v1, 31, v7
+; GFX6-NEXT:    v_add_i32_e32 v2, vcc, 0, v1
+; GFX6-NEXT:    v_addc_u32_e32 v3, vcc, 0, v1, vcc
+; GFX6-NEXT:    v_xor_b32_e32 v0, v0, v8
 ; GFX6-NEXT:    v_bfrev_b32_e32 v8, 1
-; GFX6-NEXT:    v_add_i32_e32 v0, vcc, 0, v0
-; GFX6-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; GFX6-NEXT:    v_addc_u32_e32 v9, vcc, 0, v3, vcc
-; GFX6-NEXT:    v_addc_u32_e32 v3, vcc, v3, v8, vcc
-; GFX6-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX6-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX6-NEXT:    v_addc_u32_e32 v9, vcc, 0, v1, vcc
+; GFX6-NEXT:    v_addc_u32_e32 v8, vcc, v1, v8, vcc
+; GFX6-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v4, v2, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v1, v5, v3, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v2, v6, v9, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v3, v7, v8, vcc
 ; GFX6-NEXT:    ; return to shader part epilog
 ;
 ; GFX8-LABEL: ssubsat_i128_sv:
@@ -5088,7 +5078,6 @@ define amdgpu_ps <4 x float> @ssubsat_i128_sv(i128 inreg %lhs, i128 %rhs) {
 ; GFX8-NEXT:    v_subb_u32_e32 v6, vcc, v6, v2, vcc
 ; GFX8-NEXT:    v_subb_u32_e32 v7, vcc, v7, v3, vcc
 ; GFX8-NEXT:    v_cmp_gt_u64_e32 vcc, s[0:1], v[4:5]
-; GFX8-NEXT:    s_sub_i32 s0, 0x7f, 64
 ; GFX8-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
 ; GFX8-NEXT:    v_cmp_gt_i64_e32 vcc, s[2:3], v[6:7]
 ; GFX8-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
@@ -5099,21 +5088,20 @@ define amdgpu_ps <4 x float> @ssubsat_i128_sv(i128 inreg %lhs, i128 %rhs) {
 ; GFX8-NEXT:    v_cmp_lt_i64_e32 vcc, 0, v[2:3]
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GFX8-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[2:3]
-; GFX8-NEXT:    v_ashrrev_i32_e32 v3, 31, v7
 ; GFX8-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
-; GFX8-NEXT:    v_xor_b32_e32 v2, v0, v8
-; GFX8-NEXT:    v_ashrrev_i64 v[0:1], s0, v[6:7]
+; GFX8-NEXT:    v_ashrrev_i32_e32 v1, 31, v7
+; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 0, v1
+; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, 0, v1, vcc
+; GFX8-NEXT:    v_xor_b32_e32 v0, v0, v8
 ; GFX8-NEXT:    v_bfrev_b32_e32 v8, 1
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 0, v0
-; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v9, vcc, 0, v3, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, v3, v8, vcc
-; GFX8-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX8-NEXT:    v_addc_u32_e32 v9, vcc, 0, v1, vcc
+; GFX8-NEXT:    v_addc_u32_e32 v8, vcc, v1, v8, vcc
+; GFX8-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v4, v2, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v3, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v2, v6, v9, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v7, v8, vcc
 ; GFX8-NEXT:    ; return to shader part epilog
 ;
 ; GFX9-LABEL: ssubsat_i128_sv:
@@ -5126,7 +5114,6 @@ define amdgpu_ps <4 x float> @ssubsat_i128_sv(i128 inreg %lhs, i128 %rhs) {
 ; GFX9-NEXT:    v_subb_co_u32_e32 v6, vcc, v6, v2, vcc
 ; GFX9-NEXT:    v_subb_co_u32_e32 v7, vcc, v7, v3, vcc
 ; GFX9-NEXT:    v_cmp_gt_u64_e32 vcc, s[0:1], v[4:5]
-; GFX9-NEXT:    s_sub_i32 s0, 0x7f, 64
 ; GFX9-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
 ; GFX9-NEXT:    v_cmp_gt_i64_e32 vcc, s[2:3], v[6:7]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
@@ -5137,21 +5124,20 @@ define amdgpu_ps <4 x float> @ssubsat_i128_sv(i128 inreg %lhs, i128 %rhs) {
 ; GFX9-NEXT:    v_cmp_lt_i64_e32 vcc, 0, v[2:3]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GFX9-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[2:3]
-; GFX9-NEXT:    v_ashrrev_i32_e32 v3, 31, v7
 ; GFX9-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
-; GFX9-NEXT:    v_xor_b32_e32 v2, v0, v8
-; GFX9-NEXT:    v_ashrrev_i64 v[0:1], s0, v[6:7]
+; GFX9-NEXT:    v_ashrrev_i32_e32 v1, 31, v7
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, 0, v1
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v1, vcc
+; GFX9-NEXT:    v_xor_b32_e32 v0, v0, v8
 ; GFX9-NEXT:    v_bfrev_b32_e32 v8, 1
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, 0, v0
-; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v1, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v9, vcc, 0, v3, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v8, vcc
-; GFX9-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v9, vcc, 0, v1, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v8, vcc, v1, v8, vcc
+; GFX9-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v3, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v2, v6, v9, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v7, v8, vcc
 ; GFX9-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-LABEL: ssubsat_i128_sv:
@@ -5161,7 +5147,6 @@ define amdgpu_ps <4 x float> @ssubsat_i128_sv(i128 inreg %lhs, i128 %rhs) {
 ; GFX10-NEXT:    v_sub_co_ci_u32_e32 v6, vcc_lo, s2, v2, vcc_lo
 ; GFX10-NEXT:    v_sub_co_ci_u32_e32 v7, vcc_lo, s3, v3, vcc_lo
 ; GFX10-NEXT:    v_cmp_gt_u64_e32 vcc_lo, s[0:1], v[4:5]
-; GFX10-NEXT:    s_sub_i32 s0, 0x7f, 64
 ; GFX10-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc_lo
 ; GFX10-NEXT:    v_cmp_gt_i64_e32 vcc_lo, s[2:3], v[6:7]
 ; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc_lo
@@ -5172,20 +5157,19 @@ define amdgpu_ps <4 x float> @ssubsat_i128_sv(i128 inreg %lhs, i128 %rhs) {
 ; GFX10-NEXT:    v_cmp_eq_u64_e32 vcc_lo, s[2:3], v[6:7]
 ; GFX10-NEXT:    v_cndmask_b32_e32 v8, v9, v8, vcc_lo
 ; GFX10-NEXT:    v_cmp_eq_u64_e32 vcc_lo, 0, v[2:3]
-; GFX10-NEXT:    v_ashrrev_i32_e32 v3, 31, v7
 ; GFX10-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
-; GFX10-NEXT:    v_xor_b32_e32 v2, v0, v8
-; GFX10-NEXT:    v_ashrrev_i64 v[0:1], s0, v[6:7]
-; GFX10-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX10-NEXT:    v_add_co_u32 v0, vcc_lo, v0, 0
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v1, vcc_lo, 0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, v2
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v2, vcc_lo, 0, v3, vcc_lo
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v3, vcc_lo, 0x80000000, v3, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v6, v2, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v7, v3, s0
+; GFX10-NEXT:    v_ashrrev_i32_e32 v1, 31, v7
+; GFX10-NEXT:    v_xor_b32_e32 v0, v0, v8
+; GFX10-NEXT:    v_add_co_u32 v2, vcc_lo, v1, 0
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v3, vcc_lo, 0, v1, vcc_lo
+; GFX10-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v8, vcc_lo, 0, v1, vcc_lo
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v9, vcc_lo, 0x80000000, v1, vcc_lo
+; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, v0
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, v2, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, v3, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, v6, v8, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, v7, v9, s0
 ; GFX10-NEXT:    ; return to shader part epilog
   %result = call i128 @llvm.ssub.sat.i128(i128 %lhs, i128 %rhs)
   %cast = bitcast i128 %result to <4 x float>
@@ -5209,26 +5193,24 @@ define amdgpu_ps <4 x float> @ssubsat_i128_vs(i128 %lhs, i128 inreg %rhs) {
 ; GFX6-NEXT:    v_bfrev_b32_e32 v8, 1
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_eq_u64_e32 vcc, v[6:7], v[2:3]
-; GFX6-NEXT:    v_ashrrev_i32_e32 v3, 31, v7
 ; GFX6-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[0:1]
 ; GFX6-NEXT:    v_cmp_gt_i64_e64 s[0:1], s[2:3], 0
 ; GFX6-NEXT:    v_cmp_eq_u64_e64 vcc, s[2:3], 0
 ; GFX6-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[0:1]
 ; GFX6-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX6-NEXT:    s_sub_i32 s0, 0x7f, 64
-; GFX6-NEXT:    v_xor_b32_e32 v2, v1, v0
-; GFX6-NEXT:    v_ashr_i64 v[0:1], v[6:7], s0
-; GFX6-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX6-NEXT:    v_add_i32_e32 v0, vcc, 0, v0
-; GFX6-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; GFX6-NEXT:    v_addc_u32_e32 v9, vcc, 0, v3, vcc
-; GFX6-NEXT:    v_addc_u32_e32 v3, vcc, v3, v8, vcc
-; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX6-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX6-NEXT:    v_xor_b32_e32 v0, v1, v0
+; GFX6-NEXT:    v_ashrrev_i32_e32 v1, 31, v7
+; GFX6-NEXT:    v_add_i32_e32 v2, vcc, 0, v1
+; GFX6-NEXT:    v_addc_u32_e32 v3, vcc, 0, v1, vcc
+; GFX6-NEXT:    v_addc_u32_e32 v9, vcc, 0, v1, vcc
+; GFX6-NEXT:    v_addc_u32_e32 v8, vcc, v1, v8, vcc
+; GFX6-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v4, v2, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v1, v5, v3, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v2, v6, v9, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v3, v7, v8, vcc
 ; GFX6-NEXT:    ; return to shader part epilog
 ;
 ; GFX8-LABEL: ssubsat_i128_vs:
@@ -5251,25 +5233,23 @@ define amdgpu_ps <4 x float> @ssubsat_i128_vs(i128 %lhs, i128 inreg %rhs) {
 ; GFX8-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[0:1]
 ; GFX8-NEXT:    v_cmp_gt_i64_e64 s[0:1], s[2:3], 0
-; GFX8-NEXT:    v_ashrrev_i32_e32 v3, 31, v7
+; GFX8-NEXT:    v_bfrev_b32_e32 v8, 1
 ; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[0:1]
 ; GFX8-NEXT:    s_and_b32 s0, 1, s4
 ; GFX8-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s0
 ; GFX8-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX8-NEXT:    s_sub_i32 s0, 0x7f, 64
-; GFX8-NEXT:    v_xor_b32_e32 v2, v1, v0
-; GFX8-NEXT:    v_ashrrev_i64 v[0:1], s0, v[6:7]
-; GFX8-NEXT:    v_bfrev_b32_e32 v8, 1
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 0, v0
-; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v9, vcc, 0, v3, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, v3, v8, vcc
-; GFX8-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX8-NEXT:    v_xor_b32_e32 v0, v1, v0
+; GFX8-NEXT:    v_ashrrev_i32_e32 v1, 31, v7
+; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 0, v1
+; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, 0, v1, vcc
+; GFX8-NEXT:    v_addc_u32_e32 v9, vcc, 0, v1, vcc
+; GFX8-NEXT:    v_addc_u32_e32 v8, vcc, v1, v8, vcc
+; GFX8-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v4, v2, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v3, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v2, v6, v9, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v7, v8, vcc
 ; GFX8-NEXT:    ; return to shader part epilog
 ;
 ; GFX9-LABEL: ssubsat_i128_vs:
@@ -5292,25 +5272,23 @@ define amdgpu_ps <4 x float> @ssubsat_i128_vs(i128 %lhs, i128 inreg %rhs) {
 ; GFX9-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[0:1]
 ; GFX9-NEXT:    v_cmp_gt_i64_e64 s[0:1], s[2:3], 0
-; GFX9-NEXT:    v_ashrrev_i32_e32 v3, 31, v7
+; GFX9-NEXT:    v_bfrev_b32_e32 v8, 1
 ; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[0:1]
 ; GFX9-NEXT:    s_and_b32 s0, 1, s4
 ; GFX9-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s0
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX9-NEXT:    s_sub_i32 s0, 0x7f, 64
-; GFX9-NEXT:    v_xor_b32_e32 v2, v1, v0
-; GFX9-NEXT:    v_ashrrev_i64 v[0:1], s0, v[6:7]
-; GFX9-NEXT:    v_bfrev_b32_e32 v8, 1
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, 0, v0
-; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v1, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v9, vcc, 0, v3, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v8, vcc
-; GFX9-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX9-NEXT:    v_xor_b32_e32 v0, v1, v0
+; GFX9-NEXT:    v_ashrrev_i32_e32 v1, 31, v7
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, 0, v1
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v1, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v9, vcc, 0, v1, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v8, vcc, v1, v8, vcc
+; GFX9-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v3, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v2, v6, v9, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v7, v8, vcc
 ; GFX9-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-LABEL: ssubsat_i128_vs:
@@ -5331,23 +5309,21 @@ define amdgpu_ps <4 x float> @ssubsat_i128_vs(i128 %lhs, i128 inreg %rhs) {
 ; GFX10-NEXT:    s_and_b32 s0, 1, s4
 ; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc_lo
 ; GFX10-NEXT:    v_cmp_eq_u64_e32 vcc_lo, v[6:7], v[2:3]
-; GFX10-NEXT:    v_ashrrev_i32_e32 v3, 31, v7
 ; GFX10-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
 ; GFX10-NEXT:    v_cmp_ne_u32_e64 vcc_lo, 0, s0
-; GFX10-NEXT:    s_sub_i32 s0, 0x7f, 64
 ; GFX10-NEXT:    v_cndmask_b32_e32 v1, v9, v8, vcc_lo
-; GFX10-NEXT:    v_xor_b32_e32 v2, v1, v0
-; GFX10-NEXT:    v_ashrrev_i64 v[0:1], s0, v[6:7]
-; GFX10-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX10-NEXT:    v_add_co_u32 v0, vcc_lo, v0, 0
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v1, vcc_lo, 0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, v2
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v2, vcc_lo, 0, v3, vcc_lo
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v3, vcc_lo, 0x80000000, v3, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v6, v2, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v7, v3, s0
+; GFX10-NEXT:    v_xor_b32_e32 v0, v1, v0
+; GFX10-NEXT:    v_ashrrev_i32_e32 v1, 31, v7
+; GFX10-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX10-NEXT:    v_add_co_u32 v2, vcc_lo, v1, 0
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v3, vcc_lo, 0, v1, vcc_lo
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v8, vcc_lo, 0, v1, vcc_lo
+; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, v0
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v9, vcc_lo, 0x80000000, v1, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, v2, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, v3, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, v6, v8, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, v7, v9, s0
 ; GFX10-NEXT:    ; return to shader part epilog
   %result = call i128 @llvm.ssub.sat.i128(i128 %lhs, i128 %rhs)
   %cast = bitcast i128 %result to <4 x float>
@@ -5363,13 +5339,11 @@ define <2 x i128> @v_ssubsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX6-NEXT:    v_subb_u32_e32 v18, vcc, v2, v10, vcc
 ; GFX6-NEXT:    v_subb_u32_e32 v19, vcc, v3, v11, vcc
 ; GFX6-NEXT:    v_cmp_lt_u64_e32 vcc, v[16:17], v[0:1]
-; GFX6-NEXT:    s_sub_i32 s4, 0x7f, 64
+; GFX6-NEXT:    v_bfrev_b32_e32 v20, 1
 ; GFX6-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_lt_i64_e32 vcc, v[18:19], v[2:3]
-; GFX6-NEXT:    v_bfrev_b32_e32 v20, 1
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_eq_u64_e32 vcc, v[18:19], v[2:3]
-; GFX6-NEXT:    v_ashrrev_i32_e32 v3, 31, v19
 ; GFX6-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
 ; GFX6-NEXT:    v_cmp_lt_u64_e32 vcc, 0, v[8:9]
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
@@ -5377,18 +5351,18 @@ define <2 x i128> @v_ssubsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX6-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[10:11]
 ; GFX6-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX6-NEXT:    v_xor_b32_e32 v2, v1, v0
-; GFX6-NEXT:    v_ashr_i64 v[0:1], v[18:19], s4
-; GFX6-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX6-NEXT:    v_add_i32_e32 v0, vcc, 0, v0
-; GFX6-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; GFX6-NEXT:    v_addc_u32_e32 v8, vcc, 0, v3, vcc
-; GFX6-NEXT:    v_addc_u32_e32 v3, vcc, v3, v20, vcc
-; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX6-NEXT:    v_cndmask_b32_e32 v0, v16, v0, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v1, v17, v1, vcc
+; GFX6-NEXT:    v_xor_b32_e32 v0, v1, v0
+; GFX6-NEXT:    v_ashrrev_i32_e32 v1, 31, v19
+; GFX6-NEXT:    v_add_i32_e32 v2, vcc, 0, v1
+; GFX6-NEXT:    v_addc_u32_e32 v3, vcc, 0, v1, vcc
+; GFX6-NEXT:    v_addc_u32_e32 v8, vcc, 0, v1, vcc
+; GFX6-NEXT:    v_addc_u32_e32 v9, vcc, v1, v20, vcc
+; GFX6-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GFX6-NEXT:    v_cndmask_b32_e32 v0, v16, v2, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v1, v17, v3, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v2, v18, v8, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v3, v19, v3, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v3, v19, v9, vcc
 ; GFX6-NEXT:    v_sub_i32_e32 v8, vcc, v4, v12
 ; GFX6-NEXT:    v_subb_u32_e32 v9, vcc, v5, v13, vcc
 ; GFX6-NEXT:    v_subb_u32_e32 v10, vcc, v6, v14, vcc
@@ -5398,7 +5372,6 @@ define <2 x i128> @v_ssubsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX6-NEXT:    v_cmp_lt_i64_e32 vcc, v[10:11], v[6:7]
 ; GFX6-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_eq_u64_e32 vcc, v[10:11], v[6:7]
-; GFX6-NEXT:    v_ashrrev_i32_e32 v7, 31, v11
 ; GFX6-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
 ; GFX6-NEXT:    v_cmp_lt_u64_e32 vcc, 0, v[12:13]
 ; GFX6-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
@@ -5406,18 +5379,18 @@ define <2 x i128> @v_ssubsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX6-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[14:15]
 ; GFX6-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc
-; GFX6-NEXT:    v_xor_b32_e32 v6, v5, v4
-; GFX6-NEXT:    v_ashr_i64 v[4:5], v[10:11], s4
-; GFX6-NEXT:    v_and_b32_e32 v6, 1, v6
-; GFX6-NEXT:    v_add_i32_e32 v4, vcc, 0, v4
-; GFX6-NEXT:    v_addc_u32_e32 v5, vcc, 0, v5, vcc
-; GFX6-NEXT:    v_addc_u32_e32 v12, vcc, 0, v7, vcc
-; GFX6-NEXT:    v_addc_u32_e32 v7, vcc, v7, v20, vcc
-; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
-; GFX6-NEXT:    v_cndmask_b32_e32 v4, v8, v4, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v5, v9, v5, vcc
+; GFX6-NEXT:    v_xor_b32_e32 v4, v5, v4
+; GFX6-NEXT:    v_ashrrev_i32_e32 v5, 31, v11
+; GFX6-NEXT:    v_add_i32_e32 v6, vcc, 0, v5
+; GFX6-NEXT:    v_addc_u32_e32 v7, vcc, 0, v5, vcc
+; GFX6-NEXT:    v_addc_u32_e32 v12, vcc, 0, v5, vcc
+; GFX6-NEXT:    v_addc_u32_e32 v13, vcc, v5, v20, vcc
+; GFX6-NEXT:    v_and_b32_e32 v4, 1, v4
+; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; GFX6-NEXT:    v_cndmask_b32_e32 v4, v8, v6, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v5, v9, v7, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e32 v6, v10, v12, vcc
-; GFX6-NEXT:    v_cndmask_b32_e32 v7, v11, v7, vcc
+; GFX6-NEXT:    v_cndmask_b32_e32 v7, v11, v13, vcc
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_ssubsat_v2i128:
@@ -5428,13 +5401,11 @@ define <2 x i128> @v_ssubsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX8-NEXT:    v_subb_u32_e32 v18, vcc, v2, v10, vcc
 ; GFX8-NEXT:    v_subb_u32_e32 v19, vcc, v3, v11, vcc
 ; GFX8-NEXT:    v_cmp_lt_u64_e32 vcc, v[16:17], v[0:1]
-; GFX8-NEXT:    s_sub_i32 s4, 0x7f, 64
+; GFX8-NEXT:    v_bfrev_b32_e32 v20, 1
 ; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GFX8-NEXT:    v_cmp_lt_i64_e32 vcc, v[18:19], v[2:3]
-; GFX8-NEXT:    v_bfrev_b32_e32 v20, 1
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GFX8-NEXT:    v_cmp_eq_u64_e32 vcc, v[18:19], v[2:3]
-; GFX8-NEXT:    v_ashrrev_i32_e32 v3, 31, v19
 ; GFX8-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
 ; GFX8-NEXT:    v_cmp_lt_u64_e32 vcc, 0, v[8:9]
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
@@ -5442,18 +5413,18 @@ define <2 x i128> @v_ssubsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX8-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[10:11]
 ; GFX8-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX8-NEXT:    v_xor_b32_e32 v2, v1, v0
-; GFX8-NEXT:    v_ashrrev_i64 v[0:1], s4, v[18:19]
-; GFX8-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 0, v0
-; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v8, vcc, 0, v3, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, v3, v20, vcc
-; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v16, v0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v17, v1, vcc
+; GFX8-NEXT:    v_xor_b32_e32 v0, v1, v0
+; GFX8-NEXT:    v_ashrrev_i32_e32 v1, 31, v19
+; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 0, v1
+; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, 0, v1, vcc
+; GFX8-NEXT:    v_addc_u32_e32 v8, vcc, 0, v1, vcc
+; GFX8-NEXT:    v_addc_u32_e32 v9, vcc, v1, v20, vcc
+; GFX8-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v16, v2, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v17, v3, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v2, v18, v8, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v19, v3, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v19, v9, vcc
 ; GFX8-NEXT:    v_sub_u32_e32 v8, vcc, v4, v12
 ; GFX8-NEXT:    v_subb_u32_e32 v9, vcc, v5, v13, vcc
 ; GFX8-NEXT:    v_subb_u32_e32 v10, vcc, v6, v14, vcc
@@ -5463,7 +5434,6 @@ define <2 x i128> @v_ssubsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX8-NEXT:    v_cmp_lt_i64_e32 vcc, v[10:11], v[6:7]
 ; GFX8-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GFX8-NEXT:    v_cmp_eq_u64_e32 vcc, v[10:11], v[6:7]
-; GFX8-NEXT:    v_ashrrev_i32_e32 v7, 31, v11
 ; GFX8-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
 ; GFX8-NEXT:    v_cmp_lt_u64_e32 vcc, 0, v[12:13]
 ; GFX8-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
@@ -5471,18 +5441,18 @@ define <2 x i128> @v_ssubsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; GFX8-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[14:15]
 ; GFX8-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc
-; GFX8-NEXT:    v_xor_b32_e32 v6, v5, v4
-; GFX8-NEXT:    v_ashrrev_i64 v[4:5], s4, v[10:11]
-; GFX8-NEXT:    v_and_b32_e32 v6, 1, v6
-; GFX8-NEXT:    v_add_u32_e32 v4, vcc, 0, v4
-; GFX8-NEXT:    v_addc_u32_e32 v5, vcc, 0, v5, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v12, vcc, 0, v7, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v7, vcc, v7, v20, vcc
-; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v8, v4, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v9, v5, vcc
+; GFX8-NEXT:    v_xor_b32_e32 v4, v5, v4
+; GFX8-NEXT:    v_ashrrev_i32_e32 v5, 31, v11
+; GFX8-NEXT:    v_add_u32_e32 v6, vcc, 0, v5
+; GFX8-NEXT:    v_addc_u32_e32 v7, vcc, 0, v5, vcc
+; GFX8-NEXT:    v_addc_u32_e32 v12, vcc, 0, v5, vcc
+; GFX8-NEXT:    v_addc_u32_e32 v13, vcc, v5, v20, vcc
+; GFX8-NEXT:    v_and_b32_e32 v4, 1, v4
+; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; GFX8-NEXT:    v_cndmask_b32_e32 v4, v8, v6, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v5, v9, v7, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v6, v10, v12, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v7, v11, v7, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v7, v11, v13, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_ssubsat_v2i128:
@@ -5493,13 +5463,11 @@ define <2 x i128> @v_ssubsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX9-NEXT:    v_subb_co_u32_e32 v18, vcc, v2, v10, vcc
 ; GFX9-NEXT:    v_subb_co_u32_e32 v19, vcc, v3, v11, vcc
 ; GFX9-NEXT:    v_cmp_lt_u64_e32 vcc, v[16:17], v[0:1]
-; GFX9-NEXT:    s_sub_i32 s4, 0x7f, 64
+; GFX9-NEXT:    v_bfrev_b32_e32 v20, 1
 ; GFX9-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GFX9-NEXT:    v_cmp_lt_i64_e32 vcc, v[18:19], v[2:3]
-; GFX9-NEXT:    v_bfrev_b32_e32 v20, 1
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GFX9-NEXT:    v_cmp_eq_u64_e32 vcc, v[18:19], v[2:3]
-; GFX9-NEXT:    v_ashrrev_i32_e32 v3, 31, v19
 ; GFX9-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
 ; GFX9-NEXT:    v_cmp_lt_u64_e32 vcc, 0, v[8:9]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
@@ -5507,18 +5475,18 @@ define <2 x i128> @v_ssubsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX9-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[10:11]
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX9-NEXT:    v_xor_b32_e32 v2, v1, v0
-; GFX9-NEXT:    v_ashrrev_i64 v[0:1], s4, v[18:19]
-; GFX9-NEXT:    v_and_b32_e32 v2, 1, v2
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, 0, v0
-; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v1, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v8, vcc, 0, v3, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v20, vcc
-; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v16, v0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v17, v1, vcc
+; GFX9-NEXT:    v_xor_b32_e32 v0, v1, v0
+; GFX9-NEXT:    v_ashrrev_i32_e32 v1, 31, v19
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, 0, v1
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v1, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v8, vcc, 0, v1, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v9, vcc, v1, v20, vcc
+; GFX9-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v16, v2, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v17, v3, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v2, v18, v8, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v19, v3, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v19, v9, vcc
 ; GFX9-NEXT:    v_sub_co_u32_e32 v8, vcc, v4, v12
 ; GFX9-NEXT:    v_subb_co_u32_e32 v9, vcc, v5, v13, vcc
 ; GFX9-NEXT:    v_subb_co_u32_e32 v10, vcc, v6, v14, vcc
@@ -5528,7 +5496,6 @@ define <2 x i128> @v_ssubsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX9-NEXT:    v_cmp_lt_i64_e32 vcc, v[10:11], v[6:7]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GFX9-NEXT:    v_cmp_eq_u64_e32 vcc, v[10:11], v[6:7]
-; GFX9-NEXT:    v_ashrrev_i32_e32 v7, 31, v11
 ; GFX9-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
 ; GFX9-NEXT:    v_cmp_lt_u64_e32 vcc, 0, v[12:13]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
@@ -5536,18 +5503,18 @@ define <2 x i128> @v_ssubsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; GFX9-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[14:15]
 ; GFX9-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc
-; GFX9-NEXT:    v_xor_b32_e32 v6, v5, v4
-; GFX9-NEXT:    v_ashrrev_i64 v[4:5], s4, v[10:11]
-; GFX9-NEXT:    v_and_b32_e32 v6, 1, v6
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, 0, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v12, vcc, 0, v7, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, v7, v20, vcc
-; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v8, v4, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v9, v5, vcc
+; GFX9-NEXT:    v_xor_b32_e32 v4, v5, v4
+; GFX9-NEXT:    v_ashrrev_i32_e32 v5, 31, v11
+; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, 0, v5
+; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v5, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v12, vcc, 0, v5, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v13, vcc, v5, v20, vcc
+; GFX9-NEXT:    v_and_b32_e32 v4, 1, v4
+; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; GFX9-NEXT:    v_cndmask_b32_e32 v4, v8, v6, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v5, v9, v7, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v6, v10, v12, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v11, v7, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v7, v11, v13, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_ssubsat_v2i128:
@@ -5555,7 +5522,6 @@ define <2 x i128> @v_ssubsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX10-NEXT:    v_sub_co_u32 v16, vcc_lo, v0, v8
-; GFX10-NEXT:    s_sub_i32 s6, 0x7f, 64
 ; GFX10-NEXT:    v_sub_co_ci_u32_e32 v17, vcc_lo, v1, v9, vcc_lo
 ; GFX10-NEXT:    v_sub_co_ci_u32_e32 v18, vcc_lo, v2, v10, vcc_lo
 ; GFX10-NEXT:    v_sub_co_ci_u32_e32 v19, vcc_lo, v3, v11, vcc_lo
@@ -5568,51 +5534,49 @@ define <2 x i128> @v_ssubsat_v2i128(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GFX10-NEXT:    v_cmp_lt_i64_e32 vcc_lo, 0, v[10:11]
 ; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc_lo
 ; GFX10-NEXT:    v_cmp_eq_u64_e32 vcc_lo, v[18:19], v[2:3]
-; GFX10-NEXT:    v_ashrrev_i32_e32 v3, 31, v19
 ; GFX10-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
 ; GFX10-NEXT:    v_cmp_eq_u64_e32 vcc_lo, 0, v[10:11]
 ; GFX10-NEXT:    v_cndmask_b32_e32 v1, v9, v8, vcc_lo
 ; GFX10-NEXT:    v_sub_co_u32 v8, vcc_lo, v4, v12
 ; GFX10-NEXT:    v_sub_co_ci_u32_e32 v9, vcc_lo, v5, v13, vcc_lo
 ; GFX10-NEXT:    v_sub_co_ci_u32_e32 v10, vcc_lo, v6, v14, vcc_lo
-; GFX10-NEXT:    v_xor_b32_e32 v2, v1, v0
+; GFX10-NEXT:    v_xor_b32_e32 v0, v1, v0
 ; GFX10-NEXT:    v_sub_co_ci_u32_e32 v11, vcc_lo, v7, v15, vcc_lo
 ; GFX10-NEXT:    v_cmp_lt_u64_e64 s4, v[8:9], v[4:5]
-; GFX10-NEXT:    v_ashrrev_i64 v[0:1], s6, v[18:19]
-; GFX10-NEXT:    v_and_b32_e32 v2, 1, v2
+; GFX10-NEXT:    v_ashrrev_i32_e32 v1, 31, v19
+; GFX10-NEXT:    v_and_b32_e32 v0, 1, v0
 ; GFX10-NEXT:    v_cmp_eq_u64_e64 s5, v[10:11], v[6:7]
 ; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s4
 ; GFX10-NEXT:    v_cmp_lt_i64_e64 s4, v[10:11], v[6:7]
-; GFX10-NEXT:    v_add_co_u32 v0, vcc_lo, v0, 0
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v1, vcc_lo, 0, v1, vcc_lo
+; GFX10-NEXT:    v_add_co_u32 v2, vcc_lo, v1, 0
+; GFX10-NEXT:    v_ashrrev_i32_e32 v7, 31, v11
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v3, vcc_lo, 0, v1, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s4
 ; GFX10-NEXT:    v_cmp_lt_u64_e64 s4, 0, v[12:13]
 ; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s4
 ; GFX10-NEXT:    v_cmp_lt_i64_e64 s4, 0, v[14:15]
 ; GFX10-NEXT:    v_cndmask_b32_e64 v13, 0, 1, s4
-; GFX10-NEXT:    v_cmp_ne_u32_e64 s4, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v5, v4, s5
+; GFX10-NEXT:    v_cmp_ne_u32_e64 s4, 0, v0
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v5, v4, s5
 ; GFX10-NEXT:    v_cmp_eq_u64_e64 s5, 0, v[14:15]
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v5, vcc_lo, 0, v3, vcc_lo
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v6, vcc_lo, 0x80000000, v3, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v16, v0, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v17, v1, s4
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v5, vcc_lo, 0, v1, vcc_lo
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v6, vcc_lo, 0x80000000, v1, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, v17, v3, s4
 ; GFX10-NEXT:    v_cndmask_b32_e64 v4, v13, v12, s5
-; GFX10-NEXT:    v_xor_b32_e32 v7, v4, v2
-; GFX10-NEXT:    v_ashrrev_i64 v[3:4], s6, v[10:11]
+; GFX10-NEXT:    v_xor_b32_e32 v4, v4, v0
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v16, v2, s4
 ; GFX10-NEXT:    v_cndmask_b32_e64 v2, v18, v5, s4
-; GFX10-NEXT:    v_ashrrev_i32_e32 v5, 31, v11
-; GFX10-NEXT:    v_and_b32_e32 v7, 1, v7
-; GFX10-NEXT:    v_add_co_u32 v12, vcc_lo, v3, 0
+; GFX10-NEXT:    v_and_b32_e32 v3, 1, v4
+; GFX10-NEXT:    v_add_co_u32 v4, vcc_lo, v7, 0
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v5, vcc_lo, 0, v7, vcc_lo
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v12, vcc_lo, 0, v7, vcc_lo
+; GFX10-NEXT:    v_cmp_ne_u32_e64 s5, 0, v3
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v7, vcc_lo, 0x80000000, v7, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v3, v19, v6, s4
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v13, vcc_lo, 0, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_ne_u32_e64 s5, 0, v7
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v7, vcc_lo, 0, v5, vcc_lo
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v14, vcc_lo, 0x80000000, v5, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v8, v12, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v10, v7, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v9, v13, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v11, v14, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, v8, v4, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, v10, v12, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, v11, v7, s5
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
   %result = call <2 x i128> @llvm.ssub.sat.v2i128(<2 x i128> %lhs, <2 x i128> %rhs)
   ret <2 x i128> %result
@@ -5639,34 +5603,32 @@ define amdgpu_ps <2 x i128> @s_ssubsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s2
 ; GFX6-NEXT:    s_subb_u32 s19, s3, s11
 ; GFX6-NEXT:    v_mov_b32_e32 v1, s3
-; GFX6-NEXT:    v_cmp_gt_u64_e64 s[0:1], s[8:9], 0
 ; GFX6-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_lt_i64_e32 vcc, s[18:19], v[0:1]
-; GFX6-NEXT:    s_sub_i32 s8, 0x7f, 64
+; GFX6-NEXT:    v_cmp_gt_u64_e64 s[0:1], s[8:9], 0
 ; GFX6-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; GFX6-NEXT:    v_cmp_eq_u64_e32 vcc, s[18:19], v[0:1]
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[0:1]
 ; GFX6-NEXT:    v_cmp_gt_i64_e64 s[0:1], s[10:11], 0
+; GFX6-NEXT:    s_ashr_i32 s3, s19, 31
 ; GFX6-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[0:1]
-; GFX6-NEXT:    s_ashr_i32 s3, s19, 31
-; GFX6-NEXT:    s_ashr_i64 s[0:1], s[18:19], s8
-; GFX6-NEXT:    s_add_u32 s0, s0, 0
-; GFX6-NEXT:    s_cselect_b32 s2, 1, 0
-; GFX6-NEXT:    s_and_b32 s2, s2, 1
-; GFX6-NEXT:    s_cmp_lg_u32 s2, 0
-; GFX6-NEXT:    s_addc_u32 s1, s1, 0
+; GFX6-NEXT:    s_add_u32 s0, s3, 0
+; GFX6-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX6-NEXT:    s_and_b32 s1, s1, 1
+; GFX6-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX6-NEXT:    s_addc_u32 s1, s3, 0
 ; GFX6-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX6-NEXT:    s_and_b32 s2, s2, 1
 ; GFX6-NEXT:    s_cmp_lg_u32 s2, 0
 ; GFX6-NEXT:    s_addc_u32 s2, s3, 0
+; GFX6-NEXT:    s_cselect_b32 s9, 1, 0
+; GFX6-NEXT:    s_and_b32 s9, s9, 1
 ; GFX6-NEXT:    v_cmp_eq_u64_e64 vcc, s[10:11], 0
-; GFX6-NEXT:    s_cselect_b32 s10, 1, 0
-; GFX6-NEXT:    s_and_b32 s10, s10, 1
-; GFX6-NEXT:    s_brev_b32 s9, 1
-; GFX6-NEXT:    s_cmp_lg_u32 s10, 0
+; GFX6-NEXT:    s_brev_b32 s8, 1
+; GFX6-NEXT:    s_cmp_lg_u32 s9, 0
 ; GFX6-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX6-NEXT:    s_addc_u32 s3, s3, s9
+; GFX6-NEXT:    s_addc_u32 s3, s3, s8
 ; GFX6-NEXT:    v_xor_b32_e32 v0, v1, v0
 ; GFX6-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX6-NEXT:    s_sub_u32 s0, s4, s12
@@ -5707,29 +5669,28 @@ define amdgpu_ps <2 x i128> @s_ssubsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX6-NEXT:    v_cmp_eq_u64_e32 vcc, s[2:3], v[0:1]
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
 ; GFX6-NEXT:    v_cmp_gt_i64_e64 s[4:5], s[14:15], 0
+; GFX6-NEXT:    s_ashr_i32 s7, s3, 31
 ; GFX6-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX6-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[4:5]
-; GFX6-NEXT:    s_ashr_i32 s7, s3, 31
-; GFX6-NEXT:    s_ashr_i64 s[4:5], s[2:3], s8
-; GFX6-NEXT:    s_add_u32 s4, s4, 0
-; GFX6-NEXT:    s_cselect_b32 s6, 1, 0
-; GFX6-NEXT:    s_and_b32 s6, s6, 1
-; GFX6-NEXT:    s_cmp_lg_u32 s6, 0
-; GFX6-NEXT:    s_addc_u32 s5, s5, 0
+; GFX6-NEXT:    s_add_u32 s4, s7, 0
+; GFX6-NEXT:    s_cselect_b32 s5, 1, 0
+; GFX6-NEXT:    s_and_b32 s5, s5, 1
+; GFX6-NEXT:    s_cmp_lg_u32 s5, 0
+; GFX6-NEXT:    s_addc_u32 s5, s7, 0
 ; GFX6-NEXT:    s_cselect_b32 s6, 1, 0
 ; GFX6-NEXT:    s_and_b32 s6, s6, 1
 ; GFX6-NEXT:    s_cmp_lg_u32 s6, 0
 ; GFX6-NEXT:    v_cmp_eq_u64_e64 vcc, s[14:15], 0
 ; GFX6-NEXT:    s_addc_u32 s6, s7, 0
-; GFX6-NEXT:    s_cselect_b32 s8, 1, 0
+; GFX6-NEXT:    s_cselect_b32 s9, 1, 0
 ; GFX6-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
 ; GFX6-NEXT:    v_xor_b32_e32 v0, v1, v0
-; GFX6-NEXT:    s_and_b32 s8, s8, 1
-; GFX6-NEXT:    s_cmp_lg_u32 s8, 0
+; GFX6-NEXT:    s_and_b32 s9, s9, 1
+; GFX6-NEXT:    s_cmp_lg_u32 s9, 0
 ; GFX6-NEXT:    v_and_b32_e32 v0, 1, v0
 ; GFX6-NEXT:    v_mov_b32_e32 v3, s0
 ; GFX6-NEXT:    v_mov_b32_e32 v8, s1
-; GFX6-NEXT:    s_addc_u32 s7, s7, s9
+; GFX6-NEXT:    s_addc_u32 s7, s7, s8
 ; GFX6-NEXT:    v_mov_b32_e32 v1, s4
 ; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
 ; GFX6-NEXT:    v_mov_b32_e32 v2, s5
@@ -5786,25 +5747,23 @@ define amdgpu_ps <2 x i128> @s_ssubsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[0:1]
 ; GFX8-NEXT:    s_and_b32 s0, 1, s2
-; GFX8-NEXT:    s_sub_i32 s8, 0x7f, 64
-; GFX8-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s0
 ; GFX8-NEXT:    s_ashr_i32 s3, s19, 31
-; GFX8-NEXT:    s_ashr_i64 s[0:1], s[18:19], s8
-; GFX8-NEXT:    s_add_u32 s0, s0, 0
-; GFX8-NEXT:    s_cselect_b32 s2, 1, 0
-; GFX8-NEXT:    s_and_b32 s2, s2, 1
-; GFX8-NEXT:    s_cmp_lg_u32 s2, 0
-; GFX8-NEXT:    s_addc_u32 s1, s1, 0
+; GFX8-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s0
+; GFX8-NEXT:    s_add_u32 s0, s3, 0
+; GFX8-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX8-NEXT:    s_and_b32 s1, s1, 1
+; GFX8-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX8-NEXT:    s_addc_u32 s1, s3, 0
 ; GFX8-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX8-NEXT:    s_and_b32 s2, s2, 1
 ; GFX8-NEXT:    s_cmp_lg_u32 s2, 0
 ; GFX8-NEXT:    s_addc_u32 s2, s3, 0
-; GFX8-NEXT:    s_cselect_b32 s10, 1, 0
-; GFX8-NEXT:    s_and_b32 s10, s10, 1
-; GFX8-NEXT:    s_brev_b32 s9, 1
-; GFX8-NEXT:    s_cmp_lg_u32 s10, 0
+; GFX8-NEXT:    s_cselect_b32 s9, 1, 0
+; GFX8-NEXT:    s_and_b32 s9, s9, 1
+; GFX8-NEXT:    s_brev_b32 s8, 1
+; GFX8-NEXT:    s_cmp_lg_u32 s9, 0
 ; GFX8-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX8-NEXT:    s_addc_u32 s3, s3, s9
+; GFX8-NEXT:    s_addc_u32 s3, s3, s8
 ; GFX8-NEXT:    v_xor_b32_e32 v0, v1, v0
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX8-NEXT:    s_sub_u32 s0, s4, s12
@@ -5853,27 +5812,26 @@ define amdgpu_ps <2 x i128> @s_ssubsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[4:5]
 ; GFX8-NEXT:    s_and_b32 s4, 1, s6
-; GFX8-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s4
 ; GFX8-NEXT:    s_ashr_i32 s7, s3, 31
-; GFX8-NEXT:    s_ashr_i64 s[4:5], s[2:3], s8
-; GFX8-NEXT:    s_add_u32 s4, s4, 0
-; GFX8-NEXT:    s_cselect_b32 s6, 1, 0
-; GFX8-NEXT:    s_and_b32 s6, s6, 1
-; GFX8-NEXT:    s_cmp_lg_u32 s6, 0
-; GFX8-NEXT:    s_addc_u32 s5, s5, 0
+; GFX8-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s4
+; GFX8-NEXT:    s_add_u32 s4, s7, 0
+; GFX8-NEXT:    s_cselect_b32 s5, 1, 0
+; GFX8-NEXT:    s_and_b32 s5, s5, 1
+; GFX8-NEXT:    s_cmp_lg_u32 s5, 0
+; GFX8-NEXT:    s_addc_u32 s5, s7, 0
 ; GFX8-NEXT:    s_cselect_b32 s6, 1, 0
 ; GFX8-NEXT:    s_and_b32 s6, s6, 1
 ; GFX8-NEXT:    s_cmp_lg_u32 s6, 0
 ; GFX8-NEXT:    s_addc_u32 s6, s7, 0
-; GFX8-NEXT:    s_cselect_b32 s8, 1, 0
+; GFX8-NEXT:    s_cselect_b32 s9, 1, 0
 ; GFX8-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
 ; GFX8-NEXT:    v_xor_b32_e32 v0, v1, v0
-; GFX8-NEXT:    s_and_b32 s8, s8, 1
-; GFX8-NEXT:    s_cmp_lg_u32 s8, 0
+; GFX8-NEXT:    s_and_b32 s9, s9, 1
+; GFX8-NEXT:    s_cmp_lg_u32 s9, 0
 ; GFX8-NEXT:    v_and_b32_e32 v0, 1, v0
 ; GFX8-NEXT:    v_mov_b32_e32 v3, s0
 ; GFX8-NEXT:    v_mov_b32_e32 v8, s1
-; GFX8-NEXT:    s_addc_u32 s7, s7, s9
+; GFX8-NEXT:    s_addc_u32 s7, s7, s8
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s4
 ; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
 ; GFX8-NEXT:    v_mov_b32_e32 v2, s5
@@ -5930,25 +5888,23 @@ define amdgpu_ps <2 x i128> @s_ssubsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[0:1]
 ; GFX9-NEXT:    s_and_b32 s0, 1, s2
-; GFX9-NEXT:    s_sub_i32 s8, 0x7f, 64
-; GFX9-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s0
 ; GFX9-NEXT:    s_ashr_i32 s3, s19, 31
-; GFX9-NEXT:    s_ashr_i64 s[0:1], s[18:19], s8
-; GFX9-NEXT:    s_add_u32 s0, s0, 0
-; GFX9-NEXT:    s_cselect_b32 s2, 1, 0
-; GFX9-NEXT:    s_and_b32 s2, s2, 1
-; GFX9-NEXT:    s_cmp_lg_u32 s2, 0
-; GFX9-NEXT:    s_addc_u32 s1, s1, 0
+; GFX9-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s0
+; GFX9-NEXT:    s_add_u32 s0, s3, 0
+; GFX9-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX9-NEXT:    s_and_b32 s1, s1, 1
+; GFX9-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX9-NEXT:    s_addc_u32 s1, s3, 0
 ; GFX9-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX9-NEXT:    s_and_b32 s2, s2, 1
 ; GFX9-NEXT:    s_cmp_lg_u32 s2, 0
 ; GFX9-NEXT:    s_addc_u32 s2, s3, 0
-; GFX9-NEXT:    s_cselect_b32 s10, 1, 0
-; GFX9-NEXT:    s_and_b32 s10, s10, 1
-; GFX9-NEXT:    s_brev_b32 s9, 1
-; GFX9-NEXT:    s_cmp_lg_u32 s10, 0
+; GFX9-NEXT:    s_cselect_b32 s9, 1, 0
+; GFX9-NEXT:    s_and_b32 s9, s9, 1
+; GFX9-NEXT:    s_brev_b32 s8, 1
+; GFX9-NEXT:    s_cmp_lg_u32 s9, 0
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX9-NEXT:    s_addc_u32 s3, s3, s9
+; GFX9-NEXT:    s_addc_u32 s3, s3, s8
 ; GFX9-NEXT:    v_xor_b32_e32 v0, v1, v0
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX9-NEXT:    s_sub_u32 s0, s4, s12
@@ -5997,27 +5953,26 @@ define amdgpu_ps <2 x i128> @s_ssubsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[4:5]
 ; GFX9-NEXT:    s_and_b32 s4, 1, s6
-; GFX9-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s4
 ; GFX9-NEXT:    s_ashr_i32 s7, s3, 31
-; GFX9-NEXT:    s_ashr_i64 s[4:5], s[2:3], s8
-; GFX9-NEXT:    s_add_u32 s4, s4, 0
-; GFX9-NEXT:    s_cselect_b32 s6, 1, 0
-; GFX9-NEXT:    s_and_b32 s6, s6, 1
-; GFX9-NEXT:    s_cmp_lg_u32 s6, 0
-; GFX9-NEXT:    s_addc_u32 s5, s5, 0
+; GFX9-NEXT:    v_cmp_ne_u32_e64 vcc, 0, s4
+; GFX9-NEXT:    s_add_u32 s4, s7, 0
+; GFX9-NEXT:    s_cselect_b32 s5, 1, 0
+; GFX9-NEXT:    s_and_b32 s5, s5, 1
+; GFX9-NEXT:    s_cmp_lg_u32 s5, 0
+; GFX9-NEXT:    s_addc_u32 s5, s7, 0
 ; GFX9-NEXT:    s_cselect_b32 s6, 1, 0
 ; GFX9-NEXT:    s_and_b32 s6, s6, 1
 ; GFX9-NEXT:    s_cmp_lg_u32 s6, 0
 ; GFX9-NEXT:    s_addc_u32 s6, s7, 0
-; GFX9-NEXT:    s_cselect_b32 s8, 1, 0
+; GFX9-NEXT:    s_cselect_b32 s9, 1, 0
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
 ; GFX9-NEXT:    v_xor_b32_e32 v0, v1, v0
-; GFX9-NEXT:    s_and_b32 s8, s8, 1
-; GFX9-NEXT:    s_cmp_lg_u32 s8, 0
+; GFX9-NEXT:    s_and_b32 s9, s9, 1
+; GFX9-NEXT:    s_cmp_lg_u32 s9, 0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 1, v0
 ; GFX9-NEXT:    v_mov_b32_e32 v3, s0
 ; GFX9-NEXT:    v_mov_b32_e32 v8, s1
-; GFX9-NEXT:    s_addc_u32 s7, s7, s9
+; GFX9-NEXT:    s_addc_u32 s7, s7, s8
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s4
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
 ; GFX9-NEXT:    v_mov_b32_e32 v2, s5
@@ -6071,30 +6026,28 @@ define amdgpu_ps <2 x i128> @s_ssubsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX10-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s1
 ; GFX10-NEXT:    v_cmp_gt_i64_e64 s1, s[10:11], 0
-; GFX10-NEXT:    s_sub_i32 s10, 0x7f, 64
 ; GFX10-NEXT:    v_cmp_ne_u32_e64 vcc_lo, 0, s0
-; GFX10-NEXT:    s_brev_b32 s11, 1
+; GFX10-NEXT:    s_add_u32 s0, s3, 0
+; GFX10-NEXT:    s_brev_b32 s10, 1
 ; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s1
-; GFX10-NEXT:    s_ashr_i64 s[0:1], s[18:19], s10
-; GFX10-NEXT:    s_add_u32 s0, s0, 0
-; GFX10-NEXT:    s_cselect_b32 s2, 1, 0
+; GFX10-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX10-NEXT:    s_and_b32 s1, s1, 1
 ; GFX10-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc_lo
-; GFX10-NEXT:    s_and_b32 s2, s2, 1
+; GFX10-NEXT:    s_cmp_lg_u32 s1, 0
 ; GFX10-NEXT:    v_mov_b32_e32 v2, s17
-; GFX10-NEXT:    s_cmp_lg_u32 s2, 0
-; GFX10-NEXT:    v_xor_b32_e32 v0, v1, v0
-; GFX10-NEXT:    s_addc_u32 s1, s1, 0
+; GFX10-NEXT:    s_addc_u32 s1, s3, 0
 ; GFX10-NEXT:    s_cselect_b32 s2, 1, 0
-; GFX10-NEXT:    v_mov_b32_e32 v1, s16
+; GFX10-NEXT:    v_xor_b32_e32 v0, v1, v0
 ; GFX10-NEXT:    s_and_b32 s2, s2, 1
-; GFX10-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX10-NEXT:    v_mov_b32_e32 v1, s16
 ; GFX10-NEXT:    s_cmp_lg_u32 s2, 0
+; GFX10-NEXT:    v_and_b32_e32 v0, 1, v0
 ; GFX10-NEXT:    s_addc_u32 s2, s3, 0
 ; GFX10-NEXT:    s_cselect_b32 s8, 1, 0
-; GFX10-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v0
 ; GFX10-NEXT:    s_and_b32 s8, s8, 1
+; GFX10-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v0
 ; GFX10-NEXT:    s_cmp_lg_u32 s8, 0
-; GFX10-NEXT:    s_addc_u32 s3, s3, s11
+; GFX10-NEXT:    s_addc_u32 s3, s3, s10
 ; GFX10-NEXT:    v_cndmask_b32_e64 v0, v1, s0, vcc_lo
 ; GFX10-NEXT:    s_sub_u32 s0, s4, s12
 ; GFX10-NEXT:    s_cselect_b32 s8, 1, 0
@@ -6127,20 +6080,19 @@ define amdgpu_ps <2 x i128> @s_ssubsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s4
 ; GFX10-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX10-NEXT:    s_ashr_i32 s5, s9, 31
-; GFX10-NEXT:    s_and_b32 s4, 1, s2
 ; GFX10-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s3
 ; GFX10-NEXT:    v_cmp_gt_i64_e64 s3, s[14:15], 0
-; GFX10-NEXT:    v_cmp_ne_u32_e64 vcc_lo, 0, s4
 ; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, 1, s3
-; GFX10-NEXT:    s_ashr_i64 s[2:3], s[8:9], s10
-; GFX10-NEXT:    s_add_u32 s2, s2, 0
-; GFX10-NEXT:    s_cselect_b32 s6, 1, 0
+; GFX10-NEXT:    s_and_b32 s3, 1, s2
+; GFX10-NEXT:    s_add_u32 s2, s5, 0
+; GFX10-NEXT:    v_cmp_ne_u32_e64 vcc_lo, 0, s3
+; GFX10-NEXT:    s_cselect_b32 s4, 1, 0
+; GFX10-NEXT:    s_and_b32 s4, s4, 1
 ; GFX10-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc_lo
-; GFX10-NEXT:    s_and_b32 s6, s6, 1
+; GFX10-NEXT:    s_cmp_lg_u32 s4, 0
 ; GFX10-NEXT:    v_mov_b32_e32 v6, s1
-; GFX10-NEXT:    s_cmp_lg_u32 s6, 0
-; GFX10-NEXT:    s_addc_u32 s3, s3, 0
+; GFX10-NEXT:    s_addc_u32 s3, s5, 0
 ; GFX10-NEXT:    s_cselect_b32 s4, 1, 0
 ; GFX10-NEXT:    v_xor_b32_e32 v4, v5, v4
 ; GFX10-NEXT:    s_and_b32 s4, s4, 1
@@ -6153,7 +6105,7 @@ define amdgpu_ps <2 x i128> @s_ssubsat_v2i128(<2 x i128> inreg %lhs, <2 x i128> 
 ; GFX10-NEXT:    s_and_b32 s6, s6, 1
 ; GFX10-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v4
 ; GFX10-NEXT:    s_cmp_lg_u32 s6, 0
-; GFX10-NEXT:    s_addc_u32 s1, s5, s11
+; GFX10-NEXT:    s_addc_u32 s1, s5, s10
 ; GFX10-NEXT:    v_cndmask_b32_e64 v4, v5, s2, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v5, v6, s3, vcc_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v6, v7, s4, vcc_lo


### PR DESCRIPTION
Backport https://github.com/llvm/llvm-project/commit/64bef13f083b3d980 from LLVM mainline to [stable/20210726](https://github.com/apple/llvm-project/tree/stable/20210726) branch. This fixes compile-time regression exposed by https://github.com/llvm/llvm-project/commit/d0af732bd00c0390fbcc6f900e8a59eb3954106c

Fixes https://github.com/llvm/llvm-project/issues/53109 and https://bugs.swift.org/browse/SR-15531