### PR TITLE
[lldb] Teach LLDB about ExistentialType in the Swift AST.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5740,6 +5740,7 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
 
   case swift::TypeKind::Protocol:
   case swift::TypeKind::ProtocolComposition:
+  case swift::TypeKind::Existential:
     swift_flags |= eTypeHasChildren | eTypeIsStructUnion | eTypeIsProtocol;
     break;
   case swift::TypeKind::ExistentialMetatype:
@@ -5821,6 +5822,7 @@ lldb::TypeClass SwiftASTContext::GetTypeClass(opaque_compiler_type_t type) {
   case swift::TypeKind::DependentMember:
   case swift::TypeKind::Protocol:
   case swift::TypeKind::ProtocolComposition:
+  case swift::TypeKind::Existential:
   case swift::TypeKind::Metatype:
   case swift::TypeKind::Module:
   case swift::TypeKind::PrimaryArchetype:
@@ -6320,6 +6322,7 @@ lldb::Encoding SwiftASTContext::GetEncoding(opaque_compiler_type_t type,
   case swift::TypeKind::Struct:
   case swift::TypeKind::Protocol:
   case swift::TypeKind::ProtocolComposition:
+  case swift::TypeKind::Existential:
     break;
   case swift::TypeKind::LValue:
     return lldb::eEncodingUint;
@@ -6408,7 +6411,8 @@ uint32_t SwiftASTContext::GetNumChildren(opaque_compiler_type_t type,
   }
 
   case swift::TypeKind::Protocol:
-  case swift::TypeKind::ProtocolComposition: {
+  case swift::TypeKind::ProtocolComposition:
+  case swift::TypeKind::Existential: {
     ProtocolInfo protocol_info;
     if (!GetProtocolTypeInfo(ToCompilerType(GetSwiftType(type)), protocol_info))
       break;
@@ -6546,6 +6550,7 @@ uint32_t SwiftASTContext::GetNumFields(opaque_compiler_type_t type,
 
   case swift::TypeKind::Protocol:
   case swift::TypeKind::ProtocolComposition:
+  case swift::TypeKind::Existential:
     return GetNumChildren(type, /*omit_empty_base_classes=*/false, nullptr);
 
   case swift::TypeKind::ExistentialMetatype:
@@ -6817,7 +6822,8 @@ CompilerType SwiftASTContext::GetFieldAtIndex(opaque_compiler_type_t type,
   }
 
   case swift::TypeKind::Protocol:
-  case swift::TypeKind::ProtocolComposition: {
+  case swift::TypeKind::ProtocolComposition:
+  case swift::TypeKind::Existential: {
     ProtocolInfo protocol_info;
     if (!GetProtocolTypeInfo(ToCompilerType(GetSwiftType(type)), protocol_info))
       break;
@@ -6927,6 +6933,7 @@ uint32_t SwiftASTContext::GetNumPointeeChildren(opaque_compiler_type_t type) {
   case swift::TypeKind::Function:
   case swift::TypeKind::GenericFunction:
   case swift::TypeKind::ProtocolComposition:
+  case swift::TypeKind::Existential:
     return 0;
   case swift::TypeKind::LValue:
     return 1;
@@ -7245,7 +7252,8 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
   }
 
   case swift::TypeKind::Protocol:
-  case swift::TypeKind::ProtocolComposition: {
+  case swift::TypeKind::ProtocolComposition:
+  case swift::TypeKind::Existential: {
     ProtocolInfo protocol_info;
     if (!GetProtocolTypeInfo(ToCompilerType(GetSwiftType(type)), protocol_info))
       break;
@@ -7482,7 +7490,8 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
     } break;
 
     case swift::TypeKind::Protocol:
-    case swift::TypeKind::ProtocolComposition: {
+    case swift::TypeKind::ProtocolComposition:
+    case swift::TypeKind::Existential: {
       ProtocolInfo protocol_info;
       if (!GetProtocolTypeInfo(ToCompilerType(GetSwiftType(type)),
                                protocol_info))
@@ -7876,6 +7885,7 @@ bool SwiftASTContext::DumpTypeValue(
   } break;
 
   case swift::TypeKind::ProtocolComposition:
+  case swift::TypeKind::Existential:
   case swift::TypeKind::UnboundGeneric:
   case swift::TypeKind::BoundGenericStruct:
   case swift::TypeKind::DynamicSelf:
@@ -8162,6 +8172,21 @@ void SwiftASTContext::DumpTypeDescription(opaque_compiler_type_t type,
               print_help_if_available));
 
       protocol_composition_type->print(ostream, print_options);
+      ostream.flush();
+      if (buffer.empty() == false)
+        s->Printf("%s\n", buffer.c_str());
+      break;
+    }
+    case swift::TypeKind::Existential: {
+      swift::ExistentialType *existential_type =
+          swift_can_type->castTo<swift::ExistentialType>();
+      std::string buffer;
+      llvm::raw_string_ostream ostream(buffer);
+      const swift::PrintOptions &print_options(
+          SwiftASTContext::GetUserVisibleTypePrintingOptions(
+              print_help_if_available));
+
+        existential_type->print(ostream, print_options);
       ostream.flush();
       if (buffer.empty() == false)
         s->Printf("%s\n", buffer.c_str());


### PR DESCRIPTION
This fixes the LLDB tests that started failing in https://ci.swift.org/view/LLDB/job/oss-lldb-swift-rebranch-incremental-macos-cmake/2837/

(cherry picked from commit 8d8ea5c13b49b5617b62e1b8aeb22a5b1257cb03)