### PR TITLE
[20211026][lldb] Avoid conflicts with next

### DIFF
--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -82,11 +82,11 @@ public:
   static lldb::TypeSystemSP CreateInstance(lldb::LanguageType language,
                                            Target *target);
 
-  // BEGIN APPLE
+  // BEGIN SWIFT
   static lldb::TypeSystemSP CreateInstance(lldb::LanguageType language,
                                            Target *target,
                                            const char *compiler_options);
-  // END APPLE
+  // END SWIFT
 
   // Free up any resources associated with this TypeSystem.  Done before
   // removing all the TypeSystems from the TypeSystemMap.

--- a/lldb/source/Symbol/TypeSystem.cpp
+++ b/lldb/source/Symbol/TypeSystem.cpp
@@ -328,8 +328,8 @@ TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
                                         const char *compiler_options) {
   if (can_create) {
     return GetTypeSystemForLanguage(
-        language, llvm::Optional<CreateCallback>([language, target,
-                                                  compiler_options]() {
+        language,
+        llvm::Optional<CreateCallback>([language, target, compiler_options]() {
           return TypeSystem::CreateInstance(language, target, compiler_options);
         }));
   }


### PR DESCRIPTION
`BEGIN/END SWIFT` is the standard used everywhere else, which the commit
on `next` uses.

Also use the same formatting in `TypeSystem.cpp`.