### PR TITLE
Revert "Make Objective-C interoperability configurable in the runtime"

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -461,24 +461,14 @@ void SwiftLanguageRuntimeImpl::SetupReflection() {
 
   auto &target = m_process.GetTarget();
   if (auto exe_module = target.GetExecutableModule()) {
-    bool objc_interop = (bool)findRuntime(m_process, RuntimeKind::ObjC);
-    const char *objc_interop_msg =
-        objc_interop ? "with Objective-C interopability" : "Swift only";
-
     auto &triple = exe_module->GetArchitecture().GetTriple();
-    if (triple.isArch64Bit()) {
-      LLDB_LOGF(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
-                "Initializing a 64-bit reflection context (%s) for \"%s\"",
-                triple.str().c_str(), objc_interop_msg);
+    if (triple.isArch64Bit())
       m_reflection_ctx = ReflectionContextInterface::CreateReflectionContext64(
-          this->GetMemoryReader(), objc_interop);
-    } else if (triple.isArch32Bit()) {
-      LLDB_LOGF(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
-                "Initializing a 32-bit reflection context (%s) for \"%s\"",
-                triple.str().c_str(), objc_interop_msg);
+          this->GetMemoryReader());
+    else if (triple.isArch32Bit())
       m_reflection_ctx = ReflectionContextInterface::CreateReflectionContext32(
-          this->GetMemoryReader(), objc_interop);
-    } else {
+          this->GetMemoryReader());
+    else {
       LLDB_LOGF(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES),
                 "Could not initialize reflection context for \"%s\"",
                 triple.str().c_str());

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -34,7 +34,7 @@ class MemoryReader;
 class RemoteAddress;
 } // namespace remote
 
-template <typename Runtime> struct External;
+template <typename T> struct External;
 template <unsigned PointerSize> struct RuntimeTarget;
 
 namespace reflection {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -231,10 +231,12 @@ namespace {
 
 /// An implementation of the generic ReflectionContextInterface that
 /// is templatized on target pointer width and specialized to either
-/// 32-bit or 64-bit pointers, with and without ObjC interoperability.
-template <typename ReflectionContext>
+/// 32-bit or 64-bit pointers.
+template <unsigned PointerSize>
 class TargetReflectionContext
     : public SwiftLanguageRuntimeImpl::ReflectionContextInterface {
+  using ReflectionContext = swift::reflection::ReflectionContext<
+      swift::External<swift::RuntimeTarget<PointerSize>>>;
   ReflectionContext m_reflection_ctx;
 
 public:
@@ -346,30 +348,14 @@ public:
 
 std::unique_ptr<SwiftLanguageRuntimeImpl::ReflectionContextInterface>
 SwiftLanguageRuntimeImpl::ReflectionContextInterface::CreateReflectionContext32(
-    std::shared_ptr<swift::remote::MemoryReader> reader, bool ObjCInterop) {
-  using ReflectionContext32ObjCInterop =
-      TargetReflectionContext<swift::reflection::ReflectionContext<
-          swift::External<swift::WithObjCInterop<swift::RuntimeTarget<4>>>>>;
-  using ReflectionContext32NoObjCInterop =
-      TargetReflectionContext<swift::reflection::ReflectionContext<
-          swift::External<swift::NoObjCInterop<swift::RuntimeTarget<4>>>>>;
-  if (ObjCInterop)    
-    return std::make_unique<ReflectionContext32ObjCInterop>(reader);
-  return std::make_unique<ReflectionContext32NoObjCInterop>(reader);
+    std::shared_ptr<swift::remote::MemoryReader> reader) {
+  return std::make_unique<TargetReflectionContext<4>>(reader);
 }
 
 std::unique_ptr<SwiftLanguageRuntimeImpl::ReflectionContextInterface>
 SwiftLanguageRuntimeImpl::ReflectionContextInterface::CreateReflectionContext64(
-    std::shared_ptr<swift::remote::MemoryReader> reader, bool ObjCInterop) {
-  using ReflectionContext64ObjCInterop =
-      TargetReflectionContext<swift::reflection::ReflectionContext<
-          swift::External<swift::WithObjCInterop<swift::RuntimeTarget<8>>>>>;
-  using ReflectionContext64NoObjCInterop =
-      TargetReflectionContext<swift::reflection::ReflectionContext<
-          swift::External<swift::NoObjCInterop<swift::RuntimeTarget<8>>>>>;
-  if (ObjCInterop)
-    return std::make_unique<ReflectionContext64ObjCInterop>(reader);
-  return std::make_unique<ReflectionContext64NoObjCInterop>(reader);
+    std::shared_ptr<swift::remote::MemoryReader> reader) {
+  return std::make_unique<TargetReflectionContext<8>>(reader);
 }
 
 SwiftLanguageRuntimeImpl::ReflectionContextInterface::

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -200,12 +200,12 @@ public:
     /// Return a 32-bit reflection context.
     static std::unique_ptr<ReflectionContextInterface>
     CreateReflectionContext32(
-        std::shared_ptr<swift::remote::MemoryReader> reader, bool ObjCInterop);
+        std::shared_ptr<swift::remote::MemoryReader> reader);
 
     /// Return a 64-bit reflection context.
     static std::unique_ptr<ReflectionContextInterface>
     CreateReflectionContext64(
-        std::shared_ptr<swift::remote::MemoryReader> reader, bool ObjCInterop);
+        std::shared_ptr<swift::remote::MemoryReader> reader);
 
     virtual ~ReflectionContextInterface();
 


### PR DESCRIPTION
Reverts apple/llvm-project#3789