### PR TITLE
TypeSystemSwiftTypeRef: Look up type aliases in type cache 

### DIFF
--- a/lldb/test/API/lang/swift/typealias/Dylib.swift
+++ b/lldb/test/API/lang/swift/typealias/Dylib.swift
@@ -1,0 +1,10 @@
+public struct Foo {
+    let i = 23
+    public init() {}
+}
+public struct Bar<T> {
+    let i = 42
+    public init() {}
+}
+public typealias MyAlias = Foo
+public typealias MyGenericAlias<T> = Bar<T>

--- a/lldb/test/API/lang/swift/typealias/Makefile
+++ b/lldb/test/API/lang/swift/typealias/Makefile
@@ -1,0 +1,21 @@
+SWIFT_SOURCES = main.swift
+SWIFTFLAGS_EXTRAS = -I.
+LD_EXTRAS = -L. -lDylib
+
+all: dylib $(EXE)
+
+include Makefile.rules
+
+.PHONY: dylib
+dylib:
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		-f $(THIS_FILE_DIR)/Makefile.rules \
+		DYLIB_SWIFT_SOURCES=Dylib.swift \
+		DYLIB_NAME=Dylib \
+		DYLIB_ONLY=YES \
+		SWIFT_SOURCES= \
+		LD_EXTRAS= \
+		all
+

--- a/lldb/test/API/lang/swift/typealias/TestSwiftTypeAlias.py
+++ b/lldb/test/API/lang/swift/typealias/TestSwiftTypeAlias.py
@@ -1,0 +1,35 @@
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftTypeAlias(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    def test(self):
+        """Test type aliases are only searched in the debug info once"""
+        self.build()
+        log = self.getBuildArtifact("dwarf.log")
+        self.expect("log enable dwarf lookups -f " + log)
+
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"), extra_images=['Dylib'])
+        self.expect("target variable foo", substrs=["(Dylib.MyAlias)", "23"])
+        self.expect("target variable bar",
+                    substrs=["(Dylib.MyGenericAlias<Dylib.MyAlias>)", "42"])
+
+        logfile = open(log, "r")
+        foo_lookups = 0
+        bar_lookups = 0
+        for line in logfile:
+            if ' SymbolFileDWARF::FindTypes (sc, name="$s5Dylib7MyAliasaD"' in line:
+                foo_lookups += 1
+
+            if ' SymbolFileDWARF::FindTypes (sc, name="$s5Dylib14MyGenericAliasaD' in line:
+                bar_lookups += 1
+        self.assertEquals(foo_lookups, 0)
+        # FIXME: This does not actually work yet, it should also be 0.
+        #        We look for Dylib.MyGenericAlias
+        #        but we have Dylib.MyGenericAlias<Dylib.MyAlias> in the debug info.
+        self.assertGreater(bar_lookups, 1)

--- a/lldb/test/API/lang/swift/typealias/main.swift
+++ b/lldb/test/API/lang/swift/typealias/main.swift
@@ -1,0 +1,6 @@
+import Dylib
+typealias LocalAlias = Foo
+let local = LocalAlias()
+let foo = MyAlias()
+let bar = MyGenericAlias<MyAlias>()
+print("\(local), \(foo), \(bar)") // break here


### PR DESCRIPTION
before searching them in DWARF. While looking up types in the DWARF
accelerator tables is relatively quick, when debugging from .o files
it can still incur thousands of files to be read from disk, so it's
beneficial to avoid it if possible.

rdar://86311054