### PR TITLE
TypeSystemSwiftTypeRef: Look up type aliases in type cache

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1984,8 +1984,7 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Protocol(
   }
 
   const swift::reflection::TypeRef *protocol_typeref =
-      GetTypeRef(protocol_type, &tss->GetTypeSystemSwiftTypeRef(),
-                 tss->GetSwiftASTContext());
+      GetTypeRef(protocol_type, &tss->GetTypeSystemSwiftTypeRef());
   if (!protocol_typeref) {
     if (log)
       log->Printf("Could not get protocol typeref");
@@ -2982,8 +2981,7 @@ lldb::addr_t SwiftLanguageRuntimeImpl::FixupAddress(lldb::addr_t addr,
 
 const swift::reflection::TypeRef *
 SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type,
-                                     TypeSystemSwiftTypeRef *module_holder,
-                                     SwiftASTContext *swift_ast_context) {
+                                     TypeSystemSwiftTypeRef *module_holder) {
   // Demangle the mangled name.
   swift::Demangle::Demangler dem;
   ConstString mangled_name = type.GetMangledTypeName();
@@ -2991,8 +2989,7 @@ SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type,
   if (!ts)
     return nullptr;
   swift::Demangle::NodePointer node =
-      TypeSystemSwiftTypeRef::GetCanonicalDemangleTree(
-          module_holder, swift_ast_context, dem, mangled_name.GetStringRef());
+      module_holder->GetCanonicalDemangleTree(dem, mangled_name.GetStringRef());
   if (!node)
     return nullptr;
 
@@ -3035,8 +3032,8 @@ SwiftLanguageRuntimeImpl::GetSwiftRuntimeTypeInfo(
   // BindGenericTypeParameters imports the type into the scratch
   // context, but we need to resolve (any DWARF links in) the typeref
   // in the original module.
-  const swift::reflection::TypeRef *type_ref = GetTypeRef(
-      type, &ts->GetTypeSystemSwiftTypeRef(), ts->GetSwiftASTContext());
+  const swift::reflection::TypeRef *type_ref =
+      GetTypeRef(type, &ts->GetTypeSystemSwiftTypeRef());
   if (!type_ref)
     return nullptr;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -240,8 +240,7 @@ public:
 protected:
   /// Use the reflection context to build a TypeRef object.
   const swift::reflection::TypeRef *
-  GetTypeRef(CompilerType type, TypeSystemSwiftTypeRef *module_holder,
-             SwiftASTContext *swift_ast_context);
+  GetTypeRef(CompilerType type, TypeSystemSwiftTypeRef *module_holder);
 
   /// If \p instance points to a Swift object, retrieve its
   /// RecordTypeInfo and pass it to the callback \p fn. Repeat the

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -426,7 +426,10 @@ TypeSystemSwiftTypeRef::ResolveTypeAlias(swift::Demangle::Demangler &dem,
   TypeList types;
   if (!prefer_clang_types) {
     llvm::DenseSet<SymbolFile *> searched_symbol_files;
-    if (auto *M = GetModule())
+    // First check if this type has already been parsed from DWARF.
+    if (auto cached = m_swift_type_map.Lookup(mangled.AsCString()))
+      types.Insert(cached);
+    else if (auto *M = GetModule())
       M->FindTypes({mangled}, false, 1, searched_symbol_files, types);
     else if (TargetSP target_sp = GetSwiftASTContext()
                                       ? GetSwiftASTContext()->GetTarget().lock()
@@ -1332,6 +1335,10 @@ DWARFASTParser *TypeSystemSwiftTypeRef::GetDWARFParser() {
 
 TypeSP TypeSystemSwiftTypeRef::LookupTypeInModule(
     lldb::opaque_compiler_type_t opaque_type) {
+  // First check if this type has already been parsed from DWARF.
+  if (auto cached = m_swift_type_map.Lookup(AsMangledName(opaque_type)))
+    return cached;
+
   auto *M = GetModule();
   if (!M)
     return {};

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -151,8 +151,7 @@ GetTypeAlias(swift::Demangle::Demangler &dem,
 }
 
 /// Find a Clang type by name in the modules in \p module_holder.
-static TypeSP LookupClangType(TypeSystemSwiftTypeRef *module_holder,
-                              SwiftASTContext *target_holder, StringRef name) {
+TypeSP TypeSystemSwiftTypeRef::LookupClangType(StringRef name) {
   auto lookup = [](Module &M, StringRef name) -> TypeSP {
     llvm::SmallVector<CompilerContext, 2> decl_context;
     decl_context.push_back({CompilerContextKind::AnyModule, ConstString()});
@@ -165,10 +164,10 @@ static TypeSP LookupClangType(TypeSystemSwiftTypeRef *module_holder,
       return {};
     return clang_types.GetTypeAtIndex(0);
   };
-  if (!module_holder)
-    return {};
-  if (auto *M = module_holder->GetModule())
+  if (auto *M = GetModule())
     return lookup(*M, name);
+
+  SwiftASTContext *target_holder = GetSwiftASTContext();
   if (!target_holder)
     return {};
   TargetSP target_sp = target_holder->GetTarget().lock();
@@ -183,10 +182,8 @@ static TypeSP LookupClangType(TypeSystemSwiftTypeRef *module_holder,
 }
 
 /// Find a Clang type by name in module \p M.
-static CompilerType
-LookupClangForwardType(TypeSystemSwiftTypeRef *module_holder,
-                       SwiftASTContext *target_holder, StringRef name) {
-  if (TypeSP type = LookupClangType(module_holder, target_holder, name))
+CompilerType TypeSystemSwiftTypeRef::LookupClangForwardType(StringRef name) {
+  if (TypeSP type = LookupClangType(name))
     return type->GetForwardCompilerType();
   return {};
 }
@@ -222,9 +219,9 @@ GetPointerTo(swift::Demangle::Demangler &dem,
 }
 
 /// Return a demangle tree leaf node representing \p clang_type.
-static swift::Demangle::NodePointer
-GetClangTypeNode(CompilerType clang_type, swift::Demangle::Demangler &dem,
-                 SwiftASTContext *swift_ast_context) {
+swift::Demangle::NodePointer
+TypeSystemSwiftTypeRef::GetClangTypeNode(CompilerType clang_type,
+                                         swift::Demangle::Demangler &dem) {
   using namespace swift;
   using namespace swift::Demangle;
   Node::Kind kind = Node::Kind::Structure;
@@ -246,7 +243,8 @@ GetClangTypeNode(CompilerType clang_type, swift::Demangle::Demangler &dem,
       Context(swift::ASTContext *ctx) : AST(ctx){};
     } SwiftContext;
     Adapter(swift::ASTContext *ctx) : SwiftContext(ctx){};
-  } Impl(swift_ast_context ? swift_ast_context->GetASTContext() : nullptr);
+  } Impl(GetSwiftASTContext() ? GetSwiftASTContext()->GetASTContext()
+                              : nullptr);
 #define MAP_TYPE(C_TYPE_NAME, C_TYPE_KIND, C_TYPE_BITWIDTH, SWIFT_MODULE_NAME, \
                  SWIFT_TYPE_NAME, CAN_BE_MISSING, C_NAME_MAPPING)              \
   if (clang_name.equals(C_TYPE_NAME)) {                                        \
@@ -296,8 +294,7 @@ GetClangTypeNode(CompilerType clang_type, swift::Demangle::Demangler &dem,
       break;
     auto *tuple = dem.createNode(Node::Kind::Tuple);
     NodePointer element_type = GetClangTypeNode(
-        {clang_type.GetTypeSystem(), elem_type.getAsOpaquePtr()}, dem,
-        swift_ast_context);
+        {clang_type.GetTypeSystem(), elem_type.getAsOpaquePtr()}, dem);
     for (unsigned i = 0; i < size; ++i) {
       NodePointer tuple_element = dem.createNode(Node::Kind::TupleElement);
       NodePointer type = dem.createNode(Node::Kind::Type);
@@ -392,10 +389,10 @@ GetNominal(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node) {
 /// \param prefer_clang_types if this is true, type aliases in the
 ///                           __C module are resolved as Clang types.
 ///
-static std::pair<swift::Demangle::NodePointer, CompilerType> ResolveTypeAlias(
-    TypeSystemSwiftTypeRef *module_holder, SwiftASTContext *target_holder,
-    swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
-    bool prefer_clang_types = false) {
+std::pair<swift::Demangle::NodePointer, CompilerType>
+TypeSystemSwiftTypeRef::ResolveTypeAlias(swift::Demangle::Demangler &dem,
+                                         swift::Demangle::NodePointer node,
+                                         bool prefer_clang_types) {
   LLDB_SCOPED_TIMER();
   auto resolve_clang_type = [&]() -> CompilerType {
     auto maybe_module_and_type_names = GetNominal(dem, node);
@@ -407,8 +404,7 @@ static std::pair<swift::Demangle::NodePointer, CompilerType> ResolveTypeAlias(
       return {};
 
     // Resolve the typedef within the Clang debug info.
-    auto clang_type = LookupClangForwardType(module_holder, target_holder,
-                                             node->getChild(1)->getText());
+    auto clang_type = LookupClangForwardType(node->getChild(1)->getText());
     if (!clang_type)
       return {};
 
@@ -430,9 +426,11 @@ static std::pair<swift::Demangle::NodePointer, CompilerType> ResolveTypeAlias(
   TypeList types;
   if (!prefer_clang_types) {
     llvm::DenseSet<SymbolFile *> searched_symbol_files;
-    if (auto *M = module_holder->GetModule())
+    if (auto *M = GetModule())
       M->FindTypes({mangled}, false, 1, searched_symbol_files, types);
-    else if (TargetSP target_sp = target_holder->GetTarget().lock())
+    else if (TargetSP target_sp = GetSwiftASTContext()
+                                      ? GetSwiftASTContext()->GetTarget().lock()
+                                      : nullptr)
       target_sp->GetImages().FindTypes(nullptr, {mangled},
                                        false, 1, searched_symbol_files, types);
     else {
@@ -588,9 +586,9 @@ Desugar(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
 
 /// Iteratively resolve all type aliases in \p node by looking up their
 /// desugared types in the debug info of module \p M.
-static swift::Demangle::NodePointer GetCanonicalNode(
-    TypeSystemSwiftTypeRef *module_holder, SwiftASTContext *target_holder,
-    swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node) {
+swift::Demangle::NodePointer
+TypeSystemSwiftTypeRef::GetCanonicalNode(swift::Demangle::Demangler &dem,
+                                         swift::Demangle::NodePointer node) {
   using namespace swift::Demangle;
   return TypeSystemSwiftTypeRef::Transform(dem, node, [&](NodePointer node) {
     auto kind = node->getKind();
@@ -624,10 +622,9 @@ static swift::Demangle::NodePointer GetCanonicalNode(
 
     case Node::Kind::BoundGenericTypeAlias:
     case Node::Kind::TypeAlias: {
-      auto node_clangtype =
-          ResolveTypeAlias(module_holder, target_holder, dem, node);
+      auto node_clangtype = ResolveTypeAlias(dem, node);
       if (CompilerType clang_type = node_clangtype.second)
-        return GetClangTypeNode(clang_type, dem, target_holder);
+        return GetClangTypeNode(clang_type, dem);
       if (node_clangtype.first)
         return node_clangtype.first;
       return node;
@@ -642,11 +639,10 @@ static swift::Demangle::NodePointer GetCanonicalNode(
 /// Return the demangle tree representation of this type's canonical
 /// (type aliases resolved) type.
 swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetCanonicalDemangleTree(
-    TypeSystemSwiftTypeRef *module_holder, SwiftASTContext *target_holder,
     swift::Demangle::Demangler &dem, StringRef mangled_name) {
   LLDB_SCOPED_TIMER();
   auto *node = dem.demangleSymbol(mangled_name);
-  return GetCanonicalNode(module_holder, target_holder, dem, node);
+  return GetCanonicalNode(dem, node);
 }
 
 static clang::Decl *GetDeclForTypeAndKind(clang::QualType qual_type,
@@ -787,7 +783,7 @@ TypeSystemSwiftTypeRef::GetSwiftified(swift::Demangle::Demangler &dem,
 
   // This is an imported Objective-C type; look it up in the
   // debug info.
-  TypeSP clang_type = LookupClangType(this, GetSwiftASTContext(), ident);
+  TypeSP clang_type = LookupClangType(ident);
   if (!clang_type)
     return node;
 
@@ -971,12 +967,9 @@ static bool ContainsGenericTypeParameter(swift::Demangle::NodePointer node) {
 /// determine whether a node is generic or not, it needs to visit all
 /// nodes. The \p generic_walk argument specifies that the primary
 /// attributes have been collected and that we only look for generics.
-static uint32_t collectTypeInfo(TypeSystemSwiftTypeRef *module_holder,
-                                SwiftASTContext *swift_ast_context,
-                                swift::Demangle::Demangler &dem,
-                                swift::Demangle::NodePointer node,
-                                bool &unresolved_typealias,
-                                bool generic_walk = false) {
+uint32_t TypeSystemSwiftTypeRef::CollectTypeInfo(
+    swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
+    bool &unresolved_typealias, bool generic_walk) {
   if (!node)
     return 0;
   uint32_t swift_flags = eTypeIsSwift;
@@ -1005,10 +998,8 @@ static uint32_t collectTypeInfo(TypeSystemSwiftTypeRef *module_holder,
     }
     if ((type_class & eTypeClassBuiltin)) {
       swift_flags &= ~eTypeIsStructUnion;
-      swift_flags |=
-          collectTypeInfo(module_holder, swift_ast_context, dem,
-                          GetClangTypeNode(clang_type, dem, swift_ast_context),
-                          unresolved_typealias);
+      swift_flags |= CollectTypeInfo(dem, GetClangTypeNode(clang_type, dem),
+                                     unresolved_typealias);
       return;
     }
   };
@@ -1132,8 +1123,7 @@ static uint32_t collectTypeInfo(TypeSystemSwiftTypeRef *module_holder,
           break;
 
         // Look up the Clang type in DWARF.
-        CompilerType clang_type = LookupClangForwardType(
-            module_holder, swift_ast_context, ident->getText());
+        CompilerType clang_type = LookupClangForwardType(ident->getText());
         collect_clang_type(clang_type.GetCanonicalType());
         return swift_flags;
       }
@@ -1182,8 +1172,7 @@ static uint32_t collectTypeInfo(TypeSystemSwiftTypeRef *module_holder,
     case Node::Kind::TypeAlias: {
       // Bug-for-bug compatibility.
       // swift_flags |= eTypeIsTypedef;
-      auto node_clangtype =
-          ResolveTypeAlias(module_holder, swift_ast_context, dem, node);
+      auto node_clangtype = ResolveTypeAlias(dem, node);
       if (CompilerType clang_type = node_clangtype.second) {
         collect_clang_type(clang_type);
         return swift_flags;
@@ -1193,8 +1182,7 @@ static uint32_t collectTypeInfo(TypeSystemSwiftTypeRef *module_holder,
         // then we don't have debug info to resolve it from.
         unresolved_typealias = true;
       }
-      swift_flags |= collectTypeInfo(module_holder, swift_ast_context, dem,
-                                     node_clangtype.first, generic_walk);
+      swift_flags |= CollectTypeInfo(dem, node_clangtype.first, generic_walk);
       return swift_flags;
     }
     default:
@@ -1207,9 +1195,8 @@ static uint32_t collectTypeInfo(TypeSystemSwiftTypeRef *module_holder,
 
   // Visit the child nodes.
   for (unsigned i = 0; i < node->getNumChildren(); ++i)
-    swift_flags |=
-        collectTypeInfo(module_holder, swift_ast_context, dem,
-                        node->getChild(i), unresolved_typealias, generic_walk);
+    swift_flags |= CollectTypeInfo(dem, node->getChild(i), unresolved_typealias,
+                                   generic_walk);
 
   return swift_flags;
 }
@@ -1327,7 +1314,7 @@ bool TypeSystemSwiftTypeRef::SupportsLanguage(lldb::LanguageType language) {
 
 Status TypeSystemSwiftTypeRef::IsCompatible() {
   if (auto *swift_ast_context = GetSwiftASTContext())
-    return m_swift_ast_context->IsCompatible();
+    return swift_ast_context->IsCompatible();
   return {};
 }
 
@@ -1933,7 +1920,7 @@ bool TypeSystemSwiftTypeRef::IsPossibleDynamicType(opaque_compiler_type_t type,
         return false;
 
       if (node->getKind() == Node::Kind::TypeAlias) {
-        auto resolved = ResolveTypeAlias(this, GetSwiftASTContext(), dem, node);
+        auto resolved = ResolveTypeAlias(dem, node);
         if (auto *n = std::get<swift::Demangle::NodePointer>(resolved))
           node = n;
       }
@@ -2091,8 +2078,7 @@ uint32_t TypeSystemSwiftTypeRef::GetTypeInfo(
     Demangler dem;
     NodePointer node = dem.demangleSymbol(AsMangledName(type));
     bool unresolved_typealias = false;
-    uint32_t flags = collectTypeInfo(this, GetSwiftASTContext(), dem, node,
-                                     unresolved_typealias);
+    uint32_t flags = CollectTypeInfo(dem, node, unresolved_typealias);
     if (unresolved_typealias && GetSwiftASTContext()) {
       // If this is a typealias defined in the expression evaluator,
       // then we don't have debug info to resolve it from.
@@ -2156,8 +2142,7 @@ TypeSystemSwiftTypeRef::GetCanonicalType(opaque_compiler_type_t type) {
   auto impl = [&]() {
     using namespace swift::Demangle;
     Demangler dem;
-    NodePointer canonical = GetCanonicalDemangleTree(this, GetSwiftASTContext(),
-                                                     dem, AsMangledName(type));
+    NodePointer canonical = GetCanonicalDemangleTree(dem, AsMangledName(type));
     if (ContainsUnresolvedTypeAlias(canonical)) {
       // If this is a typealias defined in the expression evaluator,
       // then we don't have debug info to resolve it from.
@@ -2547,15 +2532,14 @@ CompilerType TypeSystemSwiftTypeRef::GetFieldAtIndex(
   return {};
 }
 
-static swift::Demangle::NodePointer
-GetClangTypeTypeNode(TypeSystemSwiftTypeRef &ts,
-                     swift::Demangle::Demangler &dem, CompilerType clang_type,
-                     SwiftASTContext *swift_ast_context) {
+swift::Demangle::NodePointer
+TypeSystemSwiftTypeRef::GetClangTypeTypeNode(swift::Demangle::Demangler &dem,
+                                             CompilerType clang_type) {
   assert(llvm::isa<TypeSystemClang>(clang_type.GetTypeSystem()) &&
          "expected a clang type");
   using namespace swift::Demangle;
   NodePointer type = dem.createNode(Node::Kind::Type);
-  type->addChild(GetClangTypeNode(clang_type, dem, swift_ast_context), dem);
+  type->addChild(GetClangTypeNode(clang_type, dem), dem);
   return type;
 }
 
@@ -2657,9 +2641,7 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
             child_is_base_class = false;
             child_is_deref_of_parent = false;
             language_flags = 0;
-            return RemangleAsType(dem,
-                                  GetClangTypeTypeNode(*this, dem, raw_value,
-                                                       GetSwiftASTContext()));
+            return RemangleAsType(dem, GetClangTypeTypeNode(dem, raw_value));
           }
       // Otherwise defer to TypeSystemClang.
       //
@@ -2686,8 +2668,8 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
       if (clang_child_type) {
         std::string prefix;
         swift::Demangle::Demangler dem;
-        swift::Demangle::NodePointer node = GetClangTypeTypeNode(
-            *this, dem, clang_child_type, GetSwiftASTContext());
+        swift::Demangle::NodePointer node =
+            GetClangTypeTypeNode(dem, clang_child_type);
         switch (node->getChild(0)->getKind()) {
         case swift::Demangle::Node::Kind::Class:
             prefix = "ObjectiveC.";
@@ -2946,9 +2928,8 @@ CompilerType TypeSystemSwiftTypeRef::GetAsClangTypeOrNull(
       node->getNumChildren() == 2 && node->getChild(0)->hasText() &&
       node->getChild(0)->getText() == swift::MANGLING_MODULE_OBJC &&
       node->getChild(1)->hasText()) {
-    auto node_clangtype =
-        ResolveTypeAlias(this, GetSwiftASTContext(), dem, node,
-                         /*prefer_clang_types*/ true);
+    auto node_clangtype = ResolveTypeAlias(dem, node,
+                                           /*prefer_clang_types*/ true);
     if (node_clangtype.second)
       return node_clangtype.second;
   }
@@ -2970,8 +2951,7 @@ bool TypeSystemSwiftTypeRef::IsImportedType(opaque_compiler_type_t type,
     if (ident.empty())
       return {};
     if (original_type)
-      if (TypeSP clang_type =
-              LookupClangType(this, GetSwiftASTContext(), ident))
+      if (TypeSP clang_type = LookupClangType(ident))
         *original_type = clang_type->GetForwardCompilerType();
     return true;
   };
@@ -3272,7 +3252,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     case Node::Kind::Structure: {
       // In some instances, a swift `structure` wraps an objc enum. The enum
       // case needs to be handled, but structs are no-ops.
-      auto resolved = ResolveTypeAlias(this, GetSwiftASTContext(), dem, node, true);
+      auto resolved = ResolveTypeAlias(dem, node, true);
       auto clang_type = std::get<CompilerType>(resolved);
       if (!clang_type)
         return false;
@@ -3476,13 +3456,13 @@ TypeSystemSwiftTypeRef::GetTypedefedType(opaque_compiler_type_t type) {
     if (!node || (node->getKind() != Node::Kind::TypeAlias &&
                   node->getKind() != Node::Kind::BoundGenericTypeAlias))
       return {};
-    auto pair = ResolveTypeAlias(this, GetSwiftASTContext(), dem, node);
+    auto pair = ResolveTypeAlias(dem, node);
     NodePointer type_node = dem.createNode(Node::Kind::Type);
     if (NodePointer resolved = std::get<swift::Demangle::NodePointer>(pair)) {
       type_node->addChild(resolved, dem);
     } else {
-      NodePointer clang_node = GetClangTypeNode(std::get<CompilerType>(pair),
-                                                dem, GetSwiftASTContext());
+      NodePointer clang_node =
+          GetClangTypeNode(std::get<CompilerType>(pair), dem);
       type_node->addChild(clang_node, dem);
     }
     return RemangleAsType(dem, type_node);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -282,10 +282,9 @@ public:
                     swift::Demangle::NodePointer node);
 
   /// Return the canonicalized Demangle tree for a Swift mangled type name.
-  static swift::Demangle::NodePointer GetCanonicalDemangleTree(
-      TypeSystemSwiftTypeRef *module_holder, SwiftASTContext *target_holder,
-      swift::Demangle::Demangler &dem, llvm::StringRef mangled_name);
-
+  swift::Demangle::NodePointer
+  GetCanonicalDemangleTree(swift::Demangle::Demangler &dem,
+                           llvm::StringRef mangled_name);
   /// Return the base name of the topmost nominal type.
   static llvm::StringRef GetBaseName(swift::Demangle::NodePointer node);
 
@@ -342,6 +341,30 @@ private:
   clang::api_notes::APINotesManager *
   GetAPINotesManager(ClangExternalASTSourceCallbacks *source, unsigned id);
 
+  lldb::TypeSP LookupClangType(llvm::StringRef name);
+
+  CompilerType LookupClangForwardType(llvm::StringRef name);
+
+  std::pair<swift::Demangle::NodePointer, CompilerType>
+  ResolveTypeAlias(swift::Demangle::Demangler &dem,
+                   swift::Demangle::NodePointer node,
+                   bool prefer_clang_types = false);
+
+  swift::Demangle::NodePointer
+  GetCanonicalNode(swift::Demangle::Demangler &dem,
+                   swift::Demangle::NodePointer node);
+
+  uint32_t CollectTypeInfo(swift::Demangle::Demangler &dem,
+                           swift::Demangle::NodePointer node,
+                           bool &unresolved_typealias,
+                           bool generic_walk = false);
+
+  swift::Demangle::NodePointer
+  GetClangTypeNode(CompilerType clang_type, swift::Demangle::Demangler &dem);
+
+  swift::Demangle::NodePointer
+  GetClangTypeTypeNode(swift::Demangle::Demangler &dem,
+                       CompilerType clang_type);
 #ifndef NDEBUG
   /// Check whether the type being dealt with is tricky to validate due to
   /// discrepancies between TypeSystemSwiftTypeRef and SwiftASTContext.

--- a/lldb/test/API/lang/swift/typealias/Dylib.swift
+++ b/lldb/test/API/lang/swift/typealias/Dylib.swift
@@ -1,0 +1,10 @@
+public struct Foo {
+    let i = 23
+    public init() {}
+}
+public struct Bar<T> {
+    let i = 42
+    public init() {}
+}
+public typealias MyAlias = Foo
+public typealias MyGenericAlias<T> = Bar<T>

--- a/lldb/test/API/lang/swift/typealias/Makefile
+++ b/lldb/test/API/lang/swift/typealias/Makefile
@@ -1,0 +1,21 @@
+SWIFT_SOURCES = main.swift
+SWIFTFLAGS_EXTRAS = -I.
+LD_EXTRAS = -L. -lDylib
+
+all: dylib $(EXE)
+
+include Makefile.rules
+
+.PHONY: dylib
+dylib:
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		-f $(THIS_FILE_DIR)/Makefile.rules \
+		DYLIB_SWIFT_SOURCES=Dylib.swift \
+		DYLIB_NAME=Dylib \
+		DYLIB_ONLY=YES \
+		SWIFT_SOURCES= \
+		LD_EXTRAS= \
+		all
+

--- a/lldb/test/API/lang/swift/typealias/TestSwiftTypeAlias.py
+++ b/lldb/test/API/lang/swift/typealias/TestSwiftTypeAlias.py
@@ -1,0 +1,35 @@
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftTypeAlias(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    def test(self):
+        """Test type aliases are only searched in the debug info once"""
+        self.build()
+        log = self.getBuildArtifact("dwarf.log")
+        self.expect("log enable dwarf lookups -f " + log)
+
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"), extra_images=['Dylib'])
+        self.expect("target variable foo", substrs=["(Dylib.MyAlias)", "23"])
+        self.expect("target variable bar",
+                    substrs=["(Dylib.MyGenericAlias<Dylib.MyAlias>)", "42"])
+
+        logfile = open(log, "r")
+        foo_lookups = 0
+        bar_lookups = 0
+        for line in logfile:
+            if ' SymbolFileDWARF::FindTypes (sc, name="$s5Dylib7MyAliasaD"' in line:
+                foo_lookups += 1
+
+            if ' SymbolFileDWARF::FindTypes (sc, name="$s5Dylib14MyGenericAliasaD' in line:
+                bar_lookups += 1
+        self.assertEquals(foo_lookups, 0)
+        # FIXME: This does not actually work yet, it should also be 0.
+        #        We look for Dylib.MyGenericAlias
+        #        but we have Dylib.MyGenericAlias<Dylib.MyAlias> in the debug info.
+        self.assertGreater(bar_lookups, 1)

--- a/lldb/test/API/lang/swift/typealias/main.swift
+++ b/lldb/test/API/lang/swift/typealias/main.swift
@@ -1,0 +1,6 @@
+import Dylib
+typealias LocalAlias = Foo
+let local = LocalAlias()
+let foo = MyAlias()
+let bar = MyGenericAlias<MyAlias>()
+print("\(local), \(foo), \(bar)") // break here


### PR DESCRIPTION
before searching them in DWARF. While looking up types in the DWARF
accelerator tables is relatively quick, when debugging from .o files
it can still incur thousands of files to be read from disk, so it's
beneficial to avoid it if possible.

rdar://86311054

Cherry-picks https://github.com/apple/llvm-project/pull/3820