### PR TITLE
[lldb] Allow aliases to aliases of raw input commands

### DIFF
--- a/lldb/source/Commands/CommandObjectCommands.cpp
+++ b/lldb/source/Commands/CommandObjectCommands.cpp
@@ -485,8 +485,9 @@ protected:
     OptionArgVectorSP option_arg_vector_sp =
         OptionArgVectorSP(new OptionArgVector);
 
-    if (CommandObjectSP cmd_obj_sp =
-            m_interpreter.GetCommandSPExact(cmd_obj.GetCommandName())) {
+    const bool include_aliases = true;
+    if (CommandObjectSP cmd_obj_sp = m_interpreter.GetCommandSPExact(
+            cmd_obj.GetCommandName(), include_aliases)) {
       if (m_interpreter.AliasExists(alias_command) ||
           m_interpreter.UserCommandExists(alias_command)) {
         result.AppendWarningWithFormat(

--- a/lldb/test/API/commands/command/nested_alias/TestNestedAlias.py
+++ b/lldb/test/API/commands/command/nested_alias/TestNestedAlias.py
@@ -47,6 +47,8 @@ class NestedAliasTestCase(TestBase):
             self.runCmd('command unalias rd', check=False)
             self.runCmd('command unalias fo', check=False)
             self.runCmd('command unalias foself', check=False)
+            self.runCmd('command unalias add_two', check=False)
+            self.runCmd('command unalias two', check=False)
 
         # Execute the cleanup function during test case tear down.
         self.addTearDownHook(cleanup)
@@ -97,3 +99,8 @@ class NestedAliasTestCase(TestBase):
                 'Show variables for the current',
                 'stack frame.'],
             matching=True)
+
+        # Check that aliases can be created for raw input commands.
+        self.expect('command alias two expr -- 2')
+        self.expect('command alias add_two two +')
+        self.expect('add_two 3', patterns=[' = 5$'])


### PR DESCRIPTION
Allow users to create aliases for aliases to raw input commands. That probably
sounds convoluted, so here's an example:

```
command alias some-setup env SOMEVAR=SOMEVALUE
```

This an alias based on `env`, which itself is an alias for `_regex-env`.
`_regex-env` is a `command regex` command, which takes raw input.

The above `some-setup` alias fails with:

```
error: Unable to create requested alias.
```

This change allows such aliases to be created. lldb already supports aliases to
aliases for parsed commands.

Differential Revision: https://reviews.llvm.org/D117259

(cherry picked from commit b95150418fb6e2d22a0bd84abcdc1f3cc7e5a0bf)