### PR TITLE
Avoid repeated initalizations of SwiftASTContext after a failure. 

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1236,14 +1236,18 @@ TypeSystemSwiftTypeRef::TypeSystemSwiftTypeRef(
 }
 
 SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContext() const {
-  if (!m_swift_ast_context) {
-    if (auto *module = GetModule()) {
-      m_swift_ast_context_sp = SwiftASTContext::CreateInstance(
-          LanguageType::eLanguageTypeSwift, *module,
-          const_cast<TypeSystemSwiftTypeRef *>(this));
-      m_swift_ast_context =
-          llvm::dyn_cast_or_null<SwiftASTContext>(m_swift_ast_context_sp.get());
-    }
+  if (m_swift_ast_context_initialized)
+    return m_swift_ast_context;
+
+  // SwiftASTContext::CreateInstance() returns a nullptr on failure,
+  // there is no point in trying to initialize when that happens.
+  m_swift_ast_context_initialized = true;
+  if (auto *module = GetModule()) {
+    m_swift_ast_context_sp = SwiftASTContext::CreateInstance(
+        LanguageType::eLanguageTypeSwift, *module,
+        const_cast<TypeSystemSwiftTypeRef *>(this));
+    m_swift_ast_context =
+        llvm::dyn_cast_or_null<SwiftASTContext>(m_swift_ast_context_sp.get());
   }
   return m_swift_ast_context;
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -374,6 +374,7 @@ private:
 #endif
 
   /// The sibling SwiftASTContext.
+  mutable bool m_swift_ast_context_initialized = false;
   mutable lldb::TypeSystemSP m_swift_ast_context_sp;
   mutable SwiftASTContext *m_swift_ast_context = nullptr;
   std::unique_ptr<DWARFASTParser> m_dwarf_ast_parser_up;


### PR DESCRIPTION
Trying to intialize it again on every call to GetSwiftASTContext() is
as slow as it is pointless.

rdar://87911176