### PR TITLE
[NFC] Make getSubmoduleID assert more debuggable

### DIFF
--- a/clang/include/clang/Basic/Module.h
+++ b/clang/include/clang/Basic/Module.h
@@ -28,6 +28,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
+#include "llvm/Support/PrettyStackTrace.h"
 #include <array>
 #include <cassert>
 #include <cstdint>
@@ -745,6 +746,15 @@ public:
   Module *getModuleOrNull() const { return ClangModule; }
 };
 
+class PrettyStackTraceModuleAction : public llvm::PrettyStackTraceEntry {
+  const char *Action;
+  const Module *SubjectModule;
+
+public:
+  PrettyStackTraceModuleAction(const char *Action, const Module *SubjectModule)
+      : Action(Action), SubjectModule(SubjectModule) {}
+  void print(raw_ostream &OS) const override;
+};
 
 } // namespace clang
 

--- a/clang/lib/Basic/Module.cpp
+++ b/clang/lib/Basic/Module.cpp
@@ -238,6 +238,10 @@ std::string Module::getFullModuleName(bool AllowStringLiterals) const {
   return Result;
 }
 
+void PrettyStackTraceModuleAction::print(raw_ostream &OS) const {
+  OS << Action << " module '" << SubjectModule->getFullModuleName() << "'\n";
+}
+
 bool Module::fullModuleNameIs(ArrayRef<StringRef> nameParts) const {
   for (const Module *M = this; M; M = M->Parent) {
     if (nameParts.empty() || M->Name != nameParts.back())

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1044,6 +1044,9 @@ bool CompilerInstance::ExecuteAction(FrontendAction &Act) {
     llvm::EnableStatistics(false);
 
   for (const FrontendInputFile &FIF : getFrontendOpts().Inputs) {
+    std::string filename = FIF.getFile().str();
+    llvm::PrettyStackTraceFormat trace("Acting on file '%s'", filename.c_str());
+
     // Reset the ID tables if we are reusing the SourceManager and parsing
     // regular files.
     if (hasSourceManager() && !Act.isModelParsingAction())

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -2512,8 +2512,13 @@ unsigned ASTWriter::getSubmoduleID(Module *Mod) {
   // did not result in us loading a module file for that submodule. For
   // instance, a cross-top-level-module 'conflict' declaration will hit this.
   unsigned ID = getLocalOrImportedSubmoduleID(Mod);
-  assert((ID || !Mod) &&
-         "asked for module ID for non-local, non-imported module");
+#ifndef NDEBUG
+  if (!(ID || !Mod)) {
+    llvm::report_fatal_error(llvm::Twine("asked for module ID for non-local, "
+                                         "non-imported module '")
+                             + Mod->getFullModuleName() + "'");
+  }
+#endif
   return ID;
 }
 
@@ -4306,6 +4311,8 @@ ASTFileSignature ASTWriter::WriteAST(Sema &SemaRef,
                                      Module *WritingModule, StringRef isysroot,
                                      bool hasErrors,
                                      bool ShouldCacheASTInMemory) {
+  PrettyStackTraceModuleAction trace("Writing AST file for", WritingModule);
+
   WritingAST = true;
 
   ASTHasCompilerErrors = hasErrors;


### PR DESCRIPTION
There's an assertion in `ASTWriter::getSubmoduleID()` that's relatively easy to hit when inputs are malformed in the right way, but doesn't really really give you any useful information about the problem when you do. Switch to `report_fatal_error()` so we can embed a module name in the message, and add some PrettyStackTraces to include useful details in this and other crashes.

This change is NFC because `report_fatal_error()` is still only called in compilers built with assertions.

(I plan to merge upstream of this branch; I just wanted to get some opinions before I took the time to do that.)