### PR TITLE
Emit swift5 reflection section data in dsym bundle generated by dsymutil in the Dwarf section.

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Swift.def
+++ b/llvm/include/llvm/BinaryFormat/Swift.def
@@ -1,0 +1,26 @@
+//===- llvm/BinaryFormat/Swift.def - Swift definitions ---------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Macros for running through Swift enumerators.
+//
+//===----------------------------------------------------------------------===//
+
+#if !(defined HANDLE_SWIFT_SECTION)
+#error "Missing macro definition of HANDLE_SWIFT_SECTION"
+#endif
+
+#ifndef HANDLE_SWIFT_SECTION
+#define HANDLE_SWIFT_SECTION(KIND, MACHO, ELF, COFF)
+#endif
+
+HANDLE_SWIFT_SECTION(fieldmd, "__swift5_fieldmd", "swift5_fieldmd", ".sw5flmd")
+HANDLE_SWIFT_SECTION(assocty, "__swift5_assocty", "swift5_assocty", ".sw5asty")
+HANDLE_SWIFT_SECTION(builtin, "__swift5_builtin", "swift5_builtin", ".sw5bltn")
+HANDLE_SWIFT_SECTION(capture, "__swift5_capture", "swift5_capture", ".sw5cptr")
+HANDLE_SWIFT_SECTION(typeref, "__swift5_typeref", "swift5_typeref", ".sw5tyrf")
+HANDLE_SWIFT_SECTION(reflstr, "__swift5_reflstr", "swift5_reflstr", ".sw5rfst")

--- a/llvm/include/llvm/BinaryFormat/Swift.h
+++ b/llvm/include/llvm/BinaryFormat/Swift.h
@@ -1,0 +1,24 @@
+//===-- llvm/BinaryFormat/Swift.h ---Swift Constants-------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+#ifndef LLVM_BINARYFORMAT_SWIFT_H
+#define LLVM_BINARYFORMAT_SWIFT_H
+
+namespace llvm {
+namespace swift {
+
+enum Swift5ReflectionSectionKind {
+#define HANDLE_SWIFT_SECTION(KIND, MACHO, ELF, COFF) KIND,
+#include "llvm/BinaryFormat/Swift.def"
+#undef HANDLE_SWIFT_SECTION
+  unknown,
+  last = unknown
+};
+} // end of namespace swift
+} // end of namespace llvm
+
+#endif

--- a/llvm/include/llvm/BinaryFormat/Swift.h
+++ b/llvm/include/llvm/BinaryFormat/Swift.h
@@ -9,7 +9,7 @@
 #define LLVM_BINARYFORMAT_SWIFT_H
 
 namespace llvm {
-namespace swift {
+namespace binaryformat {
 
 enum Swift5ReflectionSectionKind {
 #define HANDLE_SWIFT_SECTION(KIND, MACHO, ELF, COFF) KIND,
@@ -18,7 +18,7 @@ enum Swift5ReflectionSectionKind {
   unknown,
   last = unknown
 };
-} // end of namespace swift
+} // end of namespace binaryformat
 } // end of namespace llvm
 
 #endif

--- a/llvm/include/llvm/DWARFLinker/DWARFStreamer.h
+++ b/llvm/include/llvm/DWARFLinker/DWARFStreamer.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DWARFLINKER_DWARFSTREAMER_H
 #define LLVM_DWARFLINKER_DWARFSTREAMER_H
 
+#include "llvm/BinaryFormat/Swift.h"
 #include "llvm/CodeGen/AccelTable.h"
 #include "llvm/CodeGen/AsmPrinter.h"
 #include "llvm/DWARFLinker/DWARFLinker.h"
@@ -48,7 +49,7 @@ public:
       : OutFile(OutFile), OutFileType(OutFileType), Translator(Translator),
         ErrorHandler(Error), WarningHandler(Warning) {}
 
-  bool init(Triple TheTriple);
+  bool init(Triple TheTriple, StringRef Swift5ReflectionSegmentName);
 
   /// Dump the file to the disk.
   void finish();
@@ -84,6 +85,11 @@ public:
 
   /// Emit the swift_ast section stored in \p Buffer.
   void emitSwiftAST(StringRef Buffer);
+
+  /// Emit the swift reflection section stored in \p Buffer.
+  void emitSwiftReflectionSection(
+      llvm::swift::Swift5ReflectionSectionKind ReflSectionKind,
+      StringRef Buffer, uint32_t Alignment, uint32_t Size);
 
   /// Emit debug_ranges for \p FuncRange by translating the
   /// original \p Entries.

--- a/llvm/include/llvm/DWARFLinker/DWARFStreamer.h
+++ b/llvm/include/llvm/DWARFLinker/DWARFStreamer.h
@@ -88,7 +88,7 @@ public:
 
   /// Emit the swift reflection section stored in \p Buffer.
   void emitSwiftReflectionSection(
-      llvm::swift::Swift5ReflectionSectionKind ReflSectionKind,
+      llvm::binaryformat::Swift5ReflectionSectionKind ReflSectionKind,
       StringRef Buffer, uint32_t Alignment, uint32_t Size);
 
   /// Emit debug_ranges for \p FuncRange by translating the

--- a/llvm/include/llvm/MC/MCContext.h
+++ b/llvm/include/llvm/MC/MCContext.h
@@ -80,6 +80,10 @@ namespace llvm {
   private:
     Environment Env;
 
+    /// The name of the Segment where Swift5 Reflection Section data will be
+    /// outputted
+    StringRef Swift5ReflectionSegmentName;
+
     /// The triple for this object.
     Triple TT;
 
@@ -399,13 +403,17 @@ namespace llvm {
                        const MCRegisterInfo *MRI, const MCSubtargetInfo *MSTI,
                        const SourceMgr *Mgr = nullptr,
                        MCTargetOptions const *TargetOpts = nullptr,
-                       bool DoAutoReset = true);
+                       bool DoAutoReset = true,
+                       StringRef Swift5ReflSegmentName = {});
     MCContext(const MCContext &) = delete;
     MCContext &operator=(const MCContext &) = delete;
     ~MCContext();
 
     Environment getObjectFileType() const { return Env; }
 
+    const StringRef &getSwift5ReflectionSegmentName() const {
+      return Swift5ReflectionSegmentName;
+    }
     const Triple &getTargetTriple() const { return TT; }
     const SourceMgr *getSourceManager() const { return SrcMgr; }
 

--- a/llvm/include/llvm/MC/MCObjectFileInfo.h
+++ b/llvm/include/llvm/MC/MCObjectFileInfo.h
@@ -230,7 +230,7 @@ protected:
   MCSection *ReadOnly16Section = nullptr;
 
   // Swift5 Reflection Data Sections
-  std::array<MCSection *, swift::Swift5ReflectionSectionKind::last>
+  std::array<MCSection *, binaryformat::Swift5ReflectionSectionKind::last>
       Swift5ReflectionSections = {};
 
 public:
@@ -430,8 +430,9 @@ public:
 
   // Swift5 Reflection Data Sections
   MCSection *getSwift5ReflectionSection(
-      llvm::swift::Swift5ReflectionSectionKind ReflSectionKind) {
-    return ReflSectionKind != llvm::swift::Swift5ReflectionSectionKind::unknown
+      llvm::binaryformat::Swift5ReflectionSectionKind ReflSectionKind) {
+    return ReflSectionKind !=
+                   llvm::binaryformat::Swift5ReflectionSectionKind::unknown
                ? Swift5ReflectionSections[ReflSectionKind]
                : nullptr;
   }

--- a/llvm/include/llvm/MC/MCObjectFileInfo.h
+++ b/llvm/include/llvm/MC/MCObjectFileInfo.h
@@ -15,6 +15,7 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Triple.h"
+#include "llvm/BinaryFormat/Swift.h"
 #include "llvm/MC/MCSymbol.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/VersionTuple.h"
@@ -228,6 +229,10 @@ protected:
   MCSection *ReadOnly8Section = nullptr;
   MCSection *ReadOnly16Section = nullptr;
 
+  // Swift5 Reflection Data Sections
+  std::array<MCSection *, swift::Swift5ReflectionSectionKind::last>
+      Swift5ReflectionSections = {};
+
 public:
   void initMCObjectFileInfo(MCContext &MCCtx, bool PIC,
                             bool LargeCodeModel = false);
@@ -422,6 +427,14 @@ public:
   MCSection *getEHFrameSection() const { return EHFrameSection; }
 
   bool isPositionIndependent() const { return PositionIndependent; }
+
+  // Swift5 Reflection Data Sections
+  MCSection *getSwift5ReflectionSection(
+      llvm::swift::Swift5ReflectionSectionKind ReflSectionKind) {
+    return ReflSectionKind != llvm::swift::Swift5ReflectionSectionKind::unknown
+               ? Swift5ReflectionSections[ReflSectionKind]
+               : nullptr;
+  }
 
 private:
   bool PositionIndependent = false;

--- a/llvm/include/llvm/Object/MachO.h
+++ b/llvm/include/llvm/Object/MachO.h
@@ -22,6 +22,7 @@
 #include "llvm/ADT/Triple.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/BinaryFormat/MachO.h"
+#include "llvm/BinaryFormat/Swift.h"
 #include "llvm/MC/SubtargetFeature.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/ObjectFile.h"
@@ -579,6 +580,9 @@ public:
   bool isRelocatableObject() const override;
 
   StringRef mapDebugSectionName(StringRef Name) const override;
+
+  llvm::swift::Swift5ReflectionSectionKind
+  mapReflectionSectionNameToEnumValue(StringRef SectionName) const override;
 
   bool hasPageZeroSegment() const { return HasPageZeroSegment; }
 

--- a/llvm/include/llvm/Object/MachO.h
+++ b/llvm/include/llvm/Object/MachO.h
@@ -581,7 +581,7 @@ public:
 
   StringRef mapDebugSectionName(StringRef Name) const override;
 
-  llvm::swift::Swift5ReflectionSectionKind
+  llvm::binaryformat::Swift5ReflectionSectionKind
   mapReflectionSectionNameToEnumValue(StringRef SectionName) const override;
 
   bool hasPageZeroSegment() const { return HasPageZeroSegment; }

--- a/llvm/include/llvm/Object/ObjectFile.h
+++ b/llvm/include/llvm/Object/ObjectFile.h
@@ -292,9 +292,9 @@ protected:
   virtual void getRelocationTypeName(DataRefImpl Rel,
                                      SmallVectorImpl<char> &Result) const = 0;
 
-  virtual llvm::swift::Swift5ReflectionSectionKind
+  virtual llvm::binaryformat::Swift5ReflectionSectionKind
   mapReflectionSectionNameToEnumValue(StringRef SectionName) const {
-    return llvm::swift::Swift5ReflectionSectionKind::unknown;
+    return llvm::binaryformat::Swift5ReflectionSectionKind::unknown;
   };
 
   Expected<uint64_t> getSymbolValue(DataRefImpl Symb) const;

--- a/llvm/include/llvm/Object/ObjectFile.h
+++ b/llvm/include/llvm/Object/ObjectFile.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/Triple.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/BinaryFormat/Magic.h"
+#include "llvm/BinaryFormat/Swift.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/Error.h"
 #include "llvm/Object/SymbolicFile.h"
@@ -290,6 +291,11 @@ protected:
   virtual uint64_t getRelocationType(DataRefImpl Rel) const = 0;
   virtual void getRelocationTypeName(DataRefImpl Rel,
                                      SmallVectorImpl<char> &Result) const = 0;
+
+  virtual llvm::swift::Swift5ReflectionSectionKind
+  mapReflectionSectionNameToEnumValue(StringRef SectionName) const {
+    return llvm::swift::Swift5ReflectionSectionKind::unknown;
+  };
 
   Expected<uint64_t> getSymbolValue(DataRefImpl Symb) const;
 

--- a/llvm/lib/DWARFLinker/DWARFStreamer.cpp
+++ b/llvm/lib/DWARFLinker/DWARFStreamer.cpp
@@ -27,7 +27,8 @@
 
 namespace llvm {
 
-bool DwarfStreamer::init(Triple TheTriple) {
+bool DwarfStreamer::init(Triple TheTriple,
+                         StringRef Swift5ReflectionSegmentName) {
   std::string ErrorStr;
   std::string TripleName;
   StringRef Context = "dwarf streamer init";
@@ -54,8 +55,9 @@ bool DwarfStreamer::init(Triple TheTriple) {
   if (!MSTI)
     return error("no subtarget info for target " + TripleName, Context), false;
 
-  MC.reset(new MCContext(TheTriple, MAI.get(), MRI.get(), MSTI.get()));
-  MOFI.reset(TheTarget->createMCObjectFileInfo(*MC, /*PIC=*/false));
+  MC.reset(new MCContext(TheTriple, MAI.get(), MRI.get(), MSTI.get(), nullptr,
+                         nullptr, true, Swift5ReflectionSegmentName));
+  MOFI.reset(TheTarget->createMCObjectFileInfo(*MC, /*PIC=*/false, false));
   MC->setObjectFileInfo(MOFI.get());
 
   MAB = TheTarget->createMCAsmBackend(*MSTI, *MRI, MCOptions);
@@ -299,6 +301,18 @@ void DwarfStreamer::emitSwiftAST(StringRef Buffer) {
   MCSection *SwiftASTSection = MOFI->getDwarfSwiftASTSection();
   SwiftASTSection->setAlignment(Align(32));
   MS->SwitchSection(SwiftASTSection);
+  MS->emitBytes(Buffer);
+}
+
+void DwarfStreamer::emitSwiftReflectionSection(
+    llvm::swift::Swift5ReflectionSectionKind ReflSectionKind, StringRef Buffer,
+    uint32_t Alignment, uint32_t Size) {
+  MCSection *ReflectionSection =
+      MOFI->getSwift5ReflectionSection(ReflSectionKind);
+  if (ReflectionSection == nullptr)
+    return;
+  ReflectionSection->setAlignment(Align(Alignment));
+  MS->SwitchSection(ReflectionSection);
   MS->emitBytes(Buffer);
 }
 

--- a/llvm/lib/DWARFLinker/DWARFStreamer.cpp
+++ b/llvm/lib/DWARFLinker/DWARFStreamer.cpp
@@ -305,8 +305,8 @@ void DwarfStreamer::emitSwiftAST(StringRef Buffer) {
 }
 
 void DwarfStreamer::emitSwiftReflectionSection(
-    llvm::swift::Swift5ReflectionSectionKind ReflSectionKind, StringRef Buffer,
-    uint32_t Alignment, uint32_t Size) {
+    llvm::binaryformat::Swift5ReflectionSectionKind ReflSectionKind,
+    StringRef Buffer, uint32_t Alignment, uint32_t Size) {
   MCSection *ReflectionSection =
       MOFI->getSwift5ReflectionSection(ReflSectionKind);
   if (ReflectionSection == nullptr)

--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -67,10 +67,10 @@ static void defaultDiagHandler(const SMDiagnostic &SMD, bool, const SourceMgr &,
 MCContext::MCContext(const Triple &TheTriple, const MCAsmInfo *mai,
                      const MCRegisterInfo *mri, const MCSubtargetInfo *msti,
                      const SourceMgr *mgr, MCTargetOptions const *TargetOpts,
-                     bool DoAutoReset)
-    : TT(TheTriple), SrcMgr(mgr), InlineSrcMgr(nullptr),
-      DiagHandler(defaultDiagHandler), MAI(mai), MRI(mri), MSTI(msti),
-      Symbols(Allocator), UsedNames(Allocator),
+                     bool DoAutoReset, StringRef Swift5ReflSegmentName)
+    : Swift5ReflectionSegmentName(Swift5ReflSegmentName), TT(TheTriple),
+      SrcMgr(mgr), InlineSrcMgr(nullptr), DiagHandler(defaultDiagHandler),
+      MAI(mai), MRI(mri), MSTI(msti), Symbols(Allocator), UsedNames(Allocator),
       InlineAsmUsedLabelNames(Allocator),
       CurrentDwarfLoc(0, 0, 0, DWARF2_FLAG_IS_STMT, 0, 0),
       AutoReset(DoAutoReset), TargetOptions(TargetOpts) {

--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -299,6 +299,17 @@ void MCObjectFileInfo::initMachOMCObjectFileInfo(const Triple &T) {
   RemarksSection = Ctx->getMachOSection(
       "__LLVM", "__remarks", MachO::S_ATTR_DEBUG, SectionKind::getMetadata());
 
+  // The architecture of dsymutil makes it very difficult to copy the Swift
+  // reflection metadata sections into the __TEXT segment, so dsymutil creates
+  // these sections in the __DWARF segment instead.
+  if (!Ctx->getSwift5ReflectionSegmentName().empty()) {
+#define HANDLE_SWIFT_SECTION(KIND, MACHO, ELF, COFF)                           \
+  Swift5ReflectionSections[llvm::swift::Swift5ReflectionSectionKind::KIND] =   \
+      Ctx->getMachOSection(Ctx->getSwift5ReflectionSegmentName().data(),       \
+                           MACHO, 0, SectionKind::getMetadata());
+#include "llvm/BinaryFormat/Swift.def"
+  }
+
   TLSExtraDataSection = TLSTLVSection;
 }
 

--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -304,9 +304,10 @@ void MCObjectFileInfo::initMachOMCObjectFileInfo(const Triple &T) {
   // these sections in the __DWARF segment instead.
   if (!Ctx->getSwift5ReflectionSegmentName().empty()) {
 #define HANDLE_SWIFT_SECTION(KIND, MACHO, ELF, COFF)                           \
-  Swift5ReflectionSections[llvm::swift::Swift5ReflectionSectionKind::KIND] =   \
-      Ctx->getMachOSection(Ctx->getSwift5ReflectionSegmentName().data(),       \
-                           MACHO, 0, SectionKind::getMetadata());
+  Swift5ReflectionSections                                                     \
+      [llvm::binaryformat::Swift5ReflectionSectionKind::KIND] =                \
+          Ctx->getMachOSection(Ctx->getSwift5ReflectionSegmentName().data(),   \
+                               MACHO, 0, SectionKind::getMetadata());
 #include "llvm/BinaryFormat/Swift.def"
   }
 

--- a/llvm/lib/Object/MachOObjectFile.cpp
+++ b/llvm/lib/Object/MachOObjectFile.cpp
@@ -20,6 +20,7 @@
 #include "llvm/ADT/Triple.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/MachO.h"
+#include "llvm/BinaryFormat/Swift.h"
 #include "llvm/Object/Error.h"
 #include "llvm/Object/MachO.h"
 #include "llvm/Object/ObjectFile.h"
@@ -4681,4 +4682,15 @@ StringRef MachOObjectFile::mapDebugSectionName(StringRef Name) const {
   return StringSwitch<StringRef>(Name)
       .Case("debug_str_offs", "debug_str_offsets")
       .Default(Name);
+}
+
+llvm::swift::Swift5ReflectionSectionKind
+MachOObjectFile::mapReflectionSectionNameToEnumValue(
+    StringRef SectionName) const {
+#define HANDLE_SWIFT_SECTION(KIND, MACHO, ELF, COFF)                           \
+  .Case(MACHO, llvm::swift::Swift5ReflectionSectionKind::KIND)
+  return StringSwitch<llvm::swift::Swift5ReflectionSectionKind>(SectionName)
+#include "llvm/BinaryFormat/Swift.def"
+      .Default(llvm::swift::Swift5ReflectionSectionKind::unknown);
+#undef HANDLE_SWIFT_SECTION
 }

--- a/llvm/lib/Object/MachOObjectFile.cpp
+++ b/llvm/lib/Object/MachOObjectFile.cpp
@@ -4684,13 +4684,14 @@ StringRef MachOObjectFile::mapDebugSectionName(StringRef Name) const {
       .Default(Name);
 }
 
-llvm::swift::Swift5ReflectionSectionKind
+llvm::binaryformat::Swift5ReflectionSectionKind
 MachOObjectFile::mapReflectionSectionNameToEnumValue(
     StringRef SectionName) const {
 #define HANDLE_SWIFT_SECTION(KIND, MACHO, ELF, COFF)                           \
-  .Case(MACHO, llvm::swift::Swift5ReflectionSectionKind::KIND)
-  return StringSwitch<llvm::swift::Swift5ReflectionSectionKind>(SectionName)
+  .Case(MACHO, llvm::binaryformat::Swift5ReflectionSectionKind::KIND)
+  return StringSwitch<llvm::binaryformat::Swift5ReflectionSectionKind>(
+             SectionName)
 #include "llvm/BinaryFormat/Swift.def"
-      .Default(llvm::swift::Swift5ReflectionSectionKind::unknown);
+      .Default(llvm::binaryformat::Swift5ReflectionSectionKind::unknown);
 #undef HANDLE_SWIFT_SECTION
 }

--- a/llvm/test/tools/dsymutil/Inputs/main.yaml
+++ b/llvm/test/tools/dsymutil/Inputs/main.yaml
@@ -1,0 +1,886 @@
+# How to generate this file:
+# 1. First take a swift file and run xcrun swiftc -g -v test.swift 
+# reflection_metadata.swift, make sure the two swift files are in a short path 
+# like /tmp/
+
+# 2. Now you can see what the driver does, generate the object files in the 
+# tmp directory and link them to create the input binary
+
+# 3. Run obj2yaml on the input binary to create a yaml file and strip out the 
+# swift5 reflection sections from the load commands in the text segment
+
+# 4. I ran delta to reduce this file.
+
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x1000007
+  cpusubtype:      0x3
+  filetype:        0x2
+  ncmds:           18
+  sizeofcmds:      2848
+  flags:           0x200085
+  reserved:        0x0
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         72
+    segname:         __PAGEZERO
+    vmaddr:          0
+    vmsize:          4294967296
+    fileoff:         0
+    filesize:        0
+    maxprot:         0
+    initprot:        0
+    nsects:          0
+    flags:           0
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         952
+    segname:         __TEXT
+    vmaddr:          4294967296
+    vmsize:          16384
+    fileoff:         0
+    filesize:        16384
+    maxprot:         5
+    initprot:        5
+    nsects:          11
+    flags:           0
+    Sections:
+      - sectname:        __text
+        segname:         __TEXT
+        addr:            0x100003EB0
+        size:            336
+        offset:          0x3EB0
+        align:           3
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x0
+        reserved1:       0x0
+        reserved2:       0x0
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         392
+    segname:         __DATA_CONST
+    vmaddr:          4294983680
+    vmsize:          16384
+    fileoff:         16384
+    filesize:        16384
+    maxprot:         3
+    initprot:        3
+    nsects:          4
+    flags:           16
+    Sections:
+      - sectname:        __got
+        segname:         __DATA_CONST
+        addr:            0x100004000
+        size:            48
+        offset:          0x4000
+        align:           3
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x6
+        reserved1:       0x11
+        reserved2:       0x0
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         392
+    segname:         __DATA
+    vmaddr:          4295000064
+    vmsize:          16384
+    fileoff:         32768
+    filesize:        16384
+    maxprot:         3
+    initprot:        3
+    nsects:          4
+    flags:           0
+    Sections:
+      - sectname:        __la_symbol_ptr
+        segname:         __DATA
+        addr:            0x100008000
+        size:            384
+        offset:          0x8088
+        align:           3
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x0
+        reserved1:       0x0
+        reserved2:       0x0
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         72
+    segname:         __LINKEDIT
+    vmaddr:          4295016448
+    vmsize:          32768
+    fileoff:         49152
+    filesize:        23584
+    maxprot:         1
+    initprot:        1
+    nsects:          0
+    flags:           0
+  - cmd:             LC_DYLD_INFO_ONLY
+    cmdsize:         48
+    rebase_off:      49152
+    rebase_size:     64
+    bind_off:        49216
+    bind_size:       216
+    weak_bind_off:   0
+    weak_bind_size:  0
+    lazy_bind_off:   49432
+    lazy_bind_size:  600
+    export_off:      50032
+    export_size:     1000
+  - cmd:             LC_SYMTAB
+    cmdsize:         24
+    symoff:          51136
+    nsyms:           638
+    stroff:          61504
+    strsize:         11232
+  - cmd:             LC_DYSYMTAB
+    cmdsize:         80
+    ilocalsym:       0
+    nlocalsym:       560
+    iextdefsym:      560
+    nextdefsym:      52
+    iundefsym:       612
+    nundefsym:       26
+    tocoff:          0
+    ntoc:            0
+    modtaboff:       0
+    nmodtab:         0
+    extrefsymoff:    0
+    nextrefsyms:     0
+    indirectsymoff:  61344
+    nindirectsyms:   40
+    extreloff:       0
+    nextrel:         0
+    locreloff:       0
+    nlocrel:         0
+  - cmd:             LC_LOAD_DYLINKER
+    cmdsize:         32
+    name:            12
+  - cmd:             LC_UUID
+    cmdsize:         24
+    uuid:            AA0A51FA-8B29-3A7B-85AA-FA6A457B2211
+  - cmd:             LC_BUILD_VERSION
+    cmdsize:         32
+    platform:        1
+    minos:           786432
+    sdk:             786688
+    ntools:          1
+  - cmd:             LC_SOURCE_VERSION
+    cmdsize:         16
+    version:         0
+  - cmd:             LC_MAIN
+    cmdsize:         24
+    entryoff:        9376
+    stacksize:       0
+  - cmd:             LC_LOAD_DYLIB
+    cmdsize:         56
+    dylib:
+      name:            24
+      timestamp:       2
+      current_version: 14942208
+      compatibility_version: 65536
+  - cmd:             LC_LOAD_DYLIB
+    cmdsize:         56
+    dylib:
+      name:            24
+      timestamp:       2
+      current_version: 85917696
+      compatibility_version: 65536
+  - cmd:             LC_LOAD_DYLIB
+    cmdsize:         64
+    dylib:
+      name:            24
+      timestamp:       2
+      current_version: 85196845
+      compatibility_version: 65536
+  - cmd:             LC_FUNCTION_STARTS
+    cmdsize:         16
+    dataoff:         51032
+    datasize:        104
+  - cmd:             LC_DATA_IN_CODE
+    cmdsize:         16
+    dataoff:         51136
+    datasize:        0
+LinkEditData:
+  NameList:
+    - n_strx:          2355
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294976208
+    - n_strx:          2398
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294976224
+    - n_strx:          2440
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294976240
+    - n_strx:          2479
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294976256
+    - n_strx:          2509
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294976272
+    - n_strx:          2570
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294976320
+    - n_strx:          2590
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294976512
+    - n_strx:          2635
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294976576
+    - n_strx:          2683
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294976608
+    - n_strx:          2731
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294976640
+    - n_strx:          2751
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294976656
+    - n_strx:          2775
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294976704
+    - n_strx:          2791
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294976720
+    - n_strx:          2814
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294976752
+    - n_strx:          2838
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294976768
+    - n_strx:          2873
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294976784
+    - n_strx:          2906
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294976832
+    - n_strx:          2926
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294977104
+    - n_strx:          2946
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294977200
+    - n_strx:          2966
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294977376
+    - n_strx:          3008
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294977392
+    - n_strx:          3049
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294977408
+    - n_strx:          3087
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294977424
+    - n_strx:          3116
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294977440
+    - n_strx:          3176
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294977488
+    - n_strx:          3201
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294977504
+    - n_strx:          3232
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294977552
+    - n_strx:          3270
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294977648
+    - n_strx:          3318
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294977664
+    - n_strx:          3364
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294978352
+    - n_strx:          3411
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294978464
+    - n_strx:          3447
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294978688
+    - n_strx:          3506
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294978832
+    - n_strx:          3567
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294978944
+    - n_strx:          3587
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294979024
+    - n_strx:          3607
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294979056
+    - n_strx:          3627
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294979136
+    - n_strx:          3647
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294979232
+    - n_strx:          3666
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294979264
+    - n_strx:          3686
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294979328
+    - n_strx:          3706
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294979536
+    - n_strx:          3726
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294979856
+    - n_strx:          3746
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294979872
+    - n_strx:          3766
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294979888
+    - n_strx:          3786
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294979920
+    - n_strx:          3814
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294979936
+    - n_strx:          3842
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294980240
+    - n_strx:          3871
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294980288
+    - n_strx:          3898
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294980320
+    - n_strx:          3927
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294980368
+    - n_strx:          3951
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294980384
+    - n_strx:          3982
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294980448
+    - n_strx:          4001
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294980464
+    - n_strx:          4032
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294980512
+    - n_strx:          4060
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294980800
+    - n_strx:          4088
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294981120
+    - n_strx:          4116
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294981136
+    - n_strx:          4144
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294981152
+    - n_strx:          4172
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294981184
+    - n_strx:          4208
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294981248
+    - n_strx:          4225
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          128
+      n_value:         4294981280
+    - n_strx:          4253
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294981328
+    - n_strx:          4276
+      n_type:          0x1E
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294981376
+    - n_strx:          4294
+      n_type:          0x1E
+      n_sect:          5
+      n_desc:          128
+      n_value:         4294981764
+    - n_strx:          4306
+      n_type:          0x1E
+      n_sect:          5
+      n_desc:          0
+      n_value:         4294981824
+    - n_strx:          4322
+      n_type:          0x1E
+      n_sect:          5
+      n_desc:          0
+      n_value:         4294981952
+    - n_strx:          4349
+      n_type:          0x1E
+      n_sect:          5
+      n_desc:          0
+      n_value:         4294981960
+    - n_strx:          4387
+      n_type:          0x1E
+      n_sect:          5
+      n_desc:          0
+      n_value:         4294981968
+    - n_strx:          4423
+      n_type:          0x1E
+      n_sect:          5
+      n_desc:          0
+      n_value:         4294982160
+    - n_strx:          4474
+      n_type:          0xE
+      n_sect:          5
+      n_desc:          0
+      n_value:         4294982352
+    - n_strx:          4503
+      n_type:          0xE
+      n_sect:          5
+      n_desc:          0
+      n_value:         4294982448
+    - n_strx:          4530
+      n_type:          0x1E
+      n_sect:          5
+      n_desc:          128
+      n_value:         4294982464
+    - n_strx:          4558
+      n_type:          0x1E
+      n_sect:          6
+      n_desc:          128
+      n_value:         4294982466
+    - n_strx:          4571
+      n_type:          0x1E
+      n_sect:          6
+      n_desc:          128
+      n_value:         4294982470
+    - n_strx:          4608
+      n_type:          0x1E
+      n_sect:          6
+      n_desc:          128
+      n_value:         4294982476
+    - n_strx:          4639
+      n_type:          0x1E
+      n_sect:          6
+      n_desc:          128
+      n_value:         4294982498
+    - n_strx:          4666
+      n_type:          0x1E
+      n_sect:          6
+      n_desc:          128
+      n_value:         4294982506
+    - n_strx:          4691
+      n_type:          0x1E
+      n_sect:          6
+      n_desc:          128
+      n_value:         4294982510
+    - n_strx:          4727
+      n_type:          0x1E
+      n_sect:          6
+      n_desc:          128
+      n_value:         4294982516
+    - n_strx:          4758
+      n_type:          0x1E
+      n_sect:          6
+      n_desc:          128
+      n_value:         4294982522
+    - n_strx:          4790
+      n_type:          0x1E
+      n_sect:          6
+      n_desc:          128
+      n_value:         4294982528
+    - n_strx:          4820
+      n_type:          0x1E
+      n_sect:          6
+      n_desc:          128
+      n_value:         4294982534
+    - n_strx:          4859
+      n_type:          0x1E
+      n_sect:          6
+      n_desc:          128
+      n_value:         4294982540
+    - n_strx:          4902
+      n_type:          0x1E
+      n_sect:          6
+      n_desc:          128
+      n_value:         4294982554
+    - n_strx:          4945
+      n_type:          0x1E
+      n_sect:          6
+      n_desc:          128
+      n_value:         4294982564
+    - n_strx:          4986
+      n_type:          0x1E
+      n_sect:          6
+      n_desc:          128
+      n_value:         0
+    - n_strx:          5987
+      n_type:          0x66
+      n_sect:          3
+      n_desc:          1
+      n_value:         1638431181
+    - n_strx:          7104
+      n_type:          0x66
+      n_sect:          3
+      n_desc:          1
+      n_value:         1638431191
+  StringTable:
+    - ' '
+    - '_$s4main10MyProtocolMp'
+    - '_$s4main10MyProtocolTL'
+    - '_$s4main11ConformanceV5innerSivM'
+    - '_$s4main11ConformanceV5innerSivg'
+    - '_$s4main11ConformanceV5innerSivpMV'
+    - '_$s4main11ConformanceV5innerSivpfi'
+    - '_$s4main11ConformanceV5innerSivs'
+    - '_$s4main11ConformanceVAA10MyProtocolAAMc'
+    - '_$s4main11ConformanceVAA10MyProtocolAAWP'
+    - '_$s4main11ConformanceVMa'
+    - '_$s4main11ConformanceVMn'
+    - '_$s4main11ConformanceVN'
+    - '_$s4main12Conformance2V5innerSivM'
+    - '_$s4main12Conformance2V5innerSivg'
+    - '_$s4main12Conformance2V5innerSivpMV'
+    - '_$s4main12Conformance2V5innerSivpfi'
+    - '_$s4main12Conformance2V5innerSivs'
+    - '_$s4main12Conformance2VAA10MyProtocolAAMc'
+    - '_$s4main12Conformance2VAA10MyProtocolAAWP'
+    - '_$s4main12Conformance2VMa'
+    - '_$s4main12Conformance2VMn'
+    - '_$s4main12Conformance2VN'
+    - '_$s4main13MyGenericEnumOMa'
+    - '_$s4main13MyGenericEnumOMn'
+    - '_$s4main14MyGenericClassC1t1i3mgs3mgeACyxGx_5InnerQzAA0bC6StructVyxGAA0bC4EnumOyxGtcfC'
+    - '_$s4main14MyGenericClassC1t1i3mgs3mgeACyxGx_5InnerQzAA0bC6StructVyxGAA0bC4EnumOyxGtcfCTq'
+    - '_$s4main14MyGenericClassC1t1i3mgs3mgeACyxGx_5InnerQzAA0bC6StructVyxGAA0bC4EnumOyxGtcfc'
+    - '_$s4main14MyGenericClassCMa'
+    - '_$s4main14MyGenericClassCMn'
+    - '_$s4main14MyGenericClassCfD'
+    - '_$s4main14MyGenericClassCfd'
+    - '_$s4main15MyGenericStructVMa'
+    - '_$s4main15MyGenericStructVMn'
+    - '_$s4main16makeSomeClosures1tyycx_tAA10MyProtocolRzlF'
+    - '_$s4main6MyEnumOMa'
+    - '_$s4main6MyEnumOMn'
+    - '_$s4main6MyEnumON'
+    - '_$s4main7MyClassC1i2ms2meACSi_AA0B6StructVAA0B4EnumOtcfC'
+    - '_$s4main7MyClassC1i2ms2meACSi_AA0B6StructVAA0B4EnumOtcfCTq'
+    - '_$s4main7MyClassC1i2ms2meACSi_AA0B6StructVAA0B4EnumOtcfc'
+    - '_$s4main7MyClassCMa'
+    - '_$s4main7MyClassCMm'
+    - '_$s4main7MyClassCMn'
+    - '_$s4main7MyClassCN'
+    - '_$s4main7MyClassCfD'
+    - '_$s4main7MyClassCfd'
+    - '_$s4main8MyStructVMa'
+    - '_$s4main8MyStructVMn'
+    - '_$s4main8MyStructVN'
+    - '_$s5Inner4main10MyProtocolPTl'
+    - __mh_execute_header
+    - _main
+    - '_$sBi64_WV'
+    - '_$sBoWV'
+    - '_$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC'
+    - '_$sSSN'
+    - '_$sSaMa'
+    - '_$ss27_allocateUninitializedArrayySayxG_BptBwlF'
+    - '_$ss5print_9separator10terminatoryypd_S2StF'
+    - '_$sypN'
+    - '_$sytWV'
+    - '_OBJC_CLASS_$__TtCs12_SwiftObject'
+    - '_OBJC_METACLASS_$__TtCs12_SwiftObject'
+    - __objc_empty_cache
+    - _objc_opt_self
+    - _swift_allocObject
+    - _swift_allocateGenericClassMetadata
+    - _swift_allocateGenericValueMetadata
+    - _swift_bridgeObjectRelease
+    - _swift_checkMetadataState
+    - _swift_deallocClassInstance
+    - _swift_deallocObject
+    - _swift_getAssociatedTypeWitness
+    - _swift_getGenericMetadata
+    - _swift_initClassMetadata2
+    - _swift_release
+    - _swift_retain
+    - dyld_stub_binder
+    - '_$s4main12Conformance2V5innerSivM.resume.0'
+    - '_$s4main12Conformance2V5innerACSi_tcfcfA_'
+    - '_$s4main12Conformance2V5innerACSi_tcfC'
+    - '_$s4main12Conformance2VACycfC'
+    - '_$s4main12Conformance2VAA10MyProtocolA2aDP5inner5InnerQzvgTW'
+    - '_$s4main3AppVAAyyFZ'
+    - '_$ss27_finalizeUninitializedArrayySayxGABnlF'
+    - '_$ss5print_9separator10terminatoryypd_S2StFfA0_'
+    - '_$ss5print_9separator10terminatoryypd_S2StFfA1_'
+    - '_$s4main3AppVACycfC'
+    - '_$s4main3AppV5$mainyyFZ'
+    - '_$s4main3AppVMa'
+    - '_$sSa12_endMutationyyF'
+    - '_$s4main7MyClassC1iSivg'
+    - '_$s4main7MyClassC2msAA0B6StructVvg'
+    - '_$s4main7MyClassC2meAA0B4EnumOvg'
+    - '_$s4main6MyEnumOWOy'
+    - '_$s4main6MyEnumOWOe'
+    - '_$s4main6MyEnumOWOh'
+    - '_$s4main11ConformanceV5innerSivM.resume.0'
+    - '_$s4main11ConformanceV5innerACSi_tcfcfA_'
+    - '_$s4main11ConformanceV5innerACSi_tcfC'
+    - '_$s4main11ConformanceVACycfC'
+    - '_$s4main11ConformanceVAA10MyProtocolA2aDP5inner5InnerQzvgTW'
+    - '_$s4main8MyStructVACycfC'
+    - '_$s4main14MyGenericClassC1txvg'
+    - '_$s4main14MyGenericClassC1i5InnerQzvg'
+    - '_$s4main14MyGenericClassC3mgsAA0bC6StructVyxGvg'
+    - '_$s4main14MyGenericClassC3mgeAA0bC4EnumOyxGvg'
+    - '_$s4main13MyGenericEnumOyxGAA0B8ProtocolRzlWOh'
+    - '_$s4main15MyGenericStructVACyxGycfC'
+    - '_$s4main16makeSomeClosures1tyycx_tAA10MyProtocolRzlFyycfU_'
+    - '_$s4main16makeSomeClosures1tyycx_tAA10MyProtocolRzlFyycfU_TA'
+    - '_$s4main6MyEnumOwCP'
+    - '_$s4main6MyEnumOwxx'
+    - '_$s4main6MyEnumOwcp'
+    - '_$s4main6MyEnumOwca'
+    - ___swift_memcpy9_8
+    - '_$s4main6MyEnumOwta'
+    - '_$s4main6MyEnumOwet'
+    - '_$s4main6MyEnumOwst'
+    - '_$s4main6MyEnumOwug'
+    - '_$s4main6MyEnumOwup'
+    - '_$s4main6MyEnumOwui'
+    - '_$s4main14MyGenericClassCMi'
+    - '_$s4main14MyGenericClassCMr'
+    - '_$s4main15MyGenericStructVMi'
+    - '_$s4main13MyGenericEnumOMi'
+    - ___swift_initWithCopy_strong
+    - ___swift_destroy_strong
+    - ___swift_assignWithCopy_strong
+    - ___swift_memcpy8_8
+    - ___swift_assignWithTake_strong
+    - '_$s4main13MyGenericEnumOwet'
+    - '_$s4main13MyGenericEnumOwst'
+    - '_$s4main13MyGenericEnumOwug'
+    - '_$s4main13MyGenericEnumOwup'
+    - '_$s4main13MyGenericEnumOwui'
+    - ___swift_instantiateGenericMetadata
+    - ___chkstk_darwin
+    - ___chkstk_darwin_llvm_probe
+    - ___chkstk_darwin_probe
+    - ____chkstk_darwin
+    - '_$s4mainMXM'
+    - '_$s4main3AppVMn'
+    - '_$s4main7MyClassC1iSivpWvd'
+    - '_$s4main7MyClassC2msAA0B6StructVvpWvd'
+    - '_$s4main7MyClassC2meAA0B4EnumOvpWvd'
+    - '_$s4main14MyGenericClassC3mgsAA0bC6StructVyxGvpWvd'
+    - '_$s4main15MyGenericStructVMP'
+    - '_$s4main13MyGenericEnumOMP'
+    - ___swift_reflection_version
+    - _symbolic Si
+    - _symbolic _____ 4main12Conformance2V
+    - '_symbolic $s4main10MyProtocolP'
+    - _symbolic _____ 4main3AppV
+    - _symbolic x
+    - _symbolic B0
+    - _symbolic _____ 4main11ConformanceV
+    - _symbolic _____ 4main7MyClassC
+    - _symbolic _____ 4main8MyStructV
+    - _symbolic _____ 4main6MyEnumO
+    - _symbolic _____ 4main14MyGenericClassC
+    - _symbolic 5Inner_____Qz 4main10MyProtocolP
+    - _symbolic _____yxG 4main15MyGenericStructV
+    - _symbolic _____yxG 4main13MyGenericEnumO
+    - _symbolic _____ 4main15MyGenericStructV
+    - _symbolic _____ 4main13MyGenericEnumO
+    - _symbolic _____yxG 4main14MyGenericClassC
+    - '_$s4main12Conformance2VAA10MyProtocolAAMA'
+    - '_$s4main11ConformanceVAA10MyProtocolAAMA'
+    - '_$s4main12Conformance2VMF'
+    - '_$s4main3AppVMF'
+    - '_$s4main10MyProtocol_pMF'
+    - '_$s4main7MyClassCMF'
+    - '_$s4main11ConformanceVMF'
+    - '_$s4main8MyStructVMF'
+    - '_$s4main6MyEnumOMF'
+    - '_$s4main14MyGenericClassCMF'
+    - '_$s4main15MyGenericStructVMF'
+    - '_$s4main13MyGenericEnumOMF'
+    - '_$s4main6MyEnumOMB'
+    - '_$s4main12Conformance2VMf'
+    - '_$s4main3AppVMf'
+    - '_$s4main3AppVN'
+    - '_$s4main11ConformanceVMf'
+    - '_$s4main8MyStructVMf'
+    - '_$s4main6MyEnumOWV'
+    - '_$s4main6MyEnumOMf'
+    - ___unnamed_23
+    - '_$s4main14MyGenericClassCMP'
+    - '_$s4main13MyGenericEnumOWV'
+    - __METACLASS_DATA__TtC4main7MyClass
+    - __IVARS__TtC4main7MyClass
+    - __DATA__TtC4main7MyClass
+    - __IVARS__TtC4main14MyGenericClass
+    - __dyld_private
+    - '_$s4main7MyClassCMf'
+    - '_$s4main14MyGenericClassCMI'
+    - '_$s4main15MyGenericStructVMI'
+    - '_$s4main13MyGenericEnumOMI'
+    - '/tmp/main-1.swiftmodule'
+    - '/Users/shubham/Development/test76973336/final2objfiletest/'
+    - test.swift
+    - '/tmp/test-1.o'
+    - '_$s4main12Conformance2V5innerSivpfi'
+    - '_$s4main12Conformance2V5innerSivg'
+    - '_$s4main12Conformance2V5innerSivs'
+    - '_$s4main12Conformance2V5innerSivM'
+    - '_$s4main12Conformance2V5innerSivM.resume.0'
+    - '_$s4main12Conformance2V5innerACSi_tcfcfA_'
+    - '_$s4main12Conformance2V5innerACSi_tcfC'
+    - '_$s4main12Conformance2VACycfC'
+    - '_$s4main12Conformance2VAA10MyProtocolA2aDP5inner5InnerQzvgTW'
+    - '_$s4main3AppVAAyyFZ'
+    - '_$ss27_finalizeUninitializedArrayySayxGABnlF'
+    - '_$ss5print_9separator10terminatoryypd_S2StFfA0_'
+    - '_$ss5print_9separator10terminatoryypd_S2StFfA1_'
+    - '_$s4main3AppVACycfC'
+    - '_$s4main3AppV5$mainyyFZ'
+    - _main
+    - '_$s4main12Conformance2VMa'
+    - '_$s4main3AppVMa'
+    - '_$sSa12_endMutationyyF'
+    - '_$s4main12Conformance2VAA10MyProtocolAAMc'
+    - '_$s4main12Conformance2V5innerSivpMV'
+    - '_$s4mainMXM'
+    - '_$s4main12Conformance2VMn'
+    - '_$s4main3AppVMn'
+    - _symbolic Si
+    - _symbolic _____ 4main12Conformance2V
+    - '_symbolic $s4main10MyProtocolP'
+    - _symbolic _____ 4main3AppV
+    - '_$s4main12Conformance2VAA10MyProtocolAAMA'
+    - '_$s4main12Conformance2VMF'
+    - '_$s4main3AppVMF'
+    - '_$s4main12Conformance2VMf'
+    - '_$s4main12Conformance2VN'
+    - '_$s4main3AppVMf'
+    - '_$s4main3AppVN'
+    - '_$s4main12Conformance2VAA10MyProtocolAAWP'
+    - reflection_metadata.swift
+    - '/tmp/reflection_metadata-1.o'

--- a/llvm/test/tools/dsymutil/Inputs/reflection_metadata.yaml
+++ b/llvm/test/tools/dsymutil/Inputs/reflection_metadata.yaml
@@ -1,0 +1,436 @@
+# How to generate this file:
+# 1. First take a swift file and run xcrun swiftc -g -v file.swift 
+# secondfile.swift, make sure the two swift files are in a short path like /tmp/
+
+# 2. Now you can see what the driver does, generate the object files in the 
+# tmp directory
+
+# 3. Run obj2yaml on object file to create a yaml file
+
+# 4. I ran delta to reduce this file.
+
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x1000007
+  cpusubtype:      0x3
+  filetype:        0x1
+  ncmds:           8
+  sizeofcmds:      2800
+  flags:           0x2000
+  reserved:        0x0
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         2552
+    segname:         ''
+    vmaddr:          0
+    vmsize:          21352
+    fileoff:         2832
+    filesize:        20967
+    maxprot:         7
+    initprot:        7
+    nsects:          31
+    flags:           0
+    Sections:
+      - sectname:        __text
+        segname:         __TEXT
+        addr:            0x0
+        size:            4571
+        offset:          0xB10
+        align:           4
+        reloff:          0x5CF8
+        nreloc:          74
+        flags:           0x80000400
+        reserved1:       0x0
+        reserved2:       0x0
+        relocations:
+          - address:         0x11A1
+            symbolnum:       142
+            pcrel:           true
+            length:          2
+            extern:          true
+            type:            1
+            scattered:       false
+            value:           0
+      - sectname:        __swift5_typeref
+        segname:         __TEXT
+        addr:            0x11DC
+        size:            117
+        offset:          0x1CEC
+        align:           1
+        reloff:          0x5F48
+        nreloc:          22
+        flags:           0x10000000
+        reserved1:       0x0
+        reserved2:       0x0
+        content:         7800423000005369000001FFFFFFFF002473346D61696E31304D7950726F746F636F6C50000001FFFFFFFF0001FFFFFFFF0001FFFFFFFF0001FFFFFFFF0035496E6E657201F9FFFFFF517A0001FFFFFFFF797847000001FFFFFFFF797847000001FFFFFFFF0001FFFFFFFF0001FFFFFFFF79784700
+        relocations:
+          - address:         0x6D
+            symbolnum:       163
+            pcrel:           false
+            length:          2
+            extern:          true
+            type:            0
+            scattered:       false
+            value:           0
+      - sectname:        __swift5_capture
+        segname:         __TEXT
+        addr:            0x1254
+        size:            24
+        offset:          0x1D64
+        align:           2
+        reloff:          0x5FF8
+        nreloc:          6
+        flags:           0x10000000
+        reserved1:       0x0
+        reserved2:       0x0
+        content:         010000000100000002000000F4FFFFFFF0FFFFFFECFFFFFF
+        relocations:
+          - address:         0x14
+            symbolnum:       29
+            pcrel:           false
+            length:          3
+            extern:          true
+            type:            0
+            scattered:       false
+            value:           0
+      - sectname:        __swift5_reflstr
+        segname:         __TEXT
+        addr:            0x17D8
+        size:            37
+        offset:          0x22E8
+        align:           0
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x10000000
+        reserved1:       0x0
+        reserved2:       0x0
+        content:         496E6E65720069006D73006D6500696E6E6572004300490074006D6773006D676500474300
+      - sectname:        __swift5_assocty
+        segname:         __TEXT
+        addr:            0x1800
+        size:            24
+        offset:          0x2310
+        align:           2
+        reloff:          0x6530
+        nreloc:          8
+        flags:           0x10000000
+        reserved1:       0x0
+        reserved2:       0x0
+        content:         00000000FCFFFFFF0100000008000000F0FFFFFFECFFFFFF
+        relocations:
+          - address:         0x14
+            symbolnum:       31
+            pcrel:           false
+            length:          2
+            extern:          true
+            type:            5
+            scattered:       false
+            value:           0
+      - sectname:        __swift5_fieldmd
+        segname:         __TEXT
+        addr:            0x1818
+        size:            260
+        offset:          0x2328
+        align:           2
+        reloff:          0x6570
+        nreloc:          60
+        flags:           0x10000000
+        reserved1:       0x0
+        reserved2:       0x0
+        content:         000000000000000004000C0000000000000000000000000001000C000300000000000000ECFFFFFFE8FFFFFF00000000E0FFFFFFDCFFFFFF00000000D4FFFFFFD0FFFFFF000000000000000000000C000100000002000000ECFFFFFFE8FFFFFF000000000000000000000C0000000000000000000000000003000C000200000000000000ECFFFFFFE8FFFFFF00000000E0FFFFFFDCFFFFFF000000000000000001000C000400000000000000ECFFFFFFE8FFFFFF00000000E0FFFFFFDCFFFFFF00000000D4FFFFFFD0FFFFFF00000000C8FFFFFFC4FFFFFF000000000000000000000C0000000000000000000000000002000C000100000000000000ECFFFFFFE8FFFFFF
+        relocations:
+          - address:         0x100
+            symbolnum:       71
+            pcrel:           false
+            length:          2
+            extern:          true
+            type:            0
+            scattered:       false
+            value:           0
+      - sectname:        __swift5_builtin
+        segname:         __TEXT
+        addr:            0x1AC8
+        size:            20
+        offset:          0x25D8
+        align:           2
+        reloff:          0x67F8
+        nreloc:          2
+        flags:           0x10000000
+        reserved1:       0x0
+        reserved2:       0x0
+        content:         00000000090000000800010010000000FE000000
+        relocations:
+          - address:         0x0
+            symbolnum:       52
+            pcrel:           false
+            length:          2
+            extern:          true
+            type:            5
+            scattered:       false
+            value:           0
+      - sectname:        __bss
+        segname:         __DATA
+        addr:            0x3372
+        size:            2084
+        offset:          0x50B0
+        align:           3
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x6800000B
+        reserved1:       0x0
+        reserved2:       0x0
+        relocations:
+          - address:         0x56
+            symbolnum:       1
+            pcrel:           false
+            length:          3
+            extern:          false
+            type:            0
+            scattered:       false
+            value:           0
+  - cmd:             LC_BUILD_VERSION
+    cmdsize:         24
+    platform:        1
+    minos:           786432
+    sdk:             786688
+    ntools:          0
+  - cmd:             LC_SYMTAB
+    cmdsize:         24
+    symoff:          27888
+    nsyms:           185
+    stroff:          30848
+    strsize:         5056
+  - cmd:             LC_DYSYMTAB
+    cmdsize:         80
+    ilocalsym:       0
+    nlocalsym:       79
+    iextdefsym:      79
+    nextdefsym:      87
+    iundefsym:       166
+    nundefsym:       19
+    tocoff:          0
+    ntoc:            0
+    modtaboff:       0
+    nmodtab:         0
+    extrefsymoff:    0
+    nextrefsyms:     0
+    indirectsymoff:  0
+    nindirectsyms:   0
+    extreloff:       0
+    nextrel:         0
+    locreloff:       0
+    nlocrel:         0
+  - cmd:             LC_LINKER_OPTION
+    cmdsize:         40
+    count:           1
+    PayloadBytes:    [ 0x2D, 0x6C, 0x73, 0x77, 0x69, 0x66, 0x74, 0x53, 
+                       0x0, 0x0, 0x0, 0x0 ]
+  - cmd:             LC_LINKER_OPTION
+    cmdsize:         24
+    count:           1
+    PayloadBytes:    [ 0x2D, 0x6C, 0x73, 0x77, 0x69, 0x66, 0x74, 0x43, 
+                       0x6F, 0x72, 0x65, 0x0 ]
+  - cmd:             LC_LINKER_OPTION
+    cmdsize:         32
+    count:           1
+    PayloadBytes:    [ 0x2D, 0x6C, 0x73, 0x77, 0x69, 0x66, 0x74, 0x5F, 
+                       0x6E, 0x63, 0x79, 0x0 ]
+  - cmd:             LC_LINKER_OPTION
+    cmdsize:         24
+    count:           1
+    PayloadBytes:    [ 0x2D, 0x6C, 0x6F, 0x62, 0x6A, 0x63, 0x0, 0x0, 0x0, 
+                       0x0, 0x0, 0x0 ]
+LinkEditData:
+  NameList:
+    - n_strx:          5014
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         5600
+  StringTable:
+    - ''
+    - l_objectdestroy
+    - '_$s4main6MyEnumOWOy'
+    - '_$s4main6MyEnumOwxx'
+    - _symbolic x
+    - '_$s4main6MyEnumOwst'
+    - '_$s4main13MyGenericEnumOwst'
+    - '_$s4main6MyEnumOwet'
+    - '_$s4main13MyGenericEnumOwet'
+    - '_OBJC_CLASS_$__TtCs12_SwiftObject'
+    - '_OBJC_METACLASS_$__TtCs12_SwiftObject'
+    - _swift_deallocObject
+    - _swift_allocObject
+    - '_$s4main11ConformanceV5innerSivs'
+    - _swift_getAssociatedTypeWitness
+    - __IVARS__TtC4main7MyClass
+    - __DATA__TtC4main7MyClass
+    - __METACLASS_DATA__TtC4main7MyClass
+    - __IVARS__TtC4main14MyGenericClass
+    - l_protocols
+    - _objc_classes
+    - l_protocol_conformances
+    - l__swift5_reflection_descriptor
+    - l_coro.devirt.trigger
+    - '_$s4main14MyGenericClassCMr'
+    - '_$s4main7MyClassC1i2ms2meACSi_AA0B6StructVAA0B4EnumOtcfCTq'
+    - '_$s4main14MyGenericClassC1t1i3mgs3mgeACyxGx_5InnerQzAA0bC6StructVyxGAA0bC4EnumOyxGtcfCTq'
+    - '_$s4main6MyEnumOwup'
+    - '_$s4main13MyGenericEnumOwup'
+    - '_$s4main6MyEnumOwcp'
+    - '_$s4main10MyProtocolMp'
+    - ___swift_reflection_version
+    - ____chkstk_darwin
+    - _swift_retain
+    - '_$s4main8MyStructVMn'
+    - '_$s4main15MyGenericStructVMn'
+    - '_$s4main11ConformanceVMn'
+    - '_$s4main6MyEnumOMn'
+    - '_$s4main13MyGenericEnumOMn'
+    - '_$s4main7MyClassCMn'
+    - '_$s4main14MyGenericClassCMn'
+    - '_$s4main7MyClassCMm'
+    - '_$s5Inner4main10MyProtocolPTl'
+    - '_$s4main6MyEnumOwui'
+    - '_$s4main13MyGenericEnumOwui'
+    - '_$s4main11ConformanceV5innerSivpfi'
+    - _symbolic Si
+    - '_$s4main15MyGenericStructVMi'
+    - '_$s4main13MyGenericEnumOMi'
+    - '_$s4main14MyGenericClassCMi'
+    - l_llvm.swift_module_hash
+    - '_$s4main13MyGenericEnumOyxGAA0B8ProtocolRzlWOh'
+    - '_$s4main6MyEnumOWOh'
+    - '_$s4main14MyGenericClassC1i5InnerQzvg'
+    - '_$s4main14MyGenericClassC1txvg'
+    - '_$s4main11ConformanceV5innerSivg'
+    - '_$s4main7MyClassC1iSivg'
+    - '_$s4main7MyClassC2msAA0B6StructVvg'
+    - '_$s4main7MyClassC2meAA0B4EnumOvg'
+    - '_$s4main14MyGenericClassC3mgsAA0bC6StructVyxGvg'
+    - '_$s4main14MyGenericClassC3mgeAA0bC4EnumOyxGvg'
+    - '_$s4main6MyEnumOwug'
+    - '_$s4main13MyGenericEnumOwug'
+    - ___swift_initWithCopy_strong
+    - ___swift_assignWithCopy_strong
+    - ___swift_destroy_strong
+    - ___swift_assignWithTake_strong
+    - _objc_opt_self
+    - '_$s4main8MyStructVMf'
+    - '_$s4main11ConformanceVMf'
+    - '_$s4main6MyEnumOMf'
+    - '_$s4main7MyClassCMf'
+    - _swift_checkMetadataState
+    - _swift_release
+    - l_type_metadata_table
+    - __objc_empty_cache
+    - _swift_deallocClassInstance
+    - ___chkstk_darwin_llvm_probe
+    - '_$s4main6MyEnumOWOe'
+    - '_$s4main7MyClassC1iSivpWvd'
+    - '_$s4main7MyClassC2msAA0B6StructVvpWvd'
+    - '_$s4main7MyClassC2meAA0B4EnumOvpWvd'
+    - '_$s4main14MyGenericClassC3mgsAA0bC6StructVyxGvpWvd'
+    - '_$s4main7MyClassCfd'
+    - '_$s4main14MyGenericClassCfd'
+    - '_$s4main7MyClassC1i2ms2meACSi_AA0B6StructVAA0B4EnumOtcfc'
+    - '_$s4main14MyGenericClassC1t1i3mgs3mgeACyxGx_5InnerQzAA0bC6StructVyxGAA0bC4EnumOyxGtcfc'
+    - '_$s4main11ConformanceVAA10MyProtocolAAMc'
+    - '_$s4main6MyEnumOwta'
+    - l_metadata
+    - _swift_allocateGenericClassMetadata
+    - _swift_allocateGenericValueMetadata
+    - _swift_getGenericMetadata
+    - ___swift_instantiateGenericMetadata
+    - '_$s4main6MyEnumOwca'
+    - '_$s4main8MyStructVMa'
+    - '_$s4main15MyGenericStructVMa'
+    - '_$s4main11ConformanceVMa'
+    - '_$s4main6MyEnumOMa'
+    - '_$s4main13MyGenericEnumOMa'
+    - '_$s4main7MyClassCMa'
+    - '_$s4main14MyGenericClassCMa'
+    - '_$s4main16makeSomeClosures1tyycx_tAA10MyProtocolRzlFyycfU_'
+    - '_$s4main11ConformanceV5innerACSi_tcfcfA_'
+    - '_$s4main11ConformanceVAA10MyProtocolA2aDP5inner5InnerQzvgTW'
+    - _symbolic _____ 4main8MyStructV
+    - _symbolic _____ 4main15MyGenericStructV
+    - _symbolic _____yxG 4main15MyGenericStructV
+    - _symbolic _____ 4main11ConformanceV
+    - '_$sytWV'
+    - '_$sBoWV'
+    - '_$sBi64_WV'
+    - '_$s4main6MyEnumOWV'
+    - '_$s4main13MyGenericEnumOWV'
+    - '_$s4main11ConformanceV5innerSivpMV'
+    - '_symbolic $s4main10MyProtocolP'
+    - _symbolic 5Inner_____Qz 4main10MyProtocolP
+    - '_$s4main11ConformanceVAA10MyProtocolAAWP'
+    - '_$s4main15MyGenericStructVMP'
+    - '_$s4main13MyGenericEnumOMP'
+    - '_$s4main14MyGenericClassCMP'
+    - '_$s4main6MyEnumOwCP'
+    - _symbolic _____ 4main6MyEnumO
+    - _symbolic _____ 4main13MyGenericEnumO
+    - _symbolic _____yxG 4main13MyGenericEnumO
+    - '_$s4main8MyStructVN'
+    - '_$s4main11ConformanceVN'
+    - '_$s4main6MyEnumON'
+    - '_$s4main7MyClassCN'
+    - '_$s4main11ConformanceV5innerSivM'
+    - '_$s4mainMXM'
+    - '_$s4main10MyProtocolTL'
+    - '_$s4main15MyGenericStructVMI'
+    - '_$s4main13MyGenericEnumOMI'
+    - '_$s4main14MyGenericClassCMI'
+    - '_$s4main16makeSomeClosures1tyycx_tAA10MyProtocolRzlF'
+    - '_$s4main10MyProtocol_pMF'
+    - '_$s4main8MyStructVMF'
+    - '_$s4main15MyGenericStructVMF'
+    - '_$s4main11ConformanceVMF'
+    - '_$s4main6MyEnumOMF'
+    - '_$s4main13MyGenericEnumOMF'
+    - '_$s4main7MyClassCMF'
+    - '_$s4main14MyGenericClassCMF'
+    - '_$s4main7MyClassCfD'
+    - '_$s4main14MyGenericClassCfD'
+    - _symbolic _____ 4main7MyClassC
+    - _symbolic _____ 4main14MyGenericClassC
+    - _symbolic _____yxG 4main14MyGenericClassC
+    - '_$s4main15MyGenericStructVACyxGycfC'
+    - '_$s4main8MyStructVACycfC'
+    - '_$s4main11ConformanceVACycfC'
+    - '_$s4main11ConformanceV5innerACSi_tcfC'
+    - '_$s4main7MyClassC1i2ms2meACSi_AA0B6StructVAA0B4EnumOtcfC'
+    - '_$s4main14MyGenericClassC1t1i3mgs3mgeACyxGx_5InnerQzAA0bC6StructVyxGAA0bC4EnumOyxGtcfC'
+    - '_$s4main6MyEnumOMB'
+    - '_$s4main16makeSomeClosures1tyycx_tAA10MyProtocolRzlFyycfU_TA'
+    - '_$s4main11ConformanceVAA10MyProtocolAAMA'
+    - l___unnamed_29
+    - l___unnamed_19
+    - ___swift_memcpy9_8
+    - ___swift_memcpy8_8
+    - l___unnamed_28
+    - l___unnamed_18
+    - l___unnamed_27
+    - l___unnamed_17
+    - l___unnamed_26
+    - l___unnamed_16
+    - l___unnamed_25
+    - l___unnamed_15
+    - l___unnamed_4
+    - l___unnamed_24
+    - l___unnamed_14
+    - l___unnamed_3
+    - ___unnamed_23
+    - l___unnamed_13
+    - _swift_initClassMetadata2
+    - l___unnamed_2
+    - l___unnamed_12
+    - l___unnamed_1
+    - l___unnamed_11
+    - _symbolic B0
+    - l___unnamed_30
+    - l___unnamed_10
+    - '_$s4main11ConformanceV5innerSivM.resume.0'

--- a/llvm/test/tools/dsymutil/Inputs/test.yaml
+++ b/llvm/test/tools/dsymutil/Inputs/test.yaml
@@ -1,0 +1,254 @@
+# How to generate this file:
+# 1. First take a swift file and run xcrun swiftc -g -v file.swift 
+# secondfile.swift, make sure the two swift files are in a short path like /tmp/
+
+# 2. Now you can see what the driver does, generate the object files in the 
+# tmp directory
+
+# 3. Run obj2yaml on object file to create a yaml file
+
+# 4. I ran delta to reduce this file.
+
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x1000007
+  cpusubtype:      0x3
+  filetype:        0x1
+  ncmds:           8
+  sizeofcmds:      2240
+  flags:           0x2000
+  reserved:        0x0
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         1992
+    segname:         ''
+    vmaddr:          0
+    vmsize:          6592
+    fileoff:         2272
+    filesize:        6592
+    maxprot:         7
+    initprot:        7
+    nsects:          24
+    flags:           0
+    Sections:
+      - sectname:        __text
+        segname:         __TEXT
+        addr:            0x0
+        size:            593
+        offset:          0x8E0
+        align:           4
+        reloff:          0x22A0
+        nreloc:          24
+        flags:           0x80000400
+        reserved1:       0x0
+        reserved2:       0x0
+        relocations:
+          - address:         0x233
+            symbolnum:       2
+            pcrel:           true
+            length:          2
+            extern:          true
+            type:            4
+            scattered:       false
+            value:           0
+      - sectname:        __swift5_typeref
+        segname:         __TEXT
+        addr:            0x2D6
+        size:            38
+        offset:          0xBB6
+        align:           1
+        reloff:          0x2418
+        nreloc:          4
+        flags:           0x10000000
+        reserved1:       0x0
+        reserved2:       0x0
+        content:         5369000001FFFFFFFF002473346D61696E31304D7950726F746F636F6C50000001FFFFFFFF00
+        relocations:
+          - address:         0x21
+            symbolnum:       46
+            pcrel:           false
+            length:          3
+            extern:          true
+            type:            0
+            scattered:       false
+            value:           0
+      - sectname:        __swift5_reflstr
+        segname:         __TEXT
+        addr:            0x318
+        size:            12
+        offset:          0xBF8
+        align:           0
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x10000000
+        reserved1:       0x0
+        reserved2:       0x0
+        content:         496E6E657200696E6E657200
+      - sectname:        __swift5_assocty
+        segname:         __TEXT
+        addr:            0x324
+        size:            24
+        offset:          0xC04
+        align:           2
+        reloff:          0x2450
+        nreloc:          8
+        flags:           0x10000000
+        reserved1:       0x0
+        reserved2:       0x0
+        content:         00000000FCFFFFFF0100000008000000F0FFFFFFECFFFFFF
+        relocations:
+          - address:         0x14
+            symbolnum:       5
+            pcrel:           false
+            length:          2
+            extern:          true
+            type:            0
+            scattered:       false
+            value:           0
+      - sectname:        __swift5_fieldmd
+        segname:         __TEXT
+        addr:            0x378
+        size:            44
+        offset:          0xC58
+        align:           2
+        reloff:          0x24C0
+        nreloc:          8
+        flags:           0x10000000
+        reserved1:       0x0
+        reserved2:       0x0
+        content:         000000000000000000000C000100000002000000ECFFFFFFE8FFFFFF000000000000000000000C0000000000
+        relocations:
+          - address:         0x1C
+            symbolnum:       12
+            pcrel:           false
+            length:          3
+            extern:          false
+            type:            0
+            scattered:       false
+            value:           0
+  - cmd:             LC_BUILD_VERSION
+    cmdsize:         24
+    platform:        1
+    minos:           786432
+    sdk:             786688
+    ntools:          0
+  - cmd:             LC_SYMTAB
+    cmdsize:         24
+    symoff:          9824
+    nsyms:           57
+    stroff:          10736
+    strsize:         1544
+  - cmd:             LC_DYSYMTAB
+    cmdsize:         80
+    ilocalsym:       0
+    nlocalsym:       16
+    iextdefsym:      16
+    nextdefsym:      31
+    iundefsym:       47
+    nundefsym:       10
+    tocoff:          0
+    ntoc:            0
+    modtaboff:       0
+    nmodtab:         0
+    extrefsymoff:    0
+    nextrefsyms:     0
+    indirectsymoff:  0
+    nindirectsyms:   0
+    extreloff:       0
+    nextrel:         0
+    locreloff:       0
+    nlocrel:         0
+  - cmd:             LC_LINKER_OPTION
+    cmdsize:         40
+    count:           1
+    PayloadBytes:    [ 0x2D, 0x6C, 0x73, 0x77, 0x69, 0x66, 0x74, 0x53, 
+                       0x0, 0x0, 0x0, 0x0 ]
+  - cmd:             LC_LINKER_OPTION
+    cmdsize:         24
+    count:           1
+    PayloadBytes:    [ 0x2D, 0x6C, 0x73, 0x77, 0x69, 0x66, 0x74, 0x43, 
+                       0x6F, 0x72, 0x65, 0x0 ]
+  - cmd:             LC_LINKER_OPTION
+    cmdsize:         32
+    count:           1
+    PayloadBytes:    [ 0x2D, 0x6C, 0x73, 0x77, 0x69, 0x66, 0x74, 0x5F, 
+                       0x6E, 0x63, 0x79, 0x0 ]
+  - cmd:             LC_LINKER_OPTION
+    cmdsize:         24
+    count:           1
+    PayloadBytes:    [ 0x2D, 0x6C, 0x6F, 0x62, 0x6A, 0x63, 0x0, 0x0, 0x0, 
+                       0x0, 0x0, 0x0 ]
+LinkEditData:
+  NameList:
+    - n_strx:          1494
+      n_type:          0xE
+      n_sect:          9
+      n_desc:          0
+      n_value:         0
+  StringTable:
+    - ''
+    - l_entry_point
+    - '_$s4main12Conformance2V5innerSivs'
+    - l_protocol_conformances
+    - l_coro.devirt.trigger
+    - '_$s4main10MyProtocolMp'
+    - ___swift_reflection_version
+    - _main
+    - '_$s4main3AppVMn'
+    - '_$s4main12Conformance2VMn'
+    - '_$s4main12Conformance2V5innerSivpfi'
+    - _symbolic Si
+    - l_llvm.swift_module_hash
+    - '_$s4main12Conformance2V5innerSivg'
+    - '_$s4main3AppVMf'
+    - '_$s4main12Conformance2VMf'
+    - _swift_bridgeObjectRelease
+    - l_type_metadata_table
+    - '_$s4main12Conformance2VAA10MyProtocolAAMc'
+    - '_$sSaMa'
+    - '_$s4main3AppVMa'
+    - '_$s4main12Conformance2VMa'
+    - '_$s4main12Conformance2V5innerACSi_tcfcfA_'
+    - '_$ss5print_9separator10terminatoryypd_S2StFfA1_'
+    - '_$ss5print_9separator10terminatoryypd_S2StFfA0_'
+    - '_$s4main3AppV5$mainyyFZ'
+    - '_$s4main3AppVAAyyFZ'
+    - '_$s4main12Conformance2VAA10MyProtocolA2aDP5inner5InnerQzvgTW'
+    - _symbolic _____ 4main3AppV
+    - '_$sytWV'
+    - '_$sBi64_WV'
+    - '_$s4main12Conformance2V5innerSivpMV'
+    - _symbolic _____ 4main12Conformance2V
+    - '_symbolic $s4main10MyProtocolP'
+    - '_$s4main12Conformance2VAA10MyProtocolAAWP'
+    - '_$sypN'
+    - '_$s4main3AppVN'
+    - '_$s4main12Conformance2VN'
+    - '_$sSSN'
+    - '_$s4main12Conformance2V5innerSivM'
+    - '_$s4mainMXM'
+    - '_$sSa12_endMutationyyF'
+    - '_$ss5print_9separator10terminatoryypd_S2StF'
+    - '_$ss27_allocateUninitializedArrayySayxG_BptBwlF'
+    - '_$ss27_finalizeUninitializedArrayySayxGABnlF'
+    - '_$s4main3AppVMF'
+    - '_$s4main12Conformance2VMF'
+    - '_$s4main3AppVACycfC'
+    - '_$s4main12Conformance2VACycfC'
+    - '_$s4main12Conformance2V5innerACSi_tcfC'
+    - '_$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC'
+    - '_$s4main12Conformance2VAA10MyProtocolAAMA'
+    - l___unnamed_8
+    - l___unnamed_7
+    - l___unnamed_6
+    - l___unnamed_5
+    - l___unnamed_4
+    - '_$s4main12Conformance2V5innerSivM.resume.0'
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''

--- a/llvm/test/tools/dsymutil/X86/reflection-dump.test
+++ b/llvm/test/tools/dsymutil/X86/reflection-dump.test
@@ -1,0 +1,44 @@
+RUN: rm -rf %t.dir && mkdir -p %t.dir/tmp
+RUN: cp %p/../Inputs/main.yaml %t.dir
+RUN: cp %p/../Inputs/test.yaml %t.dir
+RUN: cp %p/../Inputs/reflection_metadata.yaml %t.dir
+RUN: yaml2obj %p/../Inputs/main.yaml -o %t.dir/main
+RUN: yaml2obj %p/../Inputs/test.yaml -o %t.dir/tmp/test-1.o
+RUN: yaml2obj %p/../Inputs/reflection_metadata.yaml -o %t.dir/tmp/reflection_metadata-1.o
+
+RUN: dsymutil -oso-prepend-path=%t.dir %t.dir/main -o %t.dir/main.dSYM
+RUN: llvm-objdump -s %t.dir/main.dSYM/Contents/Resources/DWARF/main | FileCheck %s
+
+REQUIRES: host-byteorder-little-endian
+
+CHECK: Contents of section __DWARF,__swift5_typeref:
+CHECK-NEXT:  10000e000 53690000 01ffffff ff002473 346d6169  Si........$s4mai
+CHECK-NEXT:  10000e010 6e31304d 7950726f 746f636f 6c500000  n10MyProtocolP..
+CHECK-NEXT:  10000e020 01ffffff ff007800 42300000 53690000  ......x.B0..Si..
+CHECK-NEXT:  10000e030 01ffffff ff002473 346d6169 6e31304d  ......$s4main10M
+CHECK-NEXT:  10000e040 7950726f 746f636f 6c500000 01ffffff  yProtocolP......
+
+CHECK: Contents of section __DWARF,__swift5_reflstr:
+CHECK-NEXT:  10000e09b 496e6e65 7200696e 6e657200 496e6e65  Inner.inner.Inne
+CHECK-NEXT:  10000e0ab 72006900 6d73006d 6500696e 6e657200  r.i.ms.me.inner.
+CHECK-NEXT:  10000e0bb 43004900 74006d67 73006d67 65004743  C.I.t.mgs.mge.GC
+CHECK-NEXT:  10000e0cb 00
+
+CHECK: Contents of section __DWARF,__swift5_assocty:
+CHECK-NEXT:  10000e0cc 00000000 fcffffff 01000000 08000000  ................
+CHECK-NEXT:  10000e0dc f0ffffff ecffffff 00000000 fcffffff  ................
+CHECK-NEXT:  10000e0ec 01000000 08000000 f0ffffff ecffffff  ................
+
+CHECK: Contents of section __DWARF,__swift5_fieldmd:
+CHECK-NEXT:  10000e0fc 00000000 00000000 00000c00 01000000  ................
+CHECK-NEXT:  10000e10c 02000000 ecffffff e8ffffff 00000000  ................
+CHECK-NEXT:  10000e11c 00000000 00000c00 00000000 00000000  ................
+CHECK-NEXT:  10000e12c 00000000 04000c00 00000000 00000000  ................
+
+CHECK: Contents of section __DWARF,__swift5_capture:
+CHECK-NEXT:  10000e22c 01000000 01000000 02000000 f4ffffff  ................
+CHECK-NEXT:	 10000e23c f0ffffff ecffffff                    ........
+
+CHECK: Contents of section __DWARF,__swift5_builtin:
+CHECK-NEXT:  10000e244 00000000 09000000 08000100 10000000  ................
+CHECK-NEXT:  10000e254 fe000000                             ....

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -331,7 +331,7 @@ static bool binaryHasSwiftReflectionSections(const DebugMap &Map,
       }
       NameOrErr->consume_back("__TEXT");
       if (Object->mapReflectionSectionNameToEnumValue(*NameOrErr) !=
-          llvm::swift::Swift5ReflectionSectionKind::unknown) {
+          llvm::binaryformat::Swift5ReflectionSectionKind::unknown) {
         return true;
       }
     }


### PR DESCRIPTION

Add support for Swift reflection metadata to dsymutil.

This patch adds support for copying Swift reflection metadata (__swift5_.* sections) from .o files to into the symbol-rich binary in the output .dSYM. The functionality is automatically enabled only if a .o file has reflection metadata sections and the binary doesn't. When copying dsymutil moves the section from the __TEXT segment to the __DWARF segment.

rdar://76973336

Differential Revision: https://reviews.llvm.org/D115007

(cherry picked from commit 4ce1f3d47c33daccfb7f4e906c3f57b404900036)