### PR TITLE
Prepare TypeRefTypesystem to read static size info from Debug Info

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -247,6 +247,7 @@ public:
 
   // Swift-specific methods.
   lldb::TypeSP GetCachedType(ConstString mangled);
+  lldb::TypeSP GetCachedType(lldb::opaque_compiler_type_t type);
   void SetCachedType(ConstString mangled, const lldb::TypeSP &type_sp);
   bool IsImportedType(lldb::opaque_compiler_type_t type,
                       CompilerType *original_type) override;
@@ -306,7 +307,7 @@ private:
   const char *AsMangledName(lldb::opaque_compiler_type_t type);
 
   /// Lookup a type in the debug info.
-  lldb::TypeSP LookupTypeInModule(lldb::opaque_compiler_type_t type);
+  lldb::TypeSP FindTypeInModule(lldb::opaque_compiler_type_t type);
 
   /// Demangle the mangled name of the canonical type of \p type and
   /// drill into the Global(TypeMangling(Type())).


### PR DESCRIPTION
This patch refactors GetBitSize and GetTypeBitAlign to make it easy
let it read size info for static types from debug info. This would be
faster than reading it out of reflection metadata, but the Swift
compiler currently wrongly emit static size info for types that
shouldn't have any, including resilient types. We either need to stop
the compiler from emitting it or we need to mark resilient types to
tell LLDB that the size info cannot be trusted.