### PR TITLE
Import the Swift stdlib before importing any user modules (NFC)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1837,6 +1837,22 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
     return {};
   }
 
+  if (swift_ast_sp->HasFatalErrors()) {
+    logError(swift_ast_sp->GetFatalErrors().AsCString());
+    return {};
+  }
+
+  {
+    LLDB_SCOPED_TIMERF("%s (getStdlibModule)", m_description.c_str());
+    const bool can_create = true;
+    swift::ModuleDecl *stdlib =
+        swift_ast_sp->m_ast_context_ap->getStdlibModule(can_create);
+    if (!stdlib || IsDWARFImported(*stdlib)) {
+      logError("couldn't load the Swift stdlib");
+      return {};
+    }
+  }
+
   std::vector<std::string> module_names;
   swift_ast_sp->RegisterSectionModules(module, module_names);
   if (!module_names.size()) {
@@ -1856,17 +1872,6 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
   if (swift_ast_sp->HasFatalErrors()) {
     logError(swift_ast_sp->GetFatalErrors().AsCString());
     return {};
-  }
-
-  {
-    LLDB_SCOPED_TIMERF("%s (getStdlibModule)", m_description.c_str());
-    const bool can_create = true;
-    swift::ModuleDecl *stdlib =
-        swift_ast_sp->m_ast_context_ap->getStdlibModule(can_create);
-    if (!stdlib || IsDWARFImported(*stdlib)) {
-      logError("couldn't load the Swift stdlib");
-      return {};
-    }
   }
 
   return swift_ast_sp;


### PR DESCRIPTION
In terms of the error diagnostics it makes more sense to check whether
a stdlib for the current triple can be found at all before attempting
to import user modules. This should make it easier to pinpoint
failures and associate them with their root cause.