### PR TITLE
[lldb] Support Rosetta registers in crashlog.py

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -523,10 +523,13 @@ class JSONCrashLogParser:
     def parse_thread_registers(self, json_thread_state):
         registers = dict()
         for key, state in json_thread_state.items():
+            if key == "rosetta":
+               registers.update(self.parse_thread_registers(state))
+               continue
             try:
                value = int(state['value'])
                registers[key] = value
-            except (TypeError, ValueError):
+            except (KeyError, ValueError, TypeError):
                pass
         return registers
 

--- a/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/Inputs/a.out.ips
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/Inputs/a.out.ips
@@ -106,6 +106,17 @@
       "rcx": {
         "value": 140732860114656
       },
+      "rosetta": {
+        "tmp2": {
+          "value": 8
+        },
+        "tmp1": {
+          "value": 20
+        },
+        "tmp0": {
+          "value": 92
+        }
+      },
       "flavor": "x86_THREAD_STATE",
       "rdi": {
         "value": 1

--- a/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/json.test
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/json.test
@@ -13,5 +13,6 @@
 # CHECK: [  1] {{.*}}out`bar + 8 at test.c
 # CHECK: [  2] {{.*}}out`main + 19 at test.c
 # CHECK: rbp = 0x00007ffeec22a530
+# CHECK: tmp2 = 0x0000000000000008
 # CHECK: invalid foo
 # CHECK: invalid bar


### PR DESCRIPTION
Rosetta crashlogs can have their own thread register state. Unlike the
other registers which ware directly listed under "threadState", the
Rosetta registers are nested under their own key in the JSON, as
illustrated below:

  {
      "threadState":
      {
          "rosetta":
          {
              "tmp2":
              {
                  "value": 4935057216
              },
              "tmp1":
              {
                  "value": 4365863188
              },
              "tmp0":
              {
                  "value": 18446744073709551615
              }
          }
      }
  }

(cherry picked from commit e1cad1303bf9d2a77546469dc0987502692f80d9)
