### PR TITLE
[lldb] Unwrap the type when dereferencing the value

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -6500,7 +6500,8 @@ CompilerType TypeSystemClang::GetChildCompilerTypeAtIndex(
   case clang::Type::RValueReference:
     if (idx_is_valid) {
       const clang::ReferenceType *reference_type =
-          llvm::cast<clang::ReferenceType>(GetQualType(type).getTypePtr());
+          llvm::cast<clang::ReferenceType>(
+              RemoveWrappingTypes(GetQualType(type)).getTypePtr());
       CompilerType pointee_clang_type =
           GetType(reference_type->getPointeeType());
       if (transparent_pointers && pointee_clang_type.IsAggregateType()) {

--- a/lldb/test/API/lang/cpp/dereferencing_references/TestCPPDereferencingReferences.py
+++ b/lldb/test/API/lang/cpp/dereferencing_references/TestCPPDereferencingReferences.py
@@ -21,3 +21,7 @@ class TestCase(TestBase):
         # Same as above for rvalue references.
         rref_val = self.expect_var_path("r_ref", type="TTT &&")
         self.assertEqual(rref_val.Dereference().GetType().GetName(), "TTT")
+
+        # Typedef to a reference should dereference to the underlying type.
+        td_val = self.expect_var_path("td_to_ref_type", type="td_int_ref")
+        self.assertEqual(td_val.Dereference().GetType().GetName(), "int")

--- a/lldb/test/API/lang/cpp/dereferencing_references/main.cpp
+++ b/lldb/test/API/lang/cpp/dereferencing_references/main.cpp
@@ -1,8 +1,13 @@
 typedef int TTT;
+typedef int &td_int_ref;
 
 int main() {
   int i = 0;
+  // references to typedefs
   TTT &l_ref = i;
   TTT &&r_ref = static_cast<TTT &&>(i);
+  // typedef of a reference
+  td_int_ref td_to_ref_type = i;
+
   return l_ref; // break here
 }


### PR DESCRIPTION
The value type can be a typedef of a reference (e.g. `typedef int& myint`).
In this case `GetQualType(type)` will return `clang::Typedef`, which cannot
be casted to `clang::ReferenceType`.

Fix a regression introduced in https://reviews.llvm.org/D103532.

Reviewed By: teemperor

Differential Revision: https://reviews.llvm.org/D113673

(cherry picked from commit 95102b7dc3c1b5b3f1b688221d9aa28cb1e17974)

Also see: rdar://82009764