### PR TITLE
CAS: Extract LazyMappedFileRegion from OnDiskHashMappedTrie::MappedFileInfo

### DIFF
--- a/llvm/include/llvm/CAS/LazyMappedFileRegion.h
+++ b/llvm/include/llvm/CAS/LazyMappedFileRegion.h
@@ -11,6 +11,7 @@
 
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
+#include <atomic>
 #include <mutex>
 
 namespace llvm {

--- a/llvm/include/llvm/CAS/LazyMappedFileRegion.h
+++ b/llvm/include/llvm/CAS/LazyMappedFileRegion.h
@@ -1,0 +1,115 @@
+//===- LazyMappedFileRegion.h -----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CAS_LAZYMAPPEDFILEREGION_H
+#define LLVM_CAS_LAZYMAPPEDFILEREGION_H
+
+#include "llvm/Support/Error.h"
+#include "llvm/Support/FileSystem.h"
+#include <mutex>
+
+namespace llvm {
+
+class MemoryBuffer;
+
+namespace cas {
+
+/// Mapped file region with a lazy size. The mapped-in memory is larger than
+/// the actual size on disk, and the on-disk file is resized when necessary.
+///
+/// Process-safe. Uses file locks to increase the capacity. Adds more capacity
+/// than requested to avoid unnecessary contention on file locks.
+///
+/// Thread-safe, assuming all threads use the same instance to talk to a given
+/// file/mapping. Unsafe to have multiple instances talking to the same file
+/// in the same process since file locks will misbehave. Clients should
+/// coordinate (somehow).
+///
+/// TODO: Implement for Windows. See comment next to implementation of \a
+/// create() for a sketch of how to do this.
+///
+/// FIXME: Probably should move to Support.
+class LazyMappedFileRegion {
+public:
+  static Expected<LazyMappedFileRegion>
+  create(const Twine &Path, uint64_t Capacity, uint64_t NewFileSize = 1024ULL,
+         function_ref<Error(char *)> NewFileConstructor = nullptr,
+         uint64_t MaxSizeIncrement = 4ULL * 1024ULL * 1024ULL);
+
+  /// Get the path this was opened with.
+  ///
+  /// FIXME: While this is useful for debugging, might be better to remove
+  /// and/or update callers not to rely on this.
+  StringRef getPath() const { return Path; }
+
+  char *data() const { return Map.data(); }
+
+  /// Resize to at least \p MinSize.
+  ///
+  /// Errors if \p MinSize is bigger than \a capacity() or if the operation
+  /// fails.
+  Error extendSize(uint64_t MinSize) {
+    // Common case.
+    if (MinSize <= size())
+      return Error::success();
+    return extendSizeImpl(MinSize);
+  }
+
+  /// Size allocated on disk.
+  size_t size() const { return CachedSize; }
+
+  /// Size of the underlying \a mapped_file_region. This cannot be extended.
+  size_t capacity() const { return Map.size(); }
+
+  explicit operator bool() const { return bool(Map); }
+
+  ~LazyMappedFileRegion() { destroyImpl(); }
+
+  LazyMappedFileRegion() : CachedSize(0) {}
+  LazyMappedFileRegion(LazyMappedFileRegion &&RHS) { moveImpl(RHS); }
+  LazyMappedFileRegion &operator=(LazyMappedFileRegion &&RHS) {
+    destroyImpl();
+    moveImpl(RHS);
+    return *this;
+  }
+
+  LazyMappedFileRegion(const LazyMappedFileRegion &) = delete;
+  LazyMappedFileRegion &operator=(const LazyMappedFileRegion &) = delete;
+
+private:
+  Error extendSizeImpl(uint64_t MinSize);
+  void destroyImpl() {
+    if (FD) {
+      sys::fs::closeFile(*FD);
+      FD = None;
+    }
+  }
+  void moveImpl(LazyMappedFileRegion &RHS) {
+    Path = std::move(RHS.Path);
+    FD = std::move(RHS.FD);
+    RHS.FD = None;
+    Map = std::move(RHS.Map);
+    CachedSize = RHS.CachedSize.load();
+    RHS.CachedSize = 0;
+    MaxSizeIncrement = RHS.MaxSizeIncrement;
+
+    assert(!RHS.Map && "Expected Optional(Optional&&) to clear RHS.Map");
+  }
+
+  std::string Path;
+  Optional<sys::fs::file_t> FD;
+  sys::fs::mapped_file_region Map;
+  std::atomic<uint64_t> CachedSize;
+  std::mutex Mutex;
+  uint64_t MaxSizeIncrement = 0;
+};
+
+} // namespace cas
+} // namespace llvm
+
+#endif // LLVM_CAS_LAZYMAPPEDFILEREGION_H

--- a/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
+++ b/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
@@ -12,6 +12,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/CAS/LazyMappedFileRegion.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/SHA1.h"
@@ -137,26 +138,8 @@ public:
 
 private:
   ~OnDiskHashMappedTrie();
-  struct MappedFileInfo {
-    std::string Path;
-    sys::fs::file_t FD;
-    sys::fs::mapped_file_region Map;
-    std::atomic<uint64_t> OnDiskSize;
-    std::mutex Mutex;
-
-    static Error open(Optional<MappedFileInfo> &MFI, StringRef Path,
-                      size_t InitialSize, size_t MaxSize,
-                      function_ref<void(char *)> NewFileConstructor);
-
-    MappedFileInfo(MappedFileInfo &&) = delete;
-    MappedFileInfo(const MappedFileInfo &) = delete;
-    MappedFileInfo(StringRef Path, sys::fs::file_t FD, size_t MapSize,
-                   std::error_code &EC);
-    ~MappedFileInfo();
-    Error requestFileSize(uint64_t Size);
-  };
-  Optional<MappedFileInfo> Index;
-  Optional<MappedFileInfo> Data;
+  Optional<LazyMappedFileRegion> Index;
+  Optional<LazyMappedFileRegion> Data;
 };
 
 } // namespace cas

--- a/llvm/lib/CAS/CMakeLists.txt
+++ b/llvm/lib/CAS/CMakeLists.txt
@@ -7,6 +7,7 @@ add_llvm_component_library(LLVMCAS
   FileSystemCache.cpp
   HashMappedTrie.cpp
   HierarchicalTreeBuilder.cpp
+  LazyMappedFileRegion.cpp
   OnDiskHashMappedTrie.cpp
   PluginCAS.cpp
   Utils.cpp

--- a/llvm/lib/CAS/LazyMappedFileRegion.cpp
+++ b/llvm/lib/CAS/LazyMappedFileRegion.cpp
@@ -1,0 +1,138 @@
+//===- LazyMappedFileRegion.cpp -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/LazyMappedFileRegion.h"
+#include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+
+/// Open / resize / map in a file on-disk.
+///
+/// FIXME: This isn't portable. Windows will resize the file to match the map
+/// size, which means immediately creating a very large file. Instead, maybe
+/// we can increase the mapped region size on windows after creation, or
+/// default to a more reasonable size.
+///
+/// The effect we want is:
+///
+/// 1. Reserve virtual memory large enough for the max file size (1GB).
+/// 2. If it doesn't exist, give the file an initial smaller size (1MB).
+/// 3. Map the file into memory.
+/// 4. Assign the file to the reserved virtual memory.
+/// 5. Increase the file size and update the mapping when necessary.
+///
+/// Here's the current implementation for Unix:
+///
+/// 1. [Automatic as part of 3.]
+/// 2. Call ::ftruncate to 1MB (sys::fs::resize_file).
+/// 3. Call ::mmap with 1GB (sys::fs::mapped_file_region).
+/// 4. [Automatic as part of 3.]
+/// 5. Call ::ftruncate with the new size.
+///
+/// On Windows, I *think* this can be implemented with:
+///
+/// 1. Call VirtualAlloc2 to reserve 1GB of virtual memory.
+/// 2. [Automatic as part of 3.]
+/// 3. Call CreateFileMapping to with 1MB, or existing size.
+/// 4. Call MapViewOfFileN to place it in the reserved memory.
+/// 5. Repeat step (3) with the new size and step (4).
+Expected<LazyMappedFileRegion> LazyMappedFileRegion::create(
+    const Twine &Path, uint64_t Capacity, uint64_t NewFileSize,
+    function_ref<Error(char *)> NewFileConstructor, uint64_t MaxSizeIncrement) {
+  LazyMappedFileRegion LMFR;
+  LMFR.Path = Path.str();
+  LMFR.MaxSizeIncrement = MaxSizeIncrement;
+
+  if (Error E = sys::fs::openNativeFileForReadWrite(
+          LMFR.Path, sys::fs::CD_OpenAlways, sys::fs::OF_None).moveInto(LMFR.FD))
+    return std::move(E);
+  assert(LMFR.FD && "Expected valid file descriptor");
+
+  {
+    std::error_code EC;
+    sys::fs::mapped_file_region
+        Map(*LMFR.FD, sys::fs::mapped_file_region::readwrite, Capacity, 0, EC);
+    if (EC)
+      return createFileError(LMFR.Path, EC);
+    LMFR.Map = std::move(Map);
+  }
+
+  // Lock the file so we can initialize it.
+  if (std::error_code EC = sys::fs::lockFile(*LMFR.FD))
+    return createFileError(Path, EC);
+  auto Unlock = make_scope_exit([FD = *LMFR.FD]() { sys::fs::unlockFile(FD); });
+
+  sys::fs::file_status Status;
+  if (std::error_code EC = sys::fs::status(*LMFR.FD, Status))
+    return errorCodeToError(EC);
+  if (Status.getSize() >= NewFileSize) {
+    // The file was already constructed.
+    LMFR.CachedSize = Status.getSize();
+    return std::move(LMFR);
+  }
+
+  // This is a new file. Resize to NewFileSize and run the constructor.
+  if (std::error_code EC = sys::fs::resize_file(*LMFR.FD, NewFileSize))
+    return errorCodeToError(EC);
+  LMFR.CachedSize = NewFileSize;
+  if (Error E = NewFileConstructor(LMFR.data()))
+    return std::move(E);
+  return std::move(LMFR);
+}
+
+Error LazyMappedFileRegion::extendSizeImpl(uint64_t MinSize) {
+  assert(Map && "Expected a valid map");
+  assert(FD && "Expected a valid file descriptor");
+
+  // Synchronize with other threads.
+  std::lock_guard<std::mutex> Lock(Mutex);
+  uint64_t OldSize = CachedSize;
+  if (MinSize <= OldSize)
+    return Error::success();
+
+  // Increase sizes by doubling up to 8MB, and then limit the over-allocation
+  // to 4MB.
+  uint64_t NewSize;
+  if (MinSize < MaxSizeIncrement)
+    NewSize = NextPowerOf2(MinSize);
+  else
+    NewSize = alignTo(MinSize, MaxSizeIncrement);
+
+  if (NewSize > Map.size())
+    NewSize = Map.size();
+  if (NewSize < MinSize)
+    return errorCodeToError(std::make_error_code(std::errc::not_enough_memory));
+
+  // Synchronize with other processes.
+  if (std::error_code EC = sys::fs::lockFile(*FD))
+    return errorCodeToError(EC);
+  auto Unlock = make_scope_exit([&]() { sys::fs::unlockFile(*FD); });
+
+  sys::fs::file_status Status;
+  if (std::error_code EC = sys::fs::status(*FD, Status))
+    return errorCodeToError(EC);
+  if (Status.getSize() >= MinSize) {
+    // Another process already resized the file. Be careful not to let size()
+    // increase beyond capacity(), in case that process used a bigger map size.
+    CachedSize = std::min(Status.getSize(), (uint64_t)Map.size());
+    return Error::success();
+  }
+
+  // Resize.
+  if (std::error_code EC = sys::fs::resize_file(*FD, NewSize))
+    return errorCodeToError(EC);
+  CachedSize = NewSize;
+  return Error::success();
+}


### PR DESCRIPTION
Separate out a helper class `LazyMappedFileRegion` for lazily-growing
`mapped_file_region` logic used by `OnDiskHashMappedTrie`.

Incidentally, this fixes a couple of file descriptor leaks (previously,
OnDiskHashMappedTrie::create opened and leaked files before calling
MappedFileInfo::open).