### PR TITLE
Split up line tables by function in clang

### DIFF
--- a/clang/include/clang/Basic/DebugInfoOptions.h
+++ b/clang/include/clang/Basic/DebugInfoOptions.h
@@ -52,7 +52,7 @@ enum DebugInfoKind {
   /// Generate debug info for types that may be unused in the source
   /// (-fno-eliminate-unused-debug-types).
   UnusedTypeInfo,
-  
+
   /// Generate CAS friendly debug info to go along with the work being done for
   /// llvm-cas. this involves, amongst other things, splitting line tables per
   /// function.

--- a/clang/include/clang/Basic/DebugInfoOptions.h
+++ b/clang/include/clang/Basic/DebugInfoOptions.h
@@ -52,6 +52,11 @@ enum DebugInfoKind {
   /// Generate debug info for types that may be unused in the source
   /// (-fno-eliminate-unused-debug-types).
   UnusedTypeInfo,
+  
+  /// Generate CAS friendly debug info to go along with the work being done for
+  /// llvm-cas. this involves, amongst other things, splitting line tables per
+  /// function.
+  CasFriendlyDebugInfo
 };
 
 enum class DebugTemplateNamesKind {

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2943,6 +2943,8 @@ def g_Flag : Flag<["-"], "g">, Group<g_Group>,
   HelpText<"Generate source-level debug information">;
 def gline_tables_only : Flag<["-"], "gline-tables-only">, Group<gN_Group>,
   Flags<[CoreOption]>, HelpText<"Emit debug line number tables only">;
+def gcas_friendly_debug_info : Flag<["-"], "gcas-friendly-debug-info">, Group<gN_Group>,
+  Flags<[CoreOption]>, HelpText<"Emit debug information that is cas friendly">;
 def gline_directives_only : Flag<["-"], "gline-directives-only">, Group<gN_Group>,
   Flags<[CoreOption]>, HelpText<"Emit debug line info directives only">;
 def gmlt : Flag<["-"], "gmlt">, Alias<gline_tables_only>;

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -593,6 +593,9 @@ void CGDebugInfo::CreateCompileUnit() {
   case codegenoptions::UnusedTypeInfo:
     EmissionKind = llvm::DICompileUnit::FullDebug;
     break;
+  case codegenoptions::CasFriendlyDebugInfo:
+    EmissionKind = llvm::DICompileUnit::CasFriendly;
+    break;
   }
 
   uint64_t DwoId = 0;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -508,6 +508,8 @@ static codegenoptions::DebugInfoKind DebugLevelToInfoKind(const Arg &A) {
     return codegenoptions::DebugLineTablesOnly;
   if (A.getOption().matches(options::OPT_gline_directives_only))
     return codegenoptions::DebugDirectivesOnly;
+  if(A.getOption().matches(options::OPT_gcas_friendly_debug_info))
+    return codegenoptions::CasFriendlyDebugInfo;
   return codegenoptions::DebugInfoConstructor;
 }
 
@@ -1072,6 +1074,9 @@ static void RenderDebugEnablingArgs(const ArgList &Args, ArgStringList &CmdArgs,
     break;
   case codegenoptions::UnusedTypeInfo:
     CmdArgs.push_back("-debug-info-kind=unused-types");
+    break;
+  case codegenoptions::CasFriendlyDebugInfo:
+    CmdArgs.push_back("-debug-info-kind=cas-friendly");
     break;
   default:
     break;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -508,7 +508,7 @@ static codegenoptions::DebugInfoKind DebugLevelToInfoKind(const Arg &A) {
     return codegenoptions::DebugLineTablesOnly;
   if (A.getOption().matches(options::OPT_gline_directives_only))
     return codegenoptions::DebugDirectivesOnly;
-  if(A.getOption().matches(options::OPT_gcas_friendly_debug_info))
+  if (A.getOption().matches(options::OPT_gcas_friendly_debug_info))
     return codegenoptions::CasFriendlyDebugInfo;
   return codegenoptions::DebugInfoConstructor;
 }

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1372,6 +1372,9 @@ void CompilerInvocation::GenerateCodeGenArgs(
   case codegenoptions::LocTrackingOnly: // implied value
     DebugInfoVal = None;
     break;
+  case codegenoptions::CasFriendlyDebugInfo:
+      DebugInfoVal = "cas-friendly";
+    break;
   }
   if (DebugInfoVal)
     GenerateArg(Args, OPT_debug_info_kind_EQ, *DebugInfoVal, SA);
@@ -1629,6 +1632,7 @@ bool CompilerInvocation::ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args,
             .Case("limited", codegenoptions::LimitedDebugInfo)
             .Case("standalone", codegenoptions::FullDebugInfo)
             .Case("unused-types", codegenoptions::UnusedTypeInfo)
+            .Case("cas-friendly", codegenoptions::CasFriendlyDebugInfo)
             .Default(~0U);
     if (Val == ~0U)
       Diags.Report(diag::err_drv_invalid_value) << A->getAsString(Args)

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1373,7 +1373,7 @@ void CompilerInvocation::GenerateCodeGenArgs(
     DebugInfoVal = None;
     break;
   case codegenoptions::CasFriendlyDebugInfo:
-      DebugInfoVal = "cas-friendly";
+    DebugInfoVal = "cas-friendly";
     break;
   }
   if (DebugInfoVal)

--- a/clang/test/CodeGen/debug-info-cas-friendly-option-test.c
+++ b/clang/test/CodeGen/debug-info-cas-friendly-option-test.c
@@ -1,0 +1,5 @@
+// RUN: %clang -cc1 -debug-info-kind=cas-friendly -triple -x86_64-apple-macosx12.0.0 %s -emit-llvm -o - | FileCheck %s
+// CHECK: !DICompileUnit{{.+}}emissionKind: CasFriendly{{.*}}
+void foo() {
+	return;
+}

--- a/clang/test/CodeGen/debug-info-cas-friendly-option-test.c
+++ b/clang/test/CodeGen/debug-info-cas-friendly-option-test.c
@@ -1,4 +1,4 @@
-// RUN: %clang -cc1 -debug-info-kind=cas-friendly -triple -x86_64-apple-macosx12.0.0 %s -emit-llvm -o - | FileCheck %s
+// RUN: %clang -cc1 -debug-info-kind=cas-friendly %s -emit-llvm -o - | FileCheck %s
 // CHECK: !DICompileUnit{{.+}}emissionKind: CasFriendly{{.*}}
 void foo() {
 	return;

--- a/clang/test/Driver/debug-options.c
+++ b/clang/test/Driver/debug-options.c
@@ -280,6 +280,15 @@
 // RUN: %clang -### -target %itanium_abi_triple -gmodules -gline-directives-only %s 2>&1 \
 // RUN:        | FileCheck -check-prefix=GLIO_ONLY %s
 //
+// RUN: %clang -### -c -gcas-friendly-debug-info %s -target x86_64-apple-darwin14 2>&1 \
+// RUN:             | FileCheck -check-prefix=G_CASFRIENDLY \
+// RUN:                         -check-prefix=G_DWARF2 \
+// RUN:                         -check-prefix=G_LLDB %s
+// RUN: %clang -### -c -gcas-friendly-debug-info %s -target x86_64-apple-darwin16 2>&1 \
+// RUN:             | FileCheck -check-prefix=G_CASFRIENDLY \
+// RUN:                         -check-prefix=G_DWARF4 \
+// RUN:                         -check-prefix=G_LLDB %s
+//
 // NOG_PS4: "-cc1"
 // NOG_PS4-NOT: "-dwarf-version=
 // NOG_PS4: "-generate-arange-section"
@@ -324,6 +333,8 @@
 //
 // G_STANDALONE: "-cc1"
 // G_STANDALONE: "-debug-info-kind=standalone"
+// G_CASFRIENDLY: "-cc1"
+// G_CASFRIENDLY: "-debug-info-kind=cas-friendly"
 // G_LIMITED: "-cc1"
 // G_LIMITED: "-debug-info-kind=constructor"
 // G_DWARF2: "-dwarf-version=2"

--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -1356,7 +1356,8 @@ public:
     FullDebug,
     LineTablesOnly,
     DebugDirectivesOnly,
-    LastEmissionKind = DebugDirectivesOnly
+    CasFriendly,
+    LastEmissionKind = CasFriendly
   };
 
   enum class DebugNameTableKind : unsigned {

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -970,7 +970,7 @@ lltok::Kind LLLexer::LexIdentifier() {
   }
 
   if (Keyword == "NoDebug" || Keyword == "FullDebug" ||
-      Keyword == "LineTablesOnly" || Keyword == "DebugDirectivesOnly") {
+      Keyword == "LineTablesOnly" || Keyword == "DebugDirectivesOnly" || Keyword == "CasFriendly") {
     StrVal.assign(Keyword.begin(), Keyword.end());
     return lltok::EmissionKind;
   }

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -970,7 +970,8 @@ lltok::Kind LLLexer::LexIdentifier() {
   }
 
   if (Keyword == "NoDebug" || Keyword == "FullDebug" ||
-      Keyword == "LineTablesOnly" || Keyword == "DebugDirectivesOnly" || Keyword == "CasFriendly") {
+      Keyword == "LineTablesOnly" || Keyword == "DebugDirectivesOnly" ||
+      Keyword == "CasFriendly") {
     StrVal.assign(Keyword.begin(), Keyword.end());
     return lltok::EmissionKind;
   }

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -31,9 +31,10 @@
 #include "llvm/CodeGen/TargetLowering.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
-#include "llvm/DebugInfo/DWARF/DWARFExpression.h"
 #include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
+#include "llvm/DebugInfo/DWARF/DWARFExpression.h"
 #include "llvm/IR/Constants.h"
+#include "llvm/IR/DIBuilder.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/Module.h"
@@ -56,7 +57,6 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Target/TargetLoweringObjectFile.h"
 #include "llvm/Target/TargetMachine.h"
-#include "llvm/IR/DIBuilder.h"
 #include <algorithm>
 #include <cstddef>
 #include <iterator>
@@ -2153,14 +2153,19 @@ void DwarfDebug::beginFunctionImpl(const MachineFunction *MF) {
   if (SP->getUnit()->getEmissionKind() == DICompileUnit::NoDebug)
     return;
 
-  if(SP->getUnit()->getEmissionKind() == llvm::DICompileUnit::CasFriendly) {
+  // If the EmissionKind is CasFriendly, this indicates to us that we want to
+  // split up the line tables by function rather than have it as one monolithic
+  // entry. That is, every function gets its own line table header. To achieve
+  // this we are creating a new CompileUnit per function so each function can
+  // get it's own line table header
+  if (SP->getUnit()->getEmissionKind() == llvm::DICompileUnit::CasFriendly) {
     const Module *M = MF->getFunction().getParent();
     DIBuilder DIB(*const_cast<Module *>(M));
     DICompileUnit *DCU = SP->getUnit();
     DICompileUnit *NewDCU = DIB.createCompileUnit(
         DCU->getSourceLanguage(), DCU->getFile(), DCU->getProducer(),
         DCU->isOptimized(), DCU->getFlags(), DCU->getRuntimeVersion());
-    
+
     this->SingleCU = false;
     DwarfCompileUnit &CU = getOrCreateDwarfCompileUnit(NewDCU);
     Asm->OutStreamer->getContext().setDwarfCompileUnitID(

--- a/llvm/lib/IR/DebugInfoMetadata.cpp
+++ b/llvm/lib/IR/DebugInfoMetadata.cpp
@@ -790,6 +790,7 @@ DICompileUnit::getEmissionKind(StringRef Str) {
       .Case("FullDebug", FullDebug)
       .Case("LineTablesOnly", LineTablesOnly)
       .Case("DebugDirectivesOnly", DebugDirectivesOnly)
+      .Case("CasFriendly", CasFriendly)
       .Default(None);
 }
 
@@ -812,6 +813,8 @@ const char *DICompileUnit::emissionKindString(DebugEmissionKind EK) {
     return "LineTablesOnly";
   case DebugDirectivesOnly:
     return "DebugDirectivesOnly";
+  case CasFriendly:
+    return "CasFriendly";
   }
   return nullptr;
 }

--- a/llvm/test/DebugInfo/X86/cas-friendly.ll
+++ b/llvm/test/DebugInfo/X86/cas-friendly.ll
@@ -1,165 +1,35 @@
 ; RUN: llc -mtriple=x86_64-apple-macosx12.0.0 -filetype=obj %s -o %t 
-; RUN: llvm-dwarfdump -debug-line -v %t | FileCheck %s
+; RUN: llvm-dwarfdump -debug-line --debug-info %t | FileCheck %s
 
-; CHECK: debug_line[0x00000000]
-; CHECK-NEXT: Line table prologue:
-; CHECK-NEXT:     total_length: 0x00000042
-; CHECK-NEXT:           format: DWARF32
-; CHECK-NEXT:          version: 4
-; CHECK-NEXT:  prologue_length: 0x00000020
-; CHECK-NEXT:  min_inst_length: 1
-; CHECK-NEXT: max_ops_per_inst: 1
-; CHECK-NEXT:  default_is_stmt: 1
-; CHECK-NEXT:        line_base: -5
-; CHECK-NEXT:       line_range: 14
-; CHECK-NEXT:      opcode_base: 13
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_copy] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_advance_pc] = 1
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_advance_line] = 1
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_file] = 1
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_column] = 1
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_negate_stmt] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_basic_block] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_const_add_pc] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_fixed_advance_pc] = 1
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_prologue_end] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_epilogue_begin] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_isa] = 1
-; CHECK-NEXT: include_directories[  1] = "."
-; CHECK-NEXT: file_names[  1]:
-; CHECK-NEXT:            name: "test.c"
-; CHECK-NEXT:       dir_index: 1
-; CHECK-NEXT:        mod_time: 0x00000000
-; CHECK-NEXT:          length: 0x00000000
-; CHECK:             Address            Line   Column File   ISA Discriminator Flags
-; CHECK-NEXT:             ------------------ ------ ------ ------ --- ------------- -------------
-; CHECK-NEXT: 0x0000002a: 00 DW_LNE_set_address (0x0000000000000000)
-; CHECK-NEXT: 0x00000035: 01 DW_LNS_copy
-; CHECK-NEXT:             0x0000000000000000      1      0      1   0             0  is_stmt
-; CHECK-NEXT: 0x00000036: 05 DW_LNS_set_column (9)
-; CHECK-NEXT: 0x00000038: 0a DW_LNS_set_prologue_end
-; CHECK-NEXT: 0x00000039: 75 address += 7,  line += 1
-; CHECK-NEXT:             0x0000000000000007      2      9      1   0             0  is_stmt prologue_end
-; CHECK-NEXT: 0x0000003a: 05 DW_LNS_set_column (10)
-; CHECK-NEXT: 0x0000003c: 06 DW_LNS_negate_stmt
-; CHECK-NEXT: 0x0000003d: 3c address += 3,  line += 0
-; CHECK-NEXT:             0x000000000000000a      2     10      1   0             0 
-; CHECK-NEXT: 0x0000003e: 05 DW_LNS_set_column (2)
-; CHECK-NEXT: 0x00000040: 4a address += 4,  line += 0
-; CHECK-NEXT:             0x000000000000000e      2      2      1   0             0 
-; CHECK-NEXT: 0x00000041: 02 DW_LNS_advance_pc (2)
-; CHECK-NEXT: 0x00000043: 00 DW_LNE_end_sequence
-; CHECK-NEXT:             0x0000000000000010      2      2      1   0             0  end_sequence
+; CHECK: 0x{{[0-9a-z]+}}:   DW_TAG_subprogram
+; CHECK-NEXT:                DW_AT_low_pc ([[LOC1:0x[0-9a-z]+]])
 
-; CHECK: debug_line[0x00000046]
-; CHECK-NEXT: Line table prologue:
-; CHECK-NEXT:     total_length: 0x00000042
-; CHECK-NEXT:           format: DWARF32
-; CHECK-NEXT:          version: 4
-; CHECK-NEXT:  prologue_length: 0x00000020
-; CHECK-NEXT:  min_inst_length: 1
-; CHECK-NEXT: max_ops_per_inst: 1
-; CHECK-NEXT:  default_is_stmt: 1
-; CHECK-NEXT:        line_base: -5
-; CHECK-NEXT:       line_range: 14
-; CHECK-NEXT:      opcode_base: 13
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_copy] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_advance_pc] = 1
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_advance_line] = 1
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_file] = 1
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_column] = 1
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_negate_stmt] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_basic_block] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_const_add_pc] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_fixed_advance_pc] = 1
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_prologue_end] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_epilogue_begin] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_isa] = 1
-; CHECK-NEXT: include_directories[  1] = "."
-; CHECK-NEXT: file_names[  1]:
-; CHECK-NEXT:            name: "test.c"
-; CHECK-NEXT:       dir_index: 1
-; CHECK-NEXT:        mod_time: 0x00000000
-; CHECK-NEXT:          length: 0x00000000
-; CHECK:             Address            Line   Column File   ISA Discriminator Flags
-; CHECK-NEXT:             ------------------ ------ ------ ------ --- ------------- -------------
-; CHECK-NEXT: 0x00000070: 00 DW_LNE_set_address (0x0000000000000010)
-; CHECK-NEXT: 0x0000007b: 16 address += 0,  line += 4
-; CHECK-NEXT:             0x0000000000000010      5      0      1   0             0  is_stmt
-; CHECK-NEXT: 0x0000007c: 05 DW_LNS_set_column (11)
-; CHECK-NEXT: 0x0000007e: 0a DW_LNS_set_prologue_end
-; CHECK-NEXT: 0x0000007f: 75 address += 7,  line += 1
-; CHECK-NEXT:             0x0000000000000017      6     11      1   0             0  is_stmt prologue_end
-; CHECK-NEXT: 0x00000080: 05 DW_LNS_set_column (10)
-; CHECK-NEXT: 0x00000082: 06 DW_LNS_negate_stmt
-; CHECK-NEXT: 0x00000083: 3c address += 3,  line += 0
-; CHECK-NEXT:             0x000000000000001a      6     10      1   0             0 
-; CHECK-NEXT: 0x00000084: 05 DW_LNS_set_column (2)
-; CHECK-NEXT: 0x00000086: 3c address += 3,  line += 0
-; CHECK-NEXT:             0x000000000000001d      6      2      1   0             0 
-; CHECK-NEXT: 0x00000087: 02 DW_LNS_advance_pc (2)
-; CHECK-NEXT: 0x00000089: 00 DW_LNE_end_sequence
-; CHECK-NEXT:             0x000000000000001f      6      2      1   0             0  end_sequence
+; CHECK: 0x{{[0-9a-z]+}}:   DW_TAG_subprogram
+; CHECK-NEXT:                DW_AT_low_pc ([[LOC2:0x[0-9a-z]+]])
 
-; CHECK: debug_line[0x0000008c]
+; CHECK: 0x{{[0-9a-z]+}}:   DW_TAG_subprogram
+; CHECK-NEXT:                DW_AT_low_pc ([[LOC3:0x[0-9a-z]+]])
+
+; CHECK: debug_line[0x{{[0-9a-z]+}}]
 ; CHECK-NEXT: Line table prologue:
-; CHECK-NEXT:     total_length: 0x0000004c
-; CHECK-NEXT:           format: DWARF32
-; CHECK-NEXT:          version: 4
-; CHECK-NEXT:  prologue_length: 0x00000020
-; CHECK-NEXT:  min_inst_length: 1
-; CHECK-NEXT: max_ops_per_inst: 1
-; CHECK-NEXT:  default_is_stmt: 1
-; CHECK-NEXT:        line_base: -5
-; CHECK-NEXT:       line_range: 14
-; CHECK-NEXT:      opcode_base: 13
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_copy] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_advance_pc] = 1
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_advance_line] = 1
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_file] = 1
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_column] = 1
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_negate_stmt] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_basic_block] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_const_add_pc] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_fixed_advance_pc] = 1
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_prologue_end] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_epilogue_begin] = 0
-; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_isa] = 1
-; CHECK-NEXT: include_directories[  1] = "."
-; CHECK-NEXT: file_names[  1]:
-; CHECK-NEXT:            name: "test.c"
-; CHECK-NEXT:       dir_index: 1
-; CHECK-NEXT:        mod_time: 0x00000000
-; CHECK-NEXT:          length: 0x00000000
-; CHECK:             Address            Line   Column File   ISA Discriminator Flags
-; CHECK-NEXT:             ------------------ ------ ------ ------ --- ------------- -------------
-; CHECK-NEXT: 0x000000b6: 00 DW_LNE_set_address (0x0000000000000020)
-; CHECK-NEXT: 0x000000c1: 1a address += 0,  line += 8
-; CHECK-NEXT:             0x0000000000000020      9      0      1   0             0  is_stmt
-; CHECK-NEXT: 0x000000c2: 05 DW_LNS_set_column (13)
-; CHECK-NEXT: 0x000000c4: 0a DW_LNS_set_prologue_end
-; CHECK-NEXT: 0x000000c5: 08 DW_LNS_const_add_pc (0x0000000000000011)
-; CHECK-NEXT: 0x000000c6: 67 address += 6,  line += 1
-; CHECK-NEXT:             0x0000000000000037     10     13      1   0             0  is_stmt prologue_end
-; CHECK-NEXT: 0x000000c7: 05 DW_LNS_set_column (9)
-; CHECK-NEXT: 0x000000c9: 06 DW_LNS_negate_stmt
-; CHECK-NEXT: 0x000000ca: 3c address += 3,  line += 0
-; CHECK-NEXT:             0x000000000000003a     10      9      1   0             0 
-; CHECK-NEXT: 0x000000cb: 05 DW_LNS_set_column (25)
-; CHECK-NEXT: 0x000000cd: 74 address += 7,  line += 0
-; CHECK-NEXT:             0x0000000000000041     10     25      1   0             0 
-; CHECK-NEXT: 0x000000ce: 05 DW_LNS_set_column (21)
-; CHECK-NEXT: 0x000000d0: 3c address += 3,  line += 0
-; CHECK-NEXT:             0x0000000000000044     10     21      1   0             0 
-; CHECK-NEXT: 0x000000d1: 05 DW_LNS_set_column (19)
-; CHECK-NEXT: 0x000000d3: 58 address += 5,  line += 0
-; CHECK-NEXT:             0x0000000000000049     10     19      1   0             0 
-; CHECK-NEXT: 0x000000d4: 05 DW_LNS_set_column (2)
-; CHECK-NEXT: 0x000000d6: 2e address += 2,  line += 0
-; CHECK-NEXT:             0x000000000000004b     10      2      1   0             0 
-; CHECK-NEXT: 0x000000d7: 02 DW_LNS_advance_pc (9)
-; CHECK-NEXT: 0x000000d9: 00 DW_LNE_end_sequence
-; CHECK-NEXT:             0x0000000000000054     10      2      1   0             0  end_sequence
+
+; CHECK: Address            Line   Column File   ISA Discriminator Flags
+; CHECK-NEXT: ------------------ ------ ------ ------ --- ------------- -------------
+; CHECK-NEXT: [[LOC1]]      1      0      1   0             0  is_stmt
+
+; CHECK: debug_line[0x{{[0-9a-z]+}}]
+; CHECK-NEXT: Line table prologue:
+
+; CHECK: Address            Line   Column File   ISA Discriminator Flags
+; CHECK-NEXT: ------------------ ------ ------ ------ --- ------------- -------------
+; CHECK-NEXT: [[LOC2]]      5      0      1   0             0  is_stmt
+
+; CHECK: debug_line[0x{{[0-9a-z]+}}]
+; CHECK-NEXT: Line table prologue:
+
+; CHECK Address            Line   Column File   ISA Discriminator Flags
+; CHECK-NEXT ------------------ ------ ------ ------ --- ------------- -------------
+; CHECK-NEXT [[LOC3]]      9      0      1   0             0  is_stmt
 
 ; ModuleID = './test.c'
 source_filename = "./test.c"

--- a/llvm/test/DebugInfo/X86/cas-friendly.ll
+++ b/llvm/test/DebugInfo/X86/cas-friendly.ll
@@ -10,6 +10,8 @@
 ; CHECK: 0x{{[0-9a-z]+}}:   DW_TAG_subprogram
 ; CHECK-NEXT:                DW_AT_low_pc ([[LOC3:0x[0-9a-z]+]])
 
+; This test is checking if the cas-friendly debug info splits the line table into multiple parts per function, that is why the checks below are checking for three seperate line tables for three distinct functions in this test
+
 ; CHECK: debug_line[0x{{[0-9a-z]+}}]
 ; CHECK-NEXT: Line table prologue:
 
@@ -81,7 +83,7 @@ entry:
   ret i32 %add, !dbg !42
 }
 
-attributes #0 = { noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+attributes #0 = { noinline nounwind optnone ssp uwtable }
 attributes #1 = { nofree nosync nounwind readnone speculatable willreturn }
 
 !llvm.dbg.cu = !{!0}

--- a/llvm/test/DebugInfo/X86/cas-friendly.ll
+++ b/llvm/test/DebugInfo/X86/cas-friendly.ll
@@ -1,0 +1,263 @@
+; RUN: llc -mtriple=x86_64-apple-macosx12.0.0 -filetype=obj %s -o %t 
+; RUN: llvm-dwarfdump -debug-line -v %t | FileCheck %s
+
+; CHECK: debug_line[0x00000000]
+; CHECK-NEXT: Line table prologue:
+; CHECK-NEXT:     total_length: 0x00000042
+; CHECK-NEXT:           format: DWARF32
+; CHECK-NEXT:          version: 4
+; CHECK-NEXT:  prologue_length: 0x00000020
+; CHECK-NEXT:  min_inst_length: 1
+; CHECK-NEXT: max_ops_per_inst: 1
+; CHECK-NEXT:  default_is_stmt: 1
+; CHECK-NEXT:        line_base: -5
+; CHECK-NEXT:       line_range: 14
+; CHECK-NEXT:      opcode_base: 13
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_copy] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_advance_pc] = 1
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_advance_line] = 1
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_file] = 1
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_column] = 1
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_negate_stmt] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_basic_block] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_const_add_pc] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_fixed_advance_pc] = 1
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_prologue_end] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_epilogue_begin] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_isa] = 1
+; CHECK-NEXT: include_directories[  1] = "."
+; CHECK-NEXT: file_names[  1]:
+; CHECK-NEXT:            name: "test.c"
+; CHECK-NEXT:       dir_index: 1
+; CHECK-NEXT:        mod_time: 0x00000000
+; CHECK-NEXT:          length: 0x00000000
+; CHECK:             Address            Line   Column File   ISA Discriminator Flags
+; CHECK-NEXT:             ------------------ ------ ------ ------ --- ------------- -------------
+; CHECK-NEXT: 0x0000002a: 00 DW_LNE_set_address (0x0000000000000000)
+; CHECK-NEXT: 0x00000035: 01 DW_LNS_copy
+; CHECK-NEXT:             0x0000000000000000      1      0      1   0             0  is_stmt
+; CHECK-NEXT: 0x00000036: 05 DW_LNS_set_column (9)
+; CHECK-NEXT: 0x00000038: 0a DW_LNS_set_prologue_end
+; CHECK-NEXT: 0x00000039: 75 address += 7,  line += 1
+; CHECK-NEXT:             0x0000000000000007      2      9      1   0             0  is_stmt prologue_end
+; CHECK-NEXT: 0x0000003a: 05 DW_LNS_set_column (10)
+; CHECK-NEXT: 0x0000003c: 06 DW_LNS_negate_stmt
+; CHECK-NEXT: 0x0000003d: 3c address += 3,  line += 0
+; CHECK-NEXT:             0x000000000000000a      2     10      1   0             0 
+; CHECK-NEXT: 0x0000003e: 05 DW_LNS_set_column (2)
+; CHECK-NEXT: 0x00000040: 4a address += 4,  line += 0
+; CHECK-NEXT:             0x000000000000000e      2      2      1   0             0 
+; CHECK-NEXT: 0x00000041: 02 DW_LNS_advance_pc (2)
+; CHECK-NEXT: 0x00000043: 00 DW_LNE_end_sequence
+; CHECK-NEXT:             0x0000000000000010      2      2      1   0             0  end_sequence
+
+; CHECK: debug_line[0x00000046]
+; CHECK-NEXT: Line table prologue:
+; CHECK-NEXT:     total_length: 0x00000042
+; CHECK-NEXT:           format: DWARF32
+; CHECK-NEXT:          version: 4
+; CHECK-NEXT:  prologue_length: 0x00000020
+; CHECK-NEXT:  min_inst_length: 1
+; CHECK-NEXT: max_ops_per_inst: 1
+; CHECK-NEXT:  default_is_stmt: 1
+; CHECK-NEXT:        line_base: -5
+; CHECK-NEXT:       line_range: 14
+; CHECK-NEXT:      opcode_base: 13
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_copy] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_advance_pc] = 1
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_advance_line] = 1
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_file] = 1
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_column] = 1
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_negate_stmt] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_basic_block] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_const_add_pc] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_fixed_advance_pc] = 1
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_prologue_end] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_epilogue_begin] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_isa] = 1
+; CHECK-NEXT: include_directories[  1] = "."
+; CHECK-NEXT: file_names[  1]:
+; CHECK-NEXT:            name: "test.c"
+; CHECK-NEXT:       dir_index: 1
+; CHECK-NEXT:        mod_time: 0x00000000
+; CHECK-NEXT:          length: 0x00000000
+; CHECK:             Address            Line   Column File   ISA Discriminator Flags
+; CHECK-NEXT:             ------------------ ------ ------ ------ --- ------------- -------------
+; CHECK-NEXT: 0x00000070: 00 DW_LNE_set_address (0x0000000000000010)
+; CHECK-NEXT: 0x0000007b: 16 address += 0,  line += 4
+; CHECK-NEXT:             0x0000000000000010      5      0      1   0             0  is_stmt
+; CHECK-NEXT: 0x0000007c: 05 DW_LNS_set_column (11)
+; CHECK-NEXT: 0x0000007e: 0a DW_LNS_set_prologue_end
+; CHECK-NEXT: 0x0000007f: 75 address += 7,  line += 1
+; CHECK-NEXT:             0x0000000000000017      6     11      1   0             0  is_stmt prologue_end
+; CHECK-NEXT: 0x00000080: 05 DW_LNS_set_column (10)
+; CHECK-NEXT: 0x00000082: 06 DW_LNS_negate_stmt
+; CHECK-NEXT: 0x00000083: 3c address += 3,  line += 0
+; CHECK-NEXT:             0x000000000000001a      6     10      1   0             0 
+; CHECK-NEXT: 0x00000084: 05 DW_LNS_set_column (2)
+; CHECK-NEXT: 0x00000086: 3c address += 3,  line += 0
+; CHECK-NEXT:             0x000000000000001d      6      2      1   0             0 
+; CHECK-NEXT: 0x00000087: 02 DW_LNS_advance_pc (2)
+; CHECK-NEXT: 0x00000089: 00 DW_LNE_end_sequence
+; CHECK-NEXT:             0x000000000000001f      6      2      1   0             0  end_sequence
+
+; CHECK: debug_line[0x0000008c]
+; CHECK-NEXT: Line table prologue:
+; CHECK-NEXT:     total_length: 0x0000004c
+; CHECK-NEXT:           format: DWARF32
+; CHECK-NEXT:          version: 4
+; CHECK-NEXT:  prologue_length: 0x00000020
+; CHECK-NEXT:  min_inst_length: 1
+; CHECK-NEXT: max_ops_per_inst: 1
+; CHECK-NEXT:  default_is_stmt: 1
+; CHECK-NEXT:        line_base: -5
+; CHECK-NEXT:       line_range: 14
+; CHECK-NEXT:      opcode_base: 13
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_copy] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_advance_pc] = 1
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_advance_line] = 1
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_file] = 1
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_column] = 1
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_negate_stmt] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_basic_block] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_const_add_pc] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_fixed_advance_pc] = 1
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_prologue_end] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_epilogue_begin] = 0
+; CHECK-NEXT: standard_opcode_lengths[DW_LNS_set_isa] = 1
+; CHECK-NEXT: include_directories[  1] = "."
+; CHECK-NEXT: file_names[  1]:
+; CHECK-NEXT:            name: "test.c"
+; CHECK-NEXT:       dir_index: 1
+; CHECK-NEXT:        mod_time: 0x00000000
+; CHECK-NEXT:          length: 0x00000000
+; CHECK:             Address            Line   Column File   ISA Discriminator Flags
+; CHECK-NEXT:             ------------------ ------ ------ ------ --- ------------- -------------
+; CHECK-NEXT: 0x000000b6: 00 DW_LNE_set_address (0x0000000000000020)
+; CHECK-NEXT: 0x000000c1: 1a address += 0,  line += 8
+; CHECK-NEXT:             0x0000000000000020      9      0      1   0             0  is_stmt
+; CHECK-NEXT: 0x000000c2: 05 DW_LNS_set_column (13)
+; CHECK-NEXT: 0x000000c4: 0a DW_LNS_set_prologue_end
+; CHECK-NEXT: 0x000000c5: 08 DW_LNS_const_add_pc (0x0000000000000011)
+; CHECK-NEXT: 0x000000c6: 67 address += 6,  line += 1
+; CHECK-NEXT:             0x0000000000000037     10     13      1   0             0  is_stmt prologue_end
+; CHECK-NEXT: 0x000000c7: 05 DW_LNS_set_column (9)
+; CHECK-NEXT: 0x000000c9: 06 DW_LNS_negate_stmt
+; CHECK-NEXT: 0x000000ca: 3c address += 3,  line += 0
+; CHECK-NEXT:             0x000000000000003a     10      9      1   0             0 
+; CHECK-NEXT: 0x000000cb: 05 DW_LNS_set_column (25)
+; CHECK-NEXT: 0x000000cd: 74 address += 7,  line += 0
+; CHECK-NEXT:             0x0000000000000041     10     25      1   0             0 
+; CHECK-NEXT: 0x000000ce: 05 DW_LNS_set_column (21)
+; CHECK-NEXT: 0x000000d0: 3c address += 3,  line += 0
+; CHECK-NEXT:             0x0000000000000044     10     21      1   0             0 
+; CHECK-NEXT: 0x000000d1: 05 DW_LNS_set_column (19)
+; CHECK-NEXT: 0x000000d3: 58 address += 5,  line += 0
+; CHECK-NEXT:             0x0000000000000049     10     19      1   0             0 
+; CHECK-NEXT: 0x000000d4: 05 DW_LNS_set_column (2)
+; CHECK-NEXT: 0x000000d6: 2e address += 2,  line += 0
+; CHECK-NEXT:             0x000000000000004b     10      2      1   0             0 
+; CHECK-NEXT: 0x000000d7: 02 DW_LNS_advance_pc (9)
+; CHECK-NEXT: 0x000000d9: 00 DW_LNE_end_sequence
+; CHECK-NEXT:             0x0000000000000054     10      2      1   0             0  end_sequence
+
+; ModuleID = './test.c'
+source_filename = "./test.c"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx12.0.0"
+
+; Function Attrs: noinline nounwind optnone ssp uwtable
+define i32 @foo(i32 noundef %n) #0 !dbg !9 {
+entry:
+  %n.addr = alloca i32, align 4
+  store i32 %n, i32* %n.addr, align 4
+  call void @llvm.dbg.declare(metadata i32* %n.addr, metadata !15, metadata !DIExpression()), !dbg !16
+  %0 = load i32, i32* %n.addr, align 4, !dbg !17
+  %1 = load i32, i32* %n.addr, align 4, !dbg !18
+  %mul = mul nsw i32 %0, %1, !dbg !19
+  ret i32 %mul, !dbg !20
+}
+
+; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
+
+; Function Attrs: noinline nounwind optnone ssp uwtable
+define i32 @bar(i32 noundef %n) #0 !dbg !21 {
+entry:
+  %n.addr = alloca i32, align 4
+  store i32 %n, i32* %n.addr, align 4
+  call void @llvm.dbg.declare(metadata i32* %n.addr, metadata !22, metadata !DIExpression()), !dbg !23
+  %0 = load i32, i32* %n.addr, align 4, !dbg !24
+  %mul = mul nsw i32 2, %0, !dbg !25
+  ret i32 %mul, !dbg !26
+}
+
+; Function Attrs: noinline nounwind optnone ssp uwtable
+define i32 @main(i32 noundef %argc, i8** noundef %argv) #0 !dbg !27 {
+entry:
+  %retval = alloca i32, align 4
+  %argc.addr = alloca i32, align 4
+  %argv.addr = alloca i8**, align 8
+  store i32 0, i32* %retval, align 4
+  store i32 %argc, i32* %argc.addr, align 4
+  call void @llvm.dbg.declare(metadata i32* %argc.addr, metadata !33, metadata !DIExpression()), !dbg !34
+  store i8** %argv, i8*** %argv.addr, align 8
+  call void @llvm.dbg.declare(metadata i8*** %argv.addr, metadata !35, metadata !DIExpression()), !dbg !36
+  %0 = load i32, i32* %argc.addr, align 4, !dbg !37
+  %call = call i32 @foo(i32 noundef %0), !dbg !38
+  %1 = load i32, i32* %argc.addr, align 4, !dbg !39
+  %call1 = call i32 @bar(i32 noundef %1), !dbg !40
+  %add = add nsw i32 %call, %call1, !dbg !41
+  ret i32 %add, !dbg !42
+}
+
+attributes #0 = { noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+attributes #1 = { nofree nosync nounwind readnone speculatable willreturn }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
+!llvm.ident = !{!8}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 14.0.0 (git@github.com:apple/llvm-project.git 24e049152a8c2239a157a36f6a4d065e7a1b183b)", isOptimized: false, runtimeVersion: 0, emissionKind: CasFriendly, splitDebugInlining: false, nameTableKind: None, sysroot: "/")
+!1 = !DIFile(filename: "test.c", directory: "/Users/shubham/Development/testClangDebugInfo")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"PIC Level", i32 2}
+!6 = !{i32 7, !"uwtable", i32 1}
+!7 = !{i32 7, !"frame-pointer", i32 2}
+!8 = !{!"clang version 14.0.0 (git@github.com:apple/llvm-project.git)"}
+!9 = distinct !DISubprogram(name: "foo", scope: !10, file: !10, line: 1, type: !11, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
+!10 = !DIFile(filename: "./test.c", directory: "/Users/shubham/Development/testClangDebugInfo")
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13, !13}
+!13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!14 = !{}
+!15 = !DILocalVariable(name: "n", arg: 1, scope: !9, file: !10, line: 1, type: !13)
+!16 = !DILocation(line: 1, column: 13, scope: !9)
+!17 = !DILocation(line: 2, column: 9, scope: !9)
+!18 = !DILocation(line: 2, column: 11, scope: !9)
+!19 = !DILocation(line: 2, column: 10, scope: !9)
+!20 = !DILocation(line: 2, column: 2, scope: !9)
+!21 = distinct !DISubprogram(name: "bar", scope: !10, file: !10, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
+!22 = !DILocalVariable(name: "n", arg: 1, scope: !21, file: !10, line: 5, type: !13)
+!23 = !DILocation(line: 5, column: 13, scope: !21)
+!24 = !DILocation(line: 6, column: 11, scope: !21)
+!25 = !DILocation(line: 6, column: 10, scope: !21)
+!26 = !DILocation(line: 6, column: 2, scope: !21)
+!27 = distinct !DISubprogram(name: "main", scope: !10, file: !10, line: 9, type: !28, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
+!28 = !DISubroutineType(types: !29)
+!29 = !{!13, !13, !30}
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_signed_char)
+!33 = !DILocalVariable(name: "argc", arg: 1, scope: !27, file: !10, line: 9, type: !13)
+!34 = !DILocation(line: 9, column: 14, scope: !27)
+!35 = !DILocalVariable(name: "argv", arg: 2, scope: !27, file: !10, line: 9, type: !30)
+!36 = !DILocation(line: 9, column: 27, scope: !27)
+!37 = !DILocation(line: 10, column: 13, scope: !27)
+!38 = !DILocation(line: 10, column: 9, scope: !27)
+!39 = !DILocation(line: 10, column: 25, scope: !27)
+!40 = !DILocation(line: 10, column: 21, scope: !27)
+!41 = !DILocation(line: 10, column: 19, scope: !27)
+!42 = !DILocation(line: 10, column: 2, scope: !27)


### PR DESCRIPTION
Change the code in the ASMPrinter to be able to split up line tables by function. This is the first step in the process to be able to split up debug info for llvm-cas
rdar://88344591