### PR TITLE
[CASObjectReader] Introduce a reader interface for CAS schema objects

### DIFF
--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -483,8 +483,8 @@ static Expected<InputFile *> addCASObject(SchemaPool &CASSchemas, CASID ID,
   }
   InputFile *newFile = nullptr;
 
-  newFile = make<CASSchemaFile>(CASSchemas, ID, path);
-  if (Error E = cast<CASSchemaFile>(newFile)->parse())
+  newFile = make<CASSchemaFile>(path);
+  if (Error E = cast<CASSchemaFile>(newFile)->parse(CASSchemas, ID))
     return std::move(E);
 
   if (newFile) {

--- a/lld/MachO/InputFiles.h
+++ b/lld/MachO/InputFiles.h
@@ -37,9 +37,6 @@ class TarWriter;
 namespace casobjectformats {
 class SchemaPool;
 } // namespace casobjectformats
-namespace jitlink {
-class LinkGraph;
-} // namespace jitlink
 } // namespace llvm
 
 namespace lld {
@@ -172,17 +169,12 @@ private:
 // CAS-schema .o file
 class CASSchemaFile final : public InputFile {
 public:
-  CASSchemaFile(llvm::casobjectformats::SchemaPool &CASSchemas,
-                llvm::cas::CASID ID, StringRef filename);
+  explicit CASSchemaFile(StringRef filename);
   ~CASSchemaFile();
   static bool classof(const InputFile *f) { return f->kind() == CASSchemaKind; }
 
-  Error parse();
-
-private:
-  llvm::casobjectformats::SchemaPool &CASSchemas;
-  llvm::cas::CASID ID;
-  std::unique_ptr<llvm::jitlink::LinkGraph> linkGraph;
+  Error parse(llvm::casobjectformats::SchemaPool &CASSchemas,
+              llvm::cas::CASID ID);
 };
 
 // command-line -sectcreate file

--- a/lld/test/MachO/CAS/cpp-globalctordtor.s
+++ b/lld/test/MachO/CAS/cpp-globalctordtor.s
@@ -36,20 +36,15 @@
 
 // FLAT: l     F __TEXT,__text ___cxx_global_var_init
 // FLAT: l     F __TEXT,__text __GLOBAL__sub_I_test.cpp
-// FLAT: l     O __DATA,__data __dyld_private
-// FLAT: l     F __TEXT,__text __ZN3MySC1Ev
-// FLAT: l     F __TEXT,__text __ZN3MySD1Ev
-// FLAT: l     F __TEXT,__text __ZN3MySC2Ev
-// FLAT: l     F __TEXT,__text __ZN3MySD2Ev
 
 // NESTED: l     F __TEXT,__text __GLOBAL__sub_I_test.cpp
 // NESTED: l     F __TEXT,__text ___cxx_global_var_init
-// NESTED: l     O __DATA,__data __dyld_private
-// NESTED: l     F __TEXT,__text __ZN3MySC1Ev
-// NESTED: l     F __TEXT,__text __ZN3MySC2Ev
-// NESTED: l     F __TEXT,__text __ZN3MySD2Ev
-// NESTED: l     F __TEXT,__text __ZN3MySD1Ev
 
+// CHECK: l     O __DATA,__data __dyld_private
+// CHECK: l     F __TEXT,__text __ZN3MySC1Ev
+// CHECK: l     F __TEXT,__text __ZN3MySD1Ev
+// CHECK: l     F __TEXT,__text __ZN3MySC2Ev
+// CHECK: l     F __TEXT,__text __ZN3MySD2Ev
 // CHECK: g     F __TEXT,__text _main
 // CHECK: g     O __DATA,__common _mys1
 // CHECK: g     F __TEXT,__text __mh_execute_header

--- a/llvm/include/llvm/CASObjectFormats/CASObjectReader.h
+++ b/llvm/include/llvm/CASObjectFormats/CASObjectReader.h
@@ -1,0 +1,181 @@
+//===- llvm/CASObjectFormats/CASObjectReader.h ------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CASOBJECTFORMATS_CASOBJECTREADER_H
+#define LLVM_CASOBJECTFORMATS_CASOBJECTREADER_H
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ExecutionEngine/JITLink/MemoryFlags.h"
+#include "llvm/Support/Error.h"
+
+namespace llvm {
+
+class Triple;
+
+// FIXME: Replace the jitlink types with ones native to casobjectformats.
+namespace jitlink {
+enum class Linkage : uint8_t;
+enum class Scope : uint8_t;
+} // namespace jitlink
+
+namespace casobjectformats {
+namespace reader {
+
+/// Only valid to be used with the same \p CASObjectReader instance it came
+/// from.
+struct CASSectionRef {
+  uint64_t Idx;
+};
+
+/// Only valid to be used with the same \p CASObjectReader instance it came
+/// from.
+struct CASBlockRef {
+  uint64_t Idx;
+};
+
+/// Only valid to be used with the same \p CASObjectReader instance it came
+/// from.
+struct CASSymbolRef {
+  uint64_t Idx;
+};
+
+struct CASSection {
+  StringRef Name;
+  jitlink::MemProt Prot;
+};
+
+struct CASBlock {
+  uint64_t Size;
+  uint64_t Alignment;
+  uint64_t AlignmentOffset;
+  Optional<StringRef> Content;
+  CASSectionRef SectionRef;
+
+  bool isZeroFill() const { return !Content.hasValue(); }
+};
+
+struct CASBlockFixup {
+  uint32_t Offset;
+  /// A jitlink::Edge::Kind value.
+  uint8_t Kind;
+  int64_t Addend;
+  CASSymbolRef TargetRef;
+};
+
+struct CASSymbol {
+  StringRef Name;
+  unsigned Offset;
+  jitlink::Linkage Linkage;
+  jitlink::Scope Scope;
+  bool IsLive;
+  bool IsCallable;
+  bool IsAutoHide;
+  Optional<CASBlockRef> BlockRef;
+
+  bool isDefined() const { return BlockRef.hasValue(); }
+};
+
+/// Provides information about the symbols/blocks/sections that a CAS schema
+/// object encoded. The returned \p StringRefs have the same lifetime as the CAS
+/// database instance. Deterministic and thread-safe.
+class CASObjectReader {
+public:
+  virtual ~CASObjectReader() = default;
+
+  virtual Triple getTargetTriple() const = 0;
+
+  /// Get all symbols in the translation unit.
+  /// FIXME: Nestedv1 schema doesn't provide all the symbols that can be
+  /// referenced. More can be discovered via fixups.
+  virtual Error forEachSymbol(
+      function_ref<Error(CASSymbolRef, CASSymbol)> Callback) const = 0;
+
+  virtual Expected<CASSection> materialize(CASSectionRef Ref) const = 0;
+  virtual Expected<CASBlock> materialize(CASBlockRef Ref) const = 0;
+  virtual Expected<CASSymbol> materialize(CASSymbolRef Ref) const = 0;
+
+  virtual Error materializeFixups(
+      CASBlockRef Ref,
+      function_ref<Error(const CASBlockFixup &)> Callback) const = 0;
+
+protected:
+  CASObjectReader() = default;
+};
+
+} // namespace reader
+} // namespace casobjectformats
+} // namespace llvm
+
+namespace llvm {
+
+template <> struct DenseMapInfo<casobjectformats::reader::CASSectionRef> {
+  static casobjectformats::reader::CASSectionRef getEmptyKey() {
+    return casobjectformats::reader::CASSectionRef{
+        DenseMapInfo<uint64_t>::getEmptyKey()};
+  }
+
+  static casobjectformats::reader::CASSectionRef getTombstoneKey() {
+    return casobjectformats::reader::CASSectionRef{
+        DenseMapInfo<uint64_t>::getTombstoneKey()};
+  }
+
+  static unsigned getHashValue(casobjectformats::reader::CASSectionRef ID) {
+    return DenseMapInfo<uint64_t>::getHashValue(ID.Idx);
+  }
+
+  static bool isEqual(casobjectformats::reader::CASSectionRef LHS,
+                      casobjectformats::reader::CASSectionRef RHS) {
+    return LHS.Idx == RHS.Idx;
+  }
+};
+
+template <> struct DenseMapInfo<casobjectformats::reader::CASBlockRef> {
+  static casobjectformats::reader::CASBlockRef getEmptyKey() {
+    return casobjectformats::reader::CASBlockRef{
+        DenseMapInfo<uint64_t>::getEmptyKey()};
+  }
+
+  static casobjectformats::reader::CASBlockRef getTombstoneKey() {
+    return casobjectformats::reader::CASBlockRef{
+        DenseMapInfo<uint64_t>::getTombstoneKey()};
+  }
+
+  static unsigned getHashValue(casobjectformats::reader::CASBlockRef ID) {
+    return DenseMapInfo<uint64_t>::getHashValue(ID.Idx);
+  }
+
+  static bool isEqual(casobjectformats::reader::CASBlockRef LHS,
+                      casobjectformats::reader::CASBlockRef RHS) {
+    return LHS.Idx == RHS.Idx;
+  }
+};
+
+template <> struct DenseMapInfo<casobjectformats::reader::CASSymbolRef> {
+  static casobjectformats::reader::CASSymbolRef getEmptyKey() {
+    return casobjectformats::reader::CASSymbolRef{
+        DenseMapInfo<uint64_t>::getEmptyKey()};
+  }
+
+  static casobjectformats::reader::CASSymbolRef getTombstoneKey() {
+    return casobjectformats::reader::CASSymbolRef{
+        DenseMapInfo<uint64_t>::getTombstoneKey()};
+  }
+
+  static unsigned getHashValue(casobjectformats::reader::CASSymbolRef ID) {
+    return DenseMapInfo<uint64_t>::getHashValue(ID.Idx);
+  }
+
+  static bool isEqual(casobjectformats::reader::CASSymbolRef LHS,
+                      casobjectformats::reader::CASSymbolRef RHS) {
+    return LHS.Idx == RHS.Idx;
+  }
+};
+
+} // namespace llvm
+
+#endif // LLVM_CASOBJECTFORMATS_CASOBJECTREADER_H

--- a/llvm/include/llvm/CASObjectFormats/SchemaBase.h
+++ b/llvm/include/llvm/CASObjectFormats/SchemaBase.h
@@ -16,6 +16,10 @@
 namespace llvm {
 namespace casobjectformats {
 
+namespace reader {
+class CASObjectReader;
+}
+
 /// Schema base class for object files.
 ///
 /// All calls are expected to be thread-safe.
@@ -48,6 +52,9 @@ public:
   /// character. The caller should ensure that the parent node is in the schema
   /// before calling this.
   virtual bool isNode(const cas::NodeRef &Node) const = 0;
+
+  virtual Expected<std::unique_ptr<reader::CASObjectReader>>
+  createObjectReader(cas::NodeRef RootNode) const = 0;
 
   Expected<cas::NodeRef>
   createFromLinkGraph(const jitlink::LinkGraph &G,
@@ -95,6 +102,9 @@ public:
   ///
   /// Thread-safe.
   SchemaBase *getSchemaForRoot(cas::NodeRef Node) const;
+
+  Expected<std::unique_ptr<reader::CASObjectReader>>
+  createObjectReader(cas::CASID ID) const;
 
   cas::CASDB &getCAS() const { return Schemas.front()->CAS; }
 

--- a/llvm/include/llvm/CASObjectFormats/Utils.h
+++ b/llvm/include/llvm/CASObjectFormats/Utils.h
@@ -1,0 +1,28 @@
+//===- llvm/CASObjectFormats/Utils.h ----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CASOBJECTFORMATS_UTILS_H
+#define LLVM_CASOBJECTFORMATS_UTILS_H
+
+namespace llvm {
+
+class Error;
+class raw_ostream;
+
+namespace casobjectformats {
+
+namespace reader {
+class CASObjectReader;
+}
+
+Error printCASObject(const reader::CASObjectReader &Reader, raw_ostream &OS);
+
+} // end namespace casobjectformats
+} // end namespace llvm
+
+#endif // LLVM_CASOBJECTFORMATS_UTILS_H

--- a/llvm/lib/CASObjectFormats/CMakeLists.txt
+++ b/llvm/lib/CASObjectFormats/CMakeLists.txt
@@ -4,6 +4,7 @@ add_llvm_component_library(LLVMCASObjectFormats
   NestedV1.cpp
   SchemaBase.cpp
   ObjectFormatHelpers.cpp
+  Utils.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/CASObjectFormats

--- a/llvm/lib/CASObjectFormats/ObjectFormatHelpers.cpp
+++ b/llvm/lib/CASObjectFormats/ObjectFormatHelpers.cpp
@@ -209,6 +209,10 @@ bool helpers::compareSymbolsByLinkageAndSemantics(const jitlink::Symbol *LHS,
   if (LHS == RHS)
     return false;
 
+  // Put defined symbols ahead.
+  if (LHS->isDefined() != RHS->isDefined())
+    return LHS->isDefined();
+
   // Put locals last.
   if (LHS->getScope() != RHS->getScope())
     return LHS->getScope() < RHS->getScope();

--- a/llvm/lib/CASObjectFormats/SchemaBase.cpp
+++ b/llvm/lib/CASObjectFormats/SchemaBase.cpp
@@ -27,3 +27,15 @@ SchemaBase *SchemaPool::getSchemaForRoot(cas::NodeRef Node) const {
   }
   return nullptr;
 }
+
+Expected<std::unique_ptr<reader::CASObjectReader>>
+SchemaPool::createObjectReader(cas::CASID ID) const {
+  Expected<cas::NodeRef> Ref = getCAS().getNode(ID);
+  if (auto E = Ref.takeError())
+    return std::move(E);
+  SchemaBase *Schema = getSchemaForRoot(*Ref);
+  if (!Schema)
+    return createStringError(inconvertibleErrorCode(),
+                             "CAS object is not a recognized object file");
+  return Schema->createObjectReader(*Ref);
+}

--- a/llvm/lib/CASObjectFormats/Utils.cpp
+++ b/llvm/lib/CASObjectFormats/Utils.cpp
@@ -1,0 +1,272 @@
+//===- CASObjectFormats/Utils.cpp -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CASObjectFormats/Utils.h"
+#include "llvm/CASObjectFormats/CASObjectReader.h"
+#include "llvm/ExecutionEngine/JITLink/JITLink.h"
+
+using namespace llvm;
+using namespace llvm::casobjectformats;
+using namespace llvm::casobjectformats::reader;
+
+static std::string getDescription(const CASSection &Info) {
+  std::string Description;
+  {
+    raw_string_ostream(Description) << Info.Name << " | MemProt: " << Info.Prot;
+  }
+  return Description;
+}
+
+static std::string getDescription(const CASBlock &Info) {
+  std::string Description;
+  {
+    raw_string_ostream OS(Description);
+    OS << "size = " << formatv("{0:x4}", Info.Size)
+       << ", align = " << Info.Alignment
+       << ", alignment-offset = " << Info.AlignmentOffset;
+    if (Info.isZeroFill())
+      OS << ", zero-fill";
+  }
+  return Description;
+}
+
+static std::string
+getDescription(const CASBlockFixup &Fixup, StringRef TargetName,
+               llvm::jitlink::LinkGraph::GetEdgeKindNameFunction EdgeKindFn) {
+  std::string Description;
+  {
+    raw_string_ostream OS(Description);
+    OS << formatv("{0:x4}", Fixup.Offset) << ", addend = ";
+    if (Fixup.Addend >= 0)
+      OS << formatv("+{0:x8}", Fixup.Addend);
+    else
+      OS << formatv("-{0:x8}", -Fixup.Addend);
+    OS << ", kind = " << EdgeKindFn(Fixup.Kind) << ", target = " << TargetName;
+  }
+  return Description;
+}
+
+static std::string getDescription(StringRef Name, const CASSymbol &Info) {
+  bool IsDefined = Info.isDefined();
+  std::string Description;
+  {
+    raw_string_ostream OS(Description);
+    OS << Name << " | ";
+    if (IsDefined) {
+      OS << "offset: " << formatv("{0:x4}", Info.Offset) << ", ";
+    }
+    OS << "linkage: "
+       << formatv("{0:6}", jitlink::getLinkageName(Info.Linkage));
+    if (IsDefined) {
+      OS << ", scope: " << formatv("{0:8}", jitlink::getScopeName(Info.Scope))
+         << ", " << (Info.IsLive ? "live" : "dead");
+      if (Info.IsCallable)
+        OS << ", callable";
+      if (Info.IsAutoHide)
+        OS << ", autohide";
+    }
+  }
+  return Description;
+  return Info.Name.str();
+}
+
+Error casobjectformats::printCASObject(const reader::CASObjectReader &Reader,
+                                       raw_ostream &OS) {
+  Triple TT = Reader.getTargetTriple();
+  auto EdgeKindNameFn = jitlink::getGetEdgeKindNameFunction(TT);
+  if (auto E = EdgeKindNameFn.takeError())
+    return E;
+
+  OS << "Triple: " << TT.str() << "\n\n";
+
+  struct PrintBlock;
+  struct PrintSymbol;
+
+  struct PrintSection {
+    std::string Name;
+    std::string Description;
+    SmallVector<PrintBlock *> Blocks;
+  };
+  struct PrintBlock {
+    struct Fixup {
+      std::string Description;
+    };
+
+    CASBlockRef Ref;
+    std::string Description;
+    std::string Content;
+    PrintSection *Section = nullptr;
+    SmallVector<PrintSymbol *> Symbols;
+    SmallVector<Fixup> Fixups;
+  };
+  struct PrintSymbol {
+    unsigned Offset;
+    std::string Name;
+    std::string Description;
+    PrintBlock *Block = nullptr;
+  };
+
+  SmallVector<std::unique_ptr<PrintSection>> Sections;
+  auto createSection = [&]() -> PrintSection * {
+    Sections.push_back(std::make_unique<PrintSection>());
+    return Sections.back().get();
+  };
+
+  SmallVector<std::unique_ptr<PrintBlock>> Blocks;
+  auto createBlock = [&]() -> PrintBlock * {
+    Blocks.push_back(std::make_unique<PrintBlock>());
+    return Blocks.back().get();
+  };
+
+  SmallVector<std::unique_ptr<PrintSymbol>> Symbols;
+  auto createSymbol = [&]() -> PrintSymbol * {
+    Symbols.push_back(std::make_unique<PrintSymbol>());
+    return Symbols.back().get();
+  };
+
+  SmallDenseMap<CASSectionRef, PrintSection *> SectionMap;
+  DenseMap<CASBlockRef, PrintBlock *> BlockMap;
+  DenseMap<CASSymbolRef, PrintSymbol *> SymbolMap;
+  unsigned AnonNameIdx = 0;
+
+  auto recordSection =
+      [&](CASSectionRef SectionRef) -> Expected<PrintSection *> {
+    PrintSection *&MappedSection = SectionMap[SectionRef];
+    if (MappedSection)
+      return MappedSection;
+    Expected<CASSection> Info = Reader.materialize(SectionRef);
+    if (!Info)
+      return Info.takeError();
+    auto *PrintSection = createSection();
+    PrintSection->Name = Info->Name.str();
+    PrintSection->Description = getDescription(*Info);
+    MappedSection = PrintSection;
+    return PrintSection;
+  };
+
+  auto recordBlock = [&](CASBlockRef BlockRef) -> Expected<PrintBlock *> {
+    PrintBlock *&MappedBlock = BlockMap[BlockRef];
+    if (MappedBlock)
+      return MappedBlock;
+    Expected<CASBlock> Info = Reader.materialize(BlockRef);
+    if (!Info)
+      return Info.takeError();
+    auto *PrintBlock = createBlock();
+    auto PrintSection = recordSection(Info->SectionRef);
+    if (!PrintSection)
+      return PrintSection.takeError();
+    PrintBlock->Ref = BlockRef;
+    PrintBlock->Description = getDescription(*Info);
+    PrintBlock->Content = Info->Content.getValueOr(StringRef()).str();
+    PrintBlock->Section = *PrintSection;
+    PrintBlock->Section->Blocks.push_back(PrintBlock);
+    MappedBlock = PrintBlock;
+    return PrintBlock;
+  };
+
+  auto recordSymbol = [&](CASSymbolRef SymbolRef,
+                          CASSymbol Info) -> Expected<PrintSymbol *> {
+    PrintSymbol *&MappedSymbol = SymbolMap[SymbolRef];
+    if (MappedSymbol)
+      return MappedSymbol;
+    auto *PrintSymbol = createSymbol();
+    PrintSymbol->Offset = Info.Offset;
+    if (!Info.Name.empty()) {
+      PrintSymbol->Name = Info.Name.str();
+    } else {
+      raw_string_ostream(PrintSymbol->Name)
+          << "<anon-" << (AnonNameIdx++) << '>';
+    }
+    PrintSymbol->Description = getDescription(PrintSymbol->Name, Info);
+    if (Info.BlockRef) {
+      auto PrintBlock = recordBlock(*Info.BlockRef);
+      if (!PrintBlock)
+        return PrintBlock.takeError();
+      PrintSymbol->Block = *PrintBlock;
+    }
+    if (PrintSymbol->Block)
+      PrintSymbol->Block->Symbols.push_back(PrintSymbol);
+    MappedSymbol = PrintSymbol;
+    return PrintSymbol;
+  };
+
+  Error E = Reader.forEachSymbol(
+      [&](CASSymbolRef SymbolRef, CASSymbol Info) -> Error {
+        Expected<PrintSymbol *> Symbol = recordSymbol(SymbolRef, Info);
+        if (!Symbol)
+          return Symbol.takeError();
+        return Error::success();
+      });
+  if (E)
+    return E;
+
+  // Check for \p size() at each iteration because new blocks can be added
+  // while reading the fixups, due to new symbols getting discovered when using
+  // nestedv1 format.
+  // FIXME: Get nestedv1 to provide all the symbols that can be referenced from
+  // the translation unit, via \p forEachSymbol().
+  for (unsigned I = 0; I < Blocks.size(); ++I) {
+    PrintBlock &PBlock = *Blocks[I];
+    Error E = Reader.materializeFixups(
+        PBlock.Ref, [&](const CASBlockFixup &Fixup) -> Error {
+          PrintSymbol *Target = SymbolMap[Fixup.TargetRef];
+          if (!Target) {
+            Expected<CASSymbol> Info = Reader.materialize(Fixup.TargetRef);
+            if (!Info)
+              return Info.takeError();
+            Expected<PrintSymbol *> PrintSym =
+                recordSymbol(Fixup.TargetRef, *Info);
+            if (!PrintSym)
+              return PrintSym.takeError();
+            Target = *PrintSym;
+          }
+          std::string FixupDesc =
+              getDescription(Fixup, Target->Name, *EdgeKindNameFn);
+          PBlock.Fixups.push_back(PrintBlock::Fixup{std::move(FixupDesc)});
+          return Error::success();
+        });
+    if (E)
+      return E;
+  }
+
+  for (const auto &Section : Sections) {
+    OS << "SECTION: " << Section->Description << '\n';
+    OS << "{\n";
+    for (const auto *Block : Section->Blocks) {
+      OS.indent(2) << "BLOCK: " << Block->Description << '\n';
+      OS.indent(2) << "{\n";
+      OS.indent(4) << "Symbols:\n";
+      for (const auto *Symbol : Block->Symbols) {
+        OS.indent(6) << Symbol->Description;
+        if (Section->Name == "__TEXT,__cstring") {
+          OS << " | \"";
+          OS.write_escaped(&Block->Content[Symbol->Offset]);
+          OS << '"';
+        }
+        OS << '\n';
+      }
+      if (!Block->Fixups.empty()) {
+        OS.indent(4) << "Fixups:\n";
+        for (const auto &Fixup : Block->Fixups) {
+          OS.indent(6) << Fixup.Description << '\n';
+        }
+      }
+      OS.indent(2) << "}\n";
+    }
+    OS << "}\n\n";
+  }
+
+  OS << "UNDEFINED SYMBOLS\n{\n";
+  for (const auto &Symbol : Symbols) {
+    if (Symbol->Block)
+      continue;
+    OS.indent(2) << Symbol->Description << '\n';
+  }
+  OS << "}\n";
+  return Error::success();
+}

--- a/llvm/test/tools/llvm-cas-object-format/Inputs/main.ll
+++ b/llvm/test/tools/llvm-cas-object-format/Inputs/main.ll
@@ -6,8 +6,11 @@ define i32 @_foo() #0 {
 }
 
 define i32 @main() #0 {
+  call void @foo_ext()
   %1 = call i32 @_foo()
   ret i32 %1
 }
+
+declare void @foo_ext()
 
 attributes #0 = { noinline nounwind optnone uwtable }

--- a/llvm/test/tools/llvm-cas-object-format/Inputs/print-out-flatv1.txt
+++ b/llvm/test/tools/llvm-cas-object-format/Inputs/print-out-flatv1.txt
@@ -1,0 +1,63 @@
+Triple: x86_64-apple-darwin
+
+SECTION: __TEXT,__text | MemProt: R-X
+{
+  BLOCK: size = 0x0010, align = 16, alignment-offset = 0
+  {
+    Symbols:
+      __foo | offset: 0x0000, linkage: strong, scope: default, dead, callable
+    Fixups:
+      0x0000, addend = +0x00000000, kind = Keep-Alive, target = <anon-2>
+  }
+  BLOCK: size = 0x0010, align = 16, alignment-offset = 0
+  {
+    Symbols:
+      _main | offset: 0x0000, linkage: strong, scope: default, dead, callable
+    Fixups:
+      0x0000, addend = +0x00000000, kind = Keep-Alive, target = <anon-3>
+      0x0002, addend = +0x00000000, kind = BranchPCRel32, target = _foo_ext
+      0x0007, addend = +0x00000000, kind = BranchPCRel32, target = __foo
+  }
+}
+
+SECTION: __LD,__compact_unwind | MemProt: RW-
+{
+  BLOCK: size = 0x0020, align = 8, alignment-offset = 0
+  {
+    Symbols:
+      <anon-0> | offset: 0x0000, linkage: strong, scope: local, dead
+    Fixups:
+      0x0000, addend = +0x00000000, kind = Pointer64, target = _main
+  }
+}
+
+SECTION: __TEXT,__eh_frame | MemProt: RW-
+{
+  BLOCK: size = 0x0018, align = 8, alignment-offset = 0
+  {
+    Symbols:
+      <anon-1> | offset: 0x0000, linkage: strong, scope: local, dead
+  }
+  BLOCK: size = 0x0020, align = 8, alignment-offset = 0
+  {
+    Symbols:
+      <anon-2> | offset: 0x0000, linkage: strong, scope: local, dead
+    Fixups:
+      0x0004, addend = +0x00000000, kind = NegDelta32, target = <anon-1>
+      0x0008, addend = +0x00000000, kind = Delta64, target = __foo
+  }
+  BLOCK: size = 0x0020, align = 8, alignment-offset = 0
+  {
+    Symbols:
+      <anon-3> | offset: 0x0000, linkage: strong, scope: local, dead
+    Fixups:
+      0x0004, addend = +0x00000000, kind = NegDelta32, target = <anon-1>
+      0x0008, addend = +0x00000000, kind = Delta64, target = _main
+  }
+}
+
+UNDEFINED SYMBOLS
+{
+  _foo_ext | linkage: strong
+}
+

--- a/llvm/test/tools/llvm-cas-object-format/Inputs/print-out-nestedv1.txt
+++ b/llvm/test/tools/llvm-cas-object-format/Inputs/print-out-nestedv1.txt
@@ -1,0 +1,63 @@
+Triple: x86_64-apple-darwin
+
+SECTION: __TEXT,__text | MemProt: R-X
+{
+  BLOCK: size = 0x0010, align = 16, alignment-offset = 0
+  {
+    Symbols:
+      __foo | offset: 0x0000, linkage: strong, scope: default, dead
+    Fixups:
+      0x0000, addend = +0x00000000, kind = Keep-Alive, target = <anon-1>
+  }
+  BLOCK: size = 0x0010, align = 16, alignment-offset = 0
+  {
+    Symbols:
+      _main | offset: 0x0000, linkage: strong, scope: default, dead
+    Fixups:
+      0x0000, addend = +0x00000000, kind = Keep-Alive, target = <anon-2>
+      0x0002, addend = +0x00000000, kind = BranchPCRel32, target = _foo_ext
+      0x0007, addend = +0x00000000, kind = BranchPCRel32, target = __foo
+  }
+}
+
+SECTION: __LD,__compact_unwind | MemProt: RW-
+{
+  BLOCK: size = 0x0020, align = 8, alignment-offset = 0
+  {
+    Symbols:
+      <anon-0> | offset: 0x0000, linkage: strong, scope: local, live
+    Fixups:
+      0x0000, addend = +0x00000000, kind = Pointer64, target = _main
+  }
+}
+
+SECTION: __TEXT,__eh_frame | MemProt: RW-
+{
+  BLOCK: size = 0x0020, align = 8, alignment-offset = 0
+  {
+    Symbols:
+      <anon-1> | offset: 0x0000, linkage: strong, scope: local, dead
+    Fixups:
+      0x0004, addend = +0x00000000, kind = NegDelta32, target = <anon-3>
+      0x0008, addend = +0x00000000, kind = Delta64, target = __foo
+  }
+  BLOCK: size = 0x0020, align = 8, alignment-offset = 0
+  {
+    Symbols:
+      <anon-2> | offset: 0x0000, linkage: strong, scope: local, dead
+    Fixups:
+      0x0004, addend = +0x00000000, kind = NegDelta32, target = <anon-3>
+      0x0008, addend = +0x00000000, kind = Delta64, target = _main
+  }
+  BLOCK: size = 0x0018, align = 8, alignment-offset = 0
+  {
+    Symbols:
+      <anon-3> | offset: 0x0000, linkage: strong, scope: local, dead
+  }
+}
+
+UNDEFINED SYMBOLS
+{
+  _foo_ext | linkage: strong
+}
+

--- a/llvm/test/tools/llvm-cas-object-format/print-object.test
+++ b/llvm/test/tools/llvm-cas-object-format/print-object.test
@@ -1,0 +1,11 @@
+RUN: rm -rf %t && mkdir -p %t
+RUN: llc %S/Inputs/main.ll --filetype=obj -o %t/main.o
+
+RUN: llvm-cas-object-format --cas %t/cas %t/main.o --ingest-schema=flatv1 -silent > %t/flat.id
+RUN: llvm-cas-object-format --cas %t/cas %t/main.o --ingest-schema=nestedv1 -silent > %t/nested.id
+RUN: llvm-cas-object-format --cas %t/cas --print-cas-object @%t/flat.id > %t/flat-out.txt
+RUN: llvm-cas-object-format --cas %t/cas --print-cas-object @%t/nested.id > %t/nested-out.txt
+
+// FIXME: Match the outputs between the schemas?
+RUN: diff -u %S/Inputs/print-out-flatv1.txt %t/flat-out.txt
+RUN: diff -u %S/Inputs/print-out-nestedv1.txt %t/nested-out.txt


### PR DESCRIPTION
The interface is thread-safe and can provide information in a lazy manner.

Also
* Add a function to get readable printed output for a CAS schema object, based on the reader interface
* Get `lld` to to adopt the reader interface instead of using `jitlink` conversion

After using the reader interface instead of `jitlink`, linking the clang executable with `flatv1` CAS objects shows about -25% less memory usage and -19% less wall time.