### PR TITLE
Pr restore upstream depscan impl

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
@@ -1,0 +1,129 @@
+//===- DependencyScanningCASFilesystem.h - clang-scan-deps fs ---*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLING_DEPENDENCYSCANNING_DEPENDENCYSCANNINGCASFILESYSTEM_H
+#define LLVM_CLANG_TOOLING_DEPENDENCYSCANNING_DEPENDENCYSCANNINGCASFILESYSTEM_H
+
+#include "clang/Basic/LLVM.h"
+#include "clang/Lex/PreprocessorExcludedConditionalDirectiveSkipMapping.h"
+#include "clang/Tooling/DependencyScanning/DependencyScanningFilesystem.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/CAS/CASID.h"
+#include "llvm/CAS/ThreadSafeFileSystem.h"
+#include "llvm/Support/Allocator.h"
+#include "llvm/Support/ErrorOr.h"
+#include "llvm/Support/VirtualFileSystem.h"
+#include <mutex>
+
+namespace llvm {
+namespace cas {
+class CachingOnDiskFileSystem;
+} // namespace cas
+} // namespace llvm
+
+namespace clang {
+namespace tooling {
+namespace dependencies {
+
+// CAS based Dependency Scanning Woker Filesystem.
+// This should be a ThreadSafeFilesystem that you can create proxy with
+// `createThreadSafeproxyFS()`.
+class DependencyScanningCASFilesystem
+    : public DependencyScanningWorkerFilesystem {
+public:
+  DependencyScanningCASFilesystem(
+      DependencyScanningFilesystemSharedCache &SharedCache,
+      IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> WorkerFS,
+      ExcludedPreprocessorDirectiveSkipMapping *PPSkipMappings);
+
+  ~DependencyScanningCASFilesystem();
+
+  llvm::cas::CASDB &getCAS() const { return FS->getCAS(); }
+  Optional<llvm::cas::CASID> getFileCASID(const Twine &Path);
+
+  // FIXME: Make a templated version of ProxyFileSystem with a configurable
+  // base class.
+  llvm::vfs::directory_iterator dir_begin(const Twine &Dir,
+                                          std::error_code &EC) override {
+    return FS->dir_begin(Dir, EC);
+  }
+  llvm::ErrorOr<std::string> getCurrentWorkingDirectory() const override {
+    return FS->getCurrentWorkingDirectory();
+  }
+  std::error_code setCurrentWorkingDirectory(const Twine &Path) override {
+    return FS->setCurrentWorkingDirectory(Path);
+  }
+  std::error_code getRealPath(const Twine &Path,
+                              SmallVectorImpl<char> &Output) const override {
+    return FS->getRealPath(Path, Output);
+  }
+  std::error_code isLocal(const Twine &Path, bool &Result) override {
+    return FS->isLocal(Path, Result);
+  }
+
+  IntrusiveRefCntPtr<llvm::cas::ThreadSafeFileSystem> createThreadSafeProxyFS();
+
+  llvm::ErrorOr<llvm::vfs::Status> status(const Twine &Path) override;
+  llvm::ErrorOr<std::unique_ptr<llvm::vfs::File>>
+  openFileForRead(const Twine &Path) override;
+
+  /// Disable minimization of the given file.
+  void disableMinimization(StringRef Filename);
+  /// Enable minimization of all files.
+  void enableMinimizationOfAllFiles() { NotToBeMinimized.clear(); }
+
+private:
+  /// Check whether the file should be minimized.
+  bool shouldMinimize(StringRef Filename);
+
+  IntrusiveRefCntPtr<llvm::cas::CASFileSystemBase> FS;
+
+  struct FileEntry {
+    std::error_code EC; // If non-zero, caches a stat failure.
+    Optional<StringRef> Buffer;
+    llvm::vfs::Status Status;
+    Optional<llvm::cas::CASID> ID;
+  };
+  llvm::BumpPtrAllocator EntryAlloc;
+  llvm::StringMap<FileEntry, llvm::BumpPtrAllocator> Entries;
+
+  struct LookupPathResult {
+    const FileEntry *Entry = nullptr;
+
+    // Only filled if the Entry is nullptr.
+    llvm::ErrorOr<llvm::vfs::Status> Status;
+  };
+  Expected<StringRef>
+  computeMinimized(llvm::cas::CASID InputDataID, StringRef Identifier,
+                   Optional<llvm::cas::CASID> &MinimizedDataID);
+
+  Expected<StringRef> getMinimized(llvm::cas::CASID OutputID,
+                                   StringRef Identifier,
+                                   Optional<llvm::cas::CASID> &MinimizedDataID);
+
+  Expected<StringRef> getOriginal(llvm::cas::CASID InputDataID);
+
+  LookupPathResult lookupPath(const Twine &Path);
+
+  llvm::cas::CachingOnDiskFileSystem &getCachingFS();
+
+  llvm::cas::CASDB &CAS;
+  Optional<llvm::cas::CASID> ClangFullVersionID;
+  Optional<llvm::cas::CASID> MinimizeID;
+  Optional<llvm::cas::CASID> EmptyBlobID;
+
+  /// The set of files that should not be minimized.
+  llvm::StringSet<> NotToBeMinimized;
+};
+
+} // end namespace dependencies
+} // end namespace tooling
+} // end namespace clang
+
+#endif // LLVM_CLANG_TOOLING_DEPENDENCYSCANNING_DEPENDENCYSCANNINGCASFILESYSTEM_H

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningFilesystem.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningFilesystem.h
@@ -11,24 +11,273 @@
 
 #include "clang/Basic/LLVM.h"
 #include "clang/Lex/PreprocessorExcludedConditionalDirectiveSkipMapping.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringMap.h"
-#include "llvm/ADT/StringSet.h"
-#include "llvm/CAS/CASID.h"
-#include "llvm/CAS/ThreadSafeFileSystem.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include <mutex>
 
-namespace llvm {
-namespace cas {
-class CachingOnDiskFileSystem;
-} // namespace cas
-} // namespace llvm
-
 namespace clang {
 namespace tooling {
 namespace dependencies {
+
+/// Original and minimized contents of a cached file entry. Single instance can
+/// be shared between multiple entries.
+struct CachedFileContents {
+  CachedFileContents(std::unique_ptr<llvm::MemoryBuffer> Original)
+      : Original(std::move(Original)), MinimizedAccess(nullptr) {}
+
+  /// Owning storage for the minimized contents.
+  std::unique_ptr<llvm::MemoryBuffer> Original;
+
+  /// The mutex that must be locked before mutating minimized contents.
+  std::mutex ValueLock;
+  /// Owning storage for the minimized contents.
+  std::unique_ptr<llvm::MemoryBuffer> MinimizedStorage;
+  /// Accessor to the minimized contents that's atomic to avoid data races.
+  std::atomic<llvm::MemoryBuffer *> MinimizedAccess;
+  /// Skipped range mapping of the minimized contents.
+  /// This is initialized iff `MinimizedAccess != nullptr`.
+  PreprocessorSkippedRangeMapping PPSkippedRangeMapping;
+};
+
+/// An in-memory representation of a file system entity that is of interest to
+/// the dependency scanning filesystem.
+///
+/// It represents one of the following:
+/// - opened file with original contents and a stat value,
+/// - opened file with original contents, minimized contents and a stat value,
+/// - directory entry with its stat value,
+/// - filesystem error.
+///
+/// Single instance of this class can be shared across different filenames (e.g.
+/// a regular file and a symlink). For this reason the status filename is empty
+/// and is only materialized by \c EntryRef that knows the requested filename.
+class CachedFileSystemEntry {
+public:
+  /// Creates an entry without contents: either a filesystem error or
+  /// a directory with stat value.
+  CachedFileSystemEntry(llvm::ErrorOr<llvm::vfs::Status> Stat)
+      : MaybeStat(std::move(Stat)), Contents(nullptr) {
+    clearStatName();
+  }
+
+  /// Creates an entry representing a file with contents.
+  CachedFileSystemEntry(llvm::ErrorOr<llvm::vfs::Status> Stat,
+                        CachedFileContents *Contents)
+      : MaybeStat(std::move(Stat)), Contents(std::move(Contents)) {
+    clearStatName();
+  }
+
+  /// \returns True if the entry is a filesystem error.
+  bool isError() const { return !MaybeStat; }
+
+  /// \returns True if the current entry represents a directory.
+  bool isDirectory() const { return !isError() && MaybeStat->isDirectory(); }
+
+  /// \returns Original contents of the file.
+  StringRef getOriginalContents() const {
+    assert(!isError() && "error");
+    assert(!MaybeStat->isDirectory() && "not a file");
+    assert(Contents && "contents not initialized");
+    return Contents->Original->getBuffer();
+  }
+
+  /// \returns Minimized contents of the file.
+  StringRef getMinimizedContents() const {
+    assert(!isError() && "error");
+    assert(!MaybeStat->isDirectory() && "not a file");
+    assert(Contents && "contents not initialized");
+    llvm::MemoryBuffer *Buffer = Contents->MinimizedAccess.load();
+    assert(Buffer && "not minimized");
+    return Buffer->getBuffer();
+  }
+
+  /// \returns The error.
+  std::error_code getError() const { return MaybeStat.getError(); }
+
+  /// \returns The entry status with empty filename.
+  llvm::vfs::Status getStatus() const {
+    assert(!isError() && "error");
+    assert(MaybeStat->getName().empty() && "stat name must be empty");
+    return *MaybeStat;
+  }
+
+  /// \returns The unique ID of the entry.
+  llvm::sys::fs::UniqueID getUniqueID() const {
+    assert(!isError() && "error");
+    return MaybeStat->getUniqueID();
+  }
+
+  /// \returns The mapping between location -> distance that is used to speed up
+  /// the block skipping in the preprocessor.
+  const PreprocessorSkippedRangeMapping &getPPSkippedRangeMapping() const {
+    assert(!isError() && "error");
+    assert(!isDirectory() && "not a file");
+    assert(Contents && "contents not initialized");
+    return Contents->PPSkippedRangeMapping;
+  }
+
+  /// \returns The data structure holding both original and minimized contents.
+  CachedFileContents *getContents() const {
+    assert(!isError() && "error");
+    assert(!isDirectory() && "not a file");
+    return Contents;
+  }
+
+private:
+  void clearStatName() {
+    if (MaybeStat)
+      MaybeStat = llvm::vfs::Status::copyWithNewName(*MaybeStat, "");
+  }
+
+  /// Either the filesystem error or status of the entry.
+  /// The filename is empty and only materialized by \c EntryRef.
+  llvm::ErrorOr<llvm::vfs::Status> MaybeStat;
+
+  /// Non-owning pointer to the file contents.
+  ///
+  /// We're using pointer here to keep the size of this class small. Instances
+  /// representing directories and filesystem errors don't hold any contents
+  /// anyway.
+  CachedFileContents *Contents;
+};
+
+/// This class is a shared cache, that caches the 'stat' and 'open' calls to the
+/// underlying real file system. It distinguishes between minimized and original
+/// files.
+///
+/// It is sharded based on the hash of the key to reduce the lock contention for
+/// the worker threads.
+class DependencyScanningFilesystemSharedCache {
+public:
+  struct CacheShard {
+    /// The mutex that needs to be locked before mutation of any member.
+    mutable std::mutex CacheLock;
+
+    /// Map from filenames to cached entries.
+    llvm::StringMap<const CachedFileSystemEntry *, llvm::BumpPtrAllocator>
+        EntriesByFilename;
+
+    /// Map from unique IDs to cached entries.
+    llvm::DenseMap<llvm::sys::fs::UniqueID, const CachedFileSystemEntry *>
+        EntriesByUID;
+
+    /// The backing storage for cached entries.
+    llvm::SpecificBumpPtrAllocator<CachedFileSystemEntry> EntryStorage;
+
+    /// The backing storage for cached contents.
+    llvm::SpecificBumpPtrAllocator<CachedFileContents> ContentsStorage;
+
+    /// Returns entry associated with the filename or nullptr if none is found.
+    const CachedFileSystemEntry *findEntryByFilename(StringRef Filename) const;
+
+    /// Returns entry associated with the unique ID or nullptr if none is found.
+    const CachedFileSystemEntry *
+    findEntryByUID(llvm::sys::fs::UniqueID UID) const;
+
+    /// Returns entry associated with the filename if there is some. Otherwise,
+    /// constructs new one with the given status, associates it with the
+    /// filename and returns the result.
+    const CachedFileSystemEntry &
+    getOrEmplaceEntryForFilename(StringRef Filename,
+                                 llvm::ErrorOr<llvm::vfs::Status> Stat);
+
+    /// Returns entry associated with the unique ID if there is some. Otherwise,
+    /// constructs new one with the given status and contents, associates it
+    /// with the unique ID and returns the result.
+    const CachedFileSystemEntry &
+    getOrEmplaceEntryForUID(llvm::sys::fs::UniqueID UID, llvm::vfs::Status Stat,
+                            std::unique_ptr<llvm::MemoryBuffer> Contents);
+
+    /// Returns entry associated with the filename if there is some. Otherwise,
+    /// associates the given entry with the filename and returns it.
+    const CachedFileSystemEntry &
+    getOrInsertEntryForFilename(StringRef Filename,
+                                const CachedFileSystemEntry &Entry);
+  };
+
+  DependencyScanningFilesystemSharedCache();
+
+  /// Returns shard for the given key.
+  CacheShard &getShardForFilename(StringRef Filename) const;
+  CacheShard &getShardForUID(llvm::sys::fs::UniqueID UID) const;
+
+private:
+  std::unique_ptr<CacheShard[]> CacheShards;
+  unsigned NumShards;
+};
+
+/// This class is a local cache, that caches the 'stat' and 'open' calls to the
+/// underlying real file system. It distinguishes between minimized and original
+/// files.
+class DependencyScanningFilesystemLocalCache {
+  llvm::StringMap<const CachedFileSystemEntry *, llvm::BumpPtrAllocator> Cache;
+
+public:
+  /// Returns entry associated with the filename or nullptr if none is found.
+  const CachedFileSystemEntry *findEntryByFilename(StringRef Filename) const {
+    auto It = Cache.find(Filename);
+    return It == Cache.end() ? nullptr : It->getValue();
+  }
+
+  /// Associates the given entry with the filename and returns the given entry
+  /// pointer (for convenience).
+  const CachedFileSystemEntry &
+  insertEntryForFilename(StringRef Filename,
+                         const CachedFileSystemEntry &Entry) {
+    const auto *InsertedEntry = Cache.insert({Filename, &Entry}).first->second;
+    assert(InsertedEntry == &Entry && "entry already present");
+    return *InsertedEntry;
+  }
+};
+
+/// Reference to a CachedFileSystemEntry.
+/// If the underlying entry is an opened file, this wrapper returns the correct
+/// contents (original or minimized) and ensures consistency with file size
+/// reported by status.
+class EntryRef {
+  /// For entry that is an opened file, this bit signifies whether its contents
+  /// are minimized.
+  bool Minimized;
+
+  /// The filename used to access this entry.
+  std::string Filename;
+
+  /// The underlying cached entry.
+  const CachedFileSystemEntry &Entry;
+
+public:
+  EntryRef(bool Minimized, StringRef Name, const CachedFileSystemEntry &Entry)
+      : Minimized(Minimized), Filename(Name), Entry(Entry) {}
+
+  llvm::vfs::Status getStatus() const {
+    llvm::vfs::Status Stat = Entry.getStatus();
+    if (!Stat.isDirectory())
+      Stat = llvm::vfs::Status::copyWithNewSize(Stat, getContents().size());
+    return llvm::vfs::Status::copyWithNewName(Stat, Filename);
+  }
+
+  bool isError() const { return Entry.isError(); }
+  bool isDirectory() const { return Entry.isDirectory(); }
+
+  /// If the cached entry represents an error, promotes it into `ErrorOr`.
+  llvm::ErrorOr<EntryRef> unwrapError() const {
+    if (isError())
+      return Entry.getError();
+    return *this;
+  }
+
+  StringRef getContents() const {
+    return Minimized ? Entry.getMinimizedContents()
+                     : Entry.getOriginalContents();
+  }
+
+  const PreprocessorSkippedRangeMapping *getPPSkippedRangeMapping() const {
+    return Minimized ? &Entry.getPPSkippedRangeMapping() : nullptr;
+  }
+};
 
 /// A virtual file system optimized for the dependency discovery.
 ///
@@ -39,38 +288,14 @@ namespace dependencies {
 /// This is not a thread safe VFS. A single instance is meant to be used only in
 /// one thread. Multiple instances are allowed to service multiple threads
 /// running in parallel.
-class DependencyScanningWorkerFilesystem : public llvm::cas::CASFileSystemBase {
+class DependencyScanningWorkerFilesystem : public llvm::vfs::ProxyFileSystem {
 public:
   DependencyScanningWorkerFilesystem(
-      IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> WorkerFS,
-      ExcludedPreprocessorDirectiveSkipMapping *PPSkipMappings);
-
-  ~DependencyScanningWorkerFilesystem();
-
-  llvm::cas::CASDB &getCAS() const override { return FS->getCAS(); }
-  Optional<llvm::cas::CASID> getFileCASID(const Twine &Path) override;
-
-  // FIXME: Make a templated version of ProxyFileSystem with a configurable
-  // base class.
-  llvm::vfs::directory_iterator dir_begin(const Twine &Dir, std::error_code &EC) override {
-    return FS->dir_begin(Dir, EC);
-  }
-  llvm::ErrorOr<std::string> getCurrentWorkingDirectory() const override {
-    return FS->getCurrentWorkingDirectory();
-  }
-  std::error_code setCurrentWorkingDirectory(const Twine &Path) override {
-    return FS->setCurrentWorkingDirectory(Path);
-  }
-  std::error_code getRealPath(const Twine &Path,
-                              SmallVectorImpl<char> &Output) const override {
-    return FS->getRealPath(Path, Output);
-  }
-  std::error_code isLocal(const Twine &Path, bool &Result) override {
-    return FS->isLocal(Path, Result);
-  }
-
-  IntrusiveRefCntPtr<llvm::cas::ThreadSafeFileSystem>
-  createThreadSafeProxyFS() override;
+      DependencyScanningFilesystemSharedCache &SharedCache,
+      IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS,
+      ExcludedPreprocessorDirectiveSkipMapping *PPSkipMappings)
+      : ProxyFileSystem(std::move(FS)), SharedCache(SharedCache),
+        PPSkipMappings(PPSkipMappings) {}
 
   llvm::ErrorOr<llvm::vfs::Status> status(const Twine &Path) override;
   llvm::ErrorOr<std::unique_ptr<llvm::vfs::File>>
@@ -81,52 +306,104 @@ public:
   /// Enable minimization of all files.
   void enableMinimizationOfAllFiles() { NotToBeMinimized.clear(); }
 
-private:
+protected:
   /// Check whether the file should be minimized.
-  bool shouldMinimize(StringRef Filename);
+  bool shouldMinimize(StringRef Filename, llvm::sys::fs::UniqueID UID);
 
-  IntrusiveRefCntPtr<llvm::cas::CASFileSystemBase> FS;
+  /// Returns entry for the given filename.
+  ///
+  /// Attempts to use the local and shared caches first, then falls back to
+  /// using the underlying filesystem.
+  llvm::ErrorOr<EntryRef>
+  getOrCreateFileSystemEntry(StringRef Filename,
+                             bool DisableMinimization = false);
 
-  struct FileEntry {
-    std::error_code EC; // If non-zero, caches a stat failure.
-    Optional<StringRef> Buffer;
+  /// For a filename that's not yet associated with any entry in the caches,
+  /// uses the underlying filesystem to either look up the entry based in the
+  /// shared cache indexed by unique ID, or creates new entry from scratch.
+  llvm::ErrorOr<const CachedFileSystemEntry &>
+  computeAndStoreResult(StringRef Filename);
+
+  /// Minimizes the given entry if necessary and returns a wrapper object with
+  /// reference semantics.
+  EntryRef minimizeIfNecessary(const CachedFileSystemEntry &Entry,
+                               StringRef Filename, bool Disable);
+
+  /// Represents a filesystem entry that has been stat-ed (and potentially read)
+  /// and that's about to be inserted into the cache as `CachedFileSystemEntry`.
+  struct TentativeEntry {
     llvm::vfs::Status Status;
-    Optional<llvm::cas::CASID> ID;
+    std::unique_ptr<llvm::MemoryBuffer> Contents;
+
+    TentativeEntry(llvm::vfs::Status Status,
+                   std::unique_ptr<llvm::MemoryBuffer> Contents = nullptr)
+        : Status(std::move(Status)), Contents(std::move(Contents)) {}
   };
-  llvm::BumpPtrAllocator EntryAlloc;
-  llvm::StringMap<FileEntry, llvm::BumpPtrAllocator> Entries;
 
-  struct LookupPathResult {
-    const FileEntry *Entry = nullptr;
+  /// Reads file at the given path. Enforces consistency between the file size
+  /// in status and size of read contents.
+  llvm::ErrorOr<TentativeEntry> readFile(StringRef Filename);
 
-    // Only filled if the Entry is nullptr.
-    llvm::ErrorOr<llvm::vfs::Status> Status;
-  };
-  Expected<StringRef>
-  computeMinimized(llvm::cas::CASID InputDataID, StringRef Identifier,
-                   Optional<llvm::cas::CASID> &MinimizedDataID);
+  /// Returns entry associated with the unique ID of the given tentative entry
+  /// if there is some in the shared cache. Otherwise, constructs new one,
+  /// associates it with the unique ID and returns the result.
+  const CachedFileSystemEntry &
+  getOrEmplaceSharedEntryForUID(TentativeEntry TEntry);
 
-  Expected<StringRef> getMinimized(llvm::cas::CASID OutputID,
-                                   StringRef Identifier,
-                                   Optional<llvm::cas::CASID> &MinimizedDataID);
+  /// Returns entry associated with the filename or nullptr if none is found.
+  ///
+  /// Returns entry from local cache if there is some. Otherwise, if the entry
+  /// is found in the shared cache, writes it through the local cache and
+  /// returns it. Otherwise returns nullptr.
+  const CachedFileSystemEntry *
+  findEntryByFilenameWithWriteThrough(StringRef Filename);
 
-  Expected<StringRef> getOriginal(llvm::cas::CASID InputDataID);
+  /// Returns entry associated with the unique ID in the shared cache or nullptr
+  /// if none is found.
+  const CachedFileSystemEntry *
+  findSharedEntryByUID(llvm::vfs::Status Stat) const {
+    return SharedCache.getShardForUID(Stat.getUniqueID())
+        .findEntryByUID(Stat.getUniqueID());
+  }
 
-  LookupPathResult lookupPath(const Twine &Path);
+  /// Associates the given entry with the filename in the local cache and
+  /// returns it.
+  const CachedFileSystemEntry &
+  insertLocalEntryForFilename(StringRef Filename,
+                              const CachedFileSystemEntry &Entry) {
+    return LocalCache.insertEntryForFilename(Filename, Entry);
+  }
 
-  llvm::cas::CachingOnDiskFileSystem &getCachingFS();
+  /// Returns entry associated with the filename in the shared cache if there is
+  /// some. Otherwise, constructs new one with the given error code, associates
+  /// it with the filename and returns the result.
+  const CachedFileSystemEntry &
+  getOrEmplaceSharedEntryForFilename(StringRef Filename, std::error_code EC) {
+    return SharedCache.getShardForFilename(Filename)
+        .getOrEmplaceEntryForFilename(Filename, EC);
+  }
 
-  llvm::cas::CASDB &CAS;
-  Optional<llvm::cas::CASID> ClangFullVersionID;
-  Optional<llvm::cas::CASID> MinimizeID;
-  Optional<llvm::cas::CASID> EmptyBlobID;
+  /// Returns entry associated with the filename in the shared cache if there is
+  /// some. Otherwise, associates the given entry with the filename and returns
+  /// it.
+  const CachedFileSystemEntry &
+  getOrInsertSharedEntryForFilename(StringRef Filename,
+                                    const CachedFileSystemEntry &Entry) {
+    return SharedCache.getShardForFilename(Filename)
+        .getOrInsertEntryForFilename(Filename, Entry);
+  }
 
+  /// The global cache shared between worker threads.
+  DependencyScanningFilesystemSharedCache &SharedCache;
+  /// The local cache is used by the worker thread to cache file system queries
+  /// locally instead of querying the global cache every time.
+  DependencyScanningFilesystemLocalCache LocalCache;
   /// The optional mapping structure which records information about the
   /// excluded conditional directive skip mappings that are used by the
   /// currently active preprocessor.
   ExcludedPreprocessorDirectiveSkipMapping *PPSkipMappings;
   /// The set of files that should not be minimized.
-  llvm::StringSet<> NotToBeMinimized;
+  llvm::DenseSet<llvm::sys::fs::UniqueID> NotToBeMinimized;
 };
 
 } // end namespace dependencies

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CLANG_TOOLING_DEPENDENCYSCANNING_DEPENDENCYSCANNINGSERVICE_H
 #define LLVM_CLANG_TOOLING_DEPENDENCYSCANNING_DEPENDENCYSCANNINGSERVICE_H
 
+#include "clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningFilesystem.h"
 
 namespace clang {
@@ -67,9 +68,15 @@ public:
 
   bool canOptimizeArgs() const { return OptimizeArgs; }
 
+  DependencyScanningFilesystemSharedCache &getSharedCache() {
+    return SharedCache;
+  }
+
   bool overrideCASTokenCache() const { return OverrideCASTokenCache; }
 
   llvm::cas::CachingOnDiskFileSystem &getSharedFS() { return *SharedFS; }
+
+  bool useCASScanning() const { return (bool)SharedFS; }
 
 private:
   const ScanningMode Mode;
@@ -83,7 +90,11 @@ private:
   const bool OptimizeArgs;
   /// CAS options.
   const bool OverrideCASTokenCache;
+  /// Shared CachingOnDiskFileSystem. Set to nullptr to not use CAS dependency
+  /// scanning.
   IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> SharedFS;
+  /// The global file system cache.
+  DependencyScanningFilesystemSharedCache SharedCache;
 };
 
 } // end namespace dependencies

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
@@ -69,7 +69,9 @@ public:
   bool canOptimizeArgs() const { return OptimizeArgs; }
 
   DependencyScanningFilesystemSharedCache &getSharedCache() {
-    return SharedCache;
+    assert(!SharedFS && "Expected not to have a CASFS");
+    assert(SharedCache && "Expected a shared cache");
+    return *SharedCache;
   }
 
   bool overrideCASTokenCache() const { return OverrideCASTokenCache; }
@@ -94,7 +96,7 @@ private:
   /// scanning.
   IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> SharedFS;
   /// The global file system cache.
-  DependencyScanningFilesystemSharedCache SharedCache;
+  Optional<DependencyScanningFilesystemSharedCache> SharedCache;
 };
 
 } // end namespace dependencies

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -82,7 +82,8 @@ public:
                                              StringRef WorkingDirectory,
                                              DependencyConsumer &DepsConsumer);
 
-  llvm::cas::CachingOnDiskFileSystem &getRealFS() { return *CacheFS; }
+  llvm::vfs::FileSystem &getRealFS() { return *RealFS; }
+  llvm::cas::CachingOnDiskFileSystem &getCASFS() { return *CacheFS; }
 
 private:
   std::shared_ptr<PCHContainerOperations> PCHContainerOps;

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -98,6 +98,8 @@ private:
   /// dependencies. This filesystem persists across multiple compiler
   /// invocations.
   llvm::IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS;
+  /// The CAS Dependency Filesytem. This is not set at the sametime as DepFS;
+  llvm::IntrusiveRefCntPtr<DependencyScanningCASFilesystem> DepCASFS;
   /// The file manager that is reused across multiple invocations by this
   /// worker. If null, the file manager will not be reused.
   llvm::IntrusiveRefCntPtr<FileManager> Files;

--- a/clang/lib/Tooling/DependencyScanning/CMakeLists.txt
+++ b/clang/lib/Tooling/DependencyScanning/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_clang_library(clangDependencyScanning
+  DependencyScanningCASFilesystem.cpp
   DependencyScanningFilesystem.cpp
   DependencyScanningService.cpp
   DependencyScanningWorker.cpp

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
@@ -1,0 +1,377 @@
+//===- DependencyScanningCASFilesystem.cpp - clang-scan-deps fs -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h"
+#include "clang/Basic/Version.h"
+#include "clang/Lex/DependencyDirectivesSourceMinimizer.h"
+#include "llvm/CAS/CASDB.h"
+#include "llvm/CAS/CachingOnDiskFileSystem.h"
+#include "llvm/CAS/HierarchicalTreeBuilder.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Threading.h"
+
+using namespace clang;
+using namespace tooling;
+using namespace dependencies;
+
+template <typename T>
+static T reportAsFatalIfError(Expected<T> ValOrErr) {
+  if (!ValOrErr)
+    llvm::report_fatal_error(ValOrErr.takeError());
+  return std::move(*ValOrErr);
+}
+
+static void reportAsFatalIfError(llvm::Error E) {
+  if (E)
+    llvm::report_fatal_error(std::move(E));
+}
+
+using llvm::Error;
+namespace cas = llvm::cas;
+
+DependencyScanningCASFilesystem::DependencyScanningCASFilesystem(
+    DependencyScanningFilesystemSharedCache &SharedCache,
+    IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> WorkerFS,
+    ExcludedPreprocessorDirectiveSkipMapping *PPSkipMappings)
+    : DependencyScanningWorkerFilesystem(SharedCache, WorkerFS, PPSkipMappings),
+      FS(WorkerFS), Entries(EntryAlloc), CAS(WorkerFS->getCAS()) {}
+
+DependencyScanningCASFilesystem::~DependencyScanningCASFilesystem() =
+    default;
+
+static void addSkippedRange(llvm::DenseMap<unsigned, unsigned> &Skip,
+                            unsigned Offset, unsigned Length) {
+  // Ignore small ranges as non-profitable.
+  //
+  // FIXME: This is a heuristic, its worth investigating the tradeoffs
+  // when it should be applied.
+  if (Length >= 16)
+    Skip[Offset] = Length;
+}
+
+static Error cacheMinimized(cas::CASID InputID, cas::CASDB &CAS,
+                            cas::CASID OutputDataID,
+                            cas::CASID SkippedRangesID) {
+  cas::HierarchicalTreeBuilder Builder;
+  Builder.push(OutputDataID, cas::TreeEntry::Regular, "data");
+  Builder.push(SkippedRangesID, cas::TreeEntry::Regular, "skipped-ranges");
+  Expected<cas::CASID> OutputID = Builder.create(CAS);
+  if (!OutputID)
+    return OutputID.takeError();
+  return CAS.putCachedResult(InputID, *OutputID);
+}
+
+Expected<StringRef> DependencyScanningCASFilesystem::getMinimized(
+    cas::CASID OutputID, StringRef Identifier,
+    Optional<cas::CASID> &MinimizedDataID) {
+  // Extract the blob IDs from the tree.
+  Expected<cas::TreeRef> Tree = CAS.getTree(OutputID);
+  if (!Tree)
+    return Tree.takeError();
+  auto unwrapID =
+      [](Optional<cas::NamedTreeEntry> Entry) -> Optional<cas::CASID> {
+    if (Entry)
+      return Entry->getID();
+    return None;
+  };
+  Optional<cas::CASID> SkippedRangesID =
+      unwrapID(Tree->lookup("skipped-ranges"));
+  MinimizedDataID = unwrapID(Tree->lookup("data"));
+
+  if (!MinimizedDataID)
+    return createStringError(std::make_error_code(std::errc::invalid_argument),
+                             Twine("missing 'data' in result of minimizing '") +
+                                 Identifier + "'");
+  if (!SkippedRangesID)
+    return createStringError(
+        std::make_error_code(std::errc::invalid_argument),
+        Twine("missing 'skipped-ranges' in result of minimizing '") +
+            Identifier + "'");
+
+  StringRef OutputData = **expectedToOptional(CAS.getBlob(*MinimizedDataID));
+
+  if (!PPSkipMappings)
+    return OutputData;
+
+  // Parse the skipped ranges.
+  StringRef Ranges = **expectedToOptional(CAS.getBlob(*SkippedRangesID));
+  if (Ranges.empty())
+    return OutputData;
+
+  PreprocessorSkippedRangeMapping Skip;
+  while (!Ranges.empty()) {
+    unsigned Offset, Length;
+    if (Ranges.consumeInteger(10, Offset) || !Ranges.consume_front(" ") ||
+        Ranges.consumeInteger(10, Length) || !Ranges.consume_front("\n"))
+      return createStringError(
+          std::make_error_code(std::errc::invalid_argument),
+          "invalid skipped ranges '" + Identifier + "'");
+    addSkippedRange(Skip, Offset, Length);
+  }
+  (*PPSkipMappings)[OutputData.begin()] = std::move(Skip);
+  return OutputData;
+}
+
+Expected<StringRef> DependencyScanningCASFilesystem::computeMinimized(
+    cas::CASID InputDataID, StringRef Identifier,
+    Optional<llvm::cas::CASID> &MinimizedDataID) {
+  using namespace llvm;
+  using namespace llvm::cas;
+
+  // Get a blob for the clang version string.
+  if (!ClangFullVersionID)
+    ClangFullVersionID =
+        reportAsFatalIfError(CAS.createBlob(getClangFullVersion()));
+
+  // Get a blob for the minimize command.
+  if (!MinimizeID)
+    MinimizeID = reportAsFatalIfError(CAS.createBlob("minimize"));
+
+  // Get an empty blob.
+  if (!EmptyBlobID)
+    EmptyBlobID = reportAsFatalIfError(CAS.createBlob(""));
+
+  // Construct a tree for the input.
+  Optional<CASID> InputID;
+  {
+    HierarchicalTreeBuilder Builder;
+    Builder.push(*ClangFullVersionID, TreeEntry::Regular, "version");
+    Builder.push(*MinimizeID, TreeEntry::Regular, "command");
+    Builder.push(InputDataID, TreeEntry::Regular, "data");
+    InputID = reportAsFatalIfError(Builder.create(CAS));
+  }
+
+  // Check the result cache.
+  if (Optional<CASID> OutputID =
+          expectedToOptional(CAS.getCachedResult(*InputID))) {
+    auto Ex = getMinimized(*OutputID, Identifier, MinimizedDataID);
+    return reportAsFatalIfError(std::move(Ex));
+  }
+
+  StringRef InputData = *reportAsFatalIfError(CAS.getBlob(InputDataID));
+
+  // Try to minimize.
+  llvm::SmallString<1024> Buffer;
+  SmallVector<minimize_source_to_dependency_directives::Token, 64> Tokens;
+  if (minimizeSourceToDependencyDirectives(InputData, Buffer, Tokens)) {
+    // Failure. Cache a self-mapping and return the input data unmodified.
+    reportAsFatalIfError(cacheMinimized(*InputID, CAS, InputDataID, *EmptyBlobID));
+    return InputData;
+  }
+
+  // Success. Add to the CAS and get back persistent output data.
+  BlobRef Minimized = reportAsFatalIfError(CAS.createBlob(Buffer));
+  MinimizedDataID = Minimized;
+  StringRef OutputData = *Minimized;
+
+  // Compute skipped ranges.
+  llvm::SmallVector<minimize_source_to_dependency_directives::SkippedRange, 32>
+      SkippedRanges;
+  minimize_source_to_dependency_directives::computeSkippedRanges(Tokens,
+                                                                 SkippedRanges);
+  Optional<DenseMap<unsigned, unsigned>> SkipMappingsResults;
+  Buffer.clear();
+  if (!SkippedRanges.empty()) {
+    if (PPSkipMappings)
+      SkipMappingsResults.emplace();
+
+    raw_svector_ostream OS(Buffer);
+    for (const auto &Range : SkippedRanges) {
+      OS << Range.Offset << " " << Range.Length << "\n";
+      if (SkipMappingsResults)
+        addSkippedRange(*SkipMappingsResults, Range.Offset, Range.Length);
+    }
+  }
+
+  // Cache the computation.
+  CASID SkippedRangesID = reportAsFatalIfError(CAS.createBlob(Buffer));
+  reportAsFatalIfError(cacheMinimized(*InputID, CAS, *MinimizedDataID, SkippedRangesID));
+
+  if (SkipMappingsResults)
+    (*PPSkipMappings)[OutputData.begin()] = std::move(SkipMappingsResults);
+  return OutputData;
+}
+
+Expected<StringRef>
+DependencyScanningCASFilesystem::getOriginal(cas::CASID InputDataID) {
+  Expected<cas::BlobRef> Blob = CAS.getBlob(InputDataID);
+  if (Blob)
+    return Blob->getData();
+  return Blob.takeError();
+}
+
+/// Whitelist file extensions that should be minimized, treating no extension as
+/// a source file that should be minimized.
+///
+/// This is kinda hacky, it would be better if we knew what kind of file Clang
+/// was expecting instead.
+static bool shouldMinimizeBasedOnExtension(StringRef Filename) {
+  StringRef Ext = llvm::sys::path::extension(Filename);
+  if (Ext.empty())
+    return true; // C++ standard library
+  return llvm::StringSwitch<bool>(Ext)
+    .CasesLower(".c", ".cc", ".cpp", ".c++", ".cxx", true)
+    .CasesLower(".h", ".hh", ".hpp", ".h++", ".hxx", true)
+    .CasesLower(".m", ".mm", true)
+    .CasesLower(".i", ".ii", ".mi", ".mmi", true)
+    .CasesLower(".def", ".inc", true)
+    .Default(false);
+}
+
+static bool shouldCacheStatFailures(StringRef Filename) {
+  StringRef Ext = llvm::sys::path::extension(Filename);
+  if (Ext.empty())
+    return false; // This may be the module cache directory.
+  return shouldMinimizeBasedOnExtension(
+      Filename); // Only cache stat failures on source files.
+}
+
+void DependencyScanningCASFilesystem::disableMinimization(
+    StringRef RawFilename) {
+  llvm::SmallString<256> Filename;
+  llvm::sys::path::native(RawFilename, Filename);
+  NotToBeMinimized.insert(Filename);
+}
+
+bool DependencyScanningCASFilesystem::shouldMinimize(StringRef RawFilename) {
+  if (!shouldMinimizeBasedOnExtension(RawFilename))
+    return false;
+
+  llvm::SmallString<256> Filename;
+  llvm::sys::path::native(RawFilename, Filename);
+  return !NotToBeMinimized.contains(Filename);
+}
+
+cas::CachingOnDiskFileSystem &
+DependencyScanningCASFilesystem::getCachingFS() {
+  return static_cast<cas::CachingOnDiskFileSystem &>(*FS);
+}
+
+DependencyScanningCASFilesystem::LookupPathResult
+DependencyScanningCASFilesystem::lookupPath(const Twine &Path) {
+  SmallString<256> PathStorage;
+  StringRef PathRef = Path.toStringRef(PathStorage);
+
+  {
+    auto I = Entries.find(PathRef);
+    if (I != Entries.end()) {
+      // FIXME: Gross hack to ensure this file gets tracked as part of the
+      // compilation. Instead, we should add an explicit hook somehow /
+      // somewhere.
+      (void)getCachingFS().status(PathRef);
+      return LookupPathResult{&I->second, std::error_code()};
+    }
+  }
+
+  Optional<cas::CASID> FileID;
+  llvm::ErrorOr<llvm::vfs::Status> MaybeStatus =
+      getCachingFS().statusAndFileID(PathRef, FileID);
+  if (!MaybeStatus) {
+    if (shouldCacheStatFailures(PathRef))
+      Entries[PathRef].EC = MaybeStatus.getError();
+    return LookupPathResult{nullptr, MaybeStatus.getError()};
+  }
+
+  // Underlying file system caches directories. No need to duplicate.
+  if (MaybeStatus->isDirectory())
+    return LookupPathResult{nullptr, std::move(MaybeStatus)};
+
+  llvm::ErrorOr<StringRef> Buffer = std::error_code();
+  llvm::Optional<llvm::cas::CASID> EffectiveID;
+  if (shouldMinimize(PathRef)) {
+    Buffer = expectedToErrorOr(computeMinimized(*FileID, PathRef, EffectiveID));
+  } else {
+    Buffer = expectedToErrorOr(getOriginal(*FileID));
+    EffectiveID = *FileID;
+  }
+
+  auto &Entry = Entries[PathRef];
+  if (!Buffer) {
+    // Cache CAS failures. Not going to recover later.
+    Entry.EC = Buffer.getError();
+    return LookupPathResult{&Entry, std::error_code()};
+  }
+  assert(EffectiveID);
+
+  Entry.Buffer = std::move(*Buffer);
+  Entry.Status = llvm::vfs::Status(
+      PathRef, MaybeStatus->getUniqueID(),
+      MaybeStatus->getLastModificationTime(), MaybeStatus->getUser(),
+      MaybeStatus->getGroup(), Entry.Buffer->size(), MaybeStatus->getType(),
+      MaybeStatus->getPermissions());
+  Entry.ID = EffectiveID;
+  return LookupPathResult{&Entry, std::error_code()};
+}
+
+llvm::ErrorOr<llvm::vfs::Status>
+DependencyScanningCASFilesystem::status(const Twine &Path) {
+  LookupPathResult Result = lookupPath(Path);
+  if (!Result.Entry)
+    return std::move(Result.Status);
+  if (Result.Entry->EC)
+    return Result.Entry->EC;
+  return Result.Entry->Status;
+}
+
+Optional<llvm::cas::CASID>
+DependencyScanningCASFilesystem::getFileCASID(const Twine &Path) {
+  LookupPathResult Result = lookupPath(Path);
+  if (!Result.Entry)
+    return None;
+  if (Result.Entry->EC)
+    return None;
+  assert(Result.Entry->ID);
+  return Result.Entry->ID;
+}
+
+IntrusiveRefCntPtr<llvm::cas::ThreadSafeFileSystem>
+DependencyScanningCASFilesystem::createThreadSafeProxyFS() {
+  llvm::report_fatal_error("not implemented");
+}
+
+namespace {
+
+class MinimizedVFSFile final : public llvm::vfs::File {
+public:
+  MinimizedVFSFile(StringRef Buffer, llvm::vfs::Status Stat)
+      : Buffer(Buffer), Stat(std::move(Stat)) {}
+
+  llvm::ErrorOr<llvm::vfs::Status> status() override { return Stat; }
+
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+  getBuffer(const Twine &Name, int64_t FileSize, bool RequiresNullTerminator,
+            bool IsVolatile) override {
+    SmallString<256> Storage;
+    return llvm::MemoryBuffer::getMemBuffer(Buffer, Name.toStringRef(Storage));
+  }
+
+  std::error_code close() override { return {}; }
+
+private:
+  StringRef Buffer;
+  llvm::vfs::Status Stat;
+};
+
+} // end anonymous namespace
+
+llvm::ErrorOr<std::unique_ptr<llvm::vfs::File>>
+DependencyScanningCASFilesystem::openFileForRead(const Twine &Path) {
+  LookupPathResult Result = lookupPath(Path);
+  if (!Result.Entry) {
+    if (std::error_code EC = Result.Status.getError())
+      return EC;
+    assert(Result.Status->getType() ==
+           llvm::sys::fs::file_type::directory_file);
+    return std::make_error_code(std::errc::is_a_directory);
+  }
+  if (Result.Entry->EC)
+    return Result.Entry->EC;
+
+  return std::make_unique<MinimizedVFSFile>(*Result.Entry->Buffer,
+                                            Result.Entry->Status);
+}

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
@@ -24,10 +24,6 @@ DependencyScanningService::DependencyScanningService(
       SkipExcludedPPRanges(SkipExcludedPPRanges), OptimizeArgs(OptimizeArgs),
       OverrideCASTokenCache(OverrideCASTokenCache),
       SharedFS(std::move(SharedFS)) {
-  if (!this->SharedFS)
-    this->SharedFS = llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(
-        llvm::cas::createInMemoryCAS()));
-
   // Initialize targets for object file support.
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
@@ -24,6 +24,9 @@ DependencyScanningService::DependencyScanningService(
       SkipExcludedPPRanges(SkipExcludedPPRanges), OptimizeArgs(OptimizeArgs),
       OverrideCASTokenCache(OverrideCASTokenCache),
       SharedFS(std::move(SharedFS)) {
+  if (!this->SharedFS)
+    SharedCache.emplace();
+
   // Initialize targets for object file support.
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -156,7 +156,7 @@ private:
 
 llvm::Expected<llvm::cas::TreeRef> DependencyScanningTool::getDependencyTree(
     const std::vector<std::string> &CommandLine, StringRef CWD) {
-  llvm::cas::CachingOnDiskFileSystem &FS = Worker.getRealFS();
+  llvm::cas::CachingOnDiskFileSystem &FS = Worker.getCASFS();
   FS.trackNewAccesses();
   MakeDependencyTree Consumer(FS);
   auto Result = Worker.computeDependencies(CWD, CommandLine, Consumer);
@@ -181,7 +181,7 @@ DependencyScanningTool::getDependencyTreeFromCompilerInvocation(
     DiagnosticConsumer &DiagsConsumer,
     llvm::function_ref<StringRef(const llvm::vfs::CachedDirectoryEntry &)>
         RemapPath) {
-  llvm::cas::CachingOnDiskFileSystem &FS = Worker.getRealFS();
+  llvm::cas::CachingOnDiskFileSystem &FS = Worker.getCASFS();
   FS.trackNewAccesses();
   FS.setCurrentWorkingDirectory(CWD);
   MakeDependencyTree DepsConsumer(FS);
@@ -196,7 +196,7 @@ DependencyScanningTool::getDependencyTreeFromCompilerInvocation(
 llvm::Expected<llvm::cas::TreeRef>
 DependencyScanningTool::getDependencyTreeFromCC1CommandLine(
     ArrayRef<const char *> Args, StringRef CWD) {
-  llvm::cas::CachingOnDiskFileSystem &FS = Worker.getRealFS();
+  llvm::cas::CachingOnDiskFileSystem &FS = Worker.getCASFS();
   FS.trackNewAccesses();
   MakeDependencyTree DepsConsumer(FS);
   Worker.computeDependenciesFromCC1CommandLine(Args, CWD, DepsConsumer);

--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -79,7 +79,7 @@ list(APPEND CLANG_TEST_DEPS
   diagtool
   hmaptool
   )
-  
+
 if(CLANG_ENABLE_STATIC_ANALYZER)
   list(APPEND CLANG_TEST_DEPS
     clang-check
@@ -116,6 +116,7 @@ if( NOT CLANG_BUILT_STANDALONE )
     llvm-ar
     llvm-as
     llvm-bcanalyzer
+    llvm-cas
     llvm-cat
     llvm-cxxfilt
     llvm-dis

--- a/clang/test/ClangScanDeps/header-search-pruning.cpp
+++ b/clang/test/ClangScanDeps/header-search-pruning.cpp
@@ -1,4 +1,3 @@
-// UNSUPPORTED: cas
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: cp -r %S/Inputs/header-search-pruning/* %t
 // RUN: cp %S/header-search-pruning.cpp %t/header-search-pruning.cpp

--- a/clang/test/ClangScanDeps/modules-cas.cpp
+++ b/clang/test/ClangScanDeps/modules-cas.cpp
@@ -1,0 +1,55 @@
+// RUN: rm -rf %t.dir
+// RUN: rm -rf %t.cdb
+// RUN: rm -rf %t_clangcl.cdb
+// RUN: rm -rf %t.module-cache
+// RUN: rm -rf %t.module-cache_clangcl
+// RUN: mkdir -p %t.dir
+// RUN: cp %s %t.dir/modules_cdb_input.cpp
+// RUN: cp %s %t.dir/modules_cdb_input2.cpp
+// RUN: mkdir %t.dir/Inputs
+// RUN: cp %S/Inputs/header.h %t.dir/Inputs/header.h
+// RUN: cp %S/Inputs/header2.h %t.dir/Inputs/header2.h
+// RUN: cp %S/Inputs/module.modulemap %t.dir/Inputs/module.modulemap
+// RUN: sed -e "s|DIR|%/t.dir|g" %S/Inputs/modules_cdb.json > %t.cdb
+// RUN: sed -e "s|DIR|%/t.dir|g" %S/Inputs/modules_cdb_clangcl.json > %t_clangcl.cdb
+//
+// RUN: clang-scan-deps -cas -compilation-database %t.cdb -j 1 -mode preprocess-minimized-sources | \
+// RUN:   FileCheck --check-prefixes=CHECK1,CHECK2,CHECK2NO %s
+// RUN: clang-scan-deps -cas -compilation-database %t_clangcl.cdb -j 1 -mode preprocess-minimized-sources | \
+// RUN:   FileCheck --check-prefixes=CHECK1,CHECK2,CHECK2NO %s
+//
+// The output order is non-deterministic when using more than one thread,
+// so check the output using two runs. Note that the 'NOT' check is not used
+// as it might fail if the results for `modules_cdb_input.cpp` are reported before
+// `modules_cdb_input2.cpp`.
+//
+// RUN: clang-scan-deps -cas -compilation-database %t.cdb -j 2 -mode preprocess-minimized-sources | \
+// RUN:   FileCheck --check-prefix=CHECK1 %s
+// RUN: clang-scan-deps -cas -compilation-database %t_clangcl.cdb -j 2 -mode preprocess-minimized-sources | \
+// RUN:   FileCheck --check-prefix=CHECK1 %s
+// RUN: clang-scan-deps -cas -compilation-database %t.cdb -j 2 -mode preprocess | \
+// RUN:   FileCheck --check-prefix=CHECK1 %s
+// RUN: clang-scan-deps -cas -compilation-database %t_clangcl.cdb -j 2 -mode preprocess | \
+// RUN:   FileCheck --check-prefix=CHECK1 %s
+// RUN: clang-scan-deps -cas -compilation-database %t.cdb -j 2 -mode preprocess-minimized-sources | \
+// RUN:   FileCheck --check-prefix=CHECK2 %s
+// RUN: clang-scan-deps -cas -compilation-database %t_clangcl.cdb -j 2 -mode preprocess-minimized-sources | \
+// RUN:   FileCheck --check-prefix=CHECK2 %s
+// RUN: clang-scan-deps -cas -compilation-database %t.cdb -j 2 -mode preprocess | \
+// RUN:   FileCheck --check-prefix=CHECK2 %s
+// RUN: clang-scan-deps -cas -compilation-database %t_clangcl.cdb -j 2 -mode preprocess | \
+// RUN:   FileCheck --check-prefix=CHECK2 %s
+
+#include "header.h"
+
+// CHECK1: modules_cdb_input2.o:
+// CHECK1-NEXT: modules_cdb_input2.cpp
+// CHECK1-NEXT: Inputs{{/|\\}}module.modulemap
+// CHECK1-NEXT: Inputs{{/|\\}}header2.h
+// CHECK1: Inputs{{/|\\}}header.h
+
+// CHECK2: {{(modules_cdb_input)|(a)|(b)}}.o:
+// CHECK2-NEXT: modules_cdb_input.cpp
+// CHECK2-NEXT: Inputs{{/|\\}}module.modulemap
+// CHECK2-NEXT: Inputs{{/|\\}}header.h
+// CHECK2NO-NOT: header2

--- a/clang/test/ClangScanDeps/modules-full-by-mod-name.cpp
+++ b/clang/test/ClangScanDeps/modules-full-by-mod-name.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: powerpc64-ibm-aix, cas
+// UNSUPPORTED: powerpc64-ibm-aix
 // RUN: rm -rf %t.dir
 // RUN: rm -rf %t.cdb
 // RUN: mkdir -p %t.dir

--- a/clang/test/ClangScanDeps/modules-full.cpp
+++ b/clang/test/ClangScanDeps/modules-full.cpp
@@ -1,4 +1,3 @@
-// UNSUPPORTED: cas
 // RUN: rm -rf %t.dir
 // RUN: rm -rf %t.cdb
 // RUN: mkdir -p %t.dir

--- a/clang/test/ClangScanDeps/modules-symlink.c
+++ b/clang/test/ClangScanDeps/modules-symlink.c
@@ -2,7 +2,7 @@
 // RUN: split-file %s %t
 // Unsupported on AIX because we don't support the requisite "__clangast"
 // section in XCOFF yet.
-// UNSUPPORTED: system-windows, aix, cas
+// UNSUPPORTED: system-windows, aix
 
 //--- cdb_pch.json
 [


### PR DESCRIPTION
Restore the upstream depscan implementation.

The goal is to minimize the upstream difference so the current interface is not optimal.