### PR TITLE
Remove eager propagation of SwiftASTContext warnings to Target.

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1458,16 +1458,7 @@ public:
     return m_use_scratch_typesystem_per_module;
   }
 
-private:
-  std::mutex m_swift_messages_mutex;
-  std::unordered_set<std::string> m_swift_messages_issued;
-
 public:
-  /// Register that a message (uniquely identified by \p Key) about a Swift
-  /// context is about to be displayed to the user. Returns true iff the message
-  /// has not already been displayed.
-  bool RegisterSwiftContextMessageKey(std::string Key);
-
   StackFrameRecognizerManager &GetFrameRecognizerManager() {
     return *m_frame_recognizer_manager_up;
   }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1947,7 +1947,7 @@ static SwiftASTContext *GetModuleSwiftASTContext(Module &module) {
 /// its module SwiftASTContext to Target.
 static void
 ProcessModule(ModuleSP module_sp, std::string m_description,
-              bool use_all_compiler_flags, Target &target,
+              bool use_all_compiler_flags, Target &target, llvm::Triple triple,
               std::vector<std::string> &module_search_paths,
               std::vector<std::pair<std::string, bool>> &framework_search_paths,
               std::vector<std::string> &extra_clang_args) {
@@ -2023,37 +2023,6 @@ ProcessModule(ModuleSP module_sp, std::string m_description,
   if (!HasSwiftModules(*module_sp))
     return;
 
-  SwiftASTContext *ast_context = GetModuleSwiftASTContext(*module_sp);
-  if (!ast_context || ast_context->HasFatalErrors() ||
-      !ast_context->GetClangImporter()) {
-    // Make sure we warn about this module load failure, the one
-    // that comes from loading types often gets swallowed up and not
-    // seen, this is the only reliable point where we can show this.
-    // But only do it once per UUID so we don't overwhelm the user
-    // with warnings.
-    UUID module_uuid(module_sp->GetUUID());
-    bool unique_message =
-        target.RegisterSwiftContextMessageKey(module_uuid.GetAsString());
-    if (!unique_message)
-      return;
-    std::string buf;
-    {
-      llvm::raw_string_ostream ss(buf);
-      module_sp->GetDescription(ss, eDescriptionLevelBrief);
-      if (ast_context && ast_context->HasFatalErrors())
-        ss << ": " << ast_context->GetFatalErrors().AsCString("unknown error");
-    }
-    target.GetDebugger().GetErrorStreamSP()->Printf(
-        "Error while loading Swift module:\n%s\n"
-        "Debug info from this module will be unavailable in the "
-        "debugger.\n\n",
-        buf.c_str());
-    return;
-  }
-
-  if (ast_context->HasErrors())
-    return;
-
   // Load search path options from the module.
   if (!use_all_compiler_flags &&
       target.GetExecutableModulePointer() != module_sp.get())
@@ -2069,7 +2038,6 @@ ProcessModule(ModuleSP module_sp, std::string m_description,
   //        older versions of the same .swiftinterface.
   if (auto dsym = GetDSYMBundle(*module_sp)) {
     llvm::SmallString<256> path(*dsym);
-    llvm::Triple triple(ast_context->GetTriple());
     StringRef arch = llvm::Triple::getArchTypeName(triple.getArch());
     llvm::sys::path::append(path, "Contents", "Resources", "Swift", arch);
     bool exists = false;
@@ -2281,11 +2249,10 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
   const bool use_all_compiler_flags =
       !got_serialized_options || target.GetUseAllCompilerFlags();
 
-  warmup_astcontexts();
   for (size_t mi = 0; mi != num_images; ++mi) {
     std::vector<std::string> extra_clang_args;
     ProcessModule(target.GetImages().GetModuleAtIndex(mi), m_description,
-                  use_all_compiler_flags, target, module_search_paths,
+                  use_all_compiler_flags, target, triple, module_search_paths,
                   framework_search_paths, extra_clang_args);
     swift_ast_sp->AddExtraClangArgs(extra_clang_args);
   }
@@ -5103,7 +5070,7 @@ void SwiftASTContextForExpressions::ModulesDidLoad(ModuleList &module_list) {
     std::vector<std::string> extra_clang_args;
     lldb::ModuleSP module_sp = module_list.GetModuleAtIndex(mi);
     ProcessModule(module_sp, m_description, use_all_compiler_flags, *target_sp,
-                  module_search_paths, framework_search_paths,
+                  GetTriple(), module_search_paths, framework_search_paths,
                   extra_clang_args);
     // If the use-all-compiler-flags setting is enabled, the expression
     // context is supposed to merge all search paths from all dylibs.

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4875,10 +4875,5 @@ std::recursive_mutex &Target::GetAPIMutex() {
     return m_mutex;
 }
 
-bool Target::RegisterSwiftContextMessageKey(std::string Key) {
-  std::unique_lock<std::mutex> guard{m_swift_messages_mutex};
-  return m_swift_messages_issued.insert(std::move(Key)).second;
-}
-
 /// Get metrics associated with this target in JSON format.
 llvm::json::Value Target::ReportStatistics() { return m_stats.ToJSON(*this); }


### PR DESCRIPTION
This feature is becoming less useful, as the per-module
SwiftASTContexts are only being used as an emergency backup. The error
messages are also available in the swift-healthcheck, so it's no
longer the right trade-off to eagerly surface them. This is one of two
loops in SwiftASTContext(ForExpression)::CreateInstance() that
force-initializes all module SwiftASTContexts and we would like to get
rid of both.