### PR TITLE
CAS: Split LazyMappedFileRegionBumpPtr out of OnDiskHashMappedTrie

### DIFF
--- a/llvm/include/llvm/CAS/LazyMappedFileRegion.h
+++ b/llvm/include/llvm/CAS/LazyMappedFileRegion.h
@@ -37,10 +37,24 @@ namespace cas {
 /// FIXME: Probably should move to Support.
 class LazyMappedFileRegion {
 public:
+  /// Create a region.
+  ///
+  /// If there could be multiple instances pointing at the same underlying
+  /// file this is not safe. Use \a createShared() instead.
   static Expected<LazyMappedFileRegion>
   create(const Twine &Path, uint64_t Capacity, uint64_t NewFileSize = 1024ULL,
          function_ref<Error(char *)> NewFileConstructor = nullptr,
          uint64_t MaxSizeIncrement = 4ULL * 1024ULL * 1024ULL);
+
+  /// Create a region, shared across the process via a singleton map.
+  ///
+  /// FIXME: Singleton map should be based on sys::fs::UniqueID, but currently
+  /// it is just based on \p Path.
+  static Expected<std::shared_ptr<LazyMappedFileRegion>>
+  createShared(const Twine &Path, uint64_t Capacity,
+               uint64_t NewFileSize = 1024ULL,
+               function_ref<Error(char *)> NewFileConstructor = nullptr,
+               uint64_t MaxSizeIncrement = 4ULL * 1024ULL * 1024ULL);
 
   /// Get the path this was opened with.
   ///

--- a/llvm/include/llvm/CAS/LazyMappedFileRegionBumpPtr.h
+++ b/llvm/include/llvm/CAS/LazyMappedFileRegionBumpPtr.h
@@ -1,0 +1,67 @@
+//===- LazyMappedFileRegionBumpPtr.h ----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CAS_LAZYMAPPEDFILEREGIONBUMPPTR_H
+#define LLVM_CAS_LAZYMAPPEDFILEREGIONBUMPPTR_H
+
+#include "llvm/CAS/LazyMappedFileRegion.h"
+#include "llvm/Support/Alignment.h"
+#include "llvm/Support/FileSystem.h"
+#include <atomic>
+
+namespace llvm {
+
+class MemoryBuffer;
+
+namespace cas {
+
+/// Allocator for a lazy mapped file region.
+class LazyMappedFileRegionBumpPtr {
+public:
+  /// Minimum alignment for allocations.
+  static constexpr Align getAlign() {
+    // Trick Align into giving us '8' as a constexpr.
+    struct alignas(8) T {};
+    static_assert(alignof(T) == 8, "Tautology failed?");
+    return Align::Of<T>();
+  }
+
+  LazyMappedFileRegionBumpPtr() = delete;
+  LazyMappedFileRegionBumpPtr(LazyMappedFileRegion &LMFR, int64_t BumpPtrOffset)
+      : LMFR(LMFR) {
+    initialize(BumpPtrOffset);
+  }
+  LazyMappedFileRegionBumpPtr(std::shared_ptr<LazyMappedFileRegion> LMFR,
+                              int64_t BumpPtrOffset)
+      : LMFR(*LMFR), OwnedLMFR(std::move(LMFR)) {
+    initialize(BumpPtrOffset);
+  }
+
+  /// Allocate at least \p AllocSize. Rounds up to \a getAlignment().
+  char *allocate(uint64_t AllocSize) {
+    return data() + allocateOffset(AllocSize);
+  }
+  /// Allocate, returning the offset from \a data() instead of a pointer.
+  int64_t allocateOffset(uint64_t AllocSize);
+
+  char *data() const { return LMFR.data(); }
+  uint64_t size() const { return *BumpPtr; }
+  uint64_t capacity() const { return LMFR.capacity(); }
+
+private:
+  void initialize(int64_t BumpPtrOffset);
+
+  LazyMappedFileRegion &LMFR;
+  std::shared_ptr<LazyMappedFileRegion> OwnedLMFR;
+  std::atomic<int64_t> *BumpPtr = nullptr;
+};
+
+} // namespace cas
+} // namespace llvm
+
+#endif // LLVM_CAS_LAZYMAPPEDFILEREGIONBUMPPTR_H

--- a/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
+++ b/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
@@ -119,27 +119,24 @@ public:
     return insert(LookupResult(), Hash, Metadata, Data);
   }
 
-  static Expected<std::shared_ptr<OnDiskHashMappedTrie>>
+  static Expected<OnDiskHashMappedTrie>
   create(const Twine &Path, size_t NumHashBits, uint64_t MaxMapSize,
          Optional<size_t> InitialNumRootBits = None,
          Optional<size_t> InitialNumSubtrieBits = None);
 
-  // Move can be implemented if we add support to mapped_file_region. No need
-  // to move the mutexes.
-  OnDiskHashMappedTrie(OnDiskHashMappedTrie &&RHS) = delete;
-  OnDiskHashMappedTrie &operator=(OnDiskHashMappedTrie &&RHS) = delete;
+  OnDiskHashMappedTrie(OnDiskHashMappedTrie &&RHS) = default;
+  OnDiskHashMappedTrie &operator=(OnDiskHashMappedTrie &&RHS) = default;
 
   // No copy. Just call \a create() again.
   OnDiskHashMappedTrie(const OnDiskHashMappedTrie &) = delete;
   OnDiskHashMappedTrie &operator=(const OnDiskHashMappedTrie &) = delete;
 
-  /// Should be private, but std::make_shared needs access.
-  OnDiskHashMappedTrie() = default;
+  ~OnDiskHashMappedTrie();
 
 private:
-  ~OnDiskHashMappedTrie();
-  Optional<LazyMappedFileRegion> Index;
-  Optional<LazyMappedFileRegion> Data;
+  OnDiskHashMappedTrie() = default;
+  std::shared_ptr<LazyMappedFileRegion> Index;
+  std::shared_ptr<LazyMappedFileRegion> Data;
 };
 
 } // namespace cas

--- a/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
+++ b/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
@@ -12,7 +12,6 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/CAS/LazyMappedFileRegion.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/SHA1.h"
@@ -124,8 +123,8 @@ public:
          Optional<size_t> InitialNumRootBits = None,
          Optional<size_t> InitialNumSubtrieBits = None);
 
-  OnDiskHashMappedTrie(OnDiskHashMappedTrie &&RHS) = default;
-  OnDiskHashMappedTrie &operator=(OnDiskHashMappedTrie &&RHS) = default;
+  OnDiskHashMappedTrie(OnDiskHashMappedTrie &&RHS);
+  OnDiskHashMappedTrie &operator=(OnDiskHashMappedTrie &&RHS);
 
   // No copy. Just call \a create() again.
   OnDiskHashMappedTrie(const OnDiskHashMappedTrie &) = delete;
@@ -134,9 +133,9 @@ public:
   ~OnDiskHashMappedTrie();
 
 private:
-  OnDiskHashMappedTrie() = default;
-  std::shared_ptr<LazyMappedFileRegion> Index;
-  std::shared_ptr<LazyMappedFileRegion> Data;
+  struct ImplType;
+  explicit OnDiskHashMappedTrie(std::unique_ptr<ImplType> Impl);
+  std::unique_ptr<ImplType> Impl;
 };
 
 } // namespace cas

--- a/llvm/lib/CAS/CMakeLists.txt
+++ b/llvm/lib/CAS/CMakeLists.txt
@@ -8,6 +8,7 @@ add_llvm_component_library(LLVMCAS
   HashMappedTrie.cpp
   HierarchicalTreeBuilder.cpp
   LazyMappedFileRegion.cpp
+  LazyMappedFileRegionBumpPtr.cpp
   OnDiskHashMappedTrie.cpp
   PluginCAS.cpp
   Utils.cpp

--- a/llvm/lib/CAS/LazyMappedFileRegionBumpPtr.cpp
+++ b/llvm/lib/CAS/LazyMappedFileRegionBumpPtr.cpp
@@ -1,0 +1,39 @@
+//===- LazyMappedFileRegionBumpPtr.cpp ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/ScopeExit.h"
+#include "llvm/CAS/LazyMappedFileRegionBumpPtr.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+
+void LazyMappedFileRegionBumpPtr::initialize(int64_t BumpPtrOffset) {
+  int64_t BumpPtrEndOffset = BumpPtrOffset + sizeof(decltype(*BumpPtr));
+  assert(BumpPtrEndOffset <= int64_t(LMFR.size()) &&
+         "Expected end offset to be pre-allocated");
+  assert(isAligned(Align::Of<decltype(*BumpPtr)>(), BumpPtrOffset) &&
+         "Expected end offset to be aligned");
+  BumpPtr = reinterpret_cast<decltype(BumpPtr)>(data() + BumpPtrOffset);
+
+  int64_t ExistingValue = 0;
+  if (!BumpPtr->compare_exchange_strong(ExistingValue, BumpPtrOffset))
+    assert(ExistingValue >= BumpPtrEndOffset &&
+           "Expected 0, or past the end of the BumpPtr itself");
+}
+
+int64_t LazyMappedFileRegionBumpPtr::allocateOffset(uint64_t AllocSize) {
+  AllocSize = alignTo(AllocSize, getAlign());
+  int64_t OldEnd = BumpPtr->fetch_add(AllocSize);
+  int64_t NewEnd = OldEnd + AllocSize;
+  if (Error E = LMFR.extendSize(OldEnd + AllocSize)) {
+    // Try to return the allocation.
+    (void)BumpPtr->compare_exchange_strong(OldEnd, NewEnd);
+    report_fatal_error(std::move(E));
+  }
+  return OldEnd;
+}


### PR DESCRIPTION
Encapsulate the file allocation strategy being used in
OnDiskHashMappedTrie as LazyMappedFileRegionBumpPtr. This will make it
easier to separate the abstractions for the trie from the arbitrary
metadata/data storage.

Also includes a couple of prep commits.

e8a10885bac570412ff432968d00bdfd08d8194d CAS: Split LazyMappedFileRegionBumpPtr out of OnDiskHashMappedTrie
```
 llvm/include/llvm/CAS/LazyMappedFileRegionBumpPtr.h |  67 +++++++++++++++++++++++++++++
 llvm/lib/CAS/CMakeLists.txt                         |   1 +
 llvm/lib/CAS/LazyMappedFileRegionBumpPtr.cpp        |  39 +++++++++++++++++
 llvm/lib/CAS/OnDiskHashMappedTrie.cpp               | 214 ++++++++++++++++++++++++++++++++++++++++++++++++---------------------------------------------
 4 files changed, 217 insertions(+), 104 deletions(-)
```
9c34bc3f13ba4cae3f9e5ec640c8ed12c2bd051d CAS: Add OnDiskHashMappedTrie::ImplType to hide details
```
 llvm/include/llvm/CAS/OnDiskHashMappedTrie.h | 11 +++++------
 llvm/lib/CAS/OnDiskHashMappedTrie.cpp        | 43 +++++++++++++++++++++++++++++--------------
 2 files changed, 34 insertions(+), 20 deletions(-)
```
ff7f05544e2e6258328e87c6ffd34b44be32d268 CAS: Sink process map into LazyMappedFileRegion::createShared
```
 llvm/include/llvm/CAS/LazyMappedFileRegion.h | 14 ++++++++++++++
 llvm/include/llvm/CAS/OnDiskHashMappedTrie.h | 17 +++++++----------
 llvm/lib/CAS/BuiltinCAS.cpp                  | 43 ++++++++++++++++++++-----------------------
 llvm/lib/CAS/LazyMappedFileRegion.cpp        | 50 ++++++++++++++++++++++++++++++++++++++++++++++++++
 llvm/lib/CAS/OnDiskHashMappedTrie.cpp        | 36 +++++++-----------------------------
 5 files changed, 98 insertions(+), 62 deletions(-)
```