### PR TITLE
[clang] fix out of bounds access in an empty string when lexing a _Pr…

### DIFF
--- a/clang/lib/Lex/Pragma.cpp
+++ b/clang/lib/Lex/Pragma.cpp
@@ -262,7 +262,12 @@ void Preprocessor::Handle_Pragma(Token &Tok) {
   }
 
   SourceLocation RParenLoc = Tok.getLocation();
-  std::string StrVal = getSpelling(StrTok);
+  bool Invalid = false;
+  std::string StrVal = getSpelling(StrTok, &Invalid);
+  if (Invalid) {
+    Diag(PragmaLoc, diag::err__Pragma_malformed);
+    return;
+  }
 
   // The _Pragma is lexically sound.  Destringize according to C11 6.10.9.1:
   // "The string literal is destringized by deleting any encoding prefix,

--- a/clang/test/Preprocessor/pragma-missing-string-token.c
+++ b/clang/test/Preprocessor/pragma-missing-string-token.c
@@ -1,0 +1,27 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -emit-module -x c -fmodules -I %t/Inputs -fmodule-name=aa %t/Inputs/module.modulemap -o %t/aa.pcm
+// RUN: rm %t/Inputs/b.h
+// RUN: not %clang_cc1 -E -fmodules -I %t/Inputs -fmodule-file=%t/aa.pcm %s -o - -fallow-pcm-with-compiler-errors 2>&1 | FileCheck %s
+
+//--- Inputs/module.modulemap
+module aa {
+    header "a.h"
+    header "b.h"
+}
+
+//--- Inputs/a.h
+#define TEST(x) x
+
+//--- Inputs/b.h
+#define SUB "mypragma"
+
+//--- test.c
+#include "a.h"
+
+_Pragma(SUB);
+int a = TEST(SUB);
+
+// CHECK: int a
+// CHECK: 1 error generated


### PR DESCRIPTION
…agma with missing string token

The lexer can attempt to lex a _Pragma and crash with an out of bounds string access when it's
lexing a _Pragma whose string token is an invalid buffer, e.g. when a module header file from which the macro
expansion for that token was deleted from the file system.

Differential Revision: https://reviews.llvm.org/D116052

(cherry picked from commit 979d0ee8ab30a175220af3b39a6df7d56de9d2c8)