### PR TITLE
CAS: Finish refactoring OnDiskHashMappedTrie to use handles

### DIFF
--- a/llvm/include/llvm/CAS/LazyMappedFileRegionBumpPtr.h
+++ b/llvm/include/llvm/CAS/LazyMappedFileRegionBumpPtr.h
@@ -53,6 +53,8 @@ public:
   uint64_t size() const { return *BumpPtr; }
   uint64_t capacity() const { return LMFR.capacity(); }
 
+  LazyMappedFileRegion &getRegion() const { return LMFR; }
+
 private:
   void initialize(int64_t BumpPtrOffset);
 

--- a/llvm/lib/CAS/LazyMappedFileRegionBumpPtr.cpp
+++ b/llvm/lib/CAS/LazyMappedFileRegionBumpPtr.cpp
@@ -21,7 +21,7 @@ void LazyMappedFileRegionBumpPtr::initialize(int64_t BumpPtrOffset) {
   BumpPtr = reinterpret_cast<decltype(BumpPtr)>(data() + BumpPtrOffset);
 
   int64_t ExistingValue = 0;
-  if (!BumpPtr->compare_exchange_strong(ExistingValue, BumpPtrOffset))
+  if (!BumpPtr->compare_exchange_strong(ExistingValue, BumpPtrEndOffset))
     assert(ExistingValue >= BumpPtrEndOffset &&
            "Expected 0, or past the end of the BumpPtr itself");
 }

--- a/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
+++ b/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
@@ -593,7 +593,6 @@ OnDiskHashMappedTrie::lookup(ArrayRef<uint8_t> Hash) const {
 
     // Check for an exact match.
     if (Existing.isData()) {
-      // FIXME: Stop calling Data->getPath() here; pass in parent directory.
       OnDiskData *ExistingData = DataHeader->getData(Existing);
       return ExistingData->getHash() == Hash
                  ? LookupResult(ExistingData->getContent(Impl->DirPath))
@@ -654,7 +653,6 @@ OnDiskHashMappedTrie::insert(LookupResult Hint, ArrayRef<uint8_t> Hash,
                                          Metadata, Content);
       assert(NewData->asData() < int64_t(Impl->Data.Alloc.size()));
 
-      // FIXME: Stop calling Data->getPath() here; pass in parent directory.
       if (S.compare_exchange_strong(Index, Existing, *NewData))
         return DataHeader->getData(*NewData)->getContent(Impl->DirPath);
 
@@ -668,8 +666,6 @@ OnDiskHashMappedTrie::insert(LookupResult Hint, ArrayRef<uint8_t> Hash,
     }
 
     // Check for an exact match.
-    //
-    // FIXME: Stop calling Data->getPath() here; pass in parent directory.
     OnDiskData *ExistingData = DataHeader->getData(Existing);
     if (ExistingData->getHash() == Hash)
       return ExistingData->getContent(Impl->DirPath); // Already there!


### PR DESCRIPTION
CAS: Finish refactoring OnDiskHashMappedTrie to use handles

Clean up the abstractions on the data size the same way as the
index/trie side for OnDiskHashMappedTrie.

This is the last in series of refactorings whose goal was to separate
handles to on-disk objects from their construction and allocation. With
this in place I think we can change the on-disk format.

A top-down view of how things work right now:

- `IndexFile` stores the trie (map from hash to offset) and `DataFile`
  stores the data records (this is what the offset is an offset to).
  Small data is tail allocated with the data record itself. Big data is
  allocated externally in other files.
    - NOTE: This is not the right setup... will change in future.
      Waiting on the refactorings.
- The structs constructed on-disk / in-memory are now all simple
  "headers", all POD, and no mutators/accessors.
    - Many come with tail allocations.
- Each struct has a wrapper "handle" class (e.g., SubtrieHandle wraps
  SubtrieHandle::Header). This has convenient APIs for modifying stuff.
  E.g.:
    - TrieHandle::create() allocates and initializes an on-disk
      trie and returns a TrieHandle to use it. The allocation includes
      TrieHandle::Header and a full SubtrieHandle allocation for the
      root.
    - TrieHandle::TrieHandle() can be used directly to refer to
      an already-constructed trie.
- Allocation is done through an on-disk bump-ptr allocator called
  LazyMappedFileRegionBumpPtr. This manages an on-disk
  `std::atomic<int64_t>` that points at the offset of the next
  allocation. It uses `LazyMappedFileRegion::extendSize()` to request
  space.
- `LazyMappedFileRegion` handles exclusive access to files
  for safely resizing them. It wraps a `sys::fs::mapped_file_region`,
  where `mapped_file_region::size()` is the total memory that has been
  mapped in. This starts out as *much bigger* the the actual file size
  on disk. `extendSize()` resizes the file on disk, allowing the
  pre-existing mapping to work correctly.

None of these refactorings has changed the on-disk representation.

This includes a bunch of prep commits:
- 91ae5b673655d5671128016bdc842055506eeed6 CAS: Finish refactoring OnDiskHashMappedTrie to use handles
- e1e8773aba84919cf25b51ac321d949c95e7c59f CAS: Simplify usage of LazyMappedFileRegion::create()
- 2b7d87c621c3b1900121b4bb7cf543eda1183ed8 CAS: Refactor OnDiskHashMappedTrie to add TrieHandle
- 259a689cc7e721789399d23db8cb92bb7218b651 CAS: Clean up FIXMEs fixed by - ff7f05544e2e6258328e87c6ffd34b44be32d268
- 185e80e0eff47d5a4db45057b7ed2cf06294d579 CAS: Simplify SubtrieHandle atomic helpers in OnDiskHashMappedTrie
- 5fd3ea93828e459b2dcc210d1349376bab614e97 CAS: Add SubtrieHandle::sink to simplify OnDiskHashMappedTrie::insert
- 1cfb365909e65f7167fd44edadff85296de6061e CAS: Add/use SubtrieHandle::store in OnDiskHashMappedTrie
- 54f8a2dda4155cc641783c0c15a16d2dd5a66d0a CAS: OnDiskOffset => SubtrieSlotValue, NFC
- dee3b2d4f64123d44c703a235b6e17866ffa1323 CAS: Refactor subtrie code in OnDiskHashMappedTrie
