### PR TITLE
Introduce a `LinkGraph` builder based on the `CASObjectReader` interface

### DIFF
--- a/llvm/include/llvm/CASObjectFormats/LinkGraph.h
+++ b/llvm/include/llvm/CASObjectFormats/LinkGraph.h
@@ -1,0 +1,35 @@
+//===- llvm/CASObjectFormats/LinkGraph.h ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CASOBJECTFORMATS_LINKGRAPH_H
+#define LLVM_CASOBJECTFORMATS_LINKGRAPH_H
+
+#include "llvm/Support/Error.h"
+#include <memory>
+
+namespace llvm {
+namespace jitlink {
+class LinkGraph;
+}
+
+namespace casobjectformats {
+namespace reader {
+class CASObjectReader;
+}
+
+/// Eagerly parse the full compile unit to create a LinkGraph.
+///
+/// Ideally we'd have some sort of LazyLinkGraph that can answer questions
+/// and/or build itself up on demand.
+Expected<std::unique_ptr<jitlink::LinkGraph>>
+createLinkGraph(const reader::CASObjectReader &Reader, StringRef Name);
+
+} // end namespace casobjectformats
+} // end namespace llvm
+
+#endif // LLVM_CASOBJECTFORMATS_LINKGRAPH_H

--- a/llvm/include/llvm/CASObjectFormats/NestedV1.h
+++ b/llvm/include/llvm/CASObjectFormats/NestedV1.h
@@ -114,11 +114,6 @@ public:
   createFromLinkGraphImpl(const jitlink::LinkGraph &G,
                           raw_ostream *DebugOS) const override;
 
-  Expected<std::unique_ptr<jitlink::LinkGraph>> createLinkGraphImpl(
-      cas::NodeRef RootNode, StringRef Name,
-      jitlink::LinkGraph::GetEdgeKindNameFunction GetEdgeKindName,
-      raw_ostream *DebugOS) const override;
-
   ObjectFileSchema(cas::CASDB &CAS);
 
   Expected<ObjectFormatNodeRef> createNode(ArrayRef<cas::CASID> IDs,
@@ -946,18 +941,6 @@ public:
   }
 
   Expected<std::unique_ptr<reader::CASObjectReader>> createObjectReader();
-
-  /// Eagerly parse the full compile unit to create a LinkGraph.
-  ///
-  /// Maybe \a LinkGraph isn't really the right interface. Building one forces
-  /// us to eagerly parse the full object file, defeating some of the point of
-  /// this format.
-  ///
-  /// Ideally we'd have some sort of LazyLinkGraph that can answer questions
-  /// and/or build itself up on demand.
-  Expected<std::unique_ptr<jitlink::LinkGraph>>
-  createLinkGraph(StringRef Name,
-                  jitlink::LinkGraph::GetEdgeKindNameFunction GetEdgeKindName);
 
   static Expected<CompileUnitRef> get(Expected<ObjectFormatNodeRef> Ref);
   static Expected<CompileUnitRef> get(const ObjectFileSchema &Schema,

--- a/llvm/include/llvm/CASObjectFormats/SchemaBase.h
+++ b/llvm/include/llvm/CASObjectFormats/SchemaBase.h
@@ -62,24 +62,12 @@ public:
     return createFromLinkGraphImpl(G, DebugOS);
   }
 
-  Expected<std::unique_ptr<jitlink::LinkGraph>>
-  createLinkGraph(cas::NodeRef RootNode, StringRef Name,
-                  jitlink::LinkGraph::GetEdgeKindNameFunction GetEdgeKindName,
-                  raw_ostream *DebugOS = nullptr) const {
-    return createLinkGraphImpl(RootNode, Name, GetEdgeKindName, DebugOS);
-  }
-
   cas::CASDB &CAS;
 
 protected:
   virtual Expected<cas::NodeRef>
   createFromLinkGraphImpl(const jitlink::LinkGraph &G,
                           raw_ostream *DebugOS) const = 0;
-
-  virtual Expected<std::unique_ptr<jitlink::LinkGraph>> createLinkGraphImpl(
-      cas::NodeRef RootNode, StringRef Name,
-      jitlink::LinkGraph::GetEdgeKindNameFunction GetEdgeKindName,
-      raw_ostream *DebugOS) const = 0;
 
   SchemaBase(cas::CASDB &CAS) : CAS(CAS) {}
 

--- a/llvm/lib/CASObjectFormats/CMakeLists.txt
+++ b/llvm/lib/CASObjectFormats/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_llvm_component_library(LLVMCASObjectFormats
   Data.cpp
   FlatV1.cpp
+  LinkGraph.cpp
   NestedV1.cpp
   SchemaBase.cpp
   ObjectFormatHelpers.cpp

--- a/llvm/lib/CASObjectFormats/LinkGraph.cpp
+++ b/llvm/lib/CASObjectFormats/LinkGraph.cpp
@@ -1,0 +1,242 @@
+//===- CASObjectFormats/LinkGraph.cpp -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CASObjectFormats/LinkGraph.h"
+#include "llvm/CASObjectFormats/CASObjectReader.h"
+#include "llvm/ExecutionEngine/JITLink/JITLink.h"
+
+using namespace llvm;
+using namespace llvm::casobjectformats;
+using namespace llvm::casobjectformats::reader;
+using namespace llvm::jitlink;
+
+namespace {
+
+class LinkGraphBuilder {
+public:
+  LinkGraphBuilder(const CASObjectReader &Reader, StringRef Name,
+                   const Triple &TT, unsigned PointerSize,
+                   support::endianness Endianness,
+                   LinkGraph::GetEdgeKindNameFunction GetEdgeKindName);
+
+  struct SectionInfo {
+    jitlink::Section *Section = nullptr;
+    unsigned Size = 0;
+    unsigned Alignment = 1;
+  };
+
+  Error addSymbol(CASSymbolRef Ref, const CASSymbol &Info);
+  Expected<Symbol *> createSymbol(const CASSymbol &Info);
+  Expected<Block *> createBlock(const CASBlock &Info);
+  Section *createSection(const CASSection &Info);
+
+  Expected<Symbol *> getOrCreateSymbol(CASSymbolRef Ref);
+  Expected<Block *> getOrCreateBlock(CASBlockRef Ref);
+  Expected<SectionInfo &> getOrCreateSection(CASSectionRef Ref);
+
+  Block *getExistingBlock(CASBlockRef Ref) const;
+
+  Error addFixups();
+  Error addEdge(Block &Blk, const CASBlockFixup &Fixup);
+
+  std::unique_ptr<LinkGraph> takeLinkGraph() { return std::move(LG); }
+
+  const CASObjectReader &Reader;
+  std::unique_ptr<LinkGraph> LG;
+
+  DenseMap<CASSymbolRef, Symbol *> Symbols;
+  DenseMap<CASBlockRef, Block *> Blocks;
+  DenseMap<CASSectionRef, SectionInfo> Sections;
+
+  struct BlockForFixup {
+    CASBlockRef Ref;
+    Block *Blk;
+  };
+  SmallVector<BlockForFixup> BlocksForFixup;
+};
+
+} // anonymous namespace
+
+LinkGraphBuilder::LinkGraphBuilder(
+    const CASObjectReader &Reader, StringRef Name, const Triple &TT,
+    unsigned PointerSize, support::endianness Endianness,
+    LinkGraph::GetEdgeKindNameFunction GetEdgeKindName)
+    : Reader(Reader) {
+  LG.reset(
+      new LinkGraph(Name.str(), TT, PointerSize, Endianness, GetEdgeKindName));
+}
+
+Error LinkGraphBuilder::addSymbol(CASSymbolRef Ref, const CASSymbol &Info) {
+  Expected<Symbol *> ExpSym = createSymbol(Info);
+  if (!ExpSym)
+    return ExpSym.takeError();
+  Symbols[Ref] = *ExpSym;
+  return Error::success();
+}
+
+Expected<Symbol *> LinkGraphBuilder::createSymbol(const CASSymbol &Info) {
+  if (!Info.isDefined()) {
+    return &LG->addExternalSymbol(Info.Name, /*Size=*/0, Info.Linkage);
+  }
+
+  Expected<Block *> Block = getOrCreateBlock(*Info.BlockRef);
+  if (!Block)
+    return Block.takeError();
+  auto &Symbol =
+      Info.Name.empty()
+          ? LG->addAnonymousSymbol(**Block, Info.Offset,
+                                   /*Size=*/0, Info.IsCallable, Info.IsLive)
+          : LG->addDefinedSymbol(**Block, Info.Offset, Info.Name, /*Size=*/0,
+                                 Info.Linkage, Info.Scope, Info.IsCallable,
+                                 Info.IsLive);
+  Symbol.setAutoHide(Info.IsAutoHide);
+  return &Symbol;
+}
+
+static orc::ExecutorAddr
+getAlignedAddress(LinkGraphBuilder::SectionInfo &Section, uint64_t Size,
+                  uint64_t Alignment, uint64_t AlignmentOffset) {
+  uint64_t Address = alignTo(Section.Size + AlignmentOffset, Align(Alignment)) -
+                     AlignmentOffset;
+  Section.Size = Address + Size;
+  if (Alignment > Section.Alignment)
+    Section.Alignment = Alignment;
+  return orc::ExecutorAddr(Address);
+}
+
+Expected<Block *> LinkGraphBuilder::createBlock(const CASBlock &Info) {
+  Expected<SectionInfo &> SectionInfo = getOrCreateSection(Info.SectionRef);
+  if (!SectionInfo)
+    return SectionInfo.takeError();
+  auto Address = getAlignedAddress(*SectionInfo, Info.Size, Info.Alignment,
+                                   Info.AlignmentOffset);
+  auto &B =
+      Info.isZeroFill()
+          ? LG->createZeroFillBlock(*SectionInfo->Section, Info.Size, Address,
+                                    Info.Alignment, Info.AlignmentOffset)
+          : LG->createContentBlock(
+                *SectionInfo->Section,
+                makeArrayRef(Info.Content->begin(), Info.Content->end()),
+                Address, Info.Alignment, Info.AlignmentOffset);
+  return &B;
+}
+
+Section *LinkGraphBuilder::createSection(const CASSection &Info) {
+  return &LG->createSection(Info.Name, Info.Prot);
+}
+
+Expected<Symbol *> LinkGraphBuilder::getOrCreateSymbol(CASSymbolRef Ref) {
+  Symbol *&Sym = Symbols[Ref];
+  if (!Sym) {
+    Expected<CASSymbol> Info = Reader.materialize(Ref);
+    if (!Info)
+      return Info.takeError();
+    Expected<Symbol *> ExpSym = createSymbol(*Info);
+    if (!ExpSym)
+      return ExpSym.takeError();
+    Sym = *ExpSym;
+  }
+  return Sym;
+}
+
+Expected<Block *> LinkGraphBuilder::getOrCreateBlock(CASBlockRef Ref) {
+  Block *&Blk = Blocks[Ref];
+  if (!Blk) {
+    Expected<CASBlock> Info = Reader.materialize(Ref);
+    if (!Info)
+      return Info.takeError();
+    Expected<Block *> ExpBlk = createBlock(*Info);
+    if (!ExpBlk)
+      return ExpBlk.takeError();
+    Blk = *ExpBlk;
+    BlocksForFixup.push_back(BlockForFixup{Ref, Blk});
+  }
+  return Blk;
+}
+
+Expected<LinkGraphBuilder::SectionInfo &>
+LinkGraphBuilder::getOrCreateSection(CASSectionRef Ref) {
+  SectionInfo &Sec = Sections[Ref];
+  if (!Sec.Section) {
+    Expected<CASSection> Info = Reader.materialize(Ref);
+    if (!Info)
+      return Info.takeError();
+    Sec.Section = createSection(*Info);
+  }
+  return Sec;
+}
+
+Block *LinkGraphBuilder::getExistingBlock(CASBlockRef Ref) const {
+  auto BI = Blocks.find(Ref);
+  assert(BI != Blocks.end());
+  return BI->second;
+}
+
+Error LinkGraphBuilder::addFixups() {
+  // Check for \p size() at each iteration because new blocks can be added
+  // while reading the fixups, due to new symbols getting discovered when using
+  // nestedv1 format.
+  // FIXME: Get nestedv1 to provide all the symbols that can be referenced from
+  // the translation unit, via \p forEachSymbol().
+  for (unsigned I = 0; I < BlocksForFixup.size(); ++I) {
+    const BlockForFixup &BlkFF = BlocksForFixup[I];
+    Block *Blk = getExistingBlock(BlkFF.Ref);
+    Error E = Reader.materializeFixups(
+        BlkFF.Ref, [&](const CASBlockFixup &Fixup) -> Error {
+          return this->addEdge(*Blk, Fixup);
+        });
+    if (E)
+      return E;
+  }
+  return Error::success();
+}
+
+Error LinkGraphBuilder::addEdge(Block &Parent, const CASBlockFixup &Fixup) {
+  Expected<Symbol *> ExpSym = getOrCreateSymbol(Fixup.TargetRef);
+  if (!ExpSym)
+    return ExpSym.takeError();
+  Parent.addEdge(Fixup.Kind, Fixup.Offset, **ExpSym, Fixup.Addend);
+  return Error::success();
+}
+
+Expected<std::unique_ptr<LinkGraph>>
+casobjectformats::createLinkGraph(const CASObjectReader &Reader,
+                                  StringRef Name) {
+  Triple TT = Reader.getTargetTriple();
+  unsigned PointerSize;
+  if (TT.isArch64Bit())
+    PointerSize = 8;
+  else if (TT.isArch32Bit())
+    PointerSize = 4;
+  else if (TT.isArch16Bit())
+    PointerSize = 2;
+  else
+    return createStringError(
+        inconvertibleErrorCode(),
+        "could not infer pointer width from target triple: " + TT.str());
+  support::endianness Endianness = TT.isLittleEndian()
+                                       ? support::endianness::little
+                                       : support::endianness::big;
+  Expected<LinkGraph::GetEdgeKindNameFunction> GetEdgeKindName =
+      getGetEdgeKindNameFunction(TT);
+  if (!GetEdgeKindName)
+    return GetEdgeKindName.takeError();
+
+  LinkGraphBuilder Builder(Reader, Name, TT, PointerSize, Endianness,
+                           *GetEdgeKindName);
+  Error E =
+      Reader.forEachSymbol([&](CASSymbolRef Ref, CASSymbol Info) -> Error {
+        return Builder.addSymbol(Ref, Info);
+      });
+  if (E)
+    return std::move(E);
+  E = Builder.addFixups();
+  if (E)
+    return std::move(E);
+  return Builder.takeLinkGraph();
+}

--- a/llvm/tools/llvm-cas-object-format/llvm-cas-object-format.cpp
+++ b/llvm/tools/llvm-cas-object-format/llvm-cas-object-format.cpp
@@ -12,6 +12,7 @@
 #include "llvm/CAS/Utils.h"
 #include "llvm/CASObjectFormats/CASObjectReader.h"
 #include "llvm/CASObjectFormats/FlatV1.h"
+#include "llvm/CASObjectFormats/LinkGraph.h"
 #include "llvm/CASObjectFormats/NestedV1.h"
 #include "llvm/CASObjectFormats/Utils.h"
 #include "llvm/ExecutionEngine/JITLink/ELF_x86_64.h"
@@ -886,9 +887,9 @@ static CASID ingestFile(SchemaBase &Schema, StringRef InputFile,
   if (DebugIngest)
     OS.applyLocked([&](raw_ostream &OS) { OS << DebugIngestOutput; });
 
-  auto RoundTripG = ExitOnErr(Schema.createLinkGraph(
-      CompileUnit, FileContent.getBufferIdentifier(),
-      ExitOnErr(jitlink::getGetEdgeKindNameFunction(G->getTargetTriple()))));
+  auto Reader = ExitOnErr(Schema.createObjectReader(CompileUnit));
+  auto RoundTripG = ExitOnErr(casobjectformats::createLinkGraph(
+      *Reader, FileContent.getBufferIdentifier()));
 
   if (Dump)
     dumpGraph(*RoundTripG, OS, "after round-trip");

--- a/llvm/unittests/CASObjectFormats/FlatV1SchemaTest.cpp
+++ b/llvm/unittests/CASObjectFormats/FlatV1SchemaTest.cpp
@@ -9,6 +9,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/CASObjectFormats/FlatV1.h"
+#include "llvm/CASObjectFormats/LinkGraph.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Memory.h"
@@ -113,8 +114,10 @@ TEST(FlatV1SchemaTest, RoundTrip) {
     EXPECT_THAT_EXPECTED(CU, Succeeded());
     
     // Convert back to LinkGraph.
+    auto Reader = Schema.createObjectReader(std::move(*CU));
+    EXPECT_THAT_EXPECTED(Reader, Succeeded());
     auto RoundTripGOrError =
-        CU->createLinkGraph("round-tripped", jitlink::getGenericEdgeKindName);
+        casobjectformats::createLinkGraph(**Reader, "round-tripped");
     EXPECT_THAT_EXPECTED(RoundTripGOrError, Succeeded());
     RoundTripG = std::move(*RoundTripGOrError);
   }

--- a/llvm/unittests/CASObjectFormats/NestedV1SchemaTest.cpp
+++ b/llvm/unittests/CASObjectFormats/NestedV1SchemaTest.cpp
@@ -8,6 +8,8 @@
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/CASObjectFormats/CASObjectReader.h"
+#include "llvm/CASObjectFormats/LinkGraph.h"
 #include "llvm/CASObjectFormats/NestedV1.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Memory.h"
@@ -536,11 +538,14 @@ TEST(NestedV1SchemaTest, RoundTrip) {
                       Succeeded());
 
     // Convert back to LinkGraph.
+    Optional<std::unique_ptr<reader::CASObjectReader>> Reader;
     ASSERT_THAT_ERROR(
-        unwrapExpected(CU->createLinkGraph("round-tripped",
-                                           jitlink::getGenericEdgeKindName),
-                       RoundTripG),
+        unwrapExpected(Schema.createObjectReader(std::move(*CU)), Reader),
         Succeeded());
+    ASSERT_THAT_ERROR(unwrapExpected(casobjectformats::createLinkGraph(
+                                         **Reader, "round-tripped"),
+                                     RoundTripG),
+                      Succeeded());
   }
 
   // Check linkage for named symbols.
@@ -661,11 +666,14 @@ TEST(NestedV1SchemaTest, RoundTripBlockOrder) {
                       Succeeded());
 
     // Convert back to LinkGraph.
+    Optional<std::unique_ptr<reader::CASObjectReader>> Reader;
     ASSERT_THAT_ERROR(
-        unwrapExpected(CU->createLinkGraph("round-tripped",
-                                           jitlink::getGenericEdgeKindName),
-                       RoundTripG),
+        unwrapExpected(Schema.createObjectReader(std::move(*CU)), Reader),
         Succeeded());
+    ASSERT_THAT_ERROR(unwrapExpected(casobjectformats::createLinkGraph(
+                                         **Reader, "round-tripped"),
+                                     RoundTripG),
+                      Succeeded());
   }
 
   DenseMap<jitlink::Block *, std::vector<jitlink::Symbol *>> RTBlockSymbols;


### PR DESCRIPTION
Use the new builder to replace the specific `flatv1` and `nestedv1` builders.