### PR TITLE
[lldb] Force live memory if we can't read from the file-cache

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -177,7 +177,11 @@ bool LLDBMemoryReader::readString(swift::remote::RemoteAddress address,
   Target &target(m_process.GetTarget());
   Address addr(address.getAddressData());
   Status error;
-  target.ReadCStringFromMemory(addr, dest, error);
+  // We only want to allow the file-cache optimization if we resolved the 
+  // address to section + offset.
+  const bool force_live_memory =
+      !readMetadataFromFileCacheEnabled() || !addr.IsSectionOffset();
+  target.ReadCStringFromMemory(addr, dest, error, force_live_memory);
   if (error.Success()) {
     auto format_string = [](const std::string &dest) {
       StreamString stream;


### PR DESCRIPTION
Now that reading C strings go through the file-cache by default, make
sure that any calls that come from LLDBMemoryReader force live memory
when we can't read from the file-cache. This is the case when:
- The LLDB setting marks it as disabled.
- The target is 32 bits (this may be subject to change).
- The address we're reading from is not one of the fake addresses we
  resolved in LLDBMemoryReader.

(cherry picked from commit 03a0435ef82301a0a826e6407a12b2a835e4fb83)