### PR TITLE
[lldb] Try to map a real address to a tagged one in resolvePointer

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
@@ -23,6 +23,13 @@ public:
   swift::remote::RemoteAddress
   getSymbolAddress(const std::string &name) override;
 
+  llvm::Optional<swift::remote::RemoteAbsolutePointer>
+  resolvePointerAsSymbol(swift::remote::RemoteAddress address) override;
+
+  swift::remote::RemoteAbsolutePointer
+  resolvePointer(swift::remote::RemoteAddress address,
+                 uint64_t readValue) override;
+
   bool readBytes(swift::remote::RemoteAddress address, uint8_t *dest,
                  uint64_t size) override;
 


### PR DESCRIPTION
If we read a real process address, try to map that back as a tagged
LLDBMLLDBMemoryReader address, so further reads originating from it
benefit from the file-cache optimization.

(cherry picked from commit 3a871e87fa73f1aba099b36aea0e4f9a21322b2a)