### PR TITLE
Move (most of) No.Swiftmodule into a proper API test.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -599,21 +599,26 @@ VPATHSOURCES=$(patsubst %,$(VPATH)/%,$(SWIFT_SOURCES)) $(patsubst %,$(VPATH)/%,$
 	  -o $(BUILDDIR)/$@
 
 ifeq "$(OS)" "Darwin"
-$(EXE): $(MODULENAME).swiftmodule $(OBJECTS)
+ifeq "$(HIDE_SWIFTMODULE)" ""
+SWIFTMODULE = $(MODULENAME).swiftmodule
+LD_SWIFTFLAGS = -Xlinker -add_ast_path -Xlinker $(SWIFTMODULE)
+else
+SWIFTMODULE =
+LD_SWIFTFLAGS =
+endif
+$(EXE): $(SWIFTMODULE) $(OBJECTS)
 	@echo "### Linking" $(EXE)
-	$(SWIFTC) $(LD_EXTRAS) $(OBJECTS) \
-	  -Xlinker -add_ast_path -Xlinker $(MODULENAME).swiftmodule \
-	  $(patsubst -g,,$(SWIFTFLAGS)) -o "$(EXE)"
+	$(SWIFTC) $(LD_EXTRAS) $(LD_SWIFTFLAGS) $(OBJECTS) $(patsubst -g,,$(SWIFTFLAGS)) -o "$(EXE)"
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$(EXE)"
 endif
 else # OS = Linux
 $(EXE): $(MODULENAME).swiftmodule.o $(OBJECTS)
 	@echo "### Linking" $(EXE)
-ifneq "$(EXCLUDE_WRAPPED_SWIFTMODULE)" ""
-	$(SWIFTC) $(LD_EXTRAS) $(patsubst %.swiftmodule.o,,$^) $(patsubst -g,,$(SWIFTFLAGS)) -o "$(EXE)"
+ifneq "$(HIDE_SWIFTMODULE)" ""
+	$(SWIFTC) $(LD_EXTRAS) $(LD_SWIFTFLAGS) $(patsubst %.swiftmodule.o,,$^) $(patsubst -g,,$(SWIFTFLAGS)) -o "$(EXE)"
 else
-	$(SWIFTC) $(LD_EXTRAS) $^ $(patsubst -g,,$(SWIFTFLAGS)) -o "$(EXE)"
+	$(SWIFTC) $(LD_EXTRAS) $(LD_SWIFTFLAGS) $^ $(patsubst -g,,$(SWIFTFLAGS)) -o "$(EXE)"
 endif
 
 $(MODULENAME).swiftmodule.o: $(MODULENAME).swiftmodule
@@ -694,7 +699,7 @@ ifeq "$(OS)" "Darwin"
 DYLIB_SWIFT_FLAGS=  \
 	 -Xlinker -dylib \
 	 -Xlinker -install_name -Xlinker @executable_path/$(shell basename $@) \
-	 $(LD_EXTRAS)
+	 $(LD_EXTRAS) $(LD_SWIFTFLAGS)
 ifeq "$(DYLIB_HIDE_SWIFTMODULE)" ""
 DYLIB_SWIFT_FLAGS+= -Xlinker -add_ast_path -Xlinker $(DYLIB_NAME).swiftmodule
 endif

--- a/lldb/test/API/lang/swift/playgrounds-repl/Makefile.common
+++ b/lldb/test/API/lang/swift/playgrounds-repl/Makefile.common
@@ -3,10 +3,13 @@ SWIFT_SOURCES := PlaygroundStub.swift
 
 PlaygroundStub: libPlaygroundsRuntime.dylib
 
+ifneq ($(MAKECMDGOALS),libPlaygroundsRuntime.dylib)
+LD_EXTRAS := -L. -lPlaygroundsRuntime
+endif
+
 include Makefile.rules
 
 ifneq ($(MAKECMDGOALS),libPlaygroundsRuntime.dylib)
-LD_EXTRAS := -L. -lPlaygroundsRuntime
 libPlaygroundsRuntime.dylib: PlaygroundsRuntime.swift
 	$(MAKE) -C $(BUILDDIR) -f $(SRCDIR)/Makefile \
 		SWIFT_SOURCES= DYLIB_SWIFT_SOURCES=PlaygroundsRuntime.swift \

--- a/lldb/test/API/lang/swift/reflection_only/Makefile
+++ b/lldb/test/API/lang/swift/reflection_only/Makefile
@@ -1,0 +1,17 @@
+SWIFT_SOURCES := main.swift
+HIDE_SWIFTMODULE := YES
+
+SWIFTFLAGS_EXTRAS := -I. -enable-library-evolution
+
+LD_EXTRAS = -L. -Xlinker -rpath -Xlinker $(BUILDDIR) -ldynamic_lib
+
+all: dylib $(EXE)
+.PHONY: dylib
+
+include Makefile.rules
+dylib: lib.swift
+	$(MAKE) -f $(MAKEFILE_RULES) \
+		MAKE_DSYM=YES DYLIB_ONLY=YES DYLIB_NAME=dynamic_lib \
+		DYLIB_SWIFT_SOURCES="lib.swift" \
+		DYLIB_HIDE_SWIFTMODULE=YES \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) $(SWIFTFLAGS_EXTRAS)"

--- a/lldb/test/API/lang/swift/reflection_only/TestSwiftReflectionOnly.py
+++ b/lldb/test/API/lang/swift/reflection_only/TestSwiftReflectionOnly.py
@@ -1,0 +1,91 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+import re
+
+class TestSwiftReflectionOnly(lldbtest.TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    def test(self):
+        """Test debugging a program without swiftmodules is functional"""
+        self.build()
+
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'),
+            extra_images=['dynamic_lib'])
+        log = self.getBuildArtifact('types.log')
+        self.expect('log enable lldb types -f ' + log)
+
+        check_var = lldbutil.check_variable
+        frame = thread.frames[0]
+        var_self = frame.FindVariable("self")
+        var_self_x = var_self.GetChildMemberWithName("x")
+        check_var(self, var_self_x, value="42")
+
+        check_var(self, frame.FindVariable("number"), value="1")
+
+        array = frame.FindVariable("array")
+        check_var(self, array, num_children=3)
+        check_var(self, array.GetChildAtIndex(0), value="1")
+        check_var(self, array.GetChildAtIndex(1), value="2")
+        check_var(self, array.GetChildAtIndex(2), value="3")
+
+        check_var(self, frame.FindVariable("string"), summary='"hello"')
+
+        tup = frame.FindVariable("tuple")
+        check_var(self, tup, num_children=2)
+        check_var(self, tup.GetChildAtIndex(0), value="0")
+        check_var(self, tup.GetChildAtIndex(1), value="1")
+
+        strct = frame.FindVariable("strct")
+        check_var(self, strct, num_children=5)
+        check_var(self, strct.GetChildMemberWithName("pub"), value="1")
+        check_var(self, strct.GetChildMemberWithName("priv"), value="2")
+        check_var(self, strct.GetChildMemberWithName("filepriv"), value="3")
+        s_priv = strct.GetChildMemberWithName("s_priv")
+        check_var(self, s_priv, num_children=1)
+        check_var(self, s_priv.GetChildMemberWithName("i"), value="2")
+        s_filepriv = strct.GetChildMemberWithName("s_filepriv")
+        check_var(self, s_filepriv, num_children=1)
+        check_var(self, s_filepriv.GetChildMemberWithName("i"), value="3")
+
+        # FIXME: scratch context assertion
+        # check_var(self, frame.FindVariable("generic"), use_dynamic=True, value="42")
+
+        # gtup = frame.FindVariable("generic_tuple")
+        # check_var(self, gtup, num_children=2)
+        # check_var(self, gtup.GetChildAtIndex(0), use_dynamic=True, value="42")
+        # check_var(self, gtup.GetChildAtIndex(1), use_dynamic=True, value="42")
+
+        check_var(self, frame.FindVariable("word"), value="0")
+        check_var(self, frame.FindVariable("enum1"), value="second")
+        enum2 = frame.FindVariable("enum2")
+        check_var(self, enum2, value="with")
+        check_var(self, enum2, num_children=1)
+        # FIXME:  Fails in swift::reflection::NoPayloadEnumTypeInfo::projectEnumValue: .second
+        # check_var(self, enum2.GetChildAtIndex(0), value="42")
+
+        # Scan through the types log.
+        logfile = open(log, "r")
+        found_ref_exe = 0
+        found_ref_lib = 0
+        found_ast_exe = 0
+        found_ast_lib = 0
+        for line in logfile:
+            if 'SwiftASTContextForExpressions::RegisterSectionModules("a.out")' in line:
+                found_ast_exe += 1
+            elif 'SwiftASTContextForExpressions::RegisterSectionModules("dyld")' in line:
+                found_ast_lib += 1
+            elif re.search(r'Adding reflection metadata in .*a\.out', line):
+                found_ref_exe += 1
+            elif re.search(r'Adding reflection metadata in .*dynamic_lib', line):
+                found_ref_lib += 1
+        self.assertEqual(found_ref_exe, 1)
+        self.assertEqual(found_ref_lib, 1)
+        self.assertEqual(found_ast_exe, 0)
+        self.assertEqual(found_ast_lib, 0)

--- a/lldb/test/API/lang/swift/reflection_only/lib.swift
+++ b/lldb/test/API/lang/swift/reflection_only/lib.swift
@@ -1,0 +1,34 @@
+public struct S {
+  public init() {}
+  public let pub = 1
+  private let priv = 2
+  fileprivate let filepriv = 3
+
+  private let s_priv = SPriv()
+  fileprivate let s_filepriv = SFilePriv()
+}
+
+private struct SPriv {
+  let i = 2
+}
+
+fileprivate struct SFilePriv {
+  let i = 3
+}
+
+open class Base {
+  public let x : Int = 42
+  public init() {}
+}
+
+public enum NoPayload {
+  case first
+  case second
+}
+
+public enum WithPayload {
+  case empty
+  case with(i: Int)
+}
+
+public protocol P {}

--- a/lldb/test/API/lang/swift/reflection_only/main.swift
+++ b/lldb/test/API/lang/swift/reflection_only/main.swift
@@ -1,0 +1,25 @@
+import dynamic_lib
+
+struct MyP : P {
+  let i = 1
+}
+
+class C : Base {
+    func f<T>(_ t: T, _ p : P) {
+    let number = 1
+    let array = [1, 2, 3]
+    let string = "hello"
+    let tuple = (0, 1)
+    let strct = S()
+    let generic = t
+    let generic_tuple = (t, t)
+    let word = 0._builtinWordValue
+    let enum1 = NoPayload.second
+    // FIXME: Fails in swift::reflection::NoPayloadEnumTypeInfo::projectEnumValue: .second
+    let enum2 = WithPayload.with(i:42)
+    print("Set breakpoint here")
+  }
+}
+
+let c = C()
+c.f(42, MyP())

--- a/lldb/test/Shell/Swift/Inputs/No.swiftmodule.swift
+++ b/lldb/test/Shell/Swift/Inputs/No.swiftmodule.swift
@@ -1,37 +1,13 @@
 import NoSwiftmoduleHelper
 
-// The struct is resolved using type metadata and the Swift runtime.
-struct S { let i = 0 }
-
 func useTypeFromOtherModule(x: S2) {
   // break here
 }
 
-enum NoPayload {
-  case first
-  case second
-}
-
-enum WithPayload {
-  case empty
-  case with(i: Int)
-}
 
 func f<T>(_ t: T) {
-  let number = 1                     // CHECK-DAG: (Int) number {{=}} 1
-  let array = [1, 2, 3]              // CHECK-DAG: ([Int]) array {{=}} 3 values
-  let string = "hello"               // CHECK-DAG: (String) string {{=}} "hello"
-  let tuple = (0, 1)                 // CHECK-DAG: (Int, Int) tuple {{=}} (0 = 0, 1 = 1)
-  let strct = S()                    // CHECK-DAG: strct {{=}} (i = 0)
   let strct2 = S2()                  // CHECK-DAG: strct2 {{=}} {}{{$}}
-  let generic = t                    // CHECK-DAG: (Int) generic {{=}} 23
-  let generic_tuple = (t, t)         // CHECK-DAG: generic_tuple {{=}} (0 = 23, 1 = 23)
-  let word = 0._builtinWordValue     // CHECK-DAG: word {{=}} 0
-  let enum1 = NoPayload.second       // CHECK-DAG: enum1 {{=}}
-                                     // FIXME: Fails in swift::reflection::NoPayloadEnumTypeInfo::projectEnumValue: .second
-  let enum2 = WithPayload.with(i:42) // CHECK-DAG: enum2 {{=}} with
-                                     // CHECK-DAG: i {{=}} 42
-  print(number)
+  print(strct2)
   useTypeFromOtherModule(x: S2())
 }
 


### PR DESCRIPTION
Testing debugging from just reflection metadata is very important on
all platforms. Shell tests only run on the host. By migrating this
test to an API test we can make sure this is also tested when
debugging on iOS devices.