### PR TITLE
Increase memory buffer for scanning objc classes on darwin systems

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -2020,7 +2020,8 @@ AppleObjCRuntimeV2::SharedCacheClassInfoExtractor::UpdateISAToDescriptorMap() {
       shared_cache_base_addr == LLDB_INVALID_ADDRESS)
     return DescriptorMapUpdateResult::Fail();
 
-  const uint32_t num_classes = 128 * 1024;
+  // The number of entries to pre-allocate room for.
+  const uint32_t max_num_classes = 256 * 1024;
 
   UtilityFunction *get_class_info_code = GetClassInfoUtilityFunction(exe_ctx);
   if (!get_class_info_code) {
@@ -2042,7 +2043,7 @@ AppleObjCRuntimeV2::SharedCacheClassInfoExtractor::UpdateISAToDescriptorMap() {
   DiagnosticManager diagnostics;
 
   const uint32_t class_info_byte_size = addr_size + 4;
-  const uint32_t class_infos_byte_size = num_classes * class_info_byte_size;
+  const uint32_t class_infos_byte_size = max_num_classes * class_info_byte_size;
   lldb::addr_t class_infos_addr = process->AllocateMemory(
       class_infos_byte_size, ePermissionsReadable | ePermissionsWritable, err);
   const uint32_t relative_selector_offset_addr_size = 64;
@@ -2108,10 +2109,12 @@ AppleObjCRuntimeV2::SharedCacheClassInfoExtractor::UpdateISAToDescriptorMap() {
       num_class_infos = return_value.GetScalar().ULong();
       LLDB_LOG(log, "Discovered {0} Objective-C classes in the shared cache",
                num_class_infos);
-      assert(num_class_infos <= num_classes);
+      // Assert if there were more classes than we pre-allocated
+      // room for.
+      assert(num_class_infos <= max_num_classes);
       if (num_class_infos > 0) {
-        if (num_class_infos > num_classes) {
-          num_class_infos = num_classes;
+        if (num_class_infos > max_num_classes) {
+          num_class_infos = max_num_classes;
 
           success = false;
         } else {


### PR DESCRIPTION
Increase memory buffer for scanning objc classes on darwin systems

iOS systems are getting near this limit; double itfrom a 150kb
buffer to a 300kb buffer, which is freed after processing the
list of classes.

rdar://88454594
Differential Revision: https://reviews.llvm.org/D118972

(cherry picked from commit a37c38176a5a1f797e6bc2b8771be017394e8e32)