### PR TITLE
cas.o: Update llvm-cas-object-format's cost estimation

### DIFF
--- a/llvm/tools/llvm-cas-object-format/llvm-cas-object-format.cpp
+++ b/llvm/tools/llvm-cas-object-format/llvm-cas-object-format.cpp
@@ -296,7 +296,7 @@ struct ObjectKindInfo {
   size_t DataSize = 0;
 
   size_t getTotalSize(size_t NumHashBytes) const {
-    return NumChildren * NumHashBytes + DataSize;
+    return Count * NumHashBytes + NumChildren * sizeof(void*) + DataSize;
   }
 };
 
@@ -636,8 +636,9 @@ void StatCollector::printToOuts(ArrayRef<CASID> TopLevels) {
   size_t NumHashBytes = TopLevels.front().getHash().size();
   outs() << "  => Note: 'Parents' counts incoming edges\n"
          << "  => Note: 'Children' counts outgoing edges (to sub-objects)\n"
-         << "  => Note: number of bytes per Ref = " << NumHashBytes << "\n"
-         << "  => Note: Cost = sizeof(Ref)*Children + Data\n";
+         << "  => Note: HashSize = " << NumHashBytes << "B\n"
+         << "  => Note: PtrSize  = " << sizeof(void *) << "B\n"
+         << "  => Note: Cost     = Count*HashSize + PtrSize*Children + Data\n";
   StringLiteral HeaderFormat = "{0,-22} {1,+10} {2,+7} {3,+10} {4,+7} {5,+10} "
                                "{6,+7} {7,+10} {8,+7} {9,+10} {10,+7}\n";
   StringLiteral Format = "{0,-22} {1,+10} {2,+7:P} {3,+10} {4,+7:P} {5,+10} "


### PR DESCRIPTION
Computing cost of refs as the size of a pointer, although in the builtin
CAS they'll often cost only 4B. Also adding the cost of storing the hash
for each node in the first place.

Changed output for nestedv1 from on the `.o`s in a recent release build
directory from:
```
  => Note: number of bytes per Ref = 20
  => Note: Cost = sizeof(Ref)*Children + Data
Kind                        Count            Parents           Children           Data (B)           Cost (B)
====                        =====            =======           ========           ========           ========
builtin:node                   12   0.00%       2321   0.12%         21   0.00%        190   0.00%        610   0.00%
builtin:tree                  521   0.07%        520   0.03%       2828   0.15%      97548   0.09%     154108   0.11%
cas.o:block                171180  23.05%     201087  10.65%     466108  24.69%     607508   0.59%    9929668   7.04%
cas.o:block-data           148224  19.96%     171180   9.07%          0   0.00%   89869523  87.08%   89869523  63.75%
cas.o:compile-unit           2300   0.31%       2308   0.12%      16100   0.85%      52900   0.05%     374900   0.27%
cas.o:encoded-data          21970   2.96%      26953   1.43%          0   0.00%    1382017   1.34%    1382017   0.98%
cas.o:name                 116713  15.72%     873059  46.24%          0   0.00%   10709728  10.38%   10709728   7.60%
cas.o:name-list              2163   0.29%       4600   0.24%     132847   7.04%       2163   0.00%    2659103   1.89%
cas.o:section                  17   0.00%     171180   9.07%         17   0.00%         34   0.00%        374   0.00%
cas.o:symbol               201087  27.08%     350746  18.58%     325402  17.24%     402174   0.39%    6910214   4.90%
cas.o:symbol-table           6726   0.91%       9200   0.49%     177960   9.43%      13452   0.01%    3572652   2.53%
cas.o:target-list           71662   9.65%      74757   3.96%     766628  40.61%      71662   0.07%   15404222  10.93%
TOTAL                      742575 100.00%    1887911 100.00%    1887911 100.00%  103208899 100.00%  140967119 100.00%
```
to
```
  => Note: HashSize = 20B
  => Note: PtrSize  = 8B
  => Note: Cost     = Count*HashSize + PtrSize*Children + Data
Kind                        Count            Parents           Children           Data (B)           Cost (B)
====                        =====            =======           ========           ========           ========
builtin:node                   12   0.00%       2321   0.12%         21   0.00%        190   0.00%        598   0.00%
builtin:tree                  521   0.07%        520   0.03%       2828   0.15%      97548   0.09%     130592   0.10%
cas.o:block                171180  23.05%     201087  10.65%     466108  24.69%     607508   0.59%    7759972   5.83%
cas.o:block-data           148224  19.96%     171180   9.07%          0   0.00%   89869523  87.08%   92834003  69.71%
cas.o:compile-unit           2300   0.31%       2308   0.12%      16100   0.85%      52900   0.05%     227700   0.17%
cas.o:encoded-data          21970   2.96%      26953   1.43%          0   0.00%    1382017   1.34%    1821417   1.37%
cas.o:name                 116713  15.72%     873059  46.24%          0   0.00%   10709728  10.38%   13043988   9.80%
cas.o:name-list              2163   0.29%       4600   0.24%     132847   7.04%       2163   0.00%    1108199   0.83%
cas.o:section                  17   0.00%     171180   9.07%         17   0.00%         34   0.00%        510   0.00%
cas.o:symbol               201087  27.08%     350746  18.58%     325402  17.24%     402174   0.39%    7027130   5.28%
cas.o:symbol-table           6726   0.91%       9200   0.49%     177960   9.43%      13452   0.01%    1571652   1.18%
cas.o:target-list           71662   9.65%      74757   3.96%     766628  40.61%      71662   0.07%    7637926   5.74%
TOTAL                      742575 100.00%    1887911 100.00%    1887911 100.00%  103208899 100.00%  133163687 100.00%
```

Previously, a bunch of data was inlined into `cas.o:block-data` to work
around refs being so expensive. Probably makes sense to undo that now.
More importantly, we don't need to feel constrained anymore about the
cost.