### PR TITLE
[lldb] Enable no payload enum check on No.swiftmodule test

### DIFF
--- a/lldb/test/Shell/Swift/Inputs/No.swiftmodule.swift
+++ b/lldb/test/Shell/Swift/Inputs/No.swiftmodule.swift
@@ -27,8 +27,7 @@ func f<T>(_ t: T) {
   let generic = t                    // CHECK-DAG: (Int) generic {{=}} 23
   let generic_tuple = (t, t)         // CHECK-DAG: generic_tuple {{=}} (0 = 23, 1 = 23)
   let word = 0._builtinWordValue     // CHECK-DAG: word {{=}} 0
-  let enum1 = NoPayload.second       // CHECK-DAG: enum1 {{=}}
-                                     // FIXME: Fails in swift::reflection::NoPayloadEnumTypeInfo::projectEnumValue: .second
+  let enum1 = NoPayload.second       // CHECK-DAG: enum1 {{=}} second
   let enum2 = WithPayload.with(i:42) // CHECK-DAG: enum2 {{=}} with
                                      // CHECK-DAG: i {{=}} 42
   print(number)


### PR DESCRIPTION
Looks like this is already fixed:

```
   429 	  bool projectEnumValue(remote::MemoryReader &reader,
   430 	                       remote::RemoteAddress address,
   431 	                       int *CaseIndex) const override {
   432 	    uint32_t tag = 0;
   433 	    if (!reader.readInteger(address, getSize(), &tag)) {
   434 	      return false;
   435 	    }
   436 	    if (tag < getNumCases()) {
-> 437 	      *CaseIndex = tag;
   438 	      return true;
   439 	    } else {
   440 	      return false;
   441 	    }
   442 	  }
   443 	};
   444
   445 	// Enum with 1 payload case and zero or more non-payload cases
Target 0: (lldb) stopped.
(lldb) v tag
(uint32_t) tag = 1
```  

