### PR TITLE
CAS: Remove CASID conversion operator to ArrayRef

### DIFF
--- a/llvm/include/llvm/CAS/CASID.h
+++ b/llvm/include/llvm/CAS/CASID.h
@@ -44,7 +44,6 @@ public:
 
   CASID() = delete;
   explicit CASID(ArrayRef<uint8_t> Hash) : Hash(Hash) {}
-  explicit operator ArrayRef<uint8_t>() const { return Hash; }
 
   friend hash_code hash_value(CASID ID) { return hash_value(ID.getHash()); }
 


### PR DESCRIPTION
CASID::getHash() is more clear. Probably this doesn't add anything.