### PR TITLE
Revert "[lldb] Disable TestSwiftAsyncFrameVar.py"

### DIFF
--- a/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
+++ b/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
@@ -9,7 +9,6 @@ class TestCase(lldbtest.TestBase):
 
     @swiftTest
     @skipIf(oslist=['windows', 'linux'])
-    @expectedFailureAll(bugnumber="rdar://88142757")
     def test(self):
         """Test `frame variable` in async functions"""
         self.build()


### PR DESCRIPTION
This reverts commit 5eca70dccec29107b740dd46a9f82a56bff8e3ca, since the PR that breaks this test is being reverted.