### PR TITLE
Add support to dsymutil for dumping out new swift5 reflection sections

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Swift.def
+++ b/llvm/include/llvm/BinaryFormat/Swift.def
@@ -24,3 +24,7 @@ HANDLE_SWIFT_SECTION(builtin, "__swift5_builtin", "swift5_builtin", ".sw5bltn")
 HANDLE_SWIFT_SECTION(capture, "__swift5_capture", "swift5_capture", ".sw5cptr")
 HANDLE_SWIFT_SECTION(typeref, "__swift5_typeref", "swift5_typeref", ".sw5tyrf")
 HANDLE_SWIFT_SECTION(reflstr, "__swift5_reflstr", "swift5_reflstr", ".sw5rfst")
+HANDLE_SWIFT_SECTION(conform, "__swift5_proto", "swift5_protocol_confromances",
+                     ".sw5prtc$B")
+HANDLE_SWIFT_SECTION(protocs, "__swift5_protos", "swift5_protocols",
+                     ".sw5prt$B")

--- a/llvm/test/tools/dsymutil/Inputs/reflection_metadata.yaml
+++ b/llvm/test/tools/dsymutil/Inputs/reflection_metadata.yaml
@@ -16,12 +16,12 @@ FileHeader:
   cpusubtype:      0x3
   filetype:        0x1
   ncmds:           8
-  sizeofcmds:      2800
+  sizeofcmds:      2960
   flags:           0x2000
   reserved:        0x0
 LoadCommands:
   - cmd:             LC_SEGMENT_64
-    cmdsize:         2552
+    cmdsize:         2712
     segname:         ''
     vmaddr:          0
     vmsize:          21352
@@ -29,14 +29,14 @@ LoadCommands:
     filesize:        20967
     maxprot:         7
     initprot:        7
-    nsects:          31
+    nsects:          33
     flags:           0
     Sections:
       - sectname:        __text
         segname:         __TEXT
         addr:            0x0
         size:            4571
-        offset:          0xB10
+        offset:          0xBB0
         align:           4
         reloff:          0x5CF8
         nreloc:          74
@@ -56,7 +56,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x11DC
         size:            117
-        offset:          0x1CEC
+        offset:          0x1D8C
         align:           1
         reloff:          0x5F48
         nreloc:          22
@@ -77,7 +77,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x1254
         size:            24
-        offset:          0x1D64
+        offset:          0x1E04
         align:           2
         reloff:          0x5FF8
         nreloc:          6
@@ -98,7 +98,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x17D8
         size:            37
-        offset:          0x22E8
+        offset:          0x2388
         align:           0
         reloff:          0x0
         nreloc:          0
@@ -110,7 +110,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x1800
         size:            24
-        offset:          0x2310
+        offset:          0x23B0
         align:           2
         reloff:          0x6530
         nreloc:          8
@@ -131,7 +131,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x1818
         size:            260
-        offset:          0x2328
+        offset:          0x23C8
         align:           2
         reloff:          0x6570
         nreloc:          60
@@ -152,7 +152,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x1AC8
         size:            20
-        offset:          0x25D8
+        offset:          0x2678
         align:           2
         reloff:          0x67F8
         nreloc:          2
@@ -169,11 +169,35 @@ LoadCommands:
             type:            5
             scattered:       false
             value:           0
+      - sectname:        __swift5_proto
+        segname:         __TEXT
+        addr:            0x1AEC
+        size:            10
+        offset:          0x269C
+        align:           2
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x10000000
+        reserved1:       0x0
+        reserved2:       0x0
+        content:         41424344454647484950
+      - sectname:        __swift5_protos
+        segname:         __TEXT
+        addr:            0x1AF8
+        size:            10
+        offset:          0x26C0
+        align:           2
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x10000000
+        reserved1:       0x0
+        reserved2:       0x0
+        content:         51525354555657585960
       - sectname:        __bss
         segname:         __DATA
         addr:            0x3372
         size:            2084
-        offset:          0x50B0
+        offset:          0x5150
         align:           3
         reloff:          0x0
         nreloc:          0

--- a/llvm/test/tools/dsymutil/X86/reflection-dump.test
+++ b/llvm/test/tools/dsymutil/X86/reflection-dump.test
@@ -42,3 +42,9 @@ CHECK-NEXT:	 10000e23c f0ffffff ecffffff                    ........
 CHECK: Contents of section __DWARF,__swift5_builtin:
 CHECK-NEXT:  10000e244 00000000 09000000 08000100 10000000  ................
 CHECK-NEXT:  10000e254 fe000000                             ....
+
+CHECK: Contents of section __DWARF,__swift5_proto:
+CHECK-NEXT: 10000e258 41424344 45464748 4950               ABCDEFGHIP
+
+CHECK: Contents of section __DWARF,__swift5_protos:
+CHECK-NEXT: 10000e264 51525354 55565758 5960               QRSTUVWXY`


### PR DESCRIPTION
This change adds support for dsymutil to be able to dump out the new swift5 reflection sections called "swift5_proto and swift5_protos". The test is also updated to check for this.