### PR TITLE
cas.o: Keep unreferenced symbols alive by default

### DIFF
--- a/llvm/include/llvm/CASObjectFormats/NestedV1.h
+++ b/llvm/include/llvm/CASObjectFormats/NestedV1.h
@@ -920,6 +920,7 @@ public:
   cas::CASID getIndirectAnonymousID() const { return getReference(4); }
   cas::CASID getStrongExternalsID() const { return getReference(5); }
   cas::CASID getWeakExternalsID() const { return getReference(6); }
+  cas::CASID getUnreferencedID() const { return getReference(7); }
   Expected<SymbolTableRef> getDeadStripNever() const {
     return SymbolTableRef::get(getSchema().getNode(getDeadStripNeverID()));
   }
@@ -939,6 +940,9 @@ public:
   Expected<NameListRef> getWeakExternals() const {
     return NameListRef::get(getSchema().getNode(getWeakExternalsID()));
   }
+  Expected<SymbolTableRef> getUnreferenced() const {
+    return SymbolTableRef::get(getSchema().getNode(getUnreferencedID()));
+  }
 
   Expected<std::unique_ptr<reader::CASObjectReader>> createObjectReader();
 
@@ -952,7 +956,7 @@ public:
          support::endianness Endianness, SymbolTableRef DeadStripNever,
          SymbolTableRef DeadStripLink, SymbolTableRef IndirectDeadStripCompile,
          SymbolTableRef IndirectAnonymous, NameListRef StrongExternals,
-         NameListRef WeakExternals);
+         NameListRef WeakExternals, SymbolTableRef Unreferenced);
 
   /// Create a compile unit out of \p G.
   ///

--- a/llvm/lib/CASObjectFormats/NestedV1.cpp
+++ b/llvm/lib/CASObjectFormats/NestedV1.cpp
@@ -983,16 +983,14 @@ cl::opt<bool> DeadStripByDefault(
              "--dead-strip-section to just dead strip named sections."),
     cl::init(false));
 
-cl::opt<std::vector<std::string>>
-    DeadStripSections(
-        "dead-strip-section",
-        cl::desc("Dead-strip unreferenced symbols in the named sections."));
+cl::list<std::string> DeadStripSections(
+    "dead-strip-section",
+    cl::desc("Dead-strip unreferenced symbols in the named sections."));
 
-cl::opt<std::vector<std::string>>
-    KeepAliveSections(
-        "keep-alive-section",
-        cl::desc("Keep all unreferenced symbols in the named sections. "
-                 "Stronger than --dead-strip or --dead-strip-section."));
+cl::list<std::string> KeepAliveSections(
+    "keep-alive-section",
+    cl::desc("Keep all unreferenced symbols in the named sections. "
+             "Stronger than --dead-strip or --dead-strip-section."));
 
 cl::opt<bool>
     KeepStaticInitializersAlive("keep-static-initializers-alive",
@@ -1800,6 +1798,8 @@ Error NestedV1ObjectReader::forEachSymbol(
   if (Error E = forEachSymbol(CURef.getDeadStripLink(), Callback))
     return E;
   if (Error E = forEachSymbol(CURef.getDeadStripNever(), Callback))
+    return E;
+  if (Error E = forEachSymbol(CURef.getUnreferenced(), Callback))
     return E;
   return Error::success();
 }

--- a/llvm/lib/CASObjectFormats/NestedV1.cpp
+++ b/llvm/lib/CASObjectFormats/NestedV1.cpp
@@ -7,8 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CASObjectFormats/NestedV1.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/CASObjectFormats/CASObjectReader.h"
 #include "llvm/CASObjectFormats/Encoding.h"
 #include "llvm/CASObjectFormats/ObjectFormatHelpers.h"
@@ -16,6 +18,7 @@
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/Support/EndianStream.h"
 #include "llvm/Support/Mutex.h"
+#include "llvm/Support/Threading.h"
 
 // FIXME: For cl::opt. Should thread through or delete.
 #include "llvm/Support/CommandLine.h"
@@ -974,6 +977,23 @@ cl::opt<bool> UseDeadStripCompileForLocals(
     "use-dead-strip-compile-for-locals",
     cl::desc("Use DeadStrip=CompileUnit for local symbols."), cl::init(true));
 
+cl::opt<bool> DeadStripByDefault(
+    "dead-strip",
+    cl::desc("Dead-strip unreferenced symbols in any section. Use "
+             "--dead-strip-section to just dead strip named sections."),
+    cl::init(false));
+
+cl::opt<std::vector<std::string>>
+    DeadStripSections(
+        "dead-strip-section",
+        cl::desc("Dead-strip unreferenced symbols in the named sections."));
+
+cl::opt<std::vector<std::string>>
+    KeepAliveSections(
+        "keep-alive-section",
+        cl::desc("Keep all unreferenced symbols in the named sections. "
+                 "Stronger than --dead-strip or --dead-strip-section."));
+
 cl::opt<bool>
     KeepStaticInitializersAlive("keep-static-initializers-alive",
                                 cl::desc("Keep '__TEXT,__constructor' alive."),
@@ -985,6 +1005,46 @@ cl::opt<bool>
     KeepCompactUnwindAlive("keep-compact-unwind-alive",
                            cl::desc("Keep '__LD,__compact_unwind' alive."),
                            cl::init(true));
+
+static bool shouldKeepAliveInSection(StringRef SectionName) {
+  static StringSet<> KeepAlive;
+  static once_flag Once;
+  llvm::call_once(Once, [&]() {
+    for (StringRef S : KeepAliveSections)
+      KeepAlive.insert(S);
+
+    // FIXME: Stop using hardcoded section names.
+    if (KeepStaticInitializersAlive) {
+      KeepAlive.insert("__DATA,__mod_init_func");
+      KeepAlive.insert("__TEXT,__constructor");
+    }
+    if (KeepCompactUnwindAlive)
+      KeepAlive.insert("__LD,__compact_unwind");
+  });
+  return KeepAlive.count(SectionName);
+}
+
+static bool shouldDeadStripInSection(StringRef SectionName) {
+  static StringSet<> DeadStrip;
+  static once_flag Once;
+  llvm::call_once(Once, [&]() {
+    for (StringRef S : DeadStripSections)
+      DeadStrip.insert(S);
+  });
+  return DeadStrip.count(SectionName);
+}
+
+static bool shouldKeepAlive(const jitlink::Symbol &S) {
+  return S.isDefined() &&
+         shouldKeepAliveInSection(S.getBlock().getSection().getName());
+}
+
+static bool shouldDeadStrip(const jitlink::Symbol &S) {
+  if (DeadStripByDefault)
+    return true;
+  return !S.isDefined() ||
+         shouldDeadStripInSection(S.getBlock().getSection().getName());
+}
 
 SymbolRef::Flags SymbolRef::getFlags(const jitlink::Symbol &S) {
   Flags F;
@@ -1007,21 +1067,8 @@ SymbolRef::Flags SymbolRef::getFlags(const jitlink::Symbol &S) {
       (S.getLinkage() == jitlink::Linkage::Strong ? M_Never : M_ByName) |
       (IsAutoHide ? M_ByContent : M_Never));
 
-  bool IsLiveSection = false;
-  if (S.isDefined()) {
-    StringRef Name = S.getBlock().getSection().getName();
-
-    // FIXME: Stop using hardcoded section names.
-    if (KeepStaticInitializersAlive) {
-      IsLiveSection |=
-          Name == "__DATA,__mod_init_func" || Name == "__TEXT,__constructor";
-    }
-    if (KeepCompactUnwindAlive)
-      IsLiveSection |= Name == "__LD,__compact_unwind";
-  }
-
   // FIXME: Can we detect DS_CompileUnit in more cases?
-  F.DeadStrip = (S.isLive() || IsLiveSection)
+  F.DeadStrip = (S.isLive() || shouldKeepAlive(S))
                     ? DS_Never
                     : (IsAutoHide || (UseDeadStripCompileForLocals &&
                                       S.getScope() == jitlink::Scope::Local))
@@ -1092,7 +1139,7 @@ CompileUnitRef::get(Expected<ObjectFormatNodeRef> Ref) {
   if (!Specific)
     return Specific.takeError();
 
-  if (Specific->getNumReferences() != 7)
+  if (Specific->getNumReferences() != 8)
     return createStringError(inconvertibleErrorCode(),
                              "corrupt compile unit refs");
 
@@ -1128,7 +1175,7 @@ Expected<CompileUnitRef> CompileUnitRef::create(
     support::endianness Endianness, SymbolTableRef DeadStripNever,
     SymbolTableRef DeadStripLink, SymbolTableRef IndirectDeadStripCompile,
     SymbolTableRef IndirectAnonymous, NameListRef StrongSymbols,
-    NameListRef WeakSymbols) {
+    NameListRef WeakSymbols, SymbolTableRef Unreferenced) {
   Expected<Builder> B = Builder::startRootNode(Schema, KindString);
   if (!B)
     return B.takeError();
@@ -1141,7 +1188,7 @@ Expected<CompileUnitRef> CompileUnitRef::create(
 
   assert(B->IDs.size() == 1 && "Expected the root type-id?");
   B->IDs.append({DeadStripNever, DeadStripLink, IndirectDeadStripCompile,
-                 IndirectAnonymous, StrongSymbols, WeakSymbols});
+                 IndirectAnonymous, StrongSymbols, WeakSymbols, Unreferenced});
   return get(B->build());
 }
 
@@ -1366,6 +1413,8 @@ public:
   SmallVector<SymbolRef> DeadStripLinkSymbols;
   SmallVector<SymbolRef> IndirectDeadStripCompileSymbols;
   SmallVector<SymbolRef> IndirectAnonymousSymbols;
+  SmallVector<SymbolRef> UnreferencedSymbols;
+  MapVector<const jitlink::Symbol *, bool> UnreferencedSymbolsMap;
   SmallVector<NameRef> StrongExternals;
   SmallVector<NameRef> WeakExternals;
 
@@ -1450,6 +1499,11 @@ Error CompileUnitBuilder::makeSymbols(const jitlink::LinkGraph &G) {
           return E;
   }
 
+  // Fill the UnreferencedSymbols table.
+  for (const auto &I : UnreferencedSymbolsMap)
+    if (!I.second)
+      UnreferencedSymbols.push_back(*this->Symbols.lookup(I.first).Symbol);
+
   return Error::success();
 }
 
@@ -1498,12 +1552,22 @@ Error CompileUnitBuilder::createSymbol(const jitlink::Symbol &S) {
   // Check if the symbol should be indexed at the top level.
   switch (Symbol->getDeadStrip()) {
   case SymbolRef::DS_Never:
+    // All KeepAlive symbols end up here. That'll include attribute((used)).
     DeadStripNeverSymbols.push_back(*Symbol);
     break;
   case SymbolRef::DS_LinkUnit:
+    // All symbols that the compiler was not allowed to dead-strip end up here.
+    // For C++, that typically excludes inlines, templates, and local symbols,
+    // which end up in the next case.
     DeadStripLinkSymbols.push_back(*Symbol);
     break;
   case SymbolRef::DS_CompileUnit:
+    // Collect dead-strippable symbols that are referenced indirectly (i.e., by
+    // name) in IndirectDeadStripCompileSymbols.
+    //
+    // Remaining symbols are added to UnreferencedSymbolsMap. If a reference is
+    // added later, the value will be set to true.
+    //
     // FIXME: Fine-tune what goes here. The "named" table needs anything that
     // might be found by symbol name, so that's anything that gets referenced
     // indirectly (not by a direct CAS link).
@@ -1519,6 +1583,8 @@ Error CompileUnitBuilder::createSymbol(const jitlink::Symbol &S) {
     //   to be find-able by name.
     if (HasIndirectReference)
       IndirectDeadStripCompileSymbols.push_back(*Symbol);
+    else if (!shouldDeadStrip(S))
+      UnreferencedSymbolsMap.insert({&S, false});
     break;
   }
 
@@ -1588,6 +1654,13 @@ CompileUnitBuilder::getOrCreateTarget(const jitlink::Symbol &S,
   if (UseAbstractBackedgeForPCBeginInFDEDuringBlockIngestion &&
       isPCBeginFromFDE(S, SourceBlock))
     return None;
+
+  // Mark this symbol as NOT being unreferenced.
+  {
+    auto I = UnreferencedSymbolsMap.find(&S);
+    if (I != UnreferencedSymbolsMap.end())
+      I->second = true;
+  }
 
   // Check if the target exists already.
   auto &Info = Symbols[&S];
@@ -1680,11 +1753,15 @@ Expected<CompileUnitRef> CompileUnitRef::create(const ObjectFileSchema &Schema,
       NameListRef::create(Schema, Builder.WeakExternals);
   if (!WeakExternals)
     return WeakExternals.takeError();
+  Expected<SymbolTableRef> Unreferenced =
+      SymbolTableRef::create(Schema, Builder.UnreferencedSymbols);
+  if (!Unreferenced)
+    return Unreferenced.takeError();
 
   return CompileUnitRef::create(Schema, G.getTargetTriple(), G.getPointerSize(),
                                 G.getEndianness(), *NeverTable, *LinkTable,
                                 *CompileTable, *AnonymousTable,
-                                *StrongExternals, *WeakExternals);
+                                *StrongExternals, *WeakExternals, *Unreferenced);
 }
 
 namespace llvm {

--- a/llvm/test/tools/llvm-cas-object-format/Inputs/print-out-flatv1.txt
+++ b/llvm/test/tools/llvm-cas-object-format/Inputs/print-out-flatv1.txt
@@ -4,19 +4,15 @@ SECTION: __TEXT,__text | MemProt: R-X
 {
   BLOCK: size = 0x0010, align = 16, alignment-offset = 0
   {
-    Symbols:
-      __foo | offset: 0x0000, linkage: strong, scope: default, dead, callable
-    Fixups:
-      0x0000, addend = +0x00000000, kind = Keep-Alive, target = <anon-2>
+    SYMBOL: __foo | offset: 0x0000, linkage: strong, scope: default, dead, callable
+    FIXUP: 0x0000, addend = +0x00000000, kind = Keep-Alive, target = <anon-2>
   }
   BLOCK: size = 0x0010, align = 16, alignment-offset = 0
   {
-    Symbols:
-      _main | offset: 0x0000, linkage: strong, scope: default, dead, callable
-    Fixups:
-      0x0000, addend = +0x00000000, kind = Keep-Alive, target = <anon-3>
-      0x0002, addend = +0x00000000, kind = BranchPCRel32, target = _foo_ext
-      0x0007, addend = +0x00000000, kind = BranchPCRel32, target = __foo
+    SYMBOL: _main | offset: 0x0000, linkage: strong, scope: default, dead, callable
+    FIXUP: 0x0000, addend = +0x00000000, kind = Keep-Alive, target = <anon-3>
+    FIXUP: 0x0002, addend = +0x00000000, kind = BranchPCRel32, target = _foo_ext
+    FIXUP: 0x0007, addend = +0x00000000, kind = BranchPCRel32, target = __foo
   }
 }
 
@@ -24,10 +20,8 @@ SECTION: __LD,__compact_unwind | MemProt: RW-
 {
   BLOCK: size = 0x0020, align = 8, alignment-offset = 0
   {
-    Symbols:
-      <anon-0> | offset: 0x0000, linkage: strong, scope: local, dead
-    Fixups:
-      0x0000, addend = +0x00000000, kind = Pointer64, target = _main
+    SYMBOL: <anon-0> | offset: 0x0000, linkage: strong, scope: local, dead
+    FIXUP: 0x0000, addend = +0x00000000, kind = Pointer64, target = _main
   }
 }
 
@@ -35,24 +29,19 @@ SECTION: __TEXT,__eh_frame | MemProt: RW-
 {
   BLOCK: size = 0x0018, align = 8, alignment-offset = 0
   {
-    Symbols:
-      <anon-1> | offset: 0x0000, linkage: strong, scope: local, dead
+    SYMBOL: <anon-1> | offset: 0x0000, linkage: strong, scope: local, dead
   }
   BLOCK: size = 0x0020, align = 8, alignment-offset = 0
   {
-    Symbols:
-      <anon-2> | offset: 0x0000, linkage: strong, scope: local, dead
-    Fixups:
-      0x0004, addend = +0x00000000, kind = NegDelta32, target = <anon-1>
-      0x0008, addend = +0x00000000, kind = Delta64, target = __foo
+    SYMBOL: <anon-2> | offset: 0x0000, linkage: strong, scope: local, dead
+    FIXUP: 0x0004, addend = +0x00000000, kind = NegDelta32, target = <anon-1>
+    FIXUP: 0x0008, addend = +0x00000000, kind = Delta64, target = __foo
   }
   BLOCK: size = 0x0020, align = 8, alignment-offset = 0
   {
-    Symbols:
-      <anon-3> | offset: 0x0000, linkage: strong, scope: local, dead
-    Fixups:
-      0x0004, addend = +0x00000000, kind = NegDelta32, target = <anon-1>
-      0x0008, addend = +0x00000000, kind = Delta64, target = _main
+    SYMBOL: <anon-3> | offset: 0x0000, linkage: strong, scope: local, dead
+    FIXUP: 0x0004, addend = +0x00000000, kind = NegDelta32, target = <anon-1>
+    FIXUP: 0x0008, addend = +0x00000000, kind = Delta64, target = _main
   }
 }
 

--- a/llvm/test/tools/llvm-cas-object-format/Inputs/print-out-nestedv1.txt
+++ b/llvm/test/tools/llvm-cas-object-format/Inputs/print-out-nestedv1.txt
@@ -4,19 +4,15 @@ SECTION: __TEXT,__text | MemProt: R-X
 {
   BLOCK: size = 0x0010, align = 16, alignment-offset = 0
   {
-    Symbols:
-      __foo | offset: 0x0000, linkage: strong, scope: default, dead
-    Fixups:
-      0x0000, addend = +0x00000000, kind = Keep-Alive, target = <anon-1>
+    SYMBOL: __foo | offset: 0x0000, linkage: strong, scope: default, dead
+    FIXUP: 0x0000, addend = +0x00000000, kind = Keep-Alive, target = <anon-1>
   }
   BLOCK: size = 0x0010, align = 16, alignment-offset = 0
   {
-    Symbols:
-      _main | offset: 0x0000, linkage: strong, scope: default, dead
-    Fixups:
-      0x0000, addend = +0x00000000, kind = Keep-Alive, target = <anon-2>
-      0x0002, addend = +0x00000000, kind = BranchPCRel32, target = _foo_ext
-      0x0007, addend = +0x00000000, kind = BranchPCRel32, target = __foo
+    SYMBOL: _main | offset: 0x0000, linkage: strong, scope: default, dead
+    FIXUP: 0x0000, addend = +0x00000000, kind = Keep-Alive, target = <anon-2>
+    FIXUP: 0x0002, addend = +0x00000000, kind = BranchPCRel32, target = _foo_ext
+    FIXUP: 0x0007, addend = +0x00000000, kind = BranchPCRel32, target = __foo
   }
 }
 
@@ -24,10 +20,8 @@ SECTION: __LD,__compact_unwind | MemProt: RW-
 {
   BLOCK: size = 0x0020, align = 8, alignment-offset = 0
   {
-    Symbols:
-      <anon-0> | offset: 0x0000, linkage: strong, scope: local, live
-    Fixups:
-      0x0000, addend = +0x00000000, kind = Pointer64, target = _main
+    SYMBOL: <anon-0> | offset: 0x0000, linkage: strong, scope: local, live
+    FIXUP: 0x0000, addend = +0x00000000, kind = Pointer64, target = _main
   }
 }
 
@@ -35,24 +29,19 @@ SECTION: __TEXT,__eh_frame | MemProt: RW-
 {
   BLOCK: size = 0x0020, align = 8, alignment-offset = 0
   {
-    Symbols:
-      <anon-1> | offset: 0x0000, linkage: strong, scope: local, dead
-    Fixups:
-      0x0004, addend = +0x00000000, kind = NegDelta32, target = <anon-3>
-      0x0008, addend = +0x00000000, kind = Delta64, target = __foo
+    SYMBOL: <anon-1> | offset: 0x0000, linkage: strong, scope: local, dead
+    FIXUP: 0x0004, addend = +0x00000000, kind = NegDelta32, target = <anon-3>
+    FIXUP: 0x0008, addend = +0x00000000, kind = Delta64, target = __foo
   }
   BLOCK: size = 0x0020, align = 8, alignment-offset = 0
   {
-    Symbols:
-      <anon-2> | offset: 0x0000, linkage: strong, scope: local, dead
-    Fixups:
-      0x0004, addend = +0x00000000, kind = NegDelta32, target = <anon-3>
-      0x0008, addend = +0x00000000, kind = Delta64, target = _main
+    SYMBOL: <anon-2> | offset: 0x0000, linkage: strong, scope: local, dead
+    FIXUP: 0x0004, addend = +0x00000000, kind = NegDelta32, target = <anon-3>
+    FIXUP: 0x0008, addend = +0x00000000, kind = Delta64, target = _main
   }
   BLOCK: size = 0x0018, align = 8, alignment-offset = 0
   {
-    Symbols:
-      <anon-3> | offset: 0x0000, linkage: strong, scope: local, dead
+    SYMBOL: <anon-3> | offset: 0x0000, linkage: strong, scope: local, dead
   }
 }
 

--- a/llvm/test/tools/llvm-cas-object-format/dead-strip.ll
+++ b/llvm/test/tools/llvm-cas-object-format/dead-strip.ll
@@ -1,0 +1,78 @@
+; RUN: rm -rf %t && mkdir -p %t
+; RUN: llc %s --filetype=obj -o %t/object.o
+; RUN: llvm-cas-object-format --cas %t/cas %t/object.o --ingest-schema=nestedv1 \
+; RUN:    -silent > %t/default.id
+; RUN: llvm-cas-object-format --cas %t/cas %t/object.o --ingest-schema=nestedv1 \
+; RUN:    -silent -dead-strip > %t/dead-strip.id
+; RUN: llvm-cas-object-format --cas %t/cas %t/object.o --ingest-schema=nestedv1 \
+; RUN:    -silent -dead-strip \
+; RUN:    -keep-alive-section="__DATA,X" > %t/keep-alive-X.id
+; RUN: llvm-cas-object-format --cas %t/cas %t/object.o --ingest-schema=nestedv1 \
+; RUN:    -silent -dead-strip \
+; RUN:    -keep-alive-section="__DATA,X" -keep-alive-section="__DATA,Y" \
+; RUN:    > %t/keep-alive-XY.id
+; RUN: llvm-cas-object-format --cas %t/cas %t/object.o --ingest-schema=nestedv1 \
+; RUN:    -silent -dead-strip-section="__DATA,X" > %t/dead-strip-X.id
+; RUN: llvm-cas-object-format --cas %t/cas %t/object.o --ingest-schema=nestedv1 \
+; RUN:    -silent -dead-strip-section="__DATA,X" -dead-strip-section="__DATA,Y" \
+; RUN:    > %t/dead-strip-XY.id
+; RUN: llvm-cas-object-format --cas %t/cas --print-cas-object @%t/default.id \
+; RUN:   --print-cas-object-sort-sections \
+; RUN:   | FileCheck %s -check-prefixes=CHECK,KEEP-BSS,KEEP-X,KEEP-Y
+; RUN: llvm-cas-object-format --cas %t/cas --print-cas-object @%t/dead-strip.id \
+; RUN:   --print-cas-object-sort-sections \
+; RUN:   | FileCheck %s -check-prefixes=CHECK
+; RUN: llvm-cas-object-format --cas %t/cas --print-cas-object @%t/dead-strip-X.id \
+; RUN:   --print-cas-object-sort-sections \
+; RUN:   | FileCheck %s -check-prefixes=CHECK,KEEP-BSS,KEEP-Y
+; RUN: llvm-cas-object-format --cas %t/cas --print-cas-object @%t/dead-strip-XY.id \
+; RUN:   --print-cas-object-sort-sections \
+; RUN:   | FileCheck %s -check-prefixes=CHECK,KEEP-BSS
+; RUN: llvm-cas-object-format --cas %t/cas --print-cas-object @%t/keep-alive-X.id \
+; RUN:   --print-cas-object-sort-sections \
+; RUN:   | FileCheck %s -check-prefixes=CHECK,KEEP-X
+; RUN: llvm-cas-object-format --cas %t/cas --print-cas-object @%t/keep-alive-XY.id \
+; RUN:   --print-cas-object-sort-sections \
+; RUN:   | FileCheck %s -check-prefixes=CHECK,KEEP-X,KEEP-Y
+
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx12.0.0"
+
+; CHECK-LABEL: SECTION: __DATA,X
+; KEEP-X-NOT:  SYMBOL:
+; KEEP-X:      SYMBOL: _deadX |
+; CHECK-NOT:   SYMBOL:
+; CHECK:       SYMBOL: _liveX |
+; CHECK-NOT:   SYMBOL:
+@deadX = internal global i32 0, section "__DATA,X"
+@liveX = internal global i32 0, section "__DATA,X"
+
+; CHECK-LABEL: SECTION: __DATA,Y
+; KEEP-Y-NOT:  SYMBOL:
+; KEEP-Y:      SYMBOL: _deadY |
+; CHECK-NOT:   SYMBOL:
+; CHECK:       SYMBOL: _liveY |
+; CHECK-NOT:   SYMBOL:
+@deadY = internal global i32 0, section "__DATA,Y"
+@liveY = internal global i32 0, section "__DATA,Y"
+
+; CHECK-LABEL:  SECTION: __DATA,__bss
+; KEEP-BSS-NOT: SYMBOL:
+; KEEP-BSS:     SYMBOL: _dead |
+; CHECK-NOT:    SYMBOL:
+; CHECK:        SYMBOL: _live |
+; CHECK-NOT:    SYMBOL:
+@dead = internal global i32 0
+@live = internal global i32 0
+
+; CHECK-LABEL: SECTION: __DATA,__data
+; CHECK-NOT:   SYMBOL:
+; CHECK:       SYMBOL: _user |
+; CHECK-NOT:   SYMBOL:
+; CHECK:       SYMBOL: _userX |
+; CHECK-NOT:   SYMBOL:
+; CHECK:       SYMBOL: _userY |
+; CHECK-NOT:   SYMBOL:
+@user = global i32* @live
+@userX = global i32* @liveX
+@userY = global i32* @liveY


### PR DESCRIPTION
Stop dropping unreferenced symbols by default. Store them in an extra
table in the compile unit. Among other things, this keeps debug info
alive by default.

There are a few new options:

- `--dead-strip` restores the old behaviour.
- `--dead-strip-section` just dead-strips the named section. Can be
  specified multiple times.
- `--keep-alive-section` keeps the named section alive, adding the
  "no-dead-strip" attribute to any symbols in it. It's stronger than
  the `--dead-strip*` options.