### PR TITLE
[Analyzer] Re-enables trustnonnullchecker_test.m

### DIFF
--- a/clang/test/Analysis/trustnonnullchecker_test.m
+++ b/clang/test/Analysis/trustnonnullchecker_test.m
@@ -1,6 +1,3 @@
-// Temporarily disabling the test, it failes the "system is over-constrained"
-// assertion in *non* optimized builds.
-// REQUIRES: rdar44992170
 // RUN: %clang_analyze_cc1 -fblocks -analyze -analyzer-checker=core,nullability,apiModeling,debug.ExprInspection  -verify %s
 
 #include "Inputs/system-header-simulator-for-nullability.h"


### PR DESCRIPTION
Differential review: https://reviews.llvm.org/D119270

(cherry picked from commit ce420820c815e806bab9c5f17cb3b829a616548a)