### PR TITLE
Add support for the swift5 reflection section acfuncs

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Swift.def
+++ b/llvm/include/llvm/BinaryFormat/Swift.def
@@ -28,3 +28,5 @@ HANDLE_SWIFT_SECTION(conform, "__swift5_proto", "swift5_protocol_confromances",
                      ".sw5prtc$B")
 HANDLE_SWIFT_SECTION(protocs, "__swift5_protos", "swift5_protocols",
                      ".sw5prt$B")
+HANDLE_SWIFT_SECTION(acfuncs, "__swift5_acfuncs", "swift5_accessible_functions",
+                     ".sw5acfn$B")

--- a/llvm/test/tools/dsymutil/Inputs/reflection_metadata.yaml
+++ b/llvm/test/tools/dsymutil/Inputs/reflection_metadata.yaml
@@ -16,12 +16,12 @@ FileHeader:
   cpusubtype:      0x3
   filetype:        0x1
   ncmds:           8
-  sizeofcmds:      2960
+  sizeofcmds:      3040
   flags:           0x2000
   reserved:        0x0
 LoadCommands:
   - cmd:             LC_SEGMENT_64
-    cmdsize:         2712
+    cmdsize:         2792
     segname:         ''
     vmaddr:          0
     vmsize:          21352
@@ -36,7 +36,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x0
         size:            4571
-        offset:          0xBB0
+        offset:          0xC00
         align:           4
         reloff:          0x5CF8
         nreloc:          74
@@ -56,7 +56,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x11DC
         size:            117
-        offset:          0x1D8C
+        offset:          0x1DDC
         align:           1
         reloff:          0x5F48
         nreloc:          22
@@ -77,7 +77,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x1254
         size:            24
-        offset:          0x1E04
+        offset:          0x1E54
         align:           2
         reloff:          0x5FF8
         nreloc:          6
@@ -98,7 +98,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x17D8
         size:            37
-        offset:          0x2388
+        offset:          0x23D8
         align:           0
         reloff:          0x0
         nreloc:          0
@@ -110,7 +110,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x1800
         size:            24
-        offset:          0x23B0
+        offset:          0x2400
         align:           2
         reloff:          0x6530
         nreloc:          8
@@ -131,7 +131,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x1818
         size:            260
-        offset:          0x23C8
+        offset:          0x2418
         align:           2
         reloff:          0x6570
         nreloc:          60
@@ -152,7 +152,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x1AC8
         size:            20
-        offset:          0x2678
+        offset:          0x26C8
         align:           2
         reloff:          0x67F8
         nreloc:          2
@@ -173,7 +173,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x1AEC
         size:            10
-        offset:          0x269C
+        offset:          0x26EC
         align:           2
         reloff:          0x0
         nreloc:          0
@@ -185,7 +185,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x1AF8
         size:            10
-        offset:          0x26C0
+        offset:          0x2710
         align:           2
         reloff:          0x0
         nreloc:          0
@@ -193,11 +193,23 @@ LoadCommands:
         reserved1:       0x0
         reserved2:       0x0
         content:         51525354555657585960
+      - sectname:        __swift5_acfuncs
+        segname:         __TEXT
+        addr:            0x1B04
+        size:            10
+        offset:          0x2734
+        align:           2
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x10000000
+        reserved1:       0x0
+        reserved2:       0x0
+        content:         61626364656667686970
       - sectname:        __bss
         segname:         __DATA
         addr:            0x3372
         size:            2084
-        offset:          0x5150
+        offset:          0x51D0
         align:           3
         reloff:          0x0
         nreloc:          0

--- a/llvm/test/tools/dsymutil/X86/reflection-dump.test
+++ b/llvm/test/tools/dsymutil/X86/reflection-dump.test
@@ -48,3 +48,6 @@ CHECK-NEXT: 10000e258 41424344 45464748 4950               ABCDEFGHIP
 
 CHECK: Contents of section __DWARF,__swift5_protos:
 CHECK-NEXT: 10000e264 51525354 55565758 5960               QRSTUVWXY`
+
+CHECK: Contents of section __DWARF,__swift5_acfuncs:
+CHECK-NEXT: 10000e270 61626364 65666768 6970               abcdefghip


### PR DESCRIPTION
With bc013b3e4e862da8d0c2d91cf99dcbebf124e4ac a new section called accessible functions was added to swift/include/swift/ABI/ObjectFile.h so this change adds support for dumping it out into the dSYM bundle

Differential Revision: https://reviews.llvm.org/D119569

(cherry picked from commit d76da6c7e445478b547a75f81eb1ac9ee93d652b)