### PR TITLE
Don't quote -target cmdline opt to TARGET_SWIFTFLAGS

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -109,7 +109,7 @@ class BuilderDarwin(Builder):
         vendor, os, version, env = get_triple()
         if vendor is None or os is None or version is None or env is None:
             return ""
-        flags = 'TARGET_SWIFTFLAGS="-target {}-{}-{}{}{}"'.format(
+        flags = 'TARGET_SWIFTFLAGS=-target {}-{}-{}{}{}'.format(
             arch, vendor, os, version, (("-"+env) if env else ""))
         return flags
 


### PR DESCRIPTION
Don't quote -target cmdline opt to TARGET_SWIFTFLAGS

The double quote marks are preserved in this makefile setting, so
the -target <triple> command line option & value are passed as a
single word, which is not recognized by swiftc, when running the
testsuite against environments where we need to specify the target
value.  Not normally used when running the testsuite on a native
system.

(cherry picked from commit 3cae3f53038117189953499c6bdfd99fc3c85c62)