### PR TITLE
[lldb] Mark SwiftExtraClangFlags setting as Global

### DIFF
--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -182,6 +182,7 @@ let Definition = "target" in {
     DefaultStringValue<"">,
     Desc<"List of directories to be searched when locating modules for Swift.">;
   def SwiftExtraClangFlags: Property<"swift-extra-clang-flags", "String">,
+    Global,
     DefaultStringValue<"">,
     Desc<"Additional -Xcc flags to be passed to the Swift ClangImporter.">;
   def UseAllCompilerFlags: Property<"use-all-compiler-flags", "Boolean">,


### PR DESCRIPTION
Ensure that flags set using `settings set target.swift-extra-clang-flags <flags>` are passed to the `ClangImporter`.