### PR TITLE
[lldb] Replace asserts on .Success() with assertSuccess()

### DIFF
--- a/lldb/test/API/commands/expression/context-object-objc/TestContextObjectObjc.py
+++ b/lldb/test/API/commands/expression/context-object-objc/TestContextObjectObjc.py
@@ -36,7 +36,7 @@ class ContextObjectObjcTestCase(TestBase):
         # Test retrieving of a field (not a local with the same name)
         value = obj_val.EvaluateExpression("field")
         self.assertTrue(value.IsValid())
-        self.assertTrue(value.GetError().Success())
+        self.assertSuccess(value.GetError())
         self.assertEqual(value.GetValueAsSigned(), 1111)
 
         # Test if the self pointer is properly evaluated

--- a/lldb/test/API/commands/platform/basic/TestPlatformPython.py
+++ b/lldb/test/API/commands/platform/basic/TestPlatformPython.py
@@ -94,5 +94,5 @@ class PlatformPythonTestCase(TestBase):
         self.build()
         sh_cmd.SetShell(self.getBuildArtifact('a.out'))
         err = platform.Run(sh_cmd)
-        self.assertTrue(err.Success())
+        self.assertSuccess(err)
         self.assertIn("SUCCESS", sh_cmd.GetOutput())

--- a/lldb/test/API/commands/watchpoints/multiple_hits/TestMultipleHits.py
+++ b/lldb/test/API/commands/watchpoints/multiple_hits/TestMultipleHits.py
@@ -43,7 +43,7 @@ class MultipleHitsTestCase(TestBase):
 
             error = lldb.SBError()
             watch = member.Watch(True, True, True, error)
-            self.assertTrue(error.Success())
+            self.assertSuccess(error)
 
         process.Continue();
         self.assertEqual(process.GetState(), lldb.eStateStopped)

--- a/lldb/test/API/commands/watchpoints/step_over_watchpoint/TestStepOverWatchpoint.py
+++ b/lldb/test/API/commands/watchpoints/step_over_watchpoint/TestStepOverWatchpoint.py
@@ -55,9 +55,7 @@ class TestStepOverWatchpoint(TestBase):
 
         # resolve_location=True, read=True, write=False
         read_watchpoint = read_value.Watch(True, True, False, error)
-        self.assertTrue(error.Success(),
-                        "Error while setting watchpoint: %s" %
-                        error.GetCString())
+        self.assertSuccess(error, "Error while setting watchpoint")
         self.assertTrue(read_watchpoint, "Failed to set read watchpoint.")
 
         thread.StepOver()
@@ -85,9 +83,7 @@ class TestStepOverWatchpoint(TestBase):
         # resolve_location=True, read=False, write=True
         write_watchpoint = write_value.Watch(True, False, True, error)
         self.assertTrue(write_watchpoint, "Failed to set write watchpoint.")
-        self.assertTrue(error.Success(),
-                        "Error while setting watchpoint: %s" %
-                        error.GetCString())
+        self.assertSuccess(error, "Error while setting watchpoint")
 
         thread.StepOver()
         self.assertEquals(thread.GetStopReason(), lldb.eStopReasonWatchpoint,

--- a/lldb/test/API/functionalities/breakpoint/auto_continue/TestBreakpointAutoContinue.py
+++ b/lldb/test/API/functionalities/breakpoint/auto_continue/TestBreakpointAutoContinue.py
@@ -48,7 +48,7 @@ class BreakpointAutoContinue(TestBase):
         launch_info.SetWorkingDirectory(self.get_process_working_directory())
 
         process = self.target.Launch(launch_info, error)
-        self.assertTrue(error.Success(), "Launch failed.")
+        self.assertSuccess(error, "Launch failed.")
 
         state = process.GetState()
         self.assertEqual(state, expected_state, "Didn't get expected state")

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_command/TestBreakpointCommandsFromPython.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_command/TestBreakpointCommandsFromPython.py
@@ -110,7 +110,7 @@ class PythonBreakpointCommandSettingTestCase(TestBase):
         stream.Print('{"side_effect" : "I am fancy"}')
         extra_args.SetFromJSON(stream)
         error = fancy_bkpt.SetScriptCallbackFunction("bktptcmd.another_function", extra_args)
-        self.assertTrue(error.Success(), "Failed to add callback %s"%(error.GetCString()))
+        self.assertSuccess(error, "Failed to add callback")
 
         stream.Clear()
         stream.Print('{"side_effect" : "I am so much fancier"}')
@@ -123,14 +123,14 @@ class PythonBreakpointCommandSettingTestCase(TestBase):
         # Not so fancy gets an empty extra_args:
         empty_args = lldb.SBStructuredData()
         error = not_so_fancy_bkpt.SetScriptCallbackFunction("bktptcmd.empty_extra_args", empty_args)
-        self.assertTrue(error.Success(), "Failed to add callback %s"%(error.GetCString()))
+        self.assertSuccess(error, "Failed to add callback")
 
         # Do list breakpoint like fancy:
         stream.Clear()
         stream.Print('{"side_effect" : "I come from list input"}')
         extra_args.SetFromJSON(stream)
         error = list_bkpt.SetScriptCallbackFunction("bktptcmd.a_list_function", extra_args)
-        self.assertTrue(error.Success(), "Failed to add callback %s"%(error.GetCString()))
+        self.assertSuccess(error, "Failed to add callback")
         
         # Clear out canary variables
         side_effect.bktptcmd = None

--- a/lldb/test/API/functionalities/breakpoint/scripted_bkpt/TestScriptedResolver.py
+++ b/lldb/test/API/functionalities/breakpoint/scripted_bkpt/TestScriptedResolver.py
@@ -71,7 +71,7 @@ class TestScriptedResolver(TestBase):
         json_stream.Print(json_string)
         extra_args = lldb.SBStructuredData()
         error = extra_args.SetFromJSON(json_stream)
-        self.assertTrue(error.Success(), "Error making SBStructuredData: %s"%(error.GetCString()))
+        self.assertSuccess(error, "Error making SBStructuredData")
         return extra_args
 
     def do_test(self):

--- a/lldb/test/API/functionalities/breakpoint/serialize/TestBreakpointSerialization.py
+++ b/lldb/test/API/functionalities/breakpoint/serialize/TestBreakpointSerialization.py
@@ -119,11 +119,11 @@ class BreakpointSerialization(TestBase):
 
         if (do_write):
             error = self.orig_target.BreakpointsWriteToFile(self.bkpts_file_spec, source_bps)
-            self.assertTrue(error.Success(), "Failed writing breakpoints to file: %s."%(error.GetCString()))
+            self.assertSuccess(error, "Failed writing breakpoints to file")
 
         copy_bps = lldb.SBBreakpointList(self.copy_target)
         error = self.copy_target.BreakpointsCreateFromFile(self.bkpts_file_spec, copy_bps)
-        self.assertTrue(error.Success(), "Failed reading breakpoints from file: %s"%(error.GetCString()))
+        self.assertSuccess(error, "Failed reading breakpoints from file")
 
         num_source_bps = source_bps.GetSize()
         num_copy_bps = copy_bps.GetSize()
@@ -279,7 +279,7 @@ class BreakpointSerialization(TestBase):
 
         error = lldb.SBError()
         error = self.orig_target.BreakpointsWriteToFile(self.bkpts_file_spec, source_bps)
-        self.assertTrue(error.Success(), "Failed writing breakpoints to file: %s."%(error.GetCString()))
+        self.assertSuccess(error, "Failed writing breakpoints to file")
 
         source_bps.Clear()
 
@@ -299,7 +299,7 @@ class BreakpointSerialization(TestBase):
         all_bps.Append(bkpt)
 
         error = self.orig_target.BreakpointsWriteToFile(self.bkpts_file_spec, source_bps, True)
-        self.assertTrue(error.Success(), "Failed appending breakpoints to file: %s."%(error.GetCString()))
+        self.assertSuccess(error, "Failed appending breakpoints to file")
 
         self.check_equivalence(all_bps)
 
@@ -313,19 +313,19 @@ class BreakpointSerialization(TestBase):
 
         error = lldb.SBError()
         error = self.orig_target.BreakpointsWriteToFile(self.bkpts_file_spec, write_bps)
-        self.assertTrue(error.Success(), "Failed writing breakpoints to file: %s."%(error.GetCString()))
+        self.assertSuccess(error, "Failed writing breakpoints to file")
 
         copy_bps = lldb.SBBreakpointList(self.copy_target)
         names_list = lldb.SBStringList()
         names_list.AppendString("NoSuchName")
 
         error = self.copy_target.BreakpointsCreateFromFile(self.bkpts_file_spec, names_list, copy_bps)
-        self.assertTrue(error.Success(), "Failed reading breakpoints from file: %s"%(error.GetCString()))
+        self.assertSuccess(error, "Failed reading breakpoints from file")
         self.assertEqual(copy_bps.GetSize(), 0, "Found breakpoints with a nonexistent name.")
 
         names_list.AppendString(good_bkpt_name)
         error = self.copy_target.BreakpointsCreateFromFile(self.bkpts_file_spec, names_list, copy_bps)
-        self.assertTrue(error.Success(), "Failed reading breakpoints from file: %s"%(error.GetCString()))
+        self.assertSuccess(error, "Failed reading breakpoints from file")
         self.assertEqual(copy_bps.GetSize(), 1, "Found the matching breakpoint.")
 
     def do_check_extra_args(self):
@@ -348,12 +348,12 @@ class BreakpointSerialization(TestBase):
         write_bps = lldb.SBBreakpointList(self.orig_target)
 
         error = self.orig_target.BreakpointsWriteToFile(self.bkpts_file_spec, write_bps)
-        self.assertTrue(error.Success(), "Failed writing breakpoints: %s"%(error.GetCString()))
+        self.assertSuccess(error, "Failed writing breakpoints")
 
         side_effect.g_extra_args = None
         copy_bps = lldb.SBBreakpointList(self.copy_target)
         error = self.copy_target.BreakpointsCreateFromFile(self.bkpts_file_spec, copy_bps)
-        self.assertTrue(error.Success(), "Failed reading breakpoints: %s"%(error.GetCString()))
+        self.assertSuccess(error, "Failed reading breakpoints")
 
         self.assertEqual(copy_bps.GetSize(), 1, "Got one breakpoint from file.")
         no_keys = lldb.SBStringList()
@@ -377,7 +377,7 @@ class BreakpointSerialization(TestBase):
         write_bps = lldb.SBBreakpointList(self.orig_target)
 
         error = self.orig_target.BreakpointsWriteToFile(self.bkpts_file_spec, write_bps)
-        self.assertTrue(error.Success(), "Failed writing breakpoints: %s"%(error.GetCString()))
+        self.assertSuccess(error, "Failed writing breakpoints")
 
         orig_extra_args = side_effect.g_extra_args
         self.assertTrue(orig_extra_args.IsValid(), "Extra args originally valid")
@@ -390,7 +390,7 @@ class BreakpointSerialization(TestBase):
 
         copy_bps = lldb.SBBreakpointList(self.copy_target)
         error = self.copy_target.BreakpointsCreateFromFile(self.bkpts_file_spec, copy_bps)
-        self.assertTrue(error.Success(), "Failed reading breakpoints: %s"%(error.GetCString()))
+        self.assertSuccess(error, "Failed reading breakpoints")
 
         self.assertEqual(copy_bps.GetSize(), 1, "Got one breakpoint from file.")
 

--- a/lldb/test/API/functionalities/dlopen_other_executable/TestDlopenOtherExecutable.py
+++ b/lldb/test/API/functionalities/dlopen_other_executable/TestDlopenOtherExecutable.py
@@ -39,7 +39,7 @@ class TestCase(TestBase):
 
         # Kill the process and run the program again.
         err = self.process().Kill()
-        self.assertTrue(err.Success(), str(err))
+        self.assertSuccess(err)
 
         # Test that we hit the breakpoint after dlopen.
         lldbutil.run_to_breakpoint_do_run(self, self.target(), breakpoint)

--- a/lldb/test/API/functionalities/dyld-launch-linux/TestDyldLaunchLinux.py
+++ b/lldb/test/API/functionalities/dyld-launch-linux/TestDyldLaunchLinux.py
@@ -40,7 +40,7 @@ class TestLinux64LaunchingViaDynamicLoader(TestBase):
         launch_info.SetWorkingDirectory(self.get_process_working_directory())
         error = lldb.SBError()
         process = target.Launch(launch_info, error)
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
 
         # Stopped on main here.
         self.assertEqual(process.GetState(), lldb.eStateStopped)

--- a/lldb/test/API/functionalities/gdb_remote_client/TestJLink6Armv7RegisterDefinition.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestJLink6Armv7RegisterDefinition.py
@@ -189,7 +189,7 @@ class TestJLink6Armv7RegisterDefinition(GDBRemoteTestBase):
         data = lldb.SBData()
         data.SetData(error, val, lldb.eByteOrderBig, 4)
         self.assertEqual(r1_valobj.SetData(data, error), True)
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
 
         r1_valobj = process.GetThreadAtIndex(0).GetFrameAtIndex(0).FindRegister("r1")
         self.assertEqual(r1_valobj.GetValueAsUnsigned(), 0x11223344)

--- a/lldb/test/API/functionalities/gdb_remote_client/TestMemoryRegionDirtyPages.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestMemoryRegionDirtyPages.py
@@ -34,14 +34,14 @@ class TestMemoryRegionDirtyPages(GDBRemoteTestBase):
         # A memory region where we don't know anything about dirty pages
         region = lldb.SBMemoryRegionInfo()
         err = process.GetMemoryRegionInfo(0, region)
-        self.assertTrue(err.Success())
+        self.assertSuccess(err)
         self.assertFalse(region.HasDirtyMemoryPageList())
         self.assertEqual(region.GetNumDirtyPages(), 0)
         region.Clear()
 
         # A memory region with dirty page information -- and zero dirty pages
         err = process.GetMemoryRegionInfo(0x100000000, region)
-        self.assertTrue(err.Success())
+        self.assertSuccess(err)
         self.assertTrue(region.HasDirtyMemoryPageList())
         self.assertEqual(region.GetNumDirtyPages(), 0)
         self.assertEqual(region.GetPageSize(), 4096)
@@ -49,7 +49,7 @@ class TestMemoryRegionDirtyPages(GDBRemoteTestBase):
 
         # A memory region with one dirty page
         err = process.GetMemoryRegionInfo(0x100004000, region)
-        self.assertTrue(err.Success())
+        self.assertSuccess(err)
         self.assertTrue(region.HasDirtyMemoryPageList())
         self.assertEqual(region.GetNumDirtyPages(), 1)
         self.assertEqual(region.GetDirtyPageAddressAtIndex(0), 0x100004000)
@@ -57,7 +57,7 @@ class TestMemoryRegionDirtyPages(GDBRemoteTestBase):
 
         # A memory region with multple dirty pages
         err = process.GetMemoryRegionInfo(0x1000a2000, region)
-        self.assertTrue(err.Success())
+        self.assertSuccess(err)
         self.assertTrue(region.HasDirtyMemoryPageList())
         self.assertEqual(region.GetNumDirtyPages(), 5)
         self.assertEqual(region.GetDirtyPageAddressAtIndex(4), 0x1000a6000)

--- a/lldb/test/API/functionalities/launch_stop_at_entry/TestStopAtEntry.py
+++ b/lldb/test/API/functionalities/launch_stop_at_entry/TestStopAtEntry.py
@@ -86,7 +86,7 @@ class TestStopAtEntry(TestBase):
         error = lldb.SBError()
 
         process = target.Launch(launch_info, error)
-        self.assertTrue(error.Success(), "Launch failed: {0}".format(error.description))
+        self.assertSuccess(error, "Launch failed")
         # If we are asynchronous, we have to wait for the events:
         if not synchronous:
             listener = launch_info.GetListener()
@@ -106,7 +106,7 @@ class TestStopAtEntry(TestBase):
 
         # Now make sure that we can resume the process and have it exit.
         error = process.Continue()
-        self.assertTrue(error.Success(), "Error continuing: {0}".format(error.description))
+        self.assertSuccess(error, "Error continuing")
         # Fetch events till we get eStateExited:
         if not synchronous:
             # Get events till exited.

--- a/lldb/test/API/functionalities/load_using_paths/TestLoadUsingPaths.py
+++ b/lldb/test/API/functionalities/load_using_paths/TestLoadUsingPaths.py
@@ -85,7 +85,7 @@ class LoadUsingPathsTestCase(TestBase):
 
         # Now see that we can call a function in the loaded module.
         value = thread.frames[0].EvaluateExpression("d_function()", lldb.SBExpressionOptions())
-        self.assertTrue(value.GetError().Success(), "Got a value from the expression")
+        self.assertSuccess(value.GetError(), "Got a value from the expression")
         ret_val = value.GetValueAsSigned()
         self.assertEqual(ret_val, 12345, "Got the right value")
 

--- a/lldb/test/API/functionalities/paths/TestPaths.py
+++ b/lldb/test/API/functionalities/paths/TestPaths.py
@@ -49,7 +49,7 @@ class TestPaths(TestBase):
         info_sd = self.dbg.GetScriptInterpreterInfo(self.dbg.GetScriptingLanguage("python"))
         self.assertTrue(info_sd.IsValid())
         stream = lldb.SBStream()
-        self.assertTrue(info_sd.GetAsJSON(stream).Success())
+        self.assertSuccess(info_sd.GetAsJSON(stream))
         info = json.loads(stream.GetData())
         prefix = info['prefix']
         self.assertEqual(os.path.realpath(sys.prefix), os.path.realpath(prefix))

--- a/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
+++ b/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
@@ -109,7 +109,7 @@ class LinuxCoreTestCase(TestBase):
         error = lldb.SBError()
         F = altprocess.ReadCStringFromMemory(
             altframe.FindVariable("F").GetValueAsUnsigned(), 256, error)
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
         self.assertEqual(F, "_start")
 
         # without destroying this process, run the test which opens another core file with the

--- a/lldb/test/API/functionalities/postmortem/minidump-new/TestMiniDumpNew.py
+++ b/lldb/test/API/functionalities/postmortem/minidump-new/TestMiniDumpNew.py
@@ -65,7 +65,7 @@ class MiniDumpNewTestCase(TestBase):
         error = lldb.SBError()
         self.process = self.target.LoadCore(minidump_path, error)
         self.assertTrue(self.process, PROCESS_IS_VALID)
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
 
     def test_loadcore_error_status_failure(self):
         """Test the SBTarget.LoadCore(core, error) overload."""

--- a/lldb/test/API/functionalities/postmortem/minidump/TestMiniDump.py
+++ b/lldb/test/API/functionalities/postmortem/minidump/TestMiniDump.py
@@ -123,7 +123,7 @@ class MiniDumpTestCase(TestBase):
             self.assertEqual(process.GetState(), lldb.eStateStopped)
             self.assertTrue(process.SaveCore(core))
             self.assertTrue(os.path.isfile(core))
-            self.assertTrue(process.Kill().Success())
+            self.assertSuccess(process.Kill())
 
             # Launch with the mini dump, and inspect the stack.
             target = self.dbg.CreateTarget(None)
@@ -159,7 +159,7 @@ class MiniDumpTestCase(TestBase):
             self.assertEqual(process.GetState(), lldb.eStateStopped)
             self.assertTrue(process.SaveCore(core))
             self.assertTrue(os.path.isfile(core))
-            self.assertTrue(process.Kill().Success())
+            self.assertSuccess(process.Kill())
 
             # Launch with the mini dump, and inspect a local variable.
             target = self.dbg.CreateTarget(None)

--- a/lldb/test/API/functionalities/process_crash_info/TestProcessCrashInfo.py
+++ b/lldb/test/API/functionalities/process_crash_info/TestProcessCrashInfo.py
@@ -63,7 +63,7 @@ class PlatformProcessCrashInfoTestCase(TestBase):
 
         error = crash_info.GetAsJSON(stream)
 
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
 
         self.assertTrue(crash_info.IsValid())
 

--- a/lldb/test/API/functionalities/process_save_core/TestProcessSaveCore.py
+++ b/lldb/test/API/functionalities/process_save_core/TestProcessSaveCore.py
@@ -43,7 +43,7 @@ class ProcessSaveCoreTestCase(TestBase):
             self.assertEqual(process.GetState(), lldb.eStateStopped)
             self.assertTrue(process.SaveCore(core))
             self.assertTrue(os.path.isfile(core))
-            self.assertTrue(process.Kill().Success())
+            self.assertSuccess(process.Kill())
 
             # To verify, we'll launch with the mini dump, and ensure that we see
             # the executable in the module list.
@@ -77,7 +77,7 @@ class ProcessSaveCoreTestCase(TestBase):
             self.assertEqual(process.GetState(), lldb.eStateStopped)
             self.assertTrue(process.SaveCore(core))
             self.assertTrue(os.path.isfile(core))
-            self.assertTrue(process.Kill().Success())
+            self.assertSuccess(process.Kill())
             pid = process.GetProcessID()
 
             target = self.dbg.CreateTarget(None)

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
@@ -43,7 +43,7 @@ class ProcessSaveCoreMinidumpTestCase(TestBase):
             # save core and, kill process and verify corefile existence
             self.runCmd("process save-core --plugin-name=minidump --style=stack " + core)
             self.assertTrue(os.path.isfile(core))
-            self.assertTrue(process.Kill().Success())
+            self.assertSuccess(process.Kill())
 
             # To verify, we'll launch with the mini dump
             target = self.dbg.CreateTarget(None)

--- a/lldb/test/API/functionalities/return-value/TestReturnValue.py
+++ b/lldb/test/API/functionalities/return-value/TestReturnValue.py
@@ -50,7 +50,7 @@ class ReturnValueTestCase(TestBase):
         # inner_sint returns the variable value, so capture that here:
         in_int = thread.GetFrameAtIndex(0).FindVariable(
             "value").GetValueAsSigned(error)
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
 
         thread.StepOut()
 
@@ -65,7 +65,7 @@ class ReturnValueTestCase(TestBase):
         self.assertTrue(return_value.IsValid())
 
         ret_int = return_value.GetValueAsSigned(error)
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
         self.assertEquals(in_int, ret_int)
 
         # Run again and we will stop in inner_sint the second time outer_sint is called.
@@ -82,7 +82,7 @@ class ReturnValueTestCase(TestBase):
         fun_name = frame.GetFunctionName()
         self.assertEquals(fun_name, "outer_sint(int)")
         in_int = frame.FindVariable("value").GetValueAsSigned(error)
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
 
         thread.StepOutOfFrame(frame)
 
@@ -95,7 +95,7 @@ class ReturnValueTestCase(TestBase):
         ret_value = thread.GetStopReturnValue()
         self.assertTrue(return_value.IsValid())
         ret_int = ret_value.GetValueAsSigned(error)
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
         self.assertEquals(2 * in_int, ret_int)
 
         # Now try some simple returns that have different types:

--- a/lldb/test/API/functionalities/scripted_process/TestScriptedProcess.py
+++ b/lldb/test/API/functionalities/scripted_process/TestScriptedProcess.py
@@ -70,7 +70,7 @@ class ScriptedProcesTestCase(TestBase):
 
         process = target.Launch(launch_info, error)
 
-        self.assertTrue(error.Success(), error.GetCString())
+        self.assertSuccess(error)
         self.assertTrue(process, PROCESS_IS_VALID)
         self.assertEqual(process.GetProcessID(), 666)
         self.assertEqual(process.GetNumThreads(), 0)

--- a/lldb/test/API/functionalities/scripted_process/TestStackCoreScriptedProcess.py
+++ b/lldb/test/API/functionalities/scripted_process/TestStackCoreScriptedProcess.py
@@ -48,7 +48,7 @@ class StackCoreScriptedProcesTestCase(TestBase):
 
         self.assertTrue(main_module, "Invalid main module.")
         error = target.SetModuleLoadAddress(main_module, 0)
-        self.assertTrue(error.Success(), "Reloading main module at offset 0 failed.")
+        self.assertSuccess(error, "Reloading main module at offset 0 failed.")
 
         os.environ['SKIP_SCRIPTED_PROCESS_LAUNCH'] = '1'
         def cleanup():
@@ -77,7 +77,7 @@ class StackCoreScriptedProcesTestCase(TestBase):
 
         error = lldb.SBError()
         process = target.Launch(launch_info, error)
-        self.assertTrue(error.Success(), error.GetCString())
+        self.assertSuccess(error)
         self.assertTrue(process, PROCESS_IS_VALID)
         self.assertEqual(process.GetProcessID(), 42)
 

--- a/lldb/test/API/functionalities/step_scripted/TestStepScripted.py
+++ b/lldb/test/API/functionalities/step_scripted/TestStepScripted.py
@@ -39,7 +39,7 @@ class StepScriptedTestCase(TestBase):
         self.assertEqual("foo", frame.GetFunctionName())
 
         err = thread.StepUsingScriptedThreadPlan(name)
-        self.assertTrue(err.Success(), err.GetCString())
+        self.assertSuccess(err)
 
         frame = thread.GetFrameAtIndex(0)
         self.assertEqual("main", frame.GetFunctionName())
@@ -80,7 +80,7 @@ class StepScriptedTestCase(TestBase):
         frame = thread.GetFrameAtIndex(0)
         self.assertEqual("foo", frame.GetFunctionName())
         foo_val = frame.FindVariable("foo")
-        self.assertTrue(foo_val.GetError().Success(), "Got the foo variable")
+        self.assertSuccess(foo_val.GetError(), "Got the foo variable")
         self.assertEqual(foo_val.GetValueAsUnsigned(), 10, "foo starts at 10")
 
         if use_cli:
@@ -94,10 +94,10 @@ class StepScriptedTestCase(TestBase):
             data = lldb.SBStream()
             data.Print('{"variable_name" : "foo"}')
             error = args_data.SetFromJSON(data)
-            self.assertTrue(error.Success(), "Made the args_data correctly")
+            self.assertSuccess(error, "Made the args_data correctly")
 
             err = thread.StepUsingScriptedThreadPlan("Steps.StepUntil", args_data, True)
-            self.assertTrue(err.Success(), err.GetCString())
+            self.assertSuccess(err)
 
         # We should not have exited:
         self.assertEqual(process.GetState(), lldb.eStateStopped, "We are stopped")

--- a/lldb/test/API/functionalities/thread/exit_during_expression/TestExitDuringExpression.py
+++ b/lldb/test/API/functionalities/thread/exit_during_expression/TestExitDuringExpression.py
@@ -72,7 +72,7 @@ class TestExitDuringExpression(TestBase):
 
         error = lldb.SBError()
         timeout_value = g_timeout.GetValueAsUnsigned(error)
-        self.assertTrue(error.Success(), "Couldn't get timeout value: %s"%(error.GetCString()))
+        self.assertSuccess(error, "Couldn't get timeout value")
 
         one_thread_timeout = 0
         if (before_one_thread_timeout):
@@ -105,7 +105,7 @@ class TestExitDuringExpression(TestBase):
         # Now get the return value, if we successfully caused the thread to exit
         # it should be 10, not 20.
         ret_val = frame.FindVariable("ret_val")
-        self.assertTrue(ret_val.GetError().Success(), "Found ret_val")
+        self.assertSuccess(ret_val.GetError(), "Found ret_val")
         ret_val_value = ret_val.GetValueAsSigned(error)
-        self.assertTrue(error.Success(), "Got ret_val's value")
+        self.assertSuccess(error, "Got ret_val's value")
         self.assertEqual(ret_val_value, 10, "We put the right value in ret_val")

--- a/lldb/test/API/functionalities/thread/state_after_expression/TestStateAfterExpression.py
+++ b/lldb/test/API/functionalities/thread/state_after_expression/TestStateAfterExpression.py
@@ -43,8 +43,7 @@ class TestStopReasonAfterExpression(TestBase):
         options.SetStopOthers(True)
 
         result = thread.frames[0].EvaluateExpression('(int) printf("Hello\\n")', options)
-        self.assertTrue(result.GetError().Success(),
-                        "Expression failed: '%s'"%(result.GetError().GetCString()))
+        self.assertSuccess(result.GetError(), "Expression failed")
 
         stop_reason = other_thread.GetStopReason()
 

--- a/lldb/test/API/functionalities/var_path/TestVarPath.py
+++ b/lldb/test/API/functionalities/var_path/TestVarPath.py
@@ -24,7 +24,7 @@ class TestVarPath(TestBase):
 
     def verify_point(self, frame, var_name, var_typename, x_value, y_value):
         v = frame.GetValueForVariablePath(var_name)
-        self.assertTrue(v.GetError().Success(), "Make sure we find '%s'" % (var_name))
+        self.assertSuccess(v.GetError(), "Make sure we find '%s'" % (var_name))
         self.assertEquals(v.GetType().GetName(), var_typename,
                         "Make sure '%s' has type '%s'" % (var_name, var_typename))
 
@@ -42,14 +42,14 @@ class TestVarPath(TestBase):
         invalid_m_path = invalid_prefix + 'm'
 
         v = frame.GetValueForVariablePath(valid_x_path)
-        self.assertTrue(v.GetError().Success(), "Make sure we find '%s'" % (valid_x_path))
+        self.assertSuccess(v.GetError(), "Make sure we find '%s'" % (valid_x_path))
         self.assertEquals(v.GetValue(), str(x_value), "Make sure '%s' has a value of %i" % (valid_x_path, x_value))
         self.assertEquals(v.GetType().GetName(), "int", "Make sure '%s' has type 'int'" % (valid_x_path))
         v = frame.GetValueForVariablePath(invalid_x_path)
         self.assertTrue(v.GetError().Fail(), "Make sure we don't find '%s'" % (invalid_x_path))
 
         v = frame.GetValueForVariablePath(valid_y_path)
-        self.assertTrue(v.GetError().Success(), "Make sure we find '%s'" % (valid_y_path))
+        self.assertSuccess(v.GetError(), "Make sure we find '%s'" % (valid_y_path))
         self.assertEquals(v.GetValue(), str(y_value), "Make sure '%s' has a value of %i" % (valid_y_path, y_value))
         self.assertEquals(v.GetType().GetName(), "int", "Make sure '%s' has type 'int'" % (valid_y_path))
         v = frame.GetValueForVariablePath(invalid_y_path)
@@ -76,8 +76,7 @@ class TestVarPath(TestBase):
         self.verify_point(frame, 'pt_ptr[1]', 'Point', 5050, 6060)
         # Test arrays
         v = frame.GetValueForVariablePath('points')
-        self.assertTrue(v.GetError().Success(),
-                        "Make sure we find 'points'")
+        self.assertSuccess(v.GetError(), "Make sure we find 'points'")
         self.verify_point(frame, 'points[0]', 'Point', 1010, 2020)
         self.verify_point(frame, 'points[1]', 'Point', 3030, 4040)
         self.verify_point(frame, 'points[2]', 'Point', 5050, 6060)
@@ -87,7 +86,7 @@ class TestVarPath(TestBase):
         # Test a reference
         self.verify_point(frame, 'pt_ref', 'Point &', 1, 2)
         v = frame.GetValueForVariablePath('pt_sp')
-        self.assertTrue(v.GetError().Success(), "Make sure we find 'pt_sp'")
+        self.assertSuccess(v.GetError(), "Make sure we find 'pt_sp'")
         # Make sure we don't crash when looking for non existant child
         # in type with synthetic children. This used to cause a crash.
         v = frame.GetValueForVariablePath('pt_sp->not_valid_child')

--- a/lldb/test/API/lang/c/local_types/TestUseClosestType.py
+++ b/lldb/test/API/lang/c/local_types/TestUseClosestType.py
@@ -29,7 +29,7 @@ class TestUseClosestType(TestBase):
     def run_and_check_expr(self, num_children, child_type):
         frame = self.thread.GetFrameAtIndex(0)
         result = frame.EvaluateExpression("struct Foo *$mine = (struct Foo *) malloc(sizeof(struct Foo)); $mine")
-        self.assertTrue(result.GetError().Success(), "Failed to parse an expression using a multiply defined type: %s"%(result.GetError().GetCString()), )
+        self.assertSuccess(result.GetError(), "Failed to parse an expression using a multiply defined type")
         self.assertEqual(result.GetTypeName(), "struct Foo *", "The result has the right typename.")
         self.assertEqual(result.GetNumChildren(), num_children, "Got the right number of children")
         self.assertEqual(result.GetChildAtIndex(0).GetTypeName(), child_type, "Got the right type.")

--- a/lldb/test/API/lang/cpp/incomplete-types/TestCppIncompleteTypes.py
+++ b/lldb/test/API/lang/cpp/incomplete-types/TestCppIncompleteTypes.py
@@ -17,13 +17,13 @@ class TestCppIncompleteTypes(TestBase):
         self.assertTrue(
             value_f.IsValid(),
             "'expr f' results in a valid SBValue object")
-        self.assertTrue(value_f.GetError().Success(), "'expr f' is successful")
+        self.assertSuccess(value_f.GetError(), "'expr f' is successful")
 
         value_a = frame.EvaluateExpression("a")
         self.assertTrue(
             value_a.IsValid(),
             "'expr a' results in a valid SBValue object")
-        self.assertTrue(value_a.GetError().Success(), "'expr a' is successful")
+        self.assertSuccess(value_a.GetError(), "'expr a' is successful")
 
     @skipIf(compiler="gcc")
     # Clang on Windows asserts in external record layout in this case.
@@ -36,13 +36,13 @@ class TestCppIncompleteTypes(TestBase):
         self.assertTrue(
             value_f.IsValid(),
             "'expr f' results in a valid SBValue object")
-        self.assertTrue(value_f.GetError().Success(), "'expr f' is successful")
+        self.assertSuccess(value_f.GetError(), "'expr f' is successful")
 
         value_a = frame.EvaluateExpression("a")
         self.assertTrue(
             value_a.IsValid(),
             "'expr a' results in a valid SBValue object")
-        self.assertTrue(value_a.GetError().Success(), "'expr a' is successful")
+        self.assertSuccess(value_a.GetError(), "'expr a' is successful")
 
     def get_test_frame(self, exe):
         # Get main source file

--- a/lldb/test/API/lang/cpp/trivial_abi/TestTrivialABI.py
+++ b/lldb/test/API/lang/cpp/trivial_abi/TestTrivialABI.py
@@ -38,9 +38,9 @@ class TestTrivialABI(TestBase):
         self.expr_test(False)
 
     def check_value(self, test_var, ivar_value):
-        self.assertTrue(test_var.GetError().Success(), "Invalid valobj: %s"%(test_var.GetError().GetCString()))
+        self.assertSuccess(test_var.GetError(), "Invalid valobj")
         ivar = test_var.GetChildMemberWithName("ivar")
-        self.assertTrue(test_var.GetError().Success(), "Failed to fetch ivar")
+        self.assertSuccess(test_var.GetError(), "Failed to fetch ivar")
         self.assertEqual(ivar_value, ivar.GetValueAsSigned(), "Got the right value for ivar")
 
     def check_frame(self, thread):

--- a/lldb/test/API/lang/cpp/type_lookup/TestCppTypeLookup.py
+++ b/lldb/test/API/lang/cpp/type_lookup/TestCppTypeLookup.py
@@ -14,12 +14,10 @@ class TestCppTypeLookup(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     def check_value(self, value, ivar_name, ivar_value):
-        self.assertTrue(value.GetError().Success(),
-                        "Invalid valobj: %s" % (
-                                value.GetError().GetCString()))
+        self.assertSuccess(value.GetError(), "Invalid valobj")
         ivar = value.GetChildMemberWithName(ivar_name)
-        self.assertTrue(ivar.GetError().Success(),
-                        "Failed to fetch ivar named '%s'" % (ivar_name))
+        self.assertSuccess(ivar.GetError(),
+                           "Failed to fetch ivar named '%s'" % (ivar_name))
         self.assertEqual(ivar_value,
                          ivar.GetValueAsSigned(),
                          "Got the right value for ivar")

--- a/lldb/test/API/lang/objc/blocks/TestObjCIvarsInBlocks.py
+++ b/lldb/test/API/lang/objc/blocks/TestObjCIvarsInBlocks.py
@@ -68,10 +68,10 @@ class TestObjCIvarsInBlocks(TestBase):
 
         error = lldb.SBError()
         direct_value = direct_blocky.GetValueAsSigned(error)
-        self.assertTrue(error.Success(), "Got direct value for blocky_ivar")
+        self.assertSuccess(error, "Got direct value for blocky_ivar")
 
         indirect_value = indirect_blocky.GetValueAsSigned(error)
-        self.assertTrue(error.Success(), "Got indirect value for blocky_ivar")
+        self.assertSuccess(error, "Got indirect value for blocky_ivar")
 
         self.assertEqual(
             direct_value, indirect_value,

--- a/lldb/test/API/lang/objc/global_ptrs/TestGlobalObjects.py
+++ b/lldb/test/API/lang/objc/global_ptrs/TestGlobalObjects.py
@@ -31,7 +31,7 @@ class TestObjCGlobalVar(TestBase):
 
         # Before we launch, make an SBValue for our global object pointer:
         g_obj_ptr = target.FindFirstGlobalVariable("g_obj_ptr")
-        self.assertTrue(g_obj_ptr.GetError().Success(), "Made the g_obj_ptr")
+        self.assertSuccess(g_obj_ptr.GetError(), "Made the g_obj_ptr")
         self.assertEqual(
             g_obj_ptr.GetValueAsUnsigned(10), 0,
             "g_obj_ptr is initially null")

--- a/lldb/test/API/lang/objc/objc-checker/TestObjCCheckers.py
+++ b/lldb/test/API/lang/objc/objc-checker/TestObjCCheckers.py
@@ -85,5 +85,5 @@ class ObjCCheckerTestCase(TestBase):
         expr_value = frame.EvaluateExpression("[my_simple getBigStruct]", False)
         expr_error = expr_value.GetError()
         
-        self.assertTrue(expr_error.Success())
+        self.assertSuccess(expr_error)
         

--- a/lldb/test/API/lang/objc/objc-ivar-offsets/TestObjCIvarOffsets.py
+++ b/lldb/test/API/lang/objc/objc-ivar-offsets/TestObjCIvarOffsets.py
@@ -60,7 +60,7 @@ class TestObjCIvarOffsets(TestBase):
             mine_backed_int,
             "Found mine->backed_int local variable.")
         backed_value = mine_backed_int.GetValueAsSigned(error)
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
         self.assertEquals(backed_value, 1111)
 
         # Test the value object value for DerivedClass->_derived_backed_int
@@ -70,7 +70,7 @@ class TestObjCIvarOffsets(TestBase):
         self.assertTrue(mine_derived_backed_int,
                         "Found mine->derived_backed_int local variable.")
         derived_backed_value = mine_derived_backed_int.GetValueAsSigned(error)
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
         self.assertEquals(derived_backed_value, 3333)
 
         # Make sure we also get bit-field offsets correct:
@@ -78,5 +78,5 @@ class TestObjCIvarOffsets(TestBase):
         mine_flag2 = mine.GetChildMemberWithName("flag2")
         self.assertTrue(mine_flag2, "Found mine->flag2 local variable.")
         flag2_value = mine_flag2.GetValueAsUnsigned(error)
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
         self.assertEquals(flag2_value, 7)

--- a/lldb/test/API/lang/objc/objc-ivar-stripped/TestObjCIvarStripped.py
+++ b/lldb/test/API/lang/objc/objc-ivar-stripped/TestObjCIvarStripped.py
@@ -62,5 +62,5 @@ class TestObjCIvarStripped(TestBase):
         ivar = frame.EvaluateExpression("(mc->_foo)")
         self.assertTrue(ivar, "Got result for mc->_foo")
         ivar_value = ivar.GetValueAsSigned(error)
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
         self.assertEquals(ivar_value, 3)

--- a/lldb/test/API/lang/objc/objc-property/TestObjCProperty.py
+++ b/lldb/test/API/lang/objc/objc-property/TestObjCProperty.py
@@ -71,7 +71,7 @@ class ObjCPropertyTestCase(TestBase):
         nonexistant_value = frame.EvaluateExpression(
             "mine.nonexistantInt", False)
         nonexistant_error = nonexistant_value.GetError()
-        self.assertTrue(nonexistant_error.Success())
+        self.assertSuccess(nonexistant_error)
         nonexistant_int = nonexistant_value.GetValueAsUnsigned(123456)
         self.assertEquals(nonexistant_int, 6)
 
@@ -87,7 +87,7 @@ class ObjCPropertyTestCase(TestBase):
         nonexistant_change = frame.EvaluateExpression(
             "mine.nonexistantInt = 10", False)
         nonexistant_error = nonexistant_change.GetError()
-        self.assertTrue(nonexistant_error.Success())
+        self.assertSuccess(nonexistant_error)
 
         # Calling the setter function would up the access count, so make sure
         # that happened.
@@ -103,39 +103,39 @@ class ObjCPropertyTestCase(TestBase):
 
         backed_value = frame.EvaluateExpression("mine.backedInt", False)
         backed_error = backed_value.GetError()
-        self.assertTrue(backed_error.Success())
+        self.assertSuccess(backed_error)
         backing_value = mine.GetChildMemberWithName("_backedInt")
         self.assertTrue(backing_value.IsValid())
         self.assertTrue(backed_value.GetValueAsUnsigned(12345)
                         == backing_value.GetValueAsUnsigned(23456))
 
         value_from_typedef = frame.EvaluateExpression("typedefd.backedInt", False)
-        self.assertTrue(value_from_typedef.GetError().Success())
+        self.assertSuccess(value_from_typedef.GetError())
         self.assertEqual(value_from_typedef.GetValueAsUnsigned(12345),
                          backing_value.GetValueAsUnsigned(23456))
 
         unbacked_value = frame.EvaluateExpression("mine.unbackedInt", False)
         unbacked_error = unbacked_value.GetError()
-        self.assertTrue(unbacked_error.Success())
+        self.assertSuccess(unbacked_error)
 
         idWithProtocol_value = frame.EvaluateExpression(
             "mine.idWithProtocol", False)
         idWithProtocol_error = idWithProtocol_value.GetError()
-        self.assertTrue(idWithProtocol_error.Success())
+        self.assertSuccess(idWithProtocol_error)
         self.assertEquals(idWithProtocol_value.GetTypeName(), "id")
 
         # Make sure that class property getter works as expected
         value = frame.EvaluateExpression("BaseClass.classInt", False)
-        self.assertTrue(value.GetError().Success())
+        self.assertSuccess(value.GetError())
         self.assertEquals(value.GetValueAsUnsigned(11111), 123)
 
         # Make sure that class property setter works as expected
         value = frame.EvaluateExpression("BaseClass.classInt = 234", False)
-        self.assertTrue(value.GetError().Success())
+        self.assertSuccess(value.GetError())
 
         # Verify that setter above actually worked
         value = frame.EvaluateExpression("BaseClass.classInt", False)
-        self.assertTrue(value.GetError().Success())
+        self.assertSuccess(value.GetError())
         self.assertEquals(value.GetValueAsUnsigned(11111), 234)
 
         # Test that accessing two distinct class and instance properties that

--- a/lldb/test/API/macosx/function-starts/TestFunctionStarts.py
+++ b/lldb/test/API/macosx/function-starts/TestFunctionStarts.py
@@ -65,7 +65,7 @@ class FunctionStartsTestCase(TestBase):
         attach_info.SetProcessID(popen.pid)
         attach_info.SetIgnoreExisting(False)
         process = target.Attach(attach_info, error)
-        self.assertTrue(error.Success(), "Didn't attach successfully to %d: %s"%(popen.pid, error.GetCString()))
+        self.assertSuccess(error, "Didn't attach successfully to %d"%(popen.pid))
 
         bkpt = target.BreakpointCreateByName("dont_strip_me", exe)
         self.assertTrue(bkpt.GetNumLocations() > 0, "Didn't set the dont_strip_me bkpt.")

--- a/lldb/test/API/macosx/profile_vrs_detach/TestDetachVrsProfile.py
+++ b/lldb/test/API/macosx/profile_vrs_detach/TestDetachVrsProfile.py
@@ -73,4 +73,4 @@ class TestDetachVrsProfile(TestBase):
 
         # Now detach:
         error = process.Detach()
-        self.assertTrue(error.Success(), "Detached successfully")
+        self.assertSuccess(error, "Detached successfully")

--- a/lldb/test/API/macosx/thread_suspend/TestInternalThreadSuspension.py
+++ b/lldb/test/API/macosx/thread_suspend/TestInternalThreadSuspension.py
@@ -34,7 +34,7 @@ class TestSuspendedThreadHandling(TestBase):
         frame = thread.frames[0]
 
         value = frame.EvaluateExpression('function_to_call()')
-        self.assertTrue(value.GetError().Success(), "Successfully called the function")
+        self.assertSuccess(value.GetError(), "Successfully called the function")
         self.assertEqual(value.GetValueAsSigned(), correct_value, "Got expected value for expression")
 
         # Again, make sure we didn't let the suspend thread breakpoint run:

--- a/lldb/test/API/macosx/universal/TestUniversal.py
+++ b/lldb/test/API/macosx/universal/TestUniversal.py
@@ -143,7 +143,7 @@ class UniversalTestCase(TestBase):
         empty_listener = lldb.SBListener()
         process = target.AttachToProcessWithID(
             empty_listener, popen.pid, error)
-        self.assertTrue(error.Success(), "Attached to process.")
+        self.assertSuccess(error, "Attached to process.")
 
         self.expect("image list -A -b", substrs=["x86_64h testit"])
 

--- a/lldb/test/API/python_api/debugger/TestDebuggerAPI.py
+++ b/lldb/test/API/python_api/debugger/TestDebuggerAPI.py
@@ -81,8 +81,8 @@ class DebuggerAPITestCase(TestBase):
         error = self.dbg.SetInternalVariable(property_name,
                                              str(new_cache_line_size),
                                              self.dbg.GetInstanceName())
-        self.assertTrue(error.Success(),
-                        property_name + " value was changed successfully")
+        self.assertSuccess(error,
+                           property_name + " value was changed successfully")
 
         # Check that it was set actually.
         self.assertEqual(get_cache_line_size(), new_cache_line_size)

--- a/lldb/test/API/python_api/file_handle/TestFileHandle.py
+++ b/lldb/test/API/python_api/file_handle/TestFileHandle.py
@@ -183,7 +183,7 @@ class FileHandleTestCase(lldbtest.TestBase):
             sbf = lldb.SBFile(f.fileno(), "w", False)
             self.assertTrue(sbf.IsValid())
             e, n = sbf.Write(b'FOO\nBAR')
-            self.assertTrue(e.Success())
+            self.assertSuccess(e)
             self.assertEqual(n, 7)
             sbf.Close()
             self.assertFalse(sbf.IsValid())
@@ -195,7 +195,7 @@ class FileHandleTestCase(lldbtest.TestBase):
         with open(self.out_filename, 'w') as f:
             sbf = lldb.SBFile(f)
             e, n = sbf.Write(b'FOO\n')
-            self.assertTrue(e.Success())
+            self.assertSuccess(e)
             self.assertEqual(n, 4)
             sbf.Close()
             self.assertTrue(f.closed)
@@ -211,7 +211,7 @@ class FileHandleTestCase(lldbtest.TestBase):
             self.assertTrue(sbf.IsValid())
             buffer = bytearray(100)
             e, n = sbf.Read(buffer)
-            self.assertTrue(e.Success())
+            self.assertSuccess(e)
             self.assertEqual(buffer[:n], b'FOO')
 
 
@@ -222,7 +222,7 @@ class FileHandleTestCase(lldbtest.TestBase):
             sbf = lldb.SBFile(f)
             buf = bytearray(100)
             e, n = sbf.Read(buf)
-            self.assertTrue(e.Success())
+            self.assertSuccess(e)
             self.assertEqual(n, 3)
             self.assertEqual(buf[:n], b'foo')
             sbf.Close()
@@ -233,7 +233,7 @@ class FileHandleTestCase(lldbtest.TestBase):
         with open(self.out_filename, 'w') as f:
             sbf = lldb.SBFile(f.fileno(), "w", False)
             status = self.dbg.SetOutputFile(sbf)
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
             self.handleCmd('script 1+2')
             self.dbg.GetOutputFile().Write(b'quux')
             self.dbg.GetOutputFile().Flush()
@@ -246,7 +246,7 @@ class FileHandleTestCase(lldbtest.TestBase):
         with open(self.out_filename, 'w') as f:
             sbf = lldb.SBFile(f.fileno(), "w", False)
             status = self.dbg.SetOutputFile(sbf)
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
             self.handleCmd("help help", collect_result=False, check=False)
         with open(self.out_filename, 'r') as f:
             self.assertTrue(re.search(r'Show a list of all debugger commands', f.read()))
@@ -255,7 +255,7 @@ class FileHandleTestCase(lldbtest.TestBase):
     def test_help(self):
         with open(self.out_filename, 'w') as f:
             status = self.dbg.SetOutputFile(lldb.SBFile(f))
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
             self.handleCmd("help help", check=False, collect_result=False)
         with open(self.out_filename, 'r') as f:
             self.assertIn('Show a list of all debugger commands', f.read())
@@ -313,11 +313,11 @@ class FileHandleTestCase(lldbtest.TestBase):
 
             outsbf = lldb.SBFile(outf.fileno(), "w", False)
             status = self.dbg.SetOutputFile(outsbf)
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
 
             insbf = lldb.SBFile(inf.fileno(), "r", False)
             status = self.dbg.SetInputFile(insbf)
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
 
             opts = lldb.SBCommandInterpreterRunOptions()
             self.dbg.RunCommandInterpreter(True, False, opts, 0, False, False)
@@ -333,9 +333,9 @@ class FileHandleTestCase(lldbtest.TestBase):
         with  open(self.out_filename, 'w') as outf, \
               open(self.in_filename, 'r') as inf:
             status = self.dbg.SetOutputFile(lldb.SBFile(outf))
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
             status = self.dbg.SetInputFile(lldb.SBFile(inf))
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
             opts = lldb.SBCommandInterpreterRunOptions()
             self.dbg.RunCommandInterpreter(True, False, opts, 0, False, False)
             self.dbg.GetOutputFile().Flush()
@@ -350,9 +350,9 @@ class FileHandleTestCase(lldbtest.TestBase):
         with  open(self.out_filename, 'wb') as outf, \
               open(self.in_filename, 'rb') as inf:
             status = self.dbg.SetOutputFile(lldb.SBFile(outf))
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
             status = self.dbg.SetInputFile(lldb.SBFile(inf))
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
             opts = lldb.SBCommandInterpreterRunOptions()
             self.dbg.RunCommandInterpreter(True, False, opts, 0, False, False)
             self.dbg.GetOutputFile().Flush()
@@ -366,9 +366,9 @@ class FileHandleTestCase(lldbtest.TestBase):
         inf = io.StringIO("help help\np/x ~0\n")
         outf = io.StringIO()
         status = self.dbg.SetOutputFile(lldb.SBFile(outf))
-        self.assertTrue(status.Success())
+        self.assertSuccess(status)
         status = self.dbg.SetInputFile(lldb.SBFile(inf))
-        self.assertTrue(status.Success())
+        self.assertSuccess(status)
         opts = lldb.SBCommandInterpreterRunOptions()
         self.dbg.RunCommandInterpreter(True, False, opts, 0, False, False)
         self.dbg.GetOutputFile().Flush()
@@ -382,9 +382,9 @@ class FileHandleTestCase(lldbtest.TestBase):
         inf = io.BytesIO(b"help help\nhelp b\n")
         outf = io.BytesIO()
         status = self.dbg.SetOutputFile(lldb.SBFile(outf))
-        self.assertTrue(status.Success())
+        self.assertSuccess(status)
         status = self.dbg.SetInputFile(lldb.SBFile(inf))
-        self.assertTrue(status.Success())
+        self.assertSuccess(status)
         opts = lldb.SBCommandInterpreterRunOptions()
         self.dbg.RunCommandInterpreter(True, False, opts, 0, False, False)
         self.dbg.GetOutputFile().Flush()
@@ -398,7 +398,7 @@ class FileHandleTestCase(lldbtest.TestBase):
 
             sbf = lldb.SBFile(f.fileno(), 'w', False)
             status = self.dbg.SetErrorFile(sbf)
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
 
             self.handleCmd('lolwut', check=False, collect_result=False)
 
@@ -437,7 +437,7 @@ class FileHandleTestCase(lldbtest.TestBase):
         with open(self.out_filename, 'w') as f:
             sbf = lldb.SBFile.Create(f, borrow=True)
             e, n = sbf.Write(b'FOO')
-            self.assertTrue(e.Success())
+            self.assertSuccess(e)
             self.assertEqual(n, 3)
             sbf.Close()
             self.assertFalse(f.closed)
@@ -459,7 +459,7 @@ class FileHandleTestCase(lldbtest.TestBase):
             sbf = lldb.SBFile.Create(f, force_io_methods=True)
             e, n = sbf.Write(b'FOO')
             self.assertTrue(written)
-            self.assertTrue(e.Success())
+            self.assertSuccess(e)
             self.assertEqual(n, 3)
             sbf.Close()
             self.assertTrue(f.closed)
@@ -479,7 +479,7 @@ class FileHandleTestCase(lldbtest.TestBase):
             sbf = lldb.SBFile.Create(f, borrow=True, force_io_methods=True)
             e, n = sbf.Write(b'FOO')
             self.assertTrue(written)
-            self.assertTrue(e.Success())
+            self.assertSuccess(e)
             self.assertEqual(n, 3)
             sbf.Close()
             self.assertFalse(f.closed)
@@ -493,7 +493,7 @@ class FileHandleTestCase(lldbtest.TestBase):
         sbf = lldb.SBFile(f)
         e, n = sbf.Write(b'FOO')
         self.assertEqual(f.getvalue().strip(), "FOO")
-        self.assertTrue(e.Success())
+        self.assertSuccess(e)
         self.assertEqual(n, 3)
         sbf.Close()
         self.assertTrue(f.closed)
@@ -503,7 +503,7 @@ class FileHandleTestCase(lldbtest.TestBase):
     def test_string_out(self):
         f = io.StringIO()
         status = self.dbg.SetOutputFile(f)
-        self.assertTrue(status.Success())
+        self.assertSuccess(status)
         self.handleCmd("script 'foobar'")
         self.assertEqual(f.getvalue().strip(), "'foobar'")
 
@@ -512,7 +512,7 @@ class FileHandleTestCase(lldbtest.TestBase):
     def test_string_error(self):
         f = io.StringIO()
         status = self.dbg.SetErrorFile(f)
-        self.assertTrue(status.Success())
+        self.assertSuccess(status)
         self.handleCmd('lolwut', check=False, collect_result=False)
         errors = f.getvalue()
         self.assertTrue(re.search(r'error:.*lolwut', errors))
@@ -524,7 +524,7 @@ class FileHandleTestCase(lldbtest.TestBase):
         sbf = lldb.SBFile(f)
         e, n = sbf.Write(b'FOO')
         self.assertEqual(f.getvalue().strip(), b"FOO")
-        self.assertTrue(e.Success())
+        self.assertSuccess(e)
         self.assertEqual(n, 3)
         sbf.Close()
         self.assertTrue(f.closed)
@@ -535,7 +535,7 @@ class FileHandleTestCase(lldbtest.TestBase):
         sbf = lldb.SBFile(f)
         buf = bytearray(100)
         e, n = sbf.Read(buf)
-        self.assertTrue(e.Success())
+        self.assertSuccess(e)
         self.assertEqual(buf[:n], b'zork')
 
 
@@ -556,7 +556,7 @@ class FileHandleTestCase(lldbtest.TestBase):
         sbf = lldb.SBFile(f)
         buf = bytearray(100)
         e, n = sbf.Read(buf)
-        self.assertTrue(e.Success())
+        self.assertSuccess(e)
         self.assertEqual(buf[:n], b'zork')
 
 
@@ -565,7 +565,7 @@ class FileHandleTestCase(lldbtest.TestBase):
         with open(self.out_filename, 'w') as f:
             sbf = lldb.SBFile(f)
             status = self.dbg.SetOutputFile(sbf)
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
             self.handleCmd('script 2+2')
         with open(self.out_filename, 'r') as f:
             self.assertEqual(f.read().strip(), '4')
@@ -575,7 +575,7 @@ class FileHandleTestCase(lldbtest.TestBase):
     def test_file_out(self):
         with open(self.out_filename, 'w') as f:
             status = self.dbg.SetOutputFile(f)
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
             self.handleCmd('script 2+2')
         with open(self.out_filename, 'r') as f:
             self.assertEqual(f.read().strip(), '4')
@@ -585,7 +585,7 @@ class FileHandleTestCase(lldbtest.TestBase):
         with open(self.out_filename, 'w') as f:
             sbf = lldb.SBFile(f)
             status = self.dbg.SetErrorFile(sbf)
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
             self.handleCmd('lolwut', check=False, collect_result=False)
         with open(self.out_filename, 'r') as f:
             errors = f.read()
@@ -595,7 +595,7 @@ class FileHandleTestCase(lldbtest.TestBase):
     def test_file_error(self):
         with open(self.out_filename, 'w') as f:
             status = self.dbg.SetErrorFile(f)
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
             self.handleCmd('lolwut', check=False, collect_result=False)
         with open(self.out_filename, 'r') as f:
             errors = f.read()
@@ -681,7 +681,7 @@ class FileHandleTestCase(lldbtest.TestBase):
     def test_close(self):
         with open(self.out_filename, 'w') as f:
             status = self.dbg.SetOutputFile(f)
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
             self.handleCmd("help help", check=False, collect_result=False)
             # make sure the file wasn't closed early.
             f.write("\nZAP\n")
@@ -699,7 +699,7 @@ class FileHandleTestCase(lldbtest.TestBase):
     def test_stdout(self):
         f = io.StringIO()
         status = self.dbg.SetOutputFile(f)
-        self.assertTrue(status.Success())
+        self.assertSuccess(status)
         self.handleCmd(r"script sys.stdout.write('foobar\n')")
         self.assertEqual(f.getvalue().strip().split(), ["foobar", "7"])
 
@@ -707,7 +707,7 @@ class FileHandleTestCase(lldbtest.TestBase):
     def test_stdout_file(self):
         with open(self.out_filename, 'w') as f:
             status = self.dbg.SetOutputFile(f)
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
             self.handleCmd(r"script sys.stdout.write('foobar\n')")
         with open(self.out_filename, 'r') as f:
             # In python2 sys.stdout.write() returns None, which
@@ -804,9 +804,9 @@ class FileHandleTestCase(lldbtest.TestBase):
 
         with open(self.out_filename, 'w') as f:
             status = self.dbg.SetOutputFile(f)
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
             status = self.dbg.SetErrorFile(f)
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
             self.dbg.SetOutputFileHandle(None, False)
             self.dbg.SetErrorFileHandle(None, False)
             sbf = self.dbg.GetOutputFile()
@@ -821,7 +821,7 @@ class FileHandleTestCase(lldbtest.TestBase):
                 self.assertEqual(sbf.GetFile().fileno(), 2)
         with open(self.out_filename, 'r') as f:
             status = self.dbg.SetInputFile(f)
-            self.assertTrue(status.Success())
+            self.assertSuccess(status)
             self.dbg.SetInputFileHandle(None, False)
             sbf = self.dbg.GetInputFile()
             if sys.version_info.major >= 3:

--- a/lldb/test/API/python_api/process/read-mem-cstring/TestReadMemCString.py
+++ b/lldb/test/API/python_api/process/read-mem-cstring/TestReadMemCString.py
@@ -32,25 +32,25 @@ class TestReadMemCString(TestBase):
         err = lldb.SBError()
 
         empty_str_addr = frame.FindVariable("empty_string").GetValueAsUnsigned(err)
-        self.assertTrue(err.Success())
+        self.assertSuccess(err)
         self.assertTrue(empty_str_addr != lldb.LLDB_INVALID_ADDRESS)
 
         one_letter_str_addr = frame.FindVariable("one_letter_string").GetValueAsUnsigned(err)
-        self.assertTrue(err.Success())
+        self.assertSuccess(err)
         self.assertTrue(one_letter_str_addr != lldb.LLDB_INVALID_ADDRESS)
 
         invalid_memory_str_addr = frame.FindVariable("invalid_memory_string").GetValueAsUnsigned(err)
-        self.assertTrue(err.Success())
+        self.assertSuccess(err)
         self.assertTrue(invalid_memory_str_addr != lldb.LLDB_INVALID_ADDRESS)
 
         # Important:  An empty (0-length) c-string must come back as a Python string, not a
         # None object.
         empty_str = process.ReadCStringFromMemory(empty_str_addr, 2048, err)
-        self.assertTrue(err.Success())
+        self.assertSuccess(err)
         self.assertEqual(empty_str, "")
 
         one_letter_string = process.ReadCStringFromMemory(one_letter_str_addr, 2048, err)
-        self.assertTrue(err.Success())
+        self.assertSuccess(err)
         self.assertEqual(one_letter_string, "1")
 
         invalid_memory_string = process.ReadCStringFromMemory(invalid_memory_str_addr, 2048, err)

--- a/lldb/test/API/python_api/sbdata/TestSBData.py
+++ b/lldb/test/API/python_api/sbdata/TestSBData.py
@@ -83,10 +83,10 @@ class SBDataAPICase(TestBase):
         self.assert_data(data.GetUnsignedInt32, offset, 1)
         offset += 4
         low = data.GetSignedInt16(error, offset)
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
         offset += 2
         high = data.GetSignedInt16(error, offset)
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
         offset += 2
         self.assertTrue(
             (low == 9 and high == 0) or (
@@ -99,7 +99,7 @@ class SBDataAPICase(TestBase):
                     offset) -
                 3.14) < 1,
             'foo[0].c == 3.14')
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
         offset += 4
         self.assert_data(data.GetUnsignedInt32, offset, 8)
         offset += 4
@@ -172,7 +172,7 @@ class SBDataAPICase(TestBase):
                     offset) -
                 3.14) < 1,
             'foo[1].c == 3.14')
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
 
         data = new_foobar.GetData()
 
@@ -188,7 +188,7 @@ class SBDataAPICase(TestBase):
                     offset) -
                 6.28) < 1,
             'foo[1].c == 6.28')
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
 
         self.runCmd("n")
 
@@ -207,7 +207,7 @@ class SBDataAPICase(TestBase):
                     offset) -
                 3) < 1,
             'barfoo[0].c == 3')
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
         offset += 4
         self.assert_data(data.GetUnsignedInt32, offset, 4)
         offset += 4
@@ -220,7 +220,7 @@ class SBDataAPICase(TestBase):
                     offset) -
                 6) < 1,
             'barfoo[1].c == 6')
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
 
         new_object = barfoo.CreateValueFromData(
             "new_object", data, barfoo.GetType().GetBasicType(
@@ -239,7 +239,7 @@ class SBDataAPICase(TestBase):
                 'A\0\0\0',
                 data.GetByteOrder(),
                 data.GetAddressByteSize())
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
 
         data2 = lldb.SBData()
         data2.SetData(
@@ -247,7 +247,7 @@ class SBDataAPICase(TestBase):
             'BCD',
             data.GetByteOrder(),
             data.GetAddressByteSize())
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
 
         data.Append(data2)
 
@@ -401,7 +401,7 @@ class SBDataAPICase(TestBase):
                     0) -
                 3.14) < 0.5,
             'double data2[0] = 3.14')
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
         self.assertTrue(
             fabs(
                 data2.GetDouble(
@@ -409,7 +409,7 @@ class SBDataAPICase(TestBase):
                     8) -
                 6.28) < 0.5,
             'double data2[1] = 6.28')
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
         self.assertTrue(
             fabs(
                 data2.GetDouble(
@@ -417,7 +417,7 @@ class SBDataAPICase(TestBase):
                     16) -
                 2.71) < 0.5,
             'double data2[2] = 2.71')
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
 
         data2 = lldb.SBData()
 

--- a/lldb/test/API/python_api/sbplatform/TestSBPlatform.py
+++ b/lldb/test/API/python_api/sbplatform/TestSBPlatform.py
@@ -18,5 +18,5 @@ class SBPlatformAPICase(TestBase):
             del os.environ["MY_TEST_ENV_VAR"]
         self.addTearDownHook(cleanup)
         cmd = lldb.SBPlatformShellCommand(self.getBuildArtifact("a.out"))
-        self.assertTrue(plat.Run(cmd).Success())
+        self.assertSuccess(plat.Run(cmd))
         self.assertIn("MY_TEST_ENV_VAR=SBPlatformAPICase.test_run", cmd.GetOutput())

--- a/lldb/test/API/python_api/sbstructureddata/TestStructuredDataAPI.py
+++ b/lldb/test/API/python_api/sbstructureddata/TestStructuredDataAPI.py
@@ -37,7 +37,7 @@ class TestStructuredDataAPI(TestBase):
         # Test that GetDescription works:
         s.Clear()
         error = example.GetDescription(s)
-        self.assertTrue(error.Success(), "GetDescription works")
+        self.assertSuccess(error, "GetDescription works")
         if not "key_float" in s.GetData():
             self.fail("FAILED: could not find key_float in description output")
         

--- a/lldb/test/API/python_api/target/TestTargetAPI.py
+++ b/lldb/test/API/python_api/target/TestTargetAPI.py
@@ -136,7 +136,7 @@ class TargetAPITestCase(TestBase):
         sb_addr = lldb.SBAddress(data_section, 0)
         error = lldb.SBError()
         content = target.ReadMemory(sb_addr, 1, error)
-        self.assertTrue(error.Success(), "Make sure memory read succeeded")
+        self.assertSuccess(error, "Make sure memory read succeeded")
         self.assertEqual(len(content), 1)
 
 

--- a/lldb/test/API/python_api/value/change_values/TestChangeValueAPI.py
+++ b/lldb/test/API/python_api/value/change_values/TestChangeValueAPI.py
@@ -74,13 +74,13 @@ class ChangeValueAPITestCase(TestBase):
         val_value = frame0.FindVariable("val")
         self.assertTrue(val_value.IsValid(), "Got the SBValue for val")
         actual_value = val_value.GetValueAsSigned(error, 0)
-        self.assertTrue(error.Success(), "Got a value from val")
+        self.assertSuccess(error, "Got a value from val")
         self.assertEquals(actual_value, 100, "Got the right value from val")
 
         result = val_value.SetValueFromCString("12345")
         self.assertTrue(result, "Setting val returned True.")
         actual_value = val_value.GetValueAsSigned(error, 0)
-        self.assertTrue(error.Success(), "Got a changed value from val")
+        self.assertSuccess(error, "Got a changed value from val")
         self.assertEqual(
             actual_value, 12345,
             "Got the right changed value from val")
@@ -158,7 +158,7 @@ class ChangeValueAPITestCase(TestBase):
         result = sp_value.SetValueFromCString("1")
         self.assertTrue(result, "Setting sp returned true.")
         actual_value = sp_value.GetValueAsUnsigned(error, 0)
-        self.assertTrue(error.Success(), "Got a changed value for sp")
+        self.assertSuccess(error, "Got a changed value for sp")
         self.assertEqual(
             actual_value, 1,
             "Got the right changed value for sp.")

--- a/lldb/test/API/sample_test/TestSampleTest.py
+++ b/lldb/test/API/sample_test/TestSampleTest.py
@@ -42,7 +42,7 @@ class RenameThisSampleTestTestCase(TestBase):
 
         frame = thread.GetFrameAtIndex(0)
         test_var = frame.FindVariable("test_var")
-        self.assertTrue(test_var.GetError().Success(), "Failed to fetch test_var")
+        self.assertSuccess(test_var.GetError(), "Failed to fetch test_var")
         test_value = test_var.GetValueAsUnsigned()
         self.assertEqual(test_value, 10, "Got the right value for test_var")
 

--- a/lldb/test/API/sample_test/main.c
+++ b/lldb/test/API/sample_test/main.c
@@ -9,7 +9,7 @@ main()
   printf ("Set a breakpoint here: %d.\n", test_var);
   //% test_var = self.frame().FindVariable("test_var")
   //% test_value = test_var.GetValueAsUnsigned()
-  //% self.assertTrue(test_var.GetError().Success(), "Failed to fetch test_var")
+  //% self.assertSuccess(test_var.GetError(), "Failed to fetch test_var")
   //% self.assertEqual(test_value, 10, "Failed to get the right value for test_var")
   return global_test_var;
 }


### PR DESCRIPTION
Replace forms of `assertTrue(err.Success())` with `assertSuccess(err)` (added in [D82759](https://reviews.llvm.org/D82759)).

* `assertSuccess` prints out the error's message
* `assertSuccess` expresses explicit higher level semantics, both to the reader and for test failure output
* `assertSuccess` seems not to be well known, using it where possible will help spread knowledge
* `assertSuccess` statements are more succinct

Differential Revision: [D119616](https://reviews.llvm.org/D119616)

(cherry picked from commit 779bbbf27fe631154bdfaac7a443f198d4654688)