### PR TITLE
Alt mechanism to find the first loadable seg in a Mach-O binary

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6261,6 +6261,15 @@ Section *ObjectFileMachO::GetMachHeaderSection() {
     if (section->GetFileOffset() == 0 && SectionIsLoadable(section))
       return section;
   }
+
+  // We may have a binary in the shared cache that has a non-zero
+  // file address for its first segment, traditionally the __TEXT segment.
+  // Search for it by name and return it as our next best guess.
+  SectionSP text_segment_sp =
+      GetSectionList()->FindSectionByName(GetSegmentNameTEXT());
+  if (text_segment_sp.get() && SectionIsLoadable(text_segment_sp.get()))
+    return text_segment_sp.get();
+
   return nullptr;
 }
 


### PR DESCRIPTION
Alt mechanism to find the first loadable seg in a Mach-O binary

ObjectFileMachO, for a couple of special binaries at the initial
launch, needs to find segment load addresses before the Target's
SectionLoadList has been initialized. The calculation to find
the first segment, which is at the same address as the mach header,
was not correct if the binary was in the Darwin shared cache.
Update the logic to handle that case.

Differential Revision: https://reviews.llvm.org/D119602
rdar://88802629

(cherry picked from commit 4a394367c124172dff26ef5042ecd6fa666a6e07)