### PR TITLE
[lldb] Refactor Swift tests to use assertSuccess

### DIFF
--- a/lldb/test/API/lang/swift/address_of/TestSwiftAddressOf.py
+++ b/lldb/test/API/lang/swift/address_of/TestSwiftAddressOf.py
@@ -36,7 +36,7 @@ class TestSwiftAddressOf(lldbtest.TestBase):
         else:
             self.assertFalse(var.GetType().IsReferenceType(), name + "was supposed to be a reference.")
             addr_val = var.AddressOf()
-            self.assertTrue(addr_val.GetError().Success(), "AddressOf didn't return a good variable: %s."%(addr_val.GetError().GetCString()))
+            self.assertSuccess(addr_val.GetError(), "AddressOf didn't return a good variable")
             addr_value = addr_val.GetValueAsUnsigned()
             
         # FIXME: I want to use SBTarget::CreateValueFromAddress to make the
@@ -45,7 +45,7 @@ class TestSwiftAddressOf(lldbtest.TestBase):
         # for now I'm just telling myself that I could read the memory.
         error = lldb.SBError()
         bytes = self.process.ReadMemory(addr_value, var.GetByteSize(), error)
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
 
         
     @swiftTest

--- a/lldb/test/API/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
+++ b/lldb/test/API/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
@@ -37,8 +37,7 @@ class TestSwiftArchetypeResolution(TestBase):
         var = self.frame().FindVariable("things")
         var.SetPreferDynamicValue(lldb.eDynamicCanRunTarget)
         var.SetPreferSyntheticValue(True)
-        self.assertTrue(var.GetError().Success(),
-                        "Failed to get things: %s"%(var.GetError().GetCString()))
+        self.assertSuccess(var.GetError(), "Failed to get things")
         self.assertEqual(var.GetNumChildren(), 4,
                          "Got the right number of children")
         type_name = var.GetTypeName()
@@ -46,8 +45,6 @@ class TestSwiftArchetypeResolution(TestBase):
                          "Wrong typename: %s."%(type_name))
         for i in range(0,4):
             child = var.GetChildAtIndex(i)
-            self.assertTrue(child.GetError().Success(),
-                            "Failed to get things[%d]: %s"%
-                            (i, var.GetError().GetCString()))
+            self.assertSuccess(child.GetError(), "Failed to get things[%d]" % i)
             value = child.GetValueAsUnsigned()
             self.assertEqual(value, i, "Wrong value: %d not %d."%(value, i))

--- a/lldb/test/API/lang/swift/async/unwind/backtrace_locals/TestSwiftAsyncBacktraceLocals.py
+++ b/lldb/test/API/lang/swift/async/unwind/backtrace_locals/TestSwiftAsyncBacktraceLocals.py
@@ -76,7 +76,7 @@ class TestSwiftAsyncBacktraceLocals(lldbtest.TestBase):
                     error = lldb.SBError()
                     ret_addr = process.ReadPointerFromMemory(
                         cfa[fibonacci_number-1] + target.addr_size, error)
-                    self.assertTrue(error.Success(), "Managed to read context memory")
+                    self.assertSuccess(error, "Managed to read context memory")
                     self.assertEqual(ret_addr, frame.GetPC())
 
             self.assertIn("Main.main", thread.GetFrameAtIndex(n+1).GetFunctionName())

--- a/lldb/test/API/lang/swift/closures/TestSwiftClosures.py
+++ b/lldb/test/API/lang/swift/closures/TestSwiftClosures.py
@@ -62,7 +62,7 @@ class TestPassedClosures(TestBase):
             # First see that we can print the function we were passed:
             result = self.frame().EvaluateExpression("fn", opts)
             error = result.GetError()
-            self.assertTrue(error.Success(),"'fn' failed: %s"%(error.GetCString()))
+            self.assertSuccess(error, "'fn' failed")
             self.assertTrue("() -> Swift.Int" in result.GetValue(), "Got the function name wrong: %s."%(result.GetValue()))
             self.assertTrue("() -> Swift.Int" in result.GetTypeName(), "Got the function type wrong: %s."%(result.GetTypeName()))
         
@@ -70,7 +70,7 @@ class TestPassedClosures(TestBase):
             # Now see that we can call it:
             result = self.frame().EvaluateExpression("fn()", opts)
             error.result.GetError()
-            self.assertTrue(error.Success(),"'fn()' failed: %s"%(error.GetCString()))
+            self.assertSuccess(error, "'fn()' failed")
             self.assertTrue(result.GetValue() == "3", "Got the wrong value: %s"%(result.GetValue()))
 
     def generic_type(self, test_call):
@@ -81,7 +81,7 @@ class TestPassedClosures(TestBase):
             # First see that we can print the function we were passed:
             result = self.frame().EvaluateExpression("fn", opts)
             error = result.GetError()
-            self.assertTrue(error.Success(),"'fn' failed: %s"%(error.GetCString()))
+            self.assertSuccess(error, "'fn' failed")
             self.assertTrue("() -> A" in result.GetValue(), "Got the function name wrong: %s."%(result.GetValue()))
             self.assertTrue("() -> A" in result.GetTypeName(), "Got the function type wrong: %s."%(result.GetTypeName()))
         
@@ -89,7 +89,7 @@ class TestPassedClosures(TestBase):
             # Now see that we can call it:
             result = self.frame().EvaluateExpression("fn()", opts)
             error.result.GetError()
-            self.assertTrue(error.Success(),"'fn()' failed: %s"%(error.GetCString()))
+            self.assertSuccess(error, "'fn()' failed")
             self.assertTrue(result.GetValue() == "3", "Got the wrong value: %s"%(result.GetValue()))
 
 

--- a/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
+++ b/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
@@ -56,9 +56,8 @@ class TestClassConstrainedProtocol(TestBase):
         opts.SetFetchDynamicValue(lldb.eDynamicCanRunTarget)
         result = self.frame().EvaluateExpression("self", opts)
         error = result.GetError()
-        self.assertTrue(error.Success(),
-                        "'self' expression failed at '%s': %s"
-                        %(bkpt_pattern, error.GetCString()))
+        self.assertSuccess(error,
+                           "'self' expression failed at '%s'" % bkpt_pattern)
         f_ivar = result.GetChildMemberWithName("f")
         self.assertTrue(f_ivar.IsValid(),
                         "Could not find 'f' in self at '%s'"%(bkpt_pattern))

--- a/lldb/test/API/lang/swift/expression/equality_operators/TestEqualityOperators.py
+++ b/lldb/test/API/lang/swift/expression/equality_operators/TestEqualityOperators.py
@@ -79,10 +79,9 @@ class TestUnitTests(TestBase):
         options = lldb.SBExpressionOptions()
 
         value = self.frame().EvaluateExpression("lhs == rhs", options)
-        self.assertTrue(
-            value.GetError().Success(),
-            "Expression in %s was successful" %
-            (bkpt_name))
+        self.assertSuccess(
+            value.GetError(),
+            "Expression in %s was successful" % bkpt_name)
         summary = value.GetSummary()
         self.assertTrue(
             summary == compare_value,
@@ -92,7 +91,7 @@ class TestUnitTests(TestBase):
 
         # And make sure we got did increment the counter by the right value.
         value = self.frame().EvaluateExpression("Fooey.GetCounter()", options)
-        self.assertTrue(value.GetError().Success(), "GetCounter failed with error %s"%(value.GetError().GetCString()))
+        self.assertSuccess(value.GetError(), "GetCounter expression failed")
 
         counter = value.GetValueAsUnsigned()
         self.assertTrue(
@@ -102,9 +101,7 @@ class TestUnitTests(TestBase):
         # Make sure the presence of these type specific == operators doesn't interfere
         # with finding other unrelated == operators.
         value = self.frame().EvaluateExpression("1 == 2", options)
-        self.assertTrue(
-            value.GetError().Success(),
-            "1 == 2 expression couldn't run")
+        self.assertSuccess(value.GetError(), "1 == 2 expression couldn't run")
         self.assertTrue(
             value.GetSummary() == "false",
             "1 == 2 didn't return false.")

--- a/lldb/test/API/lang/swift/expression/errors/TestExpressionErrors.py
+++ b/lldb/test/API/lang/swift/expression/errors/TestExpressionErrors.py
@@ -104,10 +104,7 @@ class TestExpressionErrors(TestBase):
         enum_value = self.frame().EvaluateExpression(
             "IThrowEnumOver10(101)", options)
         self.assertTrue(enum_value.IsValid(), "Got a valid enum value.")
-        self.assertTrue(
-            enum_value.GetError().Success(),
-            "Got error %s getting enum value" %
-            (enum_value.GetError().GetCString()))
+        self.assertSuccess(enum_value.GetError(), "Error getting enum value")
         self.assertTrue(
             enum_value.GetValue() == "ImportantError",
             "Expected 'ImportantError', got %s" %
@@ -116,15 +113,14 @@ class TestExpressionErrors(TestBase):
         object_value = self.frame().EvaluateExpression(
             "IThrowObjectOver10(101)", options)
         self.assertTrue(object_value.IsValid(), "Got a valid object value.")
-        self.assertTrue(
-            object_value.GetError().Success(),
-            "Got error %s getting object value" %
-            (object_value.GetError().GetCString()))
+        self.assertSuccess(
+            object_value.GetError(),
+            "Error getting object value")
 
         message = object_value.GetChildMemberWithName("m_message")
         self.assertTrue(message.IsValid(), "Found some m_message child.")
-        self.assertTrue(
-            message.GetError().Success(),
+        self.assertSuccess(
+            message.GetError(),
             "No errors fetching m_message value")
         self.assertTrue(
             message.GetSummary() == '"Over 100"',

--- a/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
+++ b/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
@@ -47,7 +47,7 @@ class TestSwiftGenericExpressions(lldbtest.TestBase):
         value = self.frame().EvaluateExpression(expression, opts)
         self.assertTrue(value.IsValid(), expression + "returned a valid value")
 
-        self.assertTrue(value.GetError().Success(), "expression failed")
+        self.assertSuccess(value.GetError(), "expression failed")
         if self.TraceOn():
             print(value.GetSummary())
             print(value.GetValue())

--- a/lldb/test/API/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
+++ b/lldb/test/API/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
@@ -36,5 +36,5 @@ class TestOptionalAmbiguity(TestBase):
         # to compile, I just check that here.
         frame = thread.GetFrameAtIndex(0)
         ret_value = frame.EvaluateExpression("self")
-        self.assertTrue(ret_value.GetError().Success(), "The expression completed successfully")
+        self.assertSuccess(ret_value.GetError(), "The expression completed successfully")
 

--- a/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
+++ b/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
@@ -52,7 +52,7 @@ class TestDefiningOverloadedFunctions(TestBase):
         value_obj = self.frame().EvaluateExpression(
             "func $overload(_ a: Int) -> Int { return 1 }\n 1")
         error = value_obj.GetError()
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
 
         self.check_expression("$overload(10)", "1", False)
 
@@ -60,7 +60,7 @@ class TestDefiningOverloadedFunctions(TestBase):
         value_obj = self.frame().EvaluateExpression(
             "func $overload(_ a: String) -> Int { return 2 } \n 1")
         error = value_obj.GetError()
-        self.assertTrue(error.Success())
+        self.assertSuccess(error)
 
         self.check_expression('$overload(10)', '1', False)
         self.check_expression('$overload("some string")', '2', False)

--- a/lldb/test/API/lang/swift/expression/submodule_import/TestSubmoduleImport.py
+++ b/lldb/test/API/lang/swift/expression/submodule_import/TestSubmoduleImport.py
@@ -44,7 +44,7 @@ class TestSwiftSubmoduleImport(TestBase):
         # so even though it doesn't seem like it this does test auto-import:
         value = self.frame().EvaluateExpression("b", options)
         self.assertTrue(value.IsValid(), "Got a valid variable back from b")
-        self.assertTrue(value.GetError().Success(),
+        self.assertSuccess(value.GetError(),
                         "And the variable was successfully evaluated")
         result = value.GetSummary()
         self.assertTrue(
@@ -56,8 +56,7 @@ class TestSwiftSubmoduleImport(TestBase):
         self.assertTrue(
             value.IsValid(),
             "Got a valid value back from import Darwin.C")
-        self.assertTrue(
-            value.GetError().Success(),
-            "The import was not successful: %s" %
-            (value.GetError().GetCString()))
+        self.assertSuccess(
+            value.GetError(),
+            "The import was not successful")
 

--- a/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
+++ b/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
@@ -92,11 +92,11 @@ class TestSwiftFixIts(TestBase):
 
         # Check that the expressions were correct:
         tmp_value = frame.EvaluateExpression("$tmp == 100")
-        self.assertTrue(tmp_value.GetError().Success())
+        self.assertSuccess(tmp_value.GetError())
         self.assertTrue(tmp_value.GetSummary() == 'true')
         
         value = frame.EvaluateExpression(
                 "var $tmp2 = wrapper.wrapped", options)
         tmp_value = frame.EvaluateExpression("$tmp2 == 7")
-        self.assertTrue(tmp_value.GetError().Success())
+        self.assertSuccess(tmp_value.GetError())
         self.assertTrue(tmp_value.GetSummary() == 'true')

--- a/lldb/test/API/lang/swift/optional_of_resilient/TestResilientObjectInOptional.py
+++ b/lldb/test/API/lang/swift/optional_of_resilient/TestResilientObjectInOptional.py
@@ -42,9 +42,9 @@ class TestResilientObjectInOptional(TestBase):
         # First try getting a non-resilient optional, to make sure that
         # part isn't broken:
         t_opt_var = frame.FindVariable("t_opt")
-        self.assertTrue(t_opt_var.GetError().Success(), "Made t_opt value object")
+        self.assertSuccess(t_opt_var.GetError(), "Made t_opt value object")
         t_a_var = t_opt_var.GetChildMemberWithName("a")
-        self.assertTrue(t_a_var.GetError().Success(), "The child was a")
+        self.assertSuccess(t_a_var.GetError(), "The child was a")
         lldbutil.check_variable(self, t_a_var, False, value="2")
         
         # Make sure we can print an optional of a resilient type...
@@ -52,9 +52,9 @@ class TestResilientObjectInOptional(TestBase):
         # it's child will be "a".
         # First do this with "frame var":
         opt_var = frame.FindVariable("s_opt")
-        self.assertTrue(opt_var.GetError().Success(), "Made s_opt value object")
+        self.assertSuccess(opt_var.GetError(), "Made s_opt value object")
         a_var = opt_var.GetChildMemberWithName("a")
-        self.assertTrue(a_var.GetError().Success(), "The resilient child was 'a'")
+        self.assertSuccess(a_var.GetError(), "The resilient child was 'a'")
         lldbutil.check_variable(self, a_var, False, value="1")
         
 if __name__ == '__main__':

--- a/lldb/test/API/lang/swift/variables/globals/TestSwiftGlobals.py
+++ b/lldb/test/API/lang/swift/variables/globals/TestSwiftGlobals.py
@@ -87,7 +87,7 @@ class TestSwiftGlobals(TestBase):
             g_counter.IsValid(),
             "g_counter returned a valid value object.")
         value = g_counter.GetValueAsSigned(error)
-        self.assertTrue(error.Success(), "Got a value for g_counter")
+        self.assertSuccess(error, "Got a value for g_counter")
         self.assertTrue(
             value == 0,
             "g_counter value is the uninitialized one.")
@@ -97,14 +97,14 @@ class TestSwiftGlobals(TestBase):
             foo_var.IsValid(),
             "foo_var returned a valid value object.")
         value = foo_var.GetValueAsUnsigned(error)
-        self.assertTrue(error.Success(), "foo_var has a value.")
+        self.assertSuccess(error, "foo_var has a value.")
         self.assertTrue(value == 0, "foo_var is null before initialization.")
 
         my_large_dude = frame.EvaluateExpression("my_large_dude", options)
         self.assertTrue(my_large_dude.IsValid(),
                         "my_large_dude returned a valid value object.")
         value = my_large_dude.GetValue()
-        self.assertTrue(error.Success(), "Got a value for my_large_dude")
+        self.assertSuccess(error, "Got a value for my_large_dude")
         self.assertTrue(
             value is None,
             "my_large_dude value is the uninitialized one.")
@@ -123,7 +123,7 @@ class TestSwiftGlobals(TestBase):
             g_counter.IsValid(),
             "g_counter returned a valid value object.")
         value = g_counter.GetValueAsSigned(error)
-        self.assertTrue(error.Success(), "Got a value for g_counter")
+        self.assertSuccess(error, "Got a value for g_counter")
         self.assertTrue(value == 2, "g_counter value should be 2.")
 
         foo_var = frame.EvaluateExpression("my_foo", options)
@@ -133,7 +133,7 @@ class TestSwiftGlobals(TestBase):
         foo_var_x = foo_var.GetChildMemberWithName("x")
         self.assertTrue(foo_var_x.IsValid(), "Got value object for foo_var.x")
         value = foo_var_x.GetValueAsUnsigned(error)
-        self.assertTrue(error.Success(), "foo_var.x has a value.")
+        self.assertSuccess(error, "foo_var.x has a value.")
         self.assertTrue(value == 1, "foo_var is null before initialization.")
 
         my_large_dude = frame.EvaluateExpression("my_large_dude", options)
@@ -144,7 +144,7 @@ class TestSwiftGlobals(TestBase):
             my_large_dude_y.IsValid(),
             "Got value object for my_large_dude.y")
         value = my_large_dude_y.GetValueAsUnsigned(error)
-        self.assertTrue(error.Success(), "Got a value for my_large_dude.y")
+        self.assertSuccess(error, "Got a value for my_large_dude.y")
         self.assertTrue(
             value == 20,
             "my_large_dude value is the uninitialized one.")

--- a/lldb/test/API/lang/swift/variables/inout/TestInOutVariables.py
+++ b/lldb/test/API/lang/swift/variables/inout/TestInOutVariables.py
@@ -48,10 +48,9 @@ class TestInOutVariables(TestBase):
             message_end = "from EvaluateExpression"
             x_actual = self.frame().EvaluateExpression(
                 "x", lldb.eDynamicCanRunTarget)
-            self.assertTrue(
-                x_actual.GetError().Success(),
-                "Expression evaluation failed: %s" %
-                (x_actual.GetError().GetCString()))
+            self.assertSuccess(
+                x_actual.GetError(),
+                "Expression evaluation failed")
         else:
             message_end = "from FindVariable"
             x = self.frame().FindVariable("x").GetDynamicValue(
@@ -180,7 +179,7 @@ class TestInOutVariables(TestBase):
         var = self.frame().EvaluateExpression(
             "x = Other(in1: 556678, in2: 667788)",
             lldb.eDynamicCanRunTarget)
-        self.assertTrue(var.GetError().Success())
+        self.assertSuccess(var.GetError())
 
         #self.check_class("556677", "667788")
 

--- a/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
+++ b/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
@@ -79,6 +79,5 @@ class TestSwiftREPLExceptions(TestBase):
         options = lldb.SBExpressionOptions()
         options.SetREPLMode(True)
         val = frame.EvaluateExpression("call_cpp(); 5", options)
-        self.assertTrue(val.GetError().Success(), 
-                        "Got an error evaluating expression: %s."%(val.GetError().GetCString()))
+        self.assertSuccess(val.GetError(), "Got an error evaluating expression")
         self.assertEqual(val.GetValueAsUnsigned(), 5,"The expression didn't return the correct result")


### PR DESCRIPTION
Use `assertSuccess` to Swift specific tests. Follow up to #3940.