### PR TITLE
[lldb] Check max_size before resizing DataBufferHeap

### DIFF
--- a/lldb/include/lldb/Utility/DataBufferHeap.h
+++ b/lldb/include/lldb/Utility/DataBufferHeap.h
@@ -80,8 +80,8 @@ public:
   ///     to resize itself to.
   ///
   /// \return
-  ///     The size in bytes after that this heap buffer was
-  ///     successfully resized to.
+  ///     The size in bytes after this heap buffer was resized. If
+  ///     the resize failed the size will remain unchanged.
   lldb::offset_t SetByteSize(lldb::offset_t byte_size);
 
   /// Makes a copy of the \a src_len bytes in \a src.

--- a/lldb/source/Utility/DataBufferHeap.cpp
+++ b/lldb/source/Utility/DataBufferHeap.cpp
@@ -47,7 +47,8 @@ uint64_t DataBufferHeap::GetByteSize() const { return m_data.size(); }
 // Sets the number of bytes that this object should be able to contain. This
 // can be used prior to copying data into the buffer.
 uint64_t DataBufferHeap::SetByteSize(uint64_t new_size) {
-  m_data.resize(new_size);
+  if (new_size < m_data.max_size())
+    m_data.resize(new_size);
   return m_data.size();
 }
 


### PR DESCRIPTION
Don't resize DataBufferHeap if the newly requested size exceeds the
capacity of the underlying data structure, i.e. std::vector<uint8_t>.
This matches the existing check in the DataBufferHeap constructor.

(cherry picked from commit b7e7a982e93db82ebd7fc08bb9614468f8c0e1e5)
