### PR TITLE
fdepscan: Start writing .d files out (again...)

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -159,7 +159,7 @@ public:
       llvm::IntrusiveRefCntPtr<DependencyScanningCASFilesystem> DepCASFS,
       ExcludedPreprocessorDirectiveSkipMapping *PPSkipMappings,
       bool OverrideCASTokenCache, ScanningOutputFormat Format,
-      bool OptimizeArgs, bool EmitDependencyFile = false,
+      bool OptimizeArgs, bool EmitDependencyFile,
       llvm::Optional<StringRef> ModuleName = None)
       : WorkingDirectory(WorkingDirectory), Consumer(Consumer),
         DepFS(std::move(DepFS)), DepCASFS(std::move(DepCASFS)),
@@ -482,9 +482,10 @@ void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
 
   // FIXME: EmitDependencyFile should only be set when it's for a real
   // compilation.
-  DependencyScanningAction Action(WorkingDirectory, DepsConsumer, DepFS, DepCASFS,
-                                  PPSkipMappings.get(), OverrideCASTokenCache,
-                                  Format, /*EmitDependencyFile=*/true);
+  DependencyScanningAction Action(
+      WorkingDirectory, DepsConsumer, DepFS, DepCASFS, PPSkipMappings.get(),
+      OverrideCASTokenCache, Format, /*OptimizeArgs=*/false,
+      /*EmitDependencyFile=*/true);
 
   // Ignore result; we're just collecting dependencies.
   //

--- a/clang/test/CAS/fdepscan.c
+++ b/clang/test/CAS/fdepscan.c
@@ -4,10 +4,15 @@
 // location, which is out of test/build directory.
 // REQUIRES: system-darwin
 
-// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=daemon -fsyntax-only -x c %s
-// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=inline -fsyntax-only -x c %s
-// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=auto -fsyntax-only -x c %s
-// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=off -fsyntax-only -x c %s
+// RUN: rm -rf %t-*.d
+// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=daemon \
+// RUN:   -E -MD -MF %t-daemon.d -x c %s >/dev/null
+// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=inline \
+// RUN:   -E -MD -MF %t-inline.d -x c %s >/dev/null
+// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=auto \
+// RUN:   -E -MD -MF %t-auto.d -x c %s >/dev/null
+// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=off \
+// RUN:   -E -MD -MF %t-off.d -x c %s >/dev/null
 //
 // Check -fdepscan-share-related arguments are claimed.
 // TODO: Check behaviour.
@@ -28,6 +33,11 @@
 // RUN:     -fdepscan-share-parents 2>&1                     \
 // RUN: | FileCheck %s -check-prefix=BAD-SPELLING
 // BAD-SPELLING: error: unknown argument '-fdepscan-share-parents'
+//
+// Check that the dependency files match.
+// RUN: diff %t-off.d %t-daemon.d
+// RUN: diff %t-off.d %t-inline.d
+// RUN: diff %t-off.d %t-auto.d
 
 #include "test.h"
 


### PR DESCRIPTION
Start writing .d files out (again!) so incremental builds work.  This
was lost with 6a1f50b84ae8f8a8087fcdbe5f27dae8c76878f1, which added a
`bool` argument right before the branch's (optional)
`EmitDependencyFile`.

Besides the bugfix:

- Removed the default argument from `EmitDependencyFile` so that it's a
  compile-time error next time.
- Updated the `fdepscan.c` test to check that `.d` files are written out
  (and match `-fdepscan=off`).