### PR TITLE
fdepscan: Use absolute for writing .d output file

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -480,6 +480,16 @@ void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
   // Dependencies.IncludeSystemHeaders = true;
   // Dependencies.OutputFile = "/dev/null";
 
+  // Make the output file path absolute relative to WorkingDirectory.
+  std::string &DepFile = Invocation->getDependencyOutputOpts().OutputFile;
+  if (!llvm::sys::path::is_absolute(DepFile)) {
+    // FIXME: On Windows, WorkingDirectory is insufficient for making an
+    // absolute path if OutputFile has a root name.
+    llvm::SmallString<128> Path = StringRef(DepFile);
+    llvm::sys::fs::make_absolute(WorkingDirectory, Path);
+    DepFile = Path.str().str();
+  }
+
   // FIXME: EmitDependencyFile should only be set when it's for a real
   // compilation.
   DependencyScanningAction Action(


### PR DESCRIPTION
This should fix writing `.d` files from another directory, but it's missing a test since it'll be hard to write until https://github.com/apple/llvm-project/pull/3904.