### PR TITLE
Darwin: introduce a global override for debug prefix map entries. 

### DIFF
--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -508,6 +508,9 @@ public:
   /// compile unit information.
   virtual bool UseDwarfDebugFlags() const { return false; }
 
+  /// Add an additional -fdebug-prefix-map entry.
+  virtual std::string GetGlobalDebugPathRemapping() const { return {}; }
+  
   // Return the DWARF version to emit, in the absence of arguments
   // to the contrary.
   virtual unsigned GetDefaultDwarfVersion() const { return 4; }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -640,17 +640,24 @@ static void addDebugCompDirArg(const ArgList &Args, ArgStringList &CmdArgs,
 }
 
 /// Add a CC1 and CC1AS option to specify the debug file path prefix map.
-static void addDebugPrefixMapArg(const Driver &D, const ArgList &Args, ArgStringList &CmdArgs) {
-  for (const Arg *A : Args.filtered(options::OPT_ffile_prefix_map_EQ,
-                                    options::OPT_fdebug_prefix_map_EQ)) {
-    StringRef Map = A->getValue();
+static void addDebugPrefixMapArg(const Driver &D, const ToolChain &TC,
+                                 const ArgList &Args, ArgStringList &CmdArgs) {
+  auto AddOneArg = [&](StringRef Map, StringRef Name) {
     if (!Map.contains('='))
-      D.Diag(diag::err_drv_invalid_argument_to_option)
-          << Map << A->getOption().getName();
+      D.Diag(diag::err_drv_invalid_argument_to_option) << Map << Name;
     else
       CmdArgs.push_back(Args.MakeArgString("-fdebug-prefix-map=" + Map));
+  };
+
+  for (const Arg *A : Args.filtered(options::OPT_ffile_prefix_map_EQ,
+                                    options::OPT_fdebug_prefix_map_EQ)) {
+    AddOneArg(A->getValue(), A->getOption().getName());
     A->claim();
   }
+  std::string GlobalRemapEntry = TC.GetGlobalDebugPathRemapping();
+  if (GlobalRemapEntry.empty())
+    return;
+  AddOneArg(GlobalRemapEntry, "environment");
 }
 
 /// Add a CC1 and CC1AS option to specify the macro file path prefix map.
@@ -5627,7 +5634,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   // Add in -fdebug-compilation-dir if necessary.
   addDebugCompDirArg(Args, CmdArgs, D.getVFS());
 
-  addDebugPrefixMapArg(D, Args, CmdArgs);
+  addDebugPrefixMapArg(D, TC, Args, CmdArgs);
 
   if (Arg *A = Args.getLastArg(options::OPT_ftemplate_depth_,
                                options::OPT_ftemplate_depth_EQ)) {
@@ -7654,7 +7661,8 @@ void ClangAs::ConstructJob(Compilation &C, const JobAction &JA,
     // Add the -fdebug-compilation-dir flag if needed.
     addDebugCompDirArg(Args, CmdArgs, C.getDriver().getVFS());
 
-    addDebugPrefixMapArg(getToolChain().getDriver(), Args, CmdArgs);
+    addDebugPrefixMapArg(getToolChain().getDriver(), getToolChain(), Args,
+                         CmdArgs);
 
     // Set the AT_producer to the clang version when using the integrated
     // assembler on assembly source files.

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -2794,6 +2794,12 @@ bool MachO::UseDwarfDebugFlags() const {
   return false;
 }
 
+std::string MachO::GetGlobalDebugPathRemapping() const {
+  if (const char *S = ::getenv("RC_DEBUG_PREFIX_MAP"))
+    return S;
+  return {};
+}
+
 llvm::ExceptionHandling Darwin::GetExceptionModel(const ArgList &Args) const {
   // Darwin uses SjLj exceptions on ARM.
   if (getTriple().getArch() != llvm::Triple::arm &&

--- a/clang/lib/Driver/ToolChains/Darwin.h
+++ b/clang/lib/Driver/ToolChains/Darwin.h
@@ -260,6 +260,7 @@ public:
   bool SupportsProfiling() const override;
 
   bool UseDwarfDebugFlags() const override;
+  std::string GetGlobalDebugPathRemapping() const override;
 
   llvm::ExceptionHandling
   GetExceptionModel(const llvm::opt::ArgList &Args) const override {

--- a/clang/test/Driver/darwin-debug-prefix-map.c
+++ b/clang/test/Driver/darwin-debug-prefix-map.c
@@ -1,0 +1,6 @@
+// RUN: env RC_DEBUG_PREFIX_MAP=old=new \
+// RUN:  %clang -target arm64-apple-darwin -### -c -g %s 2>&1 | FileCheck %s
+// RUN: env RC_DEBUG_PREFIX_MAP=illegal \
+// RUN:  %clang -target arm64-apple-darwin -### -c -g %s 2>&1 | FileCheck %s --check-prefix=ERR
+// CHECK: "-fdebug-prefix-map=old=new" 
+// ERR: invalid argument 'illegal'

--- a/clang/test/Driver/darwin-debug-prefix-map.s
+++ b/clang/test/Driver/darwin-debug-prefix-map.s
@@ -1,0 +1,6 @@
+// RUN: env RC_DEBUG_PREFIX_MAP=old=new \
+// RUN:  %clang -target arm64-apple-darwin -### -c -g %s 2>&1 | FileCheck %s
+// RUN: env RC_DEBUG_PREFIX_MAP=illegal \
+// RUN:  %clang -target arm64-apple-darwin -### -c -g %s 2>&1 | FileCheck %s --check-prefix=ERR
+// CHECK: "-fdebug-prefix-map=old=new" 
+// ERR: invalid argument 'illegal'


### PR DESCRIPTION
This patch adds a new Darwin clang driver environment variable in the
spirit of RC_DEBUG_OPTIONS, called RC_DEBUG_PREFIX_MAP, which allows a
meta build tool to add one additional -fdebug-prefix-map entry without
the knowledge of the build system.

rdar://85224675

Differential Revision: https://reviews.llvm.org/D119850

(cherry picked from commit 0604d86c07ab8a28b95df689aff4ddd26347f35f)