### PR TITLE
Remove broken (and obsolete) cleanup hooks

### DIFF
--- a/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/Makefile
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/Makefile
@@ -2,7 +2,7 @@ SWIFT_SOURCES=main.swift
 SWIFTFLAGS_EXTRAS= -I.
 LD_EXTRAS=-L.
 
-all: SomeLibraryCore.swiftmodule SomeLibrary.swiftmodule a.out
+all: clean SomeLibraryCore.swiftmodule SomeLibrary.swiftmodule a.out
 
 include Makefile.rules
 

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
@@ -47,10 +47,6 @@ class TestLibraryIndirect(TestBase):
         See the ReadMe.md in the parent directory for more information.
         """
         self.build()
-        def cleanup():
-            lldbutil.execute_command("make cleanup")
-        self.addTearDownHook(cleanup)
-
         if lldb.remote_platform:
             ext = 'so'
             if self.platformIsDarwin():
@@ -87,9 +83,6 @@ class TestLibraryIndirect(TestBase):
         self.build()
         os.remove(self.getBuildArtifact("SomeLibraryCore.swiftmodule"))
         os.remove(self.getBuildArtifact("SomeLibraryCore.swiftinterface"))
-        def cleanup():
-            lldbutil.execute_command("make cleanup")
-        self.addTearDownHook(cleanup)
 
         if lldb.remote_platform:
             ext = 'so'

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/Makefile
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/Makefile
@@ -2,7 +2,7 @@ SWIFT_SOURCES=main.swift
 SWIFTFLAGS_EXTRAS= -I.
 LD_EXTRAS=-L.
 
-all: SomeLibraryCore.swiftmodule SomeLibrary.swiftmodule a.out
+all: clean SomeLibraryCore.swiftmodule SomeLibrary.swiftmodule a.out
 
 include Makefile.rules
 
@@ -18,4 +18,3 @@ SomeLibrary.swiftmodule: SomeLibrary.swift SomeLibraryCore.swiftmodule
 
 clean::
 	rm -rf *.o *.dylib *.so *.dll *.dSYM *.swiftdoc *.swiftmodule *.swiftinterface
-

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
@@ -50,9 +50,6 @@ class TestLibraryResilient(TestBase):
         """
 
         self.build()
-        def cleanup():
-            lldbutil.execute_command("make cleanup")
-        self.addTearDownHook(cleanup)
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
 
         # This test is deliberately checking what the user will see, rather than
@@ -74,9 +71,6 @@ class TestLibraryResilient(TestBase):
         self.build()
         os.remove(self.getBuildArtifact("SomeLibraryCore.swiftmodule"))
         os.remove(self.getBuildArtifact("SomeLibraryCore.swiftinterface"))
-        def cleanup():
-            lldbutil.execute_command("make cleanup")
-        self.addTearDownHook(cleanup)
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
 
         # This test is deliberately checking what the user will see, rather than

--- a/lldb/test/API/lang/swift/implementation_only_imports/main_executable/Makefile
+++ b/lldb/test/API/lang/swift/implementation_only_imports/main_executable/Makefile
@@ -3,7 +3,7 @@ SWIFTFLAGS_EXTRAS= -I$(shell pwd)
 MODULENAME=main
 LD_EXTRAS=-L$(shell pwd)
 
-all: SomeLibrary.swiftmodule a.out
+all: clean SomeLibrary.swiftmodule a.out
 
 include Makefile.rules
 

--- a/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -51,9 +51,6 @@ class TestMainExecutable(TestBase):
         """
 
         self.build()
-        def cleanup():
-            lldbutil.execute_command("make cleanup")
-        self.addTearDownHook(cleanup)
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
 
         # This test is deliberately checking what the user will see, rather than
@@ -80,9 +77,6 @@ class TestMainExecutable(TestBase):
         self.runCmd("settings set symbols.use-swift-dwarfimporter false")
         os.remove(self.getBuildArtifact("SomeLibrary.swiftmodule"))
         os.remove(self.getBuildArtifact("SomeLibrary.swiftinterface"))
-        def cleanup():
-            lldbutil.execute_command("make cleanup")
-        self.addTearDownHook(cleanup)
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
 
         # FIXME: This particular test config is producing different results on
@@ -111,9 +105,6 @@ class TestMainExecutable(TestBase):
         """
 
         self.build(dictionary={"LIBRARY_SWIFTFLAGS_EXTRAS": "-enable-library-evolution"})
-        def cleanup():
-            lldbutil.execute_command("make cleanup")
-        self.addTearDownHook(cleanup)
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
 
         # This test is deliberately checking what the user will see, rather than
@@ -137,9 +128,6 @@ class TestMainExecutable(TestBase):
         self.build(dictionary={"LIBRARY_SWIFTFLAGS_EXTRAS": "-enable-library-evolution"})
         os.remove(self.getBuildArtifact("SomeLibrary.swiftmodule"))
         os.remove(self.getBuildArtifact("SomeLibrary.swiftinterface"))
-        def cleanup():
-            lldbutil.execute_command("make cleanup")
-        self.addTearDownHook(cleanup)
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
 
         # This test is deliberately checking what the user will see, rather than

--- a/lldb/test/API/lang/swift/swift_version/TestSwiftVersion.py
+++ b/lldb/test/API/lang/swift/swift_version/TestSwiftVersion.py
@@ -37,10 +37,6 @@ class TestSwiftVersion(TestBase):
 
     def do_test(self):
         """Test that LLDB can debug different Swift language versions"""
-        def cleanup():
-            lldbutil.execute_command("make cleanup")
-        self.addTearDownHook(cleanup)
-
         exe_name = "main"
         exe_path = self.getBuildArtifact(exe_name)
 


### PR DESCRIPTION
They litter the log output with confusing error messages, because they
don't actually work with the latest Makefile.rules. They are also
obsolete because each test function is now running in its own
directory.