### PR TITLE
[lldb] [gdb-remote] Fix processing generic regnums

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -496,7 +496,7 @@ void ProcessGDBRemote::BuildDynamicRegisterInfo(bool force) {
           } else if (name.equals("dwarf")) {
             value.getAsInteger(0, reg_info.regnum_dwarf);
           } else if (name.equals("generic")) {
-            value.getAsInteger(0, reg_info.regnum_generic);
+            reg_info.regnum_generic = Args::StringToGenericRegister(value);
           } else if (name.equals("container-regs")) {
             SplitCommaSeparatedRegisterNumberString(value, reg_info.value_regs, 16);
           } else if (name.equals("invalidate-regs")) {


### PR DESCRIPTION
[lldb] [gdb-remote] Fix processing generic regnums

Fix regression in processing generic regnums that was introduced
in fa456505b80b0cf83647a1b26713e4d3b38eccc2 ("[lldb] [gdb-remote]
Refactor getting remote regs to use local vector").  Since then,
the "generic" field was wrongly interpreted as integer rather than
string constant.

Thanks to Ted Woodward for noticing and providing the correct code.

(cherry picked from commit 16a816a19e2a8c65cf34dbf2ef9d7497b200c0b1)