### PR TITLE
[lldb/Swift] Separate Swift logging from core logging (NFC)

### DIFF
--- a/lldb/include/lldb/Utility/Logging.h
+++ b/lldb/include/lldb/Utility/Logging.h
@@ -11,10 +11,6 @@
 
 #include <cstdint>
 
-#ifdef LLDB_ENABLE_SWIFT
-#include "llvm/ADT/StringRef.h"
-#endif
-
 // Log Bits specific to logging in lldb
 #define LIBLLDB_LOG_PROCESS (1u << 1)
 #define LIBLLDB_LOG_THREAD (1u << 2)
@@ -54,10 +50,6 @@
    LIBLLDB_LOG_STATE | LIBLLDB_LOG_SYMBOLS | LIBLLDB_LOG_TARGET |              \
    LIBLLDB_LOG_COMMANDS)
 
-#ifdef LLDB_ENABLE_SWIFT
-#define LIBLLDB_SWIFT_LOG_HEALTH (1u << 1)
-#endif
-
 namespace lldb_private {
 
 class Log;
@@ -65,11 +57,6 @@ class Log;
 Log *GetLogIfAllCategoriesSet(uint32_t mask);
 
 Log *GetLogIfAnyCategoriesSet(uint32_t mask);
-
-#ifdef LLDB_ENABLE_SWIFT
-Log *GetSwiftHealthLog();
-llvm::StringRef GetSwiftHealthLogData();
-#endif
 
 void InitializeLldbChannel();
 

--- a/lldb/source/Commands/CMakeLists.txt
+++ b/lldb/source/Commands/CMakeLists.txt
@@ -2,7 +2,7 @@ lldb_tablegen(CommandOptions.inc -gen-lldb-option-defs
   SOURCE Options.td
   TARGET LLDBOptionsGen)
 
-add_lldb_library(lldbCommands
+set(Command_SOURCES
   CommandCompletions.cpp
   CommandObjectApropos.cpp
   CommandObjectBreakpoint.cpp
@@ -12,7 +12,6 @@ add_lldb_library(lldbCommands
   CommandObjectExpression.cpp
   CommandObjectFrame.cpp
   CommandObjectGUI.cpp
-  CommandObjectHealthcheck.cpp
   CommandObjectHelp.cpp
   CommandObjectLanguage.cpp
   CommandObjectLog.cpp
@@ -40,6 +39,15 @@ add_lldb_library(lldbCommands
   CommandObjectWatchpoint.cpp
   CommandObjectWatchpointCommand.cpp
   CommandOptionsProcessLaunch.cpp
+)
+
+if (LLDB_ENABLE_SWIFT_SUPPORT)
+  set(Command_SOURCES ${Command_SOURCES} CommandObjectHealthcheck.cpp)
+endif()
+
+add_lldb_library(lldbCommands
+
+  ${Command_SOURCES}
 
   LINK_LIBS
     lldbBreakpoint

--- a/lldb/source/Commands/CommandObjectHealthcheck.cpp
+++ b/lldb/source/Commands/CommandObjectHealthcheck.cpp
@@ -14,6 +14,8 @@
 #include "lldb/Host/FileSystem.h"
 #include "lldb/lldb-private.h"
 
+#include "Plugins/Language/Swift/LogChannelSwift.h"
+
 using namespace lldb;
 using namespace lldb_private;
 
@@ -25,7 +27,6 @@ CommandObjectHealthcheck::CommandObjectHealthcheck(
 
 bool CommandObjectHealthcheck::DoExecute(Args &args,
                                          CommandReturnObject &result) {
-#ifdef LLDB_ENABLE_SWIFT
   std::error_code err;
   llvm::SmallString<128> temp_path;
   int temp_fd = -1;
@@ -50,6 +51,5 @@ bool CommandObjectHealthcheck::DoExecute(Args &args,
 
   result.AppendMessageWithFormat("Health check written to %s\n",
                                  temp_path.c_str());
-#endif
   return true;
 }

--- a/lldb/source/Plugins/Language/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/Swift/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LLVM_NO_RTTI 1)
 
 add_lldb_library(lldbPluginSwiftLanguage PLUGIN
   FoundationValueTypes.cpp
+  LogChannelSwift.cpp
   ObjCRuntimeSyntheticProvider.cpp
   SwiftArray.cpp
   SwiftBasicTypes.cpp

--- a/lldb/source/Plugins/Language/Swift/LogChannelSwift.cpp
+++ b/lldb/source/Plugins/Language/Swift/LogChannelSwift.cpp
@@ -1,0 +1,42 @@
+//===-- LogChannelSwift.cpp -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "LogChannelSwift.h"
+
+using namespace lldb_private;
+
+static constexpr Log::Category g_categories[] = {
+    {{"health"},
+     {"log all messages related to lldb Swift operational health"},
+     LIBLLDB_SWIFT_LOG_HEALTH},
+};
+
+static Log::Channel g_channel(g_categories, LIBLLDB_SWIFT_LOG_HEALTH);
+
+static std::string g_swift_log_buffer;
+
+Log::Channel LogChannelSwift::g_channel(g_categories, SWIFT_LOG_DEFAULT);
+
+void LogChannelSwift::Initialize() {
+  Log::Register("swift", g_channel);
+
+  llvm::raw_null_ostream error_stream;
+  Log::EnableLogChannel(
+      std::make_shared<llvm::raw_string_ostream>(g_swift_log_buffer),
+      LLDB_LOG_OPTION_THREADSAFE, "swift", {"health"}, error_stream);
+}
+
+void LogChannelSwift::Terminate() { Log::Unregister("swift"); }
+
+Log *lldb_private::GetSwiftHealthLog() {
+  return g_channel.GetLogIfAny(LIBLLDB_SWIFT_LOG_HEALTH);
+}
+
+llvm::StringRef lldb_private::GetSwiftHealthLogData() {
+  return g_swift_log_buffer;
+}

--- a/lldb/source/Plugins/Language/Swift/LogChannelSwift.h
+++ b/lldb/source/Plugins/Language/Swift/LogChannelSwift.h
@@ -1,0 +1,35 @@
+//===-- LogChannelSwift.h ---------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_LogChannelSwift_h_
+#define liblldb_LogChannelSwift_h_
+
+#include "lldb/Utility/Log.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace lldb_private {
+
+#define LIBLLDB_SWIFT_LOG_HEALTH (1u << 1)
+#define SWIFT_LOG_DEFAULT (LIBLLDB_SWIFT_LOG_HEALTH)
+
+class LogChannelSwift {
+  static Log::Channel g_channel;
+
+public:
+  static void Initialize();
+  static void Terminate();
+
+  static Log *GetLogIfAll(uint32_t mask) { return g_channel.GetLogIfAll(mask); }
+  static Log *GetLogIfAny(uint32_t mask) { return g_channel.GetLogIfAny(mask); }
+};
+
+Log *GetSwiftHealthLog();
+llvm::StringRef GetSwiftHealthLogData();
+} // namespace lldb_private
+
+#endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_LOGCHANNELDWARF_H

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -126,6 +126,7 @@
 
 #include "llvm/ADT/ScopeExit.h"
 
+#include "Plugins/Language/Swift/LogChannelSwift.h"
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
 #include "Plugins/Platform/MacOSX/PlatformDarwin.h"
 #include "Plugins/SymbolFile/DWARF/DWARFASTParserClang.h"

--- a/lldb/source/Utility/Logging.cpp
+++ b/lldb/source/Utility/Logging.cpp
@@ -51,28 +51,8 @@ static constexpr Log::Category g_categories[] = {
 
 static Log::Channel g_log_channel(g_categories, LIBLLDB_LOG_DEFAULT);
 
-#ifdef LLDB_ENABLE_SWIFT
-
-static constexpr Log::Category g_swift_categories[] = {
-  {{"health"}, {"log all messages related to lldb Swift operational health"}, LIBLLDB_SWIFT_LOG_HEALTH},
-};
-
-static Log::Channel g_swift_log_channel(g_swift_categories, LIBLLDB_SWIFT_LOG_HEALTH);
-
-static std::string g_swift_log_buffer;
-
-#endif
-
 void lldb_private::InitializeLldbChannel() {
   Log::Register("lldb", g_log_channel);
-#ifdef LLDB_ENABLE_SWIFT
-  Log::Register("swift", g_swift_log_channel);
-
-  llvm::raw_null_ostream error_stream;
-  Log::EnableLogChannel(
-      std::make_shared<llvm::raw_string_ostream>(g_swift_log_buffer),
-      LLDB_LOG_OPTION_THREADSAFE, "swift", {"health"}, error_stream);
-#endif
 }
 
 Log *lldb_private::GetLogIfAllCategoriesSet(uint32_t mask) {
@@ -84,13 +64,5 @@ Log *lldb_private::GetLogIfAnyCategoriesSet(uint32_t mask) {
 }
 
 #ifdef LLDB_ENABLE_SWIFT
-
-Log *lldb_private::GetSwiftHealthLog() {
-  return g_swift_log_channel.GetLogIfAny(LIBLLDB_SWIFT_LOG_HEALTH);
-}
-
-llvm::StringRef lldb_private::GetSwiftHealthLogData() {
-  return g_swift_log_buffer;
-}
 
 #endif


### PR DESCRIPTION
This patch removes the Swift logging channel from lldb's core logging file.
It moves it into a separate file in the Swift Language Plugin, so it can be
build conditionally when Swift support is enabled.

This also applies to the the `swift-healthcheck` command object, which
will now only be available when Swift support is enabled.

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>