### PR TITLE
[lldb] Read swift metadata from symbol rich binary

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -172,6 +172,8 @@ public:
   bool GetSwiftReadMetadataFromFileCache() const;
 
   bool GetSwiftUseReflectionSymbols() const;
+  
+  bool GetSwiftReadMetadataFromDSYM() const;
 
   bool GetEnableAutoImportClangModules() const;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -245,6 +245,8 @@ bool LLDBMemoryReader::readBytes(swift::remote::RemoteAddress address,
 
   LLDB_LOGV(log, "[MemoryReader] asked to read {0} bytes at address {1:x}",
             size, address.getAddressData());
+  if (readBytesFromSymbolObjectFile(address.getAddressData(), dest, size))
+    return true;
 
   llvm::Optional<Address> maybeAddr =
       resolveRemoteAddress(address.getAddressData());
@@ -349,9 +351,14 @@ void LLDBMemoryReader::popLocalBuffer() {
 }
 
 llvm::Optional<std::pair<uint64_t, uint64_t>>
-LLDBMemoryReader::addModuleToAddressMap(ModuleSP module) {
+LLDBMemoryReader::addModuleToAddressMap(ModuleSP module, bool register_symbol_obj_file) {
   if (!readMetadataFromFileCacheEnabled())
     return {};
+
+  assert(register_symbol_obj_file <=
+             m_process.GetTarget().GetSwiftReadMetadataFromDSYM() &&
+         "Trying to register symbol object file, but reading from it is "
+         "disabled!");
 
   // The first available address is the mask, since subsequent images are mapped
   // in ascending order, all of them will contain this mask.
@@ -374,7 +381,20 @@ LLDBMemoryReader::addModuleToAddressMap(ModuleSP module) {
            "LLDB file address bit clashes with an obj-c bit!");
 #endif
 
-  SectionList *section_list = module->GetObjectFile()->GetSectionList();
+  ObjectFile *object_file;
+  if (register_symbol_obj_file) {
+    auto *symbol_file = module->GetSymbolFile();
+    if (!symbol_file)
+      return {};
+    object_file = symbol_file->GetObjectFile();
+  } else {
+    object_file = module->GetObjectFile();
+  }
+
+  if (!object_file)
+    return {};
+
+  SectionList *section_list = object_file->GetSectionList();
 
   auto section_list_size = section_list->GetSize();
   if (section_list_size == 0)
@@ -391,22 +411,27 @@ LLDBMemoryReader::addModuleToAddressMap(ModuleSP module) {
   // available after the end of the current image.
   uint64_t next_module_start_address = llvm::alignTo(module_end_address, 8);
   m_range_module_map.emplace_back(next_module_start_address, module);
+
+  if (register_symbol_obj_file)
+    m_modules_with_metadata_in_symbol_obj_file.insert(module);
+
   return {{module_start_address, module_end_address}};
 }
 
-llvm::Optional<Address>
-LLDBMemoryReader::resolveRemoteAddress(uint64_t address) const {
-  Log *log = GetLog(LLDBLog::Types);
+llvm::Optional<std::pair<uint64_t, lldb::ModuleSP>>
+LLDBMemoryReader::getFileAddressAndModuleForTaggedAddress(
+    uint64_t tagged_address) const {
+  Log *log(GetLog(LLDBLog::Types));
 
   if (!readMetadataFromFileCacheEnabled())
-    return Address(address);
+    return {};
 
   // If the address contains our mask, this is an image we registered.
-  if (!(address & LLDB_FILE_ADDRESS_BIT))
-    return Address(address);
+  if (!(tagged_address & LLDB_FILE_ADDRESS_BIT))
+    return {};
 
   // Dummy pair with the address we're looking for.
-  auto comparison_pair = std::make_pair(address, ModuleSP());
+  auto comparison_pair = std::make_pair(tagged_address, ModuleSP());
 
   // Explicitly compare only the addresses, never the modules in the pairs.
   auto pair_iterator = std::lower_bound(
@@ -418,7 +443,7 @@ LLDBMemoryReader::resolveRemoteAddress(uint64_t address) const {
     LLDB_LOG(log,
              "[MemoryReader] Address {0:x} is larger than the upper bound "
              "address of the mapped in modules",
-             address);
+             tagged_address);
     return {};
   }
 
@@ -427,15 +452,31 @@ LLDBMemoryReader::resolveRemoteAddress(uint64_t address) const {
   if (pair_iterator == m_range_module_map.begin())
     // Since this is the first registered module,
     // clearing the tag bit will give the virtual file address.
-    file_address = address & ~LLDB_FILE_ADDRESS_BIT;
+    file_address = tagged_address & ~LLDB_FILE_ADDRESS_BIT;
   else
     // The end of the previous section is the start of the current one.
-    file_address = address - std::prev(pair_iterator)->first;
+    file_address = tagged_address - std::prev(pair_iterator)->first;
 
   LLDB_LOGV(log,
             "[MemoryReader] Successfully resolved mapped address {0:x} into "
             "file address {1:x}",
-            address, file_address);
+            tagged_address, file_address);
+  return {{file_address, module}};
+}
+
+llvm::Optional<Address>
+LLDBMemoryReader::resolveRemoteAddress(uint64_t address) const {
+  Log *log(GetLog(LLDBLog::Types));
+  auto maybe_pair = getFileAddressAndModuleForTaggedAddress(address);
+  if (!maybe_pair)
+    return Address(address);
+
+  uint64_t file_address = maybe_pair->first;
+  ModuleSP module = maybe_pair->second;
+
+  if (m_modules_with_metadata_in_symbol_obj_file.count(module))
+    return Address(address);
+
   auto *object_file = module->GetObjectFile();
   if (!object_file)
     return {};
@@ -454,6 +495,47 @@ LLDBMemoryReader::resolveRemoteAddress(uint64_t address) const {
             "file address {1:x}",
             address, resolved.GetFileAddress());
   return resolved;
+}
+
+bool LLDBMemoryReader::readBytesFromSymbolObjectFile(uint64_t address, uint8_t *dest,
+                                             uint64_t size) const {
+  Log *log(GetLog(LLDBLog::Types));
+
+  if (!m_process.GetTarget().GetSwiftReadMetadataFromDSYM())
+    return false;
+
+  auto maybe_pair = getFileAddressAndModuleForTaggedAddress(address);
+  if (!maybe_pair)
+    return false;
+
+  uint64_t file_address = maybe_pair->first;
+  ModuleSP module = maybe_pair->second;
+
+  if (!m_modules_with_metadata_in_symbol_obj_file.count(module))
+    return false;
+
+  auto *symbol_file = module->GetSymbolFile();
+  if (!symbol_file)
+    return false;
+
+  auto *object_file = symbol_file->GetObjectFile();
+  if (!object_file)
+    return false;
+
+  Address resolved(file_address, object_file->GetSectionList());
+  if (!resolved.IsSectionOffset()) {
+    LLDB_LOG(log,
+             "[MemoryReader] Could not make a real address out of file address "
+             "{0:x} and object file {1}",
+             file_address, object_file->GetFileSpec().GetFilename());
+    return false;
+  }
+
+  LLDB_LOGV(log, "[MemoryReader] Reading memory from symbol rich binary");
+
+  auto section = resolved.GetSection();
+  return object_file->ReadSectionData(section.get(), resolved.GetOffset(),
+                                      dest, size);
 }
 
 bool LLDBMemoryReader::readMetadataFromFileCacheEnabled() const {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -644,30 +644,74 @@ bool SwiftLanguageRuntimeImpl::AddJitObjectFileToReflectionContext(
 }
 
 bool SwiftLanguageRuntimeImpl::AddObjectFileToReflectionContext(
-    ModuleSP module, ObjectFile &obj_file) {
+    ModuleSP module) {
   auto obj_format_type =
-        module->GetArchitecture().GetTriple().getObjectFormat();
+      module->GetArchitecture().GetTriple().getObjectFormat();
 
   auto obj_file_format = GetObjectFileFormat(obj_format_type);
   if (!obj_file_format)
     return false;
 
-  llvm::Optional<llvm::StringRef> maybe_segment_name =
-      obj_file_format->getSegmentName();
+  bool should_register_with_symbol_obj_file = [&]() -> bool {
+    if (!m_process.GetTarget().GetSwiftReadMetadataFromDSYM())
+      return false;
+    auto *symbol_file = module->GetSymbolFile();
+    if (!symbol_file)
+      return false;
+    auto *sym_obj_file = symbol_file->GetObjectFile();
+    if (!sym_obj_file)
+      return false;
+
+    llvm::Optional<llvm::StringRef> maybe_segment_name =
+        obj_file_format->getSymbolRichSegmentName();
+    if (!maybe_segment_name)
+      return false;
+
+    llvm::StringRef segment_name = *maybe_segment_name;
+
+    auto *section_list = sym_obj_file->GetSectionList();
+    auto segment_iter = llvm::find_if(*section_list, [&](auto segment) {
+      return segment->GetName() == segment_name.begin();
+    });
+
+    if (segment_iter == section_list->end())
+      return false;
+
+    auto *segment = segment_iter->get();
+
+    auto section_iter =
+        llvm::find_if(segment->GetChildren(), [&](auto section) {
+          return obj_file_format->sectionContainsReflectionData(
+              section->GetName().GetStringRef());
+        });
+    return section_iter != segment->GetChildren().end();
+  }();
+
+  llvm::Optional<llvm::StringRef> maybe_segment_name;
+  ObjectFile *object_file;
+  if (should_register_with_symbol_obj_file) {
+    maybe_segment_name = obj_file_format->getSymbolRichSegmentName();
+    object_file = module->GetSymbolFile()->GetObjectFile();
+  } else {
+    maybe_segment_name = obj_file_format->getSegmentName();
+    object_file = module->GetObjectFile();
+  }
+
   if (!maybe_segment_name)
     return false;
 
   llvm::StringRef segment_name = *maybe_segment_name;
+
   auto lldb_memory_reader = GetMemoryReader();
-  auto maybe_start_and_end = 
-      lldb_memory_reader->addModuleToAddressMap(module);
+  auto maybe_start_and_end = lldb_memory_reader->addModuleToAddressMap(
+      module, should_register_with_symbol_obj_file);
   if (!maybe_start_and_end)
     return false;
 
   uint64_t start_address, end_address;
   std::tie(start_address, end_address) = *maybe_start_and_end;
 
-  auto *section_list = obj_file.GetSectionList();
+  auto *section_list = object_file->GetSectionList();
   auto segment_iter = llvm::find_if(*section_list, [&](auto segment) {
     return segment->GetName() == segment_name.begin();
   });
@@ -680,8 +724,7 @@ bool SwiftLanguageRuntimeImpl::AddObjectFileToReflectionContext(
   return m_reflection_ctx->addImage(
       [&](swift::ReflectionSectionKind section_kind)
           -> std::pair<swift::remote::RemoteRef<void>, uint64_t> {
-        auto section_name =
-            obj_file_format->getSectionName(section_kind);
+        auto section_name = obj_file_format->getSectionName(section_kind);
         for (auto section : segment->GetChildren()) {
           // Iterate over the sections until we find the reflection section we
           // need.
@@ -764,7 +807,7 @@ bool SwiftLanguageRuntimeImpl::AddModuleToReflectionContext(
         llvm::Optional<llvm::sys::MemoryBlock>(file_buffer));
   } else if (read_from_file_cache &&
              obj_file->GetPluginName().equals("mach-o")) {
-    if (!AddObjectFileToReflectionContext(module_sp, *obj_file))
+    if (!AddObjectFileToReflectionContext(module_sp))
       m_reflection_ctx->addImage(swift::remote::RemoteAddress(load_ptr));
   } else {
     m_reflection_ctx->addImage(swift::remote::RemoteAddress(load_ptr));

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -393,7 +393,7 @@ private:
   /// the directly from the object file.
   /// \return true on success.
   bool AddObjectFileToReflectionContext(
-      lldb::ModuleSP module, ObjectFile &obj_file);
+      lldb::ModuleSP module);
 
   /// Cache for the debug-info-originating type infos.
   /// \{

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4194,6 +4194,17 @@ bool TargetProperties::GetSwiftUseReflectionSymbols() const {
     return true;
 }
 
+bool TargetProperties::GetSwiftReadMetadataFromDSYM() const {
+  const Property *exp_property = m_collection_sp->GetPropertyAtIndex(
+      nullptr, false, ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    return exp_values->GetPropertyAtIndexAsBoolean(
+        nullptr, ePropertySwiftReadMetadataFromDSYM, true);
+
+  return true;
+}
 ArchSpec TargetProperties::GetDefaultArchitecture() const {
   OptionValueArch *value = m_collection_sp->GetPropertyAtIndexAsOptionValueArch(
       nullptr, ePropertyDefaultArch);

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -10,6 +10,9 @@ let Definition = "target_experimental" in {
   def SwiftUseReflectionSymbols : Property<"swift-use-reflection-symbols", "Boolean">,
     Global, DefaultTrue,
     Desc<"if true, optimize the loading of Swift reflection metadata by making use of available symbols.">;
+  def SwiftReadMetadataFromDSYM: Property<"swift-read-metadata-from-dsym", "Boolean">,
+    DefaultFalse,
+    Desc<"Read Swift reflection metadata from the dsym instead of the process when possible">;
 }
 
 let Definition = "target" in {


### PR DESCRIPTION
In cases where Swift metadata is present in the symbol rich binary, read
swift metadata from it instead of from the main binary or the process.
This patch essentially re-uses the functionality implemented to read
metadata from the file-cache to achieve this.