### PR TITLE
Fix typo in Swift.def, it is swift5_protocol_conformances not swift5_protocol_confromances

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Swift.def
+++ b/llvm/include/llvm/BinaryFormat/Swift.def
@@ -24,7 +24,7 @@ HANDLE_SWIFT_SECTION(builtin, "__swift5_builtin", "swift5_builtin", ".sw5bltn")
 HANDLE_SWIFT_SECTION(capture, "__swift5_capture", "swift5_capture", ".sw5cptr")
 HANDLE_SWIFT_SECTION(typeref, "__swift5_typeref", "swift5_typeref", ".sw5tyrf")
 HANDLE_SWIFT_SECTION(reflstr, "__swift5_reflstr", "swift5_reflstr", ".sw5rfst")
-HANDLE_SWIFT_SECTION(conform, "__swift5_proto", "swift5_protocol_confromances",
+HANDLE_SWIFT_SECTION(conform, "__swift5_proto", "swift5_protocol_conformances",
                      ".sw5prtc$B")
 HANDLE_SWIFT_SECTION(protocs, "__swift5_protos", "swift5_protocols",
                      ".sw5prt$B")


### PR DESCRIPTION


(cherry picked from commit 822a1aad17288c23edd8a0c15f2c8130db66f262)