### PR TITLE
[lldb] Do not return old Swift mangled symbols from resolvePointerAsSymbol

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -153,7 +153,8 @@ LLDBMemoryReader::resolvePointerAsSymbol(swift::remote::RemoteAddress address) {
     auto mangledName = symbol->GetMangled().GetMangledName().GetStringRef();
     // MemoryReader requires this to be a Swift symbol. LLDB can also be
     // aware of local symbols, so avoid returning those.
-    if (swift::Demangle::isSwiftSymbol(mangledName))
+    using namespace swift::Demangle;
+    if (isSwiftSymbol(mangledName) && !isOldFunctionTypeMangling(mangledName))
       return {{mangledName, 0}};
   }
 


### PR DESCRIPTION
`isSwiftSymbol()` returns true for old Swift type mangling, which is any symbol starting with `"_T"`. This is unwanted, so the check is expanded to exclude regular symbols that happen to collide with the old prefix.