### PR TITLE
Move ownership of DWARFImporterDelegate to TypeSystemSwiftTypeRef (NFC)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/TypeSystem/Swift/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_lldb_library(lldbPluginTypeSystemSwift PLUGIN
+  DWARFImporterDelegate.cpp
   TypeSystemSwift.cpp
   TypeSystemSwiftTypeRef.cpp
   SwiftASTContext.cpp

--- a/lldb/source/Plugins/TypeSystem/Swift/DWARFImporterDelegate.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/DWARFImporterDelegate.cpp
@@ -1,0 +1,319 @@
+//===-- DWARFImporterDelegate.cpp -----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SwiftASTContext.h"
+
+#include "swift/ClangImporter/ClangImporter.h"
+#include "clang/AST/DeclObjC.h"
+#include "clang/Basic/SourceManager.h"
+#include "llvm/ADT/StringRef.h"
+
+#include "Plugins/ExpressionParser/Clang/ClangASTImporter.h"
+#include "Plugins/ExpressionParser/Clang/ClangUtil.h"
+#include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
+#include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
+#include "lldb/Core/Module.h"
+#include "lldb/Symbol/TypeMap.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Timer.h"
+
+using namespace lldb;
+using llvm::StringRef;
+
+namespace lldb_private {
+
+/// Implements a swift::DWARFImporterDelegate to look up Clang types in DWARF.
+///
+/// During compile time, ClangImporter-imported Clang modules are compiled with
+/// -gmodules, which emits a DWARF rendition of all types defined in the module
+/// into the .pcm file. On Darwin, these types can be collected by
+/// dsymutil. This delegate allows DWARFImporter to ask LLDB to look up a Clang
+/// type by name, synthesize a Clang AST from it. DWARFImporter then hands this
+/// Clang AST to ClangImporter to import the type into Swift.
+class SwiftDWARFImporterDelegate : public swift::DWARFImporterDelegate {
+  SwiftASTContext &m_swift_ast_ctx;
+  using ModuleAndName = std::pair<const char *, const char *>;
+  std::string m_description;
+
+  /// Used to filter out types with mismatching kinds.
+  bool HasTypeKind(TypeSP clang_type_sp, swift::ClangTypeKind kind) {
+    CompilerType fwd_type = clang_type_sp->GetForwardCompilerType();
+    clang::QualType qual_type = ClangUtil::GetQualType(fwd_type);
+    switch (kind) {
+    case swift::ClangTypeKind::Typedef:
+      /*=swift::ClangTypeKind::ObjCClass:*/
+      return !qual_type->isObjCObjectOrInterfaceType() &&
+             !qual_type->getAs<clang::TypedefType>();
+    case swift::ClangTypeKind::Tag:
+      return !qual_type->isStructureOrClassType() &&
+             !qual_type->isEnumeralType() && !qual_type->isUnionType();
+    case swift::ClangTypeKind::ObjCProtocol:
+      // Not implemented since Objective-C protocols aren't yet
+      // described in DWARF.
+      return true;
+    }
+  }
+
+  clang::Decl *GetDeclForTypeAndKind(clang::QualType qual_type,
+                                     swift::ClangTypeKind kind) {
+    switch (kind) {
+    case swift::ClangTypeKind::Typedef:
+      /*=swift::ClangTypeKind::ObjCClass:*/
+      if (auto *obj_type = qual_type->getAsObjCInterfaceType())
+        return obj_type->getInterface();
+      if (auto *typedef_type = qual_type->getAs<clang::TypedefType>())
+        return typedef_type->getDecl();
+      break;
+    case swift::ClangTypeKind::Tag:
+      return qual_type->getAsTagDecl();
+    case swift::ClangTypeKind::ObjCProtocol:
+      // Not implemented since Objective-C protocols aren't yet
+      // described in DWARF.
+      break;
+    }
+    return nullptr;
+  }
+
+  static CompilerContextKind
+  GetCompilerContextKind(llvm::Optional<swift::ClangTypeKind> kind) {
+    if (!kind)
+      return CompilerContextKind::AnyType;
+    switch (*kind) {
+    case swift::ClangTypeKind::Typedef:
+      /*=swift::ClangTypeKind::ObjCClass:*/
+      return (CompilerContextKind)((uint16_t)CompilerContextKind::Any |
+                                   (uint16_t)CompilerContextKind::Typedef |
+                                   (uint16_t)CompilerContextKind::Struct);
+      break;
+    case swift::ClangTypeKind::Tag:
+      return (CompilerContextKind)((uint16_t)CompilerContextKind::Any |
+                                   (uint16_t)CompilerContextKind::Class |
+                                   (uint16_t)CompilerContextKind::Struct |
+                                   (uint16_t)CompilerContextKind::Union |
+                                   (uint16_t)CompilerContextKind::Enum);
+      // case swift::ClangTypeKind::ObjCProtocol:
+      // Not implemented since Objective-C protocols aren't yet
+      // described in DWARF.
+    default:
+      return CompilerContextKind::Invalid;
+    }
+  }
+
+  /// Import \p qual_type from one clang ASTContext to another and
+  /// add it to \p results if successful.
+  void importType(clang::QualType qual_type, clang::ASTContext &from_ctx,
+                  clang::ASTContext &to_ctx,
+                  llvm::Optional<swift::ClangTypeKind> kind,
+                  llvm::SmallVectorImpl<clang::Decl *> &results) {
+    clang::ASTImporter importer(
+        to_ctx, to_ctx.getSourceManager().getFileManager(), from_ctx,
+        from_ctx.getSourceManager().getFileManager(), false);
+    llvm::Expected<clang::QualType> clang_type(importer.Import(qual_type));
+    if (!clang_type) {
+      llvm::consumeError(clang_type.takeError());
+      return;
+    }
+
+    // Retrieve the imported type's Decl.
+    if (kind) {
+      if (clang::Decl *clang_decl = GetDeclForTypeAndKind(*clang_type, *kind))
+        results.push_back(clang_decl);
+    } else {
+      swift::ClangTypeKind kinds[] = {
+          swift::ClangTypeKind::Typedef, // =swift::ClangTypeKind::ObjCClass,
+          swift::ClangTypeKind::Tag, swift::ClangTypeKind::ObjCProtocol};
+      for (auto kind : kinds)
+        if (clang::Decl *clang_decl = GetDeclForTypeAndKind(*clang_type, kind))
+          results.push_back(clang_decl);
+    }
+  }
+
+public:
+  SwiftDWARFImporterDelegate(SwiftASTContext &swift_ast_ctx)
+      : m_swift_ast_ctx(swift_ast_ctx),
+        m_description(swift_ast_ctx.GetDescription() +
+                      "::SwiftDWARFImporterDelegate") {}
+
+  /// Look up a clang::Decl by name.
+  ///
+  /// There are two primary ways that this delegate method is called:
+  ///
+  ///    1. When resolving a type from a mangled name. In this case \p
+  ///       kind will be known, but the owning module of a Clang type
+  ///       in a mangled name is always __ObjC or __C.
+  ///
+  ///    2. When resolving a type from a serialized module
+  ///       cross reference. In this case \c kind will be unspecified,
+  ///       but the (top-level) module that the type is defined in
+  ///       will be known.
+  ///
+  /// The following diagram shows how the various components
+  /// interact. All paths lead to a call to the function
+  /// \c ClangImporter::Implementation::importDeclReal(), which turns
+  /// a \c clang::Decl into a \c swift::Decl.  The return paths leading
+  /// back from \c importDeclReal() are omitted from the diagram. Also
+  /// some auxiliary intermediate function calls are be omitted for
+  /// brevity.
+  ///
+  /// \verbatim
+  /// ╔═LLDB═════════════════════════════════════════════════════════════════╗
+  /// ║                                                                      ║
+  /// ║  ┌─DWARFASTParserSwift──────────┐   ┌─DWARFImporterDelegate──────┐   ║
+  /// ║  │                              │   │                            │   ║
+  /// ║  │ GetTypeFromMangledTypename() │ ┌─├→lookupValue()─────┐        │   ║
+  /// ║  │             │                │ │ │                   │        │   ║
+  /// ║  └─────────────┬────────────────┘ │ └───────────────────┬────────┘   ║
+  /// ║                │                  │                     │            ║
+  /// ╚════════════════╤══════════════════╧═════════════════════╤════════════╝
+  ///                  │                  │                     │
+  /// ╔═Swift Compiler═╤══════════════════╧═════════════════════╤════════════╗
+  /// ║                │                  │                     │            ║
+  /// ║  ┌─ASTDemangler┬─────────────┐    │ ┌─ClangImporter─────┬────┐       ║
+  /// ║  │             ↓             │    │ │                   │    │       ║
+  /// ║  │ findForeignTypeDecl()─────├──────├→lookupTypeDecl()  │    │       ║
+  /// ║  │                           │    │ │      ⇣            ↓    │       ║
+  /// ║  └───────────────────────────┘    └─┤─lookupTypeDeclDWARF()  │       ║
+  /// ║                                     │      ↓                 │       ║
+  /// ║                                     │ *importDeclReal()*     │       ║
+  /// ║                                     │      ↑                 │       ║
+  /// ║                                     │ lookupValueDWARF()     │       ║
+  /// ║                                     │      ↑                 │       ║
+  /// ║                                     └──────┴─────────────────┘       ║
+  /// ║                                            │                         ║
+  /// ║  ┌─Deserialization─────────┐               └──────────────────────┐  ║
+  /// ║  │ loadAllMembers()        │                                      │  ║
+  /// ║  │        ↓                │  ┌─ModuleDecl────┐ ┌─DWARFModuleUnit─┴┐ ║
+  /// ║  │ resolveCrossReference()─├──├→lookupValue()─├─├→lookupValue()───┘│ ║
+  /// ║  │                         │  └───────────────┘ └──────────────────┘ ║
+  /// ║  └─────────────────────────┘                                         ║
+  /// ╚══════════════════════════════════════════════════════════════════════╝
+  /// \endverbatim
+  void lookupValue(StringRef name, llvm::Optional<swift::ClangTypeKind> kind,
+                   StringRef inModule,
+                   llvm::SmallVectorImpl<clang::Decl *> &results) override {
+    LLDB_SCOPED_TIMER();
+
+    LLDB_LOG(GetLog(LLDBLog::Types), "%s(\"%s\")", m_description.c_str(),
+             name.str().c_str());
+
+    // We will not find any Swift types in the Clang compile units.
+    ConstString name_cs(name);
+    if (SwiftLanguageRuntime::IsSwiftMangledName(name_cs.GetStringRef()))
+      return;
+
+    auto clang_importer = m_swift_ast_ctx.GetClangImporter();
+    if (!clang_importer)
+      return;
+
+    // Find the type in the debug info.
+    TypeMap clang_types;
+    ConstString module_cs(inModule);
+
+    llvm::SmallVector<CompilerContext, 3> decl_context;
+    // Perform a lookup in a specific module, if requested.
+    if (!inModule.empty())
+      decl_context.push_back({CompilerContextKind::Module, module_cs});
+    // Swift doesn't keep track of submodules.
+    decl_context.push_back({CompilerContextKind::AnyModule, ConstString()});
+    decl_context.push_back({GetCompilerContextKind(kind), name_cs});
+    llvm::DenseSet<SymbolFile *> searched_symbol_files;
+    auto search = [&](Module &module) {
+      module.FindTypes(decl_context,
+                       TypeSystemClang::GetSupportedLanguagesForTypes(),
+                       searched_symbol_files, clang_types);
+    };
+    if (Module *module =
+            m_swift_ast_ctx.GetTypeSystemSwiftTypeRef().GetModule())
+      search(*module);
+    else if (TargetSP target_sp = m_swift_ast_ctx.GetTargetWP().lock()) {
+      // In a scratch context, check the module's DWARFImporterDelegates
+      // first.
+      //
+      // It's a common pattern that a type is revisited immediately
+      // after looking it up in a per-module context in the scratch
+      // context for dynamic type resolution.
+      auto images = target_sp->GetImages();
+      for (size_t i = 0; i != images.GetSize(); ++i) {
+        auto module_sp = images.GetModuleAtIndex(i);
+        auto *swift_ast_ctx = GetModuleSwiftASTContext(*module_sp);
+        if (!swift_ast_ctx)
+          continue;
+        auto *dwarf_imp = static_cast<SwiftDWARFImporterDelegate *>(
+            swift_ast_ctx->GetDWARFImporterDelegate());
+        if (!dwarf_imp || dwarf_imp == this)
+          continue;
+
+        llvm::SmallVector<clang::Decl *, 2> module_results;
+        dwarf_imp->lookupValue(name, kind, inModule, module_results);
+        if (!module_results.size())
+          continue;
+
+        auto *from_clang_importer = swift_ast_ctx->GetClangImporter();
+        if (!from_clang_importer)
+          continue;
+        auto &from_ctx = from_clang_importer->getClangASTContext();
+        auto &to_ctx = clang_importer->getClangASTContext();
+        for (clang::Decl *decl : module_results) {
+          clang::QualType qual_type;
+          if (auto *interface = llvm::dyn_cast<clang::ObjCInterfaceDecl>(decl))
+            qual_type = {interface->getTypeForDecl(), 0};
+          if (auto *type = llvm::dyn_cast<clang::TypeDecl>(decl))
+            qual_type = {type->getTypeForDecl(), 0};
+          importType(qual_type, from_ctx, to_ctx, kind, results);
+        }
+        // Cut the search short after we found the first result.
+        if (results.size())
+          break;
+      }
+      LLDB_LOG(GetLog(LLDBLog::Types), "%s() -- %zu types collected.",
+               m_description.c_str(), results.size());
+      return;
+    }
+
+    clang_types.ForEach([&](lldb::TypeSP &clang_type_sp) {
+      if (!clang_type_sp)
+        return true;
+
+      // Filter out types with a mismatching type kind.
+      if (kind && HasTypeKind(clang_type_sp, *kind))
+        return true;
+
+      // Realize the full type.
+      CompilerType compiler_type = clang_type_sp->GetFullCompilerType();
+
+      // Filter our non-Clang types.
+      auto *type_system = llvm::dyn_cast_or_null<TypeSystemClang>(
+          compiler_type.GetTypeSystem());
+      if (!type_system)
+        return true;
+
+      // Import the type into the DWARFImporter's context.
+      clang::ASTContext &to_ctx = clang_importer->getClangASTContext();
+      clang::ASTContext &from_ctx = type_system->getASTContext();
+
+      clang::QualType qual_type = ClangUtil::GetQualType(compiler_type);
+      importType(qual_type, from_ctx, to_ctx, kind, results);
+
+      return true;
+    });
+
+    LLDB_LOG(GetLog(LLDBLog::Types), "%s() -- %zu types from debug info.",
+             m_description.c_str(), results.size());
+  }
+};
+
+swift::DWARFImporterDelegate *
+CreateSwiftDWARFImporterDelegate(SwiftASTContext &swift_ast_context) {
+  return new SwiftDWARFImporterDelegate(swift_ast_context);
+}
+
+} // namespace lldb_private

--- a/lldb/source/Plugins/TypeSystem/Swift/DWARFImporterDelegate.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/DWARFImporterDelegate.cpp
@@ -40,7 +40,7 @@ namespace lldb_private {
 /// type by name, synthesize a Clang AST from it. DWARFImporter then hands this
 /// Clang AST to ClangImporter to import the type into Swift.
 class SwiftDWARFImporterDelegate : public swift::DWARFImporterDelegate {
-  SwiftASTContext &m_swift_ast_ctx;
+  TypeSystemSwiftTypeRef &m_swift_typesystem;
   using ModuleAndName = std::pair<const char *, const char *>;
   std::string m_description;
 
@@ -138,10 +138,9 @@ class SwiftDWARFImporterDelegate : public swift::DWARFImporterDelegate {
   }
 
 public:
-  SwiftDWARFImporterDelegate(SwiftASTContext &swift_ast_ctx)
-      : m_swift_ast_ctx(swift_ast_ctx),
-        m_description(swift_ast_ctx.GetDescription() +
-                      "::SwiftDWARFImporterDelegate") {}
+  SwiftDWARFImporterDelegate(TypeSystemSwiftTypeRef &ts)
+      : m_swift_typesystem(ts),
+        m_description(ts.GetDescription() + "::SwiftDWARFImporterDelegate") {}
 
   /// Look up a clang::Decl by name.
   ///
@@ -202,15 +201,18 @@ public:
                    llvm::SmallVectorImpl<clang::Decl *> &results) override {
     LLDB_SCOPED_TIMER();
 
-    LLDB_LOG(GetLog(LLDBLog::Types), "%s(\"%s\")", m_description.c_str(),
-             name.str().c_str());
+    LLDB_LOG(GetLog(LLDBLog::Types), "{0}::lookupValue(\"{1}\")", m_description,
+             name.str());
 
     // We will not find any Swift types in the Clang compile units.
     ConstString name_cs(name);
     if (SwiftLanguageRuntime::IsSwiftMangledName(name_cs.GetStringRef()))
       return;
 
-    auto clang_importer = m_swift_ast_ctx.GetClangImporter();
+    auto *swift_ast_ctx = m_swift_typesystem.GetSwiftASTContext();
+    if (!swift_ast_ctx)
+      return;
+    auto clang_importer = swift_ast_ctx->GetClangImporter();
     if (!clang_importer)
       return;
 
@@ -232,9 +234,9 @@ public:
                        searched_symbol_files, clang_types);
     };
     if (Module *module =
-            m_swift_ast_ctx.GetTypeSystemSwiftTypeRef().GetModule())
+            m_swift_typesystem.GetModule())
       search(*module);
-    else if (TargetSP target_sp = m_swift_ast_ctx.GetTargetWP().lock()) {
+    else if (TargetSP target_sp = m_swift_typesystem.GetTargetWP().lock()) {
       // In a scratch context, check the module's DWARFImporterDelegates
       // first.
       //
@@ -244,39 +246,12 @@ public:
       auto images = target_sp->GetImages();
       for (size_t i = 0; i != images.GetSize(); ++i) {
         auto module_sp = images.GetModuleAtIndex(i);
-        auto *swift_ast_ctx = GetModuleSwiftASTContext(*module_sp);
-        if (!swift_ast_ctx)
+        if (!module_sp)
           continue;
-        auto *dwarf_imp = static_cast<SwiftDWARFImporterDelegate *>(
-            swift_ast_ctx->GetDWARFImporterDelegate());
-        if (!dwarf_imp || dwarf_imp == this)
-          continue;
-
-        llvm::SmallVector<clang::Decl *, 2> module_results;
-        dwarf_imp->lookupValue(name, kind, inModule, module_results);
-        if (!module_results.size())
-          continue;
-
-        auto *from_clang_importer = swift_ast_ctx->GetClangImporter();
-        if (!from_clang_importer)
-          continue;
-        auto &from_ctx = from_clang_importer->getClangASTContext();
-        auto &to_ctx = clang_importer->getClangASTContext();
-        for (clang::Decl *decl : module_results) {
-          clang::QualType qual_type;
-          if (auto *interface = llvm::dyn_cast<clang::ObjCInterfaceDecl>(decl))
-            qual_type = {interface->getTypeForDecl(), 0};
-          if (auto *type = llvm::dyn_cast<clang::TypeDecl>(decl))
-            qual_type = {type->getTypeForDecl(), 0};
-          importType(qual_type, from_ctx, to_ctx, kind, results);
-        }
-        // Cut the search short after we found the first result.
-        if (results.size())
+        search(*module_sp);
+        if (!clang_types.Empty())
           break;
       }
-      LLDB_LOG(GetLog(LLDBLog::Types), "%s() -- %zu types collected.",
-               m_description.c_str(), results.size());
-      return;
     }
 
     clang_types.ForEach([&](lldb::TypeSP &clang_type_sp) {
@@ -306,14 +281,15 @@ public:
       return true;
     });
 
-    LLDB_LOG(GetLog(LLDBLog::Types), "%s() -- %zu types from debug info.",
+    LLDB_LOG(GetLog(LLDBLog::Types),
+             "{0}::lookupValue() -- imported {1} types from debug info.",
              m_description.c_str(), results.size());
   }
 };
 
 swift::DWARFImporterDelegate *
-CreateSwiftDWARFImporterDelegate(SwiftASTContext &swift_ast_context) {
-  return new SwiftDWARFImporterDelegate(swift_ast_context);
+CreateSwiftDWARFImporterDelegate(TypeSystemSwiftTypeRef &ts) {
+  return new SwiftDWARFImporterDelegate(ts);
 }
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -956,10 +956,6 @@ SwiftASTContextForModule::~SwiftASTContextForModule() {
     GetASTMap().Erase(ctx);
 }
 
-const std::string &SwiftASTContext::GetDescription() const {
-  return m_description;
-}
-
 /// Return the Xcode sdk type for the target triple, if that makes sense.
 /// Otherwise, return the unknown sdk type.
 static XcodeSDK::Type GetSDKType(const llvm::Triple &target,
@@ -1945,7 +1941,7 @@ static lldb::ModuleSP GetUnitTestModule(lldb_private::ModuleList &modules) {
   return ModuleSP();
 }
 
-SwiftASTContext *lldb_private::GetModuleSwiftASTContext(Module &module) {
+static SwiftASTContext *GetModuleSwiftASTContext(Module &module) {
   auto type_system_or_err =
       module.GetTypeSystemForLanguage(lldb::eLanguageTypeSwift);
   if (!type_system_or_err) {
@@ -3066,12 +3062,11 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
     if (!clang_importer_options.OverrideResourceDir.empty()) {
       // Create the DWARFImporterDelegate.
       const auto &props = ModuleList::GetGlobalModuleListProperties();
+      swift::DWARFImporterDelegate *delegate = nullptr;
       if (props.GetUseSwiftDWARFImporter())
-        m_dwarf_importer_delegate_up.reset(
-            CreateSwiftDWARFImporterDelegate(*this));
+        delegate = &m_typeref_typesystem->GetDWARFImporterDelegate();
       clang_importer_ap = swift::ClangImporter::create(
-          *m_ast_context_ap, "",
-          m_dependency_tracker.get(), m_dwarf_importer_delegate_up.get());
+          *m_ast_context_ap, "", m_dependency_tracker.get(), delegate);
 
       // Handle any errors.
       if (!clang_importer_ap || HasErrors()) {
@@ -3241,12 +3236,6 @@ swift::ClangImporter *SwiftASTContext::GetClangImporter() {
 
   GetASTContext();
   return m_clang_importer;
-}
-
-swift::DWARFImporterDelegate *SwiftASTContext::GetDWARFImporterDelegate() {
-  VALID_OR_RETURN(nullptr);
-
-  return m_dwarf_importer_delegate_up.get();
 }
 
 const swift::SearchPathOptions *SwiftASTContext::GetSearchPathOptions() const {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -57,8 +57,6 @@
 #include "swift/Serialization/Validation.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "clang/AST/ASTContext.h"
-#include "clang/AST/DeclObjC.h"
-#include "clang/Basic/SourceManager.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Basic/TargetOptions.h"
 #include "clang/Driver/Driver.h"
@@ -89,7 +87,6 @@
 #include "swift/Strings.h"
 
 #include "Plugins/ExpressionParser/Clang/ClangHost.h"
-#include "Plugins/ExpressionParser/Clang/ClangUtil.h"
 #include "Plugins/ExpressionParser/Swift/SwiftDiagnostic.h"
 #include "Plugins/ExpressionParser/Swift/SwiftHost.h"
 #include "Plugins/ExpressionParser/Swift/SwiftUserExpression.h"
@@ -110,7 +107,6 @@
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Symbol/SourceModule.h"
 #include "lldb/Symbol/SymbolFile.h"
-#include "lldb/Symbol/TypeMap.h"
 #include "lldb/Symbol/VariableList.h"
 #include "lldb/Target/Platform.h"
 #include "lldb/Target/Process.h"
@@ -119,7 +115,6 @@
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/LLDBAssert.h"
 #include "lldb/Utility/LLDBLog.h"
-#include "lldb/Utility/Log.h"
 #include "lldb/Utility/ReproducerProvider.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/Timer.h"
@@ -1950,7 +1945,7 @@ static lldb::ModuleSP GetUnitTestModule(lldb_private::ModuleList &modules) {
   return ModuleSP();
 }
 
-static SwiftASTContext *GetModuleSwiftASTContext(Module &module) {
+SwiftASTContext *lldb_private::GetModuleSwiftASTContext(Module &module) {
   auto type_system_or_err =
       module.GetTypeSystemForLanguage(lldb::eLanguageTypeSwift);
   if (!type_system_or_err) {
@@ -3038,283 +3033,6 @@ private:
   bool m_colorize;
 };
 
-/// Implements a swift::DWARFImporterDelegate to look up Clang types in DWARF.
-///
-/// During compile time, ClangImporter-imported Clang modules are compiled with
-/// -gmodules, which emits a DWARF rendition of all types defined in the module
-/// into the .pcm file. On Darwin, these types can be collected by
-/// dsymutil. This delegate allows DWARFImporter to ask LLDB to look up a Clang
-/// type by name, synthesize a Clang AST from it. DWARFImporter then hands this
-/// Clang AST to ClangImporter to import the type into Swift.
-class SwiftDWARFImporterDelegate : public swift::DWARFImporterDelegate {
-  SwiftASTContext &m_swift_ast_ctx;
-  using ModuleAndName = std::pair<const char *, const char *>;
-  std::string m_description;
-
-  /// Used to filter out types with mismatching kinds.
-  bool HasTypeKind(TypeSP clang_type_sp, swift::ClangTypeKind kind) {
-    CompilerType fwd_type = clang_type_sp->GetForwardCompilerType();
-    clang::QualType qual_type = ClangUtil::GetQualType(fwd_type);
-    switch (kind) {
-    case swift::ClangTypeKind::Typedef:
-      /*=swift::ClangTypeKind::ObjCClass:*/
-      return !qual_type->isObjCObjectOrInterfaceType() &&
-             !qual_type->getAs<clang::TypedefType>();
-    case swift::ClangTypeKind::Tag:
-      return !qual_type->isStructureOrClassType() &&
-             !qual_type->isEnumeralType() && !qual_type->isUnionType();
-    case swift::ClangTypeKind::ObjCProtocol:
-      // Not implemented since Objective-C protocols aren't yet
-      // described in DWARF.
-      return true;
-    }
-  }
-
-  clang::Decl *GetDeclForTypeAndKind(clang::QualType qual_type,
-                                     swift::ClangTypeKind kind) {
-    switch (kind) {
-    case swift::ClangTypeKind::Typedef:
-      /*=swift::ClangTypeKind::ObjCClass:*/
-      if (auto *obj_type = qual_type->getAsObjCInterfaceType())
-        return obj_type->getInterface();
-      if (auto *typedef_type = qual_type->getAs<clang::TypedefType>())
-        return typedef_type->getDecl();
-      break;
-    case swift::ClangTypeKind::Tag:
-      return qual_type->getAsTagDecl();
-    case swift::ClangTypeKind::ObjCProtocol:
-      // Not implemented since Objective-C protocols aren't yet
-      // described in DWARF.
-      break;
-    }
-    return nullptr;
-  }
-
-  static CompilerContextKind
-  GetCompilerContextKind(llvm::Optional<swift::ClangTypeKind> kind) {
-    if (!kind)
-      return CompilerContextKind::AnyType;
-    switch (*kind) {
-    case swift::ClangTypeKind::Typedef:
-      /*=swift::ClangTypeKind::ObjCClass:*/
-      return (CompilerContextKind)((uint16_t)CompilerContextKind::Any |
-                                   (uint16_t)CompilerContextKind::Typedef |
-                                   (uint16_t)CompilerContextKind::Struct);
-      break;
-    case swift::ClangTypeKind::Tag:
-      return (CompilerContextKind)((uint16_t)CompilerContextKind::Any |
-                                   (uint16_t)CompilerContextKind::Class |
-                                   (uint16_t)CompilerContextKind::Struct |
-                                   (uint16_t)CompilerContextKind::Union |
-                                   (uint16_t)CompilerContextKind::Enum);
-      // case swift::ClangTypeKind::ObjCProtocol:
-      // Not implemented since Objective-C protocols aren't yet
-      // described in DWARF.
-    default:
-      return CompilerContextKind::Invalid;
-    }
-  }
-
-  /// Import \p qual_type from one clang ASTContext to another and
-  /// add it to \p results if successful.
-  void importType(clang::QualType qual_type, clang::ASTContext &from_ctx,
-                  clang::ASTContext &to_ctx,
-                  llvm::Optional<swift::ClangTypeKind> kind,
-                  llvm::SmallVectorImpl<clang::Decl *> &results) {
-    clang::ASTImporter importer(to_ctx,
-                                to_ctx.getSourceManager().getFileManager(),
-                                from_ctx,
-                                from_ctx.getSourceManager().getFileManager(),
-                                false);
-    llvm::Expected<clang::QualType> clang_type(importer.Import(qual_type));
-    if (!clang_type) {
-      llvm::consumeError(clang_type.takeError());
-      return;
-    }
-
-    // Retrieve the imported type's Decl.
-    if (kind) {
-      if (clang::Decl *clang_decl = GetDeclForTypeAndKind(*clang_type, *kind))
-        results.push_back(clang_decl);
-    } else {
-      swift::ClangTypeKind kinds[] = {
-          swift::ClangTypeKind::Typedef, // =swift::ClangTypeKind::ObjCClass,
-          swift::ClangTypeKind::Tag, swift::ClangTypeKind::ObjCProtocol};
-      for (auto kind : kinds)
-        if (clang::Decl *clang_decl = GetDeclForTypeAndKind(*clang_type, kind))
-          results.push_back(clang_decl);
-    }
-  }
-
-public:
-  SwiftDWARFImporterDelegate(SwiftASTContext &swift_ast_ctx)
-      : m_swift_ast_ctx(swift_ast_ctx),
-        m_description(swift_ast_ctx.GetDescription() +
-                      "::SwiftDWARFImporterDelegate") {}
-
-  /// Look up a clang::Decl by name.
-  ///
-  /// There are two primary ways that this delegate method is called:
-  ///
-  ///    1. When resolving a type from a mangled name. In this case \p
-  ///       kind will be known, but the owning module of a Clang type
-  ///       in a mangled name is always __ObjC or __C.
-  ///
-  ///    2. When resolving a type from a serialized module
-  ///       cross reference. In this case \c kind will be unspecified,
-  ///       but the (top-level) module that the type is defined in
-  ///       will be known.
-  ///
-  /// The following diagram shows how the various components
-  /// interact. All paths lead to a call to the function
-  /// \c ClangImporter::Implementation::importDeclReal(), which turns
-  /// a \c clang::Decl into a \c swift::Decl.  The return paths leading
-  /// back from \c importDeclReal() are omitted from the diagram. Also
-  /// some auxiliary intermediate function calls are be omitted for
-  /// brevity.
-  ///
-  /// \verbatim
-  /// ╔═LLDB═════════════════════════════════════════════════════════════════╗
-  /// ║                                                                      ║
-  /// ║  ┌─DWARFASTParserSwift──────────┐   ┌─DWARFImporterDelegate──────┐   ║
-  /// ║  │                              │   │                            │   ║
-  /// ║  │ GetTypeFromMangledTypename() │ ┌─├→lookupValue()─────┐        │   ║
-  /// ║  │             │                │ │ │                   │        │   ║
-  /// ║  └─────────────┬────────────────┘ │ └───────────────────┬────────┘   ║
-  /// ║                │                  │                     │            ║
-  /// ╚════════════════╤══════════════════╧═════════════════════╤════════════╝
-  ///                  │                  │                     │
-  /// ╔═Swift Compiler═╤══════════════════╧═════════════════════╤════════════╗
-  /// ║                │                  │                     │            ║
-  /// ║  ┌─ASTDemangler┬─────────────┐    │ ┌─ClangImporter─────┬────┐       ║
-  /// ║  │             ↓             │    │ │                   │    │       ║
-  /// ║  │ findForeignTypeDecl()─────├──────├→lookupTypeDecl()  │    │       ║
-  /// ║  │                           │    │ │      ⇣            ↓    │       ║
-  /// ║  └───────────────────────────┘    └─┤─lookupTypeDeclDWARF()  │       ║
-  /// ║                                     │      ↓                 │       ║
-  /// ║                                     │ *importDeclReal()*     │       ║
-  /// ║                                     │      ↑                 │       ║
-  /// ║                                     │ lookupValueDWARF()     │       ║
-  /// ║                                     │      ↑                 │       ║
-  /// ║                                     └──────┴─────────────────┘       ║
-  /// ║                                            │                         ║
-  /// ║  ┌─Deserialization─────────┐               └──────────────────────┐  ║
-  /// ║  │ loadAllMembers()        │                                      │  ║
-  /// ║  │        ↓                │  ┌─ModuleDecl────┐ ┌─DWARFModuleUnit─┴┐ ║
-  /// ║  │ resolveCrossReference()─├──├→lookupValue()─├─├→lookupValue()───┘│ ║
-  /// ║  │                         │  └───────────────┘ └──────────────────┘ ║
-  /// ║  └─────────────────────────┘                                         ║
-  /// ╚══════════════════════════════════════════════════════════════════════╝
-  /// \endverbatim
-  void lookupValue(StringRef name, llvm::Optional<swift::ClangTypeKind> kind,
-                   StringRef inModule,
-                   llvm::SmallVectorImpl<clang::Decl *> &results) override {
-    LLDB_SCOPED_TIMER();
-    LOG_PRINTF(GetLog(LLDBLog::Types), "(\"%s\")", name.str().c_str());
-
-    // We will not find any Swift types in the Clang compile units.
-    ConstString name_cs(name);
-    if (SwiftLanguageRuntime::IsSwiftMangledName(name_cs.GetStringRef()))
-      return;
-
-    auto clang_importer = m_swift_ast_ctx.GetClangImporter();
-    if (!clang_importer)
-      return;
-
-    // Find the type in the debug info.
-    TypeMap clang_types;
-    ConstString module_cs(inModule);
-
-    llvm::SmallVector<CompilerContext, 3> decl_context;
-    // Perform a lookup in a specific module, if requested.
-    if (!inModule.empty())
-      decl_context.push_back({CompilerContextKind::Module, module_cs});
-    // Swift doesn't keep track of submodules.
-    decl_context.push_back({CompilerContextKind::AnyModule, ConstString()});
-    decl_context.push_back({GetCompilerContextKind(kind), name_cs});
-    llvm::DenseSet<SymbolFile *> searched_symbol_files;
-    auto search = [&](Module &module) {
-      module.FindTypes(decl_context,
-                       TypeSystemClang::GetSupportedLanguagesForTypes(),
-                       searched_symbol_files, clang_types);
-    };
-    if (Module *module = m_swift_ast_ctx.GetTypeSystemSwiftTypeRef().GetModule())
-      search(*module);
-    else if (TargetSP target_sp = m_swift_ast_ctx.GetTargetWP().lock()) {
-      // In a scratch context, check the module's DWARFImporterDelegates first.
-      //
-      // It's a common pattern that a type is revisited immediately
-      // after looking it up in a per-module context in the scratch
-      // context for dynamic type resolution.
-      auto images = target_sp->GetImages();
-      for (size_t i = 0; i != images.GetSize(); ++i) {
-        auto module_sp = images.GetModuleAtIndex(i);
-        auto *swift_ast_ctx = GetModuleSwiftASTContext(*module_sp);
-	if (!swift_ast_ctx)
-          continue;
-        auto *dwarf_imp = static_cast<SwiftDWARFImporterDelegate *>(
-            swift_ast_ctx->GetDWARFImporterDelegate());
-        if (!dwarf_imp || dwarf_imp == this)
-          continue;
-
-        llvm::SmallVector<clang::Decl *, 2> module_results;
-        dwarf_imp->lookupValue(name, kind, inModule, module_results);
-        if (!module_results.size())
-          continue;
-
-        auto *from_clang_importer = swift_ast_ctx->GetClangImporter();
-        if (!from_clang_importer)
-          continue;
-        auto &from_ctx = from_clang_importer->getClangASTContext();
-        auto &to_ctx = clang_importer->getClangASTContext();
-        for (clang::Decl *decl : module_results) {
-          clang::QualType qual_type;
-          if (auto *interface = llvm::dyn_cast<clang::ObjCInterfaceDecl>(decl))
-            qual_type = {interface->getTypeForDecl(), 0};
-          if (auto *type = llvm::dyn_cast<clang::TypeDecl>(decl))
-            qual_type = {type->getTypeForDecl(), 0};
-          importType(qual_type, from_ctx, to_ctx, kind, results);
-        }
-        // Cut the search short after we found the first result.
-        if (results.size())
-          break;
-      }
-      LOG_PRINTF(GetLog(LLDBLog::Types), "%zu types collected.",
-                 results.size());
-      return;
-    }
-
-    clang_types.ForEach([&](lldb::TypeSP &clang_type_sp) {
-      if (!clang_type_sp)
-        return true;
-
-      // Filter out types with a mismatching type kind.
-      if (kind && HasTypeKind(clang_type_sp, *kind))
-        return true;
-
-      // Realize the full type.
-      CompilerType compiler_type = clang_type_sp->GetFullCompilerType();
-
-      // Filter our non-Clang types.
-      auto *type_system = llvm::dyn_cast_or_null<TypeSystemClang>(
-          compiler_type.GetTypeSystem());
-      if (!type_system)
-        return true;
-
-      // Import the type into the DWARFImporter's context.
-      clang::ASTContext &to_ctx = clang_importer->getClangASTContext();
-      clang::ASTContext &from_ctx = type_system->getASTContext();
-
-      clang::QualType qual_type = ClangUtil::GetQualType(compiler_type);
-      importType(qual_type, from_ctx, to_ctx, kind, results);
-
-      return true;
-    });
-
-    LOG_PRINTF(GetLog(LLDBLog::Types), "%zu types from debug info.",
-               results.size());
-  }
-};
 } // namespace lldb_private
 
 swift::ASTContext *SwiftASTContext::GetASTContext() {
@@ -3349,8 +3067,8 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
       // Create the DWARFImporterDelegate.
       const auto &props = ModuleList::GetGlobalModuleListProperties();
       if (props.GetUseSwiftDWARFImporter())
-        m_dwarf_importer_delegate_up =
-            std::make_unique<SwiftDWARFImporterDelegate>(*this);
+        m_dwarf_importer_delegate_up.reset(
+            CreateSwiftDWARFImporterDelegate(*this));
       clang_importer_ap = swift::ClangImporter::create(
           *m_ast_context_ap, "",
           m_dependency_tracker.get(), m_dwarf_importer_delegate_up.get());

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -28,7 +28,6 @@ namespace swift {
 enum class IRGenDebugInfoLevel : unsigned;
 class CanType;
 class DependencyTracker;
-class DWARFImporterDelegate;
 struct ImplicitImportInfo;
 class IRGenOptions;
 class NominalTypeDecl;
@@ -114,10 +113,6 @@ template <> struct hash<lldb_private::detail::SwiftLibraryLookupRequest> {
 
 namespace lldb_private {
 
-swift::DWARFImporterDelegate *
-CreateSwiftDWARFImporterDelegate(SwiftASTContext &swift_ast_context);
-SwiftASTContext *GetModuleSwiftASTContext(Module &module);
-
 /// This "middle" class between TypeSystemSwiftTypeRef and
 /// SwiftASTContextForExpressions will eventually go away, as more and
 /// more functionality becomes available in TypeSystemSwiftTypeRef.
@@ -182,8 +177,6 @@ public:
   /// Provided only for unit tests.
   SwiftASTContext();
 #endif
-
-  const std::string &GetDescription() const;
 
   /// Create a SwiftASTContext from a Module.  This context is used
   /// for frame variable and uses ClangImporter options specific to
@@ -403,7 +396,6 @@ public:
   CompilerType ImportType(CompilerType &type, Status &error);
 
   swift::ClangImporter *GetClangImporter();
-  swift::DWARFImporterDelegate *GetDWARFImporterDelegate();
 
   CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) override;
@@ -843,10 +835,8 @@ protected:
   std::unique_ptr<swift::CompilerInvocation> m_compiler_invocation_ap;
   std::unique_ptr<swift::SourceManager> m_source_manager_up;
   std::unique_ptr<swift::DiagnosticEngine> m_diagnostic_engine_ap;
-  std::unique_ptr<swift::DWARFImporterDelegate> m_dwarf_importer_delegate_up;
-  // CompilerInvocation, SourceMgr, DiagEngine and
-  // DWARFImporterDelegate must come before the ASTContext, so they
-  // get deallocated *after* the ASTContext.
+  // CompilerInvocation, SourceMgr, and DiagEngine must come before
+  // the ASTContext, so they get deallocated *after* the ASTContext.
   std::unique_ptr<swift::ASTContext> m_ast_context_ap;
   std::unique_ptr<llvm::TargetOptions> m_target_options_ap;
   std::unique_ptr<swift::irgen::IRGenerator> m_ir_generator_ap;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -113,6 +113,11 @@ template <> struct hash<lldb_private::detail::SwiftLibraryLookupRequest> {
 } // end namespace std
 
 namespace lldb_private {
+
+swift::DWARFImporterDelegate *
+CreateSwiftDWARFImporterDelegate(SwiftASTContext &swift_ast_context);
+SwiftASTContext *GetModuleSwiftASTContext(Module &module);
+
 /// This "middle" class between TypeSystemSwiftTypeRef and
 /// SwiftASTContextForExpressions will eventually go away, as more and
 /// more functionality becomes available in TypeSystemSwiftTypeRef.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -114,6 +114,7 @@ public:
     LanguageFlags() = delete;
   };
 
+  const std::string &GetDescription() const { return m_description; }
   static LanguageSet GetSupportedLanguagesForTypes();
   virtual SwiftASTContext *GetSwiftASTContext() const = 0;
   virtual TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() = 0;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -29,6 +29,7 @@
 #include "Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 
+#include "swift/ClangImporter/ClangImporter.h"
 #include "swift/../../lib/ClangImporter/ClangAdapter.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/Basic/Version.h"
@@ -1346,6 +1347,13 @@ TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext() const {
 
 SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContextOrNull() const {
   return m_swift_ast_context;
+}
+
+swift::DWARFImporterDelegate &TypeSystemSwiftTypeRef::GetDWARFImporterDelegate() {
+  if (!m_dwarf_importer_delegate_up)
+    m_dwarf_importer_delegate_up.reset(CreateSwiftDWARFImporterDelegate(*this));
+  assert(m_dwarf_importer_delegate_up);
+  return *m_dwarf_importer_delegate_up;
 }
 
 void TypeSystemSwiftTypeRef::SetTriple(const llvm::Triple triple) {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -24,6 +24,7 @@
 #include "clang/Basic/Module.h"
 
 namespace swift {
+class DWARFImporterDelegate;
 namespace Demangle {
 class Node;
 using NodePointer = Node *;
@@ -64,6 +65,7 @@ public:
   const TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() const override {
     return *this;
   }
+  swift::DWARFImporterDelegate &GetDWARFImporterDelegate();
   void SetTriple(const llvm::Triple triple) override;
   void ClearModuleDependentCaches() override;
   lldb::TargetWP GetTargetWP() const override { return {}; }
@@ -381,7 +383,8 @@ protected:
   mutable bool m_swift_ast_context_initialized = false;
   mutable lldb::TypeSystemSP m_swift_ast_context_sp;
   mutable SwiftASTContext *m_swift_ast_context = nullptr;
-
+  mutable std::unique_ptr<swift::DWARFImporterDelegate>
+      m_dwarf_importer_delegate_up;
   std::unique_ptr<DWARFASTParser> m_dwarf_ast_parser_up;
 
   /// The APINotesManager responsible for each Clang module.
@@ -445,5 +448,8 @@ protected:
   mutable std::unique_ptr<SymbolContext> m_initial_symbol_context;
 };
 
+swift::DWARFImporterDelegate *
+CreateSwiftDWARFImporterDelegate(TypeSystemSwiftTypeRef &ts);
+  
 } // namespace lldb_private
 #endif


### PR DESCRIPTION
This avoids spinning up new SwiftASTContext in the (still too
expensive!) global search loop for DWARF types in the expression
context.

rdar://88458140