### PR TITLE
Make the initialization of SwiftASTContextForExpressions lazy (NFC)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1267,8 +1267,6 @@ TypeSystemSwiftTypeRefForExpressions::TypeSystemSwiftTypeRefForExpressions(
     m_swift_ast_context =
         llvm::dyn_cast_or_null<SwiftASTContext>(m_swift_ast_context_sp.get());
   }
-  // FIXME: Remove this line to make initialization lazy.
-  GetSwiftASTContext();
 }
 
 void TypeSystemSwiftTypeRefForExpressions::PerformCompileUnitImports(

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2588,14 +2588,9 @@ llvm::Optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
 
   StackFrameSP frame_sp = exe_scope.CalculateStackFrame();
   if (frame_sp && frame_sp.get() && swift_scratch_ctx) {
-    auto *swift_ast_ctx = llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
-        swift_scratch_ctx->GetSwiftASTContextOrNull());
-    if (swift_ast_ctx && !swift_ast_ctx->HasFatalErrors()) {
-      StackFrameWP frame_wp(frame_sp);
-      SymbolContext sc =
-          frame_sp->GetSymbolContext(lldb::eSymbolContextEverything);
-      swift_scratch_ctx->PerformCompileUnitImports(sc);
-    }
+    SymbolContext sc =
+        frame_sp->GetSymbolContext(lldb::eSymbolContextEverything);
+    swift_scratch_ctx->PerformCompileUnitImports(sc);
   }
 
   if (!swift_scratch_ctx)


### PR DESCRIPTION
This patch necessarily cleans up an oversight in Target.cpp where the
PerformCompileUnitImports() message is sent to SwiftASTContext instead
of TypeSystemSwiftTypeRef (which either forwards or queues the
message).