### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/lldb/source/Commands/CMakeLists.txt
+++ b/lldb/source/Commands/CMakeLists.txt
@@ -5,6 +5,7 @@ lldb_tablegen(CommandOptions.inc -gen-lldb-option-defs
 if (LLDB_ENABLE_SWIFT_SUPPORT)
   set(Healtcheck_SOURCES CommandObjectHealthcheck.cpp)
 endif()
+set(LLVM_OPTIONAL_SOURCES CommandObjectHealthcheck.cpp)
 
 add_lldb_library(lldbCommands
   CommandCompletions.cpp


### PR DESCRIPTION
Mark CommandObjectHealthcheck.cpp as an optional source to accommodate the LLVM build system which explicitly ensures that all source files are listed under all build configurations.