### PR TITLE
[lldb] Read swift metadata from symbol rich binary

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -171,6 +171,10 @@ public:
 
   bool GetSwiftReadMetadataFromFileCache() const;
 
+  bool GetSwiftUseReflectionSymbols() const;
+  
+  bool GetSwiftReadMetadataFromDSYM() const;
+
   bool GetEnableAutoImportClangModules() const;
 
   bool GetUseAllCompilerFlags() const;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -393,7 +393,7 @@ private:
   /// the directly from the object file.
   /// \return true on success.
   bool AddObjectFileToReflectionContext(
-      lldb::ModuleSP module, ObjectFile &obj_file);
+      lldb::ModuleSP module);
 
   /// Cache for the debug-info-originating type infos.
   /// \{

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4241,6 +4241,29 @@ bool TargetProperties::GetSwiftReadMetadataFromFileCache() const {
   return true;
 }
 
+bool TargetProperties::GetSwiftUseReflectionSymbols() const {
+  const Property *exp_property = m_collection_sp->GetPropertyAtIndex(
+      nullptr, false, ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    return exp_values->GetPropertyAtIndexAsBoolean(
+        nullptr, ePropertySwiftUseReflectionSymbols, true);
+  else
+    return true;
+}
+
+bool TargetProperties::GetSwiftReadMetadataFromDSYM() const {
+  const Property *exp_property = m_collection_sp->GetPropertyAtIndex(
+      nullptr, false, ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    return exp_values->GetPropertyAtIndexAsBoolean(
+        nullptr, ePropertySwiftReadMetadataFromDSYM, true);
+
+  return true;
+}
 ArchSpec TargetProperties::GetDefaultArchitecture() const {
   OptionValueArch *value = m_collection_sp->GetPropertyAtIndexAsOptionValueArch(
       nullptr, ePropertyDefaultArch);

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -7,6 +7,12 @@ let Definition = "target_experimental" in {
   def SwiftReadMetadataFromFileCache: Property<"swift-read-metadata-from-file-cache", "Boolean">,
     DefaultTrue,
     Desc<"Read Swift reflection metadata from the file cache instead of the process when possible">;
+  def SwiftUseReflectionSymbols : Property<"swift-use-reflection-symbols", "Boolean">,
+    Global, DefaultTrue,
+    Desc<"if true, optimize the loading of Swift reflection metadata by making use of available symbols.">;
+  def SwiftReadMetadataFromDSYM: Property<"swift-read-metadata-from-dsym", "Boolean">,
+    DefaultFalse,
+    Desc<"Read Swift reflection metadata from the dsym instead of the process when possible">;
 }
 
 let Definition = "target" in {


### PR DESCRIPTION
In cases where Swift metadata is present in the symbol rich binary, read
swift metadata from it instead of from the main binary or the process.
This patch essentially re-uses the functionality implemented to read
metadata from the file-cache to achieve this.

(cherry picked from commit 983632d498db5fed2b9d612560dfc2853246fa05)