### PR TITLE
[DepScanDaemon] Fix a concurrent issue around `setCurrentWorkingDirec…

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -123,6 +123,10 @@ public:
                       StringRef CWD, const llvm::StringSet<> &AlreadySeen,
                       llvm::Optional<StringRef> ModuleName = None);
 
+  llvm::cas::CachingOnDiskFileSystem &getCachingFileSystem() {
+    return Worker.getCASFS();
+  }
+
 private:
   DependencyScanningWorker Worker;
 };

--- a/clang/tools/driver/UpdateCC1Args.h
+++ b/clang/tools/driver/UpdateCC1Args.h
@@ -28,8 +28,7 @@ class DependencyScanningTool;
 } // end namespace tooling
 
 llvm::Expected<llvm::cas::CASID>
-updateCC1Args(llvm::cas::CachingOnDiskFileSystem &FS,
-              tooling::dependencies::DependencyScanningTool &Tool,
+updateCC1Args(tooling::dependencies::DependencyScanningTool &Tool,
               DiagnosticConsumer &DiagsConsumer, const char *Exec,
               ArrayRef<const char *> InputArgs, StringRef WorkingDirectory,
               SmallVectorImpl<const char *> &OutputArgs,


### PR DESCRIPTION
Fix the concurrency issue that calling `setCurrentWorkingDirectory` on
CachingOnDiskFileSystem is not thread-safe. Fix by using the proxy FS
created by DependencyScanningTool/Worker.

rdar://89254447