### PR TITLE
Updated reflection-dump.test for mpenum section

### DIFF
--- a/llvm/test/tools/dsymutil/Inputs/reflection_metadata.yaml
+++ b/llvm/test/tools/dsymutil/Inputs/reflection_metadata.yaml
@@ -16,12 +16,12 @@ FileHeader:
   cpusubtype:      0x3
   filetype:        0x1
   ncmds:           8
-  sizeofcmds:      3040
+  sizeofcmds:      3120
   flags:           0x2000
   reserved:        0x0
 LoadCommands:
   - cmd:             LC_SEGMENT_64
-    cmdsize:         2792
+    cmdsize:         2872
     segname:         ''
     vmaddr:          0
     vmsize:          21352
@@ -36,7 +36,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x0
         size:            4571
-        offset:          0xC00
+        offset:          0xC50
         align:           4
         reloff:          0x5CF8
         nreloc:          74
@@ -56,7 +56,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x11DC
         size:            117
-        offset:          0x1DDC
+        offset:          0x1E2C
         align:           1
         reloff:          0x5F48
         nreloc:          22
@@ -77,7 +77,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x1254
         size:            24
-        offset:          0x1E54
+        offset:          0x1EA4
         align:           2
         reloff:          0x5FF8
         nreloc:          6
@@ -98,7 +98,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x17D8
         size:            37
-        offset:          0x23D8
+        offset:          0x2428
         align:           0
         reloff:          0x0
         nreloc:          0
@@ -110,7 +110,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x1800
         size:            24
-        offset:          0x2400
+        offset:          0x2450
         align:           2
         reloff:          0x6530
         nreloc:          8
@@ -131,7 +131,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x1818
         size:            260
-        offset:          0x2418
+        offset:          0x2468
         align:           2
         reloff:          0x6570
         nreloc:          60
@@ -152,7 +152,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x1AC8
         size:            20
-        offset:          0x26C8
+        offset:          0x2718
         align:           2
         reloff:          0x67F8
         nreloc:          2
@@ -173,7 +173,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x1AEC
         size:            10
-        offset:          0x26EC
+        offset:          0x273C
         align:           2
         reloff:          0x0
         nreloc:          0
@@ -185,7 +185,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x1AF8
         size:            10
-        offset:          0x2710
+        offset:          0x2760
         align:           2
         reloff:          0x0
         nreloc:          0
@@ -197,7 +197,7 @@ LoadCommands:
         segname:         __TEXT
         addr:            0x1B04
         size:            10
-        offset:          0x2734
+        offset:          0x2784
         align:           2
         reloff:          0x0
         nreloc:          0
@@ -205,11 +205,23 @@ LoadCommands:
         reserved1:       0x0
         reserved2:       0x0
         content:         61626364656667686970
+      - sectname:        __swift5_mpenum
+        segname:         __TEXT
+        addr:            0x1B10
+        size:            10
+        offset:          0x27A8
+        align:           2
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x10000000
+        reserved1:       0x0
+        reserved2:       0x0
+        content:         71727374757677787980
       - sectname:        __bss
         segname:         __DATA
         addr:            0x3372
         size:            2084
-        offset:          0x51D0
+        offset:          0x5220
         align:           3
         reloff:          0x0
         nreloc:          0

--- a/llvm/test/tools/dsymutil/X86/reflection-dump.test
+++ b/llvm/test/tools/dsymutil/X86/reflection-dump.test
@@ -51,3 +51,6 @@ CHECK-NEXT: 10000e264 51525354 55565758 5960               QRSTUVWXY`
 
 CHECK: Contents of section __DWARF,__swift5_acfuncs:
 CHECK-NEXT: 10000e270 61626364 65666768 6970               abcdefghip
+
+CHECK: Contents of section __DWARF,__swift5_mpenum:
+CHECK-NEXT: 10000e27c 71727374 75767778 7980               qrstuvwxy.


### PR DESCRIPTION
With 1c1e2cce9a50ac9fe6b884b79925d71914cf5a30 a new swift5 reflection section for multi-payload enum mask information was added, which is called mpenum. This change simply adds a check to make sure dsymutil can dump out information in that section into the dSYM bundle.

Differential Revision: https://reviews.llvm.org/D120291

(cherry picked from commit c5256412b76c6e42d21dd744a191b1c75861212d)