### PR TITLE
[lldb] Prevent IsSwiftMangledName false positives

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -607,6 +607,12 @@ bool SwiftLanguageRuntime::IsSymbolARuntimeThunk(const Symbol &symbol) {
 }
 
 bool SwiftLanguageRuntime::IsSwiftMangledName(llvm::StringRef name) {
+  // Old-style mangling uses a "_T" prefix. This can lead to false positives
+  // with other symbols that just so happen to start with "_T". To prevent this,
+  // only return true for old-style mangled _class names_. ObjC classes are the
+  // only instance of old-style mangling that lldb can expect to see.
+  if (name.startswith("_T"))
+    return name.startswith("_TtC");
   return swift::Demangle::isSwiftSymbol(name);
 }
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -609,10 +609,13 @@ bool SwiftLanguageRuntime::IsSymbolARuntimeThunk(const Symbol &symbol) {
 bool SwiftLanguageRuntime::IsSwiftMangledName(llvm::StringRef name) {
   // Old-style mangling uses a "_T" prefix. This can lead to false positives
   // with other symbols that just so happen to start with "_T". To prevent this,
-  // only return true for old-style mangled _class names_. ObjC classes are the
-  // only instance of old-style mangling that lldb can expect to see.
+  // only return true for select old-style mangled names. The known cases to are
+  // ObjC classes and protocols. Classes are prefixed with either "_TtC" or
+  // "_TtGC" (generic classes). Protocols are prefixed with "_TtP". Other "_T"
+  // prefixed symbols are not considered to be Swift symbols.
   if (name.startswith("_T"))
-    return name.startswith("_TtC");
+    return name.startswith("_TtC") || name.startswith("_TtGC") ||
+           name.startswith("_TtP");
   return swift::Demangle::isSwiftSymbol(name);
 }
 

--- a/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
+++ b/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
@@ -95,7 +95,7 @@ class TestSwiftTypeLookup(TestBase):
 
         # check that mangled name lookup works
         self.expect(
-            'type lookup _TtSi',
+            'type lookup _$sSiD',
             substrs=[
                 'struct Int',
                 'extension Swift.Int'])


### PR DESCRIPTION
Some non-swift symbols can unintentionally cause `isSwiftSymbol` to return true. Any symbol starting with `_T` is considered a swift symbol because "old-style" mangling used this prefix.

Prevent this by special casing `_T`-prefixed symbols. The only kind of old-style mangled that lldb should expect to see are ObjC class and protocol names. Classes use a `_TtC` or `_TtGC` prefix (the latter is for generics). Protocols are `_TtP`.