### PR TITLE
[move-function] Address feedback from previous test commits and add even more tests!

### DIFF
--- a/lldb/test/API/lang/swift/variables/move_function/TestSwiftMoveFunction.py
+++ b/lldb/test/API/lang/swift/variables/move_function/TestSwiftMoveFunction.py
@@ -207,5 +207,29 @@ class TestSwiftMoveFunctionType(TestBase):
         # should still be None.
         self.assertIsNone(varK.value, "varK should not have a value!")
 
+        # Run again so we go and run to the next test.
+        self.runCmd('continue')
+
     def do_check_copyable_value_ccf_false(self):
-        pass
+        frame = self.thread.frames[0]
+        self.assertTrue(frame.IsValid(), "Couldn't get a frame.")
+        varK = frame.FindVariable('k')
+
+        # Check at our start point that we do not have any state for varK and
+        # then continue to our next breakpoint.
+        self.assertIsNone(varK.value, "varK should not have a value?!")
+        self.runCmd('continue')
+
+        # At this breakpoint, k should be defined since we are going to do
+        # something with it.
+        self.assertIsNotNone(varK.value, "varK should have a value?!")
+        self.runCmd('continue')
+
+        # At this breakpoint, we are now past the end of the conditional
+        # statement. We know due to the move checking that k can not have any
+        # uses that are reachable from the move. So it is safe to always not
+        # provide the value here.
+        self.assertIsNone(varK.value, "varK should have a value?!")
+
+        # Run again so we go and run to the next test.
+        self.runCmd('continue')

--- a/lldb/test/API/lang/swift/variables/move_function/TestSwiftMoveFunction.py
+++ b/lldb/test/API/lang/swift/variables/move_function/TestSwiftMoveFunction.py
@@ -45,7 +45,7 @@ class TestSwiftMoveFunctionType(TestBase):
         self.process = self.target.LaunchSimple(None, None, os.getcwd())
         threads = lldbutil.get_threads_stopped_at_breakpoint(
             self.process, self.breakpoints[0])
-        self.assertTrue(len(threads) == 1)
+        self.assertEqual(len(threads), 1)
         self.thread = threads[0]
 
         self.do_check_copyable_value_test()
@@ -68,7 +68,7 @@ class TestSwiftMoveFunctionType(TestBase):
             pat = pattern.format(name, i+1)
             brk = self.target.BreakpointCreateBySourceRegex(
                 pat, self.main_source_spec)
-            self.assertTrue(brk.GetNumLocations() > 0, VALID_BREAKPOINT)
+            self.assertGreater(brk.GetNumLocations(), 0, VALID_BREAKPOINT)
             yield brk
 
     def do_setup_breakpoints(self):
@@ -96,15 +96,15 @@ class TestSwiftMoveFunctionType(TestBase):
         # We haven't defined varK yet.
         varK = frame.FindVariable('k')
 
-        self.assertTrue(varK.value == None, "varK initialized too early?!")
+        self.assertIsNone(varK.value, "varK initialized too early?!")
 
         # Go to break point 2. k should be valid.
         self.runCmd('continue')
-        self.assertTrue(varK.unsigned > 0, "varK not initialized?!")
+        self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
 
         # Go to breakpoint 3. k should no longer be valid.
         self.runCmd('continue')
-        self.assertTrue(varK.value == None, "K is live but was moved?!")
+        self.assertIsNone(varK.value, "K is live but was moved?!")
 
         # Run so we hit the next breakpoint to jump to the next test's
         # breakpoint.
@@ -116,20 +116,20 @@ class TestSwiftMoveFunctionType(TestBase):
 
         # We haven't defined varK yet.
         varK = frame.FindVariable('k')
-        self.assertTrue(varK.value == None, "varK initialized too early?!")
+        self.assertIsNone(varK.value, "varK initialized too early?!")
 
         # Go to break point 2. k should be valid.
         self.runCmd('continue')
-        self.assertTrue(varK.unsigned > 0, "varK not initialized?!")
+        self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
 
         # Go to breakpoint 3. We invalidated k
         self.runCmd('continue')
-        self.assertTrue(varK.value == None, "K is live but was moved?!")
+        self.assertIsNone(varK.value, "K is live but was moved?!")
 
         # Go to the last breakpoint and make sure that k is reinitialized
         # properly.
         self.runCmd('continue')
-        self.assertTrue(varK.unsigned > 0, "varK not initialized")
+        self.assertGreater(varK.unsigned, 0, "varK not initialized")
 
         # Run so we hit the next breakpoint to go to the next test.
         self.runCmd('continue')
@@ -147,12 +147,11 @@ class TestSwiftMoveFunctionType(TestBase):
         # move the other variable and show the correct behavior with
         # llvm.dbg.declare.
         self.runCmd('continue')
-
-        self.assertTrue(varK.unsigned > 0, "var not initialized?!")
+        self.assertGreater(varK.unsigned, 0, "var not initialized?!")
 
         # Go to breakpoint 3.
         self.runCmd('continue')
-        self.assertTrue(varK.unsigned == 0,
+        self.assertEqual(varK.unsigned, 0,
                         "dbg thinks varK is live despite move?!")
 
         # Run so we hit the next breakpoint as part of the next test.
@@ -166,16 +165,16 @@ class TestSwiftMoveFunctionType(TestBase):
 
         # Go to break point 2. k should be valid.
         self.runCmd('continue')
-        self.assertTrue(varK.unsigned > 0, "varK not initialized?!")
+        self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
 
         # Go to breakpoint 3. K was invalidated.
         self.runCmd('continue')
-        self.assertTrue(varK.value == None, "K is live but was moved?!")
+        self.assertIsNone(varK.value, "K is live but was moved?!")
 
         # Go to the last breakpoint and make sure that k is reinitialized
         # properly.
         self.runCmd('continue')
-        self.assertTrue(varK.unsigned > 0, "varK not initialized")
+        self.assertGreater(varK.unsigned, 0, "varK not initialized")
 
         # Run so we hit the next breakpoint as part of the next test.
         self.runCmd('continue')
@@ -187,27 +186,26 @@ class TestSwiftMoveFunctionType(TestBase):
 
         # Check at our start point that we do not have any state for varK and
         # then continue to our next breakpoint.
-        self.assertTrue(varK.value == None, "varK should not have a value?!")
+        self.assertIsNone(varK.value, "varK should not have a value?!")
         self.runCmd('continue')
 
         # At this breakpoint, k should be defined since we are going to do
         # something with it.
-        self.assertTrue(varK.value != None, "varK should have a value?!")
+        self.assertIsNotNone(varK.value, "varK should have a value?!")
         self.runCmd('continue')
 
         # At this breakpoint, we are now in the conditional control flow part of
         # the loop. Make sure that we can see k still.
-        self.assertTrue(varK.value != None, "varK should have a value?!")
+        self.assertIsNotNone(varK.value, "varK should have a value?!")
         self.runCmd('continue')
 
         # Ok, we just performed the move. k should not be no longer initialized.
-        self.runCmd('fr v')
-        self.assertTrue(varK.value == None, "varK should not have a value?!")
+        self.assertIsNone(varK.value, "varK should not have a value?!")
         self.runCmd('continue')
 
         # Finally we left the conditional control flow part of the function. k
         # should still be None.
-        self.assertTrue(varK.value == None, "varK should not have a value!")
+        self.assertIsNone(varK.value, "varK should not have a value!")
 
     def do_check_copyable_value_ccf_false(self):
         pass

--- a/lldb/test/API/lang/swift/variables/move_function/main.swift
+++ b/lldb/test/API/lang/swift/variables/move_function/main.swift
@@ -91,6 +91,51 @@ public func copyableValueCCFFalseTest() {
     // Set breakpoint copyableValueCCFFalseTest here 3
 }
 
+public func copyableVarTestCCFlowTrueReinitOutOfBlockTest() {
+    var k = Klass() // Set breakpoint copyableVarTestCCFlowTrueReinitOutOfBlockTest here 1
+    k.doSomething()
+    if trueBoolValue {
+        let m = _move(k) // Set breakpoint copyableVarTestCCFlowTrueReinitOutOfBlockTest here 2
+        m.doSomething() // Set breakpoint copyableVarTestCCFlowTrueReinitOutOfBlockTest here 3
+    }
+    k = Klass() // Set breakpoint copyableVarTestCCFlowTrueReinitOutOfBlockTest here 4
+    k.doSomething() // Set breakpoint copyableVarTestCCFlowTrueReinitOutOfBlockTest here 5
+}
+
+public func copyableVarTestCCFlowTrueReinitInBlockTest() {
+    var k = Klass() // Set breakpoint copyableVarTestCCFlowTrueReinitInBlockTest here 1
+    k.doSomething()
+    if trueBoolValue {
+        let m = _move(k) // Set breakpoint copyableVarTestCCFlowTrueReinitInBlockTest here 2
+        m.doSomething()
+        k = Klass() // Set breakpoint copyableVarTestCCFlowTrueReinitInBlockTest here 3
+        k.doSomething() // Set breakpoint copyableVarTestCCFlowTrueReinitInBlockTest here 4
+    }
+    k.doSomething() // Set breakpoint copyableVarTestCCFlowTrueReinitInBlockTest here 5
+}
+
+public func copyableVarTestCCFlowFalseReinitOutOfBlockTest() {
+    var k = Klass() // Set breakpoint copyableVarTestCCFlowFalseReinitOutOfBlockTest here 1
+    k.doSomething() // Set breakpoint copyableVarTestCCFlowFalseReinitOutOfBlockTest here 2
+    if falseBoolValue {
+        let m = _move(k)
+        m.doSomething()
+    }
+    k = Klass() // Set breakpoint copyableVarTestCCFlowFalseReinitOutOfBlockTest here 3
+    k.doSomething() // Set breakpoint copyableVarTestCCFlowFalseReinitOutOfBlockTest here 4
+}
+
+public func copyableVarTestCCFlowFalseReinitInBlockTest() {
+    var k = Klass() // Set breakpoint copyableVarTestCCFlowFalseReinitInBlockTest here 1
+    k.doSomething()  // Set breakpoint copyableVarTestCCFlowFalseReinitInBlockTest here 2
+    if falseBoolValue {
+        let m = _move(k)
+        m.doSomething()
+        k = Klass()
+    }
+    k.doSomething() // Set breakpoint copyableVarTestCCFlowFalseReinitInBlockTest here 3
+}
+
 //////////////////////////
 // Top Level Entrypoint //
 //////////////////////////
@@ -102,6 +147,10 @@ func main() {
     addressOnlyVarTest(Klass())
     copyableValueCCFTrueTest()
     copyableValueCCFFalseTest()
+    copyableVarTestCCFlowTrueReinitOutOfBlockTest()
+    copyableVarTestCCFlowTrueReinitInBlockTest()
+    copyableVarTestCCFlowFalseReinitOutOfBlockTest()
+    copyableVarTestCCFlowFalseReinitInBlockTest()
 }
 
 main()

--- a/lldb/test/API/lang/swift/variables/move_function/main.swift
+++ b/lldb/test/API/lang/swift/variables/move_function/main.swift
@@ -83,8 +83,8 @@ public func copyableValueCCFTrueTest() {
 
 public func copyableValueCCFFalseTest() {
     let k = Klass() // Set breakpoint copyableValueCCFFalseTest here 1
-    k.doSomething()
-    if falseBoolValue { // Set breakpoint copyableValueCCFFalseTest here 2
+    k.doSomething() // Set breakpoint copyableValueCCFFalseTest here 2
+    if falseBoolValue {
         let m = _move(k)
         m.doSomething()
     }


### PR DESCRIPTION
This began as a commit to address @kastiglione's feedback on #3986. After I did that I decided to add even more tests using the same PR. I basically just ported some tests that I already had in Swift that FileChecked LLVM-IR to be LLDB tests of the same sort I have here: walk through programs validating that a value shows up as appropriate when moved.