### PR TITLE
[lldb] Remove old-style mangled names for generic types from stdlib hashed containers

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftDictionary.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftDictionary.cpp
@@ -50,8 +50,6 @@ DictionaryConfig::DictionaryConfig()
     ConstString("Swift.__RawDictionaryStorage");
 
   // Native storage class
-  m_nativeStorage_mangledRegex_ObjC =
-    ConstString("^_TtGCs18_DictionaryStorage.*");
   m_nativeStorage_demangledPrefix =
     ConstString("Swift._DictionaryStorage<");
   m_nativeStorage_demangledRegex =
@@ -64,8 +62,6 @@ DictionaryConfig::DictionaryConfig()
     = ConstString("Swift.__EmptyDictionarySingleton");
 
   // Deferred non-verbatim bridged dictionary
-  m_deferredBridgedStorage_mangledRegex_ObjC
-    = ConstString("^_TtGCs26_SwiftDeferredNSDictionary.*");
   m_deferredBridgedStorage_demangledPrefix
     = ConstString("Swift._SwiftDeferredNSDictionary<");
   m_deferredBridgedStorage_demangledRegex

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -210,13 +210,7 @@ HashedCollectionConfig::RegisterSummaryProviders(
   flags.SetSkipPointers(false);
   AddCXXSummary(swift_category_sp, summaryProvider,
                 m_summaryProviderName.AsCString(),
-                m_nativeStorage_mangledRegex_ObjC, flags, true);
-  AddCXXSummary(swift_category_sp, summaryProvider,
-                m_summaryProviderName.AsCString(),
                 m_emptyStorage_mangled_ObjC, flags, false);
-  AddCXXSummary(swift_category_sp, summaryProvider,
-                m_summaryProviderName.AsCString(),
-                m_deferredBridgedStorage_mangledRegex_ObjC, flags, true);
 }
 
 void
@@ -244,13 +238,7 @@ HashedCollectionConfig::RegisterSyntheticChildrenCreators(
   flags.SetSkipPointers(false);
   AddCXXSynthetic(swift_category_sp, creator,
                   m_syntheticChildrenName.AsCString(),
-                  m_nativeStorage_mangledRegex_ObjC, flags, true);
-  AddCXXSynthetic(swift_category_sp, creator,
-                  m_syntheticChildrenName.AsCString(),
                   m_emptyStorage_mangled_ObjC, flags, false);
-  AddCXXSynthetic(swift_category_sp, creator,
-                  m_syntheticChildrenName.AsCString(),
-                  m_deferredBridgedStorage_mangledRegex_ObjC, flags, true);
 }
 
 bool

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.h
@@ -99,14 +99,12 @@ protected:
   ConstString m_nativeStorageRoot_mangled;
   ConstString m_nativeStorageRoot_demangled;
 
-  ConstString m_nativeStorage_mangledRegex_ObjC;
   ConstString m_nativeStorage_demangledPrefix;
   ConstString m_nativeStorage_demangledRegex;
 
   ConstString m_emptyStorage_mangled_ObjC;
   ConstString m_emptyStorage_demangled;
 
-  ConstString m_deferredBridgedStorage_mangledRegex_ObjC;
   ConstString m_deferredBridgedStorage_demangledPrefix;
   ConstString m_deferredBridgedStorage_demangledRegex;
 };

--- a/lldb/source/Plugins/Language/Swift/SwiftSet.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftSet.cpp
@@ -51,8 +51,6 @@ SetConfig::SetConfig()
     ConstString("Swift.__RawSetStorage");
 
     // Native storage class
-  m_nativeStorage_mangledRegex_ObjC =
-    ConstString("^_TtGCs11_SetStorage.*");
   m_nativeStorage_demangledPrefix =
     ConstString("Swift._SetStorage<");
   m_nativeStorage_demangledRegex =
@@ -63,8 +61,6 @@ SetConfig::SetConfig()
   m_emptyStorage_demangled = ConstString("Swift.__EmptySetSingleton");
 
   // Deferred non-verbatim bridged set
-  m_deferredBridgedStorage_mangledRegex_ObjC
-    = ConstString("^_TtGCs19_SwiftDeferredNSSet.*");
   m_deferredBridgedStorage_demangledPrefix
     = ConstString("Swift._SwiftDeferredNSSet<");
   m_deferredBridgedStorage_demangledRegex


### PR DESCRIPTION
This removes references to specific old-style mangled names. Namely, those with the prefix `_TtG` which is for generic types. These symbols no longer exist in `swiftCore`.