### PR TITLE
PlatformMacOSX should be activated for lldb built to run on an iOS et…

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1329,3 +1329,23 @@ FileSpec PlatformDarwin::GetCurrentCommandLineToolsDirectory() {
     return FileSpec(FindComponentInPath(fspec.GetPath(), "CommandLineTools"));
   return {};
 }
+
+llvm::Triple::OSType PlatformDarwin::GetHostOSType() {
+#if !defined(__APPLE__)
+  return llvm::Triple::MacOSX;
+#else
+#if TARGET_OS_OSX
+  return llvm::Triple::MacOSX;
+#elif TARGET_OS_IOS
+  return llvm::Triple::IOS;
+#elif TARGET_OS_WATCH
+  return llvm::Triple::WatchOS;
+#elif TARGET_OS_TV
+  return llvm::Triple::TvOS;
+#elif TARGET_OS_BRIDGE
+  return llvm::Triple::BridgeOS;
+#else
+#error "LLDB being compiled for an unrecognized Darwin OS"
+#endif
+#endif // __APPLE__
+}

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -174,6 +174,9 @@ protected:
   static std::string FindComponentInPath(llvm::StringRef path,
                                          llvm::StringRef component);
 
+  // The OSType where lldb is running.
+  static llvm::Triple::OSType GetHostOSType();
+
   std::string m_developer_directory;
   llvm::StringMap<std::string> m_sdk_path;
   std::mutex m_sdk_path_mutex;

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
@@ -137,15 +137,21 @@ std::vector<ArchSpec> PlatformMacOSX::GetSupportedArchitectures() {
   std::vector<ArchSpec> result;
 #if defined(__arm__) || defined(__arm64__) || defined(__aarch64__)
   // macOS for ARM64 support both native and translated x86_64 processes
-  ARMGetSupportedArchitectures(result, llvm::Triple::MacOSX);
 
-  // We can't use x86GetSupportedArchitectures() because it uses
-  // the system architecture for some of its return values and also
-  // has a 32bits variant.
-  result.push_back(ArchSpec("x86_64-apple-macosx"));
-  result.push_back(ArchSpec("x86_64-apple-ios-macabi"));
-  result.push_back(ArchSpec("arm64-apple-ios-macabi"));
-  result.push_back(ArchSpec("arm64e-apple-ios-macabi"));
+  // When cmdline lldb is run on iOS, watchOS, etc, it is still
+  // using "PlatformMacOSX".
+  llvm::Triple::OSType host_os = GetHostOSType();
+  ARMGetSupportedArchitectures(result, host_os);
+
+  if (host_os == llvm::Triple::MacOSX) {
+    // We can't use x86GetSupportedArchitectures() because it uses
+    // the system architecture for some of its return values and also
+    // has a 32bits variant.
+    result.push_back(ArchSpec("x86_64-apple-macosx"));
+    result.push_back(ArchSpec("x86_64-apple-ios-macabi"));
+    result.push_back(ArchSpec("arm64-apple-ios-macabi"));
+    result.push_back(ArchSpec("arm64e-apple-ios-macabi"));
+  }
 #else
   x86GetSupportedArchitectures(result);
   result.push_back(ArchSpec("x86_64-apple-ios-macabi"));


### PR DESCRIPTION
PlatformMacOSX should be activated for lldb built to run on an iOS etc device

In the changes Jonas made in https://reviews.llvm.org/D117340 , a
small oversight was that PlatformMacOSX (despite the name) is active
for any native Darwin operating system, where lldb and the target
process are running on the same system. This patch uses compile-time
checks to return the appropriate OSType for the OS lldb is being
compiled to, so the "host" platform will correctly be selected when
lldb & the inferior are both running on that OS. And a small change
to PlatformMacOSX::GetSupportedArchitectures which adds additional
recognized triples when running on macOS but not other native Darwin
systems.

Differential Revision: https://reviews.llvm.org/D120517
rdar://89247060

(cherry picked from commit cd2ba23efb3e282d86cf7a94952f0bf61677fa7f)