### PR TITLE
[libclang] Create new dependency scanner API

### DIFF
--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -91,14 +91,12 @@ typedef struct {
   CXString ContextHash;
   CXStringSet *FileDeps;
   CXStringSet *ModuleDeps;
-  
+
   /**
-   * Additional arguments to append to the build of this file.
-   *
-   * This contains things like disabling implicit modules. This does not include
-   * the `-fmodule-file=` arguments that are needed.
+   * Full or additional arguments needed to build this file, excluding
+   * `-fmodule-file=`.
    */
-  CXStringSet *AdditionalArguments;
+  CXStringSet *BuildArguments;
 } CXFileDependencies;
 
 CINDEX_LINKAGE void
@@ -228,6 +226,19 @@ clang_experimental_DependencyScannerWorker_getFileDependencies_v0(
  */
 CINDEX_LINKAGE CXFileDependencies *
 clang_experimental_DependencyScannerWorker_getFileDependencies_v1(
+    CXDependencyScannerWorker Worker, int argc, const char *const *argv,
+    const char *WorkingDirectory, CXModuleDiscoveredCallback *MDC,
+    void *Context, CXString *error);
+
+/**
+ * Same as \c clang_experimental_DependencyScannerWorker_getFileDependencies_v1,
+ * but \c BuildArguments of \c CXFileDependencies contains the full Clang
+ * command line, not just additional arguments, and \c BuildArguments of each
+ * \c CXModuleDependency now contain the necessary '-fmodule-map-file='
+ * arguments.
+ */
+CINDEX_LINKAGE CXFileDependencies *
+clang_experimental_DependencyScannerWorker_getFileDependencies_v2(
     CXDependencyScannerWorker Worker, int argc, const char *const *argv,
     const char *WorkingDirectory, CXModuleDiscoveredCallback *MDC,
     void *Context, CXString *error);

--- a/clang/test/Index/Core/scan-deps-by-mod-name.m
+++ b/clang/test/Index/Core/scan-deps-by-mod-name.m
@@ -24,4 +24,4 @@
 // CHECK-NEXT:   module-deps:
 // CHECK-NEXT:     ModA:[[HASH_MOD_A]]
 // CHECK-NEXT:   file-deps:
-// CHECK-NEXT:   additional-build-args: -fno-implicit-modules -fno-implicit-module-maps
+// CHECK-NEXT:   build-args: {{.*}} -fno-implicit-modules -fno-implicit-module-maps

--- a/clang/test/Index/Core/scan-deps.m
+++ b/clang/test/Index/Core/scan-deps.m
@@ -27,4 +27,4 @@
 // CHECK-NEXT:     ModA:[[HASH_MOD_A]]
 // CHECK-NEXT:   file-deps:
 // CHECK-NEXT:     [[PREFIX]]/scan-deps.m
-// CHECK-NEXT:   additional-build-args: -fno-implicit-modules -fno-implicit-module-maps
+// CHECK-NEXT:   build-args: {{.*}} -fno-implicit-modules -fno-implicit-module-maps

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -688,7 +688,7 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory) {
       functionObjectToCCallbackRef<void(CXModuleDependencySet *)>(Callback);
 
   CXFileDependencies *Result =
-      clang_experimental_DependencyScannerWorker_getFileDependencies_v1(
+      clang_experimental_DependencyScannerWorker_getFileDependencies_v2(
           Worker, Args.size(), Args.data(), WorkingDirectory.c_str(),
           CB.Callback, CB.Context, &Error);
   if (!Result) {
@@ -708,10 +708,9 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory) {
   for (const auto &FileName :
        llvm::makeArrayRef(Result->FileDeps->Strings, Result->FileDeps->Count))
     llvm::outs() << "    " << clang_getCString(FileName) << "\n";
-  llvm::outs() << "  additional-build-args:";
-  for (const auto &Arg :
-       llvm::makeArrayRef(Result->AdditionalArguments->Strings,
-                          Result->AdditionalArguments->Count))
+  llvm::outs() << "  build-args:";
+  for (const auto &Arg : llvm::makeArrayRef(Result->BuildArguments->Strings,
+                                            Result->BuildArguments->Count))
     llvm::outs() << " " << clang_getCString(Arg);
   llvm::outs() << "\n";
 
@@ -781,10 +780,9 @@ static int scanDepsByModuleName(ArrayRef<const char *> Args,
   for (const auto &FileName :
        llvm::makeArrayRef(Result->FileDeps->Strings, Result->FileDeps->Count))
     llvm::outs() << "    " << clang_getCString(FileName) << "\n";
-  llvm::outs() << "  additional-build-args:";
-  for (const auto &Arg :
-       llvm::makeArrayRef(Result->AdditionalArguments->Strings,
-                          Result->AdditionalArguments->Count))
+  llvm::outs() << "  build-args:";
+  for (const auto &Arg : llvm::makeArrayRef(Result->BuildArguments->Strings,
+                                            Result->BuildArguments->Count))
     llvm::outs() << " " << clang_getCString(Arg);
   llvm::outs() << "\n";
 

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -281,6 +281,7 @@ LLVM_13 {
     clang_experimental_DependencyScannerWorker_dispose_v0;
     clang_experimental_DependencyScannerWorker_getFileDependencies_v0;
     clang_experimental_DependencyScannerWorker_getFileDependencies_v1;
+    clang_experimental_DependencyScannerWorker_getFileDependencies_v2;
     clang_experimental_DependencyScannerWorker_getDependenciesByModuleName_v0;
     clang_experimental_FileDependencies_dispose;
     clang_experimental_ModuleDependencySet_dispose;


### PR DESCRIPTION
This creates new version of the libclang dependency scanning API. The `_v2` function returns the full TU command-line as opposed to additional arguments, and module command lines now contain `-fmodule-map-file=` arguments.

This depends on the following upstream patches:
* https://reviews.llvm.org/D118986
* https://reviews.llvm.org/D120464
* https://reviews.llvm.org/D120465
* https://reviews.llvm.org/D120474