### PR TITLE
[dsymutil] Apply relocations present in Swift reflection sections

### DIFF
--- a/llvm/include/llvm/Object/ObjectFile.h
+++ b/llvm/include/llvm/Object/ObjectFile.h
@@ -351,6 +351,11 @@ public:
   /// True if this is a relocatable object (.o/.obj).
   virtual bool isRelocatableObject() const = 0;
 
+  /// True if the reflection section can be stripped by the linker.
+  bool isReflectionSectionStrippable(
+      llvm::binaryformat::Swift5ReflectionSectionKind ReflectionSectionKind)
+      const;
+
   /// @returns Pointer to ObjectFile subclass to handle this type of object.
   /// @param ObjectPath The path to the object file. ObjectPath.isObject must
   ///        return true.

--- a/llvm/lib/Object/ObjectFile.cpp
+++ b/llvm/lib/Object/ObjectFile.cpp
@@ -198,3 +198,12 @@ ObjectFile::createObjectFile(StringRef ObjectPath) {
 
   return OwningBinary<ObjectFile>(std::move(Obj), std::move(Buffer));
 }
+
+bool ObjectFile::isReflectionSectionStrippable(
+    llvm::binaryformat::Swift5ReflectionSectionKind ReflectionSectionKind)
+    const {
+  using llvm::binaryformat::Swift5ReflectionSectionKind;
+  return ReflectionSectionKind == Swift5ReflectionSectionKind::fieldmd ||
+         ReflectionSectionKind == Swift5ReflectionSectionKind::reflstr ||
+         ReflectionSectionKind == Swift5ReflectionSectionKind::assocty;
+}

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -296,12 +296,11 @@ DwarfLinkerForBinary::loadObject(const DebugMapObject &Obj,
   return ErrorOrObj.getError();
 }
 
-static bool binaryHasSwiftReflectionSections(const DebugMap &Map,
-                                             const LinkOptions &Options,
-                                             BinaryHolder &BinHolder) {
-  // If the input binary has swift5 reflection sections, there is no need to
-  // copy them to the .dSYM. Only copy them for binaries where the linker
-  // omitted the reflection metadata.
+static bool binaryHasStrippableSwiftReflectionSections(
+    const DebugMap &Map, const LinkOptions &Options, BinaryHolder &BinHolder) {
+  // If the input binary has strippable swift5 reflection sections, there is no
+  // need to copy them to the .dSYM. Only copy them for binaries where the
+  // linker omitted the reflection metadata.
   if (!Map.getBinaryPath().empty() &&
       Options.FileType == OutputFileType::Object) {
 
@@ -330,8 +329,9 @@ static bool binaryHasSwiftReflectionSections(const DebugMap &Map,
         continue;
       }
       NameOrErr->consume_back("__TEXT");
-      if (Object->mapReflectionSectionNameToEnumValue(*NameOrErr) !=
-          llvm::binaryformat::Swift5ReflectionSectionKind::unknown) {
+      auto ReflectionSectionKind =
+          Object->mapReflectionSectionNameToEnumValue(*NameOrErr);
+      if (Object->isReflectionSectionStrippable(ReflectionSectionKind)) {
         return true;
       }
     }
@@ -339,30 +339,226 @@ static bool binaryHasSwiftReflectionSections(const DebugMap &Map,
   return false;
 }
 
-static void
-copySwiftReflectionMetadata(const llvm::dsymutil::DebugMapObject *Obj,
-                            DwarfStreamer *Streamer) {
+static bool isMachOPairedReloc(uint64_t RelocType, uint64_t Arch) {
+  switch (Arch) {
+  case Triple::x86:
+    return RelocType == MachO::GENERIC_RELOC_SECTDIFF ||
+           RelocType == MachO::GENERIC_RELOC_LOCAL_SECTDIFF;
+  case Triple::x86_64:
+    return RelocType == MachO::X86_64_RELOC_SUBTRACTOR;
+  case Triple::arm:
+  case Triple::thumb:
+    return RelocType == MachO::ARM_RELOC_SECTDIFF ||
+           RelocType == MachO::ARM_RELOC_LOCAL_SECTDIFF ||
+           RelocType == MachO::ARM_RELOC_HALF ||
+           RelocType == MachO::ARM_RELOC_HALF_SECTDIFF;
+  case Triple::aarch64:
+    return RelocType == MachO::ARM64_RELOC_SUBTRACTOR;
+  default:
+    return false;
+  }
+}
+
+/// Calculate the start of the strippable swift reflection sections in Dwarf.
+/// Note that there's an assumption that the reflection sections will appear
+/// in alphabetic order.
+static std::unordered_map<llvm::binaryformat::Swift5ReflectionSectionKind,
+                          uint64_t>
+calculateStartOfStrippableReflectionSections(const DebugMap &Map) {
+  using llvm::binaryformat::Swift5ReflectionSectionKind;
+  uint64_t AssocTySize = 0;
+  uint64_t FieldMdSize = 0;
+  for (const auto &Obj : Map.objects()) {
+    auto OF =
+        llvm::object::ObjectFile::createObjectFile(Obj->getObjectFilename());
+    if (!OF) {
+      llvm::consumeError(OF.takeError());
+      continue;
+    }
+    if (auto *MO = dyn_cast<llvm::object::MachOObjectFile>(OF->getBinary())) {
+      for (auto &Section : MO->sections()) {
+        llvm::Expected<llvm::StringRef> NameOrErr =
+            MO->getSectionName(Section.getRawDataRefImpl());
+        if (!NameOrErr) {
+          llvm::consumeError(NameOrErr.takeError());
+          continue;
+        }
+        NameOrErr->consume_back("__TEXT");
+        auto ReflSectionKind =
+            MO->mapReflectionSectionNameToEnumValue(*NameOrErr);
+        switch (ReflSectionKind) {
+        case Swift5ReflectionSectionKind::assocty:
+          AssocTySize += Section.getSize();
+          break;
+        case Swift5ReflectionSectionKind::fieldmd:
+          FieldMdSize += Section.getSize();
+          break;
+        default:
+          break;
+        }
+      }
+    }
+  }
+  std::unordered_map<Swift5ReflectionSectionKind, uint64_t> SectionToOffset;
+  SectionToOffset[Swift5ReflectionSectionKind::assocty] = 0;
+  SectionToOffset[Swift5ReflectionSectionKind::fieldmd] =
+      llvm::alignTo(AssocTySize, 4);
+  SectionToOffset[Swift5ReflectionSectionKind::reflstr] = llvm::alignTo(
+      SectionToOffset[Swift5ReflectionSectionKind::fieldmd] + FieldMdSize, 4);
+
+  return SectionToOffset;
+}
+
+void DwarfLinkerForBinary::collectRelocationsToApplyToSwiftReflectionSections(
+    const object::SectionRef &Section, StringRef &Contents,
+    const llvm::object::MachOObjectFile *MO,
+    const std::unordered_map<llvm::binaryformat::Swift5ReflectionSectionKind,
+                       uint64_t> &SectionToOffsetInDwarf,
+    const llvm::dsymutil::DebugMapObject *Obj,
+    std::vector<MachOUtils::DwarfRelocationApplicationInfo> &RelocationsToApply)
+    const {
+  for (auto It = Section.relocation_begin(); It != Section.relocation_end();
+       ++It) {
+    object::DataRefImpl RelocDataRef = It->getRawDataRefImpl();
+    MachO::any_relocation_info MachOReloc = MO->getRelocation(RelocDataRef);
+
+    if (!isMachOPairedReloc(MO->getAnyRelocationType(MachOReloc),
+                            MO->getArch())) {
+      reportWarning(
+          "Unimplemented relocation type in strippable reflection section ",
+          Obj->getObjectFilename());
+      continue;
+    }
+
+    auto CalculateAddressOfSymbolInDwarfSegment =
+        [&]() -> llvm::Optional<int64_t> {
+      auto Symbol = It->getSymbol();
+      auto SymbolAbsoluteAddress = Symbol->getAddress();
+      if (!SymbolAbsoluteAddress)
+        return {};
+      auto Section = Symbol->getSection();
+      if (!Section)
+        return {};
+
+      auto SectionStart = (*Section)->getAddress();
+      auto SymbolAddressInSection = *SymbolAbsoluteAddress - SectionStart;
+      auto SectionName = (*Section)->getName();
+      if (!SectionName)
+        return {};
+      auto ReflSectionKind =
+          MO->mapReflectionSectionNameToEnumValue(*SectionName);
+      
+      int64_t SectionStartInLinkedBinary = 0;
+      auto It = SectionToOffsetInDwarf.find(ReflSectionKind);
+      if (It != SectionToOffsetInDwarf.end())
+        SectionStartInLinkedBinary = It->second;
+
+      auto Addr = SectionStartInLinkedBinary + SymbolAddressInSection;
+      return Addr;
+    };
+
+    // The first symbol should always be in the section we're currently
+    // iterating over.
+    auto FirstSymbolAddress = CalculateAddressOfSymbolInDwarfSegment();
+    ++It;
+
+    bool ShouldSubtractDwarfVM = false;
+    // For the second symbol there are two possibilities.
+    llvm::Optional<int64_t> SecondSymbolAddress;
+    auto Sym = It->getSymbol();
+    if (Sym != MO->symbol_end()) {
+      Expected<StringRef> SymbolName = Sym->getName();
+      if (SymbolName) {
+        if (const auto *Mapping = Obj->lookupSymbol(*SymbolName)) {
+          // First possibility: the symbol exists in the binary, and exists in a
+          // non-strippable section (for example, typeref, or __TEXT,__const),
+          // in which case we look up its address in the  binary, which dsymutil
+          // will copy verbatim.
+          SecondSymbolAddress = Mapping->getValue().BinaryAddress;
+          // Since the symbols live in different segments, we have to substract
+          // the start of the Dwarf's vmaddr so the value calculated points to
+          // the correct place.
+          ShouldSubtractDwarfVM = true;
+        }
+      }
+    }
+
+    if (!SecondSymbolAddress) {
+      // Second possibility, this symbol is not present in the main binary, and
+      // must be in one of the strippable sections (for example, reflstr).
+      // Calculate its address in the same way as we did the first one.
+      SecondSymbolAddress = CalculateAddressOfSymbolInDwarfSegment();
+    }
+
+    if (!FirstSymbolAddress || !SecondSymbolAddress)
+      continue;
+
+    auto SectionName = Section.getName();
+    if (!SectionName)
+      continue;
+
+    int32_t Addend;
+    memcpy(&Addend, Contents.data() + It->getOffset(), sizeof(int32_t));
+    int32_t Value = (*SecondSymbolAddress + Addend) - *FirstSymbolAddress;
+    auto ReflSectionKind =
+        MO->mapReflectionSectionNameToEnumValue(*SectionName);
+    uint64_t AddressFromDwarfVM =
+        SectionToOffsetInDwarf.find(ReflSectionKind)->second + It->getOffset();
+    RelocationsToApply.emplace_back(AddressFromDwarfVM, Value,
+                                    ShouldSubtractDwarfVM);
+  }
+}
+
+void DwarfLinkerForBinary::copySwiftReflectionMetadata(
+    const llvm::dsymutil::DebugMapObject *Obj, DwarfStreamer *Streamer,
+    const std::unordered_map<llvm::binaryformat::Swift5ReflectionSectionKind,
+                             uint64_t> &SectionToOffsetInDwarf,
+    std::vector<MachOUtils::DwarfRelocationApplicationInfo>
+        &RelocationsToApply) {
+  using binaryformat::Swift5ReflectionSectionKind;
   auto OF =
       llvm::object::ObjectFile::createObjectFile(Obj->getObjectFilename());
   if (!OF) {
     llvm::consumeError(OF.takeError());
     return;
-  } else if (auto *MO =
-                 dyn_cast<llvm::object::MachOObjectFile>(OF->getBinary())) {
-    for (auto &Section : OF->getBinary()->sections()) {
+  }
+  if (auto *MO = dyn_cast<llvm::object::MachOObjectFile>(OF->getBinary())) {
+    // Collect the swift reflection sections before emitting them. This is
+    // done so we control the order they're emitted.
+    std::unordered_map<Swift5ReflectionSectionKind, object::SectionRef>
+        SwiftSections;
+    for (auto &Section : MO->sections()) {
       llvm::Expected<llvm::StringRef> NameOrErr =
           MO->getSectionName(Section.getRawDataRefImpl());
       if (!NameOrErr) {
         llvm::consumeError(NameOrErr.takeError());
         continue;
       }
+      NameOrErr->consume_back("__TEXT");
+      auto ReflSectionKind =
+          MO->mapReflectionSectionNameToEnumValue(*NameOrErr);
+      if (MO->isReflectionSectionStrippable(ReflSectionKind))
+        SwiftSections[ReflSectionKind] = Section;
+    }
+    // Make sure we copy the sections in alphabetic order.
+    auto SectionKindsToEmit = {Swift5ReflectionSectionKind::assocty,
+                               Swift5ReflectionSectionKind::fieldmd,
+                               Swift5ReflectionSectionKind::reflstr};
+    for (auto SectionKind : SectionKindsToEmit) {
+      if (!SwiftSections.count(SectionKind))
+        continue;
+      auto &Section = SwiftSections[SectionKind];
       llvm::Expected<llvm::StringRef> SectionContents = Section.getContents();
-      if (SectionContents) {
-        NameOrErr->consume_back("__TEXT");
-        Streamer->emitSwiftReflectionSection(
-            MO->mapReflectionSectionNameToEnumValue(*NameOrErr),
-            *SectionContents, Section.getAlignment(), Section.getSize());
-      }
+      if (!SectionContents)
+        continue;
+      const auto *MO =
+          llvm::cast<llvm::object::MachOObjectFile>(Section.getObject());
+      collectRelocationsToApplyToSwiftReflectionSections(
+          Section, *SectionContents, MO, SectionToOffsetInDwarf, Obj,
+          RelocationsToApply);
+      Streamer->emitSwiftReflectionSection(SectionKind, *SectionContents,
+                                           Section.getAlignment(),
+                                           Section.getSize());
     }
   }
 }
@@ -467,15 +663,19 @@ bool DwarfLinkerForBinary::link(const DebugMap &Map) {
   // reflection sections.
   if (!Options.NoOutput) {
     ReflectionSectionsPresentInBinary =
-        binaryHasSwiftReflectionSections(Map, Options, BinHolder);
+        binaryHasStrippableSwiftReflectionSections(Map, Options, BinHolder);
+  }
+
+  std::vector<MachOUtils::DwarfRelocationApplicationInfo> RelocationsToApply;
+  if (!Options.NoOutput && !ReflectionSectionsPresentInBinary) {
+    auto SectionToOffsetInDwarf =
+        calculateStartOfStrippableReflectionSections(Map);
+    for (const auto &Obj : Map.objects()) 
+      copySwiftReflectionMetadata(Obj.get(), Streamer.get(),
+                                  SectionToOffsetInDwarf, RelocationsToApply);
   }
 
   for (const auto &Obj : Map.objects()) {
-    // If there is no output specified or the reflection sections are present in
-    // the Input binary, there is no need to copy the Swift Reflection Metadata
-    if (!Options.NoOutput && !ReflectionSectionsPresentInBinary)
-      copySwiftReflectionMetadata(Obj.get(), Streamer.get());
-
     // N_AST objects (swiftmodule files) should get dumped directly into the
     // appropriate DWARF section.
     if (Obj->getType() == MachO::N_AST) {
@@ -547,30 +747,10 @@ bool DwarfLinkerForBinary::link(const DebugMap &Map) {
       Options.FileType == OutputFileType::Object)
     return MachOUtils::generateDsymCompanion(
         Options.VFS, Map, Options.Translator,
-        *Streamer->getAsmPrinter().OutStreamer, OutFile);
+        *Streamer->getAsmPrinter().OutStreamer, OutFile, RelocationsToApply);
 
   Streamer->finish();
   return true;
-}
-
-static bool isMachOPairedReloc(uint64_t RelocType, uint64_t Arch) {
-  switch (Arch) {
-  case Triple::x86:
-    return RelocType == MachO::GENERIC_RELOC_SECTDIFF ||
-           RelocType == MachO::GENERIC_RELOC_LOCAL_SECTDIFF;
-  case Triple::x86_64:
-    return RelocType == MachO::X86_64_RELOC_SUBTRACTOR;
-  case Triple::arm:
-  case Triple::thumb:
-    return RelocType == MachO::ARM_RELOC_SECTDIFF ||
-           RelocType == MachO::ARM_RELOC_LOCAL_SECTDIFF ||
-           RelocType == MachO::ARM_RELOC_HALF ||
-           RelocType == MachO::ARM_RELOC_HALF_SECTDIFF;
-  case Triple::aarch64:
-    return RelocType == MachO::ARM64_RELOC_SUBTRACTOR;
-  default:
-    return false;
-  }
 }
 
 /// Iterate over the relocations of the given \p Section and

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.h
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.h
@@ -12,6 +12,7 @@
 #include "BinaryHolder.h"
 #include "DebugMap.h"
 #include "LinkUtils.h"
+#include "MachOUtils.h"
 #include "llvm/DWARFLinker/DWARFLinker.h"
 #include "llvm/DWARFLinker/DWARFLinkerCompileUnit.h"
 #include "llvm/DWARFLinker/DWARFLinkerDeclContext.h"
@@ -202,6 +203,22 @@ private:
   ErrorOr<DWARFFile &> loadObject(const DebugMapObject &Obj,
                                   const DebugMap &DebugMap,
                                   remarks::RemarkLinker &RL);
+
+  void collectRelocationsToApplyToSwiftReflectionSections(
+      const object::SectionRef &Section, StringRef &Contents,
+      const llvm::object::MachOObjectFile *MO,
+      const std::unordered_map<llvm::binaryformat::Swift5ReflectionSectionKind,
+                          uint64_t> &SectionToOffsetInDwarf,
+      const llvm::dsymutil::DebugMapObject *Obj,
+      std::vector<MachOUtils::DwarfRelocationApplicationInfo>
+          &RelocationsToApply) const;
+
+  void copySwiftReflectionMetadata(
+      const llvm::dsymutil::DebugMapObject *Obj, DwarfStreamer *Streamer,
+      const std::unordered_map<llvm::binaryformat::Swift5ReflectionSectionKind,
+                               uint64_t> &SectionToOffsetInDwarf,
+      std::vector<MachOUtils::DwarfRelocationApplicationInfo>
+          &RelocationsToApply);
 
   raw_fd_ostream &OutFile;
   BinaryHolder &BinHolder;

--- a/llvm/tools/dsymutil/MachOUtils.cpp
+++ b/llvm/tools/dsymutil/MachOUtils.cpp
@@ -354,9 +354,11 @@ static unsigned segmentLoadCommandSize(bool Is64Bit, unsigned NumSections) {
 // Stream a dSYM companion binary file corresponding to the binary referenced
 // by \a DM to \a OutFile. The passed \a MS MCStreamer is setup to write to
 // \a OutFile and it must be using a MachObjectWriter object to do so.
-bool generateDsymCompanion(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
-                           const DebugMap &DM, SymbolMapTranslator &Translator,
-                           MCStreamer &MS, raw_fd_ostream &OutFile) {
+bool generateDsymCompanion(
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS, const DebugMap &DM,
+    SymbolMapTranslator &Translator, MCStreamer &MS, raw_fd_ostream &OutFile,
+    const std::vector<MachOUtils::DwarfRelocationApplicationInfo>
+        &RelocationsToApply) {
   auto &ObjectStreamer = static_cast<MCObjectStreamer &>(MS);
   MCAssembler &MCAsm = ObjectStreamer.getAssembler();
   auto &Writer = static_cast<MachObjectWriter &>(MCAsm.getWriter());
@@ -616,6 +618,16 @@ bool generateDsymCompanion(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
     OutFile.write_zeros(alignTo(Pos, Sec.getAlignment()) - Pos);
     MCAsm.writeSectionData(OutFile, &Sec, Layout);
   }
+
+  uint64_t Pos = OutFile.tell();
+  for (auto &RelocationToApply : RelocationsToApply) {
+    OutFile.seek(DwarfSegmentStart + RelocationToApply.AddressFromDwarfStart);
+    int32_t Value = RelocationToApply.Value;
+    if (RelocationToApply.ShouldSubtractDwarfVM)
+      Value -= DwarfVMAddr;
+    OutFile.write((char *)&Value, sizeof(int32_t));
+  }
+  OutFile.seek(Pos);
 
   return true;
 }

--- a/llvm/tools/dsymutil/MachOUtils.h
+++ b/llvm/tools/dsymutil/MachOUtils.h
@@ -37,13 +37,29 @@ struct ArchAndFile {
   ~ArchAndFile();
 };
 
+struct DwarfRelocationApplicationInfo {
+  // The position in the stream that should be patched, starting from the
+  // Dwarf's segment file address.
+  uint64_t AddressFromDwarfStart;
+  int32_t Value;
+  // If we should subtract the Dwarf segment's VM address from value before
+  // writing it.
+  bool ShouldSubtractDwarfVM;
+
+  DwarfRelocationApplicationInfo(uint64_t AddressFromDwarfVM, uint32_t Value,
+                                 bool ShouldSubtractDwarfVM)
+      : AddressFromDwarfStart(AddressFromDwarfVM), Value(Value),
+        ShouldSubtractDwarfVM(ShouldSubtractDwarfVM) {}
+};
+
 bool generateUniversalBinary(SmallVectorImpl<ArchAndFile> &ArchFiles,
                              StringRef OutputFileName, const LinkOptions &,
                              StringRef SDKPath);
-
-bool generateDsymCompanion(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
-                           const DebugMap &DM, SymbolMapTranslator &Translator,
-                           MCStreamer &MS, raw_fd_ostream &OutFile);
+bool generateDsymCompanion(
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS, const DebugMap &DM,
+    SymbolMapTranslator &Translator, MCStreamer &MS, raw_fd_ostream &OutFile,
+    const std::vector<MachOUtils::DwarfRelocationApplicationInfo>
+        &RelocationsToApply);
 
 std::string getArchName(StringRef Arch);
 } // namespace MachOUtils


### PR DESCRIPTION
The strippable Swift reflection sections contain subtractor relocations
that need to be applied. There are two situations we need to support.
1) Both symbols used in the relocation come from the .o file (for
   example, one symbol lives in __swift5_fieldmd and the second in
   __swift5_reflstr).
2) One symbol comes from th .o file and the second from the main
   binary (for example, __swift5_fieldmd and __swift5_typeref).