### PR TITLE
[lldb/Host] Fix crash in FileSystem::IsLocal

### DIFF
--- a/lldb/source/Host/common/FileSystem.cpp
+++ b/lldb/source/Host/common/FileSystem.cpp
@@ -192,7 +192,8 @@ bool FileSystem::IsDirectory(const FileSpec &file_spec) const {
 
 bool FileSystem::IsLocal(const Twine &path) const {
   bool b = false;
-  m_fs->isLocal(path, b);
+  if (m_fs)
+    m_fs->isLocal(path, b);
   return b;
 }
 


### PR DESCRIPTION
This checks `m_fs` before dereferencing it to access its`isLocal` method.

rdar://67410058

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>