### PR TITLE
[Support] Allow the ability to change WithColor's auto detection function

### DIFF
--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -86,6 +86,8 @@ static void reset_stdin_termios();
 static bool g_old_stdin_termios_is_valid = false;
 static struct termios g_old_stdin_termios;
 
+static bool disable_color(const raw_ostream &OS) { return false; }
+
 static Driver *g_driver = nullptr;
 
 // In the Driver::MainLoop, we change the terminal settings.  This function is
@@ -186,6 +188,12 @@ SBError Driver::ProcessArgs(const opt::InputArgList &args, bool &exiting) {
   m_debugger.SkipLLDBInitFiles(false);
   m_debugger.SkipAppInitFiles(false);
 
+  if (args.hasArg(OPT_no_use_colors)) {
+    m_debugger.SetUseColor(false);
+    WithColor::setAutoDetectFunction(disable_color);
+    m_option_data.m_debug_mode = true;
+  }
+
   if (args.hasArg(OPT_version)) {
     m_option_data.m_print_version = true;
   }
@@ -225,11 +233,6 @@ SBError Driver::ProcessArgs(const opt::InputArgList &args, bool &exiting) {
   if (args.hasArg(OPT_local_lldbinit)) {
     lldb::SBDebugger::SetInternalVariable("target.load-cwd-lldbinit", "true",
                                           m_debugger.GetInstanceName());
-  }
-
-  if (args.hasArg(OPT_no_use_colors)) {
-    m_debugger.SetUseColor(false);
-    m_option_data.m_debug_mode = true;
   }
 
   if (auto *arg = args.getLastArg(OPT_file)) {

--- a/llvm/include/llvm/Support/WithColor.h
+++ b/llvm/include/llvm/Support/WithColor.h
@@ -51,10 +51,9 @@ enum class ColorMode {
 /// An RAII object that temporarily switches an output stream to a specific
 /// color.
 class WithColor {
-  raw_ostream &OS;
-  ColorMode Mode;
-
 public:
+  using AutoDetectFunctionType = bool (*)(const raw_ostream &OS);
+
   /// To be used like this: WithColor(OS, HighlightColor::String) << "text";
   /// @param OS The output stream
   /// @param S Symbolic name for syntax element to color
@@ -132,6 +131,19 @@ public:
   /// Implement default handling for Warning.
   /// Print "warning: " to stderr.
   static void defaultWarningHandler(Error Warning);
+
+  /// Retrieve the default color auto detection function.
+  static AutoDetectFunctionType defaultAutoDetectFunction();
+
+  /// Change the global auto detection function.
+  static void
+  setAutoDetectFunction(AutoDetectFunctionType NewAutoDetectFunction);
+
+private:
+  raw_ostream &OS;
+  ColorMode Mode;
+
+  static AutoDetectFunctionType AutoDetectFunction;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Support/WithColor.cpp
+++ b/llvm/lib/Support/WithColor.cpp
@@ -33,6 +33,14 @@ struct CreateUseColor {
 static ManagedStatic<cl::opt<cl::boolOrDefault>, CreateUseColor> UseColor;
 void llvm::initWithColorOptions() { *UseColor; }
 
+static bool DefaultAutoDetectFunction(const raw_ostream &OS) {
+  return *UseColor == cl::BOU_UNSET ? OS.has_colors()
+                                    : *UseColor == cl::BOU_TRUE;
+}
+
+WithColor::AutoDetectFunctionType WithColor::AutoDetectFunction =
+    DefaultAutoDetectFunction;
+
 WithColor::WithColor(raw_ostream &OS, HighlightColor Color, ColorMode Mode)
     : OS(OS), Mode(Mode) {
   // Detect color from terminal type unless the user passed the --color option.
@@ -127,8 +135,7 @@ bool WithColor::colorsEnabled() {
   case ColorMode::Disable:
     return false;
   case ColorMode::Auto:
-    return *UseColor == cl::BOU_UNSET ? OS.has_colors()
-                                      : *UseColor == cl::BOU_TRUE;
+    return AutoDetectFunction(OS);
   }
   llvm_unreachable("All cases handled above.");
 }
@@ -158,4 +165,13 @@ void WithColor::defaultWarningHandler(Error Warning) {
   handleAllErrors(std::move(Warning), [](ErrorInfoBase &Info) {
     WithColor::warning() << Info.message() << '\n';
   });
+}
+
+WithColor::AutoDetectFunctionType WithColor::defaultAutoDetectFunction() {
+  return DefaultAutoDetectFunction;
+}
+
+void WithColor::setAutoDetectFunction(
+    AutoDetectFunctionType NewAutoDetectFunction) {
+  AutoDetectFunction = NewAutoDetectFunction;
 }


### PR DESCRIPTION
WithColor has an "auto detection mode" which looks whether the
corresponding whether the corresponding cl::opt is enabled or not. While
this is great when opting into cl::opt, it's not so great for downstream
users of this utility, which might have their own competing options to
enable or disable colors. The WithColor constructor takes a color mode,
but the big benefit of the class are its static error and warning
helpers and default error handlers.

In order to allow users of this utility to enable or disable colors
globally, this patch adds the ability to specify a global auto detection
function. By default, the auto detection function behaves the way that
it does today. The benefit of this patch lies in that it can be
overwritten. In addition to a ability to change the auto detection
function, I've also made it possible to get your hands on the default
auto detection function, so you swap it back if if you so desire.

This patch allow downstream users (like LLDB) to globally disable colors
with its own command line flag.

Differential revision: https://reviews.llvm.org/D120593

(cherry picked from commit a83cf7a84628a9e3a24cfd33c69f786cf74df4ec)
