### PR TITLE
lld: Remove unused call to trackNewAccesses

### DIFF
--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1314,7 +1314,6 @@ static bool linkWithResultCaching(InputArgList &args, bool canExitEarly,
             toString(cacheFS.takeError()));
       return ::link(args, canExitEarly, stdoutOS, stderrOS);
     }
-    (*cacheFS)->trackNewAccesses();
     auto originalFS = std::move(config->fs);
     config->fs = *cacheFS;
 


### PR DESCRIPTION
Stop calling CachingOnDiskFileSystem::trackNewAccesses() in lld, since
it isn't followed by a call to createTreeFromNewAccesses(). Here, it's
using createTreeFromAllAccesses(), which seems fine since the lifetime
of the filesystem is short anyway.