### PR TITLE
CAS: Fix CachingOnDiskFileSystem::getRealPath()

### DIFF
--- a/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
+++ b/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
@@ -376,7 +376,7 @@ CachingOnDiskFileSystemImpl::getRealPath(const Twine &Path,
   // We can get the real path, but it's not a const operation.
   const vfs::CachedDirectoryEntry *Entry = nullptr;
   if (Error E =
-          getDirectoryEntry(Path, /*FollowSymlinks=*/false).moveInto(Entry))
+          getDirectoryEntry(Path, /*FollowSymlinks=*/true).moveInto(Entry))
     return errorToErrorCode(std::move(E));
 
   StringRef TreePath = Entry->getTreePath();

--- a/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
@@ -368,4 +368,19 @@ TEST(CachingOnDiskFileSystemTest, TrackNewAccesses) {
   }
 }
 
+TEST(CachingOnDiskFileSystemTest, getRealPath) {
+  TempDir D("caching-on-disk-file-system-test", /*Unique=*/true);
+  IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS =
+      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
+  ASSERT_FALSE(FS->setCurrentWorkingDirectory(D.path()));
+
+  TempFile File(D.path("file"), "", "content");
+  TempLink Link(File.path(), D.path("link"));
+
+  SmallString<128> FilePath, LinkPath;
+  EXPECT_FALSE(FS->getRealPath(File.path(), FilePath));
+  EXPECT_FALSE(FS->getRealPath(Link.path(), LinkPath));
+  EXPECT_EQ(FilePath, LinkPath);
+}
+
 } // namespace


### PR DESCRIPTION
Partially revert 6ffbf1475b5230647bc8e9af25a0992540ed9153, which
seems to have broken getRealPath() as an accidental drive-by. Add
a dedicated unit test while in there.