### PR TITLE
[clang] Add Swift support for PPC32

### DIFF
--- a/clang/lib/Basic/Targets/PPC.h
+++ b/clang/lib/Basic/Targets/PPC.h
@@ -400,6 +400,17 @@ public:
     // This is the ELF definition, and is overridden by the Darwin sub-target
     return TargetInfo::PowerABIBuiltinVaList;
   }
+
+  CallingConvCheckResult checkCallingConvention(CallingConv CC) const override {
+    switch (CC) {
+    case CC_Swift:
+      return CCCR_OK;
+    case CC_SwiftAsync:
+      return CCCR_Error;
+    default:
+      return CCCR_Warning;
+    }
+  }
 };
 
 // Note: ABI differences may eventually require us to have a separate


### PR DESCRIPTION
Adds support for compiling Swift targeting the PPC32 ABI

Differential Revision: https://reviews.llvm.org/D137510

Resolves [SR-15945](https://github.com/apple/swift/issues/58206).