### PR TITLE
TypeSystem: remove a stray `,` (NFC)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3793,7 +3793,7 @@ bool SwiftASTContext::LoadLibraryUsingPaths(
                found_library.GetCString());
     return true;
   } else {
-    all_dlopen_errors.Printf("Failed to find \"%s\" in paths:\n,",
+    all_dlopen_errors.Printf("Failed to find \"%s\" in paths:\n",
                              library_fullname.c_str());
     for (const std::string &search_dir : uniqued_paths)
       all_dlopen_errors.Printf("  %s\n", search_dir.c_str());


### PR DESCRIPTION
This removes a stray comma in the logging messages that has bothered me
for a while.  NFC.