### PR TITLE
[lldb] Also look for metadata in __TEXT when reading from dsym

### DIFF
--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -677,6 +677,9 @@ public:
   virtual size_t ReadSectionData(Section *section,
                                  DataExtractor &section_data);
 
+  const char *GetCStrFromSection(Section *section,
+                                 lldb::offset_t section_offset) const;
+
   bool IsInMemory() const { return m_memory_addr != LLDB_INVALID_ADDRESS; }
 
   // Strip linker annotations (such as @@VERSION) from symbol names.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
@@ -4,6 +4,7 @@
 
 #include "SwiftLanguageRuntime.h"
 #include "swift/Reflection/TypeLowering.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/Support/Memory.h"
 
 
@@ -67,8 +68,8 @@ private:
 
  /// Reads memory from the symbol rich binary from the address into dest.
  /// \return true if it was able to successfully read memory.
-  bool readBytesFromSymbolObjectFile(uint64_t address, uint8_t *dest,
-                                     uint64_t size) const;
+llvm::Optional<Address> resolveRemoteAddressFromSymbolObjectFile(uint64_t address) const;
+
 
 private:
   Process &m_process;
@@ -89,7 +90,8 @@ private:
 
   /// The set of modules where we should read memory from the symbol file's
   /// object file instead of the main object file.
-  std::unordered_set<lldb::ModuleSP> m_modules_with_metadata_in_symbol_obj_file;
+  llvm::SmallSet<lldb::ModuleSP, 8>
+   m_modules_with_metadata_in_symbol_obj_file;
 
   /// The bit used to tag LLDB's virtual addresses as such. See \c
   /// m_range_module_map.

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -556,6 +556,13 @@ size_t ObjectFile::ReadSectionData(Section *section,
                   section_data);
 }
 
+const char *
+ObjectFile::GetCStrFromSection(Section *section,
+                               lldb::offset_t section_offset) const {
+  offset_t offset = section->GetOffset() + section_offset;
+  return m_data.GetCStr(&offset);
+}
+
 bool ObjectFile::SplitArchivePathWithObject(llvm::StringRef path_with_object,
                                             FileSpec &archive_file,
                                             ConstString &archive_object,


### PR DESCRIPTION
Some swift metadata sections are not strippable, and live in __TEXT
instead of __DWARF in the dsym. Make LLDBMemoryReader take that into
account.

(cherry picked from commit 49a558c5e869a62c051ecfb8caba3c529c024c5b)