### PR TITLE
[lldb] Fix swift exception breakpoint command type filtering

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -581,6 +581,19 @@ def run_break_set_by_file_colon_line(
 
     return get_bpno_from_match(break_results)
 
+def run_break_set_by_exception(
+        test,
+        language,
+        exception_typename=None):
+    command = 'breakpoint set -E ' + language
+    if exception_typename:
+        command += ' --exception-typename ' + exception_typename
+
+    break_results = run_break_set_command(test, command)
+    # No call to check_breakpoint_result as there's nothing to check. In
+    # particular, the exception breakpoint isn't yet guaranteed to be resolved.
+    return get_bpno_from_match(break_results)
+
 def run_break_set_command(test, command):
     """Run the command passed in - it must be some break set variant - and analyze the result.
     Returns a dictionary of information gleaned from the command-line results.

--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -421,7 +421,7 @@ public:
       } break;
 
       case 'O':
-        m_exception_extra_args.AppendArgument("-O");
+        m_exception_extra_args.AppendArgument("exception-typename");
         m_exception_extra_args.AppendArgument(option_arg);
         break;
 

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -216,12 +216,6 @@ let Command = "breakpoint set" in {
   def breakpoint_set_file_colon_line : Option<"joint-specifier", "y">, Group<12>, Arg<"FileLineColumn">,
     Required, Completion<"SourceFile">,
     Desc<"A specifier in the form filename:line[:column] for setting file & line breakpoints.">;
-  /* Don't add this option till it actually does something useful...
-  def breakpoint_set_exception_typename : Option<"exception-typename", "O">,
-    Arg<"TypeName">, Desc<"The breakpoint will only stop if an "
-    "exception Object of this type is thrown.  Can be repeated multiple times "
-    "to stop for multiple object types">;
-   */
 }
 
 let Command = "breakpoint clear" in {

--- a/lldb/test/API/functionalities/breakpoint/swift_exception/TestExpressionErrorBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/swift_exception/TestExpressionErrorBreakpoint.py
@@ -26,81 +26,73 @@ class TestSwiftErrorBreakpoint(TestBase):
 
     @decorators.skipIfLinux  # <rdar://problem/30909618>
     @swiftTest
-    def test_swift_error_no_pattern(self):
+    def test_swift_error_no_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""
-        self.build()
-        self.do_test(lldb.SBStringList(), True)
+        self.do_tests(None, True)
 
     @swiftTest
-    def test_swift_error_matching_base_pattern(self):
+    def test_swift_error_matching_base_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""
-        self.build()
-        pattern = lldb.SBStringList()
-        pattern.AppendString("exception-typename")
-        pattern.AppendString("EnumError")
-        self.do_test(pattern, True)
+        self.do_tests("EnumError", True)
 
     @swiftTest
-    def test_swift_error_matching_full_pattern(self):
+    def test_swift_error_matching_full_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""
-        self.build()
-        pattern = lldb.SBStringList()
-        pattern.AppendString("exception-typename")
-        pattern.AppendString("a.EnumError")
-        self.do_test(pattern, True)
+        self.do_tests("a.EnumError", True)
 
     @swiftTest
-    def test_swift_error_bogus_pattern(self):
+    def test_swift_error_bogus_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""
-        self.build()
-        pattern = lldb.SBStringList()
-        pattern.AppendString("exception-typename")
-        pattern.AppendString("NoSuchErrorHere")
-        self.do_test(pattern, False)
+        self.do_tests("NoSuchErrorHere", False)
 
     def setUp(self):
         TestBase.setUp(self)
-        self.main_source = "main.swift"
-        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+        self.build()
 
-    def do_test(self, patterns, should_stop):
-        """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""
+    def do_tests(self, typename, should_stop):
+        self.do_test(typename, should_stop, self.create_breakpoint_with_api)
+        self.do_test(typename, should_stop, self.create_breakpoint_with_command)
 
+    def create_breakpoint_with_api(self, target, typename):
+        types = lldb.SBStringList()
+        if typename:
+            types.AppendString("exception-typename")
+            types.AppendString(typename)
+        return target.BreakpointCreateForException(
+            lldb.eLanguageTypeSwift, False, True, types)
+
+    def create_breakpoint_with_command(self, target, typename):
+        cmd = "breakpoint set -E swift"
+        if typename:
+            cmd += " --exception-typename " + typename
+        self.runCmd(cmd)
+        return target.GetBreakpointAtIndex(0)
+
+    def do_test(self, typename, should_stop, make_breakpoint):
         exe_name = "a.out"
         exe = self.getBuildArtifact(exe_name)
 
         # Create the target
         target = self.dbg.CreateTarget(exe)
-        self.target = target
         self.assertTrue(target, VALID_TARGET)
 
         # Set the breakpoints
-        swift_error_bkpt = target.BreakpointCreateForException(
-            lldb.eLanguageTypeSwift, False, True, patterns)
+        swift_error_bkpt = make_breakpoint(target, typename)
         # Note, I'm not checking locations here because we never know them
         # before launch.
 
         # Launch the process, and do not stop at the entry point.
         process = target.LaunchSimple(None, None, os.getcwd())
-        self.process = process
 
         if should_stop:
             self.assertTrue(process, PROCESS_IS_VALID)
             breakpoint_threads = lldbutil.get_threads_stopped_at_breakpoint(
                 process, swift_error_bkpt)
-            self.assertTrue(
-                len(breakpoint_threads) == 1,
+            self.assertEqual(len(breakpoint_threads), 1,
                 "We didn't stop at the error breakpoint")
         else:
             exit_state = process.GetState()
-            self.assertTrue(
-                exit_state == lldb.eStateExited,
+            self.assertEqual(exit_state, lldb.eStateExited,
                 "We stopped at the error breakpoint when we shouldn't have.")
 
         target.BreakpointDelete(swift_error_bkpt.GetID())
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()


### PR DESCRIPTION
Specifying a typename filter for Swift exception breakpoints has been broken when creating breakpoints from the command line.

In other words, this command:

```
(lldb) breakpoint set -E swift --exception-typename MyError
```

would create a breakpoint that stopped for **any** Swift exception.

The fix is a one-line fix, changing the way `m_exception_extra_args` is constructed in `CommandObjectBreakpoint`. These args are consumed in [`SwiftExceptionPrecondition::ConfigurePrecondition`](https://github.com/apple/llvm-project/blob/9509716734619d7299d296cb175e5d50f1d0a857/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp#L1524-L1531).

Most of the changes included in this PR are to refactor the associated unit tests. The tests had been creating the exception breakpoint via SB API, not via command line which is why this bug wasn't caught by the tests. The tests have been updated to create exception breakpoints via both API and CLI. While editing the tests, I cleaned them up too.

I also deleted a duplicate and commented-out definition of `breakpoint_set_exception_typename` in `Commands/Options.td`.

rdar://75959015