### PR TITLE
Fix compile error in non-asserts builds

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1213,9 +1213,7 @@ CompilerType TypeSystemSwift::GetInstanceType(CompilerType compiler_type) {
   return {};
 }
 
-#ifndef NDEBUG
 TypeSystemSwiftTypeRef::TypeSystemSwiftTypeRef() {}
-#endif
 
 TypeSystemSwiftTypeRef::~TypeSystemSwiftTypeRef() {}
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -50,10 +50,8 @@ public:
   static bool classof(const TypeSystem *ts) { return ts->isA(&ID); }
   /// \}
 
-#ifndef NDEBUG
   /// Provided only for unit tests.
   TypeSystemSwiftTypeRef();
-#endif
   ~TypeSystemSwiftTypeRef();
   TypeSystemSwiftTypeRef(Module &module);
   TypeSystemSwiftTypeRef(SwiftASTContextForExpressions &swift_ast_context);


### PR DESCRIPTION
(cherry picked from commit 426d8c115bde3bd0b92117d49bf76b1ada8f154e)

 Conflicts:
	lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp