### PR TITLE
[lldb] Add --exists flag to `settings set`

### DIFF
--- a/lldb/source/Commands/CommandObjectSettings.cpp
+++ b/lldb/source/Commands/CommandObjectSettings.cpp
@@ -103,6 +103,9 @@ insert-before or insert-after.");
       case 'g':
         m_global = true;
         break;
+      case 'e':
+        m_exists = true;
+        break;
       default:
         llvm_unreachable("Unimplemented option");
       }
@@ -113,6 +116,7 @@ insert-before or insert-after.");
     void OptionParsingStarting(ExecutionContext *execution_context) override {
       m_global = false;
       m_force = false;
+      m_exists = false;
     }
 
     llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
@@ -121,7 +125,8 @@ insert-before or insert-after.");
 
     // Instance variables to hold the values for command options.
     bool m_global = false;
-    bool m_force;
+    bool m_force = false;
+    bool m_exists = false;
   };
 
   void
@@ -220,13 +225,12 @@ protected:
                                              var_name, var_value);
     }
 
-    if (error.Fail()) {
+    if (error.Fail() && !m_options.m_exists) {
       result.AppendError(error.AsCString());
       return false;
-    } else {
-      result.SetStatus(eReturnStatusSuccessFinishResult);
     }
 
+    result.SetStatus(eReturnStatusSuccessFinishResult);
     return result.Succeeded();
   }
 

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -23,6 +23,9 @@ let Command = "settings set" in {
     Desc<"Apply the new value to the global default value.">;
   def setset_force : Option<"force", "f">,
     Desc<"Force an empty value to be accepted as the default.">;
+  def setset_exists : Option<"exists", "e">,
+    Desc<"Set the setting if it exists, but do not cause the command to raise "
+    "an error if it does not exist.">;
 }
 
 let Command = "settings write" in {

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -779,3 +779,13 @@ class SettingsCommandTestCase(TestBase):
         # finally, confirm that trying to set a setting that does not exist still fails.
         # (SHOWING a setting that does not exist does not currently yield an error.)
         self.expect('settings set target.setting-which-does-not-exist true', error=True)
+
+    def test_settings_set_exists(self):
+        cmdinterp = self.dbg.GetCommandInterpreter()
+
+        # An unknown option should succeed.
+        self.expect('settings set -e foo bar')
+        self.expect('settings set --exists foo bar')
+
+        # A known option should fail if its argument is invalid.
+        self.expect("settings set auto-confirm bogus", error=True)


### PR DESCRIPTION
Add a --exists/-e flag to `settings set` that sets the setting if it
exists, but doesn't print an error otherwise. This is useful for example
when setting options in your ~/.lldbinit that might not exist in older
versions of lldb.

Differential revision: https://reviews.llvm.org/D121155

(cherry picked from commit 8a0fa4db39d862b99eb5d440a211c5c0228e13ce)