### PR TITLE
[debug-info] Debug salvage llvm.dbg.addr in original function that point into the coroutine frame when splitting coros.

### DIFF
--- a/llvm/test/Transforms/Coroutines/coro-debug-dbg.addr-swift.ll
+++ b/llvm/test/Transforms/Coroutines/coro-debug-dbg.addr-swift.ll
@@ -8,8 +8,8 @@
 ; RUN: opt %s -passes='function(coro-early),cgscc(coro-split,simplifycfg)' -S | FileCheck %s
 
 ; CHECK-LABEL: define swifttailcc void @"$s10async_args14withGenericArgyyxnYalF"(%swift.context* swiftasync %0, %swift.opaque* noalias %1, %swift.type* %T){{.*}} {
-; CHECK: call void @llvm.dbg.declare(
-; CHECK: call void @llvm.dbg.addr(
+; CHECK: call void @llvm.dbg.declare(metadata %swift.context** [[CORO_CTX:%[a-z0-9\.]+]],
+; CHECK: call void @llvm.dbg.addr(metadata %swift.context** [[CORO_CTX]],
 ; CHECK-NOT: llvm.dbg.value
 ; CHECK-NOT: llvm.dbg.addr
 ; CHECK-NOT: llvm.dbg.declare
@@ -19,15 +19,15 @@
 
 ; CHECK-LABEL: define internal swifttailcc void @"$s10async_args14withGenericArgyyxnYalFTY0_"(i8* swiftasync %0)
 ; CHECK: entryresume.0
-; CHECK: call void @llvm.dbg.declare(
-; CHECK: call void @llvm.dbg.addr(
+; CHECK: call void @llvm.dbg.declare(metadata i8** [[CORO_CTX:%[a-z0-9\.]+]],
+; CHECK: call void @llvm.dbg.addr(metadata i8** [[CORO_CTX]],
 ; CHECK: musttail call swifttailcc void @"$s10async_args10forceSplityyYaF"(%swift.context* swiftasync
 ; CHECK-NEXT: ret void
 ; CHECK-NEXT: }
 
 ; CHECK: define internal swifttailcc void @"$s10async_args14withGenericArgyyxnYalFTQ1_"(i8* swiftasync %0)
-; CHECK: call void @llvm.dbg.declare
-; CHECK: call void @llvm.dbg.addr
+; CHECK: call void @llvm.dbg.declare(metadata i8** [[CORO_CTX:%[a-z0-9\.]+]],
+; CHECK: call void @llvm.dbg.addr(metadata i8** [[CORO_CTX]],
 ; CHECK: call void @llvm.dbg.value(metadata %swift.opaque** undef,
 ; CHECK: ret void
 ; CHECK-NEXT: }


### PR DESCRIPTION
We are already doing this in the split functions while we clone. This just
handles the original function.

I also updated the coroutine split test to validate that we are always referring
to the msg in the context object instead of in a shadow copy.

rdar://83957028

Reviewed By: aprantl

Differential Revision: https://reviews.llvm.org/D121324

(cherry picked from commit 0b647fc5299156bf83c46aa539d6c9c39647bb36)

Conflicts:
	llvm/lib/Transforms/Coroutines/CoroSplit.cpp
	llvm/test/Transforms/Coroutines/coro-debug-frame-variable.ll