### PR TITLE
Cache the result of TypeSystemSwiftTypeRef::LookupClangType(). 

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -396,6 +396,8 @@ protected:
 
   /// All lldb::Type pointers produced by DWARFASTParser Swift go here.
   ThreadSafeDenseMap<const char *, lldb::TypeSP> m_swift_type_map;
+  /// Map ConstString Clang type identifiers to Clang types.
+  ThreadSafeDenseMap<const char *, lldb::TypeSP> m_clang_type_cache;
 };
 
 /// This one owns a SwiftASTContextForExpressions.


### PR DESCRIPTION
We have seen traces showing this as a hotspot in GetBitSize(),
IsImportedType(), and indirectly GetTypeName().

rdar://89927216