### PR TITLE
[lldb/crashlog] Make interactive mode display more user-friendly

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -267,7 +267,7 @@ class CrashLog(symbolication.Symbolicator):
             self.resolved = True
             uuid_str = self.get_normalized_uuid_string()
             if self.show_symbol_progress():
-                print('Getting symbols for %s %s...' % (uuid_str, self.path), end=' ')
+                print('Getting symbols for %s %s...\n' % (uuid_str, self.path), end=' ')
             if os.path.exists(self.dsymForUUIDBinary):
                 dsym_for_uuid_command = '%s %s' % (
                     self.dsymForUUIDBinary, uuid_str)
@@ -317,7 +317,7 @@ class CrashLog(symbolication.Symbolicator):
                     pass
             if (self.resolved_path and os.path.exists(self.resolved_path)) or (
                     self.path and os.path.exists(self.path)):
-                print('ok')
+                print('Resolved symbols for %s %s...\n' % (uuid_str, self.path), end=' ')
                 return True
             else:
                 self.unavailable = True

--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -28,8 +28,10 @@
 
 from __future__ import print_function
 import cmd
+import contextlib
 import datetime
 import glob
+import json
 import optparse
 import os
 import platform
@@ -41,7 +43,6 @@ import subprocess
 import sys
 import time
 import uuid
-import json
 
 try:
     # First try for LLDB in case PYTHONPATH is already correctly setup.
@@ -1005,6 +1006,31 @@ def load_crashlog_in_scripted_process(debugger, crash_log_file):
     launch_info.SetScriptedProcessDictionary(structured_data)
     error = lldb.SBError()
     process = target.Launch(launch_info, error)
+
+    if not process or error.Fail():
+        return
+
+    @contextlib.contextmanager
+    def synchronous(debugger):
+        async_state = debugger.GetAsync()
+        debugger.SetAsync(False)
+        try:
+            yield
+        finally:
+            debugger.SetAsync(async_state)
+
+    with synchronous(debugger):
+        run_options = lldb.SBCommandInterpreterRunOptions()
+        run_options.SetStopOnError(True)
+        run_options.SetStopOnCrash(True)
+        run_options.SetEchoCommands(True)
+
+        commands_stream = lldb.SBStream()
+        commands_stream.Print("process status\n")
+        commands_stream.Print("thread backtrace\n")
+        error = debugger.SetInputString(commands_stream.GetData())
+        if error.Success():
+            debugger.RunCommandInterpreter(True, False, run_options, 0, False, True)
 
 def CreateSymbolicateCrashLogOptions(
         command_name,

--- a/lldb/test/API/functionalities/scripted_process/TestScriptedProcess.py
+++ b/lldb/test/API/functionalities/scripted_process/TestScriptedProcess.py
@@ -2,7 +2,7 @@
 Test python scripted process in lldb
 """
 
-import os
+import os, shutil
 
 import lldb
 from lldbsuite.test.decorators import *
@@ -43,29 +43,39 @@ class ScriptedProcesTestCase(TestBase):
         self.expect('script dir(ScriptedProcess)',
                     substrs=["launch"])
 
+    def move_blueprint_to_dsym(self, blueprint_name):
+        blueprint_origin_path = os.path.join(self.getSourceDir(), blueprint_name)
+        dsym_bundle = self.getBuildArtifact("a.out.dSYM")
+        blueprint_destination_path = os.path.join(dsym_bundle, "Contents",
+                                                  "Resources", "Python")
+        if not os.path.exists(blueprint_destination_path):
+            os.mkdir(blueprint_destination_path)
+
+        blueprint_destination_path = os.path.join(blueprint_destination_path, "a_out.py")
+        shutil.copy(blueprint_origin_path, blueprint_destination_path)
+
     @skipUnlessDarwin
     def test_invalid_scripted_register_context(self):
         """Test that we can launch an lldb scripted process with an invalid
         Scripted Thread, with invalid register context."""
         self.build()
-        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
-        self.assertTrue(target, VALID_TARGET)
-        log_file = self.getBuildArtifact('thread.log')
-        self.runCmd("log enable lldb thread -f " + log_file)
-        self.assertTrue(os.path.isfile(log_file))
 
         os.environ['SKIP_SCRIPTED_PROCESS_LAUNCH'] = '1'
         def cleanup():
           del os.environ["SKIP_SCRIPTED_PROCESS_LAUNCH"]
         self.addTearDownHook(cleanup)
 
-        scripted_process_example_relpath = 'invalid_scripted_process.py'
-        self.runCmd("command script import " + os.path.join(self.getSourceDir(),
-                                                            scripted_process_example_relpath))
+        self.runCmd("settings set target.load-script-from-symbol-file true")
+        self.move_blueprint_to_dsym('invalid_scripted_process.py')
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.assertTrue(target, VALID_TARGET)
+        log_file = self.getBuildArtifact('thread.log')
+        self.runCmd("log enable lldb thread -f " + log_file)
+        self.assertTrue(os.path.isfile(log_file))
 
         launch_info = lldb.SBLaunchInfo(None)
         launch_info.SetProcessPluginName("ScriptedProcess")
-        launch_info.SetScriptedProcessClassName("invalid_scripted_process.InvalidScriptedProcess")
+        launch_info.SetScriptedProcessClassName("a_out.InvalidScriptedProcess")
         error = lldb.SBError()
 
         process = target.Launch(launch_info, error)

--- a/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/scripted_crashlog_json.test
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/scripted_crashlog_json.test
@@ -4,9 +4,17 @@
 
 # RUN: cp %S/Inputs/scripted_crashlog.ips %t.crash
 # RUN: %python %S/patch-crashlog.py --binary %t.out --crashlog %t.crash --offsets '{"main":20, "bar":9, "foo":16}' --json
-# RUN: %lldb %t.out -o 'command script import lldb.macosx.crashlog' -o 'crashlog -i %t.crash' -o 'process status' 2>&1 | FileCheck %s
+# RUN: %lldb %t.out -o 'command script import lldb.macosx.crashlog' -o 'crashlog -i %t.crash' 2>&1 | FileCheck %s
 
 # CHECK: "crashlog" {{.*}} commands have been installed, use the "--help" options on these commands
-# CHECK: Process 92190 stopped
-# CHECK: * thread #1, name = 'CrashLogScriptedThread.thread-0', stop reason = EXC_BAD_ACCESS
-# CHECK: frame #0: 0x0000000104a23f68 scripted_crashlog_json.test.tmp.out`foo at test.c:3:6 [artificial]
+# CHECK: (lldb) process status
+# CHECK-NEXT: Process 92190 stopped
+# CHECK-NEXT: * thread #1, name = 'CrashLogScriptedThread.thread-0', stop reason = EXC_BAD_ACCESS
+# CHECK-NEXT: frame #0: 0x0000000104a23f68 scripted_crashlog_json.test.tmp.out`foo at test.c:3:6 [artificial]
+
+# CHECK: (lldb) thread backtrace
+# CHECK-NEXT: * thread #1, name = 'CrashLogScriptedThread.thread-0', stop reason = EXC_BAD_ACCESS
+# CHECK-NEXT: * frame #0: 0x0000000104a23f68 scripted_crashlog_json.test.tmp.out`foo at test.c:3:6 [artificial]
+# CHECK-NEXT: frame #1: 0x0000000104a23f80 scripted_crashlog_json.test.tmp.out`bar at test.c:6:21 [artificial]
+# CHECK-NEXT: frame #2: 0x0000000104a23fa0 scripted_crashlog_json.test.tmp.out`main(argc=<no summary available>, argv=<unavailable>) at test.c:8:35 [artificial]
+# CHECK-NEXT: frame #3: 0x0000000104a6108c dyld`start(kernArgs=<no summary available>) at dyldMain.cpp:879:18 [opt] [artificial]


### PR DESCRIPTION
This update the `crashlog -i` command to automatically show the process status and thread backtrace after loading the Scripted Process (rdar://89634338) and ensures that we load Scripted Process Blueprints from the dSYM bundle (rdar://74502750)