### PR TITLE
CAS: Change CAS prefix from `~{CASFS}:` to `llvmcas://`

### DIFF
--- a/llvm/lib/CAS/BuiltinCAS.cpp
+++ b/llvm/lib/CAS/BuiltinCAS.cpp
@@ -218,7 +218,7 @@ using HashType = decltype(HasherT::hash(std::declval<ArrayRef<uint8_t> &>()));
 
 } // end anonymous namespace
 
-static StringRef getCASIDPrefix() { return "~{CASFS}:"; }
+static StringRef getCASIDPrefix() { return "llvmcas://"; }
 
 static void extractPrintableHash(CASID ID, SmallVectorImpl<char> &Dest) {
   ArrayRef<uint8_t> RawHash = ID.getHash();

--- a/llvm/test/tools/llvm-cas/print-id.test
+++ b/llvm/test/tools/llvm-cas/print-id.test
@@ -1,0 +1,13 @@
+RUN: rm -rf %t
+RUN: mkdir %t
+
+RUN: llvm-cas --cas %t/cas --ingest --data %S/Inputs > %t/id
+
+# Confirm that the ID has the right prefix, is well-formed, and that there's
+# nothing else on the line.
+RUN: FileCheck %s --match-full-lines --strict-whitespace <%t/id
+CHECK:llvmcas://{{[a-z0-9]+}}
+
+# Confirm that there's a newline after.
+RUN: wc -l <%t/id | FileCheck %s -check-prefix=NEWLINE
+NEWLINE: 1

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -485,6 +485,7 @@ int ingestFileSystem(CASDB &CAS, StringRef Path) {
         createStringError(inconvertibleErrorCode(), "missing --data=<path>"));
   auto Ref = ExitOnErr(ingestFileSystemImpl(CAS, Path));
   ExitOnErr(CAS.printCASID(outs(), Ref));
+  outs() << "\n";
   return 0;
 }
 


### PR DESCRIPTION
- The URL form more easily recognizable.
- It should have LLVM in the name.
- It should not have "FS" in the name.