### PR TITLE
Add csv format output to llvm-cas-object-format

### DIFF
--- a/llvm/test/tools/llvm-cas-object-format/Inputs/csvtest.ll
+++ b/llvm/test/tools/llvm-cas-object-format/Inputs/csvtest.ll
@@ -1,0 +1,49 @@
+; ModuleID = './file.c'
+source_filename = "./file.c"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx12.0.0"
+
+; Function Attrs: noinline nounwind optnone ssp uwtable
+define i32 @foo(i32 %0) #0 {
+  %2 = alloca i32, align 4
+  store i32 %0, i32* %2, align 4
+  %3 = load i32, i32* %2, align 4
+  %4 = load i32, i32* %2, align 4
+  %5 = mul nsw i32 %3, %4
+  ret i32 %5
+}
+
+; Function Attrs: noinline nounwind optnone ssp uwtable
+define i32 @bar(i32 %0) #0 {
+  %2 = alloca i32, align 4
+  store i32 %0, i32* %2, align 4
+  %3 = load i32, i32* %2, align 4
+  %4 = sdiv i32 %3, 2
+  ret i32 %4
+}
+
+; Function Attrs: noinline nounwind optnone ssp uwtable
+define i32 @main(i32 %0, i8** %1) #0 {
+  %3 = alloca i32, align 4
+  %4 = alloca i32, align 4
+  %5 = alloca i8**, align 8
+  store i32 0, i32* %3, align 4
+  store i32 %0, i32* %4, align 4
+  store i8** %1, i8*** %5, align 8
+  %6 = load i32, i32* %4, align 4
+  %7 = call i32 @foo(i32 %6)
+  %8 = call i32 @bar(i32 %7)
+  ret i32 %8
+}
+
+attributes #0 = { noinline nounwind optnone ssp uwtable "darwin-stkchk-strong-link" "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "probe-stack"="___chkstk_darwin" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4}
+!llvm.ident = !{!5}
+
+!0 = !{i32 2, !"SDK Version", [3 x i32] [i32 12, i32 0, i32 1]}
+!1 = !{i32 1, !"wchar_size", i32 4}
+!2 = !{i32 7, !"PIC Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 1}
+!4 = !{i32 7, !"frame-pointer", i32 2}
+!5 = !{!"Apple clang version 14.0.0 (clang-1400.0.11.4)"}

--- a/llvm/test/tools/llvm-cas-object-format/csv-stats.test
+++ b/llvm/test/tools/llvm-cas-object-format/csv-stats.test
@@ -1,0 +1,66 @@
+RUN: rm -rf %t && mkdir -p %t
+RUN: llc %S/Inputs/csvtest.ll --filetype=obj -o %t/csvtest.o
+
+RUN: llvm-cas-object-format --cas %t/cas --object-stats %t/stats.csv --object-stats-format=csv --ingest-schema=nestedv1 %t/csvtest.o
+RUN: cat %t/stats.csv | FileCheck %s -check-prefix=CSV
+
+RUN: llvm-cas-object-format --cas %t/cas --object-stats - --object-stats-format=csv --ingest-schema=nestedv1 %t/csvtest.o | FileCheck %s -check-prefix=CSV
+
+RUN: llvm-cas-object-format --cas %t/cas --object-stats - --object-stats-format=pretty --ingest-schema=nestedv1 %t/csvtest.o | FileCheck %s -check-prefix=PRETTY
+
+RUN: llvm-cas-object-format --cas %t/cas --object-stats %t/statspretty.txt --object-stats-format=pretty --ingest-schema=nestedv1 %t/csvtest.o
+RUN: cat %t/statspretty.txt | FileCheck %s -check-prefix=PRETTY
+
+RUN: llvm-cas-object-format --cas %t/cas --object-stats %t/statscsv.txt --ingest-schema=nestedv1 %t/csvtest.o
+RUN: cat %t/statscsv.txt | FileCheck %s -check-prefix=PRETTY
+
+RUN: llvm-cas-object-format --cas %t/cas --object-stats - --ingest-schema=nestedv1 %t/csvtest.o | FileCheck %s -check-prefix=PRETTY
+
+CSV: Kind, Count, Parents, Children, Data (B), Cost (B)
+CSV-NEXT: builtin:node, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}
+CSV-NEXT: builtin:tree, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}
+CSV-NEXT: cas.o:block, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}
+CSV-NEXT: cas.o:block-data, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}
+CSV-NEXT: cas.o:compile-unit, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}
+CSV-NEXT: cas.o:name, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}
+CSV-NEXT: cas.o:name-list, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}
+CSV-NEXT: cas.o:section, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}
+CSV-NEXT: cas.o:symbol, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}
+CSV-NEXT: cas.o:symbol-table, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}
+CSV-NEXT: cas.o:target-list, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}
+CSV-NEXT: TOTAL, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}
+
+CSV: num-section-names, {{[0-9]+}}
+CSV-NEXT: num-symbol-names, {{[0-9]+}}
+CSV-NEXT: num-anonymous-symbols, {{[0-9]+}}
+CSV-NEXT: num-template-symbols, {{[0-9]+}}
+CSV-NEXT: num-template-targets, {{[0-9]+}}
+CSV-NEXT: num-2-target-blocks, {{[0-9]+}}
+
+
+PRETTY:   => Note: 'Parents' counts incoming edges
+PRETTY-NEXT:   => Note: 'Children' counts outgoing edges (to sub-objects)
+PRETTY-NEXT:   => Note: HashSize = {{[0-9]+}}B
+PRETTY-NEXT:   => Note: PtrSize  = {{[0-9]+}}B
+PRETTY-NEXT:   => Note: Cost     = Count*HashSize + PtrSize*Children + Data
+PRETTY-NEXT: Kind                        Count            Parents           Children           Data (B)           Cost (B)
+PRETTY-NEXT: ====                        =====            =======           ========           ========           ========
+PRETTY: builtin:node                   {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%         {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%         {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%        {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%        {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%
+PRETTY-NEXT: builtin:tree                    {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%          {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%          {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%        {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%        {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%
+PRETTY-NEXT: cas.o:block                    {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%         {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%         {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%         {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%        {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%
+PRETTY-NEXT: cas.o:block-data               {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%         {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%          {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%       {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%       {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%
+PRETTY-NEXT: cas.o:compile-unit              {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%          {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%          {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%         {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%        {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%
+PRETTY-NEXT: cas.o:name                     {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%         {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%          {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%        {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%        {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%
+PRETTY-NEXT: cas.o:name-list                 {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%          {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%          {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%          {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%         {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%
+PRETTY-NEXT: cas.o:section                  {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%         {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%         {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%         {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%        {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%
+PRETTY-NEXT: cas.o:symbol                   {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%         {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%         {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%         {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%        {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%
+PRETTY-NEXT: cas.o:symbol-table              {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%          {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%         {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%          {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%        {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%
+PRETTY-NEXT: cas.o:target-list               {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%          {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%          {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%          {{[0-9]+}}   {{[0-9]+\.[0-9]+}}%         {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%
+PRETTY-NEXT: TOTAL                          {{[0-9]+}} {{[0-9]+\.[0-9]+}}%        {{[0-9]+}} {{[0-9]+\.[0-9]+}}%        {{[0-9]+}} {{[0-9]+\.[0-9]+}}%       {{[0-9]+}} {{[0-9]+\.[0-9]+}}%       {{[0-9]+}}  {{[0-9]+\.[0-9]+}}%
+
+PRETTY: num-section-names              {{[0-9]+}}
+PRETTY-NEXT: num-symbol-names                {{[0-9]+}}
+PRETTY-NEXT: num-anonymous-symbols          {{[0-9]+}}
+PRETTY-NEXT: num-template-symbols            {{[0-9]+}}
+PRETTY-NEXT: num-template-targets            {{[0-9]+}}
+PRETTY-NEXT: num-2-target-blocks             {{[0-9]+}}

--- a/llvm/test/tools/llvm-cas-object-format/glob.test
+++ b/llvm/test/tools/llvm-cas-object-format/glob.test
@@ -4,12 +4,12 @@ RUN: llc %S/Inputs/test.ll --filetype=obj -o %t/test.o
 
 RUN: llvm-cas-object-format --cas %t/cas %t/main.o %t/test.o --just-blobs -silent > %t/blob.id
 
-RUN: llvm-cas-object-format --cas %t/cas %t/main.o --object-stats | FileCheck %s --check-prefix=CHECK-ONE-CU
-RUN: llvm-cas-object-format --cas %t/cas --ingest-cas @%t/blob.id --cas-glob "**/main.o" --object-stats | FileCheck %s --check-prefix=CHECK-ONE-CU
+RUN: llvm-cas-object-format --cas %t/cas %t/main.o --object-stats - | FileCheck %s --check-prefix=CHECK-ONE-CU
+RUN: llvm-cas-object-format --cas %t/cas --ingest-cas @%t/blob.id --cas-glob "**/main.o" --object-stats - | FileCheck %s --check-prefix=CHECK-ONE-CU
 
 RUN: llvm-cas-object-format --cas %t/cas --ingest-cas @%t/blob.id -silent > %t/cas.id
-RUN: llvm-cas-object-format --cas %t/cas --analysis-only @%t/cas.id --object-stats | FileCheck %s --check-prefix=CHECK-TWO-CU
-RUN: llvm-cas-object-format --cas %t/cas --analysis-only @%t/cas.id --cas-glob "**/main.o" --object-stats | FileCheck %s --check-prefix=CHECK-ONE-CU
+RUN: llvm-cas-object-format --cas %t/cas --analysis-only @%t/cas.id --object-stats - | FileCheck %s --check-prefix=CHECK-TWO-CU
+RUN: llvm-cas-object-format --cas %t/cas --analysis-only @%t/cas.id --cas-glob "**/main.o" --object-stats - | FileCheck %s --check-prefix=CHECK-ONE-CU
 
 CHECK-ONE-CU: cas.o:compile-unit 1
 CHECK-TWO-CU: cas.o:compile-unit 2

--- a/llvm/test/tools/llvm-cas-object-format/input-kind.test
+++ b/llvm/test/tools/llvm-cas-object-format/input-kind.test
@@ -3,7 +3,7 @@ RUN: llc %S/Inputs/main.ll --filetype=obj -o %t/main.o
 
 RUN: llvm-cas-object-format --cas %t/cas %t/main.o --just-blobs -silent > %t/blob.id
 
-RUN: llvm-cas-object-format --cas %t/cas %t/main.o --object-stats > %t/output_1.txt
-RUN: llvm-cas-object-format --cas %t/cas --ingest-cas @%t/blob.id --object-stats > %t/output_2.txt
+RUN: llvm-cas-object-format --cas %t/cas %t/main.o --object-stats - > %t/output_1.txt
+RUN: llvm-cas-object-format --cas %t/cas --ingest-cas @%t/blob.id --object-stats - > %t/output_2.txt
 
 RUN: diff %t/output_1.txt %t/output_2.txt


### PR DESCRIPTION
Adrian and I want to be able to output the object stats into a csv format to be able to quickly generate graphs to measure improvements of the changes we make to llvm for the debug-info. I have added the command line option --object-stats-csv to output the object stats in a csv format.