### PR TITLE
Fixed crash in llvm-cas-object-format

### DIFF
--- a/llvm/lib/CAS/BuiltinCAS.cpp
+++ b/llvm/lib/CAS/BuiltinCAS.cpp
@@ -2704,7 +2704,7 @@ OnDiskCAS::getObjectProxy(IndexProxy I) const {
   SmallString<256> Path;
   getStandalonePath(Object.SK, I, Path);
   ErrorOr<std::unique_ptr<MemoryBuffer>> OwnedBuffer = MemoryBuffer::getFile(
-      Path, /*IsText=*/false, /*RequiresNullTerminator=*/false);
+      Path, /*IsText=*/false, /*RequiresNullTerminator=*/true);
   if (!OwnedBuffer)
     return createCorruptObjectError(getID(I));
 


### PR DESCRIPTION
When building a cas with all of llvm-project/llvm/lib object files, I consistently saw the object files MCDisassembler.cpp.o and  ControlHeightReduction.cpp.o hit a segmentation fault. 

The reason is that on line 2689 there is the code 

```
  auto createProxy = [&](MemoryBufferRef Buffer) -> ObjectProxy {
    assert(Buffer.getBuffer().drop_back(Blob0).end()[0] == 0 &&
           "Null termination");
```

This assumes that the Buffer will end with a null terminator, but the `OwnedBuffer`, from which `Buffer` is created has the `RequiresNullTerminator` boolean argument as false. This causes the code to get a segmentation fault: `Thread 2: EXC_BAD_ACCESS (code=1, address=0x101a9b000)` 

The patch just ensures that the `OwnedBuffer` always has a Null Terminator at the end.

