### PR TITLE
[c++-interop] Teach APINotes to handle DeclContexts that are extern "C"

### DIFF
--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -822,7 +822,8 @@ void Sema::ProcessAPINotes(Decl *D) {
     return;
 
   // Globals.
-  if (D->getDeclContext()->isFileContext()) {
+  if (D->getDeclContext()->isFileContext() ||
+      D->getDeclContext()->isExternCContext()) {
     // Global variables.
     if (auto VD = dyn_cast<VarDecl>(D)) {
       for (auto Reader : APINotes.findAPINotes(D->getLocation())) {


### PR DESCRIPTION
In order for APINotes to behave correctly in the presense of Swift's
C++-Interop, it needs to not assume the top-level DeclContext of a file
(ie isFileConext) is only either a TU-Decl or a Namespace: it can be a
LinkageSpecDecl (ie an extern "C").

This change simply allows for APINotes do follow its usual behavior if
the context of the Decl is within an extern "C".

A real world application of this is something like NSURLSession which
resides in a module.modulemap that has a leading `module Foundation [extern_c] {`
and because of this all of the types inside have a LinkageSpecDecl
context. When APINotes is unable to apply the mapping then a type like
NSURLSession misses it's mapping to URLSession and everything that may
refer to it in the module will fail to compile due to a missing type.