### PR TITLE
[lldb] Add SBType::IsAggregateType

### DIFF
--- a/lldb/bindings/interface/SBType.i
+++ b/lldb/bindings/interface/SBType.i
@@ -355,6 +355,18 @@ public:
     IsScopedEnumerationType ();
 
     %feature("docstring",
+    "Returns true if this type is an aggregate type.
+
+    Language-specific behaviour:
+
+    * C: Returns true for struct values, arrays, and vectors.
+    * C++: Same a C. Also includes class instances.
+    * Objective-C: Same as C. Also includes class instances.
+    ") IsAggregateType;
+    bool
+    IsAggregateType ();
+
+    %feature("docstring",
     "Returns a type that represents a pointer to this type.
 
     If the type system of the current language can't represent a pointer to this

--- a/lldb/include/lldb/API/SBType.h
+++ b/lldb/include/lldb/API/SBType.h
@@ -133,6 +133,8 @@ public:
 
   bool IsScopedEnumerationType();
 
+  bool IsAggregateType();
+
   lldb::SBType GetPointerType();
 
   lldb::SBType GetPointeeType();

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2627,6 +2627,8 @@ FileCheck output:
         err.write(type.GetName() + ":\n")
         err.write('\t' + "ByteSize        -> " +
                   str(type.GetByteSize()) + '\n')
+        err.write('\t' + "IsAggregateType   -> " +
+                  str(type.IsAggregateType()) + '\n')
         err.write('\t' + "IsPointerType   -> " +
                   str(type.IsPointerType()) + '\n')
         err.write('\t' + "IsReferenceType -> " +

--- a/lldb/source/API/SBType.cpp
+++ b/lldb/source/API/SBType.cpp
@@ -290,6 +290,14 @@ bool SBType::IsScopedEnumerationType() {
   return m_opaque_sp->GetCompilerType(true).IsScopedEnumerationType();
 }
 
+bool SBType::IsAggregateType() {
+  LLDB_INSTRUMENT_VA(this);
+
+  if (!IsValid())
+    return false;
+  return m_opaque_sp->GetCompilerType(true).IsAggregateType();
+}
+
 lldb::SBType SBType::GetFunctionReturnType() {
   LLDB_INSTRUMENT_VA(this);
 

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -66,6 +66,7 @@ class TypeAndTypeListTestCase(TestBase):
             self.assertTrue(type)
             self.DebugSBType(type)
             self.assertFalse(type.IsAnonymousType(), "Task is not anonymous")
+            self.assertTrue(type.IsAggregateType(), "Task is aggregate")
             for field in type.fields:
                 if field.name == "type":
                     for enum_member in field.type.enum_members:
@@ -75,10 +76,12 @@ class TypeAndTypeListTestCase(TestBase):
                     self.assertFalse(
                         field.type.IsAnonymousType(),
                         "my_type_is_nameless is not an anonymous type")
+                    self.assertTrue(field.type.IsAggregateType())
                 elif field.name == "my_type_is_named":
                     self.assertFalse(
                         field.type.IsAnonymousType(),
                         "my_type_is_named has a named type")
+                    self.assertTrue(field.type.IsAggregateType())
                 elif field.name == None:
                     self.assertTrue(
                         field.type.IsAnonymousType(),
@@ -111,6 +114,7 @@ class TypeAndTypeListTestCase(TestBase):
         task_head_type = task_head.GetType()
         self.DebugSBType(task_head_type)
         self.assertTrue(task_head_type.IsPointerType())
+        self.assertFalse(task_head_type.IsAggregateType())
 
         self.assertEqual(task_head_type, task_pointer_type)
 
@@ -125,6 +129,7 @@ class TypeAndTypeListTestCase(TestBase):
         self.DebugSBValue(id)
         id_type = id.GetType()
         self.DebugSBType(id_type)
+        self.assertFalse(id_type.IsAggregateType())
 
         # SBType.GetBasicType() takes an enum 'BasicType'
         # (lldb-enumerations.h).
@@ -138,6 +143,7 @@ class TypeAndTypeListTestCase(TestBase):
         myint_arr_type = myint_arr.GetType()
         self.DebugSBType(myint_arr_type)
         self.assertTrue(myint_arr_type.IsArrayType())
+        self.assertTrue(myint_arr_type.IsAggregateType())
         myint_arr_element_type = myint_arr_type.GetArrayElementType()
         self.DebugSBType(myint_arr_element_type)
         myint_type = target.FindFirstType('myint')
@@ -150,11 +156,13 @@ class TypeAndTypeListTestCase(TestBase):
             self.assertTrue(enum_type)
             self.DebugSBType(enum_type)
             self.assertFalse(enum_type.IsScopedEnumerationType())
+            self.assertFalse(enum_type.IsAggregateType())
 
             scoped_enum_type = target.FindFirstType('ScopedEnumType')
             self.assertTrue(scoped_enum_type)
             self.DebugSBType(scoped_enum_type)
             self.assertTrue(scoped_enum_type.IsScopedEnumerationType())
+            self.assertFalse(scoped_enum_type.IsAggregateType())
             int_scoped_enum_type = scoped_enum_type.GetEnumerationIntegerType()
             self.assertTrue(int_scoped_enum_type)
             self.DebugSBType(int_scoped_enum_type)


### PR DESCRIPTION
Add `IsAggregateType` to the SB API.

I'd like to use this from tests, and there are numerous other `Is<X>Type` predicates on `SBType`.

Differential Revision: https://reviews.llvm.org/D121252

(cherry picked from commit 704001e90b3d434c710ed178c95ae42961a7f7b0)