### PR TITLE
[lldb/Process] Silence toolchain mismatch warnings for Scripted Processes (NFC)

### DIFF
--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -5912,6 +5912,14 @@ void Process::PrintWarningCantLoadSwiftModule(const Module &module,
 }
 
 void Process::PrintWarningToolchainMismatch(const SymbolContext &sc) {
+  if (GetTarget().GetProcessLaunchInfo().IsScriptedProcess())
+    // It's very likely that the debugger used to launch the ScriptedProcess
+    // will not match the compiler version used to build the target, and we
+    // shouldn't need Swift's serialized AST to symbolicate the frame where we
+    // stopped. However, because this is called from a generic place
+    // (Thread::FrameSelectedCallback), it's safe to silence the warning for
+    // Scripted Processes.
+    return;
   if (!GetWarningsToolchainMismatch())
     return;
   if (!sc.module_sp || !sc.comp_unit)


### PR DESCRIPTION
When using Scripted Processes, it's very likely that lldb's version
might not align with the swift compiler that built the target.

Thus, this will cause the toolchain mismatch warnings to be shown to the
user every time they "stop" in a Swift frame.

Since we shouldn't need Swift's AST to symbolicate the stopped stackframe,
we can safely silence these warnings for Scripted Processes.

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>