### PR TITLE
Revert "Increase memory buffer for scanning objc classes on darwin systems

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -2026,8 +2026,7 @@ AppleObjCRuntimeV2::SharedCacheClassInfoExtractor::UpdateISAToDescriptorMap() {
       shared_cache_base_addr == LLDB_INVALID_ADDRESS)
     return DescriptorMapUpdateResult::Fail();
 
-  // The number of entries to pre-allocate room for.
-  const uint32_t max_num_classes = 256 * 1024;
+  const uint32_t num_classes = 128 * 1024;
 
   UtilityFunction *get_class_info_code = GetClassInfoUtilityFunction(exe_ctx);
   if (!get_class_info_code) {
@@ -2049,7 +2048,7 @@ AppleObjCRuntimeV2::SharedCacheClassInfoExtractor::UpdateISAToDescriptorMap() {
   DiagnosticManager diagnostics;
 
   const uint32_t class_info_byte_size = addr_size + 4;
-  const uint32_t class_infos_byte_size = max_num_classes * class_info_byte_size;
+  const uint32_t class_infos_byte_size = num_classes * class_info_byte_size;
   lldb::addr_t class_infos_addr = process->AllocateMemory(
       class_infos_byte_size, ePermissionsReadable | ePermissionsWritable, err);
   const uint32_t relative_selector_offset_addr_size = 64;
@@ -2115,12 +2114,10 @@ AppleObjCRuntimeV2::SharedCacheClassInfoExtractor::UpdateISAToDescriptorMap() {
       num_class_infos = return_value.GetScalar().ULong();
       LLDB_LOG(log, "Discovered {0} Objective-C classes in the shared cache",
                num_class_infos);
-      // Assert if there were more classes than we pre-allocated
-      // room for.
-      assert(num_class_infos <= max_num_classes);
+      assert(num_class_infos <= num_classes);
       if (num_class_infos > 0) {
-        if (num_class_infos > max_num_classes) {
-          num_class_infos = max_num_classes;
+        if (num_class_infos > num_classes) {
+          num_class_infos = num_classes;
 
           success = false;
         } else {


### PR DESCRIPTION
Revert "Increase memory buffer for scanning objc classes on darwin systems"

The buffer size increase is not strictly necessary in this release,
for the shared caches that it runs against, and in certain processes
which are near their jetsam limit, this larger buffer size can exceed
the allowable memory use, resulting in no shared cache objc classes
being read into lldb.

rdar://90261374

This reverts commit 944efd0dbf3a468b0ca723aa398a01a282d1bfb1.