### PR TITLE
Replace stack frame parameter with the more general process. (NFC)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -8085,7 +8085,7 @@ static void GetNameFromModule(swift::ModuleDecl *module, std::string &result) {
 
 static swift::ModuleDecl *LoadOneModule(const SourceModule &module,
                                         SwiftASTContext &swift_ast_context,
-                                        lldb::StackFrameWP &stack_frame_wp,
+                                        lldb::ProcessSP process_sp,
                                         Status &error) {
   LLDB_SCOPED_TIMER();
   if (!module.path.size())
@@ -8097,22 +8097,16 @@ static swift::ModuleDecl *LoadOneModule(const SourceModule &module,
   LOG_PRINTF(GetLog(LLDBLog::Types | LLDBLog::Expressions),
              "Importing module %s", toplevel.AsCString());
   swift::ModuleDecl *swift_module = nullptr;
-  lldb::StackFrameSP this_frame_sp(stack_frame_wp.lock());
-
   auto *clangimporter = swift_ast_context.GetClangImporter();
   swift::ModuleDecl *imported_header_module =
       clangimporter ? clangimporter->getImportedHeaderModule() : nullptr;
   if (imported_header_module &&
       toplevel.GetStringRef() == imported_header_module->getName().str())
     swift_module = imported_header_module;
-  else if (this_frame_sp) {
-    lldb::ProcessSP process_sp(this_frame_sp->CalculateProcess());
-    if (process_sp)
-      swift_module =
-          swift_ast_context.FindAndLoadModule(module, *process_sp.get(), error);
-    else
-      swift_module = swift_ast_context.GetModule(module, error);
-  } else
+  else if (process_sp)
+    swift_module =
+        swift_ast_context.FindAndLoadModule(module, *process_sp.get(), error);
+  else
     swift_module = swift_ast_context.GetModule(module, error);
 
   if (swift_module && IsDWARFImported(*swift_module)) {
@@ -8157,12 +8151,12 @@ static swift::ModuleDecl *LoadOneModule(const SourceModule &module,
 
 bool SwiftASTContext::GetImplicitImports(
     SwiftASTContext &swift_ast_context, SymbolContext &sc,
-    ExecutionContextScope &exe_scope, lldb::StackFrameWP &stack_frame_wp,
+    ExecutionContextScope &exe_scope, lldb::ProcessSP process_sp,
     llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
         &modules,
     Status &error) {
   LLDB_SCOPED_TIMER();
-  if (!swift_ast_context.GetCompileUnitImports(sc, stack_frame_wp, modules,
+  if (!swift_ast_context.GetCompileUnitImports(sc, process_sp, modules,
                                                error)) {
     return false;
   }
@@ -8187,7 +8181,7 @@ bool SwiftASTContext::GetImplicitImports(
     SourceModule module_info;
     module_info.path.emplace_back(module_pair.first());
     auto *module =
-        LoadOneModule(module_info, swift_ast_context, stack_frame_wp, error);
+        LoadOneModule(module_info, swift_ast_context, process_sp, error);
     if (!module)
       return false;
 
@@ -8200,7 +8194,7 @@ bool SwiftASTContext::GetImplicitImports(
 bool SwiftASTContext::CacheUserImports(SwiftASTContext &swift_ast_context,
                                        SymbolContext &sc,
                                        ExecutionContextScope &exe_scope,
-                                       lldb::StackFrameWP &stack_frame_wp,
+                                       lldb::ProcessSP process_sp,
                                        swift::SourceFile &source_file,
                                        Status &error) {
   llvm::SmallString<1> m_description;
@@ -8221,8 +8215,7 @@ bool SwiftASTContext::CacheUserImports(SwiftASTContext &swift_ast_context,
         LOG_PRINTF(GetLog(LLDBLog::Types | LLDBLog::Expressions),
                    "Performing auto import on found module: %s.\n",
                    module_name.c_str());
-        if (!LoadOneModule(module_info, swift_ast_context, stack_frame_wp,
-                           error))
+        if (!LoadOneModule(module_info, swift_ast_context, process_sp, error))
           return false;
 
         // How do we tell we are in REPL or playground mode?
@@ -8235,16 +8228,16 @@ bool SwiftASTContext::CacheUserImports(SwiftASTContext &swift_ast_context,
 }
 
 bool SwiftASTContext::GetCompileUnitImports(
-    SymbolContext &sc, lldb::StackFrameWP &stack_frame_wp,
+    SymbolContext &sc, ProcessSP process_sp,
     llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
         &modules,
     Status &error) {
-  return GetCompileUnitImportsImpl(sc, stack_frame_wp, &modules, error);
+  return GetCompileUnitImportsImpl(sc, process_sp, &modules, error);
 }
 
 void SwiftASTContext::PerformCompileUnitImports(
-    SymbolContext &sc, lldb::StackFrameWP &stack_frame_wp, Status &error) {
-  GetCompileUnitImportsImpl(sc, stack_frame_wp, nullptr, error);
+    SymbolContext &sc, lldb::ProcessSP process_sp, Status &error) {
+  GetCompileUnitImportsImpl(sc, process_sp, nullptr, error);
 }
 
 static std::pair<Module *, lldb::user_id_t>
@@ -8253,7 +8246,7 @@ GetCUSignature(CompileUnit &compile_unit) {
 }
 
 bool SwiftASTContext::GetCompileUnitImportsImpl(
-    SymbolContext &sc, lldb::StackFrameWP &stack_frame_wp,
+    SymbolContext &sc, lldb::ProcessSP process_sp,
     llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
         *modules,
     Status &error) {
@@ -8277,7 +8270,7 @@ bool SwiftASTContext::GetCompileUnitImportsImpl(
   SourceModule swift_module;
   swift_module.path.emplace_back("Swift");
   auto *stdlib =
-      LoadOneModule(swift_module, *this, stack_frame_wp, error);
+      LoadOneModule(swift_module, *this, process_sp, error);
   if (!stdlib)
     return false;
 
@@ -8298,7 +8291,7 @@ bool SwiftASTContext::GetCompileUnitImportsImpl(
       continue;
 
     auto *loaded_module =
-        LoadOneModule(module, *this, stack_frame_wp, error);
+        LoadOneModule(module, *this, process_sp, error);
     if (!loaded_module)
       return false;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -757,7 +757,7 @@ public:
   /// unit as well as any imports from previous expression evaluations.
   static bool GetImplicitImports(
       SwiftASTContext &swift_ast_context, SymbolContext &sc,
-      ExecutionContextScope &exe_scope, lldb::StackFrameWP &stack_frame_wp,
+      ExecutionContextScope &exe_scope, lldb::ProcessSP process_sp,
       llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
           &modules,
       Status &error);
@@ -767,25 +767,24 @@ public:
   static bool CacheUserImports(SwiftASTContext &swift_ast_context,
                                SymbolContext &sc,
                                ExecutionContextScope &exe_scope,
-                               lldb::StackFrameWP &stack_frame_wp,
+                               lldb::ProcessSP process_sp,
                                swift::SourceFile &source_file, Status &error);
 
   /// Retrieve/import the modules imported by the compilation
   /// unit. Early-exists with false if there was an import failure.
   bool GetCompileUnitImports(
-      SymbolContext &sc, lldb::StackFrameWP &stack_frame_wp,
+      SymbolContext &sc, lldb::ProcessSP process_sp,
       llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
           &modules,
       Status &error);
 
   /// Perform all the implicit imports for the current frame.
-  void PerformCompileUnitImports(SymbolContext &sc,
-                                 lldb::StackFrameWP &stack_frame_wp,
+  void PerformCompileUnitImports(SymbolContext &sc, lldb::ProcessSP process_sp,
                                  Status &error);
 
 protected:
   bool GetCompileUnitImportsImpl(
-      SymbolContext &sc, lldb::StackFrameWP &stack_frame_wp,
+      SymbolContext &sc, lldb::ProcessSP process_sp,
       llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
           *modules,
       Status &error);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1321,9 +1321,10 @@ TypeSystemSwiftTypeRefForExpressions::TypeSystemSwiftTypeRefForExpressions(
 void TypeSystemSwiftTypeRefForExpressions::PerformCompileUnitImports(
     SymbolContext &sc) {
   Status error;
-  lldb::StackFrameWP stack_frame;
+  // FIXME: this is uninitialized!
+  lldb::ProcessSP process_sp;
   if (m_swift_ast_context_initialized)
-    GetSwiftASTContext()->PerformCompileUnitImports(sc, stack_frame, error);
+    GetSwiftASTContext()->PerformCompileUnitImports(sc, process_sp, error);
   else
     m_initial_symbol_context = std::make_unique<SymbolContext>(sc);
 }
@@ -1382,9 +1383,10 @@ TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext() const {
 
   if (m_initial_symbol_context) {
     Status error;
-    lldb::StackFrameWP stack_frame;
+    // FIXME: not initialized!
+    lldb::ProcessSP process_sp;
     m_swift_ast_context->PerformCompileUnitImports(*m_initial_symbol_context,
-                                                   stack_frame, error);
+                                                   process_sp, error);
     m_initial_symbol_context.reset();
   }
 


### PR DESCRIPTION
This is a completely NFC refactoring to replace the stack frame weak
pointer passed through the LoadModule machinery with the less-specific
lldb::ProcessSP that is actually needed in the end.