### PR TITLE
Link swift compiler modules to lldb

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -151,6 +151,40 @@ function(add_lldb_library name)
   endif()
 endfunction(add_lldb_library)
 
+# BEGIN Swift Mods
+function(add_properties_for_swift_modules target)
+  if (BOOTSTRAPPING_MODE)
+    if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+      if(BOOTSTRAPPING_MODE MATCHES "HOSTTOOLS|.*HOSTLIBS")
+        target_link_directories(${target} PRIVATE
+            "${CMAKE_OSX_SYSROOT}/usr/lib/swift"
+            "${LLDB_SWIFT_LIBS}/macosx")
+        set_property(TARGET ${target} APPEND PROPERTY INSTALL_RPATH
+            "/usr/lib/swift")
+      elseif(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
+        target_link_directories(${target} PRIVATE "${LLDB_SWIFT_LIBS}/macosx")
+        set_property(TARGET ${target} APPEND PROPERTY INSTALL_RPATH
+            "${LLDB_SWIFT_LIBS}/macosx")
+      else()
+        message(FATAL_ERROR "Unknown BOOTSTRAPPING_MODE '${BOOTSTRAPPING_MODE}'")
+      endif()
+
+      # Workaround for a linker crash related to autolinking: rdar://77839981
+      set_property(TARGET ${target} APPEND_STRING PROPERTY
+                   LINK_FLAGS " -lobjc ")
+    elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
+      string(REGEX MATCH "^[^-]*" arch ${TARGET_TRIPLE})
+      target_link_libraries(${target} PRIVATE swiftCore-linux-${arch})
+  
+      # TODO: add "${LLDB_SWIFT_LIBS}/linux" to BUILD_RPATH and not INSTALL_RPATH.
+      # This does not work for some reason.
+      set_property(TARGET ${target} APPEND PROPERTY INSTALL_RPATH
+          "${LLDB_SWIFT_LIBS}/linux;$ORIGIN/../lib/swift/linux")
+    endif()
+  endif()
+endfunction()
+# END Swift Mods
+
 function(add_lldb_executable name)
   cmake_parse_arguments(ARG
     "GENERATE_INSTALL"

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -125,6 +125,10 @@ add_lldb_library(liblldb SHARED ${option_framework}
   ${option_install_prefix}
 )
 
+# BEGIN Swift Mods
+add_properties_for_swift_modules(liblldb)
+# END Swift Mods
+
 # lib/pythonX.Y/dist-packages/lldb/_lldb.so is a symlink to lib/liblldb.so,
 # which depends on lib/libLLVM*.so (BUILD_SHARED_LIBS) or lib/libLLVM-10git.so
 # (LLVM_LINK_LLVM_DYLIB). Add an additional rpath $ORIGIN/../../../../lib so

--- a/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
@@ -2,6 +2,10 @@ if(NOT LLDB_BUILT_STANDALONE)
   set(tablegen_deps intrinsics_gen)
 endif()
 
+if (NOT BOOTSTRAPPING_MODE)
+  add_library(swiftCompilerModules ALIAS swiftCompilerStub)
+endif()
+
 add_lldb_library(lldbPluginExpressionParserSwift PLUGIN
   SwiftASTManipulator.cpp
   SwiftExpressionParser.cpp

--- a/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
@@ -2,10 +2,6 @@ if(NOT LLDB_BUILT_STANDALONE)
   set(tablegen_deps intrinsics_gen)
 endif()
 
-if (NOT BOOTSTRAPPING_MODE)
-  add_library(swiftCompilerModules ALIAS swiftCompilerStub)
-endif()
-
 add_lldb_library(lldbPluginExpressionParserSwift PLUGIN
   SwiftASTManipulator.cpp
   SwiftExpressionParser.cpp
@@ -41,7 +37,6 @@ add_lldb_library(lldbPluginExpressionParserSwift PLUGIN
     swiftSIL
     swiftSILOptimizer
     swiftSerialization
-    swiftCompilerModules
     clangAST
     clangBasic
     clangRewrite
@@ -50,3 +45,13 @@ add_lldb_library(lldbPluginExpressionParserSwift PLUGIN
     Support
     Core
   )
+
+if(BOOTSTRAPPING_MODE)
+  target_link_libraries(lldbPluginExpressionParserSwift
+    PRIVATE
+      swiftCompilerModules)
+else()
+  target_link_libraries(lldbPluginExpressionParserSwift
+    PRIVATE
+      swiftCompilerStub)
+endif()

--- a/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
@@ -41,6 +41,7 @@ add_lldb_library(lldbPluginExpressionParserSwift PLUGIN
     swiftSIL
     swiftSILOptimizer
     swiftSerialization
+    swiftCompilerModules
     clangAST
     clangBasic
     clangRewrite

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -39,6 +39,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/InitializeSwiftModules.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "llvm/Support/ConvertUTF.h"
 
@@ -80,6 +81,8 @@ void SwiftLanguage::Initialize() {
   lldb_private::formatters::NSArray_Additionals::GetAdditionalSynthetics()
       .emplace(g_NSArrayClass1,
                lldb_private::formatters::swift::ArraySyntheticFrontEndCreator);
+
+  initializeSwiftModules();
 }
 
 void SwiftLanguage::Terminate() {

--- a/lldb/tools/lldb-test/CMakeLists.txt
+++ b/lldb/tools/lldb-test/CMakeLists.txt
@@ -23,6 +23,10 @@ add_lldb_tool(lldb-test
     Support
   )
 
+# BEGIN Swift Mods
+add_properties_for_swift_modules(lldb-test)
+# END Swift Mods
+
 if(Python3_RPATH)
   set_property(TARGET lldb-test APPEND PROPERTY INSTALL_RPATH "${Python3_RPATH}")
   set_property(TARGET lldb-test APPEND PROPERTY BUILD_RPATH   "${Python3_RPATH}")


### PR DESCRIPTION
This re-applies linking the swift compiler modules to lldb, but uses `target_link_libraries` instead of using `add_library` to create an alias. `target_link_libraries` doesn't care if the libraries exist until link time, `add_library` does. In a unified build, lldb is configured before Swift, so the target doesn't exist, which is why it was failing on Windows in the unified build.

rdar://90236027