### PR TITLE
CAS: Fix a too-narrow assertion in the OnDiskCAS

### DIFF
--- a/llvm/lib/CAS/BuiltinCAS.cpp
+++ b/llvm/lib/CAS/BuiltinCAS.cpp
@@ -2689,14 +2689,14 @@ OnDiskCAS::getObjectProxy(IndexProxy I) const {
   auto createProxy = [&](MemoryBufferRef Buffer) -> ObjectProxy {
     if (Blob) {
       assert(Buffer.getBuffer().drop_back(Blob0).end()[0] == 0 &&
-             "Null termination should be guaranteed by creation logic");
+             "Standalone blob missing null termination");
       return ObjectProxy{I.Offset, Object, I.Hash, None,
                          toArrayRef(Buffer.getBuffer().drop_back(Blob0))};
     }
 
     DataRecordHandle Record = DataRecordHandle::get(Buffer.getBuffer().data());
     assert(Record.getData().end()[0] == 0 &&
-           "Null termination should be guaranteed by creation logic");
+           "Standalone object record missing null termination for data");
     return ObjectProxy{I.Offset, Object, I.Hash, Record, None};
   };
 

--- a/llvm/lib/CAS/BuiltinCAS.cpp
+++ b/llvm/lib/CAS/BuiltinCAS.cpp
@@ -2687,13 +2687,17 @@ OnDiskCAS::getObjectProxy(IndexProxy I) const {
 
   // Helper for creating the return.
   auto createProxy = [&](MemoryBufferRef Buffer) -> ObjectProxy {
-    assert(Buffer.getBuffer().drop_back(Blob0).end()[0] == 0 &&
-           "Null termination");
-    if (Blob)
+    if (Blob) {
+      assert(Buffer.getBuffer().drop_back(Blob0).end()[0] == 0 &&
+             "Null termination should be guaranteed by creation logic");
       return ObjectProxy{I.Offset, Object, I.Hash, None,
                          toArrayRef(Buffer.getBuffer().drop_back(Blob0))};
-    return ObjectProxy{I.Offset, Object, I.Hash,
-                       DataRecordHandle::get(Buffer.getBuffer().data()), None};
+    }
+
+    DataRecordHandle Record = DataRecordHandle::get(Buffer.getBuffer().data());
+    assert(Record.getData().end()[0] == 0 &&
+           "Null termination should be guaranteed by creation logic");
+    return ObjectProxy{I.Offset, Object, I.Hash, Record, None};
   };
 
   // Check if we've loaded it already.
@@ -2701,6 +2705,10 @@ OnDiskCAS::getObjectProxy(IndexProxy I) const {
     return createProxy(*Buffer);
 
   // Load it from disk.
+  //
+  // Note: Creation logic guarantees that data that needs null-termination is
+  // suitably 0-padded. Requiring null-termination here would be too expensive
+  // for extremely large objects that happen to be page-aligned.
   SmallString<256> Path;
   getStandalonePath(Object.SK, I, Path);
   ErrorOr<std::unique_ptr<MemoryBuffer>> OwnedBuffer = MemoryBuffer::getFile(

--- a/llvm/unittests/CAS/CASDBTest.cpp
+++ b/llvm/unittests/CAS/CASDBTest.cpp
@@ -115,7 +115,7 @@ TEST_P(CASDBTest, BlobsBig) {
   // Specifically check near 1MB for objects large enough they're likely to be
   // stored externally in an on-disk CAS and will be near a page boundary.
   SmallString<0> Storage;
-  const size_t InterestingSize = 1024U * 1204ULL;
+  const size_t InterestingSize = 1024U * 1024ULL;
   const size_t SizeE = InterestingSize + 2;
   if (Storage.size() < SizeE)
     Storage.resize(SizeE, '\01');

--- a/llvm/unittests/CAS/CASDBTest.cpp
+++ b/llvm/unittests/CAS/CASDBTest.cpp
@@ -111,6 +111,21 @@ TEST_P(CASDBTest, BlobsBig) {
     ASSERT_EQ(ID1, ID2);
     String2.append(String1);
   }
+
+  // Specifically check near 1MB for objects large enough they're likely to be
+  // stored externally in an on-disk CAS and will be near a page boundary.
+  SmallString<0> Storage;
+  const size_t InterestingSize = 1024U * 1204ULL;
+  const size_t SizeE = InterestingSize + 2;
+  if (Storage.size() < SizeE)
+    Storage.resize(SizeE, '\01');
+  for (size_t Size = InterestingSize - 2; Size != SizeE; ++Size) {
+    StringRef Data(Storage.data(), Size);
+    Optional<BlobRef> Blob;
+    ASSERT_THAT_ERROR(CAS->createBlob(Data).moveInto(Blob), Succeeded());
+    ASSERT_EQ(Data, Blob->getData());
+    ASSERT_EQ(0, Blob->getData().end()[0]);
+  }
 }
 
 TEST_P(CASDBTest, Trees) {
@@ -237,6 +252,35 @@ TEST_P(CASDBTest, Trees) {
       ASSERT_THAT_ERROR(CAS->getTree(ID).moveInto(Tree), Succeeded());
       for (int I = 0, E = Entries.size(); I != E; ++I)
         EXPECT_EQ(Entries[I], Tree->get(I));
+    }
+  }
+}
+
+TEST_P(CASDBTest, NodesBig) {
+  std::unique_ptr<CASDB> CAS = createCAS();
+
+  // Specifically check near 1MB for objects large enough they're likely to be
+  // stored externally in an on-disk CAS, and such that one of them will be
+  // near a page boundary.
+  SmallString<0> Storage;
+  constexpr size_t InterestingSize = 1024U * 1024ULL;
+  constexpr size_t WordSize = sizeof(void *);
+
+  // Start much smaller to account for headers.
+  constexpr size_t SizeB = InterestingSize - 8 * WordSize;
+  constexpr size_t SizeE = InterestingSize + 1;
+  if (Storage.size() < SizeE)
+    Storage.resize(SizeE, '\01');
+
+  // Avoid checking every size because this is an expensive test. Just check
+  // for data that is 8B-word-aligned, and one less.
+  for (size_t Size = SizeB; Size < SizeE; Size += WordSize) {
+    for (bool IsAligned : {false, true}) {
+      StringRef Data(Storage.data(), Size - (IsAligned ? 0 : 1));
+      Optional<NodeRef> Node;
+      ASSERT_THAT_ERROR(CAS->createNode(None, Data).moveInto(Node), Succeeded());
+      ASSERT_EQ(Data, Node->getData());
+      ASSERT_EQ(0, Node->getData().end()[0]);
     }
   }
 }


### PR DESCRIPTION
Fix an assertion about null-termination in the OnDiskCAS that was too
narrow.

The assertion was checking that `MemoryBufferRef` was null-terminated.
This was the right check for the `TrieRecordData::Blob*` on-disk
formats, but not for `TrieRecordData::Standalone`. Non-blobs do not care
if the `mmap` itself is null-terminated, but do care if the "data"
section is null-terminated.

This splits the assertion in two.

The unit tests add tests for blobs (covering Blob and Blob0 formats) and
nodes (covering Standalone). Only the test for nodes was failing before
applying the fix.

This patch is instead of: https://github.com/apple/llvm-project/pull/4059