### PR TITLE
Use target_link_libraries not add_library

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
@@ -2,10 +2,6 @@ if(NOT LLDB_BUILT_STANDALONE)
   set(tablegen_deps intrinsics_gen)
 endif()
 
-if (NOT BOOTSTRAPPING_MODE)
-  add_library(swiftCompilerModules ALIAS swiftCompilerStub)
-endif()
-
 add_lldb_library(lldbPluginExpressionParserSwift PLUGIN
   SwiftASTManipulator.cpp
   SwiftExpressionParser.cpp
@@ -41,7 +37,6 @@ add_lldb_library(lldbPluginExpressionParserSwift PLUGIN
     swiftSIL
     swiftSILOptimizer
     swiftSerialization
-    swiftCompilerModules
     clangAST
     clangBasic
     clangRewrite
@@ -50,3 +45,13 @@ add_lldb_library(lldbPluginExpressionParserSwift PLUGIN
     Support
     Core
   )
+
+if(BOOTSTRAPPING_MODE)
+  target_link_libraries(lldbPluginExpressionParserSwift
+    PRIVATE
+      swiftCompilerModules)
+else()
+  target_link_libraries(lldbPluginExpressionParserSwift
+    PRIVATE
+      swiftCompilerStub)
+endif()


### PR DESCRIPTION
add_library verifies that the target exists, so if swift isn't being
built, or hasn't been configured yet, CMake complains.
target_link_libraries doesn't care about the target at configure time.
If the library doesn't exist come link-time, then we will see an error.