### PR TITLE
cache-compile-job: Hide CASOptions from the cache key

### DIFF
--- a/clang/include/clang/CAS/CASOptions.h
+++ b/clang/include/clang/CAS/CASOptions.h
@@ -67,9 +67,22 @@ public:
   /// Get a CAS defined by the options above. Future calls will return the same
   /// CAS instance... unless the configuration has changed, in which case a new
   /// one will be created.
+  ///
+  /// If \p CreateEmptyCASOnFailure, returns an empty in-memory CAS on failure.
+  /// Else, returns \c nullptr on failure.
   std::shared_ptr<llvm::cas::CASDB>
   getOrCreateCAS(DiagnosticsEngine &Diags,
                  bool CreateEmptyCASOnFailure = false) const;
+
+  /// Get a CAS defined by the options above. Future calls will return the same
+  /// CAS instance, even if the configuration changes again later.
+  ///
+  /// The configuration will be wiped out to prevent it being observable or
+  /// affecting the output of something that takes \a CASOptions as an input.
+  /// This also "locks in" the return value of \a getOrCreateCAS(): future
+  /// calls will not check if the configuration has changed.
+  std::shared_ptr<llvm::cas::CASDB>
+  getOrCreateCASAndHideConfig(DiagnosticsEngine &Diags);
 
 private:
   struct CachedCAS {
@@ -78,6 +91,9 @@ private:
 
     /// Remember how the CAS was created.
     CASConfiguration Config;
+
+    /// Check if the configuration has been frozen.
+    bool IsFrozen = false;
   };
   mutable CachedCAS Cache;
 };

--- a/clang/lib/CAS/CASOptions.cpp
+++ b/clang/lib/CAS/CASOptions.cpp
@@ -39,7 +39,7 @@ createCAS(const CASConfiguration &Config, DiagnosticsEngine &Diags,
 std::shared_ptr<llvm::cas::CASDB>
 CASOptions::getOrCreateCAS(DiagnosticsEngine &Diags,
                            bool CreateEmptyCASOnFailure) const {
-  if (Cache.IsFrozen)
+  if (Cache.Config.IsFrozen)
     return Cache.CAS;
 
   auto &CurrentConfig = static_cast<const CASConfiguration &>(*this);
@@ -53,7 +53,7 @@ CASOptions::getOrCreateCAS(DiagnosticsEngine &Diags,
 
 std::shared_ptr<llvm::cas::CASDB>
 CASOptions::getOrCreateCASAndHideConfig(DiagnosticsEngine &Diags) {
-  if (Cache.IsFrozen)
+  if (Cache.Config.IsFrozen)
     return Cache.CAS;
 
   std::shared_ptr<llvm::cas::CASDB> CAS = getOrCreateCAS(Diags);
@@ -64,8 +64,8 @@ CASOptions::getOrCreateCASAndHideConfig(DiagnosticsEngine &Diags) {
   // needs direct access to the CAS configuration will need to be
   // scheduled/executed at a level that has access to the configuration.
   auto &CurrentConfig = static_cast<CASConfiguration &>(*this);
-  Cache.IsFrozen = true;
   CurrentConfig = CASConfiguration();
+  CurrentConfig.IsFrozen = Cache.Config.IsFrozen = true;
 
   if (CAS) {
     // Set the CASPath to the hash schema, since that leaks through CASContext's

--- a/clang/test/CAS/fcache-compile-job.c
+++ b/clang/test/CAS/fcache-compile-job.c
@@ -23,5 +23,13 @@
 // RUN:   | FileCheck %s --check-prefix=CACHE-HIT
 // RUN: ls %t/output.o
 //
+// Check for a cache hit if the CAS moves:
+// RUN: mv %t/cas %t/cas.moved
+// RUN: %clang -cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fcas-path %t/cas.moved -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache-hit -emit-obj -o output.o 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CACHE-HIT
+// RUN: ls %t/output.o
+//
 // CACHE-HIT: remark: compile job cache hit
 // CACHE-MISS-NOT: remark: compile job cache hit

--- a/clang/unittests/CAS/CASOptionsTest.cpp
+++ b/clang/unittests/CAS/CASOptionsTest.cpp
@@ -43,6 +43,7 @@ TEST(CASOptionsTest, getOrCreateCAS) {
   std::shared_ptr<cas::CASDB> InMemory = Opts.getOrCreateCAS(Diags);
   ASSERT_TRUE(InMemory);
   EXPECT_EQ(InMemory, Opts.getOrCreateCAS(Diags));
+  EXPECT_EQ(CASOptions::InMemoryCAS, Opts.getKind());
 
   // Create an on-disk CAS.
   unittest::TempDir Dir("cas-options", /*Unique=*/true);
@@ -50,6 +51,7 @@ TEST(CASOptionsTest, getOrCreateCAS) {
   std::shared_ptr<cas::CASDB> OnDisk = Opts.getOrCreateCAS(Diags);
   EXPECT_NE(InMemory, OnDisk);
   EXPECT_EQ(OnDisk, Opts.getOrCreateCAS(Diags));
+  EXPECT_EQ(CASOptions::OnDiskCAS, Opts.getKind());
 
   // Create an on-disk CAS at an automatic location.
   Opts.CASPath = "auto";
@@ -57,6 +59,7 @@ TEST(CASOptionsTest, getOrCreateCAS) {
   EXPECT_NE(InMemory, OnDiskAuto);
   EXPECT_NE(OnDisk, OnDiskAuto);
   EXPECT_EQ(OnDiskAuto, Opts.getOrCreateCAS(Diags));
+  EXPECT_EQ(CASOptions::OnDiskCAS, Opts.getKind());
 
   // Create another in-memory CAS. It won't be the same one.
   Opts.CASPath = "";
@@ -65,6 +68,7 @@ TEST(CASOptionsTest, getOrCreateCAS) {
   EXPECT_NE(OnDisk, InMemory2);
   EXPECT_NE(OnDiskAuto, InMemory2);
   EXPECT_EQ(InMemory2, Opts.getOrCreateCAS(Diags));
+  EXPECT_EQ(CASOptions::InMemoryCAS, Opts.getKind());
 }
 
 TEST(CASOptionsTest, getOrCreateCASInvalid) {
@@ -103,6 +107,7 @@ TEST(CASOptionsTest, getOrCreateCASAndHideConfig) {
   Opts.CASPath = Dir.path("cas").str().str();
   std::shared_ptr<cas::CASDB> CAS = Opts.getOrCreateCASAndHideConfig(Diags);
   ASSERT_TRUE(CAS);
+  EXPECT_EQ(CASOptions::UnknownCAS, Opts.getKind());
 
   // Check that the configuration is hidden, but calls to getOrCreateCAS()
   // still return the original CAS.
@@ -111,10 +116,15 @@ TEST(CASOptionsTest, getOrCreateCASAndHideConfig) {
   // Check that new paths are ignored.
   Opts.CASPath = "";
   EXPECT_EQ(CAS, Opts.getOrCreateCAS(Diags));
+  EXPECT_EQ(CASOptions::UnknownCAS, Opts.getKind());
   EXPECT_EQ(CAS, Opts.getOrCreateCASAndHideConfig(Diags));
+  EXPECT_EQ(CASOptions::UnknownCAS, Opts.getKind());
+
   Opts.CASPath = Dir.path("ignored-cas").str().str();
   EXPECT_EQ(CAS, Opts.getOrCreateCAS(Diags));
+  EXPECT_EQ(CASOptions::UnknownCAS, Opts.getKind());
   EXPECT_EQ(CAS, Opts.getOrCreateCASAndHideConfig(Diags));
+  EXPECT_EQ(CASOptions::UnknownCAS, Opts.getKind());
 }
 
 } // end namespace

--- a/clang/unittests/CAS/CASOptionsTest.cpp
+++ b/clang/unittests/CAS/CASOptionsTest.cpp
@@ -1,0 +1,120 @@
+//===- CASOptionsTest.cpp -------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/CAS/CASOptions.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/DiagnosticIDs.h"
+#include "clang/Basic/DiagnosticOptions.h"
+#include "llvm/CAS/CASDB.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Testing/Support/Error.h"
+#include "llvm/Testing/Support/SupportHelpers.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace clang;
+
+namespace {
+
+TEST(CASOptionsTest, getKind) {
+  CASOptions Opts;
+  EXPECT_EQ(CASOptions::InMemoryCAS, Opts.getKind());
+
+  Opts.CASPath = "auto";
+  unittest::TempDir Dir("cas-options", /*Unique=*/true);
+  EXPECT_EQ(CASOptions::OnDiskCAS, Opts.getKind());
+
+  Opts.CASPath = Dir.path("cas").str().str();
+  EXPECT_EQ(CASOptions::OnDiskCAS, Opts.getKind());
+}
+
+TEST(CASOptionsTest, getOrCreateCAS) {
+  DiagnosticsEngine Diags(new DiagnosticIDs(), new DiagnosticOptions,
+                          new IgnoringDiagConsumer());
+
+  // Create an in-memory CAS.
+  CASOptions Opts;
+  std::shared_ptr<cas::CASDB> InMemory = Opts.getOrCreateCAS(Diags);
+  ASSERT_TRUE(InMemory);
+  EXPECT_EQ(InMemory, Opts.getOrCreateCAS(Diags));
+
+  // Create an on-disk CAS.
+  unittest::TempDir Dir("cas-options", /*Unique=*/true);
+  Opts.CASPath = Dir.path("cas").str().str();
+  std::shared_ptr<cas::CASDB> OnDisk = Opts.getOrCreateCAS(Diags);
+  EXPECT_NE(InMemory, OnDisk);
+  EXPECT_EQ(OnDisk, Opts.getOrCreateCAS(Diags));
+
+  // Create an on-disk CAS at an automatic location.
+  Opts.CASPath = "auto";
+  std::shared_ptr<cas::CASDB> OnDiskAuto = Opts.getOrCreateCAS(Diags);
+  EXPECT_NE(InMemory, OnDiskAuto);
+  EXPECT_NE(OnDisk, OnDiskAuto);
+  EXPECT_EQ(OnDiskAuto, Opts.getOrCreateCAS(Diags));
+
+  // Create another in-memory CAS. It won't be the same one.
+  Opts.CASPath = "";
+  std::shared_ptr<cas::CASDB> InMemory2 = Opts.getOrCreateCAS(Diags);
+  EXPECT_NE(InMemory, InMemory2);
+  EXPECT_NE(OnDisk, InMemory2);
+  EXPECT_NE(OnDiskAuto, InMemory2);
+  EXPECT_EQ(InMemory2, Opts.getOrCreateCAS(Diags));
+}
+
+TEST(CASOptionsTest, getOrCreateCASInvalid) {
+  DiagnosticsEngine Diags(new DiagnosticIDs(), new DiagnosticOptions,
+                          new IgnoringDiagConsumer());
+
+  // Create a file, then try to put a CAS there.
+  StringRef Contents = "contents";
+  unittest::TempDir Dir("cas-options", /*Unique=*/true);
+  unittest::TempFile File(Dir.path("cas"), /*Suffix=*/"",
+                          /*Contents=*/Contents);
+
+  CASOptions Opts;
+  Opts.CASPath = File.path().str();
+  EXPECT_EQ(nullptr, Opts.getOrCreateCAS(Diags));
+
+  std::shared_ptr<cas::CASDB> Empty =
+      Opts.getOrCreateCAS(Diags, /*CreateEmptyCASOnFailure=*/true);
+  EXPECT_EQ(Empty, Opts.getOrCreateCAS(Diags));
+
+  // Ensure the file wasn't clobbered.
+  std::unique_ptr<MemoryBuffer> MemBuffer;
+  ASSERT_THAT_ERROR(
+      errorOrToExpected(MemoryBuffer::getFile(File.path())).moveInto(MemBuffer),
+      Succeeded());
+  ASSERT_EQ(Contents, MemBuffer->getBuffer());
+}
+
+TEST(CASOptionsTest, getOrCreateCASAndHideConfig) {
+  DiagnosticsEngine Diags(new DiagnosticIDs(), new DiagnosticOptions,
+                          new IgnoringDiagConsumer());
+
+  // Hide the CAS configuration when creating it.
+  unittest::TempDir Dir("cas-options", /*Unique=*/true);
+  CASOptions Opts;
+  Opts.CASPath = Dir.path("cas").str().str();
+  std::shared_ptr<cas::CASDB> CAS = Opts.getOrCreateCASAndHideConfig(Diags);
+  ASSERT_TRUE(CAS);
+
+  // Check that the configuration is hidden, but calls to getOrCreateCAS()
+  // still return the original CAS.
+  EXPECT_EQ(CAS->getHashSchemaIdentifier(), Opts.CASPath);
+
+  // Check that new paths are ignored.
+  Opts.CASPath = "";
+  EXPECT_EQ(CAS, Opts.getOrCreateCAS(Diags));
+  EXPECT_EQ(CAS, Opts.getOrCreateCASAndHideConfig(Diags));
+  Opts.CASPath = Dir.path("ignored-cas").str().str();
+  EXPECT_EQ(CAS, Opts.getOrCreateCAS(Diags));
+  EXPECT_EQ(CAS, Opts.getOrCreateCASAndHideConfig(Diags));
+}
+
+} // end namespace

--- a/clang/unittests/CAS/CMakeLists.txt
+++ b/clang/unittests/CAS/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  CAS
+  )
+
+add_clang_unittest(ClangCASTests
+  CASOptionsTest.cpp
+  )
+
+clang_target_link_libraries(ClangCASTests
+  PRIVATE
+  clangBasic
+  clangCAS
+  )
+
+target_link_libraries(ClangCASTests
+  PRIVATE
+  LLVMTestingSupport
+)

--- a/clang/unittests/CMakeLists.txt
+++ b/clang/unittests/CMakeLists.txt
@@ -19,6 +19,7 @@ function(add_clang_unittest test_dirname)
 endfunction()
 
 add_subdirectory(Basic)
+add_subdirectory(CAS)
 add_subdirectory(Lex)
 add_subdirectory(Driver)
 if(CLANG_ENABLE_STATIC_ANALYZER)


### PR DESCRIPTION
Hide the CAS configuration when hashing the `-cc1` command-line for
`-fexperimental-cache=compile-job`.

- The configuration is permanently hidden to prevent outputs (such as
  diagnostics) from depending on it. Logic that needs the configuration
  needs to run at a higher level where this is still available, or take
  the configuration in a side channel.
- The CASPath is not deleted, but replaced with a placeholder: the hash
  schema identifier for the CAS. This is leaked by the `CASDB` API and
  can affect output.
- The CAS returned by `getOrCreateCAS()` is frozen so that future calls
  return the same CAS (whether the placeholder is there, or it's wiped
  out/replaced).
- When the action cache is split out, it should similarly be frozen.
  Maybe we want `CASOptions` to have another parent class,
  `ActionCacheConfiguration`, which is frozen separately... or maybe
  `getOrCreate...()` should create both at the same time, at least when
  hiding the configuration. t.b.d.