### PR TITLE
[lldb/swift] Add swift type-system progress reporting

### DIFF
--- a/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
+++ b/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
@@ -20974,6 +20974,133 @@ SWIGINTERN PyObject *SBData_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *a
   return SWIG_Python_InitShadowInstance(args);
 }
 
+SWIGINTERN PyObject *_wrap_SBDebugger_GetProgressFromEvent(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  lldb::SBEvent *arg1 = 0 ;
+  uint64_t *arg2 = 0 ;
+  uint64_t *arg3 = 0 ;
+  uint64_t *arg4 = 0 ;
+  bool *arg5 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  uint64_t temp2 ;
+  int res2 = SWIG_TMPOBJ ;
+  uint64_t temp3 ;
+  int res3 = SWIG_TMPOBJ ;
+  uint64_t temp4 ;
+  int res4 = SWIG_TMPOBJ ;
+  bool temp5 ;
+  int res5 = SWIG_TMPOBJ ;
+  PyObject *swig_obj[1] ;
+  char *result = 0 ;
+  
+  arg2 = &temp2;
+  arg3 = &temp3;
+  arg4 = &temp4;
+  arg5 = &temp5;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1, SWIGTYPE_p_lldb__SBEvent,  0  | 0);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SBDebugger_GetProgressFromEvent" "', argument " "1"" of type '" "lldb::SBEvent const &""'"); 
+  }
+  if (!argp1) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "SBDebugger_GetProgressFromEvent" "', argument " "1"" of type '" "lldb::SBEvent const &""'"); 
+  }
+  arg1 = reinterpret_cast< lldb::SBEvent * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (char *)lldb::SBDebugger::GetProgressFromEvent((lldb::SBEvent const &)*arg1,*arg2,*arg3,*arg4,*arg5);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_FromCharPtr((const char *)result);
+  if (SWIG_IsTmpObj(res2)) {
+    resultobj = SWIG_Python_AppendOutput(resultobj, SWIG_From_unsigned_SS_long_SS_long((*arg2)));
+  } else {
+    int new_flags = SWIG_IsNewObj(res2) ? (SWIG_POINTER_OWN |  0 ) :  0 ;
+    resultobj = SWIG_Python_AppendOutput(resultobj, SWIG_NewPointerObj((void*)(arg2), SWIGTYPE_p_unsigned_long_long, new_flags));
+  }
+  if (SWIG_IsTmpObj(res3)) {
+    resultobj = SWIG_Python_AppendOutput(resultobj, SWIG_From_unsigned_SS_long_SS_long((*arg3)));
+  } else {
+    int new_flags = SWIG_IsNewObj(res3) ? (SWIG_POINTER_OWN |  0 ) :  0 ;
+    resultobj = SWIG_Python_AppendOutput(resultobj, SWIG_NewPointerObj((void*)(arg3), SWIGTYPE_p_unsigned_long_long, new_flags));
+  }
+  if (SWIG_IsTmpObj(res4)) {
+    resultobj = SWIG_Python_AppendOutput(resultobj, SWIG_From_unsigned_SS_long_SS_long((*arg4)));
+  } else {
+    int new_flags = SWIG_IsNewObj(res4) ? (SWIG_POINTER_OWN |  0 ) :  0 ;
+    resultobj = SWIG_Python_AppendOutput(resultobj, SWIG_NewPointerObj((void*)(arg4), SWIGTYPE_p_unsigned_long_long, new_flags));
+  }
+  if (SWIG_IsTmpObj(res5)) {
+    resultobj = SWIG_Python_AppendOutput(resultobj, SWIG_From_bool((*arg5)));
+  } else {
+    int new_flags = SWIG_IsNewObj(res5) ? (SWIG_POINTER_OWN |  0 ) :  0 ;
+    resultobj = SWIG_Python_AppendOutput(resultobj, SWIG_NewPointerObj((void*)(arg5), SWIGTYPE_p_bool, new_flags));
+  }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_SBDebugger_GetDiagnosticFromEvent(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  lldb::SBEvent *arg1 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  lldb::SBStructuredData result;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1, SWIGTYPE_p_lldb__SBEvent,  0  | 0);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SBDebugger_GetDiagnosticFromEvent" "', argument " "1"" of type '" "lldb::SBEvent const &""'"); 
+  }
+  if (!argp1) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "SBDebugger_GetDiagnosticFromEvent" "', argument " "1"" of type '" "lldb::SBEvent const &""'"); 
+  }
+  arg1 = reinterpret_cast< lldb::SBEvent * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = lldb::SBDebugger::GetDiagnosticFromEvent((lldb::SBEvent const &)*arg1);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new lldb::SBStructuredData(static_cast< const lldb::SBStructuredData& >(result))), SWIGTYPE_p_lldb__SBStructuredData, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_SBDebugger_GetBroadcaster(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  lldb::SBDebugger *arg1 = (lldb::SBDebugger *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  lldb::SBBroadcaster result;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_lldb__SBDebugger, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SBDebugger_GetBroadcaster" "', argument " "1"" of type '" "lldb::SBDebugger *""'"); 
+  }
+  arg1 = reinterpret_cast< lldb::SBDebugger * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (arg1)->GetBroadcaster();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new lldb::SBBroadcaster(static_cast< const lldb::SBBroadcaster& >(result))), SWIGTYPE_p_lldb__SBBroadcaster, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_SBDebugger_Initialize(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   
@@ -68306,6 +68433,33 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_SBType_IsAggregateType(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  lldb::SBType *arg1 = (lldb::SBType *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  bool result;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_lldb__SBType, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SBType_IsAggregateType" "', argument " "1"" of type '" "lldb::SBType *""'"); 
+  }
+  arg1 = reinterpret_cast< lldb::SBType * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (bool)(arg1)->IsAggregateType();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_SBType_GetPointerType(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   lldb::SBType *arg1 = (lldb::SBType *) 0 ;
@@ -82116,6 +82270,9 @@ static PyMethodDef SwigMethods[] = {
 	 { "SBData___str__", _wrap_SBData___str__, METH_O, "SBData___str__(SBData self) -> std::string"},
 	 { "SBData_swigregister", SBData_swigregister, METH_O, NULL},
 	 { "SBData_swiginit", SBData_swiginit, METH_VARARGS, NULL},
+	 { "SBDebugger_GetProgressFromEvent", _wrap_SBDebugger_GetProgressFromEvent, METH_O, "SBDebugger_GetProgressFromEvent(SBEvent event) -> char const *"},
+	 { "SBDebugger_GetDiagnosticFromEvent", _wrap_SBDebugger_GetDiagnosticFromEvent, METH_O, "SBDebugger_GetDiagnosticFromEvent(SBEvent event) -> SBStructuredData"},
+	 { "SBDebugger_GetBroadcaster", _wrap_SBDebugger_GetBroadcaster, METH_O, "SBDebugger_GetBroadcaster(SBDebugger self) -> SBBroadcaster"},
 	 { "SBDebugger_Initialize", _wrap_SBDebugger_Initialize, METH_NOARGS, "SBDebugger_Initialize()"},
 	 { "SBDebugger_InitializeWithErrorHandling", _wrap_SBDebugger_InitializeWithErrorHandling, METH_NOARGS, "SBDebugger_InitializeWithErrorHandling() -> SBError"},
 	 { "SBDebugger_Terminate", _wrap_SBDebugger_Terminate, METH_NOARGS, "SBDebugger_Terminate()"},
@@ -84934,6 +85091,17 @@ static PyMethodDef SwigMethods[] = {
 		"    * C: Returns false for all types.\n"
 		"    * C++: Return true only for C++11 scoped enums.\n"
 		"    * Objective-C: Returns false for all types.\n"
+		"\n"
+		""},
+	 { "SBType_IsAggregateType", _wrap_SBType_IsAggregateType, METH_O, "\n"
+		"SBType_IsAggregateType(SBType self) -> bool\n"
+		"Returns true if this type is an aggregate type.\n"
+		"\n"
+		"    Language-specific behaviour:\n"
+		"\n"
+		"    * C: Returns true for struct values, arrays, and vectors.\n"
+		"    * C++: Same a C. Also includes class instances.\n"
+		"    * Objective-C: Same as C. Also includes class instances.\n"
 		"\n"
 		""},
 	 { "SBType_GetPointerType", _wrap_SBType_GetPointerType, METH_O, "\n"
@@ -88390,6 +88558,9 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "SBCommunication_eBroadcastBitReadThreadShouldExit",SWIG_From_int(static_cast< int >(lldb::SBCommunication::eBroadcastBitReadThreadShouldExit)));
   SWIG_Python_SetConstant(d, "SBCommunication_eBroadcastBitPacketAvailable",SWIG_From_int(static_cast< int >(lldb::SBCommunication::eBroadcastBitPacketAvailable)));
   SWIG_Python_SetConstant(d, "SBCommunication_eAllEventBits",SWIG_From_int(static_cast< int >(lldb::SBCommunication::eAllEventBits)));
+  SWIG_Python_SetConstant(d, "SBDebugger_eBroadcastBitProgress",SWIG_From_int(static_cast< int >(lldb::SBDebugger::eBroadcastBitProgress)));
+  SWIG_Python_SetConstant(d, "SBDebugger_eBroadcastBitWarning",SWIG_From_int(static_cast< int >(lldb::SBDebugger::eBroadcastBitWarning)));
+  SWIG_Python_SetConstant(d, "SBDebugger_eBroadcastBitError",SWIG_From_int(static_cast< int >(lldb::SBDebugger::eBroadcastBitError)));
   SWIG_Python_SetConstant(d, "SBProcess_eBroadcastBitStateChanged",SWIG_From_int(static_cast< int >(lldb::SBProcess::eBroadcastBitStateChanged)));
   SWIG_Python_SetConstant(d, "SBProcess_eBroadcastBitInterrupt",SWIG_From_int(static_cast< int >(lldb::SBProcess::eBroadcastBitInterrupt)));
   SWIG_Python_SetConstant(d, "SBProcess_eBroadcastBitSTDOUT",SWIG_From_int(static_cast< int >(lldb::SBProcess::eBroadcastBitSTDOUT)));

--- a/lldb/bindings/python/static-binding/lldb.py
+++ b/lldb/bindings/python/static-binding/lldb.py
@@ -4159,6 +4159,26 @@ class SBDebugger(object):
 
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr
+    eBroadcastBitProgress = _lldb.SBDebugger_eBroadcastBitProgress
+    
+    eBroadcastBitWarning = _lldb.SBDebugger_eBroadcastBitWarning
+    
+    eBroadcastBitError = _lldb.SBDebugger_eBroadcastBitError
+    
+
+    @staticmethod
+    def GetProgressFromEvent(event):
+        r"""GetProgressFromEvent(SBEvent event) -> char const *"""
+        return _lldb.SBDebugger_GetProgressFromEvent(event)
+
+    @staticmethod
+    def GetDiagnosticFromEvent(event):
+        r"""GetDiagnosticFromEvent(SBEvent event) -> SBStructuredData"""
+        return _lldb.SBDebugger_GetDiagnosticFromEvent(event)
+
+    def GetBroadcaster(self):
+        r"""GetBroadcaster(SBDebugger self) -> SBBroadcaster"""
+        return _lldb.SBDebugger_GetBroadcaster(self)
 
     @staticmethod
     def Initialize():
@@ -4660,6 +4680,14 @@ class SBDebugger(object):
 
 # Register SBDebugger in _lldb:
 _lldb.SBDebugger_swigregister(SBDebugger)
+
+def SBDebugger_GetProgressFromEvent(event):
+    r"""SBDebugger_GetProgressFromEvent(SBEvent event) -> char const *"""
+    return _lldb.SBDebugger_GetProgressFromEvent(event)
+
+def SBDebugger_GetDiagnosticFromEvent(event):
+    r"""SBDebugger_GetDiagnosticFromEvent(SBEvent event) -> SBStructuredData"""
+    return _lldb.SBDebugger_GetDiagnosticFromEvent(event)
 
 def SBDebugger_Initialize():
     r"""SBDebugger_Initialize()"""
@@ -12336,6 +12364,20 @@ class SBType(object):
 
         """
         return _lldb.SBType_IsScopedEnumerationType(self)
+
+    def IsAggregateType(self):
+        r"""
+        IsAggregateType(SBType self) -> bool
+        Returns true if this type is an aggregate type.
+
+            Language-specific behaviour:
+
+            * C: Returns true for struct values, arrays, and vectors.
+            * C++: Same a C. Also includes class instances.
+            * Objective-C: Same as C. Also includes class instances.
+
+        """
+        return _lldb.SBType_IsAggregateType(self)
 
     def GetPointerType(self):
         r"""

--- a/lldb/packages/Python/lldbsuite/test/eventlistener.py
+++ b/lldb/packages/Python/lldbsuite/test/eventlistener.py
@@ -1,0 +1,72 @@
+import threading
+
+import lldb
+from lldbsuite.test.lldbtest import *
+
+class EventListenerTestBase(TestBase):
+
+    """
+    Base class for lldb event listener tests.
+
+    This class will setup and start an event listener for the test to use.
+
+    If the event received matches the source broadcaster, the event is
+    queued up in a list that the user can access later on.
+    """
+    NO_DEBUG_INFO_TESTCASE = True
+
+    eBroadcastBitStopListenerThread = (1 << 0)
+    events = []
+    event_mask = None
+    event_data_extractor = None
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+        self.src_broadcaster = self.dbg.GetBroadcaster()
+        self.broadcaster = lldb.SBBroadcaster('lldb.test.broadcaster')
+        self.listener = lldb.SBListener("lldb.test.listener")
+        self.listener.StartListeningForEvents(self.broadcaster,
+                                              self.eBroadcastBitStopListenerThread)
+
+        self.src_broadcaster.AddListener(self.listener, self.event_mask)
+
+        self.listener_thread = threading.Thread(target=self._fetch_events)
+        self.listener_thread.start()
+
+    def tearDown(self):
+        # Broadcast a eBroadcastBitStopListenerThread` event so the background
+        # thread stops listening to events, then join the background thread.
+        self.broadcaster.BroadcastEventByType(self.eBroadcastBitStopListenerThread)
+        self.listener_thread.join()
+        TestBase.tearDown(self)
+
+    def _fetch_events(self):
+        event = lldb.SBEvent()
+
+        done = False
+        while not done:
+            if self.listener.GetNextEvent(event):
+                event_mask = event.GetType();
+                if event.BroadcasterMatchesRef(self.broadcaster):
+                    if event_mask & self.eBroadcastBitStopListenerThread:
+                        done = True;
+                elif event.BroadcasterMatchesRef(self.src_broadcaster):
+                    # NOTE: https://wiki.python.org/moin/FromFunctionToMethod
+                    #
+                    # When assigning the `event_data_extractor` function pointer
+                    # to the `EventListenerTestBase` instance, it turns the
+                    # function object into an instance method which subsequently
+                    # passes `self` as an extra argument.
+
+                    # However, because most of the event data extractor
+                    # functions are static, passing the `self` argument makes
+                    # the number of passed arguments exceeds the function definition
+
+                    # This is why we unwrap the function from the instance
+                    # method object calling `__func__` instead.
+                    ret_args = self.event_data_extractor.__func__(event);
+                    if not ret_args:
+                        continue
+
+                    self.events.append(ret_args)

--- a/lldb/test/API/functionalities/diagnostic_reporting/TestDiagnosticReporting.py
+++ b/lldb/test/API/functionalities/diagnostic_reporting/TestDiagnosticReporting.py
@@ -2,51 +2,20 @@
 Test that we are able to broadcast and receive diagnostic events from lldb
 """
 import lldb
-from lldbsuite.test.lldbtest import *
-from lldbsuite.test.decorators import *
+
 import lldbsuite.test.lldbutil as lldbutil
-import threading
 
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.eventlistener import EventListenerTestBase
 
-class TestDiagnosticReporting(TestBase):
+class TestDiagnosticReporting(EventListenerTestBase):
 
     mydir = TestBase.compute_mydir(__file__)
-
-    eBroadcastBitStopDiagnosticThread = (1 << 0)
-
-    def setUp(self):
-        TestBase.setUp(self)
-        self.diagnostic_events = []
-
-    def fetch_events(self):
-        event = lldb.SBEvent()
-
-        done = False
-        while not done:
-            if self.listener.WaitForEvent(1, event):
-                event_mask = event.GetType()
-                if event.BroadcasterMatchesRef(self.test_broadcaster):
-                    if event_mask & self.eBroadcastBitStopDiagnosticThread:
-                        done = True
-                elif event.BroadcasterMatchesRef(self.diagnostic_broadcaster):
-                    self.diagnostic_events.append(
-                        lldb.SBDebugger.GetDiagnosticFromEvent(event))
+    event_mask = lldb.SBDebugger.eBroadcastBitWarning | lldb.SBDebugger.eBroadcastBitError
+    event_data_extractor = lldb.SBDebugger.GetDiagnosticFromEvent
 
     def test_dwarf_symbol_loading_diagnostic_report(self):
         """Test that we are able to fetch diagnostic events"""
-        self.listener = lldb.SBListener("lldb.diagnostic.listener")
-        self.test_broadcaster = lldb.SBBroadcaster('lldb.broadcaster.test')
-        self.listener.StartListeningForEvents(
-            self.test_broadcaster, self.eBroadcastBitStopDiagnosticThread)
-
-        self.diagnostic_broadcaster = self.dbg.GetBroadcaster()
-        self.diagnostic_broadcaster.AddListener(
-            self.listener, lldb.SBDebugger.eBroadcastBitWarning)
-        self.diagnostic_broadcaster.AddListener(
-            self.listener, lldb.SBDebugger.eBroadcastBitError)
-
-        listener_thread = threading.Thread(target=self.fetch_events)
-        listener_thread.start()
 
         self.yaml2obj("minidump.yaml", self.getBuildArtifact("minidump.core"))
 
@@ -55,13 +24,9 @@ class TestDiagnosticReporting(TestBase):
         self.process = self.target.LoadCore(
             self.getBuildArtifact("minidump.core"))
 
-        self.test_broadcaster.BroadcastEventByType(
-            self.eBroadcastBitStopDiagnosticThread)
-        listener_thread.join()
+        self.assertEquals(len(self.events), 1)
 
-        self.assertEquals(len(self.diagnostic_events), 1)
-
-        diagnostic_event = self.diagnostic_events[0]
+        diagnostic_event = self.events[0]
         self.assertEquals(
             diagnostic_event.GetValueForKey("type").GetStringValue(100),
             "warning")

--- a/lldb/test/API/functionalities/progress_reporting/TestProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/TestProgressReporting.py
@@ -2,57 +2,22 @@
 Test that we are able to broadcast and receive progress events from lldb
 """
 import lldb
-from lldbsuite.test.lldbtest import *
-from lldbsuite.test.decorators import *
-import lldbsuite.test.lldbutil as lldbutil
-import threading
 
-class TestProgressReporting(TestBase):
+import lldbsuite.test.lldbutil as lldbutil
+
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.eventlistener import EventListenerTestBase
+
+
+class TestProgressReporting(EventListenerTestBase):
 
     mydir = TestBase.compute_mydir(__file__)
-
-    eBroadcastBitStopProgressThread = (1 << 0)
-
-    def setUp(self):
-        TestBase.setUp(self)
-        self.progress_events = []
-
-    def fetch_events(self):
-        event = lldb.SBEvent()
-
-        done = False
-        while not done:
-            if self.listener.WaitForEvent(1, event):
-                event_mask = event.GetType();
-                if event.BroadcasterMatchesRef(self.test_broadcaster):
-                    if event_mask & self.eBroadcastBitStopProgressThread:
-                        done = True;
-                elif event.BroadcasterMatchesRef(self.progress_broadcaster):
-                    ret_args = lldb.SBDebugger().GetProgressFromEvent(event);
-                    self.assertGreater(len(ret_args), 1)
-
-                    message = ret_args[0]
-                    if message:
-                        self.progress_events.append((message, event))
+    event_mask = lldb.SBDebugger.eBroadcastBitProgress
+    event_data_extractor = lldb.SBDebugger.GetProgressFromEvent
 
     def test_dwarf_symbol_loading_progress_report(self):
         """Test that we are able to fetch dwarf symbol loading progress events"""
         self.build()
 
-        self.listener = lldb.SBListener("lldb.progress.listener")
-        self.test_broadcaster = lldb.SBBroadcaster('lldb.broadcaster.test')
-        self.listener.StartListeningForEvents(self.test_broadcaster,
-                                              self.eBroadcastBitStopProgressThread)
-
-        self.progress_broadcaster = self.dbg.GetBroadcaster()
-        self.progress_broadcaster.AddListener(self.listener, lldb.SBDebugger.eBroadcastBitProgress)
-
-        listener_thread = threading.Thread(target=self.fetch_events)
-        listener_thread.start()
-
         lldbutil.run_to_source_breakpoint(self, 'break here', lldb.SBFileSpec('main.c'))
-
-        self.test_broadcaster.BroadcastEventByType(self.eBroadcastBitStopProgressThread)
-        listener_thread.join()
-
-        self.assertGreater(len(self.progress_events), 0)
+        self.assertGreater(len(self.events), 0)

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/Invisible.swift
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/Invisible.swift
@@ -1,0 +1,1 @@
+public struct 👻 { public init() { print("boooooo!") } }

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/Makefile
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/Makefile
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/Makefile
@@ -1,3 +1,14 @@
 SWIFT_SOURCES := main.swift
 
+LD_EXTRAS := -L. -linvisible
+SWIFTFLAGS_EXTRAS := -I.
+
+all: libinvisible.dylib $(EXE)
+
 include Makefile.rules
+
+libinvisible.dylib: Invisible.swift
+	$(MAKE) -f $(MAKEFILE_RULES) \
+		MAKE_DSYM=YES DYLIB_ONLY=YES DYLIB_NAME=Invisible \
+		DYLIB_SWIFT_SOURCES="Invisible.swift" \
+		SWIFTFLAGS_EXTRAS=-I$(BUILDDIR)

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -16,6 +16,7 @@ class TestSwiftProgressReporting(EventListenerTestBase):
     event_data_extractor = lldb.SBDebugger.GetProgressFromEvent
 
     @swiftTest
+    @skipIf(oslist=no_match(["macosx"]))
     def test_swift_progress_report(self):
         """Test that we are able to fetch swift type-system progress events"""
         self.build()
@@ -28,7 +29,7 @@ class TestSwiftProgressReporting(EventListenerTestBase):
         self.assertTrue(frame, "Invalid frame.")
 
         # Resolve variable to exercise the type-system
-        self.runCmd("expr numbers")
+        self.runCmd("expr boo")
 
         self.assertGreater(len(self.events), 0)
 

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -1,0 +1,43 @@
+"""
+Test that we are able to broadcast and receive swift progress events from lldb
+"""
+import lldb
+
+import lldbsuite.test.lldbutil as lldbutil
+
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test.eventlistener import EventListenerTestBase
+
+class TestSwiftProgressReporting(EventListenerTestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+    event_mask = lldb.SBDebugger.eBroadcastBitProgress
+    event_data_extractor = lldb.SBDebugger.GetProgressFromEvent
+
+    @swiftTest
+    def test_swift_progress_report(self):
+        """Test that we are able to fetch swift type-system progress events"""
+        self.build()
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(self, 'break here',
+                                          lldb.SBFileSpec('main.swift'))
+
+        self.assertGreater(thread.GetNumFrames(), 0)
+        frame = thread.GetSelectedFrame()
+        self.assertTrue(frame, "Invalid frame.")
+
+        # Resolve variable to exercise the type-system
+        self.runCmd("expr numbers")
+
+        self.assertGreater(len(self.events), 0)
+
+        beacons = [ "Loading Swift module",
+                    "Caching Swift user imports from",
+                    "Setting up Swift reflection for",
+                    "Getting Swift compile unit imports for"]
+
+        for beacon in beacons:
+            filtered_events = list(filter(lambda event: beacon in event[0],
+                                          self.events))
+            self.assertGreater(len(filtered_events), 0)

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/main.swift
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/main.swift
@@ -1,0 +1,49 @@
+struct IntPair {
+  var original: Int
+  var opposite: Int
+
+  init(_ value: Int) {
+    self.original = value
+    self.opposite = -value
+  }
+}
+
+enum Toggle { case On; case Off }
+
+enum ColorCode {
+  case RGB(UInt8, UInt8, UInt8)
+  case Hex(Int)
+}
+
+protocol Flyable {
+  var fly : String { get }
+}
+
+struct Bird: Flyable {
+  var fly: String = "🦅"
+}
+
+struct Plane: Flyable {
+  var fly: String = "🛩"
+}
+
+class Number<T:Numeric> {
+  var number_value : T
+
+  init (number value : T) {
+    number_value = value
+  }
+}
+
+func main() {
+  let structArray = [ IntPair(1), IntPair(-2), IntPair(3) ]
+  var enumArray = [ Toggle.Off ]
+  var colors = [ColorCode.RGB(155,219,255), ColorCode.Hex(0x4545ff)]
+  var flyingObjects : [Flyable] = [ Bird(), Plane() ]
+  let numbers = [ Number(number: 42), Number(number: 3.14)]
+  let bytes = [UInt8](0...255)
+  var bits : [UInt8] = [0,1]
+  print("break here")
+}
+
+main()

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/main.swift
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/main.swift
@@ -1,48 +1,7 @@
-struct IntPair {
-  var original: Int
-  var opposite: Int
-
-  init(_ value: Int) {
-    self.original = value
-    self.opposite = -value
-  }
-}
-
-enum Toggle { case On; case Off }
-
-enum ColorCode {
-  case RGB(UInt8, UInt8, UInt8)
-  case Hex(Int)
-}
-
-protocol Flyable {
-  var fly : String { get }
-}
-
-struct Bird: Flyable {
-  var fly: String = "🦅"
-}
-
-struct Plane: Flyable {
-  var fly: String = "🛩"
-}
-
-class Number<T:Numeric> {
-  var number_value : T
-
-  init (number value : T) {
-    number_value = value
-  }
-}
+import Invisible
 
 func main() {
-  let structArray = [ IntPair(1), IntPair(-2), IntPair(3) ]
-  var enumArray = [ Toggle.Off ]
-  var colors = [ColorCode.RGB(155,219,255), ColorCode.Hex(0x4545ff)]
-  var flyingObjects : [Flyable] = [ Bird(), Plane() ]
-  let numbers = [ Number(number: 42), Number(number: 3.14)]
-  let bytes = [UInt8](0...255)
-  var bits : [UInt8] = [0,1]
+  let boo = Invisible.👻()
   print("break here")
 }
 


### PR DESCRIPTION
This patch reports progress events specific to the swift type-system.

Currently, it covers 3 long-running operations:
- Setting up the runtime reflection context
- Loading implicit modules from the compile unit
- Caching them in the expression persistent state

It also includes a test a will listen for swift progress events and make
sure it we receive them when fetching a swift variable.

rdar://75803015

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>