### PR TITLE
[lldb] Fix ^C handling in IOHandlerProcessSTDIO

### DIFF
--- a/lldb/lldb/test/API/iohandler/sigint/Makefile
+++ b/lldb/lldb/test/API/iohandler/sigint/Makefile
@@ -1,0 +1,1 @@
+include Makefile.rules

--- a/lldb/lldb/test/API/iohandler/sigint/TestProcessIOHandlerInterrupt.py
+++ b/lldb/lldb/test/API/iohandler/sigint/TestProcessIOHandlerInterrupt.py
@@ -1,0 +1,42 @@
+"""
+Test sending SIGINT Process IOHandler
+"""
+
+import os
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.lldbpexpect import PExpectTest
+
+class TestCase(PExpectTest):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def test(self):
+        self.build(dictionary={"CXX_SOURCES":"cat.cpp"})
+        self.launch(executable=self.getBuildArtifact(), timeout=5)
+
+        self.child.sendline("process launch")
+        self.child.expect("Process .* launched")
+
+        self.child.sendline("Hello cat")
+        self.child.expect_exact("read: Hello cat")
+
+        self.child.sendintr()
+        self.child.expect("Process .* stopped")
+        self.expect_prompt()
+
+        self.expect("bt", substrs=["input_copy_loop"])
+
+        self.child.sendline("continue")
+        self.child.expect("Process .* resuming")
+
+        self.child.sendline("Goodbye cat")
+        self.child.expect_exact("read: Goodbye cat")
+
+        self.child.sendeof()
+        self.child.expect("Process .* exited")
+        self.expect_prompt()
+
+        self.quit()

--- a/lldb/lldb/test/API/iohandler/sigint/cat.cpp
+++ b/lldb/lldb/test/API/iohandler/sigint/cat.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+
+void input_copy_loop() {
+  std::string str;
+  while (std::getline(std::cin, str))
+    std::cout << "read: " << str << std::endl;
+}
+
+int main() {
+  input_copy_loop();
+  return 0;
+}


### PR DESCRIPTION
D120762 accidentally moved the interrupt check into the block which was
reading stdio. This meant that a ^C only took effect after a regular
character has been pressed.

This patch fixes that and adds a (pexpect) test.

Differential revision: https://reviews.llvm.org/D121912

(cherry picked from commit f93d861349f923f6b7ca1a425d3632eec1ff2a72)
