### PR TITLE
[lldb] Minor log format change in BindGenericTypeParameters (NFC)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2037,7 +2037,7 @@ SwiftLanguageRuntimeImpl::BindGenericTypeParameters(StackFrame &stack_frame,
     return ts.GetTypeFromMangledTypename(mangled_name);
   }
   CompilerType bound_type =  scratch_ctx->RemangleAsType(dem, node);
-  LLDB_LOG(GetLog(LLDBLog::Expressions | LLDBLog::Types), "Bound {0} -> {1}.",
+  LLDB_LOG(GetLog(LLDBLog::Expressions | LLDBLog::Types), "Bound {0} -> {1}",
            mangled_name, bound_type.GetMangledTypeName());
   return bound_type;
 }


### PR DESCRIPTION
Remove the period from this log message. This is a minor change that produces cleaner results when running log output through `swift demangle`. Otherwise, the demangler treats `"."` as a suffix node.