### PR TITLE
[c++-interop] Teach APINotes to handle DeclContexts that are extern "C"

### DIFF
--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -821,7 +821,8 @@ void Sema::ProcessAPINotes(Decl *D) {
     return;
 
   // Globals.
-  if (D->getDeclContext()->isFileContext()) {
+  if (D->getDeclContext()->isFileContext() ||
+      D->getDeclContext()->isExternCContext()) {
     // Global variables.
     if (auto VD = dyn_cast<VarDecl>(D)) {
       for (auto Reader : APINotes.findAPINotes(D->getLocation())) {

--- a/clang/test/APINotes/Inputs/Frameworks/CXXInteropKit.framework/Headers/CXXInteropKit.apinotes
+++ b/clang/test/APINotes/Inputs/Frameworks/CXXInteropKit.framework/Headers/CXXInteropKit.apinotes
@@ -1,0 +1,5 @@
+---
+Name: CxxInterop
+Classes:
+- Name: NSSomeClass
+  SwiftName: SomeClass

--- a/clang/test/APINotes/Inputs/Frameworks/CXXInteropKit.framework/Headers/CXXInteropKit.h
+++ b/clang/test/APINotes/Inputs/Frameworks/CXXInteropKit.framework/Headers/CXXInteropKit.h
@@ -1,0 +1,3 @@
+@interface NSSomeClass
+  -(instancetype)init;
+@end

--- a/clang/test/APINotes/Inputs/Frameworks/CXXInteropKit.framework/Modules/module.modulemap
+++ b/clang/test/APINotes/Inputs/Frameworks/CXXInteropKit.framework/Modules/module.modulemap
@@ -1,0 +1,5 @@
+framework module CxxInteropKit [extern_c] {
+  umbrella header "CxxInteropKit.h"
+  export *
+  module * { export * }
+}

--- a/clang/test/APINotes/objcxx-swift-name.m
+++ b/clang/test/APINotes/objcxx-swift-name.m
@@ -1,0 +1,9 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/CxxInterop -fdisable-module-hash -fapinotes-modules -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -x objective-c++
+// RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/CxxInterop -fdisable-module-hash -fapinotes-modules -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter SomeClass -x objective-c++ | FileCheck %s
+
+#import <CxxInteropKit/CxxInteropKit.h>
+
+// CHECK: Dumping NSSomeClass:
+// CHECK-NEXT: ObjCInterfaceDecl {{.+}} imported in CxxInteropKit <undeserialized declarations> NSSomeClass
+// CHECK-NEXT: SwiftNameAttr {{.+}} <<invalid sloc>> "SomeClass"


### PR DESCRIPTION
In order for APINotes to behave correctly in the presense of Swift's
C++-Interop, it needs to not assume the top-level DeclContext of a file (ie
isFileConext) is only either a TU-Decl or a Namespace: it can be a
LinkageSpecDecl (ie an extern "C").

This change simply allows for APINotes do follow its usual behavior if the
context of the Decl is within an extern "C".

A real world application of this is something like NSURLSession which resides
in a module.modulemap that has a leading `module Foundation [extern_c] {` and
because of this all of the types inside have a LinkageSpecDecl context. When
APINotes is unable to apply the mapping then a type like NSURLSession misses
it's mapping to URLSession and everything that may refer to it in the module
will fail to compile due to a missing type.

(cherry picked from commit 56e3a3b2b66f75489131bf45b92b681cf7f3be5a)