### PR TITLE
[stable/20211026][Support] Add const to `FileError::getFileName`

### DIFF
--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -1283,7 +1283,7 @@ public:
     return OS.str();
   }
 
-  StringRef getFileName() { return FileName; }
+  StringRef getFileName() const { return FileName; }
 
   Error takeError() { return Error(std::move(Err)); }
 


### PR DESCRIPTION
`getFileName` returns a `StringRef`, there's no reason it shouldn't be
const.

Differential Revision: https://reviews.llvm.org/D121495