### PR TITLE
[lldb] Fix TestProcessIOHandlerInterrupt.py for macos

### DIFF
--- a/lldb/test/API/iohandler/sigint/cat.cpp
+++ b/lldb/test/API/iohandler/sigint/cat.cpp
@@ -1,9 +1,25 @@
-#include <iostream>
+#include <cstdio>
+#include <string>
+#include <unistd.h>
+
+std::string getline() {
+  std::string result;
+  while (true) {
+    int r;
+    char c;
+    do
+      r = read(fileno(stdin), &c, 1);
+    while (r == -1 && errno == EINTR);
+    if (r <= 0 || c == '\n')
+      return result;
+    result += c;
+  }
+}
 
 void input_copy_loop() {
   std::string str;
-  while (std::getline(std::cin, str))
-    std::cout << "read: " << str << std::endl;
+  while (str = getline(), !str.empty())
+    printf("read: %s\n", str.c_str());
 }
 
 int main() {


### PR DESCRIPTION
On darwin, we don't completely suppress the signal used to interrupt the
inferior. The underlying read syscall returns EINTR, which causes premature
termination of the input loop.

Work around that by hand-rolling an EINTR-resistant version of getline.

(cherry picked from commit a4d6de2031ad2f92d399fc8d1b1301229ed8255b)
