### PR TITLE
[DepScan] -fdepscan driver support with new phase

### DIFF
--- a/clang/include/clang/Driver/Action.h
+++ b/clang/include/clang/Driver/Action.h
@@ -408,6 +408,12 @@ public:
   static bool classof(const Action *A) {
     return A->getKind() == DepscanJobClass;
   }
+
+  const JobAction &getScanningJobAction() const { return *JA; }
+  void setScanningJobAction(const JobAction *Job) { JA = Job; }
+
+private:
+  const JobAction *JA;
 };
 
 class PreprocessJobAction : public JobAction {

--- a/clang/include/clang/Driver/Action.h
+++ b/clang/include/clang/Driver/Action.h
@@ -56,6 +56,7 @@ public:
     InputClass = 0,
     BindArchClass,
     OffloadClass,
+    DepscanJobClass,
     PreprocessJobClass,
     PrecompileJobClass,
     HeaderModulePrecompileJobClass,
@@ -77,7 +78,7 @@ public:
     LinkerWrapperJobClass,
     StaticLibJobClass,
 
-    JobClassFirst = PreprocessJobClass,
+    JobClassFirst = DepscanJobClass,
     JobClassLast = StaticLibJobClass
   };
 
@@ -395,6 +396,17 @@ public:
   static bool classof(const Action *A) {
     return (A->getKind() >= JobClassFirst &&
             A->getKind() <= JobClassLast);
+  }
+};
+
+class DepscanJobAction : public JobAction {
+  void anchor() override;
+
+public:
+  DepscanJobAction(Action *Input, types::ID OutputType);
+
+  static bool classof(const Action *A) {
+    return A->getKind() == DepscanJobClass;
   }
 };
 

--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -225,11 +225,6 @@ public:
   typedef int (*CC1ToolFunc)(SmallVectorImpl<const char *> &ArgV);
   CC1ToolFunc CC1Main = nullptr;
 
-  typedef void (*CC1ScanDepsFunc)(
-      const llvm::opt::Arg &, const char *, SmallVectorImpl<const char *> &, const Driver &,
-      const llvm::opt::ArgList &Args);
-  CC1ScanDepsFunc CC1ScanDeps = nullptr;
-
 private:
   /// Raw target triple.
   std::string TargetTriple;

--- a/clang/include/clang/Driver/Phases.h
+++ b/clang/include/clang/Driver/Phases.h
@@ -15,6 +15,7 @@ namespace phases {
   /// ID - Ordered values for successive stages in the
   /// compilation process which interact with user options.
   enum ID {
+    Depscan,
     Preprocess,
     Precompile,
     Compile,

--- a/clang/include/clang/Driver/Types.def
+++ b/clang/include/clang/Driver/Types.def
@@ -104,4 +104,4 @@ TYPE("api-information",          API_INFO,     INVALID,         "json",   phases
 TYPE("none",                     Nothing,      INVALID,         nullptr,  phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 
 // Generic command line type, used to pass command as response file to the next action.
-TYPE("command",                  CMD,          INVALID,         "cmd",    phases::Depscan)
+TYPE("response-file",            ResponseFile, INVALID,         "rsp",    phases::Depscan)

--- a/clang/include/clang/Driver/Types.def
+++ b/clang/include/clang/Driver/Types.def
@@ -102,3 +102,6 @@ TYPE("cuda-fatbin",              CUDA_FATBIN,  INVALID,         "fatbin", phases
 TYPE("hip-fatbin",               HIP_FATBIN,   INVALID,         "hipfb",  phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("api-information",          API_INFO,     INVALID,         "json",   phases::Precompile)
 TYPE("none",                     Nothing,      INVALID,         nullptr,  phases::Compile, phases::Backend, phases::Assemble, phases::Link)
+
+// Generic command line type, used to pass command as response file to the next action.
+TYPE("command",                  CMD,          INVALID,         "cmd",    phases::Depscan)

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -23,6 +23,7 @@ const char *Action::getClassName(ActionClass AC) {
   case BindArchClass: return "bind-arch";
   case OffloadClass:
     return "offload";
+  case DepscanJobClass: return "depscan";
   case PreprocessJobClass: return "preprocessor";
   case PrecompileJobClass: return "precompiler";
   case HeaderModulePrecompileJobClass: return "header-module-precompiler";
@@ -317,6 +318,11 @@ JobAction::JobAction(ActionClass Kind, Action *Input, types::ID Type)
 
 JobAction::JobAction(ActionClass Kind, const ActionList &Inputs, types::ID Type)
     : Action(Kind, Inputs, Type) {}
+
+void DepscanJobAction::anchor() {}
+
+DepscanJobAction::DepscanJobAction(Action *Input, types::ID OutputType)
+    : JobAction(DepscanJobClass, Input, OutputType) {}
 
 void PreprocessJobAction::anchor() {}
 

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -322,7 +322,7 @@ JobAction::JobAction(ActionClass Kind, const ActionList &Inputs, types::ID Type)
 void DepscanJobAction::anchor() {}
 
 DepscanJobAction::DepscanJobAction(Action *Input, types::ID OutputType)
-    : JobAction(DepscanJobClass, Input, OutputType) {}
+    : JobAction(DepscanJobClass, Input, OutputType), JA(this) {}
 
 void PreprocessJobAction::anchor() {}
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4199,7 +4199,7 @@ Action *Driver::ConstructPhaseAction(
   case phases::IfsMerge:
     llvm_unreachable("ifsmerge action invalid here.");
   case phases::Depscan:
-    return C.MakeAction<DepscanJobAction>(Input, types::TY_CMD);
+    return C.MakeAction<DepscanJobAction>(Input, types::TY_ResponseFile);
   case phases::Preprocess: {
     types::ID OutputTy;
     // -M and -MM specify the dependency file name by altering the output type,

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4383,17 +4383,19 @@ void Driver::BuildJobs(Compilation &C) const {
                        /*TargetDeviceOffloadKind*/ Action::OFK_None);
   }
 
+  // DepScan introduces a new DepScan binding that cannot be merged so it will
+  // end up having 2 jobs instead of 1 but we still should run the command
+  // in-process if possible.
+  bool ShouldInProcessDepScan =
+      C.getJobs().size() == 2 &&
+      isa<DepscanJobAction>(C.getJobs().begin()->getSource());
+
   // If we have more than one job, then disable integrated-cc1 for now. Do this
   // also when we need to report process execution statistics.
-  if (C.getJobs().size() > 1 || CCPrintProcessStats) {
-    // DepScan introduces a new DepScan binding that cannot be merged so it will
-    // end up having 2 jobs instead of 1 but we still should run the command
-    // in-process if possible.
-    if (C.getJobs().size() != 2 ||
-        !isa<DepscanJobAction>(C.getJobs().begin()->getSource())) {
-      for (auto &J : C.getJobs())
-        J.InProcess = false;
-    }
+  if ((C.getJobs().size() > 1 && !ShouldInProcessDepScan) ||
+      CCPrintProcessStats) {
+    for (auto &J : C.getJobs())
+      J.InProcess = false;
   }
 
   if (CCPrintProcessStats) {
@@ -4744,6 +4746,14 @@ class ToolSelector final {
     Inputs = NewInputs;
   }
 
+  void combineWithDepscan(const Tool *T, const JobAction *Current,
+                          ActionList &Inputs) {
+    for (Action *A : Inputs) {
+      if (auto *DepScan = dyn_cast<DepscanJobAction>(A))
+        DepScan->setScanningJobAction(Current);
+    }
+  }
+
 public:
   ToolSelector(const JobAction *BaseAction, const ToolChain &TC,
                const Compilation &C, bool SaveTemps, bool EmbedBitcode)
@@ -4800,6 +4810,8 @@ public:
     }
 
     combineWithPreprocessor(T, Inputs, CollapsedOffloadAction);
+
+    combineWithDepscan(T, BaseAction, Inputs);
     return T;
   }
 };

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3906,6 +3906,13 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
       if (OffloadBuilder.addHostDependenceToDeviceActions(Current, InputArg))
         break;
 
+    // FIXME: To avoid globally adding the depscan phase to all the input types,
+    // we try to inject depscan phase here if the first phase is preprocess and
+    // -fdepscan is used.
+    if (PL.front() == phases::Preprocess &&
+        Args.hasArg(options::OPT_fdepscan_EQ))
+      PL.insert(PL.begin(), phases::Depscan);
+
     for (phases::ID Phase : PL) {
 
       // Add any offload action the host action depends on.
@@ -4191,6 +4198,8 @@ Action *Driver::ConstructPhaseAction(
     llvm_unreachable("link action invalid here.");
   case phases::IfsMerge:
     llvm_unreachable("ifsmerge action invalid here.");
+  case phases::Depscan:
+    return C.MakeAction<DepscanJobAction>(Input, types::TY_CMD);
   case phases::Preprocess: {
     types::ID OutputTy;
     // -M and -MM specify the dependency file name by altering the output type,
@@ -4199,7 +4208,12 @@ Action *Driver::ConstructPhaseAction(
         !Args.hasArg(options::OPT_MD, options::OPT_MMD)) {
       OutputTy = types::TY_Dependencies;
     } else {
-      OutputTy = Input->getType();
+      // If the previous is action is depscan, bypass the output kind from
+      // depscan.
+      if (Input->getKind() == AssembleJobAction::DepscanJobClass)
+        OutputTy = Input->getInputs().front()->getType();
+      else
+        OutputTy = Input->getType();
       if (!Args.hasFlag(options::OPT_frewrite_includes,
                         options::OPT_fno_rewrite_includes, false) &&
           !Args.hasFlag(options::OPT_frewrite_imports,
@@ -4371,9 +4385,16 @@ void Driver::BuildJobs(Compilation &C) const {
 
   // If we have more than one job, then disable integrated-cc1 for now. Do this
   // also when we need to report process execution statistics.
-  if (C.getJobs().size() > 1 || CCPrintProcessStats)
-    for (auto &J : C.getJobs())
-      J.InProcess = false;
+  if (C.getJobs().size() > 1 || CCPrintProcessStats) {
+    // DepScan introduces a new DepScan binding that cannot be merged so it will
+    // end up having 2 jobs instead of 1 but we still should run the command
+    // in-process if possible.
+    if (C.getJobs().size() != 2 ||
+        !isa<DepscanJobAction>(C.getJobs().begin()->getSource())) {
+      for (auto &J : C.getJobs())
+        J.InProcess = false;
+    }
+  }
 
   if (CCPrintProcessStats) {
     C.setPostCallback([=](const Command &Cmd, int Res) {

--- a/clang/lib/Driver/Phases.cpp
+++ b/clang/lib/Driver/Phases.cpp
@@ -14,6 +14,7 @@ using namespace clang::driver;
 
 const char *phases::getPhaseName(ID Id) {
   switch (Id) {
+  case Depscan: return "depscan";
   case Preprocess: return "preprocessor";
   case Precompile: return "precompiler";
   case Compile: return "compiler";

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -358,6 +358,7 @@ Tool *ToolChain::getTool(Action::ActionClass AC) const {
   case Action::CompileJobClass:
   case Action::PrecompileJobClass:
   case Action::HeaderModulePrecompileJobClass:
+  case Action::DepscanJobClass:
   case Action::PreprocessJobClass:
   case Action::ExtractAPIJobClass:
   case Action::AnalyzeJobClass:

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4381,13 +4381,16 @@ static void renderDebugOptions(const ToolChain &TC, const Driver &D,
   RenderDebugInfoCompressionArgs(Args, CmdArgs, D, TC);
 }
 
-void Clang::ConstructJob(Compilation &C, const JobAction &JA,
+void Clang::ConstructJob(Compilation &C, const JobAction &Job,
                          const InputInfo &Output, const InputInfoList &Inputs,
                          const ArgList &Args, const char *LinkingOutput) const {
   const auto &TC = getToolChain();
   const llvm::Triple &RawTriple = TC.getTriple();
   const llvm::Triple &Triple = TC.getEffectiveTriple();
   const std::string &TripleStr = Triple.getTriple();
+  const JobAction &JA = isa<DepscanJobAction>(Job)
+                            ? cast<DepscanJobAction>(Job).getScanningJobAction()
+                            : Job;
 
   bool KernelOrKext =
       Args.hasArg(options::OPT_mkernel, options::OPT_fapple_kext);
@@ -4487,7 +4490,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     D.Diag(diag::err_drv_clang_unsupported) << "C++ for IAMCU";
 
   // Handle depscan.
-  if (JA.getKind() == Action::DepscanJobClass) {
+  if (Job.getKind() == Action::DepscanJobClass) {
     CmdArgs.push_back("-cc1depscan");
 
     // Pass depscan related options to cc1depscan.
@@ -4526,42 +4529,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     InputName += II.getFilename();
     CmdArgs.push_back(C.getArgs().MakeArgString(InputName));
 
-    // FIXME: We overwrite the output and the action kind argument. Maybe there
-    // are better ways to do that. Not all output kind is handled here.
-    // If doing this as it is, we need to factor out the common code when
-    // upstreaming.
-    if (isa<AssembleJobAction>(JA)) {
-      CmdArgs.push_back("-emit-obj");
-    } else if (isa<PreprocessJobAction>(JA)) {
-      if (Output.getType() == types::TY_Dependencies)
-        CmdArgs.push_back("-Eonly");
-      else {
-        CmdArgs.push_back("-E");
-      }
-    } else {
-      if (JA.getType() == types::TY_Nothing) {
-        CmdArgs.push_back("-fsyntax-only");
-      } else if (JA.getType() == types::TY_LLVM_IR ||
-                 JA.getType() == types::TY_LTO_IR) {
-        CmdArgs.push_back("-emit-llvm");
-      } else if (JA.getType() == types::TY_LLVM_BC ||
-                 JA.getType() == types::TY_LTO_BC) {
-        if (Args.hasArg(options::OPT_S) &&
-            Args.hasArg(options::OPT_emit_llvm)) {
-          CmdArgs.push_back("-emit-llvm");
-        } else {
-          CmdArgs.push_back("-emit-llvm-bc");
-        }
-      } else if (JA.getType() == types::TY_PP_Asm) {
-        CmdArgs.push_back("-S");
-      } else if (JA.getType() == types::TY_AST) {
-        CmdArgs.push_back("-emit-pch");
-      } else if (JA.getType() == types::TY_ModuleFile) {
-        CmdArgs.push_back("-module-file-info");
-      } else {
-        llvm_unreachable("unhandled case");
-      }
-    }
+    // FIXME: Overwrite the output filename. To fix this, we need to somehow
+    // route the final output type into Depscan ConstructJob.
     if (Output.isFilename()) {
       CmdArgs.push_back("-o");
       CmdArgs.push_back(Output.getFilename());
@@ -4570,10 +4539,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     if (D.CC1Main && !D.CCGenDiagnostics) {
       // Invoke the CC1 directly in this process
       C.addCommand(std::make_unique<CC1Command>(
-          JA, *this, ResponseFileSupport::AtFileUTF8(), Exec, CmdArgs, Inputs,
+          Job, *this, ResponseFileSupport::AtFileUTF8(), Exec, CmdArgs, Inputs,
           Output));
     } else {
-      C.addCommand(std::make_unique<Command>(JA, *this,
+      C.addCommand(std::make_unique<Command>(Job, *this,
                                              ResponseFileSupport::AtFileUTF8(),
                                              Exec, CmdArgs, Inputs, Output));
     }
@@ -4937,7 +4906,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     }
 
     C.addCommand(std::make_unique<Command>(
-        JA, *this, ResponseFileSupport::AtFileUTF8(), D.getClangProgramPath(),
+        Job, *this, ResponseFileSupport::AtFileUTF8(), D.getClangProgramPath(),
         CmdArgs, Inputs, Output));
     return;
   }
@@ -7344,11 +7313,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   if (D.CC1Main && !D.CCGenDiagnostics) {
     // Invoke the CC1 directly in this process
-    C.addCommand(std::make_unique<CC1Command>(JA, *this,
+    C.addCommand(std::make_unique<CC1Command>(Job, *this,
                                               ResponseFileSupport::AtFileUTF8(),
                                               Exec, CmdArgs, Inputs, Output));
   } else {
-    C.addCommand(std::make_unique<Command>(JA, *this,
+    C.addCommand(std::make_unique<Command>(Job, *this,
                                            ResponseFileSupport::AtFileUTF8(),
                                            Exec, CmdArgs, Inputs, Output));
   }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4486,10 +4486,99 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   if (IsIAMCU && types::isCXX(Input.getType()))
     D.Diag(diag::err_drv_clang_unsupported) << "C++ for IAMCU";
 
+  // Handle depscan.
+  if (JA.getKind() == Action::DepscanJobClass) {
+    CmdArgs.push_back("-cc1depscan");
+
+    // Pass depscan related options to cc1depscan.
+    const OptSpecifier DepScanOpts[] = {
+        options::OPT_fdepscan_EQ,
+        options::OPT_fdepscan_share_EQ,
+        options::OPT_fdepscan_share_parent,
+        options::OPT_fdepscan_share_parent_EQ,
+        options::OPT_fno_depscan_share,
+        options::OPT_fdepscan_share_stop_EQ,
+        options::OPT_fdepscan_daemon_EQ,
+        options::OPT_fdepscan_prefix_map_EQ,
+        options::OPT_fdepscan_prefix_map_sdk_EQ,
+        options::OPT_fdepscan_prefix_map_toolchain_EQ};
+
+    Args.AddAllArgs(CmdArgs, DepScanOpts);
+
+    assert(Output.isFilename() && "Depscan needs to have file output");
+    CmdArgs.push_back("-o");
+    CmdArgs.push_back(Output.getFilename());
+    CmdArgs.push_back("-cc1-args");
+  }
+
   // Invoke ourselves in -cc1 mode.
   //
   // FIXME: Implement custom jobs for internal actions.
   CmdArgs.push_back("-cc1");
+
+  // Handle full response file input.
+  if (Inputs.front().getType() == types::TY_CMD) {
+    // Render response file input first.
+    assert(Inputs.size() == 1 && "Only one response file input");
+    auto &II = Inputs.front();
+    assert(II.isFilename() && "Should be response file");
+    SmallString<128> InputName("@");
+    InputName += II.getFilename();
+    CmdArgs.push_back(C.getArgs().MakeArgString(InputName));
+
+    // FIXME: We overwrite the output and the action kind argument. Maybe there
+    // are better ways to do that. Not all output kind is handled here.
+    // If doing this as it is, we need to factor out the common code when
+    // upstreaming.
+    if (isa<AssembleJobAction>(JA)) {
+      CmdArgs.push_back("-emit-obj");
+    } else if (isa<PreprocessJobAction>(JA)) {
+      if (Output.getType() == types::TY_Dependencies)
+        CmdArgs.push_back("-Eonly");
+      else {
+        CmdArgs.push_back("-E");
+      }
+    } else {
+      if (JA.getType() == types::TY_Nothing) {
+        CmdArgs.push_back("-fsyntax-only");
+      } else if (JA.getType() == types::TY_LLVM_IR ||
+                 JA.getType() == types::TY_LTO_IR) {
+        CmdArgs.push_back("-emit-llvm");
+      } else if (JA.getType() == types::TY_LLVM_BC ||
+                 JA.getType() == types::TY_LTO_BC) {
+        if (Args.hasArg(options::OPT_S) &&
+            Args.hasArg(options::OPT_emit_llvm)) {
+          CmdArgs.push_back("-emit-llvm");
+        } else {
+          CmdArgs.push_back("-emit-llvm-bc");
+        }
+      } else if (JA.getType() == types::TY_PP_Asm) {
+        CmdArgs.push_back("-S");
+      } else if (JA.getType() == types::TY_AST) {
+        CmdArgs.push_back("-emit-pch");
+      } else if (JA.getType() == types::TY_ModuleFile) {
+        CmdArgs.push_back("-module-file-info");
+      } else {
+        llvm_unreachable("unhandled case");
+      }
+    }
+    if (Output.isFilename()) {
+      CmdArgs.push_back("-o");
+      CmdArgs.push_back(Output.getFilename());
+    }
+    const char *Exec = D.getClangProgramPath();
+    if (D.CC1Main && !D.CCGenDiagnostics) {
+      // Invoke the CC1 directly in this process
+      C.addCommand(std::make_unique<CC1Command>(
+          JA, *this, ResponseFileSupport::AtFileUTF8(), Exec, CmdArgs, Inputs,
+          Output));
+    } else {
+      C.addCommand(std::make_unique<Command>(JA, *this,
+                                             ResponseFileSupport::AtFileUTF8(),
+                                             Exec, CmdArgs, Inputs, Output));
+    }
+    return;
+  }
 
   // Add the "effective" target triple.
   CmdArgs.push_back("-triple");
@@ -4648,7 +4737,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
            "Extract API actions must generate a API information.");
     CmdArgs.push_back("-extract-api");
   } else {
-    assert((isa<CompileJobAction>(JA) || isa<BackendJobAction>(JA)) &&
+    assert((isa<CompileJobAction>(JA) || isa<BackendJobAction>(JA) || isa<DepscanJobAction>(JA)) &&
            "Invalid action for clang tool.");
     if (JA.getType() == types::TY_Nothing) {
       CmdArgs.push_back("-fsyntax-only");
@@ -4685,6 +4774,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     } else if (JA.getType() == types::TY_RewrittenLegacyObjC) {
       CmdArgs.push_back("-rewrite-objc");
       rewriteKind = RK_Fragile;
+    } else if (JA.getType() == types::TY_CMD) {
+      // DepScan response file output. Use fsyntax-only is enough.
+      CmdArgs.push_back("-fsyntax-only");
     } else {
       assert(JA.getType() == types::TY_PP_Asm && "Unexpected output type!");
     }
@@ -7249,15 +7341,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     else
       Input.getInputArg().renderAsInput(Args, CmdArgs);
   }
-
-  // Do this last! This uses the rest of the -cc1 command-line as input.
-  //
-  // FIXME: Instead of scanning now, the driver should be structured to create
-  // two -cc1 actions, the first to scan and the second to run the results of
-  // the scan (somehow). The daemon should be an optimization for running the
-  // first of these actions.
-  if (Arg *A = Args.getLastArg(options::OPT_fdepscan_EQ))
-    D.CC1ScanDeps(*A, Exec, CmdArgs, D, Args);
 
   if (D.CC1Main && !D.CCGenDiagnostics) {
     // Invoke the CC1 directly in this process

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4533,6 +4533,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &Job,
     // follows it in -cc1-args, but it doesn't currently have access to that
     // filename. To fix this, we need to somehow route the final output type
     // into Depscan ConstructJob.
+    // FIXME: This intermediate output file will adds 3-4% of overhead comparing
+    // to passing all the cc1 args in the memory. The fix might be pin DepScan
+    // job in-process and pass cc1 args in memory instead of creating an actual
+    // file here.
     if (Output.isFilename()) {
       CmdArgs.push_back("-o");
       CmdArgs.push_back(Output.getFilename());

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4519,7 +4519,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &Job,
   // FIXME: Implement custom jobs for internal actions.
   CmdArgs.push_back("-cc1");
 
-  // Handle full response file input.
+  // Handle response file input.
   if (Inputs.front().getType() == types::TY_ResponseFile) {
     // Render response file input first.
     assert(Inputs.size() == 1 && "Only one response file input");
@@ -4529,12 +4529,16 @@ void Clang::ConstructJob(Compilation &C, const JobAction &Job,
     InputName += II.getFilename();
     CmdArgs.push_back(C.getArgs().MakeArgString(InputName));
 
-    // FIXME: Overwrite the output filename. To fix this, we need to somehow
-    // route the final output type into Depscan ConstructJob.
+    // FIXME: The -cc1depscan job should include the -o for the -cc1 job that
+    // follows it in -cc1-args, but it doesn't currently have access to that
+    // filename. To fix this, we need to somehow route the final output type
+    // into Depscan ConstructJob.
     if (Output.isFilename()) {
       CmdArgs.push_back("-o");
       CmdArgs.push_back(Output.getFilename());
     }
+    // FIXME: Clean up this code and factor out the common logic (see the end of
+    // the function)
     const char *Exec = D.getClangProgramPath();
     if (D.CC1Main && !D.CCGenDiagnostics) {
       // Invoke the CC1 directly in this process
@@ -4743,9 +4747,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &Job,
     } else if (JA.getType() == types::TY_RewrittenLegacyObjC) {
       CmdArgs.push_back("-rewrite-objc");
       rewriteKind = RK_Fragile;
-    } else if (JA.getType() == types::TY_ResponseFile) {
-      // DepScan response file output. Use fsyntax-only is enough.
-      CmdArgs.push_back("-fsyntax-only");
     } else {
       assert(JA.getType() == types::TY_PP_Asm && "Unexpected output type!");
     }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4517,7 +4517,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   CmdArgs.push_back("-cc1");
 
   // Handle full response file input.
-  if (Inputs.front().getType() == types::TY_CMD) {
+  if (Inputs.front().getType() == types::TY_ResponseFile) {
     // Render response file input first.
     assert(Inputs.size() == 1 && "Only one response file input");
     auto &II = Inputs.front();
@@ -4774,7 +4774,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     } else if (JA.getType() == types::TY_RewrittenLegacyObjC) {
       CmdArgs.push_back("-rewrite-objc");
       rewriteKind = RK_Fragile;
-    } else if (JA.getType() == types::TY_CMD) {
+    } else if (JA.getType() == types::TY_ResponseFile) {
       // DepScan response file output. Use fsyntax-only is enough.
       CmdArgs.push_back("-fsyntax-only");
     } else {

--- a/clang/test/CAS/depscan-prefix-map.c
+++ b/clang/test/CAS/depscan-prefix-map.c
@@ -4,7 +4,7 @@
 //
 // RUN: rm -rf %t.d
 // RUN: mkdir %t.d
-// RUN: %clang -cc1depscan -dump-depscan-tree=%t.root                     \
+// RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=inline    \
 // RUN:    -fdepscan-prefix-map=%S=/^source                               \
 // RUN:    -fdepscan-prefix-map=%t.d=/^testdir                            \
 // RUN:    -fdepscan-prefix-map=%{objroot}=/^objroot                      \

--- a/clang/test/CAS/depscan.c
+++ b/clang/test/CAS/depscan.c
@@ -1,7 +1,7 @@
 // TODO: Test should be updated to not depend on a working cache at default location, which is out of test/build directory.
 
-// RUN: %clang -cc1depscan -cc1-args -cc1 -triple x86_64-apple-macos11.0 -x c %s -o %s.o 2>&1 | FileCheck %s
-// RUN: %clang -cc1depscan -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %s.o 2>&1 | FileCheck %s
+// RUN: %clang -cc1depscan -fdepscan=inline -cc1-args -cc1 -triple x86_64-apple-macos11.0 -x c %s -o %s.o 2>&1 | FileCheck %s
+// RUN: %clang -cc1depscan -fdepscan=inline -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %s.o 2>&1 | FileCheck %s
 
 // CHECK: "-fcas-path" "auto"
 

--- a/clang/test/CAS/fdepscan-driver.c
+++ b/clang/test/CAS/fdepscan-driver.c
@@ -3,7 +3,7 @@
 // RUN:   FileCheck %s --check-prefix=CHECK-PHASES
 
 // CHECK-PHASES: 0: input
-// CHECK-PHASES: 1: depscan, {0}, command
+// CHECK-PHASES: 1: depscan, {0}, response-file
 // CHECK-PHASES: 2: preprocessor, {1}, cpp-output
 // CHECK-PHASES: 3: compiler, {2}, ir
 // CHECK-PHASES: 4: backend, {3}, assembler

--- a/clang/test/CAS/fdepscan-driver.c
+++ b/clang/test/CAS/fdepscan-driver.c
@@ -1,0 +1,33 @@
+// RUN: %clang -target x86_64-apple-macos11 -fdepscan=daemon -c \
+// RUN:   -x c %s -ccc-print-phases 2>&1 |                      \
+// RUN:   FileCheck %s --check-prefix=CHECK-PHASES
+
+// CHECK-PHASES: 0: input
+// CHECK-PHASES: 1: depscan, {0}, command
+// CHECK-PHASES: 2: preprocessor, {1}, cpp-output
+// CHECK-PHASES: 3: compiler, {2}, ir
+// CHECK-PHASES: 4: backend, {3}, assembler
+// CHECK-PHASES: 5: assembler, {4}, object
+// CHECK-PHASES: 6: bind-arch, "x86_64", {5}, object
+
+// RUN: %clang -target x86_64-apple-macos11 -fdepscan=daemon -c \
+// RUN:   -x c %s -ccc-print-bindings 2>&1 |                    \
+// RUN:   FileCheck %s --check-prefix=CHECK-BINDINGS
+
+// CHECK-BINDINGS: # "x86_64-apple-macos11" - "clang"
+// CHECK-BINDINGS: # "x86_64-apple-macos11" - "clang"
+
+
+// RUN: %clang -target x86_64-apple-macos11 -fdepscan=daemon -c \
+// RUN:   -x c %s -### 2>&1 |                                   \
+// RUN:   FileCheck %s --check-prefix=CHECK-CMD
+
+// CHECK-CMD: clang
+// CHECK-CMD: (in-process)
+// CHECK-CMD: clang
+// CHECK-CMD-SAME: "-cc1depscan" "-fdepscan=daemon" "-o"
+// CHECK-CMD: "-cc1" "@
+
+// RUN: %clang -target x86_64-apple-macos11 -fdepscan=daemon -c \
+// RUN:   -x c %s -save-temps -###
+

--- a/clang/tools/driver/UpdateCC1Args.h
+++ b/clang/tools/driver/UpdateCC1Args.h
@@ -19,7 +19,16 @@
 #include "llvm/Support/StringSaver.h"
 #include "llvm/Support/raw_ostream.h"
 
+namespace llvm {
+namespace opt {
+class Arg;
+class ArgList;
+} // namespace opt
+} // namespace llvm
+
 namespace clang {
+
+class DiagnosticsEngine;
 
 namespace tooling {
 namespace dependencies {
@@ -40,5 +49,9 @@ updateCC1Args(const char *Exec, ArrayRef<const char *> InputArgs,
               SmallVectorImpl<const char *> &OutputArgs,
               const cc1depscand::DepscanPrefixMapping &PrefixMapping,
               llvm::function_ref<const char *(const Twine &)> SaveArg);
+
+void CC1ScanDeps(const llvm::opt::Arg &A, const char *Exec,
+                 SmallVectorImpl<const char *> &CC1Args,
+                 DiagnosticsEngine &Diag, const llvm::opt::ArgList &Args);
 
 } // end namespace clang


### PR DESCRIPTION
Put depscan action into a new phase in the Jobs so the driver can be run
with `-fdepscan` without running dependency scanning.