### PR TITLE
[lldb] Set the TERM environment variable for the API tests

### DIFF
--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -254,6 +254,9 @@ import lldbtest
 # testFormat: The test format to use to interpret tests.
 config.test_format = lldbtest.LLDBTest(dotest_cmd)
 
+# Propagate TERM or default to vt100.
+config.environment['TERM'] = os.getenv('TERM', default='vt100')
+
 # Propagate FREEBSD_LEGACY_PLUGIN
 if 'FREEBSD_LEGACY_PLUGIN' in os.environ:
   config.environment['FREEBSD_LEGACY_PLUGIN'] = os.environ[


### PR DESCRIPTION
Avoid "TERM environment variable not set" by either propagating the TERM
environment variable or defaulting to vt100. All of our CI is already
doing this explicitly through the --env dotest arg, but it's easy to
forget when setting up a new job. I don't see any downside in making it
the default.