### PR TITLE
[clang-scan-deps] Some enhancements for `clang-scan-deps` tool

### DIFF
--- a/clang/test/ClangScanDeps/cas-trees.c
+++ b/clang/test/ClangScanDeps/cas-trees.c
@@ -1,0 +1,54 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -cas -cas-path %t/cas -format experimental-tree -mode preprocess-minimized-sources > %t/result1.txt
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -cas -cas-path %t/cas -format experimental-tree -mode preprocess > %t/result2.txt
+// RUN: diff -u %t/result1.txt %t/result2.txt
+// RUN: FileCheck %s -input-file %t/result1.txt -DPREFIX=%/t
+
+// CHECK:      tree {{.*}} for '[[PREFIX]]/t1.c'
+// CHECK-NEXT: tree {{.*}} for '[[PREFIX]]/t2.c'
+
+
+//--- cdb.json.template
+[
+  {
+    "directory": "DIR",
+    "command": "clang -fsyntax-only DIR/t1.c",
+    "file": "DIR/t1.c"
+  },
+  {
+    "directory": "DIR",
+    "command": "clang -fsyntax-only DIR/t2.c",
+    "file": "DIR/t2.c"
+  }
+]
+
+//--- t1.c
+#include "top.h"
+#include "n1.h"
+
+//--- t2.c
+#include "n1.h"
+
+//--- top.h
+#ifndef _TOP_H_
+#define _TOP_H_
+
+#define WHATEVER 1
+#include "n1.h"
+
+struct S {
+  int x;
+};
+
+#endif
+
+//--- n1.h
+#ifndef _N1_H_
+#define _N1_H_
+
+int x1;
+
+#endif

--- a/clang/test/ClangScanDeps/modules-cas.cpp
+++ b/clang/test/ClangScanDeps/modules-cas.cpp
@@ -13,9 +13,9 @@
 // RUN: sed -e "s|DIR|%/t.dir|g" %S/Inputs/modules_cdb.json > %t.cdb
 // RUN: sed -e "s|DIR|%/t.dir|g" %S/Inputs/modules_cdb_clangcl.json > %t_clangcl.cdb
 //
-// RUN: clang-scan-deps -cas -compilation-database %t.cdb -j 1 -mode preprocess-minimized-sources | \
+// RUN: clang-scan-deps -cas -cas-path %t.dir/cas -compilation-database %t.cdb -j 1 -mode preprocess-minimized-sources | \
 // RUN:   FileCheck --check-prefixes=CHECK1,CHECK2,CHECK2NO %s
-// RUN: clang-scan-deps -cas -compilation-database %t_clangcl.cdb -j 1 -mode preprocess-minimized-sources | \
+// RUN: clang-scan-deps -cas -cas-path %t.dir/cas -compilation-database %t_clangcl.cdb -j 1 -mode preprocess-minimized-sources | \
 // RUN:   FileCheck --check-prefixes=CHECK1,CHECK2,CHECK2NO %s
 //
 // The output order is non-deterministic when using more than one thread,
@@ -23,21 +23,21 @@
 // as it might fail if the results for `modules_cdb_input.cpp` are reported before
 // `modules_cdb_input2.cpp`.
 //
-// RUN: clang-scan-deps -cas -compilation-database %t.cdb -j 2 -mode preprocess-minimized-sources | \
+// RUN: clang-scan-deps -cas -cas-path %t.dir/cas -compilation-database %t.cdb -j 2 -mode preprocess-minimized-sources | \
 // RUN:   FileCheck --check-prefix=CHECK1 %s
-// RUN: clang-scan-deps -cas -compilation-database %t_clangcl.cdb -j 2 -mode preprocess-minimized-sources | \
+// RUN: clang-scan-deps -cas -cas-path %t.dir/cas -compilation-database %t_clangcl.cdb -j 2 -mode preprocess-minimized-sources | \
 // RUN:   FileCheck --check-prefix=CHECK1 %s
-// RUN: clang-scan-deps -cas -compilation-database %t.cdb -j 2 -mode preprocess | \
+// RUN: clang-scan-deps -cas -cas-path %t.dir/cas -compilation-database %t.cdb -j 2 -mode preprocess | \
 // RUN:   FileCheck --check-prefix=CHECK1 %s
-// RUN: clang-scan-deps -cas -compilation-database %t_clangcl.cdb -j 2 -mode preprocess | \
+// RUN: clang-scan-deps -cas -cas-path %t.dir/cas -compilation-database %t_clangcl.cdb -j 2 -mode preprocess | \
 // RUN:   FileCheck --check-prefix=CHECK1 %s
-// RUN: clang-scan-deps -cas -compilation-database %t.cdb -j 2 -mode preprocess-minimized-sources | \
+// RUN: clang-scan-deps -cas -cas-path %t.dir/cas -compilation-database %t.cdb -j 2 -mode preprocess-minimized-sources | \
 // RUN:   FileCheck --check-prefix=CHECK2 %s
-// RUN: clang-scan-deps -cas -compilation-database %t_clangcl.cdb -j 2 -mode preprocess-minimized-sources | \
+// RUN: clang-scan-deps -cas -cas-path %t.dir/cas -compilation-database %t_clangcl.cdb -j 2 -mode preprocess-minimized-sources | \
 // RUN:   FileCheck --check-prefix=CHECK2 %s
-// RUN: clang-scan-deps -cas -compilation-database %t.cdb -j 2 -mode preprocess | \
+// RUN: clang-scan-deps -cas -cas-path %t.dir/cas -compilation-database %t.cdb -j 2 -mode preprocess | \
 // RUN:   FileCheck --check-prefix=CHECK2 %s
-// RUN: clang-scan-deps -cas -compilation-database %t_clangcl.cdb -j 2 -mode preprocess | \
+// RUN: clang-scan-deps -cas -cas-path %t.dir/cas -compilation-database %t_clangcl.cdb -j 2 -mode preprocess | \
 // RUN:   FileCheck --check-prefix=CHECK2 %s
 
 #include "header.h"


### PR DESCRIPTION
* Add `-cas-path` option for specifying the CAS path and use it for the test case
* Print the results of `-format experimental-tree` in deterministic order to make it convenient to test and compare outputs of multiple runs
* Add a test case for `-format experimental-tree`