### PR TITLE
[lldb] Unlock Swift scratch context before early return 

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2319,8 +2319,10 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
           m_scratch_type_system_map.RemoveTypeSystemsForLanguage(language);
           type_system_or_err = m_scratch_type_system_map.GetTypeSystemForLanguage(
               language, this, create_on_demand, compiler_options);
-          if (!type_system_or_err)
+          if (!type_system_or_err) {
+            GetSwiftScratchContextLock().unlock();
             return type_system_or_err.takeError();
+          }
 
           if (auto *new_swift_ast_ctx =
                   llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2296,6 +2296,9 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
         // thread) is holding a read lock to the scratch context and
         // replacing it could cause a use-after-free later on.
         if (GetSwiftScratchContextLock().try_lock()) {
+          auto unlock = llvm::make_scope_exit([this] {
+            GetSwiftScratchContextLock().unlock();
+          });
           if (m_use_scratch_typesystem_per_module)
             DisplayFallbackSwiftContextErrors(swift_ast_ctx);
           else if (StreamSP errs = GetDebugger().GetAsyncErrorStream()) {
@@ -2319,10 +2322,8 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
           m_scratch_type_system_map.RemoveTypeSystemsForLanguage(language);
           type_system_or_err = m_scratch_type_system_map.GetTypeSystemForLanguage(
               language, this, create_on_demand, compiler_options);
-          if (!type_system_or_err) {
-            GetSwiftScratchContextLock().unlock();
+          if (!type_system_or_err)
             return type_system_or_err.takeError();
-          }
 
           if (auto *new_swift_ast_ctx =
                   llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
@@ -2347,7 +2348,6 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
                   llvm::make_error<llvm::StringError>("DIAF", llvm::inconvertibleErrorCode());
             }
           }
-          GetSwiftScratchContextLock().unlock();
         }
       }
     } else if (create_on_demand) {


### PR DESCRIPTION
(cherry picked from commit 32fa0939a878d4b88a3609abafdb97f646144ae4)

rdar://90666943