### PR TITLE
Don't search for sim SDK path until we know we need it

### DIFF
--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -391,6 +391,13 @@ static std::string GetXcodeSDK(XcodeSDK sdk) {
     args.AppendArgument("--sdk");
     args.AppendArgument(sdk);
 
+    Log *log = GetLog(LLDBLog::Host);
+    if (log) {
+      std::string cmdstr;
+      args.GetCommandString(cmdstr);
+      log->Printf("GetXcodeSDK() running shell cmd '%s'", cmdstr.c_str());
+    }
+
     int status = 0;
     int signo = 0;
     std::string output_str;

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.h
@@ -40,7 +40,8 @@ public:
                  llvm::Triple::OSType preferred_os,
                  llvm::SmallVector<llvm::Triple::OSType, 4> supported_os,
                  llvm::SmallVector<llvm::StringRef, 4> supported_triples,
-                 llvm::StringRef sdk, lldb_private::XcodeSDK::Type sdk_type,
+                 std::string sdk_name_preferred, std::string sdk_name_secondary,
+                 lldb_private::XcodeSDK::Type sdk_type,
                  CoreSimulatorSupport::DeviceType::ProductFamilyID kind,
                  bool force, const lldb_private::ArchSpec *arch);
 


### PR DESCRIPTION
Don't search for sim SDK path until we know we need it

When iterating over all Platforms looking for the best one, on a Mac the
Simulator platforms (iOS, tvOS, watchOS) will first find their SDK
directory by calling xcrun, then decide if they should activate or not.
When that SDK is absent, the call to xcrun to find it can be very slow.
This patch delays that directory search until we know we're activating
this platform, so non-simulator environments don't pay a perf cost ever
time they go through the list of platforms.

Differential Revision: https://reviews.llvm.org/D122373
rdar://87960090

(cherry picked from commit 99515783a63cd5018fa9231872dc5c8b13d64947)