### PR TITLE
Load dyld manually with 'main bin spec' userland corefiles

### DIFF
--- a/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
+++ b/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
@@ -224,6 +224,16 @@ static bool load_standalone_binary(UUID uuid, addr_t value,
       target.SetArchitecture(module_sp->GetObjectFile()->GetArchitecture());
       target.GetImages().AppendIfNeeded(module_sp, false);
 
+      // TODO: Instead of using the load address as a value, if we create a
+      // memory module from that address, we could get the correct segment
+      // offset values from the in-memory load commands and set them correctly.
+      // In case the load address we were given is not correct for all segments,
+      // e.g. something in the shared cache.  DynamicLoaderDarwinKernel does
+      // something similar for kexts.  In the context of a corefile, this would
+      // be an inexpensive operation.  Not all binaries in a corefile will have
+      // a Mach-O header/load commands in memory, so this will not work in all
+      // cases.
+
       bool changed = false;
       if (module_sp->GetObjectFile()) {
         if (value != LLDB_INVALID_ADDRESS) {
@@ -355,6 +365,8 @@ Status ProcessMachCore::DoLoadCore() {
     if (objfile_binary_value != LLDB_INVALID_ADDRESS &&
         !objfile_binary_value_is_offset) {
       if (type == ObjectFile::eBinaryTypeUser) {
+        load_standalone_binary(objfile_binary_uuid, objfile_binary_value,
+                               objfile_binary_value_is_offset, GetTarget());
         m_dyld_addr = objfile_binary_value;
         m_dyld_plugin_name = DynamicLoaderMacOSXDYLD::GetPluginNameStatic();
         found_main_binary_definitively = true;


### PR DESCRIPTION
Load dyld manually with 'main bin spec' userland corefiles

In ProcessMachCore::DoLoadCore when we have a standalone
binary and a 'main bin spec' LC_NOTE detailing the UUID and
load address, ProcessMachCore will do a (potentially slow)
lookup to try to find the binary and/or dSYM.  For kernel and
userland corefile using 'main bin spec', we would follow the
normal schemes of locating them.  DynamicLoaderDarwinKernel would
use the same (possibly expensive) calls to find the correct
binary.  dyld by default would use the in-core-file binary image,
and so if the corefile didn't include the entire address space,
the LINKEDIT for dyld could be missing.  This means we can't find
the dyld4::dyld_all_image_infos struct, which tells us where the
other binaries are loaded in memory.

Treat userland 'bin main spec' like we do standalone firmewares;
try the expensive checks to find the best dyld we can, before
falling back to using a memory module out of the corefile.

Also add a little TODO for myself in this load_standalone_binary
function that we should handle the case of a binary in the shared
cache correctly, creating a memory module in the corefile and
using the segment load addresses from that to set our segment
load addresses for the final binary.

rdar://89717101
(cherry picked from commit 9a8a0a38613ae190740923a7dcdf381a1b6fc55e)