### PR TITLE
Fix a bug where an extended vector of __fp16 was being converted to a generic vector type

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -9915,9 +9915,11 @@ static bool tryVectorConvertAndSplat(Sema &S, ExprResult *scalar,
 static ExprResult convertVector(Expr *E, QualType ElementType, Sema &S) {
   const auto *VecTy = E->getType()->getAs<VectorType>();
   assert(VecTy && "Expression E must be a vector");
-  QualType NewVecTy = S.Context.getVectorType(ElementType,
-                                              VecTy->getNumElements(),
-                                              VecTy->getVectorKind());
+  QualType NewVecTy =
+      VecTy->isExtVectorType()
+          ? S.Context.getExtVectorType(ElementType, VecTy->getNumElements())
+          : S.Context.getVectorType(ElementType, VecTy->getNumElements(),
+                                    VecTy->getVectorKind());
 
   // Look through the implicit cast. Return the subexpression if its type is
   // NewVecTy.

--- a/clang/test/Sema/fp16vec-sema.c
+++ b/clang/test/Sema/fp16vec-sema.c
@@ -4,6 +4,7 @@ typedef __fp16 half4 __attribute__ ((vector_size (8)));
 typedef float float4 __attribute__ ((vector_size (16)));
 typedef short short4 __attribute__ ((vector_size (8)));
 typedef int int4 __attribute__ ((vector_size (16)));
+typedef __fp16 exthalf4 __attribute__((ext_vector_type(4)));
 
 half4 hv0, hv1;
 float4 fv0, fv1;
@@ -50,4 +51,9 @@ void testFP16Vec(int c) {
   sv0 = !hv0; // expected-error{{invalid argument type}}
   hv0++; // expected-error{{cannot increment value of type}}
   ++hv0; // expected-error{{cannot increment value of type}}
+}
+
+void testExtVec(exthalf4 a) {
+  // Check that the type of "(-a)" is exthalf4.
+  __fp16 t0 = (-a).z;
 }


### PR DESCRIPTION
rdar://86109177
(cherry picked from commit 350d43f1efd711d057cdb53decabb6f32491dff0)