### PR TITLE
cc1depscan: Refactor to make scanning CASOptions explicit, NFC

### DIFF
--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -1185,7 +1185,8 @@ updateCC1Args(const CASOptions &CASOpts,
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "failed to create compiler invocation");
 
-  // Override the CASOptions if they don't match.
+  // Override the CASOptions. They may match (the caller having sniffed them
+  // out of InputArgs) but if they have been overridden we want the new ones.
   Invocation->getCASOpts() = CASOpts;
 
   llvm::BumpPtrAllocator Alloc;


### PR DESCRIPTION
This refactoring makes the CASOptions used for scanning explicit.
It still hardcodes the automatic on-disk path (`-fcas-path=auto`)
for now, but prepares for:

 1. Change `-cc1depscand` to take CASOptions on the command-line, and
    update the code that determines the "daemon key" to incorporate a
    hash of the serialized CASOptions.

 2. Change `-cc1depscan` to sniff CASOptions (`-fcas-path`) out of
    `-cc1-args`. This is a natural way to specify the CAS that is
    used for scanning. It should not override `-fcas-path` any more:
    the driver (and all tests) should instead specify `auto` or a manual
    path when in-memory isn't going to work (e.g., `-fdepscan` should
    imply non-empty `-fcas-path`).

 3. Change the driver to accept `-fcas-path`, which it can now forward
    to `-cc1*` since it will no longer be clobbered by `-fdepscan`!!!

Again, those steps aren't done, but they should be straightforward now.