### PR TITLE
Adopt new dyld SPIs to introspect the shared cache.

### DIFF
--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -35,6 +35,10 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <Foundation/Foundation.h>
 #include <mach-o/dyld.h>
+#if __has_include(<mach-o/dyld_introspection.h>)
+#include <mach-o/dyld_introspection.h>
+#define SDK_HAS_NEW_DYLD_INTROSPECTION_SPIS
+#endif
 #include <objc/objc-auto.h>
 
 // These are needed when compiling on systems
@@ -537,6 +541,41 @@ private:
 }
 
 SharedCacheInfo::SharedCacheInfo() {
+#if defined(SDK_HAS_NEW_DYLD_INTROSPECTION_SPIS)
+  if (__builtin_available(macOS 12, *)) {
+    if (dyld_process_create_for_current_task) {
+      auto dyld_process = dyld_process_create_for_current_task();
+      auto snapshot =
+          dyld_process_snapshot_create_for_process(dyld_process, nullptr);
+      auto shared_cache = dyld_process_snapshot_get_shared_cache(snapshot);
+      assert(dyld_process && snapshot && shared_cache);
+
+      dyld_shared_cache_for_each_image(shared_cache, ^(dyld_image_t image) {
+        __block uint64_t minVmAddr = UINT64_MAX;
+        __block uint64_t maxVmAddr = 0;
+        uuid_t uuidStore;
+        __block uuid_t *uuid = &uuidStore;
+
+        dyld_image_for_each_segment_info(image, ^(const char *segmentName,
+                                                  uint64_t vmAddr,
+                                                  uint64_t vmSize, int perm) {
+          minVmAddr = std::min(minVmAddr, vmAddr);
+          maxVmAddr = std::max(maxVmAddr, vmAddr + vmSize);
+          dyld_image_copy_uuid(image, uuid);
+        });
+        assert(minVmAddr != UINT_MAX);
+        assert(maxVmAddr != 0);
+        m_images[dyld_image_get_installname(image)] = SharedCacheImageInfo{
+            UUID::fromData(uuid, 16),
+            std::make_shared<DataBufferUnowned>((uint8_t *)minVmAddr,
+                                                maxVmAddr - minVmAddr)};
+      });
+      dyld_process_snapshot_dispose(snapshot);
+      return;
+    }
+  }
+#endif
+
   size_t shared_cache_size;
   uint8_t *shared_cache_start =
       _dyld_get_shared_cache_range(&shared_cache_size);


### PR DESCRIPTION
With the shared cache getting split into multiple files, the current
way we created ObjectFileMachO objects for shared cache dylib images
will break.

This patch conditionally adopts new SPIs which will do the right
thing in the new world of multi-file caches.

(cherry picked from commit 3427eddd9aabcb1505ffe16adfcba7d6e8b28bf8)
