### PR TITLE
fdepscan: Continue unifying code paths; mostly NFC

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3914,9 +3914,10 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     // FIXME: To avoid globally adding the depscan phase to all the input types,
     // we try to inject depscan phase here if the first phase is preprocess and
     // -fdepscan is used.
-    if (PL.front() == phases::Preprocess &&
-        Args.hasArg(options::OPT_fdepscan_EQ))
-      PL.insert(PL.begin(), phases::Depscan);
+    if (PL.front() == phases::Preprocess)
+      if (Arg *A = Args.getLastArg(options::OPT_fdepscan_EQ))
+        if (A->getValue() != llvm::StringLiteral("off"))
+          PL.insert(PL.begin(), phases::Depscan);
 
     for (phases::ID Phase : PL) {
 

--- a/clang/test/CAS/depscan.c
+++ b/clang/test/CAS/depscan.c
@@ -2,7 +2,13 @@
 
 // RUN: %clang -cc1depscan -fdepscan=inline -cc1-args -cc1 -triple x86_64-apple-macos11.0 -x c %s -o %s.o 2>&1 | FileCheck %s
 // RUN: %clang -cc1depscan -fdepscan=inline -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %s.o 2>&1 | FileCheck %s
+//
+// Check that inline/daemon have identical output.
+// RUN: %clang -cc1depscan -o inline.rsp -fdepscan=inline -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %s.o
+// RUN: %clang -cc1depscan -o daemon.rsp -fdepscan=daemon -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %s.o
+// RUN: diff inline.rsp daemon.rsp
 
+// CHECK: {{^}}"-cc1"
 // CHECK: "-fcas-path" "auto"
 
 int test() { return 0; }

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -389,6 +389,13 @@ static llvm::Expected<llvm::cas::CASID> scanAndUpdateCC1UsingDaemon(
     const CASOptions &CASOpts, llvm::cas::CASDB &CAS) {
   using namespace clang::cc1depscand;
 
+  // FIXME: A bunch of data is sent back and forth to the daemon using IPC. Why
+  // not use the CAS?
+  // - Send the daemon the ID of a structured object describing the action,
+  //   with the working directory, original -cc1, and mapping instructions.
+  // - Daemon sends back the ID of a structured object with the result, new
+  //   args, and filesystem tree.
+
   // FIXME: Forward CASOptions to the daemon.
   // FIXME: Skip some of this if -fcas-fs has been passed.
   SmallString<128> WorkingDirectory;

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -394,7 +394,7 @@ static llvm::Expected<llvm::cas::CASID> scanAndUpdateCC1UsingDaemon(
   SmallString<128> WorkingDirectory;
   if (auto E =
           llvm::errorCodeToError(llvm::sys::fs::current_path(WorkingDirectory)))
-    return E;
+    return std::move(E);
 
   // llvm::dbgs() << "connecting to daemon...\n";
   auto Daemon = NoSpawnDaemon ? ScanDaemon::connectToDaemonAndShakeHands(Path)
@@ -405,7 +405,7 @@ static llvm::Expected<llvm::cas::CASID> scanAndUpdateCC1UsingDaemon(
 
   // llvm::dbgs() << "sending request...\n";
   if (auto E = Comms.putCommand(WorkingDirectory, OldArgs, Mapping))
-    return E;
+    return std::move(E);
 
   llvm::BumpPtrAllocator Alloc;
   llvm::StringSaver Saver(Alloc);
@@ -415,7 +415,7 @@ static llvm::Expected<llvm::cas::CASID> scanAndUpdateCC1UsingDaemon(
   StringRef RootID;
   if (auto E =
           Comms.getScanResult(Saver, Result, FailedReason, RootID, RawNewArgs))
-    return E;
+    return std::move(E);
 
   if (Result != CC1DepScanDProtocol::SuccessResult)
     return llvm::createStringError(llvm::inconvertibleErrorCode(),

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -422,10 +422,9 @@ static llvm::Expected<llvm::cas::CASID> scanAndUpdateCC1UsingDaemon(
                                    "depscan daemon failed: " + FailedReason);
 
   // FIXME: Avoid this duplication.
-  NewArgs.resize(RawNewArgs.size() + 1);
-  NewArgs[0] = OldArgs[0];
+  NewArgs.resize(RawNewArgs.size());
   for (int I = 0, E = RawNewArgs.size(); I != E; ++I)
-    NewArgs[I + 1] = SaveArg(RawNewArgs[I]);
+    NewArgs[I] = SaveArg(RawNewArgs[I]);
 
   return CAS.parseID(RootID);
 }

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -382,7 +382,8 @@ static void shutdownCC1ScanDepsDaemon(StringRef Path) {
 }
 
 static llvm::Expected<llvm::cas::CASID> scanAndUpdateCC1UsingDaemon(
-    const char *Exec, SmallVectorImpl<const char *> &Argv,
+    const char *Exec, ArrayRef<const char *> OldArgs,
+    SmallVectorImpl<const char *> &NewArgs,
     const cc1depscand::DepscanPrefixMapping &Mapping, StringRef Path,
     bool NoSpawnDaemon, llvm::function_ref<const char *(const Twine &)> SaveArg,
     const CASOptions &CASOpts, llvm::cas::CASDB &CAS) {
@@ -403,17 +404,17 @@ static llvm::Expected<llvm::cas::CASID> scanAndUpdateCC1UsingDaemon(
   CC1DepScanDProtocol Comms(*Daemon);
 
   // llvm::dbgs() << "sending request...\n";
-  if (auto E = Comms.putCommand(WorkingDirectory, Argv, Mapping))
+  if (auto E = Comms.putCommand(WorkingDirectory, OldArgs, Mapping))
     return E;
 
   llvm::BumpPtrAllocator Alloc;
   llvm::StringSaver Saver(Alloc);
-  SmallVector<const char *> NewArgs;
+  SmallVector<const char *> RawNewArgs;
   CC1DepScanDProtocol::ResultKind Result;
   StringRef FailedReason;
   StringRef RootID;
   if (auto E =
-          Comms.getScanResult(Saver, Result, FailedReason, RootID, NewArgs))
+          Comms.getScanResult(Saver, Result, FailedReason, RootID, RawNewArgs))
     return E;
 
   if (Result != CC1DepScanDProtocol::SuccessResult)
@@ -421,9 +422,10 @@ static llvm::Expected<llvm::cas::CASID> scanAndUpdateCC1UsingDaemon(
                                    "depscan daemon failed: " + FailedReason);
 
   // FIXME: Avoid this duplication.
-  Argv.resize(NewArgs.size() + 1);
-  for (int I = 0, E = NewArgs.size(); I != E; ++I)
-    Argv[I + 1] = SaveArg(NewArgs[I]);
+  NewArgs.resize(RawNewArgs.size() + 1);
+  NewArgs[0] = OldArgs[0];
+  for (int I = 0, E = RawNewArgs.size(); I != E; ++I)
+    NewArgs[I + 1] = SaveArg(RawNewArgs[I]);
 
   return CAS.parseID(RootID);
 }
@@ -470,12 +472,12 @@ parseCASFSAutoPrefixMappings(DiagnosticsEngine &Diag, const ArgList &Args) {
   return Mapping;
 }
 
-static void scanAndUpdateCC1(const llvm::opt::Arg &ModeArg, const char *Exec,
-                             SmallVectorImpl<const char *> &CC1Args,
-                             DiagnosticsEngine &Diag,
-                             const llvm::opt::ArgList &Args,
-                             const CASOptions &CASOpts, llvm::cas::CASDB &CAS,
-                             llvm::Optional<llvm::cas::CASID> &RootID) {
+static int scanAndUpdateCC1(const char *Exec, ArrayRef<const char *> OldArgs,
+                            SmallVectorImpl<const char *> &NewArgs,
+                            DiagnosticsEngine &Diag,
+                            const llvm::opt::ArgList &Args,
+                            const CASOptions &CASOpts, llvm::cas::CASDB &CAS,
+                            llvm::Optional<llvm::cas::CASID> &RootID) {
   using namespace clang::driver;
 
   // Collect these before returning to ensure they're claimed.
@@ -499,13 +501,16 @@ static void scanAndUpdateCC1(const llvm::opt::Arg &ModeArg, const char *Exec,
   if (Arg *A = Args.getLastArg(options::OPT_fdepscan_daemon_EQ))
     Sharing.Path = A->getValue();
 
-  StringRef Mode = ModeArg.getValue();
-  if (Mode == "off")
-    return;
-
-  if (Mode != "daemon" && Mode != "inline" && Mode != "auto")
-    Diag.Report(diag::err_drv_invalid_argument_to_option)
-        << Mode << ModeArg.getOption().getName();
+  StringRef Mode = "auto";
+  if (Arg *A = Args.getLastArg(clang::driver::options::OPT_fdepscan_EQ)) {
+    Mode = A->getValue();
+    // Note: -cc1depscan does not accept '-fdepscan=off'.
+    if (Mode != "daemon" && Mode != "inline" && Mode != "auto") {
+      Diag.Report(diag::err_drv_invalid_argument_to_option)
+          << Mode << A->getOption().getName();
+      return 1;
+    }
+  }
 
   cc1depscand::DepscanPrefixMapping PrefixMapping =
       parseCASFSAutoPrefixMappings(Diag, Args);
@@ -513,30 +518,25 @@ static void scanAndUpdateCC1(const llvm::opt::Arg &ModeArg, const char *Exec,
   auto SaveArg = [&Args](const Twine &T) { return Args.MakeArgString(T); };
 
   // FIXME: Use CASOptions to determine the daemon path.
-  if (Optional<std::string> DaemonPath = makeDepscanDaemonPath(Mode, Sharing)) {
-    if (Error E =
-            scanAndUpdateCC1UsingDaemon(
-                Exec, CC1Args, PrefixMapping, *DaemonPath,
-                /*NoSpawnDaemon*/ (bool)Sharing.Path, SaveArg, CASOpts, CAS)
-                .moveInto(RootID))
-      Diag.Report(diag::err_cas_depscan_daemon_connection)
-          << toString(std::move(E));
-    return;
-  }
-
-  if (llvm::Error E =
-          scanAndUpdateCC1Inline(Exec, CC1Args, CC1Args, PrefixMapping, SaveArg,
-                                 CASOpts, CAS)
-              .moveInto(RootID))
+  auto ScanAndUpdate = [&]() {
+    if (Optional<std::string> DaemonPath = makeDepscanDaemonPath(Mode, Sharing))
+      return scanAndUpdateCC1UsingDaemon(
+          Exec, OldArgs, NewArgs, PrefixMapping, *DaemonPath,
+          /*NoSpawnDaemon=*/(bool)Sharing.Path, SaveArg, CASOpts, CAS);
+    return scanAndUpdateCC1Inline(Exec, OldArgs, NewArgs, PrefixMapping,
+                                  SaveArg, CASOpts, CAS);
+  };
+  if (llvm::Error E = ScanAndUpdate().moveInto(RootID)) {
     Diag.Report(diag::err_cas_depscan_failed) << toString(std::move(E));
+    return 1;
+  }
+  return 0;
 }
 
 int cc1depscan_main(ArrayRef<const char *> Argv, const char *Argv0,
                     void *MainAddr) {
-  SmallString<128> DiagsBuffer;
-  llvm::raw_svector_ostream DiagsOS(DiagsBuffer);
   auto DiagsConsumer = std::make_unique<TextDiagnosticPrinter>(
-      DiagsOS, new DiagnosticOptions(), false);
+      llvm::errs(), new DiagnosticOptions(), false);
   DiagnosticsEngine Diags(new DiagnosticIDs(), new DiagnosticOptions());
   Diags.setClient(DiagsConsumer.get(), /*ShouldOwnClient=*/false);
 
@@ -593,34 +593,9 @@ int cc1depscan_main(ArrayRef<const char *> Argv, const char *Argv0,
   if (!CAS)
     return 1;
 
-  auto *DepScanArg = Args.getLastArg(clang::driver::options::OPT_fdepscan_EQ);
-  assert(DepScanArg && "-fdepscan not passed");
-  if (DepScanArg && StringRef(DepScanArg->getValue()) != "inline") {
-    for (auto *A : CC1Args->getValues())
-      NewArgs.push_back(A);
-    scanAndUpdateCC1(*DepScanArg, Argv0, NewArgs, Diags, Args, CASOpts, *CAS,
-                     RootID);
-  } else {
-
-    IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> FS =
-        llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*CAS));
-    tooling::dependencies::DependencyScanningService Service(
-        tooling::dependencies::ScanningMode::MinimizedSourcePreprocessing,
-        tooling::dependencies::ScanningOutputFormat::Tree, FS,
-        /*ReuseFileManager=*/false,
-        /*SkipExcludedPPRanges=*/true);
-    tooling::dependencies::DependencyScanningTool Tool(Service);
-    if (Error E =
-            scanAndUpdateCC1InlineWithTool(
-                CASOpts, Tool, *DiagsConsumer, Argv0, CC1Args->getValues(),
-                WorkingDirectory, NewArgs, PrefixMapping,
-                [&](const Twine &T) { return Saver.save(T).data(); })
-                .moveInto(RootID)) {
-      llvm::errs() << "failed to update -cc1: " << toString(std::move(E))
-                   << "\n";
-      return 1;
-    }
-  }
+  if (int Ret = scanAndUpdateCC1(Argv0, CC1Args->getValues(), NewArgs, Diags,
+                                 Args, CASOpts, *CAS, RootID))
+    return Ret;
 
   // FIXME: Use OutputBackend to OnDisk only now.
   auto OutputBackend =


### PR DESCRIPTION
No important functional changes here, just unifying a few code paths
that were diverged because of history of driver vs. separate tool.