### PR TITLE
CAS: Switch from SHA1 to BLAKE3

### DIFF
--- a/llvm/include/llvm/CAS/HashMappedTrie.h
+++ b/llvm/include/llvm/CAS/HashMappedTrie.h
@@ -14,7 +14,6 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
-#include "llvm/Support/SHA1.h"
 #include <atomic>
 
 namespace llvm {

--- a/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
+++ b/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
@@ -15,7 +15,6 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/FileSystem.h"
-#include "llvm/Support/SHA1.h"
 #include <atomic>
 #include <mutex>
 

--- a/llvm/lib/CAS/BuiltinCAS.h
+++ b/llvm/lib/CAS/BuiltinCAS.h
@@ -12,8 +12,8 @@
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/CAS/CASDB.h"
+#include "llvm/Support/BLAKE3.h"
 #include "llvm/Support/Error.h"
-#include "llvm/Support/SHA1.h"
 #include <cstddef>
 
 namespace llvm {
@@ -107,15 +107,62 @@ inline ArrayRef<char> toArrayRef(StringRef Data) {
 }
 
 /// Current hash type for the internal CAS.
-using HasherT = SHA1;
+///
+/// FIXME: This should be configurable via an enum to allow configuring the hash
+/// function. The enum should be sent into \a createInMemoryCAS() and \a
+/// createOnDiskCAS().
+///
+/// This is important (at least) for future-proofing, when we want to make new
+/// CAS instances use BLAKE7, but still know how to read/write BLAKE3.
+///
+/// Even just for BLAKE3, it would be useful to have these values:
+///
+///     BLAKE3     => 32B hash from BLAKE3
+///     BLAKE3_16B => 16B hash from BLAKE3 (truncated)
+///
+/// ... where BLAKE3_16 uses \a TruncatedBLAKE3<16>.
+///
+/// Motivation for a truncated hash is that it's cheaper to store. It's not
+/// clear if we always (or ever) need the full 32B, and for an ephemeral
+/// in-memory CAS, we almost certainly don't need it.
+///
+/// Note that the cost is linear in the number of objects for the builtin CAS
+/// and embedded action cache, since we're using internal offsets and/or
+/// pointers as an optimization.
+///
+/// However, it's possible we'll want to hook up a local builtin CAS to, e.g.,
+/// a distributed generic hash map to use as an ActionCache. In that scenario,
+/// the transitive closure of the structured objects that are the results of
+/// the cached actions would need to be serialized into the map, something
+/// like:
+///
+///     "action:<schema>:<key>" -> "0123"
+///     "object:<schema>:0123"  -> "3,4567,89AB,CDEF,9,some data"
+///     "object:<schema>:4567"  -> ...
+///     "object:<schema>:89AB"  -> ...
+///     "object:<schema>:CDEF"  -> ...
+///
+/// These references would be full cost.
+using HasherT = BLAKE3;
 using HashType = decltype(HasherT::hash(std::declval<ArrayRef<uint8_t> &>()));
 
 class BuiltinCAS : public CASDB {
   void printIDImpl(raw_ostream &OS, const CASID &ID) const final;
 
 public:
+  /// Get the name of the hash for any table identifiers.
+  ///
+  /// FIXME: This should be configurable via an enum, with at the following values:
+  ///
+  ///     "BLAKE3"    => 32B hash from BLAKE3
+  ///     "BLAKE3.16" => 16B hash from BLAKE3 (truncated)
+  ///
+  /// Enum can be sent into \a createInMemoryCAS() and \a createOnDiskCAS().
+  static StringRef getHashName() { return "BLAKE3"; }
   StringRef getHashSchemaIdentifier() const final {
-    return "llvm.cas.builtin.v1[SHA1]";
+    static const std::string ID =
+        ("llvm.cas.builtin.v1[" + getHashName() + "]").str();
+    return ID;
   }
 
   Expected<CASID> parseID(StringRef Reference) final;

--- a/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
+++ b/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
@@ -15,7 +15,6 @@
 #include "llvm/CAS/HierarchicalTreeBuilder.h"
 #include "llvm/Support/AlignOf.h"
 #include "llvm/Support/Allocator.h"
-#include "llvm/Support/SHA1.h"
 #include <mutex>
 
 // FIXME: Put the functions we need in FileSystem.h.

--- a/llvm/lib/CAS/OnDiskCAS.cpp
+++ b/llvm/lib/CAS/OnDiskCAS.cpp
@@ -643,14 +643,35 @@ struct OnDiskObjectProxy {
 /// Here's a top-level description of the current layout (could expose or make
 /// this configurable in the future).
 ///
-/// Files:
-/// - db/v1.index: HashMappedTrie(name="cas.hashes[<hashname>]")
-/// - db/v1.data: DataStore(name="cas.objects[64K]") for objects <64KB
-/// - db/v1.<TrieRecordOffset>: Objects >=64KB
+/// Files, each with a prefix set by \a FilePrefix():
 ///
-/// In theory, these could all be in one file (using a root record that points
-/// at the two types of stores), but splitting the files enables setting
-/// different max settings.
+/// - db/<prefix>.index: a file for the "index" table, named by \a
+///   getIndexTableName() and managed by \a HashMappedTrie. The contents are 8B
+///   that are accessed atomically, describing the object kind and where/how
+///   it's stored (including an optional file offset). See \a TrieRecord for
+///   more details.
+/// - db/<prefix>.data: a file for the "data" table, named by \a
+///   getDataPoolTableName() and managed by \a DataStore. New objects within
+///   TrieRecord::MaxEmbeddedSize are inserted here as either \a
+///   TrieRecord::StorageKind::DataPool or
+///   TrieRecord::StorageKind::DataPoolString2B.
+///     - db/<prefix>.<offset>.data: a file storing an object outside the main
+///       "data" table, named by its offset into the "index" table, with the
+///       format of \a TrieRecord::StorageKind::Standalone.
+///     - db/<prefix>.<offset>.blob: a file storing a blob object outside the
+///       main "data" table, named by its offset into the "index" table, with
+///       the format of \a TrieRecord::StorageKind::StandaloneBlob.
+///     - db/<prefix>.<offset>.blob0: a file storing a blob object outside the
+///       main "data" table, named by its offset into the "index" table, with
+///       the format of \a TrieRecord::StorageKind::StandaloneBlob0.
+/// - db/<prefix>.actions: a file for the "actions" table, named by \a
+///   getActionCacheTableName() and managed by \a HashMappedTrie. The contents
+///   are \a CASID::getInternalID(), stored as \a ActionCacheResultT;
+///   effectively, a pointer into the "index" table.
+///
+/// The "index", "data", and "actions" tables could be stored in a single file,
+/// (using a root record that points at the two types of stores), but splitting
+/// the files seems more convenient for now.
 ///
 /// Eventually: update UniqueID/CASID to store:
 /// - uint64_t: for BuiltinCAS, this is a pointer to Trie record

--- a/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
+++ b/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
@@ -660,7 +660,7 @@ OnDiskHashMappedTrie::recoverFromFileOffset(FileOffset Offset) const {
   // Check bounds.
   const uint64_t CurrentFileSize = Impl->File.getAlloc().size();
   if (Offset.get() > (int64_t)CurrentFileSize ||
-      Offset.get() + Impl->Trie.getRecordSize() >= CurrentFileSize)
+      Offset.get() + Impl->Trie.getRecordSize() > CurrentFileSize)
     return const_pointer();
 
   // Looks okay...

--- a/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
+++ b/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
@@ -658,9 +658,12 @@ OnDiskHashMappedTrie::recoverFromFileOffset(FileOffset Offset) const {
     return const_pointer();
 
   // Check bounds.
-  const uint64_t CurrentFileSize = Impl->File.getAlloc().size();
-  if (Offset.get() > (int64_t)CurrentFileSize ||
-      Offset.get() + Impl->Trie.getRecordSize() > CurrentFileSize)
+  //
+  // Note: There's no potential overflow when using \c uint64_t because Offset
+  // is in \c [0,INT64_MAX] and the record size is in \c [0,UINT32_MAX].
+  assert(Offset.get() >= 0 && "Expected FileOffset constructor guarantee this");
+  if ((uint64_t)Offset.get() + Impl->Trie.getRecordSize() >
+      Impl->File.getAlloc().size())
     return const_pointer();
 
   // Looks okay...

--- a/llvm/unittests/CAS/CASDBTest.cpp
+++ b/llvm/unittests/CAS/CASDBTest.cpp
@@ -40,6 +40,25 @@ protected:
   }
 };
 
+TEST_P(CASDBTest, PrintIDs) {
+  std::unique_ptr<CASDB> CAS = createCAS();
+  ExitOnError ExitOnErr("PrintID");
+
+  Optional<CASID> ID1, ID2;
+  ASSERT_THAT_ERROR(CAS->createBlob("1").moveInto(ID1), Succeeded());
+  ASSERT_THAT_ERROR(CAS->createBlob("2").moveInto(ID2), Succeeded());
+  EXPECT_NE(ID1, ID2);
+  std::string PrintedID1 = ID1->toString();
+  std::string PrintedID2 = ID2->toString();
+  EXPECT_NE(PrintedID1, PrintedID2);
+
+  Optional<CASID> ParsedID1, ParsedID2;
+  ASSERT_THAT_ERROR(CAS->parseID(PrintedID1).moveInto(ParsedID1), Succeeded());
+  ASSERT_THAT_ERROR(CAS->parseID(PrintedID2).moveInto(ParsedID2), Succeeded());
+  EXPECT_EQ(ID1, ParsedID1);
+  EXPECT_EQ(ID2, ParsedID2);
+}
+
 TEST_P(CASDBTest, Blobs) {
   std::unique_ptr<CASDB> CAS1 = createCAS();
   StringRef ContentStrings[] = {

--- a/llvm/unittests/CAS/CMakeLists.txt
+++ b/llvm/unittests/CAS/CMakeLists.txt
@@ -11,6 +11,7 @@ add_llvm_unittest(CASTests
   CASUtilsTest.cpp
   CachingOnDiskFileSystemTest.cpp
   HashMappedTrieTest.cpp
+  OnDiskHashMappedTrieTest.cpp
   HierarchicalTreeBuilderTest.cpp
   )
 

--- a/llvm/unittests/CAS/HashMappedTrieTest.cpp
+++ b/llvm/unittests/CAS/HashMappedTrieTest.cpp
@@ -9,6 +9,7 @@
 #include "llvm/CAS/HashMappedTrie.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/Endian.h"
+#include "llvm/Support/SHA1.h"
 #include "gtest/gtest.h"
 
 using namespace llvm;

--- a/llvm/unittests/CAS/OnDiskHashMappedTrieTest.cpp
+++ b/llvm/unittests/CAS/OnDiskHashMappedTrieTest.cpp
@@ -21,10 +21,14 @@ namespace {
 TEST(OnDiskHashMappedTrieTest, Insertion) {
   unittest::TempDir Temp("on-disk-hash-mapped-trie", /*Unique=*/true);
 
-  // Create tries with various sizes of "hash" and with data. We want to check
-  // hash sizes that are either 8B-aligned or not.
+  // Create tries with various sizes of hash and with data.
+  //
+  // NOTE: The check related to \a recoverFromFileOffset() catches a potential
+  // off-by-one bounds-checking bug when the trie record size (data + hash) add
+  // up to a multiple of 8B. Iterate through a few different hash sizes to
+  // check it both ways.
   constexpr size_t MB = 1024u * 1024u;
-  constexpr size_t DataSize = 8; // 8B-aligned.
+  constexpr size_t DataSize = 8; // Multiple of 8B.
   for (size_t NumHashBytes : {1, 2, 4, 8}) {
     size_t NumHashBits = NumHashBytes * 8;
 

--- a/llvm/unittests/CAS/OnDiskHashMappedTrieTest.cpp
+++ b/llvm/unittests/CAS/OnDiskHashMappedTrieTest.cpp
@@ -1,0 +1,141 @@
+//===- OnDiskHashMappedTrieTest.cpp ---------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/OnDiskHashMappedTrie.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Alignment.h"
+#include "llvm/Testing/Support/Error.h"
+#include "llvm/Testing/Support/SupportHelpers.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+
+namespace {
+
+TEST(OnDiskHashMappedTrieTest, Insertion) {
+  unittest::TempDir Temp("on-disk-hash-mapped-trie", /*Unique=*/true);
+
+  // Create tries with various sizes of "hash" and with data. We want to check
+  // hash sizes that are either 8B-aligned or not.
+  constexpr size_t MB = 1024u * 1024u;
+  constexpr size_t DataSize = 8; // 8B-aligned.
+  for (size_t NumHashBytes : {1, 2, 4, 8}) {
+    size_t NumHashBits = NumHashBytes * 8;
+
+    auto createTrie = [&]() {
+      return OnDiskHashMappedTrie::create(
+          Temp.path((Twine(NumHashBytes) + "B").str()), "index",
+          /*NumHashBits=*/NumHashBits, DataSize, /*MaxFileSize=*/MB,
+          /*NewInitialFileSize=*/None);
+    };
+
+    Optional<OnDiskHashMappedTrie> Trie1;
+    ASSERT_THAT_ERROR(createTrie().moveInto(Trie1), Succeeded());
+    Optional<OnDiskHashMappedTrie> Trie2;
+    ASSERT_THAT_ERROR(createTrie().moveInto(Trie2), Succeeded());
+
+    uint8_t Hash0Bytes[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t Hash1Bytes[8] = {1, 0, 0, 0, 0, 0, 0, 0};
+    auto Hash0 = makeArrayRef(Hash0Bytes).take_front(NumHashBytes);
+    auto Hash1 = makeArrayRef(Hash1Bytes).take_front(NumHashBytes);
+    constexpr StringLiteral Data0v1Bytes = "data0.v1";
+    constexpr StringLiteral Data0v2Bytes = "data0.v2";
+    constexpr StringLiteral Data1Bytes = "data1...";
+    static_assert(Data0v1Bytes.size() == DataSize, "math error");
+    static_assert(Data0v2Bytes.size() == DataSize, "math error");
+    static_assert(Data1Bytes.size() == DataSize, "math error");
+    ArrayRef<char> Data0v1 =
+        makeArrayRef(Data0v1Bytes.data(), Data0v1Bytes.size());
+    ArrayRef<char> Data0v2 =
+        makeArrayRef(Data0v2Bytes.data(), Data0v2Bytes.size());
+    ArrayRef<char> Data1 = makeArrayRef(Data1Bytes.data(), Data1Bytes.size());
+
+    // Lookup when trie is empty.
+    EXPECT_FALSE(Trie1->find(Hash0));
+
+    // Insert.
+    Optional<FileOffset> Offset;
+    Optional<MutableArrayRef<char>> Data;
+    {
+      auto Insertion = Trie1->insert({Hash0, Data0v1});
+      ASSERT_TRUE(Insertion);
+      EXPECT_EQ(Hash0, Insertion->Hash);
+      EXPECT_EQ(Data0v1, Insertion->Data);
+      EXPECT_TRUE(isAddrAligned(Align(8), Insertion->Data.data()));
+
+      Offset = Insertion.getOffset();
+      Data = Insertion->Data;
+    }
+
+    // Find.
+    {
+      auto Lookup = Trie1->find(Hash0);
+      ASSERT_TRUE(Lookup);
+      EXPECT_EQ(Hash0, Lookup->Hash);
+      EXPECT_EQ(Data0v1, Lookup->Data);
+      EXPECT_EQ(Offset->get(), Lookup.getOffset().get());
+    }
+
+    // Find in a different instance of the same on-disk trie that existed
+    // before the insertion.
+    {
+      auto Lookup = Trie2->find(Hash0);
+      ASSERT_TRUE(Lookup);
+      EXPECT_EQ(Hash0, Lookup->Hash);
+      EXPECT_EQ(Data0v1, Lookup->Data);
+      EXPECT_EQ(Offset->get(), Lookup.getOffset().get());
+    }
+
+    // Create a new instance and check that too.
+    Trie2.reset();
+    ASSERT_THAT_ERROR(createTrie().moveInto(Trie2), Succeeded());
+    {
+      auto Lookup = Trie2->find(Hash0);
+      ASSERT_TRUE(Lookup);
+      EXPECT_EQ(Hash0, Lookup->Hash);
+      EXPECT_EQ(Data0v1, Lookup->Data);
+      EXPECT_EQ(Offset->get(), Lookup.getOffset().get());
+    }
+
+    // Change the data.
+    llvm::copy(Data0v2, Data->data());
+    {
+      auto Lookup = Trie2->find(Hash0);
+      ASSERT_TRUE(Lookup);
+      EXPECT_EQ(Hash0, Lookup->Hash);
+      EXPECT_EQ(Data0v2, Lookup->Data);
+      EXPECT_EQ(Offset->get(), Lookup.getOffset().get());
+    }
+
+    // Find different hash.
+    EXPECT_FALSE(Trie1->find(Hash1));
+    EXPECT_FALSE(Trie2->find(Hash1));
+
+    // Recover from an offset.
+    {
+      auto Recovered = Trie1->recoverFromFileOffset(*Offset);
+      ASSERT_TRUE(Recovered);
+      EXPECT_EQ(Offset->get(), Recovered.getOffset().get());
+      EXPECT_EQ(Hash0, Recovered->Hash);
+      EXPECT_EQ(Data0v2, Recovered->Data);
+    }
+
+    // Insert another thing.
+    {
+      auto Insertion = Trie1->insert({Hash1, Data1});
+      ASSERT_TRUE(Insertion);
+      EXPECT_EQ(Hash1, Insertion->Hash);
+      EXPECT_EQ(Data1, Insertion->Data);
+      EXPECT_TRUE(isAddrAligned(Align(8), Insertion->Data.data()));
+      EXPECT_NE(Offset->get(), Insertion.getOffset().get());
+    }
+  }
+}
+
+} // namespace


### PR DESCRIPTION
Really we should be adding an enum to choose, but that's kind of hard.
For now, I've reduced the places that name the hash down to two -- a
typedef and BuiltinCAS::getHashName() -- and added some FIXMEs to both
locations that sketch what it could look like.

Why is it hard? Mainly because we'd need to deal with error paths, such
as opening a valid builtin CAS that had a different hash function than
the new/current configuration. Not insurmountable, but let's just move
over.

The downside is that landing this will require a "flag day". Compilers
with this patch can't co-exist with compilers that lack this.

This PR also includes a prep commit "CAS: Remove unused includes of llvm/Support/SHA1.h": cdef20fb1629743b983889de32ea8a35e6dee2b9.