### PR TITLE
[lldb] Explicitly declare the default constructor in PlatformAndroidR…

### DIFF
--- a/lldb/source/Plugins/Platform/Android/PlatformAndroidRemoteGDBServer.h
+++ b/lldb/source/Plugins/Platform/Android/PlatformAndroidRemoteGDBServer.h
@@ -24,7 +24,7 @@ namespace platform_android {
 class PlatformAndroidRemoteGDBServer
     : public platform_gdb_server::PlatformRemoteGDBServer {
 public:
-  using PlatformRemoteGDBServer::PlatformRemoteGDBServer;
+  PlatformAndroidRemoteGDBServer() = default;
 
   ~PlatformAndroidRemoteGDBServer() override;
 


### PR DESCRIPTION
…emoteGDBServer

MSVC does not seem to like the inheriting constructor.

(cherry picked from commit 4977da2c555b0a8d49be68bad4c54b816d7cc908)