### PR TITLE
[OnDiskCAS] makeProxy should return error when type doesn't match

### DIFF
--- a/llvm/test/tools/llvm-cas/ingest.test
+++ b/llvm/test/tools/llvm-cas/ingest.test
@@ -23,3 +23,6 @@ CHECK-TEST-FILE: test
 RUN: not llvm-cas --cas  %t/cas --get-cas-id --data %s @%t/cas.id 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 
 CHECK-ERROR: llvm-cas: get-cas-id: No such file or directory
+
+RUN: not llvm-cas --cas  %t/cas --ls-node-refs @%t/cas.id 2>&1 | FileCheck %s --check-prefix=CHECK-WRONG-TYPE
+CHECK-WRONG-TYPE: llvm-cas: ls-node-refs: invalid object

--- a/llvm/test/tools/llvm-cas/make-node.test
+++ b/llvm/test/tools/llvm-cas/make-node.test
@@ -35,3 +35,6 @@ RUN: llvm-cas --cas %t/cas --ls-node-refs @%t/complex.casid |\
 RUN:   FileCheck %t/complex.check
 COMPLEX-KIND: node
 COMPLEX-DATA: content
+
+RUN: not llvm-cas --cas  %t/cas --ls-tree @%t/complex.casid 2>&1 | FileCheck %s --check-prefix=CHECK-WRONG-TYPE
+CHECK-WRONG-TYPE: llvm-cas: ls-tree: invalid object


### PR DESCRIPTION
When makeNode/Tree/Blob is used, it should return error if the
TrieRecord type doesn't match the object kind requested.