### PR TITLE
Add a setting to not require --overwrite to overwrite commands.

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandInterpreter.h
+++ b/lldb/include/lldb/Interpreter/CommandInterpreter.h
@@ -548,6 +548,8 @@ public:
   void SetEchoCommentCommands(bool enable);
 
   bool GetRepeatPreviousCommand() const;
+  
+  bool GetRequireCommandOverwrite() const;
 
   const CommandObject::CommandMap &GetUserCommands() const {
     return m_user_dict;

--- a/lldb/source/Commands/CommandObjectCommands.cpp
+++ b/lldb/source/Commands/CommandObjectCommands.cpp
@@ -1450,7 +1450,7 @@ protected:
           m_short_help = std::string(option_arg);
         break;
       case 'o':
-        m_overwrite = true;
+        m_overwrite_lazy = eLazyBoolYes;
         break;
       case 's':
         m_synchronicity =
@@ -1472,7 +1472,7 @@ protected:
       m_class_name.clear();
       m_funct_name.clear();
       m_short_help.clear();
-      m_overwrite = false;
+      m_overwrite_lazy = eLazyBoolCalculate;
       m_synchronicity = eScriptedCommandSynchronicitySynchronous;
     }
 
@@ -1485,7 +1485,7 @@ protected:
     std::string m_class_name;
     std::string m_funct_name;
     std::string m_short_help;
-    bool m_overwrite;
+    LazyBool m_overwrite_lazy;
     ScriptedCommandSynchronicity m_synchronicity =
         eScriptedCommandSynchronicitySynchronous;
   };
@@ -1504,7 +1504,6 @@ protected:
 
     ScriptInterpreter *interpreter = GetDebugger().GetScriptInterpreter();
     if (interpreter) {
-
       StringList lines;
       lines.SplitIntoLines(data);
       if (lines.GetSize() > 0) {
@@ -1567,8 +1566,19 @@ protected:
       result.AppendError("'command script add' requires at least one argument");
       return false;
     }
-    // Store the options in case we get multi-line input
-    m_overwrite = m_options.m_overwrite;
+    // Store the options in case we get multi-line input, also figure out the
+    // default if not user supplied:
+    switch (m_options.m_overwrite_lazy) {
+      case eLazyBoolCalculate:
+        m_overwrite = !GetDebugger().GetCommandInterpreter().GetRequireCommandOverwrite();
+        break;
+      case eLazyBoolYes:
+        m_overwrite = true;
+        break;
+      case eLazyBoolNo:
+        m_overwrite = false;
+    }
+    
     Status path_error;
     m_container = GetCommandInterpreter().VerifyUserMultiwordCmdPath(
         command, true, path_error);
@@ -1642,8 +1652,9 @@ protected:
   std::string m_cmd_name;
   CommandObjectMultiword *m_container = nullptr;
   std::string m_short_help;
-  bool m_overwrite;
-  ScriptedCommandSynchronicity m_synchronicity;
+  bool m_overwrite = eLazyBoolCalculate;
+  ScriptedCommandSynchronicity m_synchronicity =
+      eScriptedCommandSynchronicitySynchronous;
 };
 
 // CommandObjectCommandsScriptList

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -241,6 +241,12 @@ bool CommandInterpreter::GetRepeatPreviousCommand() const {
       nullptr, idx, g_interpreter_properties[idx].default_uint_value != 0);
 }
 
+bool CommandInterpreter::GetRequireCommandOverwrite() const {
+  const uint32_t idx = ePropertyRequireCommandOverwrite;
+  return m_collection_sp->GetPropertyAtIndexAsBoolean(
+      nullptr, idx, g_interpreter_properties[idx].default_uint_value != 0);
+}
+
 void CommandInterpreter::Initialize() {
   LLDB_SCOPED_TIMER();
 

--- a/lldb/source/Interpreter/InterpreterProperties.td
+++ b/lldb/source/Interpreter/InterpreterProperties.td
@@ -36,4 +36,8 @@ let Definition = "interpreter" in {
     Global,
     DefaultTrue,
     Desc<"If true, LLDB will repeat the previous command if no command was passed to the interpreter. If false, LLDB won't repeat the previous command but only return a new prompt.">;
+  def RequireCommandOverwrite: Property<"require-overwrite", "Boolean">,
+    Global,
+    DefaultTrue,
+    Desc<"If true, require --overwrite in 'command script add' before overwriting existing user commands.">;
 }

--- a/lldb/test/API/commands/command/container/TestContainerCommands.py
+++ b/lldb/test/API/commands/command/container/TestContainerCommands.py
@@ -57,8 +57,9 @@ class TestCmdContainer(TestBase):
         self.expect("test-multi test-multi-sub welcome friend", "Test command works",
                     substrs=["Hello friend, welcome to LLDB"])
 
-        # Make sure overwriting works, first the leaf command:
-        # We should not be able to remove extant commands by default:
+        # Make sure overwriting works on the leaf command.  First using the
+        # explicit option so we should not be able to remove extant commands by default:
+
         self.expect("command script add -c welcome.WelcomeCommand2 test-multi test-multi-sub welcome",
                     "overwrite command w/o -o",
                     substrs=["cannot add command: sub-command already exists"], error=True)
@@ -67,8 +68,14 @@ class TestCmdContainer(TestBase):
         # Make sure we really did overwrite:
         self.expect("test-multi test-multi-sub welcome friend", "Used the new command class",
                     substrs=["Hello friend, welcome again to LLDB"])
-
-        self.expect("apropos welcome", "welcome should show up in apropos", substrs=["Just a docstring for the second Welcome"])
+        self.expect("apropos welcome", "welcome should show up in apropos", substrs=["A docstring for the second Welcome"])
+        
+        # Now switch the default and make sure we can now delete w/o the overwrite option:
+        self.runCmd("settings set interpreter.require-overwrite 0")
+        self.runCmd("command script add -c welcome.WelcomeCommand test-multi test-multi-sub welcome")
+        # Make sure we really did overwrite:
+        self.expect("test-multi test-multi-sub welcome friend", "Used the new command class",
+                    substrs=["Hello friend, welcome to LLDB"])
         
         # Make sure we give good errors when the input is wrong:
         self.expect("command script delete test-mult test-multi-sub welcome", "Delete script command - wrong first path component",


### PR DESCRIPTION
Protecting against accidental overwriting of commands is good, but
having to pass a flag to overwrite the command when developing your
commands is pretty annoying.  This adds a setting to defeat the protection
so you can do this once at the start of your session and not have to
worry about it again.

Differential Revision: https://reviews.llvm.org/D122680

(cherry picked from commit 1f7b58f2a50461493f083b2ed807b25e036286f6)