### PR TITLE
[lldb] Remove lldbassert from CommandInterpreter::PrintCommandOutput

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -2982,24 +2982,18 @@ void CommandInterpreter::PrintCommandOutput(IOHandler &io_handler,
   lldb::StreamFileSP stream = is_stdout ? io_handler.GetOutputStreamFileSP()
                                         : io_handler.GetErrorStreamFileSP();
   // Split the output into lines and poll for interrupt requests
-  const char *data = str.data();
   size_t size = str.size();
   while (size > 0 && !WasInterrupted()) {
-    size_t chunk_size = 0;
-    for (; chunk_size < size; ++chunk_size) {
-      lldbassert(data[chunk_size] != '\0');
-      if (data[chunk_size] == '\n') {
-        ++chunk_size;
-        break;
-      }
-    }
+    llvm::StringRef line;
+    size_t written = 0;
+    std::tie(line, str) = str.split('\n');
     {
       std::lock_guard<std::recursive_mutex> guard(io_handler.GetOutputMutex());
-      chunk_size = stream->Write(data, chunk_size);
+      written += stream->Write(line.data(), line.size());
+      written += stream->Write("\n", 1);
     }
-    lldbassert(size >= chunk_size);
-    data += chunk_size;
-    size -= chunk_size;
+    lldbassert(size >= written);
+    size -= written;
   }
 
   std::lock_guard<std::recursive_mutex> guard(io_handler.GetOutputMutex());


### PR DESCRIPTION
The assertion checks that the command output doesn't contain any null
bytes. I'm not sure if the intention was to make sure the string wasn't
shorter than the reported length or if this was a way to catch us
accidentally writing an (unformatted) null byte.

The consensus is that we don't want to have embedded nulls in the
command output, but that this isn't the right place to enforce that.

Differential revision: https://reviews.llvm.org/D122025

(cherry picked from commit b0f1f3b95cd5f3e951e316fea39feca9a2878942)
