### PR TITLE
[debug-info] Only hoist the first dbg inst associated with an async debug variable.

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -738,13 +738,6 @@ static bool Evaluate_DW_OP_entry_value(std::vector<Value> &stack,
     return false;
   }
 
-  Function *parent_func =
-      parent_frame->GetSymbolContext(eSymbolContextFunction).function;
-  if (!parent_func) {
-    LLDB_LOG(log, "Evaluate_DW_OP_entry_value: no parent function");
-    return false;
-  }
-
   // 2. Find the call edge in the parent function responsible for creating the
   //    current activation.
   Function *current_func =
@@ -758,6 +751,7 @@ static bool Evaluate_DW_OP_entry_value(std::vector<Value> &stack,
   ModuleList &modlist = target.GetImages();
   ExecutionContext parent_exe_ctx = *exe_ctx;
   parent_exe_ctx.SetFrameSP(parent_frame);
+  Function *parent_func = nullptr;
 #ifdef LLDB_ENABLE_SWIFT
   // Swift async function arguments are represented relative to a
   // DW_OP_entry_value that fetches the async context register. This
@@ -767,6 +761,14 @@ static bool Evaluate_DW_OP_entry_value(std::vector<Value> &stack,
   auto fn_name = current_func->GetMangled().GetMangledName().GetStringRef();
   if (!SwiftLanguageRuntime::IsAnySwiftAsyncFunctionSymbol(fn_name)) {
 #endif
+
+  parent_func =
+    parent_frame->GetSymbolContext(eSymbolContextFunction).function;
+  if (!parent_func) {
+    LLDB_LOG(log, "Evaluate_DW_OP_entry_value: no parent function");
+    return false;
+  }
+
   if (!parent_frame->IsArtificial()) {
     // If the parent frame is not artificial, the current activation may be
     // produced by an ambiguous tail call. In this case, refuse to proceed.
@@ -852,7 +854,8 @@ static bool Evaluate_DW_OP_entry_value(std::vector<Value> &stack,
   }
   llvm::Optional<DWARFExpression> subexpr;
   if (!matched_param) {
-    subexpr.emplace(parent_func->CalculateSymbolContextModule(),
+    auto *ctx_func = parent_func ? parent_func : current_func;
+    subexpr.emplace(ctx_func->CalculateSymbolContextModule(),
                     DataExtractor(opcodes, subexpr_offset, subexpr_len),
                     dwarf_cu);
   }

--- a/lldb/test/API/lang/swift/variables/move_function/TestSwiftMoveFunction.py
+++ b/lldb/test/API/lang/swift/variables/move_function/TestSwiftMoveFunction.py
@@ -134,16 +134,16 @@ class TestSwiftMoveFunctionType(TestBase):
         self.assertIsNone(varK.value, "varK initialized too early?!")
 
         # Go to break point 2. k should be valid.
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
 
         # Go to breakpoint 3. k should no longer be valid.
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertIsNone(varK.value, "K is live but was moved?!")
 
         # Run so we hit the next breakpoint to jump to the next test's
         # breakpoint.
-        self.runCmd('continue')
+        self.process.Continue()
 
     def do_check_copyable_var_test(self):
         # We haven't defined varK yet.
@@ -151,20 +151,20 @@ class TestSwiftMoveFunctionType(TestBase):
         self.assertIsNone(varK.value, "varK initialized too early?!")
 
         # Go to break point 2. k should be valid.
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
 
         # Go to breakpoint 3. We invalidated k
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertIsNone(varK.value, "K is live but was moved?!")
 
         # Go to the last breakpoint and make sure that k is reinitialized
         # properly.
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertGreater(varK.unsigned, 0, "varK not initialized")
 
         # Run so we hit the next breakpoint to go to the next test.
-        self.runCmd('continue')
+        self.process.Continue()
 
     def do_check_addressonly_value_test(self):
         # We haven't defined varK yet.
@@ -175,35 +175,35 @@ class TestSwiftMoveFunctionType(TestBase):
         # so we don't do so. We have an additional llvm.dbg.addr test where we
         # move the other variable and show the correct behavior with
         # llvm.dbg.declare.
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertGreater(varK.unsigned, 0, "var not initialized?!")
 
         # Go to breakpoint 3.
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertEqual(varK.unsigned, 0,
                         "dbg thinks varK is live despite move?!")
 
         # Run so we hit the next breakpoint as part of the next test.
-        self.runCmd('continue')
+        self.process.Continue()
 
     def do_check_addressonly_var_test(self):
         varK = self.get_var('k')
 
         # Go to break point 2. k should be valid.
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
 
         # Go to breakpoint 3. K was invalidated.
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertIsNone(varK.value, "K is live but was moved?!")
 
         # Go to the last breakpoint and make sure that k is reinitialized
         # properly.
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertGreater(varK.unsigned, 0, "varK not initialized")
 
         # Run so we hit the next breakpoint as part of the next test.
-        self.runCmd('continue')
+        self.process.Continue()
 
     def do_check_copyable_value_arg_test(self):
         # k is defined by the argument so it is valid.
@@ -211,16 +211,16 @@ class TestSwiftMoveFunctionType(TestBase):
         self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
 
         # Go to break point 2. k should be valid.
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
 
         # Go to breakpoint 3. k should no longer be valid.
-        self.runCmd('continue')
+        self.process.Continue()
         #self.assertIsNone(varK.value, "K is live but was moved?!")
 
         # Run so we hit the next breakpoint to jump to the next test's
         # breakpoint.
-        self.runCmd('continue')
+        self.process.Continue()
 
     def do_check_copyable_var_arg_test(self):
         # k is already defined and is an argument.
@@ -228,20 +228,20 @@ class TestSwiftMoveFunctionType(TestBase):
         self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
 
         # Go to break point 2. k should be valid.
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
 
         # Go to breakpoint 3. We invalidated k
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertIsNone(varK.value, "K is live but was moved?!")
 
         # Go to the last breakpoint and make sure that k is reinitialized
         # properly.
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertGreater(varK.unsigned, 0, "varK not initialized")
 
         # Run so we hit the next breakpoint to go to the next test.
-        self.runCmd('continue')
+        self.process.Continue()
 
     def do_check_addressonly_value_arg_test(self):
         # k is defined since it is an argument.
@@ -253,39 +253,39 @@ class TestSwiftMoveFunctionType(TestBase):
         # so we don't do so. We have an additional llvm.dbg.addr test where we
         # move the other variable and show the correct behavior with
         # llvm.dbg.declare.
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertGreater(varK.unsigned, 0, "var not initialized?!")
 
         # Go to breakpoint 3.
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertEqual(varK.unsigned, 0,
                         "dbg thinks varK is live despite move?!")
 
         # Run so we hit the next breakpoint as part of the next test.
-        self.runCmd('continue')
+        self.process.Continue()
 
     def do_check_addressonly_var_arg_test(self):
         varK = self.get_var('k')
         self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
 
         # Go to break point 2. k should be valid.
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
 
         # Go to breakpoint 3. K was invalidated.
-        self.runCmd('continue')
+        self.process.Continue()
         self.assertIsNone(varK.value, "K is live but was moved?!")
 
         # Go to the last breakpoint and make sure that k is reinitialized
         # properly.
-        self.runCmd('continue')
+        self.process.Continue()
         # There is some sort of bug here. We should have the value here. For now
         # leave the next line commented out and validate we are not seeing the
         # value so we can detect change in behavior.
         self.assertGreater(varK.unsigned, 0, "varK not initialized")
 
         # Run so we hit the next breakpoint as part of the next test.
-        self.runCmd('continue')
+        self.process.Continue()
 
     def do_check_copyable_value_ccf_true(self):
         varK = self.get_var('k')
@@ -293,28 +293,28 @@ class TestSwiftMoveFunctionType(TestBase):
         # Check at our start point that we do not have any state for varK and
         # then continue to our next breakpoint.
         self.assertIsNone(varK.value, "varK should not have a value?!")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # At this breakpoint, k should be defined since we are going to do
         # something with it.
         self.assertIsNotNone(varK.value, "varK should have a value?!")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # At this breakpoint, we are now in the conditional control flow part of
         # the loop. Make sure that we can see k still.
         self.assertIsNotNone(varK.value, "varK should have a value?!")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # Ok, we just performed the move. k should not be no longer initialized.
         self.assertIsNone(varK.value, "varK should not have a value?!")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # Finally we left the conditional control flow part of the function. k
         # should still be None.
         self.assertIsNone(varK.value, "varK should not have a value!")
 
         # Run again so we go and run to the next test.
-        self.runCmd('continue')
+        self.process.Continue()
 
     def do_check_copyable_value_ccf_false(self):
         varK = self.get_var('k')
@@ -322,12 +322,12 @@ class TestSwiftMoveFunctionType(TestBase):
         # Check at our start point that we do not have any state for varK and
         # then continue to our next breakpoint.
         self.assertIsNone(varK.value, "varK should not have a value?!")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # At this breakpoint, k should be defined since we are going to do
         # something with it.
         self.assertIsNotNone(varK.value, "varK should have a value?!")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # At this breakpoint, we are now past the end of the conditional
         # statement. We know due to the move checking that k can not have any
@@ -336,31 +336,31 @@ class TestSwiftMoveFunctionType(TestBase):
         self.assertIsNone(varK.value, "varK should have a value?!")
 
         # Run again so we go and run to the next test.
-        self.runCmd('continue')
+        self.process.Continue()
 
     def do_check_copyable_var_ccf_true_reinit_out_block(self):
         varK = self.get_var('k')
 
         # At first we should not have a value for k.
         self.assertEqual(varK.unsigned, 0, "varK should be nullptr!")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # Now we are in the conditional true block. K should be defined since we
         # are on the move itself.
         self.assertGreater(varK.unsigned, 0, "varK should not be nullptr!")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # Now we have executed the move and we are about to run code using
         # m. Make sure that K is not available!
         self.assertEqual(varK.unsigned, 0,
                          "varK was already moved! Should be nullptr")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # We are now out of the conditional lexical block on the line of code
         # that redefines k. k should still be not available.
         self.assertEqual(varK.unsigned, 0,
                          "varK was already moved! Should be nullptr")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # Ok, we have now reinit k and are about to call a method on it. We
         # should be valid now.
@@ -368,31 +368,31 @@ class TestSwiftMoveFunctionType(TestBase):
                            "varK should have be reinitialized?!")
 
         # Run again so we go and run to the next test.
-        self.runCmd('continue')
+        self.process.Continue()
 
     def do_check_copyable_var_ccf_true_reinit_in_block(self):
         varK = self.get_var('k')
 
         # At first we should not have a value for k.
         self.assertEqual(varK.unsigned, 0, "varK should be nullptr!")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # Now we are in the conditional true block. K should be defined since we
         # are on the move itself.
         self.assertGreater(varK.unsigned, 0, "varK should not be nullptr!")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # Now we have executed the move and we are about to reinit k but have
         # not yet. Make sure we are not available!
         self.assertEqual(varK.unsigned, 0,
                          "varK was already moved! Should be nullptr")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # We are now still inside the conditional part of the code, but have
         # reinitialized varK.
         self.assertGreater(varK.unsigned, 0,
                            "varK was reinit! Should be valid value!")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # We now have left the conditional part of the function. k should still
         # be available.
@@ -400,26 +400,26 @@ class TestSwiftMoveFunctionType(TestBase):
                            "varK should have be reinitialized?!")
 
         # Run again so we go and run to the next test.
-        self.runCmd('continue')
+        self.process.Continue()
 
     def do_check_copyable_var_ccf_false_reinit_out_block(self):
         varK = self.get_var('k')
 
         # At first we should not have a value for k.
         self.assertEqual(varK.unsigned, 0, "varK should be nullptr!")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # Now we are right above the beginning of the false check. varK should
         # still be valid.
         self.assertGreater(varK.unsigned, 0, "varK should not be nullptr!")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # Now we are after the conditional part of the code on the reinit
         # line. Since this is reachable from the move and we haven't reinit yet,
         # k should not be available.
         self.assertEqual(varK.unsigned, 0,
                          "varK was already moved! Should be nullptr")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # Ok, we have now reinit k and are about to call a method on it. We
         # should be valid now.
@@ -427,19 +427,19 @@ class TestSwiftMoveFunctionType(TestBase):
                            "varK should have be reinitialized?!")
 
         # Run again so we go and run to the next test.
-        self.runCmd('continue')
+        self.process.Continue()
 
     def do_check_copyable_var_ccf_false_reinit_in_block(self):
         varK = self.get_var('k')
 
         # At first we should not have a value for k.
         self.assertEqual(varK.unsigned, 0, "varK should be nullptr!")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # Now we are on the doSomething above the false check. So varK should be
         # valid.
         self.assertGreater(varK.unsigned, 0, "varK should not be nullptr!")
-        self.runCmd('continue')
+        self.process.Continue()
 
         # Now we are after the conditional scope. Since k was reinitialized in
         # the conditional scope, along all paths we are valid so varK should
@@ -448,4 +448,4 @@ class TestSwiftMoveFunctionType(TestBase):
                            "varK should not be nullptr?!")
 
         # Run again so we go and run to the next test.
-        self.runCmd('continue')
+        self.process.Continue()

--- a/lldb/test/API/lang/swift/variables/move_function/main.swift
+++ b/lldb/test/API/lang/swift/variables/move_function/main.swift
@@ -31,40 +31,40 @@ var falseBoolValue : Bool { false }
 //////////////////
 
 public func copyableValueTest() {
-    print("stop here") // Set breakpoint copyableValueTest here 1
+    print("stop here") // Set breakpoint
     let k = Klass()
     k.doSomething()
-    let m = _move(k) // Set breakpoint copyableValueTest here 2
-    m.doSomething() // Set breakpoint copyableValueTest here 3
+    let m = _move(k) // Set breakpoint
+    m.doSomething() // Set breakpoint
 }
 
 public func copyableVarTest() {
-    print("stop here") // Set breakpoint copyableVarTest here 1
+    print("stop here") // Set breakpoint
     var k = Klass()
     k.doSomething()
-    let m = _move(k) // Set breakpoint copyableVarTest here 2
+    let m = _move(k) // Set breakpoint
     m.doSomething()
-    k = Klass()     // Set breakpoint copyableVarTest here 3
-    k.doSomething() // Set breakpoint copyableVarTest here 4
+    k = Klass()     // Set breakpoint
+    k.doSomething() // Set breakpoint
     print("stop here")
 }
 
 public func addressOnlyValueTest<T : P>(_ x: T) {
-    print("stop here") // Set breakpoint addressOnlyValueTest here 1
+    print("stop here") // Set breakpoint
     let k = x
     k.doSomething()
-    let m = _move(k) // Set breakpoint addressOnlyValueTest here 2
-    m.doSomething() // Set breakpoint addressOnlyValueTest here 3
+    let m = _move(k) // Set breakpoint
+    m.doSomething() // Set breakpoint
 }
 
 public func addressOnlyVarTest<T : P>(_ x: T) {
-    print("stop here") // Set breakpoint addressOnlyVarTest here 1
+    print("stop here") // Set breakpoint
     var k = x
     k.doSomething()
-    let m = _move(k) // Set breakpoint addressOnlyVarTest here 2
+    let m = _move(k) // Set breakpoint
     m.doSomething()
-    k = x // Set breakpoint addressOnlyVarTest here 3
-    k.doSomething() // Set breakpoint addressOnlyVarTest here 4
+    k = x // Set breakpoint
+    k.doSomething() // Set breakpoint
 }
 
 //////////////////////
@@ -72,36 +72,36 @@ public func addressOnlyVarTest<T : P>(_ x: T) {
 //////////////////////
 
 public func copyableValueArgTest(_ k: __owned Klass) {
-    print("stop here") // Set breakpoint copyableValueArgTest here 1
+    print("stop here") // Set breakpoint
     k.doSomething()
-    let m = _move(k) // Set breakpoint copyableValueArgTest here 2
-    m.doSomething() // Set breakpoint copyableValueArgTest here 3
+    let m = _move(k) // Set breakpoint
+    m.doSomething() // Set breakpoint
 }
 
 public func copyableVarArgTest(_ k: inout Klass) {
-    print("stop here") // Set breakpoint copyableVarArgTest here 1
+    print("stop here") // Set breakpoint
     k.doSomething()
-    let m = _move(k) // Set breakpoint copyableVarArgTest here 2
+    let m = _move(k) // Set breakpoint
     m.doSomething()
-    k = Klass()     // Set breakpoint copyableVarArgTest here 3
-    k.doSomething() // Set breakpoint copyableVarArgTest here 4
+    k = Klass()     // Set breakpoint
+    k.doSomething() // Set breakpoint
     print("stop here")
 }
 
 public func addressOnlyValueArgTest<T : P>(_ k: __owned T) {
-    print("stop here") // Set breakpoint addressOnlyValueArgTest here 1
+    print("stop here") // Set breakpoint
     k.doSomething()
-    let m = _move(k) // Set breakpoint addressOnlyValueArgTest here 2
-    m.doSomething() // Set breakpoint addressOnlyValueArgTest here 3
+    let m = _move(k) // Set breakpoint
+    m.doSomething() // Set breakpoint
 }
 
 public func addressOnlyVarArgTest<T : P>(_ k: inout T, _ x: T) {
-    print("stop here") // Set breakpoint addressOnlyVarArgTest here 1
+    print("stop here") // Set breakpoint
     k.doSomething()
-    let m = _move(k) // Set breakpoint addressOnlyVarArgTest here 2
+    let m = _move(k) // Set breakpoint
     m.doSomething()
-    k = x // Set breakpoint addressOnlyVarArgTest here 3
-    k.doSomething() // Set breakpoint addressOnlyVarArgTest here 4
+    k = x // Set breakpoint
+    k.doSomething() // Set breakpoint
 }
 
 ////////////////////////////////////
@@ -109,68 +109,68 @@ public func addressOnlyVarArgTest<T : P>(_ k: inout T, _ x: T) {
 ////////////////////////////////////
 
 public func copyableValueCCFTrueTest() {
-    let k = Klass() // Set breakpoint copyableValueCCFTrueTest here 1
-    k.doSomething() // Set breakpoint copyableValueCCFTrueTest here 2
+    let k = Klass() // Set breakpoint
+    k.doSomething() // Set breakpoint
     if trueBoolValue {
-        let m = _move(k) // Set breakpoint copyableValueCCFTrueTest here 3
-        m.doSomething() // Set breakpoint copyableValueCCFTrueTest here 4
+        let m = _move(k) // Set breakpoint
+        m.doSomething() // Set breakpoint
     }
-    // Set breakpoint copyableValueCCFTrueTest here 5
+    // Set breakpoint
 }
 
 public func copyableValueCCFFalseTest() {
-    let k = Klass() // Set breakpoint copyableValueCCFFalseTest here 1
-    k.doSomething() // Set breakpoint copyableValueCCFFalseTest here 2
+    let k = Klass() // Set breakpoint
+    k.doSomething() // Set breakpoint
     if falseBoolValue {
         let m = _move(k)
         m.doSomething()
     }
-    // Set breakpoint copyableValueCCFFalseTest here 3
+    // Set breakpoint
 }
 
 public func copyableVarTestCCFlowTrueReinitOutOfBlockTest() {
-    var k = Klass() // Set breakpoint copyableVarTestCCFlowTrueReinitOutOfBlockTest here 1
+    var k = Klass() // Set breakpoint
     k.doSomething()
     if trueBoolValue {
-        let m = _move(k) // Set breakpoint copyableVarTestCCFlowTrueReinitOutOfBlockTest here 2
-        m.doSomething() // Set breakpoint copyableVarTestCCFlowTrueReinitOutOfBlockTest here 3
+        let m = _move(k) // Set breakpoint
+        m.doSomething() // Set breakpoint
     }
-    k = Klass() // Set breakpoint copyableVarTestCCFlowTrueReinitOutOfBlockTest here 4
-    k.doSomething() // Set breakpoint copyableVarTestCCFlowTrueReinitOutOfBlockTest here 5
+    k = Klass() // Set breakpoint
+    k.doSomething() // Set breakpoint
 }
 
 public func copyableVarTestCCFlowTrueReinitInBlockTest() {
-    var k = Klass() // Set breakpoint copyableVarTestCCFlowTrueReinitInBlockTest here 1
+    var k = Klass() // Set breakpoint
     k.doSomething()
     if trueBoolValue {
-        let m = _move(k) // Set breakpoint copyableVarTestCCFlowTrueReinitInBlockTest here 2
+        let m = _move(k) // Set breakpoint
         m.doSomething()
-        k = Klass() // Set breakpoint copyableVarTestCCFlowTrueReinitInBlockTest here 3
-        k.doSomething() // Set breakpoint copyableVarTestCCFlowTrueReinitInBlockTest here 4
+        k = Klass() // Set breakpoint
+        k.doSomething() // Set breakpoint
     }
-    k.doSomething() // Set breakpoint copyableVarTestCCFlowTrueReinitInBlockTest here 5
+    k.doSomething() // Set breakpoint
 }
 
 public func copyableVarTestCCFlowFalseReinitOutOfBlockTest() {
-    var k = Klass() // Set breakpoint copyableVarTestCCFlowFalseReinitOutOfBlockTest here 1
-    k.doSomething() // Set breakpoint copyableVarTestCCFlowFalseReinitOutOfBlockTest here 2
+    var k = Klass() // Set breakpoint
+    k.doSomething() // Set breakpoint
     if falseBoolValue {
         let m = _move(k)
         m.doSomething()
     }
-    k = Klass() // Set breakpoint copyableVarTestCCFlowFalseReinitOutOfBlockTest here 3
-    k.doSomething() // Set breakpoint copyableVarTestCCFlowFalseReinitOutOfBlockTest here 4
+    k = Klass() // Set breakpoint
+    k.doSomething() // Set breakpoint
 }
 
 public func copyableVarTestCCFlowFalseReinitInBlockTest() {
-    var k = Klass() // Set breakpoint copyableVarTestCCFlowFalseReinitInBlockTest here 1
-    k.doSomething()  // Set breakpoint copyableVarTestCCFlowFalseReinitInBlockTest here 2
+    var k = Klass() // Set breakpoint
+    k.doSomething()  // Set breakpoint
     if falseBoolValue {
         let m = _move(k)
         m.doSomething()
         k = Klass()
     }
-    k.doSomething() // Set breakpoint copyableVarTestCCFlowFalseReinitInBlockTest here 3
+    k.doSomething() // Set breakpoint
 }
 
 //////////////////////////

--- a/lldb/test/API/lang/swift/variables/move_function_async/Makefile
+++ b/lldb/test/API/lang/swift/variables/move_function_async/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/move_function_async/TestSwiftMoveFunctionAsync.py
+++ b/lldb/test/API/lang/swift/variables/move_function_async/TestSwiftMoveFunctionAsync.py
@@ -1,0 +1,157 @@
+# TestSwiftMoveFunctionAsync.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+"""
+Check that we properly show variables at various points of the CFG while
+stepping with the move function.
+"""
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import sys
+import unittest2
+
+def stderr_print(line):
+    sys.stderr.write(line + "\n")
+
+class TestSwiftMoveFunctionAsyncType(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    def test_swift_move_function_async(self):
+        """Check that we properly show variables at various points of the CFG while
+        stepping with the move function.
+        """
+        self.build()
+
+        self.target, self.process, self.thread, self.bkpt = \
+            lldbutil.run_to_source_breakpoint(
+                self, 'Set breakpoint', lldb.SBFileSpec('main.swift'))
+
+        # We setup a single breakpoint in copyable var test so we can disable it
+        # after we hit it.
+        self.do_setup_breakpoints()
+
+        self.do_check_copyable_value_test()
+        self.do_check_copyable_var_test()
+
+    def setUp(self):
+        TestBase.setUp(self)
+        self.main_source = "main.swift"
+        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+        self.exec_name = "a.out"
+
+    def get_var(self, name):
+        frame = self.thread.frames[0]
+        return frame.FindVariable(name)
+
+    def do_setup_breakpoints(self):
+        self.breakpoints = []
+        pattern = 'Special breakpoint'
+        brk = self.target.BreakpointCreateBySourceRegex(
+            pattern, self.main_source_spec)
+        self.assertGreater(brk.GetNumLocations(), 0, VALID_BREAKPOINT)
+        self.breakpoints.append(brk)
+
+    def do_check_copyable_value_test(self):
+        # We haven't defined varK yet.
+        varK = self.get_var('k')
+        self.assertEqual(varK.unsigned, 0, "varK initialized too early?!")
+
+        # Go to break point 2.1. k should be valid.
+        self.process.Continue()
+        varK = self.get_var('k')
+        self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
+
+        # Go to breakpoint 2.2. k should still be valid. And we should be on the
+        # other side of the force split.
+        self.process.Continue()
+        varK = self.get_var('k')
+        self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
+
+        # Go to breakpoint 3. k should still be valid. We should be at the move
+        # on the other side of the forceSplit.
+        self.process.Continue()
+        varK = self.get_var('k')
+        self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
+
+        # We are now at break point 4. We have moved k, it should be empty.
+        self.process.Continue()
+        varK = self.get_var('k')
+        self.assertIsNone(varK.value, "K is live but was moved?!")
+
+        # Finally, we are on the other side of the final force split. Make sure
+        # the value still isn't available.
+        self.process.Continue()
+        varK = self.get_var('k')
+        self.assertIsNone(varK.value, "K is live but was moved?!")
+
+        # Run so we hit the next breakpoint to jump to the next test's
+        # breakpoint.
+        self.process.Continue()
+
+    def do_check_copyable_var_test(self):
+        # We haven't defined varK yet.
+        varK = self.get_var('k')
+        self.assertEqual(varK.unsigned, 0, "varK initialized too early?!")
+
+        # Go to break point 2.1. k should be valid.
+        self.process.Continue()
+        varK = self.get_var('k')
+        self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
+
+        # Go to breakpoint 2.2. k should still be valid. And we should be on the
+        # other side of the force split.
+        self.process.Continue()
+        varK = self.get_var('k')
+        self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
+
+        # Go to breakpoint 3. k should still be valid. We should be at the move
+        # on the other side of the forceSplit.
+        self.process.Continue()
+        varK = self.get_var('k')
+        self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
+
+        # There is an instruction with the wrong debug location on Linux,
+        # causing us to jump back to 'step backwards' to an earlier location
+        # before we have run the move. So disable that breakpoint so when we
+        # continue, we get to the appropriate location on Linux and other
+        # platforms.
+        #
+        # TODO: Investigate why this is happening!
+        self.runCmd('# Skipping bad loc by disabling earlier break point 6')
+        self.runCmd('break dis 2')
+
+        # We are now at break point 4. We have moved k, it should be empty.
+        self.process.Continue()
+        varK = self.get_var('k')
+        self.assertIsNone(varK.value, "K is live but was moved?!")
+
+        # Now, we are on the other side of the final force split. Make sure
+        # the value still isn't available.
+        self.process.Continue()
+        self.runCmd('# On other side of force split')
+        varK = self.get_var('k')
+        self.assertIsNone(varK.value, "K is live but was moved?!")
+
+        # Finally, we have reinitialized k, look for k.
+        self.process.Continue()
+        self.runCmd('# After var reinit')
+        varK = self.get_var('k')
+        self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
+
+        # Run so we hit the next breakpoint to jump to the next test's
+        # breakpoint.
+        self.runCmd('# At end of routine!')
+        self.process.Continue()

--- a/lldb/test/API/lang/swift/variables/move_function_async/main.swift
+++ b/lldb/test/API/lang/swift/variables/move_function_async/main.swift
@@ -1,0 +1,56 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+
+public class Klass {
+    public func doSomething() {}
+}
+
+public func forceSplit() async {}
+
+//////////////////
+// Simple Tests //
+//////////////////
+
+public func copyableValueTest() async {
+    print("stop here") // Set breakpoint
+    let k = Klass()
+    k.doSomething()
+    await forceSplit() // Set breakpoint
+    let m = _move(k) // Set breakpoint
+    m.doSomething() // Set breakpoint
+    await forceSplit()
+    m.doSomething() // Set breakpoint
+}
+
+public func copyableVarTest() async {
+    print("stop here")
+    var k = Klass() // Special breakpoint
+    k.doSomething()
+    await forceSplit() // Set breakpoint
+    let m = _move(k) // Set breakpoint
+    m.doSomething() // Set breakpoint
+    await forceSplit()
+    k = Klass() // Set breakpoint
+    k.doSomething() // Set breakpoint
+    print("stop here")
+}
+
+//////////////////////////
+// Top Level Entrypoint //
+//////////////////////////
+
+@main struct Main {
+  static func main() async {
+      await copyableValueTest()
+      await copyableVarTest()
+  }
+}

--- a/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
@@ -2197,12 +2197,19 @@ bool VarLocBasedLDV::ExtendRanges(MachineFunction &MF,
   // function parameters in order to generate debug entry values for them.
   SmallVector<MachineInstr *, 8> AsyncDbgValues;
   MachineBasicBlock &First_MBB = *(MF.begin());
+  // Use a cache so that we only hoist the first swift async context debug inst
+  // for a specific DBG_VALUE. Otherwise, we may hoist inappropriately over a
+  // llvm.dbg.value.
+  SmallDenseSet<DebugVariable, 8> SeenDebugVars;
   for (auto &MI : First_MBB) {
     collectRegDefs(MI, DefinedRegs, TRI);
     if (MI.isDebugValue()) {
       // In Swift async functions entry values are preferred, since they
       // can be evaluated in both live frames and virtual backtraces.
-      if (isSwiftAsyncContext(MI)) {
+      if (SeenDebugVars.insert(DebugVariable(MI.getDebugVariable(),
+                                             MI.getDebugExpression(),
+                                             MI.getDebugLoc()->getInlinedAt())).second  &&
+          isSwiftAsyncContext(MI)) {
         // If our instruction is not an entry value yet, make it an entry value.
         if (!MI.getDebugExpression()->isEntryValue()) {
           MI.getOperand(3).setMetadata(DIExpression::prepend(


### PR DESCRIPTION
Otherwise, we may hoist a llvm.dbg.addr over another llvm.dbg.addr or
llvm.dbg.value, changing observable debugging state.

As an additional benefit, this finally lets me add straight line end to end lldb
tests for async var and lets. This was the last thing stopping me from doing that.