### PR TITLE
Prevent GetAugmentedArchSpec() from attaching "unknown" environments

### DIFF
--- a/lldb/source/Host/common/HostInfoBase.cpp
+++ b/lldb/source/Host/common/HostInfoBase.cpp
@@ -205,7 +205,8 @@ ArchSpec HostInfoBase::GetAugmentedArchSpec(llvm::StringRef triple) {
     normalized_triple.setVendor(host_triple.getVendor());
   if (normalized_triple.getOSName().empty())
     normalized_triple.setOS(host_triple.getOS());
-  if (normalized_triple.getEnvironmentName().empty())
+  if (normalized_triple.getEnvironmentName().empty() &&
+      !host_triple.getEnvironmentName().empty())
     normalized_triple.setEnvironment(host_triple.getEnvironment());
   return ArchSpec(normalized_triple);
 }

--- a/lldb/unittests/Host/HostInfoTest.cpp
+++ b/lldb/unittests/Host/HostInfoTest.cpp
@@ -43,6 +43,9 @@ TEST_F(HostInfoTest, GetAugmentedArchSpec) {
   // Test LLDB_ARCH_DEFAULT
   EXPECT_EQ(HostInfo::GetAugmentedArchSpec(LLDB_ARCH_DEFAULT).GetTriple(),
             HostInfo::GetArchitecture(HostInfo::eArchKindDefault).GetTriple());
+  EXPECT_NE(
+      HostInfo::GetAugmentedArchSpec("armv7k").GetTriple().getEnvironmentName(),
+      "unknown");
 }
 
 TEST_F(HostInfoTest, GetHostname) {


### PR DESCRIPTION
Environments are optional and a missing environment is distinct from
the default "unknown" environment enumerator.  The test is negative,
because the function uses the host triple and is unpredictable.

rdar://91007207

https://reviews.llvm.org/D122946

Differential Revision: https://reviews.llvm.org/D122946

(cherry picked from commit cf3e4011b57b07d88e3e577295c3327b07c15922)