### PR TITLE
The test added to TestContainerCommands.py cherry-picked

### DIFF
--- a/lldb/test/API/commands/command/container/TestContainerCommands.py
+++ b/lldb/test/API/commands/command/container/TestContainerCommands.py
@@ -68,7 +68,7 @@ class TestCmdContainer(TestBase):
         # Make sure we really did overwrite:
         self.expect("test-multi test-multi-sub welcome friend", "Used the new command class",
                     substrs=["Hello friend, welcome again to LLDB"])
-        self.expect("apropos welcome", "welcome should show up in apropos", substrs=["A docstring for the second Welcome"])
+        self.expect("apropos welcome", "welcome should show up in apropos", substrs=["a docstring for the second Welcome"])
         
         # Now switch the default and make sure we can now delete w/o the overwrite option:
         self.runCmd("settings set interpreter.require-overwrite 0")


### PR DESCRIPTION
in 78233d951bd4262aa6d9673fe98a9f22a113f45c checks the apropos
string to make sure the command was added, but in TOT the first
letter of the short help is capitalized, whereas in this branch
it isn't, so the test had to be modified for this branch.