### PR TITLE
Fix a mistyping introduced with the new container command.

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1454,7 +1454,7 @@ void CommandInterpreter::GetHelp(CommandReturnObject &result,
     result.AppendMessage("Current user-defined container commands:");
     result.AppendMessage("");
     max_len = FindLongestCommandWord(m_user_mw_dict);
-    for (pos = m_user_dict.begin(); pos != m_user_mw_dict.end(); ++pos) {
+    for (pos = m_user_mw_dict.begin(); pos != m_user_mw_dict.end(); ++pos) {
       OutputFormattedHelpText(result.GetOutputStream(), pos->first, "--",
                               pos->second->GetHelp(), max_len);
     }

--- a/lldb/test/API/commands/command/container/TestContainerCommands.py
+++ b/lldb/test/API/commands/command/container/TestContainerCommands.py
@@ -69,7 +69,9 @@ class TestCmdContainer(TestBase):
         self.expect("test-multi test-multi-sub welcome friend", "Used the new command class",
                     substrs=["Hello friend, welcome again to LLDB"])
         self.expect("apropos welcome", "welcome should show up in apropos", substrs=["A docstring for the second Welcome"])
-        
+        self.expect("help test-multi test-multi-sub welcome", "welcome should show up in help", substrs=["A docstring for the second Welcome"])
+        self.expect("help", "test-multi should show up in help", substrs=["test-multi"])
+                    
         # Now switch the default and make sure we can now delete w/o the overwrite option:
         self.runCmd("settings set interpreter.require-overwrite 0")
         self.runCmd("command script add -c welcome.WelcomeCommand test-multi test-multi-sub welcome")


### PR DESCRIPTION
I also added a call to help in the test which was crashing before
the test, and not after.

(cherry picked from commit 8c3a6fe37fc36537b939ea75a59fb2d5963246fb)