### PR TITLE
[clang-scan-deps] Introduce `-emit-cas-compdb` option

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -126,6 +126,13 @@ public:
     return Worker.getCASFS();
   }
 
+  /// If \p DependencyScanningService enabled sharing of \p FileManager this
+  /// will return the same instance, otherwise it will create a new one for
+  /// each invocation.
+  llvm::IntrusiveRefCntPtr<FileManager> getOrCreateFileManager() const {
+    return Worker.getOrCreateFileManager();
+  }
+
 private:
   DependencyScanningWorker Worker;
 };

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -83,6 +83,11 @@ public:
   llvm::cas::CachingOnDiskFileSystem &getCASFS() { return *CacheFS; }
   bool useCAS() const { return UseCAS; }
 
+  /// If \p DependencyScanningService enabled sharing of \p FileManager this
+  /// will return the same instance, otherwise it will create a new one for
+  /// each invocation.
+  llvm::IntrusiveRefCntPtr<FileManager> getOrCreateFileManager() const;
+
 private:
   std::shared_ptr<PCHContainerOperations> PCHContainerOps;
   std::unique_ptr<ExcludedPreprocessorDirectiveSkipMapping> PPSkipMappings;

--- a/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
@@ -1,0 +1,51 @@
+//===--- ScanAndUpdateArgs.h - Util for CC1 Dependency Scanning -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_DRIVER_SCANANDUPDATEARGS_H
+#define LLVM_CLANG_DRIVER_SCANANDUPDATEARGS_H
+
+#include "clang/Basic/LLVM.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace llvm {
+namespace cas {
+class CASID;
+}
+} // namespace llvm
+
+namespace clang {
+
+class CASOptions;
+class CompilerInvocation;
+class DiagnosticConsumer;
+
+namespace tooling {
+namespace dependencies {
+class DependencyScanningTool;
+}
+} // namespace tooling
+
+namespace cc1depscand {
+struct DepscanPrefixMapping {
+  Optional<StringRef> NewSDKPath;
+  Optional<StringRef> NewToolchainPath;
+  SmallVector<StringRef> PrefixMap;
+};
+} // namespace cc1depscand
+
+Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
+    const CASOptions &CASOpts,
+    tooling::dependencies::DependencyScanningTool &Tool,
+    DiagnosticConsumer &DiagsConsumer, const char *Exec,
+    CompilerInvocation &Invocation, StringRef WorkingDirectory,
+    const cc1depscand::DepscanPrefixMapping &PrefixMapping);
+
+} // end namespace clang
+
+#endif

--- a/clang/lib/Tooling/DependencyScanning/CMakeLists.txt
+++ b/clang/lib/Tooling/DependencyScanning/CMakeLists.txt
@@ -12,6 +12,7 @@ add_clang_library(clangDependencyScanning
   DependencyScanningWorker.cpp
   DependencyScanningTool.cpp
   ModuleDepCollector.cpp
+  ScanAndUpdateArgs.cpp
 
   DEPENDS
   ClangDriverOptions

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -373,6 +373,13 @@ DependencyScanningWorker::DependencyScanningWorker(
     Files = new FileManager(FileSystemOptions(), RealFS);
 }
 
+llvm::IntrusiveRefCntPtr<FileManager>
+DependencyScanningWorker::getOrCreateFileManager() const {
+  if (Files)
+    return Files;
+  return new FileManager(FileSystemOptions(), RealFS);
+}
+
 static llvm::Error
 runWithDiags(DiagnosticOptions *DiagOpts,
              llvm::function_ref<bool(DiagnosticConsumer &, DiagnosticOptions &)>

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -1,0 +1,213 @@
+//===- ScanAndUpdateArgs.cpp - Util for CC1 Dependency Scanning -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Frontend/CompilerInvocation.h"
+#include "clang/Lex/HeaderSearchOptions.h"
+#include "clang/Tooling/DependencyScanning/DependencyScanningTool.h"
+#include "clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h"
+#include "llvm/CAS/CASDB.h"
+#include "llvm/CAS/CachingOnDiskFileSystem.h"
+#include "llvm/Support/PrefixMapper.h"
+
+using namespace clang;
+using llvm::Error;
+
+static Error computeSDKMapping(llvm::StringSaver &Saver,
+                               const CompilerInvocation &Invocation,
+                               StringRef New,
+                               llvm::TreePathPrefixMapper &Mapper) {
+  StringRef SDK = Invocation.getHeaderSearchOpts().Sysroot;
+  if (SDK.empty())
+    return Error::success();
+
+  // Need a new copy of the string since the invocation will be modified.
+  return Mapper.add(llvm::MappedPrefix{Saver.save(SDK), New});
+}
+
+static Error computeToolchainMapping(llvm::StringSaver &Saver,
+                                     StringRef ClangPath, StringRef New,
+                                     llvm::TreePathPrefixMapper &Mapper) {
+  // Look up from clang for the toolchain, assuming clang is at
+  // <toolchain>/usr/bin/clang. Return a shallower guess if the directories
+  // don't match.
+  //
+  // FIXME: Should this append ".." instead of calling parent_path?
+  StringRef Guess = llvm::sys::path::parent_path(ClangPath);
+  for (StringRef Dir : {"bin", "usr"}) {
+    if (llvm::sys::path::filename(Guess) != Dir)
+      break;
+    Guess = llvm::sys::path::parent_path(Guess);
+  }
+  return Mapper.add(llvm::MappedPrefix{Guess, New});
+}
+
+static Error
+computeFullMapping(llvm::StringSaver &Saver, StringRef ClangPath,
+                   const CompilerInvocation &Invocation,
+                   const cc1depscand::DepscanPrefixMapping &DepscanMapping,
+                   llvm::TreePathPrefixMapper &Mapper) {
+  if (DepscanMapping.NewSDKPath)
+    if (Error E = computeSDKMapping(Saver, Invocation,
+                                    *DepscanMapping.NewSDKPath, Mapper))
+      return E;
+
+  if (DepscanMapping.NewToolchainPath)
+    if (Error E = computeToolchainMapping(
+            Saver, ClangPath, *DepscanMapping.NewToolchainPath, Mapper))
+      return E;
+
+  if (!DepscanMapping.PrefixMap.empty()) {
+    llvm::SmallVector<llvm::MappedPrefix> Split;
+    llvm::MappedPrefix::transformJoinedIfValid(DepscanMapping.PrefixMap, Split);
+    if (Error E = Mapper.addRange(Split))
+      return E;
+  }
+
+  Mapper.sort();
+  return Error::success();
+}
+
+static void updateCompilerInvocation(CompilerInvocation &Invocation,
+                                     llvm::StringSaver &Saver,
+                                     llvm::cas::CachingOnDiskFileSystem &FS,
+                                     std::string RootID,
+                                     StringRef CASWorkingDirectory,
+                                     llvm::TreePathPrefixMapper &Mapper) {
+  // "Fix" the CAS options.
+  auto &FileSystemOpts = Invocation.getFileSystemOpts();
+  FileSystemOpts.CASFileSystemRootID = RootID;
+  FileSystemOpts.CASFileSystemWorkingDirectory = CASWorkingDirectory.str();
+  auto &FrontendOpts = Invocation.getFrontendOpts();
+  FrontendOpts.CacheCompileJob = true; // FIXME: Don't set.
+
+  // If there are no mappings, we're done. Otherwise, continue and remap
+  // everything.
+  if (Mapper.getMappings().empty())
+    return;
+
+  // Turn off dependency outputs. Should have already been emitted.
+  Invocation.getDependencyOutputOpts().OutputFile.clear();
+
+  // Returns "false" on success, "true" if the path doesn't exist.
+  auto remapInPlace = [&](std::string &S) -> bool {
+    return errorToBool(Mapper.mapInPlace(S));
+  };
+
+  auto remapInPlaceOrFilterOutWith = [&](auto &Vector, auto Remapper) {
+    Vector.erase(llvm::remove_if(Vector, Remapper), Vector.end());
+  };
+
+  auto remapInPlaceOrFilterOut = [&](std::vector<std::string> &Vector) {
+    remapInPlaceOrFilterOutWith(Vector, remapInPlace);
+  };
+
+  // If we can't remap the working directory, skip everything else.
+  if (remapInPlace(FileSystemOpts.CASFileSystemWorkingDirectory))
+    return;
+
+  // Remap header search.
+  auto &HeaderSearchOpts = Invocation.getHeaderSearchOpts();
+  Mapper.mapInPlaceOrClear(HeaderSearchOpts.Sysroot);
+  remapInPlaceOrFilterOutWith(HeaderSearchOpts.UserEntries,
+                              [&](HeaderSearchOptions::Entry &Entry) {
+                                if (Entry.IgnoreSysRoot)
+                                  return remapInPlace(Entry.Path);
+                                return false;
+                              });
+  remapInPlaceOrFilterOutWith(
+      HeaderSearchOpts.SystemHeaderPrefixes,
+      [&](HeaderSearchOptions::SystemHeaderPrefix &Prefix) {
+        return remapInPlace(Prefix.Prefix);
+      });
+  Mapper.mapInPlaceOrClear(HeaderSearchOpts.ResourceDir);
+  Mapper.mapInPlaceOrClear(HeaderSearchOpts.ModuleCachePath);
+  Mapper.mapInPlaceOrClear(HeaderSearchOpts.ModuleUserBuildPath);
+  for (auto I = HeaderSearchOpts.PrebuiltModuleFiles.begin(),
+            E = HeaderSearchOpts.PrebuiltModuleFiles.end();
+       I != E;) {
+    auto Current = I++;
+    if (remapInPlace(Current->second))
+      HeaderSearchOpts.PrebuiltModuleFiles.erase(Current);
+  }
+  remapInPlaceOrFilterOut(HeaderSearchOpts.PrebuiltModulePaths);
+  remapInPlaceOrFilterOut(HeaderSearchOpts.VFSOverlayFiles);
+
+  // Frontend options.
+  remapInPlaceOrFilterOutWith(
+      FrontendOpts.Inputs, [&](FrontendInputFile &Input) {
+        if (Input.isBuffer())
+          return false; // FIXME: Can this happen when parsing command-line?
+
+        Optional<StringRef> RemappedFile = Mapper.mapOrNone(Input.getFile());
+        if (!RemappedFile)
+          return true;
+        if (RemappedFile != Input.getFile())
+          Input = FrontendInputFile(*RemappedFile, Input.getKind(),
+                                    Input.isSystem());
+        return false;
+      });
+
+  // Skip the output file. That's not the input CAS filesystem.
+  //   Mapper.mapInPlaceOrClear(OutputFile); <-- this doesn't make sense.
+
+  Mapper.mapInPlaceOrClear(FrontendOpts.CodeCompletionAt.FileName);
+
+  // Don't remap plugins (for now), since we don't know how to remap their
+  // arguments. Maybe they should be loaded outside of the CAS filesystem?
+  // Maybe we should error?
+  //
+  //  remapInPlaceOrFilterOut(FrontendOpts.Plugins);
+
+  remapInPlaceOrFilterOut(FrontendOpts.ModuleMapFiles);
+  remapInPlaceOrFilterOut(FrontendOpts.ModuleFiles);
+  remapInPlaceOrFilterOut(FrontendOpts.ModulesEmbedFiles);
+  remapInPlaceOrFilterOut(FrontendOpts.ASTMergeFiles);
+  Mapper.mapInPlaceOrClear(FrontendOpts.OverrideRecordLayoutsFile);
+  Mapper.mapInPlaceOrClear(FrontendOpts.StatsFile);
+
+  // Filesystem options.
+  Mapper.mapInPlaceOrClear(FileSystemOpts.WorkingDir);
+
+  // Code generation options.
+  auto &CodeGenOpts = Invocation.getCodeGenOpts();
+  Mapper.mapInPlaceOrClear(CodeGenOpts.DebugCompilationDir);
+  Mapper.mapInPlaceOrClear(CodeGenOpts.CoverageCompilationDir);
+}
+
+Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
+    const CASOptions &CASOpts,
+    tooling::dependencies::DependencyScanningTool &Tool,
+    DiagnosticConsumer &DiagsConsumer, const char *Exec,
+    CompilerInvocation &Invocation, StringRef WorkingDirectory,
+    const cc1depscand::DepscanPrefixMapping &PrefixMapping) {
+  llvm::cas::CachingOnDiskFileSystem &FS = Tool.getCachingFileSystem();
+
+  // Override the CASOptions. They may match (the caller having sniffed them
+  // out of InputArgs) but if they have been overridden we want the new ones.
+  Invocation.getCASOpts() = CASOpts;
+
+  llvm::BumpPtrAllocator Alloc;
+  llvm::StringSaver Saver(Alloc);
+  llvm::TreePathPrefixMapper Mapper(&FS, Alloc);
+  if (Error E =
+          computeFullMapping(Saver, Exec, Invocation, PrefixMapping, Mapper))
+    return std::move(E);
+
+  Optional<llvm::cas::CASID> Root;
+  if (Error E = Tool.getDependencyTreeFromCompilerInvocation(
+                        std::make_shared<CompilerInvocation>(Invocation),
+                        WorkingDirectory, DiagsConsumer,
+                        [&](const llvm::vfs::CachedDirectoryEntry &Entry) {
+                          return Mapper.map(Entry);
+                        })
+                    .moveInto(Root))
+    return std::move(E);
+  updateCompilerInvocation(Invocation, Saver, FS, Root->toString(),
+                           WorkingDirectory, Mapper);
+  return *Root;
+}

--- a/clang/test/ClangScanDeps/cas-trees.c
+++ b/clang/test/ClangScanDeps/cas-trees.c
@@ -50,6 +50,23 @@
 // FULL-TREE-NEXT:   ]
 // FULL-TREE-NEXT: }
 
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -cas-path %t/cas -format experimental-tree -emit-cas-compdb | FileCheck %s -DPREFIX=%/t -check-prefix=COMPDB
+// Check without sharing FileManager.
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -cas-path %t/cas -format experimental-tree -reuse-filemanager=0 -emit-cas-compdb | FileCheck %s -DPREFIX=%/t -check-prefix=COMPDB
+// COMPDB: [
+// COMPDB:   {
+// COMPDB:     "file": "[[PREFIX]]/t1.c",
+// COMPDB:     "directory": "[[PREFIX]]",
+// COMPDB:     "arguments": [
+// COMPDB:       "clang",
+// COMPDB:       "-cc1",
+// COMPDB:       "-fcas-path",
+// COMPDB:       "[[PREFIX]]/cas",
+// COMPDB:       "-fcas-fs",
+// COMPDB:   {
+// COMPDB:     "file": "[[PREFIX]]/t2.c",
+// COMPDB:     "directory": "[[PREFIX]]",
+// COMPDB:     "arguments": [
 
 
 //--- cdb.json.template

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -7,11 +7,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningService.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningTool.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningWorker.h"
+#include "clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h"
 #include "clang/Tooling/JSONCompilationDatabase.h"
+#include "clang/Tooling/Tooling.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/CAS/CASDB.h"
@@ -28,6 +31,7 @@
 #include <thread>
 
 using namespace clang;
+using namespace tooling;
 using namespace tooling::dependencies;
 
 namespace {
@@ -230,6 +234,12 @@ static llvm::cl::opt<ResourceDirRecipeKind> ResourceDirRecipe(
     llvm::cl::init(RDRK_ModifyCompilerPath),
     llvm::cl::cat(DependencyScannerCategory));
 
+llvm::cl::opt<bool> EmitCASCompDB(
+    "emit-cas-compdb",
+    llvm::cl::desc("Emit compilation DB with updated clang arguments for CAS "
+                   "based dependency scanning build."),
+    llvm::cl::init(false), llvm::cl::cat(DependencyScannerCategory));
+
 llvm::cl::opt<bool> OverrideCASTokenCache(
     "override-cas-token-cache",
     llvm::cl::desc("Override the CAS-based token cache, using it always."),
@@ -250,6 +260,156 @@ llvm::cl::opt<bool> Verbose("v", llvm::cl::Optional,
                             llvm::cl::cat(DependencyScannerCategory));
 
 } // end anonymous namespace
+
+static bool emitCompilationDBWithCASTreeArguments(
+    llvm::cas::CASDB &CAS, const CASOptions &CASOpts,
+    std::vector<tooling::CompileCommand> Inputs,
+    DiagnosticConsumer &DiagsConsumer, const char *Exec,
+    const cc1depscand::DepscanPrefixMapping &PrefixMapping,
+    DependencyScanningService &Service, llvm::ThreadPool &Pool,
+    llvm::raw_ostream &OS) {
+
+  // Follow `-cc1depscan` and also ignore diagnostics.
+  // FIXME: Seems not a good idea to do this..
+  auto IgnoringDiagsConsumer = std::make_unique<IgnoringDiagConsumer>();
+
+  struct PerThreadState {
+    DependencyScanningTool Worker;
+    llvm::BumpPtrAllocator Alloc;
+    llvm::StringSaver Saver;
+    explicit PerThreadState(DependencyScanningService &Service)
+        : Worker(Service), Saver(Alloc) {}
+  };
+  std::vector<std::unique_ptr<PerThreadState>> PerThreadStates;
+  for (unsigned I = 0, E = Pool.getThreadCount(); I != E; ++I)
+    PerThreadStates.push_back(std::make_unique<PerThreadState>(Service));
+
+  std::atomic<bool> HadErrors(false);
+  std::mutex Lock;
+  size_t Index = 0;
+
+  struct CompDBEntry {
+    size_t Index;
+    std::string Filename;
+    std::string WorkDir;
+    SmallVector<const char *> Args;
+  };
+  std::vector<CompDBEntry> CompDBEntries;
+
+  for (unsigned I = 0, E = Pool.getThreadCount(); I != E; ++I) {
+    Pool.async([&, I]() {
+      while (true) {
+        const tooling::CompileCommand *Input;
+        std::string Filename;
+        std::string CWD;
+        size_t LocalIndex;
+        // Take the next input.
+        {
+          std::unique_lock<std::mutex> LockGuard(Lock);
+          if (Index >= Inputs.size())
+            return;
+          LocalIndex = Index;
+          Input = &Inputs[Index++];
+          Filename = std::move(Input->Filename);
+          CWD = std::move(Input->Directory);
+        }
+
+        tooling::dependencies::DependencyScanningTool &WorkerTool =
+            PerThreadStates[I]->Worker;
+
+        class ScanForCC1Action : public ToolAction {
+          const CASOptions &CASOpts;
+          tooling::dependencies::DependencyScanningTool &WorkerTool;
+          DiagnosticConsumer &DiagsConsumer;
+          const char *Exec;
+          StringRef CWD;
+          const cc1depscand::DepscanPrefixMapping &PrefixMapping;
+          SmallVectorImpl<const char *> &OutputArgs;
+          llvm::StringSaver &Saver;
+
+        public:
+          ScanForCC1Action(
+              const CASOptions &CASOpts,
+              tooling::dependencies::DependencyScanningTool &WorkerTool,
+              DiagnosticConsumer &DiagsConsumer, const char *Exec,
+              StringRef CWD,
+              const cc1depscand::DepscanPrefixMapping &PrefixMapping,
+              SmallVectorImpl<const char *> &OutputArgs,
+              llvm::StringSaver &Saver)
+              : CASOpts(CASOpts), WorkerTool(WorkerTool),
+                DiagsConsumer(DiagsConsumer), Exec(Exec), CWD(CWD),
+                PrefixMapping(PrefixMapping), OutputArgs(OutputArgs),
+                Saver(Saver) {}
+
+          bool
+          runInvocation(std::shared_ptr<CompilerInvocation> Invocation,
+                        FileManager *Files,
+                        std::shared_ptr<PCHContainerOperations> PCHContainerOps,
+                        DiagnosticConsumer *DiagConsumer) override {
+            Expected<llvm::cas::CASID> Root = scanAndUpdateCC1InlineWithTool(
+                CASOpts, WorkerTool, DiagsConsumer, Exec, *Invocation, CWD,
+                PrefixMapping);
+            if (!Root) {
+              llvm::consumeError(Root.takeError());
+              return false;
+            }
+            OutputArgs.push_back("-cc1");
+            Invocation->generateCC1CommandLine(OutputArgs, [&](const Twine &T) {
+              return Saver.save(T).data();
+            });
+            return true;
+          }
+        };
+
+        SmallVector<const char *> OutputArgs;
+        llvm::StringSaver &Saver = PerThreadStates[I]->Saver;
+        OutputArgs.push_back(Saver.save(Input->CommandLine.front()).data());
+        ScanForCC1Action Action(CASOpts, WorkerTool, *IgnoringDiagsConsumer,
+                                Exec, CWD, PrefixMapping, OutputArgs, Saver);
+
+        llvm::IntrusiveRefCntPtr<FileManager> FileMgr =
+            WorkerTool.getOrCreateFileManager();
+        ToolInvocation Invocation(Input->CommandLine, &Action, FileMgr.get(),
+                                  std::make_shared<PCHContainerOperations>());
+        if (!Invocation.run()) {
+          HadErrors = true;
+          continue;
+        }
+
+        {
+          std::unique_lock<std::mutex> LockGuard(Lock);
+          CompDBEntries.push_back({LocalIndex, std::move(Filename),
+                                   std::move(CWD), std::move(OutputArgs)});
+        }
+      }
+    });
+  }
+  Pool.wait();
+
+  std::sort(CompDBEntries.begin(), CompDBEntries.end(),
+            [](const CompDBEntry &LHS, const CompDBEntry &RHS) -> bool {
+              return LHS.Index < RHS.Index;
+            });
+
+  llvm::json::OStream J(OS, /*IndentSize*/ 2);
+  J.arrayBegin();
+  for (const auto &Entry : CompDBEntries) {
+    J.objectBegin();
+    J.attribute("file", Entry.Filename);
+    J.attribute("directory", Entry.WorkDir);
+    J.attributeBegin("arguments");
+    J.arrayBegin();
+    for (const char *Arg : Entry.Args) {
+      J.value(Arg);
+    }
+    J.arrayEnd();
+    J.attributeEnd();
+    J.objectEnd();
+  }
+  J.arrayEnd();
+
+  return HadErrors;
+}
 
 /// Takes the result of a dependency scan and prints error / dependency files
 /// based on the result.
@@ -518,6 +678,9 @@ int main(int argc, const char **argv) {
   AdjustingCompilations->appendArgumentsAdjuster(
       [&ResourceDirCache](const tooling::CommandLineArguments &Args,
                           StringRef FileName) {
+        if (EmitCASCompDB)
+          return Args; // Don't adjust.
+
         std::string LastO;
         bool HasResourceDir = false;
         bool ClangCLMode = false;
@@ -578,25 +741,43 @@ int main(int argc, const char **argv) {
   // Print out the dependency results to STDOUT by default.
   SharedStream DependencyOS(llvm::outs());
 
-  std::unique_ptr<llvm::cas::CASDB> CAS;
+  auto DiagsConsumer = std::make_unique<TextDiagnosticPrinter>(
+      llvm::errs(), new DiagnosticOptions(), false);
+  DiagnosticsEngine Diags(new DiagnosticIDs(), new DiagnosticOptions());
+  Diags.setClient(DiagsConsumer.get(), /*ShouldOwnClient=*/false);
+
+  CASOptions CASOpts;
+  std::shared_ptr<llvm::cas::CASDB> CAS;
   IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> FS;
   if (outputFormatRequiresCAS()) {
-    if (InMemoryCAS) {
-      CAS = llvm::cas::createInMemoryCAS();
-    } else {
-      SmallString<128> CASPath;
-      if (OnDiskCASPath.empty())
-        llvm::cas::getDefaultOnDiskCASPath(CASPath);
+    if (!InMemoryCAS) {
+      if (!OnDiskCASPath.empty())
+        CASOpts.CASPath = OnDiskCASPath;
       else
-        CASPath += OnDiskCASPath;
-      CAS = cantFail(llvm::cas::createOnDiskCAS(CASPath));
+        CASOpts.ensurePersistentCAS();
     }
+    CAS = CASOpts.getOrCreateCAS(Diags);
+    if (!CAS)
+      return 1;
     FS = llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*CAS));
   }
   DependencyScanningService Service(ScanMode, Format, FS, ReuseFileManager,
                                     SkipExcludedPPRanges, OptimizeArgs,
                                     OverrideCASTokenCache);
   llvm::ThreadPool Pool(llvm::hardware_concurrency(NumThreads));
+
+  if (EmitCASCompDB) {
+    if (!CAS) {
+      llvm::errs() << "'-emit-cas-compdb' needs CAS setup\n";
+      return 1;
+    }
+    // FIXME: Configure this.
+    cc1depscand::DepscanPrefixMapping PrefixMapping;
+    return emitCompilationDBWithCASTreeArguments(
+        *CAS, CASOpts, AdjustingCompilations->getAllCompileCommands(),
+        *DiagsConsumer, argv[0], PrefixMapping, Service, Pool, llvm::outs());
+  }
+
   std::vector<std::unique_ptr<DependencyScanningTool>> WorkerTools;
   for (unsigned I = 0; I < Pool.getThreadCount(); ++I)
     WorkerTools.push_back(std::make_unique<DependencyScanningTool>(Service));

--- a/clang/tools/driver/cc1depscanProtocol.cpp
+++ b/clang/tools/driver/cc1depscanProtocol.cpp
@@ -8,6 +8,7 @@
 
 #include "cc1depscanProtocol.h"
 #include "clang/Frontend/CompilerInvocation.h"
+#include "clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h"
 #include "llvm/CAS/CASDB.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/Error.h"

--- a/clang/tools/driver/cc1depscanProtocol.h
+++ b/clang/tools/driver/cc1depscanProtocol.h
@@ -24,11 +24,7 @@ class CASOptions;
 
 namespace cc1depscand {
 
-struct DepscanPrefixMapping {
-  Optional<StringRef> NewSDKPath;
-  Optional<StringRef> NewToolchainPath;
-  SmallVector<StringRef> PrefixMap;
-};
+struct DepscanPrefixMapping;
 
 struct AutoArgEdit {
   uint32_t Index = -1u;

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -23,6 +23,7 @@
 #include "clang/FrontendTool/Utils.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningService.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningTool.h"
+#include "clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Bitstream/BitstreamReader.h"
@@ -1069,168 +1070,6 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
   return 0;
 }
 
-static llvm::Error computeSDKMapping(llvm::StringSaver &Saver,
-                                     const CompilerInvocation &Invocation,
-                                     StringRef New,
-                                     llvm::TreePathPrefixMapper &Mapper) {
-  StringRef SDK = Invocation.getHeaderSearchOpts().Sysroot;
-  if (SDK.empty())
-    return llvm::Error::success();
-
-  // Need a new copy of the string since the invocation will be modified.
-  return Mapper.add(llvm::MappedPrefix{Saver.save(SDK), New});
-}
-
-static llvm::Error computeToolchainMapping(llvm::StringSaver &Saver,
-                                           StringRef ClangPath, StringRef New,
-                                           llvm::TreePathPrefixMapper &Mapper) {
-  // Look up from clang for the toolchain, assuming clang is at
-  // <toolchain>/usr/bin/clang. Return a shallower guess if the directories
-  // don't match.
-  //
-  // FIXME: Should this append ".." instead of calling parent_path?
-  StringRef Guess = llvm::sys::path::parent_path(ClangPath);
-  for (StringRef Dir : {"bin", "usr"}) {
-    if (llvm::sys::path::filename(Guess) != Dir)
-      break;
-    Guess = llvm::sys::path::parent_path(Guess);
-  }
-  return Mapper.add(llvm::MappedPrefix{Guess, New});
-}
-
-static llvm::Error
-computeFullMapping(llvm::StringSaver &Saver, StringRef ClangPath,
-                   const CompilerInvocation &Invocation,
-                   const cc1depscand::DepscanPrefixMapping &DepscanMapping,
-                   llvm::TreePathPrefixMapper &Mapper) {
-  if (DepscanMapping.NewSDKPath)
-    if (llvm::Error E = computeSDKMapping(Saver, Invocation,
-                                          *DepscanMapping.NewSDKPath, Mapper))
-      return E;
-
-  if (DepscanMapping.NewToolchainPath)
-    if (llvm::Error E = computeToolchainMapping(
-            Saver, ClangPath, *DepscanMapping.NewToolchainPath, Mapper))
-      return E;
-
-  if (!DepscanMapping.PrefixMap.empty()) {
-    llvm::SmallVector<llvm::MappedPrefix> Split;
-    llvm::MappedPrefix::transformJoinedIfValid(DepscanMapping.PrefixMap, Split);
-    if (llvm::Error E = Mapper.addRange(Split))
-      return E;
-  }
-
-  Mapper.sort();
-  return llvm::Error::success();
-}
-
-static void updateCompilerInvocation(CompilerInvocation &Invocation,
-                                     llvm::StringSaver &Saver,
-                                     llvm::cas::CachingOnDiskFileSystem &FS,
-                                     std::string RootID,
-                                     StringRef CASWorkingDirectory,
-                                     llvm::TreePathPrefixMapper &Mapper) {
-  // "Fix" the CAS options.
-  auto &FileSystemOpts = Invocation.getFileSystemOpts();
-  FileSystemOpts.CASFileSystemRootID = RootID;
-  FileSystemOpts.CASFileSystemWorkingDirectory = CASWorkingDirectory.str();
-  auto &FrontendOpts = Invocation.getFrontendOpts();
-  FrontendOpts.CacheCompileJob = true;      // FIXME: Don't set.
-
-  // If there are no mappings, we're done. Otherwise, continue and remap
-  // everything.
-  if (Mapper.getMappings().empty())
-    return;
-
-  // Turn off dependency outputs. Should have already been emitted.
-  Invocation.getDependencyOutputOpts().OutputFile.clear();
-
-  // Returns "false" on success, "true" if the path doesn't exist.
-  auto remapInPlace = [&](std::string &S) -> bool {
-    return errorToBool(Mapper.mapInPlace(S));
-  };
-
-  auto remapInPlaceOrFilterOutWith = [&](auto &Vector, auto Remapper) {
-    Vector.erase(llvm::remove_if(Vector, Remapper), Vector.end());
-  };
-
-  auto remapInPlaceOrFilterOut = [&](std::vector<std::string> &Vector) {
-    remapInPlaceOrFilterOutWith(Vector, remapInPlace);
-  };
-
-  // If we can't remap the working directory, skip everything else.
-  if (remapInPlace(FileSystemOpts.CASFileSystemWorkingDirectory))
-    return;
-
-  // Remap header search.
-  auto &HeaderSearchOpts = Invocation.getHeaderSearchOpts();
-  Mapper.mapInPlaceOrClear(HeaderSearchOpts.Sysroot);
-  remapInPlaceOrFilterOutWith(HeaderSearchOpts.UserEntries,
-                              [&](HeaderSearchOptions::Entry &Entry) {
-                                if (Entry.IgnoreSysRoot)
-                                  return remapInPlace(Entry.Path);
-                                return false;
-                              });
-  remapInPlaceOrFilterOutWith(
-      HeaderSearchOpts.SystemHeaderPrefixes,
-      [&](HeaderSearchOptions::SystemHeaderPrefix &Prefix) {
-        return remapInPlace(Prefix.Prefix);
-      });
-  Mapper.mapInPlaceOrClear(HeaderSearchOpts.ResourceDir);
-  Mapper.mapInPlaceOrClear(HeaderSearchOpts.ModuleCachePath);
-  Mapper.mapInPlaceOrClear(HeaderSearchOpts.ModuleUserBuildPath);
-  for (auto I = HeaderSearchOpts.PrebuiltModuleFiles.begin(),
-            E = HeaderSearchOpts.PrebuiltModuleFiles.end();
-       I != E;) {
-    auto Current = I++;
-    if (remapInPlace(Current->second))
-      HeaderSearchOpts.PrebuiltModuleFiles.erase(Current);
-  }
-  remapInPlaceOrFilterOut(HeaderSearchOpts.PrebuiltModulePaths);
-  remapInPlaceOrFilterOut(HeaderSearchOpts.VFSOverlayFiles);
-
-  // Frontend options.
-  remapInPlaceOrFilterOutWith(
-      FrontendOpts.Inputs, [&](FrontendInputFile &Input) {
-        if (Input.isBuffer())
-          return false; // FIXME: Can this happen when parsing command-line?
-
-        Optional<StringRef> RemappedFile = Mapper.mapOrNone(Input.getFile());
-        if (!RemappedFile)
-          return true;
-        if (RemappedFile != Input.getFile())
-          Input = FrontendInputFile(*RemappedFile, Input.getKind(),
-                                    Input.isSystem());
-        return false;
-      });
-
-  // Skip the output file. That's not the input CAS filesystem.
-  //   Mapper.mapInPlaceOrClear(OutputFile); <-- this doesn't make sense.
-
-  Mapper.mapInPlaceOrClear(FrontendOpts.CodeCompletionAt.FileName);
-
-  // Don't remap plugins (for now), since we don't know how to remap their
-  // arguments. Maybe they should be loaded outside of the CAS filesystem?
-  // Maybe we should error?
-  //
-  //  remapInPlaceOrFilterOut(FrontendOpts.Plugins);
-
-  remapInPlaceOrFilterOut(FrontendOpts.ModuleMapFiles);
-  remapInPlaceOrFilterOut(FrontendOpts.ModuleFiles);
-  remapInPlaceOrFilterOut(FrontendOpts.ModulesEmbedFiles);
-  remapInPlaceOrFilterOut(FrontendOpts.ASTMergeFiles);
-  Mapper.mapInPlaceOrClear(FrontendOpts.OverrideRecordLayoutsFile);
-  Mapper.mapInPlaceOrClear(FrontendOpts.StatsFile);
-
-  // Filesystem options.
-  Mapper.mapInPlaceOrClear(FileSystemOpts.WorkingDir);
-
-  // Code generation options.
-  auto &CodeGenOpts = Invocation.getCodeGenOpts();
-  Mapper.mapInPlaceOrClear(CodeGenOpts.DebugCompilationDir);
-  Mapper.mapInPlaceOrClear(CodeGenOpts.CoverageCompilationDir);
-}
-
 static Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
     const CASOptions &CASOpts,
     tooling::dependencies::DependencyScanningTool &Tool,
@@ -1239,8 +1078,6 @@ static Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
     SmallVectorImpl<const char *> &OutputArgs,
     const cc1depscand::DepscanPrefixMapping &PrefixMapping,
     llvm::function_ref<const char *(const Twine &)> SaveArg) {
-  llvm::cas::CachingOnDiskFileSystem &FS = Tool.getCachingFileSystem();
-
   DiagnosticsEngine Diags(new DiagnosticIDs(), new DiagnosticOptions());
   Diags.setClient(&DiagsConsumer, /*ShouldOwnClient=*/false);
   auto Invocation = std::make_shared<CompilerInvocation>();
@@ -1248,28 +1085,11 @@ static Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "failed to create compiler invocation");
 
-  // Override the CASOptions. They may match (the caller having sniffed them
-  // out of InputArgs) but if they have been overridden we want the new ones.
-  Invocation->getCASOpts() = CASOpts;
-
-  llvm::BumpPtrAllocator Alloc;
-  llvm::StringSaver Saver(Alloc);
-  llvm::TreePathPrefixMapper Mapper(&FS, Alloc);
-  if (llvm::Error E =
-          computeFullMapping(Saver, Exec, *Invocation, PrefixMapping, Mapper))
-    return std::move(E);
-
-  Optional<llvm::cas::CASID> Root;
-  if (Error E = Tool.getDependencyTreeFromCompilerInvocation(
-                        std::make_shared<CompilerInvocation>(*Invocation),
-                        WorkingDirectory, DiagsConsumer,
-                        [&](const llvm::vfs::CachedDirectoryEntry &Entry) {
-                          return Mapper.map(Entry);
-                        })
-                    .moveInto(Root))
-    return std::move(E);
-  updateCompilerInvocation(*Invocation, Saver, FS, Root->toString(),
-                           WorkingDirectory, Mapper);
+  Expected<llvm::cas::CASID> Root = scanAndUpdateCC1InlineWithTool(
+      CASOpts, Tool, DiagsConsumer, Exec, *Invocation, WorkingDirectory,
+      PrefixMapping);
+  if (!Root)
+    return Root;
 
   OutputArgs.resize(1);
   OutputArgs[0] = "-cc1";


### PR DESCRIPTION
This uses the `clang -cc1depscan` functionality to convert a compilation database input
into a new compilation database with updated `-cc1` arguments.

Majority of changes is refactoring to make the `-cc1depscan` functionality accessible via `libclangDriver`.

`-emit-cas-compdb` is intended for testing purposes.