### PR TITLE
Change the LLVM signpost category

### DIFF
--- a/llvm/lib/Support/Signposts.cpp
+++ b/llvm/lib/Support/Signposts.cpp
@@ -25,7 +25,7 @@ using namespace llvm;
 namespace {
 os_log_t *LogCreator() {
   os_log_t *X = new os_log_t;
-  *X = os_log_create("org.llvm.signposts", OS_LOG_CATEGORY_POINTS_OF_INTEREST);
+  *X = os_log_create("org.llvm.signposts", "toolchain");
   return X;
 }
 struct LogDeleter {


### PR DESCRIPTION
Currently, the LLVM/LLDB timers are visible in Instruments for all apps.

The developer-visible "PointsOfInterest" category is reserved for
runtime issues and developer-authored "important" logging. These logs
are visible to developer almost always in Instruments

The LLVM/LLDB timers do not belong there. Having these present in the
system is noisy and confusing to developers. This patch moves them under
a new "toolchain" category.

rdar://91266582

Differential revision: https://reviews.llvm.org/D123149

(cherry picked from commit e9ec16177f2b675829a7b73b6b72c64f5b40e73f)
