### PR TITLE
[c++-interop] Test that APINotes handles ObjCMethods while in C++-Interop

### DIFF
--- a/clang/test/APINotes/Inputs/Frameworks/CXXInteropKit.framework/Headers/CXXInteropKit.apinotes
+++ b/clang/test/APINotes/Inputs/Frameworks/CXXInteropKit.framework/Headers/CXXInteropKit.apinotes
@@ -3,6 +3,10 @@ Name: CxxInterop
 Classes:
 - Name: NSSomeClass
   SwiftName: SomeClass
+  Methods:
+  - Selector: 'didMoveToParentViewController:'
+    SwiftName: didMove(toParent:)
+    MethodKind: Instance
 Enumerators:
 - Name: SomeClassRed
   SwiftName: red

--- a/clang/test/APINotes/Inputs/Frameworks/CXXInteropKit.framework/Headers/CXXInteropKit.h
+++ b/clang/test/APINotes/Inputs/Frameworks/CXXInteropKit.framework/Headers/CXXInteropKit.h
@@ -2,5 +2,12 @@
   -(instancetype)init;
 @end
 
+// Extension, inspired by UIKit UIViewController.h
+@interface NSSomeClass (UIContainerViewControllerCallbacks)
+
+- (void)didMoveToParentViewController:(NSSomeClass *)parent;
+
+@end
+
 // Named "SomeClassRed" for ast node filtering in the test.
 enum ColorEnum { SomeClassRed, SomeClassGreen, SomeClassBlue };

--- a/clang/test/APINotes/objcxx-swift-name.m
+++ b/clang/test/APINotes/objcxx-swift-name.m
@@ -8,6 +8,11 @@
 // CHECK-NEXT: ObjCInterfaceDecl {{.+}} imported in CxxInteropKit <undeserialized declarations> NSSomeClass
 // CHECK-NEXT: SwiftNameAttr {{.+}} <<invalid sloc>> "SomeClass"
 
+// CHECK: Dumping NSSomeClass::didMoveToParentViewController::
+// CHECK-NEXT: ObjCMethodDecl {{.+}} imported in CxxInteropKit - didMoveToParentViewController: 'void'
+// CHECK-NEXT: ParmVarDecl
+// CHECK-NEXT: SwiftNameAttr {{.+}} <<invalid sloc>> "didMove(toParent:)"
+
 // CHECK: Dumping SomeClassRed:
 // CHECK-NEXT: EnumConstantDecl {{.+}} imported in CxxInteropKit SomeClassRed 'ColorEnum'
 // CHECK-NEXT: SwiftNameAttr {{.+}} <<invalid sloc>> "red"


### PR DESCRIPTION
In a previous commit I taught APINotes to treat extern-c context as a
toplevel file context, but this only makes sense when we are handling
the decls handled in the block like VarDecls, FunctionDecls,
ObjCInterfaceDecls, etc.

But when the decl being handled for APINote is an ObjCMethod inside of a
ObjCContainer then it is important to allow the subsequent code in the
Sema::ProcessAPINotes function to handle things.

This can be excercised by the following APINote:

```
---
Name: SomeModule
Classes:
- Name: NSSomeClass
  SwiftName: SomeClass
  Methods:
  - Selector: 'didMoveToParentViewController:'
    SwiftName: didMove(toParent:)
    MethodKind: Instance
```

This commit is now just a test case due to another commit that has
already landed.

(cherry picked from commit 4416d1515e59451bf01bbf5fd68e78cf921b1411)