### PR TITLE
Fix the 5.6 CI

### DIFF
--- a/lldb/test/API/commands/platform/sdk/TestPlatformSDK.py
+++ b/lldb/test/API/commands/platform/sdk/TestPlatformSDK.py
@@ -39,6 +39,7 @@ class PlatformSDKTestCase(TestBase):
             return '{} not available'.format(self.PORT)
         return None
 
+    @skipIf
     @no_debug_info_test
     @skipUnlessDarwin
     @expectedFailureIfFn(no_debugserver)

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -266,6 +266,9 @@ import lldbtest
 # testFormat: The test format to use to interpret tests.
 config.test_format = lldbtest.LLDBTest(dotest_cmd)
 
+# Propagate TERM or default to vt100.
+config.environment['TERM'] = os.getenv('TERM', default='vt100')
+
 # Propagate FREEBSD_LEGACY_PLUGIN
 if 'FREEBSD_LEGACY_PLUGIN' in os.environ:
   config.environment['FREEBSD_LEGACY_PLUGIN'] = os.environ[


### PR DESCRIPTION
 - Fix TestPlatformSDK after the remote-macosx platform was disabled
 - Fix TestDarwinNSLogOutput by setting the TERM env variable