### PR TITLE
Correct debugserver to write xmm/ymm/zmm reg values

### DIFF
--- a/lldb/test/Shell/Register/x86-64-write.test
+++ b/lldb/test/Shell/Register/x86-64-write.test
@@ -1,4 +1,9 @@
-# XFAIL: system-darwin
+# xfail with system debugserver until the fix for
+# https://reviews.llvm.org/D123269 in
+# lldb/tools/debugserver/source/MacOSX/x86_64/DNBArchImplX86_64.cpp
+# has made it into released tools.
+# XFAIL: system-debugserver
+
 # XFAIL: system-windows
 # REQUIRES: native && target-x86_64
 # RUN: %clangxx_host %p/Inputs/x86-64-write.cpp -o %t

--- a/lldb/test/Shell/Register/x86-64-ymm-write.test
+++ b/lldb/test/Shell/Register/x86-64-ymm-write.test
@@ -1,4 +1,9 @@
-# XFAIL: system-darwin
+# xfail with system debugserver until the fix for
+# https://reviews.llvm.org/D123269 in
+# lldb/tools/debugserver/source/MacOSX/x86_64/DNBArchImplX86_64.cpp
+# has made it into released tools.
+# XFAIL: system-debugserver
+
 # XFAIL: system-windows
 # REQUIRES: native && target-x86_64 && native-cpu-avx
 # RUN: %clangxx_host %p/Inputs/x86-ymm-write.cpp -o %t

--- a/lldb/test/Shell/Register/x86-64-zmm-write.test
+++ b/lldb/test/Shell/Register/x86-64-zmm-write.test
@@ -1,4 +1,9 @@
-# XFAIL: system-darwin
+# xfail with system debugserver until the fix for
+# https://reviews.llvm.org/D123269 in
+# lldb/tools/debugserver/source/MacOSX/x86_64/DNBArchImplX86_64.cpp
+# has made it into released tools.
+# XFAIL: system-debugserver
+
 # XFAIL: system-freebsd
 # XFAIL: system-linux
 # XFAIL: system-netbsd

--- a/lldb/tools/debugserver/source/MacOSX/x86_64/DNBArchImplX86_64.cpp
+++ b/lldb/tools/debugserver/source/MacOSX/x86_64/DNBArchImplX86_64.cpp
@@ -2632,7 +2632,8 @@ bool DNBArchImplX86_64::SetRegisterValue(uint32_t set, uint32_t reg,
                &value->value.uint8, 16);
         memcpy(&m_state.context.fpu.avx.__fpu_ymmh0 + (reg - fpu_ymm0),
                (&value->value.uint8) + 16, 16);
-        return true;
+        success = true;
+        break;
       case fpu_k0:
       case fpu_k1:
       case fpu_k2:
@@ -2643,7 +2644,8 @@ bool DNBArchImplX86_64::SetRegisterValue(uint32_t set, uint32_t reg,
       case fpu_k7:
         memcpy(&m_state.context.fpu.avx512f.__fpu_k0 + (reg - fpu_k0),
                &value->value.uint8, 8);
-        return true;
+        success = true;
+        break;
       case fpu_zmm0:
       case fpu_zmm1:
       case fpu_zmm2:
@@ -2666,7 +2668,8 @@ bool DNBArchImplX86_64::SetRegisterValue(uint32_t set, uint32_t reg,
                &value->value.uint8 + 16, 16);
         memcpy(&m_state.context.fpu.avx512f.__fpu_zmmh0 + (reg - fpu_zmm0),
                &value->value.uint8 + 32, 32);
-        return true;
+        success = true;
+        break;
       case fpu_zmm16:
       case fpu_zmm17:
       case fpu_zmm18:
@@ -2685,7 +2688,8 @@ bool DNBArchImplX86_64::SetRegisterValue(uint32_t set, uint32_t reg,
       case fpu_zmm31:
         memcpy(&m_state.context.fpu.avx512f.__fpu_zmm16 + (reg - fpu_zmm16),
                &value->value.uint8, 64);
-        return true;
+        success = true;
+        break;
       }
       break;
 


### PR DESCRIPTION
Correct debugserver to write xmm/ymm/zmm reg values

debugserver does not call thread_set_state when changing xmm/ymm/zmm
register values, so the register contents are never updated.  Fix
that.  Mark the shell tests which xfail'ed these tests on darwin systems
to xfail them when the system debugserver, they will pass when using
the in-tree debugserver.  When this makes it into the installed
system debugservers, we'll remove the xfails.

Differential Revision: https://reviews.llvm.org/D123269
rdar://91258333
rdar://31294382

(cherry picked from commit 4d3cc27831383987b38e60875573982af5e0538b)