### PR TITLE
CAS: Return Hasher.final() directly in BuiltinObjectHasher, NFC

### DIFF
--- a/llvm/include/llvm/CAS/BuiltinObjectHasher.h
+++ b/llvm/include/llvm/CAS/BuiltinObjectHasher.h
@@ -113,12 +113,7 @@ private:
     updateKind(Kind);
   }
 
-  HashT finish() {
-    auto Final = Hasher.final();
-    HashT Hash;
-    std::copy(Final.begin(), Final.end(), Hash.data());
-    return Hash;
-  }
+  HashT finish() { return Hasher.final(); }
 
   void updateKind(StableObjectKind Kind) {
     static_assert(sizeof(Kind) == 1, "Expected kind to be 1-byte");


### PR DESCRIPTION
Delete some StringRef to std::array conversion code that's no longer
necessary after 330268ba346b679af786879d8f696c8c412a40eb.