### PR TITLE
[CAS depscan] Ensure `CASOptions` are passed via `CompilerInvocation` and remove `extractCASFromFS`

### DIFF
--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -418,8 +418,6 @@ public:
   llvm::vfs::OutputBackend &getOrCreateOutputBackend();
 
   /// Get the CAS, or create it using the configuration in CompilerInvocation.
-  ///
-  /// FIXME: Requires the filemanager to be set up already, but shouldn't.
   llvm::cas::CASDB &getOrCreateCAS();
 
   /// }

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CLANG_TOOLING_DEPENDENCYSCANNING_DEPENDENCYSCANNINGSERVICE_H
 #define LLVM_CLANG_TOOLING_DEPENDENCYSCANNING_DEPENDENCYSCANNINGSERVICE_H
 
+#include "clang/CAS/CASOptions.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningFilesystem.h"
 
@@ -55,7 +56,7 @@ enum class ScanningOutputFormat {
 class DependencyScanningService {
 public:
   DependencyScanningService(
-      ScanningMode Mode, ScanningOutputFormat Format,
+      ScanningMode Mode, ScanningOutputFormat Format, CASOptions CASOpts,
       IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> SharedFS,
       bool ReuseFileManager = true, bool SkipExcludedPPRanges = true,
       bool OptimizeArgs = false, bool OverrideCASTokenCache = false);
@@ -65,6 +66,8 @@ public:
   ScanningMode getMode() const { return Mode; }
 
   ScanningOutputFormat getFormat() const { return Format; }
+
+  const CASOptions &getCASOpts() const { return CASOpts; }
 
   bool canReuseFileManager() const { return ReuseFileManager; }
 
@@ -87,6 +90,7 @@ public:
 private:
   const ScanningMode Mode;
   const ScanningOutputFormat Format;
+  CASOptions CASOpts;
   const bool ReuseFileManager;
   /// Set to true to use the preprocessor optimization that skips excluded PP
   /// ranges by bumping the buffer pointer in the lexer instead of lexing the

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -122,6 +122,8 @@ public:
                       StringRef CWD, const llvm::StringSet<> &AlreadySeen,
                       llvm::Optional<StringRef> ModuleName = None);
 
+  const CASOptions &getCASOpts() const { return Worker.getCASOpts(); }
+
   llvm::cas::CachingOnDiskFileSystem &getCachingFileSystem() {
     return Worker.getCASFS();
   }

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -82,6 +82,7 @@ public:
   llvm::vfs::FileSystem &getRealFS() { return *RealFS; }
   llvm::cas::CachingOnDiskFileSystem &getCASFS() { return *CacheFS; }
   bool useCAS() const { return UseCAS; }
+  const CASOptions &getCASOpts() const { return CASOpts; }
 
   /// If \p DependencyScanningService enabled sharing of \p FileManager this
   /// will return the same instance, otherwise it will create a new one for
@@ -111,6 +112,7 @@ private:
   /// Whether to optimize the modules' command-line arguments.
   bool OptimizeArgs;
 
+  CASOptions CASOpts;
   bool UseCAS;
   bool OverrideCASTokenCache;
 };

--- a/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
@@ -40,7 +40,6 @@ struct DepscanPrefixMapping {
 } // namespace cc1depscand
 
 Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
-    const CASOptions &CASOpts,
     tooling::dependencies::DependencyScanningTool &Tool,
     DiagnosticConsumer &DiagsConsumer, const char *Exec,
     CompilerInvocation &Invocation, StringRef WorkingDirectory,

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
@@ -16,11 +16,12 @@ using namespace tooling;
 using namespace dependencies;
 
 DependencyScanningService::DependencyScanningService(
-    ScanningMode Mode, ScanningOutputFormat Format,
+    ScanningMode Mode, ScanningOutputFormat Format, CASOptions CASOpts,
     IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> SharedFS,
     bool ReuseFileManager, bool SkipExcludedPPRanges, bool OptimizeArgs,
     bool OverrideCASTokenCache)
-    : Mode(Mode), Format(Format), ReuseFileManager(ReuseFileManager),
+    : Mode(Mode), Format(Format), CASOpts(std::move(CASOpts)),
+      ReuseFileManager(ReuseFileManager),
       SkipExcludedPPRanges(SkipExcludedPPRanges), OptimizeArgs(OptimizeArgs),
       OverrideCASTokenCache(OverrideCASTokenCache),
       SharedFS(std::move(SharedFS)) {

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -180,7 +180,6 @@ static void updateCompilerInvocation(CompilerInvocation &Invocation,
 }
 
 Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
-    const CASOptions &CASOpts,
     tooling::dependencies::DependencyScanningTool &Tool,
     DiagnosticConsumer &DiagsConsumer, const char *Exec,
     CompilerInvocation &Invocation, StringRef WorkingDirectory,
@@ -189,7 +188,7 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
 
   // Override the CASOptions. They may match (the caller having sniffed them
   // out of InputArgs) but if they have been overridden we want the new ones.
-  Invocation.getCASOpts() = CASOpts;
+  Invocation.getCASOpts() = Tool.getCASOpts();
 
   llvm::BumpPtrAllocator Alloc;
   llvm::StringSaver Saver(Alloc);


### PR DESCRIPTION
Use `DependencyScanningService` to hold and pass `CASOptions`, which simplifies APIs since it avoids the need to be passing it around across APIs.