### PR TITLE
CAS: Fix potential use-after-scope in CASOutputBackend

### DIFF
--- a/llvm/include/llvm/CAS/CASOutputBackend.h
+++ b/llvm/include/llvm/CAS/CASOutputBackend.h
@@ -32,13 +32,13 @@ public:
   CASOutputBackend(
       std::shared_ptr<CASDB> CAS,
       IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend,
-      function_ref<std::string(StringRef)> CASPathRewriter);
+      unique_function<std::string(StringRef)> CASPathRewriter);
   /// \param CASIDOutputBackend if set it will be used to write out the file
   /// contents as embedded CASID. Can be \p nullptr.
   CASOutputBackend(
       CASDB &CAS,
       IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend,
-      function_ref<std::string(StringRef)> CASPathRewriter);
+      unique_function<std::string(StringRef)> CASPathRewriter);
 
 private:
   ~CASOutputBackend();
@@ -48,7 +48,7 @@ private:
   CASDB &CAS;
   std::shared_ptr<CASDB> OwnedCAS;
   IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend;
-  function_ref<std::string(StringRef)> CASPathRewriter;
+  unique_function<std::string(StringRef)> CASPathRewriter;
 };
 
 } // namespace cas

--- a/llvm/lib/CAS/CASOutputBackend.cpp
+++ b/llvm/lib/CAS/CASOutputBackend.cpp
@@ -41,18 +41,19 @@ private:
 CASOutputBackend::CASOutputBackend(
     std::shared_ptr<CASDB> CAS,
     IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend,
-    function_ref<std::string(StringRef)> CASPathRewriter)
-    : CASOutputBackend(*CAS, std::move(CASIDOutputBackend), CASPathRewriter) {
+    unique_function<std::string(StringRef)> CASPathRewriter)
+    : CASOutputBackend(*CAS, std::move(CASIDOutputBackend),
+                       std::move(CASPathRewriter)) {
   this->OwnedCAS = std::move(CAS);
 }
 
 CASOutputBackend::CASOutputBackend(
     CASDB &CAS, IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend,
-    function_ref<std::string(StringRef)> CASPathRewriter)
+    unique_function<std::string(StringRef)> CASPathRewriter)
     : StableUniqueEntityAdaptorType(
           sys::path::Style::native /*FIXME: should be posix?*/),
       CAS(CAS), CASIDOutputBackend(std::move(CASIDOutputBackend)),
-      CASPathRewriter(CASPathRewriter) {}
+      CASPathRewriter(std::move(CASPathRewriter)) {}
 
 CASOutputBackend::~CASOutputBackend() = default;
 


### PR DESCRIPTION
`llvm::function_ref` is never supposed to escape, but it's currently
escaping in CASOutputBackend's constructor! This was caused by
a3c4bdaaf6c1f484dc8f93a84f2cc091c9e5f9d6. Switch to unique_function.