### PR TITLE
[lldb] Search PrivateFrameworks when using an internal SDK

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -79,7 +79,7 @@ class BuilderDarwin(Builder):
         if configuration.dsymutil:
             args['DSYMUTIL'] = configuration.dsymutil
 
-        if 'internal' in configuration.apple_sdk:
+        if configuration.apple_sdk and 'internal' in configuration.apple_sdk:
             sdk_root = lldbutil.get_xcode_sdk_root(configuration.apple_sdk)
             if sdk_root:
                 private_frameworks = os.path.join(sdk_root, 'System',

--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -79,6 +79,14 @@ class BuilderDarwin(Builder):
         if configuration.dsymutil:
             args['DSYMUTIL'] = configuration.dsymutil
 
+        if 'internal' in configuration.apple_sdk:
+            sdk_root = lldbutil.get_xcode_sdk_root(configuration.apple_sdk)
+            if sdk_root:
+                private_frameworks = os.path.join(sdk_root, 'System',
+                                                  'Library',
+                                                  'PrivateFrameworks')
+                args['FRAMEWORK_INCLUDES'] = '-F{}'.format(private_frameworks)
+
         operating_system, env = get_os_and_env()
         if operating_system and operating_system != "macosx":
             builder_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Make sure to add the PrivateFrameworks directory to the frameworks path
when using an internal SDK. This is necessary for the "on-device" test
suite.

rdar://84519268

Differential revision: https://reviews.llvm.org/D114742

(cherry picked from commit 0a302f66673720a0d3fd3f0ce32ec9cfda428cf1)
