### PR TITLE
🍒/5.7/af2ea183f5e3+257f98466222+66b829ac7b68

### DIFF
--- a/lldb/test/API/commands/expression/import-std-module/missing-module-sources/TestStdModuleSourcesMissing.py
+++ b/lldb/test/API/commands/expression/import-std-module/missing-module-sources/TestStdModuleSourcesMissing.py
@@ -18,6 +18,7 @@ class TestCase(TestBase):
     # test configurations where libc++ is actually supposed to be tested.
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIfRemote
     def test(self):
         # The path to our temporary target root that contains the temporary
         # module sources.

--- a/lldb/test/API/commands/platform/basic/TestPlatformCommand.py
+++ b/lldb/test/API/commands/platform/basic/TestPlatformCommand.py
@@ -95,6 +95,7 @@ class PlatformCommandTestCase(TestBase):
                     "error: timed out waiting for shell command to complete"])
 
     @no_debug_info_test
+    @skipIfRemote
     def test_host_shell_interpreter(self):
         """ Test the host platform shell with a different interpreter """
         self.build()

--- a/lldb/test/API/commands/platform/basic/TestPlatformPython.py
+++ b/lldb/test/API/commands/platform/basic/TestPlatformPython.py
@@ -82,6 +82,7 @@ class PlatformPythonTestCase(TestBase):
 
     @add_test_categories(['pyapi'])
     @no_debug_info_test
+    @skipIfRemote
     def test_shell_interpreter(self):
         """ Test a shell with a custom interpreter """
         platform = self.dbg.GetSelectedPlatform()

--- a/lldb/test/API/commands/platform/sdk/TestPlatformSDK.py
+++ b/lldb/test/API/commands/platform/sdk/TestPlatformSDK.py
@@ -43,6 +43,7 @@ class PlatformSDKTestCase(TestBase):
     @skipUnlessDarwin
     @expectedFailureIfFn(no_debugserver)
     @expectedFailureIfFn(port_not_available)
+    @skipIfRemote
     def test_macos_sdk(self):
         self.build()
 

--- a/lldb/test/API/commands/settings/quoting/TestQuoting.py
+++ b/lldb/test/API/commands/settings/quoting/TestQuoting.py
@@ -50,16 +50,17 @@ class SettingsCommandTestCase(TestBase):
         to stdout. Compare the stdout with args_out."""
 
         filename = SettingsCommandTestCase.output_file_name
+        outfile = self.getBuildArtifact(filename)
 
         if lldb.remote_platform:
-            outfile = lldb.remote_platform.GetWorkingDirectory() + filename
+            outfile_arg = os.path.join(lldb.remote_platform.GetWorkingDirectory(), filename)
         else:
-            outfile = self.getBuildArtifact(filename)
+            outfile_arg = outfile
 
-        self.runCmd("process launch -- %s %s" % (outfile, args_in))
+        self.runCmd("process launch -- %s %s" % (outfile_arg, args_in))
 
         if lldb.remote_platform:
-            src_file_spec = lldb.SBFileSpec(outfile, False)
+            src_file_spec = lldb.SBFileSpec(outfile_arg, False)
             dst_file_spec = lldb.SBFileSpec(outfile, True)
             lldb.remote_platform.Get(src_file_spec, dst_file_spec)
 
@@ -67,5 +68,4 @@ class SettingsCommandTestCase(TestBase):
             output = f.read()
 
         self.RemoveTempFile(outfile)
-
         self.assertEqual(output, args_out)

--- a/lldb/test/API/lang/objc/conflicting-definition/Test/Test.m
+++ b/lldb/test/API/lang/objc/conflicting-definition/Test/Test.m
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 #import "Test.h"
 
 @implementation Test

--- a/lldb/test/API/lang/objc/conflicting-definition/TestExt/TestExt.m
+++ b/lldb/test/API/lang/objc/conflicting-definition/TestExt/TestExt.m
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 #import "TestExt.h"
 #import "Foo.h"
 

--- a/lldb/test/API/macosx/profile_vrs_detach/TestDetachVrsProfile.py
+++ b/lldb/test/API/macosx/profile_vrs_detach/TestDetachVrsProfile.py
@@ -23,6 +23,7 @@ class TestDetachVrsProfile(TestBase):
 
     @skipUnlessDarwin
     @skipIfOutOfTreeDebugserver
+    @skipIfRemote
     def test_profile_and_detach(self):
         """There can be many tests in a test case - describe this test here."""
         self.build()

--- a/lldb/test/API/python_api/process/TestProcessAPI.py
+++ b/lldb/test/API/python_api/process/TestProcessAPI.py
@@ -320,6 +320,7 @@ class ProcessAPITestCase(TestBase):
             print("Number of supported hardware watchpoints: %d" % num)
 
     @no_debug_info_test
+    @skipIfRemote
     def test_get_process_info(self):
         """Test SBProcess::GetProcessInfo() API with a locally launched process."""
         self.build()

--- a/lldb/test/API/python_api/sbmodule/TestSBModule.py
+++ b/lldb/test/API/python_api/sbmodule/TestSBModule.py
@@ -21,6 +21,7 @@ class SBModuleAPICase(TestBase):
             os.kill(self.background_pid, signal.SIGKILL)
 
     @skipUnlessDarwin
+    @skipIfRemote
     def test_module_is_file_backed(self):
         """Test the SBModule::IsFileBacked() method"""
         self.build()

--- a/lldb/test/API/python_api/target/TestTargetAPI.py
+++ b/lldb/test/API/python_api/target/TestTargetAPI.py
@@ -460,6 +460,7 @@ class TargetAPITestCase(TestBase):
         self.assertTrue(desc1 and desc2 and desc1 == desc2,
                         "The two addresses should resolve to the same symbol")
 
+    @skipIfRemote
     def test_default_arch(self):
         """ Test the other two target create methods using LLDB_ARCH_DEFAULT. """
         self.build()


### PR DESCRIPTION
- [lldb] Import Foundation in TestConflictingDefinition.py
- [lldb] Fix TestQuoting when run remotely
- [lldb] Skip a bunch of tests that shouldn't run remotely
