### PR TITLE
Simplify NativeHashedStorageHandler()

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -459,14 +459,12 @@ NativeHashedStorageHandler::NativeHashedStorageHandler(
       std::vector<TypeSystemSwift::TupleElement> tuple_elements{
           {g_key, key_type}, {g_value, value_type}};
       m_element_type = type_system->CreateTupleType(tuple_elements);
-      auto element_stride = m_element_type.GetByteStride(m_process);
-      if (element_stride)
-        m_key_stride_padded = *element_stride - m_value_stride;
       Status error;
-      llvm::Optional<uint64_t> result = runtime->GetMemberVariableOffset(
-          m_element_type, nativeStorage_sp.get(), "1", &error);
-      if (result)
-        m_key_stride_padded = result.getValue();
+      if (auto result = runtime->GetMemberVariableOffset(
+              m_element_type, nativeStorage_sp.get(), "1", &error))
+        m_key_stride_padded = *result;
+      else if (auto element_stride = m_element_type.GetByteStride(m_process))
+        m_key_stride_padded = *element_stride - m_value_stride;
     }
   } else {
     m_element_type = key_type;

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -459,20 +459,14 @@ NativeHashedStorageHandler::NativeHashedStorageHandler(
       std::vector<TypeSystemSwift::TupleElement> tuple_elements{
           {g_key, key_type}, {g_value, value_type}};
       m_element_type = type_system->CreateTupleType(tuple_elements);
-      auto *swift_type = 
-          m_element_type.GetCanonicalType().GetOpaqueQualType();
       auto element_stride = m_element_type.GetByteStride(m_process);
-      if (element_stride) {
+      if (element_stride)
         m_key_stride_padded = *element_stride - m_value_stride;
-      }
-      if (type_system->IsTupleType(swift_type)) {
-        Status error;
-        llvm::Optional<uint64_t> result = runtime->GetMemberVariableOffset(
-            {type_system, swift_type}, nativeStorage_sp.get(), "1",
-            &error);
-        if (result)
-          m_key_stride_padded = result.getValue();
-      }
+      Status error;
+      llvm::Optional<uint64_t> result = runtime->GetMemberVariableOffset(
+          m_element_type, nativeStorage_sp.get(), "1", &error);
+      if (result)
+        m_key_stride_padded = result.getValue();
     }
   } else {
     m_element_type = key_type;

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -459,9 +459,8 @@ NativeHashedStorageHandler::NativeHashedStorageHandler(
       std::vector<TypeSystemSwift::TupleElement> tuple_elements{
           {g_key, key_type}, {g_value, value_type}};
       m_element_type = type_system->CreateTupleType(tuple_elements);
-      Status error;
       if (auto result = runtime->GetMemberVariableOffset(
-              m_element_type, nativeStorage_sp.get(), "1", &error))
+              m_element_type, nativeStorage_sp.get(), "1"))
         m_key_stride_padded = *result;
       else if (auto element_stride = m_element_type.GetByteStride(m_process))
         m_key_stride_padded = *element_stride - m_value_stride;


### PR DESCRIPTION
This avoids an opportunity for type(system) confusion, by always using
the full CompilerType instead of assuming that the type system hasn't
changed in CreateTupleType and GetCanononicalType(). Also the call to
GetCanonicalType() and IsTupleType was redundant.

Unfortunately I was not able to construct a reproducer for the type
confusion using a REPL-defined alias type, but I received a crashlog
that seems indicate that it's indeed possible.

rdar://[91291458