### PR TITLE
Restore import search path recovery behavior

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -177,6 +177,8 @@ public:
   
   bool GetSwiftReadMetadataFromDSYM() const;
 
+  bool GetSwiftDiscoverImplicitSearchPaths() const;
+
   bool GetSwiftAutoImportFrameworks() const;
 
   bool GetEnableAutoImportClangModules() const;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1960,7 +1960,8 @@ static SwiftASTContext *GetModuleSwiftASTContext(Module &module) {
 /// its module SwiftASTContext to Target.
 static void
 ProcessModule(ModuleSP module_sp, std::string m_description,
-              bool use_all_compiler_flags, Target &target, llvm::Triple triple,
+              bool discover_implicit_search_paths, bool use_all_compiler_flags,
+              Target &target, llvm::Triple triple,
               std::vector<std::string> &module_search_paths,
               std::vector<std::pair<std::string, bool>> &framework_search_paths,
               std::vector<std::string> &extra_clang_args) {
@@ -2112,13 +2113,20 @@ ProcessModule(ModuleSP module_sp, std::string m_description,
       return;
 
     SwiftASTContext *ast_context = ts->GetSwiftASTContext();
-    if (ast_context && !ast_context->HasErrors()) {
-      if (use_all_compiler_flags ||
-          target.GetExecutableModulePointer() == module_sp.get()) {
-        const auto &opts = ast_context->GetSearchPathOptions();
-        for (const auto &fwsp : opts.getFrameworkSearchPaths())
-          framework_search_paths.push_back({fwsp.Path, fwsp.IsSystem});
-      }
+    if (!ast_context || ast_context->HasErrors())
+      return;
+
+    if (discover_implicit_search_paths) {
+      const auto &opts = ast_context->GetSearchPathOptions();
+      for (const auto &isp : opts.getImportSearchPaths())
+        module_search_paths.push_back(isp);
+    }
+
+    if (use_all_compiler_flags ||
+        target.GetExecutableModulePointer() == module_sp.get()) {
+      const auto &opts = ast_context->GetSearchPathOptions();
+      for (const auto &fwsp : opts.getFrameworkSearchPaths())
+        framework_search_paths.push_back({fwsp.Path, fwsp.IsSystem});
     }
   }
 }
@@ -2303,6 +2311,10 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   std::string resource_dir = swift_ast_sp->GetResourceDir(triple);
   ConfigureResourceDirs(swift_ast_sp->GetCompilerInvocation(),
                         FileSpec(resource_dir), triple);
+  const bool discover_implicit_search_paths =
+      target.GetSwiftDiscoverImplicitSearchPaths();
+  if (discover_implicit_search_paths)
+    warmup_astcontexts();
 
   const bool use_all_compiler_flags =
       !got_serialized_options || target.GetUseAllCompilerFlags();
@@ -2310,8 +2322,9 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   for (size_t mi = 0; mi != num_images; ++mi) {
     std::vector<std::string> extra_clang_args;
     ProcessModule(target.GetImages().GetModuleAtIndex(mi), m_description,
-                  use_all_compiler_flags, target, triple, module_search_paths,
-                  framework_search_paths, extra_clang_args);
+                  discover_implicit_search_paths, use_all_compiler_flags,
+                  target, triple, module_search_paths, framework_search_paths,
+                  extra_clang_args);
     swift_ast_sp->AddExtraClangArgs(extra_clang_args);
   }
 
@@ -4888,6 +4901,8 @@ void SwiftASTContextForExpressions::ModulesDidLoad(ModuleList &module_list) {
   if (!target_sp)
     return;
 
+  bool discover_implicit_search_paths =
+      target_sp->GetSwiftDiscoverImplicitSearchPaths();
   bool use_all_compiler_flags = target_sp->GetUseAllCompilerFlags();
   unsigned num_images = module_list.GetSize();
   for (size_t mi = 0; mi != num_images; ++mi) {
@@ -4895,8 +4910,9 @@ void SwiftASTContextForExpressions::ModulesDidLoad(ModuleList &module_list) {
     std::vector<std::pair<std::string, bool>> framework_search_paths;
     std::vector<std::string> extra_clang_args;
     lldb::ModuleSP module_sp = module_list.GetModuleAtIndex(mi);
-    ProcessModule(module_sp, m_description, use_all_compiler_flags, *target_sp,
-                  GetTriple(), module_search_paths, framework_search_paths,
+    ProcessModule(module_sp, m_description, discover_implicit_search_paths,
+                  use_all_compiler_flags, *target_sp, GetTriple(),
+                  module_search_paths, framework_search_paths,
                   extra_clang_args);
     // If the use-all-compiler-flags setting is enabled, the expression
     // context is supposed to merge all search paths from all dylibs.

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4175,7 +4175,6 @@ bool TargetProperties::GetSwiftCreateModuleContextsInParallel() const {
     return true;
 }
 
-
 bool TargetProperties::GetSwiftReadMetadataFromFileCache() const {
   const Property *exp_property = m_collection_sp->GetPropertyAtIndex(
       nullptr, false, ePropertyExperimental);
@@ -4208,6 +4207,18 @@ bool TargetProperties::GetSwiftReadMetadataFromDSYM() const {
   if (exp_values)
     return exp_values->GetPropertyAtIndexAsBoolean(
         nullptr, ePropertySwiftReadMetadataFromDSYM, true);
+
+  return true;
+}
+
+bool TargetProperties::GetSwiftDiscoverImplicitSearchPaths() const {
+  const Property *exp_property = m_collection_sp->GetPropertyAtIndex(
+      nullptr, false, ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    return exp_values->GetPropertyAtIndexAsBoolean(
+        nullptr, ePropertySwiftDiscoverImplicitSearchPaths, true);
 
   return true;
 }

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -16,6 +16,9 @@ let Definition = "target_experimental" in {
   def SwiftReadMetadataFromDSYM: Property<"swift-read-metadata-from-dsym", "Boolean">,
     DefaultFalse,
     Desc<"Read Swift reflection metadata from the dsym instead of the process when possible">;
+  def SwiftDiscoverImplicitSearchPaths: Property<"swift-discover-implicit-search-paths", "Boolean">,
+    DefaultTrue,
+    Desc<"Discover implicit search paths from all implicitly imported Swift modules and make them available to the expression context. A Swift module built with -serialize-debugging-options can contain additional search paths which are discovered as the module is imported. This optiondoes an eager import of all modules first to make sure all implicit search paths are availableto the expression evaluator. If the build system registers all Swift modules with the linker (Darwin: via -add_ast_path, Other platforms: -module-wrap), turning this on is not necessary.">;
 }
 
 let Definition = "target" in {

--- a/lldb/test/API/lang/swift/expression/import_search_paths/Direct.swift
+++ b/lldb/test/API/lang/swift/expression/import_search_paths/Direct.swift
@@ -1,0 +1,6 @@
+import Indirect
+
+public struct MyType {
+    public let inner = InnerType()
+    public init() {}
+}

--- a/lldb/test/API/lang/swift/expression/import_search_paths/Makefile
+++ b/lldb/test/API/lang/swift/expression/import_search_paths/Makefile
@@ -1,0 +1,30 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
+LD_EXTRAS = -L$(BUILDDIR) -lDirect
+
+all: libDirect $(EXE)
+.phony: libDirect libHidden
+
+include Makefile.rules
+
+libHidden: $(SRCDIR)/hidden/Indirect.swift
+	mkdir -p $(BUILDDIR)/hidden
+	$(MAKE) -f $(MAKEFILE_RULES) \
+		-C $(BUILDDIR)/hidden VPATH=$(SRCDIR)/hidden \
+		DYLIB_ONLY=YES \
+		DYLIB_NAME=Indirect \
+		DYLIB_SWIFT_SOURCES=Indirect.swift \
+		DYLIB_MODULENAME=Indirect \
+		SWIFTFLAGS_EXTRAS="-gnone" \
+		MAKE_DSYM=NO
+
+libDirect: $(SRCDIR)/Direct.swift libHidden
+	$(MAKE) -f $(MAKEFILE_RULES) \
+		DYLIB_ONLY=YES \
+		DYLIB_NAME=Direct \
+		DYLIB_SWIFT_SOURCES=Direct.swift \
+		DYLIB_MODULENAME=Direct \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR)/hidden" \
+		LD_EXTRAS="-L$(BUILDDIR)/hidden -lIndirect" \
+		MAKE_DSYM=NO
+

--- a/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
+++ b/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
@@ -1,0 +1,51 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+class TestSwiftImportSearchPaths(lldbtest.TestBase):
+
+    NO_DEBUG_INFO_TESTCASE = True
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    def test_positive(self):
+        self.do_test('true')
+
+    @swiftTest
+    def test_negative(self):
+        self.do_test('false')
+        
+    def do_test(self, flag):
+        """Test a .swiftmodule that was compiled with serialized debugging
+           options, using a search path to another module it imports. We then
+           need to build a (third) Swift (application) module with search paths
+           to #1 but not to #2, relying on the serialized options."""
+        self.build()
+        self.expect('settings set '
+                    + 'target.experimental.swift-discover-implicit-search-paths '
+                    + flag)
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'),
+            extra_images=['Direct', self.getBuildArtifact('hidden/libIndirect')])
+
+        log = self.getBuildArtifact("types.log")
+        self.expect('settings show '
+                    + 'target.experimental')
+        self.expect("log enable lldb types -f " + log)
+        self.expect("expr -- x.inner.hidden", substrs=['=', '42'])
+
+        import io, re
+        logfile = io.open(log, "r", encoding='utf-8')
+        sanity = 0
+        found = 0
+        for line in logfile:
+            if re.match(r'.*SwiftASTContextForModule\("a\.out"\)::LogConfiguration\(\).*hidden$',
+                        line.strip('\n')):
+                sanity += 1
+            elif re.match(r'.*SwiftASTContextForExpressions::LogConfiguration\(\).*hidden$',
+                          line.strip('\n')):
+                found += 1
+        self.assertEqual(sanity, 1)
+        self.assertEqual(found, 1 if flag == 'true' else 0)

--- a/lldb/test/API/lang/swift/expression/import_search_paths/hidden/Indirect.swift
+++ b/lldb/test/API/lang/swift/expression/import_search_paths/hidden/Indirect.swift
@@ -1,0 +1,4 @@
+public class InnerType {
+  let hidden = 42
+  public init() {}
+}

--- a/lldb/test/API/lang/swift/expression/import_search_paths/main.swift
+++ b/lldb/test/API/lang/swift/expression/import_search_paths/main.swift
@@ -1,0 +1,4 @@
+import Direct
+
+let x = MyType()
+print("break here \(x)")


### PR DESCRIPTION
This functionality regressed in 5.6. Thanks to @dreampiggy for reporting this in https://github.com/apple/llvm-project/pull/3353!

rdar://91509016