### PR TITLE
[DependencyScanningCASFilesystem] Fix issue where the PP skipped range mappings are not set when doing CAS dep-scanning

### DIFF
--- a/clang/include/clang/Lex/PreprocessorExcludedConditionalDirectiveSkipMapping.h
+++ b/clang/include/clang/Lex/PreprocessorExcludedConditionalDirectiveSkipMapping.h
@@ -23,7 +23,7 @@ using PreprocessorSkippedRangeMapping = llvm::DenseMap<unsigned, unsigned>;
 /// The datastructure that holds the mapping between the active memory buffers
 /// and the individual skip mappings.
 using ExcludedPreprocessorDirectiveSkipMapping =
-    llvm::DenseMap<const char *, Optional<PreprocessorSkippedRangeMapping>>;
+    llvm::DenseMap<const char *, const PreprocessorSkippedRangeMapping *>;
 
 } // end namespace clang
 

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
@@ -84,6 +84,7 @@ private:
     Optional<StringRef> Buffer;
     llvm::vfs::Status Status;
     Optional<llvm::cas::CASID> ID;
+    std::unique_ptr<PreprocessorSkippedRangeMapping> PPSkippedRangeMapping;
   };
   llvm::BumpPtrAllocator EntryAlloc;
   llvm::StringMap<FileEntry, llvm::BumpPtrAllocator> Entries;
@@ -94,13 +95,15 @@ private:
     // Only filled if the Entry is nullptr.
     llvm::ErrorOr<llvm::vfs::Status> Status;
   };
-  Expected<StringRef>
-  computeMinimized(llvm::cas::CASID InputDataID, StringRef Identifier,
-                   Optional<llvm::cas::CASID> &MinimizedDataID);
+  Expected<StringRef> computeMinimized(
+      llvm::cas::CASID InputDataID, StringRef Identifier,
+      Optional<llvm::cas::CASID> &MinimizedDataID,
+      std::unique_ptr<PreprocessorSkippedRangeMapping> &PPSkippedRangeMapping);
 
-  Expected<StringRef> getMinimized(llvm::cas::CASID OutputID,
-                                   StringRef Identifier,
-                                   Optional<llvm::cas::CASID> &MinimizedDataID);
+  Expected<StringRef> getMinimized(
+      llvm::cas::CASID OutputID, StringRef Identifier,
+      Optional<llvm::cas::CASID> &MinimizedDataID,
+      std::unique_ptr<PreprocessorSkippedRangeMapping> &PPSkippedRangeMapping);
 
   Expected<StringRef> getOriginal(llvm::cas::CASID InputDataID);
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningFilesystem.cpp
@@ -343,7 +343,7 @@ llvm::ErrorOr<std::unique_ptr<llvm::vfs::File>> MinimizedVFSFile::create(
 
   const auto *EntrySkipMappings = Entry.getPPSkippedRangeMapping();
   if (EntrySkipMappings && !EntrySkipMappings->empty() && PPSkipMappings)
-    (*PPSkipMappings)[Result->Buffer->getBufferStart()] = *EntrySkipMappings;
+    (*PPSkipMappings)[Result->Buffer->getBufferStart()] = EntrySkipMappings;
 
   return llvm::ErrorOr<std::unique_ptr<llvm::vfs::File>>(
       std::unique_ptr<llvm::vfs::File>(std::move(Result)));


### PR DESCRIPTION
Previously the skipped range mappings were only applied to the preprocessor's `PPSkipMappings` when getting the minimized info,
but the minimized info was getting cached for subsequent invocations while the preprocessor was clearing out its `PPSkipMappings`;
this resulted in the PP skipped range optimization only being active for the first invocation of a `DependencyScanningWorker`.

To fix this, do as `DependencyScanningFilesystem` and cache the range mappings and apply them when `openFileForRead()` is called.

This reduces CAS dep-scanning time for clang sources by ~ -17%.