### PR TITLE
Cleanup libclang dependency scanning API

### DIFF
--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -70,9 +70,8 @@ typedef struct {
   CXStringSet *ModuleDeps;
 
   /**
-   * The canonical command-line to build this module, excluding arguments
-   * containing modules-related paths: "-fmodule-file=", "-o",
-   * "-fmodule-map-file=".
+   * The canonical command line to build this module, excluding arguments
+   * containing modules-related paths: "-fmodule-file=", "-o".
    */
   CXStringSet *BuildArguments;
 } CXModuleDependency;
@@ -195,9 +194,7 @@ typedef void CXModuleDiscoveredCallback(void *Context,
  * Returns the list of file dependencies for a particular compiler invocation.
  *
  * \param argc the number of compiler invocation arguments (including argv[0]).
- * \param argv the compiler invocation arguments (including argv[0]).
- *             the invocation may be a -cc1 clang invocation or a driver
- *             invocation.
+ * \param argv the compiler driver invocation arguments (including argv[0]).
  * \param WorkingDirectory the directory in which the invocation runs.
  * \param MDC a callback that is called whenever a new module is discovered.
  *            This may receive the same module on different workers. This should

--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -70,9 +70,9 @@ typedef struct {
   CXStringSet *ModuleDeps;
 
   /**
-   * The canonical command-line or additional arguments needed to build this
-   * module, excluding arguments containing modules-related paths:
-   * "-fmodule-file=", "-o", "-fmodule-map-file=".
+   * The canonical command-line to build this module, excluding arguments
+   * containing modules-related paths: "-fmodule-file=", "-o",
+   * "-fmodule-map-file=".
    */
   CXStringSet *BuildArguments;
 } CXModuleDependency;
@@ -93,8 +93,8 @@ typedef struct {
   CXStringSet *ModuleDeps;
 
   /**
-   * Full or additional arguments needed to build this file, excluding
-   * `-fmodule-file=`.
+   * Full command line to build this file, excluding arguments containing
+   * modules-related paths: `-fmodule-file=`.
    */
   CXStringSet *BuildArguments;
 } CXFileDependencies;
@@ -184,7 +184,7 @@ CINDEX_LINKAGE void clang_experimental_DependencyScannerWorker_dispose_v0(
  * \c CXDependencyMode_Full mode.
  *
  * \param Context the context that was passed to
- *         \c clang_experimental_DependencyScannerWorker_getFileDependencies_v0.
+ *         \c clang_experimental_DependencyScannerWorker_getFileDependencies_vX.
  * \param MDS the list of discovered modules. Must be freed by calling
  *            \c clang_experimental_ModuleDependencySet_dispose.
  */
@@ -214,37 +214,13 @@ typedef void CXModuleDiscoveredCallback(void *Context,
  *          \c clang_experimental_FileDependencies_dispose.
  */
 CINDEX_LINKAGE CXFileDependencies *
-clang_experimental_DependencyScannerWorker_getFileDependencies_v0(
-    CXDependencyScannerWorker Worker, int argc, const char *const *argv,
-    const char *WorkingDirectory, CXModuleDiscoveredCallback *MDC,
-    void *Context, CXString *error);
-
-/**
- * Same as \c clang_experimental_DependencyScannerWorker_getFileDependencies_v0,
- * but \c BuildArguments of each \c CXModuleDependency passed to \c MDC contains
- * the canonical Clang command line, not just additional arguments.
- */
-CINDEX_LINKAGE CXFileDependencies *
-clang_experimental_DependencyScannerWorker_getFileDependencies_v1(
-    CXDependencyScannerWorker Worker, int argc, const char *const *argv,
-    const char *WorkingDirectory, CXModuleDiscoveredCallback *MDC,
-    void *Context, CXString *error);
-
-/**
- * Same as \c clang_experimental_DependencyScannerWorker_getFileDependencies_v1,
- * but \c BuildArguments of \c CXFileDependencies contains the full Clang
- * command line, not just additional arguments, and \c BuildArguments of each
- * \c CXModuleDependency now contain the necessary '-fmodule-map-file='
- * arguments.
- */
-CINDEX_LINKAGE CXFileDependencies *
 clang_experimental_DependencyScannerWorker_getFileDependencies_v2(
     CXDependencyScannerWorker Worker, int argc, const char *const *argv,
     const char *WorkingDirectory, CXModuleDiscoveredCallback *MDC,
     void *Context, CXString *error);
 
 /**
- * Same as \c clang_experimental_DependencyScannerWorker_getFileDependencies_v1,
+ * Same as \c clang_experimental_DependencyScannerWorker_getFileDependencies_v2,
  * but get the dependencies by module name alone.
  */
 CINDEX_LINKAGE CXFileDependencies *

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4880,22 +4880,6 @@ def emit_fir : Flag<["-"], "emit-fir">, Alias<emit_mlir>;
 } // let Flags = [FC1Option, FlangOnlyOption]
 
 //===----------------------------------------------------------------------===//
-// Option Options
-//===----------------------------------------------------------------------===//
-
-let Flags = [CC1Option, NoDriverOption] in {
-
-def remove_preceeding_explicit_module_build_incompatible_options :
-  Flag<["-"], "remove-preceeding-explicit-module-build-incompatible-options">,
-  HelpText<"Removes any arguments before this one that would be incompatible "
-           "with explicitly building a module. This includes things like -o "
-           "and input files. This option can be used to append arguments to "
-           "convert a build of a translation unit with implicit modules "
-           "into an explicit build of a specific module.">;
-
-} // let Flags = [CC1Option, NoDriverOption]
-
-//===----------------------------------------------------------------------===//
 // Target Options (cc1 + cc1as)
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -56,10 +56,6 @@ struct FullDependencies {
 
   /// Get the full command line, excluding -fmodule-file=" arguments.
   std::vector<std::string> getCommandLineWithoutModulePaths() const;
-
-  /// Get additional arguments suitable for appending to the original Clang
-  /// command line, excluding "-fmodule-file=" arguments.
-  std::vector<std::string> getAdditionalArgsWithoutModulePaths() const;
 };
 
 struct FullDependenciesResult {

--- a/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
@@ -119,11 +119,6 @@ struct ModuleDeps {
   /// Gets the canonical command line suitable for passing to clang, excluding
   /// "-fmodule-file=" and "-o" arguments.
   std::vector<std::string> getCanonicalCommandLineWithoutModulePaths() const;
-
-  /// Gets additional arguments suitable for appending to the original Clang
-  /// command line, excluding arguments containing modules-related paths:
-  /// "-fmodule-file=", "-o", "-fmodule-map-file=".
-  std::vector<std::string> getAdditionalArgsWithoutModulePaths() const;
 };
 
 class ModuleDepCollector;

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4721,28 +4721,6 @@ static bool ParseTargetArgs(TargetOptions &Opts, ArgList &Args,
   return Diags.getNumErrors() == NumErrorsBefore;
 }
 
-static void removeExplicitModuleBuildIncompatibleOptions(InputArgList &Args) {
-  auto REMBIO = llvm::find_if(Args, [](const Arg *A){
-    return A->getOption().getID() ==
-        OPT_remove_preceeding_explicit_module_build_incompatible_options;
-  });
-  if (REMBIO == Args.end())
-    return;
-
-  llvm::SmallPtrSet<const Arg *, 32> BeforeREMBIO;
-  for (auto I = Args.begin(); I != REMBIO; ++I)
-    BeforeREMBIO.insert(*I);
-
-  Args.eraseArgIf([&](const Arg *A) {
-    if (!BeforeREMBIO.count(A))
-      return false;
-    const Option &O = A->getOption();
-    return O.matches(OPT_INPUT) ||
-           O.matches(OPT_Action_Group) ||
-           O.matches(OPT__output);
-  });
-}
-
 bool CompilerInvocation::CreateFromArgsImpl(
     CompilerInvocation &Res, ArrayRef<const char *> CommandLineArgs,
     DiagnosticsEngine &Diags, const char *Argv0) {
@@ -4754,8 +4732,6 @@ bool CompilerInvocation::CreateFromArgsImpl(
   unsigned MissingArgIndex, MissingArgCount;
   InputArgList Args = Opts.ParseArgs(CommandLineArgs, MissingArgIndex,
                                      MissingArgCount, IncludedFlagsBitmask);
-
-  removeExplicitModuleBuildIncompatibleOptions(Args);
 
   LangOptions &LangOpts = *Res.getLangOpts();
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -27,9 +27,10 @@ std::vector<std::string>
 FullDependencies::getCommandLineWithoutModulePaths() const {
   std::vector<std::string> Args = OriginalCommandLine;
 
-  std::vector<std::string> AdditionalArgs =
-      getAdditionalArgsWithoutModulePaths();
-  Args.insert(Args.end(), AdditionalArgs.begin(), AdditionalArgs.end());
+  Args.push_back("-fno-implicit-modules");
+  Args.push_back("-fno-implicit-module-maps");
+  for (const PrebuiltModuleDep &PMD : PrebuiltModuleDeps)
+    Args.push_back("-fmodule-file=" + PMD.PCMFile);
 
   // This argument is unused in explicit compiles.
   llvm::erase_if(Args, [](const std::string &Arg) {
@@ -38,19 +39,6 @@ FullDependencies::getCommandLineWithoutModulePaths() const {
 
   // TODO: Filter out the remaining implicit modules leftovers
   // (e.g. "-fmodules-prune-interval=" or "-fmodules-prune-after=").
-
-  return Args;
-}
-
-std::vector<std::string>
-FullDependencies::getAdditionalArgsWithoutModulePaths() const {
-  std::vector<std::string> Args{
-      "-fno-implicit-modules",
-      "-fno-implicit-module-maps",
-  };
-
-  for (const PrebuiltModuleDep &PMD : PrebuiltModuleDeps)
-    Args.push_back("-fmodule-file=" + PMD.PCMFile);
 
   return Args;
 }

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -120,22 +120,6 @@ ModuleDeps::getCanonicalCommandLineWithoutModulePaths() const {
   return serializeCompilerInvocation(BuildInvocation);
 }
 
-std::vector<std::string>
-ModuleDeps::getAdditionalArgsWithoutModulePaths() const {
-  std::vector<std::string> Ret{
-    "-remove-preceeding-explicit-module-build-incompatible-options",
-    "-fno-implicit-modules", "-emit-module", "-fmodule-name=" + ID.ModuleName,
-  };
-
-  if (IsSystem)
-    Ret.push_back("-fsystem-module");
-
-  if (BuildInvocation.getLangOpts()->NeededByPCHOrCompilationUsesPCH)
-    Ret.push_back("-fmodule-related-to-pch");
-
-  return Ret;
-}
-
 void ModuleDepCollectorPP::FileChanged(SourceLocation Loc,
                                        FileChangeReason Reason,
                                        SrcMgr::CharacteristicKind FileType,

--- a/clang/test/Modules/remove-preceeding-explicit-module-build-incompatible-options.c
+++ b/clang/test/Modules/remove-preceeding-explicit-module-build-incompatible-options.c
@@ -1,6 +1,0 @@
-// RUN: rm -rf %t
-// RUN: %clang_cc1 -emit-obj -o %t.o input-that-doesnt-exist.c \
-// RUN:   -remove-preceeding-explicit-module-build-incompatible-options \
-// RUN:   -emit-llvm-bc -o %t.bc %s
-// RUN: not ls %t.o
-// RUN: llvm-dis %t.bc

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -145,15 +145,15 @@ static llvm::cl::opt<ScanningOutputFormat> Format(
 // Build tools that want to put the PCM files in a different location should use
 // the C++ APIs instead, of which there are two flavors:
 //
-// 1. APIs that generate arguments with paths to modulemap and PCM files via
-//    callbacks provided by the client:
-//     * ModuleDeps::getCanonicalCommandLine(LookupPCMPath, LookupModuleDeps)
-//     * FullDependencies::getAdditionalArgs(LookupPCMPath, LookupModuleDeps)
+// 1. APIs that generate arguments with paths PCM files via a callback provided
+//    by the client:
+//     * ModuleDeps::getCanonicalCommandLine(LookupPCMPath)
+//     * FullDependencies::getCommandLine(LookupPCMPath)
 //
-// 2. APIs that don't generate arguments with paths to modulemap or PCM files
-//    and instead expect the client to append them manually after the fact:
+// 2. APIs that don't generate arguments with paths PCM files and instead expect
+//     the client to append them manually after the fact:
 //     * ModuleDeps::getCanonicalCommandLineWithoutModulePaths()
-//     * FullDependencies::getAdditionalArgsWithoutModulePaths()
+//     * FullDependencies::getCommandLineWithoutModulePaths()
 //
 static llvm::cl::opt<bool> GenerateModulesPathArgs(
     "generate-modules-path-args",

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -242,41 +242,6 @@ getFileDependencies(CXDependencyScannerWorker W, int argc,
 }
 
 CXFileDependencies *
-clang_experimental_DependencyScannerWorker_getFileDependencies_v0(
-    CXDependencyScannerWorker W, int argc, const char *const *argv,
-    const char *WorkingDirectory, CXModuleDiscoveredCallback *MDC,
-    void *Context, CXString *error) {
-  return getFileDependencies(
-      W, argc, argv, WorkingDirectory, MDC, Context, error,
-      [](const FullDependencies &FD) {
-        return FD.getAdditionalArgsWithoutModulePaths();
-      },
-      [](const ModuleDeps &MD) {
-        return MD.getAdditionalArgsWithoutModulePaths();
-      });
-}
-
-CXFileDependencies *
-clang_experimental_DependencyScannerWorker_getFileDependencies_v1(
-    CXDependencyScannerWorker W, int argc, const char *const *argv,
-    const char *WorkingDirectory, CXModuleDiscoveredCallback *MDC,
-    void *Context, CXString *error) {
-  return getFileDependencies(
-      W, argc, argv, WorkingDirectory, MDC, Context, error,
-      [](const FullDependencies &FD) {
-        return FD.getAdditionalArgsWithoutModulePaths();
-      },
-      [](const ModuleDeps &MD) {
-        std::vector<std::string> Args =
-            MD.getCanonicalCommandLineWithoutModulePaths();
-        llvm::remove_if(Args, [](const std::string &Arg) {
-          return Arg.find("-fmodule-map-file=") == 0;
-        });
-        return Args;
-      });
-}
-
-CXFileDependencies *
 clang_experimental_DependencyScannerWorker_getFileDependencies_v2(
     CXDependencyScannerWorker W, int argc, const char *const *argv,
     const char *WorkingDirectory, CXModuleDiscoveredCallback *MDC,

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -279,8 +279,6 @@ LLVM_13 {
     clang_experimental_DependencyScannerService_dispose_v0;
     clang_experimental_DependencyScannerWorker_create_v0;
     clang_experimental_DependencyScannerWorker_dispose_v0;
-    clang_experimental_DependencyScannerWorker_getFileDependencies_v0;
-    clang_experimental_DependencyScannerWorker_getFileDependencies_v1;
     clang_experimental_DependencyScannerWorker_getFileDependencies_v2;
     clang_experimental_DependencyScannerWorker_getDependenciesByModuleName_v0;
     clang_experimental_FileDependencies_dispose;

--- a/llvm/include/llvm/Option/ArgList.h
+++ b/llvm/include/llvm/Option/ArgList.h
@@ -228,18 +228,6 @@ public:
 
   /// eraseArg - Remove any option matching \p Id.
   void eraseArg(OptSpecifier Id);
-  
-  /// eraseArgIf - Remove every `const Arg *A` for which P(A) is true.
-  template <typename Pred>
-  void eraseArgIf(Pred P) {
-    for (Arg *const &A : Args) {
-      if (P(A)) {
-        Arg **ArgsBegin = Args.data();
-        ArgsBegin[&A - ArgsBegin] = nullptr;
-        // Don't update OptRanges as it's not required and would be slow to do.
-      }
-    }
-  }
 
   /// @}
   /// @name Arg Access


### PR DESCRIPTION
The libclang API for dependency scanning contains a couple of old and unused functions (`_v0` and `_v1`). This PR removes those and all code that exists solely to support them. This cleanup should make it easier to upstream the API.