### PR TITLE
[ObjCARC] Tolerate missing attachedcall op by ignoring the bundle.

### DIFF
--- a/llvm/lib/Transforms/ObjCARC/ObjCARCContract.cpp
+++ b/llvm/lib/Transforms/ObjCARC/ObjCARCContract.cpp
@@ -580,8 +580,8 @@ bool ObjCARCContract::run(Function &F, AAResults *A, DominatorTree *D) {
 
     if (auto *CI = dyn_cast<CallInst>(Inst))
       if (objcarc::hasAttachedCallOpBundle(CI)) {
-        BundledInsts->insertRVCallWithColors(&*I, CI, BlockColors);
-        --I;
+        if (BundledInsts->insertRVCallWithColors(&*I, CI, BlockColors))
+          --I;
         Changed = true;
       }
 

--- a/llvm/test/Transforms/ObjCARC/contract-rv-attr-empty-bundle.ll
+++ b/llvm/test/Transforms/ObjCARC/contract-rv-attr-empty-bundle.ll
@@ -1,0 +1,32 @@
+; RUN: opt -objc-arc-contract -S < %s | FileCheck %s
+; RUN: opt -passes=objc-arc-contract -S < %s | FileCheck %s
+
+; CHECK-LABEL: define void @test0() {
+; CHECK: %[[CALL:.*]] = notail call i8* @foo() [ "clang.arc.attachedcall"() ]
+; CHECK-NEXT: call void asm sideeffect "mov\09fp, fp\09\09// marker for objc_retainAutoreleaseReturnValue", ""()
+; CHECK-NEXT: call i8* @llvm.objc.retainAutoreleasedReturnValue(i8* %[[CALL]])
+
+define void @test0() {
+  %call1 = notail call i8* @foo() [ "clang.arc.attachedcall"() ]
+  call i8* @llvm.objc.retainAutoreleasedReturnValue(i8* %call1)
+  ret void
+}
+
+; CHECK-LABEL: define void @test1() {
+; CHECK: %[[CALL:.*]] = notail call i8* @foo() [ "clang.arc.attachedcall"() ]
+; CHECK-NEXT: call void asm sideeffect "mov\09fp, fp\09\09// marker for objc_retainAutoreleaseReturnValue", ""()
+; CHECK-NEXT: call i8* @llvm.objc.unsafeClaimAutoreleasedReturnValue(i8* %[[CALL]])
+
+define void @test1() {
+  %call1 = notail call i8* @foo() [ "clang.arc.attachedcall"() ]
+  call i8* @llvm.objc.unsafeClaimAutoreleasedReturnValue(i8* %call1)
+  ret void
+}
+
+declare i8* @foo()
+declare i8* @llvm.objc.retainAutoreleasedReturnValue(i8*)
+declare i8* @llvm.objc.unsafeClaimAutoreleasedReturnValue(i8*)
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 1, !"clang.arc.retainAutoreleasedReturnValueMarker", !"mov\09fp, fp\09\09// marker for objc_retainAutoreleaseReturnValue"}


### PR DESCRIPTION
In some situations (swiftc bitcode) we end up running the
objc-arc-contract pass twice, which is not supposed to occur.

This was fine until relatively recently, where the
clang.arc.attachedcall operand bundle support caused the second run to
crash: when emitting the calls, the pass was assuming that the bundle
always had an operand, which is not true in 5.6.

That will be true in the future, but that's a massive change.
For now, try to workaround the issue by ignoring the nullary bundles,
and not emitting the call.

The pass will get a little confused, but the semantics are preserved
by the presence of the intrinsic call later on (emitted by the first
run of the pass).  However, one difference is that we're now going
to emit a redundant inline-asm marker, since we're not able to
eliminate the (standalone) intrinsic anymore, as we don't remember
emitting it in the pass.  That costs us an extra nop, which is okay.

rdar://90366906