### PR TITLE
[lldb] Print diagnostic prefixes (error, warning) in color

### DIFF
--- a/lldb/include/lldb/Core/StreamAsynchronousIO.h
+++ b/lldb/include/lldb/Core/StreamAsynchronousIO.h
@@ -20,7 +20,7 @@ class Debugger;
 
 class StreamAsynchronousIO : public Stream {
 public:
-  StreamAsynchronousIO(Debugger &debugger, bool for_stdout);
+  StreamAsynchronousIO(Debugger &debugger, bool for_stdout, bool colors);
 
   ~StreamAsynchronousIO() override;
 

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -1239,11 +1239,11 @@ bool Debugger::PopIOHandler(const IOHandlerSP &pop_reader_sp) {
 }
 
 StreamSP Debugger::GetAsyncOutputStream() {
-  return std::make_shared<StreamAsynchronousIO>(*this, true);
+  return std::make_shared<StreamAsynchronousIO>(*this, true, GetUseColor());
 }
 
 StreamSP Debugger::GetAsyncErrorStream() {
-  return std::make_shared<StreamAsynchronousIO>(*this, false);
+  return std::make_shared<StreamAsynchronousIO>(*this, false, GetUseColor());
 }
 
 size_t Debugger::GetNumDebuggers() {

--- a/lldb/source/Core/DebuggerEvents.cpp
+++ b/lldb/source/Core/DebuggerEvents.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Core/DebuggerEvents.h"
+#include "llvm/Support/WithColor.h"
 
 using namespace lldb_private;
 
@@ -55,7 +56,12 @@ llvm::StringRef DiagnosticEventData::GetPrefix() const {
 }
 
 void DiagnosticEventData::Dump(Stream *s) const {
-  *s << GetPrefix() << ": " << GetMessage() << '\n';
+  llvm::HighlightColor color = m_type == Type::Warning
+                                   ? llvm::HighlightColor::Warning
+                                   : llvm::HighlightColor::Error;
+  llvm::WithColor(s->AsRawOstream(), color, llvm::ColorMode::Enable)
+      << GetPrefix();
+  *s << ": " << GetMessage() << '\n';
   s->Flush();
 }
 

--- a/lldb/source/Core/StreamAsynchronousIO.cpp
+++ b/lldb/source/Core/StreamAsynchronousIO.cpp
@@ -14,8 +14,9 @@
 using namespace lldb;
 using namespace lldb_private;
 
-StreamAsynchronousIO::StreamAsynchronousIO(Debugger &debugger, bool for_stdout)
-    : Stream(0, 4, eByteOrderBig), m_debugger(debugger), m_data(),
+StreamAsynchronousIO::StreamAsynchronousIO(Debugger &debugger, bool for_stdout,
+                                           bool colors)
+    : Stream(0, 4, eByteOrderBig, colors), m_debugger(debugger), m_data(),
       m_for_stdout(for_stdout) {}
 
 StreamAsynchronousIO::~StreamAsynchronousIO() {


### PR DESCRIPTION
Print diagnostic prefixes (error, warning) in their respective colors
when colors are enabled.

(cherry picked from commit 990d0c71090836fb117e72c262d6d19b76f346cc)
