### PR TITLE
clang: Add CompileJobCache and stop caching CASID file

### DIFF
--- a/llvm/include/llvm/CAS/CASOutputBackend.h
+++ b/llvm/include/llvm/CAS/CASOutputBackend.h
@@ -16,29 +16,19 @@ namespace llvm {
 namespace cas {
 class CASDB;
 class CASID;
-class TreeProxy;
+class NodeProxy;
 
 /// Handle the cas
 class CASOutputBackend final : public vfs::StableUniqueEntityAdaptor<> {
 public:
   /// Create a top-level tree for all created files. This will contain all files
-  Expected<TreeProxy> createTree();
+  Expected<NodeProxy> createNode();
 
   Expected<std::unique_ptr<vfs::OutputFile>>
   createFileImpl(StringRef ResolvedPath, vfs::OutputConfig Config) override;
 
-  /// \param CASIDOutputBackend if set it will be used to write out the file
-  /// contents as embedded CASID. Can be \p nullptr.
-  CASOutputBackend(
-      std::shared_ptr<CASDB> CAS,
-      IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend,
-      unique_function<std::string(StringRef)> CASPathRewriter);
-  /// \param CASIDOutputBackend if set it will be used to write out the file
-  /// contents as embedded CASID. Can be \p nullptr.
-  CASOutputBackend(
-      CASDB &CAS,
-      IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend,
-      unique_function<std::string(StringRef)> CASPathRewriter);
+  CASOutputBackend(std::shared_ptr<CASDB> CAS);
+  CASOutputBackend(CASDB &CAS);
 
 private:
   ~CASOutputBackend();
@@ -47,8 +37,6 @@ private:
 
   CASDB &CAS;
   std::shared_ptr<CASDB> OwnedCAS;
-  IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend;
-  unique_function<std::string(StringRef)> CASPathRewriter;
 };
 
 } // namespace cas

--- a/llvm/lib/CAS/CASOutputBackend.cpp
+++ b/llvm/lib/CAS/CASOutputBackend.cpp
@@ -7,9 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CAS/CASOutputBackend.h"
-#include "llvm/ADT/StringMap.h"
 #include "llvm/CAS/CASDB.h"
-#include "llvm/CAS/HierarchicalTreeBuilder.h"
 #include "llvm/CAS/Utils.h"
 #include "llvm/Support/AlignOf.h"
 #include "llvm/Support/Allocator.h"
@@ -38,53 +36,22 @@ private:
 };
 } // namespace
 
-CASOutputBackend::CASOutputBackend(
-    std::shared_ptr<CASDB> CAS,
-    IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend,
-    unique_function<std::string(StringRef)> CASPathRewriter)
-    : CASOutputBackend(*CAS, std::move(CASIDOutputBackend),
-                       std::move(CASPathRewriter)) {
+CASOutputBackend::CASOutputBackend(std::shared_ptr<CASDB> CAS)
+    : CASOutputBackend(*CAS) {
   this->OwnedCAS = std::move(CAS);
 }
 
-CASOutputBackend::CASOutputBackend(
-    CASDB &CAS, IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CASIDOutputBackend,
-    unique_function<std::string(StringRef)> CASPathRewriter)
+CASOutputBackend::CASOutputBackend(CASDB &CAS)
     : StableUniqueEntityAdaptorType(
           sys::path::Style::native /*FIXME: should be posix?*/),
-      CAS(CAS), CASIDOutputBackend(std::move(CASIDOutputBackend)),
-      CASPathRewriter(std::move(CASPathRewriter)) {}
+      CAS(CAS) {}
 
 CASOutputBackend::~CASOutputBackend() = default;
 
 struct CASOutputBackend::PrivateImpl {
-  HierarchicalTreeBuilder Builder;
+  // FIXME: Use a NodeBuilder here once it exists.
+  SmallVector<CASID> IDs;
 };
-
-static Error writeOutputAsCASID(CASDB &CAS, CASID &ID, StringRef ResolvedPath,
-                                llvm::vfs::OutputBackend &CASIDOutputBackend,
-                                vfs::OutputConfig Config) {
-  auto ExpOutFile = CASIDOutputBackend.createFile(ResolvedPath, Config);
-  if (!ExpOutFile)
-    return ExpOutFile.takeError();
-  auto OutFile = std::move(*ExpOutFile);
-  if (CASOutputFile::isNull(*OutFile))
-    return Error::success();
-
-  writeCASIDBuffer(ID, *OutFile->getOS());
-
-  SmallString<50> Contents;
-  {
-    raw_svector_ostream OS(Contents);
-    writeCASIDBuffer(ID, OS);
-  }
-  Expected<BlobProxy> Blob = CAS.createBlob(Contents);
-  if (!Blob)
-    return Blob.takeError();
-  ID = *Blob;
-
-  return OutFile->close();
-}
 
 Expected<std::unique_ptr<vfs::OutputFile>>
 CASOutputBackend::createFileImpl(StringRef ResolvedPath,
@@ -94,26 +61,26 @@ CASOutputBackend::createFileImpl(StringRef ResolvedPath,
 
   return std::make_unique<CASOutputFile>(
       ResolvedPath, [&](StringRef Path, StringRef Bytes) -> Error {
-        Expected<BlobProxy> Blob = CAS.createBlob(Bytes);
-        if (!Blob)
-          return Blob.takeError();
-        CASID ID = *Blob;
-        if (CASIDOutputBackend) {
-          if (Error E = writeOutputAsCASID(CAS, ID, Path, *CASIDOutputBackend,
-                                           Config))
-            return E;
-        }
-        std::string TreePath = CASPathRewriter(Path);
-        Impl->Builder.push(ID, TreeEntry::Regular, TreePath);
+        Optional<BlobProxy> PathBlob;
+        Optional<BlobProxy> BytesBlob;
+        if (Error E = CAS.createBlob(Path).moveInto(PathBlob))
+          return E;
+        if (Error E = CAS.createBlob(Bytes).moveInto(BytesBlob))
+          return E;
+
+        // FIXME: Should there be a lock taken before accessing PrivateImpl?
+        Impl->IDs.push_back(PathBlob->getID());
+        Impl->IDs.push_back(BytesBlob->getID());
         return Error::success();
       });
 }
 
-Expected<TreeProxy> CASOutputBackend::createTree() {
+Expected<NodeProxy> CASOutputBackend::createNode() {
+  // FIXME: Should there be a lock taken before accessing PrivateImpl?
   if (!Impl)
-    return CAS.createTree();
+    return CAS.createNode(None, "");
 
-  Expected<TreeProxy> ExpectedTree = Impl->Builder.create(CAS);
-  Impl->Builder.clear();
-  return ExpectedTree;
+  SmallVector<CASID> MovedIDs;
+  std::swap(MovedIDs, Impl->IDs);
+  return CAS.createNode(MovedIDs, "");
 }


### PR DESCRIPTION
This is a fairly big refactoring of the caching logic in `cc1_main()`:

- Adds a ReplayManager to clarify how the logic fits together and
  simplify `cc1_main()` itself.
- Adds obvious places to canonicalize CompilerInvocation.
- Adds FIXMEs for going further.
- Simplifies CASOutputBackend significantly, by writing a simple list of
  outputs (pairs of path and contents) instead of building and reading
  from a CAS tree.
- Reimplements the CASID file logic in `cc1_main()` as a
  decanonicalization/replay step.