### PR TITLE
[lldb] Port Process::PrintWarning* to use the new diagnostic events

### DIFF
--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -818,6 +818,12 @@ public:
   void ReportErrorIfModifyDetected(const char *format, ...)
       __attribute__((format(printf, 2, 3)));
 
+  void ReportWarningOptimization(llvm::Optional<lldb::user_id_t> debugger_id);
+
+  void
+  ReportWarningUnsupportedLanguage(lldb::LanguageType language,
+                                   llvm::Optional<lldb::user_id_t> debugger_id);
+
   // Return true if the file backing this module has changed since the module
   // was originally created  since we saved the initial file modification time
   // when the module first gets created.
@@ -1028,6 +1034,9 @@ protected:
   /// an object file and a symbol file which both have symbol tables. The parse
   /// time for the symbol tables can be aggregated here.
   StatsDuration m_symtab_index_time;
+
+  std::once_flag m_optimization_warning;
+  std::once_flag m_language_warning;
 
   /// Resolve a file or load virtual address.
   ///

--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -824,6 +824,15 @@ public:
   ReportWarningUnsupportedLanguage(lldb::LanguageType language,
                                    llvm::Optional<lldb::user_id_t> debugger_id);
 
+#ifdef LLDB_ENABLE_SWIFT
+  void
+  ReportWarningCantLoadSwiftModule(std::string details,
+                                   llvm::Optional<lldb::user_id_t> debugger_id);
+  void
+  ReportWarningToolchainMismatch(CompileUnit &comp_unit,
+                                 llvm::Optional<lldb::user_id_t> debugger_id);
+#endif
+
   // Return true if the file backing this module has changed since the module
   // was originally created  since we saved the initial file modification time
   // when the module first gets created.
@@ -1037,6 +1046,10 @@ protected:
 
   std::once_flag m_optimization_warning;
   std::once_flag m_language_warning;
+#ifdef LLDB_ENABLE_SWIFT
+  std::once_flag m_swift_import_warning;
+  std::once_flag m_toolchain_mismatch_warning;
+#endif
 
   /// Resolve a file or load virtual address.
   ///

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -371,14 +371,6 @@ public:
     eBroadcastInternalStateControlResume = (1 << 2)
   };
 
-  /// Process warning types.
-  enum Warnings {
-    eWarningsOptimization = 1,
-    eWarningsUnsupportedLanguage = 2,
-    eWarningsSwiftImport,
-    eWarningsToolchainMismatch
-  };
-
   typedef Range<lldb::addr_t, lldb::addr_t> LoadRange;
   // We use a read/write lock to allow on or more clients to access the process
   // state while the process is stopped (reader). We lock the write lock to
@@ -2685,35 +2677,6 @@ protected:
   // Called internally
   void CompleteAttach();
 
-  /// Print a user-visible warning one time per Process
-  ///
-  /// A facility for printing a warning to the user once per repeat_key.
-  ///
-  /// warning_type is from the Process::Warnings enums. repeat_key is a
-  /// pointer value that will be used to ensure that the warning message is
-  /// not printed multiple times.  For instance, with a warning about a
-  /// function being optimized, you can pass the CompileUnit pointer to have
-  /// the warning issued for only the first function in a CU, or the Function
-  /// pointer to have it issued once for every function, or a Module pointer
-  /// to have it issued once per Module.
-  ///
-  /// Classes outside Process should call a specific PrintWarning method so
-  /// that the warning strings are all centralized in Process, instead of
-  /// calling PrintWarning() directly.
-  ///
-  /// \param [in] warning_type
-  ///     One of the types defined in Process::Warnings.
-  ///
-  /// \param [in] repeat_key
-  ///     A pointer value used to ensure that the warning is only printed once.
-  ///     May be nullptr, indicating that the warning is printed unconditionally
-  ///     every time.
-  ///
-  /// \param [in] fmt
-  ///     printf style format string
-  void PrintWarning(uint64_t warning_type, const void *repeat_key,
-                    const char *fmt, ...) __attribute__((format(printf, 4, 5)));
-
   // NextEventAction provides a way to register an action on the next event
   // that is delivered to this process.  There is currently only one next event
   // action allowed in the process at one time.  If a new "NextEventAction" is
@@ -2878,8 +2841,6 @@ protected:
   // Type definitions
   typedef std::map<lldb::LanguageType, lldb::LanguageRuntimeSP>
       LanguageRuntimeCollection;
-  typedef std::unordered_set<const void *> WarningsPointerSet;
-  typedef std::map<uint64_t, WarningsPointerSet> WarningsCollection;
 
   struct PreResumeCallbackAndBaton {
     bool (*callback)(void *);
@@ -3014,8 +2975,6 @@ protected:
   bool m_can_interpret_function_calls;  // Some targets, e.g the OSX kernel,
                                         // don't support the ability to modify
                                         // the stack.
-  WarningsCollection m_warnings_issued; // A set of object pointers which have
-                                        // already had warnings printed
   std::mutex m_run_thread_plan_lock;
   StructuredDataPluginMap m_structured_data_plugin_map;
 

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -1332,14 +1332,13 @@ public:
   ///
   /// @param [in] module
   ///     The affected Module.
-  void PrintWarningCantLoadSwiftModule(const Module &module,
-                                       std::string details);
+  void PrintWarningCantLoadSwiftModule(Module &module, std::string details);
 
   /// Print a user-visible warning about Swift CUs compiled with a
   /// different Swift compiler than the one embedded in LLDB.
   void PrintWarningToolchainMismatch(const SymbolContext &sc);
 #endif
-  
+
   /// Print a user-visible warning about a function written in a
   /// language that this version of LLDB doesn't support.
   ///

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1181,6 +1181,37 @@ void Module::ReportWarningUnsupportedLanguage(
                           &m_language_warning);
 }
 
+#ifdef LLDB_ENABLE_SWIFT
+void Module::ReportWarningCantLoadSwiftModule(
+    std::string details, llvm::Optional<lldb::user_id_t> debugger_id) {
+  StreamString ss;
+  ss << GetFileSpec().GetCString() << ": "
+     << "Cannot load Swift type information: " << details;
+  Debugger::ReportWarning(std::string(ss.GetString()), debugger_id,
+                          &m_swift_import_warning);
+}
+
+void Module::ReportWarningToolchainMismatch(
+    CompileUnit &comp_unit, llvm::Optional<lldb::user_id_t> debugger_id) {
+  if (SymbolFile *sym_file = GetSymbolFile()) {
+    llvm::VersionTuple sym_file_version =
+        sym_file->GetProducerVersion(comp_unit);
+    llvm::VersionTuple swift_version =
+        swift::version::Version::getCurrentCompilerVersion();
+    if (sym_file_version != swift_version) {
+      std::string str = llvm::formatv(
+          "{0} was compiled with a different Swift compiler "
+          "(version '{1}') than the Swift compiler integrated into LLDB "
+          "(version '{2}'). Swift expression evaluation requires a matching "
+          "compiler and debugger from the same toolchain.",
+          GetFileSpec().GetFilename(), sym_file_version.getAsString(),
+          swift_version.getAsString());
+      Debugger::ReportWarning(str, debugger_id, &m_toolchain_mismatch_warning);
+    }
+  }
+}
+#endif
+
 void Module::ReportErrorIfModifyDetected(const char *format, ...) {
   if (!m_first_file_changed_log) {
     if (FileHasChanged()) {

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1156,6 +1156,31 @@ bool Module::FileHasChanged() const {
   return m_file_has_changed;
 }
 
+void Module::ReportWarningOptimization(
+    llvm::Optional<lldb::user_id_t> debugger_id) {
+  ConstString file_name = GetFileSpec().GetFilename();
+  if (file_name.IsEmpty())
+    return;
+
+  StreamString ss;
+  ss << file_name.GetStringRef()
+     << " was compiled with optimization - stepping may behave "
+        "oddly; variables may not be available.";
+  Debugger::ReportWarning(std::string(ss.GetString()), debugger_id,
+                          &m_optimization_warning);
+}
+
+void Module::ReportWarningUnsupportedLanguage(
+    LanguageType language, llvm::Optional<lldb::user_id_t> debugger_id) {
+  StreamString ss;
+  ss << "This version of LLDB has no plugin for the language \""
+     << Language::GetNameForLanguageType(language)
+     << "\". "
+        "Inspection of frame variables will be limited.";
+  Debugger::ReportWarning(std::string(ss.GetString()), debugger_id,
+                          &m_language_warning);
+}
+
 void Module::ReportErrorIfModifyDetected(const char *format, ...) {
   if (!m_first_file_changed_log) {
     if (FileHasChanged()) {

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -5897,11 +5897,10 @@ void Process::PrintWarningOptimization(const SymbolContext &sc) {
 }
 
 #ifdef LLDB_ENABLE_SWIFT
-void Process::PrintWarningCantLoadSwiftModule(const Module &module,
+void Process::PrintWarningCantLoadSwiftModule(Module &module,
                                               std::string details) {
-  PrintWarning(Process::Warnings::eWarningsSwiftImport, (void *)&module,
-               "%s: Cannot load Swift type information; %s\n",
-               module.GetFileSpec().GetCString(), details.c_str());
+  module.ReportWarningCantLoadSwiftModule(std::move(details),
+                                          GetTarget().GetDebugger().GetID());
 }
 
 void Process::PrintWarningToolchainMismatch(const SymbolContext &sc) {
@@ -5919,22 +5918,8 @@ void Process::PrintWarningToolchainMismatch(const SymbolContext &sc) {
     return;
   if (sc.GetLanguage() != eLanguageTypeSwift)
     return;
-  if (SymbolFile *sym_file = sc.module_sp->GetSymbolFile()) {
-    llvm::VersionTuple sym_file_version =
-        sym_file->GetProducerVersion(*sc.comp_unit);
-    llvm::VersionTuple swift_version =
-        swift::version::Version::getCurrentCompilerVersion();
-    if (sym_file_version != swift_version)
-      PrintWarning(
-          Process::Warnings::eWarningsToolchainMismatch, sc.module_sp.get(),
-          "%s was compiled with a different Swift compiler "
-          "(version '%s') than the Swift compiler integrated into LLDB "
-          "(version '%s'). Swift expression evaluation requires a matching "
-          "compiler and debugger from the same toolchain.",
-          sc.module_sp->GetFileSpec().GetFilename().GetCString(),
-          sym_file_version.getAsString().c_str(),
-          swift_version.getAsString().c_str());
-  }
+  sc.module_sp->ReportWarningToolchainMismatch(
+      *sc.comp_unit, GetTarget().GetDebugger().GetID());
 }
 #endif
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -451,8 +451,8 @@ Process::Process(lldb::TargetSP target_sp, ListenerSP listener_sp,
       m_clear_thread_plans_on_stop(false), m_force_next_event_delivery(false),
       m_destroy_in_process(false), m_destroy_complete(false),
       m_last_broadcast_state(eStateInvalid),
-      m_can_interpret_function_calls(false), m_warnings_issued(),
-      m_run_thread_plan_lock(), m_can_jit(eCanJITDontKnow) {
+      m_can_interpret_function_calls(false), m_run_thread_plan_lock(),
+      m_can_jit(eCanJITDontKnow) {
   CheckInWithManager();
 
   Log *log = GetLog(LLDBLog::Object);
@@ -5888,48 +5888,12 @@ void Process::ModulesDidLoad(ModuleList &module_list) {
   }
 }
 
-void Process::PrintWarning(uint64_t warning_type, const void *repeat_key,
-                           const char *fmt, ...) {
-  bool print_warning = true;
-
-  StreamSP stream_sp = GetTarget().GetDebugger().GetAsyncOutputStream();
-  if (!stream_sp)
-    return;
-
-  if (repeat_key != nullptr) {
-    WarningsCollection::iterator it = m_warnings_issued.find(warning_type);
-    if (it == m_warnings_issued.end()) {
-      m_warnings_issued[warning_type] = WarningsPointerSet();
-      m_warnings_issued[warning_type].insert(repeat_key);
-    } else {
-      if (it->second.find(repeat_key) != it->second.end()) {
-        print_warning = false;
-      } else {
-        it->second.insert(repeat_key);
-      }
-    }
-  }
-
-  if (print_warning) {
-    va_list args;
-    va_start(args, fmt);
-    stream_sp->PrintfVarArg(fmt, args);
-    va_end(args);
-  }
-}
-
 void Process::PrintWarningOptimization(const SymbolContext &sc) {
   if (!GetWarningsOptimization())
     return;
-  if (!sc.module_sp)
+  if (!sc.module_sp || !sc.function || !sc.function->GetIsOptimized())
     return;
-  if (!sc.module_sp->GetFileSpec().GetFilename().IsEmpty() && sc.function &&
-      sc.function->GetIsOptimized()) {
-    PrintWarning(Process::Warnings::eWarningsOptimization, sc.module_sp.get(),
-                 "%s was compiled with optimization - stepping may behave "
-                 "oddly; variables may not be available.\n",
-                 sc.module_sp->GetFileSpec().GetFilename().GetCString());
-  }
+  sc.module_sp->ReportWarningOptimization(GetTarget().GetDebugger().GetID());
 }
 
 #ifdef LLDB_ENABLE_SWIFT
@@ -5984,13 +5948,10 @@ void Process::PrintWarningUnsupportedLanguage(const SymbolContext &sc) {
     return;
   LanguageSet plugins =
       PluginManager::GetAllTypeSystemSupportedLanguagesForTypes();
-  if (!plugins[language]) {
-    PrintWarning(Process::Warnings::eWarningsUnsupportedLanguage,
-                 sc.module_sp.get(),
-                 "This version of LLDB has no plugin for the language \"%s\". "
-                 "Inspection of frame variables will be limited.\n",
-                 Language::GetNameForLanguageType(language));
-  }
+  if (plugins[language])
+    return;
+  sc.module_sp->ReportWarningUnsupportedLanguage(
+      language, GetTarget().GetDebugger().GetID());
 }
 
 bool Process::GetProcessInfo(ProcessInstanceInfo &info) {

--- a/lldb/test/Shell/Process/Optimization.test
+++ b/lldb/test/Shell/Process/Optimization.test
@@ -1,6 +1,6 @@
 Test warnings.
 REQUIRES: shell, system-darwin
 RUN: %clang_host -O3 %S/Inputs/true.c -std=c99 -g -o %t.exe
-RUN: %lldb -o "b main" -o r -o q -b %t.exe | FileCheck %s
+RUN: %lldb -o "b main" -o r -o q -b %t.exe 2>&1 | FileCheck %s
 
 CHECK: compiled with optimization

--- a/lldb/test/Shell/Process/UnsupportedLanguage.test
+++ b/lldb/test/Shell/Process/UnsupportedLanguage.test
@@ -3,6 +3,6 @@ REQUIRES: shell
 RUN: %clang_host %S/Inputs/true.c -std=c99 -g -c -S -emit-llvm -o - \
 RUN:   | sed -e 's/DW_LANG_C99/DW_LANG_Mips_Assembler/g' >%t.ll
 RUN: %clang_host %t.ll -g -o %t.exe
-RUN: %lldb -o "b main" -o r -o q -b %t.exe | FileCheck %s
+RUN: %lldb -o "b main" -o r -o q -b %t.exe 2>&1 | FileCheck %s
 
 CHECK: This version of LLDB has no plugin for the language "assembler"

--- a/lldb/test/Shell/Swift/ToolchainMismatch.test
+++ b/lldb/test/Shell/Swift/ToolchainMismatch.test
@@ -32,7 +32,7 @@ run
 quit
 
 # The {{ }} avoids accidentally matching the input script!
-# CHECK: {{a\.out}} was compiled with a different Swift compiler
-# CHECK: stop reason{{ = }}breakpoint
+# CHECK-DAG: {{a\.out}} was compiled with a different Swift compiler
+# CHECK-DAG: stop reason{{ = }}breakpoint
 # SANITY-NOT: {{a\.out}} was compiled with a different Swift compiler
 # SANITY: stop reason{{ = }}breakpoint


### PR DESCRIPTION
Port the two Process::PrintWarning functions to use the new diagnostic
events through Debugger::ReportWarning. I kept the wrapper function in
the process, but delegated the work to the Module. Consistent with the
current code, the Module ensures the warning is only printed once per
module.

Differential revision: https://reviews.llvm.org/D123698