### PR TITLE
Handle case-insensitivity in OnDiskCachingFileSystem

### DIFF
--- a/clang/test/ClangScanDeps/cas-case-sensitivity.c
+++ b/clang/test/ClangScanDeps/cas-case-sensitivity.c
@@ -1,0 +1,62 @@
+// REQUIRES: case_insensitive_src_dir
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb1.json.template > %t/cdb1.json
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb2.json.template > %t/cdb2.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb1.json -cas-path %t/cas -format experimental-tree -reuse-filemanager=0 -mode preprocess-minimized-sources > %t/result1.txt
+// RUN: clang-scan-deps -compilation-database %t/cdb2.json -cas-path %t/cas -format experimental-tree -reuse-filemanager=0 -mode preprocess > %t/result2.txt
+// RUN: sed -e 's/^.*llvmcas/llvmcas/' -e 's/ for.*$//' %t/result1.txt > %t/casid1
+// RUN: sed -e 's/^.*llvmcas/llvmcas/' -e 's/ for.*$//' %t/result2.txt > %t/casid2
+
+// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/casid1 | FileCheck -check-prefix=TREE %s -DPREFIX=%/t
+// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/casid2 | FileCheck -check-prefix=TREE %s -DPREFIX=%/t
+
+// asdf: FileCheck -check-prefix=TREE %s -input-file %t/result1.txt -DPREFIX=%/t
+
+// TREE: file llvmcas://{{.*}} [[PREFIX]]/Header.h
+// TREE: syml llvmcas://{{.*}} [[PREFIX]]/header.h -> Header
+// TREE: file llvmcas://{{.*}} [[PREFIX]]/t{{[12]}}.c
+
+//--- cdb1.json.template
+[
+  {
+    "directory": "DIR",
+    "command": "clang -fsyntax-only DIR/t1.c",
+    "file": "DIR/t1.c"
+  }
+]
+
+//--- cdb2.json.template
+[
+  {
+    "directory": "DIR",
+    "command": "clang -fsyntax-only DIR/t2.c",
+    "file": "DIR/t2.c"
+  }
+]
+
+//--- t1.c
+#include "header.h"
+#include "Header.h"
+
+void bar1(void) {
+  foo();
+}
+
+//--- t2.c
+#include "Header.h"
+#include "header.h"
+
+void bar2(void) {
+  foo();
+}
+
+//--- header.h
+#pragma once
+void foo(void);
+
+//--- Header.h
+#pragma once
+void foo(void);

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -273,3 +273,5 @@ if 'aix' in config.target_triple:
                       '/ASTMerge/anonymous-fields', '/ASTMerge/injected-class-name-decl'):
         exclude_unsupported_files_for_aix(config.test_source_root + directory)
 
+if os.path.exists(os.path.join(config.clang_src_dir, 'TeSt')):
+    config.available_features.add('case_insensitive_src_dir')

--- a/llvm/include/llvm/CAS/FileSystemCache.h
+++ b/llvm/include/llvm/CAS/FileSystemCache.h
@@ -126,9 +126,10 @@ public:
 
   /// Request a directory entry. The first parameter is the parent to look
   /// under, the second is the name of the entry, and the third is true if the
-  /// name came from a call to \a PreloadTreePathType.
-  using RequestDirectoryEntryType =
-      function_ref<Expected<DirectoryEntry *>(DirectoryEntry &, StringRef)>;
+  /// name is requested because a prior result from PreloadTreePath failed to
+  /// match at this position.
+  using RequestDirectoryEntryType = function_ref<Expected<DirectoryEntry *>(
+      DirectoryEntry &, StringRef, bool)>;
 
   /// Request target of (lazy) symlink be filled in.
   using RequestSymlinkTargetType = function_ref<Error(DirectoryEntry &)>;
@@ -160,7 +161,7 @@ public:
   /// returning early on a symlink.
   Expected<LookupPathState> lookupRealPathPrefixFrom(
       LookupPathState State, RequestDirectoryEntryType RequestDirectoryEntry,
-      PreloadTreePathType &PreloadTreePath,
+      PreloadTreePathType PreloadTreePath,
       function_ref<void(DirectoryEntry &)> TrackNonRealPathEntries);
 
   /// Lookup \p Path, knowing that \a sys::fs::real_path() was called and

--- a/llvm/lib/CAS/CASFileSystem.cpp
+++ b/llvm/lib/CAS/CASFileSystem.cpp
@@ -316,9 +316,9 @@ CASFileSystem::getDirectoryIterator(const Twine &Path) {
 
 Expected<CASFileSystem::DirectoryEntry *>
 CASFileSystem::lookupPath(StringRef Path, bool FollowSymlinks) {
-  auto RequestDirectoryEntry =
-      [this](FileSystemCache::DirectoryEntry &Parent,
-             StringRef Name) -> Expected<DirectoryEntry *> {
+  auto RequestDirectoryEntry = [this](FileSystemCache::DirectoryEntry &Parent,
+                                      StringRef Name,
+                                      bool) -> Expected<DirectoryEntry *> {
     if (Parent.asDirectory().isComplete())
       return errorCodeToError(
           std::make_error_code(std::errc::no_such_file_or_directory));


### PR DESCRIPTION
When encountering a case-insensitive match for a path, attempt to create
a fake symlink to the canonical name. This ensures that the realpath and
uniqueid of paths will be correct on case-insensitive filesystems. Each
non-canonical path component uses an additional realpath+lstat the first
time it is resolved in order to resolve its spelling.