### PR TITLE
[lldb] Prevent crash when adding a stop hook with --shlib

### DIFF
--- a/lldb/source/Symbol/SymbolContext.cpp
+++ b/lldb/source/Symbol/SymbolContext.cpp
@@ -963,8 +963,9 @@ bool SymbolContextSpecifier::AddSpecification(const char *spec_string,
     // See if we can find the Module, if so stick it in the SymbolContext.
     FileSpec module_file_spec(spec_string);
     ModuleSpec module_spec(module_file_spec);
-    lldb::ModuleSP module_sp(
-        m_target_sp->GetImages().FindFirstModule(module_spec));
+    lldb::ModuleSP module_sp =
+        m_target_sp ? m_target_sp->GetImages().FindFirstModule(module_spec)
+                    : nullptr;
     m_type |= eModuleSpecified;
     if (module_sp)
       m_module_sp = module_sp;

--- a/lldb/test/Shell/Commands/command-stop-hook-no-target.test
+++ b/lldb/test/Shell/Commands/command-stop-hook-no-target.test
@@ -1,0 +1,4 @@
+# RUN: %clang_host -g %S/Inputs/main.c -o %t
+# RUN: %lldb -b -o 'target stop-hook add --name test --shlib test -o "p 95000 + 126"' -o 'file %t' -o 'b main' -o 'r' 2>&1 | FileCheck %s
+# CHECK: Stop hook #1 added
+# CHECK-NOT: 95126


### PR DESCRIPTION
Currently, lldb crashes when adding a stop hook with --shlib because we
unconditionally use the target in SymbolContextSpecifier::AddSpecification.
This patch prevents the crash and add a test.

rdar://68524781

Differential revision: https://reviews.llvm.org/D123746

(cherry picked from commit 64d9b233b9905a951b450eff5b258707a35e110f)
