### PR TITLE
🍒 [clang] Do not duplicate "EnableSplitLTOUnit" module flag

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1036,8 +1036,9 @@ void EmitAssemblyHelper::EmitAssemblyWithLegacyPassManager(
         if (!ThinLinkOS)
           return;
       }
-      TheModule->addModuleFlag(Module::Error, "EnableSplitLTOUnit",
-                               CodeGenOpts.EnableSplitLTOUnit);
+      if (!TheModule->getModuleFlag("EnableSplitLTOUnit"))
+        TheModule->addModuleFlag(Module::Error, "EnableSplitLTOUnit",
+                                 CodeGenOpts.EnableSplitLTOUnit);
       PerModulePasses.add(createWriteThinLTOBitcodePass(
           *OS, ThinLinkOS ? &ThinLinkOS->os() : nullptr));
     } else {
@@ -1051,8 +1052,9 @@ void EmitAssemblyHelper::EmitAssemblyWithLegacyPassManager(
       if (EmitLTOSummary) {
         if (!TheModule->getModuleFlag("ThinLTO"))
           TheModule->addModuleFlag(Module::Error, "ThinLTO", uint32_t(0));
-        TheModule->addModuleFlag(Module::Error, "EnableSplitLTOUnit",
-                                 uint32_t(1));
+        if (!TheModule->getModuleFlag("EnableSplitLTOUnit"))
+          TheModule->addModuleFlag(Module::Error, "EnableSplitLTOUnit",
+                                   uint32_t(1));
       }
 
       PerModulePasses.add(createBitcodeWriterPass(
@@ -1454,8 +1456,9 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
         if (!ThinLinkOS)
           return;
       }
-      TheModule->addModuleFlag(Module::Error, "EnableSplitLTOUnit",
-                               CodeGenOpts.EnableSplitLTOUnit);
+      if (!TheModule->getModuleFlag("EnableSplitLTOUnit"))
+        TheModule->addModuleFlag(Module::Error, "EnableSplitLTOUnit",
+                                 CodeGenOpts.EnableSplitLTOUnit);
       MPM.addPass(ThinLTOBitcodeWriterPass(*OS, ThinLinkOS ? &ThinLinkOS->os()
                                                            : nullptr));
     } else {
@@ -1468,8 +1471,9 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
       if (EmitLTOSummary) {
         if (!TheModule->getModuleFlag("ThinLTO"))
           TheModule->addModuleFlag(Module::Error, "ThinLTO", uint32_t(0));
-        TheModule->addModuleFlag(Module::Error, "EnableSplitLTOUnit",
-                                 uint32_t(1));
+        if (!TheModule->getModuleFlag("EnableSplitLTOUnit"))
+          TheModule->addModuleFlag(Module::Error, "EnableSplitLTOUnit",
+                                   uint32_t(1));
       }
       MPM.addPass(
           BitcodeWriterPass(*OS, CodeGenOpts.EmitLLVMUseLists, EmitLTOSummary));

--- a/clang/test/CodeGen/enable-split-lto-unit.ll
+++ b/clang/test/CodeGen/enable-split-lto-unit.ll
@@ -1,0 +1,25 @@
+; Test that we do not duplicate the EnableSplitLTOUnit module flag.
+;
+; Disable the verifier so the compiler doesn't abort and thus lead to empty
+; output and false pass.
+;
+; RUN: %clang_cc1 -fno-legacy-pass-manager -emit-llvm-bc -flto=full -disable-llvm-verifier -o - %s | llvm-dis | FileCheck %s --check-prefix=FULL-NPM
+; RUN: %clang_cc1 -fno-legacy-pass-manager -emit-llvm-bc -flto=thin -disable-llvm-verifier -o - %s | llvm-dis | FileCheck %s --check-prefix=THIN-NPM
+; RUN: %clang_cc1 -flegacy-pass-manager -emit-llvm-bc -flto=full -disable-llvm-verifier -o - %s | llvm-dis | FileCheck %s --check-prefix=FULL-OPM
+; RUN: %clang_cc1 -flegacy-pass-manager -emit-llvm-bc -flto=thin -disable-llvm-verifier -o - %s | llvm-dis | FileCheck %s --check-prefix=THIN-OPM
+
+define dso_local void @main() local_unnamed_addr {
+entry:
+  ret void
+}
+
+; FULL-NPM-NOT: !llvm.module.flags = !{!0, !1, !2, !3, !3}
+; FULL-OPM-NOT: !llvm.module.flags = !{!0, !1, !2, !3, !3}
+; THIN-NPM-NOT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
+; THIN-OPM-NOT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
+!llvm.module.flags = !{!0, !1, !2, !3}
+
+!0 = !{i32 1, !"wchar_size", i32 2}
+!1 = !{i32 7, !"frame-pointer", i32 2}
+!2 = !{i32 1, !"ThinLTO", i32 0}
+!3 = !{i32 1, !"EnableSplitLTOUnit", i32 1}


### PR DESCRIPTION
Cherry-pick 53adfa8750eaf4558c41a50f699616545eb0151b to unlock hermetic-seal-at-link on non-Darwin platforms.

Since .bc can be archived into .a without processing it by clang linker, IRGen is responsible to add `EnableSplitLTOUnit`. However, main module's .bc is processed by clang linker, then `EnableSplitLTOUnit` is added twice.

```
module flag identifiers must be unique (or of 'require' type)
!"EnableSplitLTOUnit"
LLVM ERROR: Broken module found, compilation aborted!
```

---
Original commit message

If clang's output is set to bitcode and LTO is enabled, clang would
unconditionally add the flag to the module.  Unfortunately, if the input were a
bitcode or IR file and had the flag set, this would result in two copies of the
flag, which is illegal IR.  Guard the setting of the flag by checking whether it
already exists.  This follows existing practice for the related "ThinLTO" module
flag.

Differential Revision: https://reviews.llvm.org/D112177