### PR TITLE
[lldb] Fix invalid use of mutating keyword in generated expressions

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -155,9 +155,13 @@ findSwiftSelf(StackFrame &frame, lldb::VariableSP self_var_sp) {
     info.is_metatype = true;
   }
 
+  info.swift_type = GetSwiftType(info.type).getPointer();
+  if (auto *dyn_self =
+          llvm::dyn_cast_or_null<swift::DynamicSelfType>(info.swift_type))
+    info.swift_type = dyn_self->getSelfType().getPointer();
+
   // 5) If the adjusted type isn't equal to the type according to the runtime,
   // switch it to the latter type.
-  info.swift_type = GetSwiftType(info.type).getPointer();
   if (info.swift_type && (info.swift_type != info.type.GetOpaqueQualType()))
     info.type = ToCompilerType(info.swift_type);
 

--- a/lldb/test/API/lang/swift/designated_initializer_self/Makefile
+++ b/lldb/test/API/lang/swift/designated_initializer_self/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/designated_initializer_self/TestDesignatedInitializerSelf.py
+++ b/lldb/test/API/lang/swift/designated_initializer_self/TestDesignatedInitializerSelf.py
@@ -1,0 +1,4 @@
+import lldbsuite.test.lldbinline as lldbinline
+from lldbsuite.test.decorators import *
+
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/designated_initializer_self/main.swift
+++ b/lldb/test/API/lang/swift/designated_initializer_self/main.swift
@@ -1,0 +1,10 @@
+class C {
+  init() {}
+  convenience init(unused: Bool) { 
+    self.init()
+    print(1)//%self.expect('po self', substrs=['<C: 0x'])
+  }
+}
+
+C(unused: true)
+


### PR DESCRIPTION
Prevent conditional logic from falling through to adding the mutating
keyword when evaluating Swift expressions inside of a a function whose
self type is a dynamic Self.

After determining the type of self, resolve instances of DynamicSelfType
to their self type. This allows consumers to properly determine when a
type is a class, for example, which is not possible when using the
dynamic self directly.

(cherry picked from commit dcea4faa1f5c6c8643d8b25f03d4ef464805ed6f)