### PR TITLE
Handle case-insensitivity in OnDiskCachingFileSystem

### DIFF
--- a/clang/test/ClangScanDeps/cas-case-sensitivity.c
+++ b/clang/test/ClangScanDeps/cas-case-sensitivity.c
@@ -1,0 +1,62 @@
+// REQUIRES: case_insensitive_src_dir
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb1.json.template > %t/cdb1.json
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb2.json.template > %t/cdb2.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb1.json -cas-path %t/cas -format experimental-tree -reuse-filemanager=0 -mode preprocess-minimized-sources > %t/result1.txt
+// RUN: clang-scan-deps -compilation-database %t/cdb2.json -cas-path %t/cas -format experimental-tree -reuse-filemanager=0 -mode preprocess > %t/result2.txt
+// RUN: sed -e 's/^.*llvmcas/llvmcas/' -e 's/ for.*$//' %t/result1.txt > %t/casid1
+// RUN: sed -e 's/^.*llvmcas/llvmcas/' -e 's/ for.*$//' %t/result2.txt > %t/casid2
+
+// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/casid1 | FileCheck -check-prefix=TREE %s -DPREFIX=%/t
+// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/casid2 | FileCheck -check-prefix=TREE %s -DPREFIX=%/t
+
+// asdf: FileCheck -check-prefix=TREE %s -input-file %t/result1.txt -DPREFIX=%/t
+
+// TREE: file llvmcas://{{.*}} [[PREFIX]]/Header.h
+// TREE: syml llvmcas://{{.*}} [[PREFIX]]/header.h -> Header
+// TREE: file llvmcas://{{.*}} [[PREFIX]]/t{{[12]}}.c
+
+//--- cdb1.json.template
+[
+  {
+    "directory": "DIR",
+    "command": "clang -fsyntax-only DIR/t1.c",
+    "file": "DIR/t1.c"
+  }
+]
+
+//--- cdb2.json.template
+[
+  {
+    "directory": "DIR",
+    "command": "clang -fsyntax-only DIR/t2.c",
+    "file": "DIR/t2.c"
+  }
+]
+
+//--- t1.c
+#include "header.h"
+#include "Header.h"
+
+void bar1(void) {
+  foo();
+}
+
+//--- t2.c
+#include "Header.h"
+#include "header.h"
+
+void bar2(void) {
+  foo();
+}
+
+//--- header.h
+#pragma once
+void foo(void);
+
+//--- Header.h
+#pragma once
+void foo(void);

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -273,3 +273,5 @@ if 'aix' in config.target_triple:
                       '/ASTMerge/anonymous-fields', '/ASTMerge/injected-class-name-decl'):
         exclude_unsupported_files_for_aix(config.test_source_root + directory)
 
+if os.path.exists(os.path.join(config.clang_src_dir, 'TeSt')):
+    config.available_features.add('case_insensitive_src_dir')

--- a/llvm/include/llvm/CAS/FileSystemCache.h
+++ b/llvm/include/llvm/CAS/FileSystemCache.h
@@ -279,6 +279,19 @@ public:
     (void)Node.compare_exchange_strong(Null, &S, std::memory_order_acq_rel);
   }
 
+  /// If \p Other is a prefix of the current entry, returns the child of
+  /// \p Other that would be next in the current entry, if any.
+  DirectoryEntry *nextEntryAfterPrefix(DirectoryEntry &Other) {
+    DirectoryEntry *E = this, *P = Parent;
+    while (P) {
+      if (P == &Other)
+        return E;
+      E = P;
+      P = P->Parent;
+    }
+    return nullptr;
+  }
+
   DirectoryEntry() = delete;
 
   DirectoryEntry(DirectoryEntry *Parent, StringRef TreePath, EntryKind Kind,

--- a/llvm/lib/CAS/CASFileSystem.cpp
+++ b/llvm/lib/CAS/CASFileSystem.cpp
@@ -315,10 +315,10 @@ CASFileSystem::getDirectoryIterator(const Twine &Path) {
 }
 
 namespace {
-class CASFileSystemDI final : public FileSystemCache::DiscoveryInstance {
+class DiscoveryInstanceImpl final : public FileSystemCache::DiscoveryInstance {
 public:
-  CASFileSystemDI(CASFileSystem &FS) : FS(FS) {}
-  ~CASFileSystemDI() {}
+  DiscoveryInstanceImpl(CASFileSystem &FS) : FS(FS) {}
+  ~DiscoveryInstanceImpl() {}
 
 private:
   using DirectoryEntry = FileSystemCache::DirectoryEntry;
@@ -340,7 +340,6 @@ private:
         std::make_error_code(std::errc::no_such_file_or_directory));
   }
   Error requestSymlinkTarget(DirectoryEntry &Symlink) override {
-    // FIXME: Need to handle lazy symlinks somehow.
     return FS.loadSymlink(Symlink);
   }
 
@@ -351,7 +350,7 @@ private:
 
 Expected<CASFileSystem::DirectoryEntry *>
 CASFileSystem::lookupPath(StringRef Path, bool FollowSymlinks) {
-  CASFileSystemDI DI(*this);
+  DiscoveryInstanceImpl DI(*this);
   return Cache->lookupPath(DI, Path, *WorkingDirectory.Entry, FollowSymlinks);
 }
 

--- a/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
+++ b/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
@@ -63,18 +63,28 @@ public:
   DirectoryEntry *makeDirectory(DirectoryEntry &Parent, StringRef TreePath);
 
   Expected<DirectoryEntry *> makeSymlink(DirectoryEntry &Parent,
-                                         const std::string &TreePath);
+                                         StringRef TreePath);
+  Expected<DirectoryEntry *>
+  makeSymlinkTo(DirectoryEntry &Parent, StringRef TreePath, StringRef Target);
 
   Expected<DirectoryEntry *> makeFile(DirectoryEntry &Parent,
                                       StringRef TreePath, int BorrowedFD,
                                       sys::fs::file_status Status);
 
-  /// Preload the real path for \p Remaining, relative to \p From.
-  Error preloadRealPath(DirectoryEntry &From, StringRef Remaining);
+  /// Create an entry for \p TreePath, which is contained in \p Parent. If
+  /// \p KnownStatus is provided, it is used to determine which kind of entry
+  /// to create (file, directory, symlink); otherwise, it is determined using
+  /// status(TreePath, /*FollowSymlinks=*/false).
+  Expected<DirectoryEntry *>
+  makeEntry(DirectoryEntry &Parent, StringRef TreePath,
+            Optional<sys::fs::file_status> KnownStatus);
 
-  /// Look up a name on disk inside \p From.
-  Expected<DirectoryEntry *> lookupOnDiskFrom(DirectoryEntry &Parent,
-                                              StringRef Name);
+  /// Preload the real path for \p Remaining, relative to \p From.
+  /// \returns The real path entry if it can be computed, an error if the path
+  ///          cannot be accessed, or nullptr if the path was accessed but there
+  ///          was a subsequent filesystem modification.
+  Expected<FileSystemCache::DirectoryEntry *>
+  preloadRealPath(DirectoryEntry &From, StringRef Remaining);
 
   ErrorOr<vfs::Status> statusAndFileID(const Twine &Path,
                                        Optional<CASID> &FileID) final;
@@ -151,6 +161,30 @@ private:
   WorkingDirectoryType WorkingDirectory;
 };
 
+class DiscoveryInstanceImpl final : public FileSystemCache::DiscoveryInstance {
+public:
+  using DirectoryEntry = FileSystemCache::DirectoryEntry;
+  DiscoveryInstanceImpl(
+      CachingOnDiskFileSystemImpl &FS,
+      function_ref<void(DirectoryEntry &)> TrackNonRealPathEntries,
+      bool IsTrackingStats, bool LookupOnDisk);
+  ~DiscoveryInstanceImpl();
+
+private:
+  Expected<DirectoryEntry *> requestDirectoryEntry(DirectoryEntry &Parent,
+                                                   StringRef Name) override;
+  Error requestSymlinkTarget(DirectoryEntry &Symlink) override;
+  Error preloadRealPath(DirectoryEntry &Parent, StringRef Remaining) override;
+  void trackNonRealPathEntry(DirectoryEntry &Entry) override;
+
+private:
+  CachingOnDiskFileSystemImpl &FS;
+  function_ref<void(DirectoryEntry &)> TrackNonRealPathEntries;
+  DirectoryEntry *RealPath = nullptr;
+  bool IsTrackingStats;
+  bool LookupOnDisk;
+  bool ComputedRealPath = false;
+};
 } // namespace
 
 CachingOnDiskFileSystem::CachingOnDiskFileSystem(std::shared_ptr<CASDB> DB)
@@ -267,20 +301,34 @@ CachingOnDiskFileSystemImpl::makeDirectory(DirectoryEntry &Parent,
   return &Cache->makeDirectory(Parent, TreePath);
 }
 
-Expected<FileSystemCache::DirectoryEntry *>
-CachingOnDiskFileSystemImpl::makeSymlink(DirectoryEntry &Parent,
-                                         const std::string &TreePath) {
+// FIXME: sink into llvm::sys::fs?
+static Error readlink(const llvm::Twine &Path, SmallVectorImpl<char> &Dest) {
+  SmallString<128> PathStorage;
+  StringRef P = Path.toNullTerminatedStringRef(PathStorage);
   char TargetBuffer[PATH_MAX] = {0};
-  int TargetLength =
-      ::readlink(TreePath.c_str(), TargetBuffer, sizeof(TargetBuffer));
+  int TargetLength = ::readlink(P.data(), TargetBuffer, sizeof(TargetBuffer));
   if (TargetLength == -1)
     return errorCodeToError(std::error_code(errno, std::generic_category()));
-  StringRef Target = StringRef(TargetBuffer, TargetLength);
+  Dest.assign(TargetBuffer, TargetBuffer + TargetLength);
+  return Error::success();
+}
 
+Expected<FileSystemCache::DirectoryEntry *>
+CachingOnDiskFileSystemImpl::makeSymlink(DirectoryEntry &Parent,
+                                         StringRef TreePath) {
+  SmallString<128> Target;
+  if (auto Err = readlink(TreePath, Target))
+    return std::move(Err);
+  return makeSymlinkTo(Parent, TreePath, Target);
+}
+
+Expected<FileSystemCache::DirectoryEntry *>
+CachingOnDiskFileSystemImpl::makeSymlinkTo(DirectoryEntry &Parent,
+                                           StringRef TreePath,
+                                           StringRef Target) {
   Expected<BlobProxy> Blob = DB.createBlob(Target);
   if (!Blob)
     return Blob.takeError();
-
   return &Cache->makeSymlink(Parent, TreePath, *Blob, **Blob);
 }
 
@@ -300,34 +348,32 @@ CachingOnDiskFileSystemImpl::makeFile(DirectoryEntry &Parent,
 }
 
 Expected<FileSystemCache::DirectoryEntry *>
-CachingOnDiskFileSystemImpl::lookupOnDiskFrom(DirectoryEntry &Parent,
-                                              StringRef Name) {
+CachingOnDiskFileSystemImpl::makeEntry(
+    DirectoryEntry &Parent, StringRef TreePath,
+    Optional<sys::fs::file_status> KnownStatus) {
   assert(Parent.isDirectory() && "Expected a directory");
-
-  // Open the path on disk.
-  StringRef ParentPath = Parent.getTreePath();
-  std::string Path =
-      (ParentPath.endswith("/") ? ParentPath + Name : ParentPath + "/" + Name)
-          .str();
 
   // lstat is extremely slow...
   sys::fs::file_status Status;
-  if (std::error_code EC = sys::fs::status(Path, Status, /*follow=*/false))
+  if (KnownStatus) {
+    Status = std::move(*KnownStatus);
+  } else if (auto EC = sys::fs::status(TreePath, Status, /*follow=*/false)) {
     return errorCodeToError(EC);
+  }
 
   if (Status.type() == sys::fs::file_type::directory_file)
-    return makeDirectory(Parent, Path);
+    return makeDirectory(Parent, TreePath);
 
   if (Status.type() == sys::fs::file_type::symlink_file)
-    return makeSymlink(Parent, Path);
+    return makeSymlink(Parent, TreePath);
 
   int FD;
   if (std::error_code EC =
-          sys::fs::openFile(Path, FD, sys::fs::CD_OpenExisting,
+          sys::fs::openFile(TreePath, FD, sys::fs::CD_OpenExisting,
                             sys::fs::FA_Read, sys::fs::OF_None))
     return errorCodeToError(EC);
   auto CloseOnExit = make_scope_exit([&FD]() { ::close(FD); });
-  return makeFile(Parent, Path, FD, Status);
+  return makeFile(Parent, TreePath, FD, Status);
 }
 
 ErrorOr<vfs::Status>
@@ -431,10 +477,10 @@ CachingOnDiskFileSystemImpl::getDirectoryIterator(const Twine &Path) {
 
   // Walk the directory on-disk to discover entries.
   std::error_code EC;
-  SmallVector<std::string> Names;
+  SmallVector<std::string> TreePaths;
   for (sys::fs::directory_iterator I(Entry->getTreePath(), EC), E;
        !EC && I != E; I.increment(EC))
-    Names.emplace_back(sys::path::filename(I->path()).str());
+    TreePaths.emplace_back(I->path());
   if (EC)
     return EC;
 
@@ -444,13 +490,16 @@ CachingOnDiskFileSystemImpl::getDirectoryIterator(const Twine &Path) {
   // Filter out names that we know about.
   {
     Directory::Reader R(D);
-    Names.erase(
-        llvm::remove_if(Names, [&D](StringRef Name) { return D.lookup(Name); }),
-        Names.end());
+    TreePaths.erase(llvm::remove_if(TreePaths,
+                                    [&D](StringRef TreePath) {
+                                      return D.lookup(
+                                          sys::path::filename(TreePath));
+                                    }),
+                    TreePaths.end());
   }
 
-  for (StringRef Name : Names)
-    if (Error E = lookupOnDiskFrom(*Entry, Name).takeError())
+  for (StringRef TreePath : TreePaths)
+    if (Error E = makeEntry(*Entry, TreePath, /*KnownStatus=*/None).takeError())
       return errorToErrorCode(std::move(E));
 
   return Cache->getCachedVFSDirIter(
@@ -458,8 +507,9 @@ CachingOnDiskFileSystemImpl::getDirectoryIterator(const Twine &Path) {
       WorkingDirectory.Path, PathRef);
 }
 
-Error CachingOnDiskFileSystemImpl::preloadRealPath(DirectoryEntry &From,
-                                                   StringRef Remaining) {
+Expected<FileSystemCache::DirectoryEntry *>
+CachingOnDiskFileSystemImpl::preloadRealPath(DirectoryEntry &From,
+                                             StringRef Remaining) {
   SmallString<256> ExpectedRealPath;
   ExpectedRealPath = From.getTreePath();
   sys::path::append(ExpectedRealPath, Remaining);
@@ -501,7 +551,7 @@ Error CachingOnDiskFileSystemImpl::preloadRealPath(DirectoryEntry &From,
 
   // Real path is already fully cached.
   if (State.Remaining.empty())
-    return Error::success();
+    return State.Entry;
 
   // All but the last component must be directories.
   while (!State.AfterName.empty()) {
@@ -511,7 +561,7 @@ Error CachingOnDiskFileSystemImpl::preloadRealPath(DirectoryEntry &From,
     // If we don't get back a directory, the disk state must have changed and
     // another thread raced. Give up on this endeavour.
     if (!Entry.isDirectory())
-      return Error::success();
+      return nullptr;
 
     State.advance(Entry);
   }
@@ -521,64 +571,17 @@ Error CachingOnDiskFileSystemImpl::preloadRealPath(DirectoryEntry &From,
   // Skip all errors from here out. This is just priming the cache.
   sys::fs::file_status Status;
   if (/*std::error_code EC =*/sys::fs::status(FD, Status))
-    return Error::success();
-
-  if (Status.type() == sys::fs::file_type::directory_file) {
-    (void)makeDirectory(*State.Entry, RealPath);
-    return Error::success();
-  }
-
-  if (Error E = makeFile(*State.Entry, RealPath, FD, Status).takeError())
-    llvm::consumeError(std::move(E));
-  return Error::success();
-}
-
-namespace {
-class OnDiskCachingFileSystemDI final
-    : public FileSystemCache::DiscoveryInstance {
-public:
-  using DirectoryEntry = FileSystemCache::DirectoryEntry;
-  OnDiskCachingFileSystemDI(
-      CachingOnDiskFileSystemImpl &FS,
-      function_ref<void(DirectoryEntry &)> TrackNonRealPathEntries,
-      bool IsTrackingStats, bool LookupOnDisk)
-      : FS(FS), TrackNonRealPathEntries(TrackNonRealPathEntries),
-        IsTrackingStats(IsTrackingStats), LookupOnDisk(LookupOnDisk) {}
-  ~OnDiskCachingFileSystemDI() {}
-
-private:
-  Expected<DirectoryEntry *> requestDirectoryEntry(DirectoryEntry &Parent,
-                                                   StringRef Name) override {
-    if (LookupOnDisk)
-      return FS.lookupOnDiskFrom(Parent, Name);
     return nullptr;
-  }
-  Error requestSymlinkTarget(DirectoryEntry &Symlink) override {
-    assert(Symlink.hasNode());
-    return Error::success();
-  }
-  Error preloadRealPath(DirectoryEntry &Parent, StringRef Remaining) override {
-    if (LookupOnDisk && !ComputedRealPath) {
-      ComputedRealPath = true;
-      return FS.preloadRealPath(Parent, Remaining);
-    }
-    return Error::success();
-  }
-  void trackNonRealPathEntry(DirectoryEntry &Entry) override {
-    if (TrackNonRealPathEntries)
-      TrackNonRealPathEntries(Entry);
-    if (IsTrackingStats)
-      FS.trackAccess(Entry);
-  }
 
-private:
-  CachingOnDiskFileSystemImpl &FS;
-  function_ref<void(DirectoryEntry &)> TrackNonRealPathEntries;
-  bool IsTrackingStats;
-  bool LookupOnDisk;
-  bool ComputedRealPath = false;
-};
-} // end anonymous namespace
+  if (Status.type() == sys::fs::file_type::directory_file)
+    return makeDirectory(*State.Entry, RealPath);
+
+  auto F = makeFile(*State.Entry, RealPath, FD, Status);
+  if (F)
+    return *F;
+  llvm::consumeError(F.takeError());
+  return nullptr;
+}
 
 Expected<FileSystemCache::DirectoryEntry *>
 CachingOnDiskFileSystemImpl::lookupPath(
@@ -586,8 +589,8 @@ CachingOnDiskFileSystemImpl::lookupPath(
     function_ref<void(FileSystemCache::DirectoryEntry &)>
         TrackNonRealPathEntries) {
   bool IsTrackingStats = isTrackingAccess();
-  OnDiskCachingFileSystemDI DI(*this, TrackNonRealPathEntries, IsTrackingStats,
-                               LookupOnDisk);
+  DiscoveryInstanceImpl DI(*this, TrackNonRealPathEntries, IsTrackingStats,
+                           LookupOnDisk);
   Expected<DirectoryEntry *> ExpectedEntry =
       Cache->lookupPath(DI, Path, *WorkingDirectory.Entry, FollowSymlinks);
   if (IsTrackingStats && ExpectedEntry && *ExpectedEntry)
@@ -669,6 +672,91 @@ Expected<TreeProxy> CachingOnDiskFileSystemImpl::createTreeFromAllAccesses() {
   if (Error E = Builder->push("/"))
     return std::move(E);
   return Builder->create();
+}
+
+DiscoveryInstanceImpl::DiscoveryInstanceImpl(
+    CachingOnDiskFileSystemImpl &FS,
+    function_ref<void(DirectoryEntry &)> TrackNonRealPathEntries,
+    bool IsTrackingStats, bool LookupOnDisk)
+    : FS(FS), TrackNonRealPathEntries(TrackNonRealPathEntries),
+      IsTrackingStats(IsTrackingStats), LookupOnDisk(LookupOnDisk) {}
+DiscoveryInstanceImpl::~DiscoveryInstanceImpl() {}
+
+Expected<FileSystemCache::DirectoryEntry *>
+DiscoveryInstanceImpl::requestDirectoryEntry(DirectoryEntry &Parent,
+                                             StringRef Name) {
+  if (!LookupOnDisk)
+    return nullptr;
+
+  assert(Parent.isDirectory() && "Expected a directory");
+  SmallString<256> Path(Parent.getTreePath());
+  sys::path::append(Path, Name);
+
+  // lstat is extremely slow...
+  sys::fs::file_status Status;
+  if (std::error_code EC = sys::fs::status(Path, Status, /*follow=*/false))
+    return errorCodeToError(EC);
+
+  DirectoryEntry *Next =
+      RealPath ? RealPath->nextEntryAfterPrefix(Parent) : nullptr;
+  if (!Next) {
+    // We do not know the realpath, or it does not contain Parent, which
+    // may indicate we are in the middle of looking up a path that contains a
+    // symlink to an absolute path in the current or a subsequent component, or
+    // that we hit F_GETPATH non-determinism for a hard link on Darwin. We need
+    // to get the realpath of Parent + Name, which may be different from the
+    // realpath of the path that's ultimately being looked up.
+    auto RP = FS.preloadRealPath(Parent, Name);
+    if (!RP)
+      return RP.takeError();
+    if (*RP)
+      Next = (*RP)->nextEntryAfterPrefix(Parent);
+  }
+  if (Next) {
+    StringRef NextName = Next->getName();
+    if (Name == NextName)
+      return Next;
+    if (Name.equals_insensitive(NextName) || !isASCII(Name)) {
+      // Might be a case-insensitive match, check if it's the same entity.
+      // FIXME: put this unique id in the cache.
+      sys::fs::file_status StatNext;
+      if (std::error_code EC =
+              sys::fs::status(Next->getTreePath(), StatNext, /*follow=*/false))
+        return errorCodeToError(EC);
+      if (Status.getUniqueID() == StatNext.getUniqueID()) {
+        // Case-insensitive match! Create a fake symlink so that it will have
+        // the correct realpath and uid.
+        return FS.makeSymlinkTo(Parent, Path, NextName);
+      }
+    }
+    // Fallthrough and create a new entry...
+  }
+
+  return FS.makeEntry(Parent, Path, Status);
+}
+
+Error DiscoveryInstanceImpl::requestSymlinkTarget(DirectoryEntry &Symlink) {
+  assert(Symlink.hasNode());
+  return Error::success();
+}
+
+Error DiscoveryInstanceImpl::preloadRealPath(DirectoryEntry &Parent,
+                                             StringRef Remaining) {
+  if (LookupOnDisk && !ComputedRealPath) {
+    ComputedRealPath = true;
+    auto Entry = FS.preloadRealPath(Parent, Remaining);
+    if (Entry)
+      RealPath = *Entry;
+    return Entry.takeError();
+  }
+  return Error::success();
+}
+
+void DiscoveryInstanceImpl::trackNonRealPathEntry(DirectoryEntry &Entry) {
+  if (TrackNonRealPathEntries)
+    TrackNonRealPathEntries(Entry);
+  if (IsTrackingStats)
+    FS.trackAccess(Entry);
 }
 
 class CachingOnDiskFileSystemImpl::TreeBuilder final

--- a/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
@@ -383,4 +383,113 @@ TEST(CachingOnDiskFileSystemTest, getRealPath) {
   EXPECT_EQ(FilePath, LinkPath);
 }
 
+TEST(CachingOnDiskFileSystemTest, caseSensitivityFile) {
+  TempDir D("caching-on-disk-file-system-test", /*Unique=*/true);
+  IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS =
+      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
+  ASSERT_FALSE(FS->setCurrentWorkingDirectory(D.path()));
+
+  std::vector<std::pair<std::string, std::string>> Files = {{"file", "File"},
+                                                            {"filé", "filÉ"}};
+
+  for (auto &Pair : Files) {
+    TempFile File1(D.path(Pair.first), "", "content");
+    TempFile File2(D.path(Pair.second), "", "content");
+    SmallString<128> File1PathReal, File2PathReal;
+    ASSERT_EQ(llvm::sys::fs::real_path(File1.path(), File1PathReal),
+              std::error_code());
+    ASSERT_EQ(llvm::sys::fs::real_path(File2.path(), File2PathReal),
+              std::error_code());
+    SmallString<128> File1Path, File2Path;
+    EXPECT_FALSE(FS->getRealPath(File1.path(), File1Path));
+    EXPECT_FALSE(FS->getRealPath(File2.path(), File2Path));
+    EXPECT_EQ(File1Path, File1PathReal);
+    llvm::vfs::Status Stat1, Stat2;
+    ASSERT_THAT_ERROR(
+        errorOrToExpected(FS->status(File1.path())).moveInto(Stat1),
+        Succeeded());
+    ASSERT_THAT_ERROR(
+        errorOrToExpected(FS->status(File2.path())).moveInto(Stat2),
+        Succeeded());
+
+    if (File1PathReal == File2PathReal) {
+      // Case-insensitive underlying filesystem.
+      EXPECT_EQ(File1Path, File2Path);
+      EXPECT_EQ(Stat1.getUniqueID(), Stat2.getUniqueID());
+    } else {
+      // Case-sensitive underlying filesystem.
+      EXPECT_EQ(File2Path, File2PathReal);
+      EXPECT_NE(File1Path, File2Path);
+      EXPECT_NE(Stat1.getUniqueID(), Stat2.getUniqueID());
+    }
+  }
+}
+
+TEST(CachingOnDiskFileSystemTest, caseSensitivityDir) {
+  TempDir D("caching-on-disk-file-system-test", /*Unique=*/true);
+  IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS =
+      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
+  ASSERT_FALSE(FS->setCurrentWorkingDirectory(D.path()));
+
+  TempDir Dir1(D.path("dir"));
+  if (!llvm::sys::fs::exists(D.path("Dir")))
+    return; // Case-sensitive filesystem.
+  llvm::vfs::Status StatD1, StatD2;
+  ASSERT_THAT_ERROR(errorOrToExpected(FS->status(Dir1.path())).moveInto(StatD1),
+                    Succeeded());
+  ASSERT_THAT_ERROR(
+      errorOrToExpected(FS->status(D.path("Dir"))).moveInto(StatD2),
+      Succeeded());
+  EXPECT_EQ(StatD1.getUniqueID(), StatD2.getUniqueID());
+
+  TempDir DirDir(Dir1.path("dir"));
+  TempLink Link1("dir", Dir1.path("link1"));
+  TempLink Link2("Dir", Dir1.path("link2"));
+  TempDir D2("caching-on-disk-file-system-test-other", /*Unique=*/true);
+  TempLink Link3(D2.path(), Dir1.path("link3"));
+  std::string RelativeD2 = "../../" + sys::path::filename(D2.path()).str();
+  TempLink Link4(RelativeD2, Dir1.path("link4"));
+
+  std::vector<std::pair<std::string, std::string>> Files = {
+      {"file", "file"},             // noncanon/canon
+      {"file", "File"},             // noncanon/noncanon
+      {"dir/file", "dir/file"},     // noncanon/canon/canon
+      {"dir/file", "dir/File"},     // noncanon/canon/noncanon
+      {"dir/file", "Dir/file"},     // noncanon/noncanon/canon
+      {"dir/file", "Dir/File"},     // noncanon/noncanon/noncanon
+      {"dir/file", "link1/file"},   // symlink
+      {"dir/file", "Link1/file"},   // symlink with case-insensitivity
+      {"dir/file", "link2/file"},   // symlink -> noncanon
+      {"dir/file", "Link2/file"},   // symlink -> noncanon
+      {"link3/file", "link4/file"}, // absolute symlink/canon
+      {"link4/file", "link4/File"}, // absolute symlink/noncanon
+  };
+
+  for (auto &Pair : Files) {
+    TempFile File1(D.path("dir/" + Pair.first), "", "content");
+    TempFile File2(D.path("Dir/" + Pair.second), "", "content");
+
+    SmallString<128> File1PathReal, File2PathReal;
+    ASSERT_EQ(llvm::sys::fs::real_path(File1.path(), File1PathReal),
+              std::error_code());
+    ASSERT_EQ(llvm::sys::fs::real_path(File2.path(), File2PathReal),
+              std::error_code());
+    SmallString<128> File1Path, File2Path;
+    EXPECT_FALSE(FS->getRealPath(File1.path(), File1Path));
+    EXPECT_FALSE(FS->getRealPath(File2.path(), File2Path));
+    EXPECT_EQ(File1Path, File1PathReal);
+    llvm::vfs::Status StatF1, StatF2;
+    ASSERT_THAT_ERROR(
+        errorOrToExpected(FS->status(File1.path())).moveInto(StatF1),
+        Succeeded());
+    ASSERT_THAT_ERROR(
+        errorOrToExpected(FS->status(File2.path())).moveInto(StatF2),
+        Succeeded());
+
+    EXPECT_EQ(File1PathReal, File2PathReal);
+    EXPECT_EQ(File1Path, File2Path);
+    EXPECT_EQ(StatF1.getUniqueID(), StatF2.getUniqueID());
+  }
+}
+
 } // namespace


### PR DESCRIPTION
When encountering a case-insensitive match for a path, attempt to create a fake symlink to the canonical name. This ensures that the realpath and uniqueid of paths will be correct on case-insensitive filesystems.

---

New version of #4223 that only does extra realpath calls only when they are not contained within the original realpath. Also adds test cases involving symlinks to exercise that.