### PR TITLE
[lldb] Fix swift-healtcheck channel definition

### DIFF
--- a/lldb/source/Plugins/Language/Swift/LogChannelSwift.cpp
+++ b/lldb/source/Plugins/Language/Swift/LogChannelSwift.cpp
@@ -20,8 +20,6 @@ static Log::Channel g_channel(g_categories, SwiftLog::Health);
 
 static std::string g_swift_log_buffer;
 
-Log::Channel LogChannelSwift::g_channel(g_categories, SwiftLog::Health);
-
 template <> Log::Channel &lldb_private::LogChannelFor<SwiftLog>() {
   return g_channel;
 }

--- a/lldb/source/Plugins/Language/Swift/LogChannelSwift.h
+++ b/lldb/source/Plugins/Language/Swift/LogChannelSwift.h
@@ -20,10 +20,7 @@ enum class SwiftLog : Log::MaskType {
   LLVM_MARK_AS_BITMASK_ENUM(Health)
 };
 
-class LogChannelSwift {
-  static Log::Channel g_channel;
-
-public:
+struct LogChannelSwift {
   static void Initialize();
   static void Terminate();
 


### PR DESCRIPTION
In 41098357c8deb995a06deeb302ef3061e079b733, there ended up being two definitions of `g_channel`, the `Log::Channel` instance backing the `swift-healthcheck` command. This removes the duplicate.

rdar://91652023