### PR TITLE
Fix sanitizer stack traces on aarch64.

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
@@ -903,11 +903,7 @@ static void GetPcSpBp(void *context, uptr *pc, uptr *sp, uptr *bp) {
   ucontext_t *ucontext = (ucontext_t*)context;
 # if defined(__aarch64__)
   *pc = AARCH64_GET_REG(pc);
-#   if defined(__IPHONE_8_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_8_0
   *bp = AARCH64_GET_REG(fp);
-#   else
-  *bp = AARCH64_GET_REG(lr);
-#   endif
   *sp = AARCH64_GET_REG(sp);
 # elif defined(__x86_64__)
   *pc = ucontext->uc_mcontext->__ss.__rip;


### PR DESCRIPTION
Fixes llvm-project/compiler-rt/test/asan/TestCases/null_deref.cpp on
macOS/aarch64.

The bp (base pointer) variable was being loaded from register LR and
not FP on aarch64 (except for this narrow case):
defined(__IPHONE_8_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_8_0

Without a valid bp from the FP register, it is not possible to traverse
previous frames for a complete stack trace. The rationale for fetching
the LR as the bp for all cases except above is not clear but since the
FP register is the canonical register for use as the frame pointer, this
commit removes the restriction above for unconditional use all aarch64.

rdar://91587039

Differential Revision: https://reviews.llvm.org/D124140

(cherry picked from commit d179627ef012f061a9186c9f026a3f0ec771c3e9)