### PR TITLE
Add Template Definition for targetImplicitGenericParamDescriptors

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -41,6 +41,12 @@
 using namespace lldb;
 using namespace lldb_private;
 
+template <class Runtime>
+const swift::GenericParamDescriptor *
+swift::targetImplicitGenericParamDescriptors() {
+  return swift::externalTargetImplicitGenericParamDescriptors();
+}
+
 namespace lldb_private {
 swift::Type GetSwiftType(CompilerType type) {
   auto *ts = type.GetTypeSystem();


### PR DESCRIPTION
This is needed for the remote metadata resolution machinery to be
able to interpret extended existential type metadata and shapes.