### PR TITLE
[dsymutil] Fix memory issue in the BinaryHolder

### DIFF
--- a/llvm/tools/dsymutil/BinaryHolder.h
+++ b/llvm/tools/dsymutil/BinaryHolder.h
@@ -118,7 +118,7 @@ public:
 
   private:
     std::vector<std::unique_ptr<object::Archive>> Archives;
-    DenseMap<KeyTy, ObjectEntry> MemberCache;
+    DenseMap<KeyTy, std::unique_ptr<ObjectEntry>> MemberCache;
     std::mutex MemberCacheMutex;
   };
 
@@ -130,11 +130,11 @@ public:
 private:
   /// Cache of static archives. Objects that are part of a static archive are
   /// stored under this object, rather than in the map below.
-  StringMap<ArchiveEntry> ArchiveCache;
+  StringMap<std::unique_ptr<ArchiveEntry>> ArchiveCache;
   std::mutex ArchiveCacheMutex;
 
   /// Object entries for objects that are not in a static archive.
-  StringMap<ObjectEntry> ObjectCache;
+  StringMap<std::unique_ptr<ObjectEntry>> ObjectCache;
   std::mutex ObjectCacheMutex;
 
   /// Virtual File System instance.


### PR DESCRIPTION
The BinaryHolder has two caches for object and archive entries. These
are implemented as StringMaps of ObjectEntry and ArchiveEntry
respectively. The fact that they're stored by value is problematic
because the BinaryHolder hands out references that become invalidate
when the data structure grows. This patch wraps those object instances
in unique pointers and changes the interface to hand out pointers. This
resulted in transient failures.

rdar://90412671

Differential revision: https://reviews.llvm.org/D124567

(cherry picked from commit 7d67a1e45a04854506b1d14f219c643489d6d78e)
