### PR TITLE
Support: report_fatal_error on double-closing OutputFile

### DIFF
--- a/llvm/include/llvm/Support/VirtualOutputFile.h
+++ b/llvm/include/llvm/Support/VirtualOutputFile.h
@@ -69,14 +69,18 @@ public:
     return getOS() << std::forward<T>(V);
   }
 
-  /// Keep an output. Errors if this fails or it's already closed.
+  /// Keep an output. Errors if this fails.
+  ///
+  /// If it has already been closed, calls \a report_fatal_error().
   ///
   /// If there's an open proxy from \a createProxy(), calls \a discard() to
   /// clean up temporaries followed by \a report_fatal_error().
   Error keep();
 
   /// Discard an output, cleaning up any temporary state. Errors if clean-up
-  /// fails or it's already closed.
+  /// fails.
+  ///
+  /// If it has already been closed, calls \a report_fatal_error().
   Error discard();
 
   /// Discard the output when destroying it if it's still open, sending the

--- a/llvm/lib/Support/VirtualOutputFile.cpp
+++ b/llvm/lib/Support/VirtualOutputFile.cpp
@@ -47,8 +47,10 @@ Expected<std::unique_ptr<raw_pwrite_stream>> OutputFile::createProxy() {
 }
 
 Error OutputFile::keep() {
-  if (!Impl)
-    return make_error<OutputError>(getPath(), OutputErrorCode::already_closed);
+  // Catch double-closing logic bugs.
+  if (LLVM_UNLIKELY(!Impl))
+    report_fatal_error(
+        make_error<OutputError>(getPath(), OutputErrorCode::already_closed));
 
   // Report a fatal error if there's an open proxy and the file is being kept.
   // This is safer than relying on clients to remember to flush(). Also call
@@ -66,8 +68,10 @@ Error OutputFile::keep() {
 }
 
 Error OutputFile::discard() {
-  if (!Impl)
-    return make_error<OutputError>(getPath(), OutputErrorCode::already_closed);
+  // Catch double-closing logic bugs.
+  if (LLVM_UNLIKELY(!Impl))
+    report_fatal_error(
+        make_error<OutputError>(getPath(), OutputErrorCode::already_closed));
 
   // Be lenient about open proxies since client teardown paths won't
   // necessarily clean up in the right order. Reset the proxy to flush any

--- a/llvm/unittests/Support/VirtualOutputFileTest.cpp
+++ b/llvm/unittests/Support/VirtualOutputFileTest.cpp
@@ -148,11 +148,12 @@ TEST(VirtualOutputFileTest, discard) {
     EXPECT_EQ(0, Data.Kept);
     EXPECT_EQ(1, Data.Discarded);
 
-    EXPECT_THAT_ERROR(
-        F.keep(), FailedWithMessage("some/file/path: output already closed"));
-    EXPECT_THAT_ERROR(
-        F.discard(),
-        FailedWithMessage("some/file/path: output already closed"));
+#if GTEST_HAS_DEATH_TEST
+    EXPECT_DEATH(
+        consumeError(F.keep()), "some/file/path: output already closed");
+    EXPECT_DEATH(
+        consumeError(F.discard()), "some/file/path: output already closed");
+#endif
   }
   EXPECT_EQ(0, Data.Kept);
   EXPECT_EQ(1, Data.Discarded);
@@ -227,11 +228,12 @@ TEST(VirtualOutputFileTest, keep) {
     EXPECT_EQ(1, Data.Kept);
     EXPECT_EQ(0, Data.Discarded);
 
-    EXPECT_THAT_ERROR(
-        F.keep(), FailedWithMessage("some/file/path: output already closed"));
-    EXPECT_THAT_ERROR(
-        F.discard(),
-        FailedWithMessage("some/file/path: output already closed"));
+#if GTEST_HAS_DEATH_TEST
+    EXPECT_DEATH(
+        consumeError(F.keep()), "some/file/path: output already closed");
+    EXPECT_DEATH(
+        consumeError(F.discard()), "some/file/path: output already closed");
+#endif
   }
   EXPECT_EQ(1, Data.Kept);
   EXPECT_EQ(0, Data.Discarded);


### PR DESCRIPTION
PR just for:

@swift-ci test