### PR TITLE
[cas] Add a clang-cas-test utility with option to dump compile-job cache keys

### DIFF
--- a/clang/include/clang/Frontend/CompileJobCacheKey.h
+++ b/clang/include/clang/Frontend/CompileJobCacheKey.h
@@ -1,0 +1,50 @@
+//===- CompileJobCacheKey.h -------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file Functions for working with compile job cache keys.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_FRONTEND_COMPILEJOBCACHEKEY_H
+#define LLVM_CLANG_FRONTEND_COMPILEJOBCACHEKEY_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/CAS/CASID.h"
+#include "llvm/Support/Error.h"
+
+namespace llvm {
+namespace cas {
+class CASDB;
+}
+class raw_ostream;
+} // namespace llvm
+
+namespace clang {
+
+class CompilerInvocation;
+class DiagnosticsEngine;
+
+/// Create a cache key for the given \c CompilerInvocation as a \c CASID.
+llvm::Optional<llvm::cas::CASID>
+createCompileJobCacheKey(llvm::cas::CASDB &CAS, DiagnosticsEngine &Diags,
+                         const CompilerInvocation &Invocation);
+
+/// Create a cache key for the given cc1 command-line arguments and filesystem
+/// as a \c CASID.
+llvm::cas::CASID createCompileJobCacheKey(llvm::cas::CASDB &CAS,
+                                          llvm::ArrayRef<const char *> CC1Args,
+                                          llvm::cas::CASID FileSystemRootID);
+
+/// Print the structure of the cache key given by \p Key to \p OS. Returns an
+/// error if the key object does not exist in \p CAS, or is malformed.
+llvm::Error printCompileJobCacheKey(llvm::cas::CASDB &CAS, llvm::cas::CASID Key,
+                                    llvm::raw_ostream &OS);
+
+} // namespace clang
+
+#endif // LLVM_CLANG_FRONTEND_COMPILEJOBCACHEKEY_H

--- a/clang/include/clang/Frontend/CompileJobCacheKey.h
+++ b/clang/include/clang/Frontend/CompileJobCacheKey.h
@@ -35,7 +35,7 @@ createCompileJobCacheKey(llvm::cas::CASDB &CAS, DiagnosticsEngine &Diags,
                          const CompilerInvocation &Invocation);
 
 /// Create a cache key for the given cc1 command-line arguments and filesystem
-/// as a \c CASID.
+/// as a \c CASID. The first argument must be "-cc1".
 llvm::cas::CASID createCompileJobCacheKey(llvm::cas::CASDB &CAS,
                                           llvm::ArrayRef<const char *> CC1Args,
                                           llvm::cas::CASID FileSystemRootID);

--- a/clang/lib/Frontend/CMakeLists.txt
+++ b/clang/lib/Frontend/CMakeLists.txt
@@ -15,6 +15,7 @@ add_clang_library(clangFrontend
   ASTUnit.cpp
   ChainedDiagnosticConsumer.cpp
   ChainedIncludesSource.cpp
+  CompileJobCacheKey.cpp
   CompilerInstance.cpp
   CompilerInvocation.cpp
   CreateInvocationFromCommandLine.cpp

--- a/clang/lib/Frontend/CompileJobCacheKey.cpp
+++ b/clang/lib/Frontend/CompileJobCacheKey.cpp
@@ -23,6 +23,7 @@ using namespace llvm::cas;
 llvm::cas::CASID
 clang::createCompileJobCacheKey(CASDB &CAS, ArrayRef<const char *> CC1Args,
                                 llvm::cas::CASID FileSystemRootID) {
+  assert(!CC1Args.empty() && StringRef(CC1Args[0]) == "-cc1");
   SmallString<256> CommandLine;
   for (StringRef Arg : CC1Args) {
     CommandLine.append(Arg);
@@ -50,6 +51,7 @@ clang::createCompileJobCacheKey(CASDB &CAS, DiagnosticsEngine &Diags,
   llvm::BumpPtrAllocator Alloc;
   llvm::StringSaver Saver(Alloc);
   llvm::SmallVector<const char *> Argv;
+  Argv.push_back("-cc1");
   Invocation.generateCC1CommandLine(
       Argv, [&Saver](const llvm::Twine &T) { return Saver.save(T).data(); });
 

--- a/clang/lib/Frontend/CompileJobCacheKey.cpp
+++ b/clang/lib/Frontend/CompileJobCacheKey.cpp
@@ -1,0 +1,139 @@
+//===- CompileJobCacheKey.cpp ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Frontend/CompileJobCacheKey.h"
+#include "clang/Basic/DiagnosticCAS.h"
+#include "clang/Basic/Version.h"
+#include "clang/Frontend/CompilerInvocation.h"
+#include "llvm/CAS/CASDB.h"
+#include "llvm/CAS/HierarchicalTreeBuilder.h"
+#include "llvm/CAS/Utils.h"
+#include "llvm/Support/StringSaver.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace clang;
+using namespace llvm;
+using namespace llvm::cas;
+
+llvm::cas::CASID
+clang::createCompileJobCacheKey(CASDB &CAS, ArrayRef<const char *> CC1Args,
+                                llvm::cas::CASID FileSystemRootID) {
+  SmallString<256> CommandLine;
+  for (StringRef Arg : CC1Args) {
+    CommandLine.append(Arg);
+    CommandLine.push_back(0);
+  }
+
+  llvm::cas::HierarchicalTreeBuilder Builder;
+  Builder.push(FileSystemRootID, llvm::cas::TreeEntry::Tree, "filesystem");
+  Builder.push(llvm::cantFail(CAS.createBlob(CommandLine)),
+               llvm::cas::TreeEntry::Regular, "command-line");
+  Builder.push(llvm::cantFail(CAS.createBlob("-cc1")),
+               llvm::cas::TreeEntry::Regular, "computation");
+
+  // FIXME: The version is maybe insufficient...
+  Builder.push(llvm::cantFail(CAS.createBlob(getClangFullVersion())),
+               llvm::cas::TreeEntry::Regular, "version");
+
+  return llvm::cantFail(Builder.create(CAS)).getID();
+}
+
+Optional<llvm::cas::CASID>
+clang::createCompileJobCacheKey(CASDB &CAS, DiagnosticsEngine &Diags,
+                                const CompilerInvocation &Invocation) {
+  // Generate a new command-line in case Invocation has been canonicalized.
+  llvm::BumpPtrAllocator Alloc;
+  llvm::StringSaver Saver(Alloc);
+  llvm::SmallVector<const char *> Argv;
+  Invocation.generateCC1CommandLine(
+      Argv, [&Saver](const llvm::Twine &T) { return Saver.save(T).data(); });
+
+  // FIXME: currently correct since the main executable is always in the root
+  // from scanning, but we should probably make it explicit here...
+  StringRef RootIDString = Invocation.getFileSystemOpts().CASFileSystemRootID;
+  Expected<llvm::cas::CASID> RootID = CAS.parseID(RootIDString);
+  if (!RootID) {
+    llvm::consumeError(RootID.takeError());
+    Diags.Report(diag::err_cas_cannot_parse_root_id) << RootIDString;
+    return None;
+  }
+
+  return createCompileJobCacheKey(CAS, Argv, *RootID);
+}
+
+static Error printFileSystem(cas::CASDB &CAS, cas::CASID ID, raw_ostream &OS) {
+  return cas::walkFileTreeRecursively(
+      CAS, ID,
+      [&](const cas::NamedTreeEntry &Entry, Optional<cas::TreeProxy> Tree) {
+        if (Entry.getKind() != cas::TreeEntry::Tree || Tree->empty()) {
+          OS << "\n  ";
+          Entry.print(OS, CAS);
+        }
+        return Error::success();
+      });
+}
+
+static Error printCompileJobCacheKey(cas::CASDB &CAS, cas::TreeHandle Tree,
+                                     raw_ostream &OS) {
+  auto strError = [](const Twine &Err) {
+    return createStringError(inconvertibleErrorCode(), Err);
+  };
+
+  // Not exhaustive, but quick check that this looks like a cache key.
+  if (!CAS.lookupTreeEntry(Tree, "computation"))
+    return strError("cas object is not a valid cache key");
+
+  return CAS.forEachTreeEntry(Tree, [&](const cas::NamedTreeEntry &E) -> Error {
+    OS << E.getName() << ": " << E.getID();
+    if (E.getKind() == cas::TreeEntry::Tree)
+      return printFileSystem(CAS, E.getID(), OS);
+
+    if (E.getKind() != cas::TreeEntry::Regular)
+      return strError("expected blob for entry " + E.getName());
+    auto Blob = CAS.getBlob(E.getID());
+    if (!Blob)
+      return Blob.takeError();
+
+    auto Data = Blob->getData();
+    if (E.getName() == "command-line") {
+      StringRef Arg;
+      StringRef Trailing;
+      do {
+        std::tie(Arg, Data) = Data.split('\0');
+        if (Arg.startswith("-")) {
+          OS << Trailing << "\n  " << Arg;
+        } else {
+          OS << " " << Arg;
+        }
+        Trailing = " \\";
+      } while (!Data.empty());
+    } else {
+      OS << "\n  " << Data;
+    }
+    OS << "\n";
+    return Error::success();
+  });
+}
+
+Error clang::printCompileJobCacheKey(CASDB &CAS, CASID Key, raw_ostream &OS) {
+  auto H = CAS.loadObject(Key);
+  if (!H)
+    return H.takeError();
+  if (!*H)
+    return createStringError(inconvertibleErrorCode(),
+                             "cache key not present in CAS");
+  auto Tree = (*H)->dyn_cast<cas::TreeHandle>();
+  if (!Tree) {
+    std::string ErrStr;
+    llvm::raw_string_ostream Err(ErrStr);
+    Err << "expected cache key to be a CAS tree; got ";
+    (*H)->print(Err);
+    return createStringError(inconvertibleErrorCode(), Err.str());
+  }
+  return ::printCompileJobCacheKey(CAS, *Tree, OS);
+}

--- a/clang/test/CAS/print-compile-job-cache-key.c
+++ b/clang/test/CAS/print-compile-job-cache-key.c
@@ -1,0 +1,34 @@
+// REQUIRES: shell
+
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
+//
+// RUN: %clang -cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache-miss -emit-obj -o %t/output.o %s 2> %t/output.txt
+//
+// RUN: cat %t/output.txt | sed \
+// RUN:   -e "s/^.*miss for '//" \
+// RUN:   -e "s/' .*$//" > %t/cache-key
+//
+// RUN: not clang-cas-test -print-compile-job-cache-key -cas %t/cas 2>&1 | FileCheck %s -check-prefix=NO_KEY
+// NO_KEY: missing compile-job cache key
+//
+// RUN: not clang-cas-test -print-compile-job-cache-key -cas %t/cas asdf 2>&1 | FileCheck %s -check-prefix=INVALID_KEY
+// INVALID_KEY: invalid cas-id 'asdf'
+//
+// RUN: not clang-cas-test -print-compile-job-cache-key -cas %t/cas @%t/casid 2>&1 | FileCheck %s -check-prefix=NOT_A_KEY
+// NOT_A_KEY: not a valid cache key
+//
+// RUN: clang-cas-test -print-compile-job-cache-key -cas %t/cas @%t/cache-key | FileCheck %s
+//
+// CHECK: command-line: llvmcas://
+// CHECK:   -fcas-path llvm.cas.builtin.v2[BLAKE3]
+// CHECK:   -fcas-fs llvmcas://
+// CHECK:   -x c {{.*}}print-compile-job-cache-key.c
+// CHECK: computation: llvmcas://
+// CHECK:   -cc1
+// CHECK: filesystem: llvmcas://
+// CHECK:   file llvmcas://
+// CHECK: version: llvmcas://
+// CHECK:   clang version

--- a/clang/test/CAS/print-compile-job-cache-key.c
+++ b/clang/test/CAS/print-compile-job-cache-key.c
@@ -23,6 +23,7 @@
 // RUN: clang-cas-test -print-compile-job-cache-key -cas %t/cas @%t/cache-key | FileCheck %s
 //
 // CHECK: command-line: llvmcas://
+// CHECK:   -cc1
 // CHECK:   -fcas-path llvm.cas.builtin.v2[BLAKE3]
 // CHECK:   -fcas-fs llvmcas://
 // CHECK:   -x c {{.*}}print-compile-job-cache-key.c

--- a/clang/tools/CMakeLists.txt
+++ b/clang/tools/CMakeLists.txt
@@ -14,6 +14,7 @@ add_clang_subdirectory(clang-offload-bundler)
 add_clang_subdirectory(clang-offload-wrapper)
 add_clang_subdirectory(clang-scan-deps)
 add_clang_subdirectory(clang-repl)
+add_clang_subdirectory(clang-cas-test)
 
 add_clang_subdirectory(c-index-test)
 

--- a/clang/tools/clang-cas-test/CMakeLists.txt
+++ b/clang/tools/clang-cas-test/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(LLVM_LINK_COMPONENTS
+  CAS
+  Support
+  )
+
+add_clang_executable(clang-cas-test
+  ClangCASTest.cpp
+  )
+
+clang_target_link_libraries(clang-cas-test PRIVATE
+  clangBasic
+  clangCAS
+  clangFrontend
+  )

--- a/clang/tools/clang-cas-test/ClangCASTest.cpp
+++ b/clang/tools/clang-cas-test/ClangCASTest.cpp
@@ -1,0 +1,74 @@
+//===- ClangCASTest.cpp ---------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Frontend/CompileJobCacheKey.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "llvm/CAS/CASDB.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/InitLLVM.h"
+
+using namespace clang;
+using namespace llvm;
+
+static void printCompileJobCacheKey(StringRef CASPath, StringRef Key) {
+  ExitOnError ExitOnErr;
+  IntrusiveRefCntPtr<DiagnosticsEngine> Diags(
+      CompilerInstance::createDiagnostics(new DiagnosticOptions));
+
+  CASOptions Opts;
+  // Printing a cache key only makes sense in an existing CAS, so default to
+  // on-disk instead of in-memory if no --cas path is specified.
+  Opts.CASPath = CASPath.empty() ? "auto" : CASPath.str();
+
+  auto CAS = Opts.getOrCreateCAS(*Diags, /*CreateEmptyCASOnFailure=*/false);
+  if (!CAS)
+    return;
+
+  auto KeyID = ExitOnErr(CAS->parseID(Key));
+  ExitOnErr(printCompileJobCacheKey(*CAS, KeyID, outs()));
+}
+
+int main(int Argc, const char **Argv) {
+  llvm::InitLLVM X(Argc, Argv);
+
+  enum ActionType {
+    None,
+    PrintCompileJobCacheKey,
+  };
+
+  cl::opt<ActionType> Action(
+      cl::desc("Action:"), cl::init(ActionType::None),
+      cl::values(
+          clEnumValN(PrintCompileJobCacheKey, "print-compile-job-cache-key",
+                     "Print a compile-job result cache key's structure")));
+
+  cl::opt<std::string> CASPath("cas", cl::desc("On-disk CAS path"),
+                               cl::value_desc("path"));
+  cl::list<std::string> Inputs(cl::Positional, cl::desc("<input>..."));
+
+  cl::ParseCommandLineOptions(Argc, Argv, "clang-cas-test");
+  ExitOnError ExitOnErr("clang-cas-test: ");
+
+  if (Action == ActionType::None) {
+    errs() << "error: action required; pass '-help' for options\n";
+    return 1;
+  }
+
+  if (Action == ActionType::PrintCompileJobCacheKey) {
+    if (Inputs.empty()) {
+      errs() << "error: missing compile-job cache key in inputs'\n";
+      return 1;
+    }
+    for (StringRef CacheKey : Inputs)
+      printCompileJobCacheKey(CASPath, CacheKey);
+  }
+
+  return 0;
+}

--- a/llvm/include/llvm/CAS/TreeEntry.h
+++ b/llvm/include/llvm/CAS/TreeEntry.h
@@ -15,6 +15,8 @@
 namespace llvm {
 namespace cas {
 
+class CASDB;
+
 class TreeEntry {
 public:
   enum EntryKind {
@@ -57,6 +59,8 @@ public:
 
   NamedTreeEntry(CASID ID, EntryKind Kind, StringRef Name)
       : TreeEntry(ID, Kind), Name(Name) {}
+
+  void print(raw_ostream &OS, CASDB &CAS) const;
 
 private:
   StringRef Name;

--- a/llvm/lib/CAS/Utils.cpp
+++ b/llvm/lib/CAS/Utils.cpp
@@ -85,3 +85,32 @@ Error cas::walkFileTreeRecursively(
 
   return Error::success();
 }
+
+static void printTreeEntryKind(raw_ostream &OS, TreeEntry::EntryKind Kind) {
+  switch (Kind) {
+  case TreeEntry::Regular:
+    OS << "file";
+    break;
+  case TreeEntry::Executable:
+    OS << "exec";
+    break;
+  case TreeEntry::Symlink:
+    OS << "syml";
+    break;
+  case TreeEntry::Tree:
+    OS << "tree";
+    break;
+  }
+}
+
+void cas::NamedTreeEntry::print(raw_ostream &OS, CASDB &CAS) const {
+  printTreeEntryKind(OS, getKind());
+  OS << " " << getID() << " " << Name;
+  if (getKind() == TreeEntry::Tree)
+    OS << "/";
+  if (getKind() == TreeEntry::Symlink) {
+    auto Target = cantFail(CAS.getBlob(getID()));
+    OS << " -> " << *Target;
+  }
+  OS << "\n";
+}


### PR DESCRIPTION
Usage:

```
clang-cas-test -print-compile-job-cache-key [-cas PATH] <KEY>
```

This makes it easier to debug what went into a given compile-job cache
key and to compare it to another key by printing out the command-line,
filesystem, and other entries in a format that is amenable to diff.

Incidentally, factor the code for creating a cache key into the same
file as the printer.