### PR TITLE
[driver] Introduce `clang-cache` driver variant, intended to be used as a compiler launcher for compilation caching

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -126,6 +126,24 @@ Optionally also install experimental libtool and linker support:
 
 ### Caching with just-built toolchain
 
+#### Use `clang-cache` as compiler launcher
+
+Using `clang-cache` there's no need to modify compiler arguments.
+Set the environment variable `CLANG_CACHE_CAS_PATH` to specify a non-default
+location for the on-disk CAS.
+
+```
+% CLANG="$TOOLCHAIN"/usr/bin/clang
+% cmake -G Ninja                                   \
+     -DLLVM_ENABLE_PROJECTS="clang"                \
+     -DCMAKE_C_COMPILER_LAUNCHER=${CLANG}-cache    \
+     -DCMAKE_CXX_COMPILER_LAUNCHER=${CLANG}-cache  \
+     -DCMAKE_C_COMPILER=$CLANG                     \
+     -DCMAKE_CXX_COMPILER=${CLANG}++               \
+     ../llvm
+% ninja
+```
+
 #### LLVM project CMake configuration
 
 For building a CAS-aware branch (i.e., this one!), there are some extra CMake

--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -24,6 +24,10 @@ def err_cas_depscan_daemon_connection: Error<
 def err_cas_depscan_failed: Error<
   "CAS-based dependency scan failed: %0">, DefaultFatal;
 
+def warn_clang_cache_disabled_caching: Warning<
+  "clang-cache invokes a different clang binary than itself, it will perform "
+  "a normal non-caching invocation of the compiler">, InGroup<CompileJobCache>;
+
 def remark_compile_job_cache_hit : Remark<
   "compile job cache hit for '%0' => '%1'">, InGroup<CompileJobCacheHit>;
 def remark_compile_job_cache_miss : Remark<

--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -707,6 +707,9 @@ llvm::StringRef getDriverMode(StringRef ProgName, ArrayRef<const char *> Args);
 /// Checks whether the value produced by getDriverMode is for CL mode.
 bool IsClangCL(StringRef DriverMode);
 
+/// Checks whether the value produced by getDriverMode is for 'cache' mode.
+bool isClangCache(StringRef DriverMode);
+
 } // end namespace driver
 } // end namespace clang
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6229,3 +6229,7 @@ llvm::StringRef clang::driver::getDriverMode(StringRef ProgName,
 }
 
 bool driver::IsClangCL(StringRef DriverMode) { return DriverMode.equals("cl"); }
+
+bool driver::isClangCache(StringRef DriverMode) {
+  return DriverMode == "cache";
+}

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -154,6 +154,7 @@ static const DriverSuffix *FindDriverSuffix(StringRef ProgName, size_t &Pos) {
       {"++", "--driver-mode=g++"},
       {"flang", "--driver-mode=flang"},
       {"clang-dxc", "--driver-mode=dxc"},
+      {"clang-cache", "--driver-mode=cache"},
   };
 
   for (size_t i = 0; i < llvm::array_lengthof(DriverSuffixes); ++i) {

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -1,0 +1,26 @@
+// REQUIRES: shell
+
+// RUN: rm -rf %t && mkdir %t
+// RUN: echo "#!/bin/sh"              > %t/clang
+// RUN: echo "echo 'run some clang'" >> %t/clang
+// RUN: chmod +x %t/clang
+// RUN: ln -s %clang %t/clang-symlink-outside-bindir
+
+// 'clang-cache' launcher invokes itself, enables caching.
+// RUN: env CLANG_CACHE_CAS_PATH=%t/cas clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG -DPREFIX=%t
+// RUN: env CLANG_CACHE_CAS_PATH=%t/cas clang-cache %clang++ -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANGPP -DPREFIX=%t
+// RUN: env CLANG_CACHE_CAS_PATH=%t/cas clang-cache %t/clang-symlink-outside-bindir -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG -DPREFIX=%t
+
+// 'clang-cache' launcher invokes a different clang, does normal non-caching launch.
+// RUN: env CLANG_CACHE_CAS_PATH=%t/cas clang-cache %t/clang -c %s -o %t.o 2>&1 | FileCheck %s -check-prefix=OTHERCLANG
+
+// CLANG: "-cc1depscan" "-fdepscan=inline"
+// CLANG: "-fcas-path" "[[PREFIX]]/cas" "-fcas-token-cache" "-greproducible"
+// CLANG: "-x" "c"
+
+// CLANGPP: "-cc1depscan" "-fdepscan=inline"
+// CLANGPP: "-fcas-path" "[[PREFIX]]/cas" "-fcas-token-cache" "-greproducible"
+// CLANGPP: "-x" "c++"
+
+// OTHERCLANG: warning: clang-cache invokes a different clang binary than itself, it will perform a normal non-caching invocation of the compiler
+// OTHERCLANG-NEXT: run some clang

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -63,7 +63,7 @@ config.substitutions.append(('%PATH%', config.environment['PATH']))
 tool_dirs = [config.clang_tools_dir, config.llvm_tools_dir]
 
 tools = [
-    'apinotes-test', 'c-index-test', 'clang-diff', 'clang-format', 'clang-repl',
+    'apinotes-test', 'c-index-test', 'clang-cache', 'clang-diff', 'clang-format', 'clang-repl',
     'clang-tblgen', 'clang-scan-deps', 'opt', 'llvm-ifs', 'yaml2obj', 'clang-linker-wrapper',
     ToolSubst('%clang_extdef_map', command=FindTool(
         'clang-extdef-mapping'), unresolved='ignore'),

--- a/clang/tools/driver/CMakeLists.txt
+++ b/clang/tools/driver/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 
 add_clang_tool(clang
   driver.cpp
+  CacheLauncherMode.cpp
   cc1_main.cpp
   cc1as_main.cpp
   cc1gen_reproducer_main.cpp
@@ -62,7 +63,7 @@ endif()
 add_dependencies(clang clang-resource-headers)
 
 if(NOT CLANG_LINKS_TO_CREATE)
-  set(CLANG_LINKS_TO_CREATE clang++ clang-cl clang-cpp)
+  set(CLANG_LINKS_TO_CREATE clang++ clang-cl clang-cpp clang-cache)
 endif()
 
 foreach(link ${CLANG_LINKS_TO_CREATE})

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -1,0 +1,70 @@
+//===-- CacheLauncherMode.cpp - clang-cache driver mode -------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CacheLauncherMode.h"
+#include "clang/Basic/DiagnosticCAS.h"
+#include "clang/Frontend/TextDiagnosticPrinter.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/Program.h"
+
+using namespace clang;
+
+static bool isSameProgram(const char *clangCachePath,
+                          const char *compilerPath) {
+  // Fast path check, see if they have the same parent path.
+  if (llvm::sys::path::parent_path(clangCachePath) ==
+      llvm::sys::path::parent_path(compilerPath))
+    return true;
+  // Check the file status IDs;
+  llvm::sys::fs::file_status CacheStat, CompilerStat;
+  if (llvm::sys::fs::status(clangCachePath, CacheStat))
+    return false;
+  if (llvm::sys::fs::status(compilerPath, CompilerStat))
+    return false;
+  return CacheStat.getUniqueID() == CompilerStat.getUniqueID();
+}
+
+Optional<int>
+clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
+                                  llvm::StringSaver &Saver) {
+  assert(Args.size() >= 2);
+  const char *clangCachePath = Args.front();
+  // Drop initial '/path/to/clang-cache' program name.
+  Args.erase(Args.begin());
+  const char *compilerPath = Args.front();
+
+  if (isSameProgram(clangCachePath, compilerPath)) {
+    if (const char *CASPath = ::getenv("CLANG_CACHE_CAS_PATH")) {
+      Args.append({"-Xclang", "-fcas-path", "-Xclang", CASPath});
+    }
+    // FIXME: Add capability to connect to a depscan daemon via 'clang-cache'
+    // launcher.
+    Args.append(
+        {"-fdepscan=inline", "-greproducible", "-Xclang", "-fcas-token-cache"});
+    return None;
+  }
+
+  // FIXME: If it's invoking a different clang binary determine whether that
+  // clang supports the caching options, don't immediately give up on caching.
+
+  // Not invoking same clang binary, do a normal invocation without changing
+  // arguments, but warn because this may be unexpected to the user.
+  auto DiagsConsumer = std::make_unique<TextDiagnosticPrinter>(
+      llvm::errs(), new DiagnosticOptions(), false);
+  DiagnosticsEngine Diags(new DiagnosticIDs(), new DiagnosticOptions());
+  Diags.setClient(DiagsConsumer.get(), /*ShouldOwnClient=*/false);
+  Diags.Report(diag::warn_clang_cache_disabled_caching);
+
+  SmallVector<StringRef, 128> RefArgs;
+  RefArgs.reserve(Args.size());
+  for (const char *Arg : ArrayRef<const char *>(Args).drop_front()) {
+    RefArgs.push_back(Arg);
+  }
+  return llvm::sys::ExecuteAndWait(compilerPath, RefArgs);
+}

--- a/clang/tools/driver/CacheLauncherMode.h
+++ b/clang/tools/driver/CacheLauncherMode.h
@@ -1,0 +1,33 @@
+//===-- CacheLauncherMode.h - clang-cache driver mode -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_DRIVER_CACHELAUNCHERMODE_H
+#define LLVM_CLANG_TOOLS_DRIVER_CACHELAUNCHERMODE_H
+
+#include "clang/Basic/LLVM.h"
+
+namespace llvm {
+class StringSaver;
+}
+
+namespace clang {
+
+/// Invoked at the beginning of a "/path/to/clang-cache /path/to/clang -c ..."
+/// invocation. If "/path/to/clang" points to the same clang binary as
+/// "/path/to/clang-cache" then the arguments will be adjusted for compilation
+/// caching, and the function will return, otherwise the "/path/to/clang -c ..."
+/// invocation will be invoked as a separate process and its exit value will be
+/// returned.
+///
+/// \returns \p None if the arguments got adjusted, or the exit code to return.
+Optional<int> handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
+                                         llvm::StringSaver &Saver);
+
+} // namespace clang
+
+#endif


### PR DESCRIPTION
`clang-cache` provides capability to use compilation caching without needing to modify any of the compiler arguments.
It is intended to be used as the compiler launcher along with using the same clang binary for compilation.

Environment variable `CLANG_CACHE_CAS_PATH` can be used to control the on-disk CAS path, otherwise the default location is used.