### PR TITLE
[lldb] Add setting for max depth of value object printing

### DIFF
--- a/lldb/include/lldb/DataFormatters/DumpValueObjectOptions.h
+++ b/lldb/include/lldb/DataFormatters/DumpValueObjectOptions.h
@@ -69,7 +69,7 @@ public:
   DumpValueObjectOptions &
   SetMaximumPointerDepth(PointerDepth depth = {PointerDepth::Mode::Never, 0});
 
-  DumpValueObjectOptions &SetMaximumDepth(uint32_t depth = 0);
+  DumpValueObjectOptions &SetMaximumDepth(uint32_t depth, bool is_default);
 
   DumpValueObjectOptions &SetDeclPrintingHelper(DeclPrintingHelper helper);
 
@@ -128,6 +128,7 @@ public:
   SetPointerAsArray(const PointerAsArraySettings &ptr_array);
 
   uint32_t m_max_depth = UINT32_MAX;
+  bool m_max_depth_is_default = true;
   lldb::DynamicValueType m_use_dynamic = lldb::eNoDynamicValues;
   uint32_t m_omit_summary_depth = 0;
   lldb::Format m_format = lldb::eFormatDefault;

--- a/lldb/include/lldb/DataFormatters/ValueObjectPrinter.h
+++ b/lldb/include/lldb/DataFormatters/ValueObjectPrinter.h
@@ -117,6 +117,8 @@ protected:
 
   bool PrintChildrenOneLiner(bool hide_names);
 
+  bool HasReachedMaximumDepth();
+
 private:
   ValueObject *m_orig_valobj;
   ValueObject *m_valobj;

--- a/lldb/include/lldb/Interpreter/CommandInterpreter.h
+++ b/lldb/include/lldb/Interpreter/CommandInterpreter.h
@@ -223,11 +223,11 @@ public:
     eBroadcastBitAsynchronousErrorData = (1 << 4)
   };
 
-  enum ChildrenTruncatedWarningStatus // tristate boolean to manage children
-                                      // truncation warning
-  { eNoTruncation = 0,                // never truncated
-    eUnwarnedTruncation = 1,          // truncated but did not notify
-    eWarnedTruncation = 2             // truncated and notified
+  /// Tristate boolean to manage children omission warnings.
+  enum ChildrenOmissionWarningStatus {
+    eNoOmission = 0,       ///< No children were omitted.
+    eUnwarnedOmission = 1, ///< Children omitted, and not yet notified.
+    eWarnedOmission = 2    ///< Children omitted and notified.
   };
 
   enum CommandTypes {
@@ -495,21 +495,33 @@ public:
   }
 
   void ChildrenTruncated() {
-    if (m_truncation_warning == eNoTruncation)
-      m_truncation_warning = eUnwarnedTruncation;
+    if (m_truncation_warning == eNoOmission)
+      m_truncation_warning = eUnwarnedOmission;
   }
 
-  bool TruncationWarningNecessary() {
-    return (m_truncation_warning == eUnwarnedTruncation);
+  void SetReachedMaximumDepth() {
+    if (m_max_depth_warning == eNoOmission)
+      m_max_depth_warning = eUnwarnedOmission;
   }
 
-  void TruncationWarningGiven() { m_truncation_warning = eWarnedTruncation; }
+  void PrintWarningsIfNecessary(Stream &s, const std::string &cmd_name) {
+    if (m_truncation_warning == eUnwarnedOmission) {
+      s.Printf("*** Some of the displayed variables have more members than the "
+               "debugger will show by default. To show all of them, you can "
+               "either use the --show-all-children option to %s or raise the "
+               "limit by changing the target.max-children-count setting.\n",
+               cmd_name.c_str());
+      m_truncation_warning = eWarnedOmission;
+    }
 
-  const char *TruncationWarningText() {
-    return "*** Some of your variables have more members than the debugger "
-           "will show by default. To show all of them, you can either use the "
-           "--show-all-children option to %s or raise the limit by changing "
-           "the target.max-children-count setting.\n";
+    if (m_max_depth_warning == eUnwarnedOmission) {
+      s.Printf("*** Some of the displayed variables have a greater depth of "
+               "members than the debugger will show by default. To increase "
+               "the limit, use the --depth option to %s, or raise the limit by "
+               "changing the target.max-children-depth setting.\n",
+               cmd_name.c_str());
+      m_max_depth_warning = eWarnedOmission;
+    }
   }
 
   CommandHistory &GetCommandHistory() { return m_command_history; }
@@ -700,9 +712,12 @@ private:
   lldb::IOHandlerSP m_command_io_handler_sp;
   char m_comment_char;
   bool m_batch_command_mode;
-  ChildrenTruncatedWarningStatus m_truncation_warning; // Whether we truncated
-                                                       // children and whether
-                                                       // the user has been told
+  /// Whether we truncated a value's list of children and whether the user has
+  /// been told.
+  ChildrenOmissionWarningStatus m_truncation_warning;
+  /// Whether we reached the maximum child nesting depth and whether the user
+  /// has been told.
+  ChildrenOmissionWarningStatus m_max_depth_warning;
 
   // FIXME: Stop using this to control adding to the history and then replace
   // this with m_command_source_dirs.size().

--- a/lldb/include/lldb/Interpreter/OptionGroupValueObjectDisplay.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupValueObjectDisplay.h
@@ -43,7 +43,8 @@ public:
       lldb::TypeSummaryImplSP summary_sp = lldb::TypeSummaryImplSP());
 
   bool show_types : 1, show_location : 1, flat_output : 1, use_objc : 1,
-      use_synth : 1, be_raw : 1, ignore_cap : 1, run_validator : 1;
+      use_synth : 1, be_raw : 1, ignore_cap : 1, run_validator : 1,
+      max_depth_is_default : 1;
 
   uint32_t no_summary_depth;
   uint32_t max_depth;

--- a/lldb/include/lldb/Interpreter/OptionValueProperties.h
+++ b/lldb/include/lldb/Interpreter/OptionValueProperties.h
@@ -152,6 +152,10 @@ public:
   GetPropertyAtIndexAsOptionValueSInt64(const ExecutionContext *exe_ctx,
                                         uint32_t idx) const;
 
+  OptionValueUInt64 *
+  GetPropertyAtIndexAsOptionValueUInt64(const ExecutionContext *exe_ctx,
+                                        uint32_t idx) const;
+
   int64_t GetPropertyAtIndexAsSInt64(const ExecutionContext *exe_ctx,
                                      uint32_t idx, int64_t fail_value) const;
 

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -203,6 +203,15 @@ public:
 
   uint32_t GetMaximumNumberOfChildrenToDisplay() const;
 
+  /// Get the max depth value, augmented with a bool to indicate whether the
+  /// depth is the default.
+  ///
+  /// When the user has customized the max depth, the bool will be false.
+  ///
+  /// \returns the max depth, and true if the max depth is the system default,
+  /// otherwise false.
+  std::pair<uint32_t, bool> GetMaximumDepthOfChildrenToDisplay() const;
+
   uint32_t GetMaximumSizeOfStringSummary() const;
 
   uint32_t GetMaximumMemReadSize() const;

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -700,11 +700,8 @@ protected:
       }
     }
 
-    if (m_interpreter.TruncationWarningNecessary()) {
-      result.GetOutputStream().Printf(m_interpreter.TruncationWarningText(),
-                                      m_cmd_name.c_str());
-      m_interpreter.TruncationWarningGiven();
-    }
+    m_interpreter.PrintWarningsIfNecessary(result.GetOutputStream(),
+                                           m_cmd_name);
 
     // Increment statistics.
     bool res = result.Succeeded();

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -975,11 +975,8 @@ protected:
       }
     }
 
-    if (m_interpreter.TruncationWarningNecessary()) {
-      result.GetOutputStream().Printf(m_interpreter.TruncationWarningText(),
-                                      m_cmd_name.c_str());
-      m_interpreter.TruncationWarningGiven();
-    }
+    m_interpreter.PrintWarningsIfNecessary(result.GetOutputStream(),
+                                           m_cmd_name);
 
     return result.Succeeded();
   }

--- a/lldb/source/DataFormatters/DumpValueObjectOptions.cpp
+++ b/lldb/source/DataFormatters/DumpValueObjectOptions.cpp
@@ -38,8 +38,9 @@ DumpValueObjectOptions::SetMaximumPointerDepth(PointerDepth depth) {
 }
 
 DumpValueObjectOptions &
-DumpValueObjectOptions::SetMaximumDepth(uint32_t depth) {
+DumpValueObjectOptions::SetMaximumDepth(uint32_t depth, bool is_default) {
   m_max_depth = depth;
+  m_max_depth_is_default = is_default;
   return *this;
 }
 

--- a/lldb/source/DataFormatters/ValueObjectPrinter.cpp
+++ b/lldb/source/DataFormatters/ValueObjectPrinter.cpp
@@ -521,7 +521,7 @@ bool ValueObjectPrinter::ShouldPrintChildren(
   if (m_options.m_use_objc)
     return false;
 
-  if (is_failed_description || m_curr_depth < m_options.m_max_depth) {
+  if (is_failed_description || !HasReachedMaximumDepth()) {
     // We will show children for all concrete types. We won't show pointer
     // contents unless a pointer depth has been specified. We won't reference
     // contents unless the reference is the root object (depth of zero).
@@ -808,9 +808,22 @@ void ValueObjectPrinter::PrintChildrenIfNeeded(bool value_printed,
       m_stream->EOL();
     } else
       PrintChildren(value_printed, summary_printed, curr_ptr_depth);
-  } else if (m_curr_depth >= m_options.m_max_depth && IsAggregate() &&
+  } else if (HasReachedMaximumDepth() && IsAggregate() &&
              ShouldPrintValueObject()) {
     m_stream->PutCString("{...}\n");
+    // The maximum child depth has been reached. If `m_max_depth` is the default
+    // (i.e. the user has _not_ customized it), then lldb presents a warning to
+    // the user. The warning tells the user that the limit has been reached, but
+    // more importantly tells them how to expand the limit if desired.
+    if (m_options.m_max_depth_is_default)
+      m_valobj->GetTargetSP()
+          ->GetDebugger()
+          .GetCommandInterpreter()
+          .SetReachedMaximumDepth();
   } else
     m_stream->EOL();
+}
+
+bool ValueObjectPrinter::HasReachedMaximumDepth() {
+  return m_curr_depth >= m_options.m_max_depth;
 }

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -125,7 +125,8 @@ CommandInterpreter::CommandInterpreter(Debugger &debugger,
       m_debugger(debugger), m_synchronous_execution(true),
       m_skip_lldbinit_files(false), m_skip_app_init_files(false),
       m_comment_char('#'), m_batch_command_mode(false),
-      m_truncation_warning(eNoTruncation), m_command_source_depth(0) {
+      m_truncation_warning(eNoOmission), m_max_depth_warning(eNoOmission),
+      m_command_source_depth(0) {
   SetEventName(eBroadcastBitThreadShouldExit, "thread-should-exit");
   SetEventName(eBroadcastBitResetPrompt, "reset-prompt");
   SetEventName(eBroadcastBitQuitCommandReceived, "quit");

--- a/lldb/source/Interpreter/OptionValueProperties.cpp
+++ b/lldb/source/Interpreter/OptionValueProperties.cpp
@@ -411,6 +411,17 @@ OptionValueSInt64 *OptionValueProperties::GetPropertyAtIndexAsOptionValueSInt64(
   return nullptr;
 }
 
+OptionValueUInt64 *OptionValueProperties::GetPropertyAtIndexAsOptionValueUInt64(
+    const ExecutionContext *exe_ctx, uint32_t idx) const {
+  const Property *property = GetPropertyAtIndex(exe_ctx, false, idx);
+  if (property) {
+    OptionValue *value = property->GetValue().get();
+    if (value)
+      return value->GetAsUInt64();
+  }
+  return nullptr;
+}
+
 int64_t OptionValueProperties::GetPropertyAtIndexAsSInt64(
     const ExecutionContext *exe_ctx, uint32_t idx, int64_t fail_value) const {
   const Property *property = GetPropertyAtIndex(exe_ctx, false, idx);

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4584,6 +4584,15 @@ uint32_t TargetProperties::GetMaximumNumberOfChildrenToDisplay() const {
       nullptr, idx, g_target_properties[idx].default_uint_value);
 }
 
+std::pair<uint32_t, bool>
+TargetProperties::GetMaximumDepthOfChildrenToDisplay() const {
+  const uint32_t idx = ePropertyMaxChildrenDepth;
+  auto *option_value =
+      m_collection_sp->GetPropertyAtIndexAsOptionValueUInt64(nullptr, idx);
+  bool is_default = !option_value->OptionWasSet();
+  return {option_value->GetCurrentValue(), is_default};
+}
+
 uint32_t TargetProperties::GetMaximumSizeOfStringSummary() const {
   const uint32_t idx = ePropertyMaxSummaryLength;
   return m_collection_sp->GetPropertyAtIndexAsSInt64(

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -88,7 +88,7 @@ let Definition = "target" in {
     DefaultUnsignedValue<256>,
     Desc<"Maximum number of children to expand in any level of depth.">;
   def MaxChildrenDepth: Property<"max-children-depth", "UInt64">,
-    DefaultUnsignedValue<0xFFFFFFFF>,
+    DefaultUnsignedValue<6>,
     Desc<"Maximum depth to expand children.">;
   def MaxSummaryLength: Property<"max-string-summary-length", "SInt64">,
     DefaultUnsignedValue<1024>,

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -87,6 +87,9 @@ let Definition = "target" in {
   def MaxChildrenCount: Property<"max-children-count", "SInt64">,
     DefaultUnsignedValue<256>,
     Desc<"Maximum number of children to expand in any level of depth.">;
+  def MaxChildrenDepth: Property<"max-children-depth", "UInt64">,
+    DefaultUnsignedValue<0xFFFFFFFF>,
+    Desc<"Maximum depth to expand children.">;
   def MaxSummaryLength: Property<"max-string-summary-length", "SInt64">,
     DefaultUnsignedValue<1024>,
     Desc<"Maximum number of characters to show when using %s in summary strings.">;

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-advanced/TestDataFormatterAdv.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-advanced/TestDataFormatterAdv.py
@@ -42,6 +42,9 @@ class AdvDataFormatterTestCase(TestBase):
             self.runCmd(
                 "settings set target.max-children-count 256",
                 check=False)
+            self.runCmd(
+                "settings clear target.max-children-depth",
+                check=False)
 
         # Execute the cleanup function during test case tear down.
         self.addTearDownHook(cleanup)
@@ -346,3 +349,30 @@ class AdvDataFormatterTestCase(TestBase):
             'frame variable a_long_guy --show-all-children',
             matching=False,
             substrs=['...'])
+
+        # The below tests need the hex formatting of int removed.
+        self.runCmd('type format delete int')
+
+        # First, check the following:
+        #   1. Verify the default max-children-depth (6) is applied
+        #   2. Ensure the one-time warning is printed
+        warning = '*** Some of the displayed variables have a greater depth'
+        self.expect(
+            'frame variable quite_nested',
+            matching=True,
+            substrs=['six ={...}', warning])
+        self.expect(
+            'frame variable quite_nested',
+            matching=False,
+            substrs=['leaf = 41', warning])
+
+        # Check that both ways of overriding max-children-depth work.
+        self.expect(
+            'frame variable --depth 8 quite_nested',
+            matching=True,
+            substrs=['leaf = 41'])
+        self.runCmd("settings set target.max-children-depth 8")
+        self.expect(
+            'frame variable quite_nested',
+            matching=True,
+            substrs=['leaf = 41'])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-advanced/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-advanced/main.cpp
@@ -124,6 +124,31 @@ struct VeryLong
     int z_2;
 };
 
+struct QuiteNested {
+  struct One {
+    struct Two {
+      struct Three {
+        struct Four {
+          struct Five {
+            struct Six {
+              struct Seven {
+                int leaf = 41;
+              };
+              Seven seven;
+            };
+            Six six;
+          };
+          Five five;
+        };
+        Four four;
+      };
+      Three three;
+    };
+    Two two;
+  };
+  One one;
+};
+
 int main (int argc, const char * argv[])
 {
     
@@ -164,5 +189,7 @@ int main (int argc, const char * argv[])
     
     VeryLong a_long_guy;
     
+    QuiteNested quite_nested;
+
     return 0; // Set break point at this line.
 }


### PR DESCRIPTION
This PR contains:
* cherry pick of [D123954](https://reviews.llvm.org/D123954) (see commit 2f9fc576be206bd5c4fddfec5f89fceb3554a8d6), which is an NFC change to add `target.max-children-depth`
* a followup commit to <ins>change the maximum nesting depth default value to 6</ins>.

This change is to avoid the case where lldb traverses extremely large aggregate Swift types, in particular, class types. Unlike ObjC, Swift objects are references not pointers. lldb's object printing does not dereference pointers, however it does traverse references (treating them like other value types). Limiting the depth prevents slow performance when an object tree (graph) transitively prints unwanted/excessive data.

rdar://87466495