### PR TITLE
[lldb] Add a function to check if lldb is running in an interactive session

### DIFF
--- a/lldb/include/lldb/Host/Host.h
+++ b/lldb/include/lldb/Host/Host.h
@@ -259,6 +259,13 @@ public:
   static bool OpenFileInExternalEditor(const FileSpec &file_spec,
                                        uint32_t line_no);
 
+  /// Check if we're running in an interactive graphical session.
+  ///
+  /// \return
+  ///     True if we're running in an interactive graphical session. False if
+  ///     we're not or don't know.
+  static bool IsInteractiveGraphicSession();
+
   static Environment GetEnvironment();
 
   static std::unique_ptr<Connection>

--- a/lldb/source/Host/common/Host.cpp
+++ b/lldb/source/Host/common/Host.cpp
@@ -646,6 +646,7 @@ bool Host::OpenFileInExternalEditor(const FileSpec &file_spec,
   return false;
 }
 
+bool Host::IsInteractiveGraphicSession() { return false; }
 #endif
 
 std::unique_ptr<Connection> Host::CreateDefaultConnection(llvm::StringRef url) {

--- a/lldb/source/Host/macosx/objcxx/Host.mm
+++ b/lldb/source/Host/macosx/objcxx/Host.mm
@@ -32,6 +32,8 @@
 #define LauncherXPCServiceErrorTypeKey "errorType"
 #define LauncherXPCServiceCodeTypeKey "errorCode"
 
+#include <bsm/audit.h>
+#include <bsm/audit_session.h>
 #endif
 
 #include "llvm/Support/Host.h"
@@ -405,6 +407,16 @@ bool Host::OpenFileInExternalEditor(const FileSpec &file_spec,
 
   return true;
 #endif // TARGET_OS_OSX
+}
+
+bool Host::IsInteractiveGraphicSession() {
+#if !TARGET_OS_OSX
+  return false;
+#else
+  auditinfo_addr_t info;
+  getaudit_addr(&info, sizeof(info));
+  return info.ai_flags & AU_SESSION_FLAG_HAS_GRAPHIC_ACCESS;
+#endif
 }
 
 Environment Host::GetEnvironment() { return Environment(*_NSGetEnviron()); }


### PR DESCRIPTION
This patch adds a function to check if lldb is running in an interactive
debug session. Currently this API only works on macOS. It's expected to
be used in combination with Host::OpenFileInExternalEditor.

Differential revision: https://reviews.llvm.org/D124872

(cherry picked from commit b945b62cf35e1b45ffb9233958756743b2b5fd46)
