### PR TITLE
[clang-cache] Enhancements for `clang-cache` invocations

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -27,6 +27,12 @@ def err_cas_depscan_failed: Error<
 def warn_clang_cache_disabled_caching: Warning<
   "clang-cache invokes a different clang binary than itself, it will perform "
   "a normal non-caching invocation of the compiler">, InGroup<CompileJobCache>;
+def err_clang_cache_failed_execution: Error<
+  "clang-cache failed to execute compiler: %0">;
+def err_clang_cache_cannot_find_binary: Error<
+  "clang-cache cannot find compiler binary %0">;
+def err_clang_cache_missing_compiler_command: Error<
+  "missing compiler command for clang-cache">;
 
 def remark_compile_job_cache_hit : Remark<
   "compile job cache hit for '%0' => '%1'">, InGroup<CompileJobCacheHit>;

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -2,7 +2,7 @@
 
 // RUN: rm -rf %t && mkdir %t
 // RUN: echo "#!/bin/sh"              > %t/clang
-// RUN: echo "echo 'run some clang'" >> %t/clang
+// RUN: echo "echo run some compiler with opts \$*" >> %t/clang
 // RUN: chmod +x %t/clang
 // RUN: ln -s %clang %t/clang-symlink-outside-bindir
 
@@ -10,9 +10,7 @@
 // RUN: env CLANG_CACHE_CAS_PATH=%t/cas clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG -DPREFIX=%t
 // RUN: env CLANG_CACHE_CAS_PATH=%t/cas clang-cache %clang++ -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANGPP -DPREFIX=%t
 // RUN: env CLANG_CACHE_CAS_PATH=%t/cas clang-cache %t/clang-symlink-outside-bindir -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG -DPREFIX=%t
-
-// 'clang-cache' launcher invokes a different clang, does normal non-caching launch.
-// RUN: env CLANG_CACHE_CAS_PATH=%t/cas clang-cache %t/clang -c %s -o %t.o 2>&1 | FileCheck %s -check-prefix=OTHERCLANG
+// RUN: env CLANG_CACHE_CAS_PATH=%t/cas PATH="%t:$PATH" clang-cache clang-symlink-outside-bindir -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG -DPREFIX=%t
 
 // CLANG: "-cc1depscan" "-fdepscan=inline"
 // CLANG: "-fcas-path" "[[PREFIX]]/cas" "-fcas-token-cache" "-greproducible"
@@ -22,5 +20,13 @@
 // CLANGPP: "-fcas-path" "[[PREFIX]]/cas" "-fcas-token-cache" "-greproducible"
 // CLANGPP: "-x" "c++"
 
+// 'clang-cache' launcher invokes a different clang, does normal non-caching launch.
+// RUN: env CLANG_CACHE_CAS_PATH=%t/cas clang-cache %t/clang -c %s -o %t.o 2>&1 | FileCheck %s -check-prefix=OTHERCLANG -DSRC=%s -DPREFIX=%t
 // OTHERCLANG: warning: clang-cache invokes a different clang binary than itself, it will perform a normal non-caching invocation of the compiler
-// OTHERCLANG-NEXT: run some clang
+// OTHERCLANG-NEXT: run some compiler with opts -c [[SRC]] -o [[PREFIX]].o
+
+// RUN: not clang-cache %t/nonexistent -c %s -o %t.o 2>&1 | FileCheck %s -check-prefix=NONEXISTENT
+// NONEXISTENT: error: clang-cache failed to execute compiler
+
+// RUN: not clang-cache 2>&1 | FileCheck %s -check-prefix=NOCOMMAND
+// NOCOMMAND: error: missing compiler command for clang-cache


### PR DESCRIPTION
* Search for the compiler binary if it's given just by name
* Fix off-by-one argument passing for the non-caching command invocation
* Emit additional error messages, e.g. when non-caching command execution fails