### PR TITLE
CAS: Remove blobs from CASDB (=> "leaf" nodes)

### DIFF
--- a/llvm/lib/CAS/BuiltinCAS.h
+++ b/llvm/lib/CAS/BuiltinCAS.h
@@ -174,34 +174,28 @@ public:
                                              ArrayRef<ObjectRef> Refs,
                                              ArrayRef<char> Data) = 0;
 
-  Expected<BlobHandle>
-  storeBlobFromOpenFileImpl(sys::fs::file_t FD,
+  Expected<NodeHandle>
+  storeNodeFromOpenFileImpl(sys::fs::file_t FD,
                             Optional<sys::fs::file_status> Status) override;
-  virtual Expected<BlobHandle>
-  storeBlobFromNullTerminatedRegion(ArrayRef<uint8_t> ComputedHash,
+  virtual Expected<NodeHandle>
+  storeNodeFromNullTerminatedRegion(ArrayRef<uint8_t> ComputedHash,
                                     sys::fs::mapped_file_region Map) {
-    return storeBlobImpl(ComputedHash, makeArrayRef(Map.data(), Map.size()));
+    return storeNodeImpl(ComputedHash, None,
+                         makeArrayRef(Map.data(), Map.size()));
   }
-
-  Expected<BlobHandle> storeBlob(StringRef Data) final {
-    return storeBlob(makeArrayRef(Data.data(), Data.size()));
-  }
-  Expected<BlobHandle> storeBlob(ArrayRef<char> Data);
-  virtual Expected<BlobHandle> storeBlobImpl(ArrayRef<uint8_t> ComputedHash,
-                                             ArrayRef<char> Data) = 0;
 
   /// Both builtin CAS implementations provide lifetime for free, so this can
   /// be const, and readData() and getDataSize() can be implemented on top of
   /// it.
-  virtual ArrayRef<char> getDataConst(AnyDataHandle Data) const = 0;
+  virtual ArrayRef<char> getDataConst(NodeHandle Node) const = 0;
 
-  ArrayRef<char> getDataImpl(AnyDataHandle Data, bool NullTerminate) final {
-    return getDataConst(Data);
+  ArrayRef<char> getDataImpl(NodeHandle Node, bool NullTerminate) final {
+    return getDataConst(Node);
   }
-  uint64_t getDataSize(AnyDataHandle Data) const final {
-    return getDataConst(Data).size();
+  uint64_t getDataSize(NodeHandle Node) const final {
+    return getDataConst(Node).size();
   }
-  uint64_t readDataImpl(AnyDataHandle Data, raw_ostream &OS, uint64_t Offset,
+  uint64_t readDataImpl(NodeHandle Node, raw_ostream &OS, uint64_t Offset,
                         uint64_t MaxBytes) const final;
 
   Error createUnknownObjectError(CASID ID) const {

--- a/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
+++ b/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
@@ -336,14 +336,13 @@ Expected<FileSystemCache::DirectoryEntry *>
 CachingOnDiskFileSystemImpl::makeFile(DirectoryEntry &Parent,
                                       StringRef TreePath, int BorrowedFD,
                                       sys::fs::file_status Status) {
-  Expected<BlobProxy> ExpectedBlob =
-      DB.createBlobFromOpenFile(BorrowedFD, Status);
-  if (!ExpectedBlob)
-    return ExpectedBlob.takeError();
+  Expected<NodeHandle> Node = DB.storeNodeFromOpenFile(BorrowedFD, Status);
+  if (!Node)
+    return Node.takeError();
 
   // Do not trust Status.size() in case the file is volatile.
-  return &Cache->makeFile(Parent, TreePath, *ExpectedBlob,
-                          ExpectedBlob->getData().size(),
+  return &Cache->makeFile(Parent, TreePath, DB.getObjectID(*Node),
+                          DB.getDataSize(*Node),
                           Status.permissions() & sys::fs::perms::owner_exe);
 }
 

--- a/llvm/test/tools/llvm-cas/make-blob.test
+++ b/llvm/test/tools/llvm-cas/make-blob.test
@@ -19,7 +19,7 @@ RUN:   FileCheck %s -check-prefix CHECK-EMPTY -allow-empty
 RUN: llvm-cas --cas %t.cas --print-kind @%t/empty.casid |\
 RUN:   FileCheck %s -check-prefix CHECK-KIND
 CHECK-EMPTY-NOT: {{.}}
-CHECK-KIND: blob
+CHECK-KIND: node
 
 RUN: llvm-cas --cas %t.cas --cat-blob @%t/abc.casid |\
 RUN:   FileCheck %s -check-prefix CHECK-ABC

--- a/llvm/tools/llvm-cas-object-format/llvm-cas-object-format.cpp
+++ b/llvm/tools/llvm-cas-object-format/llvm-cas-object-format.cpp
@@ -418,16 +418,6 @@ void StatCollector::visitPOTItem(ExitOnError &ExitOnErr, const POTItem &Item) {
   };
 
   size_t NumParents = Nodes.lookup(ID).NumParents;
-  if (auto Blob = Object->dyn_cast<BlobHandle>()) {
-    auto &Info = Stats["builtin:blob"];
-    ++Info.Count;
-    Info.DataSize += CAS.getDataSize(Blob->getData());
-    Info.NumPaths += NumPaths;
-    Info.NumParents += NumParents;
-    Totals.NumPaths += NumPaths; // Count paths to leafs.
-    return;
-  }
-
   if (auto TreeH = Object->dyn_cast<TreeHandle>()) {
     auto &Info = Stats["builtin:tree"];
     ++Info.Count;
@@ -612,9 +602,6 @@ static void computeStats(CASDB &CAS, ArrayRef<CASID> TopLevels,
       Worklist.pop_back();
       continue;
     }
-
-    if (Object->is<BlobHandle>())
-      continue;
 
     if (auto Tree = Object->dyn_cast<TreeHandle>()) {
       ExitOnErr(CAS.forEachTreeEntry(*Tree, [&](const NamedTreeEntry &Entry) {

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -242,8 +242,6 @@ int catNodeData(CASDB &CAS, CASID ID) {
 }
 
 static StringRef getKindString(AnyObjectHandle Object) {
-  if (Object.is<BlobHandle>())
-    return "blob";
   if (Object.is<TreeHandle>())
     return "tree";
   assert(Object.is<NodeHandle>());
@@ -317,7 +315,7 @@ static GraphInfo traverseObjectGraph(CASDB &CAS, CASID TopLevel) {
     Worklist.back().second = true;
     CASID ID = Worklist.back().first;
     Optional<AnyObjectHandle> Object = ExitOnErr(CAS.loadObject(ID));
-    if (!Object || Object->is<BlobHandle>())
+    if (!Object)
       continue;
 
     if (auto Tree = Object->dyn_cast<TreeHandle>()) {

--- a/llvm/unittests/CAS/CASDBTest.cpp
+++ b/llvm/unittests/CAS/CASDBTest.cpp
@@ -351,7 +351,7 @@ multiline text multiline text multiline text multiline text multiline text)",
       ASSERT_TRUE(Object);
       Optional<NodeHandle> Node = Object->dyn_cast<NodeHandle>();
       ASSERT_TRUE(Node);
-      EXPECT_EQ(ContentStrings[I], CAS1->getDataString(Node->getData()));
+      EXPECT_EQ(ContentStrings[I], CAS1->getDataString(*Node));
     }
   }
 
@@ -380,7 +380,7 @@ multiline text multiline text multiline text multiline text multiline text)",
     ASSERT_TRUE(Object);
     Node = Object->dyn_cast<NodeHandle>();
     ASSERT_TRUE(Node);
-    EXPECT_EQ(Content, CAS2->getDataString(Node->getData()));
+    EXPECT_EQ(Content, CAS2->getDataString(*Node));
   }
 }
 

--- a/llvm/unittests/CAS/CASReferenceTest.cpp
+++ b/llvm/unittests/CAS/CASReferenceTest.cpp
@@ -29,32 +29,8 @@ using namespace llvm::cas::testing_helpers;
 
 namespace {
 
-TEST(CASReferenceTest, BlobHandle) {
-  static_assert(std::is_convertible<BlobHandle, AnyObjectHandle>(), "");
-  static_assert(!std::is_constructible<AnyDataHandle, BlobHandle>(), "");
-  static_assert(!std::is_constructible<TreeHandle, BlobHandle>(), "");
-  static_assert(!std::is_constructible<NodeHandle, BlobHandle>(), "");
-  static_assert(!std::is_constructible<ObjectRef, BlobHandle>(), "");
-  static_assert(!std::is_constructible<BlobHandle, ObjectRef>(), "");
-
-  BlobHandle Blob = HandleFactory::make<BlobHandle>();
-  AnyObjectHandle AnyObject = Blob;
-  ASSERT_TRUE(AnyObject.is<BlobHandle>());
-  ASSERT_EQ(Blob, AnyObject.get<BlobHandle>());
-  ASSERT_TRUE(AnyObject.is<BlobHandle>());
-
-  AnyDataHandle AnyData = Blob.getData();
-  ASSERT_EQ(Blob, AnyData.get<BlobHandle>());
-
-  ASSERT_TRUE(AnyObject.getData());
-  AnyData = *AnyObject.getData();
-  ASSERT_TRUE(AnyData.is<BlobHandle>());
-}
-
 TEST(CASReferenceTest, TreeHandle) {
   static_assert(std::is_convertible<TreeHandle, AnyObjectHandle>(), "");
-  static_assert(!std::is_constructible<AnyDataHandle, TreeHandle>(), "");
-  static_assert(!std::is_constructible<BlobHandle, TreeHandle>(), "");
   static_assert(!std::is_constructible<NodeHandle, TreeHandle>(), "");
   static_assert(!std::is_constructible<ObjectRef, TreeHandle>(), "");
   static_assert(!std::is_constructible<TreeHandle, ObjectRef>(), "");
@@ -68,8 +44,6 @@ TEST(CASReferenceTest, TreeHandle) {
 
 TEST(CASReferenceTest, NodeHandle) {
   static_assert(std::is_convertible<NodeHandle, AnyObjectHandle>(), "");
-  static_assert(!std::is_constructible<AnyDataHandle, NodeHandle>(), "");
-  static_assert(!std::is_constructible<BlobHandle, NodeHandle>(), "");
   static_assert(!std::is_constructible<TreeHandle, NodeHandle>(), "");
   static_assert(!std::is_constructible<ObjectRef, NodeHandle>(), "");
   static_assert(!std::is_constructible<NodeHandle, ObjectRef>(), "");
@@ -79,13 +53,6 @@ TEST(CASReferenceTest, NodeHandle) {
   ASSERT_TRUE(AnyObject.is<NodeHandle>());
   ASSERT_EQ(Node, AnyObject.get<NodeHandle>());
   ASSERT_TRUE(AnyObject.is<NodeHandle>());
-
-  AnyDataHandle AnyData = Node.getData();
-  ASSERT_EQ(Node, AnyData.get<NodeHandle>());
-
-  ASSERT_TRUE(AnyObject.getData());
-  AnyData = *AnyObject.getData();
-  ASSERT_TRUE(AnyData.is<NodeHandle>());
 }
 
 } // end namespace


### PR DESCRIPTION
Remove the "blob" object kind from CASDB.

- Remove most APIs.
- Add LeafNodeProxy, as a convenience for nodes that are expected to
  have no references. I'm not sure how useful this is long-term, but
  short-term there's also a `using BlobProxy = LeafNodeProxy` that's
  convenient to avoid disturbing existing code.
- OnDiskCAS differentiates between "leaf nodes" and other nodes when
  making standalone records, as an alternate TrieRecord::StorageKind.
  The "leaf" and "leaf+0" formats are more convenient for optimizing
  with `::clonefile()`.