### PR TITLE
CAS: Change FileSystemCache to store cas::ObjectRef instead of CASID

### DIFF
--- a/llvm/include/llvm/CAS/CASDB.h
+++ b/llvm/include/llvm/CAS/CASDB.h
@@ -182,6 +182,11 @@ public:
   virtual Expected<NodeHandle> storeNode(ArrayRef<ObjectRef> Refs,
                                          ArrayRef<char> Data) = 0;
 
+  Expected<NodeHandle> storeNodeFromString(ArrayRef<ObjectRef> Refs,
+                                           StringRef String) {
+    return storeNode(Refs, arrayRefFromStringRef<char>(String));
+  }
+
   /// Default implementation reads \p FD and calls \a storeNode(). Does not
   /// take ownership of \p FD; the caller is responsible for closing it.
   ///


### PR DESCRIPTION
Start relying less on CASID, storing cas::ObjectRef in FilesystemCache
instead. For now, avoid changing the APIs of CASFileSystem and
CachingOnDiskFileSystem, but in the future they should probably stop
exposing CASID and expose ObjectRef instead.

This commit makes it easier to do similar to TreeEntry in a future
commit.