### PR TITLE
CAS: Switch TreeEntry from CASID => ObjectRef

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -38,5 +38,8 @@ def remark_compile_job_cache_hit : Remark<
   "compile job cache hit for '%0' => '%1'">, InGroup<CompileJobCacheHit>;
 def remark_compile_job_cache_miss : Remark<
   "compile job cache miss for '%0'">, InGroup<CompileJobCacheMiss>;
+def remark_compile_job_cache_miss_result_not_found : Remark<
+  "compile job cache miss for '%0' (result not found: '%1')">,
+  InGroup<CompileJobCacheMiss>;
 
 } // let Component = "CAS" in

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
@@ -15,6 +15,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/CAS/CASID.h"
+#include "llvm/CAS/CASReference.h"
 #include "llvm/CAS/ThreadSafeFileSystem.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/ErrorOr.h"
@@ -96,7 +97,7 @@ private:
     llvm::ErrorOr<llvm::vfs::Status> Status;
   };
   Expected<StringRef> computeMinimized(
-      llvm::cas::CASID InputDataID, StringRef Identifier,
+      llvm::cas::ObjectRef InputDataID, StringRef Identifier,
       Optional<llvm::cas::CASID> &MinimizedDataID,
       std::unique_ptr<PreprocessorSkippedRangeMapping> &PPSkippedRangeMapping);
 
@@ -112,9 +113,9 @@ private:
   llvm::cas::CachingOnDiskFileSystem &getCachingFS();
 
   llvm::cas::CASDB &CAS;
-  Optional<llvm::cas::CASID> ClangFullVersionID;
-  Optional<llvm::cas::CASID> MinimizeID;
-  Optional<llvm::cas::CASID> EmptyBlobID;
+  Optional<llvm::cas::ObjectRef> ClangFullVersionID;
+  Optional<llvm::cas::ObjectRef> MinimizeID;
+  Optional<llvm::cas::ObjectRef> EmptyBlobID;
 
   /// The optional mapping structure which records information about the
   /// excluded conditional directive skip mappings that are used by the

--- a/clang/lib/Lex/PTHLexer.cpp
+++ b/clang/lib/Lex/PTHLexer.cpp
@@ -601,12 +601,17 @@ Expected<llvm::cas::CASID> PTHManager::computePTH(llvm::cas::CASID InputFile) {
   }
 
   llvm::cas::HierarchicalTreeBuilder Builder;
-  Builder.push(InputFile, llvm::cas::TreeEntry::Regular, "data");
-  Builder.push(*ClangVersion, llvm::cas::TreeEntry::Regular, "version");
-  Builder.push(*Operation, llvm::cas::TreeEntry::Regular, "operation");
-  Builder.push(*SerializedLangOpts, llvm::cas::TreeEntry::Regular, "lang-opts");
+  Builder.push(*CAS.getReference(InputFile), llvm::cas::TreeEntry::Regular,
+               "data");
+  Builder.push(*CAS.getReference(*ClangVersion), llvm::cas::TreeEntry::Regular,
+               "version");
+  Builder.push(*CAS.getReference(*Operation), llvm::cas::TreeEntry::Regular,
+               "operation");
+  Builder.push(*CAS.getReference(*SerializedLangOpts),
+               llvm::cas::TreeEntry::Regular, "lang-opts");
 
-  llvm::cas::CASID CacheKey = llvm::cantFail(Builder.create(CAS)).getID();
+  llvm::cas::CASID CacheKey =
+      CAS.getObjectID(llvm::cantFail(Builder.create(CAS)));
   if (Optional<llvm::cas::CASID> CachedPTH =
           expectedToOptional(CAS.getCachedResult(CacheKey)))
     return *CachedPTH;

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -254,7 +254,7 @@ private:
   /// Replay a cache hit.
   ///
   /// Return status if should exit immediately, otherwise None.
-  Optional<int> replayCachedResult(llvm::cas::CASID ResultID,
+  Optional<int> replayCachedResult(llvm::cas::ObjectRef ResultID,
                                    bool JustComputedResult);
 
   bool CacheCompileJob = false;
@@ -346,16 +346,22 @@ Optional<int> CompileJobCache::tryReplayCachedResult(CompilerInstance &Clang) {
 
   Expected<llvm::cas::CASID> Result = CAS->getCachedResult(*ResultCacheKey);
   if (Result) {
-    Clang.getDiagnostics().Report(diag::remark_compile_job_cache_hit)
+    if (Optional<llvm::cas::ObjectRef> ResultRef = CAS->getReference(*Result)) {
+      Clang.getDiagnostics().Report(diag::remark_compile_job_cache_hit)
+          << ResultCacheKey->toString() << Result->toString();
+      Optional<int> Status =
+          replayCachedResult(*ResultRef, /*JustComputedResult=*/false);
+      assert(Status && "Expected a status for a cache hit");
+      return *Status;
+    }
+    Clang.getDiagnostics().Report(
+        diag::remark_compile_job_cache_miss_result_not_found)
         << ResultCacheKey->toString() << Result->toString();
-    Optional<int> Status =
-        replayCachedResult(std::move(*Result), /*JustComputedResult=*/false);
-    assert(Status && "Expected a status for a cache hit");
-    return *Status;
+  } else {
+    llvm::consumeError(Result.takeError());
+    Clang.getDiagnostics().Report(diag::remark_compile_job_cache_miss)
+        << ResultCacheKey->toString();
   }
-  Clang.getDiagnostics().Report(diag::remark_compile_job_cache_miss)
-      << ResultCacheKey->toString();
-  llvm::consumeError(Result.takeError());
 
   // Create an on-disk backend for streaming the results live if we run the
   // computation. If we're writing the output as a CASID, skip it here, since
@@ -410,7 +416,7 @@ void CompileJobCache::finishComputedResult(CompilerInstance &Clang,
     return;
 
   // FIXME: Stop calling report_fatal_error().
-  Expected<llvm::cas::CASID> Outputs = CASOutputs->createNode();
+  Expected<llvm::cas::NodeProxy> Outputs = CASOutputs->createNode();
   if (!Outputs)
     llvm::report_fatal_error(Outputs.takeError());
 
@@ -425,37 +431,38 @@ void CompileJobCache::finishComputedResult(CompilerInstance &Clang,
   //
   // FIXME: Stop calling report_fatal_error().
   llvm::cas::HierarchicalTreeBuilder Builder;
-  Builder.push(*Outputs, llvm::cas::TreeEntry::Regular, "outputs");
-  Builder.push(*Errs, llvm::cas::TreeEntry::Regular, "stderr");
-  Expected<llvm::cas::CASID> Result = Builder.create(*CAS);
+  Builder.push(Outputs->getRef(), llvm::cas::TreeEntry::Regular, "outputs");
+  Builder.push(Errs->getRef(), llvm::cas::TreeEntry::Regular, "stderr");
+  Expected<llvm::cas::TreeHandle> Result = Builder.create(*CAS);
   if (!Result)
     llvm::report_fatal_error(Result.takeError());
-  if (llvm::Error E = CAS->putCachedResult(*ResultCacheKey, *Result))
+  if (llvm::Error E =
+          CAS->putCachedResult(*ResultCacheKey, CAS->getObjectID(*Result)))
     llvm::report_fatal_error(std::move(E));
 
   // Replay / decanonicalize as necessary.
-  Optional<int> Status =
-      replayCachedResult(std::move(*Result), /*JustComputedResult=*/true);
+  Optional<int> Status = replayCachedResult(CAS->getReference(*Result),
+                                            /*JustComputedResult=*/true);
   (void)Status;
   assert(Status == None);
 }
 
 /// Replay a result after a cache hit.
-Optional<int> CompileJobCache::replayCachedResult(llvm::cas::CASID ResultID,
+Optional<int> CompileJobCache::replayCachedResult(llvm::cas::ObjectRef ResultID,
                                                   bool JustComputedResult) {
   if (JustComputedResult && !ComputedJobNeedsReplay)
     return None;
 
   // FIXME: Stop calling report_fatal_error().
   Optional<llvm::cas::TreeProxy> Result;
-  if (Error E = CAS->getTree(ResultID).moveInto(Result))
+  if (Error E = CAS->loadTree(ResultID).moveInto(Result))
     llvm::report_fatal_error(std::move(E));
 
   // Replay diagnostics to stderr.
   if (!JustComputedResult) {
     Optional<llvm::cas::BlobProxy> Errs;
     if (Optional<llvm::cas::NamedTreeEntry> Entry = Result->lookup("stderr"))
-      if (Error E = CAS->getBlob(Entry->getID()).moveInto(Errs))
+      if (Error E = CAS->loadBlob(Entry->getRef()).moveInto(Errs))
         llvm::report_fatal_error(std::move(E));
     if (!Errs)
       llvm::report_fatal_error("CAS error accessing stderr");
@@ -467,7 +474,7 @@ Optional<int> CompileJobCache::replayCachedResult(llvm::cas::CASID ResultID,
   // FIXME: Use a NodeReader here once it exists.
   Optional<llvm::cas::NodeProxy> Outputs;
   if (Optional<llvm::cas::NamedTreeEntry> Entry = Result->lookup("outputs"))
-    if (Error E = CAS->getNode(Entry->getID()).moveInto(Outputs))
+    if (Error E = CAS->loadNode(Entry->getRef()).moveInto(Outputs))
       llvm::report_fatal_error(std::move(E));
   if (!Outputs)
     llvm::report_fatal_error("CAS error accessing outputs");

--- a/lld/MachO/InputFiles.cpp
+++ b/lld/MachO/InputFiles.cpp
@@ -880,8 +880,8 @@ ObjFile::ObjFile(MemoryBufferRef mb, uint32_t modTime, StringRef archiveName,
   init(archiveName);
 }
 
-ObjFile::ObjFile(MemoryBufferRef mb, llvm::cas::CASID ID, StringRef archiveName,
-                 bool lazy)
+ObjFile::ObjFile(MemoryBufferRef mb, llvm::cas::ObjectRef ID,
+                 StringRef archiveName, bool lazy)
     : InputFile(ObjKind, mb, lazy), modTime(0), casID(std::move(ID)) {
   init(archiveName);
 }
@@ -1585,7 +1585,7 @@ static Expected<InputFile *> loadArchiveMember(MemoryBufferRef mb,
     if (!blobRef)
       return blobRef.takeError();
     MemoryBufferRef objectMB(blobRef->getData(), memberName);
-    return make<ObjFile>(objectMB, *blobRef, archiveName);
+    return make<ObjFile>(objectMB, blobRef->getRef(), archiveName);
   }
   default:
     return createStringError(inconvertibleErrorCode(),
@@ -1788,8 +1788,8 @@ static void applyArchRelocationProperties(jitlink::Edge::Kind kind,
   }
 }
 
-Error CASSchemaFile::parse(ObjectFormatSchemaPool &CASSchemas, CASID ID) {
-  Expected<cas::NodeProxy> Ref = CASSchemas.getCAS().getNode(ID);
+Error CASSchemaFile::parse(ObjectFormatSchemaPool &CASSchemas, ObjectRef ID) {
+  Expected<cas::NodeProxy> Ref = CASSchemas.getCAS().loadNode(ID);
   if (auto E = Ref.takeError())
     return E;
   ObjectFormatSchemaBase *Schema = CASSchemas.getSchemaForRoot(*Ref);

--- a/lld/MachO/InputFiles.h
+++ b/lld/MachO/InputFiles.h
@@ -18,7 +18,7 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/BinaryFormat/MachO.h"
-#include "llvm/CAS/CASID.h"
+#include "llvm/CAS/CASReference.h"
 #include "llvm/DebugInfo/DWARF/DWARFUnit.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -151,13 +151,13 @@ public:
   ArrayRef<llvm::MachO::data_in_code_entry> getDataInCode() const;
   template <class LP> void parse();
 
-  ObjFile(MemoryBufferRef mb, llvm::cas::CASID ID, StringRef archiveName,
+  ObjFile(MemoryBufferRef mb, llvm::cas::ObjectRef ID, StringRef archiveName,
           bool lazy = false);
   static bool classof(const InputFile *f) { return f->kind() == ObjKind; }
 
   llvm::DWARFUnit *compileUnit = nullptr;
   const uint32_t modTime;
-  const llvm::Optional<llvm::cas::CASID> casID;
+  const llvm::Optional<llvm::cas::ObjectRef> casID;
   std::vector<ConcatInputSection *> debugSections;
   std::vector<CallGraphEntry> callGraph;
   Section *addrSigSection = nullptr;
@@ -189,7 +189,7 @@ public:
   static bool classof(const InputFile *f) { return f->kind() == CASSchemaKind; }
 
   Error parse(llvm::casobjectformats::ObjectFormatSchemaPool &CASSchemas,
-              llvm::cas::CASID ID);
+              llvm::cas::ObjectRef ID);
 };
 
 // command-line -sectcreate file

--- a/llvm/include/llvm/CAS/BuiltinObjectHasher.h
+++ b/llvm/include/llvm/CAS/BuiltinObjectHasher.h
@@ -75,12 +75,12 @@ public:
     return H.finish();
   }
 
-  static HashT hashTree(ArrayRef<NamedTreeEntry> Entries) {
+  static HashT hashTree(const CASDB &CAS, ArrayRef<NamedTreeEntry> Entries) {
     BuiltinObjectHasher H;
     H.start(StableObjectKind::Tree);
     H.updateSize(Entries.size());
     for (const NamedTreeEntry &Entry : Entries) {
-      H.updateID(Entry.getID());
+      H.updateRef(CAS, Entry.getRef());
       H.updateString(Entry.getName());
       H.updateKind(getStableKind(Entry.getKind()));
     }

--- a/llvm/include/llvm/CAS/CASDB.h
+++ b/llvm/include/llvm/CAS/CASDB.h
@@ -124,8 +124,6 @@ class TreeProxy;
 ///
 /// - Lift trees into a filesystem schema, dropping TreeHandle and making
 ///   TreeProxy inherit from NodeProxy.
-/// - Change TreeEntry and NamedTreeEntry to use ObjectRef instead of
-///   CASID.
 /// - Add APIs for bypassing CASID when parsing:
 ///     - Validate an ID without doing anything else (current check done by
 ///       `parseID()`).
@@ -257,6 +255,11 @@ public:
   Expected<TreeProxy> getTree(CASID ID);
   Expected<NodeProxy> getNode(CASID ID);
 
+  /// FIXME: Move to the Filesystem schema once trees are removed from CASDB.
+  Expected<TreeProxy> loadTree(ObjectRef Ref);
+  Expected<LeafNodeProxy> loadBlob(ObjectRef Ref);
+  Expected<NodeProxy> loadNode(ObjectRef Ref);
+
   /// Get the size of some data.
   virtual uint64_t getDataSize(NodeHandle Node) const = 0;
 
@@ -338,6 +341,9 @@ public:
   const CASDB &getCAS() const { return *CAS; }
   CASID getID() const {
     return CAS->getObjectID(*static_cast<const ObjectHandle *>(this));
+  }
+  ObjectRef getRef() const {
+    return CAS->getReference(*static_cast<const ObjectHandle *>(this));
   }
 
   /// FIXME: Remove this.

--- a/llvm/include/llvm/CAS/CASReference.h
+++ b/llvm/include/llvm/CAS/CASReference.h
@@ -168,7 +168,7 @@ private:
   }
   explicit ObjectRef(DenseMapEmptyTag T) : ReferenceBase(T) {}
   explicit ObjectRef(DenseMapTombstoneTag T) : ReferenceBase(T) {}
-  ObjectRef(ReferenceBase) = delete;
+  explicit ObjectRef(ReferenceBase) = delete;
 };
 
 /// Handle to a loaded object in a \a CASDB instance.
@@ -201,7 +201,7 @@ private:
   friend class ReferenceBase;
   friend class testing_helpers::HandleFactory;
   using ReferenceBase::ReferenceBase;
-  ObjectHandle(ReferenceBase) = delete;
+  explicit ObjectHandle(ReferenceBase) = delete;
   ObjectHandle(const CASDB &CAS, uint64_t InternalRef)
       : ReferenceBase(&CAS, InternalRef, /*IsHandle=*/true) {}
   template <class HandleT, HandleKind> friend class AnyObjectHandleImpl;
@@ -213,7 +213,7 @@ class NodeHandle : public ObjectHandle {
   friend class CASDB;
   friend class testing_helpers::HandleFactory;
   using ObjectHandle::ObjectHandle;
-  NodeHandle(ObjectHandle) = delete;
+  explicit NodeHandle(ObjectHandle) = delete;
   template <class HandleT, HandleKind> friend class AnyObjectHandleImpl;
   static constexpr HandleKind getHandleKind() { return NodeKind; }
 };
@@ -223,7 +223,7 @@ class TreeHandle : public ObjectHandle {
   friend class CASDB;
   friend class testing_helpers::HandleFactory;
   using ObjectHandle::ObjectHandle;
-  TreeHandle(ObjectHandle) = delete;
+  explicit TreeHandle(ObjectHandle) = delete;
   template <class HandleT, HandleKind> friend class AnyObjectHandleImpl;
   static constexpr HandleKind getHandleKind() { return TreeKind; }
 };

--- a/llvm/include/llvm/CAS/TreeEntry.h
+++ b/llvm/include/llvm/CAS/TreeEntry.h
@@ -10,7 +10,7 @@
 #define LLVM_CAS_TREEENTRY_H
 
 #include "llvm/ADT/StringRef.h"
-#include "llvm/CAS/CASID.h"
+#include "llvm/CAS/CASReference.h"
 
 namespace llvm {
 namespace cas {
@@ -32,17 +32,17 @@ public:
   bool isSymlink() const { return Kind == Symlink; }
   bool isTree() const { return Kind == Tree; }
 
-  CASID getID() const { return ID; }
+  ObjectRef getRef() const { return Ref; }
 
   friend bool operator==(const TreeEntry &LHS, const TreeEntry &RHS) {
-    return LHS.Kind == RHS.Kind && LHS.ID == RHS.ID;
+    return LHS.Kind == RHS.Kind && LHS.Ref == RHS.Ref;
   }
 
-  TreeEntry(CASID ID, EntryKind Kind) : Kind(Kind), ID(ID) {}
+  TreeEntry(ObjectRef Ref, EntryKind Kind) : Kind(Kind), Ref(Ref) {}
 
 private:
   EntryKind Kind;
-  CASID ID;
+  ObjectRef Ref;
 };
 
 class NamedTreeEntry : public TreeEntry {
@@ -57,8 +57,8 @@ public:
     return LHS.Name < RHS.Name;
   }
 
-  NamedTreeEntry(CASID ID, EntryKind Kind, StringRef Name)
-      : TreeEntry(ID, Kind), Name(Name) {}
+  NamedTreeEntry(ObjectRef Ref, EntryKind Kind, StringRef Name)
+      : TreeEntry(Ref, Kind), Name(Name) {}
 
   void print(raw_ostream &OS, CASDB &CAS) const;
 

--- a/llvm/include/llvm/CAS/Utils.h
+++ b/llvm/include/llvm/CAS/Utils.h
@@ -20,6 +20,7 @@ class CASDB;
 class CASID;
 class NamedTreeEntry;
 class TreeProxy;
+class TreeHandle;
 
 Expected<CASID> readCASIDBuffer(cas::CASDB &CAS, llvm::MemoryBufferRef Buffer);
 
@@ -34,7 +35,7 @@ void writeCASIDBuffer(const CASID &ID, llvm::raw_ostream &OS);
 /// Passes the \p TreeProxy if the entry is a \p TreeEntry::Tree, otherwise
 /// passes \p None.
 Error walkFileTreeRecursively(
-    CASDB &CAS, CASID ID,
+    CASDB &CAS, const TreeHandle &Root,
     function_ref<Error(const NamedTreeEntry &, Optional<TreeProxy>)> Callback);
 
 } // namespace cas

--- a/llvm/include/llvm/TableGen/ScanDependencies.h
+++ b/llvm/include/llvm/TableGen/ScanDependencies.h
@@ -42,29 +42,29 @@ void scanTextForIncludes(StringRef Input, SmallVectorImpl<StringRef> &Includes);
 ///
 /// \p ExecID is the Blob for the running executable. It can be used as part of
 /// the key for caching to avoid (fixed) bugs poisoning results.
-Error scanTextForIncludes(cas::CASDB &CAS, cas::CASID ExecID,
+Error scanTextForIncludes(cas::CASDB &CAS, cas::ObjectRef ExecID,
                           const cas::BlobProxy &Blob,
                           SmallVectorImpl<StringRef> &Includes);
 
 /// Match logic from SourceMgr::AddIncludeFile.
 ///
 /// FIXME: Take CASFileSystemBase once it adds statusAndFileID().
-Optional<cas::CASID> lookupIncludeID(cas::CachingOnDiskFileSystem &FS,
-                                     ArrayRef<std::string> IncludeDirs,
-                                     StringRef Filename);
+Optional<cas::ObjectRef> lookupIncludeID(cas::CachingOnDiskFileSystem &FS,
+                                         ArrayRef<std::string> IncludeDirs,
+                                         StringRef Filename);
 
 /// Helper to access all includes under \p MainFileBlob.
 ///
 /// \p ExecID is the Blob for the running executable. It can be used as part of
 /// the key for caching to avoid (fixed) bugs poisoning results.
-Error accessAllIncludes(cas::CachingOnDiskFileSystem &FS, cas::CASID ExecID,
+Error accessAllIncludes(cas::CachingOnDiskFileSystem &FS, cas::ObjectRef ExecID,
                         ArrayRef<std::string> IncludeDirs,
                         const cas::BlobProxy &MainFileBlob);
 
 Error createMainFileError(StringRef MainFilename, std::error_code EC);
 
 struct ScanIncludesResult {
-  cas::CASID IncludesTree;
+  cas::ObjectRef IncludesTree;
   cas::BlobProxy MainBlob;
 };
 
@@ -79,7 +79,7 @@ struct ScanIncludesResult {
 /// it'd be useful for build systems that want to collect dependencies ahead of
 /// time. Maybe can separate a tool/etc. for that.
 Expected<ScanIncludesResult>
-scanIncludes(cas::CASDB &CAS, cas::CASID ExecID, StringRef MainFilename,
+scanIncludes(cas::CASDB &CAS, cas::ObjectRef ExecID, StringRef MainFilename,
              ArrayRef<std::string> IncludeDirs,
              ArrayRef<MappedPrefix> PrefixMappings = None,
              Optional<TreePathPrefixMapper> *CapturedPM = nullptr);
@@ -91,7 +91,7 @@ scanIncludes(cas::CASDB &CAS, cas::CASID ExecID, StringRef MainFilename,
 /// \p ExecID is the Blob for the running executable. It can be used as part of
 /// the key for caching to avoid (fixed) bugs poisoning results.
 Expected<ScanIncludesResult>
-scanIncludesAndRemap(cas::CASDB &CAS, cas::CASID ExecID,
+scanIncludesAndRemap(cas::CASDB &CAS, cas::ObjectRef ExecID,
                      std::string &MainFilename,
                      std::vector<std::string> &IncludeDirs,
                      ArrayRef<MappedPrefix> PrefixMappings);

--- a/llvm/lib/CAS/BuiltinCAS.cpp
+++ b/llvm/lib/CAS/BuiltinCAS.cpp
@@ -102,7 +102,8 @@ Expected<TreeHandle> BuiltinCAS::storeTree(ArrayRef<NamedTreeEntry> Entries) {
   std::stable_sort(Sorted.begin(), Sorted.end());
   Sorted.erase(std::unique(Sorted.begin(), Sorted.end()), Sorted.end());
 
-  return storeTreeImpl(BuiltinObjectHasher<HasherT>::hashTree(Sorted), Sorted);
+  return storeTreeImpl(BuiltinObjectHasher<HasherT>::hashTree(*this, Sorted),
+                       Sorted);
 }
 
 Expected<NodeHandle> BuiltinCAS::storeNode(ArrayRef<ObjectRef> Refs,

--- a/llvm/lib/CAS/CASFileSystem.cpp
+++ b/llvm/lib/CAS/CASFileSystem.cpp
@@ -163,19 +163,19 @@ Error CASFileSystem::loadDirectory(DirectoryEntry &Parent) {
   size_t ParentPathSize = Path.size();
   auto makeCachedEntry =
       [&](const NamedTreeEntry &NewEntry) -> DirectoryEntry & {
-    Optional<ObjectRef> Ref = DB.getReference(NewEntry.getID());
-    assert(Ref && "Expected valid reference for new tree entry");
     Path.resize(ParentPathSize);
     sys::path::append(Path, sys::path::Style::posix, NewEntry.getName());
     switch (NewEntry.getKind()) {
     case TreeEntry::Regular:
     case TreeEntry::Executable:
-      return Cache->makeLazyFileAlreadyLocked(
-          Parent, Path, *Ref, NewEntry.getKind() == TreeEntry::Executable);
+      return Cache->makeLazyFileAlreadyLocked(Parent, Path, NewEntry.getRef(),
+                                              NewEntry.getKind() ==
+                                                  TreeEntry::Executable);
     case TreeEntry::Symlink:
-      return Cache->makeLazySymlinkAlreadyLocked(Parent, Path, *Ref);
+      return Cache->makeLazySymlinkAlreadyLocked(Parent, Path,
+                                                 NewEntry.getRef());
     case TreeEntry::Tree:
-      return Cache->makeDirectoryAlreadyLocked(Parent, Path, *Ref);
+      return Cache->makeDirectoryAlreadyLocked(Parent, Path, NewEntry.getRef());
     }
     llvm_unreachable("invalid tree type");
   };

--- a/llvm/lib/CAS/InMemoryCAS.cpp
+++ b/llvm/lib/CAS/InMemoryCAS.cpp
@@ -379,7 +379,8 @@ public:
 private:
   // TreeAPI.
   NamedTreeEntry makeTreeEntry(const InMemoryTree::NamedEntry &Entry) const {
-    return NamedTreeEntry(getID(*Entry.Ref), Entry.Kind, Entry.Name->get());
+    return NamedTreeEntry(toReference(*Entry.Ref), Entry.Kind,
+                          Entry.Name->get());
   }
   NamedTreeEntry loadTreeEntry(TreeHandle Tree, size_t I) const final {
     return makeTreeEntry(getInMemoryTree(Tree)[I]);
@@ -552,10 +553,8 @@ InMemoryCAS::storeTreeImpl(ArrayRef<uint8_t> ComputedHash,
   // Create the tree.
   SmallVector<InMemoryTree::NamedEntry> InternalEntries;
   for (const NamedTreeEntry &E : SortedEntries) {
-    InternalEntries.push_back({getInMemoryObject(E.getID()),
+    InternalEntries.push_back({&asInMemoryObject(E.getRef()),
                                &getOrCreateString(E.getName()), E.getKind()});
-    if (!InternalEntries.back().Ref)
-      return createUnknownObjectError(E.getID());
   }
   auto Allocator = [&](size_t Size) -> void * {
     return Objects.Allocate(Size, alignof(InMemoryObject));

--- a/llvm/lib/CAS/OnDiskCAS.cpp
+++ b/llvm/lib/CAS/OnDiskCAS.cpp
@@ -1872,14 +1872,8 @@ OnDiskCAS::storeTreeImpl(ArrayRef<uint8_t> ComputedHash,
   }
 
   // Then target refs.
-  for (const NamedTreeEntry &E : SortedEntries) {
-    // Note that these calls to getInternalRef() each do a data access,
-    // converting from CASID to InternalRef.
-    if (Optional<ObjectRef> Ref = getReference(E.getID()))
-      Refs.push_back(getInternalRef(*Ref));
-    else
-      return createUnknownObjectError(E.getID());
-  }
+  for (const NamedTreeEntry &E : SortedEntries)
+    Refs.push_back(getInternalRef(E.getRef()));
 
   // Create the object.
   return castExpected<TreeHandle>(
@@ -2025,10 +2019,10 @@ NamedTreeEntry OnDiskCAS::makeTreeEntry(TreeHandle Tree,
   assert(I < NumNames);
   assert(Record.getNumRefs() % 2 == 0);
   StringRef Name = getTreeEntryName(Tree, Record.getRefs()[I]);
-  Optional<CASID> ID = getID(Record.getRefs()[I + NumNames]);
+  InternalRef Ref = Record.getRefs()[I + NumNames];
   TreeEntry::EntryKind Kind =
       getUnstableKind((StableTreeEntryKind)Record.getData()[I]);
-  return NamedTreeEntry(*ID, Kind, Name);
+  return NamedTreeEntry(getExternalReference(Ref), Kind, Name);
 }
 
 Optional<size_t> OnDiskCAS::lookupTreeEntry(TreeHandle Tree,

--- a/llvm/unittests/CAS/CASUtilsTest.cpp
+++ b/llvm/unittests/CAS/CASUtilsTest.cpp
@@ -19,7 +19,7 @@ TEST(CASUtilsTest, walkFileTreeRecursively) {
   std::unique_ptr<CASDB> CAS = createInMemoryCAS();
 
   auto make = [&](StringRef Content) {
-    return cantFail(CAS->createBlob(Content));
+    return CAS->getReference(cantFail(CAS->storeNodeFromString(None, Content)));
   };
 
   HierarchicalTreeBuilder Builder;
@@ -27,7 +27,7 @@ TEST(CASUtilsTest, walkFileTreeRecursively) {
   Builder.push(make("blob1"), TreeEntry::Regular, "/t1/d1");
   Builder.push(make("blob3"), TreeEntry::Regular, "/t3/d3");
   Builder.push(make("blob1"), TreeEntry::Regular, "/t3/t1nested/d1");
-  Optional<TreeProxy> Root;
+  Optional<TreeHandle> Root;
   ASSERT_THAT_ERROR(Builder.create(*CAS).moveInto(Root), Succeeded());
 
   std::pair<std::string, bool> ExpectedEntries[] = {


### PR DESCRIPTION
Not quite finished, but not sure I'll have time. Maybe @cachemeifyoucan can put this over the line?

Clang compiles, but a couple of tests fail:
```
Failed Tests (2):
  Clang :: CAS/fcache-compile-job.c
  Clang :: CAS/fcas-fs-result-cache-serialized-diagnostics.c
```

Haven't tried building lld yet.