### PR TITLE
[swift/release/5.7][Index] Remove reference to `UnresolvedUsingIfExists`

### DIFF
--- a/clang/lib/Index/IndexDecl.cpp
+++ b/clang/lib/Index/IndexDecl.cpp
@@ -605,9 +605,16 @@ public:
     const NamedDecl *Parent = dyn_cast<NamedDecl>(DC);
     IndexCtx.indexNestedNameSpecifierLoc(D->getQualifierLoc(), Parent,
                                          D->getLexicalDeclContext());
-    for (const auto *I : D->shadows())
+    for (const auto *I : D->shadows()) {
+      // Skip unresolved using decls - we already have a decl for the using
+      // itself, so there's not much point adding another decl or reference to
+      // refer to the same location.
+      if (isa<UnresolvedUsingIfExistsDecl>(I->getUnderlyingDecl()))
+        continue;
+
       IndexCtx.handleReference(I->getUnderlyingDecl(), D->getLocation(), Parent,
                                D->getLexicalDeclContext(), SymbolRoleSet());
+    }
     return true;
   }
 

--- a/clang/test/Index/using_if_exists.cpp
+++ b/clang/test/Index/using_if_exists.cpp
@@ -1,0 +1,9 @@
+// RUN: c-index-test core -print-source-symbols -- %s -target x86_64-unknown-unknown 2>&1 | FileCheck %s
+
+namespace ns {
+//  void foo();
+}
+
+using ns::foo __attribute__((using_if_exists));
+// CHECK: [[@LINE-1]]:11 | using/C++ | foo | c:@UD@foo | <no-cgname> | Decl | rel: 0
+// CHECK-NOT: <unknown>


### PR DESCRIPTION
Cherry-picks https://github.com/apple/llvm-project/commit/089b6efefc3dbfc88e8fa92673eeb63ee78e4adf

Resolves rdar://90812252.

-----

Assuming `ns::foo` doesn't exist, given:
```
using ns::foo __attribute__((using_if_exists));
```

The AST will look something like:
UsingDecl
  UsingShadowDecl
    UnresolvedUsingIfExistsDecl

Thus we end up adding a reference to `UnresolvedUsingIfExistsDecl` when
processing `UsingDecl`, but never add the decl itself. In this case the
decl is really the `UsingDecl` anyway though (which we do output), so it
makes more sense to just remove the extra reference.

Differential Revision: https://reviews.llvm.org/D124288