### PR TITLE
[compiler-rt] Add missing arguments to dynamic cflags

### DIFF
--- a/compiler-rt/lib/tsan/rtl/CMakeLists.txt
+++ b/compiler-rt/lib/tsan/rtl/CMakeLists.txt
@@ -7,9 +7,6 @@ append_list_if(SANITIZER_LIMIT_FRAME_SIZE -Wframe-larger-than=530
 append_list_if(COMPILER_RT_HAS_WGLOBAL_CONSTRUCTORS_FLAG -Wglobal-constructors
                TSAN_RTL_CFLAGS)
 
-set(TSAN_RTL_DYNAMIC_CFLAGS ${TSAN_RTL_CFLAGS})
-list(REMOVE_ITEM TSAN_RTL_DYNAMIC_CFLAGS -fPIE)
-
 set(TSAN_DYNAMIC_LINK_LIBS ${SANITIZER_CXX_ABI_LIBRARIES} ${SANITIZER_COMMON_LINK_LIBS})
 
 append_list_if(COMPILER_RT_HAS_LIBDL dl TSAN_DYNAMIC_LINK_LIBS)
@@ -251,6 +248,9 @@ else()
       PARENT_TARGET tsan)
     list(APPEND TSAN_RUNTIME_LIBRARIES clang_rt.tsan-${arch}
                                        clang_rt.tsan_cxx-${arch})
+
+    set(TSAN_RTL_DYNAMIC_CFLAGS ${TSAN_RTL_CFLAGS})
+    list(REMOVE_ITEM TSAN_RTL_DYNAMIC_CFLAGS -fPIE)
     add_compiler_rt_runtime(clang_rt.tsan
       SHARED
       ARCHS ${arch}


### PR DESCRIPTION
91bfccf83733e6d12a6da9f2e1a2d20a88fb974c added a shared library for
`clang_rt.tsan` and using `TSAN_RTL_DYNAMIC_CFLAGS` for its CFLAGS. But
`TSAN_RTL_DYNAMIC_CFLAGS` was adding `TSAN_RTL_CFLAGS` before it had
actually been set with further arguments (eg. in the
`COMPILER_RT_INTERCEPT_LIBDISPATCH` block). Set it right before its use
to avoid this problem in the future.