### PR TITLE
Turn the HEALTH_LOG macro into a statement.

### DIFF
--- a/lldb/source/Commands/CommandObjectHealthcheck.cpp
+++ b/lldb/source/Commands/CommandObjectHealthcheck.cpp
@@ -53,11 +53,15 @@ bool CommandObjectHealthcheck::DoExecute(Args &args,
   result.AppendMessageWithFormat("Health check written to %s\n",
                                  temp_path.c_str());
 
+#if APPLE
   // When in an interactive graphical session and not, for example,
   // running LLDB running over ssh, open the log file straight away in
   // the user's configured editor or the default Console.app otherwise.
-  if (Host::IsInteractiveGraphicSession())
+  if ((strcmp("lldb", getprogname()) == 0 ||
+       strcmp("lldb-rpc-server", getprogname()) == 0) &&
+      Host::IsInteractiveGraphicSession())
     Host::OpenFileInExternalEditor(FileSpec(temp_path), 0);
+#endif
 
   return true;
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -156,8 +156,11 @@ std::recursive_mutex g_log_mutex;
   } while (0)
 
 #define HEALTH_LOG_PRINTF(FMT, ...)                                            \
-  LOG_PRINTF(GetLog(LLDBLog::Types), FMT, ##__VA_ARGS__);                      \
-  LOG_PRINTF_IMPL(lldb_private::GetSwiftHealthLog(), false, FMT, ##__VA_ARGS__)
+  do {                                                                         \
+    LOG_PRINTF(GetLog(LLDBLog::Types), FMT, ##__VA_ARGS__);                    \
+    LOG_PRINTF_IMPL(lldb_private::GetSwiftHealthLog(), false, FMT,             \
+                    ##__VA_ARGS__);                                            \
+  } while (0)
 
 #define VALID_OR_RETURN(value)                                                 \
   do {                                                                         \

--- a/lldb/test/API/lang/swift/swift-healthcheck/Makefile
+++ b/lldb/test/API/lang/swift/swift-healthcheck/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/swift-healthcheck/TestSwiftHealthCheck.py
+++ b/lldb/test/API/lang/swift/swift-healthcheck/TestSwiftHealthCheck.py
@@ -1,0 +1,39 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftHealthCheck(TestBase):
+
+    NO_DEBUG_INFO_TESTCASE = True
+    mydir = TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    @skipIfDarwinEmbedded
+    def test(self):
+        """Test that an underspecified triple is upgraded with a version number.
+        """
+        self.build()
+
+        target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(
+            self, 'main')
+        self.expect("p 1")
+        result = lldb.SBCommandReturnObject()
+        ret_val = self.dbg.GetCommandInterpreter().HandleCommand("swift-healthcheck", result)
+        log = result.GetOutput()[:-1].split(" ")[-1]
+        self.assertEquals(log[-4:], ".log")
+        import io, re
+        logfile = io.open(log, "r", encoding='utf-8')
+        good = 0
+        bad = 0
+        for line in logfile:
+            if re.search('swift-healthcheck', line):
+                good += 1
+                continue
+            if re.search('Unsupported mixing"', line):
+                bad += 1
+                break
+        self.assertGreater(good, 1)
+        self.assertEquals(bad, 0)

--- a/lldb/test/API/lang/swift/swift-healthcheck/main.swift
+++ b/lldb/test/API/lang/swift/swift-healthcheck/main.swift
@@ -1,0 +1,1 @@
+print("this space intentionally left blank")


### PR DESCRIPTION
At least one call site had the form

if (condition)
  HEALTH_LOG();

without curly braces, resulting in incorrect log messages being printed.

Also, add a test for swift-healthcheck, and make sure the console
isn't being opened when running the test suite.

rdar://92913227