### PR TITLE
[CASDB] OnDiskCAS should not create LeafNode when node has refs

### DIFF
--- a/llvm/lib/CAS/OnDiskCAS.cpp
+++ b/llvm/lib/CAS/OnDiskCAS.cpp
@@ -765,7 +765,7 @@ public:
   static constexpr StringLiteral DataPoolFile = "data";
   static constexpr StringLiteral ActionCacheFile = "actions";
 
-  static constexpr StringLiteral FilePrefix = "v3.";
+  static constexpr StringLiteral FilePrefix = "v4.";
   static constexpr StringLiteral FileSuffixData = ".data";
   static constexpr StringLiteral FileSuffixLeaf = ".leaf";
   static constexpr StringLiteral FileSuffixLeaf0 = ".leaf+0";

--- a/llvm/lib/CAS/OnDiskCAS.cpp
+++ b/llvm/lib/CAS/OnDiskCAS.cpp
@@ -1903,7 +1903,7 @@ Expected<NodeHandle> OnDiskCAS::storeNodeImpl(ArrayRef<uint8_t> ComputedHash,
   }
 
   // Big leaf nodes.
-  if (Data.size() > TrieRecord::MaxEmbeddedSize)
+  if (Refs.empty() && Data.size() > TrieRecord::MaxEmbeddedSize)
     return createStandaloneLeaf(I, Data);
 
   // TODO: Check whether it's worth checking the index for an already existing


### PR DESCRIPTION
Fix a bug that OnDiskCAS drops all the references when the data is
large and a leaf node is created. Leaf node should only be used when
there are no refs.