### PR TITLE
Fix cc1depscand tests after addition of -cas-args

### DIFF
--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -664,7 +664,7 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
   bool KeepAlive = false;
   bool Detached = false;
   bool Debug = false;
-  if (Argv.size() == 3) {
+  if (Argv.size() >= 3) {
     if (StringRef(Argv[2]) == "-shutdown")
       ShutDownTest = true;
     if (StringRef(Argv[2]) == "-detach")


### PR DESCRIPTION
In 3fcd4432c83d2 we added optional -cas-args to the cc1despcand
invocations, so we need to handle argument lists of arbitrary length
when detecting "-detach", "-shutdown", and "-debug". This was not
noticed before, because these tests only run when the directory name is
short.