### PR TITLE
Use OutputBackend to write dependency files

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -12,6 +12,7 @@ let Component = "Frontend" in {
 
 def err_fe_error_opening : Error<"error opening '%0': %1">;
 def err_fe_error_reading : Error<"error reading '%0'">;
+def err_fe_error_writing : Error<"error writing '%0': %1">;
 def err_fe_error_reading_stdin : Error<"error reading stdin: %0">;
 def err_fe_error_backend : Error<"error in backend: %0">, DefaultFatal;
 

--- a/clang/include/clang/Frontend/Utils.h
+++ b/clang/include/clang/Frontend/Utils.h
@@ -24,6 +24,7 @@
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/FileCollector.h"
 #include "llvm/Support/VirtualFileSystem.h"
+#include "llvm/Support/VirtualOutputBackend.h"
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -101,7 +102,12 @@ private:
 /// loaded.
 class DependencyFileGenerator : public DependencyCollector {
 public:
-  DependencyFileGenerator(const DependencyOutputOptions &Opts);
+  /// Constructs a \c DependencyFileGenerator with the given options and output
+  /// backend. If \p OutputBackend is null, a default on-disk backend will be
+  /// used.
+  DependencyFileGenerator(
+      const DependencyOutputOptions &Opts,
+      IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutputBackend = nullptr);
 
   void attachToPreprocessor(Preprocessor &PP) override;
 
@@ -118,6 +124,7 @@ protected:
 private:
   void outputDependencyFile(DiagnosticsEngine &Diags);
 
+  IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutputBackend;
   std::string OutputFile;
   std::vector<std::string> Targets;
   bool IncludeSystemHeaders;

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -508,7 +508,8 @@ void CompilerInstance::createPreprocessor(TranslationUnitKind TUKind) {
   // Handle generating dependencies, if requested.
   const DependencyOutputOptions &DepOpts = getDependencyOutputOpts();
   if (!DepOpts.OutputFile.empty())
-    addDependencyCollector(std::make_shared<DependencyFileGenerator>(DepOpts));
+    addDependencyCollector(
+        std::make_shared<DependencyFileGenerator>(DepOpts, TheOutputBackend));
   if (!DepOpts.DOTOutputFile.empty())
     AttachDependencyGraphGen(*PP, DepOpts.DOTOutputFile,
                              getHeaderSearchOpts().Sysroot);

--- a/clang/lib/Frontend/DependencyFile.cpp
+++ b/clang/lib/Frontend/DependencyFile.cpp
@@ -24,6 +24,7 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/VirtualOutputBackends.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace clang;
@@ -185,13 +186,16 @@ void DependencyCollector::attachToASTReader(ASTReader &R) {
 }
 
 DependencyFileGenerator::DependencyFileGenerator(
-    const DependencyOutputOptions &Opts)
-    : OutputFile(Opts.OutputFile), Targets(Opts.Targets),
-      IncludeSystemHeaders(Opts.IncludeSystemHeaders),
+    const DependencyOutputOptions &Opts,
+    IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OB)
+    : OutputBackend(std::move(OB)), OutputFile(Opts.OutputFile),
+      Targets(Opts.Targets), IncludeSystemHeaders(Opts.IncludeSystemHeaders),
       PhonyTarget(Opts.UsePhonyTargets),
       AddMissingHeaderDeps(Opts.AddMissingHeaderDeps), SeenMissingHeader(false),
       IncludeModuleFiles(Opts.IncludeModuleFiles),
       OutputFormat(Opts.OutputFormat), InputFileIndex(0) {
+  if (!OutputBackend)
+    OutputBackend = llvm::makeIntrusiveRefCnt<llvm::vfs::OnDiskOutputBackend>();
   for (const auto &ExtraDep : Opts.ExtraDeps) {
     if (addDependency(ExtraDep.first))
       ++InputFileIndex;
@@ -312,19 +316,33 @@ static void PrintFilename(raw_ostream &OS, StringRef Filename,
 }
 
 void DependencyFileGenerator::outputDependencyFile(DiagnosticsEngine &Diags) {
+  // The use of NoAtomicWrite and calling discard on SeenMissingHeader
+  // preserves the previous behaviour: no temporary files are used, and when
+  // SeenMissingHeader is true it deletes a previously-existing file.
+  // FIXME: switch to atomic-write based on FrontendOptions::UseTemporary and
+  // and not deleting the previous file, if possible.
+  Expected<llvm::vfs::OutputFile> O =
+      OutputBackend->createFile(OutputFile, llvm::vfs::OutputConfig()
+                                                .setTextWithCRLF()
+                                                .setNoAtomicWrite()
+                                                .setNoDiscardOnSignal());
+
+  if (!O) {
+    Diags.Report(diag::err_fe_error_opening)
+        << OutputFile << toString(O.takeError());
+    return;
+  }
+
   if (SeenMissingHeader) {
-    llvm::sys::fs::remove(OutputFile);
+    consumeError(O->discard());
     return;
   }
 
-  std::error_code EC;
-  llvm::raw_fd_ostream OS(OutputFile, EC, llvm::sys::fs::OF_TextWithCRLF);
-  if (EC) {
-    Diags.Report(diag::err_fe_error_opening) << OutputFile << EC.message();
-    return;
-  }
+  outputDependencyFile(O->getOS());
 
-  outputDependencyFile(OS);
+  if (auto Err = O->keep())
+    Diags.Report(diag::err_fe_error_writing)
+        << OutputFile << toString(std::move(Err));
 }
 
 void DependencyFileGenerator::outputDependencyFile(llvm::raw_ostream &OS) {

--- a/clang/test/CAS/fcache-compile-job-dependency-file.c
+++ b/clang/test/CAS/fcache-compile-job-dependency-file.c
@@ -1,0 +1,23 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
+//
+// RUN: %clang -cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache -emit-obj -o %t/output.o \
+// RUN:   -dependency-file %t/deps.d -MT %t/output.o 2>&1 \
+// RUN:   | FileCheck %s --allow-empty --check-prefix=CACHE-MISS
+//
+// RUN: ls %t/output.o && rm %t/output.o
+// RUN: ls %t/deps.d && mv %t/deps.d %t/deps.d.orig
+//
+// RUN: %clang -cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache -emit-obj -o %t/output.o \
+// RUN:   -dependency-file %t/deps.d -MT %t/output.o 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CACHE-HIT
+//
+// RUN: ls %t/output.o
+// RUN: diff -u %t/deps.d %t/deps.d.orig
+//
+// CACHE-HIT: remark: compile job cache hit
+// CACHE-MISS-NOT: remark: compile job cache hit

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -405,7 +405,9 @@ void CompileJobCache::finishComputedResult(CompilerInstance &Clang,
 
   // Don't cache failed builds.
   //
-  // TODO: Consider caching failed builds!
+  // TODO: Consider caching failed builds! Note: when output files are written
+  // without a temporary (non-atomically), failure may cause the removal of a
+  // preexisting file. That behaviour is not currently modeled by the cache.
   if (!Success)
     return;
 


### PR DESCRIPTION
Fixes caching of cc1 commands that include -dependency-file.

---

Note: this doesn't change the policy for when .d files should be generated when using dependency scanning, whether that should be during the scan, or during the build. It only seeks to make the cache hit consistent with the cache miss.