### PR TITLE
[stable/20220421] Revert "[FastISel] Reuse register for bitcast that does not change MVT"

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
@@ -1406,6 +1406,16 @@ bool FastISel::selectCast(const User *I, unsigned Opcode) {
 }
 
 bool FastISel::selectBitCast(const User *I) {
+  // If the bitcast doesn't change the type, just use the operand value.
+  if (I->getType() == I->getOperand(0)->getType()) {
+    Register Reg = getRegForValue(I->getOperand(0));
+    if (!Reg)
+      return false;
+    updateValueMap(I, Reg);
+    return true;
+  }
+
+  // Bitcasts of other values become reg-reg copies or BITCAST operators.
   EVT SrcEVT = TLI.getValueType(DL, I->getOperand(0)->getType());
   EVT DstEVT = TLI.getValueType(DL, I->getType());
   if (SrcEVT == MVT::Other || DstEVT == MVT::Other ||
@@ -1419,14 +1429,18 @@ bool FastISel::selectBitCast(const User *I) {
   if (!Op0) // Unhandled operand. Halt "fast" selection and bail.
     return false;
 
-  // If the bitcast doesn't change the type, just use the operand value.
+  // First, try to perform the bitcast by inserting a reg-reg copy.
+  Register ResultReg;
   if (SrcVT == DstVT) {
-    updateValueMap(I, Op0);
-    return true;
+    ResultReg = createResultReg(TLI.getRegClassFor(DstVT));
+    BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, DbgLoc,
+            TII.get(TargetOpcode::COPY), ResultReg).addReg(Op0);
   }
 
-  // Otherwise, select a BITCAST opcode.
-  Register ResultReg = fastEmit_r(SrcVT, DstVT, ISD::BITCAST, Op0);
+  // If the reg-reg copy failed, select a BITCAST opcode.
+  if (!ResultReg)
+    ResultReg = fastEmit_r(SrcVT, DstVT, ISD::BITCAST, Op0);
+
   if (!ResultReg)
     return false;
 

--- a/llvm/test/CodeGen/AArch64/swifterror.ll
+++ b/llvm/test/CodeGen/AArch64/swifterror.ll
@@ -117,14 +117,16 @@ define float @caller(i8* %error_ref) {
 ; CHECK-O0-AARCH64-NEXT:    .cfi_offset w21, -24
 ; CHECK-O0-AARCH64-NEXT:    .cfi_offset w22, -32
 ; CHECK-O0-AARCH64-NEXT:    ; implicit-def: $x1
-; CHECK-O0-AARCH64-NEXT:    str x0, [sp, #8] ; 8-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    str x0, [sp] ; 8-byte Folded Spill
 ; CHECK-O0-AARCH64-NEXT:    mov x21, xzr
 ; CHECK-O0-AARCH64-NEXT:    bl _foo
-; CHECK-O0-AARCH64-NEXT:    str x21, [sp, #16] ; 8-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    str x21, [sp, #8] ; 8-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    mov x0, x21
+; CHECK-O0-AARCH64-NEXT:    str x0, [sp, #16] ; 8-byte Folded Spill
 ; CHECK-O0-AARCH64-NEXT:    cbnz x21, LBB1_2
 ; CHECK-O0-AARCH64-NEXT:  ; %bb.1: ; %cont
-; CHECK-O0-AARCH64-NEXT:    ldr x9, [sp, #8] ; 8-byte Folded Reload
-; CHECK-O0-AARCH64-NEXT:    ldr x8, [sp, #16] ; 8-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    ldr x9, [sp] ; 8-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    ldr x8, [sp, #8] ; 8-byte Folded Reload
 ; CHECK-O0-AARCH64-NEXT:    ldrb w8, [x8, #8]
 ; CHECK-O0-AARCH64-NEXT:    strb w8, [x9]
 ; CHECK-O0-AARCH64-NEXT:  LBB1_2: ; %handler
@@ -179,15 +181,17 @@ define float @caller(i8* %error_ref) {
 ; CHECK-O0-ARM64_32-NEXT:    .cfi_offset w21, -24
 ; CHECK-O0-ARM64_32-NEXT:    .cfi_offset w22, -32
 ; CHECK-O0-ARM64_32-NEXT:    ; implicit-def: $x1
-; CHECK-O0-ARM64_32-NEXT:    str x0, [sp, #8] ; 8-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    str x0, [sp] ; 8-byte Folded Spill
 ; CHECK-O0-ARM64_32-NEXT:    mov x21, xzr
 ; CHECK-O0-ARM64_32-NEXT:    bl _foo
-; CHECK-O0-ARM64_32-NEXT:    str x21, [sp, #16] ; 8-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    str x21, [sp, #8] ; 8-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    mov x0, x21
+; CHECK-O0-ARM64_32-NEXT:    str x0, [sp, #16] ; 8-byte Folded Spill
 ; CHECK-O0-ARM64_32-NEXT:    cmp x21, #0
 ; CHECK-O0-ARM64_32-NEXT:    b.ne LBB1_2
 ; CHECK-O0-ARM64_32-NEXT:  ; %bb.1: ; %cont
-; CHECK-O0-ARM64_32-NEXT:    ldr x9, [sp, #8] ; 8-byte Folded Reload
-; CHECK-O0-ARM64_32-NEXT:    ldr x8, [sp, #16] ; 8-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    ldr x9, [sp] ; 8-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    ldr x8, [sp, #8] ; 8-byte Folded Reload
 ; CHECK-O0-ARM64_32-NEXT:    ldrb w8, [x8, #8]
 ; CHECK-O0-ARM64_32-NEXT:    ; kill: def $w0 killed $w8
 ; CHECK-O0-ARM64_32-NEXT:    strb w8, [x9]
@@ -266,43 +270,45 @@ define float @caller2(i8* %error_ref) {
 ;
 ; CHECK-O0-AARCH64-LABEL: caller2:
 ; CHECK-O0-AARCH64:       ; %bb.0: ; %entry
-; CHECK-O0-AARCH64-NEXT:    sub sp, sp, #64
-; CHECK-O0-AARCH64-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-O0-AARCH64-NEXT:    stp x22, x21, [sp, #32] ; 16-byte Folded Spill
-; CHECK-O0-AARCH64-NEXT:    stp x29, x30, [sp, #48] ; 16-byte Folded Spill
-; CHECK-O0-AARCH64-NEXT:    add x29, sp, #48
+; CHECK-O0-AARCH64-NEXT:    sub sp, sp, #80
+; CHECK-O0-AARCH64-NEXT:    .cfi_def_cfa_offset 80
+; CHECK-O0-AARCH64-NEXT:    stp x22, x21, [sp, #48] ; 16-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    stp x29, x30, [sp, #64] ; 16-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    add x29, sp, #64
 ; CHECK-O0-AARCH64-NEXT:    .cfi_def_cfa w29, 16
 ; CHECK-O0-AARCH64-NEXT:    .cfi_offset w30, -8
 ; CHECK-O0-AARCH64-NEXT:    .cfi_offset w29, -16
 ; CHECK-O0-AARCH64-NEXT:    .cfi_offset w21, -24
 ; CHECK-O0-AARCH64-NEXT:    .cfi_offset w22, -32
 ; CHECK-O0-AARCH64-NEXT:    ; implicit-def: $x1
-; CHECK-O0-AARCH64-NEXT:    str x0, [sp, #16] ; 8-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    str x0, [sp, #32] ; 8-byte Folded Spill
 ; CHECK-O0-AARCH64-NEXT:  LBB2_1: ; %bb_loop
 ; CHECK-O0-AARCH64-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-O0-AARCH64-NEXT:    mov x21, xzr
 ; CHECK-O0-AARCH64-NEXT:    bl _foo
-; CHECK-O0-AARCH64-NEXT:    str s0, [sp, #4] ; 4-byte Folded Spill
-; CHECK-O0-AARCH64-NEXT:    str x21, [sp, #8] ; 8-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    str s0, [sp, #12] ; 4-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    str x21, [sp, #16] ; 8-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    mov x0, x21
+; CHECK-O0-AARCH64-NEXT:    str x0, [sp, #24] ; 8-byte Folded Spill
 ; CHECK-O0-AARCH64-NEXT:    cbnz x21, LBB2_4
 ; CHECK-O0-AARCH64-NEXT:  ; %bb.2: ; %cont
 ; CHECK-O0-AARCH64-NEXT:    ; in Loop: Header=BB2_1 Depth=1
-; CHECK-O0-AARCH64-NEXT:    ldr s0, [sp, #4] ; 4-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    ldr s0, [sp, #12] ; 4-byte Folded Reload
 ; CHECK-O0-AARCH64-NEXT:    fmov s1, #1.00000000
 ; CHECK-O0-AARCH64-NEXT:    fcmp s0, s1
 ; CHECK-O0-AARCH64-NEXT:    b.le LBB2_1
 ; CHECK-O0-AARCH64-NEXT:  ; %bb.3: ; %bb_end
-; CHECK-O0-AARCH64-NEXT:    ldr x9, [sp, #16] ; 8-byte Folded Reload
-; CHECK-O0-AARCH64-NEXT:    ldr x8, [sp, #8] ; 8-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    ldr x9, [sp, #32] ; 8-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    ldr x8, [sp, #16] ; 8-byte Folded Reload
 ; CHECK-O0-AARCH64-NEXT:    ldrb w8, [x8, #8]
 ; CHECK-O0-AARCH64-NEXT:    strb w8, [x9]
 ; CHECK-O0-AARCH64-NEXT:  LBB2_4: ; %handler
-; CHECK-O0-AARCH64-NEXT:    ldr x0, [sp, #8] ; 8-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    ldr x0, [sp, #24] ; 8-byte Folded Reload
 ; CHECK-O0-AARCH64-NEXT:    bl _free
 ; CHECK-O0-AARCH64-NEXT:    fmov s0, #1.00000000
-; CHECK-O0-AARCH64-NEXT:    ldp x29, x30, [sp, #48] ; 16-byte Folded Reload
-; CHECK-O0-AARCH64-NEXT:    ldp x22, x21, [sp, #32] ; 16-byte Folded Reload
-; CHECK-O0-AARCH64-NEXT:    add sp, sp, #64
+; CHECK-O0-AARCH64-NEXT:    ldp x29, x30, [sp, #64] ; 16-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    ldp x22, x21, [sp, #48] ; 16-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    add sp, sp, #80
 ; CHECK-O0-AARCH64-NEXT:    ret
 ;
 ; CHECK-APPLE-ARM64_32-LABEL: caller2:
@@ -350,43 +356,45 @@ define float @caller2(i8* %error_ref) {
 ;
 ; CHECK-O0-ARM64_32-LABEL: caller2:
 ; CHECK-O0-ARM64_32:       ; %bb.0: ; %entry
-; CHECK-O0-ARM64_32-NEXT:    sub sp, sp, #64
-; CHECK-O0-ARM64_32-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-O0-ARM64_32-NEXT:    stp x22, x21, [sp, #32] ; 16-byte Folded Spill
-; CHECK-O0-ARM64_32-NEXT:    stp x29, x30, [sp, #48] ; 16-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    sub sp, sp, #80
+; CHECK-O0-ARM64_32-NEXT:    .cfi_def_cfa_offset 80
+; CHECK-O0-ARM64_32-NEXT:    stp x22, x21, [sp, #48] ; 16-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    stp x29, x30, [sp, #64] ; 16-byte Folded Spill
 ; CHECK-O0-ARM64_32-NEXT:    .cfi_offset w30, -8
 ; CHECK-O0-ARM64_32-NEXT:    .cfi_offset w29, -16
 ; CHECK-O0-ARM64_32-NEXT:    .cfi_offset w21, -24
 ; CHECK-O0-ARM64_32-NEXT:    .cfi_offset w22, -32
 ; CHECK-O0-ARM64_32-NEXT:    ; implicit-def: $x1
-; CHECK-O0-ARM64_32-NEXT:    str x0, [sp, #16] ; 8-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    str x0, [sp, #32] ; 8-byte Folded Spill
 ; CHECK-O0-ARM64_32-NEXT:  LBB2_1: ; %bb_loop
 ; CHECK-O0-ARM64_32-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-O0-ARM64_32-NEXT:    mov x21, xzr
 ; CHECK-O0-ARM64_32-NEXT:    bl _foo
-; CHECK-O0-ARM64_32-NEXT:    str s0, [sp, #4] ; 4-byte Folded Spill
-; CHECK-O0-ARM64_32-NEXT:    str x21, [sp, #8] ; 8-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    str s0, [sp, #12] ; 4-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    str x21, [sp, #16] ; 8-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    mov x0, x21
+; CHECK-O0-ARM64_32-NEXT:    str x0, [sp, #24] ; 8-byte Folded Spill
 ; CHECK-O0-ARM64_32-NEXT:    cmp x21, #0
 ; CHECK-O0-ARM64_32-NEXT:    b.ne LBB2_4
 ; CHECK-O0-ARM64_32-NEXT:  ; %bb.2: ; %cont
 ; CHECK-O0-ARM64_32-NEXT:    ; in Loop: Header=BB2_1 Depth=1
-; CHECK-O0-ARM64_32-NEXT:    ldr s0, [sp, #4] ; 4-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    ldr s0, [sp, #12] ; 4-byte Folded Reload
 ; CHECK-O0-ARM64_32-NEXT:    fmov s1, #1.00000000
 ; CHECK-O0-ARM64_32-NEXT:    fcmp s0, s1
 ; CHECK-O0-ARM64_32-NEXT:    b.le LBB2_1
 ; CHECK-O0-ARM64_32-NEXT:  ; %bb.3: ; %bb_end
-; CHECK-O0-ARM64_32-NEXT:    ldr x9, [sp, #16] ; 8-byte Folded Reload
-; CHECK-O0-ARM64_32-NEXT:    ldr x8, [sp, #8] ; 8-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    ldr x9, [sp, #32] ; 8-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    ldr x8, [sp, #16] ; 8-byte Folded Reload
 ; CHECK-O0-ARM64_32-NEXT:    ldrb w8, [x8, #8]
 ; CHECK-O0-ARM64_32-NEXT:    ; kill: def $w0 killed $w8
 ; CHECK-O0-ARM64_32-NEXT:    strb w8, [x9]
 ; CHECK-O0-ARM64_32-NEXT:  LBB2_4: ; %handler
-; CHECK-O0-ARM64_32-NEXT:    ldr x0, [sp, #8] ; 8-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    ldr x0, [sp, #24] ; 8-byte Folded Reload
 ; CHECK-O0-ARM64_32-NEXT:    bl _free
 ; CHECK-O0-ARM64_32-NEXT:    fmov s0, #1.00000000
-; CHECK-O0-ARM64_32-NEXT:    ldp x29, x30, [sp, #48] ; 16-byte Folded Reload
-; CHECK-O0-ARM64_32-NEXT:    ldp x22, x21, [sp, #32] ; 16-byte Folded Reload
-; CHECK-O0-ARM64_32-NEXT:    add sp, sp, #64
+; CHECK-O0-ARM64_32-NEXT:    ldp x29, x30, [sp, #64] ; 16-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    ldp x22, x21, [sp, #48] ; 16-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    add sp, sp, #80
 ; CHECK-O0-ARM64_32-NEXT:    ret
 ; Access part of the error object and save it to error_ref
 
@@ -797,36 +805,38 @@ define float @caller3(i8* %error_ref) {
 ;
 ; CHECK-O0-AARCH64-LABEL: caller3:
 ; CHECK-O0-AARCH64:       ; %bb.0: ; %entry
-; CHECK-O0-AARCH64-NEXT:    sub sp, sp, #80
-; CHECK-O0-AARCH64-NEXT:    .cfi_def_cfa_offset 80
-; CHECK-O0-AARCH64-NEXT:    stp x22, x21, [sp, #48] ; 16-byte Folded Spill
-; CHECK-O0-AARCH64-NEXT:    stp x29, x30, [sp, #64] ; 16-byte Folded Spill
-; CHECK-O0-AARCH64-NEXT:    add x29, sp, #64
+; CHECK-O0-AARCH64-NEXT:    sub sp, sp, #96
+; CHECK-O0-AARCH64-NEXT:    .cfi_def_cfa_offset 96
+; CHECK-O0-AARCH64-NEXT:    stp x22, x21, [sp, #64] ; 16-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    stp x29, x30, [sp, #80] ; 16-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    add x29, sp, #80
 ; CHECK-O0-AARCH64-NEXT:    .cfi_def_cfa w29, 16
 ; CHECK-O0-AARCH64-NEXT:    .cfi_offset w30, -8
 ; CHECK-O0-AARCH64-NEXT:    .cfi_offset w29, -16
 ; CHECK-O0-AARCH64-NEXT:    .cfi_offset w21, -24
 ; CHECK-O0-AARCH64-NEXT:    .cfi_offset w22, -32
 ; CHECK-O0-AARCH64-NEXT:    ; implicit-def: $x1
-; CHECK-O0-AARCH64-NEXT:    str x0, [sp] ; 8-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    str x0, [sp, #8] ; 8-byte Folded Spill
 ; CHECK-O0-AARCH64-NEXT:    mov x21, xzr
-; CHECK-O0-AARCH64-NEXT:    add x8, sp, #24
+; CHECK-O0-AARCH64-NEXT:    add x8, sp, #40
 ; CHECK-O0-AARCH64-NEXT:    mov w0, #1
 ; CHECK-O0-AARCH64-NEXT:    bl _foo_sret
-; CHECK-O0-AARCH64-NEXT:    str x21, [sp, #8] ; 8-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    str x21, [sp, #16] ; 8-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    mov x0, x21
+; CHECK-O0-AARCH64-NEXT:    str x0, [sp, #24] ; 8-byte Folded Spill
 ; CHECK-O0-AARCH64-NEXT:    cbnz x21, LBB6_2
 ; CHECK-O0-AARCH64-NEXT:  ; %bb.1: ; %cont
-; CHECK-O0-AARCH64-NEXT:    ldr x9, [sp] ; 8-byte Folded Reload
-; CHECK-O0-AARCH64-NEXT:    ldr x8, [sp, #8] ; 8-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    ldr x9, [sp, #8] ; 8-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    ldr x8, [sp, #16] ; 8-byte Folded Reload
 ; CHECK-O0-AARCH64-NEXT:    ldrb w8, [x8, #8]
 ; CHECK-O0-AARCH64-NEXT:    strb w8, [x9]
 ; CHECK-O0-AARCH64-NEXT:  LBB6_2: ; %handler
-; CHECK-O0-AARCH64-NEXT:    ldr x0, [sp, #8] ; 8-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    ldr x0, [sp, #24] ; 8-byte Folded Reload
 ; CHECK-O0-AARCH64-NEXT:    bl _free
 ; CHECK-O0-AARCH64-NEXT:    fmov s0, #1.00000000
-; CHECK-O0-AARCH64-NEXT:    ldp x29, x30, [sp, #64] ; 16-byte Folded Reload
-; CHECK-O0-AARCH64-NEXT:    ldp x22, x21, [sp, #48] ; 16-byte Folded Reload
-; CHECK-O0-AARCH64-NEXT:    add sp, sp, #80
+; CHECK-O0-AARCH64-NEXT:    ldp x29, x30, [sp, #80] ; 16-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    ldp x22, x21, [sp, #64] ; 16-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    add sp, sp, #96
 ; CHECK-O0-AARCH64-NEXT:    ret
 ;
 ; CHECK-APPLE-ARM64_32-LABEL: caller3:
@@ -865,36 +875,38 @@ define float @caller3(i8* %error_ref) {
 ;
 ; CHECK-O0-ARM64_32-LABEL: caller3:
 ; CHECK-O0-ARM64_32:       ; %bb.0: ; %entry
-; CHECK-O0-ARM64_32-NEXT:    sub sp, sp, #80
-; CHECK-O0-ARM64_32-NEXT:    .cfi_def_cfa_offset 80
-; CHECK-O0-ARM64_32-NEXT:    stp x22, x21, [sp, #48] ; 16-byte Folded Spill
-; CHECK-O0-ARM64_32-NEXT:    stp x29, x30, [sp, #64] ; 16-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    sub sp, sp, #96
+; CHECK-O0-ARM64_32-NEXT:    .cfi_def_cfa_offset 96
+; CHECK-O0-ARM64_32-NEXT:    stp x22, x21, [sp, #64] ; 16-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    stp x29, x30, [sp, #80] ; 16-byte Folded Spill
 ; CHECK-O0-ARM64_32-NEXT:    .cfi_offset w30, -8
 ; CHECK-O0-ARM64_32-NEXT:    .cfi_offset w29, -16
 ; CHECK-O0-ARM64_32-NEXT:    .cfi_offset w21, -24
 ; CHECK-O0-ARM64_32-NEXT:    .cfi_offset w22, -32
 ; CHECK-O0-ARM64_32-NEXT:    ; implicit-def: $x1
-; CHECK-O0-ARM64_32-NEXT:    str x0, [sp] ; 8-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    str x0, [sp, #8] ; 8-byte Folded Spill
 ; CHECK-O0-ARM64_32-NEXT:    mov x21, xzr
-; CHECK-O0-ARM64_32-NEXT:    add x8, sp, #24
+; CHECK-O0-ARM64_32-NEXT:    add x8, sp, #40
 ; CHECK-O0-ARM64_32-NEXT:    mov w0, #1
 ; CHECK-O0-ARM64_32-NEXT:    bl _foo_sret
-; CHECK-O0-ARM64_32-NEXT:    str x21, [sp, #8] ; 8-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    str x21, [sp, #16] ; 8-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    mov x0, x21
+; CHECK-O0-ARM64_32-NEXT:    str x0, [sp, #24] ; 8-byte Folded Spill
 ; CHECK-O0-ARM64_32-NEXT:    cmp x21, #0
 ; CHECK-O0-ARM64_32-NEXT:    b.ne LBB6_2
 ; CHECK-O0-ARM64_32-NEXT:  ; %bb.1: ; %cont
-; CHECK-O0-ARM64_32-NEXT:    ldr x9, [sp] ; 8-byte Folded Reload
-; CHECK-O0-ARM64_32-NEXT:    ldr x8, [sp, #8] ; 8-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    ldr x9, [sp, #8] ; 8-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    ldr x8, [sp, #16] ; 8-byte Folded Reload
 ; CHECK-O0-ARM64_32-NEXT:    ldrb w8, [x8, #8]
 ; CHECK-O0-ARM64_32-NEXT:    ; kill: def $w0 killed $w8
 ; CHECK-O0-ARM64_32-NEXT:    strb w8, [x9]
 ; CHECK-O0-ARM64_32-NEXT:  LBB6_2: ; %handler
-; CHECK-O0-ARM64_32-NEXT:    ldr x0, [sp, #8] ; 8-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    ldr x0, [sp, #24] ; 8-byte Folded Reload
 ; CHECK-O0-ARM64_32-NEXT:    bl _free
 ; CHECK-O0-ARM64_32-NEXT:    fmov s0, #1.00000000
-; CHECK-O0-ARM64_32-NEXT:    ldp x29, x30, [sp, #64] ; 16-byte Folded Reload
-; CHECK-O0-ARM64_32-NEXT:    ldp x22, x21, [sp, #48] ; 16-byte Folded Reload
-; CHECK-O0-ARM64_32-NEXT:    add sp, sp, #80
+; CHECK-O0-ARM64_32-NEXT:    ldp x29, x30, [sp, #80] ; 16-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    ldp x22, x21, [sp, #64] ; 16-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    add sp, sp, #96
 ; CHECK-O0-ARM64_32-NEXT:    ret
 ; Access part of the error object and save it to error_ref
 
@@ -1133,18 +1145,18 @@ define float @caller4(i8* %error_ref) {
 ;
 ; CHECK-O0-AARCH64-LABEL: caller4:
 ; CHECK-O0-AARCH64:       ; %bb.0: ; %entry
-; CHECK-O0-AARCH64-NEXT:    sub sp, sp, #96
-; CHECK-O0-AARCH64-NEXT:    .cfi_def_cfa_offset 96
-; CHECK-O0-AARCH64-NEXT:    stp x22, x21, [sp, #64] ; 16-byte Folded Spill
-; CHECK-O0-AARCH64-NEXT:    stp x29, x30, [sp, #80] ; 16-byte Folded Spill
-; CHECK-O0-AARCH64-NEXT:    add x29, sp, #80
+; CHECK-O0-AARCH64-NEXT:    sub sp, sp, #112
+; CHECK-O0-AARCH64-NEXT:    .cfi_def_cfa_offset 112
+; CHECK-O0-AARCH64-NEXT:    stp x22, x21, [sp, #80] ; 16-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    stp x29, x30, [sp, #96] ; 16-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    add x29, sp, #96
 ; CHECK-O0-AARCH64-NEXT:    .cfi_def_cfa w29, 16
 ; CHECK-O0-AARCH64-NEXT:    .cfi_offset w30, -8
 ; CHECK-O0-AARCH64-NEXT:    .cfi_offset w29, -16
 ; CHECK-O0-AARCH64-NEXT:    .cfi_offset w21, -24
 ; CHECK-O0-AARCH64-NEXT:    .cfi_offset w22, -32
 ; CHECK-O0-AARCH64-NEXT:    ; implicit-def: $x1
-; CHECK-O0-AARCH64-NEXT:    str x0, [sp, #24] ; 8-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    str x0, [sp, #32] ; 8-byte Folded Spill
 ; CHECK-O0-AARCH64-NEXT:    mov x21, xzr
 ; CHECK-O0-AARCH64-NEXT:    mov w8, #10
 ; CHECK-O0-AARCH64-NEXT:    stur w8, [x29, #-28]
@@ -1163,20 +1175,22 @@ define float @caller4(i8* %error_ref) {
 ; CHECK-O0-AARCH64-NEXT:    str x10, [x9, #8]
 ; CHECK-O0-AARCH64-NEXT:    str x8, [x9]
 ; CHECK-O0-AARCH64-NEXT:    bl _foo_vararg
-; CHECK-O0-AARCH64-NEXT:    str x21, [sp, #32] ; 8-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    str x21, [sp, #40] ; 8-byte Folded Spill
+; CHECK-O0-AARCH64-NEXT:    mov x0, x21
+; CHECK-O0-AARCH64-NEXT:    str x0, [sp, #48] ; 8-byte Folded Spill
 ; CHECK-O0-AARCH64-NEXT:    cbnz x21, LBB8_2
 ; CHECK-O0-AARCH64-NEXT:  ; %bb.1: ; %cont
-; CHECK-O0-AARCH64-NEXT:    ldr x9, [sp, #24] ; 8-byte Folded Reload
-; CHECK-O0-AARCH64-NEXT:    ldr x8, [sp, #32] ; 8-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    ldr x9, [sp, #32] ; 8-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    ldr x8, [sp, #40] ; 8-byte Folded Reload
 ; CHECK-O0-AARCH64-NEXT:    ldrb w8, [x8, #8]
 ; CHECK-O0-AARCH64-NEXT:    strb w8, [x9]
 ; CHECK-O0-AARCH64-NEXT:  LBB8_2: ; %handler
-; CHECK-O0-AARCH64-NEXT:    ldr x0, [sp, #32] ; 8-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    ldr x0, [sp, #48] ; 8-byte Folded Reload
 ; CHECK-O0-AARCH64-NEXT:    bl _free
 ; CHECK-O0-AARCH64-NEXT:    fmov s0, #1.00000000
-; CHECK-O0-AARCH64-NEXT:    ldp x29, x30, [sp, #80] ; 16-byte Folded Reload
-; CHECK-O0-AARCH64-NEXT:    ldp x22, x21, [sp, #64] ; 16-byte Folded Reload
-; CHECK-O0-AARCH64-NEXT:    add sp, sp, #96
+; CHECK-O0-AARCH64-NEXT:    ldp x29, x30, [sp, #96] ; 16-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    ldp x22, x21, [sp, #80] ; 16-byte Folded Reload
+; CHECK-O0-AARCH64-NEXT:    add sp, sp, #112
 ; CHECK-O0-AARCH64-NEXT:    ret
 ;
 ; CHECK-APPLE-ARM64_32-LABEL: caller4:
@@ -1222,47 +1236,49 @@ define float @caller4(i8* %error_ref) {
 ;
 ; CHECK-O0-ARM64_32-LABEL: caller4:
 ; CHECK-O0-ARM64_32:       ; %bb.0: ; %entry
-; CHECK-O0-ARM64_32-NEXT:    sub sp, sp, #80
-; CHECK-O0-ARM64_32-NEXT:    .cfi_def_cfa_offset 80
-; CHECK-O0-ARM64_32-NEXT:    stp x22, x21, [sp, #48] ; 16-byte Folded Spill
-; CHECK-O0-ARM64_32-NEXT:    stp x29, x30, [sp, #64] ; 16-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    sub sp, sp, #96
+; CHECK-O0-ARM64_32-NEXT:    .cfi_def_cfa_offset 96
+; CHECK-O0-ARM64_32-NEXT:    stp x22, x21, [sp, #64] ; 16-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    stp x29, x30, [sp, #80] ; 16-byte Folded Spill
 ; CHECK-O0-ARM64_32-NEXT:    .cfi_offset w30, -8
 ; CHECK-O0-ARM64_32-NEXT:    .cfi_offset w29, -16
 ; CHECK-O0-ARM64_32-NEXT:    .cfi_offset w21, -24
 ; CHECK-O0-ARM64_32-NEXT:    .cfi_offset w22, -32
 ; CHECK-O0-ARM64_32-NEXT:    ; implicit-def: $x1
-; CHECK-O0-ARM64_32-NEXT:    str x0, [sp, #16] ; 8-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    str x0, [sp, #24] ; 8-byte Folded Spill
 ; CHECK-O0-ARM64_32-NEXT:    mov x21, xzr
 ; CHECK-O0-ARM64_32-NEXT:    mov w8, #10
-; CHECK-O0-ARM64_32-NEXT:    str w8, [sp, #40]
+; CHECK-O0-ARM64_32-NEXT:    str w8, [sp, #56]
 ; CHECK-O0-ARM64_32-NEXT:    mov w8, #11
-; CHECK-O0-ARM64_32-NEXT:    str w8, [sp, #36]
+; CHECK-O0-ARM64_32-NEXT:    str w8, [sp, #52]
 ; CHECK-O0-ARM64_32-NEXT:    mov w8, #12
-; CHECK-O0-ARM64_32-NEXT:    str w8, [sp, #32]
-; CHECK-O0-ARM64_32-NEXT:    ldr w8, [sp, #40]
-; CHECK-O0-ARM64_32-NEXT:    ldr w10, [sp, #36]
-; CHECK-O0-ARM64_32-NEXT:    ldr w11, [sp, #32]
+; CHECK-O0-ARM64_32-NEXT:    str w8, [sp, #48]
+; CHECK-O0-ARM64_32-NEXT:    ldr w8, [sp, #56]
+; CHECK-O0-ARM64_32-NEXT:    ldr w10, [sp, #52]
+; CHECK-O0-ARM64_32-NEXT:    ldr w11, [sp, #48]
 ; CHECK-O0-ARM64_32-NEXT:    mov x9, sp
 ; CHECK-O0-ARM64_32-NEXT:    str w11, [x9, #8]
 ; CHECK-O0-ARM64_32-NEXT:    str w10, [x9, #4]
 ; CHECK-O0-ARM64_32-NEXT:    str w8, [x9]
 ; CHECK-O0-ARM64_32-NEXT:    bl _foo_vararg
-; CHECK-O0-ARM64_32-NEXT:    str x21, [sp, #24] ; 8-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    str x21, [sp, #32] ; 8-byte Folded Spill
+; CHECK-O0-ARM64_32-NEXT:    mov x0, x21
+; CHECK-O0-ARM64_32-NEXT:    str x0, [sp, #40] ; 8-byte Folded Spill
 ; CHECK-O0-ARM64_32-NEXT:    cmp x21, #0
 ; CHECK-O0-ARM64_32-NEXT:    b.ne LBB8_2
 ; CHECK-O0-ARM64_32-NEXT:  ; %bb.1: ; %cont
-; CHECK-O0-ARM64_32-NEXT:    ldr x9, [sp, #16] ; 8-byte Folded Reload
-; CHECK-O0-ARM64_32-NEXT:    ldr x8, [sp, #24] ; 8-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    ldr x9, [sp, #24] ; 8-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    ldr x8, [sp, #32] ; 8-byte Folded Reload
 ; CHECK-O0-ARM64_32-NEXT:    ldrb w8, [x8, #8]
 ; CHECK-O0-ARM64_32-NEXT:    ; kill: def $w0 killed $w8
 ; CHECK-O0-ARM64_32-NEXT:    strb w8, [x9]
 ; CHECK-O0-ARM64_32-NEXT:  LBB8_2: ; %handler
-; CHECK-O0-ARM64_32-NEXT:    ldr x0, [sp, #24] ; 8-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    ldr x0, [sp, #40] ; 8-byte Folded Reload
 ; CHECK-O0-ARM64_32-NEXT:    bl _free
 ; CHECK-O0-ARM64_32-NEXT:    fmov s0, #1.00000000
-; CHECK-O0-ARM64_32-NEXT:    ldp x29, x30, [sp, #64] ; 16-byte Folded Reload
-; CHECK-O0-ARM64_32-NEXT:    ldp x22, x21, [sp, #48] ; 16-byte Folded Reload
-; CHECK-O0-ARM64_32-NEXT:    add sp, sp, #80
+; CHECK-O0-ARM64_32-NEXT:    ldp x29, x30, [sp, #80] ; 16-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    ldp x22, x21, [sp, #64] ; 16-byte Folded Reload
+; CHECK-O0-ARM64_32-NEXT:    add sp, sp, #96
 ; CHECK-O0-ARM64_32-NEXT:    ret
 
 

--- a/llvm/test/CodeGen/ARM/swifterror.ll
+++ b/llvm/test/CodeGen/ARM/swifterror.ll
@@ -83,12 +83,14 @@ define float @caller(i8* %error_ref) {
 ; CHECK-O0-NEXT:    push {r7, lr}
 ; CHECK-O0-NEXT:    mov r7, sp
 ; CHECK-O0-NEXT:    push {r8}
-; CHECK-O0-NEXT:    sub sp, sp, #12
+; CHECK-O0-NEXT:    sub sp, sp, #16
 ; CHECK-O0-NEXT:    @ implicit-def: $r1
 ; CHECK-O0-NEXT:    str r0, [sp] @ 4-byte Spill
 ; CHECK-O0-NEXT:    mov r8, #0
 ; CHECK-O0-NEXT:    bl _foo
 ; CHECK-O0-NEXT:    str r8, [sp, #4] @ 4-byte Spill
+; CHECK-O0-NEXT:    mov r0, r8
+; CHECK-O0-NEXT:    str r0, [sp, #8] @ 4-byte Spill
 ; CHECK-O0-NEXT:    movw r0, #0
 ; CHECK-O0-NEXT:    cmp r8, r0
 ; CHECK-O0-NEXT:    bne LBB1_2
@@ -98,7 +100,7 @@ define float @caller(i8* %error_ref) {
 ; CHECK-O0-NEXT:    ldrb r0, [r0, #8]
 ; CHECK-O0-NEXT:    strb r0, [r1]
 ; CHECK-O0-NEXT:  LBB1_2: @ %handler
-; CHECK-O0-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
+; CHECK-O0-NEXT:    ldr r0, [sp, #8] @ 4-byte Reload
 ; CHECK-O0-NEXT:    bl _free
 ; CHECK-O0-NEXT:    mov r0, #1065353216
 ; CHECK-O0-NEXT:    sub sp, r7, #4
@@ -181,9 +183,9 @@ define float @caller2(i8* %error_ref) {
 ; CHECK-O0-NEXT:    push {r7, lr}
 ; CHECK-O0-NEXT:    mov r7, sp
 ; CHECK-O0-NEXT:    push {r8}
-; CHECK-O0-NEXT:    sub sp, sp, #16
+; CHECK-O0-NEXT:    sub sp, sp, #20
 ; CHECK-O0-NEXT:    @ implicit-def: $r1
-; CHECK-O0-NEXT:    str r0, [sp, #8] @ 4-byte Spill
+; CHECK-O0-NEXT:    str r0, [sp, #12] @ 4-byte Spill
 ; CHECK-O0-NEXT:  LBB2_1: @ %bb_loop
 ; CHECK-O0-NEXT:    @ =>This Inner Loop Header: Depth=1
 ; CHECK-O0-NEXT:    mov r8, #0
@@ -191,6 +193,8 @@ define float @caller2(i8* %error_ref) {
 ; CHECK-O0-NEXT:    vmov s0, r0
 ; CHECK-O0-NEXT:    vstr s0, [sp] @ 4-byte Spill
 ; CHECK-O0-NEXT:    str r8, [sp, #4] @ 4-byte Spill
+; CHECK-O0-NEXT:    mov r0, r8
+; CHECK-O0-NEXT:    str r0, [sp, #8] @ 4-byte Spill
 ; CHECK-O0-NEXT:    movw r0, #0
 ; CHECK-O0-NEXT:    cmp r8, r0
 ; CHECK-O0-NEXT:    bne LBB2_4
@@ -202,12 +206,12 @@ define float @caller2(i8* %error_ref) {
 ; CHECK-O0-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-O0-NEXT:    ble LBB2_1
 ; CHECK-O0-NEXT:  @ %bb.3: @ %bb_end
-; CHECK-O0-NEXT:    ldr r1, [sp, #8] @ 4-byte Reload
+; CHECK-O0-NEXT:    ldr r1, [sp, #12] @ 4-byte Reload
 ; CHECK-O0-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
 ; CHECK-O0-NEXT:    ldrb r0, [r0, #8]
 ; CHECK-O0-NEXT:    strb r0, [r1]
 ; CHECK-O0-NEXT:  LBB2_4: @ %handler
-; CHECK-O0-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
+; CHECK-O0-NEXT:    ldr r0, [sp, #8] @ 4-byte Reload
 ; CHECK-O0-NEXT:    bl _free
 ; CHECK-O0-NEXT:    mov r0, #1065353216
 ; CHECK-O0-NEXT:    sub sp, r7, #4
@@ -600,18 +604,20 @@ define float @caller3(i8* %error_ref) {
 ; CHECK-O0-NEXT:    sub sp, sp, #44
 ; CHECK-O0-NEXT:    bfc sp, #0, #3
 ; CHECK-O0-NEXT:    @ implicit-def: $r1
-; CHECK-O0-NEXT:    str r0, [sp, #4] @ 4-byte Spill
+; CHECK-O0-NEXT:    str r0, [sp] @ 4-byte Spill
 ; CHECK-O0-NEXT:    mov r8, #0
 ; CHECK-O0-NEXT:    add r0, sp, #16
 ; CHECK-O0-NEXT:    mov r1, #1
 ; CHECK-O0-NEXT:    bl _foo_sret
-; CHECK-O0-NEXT:    str r8, [sp, #8] @ 4-byte Spill
+; CHECK-O0-NEXT:    str r8, [sp, #4] @ 4-byte Spill
+; CHECK-O0-NEXT:    mov r0, r8
+; CHECK-O0-NEXT:    str r0, [sp, #8] @ 4-byte Spill
 ; CHECK-O0-NEXT:    movw r0, #0
 ; CHECK-O0-NEXT:    cmp r8, r0
 ; CHECK-O0-NEXT:    bne LBB6_2
 ; CHECK-O0-NEXT:  @ %bb.1: @ %cont
-; CHECK-O0-NEXT:    ldr r1, [sp, #4] @ 4-byte Reload
-; CHECK-O0-NEXT:    ldr r0, [sp, #8] @ 4-byte Reload
+; CHECK-O0-NEXT:    ldr r1, [sp] @ 4-byte Reload
+; CHECK-O0-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
 ; CHECK-O0-NEXT:    ldrb r0, [r0, #8]
 ; CHECK-O0-NEXT:    strb r0, [r1]
 ; CHECK-O0-NEXT:  LBB6_2: @ %handler
@@ -822,21 +828,23 @@ define float @caller4(i8* %error_ref) {
 ; CHECK-O0-NEXT:    push {r7, lr}
 ; CHECK-O0-NEXT:    mov r7, sp
 ; CHECK-O0-NEXT:    push {r8}
-; CHECK-O0-NEXT:    sub sp, sp, #24
+; CHECK-O0-NEXT:    sub sp, sp, #28
 ; CHECK-O0-NEXT:    @ implicit-def: $r1
 ; CHECK-O0-NEXT:    str r0, [sp] @ 4-byte Spill
 ; CHECK-O0-NEXT:    mov r8, #0
 ; CHECK-O0-NEXT:    mov r0, #10
 ; CHECK-O0-NEXT:    str r0, [r7, #-12]
 ; CHECK-O0-NEXT:    mov r0, #11
-; CHECK-O0-NEXT:    str r0, [sp, #12]
+; CHECK-O0-NEXT:    str r0, [sp, #16]
 ; CHECK-O0-NEXT:    mov r0, #12
-; CHECK-O0-NEXT:    str r0, [sp, #8]
+; CHECK-O0-NEXT:    str r0, [sp, #12]
 ; CHECK-O0-NEXT:    ldr r0, [r7, #-12]
-; CHECK-O0-NEXT:    ldr r1, [sp, #12]
-; CHECK-O0-NEXT:    ldr r2, [sp, #8]
+; CHECK-O0-NEXT:    ldr r1, [sp, #16]
+; CHECK-O0-NEXT:    ldr r2, [sp, #12]
 ; CHECK-O0-NEXT:    bl _foo_vararg
 ; CHECK-O0-NEXT:    str r8, [sp, #4] @ 4-byte Spill
+; CHECK-O0-NEXT:    mov r0, r8
+; CHECK-O0-NEXT:    str r0, [sp, #8] @ 4-byte Spill
 ; CHECK-O0-NEXT:    movw r0, #0
 ; CHECK-O0-NEXT:    cmp r8, r0
 ; CHECK-O0-NEXT:    bne LBB8_2
@@ -846,7 +854,7 @@ define float @caller4(i8* %error_ref) {
 ; CHECK-O0-NEXT:    ldrb r0, [r0, #8]
 ; CHECK-O0-NEXT:    strb r0, [r1]
 ; CHECK-O0-NEXT:  LBB8_2: @ %handler
-; CHECK-O0-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
+; CHECK-O0-NEXT:    ldr r0, [sp, #8] @ 4-byte Reload
 ; CHECK-O0-NEXT:    bl _free
 ; CHECK-O0-NEXT:    mov r0, #1065353216
 ; CHECK-O0-NEXT:    sub sp, r7, #4

--- a/llvm/test/CodeGen/X86/atomic64.ll
+++ b/llvm/test/CodeGen/X86/atomic64.ll
@@ -18,18 +18,21 @@ define void @atomic_fetch_add64() nounwind {
 ; I486-LABEL: atomic_fetch_add64:
 ; I486:       # %bb.0: # %entry
 ; I486-NEXT:    subl $16, %esp
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl $2, 12(%eax)
 ; I486-NEXT:    movl $0, 8(%eax)
 ; I486-NEXT:    movl $1, 4(%eax)
 ; I486-NEXT:    movl $sc64, (%eax)
 ; I486-NEXT:    calll __atomic_fetch_add_8@PLT
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl $2, 12(%eax)
 ; I486-NEXT:    movl $0, 8(%eax)
 ; I486-NEXT:    movl $3, 4(%eax)
 ; I486-NEXT:    movl $sc64, (%eax)
 ; I486-NEXT:    calll __atomic_fetch_add_8@PLT
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl $2, 12(%eax)
 ; I486-NEXT:    movl $0, 8(%eax)
@@ -37,6 +40,7 @@ define void @atomic_fetch_add64() nounwind {
 ; I486-NEXT:    movl $sc64, (%eax)
 ; I486-NEXT:    calll __atomic_fetch_add_8@PLT
 ; I486-NEXT:    movl %eax, %ecx
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl %edx, 8(%eax)
 ; I486-NEXT:    movl %ecx, 4(%eax)
@@ -66,18 +70,21 @@ define void @atomic_fetch_sub64() nounwind {
 ; I486-LABEL: atomic_fetch_sub64:
 ; I486:       # %bb.0:
 ; I486-NEXT:    subl $16, %esp
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl $2, 12(%eax)
 ; I486-NEXT:    movl $0, 8(%eax)
 ; I486-NEXT:    movl $1, 4(%eax)
 ; I486-NEXT:    movl $sc64, (%eax)
 ; I486-NEXT:    calll __atomic_fetch_sub_8@PLT
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl $2, 12(%eax)
 ; I486-NEXT:    movl $0, 8(%eax)
 ; I486-NEXT:    movl $3, 4(%eax)
 ; I486-NEXT:    movl $sc64, (%eax)
 ; I486-NEXT:    calll __atomic_fetch_sub_8@PLT
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl $2, 12(%eax)
 ; I486-NEXT:    movl $0, 8(%eax)
@@ -85,6 +92,7 @@ define void @atomic_fetch_sub64() nounwind {
 ; I486-NEXT:    movl $sc64, (%eax)
 ; I486-NEXT:    calll __atomic_fetch_sub_8@PLT
 ; I486-NEXT:    movl %eax, %ecx
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl %edx, 8(%eax)
 ; I486-NEXT:    movl %ecx, 4(%eax)
@@ -127,12 +135,14 @@ define void @atomic_fetch_and64() nounwind {
 ; I486-LABEL: atomic_fetch_and64:
 ; I486:       # %bb.0:
 ; I486-NEXT:    subl $16, %esp
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl $2, 12(%eax)
 ; I486-NEXT:    movl $0, 8(%eax)
 ; I486-NEXT:    movl $3, 4(%eax)
 ; I486-NEXT:    movl $sc64, (%eax)
 ; I486-NEXT:    calll __atomic_fetch_and_8@PLT
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl $2, 12(%eax)
 ; I486-NEXT:    movl $0, 8(%eax)
@@ -140,6 +150,7 @@ define void @atomic_fetch_and64() nounwind {
 ; I486-NEXT:    movl $sc64, (%eax)
 ; I486-NEXT:    calll __atomic_fetch_and_8@PLT
 ; I486-NEXT:    movl %eax, %ecx
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl %edx, 8(%eax)
 ; I486-NEXT:    movl %ecx, 4(%eax)
@@ -180,12 +191,14 @@ define void @atomic_fetch_or64() nounwind {
 ; I486-LABEL: atomic_fetch_or64:
 ; I486:       # %bb.0:
 ; I486-NEXT:    subl $16, %esp
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl $2, 12(%eax)
 ; I486-NEXT:    movl $0, 8(%eax)
 ; I486-NEXT:    movl $3, 4(%eax)
 ; I486-NEXT:    movl $sc64, (%eax)
 ; I486-NEXT:    calll __atomic_fetch_or_8@PLT
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl $2, 12(%eax)
 ; I486-NEXT:    movl $0, 8(%eax)
@@ -193,6 +206,7 @@ define void @atomic_fetch_or64() nounwind {
 ; I486-NEXT:    movl $sc64, (%eax)
 ; I486-NEXT:    calll __atomic_fetch_or_8@PLT
 ; I486-NEXT:    movl %eax, %ecx
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl %edx, 8(%eax)
 ; I486-NEXT:    movl %ecx, 4(%eax)
@@ -233,12 +247,14 @@ define void @atomic_fetch_xor64() nounwind {
 ; I486-LABEL: atomic_fetch_xor64:
 ; I486:       # %bb.0:
 ; I486-NEXT:    subl $16, %esp
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl $2, 12(%eax)
 ; I486-NEXT:    movl $0, 8(%eax)
 ; I486-NEXT:    movl $3, 4(%eax)
 ; I486-NEXT:    movl $sc64, (%eax)
 ; I486-NEXT:    calll __atomic_fetch_xor_8@PLT
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl $2, 12(%eax)
 ; I486-NEXT:    movl $0, 8(%eax)
@@ -246,6 +262,7 @@ define void @atomic_fetch_xor64() nounwind {
 ; I486-NEXT:    movl $sc64, (%eax)
 ; I486-NEXT:    calll __atomic_fetch_xor_8@PLT
 ; I486-NEXT:    movl %eax, %ecx
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl %edx, 8(%eax)
 ; I486-NEXT:    movl %ecx, 4(%eax)
@@ -288,6 +305,7 @@ define void @atomic_fetch_nand64(i64 %x) nounwind {
 ; I486-NEXT:    subl $16, %esp
 ; I486-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I486-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl %edx, 8(%eax)
 ; I486-NEXT:    movl %ecx, 4(%eax)
@@ -690,6 +708,7 @@ define void @atomic_fetch_cmpxchg64() nounwind {
 ; I486-NEXT:    leal {{[0-9]+}}(%esp), %ecx
 ; I486-NEXT:    movl $0, {{[0-9]+}}(%esp)
 ; I486-NEXT:    movl $0, {{[0-9]+}}(%esp)
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl %ecx, 4(%eax)
 ; I486-NEXT:    movl $2, 20(%eax)
@@ -716,6 +735,7 @@ define void @atomic_fetch_store64(i64 %x) nounwind {
 ; I486-NEXT:    subl $16, %esp
 ; I486-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I486-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl %edx, 8(%eax)
 ; I486-NEXT:    movl %ecx, 4(%eax)
@@ -739,6 +759,7 @@ define void @atomic_fetch_swap64(i64 %x) nounwind {
 ; I486-NEXT:    subl $16, %esp
 ; I486-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I486-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; I486-NEXT:    leal sc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl %edx, 8(%eax)
 ; I486-NEXT:    movl %ecx, 4(%eax)
@@ -768,6 +789,7 @@ define void @atomic_fetch_swapf64(double %x) nounwind {
 ; I486-NEXT:    fstpl {{[0-9]+}}(%esp)
 ; I486-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; I486-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; I486-NEXT:    leal fsc64, %eax
 ; I486-NEXT:    movl %esp, %eax
 ; I486-NEXT:    movl %edx, 8(%eax)
 ; I486-NEXT:    movl %ecx, 4(%eax)

--- a/llvm/test/CodeGen/X86/swifterror.ll
+++ b/llvm/test/CodeGen/X86/swifterror.ll
@@ -98,15 +98,17 @@ define float @caller(i8* %error_ref) {
 ; CHECK-O0-NEXT:    .cfi_def_cfa_offset 48
 ; CHECK-O0-NEXT:    .cfi_offset %r12, -16
 ; CHECK-O0-NEXT:    ## implicit-def: $rax
-; CHECK-O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) ## 8-byte Spill
+; CHECK-O0-NEXT:    movq %rdi, (%rsp) ## 8-byte Spill
 ; CHECK-O0-NEXT:    xorl %eax, %eax
 ; CHECK-O0-NEXT:    movl %eax, %r12d
 ; CHECK-O0-NEXT:    callq _foo
 ; CHECK-O0-NEXT:    movq %r12, {{[-0-9]+}}(%r{{[sb]}}p) ## 8-byte Spill
+; CHECK-O0-NEXT:    movq %r12, %rax
+; CHECK-O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) ## 8-byte Spill
 ; CHECK-O0-NEXT:    cmpq $0, %r12
 ; CHECK-O0-NEXT:    jne LBB1_2
 ; CHECK-O0-NEXT:  ## %bb.1: ## %cont
-; CHECK-O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax ## 8-byte Reload
+; CHECK-O0-NEXT:    movq (%rsp), %rax ## 8-byte Reload
 ; CHECK-O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx ## 8-byte Reload
 ; CHECK-O0-NEXT:    movb 8(%rcx), %cl
 ; CHECK-O0-NEXT:    movb %cl, (%rax)
@@ -199,8 +201,8 @@ define float @caller2(i8* %error_ref) {
 ; CHECK-O0:       ## %bb.0: ## %entry
 ; CHECK-O0-NEXT:    pushq %r12
 ; CHECK-O0-NEXT:    .cfi_def_cfa_offset 16
-; CHECK-O0-NEXT:    subq $32, %rsp
-; CHECK-O0-NEXT:    .cfi_def_cfa_offset 48
+; CHECK-O0-NEXT:    subq $48, %rsp
+; CHECK-O0-NEXT:    .cfi_def_cfa_offset 64
 ; CHECK-O0-NEXT:    .cfi_offset %r12, -16
 ; CHECK-O0-NEXT:    ## implicit-def: $rax
 ; CHECK-O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) ## 8-byte Spill
@@ -211,6 +213,8 @@ define float @caller2(i8* %error_ref) {
 ; CHECK-O0-NEXT:    callq _foo
 ; CHECK-O0-NEXT:    movss %xmm0, {{[-0-9]+}}(%r{{[sb]}}p) ## 4-byte Spill
 ; CHECK-O0-NEXT:    movq %r12, {{[-0-9]+}}(%r{{[sb]}}p) ## 8-byte Spill
+; CHECK-O0-NEXT:    movq %r12, %rax
+; CHECK-O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) ## 8-byte Spill
 ; CHECK-O0-NEXT:    cmpq $0, %r12
 ; CHECK-O0-NEXT:    jne LBB2_4
 ; CHECK-O0-NEXT:  ## %bb.2: ## %cont
@@ -229,7 +233,7 @@ define float @caller2(i8* %error_ref) {
 ; CHECK-O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rdi ## 8-byte Reload
 ; CHECK-O0-NEXT:    callq _free
 ; CHECK-O0-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
-; CHECK-O0-NEXT:    addq $32, %rsp
+; CHECK-O0-NEXT:    addq $48, %rsp
 ; CHECK-O0-NEXT:    popq %r12
 ; CHECK-O0-NEXT:    retq
 ;
@@ -652,21 +656,23 @@ define float @caller3(i8* %error_ref) {
 ; CHECK-O0:       ## %bb.0: ## %entry
 ; CHECK-O0-NEXT:    pushq %r12
 ; CHECK-O0-NEXT:    .cfi_def_cfa_offset 16
-; CHECK-O0-NEXT:    subq $48, %rsp
-; CHECK-O0-NEXT:    .cfi_def_cfa_offset 64
+; CHECK-O0-NEXT:    subq $64, %rsp
+; CHECK-O0-NEXT:    .cfi_def_cfa_offset 80
 ; CHECK-O0-NEXT:    .cfi_offset %r12, -16
 ; CHECK-O0-NEXT:    ## implicit-def: $rax
-; CHECK-O0-NEXT:    movq %rdi, (%rsp) ## 8-byte Spill
+; CHECK-O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) ## 8-byte Spill
 ; CHECK-O0-NEXT:    xorl %eax, %eax
 ; CHECK-O0-NEXT:    movl %eax, %r12d
-; CHECK-O0-NEXT:    leaq 24(%rsp), %rdi
+; CHECK-O0-NEXT:    leaq 40(%rsp), %rdi
 ; CHECK-O0-NEXT:    movl $1, %esi
 ; CHECK-O0-NEXT:    callq _foo_sret
 ; CHECK-O0-NEXT:    movq %r12, {{[-0-9]+}}(%r{{[sb]}}p) ## 8-byte Spill
+; CHECK-O0-NEXT:    movq %r12, %rax
+; CHECK-O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) ## 8-byte Spill
 ; CHECK-O0-NEXT:    cmpq $0, %r12
 ; CHECK-O0-NEXT:    jne LBB6_2
 ; CHECK-O0-NEXT:  ## %bb.1: ## %cont
-; CHECK-O0-NEXT:    movq (%rsp), %rax ## 8-byte Reload
+; CHECK-O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax ## 8-byte Reload
 ; CHECK-O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx ## 8-byte Reload
 ; CHECK-O0-NEXT:    movb 8(%rcx), %cl
 ; CHECK-O0-NEXT:    movb %cl, (%rax)
@@ -674,7 +680,7 @@ define float @caller3(i8* %error_ref) {
 ; CHECK-O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rdi ## 8-byte Reload
 ; CHECK-O0-NEXT:    callq _free
 ; CHECK-O0-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
-; CHECK-O0-NEXT:    addq $48, %rsp
+; CHECK-O0-NEXT:    addq $64, %rsp
 ; CHECK-O0-NEXT:    popq %r12
 ; CHECK-O0-NEXT:    retq
 ;
@@ -784,7 +790,7 @@ define float @caller_with_multiple_swifterror_values(i8* %error_ref, i8* %error_
 ; CHECK-O0-NEXT:    movq %rsp, %rbp
 ; CHECK-O0-NEXT:    .cfi_def_cfa_register %rbp
 ; CHECK-O0-NEXT:    pushq %r12
-; CHECK-O0-NEXT:    subq $40, %rsp
+; CHECK-O0-NEXT:    subq $56, %rsp
 ; CHECK-O0-NEXT:    .cfi_offset %r12, -24
 ; CHECK-O0-NEXT:    ## implicit-def: $rax
 ; CHECK-O0-NEXT:    ## implicit-def: $rax
@@ -794,6 +800,8 @@ define float @caller_with_multiple_swifterror_values(i8* %error_ref, i8* %error_
 ; CHECK-O0-NEXT:    movl %eax, %r12d
 ; CHECK-O0-NEXT:    callq _foo
 ; CHECK-O0-NEXT:    movq %r12, {{[-0-9]+}}(%r{{[sb]}}p) ## 8-byte Spill
+; CHECK-O0-NEXT:    movq %r12, %rax
+; CHECK-O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) ## 8-byte Spill
 ; CHECK-O0-NEXT:    cmpq $0, %r12
 ; CHECK-O0-NEXT:    jne LBB7_2
 ; CHECK-O0-NEXT:  ## %bb.1: ## %cont
@@ -811,6 +819,8 @@ define float @caller_with_multiple_swifterror_values(i8* %error_ref, i8* %error_
 ; CHECK-O0-NEXT:    movl %eax, %r12d
 ; CHECK-O0-NEXT:    callq _foo
 ; CHECK-O0-NEXT:    movq %r12, {{[-0-9]+}}(%r{{[sb]}}p) ## 8-byte Spill
+; CHECK-O0-NEXT:    movq %r12, %rax
+; CHECK-O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) ## 8-byte Spill
 ; CHECK-O0-NEXT:    cmpq $0, %r12
 ; CHECK-O0-NEXT:    jne LBB7_4
 ; CHECK-O0-NEXT:  ## %bb.3: ## %cont2


### PR DESCRIPTION
This reverts commit ff040eca93fb5700b30fc81cde9b8f9401c8da67, which
causes crashes on x86_64 with -verify-machineinstrs.

Resolves rdar://93109674.