### PR TITLE
Avoid writing dependency file twice with -fdepscan

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -85,13 +85,13 @@ static void updateCompilerInvocation(CompilerInvocation &Invocation,
   auto &FrontendOpts = Invocation.getFrontendOpts();
   FrontendOpts.CacheCompileJob = true; // FIXME: Don't set.
 
+  // Turn off dependency outputs. Should have already been emitted.
+  Invocation.getDependencyOutputOpts().OutputFile.clear();
+
   // If there are no mappings, we're done. Otherwise, continue and remap
   // everything.
   if (Mapper.getMappings().empty())
     return;
-
-  // Turn off dependency outputs. Should have already been emitted.
-  Invocation.getDependencyOutputOpts().OutputFile.clear();
 
   // Returns "false" on success, "true" if the path doesn't exist.
   auto remapInPlace = [&](std::string &S) -> bool {

--- a/clang/test/CAS/depscan.c
+++ b/clang/test/CAS/depscan.c
@@ -1,13 +1,16 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %clang -cc1depscan -fdepscan=inline -cc1-args -cc1 -triple x86_64-apple-macos11.0 -x c %s -o %s.o -fcas-path %t/cas 2>&1 | FileCheck %s -DPREFIX=%t
-// RUN: %clang -cc1depscan -fdepscan=inline -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %s.o -fcas-path %t/cas 2>&1 | FileCheck %s -DPREFIX=%t
+// RUN: %clang -cc1depscan -fdepscan=inline -cc1-args -cc1 -triple x86_64-apple-macos11.0 -x c %s -o %s.o -MT %s.o -dependency-file %t.d -fcas-path %t/cas 2>&1 | FileCheck %s -DPREFIX=%t
+// RUN: %clang -cc1depscan -fdepscan=inline -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %s.o -MT %s.o -dependency-file %t.d -fcas-path %t/cas 2>&1 | FileCheck %s -DPREFIX=%t
 //
 // Check that inline/daemon have identical output.
-// RUN: %clang -cc1depscan -o %t/inline.rsp -fdepscan=inline -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %s.o -fcas-path %t/cas
-// RUN: %clang -cc1depscan -o %t/daemon.rsp -fdepscan=daemon -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %s.o -fcas-path %t/cas
+// RUN: %clang -cc1depscan -o %t/inline.rsp -fdepscan=inline -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %s.o -MT %s.o -dependency-file %t/inline.d -fcas-path %t/cas
+// RUN: %clang -cc1depscan -o %t/daemon.rsp -fdepscan=daemon -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %s.o -MT %s.o -dependency-file %t/daemon.d -fcas-path %t/cas
 // RUN: diff %t/inline.rsp %t/daemon.rsp
+// RUN: diff %t/inline.d %t/daemon.d
 
 // CHECK: {{^}}"-cc1"
 // CHECK: "-fcas-path" "[[PREFIX]]/cas"
+// CHECK-NOT: dependency-file
+// CHECK-NOT: [[PREFIX]].d
 
 int test() { return 0; }


### PR DESCRIPTION
In some cases were were not clearing the output file during depscan,
leading to writing the .d file once during the scan and again during the
compilation. For now, only write it during the scan.

---

Note: the experimental libclang APIs for scanning do the opposite and only write the .d file during the compilation, not the scan.  But since neither behaviour is obviously correct to me, I'm just fixing it to be self-consistent here for now.