### PR TITLE
[CodeGen] Don't set the visibility of a ptrauth virtual member function pointer thunk to hidden if the thunk has internal linkage

### DIFF
--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -3218,7 +3218,8 @@ ItaniumCXXABI::getOrCreateVirtualFunctionPointerThunk(const CXXMethodDecl *MD) {
                                 : llvm::GlobalValue::InternalLinkage;
   ThunkFn =
       llvm::Function::Create(ThunkTy, Linkage, ThunkName, &CGM.getModule());
-  ThunkFn->setVisibility(llvm::GlobalValue::HiddenVisibility);
+  if (Linkage == llvm::GlobalValue::LinkOnceODRLinkage)
+    ThunkFn->setVisibility(llvm::GlobalValue::HiddenVisibility);
   assert(ThunkFn->getName() == ThunkName && "name was uniqued!");
 
   CGM.SetLLVMFunctionAttributes(MD, FnInfo, ThunkFn, /*IsThunk=*/true);

--- a/clang/test/CodeGenCXX/ptrauth-member-function-pointer.cpp
+++ b/clang/test/CodeGenCXX/ptrauth-member-function-pointer.cpp
@@ -371,6 +371,20 @@ namespace testNonVirtualThunk {
   D d;
 }
 
+// CHECK: define internal void @_ZN22TestAnonymousNamespace12_GLOBAL__N_11S3fooEv_vfpthunk_(
+
+namespace TestAnonymousNamespace {
+namespace {
+struct S {
+  virtual void foo(){};
+};
+} // namespace
+
+void test() {
+  auto t = &S::foo;
+}
+} // namespace TestAnonymousNamespace
+
 // CHECK: define void @_Z39test_builtin_ptrauth_type_discriminatorv()
 // CHECK: store i32 [[TYPEDISC0]], i32* %
 // CHECK: store i32 [[TYPEDISC1]], i32* %


### PR DESCRIPTION
rdar://76372295
(cherry picked from commit 4f8c1919a2fa2bfe2006b3ce941090d07ccc3434)