### PR TITLE
[stable/20220421][lldb] Update use of swift::ser::validateSerializedAST to new API

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1346,7 +1346,8 @@ static bool DeserializeAllCompilerFlags(swift::CompilerInvocation &invocation,
     for (; !buf.empty(); buf = buf.substr(info.bytes)) {
       swift::serialization::ExtendedValidationInfo extended_validation_info;
       info = swift::serialization::validateSerializedAST(
-          buf, invocation.getSILOptions().EnableOSSAModules, &extended_validation_info);
+          buf, invocation.getSILOptions().EnableOSSAModules,
+          /*requiredSDK*/StringRef(), &extended_validation_info);
       bool invalid_ast = info.status != swift::serialization::Status::Valid;
       bool invalid_size = (info.bytes == 0) || (info.bytes > buf.size());
       bool invalid_name = info.name.empty();


### PR DESCRIPTION
The Swift service `validateSerializedAST` now accepts the name of the client SDK to limit loading only swiftmodules built with a compatible SDK. This prevents loading swiftmodules built with an incompatible SDK where the context is different enough that it can lead to hard compiler crashes.

In this use site, loading the swiftmodule from a binary should be safe as the SDK context will be extracted from that swiftmodule, so there's no need to require a specific SDK. Other imports will use regular loading path and apply the expected SDK restriction.

Swift API change: https://github.com/apple/swift/pull/58935

---

Cherry-pick of https://github.com/apple/llvm-project/pull/4692 for rebranch.