### PR TITLE
[driver] Introduce `clang-cache-build-session`

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -144,6 +144,18 @@ location for the on-disk CAS.
 % ninja
 ```
 
+`clang-cache-build-session` can be used in combination with `clang-cache` to
+start a build command that indicates a "build session". After configuring with
+the above command, you can use it like this:
+
+```
+% $TOOLCHAIN/usr/bin/clang-cache-build-session ninja
+```
+
+`clang-cache-build-session` accepts a command that triggers a build and, while
+the command is running, all the clang invocations that are part of that build
+will be sharing the same dependency scanning daemon.
+
 #### LLVM project CMake configuration
 
 For building a CAS-aware branch (i.e., this one!), there are some extra CMake

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6274,6 +6274,12 @@ def fdepscan_share_stop_EQ : Joined<["-"], "fdepscan-share-stop=">,
              " process tree; if 'ninja' is found first, state is shared based"
              " on ninja's PID; if 'cmake' is found first, state is not"
              " shared.">;
+def fdepscan_share_identifier : Separate<["-"], "fdepscan-share-identifier">,
+    Group<f_Group>,
+    HelpText<"Share depscan daemon for Clang invocations using the same string "
+             "identifier.">;
+def fdepscan_share_identifier_EQ : Joined<["-"], "fdepscan-share-identifier=">,
+    Alias<fdepscan_share_identifier>;
 def fdepscan_daemon_EQ : Joined<["-"], "fdepscan-daemon=">, Group<f_Group>,
     HelpText<"Specify the path to the daemon to be used. Clang will use the"
              " daemon specified, rather than try to spawn its own based on"

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4498,6 +4498,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &Job,
     const OptSpecifier DepScanOpts[] = {
         options::OPT_fdepscan_EQ,
         options::OPT_fdepscan_share_EQ,
+        options::OPT_fdepscan_share_identifier,
         options::OPT_fdepscan_share_parent,
         options::OPT_fdepscan_share_parent_EQ,
         options::OPT_fno_depscan_share,

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -12,13 +12,17 @@
 // RUN: env CLANG_CACHE_CAS_PATH=%t/cas clang-cache %t/clang-symlink-outside-bindir -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG -DPREFIX=%t
 // RUN: env CLANG_CACHE_CAS_PATH=%t/cas PATH="%t:$PATH" clang-cache clang-symlink-outside-bindir -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG -DPREFIX=%t
 
-// CLANG: "-cc1depscan" "-fdepscan=inline"
+// CLANG: "-cc1depscan" "-fdepscan=auto"
 // CLANG: "-fcas-path" "[[PREFIX]]/cas" "-fcas-token-cache" "-greproducible"
 // CLANG: "-x" "c"
 
-// CLANGPP: "-cc1depscan" "-fdepscan=inline"
+// CLANGPP: "-cc1depscan" "-fdepscan=auto"
 // CLANGPP: "-fcas-path" "[[PREFIX]]/cas" "-fcas-token-cache" "-greproducible"
 // CLANGPP: "-x" "c++"
+
+// RUN: env CLANG_CACHE_CAS_PATH=%t/cas clang-cache-build-session clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=SESSION -DPREFIX=%t
+// SESSION: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-share-identifier"
+// SESSION: "-fcas-path" "[[PREFIX]]/cas" "-fcas-token-cache" "-greproducible"
 
 // 'clang-cache' launcher invokes a different clang, does normal non-caching launch.
 // RUN: env CLANG_CACHE_CAS_PATH=%t/cas clang-cache %t/clang -c %s -o %t.o 2>&1 | FileCheck %s -check-prefix=OTHERCLANG -DSRC=%s -DPREFIX=%t

--- a/clang/test/CAS/fdepscan.c
+++ b/clang/test/CAS/fdepscan.c
@@ -22,6 +22,7 @@
 // RUN:     -fdepscan-share=python                                     \
 // RUN:     -fdepscan-share=                                           \
 // RUN:     -fdepscan-share-stop=python                                \
+// RUN:     -fdepscan-share-identifier                                 \
 // RUN:     -fno-depscan-share                                         \
 // RUN:     -fsyntax-only -x c %s                                      \
 // RUN:     -Xclang -fcas-path -Xclang %t.cas                          \

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -63,7 +63,8 @@ config.substitutions.append(('%PATH%', config.environment['PATH']))
 tool_dirs = [config.clang_tools_dir, config.llvm_tools_dir]
 
 tools = [
-    'apinotes-test', 'c-index-test', 'clang-cache', 'clang-diff', 'clang-format', 'clang-repl', 'clang-offload-packager',
+    'apinotes-test', 'c-index-test', 'clang-cache', 'clang-cache-build-session',
+    'clang-diff', 'clang-format', 'clang-repl', 'clang-offload-packager',
     'clang-tblgen', 'clang-scan-deps', 'opt', 'llvm-ifs', 'yaml2obj', 'clang-linker-wrapper',
     ToolSubst('%clang_extdef_map', command=FindTool(
         'clang-extdef-mapping'), unresolved='ignore'),

--- a/clang/tools/driver/CMakeLists.txt
+++ b/clang/tools/driver/CMakeLists.txt
@@ -70,6 +70,29 @@ foreach(link ${CLANG_LINKS_TO_CREATE})
   add_clang_symlink(${link} clang)
 endforeach()
 
+# Add clang-cache-build-session file into usr/bin
+set(clang_cache_build_session_src "${CMAKE_CURRENT_SOURCE_DIR}/clang-cache-build-session")
+set(clang_cache_build_session_dest "${CMAKE_BINARY_DIR}/bin/clang-cache-build-session")
+
+add_custom_command(OUTPUT "${clang_cache_build_session_dest}"
+                   COMMAND ${CMAKE_COMMAND} -E copy
+                     "${clang_cache_build_session_src}"
+                     "${clang_cache_build_session_dest}"
+                   DEPENDS "${clang_cache_build_session_src}")
+
+add_custom_target(clang-cache-build-session DEPENDS "${clang_cache_build_session_dest}")
+add_dependencies(clang clang-cache-build-session)
+if (CLANG_BUILD_TOOLS)
+  install(FILES "${clang_cache_build_session_dest}"
+          RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+          COMPONENT clang)
+  if(NOT LLVM_ENABLE_IDE)
+    add_llvm_install_targets(install-clang-cache-build-session
+                             DEPENDS clang-cache-build-session
+                             COMPONENT clang)
+  endif()
+endif()
+
 # Configure plist creation for OS X.
 set (TOOL_INFO_PLIST "Info.plist" CACHE STRING "Plist name")
 if (APPLE)

--- a/clang/tools/driver/clang-cache-build-session
+++ b/clang/tools/driver/clang-cache-build-session
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Set 'CLANG_CACHE_BUILD_SESSION_ID' to the process id so that clang invocations
+# under the given command share the same depscan daemon while the command is
+# running.
+env CLANG_CACHE_BUILD_SESSION_ID=$$ "$@"


### PR DESCRIPTION
`clang-cache-build-session` can be used in combination with `clang-cache`
to start a build command that indicates a "build session". After configuring
to use `clang-cache` as the compiler launcher, you can use it like this:

```
% $TOOLCHAIN/usr/bin/clang-cache-build-session ninja
```

`clang-cache-build-session` accepts a command that triggers a build and,
while the command is running, all the clang invocations that are part of
that build will be sharing the same dependency scanning daemon.

This is accomplished by having `clang-cache-build-session` set
`CLANG_CACHE_BUILD_SESSION_ID=<pid>` as environment variable which is then
passed on to the new "depscan" flag `-fdepscan-share-identifier`.