### PR TITLE
Cherry-pick some -Wstrict-prototype changes

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -144,14 +144,17 @@ Improvements to Clang's diagnostics
   now only diagnose deprecated declarations and definitions of functions
   without a prototype where the behavior in C2x will remain correct. This
   diagnostic remains off by default but is now enabled via ``-pedantic`` due to
-  it being a deprecation warning. ``-Wdeprecated-non-prototype`` will diagnose
-  cases where the deprecated declarations or definitions of a function without
-  a prototype will change behavior in C2x. Additionally, it will diagnose calls
-  which pass arguments to a function without a prototype. This warning is
-  enabled only when the ``-Wdeprecated-non-prototype`` option is enabled at the
-  function declaration site, which allows a developer to disable the diagnostic
-  for all callers at the point of declaration. This diagnostic is grouped under
-  the ``-Wstrict-prototypes`` warning group, but is enabled by default.
+  it being a deprecation warning. ``-Wstrict-prototypes`` has no effect in C2x
+  or when ``-fno-knr-functions`` is enabled. ``-Wdeprecated-non-prototype``
+  will diagnose cases where the deprecated declarations or definitions of a
+  function without a prototype will change behavior in C2x. Additionally, it
+  will diagnose calls which pass arguments to a function without a prototype.
+  This warning is enabled only when the ``-Wdeprecated-non-prototype`` option
+  is enabled at the function declaration site, which allows a developer to
+  disable the diagnostic for all callers at the point of declaration. This
+  diagnostic is grouped under the ``-Wstrict-prototypes`` warning group, but is
+  enabled by default. ``-Wdeprecated-non-prototype`` has no effect in C2x or
+  when ``-fno-knr-functions`` is enabled.
 - Clang now appropriately issues an error in C when a definition of a function
   without a prototype and with no arguments is an invalid redeclaration of a
   function with a prototype. e.g., ``void f(int); void f() {}`` is now properly

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5282,6 +5282,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   if (Freestanding)
     CmdArgs.push_back("-ffreestanding");
 
+  Args.AddLastArg(CmdArgs, options::OPT_fno_knr_functions);
+
   // This is a coarse approximation of what llvm-gcc actually does, both
   // -fasynchronous-unwind-tables and -fnon-call-exceptions interact in more
   // complicated ways.

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -5578,7 +5578,7 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
   //   of the parameters is supplied.
   // See ActOnFinishFunctionBody() and MergeFunctionDecl() for handling of
   // function declarations whose behavior changes in C2x.
-  if (!LangOpts.CPlusPlus) {
+  if (!LangOpts.requiresStrictPrototypes()) {
     bool IsBlock = false;
     for (const DeclaratorChunk &DeclType : D.type_objects()) {
       switch (DeclType.Kind) {

--- a/clang/test/Driver/no-knr-functions.c
+++ b/clang/test/Driver/no-knr-functions.c
@@ -7,5 +7,9 @@
 // RUN: not %clang -fknr-functions -x c %s 2>&1 | FileCheck --check-prefixes=POS %s
 // RUN: not %clang -fknr-functions -std=c89 -x c %s 2>&1 | FileCheck --check-prefixes=POS %s
 
+// Ensure that the driver flag is actually accepted though.
+// RUN: %clang -fno-knr-functions -### %s 2>&1 | FileCheck --check-prefixes=ACCEPTED %s
+
 // NONO: error: unknown argument: '-fno-no-knr-functions'
 // POS: error: unknown argument: '-fknr-functions'
+// ACCEPTED-NOT: warning: argument unused during compilation: '-fno-knr-functions'

--- a/clang/test/Sema/c2x-warn-strict-prototypes.c
+++ b/clang/test/Sema/c2x-warn-strict-prototypes.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -fsyntax-only -Wstrict-prototypes -verify -std=c2x %s
+// RUN: %clang_cc1 -fsyntax-only -Wstrict-prototypes -verify -fno-knr-functions %s
+// expected-no-diagnostics
+
+void foo();
+void bar() {}
+
+void baz(void);
+void baz() {}


### PR DESCRIPTION
These changes are associated with other `-Wstrict-prototype` changes that made it onto the `next` branch but missed the stable branch cutoff. They should help make strict prototypes smoother in C2x.