### PR TITLE
[lldb/Core] Fix "sticky" long progress messages

### DIFF
--- a/lldb/include/lldb/Core/DebuggerEvents.h
+++ b/lldb/include/lldb/Core/DebuggerEvents.h
@@ -32,6 +32,7 @@ public:
 
   static const ProgressEventData *GetEventDataFromEvent(const Event *event_ptr);
   uint64_t GetID() const { return m_id; }
+  bool IsFinite() const { return m_total != UINT64_MAX; }
   uint64_t GetCompleted() const { return m_completed; }
   uint64_t GetTotal() const { return m_total; }
   const std::string &GetMessage() const { return m_message; }

--- a/lldb/packages/Python/lldbsuite/test/lldbpexpect.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbpexpect.py
@@ -36,8 +36,9 @@ class PExpectTest(TestBase):
         if not use_colors:
             args += '--no-use-colors'
         for cmd in self.setUpCommands():
-            if use_colors and "use-color false" not in cmd:
-                args += ['-O', cmd]
+            if "use-color false" in cmd and use_colors:
+                continue
+            args += ['-O', cmd]
         if executable is not None:
             args += ['--file', executable]
         if extra_args is not None:
@@ -58,9 +59,10 @@ class PExpectTest(TestBase):
             post_spawn()
         self.expect_prompt()
         for cmd in self.setUpCommands():
-            if use_colors and "use-color false" not in cmd:
-                self.child.expect_exact(cmd)
-                self.expect_prompt()
+            if "use-color false" in cmd and use_colors:
+                continue
+            self.child.expect_exact(cmd)
+            self.expect_prompt()
         if executable is not None:
             self.child.expect_exact("target create")
             self.child.expect_exact("Current executable set to")

--- a/lldb/packages/Python/lldbsuite/test/lldbpexpect.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbpexpect.py
@@ -47,6 +47,8 @@ class PExpectTest(TestBase):
         self.child = pexpect.spawn(
                 args[0], args=args[1:], logfile=logfile,
                 timeout=timeout, dimensions=dimensions, env=env)
+        self.child.ptyproc.delayafterclose = timeout/10
+        self.child.ptyproc.delayafterterminate = timeout/10
 
         if post_spawn is not None:
             post_spawn()

--- a/lldb/packages/Python/lldbsuite/test/lldbpexpect.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbpexpect.py
@@ -34,7 +34,7 @@ class PExpectTest(TestBase):
             args += run_under
         args += [lldbtest_config.lldbExec, '--no-lldbinit']
         if not use_colors:
-            args += '--no-use-colors'
+            args.append('--no-use-colors')
         for cmd in self.setUpCommands():
             if "use-color false" in cmd and use_colors:
                 continue

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -1906,20 +1906,26 @@ void Debugger::HandleProgressEvent(const lldb::EventSP &event_sp) {
     return;
   }
 
+  // Trim the progress message if it exceeds the window's width and print it.
+  std::string message = data->GetMessage();
+  if (data->IsFinite())
+    message = llvm::formatv("[{0}/{1}] {2}", data->GetCompleted(),
+                            data->GetTotal(), message)
+                  .str();
+
+  // Trim the progress message if it exceeds the window's width and print it.
+  const uint32_t term_width = GetTerminalWidth();
+  const uint32_t ellipsis = 3;
+  if (message.size() + ellipsis >= term_width)
+    message = message.substr(0, term_width - ellipsis);
+
   const bool use_color = GetUseColor();
   llvm::StringRef ansi_prefix = GetShowProgressAnsiPrefix();
   if (!ansi_prefix.empty())
     output->Printf(
         "%s", ansi::FormatAnsiTerminalCodes(ansi_prefix, use_color).c_str());
 
-  // Print the progress message.
-  std::string message = data->GetMessage();
-  if (data->GetTotal() != UINT64_MAX) {
-    output->Printf("[%" PRIu64 "/%" PRIu64 "] %s...", data->GetCompleted(),
-                   data->GetTotal(), message.c_str());
-  } else {
-    output->Printf("%s...", message.c_str());
-  }
+  output->Printf("%s...", message.c_str());
 
   llvm::StringRef ansi_suffix = GetShowProgressAnsiSuffix();
   if (!ansi_suffix.empty())

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -1890,45 +1890,47 @@ void Debugger::HandleProgressEvent(const lldb::EventSP &event_sp) {
   // Determine whether the current output file is an interactive terminal with
   // color support. We assume that if we support ANSI escape codes we support
   // vt100 escape codes.
-  File &output = GetOutputFile();
-  if (!output.GetIsInteractive() || !output.GetIsTerminalWithColors())
+  File &file = GetOutputFile();
+  if (!file.GetIsInteractive() || !file.GetIsTerminalWithColors())
     return;
 
+  StreamSP output = GetAsyncOutputStream();
+
   // Print over previous line, if any.
-  output.Printf("\r");
+  output->Printf("\r");
 
   if (data->GetCompleted()) {
     // Clear the current line.
-    output.Printf("\x1B[2K");
-    output.Flush();
+    output->Printf("\x1B[2K");
+    output->Flush();
     return;
   }
 
   const bool use_color = GetUseColor();
   llvm::StringRef ansi_prefix = GetShowProgressAnsiPrefix();
   if (!ansi_prefix.empty())
-    output.Printf(
+    output->Printf(
         "%s", ansi::FormatAnsiTerminalCodes(ansi_prefix, use_color).c_str());
 
   // Print the progress message.
   std::string message = data->GetMessage();
   if (data->GetTotal() != UINT64_MAX) {
-    output.Printf("[%" PRIu64 "/%" PRIu64 "] %s...", data->GetCompleted(), data->GetTotal(),
-                  message.c_str());
+    output->Printf("[%" PRIu64 "/%" PRIu64 "] %s...", data->GetCompleted(),
+                   data->GetTotal(), message.c_str());
   } else {
-    output.Printf("%s...", message.c_str());
+    output->Printf("%s...", message.c_str());
   }
 
   llvm::StringRef ansi_suffix = GetShowProgressAnsiSuffix();
   if (!ansi_suffix.empty())
-    output.Printf(
+    output->Printf(
         "%s", ansi::FormatAnsiTerminalCodes(ansi_suffix, use_color).c_str());
 
   // Clear until the end of the line.
-  output.Printf("\x1B[K\r");
+  output->Printf("\x1B[K\r");
 
   // Flush the output.
-  output.Flush();
+  output->Flush();
 }
 
 void Debugger::HandleDiagnosticEvent(const lldb::EventSP &event_sp) {

--- a/lldb/test/API/functionalities/progress_reporting/TestTrimmedProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/TestTrimmedProgressReporting.py
@@ -1,0 +1,50 @@
+"""
+Test trimming long progress report in tiny terminal windows
+"""
+
+import os
+import pexpect
+import tempfile
+import re
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.lldbpexpect import PExpectTest
+
+class TestTrimmedProgressReporting(PExpectTest):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def do_test(self, term_width, pattern_list):
+        self.build()
+        # Start with a small window
+        self.launch(use_colors=True)
+        self.expect("set set show-progress true")
+        self.expect("set show show-progress", substrs=["show-progress (boolean) = true"])
+        self.expect("set set term-width " + str(term_width))
+        self.expect("set show term-width", substrs=["term-width (int) = " + str(term_width)])
+
+        self.child.send("file " + self.getBuildArtifact("a.out") + "\n")
+        self.child.expect(pattern_list)
+
+
+    # PExpect uses many timeouts internally and doesn't play well
+    # under ASAN on a loaded machine..
+    @skipIfAsan
+    @skipUnlessDarwin
+    @skipIfEditlineSupportMissing
+    def test_trimmed_progress_message(self):
+        self.do_test(19, ['Locating externa...',
+                          'Loading Apple DW...',
+                          'Parsing symbol t...'])
+
+    # PExpect uses many timeouts internally and doesn't play well
+    # under ASAN on a loaded machine..
+    @skipIfAsan
+    @skipUnlessDarwin
+    @skipIfEditlineSupportMissing
+    def test_long_progress_message(self):
+        self.do_test(80, ['Locating external symbol file for a.out...',
+                          'Loading Apple DWARF index for a.out...',
+                          'Parsing symbol table for dyld...'])

--- a/lldb/test/API/iohandler/autosuggestion/TestAutosuggestion.py
+++ b/lldb/test/API/iohandler/autosuggestion/TestAutosuggestion.py
@@ -26,7 +26,8 @@ class TestCase(PExpectTest):
     @skipIfAsan
     @skipIfEditlineSupportMissing
     def test_autosuggestion_add_spaces(self):
-        self.launch(extra_args=["-o", "settings set show-autosuggestion true", "-o", "settings set use-color true"])
+        self.launch(use_colors=True,
+                    extra_args=["-o", "settings set show-autosuggestion true", "-o", "settings set use-color true"])
 
 
         # Check if spaces are added to hide the previous gray characters.
@@ -40,7 +41,8 @@ class TestCase(PExpectTest):
     @skipIfAsan
     @skipIfEditlineSupportMissing
     def test_autosuggestion(self):
-        self.launch(extra_args=["-o", "settings set show-autosuggestion true", "-o", "settings set use-color true"])
+        self.launch(use_colors=True,
+                    extra_args=["-o", "settings set show-autosuggestion true", "-o", "settings set use-color true"])
 
         # Common input codes.
         ctrl_f = "\x06"
@@ -107,7 +109,8 @@ class TestCase(PExpectTest):
     @skipIfAsan
     @skipIfEditlineSupportMissing
     def test_autosuggestion_custom_ansi_prefix_suffix(self):
-        self.launch(extra_args=["-o", "settings set show-autosuggestion true",
+        self.launch(use_colors=True,
+                    extra_args=["-o", "settings set show-autosuggestion true",
                                 "-o", "settings set use-color true",
                                 "-o", "settings set show-autosuggestion-ansi-prefix ${ansi.fg.red}",
                                 "-o", "setting set show-autosuggestion-ansi-suffix ${ansi.fg.cyan}"])

--- a/llvm/lib/Support/Unix/Process.inc
+++ b/llvm/lib/Support/Unix/Process.inc
@@ -331,6 +331,23 @@ extern "C" int tigetnum(char *capname);
 static ManagedStatic<std::mutex> TermColorMutex;
 #endif
 
+bool checkTerminalEnvironmentForColors() {
+  if (const char *TermStr = std::getenv("TERM")) {
+    return StringSwitch<bool>(TermStr)
+      .Case("ansi", true)
+      .Case("cygwin", true)
+      .Case("linux", true)
+      .StartsWith("screen", true)
+      .StartsWith("xterm", true)
+      .StartsWith("vt100", true)
+      .StartsWith("rxvt", true)
+      .EndsWith("color", true)
+      .Default(false);
+  }
+
+  return false;
+}
+
 static bool terminalHasColors(int fd) {
 #ifdef LLVM_ENABLE_TERMINFO
   // First, acquire a global lock because these C routines are thread hostile.
@@ -356,7 +373,8 @@ static bool terminalHasColors(int fd) {
   //
   // The 'tigetnum' routine returns -2 or -1 on errors, and might return 0 if
   // the terminfo says that no colors are supported.
-  bool HasColors = tigetnum(const_cast<char *>("colors")) > 0;
+  int colors_ti = tigetnum(const_cast<char *>("colors"));
+  bool HasColors = colors_ti >= 0 ? colors_ti : checkTerminalEnvironmentForColors();
 
   // Now extract the structure allocated by setupterm and free its memory
   // through a really silly dance.
@@ -364,27 +382,12 @@ static bool terminalHasColors(int fd) {
   (void)del_curterm(termp); // Drop any errors here.
 
   // Return true if we found a color capabilities for the current terminal.
-  if (HasColors)
-    return true;
+  return HasColors;
 #else
   // When the terminfo database is not available, check if the current terminal
   // is one of terminals that are known to support ANSI color escape codes.
-  if (const char *TermStr = std::getenv("TERM")) {
-    return StringSwitch<bool>(TermStr)
-      .Case("ansi", true)
-      .Case("cygwin", true)
-      .Case("linux", true)
-      .StartsWith("screen", true)
-      .StartsWith("xterm", true)
-      .StartsWith("vt100", true)
-      .StartsWith("rxvt", true)
-      .EndsWith("color", true)
-      .Default(false);
-  }
+  return checkTerminalEnvironmentForColors();
 #endif
-
-  // Otherwise, be conservative.
-  return false;
 }
 
 bool Process::FileDescriptorHasColors(int fd) {


### PR DESCRIPTION
When the terminal window is too small, lldb would wrap progress messages
accross multiple lines which would break the progress event handling
code that is supposed to clear the message once the progress is completed.

This causes the progress message to remain on the screen, sometimes partially,
which can be confusing for the user.

To fix this issue, this patch trims the progress message to the terminal
width taking into account the progress counter leading the message for
finite progress events and also the trailing `...`.

rdar://91993836

Differential Revision: https://reviews.llvm.org/D124785