### PR TITLE
🍒[cxx-interop] Allow Swift to extract libstdc++ installation path from Clang

### DIFF
--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -565,6 +565,18 @@ public:
     return IsOffload ? OffloadLTOMode : LTOMode;
   }
 
+  /// Addition for Swift. Allows ClangImporter to extract the path to libstdc++.
+  std::vector<std::string>
+  getLibStdCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
+                           const llvm::Triple &Target) const {
+    llvm::opt::ArgStringList ArgStrings;
+    getToolChain(DriverArgs, Target)
+        .addLibStdCxxIncludePaths(DriverArgs, ArgStrings);
+    unsigned Unused1, Unused2;
+    auto ParsedArgs = getOpts().ParseArgs(ArgStrings, Unused1, Unused2);
+    return ParsedArgs.getAllArgValues(options::OPT_internal_isystem);
+  }
+
 private:
 
   /// Tries to load options from configuration file.

--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -222,6 +222,11 @@ public:
   llvm::vfs::FileSystem &getVFS() const;
   const llvm::Triple &getTriple() const { return Triple; }
 
+  /// Addition for Swift. Allows ClangImporter to extract the path to libstdc++.
+  virtual void
+  addLibStdCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
+                           llvm::opt::ArgStringList &CC1Args) const {};
+
   /// Get the toolchain's aux triple, if it has one.
   ///
   /// Exactly what the aux triple represents depends on the toolchain, but for


### PR DESCRIPTION
See https://github.com/apple/swift/pull/58962 for details.

rdar://93341210