### PR TITLE
Relax an assertion in AddInitializerToStaticVarDecl

### DIFF
--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -359,7 +359,7 @@ CodeGenFunction::AddInitializerToStaticVarDecl(const VarDecl &D,
                       D.getFlexibleArrayInitChars(getContext());
   CharUnits CstSize = CharUnits::fromQuantity(
       CGM.getDataLayout().getTypeAllocSize(Init->getType()));
-  assert(VarSize == CstSize && "Emitted constant has unexpected size");
+  assert((VarSize == CstSize || D.getType()->isArrayType()) && "Emitted constant has unexpected size");
 #endif
 
   // The initializer may differ in type from the global. Rewrite


### PR DESCRIPTION
The assertion was introduced in https://reviews.llvm.org/D123649. In the long term, we should probably disable arrays that have elements whose alignment is larger than their size.

rdar://92845558