### PR TITLE
[driver/cc1depscanProtocol] For daemons shared via identifier, increase the timeout before they shutdown

### DIFF
--- a/clang/tools/driver/cc1depscanProtocol.cpp
+++ b/clang/tools/driver/cc1depscanProtocol.cpp
@@ -156,6 +156,11 @@ Expected<ScanDaemon> ScanDaemon::launchDaemon(StringRef BasePath,
   ArrayRef<const char *> InitialArgs =
       LaunchTestDaemon ? makeArrayRef(ArgsTestMode) : makeArrayRef(Args);
   SmallVector<const char *> LaunchArgs(InitialArgs.begin(), InitialArgs.end());
+  if (Sharing.ShareViaIdentifier) {
+    // Invocations that share state via identifier will be isolated from
+    // unrelated daemons, so the daemon they share is safe to stay alive longer.
+    LaunchArgs.push_back("-long-running");
+  }
   LaunchArgs.push_back("-cas-args");
   LaunchArgs.append(Sharing.CASArgs);
   LaunchArgs.push_back(nullptr);

--- a/clang/tools/driver/cc1depscanProtocol.h
+++ b/clang/tools/driver/cc1depscanProtocol.h
@@ -20,11 +20,19 @@
 #include <unistd.h>     // FIXME: Unix-only. Not portable.
 
 namespace clang {
-class CASOptions;
 
 namespace cc1depscand {
 
 struct DepscanPrefixMapping;
+
+struct DepscanSharing {
+  bool OnlyShareParent = false;
+  bool ShareViaIdentifier = false;
+  Optional<StringRef> Name;
+  Optional<StringRef> Stop;
+  Optional<StringRef> Path;
+  SmallVector<const char *> CASArgs;
+};
 
 struct AutoArgEdit {
   uint32_t Index = -1u;
@@ -201,11 +209,11 @@ private:
 class ScanDaemon : public OpenSocket {
 public:
   static Expected<ScanDaemon> create(StringRef BasePath, const char *Arg0,
-                                     const CASOptions &CASOpts);
+                                     const DepscanSharing &Sharing);
 
-  static Expected<ScanDaemon> constructAndShakeHands(StringRef BasePath,
-                                                     const char *Arg0,
-                                                     const CASOptions &CASOpts);
+  static Expected<ScanDaemon>
+  constructAndShakeHands(StringRef BasePath, const char *Arg0,
+                         const DepscanSharing &Sharing);
 
   static Expected<ScanDaemon> connectToDaemonAndShakeHands(StringRef BasePath);
 
@@ -213,7 +221,7 @@ public:
 
 private:
   static Expected<ScanDaemon> launchDaemon(StringRef BasePath, const char *Arg0,
-                                           const CASOptions &CASOpts);
+                                           const DepscanSharing &Sharing);
   static Expected<ScanDaemon> connectToDaemon(StringRef BasePath,
                                               bool ShouldWait);
   static Expected<ScanDaemon> connectToExistingDaemon(StringRef BasePath) {

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -57,6 +57,7 @@
 
 using namespace clang;
 using namespace llvm::opt;
+using cc1depscand::DepscanSharing;
 using llvm::Error;
 
 #define DEBUG_TYPE "cc1depscand"
@@ -280,17 +281,6 @@ ProcessAncestorIterator &ProcessAncestorIterator::setPID(uint64_t NewPID) {
   return *this;
 }
 
-namespace {
-struct DepscanSharing {
-  bool OnlyShareParent = false;
-  bool ShareViaIdentifier = false;
-  Optional<StringRef> Name;
-  Optional<StringRef> Stop;
-  Optional<StringRef> Path;
-  SmallVector<const char *> CASArgs;
-};
-} // end namespace
-
 static Optional<std::string>
 makeDepscanDaemonKey(StringRef Mode, const DepscanSharing &Sharing) {
   auto completeKey = [&Sharing](llvm::BLAKE3 &Hasher) -> std::string {
@@ -417,8 +407,9 @@ static llvm::Expected<llvm::cas::CASID> scanAndUpdateCC1UsingDaemon(
     const char *Exec, ArrayRef<const char *> OldArgs,
     SmallVectorImpl<const char *> &NewArgs,
     const cc1depscand::DepscanPrefixMapping &Mapping, StringRef Path,
-    bool NoSpawnDaemon, llvm::function_ref<const char *(const Twine &)> SaveArg,
-    const CASOptions &CASOpts, llvm::cas::CASDB &CAS) {
+    const DepscanSharing &Sharing,
+    llvm::function_ref<const char *(const Twine &)> SaveArg,
+    llvm::cas::CASDB &CAS) {
   using namespace clang::cc1depscand;
 
   // FIXME: Skip some of this if -fcas-fs has been passed.
@@ -427,10 +418,11 @@ static llvm::Expected<llvm::cas::CASID> scanAndUpdateCC1UsingDaemon(
           llvm::errorCodeToError(llvm::sys::fs::current_path(WorkingDirectory)))
     return std::move(E);
 
+  bool NoSpawnDaemon = (bool)Sharing.Path;
   // llvm::dbgs() << "connecting to daemon...\n";
   auto Daemon = NoSpawnDaemon
                     ? ScanDaemon::connectToDaemonAndShakeHands(Path)
-                    : ScanDaemon::constructAndShakeHands(Path, Exec, CASOpts);
+                    : ScanDaemon::constructAndShakeHands(Path, Exec, Sharing);
   if (!Daemon)
     return Daemon.takeError();
   CC1DepScanDProtocol Comms(*Daemon);
@@ -555,9 +547,8 @@ static int scanAndUpdateCC1(const char *Exec, ArrayRef<const char *> OldArgs,
 
   auto ScanAndUpdate = [&]() {
     if (Optional<std::string> DaemonPath = makeDepscanDaemonPath(Mode, Sharing))
-      return scanAndUpdateCC1UsingDaemon(
-          Exec, OldArgs, NewArgs, PrefixMapping, *DaemonPath,
-          /*NoSpawnDaemon=*/(bool)Sharing.Path, SaveArg, CASOpts, CAS);
+      return scanAndUpdateCC1UsingDaemon(Exec, OldArgs, NewArgs, PrefixMapping,
+                                         *DaemonPath, Sharing, SaveArg, CAS);
     return scanAndUpdateCC1Inline(Exec, OldArgs, NewArgs, PrefixMapping,
                                   SaveArg, CASOpts, CAS);
   };

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -692,6 +692,13 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
     CASArgs = llvm::makeArrayRef(CASArgsI + 1, Argv.end());
   }
 
+  // Whether the daemon can safely stay alive a longer period of time.
+  // FIXME: Consider designing a mechanism to notify daemons, started for a
+  // particular "build session", to shutdown, then have it stay alive until the
+  // session is finished.
+  bool LongRunning =
+      std::find(Argv.begin(), CASArgsI, StringRef("-long-running")) != CASArgsI;
+
   auto formSpawnArgsForCommand =
       [&](const char *Command) -> SmallVector<const char *> {
     SmallVector<const char *> Args{Argv0,     "-cc1depscand",
@@ -1025,7 +1032,7 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
 
   // Wait for the work to finish.
   const uint64_t SecondsBetweenAttempts = 5;
-  const uint64_t SecondsBeforeDestruction = 15;
+  const uint64_t SecondsBeforeDestruction = LongRunning ? 45 : 15;
   uint64_t SleepTime = SecondsBeforeDestruction;
   while (true) {
     ::sleep(SleepTime);


### PR DESCRIPTION
Commits:
1. Refactoring to pass a `DepscanSharing` parameter to the `ScanDaemon` functions, instead of just the `CASOpts`
2. Invocations that share state via identifier will be isolated from unrelated daemons, so the daemon they share is safe to stay alive longer.
