### PR TITLE
Sema: adjust assertion to account for deduced types

### DIFF
--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -516,7 +516,8 @@ public:
   SourceLocation getTypeSpecSatLoc() const { return TSSatLoc; }
 
   SourceLocation getTypeSpecTypeNameLoc() const {
-    assert(isDeclRep((TST) TypeSpecType) || TypeSpecType == TST_typename);
+    assert(isDeclRep((TST)TypeSpecType) || isTypeRep((TST)TypeSpecType) ||
+           isExprRep((TST)TypeSpecType));
     return TSTNameLoc;
   }
 

--- a/clang/test/Sema/typerep-typespec.c
+++ b/clang/test/Sema/typerep-typespec.c
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -std=c11 -x c %s -fsyntax-only -verify
+// REQUIRES: asserts
+
+struct dispatch_object_s;
+void _dispatch_queue_get_head(struct dispatch_object_s * volatile dq_items_head) {
+  (_Atomic __typeof__(dq_items_head) *)0; // expected-warning{{expression result unused}}
+}


### PR DESCRIPTION
Previous changes for the BTF attributes introduced a new sub-tree
visitation.  That uncovered that when accessing the typespec location we
would assert that the type specification is either a type declaration or
`typename`.  However, `typename` was explicitly permitted.  This change
predates the introduction of newer deduced type representations such as
`__underlying_type` from C++ and the addition of the GNU `__typeof__`
expression.

Thanks to aaron.ballman for the valuable discussion and pointer to
`isTypeRep`.