### PR TITLE
Initialize a new object field in unittests 

### DIFF
--- a/llvm/unittests/CodeGen/InstrRefLDVTest.cpp
+++ b/llvm/unittests/CodeGen/InstrRefLDVTest.cpp
@@ -142,6 +142,7 @@ public:
     LDV->TRI = STI.getRegisterInfo();
     LDV->TFI = STI.getFrameLowering();
     LDV->MFI = &MF->getFrameInfo();
+    LDV->MRI = &MF->getRegInfo();
 
     DomTree = std::make_unique<MachineDominatorTree>(*MF);
     LDV->DomTree = &*DomTree;


### PR DESCRIPTION
Over in e7084ceab3122 the InstrRefBasedLDV class grew a MachineRegisterInfo
pointer to lookup register sizes -- however, that field wasn't initialized
in the corresponding unit tests. This patch initializes it!

Fixes a buildbot failure reported on D112006

(cherry picked from commit c99fdd456ff4192fc91781732724861bf000ebda)