### PR TITLE
[stable/20220421] Silence some false positive -Wstrict-prototype warnings

### DIFF
--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -5589,8 +5589,10 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
         const DeclaratorChunk::FunctionTypeInfo &FTI = DeclType.Fun;
         // We suppress the warning when there's no LParen location, as this
         // indicates the declaration was an implicit declaration, which gets
-        // warned about separately via -Wimplicit-function-declaration.
-        if (FTI.NumParams == 0 && !FTI.isVariadic && FTI.getLParenLoc().isValid())
+        // warned about separately via -Wimplicit-function-declaration. We also
+        // suppress the warning when we know the function has a prototype.
+        if (!FTI.hasPrototype && FTI.NumParams == 0 && !FTI.isVariadic &&
+            FTI.getLParenLoc().isValid())
           S.Diag(DeclType.Loc, diag::warn_strict_prototypes)
               << IsBlock
               << FixItHint::CreateInsertion(FTI.getRParenLoc(), "void");

--- a/clang/test/Parser/opencl-kernel.cl
+++ b/clang/test/Parser/opencl-kernel.cl
@@ -1,9 +1,10 @@
 // RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only
+// expected-no-diagnostics
 
-__kernel void test() // expected-warning {{a function declaration without a prototype is deprecated in all versions of C}}
+__kernel void test()
 {
 }
 
-kernel void test1() // expected-warning {{a function declaration without a prototype is deprecated in all versions of C}}
+kernel void test1()
 {
 }

--- a/clang/test/Sema/block-return.c
+++ b/clang/test/Sema/block-return.c
@@ -100,7 +100,7 @@ bptr foo5(int j) {
 int (*funcptr3[5])(long);
 int sz8 = sizeof(^int (*[5])(long) {return funcptr3;}); // expected-error {{block cannot return array type}} expected-warning {{incompatible pointer to integer conversion}}
 int sz9 = sizeof(^int(*())()[3]{ }); // expected-error {{function cannot return array type}}
-                                     // expected-warning@-1 2 {{a function declaration without a prototype is deprecated in all versions of C}}
+                                     // expected-warning@-1 {{a function declaration without a prototype is deprecated in all versions of C}}
 
 void foo6(void) {
   int (^b)(int) __attribute__((noreturn));

--- a/clang/test/Sema/warn-strict-prototypes.m
+++ b/clang/test/Sema/warn-strict-prototypes.m
@@ -17,7 +17,7 @@ void foo() { // expected-warning {{a function declaration without a prototype is
   // FIXME: this should say "a block declaration" instead, but block literal
   // expressions do not track their full declarator information, so we don't
   // know it's a block when diagnosing.
-  void (^block2)(void) = ^void() { // expected-warning {{a function declaration without a prototype is deprecated in all versions of C}}
+  void (^block2)(void) = ^void() {
   };
   void (^block3)(void) = ^ { // no warning
   };

--- a/clang/test/SemaOpenCL/address-spaces.cl
+++ b/clang/test/SemaOpenCL/address-spaces.cl
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 %s -verify=expected,c -pedantic -fsyntax-only
-// RUN: %clang_cc1 %s -cl-std=CL2.0 -verify=expected,c -pedantic -fsyntax-only
-// RUN: %clang_cc1 %s -cl-std=CL3.0 -cl-ext=+__opencl_c_generic_address_space -verify=expected,c -pedantic -fsyntax-only
+// RUN: %clang_cc1 %s -verify=expected -pedantic -fsyntax-only
+// RUN: %clang_cc1 %s -cl-std=CL2.0 -verify=expected -pedantic -fsyntax-only
+// RUN: %clang_cc1 %s -cl-std=CL3.0 -cl-ext=+__opencl_c_generic_address_space -verify=expected -pedantic -fsyntax-only
 // RUN: %clang_cc1 %s -cl-std=clc++1.0 -verify -pedantic -fsyntax-only
 // RUN: %clang_cc1 %s -cl-std=clc++2021 -cl-ext=+__opencl_c_generic_address_space -verify -pedantic -fsyntax-only
 
@@ -251,7 +251,7 @@ void func_multiple_addr(void) {
 
 void func_with_array_param(const unsigned data[16]);
 
-__kernel void k() { // c-warning {{a function declaration without a prototype is deprecated in all versions of C}}
+__kernel void k() {
   unsigned data[16];
   func_with_array_param(data);
 }

--- a/clang/test/SemaOpenCL/cl20-device-side-enqueue.cl
+++ b/clang/test/SemaOpenCL/cl20-device-side-enqueue.cl
@@ -223,22 +223,16 @@ kernel void work_group_size_tests(void) {
 kernel void foo(global unsigned int *buf)
 {
   ndrange_t n;
-  // FIXME: this should be diagnosed as a block instead of a function, but
-  // block literals don't track the ^ as part of their declarator.
-  buf[0] = get_kernel_max_sub_group_size_for_ndrange(n, ^(){}); // expected-warning {{a function declaration without a prototype is deprecated in all versions of C}}
+  buf[0] = get_kernel_max_sub_group_size_for_ndrange(n, ^(){});
   buf[0] = get_kernel_max_sub_group_size_for_ndrange(0, ^(){}); // expected-error{{illegal call to 'get_kernel_max_sub_group_size_for_ndrange', expected 'ndrange_t' argument type}}
-                                                                // expected-warning@-1 {{a function declaration without a prototype is deprecated in all versions of C}}
   buf[0] = get_kernel_max_sub_group_size_for_ndrange(n, 1); // expected-error{{illegal call to 'get_kernel_max_sub_group_size_for_ndrange', expected block argument type}}
 }
 
 kernel void bar(global unsigned int *buf)
 {
   __private ndrange_t n;
-  // FIXME: this should be diagnosed as a block instead of a function, but
-  // block literals don't track the ^ as part of their declarator.
-  buf[0] = get_kernel_sub_group_count_for_ndrange(n, ^(){}); // expected-warning {{a function declaration without a prototype is deprecated in all versions of C}}
+  buf[0] = get_kernel_sub_group_count_for_ndrange(n, ^(){});
   buf[0] = get_kernel_sub_group_count_for_ndrange(0, ^(){}); // expected-error{{illegal call to 'get_kernel_sub_group_count_for_ndrange', expected 'ndrange_t' argument type}}
-                                                             // expected-warning@-1 {{a function declaration without a prototype is deprecated in all versions of C}}
   buf[0] = get_kernel_sub_group_count_for_ndrange(n, 1); // expected-error{{illegal call to 'get_kernel_sub_group_count_for_ndrange', expected block argument type}}
 }
 
@@ -247,18 +241,12 @@ kernel void bar(global unsigned int *buf)
 kernel void foo1(global unsigned int *buf)
 {
   ndrange_t n;
-  // FIXME: this should be diagnosed as a block instead of a function, but
-  // block literals don't track the ^ as part of their declarator.
   buf[0] = get_kernel_max_sub_group_size_for_ndrange(n, ^(){}); // expected-error {{use of declaration 'get_kernel_max_sub_group_size_for_ndrange' requires cl_khr_subgroups or __opencl_c_subgroups support}}
-                                                                // expected-warning@-1 {{a function declaration without a prototype is deprecated in all versions of C}}
 }
 
 kernel void bar1(global unsigned int *buf)
 {
   ndrange_t n;
-  // FIXME: this should be diagnosed as a block instead of a function, but
-  // block literals don't track the ^ as part of their declarator.
   buf[0] = get_kernel_sub_group_count_for_ndrange(n, ^(){}); // expected-error {{use of declaration 'get_kernel_sub_group_count_for_ndrange' requires cl_khr_subgroups or __opencl_c_subgroups support}}
-                                                             // expected-warning@-1 {{a function declaration without a prototype is deprecated in all versions of C}}
 }
 #endif // ifdef cl_khr_subgroups

--- a/clang/test/SemaOpenCL/func.cl
+++ b/clang/test/SemaOpenCL/func.cl
@@ -43,9 +43,9 @@ void foo(void*);
 #endif
 
 // Expect no diagnostics for an empty parameter list.
-void bar(); // expected-warning {{a function declaration without a prototype is deprecated in all versions of C}}
+void bar();
 
-void bar() // expected-warning {{a function declaration without a prototype is deprecated in all versions of C}}
+void bar()
 {
   // declaring a function pointer is an error
   void (*fptr)(int);


### PR DESCRIPTION
Before issuing the warning about use of a strict prototype, check if
the declarator is required to have a prototype through some other means
determined at parse time.

This silences false positives in OpenCL code (where the functions are
forced to have a prototype) and block literal expressions.

(cherry picked from commit 4be105c98a9c7e083cd878ee1751e11160b97b4a)

Follow-up for #4700 