### PR TITLE
Cherrypick AS test fixes

### DIFF
--- a/lldb/test/API/tools/lldb-server/TestLldbGdbServer.py
+++ b/lldb/test/API/tools/lldb-server/TestLldbGdbServer.py
@@ -852,7 +852,7 @@ class LldbGdbServerTestCase(gdbremote_testcase.GdbRemoteTestCaseBase, DwarfOpcod
         target_arch = self.getArchitecture()
 
         # Set the breakpoint.
-        if (target_arch == "arm") or (target_arch == "aarch64"):
+        if target_arch in ["arm", "arm64", "aarch64"]:
             # TODO: Handle case when setting breakpoint in thumb code
             BREAKPOINT_KIND = 4
         else:

--- a/lldb/tools/debugserver/source/MacOSX/arm64/DNBArchImplARM64.cpp
+++ b/lldb/tools/debugserver/source/MacOSX/arm64/DNBArchImplARM64.cpp
@@ -1643,7 +1643,7 @@ const DNBRegisterInfo DNBArchMachARM64::g_gpr_registers[] = {
     // used for
     // userland debugging.
     {e_regSetGPR, gpr_cpsr, "cpsr", "flags", Uint, Hex, 4,
-     GPR_OFFSET_NAME(cpsr), dwarf_elr_mode, dwarf_elr_mode, INVALID_NUB_REGNUM,
+     GPR_OFFSET_NAME(cpsr), dwarf_elr_mode, dwarf_elr_mode, GENERIC_REGNUM_FLAGS,
      debugserver_gpr_cpsr, NULL, NULL},
 
     DEFINE_PSEUDO_GPR_IDX(0, w0),


### PR DESCRIPTION
- [lldb] Update test_software_breakpoint_set_and_remove_work for AS
- [lldb] Set correct register number for cpsr (GENERIC_REGNUM_FLAGS)
