### PR TITLE
[lldb] Relax substring check in TestProtocolExtensionComputerProperty.py

### DIFF
--- a/lldb/test/API/lang/swift/protocol_extension_computed_property/main.swift
+++ b/lldb/test/API/lang/swift/protocol_extension_computed_property/main.swift
@@ -13,7 +13,7 @@ extension Measurement where UnitType == UnitAngle {
   }
 
   func f() {
-    return //%self.expect('p self.radians', substrs=["CGFloat) $R0 = 1.745"])
+    return //%self.expect('p self.radians', substrs=["CGFloat) $R0", "= 1.745"])
            //%self.expect('p self', substrs=["Measurement<UnitAngle>"])
   }
 }


### PR DESCRIPTION
Older versions of the SDK printed `$R0 = 1.7453292519943295` while newer
versions print `$R0 = (native = 1.7453292519943295)`. Update the
test to accept both.