### PR TITLE
[Clang] Avoid misleading 'conflicting types' diagnostic with no-proto…

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -3912,6 +3912,8 @@ bool Sema::MergeFunctionDecl(FunctionDecl *New, NamedDecl *&OldD, Scope *S,
     // ASTContext::typesAreCompatible().
     if (Old->hasPrototype() && !New->hasWrittenPrototype() && NewDeclIsDefn &&
         Old->getNumParams() != New->getNumParams()) {
+      if (Old->hasInheritedPrototype())
+        Old = Old->getCanonicalDecl();
       Diag(New->getLocation(), diag::err_conflicting_types) << New;
       Diag(Old->getLocation(), PrevDiag) << Old << Old->getType();
       return true;

--- a/clang/test/Sema/prototype-redecls.c
+++ b/clang/test/Sema/prototype-redecls.c
@@ -12,6 +12,10 @@ void blarg() {}       // expected-error {{conflicting types for 'blarg'}}
 void blerp(short);      // expected-note {{previous}}
 void blerp(x) int x; {} // expected-error {{conflicting types for 'blerp'}}
 
+void foo(int); // expected-note {{previous}}
+void foo();
+void foo() {} // expected-error {{conflicting types for 'foo'}}
+
 void glerp(int);
 void glerp(x) short x; {} // Okay, promoted type is fine
 


### PR DESCRIPTION
…type decls.

Clang has recently started diagnosing prototype redeclaration errors like [rG385e7df33046](https://reviews.llvm.org/rG385e7df33046d7292612ee1e3ac00a59d8bc0441)

This flagged legitimate issues in a codebase but was confusing to resolve because it actually conflicted with a function declaration from a system header and not from the one emitted with "note: ".

This patch updates the error handling to use the canonical declaration's source location instead to avoid misleading errors like the one described.

Reviewed By: aaron.ballman

Differential Revision: https://reviews.llvm.org/D126258

(cherry picked from commit a1a14e817eeb5a0663b1342a125674348b8aac06)