### PR TITLE
[lldb] Prevent underflow in crashlog.py

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -112,14 +112,12 @@ class CrashLog(symbolication.Symbolicator):
             for frame_idx, frame in enumerate(self.frames):
                 disassemble = (
                     this_thread_crashed or options.disassemble_all_threads) and frame_idx < options.disassemble_depth
-                if frame_idx == 0:
-                    symbolicated_frame_addresses = crash_log.symbolicate(
-                        frame.pc & crash_log.addr_mask, options.verbose)
-                else:
-                    # Any frame above frame zero and we have to subtract one to
-                    # get the previous line entry
-                    symbolicated_frame_addresses = crash_log.symbolicate(
-                        (frame.pc & crash_log.addr_mask) - 1, options.verbose)
+
+                # Any frame above frame zero and we have to subtract one to
+                # get the previous line entry.
+                pc = frame.pc & crash_log.addr_mask
+                pc = pc if frame_idx == 0 or pc == 0 else pc - 1
+                symbolicated_frame_addresses = crash_log.symbolicate(pc, options.verbose)
 
                 if symbolicated_frame_addresses:
                     symbolicated_frame_address_idx = 0

--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -113,8 +113,8 @@ class CrashLog(symbolication.Symbolicator):
                 disassemble = (
                     this_thread_crashed or options.disassemble_all_threads) and frame_idx < options.disassemble_depth
 
-                # Any frame above frame zero and we have to subtract one to
-                # get the previous line entry.
+                # Except for the zeroth frame, we should subtract 1 from every
+                # frame pc to get the previous line entry.
                 pc = frame.pc & crash_log.addr_mask
                 pc = pc if frame_idx == 0 or pc == 0 else pc - 1
                 symbolicated_frame_addresses = crash_log.symbolicate(pc, options.verbose)

--- a/lldb/examples/python/scripted_process/crashlog_scripted_process.py
+++ b/lldb/examples/python/scripted_process/crashlog_scripted_process.py
@@ -16,6 +16,7 @@ class CrashLogScriptedProcess(ScriptedProcess):
             return
 
         self.pid = crash_log.process_id
+        self.addr_mask = crash_log.addr_mask
         self.crashed_thread_idx = crash_log.crashed_thread_idx
         self.loaded_images = []
 
@@ -122,11 +123,13 @@ class CrashLogScriptedThread(ScriptedThread):
             return None
 
         for frame in self.backing_thread.frames:
+            frame_pc = frame.pc & self.scripted_process.addr_mask
+            pc = frame_pc if frame.index == 0  or frame_pc == 0 else frame_pc - 1
             sym_addr = lldb.SBAddress()
-            sym_addr.SetLoadAddress(frame.pc, self.target)
+            sym_addr.SetLoadAddress(pc, self.target)
             if not sym_addr.IsValid():
                 continue
-            self.frames.append({"idx": frame.index, "pc": frame.pc})
+            self.frames.append({"idx": frame.index, "pc": pc})
 
         return self.frames
 


### PR DESCRIPTION
Avoid a OverflowError (an underflow really) when the pc is zero. This
can happen for "unknown frames" where the crashlog generator reports a
zero pc. We could omit them altogether, but if they're part of the
crashlog it seems fair to display them in lldb as well.

rdar://92686666

Differential revision: https://reviews.llvm.org/D125716
Differential Revision: https://reviews.llvm.org/D125928

