### PR TITLE
LocationListLookup test case failing on lldb-arm-ubuntu

### DIFF
--- a/lldb/test/API/functionalities/location-list-lookup/TestLocationListLookup.py
+++ b/lldb/test/API/functionalities/location-list-lookup/TestLocationListLookup.py
@@ -14,6 +14,7 @@ class LocationListLookupTestCase(TestBase):
         # Call super's setUp().
         TestBase.setUp(self)
 
+    @skipIf(oslist=["linux"], archs=["arm"])
     def test_loclist(self):
         self.build()
         exe = self.getBuildArtifact("a.out")


### PR DESCRIPTION
LocationListLookup test case failing on lldb-arm-ubuntu

Skip on linux+arm for now until I can try to repo the setup of the
lldb-arm-ubuntu bot.  The name of the binary in argv[0] was not
able to be retrieved here; if the compiler's codegen had it stored
in a caller saved register, because it's not needed at this point,
it may not be retreivable.

(cherry picked from commit 9c8179f9ce10158d6a9f28ec932e2facfde413d8)
(cherry picked from commit f0b5a511bf02ae03fd188f2770024ab2a9fc687e)