### PR TITLE
[lldb] Pass the class type as a parameter to GetDynamicTypeAndAddress…

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -258,6 +258,7 @@ protected:
                                 bool is_indirect_enum_case);
 
   bool GetDynamicTypeAndAddress_Class(ValueObject &in_value,
+                                      CompilerType class_type,
                                       lldb::DynamicValueType use_dynamic,
                                       TypeAndOrName &class_type_or_name,
                                       Address &address);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3141,6 +3141,15 @@ bool TypeSystemSwiftTypeRef::IsImportedType(opaque_compiler_type_t type,
     Demangler dem;
     NodePointer node = GetDemangledType(dem, AsMangledName(type));
 
+    auto *log = GetLog(LLDBLog::Types);
+    // Types with generic parameters have to be resolved before calling
+    // IsImportedType.
+    if (log && ContainsGenericTypeParameter(node))
+      LLDB_LOGF(log,
+                "Checking if type %s which contains a generic parameter is "
+                "an imported type",
+                AsMangledName(type));
+
     // This is an imported Objective-C type; look it up in the debug info.
     StringRef ident = GetObjCTypeName(node);
     if (ident.empty())


### PR DESCRIPTION
…_Class

GetDynamicTypeAndAddress_Class may be called after resolving a bound type. We need to allow
the compiler type to be passed separately from value object for situations like this.