### PR TITLE
Skip all watchpoint hit-count/ignore-count tests for multithreaded API tests for now on arm64 Darwin.

### DIFF
--- a/lldb/test/API/commands/watchpoints/hello_watchlocation/TestWatchLocation.py
+++ b/lldb/test/API/commands/watchpoints/hello_watchlocation/TestWatchLocation.py
@@ -31,12 +31,18 @@ class HelloWatchLocationTestCase(TestBase):
         self.exe_name = self.testMethodName
         self.d = {'CXX_SOURCES': self.source, 'EXE': self.exe_name}
 
+    # on arm64 targets, lldb has incorrect hit-count / ignore-counts
+    # for watchpoints when they are hit with multiple threads at
+    # the same time.  Tracked as llvm.org/pr49433
+    # or rdar://93863107 inside Apple.
+    def affected_by_radar_93863107(self): 
+        return (self.getArchitecture() in ['arm64', 'arm64e']) and self.platformIsDarwin()
+
     # Most of the MIPS boards provide only one H/W watchpoints, and S/W
     # watchpoints are not supported yet
     @expectedFailureAll(triple=re.compile('^mips'))
     # SystemZ and PowerPC also currently supports only one H/W watchpoint
     @expectedFailureAll(archs=['powerpc64le', 's390x'])
-    @skipIfDarwin
     @skipIfWindows # This test is flaky on Windows
     def test_hello_watchlocation(self):
         """Test watching a location with '-s size' option."""
@@ -103,8 +109,13 @@ class HelloWatchLocationTestCase(TestBase):
                     substrs=[self.violating_func])
 
         # Use the '-v' option to do verbose listing of the watchpoint.
-        # The hit count should now be 1.
-        self.expect("watchpoint list -v",
-                    substrs=['hit_count = 1'])
+        # The hit count should now be the same as the number of threads that
+        # stopped on a watchpoint.
+        threads = lldbutil.get_stopped_threads(
+            self.process(), lldb.eStopReasonWatchpoint)
+
+        if not self.affected_by_radar_93863107():
+          self.expect("watchpoint list -v",
+                      substrs=['hit_count = %d' % len(threads)])
 
         self.runCmd("thread backtrace all")

--- a/lldb/test/API/commands/watchpoints/watchpoint_set_command/TestWatchLocationWithWatchSet.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_set_command/TestWatchLocationWithWatchSet.py
@@ -15,6 +15,13 @@ class WatchLocationUsingWatchpointSetTestCase(TestBase):
     mydir = TestBase.compute_mydir(__file__)
     NO_DEBUG_INFO_TESTCASE = True
 
+    # on arm64 targets, lldb has incorrect hit-count / ignore-counts
+    # for watchpoints when they are hit with multiple threads at
+    # the same time.  Tracked as llvm.org/pr49433
+    # or rdar://93863107 inside Apple.
+    def affected_by_radar_93863107(self):
+        return (self.getArchitecture() in ['arm64', 'arm64e']) and self.platformIsDarwin()
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)
@@ -102,7 +109,9 @@ class WatchLocationUsingWatchpointSetTestCase(TestBase):
         # stopped on a watchpoint.
         threads = lldbutil.get_stopped_threads(
             self.process(), lldb.eStopReasonWatchpoint)
-        self.expect("watchpoint list -v",
-                    substrs=['hit_count = %d' % len(threads)])
+
+        if not self.affected_by_radar_93863107():
+          self.expect("watchpoint list -v",
+                      substrs=['hit_count = %d' % len(threads)])
 
         self.runCmd("thread backtrace all")

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyWatchpoints.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyWatchpoints.py
@@ -15,7 +15,7 @@ class ConcurrentManyWatchpoints(ConcurrentEventsBase):
     @skipIf(
         oslist=["ios", "watchos", "tvos", "bridgeos", "macosx"],
         archs=['arm64', 'arm64e', 'arm64_32', 'arm'],
-        bugnumber="rdar://81811539")
+        bugnumber="rdar://93863107")
     @add_test_categories(["watchpoint"])
     @skipIfOutOfTreeDebugserver
     def test(self):

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentNWatchNBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentNWatchNBreak.py
@@ -18,7 +18,7 @@ class ConcurrentNWatchNBreak(ConcurrentEventsBase):
     @skipIf(
         oslist=["ios", "watchos", "tvos", "bridgeos", "macosx"],
         archs=['arm64', 'arm64e', 'arm64_32', 'arm'],
-        bugnumber="rdar://81811539")
+        bugnumber="rdar://93863107")
     @add_test_categories(["watchpoint"])
     def test(self):
         """Test with 5 watchpoint and breakpoint threads."""

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalNWatchNBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalNWatchNBreak.py
@@ -19,7 +19,7 @@ class ConcurrentSignalNWatchNBreak(ConcurrentEventsBase):
     @skipIf(
         oslist=["ios", "watchos", "tvos", "bridgeos", "macosx"],
         archs=['arm64', 'arm64e', 'arm64_32', 'arm'],
-        bugnumber="rdar://81811539")
+        bugnumber="rdar://93863107")
     @add_test_categories(["watchpoint"])
     def test(self):
         """Test one signal thread with 5 watchpoint and breakpoint threads."""

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalWatch.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalWatch.py
@@ -16,7 +16,7 @@ class ConcurrentSignalWatch(ConcurrentEventsBase):
     @skipIf(
         oslist=["ios", "watchos", "tvos", "bridgeos", "macosx"],
         archs=['arm64', 'arm64e', 'arm64_32', 'arm'],
-        bugnumber="rdar://81811539")
+        bugnumber="rdar://93863107")
     @add_test_categories(["watchpoint"])
     def test(self):
         """Test a watchpoint and a signal in multiple threads."""

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalWatchBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalWatchBreak.py
@@ -17,7 +17,7 @@ class ConcurrentSignalWatchBreak(ConcurrentEventsBase):
     @skipIf(
         oslist=["ios", "watchos", "tvos", "bridgeos", "macosx"],
         archs=['arm64', 'arm64e', 'arm64_32', 'arm'],
-        bugnumber="rdar://81811539")
+        bugnumber="rdar://93863107")
     @add_test_categories(["watchpoint"])
     def test(self):
         """Test a signal/watchpoint/breakpoint in multiple threads."""

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointThreads.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointThreads.py
@@ -16,7 +16,7 @@ class ConcurrentTwoWatchpointThreads(ConcurrentEventsBase):
     @skipIf(
         oslist=["ios", "watchos", "tvos", "bridgeos", "macosx"],
         archs=['arm64', 'arm64e', 'arm64_32', 'arm'],
-        bugnumber="rdar://81811539")
+        bugnumber="rdar://93863107")
     @add_test_categories(["watchpoint"])
     def test(self):
         """Test two threads that trigger a watchpoint. """

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneBreakpoint.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneBreakpoint.py
@@ -16,7 +16,7 @@ class ConcurrentTwoWatchpointsOneBreakpoint(ConcurrentEventsBase):
     @skipIf(
         oslist=["ios", "watchos", "tvos", "bridgeos", "macosx"],
         archs=['arm64', 'arm64e', 'arm64_32', 'arm'],
-        bugnumber="rdar://81811539")
+        bugnumber="rdar://93863107")
     @add_test_categories(["watchpoint"])
     def test(self):
         """Test two threads that trigger a watchpoint and one breakpoint thread. """

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneDelayBreakpoint.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneDelayBreakpoint.py
@@ -16,7 +16,7 @@ class ConcurrentTwoWatchpointsOneDelayBreakpoint(ConcurrentEventsBase):
     @skipIf(
         oslist=["ios", "watchos", "tvos", "bridgeos", "macosx"],
         archs=['arm64', 'arm64e', 'arm64_32', 'arm'],
-        bugnumber="rdar://81811539")
+        bugnumber="rdar://93863107")
     @add_test_categories(["watchpoint"])
     def test(self):
         """Test two threads that trigger a watchpoint and one (1 second delay) breakpoint thread. """

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneSignal.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneSignal.py
@@ -17,7 +17,7 @@ class ConcurrentTwoWatchpointsOneSignal(ConcurrentEventsBase):
     @skipIf(
         oslist=["ios", "watchos", "tvos", "bridgeos", "macosx"],
         archs=['arm64', 'arm64e', 'arm64_32', 'arm'],
-        bugnumber="rdar://81811539")
+        bugnumber="rdar://93863107")
     @add_test_categories(["watchpoint"])
     def test(self):
         """Test two threads that trigger a watchpoint and one signal thread. """

--- a/lldb/test/API/python_api/watchpoint/TestWatchpointIgnoreCount.py
+++ b/lldb/test/API/python_api/watchpoint/TestWatchpointIgnoreCount.py
@@ -25,6 +25,13 @@ class WatchpointIgnoreCountTestCase(TestBase):
         self.line = line_number(
             self.source, '// Set break point at this line.')
 
+    # on arm64 targets, lldb has incorrect hit-count / ignore-counts
+    # for watchpoints when they are hit with multiple threads at
+    # the same time.  Tracked as llvm.org/pr49433
+    # or rdar://93863107 inside Apple.
+    def affected_by_radar_93863107(self):
+        return (self.getArchitecture() in ['arm64', 'arm64e']) and self.platformIsDarwin()
+
     # Read-write watchpoints not supported on SystemZ
     @expectedFailureAll(archs=['s390x'])
     def test_set_watch_ignore_count(self):
@@ -87,5 +94,6 @@ class WatchpointIgnoreCountTestCase(TestBase):
         # Verify some vital statistics.
         self.assertTrue(watchpoint)
         self.assertEqual(watchpoint.GetWatchSize(), 4)
-        self.assertEqual(watchpoint.GetHitCount(), 2)
+        if not self.affected_by_radar_93863107():
+          self.assertEqual(watchpoint.GetHitCount(), 2)
         print(watchpoint)


### PR DESCRIPTION
Skip all watchpoint hit-count/ignore-count tests for multithreaded
API tests for now on arm64 Darwin.

On AArch64, insns that trigger a WP are rolled back and we are
notified.  lldb needs to disable the WP, insn step, re-enable it,
then report it to the user.  lldb only does this full step action
for the "selected thread", and so when a program stops with
multiple threads hitting a stop reason, some of them watchpoints,
any non-selected-thread will not be completed in this way.  But
all threads with the initial watchpoint exception will have their
hit-count/ignore-counts updated.  When we resume execution, the
other threads sitting at the instruction will again execute &
trigger the WP exceptoin again, repeating until we've gone through
all of the threads.

This bug is being tracked in llvm.org/pr49433 and inside apple
in rdar://93863107

(cherry picked from commit bef4da4a6aef8196f007f44e3e9c8e3419ffb623)