### PR TITLE
Update three tests to realpath paths that we compare to dyld paths

### DIFF
--- a/lldb/test/API/commands/platform/sdk/TestPlatformSDK.py
+++ b/lldb/test/API/commands/platform/sdk/TestPlatformSDK.py
@@ -58,6 +58,7 @@ class PlatformSDKTestCase(TestBase):
 
         # Create a fake 'SDK' directory.
         test_home = os.path.join(self.getBuildDir(), 'fake_home.noindex')
+        test_home = os.path.realpath(test_home)
         macos_version = platform.mac_ver()[0]
         sdk_dir = os.path.join(test_home, 'Library', 'Developer', 'Xcode',
                                'macOS DeviceSupport', macos_version)

--- a/lldb/test/API/macosx/function-starts/TestFunctionStarts.py
+++ b/lldb/test/API/macosx/function-starts/TestFunctionStarts.py
@@ -35,7 +35,7 @@ class FunctionStartsTestCase(TestBase):
         """Run the binary, stop at our unstripped function,
            make sure the caller has synthetic symbols"""
 
-        exe = self.getBuildArtifact(exe_name)
+        exe = os.path.realpath(self.getBuildArtifact(exe_name))
         # Now strip the binary, but leave externals so we can break on dont_strip_me.
         self.runBuildCommand(["strip", "-u", "-x", "-S", exe])
 

--- a/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
+++ b/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
@@ -68,7 +68,7 @@ class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
                 'ARCH': arch,
                 'ARCH_CFLAGS': '-target {} {}'.format(triple, version_min),
             })
-        exe_path = self.getBuildArtifact(exe_name)
+        exe_path = os.path.realpath(self.getBuildArtifact(exe_name))
         cmd = [
             'xcrun', 'simctl', 'spawn', '-s', deviceUDID, exe_path,
             'print-pid', 'sleep:10'


### PR DESCRIPTION
Update three tests to realpath paths that we compare to dyld paths

I get to my work directory through a symlink, so the pathnames the
tests get for their build artifacts etc are via that symlink.  There
are three tests which compare those symlink paths to a directory
received from dyld on macOS, which is the actual real pathname.

These tests have always failed for me on my dekstop but I finally
sat down to figure out why. Easy quick fix.

(cherry picked from commit 8ee35c5558aa86e3be5f2882f1db030d6281578f)