### PR TITLE
[C++-Interop] Use the QualType name for an anonymous enum in APINotes Tag lookup

### DIFF
--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -15,6 +15,7 @@
 #include "clang/Sema/SemaInternal.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/APINotes/APINotesReader.h"
+#include "clang/Lex/Lexer.h"
 using namespace clang;
 
 namespace {
@@ -856,8 +857,32 @@ void Sema::ProcessAPINotes(Decl *D) {
 
     // Tags
     if (auto Tag = dyn_cast<TagDecl>(D)) {
+      std::string LookupName = Tag->getName().str();
+
+      // Use the source location to discern if this Tag is an OPTIONS macro.
+      // For now we would like to limit this trick of looking up the APINote tag
+      // using the EnumDecl's QualType in the case where the enum is anonymous.
+      // This is only being used to support APINotes lookup for C++ NS/CF_OPTIONS
+      // when C++-Interop is enabled.
+      std::string MacroName =
+          LookupName.empty() && Tag->getOuterLocStart().isMacroID()
+              ? clang::Lexer::getImmediateMacroName(
+                    Tag->getOuterLocStart(),
+                    Tag->getASTContext().getSourceManager(), LangOpts)
+                    .str()
+              : "";
+
+      if (LookupName.empty() && isa<clang::EnumDecl>(Tag) &&
+          (MacroName == "CF_OPTIONS" || MacroName == "NS_OPTIONS" ||
+           MacroName == "OBJC_OPTIONS" || MacroName == "SWIFT_OPTIONS")) {
+
+        clang::QualType T = llvm::cast<clang::EnumDecl>(Tag)->getIntegerType();
+        LookupName = clang::QualType::getAsString(
+            T.split(), getASTContext().getPrintingPolicy());
+      }
+
       for (auto Reader : APINotes.findAPINotes(D->getLocation())) {
-        auto Info = Reader->lookupTag(Tag->getName());
+        auto Info = Reader->lookupTag(LookupName);
         ProcessVersionedAPINotes(*this, Tag, Info);
       }
 

--- a/clang/test/APINotes/Inputs/Frameworks/CXXInteropKit.framework/Headers/CXXInteropKit.apinotes
+++ b/clang/test/APINotes/Inputs/Frameworks/CXXInteropKit.framework/Headers/CXXInteropKit.apinotes
@@ -10,3 +10,6 @@ Classes:
 Enumerators:
 - Name: SomeClassRed
   SwiftName: red
+Tags:
+- Name: NSSomeEnumOptions
+  SwiftName: SomeEnum.Options

--- a/clang/test/APINotes/Inputs/Frameworks/CXXInteropKit.framework/Headers/CXXInteropKit.h
+++ b/clang/test/APINotes/Inputs/Frameworks/CXXInteropKit.framework/Headers/CXXInteropKit.h
@@ -11,3 +11,13 @@
 
 // Named "SomeClassRed" for ast node filtering in the test.
 enum ColorEnum { SomeClassRed, SomeClassGreen, SomeClassBlue };
+
+#define CF_OPTIONS(_type, _name) _type __attribute__((availability(swift, unavailable))) _name; enum : _name
+#define NS_OPTIONS(_type, _name) CF_OPTIONS(_type, _name)
+
+typedef unsigned long NSUInteger;
+typedef NS_OPTIONS(NSUInteger, NSSomeEnumOptions) {
+	NSSomeEnumWithRed = 1,
+	NSSomeEnumWithGreen,
+	NSSomeEnumWithBlue,
+};

--- a/clang/test/APINotes/objcxx-swift-name.m
+++ b/clang/test/APINotes/objcxx-swift-name.m
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/CxxInterop -fdisable-module-hash -fapinotes-modules -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -x objective-c++
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/CxxInterop -fdisable-module-hash -fapinotes-modules -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter SomeClass -x objective-c++ | FileCheck %s
+// RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/CxxInterop -fdisable-module-hash -fapinotes-modules -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter "(anonymous)" -x objective-c++ | FileCheck -check-prefix=CHECK-ANONYMOUS-ENUM %s
 
 #import <CxxInteropKit/CxxInteropKit.h>
 
@@ -16,3 +17,7 @@
 // CHECK: Dumping SomeClassRed:
 // CHECK-NEXT: EnumConstantDecl {{.+}} imported in CxxInteropKit SomeClassRed 'ColorEnum'
 // CHECK-NEXT: SwiftNameAttr {{.+}} <<invalid sloc>> "red"
+
+// CHECK-ANONYMOUS-ENUM: Dumping (anonymous):
+// CHECK-ANONYMOUS-ENUM-NEXT: EnumDecl {{.+}} imported in CxxInteropKit <undeserialized declarations> 'NSSomeEnumOptions':'unsigned long'
+// CHECK-ANONYMOUS-ENUM-NEXT: SwiftNameAttr {{.+}} <<invalid sloc>> "SomeEnum.Options"


### PR DESCRIPTION
Because of proposed changes to CFAvailability.h for CF_OPTIONS in the presence of C++ and Swift C++-Interop, the EnumDecls that APINotes receives are anonymous. This is problematic or Tag lookups for things like mapping NSISO8601DateFormatOptions to  ISO8601DateFormatter.Options. Specific examples are Foundation.apinotes:

```
---
Name: Foundation
Tags:
- Name: NSISO8601DateFormatOptions
  SwiftName: ISO8601DateFormatter.Options
```

In the case of a Tag lookup where we encounter an anonymous enum, we attempt to use the EnumDecl's QualType's name.

This assumes a CF_OPTIONS that looks something like the following in the __cplusplus case:


```
#define CF_OPTIONS(_type, _name) _type __attribute__((availability(swift, unavailable))) _name; \
    enum __CF_OPTIONS_ATTRIBUTES : _name
```

I am still working on standalone test here, but I have tested this on Foundation.NSISO8601DateFormatter.