### PR TITLE
Check that a FileSpec has a Directory component before using

### DIFF
--- a/lldb/source/Core/SourceManager.cpp
+++ b/lldb/source/Core/SourceManager.cpp
@@ -51,6 +51,7 @@ static inline bool is_newline_char(char ch) { return ch == '\n' || ch == '\r'; }
 
 static void resolve_tilde(FileSpec &file_spec) {
   if (!FileSystem::Instance().Exists(file_spec) &&
+      file_spec.GetDirectory() &&
       file_spec.GetDirectory().GetCString()[0] == '~') {
     FileSystem::Instance().Resolve(file_spec);
   }


### PR DESCRIPTION
Check that a FileSpec has a Directory component before using

A follow on to my patch for https://reviews.llvm.org/D126435
hit by an x86_64 linux bot; I assumed that a FileSpec had a
directory component and checked if the first character was a
'~'.  This was not a valid assumption.

(cherry picked from commit bd67468645c08a96aec7839c30385956edd88021)