### PR TITLE
One further tweak for realpathing filepath to match dyld

### DIFF
--- a/lldb/test/API/commands/platform/sdk/TestPlatformSDK.py
+++ b/lldb/test/API/commands/platform/sdk/TestPlatformSDK.py
@@ -85,7 +85,7 @@ class PlatformSDKTestCase(TestBase):
         lldbutil.wait_for_file_on_target(self, token)
 
         # Move the binary into the 'SDK'.
-        rel_exe_path = os.path.relpath(exe, '/')
+        rel_exe_path = os.path.relpath(os.path.realpath(exe), '/')
         exe_sdk_path = os.path.join(symbols_dir, rel_exe_path)
         lldbutil.mkdir_p(os.path.dirname(exe_sdk_path))
         shutil.move(exe, exe_sdk_path)


### PR DESCRIPTION
One further tweak for realpathing filepath to match dyld

I missed one place I need to realpath the build artifact path,
to make it match the path we get back from dyld.

(cherry picked from commit ea6d0c4b2a1ec9c12aa5513ddf574f3146cf9025)