### PR TITLE
[lldb] Add tests for Swift regex support

### DIFF
--- a/lldb/test/API/lang/swift/regex/Makefile
+++ b/lldb/test/API/lang/swift/regex/Makefile
@@ -1,0 +1,5 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -Xfrontend -enable-bare-slash-regex -Xfrontend -disable-availability-checking
+
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
+++ b/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
@@ -1,0 +1,56 @@
+# TestSwiftRegex.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+"""
+Test Swift's regex support
+"""
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftRegex(TestBase):
+    mydir = TestBase.compute_mydir(__file__)
+
+    def setUp(self):
+        TestBase.setUp(self)
+        self.main_source = "main.swift"
+        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+
+    @swiftTest
+    def test_swift_regex(self):
+        """Test Swift's regex support"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'Set breakpoint here', self.main_source_spec)
+        self.expect('v regex',
+                    substrs=['_StringProcessing.Regex<(Substring, Substring, Substring, Substring)>) regex = {'])
+        self.expect('po regex',
+                    substrs=['Regex<(Substring, Substring, Substring, Substring)>'])
+
+        self.expect('v dslRegex',
+                    substrs=['(_StringProcessing.Regex<Substring>) dslRegex = {'])
+        self.expect('po dslRegex',
+                    substrs=['Regex<Substring>'])
+
+    @swiftTest
+    # Expected to fail because of availability checking while Regex support isn't stabilized
+    @expectedFailureDarwin
+    def test_swift_regex_in_exp(self):
+        """Test Swift's regex support"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'Set breakpoint here', self.main_source_spec)
+        self.runCmd(
+            "settings set target.experimental.swift-enable-bare-slash-regex true")
+        self.expect('e -- /Order from <(.*)>, type: (.*), count in dozen: ([0-9]+)/',
+                    substrs=['_StringProcessing.Regex<(Substring, Substring, Substring, Substring)>'])

--- a/lldb/test/API/lang/swift/regex/main.swift
+++ b/lldb/test/API/lang/swift/regex/main.swift
@@ -1,0 +1,19 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+import RegexBuilder
+
+let regex = /Order from <(.*)>, type: (.*), count in dozen: ([0-9]+)/
+
+let dslRegex = Regex { .digit }
+
+print(regex) // Set breakpoint here
+

--- a/lldb/test/Shell/SwiftREPL/Regex.test
+++ b/lldb/test/Shell/SwiftREPL/Regex.test
@@ -1,0 +1,14 @@
+// Test that we can use Swift's regex functionalities on the REPL.
+// REQUIRES: swift
+// XFAIL: system-darwin
+// This is expected to fail on macOS for now because Regex has an availability of 9999 (for now).
+
+// RUN: %lldb --repl < %s | FileCheck %s
+
+:settings set target.experimental.swift-enable-bare-slash-regex true
+let regex = /Order from <(.*)>, type: (.*), count in dozen: ([0-9]+)/
+// CHECK: _StringProcessing.Regex<(Substring, Substring, Substring, Substring)> =
+
+import RegexBuilder
+let dslRegex = Regex { .digit }
+// CHECK: _StringProcessing.Regex<Substring> =


### PR DESCRIPTION
rdar://93102841, rdar://93102751
(cherry picked from commit 229bc99d746fa2aba87c09c11f583e8b50392bd1)