### PR TITLE
[lldb] Remove explicit '_Concurrency' import from playgrounds test

### DIFF
--- a/lldb/test/API/lang/swift/playgrounds/Concurrency.swift
+++ b/lldb/test/API/lang/swift/playgrounds/Concurrency.swift
@@ -1,4 +1,3 @@
-import _Concurrency
 import Darwin
 // Test that the pass pipeline is set up to support concurrency.
 var i: Int = 0


### PR DESCRIPTION
(cherry picked from commit 9034bc55fb2573b9c0fccf4097bbdb1b1296f903)