### PR TITLE
[CAS] Fix dropped reference when expanding from 4B to 8B references

### DIFF
--- a/llvm/lib/CAS/OnDiskCAS.cpp
+++ b/llvm/lib/CAS/OnDiskCAS.cpp
@@ -325,6 +325,7 @@ public:
     FullRefs.reserve(SmallRefs.size() + 1);
     for (InternalRef4B Small : SmallRefs)
       FullRefs.push_back(Small);
+    FullRefs.push_back(Ref);
     SmallRefs.clear();
   }
 


### PR DESCRIPTION
When we detect a reference that doesn't fit in OnDiskCAS's 4B format, we
were expanding the existing references to 8B, but forgot to add the
reference that triggered the conversion, causing corrupt CAS objects.

rdar://93936479