### PR TITLE
[CAS] Add an option to validate CASID in CASDB

### DIFF
--- a/llvm/include/llvm/CAS/CASDB.h
+++ b/llvm/include/llvm/CAS/CASDB.h
@@ -248,6 +248,8 @@ public:
   template <class ProxyT, class HandleT>
   Expected<ProxyT> loadObjectProxy(Expected<HandleT> H);
 
+  virtual Error validateObject(const CASID &ID) = 0;
+
 public:
   /// FIXME: Delete these. Update callers to call \a loadObject() and create
   /// the proxy themselves.

--- a/llvm/lib/CAS/BuiltinCAS.h
+++ b/llvm/lib/CAS/BuiltinCAS.h
@@ -233,6 +233,8 @@ public:
                              "result cache corrupt for '" + Input.toString() +
                                  "'");
   }
+
+  Error validateObject(const CASID &ID) final;
 };
 
 } // end namespace builtin

--- a/llvm/unittests/CAS/CASDBTest.cpp
+++ b/llvm/unittests/CAS/CASDBTest.cpp
@@ -94,6 +94,10 @@ multiline text multiline text multiline text multiline text multiline text)",
     EXPECT_EQ(IDs[I], Blob->getID());
   }
 
+  // Run validation on all CASIDs.
+  for (int I = 0, E = IDs.size(); I != E; ++I)
+    ASSERT_THAT_ERROR(CAS1->validateObject(IDs[I]), Succeeded());
+
   // Check that the blobs can be retrieved multiple times.
   for (int I = 0, E = IDs.size(); I != E; ++I) {
     for (int J = 0, JE = 3; J != JE; ++J) {
@@ -133,10 +137,15 @@ TEST_P(CASDBTest, BlobsBig) {
     Optional<CASID> ID2;
     ASSERT_THAT_ERROR(CAS->createBlob(String1).moveInto(ID1), Succeeded());
     ASSERT_THAT_ERROR(CAS->createBlob(String1).moveInto(ID2), Succeeded());
+    ASSERT_THAT_ERROR(CAS->validateObject(*ID1), Succeeded());
+    ASSERT_THAT_ERROR(CAS->validateObject(*ID2), Succeeded());
     ASSERT_EQ(ID1, ID2);
+
     String1.append(String2);
     ASSERT_THAT_ERROR(CAS->createBlob(String2).moveInto(ID1), Succeeded());
     ASSERT_THAT_ERROR(CAS->createBlob(String2).moveInto(ID2), Succeeded());
+    ASSERT_THAT_ERROR(CAS->validateObject(*ID1), Succeeded());
+    ASSERT_THAT_ERROR(CAS->validateObject(*ID2), Succeeded());
     ASSERT_EQ(ID1, ID2);
     String2.append(String1);
   }
@@ -220,6 +229,10 @@ TEST_P(CASDBTest, Trees) {
                       Succeeded());
     EXPECT_EQ(FlatTreeEntries[I].size(), NumCalls);
   }
+
+  // Run validation.
+  for (int I = 1, E = FlatIDs.size(); I != E; ++I)
+    ASSERT_THAT_ERROR(CAS1->validateObject(FlatIDs[I]), Succeeded());
 
   // Confirm these trees don't exist in a fresh CAS instance. Skip the first
   // tree, which is empty and could be implicitly in some CAS.
@@ -306,6 +319,7 @@ TEST_P(CASDBTest, Trees) {
       ASSERT_THAT_ERROR(CAS->createTree(NewEntries).moveInto(Tree),
                         Succeeded());
       ASSERT_EQ(*ID, Tree->getID());
+      ASSERT_THAT_ERROR(CAS->validateObject(*ID), Succeeded());
       Tree.reset();
       ASSERT_THAT_ERROR(CAS->getTree(*ID).moveInto(Tree), Succeeded());
       for (int I = 0, E = NewEntries.size(); I != E; ++I)
@@ -437,6 +451,9 @@ TEST_P(CASDBTest, NodesBig) {
       CreatedNodes.emplace_back(Node->getID());
     }
   }
+
+  for (auto ID: CreatedNodes)
+    ASSERT_THAT_ERROR(CAS->validateObject(ID), Succeeded());
 }
 
 INSTANTIATE_TEST_SUITE_P(InMemoryCAS, CASDBTest, ::testing::Values([](int) {


### PR DESCRIPTION
Add a debug option that validate a CASID in the CASDB by loading the
object then rehash its content to make sure it matches the hash value
from the CASID.