### PR TITLE
Split Debug Abbreviation section up by creating an abbreviation contribution per compile unit

### DIFF
--- a/llvm/include/llvm/CodeGen/DIE.h
+++ b/llvm/include/llvm/CodeGen/DIE.h
@@ -153,8 +153,12 @@ public:
   /// owned by this class.
   DIEAbbrev &uniqueAbbreviation(DIE &Die);
 
-  /// Print all abbreviations using the specified asm printer.
-  void Emit(const AsmPrinter *AP, MCSection *Section) const;
+  /// Print all abbreviations using the specified AsmPrinter. This function
+  /// does not switch to the Abbreviation section, this is should be done before
+  /// it is called.
+  void Emit(const AsmPrinter *AP) const;
+
+  bool isAbbreviationListEmpty() { return Abbreviations.empty(); }
 };
 
 //===--------------------------------------------------------------------===//
@@ -830,8 +834,10 @@ public:
   /// \param CUOffset the compile/type unit relative offset in bytes.
   /// \returns the offset for the DIE that follows this DIE within the
   /// current compile/type unit.
-  unsigned computeOffsetsAndAbbrevs(const dwarf::FormParams &FormParams,
-                                    DIEAbbrevSet &AbbrevSet, unsigned CUOffset);
+  unsigned computeOffsetsAndAbbrevs(
+      const dwarf::FormParams &FormParams,
+      std::vector<std::unique_ptr<DIEAbbrevSet>> &AbbrevSetVec,
+      unsigned CUOffset);
 
   /// Climb up the parent chain to get the compile unit or type unit DIE that
   /// this DIE belongs to.

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -2161,7 +2161,9 @@ void DwarfDebug::beginFunctionImpl(const MachineFunction *MF) {
     DICompileUnit *DCU = SP->getUnit();
     DICompileUnit *NewDCU = DIB.createCompileUnit(
         DCU->getSourceLanguage(), DCU->getFile(), DCU->getProducer(),
-        DCU->isOptimized(), DCU->getFlags(), DCU->getRuntimeVersion());
+        DCU->isOptimized(), DCU->getFlags(), DCU->getRuntimeVersion(), {},
+        DICompileUnit::DebugEmissionKind::FullDebug, 0, true, false,
+        DICompileUnit::DebugNameTableKind::Default, false, {}, {}, true);
 
     this->SingleCU = false;
     DwarfCompileUnit &CU = getOrCreateDwarfCompileUnit(NewDCU);

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfFile.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfFile.cpp
@@ -18,7 +18,9 @@
 using namespace llvm;
 
 DwarfFile::DwarfFile(AsmPrinter *AP, StringRef Pref, BumpPtrAllocator &DA)
-    : Asm(AP), Abbrevs(AbbrevAllocator), StrPool(DA, *Asm, Pref) {}
+    : Asm(AP), StrPool(DA, *Asm, Pref) {
+  Abbrevs.emplace_back(std::make_unique<DIEAbbrevSet>(AbbrevAllocator));
+}
 
 void DwarfFile::addUnit(std::unique_ptr<DwarfCompileUnit> U) {
   CUs.push_back(std::move(U));
@@ -27,8 +29,19 @@ void DwarfFile::addUnit(std::unique_ptr<DwarfCompileUnit> U) {
 // Emit the various dwarf units to the unit section USection with
 // the abbreviations going into ASection.
 void DwarfFile::emitUnits(bool UseOffsets) {
-  for (const auto &TheU : CUs)
+  bool FirstContribution = true;
+  for (const auto &TheU : CUs) {
+    getOrCreateAbbrevSectionStart();
+    TheU.get()->setAbbrevSectionBegin(AbbrevSectionStart);
+    // If there is only one Abbreviation contribution or we are working with the
+    // first compile unit, we can avoid label arithmetic by setting the offset
+    // to the start of the section.
+    if (FirstContribution || Abbrevs.size() == 1) {
+      FirstContribution = false;
+      TheU.get()->setAbbrevOffset(AbbrevSectionStart);
+    }
     emitUnit(TheU.get(), UseOffsets);
+  }
 }
 
 void DwarfFile::emitUnit(DwarfUnit *TheU, bool UseOffsets) {
@@ -53,6 +66,12 @@ void DwarfFile::emitUnit(DwarfUnit *TheU, bool UseOffsets) {
     Asm->OutStreamer->emitLabel(EndLabel);
 }
 
+MCSymbol *DwarfFile::getOrCreateAbbrevSectionStart() {
+  if (!AbbrevSectionStart)
+    AbbrevSectionStart = Asm->createTempSymbol("debug_abbrev_begin");
+  return AbbrevSectionStart;
+}
+
 // Compute the size and offset for each DIE.
 void DwarfFile::computeSizeAndOffsets() {
   // Offset from the first CU in the debug info section is 0 initially.
@@ -71,6 +90,14 @@ void DwarfFile::computeSizeAndOffsets() {
 
     TheU->setDebugSectionOffset(SecOffset);
     SecOffset += computeSizeAndOffsetsForUnit(TheU.get());
+    // Only push_back a new .debug_abbrev contribution when emitting
+    // CAS-friendly debug info, and make sure to not add an extra compile unit.
+    // An initial Abbreviation contribution is pushed back when the DwarfFile is
+    // created because there are cases where the compile units are emitted
+    // without computing size and offsets for each DIE.
+    if (Abbrevs.size() != CUs.size() && TheU->getCUNode()->isCasFriendly()) {
+      Abbrevs.emplace_back(std::make_unique<DIEAbbrevSet>(AbbrevAllocator));
+    }
   }
   if (SecOffset > UINT32_MAX && !Asm->isDwarf64())
     report_fatal_error("The generated debug information is too large "
@@ -94,7 +121,42 @@ unsigned DwarfFile::computeSizeAndOffset(DIE &Die, unsigned Offset) {
                                       Offset);
 }
 
-void DwarfFile::emitAbbrevs(MCSection *Section) { Abbrevs.Emit(Asm, Section); }
+void DwarfFile::emitAbbrevs(MCSection *Section) {
+  // If the abbreviation vector only has one .debug_abbrev contribution and the
+  // contribution has non-zero abbreviations in use, emit it without emitting
+  // any labels. This is done because there are some targets do not support
+  // labels inside debug sections.
+  if (Abbrevs.size() == 1 && !Abbrevs[0]->isAbbreviationListEmpty()) {
+    Asm->OutStreamer->SwitchSection(Section);
+    Abbrevs[0]->Emit(Asm);
+    return;
+  }
+  for (unsigned I = 0; I < Abbrevs.size(); I++) {
+    // If the abbreviation contribution is empty, do not
+    // switch sections or emit labels.
+    if (Abbrevs[I]->isAbbreviationListEmpty())
+      continue;
+
+    Asm->OutStreamer->SwitchSection(Section);
+    MCSymbol *AbbrevStartSym = getOrCreateAbbrevSectionStart();
+    // Do not emit the same label again, AbbrevStartSym should be the same for
+    // all abbreviation contributions, it denotes the start of the
+    // abbreviation Section.
+    if (!AbbrevStartEmitted) {
+      AbbrevStartEmitted = true;
+      Asm->OutStreamer->emitLabel(AbbrevStartSym);
+    }
+    CUs[I]->setAbbrevSectionBegin(AbbrevSectionStart);
+    // If this is the first abbreviation contribution, we do not emit label
+    // differences, therefore the abbreviation offset is set to be the same
+    // as the start of the abbreviation section.
+    if (I == 0)
+      CUs[0]->setAbbrevOffset(AbbrevSectionStart);
+    else
+      Asm->OutStreamer->emitLabel(CUs[I]->getOrCreateAbbrevOffset());
+    Abbrevs[I]->Emit(Asm);
+  }
+}
 
 // Emit strings into a string section.
 void DwarfFile::emitStrings(MCSection *StrSection, MCSection *OffsetSection,

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfFile.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfFile.h
@@ -18,6 +18,7 @@
 #include <map>
 #include <memory>
 #include <utility>
+#include <vector>
 
 namespace llvm {
 
@@ -47,13 +48,21 @@ struct RangeSpanList {
 };
 
 class DwarfFile {
+
+  // A flag to denote if the label corresponding to the start of the
+  // Abbreviation Section has been emitted.
+  bool AbbrevStartEmitted = false;
+
+  // A label corresponding to the start of the Abbreviation Section.
+  MCSymbol *AbbrevSectionStart = nullptr;
+
   // Target of Dwarf emission, used for sizing of abbreviations.
   AsmPrinter *Asm;
 
   BumpPtrAllocator AbbrevAllocator;
 
   // Used to uniquely define abbreviations.
-  DIEAbbrevSet Abbrevs;
+  std::vector<std::unique_ptr<DIEAbbrevSet>> Abbrevs;
 
   // A pointer to all units in the section.
   SmallVector<std::unique_ptr<DwarfCompileUnit>, 1> CUs;
@@ -109,6 +118,10 @@ public:
   const SmallVectorImpl<RangeSpanList> &getRangeLists() const {
     return CURangeLists;
   }
+
+  /// Create the label for the start of the Abbreviation Section and return it,
+  /// and if it already exists, just return it.
+  MCSymbol *getOrCreateAbbrevSectionStart();
 
   /// Compute the size and offset of a DIE given an incoming Offset.
   unsigned computeSizeAndOffset(DIE &Die, unsigned Offset);

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -1762,16 +1762,27 @@ void DwarfUnit::emitCommonHeader(bool UseOffsets, dwarf::UnitType UT) {
     Asm->emitInt8(Asm->MAI->getCodePointerSize());
   }
 
-  // We share one abbreviations table across all units so it's always at the
-  // start of the section. Use a relocatable offset where needed to ensure
-  // linking doesn't invalidate that offset.
+  // Since there can be multiple compile units in one translation unit, every
+  // DwarfUnit has its own Abbreviation Offset begin and end labels that are
+  // used to calculate the offset into the abbreviations section that pertains
+  // to that compile unit.
   Asm->OutStreamer->AddComment("Offset Into Abbrev. Section");
-  const TargetLoweringObjectFile &TLOF = Asm->getObjFileLowering();
-  if (UseOffsets)
-    Asm->emitDwarfLengthOrOffset(0);
-  else
-    Asm->emitDwarfSymbolReference(
-        TLOF.getDwarfAbbrevSection()->getBeginSymbol(), false);
+  // If the AbbrevOffset is the same as AbbrevOffsetBegin, that means that this
+  // is either the first compile unit, or there is only one Abbreviation
+  // contribution, in either case, emit the Abbreviation Offset to be the start
+  // of the Abbreviation Section, otherwise emit the offset as a label
+  // difference.
+  if (AbbrevSectionBegin && AbbrevOffset != AbbrevSectionBegin)
+    Asm->emitLabelDifference(getOrCreateAbbrevOffset(), AbbrevSectionBegin,
+                             Asm->getDwarfOffsetByteSize());
+  else {
+    const TargetLoweringObjectFile &TLOF = Asm->getObjFileLowering();
+    if (UseOffsets)
+      Asm->emitDwarfLengthOrOffset(0);
+    else
+      Asm->emitDwarfSymbolReference(
+          TLOF.getDwarfAbbrevSection()->getBeginSymbol(), false);
+  }
 
   if (Version <= 4) {
     Asm->OutStreamer->AddComment("Address Size (in bytes)");

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
@@ -34,6 +34,13 @@ class MCSymbol;
 /// source file.
 class DwarfUnit : public DIEUnit {
 protected:
+  // Label to denote the beginning of the Abbreviation contribution of this
+  // compile unit.
+  MCSymbol *AbbrevOffset = nullptr;
+
+  // Label to denote the start of Abbreviation Section.
+  MCSymbol *AbbrevSectionBegin = nullptr;
+
   /// MDNode for the compile unit.
   const DICompileUnit *CUNode;
 
@@ -98,7 +105,16 @@ public:
   uint16_t getLanguage() const { return CUNode->getSourceLanguage(); }
   const DICompileUnit *getCUNode() const { return CUNode; }
   DwarfDebug &getDwarfDebug() const { return *DD; }
-
+  /// Create a label to denote the end of a compile unit's abbreviation
+  /// contribution and return it, if it already exists, just return it.
+  MCSymbol *getOrCreateAbbrevOffset() {
+    if (!AbbrevOffset)
+      AbbrevOffset = Asm->createTempSymbol("debug_abbrev_begin");
+    return AbbrevOffset;
+  }
+  void setAbbrevOffset(MCSymbol *Sym) { AbbrevOffset = Sym; }
+  MCSymbol *getAbbrevSectionBegin() { return AbbrevSectionBegin; }
+  void setAbbrevSectionBegin(MCSymbol *Sym) { AbbrevSectionBegin = Sym; }
   /// Return true if this compile unit has something to write out.
   bool hasContent() const { return getUnitDie().hasChildren(); }
 

--- a/llvm/test/DebugInfo/X86/debug-abbrev-split.ll
+++ b/llvm/test/DebugInfo/X86/debug-abbrev-split.ll
@@ -1,0 +1,107 @@
+; RUN: llc -mtriple=arm64-apple-darwin21.5.0 -filetype=obj %s -o %t
+; RUN: llvm-dwarfdump --debug-info --debug-abbrev %t | FileCheck %s
+
+
+; CHECK: .debug_abbrev contents:
+; CHECK-NEXT: Abbrev table for offset: 0x0000[[ABBREV_OFFSET1:[0-9a-z]+]]
+; CHECK-NEXT: [1] DW_TAG_compile_unit DW_CHILDREN_yes
+
+; CHECK: Abbrev table for offset: 0x0000[[ABBREV_OFFSET2:[0-9a-z]+]]
+; CHECK-NEXT: [1] DW_TAG_compile_unit DW_CHILDREN_yes
+
+; CHECK: Abbrev table for offset: 0x0000[[ABBREV_OFFSET3:[0-9a-z]+]]
+; CHECK-NEXT: [1] DW_TAG_compile_unit DW_CHILDREN_yes
+
+; CHECK: .debug_info contents:
+; CHECK-NEXT: {{[a-z0-9]+}}: Compile Unit: length = {{[a-z0-9]+}}, format = DWARF32, version = {{[a-z0-9]+}}, abbr_offset = 0x[[ABBREV_OFFSET1]], addr_size = {{[a-z0-9]+}}{{.*}}
+
+; CHECK: {{[a-z0-9]+}}: Compile Unit: length = {{[a-z0-9]+}}, format = DWARF32, version = {{[a-z0-9]+}}, abbr_offset = 0x[[ABBREV_OFFSET2]], addr_size = {{[a-z0-9]+}}{{.*}}
+
+; CHECK: {{[a-z0-9]+}}: Compile Unit: length = {{[a-z0-9]+}}, format = DWARF32, version = {{[a-z0-9]+}}, abbr_offset = 0x[[ABBREV_OFFSET3]], addr_size = {{[a-z0-9]+}}{{.*}}
+
+; ModuleID = 'a.cpp'
+source_filename = "a.cpp"
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+target triple = "arm64-apple-macosx12.0.0"
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable
+define noundef i32 @_Z1av() #0 !dbg !13 {
+entry:
+  %call = call noundef i32 @_Z3fooIiET_S0_(i32 noundef 2), !dbg !18
+  ret i32 %call, !dbg !19
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable
+define linkonce_odr noundef i32 @_Z3fooIiET_S0_(i32 noundef %s) #1 !dbg !20 {
+entry:
+  %s.addr = alloca i32, align 4
+  store i32 %s, ptr %s.addr, align 4
+  call void @llvm.dbg.declare(metadata ptr %s.addr, metadata !26, metadata !DIExpression()), !dbg !27
+  %0 = load i32, ptr %s.addr, align 4, !dbg !28
+  %1 = load i32, ptr %s.addr, align 4, !dbg !29
+  %mul = mul nsw i32 %0, %1, !dbg !30
+  ret i32 %mul, !dbg !31
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable
+define noundef i32 @_Z1bi(i32 noundef %x) #1 !dbg !32 {
+entry:
+  %x.addr = alloca i32, align 4
+  store i32 %x, ptr %x.addr, align 4
+  call void @llvm.dbg.declare(metadata ptr %x.addr, metadata !33, metadata !DIExpression()), !dbg !34
+  %0 = load i32, ptr %x.addr, align 4, !dbg !35
+  %1 = load i32, ptr %x.addr, align 4, !dbg !36
+  %mul = mul nsw i32 %0, %1, !dbg !37
+  ret i32 %mul, !dbg !38
+}
+
+; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #2
+
+attributes #0 = { mustprogress noinline optnone ssp uwtable "frame-pointer"="non-leaf" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+crc,+crypto,+dotprod,+fp-armv8,+fp16fml,+fullfp16,+lse,+neon,+ras,+rcpc,+rdm,+sha2,+sha3,+sm4,+v8.5a,+zcm,+zcz" }
+attributes #1 = { mustprogress noinline nounwind optnone ssp uwtable "frame-pointer"="non-leaf" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+crc,+crypto,+dotprod,+fp-armv8,+fp16fml,+fullfp16,+lse,+neon,+ras,+rcpc,+rdm,+sha2,+sha3,+sm4,+v8.5a,+zcm,+zcz" }
+attributes #2 = { nocallback nofree nosync nounwind readnone speculatable willreturn }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8, !9, !10, !11}
+!llvm.ident = !{!12}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 15.0.0 (git@github.com:apple/llvm-project.git a9613e5bc4afee75335dfc5fbb92954264c04e85)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: true)
+!1 = !DIFile(filename: "a.cpp", directory: "/Users/shubhamrastogi/Development/testCASDeDupe")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 8, !"branch-target-enforcement", i32 0}
+!6 = !{i32 8, !"sign-return-address", i32 0}
+!7 = !{i32 8, !"sign-return-address-all", i32 0}
+!8 = !{i32 8, !"sign-return-address-with-bkey", i32 0}
+!9 = !{i32 7, !"PIC Level", i32 2}
+!10 = !{i32 7, !"uwtable", i32 2}
+!11 = !{i32 7, !"frame-pointer", i32 1}
+!12 = !{!"clang version 15.0.0 (git@github.com:apple/llvm-project.git)"}
+!13 = distinct !DISubprogram(name: "a", linkageName: "_Z1av", scope: !1, file: !1, line: 2, type: !14, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !17)
+!14 = !DISubroutineType(types: !15)
+!15 = !{!16}
+!16 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!17 = !{}
+!18 = !DILocation(line: 3, column: 9, scope: !13)
+!19 = !DILocation(line: 3, column: 2, scope: !13)
+!20 = distinct !DISubprogram(name: "foo<int>", linkageName: "_Z3fooIiET_S0_", scope: !21, file: !21, line: 2, type: !22, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, templateParams: !24, retainedNodes: !17)
+!21 = !DIFile(filename: "./foo.h", directory: "/Users/shubhamrastogi/Development/testCASDeDupe")
+!22 = !DISubroutineType(types: !23)
+!23 = !{!16, !16}
+!24 = !{!25}
+!25 = !DITemplateTypeParameter(name: "T", type: !16)
+!26 = !DILocalVariable(name: "s", arg: 1, scope: !20, file: !21, line: 2, type: !16)
+!27 = !DILocation(line: 2, column: 9, scope: !20)
+!28 = !DILocation(line: 3, column: 12, scope: !20)
+!29 = !DILocation(line: 3, column: 14, scope: !20)
+!30 = !DILocation(line: 3, column: 13, scope: !20)
+!31 = !DILocation(line: 3, column: 5, scope: !20)
+!32 = distinct !DISubprogram(name: "b", linkageName: "_Z1bi", scope: !1, file: !1, line: 6, type: !22, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !17)
+!33 = !DILocalVariable(name: "x", arg: 1, scope: !32, file: !1, line: 6, type: !16)
+!34 = !DILocation(line: 6, column: 11, scope: !32)
+!35 = !DILocation(line: 7, column: 9, scope: !32)
+!36 = !DILocation(line: 7, column: 11, scope: !32)
+!37 = !DILocation(line: 7, column: 10, scope: !32)
+!38 = !DILocation(line: 7, column: 2, scope: !32)

--- a/llvm/unittests/DebugInfo/DWARF/DwarfGenerator.h
+++ b/llvm/unittests/DebugInfo/DWARF/DwarfGenerator.h
@@ -256,7 +256,7 @@ class Generator {
   std::unique_ptr<DwarfStringPool> StringPool; // Entries owned by Allocator.
   std::vector<std::unique_ptr<CompileUnit>> CompileUnits;
   std::vector<std::unique_ptr<LineTable>> LineTables;
-  DIEAbbrevSet Abbreviations;
+  std::vector<std::unique_ptr<DIEAbbrevSet>> Abbreviations;
 
   MCSymbol *StringOffsetsStartSym;
 
@@ -309,7 +309,9 @@ public:
   BumpPtrAllocator &getAllocator() { return Allocator; }
   AsmPrinter *getAsmPrinter() const { return Asm.get(); }
   MCContext *getMCContext() const { return MC.get(); }
-  DIEAbbrevSet &getAbbrevSet() { return Abbreviations; }
+  std::vector<std::unique_ptr<DIEAbbrevSet>> &getAbbrevSet() {
+    return Abbreviations;
+  }
   DwarfStringPool &getStringPool() { return *StringPool; }
   MCSymbol *getStringOffsetsStartSym() const { return StringOffsetsStartSym; }
 


### PR DESCRIPTION
To make debug info more cas friendly, and have higher deduplication, we have split the debug info section into multiple compile units, one per function, this was achieved with https://github.com/apple/llvm-project/pull/3870

The next step is to make a unique contribution into the debug abbreviation section per compile unit, then pass each compile unit its abbreviation contribution's offset.

This change achieves both goals.