### PR TITLE
🍒[clang] Don't crash on an incomplete-type base specifier in template context.

### DIFF
--- a/clang/lib/AST/DeclCXX.cpp
+++ b/clang/lib/AST/DeclCXX.cpp
@@ -178,6 +178,8 @@ static bool hasRepeatedBaseClass(const CXXRecordDecl *StartRD) {
   SmallVector<const CXXRecordDecl*, 8> WorkList = {StartRD};
   while (!WorkList.empty()) {
     const CXXRecordDecl *RD = WorkList.pop_back_val();
+    if (RD->getTypeForDecl()->isDependentType())
+      continue;
     for (const CXXBaseSpecifier &BaseSpec : RD->bases()) {
       if (const CXXRecordDecl *B = BaseSpec.getType()->getAsCXXRecordDecl()) {
         if (!SeenBaseTypes.insert(B).second)

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -2729,6 +2729,8 @@ bool Sema::AttachBaseSpecifiers(CXXRecordDecl *Class,
       KnownBase = Bases[idx];
       Bases[NumGoodBases++] = Bases[idx];
 
+      if (NewBaseType->isDependentType())
+        continue;
       // Note this base's direct & indirect bases, if there could be ambiguity.
       if (Bases.size() > 1)
         NoteIndirectBases(Context, IndirectBaseTypes, NewBaseType);

--- a/clang/test/SemaCXX/base-class-ambiguity-check.cpp
+++ b/clang/test/SemaCXX/base-class-ambiguity-check.cpp
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
-// expected-no-diagnostics
 
 template <typename T> class Foo {
   struct Base : T {};
@@ -7,3 +6,14 @@ template <typename T> class Foo {
   // Test that this code no longer causes a crash in Sema. rdar://23291875
   struct Derived : Base, T {};
 };
+
+
+template <typename T> struct Foo2 {
+  struct Base1; // expected-note{{member is declared here}}
+  struct Base2; // expected-note{{member is declared here}}
+  // Should not crash on an incomplete-type and dependent base specifier.
+  struct Derived : Base1, Base2 {}; // expected-error {{implicit instantiation of undefined member 'Foo2<int>::Base1'}} \
+                                       expected-error {{implicit instantiation of undefined member 'Foo2<int>::Base2'}}
+};
+
+Foo2<int>::Derived a; // expected-note{{in instantiation of member class}}

--- a/clang/test/SemaCXX/ms-interface.cpp
+++ b/clang/test/SemaCXX/ms-interface.cpp
@@ -106,3 +106,10 @@ static_assert(!__is_interface_class(HasProp), "oops");
 static_assert(!__is_interface_class(IUnknown), "oops");
 static_assert(!__is_interface_class(IFaceStruct), "oops");
 static_assert(!__is_interface_class(IFaceInheritsStruct), "oops");
+
+template<typename>
+class TemplateContext {
+  class Base;
+  // Should not crash on an incomplete-type and dependent base specifier.
+  __interface Foo : Base {};
+};


### PR DESCRIPTION
Differential Revision: https://reviews.llvm.org/D113474

(cherry picked from commit 603c1a62f8595f70c3e96ecbec8976d411c0cc08)
rdar://93610386