### PR TITLE
[lldb/Swift] Add progress report callback when loading a module

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3137,7 +3137,8 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
   m_ast_context_ap.reset(swift::ASTContext::get(
       GetLanguageOptions(), GetTypeCheckerOptions(), GetSILOptions(),
       GetSearchPathOptions(), GetClangImporterOptions(),
-      GetSymbolGraphOptions(), GetSourceManager(), GetDiagnosticEngine()));
+      GetSymbolGraphOptions(), GetSourceManager(), GetDiagnosticEngine(),
+      ReportModuleLoadingProgress));
   m_diagnostic_consumer_ap.reset(new StoringDiagnosticConsumer(*this));
 
   if (getenv("LLDB_SWIFT_DUMP_DIAGS")) {
@@ -3405,6 +3406,15 @@ void SwiftASTContext::CacheModule(swift::ModuleDecl *module) {
   if (m_swift_module_cache.find(ID) != m_swift_module_cache.end())
     return;
   m_swift_module_cache.insert({ID, module});
+}
+
+bool SwiftASTContext::ReportModuleLoadingProgress(llvm::StringRef module_name,
+                                                  bool is_overlay) {
+  Progress progress(llvm::formatv(is_overlay ? "Importing overlay module {0}"
+                                             : "Importing module {0}",
+                                  module_name.data())
+                        .str());
+  return true;
 }
 
 swift::ModuleDecl *SwiftASTContext::GetModule(const SourceModule &module,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -281,6 +281,9 @@ public:
   swift::ModuleDecl *CreateModule(const SourceModule &module, Status &error,
                                   swift::ImplicitImportInfo importInfo);
 
+  static bool ReportModuleLoadingProgress(llvm::StringRef module_name,
+                                          bool is_overlay);
+
   // This function should only be called when all search paths
   // for all items in a swift::ASTContext have been setup to
   // allow for imports to happen correctly. Use with caution,

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -17,8 +17,11 @@ class TestSwiftProgressReporting(TestBase):
         self.broadcaster = self.dbg.GetBroadcaster()
         self.listener = lldbutil.start_listening_from(self.broadcaster,
                                         lldb.SBDebugger.eBroadcastBitProgress)
+
+    # Don't run ClangImporter tests if Clangimporter is disabled.
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipUnlessDarwin
     @swiftTest
-    @skipIf(oslist=no_match(["macosx"]))
     def test_swift_progress_report(self):
         """Test that we are able to fetch swift type-system progress events"""
         self.build()
@@ -32,11 +35,13 @@ class TestSwiftProgressReporting(TestBase):
 
         # Resolve variable to exercise the type-system
         self.runCmd("expr boo")
+        self.runCmd("v s")
 
         beacons = [ "Loading Swift module",
                     "Caching Swift user imports from",
                     "Setting up Swift reflection for",
-                    "Getting Swift compile unit imports for"]
+                    "Getting Swift compile unit imports for",
+                    "Importing module", "Importing overlay module"]
 
         while len(beacons):
             event = lldbutil.fetch_next_event(self, self.listener, self.broadcaster)

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/main.swift
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/main.swift
@@ -1,7 +1,9 @@
 import Invisible
+import Foundation
 
 func main() {
   let boo = Invisible.👻()
+  let s = NSAttributedString(string: "Hello")
   print("break here")
 }
 


### PR DESCRIPTION
This patch introduces a new `ReportModuleLoadingProgress` callback that
gets invoked by the Swift AST Context when loading new modules and
module overlays.

This patch also updates `TestSwiftProgressReporting` to check that these
new progress reports are broadcasted correctly.

rdar://94165195

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>