### PR TITLE
[Index/IndexStore] Preserve the canonical output file path

### DIFF
--- a/clang/lib/Index/IndexUnitReader.cpp
+++ b/clang/lib/Index/IndexUnitReader.cpp
@@ -212,7 +212,11 @@ public:
       case UNIT_PATH_BUFFER:
         Reader.PathsBuffer = Blob;
         Reader.WorkingDir = Reader.getAndRemapPathFromBuffer(WorkDirOffset, WorkDirSize);
-        Reader.OutputFile = Reader.getAndRemapPathFromBuffer(OutputFileOffset, OutputFileSize);
+        // We intentionally do -not- remap the output file and instead leave it
+        // in the canonical form. This is because the output file need not be an
+        // actual real file path and this allows clients to provide the same
+        // canonical output path e.g. in the explicit output files list.
+        Reader.OutputFile = Reader.getPathFromBuffer(OutputFileOffset, OutputFileSize).str();
         Reader.SysrootPath = Reader.getAndRemapPathFromBuffer(SysrootOffset, SysrootSize);
 
         // now we can populate the main file's path

--- a/clang/test/Index/Store/print-unit-roundtrip-remapping.c
+++ b/clang/test/Index/Store/print-unit-roundtrip-remapping.c
@@ -14,8 +14,7 @@ void foo(int i);
 // CHECK-NOT: main-path: SRC_ROOT{{/|\\}}print-unit-roundtrip-remapping.c
 // CHECK: main-path: {{.*}}{{/|\\}}print-unit-roundtrip-remapping.c
 // CHECK-NOT: work-dir: BUILD_ROOT
-// CHECK-NOT: out-file: SRC_ROOT{{/|\\}}print-unit-roundtrip-remapping.c.o
-// CHECK: out-file: {{.*}}{{/|\\}}print-unit-roundtrip-remapping.c.o
+// CHECK: out-file: SRC_ROOT{{/|\\}}print-unit-roundtrip-remapping.c.o
 // CHECK: target: x86_64-apple-macosx10.8
 // CHECK: is-debug: 1
 // CHECK: DEPEND START

--- a/clang/tools/IndexStore/IndexStore.cpp
+++ b/clang/tools/IndexStore/IndexStore.cpp
@@ -613,7 +613,10 @@ indexstore_store_get_unit_name_from_output_path(indexstore_t c_store,
                                                 size_t buf_size) {
   IndexDataStore *store = static_cast<IndexDataStore*>(c_store);
   SmallString<256> unitName;
-  auto remapper = store->getPathRemapper();
+  // We intentionally don't use the index store's path remapper since it
+  // maps from canonical -> local instead of local -> canonical. This means that
+  // callers must gives us the canonical `output_path`, not the local one.
+  PathRemapper remapper;
   IndexUnitWriter::getUnitNameForAbsoluteOutputFile(output_path, unitName,
                                                     remapper);
   size_t nameLen = unitName.size();


### PR DESCRIPTION
Additionally, make sure we don't accidentally convert the output file
path to the local equivalent when computing the unit name in IndexStore,
as that will accidentally treat it as a different unit.