### PR TITLE
Fix install command for clang-cache-build-session

### DIFF
--- a/clang/tools/driver/CMakeLists.txt
+++ b/clang/tools/driver/CMakeLists.txt
@@ -84,7 +84,7 @@ add_custom_target(clang-cache-build-session DEPENDS "${clang_cache_build_session
 add_dependencies(clang clang-cache-build-session)
 if (CLANG_BUILD_TOOLS)
   install(FILES "${clang_cache_build_session_dest}"
-          RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+          DESTINATION "${CMAKE_INSTALL_BINDIR}"
           COMPONENT clang)
   if(NOT LLVM_ENABLE_IDE)
     add_llvm_install_targets(install-clang-cache-build-session


### PR DESCRIPTION
The RUNTIMES flag seems to only work with install(TARGETS ...) not with
install(FILES ...).

---

 Fixes the following error when doing `ninja install-clang`
```
CMake Error at cmake_install.cmake:91 (file):
  file INSTALL cannot find
  "/Users/blangmuir/src/cas/llvm-project/clang/tools/driver/RUNTIME": No such
  file or directory.
```