### PR TITLE
[5.7] Add `-index-ignore-pcms` to prevent indexing PCMs for imports/deps

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -639,6 +639,9 @@ def index_unit_output_path : Separate<["-"], "index-unit-output-path">, MetaVarN
 def index_ignore_macros : Flag<["-"], "index-ignore-macros">, Flags<[CC1Option]>,
   HelpText<"Ignore macros during indexing">,
   MarshallingInfoFlag<FrontendOpts<"IndexIgnoreMacros">>;
+def index_ignore_pcms : Flag<["-"], "index-ignore-pcms">, Flags<[CC1Option]>,
+  HelpText<"Ignore symbols from imported pcm modules">,
+  MarshallingInfoFlag<FrontendOpts<"IndexIgnorePcms">>;
 
 // Make sure all other -ccc- options are rejected.
 def ccc_ : Joined<["-"], "ccc-">, Group<internal_Group>, Flags<[Unsupported]>;

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -310,6 +310,7 @@ public:
   unsigned IndexIgnoreSystemSymbols : 1;
   unsigned IndexRecordCodegenName : 1;
   unsigned IndexIgnoreMacros : 1;
+  unsigned IndexIgnorePcms : 1;
 
   /// Output (and read) PCM files regardless of compiler errors.
   unsigned AllowPCMWithCompilerErrors : 1;

--- a/clang/include/clang/Index/IndexingOptions.h
+++ b/clang/include/clang/Index/IndexingOptions.h
@@ -33,6 +33,7 @@ struct IndexingOptions {
   // callback is not available (e.g. after parsing has finished). Note that
   // macro references are not available in Proprocessor.
   bool IndexMacrosInPreprocessor = false;
+  bool IndexPcms = true;
   // Has no effect if IndexFunctionLocals are false.
   bool IndexParametersInDeclarations = false;
   bool IndexTemplateParameters = false;

--- a/clang/lib/Index/IndexingAction.cpp
+++ b/clang/lib/Index/IndexingAction.cpp
@@ -850,12 +850,15 @@ static void writeUnitData(const CompilerInstance &CI,
       [&](const FileEntry *Source, unsigned Line, const FileEntry *Target) {
         UnitWriter.addInclude(Source, Line, Target);
       });
+  bool IndexPcms = IndexOpts.IndexPcms;
+  bool WithoutUnitName = !IndexPcms;
   DepProvider.visitModuleImports(CI, [&](serialization::ModuleFile &Mod,
                                          bool isSystemMod) {
     Module *UnitMod = HS.lookupModule(Mod.ModuleName, Mod.ImportLoc,
                                       /*AllowSearch=*/false);
-    UnitWriter.addASTFileDependency(Mod.File, isSystemMod, UnitMod);
-    if (Mod.isModule()) {
+    UnitWriter.addASTFileDependency(Mod.File, isSystemMod, UnitMod,
+                                    WithoutUnitName);
+    if (Mod.isModule() && IndexPcms) {
       produceIndexDataForModuleFile(Mod, CI, IndexOpts, RecordOpts, UnitWriter);
     }
   });
@@ -1027,6 +1030,7 @@ getIndexOptionsFromFrontendOptions(const FrontendOptions &FEOpts) {
   }
   IndexOpts.IndexMacros = !FEOpts.IndexIgnoreMacros;
   IndexOpts.IndexMacrosInPreprocessor = !FEOpts.IndexIgnoreMacros;
+  IndexOpts.IndexPcms = !FEOpts.IndexIgnorePcms;
   RecordOpts.RecordSymbolCodeGenName = FEOpts.IndexRecordCodegenName;
   return {IndexOpts, RecordOpts};
 }

--- a/clang/test/Index/Store/print-units-with-modules.m
+++ b/clang/test/Index/Store/print-units-with-modules.m
@@ -1,57 +1,66 @@
 // RUN: rm -rf %t.idx %t.mcp
 // RUN: %clang -arch x86_64 -mmacosx-version-min=10.7 -c %s -o %t.o -index-store-path %t.idx -fmodules -fmodules-cache-path=%t.mcp -Xclang -fdisable-module-hash -I %S/Inputs/module
-// RUN: c-index-test core -print-unit %t.idx | FileCheck %s
+// RUN: c-index-test core -print-unit %t.idx | FileCheck %s --check-prefixes=ALL,MODULES
+
+// RUN: rm -rf %t.idx %t.mcp
+// RUN: %clang -arch x86_64 -mmacosx-version-min=10.7 -c %s -o %t.o -index-store-path %t.idx -index-ignore-pcms -fmodules -fmodules-cache-path=%t.mcp -Xclang -fdisable-module-hash -I %S/Inputs/module
+// RUN: c-index-test core -print-unit %t.idx | FileCheck %s --check-prefixes=ALL,IGNORE
 
 @import ModDep;
 @import ModSystem;
 
-// CHECK: ModDep.pcm
-// CHECK: provider: clang-
-// CHECK: is-system: 0
-// CHECK: is-module: 1
-// CHECK: module-name: ModDep
-// CHECK: has-main: 0
-// CHECK: main-path: {{$}}
-// CHECK: out-file: {{.*}}{{/|\\}}ModDep.pcm
-// CHECK: DEPEND START
-// CHECK: Unit | user | ModTop | {{.*}}{{/|\\}}ModTop.pcm | ModTop.pcm
-// CHECK: Record | user | ModDep | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModDep.h | ModDep.h
-// CHECK: DEPEND END (2)
+// IGNORE-NOT: ModDep.pcm
+// MODULES: ModDep.pcm
+// MODULES: provider: clang-
+// MODULES: is-system: 0
+// MODULES: is-module: 1
+// MODULES: module-name: ModDep
+// MODULES: has-main: 0
+// MODULES: main-path: {{$}}
+// MODULES: out-file: {{.*}}{{/|\\}}ModDep.pcm
+// MODULES: DEPEND START
+// MODULES: Unit | user | ModTop | {{.*}}{{/|\\}}ModTop.pcm | ModTop.pcm
+// MODULES: Record | user | ModDep | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModDep.h | ModDep.h
+// MODULES: DEPEND END (2)
 
-// CHECK: ModSystem.pcm
-// CHECK: is-system: 1
-// CHECK: is-module: 1
-// CHECK: module-name: ModSystem
-// CHECK: has-main: 0
-// CHECK: main-path: {{$}}
-// CHECK: out-file: {{.*}}{{/|\\}}ModSystem.pcm
-// CHECK: DEPEND START
-// CHECK: Record | system | ModSystem | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModSystem.h | ModSystem.h
-// CHECK: DEPEND END (1)
+// IGNORE-NOT: ModSystem.pcm
+// MODULES: ModSystem.pcm
+// MODULES: is-system: 1
+// MODULES: is-module: 1
+// MODULES: module-name: ModSystem
+// MODULES: has-main: 0
+// MODULES: main-path: {{$}}
+// MODULES: out-file: {{.*}}{{/|\\}}ModSystem.pcm
+// MODULES: DEPEND START
+// MODULES: Record | system | ModSystem | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModSystem.h | ModSystem.h
+// MODULES: DEPEND END (1)
 
-// CHECK: ModTop.pcm
-// CHECK: is-system: 0
-// CHECK: is-module: 1
-// CHECK: module-name: ModTop
-// CHECK: has-main: 0
-// CHECK: main-path: {{$}}
-// CHECK: out-file: {{.*}}{{/|\\}}ModTop.pcm
-// CHECK: DEPEND START
-// CHECK: Record | user | ModTop | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModTop.h | ModTop.h
-// CHECK: Record | user | ModTop.Sub1 | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModTopSub1.h | ModTopSub1.h
-// CHECK: File | user | ModTop.Sub2 | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModTopSub2.h{{$}}
-// CHECK: DEPEND END (3)
+// IGNORE-NOT: ModTop.pcm
+// MODULES: ModTop.pcm
+// MODULES: is-system: 0
+// MODULES: is-module: 1
+// MODULES: module-name: ModTop
+// MODULES: has-main: 0
+// MODULES: main-path: {{$}}
+// MODULES: out-file: {{.*}}{{/|\\}}ModTop.pcm
+// MODULES: DEPEND START
+// MODULES: Record | user | ModTop | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModTop.h | ModTop.h
+// MODULES: Record | user | ModTop.Sub1 | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModTopSub1.h | ModTopSub1.h
+// MODULES: File | user | ModTop.Sub2 | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModTopSub2.h{{$}}
+// MODULES: DEPEND END (3)
 
-// CHECK: print-units-with-modules.m.tmp.o
-// CHECK: is-system: 0
-// CHECK: is-module: 0
-// CHECK: module-name: <none>
-// CHECK: has-main: 1
-// CHECK: main-path: {{.*}}{{/|\\}}print-units-with-modules.m
-// CHECK: out-file: {{.*}}{{/|\\}}print-units-with-modules.m.tmp.o
-// CHECK: DEPEND START
-// CHECK: Unit | user | ModDep | {{.*}}{{/|\\}}ModDep.pcm | ModDep.pcm
-// CHECK: Unit | system | ModSystem | {{.*}}{{/|\\}}ModSystem.pcm | ModSystem.pcm
-// CHECK: File | user | {{.*}}{{/|\\}}print-units-with-modules.m{{$}}
-// CHECK: File | user | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}module.modulemap{{$}}
-// CHECK: DEPEND END (4)
+// ALL: print-units-with-modules.m.tmp.o
+// ALL: is-system: 0
+// ALL: is-module: 0
+// ALL: module-name: <none>
+// ALL: has-main: 1
+// ALL: main-path: {{.*}}{{/|\\}}print-units-with-modules.m
+// ALL: out-file: {{.*}}{{/|\\}}print-units-with-modules.m.tmp.o
+// ALL: DEPEND START
+// MODULES: Unit | user | ModDep | {{.*}}{{/|\\}}ModDep.pcm | ModDep.pcm
+// MODULES: Unit | system | ModSystem | {{.*}}{{/|\\}}ModSystem.pcm | ModSystem.pcm
+// IGNORE: Unit | user | ModDep | {{.*}}{{/|\\}}ModDep.pcm
+// IGNORE: Unit | system | ModSystem | {{.*}}{{/|\\}}ModSystem.pcm
+// ALL: File | user | {{.*}}{{/|\\}}print-units-with-modules.m{{$}}
+// ALL: File | user | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}module.modulemap{{$}}
+// ALL: DEPEND END (4)


### PR DESCRIPTION
This is the clang equivalent of
https://github.com/apple/swift/pull/58932, to be used when building
explicit clang modules for Swift to prevent repeated indexing of the
same Clang PCM during remote builds. With this, the build system
can index the Clang PCM when it is created and there's no need to
ever index it again.