### PR TITLE
[FlatV1] Fix FlatV1 when it has two identical symbols except name

### DIFF
--- a/llvm/include/llvm/CASObjectFormats/ObjectFormatHelpers.h
+++ b/llvm/include/llvm/CASObjectFormats/ObjectFormatHelpers.h
@@ -51,6 +51,11 @@ bool compareSymbolsBySemanticsAnd(
 bool compareSymbolsByLinkageAndSemantics(const jitlink::Symbol *LHS,
                                          const jitlink::Symbol *RHS);
 
+bool compareSymbolsByAddressAnd(
+    const jitlink::Symbol *LHS, const jitlink::Symbol *RHS,
+    function_ref<bool(const jitlink::Symbol *, const jitlink::Symbol *)>
+        NextCompare);
+
 bool compareSymbolsByAddress(const jitlink::Symbol *LHS,
                              const jitlink::Symbol *RHS);
 

--- a/llvm/lib/CASObjectFormats/FlatV1.cpp
+++ b/llvm/lib/CASObjectFormats/FlatV1.cpp
@@ -763,11 +763,17 @@ Expected<CompileUnitRef> CompileUnitRef::create(const ObjectFileSchema &Schema,
   // Visit symbols. Sort the symbols for stable ordering.
   // FIXME: duplicated code for sorting and comparsion.
   SmallVector<const jitlink::Symbol *, 16> Symbols;
+  auto compareSymbol = [](const jitlink::Symbol *LHS,
+                          const jitlink::Symbol *RHS) {
+    return helpers::compareSymbolsByAddressAnd(
+        LHS, RHS, [](const jitlink::Symbol *LHS, const jitlink::Symbol *RHS) {
+          return LHS->getName().compare(RHS->getName()) < 0;
+        });
+  };
   auto appendSymbols = [&](auto &&NewSymbols) {
     size_t PreviousSize = Symbols.size();
     Symbols.append(NewSymbols.begin(), NewSymbols.end());
-    llvm::sort(Symbols.begin() + PreviousSize, Symbols.end(),
-               helpers::compareSymbolsByAddress);
+    llvm::sort(Symbols.begin() + PreviousSize, Symbols.end(), compareSymbol);
   };
   for (const jitlink::Section &Section : G.sections())
     appendSymbols(Section.symbols());

--- a/llvm/lib/CASObjectFormats/ObjectFormatHelpers.cpp
+++ b/llvm/lib/CASObjectFormats/ObjectFormatHelpers.cpp
@@ -230,10 +230,13 @@ bool helpers::compareSymbolsByLinkageAndSemantics(const jitlink::Symbol *LHS,
       [](const jitlink::Symbol *, const jitlink::Symbol *) { return false; });
 }
 
-bool helpers::compareSymbolsByAddress(const jitlink::Symbol *LHS,
-                                      const jitlink::Symbol *RHS) {
+bool helpers::compareSymbolsByAddressAnd(
+    const jitlink::Symbol *LHS, const jitlink::Symbol *RHS,
+    function_ref<bool(const jitlink::Symbol *, const jitlink::Symbol *)>
+        NextCompare) {
   if (LHS == RHS)
-    return false;
+    return NextCompare(LHS, RHS);
+
 
   if (LHS->isExternal() != RHS->isExternal())
     return LHS->isExternal() < RHS->isExternal();
@@ -243,6 +246,16 @@ bool helpers::compareSymbolsByAddress(const jitlink::Symbol *LHS,
   if (LAddr != RAddr)
     return LAddr < RAddr;
 
-  return LHS->getSize() < RHS->getSize();
+  if (LHS->getSize() != RHS->getSize())
+    return LHS->getSize() < RHS->getSize();
+
+  return NextCompare(LHS, RHS);
+}
+
+bool helpers::compareSymbolsByAddress(const jitlink::Symbol *LHS,
+                                      const jitlink::Symbol *RHS) {
+  return compareSymbolsByAddressAnd(
+      LHS, RHS,
+      [](const jitlink::Symbol *, const jitlink::Symbol *) { return false; });
 }
 

--- a/llvm/test/tools/llvm-cas-object-format/symbol_sort.s
+++ b/llvm/test/tools/llvm-cas-object-format/symbol_sort.s
@@ -1,0 +1,10 @@
+// REQUIRES: x86-registered-target
+// RUN: llvm-mc -triple x86_64-apple-macos11 %s -filetype=obj -o %t.o
+// RUN: llvm-cas-object-format --cas %t/cas --ingest-schema=flatv1 %t.o
+// RUN: llvm-cas-object-format --cas %t/cas --ingest-schema=nestedv1 %t.o
+
+.text
+.p2align  6
+_test:
+test:
+  ret


### PR DESCRIPTION
FlatV1 can have indeterministic ordering when two symbols of the same
kind are pointing to the same Atom. Fix the problem by checking name
when sorting.

rdar://94237463