### PR TITLE
Remove unused var in IndexStore.cpp

### DIFF
--- a/clang/tools/IndexStore/IndexStore.cpp
+++ b/clang/tools/IndexStore/IndexStore.cpp
@@ -611,7 +611,6 @@ indexstore_store_get_unit_name_from_output_path(indexstore_t c_store,
                                                 const char *output_path,
                                                 char *name_buf,
                                                 size_t buf_size) {
-  IndexDataStore *store = static_cast<IndexDataStore*>(c_store);
   SmallString<256> unitName;
   // We intentionally don't use the index store's path remapper since it
   // maps from canonical -> local instead of local -> canonical. This means that


### PR DESCRIPTION
This removes an unused var that was causing a warning.

(cherry picked from commit 92d86b85b82958733f10185c3e39eee14f7fc9b7/https://github.com/apple/llvm-project/pull/4782)