### PR TITLE
[Driver] Call hasFlag instead of hasArg

### DIFF
--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -963,7 +963,7 @@ void MSVCToolChain::addClangTargetOptions(
     Action::OffloadKind DeviceOffloadKind) const {
   // MSVC STL kindly allows removing all usages of typeid by defining
   // _HAS_STATIC_RTTI to 0. Do so, when compiling with -fno-rtti
-  if (DriverArgs.hasArg(options::OPT_fno_rtti, options::OPT_frtti,
-                        /*Default=*/false))
+  if (DriverArgs.hasFlag(options::OPT_fno_rtti, options::OPT_frtti,
+                         /*Default=*/false))
     CC1Args.push_back("-D_HAS_STATIC_RTTI=0");
 }

--- a/clang/test/Driver/msvc-static-rtti.cpp
+++ b/clang/test/Driver/msvc-static-rtti.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang -target x86_64-pc-windows-msvc -fno-rtti -### %s 2>&1 | FileCheck %s -check-prefix STATIC-RTTI-DEF
-// RUN: %clang -target x86_64-pc-windows-msvc -frtti -### %s 2>&1 | FileCheck %s -check-prefix STATIC-RTTI-DEF-NOT
+// RUN: %clang -target x86_64-pc-windows-msvc -fno-rtti -### %s 2>&1 | FileCheck %s -check-prefix NO-RTTI
+// RUN: %clang -target x86_64-pc-windows-msvc -frtti -### %s 2>&1 | FileCheck %s -check-prefix RTTI
 
-// STATIC-RTTI-DEF: -D_HAS_STATIC_RTTI=0
-// STATIC-RTTI-DEF-NOT: -D_HAS_STATIC_RTTI=0
+// RTTI-NOT: -D_HAS_STATIC_RTTI=0
+// NO-RTTI: -D_HAS_STATIC_RTTI=0


### PR DESCRIPTION
`_HAS_STATIC_RTTI` should be set to 0 only by `-fno-rtti` according to the summary of https://reviews.llvm.org/D103771.

rdar://92039243

Differential Revision: https://reviews.llvm.org/D124312

(cherry picked from commit 3b578ae9088caf08932dc7d18e87d2a17fb4f7a8)