### PR TITLE
[next] Make sure to mark declaration as demoted definition

### DIFF
--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -830,7 +830,7 @@ void ASTDeclReader::VisitRecordDecl(RecordDecl *RD) {
     }
     if (OldDef) {
       Reader.MergedDeclContexts.insert(std::make_pair(RD, OldDef));
-      RD->setCompleteDefinition(false);
+      RD->demoteThisDefinitionToDeclaration();
       Reader.mergeDefinitionVisibility(OldDef, RD);
     } else {
       OldDef = RD;


### PR DESCRIPTION
This looks to be a bad merge at some point, ie. LLVM upstream has
`isThisDeclarationADemotedDefinition` and so does stable/20211026.

Resolves rdar://93135127.