### PR TITLE
[clang] Add deployment target env vars to features.json

### DIFF
--- a/clang/tools/driver/CMakeLists.txt
+++ b/clang/tools/driver/CMakeLists.txt
@@ -124,13 +124,7 @@ endif()
 set(features_file_src "${CMAKE_CURRENT_SOURCE_DIR}/features.json")
 set(features_file_dest "${CMAKE_BINARY_DIR}/share/clang/features.json")
 
-add_custom_command(OUTPUT ${features_file_dest}
-                   COMMAND ${CMAKE_COMMAND} -E make_directory
-                     ${CMAKE_BINARY_DIR}/share/clang
-                   COMMAND ${CMAKE_COMMAND} -E copy
-                     ${features_file_src}
-                     ${features_file_dest}
-                   DEPENDS ${features_file_src})
+configure_file(${features_file_src} ${features_file_dest} @ONLY)
 
 add_custom_target(clang-features-file DEPENDS ${features_file_dest})
 add_dependencies(clang clang-features-file)

--- a/clang/tools/driver/features.json
+++ b/clang/tools/driver/features.json
@@ -11,6 +11,17 @@
     },
     {
       "name": "vfs-redirecting-with"
+    },
+    {
+      "name": "deployment-target-environment-variables",
+      "value": [
+        "MACOSX_DEPLOYMENT_TARGET",
+        "IPHONEOS_DEPLOYMENT_TARGET",
+        "TVOS_DEPLOYMENT_TARGET",
+        "WATCHOS_DEPLOYMENT_TARGET",
+        "BRIDGEOS_DEPLOYMENT_TARGET",
+        "DRIVERKIT_DEPLOYMENT_TARGET"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This adds new entry to the `features.json` file with list of environment variables used when deciding the deployment target. To be able to make these values depend on `#ifdef` directives, we run the file through the preprocessor instead of simple copy.

rdar://91377604