### PR TITLE
[gmodules] Skip CXXDeductionGuideDecls when visiting FunctionDecls in DebugTypeVisitor

### DIFF
--- a/clang/lib/CodeGen/ObjectFilePCHContainerOperations.cpp
+++ b/clang/lib/CodeGen/ObjectFilePCHContainerOperations.cpp
@@ -96,6 +96,10 @@ class PCHContainerGenerator : public ASTConsumer {
     }
 
     bool VisitFunctionDecl(FunctionDecl *D) {
+      // Skip deduction guides.
+      if (isa<CXXDeductionGuideDecl>(D))
+        return true;
+
       if (isa<CXXMethodDecl>(D))
         // This is not yet supported. Constructing the `this' argument
         // mandates a CodeGenFunction.

--- a/clang/test/Modules/Inputs/gmodules-deduction-guide.h
+++ b/clang/test/Modules/Inputs/gmodules-deduction-guide.h
@@ -1,0 +1,11 @@
+struct A {
+};
+
+template <class T>
+struct S{
+  S(const A &);
+};
+
+S(const A&) -> S<A>;
+
+typedef decltype(S(A())) Type0;

--- a/clang/test/Modules/gmodules-deduction-guide.cpp
+++ b/clang/test/Modules/gmodules-deduction-guide.cpp
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -std=c++2b -x c++-header -emit-pch -fmodule-format=obj -I %S/Inputs \
+// RUN:   -o %t.pch %S/Inputs/gmodules-deduction-guide.h \
+// RUN:   -mllvm -debug-only=pchcontainer &>%t-pch.ll
+// RUN: cat %t-pch.ll | FileCheck %s
+
+// CHECK: ![[V0:.*]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "S<A>",
+// CHECK: !DIDerivedType(tag: DW_TAG_typedef, name: "Type0",{{.*}}, baseType: ![[V0]])


### PR DESCRIPTION
Differential Revision: https://reviews.llvm.org/D125839

(cherry picked from commit d1346e2ee2741919a8cc1b1ffe400001e76a6d06)