### PR TITLE
[lldb] Unlock Swift scratch context before early exit

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2546,6 +2546,9 @@ llvm::Optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
     if (!create_on_demand || !GetSwiftScratchContextLock().try_lock())
       return nullptr;
 
+    auto unlock = llvm::make_scope_exit(
+        [this] { GetSwiftScratchContextLock().unlock(); });
+
     auto type_system_or_err = GetScratchTypeSystemForLanguage(eLanguageTypeSwift, false);
     if (!type_system_or_err) {
       llvm::consumeError(type_system_or_err.takeError());
@@ -2564,7 +2567,6 @@ llvm::Optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
         lldb::eLanguageTypeSwift, *this, *lldb_module);
     typesystem_sp->GetSwiftASTContext();
     m_scratch_typesystem_for_module.insert({idx, typesystem_sp});
-    GetSwiftScratchContextLock().unlock();
     if (log)
       log->Printf("created module-wide scratch context\n");
     return typesystem_sp.get();


### PR DESCRIPTION
Followup to https://github.com/apple/llvm-project/pull/3865. On closer look, it wasn't the only function using the same anti-pattern.

rdar://85399160