### PR TITLE
[lldb/DWARF] Fix linking direction in CopyUniqueClassMethodTypes

### DIFF
--- a/lldb/source/API/SystemInitializerFull.cpp
+++ b/lldb/source/API/SystemInitializerFull.cpp
@@ -39,7 +39,7 @@ constexpr lldb_private::HostInfo::SharedLibraryDirectoryHelper
 
 #else
 constexpr lldb_private::HostInfo::SharedLibraryDirectoryHelper
-    *g_shlib_dir_helper = 0;
+    *g_shlib_dir_helper = nullptr;
 #endif
 
 using namespace lldb_private;

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -773,9 +773,9 @@ public:
       // Write out the EXC registers
       data.PutHex32(EXCRegSet);
       data.PutHex32(EXCWordCount);
-      PrintRegisterValue(reg_ctx, "far", NULL, 8, data);
-      PrintRegisterValue(reg_ctx, "esr", NULL, 4, data);
-      PrintRegisterValue(reg_ctx, "exception", NULL, 4, data);
+      PrintRegisterValue(reg_ctx, "far", nullptr, 8, data);
+      PrintRegisterValue(reg_ctx, "esr", nullptr, 4, data);
+      PrintRegisterValue(reg_ctx, "exception", nullptr, 4, data);
       return true;
     }
     return false;
@@ -5133,7 +5133,7 @@ void ObjectFileMachO::GetAllArchSpecs(const llvm::MachO::mach_header &header,
   lldb::offset_t offset = lc_offset;
   for (uint32_t i = 0; i < header.ncmds; ++i) {
     const lldb::offset_t cmd_offset = offset;
-    if (data.GetU32(&offset, &load_cmd, 2) == NULL)
+    if (data.GetU32(&offset, &load_cmd, 2) == nullptr)
       break;
 
     llvm::MachO::version_min_command version_min;
@@ -5183,7 +5183,7 @@ void ObjectFileMachO::GetAllArchSpecs(const llvm::MachO::mach_header &header,
   offset = lc_offset;
   for (uint32_t i = 0; i < header.ncmds; ++i) {
     const lldb::offset_t cmd_offset = offset;
-    if (data.GetU32(&offset, &load_cmd, 2) == NULL)
+    if (data.GetU32(&offset, &load_cmd, 2) == nullptr)
       break;
 
     do {

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
@@ -272,7 +272,8 @@ Status MinidumpFileBuilder::AddModuleList(Target &target) {
         mod->GetObjectFile()->GetBaseAddress().GetLoadAddress(&target));
     m.SizeOfImage = static_cast<llvm::support::ulittle32_t>(mod_size);
     m.Checksum = static_cast<llvm::support::ulittle32_t>(0);
-    m.TimeDateStamp = static_cast<llvm::support::ulittle32_t>(std::time(0));
+    m.TimeDateStamp =
+        static_cast<llvm::support::ulittle32_t>(std::time(nullptr));
     m.ModuleNameRVA = static_cast<llvm::support::ulittle32_t>(
         size_before + module_stream_size + helper_data.GetByteSize());
     m.VersionInfo = info;
@@ -719,7 +720,7 @@ Status MinidumpFileBuilder::Dump(lldb::FileUP &core_file) const {
   header.Checksum = static_cast<llvm::support::ulittle32_t>(
       0u), // not used in most of the writers
       header.TimeDateStamp =
-          static_cast<llvm::support::ulittle32_t>(std::time(0));
+          static_cast<llvm::support::ulittle32_t>(std::time(nullptr));
   header.Flags =
       static_cast<llvm::support::ulittle64_t>(0u); // minidump normal flag
 

--- a/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.cpp
@@ -178,10 +178,10 @@ static const lldb_private::RegisterSet g_reg_sets_arm64[k_num_register_sets] = {
      g_sve_regnums_arm64}};
 
 static const lldb_private::RegisterSet g_reg_set_pauth_arm64 = {
-    "Pointer Authentication Registers", "pauth", k_num_pauth_register, NULL};
+    "Pointer Authentication Registers", "pauth", k_num_pauth_register, nullptr};
 
 static const lldb_private::RegisterSet g_reg_set_mte_arm64 = {
-    "MTE Control Register", "mte", k_num_mte_register, NULL};
+    "MTE Control Register", "mte", k_num_mte_register, nullptr};
 
 RegisterInfoPOSIX_arm64::RegisterInfoPOSIX_arm64(
     const lldb_private::ArchSpec &target_arch, lldb_private::Flags opt_regsets)

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -3499,7 +3499,7 @@ bool DWARFASTParserClang::CopyUniqueClassMethodTypes(
   class_type->GetFullCompilerType();
 
   auto gather = [](DWARFDIE die, UniqueCStringMap<DWARFDIE> &map,
-                   UniqueCStringMap<DWARFDIE> map_artificial) {
+                   UniqueCStringMap<DWARFDIE> &map_artificial) {
     if (die.Tag() != DW_TAG_subprogram)
       return;
     // Make sure this is a declaration and not a concrete instance by looking

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -1038,10 +1038,8 @@ TypeSP DWARFASTParserClang::ParseSubroutine(const DWARFDIE &die,
         // struct and see if this is actually a C++ method
         Type *class_type = dwarf->ResolveType(decl_ctx_die);
         if (class_type) {
-          bool alternate_defn = false;
           if (class_type->GetID() != decl_ctx_die.GetID() ||
               IsClangModuleFwdDecl(decl_ctx_die)) {
-            alternate_defn = true;
 
             // We uniqued the parent class of this function to another
             // class so we now need to associate all dies under
@@ -1110,7 +1108,7 @@ TypeSP DWARFASTParserClang::ParseSubroutine(const DWARFDIE &die,
             CompilerType class_opaque_type =
                 class_type->GetForwardCompilerType();
             if (TypeSystemClang::IsCXXClassType(class_opaque_type)) {
-              if (class_opaque_type.IsBeingDefined() || alternate_defn) {
+              if (class_opaque_type.IsBeingDefined()) {
                 if (!is_static && !die.HasChildren()) {
                   // We have a C++ member function with no children (this
                   // pointer!) and clang will get mad if we try and make
@@ -1118,84 +1116,50 @@ TypeSP DWARFASTParserClang::ParseSubroutine(const DWARFDIE &die,
                   // we will just skip it...
                   type_handled = true;
                 } else {
-                  bool add_method = true;
-                  if (alternate_defn) {
-                    // If an alternate definition for the class exists,
-                    // then add the method only if an equivalent is not
-                    // already present.
-                    clang::CXXRecordDecl *record_decl =
-                        m_ast.GetAsCXXRecordDecl(
-                            class_opaque_type.GetOpaqueQualType());
-                    if (record_decl) {
-                      for (auto method_iter = record_decl->method_begin();
-                           method_iter != record_decl->method_end();
-                           method_iter++) {
-                        clang::CXXMethodDecl *method_decl = *method_iter;
-                        if (method_decl->getNameInfo().getAsString() ==
-                            attrs.name.GetStringRef()) {
-                          if (method_decl->getType() ==
-                              ClangUtil::GetQualType(clang_type)) {
-                            add_method = false;
-                            LinkDeclContextToDIE(method_decl, die);
-                            type_handled = true;
+                  llvm::PrettyStackTraceFormat stack_trace(
+                      "SymbolFileDWARF::ParseType() is adding a method "
+                      "%s to class %s in DIE 0x%8.8" PRIx64 " from %s",
+                      attrs.name.GetCString(),
+                      class_type->GetName().GetCString(), die.GetID(),
+                      dwarf->GetObjectFile()->GetFileSpec().GetPath().c_str());
 
-                            break;
-                          }
-                        }
-                      }
+                  const bool is_attr_used = false;
+                  // Neither GCC 4.2 nor clang++ currently set a valid
+                  // accessibility in the DWARF for C++ methods...
+                  // Default to public for now...
+                  if (attrs.accessibility == eAccessNone)
+                    attrs.accessibility = eAccessPublic;
+
+                  clang::CXXMethodDecl *cxx_method_decl =
+                      m_ast.AddMethodToCXXRecordType(
+                          class_opaque_type.GetOpaqueQualType(),
+                          attrs.name.GetCString(), attrs.mangled_name,
+                          clang_type, attrs.accessibility, attrs.is_virtual,
+                          is_static, attrs.is_inline, attrs.is_explicit,
+                          is_attr_used, attrs.is_artificial);
+
+                  type_handled = cxx_method_decl != nullptr;
+                  // Artificial methods are always handled even when we
+                  // don't create a new declaration for them.
+                  type_handled |= attrs.is_artificial;
+
+                  if (cxx_method_decl) {
+                    LinkDeclContextToDIE(cxx_method_decl, die);
+
+                    ClangASTMetadata metadata;
+                    metadata.SetUserID(die.GetID());
+
+                    if (!object_pointer_name.empty()) {
+                      metadata.SetObjectPtrName(object_pointer_name.c_str());
+                      LLDB_LOGF(log,
+                                "Setting object pointer name: %s on method "
+                                "object %p.\n",
+                                object_pointer_name.c_str(),
+                                static_cast<void *>(cxx_method_decl));
                     }
-                  }
-
-                  if (add_method) {
-                    llvm::PrettyStackTraceFormat stack_trace(
-                        "SymbolFileDWARF::ParseType() is adding a method "
-                        "%s to class %s in DIE 0x%8.8" PRIx64 " from %s",
-                        attrs.name.GetCString(),
-                        class_type->GetName().GetCString(), die.GetID(),
-                        dwarf->GetObjectFile()
-                            ->GetFileSpec()
-                            .GetPath()
-                            .c_str());
-
-                    const bool is_attr_used = false;
-                    // Neither GCC 4.2 nor clang++ currently set a valid
-                    // accessibility in the DWARF for C++ methods...
-                    // Default to public for now...
-                    if (attrs.accessibility == eAccessNone)
-                      attrs.accessibility = eAccessPublic;
-
-                    clang::CXXMethodDecl *cxx_method_decl =
-                        m_ast.AddMethodToCXXRecordType(
-                            class_opaque_type.GetOpaqueQualType(),
-                            attrs.name.GetCString(), attrs.mangled_name,
-                            clang_type, attrs.accessibility, attrs.is_virtual,
-                            is_static, attrs.is_inline, attrs.is_explicit,
-                            is_attr_used, attrs.is_artificial);
-
-                    type_handled = cxx_method_decl != nullptr;
-                    // Artificial methods are always handled even when we
-                    // don't create a new declaration for them.
-                    type_handled |= attrs.is_artificial;
-
-                    if (cxx_method_decl) {
-                      LinkDeclContextToDIE(cxx_method_decl, die);
-
-                      ClangASTMetadata metadata;
-                      metadata.SetUserID(die.GetID());
-
-                      if (!object_pointer_name.empty()) {
-                        metadata.SetObjectPtrName(
-                            object_pointer_name.c_str());
-                        LLDB_LOGF(log,
-                                  "Setting object pointer name: %s on method "
-                                  "object %p.\n",
-                                  object_pointer_name.c_str(),
-                                  static_cast<void *>(cxx_method_decl));
-                      }
-                      m_ast.SetMetadata(cxx_method_decl, metadata);
-                    } else {
-                      ignore_containing_context = true;
-                    }
+                    m_ast.SetMetadata(cxx_method_decl, metadata);
+                  } else {
+                    ignore_containing_context = true;
                   }
                 }
               } else {
@@ -3569,10 +3533,10 @@ bool DWARFASTParserClang::CopyUniqueClassMethodTypes(
   auto link = [&](DWARFDIE src, DWARFDIE dst) {
     SymbolFileDWARF::DIEToTypePtr &die_to_type =
         dst_class_die.GetDWARF()->GetDIEToType();
-    clang::DeclContext *src_decl_ctx =
-        src_dwarf_ast_parser->m_die_to_decl_ctx[src.GetDIE()];
-    if (src_decl_ctx)
-      dst_dwarf_ast_parser->LinkDeclContextToDIE(src_decl_ctx, dst);
+    clang::DeclContext *dst_decl_ctx =
+        dst_dwarf_ast_parser->m_die_to_decl_ctx[dst.GetDIE()];
+    if (dst_decl_ctx)
+      src_dwarf_ast_parser->LinkDeclContextToDIE(dst_decl_ctx, src);
 
     if (Type *src_child_type = die_to_type[src.GetDIE()])
       die_to_type[dst.GetDIE()] = src_child_type;

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -3498,49 +3498,37 @@ bool DWARFASTParserClang::CopyUniqueClassMethodTypes(
   // in "dst_cu" and "dst_class_die"
   class_type->GetFullCompilerType();
 
-  DWARFDIE src_die;
-  DWARFDIE dst_die;
+  auto gather = [](DWARFDIE die, UniqueCStringMap<DWARFDIE> &map,
+                   UniqueCStringMap<DWARFDIE> map_artificial) {
+    if (die.Tag() != DW_TAG_subprogram)
+      return;
+    // Make sure this is a declaration and not a concrete instance by looking
+    // for DW_AT_declaration set to 1. Sometimes concrete function instances are
+    // placed inside the class definitions and shouldn't be included in the list
+    // of things are are tracking here.
+    if (die.GetAttributeValueAsUnsigned(DW_AT_declaration, 0) != 1)
+      return;
+
+    if (const char *name = die.GetMangledName()) {
+      ConstString const_name(name);
+      if (die.GetAttributeValueAsUnsigned(DW_AT_artificial, 0))
+        map_artificial.Append(const_name, die);
+      else
+        map.Append(const_name, die);
+    }
+  };
+
   UniqueCStringMap<DWARFDIE> src_name_to_die;
   UniqueCStringMap<DWARFDIE> dst_name_to_die;
   UniqueCStringMap<DWARFDIE> src_name_to_die_artificial;
   UniqueCStringMap<DWARFDIE> dst_name_to_die_artificial;
-  for (src_die = src_class_die.GetFirstChild(); src_die.IsValid();
+  for (DWARFDIE src_die = src_class_die.GetFirstChild(); src_die.IsValid();
        src_die = src_die.GetSibling()) {
-    if (src_die.Tag() == DW_TAG_subprogram) {
-      // Make sure this is a declaration and not a concrete instance by looking
-      // for DW_AT_declaration set to 1. Sometimes concrete function instances
-      // are placed inside the class definitions and shouldn't be included in
-      // the list of things are are tracking here.
-      if (src_die.GetAttributeValueAsUnsigned(DW_AT_declaration, 0) == 1) {
-        const char *src_name = src_die.GetMangledName();
-        if (src_name) {
-          ConstString src_const_name(src_name);
-          if (src_die.GetAttributeValueAsUnsigned(DW_AT_artificial, 0))
-            src_name_to_die_artificial.Append(src_const_name, src_die);
-          else
-            src_name_to_die.Append(src_const_name, src_die);
-        }
-      }
-    }
+    gather(src_die, src_name_to_die, src_name_to_die_artificial);
   }
-  for (dst_die = dst_class_die.GetFirstChild(); dst_die.IsValid();
+  for (DWARFDIE dst_die = dst_class_die.GetFirstChild(); dst_die.IsValid();
        dst_die = dst_die.GetSibling()) {
-    if (dst_die.Tag() == DW_TAG_subprogram) {
-      // Make sure this is a declaration and not a concrete instance by looking
-      // for DW_AT_declaration set to 1. Sometimes concrete function instances
-      // are placed inside the class definitions and shouldn't be included in
-      // the list of things are are tracking here.
-      if (dst_die.GetAttributeValueAsUnsigned(DW_AT_declaration, 0) == 1) {
-        const char *dst_name = dst_die.GetMangledName();
-        if (dst_name) {
-          ConstString dst_const_name(dst_name);
-          if (dst_die.GetAttributeValueAsUnsigned(DW_AT_artificial, 0))
-            dst_name_to_die_artificial.Append(dst_const_name, dst_die);
-          else
-            dst_name_to_die.Append(dst_const_name, dst_die);
-        }
-      }
-    }
+    gather(dst_die, dst_name_to_die, dst_name_to_die_artificial);
   }
   const uint32_t src_size = src_name_to_die.GetSize();
   const uint32_t dst_size = dst_name_to_die.GetSize();
@@ -3555,8 +3543,8 @@ bool DWARFASTParserClang::CopyUniqueClassMethodTypes(
 
   if (fast_path) {
     for (idx = 0; idx < src_size; ++idx) {
-      src_die = src_name_to_die.GetValueAtIndexUnchecked(idx);
-      dst_die = dst_name_to_die.GetValueAtIndexUnchecked(idx);
+      DWARFDIE src_die = src_name_to_die.GetValueAtIndexUnchecked(idx);
+      DWARFDIE dst_die = dst_name_to_die.GetValueAtIndexUnchecked(idx);
 
       if (src_die.Tag() != dst_die.Tag())
         fast_path = false;
@@ -3574,28 +3562,29 @@ bool DWARFASTParserClang::CopyUniqueClassMethodTypes(
 
   DWARFASTParserClang *src_dwarf_ast_parser =
       static_cast<DWARFASTParserClang *>(
-          SymbolFileDWARF::GetDWARFParser(*src_die.GetCU()));
+          SymbolFileDWARF::GetDWARFParser(*src_class_die.GetCU()));
   DWARFASTParserClang *dst_dwarf_ast_parser =
       static_cast<DWARFASTParserClang *>(
-          SymbolFileDWARF::GetDWARFParser(*dst_die.GetCU()));
+          SymbolFileDWARF::GetDWARFParser(*dst_class_die.GetCU()));
+  auto link = [&](DWARFDIE src, DWARFDIE dst) {
+    SymbolFileDWARF::DIEToTypePtr &die_to_type =
+        dst_class_die.GetDWARF()->GetDIEToType();
+    clang::DeclContext *src_decl_ctx =
+        src_dwarf_ast_parser->m_die_to_decl_ctx[src.GetDIE()];
+    if (src_decl_ctx)
+      dst_dwarf_ast_parser->LinkDeclContextToDIE(src_decl_ctx, dst);
+
+    if (Type *src_child_type = die_to_type[src.GetDIE()])
+      die_to_type[dst.GetDIE()] = src_child_type;
+  };
 
   // Now do the work of linking the DeclContexts and Types.
   if (fast_path) {
     // We can do this quickly.  Just run across the tables index-for-index
     // since we know each node has matching names and tags.
     for (idx = 0; idx < src_size; ++idx) {
-      src_die = src_name_to_die.GetValueAtIndexUnchecked(idx);
-      dst_die = dst_name_to_die.GetValueAtIndexUnchecked(idx);
-
-      clang::DeclContext *src_decl_ctx =
-          src_dwarf_ast_parser->m_die_to_decl_ctx[src_die.GetDIE()];
-      if (src_decl_ctx)
-        dst_dwarf_ast_parser->LinkDeclContextToDIE(src_decl_ctx, dst_die);
-
-      Type *src_child_type =
-          dst_die.GetDWARF()->GetDIEToType()[src_die.GetDIE()];
-      if (src_child_type)
-        dst_die.GetDWARF()->GetDIEToType()[dst_die.GetDIE()] = src_child_type;
+      link(src_name_to_die.GetValueAtIndexUnchecked(idx),
+           dst_name_to_die.GetValueAtIndexUnchecked(idx));
     }
   } else {
     // We must do this slowly.  For each member of the destination, look up a
@@ -3607,24 +3596,13 @@ bool DWARFASTParserClang::CopyUniqueClassMethodTypes(
 
       for (idx = 0; idx < dst_size; ++idx) {
         ConstString dst_name = dst_name_to_die.GetCStringAtIndex(idx);
-        dst_die = dst_name_to_die.GetValueAtIndexUnchecked(idx);
-        src_die = src_name_to_die.Find(dst_name, DWARFDIE());
+        DWARFDIE dst_die = dst_name_to_die.GetValueAtIndexUnchecked(idx);
+        DWARFDIE src_die = src_name_to_die.Find(dst_name, DWARFDIE());
 
-        if (src_die && (src_die.Tag() == dst_die.Tag())) {
-          clang::DeclContext *src_decl_ctx =
-              src_dwarf_ast_parser->m_die_to_decl_ctx[src_die.GetDIE()];
-          if (src_decl_ctx)
-            dst_dwarf_ast_parser->LinkDeclContextToDIE(src_decl_ctx, dst_die);
-
-          Type *src_child_type =
-              dst_die.GetDWARF()->GetDIEToType()[src_die.GetDIE()];
-          if (src_child_type) {
-            dst_die.GetDWARF()->GetDIEToType()[dst_die.GetDIE()] =
-                src_child_type;
-          }
-        } else {
+        if (src_die && (src_die.Tag() == dst_die.Tag()))
+          link(src_die, dst_die);
+        else
           failures.push_back(dst_die);
-        }
       }
     }
   }
@@ -3638,29 +3616,21 @@ bool DWARFASTParserClang::CopyUniqueClassMethodTypes(
     for (idx = 0; idx < src_size_artificial; ++idx) {
       ConstString src_name_artificial =
           src_name_to_die_artificial.GetCStringAtIndex(idx);
-      src_die = src_name_to_die_artificial.GetValueAtIndexUnchecked(idx);
-      dst_die =
+      DWARFDIE src_die =
+          src_name_to_die_artificial.GetValueAtIndexUnchecked(idx);
+      DWARFDIE dst_die =
           dst_name_to_die_artificial.Find(src_name_artificial, DWARFDIE());
 
-      if (dst_die) {
-        // Both classes have the artificial types, link them
-        clang::DeclContext *src_decl_ctx =
-            src_dwarf_ast_parser->m_die_to_decl_ctx[src_die.GetDIE()];
-        if (src_decl_ctx)
-          dst_dwarf_ast_parser->LinkDeclContextToDIE(src_decl_ctx, dst_die);
-
-        Type *src_child_type =
-            dst_die.GetDWARF()->GetDIEToType()[src_die.GetDIE()];
-        if (src_child_type)
-          dst_die.GetDWARF()->GetDIEToType()[dst_die.GetDIE()] = src_child_type;
-      }
+      // Both classes have the artificial types, link them
+      if (dst_die)
+        link(src_die, dst_die);
     }
   }
 
   if (dst_size_artificial) {
     for (idx = 0; idx < dst_size_artificial; ++idx) {
-      dst_die = dst_name_to_die_artificial.GetValueAtIndexUnchecked(idx);
-      failures.push_back(dst_die);
+      failures.push_back(
+          dst_name_to_die_artificial.GetValueAtIndexUnchecked(idx));
     }
   }
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -927,7 +927,7 @@ TypeSP DWARFASTParserClang::ParseSubroutine(const DWARFDIE &die,
                DW_TAG_value_to_name(tag), type_name_cstr);
 
   CompilerType return_clang_type;
-  Type *func_type = NULL;
+  Type *func_type = nullptr;
 
   if (attrs.type.IsValid())
     func_type = dwarf->ResolveTypeUID(attrs.type.Reference(), true);
@@ -1021,7 +1021,7 @@ TypeSP DWARFASTParserClang::ParseSubroutine(const DWARFDIE &die,
                   class_opaque_type, attrs.name.GetCString(), clang_type,
                   attrs.accessibility, attrs.is_artificial, is_variadic,
                   attrs.is_objc_direct_call);
-          type_handled = objc_method_decl != NULL;
+          type_handled = objc_method_decl != nullptr;
           if (type_handled) {
             LinkDeclContextToDIE(objc_method_decl, die);
             m_ast.SetMetadataAsUserID(objc_method_decl, die.GetID());
@@ -1172,7 +1172,7 @@ TypeSP DWARFASTParserClang::ParseSubroutine(const DWARFDIE &die,
                             is_static, attrs.is_inline, attrs.is_explicit,
                             is_attr_used, attrs.is_artificial);
 
-                    type_handled = cxx_method_decl != NULL;
+                    type_handled = cxx_method_decl != nullptr;
                     // Artificial methods are always handled even when we
                     // don't create a new declaration for them.
                     type_handled |= attrs.is_artificial;
@@ -2034,7 +2034,7 @@ bool DWARFASTParserClang::ParseTemplateDIE(
         if (name && name[0])
           template_param_infos.names.push_back(name);
         else
-          template_param_infos.names.push_back(NULL);
+          template_param_infos.names.push_back(nullptr);
 
         // Get the signed value for any integer or enumeration if available
         clang_type.IsIntegerOrEnumerationType(is_signed);
@@ -3323,7 +3323,8 @@ DWARFASTParserClang::GetOwningClangModule(const DWARFDIE &die) {
       auto it = m_die_to_module.find(module_die.GetDIE());
       if (it != m_die_to_module.end())
         return it->second;
-      const char *name = module_die.GetAttributeValueAsString(DW_AT_name, 0);
+      const char *name =
+          module_die.GetAttributeValueAsString(DW_AT_name, nullptr);
       if (!name)
         return {};
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.h
@@ -269,7 +269,7 @@ protected:
     ExtractUnitDIENoDwoIfNeeded();
     // m_first_die_mutex is not required as m_first_die is never cleared.
     if (!m_first_die)
-      return NULL;
+      return nullptr;
     return &m_first_die;
   }
 
@@ -277,7 +277,7 @@ protected:
   const DWARFDebugInfoEntry *DIEPtr() {
     ExtractDIEsIfNeeded();
     if (m_die_array.empty())
-      return NULL;
+      return nullptr;
     return &m_die_array[0];
   }
 

--- a/lldb/test/API/lang/cpp/incomplete-types/members/Makefile
+++ b/lldb/test/API/lang/cpp/incomplete-types/members/Makefile
@@ -1,0 +1,10 @@
+CXX_SOURCES := main.cpp f.cpp g.cpp
+
+include Makefile.rules
+
+# Force main.cpp to be built with no debug information
+main.o: CFLAGS = $(CFLAGS_NO_DEBUG)
+
+# And force -flimit-debug-info on the rest.
+f.o: CFLAGS_EXTRAS += $(LIMIT_DEBUG_INFO_FLAGS)
+g.o: CFLAGS_EXTRAS += $(LIMIT_DEBUG_INFO_FLAGS)

--- a/lldb/test/API/lang/cpp/incomplete-types/members/TestCppIncompleteTypeMembers.py
+++ b/lldb/test/API/lang/cpp/incomplete-types/members/TestCppIncompleteTypeMembers.py
@@ -13,7 +13,7 @@ class TestCppIncompleteTypeMembers(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
-    @skipIfDarwin
+    @skipIf(oslist=['darwin','macos'], debug_info="gmodules")
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "// break here",

--- a/lldb/test/API/lang/cpp/incomplete-types/members/TestCppIncompleteTypeMembers.py
+++ b/lldb/test/API/lang/cpp/incomplete-types/members/TestCppIncompleteTypeMembers.py
@@ -13,6 +13,7 @@ class TestCppIncompleteTypeMembers(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
+    @skipIfDarwin
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "// break here",

--- a/lldb/test/API/lang/cpp/incomplete-types/members/TestCppIncompleteTypeMembers.py
+++ b/lldb/test/API/lang/cpp/incomplete-types/members/TestCppIncompleteTypeMembers.py
@@ -1,0 +1,32 @@
+"""
+Test situations where we don't have a definition for a type, but we have (some)
+of its member functions.
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCppIncompleteTypeMembers(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "// break here",
+                lldb.SBFileSpec("f.cpp"))
+
+        # Sanity check that we really have to debug info for this type.
+        this = self.expect_var_path("this", type="A *")
+        self.assertEquals(this.GetType().GetPointeeType().GetNumberOfFields(),
+                0, str(this))
+
+        self.expect_var_path("af.x", value='42')
+
+        lldbutil.run_break_set_by_source_regexp(self, "// break here",
+                extra_options="-f g.cpp")
+        self.runCmd("continue")
+
+        self.expect_var_path("ag.a", value='47')

--- a/lldb/test/API/lang/cpp/incomplete-types/members/a.h
+++ b/lldb/test/API/lang/cpp/incomplete-types/members/a.h
@@ -1,0 +1,14 @@
+#ifndef A_H
+#define A_H
+
+class A {
+public:
+  A();
+  virtual void anchor();
+  int f();
+  int g();
+
+  int member = 47;
+};
+
+#endif

--- a/lldb/test/API/lang/cpp/incomplete-types/members/f.cpp
+++ b/lldb/test/API/lang/cpp/incomplete-types/members/f.cpp
@@ -1,0 +1,8 @@
+#include "a.h"
+
+int A::f() {
+  struct Af {
+    int x, y;
+  } af{42, 47};
+  return af.x + af.y; // break here
+}

--- a/lldb/test/API/lang/cpp/incomplete-types/members/g.cpp
+++ b/lldb/test/API/lang/cpp/incomplete-types/members/g.cpp
@@ -1,0 +1,8 @@
+#include "a.h"
+
+int A::g() {
+  struct Ag {
+    int a, b;
+  } ag{47, 42};
+  return ag.a + ag.b; // break here
+}

--- a/lldb/test/API/lang/cpp/incomplete-types/members/main.cpp
+++ b/lldb/test/API/lang/cpp/incomplete-types/members/main.cpp
@@ -1,0 +1,9 @@
+#include "a.h"
+
+A::A() = default;
+void A::anchor() {}
+
+int main() {
+  A().f();
+  A().g();
+}


### PR DESCRIPTION
IIUC, the purpose of CopyUniqueClassMethodTypes is to link together
class definitions in two compile units so that we only have a single
definition of a class. It does this by adding entries to the die_to_type
and die_to_decl_ctx maps.

However, the direction of the linking seems to be reversed. It is taking
entries from the class that has not yet been parsed, and copying them to
the class which has been parsed already -- i.e., it is a very
complicated no-op.

Changing the linking order allows us to revert the changes in D13224
(while keeping the associated test case passing), and is sufficient to
fix PR54761, which was caused by an undesired interaction with that
patch.

Differential Revision: https://reviews.llvm.org/D124370

(cherry picked from commit https://github.com/apple/llvm-project/commit/ae7fe65cf65dd4f71e117dee868965c152d27542)