### PR TITLE
[5.7] Fix -index-ignore-pcms not being propagated properly to the frontend

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5476,6 +5476,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     Args.AddLastArg(CmdArgs, options::OPT_index_record_codegen_name);
     Args.AddLastArg(CmdArgs, options::OPT_index_unit_output_path);
     Args.AddLastArg(CmdArgs, options::OPT_index_ignore_macros);
+    Args.AddLastArg(CmdArgs, options::OPT_index_ignore_pcms);
 
     // If '-o' is passed along with '-fsyntax-only' pass it along the cc1
     // invocation so that the index action knows what the out file is.

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -539,6 +539,7 @@ void darwin::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   Args.ClaimAllArgs(options::OPT_index_ignore_system_symbols);
   Args.ClaimAllArgs(options::OPT_index_record_codegen_name);
   Args.ClaimAllArgs(options::OPT_index_ignore_macros);
+  Args.ClaimAllArgs(options::OPT_index_ignore_pcms);
 
   /// Hack(tm) to ignore linking errors when we are doing ARC migration.
   if (Args.hasArg(options::OPT_ccc_arcmt_check,

--- a/clang/test/Index/Store/Inputs/explicit-modules/DependencyA.h
+++ b/clang/test/Index/Store/Inputs/explicit-modules/DependencyA.h
@@ -1,0 +1,1 @@
+int dependencyAVersion(void);

--- a/clang/test/Index/Store/Inputs/explicit-modules/module.modulemap
+++ b/clang/test/Index/Store/Inputs/explicit-modules/module.modulemap
@@ -1,0 +1,3 @@
+module DependencyA {
+  header "DependencyA.h"
+}

--- a/clang/test/Index/Store/print-units-explicit-modules-ignore-pcms.m
+++ b/clang/test/Index/Store/print-units-explicit-modules-ignore-pcms.m
@@ -1,0 +1,41 @@
+// RUN: rm -rf %t %t.idxdep %t.idxignore %t.idx %t.mcp %t.o
+
+// ------------------ Build explicit PCM DependencyA, indexing PCM flag does not disable indexing
+
+// RUN: %clang_cc1 -x objective-c -std=gnu11 -triple x86_64-apple-macosx10.8 \
+// RUN:            -fmodules -fimplicit-module-maps -fmodules-cache-path=%t.mcp -fdisable-module-hash \
+// RUN:            -fmodule-name=DependencyA -emit-module %S/Inputs/explicit-modules/module.modulemap -o %t/DependencyA.pcm \
+// RUN:            -index-store-path %t.idxdep -index-ignore-pcms
+// RUN: c-index-test core -print-unit %t.idxdep | FileCheck %s --check-prefixes=DEPA
+
+// ------------------ Build without indexing imported PCMs
+
+// RUN: %clang_cc1 -std=gnu11 -triple x86_64-apple-macosx10.8 \
+// RUN:            -fmodules -fimplicit-module-maps -fmodules-cache-path=%t.mcp -fdisable-module-hash \
+// RUN:            -fmodule-file=%t/DependencyA.pcm %s -o %t.o \
+// RUN:            -index-store-path %t.idxignore -index-ignore-pcms
+// RUN: c-index-test core -print-unit %t.idxignore | FileCheck %s --check-prefixes=MAIN,IGNORE
+
+// ------------------ Build with indexing of imported PCMs
+
+// RUN: %clang_cc1 -std=gnu11 -triple x86_64-apple-macosx10.8 \
+// RUN:            -fmodules -fimplicit-module-maps -fmodules-cache-path=%t.mcp -fdisable-module-hash \
+// RUN:            -fmodule-file=%t/DependencyA.pcm %s -o %t.o \
+// RUN:            -index-store-path %t.idx
+// RUN: c-index-test core -print-unit %t.idx | FileCheck %s --check-prefixes=DEPA,MAIN,INDEXMAIN
+
+@import DependencyA;
+
+int fetchDependencyAVersion() {
+  return dependencyAVersion();
+}
+
+// IGNORE-NOT: DependencyA.pcm
+// DEPA: DependencyA.pcm
+// DEPA: module-name: DependencyA
+
+// MAIN: print-units-explicit-modules-ignore-pcms.m.tmp.o
+// MAIN: DEPEND START
+// INDEXMAIN: Unit | user | DependencyA | {{.*}}{{/|\\}}DependencyA.pcm | DependencyA.pcm
+// IGNORE-NOT: Unit | user | DependencyA | {{.*}}{{/|\\}}DependencyA.pcm | DependencyA.pcm
+// IGNORE: Unit | user | DependencyA | {{.*}}{{/|\\}}DependencyA.pcm

--- a/clang/test/Index/Store/print-units-with-modules.m
+++ b/clang/test/Index/Store/print-units-with-modules.m
@@ -1,66 +1,57 @@
 // RUN: rm -rf %t.idx %t.mcp
 // RUN: %clang -arch x86_64 -mmacosx-version-min=10.7 -c %s -o %t.o -index-store-path %t.idx -fmodules -fmodules-cache-path=%t.mcp -Xclang -fdisable-module-hash -I %S/Inputs/module
-// RUN: c-index-test core -print-unit %t.idx | FileCheck %s --check-prefixes=ALL,MODULES
-
-// RUN: rm -rf %t.idx %t.mcp
-// RUN: %clang -arch x86_64 -mmacosx-version-min=10.7 -c %s -o %t.o -index-store-path %t.idx -index-ignore-pcms -fmodules -fmodules-cache-path=%t.mcp -Xclang -fdisable-module-hash -I %S/Inputs/module
-// RUN: c-index-test core -print-unit %t.idx | FileCheck %s --check-prefixes=ALL,IGNORE
+// RUN: c-index-test core -print-unit %t.idx | FileCheck %s
 
 @import ModDep;
 @import ModSystem;
 
-// IGNORE-NOT: ModDep.pcm
-// MODULES: ModDep.pcm
-// MODULES: provider: clang-
-// MODULES: is-system: 0
-// MODULES: is-module: 1
-// MODULES: module-name: ModDep
-// MODULES: has-main: 0
-// MODULES: main-path: {{$}}
-// MODULES: out-file: {{.*}}{{/|\\}}ModDep.pcm
-// MODULES: DEPEND START
-// MODULES: Unit | user | ModTop | {{.*}}{{/|\\}}ModTop.pcm | ModTop.pcm
-// MODULES: Record | user | ModDep | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModDep.h | ModDep.h
-// MODULES: DEPEND END (2)
+// CHECK: ModDep.pcm
+// CHECK: provider: clang-
+// CHECK: is-system: 0
+// CHECK: is-module: 1
+// CHECK: module-name: ModDep
+// CHECK: has-main: 0
+// CHECK: main-path: {{$}}
+// CHECK: out-file: {{.*}}{{/|\\}}ModDep.pcm
+// CHECK: DEPEND START
+// CHECK: Unit | user | ModTop | {{.*}}{{/|\\}}ModTop.pcm | ModTop.pcm
+// CHECK: Record | user | ModDep | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModDep.h | ModDep.h
+// CHECK: DEPEND END (2)
 
-// IGNORE-NOT: ModSystem.pcm
-// MODULES: ModSystem.pcm
-// MODULES: is-system: 1
-// MODULES: is-module: 1
-// MODULES: module-name: ModSystem
-// MODULES: has-main: 0
-// MODULES: main-path: {{$}}
-// MODULES: out-file: {{.*}}{{/|\\}}ModSystem.pcm
-// MODULES: DEPEND START
-// MODULES: Record | system | ModSystem | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModSystem.h | ModSystem.h
-// MODULES: DEPEND END (1)
+// CHECK: ModSystem.pcm
+// CHECK: is-system: 1
+// CHECK: is-module: 1
+// CHECK: module-name: ModSystem
+// CHECK: has-main: 0
+// CHECK: main-path: {{$}}
+// CHECK: out-file: {{.*}}{{/|\\}}ModSystem.pcm
+// CHECK: DEPEND START
+// CHECK: Record | system | ModSystem | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModSystem.h | ModSystem.h
+// CHECK: DEPEND END (1)
 
-// IGNORE-NOT: ModTop.pcm
-// MODULES: ModTop.pcm
-// MODULES: is-system: 0
-// MODULES: is-module: 1
-// MODULES: module-name: ModTop
-// MODULES: has-main: 0
-// MODULES: main-path: {{$}}
-// MODULES: out-file: {{.*}}{{/|\\}}ModTop.pcm
-// MODULES: DEPEND START
-// MODULES: Record | user | ModTop | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModTop.h | ModTop.h
-// MODULES: Record | user | ModTop.Sub1 | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModTopSub1.h | ModTopSub1.h
-// MODULES: File | user | ModTop.Sub2 | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModTopSub2.h{{$}}
-// MODULES: DEPEND END (3)
+// CHECK: ModTop.pcm
+// CHECK: is-system: 0
+// CHECK: is-module: 1
+// CHECK: module-name: ModTop
+// CHECK: has-main: 0
+// CHECK: main-path: {{$}}
+// CHECK: out-file: {{.*}}{{/|\\}}ModTop.pcm
+// CHECK: DEPEND START
+// CHECK: Record | user | ModTop | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModTop.h | ModTop.h
+// CHECK: Record | user | ModTop.Sub1 | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModTopSub1.h | ModTopSub1.h
+// CHECK: File | user | ModTop.Sub2 | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}ModTopSub2.h{{$}}
+// CHECK: DEPEND END (3)
 
-// ALL: print-units-with-modules.m.tmp.o
-// ALL: is-system: 0
-// ALL: is-module: 0
-// ALL: module-name: <none>
-// ALL: has-main: 1
-// ALL: main-path: {{.*}}{{/|\\}}print-units-with-modules.m
-// ALL: out-file: {{.*}}{{/|\\}}print-units-with-modules.m.tmp.o
-// ALL: DEPEND START
-// MODULES: Unit | user | ModDep | {{.*}}{{/|\\}}ModDep.pcm | ModDep.pcm
-// MODULES: Unit | system | ModSystem | {{.*}}{{/|\\}}ModSystem.pcm | ModSystem.pcm
-// IGNORE: Unit | user | ModDep | {{.*}}{{/|\\}}ModDep.pcm
-// IGNORE: Unit | system | ModSystem | {{.*}}{{/|\\}}ModSystem.pcm
-// ALL: File | user | {{.*}}{{/|\\}}print-units-with-modules.m{{$}}
-// ALL: File | user | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}module.modulemap{{$}}
-// ALL: DEPEND END (4)
+// CHECK: print-units-with-modules.m.tmp.o
+// CHECK: is-system: 0
+// CHECK: is-module: 0
+// CHECK: module-name: <none>
+// CHECK: has-main: 1
+// CHECK: main-path: {{.*}}{{/|\\}}print-units-with-modules.m
+// CHECK: out-file: {{.*}}{{/|\\}}print-units-with-modules.m.tmp.o
+// CHECK: DEPEND START
+// CHECK: Unit | user | ModDep | {{.*}}{{/|\\}}ModDep.pcm | ModDep.pcm
+// CHECK: Unit | system | ModSystem | {{.*}}{{/|\\}}ModSystem.pcm | ModSystem.pcm
+// CHECK: File | user | {{.*}}{{/|\\}}print-units-with-modules.m{{$}}
+// CHECK: File | user | {{.*}}{{/|\\}}Inputs{{/|\\}}module{{/|\\}}module.modulemap{{$}}
+// CHECK: DEPEND END (4)


### PR DESCRIPTION
Update the corresponding test to use explicit modules. Implicit modules will still be indexed while they are themselves compiled, as `-index-ignore-pcms` only ignores imported modules.