### PR TITLE
[lldb/crashlog] Show help when the command is called without any argument

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -1193,6 +1193,11 @@ be disassembled and lookups can be performed using the addresses found in the cr
 
 def SymbolicateCrashLogs(debugger, command_args):
     option_parser = CrashLogOptionParser()
+
+    if not len(command_args):
+        option_parser.print_help()
+        return
+
     try:
         (options, args) = option_parser.parse_args(command_args)
     except:

--- a/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/no-args.test
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/no-args.test
@@ -1,0 +1,9 @@
+# RUN: %lldb -o 'command script import lldb.macosx.crashlog' -o 'crashlog' 2>&1 | FileCheck %s
+
+# CHECK: "crashlog" {{.*}} commands have been installed, use the "--help" options on these commands
+
+# CHECK: Usage: crashlog [options] <FILE> [FILE ...]
+# CHECK: Symbolicate one or more darwin crash log files to provide source file and line
+# CHECK: Options:
+# CHECK:  -h, --help            show this help message and exit
+


### PR DESCRIPTION
This patch changes the `crashlog` command behavior to print the help
message if no argument was provided with the command.

rdar://94576026

Differential Revision: https://reviews.llvm.org/D127362

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>
(cherry picked from commit d66ba25e2aa78f0da478741be79b9173d2290e54)