### PR TITLE
[lldb/test] Skip TestCppIncompleteTypeMembers.py for -gmodules on macOS

### DIFF
--- a/lldb/test/API/lang/cpp/incomplete-types/members/TestCppIncompleteTypeMembers.py
+++ b/lldb/test/API/lang/cpp/incomplete-types/members/TestCppIncompleteTypeMembers.py
@@ -13,7 +13,7 @@ class TestCppIncompleteTypeMembers(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
-    @skipIfDarwin
+    @skipIf(oslist=['darwin','macos'], debug_info="gmodules")
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "// break here",


### PR DESCRIPTION
Following 8b9caad8eb449c1dc4df13e566a5f6c59de9be7c, this only skips
TestCppIncompleteTypeMembers.py on macOS if we test with `-gmodules` enabled.

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>
(cherry picked from commit 2d7b49f389781751eac36f479b59d854664e9da5)
(cherry picked from commit 665b3f373402259b375b2f78c4edfeebbd0d9b35)