### PR TITLE
[clang][deps] Remove IndexUnitOutputPath from module deps

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -54,6 +54,8 @@ CompilerInvocation ModuleDepCollector::makeInvocationForModuleBuildWithoutPaths(
   // units.
   CI.getFrontendOpts().Inputs.clear();
   CI.getFrontendOpts().OutputFile.clear();
+  // FIXME: a build system may want to provide a new path.
+  CI.getFrontendOpts().IndexUnitOutputPath.clear();
   CI.getCodeGenOpts().MainFileName.clear();
   CI.getCodeGenOpts().DwarfDebugFlags.clear();
 

--- a/clang/test/ClangScanDeps/modules-index-store-path.c
+++ b/clang/test/ClangScanDeps/modules-index-store-path.c
@@ -1,0 +1,45 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-full \
+// RUN:   -generate-modules-path-args -module-files-dir %t/build > %t/result.json
+
+// RUN: cat %t/result.json | sed 's:\\\\\?:/:g' | FileCheck %s -DPREFIX=%/t
+// CHECK:      {
+// CHECK-NEXT:   "modules": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "clang-module-deps": [],
+// CHECK-NEXT:       "clang-modulemap-file": "[[PREFIX]]/module.modulemap",
+// CHECK-NEXT:       "command-line": [
+// CHECK-NEXT:         "-cc1"
+// CHECK-NOT:          "-index-unit-output-path"
+// CHECK:            ]
+
+// RUN: %deps-to-rsp %t/result.json --module-name=Mod > %t/Mod.cc1.rsp
+// RUN: %deps-to-rsp %t/result.json --tu-index=0 > %t/tu.cc1.rsp
+// RUN: %clang @%t/Mod.cc1.rsp -pedantic -Werror
+// RUN: %clang @%t/tu.cc1.rsp -pedantic -Werror
+// RUN: c-index-test core -print-unit %t/index | FileCheck %s -DPREFIX=%/t -check-prefix=INDEX
+// INDEX-DAG: out-file: [[PREFIX]]{{/|\\}}build/{{.*(/|\\)}}Mod-{{.*}}.pcm
+// INDEX-DAG: out-file: /tu.o
+
+//--- cdb.json.template
+[
+  {
+    "directory": "DIR",
+    "command": "clang -fsyntax-only DIR/tu.c -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/cache -index-store-path DIR/index -index-unit-output-path /tu.o -o DIR/tu.o",
+    "file": "DIR/tu.c"
+  }
+]
+
+//--- module.modulemap
+module Mod { header "Mod.h" }
+
+//--- Mod.h
+void mod(void);
+
+//--- tu.c
+#include "Mod.h"
+void tu(void) {
+  mod();
+}


### PR DESCRIPTION
Similar to https://reviews.llvm.org/D127883, but this option is only on the 'next' branch.

---

The -index-unit-output-path is specific to the TU and should not be
inherited by the module builds. In principle, a build system may want to
provide an explicit path for it, but we don't have an API for that yet.