### PR TITLE
[cherry-pick][Clang][Modules] Merge availability attributes on imported decls

### DIFF
--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -3664,6 +3664,13 @@ void ASTDeclReader::mergeInheritableAttributes(ASTReader &Reader, Decl *D,
     NewAttr->setInherited(true);
     D->addAttr(NewAttr);
   }
+
+  const auto *AA = Previous->getAttr<AvailabilityAttr>();
+  if (AA && !D->hasAttr<AvailabilityAttr>()) {
+    NewAttr = AA->clone(Context);
+    NewAttr->setInherited(true);
+    D->addAttr(NewAttr);
+  }
 }
 
 template<typename DeclT>

--- a/clang/test/Modules/decl-attr-merge.mm
+++ b/clang/test/Modules/decl-attr-merge.mm
@@ -1,0 +1,41 @@
+// RUN: rm -rf %t.dir
+// RUN: split-file %s %t.dir
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps \
+// RUN:   -fmodules-cache-path=%t.dir/cache -triple x86_64-apple-macosx10.11.0 \
+// RUN:   -I%t.dir/headers %t.dir/main.m -emit-llvm -o %t.dir/main.ll
+// RUN: cat %t.dir/main.ll | FileCheck %s
+
+//--- headers/a.h
+
+__attribute__((availability(macos,introduced=10.16)))
+@interface INIntent
+- (instancetype)self;
+@end
+
+//--- headers/b.h
+
+@class INIntent;
+
+//--- headers/module.modulemap
+
+module A {
+  header "a.h"
+}
+
+module B {
+  header "b.h"
+}
+
+//--- main.m
+
+#import <a.h>
+#import <b.h> // NOTE: Non attributed decl imported after one with attrs.
+
+void F(id);
+
+int main() {
+  if (@available(macOS 11.0, *))
+    F([INIntent self]);
+}
+
+// CHECK: @"OBJC_CLASS_$_INIntent" = extern_weak


### PR DESCRIPTION
Currently we do not in general merge attributes when importing decls from modules. This patch handles availability, but long term we need to properly handle all attributes.

I tried to use Sema::mergeDeclAttributes, but it caused test crashes as I don't think it expects to be called in this context. We really shouldn't have duplicate code for merging attributes long term, but for now this fixes availability. There's already a TODO for this in the declaration of ASTDeclReader::mergeInheritableAttributes.

Differential Revision: https://reviews.llvm.org/D127182

rdar://85820301