### PR TITLE
Adjust the Apple ObjC2 runtime class info expr to ObjC runtime changes.

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -176,6 +176,7 @@ extern "C" {
     void free(void *ptr);
     Class* objc_copyRealizedClassList_nolock(unsigned int *outCount);
     const char* objc_debug_class_getNameRaw(Class cls);
+    const char* class_getName(Class cls);
 }
 
 #define DEBUG_PRINTF(fmt, ...) if (should_log) printf(fmt, ## __VA_ARGS__)
@@ -211,7 +212,11 @@ __lldb_apple_objc_v2_get_dynamic_class_info2(void *gdb_objc_realized_classes_ptr
         {
             Class isa = realized_class_list[i];
             const char *name_ptr = objc_debug_class_getNameRaw(isa);
-            if (name_ptr == NULL)
+            if (!name_ptr) {
+              class_getName(isa); /* Realize lazy names of bridged Swift classes. */
+              name_ptr = objc_debug_class_getNameRaw(isa);
+            }
+            if (!name_ptr)
                 continue;
             const char *s = name_ptr;
             uint32_t h = 5381;


### PR DESCRIPTION
Recent revisions of the Objective-C runtime changed
objc_debug_class_getNameRaw() in a way that no longer triggers lazy
names to be instantiated. This has the unintended side-effect of
making generic bridged Swift classes, such as
_SwiftDeferredNSDictionary<U,V> to become invisible to the Objective-C
runtime. This patch detects this situation and forces the names to be
instantiated by calling class_getName() and discarding the result
before calling objc_debug_class_getNameRaw() again.

This fixes the Swift REPL tests on macOS Ventura.

Many thanks to Mike Ash for outlining the solution!

rdar://95245318