### PR TITLE
Change the 'casFriendly' flag in DICompileUnit from a bool to an enum

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -370,8 +370,8 @@ VALUE_CODEGENOPT(SSPBufferSize, 32, 0)
 /// The kind of generated debug info.
 ENUM_CODEGENOPT(DebugInfo, codegenoptions::DebugInfoKind, 4, codegenoptions::NoDebugInfo)
 
-/// Whether to split up debug info for the CAS
-CODEGENOPT(CasFriendliness, 1, 0)
+/// How to split up the debug info.
+ENUM_CODEGENOPT(CasFriendliness, codegenoptions::CasFriendlinessKind, 2, codegenoptions::NoCasFriendlyDebugInfo)
 
 /// Whether to make debug info reproducible.
 CODEGENOPT(ReproducibleDebugInfo, 1, 0)

--- a/clang/include/clang/Basic/DebugInfoOptions.h
+++ b/clang/include/clang/Basic/DebugInfoOptions.h
@@ -21,9 +21,17 @@ enum CasFriendlinessKind {
   NoCasFriendlyDebugInfo,
 
   /// Generate CAS friendly debug info to go along with the work being done for
-  /// llvm-cas. This involves, amongst other things, splitting line tables per
-  /// function.
-  CasFriendlyDebugInfo
+  /// llvm-cas. This option will split the line tables so that every function
+  /// has its own line table header. Note: To achieve this, every function is
+  /// given its own compile unit.
+  DebugLineOnly,
+
+  /// Generate CAS friendly debug info to go along with the work being done for
+  /// llvm-cas. This option will make it so that every compiler unit has its own
+  /// contribution into the debug abbreviation section. Note: To achieve this,
+  /// every function is given its own compile unit, which means each compile
+  /// unit also has its own line table header.
+  DebugAbbrev
 };
 
 enum DebugInfoKind {

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -354,6 +354,9 @@ def warn_drv_unsupported_opt_for_target : Warning<
 def warn_drv_unsupported_debug_info_opt_for_target : Warning<
   "debug information option '%0' is not supported for target '%1'">,
   InGroup<UnsupportedTargetOpt>;
+def warn_drv_unsupported_cas_friendliness_opt_for_target : Warning<
+  "cas friendliness option '%0' is not supported for target '%1'">,
+  InGroup<UnsupportedTargetOpt>;
 def warn_drv_dwarf_version_limited_by_target : Warning<
   "debug information option '%0' is not supported; requires DWARF-%2 but "
   "target '%1' only provides DWARF-%3">,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2734,8 +2734,10 @@ def ftrivial_auto_var_init_stop_after : Joined<["-"], "ftrivial-auto-var-init-st
   MarshallingInfoInt<LangOpts<"TrivialAutoVarInitStopAfter">>;
 def fstandalone_debug : Flag<["-"], "fstandalone-debug">, Group<f_Group>, Flags<[CoreOption]>,
   HelpText<"Emit full debug info for all types used by the program">;
-def fcas_friendly_debug_info : Flag<["-"], "fcas-friendly-debug-info">, Group<f_Group>,
-  Flags<[CoreOption]>, HelpText<"Emit debug information that is cas friendly">;
+def fcas_friendly_debug_info : Joined<["-"], "fcas-friendly-debug-info=">, Group<f_Group>,
+  Flags<[CoreOption]>, HelpText<"Emit debug information that is cas friendly"
+  "debug-line-only: Only split up the debug_line section (It will also split up the debug_info section)"
+  "debug-abbrev: Split up debug_abbrev section (debug_line and debug_info sections will be split up also)">;
 def fno_standalone_debug : Flag<["-"], "fno-standalone-debug">, Group<f_Group>, Flags<[CoreOption]>,
   HelpText<"Limit debug information produced to reduce size of debug binary">;
 def flimit_debug_info : Flag<["-"], "flimit-debug-info">, Flags<[CoreOption]>, Alias<fno_standalone_debug>;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4230,8 +4230,16 @@ static void renderDebugOptions(const ToolChain &TC, const Driver &D,
   if (T.isOSBinFormatELF() && SplitDWARFInlining)
     CmdArgs.push_back("-fsplit-dwarf-inlining");
 
-  if (const Arg *A = Args.getLastArg(options::OPT_fcas_friendly_debug_info))
-    CmdArgs.push_back("-cas-friendliness-kind=cas-friendly");
+  if (const Arg *A = Args.getLastArg(options::OPT_fcas_friendly_debug_info)) {
+    StringRef ArgValue = A->getValue();
+    if (ArgValue == "debug-line-only")
+      CmdArgs.push_back("-cas-friendliness-kind=debug-line-only");
+    else if (ArgValue == "debug-abbrev")
+      CmdArgs.push_back("-cas-friendliness-kind=debug-abbrev");
+    else
+      D.Diag(diag::warn_drv_unsupported_debug_info_opt_for_target)
+          << A->getAsString(Args) << TC.getTripleString();
+  }
 
   // After we've dealt with all combinations of things that could
   // make DebugInfoKind be other than None or DebugLineTablesOnly,

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1387,10 +1387,14 @@ void CompilerInvocation::GenerateCodeGenArgs(
 
   Optional<StringRef> CasFriendlinessVal;
   switch (Opts.CasFriendliness) {
-  case codegenoptions::CasFriendlyDebugInfo:
-    CasFriendlinessVal = "cas-friendly";
-    break;
   case codegenoptions::NoCasFriendlyDebugInfo:
+    CasFriendlinessVal = None;
+    break;
+  case codegenoptions::DebugLineOnly:
+    CasFriendlinessVal = "debug-line-only";
+    break;
+  case codegenoptions::DebugAbbrev:
+    CasFriendlinessVal = "debug-abbrev";
     break;
   }
   if (CasFriendlinessVal)
@@ -1647,10 +1651,10 @@ bool CompilerInvocation::ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args,
        LangOpts->PICLevel == 0);
 
   if (Arg *A = Args.getLastArg(OPT_cas_friendliness_kind_EQ)) {
-    unsigned Val =
-        llvm::StringSwitch<unsigned>(A->getValue())
-            .Case("cas-friendly", codegenoptions::CasFriendlyDebugInfo)
-            .Default(codegenoptions::NoCasFriendlyDebugInfo);
+    unsigned Val = llvm::StringSwitch<unsigned>(A->getValue())
+                       .Case("debug-line-only", codegenoptions::DebugLineOnly)
+                       .Case("debug-abbrev", codegenoptions::DebugAbbrev)
+                       .Default(codegenoptions::NoCasFriendlyDebugInfo);
 
     Opts.CasFriendliness =
         static_cast<codegenoptions::CasFriendlinessKind>(Val);

--- a/clang/test/CodeGen/debug-info-cas-friendly-option-test.c
+++ b/clang/test/CodeGen/debug-info-cas-friendly-option-test.c
@@ -1,5 +1,8 @@
-// RUN: %clang -cc1 -debug-info-kind=standalone -cas-friendliness-kind=cas-friendly %s -emit-llvm -o - | FileCheck %s
-// CHECK: !DICompileUnit{{.+}}casFriendly: true{{.*}}
+// RUN: %clang -cc1 -debug-info-kind=standalone -cas-friendliness-kind=debug-line-only %s -emit-llvm -o - | FileCheck %s --check-prefix DEBUG_LINE_ONLY
+// DEBUG_LINE_ONLY: !DICompileUnit{{.+}}casFriendly: DebugLineOnly{{.*}}
+
+// RUN: %clang -cc1 -debug-info-kind=standalone -cas-friendliness-kind=debug-abbrev %s -emit-llvm -o - | FileCheck %s --check-prefix DEBUG_ABBREV
+// DEBUG_ABBREV: !DICompileUnit{{.+}}casFriendly: DebugAbbrev{{.*}}
 void foo() {
   return;
 }

--- a/clang/test/Driver/debug-options.c
+++ b/clang/test/Driver/debug-options.c
@@ -284,12 +284,20 @@
 // RUN: %clang -### -target %itanium_abi_triple -gmodules -gline-directives-only %s 2>&1 \
 // RUN:        | FileCheck -check-prefix=GLIO_ONLY %s
 //
-// RUN: %clang -### -c -g -fcas-friendly-debug-info %s -target x86_64-apple-darwin14 2>&1 \
-// RUN:             | FileCheck -check-prefix=F_CASFRIENDLY \
+// RUN: %clang -### -c -g -fcas-friendly-debug-info=debug-line-only %s -target x86_64-apple-darwin14 2>&1 \
+// RUN:             | FileCheck -check-prefix=F_CASFRIENDLY_DEBUG_LINE \
 // RUN:                         -check-prefix=G_DWARF2 \
 // RUN:                         -check-prefix=G_LLDB %s
-// RUN: %clang -### -c -g -fcas-friendly-debug-info %s -target x86_64-apple-darwin16 2>&1 \
-// RUN:             | FileCheck -check-prefix=F_CASFRIENDLY \
+// RUN: %clang -### -c -g -fcas-friendly-debug-info=debug-line-only %s -target x86_64-apple-darwin16 2>&1 \
+// RUN:             | FileCheck -check-prefix=F_CASFRIENDLY_DEBUG_LINE \
+// RUN:                         -check-prefix=G_DWARF4 \
+// RUN:                         -check-prefix=G_LLDB %s
+// RUN: %clang -### -c -g -fcas-friendly-debug-info=debug-abbrev %s -target x86_64-apple-darwin14 2>&1 \
+// RUN:             | FileCheck -check-prefix=F_CASFRIENDLY_DEBUG_ABBREV \
+// RUN:                         -check-prefix=G_DWARF2 \
+// RUN:                         -check-prefix=G_LLDB %s
+// RUN: %clang -### -c -g -fcas-friendly-debug-info=debug-abbrev %s -target x86_64-apple-darwin16 2>&1 \
+// RUN:             | FileCheck -check-prefix=F_CASFRIENDLY_DEBUG_ABBREV \
 // RUN:                         -check-prefix=G_DWARF4 \
 // RUN:                         -check-prefix=G_LLDB %s
 //
@@ -332,8 +340,10 @@
 //
 // G_STANDALONE: "-cc1"
 // G_STANDALONE: "-debug-info-kind=standalone"
-// F_CASFRIENDLY: "-cc1"
-// F_CASFRIENDLY: "-cas-friendliness-kind=cas-friendly"
+// F_CASFRIENDLY_DEBUG_LINE: "-cc1"
+// F_CASFRIENDLY_DEBUG_LINE: "-cas-friendliness-kind=debug-line-only"
+// F_CASFRIENDLY_DEBUG_ABBREV: "-cc1"
+// F_CASFRIENDLY_DEBUG_ABBREV: "-cas-friendliness-kind=debug-abbrev"
 // G_LIMITED: "-cc1"
 // G_LIMITED: "-debug-info-kind=constructor"
 // G_DWARF2: "-dwarf-version=2"

--- a/llvm/include/llvm/AsmParser/LLToken.h
+++ b/llvm/include/llvm/AsmParser/LLToken.h
@@ -412,24 +412,25 @@ enum Kind {
   SummaryID,  // ^42
 
   // String valued tokens (StrVal).
-  LabelStr,         // foo:
-  GlobalVar,        // @foo @"foo"
-  ComdatVar,        // $foo
-  LocalVar,         // %foo %"foo"
-  MetadataVar,      // !foo
-  StringConstant,   // "foo"
-  DwarfTag,         // DW_TAG_foo
-  DwarfAttEncoding, // DW_ATE_foo
-  DwarfVirtuality,  // DW_VIRTUALITY_foo
-  DwarfLang,        // DW_LANG_foo
-  DwarfCC,          // DW_CC_foo
-  EmissionKind,     // lineTablesOnly
-  NameTableKind,    // GNU
-  DwarfOp,          // DW_OP_foo
-  DIFlag,           // DIFlagFoo
-  DISPFlag,         // DISPFlagFoo
-  DwarfMacinfo,     // DW_MACINFO_foo
-  ChecksumKind,     // CSK_foo
+  LabelStr,            // foo:
+  GlobalVar,           // @foo @"foo"
+  ComdatVar,           // $foo
+  LocalVar,            // %foo %"foo"
+  MetadataVar,         // !foo
+  StringConstant,      // "foo"
+  DwarfTag,            // DW_TAG_foo
+  DwarfAttEncoding,    // DW_ATE_foo
+  DwarfVirtuality,     // DW_VIRTUALITY_foo
+  DwarfLang,           // DW_LANG_foo
+  DwarfCC,             // DW_CC_foo
+  EmissionKind,        // lineTablesOnly
+  CasFriendlinessKind, // casFriendliness
+  NameTableKind,       // GNU
+  DwarfOp,             // DW_OP_foo
+  DIFlag,              // DIFlagFoo
+  DISPFlag,            // DISPFlagFoo
+  DwarfMacinfo,        // DW_MACINFO_foo
+  ChecksumKind,        // CSK_foo
 
   // Type valued tokens (TyVal).
   Type,

--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -152,18 +152,19 @@ namespace llvm {
     /// \param SysRoot       The clang system root (value of -isysroot).
     /// \param SDK           The SDK name. On Darwin, this is the last component
     ///                      of the sysroot.
-    DICompileUnit *
-    createCompileUnit(unsigned Lang, DIFile *File, StringRef Producer,
-                      bool isOptimized, StringRef Flags, unsigned RV,
-                      StringRef SplitName = StringRef(),
-                      DICompileUnit::DebugEmissionKind Kind =
-                          DICompileUnit::DebugEmissionKind::FullDebug,
-                      uint64_t DWOId = 0, bool SplitDebugInlining = true,
-                      bool DebugInfoForProfiling = false,
-                      DICompileUnit::DebugNameTableKind NameTableKind =
-                          DICompileUnit::DebugNameTableKind::Default,
-                      bool RangesBaseAddress = false, StringRef SysRoot = {},
-                      StringRef SDK = {}, bool CasFriendliness = false);
+    DICompileUnit *createCompileUnit(
+        unsigned Lang, DIFile *File, StringRef Producer, bool isOptimized,
+        StringRef Flags, unsigned RV, StringRef SplitName = StringRef(),
+        DICompileUnit::DebugEmissionKind Kind =
+            DICompileUnit::DebugEmissionKind::FullDebug,
+        uint64_t DWOId = 0, bool SplitDebugInlining = true,
+        bool DebugInfoForProfiling = false,
+        DICompileUnit::DebugNameTableKind NameTableKind =
+            DICompileUnit::DebugNameTableKind::Default,
+        bool RangesBaseAddress = false, StringRef SysRoot = {},
+        StringRef SDK = {},
+        DICompileUnit::CasFriendlinessKind CasFriendliness =
+            DICompileUnit::CasFriendlinessKind::NoCasFriendlyDebugInfo);
 
     /// Create a file descriptor to hold debugging information for a file.
     /// \param Filename  File name.

--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -1333,8 +1333,17 @@ public:
     LastDebugNameTableKind = None
   };
 
+  enum CasFriendlinessKind : unsigned {
+    NoCasFriendlyDebugInfo = 0,
+    DebugLineOnly,
+    DebugAbbrev,
+    LastCasFriendlinessKind = DebugAbbrev
+  };
+
   static Optional<DebugEmissionKind> getEmissionKind(StringRef Str);
+  static Optional<CasFriendlinessKind> getCasFriendlinessKind(StringRef Str);
   static const char *emissionKindString(DebugEmissionKind EK);
+  static const char *casFriendlinessString(CasFriendlinessKind CFK);
   static Optional<DebugNameTableKind> getNameTableKind(StringRef Str);
   static const char *nameTableKindString(DebugNameTableKind PK);
 
@@ -1348,14 +1357,14 @@ private:
   bool DebugInfoForProfiling;
   unsigned NameTableKind;
   bool RangesBaseAddress;
-  bool CasFriendliness;
-    
+  unsigned CasFriendliness;
+
   DICompileUnit(LLVMContext &C, StorageType Storage, unsigned SourceLanguage,
                 bool IsOptimized, unsigned RuntimeVersion,
                 unsigned EmissionKind, uint64_t DWOId, bool SplitDebugInlining,
                 bool DebugInfoForProfiling, unsigned NameTableKind,
                 bool RangesBaseAddress, ArrayRef<Metadata *> Ops,
-                bool CasFriendliness);
+                unsigned CasFriendliness);
   ~DICompileUnit() = default;
 
   static DICompileUnit *
@@ -1368,7 +1377,7 @@ private:
           DIImportedEntityArray ImportedEntities, DIMacroNodeArray Macros,
           uint64_t DWOId, bool SplitDebugInlining, bool DebugInfoForProfiling,
           unsigned NameTableKind, bool RangesBaseAddress, StringRef SysRoot,
-          StringRef SDK, bool CasFriendlieness, StorageType Storage,
+          StringRef SDK, unsigned CasFriendlieness, StorageType Storage,
           bool ShouldCreate = true) {
     return getImpl(
         Context, SourceLanguage, File, getCanonicalMDString(Context, Producer),
@@ -1390,7 +1399,8 @@ private:
           Metadata *Macros, uint64_t DWOId, bool SplitDebugInlining,
           bool DebugInfoForProfiling, unsigned NameTableKind,
           bool RangesBaseAddress, MDString *SysRoot, MDString *SDK,
-          bool CasFriendliness, StorageType Storage, bool ShouldCreate = true);
+          unsigned CasFriendliness, StorageType Storage,
+          bool ShouldCreate = true);
 
   TempDICompileUnit cloneImpl() const {
     return getTemporary(
@@ -1399,7 +1409,8 @@ private:
         getEmissionKind(), getEnumTypes(), getRetainedTypes(),
         getGlobalVariables(), getImportedEntities(), getMacros(), DWOId,
         getSplitDebugInlining(), getDebugInfoForProfiling(), getNameTableKind(),
-        getRangesBaseAddress(), getSysRoot(), getSDK(), isCasFriendly());
+        getRangesBaseAddress(), getSysRoot(), getSDK(),
+        getCasFriendlinessKind());
   }
 
 public:
@@ -1416,7 +1427,7 @@ public:
        DIImportedEntityArray ImportedEntities, DIMacroNodeArray Macros,
        uint64_t DWOId, bool SplitDebugInlining, bool DebugInfoForProfiling,
        DebugNameTableKind NameTableKind, bool RangesBaseAddress,
-       StringRef SysRoot, StringRef SDK, bool CasFriendliness),
+       StringRef SysRoot, StringRef SDK, unsigned CasFriendliness),
       (SourceLanguage, File, Producer, IsOptimized, Flags, RuntimeVersion,
        SplitDebugFilename, EmissionKind, EnumTypes, RetainedTypes,
        GlobalVariables, ImportedEntities, Macros, DWOId, SplitDebugInlining,
@@ -1431,7 +1442,7 @@ public:
        Metadata *ImportedEntities, Metadata *Macros, uint64_t DWOId,
        bool SplitDebugInlining, bool DebugInfoForProfiling,
        unsigned NameTableKind, bool RangesBaseAddress, MDString *SysRoot,
-       MDString *SDK, bool CasFriendliness),
+       MDString *SDK, unsigned CasFriendliness),
       (SourceLanguage, File, Producer, IsOptimized, Flags, RuntimeVersion,
        SplitDebugFilename, EmissionKind, EnumTypes, RetainedTypes,
        GlobalVariables, ImportedEntities, Macros, DWOId, SplitDebugInlining,
@@ -1446,7 +1457,9 @@ public:
   DebugEmissionKind getEmissionKind() const {
     return (DebugEmissionKind)EmissionKind;
   }
-  bool isCasFriendly() const { return CasFriendliness; }
+  CasFriendlinessKind getCasFriendlinessKind() const {
+    return (CasFriendlinessKind)CasFriendliness;
+  }
   bool isDebugDirectivesOnly() const {
     return EmissionKind == DebugDirectivesOnly;
   }

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -911,6 +911,12 @@ lltok::Kind LLLexer::LexIdentifier() {
     return lltok::EmissionKind;
   }
 
+  if (Keyword == "NoCasFriendlyDebugInfo" || Keyword == "DebugLineOnly" ||
+      Keyword == "DebugAbbrev") {
+    StrVal.assign(Keyword.begin(), Keyword.end());
+    return lltok::CasFriendlinessKind;
+  }
+
   if (Keyword == "GNU" || Keyword == "None" || Keyword == "Default") {
     StrVal.assign(Keyword.begin(), Keyword.end());
     return lltok::NameTableKind;

--- a/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
+++ b/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
@@ -1639,7 +1639,7 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
         Record.size() <= 19 ? false : Record[19],
         Record.size() <= 20 ? nullptr : getMDString(Record[20]),
         Record.size() <= 21 ? nullptr : getMDString(Record[21]),
-        Record.size() <= 22 ? false : Record[22]);
+        Record.size() <= 22 ? 0 : Record[22]);
 
     MetadataList.assignValue(CU, NextMetadataNo);
     NextMetadataNo++;

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -1812,7 +1812,7 @@ void ModuleBitcodeWriter::writeDICompileUnit(const DICompileUnit *N,
   Record.push_back(N->getRangesBaseAddress());
   Record.push_back(VE.getMetadataOrNullID(N->getRawSysRoot()));
   Record.push_back(VE.getMetadataOrNullID(N->getRawSDK()));
-  Record.push_back(N->isCasFriendly());
+  Record.push_back(N->getCasFriendlinessKind());
 
   Stream.EmitRecord(bitc::METADATA_COMPILE_UNIT, Record, Abbrev);
   Record.clear();

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -2155,7 +2155,8 @@ void DwarfDebug::beginFunctionImpl(const MachineFunction *MF) {
   // entry. That is, every function gets its own line table header. To achieve
   // this we are creating a new CompileUnit per function so each function can
   // get it's own line table header
-  if (SP->getUnit()->isCasFriendly()) {
+  if (SP->getUnit()->getCasFriendlinessKind() !=
+      DICompileUnit::NoCasFriendlyDebugInfo) {
     const Module *M = MF->getFunction().getParent();
     DIBuilder DIB(*const_cast<Module *>(M));
     DICompileUnit *DCU = SP->getUnit();
@@ -2163,7 +2164,8 @@ void DwarfDebug::beginFunctionImpl(const MachineFunction *MF) {
         DCU->getSourceLanguage(), DCU->getFile(), DCU->getProducer(),
         DCU->isOptimized(), DCU->getFlags(), DCU->getRuntimeVersion(), {},
         DICompileUnit::DebugEmissionKind::FullDebug, 0, true, false,
-        DICompileUnit::DebugNameTableKind::Default, false, {}, {}, true);
+        DICompileUnit::DebugNameTableKind::Default, false, {}, {},
+        DCU->getCasFriendlinessKind());
 
     this->SingleCU = false;
     DwarfCompileUnit &CU = getOrCreateDwarfCompileUnit(NewDCU);

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfFile.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfFile.cpp
@@ -95,7 +95,9 @@ void DwarfFile::computeSizeAndOffsets() {
     // An initial Abbreviation contribution is pushed back when the DwarfFile is
     // created because there are cases where the compile units are emitted
     // without computing size and offsets for each DIE.
-    if (Abbrevs.size() != CUs.size() && TheU->getCUNode()->isCasFriendly()) {
+    if (Abbrevs.size() != CUs.size() &&
+        TheU->getCUNode()->getCasFriendlinessKind() ==
+            DICompileUnit::DebugAbbrev) {
       Abbrevs.emplace_back(std::make_unique<DIEAbbrevSet>(AbbrevAllocator));
     }
   }

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -1677,6 +1677,9 @@ struct MDFieldPrinter {
   void printDwarfEnum(StringRef Name, IntTy Value, Stringifier toString,
                       bool ShouldSkipZero = true);
   void printEmissionKind(StringRef Name, DICompileUnit::DebugEmissionKind EK);
+  void printCasFriendlinessKind(
+      StringRef Name, DICompileUnit::CasFriendlinessKind EK,
+      Optional<DICompileUnit::CasFriendlinessKind> Default = None);
   void printNameTableKind(StringRef Name,
                           DICompileUnit::DebugNameTableKind NTK);
 };
@@ -1806,6 +1809,14 @@ void MDFieldPrinter::printDISPFlags(StringRef Name,
 void MDFieldPrinter::printEmissionKind(StringRef Name,
                                        DICompileUnit::DebugEmissionKind EK) {
   Out << FS << Name << ": " << DICompileUnit::emissionKindString(EK);
+}
+
+void MDFieldPrinter::printCasFriendlinessKind(
+    StringRef Name, DICompileUnit::CasFriendlinessKind EK,
+    Optional<DICompileUnit::CasFriendlinessKind> Default) {
+  if (Default && *Default == EK)
+    return;
+  Out << FS << Name << ": " << DICompileUnit::casFriendlinessString(EK);
 }
 
 void MDFieldPrinter::printNameTableKind(StringRef Name,
@@ -2107,7 +2118,8 @@ static void writeDICompileUnit(raw_ostream &Out, const DICompileUnit *N,
   Printer.printBool("rangesBaseAddress", N->getRangesBaseAddress(), false);
   Printer.printString("sysroot", N->getSysRoot());
   Printer.printString("sdk", N->getSDK());
-  Printer.printBool("casFriendly", N->isCasFriendly(), false);
+  Printer.printCasFriendlinessKind("casFriendly", N->getCasFriendlinessKind(),
+                                   DICompileUnit::NoCasFriendlyDebugInfo);
   Out << ")";
 }
 

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -152,7 +152,8 @@ DICompileUnit *DIBuilder::createCompileUnit(
     DICompileUnit::DebugEmissionKind Kind, uint64_t DWOId,
     bool SplitDebugInlining, bool DebugInfoForProfiling,
     DICompileUnit::DebugNameTableKind NameTableKind, bool RangesBaseAddress,
-    StringRef SysRoot, StringRef SDK, bool CasFriendliness) {
+    StringRef SysRoot, StringRef SDK,
+    DICompileUnit::CasFriendlinessKind CasFriendliness) {
 
   assert(((Lang <= dwarf::DW_LANG_Fortran08 && Lang >= dwarf::DW_LANG_C89) ||
           (Lang <= dwarf::DW_LANG_hi_user && Lang >= dwarf::DW_LANG_lo_user)) &&

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -610,7 +610,7 @@ private:
         CU->getDWOId(), CU->getSplitDebugInlining(),
         CU->getDebugInfoForProfiling(), CU->getNameTableKind(),
         CU->getRangesBaseAddress(), CU->getSysRoot(), CU->getSDK(),
-        CU->isCasFriendly());
+        CU->getCasFriendlinessKind());
   }
 
   DILocation *getReplacementMDLocation(DILocation *MLD) {
@@ -930,7 +930,9 @@ LLVMMetadataRef LLVMDIBuilderCreateCompileUnit(
       static_cast<DICompileUnit::DebugEmissionKind>(Kind), DWOId,
       SplitDebugInlining, DebugInfoForProfiling,
       DICompileUnit::DebugNameTableKind::Default, false,
-      StringRef(SysRoot, SysRootLen), StringRef(SDK, SDKLen), false));
+      StringRef(SysRoot, SysRootLen), StringRef(SDK, SDKLen),
+      /*NoCasFriendlyDebugInfo*/
+      static_cast<DICompileUnit::CasFriendlinessKind>(0)));
 }
 
 LLVMMetadataRef

--- a/llvm/lib/IR/DebugInfoMetadata.cpp
+++ b/llvm/lib/IR/DebugInfoMetadata.cpp
@@ -816,7 +816,7 @@ DICompileUnit::DICompileUnit(LLVMContext &C, StorageType Storage,
                              uint64_t DWOId, bool SplitDebugInlining,
                              bool DebugInfoForProfiling, unsigned NameTableKind,
                              bool RangesBaseAddress, ArrayRef<Metadata *> Ops,
-                             bool CasFriendliness)
+                             unsigned CasFriendliness)
     : DIScope(C, DICompileUnitKind, Storage, dwarf::DW_TAG_compile_unit, Ops),
       SourceLanguage(SourceLanguage), IsOptimized(IsOptimized),
       RuntimeVersion(RuntimeVersion), EmissionKind(EmissionKind), DWOId(DWOId),
@@ -835,7 +835,8 @@ DICompileUnit *DICompileUnit::getImpl(
     Metadata *GlobalVariables, Metadata *ImportedEntities, Metadata *Macros,
     uint64_t DWOId, bool SplitDebugInlining, bool DebugInfoForProfiling,
     unsigned NameTableKind, bool RangesBaseAddress, MDString *SysRoot,
-    MDString *SDK, bool CasFriendliness, StorageType Storage, bool ShouldCreate) {
+    MDString *SDK, unsigned CasFriendliness, StorageType Storage,
+    bool ShouldCreate) {
   assert(Storage != Uniqued && "Cannot unique DICompileUnit");
   assert(isCanonical(Producer) && "Expected canonical MDString");
   assert(isCanonical(Flags) && "Expected canonical MDString");
@@ -870,6 +871,15 @@ DICompileUnit::getEmissionKind(StringRef Str) {
       .Default(None);
 }
 
+Optional<DICompileUnit::CasFriendlinessKind>
+DICompileUnit::getCasFriendlinessKind(StringRef Str) {
+  return StringSwitch<Optional<CasFriendlinessKind>>(Str)
+      .Case("NoCasFriendlyDebugInfo", NoCasFriendlyDebugInfo)
+      .Case("DebugLineOnly", DebugLineOnly)
+      .Case("DebugAbbrev", DebugAbbrev)
+      .Default(None);
+}
+
 Optional<DICompileUnit::DebugNameTableKind>
 DICompileUnit::getNameTableKind(StringRef Str) {
   return StringSwitch<Optional<DebugNameTableKind>>(Str)
@@ -889,6 +899,18 @@ const char *DICompileUnit::emissionKindString(DebugEmissionKind EK) {
     return "LineTablesOnly";
   case DebugDirectivesOnly:
     return "DebugDirectivesOnly";
+  }
+  return nullptr;
+}
+
+const char *DICompileUnit::casFriendlinessString(CasFriendlinessKind CFK) {
+  switch (CFK) {
+  case NoCasFriendlyDebugInfo:
+    return "NoCasFriendlyDebugInfo";
+  case DebugLineOnly:
+    return "DebugLineOnly";
+  case DebugAbbrev:
+    return "DebugAbbrev";
   }
   return nullptr;
 }

--- a/llvm/test/Assembler/dicompileunit.ll
+++ b/llvm/test/Assembler/dicompileunit.ll
@@ -16,25 +16,25 @@
 !6 = distinct !{}
 !7 = distinct !{}
 
-; CHECK: !8 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, flags: "-O2", runtimeVersion: 2, splitDebugFilename: "abc.debug", emissionKind: FullDebug, enums: !2, retainedTypes: !3, globals: !5, imports: !6, macros: !7, dwoId: 42, rangesBaseAddress: true, sysroot: "/", casFriendly: true)
+; CHECK: !8 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, flags: "-O2", runtimeVersion: 2, splitDebugFilename: "abc.debug", emissionKind: FullDebug, enums: !2, retainedTypes: !3, globals: !5, imports: !6, macros: !7, dwoId: 42, rangesBaseAddress: true, sysroot: "/", casFriendly: DebugLineOnly)
 !8 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang",
                              isOptimized: true, flags: "-O2", runtimeVersion: 2,
                              splitDebugFilename: "abc.debug",
                              emissionKind: FullDebug,
                              enums: !2, retainedTypes: !3,
                              globals: !5, imports: !6, macros: !7, dwoId: 42,
-                             splitDebugInlining: true, rangesBaseAddress: true, sysroot: "/", casFriendly: true)
+                             splitDebugInlining: true, rangesBaseAddress: true, sysroot: "/", casFriendly: DebugLineOnly)
 
 ; CHECK: !9 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, isOptimized: false, runtimeVersion: 0, emissionKind: NoDebug)
 !9 = distinct !DICompileUnit(language: 12, file: !1, producer: "",
                              isOptimized: false, flags: "", runtimeVersion: 0,
                              splitDebugFilename: "", emissionKind: NoDebug)
 
-; CHECK: !10 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, flags: "-O2", runtimeVersion: 2, splitDebugFilename: "abc.debug", emissionKind: LineTablesOnly, splitDebugInlining: false)
+; CHECK: !10 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, flags: "-O2", runtimeVersion: 2, splitDebugFilename: "abc.debug", emissionKind: LineTablesOnly, splitDebugInlining: false, casFriendly: DebugAbbrev)
 !10 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang",
                              isOptimized: true, flags: "-O2", runtimeVersion: 2,
                              splitDebugFilename: "abc.debug",
-                             emissionKind: LineTablesOnly, splitDebugInlining: false)
+                             emissionKind: LineTablesOnly, splitDebugInlining: false, casFriendly: DebugAbbrev)
 
 !llvm.module.flags = !{!11}
 !11 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/DebugInfo/X86/cas-friendly.ll
+++ b/llvm/test/DebugInfo/X86/cas-friendly.ll
@@ -90,7 +90,7 @@ attributes #1 = { nofree nosync nounwind readnone speculatable willreturn }
 !llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
 !llvm.ident = !{!8}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 14.0.0 (git@github.com:apple/llvm-project.git 24e049152a8c2239a157a36f6a4d065e7a1b183b)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: true)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 14.0.0 (git@github.com:apple/llvm-project.git 24e049152a8c2239a157a36f6a4d065e7a1b183b)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
 !1 = !DIFile(filename: "test.c", directory: "/Users/shubham/Development/testClangDebugInfo")
 !2 = !{i32 7, !"Dwarf Version", i32 4}
 !3 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/DebugInfo/X86/debug-abbrev-split.ll
+++ b/llvm/test/DebugInfo/X86/debug-abbrev-split.ll
@@ -66,7 +66,7 @@ attributes #2 = { nocallback nofree nosync nounwind readnone speculatable willre
 !llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8, !9, !10, !11}
 !llvm.ident = !{!12}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 15.0.0 (git@github.com:apple/llvm-project.git a9613e5bc4afee75335dfc5fbb92954264c04e85)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: true)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 15.0.0 (git@github.com:apple/llvm-project.git a9613e5bc4afee75335dfc5fbb92954264c04e85)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugAbbrev)
 !1 = !DIFile(filename: "a.cpp", directory: "/Users/shubhamrastogi/Development/testCASDeDupe")
 !2 = !{i32 7, !"Dwarf Version", i32 4}
 !3 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/tools/llvm-cas-object-format/Inputs/debug_line_split.ll
+++ b/llvm/test/tools/llvm-cas-object-format/Inputs/debug_line_split.ll
@@ -54,7 +54,7 @@ attributes #1 = { nofree nosync nounwind readnone speculatable willreturn }
 !llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
 !llvm.ident = !{!8}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 15.0.0 (git@github.com:apple/llvm-project.git d70b109980a620c1041801e0eef829da0ea7aef6)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: true)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 15.0.0 (git@github.com:apple/llvm-project.git d70b109980a620c1041801e0eef829da0ea7aef6)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
 !1 = !DIFile(filename: "test.c", directory: "/Users/shubham/Development/testCASSymbols")
 !2 = !{i32 7, !"Dwarf Version", i32 4}
 !3 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/tools/llvm-cas-object-format/different_functions_same_header_dedupe.test
+++ b/llvm/test/tools/llvm-cas-object-format/different_functions_same_header_dedupe.test
@@ -3,8 +3,8 @@
 RUN: rm -rf %t && mkdir -p %t
 RUN: split-file %s %t
 
-RUN: clang %t/temp_a.cpp -c -g -fcas-friendly-debug-info --target=x86_64-apple-darwin21.1.0 -o %t/temp_a.o
-RUN: clang %t/temp_b.cpp -c -g -fcas-friendly-debug-info --target=x86_64-apple-darwin21.1.0 -o %t/temp_b.o
+RUN: clang %t/temp_a.cpp -c -g -fcas-friendly-debug-info=debug-line-only --target=x86_64-apple-darwin21.1.0 -o %t/temp_a.o
+RUN: clang %t/temp_b.cpp -c -g -fcas-friendly-debug-info=debug-line-only --target=x86_64-apple-darwin21.1.0 -o %t/temp_b.o
 RUN: find %t -name "*.o" &> %t/objects_to_ingest
 RUN: llvm-cas-object-format --cas %t/cas --ingest-schema=nestedv1 @%t/objects_to_ingest -silent > %t/output.casid
 RUN: llvm-cas-object-format --cas %t/cas --ingest-schema=nestedv1 --print-cas-tree @%t/output.casid | FileCheck %s --check-prefix NESTED

--- a/llvm/test/tools/llvm-cas-object-format/different_line_numbers_same_function_dedupe.test
+++ b/llvm/test/tools/llvm-cas-object-format/different_line_numbers_same_function_dedupe.test
@@ -3,8 +3,8 @@
 RUN: rm -rf %t && mkdir -p %t
 RUN: split-file %s %t
 
-RUN: clang %t/temp_a.cpp -c -g -fcas-friendly-debug-info --target=x86_64-apple-darwin21.1.0 -o %t/temp_a.o
-RUN: clang %t/temp_b.cpp -c -g -fcas-friendly-debug-info --target=x86_64-apple-darwin21.1.0 -o %t/temp_b.o
+RUN: clang %t/temp_a.cpp -c -g -fcas-friendly-debug-info=debug-line-only --target=x86_64-apple-darwin21.1.0 -o %t/temp_a.o
+RUN: clang %t/temp_b.cpp -c -g -fcas-friendly-debug-info=debug-line-only --target=x86_64-apple-darwin21.1.0 -o %t/temp_b.o
 RUN: find %t -name "*.o" &> %t/objects_to_ingest
 RUN: llvm-cas-object-format --cas %t/cas --ingest-schema=nestedv1 @%t/objects_to_ingest -silent > %t/output.casid
 RUN: llvm-cas-object-format --cas %t/cas --ingest-schema=nestedv1 --print-cas-tree @%t/output.casid | FileCheck %s --check-prefix NESTED

--- a/llvm/test/tools/llvm-cas-object-format/same_functions_same_header_dedupe.test
+++ b/llvm/test/tools/llvm-cas-object-format/same_functions_same_header_dedupe.test
@@ -3,8 +3,8 @@
 RUN: rm -rf %t && mkdir -p %t
 RUN: split-file %s %t
 
-RUN: clang %t/temp_a.cpp -c -g -fcas-friendly-debug-info --target=x86_64-apple-darwin21.1.0 -o %t/temp_a.o
-RUN: clang %t/temp_b.cpp -c -g -fcas-friendly-debug-info --target=x86_64-apple-darwin21.1.0 -o %t/temp_b.o
+RUN: clang %t/temp_a.cpp -c -g -fcas-friendly-debug-info=debug-line-only --target=x86_64-apple-darwin21.1.0 -o %t/temp_a.o
+RUN: clang %t/temp_b.cpp -c -g -fcas-friendly-debug-info=debug-line-only --target=x86_64-apple-darwin21.1.0 -o %t/temp_b.o
 RUN: find %t -name "*.o" &> %t/objects_to_ingest
 RUN: llvm-cas-object-format --cas %t/cas --ingest-schema=nestedv1 @%t/objects_to_ingest -silent > %t/output.casid
 RUN: llvm-cas-object-format --cas %t/cas --ingest-schema=nestedv1 --print-cas-tree @%t/output.casid | FileCheck %s --check-prefix NESTED

--- a/llvm/unittests/IR/MetadataTest.cpp
+++ b/llvm/unittests/IR/MetadataTest.cpp
@@ -97,7 +97,8 @@ protected:
         Context, 1, getFile(), "clang", false, "-g", 2, "",
         DICompileUnit::FullDebug, getTuple(), getTuple(), getTuple(),
         getTuple(), getTuple(), 0, true, false,
-        DICompileUnit::DebugNameTableKind::Default, false, "/", "", false);
+        DICompileUnit::DebugNameTableKind::Default, false, "/", "",
+        DICompileUnit::NoCasFriendlyDebugInfo);
   }
   DIType *getBasicType(StringRef Name) {
     return DIBasicType::get(Context, dwarf::DW_TAG_unspecified_type, Name);
@@ -2177,13 +2178,13 @@ TEST_F(DICompileUnitTest, get) {
   MDTuple *Macros = getTuple();
   StringRef SysRoot = "/";
   StringRef SDK = "MacOSX.sdk";
-    bool CasFriendly = true;
+  auto CasFriendlinessKind = DICompileUnit::NoCasFriendlyDebugInfo;
   auto *N = DICompileUnit::getDistinct(
       Context, SourceLanguage, File, Producer, IsOptimized, Flags,
       RuntimeVersion, SplitDebugFilename, EmissionKind, EnumTypes,
       RetainedTypes, GlobalVariables, ImportedEntities, Macros, DWOId, true,
       false, DICompileUnit::DebugNameTableKind::Default, false, SysRoot, SDK,
-      CasFriendly);
+      CasFriendlinessKind);
 
   EXPECT_EQ(dwarf::DW_TAG_compile_unit, N->getTag());
   EXPECT_EQ(SourceLanguage, N->getSourceLanguage());
@@ -2202,7 +2203,7 @@ TEST_F(DICompileUnitTest, get) {
   EXPECT_EQ(DWOId, N->getDWOId());
   EXPECT_EQ(SysRoot, N->getSysRoot());
   EXPECT_EQ(SDK, N->getSDK());
-  EXPECT_EQ(CasFriendly, N->isCasFriendly());
+  EXPECT_EQ(CasFriendlinessKind, N->getCasFriendlinessKind());
 
   TempDICompileUnit Temp = N->clone();
   EXPECT_EQ(dwarf::DW_TAG_compile_unit, Temp->getTag());
@@ -2221,7 +2222,7 @@ TEST_F(DICompileUnitTest, get) {
   EXPECT_EQ(Macros, Temp->getMacros().get());
   EXPECT_EQ(SysRoot, Temp->getSysRoot());
   EXPECT_EQ(SDK, Temp->getSDK());
-  EXPECT_EQ(CasFriendly, Temp->isCasFriendly());
+  EXPECT_EQ(CasFriendlinessKind, Temp->getCasFriendlinessKind());
 
   auto *TempAddress = Temp.get();
   auto *Clone = MDNode::replaceWithPermanent(std::move(Temp));
@@ -2244,11 +2245,13 @@ TEST_F(DICompileUnitTest, replaceArrays) {
   uint64_t DWOId = 0xc0ffee;
   StringRef SysRoot = "/";
   StringRef SDK = "MacOSX.sdk";
+  auto CasFriendlinessKind = DICompileUnit::NoCasFriendlyDebugInfo;
   auto *N = DICompileUnit::getDistinct(
       Context, SourceLanguage, File, Producer, IsOptimized, Flags,
       RuntimeVersion, SplitDebugFilename, EmissionKind, EnumTypes,
       RetainedTypes, nullptr, ImportedEntities, nullptr, DWOId, true, false,
-      DICompileUnit::DebugNameTableKind::Default, false, SysRoot, SDK, false);
+      DICompileUnit::DebugNameTableKind::Default, false, SysRoot, SDK,
+      CasFriendlinessKind);
 
   auto *GlobalVariables = MDTuple::getDistinct(Context, None);
   EXPECT_EQ(nullptr, N->getGlobalVariables().get());


### PR DESCRIPTION
With https://github.com/apple/llvm-project/pull/4266 a new bool flag was added to DICompileUnit to control whether the debug info emitted should be cas friendly or not i.e. whether llvm should split up the debug info to make it more dedup-able for the cas. 

We quickly realized that we may need more fine-grained control onver what parts of the debug info we split up and what debug info we keep intact.

This patch addresses that