### PR TITLE
Add tapi to CMake Configs

### DIFF
--- a/clang/tools/CMakeLists.txt
+++ b/clang/tools/CMakeLists.txt
@@ -50,6 +50,9 @@ endif()
 # It also may be included by LLVM_EXTERNAL_CLANG_TOOLS_EXTRA_SOURCE_DIR.
 add_llvm_external_project(clang-tools-extra extra)
 
+# add tapi.
+add_llvm_external_project(tapi)
+
 # libclang may require clang-tidy in clang-tools-extra.
 add_clang_subdirectory(libclang)
 

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -85,6 +85,10 @@ endif()
 # This allows an easy way of setting up a build directory for llvm and another
 # one for llvm+clang+... using the same sources.
 set(LLVM_ALL_PROJECTS "bolt;clang;clang-tools-extra;compiler-rt;cross-project-tests;libc;libclc;libcxx;libcxxabi;libunwind;lld;lldb;mlir;openmp;polly;pstl")
+
+# Add tapi to the list of llvm projects.
+set(LLVM_ALL_PROJECTS "${LLVM_ALL_PROJECTS};tapi")
+
 # The flang project is not yet part of "all" projects (see C++ requirements)
 set(LLVM_EXTRA_PROJECTS "flang")
 # List of all known projects in the mono repo


### PR DESCRIPTION
For external developers to build tapi against the apple fork of LLVM,
we need cmake to be aware of tapi when it is under the llvm directory
structure. Tapi's open source drop can be found in: https://github.com/apple-oss-distributions/tapi