### PR TITLE
Add tapi to CMake Configs

### DIFF
--- a/clang/tools/CMakeLists.txt
+++ b/clang/tools/CMakeLists.txt
@@ -42,6 +42,9 @@ endif()
 # It also may be included by LLVM_EXTERNAL_CLANG_TOOLS_EXTRA_SOURCE_DIR.
 add_llvm_external_project(clang-tools-extra extra)
 
+# add tapi.
+add_llvm_external_project(tapi)
+
 # libclang may require clang-tidy in clang-tools-extra.
 add_clang_subdirectory(libclang)
 

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -76,6 +76,10 @@ endif()
 # This allows an easy way of setting up a build directory for llvm and another
 # one for llvm+clang+... using the same sources.
 set(LLVM_ALL_PROJECTS "clang;clang-tools-extra;compiler-rt;debuginfo-tests;libc;libclc;libcxx;libcxxabi;libunwind;lld;lldb;mlir;openmp;parallel-libs;polly;pstl")
+
+# Add tapi to the list of llvm projects.
+set(LLVM_ALL_PROJECTS "${LLVM_ALL_PROJECTS};tapi")
+
 # The flang project is not yet part of "all" projects (see C++ requirements)
 set(LLVM_EXTRA_PROJECTS "flang")
 # List of all known projects in the mono repo


### PR DESCRIPTION
For external developers to build tapi against the apple fork of LLVM,
we need cmake to be aware of tapi when it is under the llvm directory
structure. Tapi's open source drop can be found in: https://github.com/apple-oss-distributions/tapi

(cherry picked from commit 1b59cf80f71f35e1df22de5c3d6a29c0bd8028ab)