### PR TITLE
[lldb] Look through existential types when handling typealiases in SwiftASTContext to correctly handle `AnyObject` existentials.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5247,6 +5247,13 @@ bool SwiftASTContext::IsTypedefType(opaque_compiler_type_t type) {
   if (!type)
     return false;
   swift::Type swift_type(GetSwiftType(type));
+
+  swift::ExistentialType *existential_type  =
+      swift::dyn_cast<swift::ExistentialType>(swift_type.getPointer());
+  if (existential_type) {
+    swift_type = existential_type->getConstraintType();
+  }
+
   return swift::isa<swift::TypeAliasType>(swift_type.getPointer());
 }
 
@@ -5881,6 +5888,13 @@ CompilerType SwiftASTContext::GetTypedefedType(opaque_compiler_type_t type) {
   VALID_OR_RETURN_CHECK_TYPE(type, CompilerType());
 
   swift::Type swift_type(GetSwiftType({this, type}));
+
+  swift::ExistentialType *existential_type  =
+      swift::dyn_cast<swift::ExistentialType>(swift_type.getPointer());
+  if (existential_type) {
+    swift_type = existential_type->getConstraintType();
+  }
+
   swift::TypeAliasType *name_alias_type =
       swift::dyn_cast<swift::TypeAliasType>(swift_type.getPointer());
   if (name_alias_type) {

--- a/lldb/test/Shell/SwiftREPL/DeferredNSArray.test
+++ b/lldb/test/Shell/SwiftREPL/DeferredNSArray.test
@@ -6,7 +6,17 @@
 
 import Foundation
 let patatino = [1,2,3,4] as AnyObject
-// CHECK: patatino: __SwiftDeferredNSArray = 4 values {
+// CHECK: patatino: AnyObject = {
+// CHECK-NEXT: object = 4 values {
+// CHECK-NEXT:  [0] = 1
+// CHECK-NEXT:  [1] = 2
+// CHECK-NEXT:  [2] = 3
+// CHECK-NEXT:  [3] = 4
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+let deferred = [1,2,3,4] as Array as NSArray
+// CHECK: deferred: __SwiftDeferredNSArray = 4 values {
 // CHECK-NEXT:  [0] = 1
 // CHECK-NEXT:  [1] = 2
 // CHECK-NEXT:  [2] = 3


### PR DESCRIPTION
https://github.com/apple/swift/pull/41909 updates the representation of `Any` and `AnyObject` in the Swift frontend to use `ExistentialType`. Typealiases like `AnyObject` can be used as existential types, which are represented as `ExistentialType(TypeAliasType)`, so LLDB should look through to an existential type's constraint when checking whether it has a typealias.