### PR TITLE
Make test more reliable and easier to debug.

### DIFF
--- a/lldb/test/API/lang/swift/variables/move_function_async/main.swift
+++ b/lldb/test/API/lang/swift/variables/move_function_async/main.swift
@@ -21,26 +21,26 @@ public func forceSplit() async {}
 //////////////////
 
 public func copyableValueTest() async {
-    print("stop here") // Set breakpoint
+    print("stop here") // Set breakpoint 00
     let k = Klass()
     k.doSomething()
-    await forceSplit() // Set breakpoint
-    let m = _move(k) // Set breakpoint
-    m.doSomething() // Set breakpoint
+    await forceSplit() // Set breakpoint 01
+    let m = _move(k)   // Set breakpoint 02
+    m.doSomething()    // Set breakpoint 03
     await forceSplit()
-    m.doSomething() // Set breakpoint
+    m.doSomething()    // Set breakpoint 04
 }
 
 public func copyableVarTest() async {
     print("stop here")
-    var k = Klass() // Special breakpoint
+    var k = Klass()    // Set breakpoint 05
     k.doSomething()
-    await forceSplit() // Set breakpoint
-    let m = _move(k) // Set breakpoint
-    m.doSomething() // Set breakpoint
+    await forceSplit() // Set breakpoint 06
+    let m = _move(k)   // Set breakpoint 07
+    m.doSomething()    // Set breakpoint 08
     await forceSplit()
-    k = Klass() // Set breakpoint
-    k.doSomething() // Set breakpoint
+    k = Klass()        // Set breakpoint 09
+    k.doSomething()    // Set breakpoint 10
     print("stop here")
 }
 


### PR DESCRIPTION
The many process.Continue() calls in this test make it hard to keep
track where in the program we are when debugging the test. This patch
makes it so we explicitly continue to the requested breakpoint.