### PR TITLE
CommandObjectRegexCommand shouldn't put two commands on the history s…

### DIFF
--- a/lldb/source/Commands/CommandObjectRegexCommand.cpp
+++ b/lldb/source/Commands/CommandObjectRegexCommand.cpp
@@ -71,11 +71,10 @@ bool CommandObjectRegexCommand::DoExecute(llvm::StringRef command,
       // Interpret the new command and return this as the result!
       if (m_interpreter.GetExpandRegexAliases())
         result.GetOutputStream().Printf("%s\n", new_command->c_str());
-      // Pass in true for "no context switching".  The command that called us
-      // should have set up the context appropriately, we shouldn't have to
-      // redo that.
+      // We don't have to pass an override_context here, as the command that 
+      // called us should have set up the context appropriately.
       return m_interpreter.HandleCommand(new_command->c_str(),
-                                         eLazyBoolCalculate, result);
+                                         eLazyBoolNo, result);
     }
   }
   result.SetStatus(eReturnStatusFailed);

--- a/lldb/test/API/functionalities/history/TestHistoryRecall.py
+++ b/lldb/test/API/functionalities/history/TestHistoryRecall.py
@@ -1,5 +1,5 @@
 """
-Make sure the !N and !-N commands work properly.
+Test some features of "session history" and history recall.
 """
 
 
@@ -20,9 +20,25 @@ class TestHistoryRecall(TestBase):
 
     def test_history_recall(self):
         """Test the !N and !-N functionality of the command interpreter."""
-        self.sample_test()
+        self.do_bang_N_test()
 
-    def sample_test(self):
+    def test_regex_history(self):
+        """Test the regex commands don't add two elements to the history"""
+        self.do_regex_history_test()
+
+    def do_regex_history_test(self):
+        interp = self.dbg.GetCommandInterpreter()
+        result = lldb.SBCommandReturnObject()
+        command = "_regexp-break foo.c:12"
+        self.runCmd(command, msg="Run the regex break command", inHistory = True)
+        interp.HandleCommand("session history", result, True)
+        self.assertTrue(result.Succeeded(), "session history ran successfully")
+        results = result.GetOutput()
+        self.assertIn(command, results, "Recorded the actual command")
+        self.assertNotIn("breakpoint set --file 'foo.c' --line 12", results,
+                         "Didn't record the resolved command")
+        
+    def do_bang_N_test(self):
         interp = self.dbg.GetCommandInterpreter()
         result = lldb.SBCommandReturnObject()
         interp.HandleCommand("session history", result, True)


### PR DESCRIPTION
…tack.

It was putting the command the user typed, and then the resolved command in the
command history.  That caused up-arrow not to work correctly when the regex command
was invoked from a Python-command.  Plus it's just weird.

Differential Revision: https://reviews.llvm.org/D126789

(cherry picked from commit 8cc8b36f24d6f3133c44e238a657309620eedc19)