### PR TITLE
[lldb/swift] Fix ASAN heap-buffer overlow when loading modules

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3412,7 +3412,7 @@ bool SwiftASTContext::ReportModuleLoadingProgress(llvm::StringRef module_name,
                                                   bool is_overlay) {
   Progress progress(llvm::formatv(is_overlay ? "Importing overlay module {0}"
                                              : "Importing module {0}",
-                                  module_name.data())
+                                  module_name)
                         .str());
   return true;
 }


### PR DESCRIPTION
This patch should fix an ASAN failure when reporting swift module
loading. This was passing the module name to a format function as a
CString instead of passing the whole StringRef. That CString was
probably not null-terminated causing the buffer overflow.

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>