### PR TITLE
[5.7][lldb] Look through existential types when handling typealiases in SwiftASTContext to correctly handle `AnyObject` existentials.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5247,6 +5247,13 @@ bool SwiftASTContext::IsTypedefType(opaque_compiler_type_t type) {
   if (!type)
     return false;
   swift::Type swift_type(GetSwiftType(type));
+
+  swift::ExistentialType *existential_type  =
+      swift::dyn_cast<swift::ExistentialType>(swift_type.getPointer());
+  if (existential_type) {
+    swift_type = existential_type->getConstraintType();
+  }
+
   return swift::isa<swift::TypeAliasType>(swift_type.getPointer());
 }
 
@@ -5881,6 +5888,13 @@ CompilerType SwiftASTContext::GetTypedefedType(opaque_compiler_type_t type) {
   VALID_OR_RETURN_CHECK_TYPE(type, CompilerType());
 
   swift::Type swift_type(GetSwiftType({this, type}));
+
+  swift::ExistentialType *existential_type  =
+      swift::dyn_cast<swift::ExistentialType>(swift_type.getPointer());
+  if (existential_type) {
+    swift_type = existential_type->getConstraintType();
+  }
+
   swift::TypeAliasType *name_alias_type =
       swift::dyn_cast<swift::TypeAliasType>(swift_type.getPointer());
   if (name_alias_type) {


### PR DESCRIPTION
This is https://github.com/apple/llvm-project/pull/4852, against the right branch this time 🙂

https://github.com/apple/swift/pull/59657 updates the representation of Any and AnyObject in the Swift frontend to use `ExistentialType`. Typealiases like `AnyObject` can be used as existential types, which are represented as `ExistentialType(TypeAliasType)`, so LLDB should look through to an existential type's constraint when checking whether it has a typealias.

