### PR TITLE
[rebranch][lld] Add SmallVector include to InputFiles.h

### DIFF
--- a/lld/ELF/InputFiles.h
+++ b/lld/ELF/InputFiles.h
@@ -15,6 +15,7 @@
 #include "lld/Common/LLVM.h"
 #include "lld/Common/Reproduce.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/BinaryFormat/Magic.h"
 #include "llvm/Object/ELF.h"
 #include "llvm/Support/MemoryBufferRef.h"


### PR DESCRIPTION
The most recent compiler on CentOS 7 has a bug that does not properly
merge default template arguments, which causes uses of `SmallVector`
without an explicit stack size to fail to compile when using the forward
declaration from `LLVM.h`.

We could either give the use a default size, or just include SmallVector
in the header. Do the latter for now since that's a single change verses
the two we'd have to make if giving an explicit initial size.