### PR TITLE
Turn Skip into XFail.

### DIFF
--- a/lldb/test/API/lang/swift/protocol_extension_computed_property/TestProtocolExtensionComputerProperty.py
+++ b/lldb/test/API/lang/swift/protocol_extension_computed_property/TestProtocolExtensionComputerProperty.py
@@ -5,6 +5,6 @@ lldbinline.MakeInlineTest(
     __file__, globals(),
         decorators=[
             swiftTest,skipUnlessDarwin,
-            skipIf(bugnumber="rdar://60396797", # should work but crashes.
+            expectedFailureAll(bugnumber="rdar://60396797",
                    setting=('symbols.use-swift-clangimporter', 'false'))
     ])


### PR DESCRIPTION
This test no longer crashes, but still doesn't work.