### PR TITLE
[Sema] Check whether `__auto_type` has been deduced before merging

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -10310,11 +10310,11 @@ QualType ASTContext::mergeTypes(QualType LHS, QualType RHS,
     // Allow __auto_type to match anything; it merges to the type with more
     // information.
     if (const auto *AT = LHS->getAs<AutoType>()) {
-      if (AT->isGNUAutoType())
+      if (!AT->isDeduced() && AT->isGNUAutoType())
         return RHS;
     }
     if (const auto *AT = RHS->getAs<AutoType>()) {
-      if (AT->isGNUAutoType())
+      if (!AT->isDeduced() && AT->isGNUAutoType())
         return LHS;
     }
     return {};

--- a/clang/test/Sema/warn-memset-bad-sizeof.c
+++ b/clang/test/Sema/warn-memset-bad-sizeof.c
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+// expected-no-diagnostics
+
+typedef __SIZE_TYPE__ size_t;
+void *memset(void *, int, size_t);
+
+typedef struct {
+  int a;
+} S;
+
+void test() {
+  S s;
+  __auto_type dstptr = &s;
+  memset(dstptr, 0, sizeof(s));
+}


### PR DESCRIPTION
This fixes a bug in clang where it emits the following diagnostic when
compiling the test case:

"argument to 'sizeof' in 'memset' call is the same pointer type 'S' as
the destination"

The code that merges __auto_type with other types was committed in
https://reviews.llvm.org/D122029.

Differential Revision: https://reviews.llvm.org/D128373

(cherry picked from commit 5fa4629581f6938cc175be5d4a3fccdfbf9fc227)