### PR TITLE
Adapt Swift mangled name handling to upstream changes 

### DIFF
--- a/lldb/include/lldb/Core/Mangled.h
+++ b/lldb/include/lldb/Core/Mangled.h
@@ -44,7 +44,10 @@ public:
     eManglingSchemeMSVC,
     eManglingSchemeItanium,
     eManglingSchemeRustV0,
-    eManglingSchemeD
+    eManglingSchemeD,
+#ifdef LLDB_ENABLE_SWIFT
+    eManglingSchemeSwift
+#endif // LLDB_ENABLE_SWIFT
   };
 
   /// Default constructor.

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -269,15 +269,19 @@ std::string CPlusPlusLanguage::MethodName::GetScopeQualifiedName() {
 }
 
 bool CPlusPlusLanguage::IsCPPMangledName(llvm::StringRef name) {
-  // FIXME!! we should really run through all the known C++ Language plugins
-  // and ask each one if this is a C++ mangled name
-
   Mangled::ManglingScheme scheme = Mangled::GetManglingScheme(name);
-
-  if (scheme == Mangled::eManglingSchemeNone)
+  switch (scheme) {
+  case Mangled::eManglingSchemeMSVC:
+  case Mangled::eManglingSchemeItanium:
+    return true;
+  case Mangled::eManglingSchemeNone:
+  case Mangled::eManglingSchemeRustV0:
+  case Mangled::eManglingSchemeD:
+#ifdef LLDB_ENABLE_SWIFT
+  case Mangled::eManglingSchemeSwift:
+#endif
     return false;
-
-  return true;
+  }
 }
 
 bool CPlusPlusLanguage::ExtractContextAndIdentifier(

--- a/lldb/source/Symbol/Symtab.cpp
+++ b/lldb/source/Symbol/Symtab.cpp
@@ -263,6 +263,10 @@ static bool lldb_skip_name(llvm::StringRef mangled,
   case Mangled::eManglingSchemeD:
     return false;
 
+#ifdef LLDB_ENABLE_SWIFT
+  case Mangled::eManglingSchemeSwift:
+    // This is handled separately.
+#endif // LLDB_ENABLE_SWIFT
   // Don't try and demangle things we can't categorize.
   case Mangled::eManglingSchemeNone:
     return true;


### PR DESCRIPTION
and make it slightly more consistent with how other languages are
handled, by introducing an enumerator for mangled Swift names.

rdar://92571418