### PR TITLE
[rebranch][lld] Add explicit stack size to SmallVector use

### DIFF
--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -43,7 +43,7 @@ using namespace lld::elf;
 bool InputFile::isInGroup;
 uint32_t InputFile::nextGroupId;
 
-SmallVector<std::unique_ptr<MemoryBuffer>> elf::memoryBuffers;
+SmallVector<std::unique_ptr<MemoryBuffer>, 6> elf::memoryBuffers;
 SmallVector<BinaryFile *, 0> elf::binaryFiles;
 SmallVector<BitcodeFile *, 0> elf::bitcodeFiles;
 SmallVector<BitcodeFile *, 0> elf::lazyBitcodeFiles;

--- a/lld/ELF/InputFiles.h
+++ b/lld/ELF/InputFiles.h
@@ -15,7 +15,6 @@
 #include "lld/Common/LLVM.h"
 #include "lld/Common/Reproduce.h"
 #include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/BinaryFormat/Magic.h"
 #include "llvm/Object/ELF.h"
 #include "llvm/Support/MemoryBufferRef.h"
@@ -383,7 +382,7 @@ inline bool isBitcode(MemoryBufferRef mb) {
 
 std::string replaceThinLTOSuffix(StringRef path);
 
-extern SmallVector<std::unique_ptr<MemoryBuffer>> memoryBuffers;
+extern SmallVector<std::unique_ptr<MemoryBuffer>, 6> memoryBuffers;
 extern SmallVector<BinaryFile *, 0> binaryFiles;
 extern SmallVector<BitcodeFile *, 0> bitcodeFiles;
 extern SmallVector<BitcodeFile *, 0> lazyBitcodeFiles;


### PR DESCRIPTION
This reverts commit 6d439d41be35954a8d7b9733b7424a68db9990b7 as the use
isn't in the LLVM namespace, so including the header doesn't change
anything. Then adds an explicit size to the uses instead.