### PR TITLE
[stable/20220421][test] Fix another capitalization issue in objcxx-swift-name.m

### DIFF
--- a/clang/test/APINotes/objcxx-swift-name.m
+++ b/clang/test/APINotes/objcxx-swift-name.m
@@ -19,5 +19,5 @@
 // CHECK-NEXT: SwiftNameAttr {{.+}} <<invalid sloc>> "red"
 
 // CHECK-ANONYMOUS-ENUM: Dumping (anonymous):
-// CHECK-ANONYMOUS-ENUM-NEXT: EnumDecl {{.+}} imported in CxxInteropKit <undeserialized declarations> 'NSSomeEnumOptions':'unsigned long'
+// CHECK-ANONYMOUS-ENUM-NEXT: EnumDecl {{.+}} imported in CXXInteropKit <undeserialized declarations> 'NSSomeEnumOptions':'unsigned long'
 // CHECK-ANONYMOUS-ENUM-NEXT: SwiftNameAttr {{.+}} <<invalid sloc>> "SomeEnum.Options"


### PR DESCRIPTION
rdar://95065603
(cherry picked from commit 97aa57eae61961eedb025fdf97a8de94a46f7c3c)