### PR TITLE
Relax verification of AnyObject type alias.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3708,6 +3708,16 @@ bool TypeSystemSwiftTypeRef::IsTypedefType(opaque_compiler_type_t type) {
                     node->getKind() == Node::Kind::BoundGenericTypeAlias);
   };
 
+#ifndef NDEBUG
+  {
+    // Sometimes SwiftASTContext returns the resolved AnyObject type.
+    Demangler dem;
+    NodePointer node = GetDemangledType(dem, AsMangledName(type));
+    if (IsAnyObjectTypeAlias(node))
+      return impl();
+  }
+#endif
+
   VALIDATE_AND_RETURN(impl, IsTypedefType, type, g_no_exe_ctx,
                       (ReconstructType(type)), (ReconstructType(type)));
 }


### PR DESCRIPTION
There are situations where TypeSystemSwiftTypeRef returns a more
accurate result, so skip the verification there.

rdar://96020392
(cherry picked from commit fd52f17ef0d0f6610c9d9af0fe43b01f8c383b75)