### PR TITLE
TestIgnoredExceptions.py needs support from debugserver, so it

### DIFF
--- a/lldb/test/API/macosx/ignore_exceptions/TestIgnoredExceptions.py
+++ b/lldb/test/API/macosx/ignore_exceptions/TestIgnoredExceptions.py
@@ -14,6 +14,7 @@ class TestDarwinSignalHandlers(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipIfOutOfTreeDebugserver
     @skipUnlessDarwin
     def test_ignored_thread(self):
         """It isn't possible to convert an EXC_BAD_ACCESS to a signal when


### PR DESCRIPTION
needs to be marked skip if out of tree debugserver.

(cherry picked from commit f7bf9d13d50d785889952deb18cc93de0176cb96)