### PR TITLE
[rebranch] Disable getPointerElementType deprecation warning for Swift

### DIFF
--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -366,11 +366,14 @@ public:
     return ContainedTys[0];
   }
 
+  // Skip the deprecation warning while Swift migrates to opaque pointers
+#ifndef SWIFT_LLVM_SUPPORT_IS_AVAILABLE
   /// This method is deprecated without replacement. Pointer element types are
   /// not available with opaque pointers.
   [[deprecated("Deprecated without replacement, see "
                "https://llvm.org/docs/OpaquePointers.html for context and "
                "migration instructions")]]
+#endif
   Type *getPointerElementType() const {
     return getNonOpaquePointerElementType();
   }


### PR DESCRIPTION
Disable the `Type::getPointerElementType` deprecation warning when
included by Swift while it migrates to opaque pointers. Co-opting
`SWIFT_LLVM_SUPPORT_IS_AVAILABLE` for this purpose since it's defined
when compiling all the relevant Swift libraries (ie. any that use LLVM).