### PR TITLE
[clang] add option to suppress conflicting type errors on function decls

### DIFF
--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -462,6 +462,8 @@ VALUE_LANGOPT(FuchsiaAPILevel, 32, 0, "Fuchsia API level")
 // on large _BitInts.
 BENIGN_VALUE_LANGOPT(MaxBitIntWidth, 32, 128, "Maximum width of a _BitInt")
 
+LANGOPT(IgnoreConflictingTypes, 1, 0, "Suppress conflicting type errors from mismatching declarations")
+
 #undef LANGOPT
 #undef COMPATIBLE_LANGOPT
 #undef BENIGN_LANGOPT

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -7097,3 +7097,7 @@ def fcgl : DXCFlag<"fcgl">, Alias<emit_pristine_llvm>;
 def enable_16bit_types : DXCFlag<"enable-16bit-types">, Alias<fnative_half_type>,
   HelpText<"Enable 16-bit types and disable min precision types."
            "Available in HLSL 2018 and shader model 6.2.">;
+
+def fsuppress_conflicting_types: Flag<["-"], "fsuppress-conflicting-types">, Group<f_Group>,
+  MarshallingInfoFlag<LangOpts<"IgnoreConflictingTypes">>,
+  HelpText<"Ignore errors from conflicting types in function declarations">, Flags<[CC1Option]>;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6289,6 +6289,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &Job,
   Args.AddLastArg(CmdArgs, options::OPT_ftrapv);
   Args.AddLastArg(CmdArgs, options::OPT_malign_double);
   Args.AddLastArg(CmdArgs, options::OPT_fno_temp_file);
+  Args.AddLastArg(CmdArgs, options::OPT_fsuppress_conflicting_types);
 
   if (Arg *A = Args.getLastArg(options::OPT_ftrapv_handler_EQ)) {
     CmdArgs.push_back("-ftrapv-handler");

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -3911,7 +3911,8 @@ bool Sema::MergeFunctionDecl(FunctionDecl *New, NamedDecl *&OldD, Scope *S,
     // we need to cover here is that the number of arguments agree as the
     // default argument promotion rules were already checked by
     // ASTContext::typesAreCompatible().
-    if (Old->hasPrototype() && !New->hasWrittenPrototype() && NewDeclIsDefn &&
+    if (!getLangOpts().IgnoreConflictingTypes && Old->hasPrototype() &&
+        !New->hasWrittenPrototype() && NewDeclIsDefn &&
         Old->getNumParams() != New->getNumParams()) {
       if (Old->hasInheritedPrototype())
         Old = Old->getCanonicalDecl();
@@ -3969,7 +3970,8 @@ bool Sema::MergeFunctionDecl(FunctionDecl *New, NamedDecl *&OldD, Scope *S,
       }
     }
 
-    if (Context.typesAreCompatible(OldQType, NewQType)) {
+    if (Context.typesAreCompatible(OldQType, NewQType) ||
+        getLangOpts().IgnoreConflictingTypes) {
       const FunctionType *OldFuncType = OldQType->getAs<FunctionType>();
       const FunctionType *NewFuncType = NewQType->getAs<FunctionType>();
       const FunctionProtoType *OldProto = nullptr;

--- a/clang/test/Sema/ignore-prototype-redecls.c
+++ b/clang/test/Sema/ignore-prototype-redecls.c
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fsuppress-conflicting-types -verify %s
+// expected-no-diagnostics
+
+void blapp(int);
+void blapp() {}
+
+void yarp(int, ...);
+void yarp();
+
+void blarg(int, ...);
+void blarg() {}
+
+void blerp(short);
+void blerp(x) int x;
+{}
+
+void foo(int);
+void foo();
+void foo() {}


### PR DESCRIPTION
This optionally supresses the check of C standard introduced in rG385e7df to unblock qualifications

Resolves: rdar://96080355