### PR TITLE
[clang] add option to suppress conflicting type errors on function decls

### DIFF
--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -455,6 +455,8 @@ ENUM_LANGOPT(ExtendIntArgs, ExtendArgsKind, 1, ExtendArgsKind::ExtendTo32,
 
 VALUE_LANGOPT(FuchsiaAPILevel, 32, 0, "Fuchsia API level")
 
+LANGOPT(IgnoreConflictingTypes, 1, 0, "Suppress conflicting type errors from mismatching declarations")
+
 #undef LANGOPT
 #undef COMPATIBLE_LANGOPT
 #undef BENIGN_LANGOPT

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6966,3 +6966,7 @@ def target_profile : DXCJoinedOrSeparate<"T">, MetaVarName<"<profile>">,
          "lib_6_3, lib_6_4, lib_6_5, lib_6_6, lib_6_7, lib_6_x,"
          "ms_6_5, ms_6_6, ms_6_7,"
          "as_6_5, as_6_6, as_6_7">;
+
+def fsuppress_conflicting_types: Flag<["-"], "fsuppress-conflicting-types">, Group<f_Group>,
+  MarshallingInfoFlag<LangOpts<"IgnoreConflictingTypes">>,
+  HelpText<"Ignore errors from conflicting types in function declarations">, Flags<[CC1Option]>;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6228,6 +6228,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &Job,
   Args.AddLastArg(CmdArgs, options::OPT_ftrapv);
   Args.AddLastArg(CmdArgs, options::OPT_malign_double);
   Args.AddLastArg(CmdArgs, options::OPT_fno_temp_file);
+  Args.AddLastArg(CmdArgs, options::OPT_fsuppress_conflicting_types);
 
   if (Arg *A = Args.getLastArg(options::OPT_ftrapv_handler_EQ)) {
     CmdArgs.push_back("-ftrapv-handler");

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -3910,7 +3910,8 @@ bool Sema::MergeFunctionDecl(FunctionDecl *New, NamedDecl *&OldD, Scope *S,
     // we need to cover here is that the number of arguments agree as the
     // default argument promotion rules were already checked by
     // ASTContext::typesAreCompatible().
-    if (Old->hasPrototype() && !New->hasWrittenPrototype() && NewDeclIsDefn &&
+    if (!getLangOpts().IgnoreConflictingTypes && Old->hasPrototype() &&
+        !New->hasWrittenPrototype() && NewDeclIsDefn &&
         Old->getNumParams() != New->getNumParams()) {
       if (Old->hasInheritedPrototype())
         Old = Old->getCanonicalDecl();

--- a/clang/test/Sema/ignore-prototype-redecls.c
+++ b/clang/test/Sema/ignore-prototype-redecls.c
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fsuppress-conflicting-types -verify %s
+
+void blapp(int);
+void blapp() {}
+
+void foo(int);
+void foo();
+void foo() {}
+
+// Maintain preexisting released clang behavior that catches conflicting type errors.
+void yarp(int, ...); // expected-note {{previous}}
+void yarp();         // expected-error {{conflicting types for 'yarp'}}
+
+void blarg(int, ...); // expected-note {{previous}}
+void blarg() {}       // expected-error {{conflicting types for 'blarg'}}


### PR DESCRIPTION
This optionally supresses the check of C standard introduced in rG385e7df to unblock qualifications

Resolves: rdar://96080355