### PR TITLE
[cxx-interop] Allow Swift to get a Clang Toolchain from the Driver

### DIFF
--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -598,6 +598,7 @@ private:
   /// compilation based on which -f(no-)?lto(=.*)? option occurs last.
   void setLTOMode(const llvm::opt::ArgList &Args);
 
+public:
   /// Retrieves a ToolChain for a particular \p Target triple.
   ///
   /// Will cache ToolChains for the life of the driver object, and create them
@@ -606,6 +607,7 @@ private:
                                 const llvm::Triple &Target) const;
 
   /// @}
+private:
 
   /// Get bitmasks for which option flags to include and exclude based on
   /// the driver mode.


### PR DESCRIPTION
Swift uses the Clang Driver to detect default include paths for C++ interop.

This will allow us to revert https://github.com/apple/llvm-project/pull/4693 and have a smaller diff with upstream.