### PR TITLE
[InMemoryCAS] Drop Reserved Kind bits to 2

### DIFF
--- a/llvm/lib/CAS/InMemoryCAS.cpp
+++ b/llvm/lib/CAS/InMemoryCAS.cpp
@@ -77,7 +77,7 @@ protected:
 
 private:
   enum Counts : int {
-    NumKindBits = 3,
+    NumKindBits = 2,
   };
   PointerIntPair<const InMemoryIndexValueT *, NumKindBits, Kind> IndexAndKind;
   static_assert((1U << NumKindBits) <= alignof(InMemoryIndexValueT),


### PR DESCRIPTION
With less object type needs to be supported by InMemoryCAS, drop the tag
bits to 2 bit so it can be built on 32 bit architecture.