### PR TITLE
[lldb] Avoid conflict between mach/machine.h and llvm/BinaryFormat/Ma…

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
@@ -2,8 +2,14 @@
 #ifndef liblldb_LLDBMemoryReader_h_
 #define liblldb_LLDBMemoryReader_h_
 
+
 #include "SwiftLanguageRuntime.h"
+
+// We need to include ReflectionContext.h before TypeLowering.h to avoid
+// conflicts between mach/machine.h and llvm/BinaryFormat/MachO.h.
+#include "swift/Reflection/ReflectionContext.h"
 #include "swift/Reflection/TypeLowering.h"
+
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/Support/Memory.h"
 


### PR DESCRIPTION
…chO.h

Certain SDKs transitively include mach/machine.h which defines constants
that conflict with llvm/BinaryFormat/MachO.h. By ordering the includes
we can avoid the conflict.

rdar://96148553