### PR TITLE
Fix build failures with clang-5

### DIFF
--- a/llvm/include/llvm/CAS/HashMappedTrie.h
+++ b/llvm/include/llvm/CAS/HashMappedTrie.h
@@ -62,7 +62,7 @@ protected:
     void *get() const { return I == -2u ? P : nullptr; }
 
   public:
-    PointerBase() noexcept = default;
+    PointerBase() noexcept {}
     PointerBase(PointerBase &&) = default;
     PointerBase(const PointerBase &) = default;
     PointerBase &operator=(PointerBase &&) = default;


### PR DESCRIPTION
Workaround a bug in clang-5 that causes build failure as it is still the
minimum supported version.