### PR TITLE
[clang-cache] Rename `CLANG_CACHE_CAS_PATH` variable to `LLVM_CACHE_CAS_PATH`

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -129,7 +129,7 @@ Optionally also install experimental libtool and linker support:
 #### Use `clang-cache` as compiler launcher
 
 Using `clang-cache` there's no need to modify compiler arguments.
-Set the environment variable `CLANG_CACHE_CAS_PATH` to specify a non-default
+Set the environment variable `LLVM_CACHE_CAS_PATH` to specify a non-default
 location for the on-disk CAS.
 
 ```

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -7,10 +7,10 @@
 // RUN: ln -s %clang %t/clang-symlink-outside-bindir
 
 // 'clang-cache' launcher invokes itself, enables caching.
-// RUN: env CLANG_CACHE_CAS_PATH=%t/cas clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG -DPREFIX=%t
-// RUN: env CLANG_CACHE_CAS_PATH=%t/cas clang-cache %clang++ -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANGPP -DPREFIX=%t
-// RUN: env CLANG_CACHE_CAS_PATH=%t/cas clang-cache %t/clang-symlink-outside-bindir -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG -DPREFIX=%t
-// RUN: env CLANG_CACHE_CAS_PATH=%t/cas PATH="%t:$PATH" clang-cache clang-symlink-outside-bindir -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG -DPREFIX=%t
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG -DPREFIX=%t
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas clang-cache %clang++ -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANGPP -DPREFIX=%t
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas clang-cache %t/clang-symlink-outside-bindir -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG -DPREFIX=%t
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas PATH="%t:$PATH" clang-cache clang-symlink-outside-bindir -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG -DPREFIX=%t
 
 // CLANG: "-cc1depscan" "-fdepscan=auto"
 // CLANG: "-fcas-path" "[[PREFIX]]/cas" "-fcas-token-cache"
@@ -22,7 +22,7 @@
 // CLANGPP: "-greproducible"
 // CLANGPP: "-x" "c++"
 
-// RUN: env CLANG_CACHE_CAS_PATH=%t/cas cache-build-session clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=SESSION -DPREFIX=%t
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=SESSION -DPREFIX=%t
 // SESSION: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-share-identifier"
 // SESSION: "-fcas-path" "[[PREFIX]]/cas" "-fcas-token-cache"
 // SESSION: "-greproducible"
@@ -30,7 +30,7 @@
 // RUN: cp -R %S/Inputs/cmake-build %t/cmake-build
 // RUN: pushd %t/cmake-build
 // RUN: cache-build-session -prefix-map-cmake -v echo 2>&1 | FileCheck %s -check-prefix=SESSION-CMAKE-PREFIX
-// RUN: env CLANG_CACHE_CAS_PATH=%t/cas cache-build-session -prefix-map-cmake clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG-CMAKE-PREFIX -DPREFIX=%t
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session -prefix-map-cmake clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG-CMAKE-PREFIX -DPREFIX=%t
 // RUN: popd
 
 // SESSION-CMAKE-PREFIX: note: setting LLVM_CACHE_PREFIX_MAPS=/llvm/build=/^build;/llvm/llvm-project/llvm=/^src;/llvm/llvm-project/clang=/^src-clang;/llvm/llvm-project/clang-tools-extra=/^src-clang-tools-extra;/llvm/llvm-project/third-party/benchmark=/^src-benchmark;/llvm/llvm-project/other/benchmark=/^src-benchmark-1;/llvm/llvm-project/another/benchmark=/^src-benchmark-2{{$}}
@@ -51,7 +51,7 @@
 // SESSION-SCRIPT: run some compiler with opts -c [[SRC]] -o [[PREFIX]].o
 
 // 'clang-cache' launcher invokes a different clang, does normal non-caching launch.
-// RUN: env CLANG_CACHE_CAS_PATH=%t/cas clang-cache %t/clang -c %s -o %t.o 2>&1 | FileCheck %s -check-prefix=OTHERCLANG -DSRC=%s -DPREFIX=%t
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas clang-cache %t/clang -c %s -o %t.o 2>&1 | FileCheck %s -check-prefix=OTHERCLANG -DSRC=%s -DPREFIX=%t
 // OTHERCLANG: warning: clang-cache invokes a different clang binary than itself, it will perform a normal non-caching invocation of the compiler
 // OTHERCLANG-NEXT: run some compiler with opts -c [[SRC]] -o [[PREFIX]].o
 

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -90,7 +90,7 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
         Args.push_back(Saver.save("-fdepscan-prefix-map=" + PrefixMap).data());
       }
     }
-    if (const char *CASPath = ::getenv("CLANG_CACHE_CAS_PATH")) {
+    if (const char *CASPath = ::getenv("LLVM_CACHE_CAS_PATH")) {
       Args.append({"-Xclang", "-fcas-path", "-Xclang", CASPath});
     }
     Args.append({"-greproducible", "-Xclang", "-fcas-token-cache"});


### PR DESCRIPTION
Using `LLVM_` as a a more tool-independent prefix since other tools other then clang (or the compilers)
could use the same variable in the future.