### PR TITLE
Revert "[cxx-interop] Allow Swift to extract libstdc++ installation path from Clang"

### DIFF
--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -565,18 +565,6 @@ public:
     return IsOffload ? OffloadLTOMode : LTOMode;
   }
 
-  /// Addition for Swift. Allows ClangImporter to extract the path to libstdc++.
-  std::vector<std::string>
-  getLibStdCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
-                           const llvm::Triple &Target) const {
-    llvm::opt::ArgStringList ArgStrings;
-    getToolChain(DriverArgs, Target)
-        .addLibStdCxxIncludePaths(DriverArgs, ArgStrings);
-    unsigned Unused1, Unused2;
-    auto ParsedArgs = getOpts().ParseArgs(ArgStrings, Unused1, Unused2);
-    return ParsedArgs.getAllArgValues(options::OPT_internal_isystem);
-  }
-
 private:
 
   /// Tries to load options from configuration file.

--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -225,11 +225,6 @@ public:
   llvm::vfs::FileSystem &getVFS() const;
   const llvm::Triple &getTriple() const { return Triple; }
 
-  /// Addition for Swift. Allows ClangImporter to extract the path to libstdc++.
-  virtual void
-  addLibStdCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
-                           llvm::opt::ArgStringList &CC1Args) const {};
-
   /// Get the toolchain's aux triple, if it has one.
   ///
   /// Exactly what the aux triple represents depends on the toolchain, but for


### PR DESCRIPTION
This trick is no longer needed, Swift switched to another way to retrieving the include paths.

This reverts commit dd4e7124318ba0cb2d2414c4a777ba1cf7a600d9.