### PR TITLE
[cas] Rename clang-cache warning group

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -26,7 +26,8 @@ def err_cas_depscan_failed: Error<
 
 def warn_clang_cache_disabled_caching: Warning<
   "clang-cache invokes a different clang binary than itself, it will perform "
-  "a normal non-caching invocation of the compiler">, InGroup<CompileJobCache>;
+  "a normal non-caching invocation of the compiler">,
+  InGroup<DiagGroup<"clang-cache">>;
 def err_clang_cache_failed_execution: Error<
   "clang-cache failed to execute compiler: %0">;
 def err_clang_cache_cannot_find_binary: Error<


### PR DESCRIPTION
Fixes an error building docs:
error: Diagnostic group contains both remark and non-remark diagnostics

rdar://96442442