### PR TITLE
[Docs] Don't mix warnings and remarks in the same DiagGroup

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -26,7 +26,7 @@ def err_cas_depscan_failed: Error<
 
 def warn_clang_cache_disabled_caching: Warning<
   "clang-cache invokes a different clang binary than itself, it will perform "
-  "a normal non-caching invocation of the compiler">, InGroup<CompileJobCache>;
+  "a normal non-caching invocation of the compiler">, InGroup<ClangCache>;
 def err_clang_cache_failed_execution: Error<
   "clang-cache failed to execute compiler: %0">;
 def err_clang_cache_cannot_find_binary: Error<

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1368,6 +1368,9 @@ def CompileJobCacheHit : DiagGroup<"compile-job-cache-hit">;
 def CompileJobCache : DiagGroup<"compile-job-cache", [CompileJobCacheMiss,
                                                       CompileJobCacheHit]>;
 
+// clang-cache warnings.
+def ClangCache : DiagGroup<"clang-cache">;
+
 // Warnings and extensions to make preprocessor macro usage pedantic.
 def PedanticMacros : DiagGroup<"pedantic-macros",
                     [DeprecatedPragma,


### PR DESCRIPTION
Fix clang-docs build for clang-cache diagnostics.

rdar://96442442