### PR TITLE
[stable][driver/CMakeLists.txt] Add symlink to `clang-cache` separate from the `CLANG_LINKS_TO_CREATE` variable

### DIFF
--- a/clang/tools/driver/CMakeLists.txt
+++ b/clang/tools/driver/CMakeLists.txt
@@ -64,12 +64,14 @@ endif()
 add_dependencies(clang clang-resource-headers)
 
 if(NOT CLANG_LINKS_TO_CREATE)
-  set(CLANG_LINKS_TO_CREATE clang++ clang-cl clang-cpp clang-cache)
+  set(CLANG_LINKS_TO_CREATE clang++ clang-cl clang-cpp)
 endif()
 
 foreach(link ${CLANG_LINKS_TO_CREATE})
   add_clang_symlink(${link} clang)
 endforeach()
+# Adding `clang-cache` tool as a symlink to clang.
+add_clang_symlink(clang-cache clang)
 
 # Configure plist creation for OS X.
 set (TOOL_INFO_PLIST "Info.plist" CACHE STRING "Plist name")


### PR DESCRIPTION
`CLANG_LINKS_TO_CREATE` could be overridden during configure but `clang-cache` should be considered a separate tool that is a symlink
as implemention detail only.

rdar://96444437