### PR TITLE
[lldb] Pass likely module names to reflection parsing machinery

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -247,17 +247,23 @@ public:
   bool addImage(
       llvm::function_ref<std::pair<swift::remote::RemoteRef<void>, uint64_t>(
           swift::ReflectionSectionKind)>
-          find_section) override {
-    return m_reflection_ctx.addImage(find_section);
+          find_section,
+      llvm::SmallVector<llvm::StringRef, 1> likely_module_names) override {
+    return m_reflection_ctx.addImage(find_section, likely_module_names);
   }
 
-  bool addImage(swift::remote::RemoteAddress image_start) override {
-    return m_reflection_ctx.addImage(image_start);
+  bool
+  addImage(swift::remote::RemoteAddress image_start,
+           llvm::SmallVector<llvm::StringRef, 1> likely_module_names) override {
+    return m_reflection_ctx.addImage(image_start, likely_module_names);
   }
 
-  bool readELF(swift::remote::RemoteAddress ImageStart,
-               llvm::Optional<llvm::sys::MemoryBlock> FileBuffer) override {
-    return m_reflection_ctx.readELF(ImageStart, FileBuffer);
+  bool readELF(
+      swift::remote::RemoteAddress ImageStart,
+      llvm::Optional<llvm::sys::MemoryBlock> FileBuffer,
+      llvm::SmallVector<llvm::StringRef, 1> likely_module_names = {}) override {
+    return m_reflection_ctx.readELF(ImageStart, FileBuffer,
+                                    likely_module_names);
   }
 
   const swift::reflection::TypeInfo *

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -213,10 +213,15 @@ public:
     virtual bool addImage(
         llvm::function_ref<std::pair<swift::remote::RemoteRef<void>, uint64_t>(
             swift::ReflectionSectionKind)>
-            find_section) = 0;
-    virtual bool addImage(swift::remote::RemoteAddress image_start) = 0;
-    virtual bool readELF(swift::remote::RemoteAddress ImageStart,
-                         llvm::Optional<llvm::sys::MemoryBlock> FileBuffer) = 0;
+            find_section,
+        llvm::SmallVector<llvm::StringRef, 1> likely_module_names = {}) = 0;
+    virtual bool addImage(
+        swift::remote::RemoteAddress image_start,
+        llvm::SmallVector<llvm::StringRef, 1> likely_module_names = {}) = 0;
+    virtual bool
+    readELF(swift::remote::RemoteAddress ImageStart,
+            llvm::Optional<llvm::sys::MemoryBlock> FileBuffer,
+            llvm::SmallVector<llvm::StringRef, 1> likely_module_names = {}) = 0;
     virtual const swift::reflection::TypeInfo *
     getTypeInfo(const swift::reflection::TypeRef *type_ref,
                 swift::remote::TypeInfoProvider *provider) = 0;
@@ -388,13 +393,15 @@ private:
   /// Add the contents of the object file to the reflection context.
   /// \return true on success.
   bool AddJitObjectFileToReflectionContext(
-      ObjectFile &obj_file, llvm::Triple::ObjectFormatType obj_format_type);
+      ObjectFile &obj_file, llvm::Triple::ObjectFormatType obj_format_type,
+      llvm::SmallVector<llvm::StringRef, 1> likely_module_names);
 
   /// Add the reflections sections to the reflection context by extracting
   /// the directly from the object file.
   /// \return true on success.
   bool AddObjectFileToReflectionContext(
-      lldb::ModuleSP module);
+      lldb::ModuleSP module,
+      llvm::SmallVector<llvm::StringRef, 1> likely_module_names);
 
   /// Cache for the debug-info-originating type infos.
   /// \{


### PR DESCRIPTION
rdar://87889973
(cherry picked from commit 5931c1e4f961775eaf05b7977e9cbc6cb1bbd7eb)

Description: Currently, whenever we're asked to retrieve a particular FieldDescriptor for a TypeRef, we naively parse all the ReflectionInfos in the order they were registered (caching everything) until we find the one we're looking for. This can be very costly for the debugger, as we may be reading memory from a remote target. This patch introduces a heuristic to prioritize this search by processing first ReflectionInfos where the FieldDescriptor we're looking for is likely to be. If the heuristic fails, we fallback to the old behavior. In profiling debugging large apps, this has significant impact on the time to stop on the first breakpoint.
Risk: Low. If the heuristic fails we fall back to the old behavior.
Testing: swift lldb tests that use frame variable.
Original PR: https://github.com/apple/llvm-project/pull/4927
Issue: rdar://87889973