### PR TITLE
[stable/20220421] Handle Swift-only CommentTag SymbolKind

### DIFF
--- a/clang-tools-extra/clangd/CodeComplete.cpp
+++ b/clang-tools-extra/clangd/CodeComplete.cpp
@@ -82,6 +82,7 @@ CompletionItemKind toCompletionItemKind(index::SymbolKind Kind) {
   using SK = index::SymbolKind;
   switch (Kind) {
   case SK::Unknown:
+  case SK::CommentTag:
     return CompletionItemKind::Missing;
   case SK::Module:
   case SK::Namespace:

--- a/clang-tools-extra/clangd/Protocol.cpp
+++ b/clang-tools-extra/clangd/Protocol.cpp
@@ -249,6 +249,7 @@ SymbolKind adjustKindToCapability(SymbolKind Kind,
 SymbolKind indexSymbolKindToSymbolKind(index::SymbolKind Kind) {
   switch (Kind) {
   case index::SymbolKind::Unknown:
+  case index::SymbolKind::CommentTag:
     return SymbolKind::Variable;
   case index::SymbolKind::Module:
     return SymbolKind::Module;

--- a/clang-tools-extra/clangd/Quality.cpp
+++ b/clang-tools-extra/clangd/Quality.cpp
@@ -146,6 +146,7 @@ categorize(const index::SymbolInfo &D) {
   case index::SymbolKind::Using:
   case index::SymbolKind::Module:
   case index::SymbolKind::Unknown:
+  case index::SymbolKind::CommentTag:
     return SymbolQualitySignals::Unknown;
   }
   llvm_unreachable("Unknown index::SymbolKind");


### PR DESCRIPTION
Cherry-picks ea05319cbb085c34b95951a72c69db0276c721ed (https://github.com/apple/llvm-project/pull/4275).