### PR TITLE
[lldb] Make LLDBMemoryReader::resolvePointer strip the pointer

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -189,6 +189,11 @@ LLDBMemoryReader::resolvePointer(swift::remote::RemoteAddress address,
   if (!readMetadataFromFileCacheEnabled())
     return process_pointer;
 
+  // Try to strip the pointer before checking if we have it mapped.
+  auto strippedPointer = signedPointerStripper(process_pointer);
+  if (strippedPointer.isResolved())
+    readValue = strippedPointer.getOffset();
+
   auto &target = m_process.GetTarget();
   Address addr;
   if (!target.ResolveLoadAddress(readValue, addr)) {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
@@ -17,8 +17,12 @@
 namespace lldb_private {
 class LLDBMemoryReader : public swift::remote::MemoryReader {
 public:
-  LLDBMemoryReader(Process &p, size_t max_read_amount = INT32_MAX)
-      : m_process(p), m_range_module_map() {
+  LLDBMemoryReader(Process &p,
+                   std::function<swift::remote::RemoteAbsolutePointer(
+                       swift::remote::RemoteAbsolutePointer)>
+                       stripper,
+                   size_t max_read_amount = INT32_MAX)
+      : m_process(p), signedPointerStripper(stripper), m_range_module_map() {
     m_max_read_amount = max_read_amount;
   }
 
@@ -83,6 +87,10 @@ private:
 
   llvm::Optional<uint64_t> m_local_buffer;
   uint64_t m_local_buffer_size = 0;
+
+  std::function<swift::remote::RemoteAbsolutePointer(
+      swift::remote::RemoteAbsolutePointer)>
+      signedPointerStripper;
 
   /// LLDBMemoryReader prefers to read reflection metadata from the
   /// binary on disk, which is faster than reading it out of process

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -243,6 +243,8 @@ public:
     virtual swift::reflection::TypeRefBuilder &getBuilder() = 0;
     virtual llvm::Optional<bool> isValueInlinedInExistentialContainer(
         swift::remote::RemoteAddress existential_address) = 0;
+    virtual swift::remote::RemoteAbsolutePointer
+    stripSignedPointer(swift::remote::RemoteAbsolutePointer pointer) = 0;
   };
 
 protected:


### PR DESCRIPTION
In order to know if the pointer we're dealing with is mapped by
LLDBMemoryReader, we need to strip it first.

rdar://94239864