### PR TITLE
[lldb] Handle unsupported type in GetPointerType

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2431,6 +2431,9 @@ TypeSystemSwiftTypeRef::GetPointerType(opaque_compiler_type_t type) {
 
     // The type that will be wrapped in UnsafePointer.
     auto *pointee_type = GetDemangledType(dem, AsMangledName(type));
+    if (!pointee_type)
+      return {};
+
     // The UnsafePointer type.
     auto *pointer_type = dem.createNode(Node::Kind::Type);
 


### PR DESCRIPTION
For `TypeSystemSwiftTypeRef::GetPointerType` to succeed, the given type variable first must be demangled. If that fails, the function must return an empty `CompilerType`.

This fixes downstream crashes [in `GetPointerTO` where `Node::addChild` is called](https://github.com/apple/llvm-project/blob/1d75a24ee862516c100d6a540c566349a79c3522/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp#L269), but with a null node. This causes an [abort in `addChild`](https://github.com/apple/swift/blob/380e370157655a102e6cf1abd46b74d575f2ecce/lib/Demangling/Demangler.cpp#L345), where the child node is required to be non-null.

rdar://96170947

(cherry picked from #4954)
