### PR TITLE
Introduce `clang::cas` namespace, with typealiases from `llvm::cas` for convenience

### DIFF
--- a/clang/include/clang/Basic/LLVM.h
+++ b/clang/include/clang/Basic/LLVM.h
@@ -51,6 +51,14 @@ namespace llvm {
   class raw_ostream;
   class raw_pwrite_stream;
   // TODO: DenseMap, ...
+
+  namespace cas {
+  class CASDB;
+  class CASID;
+  class LeafNodeProxy;
+  class NodeProxy;
+  class ObjectRef;
+  } // namespace cas
 }
 
 
@@ -87,6 +95,14 @@ namespace clang {
 
   using llvm::raw_ostream;
   using llvm::raw_pwrite_stream;
+
+  namespace cas {
+  using llvm::cas::CASDB;
+  using llvm::cas::CASID;
+  using llvm::cas::LeafNodeProxy;
+  using llvm::cas::NodeProxy;
+  using llvm::cas::ObjectRef;
+  } // namespace cas
 } // end namespace clang.
 
 #endif

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
@@ -32,7 +32,6 @@ static void reportAsFatalIfError(llvm::Error E) {
 }
 
 using llvm::Error;
-namespace cas = llvm::cas;
 
 DependencyScanningCASFilesystem::DependencyScanningCASFilesystem(
     IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> WorkerFS)
@@ -191,7 +190,7 @@ void DependencyScanningCASFilesystem::scanForDirectives(
 
 Expected<StringRef>
 DependencyScanningCASFilesystem::getOriginal(cas::CASID InputDataID) {
-  Expected<cas::BlobProxy> Blob = CAS.getBlob(InputDataID);
+  Expected<cas::LeafNodeProxy> Blob = CAS.getBlob(InputDataID);
   if (Blob)
     return Blob->getData();
   return Blob.takeError();
@@ -228,8 +227,9 @@ bool DependencyScanningCASFilesystem::shouldScanForDirectives(
   return shouldScanForDirectivesBasedOnExtension(RawFilename);
 }
 
-cas::CachingOnDiskFileSystem &DependencyScanningCASFilesystem::getCachingFS() {
-  return static_cast<cas::CachingOnDiskFileSystem &>(*FS);
+llvm::cas::CachingOnDiskFileSystem &
+DependencyScanningCASFilesystem::getCachingFS() {
+  return static_cast<llvm::cas::CachingOnDiskFileSystem &>(*FS);
 }
 
 DependencyScanningCASFilesystem::LookupPathResult

--- a/clang/unittests/CAS/CASOptionsTest.cpp
+++ b/clang/unittests/CAS/CASOptionsTest.cpp
@@ -20,6 +20,7 @@
 
 using namespace llvm;
 using namespace clang;
+using namespace clang::cas;
 
 namespace {
 
@@ -43,7 +44,7 @@ TEST(CASOptionsTest, getOrCreateCAS) {
 
   // Create an in-memory CAS.
   CASOptions Opts;
-  std::shared_ptr<cas::CASDB> InMemory = Opts.getOrCreateCAS(Diags);
+  std::shared_ptr<CASDB> InMemory = Opts.getOrCreateCAS(Diags);
   ASSERT_TRUE(InMemory);
   EXPECT_EQ(InMemory, Opts.getOrCreateCAS(Diags));
   EXPECT_EQ(CASOptions::InMemoryCAS, Opts.getKind());
@@ -52,14 +53,14 @@ TEST(CASOptionsTest, getOrCreateCAS) {
   // Create an on-disk CAS.
   unittest::TempDir Dir("cas-options", /*Unique=*/true);
   Opts.CASPath = Dir.path("cas").str().str();
-  std::shared_ptr<cas::CASDB> OnDisk = Opts.getOrCreateCAS(Diags);
+  std::shared_ptr<CASDB> OnDisk = Opts.getOrCreateCAS(Diags);
   EXPECT_NE(InMemory, OnDisk);
   EXPECT_EQ(OnDisk, Opts.getOrCreateCAS(Diags));
   EXPECT_EQ(CASOptions::OnDiskCAS, Opts.getKind());
 
   // Create an on-disk CAS at an automatic location.
   Opts.CASPath = "auto";
-  std::shared_ptr<cas::CASDB> OnDiskAuto = Opts.getOrCreateCAS(Diags);
+  std::shared_ptr<CASDB> OnDiskAuto = Opts.getOrCreateCAS(Diags);
   EXPECT_NE(InMemory, OnDiskAuto);
   EXPECT_NE(OnDisk, OnDiskAuto);
   EXPECT_EQ(OnDiskAuto, Opts.getOrCreateCAS(Diags));
@@ -67,7 +68,7 @@ TEST(CASOptionsTest, getOrCreateCAS) {
 
   // Create another in-memory CAS. It won't be the same one.
   Opts.CASPath = "";
-  std::shared_ptr<cas::CASDB> InMemory2 = Opts.getOrCreateCAS(Diags);
+  std::shared_ptr<CASDB> InMemory2 = Opts.getOrCreateCAS(Diags);
   EXPECT_NE(InMemory, InMemory2);
   EXPECT_NE(OnDisk, InMemory2);
   EXPECT_NE(OnDiskAuto, InMemory2);
@@ -91,7 +92,7 @@ TEST(CASOptionsTest, getOrCreateCASInvalid) {
   Opts.CASPath = File.path().str();
   EXPECT_EQ(nullptr, Opts.getOrCreateCAS(Diags));
 
-  std::shared_ptr<cas::CASDB> Empty =
+  std::shared_ptr<CASDB> Empty =
       Opts.getOrCreateCAS(Diags, /*CreateEmptyCASOnFailure=*/true);
   EXPECT_EQ(Empty, Opts.getOrCreateCAS(Diags));
 
@@ -111,7 +112,7 @@ TEST(CASOptionsTest, getOrCreateCASAndHideConfig) {
   unittest::TempDir Dir("cas-options", /*Unique=*/true);
   CASOptions Opts;
   Opts.CASPath = Dir.path("cas").str().str();
-  std::shared_ptr<cas::CASDB> CAS = Opts.getOrCreateCASAndHideConfig(Diags);
+  std::shared_ptr<CASDB> CAS = Opts.getOrCreateCASAndHideConfig(Diags);
   ASSERT_TRUE(CAS);
   EXPECT_EQ(CASOptions::UnknownCAS, Opts.getKind());
 


### PR DESCRIPTION
`clang::cas` namespace will be useful for encompassing clang-specific CAS-related symbols.