### PR TITLE
[libclang][deps] Add getFileDependencies_v3 that provides whole command lines

### DIFF
--- a/clang/test/ClangScanDeps/modules-outputs-c-api.c
+++ b/clang/test/ClangScanDeps/modules-outputs-c-api.c
@@ -1,0 +1,93 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: c-index-test core -scan-deps %t -output-dir %t/out -- \
+// RUN:   clang_tool -c %t/tu.c -fmodules -fmodules-cache-path=%t/cache \
+// RUN:   -fimplicit-modules -fimplicit-module-maps \
+// RUN:   -serialize-diagnostics %t/tu.diag -MD -MF %t/tu.d -o %t/tu.o \
+// RUN: | FileCheck %s -DPREFIX=%/t -check-prefix=NONE
+
+// NONE:        build-args:
+// NONE-NOT:      -MT
+// NONE-NOT:      -serialize-diagnostics-file
+// NONE-NOT:      -dependency-file
+// NONE:      build-args:
+// NONE-SAME:   -fmodule-file=[[PREFIX]]/out/Mod_{{.*}}.pcm
+
+// RUN: c-index-test core -scan-deps %t -output-dir %t/out -serialize-diagnostics -- \
+// RUN:   clang_tool -c %t/tu.c -fmodules -fmodules-cache-path=%t/cache \
+// RUN:   -fimplicit-modules -fimplicit-module-maps \
+// RUN:   -serialize-diagnostics %t/tu.diag -MD -MF %t/tu.d -o %t/tu.o \
+// RUN: | FileCheck %s -DPREFIX=%/t -check-prefix=DIAGS
+
+// DIAGS:        build-args:
+// DIAGS-NOT:      -MT
+// DIAGS-NOT:      -dependency-file
+// DIAGS-SAME:     -serialize-diagnostic-file [[PREFIX]]/out/Mod_{{.*}}.diag
+// DIAGS-NOT:      -MT
+// DIAGS-NOT:      -dependency-file
+// DIAGS:      build-args:
+// DIAGS-SAME:   -fmodule-file=[[PREFIX]]/out/Mod_{{.*}}.pcm
+
+// RUN: c-index-test core -scan-deps %t -output-dir %t/out -dependency-file -- \
+// RUN:   clang_tool -c %t/tu.c -fmodules -fmodules-cache-path=%t/cache \
+// RUN:   -fimplicit-modules -fimplicit-module-maps \
+// RUN:   -serialize-diagnostics %t/tu.diag -MD -MF %t/tu.d -o %t/tu.o \
+// RUN: | FileCheck %s -DPREFIX=%/t -check-prefix=DEPS
+
+// DEPS:        build-args:
+// DEPS-NOT:      -serialize-diagnostic-file
+// DEPS-SAME:     -MT [[PREFIX]]/out/Mod_{{.*}}.pcm
+// DEPS-NOT:      -serialize-diagnostic-file
+// DEPS-SAME:     -dependency-file [[PREFIX]]/out/Mod_{{.*}}.d
+// DEPS-NOT:      -serialize-diagnostic-file
+// DEPS:      build-args:
+// DEPS-SAME:   -fmodule-file=[[PREFIX]]/out/Mod_{{.*}}.pcm
+
+// RUN: c-index-test core -scan-deps %t -output-dir %t/out -dependency-file -dependency-target foo -- \
+// RUN:   clang_tool -c %t/tu.c -fmodules -fmodules-cache-path=%t/cache \
+// RUN:   -fimplicit-modules -fimplicit-module-maps \
+// RUN:   -serialize-diagnostics %t/tu.diag -MD -MF %t/tu.d -o %t/tu.o \
+// RUN: | FileCheck %s -DPREFIX=%/t -check-prefix=DEPS_MT1
+
+// DEPS_MT1:        build-args:
+// DEPS_MT1-NOT:      -serialize-diagnostic-file
+// DEPS_MT1-SAME:     -MT foo
+// DEPS_MT1-NOT:      -serialize-diagnostic-file
+// DEPS_MT1:      build-args:
+// DEPS_MT1-SAME:   -fmodule-file=[[PREFIX]]/out/Mod_{{.*}}.pcm
+
+// RUN: c-index-test core -scan-deps %t -output-dir %t/out -dependency-file -dependency-target foo -dependency-target bar -- \
+// RUN:   clang_tool -c %t/tu.c -fmodules -fmodules-cache-path=%t/cache \
+// RUN:   -fimplicit-modules -fimplicit-module-maps \
+// RUN:   -serialize-diagnostics %t/tu.diag -MD -MF %t/tu.d -o %t/tu.o \
+// RUN: | FileCheck %s -DPREFIX=%/t -check-prefix=DEPS_MT2
+
+// DEPS_MT2:        build-args:
+// DEPS_MT2-NOT:      -serialize-diagnostic-file
+// DEPS_MT2-SAME:     -MT foo
+// DEPS_MT2-SAME:     -MT bar
+// DEPS_MT2-NOT:      -serialize-diagnostic-file
+// DEPS_MT2:      build-args:
+// DEPS_MT2-SAME:   -fmodule-file=[[PREFIX]]/out/Mod_{{.*}}.pcm
+
+// RUN: echo 'this_target_name_is_longer_than_the_256_byte_initial_buffer_size_to_test_that_we_alloc_and_call_again_with_a_sufficient_buffer_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_end' > %t/target-name.txt
+// RUN: cat %t/target-name.txt > %t/long.txt
+// RUN: c-index-test core -scan-deps %t -output-dir %t/out -dependency-file \
+// RUN:     -dependency-target @%t/target-name.txt -- \
+// RUN:   clang_tool -c %t/tu.c -fmodules -fmodules-cache-path=%t/cache \
+// RUN:   -fimplicit-modules -fimplicit-module-maps \
+// RUN:   -serialize-diagnostics %t/tu.diag -MD -MF %t/tu.d -o %t/tu.o \
+// RUN: >> %t/long.txt
+// RUN: FileCheck %s -check-prefix=LONG_OUT < %t/long.txt
+
+// LONG_OUT: [[TARGET:this_target_.*_end]]
+// LONG_OUT: -MT [[TARGET]]
+
+//--- module.modulemap
+module Mod { header "Mod.h" }
+
+//--- Mod.h
+
+//--- tu.c
+#include "Mod.h"

--- a/clang/test/Index/Core/scan-deps-by-mod-name.m
+++ b/clang/test/Index/Core/scan-deps-by-mod-name.m
@@ -1,10 +1,17 @@
 // Use driver arguments.
 // RUN: rm -rf %t.mcp
 // RUN: echo %S > %t.result
-// RUN: c-index-test core --scan-deps-by-mod-name -module-name=ModA %S -- %clang -c -I %S/Inputs/module \
+// RUN: echo %S > %t_v2.result
+//
+// RUN: c-index-test core --scan-deps-by-mod-name -output-dir %t -module-name=ModA %S -- %clang -c -I %S/Inputs/module \
 // RUN:     -fmodules -fmodules-cache-path=%t.mcp \
 // RUN:     -o FoE.o -x objective-c >> %t.result
-// RUN: cat %t.result | sed 's/\\/\//g' | FileCheck %s
+// RUN: cat %t.result | sed 's/\\/\//g' | FileCheck %s -check-prefixes=CHECK,CHECK_V3 -DOUTPUTS=%/t
+//
+// RUN: c-index-test core --scan-deps-by-mod-name -scandeps-v2 -module-name=ModA %S -- %clang -c -I %S/Inputs/module \
+// RUN:     -fmodules -fmodules-cache-path=%t.mcp \
+// RUN:     -o FoE.o -x objective-c >> %t_v2.result
+// RUN: cat %t_v2.result | sed 's/\\/\//g' | FileCheck %s -check-prefixes=CHECK,CHECK_V2
 
 // CHECK: [[PREFIX:.*]]
 // CHECK-NEXT: modules:
@@ -25,3 +32,5 @@
 // CHECK-NEXT:     ModA:[[HASH_MOD_A]]
 // CHECK-NEXT:   file-deps:
 // CHECK-NEXT:   build-args: {{.*}} -fno-implicit-modules -fno-implicit-module-maps
+// CHECK_V3:     -fmodule-file={{.*}}ModA_{{.*}}.pcm
+// CHECK_V2-NOT: -fmodule-file=

--- a/clang/test/Index/Core/scan-deps.m
+++ b/clang/test/Index/Core/scan-deps.m
@@ -1,10 +1,17 @@
 // Use driver arguments.
 // RUN: rm -rf %t.mcp
 // RUN: echo %S > %t.result
-// RUN: c-index-test core --scan-deps %S -- %clang -c -I %S/Inputs/module \
+// RUN: echo %S > %t_v2.result
+//
+// RUN: c-index-test core --scan-deps %S -output-dir=%t -- %clang -c -I %S/Inputs/module \
 // RUN:     -fmodules -fmodules-cache-path=%t.mcp \
 // RUN:     -o FoE.o -x objective-c %s >> %t.result
-// RUN: cat %t.result | sed 's/\\/\//g' | FileCheck %s
+// RUN: cat %t.result | sed 's/\\/\//g' | FileCheck %s -check-prefixes=CHECK,CHECK_V3 -DOUTPUTS=%/t
+//
+// RUN: c-index-test core --scan-deps -scandeps-v2 %S -- %clang -c -I %S/Inputs/module \
+// RUN:     -fmodules -fmodules-cache-path=%t.mcp \
+// RUN:     -o FoE.o -x objective-c %s >> %t_v2.result
+// RUN: cat %t_v2.result | sed 's/\\/\//g' | FileCheck %s -check-prefixes=CHECK,CHECK_V2
 
 @import ModA;
 
@@ -28,3 +35,5 @@
 // CHECK-NEXT:   file-deps:
 // CHECK-NEXT:     [[PREFIX]]/scan-deps.m
 // CHECK-NEXT:   build-args: {{.*}} -fno-implicit-modules -fno-implicit-module-maps
+// CHECK_V3:     -fmodule-file={{.*}}ModA_{{.*}}.pcm
+// CHECK_V2-NOT: -fmodule-file=

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -661,7 +661,8 @@ static void printSymbolNameAndUSR(const clang::Module *Mod, raw_ostream &OS) {
   generateFullUSRForModule(Mod, OS);
 }
 
-static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory) {
+static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
+                    Optional<std::string> ModuleName = None) {
   CXDependencyScannerService Service =
       clang_experimental_DependencyScannerService_create_v0(
           CXDependencyMode_Full);
@@ -698,82 +699,18 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory) {
   auto CB =
       functionObjectToCCallbackRef<void(CXModuleDependencySet *)>(Callback);
 
-  CXFileDependencies *Result =
-      clang_experimental_DependencyScannerWorker_getFileDependencies_v2(
-          Worker, Args.size(), Args.data(), WorkingDirectory.c_str(),
-          CB.Callback, CB.Context, &Error);
-  if (!Result) {
-    llvm::errs() << "error: failed to get dependencies\n";
-    llvm::errs() << clang_getCString(Error) << "\n";
-    clang_disposeString(Error);
-    return 1;
-  }
-  llvm::outs() << "dependencies:\n";
-  llvm::outs() << "  context-hash: " << clang_getCString(Result->ContextHash)
-               << "\n"
-               << "  module-deps:\n";
-  for (const auto &ModuleName : llvm::makeArrayRef(Result->ModuleDeps->Strings,
-                                                   Result->ModuleDeps->Count))
-    llvm::outs() << "    " << clang_getCString(ModuleName) << "\n";
-  llvm::outs() << "  file-deps:\n";
-  for (const auto &FileName :
-       llvm::makeArrayRef(Result->FileDeps->Strings, Result->FileDeps->Count))
-    llvm::outs() << "    " << clang_getCString(FileName) << "\n";
-  llvm::outs() << "  build-args:";
-  for (const auto &Arg : llvm::makeArrayRef(Result->BuildArguments->Strings,
-                                            Result->BuildArguments->Count))
-    llvm::outs() << " " << clang_getCString(Arg);
-  llvm::outs() << "\n";
-
-  clang_experimental_FileDependencies_dispose(Result);
-  clang_experimental_DependencyScannerWorker_dispose_v0(Worker);
-  clang_experimental_DependencyScannerService_dispose_v0(Service);
-  return 0;
-}
-
-static int scanDepsByModuleName(ArrayRef<const char *> Args,
-                                std::string WorkingDirectory,
-                                std::string ModuleName) {
-  CXDependencyScannerService Service =
-      clang_experimental_DependencyScannerService_create_v0(
-          CXDependencyMode_Full);
-  CXDependencyScannerWorker Worker =
-      clang_experimental_DependencyScannerWorker_create_v0(Service);
-  CXString Error;
-
-  auto Callback = [&](CXModuleDependencySet *MDS) {
-    llvm::outs() << "modules:\n";
-    for (const auto &M : llvm::makeArrayRef(MDS->Modules, MDS->Count)) {
-      llvm::outs() << "  module:\n"
-                   << "    name: " << clang_getCString(M.Name) << "\n"
-                   << "    context-hash: " << clang_getCString(M.ContextHash)
-                   << "\n"
-                   << "    module-map-path: "
-                   << clang_getCString(M.ModuleMapPath) << "\n"
-                   << "    module-deps:\n";
-      for (const auto &ModuleName :
-           llvm::makeArrayRef(M.ModuleDeps->Strings, M.ModuleDeps->Count))
-        llvm::outs() << "      " << clang_getCString(ModuleName) << "\n";
-      llvm::outs() << "    file-deps:\n";
-      for (const auto &FileName :
-           llvm::makeArrayRef(M.FileDeps->Strings, M.FileDeps->Count))
-        llvm::outs() << "      " << clang_getCString(FileName) << "\n";
-      llvm::outs() << "    build-args:";
-      for (const auto &Arg : llvm::makeArrayRef(M.BuildArguments->Strings,
-                                                M.BuildArguments->Count))
-        llvm::outs() << " " << clang_getCString(Arg);
-      llvm::outs() << "\n";
-    }
-    clang_experimental_ModuleDependencySet_dispose(MDS);
-  };
-
-  auto CB =
-      functionObjectToCCallbackRef<void(CXModuleDependencySet *)>(Callback);
-
-  CXFileDependencies *Result =
+  CXFileDependencies *Result = nullptr;
+  if (ModuleName) {
+    Result =
       clang_experimental_DependencyScannerWorker_getDependenciesByModuleName_v0(
-          Worker, Args.size(), Args.data(), ModuleName.c_str(),
-          WorkingDirectory.c_str(), CB.Callback, CB.Context, &Error);
+            Worker, Args.size(), Args.data(), ModuleName->c_str(),
+            WorkingDirectory.c_str(), CB.Callback, CB.Context, &Error);
+  } else {
+    Result = clang_experimental_DependencyScannerWorker_getFileDependencies_v2(
+        Worker, Args.size(), Args.data(), WorkingDirectory.c_str(), CB.Callback,
+        CB.Context, &Error);
+  }
+
   if (!Result) {
     llvm::errs() << "error: failed to get dependencies\n";
     llvm::errs() << clang_getCString(Error) << "\n";
@@ -1122,8 +1059,7 @@ int indextest_core_main(int argc, const char **argv) {
       errs() << "error: missing module name\n";
       return 1;
     }
-    return scanDepsByModuleName(CompArgs, options::InputFiles[0],
-                                options::ModuleName);
+    return scanDeps(CompArgs, options::InputFiles[0], options::ModuleName);
   }
 
   if (options::Action == ActionType::WatchDir) {

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -123,6 +123,21 @@ FilePathAndRange("filepath",
 static cl::opt<std::string>
     ModuleName("module-name", cl::desc("name of the module, of which we are "
                                        "getting file and module dependencies"));
+
+static cl::opt<std::string>
+    OutputDir("output-dir", cl::desc("directory for module output files "
+                                     "(defaults 'module-outputs')"));
+static cl::opt<bool> UseScanDepsV2("scandeps-v2",
+                                   cl::desc("use the old v2 scandeps API"));
+static cl::opt<bool>
+    SerializeDiags("serialize-diagnostics",
+                   cl::desc("module builds should serialize diagnostics"));
+static cl::opt<bool>
+    DependencyFile("dependency-file",
+                   cl::desc("module builds should write dependency files"));
+static cl::list<std::string> DependencyTargets(
+    "dependency-target",
+    cl::desc("module builds should use the given dependency target(s)"));
 }
 } // anonymous namespace
 
@@ -662,6 +677,9 @@ static void printSymbolNameAndUSR(const clang::Module *Mod, raw_ostream &OS) {
 }
 
 static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
+                    bool SerializeDiags, bool DependencyFile,
+                    ArrayRef<std::string> DepTargets, bool UseV2API,
+                    std::string OutputPath,
                     Optional<std::string> ModuleName = None) {
   CXDependencyScannerService Service =
       clang_experimental_DependencyScannerService_create_v0(
@@ -699,16 +717,59 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
   auto CB =
       functionObjectToCCallbackRef<void(CXModuleDependencySet *)>(Callback);
 
+  auto LookupOutput = [&](const char *ModuleName, const char *ContextHash,
+                          CXOutputKind Kind, char *Output, size_t MaxLen) {
+    std::string Out = OutputPath + "/" + ModuleName + "_" + ContextHash;
+    switch (Kind) {
+    case CXOutputKind_ModuleFile:
+      Out += ".pcm";
+      break;
+    case CXOutputKind_Dependencies:
+      if (!DependencyFile)
+        return (size_t)0;
+      Out += ".d";
+      break;
+    case CXOutputKind_DependenciesTarget:
+      if (DepTargets.empty())
+        return (size_t)0;
+      Out = join(DepTargets, StringRef("\0", 1));
+      break;
+    case CXOutputKind_SerializedDiagnostics:
+      if (!SerializeDiags)
+        return (size_t)0;
+      Out += ".diag";
+      break;
+    }
+    if (0 < Out.size() && Out.size() <= MaxLen)
+      memcpy(Output, Out.data(), Out.size());
+    return Out.size();
+  };
+
+  auto LookupOutputCB = functionObjectToCCallbackRef<size_t(
+      const char *ModuleName, const char *ContextHash, CXOutputKind Kind,
+      char *Output, size_t MaxLen)>(LookupOutput);
+
+
   CXFileDependencies *Result = nullptr;
-  if (ModuleName) {
-    Result =
-      clang_experimental_DependencyScannerWorker_getDependenciesByModuleName_v0(
-            Worker, Args.size(), Args.data(), ModuleName->c_str(),
-            WorkingDirectory.c_str(), CB.Callback, CB.Context, &Error);
+  if (UseV2API) {
+    if (ModuleName) {
+      Result =
+          clang_experimental_DependencyScannerWorker_getDependenciesByModuleName_v0(
+              Worker, Args.size(), Args.data(), ModuleName->c_str(),
+              WorkingDirectory.c_str(), CB.Callback, CB.Context, &Error);
+    } else {
+      Result =
+          clang_experimental_DependencyScannerWorker_getFileDependencies_v2(
+              Worker, Args.size(), Args.data(), WorkingDirectory.c_str(),
+              CB.Callback, CB.Context, &Error);
+    }
   } else {
-    Result = clang_experimental_DependencyScannerWorker_getFileDependencies_v2(
-        Worker, Args.size(), Args.data(), WorkingDirectory.c_str(), CB.Callback,
-        CB.Context, &Error);
+    // Current API
+    Result = clang_experimental_DependencyScannerWorker_getFileDependencies_v3(
+        Worker, Args.size(), Args.data(),
+        ModuleName ? ModuleName->c_str() : nullptr, WorkingDirectory.c_str(),
+        CB.Context, CB.Callback, LookupOutputCB.Context,
+        LookupOutputCB.Callback, /*Options=*/0, &Error);
   }
 
   if (!Result) {
@@ -1046,7 +1107,9 @@ int indextest_core_main(int argc, const char **argv) {
       errs() << "error: missing working directory\n";
       return 1;
     }
-    return scanDeps(CompArgs, options::InputFiles[0]);
+    return scanDeps(CompArgs, options::InputFiles[0], options::SerializeDiags,
+                    options::DependencyFile, options::DependencyTargets,
+                    options::UseScanDepsV2, options::OutputDir);
   }
 
   if (options::Action == ActionType::ScanDepsByModuleName) {
@@ -1059,7 +1122,10 @@ int indextest_core_main(int argc, const char **argv) {
       errs() << "error: missing module name\n";
       return 1;
     }
-    return scanDeps(CompArgs, options::InputFiles[0], options::ModuleName);
+    return scanDeps(CompArgs, options::InputFiles[0], options::SerializeDiags,
+                    options::DependencyFile, options::DependencyTargets,
+                    options::UseScanDepsV2, options::OutputDir,
+                    options::ModuleName);
   }
 
   if (options::Action == ActionType::WatchDir) {

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -280,6 +280,7 @@ LLVM_13 {
     clang_experimental_DependencyScannerWorker_create_v0;
     clang_experimental_DependencyScannerWorker_dispose_v0;
     clang_experimental_DependencyScannerWorker_getFileDependencies_v2;
+    clang_experimental_DependencyScannerWorker_getFileDependencies_v3;
     clang_experimental_DependencyScannerWorker_getDependenciesByModuleName_v0;
     clang_experimental_FileDependencies_dispose;
     clang_experimental_ModuleDependencySet_dispose;


### PR DESCRIPTION
Add `clang_experimental_DependencyScannerWorker_getFileDependencies_v3`
to provide `CXFileDependencies` that contain complete command-lines that
do not require additional modifications by the client. The per-module
arguments like `-o`, and `-fmodule-file=` are constructed using a
callback to the client to choose the specific paths while allowing
libclang to choose how they will be spelled in the command-line, if
needed. Optional outputs like dependency files can be removed if they
are not needed for the module builds.

Incidentally, the new API also takes an optional ModuleName allowing it
to perform the functionality previously provided by
`getDependenciesByModuleName_v0`.