### PR TITLE
[lldb] Be aware of async functions in the form of closures

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -82,9 +82,17 @@ static bool IsSwiftAsyncFunctionSymbol(swift::Demangle::NodePointer node) {
     return false;
   if (hasChild(node, Node::Kind::AsyncSuspendResumePartialFunction))
     return false;
-  if (node->getFirstChild()->getKind() == Node::Kind::Static)
-    // Traverse forward to the static node, to handle static functions.
+
+  // Peel off layers over top of Function nodes.
+  switch (node->getFirstChild()->getKind()) {
+  case Node::Kind::Static:
+  case Node::Kind::ExplicitClosure:
     node = node->getFirstChild();
+    break;
+  default:
+    break;
+  }
+
   return childAtPath(node,
                      {Node::Kind::Function, Node::Kind::Type,
                       Node::Kind::FunctionType, Node::Kind::AsyncAnnotation}) ||

--- a/lldb/test/API/lang/swift/async/async_fnargs/TestSwiftAsyncFnArgs.py
+++ b/lldb/test/API/lang/swift/async/async_fnargs/TestSwiftAsyncFnArgs.py
@@ -18,13 +18,6 @@ class TestSwiftAsyncFnArgs(lldbtest.TestBase):
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', src)
 
-        self.expect("frame var -d run-target -- msg", substrs=['"world"'])
-
-        # Continue into the second coroutine funclet.
-        bkpt2 = target.BreakpointCreateBySourceRegex("And also here", src, None)
-        self.assertGreater(bkpt2.GetNumLocations(), 0)
-        process.Continue()
-        self.assertEqual(
-             len(lldbutil.get_threads_stopped_at_breakpoint(process, bkpt2)), 1)
-
-        self.expect("frame var -d run-target -- msg", substrs=['"world"'])
+        while process.selected_thread.stop_reason == lldb.eStopReasonBreakpoint:
+            self.expect("frame var -d run-target msg", patterns=['"(basic|generic|static|closure) world"'])
+            process.Continue()

--- a/lldb/test/API/lang/swift/async/async_fnargs/main.swift
+++ b/lldb/test/API/lang/swift/async/async_fnargs/main.swift
@@ -5,15 +5,37 @@ func sayHello() async {
   print("hello")
 }
 
+func sayBasic(_ msg: String) async {
+  print("Set breakpoint here")
+  await sayHello()
+  print(msg) // Set breakpoint here
+}
+
 func sayGeneric<T>(_ msg: T) async {
   print("Set breakpoint here")
   await sayHello()
-  print(msg) // And also here.
+  print(msg) // Set breakpoint here
+}
+
+struct Struct {
+  static func sayStatic(_ msg: String) async {
+    print("Set breakpoint here")
+    await sayHello()
+    print(msg) // Set breakpoint here
+  }
 }
 
 @main struct Main {
   static func main() async {
-    await sayHello()
-    await sayGeneric("world")
+    let closure = { msg in
+      print("Set breakpoint here")
+      await sayHello()
+      print(msg) // Set breakpoint here
+    }
+
+    await sayBasic("basic world")
+    await sayGeneric("generic world")
+    await Struct.sayStatic("static world")
+    await closure("closure world")
   }
 }


### PR DESCRIPTION
Recognize async closures as being async, in `IsSwiftAsyncFunctionSymbol`. Like `static` functions, this requires peeling off a wrapper node to get to the `Function` node.

rdar://94840584