### PR TITLE
[lldb] XFAIL TestVSCode_breakpointEvents.py on Ventura

### DIFF
--- a/lldb/test/API/lang/objcxx/cxx-bridged-po/TestObjCXXBridgedPO.py
+++ b/lldb/test/API/lang/objcxx/cxx-bridged-po/TestObjCXXBridgedPO.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestObjCXXBridgedPO(TestBase):
 
+    @expectedFailureAll(macos_version=[">=", "10.16"]) # rdar://96224141
     def test_bridged_type_po(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/objcxx/cxx-bridged-po/TestObjCXXBridgedPO.py
+++ b/lldb/test/API/lang/objcxx/cxx-bridged-po/TestObjCXXBridgedPO.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestObjCXXBridgedPO(TestBase):
 
-    @expectedFailureAll(macos_version=[">=", "10.16"]) # rdar://96224141
+    @expectedFailureAll(macos_version=[">=", "13.0"]) # rdar://96224141
     def test_bridged_type_po(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/tools/lldb-vscode/breakpoint-events/TestVSCode_breakpointEvents.py
+++ b/lldb/test/API/tools/lldb-vscode/breakpoint-events/TestVSCode_breakpointEvents.py
@@ -16,6 +16,7 @@ class TestVSCode_breakpointEvents(lldbvscode_testcase.VSCodeTestCaseBase):
 
     @skipIfWindows
     @skipUnlessDarwin
+    @expectedFailureAll(macos_version=[">=", "10.16"])
     def test_breakpoint_events(self):
         '''
             This test sets a breakpoint in a shared library and runs and stops

--- a/lldb/test/API/tools/lldb-vscode/breakpoint-events/TestVSCode_breakpointEvents.py
+++ b/lldb/test/API/tools/lldb-vscode/breakpoint-events/TestVSCode_breakpointEvents.py
@@ -16,7 +16,7 @@ class TestVSCode_breakpointEvents(lldbvscode_testcase.VSCodeTestCaseBase):
 
     @skipIfWindows
     @skipUnlessDarwin
-    @expectedFailureAll(macos_version=[">=", "10.16"])
+    @expectedFailureAll(macos_version=[">=", "13.0"])
     def test_breakpoint_events(self):
         '''
             This test sets a breakpoint in a shared library and runs and stops


### PR DESCRIPTION
TestVSCode_breakpointEvents.py is failing on macOS Ventura because we
receive 3 breakpoint events instead of one. This is likely the result of
dyld moving into the shared cache.

(cherry picked from commit 65a7ebff33428f1b9941e23fd79167d30d642b7b)
