### PR TITLE
[lldb] Restore missing call to ThreadPlanStack::SetTID

### DIFF
--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1353,6 +1353,7 @@ ThreadPlanSP Process::DoesStackExplainStopNoLock(ThreadPlanStack &stack,
   ThreadPlanSP plan_sp = stack.GetCurrentPlan();
   plan_sp->SetTID(thread.GetID());
   if (plan_sp->DoPlanExplainsStop(event_ptr)) {
+    stack.SetTID(thread.GetID());
     m_thread_plans.Activate(stack);
     return plan_sp;
   }


### PR DESCRIPTION
This call to `ThreadPlanStack::SetTID` seems to have been unintentionally deleted in https://github.com/apple/llvm-project/pull/3172. This call sets the TID of all thread plans in the stack, and must be called before calling `Activate`.

This resulted in downstream misbehavior, one example of which is in `ThreadPlanStackMap::Update` where a base plan was being queued multiple times on to the same plan stack because the TID wasn't correct.

https://github.com/apple/llvm-project/blob/be3823b722c461f7c11f81601e33a3e53ea76565/lldb/source/Target/ThreadPlanStack.cpp#L418-L422

rdar://96534399
(cherry-picked from commit 24f473760905d40283d01085f1e2d7fd29f3ffca)