### PR TITLE
[lldb] Call ClearThreadCache after changing ThreadPlan TID

### DIFF
--- a/lldb/include/lldb/Target/ThreadPlan.h
+++ b/lldb/include/lldb/Target/ThreadPlan.h
@@ -485,9 +485,19 @@ public:
 
   bool IsTID(lldb::tid_t tid) { return tid == m_tid; }
   bool HasTID() { return m_tid != LLDB_INVALID_THREAD_ID; }
-  void ClearTID() { m_tid = LLDB_INVALID_THREAD_ID; }
   lldb::tid_t GetTID() { return m_tid; }
-  void SetTID(lldb::tid_t tid) { m_tid = tid; }
+
+  void SetTID(lldb::tid_t tid) {
+    if (m_tid != tid) {
+      m_tid = tid;
+      ClearThreadCache();
+    }
+  }
+
+  void ClearTID() {
+    m_tid = LLDB_INVALID_THREAD_ID;
+    ClearThreadCache();
+  }
 
   friend lldb::ThreadPlanSP
   Process::DoesStackExplainStopNoLock(ThreadPlanStack &stack, Thread &thread,


### PR DESCRIPTION
`ThreadPlan`s have a TID field, but also have a `Thread` field where the thread for the TID is "cached". When assigning or clearing the TID, the `m_thread` field needs to be cleared. This can cause issues in particular with async code, where thread plans move from one thread to another.
