### PR TITLE
Enhance FileSystem related APIs to be able to cache and provide the `cas::ObjectRef` for a file's contents

### DIFF
--- a/clang/include/clang/Basic/FileManager.h
+++ b/clang/include/clang/Basic/FileManager.h
@@ -287,7 +287,7 @@ public:
   /// file. If both the buffer and its `cas::ObjectRef` are needed use \p
   /// getBufferForFile to avoid the extra file lookup.
   llvm::ErrorOr<Optional<cas::ObjectRef>>
-  getCASContentsForFile(const Twine &Filename);
+  getObjectRefForFileContent(const Twine &Filename);
 
 private:
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>

--- a/clang/include/clang/Basic/FileManager.h
+++ b/clang/include/clang/Basic/FileManager.h
@@ -272,18 +272,21 @@ public:
   /// MemoryBuffer if successful, otherwise returning null.
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
   getBufferForFile(const FileEntry *Entry, bool isVolatile = false,
-                   bool RequiresNullTerminator = true);
+                   bool RequiresNullTerminator = true,
+                   Optional<cas::ObjectRef> *CASContents = nullptr);
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
   getBufferForFile(StringRef Filename, bool isVolatile = false,
-                   bool RequiresNullTerminator = true) {
+                   bool RequiresNullTerminator = true,
+                   Optional<cas::ObjectRef> *CASContents = nullptr) {
     return getBufferForFileImpl(Filename, /*FileSize=*/-1, isVolatile,
-                                RequiresNullTerminator);
+                                RequiresNullTerminator, CASContents);
   }
 
 private:
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
   getBufferForFileImpl(StringRef Filename, int64_t FileSize, bool isVolatile,
-                       bool RequiresNullTerminator);
+                       bool RequiresNullTerminator,
+                       Optional<cas::ObjectRef> *CASContents);
 
 public:
   /// Get the 'stat' information for the given \p Path.

--- a/clang/include/clang/Basic/FileManager.h
+++ b/clang/include/clang/Basic/FileManager.h
@@ -282,6 +282,13 @@ public:
                                 RequiresNullTerminator, CASContents);
   }
 
+  /// This is a convenience method that opens a file, gets the \p cas::ObjectRef
+  /// for its contents if supported by the file system, and then closes the
+  /// file. If both the buffer and its `cas::ObjectRef` are needed use \p
+  /// getBufferForFile to avoid the extra file lookup.
+  llvm::ErrorOr<Optional<cas::ObjectRef>>
+  getCASContentsForFile(const Twine &Filename);
+
 private:
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
   getBufferForFileImpl(StringRef Filename, int64_t FileSize, bool isVolatile,

--- a/clang/include/clang/Lex/PTHManager.h
+++ b/clang/include/clang/Lex/PTHManager.h
@@ -98,7 +98,7 @@ class PTHManager {
   llvm::SpecificBumpPtrAllocator<IdentifierInfo *> IdentifierInfoCacheAlloc;
 
   llvm::cas::CASDB &CAS;
-  IntrusiveRefCntPtr<llvm::cas::CASFileSystemBase> FS;
+  IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS;
   LangOptions CanonicalLangOpts;
   Optional<llvm::cas::CASID> SerializedLangOpts;
   Optional<llvm::cas::CASID> ClangVersion;
@@ -121,8 +121,7 @@ public:
   PTHManager() = delete;
 
   PTHManager(llvm::cas::CASDB &CAS,
-             IntrusiveRefCntPtr<llvm::cas::CASFileSystemBase> FS,
-             Preprocessor &PP);
+             IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS, Preprocessor &PP);
 
   void setPreprocessor(Preprocessor *pp) { PP = pp; }
 

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
@@ -31,15 +31,12 @@ namespace clang {
 namespace tooling {
 namespace dependencies {
 
-class DependencyScanningCASFilesystem : public llvm::cas::CASFileSystemBase {
+class DependencyScanningCASFilesystem : public llvm::cas::ThreadSafeFileSystem {
 public:
   DependencyScanningCASFilesystem(
       IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> WorkerFS);
 
   ~DependencyScanningCASFilesystem();
-
-  llvm::cas::CASDB &getCAS() const override { return FS->getCAS(); }
-  Optional<llvm::cas::CASID> getFileCASID(const Twine &Path) override;
 
   // FIXME: Make a templated version of ProxyFileSystem with a configurable
   // base class.
@@ -76,7 +73,7 @@ private:
   /// Check whether the file should be scanned for preprocessor directives.
   bool shouldScanForDirectives(StringRef Filename);
 
-  IntrusiveRefCntPtr<llvm::cas::CASFileSystemBase> FS;
+  IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS;
 
   struct FileEntry {
     std::error_code EC; // If non-zero, caches a stat failure.
@@ -84,7 +81,7 @@ private:
     SmallVector<dependency_directives_scan::Token, 64> DepTokens;
     SmallVector<dependency_directives_scan::Directive, 16> DepDirectives;
     llvm::vfs::Status Status;
-    Optional<llvm::cas::CASID> ID;
+    Optional<llvm::cas::ObjectRef> CASContents;
   };
   llvm::BumpPtrAllocator EntryAlloc;
   llvm::StringMap<FileEntry, llvm::BumpPtrAllocator&> Entries;

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningFilesystem.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningFilesystem.h
@@ -91,7 +91,7 @@ public:
     return Contents->Original->getBuffer();
   }
 
-  Optional<cas::ObjectRef> getCASContents() const {
+  Optional<cas::ObjectRef> getObjectRefForContent() const {
     assert(!isError() && "error");
     assert(!MaybeStat->isDirectory() && "not a file");
     assert(Contents && "contents not initialized");
@@ -275,8 +275,8 @@ public:
   }
 
   StringRef getContents() const { return Entry.getOriginalContents(); }
-  Optional<cas::ObjectRef> getCASContents() const {
-    return Entry.getCASContents();
+  Optional<cas::ObjectRef> getObjectRefForContent() const {
+    return Entry.getObjectRefForContent();
   }
 
   Optional<ArrayRef<dependency_directives_scan::Directive>>

--- a/clang/lib/Basic/FileManager.cpp
+++ b/clang/lib/Basic/FileManager.cpp
@@ -609,6 +609,17 @@ FileManager::getBufferForFileImpl(StringRef Filename, int64_t FileSize,
                               isVolatile, CASContents);
 }
 
+llvm::ErrorOr<Optional<cas::ObjectRef>>
+FileManager::getCASContentsForFile(const Twine &Filename) {
+  if (FileSystemOpts.WorkingDir.empty())
+    return FS->getCASContentsForFile(Filename);
+
+  SmallString<128> FilePath;
+  Filename.toVector(FilePath);
+  FixupRelativePath(FilePath);
+  return FS->getCASContentsForFile(FilePath);
+}
+
 /// getStatValue - Get the 'stat' information for the specified path,
 /// using the cache to accelerate it if possible.  This returns true
 /// if the path points to a virtual file or does not exist, or returns

--- a/clang/lib/Basic/FileManager.cpp
+++ b/clang/lib/Basic/FileManager.cpp
@@ -581,7 +581,7 @@ FileManager::getBufferForFile(const FileEntry *Entry, bool isVolatile,
     auto Result = Entry->File->getBuffer(Filename, FileSize,
                                          RequiresNullTerminator, isVolatile);
     if (CASContents) {
-      auto CASRef = Entry->File->getCASContents();
+      auto CASRef = Entry->File->getObjectRefForContent();
       if (!CASRef)
         return CASRef.getError();
       *CASContents = *CASRef;
@@ -610,14 +610,14 @@ FileManager::getBufferForFileImpl(StringRef Filename, int64_t FileSize,
 }
 
 llvm::ErrorOr<Optional<cas::ObjectRef>>
-FileManager::getCASContentsForFile(const Twine &Filename) {
+FileManager::getObjectRefForFileContent(const Twine &Filename) {
   if (FileSystemOpts.WorkingDir.empty())
-    return FS->getCASContentsForFile(Filename);
+    return FS->getObjectRefForFileContent(Filename);
 
   SmallString<128> FilePath;
   Filename.toVector(FilePath);
   FixupRelativePath(FilePath);
-  return FS->getCASContentsForFile(FilePath);
+  return FS->getObjectRefForFileContent(FilePath);
 }
 
 /// getStatValue - Get the 'stat' information for the specified path,

--- a/clang/lib/Basic/FileManager.cpp
+++ b/clang/lib/Basic/FileManager.cpp
@@ -21,6 +21,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/Statistic.h"
+#include "llvm/CAS/CASReference.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -562,7 +563,8 @@ void FileManager::fillRealPathName(FileEntry *UFE, llvm::StringRef FileName) {
 
 llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
 FileManager::getBufferForFile(const FileEntry *Entry, bool isVolatile,
-                              bool RequiresNullTerminator) {
+                              bool RequiresNullTerminator,
+                              Optional<cas::ObjectRef> *CASContents) {
   // If the content is living on the file entry, return a reference to it.
   if (Entry->Content)
     return llvm::MemoryBuffer::getMemBuffer(Entry->Content->getMemBufferRef());
@@ -578,27 +580,33 @@ FileManager::getBufferForFile(const FileEntry *Entry, bool isVolatile,
   if (Entry->File) {
     auto Result = Entry->File->getBuffer(Filename, FileSize,
                                          RequiresNullTerminator, isVolatile);
+    if (CASContents) {
+      auto CASRef = Entry->File->getCASContents();
+      if (!CASRef)
+        return CASRef.getError();
+      *CASContents = *CASRef;
+    }
     Entry->closeFile();
     return Result;
   }
 
   // Otherwise, open the file.
   return getBufferForFileImpl(Filename, FileSize, isVolatile,
-                              RequiresNullTerminator);
+                              RequiresNullTerminator, CASContents);
 }
 
 llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
 FileManager::getBufferForFileImpl(StringRef Filename, int64_t FileSize,
-                                  bool isVolatile,
-                                  bool RequiresNullTerminator) {
+                                  bool isVolatile, bool RequiresNullTerminator,
+                                  Optional<cas::ObjectRef> *CASContents) {
   if (FileSystemOpts.WorkingDir.empty())
     return FS->getBufferForFile(Filename, FileSize, RequiresNullTerminator,
-                                isVolatile);
+                                isVolatile, CASContents);
 
   SmallString<128> FilePath(Filename);
   FixupRelativePath(FilePath);
   return FS->getBufferForFile(FilePath, FileSize, RequiresNullTerminator,
-                              isVolatile);
+                              isVolatile, CASContents);
 }
 
 /// getStatValue - Get the 'stat' information for the specified path,

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -469,9 +469,8 @@ void CompilerInstance::createPreprocessor(TranslationUnitKind TUKind) {
     // token-caching can fall back to ingesting into an in-memory CAS itself.
     llvm::vfs::FileSystem &FS = getFileManager().getVirtualFileSystem();
     if (FS.isCASFS())
-      PP->setPTHManager(std::make_unique<PTHManager>(
-          getOrCreateCAS(), &static_cast<llvm::cas::CASFileSystemBase &>(FS),
-          *PP));
+      PP->setPTHManager(
+          std::make_unique<PTHManager>(getOrCreateCAS(), &FS, *PP));
   }
 
   if (PPOpts.DetailedRecord)

--- a/clang/lib/Lex/PTHLexer.cpp
+++ b/clang/lib/Lex/PTHLexer.cpp
@@ -524,7 +524,7 @@ std::unique_ptr<PTHLexer> PTHManager::createLexer(FileID FID) {
   // FIXME: Consider reporting diag::err_invalid_pth_file or similar?
   StringRef Filename = FE->getName();
   if (llvm::ErrorOr<Optional<cas::ObjectRef>> InputRefOrErr =
-          FS->getCASContentsForFile(Filename)) {
+          FS->getObjectRefForFileContent(Filename)) {
     if (Optional<cas::ObjectRef> InputRef = *InputRefOrErr)
       if (Optional<llvm::cas::CASID> PTHFile =
               expectedToOptional(computePTH(CAS.getID(*InputRef))))

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
@@ -318,7 +318,7 @@ public:
     return llvm::MemoryBuffer::getMemBuffer(Buffer, Name.toStringRef(Storage));
   }
 
-  llvm::ErrorOr<Optional<cas::ObjectRef>> getCASContents() override {
+  llvm::ErrorOr<Optional<cas::ObjectRef>> getObjectRefForContent() override {
     return CASContents;
   }
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
@@ -264,7 +264,7 @@ DependencyScanningCASFilesystem::lookupPath(const Twine &Path) {
     return LookupPathResult{nullptr, std::move(MaybeStatus)};
 
   auto &Entry = Entries[PathRef];
-  Entry.ID = *FileID;
+  Entry.CASContents = CAS.getReference(*FileID);
   llvm::ErrorOr<StringRef> Buffer = expectedToErrorOr(getOriginal(*FileID));
   if (!Buffer) {
     // Cache CAS failures. Not going to recover later.
@@ -295,17 +295,6 @@ DependencyScanningCASFilesystem::status(const Twine &Path) {
   return Result.Entry->Status;
 }
 
-Optional<llvm::cas::CASID>
-DependencyScanningCASFilesystem::getFileCASID(const Twine &Path) {
-  LookupPathResult Result = lookupPath(Path);
-  if (!Result.Entry)
-    return None;
-  if (Result.Entry->EC)
-    return None;
-  assert(Result.Entry->ID);
-  return Result.Entry->ID;
-}
-
 IntrusiveRefCntPtr<llvm::cas::ThreadSafeFileSystem>
 DependencyScanningCASFilesystem::createThreadSafeProxyFS() {
   llvm::report_fatal_error("not implemented");
@@ -315,8 +304,10 @@ namespace {
 
 class DepScanFile final : public llvm::vfs::File {
 public:
-  DepScanFile(StringRef Buffer, llvm::vfs::Status Stat)
-      : Buffer(Buffer), Stat(std::move(Stat)) {}
+  DepScanFile(StringRef Buffer, Optional<cas::ObjectRef> CASContents,
+              llvm::vfs::Status Stat)
+      : Buffer(Buffer), CASContents(std::move(CASContents)),
+        Stat(std::move(Stat)) {}
 
   llvm::ErrorOr<llvm::vfs::Status> status() override { return Stat; }
 
@@ -327,10 +318,15 @@ public:
     return llvm::MemoryBuffer::getMemBuffer(Buffer, Name.toStringRef(Storage));
   }
 
+  llvm::ErrorOr<Optional<cas::ObjectRef>> getCASContents() override {
+    return CASContents;
+  }
+
   std::error_code close() override { return {}; }
 
 private:
   StringRef Buffer;
+  Optional<cas::ObjectRef> CASContents;
   llvm::vfs::Status Stat;
 };
 
@@ -349,8 +345,8 @@ DependencyScanningCASFilesystem::openFileForRead(const Twine &Path) {
   if (Result.Entry->EC)
     return Result.Entry->EC;
 
-  return std::make_unique<DepScanFile>(*Result.Entry->Buffer,
-                                       Result.Entry->Status);
+  return std::make_unique<DepScanFile>(
+      *Result.Entry->Buffer, Result.Entry->CASContents, Result.Entry->Status);
 }
 
 Optional<ArrayRef<dependency_directives_scan::Directive>>

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningFilesystem.cpp
@@ -33,11 +33,16 @@ DependencyScanningWorkerFilesystem::readFile(StringRef Filename) {
     return MaybeBuffer.getError();
   auto Buffer = std::move(*MaybeBuffer);
 
+  auto MaybeCASContents = File->getCASContents();
+  if (!MaybeCASContents)
+    return MaybeCASContents.getError();
+  auto CASContents = std::move(*MaybeCASContents);
+
   // If the file size changed between read and stat, pretend it didn't.
   if (Stat.getSize() != Buffer->getBufferSize())
     Stat = llvm::vfs::Status::copyWithNewSize(Stat, Buffer->getBufferSize());
 
-  return TentativeEntry(Stat, std::move(Buffer));
+  return TentativeEntry(Stat, std::move(Buffer), std::move(CASContents));
 }
 
 EntryRef DependencyScanningWorkerFilesystem::scanForDirectivesIfNecessary(
@@ -136,14 +141,15 @@ DependencyScanningFilesystemSharedCache::CacheShard::
 const CachedFileSystemEntry &
 DependencyScanningFilesystemSharedCache::CacheShard::getOrEmplaceEntryForUID(
     llvm::sys::fs::UniqueID UID, llvm::vfs::Status Stat,
-    std::unique_ptr<llvm::MemoryBuffer> Contents) {
+    std::unique_ptr<llvm::MemoryBuffer> Contents,
+    Optional<cas::ObjectRef> CASContents) {
   std::lock_guard<std::mutex> LockGuard(CacheLock);
   auto Insertion = EntriesByUID.insert({UID, nullptr});
   if (Insertion.second) {
     CachedFileContents *StoredContents = nullptr;
     if (Contents)
       StoredContents = new (ContentsStorage.Allocate())
-          CachedFileContents(std::move(Contents));
+          CachedFileContents(std::move(Contents), std::move(CASContents));
     Insertion.first->second = new (EntryStorage.Allocate())
         CachedFileSystemEntry(std::move(Stat), StoredContents);
   }
@@ -193,9 +199,9 @@ const CachedFileSystemEntry &
 DependencyScanningWorkerFilesystem::getOrEmplaceSharedEntryForUID(
     TentativeEntry TEntry) {
   auto &Shard = SharedCache.getShardForUID(TEntry.Status.getUniqueID());
-  return Shard.getOrEmplaceEntryForUID(TEntry.Status.getUniqueID(),
-                                       std::move(TEntry.Status),
-                                       std::move(TEntry.Contents));
+  return Shard.getOrEmplaceEntryForUID(
+      TEntry.Status.getUniqueID(), std::move(TEntry.Status),
+      std::move(TEntry.Contents), std::move(TEntry.CASContents));
 }
 
 const CachedFileSystemEntry *
@@ -270,8 +276,9 @@ namespace {
 class DepScanFile final : public llvm::vfs::File {
 public:
   DepScanFile(std::unique_ptr<llvm::MemoryBuffer> Buffer,
-              llvm::vfs::Status Stat)
-      : Buffer(std::move(Buffer)), Stat(std::move(Stat)) {}
+              Optional<cas::ObjectRef> CASContents, llvm::vfs::Status Stat)
+      : Buffer(std::move(Buffer)), CASContents(std::move(CASContents)),
+        Stat(std::move(Stat)) {}
 
   static llvm::ErrorOr<std::unique_ptr<llvm::vfs::File>> create(EntryRef Entry);
 
@@ -283,10 +290,15 @@ public:
     return std::move(Buffer);
   }
 
+  llvm::ErrorOr<Optional<cas::ObjectRef>> getCASContents() override {
+    return CASContents;
+  }
+
   std::error_code close() override { return {}; }
 
 private:
   std::unique_ptr<llvm::MemoryBuffer> Buffer;
+  Optional<cas::ObjectRef> CASContents;
   llvm::vfs::Status Stat;
 };
 
@@ -303,7 +315,7 @@ DepScanFile::create(EntryRef Entry) {
       llvm::MemoryBuffer::getMemBuffer(Entry.getContents(),
                                        Entry.getStatus().getName(),
                                        /*RequiresNullTerminator=*/false),
-      Entry.getStatus());
+      Entry.getCASContents(), Entry.getStatus());
 
   return llvm::ErrorOr<std::unique_ptr<llvm::vfs::File>>(
       std::unique_ptr<llvm::vfs::File>(std::move(Result)));

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningFilesystem.cpp
@@ -33,7 +33,7 @@ DependencyScanningWorkerFilesystem::readFile(StringRef Filename) {
     return MaybeBuffer.getError();
   auto Buffer = std::move(*MaybeBuffer);
 
-  auto MaybeCASContents = File->getCASContents();
+  auto MaybeCASContents = File->getObjectRefForContent();
   if (!MaybeCASContents)
     return MaybeCASContents.getError();
   auto CASContents = std::move(*MaybeCASContents);
@@ -290,7 +290,7 @@ public:
     return std::move(Buffer);
   }
 
-  llvm::ErrorOr<Optional<cas::ObjectRef>> getCASContents() override {
+  llvm::ErrorOr<Optional<cas::ObjectRef>> getObjectRefForContent() override {
     return CASContents;
   }
 
@@ -315,7 +315,7 @@ DepScanFile::create(EntryRef Entry) {
       llvm::MemoryBuffer::getMemBuffer(Entry.getContents(),
                                        Entry.getStatus().getName(),
                                        /*RequiresNullTerminator=*/false),
-      Entry.getCASContents(), Entry.getStatus());
+      Entry.getObjectRefForContent(), Entry.getStatus());
 
   return llvm::ErrorOr<std::unique_ptr<llvm::vfs::File>>(
       std::unique_ptr<llvm::vfs::File>(std::move(Result)));

--- a/clang/unittests/Basic/FileManagerTest.cpp
+++ b/clang/unittests/Basic/FileManagerTest.cpp
@@ -12,6 +12,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/CAS/CASDB.h"
 #include "llvm/CAS/CASProvidingFileSystem.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Testing/Support/Error.h"
@@ -554,7 +555,8 @@ TEST_F(FileManagerTest, getBypassFile) {
 TEST_F(FileManagerTest, CASProvider) {
   std::shared_ptr<CASDB> DB = llvm::cas::createInMemoryCAS();
   auto FS = makeIntrusiveRefCnt<vfs::InMemoryFileSystem>();
-  StringRef Path = "a.txt";
+  auto Sept = llvm::sys::path::get_separator();
+  std::string Path = std::string(llvm::formatv("{0}root{0}a.txt", Sept));
   StringRef Contents = "a";
   FS->addFile(Path, 0, MemoryBuffer::getMemBuffer(Contents));
   llvm::IntrusiveRefCntPtr<vfs::FileSystem> CASFS =
@@ -590,6 +592,31 @@ TEST_F(FileManagerTest, CASProvider) {
     ASSERT_TRUE(CASContents);
     Optional<ObjectProxy> BlobContents;
     ASSERT_THAT_ERROR(DB->getProxy(*CASContents).moveInto(BlobContents),
+                      llvm::Succeeded());
+    EXPECT_EQ(BlobContents->getData(), Contents);
+  }
+  {
+    FileSystemOptions Opts;
+    FileManager Manager(Opts, CASFS);
+    llvm::ErrorOr<Optional<ObjectRef>> CASContents =
+        Manager.getCASContentsForFile(Path);
+    ASSERT_TRUE(CASContents);
+    ASSERT_TRUE(*CASContents);
+    Optional<ObjectProxy> BlobContents;
+    ASSERT_THAT_ERROR(DB->getProxy(**CASContents).moveInto(BlobContents),
+                      llvm::Succeeded());
+    EXPECT_EQ(BlobContents->getData(), Contents);
+  }
+  {
+    FileSystemOptions Opts;
+    Opts.WorkingDir = "/root";
+    FileManager Manager(Opts, CASFS);
+    llvm::ErrorOr<Optional<ObjectRef>> CASContents =
+        Manager.getCASContentsForFile("a.txt");
+    ASSERT_TRUE(CASContents);
+    ASSERT_TRUE(*CASContents);
+    Optional<ObjectProxy> BlobContents;
+    ASSERT_THAT_ERROR(DB->getProxy(**CASContents).moveInto(BlobContents),
                       llvm::Succeeded());
     EXPECT_EQ(BlobContents->getData(), Contents);
   }

--- a/clang/unittests/Basic/FileManagerTest.cpp
+++ b/clang/unittests/Basic/FileManagerTest.cpp
@@ -10,6 +10,8 @@
 #include "clang/Basic/FileSystemOptions.h"
 #include "clang/Basic/FileSystemStatCache.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/CAS/CASDB.h"
+#include "llvm/CAS/CASProvidingFileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Testing/Support/Error.h"
@@ -17,6 +19,7 @@
 
 using namespace llvm;
 using namespace clang;
+using namespace clang::cas;
 
 namespace {
 
@@ -546,6 +549,50 @@ TEST_F(FileManagerTest, getBypassFile) {
   ASSERT_THAT_ERROR(Manager.getFileRef("/tmp/test").moveInto(SearchRef),
                     Succeeded());
   EXPECT_EQ(&FE, &SearchRef->getFileEntry());
+}
+
+TEST_F(FileManagerTest, CASProvider) {
+  std::shared_ptr<CASDB> DB = llvm::cas::createInMemoryCAS();
+  auto FS = makeIntrusiveRefCnt<vfs::InMemoryFileSystem>();
+  StringRef Path = "a.txt";
+  StringRef Contents = "a";
+  FS->addFile(Path, 0, MemoryBuffer::getMemBuffer(Contents));
+  llvm::IntrusiveRefCntPtr<vfs::FileSystem> CASFS =
+      llvm::cas::createCASProvidingFileSystem(DB, FS);
+
+  FileSystemOptions Opts;
+  {
+    FileManager Manager(Opts, CASFS);
+    Optional<ObjectRef> CASContents;
+    auto Buf = Manager.getBufferForFile(Path, /*IsVolatile*/ false,
+                                        /*RequiresNullTerminator*/ false,
+                                        &CASContents);
+    ASSERT_TRUE(Buf);
+    EXPECT_EQ(Contents, (*Buf)->getBuffer());
+    ASSERT_TRUE(CASContents);
+    Optional<ObjectProxy> BlobContents;
+    ASSERT_THAT_ERROR(DB->getProxy(*CASContents).moveInto(BlobContents),
+                      llvm::Succeeded());
+    EXPECT_EQ(BlobContents->getData(), Contents);
+  }
+  {
+    FileManager Manager(Opts, CASFS);
+    Optional<FileEntryRef> FERef;
+    ASSERT_THAT_ERROR(
+        Manager.getFileRef(Path, /*OpenFile*/ true).moveInto(FERef),
+        llvm::Succeeded());
+    Optional<ObjectRef> CASContents;
+    auto Buf = Manager.getBufferForFile(*FERef, /*IsVolatile*/ false,
+                                        /*RequiresNullTerminator*/ false,
+                                        &CASContents);
+    ASSERT_TRUE(Buf);
+    EXPECT_EQ(Contents, (*Buf)->getBuffer());
+    ASSERT_TRUE(CASContents);
+    Optional<ObjectProxy> BlobContents;
+    ASSERT_THAT_ERROR(DB->getProxy(*CASContents).moveInto(BlobContents),
+                      llvm::Succeeded());
+    EXPECT_EQ(BlobContents->getData(), Contents);
+  }
 }
 
 } // anonymous namespace

--- a/clang/unittests/Basic/FileManagerTest.cpp
+++ b/clang/unittests/Basic/FileManagerTest.cpp
@@ -599,7 +599,7 @@ TEST_F(FileManagerTest, CASProvider) {
     FileSystemOptions Opts;
     FileManager Manager(Opts, CASFS);
     llvm::ErrorOr<Optional<ObjectRef>> CASContents =
-        Manager.getCASContentsForFile(Path);
+        Manager.getObjectRefForFileContent(Path);
     ASSERT_TRUE(CASContents);
     ASSERT_TRUE(*CASContents);
     Optional<ObjectProxy> BlobContents;
@@ -612,7 +612,7 @@ TEST_F(FileManagerTest, CASProvider) {
     Opts.WorkingDir = "/root";
     FileManager Manager(Opts, CASFS);
     llvm::ErrorOr<Optional<ObjectRef>> CASContents =
-        Manager.getCASContentsForFile("a.txt");
+        Manager.getObjectRefForFileContent("a.txt");
     ASSERT_TRUE(CASContents);
     ASSERT_TRUE(*CASContents);
     Optional<ObjectProxy> BlobContents;

--- a/clang/unittests/Tooling/DependencyScannerTest.cpp
+++ b/clang/unittests/Tooling/DependencyScannerTest.cpp
@@ -17,6 +17,8 @@
 #include "clang/Tooling/DependencyScanning/DependencyScanningTool.h"
 #include "clang/Tooling/Tooling.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/CAS/CASDB.h"
+#include "llvm/CAS/CASProvidingFileSystem.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -28,6 +30,7 @@
 #include <string>
 
 using namespace clang;
+using namespace clang::cas;
 using namespace tooling;
 using namespace dependencies;
 
@@ -236,4 +239,51 @@ TEST(DependencyScanner, ScanDepsWithFS) {
   using llvm::sys::path::convert_to_slash;
   EXPECT_EQ(convert_to_slash(DepFile),
             "test.cpp.o: /root/test.cpp /root/header.h\n");
+}
+
+TEST(DependencyScanner, DepScanFSWithCASProvider) {
+  std::shared_ptr<CASDB> DB = llvm::cas::createInMemoryCAS();
+  auto FS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  StringRef Path = "a.h";
+  StringRef Contents = "a";
+  FS->addFile(Path, 0, llvm::MemoryBuffer::getMemBuffer(Contents));
+  std::unique_ptr<llvm::vfs::FileSystem> CASFS =
+      llvm::cas::createCASProvidingFileSystem(DB, FS);
+
+  DependencyScanningService Service(ScanningMode::DependencyDirectivesScan,
+                                    ScanningOutputFormat::Make, CASOptions(),
+                                    nullptr);
+  {
+    DependencyScanningWorkerFilesystem DepFS(Service.getSharedCache(),
+                                             std::move(CASFS));
+    Optional<ObjectRef> CASContents;
+    auto Buf = DepFS.getBufferForFile(Path, /*FileSize*/ -1,
+                                      /*RequiresNullTerminator*/ false,
+                                      /*IsVolatile*/ false, &CASContents);
+    ASSERT_TRUE(Buf);
+    EXPECT_EQ(Contents, (*Buf)->getBuffer());
+    ASSERT_TRUE(CASContents);
+    Optional<ObjectProxy> BlobContents;
+    ASSERT_THAT_ERROR(DB->getProxy(*CASContents).moveInto(BlobContents),
+                      llvm::Succeeded());
+    EXPECT_EQ(BlobContents->getData(), Contents);
+  }
+  {
+    // Check that even though we pass a new InMemoryFileSystem instance here the
+    // DependencyScanningService's SharedCache cached the file's buffer and
+    // cas::ObjectRef and will be able to provide it.
+    DependencyScanningWorkerFilesystem DepFS(Service.getSharedCache(),
+                                             new llvm::vfs::InMemoryFileSystem);
+    llvm::ErrorOr<std::unique_ptr<llvm::vfs::File>> File =
+        DepFS.openFileForRead(Path);
+    ASSERT_TRUE(File);
+    ASSERT_TRUE(*File);
+    llvm::ErrorOr<Optional<ObjectRef>> Ref = (*File)->getCASContents();
+    ASSERT_TRUE(Ref);
+    ASSERT_TRUE(*Ref);
+    Optional<ObjectProxy> BlobContents;
+    ASSERT_THAT_ERROR(DB->getProxy(**Ref).moveInto(BlobContents),
+                      llvm::Succeeded());
+    EXPECT_EQ(BlobContents->getData(), Contents);
+  }
 }

--- a/clang/unittests/Tooling/DependencyScannerTest.cpp
+++ b/clang/unittests/Tooling/DependencyScannerTest.cpp
@@ -278,7 +278,7 @@ TEST(DependencyScanner, DepScanFSWithCASProvider) {
         DepFS.openFileForRead(Path);
     ASSERT_TRUE(File);
     ASSERT_TRUE(*File);
-    llvm::ErrorOr<Optional<ObjectRef>> Ref = (*File)->getCASContents();
+    llvm::ErrorOr<Optional<ObjectRef>> Ref = (*File)->getObjectRefForContent();
     ASSERT_TRUE(Ref);
     ASSERT_TRUE(*Ref);
     Optional<ObjectProxy> BlobContents;

--- a/llvm/include/llvm/CAS/CASFileSystem.h
+++ b/llvm/include/llvm/CAS/CASFileSystem.h
@@ -19,12 +19,12 @@ class CASID;
 
 // FIXME: Consider taking a "mount point". Then this could perhaps be
 // generalized for windows.
-Expected<std::unique_ptr<CASFileSystemBase>>
+Expected<std::unique_ptr<vfs::FileSystem>>
 createCASFileSystem(std::shared_ptr<CASDB> DB, const CASID &RootID);
 
 // FIXME: Consider taking a "mount point". Then this could perhaps be
 // generalized for windows.
-Expected<std::unique_ptr<CASFileSystemBase>>
+Expected<std::unique_ptr<vfs::FileSystem>>
 createCASFileSystem(CASDB &DB, const CASID &RootID);
 
 } // namespace cas

--- a/llvm/include/llvm/CAS/CASProvidingFileSystem.h
+++ b/llvm/include/llvm/CAS/CASProvidingFileSystem.h
@@ -20,9 +20,9 @@ class FileSystem;
 namespace cas {
 class CASDB;
 
-/// Implements \p vfs::File::getCASContents() by ingesting the file buffer
-/// into the \p DB, unless the \p UnderlyingFS already supports \p
-/// vfs::File::getCASContents().
+/// Implements \p vfs::File::getObjectRefForContent() by ingesting the file
+/// buffer into the \p DB, unless the \p UnderlyingFS already supports \p
+/// vfs::File::getObjectRefForContent().
 std::unique_ptr<llvm::vfs::FileSystem> createCASProvidingFileSystem(
     std::shared_ptr<CASDB> DB,
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> UnderlyingFS);

--- a/llvm/include/llvm/CAS/CASProvidingFileSystem.h
+++ b/llvm/include/llvm/CAS/CASProvidingFileSystem.h
@@ -1,0 +1,33 @@
+//===- llvm/CAS/CASProvidingFileSystem.h ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CAS_CASPROVIDINGFILESYSTEM_H
+#define LLVM_CAS_CASPROVIDINGFILESYSTEM_H
+
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/Support/Error.h"
+
+namespace llvm {
+namespace vfs {
+class FileSystem;
+}
+
+namespace cas {
+class CASDB;
+
+/// Implements \p vfs::File::getCASContents() by ingesting the file buffer
+/// into the \p DB, unless the \p UnderlyingFS already supports \p
+/// vfs::File::getCASContents().
+std::unique_ptr<llvm::vfs::FileSystem> createCASProvidingFileSystem(
+    std::shared_ptr<CASDB> DB,
+    IntrusiveRefCntPtr<llvm::vfs::FileSystem> UnderlyingFS);
+
+} // namespace cas
+} // namespace llvm
+
+#endif // LLVM_CAS_CASPROVIDINGFILESYSTEM_H

--- a/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
+++ b/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
@@ -28,7 +28,7 @@ class ObjectProxy;
 /// working directory. This allows a single caching on-disk filesystem to be
 /// used across the filesystem, with each thread using a different proxy to set
 /// the working directory.
-class CachingOnDiskFileSystem : public CASFileSystemBase {
+class CachingOnDiskFileSystem : public ThreadSafeFileSystem {
   void anchor() override;
 
 public:
@@ -99,7 +99,7 @@ public:
   /// cached filesystem contents.
   virtual std::unique_ptr<TreeBuilder> createTreeBuilder() = 0;
 
-  CASDB &getCAS() const final { return DB; }
+  CASDB &getCAS() const { return DB; }
 
   /// Get a proxy FS that has an independent working directory but uses the
   /// same thread-safe cache.

--- a/llvm/include/llvm/CAS/ThreadSafeFileSystem.h
+++ b/llvm/include/llvm/CAS/ThreadSafeFileSystem.h
@@ -28,20 +28,6 @@ public:
   createThreadSafeProxyFS() = 0;
 };
 
-/// For filesystems that use a CAS.
-class CASFileSystemBase : public ThreadSafeFileSystem {
-  virtual void anchor() override;
-
-public:
-  /// Get a proxy FS that has an independent working directory.
-  virtual CASDB &getCAS() const = 0;
-
-  /// An extra API to pull out the \a CASID if \p Path refers to a file.
-  virtual Optional<CASID> getFileCASID(const Twine &Path) = 0;
-
-  bool isCASFS() const final { return true; }
-};
-
 } // namespace cas
 } // namespace llvm
 

--- a/llvm/include/llvm/Support/VirtualFileSystem.h
+++ b/llvm/include/llvm/Support/VirtualFileSystem.h
@@ -294,6 +294,13 @@ public:
                    bool RequiresNullTerminator = true, bool IsVolatile = false,
                    Optional<cas::ObjectRef> *CASContents = nullptr);
 
+  /// This is a convenience method that opens a file, gets the \p cas::ObjectRef
+  /// for its contents if supported by the file system, and then closes the
+  /// file. If both the buffer and its `cas::ObjectRef` are needed use \p
+  /// getBufferForFile to avoid the extra file lookup.
+  llvm::ErrorOr<Optional<cas::ObjectRef>>
+  getCASContentsForFile(const Twine &Name);
+
   /// Get a directory_iterator for \p Dir.
   /// \note The 'end' iterator is directory_iterator().
   virtual directory_iterator dir_begin(const Twine &Dir,

--- a/llvm/include/llvm/Support/VirtualFileSystem.h
+++ b/llvm/include/llvm/Support/VirtualFileSystem.h
@@ -44,6 +44,10 @@ class MemoryBuffer;
 class MemoryBufferRef;
 class Twine;
 
+namespace cas {
+class ObjectRef;
+}
+
 namespace vfs {
 
 /// The result of a \p status operation.
@@ -135,6 +139,11 @@ public:
   virtual llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
   getBuffer(const Twine &Name, int64_t FileSize = -1,
             bool RequiresNullTerminator = true, bool IsVolatile = false) = 0;
+
+  /// Get the CAS reference for the contents of the file.
+  /// \returns \p None if the underlying \p FileSystem doesn't support providing
+  /// CAS references.
+  virtual llvm::ErrorOr<Optional<cas::ObjectRef>> getCASContents();
 
   /// Closes the file.
   virtual std::error_code close() = 0;
@@ -282,7 +291,8 @@ public:
   /// closes the file.
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
   getBufferForFile(const Twine &Name, int64_t FileSize = -1,
-                   bool RequiresNullTerminator = true, bool IsVolatile = false);
+                   bool RequiresNullTerminator = true, bool IsVolatile = false,
+                   Optional<cas::ObjectRef> *CASContents = nullptr);
 
   /// Get a directory_iterator for \p Dir.
   /// \note The 'end' iterator is directory_iterator().

--- a/llvm/include/llvm/Support/VirtualFileSystem.h
+++ b/llvm/include/llvm/Support/VirtualFileSystem.h
@@ -143,7 +143,7 @@ public:
   /// Get the CAS reference for the contents of the file.
   /// \returns \p None if the underlying \p FileSystem doesn't support providing
   /// CAS references.
-  virtual llvm::ErrorOr<Optional<cas::ObjectRef>> getCASContents();
+  virtual llvm::ErrorOr<Optional<cas::ObjectRef>> getObjectRefForContent();
 
   /// Closes the file.
   virtual std::error_code close() = 0;
@@ -299,7 +299,7 @@ public:
   /// file. If both the buffer and its `cas::ObjectRef` are needed use \p
   /// getBufferForFile to avoid the extra file lookup.
   llvm::ErrorOr<Optional<cas::ObjectRef>>
-  getCASContentsForFile(const Twine &Name);
+  getObjectRefForFileContent(const Twine &Name);
 
   /// Get a directory_iterator for \p Dir.
   /// \note The 'end' iterator is directory_iterator().

--- a/llvm/lib/CAS/CASFileSystem.cpp
+++ b/llvm/lib/CAS/CASFileSystem.cpp
@@ -107,7 +107,7 @@ public:
                                       Name.toStringRef(Storage));
   }
 
-  llvm::ErrorOr<Optional<cas::ObjectRef>> getCASContents() final {
+  llvm::ErrorOr<Optional<cas::ObjectRef>> getObjectRefForContent() final {
     return Entry->getRef();
   }
 

--- a/llvm/lib/CAS/CASProvidingFileSystem.cpp
+++ b/llvm/lib/CAS/CASProvidingFileSystem.cpp
@@ -1,0 +1,79 @@
+//===- CASProvidingFileSystem.cpp -------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/CASProvidingFileSystem.h"
+#include "llvm/CAS/CASDB.h"
+#include "llvm/Support/VirtualFileSystem.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+
+namespace {
+
+class CASProvidingFile final : public vfs::File {
+  std::shared_ptr<CASDB> DB;
+  std::unique_ptr<File> UnderlyingFile;
+
+public:
+  CASProvidingFile(std::shared_ptr<CASDB> DB,
+                   std::unique_ptr<File> UnderlyingFile)
+      : DB(std::move(DB)), UnderlyingFile(std::move(UnderlyingFile)) {}
+
+  ErrorOr<vfs::Status> status() override { return UnderlyingFile->status(); }
+
+  ErrorOr<std::unique_ptr<MemoryBuffer>> getBuffer(const Twine &Name,
+                                                   int64_t FileSize,
+                                                   bool RequiresNullTerminator,
+                                                   bool IsVolatile) override {
+    return UnderlyingFile->getBuffer(Name, FileSize, RequiresNullTerminator,
+                                     IsVolatile);
+  }
+
+  ErrorOr<Optional<cas::ObjectRef>> getCASContents() override {
+    auto UnderlyingCASRef = UnderlyingFile->getCASContents();
+    if (!UnderlyingCASRef || *UnderlyingCASRef)
+      return UnderlyingCASRef;
+
+    auto Buffer = UnderlyingFile->getBuffer("<contents>", /*FileSize*/ -1,
+                                            /*RequiresNullTerminator*/ false);
+    if (!Buffer)
+      return Buffer.getError();
+    auto Blob = DB->createProxy(None, (*Buffer)->getBuffer());
+    if (!Blob)
+      return errorToErrorCode(Blob.takeError());
+    return Blob->getRef();
+  }
+
+  std::error_code close() override { return UnderlyingFile->close(); }
+};
+
+class CASProvidingFileSystem : public vfs::ProxyFileSystem {
+  std::shared_ptr<CASDB> DB;
+
+public:
+  CASProvidingFileSystem(std::shared_ptr<CASDB> DB,
+                         IntrusiveRefCntPtr<vfs::FileSystem> FS)
+      : ProxyFileSystem(std::move(FS)), DB(std::move(DB)) {}
+
+  ErrorOr<std::unique_ptr<vfs::File>>
+  openFileForRead(const Twine &Path) override {
+    auto UnderlyingFile = ProxyFileSystem::openFileForRead(Path);
+    if (!UnderlyingFile)
+      return UnderlyingFile.getError();
+    return std::make_unique<CASProvidingFile>(DB, std::move(*UnderlyingFile));
+  }
+};
+
+} // namespace
+
+std::unique_ptr<vfs::FileSystem> cas::createCASProvidingFileSystem(
+    std::shared_ptr<CASDB> DB,
+    IntrusiveRefCntPtr<vfs::FileSystem> UnderlyingFS) {
+  return std::make_unique<CASProvidingFileSystem>(std::move(DB),
+                                                  std::move(UnderlyingFS));
+}

--- a/llvm/lib/CAS/CASProvidingFileSystem.cpp
+++ b/llvm/lib/CAS/CASProvidingFileSystem.cpp
@@ -34,8 +34,8 @@ public:
                                      IsVolatile);
   }
 
-  ErrorOr<Optional<cas::ObjectRef>> getCASContents() override {
-    auto UnderlyingCASRef = UnderlyingFile->getCASContents();
+  ErrorOr<Optional<cas::ObjectRef>> getObjectRefForContent() override {
+    auto UnderlyingCASRef = UnderlyingFile->getObjectRefForContent();
     if (!UnderlyingCASRef || *UnderlyingCASRef)
       return UnderlyingCASRef;
 

--- a/llvm/lib/CAS/CMakeLists.txt
+++ b/llvm/lib/CAS/CMakeLists.txt
@@ -4,6 +4,7 @@ add_llvm_component_library(LLVMCAS
   CASFileSystem.cpp
   CASNodeSchema.cpp
   CASOutputBackend.cpp
+  CASProvidingFileSystem.cpp
   CachingOnDiskFileSystem.cpp
   FileSystemCache.cpp
   HashMappedTrie.cpp

--- a/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
+++ b/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
@@ -86,7 +86,6 @@ public:
 
   ErrorOr<vfs::Status> statusAndFileID(const Twine &Path,
                                        Optional<CASID> &FileID) final;
-  Optional<CASID> getFileCASID(const Twine &Path) final;
   ErrorOr<vfs::Status> status(const Twine &Path) final;
   ErrorOr<std::unique_ptr<vfs::File>> openFileForRead(const Twine &Path) final;
   vfs::directory_iterator dir_begin(const Twine &Dir,
@@ -206,6 +205,10 @@ public:
     SmallString<256> Storage;
     return MemoryBuffer::getMemBuffer(DB.getDataString(*Object),
                                       RequestedName.toStringRef(Storage));
+  }
+
+  llvm::ErrorOr<Optional<cas::ObjectRef>> getCASContents() final {
+    return Entry->getRef();
   }
 
   /// Closes the file.
@@ -408,19 +411,6 @@ CachingOnDiskFileSystemImpl::statusAndFileID(const Twine &Path,
   if (Entry->isFile())
     FileID = DB.getID(*Entry->getRef());
   return StatusOrErr;
-}
-
-Optional<CASID> CachingOnDiskFileSystemImpl::getFileCASID(const Twine &Path) {
-  // FIXME: This is the correct implementation, but hack it out for now to
-  // focus on CASFileSystem.
-  //
-  // return None;
-  //
-  // ... or don't hack it out.
-
-  Optional<CASID> ID;
-  (void)statusAndFileID(Path, ID);
-  return ID;
 }
 
 Expected<const vfs::CachedDirectoryEntry *>

--- a/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
+++ b/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
@@ -207,7 +207,7 @@ public:
                                       RequestedName.toStringRef(Storage));
   }
 
-  llvm::ErrorOr<Optional<cas::ObjectRef>> getCASContents() final {
+  llvm::ErrorOr<Optional<cas::ObjectRef>> getObjectRefForContent() final {
     return Entry->getRef();
   }
 

--- a/llvm/lib/Support/VirtualFileSystem.cpp
+++ b/llvm/lib/Support/VirtualFileSystem.cpp
@@ -135,6 +135,14 @@ FileSystem::getBufferForFile(const llvm::Twine &Name, int64_t FileSize,
   return (*F)->getBuffer(Name, FileSize, RequiresNullTerminator, IsVolatile);
 }
 
+llvm::ErrorOr<Optional<cas::ObjectRef>>
+FileSystem::getCASContentsForFile(const Twine &Name) {
+  auto F = openFileForRead(Name);
+  if (!F)
+    return F.getError();
+  return (*F)->getCASContents();
+}
+
 std::error_code FileSystem::makeAbsolute(SmallVectorImpl<char> &Path) const {
   if (llvm::sys::path::is_absolute(Path))
     return {};

--- a/llvm/lib/Support/VirtualFileSystem.cpp
+++ b/llvm/lib/Support/VirtualFileSystem.cpp
@@ -114,7 +114,9 @@ bool Status::exists() const {
 
 File::~File() = default;
 
-llvm::ErrorOr<Optional<cas::ObjectRef>> File::getCASContents() { return None; }
+llvm::ErrorOr<Optional<cas::ObjectRef>> File::getObjectRefForContent() {
+  return None;
+}
 
 FileSystem::~FileSystem() = default;
 
@@ -126,7 +128,7 @@ FileSystem::getBufferForFile(const llvm::Twine &Name, int64_t FileSize,
   if (!F)
     return F.getError();
   if (CASContents) {
-    auto CASRef = (*F)->getCASContents();
+    auto CASRef = (*F)->getObjectRefForContent();
     if (!CASRef)
       return CASRef.getError();
     *CASContents = *CASRef;
@@ -136,11 +138,11 @@ FileSystem::getBufferForFile(const llvm::Twine &Name, int64_t FileSize,
 }
 
 llvm::ErrorOr<Optional<cas::ObjectRef>>
-FileSystem::getCASContentsForFile(const Twine &Name) {
+FileSystem::getObjectRefForFileContent(const Twine &Name) {
   auto F = openFileForRead(Name);
   if (!F)
     return F.getError();
-  return (*F)->getCASContents();
+  return (*F)->getObjectRefForContent();
 }
 
 std::error_code FileSystem::makeAbsolute(SmallVectorImpl<char> &Path) const {

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -465,7 +465,7 @@ int getCASIDForFile(CASDB &CAS, CASID ID, StringRef Path) {
   if (!FS)
     ExitOnErr(FS.takeError());
 
-  auto FileRef = (*FS)->getCASContentsForFile(Path);
+  auto FileRef = (*FS)->getObjectRefForFileContent(Path);
   if (!FileRef)
     ExitOnErr(errorCodeToError(
         std::make_error_code(std::errc::no_such_file_or_directory)));

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -465,12 +465,13 @@ int getCASIDForFile(CASDB &CAS, CASID ID, StringRef Path) {
   if (!FS)
     ExitOnErr(FS.takeError());
 
-  auto FileID = (*FS)->getFileCASID(Path);
-  if (!FileID)
+  auto FileRef = (*FS)->getCASContentsForFile(Path);
+  if (!FileRef)
     ExitOnErr(errorCodeToError(
         std::make_error_code(std::errc::no_such_file_or_directory)));
 
-  outs() << *FileID << "\n";
+  CASID FileID = CAS.getID(**FileRef);
+  outs() << FileID << "\n";
   return 0;
 }
 

--- a/llvm/unittests/CAS/CASProvidingFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CASProvidingFileSystemTest.cpp
@@ -39,6 +39,14 @@ TEST(CASProvidingFileSystemTest, Basic) {
     EXPECT_EQ(BlobContents->getData(), Contents1);
   }
   {
+    ErrorOr<Optional<cas::ObjectRef>> Ref = CASFS->getCASContentsForFile(Path1);
+    ASSERT_TRUE(Ref);
+    ASSERT_TRUE(*Ref);
+    Optional<ObjectProxy> BlobContents;
+    ASSERT_THAT_ERROR(DB->getProxy(**Ref).moveInto(BlobContents), Succeeded());
+    EXPECT_EQ(BlobContents->getData(), Contents1);
+  }
+  {
     Optional<cas::ObjectRef> CASContents;
     auto Buf = CASFS->getBufferForFile(Path2, /*FileSize*/ -1,
                                        /*RequiresNullTerminator*/ false,

--- a/llvm/unittests/CAS/CASProvidingFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CASProvidingFileSystemTest.cpp
@@ -31,7 +31,7 @@ TEST(CASProvidingFileSystemTest, Basic) {
     ErrorOr<std::unique_ptr<vfs::File>> File = CASFS->openFileForRead(Path1);
     ASSERT_TRUE(File);
     ASSERT_TRUE(*File);
-    ErrorOr<Optional<cas::ObjectRef>> Ref = (*File)->getCASContents();
+    ErrorOr<Optional<cas::ObjectRef>> Ref = (*File)->getObjectRefForContent();
     ASSERT_TRUE(Ref);
     ASSERT_TRUE(*Ref);
     Optional<ObjectProxy> BlobContents;
@@ -39,7 +39,8 @@ TEST(CASProvidingFileSystemTest, Basic) {
     EXPECT_EQ(BlobContents->getData(), Contents1);
   }
   {
-    ErrorOr<Optional<cas::ObjectRef>> Ref = CASFS->getCASContentsForFile(Path1);
+    ErrorOr<Optional<cas::ObjectRef>> Ref =
+        CASFS->getObjectRefForFileContent(Path1);
     ASSERT_TRUE(Ref);
     ASSERT_TRUE(*Ref);
     Optional<ObjectProxy> BlobContents;
@@ -79,7 +80,7 @@ TEST(CASProvidingFileSystemTest, WithCASSupportingFS) {
   ErrorOr<std::unique_ptr<vfs::File>> File = CASFS->openFileForRead(Path);
   ASSERT_TRUE(File);
   ASSERT_TRUE(*File);
-  ErrorOr<Optional<cas::ObjectRef>> Ref = (*File)->getCASContents();
+  ErrorOr<Optional<cas::ObjectRef>> Ref = (*File)->getObjectRefForContent();
   ASSERT_TRUE(Ref);
   ASSERT_TRUE(*Ref);
   Optional<ObjectProxy> BlobContents;

--- a/llvm/unittests/CAS/CASProvidingFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CASProvidingFileSystemTest.cpp
@@ -1,0 +1,88 @@
+//===- CASProvidingFileSystemTest.cpp -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/CASProvidingFileSystem.h"
+#include "llvm/CAS/CASDB.h"
+#include "llvm/Support/VirtualFileSystem.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+
+TEST(CASProvidingFileSystemTest, Basic) {
+  std::shared_ptr<CASDB> DB = createInMemoryCAS();
+  auto FS = makeIntrusiveRefCnt<vfs::InMemoryFileSystem>();
+  StringRef Path1 = "a.txt";
+  StringRef Contents1 = "a";
+  StringRef Path2 = "b.txt";
+  StringRef Contents2 = "b";
+  FS->addFile(Path1, 0, MemoryBuffer::getMemBuffer(Contents1));
+  FS->addFile(Path2, 0, MemoryBuffer::getMemBuffer(Contents2));
+
+  std::unique_ptr<vfs::FileSystem> CASFS = createCASProvidingFileSystem(DB, FS);
+  ASSERT_TRUE(CASFS);
+  {
+    ErrorOr<std::unique_ptr<vfs::File>> File = CASFS->openFileForRead(Path1);
+    ASSERT_TRUE(File);
+    ASSERT_TRUE(*File);
+    ErrorOr<Optional<cas::ObjectRef>> Ref = (*File)->getCASContents();
+    ASSERT_TRUE(Ref);
+    ASSERT_TRUE(*Ref);
+    Optional<ObjectProxy> BlobContents;
+    ASSERT_THAT_ERROR(DB->getProxy(**Ref).moveInto(BlobContents), Succeeded());
+    EXPECT_EQ(BlobContents->getData(), Contents1);
+  }
+  {
+    Optional<cas::ObjectRef> CASContents;
+    auto Buf = CASFS->getBufferForFile(Path2, /*FileSize*/ -1,
+                                       /*RequiresNullTerminator*/ false,
+                                       /*IsVolatile*/ false, &CASContents);
+    ASSERT_TRUE(Buf);
+    EXPECT_EQ(Contents2, (*Buf)->getBuffer());
+    ASSERT_TRUE(CASContents);
+    Optional<ObjectProxy> BlobContents;
+    ASSERT_THAT_ERROR(DB->getProxy(*CASContents).moveInto(BlobContents),
+                      Succeeded());
+    EXPECT_EQ(BlobContents->getData(), Contents2);
+  }
+}
+
+TEST(CASProvidingFileSystemTest, WithCASSupportingFS) {
+  std::shared_ptr<CASDB> UnderlyingDB = createInMemoryCAS();
+  auto FS = makeIntrusiveRefCnt<vfs::InMemoryFileSystem>();
+  StringRef Path = "a.txt";
+  StringRef Contents = "a";
+  FS->addFile(Path, 0, MemoryBuffer::getMemBuffer(Contents));
+  std::unique_ptr<vfs::FileSystem> UnderlyingFS =
+      createCASProvidingFileSystem(UnderlyingDB, FS);
+  ASSERT_TRUE(UnderlyingFS);
+
+  std::shared_ptr<CASDB> DB = createInMemoryCAS();
+  std::unique_ptr<vfs::FileSystem> CASFS =
+      createCASProvidingFileSystem(DB, std::move(UnderlyingFS));
+  ASSERT_TRUE(CASFS);
+
+  ErrorOr<std::unique_ptr<vfs::File>> File = CASFS->openFileForRead(Path);
+  ASSERT_TRUE(File);
+  ASSERT_TRUE(*File);
+  ErrorOr<Optional<cas::ObjectRef>> Ref = (*File)->getCASContents();
+  ASSERT_TRUE(Ref);
+  ASSERT_TRUE(*Ref);
+  Optional<ObjectProxy> BlobContents;
+  ASSERT_THAT_ERROR(UnderlyingDB->getProxy(**Ref).moveInto(BlobContents),
+                    Succeeded());
+  EXPECT_EQ(BlobContents->getData(), Contents);
+
+  CASID ID = UnderlyingDB->getID(**Ref);
+  Optional<ObjectHandle> Handle;
+  ASSERT_THAT_ERROR(DB->load(ID).moveInto(Handle), Succeeded());
+  // It didn't have to ingest in DB because the underlying FS provided a CAS
+  // reference.
+  EXPECT_FALSE(Handle);
+}

--- a/llvm/unittests/CAS/CMakeLists.txt
+++ b/llvm/unittests/CAS/CMakeLists.txt
@@ -8,6 +8,7 @@ add_llvm_unittest(CASTests
   CASDBTest.cpp
   CASFileSystemTest.cpp
   CASOutputBackendTest.cpp
+  CASProvidingFileSystemTest.cpp
   CachingOnDiskFileSystemTest.cpp
   HashMappedTrieTest.cpp
   HierarchicalTreeBuilderTest.cpp


### PR DESCRIPTION
* Introduce `vfs::File::getCASContents()` which returns a `cas::ObjectRef` for filesystem implementations that are able to provide this
* Introduce `llvm::cas::createCASProvidingFileSystem()` which returns a `vfs::FileSystem` that supports `vfs::File::getCASContents()`
* Enhance `DependencyScanningWorkerFilesystem` to be able to cache and retrieve the `cas::ObjectRef` for a file's contents,
  if the underlying filesystem provided it
* Enhance `clang::FileManager::getBufferForFile()` APIs so that they can provide the `cas::ObjectRef` for a file's contents,
  if the underlying filesystem can provide it

The overall goal is to be able to efficiently retrieve a file's contents `cas::ObjectRef` during dependency scanning,
by taking advantage of `DependencyScanningWorkerFilesystem` caching mechanism and only ingesting a file once during the lifetime
of a `DependencyScanningService` instance.