### PR TITLE
[lldb] Skip validation of CGPoint in TypeSystemSwiftTypeRef

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3857,6 +3857,11 @@ bool TypeSystemSwiftTypeRef::ShouldSkipValidation(opaque_compiler_type_t type) {
   if (mangled_name == "$sSo11CFStringRefaD")
     return true;
 
+  if (mangled_name == "$sSo7CGPointVD")
+    return true;
+
+  if (mangled_name == "$sSo6CGSizeVD")
+    return true;
   // We skip validation when dealing with a builtin type since builtins are
   // considered type aliases by Swift, which we're deviating from since
   // SwiftASTContext reconstructs Builtin types as TypeAliases pointing to the


### PR DESCRIPTION
rdar://96166383
rdar://96166324
(cherry picked from commit b109b052bd14a1bfb6eaab414f6cbd2ba1399b97)