### PR TITLE
Introduce mechanism for producing an "include-tree" during dependency scanning

### DIFF
--- a/clang/include/clang/CAS/IncludeTree.h
+++ b/clang/include/clang/CAS/IncludeTree.h
@@ -1,0 +1,264 @@
+//===- IncludeTree.h - Include-tree CAS graph -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_CAS_CASINCLUDETREE_H
+#define LLVM_CLANG_CAS_CASINCLUDETREE_H
+
+#include "clang/Basic/SourceManager.h"
+#include "llvm/CAS/CASDB.h"
+
+namespace llvm {
+class SmallBitVector;
+}
+
+namespace clang {
+namespace cas {
+
+/// Base class for include-tree related nodes. It makes it convenient to
+/// add/skip/check the "node kind identifier" (\p getNodeKind()) that is put
+/// at the beginning of the object data for every include-tree related node.
+template <typename NodeT> class IncludeTreeBase : public ObjectProxy {
+protected:
+  explicit IncludeTreeBase(ObjectProxy Node) : ObjectProxy(std::move(Node)) {
+    assert(isValid(*this));
+  }
+
+  StringRef getData() const {
+    return ObjectProxy::getData().substr(NodeT::getNodeKind().size());
+  }
+
+  static Expected<NodeT> create(CASDB &DB, ArrayRef<ObjectRef> Refs,
+                                ArrayRef<char> Data);
+
+  static bool isValid(const ObjectProxy &Node) {
+    return Node.getData().startswith(NodeT::getNodeKind());
+  }
+
+  friend class IncludeFile;
+  friend class IncludeTree;
+  friend class IncludeTreeRoot;
+};
+
+/// Represents a \p SourceManager file (or buffer in the case of preprocessor
+/// predefines) that got included by the preprocessor.
+class IncludeFile : public IncludeTreeBase<IncludeFile> {
+public:
+  static constexpr StringRef getNodeKind() { return "File"; }
+
+  ObjectRef getFilenameRef() const { return getReference(0); }
+  ObjectRef getContentsRef() const { return getReference(1); }
+
+  Expected<ObjectProxy> getFilename() {
+    return getCAS().getProxy(getFilenameRef());
+  }
+
+  Expected<ObjectProxy> getContents() {
+    return getCAS().getProxy(getContentsRef());
+  }
+
+  struct FileInfo {
+    StringRef Filename;
+    StringRef Contents;
+  };
+
+  Expected<FileInfo> getFileInfo() {
+    auto Filename = getFilename();
+    if (!Filename)
+      return Filename.takeError();
+    auto Contents = getContents();
+    if (!Contents)
+      return Contents.takeError();
+    return FileInfo{Filename->getData(), Contents->getData()};
+  }
+
+  static Expected<IncludeFile> create(CASDB &DB, StringRef Filename,
+                                      ObjectRef Contents);
+
+  llvm::Error print(llvm::raw_ostream &OS, unsigned Indent = 0);
+
+  static bool isValid(const ObjectProxy &Node) {
+    if (!IncludeTreeBase::isValid(Node))
+      return false;
+    IncludeTreeBase Base(Node);
+    return Base.getNumReferences() == 2 && Base.getData().empty();
+  }
+  static bool isValid(CASDB &DB, ObjectRef Ref) {
+    auto Node = DB.getProxy(Ref);
+    if (!Node) {
+      llvm::consumeError(Node.takeError());
+      return false;
+    }
+    return isValid(*Node);
+  }
+
+private:
+  friend class IncludeTreeBase;
+  friend class IncludeTree;
+  friend class IncludeTreeRoot;
+
+  explicit IncludeFile(ObjectProxy Node) : IncludeTreeBase(std::move(Node)) {
+    assert(isValid(*this));
+  }
+};
+
+/// Represents a DAG of included files by the preprocessor.
+/// Each node in the DAG represents a particular inclusion of a file that
+/// encompasses inclusions of other files as sub-trees, along with all the
+/// \p __has_include() preprocessor checks that occurred during preprocessing
+/// of that file.
+class IncludeTree : public IncludeTreeBase<IncludeTree> {
+public:
+  static constexpr StringRef getNodeKind() { return "Tree"; }
+
+  Expected<IncludeFile> getBaseFile() {
+    auto Node = getCAS().getProxy(getBaseFileRef());
+    if (!Node)
+      return Node.takeError();
+    return IncludeFile(std::move(*Node));
+  }
+
+  /// The include file that resulted in this include-tree.
+  ObjectRef getBaseFileRef() const { return getReference(0); }
+
+  Expected<IncludeFile::FileInfo> getBaseFileInfo() {
+    auto File = getBaseFile();
+    if (!File)
+      return File.takeError();
+    return File->getFileInfo();
+  }
+
+  SrcMgr::CharacteristicKind getFileCharacteristic() const {
+    return (SrcMgr::CharacteristicKind)dataSkippingIncludes().front();
+  }
+
+  size_t getNumIncludes() const { return getNumReferences() - 1; }
+
+  ObjectRef getIncludeRef(size_t I) const {
+    assert(I < getNumIncludes());
+    return getReference(I + 1);
+  }
+
+  /// The sub-include-trees of included files, in the order that they occurred.
+  Expected<IncludeTree> getInclude(size_t I) {
+    return getInclude(getIncludeRef(I));
+  }
+
+  /// The source byte offset for a particular include, pointing to the beginning
+  /// of the line just after the #include directive. The offset represents the
+  /// location at which point the include-tree would have been processed by the
+  /// preprocessor and parser.
+  ///
+  /// For example:
+  /// \code
+  ///   #include "a.h" -> include-tree("a.h")
+  ///   | <- include-tree-offset("a.h")
+  /// \endcode
+  ///
+  /// Using the "after #include" offset makes it trivial to identify the part
+  /// of the source file that encompasses a set of include-trees (for example in
+  /// the case where want to identify the "includes preamble" of the main file.
+  uint32_t getIncludeOffset(size_t I) const;
+
+  /// The \p __has_include() preprocessor checks, in the order that they
+  /// occurred. The source offsets for the checks are not tracked, "replaying"
+  /// the include-tree depends on the invariant that the same exact checks will
+  /// occur in the same order.
+  bool getCheckResult(size_t I) const;
+
+  /// Passes pairs of (IncludeTree, include offset) to \p Callback.
+  llvm::Error forEachInclude(
+      llvm::function_ref<llvm::Error(std::pair<IncludeTree, uint32_t>)>
+          Callback);
+
+  static Expected<IncludeTree>
+  create(CASDB &DB, SrcMgr::CharacteristicKind FileCharacteristic,
+         ObjectRef BaseFile, ArrayRef<std::pair<ObjectRef, uint32_t>> Includes,
+         llvm::SmallBitVector Checks);
+
+  static Expected<IncludeTree> get(CASDB &DB, ObjectRef Ref);
+
+  llvm::Error print(llvm::raw_ostream &OS, unsigned Indent = 0);
+
+private:
+  friend class IncludeTreeBase;
+  friend class IncludeTreeRoot;
+
+  explicit IncludeTree(ObjectProxy Node) : IncludeTreeBase(std::move(Node)) {
+    assert(isValid(*this));
+  }
+
+  Expected<IncludeTree> getInclude(ObjectRef Ref) {
+    auto Node = getCAS().getProxy(Ref);
+    if (!Node)
+      return Node.takeError();
+    return IncludeTree(std::move(*Node));
+  }
+
+  StringRef dataSkippingIncludes() const {
+    return getData().drop_front(getNumIncludes() * sizeof(uint32_t));
+  }
+
+  static bool isValid(const ObjectProxy &Node);
+  static bool isValid(CASDB &DB, ObjectRef Ref) {
+    auto Node = DB.getProxy(Ref);
+    if (!Node) {
+      llvm::consumeError(Node.takeError());
+      return false;
+    }
+    return isValid(*Node);
+  }
+};
+
+/// Represents the include-tree result for a translation unit.
+class IncludeTreeRoot : public IncludeTreeBase<IncludeTreeRoot> {
+public:
+  static constexpr StringRef getNodeKind() { return "Root"; }
+
+  ObjectRef getMainFileTreeRef() const { return getReference(0); }
+
+  Expected<IncludeTree> getMainFileTree() {
+    auto Node = getCAS().getProxy(getMainFileTreeRef());
+    if (!Node)
+      return Node.takeError();
+    return IncludeTree(std::move(*Node));
+  }
+
+  static Expected<IncludeTreeRoot> create(CASDB &DB, ObjectRef MainFileTree);
+
+  static Expected<IncludeTreeRoot> get(CASDB &DB, ObjectRef Ref);
+
+  llvm::Error print(llvm::raw_ostream &OS, unsigned Indent = 0);
+
+  static bool isValid(const ObjectProxy &Node) {
+    if (!IncludeTreeBase::isValid(Node))
+      return false;
+    IncludeTreeBase Base(Node);
+    return Base.getNumReferences() == 1 && Base.getData().empty();
+  }
+  static bool isValid(CASDB &DB, ObjectRef Ref) {
+    auto Node = DB.getProxy(Ref);
+    if (!Node) {
+      llvm::consumeError(Node.takeError());
+      return false;
+    }
+    return isValid(*Node);
+  }
+
+private:
+  friend class IncludeTreeBase;
+
+  explicit IncludeTreeRoot(ObjectProxy Node)
+      : IncludeTreeBase(std::move(Node)) {
+    assert(isValid(*this));
+  }
+};
+
+} // namespace cas
+} // namespace clang
+
+#endif

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
@@ -47,6 +47,9 @@ enum class ScanningOutputFormat {
   /// This emits the full dependency graph but with CAS tree embedded as file
   /// dependency.
   FullTree,
+
+  /// This emits the CAS ID of the include tree.
+  IncludeTree,
 };
 
 /// The dependency scanning service contains the shared state that is used by

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -24,6 +24,9 @@ class ObjectProxy;
 } // namespace llvm
 
 namespace clang {
+namespace cas {
+class IncludeTreeRoot;
+}
 namespace tooling {
 namespace dependencies {
 
@@ -104,6 +107,14 @@ public:
       llvm::function_ref<StringRef(const llvm::vfs::CachedDirectoryEntry &)>
           RemapPath = nullptr);
 
+  Expected<cas::IncludeTreeRoot>
+  getIncludeTree(cas::CASDB &DB, const std::vector<std::string> &CommandLine,
+                 StringRef CWD);
+
+  Expected<cas::IncludeTreeRoot> getIncludeTreeFromCompilerInvocation(
+      cas::CASDB &DB, std::shared_ptr<CompilerInvocation> Invocation,
+      StringRef CWD, DiagnosticConsumer &DiagsConsumer);
+
   /// Collect the full module dependency graph for the input, ignoring any
   /// modules which have already been seen. If \p ModuleName isn't empty, this
   /// function returns the full dependency information of module \p ModuleName.
@@ -120,6 +131,10 @@ public:
   getFullDependencies(const std::vector<std::string> &CommandLine,
                       StringRef CWD, const llvm::StringSet<> &AlreadySeen,
                       llvm::Optional<StringRef> ModuleName = None);
+
+  ScanningOutputFormat getScanningFormat() const {
+    return Worker.getScanningFormat();
+  }
 
   const CASOptions &getCASOpts() const { return Worker.getCASOpts(); }
 

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -34,10 +34,13 @@ namespace dependencies {
 
 class DependencyScanningWorkerFilesystem;
 
-class DependencyConsumer {
+class DependencyScanningConsumerBase {
 public:
-  virtual ~DependencyConsumer() {}
+  virtual ~DependencyScanningConsumerBase() {}
+};
 
+class DependencyConsumer : public DependencyScanningConsumerBase {
+public:
   virtual void
   handleDependencyOutputOpts(const DependencyOutputOptions &Opts) = 0;
 
@@ -48,6 +51,18 @@ public:
   virtual void handleModuleDependency(ModuleDeps MD) = 0;
 
   virtual void handleContextHash(std::string Hash) = 0;
+};
+
+// FIXME: This may need to merge with \p DependencyConsumer in order to support
+// clang modules for the include-tree.
+class PPIncludeActionsConsumer : public DependencyScanningConsumerBase {
+public:
+  virtual void enteredInclude(Preprocessor &PP, FileID FID) = 0;
+
+  virtual void exitedInclude(Preprocessor &PP, FileID IncludedBy,
+                             FileID Include, SourceLocation ExitLoc) = 0;
+
+  virtual void handleHasIncludeCheck(Preprocessor &PP, bool Result) = 0;
 };
 
 /// An individual dependency scanning worker that is able to run on its own
@@ -70,14 +85,16 @@ public:
   /// occurred, success otherwise.
   llvm::Error computeDependencies(StringRef WorkingDirectory,
                                   const std::vector<std::string> &CommandLine,
-                                  DependencyConsumer &Consumer,
+                                  DependencyScanningConsumerBase &Consumer,
                                   llvm::Optional<StringRef> ModuleName = None);
 
   /// Scan from a compiler invocation.
   void computeDependenciesFromCompilerInvocation(
       std::shared_ptr<CompilerInvocation> Invocation,
-      StringRef WorkingDirectory, DependencyConsumer &Consumer,
+      StringRef WorkingDirectory, DependencyScanningConsumerBase &Consumer,
       DiagnosticConsumer &DiagsConsumer);
+
+  ScanningOutputFormat getScanningFormat() const { return Format; }
 
   llvm::vfs::FileSystem &getRealFS() { return *RealFS; }
   llvm::cas::CachingOnDiskFileSystem &getCASFS() { return *CacheFS; }

--- a/clang/lib/CAS/CMakeLists.txt
+++ b/clang/lib/CAS/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
 
 add_clang_library(clangCAS
   CASOptions.cpp
+  IncludeTree.cpp
 
   LINK_LIBS
   clangBasic

--- a/clang/lib/CAS/IncludeTree.cpp
+++ b/clang/lib/CAS/IncludeTree.cpp
@@ -1,0 +1,207 @@
+//===- IncludeTree.cpp - Include-tree CAS graph -----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/CAS/IncludeTree.h"
+#include "llvm/ADT/SmallBitVector.h"
+#include "llvm/Support/EndianStream.h"
+
+using namespace clang;
+using namespace clang::cas;
+
+template <typename NodeT>
+Expected<NodeT> IncludeTreeBase<NodeT>::create(CASDB &DB,
+                                               ArrayRef<ObjectRef> Refs,
+                                               ArrayRef<char> Data) {
+  SmallString<256> Buf{NodeT::getNodeKind()};
+  Buf.reserve(Data.size() + NodeT::getNodeKind().size());
+  Buf.append(Data.begin(), Data.end());
+  auto Node = DB.store(Refs, Buf);
+  if (!Node)
+    return Node.takeError();
+  return NodeT(ObjectProxy::load(DB, *Node));
+}
+
+Expected<IncludeFile> IncludeFile::create(CASDB &DB, StringRef Filename,
+                                          ObjectRef Contents) {
+  auto PathHandle = DB.storeFromString({}, Filename);
+  if (!PathHandle)
+    return PathHandle.takeError();
+  std::array<ObjectRef, 2> Refs{DB.getReference(*PathHandle), Contents};
+  return IncludeTreeBase::create(DB, Refs, {});
+}
+
+llvm::Error IncludeTree::forEachInclude(
+    llvm::function_ref<llvm::Error(std::pair<IncludeTree, uint32_t>)>
+        Callback) {
+  size_t RefI = 0;
+  return forEachReference([&](ObjectRef Ref) -> llvm::Error {
+    if (RefI == 0) {
+      ++RefI;
+      return llvm::Error::success();
+    }
+    size_t IncludeI = RefI - 1;
+    ++RefI;
+    auto Include = getInclude(Ref);
+    if (!Include)
+      return Include.takeError();
+    return Callback({*Include, getIncludeOffset(IncludeI)});
+  });
+}
+
+Expected<IncludeTree>
+IncludeTree::create(CASDB &DB, SrcMgr::CharacteristicKind FileCharacteristic,
+                    ObjectRef BaseFile,
+                    ArrayRef<std::pair<ObjectRef, uint32_t>> Includes,
+                    llvm::SmallBitVector Checks) {
+  // The data buffer is composed of
+  // 1. `uint32_t` offsets of includes
+  // 2. 1 byte for `CharacteristicKind`
+  // 3. variable number of bitset bytes for `Checks`.
+
+  char Kind = FileCharacteristic;
+  assert(Kind == FileCharacteristic && "SrcMgr::CharacteristicKind too big!");
+  assert(IncludeFile::isValid(DB, BaseFile));
+  SmallVector<ObjectRef, 16> Refs;
+  Refs.reserve(Includes.size() + 1);
+  Refs.push_back(BaseFile);
+  SmallString<64> Buffer;
+  Buffer.reserve(Includes.size() * sizeof(uint32_t) + 1);
+
+  llvm::raw_svector_ostream BufOS(Buffer);
+  llvm::support::endian::Writer Writer(BufOS, llvm::support::little);
+
+  for (const auto &Include : Includes) {
+    ObjectRef FileRef = Include.first;
+    uint32_t Offset = Include.second;
+    assert(IncludeTree::isValid(DB, FileRef));
+    Refs.push_back(FileRef);
+    Writer.write(Offset);
+  }
+
+  Buffer += Kind;
+
+  uintptr_t Store;
+  ArrayRef<uintptr_t> BitWords = Checks.getData(Store);
+  size_t RemainingBitsCount = Checks.size();
+  while (RemainingBitsCount > 0) {
+    if (BitWords.size() > 1) {
+      Writer.write(BitWords.front());
+      BitWords = BitWords.drop_front();
+      RemainingBitsCount -= sizeof(uintptr_t) * CHAR_BIT;
+      continue;
+    }
+    assert(RemainingBitsCount <= sizeof(uintptr_t) * CHAR_BIT);
+    uintptr_t LastWord = BitWords.front();
+    unsigned BytesNum = RemainingBitsCount / CHAR_BIT;
+    if (RemainingBitsCount % CHAR_BIT != 0)
+      ++BytesNum;
+    while (BytesNum--) {
+      Buffer.push_back(LastWord & 0xFF);
+      LastWord >>= CHAR_BIT;
+    }
+    break;
+  }
+
+  return IncludeTreeBase::create(DB, Refs, Buffer);
+}
+
+Expected<IncludeTree> IncludeTree::get(CASDB &DB, ObjectRef Ref) {
+  auto Node = DB.getProxy(Ref);
+  if (!Node)
+    return Node.takeError();
+  if (!isValid(*Node))
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "not a IncludeTree node kind");
+  return IncludeTree(std::move(*Node));
+}
+
+uint32_t IncludeTree::getIncludeOffset(size_t I) const {
+  assert(I < getNumIncludes());
+  StringRef Data = getData();
+  assert(Data.size() >= (I + 1) * sizeof(uint32_t));
+  uint32_t Offset =
+      llvm::support::endian::read<uint32_t, llvm::support::little>(
+          Data.data() + I * sizeof(uint32_t));
+  return Offset;
+}
+
+bool IncludeTree::getCheckResult(size_t I) const {
+  // Skip include offsets and CharacteristicKind.
+  StringRef Data = dataSkippingIncludes().drop_front();
+  unsigned ByteIndex = I / CHAR_BIT;
+  size_t RemainingIndex = I % CHAR_BIT;
+  uint8_t Bits = Data[ByteIndex];
+  return Bits & (1 << RemainingIndex);
+}
+
+bool IncludeTree::isValid(const ObjectProxy &Node) {
+  if (!IncludeTreeBase::isValid(Node))
+    return false;
+  IncludeTreeBase Base(Node);
+  if (Base.getNumReferences() == 0)
+    return false;
+  unsigned NumIncludes = Base.getNumReferences() - 1;
+  return Base.getData().size() >= NumIncludes * sizeof(uint32_t) + 1;
+}
+
+Expected<IncludeTreeRoot> IncludeTreeRoot::create(CASDB &DB,
+                                                  ObjectRef MainFileTree) {
+  assert(IncludeTree::isValid(DB, MainFileTree));
+  return IncludeTreeBase::create(DB, MainFileTree, {});
+}
+
+Expected<IncludeTreeRoot> IncludeTreeRoot::get(CASDB &DB, ObjectRef Ref) {
+  auto Node = DB.getProxy(Ref);
+  if (!Node)
+    return Node.takeError();
+  if (!isValid(*Node))
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "not a IncludeTreeRoot node kind");
+  return IncludeTreeRoot(std::move(*Node));
+}
+
+llvm::Error IncludeFile::print(llvm::raw_ostream &OS, unsigned Indent) {
+  auto Filename = getFilename();
+  if (!Filename)
+    return Filename.takeError();
+  OS.indent(Indent) << Filename->getData() << ' ';
+  CAS->getID(getContentsRef()).print(OS);
+  OS << '\n';
+  return llvm::Error::success();
+}
+
+llvm::Error IncludeTree::print(llvm::raw_ostream &OS, unsigned Indent) {
+  auto IncludeBy = getBaseFile();
+  if (!IncludeBy)
+    return IncludeBy.takeError();
+  if (llvm::Error E = IncludeBy->print(OS))
+    return E;
+
+  llvm::SourceMgr SM;
+  auto Blob = IncludeBy->getContents();
+  if (!Blob)
+    return Blob.takeError();
+  auto MemBuf = llvm::MemoryBuffer::getMemBuffer(Blob->getData());
+  unsigned BufID = SM.AddNewSourceBuffer(std::move(MemBuf), llvm::SMLoc());
+
+  return forEachInclude(
+      [&](std::pair<cas::IncludeTree, uint32_t> Include) -> llvm::Error {
+        llvm::SMLoc Loc = llvm::SMLoc::getFromPointer(
+            SM.getMemoryBuffer(BufID)->getBufferStart() + Include.second);
+        auto LineCol = SM.getLineAndColumn(Loc);
+        OS.indent(Indent) << LineCol.first << ':' << LineCol.second << ' ';
+        return Include.first.print(OS, Indent + 2);
+      });
+}
+
+llvm::Error IncludeTreeRoot::print(llvm::raw_ostream &OS, unsigned Indent) {
+  Optional<cas::IncludeTree> MainTree;
+  if (llvm::Error E = getMainFileTree().moveInto(MainTree))
+    return E;
+  return MainTree->print(OS, Indent);
+}

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -136,12 +136,64 @@ static void sanitizeDiagOpts(DiagnosticOptions &DiagOpts) {
   DiagOpts.Warnings.push_back("no-error");
 }
 
+struct IncludeTreePPCallbacks : public PPCallbacks {
+  PPIncludeActionsConsumer &Consumer;
+  Preprocessor &PP;
+
+public:
+  IncludeTreePPCallbacks(PPIncludeActionsConsumer &Consumer, Preprocessor &PP)
+      : Consumer(Consumer), PP(PP) {}
+
+  void LexedFileChanged(FileID FID, LexedFileChangeReason Reason,
+                        SrcMgr::CharacteristicKind FileType, FileID PrevFID,
+                        SourceLocation Loc) override {
+    switch (Reason) {
+    case LexedFileChangeReason::EnterFile:
+      Consumer.enteredInclude(PP, FID);
+      break;
+    case LexedFileChangeReason::ExitFile: {
+      Consumer.exitedInclude(PP, FID, PrevFID, Loc);
+      break;
+    }
+    }
+  }
+
+  void HasInclude(SourceLocation Loc, StringRef FileName, bool IsAngled,
+                  Optional<FileEntryRef> File,
+                  SrcMgr::CharacteristicKind FileType) override {
+    Consumer.handleHasIncludeCheck(PP, File.hasValue());
+  }
+};
+
+class IncludeTreeCollector : public DependencyFileGenerator {
+  PPIncludeActionsConsumer &Consumer;
+  std::unique_ptr<DependencyOutputOptions> Opts;
+  bool EmitDependencyFile = false;
+
+public:
+  IncludeTreeCollector(PPIncludeActionsConsumer &Consumer,
+                       std::unique_ptr<DependencyOutputOptions> Opts,
+                       bool EmitDependencyFile)
+      : DependencyFileGenerator(*Opts), Consumer(Consumer),
+        Opts(std::move(Opts)), EmitDependencyFile(EmitDependencyFile) {}
+
+  void attachToPreprocessor(Preprocessor &PP) override {
+    PP.addPPCallbacks(std::make_unique<IncludeTreePPCallbacks>(Consumer, PP));
+    DependencyFileGenerator::attachToPreprocessor(PP);
+  }
+
+  void finishedMainFile(DiagnosticsEngine &Diags) override {
+    if (EmitDependencyFile)
+      DependencyFileGenerator::finishedMainFile(Diags);
+  }
+};
+
 /// A clang tool that runs the preprocessor in a mode that's optimized for
 /// dependency scanning for the given compiler invocation.
 class DependencyScanningAction : public tooling::ToolAction {
 public:
   DependencyScanningAction(
-      StringRef WorkingDirectory, DependencyConsumer &Consumer,
+      StringRef WorkingDirectory, DependencyScanningConsumerBase &Consumer,
       const CASOptions &CASOpts,
       llvm::IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS,
       llvm::IntrusiveRefCntPtr<DependencyScanningCASFilesystem> DepCASFS,
@@ -252,14 +304,22 @@ public:
     case ScanningOutputFormat::Make:
     case ScanningOutputFormat::Tree:
       ScanInstance.addDependencyCollector(
-          std::make_shared<DependencyConsumerForwarder>(std::move(Opts),
-                                                        Consumer,
-                                                        EmitDependencyFile));
+          std::make_shared<DependencyConsumerForwarder>(
+              std::move(Opts), static_cast<DependencyConsumer &>(Consumer),
+              EmitDependencyFile));
       break;
+    case ScanningOutputFormat::IncludeTree: {
+      ScanInstance.addDependencyCollector(
+          std::make_shared<IncludeTreeCollector>(
+              static_cast<PPIncludeActionsConsumer &>(Consumer),
+              std::move(Opts), EmitDependencyFile));
+      break;
+    }
     case ScanningOutputFormat::Full:
     case ScanningOutputFormat::FullTree:
       ScanInstance.addDependencyCollector(std::make_shared<ModuleDepCollector>(
-          std::move(Opts), ScanInstance, Consumer,
+          std::move(Opts), ScanInstance,
+          static_cast<DependencyConsumer &>(Consumer),
           std::move(OriginalInvocation), OptimizeArgs));
       break;
     }
@@ -302,7 +362,7 @@ public:
 
 private:
   StringRef WorkingDirectory;
-  DependencyConsumer &Consumer;
+  DependencyScanningConsumerBase &Consumer;
   const CASOptions &CASOpts;
   llvm::IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS;
   llvm::IntrusiveRefCntPtr<DependencyScanningCASFilesystem> DepCASFS;
@@ -380,7 +440,8 @@ runWithDiags(DiagnosticOptions *DiagOpts,
 
 llvm::Error DependencyScanningWorker::computeDependencies(
     StringRef WorkingDirectory, const std::vector<std::string> &CommandLine,
-    DependencyConsumer &Consumer, llvm::Optional<StringRef> ModuleName) {
+    DependencyScanningConsumerBase &Consumer,
+    llvm::Optional<StringRef> ModuleName) {
   // Reset what might have been modified in the previous worker invocation.
   RealFS->setCurrentWorkingDirectory(WorkingDirectory);
   if (Files)
@@ -429,7 +490,8 @@ llvm::Error DependencyScanningWorker::computeDependencies(
 
 void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
     std::shared_ptr<CompilerInvocation> Invocation, StringRef WorkingDirectory,
-    DependencyConsumer &DepsConsumer, DiagnosticConsumer &DiagsConsumer) {
+    DependencyScanningConsumerBase &DepsConsumer,
+    DiagnosticConsumer &DiagsConsumer) {
   RealFS->setCurrentWorkingDirectory(WorkingDirectory);
 
   // Adjust the invocation.

--- a/clang/test/ClangScanDeps/include-tree.c
+++ b/clang/test/ClangScanDeps/include-tree.c
@@ -1,0 +1,93 @@
+// RUN: rm -rf %t
+// RUN: split-file --leading-lines %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-include-tree -cas-path %t/cas > %t/result1.txt
+// Try again to ensure a pre-populated CASDB doesn't change output.
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-include-tree -cas-path %t/cas > %t/result2.txt
+// RUN: diff -u %t/result1.txt %t/result2.txt
+// RUN: FileCheck %s -input-file %t/result1.txt -DPREFIX=%/t
+
+// Make sure order is as expected.
+// RUN: FileCheck %s -input-file %t/result1.txt -DPREFIX=%/t -check-prefix ORDER
+
+// ORDER:      {{.*}} - [[PREFIX]]/t.c
+// ORDER-NEXT: [[PREFIX]]/t.c
+// ORDER-NEXT: 1:1 <built-in>
+// ORDER-NEXT:   [[PREFIX]]/top.h
+// ORDER-NEXT:     [[PREFIX]]/n1.h
+// ORDER-NEXT:       [[PREFIX]]/n2.h
+// ORDER-NEXT:     [[PREFIX]]/n3.h
+// ORDER-NEXT: [[PREFIX]]/n3.h
+// ORDER-NEXT: [[PREFIX]]/n2.h
+// ORDER-NOT: [[PREFIX]]
+
+
+//--- cdb.json.template
+[
+  {
+    "directory": "DIR",
+    "command": "clang -fsyntax-only DIR/t.c",
+    "file": "DIR/t.c"
+  }
+]
+
+//--- t.c
+
+#include "top.h" // this is top
+// CHECK: [[@LINE]]:1 [[PREFIX]]/top.h
+
+// Skipped because of macro guard.
+#include "n1.h"
+
+#include "n3.h"
+// CHECK-DAG: [[@LINE]]:1 [[PREFIX]]/n3.h
+
+#include "n2.h"
+// CHECK-DAG: [[@LINE]]:1 [[PREFIX]]/n2.h
+
+//--- top.h
+#ifndef _TOP_H_
+#define _TOP_H_
+
+#if WHATEVER
+typedef int MyT;
+#endif
+
+#define WHATEVER 1
+#include "n1.h"
+// CHECK-DAG:   [[@LINE]]:1 [[PREFIX]]/n1.h
+
+#include "n3.h"
+// CHECK-DAG:   [[@LINE]]:1 [[PREFIX]]/n3.h
+
+#define ANOTHER 2
+
+struct S {
+  int x;
+};
+
+#endif
+
+//--- n1.h
+#pragma once
+
+int x1;
+#include "n2.h"
+// CHECK-DAG:     [[@LINE]]:1 [[PREFIX]]/n2.h
+
+int x2;
+
+//--- n2.h
+void foo(void);
+
+//--- n3.h
+#ifndef _N3_H_
+#define _N3_H_
+
+int x3;
+
+#endif
+
+// More stuff after following '#endif', invalidate the macro guard optimization.
+#define THIS_INVALIDATES_THE_MACRO_GUARD 1

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "clang/CAS/IncludeTree.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Tooling/CommonOptionsParser.h"
@@ -18,6 +19,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/CAS/CASDB.h"
+#include "llvm/CAS/CASProvidingFileSystem.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileUtilities.h"
@@ -142,6 +144,9 @@ static llvm::cl::opt<ScanningOutputFormat> Format(
                    "Write out a CAS tree that contains the dependencies."),
         clEnumValN(ScanningOutputFormat::FullTree, "experimental-tree-full",
                    "Full dependency graph with CAS tree as depdendency."),
+        clEnumValN(ScanningOutputFormat::IncludeTree,
+                   "experimental-include-tree",
+                   "Write out a CAS include tree."),
         clEnumValN(ScanningOutputFormat::Full, "experimental-full",
                    "Full dependency graph suitable"
                    " for explicitly building modules. This format "
@@ -448,6 +453,41 @@ static bool handleTreeDependencyToolResult(
   return false;
 }
 
+static bool
+handleIncludeTreeToolResult(llvm::cas::CASDB &CAS, const std::string &Input,
+                            Expected<cas::IncludeTreeRoot> &MaybeTree,
+                            SharedStream &OS, SharedStream &Errs) {
+  if (!MaybeTree) {
+    llvm::handleAllErrors(
+        MaybeTree.takeError(), [&Input, &Errs](llvm::StringError &Err) {
+          Errs.applyLocked([&](raw_ostream &OS) {
+            OS << "Error while scanning dependencies for " << Input << ":\n";
+            OS << Err.getMessage();
+            OS << "\n";
+          });
+        });
+    return true;
+  }
+  auto printError = [&Errs](llvm::Error &&E) -> bool {
+    llvm::handleAllErrors(std::move(E), [&Errs](llvm::StringError &Err) {
+      Errs.applyLocked([&](raw_ostream &OS) {
+        OS << "Error while printing include tree: " << Err.getMessage() << "\n";
+      });
+    });
+    return true;
+  };
+
+  Optional<llvm::Error> E;
+  OS.applyLocked([&](llvm::raw_ostream &OS) {
+    MaybeTree->getID().print(OS);
+    OS << " - " << Input << "\n";
+    E = MaybeTree->print(OS);
+  });
+  if (*E)
+    return printError(std::move(*E));
+  return false;
+}
+
 static bool outputFormatRequiresCAS() {
   switch (Format) {
     case ScanningOutputFormat::Make:
@@ -455,6 +495,7 @@ static bool outputFormatRequiresCAS() {
       return false;
     case ScanningOutputFormat::Tree:
     case ScanningOutputFormat::FullTree:
+    case ScanningOutputFormat::IncludeTree:
       return true;
   }
 }
@@ -769,7 +810,8 @@ int main(int argc, const char **argv) {
     CAS = CASOpts.getOrCreateCAS(Diags);
     if (!CAS)
       return 1;
-    FS = llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*CAS));
+    if (Format != ScanningOutputFormat::IncludeTree)
+      FS = llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*CAS));
   }
   DependencyScanningService Service(ScanMode, Format, CASOpts, FS,
                                     ReuseFileManager, OptimizeArgs,
@@ -789,8 +831,14 @@ int main(int argc, const char **argv) {
   }
 
   std::vector<std::unique_ptr<DependencyScanningTool>> WorkerTools;
-  for (unsigned I = 0; I < Pool.getThreadCount(); ++I)
-    WorkerTools.push_back(std::make_unique<DependencyScanningTool>(Service));
+  for (unsigned I = 0; I < Pool.getThreadCount(); ++I) {
+    std::unique_ptr<llvm::vfs::FileSystem> FS =
+        llvm::vfs::createPhysicalFileSystem();
+    if (CAS)
+      FS = llvm::cas::createCASProvidingFileSystem(CAS, std::move(FS));
+    WorkerTools.push_back(
+        std::make_unique<DependencyScanningTool>(Service, std::move(FS)));
+  }
 
   std::vector<tooling::CompileCommand> Inputs =
       AdjustingCompilations->getAllCompileCommands();
@@ -803,16 +851,26 @@ int main(int argc, const char **argv) {
   struct DepTreeResult {
     size_t Index;
     std::string Filename;
-    Expected<llvm::cas::ObjectProxy> MaybeTree;
+    Optional<Expected<cas::ObjectProxy>> MaybeTree;
+    Optional<Expected<cas::IncludeTreeRoot>> MaybeIncludeTree;
+
+    DepTreeResult(size_t Index, std::string Filename,
+                  Expected<cas::ObjectProxy> Tree)
+        : Index(Index), Filename(std::move(Filename)),
+          MaybeTree(std::move(Tree)) {}
+    DepTreeResult(size_t Index, std::string Filename,
+                  Expected<cas::IncludeTreeRoot> Tree)
+        : Index(Index), Filename(std::move(Filename)),
+          MaybeIncludeTree(std::move(Tree)) {}
   };
-  std::vector<DepTreeResult> TreeResults;
+  SmallVector<DepTreeResult> TreeResults;
 
   if (Verbose) {
     llvm::outs() << "Running clang-scan-deps on " << Inputs.size()
                  << " files using " << Pool.getThreadCount() << " workers\n";
   }
   for (unsigned I = 0; I < Pool.getThreadCount(); ++I) {
-    Pool.async([I, &Lock, &Index, &Inputs, &TreeResults, &HadErrors, &FD,
+    Pool.async([I, &CAS, &Lock, &Index, &Inputs, &TreeResults, &HadErrors, &FD,
                 &WorkerTools, &DependencyOS, &Errs]() {
       llvm::StringSet<> AlreadySeenModules;
       while (true) {
@@ -844,8 +902,14 @@ int main(int argc, const char **argv) {
           auto MaybeTree =
               WorkerTools[I]->getDependencyTree(Input->CommandLine, CWD);
           std::unique_lock<std::mutex> LockGuard(Lock);
-          TreeResults.push_back(
-              {LocalIndex, std::move(Filename), std::move(MaybeTree)});
+          TreeResults.emplace_back(LocalIndex, std::move(Filename),
+                                   std::move(MaybeTree));
+        } else if (Format == ScanningOutputFormat::IncludeTree) {
+          auto MaybeTree =
+              WorkerTools[I]->getIncludeTree(*CAS, Input->CommandLine, CWD);
+          std::unique_lock<std::mutex> LockGuard(Lock);
+          TreeResults.emplace_back(LocalIndex, std::move(Filename),
+                                   std::move(MaybeTree));
         } else {
           auto MaybeFullDeps = WorkerTools[I]->getFullDependencies(
               Input->CommandLine, CWD, AlreadySeenModules, MaybeModuleName);
@@ -858,15 +922,22 @@ int main(int argc, const char **argv) {
   }
   Pool.wait();
 
+  std::sort(TreeResults.begin(), TreeResults.end(),
+            [](const DepTreeResult &LHS, const DepTreeResult &RHS) -> bool {
+              return LHS.Index < RHS.Index;
+            });
   if (Format == ScanningOutputFormat::Tree) {
-    std::sort(TreeResults.begin(), TreeResults.end(),
-              [](const DepTreeResult &LHS, const DepTreeResult &RHS) -> bool {
-                return LHS.Index < RHS.Index;
-              });
     for (auto &TreeResult : TreeResults) {
       if (handleTreeDependencyToolResult(*CAS, TreeResult.Filename,
-                                         TreeResult.MaybeTree, DependencyOS,
+                                         *TreeResult.MaybeTree, DependencyOS,
                                          Errs))
+        HadErrors = true;
+    }
+  } else if (Format == ScanningOutputFormat::IncludeTree) {
+    for (auto &TreeResult : TreeResults) {
+      if (handleIncludeTreeToolResult(*CAS, TreeResult.Filename,
+                                      *TreeResult.MaybeIncludeTree,
+                                      DependencyOS, Errs))
         HadErrors = true;
     }
   } else if (Format == ScanningOutputFormat::Full ||

--- a/clang/unittests/CAS/CMakeLists.txt
+++ b/clang/unittests/CAS/CMakeLists.txt
@@ -5,12 +5,14 @@ set(LLVM_LINK_COMPONENTS
 
 add_clang_unittest(ClangCASTests
   CASOptionsTest.cpp
+  IncludeTreeTest.cpp
   )
 
 clang_target_link_libraries(ClangCASTests
   PRIVATE
   clangBasic
   clangCAS
+  clangDependencyScanning
   )
 
 target_link_libraries(ClangCASTests

--- a/clang/unittests/CAS/IncludeTreeTest.cpp
+++ b/clang/unittests/CAS/IncludeTreeTest.cpp
@@ -1,0 +1,119 @@
+#include "clang/CAS/IncludeTree.h"
+#include "clang/Tooling/DependencyScanning/DependencyScanningTool.h"
+#include "llvm/CAS/CASDB.h"
+#include "llvm/CAS/CASProvidingFileSystem.h"
+#include "llvm/CAS/CachingOnDiskFileSystem.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+
+using namespace clang;
+using namespace clang::cas;
+
+using namespace tooling;
+using namespace dependencies;
+
+TEST(IncludeTree, IncludeTreeScan) {
+  std::shared_ptr<CASDB> DB = llvm::cas::createInMemoryCAS();
+  auto FS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  auto add = [&](StringRef Path, StringRef Contents) {
+    FS->addFile(Path, 0, llvm::MemoryBuffer::getMemBuffer(Contents));
+  };
+  StringRef MainContents = R"(
+    #include "a1.h"
+    #include "sys.h"
+  )";
+  StringRef A1Contents = R"(
+    #if __has_include("other.h")
+      #include "other.h"
+    #endif
+    #if __has_include("b1.h")
+      #include "b1.h"
+    #endif
+  )";
+  add("t.cpp", MainContents);
+  add("a1.h", A1Contents);
+  add("b1.h", "");
+  add("sys/sys.h", "");
+  std::unique_ptr<llvm::vfs::FileSystem> VFS =
+      llvm::cas::createCASProvidingFileSystem(DB, FS);
+
+  DependencyScanningService Service(ScanningMode::DependencyDirectivesScan,
+                                    ScanningOutputFormat::IncludeTree,
+                                    CASOptions(), nullptr);
+  DependencyScanningTool ScanTool(Service, std::move(VFS));
+
+  std::vector<std::string> CommandLine = {"clang",
+                                          "-target",
+                                          "x86_64-apple-macos11",
+                                          "-isystem",
+                                          "sys",
+                                          "-c",
+                                          "t.cpp",
+                                          "-o"
+                                          "t.cpp.o"};
+  Optional<IncludeTreeRoot> Root;
+  ASSERT_THAT_ERROR(
+      ScanTool.getIncludeTree(*DB, CommandLine, /*CWD*/ "").moveInto(Root),
+      llvm::Succeeded());
+  Optional<IncludeTree> Main;
+  ASSERT_THAT_ERROR(Root->getMainFileTree().moveInto(Main), llvm::Succeeded());
+  {
+    EXPECT_EQ(Main->getFileCharacteristic(), SrcMgr::C_User);
+    IncludeFile::FileInfo FI;
+    ASSERT_THAT_ERROR(Main->getBaseFileInfo().moveInto(FI), llvm::Succeeded());
+    EXPECT_EQ(FI.Filename, "t.cpp");
+    EXPECT_EQ(FI.Contents, MainContents);
+  }
+  ASSERT_EQ(Main->getNumIncludes(), uint32_t(3));
+
+  Optional<IncludeTree> Predef;
+  ASSERT_THAT_ERROR(Main->getInclude(0).moveInto(Predef), llvm::Succeeded());
+  EXPECT_EQ(Main->getIncludeOffset(0), uint32_t(0));
+  {
+    EXPECT_EQ(Predef->getFileCharacteristic(), SrcMgr::C_User);
+    IncludeFile::FileInfo FI;
+    ASSERT_THAT_ERROR(Predef->getBaseFileInfo().moveInto(FI),
+                      llvm::Succeeded());
+    EXPECT_EQ(FI.Filename, "<built-in>");
+  }
+
+  Optional<IncludeTree> A1;
+  ASSERT_THAT_ERROR(Main->getInclude(1).moveInto(A1), llvm::Succeeded());
+  EXPECT_EQ(Main->getIncludeOffset(1), uint32_t(21));
+  {
+    EXPECT_EQ(A1->getFileCharacteristic(), SrcMgr::C_User);
+    IncludeFile::FileInfo FI;
+    ASSERT_THAT_ERROR(A1->getBaseFileInfo().moveInto(FI), llvm::Succeeded());
+    EXPECT_EQ(FI.Filename, "./a1.h");
+    EXPECT_EQ(FI.Contents, A1Contents);
+    EXPECT_FALSE(A1->getCheckResult(0));
+    EXPECT_TRUE(A1->getCheckResult(1));
+
+    ASSERT_EQ(A1->getNumIncludes(), uint32_t(1));
+    Optional<IncludeTree> B1;
+    ASSERT_THAT_ERROR(A1->getInclude(0).moveInto(B1), llvm::Succeeded());
+    EXPECT_EQ(A1->getIncludeOffset(0), uint32_t(122));
+    {
+      EXPECT_EQ(B1->getFileCharacteristic(), SrcMgr::C_User);
+      IncludeFile::FileInfo FI;
+      ASSERT_THAT_ERROR(B1->getBaseFileInfo().moveInto(FI), llvm::Succeeded());
+      EXPECT_EQ(FI.Filename, "./b1.h");
+      EXPECT_EQ(FI.Contents, "");
+
+      ASSERT_EQ(B1->getNumIncludes(), uint32_t(0));
+    }
+  }
+
+  Optional<IncludeTree> Sys;
+  ASSERT_THAT_ERROR(Main->getInclude(2).moveInto(Sys), llvm::Succeeded());
+  EXPECT_EQ(Main->getIncludeOffset(2), uint32_t(42));
+  {
+    EXPECT_EQ(Sys->getFileCharacteristic(), SrcMgr::C_System);
+    IncludeFile::FileInfo FI;
+    ASSERT_THAT_ERROR(Sys->getBaseFileInfo().moveInto(FI), llvm::Succeeded());
+    EXPECT_EQ(FI.Filename, "sys/sys.h");
+    EXPECT_EQ(FI.Contents, "");
+
+    ASSERT_EQ(Sys->getNumIncludes(), uint32_t(0));
+  }
+}

--- a/llvm/include/llvm/CAS/CASDB.h
+++ b/llvm/include/llvm/CAS/CASDB.h
@@ -273,6 +273,7 @@ public:
 template <class HandleT> class ProxyBase : public HandleT {
 public:
   const CASDB &getCAS() const { return *CAS; }
+  CASDB &getCAS() { return *CAS; }
   CASID getID() const {
     return CAS->getID(*static_cast<const ObjectHandle *>(this));
   }
@@ -298,8 +299,8 @@ public:
   }
 
 protected:
-  ProxyBase(const CASDB &CAS, HandleT H) : HandleT(H), CAS(&CAS) {}
-  const CASDB *CAS;
+  ProxyBase(CASDB &CAS, HandleT H) : HandleT(H), CAS(&CAS) {}
+  CASDB *CAS;
 };
 
 
@@ -354,8 +355,7 @@ public:
   }
 
 private:
-  ObjectProxy(const CASDB &CAS, ObjectHandle H, size_t NumReferences,
-              StringRef Data)
+  ObjectProxy(CASDB &CAS, ObjectHandle H, size_t NumReferences, StringRef Data)
       : ProxyBase::ProxyBase(CAS, H), NumReferences(NumReferences), Data(Data) {
   }
 


### PR DESCRIPTION
This is the first step towards introducing the "include-tree" mechanism, which records a DAG of included files by the preprocessor during CAS-enabled dependency scanning, and then uses it as input to "replay" when invoking clang to produce the build artifacts.
    
The primary advantage of the include-tree compared to the `CachingOnDiskFileSystem` mechanism is that

1. We avoid the complexity of needing to accurately simulate the file-system and match exactly what the file-system interactions were during dependency scanning
2. We avoid getting input dependencies that are not materially affecting the compilation. Specifically we avoid needing any search paths, headermaps, or VFS files, when running the actual compilation. For example if a search path is added, or a new header is added in a headermap, and this change doesn't affect the files that the preprocessor is seeing during dependency scanning then the compilation cache key will remain the same.

As additional benefit, the include-tree mechanism provides better performance during CAS-enabled dependency scanning; the following are wall-time measurements on an M1Pro with a thin-LTO enabled build, where `clang-scan-deps` is run over a compilation-db that includes all the files that are linked to the clang executable. It compares `-format=experimental-include-tree` with `-format=experimental-tree` and `-format=make`.

|              | casfs-tree | make  |
|--------------|------------|-------|
| include-tree | -22.2%     | +5.7% |
