### PR TITLE
[CAS] CASDB interface cleanup

### DIFF
--- a/llvm/include/llvm/CAS/CASDB.h
+++ b/llvm/include/llvm/CAS/CASDB.h
@@ -83,10 +83,8 @@ class ObjectProxy;
 ///
 /// TODO: Remove CASID.
 ///
-/// Here's how to remove CASID and Tree:
+/// Here's how to remove CASID:
 ///
-/// - Lift trees into a filesystem schema, dropping TreeHandle and making
-///   TreeProxy inherit from NodeProxy.
 /// - Add APIs for bypassing CASID when parsing:
 ///     - Validate an ID without doing anything else (current check done by
 ///       `parseID()`).
@@ -134,10 +132,67 @@ public:
   /// extractHashFromID().
   virtual Expected<CASID> parseID(StringRef ID) = 0;
 
-  Expected<ObjectProxy> createProxy(ArrayRef<ObjectRef> Refs, StringRef Data);
+  /// Store object into CASDB.
   virtual Expected<ObjectHandle> store(ArrayRef<ObjectRef> Refs,
                                        ArrayRef<char> Data) = 0;
+  /// Get an ID for \p Ref.
+  virtual CASID getID(ObjectRef Ref) const = 0;
+  /// Get an ID for \p Handle.
+  virtual CASID getID(ObjectHandle Handle) const = 0;
 
+  /// Get a reference to the object called \p ID.
+  ///
+  /// Returns \c None if not stored in this CAS.
+  virtual Optional<ObjectRef> getReference(const CASID &ID) const = 0;
+
+  /// Get a Ref from Handle.
+  virtual ObjectRef getReference(ObjectHandle Handle) const = 0;
+
+  /// Load the object referenced by \p Ref.
+  ///
+  /// Errors if the object cannot be loaded.
+  virtual Expected<ObjectHandle> load(ObjectRef Ref) = 0;
+
+  /// Validate the underlying object referred by CASID.
+  virtual Error validate(const CASID &ID) = 0;
+
+  /// Get the size of some data.
+  virtual uint64_t getDataSize(ObjectHandle Node) const = 0;
+
+  /// Methods for handling objects.
+  virtual Error forEachRef(ObjectHandle Node,
+                           function_ref<Error(ObjectRef)> Callback) const = 0;
+  virtual ObjectRef readRef(ObjectHandle Node, size_t I) const = 0;
+  virtual size_t getNumRefs(ObjectHandle Node) const = 0;
+  virtual ArrayRef<char> getData(ObjectHandle Node,
+                                 bool RequiresNullTerminator = false) const = 0;
+
+public:
+  /// ActionCache APIs.
+  // FIXME: Split out in the future. This should also be generic key-value
+  // storage interface, rather than CASID -> CASID.
+  virtual Expected<CASID> getCachedResult(CASID InputID) = 0;
+  virtual Error putCachedResult(CASID InputID, CASID OutputID) = 0;
+
+protected:
+  virtual Expected<ObjectHandle>
+  storeFromOpenFileImpl(sys::fs::file_t FD,
+                        Optional<sys::fs::file_status> Status);
+
+  /// Allow CASDB implementations to create internal handles.
+#define MAKE_CAS_HANDLE_CONSTRUCTOR(HandleKind)                                \
+  HandleKind make##HandleKind(uint64_t InternalRef) const {                    \
+    return HandleKind(*this, InternalRef);                                     \
+  }
+  MAKE_CAS_HANDLE_CONSTRUCTOR(ObjectHandle)
+  MAKE_CAS_HANDLE_CONSTRUCTOR(ObjectRef)
+#undef MAKE_CAS_HANDLE_CONSTRUCTOR
+
+public:
+  /// Helper functions to store object and returns a ObjectProxy.
+  Expected<ObjectProxy> createProxy(ArrayRef<ObjectRef> Refs, StringRef Data);
+
+  /// Store object from StringRef.
   Expected<ObjectHandle> storeFromString(ArrayRef<ObjectRef> Refs,
                                          StringRef String) {
     return store(Refs, arrayRefFromStringRef<char>(String));
@@ -158,37 +213,6 @@ public:
     return storeFromOpenFileImpl(FD, Status);
   }
 
-protected:
-  virtual Expected<ObjectHandle>
-  storeFromOpenFileImpl(sys::fs::file_t FD,
-                        Optional<sys::fs::file_status> Status);
-
-  /// Allow CASDB implementations to create internal handles.
-#define MAKE_CAS_HANDLE_CONSTRUCTOR(HandleKind)                                \
-  HandleKind make##HandleKind(uint64_t InternalRef) const {                    \
-    return HandleKind(*this, InternalRef);                                     \
-  }
-  MAKE_CAS_HANDLE_CONSTRUCTOR(ObjectHandle)
-  MAKE_CAS_HANDLE_CONSTRUCTOR(ObjectRef)
-#undef MAKE_CAS_HANDLE_CONSTRUCTOR
-
-public:
-  /// Get an ID for \p Ref.
-  virtual CASID getID(ObjectRef Ref) const = 0;
-  virtual CASID getID(ObjectHandle Handle) const = 0;
-
-  /// Get a reference to the object called \p ID.
-  ///
-  /// Returns \c None if not stored in this CAS.
-  virtual Optional<ObjectRef> getReference(const CASID &ID) const = 0;
-
-  virtual ObjectRef getReference(ObjectHandle Handle) const = 0;
-
-  /// Load the object referenced by \p Ref.
-  ///
-  /// Errors if the object cannot be loaded.
-  virtual Expected<ObjectHandle> load(ObjectRef Ref) = 0;
-
   /// Load the object called \p ID.
   ///
   /// Returns \c None if it's unknown in this CAS instance.
@@ -198,76 +222,48 @@ public:
 
   static Error createUnknownObjectError(CASID ID);
 
+  /// Create ObjectProxy from other types that refer to object.
   Expected<ObjectProxy> getProxy(CASID ID);
   Expected<ObjectProxy> getProxy(ObjectRef Ref);
   Expected<ObjectProxy> getProxy(Expected<ObjectHandle> H);
 
-  virtual Error validate(const CASID &ID) = 0;
-
-public:
-  /// Get the size of some data.
-  virtual uint64_t getDataSize(ObjectHandle Node) const = 0;
-
   /// Read the data from \p Data into \p OS.
   uint64_t readData(ObjectHandle Node, raw_ostream &OS, uint64_t Offset = 0,
                     uint64_t MaxBytes = -1ULL) const {
-    return readDataImpl(Node, OS, Offset, MaxBytes);
+    ArrayRef<char> Data = getData(Node);
+    assert(Offset < Data.size() && "Expected valid offset");
+    Data = Data.drop_front(Offset).take_front(MaxBytes);
+    OS << toStringRef(Data);
+    return Data.size();
   }
 
-protected:
-  virtual uint64_t readDataImpl(ObjectHandle Node, raw_ostream &OS,
-                                uint64_t Offset, uint64_t MaxBytes) const = 0;
-
-public:
   /// Get a lifetime-extended StringRef pointing at \p Data.
   ///
   /// Depending on the CAS implementation, this may involve in-memory storage
   /// overhead.
-  StringRef getDataString(ObjectHandle Node, bool NullTerminate = true) {
-    return toStringRef(getDataImpl(Node, NullTerminate));
+  StringRef getDataString(ObjectHandle Node) {
+    return toStringRef(getData(Node));
   }
 
-  /// Get a lifetime-extended ArrayRef pointing at \p Data.
+  /// Get a lifetime-extended MemoryBuffer pointing at \p Data.
   ///
   /// Depending on the CAS implementation, this may involve in-memory storage
   /// overhead.
-  template <class CharT = char>
-  ArrayRef<CharT> getDataArray(ObjectHandle Node, bool NullTerminate = true) {
-    static_assert(std::is_same<CharT, char>::value ||
-                      std::is_same<CharT, unsigned char>::value ||
-                      std::is_same<CharT, signed char>::value,
-                  "Expected byte type");
-    ArrayRef<char> S = getDataImpl(Node, NullTerminate);
-    return makeArrayRef(reinterpret_cast<const CharT *>(S.data()), S.size());
-  }
+  std::unique_ptr<MemoryBuffer>
+  getMemoryBuffer(ObjectHandle Node, StringRef Name = "",
+                  bool RequiresNullTerminator = true);
 
-protected:
-  virtual ArrayRef<char> getDataImpl(ObjectHandle Node, bool NullTerminate) = 0;
-
-public:
   /// Get a MemoryBuffer with the contents of \p Data whose lifetime is
   /// independent of this CAS instance.
-  Expected<std::unique_ptr<MemoryBuffer>>
+  virtual Expected<std::unique_ptr<MemoryBuffer>>
   loadIndependentDataBuffer(ObjectHandle Node, const Twine &Name = "",
                             bool NullTerminate = true) const;
 
-protected:
-  virtual Expected<std::unique_ptr<MemoryBuffer>>
-  loadIndependentDataBufferImpl(ObjectHandle Node, const Twine &Name,
-                                bool NullTerminate) const;
-
-public:
-  virtual Error forEachRef(ObjectHandle Node,
-                           function_ref<Error(ObjectRef)> Callback) const = 0;
+  /// Read all the refs from object in a SmallVector.
   virtual void readRefs(ObjectHandle Node,
                         SmallVectorImpl<ObjectRef> &Refs) const;
-  virtual ObjectRef readRef(ObjectHandle Node, size_t I) const = 0;
-  virtual size_t getNumRefs(ObjectHandle Node) const = 0;
 
-
-  virtual Expected<CASID> getCachedResult(CASID InputID) = 0;
-  virtual Error putCachedResult(CASID InputID, CASID OutputID) = 0;
-
+  /// Print the CASDB internals for debugging purpose.
   virtual void print(raw_ostream &) const {}
   void dump() const;
 

--- a/llvm/lib/CAS/BuiltinCAS.cpp
+++ b/llvm/lib/CAS/BuiltinCAS.cpp
@@ -103,15 +103,6 @@ Expected<ObjectHandle> BuiltinCAS::store(ArrayRef<ObjectRef> Refs,
                    Refs, Data);
 }
 
-uint64_t BuiltinCAS::readDataImpl(ObjectHandle Node, raw_ostream &OS,
-                                  uint64_t Offset, uint64_t MaxBytes) const {
-  ArrayRef<char> Data = getDataConst(Node);
-  assert(Offset < Data.size() && "Expected valid offset");
-  Data = Data.drop_front(Offset).take_front(MaxBytes);
-  OS << toStringRef(Data);
-  return Data.size();
-}
-
 Error BuiltinCAS::validate(const CASID &ID) {
   auto Handle = load(ID);
   if (!Handle)

--- a/llvm/lib/CAS/BuiltinCAS.h
+++ b/llvm/lib/CAS/BuiltinCAS.h
@@ -183,14 +183,14 @@ public:
   /// it.
   virtual ArrayRef<char> getDataConst(ObjectHandle Node) const = 0;
 
-  ArrayRef<char> getDataImpl(ObjectHandle Node, bool NullTerminate) final {
+  ArrayRef<char> getData(ObjectHandle Node,
+                         bool RequiresNullTerminator) const final {
+    // BuiltinCAS Objects are always null terminated.
     return getDataConst(Node);
   }
   uint64_t getDataSize(ObjectHandle Node) const final {
     return getDataConst(Node).size();
   }
-  uint64_t readDataImpl(ObjectHandle Node, raw_ostream &OS, uint64_t Offset,
-                        uint64_t MaxBytes) const final;
 
   Error createUnknownObjectError(CASID ID) const {
     return createStringError(std::make_error_code(std::errc::invalid_argument),

--- a/llvm/lib/CAS/CASDB.cpp
+++ b/llvm/lib/CAS/CASDB.cpp
@@ -57,6 +57,14 @@ void ReferenceBase::print(raw_ostream &OS, const ObjectRef &This) const {
   printReferenceBase(OS, "object-ref", InternalRef, ID);
 }
 
+std::unique_ptr<MemoryBuffer>
+CASDB::getMemoryBuffer(ObjectHandle Node, StringRef Name,
+                       bool RequiresNullTerminator) {
+  return MemoryBuffer::getMemBuffer(
+      toStringRef(getData(Node, RequiresNullTerminator)), Name,
+      RequiresNullTerminator);
+}
+
 /// Default implementation opens the file and calls \a createBlob().
 Expected<ObjectHandle>
 CASDB::storeFromOpenFileImpl(sys::fs::file_t FD,
@@ -124,12 +132,6 @@ Expected<ObjectProxy> CASDB::createProxy(ArrayRef<ObjectRef> Refs,
 Expected<std::unique_ptr<MemoryBuffer>>
 CASDB::loadIndependentDataBuffer(ObjectHandle Node, const Twine &Name,
                                  bool NullTerminate) const {
-  return loadIndependentDataBufferImpl(Node, Name, NullTerminate);
-}
-
-Expected<std::unique_ptr<MemoryBuffer>>
-CASDB::loadIndependentDataBufferImpl(ObjectHandle Node, const Twine &Name,
-                                     bool NullTerminate) const {
   SmallString<256> Bytes;
   raw_svector_ostream OS(Bytes);
   readData(Node, OS);

--- a/llvm/lib/CAS/CASFileSystem.cpp
+++ b/llvm/lib/CAS/CASFileSystem.cpp
@@ -103,8 +103,7 @@ public:
       return errorToErrorCode(Object.takeError());
     assert(DB.getNumRefs(*Object) == 0 && "Expected a leaf node");
     SmallString<256> Storage;
-    return MemoryBuffer::getMemBuffer(DB.getDataString(*Object),
-                                      Name.toStringRef(Storage));
+    return DB.getMemoryBuffer(*Object, Name.toStringRef(Storage));
   }
 
   llvm::ErrorOr<Optional<cas::ObjectRef>> getObjectRefForContent() final {

--- a/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
+++ b/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
@@ -203,8 +203,7 @@ public:
       return errorToErrorCode(Object.takeError());
     assert(DB.getNumRefs(*Object) == 0 && "Expected a leaf node");
     SmallString<256> Storage;
-    return MemoryBuffer::getMemBuffer(DB.getDataString(*Object),
-                                      RequestedName.toStringRef(Storage));
+    return DB.getMemoryBuffer(*Object, RequestedName.toStringRef(Storage));
   }
 
   llvm::ErrorOr<Optional<cas::ObjectRef>> getObjectRefForContent() final {

--- a/llvm/lib/CAS/InMemoryCAS.cpp
+++ b/llvm/lib/CAS/InMemoryCAS.cpp
@@ -84,11 +84,6 @@ public:
   inline ArrayRef<char> getData() const;
 
   inline ArrayRef<const InMemoryObject *> getRefs() const;
-
-  StringRef getDataString() const {
-    ArrayRef<char> Array = getData();
-    return StringRef(Array.begin(), Array.size());
-  }
 };
 
 class InMemoryRefObject : public InMemoryObject {


### PR DESCRIPTION
 Cleanup the interface of CASDB, including:

    * Re-order the methods (e.g. all pure virtual functions grouped together)
    * Improve comments
    * Clean up some helper methods if they can be implemented from other
      APIs.
    * Clean up null terminated parameter so it is default to not required to
      be null terminated and only request that by default when creating a
      MemBuffer out of the data.
    * Remove unused functions.

    This should be a NFC change to make it clearer what needs to provided
    from a new CASDB implementation.