### PR TITLE
Split the debug_line section in MCCAS

### DIFF
--- a/clang/test/CAS/debug-line-split.c
+++ b/clang/test/CAS/debug-line-split.c
@@ -1,0 +1,14 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang -g -c -fcas-friendly-debug-info=debug-line-only --target=x86_64-apple-darwin21.6.0 -Xclang -fcas-backend -Xclang -fcas-backend-mode=verify -Xclang -fcas-path -Xclang %t/cas %s 
+// RUN: %clang -g -c -fcas-friendly-debug-info=debug-line-only --target=x86_64-apple-darwin21.6.0 -Xclang -fcas-backend -Xclang -fcas-backend-mode=casid -Xclang -fcas-path -Xclang %t/cas %s -o %t/cas-file.o
+// RUN: llvm-cas-object-format --casid-file %t/cas-file.o --object-stats=- --cas %t/cas | FileCheck %s
+
+//CHECK: mc:debug_line             2 {{[0-9]+}}.{{[0-9]+}}% 2 {{[0-9]+}}.{{[0-9]+}}% 0{{.*}}
+
+int foo() {
+    return 1;
+}
+
+int bar(int x) {
+    return x*x;
+}

--- a/llvm/include/llvm/MC/CAS/MCCASObjectV1.def
+++ b/llvm/include/llvm/MC/CAS/MCCASObjectV1.def
@@ -19,6 +19,7 @@ CASV1_SIMPLE_DATA_REF(CStringRef, mc:cstring)
 CASV1_SIMPLE_DATA_REF(MergedFragmentRef, mc:merged_fragment)
 CASV1_SIMPLE_DATA_REF(DebugStrRef, mc:debug_string)
 CASV1_SIMPLE_DATA_REF(DebugInfoCURef, mc:debug_info_cu)
+CASV1_SIMPLE_DATA_REF(DebugLineRef, mc:debug_line)
 
 #undef CASV1_SIMPLE_DATA_REF
 #endif /* CASV1_SIMPLE_DATA_REF */

--- a/llvm/include/llvm/MC/CAS/MCCASObjectV1.h
+++ b/llvm/include/llvm/MC/CAS/MCCASObjectV1.h
@@ -314,10 +314,6 @@ public:
   Error buildDataInCodeRegion();
   Error buildSymbolTable();
 
-  /// For each compile unit inside the __debug_info section, create a
-  /// corresponding DebugInfoRef CAS object.
-  Error splitDebugInfoCUs();
-
   void startGroup();
   Error finalizeGroup();
 
@@ -349,6 +345,15 @@ private:
   // Helper functions.
   Error createStringSection(StringRef S,
                             std::function<Error(StringRef)> CreateFn);
+  // If the Section is the DWARF Line Section, append all the contents of the
+  // section into a buffer and split it up into multiple CAS blocks, where one
+  // block represents one function's contribution into the section or one line
+  // table.
+  Error createLineSection(const MCSection *DebugLineSection);
+
+  /// For each compile unit inside the __debug_info section, create a
+  /// corresponding DebugInfoRef CAS object.
+  Error splitDebugInfoCUs();
 
   const MCSection *CurrentSection = nullptr;
   const MCSymbol *CurrentAtom = nullptr;


### PR DESCRIPTION
Use MCCAS to split the debug_line section by adding one block per line table entry. I created my own block kind call DebugLineRef which represents one line table entry