### PR TITLE
[libclang][deps] Fix missing include in Dependencies.h

### DIFF
--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -24,6 +24,7 @@
 #include "clang-c/CXErrorCode.h"
 #include "clang-c/CXString.h"
 #include "clang-c/Platform.h"
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This header was not building standalone, which unfortunately was only
caught late.