### PR TITLE
[MCCAS] Split debug info section

### DIFF
--- a/clang/test/CAS/debug_info_split.c
+++ b/clang/test/CAS/debug_info_split.c
@@ -1,0 +1,13 @@
+// RUN: %clang -g -c -o %t %s --target=arm64-apple-darwin10 \
+// RUN:   -fcas-friendly-debug-info=debug-abbrev -Xclang -fcas-backend \
+// RUN:   -Xclang -fcas-backend-mode=verify
+
+int gv1 = 10;
+
+int foo1() {
+  return 1;
+}
+
+double foo2() {
+  return 2;
+}

--- a/llvm/include/llvm/MC/CAS/MCCASObjectV1.def
+++ b/llvm/include/llvm/MC/CAS/MCCASObjectV1.def
@@ -18,6 +18,7 @@ CASV1_SIMPLE_DATA_REF(DataInCodeRef, mc:data_in_code)
 CASV1_SIMPLE_DATA_REF(CStringRef, mc:cstring)
 CASV1_SIMPLE_DATA_REF(MergedFragmentRef, mc:merged_fragment)
 CASV1_SIMPLE_DATA_REF(DebugStrRef, mc:debug_string)
+CASV1_SIMPLE_DATA_REF(DebugInfoCURef, mc:debug_info_cu)
 
 #undef CASV1_SIMPLE_DATA_REF
 #endif /* CASV1_SIMPLE_DATA_REF */

--- a/llvm/include/llvm/MC/CAS/MCCASObjectV1.h
+++ b/llvm/include/llvm/MC/CAS/MCCASObjectV1.h
@@ -314,6 +314,10 @@ public:
   Error buildDataInCodeRegion();
   Error buildSymbolTable();
 
+  /// For each compile unit inside the __debug_info section, create a
+  /// corresponding DebugInfoRef CAS object.
+  Error splitDebugInfoCUs();
+
   void startGroup();
   Error finalizeGroup();
 


### PR DESCRIPTION
This commit changes the MCCASBuilder so that it is able to split the
debug info section based on its compilation units. For each compilation
unit in the debug info section, one CAS object is created.

This patch does not handle dwarf 64 formats and does not attempt to
enable deduplication of debug info sections.

Testing is done with the verify mode of the CAS backend, which compares
an object file generated through CAS with an object file generated
through the traditional flow. Once tooling is developed, we should be
able to check that multiple CAS objects are actually created.