### PR TITLE
[llvm-mc][CAS] Add sanity check for CAS backend flags

### DIFF
--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -549,6 +549,12 @@ int main(int argc, char **argv) {
   assert(MCII && "Unable to create instruction info!");
 
   MCInstPrinter *IP = nullptr;
+
+  if (UseMCCASBackend && FileType != OFT_ObjectFile) {
+    WithColor::error() << "-cas-backend is only compatible with -filetype=obj";
+    return 1;
+  }
+
   if (FileType == OFT_AssemblyFile) {
     IP = TheTarget->createMCInstPrinter(Triple(TripleName), OutputAsmVariant,
                                         *MAI, *MCII, *MRI);


### PR DESCRIPTION
The `--cas-backend` flag is only compatible with `--filetype=obj`,
however no error is produced if a different filetype is specified, and
the `--cas-backend` flag is silently ignored. This patch emits an error
in these cases, to prevent incorrect usage of the tool.