### PR TITLE
[clangd][NFC] includes missing headers

### DIFF
--- a/clang-tools-extra/clangd/support/Shutdown.h
+++ b/clang-tools-extra/clangd/support/Shutdown.h
@@ -45,6 +45,8 @@
 
 #include <cerrno>
 #include <chrono>
+#include <type_traits>
+#include <utility>
 
 namespace clang {
 namespace clangd {


### PR DESCRIPTION
`Shutdown.h` was transitively depending on two headers, but this isn't
allowed under a modules build, so they're now explicitly included.

Differential Revision: https://reviews.llvm.org/D119806