### PR TITLE
Re-enable Swift LLDB ASAN test for testing

### DIFF
--- a/lldb/test/API/functionalities/asan/swift/TestAsanSwift.py
+++ b/lldb/test/API/functionalities/asan/swift/TestAsanSwift.py
@@ -26,7 +26,7 @@ class AsanSwiftTestCase(lldbtest.TestBase):
     @decorators.swiftTest
     @decorators.skipIfLinux
     @decorators.skipUnlessSwiftAddressSanitizer
-    @decorators.skipIf(bugnumber="rdar://97091621")
+    # @decorators.skipIf(bugnumber="rdar://97091621")
     def test_asan_swift(self):
         self.build()
         self.do_test()


### PR DESCRIPTION
This is attempt to rerun the failing test which log is not available anymore - please do not review.