### PR TITLE
[CAS depscan] Treat an error from CAS dep-scanning as if the main compilation has failed

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -100,10 +100,15 @@ public:
   llvm::Expected<llvm::cas::ObjectProxy>
   getDependencyTree(const std::vector<std::string> &CommandLine, StringRef CWD);
 
+  /// If \p DiagGenerationAsCompilation is true it will generate error
+  /// diagnostics same way as the normal compilation, with "N errors generated"
+  /// message and the serialized diagnostics file emitted if the
+  /// \p DiagOpts.DiagnosticSerializationFile setting is set for the invocation.
   llvm::Expected<llvm::cas::ObjectProxy>
   getDependencyTreeFromCompilerInvocation(
       std::shared_ptr<CompilerInvocation> Invocation, StringRef CWD,
-      DiagnosticConsumer &DiagsConsumer,
+      DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
+      bool DiagGenerationAsCompilation,
       llvm::function_ref<StringRef(const llvm::vfs::CachedDirectoryEntry &)>
           RemapPath = nullptr);
 
@@ -111,9 +116,14 @@ public:
   getIncludeTree(cas::CASDB &DB, const std::vector<std::string> &CommandLine,
                  StringRef CWD);
 
+  /// If \p DiagGenerationAsCompilation is true it will generate error
+  /// diagnostics same way as the normal compilation, with "N errors generated"
+  /// message and the serialized diagnostics file emitted if the
+  /// \p DiagOpts.DiagnosticSerializationFile setting is set for the invocation.
   Expected<cas::IncludeTreeRoot> getIncludeTreeFromCompilerInvocation(
       cas::CASDB &DB, std::shared_ptr<CompilerInvocation> Invocation,
-      StringRef CWD, DiagnosticConsumer &DiagsConsumer);
+      StringRef CWD, DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
+      bool DiagGenerationAsCompilation);
 
   /// Collect the full module dependency graph for the input, ignoring any
   /// modules which have already been seen. If \p ModuleName isn't empty, this

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -89,10 +89,15 @@ public:
                                   llvm::Optional<StringRef> ModuleName = None);
 
   /// Scan from a compiler invocation.
+  /// If \p DiagGenerationAsCompilation is true it will generate error
+  /// diagnostics same way as the normal compilation, with "N errors generated"
+  /// message and the serialized diagnostics file emitted if the
+  /// \p DiagOpts.DiagnosticSerializationFile setting is set for the invocation.
   void computeDependenciesFromCompilerInvocation(
       std::shared_ptr<CompilerInvocation> Invocation,
       StringRef WorkingDirectory, DependencyScanningConsumerBase &Consumer,
-      DiagnosticConsumer &DiagsConsumer);
+      DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
+      bool DiagGenerationAsCompilation);
 
   ScanningOutputFormat getScanningFormat() const { return Format; }
 

--- a/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
@@ -41,7 +41,7 @@ struct DepscanPrefixMapping {
 
 Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
     tooling::dependencies::DependencyScanningTool &Tool,
-    DiagnosticConsumer &DiagsConsumer, const char *Exec,
+    DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS, const char *Exec,
     CompilerInvocation &Invocation, StringRef WorkingDirectory,
     const cc1depscand::DepscanPrefixMapping &PrefixMapping);
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -191,15 +191,17 @@ DependencyScanningTool::getDependencyTree(
 llvm::Expected<llvm::cas::ObjectProxy>
 DependencyScanningTool::getDependencyTreeFromCompilerInvocation(
     std::shared_ptr<CompilerInvocation> Invocation, StringRef CWD,
-    DiagnosticConsumer &DiagsConsumer,
+    DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
+    bool DiagGenerationAsCompilation,
     llvm::function_ref<StringRef(const llvm::vfs::CachedDirectoryEntry &)>
         RemapPath) {
   llvm::cas::CachingOnDiskFileSystem &FS = Worker.getCASFS();
   FS.trackNewAccesses();
   FS.setCurrentWorkingDirectory(CWD);
   MakeDependencyTree DepsConsumer(FS);
-  Worker.computeDependenciesFromCompilerInvocation(std::move(Invocation), CWD,
-                                                   DepsConsumer, DiagsConsumer);
+  Worker.computeDependenciesFromCompilerInvocation(
+      std::move(Invocation), CWD, DepsConsumer, DiagsConsumer, VerboseOS,
+      DiagGenerationAsCompilation);
   // return DepsConsumer.makeTree();
   //
   // FIXME: See FIXME in getDepencyTree().
@@ -380,10 +382,12 @@ Expected<cas::IncludeTreeRoot> DependencyScanningTool::getIncludeTree(
 Expected<cas::IncludeTreeRoot>
 DependencyScanningTool::getIncludeTreeFromCompilerInvocation(
     cas::CASDB &DB, std::shared_ptr<CompilerInvocation> Invocation,
-    StringRef CWD, DiagnosticConsumer &DiagsConsumer) {
+    StringRef CWD, DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
+    bool DiagGenerationAsCompilation) {
   IncludeTreePPConsumer Consumer(DB);
-  Worker.computeDependenciesFromCompilerInvocation(std::move(Invocation), CWD,
-                                                   Consumer, DiagsConsumer);
+  Worker.computeDependenciesFromCompilerInvocation(
+      std::move(Invocation), CWD, Consumer, DiagsConsumer, VerboseOS,
+      DiagGenerationAsCompilation);
   return Consumer.getIncludeTree();
 }
 

--- a/clang/test/CAS/depscan-with-error.c
+++ b/clang/test/CAS/depscan-with-error.c
@@ -1,0 +1,55 @@
+// REQUIRES: ansi-escape-sequences
+
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: not %clang -cc1depscan -fdepscan=inline -cc1-args -cc1 -triple x86_64-apple-macos11 -x c %s -o %t/t.o -fcas-path %t/cas \
+// RUN:   2>&1 | FileCheck %s -check-prefix=ERROR
+
+// Using normal compilation as baseline.
+// RUN: not %clang -target x86_64-apple-macos11 -c %s -o %t.o -fmodules-cache-path=%t/mcp --serialize-diagnostics %t/t1.diag \
+// RUN:   2>&1 | FileCheck %s -check-prefix=ERROR -check-prefix=DRIVER
+// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t.o -fmodules-cache-path=%t/mcp --serialize-diagnostics %t/t2.diag \
+// RUN:   2>&1 | FileCheck %s -check-prefix=ERROR -check-prefix=DRIVER
+// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t.o -fmodules-cache-path=%t/mcp --serialize-diagnostics %t/t3.diag \
+// RUN:   2>&1 | FileCheck %s -check-prefix=ERROR -check-prefix=DRIVER
+
+// RUN: diff %t/t1.diag %t/t2.diag
+// RUN: diff %t/t1.diag %t/t3.diag
+
+// DRIVER: warning: argument unused during compilation
+// ERROR: error: 'non-existent.h' file not found
+// ERROR: 1 error generated.
+
+// Make sure successful compilation clears the diagnostic file.
+// RUN: echo "int x;" > %t/a.c
+// RUN: echo "int y;" > %t/b.c
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %t/a.c -o %t.o --serialize-diagnostics %t/t2.diag
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %t/b.c -o %t.o --serialize-diagnostics %t/t3.diag
+
+// RUN: c-index-test -read-diagnostics %t/t2.diag 2>&1 | FileCheck %s -check-prefix=SERIAL
+// RUN: c-index-test -read-diagnostics %t/t3.diag 2>&1 | FileCheck %s -check-prefix=SERIAL
+// SERIAL: Number of diagnostics: 0
+
+// Make sure warnings are still emitted for normal compilation.
+// RUN: echo "#warning some warning" > %t/warn.c
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %t/warn.c -o %t.o \
+// RUN:   2>&1 | FileCheck %s -check-prefix=WARN
+// WARN: warning: some warning
+
+// Make sure diagnostics emitted during CAS dep-scanning respect the color settings.
+// RUN: not %clang -target x86_64-apple-macos11 -c %s -o %t.o -fdiagnostics-color=always -fansi-escape-codes \
+// RUN:   2>&1 | FileCheck %s -check-prefix=COLOR-DIAG
+// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t.o -fdiagnostics-color=always -fansi-escape-codes \
+// RUN:   2>&1 | FileCheck %s -check-prefix=COLOR-DIAG
+// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t.o -fdiagnostics-color=always -fansi-escape-codes \
+// RUN:   2>&1 | FileCheck %s -check-prefix=COLOR-DIAG
+// COLOR-DIAG: [[RED:.\[0;1;31m]]fatal error: [[RESET:.\[0m]]
+
+#include "non-existent.h"

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -345,9 +345,9 @@ static bool emitCompilationDBWithCASTreeArguments(
                         FileManager *Files,
                         std::shared_ptr<PCHContainerOperations> PCHContainerOps,
                         DiagnosticConsumer *DiagConsumer) override {
-            Expected<llvm::cas::CASID> Root =
-                scanAndUpdateCC1InlineWithTool(WorkerTool, DiagsConsumer, Exec,
-                                               *Invocation, CWD, PrefixMapping);
+            Expected<llvm::cas::CASID> Root = scanAndUpdateCC1InlineWithTool(
+                WorkerTool, DiagsConsumer, /*VerboseOS*/ nullptr, Exec,
+                *Invocation, CWD, PrefixMapping);
             if (!Root) {
               llvm::consumeError(Root.takeError());
               return false;

--- a/clang/tools/driver/cc1depscanProtocol.cpp
+++ b/clang/tools/driver/cc1depscanProtocol.cpp
@@ -364,7 +364,8 @@ CC1DepScanDProtocol::getDepscanPrefixMapping(llvm::StringSaver &Saver,
 llvm::Error
 CC1DepScanDProtocol::getScanResult(llvm::StringSaver &Saver, ResultKind &Result,
                                    StringRef &FailedReason, StringRef &RootID,
-                                   SmallVectorImpl<const char *> &Args) {
+                                   SmallVectorImpl<const char *> &Args,
+                                   StringRef &DiagnosticOutput) {
   if (Error E = getResultKind(Result))
     return E;
 
@@ -378,17 +379,20 @@ CC1DepScanDProtocol::getScanResult(llvm::StringSaver &Saver, ResultKind &Result,
 
   if (Error E = getString(Saver, RootID))
     return E;
-  return getArgs(Saver, Args);
+  if (Error E = getArgs(Saver, Args))
+    return E;
+  return getString(Saver, DiagnosticOutput);
 }
 
-llvm::Error
-CC1DepScanDProtocol::putScanResultSuccess(StringRef RootID,
-                                          ArrayRef<const char *> Args) {
+llvm::Error CC1DepScanDProtocol::putScanResultSuccess(
+    StringRef RootID, ArrayRef<const char *> Args, StringRef DiagnosticOutput) {
   if (Error E = putResultKind(SuccessResult))
     return E;
   if (Error E = putString(RootID))
     return E;
-  return putArgs(Args);
+  if (Error E = putArgs(Args))
+    return E;
+  return putString(DiagnosticOutput);
 }
 
 llvm::Error CC1DepScanDProtocol::putScanResultFailed(StringRef Reason) {

--- a/clang/tools/driver/cc1depscanProtocol.h
+++ b/clang/tools/driver/cc1depscanProtocol.h
@@ -152,10 +152,12 @@ public:
 
   llvm::Error putScanResultFailed(StringRef Reason);
   llvm::Error putScanResultSuccess(StringRef RootID,
-                                   ArrayRef<const char *> Args);
+                                   ArrayRef<const char *> Args,
+                                   StringRef DiagnosticOutput);
   llvm::Error getScanResult(llvm::StringSaver &Saver, ResultKind &Result,
                             StringRef &FailedReason, StringRef &RootID,
-                            SmallVectorImpl<const char *> &Args);
+                            SmallVectorImpl<const char *> &Args,
+                            StringRef &DiagnosticOutput);
 
   explicit CC1DepScanDProtocol(int Socket) : Socket(Socket) {}
   CC1DepScanDProtocol() = delete;


### PR DESCRIPTION
If diagnostic errors occur during CAS dep-scanning (like "header not found") then fail the depscan action directly.
Previously CASFS dep-scanning was ignoring errors and deferring them for the main compilation but for include-tree
dep-scanning we need to fail early, since the invariant for the main compilation is that all the header includes
have already been resolved successfully.