### PR TITLE
Patch Relocation Addends in the debug_line section to improve deduplication

### DIFF
--- a/llvm/include/llvm/MC/CAS/MCCASObjectV1.def
+++ b/llvm/include/llvm/MC/CAS/MCCASObjectV1.def
@@ -20,6 +20,7 @@ CASV1_SIMPLE_DATA_REF(MergedFragmentRef, mc:merged_fragment)
 CASV1_SIMPLE_DATA_REF(DebugStrRef, mc:debug_string)
 CASV1_SIMPLE_DATA_REF(DebugInfoCURef, mc:debug_info_cu)
 CASV1_SIMPLE_DATA_REF(DebugLineRef, mc:debug_line)
+CASV1_SIMPLE_DATA_REF(RelocAddendRef, mc:reloc_addend)
 
 #undef CASV1_SIMPLE_DATA_REF
 #endif /* CASV1_SIMPLE_DATA_REF */

--- a/llvm/test/DebugInfo/CAS/AArch64/debug-line-dedupe.test
+++ b/llvm/test/DebugInfo/CAS/AArch64/debug-line-dedupe.test
@@ -1,0 +1,96 @@
+RUN: rm -rf %t && mkdir -p %t
+RUN: split-file %s %t
+
+RUN: llc -O0 --filetype=obj --cas-backend --cas=%t/cas --mccas-casid %t/a.ll -o %t/a.id
+RUN: llc -O0 --filetype=obj --cas-backend --cas=%t/cas --mccas-casid %t/b.ll -o %t/b.id
+RUN: llvm-cas-dump --cas=%t/cas --casid-file %t/a.id %t/b.id | FileCheck %s
+
+CHECK: mc:debug_line   llvmcas://[[CASID:[a-z0-9]+]]
+CHECK-NEXT: mc:debug_line   llvmcas://
+
+CHECK: mc:debug_line   llvmcas:// 
+CHECK-NEXT: mc:debug_line   llvmcas://[[CASID]]
+CHECK-NEXT: mc:debug_line   llvmcas:// 
+
+//--- a.ll
+
+target triple = "x86_64-apple-macosx12.0.0"
+define void @foo() #0 !dbg !9 {
+  ret void, !dbg !14
+}
+define i32 @bar(i32 noundef %x) #0 !dbg !15 {
+entry:
+  %x.addr = alloca i32, align 4
+  %0 = load i32, ptr %x.addr, align 4, !dbg !21
+  %add = add nsw i32 %0, 1, !dbg !22
+  ret i32 %add, !dbg !23
+}
+attributes #0 = { noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git d74d0d9fde90cccba7bf18066ac56e55e4402948)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
+!1 = !DIFile(filename: "a.c", directory: "/Users/shubham/Development/CASDelta")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"PIC Level", i32 2}
+!6 = !{i32 7, !"uwtable", i32 2}
+!7 = !{i32 7, !"frame-pointer", i32 2}
+!9 = distinct !DISubprogram(name: "foo", scope: !10, file: !10, line: 1, type: !11, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!10 = !DIFile(filename: "./foo.h", directory: "/Users/shubham/Development/CASDelta")
+!11 = !DISubroutineType(types: !12)
+!12 = !{null}
+!13 = !{}
+!14 = !DILocation(line: 2, column: 3, scope: !9)
+!15 = distinct !DISubprogram(name: "bar", scope: !1, file: !1, line: 2, type: !16, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!16 = !DISubroutineType(types: !17)
+!17 = !{!18, !18}
+!18 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!21 = !DILocation(line: 3, column: 10, scope: !15)
+!22 = !DILocation(line: 3, column: 11, scope: !15)
+!23 = !DILocation(line: 3, column: 3, scope: !15)
+
+//--- b.ll
+
+target triple = "x86_64-apple-macosx12.0.0"
+define i32 @baz() #0 !dbg !9 {
+  ret i32 1, !dbg !14
+}
+define void @foo() #0 !dbg !15 {
+  ret void, !dbg !19
+}
+define i32 @bar(i32 noundef %x) #0 !dbg !20 {
+entry:
+  %x.addr = alloca i32, align 4
+  %0 = load i32, ptr %x.addr, align 4, !dbg !25
+  %add = add nsw i32 %0, 1, !dbg !26
+  ret i32 %add, !dbg !27
+}
+attributes #0 = { noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git d74d0d9fde90cccba7bf18066ac56e55e4402948)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
+!1 = !DIFile(filename: "b.c", directory: "/Users/shubham/Development/CASDelta")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"PIC Level", i32 2}
+!6 = !{i32 7, !"uwtable", i32 2}
+!7 = !{i32 7, !"frame-pointer", i32 2}
+!9 = distinct !DISubprogram(name: "baz", scope: !1, file: !1, line: 1, type: !10, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!10 = !DISubroutineType(types: !11)
+!11 = !{!12}
+!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!13 = !{}
+!14 = !DILocation(line: 2, column: 5, scope: !9)
+!15 = distinct !DISubprogram(name: "foo", scope: !16, file: !16, line: 1, type: !17, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!16 = !DIFile(filename: "./foo.h", directory: "/Users/shubham/Development/CASDelta")
+!17 = !DISubroutineType(types: !18)
+!18 = !{null}
+!19 = !DILocation(line: 2, column: 3, scope: !15)
+!20 = distinct !DISubprogram(name: "bar", scope: !1, file: !1, line: 6, type: !21, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!21 = !DISubroutineType(types: !22)
+!22 = !{!12, !12}
+!25 = !DILocation(line: 7, column: 10, scope: !20)
+!26 = !DILocation(line: 7, column: 11, scope: !20)
+!27 = !DILocation(line: 7, column: 3, scope: !20)


### PR DESCRIPTION
 Relocation Addends are stored directly in the section contents, therefore a function that is defined in a header file and included in multiple translation units will not dedupe in the debug_line section because the contents of the two CAS blocks representing that function in the different translation units will not be identical. This will cas deduplication to fail. To improve deduplication, copy the relocation addends into a cas block and zero them out in the cas block, then, when emitting the object file, reapply those relocation addends into the section contents so the object file that will be printed out will be identical to one produced without the cas backend.

Currently the test llvm/test/tools/llvm-cas-dump/basic_debug_test.ll doesn't pass because of the dump tool's expectation that all DWARF sections have to have their first reference be a block with a `KindString` to contain the word 'debug'. This is being addressed with https://github.com/apple/llvm-project/pull/5080