### PR TITLE
[MCCAS] Introduce llvm-cas-mc-dump tool

### DIFF
--- a/llvm/include/llvm/MC/CAS/MCCASObjectV1.h
+++ b/llvm/include/llvm/MC/CAS/MCCASObjectV1.h
@@ -287,6 +287,13 @@ public:
 
   Error materialize(raw_ostream &OS) const;
 
+  static Optional<MCAssemblerRef> Cast(MCObjectProxy Ref) {
+    auto Specific = SpecificRefT::Cast(Ref);
+    if (!Specific)
+      return None;
+    return MCAssemblerRef(*Specific);
+  }
+
 private:
   MCAssemblerRef(SpecificRefT Ref) : SpecificRefT(Ref) {}
 };

--- a/llvm/test/tools/llvm-cas-dump/basic_debug_test.ll
+++ b/llvm/test/tools/llvm-cas-dump/basic_debug_test.ll
@@ -1,0 +1,54 @@
+; RUN: llc -O0 --filetype=obj --cas-backend --cas=%t.casdb --mccas-casid -o %t.casid %s
+; RUN: llvm-cas-dump --cas=%t.casdb --dwarf-sections-only --casid-file %t.casid | FileCheck %s
+
+; This test is created from a C program like:
+; int foo() { return 10; }
+
+; CHECK:      mc:assembler  llvmcas://{{.*}}
+; CHECK-NEXT:   mc:header  llvmcas://{{.*}}
+; CHECK-NEXT:   mc:group  llvmcas://{{.*}}
+; CHECK-NEXT:     mc:section  llvmcas://{{.*}}
+; CHECK-NEXT:       mc:debug_info_cu  llvmcas://{{.*}}
+; CHECK-NEXT:       mc:padding  llvmcas://{{.*}}
+; CHECK-NEXT:     mc:section  llvmcas://{{.*}}
+; CHECK-NEXT:       mc:debug_string  llvmcas://{{.*}}
+; CHECK-NEXT:       mc:debug_string  llvmcas://{{.*}}
+; CHECK-NEXT:       mc:debug_string  llvmcas://{{.*}}
+; CHECK-NEXT:       mc:debug_string  llvmcas://{{.*}}
+; CHECK-NEXT:       mc:debug_string  llvmcas://{{.*}}
+; CHECK-NEXT:     mc:section  llvmcas://{{.*}}
+; CHECK-NEXT:       mc:debug_line  llvmcas://{{.*}}
+; CHECK-NEXT:       mc:padding  llvmcas://{{.*}}
+; CHECK-NEXT:   mc:data_in_code  llvmcas://{{.*}}
+; CHECK-NEXT:   mc:symbol_table  llvmcas://{{.*}}
+; CHECK-NEXT:     mc:cstring  llvmcas://{{.*}}
+; CHECK-NEXT:     mc:cstring  llvmcas://{{.*}}
+; CHECK-NEXT:     mc:cstring  llvmcas://{{.*}}
+; CHECK-NEXT:     mc:cstring  llvmcas://{{.*}}
+
+target triple = "arm64-apple-macosx12.0.0"
+
+define i32 @foo() !dbg !9 {
+entry:
+  ret i32 10, !dbg !14
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
+!llvm.ident = !{!8}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "some_clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugAbbrev)
+!1 = !DIFile(filename: "test.c", directory: "some_dir")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"PIC Level", i32 2}
+!6 = !{i32 7, !"uwtable", i32 2}
+!7 = !{i32 7, !"frame-pointer", i32 1}
+!8 = !{!"some_clang"}
+!9 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 2, type: !10, scopeLine: 2, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!10 = !DISubroutineType(types: !11)
+!11 = !{!12}
+!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!13 = !{}
+!14 = !DILocation(line: 3, column: 3, scope: !9)

--- a/llvm/tools/CMakeLists.txt
+++ b/llvm/tools/CMakeLists.txt
@@ -36,6 +36,7 @@ add_llvm_tool_subdirectory(llvm-config)
 add_llvm_tool_subdirectory(llvm-lto)
 add_llvm_tool_subdirectory(llvm-profdata)
 add_llvm_tool_subdirectory(llvm-cas)
+add_llvm_tool_subdirectory(llvm-cas-dump)
 
 # Projects supported via LLVM_EXTERNAL_*_SOURCE_DIR need to be explicitly
 # specified.

--- a/llvm/tools/llvm-cas-dump/CMakeLists.txt
+++ b/llvm/tools/llvm-cas-dump/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  CAS
+  CASObjectFormats
+  )
+
+add_llvm_tool(llvm-cas-dump
+  llvm-cas-dump.cpp
+  MCCASPrinter.cpp
+)

--- a/llvm/tools/llvm-cas-dump/MCCASPrinter.cpp
+++ b/llvm/tools/llvm-cas-dump/MCCASPrinter.cpp
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "MCCASPrinter.h"
+#include "llvm/Support/FormatVariadic.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+using namespace llvm::mccasformats::v1;
+
+namespace {
+struct IndentGuard {
+  constexpr static int IndentWidth = 2;
+  IndentGuard(int &Indent) : Indent{Indent} { Indent += IndentWidth; }
+  ~IndentGuard() { Indent -= IndentWidth; }
+  int &Indent;
+};
+
+bool isDwarfSection(MCObjectProxy MCObj) {
+  // Currently, the only way to detect debug sections is through the kind of its
+  // children objects. TODO: find a better way to check this.
+  // Dwarf Sections have >= 1 references.
+  if (MCObj.getNumReferences() == 0)
+    return false;
+
+  ObjectRef FirstRef = MCObj.getReference(0);
+  const MCSchema &Schema = MCObj.getSchema();
+  Expected<MCObjectProxy> FirstMCRef = Schema.get(FirstRef);
+  if (!FirstMCRef)
+    return false;
+
+  return FirstMCRef->getKindString().contains("debug");
+}
+} // namespace
+
+MCCASPrinter::MCCASPrinter(PrinterOptions Options, CASDB &CAS, raw_ostream &OS)
+    : Options(Options), MCSchema(CAS), Indent{0}, OS(OS) {}
+
+Error MCCASPrinter::printMCObject(ObjectRef CASObj) {
+  // The object identifying the schema is not considered an MCObject, as such we
+  // don't attempt to cast or print it.
+  if (CASObj == MCSchema.getRootNodeTypeID())
+    return Error::success();
+
+  Expected<MCObjectProxy> MCObj = MCSchema.get(CASObj);
+  if (!MCObj)
+    return MCObj.takeError();
+  return printMCObject(*MCObj);
+}
+
+Error MCCASPrinter::printMCObject(MCObjectProxy MCObj) {
+  // If only debug sections were requested, skip non-debug sections.
+  if (Options.DwarfSectionsOnly && SectionRef::Cast(MCObj) &&
+      !isDwarfSection(MCObj))
+    return Error::success();
+
+  OS.indent(Indent);
+  OS << formatv("{0, -15} {1} \n", MCObj.getKindString(),
+                MCSchema.CAS.getID(MCObj));
+
+  return printSimpleNested(MCObj);
+}
+
+Error MCCASPrinter::printSimpleNested(MCObjectProxy AssemblerRef) {
+  IndentGuard Guard(Indent);
+  return AssemblerRef.forEachReference(
+      [this](ObjectRef CASObj) { return printMCObject(CASObj); });
+}

--- a/llvm/tools/llvm-cas-dump/MCCASPrinter.h
+++ b/llvm/tools/llvm-cas-dump/MCCASPrinter.h
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/MC/CAS/MCCASObjectV1.h"
+#include "llvm/Support/Error.h"
+
+namespace llvm {
+class raw_ostream;
+
+namespace mccasformats {
+namespace v1 {
+
+struct PrinterOptions {
+  bool DwarfSectionsOnly;
+};
+
+struct MCCASPrinter {
+  /// Creates a printer object capable of printing MCCAS objects inside `CAS`.
+  /// Output is sent to `OS`.
+  MCCASPrinter(PrinterOptions Options, cas::CASDB &CAS, raw_ostream &OS);
+
+  /// If `CASObj` is an MCObject, prints its contents and all nodes referenced
+  /// by it recursively. If CASObj or any of its children are not MCObjects, an
+  /// error is returned.
+  Error printMCObject(cas::ObjectRef CASObj);
+
+  /// Prints the contents of `MCObject` and all nodes referenced by it
+  /// recursively. If any of its children are not MCObjects, an error is
+  /// returned.
+  Error printMCObject(MCObjectProxy MCObj);
+
+private:
+  PrinterOptions Options;
+  llvm::mccasformats::v1::MCSchema MCSchema;
+  int Indent;
+  raw_ostream &OS;
+
+  Error printSimpleNested(MCObjectProxy AssemblerRef);
+};
+} // namespace v1
+} // namespace mccasformats
+} // namespace llvm

--- a/llvm/tools/llvm-cas-dump/llvm-cas-dump.cpp
+++ b/llvm/tools/llvm-cas-dump/llvm-cas-dump.cpp
@@ -1,0 +1,70 @@
+//===- llvm-cas-dump.cpp - Tool for printing MC CAS objects ------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "MCCASPrinter.h"
+#include "llvm/CAS/Utils.h"
+#include "llvm/MC/CAS/MCCASObjectV1.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/MemoryBufferRef.h"
+#include "llvm/Support/raw_ostream.h"
+#include <memory>
+
+using namespace llvm;
+using namespace llvm::cas;
+using namespace llvm::mccasformats::v1;
+
+cl::opt<std::string> CASPath("cas", cl::Required, cl::desc("Path to CAS."));
+cl::list<std::string> InputStrings(cl::Positional,
+                                   cl::desc("CAS ID of the object to print"));
+cl::opt<bool> CASIDFile("casid-file", cl::desc("Treat inputs as CASID files"));
+cl::opt<bool> DwarfSectionsOnly("dwarf-sections-only",
+                                cl::desc("Only print dwarf related sections"));
+
+namespace {
+
+/// If the input is a file (--casid-file), open the file given by `InputStr`
+/// and get the ID from the file buffer.
+/// Otherwise parse `InputStr` as a CASID.
+CASID getCASIDFromInput(CASDB &CAS, StringRef InputStr) {
+  ExitOnError ExitOnErr;
+  ExitOnErr.setBanner((InputStr + ": ").str());
+
+  if (!CASIDFile)
+    return ExitOnErr(CAS.parseID(InputStr));
+
+  auto ObjBuffer =
+      ExitOnErr(errorOrToExpected(MemoryBuffer::getFile(InputStr)));
+  return ExitOnErr(readCASIDBuffer(CAS, ObjBuffer->getMemBufferRef()));
+}
+} // namespace
+
+int main(int argc, char *argv[]) {
+  ExitOnError ExitOnErr;
+  ExitOnErr.setBanner(std::string(argv[0]) + ": ");
+
+  cl::ParseCommandLineOptions(argc, argv);
+  PrinterOptions Options = {DwarfSectionsOnly};
+
+  std::unique_ptr<CASDB> CAS = ExitOnErr(createOnDiskCAS(CASPath));
+  MCCASPrinter Printer(Options, *CAS, llvm::outs());
+
+  for (StringRef InputStr : InputStrings) {
+    auto ID = getCASIDFromInput(*CAS, InputStr);
+
+    auto Ref = CAS->getReference(ID);
+    if (!Ref) {
+      llvm::errs() << "ID is invalid for this CAS\n";
+      return 1;
+    }
+
+    ExitOnErr(Printer.printMCObject(*Ref));
+  }
+  return 0;
+}


### PR DESCRIPTION
This is an initial attempt at a tool that navigates the CAS tree of an
object using the MC Schema and prints the tools structure.

Currently, it only prints the node kind, followed by its ID, followed by
a nested list of children nodes (recursively). Since the CAS is always a
DAG, there is no risk of infinite loops here.

For example, one possible output:

```
mc:assembler    llvmcas://5f77...
  mc:header       llvmcas://5264...
  mc:group        llvmcas://dfa25...
    mc:section      llvmcas://1a762...
      mc:debug_info_cu llvmcas://64c13...
      mc:debug_info_cu llvmcas://d0c6c744...
```

Since the first use case for this tool is to check how many objects each debug
section contains, we provide a flag to filter non-debug sections.

There are limitations to the tool at this point, all of which can be resolved
in the future:

1. It does not understand the _contents_ of each CAS object beyond the "type"
of object it is. So, for example, we cannot print the name of a section.

2. If one object contains multiple edges with the same destination, the MC CAS
encoding may choose to only add unique edges, and encode the duplicates inside
the "Data" section of the object. The tool currently does not look at those, so
there may be situations in which duplicate edges are not printed.

3. Because we don't use any nesting marks other than whitespaces, and
FileCheck does not usually distinguish whitespaces, nesting levels may
be ambiguous for FileCheck. We should explore using `{}` in the future.