### PR TITLE
🍒/rebranch/880b2128ef4b884612a59836583a5d3d4108fb43+2b61b770df813539b38b620efcae8fd3d11faad2

### DIFF
--- a/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
@@ -82,8 +82,10 @@ class ModuleLoadedNotifysTestCase(TestBase):
                         module = lldb.SBTarget.GetModuleAtIndexFromEvent(i, event)
                         # On macOS Ventura and later, dyld and the main binary
                         # will be loaded again when dyld moves itself into the
-                        # shared cache.
-                        if module.file.fullpath not in ['/usr/lib/dyld', exe]:
+                        # shared cache. Use the basename so this also works
+                        # when reading dyld from the expanded shared cache.
+                        exe_basename = lldb.SBFileSpec(exe).basename
+                        if module.file.basename not in ['dyld', exe_basename]:
                             self.assertTrue(module not in already_loaded_modules, '{} is already loaded'.format(module))
                         already_loaded_modules.append(module)
                         if self.TraceOn():

--- a/lldb/test/API/macosx/rosetta/TestRosetta.py
+++ b/lldb/test/API/macosx/rosetta/TestRosetta.py
@@ -35,6 +35,7 @@ class TestRosetta(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipUnlessAppleSilicon
+    @skipIfDarwinEmbedded
     def test_rosetta(self):
         """There can be many tests in a test case - describe this test here."""
         self.build()


### PR DESCRIPTION
- [lldb] Mark TestRosetta as skipIfDarwinEmbedded
- [lldb] Make TestModuleLoadedNotifys work with dyld from the shared cache
