### PR TITLE
[MCCAS] Fix bug where a PaddingRef cas object is not added to the debug_line and debug_info sections

### DIFF
--- a/clang/test/CAS/debug-line-split.c
+++ b/clang/test/CAS/debug-line-split.c
@@ -5,6 +5,9 @@
 
 //CHECK: mc:debug_line             2 {{[0-9]+}}.{{[0-9]+}}% 2 {{[0-9]+}}.{{[0-9]+}}% 0{{.*}}
 
+// RUN: %clang -g -c -fcas-friendly-debug-info=debug-line-only --target=x86_64-apple-darwin21.6.0 -Xclang -fcas-backend -Xclang -fcas-backend-mode=native -Xclang -fcas-path -Xclang %t/cas %s -S -o %t/out.s
+// RUN: llvm-mc -n -cas-backend -triple x86_64-apple-darwin21.6.0 %t/out.s -filetype=obj --mccas-verify
+
 int foo() {
     return 1;
 }

--- a/llvm/include/llvm/MC/CAS/MCCASObjectV1.h
+++ b/llvm/include/llvm/MC/CAS/MCCASObjectV1.h
@@ -368,6 +368,11 @@ private:
   // string in the section.
   Error createDebugStrSection();
 
+  /// If there is any padding between one section and the next, create a
+  /// PaddingRef CAS object to represent the bytes of Padding between the two
+  /// sections.
+  Error createPaddingRef(const MCSection *Sec);
+
   const MCSection *CurrentSection = nullptr;
   const MCSymbol *CurrentAtom = nullptr;
 


### PR DESCRIPTION
Felipe noticed some issues when he used the `--mccas-verify` option with `llvm-mc` the object files wouldn't match up. The issue is that a `PaddingRef` object was not being added to section cas block. 