### PR TITLE
Remove the check for eStateConnected in remote testing sessions.

### DIFF
--- a/lldb/test/API/functionalities/signal/TestSendSignal.py
+++ b/lldb/test/API/functionalities/signal/TestSendSignal.py
@@ -70,10 +70,6 @@ class SendSignalTestCase(TestBase):
         # Now continue:
         process.Continue()
 
-        # If running remote test, there should be a connected event
-        if lldb.remote_platform:
-            self.match_state(process_listener, lldb.eStateConnected)
-
         self.match_state(process_listener, lldb.eStateRunning)
 
         # Now signal the process, and make sure it stops:


### PR DESCRIPTION
This check is clearly incorrect, there's no way you should have an
eStateConnected event left on the queue if you've already launched
and hit a breakpoint in the program.  This check fails running remotely
on Darwin systems and on one remote Linux platform.  And if we do
find this failing somewhere, we should fix the bogus eStateConnected,
not the test.

(cherry picked from commit b06da9c18390f84950e1d8f70ef2bb0efb433075)
