### PR TITLE
[lldb] Improve EXC_RESOURCE exception reason

### DIFF
--- a/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
+++ b/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
@@ -410,7 +410,8 @@ const char *StopInfoMachException::GetDescription() {
 
       switch (resource_type) {
       case RESOURCE_TYPE_CPU:
-        exc_desc = "EXC_RESOURCE RESOURCE_TYPE_CPU";
+        exc_desc =
+            "EXC_RESOURCE (RESOURCE_TYPE_CPU: CPU usage monitor tripped)";
         snprintf(code_desc_buf, sizeof(code_desc_buf), "%d%%",
                  (int)EXC_RESOURCE_CPUMONITOR_DECODE_PERCENTAGE(m_exc_code));
         snprintf(subcode_desc_buf, sizeof(subcode_desc_buf), "%d%%",
@@ -418,7 +419,8 @@ const char *StopInfoMachException::GetDescription() {
                      m_exc_subcode));
         break;
       case RESOURCE_TYPE_WAKEUPS:
-        exc_desc = "EXC_RESOURCE RESOURCE_TYPE_WAKEUPS";
+        exc_desc = "EXC_RESOURCE (RESOURCE_TYPE_WAKEUPS: idle wakeups monitor "
+                   "tripped)";
         snprintf(
             code_desc_buf, sizeof(code_desc_buf), "%d w/s",
             (int)EXC_RESOURCE_CPUMONITOR_DECODE_WAKEUPS_PERMITTED(m_exc_code));
@@ -427,11 +429,12 @@ const char *StopInfoMachException::GetDescription() {
                      m_exc_subcode));
         break;
       case RESOURCE_TYPE_MEMORY:
-        exc_desc = "EXC_RESOURCE RESOURCE_TYPE_MEMORY";
+        exc_desc = "EXC_RESOURCE (RESOURCE_TYPE_MEMORY: high watermark memory "
+                   "limit exceeded)";
         snprintf(code_desc_buf, sizeof(code_desc_buf), "%d MB",
                  (int)EXC_RESOURCE_HWM_DECODE_LIMIT(m_exc_code));
         subcode_desc = nullptr;
-        subcode_label = "unused";
+        subcode_label = nullptr;
         break;
 #if defined(RESOURCE_TYPE_IO)
       // RESOURCE_TYPE_IO is introduced in macOS SDK 10.12.
@@ -468,9 +471,9 @@ const char *StopInfoMachException::GetDescription() {
   }
 
   if (m_exc_data_count >= 2) {
-    if (subcode_desc)
+    if (subcode_label && subcode_desc)
       strm.Printf(", %s=%s", subcode_label, subcode_desc);
-    else
+    else if (subcode_label)
       strm.Printf(", %s=0x%" PRIx64, subcode_label, m_exc_subcode);
   }
 


### PR DESCRIPTION
Jason noted that the stop message we print for a memory high water mark
notification (EXC_RESOURCE) could be clearer. Currently, the stop
reason looks like this:

  * thread #3, queue = 'com.apple.CFNetwork.LoaderQ', stop reason =
    EXC_RESOURCE RESOURCE_TYPE_MEMORY (limit=14 MB, unused=0x0)

It's hard to read the message because the exception and the type
(EXC_RESOURCE RESOURCE_TYPE_MEMORY) blend together. Additionally, the
"observed=0x0" should not be printed for memory limit exceptions.

I wanted to continue to include the resource type from
<kern/exc_resource.h> while also explaining what it actually is. I used
the wording from the comments in the header. With this path, the stop
reason now looks like this:

  * thread #5, stop reason = EXC_RESOURCE (RESOURCE_TYPE_MEMORY: high
    watermark memory limit exceeded) (limit=14 MB)

rdar://40466897

Differential revision: https://reviews.llvm.org/D131130

(cherry picked from commit 9c81b743e31a7dca288b37b6cf6cca3213bfd923)
