### PR TITLE
[clang][cas] Add test dependency on llvm-mc

### DIFF
--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -119,6 +119,7 @@ if( NOT CLANG_BUILT_STANDALONE )
     llvm-dwarfdump
     llvm-ifs
     llvm-lto2
+    llvm-mc
     llvm-modextract
     llvm-nm
     llvm-objcopy


### PR DESCRIPTION
There is a clang CAS test using llvm-mc, so add a dependency.