### PR TITLE
Teach isTriviallyCopyableType to return false when the type is an address-discriminated ptrauth type or a struct containing a field that has such a type

### DIFF
--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -2467,6 +2467,10 @@ bool QualType::isTriviallyCopyableType(const ASTContext &Context) const {
   if (hasNonTrivialObjCLifetime())
     return false;
 
+  PrimitiveCopyKind PCK = isNonTrivialToPrimitiveCopy();
+  if (PCK != PCK_Trivial && PCK != PCK_VolatileTrivial)
+    return false;
+
   // C++11 [basic.types]p9 - See Core 2094
   //   Scalar types, trivially copyable class types, arrays of such types, and
   //   cv-qualified versions of these types are collectively

--- a/clang/test/CodeGen/ptrauth-in-c-struct.c
+++ b/clang/test/CodeGen/ptrauth-in-c-struct.c
@@ -27,6 +27,8 @@ typedef struct {
 SA getSA(void);
 void calleeSA(SA);
 
+int g0;
+
 // CHECK: define void @test_copy_constructor_SA(%[[STRUCT_SA]]* noundef %{{.*}})
 // CHECK: call void @__copy_constructor_8_8_t0w4_pa1_50_8(
 
@@ -161,4 +163,22 @@ void test_copy_constructor_SI(SI *s) {
 // CHECK: ret void
 
 void test_parameter_SI(SI a) {
+}
+
+// CHECK-LABEL: define void @test_array(
+// CHECK: %[[F1:.*]] = getelementptr inbounds %[[STRUCT_SA]], %[[STRUCT_SA]]* %{{.*}}, i32 0, i32 1
+// CHECK: %[[V0:.*]] = ptrtoint i32** %[[F1]] to i64
+// CHECK: %[[V1:.*]] = call i64 @llvm.ptrauth.blend(i64 %[[V0]], i64 50)
+// CHECK: %[[V2:.*]] = call i64 @llvm.ptrauth.sign(i64 ptrtoint (i32* @g0 to i64), i32 1, i64 %[[V1]])
+// CHECK: %[[V3:.*]] = inttoptr i64 %[[V2]] to i32*
+// CHECK: store i32* %[[V3]], i32** %[[F1]], align 8
+// CHECK: %[[F12:.*]] = getelementptr inbounds %[[STRUCT_SA]], %[[STRUCT_SA]]* %{{.*}}, i32 0, i32 1
+// CHECK: %[[V4:.*]] = ptrtoint i32** %[[F12]] to i64
+// CHECK: %[[V5:.*]] = call i64 @llvm.ptrauth.blend(i64 %[[V4]], i64 50)
+// CHECK: %[[V6:.*]] = call i64 @llvm.ptrauth.sign(i64 ptrtoint (i32* @g0 to i64), i32 1, i64 %[[V5]])
+// CHECK: %[[V7:.*]] = inttoptr i64 %[[V6]] to i32*
+// CHECK: store i32* %[[V7]], i32** %[[F12]], align 8
+
+void test_array(void) {
+  const SA a[] = {{0, &g0}, {1, &g0}};
 }


### PR DESCRIPTION
This fixes a crash in AggExprEmitter::EmitArrayInit that occurs when it tries to initialize an array of a struct with an address-discriminated ptrauth type field from a global.

rdar://85173549
(cherry picked from commit 997b1790ef32a2783cc072c6bc3b6a6f2e8e6522)

Conflicts:
	clang/test/CodeGen/ptrauth-in-c-struct.c