### PR TITLE
Add a --dwarf-dump option to llvm-cas-dump.

### DIFF
--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -73,6 +73,7 @@ set(LLVM_TEST_DEPENDS
           llvm-cat
           llvm-cas
           llvm-cas-object-format
+          llvm-cas-dump
           llvm-cfi-verify
           llvm-config
           llvm-cov

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -160,6 +160,7 @@ tools.extend([
     'dsymutil', 'lli', 'lli-child-target', 'llvm-ar', 'llvm-as',
     'llvm-addr2line', 'llvm-bcanalyzer', 'llvm-bitcode-strip', 'llvm-config',
     'llvm-cov', 'llvm-cxxdump', 'llvm-cvtres', 'llvm-debuginfod-find', 'llvm-debuginfod',
+    'llvm-cas-dump',
     'llvm-diff', 'llvm-dis', 'llvm-dwarfdump', 'llvm-dwarfutil', 'llvm-dlltool',
     'llvm-exegesis', 'llvm-extract', 'llvm-isel-fuzzer', 'llvm-ifs',
     'llvm-install-name-tool', 'llvm-jitlink', 'llvm-opt-fuzzer', 'llvm-lib',

--- a/llvm/test/tools/llvm-cas-dump/basic_debug_test.ll
+++ b/llvm/test/tools/llvm-cas-dump/basic_debug_test.ll
@@ -1,5 +1,6 @@
 ; RUN: llc -O0 --filetype=obj --cas-backend --cas=%t.casdb --mccas-casid -o %t.casid %s
 ; RUN: llvm-cas-dump --cas=%t.casdb --dwarf-sections-only --casid-file %t.casid | FileCheck %s
+; RUN: llvm-cas-dump --cas=%t.casdb --dwarf-sections-only --dwarf-dump --casid-file %t.casid | FileCheck %s --check-prefix=DWARF
 
 ; This test is created from a C program like:
 ; int foo() { return 10; }
@@ -25,6 +26,39 @@
 ; CHECK-NEXT:     mc:cstring  llvmcas://{{.*}}
 ; CHECK-NEXT:     mc:cstring  llvmcas://{{.*}}
 ; CHECK-NEXT:     mc:cstring  llvmcas://{{.*}}
+
+; DWARF: mc:debug_info_cu
+; DWARF: Compile Unit: length = 0x00000047, format = DWARF32, version = 0x0004, abbr_offset = 0x0000, addr_size = 0x08
+; DWARF: DW_TAG_compile_unit
+; DWARF:   DW_AT_producer	("some_clang")
+; DWARF:   DW_AT_language	(DW_LANG_C99)
+; DWARF:   DW_AT_name	("test.c")
+; DWARF:   DW_AT_stmt_list	(0x00000000)
+; DWARF:   DW_AT_comp_dir	("some_dir")
+; DWARF:   DW_AT_low_pc	(0x0000000000000000)
+; DWARF:   DW_AT_high_pc	(0x0000000000000008)
+
+; DWARF: mc:debug_string
+; DWARF:   0x00000000: "some_clang"
+; DWARF: mc:debug_string
+; DWARF:   0x00000000: "test.c"
+; DWARF: mc:debug_string
+; DWARF:   0x00000000: "some_dir"
+; DWARF: mc:debug_string
+; DWARF:   0x00000000: "foo"
+; DWARF: mc:debug_string
+; DWARF:   0x00000000: "int"
+
+; DWARF: mc:debug_line
+; DWARF:   debug_line[0x00000000]
+; DWARF:   Line table prologue:
+; DWARF:       total_length: 0x00000039
+; DWARF:             format: DWARF32
+; DWARF:            version: 4
+; DWARF:    prologue_length: 0x0000001e
+; DWARF: 0x0000000000000000      2      0      1   0             0  is_stmt
+; DWARF: 0x0000000000000004      3      3      1   0             0  is_stmt prologue_end
+; DWARF: 0x0000000000000008      3      3      1   0             0  is_stmt end_sequence
 
 target triple = "arm64-apple-macosx12.0.0"
 

--- a/llvm/tools/llvm-cas-dump/CASDWARFObject.cpp
+++ b/llvm/tools/llvm-cas-dump/CASDWARFObject.cpp
@@ -1,0 +1,194 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CASDWARFObject.h"
+#include "llvm/DebugInfo/DWARF/DWARFCompileUnit.h"
+#include "llvm/DebugInfo/DWARF/DWARFContext.h"
+#include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
+#include "llvm/DebugInfo/DWARF/DWARFDebugAbbrev.h"
+#include "llvm/DebugInfo/DWARF/DWARFDebugLine.h"
+#include "llvm/Object/MachO.h"
+#include "llvm/Support/DataExtractor.h"
+#include "llvm/Support/FormatVariadic.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+using namespace llvm::mccasformats::v1;
+
+namespace {
+/// Parse the MachO header to extract details such as endianness.
+/// Unfortunately object::MachOObjectfile() doesn't support parsing
+/// incomplete files.
+struct MachOHeaderParser {
+  bool Is64Bit = true;
+  bool IsLittleEndian = true;
+  uint32_t DebugAbbrevOffset = 0;
+  uint64_t DebugAbbrevSize = 0;
+
+  /// Stolen from MachOObjectfile.
+  template <typename T>
+  Expected<T> getStructOrErr(StringRef Data, const char *P) {
+    // Don't read before the beginning or past the end of the file
+    if (P < Data.begin() || P + sizeof(T) > Data.end())
+      return make_error<llvm::object::GenericBinaryError>(
+          "Structure read out-of-range");
+
+    T Cmd;
+    memcpy(&Cmd, P, sizeof(T));
+    if (IsLittleEndian != sys::IsLittleEndianHost)
+      MachO::swapStruct(Cmd);
+    return Cmd;
+  }
+
+  /// Parse an mc::header.
+  Error parse(StringRef Data) {
+    // MachO 64-bit header.
+    const char *P = Data.data();
+    auto Header64 = getStructOrErr<MachO::mach_header_64>(Data, P);
+    P += sizeof(MachO::mach_header_64);
+    if (!Header64)
+      return Header64.takeError();
+    if (Header64->magic == MachO::MH_MAGIC_64) {
+      Is64Bit = true;
+      IsLittleEndian = true;
+    } else {
+      return make_error<object::GenericBinaryError>("Unsupported MachO format");
+    }
+    // Iterate over load commands to find the __debug_abbrev section.
+    // This code can be removed once that section gets its own block kind.
+    for (unsigned I = 0; I < Header64->ncmds; ++I) {
+      auto LoadCmd = getStructOrErr<MachO::load_command>(Data, P);
+      if (!LoadCmd)
+        return LoadCmd.takeError();
+      if (LoadCmd->cmd != MachO::LC_SEGMENT_64) {
+        P += LoadCmd->cmdsize;
+        continue;
+      }
+      auto SegCmd = getStructOrErr<MachO::segment_command_64>(Data, P);
+      if (!SegCmd)
+        return SegCmd.takeError();
+      P += sizeof(MachO::segment_command_64);
+      for (unsigned J = 0; J < SegCmd->nsects; ++J) {
+        auto Section = getStructOrErr<MachO::section_64>(Data, P);
+        if (!Section)
+          return Section.takeError();
+        P += sizeof(MachO::section_64);
+        if (StringRef(Section->sectname,
+                      strnlen(Section->sectname, sizeof(Section->sectname))) ==
+            "__debug_abbrev") {
+          DebugAbbrevOffset = Section->offset - Data.size();
+          DebugAbbrevSize = Section->size;
+          return Error::success();
+        }
+      }
+    }
+    return Error::success();
+  }
+};
+} // namespace
+
+Error CASDWARFObject::discoverDwarfSections(ObjectRef CASObj) {
+  if (CASObj == Schema.getRootNodeTypeID())
+    return Error::success();
+  Expected<MCObjectProxy> MCObj = Schema.get(CASObj);
+  if (!MCObj)
+    return MCObj.takeError();
+  return discoverDwarfSections(*MCObj);
+}
+
+Error CASDWARFObject::discoverDwarfSections(MCObjectProxy MCObj) {
+  StringRef Data = MCObj.getData();
+  if (HeaderRef::Cast(MCObj)) {
+    MachOHeaderParser P;
+    if (Error Err = P.parse(MCObj.getData()))
+      return Err;
+    Is64Bit = P.Is64Bit;
+    IsLittleEndian = P.IsLittleEndian;
+    DebugAbbrevOffset = P.DebugAbbrevOffset;
+    DebugAbbrevSize = P.DebugAbbrevSize;
+  }
+  if (DebugAbbrevSection.empty() &&
+      MCObj.getKindString().startswith("mc:data")) {
+    StringRef Data = MCObj.getData();
+    if (DebugAbbrevOffset < Data.size()) {
+      DebugAbbrevSection =
+          Data.drop_front(DebugAbbrevOffset).take_front(DebugAbbrevSize);
+    } else {
+      DebugAbbrevOffset -= Data.size();
+    }
+  }
+
+  if (DebugStrRef::Cast(MCObj)) {
+    DebugStringSection.append(Data.begin(), Data.end());
+    DebugStringSection.push_back(0);
+  }
+  return MCObj.forEachReference(
+      [this](ObjectRef CASObj) { return discoverDwarfSections(CASObj); });
+}
+
+Error CASDWARFObject::dump(raw_ostream &OS, int Indent, DWARFContext &DWARFCtx,
+                           MCObjectProxy MCObj) const {
+  OS.indent(Indent);
+  DIDumpOptions DumpOpts;
+  Error Err = Error::success();
+  StringRef Data = MCObj.getData();
+  if (Data.empty())
+    return Err;
+  if (DebugStrRef::Cast(MCObj)) {
+    // Dump __debug_str data.
+    assert(Data.data()[Data.size()] == 0);
+    DataExtractor StrData(StringRef(Data.data(), Data.size() + 1),
+                          isLittleEndian(), 0);
+    // This is almost identical with the DumpStrSection lambda in
+    // DWARFContext.cpp
+    uint64_t Offset = 0;
+    uint64_t StrOffset = 0;
+    while (StrData.isValidOffset(Offset)) {
+      const char *CStr = StrData.getCStr(&Offset, &Err);
+      if (Err)
+        return Err;
+      OS << format("0x%8.8" PRIx64 ": \"", StrOffset);
+      OS.write_escaped(CStr);
+      OS << "\"\n";
+      StrOffset = Offset;
+    }
+  } else if (DebugLineRef::Cast(MCObj)) {
+    // Dump __debug_line data.
+    uint64_t Address = 0;
+    DWARFDataExtractor LineData(*this, {Data, Address}, isLittleEndian(), 0);
+    DWARFDebugLine::SectionParser Parser(LineData, DWARFCtx,
+                                         DWARFCtx.normal_units());
+    while (!Parser.done()) {
+      OS << "debug_line[" << format("0x%8.8" PRIx64, Parser.getOffset())
+         << "]\n";
+      Parser.parseNext(DumpOpts.WarningHandler, DumpOpts.WarningHandler, &OS,
+                       DumpOpts.Verbose);
+    }
+  } else if (DebugInfoCURef::Cast(MCObj)) {
+    // Dump __debug_info data.
+    DWARFUnitVector UV;
+    uint64_t Address = 0;
+    DWARFSection Section = {Data, Address};
+    DWARFUnitHeader Header;
+    DWARFDebugAbbrev Abbrev;
+    Abbrev.extract(
+        DataExtractor(getAbbrevSection(), isLittleEndian(), getAddressSize()));
+    uint64_t offset_ptr = 0;
+    Header.extract(
+        DWARFCtx,
+        DWARFDataExtractor(*this, Section, isLittleEndian(), getAddressSize()),
+        &offset_ptr, DWARFSectionKind::DW_SECT_INFO);
+    DWARFCompileUnit U(DWARFCtx, Section, Header, &Abbrev, &getRangesSection(),
+                       &getLocSection(), getStrSection(),
+                       getStrOffsetsSection(), &getAddrSection(),
+                       getLocSection(), isLittleEndian(), false, UV);
+    U.dump(OS, DumpOpts);
+    // TODO: Dump more than just the CU.
+  }
+  return Err;
+}

--- a/llvm/tools/llvm-cas-dump/CASDWARFObject.h
+++ b/llvm/tools/llvm-cas-dump/CASDWARFObject.h
@@ -1,0 +1,55 @@
+//===-----------------------------------------------------------*- C++ -*--===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TOOLS_LLVM_CAS_DUMP_CASDWARFOBJECT_H
+#define LLVM_TOOLS_LLVM_CAS_DUMP_CASDWARFOBJECT_H
+
+#include "MCCASPrinter.h"
+#include "llvm/DebugInfo/DWARF/DWARFObject.h"
+#include "llvm/MC/CAS/MCCASObjectV1.h"
+
+namespace llvm {
+
+/// A DWARFObject implementation that just supports enough to
+/// dwarfdump section contents.
+class CASDWARFObject : public DWARFObject {
+  bool Is64Bit = true;
+  bool IsLittleEndian = true;
+  uint32_t DebugAbbrevOffset = 0;
+  uint64_t DebugAbbrevSize = 0;
+  SmallVector<uint8_t> DebugStringSection;
+  StringRef DebugAbbrevSection;
+  const mccasformats::v1::MCSchema &Schema;
+
+  Error discoverDwarfSections(cas::ObjectRef CASObj);
+
+public:
+  CASDWARFObject(const mccasformats::v1::MCSchema &Schema) : Schema(Schema) {}
+
+  Error discoverDwarfSections(mccasformats::v1::MCObjectProxy MCObj);
+
+  /// Dump MCObj as textual DWARF output.
+  Error dump(raw_ostream &OS, int Indent, DWARFContext &DWARFCtx,
+             mccasformats::v1::MCObjectProxy MCObj) const;
+
+  StringRef getFileName() const override { return "CAS"; }
+  ArrayRef<SectionName> getSectionNames() const override { return {}; }
+  bool isLittleEndian() const override { return IsLittleEndian; }
+  uint8_t getAddressSize() const override { return Is64Bit ? 8 : 4; }
+  StringRef getAbbrevSection() const override { return DebugAbbrevSection; }
+  StringRef getStrSection() const override {
+    return llvm::toStringRef(DebugStringSection);
+  }
+  Optional<RelocAddrEntry> find(const DWARFSection &Sec,
+                                uint64_t Pos) const override {
+    return {};
+  };
+};
+} // namespace llvm
+
+#endif

--- a/llvm/tools/llvm-cas-dump/CMakeLists.txt
+++ b/llvm/tools/llvm-cas-dump/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(LLVM_LINK_COMPONENTS
+  DebugInfoDWARF
   Support
   CAS
   CASObjectFormats
@@ -6,5 +7,6 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_tool(llvm-cas-dump
   llvm-cas-dump.cpp
+  CASDWARFObject.cpp
   MCCASPrinter.cpp
 )

--- a/llvm/tools/llvm-cas-dump/MCCASPrinter.cpp
+++ b/llvm/tools/llvm-cas-dump/MCCASPrinter.cpp
@@ -7,6 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "MCCASPrinter.h"
+#include "CASDWARFObject.h"
+#include "llvm/DebugInfo/DWARF/DWARFContext.h"
+#include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/FormatVariadic.h"
 
 using namespace llvm;
@@ -41,7 +44,9 @@ bool isDwarfSection(MCObjectProxy MCObj) {
 MCCASPrinter::MCCASPrinter(PrinterOptions Options, CASDB &CAS, raw_ostream &OS)
     : Options(Options), MCSchema(CAS), Indent{0}, OS(OS) {}
 
-Error MCCASPrinter::printMCObject(ObjectRef CASObj) {
+MCCASPrinter::~MCCASPrinter() {}
+
+Error MCCASPrinter::printMCObject(ObjectRef CASObj, DWARFContext *DWARFCtx) {
   // The object identifying the schema is not considered an MCObject, as such we
   // don't attempt to cast or print it.
   if (CASObj == MCSchema.getRootNodeTypeID())
@@ -50,24 +55,44 @@ Error MCCASPrinter::printMCObject(ObjectRef CASObj) {
   Expected<MCObjectProxy> MCObj = MCSchema.get(CASObj);
   if (!MCObj)
     return MCObj.takeError();
-  return printMCObject(*MCObj);
+  return printMCObject(*MCObj, DWARFCtx);
 }
 
-Error MCCASPrinter::printMCObject(MCObjectProxy MCObj) {
+Error MCCASPrinter::printMCObject(MCObjectProxy MCObj, DWARFContext *DWARFCtx) {
+  // Initialize DWARFObj and scan and make a first pass through the sections.
+  std::unique_ptr<DWARFContext> DWARFContextHolder;
+  if (Options.DwarfDump && !DWARFCtx) {
+    auto DWARFObj = std::make_unique<CASDWARFObject>(MCObj.getSchema());
+    if (Error err = DWARFObj->discoverDwarfSections(MCObj))
+      return err;
+    DWARFContextHolder = std::make_unique<DWARFContext>(std::move(DWARFObj));
+    DWARFCtx = DWARFContextHolder.get();
+  }
+
   // If only debug sections were requested, skip non-debug sections.
   if (Options.DwarfSectionsOnly && SectionRef::Cast(MCObj) &&
       !isDwarfSection(MCObj))
     return Error::success();
 
+  // Print CAS Id.
   OS.indent(Indent);
   OS << formatv("{0, -15} {1} \n", MCObj.getKindString(),
                 MCSchema.CAS.getID(MCObj));
 
-  return printSimpleNested(MCObj);
+  // Dwarfdump.
+  if (DWARFCtx) {
+    IndentGuard Guard(Indent);
+    auto *DWARFObj =
+        static_cast<const CASDWARFObject *>(&DWARFCtx->getDWARFObj());
+    if (Error Err = DWARFObj->dump(OS, Indent, *DWARFCtx, MCObj))
+      return Err;
+  }
+  return printSimpleNested(MCObj, DWARFCtx);
 }
 
-Error MCCASPrinter::printSimpleNested(MCObjectProxy AssemblerRef) {
+Error MCCASPrinter::printSimpleNested(MCObjectProxy AssemblerRef,
+                                      DWARFContext *DWARFCtx) {
   IndentGuard Guard(Indent);
   return AssemblerRef.forEachReference(
-      [this](ObjectRef CASObj) { return printMCObject(CASObj); });
+      [&](ObjectRef CASObj) { return printMCObject(CASObj, DWARFCtx); });
 }

--- a/llvm/tools/llvm-cas-dump/MCCASPrinter.h
+++ b/llvm/tools/llvm-cas-dump/MCCASPrinter.h
@@ -1,4 +1,4 @@
-//===----------------------------------------------------------------------===//
+//===-----------------------------------------------------------*- C++ -*--===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,33 +6,39 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef LLVM_TOOLS_LLVM_CAS_DUMP_MCCASPRINTER_H
+#define LLVM_TOOLS_LLVM_CAS_DUMP_MCCASPRINTER_H
+
 #include "llvm/MC/CAS/MCCASObjectV1.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
 class raw_ostream;
+class DWARFContext;
 
 namespace mccasformats {
 namespace v1 {
 
 struct PrinterOptions {
-  bool DwarfSectionsOnly;
+  bool DwarfSectionsOnly = false;
+  bool DwarfDump = false;
 };
 
 struct MCCASPrinter {
   /// Creates a printer object capable of printing MCCAS objects inside `CAS`.
   /// Output is sent to `OS`.
   MCCASPrinter(PrinterOptions Options, cas::CASDB &CAS, raw_ostream &OS);
+  ~MCCASPrinter();
 
   /// If `CASObj` is an MCObject, prints its contents and all nodes referenced
   /// by it recursively. If CASObj or any of its children are not MCObjects, an
   /// error is returned.
-  Error printMCObject(cas::ObjectRef CASObj);
+  Error printMCObject(cas::ObjectRef CASObj, DWARFContext *DWARFCtx = nullptr);
 
   /// Prints the contents of `MCObject` and all nodes referenced by it
   /// recursively. If any of its children are not MCObjects, an error is
   /// returned.
-  Error printMCObject(MCObjectProxy MCObj);
+  Error printMCObject(MCObjectProxy MCObj, DWARFContext *DWARFCtx);
 
 private:
   PrinterOptions Options;
@@ -40,8 +46,9 @@ private:
   int Indent;
   raw_ostream &OS;
 
-  Error printSimpleNested(MCObjectProxy AssemblerRef);
+  Error printSimpleNested(MCObjectProxy AssemblerRef, DWARFContext *DWARFCtx);
 };
 } // namespace v1
 } // namespace mccasformats
 } // namespace llvm
+#endif

--- a/llvm/tools/llvm-cas-dump/llvm-cas-dump.cpp
+++ b/llvm/tools/llvm-cas-dump/llvm-cas-dump.cpp
@@ -25,7 +25,9 @@ cl::list<std::string> InputStrings(cl::Positional,
                                    cl::desc("CAS ID of the object to print"));
 cl::opt<bool> CASIDFile("casid-file", cl::desc("Treat inputs as CASID files"));
 cl::opt<bool> DwarfSectionsOnly("dwarf-sections-only",
-                                cl::desc("Only print dwarf related sections"));
+                                cl::desc("Only print DWARF related sections"));
+cl::opt<bool> DwarfDump("dwarf-dump",
+                        cl::desc("Print the contents of DWARF sections"));
 
 namespace {
 
@@ -50,7 +52,7 @@ int main(int argc, char *argv[]) {
   ExitOnErr.setBanner(std::string(argv[0]) + ": ");
 
   cl::ParseCommandLineOptions(argc, argv);
-  PrinterOptions Options = {DwarfSectionsOnly};
+  PrinterOptions Options = {DwarfSectionsOnly, DwarfDump};
 
   std::unique_ptr<CASDB> CAS = ExitOnErr(createOnDiskCAS(CASPath));
   MCCASPrinter Printer(Options, *CAS, llvm::outs());


### PR DESCRIPTION
This patch adds rudimentary support for printing the contents of debug
info sections in a CAS tree dump. This should make debugging and
testing a little easier.

Not quite ready for merging yet, but it's a start!