### PR TITLE
Fix dump tool bug with option '--dwarf-sections-only'

### DIFF
--- a/llvm/include/llvm/MC/CAS/MCCASObjectV1.def
+++ b/llvm/include/llvm/MC/CAS/MCCASObjectV1.def
@@ -20,6 +20,7 @@ CASV1_SIMPLE_DATA_REF(MergedFragmentRef, mc:merged_fragment)
 CASV1_SIMPLE_DATA_REF(DebugStrRef, mc:debug_string)
 CASV1_SIMPLE_DATA_REF(DebugInfoCURef, mc:debug_info_cu)
 CASV1_SIMPLE_DATA_REF(DebugLineRef, mc:debug_line)
+CASV1_SIMPLE_DATA_REF(RelocAddendRef, mc:reloc_addend)
 
 #undef CASV1_SIMPLE_DATA_REF
 #endif /* CASV1_SIMPLE_DATA_REF */

--- a/llvm/lib/MC/MCCASObjectV1.cpp
+++ b/llvm/lib/MC/MCCASObjectV1.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/MC/CAS/MCCASObjectV1.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Triple.h"
 #include "llvm/BinaryFormat/MachO.h"
 #include "llvm/CAS/CASDB.h"
 #include "llvm/CAS/CASID.h"
@@ -17,6 +18,7 @@
 #include "llvm/Support/BinaryStreamReader.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/EndianStream.h"
+#include <_types/_uint32_t.h>
 #include <memory>
 
 // FIXME: Fix dependency here.
@@ -63,6 +65,50 @@ cl::opt<RelEncodeLoc> RelocLocation(
     cl::values(clEnumVal(Atom, "In atom"), clEnumVal(Section, "In section"),
                clEnumVal(CompileUnit, "In compile unit")),
     cl::init(Atom));
+
+static bool isScatteredRelocation(const MachO::any_relocation_info &RelocInfo,
+                                  Triple::ArchType Arch) {
+  if (Arch == Triple::ArchType::x86_64)
+    return false;
+  return RelocInfo.r_word0 & MachO::R_SCATTERED;
+}
+
+static uint64_t getRelocationType(const MachO::any_relocation_info &RelocInfo,
+                                  support::endianness Endian) {
+  if (Endian == support::little ||
+      (Endian == support::native &&
+       support::endian::system_endianness() == support::little))
+    return RelocInfo.r_word1 >> 28;
+  return RelocInfo.r_word1 & 0xf;
+}
+
+static uint32_t getRelocationLength(const MachO::any_relocation_info &RelocInfo,
+                                    support::endianness Endian) {
+  if (Endian == support::little ||
+      (Endian == support::native &&
+       support::endian::system_endianness() == support::little))
+    return (RelocInfo.r_word1 >> 25) & 3;
+  return (RelocInfo.r_word1 >> 5) & 3;
+}
+
+static Expected<uint32_t> getRelocationSize(MachO::any_relocation_info Reloc,
+                                            support::endianness Endian,
+                                            Triple::ArchType Arch) {
+  uint32_t Size;
+  if (isScatteredRelocation(Reloc, Arch))
+    return createStringError(inconvertibleErrorCode(),
+                             "Scattered Relocations are not support in MCCAS");
+  uint64_t RelocType = getRelocationType(Reloc, Endian);
+  if ((Arch == Triple::ArchType::x86_64 &&
+       RelocType == MachO::X86_64_RELOC_UNSIGNED) ||
+      (Arch == Triple::ArchType::aarch64 &&
+       RelocType == MachO::ARM64_RELOC_UNSIGNED)) {
+    Size = 1 << getRelocationLength(Reloc, Endian);
+  } else {
+    llvm_unreachable("Unsupported relocation type!");
+  }
+  return Size;
+}
 
 Expected<cas::ObjectProxy>
 MCSchema::createFromMCAssemblerImpl(MachOCASWriter &ObjectWriter,
@@ -421,27 +467,128 @@ Expected<SectionRef> SectionRef::create(MCCASBuilder &MB,
   return get(B->build());
 }
 
+Expected<SmallVector<char, 0>> MCCASReader::applyRelocationAddends(
+    const SmallVector<cas::ObjectRef> &Refs, StringRef RelocData,
+    StringLiteral KindString, StringRef SectionName,
+    bool &IsPaddingRefPresent) {
+  if (auto E = decodeRelocations(*this, RelocData))
+    return std::move(E);
+  SmallVector<char, 0> SectionData;
+  auto RelocRef = MCObjectProxy::get(Schema, Schema.CAS.getProxy(Refs[0]));
+  if (!RelocRef)
+    return RelocRef.takeError();
+  if (auto R = RelocAddendRef::Cast(*RelocRef)) {
+    auto RelocationData = R->getData();
+    for (uint32_t I = 1; I < Refs.size(); I++) {
+      auto BlockRef = MCObjectProxy::get(Schema, Schema.CAS.getProxy(Refs[I]));
+      if (!BlockRef)
+        return BlockRef.takeError();
+      if (BlockRef->getKindString() == KindString) {
+        llvm::append_range(SectionData, BlockRef->getData());
+      } else if (auto P = PaddingRef::Cast(*BlockRef)) {
+        if (I != Refs.size() - 1)
+          return createStringError(
+              inconvertibleErrorCode(),
+              "PaddingRef must be the last reference of the Section");
+        IsPaddingRefPresent = true;
+      } else {
+        StringLiteral ErrorMsg =
+            "Every other reference to a {0}, must be a {1}, or {2} object!";
+        llvm::format(ErrorMsg.begin(), SectionName.data(), KindString.data(),
+                     PaddingRef::KindString.data());
+        return createStringError(inconvertibleErrorCode(), ErrorMsg.data());
+      }
+    }
+    uint32_t RelocDataIndex = 0;
+    for (auto Relocs : Relocations.back()) {
+      auto Size = getRelocationSize(Relocs, this->getEndian(), this->getArch());
+      if (!Size)
+        return Size.takeError();
+      if (*Size + RelocDataIndex > RelocationData.size()) {
+        return createStringError(inconvertibleErrorCode(),
+                                 "Relocation Data not encoded correctly, "
+                                 "reading past the end of the relocation data");
+      }
+      for (uint32_t I = 0; I < *Size; I++)
+        SectionData[Relocs.r_word0 + I] = RelocationData[RelocDataIndex + I];
+      RelocDataIndex += *Size;
+    }
+    return SectionData;
+  }
+  return createStringError(
+      inconvertibleErrorCode(),
+      "First reference to debug line section must be a RelocAddendRef object!");
+}
+
+Expected<uint64_t> MCCASReader::materializeDebugLineSection(
+    const SmallVector<cas::ObjectRef> &Refs, StringRef RelocData) {
+  bool IsPaddingRefPresent = false;
+  auto DebugLineData =
+      applyRelocationAddends(Refs, RelocData, DebugLineRef::KindString,
+                             "debug_line", IsPaddingRefPresent);
+  if (!DebugLineData)
+    return DebugLineData.takeError();
+  OS << *DebugLineData;
+  if (IsPaddingRefPresent) {
+    auto PadRef =
+        MCObjectProxy::get(Schema, Schema.CAS.getProxy(Refs[Refs.size() - 1]));
+    if (!PadRef)
+      return PadRef.takeError();
+    if (auto P = PaddingRef::Cast(*PadRef)) {
+      auto PadSize = P->materialize(OS);
+      if (!PadSize)
+        return PadSize.takeError();
+      return *PadSize + DebugLineData->size();
+    }
+  }
+  return DebugLineData->size();
+}
+
+Expected<bool>
+MCCASReader::isDebugLineSection(const SmallVector<cas::ObjectRef> &Refs) {
+  auto RelocRef = MCObjectProxy::get(Schema, Schema.CAS.getProxy(Refs[0]));
+  if (!RelocRef)
+    return RelocRef.takeError();
+  if (auto R = RelocAddendRef::Cast(*RelocRef)) {
+    auto DbgLineRef = MCObjectProxy::get(Schema, Schema.CAS.getProxy(Refs[1]));
+    if (!DbgLineRef)
+      return DbgLineRef.takeError();
+    if (auto D = DebugLineRef::Cast(*DbgLineRef))
+      return true;
+  }
+  return false;
+}
+
 Expected<uint64_t> SectionRef::materialize(MCCASReader &Reader) const {
   // Start a new section for relocations.
   Reader.Relocations.emplace_back();
 
-  unsigned Size = 0;
   StringRef Remaining = getData();
   auto Refs = decodeReferences(*this, Remaining);
   if (!Refs)
     return Refs.takeError();
 
-  for (auto ID : *Refs) {
-    auto FragmentSize = Reader.materializeSection(ID);
-    if (!FragmentSize)
-      return FragmentSize.takeError();
-    Size += *FragmentSize;
+  auto IsDebugLineSection = Reader.isDebugLineSection(*Refs);
+  if (!IsDebugLineSection)
+    return IsDebugLineSection.takeError();
+
+  if (*IsDebugLineSection) {
+    // Handle Debug Line Section
+    return Reader.materializeDebugLineSection(*Refs, Remaining);
+  } else {
+    unsigned Size = 0;
+    for (auto ID : *Refs) {
+      auto FragmentSize = Reader.materializeSection(ID);
+      if (!FragmentSize)
+        return FragmentSize.takeError();
+      Size += *FragmentSize;
+    }
+
+    if (auto E = decodeRelocations(Reader, Remaining))
+      return std::move(E);
+
+    return Size;
   }
-
-  if (auto E = decodeRelocations(Reader, Remaining))
-    return std::move(E);
-
-  return Size;
 }
 
 Expected<AtomRef> AtomRef::create(MCCASBuilder &MB,
@@ -1084,6 +1231,12 @@ Error MCCASBuilder::createLineSection() {
 
   startSection(DwarfSections.Line);
 
+  // Create a block to the relocation addend values and zero the addends out in
+  // the section contents to improve deduplication.
+  if (auto E = createRelocAddendRefBlock(*DebugLineData)) {
+    return E;
+  }
+
   StringRef DebugLineStrRef(DebugLineData->data(), DebugLineData->size());
   BinaryStreamReader SectionReader(DebugLineStrRef, Asm.getBackend().Endian);
   // Iterate over the line section contents and split it up into individual cas
@@ -1103,6 +1256,26 @@ Error MCCASBuilder::createLineSection() {
   if (auto E = createPaddingRef(DwarfSections.Line))
     return E;
   return finalizeSection();
+}
+
+Error MCCASBuilder::createRelocAddendRefBlock(SmallVector<char, 0> &SectionContents) {
+  SmallVector<char, 0> RelocationData;
+  for (auto &Reloc : SectionRelocs) {
+    auto Size = getRelocationSize(Reloc, Asm.getBackend().Endian,
+                                  this->ObjectWriter.Target.getArch());
+    if (!Size)
+      return Size.takeError();
+    for (unsigned I = 0; I < *Size; I++) {
+      RelocationData.push_back(SectionContents[Reloc.r_word0 + I]);
+      SectionContents[Reloc.r_word0 + I] = 0;
+    }
+  }
+  StringRef RelocStrRef(RelocationData.data(), RelocationData.size());
+  auto RelocRef = RelocAddendRef::create(*this, RelocStrRef);
+  if (!RelocRef)
+    return RelocRef.takeError();
+  addNode(*RelocRef);
+  return Error::success();
 }
 
 Error MCCASBuilder::createDebugStrSection() {

--- a/llvm/test/DebugInfo/CAS/AArch64/debug-line-dedupe.test
+++ b/llvm/test/DebugInfo/CAS/AArch64/debug-line-dedupe.test
@@ -1,0 +1,96 @@
+RUN: rm -rf %t && mkdir -p %t
+RUN: split-file %s %t
+
+RUN: llc -O0 --filetype=obj --cas-backend --cas=%t/cas --mccas-casid %t/a.ll -o %t/a.id
+RUN: llc -O0 --filetype=obj --cas-backend --cas=%t/cas --mccas-casid %t/b.ll -o %t/b.id
+RUN: llvm-cas-dump --cas=%t/cas --casid-file %t/a.id %t/b.id | FileCheck %s
+
+CHECK: mc:debug_line   llvmcas://[[CASID:[a-z0-9]+]]
+CHECK-NEXT: mc:debug_line   llvmcas://
+
+CHECK: mc:debug_line   llvmcas:// 
+CHECK-NEXT: mc:debug_line   llvmcas://[[CASID]]
+CHECK-NEXT: mc:debug_line   llvmcas:// 
+
+//--- a.ll
+
+target triple = "x86_64-apple-macosx12.0.0"
+define void @foo() #0 !dbg !9 {
+  ret void, !dbg !14
+}
+define i32 @bar(i32 noundef %x) #0 !dbg !15 {
+entry:
+  %x.addr = alloca i32, align 4
+  %0 = load i32, ptr %x.addr, align 4, !dbg !21
+  %add = add nsw i32 %0, 1, !dbg !22
+  ret i32 %add, !dbg !23
+}
+attributes #0 = { noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git d74d0d9fde90cccba7bf18066ac56e55e4402948)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
+!1 = !DIFile(filename: "a.c", directory: "/Users/shubham/Development/CASDelta")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"PIC Level", i32 2}
+!6 = !{i32 7, !"uwtable", i32 2}
+!7 = !{i32 7, !"frame-pointer", i32 2}
+!9 = distinct !DISubprogram(name: "foo", scope: !10, file: !10, line: 1, type: !11, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!10 = !DIFile(filename: "./foo.h", directory: "/Users/shubham/Development/CASDelta")
+!11 = !DISubroutineType(types: !12)
+!12 = !{null}
+!13 = !{}
+!14 = !DILocation(line: 2, column: 3, scope: !9)
+!15 = distinct !DISubprogram(name: "bar", scope: !1, file: !1, line: 2, type: !16, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!16 = !DISubroutineType(types: !17)
+!17 = !{!18, !18}
+!18 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!21 = !DILocation(line: 3, column: 10, scope: !15)
+!22 = !DILocation(line: 3, column: 11, scope: !15)
+!23 = !DILocation(line: 3, column: 3, scope: !15)
+
+//--- b.ll
+
+target triple = "x86_64-apple-macosx12.0.0"
+define i32 @baz() #0 !dbg !9 {
+  ret i32 1, !dbg !14
+}
+define void @foo() #0 !dbg !15 {
+  ret void, !dbg !19
+}
+define i32 @bar(i32 noundef %x) #0 !dbg !20 {
+entry:
+  %x.addr = alloca i32, align 4
+  %0 = load i32, ptr %x.addr, align 4, !dbg !25
+  %add = add nsw i32 %0, 1, !dbg !26
+  ret i32 %add, !dbg !27
+}
+attributes #0 = { noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git d74d0d9fde90cccba7bf18066ac56e55e4402948)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
+!1 = !DIFile(filename: "b.c", directory: "/Users/shubham/Development/CASDelta")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"PIC Level", i32 2}
+!6 = !{i32 7, !"uwtable", i32 2}
+!7 = !{i32 7, !"frame-pointer", i32 2}
+!9 = distinct !DISubprogram(name: "baz", scope: !1, file: !1, line: 1, type: !10, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!10 = !DISubroutineType(types: !11)
+!11 = !{!12}
+!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!13 = !{}
+!14 = !DILocation(line: 2, column: 5, scope: !9)
+!15 = distinct !DISubprogram(name: "foo", scope: !16, file: !16, line: 1, type: !17, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!16 = !DIFile(filename: "./foo.h", directory: "/Users/shubham/Development/CASDelta")
+!17 = !DISubroutineType(types: !18)
+!18 = !{null}
+!19 = !DILocation(line: 2, column: 3, scope: !15)
+!20 = distinct !DISubprogram(name: "bar", scope: !1, file: !1, line: 6, type: !21, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!21 = !DISubroutineType(types: !22)
+!22 = !{!12, !12}
+!25 = !DILocation(line: 7, column: 10, scope: !20)
+!26 = !DILocation(line: 7, column: 11, scope: !20)
+!27 = !DILocation(line: 7, column: 3, scope: !20)

--- a/llvm/tools/llvm-cas-dump/MCCASPrinter.cpp
+++ b/llvm/tools/llvm-cas-dump/MCCASPrinter.cpp
@@ -34,6 +34,17 @@ bool isDwarfSection(MCObjectProxy MCObj) {
   if (!FirstMCRef)
     return false;
 
+  if (FirstMCRef->getKindString() == "reloc_addend") {
+    // The FirstRef is a RelocAddendRef, check the second reference if it
+    // exists.
+    if (MCObj.getNumReferences() < 2)
+      return false;
+    ObjectRef SecondRef = MCObj.getReference(1);
+    Expected<MCObjectProxy> SecondMCRef = Schema.get(SecondRef);
+    if (!SecondMCRef)
+      return false;
+    return SecondMCRef->getKindString().contains("debug");
+  }
   return FirstMCRef->getKindString().contains("debug");
 }
 } // namespace


### PR DESCRIPTION
the '--dwarf-sections-only' expects that the first reference of a debug section cas object will be a block with a KindString that contains the word 'debug', since some sections can have a RelocAddendRef as the first reference.