### PR TITLE
Fix dump tool issue with option '--dwarf-sections-only'

### DIFF
--- a/llvm/tools/llvm-cas-dump/MCCASPrinter.cpp
+++ b/llvm/tools/llvm-cas-dump/MCCASPrinter.cpp
@@ -34,6 +34,17 @@ bool isDwarfSection(MCObjectProxy MCObj) {
   if (!FirstMCRef)
     return false;
 
+  if (FirstMCRef->getKindString() == "reloc_addend") {
+    // The FirstRef is a RelocAddendRef, check the second reference if it
+    // exists.
+    if (MCObj.getNumReferences() < 2)
+      return false;
+    ObjectRef SecondRef = MCObj.getReference(1);
+    Expected<MCObjectProxy> SecondMCRef = Schema.get(SecondRef);
+    if (!SecondMCRef)
+      return false;
+    return SecondMCRef->getKindString().contains("debug");
+  }
   return FirstMCRef->getKindString().contains("debug");
 }
 } // namespace


### PR DESCRIPTION
The '--dwarf-sections-only' expects that the first reference of a debug section cas object will be a block with a `KindString` that contains the word 'debug', since some sections can have a `RelocAddendRef` as the first reference.