### PR TITLE
Revert "[lldb] Disable BreakpointSimple.test"

### DIFF
--- a/lldb/test/Shell/SwiftREPL/BreakpointSimple.test
+++ b/lldb/test/Shell/SwiftREPL/BreakpointSimple.test
@@ -1,5 +1,4 @@
 // Test that we can set breakpoints in the REPL.
-// XFAIL: *
 // REQUIRES: swift
 // RUN: %lldb --repl < %s | FileCheck %s
 


### PR DESCRIPTION
This reverts commit 7b5f5e1080c3be83d7217a3eca85425bc5caf5cc.

This patch inserted a line into the source file which broke the CHECK
line with a hardcoded line number bleow and so the XFAIL became a
self-fullfilling prophecy.

(I also can't reproduce the original failure)
rdar://93999875