### PR TITLE
[next][move-keyword] Now that move keyword is back behind a feature flag, add that flag to the tests that use it...

### DIFF
--- a/lldb/test/API/lang/swift/variables/move_function/Makefile
+++ b/lldb/test/API/lang/swift/variables/move_function/Makefile
@@ -1,3 +1,4 @@
 SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -Xfrontend -enable-experimental-move-only
 
 include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/move_function_async/Makefile
+++ b/lldb/test/API/lang/swift/variables/move_function_async/Makefile
@@ -1,3 +1,4 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
+SWIFTFLAGS_EXTRAS := -parse-as-library -Xfrontend -enable-experimental-move-only
+
 include Makefile.rules


### PR DESCRIPTION

(cherry picked from commit 60b6eb4c2f270410e3b82ea29c8c75bee3363332)

---

Just propagating commits.