### PR TITLE
Change llvm tests to not use clang anymore, change the .cpp files to .ll files

### DIFF
--- a/llvm/test/tools/llvm-cas-object-format/different_functions_same_header_dedupe.test
+++ b/llvm/test/tools/llvm-cas-object-format/different_functions_same_header_dedupe.test
@@ -3,8 +3,8 @@
 RUN: rm -rf %t && mkdir -p %t
 RUN: split-file %s %t
 
-RUN: clang %t/temp_a.cpp -c -g -fcas-friendly-debug-info=debug-line-only --target=x86_64-apple-darwin21.1.0 -o %t/temp_a.o
-RUN: clang %t/temp_b.cpp -c -g -fcas-friendly-debug-info=debug-line-only --target=x86_64-apple-darwin21.1.0 -o %t/temp_b.o
+RUN: llc %t/temp_a.ll -O0 --filetype=obj -o %t/temp_a.o
+RUN: llc %t/temp_b.ll -O0 --filetype=obj -o %t/temp_b.o
 RUN: find %t -name "*.o" &> %t/objects_to_ingest
 RUN: llvm-cas-object-format --cas %t/cas --ingest-schema=nestedv1 @%t/objects_to_ingest -silent > %t/output.casid
 RUN: llvm-cas-object-format --cas %t/cas --ingest-schema=nestedv1 --print-cas-tree @%t/output.casid | FileCheck %s --check-prefix NESTED
@@ -94,24 +94,172 @@ FLAT-NEXT:   }
 FLAT-NEXT: }
 
 
-//--- temp_a.cpp
-int bar(int x) {
-	return x*x;
-}
-#include "template_function_header.h"
-int a() {
-  return foo<int>(2);
+//--- temp_a.ll
+; ModuleID = 'temp_a.cpp'
+source_filename = "temp_a.cpp"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx12.0.0"
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable
+define noundef i32 @_Z3bari(i32 noundef %x) #0 !dbg !9 {
+entry:
+  %x.addr = alloca i32, align 4
+  store i32 %x, ptr %x.addr, align 4
+  call void @llvm.dbg.declare(metadata ptr %x.addr, metadata !14, metadata !DIExpression()), !dbg !15
+  %0 = load i32, ptr %x.addr, align 4, !dbg !16
+  %1 = load i32, ptr %x.addr, align 4, !dbg !17
+  %mul = mul nsw i32 %0, %1, !dbg !18
+  ret i32 %mul, !dbg !19
 }
 
-//--- template_function_header.h
-template <typename T>
-T foo(T s) {
-  return s * s;
+; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable
+define noundef i32 @_Z1av() #2 !dbg !20 {
+entry:
+  %call = call noundef i32 @_Z3fooIiET_S0_(i32 noundef 2), !dbg !23
+  ret i32 %call, !dbg !24
 }
 
-//--- temp_b.cpp
-#include "template_function_header.h"
-int b() {
-  return foo<int>(2);
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable
+define linkonce_odr noundef i32 @_Z3fooIiET_S0_(i32 noundef %s) #0 !dbg !25 {
+entry:
+  %s.addr = alloca i32, align 4
+  store i32 %s, ptr %s.addr, align 4
+  call void @llvm.dbg.declare(metadata ptr %s.addr, metadata !29, metadata !DIExpression()), !dbg !30
+  %0 = load i32, ptr %s.addr, align 4, !dbg !31
+  %1 = load i32, ptr %s.addr, align 4, !dbg !32
+  %mul = mul nsw i32 %0, %1, !dbg !33
+  ret i32 %mul, !dbg !34
 }
 
+attributes #0 = { mustprogress noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+attributes #1 = { nocallback nofree nosync nounwind readnone speculatable willreturn }
+attributes #2 = { mustprogress noinline optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
+!llvm.ident = !{!8}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git bbb984fa5a46b27c0c628ae79b7e4f033ad66c1e)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
+!1 = !DIFile(filename: "temp_a.cpp", directory: "/Users/shubham/Development/changeTest")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"PIC Level", i32 2}
+!6 = !{i32 7, !"uwtable", i32 2}
+!7 = !{i32 7, !"frame-pointer", i32 2}
+!8 = !{!"clang version 16.0.0 (https://github.com/apple/llvm-project.git)"}
+!9 = distinct !DISubprogram(name: "bar", linkageName: "_Z3bari", scope: !1, file: !1, line: 1, type: !10, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!10 = !DISubroutineType(types: !11)
+!11 = !{!12, !12}
+!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!13 = !{}
+!14 = !DILocalVariable(name: "x", arg: 1, scope: !9, file: !1, line: 1, type: !12)
+!15 = !DILocation(line: 1, column: 13, scope: !9)
+!16 = !DILocation(line: 2, column: 9, scope: !9)
+!17 = !DILocation(line: 2, column: 11, scope: !9)
+!18 = !DILocation(line: 2, column: 10, scope: !9)
+!19 = !DILocation(line: 2, column: 2, scope: !9)
+!20 = distinct !DISubprogram(name: "a", linkageName: "_Z1av", scope: !1, file: !1, line: 5, type: !21, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!21 = !DISubroutineType(types: !22)
+!22 = !{!12}
+!23 = !DILocation(line: 6, column: 10, scope: !20)
+!24 = !DILocation(line: 6, column: 3, scope: !20)
+!25 = distinct !DISubprogram(name: "foo<int>", linkageName: "_Z3fooIiET_S0_", scope: !26, file: !26, line: 2, type: !10, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, templateParams: !27, retainedNodes: !13)
+!26 = !DIFile(filename: "./template_function_header.h", directory: "/Users/shubham/Development/changeTest")
+!27 = !{!28}
+!28 = !DITemplateTypeParameter(name: "T", type: !12)
+!29 = !DILocalVariable(name: "s", arg: 1, scope: !25, file: !26, line: 2, type: !12)
+!30 = !DILocation(line: 2, column: 9, scope: !25)
+!31 = !DILocation(line: 3, column: 10, scope: !25)
+!32 = !DILocation(line: 3, column: 14, scope: !25)
+!33 = !DILocation(line: 3, column: 12, scope: !25)
+!34 = !DILocation(line: 3, column: 3, scope: !25)
+
+//--- temp_b.ll
+; ModuleID = 'temp_b.cpp'
+source_filename = "temp_b.cpp"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx12.0.0"
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable
+define noundef i32 @_Z1bv() #0 !dbg !9 {
+entry:
+  %call = call noundef i32 @_Z3fooIiET_S0_(i32 noundef 2), !dbg !14
+  ret i32 %call, !dbg !15
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable
+define linkonce_odr noundef i32 @_Z3fooIiET_S0_(i32 noundef %s) #1 !dbg !16 {
+entry:
+  %s.addr = alloca i32, align 4
+  store i32 %s, ptr %s.addr, align 4
+  call void @llvm.dbg.declare(metadata ptr %s.addr, metadata !22, metadata !DIExpression()), !dbg !23
+  %0 = load i32, ptr %s.addr, align 4, !dbg !24
+  %1 = load i32, ptr %s.addr, align 4, !dbg !25
+  %mul = mul nsw i32 %0, %1, !dbg !26
+  ret i32 %mul, !dbg !27
+}
+
+; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #2
+
+attributes #0 = { mustprogress noinline optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+attributes #1 = { mustprogress noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+attributes #2 = { nocallback nofree nosync nounwind readnone speculatable willreturn }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
+!llvm.ident = !{!8}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git bbb984fa5a46b27c0c628ae79b7e4f033ad66c1e)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
+!1 = !DIFile(filename: "temp_b.cpp", directory: "/Users/shubham/Development/changeTest")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"PIC Level", i32 2}
+!6 = !{i32 7, !"uwtable", i32 2}
+!7 = !{i32 7, !"frame-pointer", i32 2}
+!8 = !{!"clang version 16.0.0 (https://github.com/apple/llvm-project.git)"}
+!9 = distinct !DISubprogram(name: "b", linkageName: "_Z1bv", scope: !1, file: !1, line: 2, type: !10, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!10 = !DISubroutineType(types: !11)
+!11 = !{!12}
+!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!13 = !{}
+!14 = !DILocation(line: 3, column: 10, scope: !9)
+!15 = !DILocation(line: 3, column: 3, scope: !9)
+!16 = distinct !DISubprogram(name: "foo<int>", linkageName: "_Z3fooIiET_S0_", scope: !17, file: !17, line: 2, type: !18, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, templateParams: !20, retainedNodes: !13)
+!17 = !DIFile(filename: "./template_function_header.h", directory: "/Users/shubham/Development/changeTest")
+!18 = !DISubroutineType(types: !19)
+!19 = !{!12, !12}
+!20 = !{!21}
+!21 = !DITemplateTypeParameter(name: "T", type: !12)
+!22 = !DILocalVariable(name: "s", arg: 1, scope: !16, file: !17, line: 2, type: !12)
+!23 = !DILocation(line: 2, column: 9, scope: !16)
+!24 = !DILocation(line: 3, column: 10, scope: !16)
+!25 = !DILocation(line: 3, column: 14, scope: !16)
+!26 = !DILocation(line: 3, column: 12, scope: !16)
+!27 = !DILocation(line: 3, column: 3, scope: !16)
+
+; temp_a.cpp
+;int bar(int x) {
+;	return x*x;
+;}
+;#include "template_function_header.h"
+;int a() {
+;  return foo<int>(2);
+;}
+
+;template_function_header.h
+;template <typename T>
+;T foo(T s) {
+;return s * s;
+;}
+
+;temp_b.cpp
+;#include "template_function_header.h"
+;int b() {
+;  return foo<int>(2);
+;}

--- a/llvm/test/tools/llvm-cas-object-format/different_line_numbers_same_function_dedupe.test
+++ b/llvm/test/tools/llvm-cas-object-format/different_line_numbers_same_function_dedupe.test
@@ -3,8 +3,8 @@
 RUN: rm -rf %t && mkdir -p %t
 RUN: split-file %s %t
 
-RUN: clang %t/temp_a.cpp -c -g -fcas-friendly-debug-info=debug-line-only --target=x86_64-apple-darwin21.1.0 -o %t/temp_a.o
-RUN: clang %t/temp_b.cpp -c -g -fcas-friendly-debug-info=debug-line-only --target=x86_64-apple-darwin21.1.0 -o %t/temp_b.o
+RUN: llc %t/temp_a.ll -O0 --filetype=obj -o %t/temp_a.o
+RUN: llc %t/temp_b.ll -O0 --filetype=obj -o %t/temp_b.o
 RUN: find %t -name "*.o" &> %t/objects_to_ingest
 RUN: llvm-cas-object-format --cas %t/cas --ingest-schema=nestedv1 @%t/objects_to_ingest -silent > %t/output.casid
 RUN: llvm-cas-object-format --cas %t/cas --ingest-schema=nestedv1 --print-cas-tree @%t/output.casid | FileCheck %s --check-prefix NESTED
@@ -79,21 +79,148 @@ FLAT-NEXT:     FIXUP: 0x{{[a-z0-9]+}}, addend = +0x{{[a-z0-9]+}}, kind = {{.*}},
 FLAT-NEXT:   }
 FLAT-NEXT: }
 
-//--- temp_a.cpp
-template <typename T>
-T foo(T s) {
-  return s * s;
-}
-int a() {
-  return foo<int>(2);
+//--- temp_a.ll
+; ModuleID = 'temp_a.cpp'
+source_filename = "temp_a.cpp"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx12.0.0"
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable
+define noundef i32 @_Z1av() #0 !dbg !9 {
+entry:
+  %call = call noundef i32 @_Z3fooIiET_S0_(i32 noundef 2), !dbg !14
+  ret i32 %call, !dbg !15
 }
 
-//--- temp_b.cpp
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable
+define linkonce_odr noundef i32 @_Z3fooIiET_S0_(i32 noundef %s) #1 !dbg !16 {
+entry:
+  %s.addr = alloca i32, align 4
+  store i32 %s, ptr %s.addr, align 4
+  call void @llvm.dbg.declare(metadata ptr %s.addr, metadata !21, metadata !DIExpression()), !dbg !22
+  %0 = load i32, ptr %s.addr, align 4, !dbg !23
+  %1 = load i32, ptr %s.addr, align 4, !dbg !24
+  %mul = mul nsw i32 %0, %1, !dbg !25
+  ret i32 %mul, !dbg !26
+}
 
-template <typename T>
-T foo(T s) {
-  return s * s;
+; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #2
+
+attributes #0 = { mustprogress noinline optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+attributes #1 = { mustprogress noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+attributes #2 = { nocallback nofree nosync nounwind readnone speculatable willreturn }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
+!llvm.ident = !{!8}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git bbb984fa5a46b27c0c628ae79b7e4f033ad66c1e)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
+!1 = !DIFile(filename: "temp_a.cpp", directory: "/Users/shubham/Development/changeTest")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"PIC Level", i32 2}
+!6 = !{i32 7, !"uwtable", i32 2}
+!7 = !{i32 7, !"frame-pointer", i32 2}
+!8 = !{!"clang version 16.0.0 (https://github.com/apple/llvm-project.git)"}
+!9 = distinct !DISubprogram(name: "a", linkageName: "_Z1av", scope: !1, file: !1, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!10 = !DISubroutineType(types: !11)
+!11 = !{!12}
+!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!13 = !{}
+!14 = !DILocation(line: 6, column: 10, scope: !9)
+!15 = !DILocation(line: 6, column: 3, scope: !9)
+!16 = distinct !DISubprogram(name: "foo<int>", linkageName: "_Z3fooIiET_S0_", scope: !1, file: !1, line: 2, type: !17, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, templateParams: !19, retainedNodes: !13)
+!17 = !DISubroutineType(types: !18)
+!18 = !{!12, !12}
+!19 = !{!20}
+!20 = !DITemplateTypeParameter(name: "T", type: !12)
+!21 = !DILocalVariable(name: "s", arg: 1, scope: !16, file: !1, line: 2, type: !12)
+!22 = !DILocation(line: 2, column: 9, scope: !16)
+!23 = !DILocation(line: 3, column: 10, scope: !16)
+!24 = !DILocation(line: 3, column: 14, scope: !16)
+!25 = !DILocation(line: 3, column: 12, scope: !16)
+!26 = !DILocation(line: 3, column: 3, scope: !16)
+
+//--- temp_b.ll
+; ModuleID = 'temp_b.cpp'
+source_filename = "temp_b.cpp"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx12.0.0"
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable
+define noundef i32 @_Z1av() #0 !dbg !9 {
+entry:
+  %call = call noundef i32 @_Z3fooIiET_S0_(i32 noundef 2), !dbg !14
+  ret i32 %call, !dbg !15
 }
-int a() {
-  return foo<int>(2);
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable
+define linkonce_odr noundef i32 @_Z3fooIiET_S0_(i32 noundef %s) #1 !dbg !16 {
+entry:
+  %s.addr = alloca i32, align 4
+  store i32 %s, ptr %s.addr, align 4
+  call void @llvm.dbg.declare(metadata ptr %s.addr, metadata !21, metadata !DIExpression()), !dbg !22
+  %0 = load i32, ptr %s.addr, align 4, !dbg !23
+  %1 = load i32, ptr %s.addr, align 4, !dbg !24
+  %mul = mul nsw i32 %0, %1, !dbg !25
+  ret i32 %mul, !dbg !26
 }
+
+; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #2
+
+attributes #0 = { mustprogress noinline optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+attributes #1 = { mustprogress noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+attributes #2 = { nocallback nofree nosync nounwind readnone speculatable willreturn }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
+!llvm.ident = !{!8}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git bbb984fa5a46b27c0c628ae79b7e4f033ad66c1e)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
+!1 = !DIFile(filename: "temp_b.cpp", directory: "/Users/shubham/Development/changeTest")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"PIC Level", i32 2}
+!6 = !{i32 7, !"uwtable", i32 2}
+!7 = !{i32 7, !"frame-pointer", i32 2}
+!8 = !{!"clang version 16.0.0 (https://github.com/apple/llvm-project.git)"}
+!9 = distinct !DISubprogram(name: "a", linkageName: "_Z1av", scope: !1, file: !1, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!10 = !DISubroutineType(types: !11)
+!11 = !{!12}
+!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!13 = !{}
+!14 = !DILocation(line: 6, column: 10, scope: !9)
+!15 = !DILocation(line: 6, column: 3, scope: !9)
+!16 = distinct !DISubprogram(name: "foo<int>", linkageName: "_Z3fooIiET_S0_", scope: !1, file: !1, line: 2, type: !17, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, templateParams: !19, retainedNodes: !13)
+!17 = !DISubroutineType(types: !18)
+!18 = !{!12, !12}
+!19 = !{!20}
+!20 = !DITemplateTypeParameter(name: "T", type: !12)
+!21 = !DILocalVariable(name: "s", arg: 1, scope: !16, file: !1, line: 2, type: !12)
+!22 = !DILocation(line: 2, column: 9, scope: !16)
+!23 = !DILocation(line: 3, column: 10, scope: !16)
+!24 = !DILocation(line: 3, column: 14, scope: !16)
+!25 = !DILocation(line: 3, column: 12, scope: !16)
+!26 = !DILocation(line: 3, column: 3, scope: !16)
+
+;temp_a.cpp
+;template <typename T>
+;T foo(T s) {
+;  return s * s;
+;}
+;int a() {
+;  return foo<int>(2);
+;}
+
+;temp_b.cpp
+;template <typename T>
+;T foo(T s) {
+;  return s * s;
+;}
+;int a() {
+;  return foo<int>(2);
+;}

--- a/llvm/test/tools/llvm-cas-object-format/same_functions_same_header_dedupe.test
+++ b/llvm/test/tools/llvm-cas-object-format/same_functions_same_header_dedupe.test
@@ -3,8 +3,8 @@
 RUN: rm -rf %t && mkdir -p %t
 RUN: split-file %s %t
 
-RUN: clang %t/temp_a.cpp -c -g -fcas-friendly-debug-info=debug-line-only --target=x86_64-apple-darwin21.1.0 -o %t/temp_a.o
-RUN: clang %t/temp_b.cpp -c -g -fcas-friendly-debug-info=debug-line-only --target=x86_64-apple-darwin21.1.0 -o %t/temp_b.o
+RUN: llc %t/temp_a.ll -O0 --filetype=obj -o %t/temp_a.o
+RUN: llc %t/temp_b.ll -O0 --filetype=obj -o %t/temp_b.o
 RUN: find %t -name "*.o" &> %t/objects_to_ingest
 RUN: llvm-cas-object-format --cas %t/cas --ingest-schema=nestedv1 @%t/objects_to_ingest -silent > %t/output.casid
 RUN: llvm-cas-object-format --cas %t/cas --ingest-schema=nestedv1 --print-cas-tree @%t/output.casid | FileCheck %s --check-prefix NESTED
@@ -77,20 +77,150 @@ FLAT-NEXT:     FIXUP: 0x{{[a-z0-9]+}}, addend = +0x{{[a-z0-9]+}}, kind = {{.*}},
 FLAT-NEXT:   }
 FLAT-NEXT: }
 
-//--- temp_a.cpp
-#include "template_function_header.h"
-int a() {
-  return foo<int>(2);
+//--- temp_a.ll
+; ModuleID = 'temp_a.cpp'
+source_filename = "temp_a.cpp"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx12.0.0"
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable
+define noundef i32 @_Z1av() #0 !dbg !9 {
+entry:
+  %call = call noundef i32 @_Z3fooIiET_S0_(i32 noundef 2), !dbg !14
+  ret i32 %call, !dbg !15
 }
 
-//--- template_function_header.h
-template <typename T>
-T foo(T s) {
-  return s * s;
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable
+define linkonce_odr noundef i32 @_Z3fooIiET_S0_(i32 noundef %s) #1 !dbg !16 {
+entry:
+  %s.addr = alloca i32, align 4
+  store i32 %s, ptr %s.addr, align 4
+  call void @llvm.dbg.declare(metadata ptr %s.addr, metadata !22, metadata !DIExpression()), !dbg !23
+  %0 = load i32, ptr %s.addr, align 4, !dbg !24
+  %1 = load i32, ptr %s.addr, align 4, !dbg !25
+  %mul = mul nsw i32 %0, %1, !dbg !26
+  ret i32 %mul, !dbg !27
 }
 
-//--- temp_b.cpp
-#include "template_function_header.h"
-int b() {
-  return foo<int>(2);
+; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #2
+
+attributes #0 = { mustprogress noinline optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+attributes #1 = { mustprogress noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+attributes #2 = { nocallback nofree nosync nounwind readnone speculatable willreturn }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
+!llvm.ident = !{!8}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git bbb984fa5a46b27c0c628ae79b7e4f033ad66c1e)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
+!1 = !DIFile(filename: "temp_a.cpp", directory: "/Users/shubham/Development/changeTest")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"PIC Level", i32 2}
+!6 = !{i32 7, !"uwtable", i32 2}
+!7 = !{i32 7, !"frame-pointer", i32 2}
+!8 = !{!"clang version 16.0.0 (https://github.com/apple/llvm-project.git)"}
+!9 = distinct !DISubprogram(name: "a", linkageName: "_Z1av", scope: !1, file: !1, line: 2, type: !10, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!10 = !DISubroutineType(types: !11)
+!11 = !{!12}
+!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!13 = !{}
+!14 = !DILocation(line: 3, column: 10, scope: !9)
+!15 = !DILocation(line: 3, column: 3, scope: !9)
+!16 = distinct !DISubprogram(name: "foo<int>", linkageName: "_Z3fooIiET_S0_", scope: !17, file: !17, line: 2, type: !18, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, templateParams: !20, retainedNodes: !13)
+!17 = !DIFile(filename: "./template_function_header.h", directory: "/Users/shubham/Development/changeTest")
+!18 = !DISubroutineType(types: !19)
+!19 = !{!12, !12}
+!20 = !{!21}
+!21 = !DITemplateTypeParameter(name: "T", type: !12)
+!22 = !DILocalVariable(name: "s", arg: 1, scope: !16, file: !17, line: 2, type: !12)
+!23 = !DILocation(line: 2, column: 9, scope: !16)
+!24 = !DILocation(line: 3, column: 10, scope: !16)
+!25 = !DILocation(line: 3, column: 14, scope: !16)
+!26 = !DILocation(line: 3, column: 12, scope: !16)
+!27 = !DILocation(line: 3, column: 3, scope: !16)
+
+//--- temp_b.ll
+; ModuleID = 'temp_b.cpp'
+source_filename = "temp_b.cpp"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx12.0.0"
+
+; Function Attrs: mustprogress noinline optnone ssp uwtable
+define noundef i32 @_Z1bv() #0 !dbg !9 {
+entry:
+  %call = call noundef i32 @_Z3fooIiET_S0_(i32 noundef 2), !dbg !14
+  ret i32 %call, !dbg !15
 }
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable
+define linkonce_odr noundef i32 @_Z3fooIiET_S0_(i32 noundef %s) #1 !dbg !16 {
+entry:
+  %s.addr = alloca i32, align 4
+  store i32 %s, ptr %s.addr, align 4
+  call void @llvm.dbg.declare(metadata ptr %s.addr, metadata !22, metadata !DIExpression()), !dbg !23
+  %0 = load i32, ptr %s.addr, align 4, !dbg !24
+  %1 = load i32, ptr %s.addr, align 4, !dbg !25
+  %mul = mul nsw i32 %0, %1, !dbg !26
+  ret i32 %mul, !dbg !27
+}
+
+; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #2
+
+attributes #0 = { mustprogress noinline optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+attributes #1 = { mustprogress noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+attributes #2 = { nocallback nofree nosync nounwind readnone speculatable willreturn }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
+!llvm.ident = !{!8}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git bbb984fa5a46b27c0c628ae79b7e4f033ad66c1e)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
+!1 = !DIFile(filename: "temp_b.cpp", directory: "/Users/shubham/Development/changeTest")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"PIC Level", i32 2}
+!6 = !{i32 7, !"uwtable", i32 2}
+!7 = !{i32 7, !"frame-pointer", i32 2}
+!8 = !{!"clang version 16.0.0 (https://github.com/apple/llvm-project.git)"}
+!9 = distinct !DISubprogram(name: "b", linkageName: "_Z1bv", scope: !1, file: !1, line: 2, type: !10, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!10 = !DISubroutineType(types: !11)
+!11 = !{!12}
+!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!13 = !{}
+!14 = !DILocation(line: 3, column: 10, scope: !9)
+!15 = !DILocation(line: 3, column: 3, scope: !9)
+!16 = distinct !DISubprogram(name: "foo<int>", linkageName: "_Z3fooIiET_S0_", scope: !17, file: !17, line: 2, type: !18, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, templateParams: !20, retainedNodes: !13)
+!17 = !DIFile(filename: "./template_function_header.h", directory: "/Users/shubham/Development/changeTest")
+!18 = !DISubroutineType(types: !19)
+!19 = !{!12, !12}
+!20 = !{!21}
+!21 = !DITemplateTypeParameter(name: "T", type: !12)
+!22 = !DILocalVariable(name: "s", arg: 1, scope: !16, file: !17, line: 2, type: !12)
+!23 = !DILocation(line: 2, column: 9, scope: !16)
+!24 = !DILocation(line: 3, column: 10, scope: !16)
+!25 = !DILocation(line: 3, column: 14, scope: !16)
+!26 = !DILocation(line: 3, column: 12, scope: !16)
+!27 = !DILocation(line: 3, column: 3, scope: !16)
+
+;temp_a.cpp
+;#include "template_function_header.h"
+;int a() {
+;  return foo<int>(2);
+;}
+
+;template_function_header.h
+;template <typename T>
+;T foo(T s) {
+;  return s * s;
+;}
+
+;temp_b.cpp
+;#include "template_function_header.h"
+;int b() {
+;  return foo<int>(2);
+;}


### PR DESCRIPTION
The tests:

  LLVM :: tools/llvm-cas-object-format/different_functions_same_header_dedupe.test
  LLVM :: tools/llvm-cas-object-format/different_line_numbers_same_function_dedupe.test
  LLVM :: tools/llvm-cas-object-format/same_functions_same_header_dedupe.test

Use clang and cpp files and are llvm tests, so they shouldn't be using clang, this change fixes that