### PR TITLE
[Sanitizer][stable/20220421]Cherry-pick/sanitizer test fixes

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/free_hook_realloc.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/free_hook_realloc.cpp
@@ -8,13 +8,16 @@
 
 static void *glob_ptr;
 
-extern "C" {
-void __sanitizer_free_hook(const volatile void *ptr) {
+// Required for dyld macOS 12.0+
+#if (__APPLE__)
+__attribute__((weak))
+#endif
+extern "C" void
+__sanitizer_free_hook(const volatile void *ptr) {
   if (ptr == glob_ptr) {
     *(int*)ptr = 0;
     write(1, "FreeHook\n", sizeof("FreeHook\n"));
   }
-}
 }
 
 int main() {

--- a/compiler-rt/test/asan/TestCases/debug_double_free.cpp
+++ b/compiler-rt/test/asan/TestCases/debug_double_free.cpp
@@ -37,7 +37,12 @@ int main() {
   return 0;
 }
 
-void __asan_on_error() {
+// Required for dyld macOS 12.0+
+#if (__APPLE__)
+__attribute__((weak))
+#endif
+extern "C" void
+__asan_on_error() {
   int present = __asan_report_present();
   void *addr = __asan_get_report_address();
   const char *description = __asan_get_report_description();

--- a/compiler-rt/test/asan/TestCases/debug_report.cpp
+++ b/compiler-rt/test/asan/TestCases/debug_report.cpp
@@ -37,7 +37,12 @@ int main() {
 # define PTR_FMT "%p"
 #endif
 
-void __asan_on_error() {
+// Required for dyld macOS 12.0+
+#if (__APPLE__)
+__attribute__((weak))
+#endif
+extern "C" void
+__asan_on_error() {
   int present = __asan_report_present();
   void *pc = __asan_get_report_pc();
   void *bp = __asan_get_report_bp();

--- a/compiler-rt/test/asan/TestCases/default_options.cpp
+++ b/compiler-rt/test/asan/TestCases/default_options.cpp
@@ -6,9 +6,13 @@
 
 const char *kAsanDefaultOptions = "verbosity=1 help=1";
 
-extern "C"
+// Required for dyld macOS 12.0+
+#if (__APPLE__)
+__attribute__((weak))
+#endif
 __attribute__((no_sanitize_address))
-const char *__asan_default_options() {
+extern "C" const char *
+__asan_default_options() {
   // CHECK: Available flags for AddressSanitizer:
   return kAsanDefaultOptions;
 }

--- a/compiler-rt/test/asan/TestCases/on_error_callback.cpp
+++ b/compiler-rt/test/asan/TestCases/on_error_callback.cpp
@@ -6,8 +6,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-extern "C"
-void __asan_on_error() {
+// Required for dyld macOS 12.0+
+#if (__APPLE__)
+__attribute__((weak))
+#endif
+extern "C" void
+__asan_on_error() {
   fprintf(stderr, "__asan_on_error called\n");
   fflush(stderr);
 }

--- a/compiler-rt/test/memprof/TestCases/free_hook_realloc.cpp
+++ b/compiler-rt/test/memprof/TestCases/free_hook_realloc.cpp
@@ -7,13 +7,17 @@
 
 static void *glob_ptr;
 
-extern "C" {
-void __sanitizer_free_hook(const volatile void *ptr) {
+// (Speculative fix if memprof is enabled on Apple platforms)
+// Required for dyld macOS 12.0+
+#if (__APPLE__)
+__attribute__((weak))
+#endif
+extern "C" void
+__sanitizer_free_hook(const volatile void *ptr) {
   if (ptr == glob_ptr) {
     *(int *)ptr = 0;
     write(1, "FreeHook\n", sizeof("FreeHook\n"));
   }
-}
 }
 
 int main() {

--- a/compiler-rt/test/sanitizer_common/TestCases/Darwin/abort_on_error.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Darwin/abort_on_error.cpp
@@ -16,8 +16,8 @@ int global;
 
 int main() {
 #if defined(USING_ubsan)
-  int value = 5;
-  int computation = value / 0; // Division by zero.
+  volatile int *null = 0;
+  *null = 0;
 #else
   volatile int *a = new int[100];
   delete[] a;

--- a/compiler-rt/test/tsan/Darwin/debug_external.cpp
+++ b/compiler-rt/test/tsan/Darwin/debug_external.cpp
@@ -42,7 +42,12 @@ int main() {
   return 0;
 }
 
-__attribute__((disable_sanitizer_instrumentation)) void
+// Required for dyld macOS 12.0+
+#if (__APPLE__)
+__attribute__((weak))
+#endif
+__attribute__((disable_sanitizer_instrumentation))
+extern "C" void
 __tsan_on_report(void *report) {
   const char *type;
   void *addr;

--- a/compiler-rt/test/tsan/Darwin/main_tid.mm
+++ b/compiler-rt/test/tsan/Darwin/main_tid.mm
@@ -13,8 +13,13 @@ int __tsan_get_report_thread(void *report, unsigned long idx, int *tid,
                              unsigned long trace_size);
 }
 
+// Required for dyld macOS 12.0+
+#if (__APPLE__)
+__attribute__((weak))
+#endif
 __attribute__((disable_sanitizer_instrumentation))
-void __tsan_on_report(void *report) {
+extern "C" void
+__tsan_on_report(void *report) {
   fprintf(stderr, "__tsan_on_report(%p)\n", report);
 
   int tid;

--- a/compiler-rt/test/tsan/cxa_guard_acquire.cpp
+++ b/compiler-rt/test/tsan/cxa_guard_acquire.cpp
@@ -4,10 +4,16 @@
 
 namespace __tsan {
 
+#if (__APPLE__)
+__attribute__((weak))
+#endif
 void OnPotentiallyBlockingRegionBegin() {
   printf("Enter __cxa_guard_acquire\n");
 }
 
+#if (__APPLE__)
+__attribute__((weak))
+#endif
 void OnPotentiallyBlockingRegionEnd() { printf("Exit __cxa_guard_acquire\n"); }
 
 } // namespace __tsan

--- a/compiler-rt/test/tsan/debugging.cpp
+++ b/compiler-rt/test/tsan/debugging.cpp
@@ -46,7 +46,12 @@ int main() {
   fprintf(stderr, "Done.\n");
 }
 
-__attribute__((disable_sanitizer_instrumentation)) void
+// Required for dyld macOS 12.0+
+#if (__APPLE__)
+__attribute__((weak))
+#endif
+__attribute__((disable_sanitizer_instrumentation))
+extern "C" void
 __tsan_on_report(void *report) {
   fprintf(stderr, "__tsan_on_report(%p)\n", report);
   fprintf(stderr, "__tsan_get_current_report() = %p\n",

--- a/compiler-rt/test/tsan/default_options.cpp
+++ b/compiler-rt/test/tsan/default_options.cpp
@@ -2,6 +2,9 @@
 #include <pthread.h>
 #include <stdio.h>
 
+#if (__APPLE__)
+__attribute__((weak))
+#endif
 extern "C" const char *__tsan_default_options() {
   return "report_bugs=0";
 }

--- a/compiler-rt/test/tsan/java_symbolization.cpp
+++ b/compiler-rt/test/tsan/java_symbolization.cpp
@@ -2,7 +2,11 @@
 #include "java.h"
 #include <memory.h>
 
-extern "C" __attribute__((disable_sanitizer_instrumentation)) void
+#if (__APPLE__)
+__attribute__((weak)) // Required for dyld macOS 12.0+
+#endif
+__attribute__((disable_sanitizer_instrumentation))
+extern "C" void
 __tsan_symbolize_external_ex(jptr pc,
                              void (*add_frame)(void *, const char *,
                                                const char *, int, int),

--- a/compiler-rt/test/tsan/java_symbolization_legacy.cpp
+++ b/compiler-rt/test/tsan/java_symbolization_legacy.cpp
@@ -2,7 +2,11 @@
 #include "java.h"
 #include <memory.h>
 
-extern "C" __attribute__((disable_sanitizer_instrumentation)) bool
+#if (__APPLE__)
+__attribute__((weak)) // Required for dyld macOS 12.0+
+#endif
+__attribute__((disable_sanitizer_instrumentation))
+extern "C" bool
 __tsan_symbolize_external(jptr pc, char *func_buf, jptr func_siz,
                           char *file_buf, jptr file_siz, int *line, int *col) {
   if (pc == (1234 | kExternalPCBit)) {

--- a/compiler-rt/test/tsan/libdispatch/dispatch_once_deadlock.c
+++ b/compiler-rt/test/tsan/libdispatch/dispatch_once_deadlock.c
@@ -22,8 +22,13 @@ void f() {
   h++;
 }
 
+// Required for dyld macOS 12.0+
+#if (__APPLE__)
+__attribute__((weak))
+#endif
 __attribute__((disable_sanitizer_instrumentation))
-void __tsan_on_report() {
+extern void
+__tsan_on_report() {
   fprintf(stderr, "Report.\n");
 
   // Without these annotations this test deadlocks for COMPILER_RT_DEBUG=ON

--- a/compiler-rt/test/ubsan/TestCases/Misc/monitor.cpp
+++ b/compiler-rt/test/ubsan/TestCases/Misc/monitor.cpp
@@ -10,19 +10,21 @@
 
 #include <cstdio>
 
-extern "C" {
-void __ubsan_get_current_report_data(const char **OutIssueKind,
-                                     const char **OutMessage,
-                                     const char **OutFilename,
-                                     unsigned *OutLine, unsigned *OutCol,
-                                     char **OutMemoryAddr);
-
-// Override the definition of __ubsan_on_report from the runtime, just for
-// testing purposes.
-void __ubsan_on_report(void) {
+// Override __ubsan_on_report() from the runtime, just for testing purposes.
+// Required for dyld macOS 12.0+
+#if (__APPLE__)
+__attribute__((weak))
+#endif
+extern "C" void
+__ubsan_on_report(void) {
+  void __ubsan_get_current_report_data(
+      const char **OutIssueKind, const char **OutMessage,
+      const char **OutFilename, unsigned *OutLine, unsigned *OutCol,
+      char **OutMemoryAddr);
   const char *IssueKind, *Message, *Filename;
   unsigned Line, Col;
   char *Addr;
+
   __ubsan_get_current_report_data(&IssueKind, &Message, &Filename, &Line, &Col,
                                   &Addr);
 
@@ -32,7 +34,6 @@ void __ubsan_on_report(void) {
   fflush(stdout);
 
   (void)Addr;
-}
 }
 
 int main() {


### PR DESCRIPTION
Various sanitizer test fixes. 
Mostly test fixes are work arounds for dyld macOS 12.0+. 
Abort_on_error test fix for arm64 (division by zero is handled differently in arm).
