### PR TITLE
[CAS] Update friend declaration to include template

### DIFF
--- a/clang/include/clang/CAS/IncludeTree.h
+++ b/clang/include/clang/CAS/IncludeTree.h
@@ -97,7 +97,7 @@ public:
   }
 
 private:
-  friend class IncludeTreeBase;
+  friend class IncludeTreeBase<IncludeFile>;
   friend class IncludeTree;
   friend class IncludeTreeRoot;
 
@@ -185,7 +185,7 @@ public:
   llvm::Error print(llvm::raw_ostream &OS, unsigned Indent = 0);
 
 private:
-  friend class IncludeTreeBase;
+  friend class IncludeTreeBase<IncludeTree>;
   friend class IncludeTreeRoot;
 
   explicit IncludeTree(ObjectProxy Node) : IncludeTreeBase(std::move(Node)) {
@@ -250,7 +250,7 @@ public:
   }
 
 private:
-  friend class IncludeTreeBase;
+  friend class IncludeTreeBase<IncludeTreeRoot>;
 
   explicit IncludeTreeRoot(ObjectProxy Node)
       : IncludeTreeBase(std::move(Node)) {


### PR DESCRIPTION
This fails on windows with `non-class template has already been declared
as a class template`. Add the template.