### PR TITLE
[analyzer] Fix false positive in use-after-move checker

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/MoveChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MoveChecker.cpp
@@ -619,10 +619,6 @@ void MoveChecker::checkPreCall(const CallEvent &Call, CheckerContext &C) const {
   if (!IC)
     return;
 
-  // Calling a destructor on a moved object is fine.
-  if (isa<CXXDestructorCall>(IC))
-    return;
-
   const MemRegion *ThisRegion = IC->getCXXThisVal().getAsRegion();
   if (!ThisRegion)
     return;
@@ -630,6 +626,10 @@ void MoveChecker::checkPreCall(const CallEvent &Call, CheckerContext &C) const {
   // The remaining part is check only for method call on a moved-from object.
   const auto MethodDecl = dyn_cast_or_null<CXXMethodDecl>(IC->getDecl());
   if (!MethodDecl)
+    return;
+
+  // Calling a destructor on a moved object is fine.
+  if (isa<CXXDestructorDecl>(MethodDecl))
     return;
 
   // We want to investigate the whole object, not only sub-object of a parent

--- a/clang/test/Analysis/use-after-move.cpp
+++ b/clang/test/Analysis/use-after-move.cpp
@@ -900,6 +900,28 @@ void checkMoreLoopZombies4(bool flag) {
   }
 }
 
+void checkExplicitDestructorCalls() {
+  // The below code segments invoke the destructor twice (explicit and 
+  // implicit). While this is not a desired code behavior, it is 
+  // not the use-after-move checker's responsibility to issue such a warning.
+  {
+     B* b = new B;
+     B a = std::move(*b);
+     b->~B(); // no-warning 
+     delete b;
+  }
+  {
+    B a, b;
+    new (&a) B(reinterpret_cast<B &&>(b));
+    (&b)->~B(); // no-warning
+  }
+  {
+    B b;
+    B a  = std::move(b);
+    b.~B(); // no-warning 
+  }
+}
+
 struct MoveOnlyWithDestructor {
   MoveOnlyWithDestructor();
   ~MoveOnlyWithDestructor();


### PR DESCRIPTION
Differential Revision: https://reviews.llvm.org/D131525

(cherry picked from commit c74a204826da331cb18023c626b0717d5b8a927d)