### PR TITLE
[clang][cas] Simplify CASDependencyCollector NFC

### DIFF
--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -93,10 +93,6 @@ class CompilerInstance : public ModuleLoader {
   /// The output context.
   IntrusiveRefCntPtr<llvm::vfs::OutputBackend> TheOutputBackend;
 
-  /// The underlying CAS output context, if any. Used to create CAS-specific
-  /// outputs.
-  IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> CASOutputBackend;
-
   /// The source manager.
   IntrusiveRefCntPtr<SourceManager> SourceMgr;
 
@@ -421,19 +417,13 @@ public:
   /// Set the output manager.
   void setOutputBackend(IntrusiveRefCntPtr<llvm::vfs::OutputBackend> NewOutputs);
 
-  void setCASOutputBackend(
-      clang::IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> NewOutputs);
-
   /// Create an output manager.
   void createOutputBackend();
 
   bool hasOutputBackend() const { return bool(TheOutputBackend); }
-  bool hasCASOutputBackend() const { return bool(CASOutputBackend); }
 
   llvm::vfs::OutputBackend &getOutputBackend();
   llvm::vfs::OutputBackend &getOrCreateOutputBackend();
-
-  llvm::cas::CASOutputBackend &getCASOutputBackend();
 
   /// Get the CAS, or create it using the configuration in CompilerInvocation.
   llvm::cas::CASDB &getOrCreateCAS();

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -507,13 +507,9 @@ void CompilerInstance::createPreprocessor(TranslationUnitKind TUKind) {
 
   // Handle generating dependencies, if requested.
   const DependencyOutputOptions &DepOpts = getDependencyOutputOpts();
-  if (!DepOpts.OutputFile.empty()) {
-    if (hasCASOutputBackend())
-      addDependencyCollector(
-          std::make_shared<CASDependencyCollector>(DepOpts, CASOutputBackend));
+  if (!DepOpts.OutputFile.empty())
     addDependencyCollector(
         std::make_shared<DependencyFileGenerator>(DepOpts, TheOutputBackend));
-  }
   if (!DepOpts.DOTOutputFile.empty())
     AttachDependencyGraphGen(*PP, DepOpts.DOTOutputFile,
                              getHeaderSearchOpts().Sysroot);
@@ -831,11 +827,6 @@ void CompilerInstance::setOutputBackend(
   assert(!TheOutputBackend && "Already has an output manager");
   TheOutputBackend = std::move(NewOutputs);
 }
-void CompilerInstance::setCASOutputBackend(
-    clang::IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> NewOutputs) {
-  assert(!CASOutputBackend && "Already has a CAS output backend");
-  CASOutputBackend = std::move(NewOutputs);
-}
 
 void CompilerInstance::createOutputBackend() {
   assert(!TheOutputBackend && "Already has an output manager");
@@ -851,11 +842,6 @@ llvm::vfs::OutputBackend &CompilerInstance::getOrCreateOutputBackend() {
   if (!hasOutputBackend())
     createOutputBackend();
   return getOutputBackend();
-}
-
-llvm::cas::CASOutputBackend &CompilerInstance::getCASOutputBackend() {
-  assert(CASOutputBackend);
-  return *CASOutputBackend;
 }
 
 llvm::cas::CASDB &CompilerInstance::getOrCreateCAS() {

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -299,6 +299,7 @@ private:
   std::string SerialDiagsFile;
   std::string DependenciesFile;
   Optional<llvm::cas::CASID> MCOutputID;
+  Optional<llvm::cas::ObjectRef> DependenciesOutput;
   Optional<llvm::vfs::OutputFile> SerialDiagsOutput;
 };
 } // end anonymous namespace
@@ -471,7 +472,6 @@ Optional<int> CompileJobCache::tryReplayCachedResult(CompilerInstance &Clang) {
 
   // Set up the output backend so we can save / cache the result after.
   CASOutputs = llvm::makeIntrusiveRefCnt<llvm::cas::CASOutputBackend>(*CAS);
-  Clang.setCASOutputBackend(CASOutputs);
   for (OutputKind K : getAllOutputKinds()) {
     StringRef OutPath = getPathForOutputKind(K);
     if (!OutPath.empty())
@@ -489,6 +489,11 @@ Optional<int> CompileJobCache::tryReplayCachedResult(CompilerInstance &Clang) {
       FilterBackend, std::move(OnDiskOutputs)));
   ResultDiagsOS = std::make_unique<raw_mirroring_ostream>(
       llvm::errs(), std::make_unique<llvm::raw_svector_ostream>(ResultDiags));
+
+  if (!Clang.getDependencyOutputOpts().OutputFile.empty())
+    Clang.addDependencyCollector(std::make_shared<CASDependencyCollector>(
+        Clang.getDependencyOutputOpts(), *CAS,
+        [this](Optional<cas::ObjectRef> Deps) { DependenciesOutput = Deps; }));
 
   // FIXME: This should be saving/replaying structured diagnostics, not saving
   // stderr and a separate diagnostics file, thus using the current llvm::errs()
@@ -604,6 +609,11 @@ void CompileJobCache::finishComputedResult(CompilerInstance &Clang,
             SerialDiags->getRef()))
       llvm::report_fatal_error(std::move(E));
   }
+
+  if (DependenciesOutput)
+    if (auto E = CASOutputs->addObject(
+            getOutputKindName(OutputKind::Dependencies), *DependenciesOutput))
+      llvm::report_fatal_error(std::move(E));
 
   Expected<llvm::cas::ObjectProxy> Outputs = CASOutputs->getCASProxy();
   if (!Outputs)


### PR DESCRIPTION
Hoist the use of CASOutputBackend into cc1_main and avoid needing
explicit access to the output backend in CompilerInstance.