### PR TITLE
[clang][cas] Simplify CASDependencyCollector NFC

### DIFF
--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -93,10 +93,6 @@ class CompilerInstance : public ModuleLoader {
   /// The output context.
   IntrusiveRefCntPtr<llvm::vfs::OutputBackend> TheOutputBackend;
 
-  /// The underlying CAS output context, if any. Used to create CAS-specific
-  /// outputs.
-  IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> CASOutputBackend;
-
   /// The source manager.
   IntrusiveRefCntPtr<SourceManager> SourceMgr;
 
@@ -434,19 +430,13 @@ public:
   /// Set the output manager.
   void setOutputBackend(IntrusiveRefCntPtr<llvm::vfs::OutputBackend> NewOutputs);
 
-  void setCASOutputBackend(
-      clang::IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> NewOutputs);
-
   /// Create an output manager.
   void createOutputBackend();
 
   bool hasOutputBackend() const { return bool(TheOutputBackend); }
-  bool hasCASOutputBackend() const { return bool(CASOutputBackend); }
 
   llvm::vfs::OutputBackend &getOutputBackend();
   llvm::vfs::OutputBackend &getOrCreateOutputBackend();
-
-  llvm::cas::CASOutputBackend &getCASOutputBackend();
 
   /// Get the CAS, or create it using the configuration in CompilerInvocation.
   llvm::cas::CASDB &getOrCreateCAS();

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -500,13 +500,9 @@ void CompilerInstance::createPreprocessor(TranslationUnitKind TUKind) {
 
   // Handle generating dependencies, if requested.
   const DependencyOutputOptions &DepOpts = getDependencyOutputOpts();
-  if (!DepOpts.OutputFile.empty()) {
-    if (hasCASOutputBackend())
-      addDependencyCollector(
-          std::make_shared<CASDependencyCollector>(DepOpts, CASOutputBackend));
+  if (!DepOpts.OutputFile.empty())
     addDependencyCollector(
         std::make_shared<DependencyFileGenerator>(DepOpts, TheOutputBackend));
-  }
   if (!DepOpts.DOTOutputFile.empty())
     AttachDependencyGraphGen(*PP, DepOpts.DOTOutputFile,
                              getHeaderSearchOpts().Sysroot);
@@ -845,11 +841,6 @@ void CompilerInstance::setOutputBackend(
   assert(!TheOutputBackend && "Already has an output manager");
   TheOutputBackend = std::move(NewOutputs);
 }
-void CompilerInstance::setCASOutputBackend(
-    clang::IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> NewOutputs) {
-  assert(!CASOutputBackend && "Already has a CAS output backend");
-  CASOutputBackend = std::move(NewOutputs);
-}
 
 void CompilerInstance::createOutputBackend() {
   assert(!TheOutputBackend && "Already has an output manager");
@@ -865,11 +856,6 @@ llvm::vfs::OutputBackend &CompilerInstance::getOrCreateOutputBackend() {
   if (!hasOutputBackend())
     createOutputBackend();
   return getOutputBackend();
-}
-
-llvm::cas::CASOutputBackend &CompilerInstance::getCASOutputBackend() {
-  assert(CASOutputBackend);
-  return *CASOutputBackend;
 }
 
 llvm::cas::CASDB &CompilerInstance::getOrCreateCAS() {


### PR DESCRIPTION
Hoist the use of CASOutputBackend into cc1_main and avoid needing
explicit access to the output backend in CompilerInstance.

(cherry picked from commit f377dcfe2ed958bbebf27862679421698c6eabab)