### PR TITLE
[stable/20220421] Cherry-pick recent dep scan and caching improvements

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -23,6 +23,7 @@ def err_cas_depscan_daemon_connection: Error<
   "Failed to establish connection with depscan daemon: %0">, DefaultFatal;
 def err_cas_depscan_failed: Error<
   "CAS-based dependency scan failed: %0">, DefaultFatal;
+def err_cas_store: Error<"failed to store to CAS: %0">, DefaultFatal;
 
 def warn_clang_cache_disabled_caching: Warning<
   "caching disabled because %0">,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5952,6 +5952,9 @@ def fallow_pch_with_different_modules_cache_path :
   Flag<["-"], "fallow-pch-with-different-modules-cache-path">,
   HelpText<"Accept a PCH file that was created with a different modules cache path">,
   MarshallingInfoFlag<PreprocessorOpts<"AllowPCHWithDifferentModulesCachePath">>;
+def fno_modules_share_filemanager : Flag<["-"], "fno-modules-share-filemanager">,
+  HelpText<"Disable sharing the FileManager when building a module implicitly">,
+  MarshallingInfoNegativeFlag<FrontendOpts<"ModulesShareFileManager">>;
 def dump_deserialized_pch_decls : Flag<["-"], "dump-deserialized-decls">,
   HelpText<"Dump declarations that are deserialized from PCH, for testing">,
   MarshallingInfoFlag<PreprocessorOpts<"DumpDeserializedPCHDecls">>;

--- a/clang/include/clang/Frontend/CASDependencyCollector.h
+++ b/clang/include/clang/Frontend/CASDependencyCollector.h
@@ -1,0 +1,42 @@
+//===- CASDependencyCollector.h ---------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_FRONTEND_CASDEPENDENCYCOLLECTOR_H
+#define LLVM_CLANG_FRONTEND_CASDEPENDENCYCOLLECTOR_H
+
+#include "clang/Frontend/Utils.h"
+
+namespace llvm::cas {
+class CASOutputBackend;
+}
+
+namespace clang {
+
+/// Collects dependencies when attached to a Preprocessor (for includes) and
+/// ASTReader (for module imports), and writes it to the CAS in a manner
+/// suitable to be replayed into a DependencyFileGenerator.
+class CASDependencyCollector : public DependencyFileGenerator {
+public:
+  CASDependencyCollector(
+      const DependencyOutputOptions &Opts,
+      IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> OutputBackend);
+
+  static llvm::Error replay(const DependencyOutputOptions &Opts,
+                            cas::CASDB &CAS, cas::ObjectRef DepsRef,
+                            llvm::raw_ostream &OS);
+
+private:
+  void finishedMainFile(DiagnosticsEngine &Diags) override;
+
+  IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> CASOutputs;
+  std::string OutputName;
+};
+
+} // namespace clang
+
+#endif // LLVM_CLANG_FRONTEND_CASDEPENDENCYCOLLECTOR_H

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -21,6 +21,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/CAS/CASOutputBackend.h"
 #include "llvm/Support/BuryPointer.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/VirtualOutputBackend.h"
@@ -91,6 +92,10 @@ class CompilerInstance : public ModuleLoader {
 
   /// The output context.
   IntrusiveRefCntPtr<llvm::vfs::OutputBackend> TheOutputBackend;
+
+  /// The underlying CAS output context, if any. Used to create CAS-specific
+  /// outputs.
+  IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> CASOutputBackend;
 
   /// The source manager.
   IntrusiveRefCntPtr<SourceManager> SourceMgr;
@@ -429,13 +434,19 @@ public:
   /// Set the output manager.
   void setOutputBackend(IntrusiveRefCntPtr<llvm::vfs::OutputBackend> NewOutputs);
 
+  void setCASOutputBackend(
+      clang::IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> NewOutputs);
+
   /// Create an output manager.
   void createOutputBackend();
 
   bool hasOutputBackend() const { return bool(TheOutputBackend); }
+  bool hasCASOutputBackend() const { return bool(CASOutputBackend); }
 
   llvm::vfs::OutputBackend &getOutputBackend();
   llvm::vfs::OutputBackend &getOrCreateOutputBackend();
+
+  llvm::cas::CASOutputBackend &getCASOutputBackend();
 
   /// Get the CAS, or create it using the configuration in CompilerInvocation.
   llvm::cas::CASDB &getOrCreateCAS();

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -93,10 +93,6 @@ class CompilerInstance : public ModuleLoader {
   /// The output context.
   IntrusiveRefCntPtr<llvm::vfs::OutputBackend> TheOutputBackend;
 
-  /// The underlying CAS output context, if any. Used to create CAS-specific
-  /// outputs.
-  IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> CASOutputBackend;
-
   /// The source manager.
   IntrusiveRefCntPtr<SourceManager> SourceMgr;
 
@@ -434,19 +430,13 @@ public:
   /// Set the output manager.
   void setOutputBackend(IntrusiveRefCntPtr<llvm::vfs::OutputBackend> NewOutputs);
 
-  void setCASOutputBackend(
-      clang::IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> NewOutputs);
-
   /// Create an output manager.
   void createOutputBackend();
 
   bool hasOutputBackend() const { return bool(TheOutputBackend); }
-  bool hasCASOutputBackend() const { return bool(CASOutputBackend); }
 
   llvm::vfs::OutputBackend &getOutputBackend();
   llvm::vfs::OutputBackend &getOrCreateOutputBackend();
-
-  llvm::cas::CASOutputBackend &getCASOutputBackend();
 
   /// Get the CAS, or create it using the configuration in CompilerInvocation.
   llvm::cas::CASDB &getOrCreateCAS();

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -356,6 +356,9 @@ public:
   /// Output (and read) PCM files regardless of compiler errors.
   unsigned AllowPCMWithCompilerErrors : 1;
 
+  /// Whether to share the FileManager when building modules.
+  unsigned ModulesShareFileManager : 1;
+
   CodeCompleteOptions CodeCompleteOpts;
 
   /// Specifies the output format of the AST.
@@ -522,7 +525,8 @@ public:
         ASTDumpLookups(false), BuildingImplicitModule(false),
         BuildingImplicitModuleUsesLock(true), ModulesEmbedAllFiles(false),
         IncludeTimestamps(true), UseTemporary(true), CacheCompileJob(false),
-        AllowPCMWithCompilerErrors(false), TimeTraceGranularity(500) {}
+        AllowPCMWithCompilerErrors(false), ModulesShareFileManager(true),
+        TimeTraceGranularity(500) {}
 
   /// getInputKindForExtension - Return the appropriate input kind for a file
   /// extension. For example, "c" would return Language::C.

--- a/clang/lib/Frontend/CASDependencyCollector.cpp
+++ b/clang/lib/Frontend/CASDependencyCollector.cpp
@@ -1,0 +1,73 @@
+//===--- CASDependencyCollector.cpp ---------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Frontend/CASDependencyCollector.h"
+#include "clang/Basic/DiagnosticCAS.h"
+#include "llvm/CAS/CASDB.h"
+#include "llvm/CAS/CASOutputBackend.h"
+#include "llvm/Support/VirtualOutputBackends.h"
+
+using namespace clang;
+using namespace clang::cas;
+
+CASDependencyCollector::CASDependencyCollector(
+    const DependencyOutputOptions &Opts,
+    IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> OutputBackend)
+    : DependencyFileGenerator(Opts, llvm::vfs::makeNullOutputBackend()),
+      CASOutputs(std::move(OutputBackend)), OutputName(Opts.OutputFile) {}
+
+llvm::Error CASDependencyCollector::replay(const DependencyOutputOptions &Opts,
+                                           CASDB &CAS, ObjectRef DepsRef,
+                                           llvm::raw_ostream &OS) {
+  auto Refs = CAS.load(DepsRef);
+  if (!Refs)
+    return Refs.takeError();
+
+  CASDependencyCollector DC(Opts, nullptr);
+  auto Err = CAS.forEachRef(*Refs, [&](ObjectRef Ref) -> llvm::Error {
+    auto PathHandle = CAS.load(Ref);
+    if (!PathHandle)
+      return PathHandle.takeError();
+    StringRef Path = CAS.getDataString(*PathHandle);
+    // This assumes the replay has the same filtering options as when it was
+    // originally computed. That avoids needing to store many unnecessary paths.
+    // FIXME: if a prefix map is enabled, we should remap the paths to the
+    // invocation's environment.
+    DC.addDependency(Path);
+    return llvm::Error::success();
+  });
+  if (Err)
+    return Err;
+
+  DC.outputDependencyFile(OS);
+  return llvm::Error::success();
+}
+
+void CASDependencyCollector::finishedMainFile(DiagnosticsEngine &Diags) {
+  CASDB &CAS = CASOutputs->getCAS();
+  ArrayRef<std::string> Files = getDependencies();
+  std::vector<ObjectRef> Refs;
+  Refs.reserve(Files.size());
+  for (StringRef File : Files) {
+    auto Handle = CAS.storeFromString({}, File);
+    if (!Handle) {
+      Diags.Report({}, diag::err_cas_store) << toString(Handle.takeError());
+      return;
+    }
+    Refs.push_back(CAS.getReference(*Handle));
+  }
+
+  auto Handle = CAS.store(Refs, {});
+  if (!Handle) {
+    Diags.Report({}, diag::err_cas_store) << toString(Handle.takeError());
+    return;
+  }
+
+  if (auto Err = CASOutputs->addObject(OutputName, CAS.getReference(*Handle)))
+    Diags.Report({}, diag::err_cas_store) << toString(std::move(Err));
+}

--- a/clang/lib/Frontend/CMakeLists.txt
+++ b/clang/lib/Frontend/CMakeLists.txt
@@ -13,6 +13,7 @@ add_clang_library(clangFrontend
   ASTConsumers.cpp
   ASTMerge.cpp
   ASTUnit.cpp
+  CASDependencyCollector.cpp
   ChainedDiagnosticConsumer.cpp
   ChainedIncludesSource.cpp
   CompileJobCacheKey.cpp

--- a/clang/lib/Frontend/CompileJobCacheKey.cpp
+++ b/clang/lib/Frontend/CompileJobCacheKey.cpp
@@ -60,14 +60,20 @@ clang::createCompileJobCacheKey(CASDB &CAS, DiagnosticsEngine &Diags,
   CompilerInvocation InvocationForCacheKey(OriginalInvocation);
   FrontendOptions &FrontendOpts = InvocationForCacheKey.getFrontendOpts();
   DiagnosticOptions &DiagOpts = InvocationForCacheKey.getDiagnosticOpts();
+  DependencyOutputOptions &DepOpts =
+      InvocationForCacheKey.getDependencyOutputOpts();
   // Keep the key independent of the paths of these outputs.
   if (!FrontendOpts.OutputFile.empty())
     FrontendOpts.OutputFile = "-";
-  if (!InvocationForCacheKey.getDependencyOutputOpts().OutputFile.empty())
-    InvocationForCacheKey.getDependencyOutputOpts().OutputFile = "-";
+  if (!DepOpts.OutputFile.empty())
+    DepOpts.OutputFile = "-";
   // We always generate the serialized diagnostics so the key is independent of
   // the presence of '--serialize-diagnostics'.
   DiagOpts.DiagnosticSerializationFile.clear();
+  // Dependency options that do not affect the list of files are canonicalized.
+  if (!DepOpts.Targets.empty())
+    DepOpts.Targets = {"-"};
+  DepOpts.UsePhonyTargets = false;
 
   // Generate a new command-line in case Invocation has been canonicalized.
   llvm::BumpPtrAllocator Alloc;

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -20,6 +20,7 @@
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Basic/Version.h"
 #include "clang/Config/config.h"
+#include "clang/Frontend/CASDependencyCollector.h"
 #include "clang/Frontend/ChainedDiagnosticConsumer.h"
 #include "clang/Frontend/FrontendAction.h"
 #include "clang/Frontend/FrontendActions.h"
@@ -499,9 +500,13 @@ void CompilerInstance::createPreprocessor(TranslationUnitKind TUKind) {
 
   // Handle generating dependencies, if requested.
   const DependencyOutputOptions &DepOpts = getDependencyOutputOpts();
-  if (!DepOpts.OutputFile.empty())
+  if (!DepOpts.OutputFile.empty()) {
+    if (hasCASOutputBackend())
+      addDependencyCollector(
+          std::make_shared<CASDependencyCollector>(DepOpts, CASOutputBackend));
     addDependencyCollector(
         std::make_shared<DependencyFileGenerator>(DepOpts, TheOutputBackend));
+  }
   if (!DepOpts.DOTOutputFile.empty())
     AttachDependencyGraphGen(*PP, DepOpts.DOTOutputFile,
                              getHeaderSearchOpts().Sysroot);
@@ -843,6 +848,11 @@ void CompilerInstance::setOutputBackend(
   assert(!TheOutputBackend && "Already has an output manager");
   TheOutputBackend = std::move(NewOutputs);
 }
+void CompilerInstance::setCASOutputBackend(
+    clang::IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> NewOutputs) {
+  assert(!CASOutputBackend && "Already has a CAS output backend");
+  CASOutputBackend = std::move(NewOutputs);
+}
 
 void CompilerInstance::createOutputBackend() {
   assert(!TheOutputBackend && "Already has an output manager");
@@ -858,6 +868,11 @@ llvm::vfs::OutputBackend &CompilerInstance::getOrCreateOutputBackend() {
   if (!hasOutputBackend())
     createOutputBackend();
   return getOutputBackend();
+}
+
+llvm::cas::CASOutputBackend &CompilerInstance::getCASOutputBackend() {
+  assert(CASOutputBackend);
+  return *CASOutputBackend;
 }
 
 llvm::cas::CASDB &CompilerInstance::getOrCreateCAS() {

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1199,11 +1199,16 @@ compileModuleImpl(CompilerInstance &ImportingInstance, SourceLocation ImportLoc,
                                    ImportingInstance.getDiagnosticClient()),
                              /*ShouldOwnClient=*/true);
 
-  // Note that this module is part of the module build stack, so that we
-  // can detect cycles in the module graph.
-  Instance.setFileManager(&ImportingInstance.getFileManager());
+  if (FrontendOpts.ModulesShareFileManager) {
+    Instance.setFileManager(&ImportingInstance.getFileManager());
+  } else {
+    Instance.createFileManager(&ImportingInstance.getVirtualFileSystem());
+  }
   Instance.createSourceManager(Instance.getFileManager());
   SourceManager &SourceMgr = Instance.getSourceManager();
+
+  // Note that this module is part of the module build stack, so that we
+  // can detect cycles in the module graph.
   SourceMgr.setModuleBuildStack(
     ImportingInstance.getSourceManager().getModuleBuildStack());
   SourceMgr.pushModuleBuildStack(ModuleName,
@@ -1304,12 +1309,16 @@ static bool compileModule(CompilerInstance &ImportingInstance,
             ModuleMapFile, ImportingInstance.getFileManager()))
       ModuleMapFile = PublicMMFile;
 
+    // FIXME: Update header search to keep FileEntryRef rather than rely on
+    // getLastRef().
+    StringRef ModuleMapFilePath =
+        ModuleMapFile->getLastRef().getNameAsRequested();
+
     // Use the module map where this module resides.
     Result = compileModuleImpl(
         ImportingInstance, ImportLoc, Module->getTopLevelModuleName(),
-        FrontendInputFile(ModuleMapFile->getName(), IK, +Module->IsSystem),
-        ModMap.getModuleMapFileForUniquing(Module)->getName(),
-        ModuleFileName);
+        FrontendInputFile(ModuleMapFilePath, IK, +Module->IsSystem),
+        ModMap.getModuleMapFileForUniquing(Module)->getName(), ModuleFileName);
   } else {
     // FIXME: We only need to fake up an input file here as a way of
     // transporting the module's directory to the module map parser. We should

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -500,13 +500,9 @@ void CompilerInstance::createPreprocessor(TranslationUnitKind TUKind) {
 
   // Handle generating dependencies, if requested.
   const DependencyOutputOptions &DepOpts = getDependencyOutputOpts();
-  if (!DepOpts.OutputFile.empty()) {
-    if (hasCASOutputBackend())
-      addDependencyCollector(
-          std::make_shared<CASDependencyCollector>(DepOpts, CASOutputBackend));
+  if (!DepOpts.OutputFile.empty())
     addDependencyCollector(
         std::make_shared<DependencyFileGenerator>(DepOpts, TheOutputBackend));
-  }
   if (!DepOpts.DOTOutputFile.empty())
     AttachDependencyGraphGen(*PP, DepOpts.DOTOutputFile,
                              getHeaderSearchOpts().Sysroot);
@@ -848,11 +844,6 @@ void CompilerInstance::setOutputBackend(
   assert(!TheOutputBackend && "Already has an output manager");
   TheOutputBackend = std::move(NewOutputs);
 }
-void CompilerInstance::setCASOutputBackend(
-    clang::IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> NewOutputs) {
-  assert(!CASOutputBackend && "Already has a CAS output backend");
-  CASOutputBackend = std::move(NewOutputs);
-}
 
 void CompilerInstance::createOutputBackend() {
   assert(!TheOutputBackend && "Already has an output manager");
@@ -868,11 +859,6 @@ llvm::vfs::OutputBackend &CompilerInstance::getOrCreateOutputBackend() {
   if (!hasOutputBackend())
     createOutputBackend();
   return getOutputBackend();
-}
-
-llvm::cas::CASOutputBackend &CompilerInstance::getCASOutputBackend() {
-  assert(CASOutputBackend);
-  return *CASOutputBackend;
 }
 
 llvm::cas::CASDB &CompilerInstance::getOrCreateCAS() {

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -239,6 +239,7 @@ public:
 
     ScanInstance.getFrontendOpts().GenerateGlobalModuleIndex = false;
     ScanInstance.getFrontendOpts().UseGlobalModuleIndex = false;
+    ScanInstance.getFrontendOpts().ModulesShareFileManager = false;
 
     FileMgr->getFileSystemOpts().WorkingDir = std::string(WorkingDirectory);
     ScanInstance.setFileManager(FileMgr);

--- a/clang/test/CAS/daemon-cwd.c
+++ b/clang/test/CAS/daemon-cwd.c
@@ -13,8 +13,8 @@
 // RUN:    -MD -MF %t/test.d -Iinclude                                    \
 // RUN:    -fsyntax-only -x c %s)
 // RUN: %clang -cc1depscand -shutdown %{clang-daemon-dir}/daemon-cwd
-// RUN: %clang -target x86_64-apple-macos11 -MD -MF %t/test2.d            \
-// RUN:    -I %t/include -fsyntax-only -x c %s
+// RUN: (cd %t && %clang -target x86_64-apple-macos11 -MD -MF %t/test2.d  \
+// RUN:    -Iinclude -fsyntax-only -x c %s)
 // RUN: diff %t/test.d %t/test2.d
 
 #include "test.h"

--- a/clang/test/CAS/fcache-compile-job-dependency-file.c
+++ b/clang/test/CAS/fcache-compile-job-dependency-file.c
@@ -4,7 +4,7 @@
 //
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache %t/main.c -emit-obj -o %t/output.o \
+// RUN:   -Rcompile-job-cache %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
 // RUN:   -dependency-file %t/deps1.d -MT depends 2>&1 \
 // RUN:   | FileCheck %s --allow-empty --check-prefix=CACHE-MISS
 //
@@ -12,12 +12,13 @@
 // DEPS: depends:
 // DEPS: main.c
 // DEPS: my_header.h
+// DEPS-NOT: sys.h
 
 // RUN: ls %t/output.o && rm %t/output.o
 //
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache %t/main.c -emit-obj -o %t/output.o \
+// RUN:   -Rcompile-job-cache %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
 // RUN:   -dependency-file %t/deps2.d -MT depends 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CACHE-HIT
 //
@@ -27,7 +28,38 @@
 // CACHE-HIT: remark: compile job cache hit
 // CACHE-MISS-NOT: remark: compile job cache hit
 
+// RUN: %clang -cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
+// RUN:   -dependency-file %t/deps3.d -MT other1 -MT other2 -MP 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CACHE-HIT
+
+// RUN: FileCheck %s --input-file=%t/deps3.d --check-prefix=DEPS_OTHER
+// DEPS_OTHER: other1 other2:
+// DEPS_OTHER: main.c
+// DEPS_OTHER: my_header.h
+// DEPS_OTHER-NOT: sys.h
+// DEPS_OTHER: my_header.h:
+
+// RUN: %clang -cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
+// RUN:   -sys-header-deps -dependency-file %t/deps4.d -MT depends 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CACHE-MISS
+
+// Note: currently options that affect the list of deps (like sys-header-deps)
+// are part of the cache key, to avoid saving unnecessary paths.
+
+// RUN: FileCheck %s --input-file=%t/deps4.d --check-prefix=DEPS_SYS
+// DEPS_SYS: depends:
+// DEPS_SYS: main.c
+// DEPS_SYS: my_header.h
+// DEPS_SYS: sys.h
+
 //--- main.c
 #include "my_header.h"
+#include <sys.h>
 
 //--- my_header.h
+
+//--- sys/sys.h

--- a/clang/test/ClangScanDeps/modules-file-path-isolation.c
+++ b/clang/test/ClangScanDeps/modules-file-path-isolation.c
@@ -1,0 +1,44 @@
+// Ensure that the spelling of a path seen outside a module (e.g. header via
+// symlink) does not leak into the compilation of that module unnecessarily.
+// Note: the spelling of the modulemap path still depends on the includer, since
+// that is the only source of information about it.
+
+// REQUIRES: shell
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.in > %t/cdb.json
+// RUN: ln -s A.h %t/Z.h
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -j 1 -format experimental-full \
+// RUN:   -mode preprocess-dependency-directives -generate-modules-path-args > %t/output
+// RUN: FileCheck %s < %t/output
+
+// CHECK:      "modules": [
+// CHECK-NEXT:   {
+// CHECK:          "file-deps": [
+// CHECK-NEXT:       "{{.*}}A.h",
+// CHECK-NEXT:       "{{.*}}module.modulemap"
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "name": "A"
+// CHECK-NEXT:   }
+
+//--- cdb.json.in
+[{
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu.c -fmodules -fmodules-cache-path=DIR/module-cache -fimplicit-modules -fimplicit-module-maps",
+  "file": "DIR/tu.c"
+}]
+
+//--- module.modulemap
+module A { header "A.h" }
+module B { header "B.h" }
+module C { header "C.h" }
+
+//--- A.h
+
+//--- B.h
+#include "Z.h"
+
+//--- tu.c
+#include "B.h"

--- a/clang/test/Modules/submodule-in-private-mmap-vfs.m
+++ b/clang/test/Modules/submodule-in-private-mmap-vfs.m
@@ -1,0 +1,38 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/vfs.json.in > %t/vfs.json
+// RUN: %clang_cc1 -fmodules -fno-modules-share-filemanager -fimplicit-module-maps \
+// RUN:   -fmodules-cache-path=%t -I%t/Virtual -ivfsoverlay %t/vfs.json -fsyntax-only %t/tu.m -verify
+
+//--- Dir1/module.modulemap
+
+//--- Dir2/module.private.modulemap
+module Foo_Private {}
+
+//--- vfs.json.in
+{
+  'version': 0,
+  'use-external-names': true,
+  'roots': [
+    {
+      'name': 'DIR/Virtual',
+      'type': 'directory',
+      'contents': [
+        {
+          'name': 'module.modulemap',
+          'type': 'file',
+          'external-contents': 'DIR/Dir1/module.modulemap'
+        },
+        {
+          'name': 'module.private.modulemap',
+          'type': 'file',
+          'external-contents': 'DIR/Dir2/module.private.modulemap'
+        }
+      ]
+    }
+  ]
+}
+
+//--- tu.m
+@import Foo_Private;
+// expected-no-diagnostics

--- a/clang/test/VFS/module-import.m
+++ b/clang/test/VFS/module-import.m
@@ -1,6 +1,7 @@
-// RUN: rm -rf %t
+// RUN: rm -rf %t %t-unshared
 // RUN: sed -e "s@INPUT_DIR@%{/S:regex_replacement}/Inputs@g" -e "s@OUT_DIR@%{/t:regex_replacement}@g" %S/Inputs/vfsoverlay.yaml > %t.yaml
 // RUN: %clang_cc1 -Werror -fmodules -fimplicit-module-maps -fmodules-cache-path=%t -ivfsoverlay %t.yaml -I %t -fsyntax-only %s
+// RUN: %clang_cc1 -Werror -fmodules -fno-modules-share-filemanager -fimplicit-module-maps -fmodules-cache-path=%t-unshared -ivfsoverlay %t.yaml -I %t -fsyntax-only %s
 
 @import not_real;
 
@@ -18,9 +19,12 @@ void foo(void) {
 // Override the module map (vfsoverlay2 on top)
 // RUN: sed -e "s@INPUT_DIR@%{/S:regex_replacement}/Inputs@g" -e "s@OUT_DIR@%{/t:regex_replacement}@g" %S/Inputs/vfsoverlay2.yaml > %t2.yaml
 // RUN: %clang_cc1 -Werror -fmodules -fimplicit-module-maps -fmodules-cache-path=%t -ivfsoverlay %t.yaml -ivfsoverlay %t2.yaml -I %t -fsyntax-only %s
+// RUN: %clang_cc1 -Werror -fmodules -fno-modules-share-filemanager -fimplicit-module-maps -fmodules-cache-path=%t-unshared -ivfsoverlay %t.yaml -ivfsoverlay %t2.yaml -I %t -fsyntax-only %s
 
 // vfsoverlay2 not present
 // RUN: not %clang_cc1 -Werror -fmodules -fimplicit-module-maps -fmodules-cache-path=%t -ivfsoverlay %t.yaml -I %t -fsyntax-only %s -DIMPORT2 2>&1 | FileCheck -check-prefix=CHECK-VFS2 %s
+// RUN: not %clang_cc1 -Werror -fmodules -fno-modules-share-filemanager -fimplicit-module-maps -fmodules-cache-path=%t-unshared -ivfsoverlay %t.yaml -I %t -fsyntax-only %s -DIMPORT2 2>&1 | FileCheck -check-prefix=CHECK-VFS2 %s
 
 // vfsoverlay2 on the bottom
 // RUN: not %clang_cc1 -Werror -fmodules -fimplicit-module-maps -fmodules-cache-path=%t -ivfsoverlay %t2.yaml -ivfsoverlay %t.yaml -I %t -fsyntax-only %s -DIMPORT2 2>&1 | FileCheck -check-prefix=CHECK-VFS2 %s
+// RUN: not %clang_cc1 -Werror -fmodules -fno-modules-share-filemanager -fimplicit-module-maps -fmodules-cache-path=%t-unshared -ivfsoverlay %t2.yaml -ivfsoverlay %t.yaml -I %t -fsyntax-only %s -DIMPORT2 2>&1 | FileCheck -check-prefix=CHECK-VFS2 %s

--- a/llvm/include/llvm/CAS/CASOutputBackend.h
+++ b/llvm/include/llvm/CAS/CASOutputBackend.h
@@ -36,6 +36,8 @@ public:
   /// the \p Kind string instead of its path.
   void addKindMap(StringRef Kind, StringRef Path);
 
+  CASDB &getCAS() const { return CAS; }
+
 private:
   Expected<std::unique_ptr<vfs::OutputFileImpl>>
   createFileImpl(StringRef Path, Optional<vfs::OutputConfig> Config) override;


### PR DESCRIPTION
* Stop sharing the FileManager across module builds in the scanner - improves correctness and also a requirement for caching with modules.
* Remove -MT and -MP from the compile job cache key - improves cache hit rate and may simplify caching with modules