### PR TITLE
[MCCAS] Introduce zeroing-out of the abbreviation offsets

### DIFF
--- a/llvm/include/llvm/MC/CAS/MCCASObjectV1.def
+++ b/llvm/include/llvm/MC/CAS/MCCASObjectV1.def
@@ -30,6 +30,7 @@ CASV1_SIMPLE_DATA_REF(DebugAbbrevOffsetsRef, mc:debug_abbrev_offsets)
 
 CASV1_SIMPLE_GROUP_REF(GroupRef, mc:group)
 CASV1_SIMPLE_GROUP_REF(SectionRef, mc:section)
+CASV1_SIMPLE_GROUP_REF(DebugInfoSectionRef, mc:debug_info_section)
 CASV1_SIMPLE_GROUP_REF(AtomRef, mc:atom)
 CASV1_SIMPLE_GROUP_REF(SymbolTableRef, mc:symbol_table)
 

--- a/llvm/include/llvm/MC/CAS/MCCASObjectV1.h
+++ b/llvm/include/llvm/MC/CAS/MCCASObjectV1.h
@@ -358,7 +358,7 @@ public:
   Error finalizeGroup();
 
   void startSection(const MCSection *Sec);
-  Error finalizeSection();
+  template <typename SectionRefTy = SectionRef> Error finalizeSection();
 
   void startAtom(const MCSymbol *Atom);
   Error finalizeAtom();

--- a/llvm/test/DebugInfo/CAS/AArch64/debug_abbrev_split.ll
+++ b/llvm/test/DebugInfo/CAS/AArch64/debug_abbrev_split.ll
@@ -1,7 +1,7 @@
 ; RUN: llc -O0 --filetype=obj --cas-backend --cas=%t.casdb --mccas-verify -o %t.bin %s
 
 ; RUN: llc -O0 --filetype=obj --cas-backend --cas=%t.casdb --mccas-casid -o %t.casid %s
-; RUN: llvm-cas-dump --cas=%t.casdb --dwarf-sections-only --debug-abbrev-offsets --casid-file %t.casid | FileCheck %s
+; RUN: llvm-cas-dump --cas=%t.casdb --dwarf-dump --dwarf-sections-only --debug-abbrev-offsets --casid-file %t.casid | FileCheck %s
 
 target triple = "arm64-apple-macosx12.0.0"
 
@@ -24,7 +24,11 @@ entry:
 ; CHECK-NEXT:       mc:debug_abbrev_offsets llvmcas://
 ; CHECK-NEXT:         0, 55
 ; CHECK-NEXT:       mc:debug_info_cu llvmcas://
-; CHECK-NEXT:       mc:debug_info_cu llvmcas://
+; CHECK-NEXT:         Real abbr_offset: 0
+; CHECK-NEXT:         abbr_offset = 0x0000
+; CHECK:            mc:debug_info_cu llvmcas://
+; CHECK-NEXT:         Real abbr_offset: 55
+; CHECK-NEXT:         abbr_offset = 0x0000
 ; CHECK-NOT: debug_abbrev
 
 

--- a/llvm/test/DebugInfo/CAS/AArch64/debug_abbrev_split.ll
+++ b/llvm/test/DebugInfo/CAS/AArch64/debug_abbrev_split.ll
@@ -20,7 +20,7 @@ entry:
 ; CHECK-NEXT:       mc:debug_abbrev llvmcas://
 ; CHECK-NEXT:       mc:debug_abbrev llvmcas://
 ; CHECK-NEXT:       mc:padding llvmcas://
-; CHECK-NEXT:     mc:section      llvmcas://
+; CHECK-NEXT:     mc:debug_info_section      llvmcas://
 ; CHECK-NEXT:       mc:debug_abbrev_offsets llvmcas://
 ; CHECK-NEXT:         0, 55
 ; CHECK-NEXT:       mc:debug_info_cu llvmcas://

--- a/llvm/test/tools/llvm-cas-dump/basic_debug_test.ll
+++ b/llvm/test/tools/llvm-cas-dump/basic_debug_test.ll
@@ -11,7 +11,7 @@
 ; CHECK-NEXT:     mc:section  llvmcas://{{.*}}
 ; CHECK-NEXT:       mc:debug_abbrev  llvmcas://{{.*}}
 ; CHECK-NEXT:       mc:padding  llvmcas://{{.*}}
-; CHECK-NEXT:     mc:section  llvmcas://{{.*}}
+; CHECK-NEXT:     mc:debug_info_section  llvmcas://{{.*}}
 ; CHECK-NEXT:       mc:debug_abbrev_offsets  llvmcas://{{.*}}
 ; CHECK-NEXT:         0
 ; CHECK-NEXT:       mc:debug_info_cu  llvmcas://{{.*}}

--- a/llvm/tools/llvm-cas-dump/CASDWARFObject.h
+++ b/llvm/tools/llvm-cas-dump/CASDWARFObject.h
@@ -23,6 +23,8 @@ class CASDWARFObject : public DWARFObject {
   SmallVector<uint8_t> DebugStringSection;
 
   SmallVector<uint8_t> DebugAbbrevSection;
+  SmallVector<size_t> DebugAbbrevOffsets;
+  DenseMap<cas::ObjectRef, size_t> CUToOffset;
 
   const mccasformats::v1::MCSchema &Schema;
 


### PR DESCRIPTION
This PR implements the required refactors as well as the zeroing out of abbreviation offsets inside the CUs of `__debug_abrev` sections