### PR TITLE
[CAS] Remove nested namespace definition

### DIFF
--- a/clang/include/clang/Frontend/CASDependencyCollector.h
+++ b/clang/include/clang/Frontend/CASDependencyCollector.h
@@ -12,8 +12,10 @@
 #include "clang/Frontend/Utils.h"
 #include "llvm/CAS/CASReference.h"
 
-namespace llvm::cas {
-class CASOutputBackend;
+namespace llvm {
+  namespace cas {
+    class CASOutputBackend;
+  }
 }
 
 namespace clang {


### PR DESCRIPTION
Nested namespace specifiers are a C++17 feature. Just use a nested
namespace for now.