### PR TITLE
[clang-cas-test] Mark `clang-cas-test` as a 'clang tool'

### DIFF
--- a/clang/tools/clang-cas-test/CMakeLists.txt
+++ b/clang/tools/clang-cas-test/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_executable(clang-cas-test
+add_clang_tool(clang-cas-test
   ClangCASTest.cpp
   )
 


### PR DESCRIPTION
(cherry picked from commit 53a49f571a9ca3bafbf3b796bcfa5d6042cbc5d8)