### PR TITLE
[clang][deps][cas] Reduce diff footprint with upstream 

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
@@ -84,7 +84,7 @@ private:
     Optional<llvm::cas::ObjectRef> CASContents;
   };
   llvm::BumpPtrAllocator EntryAlloc;
-  llvm::StringMap<FileEntry, llvm::BumpPtrAllocator&> Entries;
+  llvm::StringMap<FileEntry, llvm::BumpPtrAllocator &> Entries;
 
   struct LookupPathResult {
     const FileEntry *Entry = nullptr;

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
@@ -62,13 +62,9 @@ public:
       bool ReuseFileManager = true, bool OptimizeArgs = false,
       bool OverrideCASTokenCache = false);
 
-  ~DependencyScanningService();
-
   ScanningMode getMode() const { return Mode; }
 
   ScanningOutputFormat getFormat() const { return Format; }
-
-  const CASOptions &getCASOpts() const { return CASOpts; }
 
   bool canReuseFileManager() const { return ReuseFileManager; }
 
@@ -79,6 +75,8 @@ public:
     assert(SharedCache && "Expected a shared cache");
     return *SharedCache;
   }
+
+  const CASOptions &getCASOpts() const { return CASOpts; }
 
   bool overrideCASTokenCache() const { return OverrideCASTokenCache; }
 

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -168,8 +168,7 @@ public:
   FullDependencyConsumer(const llvm::StringSet<> &AlreadySeen)
       : AlreadySeen(AlreadySeen) {}
 
-  void
-  handleDependencyOutputOpts(const DependencyOutputOptions &Opts) override {}
+  void handleDependencyOutputOpts(const DependencyOutputOptions &) override {}
 
   void handleFileDependency(StringRef File) override {
     Dependencies.push_back(std::string(File));
@@ -187,9 +186,9 @@ public:
     ContextHash = std::move(Hash);
   }
 
-  Expected<FullDependenciesResult>
-  getFullDependencies(const std::vector<std::string> &OriginalCommandLine,
-                      llvm::cas::CachingOnDiskFileSystem *FS) const;
+  FullDependenciesResult getFullDependencies(
+      const std::vector<std::string> &OriginalCommandLine,
+      Optional<cas::CASID> CASFileSystemRootID = None) const;
 
 private:
   std::vector<std::string> Dependencies;

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -132,14 +132,10 @@ private:
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> RealFS;
   /// The in-memory filesystem laid on top the physical filesystem in `RealFS`.
   llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> InMemoryFS;
-  /// The caching file system.
-  llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> CacheFS;
   /// The file system that is used by each worker when scanning for
   /// dependencies. This filesystem persists across multiple compiler
   /// invocations.
   llvm::IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS;
-  /// The CAS Dependency Filesytem. This is not set at the sametime as DepFS;
-  llvm::IntrusiveRefCntPtr<DependencyScanningCASFilesystem> DepCASFS;
   /// The file manager that is reused across multiple invocations by this
   /// worker. If null, the file manager will not be reused.
   llvm::IntrusiveRefCntPtr<FileManager> Files;
@@ -147,6 +143,10 @@ private:
   /// Whether to optimize the modules' command-line arguments.
   bool OptimizeArgs;
 
+  /// The caching file system.
+  llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> CacheFS;
+  /// The CAS Dependency Filesytem. This is not set at the sametime as DepFS;
+  llvm::IntrusiveRefCntPtr<DependencyScanningCASFilesystem> DepCASFS;
   CASOptions CASOpts;
   bool UseCAS;
   bool OverrideCASTokenCache;

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -34,13 +34,10 @@ namespace dependencies {
 
 class DependencyScanningWorkerFilesystem;
 
-class DependencyScanningConsumerBase {
+class DependencyConsumer {
 public:
-  virtual ~DependencyScanningConsumerBase() {}
-};
+  virtual ~DependencyConsumer() {}
 
-class DependencyConsumer : public DependencyScanningConsumerBase {
-public:
   virtual void
   handleDependencyOutputOpts(const DependencyOutputOptions &Opts) = 0;
 
@@ -55,7 +52,7 @@ public:
 
 // FIXME: This may need to merge with \p DependencyConsumer in order to support
 // clang modules for the include-tree.
-class PPIncludeActionsConsumer : public DependencyScanningConsumerBase {
+class PPIncludeActionsConsumer : public DependencyConsumer {
 public:
   virtual void enteredInclude(Preprocessor &PP, FileID FID) = 0;
 
@@ -63,6 +60,23 @@ public:
                              FileID Include, SourceLocation ExitLoc) = 0;
 
   virtual void handleHasIncludeCheck(Preprocessor &PP, bool Result) = 0;
+
+protected:
+  void handleDependencyOutputOpts(const DependencyOutputOptions &Opts) override {
+    llvm::report_fatal_error("unexpected callback for include-tree");
+  }
+  void handleFileDependency(StringRef Filename) override {
+    llvm::report_fatal_error("unexpected callback for include-tree");
+  }
+  void handlePrebuiltModuleDependency(PrebuiltModuleDep PMD) override {
+    llvm::report_fatal_error("unexpected callback for include-tree");
+  }
+  void handleModuleDependency(ModuleDeps MD) override {
+    llvm::report_fatal_error("unexpected callback for include-tree");
+  }
+  void handleContextHash(std::string Hash) override {
+    llvm::report_fatal_error("unexpected callback for include-tree");
+  }
 };
 
 /// An individual dependency scanning worker that is able to run on its own
@@ -85,7 +99,7 @@ public:
   /// occurred, success otherwise.
   llvm::Error computeDependencies(StringRef WorkingDirectory,
                                   const std::vector<std::string> &CommandLine,
-                                  DependencyScanningConsumerBase &Consumer,
+                                  DependencyConsumer &Consumer,
                                   llvm::Optional<StringRef> ModuleName = None);
 
   /// Scan from a compiler invocation.
@@ -95,7 +109,7 @@ public:
   /// \p DiagOpts.DiagnosticSerializationFile setting is set for the invocation.
   void computeDependenciesFromCompilerInvocation(
       std::shared_ptr<CompilerInvocation> Invocation,
-      StringRef WorkingDirectory, DependencyScanningConsumerBase &Consumer,
+      StringRef WorkingDirectory, DependencyConsumer &Consumer,
       DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
       bool DiagGenerationAsCompilation);
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
@@ -32,5 +32,3 @@ DependencyScanningService::DependencyScanningService(
   llvm::InitializeAllAsmPrinters();
   llvm::InitializeAllAsmParsers();
 }
-
-DependencyScanningService::~DependencyScanningService() = default;

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -399,12 +399,20 @@ DependencyScanningTool::getFullDependencies(
   if (Result)
     return std::move(Result);
 
-  return Consumer.getFullDependencies(CommandLine, FS);
+  Optional<cas::CASID> CASFileSystemRootID;
+  if (FS) {
+    if (auto Tree = FS->createTreeFromNewAccesses())
+      CASFileSystemRootID = Tree->getID();
+    else
+      return Tree.takeError();
+  }
+
+  return Consumer.getFullDependencies(CommandLine, CASFileSystemRootID);
 }
 
-Expected<FullDependenciesResult> FullDependencyConsumer::getFullDependencies(
+FullDependenciesResult FullDependencyConsumer::getFullDependencies(
     const std::vector<std::string> &OriginalCommandLine,
-    llvm::cas::CachingOnDiskFileSystem *FS) const {
+    Optional<cas::CASID> CASFileSystemRootID) const {
   FullDependencies FD;
 
   FD.OriginalCommandLine = ArrayRef<std::string>(OriginalCommandLine).slice(1);
@@ -421,12 +429,7 @@ Expected<FullDependenciesResult> FullDependencyConsumer::getFullDependencies(
 
   FD.PrebuiltModuleDeps = std::move(PrebuiltModuleDeps);
 
-  if (FS) {
-    if (auto Tree = FS->createTreeFromNewAccesses())
-      FD.CASFileSystemRootID = Tree->getID();
-    else
-      return Tree.takeError();
-  }
+  FD.CASFileSystemRootID = CASFileSystemRootID;
 
   FullDependenciesResult FDR;
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -196,21 +196,20 @@ class DependencyScanningAction : public tooling::ToolAction {
 public:
   DependencyScanningAction(
       StringRef WorkingDirectory, DependencyConsumer &Consumer,
-      const CASOptions &CASOpts,
       llvm::IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS,
       llvm::IntrusiveRefCntPtr<DependencyScanningCASFilesystem> DepCASFS,
-      bool OverrideCASTokenCache, ScanningOutputFormat Format,
-      bool OptimizeArgs, bool EmitDependencyFile,
-      bool DiagGenerationAsCompilation, bool DisableFree,
+      ScanningOutputFormat Format, bool OptimizeArgs, bool DisableFree,
+      bool EmitDependencyFile, bool DiagGenerationAsCompilation,
+      const CASOptions &CASOpts, bool OverrideCASTokenCache,
       llvm::Optional<StringRef> ModuleName = None,
       raw_ostream *VerboseOS = nullptr)
       : WorkingDirectory(WorkingDirectory), Consumer(Consumer),
-        CASOpts(CASOpts), DepFS(std::move(DepFS)),
-        DepCASFS(std::move(DepCASFS)), Format(Format),
-        OverrideCASTokenCache(OverrideCASTokenCache),
-        OptimizeArgs(OptimizeArgs), EmitDependencyFile(EmitDependencyFile),
+        DepFS(std::move(DepFS)), DepCASFS(std::move(DepCASFS)), Format(Format),
+        OptimizeArgs(OptimizeArgs), DisableFree(DisableFree),
+        CASOpts(CASOpts), OverrideCASTokenCache(OverrideCASTokenCache),
+        EmitDependencyFile(EmitDependencyFile),
         DiagGenerationAsCompilation(DiagGenerationAsCompilation),
-        DisableFree(DisableFree), ModuleName(ModuleName), VerboseOS(VerboseOS) {
+        ModuleName(ModuleName), VerboseOS(VerboseOS) {
   }
 
   bool runInvocation(std::shared_ptr<CompilerInvocation> Invocation,
@@ -371,15 +370,15 @@ public:
 private:
   StringRef WorkingDirectory;
   DependencyConsumer &Consumer;
-  const CASOptions &CASOpts;
   llvm::IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS;
   llvm::IntrusiveRefCntPtr<DependencyScanningCASFilesystem> DepCASFS;
   ScanningOutputFormat Format;
-  bool OverrideCASTokenCache;
   bool OptimizeArgs;
+  bool DisableFree;
+  const CASOptions &CASOpts;
+  bool OverrideCASTokenCache;
   bool EmitDependencyFile = false;
   bool DiagGenerationAsCompilation;
-  bool DisableFree;
   llvm::Optional<StringRef> ModuleName;
   raw_ostream *VerboseOS;
 };
@@ -480,10 +479,11 @@ llvm::Error DependencyScanningWorker::computeDependencies(
                         // always true for a driver invocation.
                         bool DisableFree = true;
                         DependencyScanningAction Action(
-                            WorkingDirectory, Consumer, getCASOpts(), DepFS,
-                            DepCASFS, OverrideCASTokenCache, Format,
-                            OptimizeArgs, /*EmitDependencyFile=*/false,
-                            /*DiagGenerationAsCompilation=*/false, DisableFree,
+                            WorkingDirectory, Consumer, DepFS, DepCASFS, Format,
+                            OptimizeArgs, DisableFree,
+                            /*EmitDependencyFile=*/false,
+                            /*DiagGenerationAsCompilation=*/false,
+                            getCASOpts(), OverrideCASTokenCache,
                             ModuleName);
                         // Create an invocation that uses the underlying file
                         // system to ensure that any file system requests that
@@ -528,11 +528,10 @@ void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
   // FIXME: EmitDependencyFile should only be set when it's for a real
   // compilation.
   DependencyScanningAction Action(
-      WorkingDirectory, DepsConsumer, getCASOpts(), DepFS, DepCASFS,
-      OverrideCASTokenCache, Format,
-      /*OptimizeArgs=*/false,
+      WorkingDirectory, DepsConsumer, DepFS, DepCASFS, Format,
+      /*OptimizeArgs=*/false, /*DisableFree=*/false,
       /*EmitDependencyFile=*/!DepFile.empty(), DiagGenerationAsCompilation,
-      /*DisableFree=*/false, /*ModuleName=*/None, VerboseOS);
+      getCASOpts(), OverrideCASTokenCache, /*ModuleName=*/None, VerboseOS);
 
   // Ignore result; we're just collecting dependencies.
   //


### PR DESCRIPTION
* The separation between DependencyConsumer and DependencyScanningConsumerBase was causing spurious merge issues. There is no type safety provided by having an empty base class, so just use the main consumer and make all the base callbacks error.
* Reduce unnecessary differences with upstream dep scanning code, and group some of the changes so they are in larger regions that are easier to follow.