### PR TITLE
CodeGen: correct handling of debug info generation for aliases

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -5225,7 +5225,7 @@ void CodeGenModule::EmitAliasDefinition(GlobalDecl GD) {
   // Emit global alias debug information.
   if (isa<VarDecl>(D))
     if (CGDebugInfo *DI = getModuleDebugInfo())
-      DI->EmitGlobalAlias(cast<llvm::GlobalValue>(GA->getAliasee()), GD);
+      DI->EmitGlobalAlias(cast<llvm::GlobalValue>(GA->getAliasee()->stripPointerCasts()), GD);
 }
 
 void CodeGenModule::emitIFuncDefinition(GlobalDecl GD) {

--- a/clang/test/CodeGen/debug-info-alias-pointer.c
+++ b/clang/test/CodeGen/debug-info-alias-pointer.c
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-windows-msvc -emit-llvm -debug-info-kind=limited %s -o - | FileCheck %s
+// REQUIRES: asserts
+
+struct S {
+  void *p;
+};
+
+struct S s[] = {
+  { .p = (void *)0, },
+};
+
+extern struct S t __attribute__((__alias__("s")));
+
+// CHECK: !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "t", scope: {{.*}}, entity: {{.*}}, file: {{.*}}, line: 12)


### PR DESCRIPTION
When aliasing a static array, the aliasee is going to be a GEP which
points to the value.  We should strip pointer casts before forming the
reference.  This was occluded by the use of opaque pointers.

This problem has existed since the introduction of the debug info
generation for aliases in b1ea0191a42074341847d767609f66a26b6d5a41.  The
test case would assert due to the invalid cast with or without
`-no-opaque-pointers` at that revision.

Fixes: #57179
(cherry picked from commit 585f62be1a438ca132aa443e556d102bc908a072)