### PR TITLE
[cas][include-tree] Handle PCH files for the include-tree mechanism

### DIFF
--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -673,7 +673,8 @@ public:
   void createPCHExternalASTSource(
       StringRef Path, DisableValidationForModuleKind DisableValidation,
       bool AllowPCHWithCompilerErrors, void *DeserializationListener,
-      bool OwnDeserializationListener);
+      bool OwnDeserializationListener,
+      std::unique_ptr<llvm::MemoryBuffer> PCHBuffer = nullptr);
 
   /// Create an external AST source to read a PCH file.
   ///
@@ -687,7 +688,8 @@ public:
       ArrayRef<std::shared_ptr<ModuleFileExtension>> Extensions,
       ArrayRef<std::shared_ptr<DependencyCollector>> DependencyCollectors,
       void *DeserializationListener, bool OwnDeserializationListener,
-      bool Preamble, bool UseGlobalModuleIndex);
+      bool Preamble, bool UseGlobalModuleIndex,
+      std::unique_ptr<llvm::MemoryBuffer> PCHBuffer = nullptr);
 
   /// Create a code completion consumer using the invocation; note that this
   /// will cause the source manager to truncate the input source file at the

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -38,6 +38,8 @@ class DependencyConsumer {
 public:
   virtual ~DependencyConsumer() {}
 
+  virtual void finalize(CompilerInstance &CI) {}
+
   virtual void
   handleDependencyOutputOpts(const DependencyOutputOptions &Opts) = 0;
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -350,6 +350,7 @@ public:
       Action = std::make_unique<ReadPCHAndPreprocessAction>();
 
     const bool Result = ScanInstance.ExecuteAction(*Action);
+    Consumer.finalize(ScanInstance);
     if (!getDepScanFS())
       FileMgr->clearStatCache();
     return Result;

--- a/clang/test/CAS/fcas-include-tree-with-pch.c
+++ b/clang/test/CAS/fcas-include-tree-with-pch.c
@@ -1,0 +1,51 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: ln -s s2.h %t/s2-link.h
+// RUN: ln -s s3.h %t/s3-link1.h
+// RUN: ln -s s3.h %t/s3-link2.h
+
+// Normal compilation for baseline.
+// RUN: %clang_cc1 -x c-header %t/prefix.h -DCMD_MACRO=1 -emit-pch -o %t/prefix1.pch
+// RUN: %clang_cc1 %t/t1.c -include-pch %t/prefix1.pch -emit-llvm -o %t/source.ll -DCMD_MACRO=1
+
+// RUN: %clang -cc1depscan -o %t/pch.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
+// RUN:     -cc1 -x c-header %t/prefix.h -DCMD_MACRO=1 -fcas-path %t/cas
+// RUN: %clang @%t/pch.rsp -emit-pch -o %t/prefix2.pch
+
+// RUN: %clang -cc1depscan -o %t/tu.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
+// RUN:     -cc1 %t/t1.c -include-pch %t/prefix2.pch -DCMD_MACRO=1 -fcas-path %t/cas
+// RUN: rm %t/prefix2.pch
+
+// RUN: %clang @%t/tu.rsp -emit-llvm -o %t/tree.ll
+// RUN: diff -u %t/source.ll %t/tree.ll
+
+//--- t1.c
+#if S2_MACRO
+#include "s2-link.h"
+#endif
+#include "s3-link2.h"
+
+int test(struct S *s, struct S2 *s2) {
+  return s->x + s2->y + CMD_MACRO + PREFIX_MACRO + S2_MACRO + S3_MACRO;
+}
+
+//--- prefix.h
+#include "s2.h"
+#include "s3.h"
+#include "s3-link1.h"
+
+#define PREFIX_MACRO S3_MACRO
+
+struct S {
+  int x;
+};
+
+//--- s2.h
+#pragma once
+#define S2_MACRO 3
+struct S2 {
+  int y;
+};
+
+//--- s3.h
+#define S3_MACRO 4

--- a/clang/test/ClangScanDeps/include-tree-with-pch.c
+++ b/clang/test/ClangScanDeps/include-tree-with-pch.c
@@ -1,0 +1,59 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: %clang -x c-header %t/prefix.h -o %t/prefix.pch -fdepscan=inline -fdepscan-include-tree -Xclang -fcas-path -Xclang %t/cas
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-include-tree -cas-path %t/cas > %t/result.txt
+// RUN: FileCheck %s -input-file %t/result.txt -DPREFIX=%/t
+
+// CHECK:      {{.*}} - [[PREFIX]]/t.c
+// CHECK-NEXT: (PCH)
+// CHECK-NEXT: [[PREFIX]]/t.c
+// CHECK-NEXT: 1:1 <built-in>
+// CHECK-NEXT: [[PREFIX]]/t.h
+// CHECK-NEXT: Files:
+// CHECK-NEXT: [[PREFIX]]/t.c
+// CHECK-NEXT: [[PREFIX]]/t.h
+// CHECK-NEXT: [[PREFIX]]/n3.h
+// CHECK-NEXT: [[PREFIX]]/n2.h
+// CHECK-NEXT: [[PREFIX]]/n1.h
+// CHECK-NEXT: [[PREFIX]]/prefix.h
+// CHECK-NOT: [[PREFIX]]
+
+//--- prefix.h
+#include "n1.h"
+#import "n2.h"
+#include "n3.h"
+
+//--- n1.h
+#ifndef _N1_H_
+#define _N1_H_
+
+int n1 = 0;
+
+#endif
+
+//--- n2.h
+int n2 = 0;
+
+//--- n3.h
+#pragma once
+int n3 = 0;
+
+//--- cdb.json.template
+[{
+  "directory" : "DIR",
+  "command" : "clang -fsyntax-only DIR/t.c -Xclang -include-pch -Xclang DIR/prefix.pch",
+  "file" : "DIR/t.c"
+}]
+
+//--- t.c
+#include "t.h"
+// Should not include due to macro guard.
+#include "n1.h"
+// Should not include due to #import from 'prefix.h'.
+#include "n2.h"
+// Should not include due to '#pragma once'
+#include "n3.h"
+
+//--- t.h


### PR DESCRIPTION
If a PCH file is used during dep-scanning, its contents are recorded as a buffer in the CAS and referenced by the `IncludeTreeRoot`.
During replaying the PCH buffer is loaded via the `ASTReader`.