### PR TITLE
Zero-out and patch relocation addends in MachObjectWriter and MCCAS:

### DIFF
--- a/llvm/include/llvm/MC/MCAsmBackend.h
+++ b/llvm/include/llvm/MC/MCAsmBackend.h
@@ -147,7 +147,8 @@ public:
   virtual void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                           const MCValue &Target, MutableArrayRef<char> Data,
                           uint64_t Value, bool IsResolved,
-                          const MCSubtargetInfo *STI) const = 0;
+                          const MCSubtargetInfo *STI,
+                          const MCFragment *Fragment) const = 0;
 
   /// @}
 

--- a/llvm/include/llvm/MC/MCMachOCASWriter.h
+++ b/llvm/include/llvm/MC/MCMachOCASWriter.h
@@ -105,9 +105,9 @@ public:
     MOW.writeSymbolTable(Asm, Layout);
   }
 
-  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint8_t Size,
-                 uint32_t Offset) override {
-    return MOW.addAddend(Fragment, Addend, Size, Offset);
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Offset,
+                 uint8_t Size) override {
+    return MOW.addAddend(Fragment, Addend, Offset, Size);
   }
 
   uint64_t writeObject(MCAssembler &Asm, const MCAsmLayout &Layout) override;

--- a/llvm/include/llvm/MC/MCMachOCASWriter.h
+++ b/llvm/include/llvm/MC/MCMachOCASWriter.h
@@ -77,6 +77,10 @@ public:
     return MOW.getPaddingSize(SD, Layout);
   }
 
+  void applyAddends(MCAssembler &Asm, const MCAsmLayout &Layout) {
+    MOW.applyAddends(Asm, Layout);
+  }
+
   void prepareObject(MCAssembler &Asm, const MCAsmLayout &Layout) {
     MOW.prepareObject(Asm, Layout);
   }
@@ -101,6 +105,13 @@ public:
     MOW.writeSymbolTable(Asm, Layout);
   }
 
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Size,
+                 uint32_t Offset, uint32_t FullSizeInBytes, uint32_t RefKind,
+                 bool TargetKindIsFixupAarch64Movw) override {
+    return MOW.addAddend(Fragment, Addend, Size, Offset, FullSizeInBytes,
+                         RefKind, TargetKindIsFixupAarch64Movw);
+  }
+
   uint64_t writeObject(MCAssembler &Asm, const MCAsmLayout &Layout) override;
 
   void resetBuffer() { OSOffset = InternalOS.tell(); }
@@ -110,6 +121,12 @@ public:
   DenseMap<const MCSection *, std::vector<MachObjectWriter::RelAndSymbol>> &
   getRelocations() {
     return MOW.getRelocations();
+  }
+
+  DenseMap<const MCFragment *,
+           std::vector<MachObjectWriter::AddendsSizeAndOffset>> &
+  getAddends() {
+    return MOW.getAddends();
   }
 
 private:

--- a/llvm/include/llvm/MC/MCMachOCASWriter.h
+++ b/llvm/include/llvm/MC/MCMachOCASWriter.h
@@ -105,11 +105,9 @@ public:
     MOW.writeSymbolTable(Asm, Layout);
   }
 
-  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Size,
-                 uint32_t Offset, uint32_t FullSizeInBytes, uint32_t RefKind,
-                 bool TargetKindIsFixupAarch64Movw) override {
-    return MOW.addAddend(Fragment, Addend, Size, Offset, FullSizeInBytes,
-                         RefKind, TargetKindIsFixupAarch64Movw);
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint8_t Size,
+                 uint32_t Offset) override {
+    return MOW.addAddend(Fragment, Addend, Size, Offset);
   }
 
   uint64_t writeObject(MCAssembler &Asm, const MCAsmLayout &Layout) override;

--- a/llvm/include/llvm/MC/MCMachObjectWriter.h
+++ b/llvm/include/llvm/MC/MCMachObjectWriter.h
@@ -110,11 +110,8 @@ public:
 
   struct AddendsSizeAndOffset {
     uint64_t Value;
-    uint32_t Size;
+    uint8_t Size;
     uint32_t Offset;
-    uint32_t FullSizeInBytes;
-    uint32_t RefKind;
-    bool TargetKindIsFixupAarch64Movw;
   };
 
 private:
@@ -280,11 +277,9 @@ public:
     Relocations[F->getParent()].push_back(P);
   }
 
-  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Size,
-                 uint32_t Offset, uint32_t FullSizeInBytes, uint32_t RefKind,
-                 bool TargetKindIsFixupAarch64Movw) override {
-    Addends[Fragment].push_back({Addend, Size, Offset, FullSizeInBytes, RefKind,
-                                 TargetKindIsFixupAarch64Movw});
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint8_t Size,
+                 uint32_t Offset) override {
+    Addends[Fragment].push_back({Addend, Size, Offset});
     return true;
   }
 

--- a/llvm/include/llvm/MC/MCMachObjectWriter.h
+++ b/llvm/include/llvm/MC/MCMachObjectWriter.h
@@ -110,8 +110,8 @@ public:
 
   struct AddendsSizeAndOffset {
     uint64_t Value;
-    uint8_t Size;
     uint32_t Offset;
+    uint8_t Size;
   };
 
 private:
@@ -191,16 +191,6 @@ public:
     return CPUType == MachO::CPU_TYPE_X86_64;
   }
 
-  bool isI386() const {
-    uint32_t CPUType = TargetObjectWriter->getCPUType();
-    return CPUType == MachO::CPU_TYPE_I386;
-  }
-
-  bool isAArch64() const {
-    uint32_t CPUType = TargetObjectWriter->getCPUType();
-    return CPUType == MachO::CPU_TYPE_ARM64;
-  }
-
   /// @}
 
   void writeHeader(MachO::HeaderFileType Type, unsigned NumLoadCommands,
@@ -277,9 +267,9 @@ public:
     Relocations[F->getParent()].push_back(P);
   }
 
-  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint8_t Size,
-                 uint32_t Offset) override {
-    Addends[Fragment].push_back({Addend, Size, Offset});
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Offset,
+                 uint8_t Size) override {
+    Addends[Fragment].push_back({Addend, Offset, Size});
     return true;
   }
 
@@ -317,7 +307,7 @@ public:
   // FIXME: Break down writeObject into following stages for slicing the output.
   // This is a very rough slicing and need to be improved.
   void applyAddends(MCAssembler &Asm, const MCAsmLayout &Layout);
-  void applyAddendsHelper(MutableArrayRef<char> &Contents,
+  void applyAddendsHelper(MutableArrayRef<char> Contents,
                           const MCFragment *Fragment);
   void prepareObject(MCAssembler &Asm, const MCAsmLayout &Layout);
   void writeMachOHeader(MCAssembler &Asm, const MCAsmLayout &Layout);

--- a/llvm/include/llvm/MC/MCObjectWriter.h
+++ b/llvm/include/llvm/MC/MCObjectWriter.h
@@ -113,9 +113,7 @@ public:
   virtual uint64_t writeObject(MCAssembler &Asm, const MCAsmLayout &Layout) = 0;
 
   virtual bool addAddend(const MCFragment *Fragment, uint64_t Addend,
-                         uint32_t Size, uint32_t Offset,
-                         uint32_t FullSizeInBytes, uint32_t RefKind,
-                         bool TargetKindIsFixupAarch64Movw) = 0;
+                         uint8_t Size, uint32_t Offset) = 0;
 
   /// @}
 };

--- a/llvm/include/llvm/MC/MCObjectWriter.h
+++ b/llvm/include/llvm/MC/MCObjectWriter.h
@@ -112,8 +112,11 @@ public:
   /// generated.
   virtual uint64_t writeObject(MCAssembler &Asm, const MCAsmLayout &Layout) = 0;
 
+  /// Copy the Addend Value, Offset in the fragment, and size into the
+  /// objectwriter if it is a MachOCASWriter or a MachObjectWriter otherwise
+  /// return false.
   virtual bool addAddend(const MCFragment *Fragment, uint64_t Addend,
-                         uint8_t Size, uint32_t Offset) = 0;
+                         uint32_t Offset, uint8_t Size) = 0;
 
   /// @}
 };

--- a/llvm/include/llvm/MC/MCObjectWriter.h
+++ b/llvm/include/llvm/MC/MCObjectWriter.h
@@ -112,6 +112,11 @@ public:
   /// generated.
   virtual uint64_t writeObject(MCAssembler &Asm, const MCAsmLayout &Layout) = 0;
 
+  virtual bool addAddend(const MCFragment *Fragment, uint64_t Addend,
+                         uint32_t Size, uint32_t Offset,
+                         uint32_t FullSizeInBytes, uint32_t RefKind,
+                         bool TargetKindIsFixupAarch64Movw) = 0;
+
   /// @}
 };
 

--- a/llvm/lib/MC/ELFObjectWriter.cpp
+++ b/llvm/lib/MC/ELFObjectWriter.cpp
@@ -261,8 +261,8 @@ public:
   void markGnuAbi() override { SeenGnuAbi = true; }
   bool seenGnuAbi() const { return SeenGnuAbi; }
 
-  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint8_t Size,
-                 uint32_t Offset) override {
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Offset,
+                 uint8_t Size) override {
     return false;
   }
 

--- a/llvm/lib/MC/ELFObjectWriter.cpp
+++ b/llvm/lib/MC/ELFObjectWriter.cpp
@@ -261,9 +261,8 @@ public:
   void markGnuAbi() override { SeenGnuAbi = true; }
   bool seenGnuAbi() const { return SeenGnuAbi; }
 
-  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Size,
-                 uint32_t Offset, uint32_t FulleSizeInBytes, uint32_t RefKind,
-                 bool TargetKindIsFixupAarch64Movw) override {
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint8_t Size,
+                 uint32_t Offset) override {
     return false;
   }
 

--- a/llvm/lib/MC/ELFObjectWriter.cpp
+++ b/llvm/lib/MC/ELFObjectWriter.cpp
@@ -261,6 +261,12 @@ public:
   void markGnuAbi() override { SeenGnuAbi = true; }
   bool seenGnuAbi() const { return SeenGnuAbi; }
 
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Size,
+                 uint32_t Offset, uint32_t FulleSizeInBytes, uint32_t RefKind,
+                 bool TargetKindIsFixupAarch64Movw) override {
+    return false;
+  }
+
   friend struct ELFWriter;
 };
 

--- a/llvm/lib/MC/MCAssembler.cpp
+++ b/llvm/lib/MC/MCAssembler.cpp
@@ -926,7 +926,7 @@ void MCAssembler::layout(MCAsmLayout &Layout) {
         std::tie(Target, FixedValue, IsResolved) =
             handleFixup(Layout, Frag, Fixup);
         getBackend().applyFixup(*this, Fixup, Target, Contents, FixedValue,
-                                IsResolved, STI);
+                                IsResolved, STI, &Frag);
       }
     }
   }

--- a/llvm/lib/MC/MCCASObjectV1.cpp
+++ b/llvm/lib/MC/MCCASObjectV1.cpp
@@ -294,8 +294,8 @@ static void writeRelocationsAndAddends(
   writeVBR8(Addends.size(), Data);
   for (unsigned I = 0; I < Addends.size(); I++) {
     writeVBR8(Addends[I].Value, Data);
-    writeVBR8(Addends[I].Size, Data);
     writeVBR8(Addends[I].Offset, Data);
+    writeVBR8(Addends[I].Size, Data);
   }
 }
 
@@ -317,9 +317,9 @@ static Error decodeRelocationsAndAddends(MCCASReader &Reader, StringRef Data) {
   for (unsigned I = 0; I < Size; I++) {
     if (auto E = consumeVBR8(Data, Add.Value))
       return E;
-    if (auto E = consumeVBR8(Data, Add.Size))
-      return E;
     if (auto E = consumeVBR8(Data, Add.Offset))
+      return E;
+    if (auto E = consumeVBR8(Data, Add.Size))
       return E;
     Reader.Addends.push_back(Add);
   }
@@ -1498,8 +1498,9 @@ static void createAddendVector(
   // offset in that section.
   for (auto Addend : Source)
     Dest.push_back(
-        {Addend.Value, Addend.Size,
-         static_cast<uint32_t>(Addend.Offset + Layout.getFragmentOffset(F))});
+        {Addend.Value,
+         static_cast<uint32_t>(Addend.Offset + Layout.getFragmentOffset(F)),
+         Addend.Size});
 }
 
 Error MCCASBuilder::buildFragments() {

--- a/llvm/lib/MC/MCDXContainerWriter.cpp
+++ b/llvm/lib/MC/MCDXContainerWriter.cpp
@@ -43,6 +43,12 @@ private:
                                 const MCAsmLayout &Layout) override {}
 
   uint64_t writeObject(MCAssembler &Asm, const MCAsmLayout &Layout) override;
+
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Size,
+                 uint32_t Offset, uint32_t FulleSizeInBytes, uint32_t RefKind,
+                 bool TargetKindIsFixupAarch64Movw) override {
+    return false;
+  }
 };
 } // namespace
 

--- a/llvm/lib/MC/MCDXContainerWriter.cpp
+++ b/llvm/lib/MC/MCDXContainerWriter.cpp
@@ -44,9 +44,8 @@ private:
 
   uint64_t writeObject(MCAssembler &Asm, const MCAsmLayout &Layout) override;
 
-  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Size,
-                 uint32_t Offset, uint32_t FulleSizeInBytes, uint32_t RefKind,
-                 bool TargetKindIsFixupAarch64Movw) override {
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint8_t Size,
+                 uint32_t Offset) override {
     return false;
   }
 };

--- a/llvm/lib/MC/MCDXContainerWriter.cpp
+++ b/llvm/lib/MC/MCDXContainerWriter.cpp
@@ -44,8 +44,8 @@ private:
 
   uint64_t writeObject(MCAssembler &Asm, const MCAsmLayout &Layout) override;
 
-  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint8_t Size,
-                 uint32_t Offset) override {
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Offset,
+                 uint8_t Size) override {
     return false;
   }
 };

--- a/llvm/lib/MC/MachObjectWriter.cpp
+++ b/llvm/lib/MC/MachObjectWriter.cpp
@@ -1159,31 +1159,8 @@ void MachObjectWriter::applyAddends(MCAssembler &Asm,
 void MachObjectWriter::applyAddendsHelper(MutableArrayRef<char> &Contents,
                                           const MCFragment *Fragment) {
   for (auto ASO : Addends[Fragment]) {
-    for (unsigned I = 0; I != ASO.Size; ++I) {
-      if (!ASO.FullSizeInBytes) {
-        // Handle as little endian
-        if (isX86_64() || isI386())
-          Contents[ASO.Offset + I] = uint8_t(ASO.Value >> (I * 8));
-        else
-          Contents[ASO.Offset + I] |= uint8_t((ASO.Value >> (I * 8)) & 0xff);
-      } else {
-        // Handle as big endian
-        assert((ASO.Offset + ASO.FullSizeInBytes) <= Contents.size() &&
-               "Invalid fixup size!");
-        assert(ASO.Size <= ASO.FullSizeInBytes && "Invalid fixup size!");
-        unsigned Idx = ASO.FullSizeInBytes - 1 - I;
-        Contents[ASO.Offset + Idx] |= uint8_t((ASO.Value >> (I * 8)) & 0xff);
-      }
-    }
-    if (isAArch64()) {
-      if ((ASO.RefKind & 0x00f) == 0x002 /*VariantKind::VK_SABS*/ ||
-          (!ASO.RefKind && ASO.TargetKindIsFixupAarch64Movw)) {
-        if (static_cast<int64_t>(ASO.Value) < 0)
-          Contents[ASO.Offset + 3] &= ~(1 << 6);
-        else
-          Contents[ASO.Offset + 3] |= (1 << 6);
-      }
-    }
+    for (unsigned I = 0; I != ASO.Size; ++I)
+      Contents[ASO.Offset + I] = uint8_t(ASO.Value >> (I * 8));
   }
 }
 

--- a/llvm/lib/MC/MachObjectWriter.cpp
+++ b/llvm/lib/MC/MachObjectWriter.cpp
@@ -1107,56 +1107,56 @@ void MachObjectWriter::applyAddends(MCAssembler &Asm,
                                     const MCAsmLayout &Layout) {
   for (MCSection &Sec : Asm) {
     for (MCFragment &F : Sec) {
+      MutableArrayRef<char> Contents;
       switch (F.getKind()) {
-      default:
+      case MCFragment::FT_Align:
+      case MCFragment::FT_CompactEncodedInst:
+      case MCFragment::FT_Fill:
+      case MCFragment::FT_Nops:
+      case MCFragment::FT_Org:
+      case MCFragment::FT_LEB:
+      case MCFragment::FT_BoundaryAlign:
+      case MCFragment::FT_SymbolId:
+      case MCFragment::FT_CVInlineLines:
+      case MCFragment::FT_Dummy:
         continue;
 
       case MCFragment::FT_Data: {
-        MutableArrayRef<char> Contents = cast<MCDataFragment>(F).getContents();
-        applyAddendsHelper(Contents, &F);
+        Contents = cast<MCDataFragment>(F).getContents();
         break;
       }
 
       case MCFragment::FT_Relaxable: {
-        MutableArrayRef<char> Contents =
-            cast<MCRelaxableFragment>(F).getContents();
-        applyAddendsHelper(Contents, &F);
+        Contents = cast<MCRelaxableFragment>(F).getContents();
         break;
       }
 
       case MCFragment::FT_CVDefRange: {
-        MutableArrayRef<char> Contents =
-            cast<MCCVDefRangeFragment>(F).getContents();
-        applyAddendsHelper(Contents, &F);
+        Contents = cast<MCCVDefRangeFragment>(F).getContents();
         break;
       }
 
       case MCFragment::FT_Dwarf: {
-        MutableArrayRef<char> Contents =
-            cast<MCDwarfLineAddrFragment>(F).getContents();
-        applyAddendsHelper(Contents, &F);
+        Contents = cast<MCDwarfLineAddrFragment>(F).getContents();
         break;
       }
 
       case MCFragment::FT_DwarfFrame: {
-        MutableArrayRef<char> Contents =
-            cast<MCDwarfCallFrameFragment>(F).getContents();
-        applyAddendsHelper(Contents, &F);
+        Contents = cast<MCDwarfCallFrameFragment>(F).getContents();
         break;
       }
 
       case MCFragment::FT_PseudoProbe: {
-        MutableArrayRef<char> Contents =
-            cast<MCPseudoProbeAddrFragment>(F).getContents();
-        applyAddendsHelper(Contents, &F);
+        Contents = cast<MCPseudoProbeAddrFragment>(F).getContents();
         break;
       }
       }
+      applyAddendsHelper(Contents, &F);
     }
   }
 }
 
-void MachObjectWriter::applyAddendsHelper(MutableArrayRef<char> &Contents,
+void MachObjectWriter::applyAddendsHelper(MutableArrayRef<char> Contents,
                                           const MCFragment *Fragment) {
   for (auto ASO : Addends[Fragment]) {
     for (unsigned I = 0; I != ASO.Size; ++I)

--- a/llvm/lib/MC/SPIRVObjectWriter.cpp
+++ b/llvm/lib/MC/SPIRVObjectWriter.cpp
@@ -37,6 +37,12 @@ private:
 
   uint64_t writeObject(MCAssembler &Asm, const MCAsmLayout &Layout) override;
   void writeHeader(const MCAssembler &Asm);
+
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Size,
+                 uint32_t Offset, uint32_t FulleSizeInBytes, uint32_t RefKind,
+                 bool TargetKindIsFixupAarch64Movw) override {
+    return false;
+  }
 };
 
 void SPIRVObjectWriter::writeHeader(const MCAssembler &Asm) {

--- a/llvm/lib/MC/SPIRVObjectWriter.cpp
+++ b/llvm/lib/MC/SPIRVObjectWriter.cpp
@@ -38,9 +38,8 @@ private:
   uint64_t writeObject(MCAssembler &Asm, const MCAsmLayout &Layout) override;
   void writeHeader(const MCAssembler &Asm);
 
-  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Size,
-                 uint32_t Offset, uint32_t FulleSizeInBytes, uint32_t RefKind,
-                 bool TargetKindIsFixupAarch64Movw) override {
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint8_t Size,
+                 uint32_t Offset) override {
     return false;
   }
 };

--- a/llvm/lib/MC/SPIRVObjectWriter.cpp
+++ b/llvm/lib/MC/SPIRVObjectWriter.cpp
@@ -38,8 +38,8 @@ private:
   uint64_t writeObject(MCAssembler &Asm, const MCAsmLayout &Layout) override;
   void writeHeader(const MCAssembler &Asm);
 
-  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint8_t Size,
-                 uint32_t Offset) override {
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Offset,
+                 uint8_t Size) override {
     return false;
   }
 };

--- a/llvm/lib/MC/WasmObjectWriter.cpp
+++ b/llvm/lib/MC/WasmObjectWriter.cpp
@@ -361,6 +361,11 @@ private:
   uint32_t getTagType(const MCSymbolWasm &Symbol);
   void registerFunctionType(const MCSymbolWasm &Symbol);
   void registerTagType(const MCSymbolWasm &Symbol);
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Size,
+                 uint32_t Offset, uint32_t FulleSizeInBytes, uint32_t RefKind,
+                 bool TargetKindIsFixupAarch64Movw) override {
+    return false;
+  }
 };
 
 } // end anonymous namespace

--- a/llvm/lib/MC/WasmObjectWriter.cpp
+++ b/llvm/lib/MC/WasmObjectWriter.cpp
@@ -361,8 +361,8 @@ private:
   uint32_t getTagType(const MCSymbolWasm &Symbol);
   void registerFunctionType(const MCSymbolWasm &Symbol);
   void registerTagType(const MCSymbolWasm &Symbol);
-  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint8_t Size,
-                 uint32_t Offset) override {
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Offset,
+                 uint8_t Size) override {
     return false;
   }
 };

--- a/llvm/lib/MC/WasmObjectWriter.cpp
+++ b/llvm/lib/MC/WasmObjectWriter.cpp
@@ -361,9 +361,8 @@ private:
   uint32_t getTagType(const MCSymbolWasm &Symbol);
   void registerFunctionType(const MCSymbolWasm &Symbol);
   void registerTagType(const MCSymbolWasm &Symbol);
-  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Size,
-                 uint32_t Offset, uint32_t FulleSizeInBytes, uint32_t RefKind,
-                 bool TargetKindIsFixupAarch64Movw) override {
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint8_t Size,
+                 uint32_t Offset) override {
     return false;
   }
 };

--- a/llvm/lib/MC/WinCOFFObjectWriter.cpp
+++ b/llvm/lib/MC/WinCOFFObjectWriter.cpp
@@ -220,6 +220,12 @@ public:
   void assignFileOffsets(MCAssembler &Asm, const MCAsmLayout &Layout);
 
   uint64_t writeObject(MCAssembler &Asm, const MCAsmLayout &Layout) override;
+
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Size,
+                 uint32_t Offset, uint32_t FulleSizeInBytes, uint32_t RefKind,
+                 bool TargetKindIsFixupAarch64Movw) override {
+    return false;
+  }
 };
 
 } // end anonymous namespace

--- a/llvm/lib/MC/WinCOFFObjectWriter.cpp
+++ b/llvm/lib/MC/WinCOFFObjectWriter.cpp
@@ -221,8 +221,8 @@ public:
 
   uint64_t writeObject(MCAssembler &Asm, const MCAsmLayout &Layout) override;
 
-  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint8_t Size,
-                 uint32_t Offset) override {
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Offset,
+                 uint8_t Size) override {
     return false;
   }
 };

--- a/llvm/lib/MC/WinCOFFObjectWriter.cpp
+++ b/llvm/lib/MC/WinCOFFObjectWriter.cpp
@@ -221,9 +221,8 @@ public:
 
   uint64_t writeObject(MCAssembler &Asm, const MCAsmLayout &Layout) override;
 
-  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Size,
-                 uint32_t Offset, uint32_t FulleSizeInBytes, uint32_t RefKind,
-                 bool TargetKindIsFixupAarch64Movw) override {
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint8_t Size,
+                 uint32_t Offset) override {
     return false;
   }
 };

--- a/llvm/lib/MC/XCOFFObjectWriter.cpp
+++ b/llvm/lib/MC/XCOFFObjectWriter.cpp
@@ -322,6 +322,12 @@ public:
   void writeWord(uint64_t Word) {
     is64Bit() ? W.write<uint64_t>(Word) : W.write<uint32_t>(Word);
   }
+
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Size,
+                 uint32_t Offset, uint32_t FulleSizeInBytes, uint32_t RefKind,
+                 bool TargetKindIsFixupAarch64Movw) override {
+    return false;
+  }
 };
 
 XCOFFObjectWriter::XCOFFObjectWriter(

--- a/llvm/lib/MC/XCOFFObjectWriter.cpp
+++ b/llvm/lib/MC/XCOFFObjectWriter.cpp
@@ -323,9 +323,8 @@ public:
     is64Bit() ? W.write<uint64_t>(Word) : W.write<uint32_t>(Word);
   }
 
-  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Size,
-                 uint32_t Offset, uint32_t FulleSizeInBytes, uint32_t RefKind,
-                 bool TargetKindIsFixupAarch64Movw) override {
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint8_t Size,
+                 uint32_t Offset) override {
     return false;
   }
 };

--- a/llvm/lib/MC/XCOFFObjectWriter.cpp
+++ b/llvm/lib/MC/XCOFFObjectWriter.cpp
@@ -323,8 +323,8 @@ public:
     is64Bit() ? W.write<uint64_t>(Word) : W.write<uint32_t>(Word);
   }
 
-  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint8_t Size,
-                 uint32_t Offset) override {
+  bool addAddend(const MCFragment *Fragment, uint64_t Addend, uint32_t Offset,
+                 uint8_t Size) override {
     return false;
   }
 };

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AsmBackend.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AsmBackend.cpp
@@ -448,7 +448,7 @@ void AArch64AsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
   // will be applied later when the object file is being written out.
   if (!IsResolved) {
     std::memcpy(&Value, &Data[Offset], NumBytes);
-    if (Asm.getWriter().addAddend(Fragment, Value, NumBytes, Offset)) {
+    if (Asm.getWriter().addAddend(Fragment, Value, Offset, NumBytes)) {
       std::memset(&Data[Offset], 0, NumBytes);
     }
   }

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUAsmBackend.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUAsmBackend.cpp
@@ -34,8 +34,8 @@ public:
 
   void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                   const MCValue &Target, MutableArrayRef<char> Data,
-                  uint64_t Value, bool IsResolved,
-                  const MCSubtargetInfo *STI) const override;
+                  uint64_t Value, bool IsResolved, const MCSubtargetInfo *STI,
+                  const MCFragment *Fragment) const override;
   bool fixupNeedsRelaxation(const MCFixup &Fixup, uint64_t Value,
                             const MCRelaxableFragment *DF,
                             const MCAsmLayout &Layout) const override;
@@ -138,8 +138,8 @@ static uint64_t adjustFixupValue(const MCFixup &Fixup, uint64_t Value,
 void AMDGPUAsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                                   const MCValue &Target,
                                   MutableArrayRef<char> Data, uint64_t Value,
-                                  bool IsResolved,
-                                  const MCSubtargetInfo *STI) const {
+                                  bool IsResolved, const MCSubtargetInfo *STI,
+                                  const MCFragment *Fragment) const {
   if (Fixup.getKind() >= FirstLiteralRelocationKind)
     return;
 

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
@@ -1079,7 +1079,7 @@ void ARMAsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
   // will be applied later when the object file is being written out.
   if (!IsResolved) {
     std::memcpy(&Value, &Data[Offset], NumBytes);
-    if (Asm.getWriter().addAddend(Fragment, Value, NumBytes, Offset)) {
+    if (Asm.getWriter().addAddend(Fragment, Value, Offset, NumBytes)) {
       std::memset(&Data[Offset], 0, NumBytes);
     }
   }

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.h
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.h
@@ -45,8 +45,8 @@ public:
 
   void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                   const MCValue &Target, MutableArrayRef<char> Data,
-                  uint64_t Value, bool IsResolved,
-                  const MCSubtargetInfo *STI) const override;
+                  uint64_t Value, bool IsResolved, const MCSubtargetInfo *STI,
+                  const MCFragment *Fragment) const override;
 
   unsigned getRelaxedOpcode(unsigned Op, const MCSubtargetInfo &STI) const;
 

--- a/llvm/lib/Target/AVR/MCTargetDesc/AVRAsmBackend.cpp
+++ b/llvm/lib/Target/AVR/MCTargetDesc/AVRAsmBackend.cpp
@@ -364,8 +364,8 @@ AVRAsmBackend::createObjectTargetWriter() const {
 void AVRAsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                                const MCValue &Target,
                                MutableArrayRef<char> Data, uint64_t Value,
-                               bool IsResolved,
-                               const MCSubtargetInfo *STI) const {
+                               bool IsResolved, const MCSubtargetInfo *STI,
+                               const MCFragment *Fragment) const {
   adjustFixupValue(Fixup, Target, Value, &Asm.getContext());
   if (Value == 0)
     return; // Doesn't change encoding.

--- a/llvm/lib/Target/AVR/MCTargetDesc/AVRAsmBackend.h
+++ b/llvm/lib/Target/AVR/MCTargetDesc/AVRAsmBackend.h
@@ -39,8 +39,8 @@ public:
 
   void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                   const MCValue &Target, MutableArrayRef<char> Data,
-                  uint64_t Value, bool IsResolved,
-                  const MCSubtargetInfo *STI) const override;
+                  uint64_t Value, bool IsResolved, const MCSubtargetInfo *STI,
+                  const MCFragment *Fragment) const override;
 
   const MCFixupKindInfo &getFixupKindInfo(MCFixupKind Kind) const override;
 

--- a/llvm/lib/Target/BPF/MCTargetDesc/BPFAsmBackend.cpp
+++ b/llvm/lib/Target/BPF/MCTargetDesc/BPFAsmBackend.cpp
@@ -28,8 +28,8 @@ public:
 
   void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                   const MCValue &Target, MutableArrayRef<char> Data,
-                  uint64_t Value, bool IsResolved,
-                  const MCSubtargetInfo *STI) const override;
+                  uint64_t Value, bool IsResolved, const MCSubtargetInfo *STI,
+                  const MCFragment *Fragment) const override;
 
   std::unique_ptr<MCObjectTargetWriter>
   createObjectTargetWriter() const override;
@@ -63,8 +63,8 @@ bool BPFAsmBackend::writeNopData(raw_ostream &OS, uint64_t Count,
 void BPFAsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                                const MCValue &Target,
                                MutableArrayRef<char> Data, uint64_t Value,
-                               bool IsResolved,
-                               const MCSubtargetInfo *STI) const {
+                               bool IsResolved, const MCSubtargetInfo *STI,
+                               const MCFragment *Fragment) const {
   if (Fixup.getKind() == FK_SecRel_8) {
     // The Value is 0 for global variables, and the in-section offset
     // for static variables. Write to the immediate field of the inst.

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonAsmBackend.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonAsmBackend.cpp
@@ -415,7 +415,8 @@ public:
   void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                   const MCValue &Target, MutableArrayRef<char> Data,
                   uint64_t FixupValue, bool IsResolved,
-                  const MCSubtargetInfo *STI) const override {
+                  const MCSubtargetInfo *STI,
+                  const MCFragment *Fragment) const override {
 
     // When FixupValue is 0 the relocation is external and there
     // is nothing for us to do.

--- a/llvm/lib/Target/Lanai/MCTargetDesc/LanaiAsmBackend.cpp
+++ b/llvm/lib/Target/Lanai/MCTargetDesc/LanaiAsmBackend.cpp
@@ -50,8 +50,8 @@ public:
 
   void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                   const MCValue &Target, MutableArrayRef<char> Data,
-                  uint64_t Value, bool IsResolved,
-                  const MCSubtargetInfo *STI) const override;
+                  uint64_t Value, bool IsResolved, const MCSubtargetInfo *STI,
+                  const MCFragment *Fragment) const override;
 
   std::unique_ptr<MCObjectTargetWriter>
   createObjectTargetWriter() const override;
@@ -88,7 +88,8 @@ void LanaiAsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                                  const MCValue &Target,
                                  MutableArrayRef<char> Data, uint64_t Value,
                                  bool /*IsResolved*/,
-                                 const MCSubtargetInfo * /*STI*/) const {
+                                 const MCSubtargetInfo * /*STI*/,
+                                 const MCFragment *Fragment) const {
   MCFixupKind Kind = Fixup.getKind();
   Value = adjustFixupValue(static_cast<unsigned>(Kind), Value);
 

--- a/llvm/lib/Target/MSP430/MCTargetDesc/MSP430AsmBackend.cpp
+++ b/llvm/lib/Target/MSP430/MCTargetDesc/MSP430AsmBackend.cpp
@@ -39,8 +39,8 @@ public:
 
   void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                   const MCValue &Target, MutableArrayRef<char> Data,
-                  uint64_t Value, bool IsResolved,
-                  const MCSubtargetInfo *STI) const override;
+                  uint64_t Value, bool IsResolved, const MCSubtargetInfo *STI,
+                  const MCFragment *Fragment) const override;
 
   std::unique_ptr<MCObjectTargetWriter>
   createObjectTargetWriter() const override {
@@ -125,9 +125,9 @@ uint64_t MSP430AsmBackend::adjustFixupValue(const MCFixup &Fixup,
 
 void MSP430AsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                                   const MCValue &Target,
-                                  MutableArrayRef<char> Data,
-                                  uint64_t Value, bool IsResolved,
-                                  const MCSubtargetInfo *STI) const {
+                                  MutableArrayRef<char> Data, uint64_t Value,
+                                  bool IsResolved, const MCSubtargetInfo *STI,
+                                  const MCFragment *Fragment) const {
   Value = adjustFixupValue(Fixup, Value, Asm.getContext());
   MCFixupKindInfo Info = getFixupKindInfo(Fixup.getKind());
   if (!Value)

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsAsmBackend.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsAsmBackend.cpp
@@ -243,8 +243,8 @@ static unsigned calculateMMLEIndex(unsigned i) {
 void MipsAsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                                 const MCValue &Target,
                                 MutableArrayRef<char> Data, uint64_t Value,
-                                bool IsResolved,
-                                const MCSubtargetInfo *STI) const {
+                                bool IsResolved, const MCSubtargetInfo *STI,
+                                const MCFragment *Fragment) const {
   MCFixupKind Kind = Fixup.getKind();
   MCContext &Ctx = Asm.getContext();
   Value = adjustFixupValue(Fixup, Value, Ctx);

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsAsmBackend.h
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsAsmBackend.h
@@ -40,8 +40,8 @@ public:
 
   void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                   const MCValue &Target, MutableArrayRef<char> Data,
-                  uint64_t Value, bool IsResolved,
-                  const MCSubtargetInfo *STI) const override;
+                  uint64_t Value, bool IsResolved, const MCSubtargetInfo *STI,
+                  const MCFragment *Fragment) const override;
 
   Optional<MCFixupKind> getFixupKind(StringRef Name) const override;
   const MCFixupKindInfo &getFixupKindInfo(MCFixupKind Kind) const override;

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCAsmBackend.cpp
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCAsmBackend.cpp
@@ -138,8 +138,8 @@ public:
 
   void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                   const MCValue &Target, MutableArrayRef<char> Data,
-                  uint64_t Value, bool IsResolved,
-                  const MCSubtargetInfo *STI) const override {
+                  uint64_t Value, bool IsResolved, const MCSubtargetInfo *STI,
+                  const MCFragment *Fragment) const override {
     MCFixupKind Kind = Fixup.getKind();
     if (Kind >= FirstLiteralRelocationKind)
       return;

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
@@ -557,8 +557,8 @@ bool RISCVAsmBackend::evaluateTargetFixup(
 void RISCVAsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                                  const MCValue &Target,
                                  MutableArrayRef<char> Data, uint64_t Value,
-                                 bool IsResolved,
-                                 const MCSubtargetInfo *STI) const {
+                                 bool IsResolved, const MCSubtargetInfo *STI,
+                                 const MCFragment *Fragment) const {
   MCFixupKind Kind = Fixup.getKind();
   if (Kind >= FirstLiteralRelocationKind)
     return;

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.h
@@ -55,8 +55,8 @@ public:
 
   void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                   const MCValue &Target, MutableArrayRef<char> Data,
-                  uint64_t Value, bool IsResolved,
-                  const MCSubtargetInfo *STI) const override;
+                  uint64_t Value, bool IsResolved, const MCSubtargetInfo *STI,
+                  const MCFragment *Fragment) const override;
 
   std::unique_ptr<MCObjectTargetWriter>
   createObjectTargetWriter() const override;

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcAsmBackend.cpp
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcAsmBackend.cpp
@@ -340,8 +340,8 @@ namespace {
 
     void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                     const MCValue &Target, MutableArrayRef<char> Data,
-                    uint64_t Value, bool IsResolved,
-                    const MCSubtargetInfo *STI) const override {
+                    uint64_t Value, bool IsResolved, const MCSubtargetInfo *STI,
+                    const MCFragment *Fragment) const override {
 
       if (Fixup.getKind() >= FirstLiteralRelocationKind)
         return;

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmBackend.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmBackend.cpp
@@ -95,8 +95,8 @@ public:
                              const MCValue &Target) override;
   void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                   const MCValue &Target, MutableArrayRef<char> Data,
-                  uint64_t Value, bool IsResolved,
-                  const MCSubtargetInfo *STI) const override;
+                  uint64_t Value, bool IsResolved, const MCSubtargetInfo *STI,
+                  const MCFragment *Fragment) const override;
   bool fixupNeedsRelaxation(const MCFixup &Fixup, uint64_t Value,
                             const MCRelaxableFragment *Fragment,
                             const MCAsmLayout &Layout) const override {
@@ -158,12 +158,10 @@ bool SystemZMCAsmBackend::shouldForceRelocation(const MCAssembler &,
   return Fixup.getKind() >= FirstLiteralRelocationKind;
 }
 
-void SystemZMCAsmBackend::applyFixup(const MCAssembler &Asm,
-                                     const MCFixup &Fixup,
-                                     const MCValue &Target,
-                                     MutableArrayRef<char> Data, uint64_t Value,
-                                     bool IsResolved,
-                                     const MCSubtargetInfo *STI) const {
+void SystemZMCAsmBackend::applyFixup(
+    const MCAssembler &Asm, const MCFixup &Fixup, const MCValue &Target,
+    MutableArrayRef<char> Data, uint64_t Value, bool IsResolved,
+    const MCSubtargetInfo *STI, const MCFragment *Fragment) const {
   MCFixupKind Kind = Fixup.getKind();
   if (Kind >= FirstLiteralRelocationKind)
     return;

--- a/llvm/lib/Target/VE/MCTargetDesc/VEAsmBackend.cpp
+++ b/llvm/lib/Target/VE/MCTargetDesc/VEAsmBackend.cpp
@@ -189,8 +189,8 @@ public:
 
   void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                   const MCValue &Target, MutableArrayRef<char> Data,
-                  uint64_t Value, bool IsResolved,
-                  const MCSubtargetInfo *STI) const override {
+                  uint64_t Value, bool IsResolved, const MCSubtargetInfo *STI,
+                  const MCFragment *Fragment) const override {
     Value = adjustFixupValue(Fixup.getKind(), Value);
     if (!Value)
       return; // Doesn't change encoding.

--- a/llvm/lib/Target/WebAssembly/MCTargetDesc/WebAssemblyAsmBackend.cpp
+++ b/llvm/lib/Target/WebAssembly/MCTargetDesc/WebAssemblyAsmBackend.cpp
@@ -46,8 +46,8 @@ public:
 
   void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                   const MCValue &Target, MutableArrayRef<char> Data,
-                  uint64_t Value, bool IsPCRel,
-                  const MCSubtargetInfo *STI) const override;
+                  uint64_t Value, bool IsPCRel, const MCSubtargetInfo *STI,
+                  const MCFragment *Fragment) const override;
 
   std::unique_ptr<MCObjectTargetWriter>
   createObjectTargetWriter() const override;
@@ -92,12 +92,10 @@ bool WebAssemblyAsmBackend::writeNopData(raw_ostream &OS, uint64_t Count,
   return true;
 }
 
-void WebAssemblyAsmBackend::applyFixup(const MCAssembler &Asm,
-                                       const MCFixup &Fixup,
-                                       const MCValue &Target,
-                                       MutableArrayRef<char> Data,
-                                       uint64_t Value, bool IsPCRel,
-                                       const MCSubtargetInfo *STI) const {
+void WebAssemblyAsmBackend::applyFixup(
+    const MCAssembler &Asm, const MCFixup &Fixup, const MCValue &Target,
+    MutableArrayRef<char> Data, uint64_t Value, bool IsPCRel,
+    const MCSubtargetInfo *STI, const MCFragment *Fragment) const {
   const MCFixupKindInfo &Info = getFixupKindInfo(Fixup.getKind());
   assert(Info.Flags == 0 && "WebAssembly does not use MCFixupKindInfo flags");
 

--- a/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
@@ -177,8 +177,8 @@ public:
 
   void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                   const MCValue &Target, MutableArrayRef<char> Data,
-                  uint64_t Value, bool IsResolved,
-                  const MCSubtargetInfo *STI) const override;
+                  uint64_t Value, bool IsResolved, const MCSubtargetInfo *STI,
+                  const MCFragment *Fragment) const override;
 
   bool mayNeedRelaxation(const MCInst &Inst,
                          const MCSubtargetInfo &STI) const override;
@@ -689,9 +689,9 @@ static unsigned getFixupKindSize(unsigned Kind) {
 
 void X86AsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                                const MCValue &Target,
-                               MutableArrayRef<char> Data,
-                               uint64_t Value, bool IsResolved,
-                               const MCSubtargetInfo *STI) const {
+                               MutableArrayRef<char> Data, uint64_t Value,
+                               bool IsResolved, const MCSubtargetInfo *STI,
+                               const MCFragment *Fragment) const {
   unsigned Kind = Fixup.getKind();
   if (Kind >= FirstLiteralRelocationKind)
     return;

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MachObjectWriter.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MachObjectWriter.cpp
@@ -358,6 +358,9 @@ void X86MachObjectWriter::RecordX86_64Relocation(
   MRE.r_word1 = (Index << 0) | (IsPCRel << 24) | (Log2Size << 25) |
                 (IsExtern << 27) | (Type << 28);
   Writer->addRelocation(RelSymbol, Fragment, MRE);
+  Writer->addAddend(Fragment, FixedValue, (1 << Log2Size), Fixup.getOffset(), 0,
+                    0, 0);
+  FixedValue = 0;
 }
 
 bool X86MachObjectWriter::recordScatteredRelocation(MachObjectWriter *Writer,
@@ -597,6 +600,9 @@ void X86MachObjectWriter::RecordX86Relocation(MachObjectWriter *Writer,
   MRE.r_word1 =
       (Index << 0) | (IsPCRel << 24) | (Log2Size << 25) | (Type << 28);
   Writer->addRelocation(RelSymbol, Fragment, MRE);
+  Writer->addAddend(Fragment, FixedValue, (1 << Log2Size), Fixup.getOffset(), 0,
+                    0, 0);
+  FixedValue = 0;
 }
 
 std::unique_ptr<MCObjectTargetWriter>

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MachObjectWriter.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MachObjectWriter.cpp
@@ -358,8 +358,6 @@ void X86MachObjectWriter::RecordX86_64Relocation(
   MRE.r_word1 = (Index << 0) | (IsPCRel << 24) | (Log2Size << 25) |
                 (IsExtern << 27) | (Type << 28);
   Writer->addRelocation(RelSymbol, Fragment, MRE);
-  Writer->addAddend(Fragment, FixedValue, (1 << Log2Size), Fixup.getOffset());
-  FixedValue = 0;
 }
 
 bool X86MachObjectWriter::recordScatteredRelocation(MachObjectWriter *Writer,
@@ -599,8 +597,6 @@ void X86MachObjectWriter::RecordX86Relocation(MachObjectWriter *Writer,
   MRE.r_word1 =
       (Index << 0) | (IsPCRel << 24) | (Log2Size << 25) | (Type << 28);
   Writer->addRelocation(RelSymbol, Fragment, MRE);
-  Writer->addAddend(Fragment, FixedValue, (1 << Log2Size), Fixup.getOffset());
-  FixedValue = 0;
 }
 
 std::unique_ptr<MCObjectTargetWriter>

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MachObjectWriter.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MachObjectWriter.cpp
@@ -358,8 +358,7 @@ void X86MachObjectWriter::RecordX86_64Relocation(
   MRE.r_word1 = (Index << 0) | (IsPCRel << 24) | (Log2Size << 25) |
                 (IsExtern << 27) | (Type << 28);
   Writer->addRelocation(RelSymbol, Fragment, MRE);
-  Writer->addAddend(Fragment, FixedValue, (1 << Log2Size), Fixup.getOffset(), 0,
-                    0, 0);
+  Writer->addAddend(Fragment, FixedValue, (1 << Log2Size), Fixup.getOffset());
   FixedValue = 0;
 }
 
@@ -600,8 +599,7 @@ void X86MachObjectWriter::RecordX86Relocation(MachObjectWriter *Writer,
   MRE.r_word1 =
       (Index << 0) | (IsPCRel << 24) | (Log2Size << 25) | (Type << 28);
   Writer->addRelocation(RelSymbol, Fragment, MRE);
-  Writer->addAddend(Fragment, FixedValue, (1 << Log2Size), Fixup.getOffset(), 0,
-                    0, 0);
+  Writer->addAddend(Fragment, FixedValue, (1 << Log2Size), Fixup.getOffset());
   FixedValue = 0;
 }
 

--- a/llvm/test/DebugInfo/CAS/AArch64/debug_line_dedupe.test
+++ b/llvm/test/DebugInfo/CAS/AArch64/debug_line_dedupe.test
@@ -1,0 +1,96 @@
+RUN: rm -rf %t && mkdir -p %t
+RUN: split-file %s %t
+
+RUN: llc -O0 --filetype=obj --cas-backend --cas=%t/cas --mccas-casid %t/a.ll -o %t/a.id
+RUN: llc -O0 --filetype=obj --cas-backend --cas=%t/cas --mccas-casid %t/b.ll -o %t/b.id
+RUN: llvm-cas-dump --cas=%t/cas --casid-file %t/a.id %t/b.id | FileCheck %s
+
+CHECK: mc:debug_line   llvmcas://[[CASID:[a-z0-9]+]]
+CHECK-NEXT: mc:debug_line   llvmcas://
+
+CHECK: mc:debug_line   llvmcas:// 
+CHECK-NEXT: mc:debug_line   llvmcas://[[CASID]]
+CHECK-NEXT: mc:debug_line   llvmcas:// 
+
+//--- a.ll
+
+target triple = "arm64-apple-macosx12.0.0"
+define void @foo() #0 !dbg !9 {
+  ret void, !dbg !14
+}
+define i32 @bar(i32 noundef %x) #0 !dbg !15 {
+entry:
+  %x.addr = alloca i32, align 4
+  %0 = load i32, ptr %x.addr, align 4, !dbg !21
+  %add = add nsw i32 %0, 1, !dbg !22
+  ret i32 %add, !dbg !23
+}
+attributes #0 = { noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git d74d0d9fde90cccba7bf18066ac56e55e4402948)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
+!1 = !DIFile(filename: "a.c", directory: "/Users/shubham/Development/CASDelta")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"PIC Level", i32 2}
+!6 = !{i32 7, !"uwtable", i32 2}
+!7 = !{i32 7, !"frame-pointer", i32 2}
+!9 = distinct !DISubprogram(name: "foo", scope: !10, file: !10, line: 1, type: !11, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!10 = !DIFile(filename: "./foo.h", directory: "/Users/shubham/Development/CASDelta")
+!11 = !DISubroutineType(types: !12)
+!12 = !{null}
+!13 = !{}
+!14 = !DILocation(line: 2, column: 3, scope: !9)
+!15 = distinct !DISubprogram(name: "bar", scope: !1, file: !1, line: 2, type: !16, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!16 = !DISubroutineType(types: !17)
+!17 = !{!18, !18}
+!18 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!21 = !DILocation(line: 3, column: 10, scope: !15)
+!22 = !DILocation(line: 3, column: 11, scope: !15)
+!23 = !DILocation(line: 3, column: 3, scope: !15)
+
+//--- b.ll
+
+target triple = "arm64-apple-macosx12.0.0"
+define i32 @baz() #0 !dbg !9 {
+  ret i32 1, !dbg !14
+}
+define void @foo() #0 !dbg !15 {
+  ret void, !dbg !19
+}
+define i32 @bar(i32 noundef %x) #0 !dbg !20 {
+entry:
+  %x.addr = alloca i32, align 4
+  %0 = load i32, ptr %x.addr, align 4, !dbg !25
+  %add = add nsw i32 %0, 1, !dbg !26
+  ret i32 %add, !dbg !27
+}
+attributes #0 = { noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git d74d0d9fde90cccba7bf18066ac56e55e4402948)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
+!1 = !DIFile(filename: "b.c", directory: "/Users/shubham/Development/CASDelta")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"PIC Level", i32 2}
+!6 = !{i32 7, !"uwtable", i32 2}
+!7 = !{i32 7, !"frame-pointer", i32 2}
+!9 = distinct !DISubprogram(name: "baz", scope: !1, file: !1, line: 1, type: !10, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!10 = !DISubroutineType(types: !11)
+!11 = !{!12}
+!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!13 = !{}
+!14 = !DILocation(line: 2, column: 5, scope: !9)
+!15 = distinct !DISubprogram(name: "foo", scope: !16, file: !16, line: 1, type: !17, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!16 = !DIFile(filename: "./foo.h", directory: "/Users/shubham/Development/CASDelta")
+!17 = !DISubroutineType(types: !18)
+!18 = !{null}
+!19 = !DILocation(line: 2, column: 3, scope: !15)
+!20 = distinct !DISubprogram(name: "bar", scope: !1, file: !1, line: 6, type: !21, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
+!21 = !DISubroutineType(types: !22)
+!22 = !{!12, !12}
+!25 = !DILocation(line: 7, column: 10, scope: !20)
+!26 = !DILocation(line: 7, column: 11, scope: !20)
+!27 = !DILocation(line: 7, column: 3, scope: !20)

--- a/llvm/test/DebugInfo/CAS/AArch64/debug_line_dedupe.test
+++ b/llvm/test/DebugInfo/CAS/AArch64/debug_line_dedupe.test
@@ -18,12 +18,8 @@ target triple = "arm64-apple-macosx12.0.0"
 define void @foo() #0 !dbg !9 {
   ret void, !dbg !14
 }
-define i32 @bar(i32 noundef %x) #0 !dbg !15 {
-entry:
-  %x.addr = alloca i32, align 4
-  %0 = load i32, ptr %x.addr, align 4, !dbg !21
-  %add = add nsw i32 %0, 1, !dbg !22
-  ret i32 %add, !dbg !23
+define void @bar(i32 noundef %x) #0 !dbg !15 {
+  ret void, !dbg !23
 }
 attributes #0 = { noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
 !llvm.dbg.cu = !{!0}
@@ -46,8 +42,6 @@ attributes #0 = { noinline nounwind optnone ssp uwtable "frame-pointer"="all" "m
 !16 = !DISubroutineType(types: !17)
 !17 = !{!18, !18}
 !18 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-!21 = !DILocation(line: 3, column: 10, scope: !15)
-!22 = !DILocation(line: 3, column: 11, scope: !15)
 !23 = !DILocation(line: 3, column: 3, scope: !15)
 
 //--- b.ll
@@ -59,12 +53,9 @@ define i32 @baz() #0 !dbg !9 {
 define void @foo() #0 !dbg !15 {
   ret void, !dbg !19
 }
-define i32 @bar(i32 noundef %x) #0 !dbg !20 {
+define void @bar(i32 noundef %x) #0 !dbg !20 {
 entry:
-  %x.addr = alloca i32, align 4
-  %0 = load i32, ptr %x.addr, align 4, !dbg !25
-  %add = add nsw i32 %0, 1, !dbg !26
-  ret i32 %add, !dbg !27
+ret void, !dbg !27
 }
 attributes #0 = { noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
 !llvm.dbg.cu = !{!0}

--- a/llvm/test/DebugInfo/CAS/AArch64/test_relocation_zero.ll
+++ b/llvm/test/DebugInfo/CAS/AArch64/test_relocation_zero.ll
@@ -1,0 +1,64 @@
+;RUN: llc -O0 --filetype=obj --cas-backend  --cas=%t/cas  --mccas-casid %s -o %t/test.id
+;RUN: llvm-cas-dump --cas=%t/cas --casid-file %t/test.id --hex-dump | FileCheck %s
+
+;CHECK: mc:debug_info_cu llvmcas://{{[0-9a-z]+}}
+;CHECK-NEXT: 0x3c 0x00 0x00 0x00 0x04 0x00 0x00 0x00
+;CHECK-NEXT: 0x00 0x00 0x08 0x01 0x00 0x00 0x00 0x00
+;CHECK-NEXT: 0x0c 0x00 0x6a 0x00 0x00 0x00 0x00 0x00
+;CHECK-NEXT: 0x00 0x00 0x93 0x00 0x00 0x00 0x00 0x00
+;CHECK-NEXT: 0x00 0x00 0x00 0x00 0x00 0x00 0x04 0x00
+;CHECK-NEXT: 0x00 0x00 0x02 0x00 0x00 0x00 0x00 0x00
+;CHECK-NEXT: 0x00 0x00 0x00 0x04 0x00 0x00 0x00 0x01
+;CHECK-NEXT: 0x6f 0xb8 0x00 0x00 0x00 0x01 0x01 0x00
+;CHECK-NEXT: mc:debug_info_cu llvmcas://{{[0-9a-z]+}} 
+;CHECK-NEXT: 0x56 0x00 0x00 0x00 0x04 0x00 0x00 0x00
+;CHECK-NEXT: 0x00 0x00 0x08 0x01 0x00 0x00 0x00 0x00
+;CHECK-NEXT: 0x0c 0x00 0x6a 0x00 0x00 0x00 0x3c 0x00
+;CHECK-NEXT: 0x00 0x00 0x93 0x00 0x00 0x00 0x00 0x00
+;CHECK-NEXT: 0x00 0x00 0x00 0x00 0x00 0x00 0x18 0x00
+;CHECK-NEXT: 0x00 0x00 0x02 0x00 0x00 0x00 0x00 0x00
+;CHECK-NEXT: 0x00 0x00 0x00 0x18 0x00 0x00 0x00 0x01
+;CHECK-NEXT: 0x6f 0xbc 0x00 0x00 0x00 0x01 0x02 0x52
+;CHECK-NEXT: 0x00 0x00 0x00 0x03 0x02 0x91 0x0c 0xc4
+;CHECK-NEXT: 0x00 0x00 0x00 0x01 0x02 0x52 0x00 0x00
+;CHECK-NEXT: 0x00 0x00 0x04 0xc0 0x00 0x00 0x00 0x05
+;CHECK-NEXT: 0x04 0x00
+
+define void @foo() #0 !dbg !9 {
+  ret void, !dbg !14
+}
+define i32 @bar(i32 noundef %x) #0 !dbg !15 {
+entry:
+  %x.addr = alloca i32, align 4
+  store i32 %x, ptr %x.addr, align 4
+  call void @llvm.dbg.declare(metadata ptr %x.addr, metadata !20, metadata !DIExpression()), !dbg !21
+  %0 = load i32, ptr %x.addr, align 4, !dbg !22
+  %add = add nsw i32 %0, 1, !dbg !23
+  ret i32 %add, !dbg !24
+}
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !7}
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git 24ab32497e30b8510454973371365693ccdbc718)",
+ emissionKind: FullDebug, casFriendly: DebugAbbrev)
+!1 = !DIFile(filename: "/Users/shubham/Development/testclang/a.c", directory: "/Users/shubham/Development/testclang")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 8, i32 2}
+!7 = !{i32 7, !"frame-pointer", i32 1}
+!9 = distinct !DISubprogram(name: "foo", file: !10, line: 1, type: !11, unit: !0, retainedNodes: !13)
+!10 = !DIFile(filename: "foo.h", directory: "/Users/shubham/Development/testclang")
+!11 = !DISubroutineType(types: !12)
+!12 = !{null}
+!13 = !{}
+!14 = !DILocation(line: 2, column: 3, scope: !9)
+!15 = distinct !DISubprogram(name: "bar", file: !16, line: 2, type: !17, unit: !0, retainedNodes: !13)
+!16 = !DIFile(filename: "a.c", directory: "/Users/shubham/Development/testclang")
+!17 = !DISubroutineType(types: !18)
+!18 = !{!19, !19}
+!19 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!20 = !DILocalVariable(name: "x", scope: !15, file: !16, line: 2, type: !19)
+!21 = !DILocation(line: 2, scope: !15)
+!22 = !DILocation(line: 3, scope: !15)
+!23 = !DILocation(line: 3, scope: !15)
+!24 = !DILocation(line: 3, scope: !15)

--- a/llvm/test/DebugInfo/CAS/AArch64/test_relocation_zero.ll
+++ b/llvm/test/DebugInfo/CAS/AArch64/test_relocation_zero.ll
@@ -1,64 +1,35 @@
 ;RUN: llc -O0 --filetype=obj --cas-backend  --cas=%t/cas  --mccas-casid %s -o %t/test.id
-;RUN: llvm-cas-dump --cas=%t/cas --casid-file %t/test.id --hex-dump | FileCheck %s
+;RUN: llvm-cas-dump --cas=%t/cas --casid-file %t/test.id --hex-dump --hex-dump-one-line | FileCheck %s
+
+; This file checks to see if relocation addends are zero-ed out correctly in the CAS. The offset's 30, 43, 94, and 107 should all have 8 0x00 bytes.
 
 ;CHECK: mc:debug_info_cu llvmcas://{{[0-9a-z]+}}
-;CHECK-NEXT: 0x3c 0x00 0x00 0x00 0x04 0x00 0x00 0x00
-;CHECK-NEXT: 0x00 0x00 0x08 0x01 0x00 0x00 0x00 0x00
-;CHECK-NEXT: 0x0c 0x00 0x6a 0x00 0x00 0x00 0x00 0x00
-;CHECK-NEXT: 0x00 0x00 0x93 0x00 0x00 0x00 0x00 0x00
-;CHECK-NEXT: 0x00 0x00 0x00 0x00 0x00 0x00 0x04 0x00
-;CHECK-NEXT: 0x00 0x00 0x02 0x00 0x00 0x00 0x00 0x00
-;CHECK-NEXT: 0x00 0x00 0x00 0x04 0x00 0x00 0x00 0x01
-;CHECK-NEXT: 0x6f 0xb8 0x00 0x00 0x00 0x01 0x01 0x00
-;CHECK-NEXT: mc:debug_info_cu llvmcas://{{[0-9a-z]+}} 
-;CHECK-NEXT: 0x56 0x00 0x00 0x00 0x04 0x00 0x00 0x00
-;CHECK-NEXT: 0x00 0x00 0x08 0x01 0x00 0x00 0x00 0x00
-;CHECK-NEXT: 0x0c 0x00 0x6a 0x00 0x00 0x00 0x3c 0x00
-;CHECK-NEXT: 0x00 0x00 0x93 0x00 0x00 0x00 0x00 0x00
-;CHECK-NEXT: 0x00 0x00 0x00 0x00 0x00 0x00 0x18 0x00
-;CHECK-NEXT: 0x00 0x00 0x02 0x00 0x00 0x00 0x00 0x00
-;CHECK-NEXT: 0x00 0x00 0x00 0x18 0x00 0x00 0x00 0x01
-;CHECK-NEXT: 0x6f 0xbc 0x00 0x00 0x00 0x01 0x02 0x52
-;CHECK-NEXT: 0x00 0x00 0x00 0x03 0x02 0x91 0x0c 0xc4
-;CHECK-NEXT: 0x00 0x00 0x00 0x01 0x02 0x52 0x00 0x00
-;CHECK-NEXT: 0x00 0x00 0x04 0xc0 0x00 0x00 0x00 0x05
-;CHECK-NEXT: 0x04 0x00
+;CHECK-NEXT: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+;CHECK-SAME: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+;CHECK-NEXT: mc:debug_info_cu llvmcas://{{[0-9a-z]+}}
+;CHECK-NEXT: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+;CHECK-SAME: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
 
-define void @foo() #0 !dbg !9 {
-  ret void, !dbg !14
+target triple = "arm64-apple-macosx12.0.0"
+
+define void @foo(i32 noundef %x) #0 !dbg !9 {
+  ret void, !dbg !16
 }
-define i32 @bar(i32 noundef %x) #0 !dbg !15 {
-entry:
-  %x.addr = alloca i32, align 4
-  store i32 %x, ptr %x.addr, align 4
-  call void @llvm.dbg.declare(metadata ptr %x.addr, metadata !20, metadata !DIExpression()), !dbg !21
-  %0 = load i32, ptr %x.addr, align 4, !dbg !22
-  %add = add nsw i32 %0, 1, !dbg !23
-  ret i32 %add, !dbg !24
+define void @bar(i32 noundef %x) #0 !dbg !17 {
+  ret void, !dbg !20
 }
-declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!2, !3, !7}
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git 24ab32497e30b8510454973371365693ccdbc718)",
- emissionKind: FullDebug, casFriendly: DebugAbbrev)
-!1 = !DIFile(filename: "/Users/shubham/Development/testclang/a.c", directory: "/Users/shubham/Development/testclang")
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git 4a36109b6b7cbe6f88be348fc0073875b19636ed)", emissionKind: FullDebug, casFriendly: DebugAbbrev)
+!1 = !DIFile(filename: "c.c", directory: "/Users/shubham/Development/testclang")
 !2 = !{i32 7, !"Dwarf Version", i32 4}
 !3 = !{i32 2, !"Debug Info Version", i32 3}
-!5 = !{i32 8, i32 2}
 !7 = !{i32 7, !"frame-pointer", i32 1}
-!9 = distinct !DISubprogram(name: "foo", file: !10, line: 1, type: !11, unit: !0, retainedNodes: !13)
-!10 = !DIFile(filename: "foo.h", directory: "/Users/shubham/Development/testclang")
-!11 = !DISubroutineType(types: !12)
-!12 = !{null}
+!9 = distinct !DISubprogram(name: "foo", file: !1, line: 1, type: !10, unit: !0, retainedNodes: !13)
+!10 = !DISubroutineType(types: !11)
+!11 = !{null, !12}
+!12 = !DIBasicType(name: "int", encoding: DW_ATE_signed)
 !13 = !{}
-!14 = !DILocation(line: 2, column: 3, scope: !9)
-!15 = distinct !DISubprogram(name: "bar", file: !16, line: 2, type: !17, unit: !0, retainedNodes: !13)
-!16 = !DIFile(filename: "a.c", directory: "/Users/shubham/Development/testclang")
-!17 = !DISubroutineType(types: !18)
-!18 = !{!19, !19}
-!19 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-!20 = !DILocalVariable(name: "x", scope: !15, file: !16, line: 2, type: !19)
-!21 = !DILocation(line: 2, scope: !15)
-!22 = !DILocation(line: 3, scope: !15)
-!23 = !DILocation(line: 3, scope: !15)
-!24 = !DILocation(line: 3, scope: !15)
+!16 = !DILocation(line: 2, column: 3, scope: !9)
+!17 = distinct !DISubprogram(name: "bar", file: !1, line: 4, type: !10, unit: !0, retainedNodes: !13)
+!20 = !DILocation(line: 5, scope: !17)


### PR DESCRIPTION
Relocation addends pose as an obstacle to achieve deduplication within the CAS. To fix this, zero-out the relocation addend and store the addend fixup within the MachObjectWriter, then reapply the addends per fragment when the object file is written out, if the MCCAS backend is being used, store the addends within either the AtomRef or SectionRef and then reapply the addends per section when the object file is written out.