### PR TITLE
[lldb/Symbol] Fix null-deref in TypeList::Dump

### DIFF
--- a/lldb/source/Symbol/TypeList.cpp
+++ b/lldb/source/Symbol/TypeList.cpp
@@ -92,9 +92,9 @@ void TypeList::ForEach(
 }
 
 void TypeList::Dump(Stream *s, bool show_context) {
-  for (iterator pos = m_types.begin(), end = m_types.end(); pos != end; ++pos) {
-    pos->get()->Dump(s, show_context);
-  }
+  for (iterator pos = m_types.begin(), end = m_types.end(); pos != end; ++pos)
+    if (Type *t = pos->get())
+      t->Dump(s, show_context);
 }
 
 void TypeList::RemoveMismatchedTypes(const char *qualified_typename,


### PR DESCRIPTION
This patch should fix a crash caused by a null pointer dereferencing
when dumping a type. It makes sure that the pointer is valid.

rdar://97455134

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>