### PR TITLE
[lldb] Support non-pointer implicit this/self in GetValueForVariableExpressionPath

### DIFF
--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -552,7 +552,7 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
 
   if (!var_sp && (options & eExpressionPathOptionsAllowDirectIVarAccess)) {
     // Check for direct ivars access which helps us with implicit access to
-    // ivars with the "this->" or "self->"
+    // ivars using "this" or "self".
     GetSymbolContext(eSymbolContextFunction | eSymbolContextBlock);
     lldb::LanguageType method_language = eLanguageTypeUnknown;
     bool is_instance_method = false;
@@ -563,7 +563,13 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
         var_sp = variable_list->FindVariable(method_object_name);
         if (var_sp) {
           separator_idx = 0;
-          var_expr_storage = "->";
+          if (Type *var_type = var_sp->GetType())
+            if (auto compiler_type = var_type->GetForwardCompilerType())
+              if (!compiler_type.IsPointerType())
+                var_expr_storage = ".";
+
+          if (var_expr_storage.empty())
+            var_expr_storage = "->";
           var_expr_storage += var_expr;
           var_expr = var_expr_storage;
           synthetically_added_instance_object = true;


### PR DESCRIPTION
The `frame variable` command supports an implicit `this`/`self`, allowing a
user to run `v some_field` instead of `v this->some_field`. However, some
languages have non-pointer `this`/`self` types (for example, Swift).

This change adds support for non-pointer implicit `this`/`self`. This is done
by consulting the type of the instance variable. If the type is known to be
non-pointer, the dot operator is used instead of the arrow operator.

The C language of families each have a pointer instance type, which makes
testing of this difficult. Tests for this feature will be done in the Swift
downstream fork, as Swift's `self` is a non-pointer (reference) type.

rdar://82095148

Reviewed By: aprantl

Differential Revision: https://reviews.llvm.org/D127605

(cherry picked from commit e30c493894c410825ad7467f4996aca7f613ce81)
