### PR TITLE
[include-tree] Enable producing an `include-tree` via a driver invocation and replaying it for compilation

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -667,6 +667,9 @@ def warn_drv_fjmc_for_elf_only : Warning<
 def err_drv_target_variant_invalid : Error<
   "unsupported '%0' value '%1'; use 'ios-macabi' instead">;
 
+def err_drv_inputs_and_include_tree : Error<
+  "passing input files is incompatible with '-fcas-include-tree'">;
+
 def err_drv_invalid_directx_shader_module : Error<
   "invalid profile : %0">;
 def err_drv_dxc_missing_target_profile : Error<

--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -129,6 +129,11 @@ def warn_fe_concepts_ts_flag : Warning<
   "-fconcepts-ts is deprecated - use '-std=c++20' for Concepts support">,
   InGroup<Deprecated>;
 
+def err_fe_unable_to_load_include_tree : Error<
+  "unable to load the CAS include-tree '%0': '%1'">;
+def err_unable_to_load_include_tree_node : Error<
+  "unable to load a node from the CAS include-tree: '%0'">;
+
 def err_fe_unable_to_load_basic_block_sections_file : Error<
     "unable to load basic block sections function list: '%0'">;
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6453,6 +6453,9 @@ def fdepscan_daemon_EQ : Joined<["-"], "fdepscan-daemon=">, Group<f_Group>,
              " daemon specified, rather than try to spawn its own based on"
              " parent processes.">;
 
+def fdepscan_include_tree : Flag<["-"], "fdepscan-include-tree">,
+    Group<f_Group>, HelpText<"Set dep-scanner to produce the include tree">;
+
 // CAS prefix map options.
 //
 // FIXME: Add DepscanOption flag.
@@ -6510,6 +6513,11 @@ def fcas_fs_working_directory : Separate<["-"], "fcas-fs-working-directory">,
     HelpText<"Working directory for -fcas-fs (if not the root).">,
     ShouldParseIf<!strconcat("!", fcas_fs.KeyPath, ".empty()")>,
     MarshallingInfoString<FileSystemOpts<"CASFileSystemWorkingDirectory">>;
+
+def fcas_include_tree : Separate<["-"], "fcas-include-tree">,
+    Group<f_Group>, MetaVarName<"<tree>">,
+    HelpText<"Configure the frontend to use a CAS include tree.">,
+    MarshallingInfoString<FrontendOpts<"CASIncludeTreeID">>;
 
 // FIXME: Add to driver under -fexperimental-cache=compile-job.
 defm cache_compile_job : BoolFOption<"cache-compile-job",

--- a/clang/include/clang/Frontend/IncludeTreePPActions.h
+++ b/clang/include/clang/Frontend/IncludeTreePPActions.h
@@ -1,0 +1,32 @@
+//===- IncludeTreePPActions.h - PP actions using include-tree ---*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Uses the info from an include-tree to drive the preprocessor via
+// \p PPCachedActions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_FRONTEND_INCLUDETREEPPACTIONS_H
+#define LLVM_CLANG_FRONTEND_INCLUDETREEPPACTIONS_H
+
+#include "clang/Basic/LLVM.h"
+
+namespace clang {
+
+class PPCachedActions;
+
+namespace cas {
+class IncludeTreeRoot;
+}
+
+Expected<std::unique_ptr<PPCachedActions>>
+createPPActionsFromIncludeTree(cas::IncludeTreeRoot &Root);
+
+} // namespace clang
+
+#endif

--- a/clang/include/clang/Lex/PPCachedActions.h
+++ b/clang/include/clang/Lex/PPCachedActions.h
@@ -1,0 +1,53 @@
+//===--- PPCachedActions.h - Callbacks for PP cached actions ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Defines the PPCachedActions interface.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_LEX_PPCACHEDACTIONS_H
+#define LLVM_CLANG_LEX_PPCACHEDACTIONS_H
+
+#include "clang/Basic/SourceLocation.h"
+
+namespace clang {
+
+class Preprocessor;
+
+/// This interface provides a way to override the actions of the preprocessor as
+/// it does its thing.
+///
+/// A client can use this to control how include directives are resolved.
+class PPCachedActions {
+  virtual void anchor();
+
+public:
+  virtual ~PPCachedActions() = default;
+
+  /// \returns the \p FileID that should be used for predefines.
+  virtual FileID handlePredefines(Preprocessor &PP) = 0;
+
+  /// \returns the evaluation result for a \p __has_include check.
+  virtual bool evaluateHasInclude(Preprocessor &PP, SourceLocation Loc,
+                                  bool IsIncludeNext) = 0;
+
+  /// \returns the \p FileID that should be entered for an include directive.
+  /// \p None indicates that the directive should be skipped.
+  virtual Optional<FileID>
+  handleIncludeDirective(Preprocessor &PP, SourceLocation IncludeLoc,
+                         SourceLocation AfterDirectiveLoc) = 0;
+
+  /// Notifies the \p PPCachedActions implementation that the preprocessor
+  /// finished lexing an include file.
+  virtual void exitedFile(Preprocessor &PP, FileID FID) {}
+};
+
+} // namespace clang
+
+#endif

--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -28,6 +28,7 @@
 #include "clang/Lex/MacroInfo.h"
 #include "clang/Lex/ModuleLoader.h"
 #include "clang/Lex/ModuleMap.h"
+#include "clang/Lex/PPCachedActions.h"
 #include "clang/Lex/PPCallbacks.h"
 #include "clang/Lex/Token.h"
 #include "clang/Lex/TokenLexer.h"
@@ -656,6 +657,10 @@ private:
   /// encountered (e.g. a file is \#included, etc).
   std::unique_ptr<PPCallbacks> Callbacks;
 
+  /// Actions that can override certain preprocessor activities, like handling
+  /// of \#include directives.
+  std::unique_ptr<PPCachedActions> CachedActions;
+
   struct MacroExpandsInfo {
     Token Tok;
     MacroDefinition MD;
@@ -1169,6 +1174,11 @@ public:
     Callbacks = std::move(C);
   }
   /// \}
+
+  PPCachedActions *getPPCachedActions() const { return CachedActions.get(); }
+  void setPPCachedActions(std::unique_ptr<PPCachedActions> CA) {
+    CachedActions = std::move(CA);
+  }
 
   /// Get the number of tokens processed so far.
   unsigned getTokenCount() const { return TokenCount; }

--- a/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
@@ -15,6 +15,7 @@
 
 namespace llvm {
 namespace cas {
+class CASDB;
 class CASID;
 }
 } // namespace llvm
@@ -43,7 +44,8 @@ Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
     tooling::dependencies::DependencyScanningTool &Tool,
     DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS, const char *Exec,
     CompilerInvocation &Invocation, StringRef WorkingDirectory,
-    const cc1depscand::DepscanPrefixMapping &PrefixMapping);
+    const cc1depscand::DepscanPrefixMapping &PrefixMapping,
+    llvm::cas::CASDB &DB);
 
 } // end namespace clang
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4550,6 +4550,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &Job,
   {
     const OptSpecifier DepScanOpts[] = {
         options::OPT_fdepscan_EQ,
+        options::OPT_fdepscan_include_tree,
         options::OPT_fdepscan_share_EQ,
         options::OPT_fdepscan_share_identifier,
         options::OPT_fdepscan_share_parent,

--- a/clang/lib/Frontend/CMakeLists.txt
+++ b/clang/lib/Frontend/CMakeLists.txt
@@ -27,6 +27,7 @@ add_clang_library(clangFrontend
   FrontendActions.cpp
   FrontendOptions.cpp
   HeaderIncludeGen.cpp
+  IncludeTreePPActions.cpp
   InitPreprocessor.cpp
   LayoutOverrideSource.cpp
   LogDiagnosticPrinter.cpp

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -474,9 +474,11 @@ void CompilerInstance::createPreprocessor(TranslationUnitKind TUKind) {
   InitializeFileRemapping(PP->getDiagnostics(), PP->getSourceManager(),
                           PP->getFileManager(), PPOpts);
 
-  // Predefine macros and configure the preprocessor.
-  InitializePreprocessor(*PP, PPOpts, getPCHContainerReader(),
-                         getFrontendOpts());
+  if (getFrontendOpts().CASIncludeTreeID.empty()) {
+    // Predefine macros and configure the preprocessor.
+    InitializePreprocessor(*PP, PPOpts, getPCHContainerReader(),
+                           getFrontendOpts());
+  }
 
   // Initialize the header search object.  In CUDA compilations, we use the aux
   // triple (the host triple) to initialize our header search, since we need to

--- a/clang/lib/Frontend/IncludeTreePPActions.cpp
+++ b/clang/lib/Frontend/IncludeTreePPActions.cpp
@@ -1,0 +1,154 @@
+//===- IncludeTreePPActions.cpp - PP actions using include-tree -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Frontend/IncludeTreePPActions.h"
+#include "clang/CAS/IncludeTree.h"
+#include "clang/Frontend/FrontendDiagnostic.h"
+#include "clang/Lex/PPCachedActions.h"
+#include "clang/Lex/Preprocessor.h"
+
+using namespace clang;
+
+namespace {
+
+struct IncludeStackInfo {
+  cas::IncludeTree Tree;
+  SourceLocation FileStartLoc;
+  unsigned CurIncludeIndex = 0;
+  unsigned CurHasIncludeCheckIndex = 0;
+};
+
+/// Uses the info from an \p IncludeTreeRoot to resolve include directives
+/// and evaluate \p __has_include checks.
+class IncludeTreePPActions final : public PPCachedActions {
+  cas::IncludeTree MainTree;
+  SmallVector<IncludeStackInfo> IncludeStack;
+  bool HasCASErrorOccurred = false;
+
+  void reportError(Preprocessor &PP, llvm::Error &&E) {
+    PP.getDiagnostics().Report(diag::err_unable_to_load_include_tree_node)
+        << llvm::toString(std::move(E));
+    HasCASErrorOccurred = true;
+  }
+
+public:
+  IncludeTreePPActions(cas::IncludeTree MainTree)
+      : MainTree(std::move(MainTree)) {}
+
+  FileID handlePredefines(Preprocessor &PP) override {
+    auto createEmptyFID = [&]() -> FileID {
+      llvm::MemoryBufferRef Buffer({}, "<built-in>");
+      return PP.getSourceManager().createFileID(Buffer);
+    };
+
+    if (HasCASErrorOccurred) {
+      return createEmptyFID();
+    }
+
+    auto reportError = [&](llvm::Error &&E) -> FileID {
+      this->reportError(PP, std::move(E));
+      return createEmptyFID();
+    };
+
+    SourceManager &SM = PP.getSourceManager();
+    SourceLocation MainFileLoc = SM.getLocForStartOfFile(SM.getMainFileID());
+    IncludeStack.push_back({std::move(MainTree), MainFileLoc});
+
+    IncludeStackInfo &IncludeInfo = IncludeStack.back();
+    Expected<cas::IncludeTree> EnteredTree =
+        IncludeInfo.Tree.getInclude(IncludeInfo.CurIncludeIndex++);
+    if (!EnteredTree)
+      return reportError(EnteredTree.takeError());
+    auto FileInfo = EnteredTree->getBaseFileInfo();
+    if (!FileInfo)
+      return reportError(FileInfo.takeError());
+    llvm::MemoryBufferRef Buffer(FileInfo->Contents, FileInfo->Filename);
+    FileID FID = SM.createFileID(Buffer);
+    IncludeStack.push_back(
+        {std::move(*EnteredTree), SM.getLocForStartOfFile(FID)});
+    return FID;
+  }
+
+  bool evaluateHasInclude(Preprocessor &PP, SourceLocation Loc,
+                          bool IsIncludeNext) override {
+    if (HasCASErrorOccurred)
+      return false;
+
+    IncludeStackInfo &IncludeInfo = IncludeStack.back();
+    unsigned Index = IncludeInfo.CurHasIncludeCheckIndex++;
+    return IncludeInfo.Tree.getCheckResult(Index);
+  }
+
+  Optional<FileID>
+  handleIncludeDirective(Preprocessor &PP, SourceLocation IncludeLoc,
+                         SourceLocation AfterDirectiveLoc) override {
+    if (HasCASErrorOccurred)
+      return None;
+
+    IncludeStackInfo &IncludeInfo = IncludeStack.back();
+    if (IncludeInfo.CurIncludeIndex >= IncludeInfo.Tree.getNumIncludes())
+      return None;
+
+    unsigned ExpectedOffset =
+        IncludeInfo.Tree.getIncludeOffset(IncludeInfo.CurIncludeIndex);
+    SourceLocation ExpectedLoc =
+        IncludeInfo.FileStartLoc.getLocWithOffset(ExpectedOffset);
+    if (ExpectedLoc != AfterDirectiveLoc)
+      return None;
+
+    auto reportError = [&](llvm::Error &&E) -> Optional<FileID> {
+      this->reportError(PP, std::move(E));
+      return None;
+    };
+
+    Expected<cas::IncludeTree> EnteredTree =
+        IncludeInfo.Tree.getInclude(IncludeInfo.CurIncludeIndex++);
+    if (!EnteredTree)
+      return reportError(EnteredTree.takeError());
+    auto File = EnteredTree->getBaseFile();
+    if (!File)
+      return reportError(File.takeError());
+    auto FilenameBlob = File->getFilename();
+    if (!FilenameBlob)
+      return reportError(FilenameBlob.takeError());
+
+    SourceManager &SM = PP.getSourceManager();
+    Expected<FileEntryRef> FE =
+        SM.getFileManager().getFileRef(FilenameBlob->getData(),
+                                       /*OpenFile=*/true);
+    if (!FE)
+      return reportError(FE.takeError());
+    FileID FID =
+        SM.createFileID(*FE, IncludeLoc, EnteredTree->getFileCharacteristic());
+    PP.markIncluded(*FE);
+    IncludeStack.push_back(
+        {std::move(*EnteredTree), SM.getLocForStartOfFile(FID)});
+    return FID;
+  }
+
+  void exitedFile(Preprocessor &PP, FileID FID) override {
+    if (HasCASErrorOccurred)
+      return;
+
+    assert(!IncludeStack.empty());
+    assert(IncludeStack.back().FileStartLoc ==
+           PP.getSourceManager().getLocForStartOfFile(FID));
+    assert(IncludeStack.back().CurIncludeIndex ==
+           IncludeStack.back().Tree.getNumIncludes());
+    IncludeStack.pop_back();
+  }
+};
+} // namespace
+
+Expected<std::unique_ptr<PPCachedActions>>
+clang::createPPActionsFromIncludeTree(cas::IncludeTreeRoot &Root) {
+  auto MainTree = Root.getMainFileTree();
+  if (!MainTree)
+    return MainTree.takeError();
+  return std::make_unique<IncludeTreePPActions>(std::move(*MainTree));
+}

--- a/clang/lib/Lex/PPCallbacks.cpp
+++ b/clang/lib/Lex/PPCallbacks.cpp
@@ -8,6 +8,7 @@
 
 #include "clang/Lex/PPCallbacks.h"
 #include "clang/Basic/FileManager.h"
+#include "clang/Lex/PPCachedActions.h"
 
 using namespace clang;
 
@@ -28,3 +29,4 @@ void PPChainedCallbacks::HasInclude(SourceLocation Loc, StringRef FileName,
   Second->HasInclude(Loc, FileName, IsAngled, File, FileType);
 }
 
+void PPCachedActions::anchor() {}

--- a/clang/lib/Lex/PPLexerChange.cpp
+++ b/clang/lib/Lex/PPLexerChange.cpp
@@ -504,6 +504,10 @@ bool Preprocessor::HandleEndOfFile(Token &Result, bool isEndOfMacro) {
                                   PPCallbacks::LexedFileChangeReason::ExitFile,
                                   FileType, ExitedFID, Loc);
     }
+    if (auto *CActions = getPPCachedActions()) {
+      if (ExitedFID.isValid())
+        CActions->exitedFile(*this, ExitedFID);
+    }
 
     // Restore conditional stack as well as the recorded
     // \#pragma clang assume_nonnull from the preamble right after exiting

--- a/clang/lib/Lex/Preprocessor.cpp
+++ b/clang/lib/Lex/Preprocessor.cpp
@@ -566,12 +566,17 @@ void Preprocessor::EnterMainSourceFile() {
       markIncluded(FE);
   }
 
-  // Preprocess Predefines to populate the initial preprocessor state.
-  std::unique_ptr<llvm::MemoryBuffer> SB =
-    llvm::MemoryBuffer::getMemBufferCopy(Predefines, "<built-in>");
-  assert(SB && "Cannot create predefined source buffer");
-  FileID FID = SourceMgr.createFileID(std::move(SB));
-  assert(FID.isValid() && "Could not create FileID for predefines?");
+  FileID FID;
+  if (auto *CActions = getPPCachedActions()) {
+    FID = CActions->handlePredefines(*this);
+  } else {
+    // Preprocess Predefines to populate the initial preprocessor state.
+    std::unique_ptr<llvm::MemoryBuffer> SB =
+        llvm::MemoryBuffer::getMemBufferCopy(Predefines, "<built-in>");
+    assert(SB && "Cannot create predefined source buffer");
+    FID = SourceMgr.createFileID(std::move(SB));
+    assert(FID.isValid() && "Could not create FileID for predefines?");
+  }
   setPredefinesFileID(FID);
 
   // Start parsing the predefines.

--- a/clang/test/CAS/depscan-include-tree.c
+++ b/clang/test/CAS/depscan-include-tree.c
@@ -1,0 +1,43 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %clang -cc1depscan -o %t/inline.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args -cc1 -triple x86_64-apple-macos11.0 \
+// RUN:     -fsyntax-only %t/t.c -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -DSOME_MACRO -dependency-file %t/inline.d -MT deps
+// RUN: %clang -cc1depscan -o %t/daemon.rsp -fdepscan=daemon -fdepscan-include-tree -cc1-args -cc1 -triple x86_64-apple-macos11.0 \
+// RUN:     -fsyntax-only %t/t.c -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -DSOME_MACRO -dependency-file %t/daemon.d -MT deps
+
+// RUN: diff -u %t/inline.rsp %t/daemon.rsp
+// RUN: FileCheck %s -input-file %t/inline.rsp -DPREFIX=%t
+// RUN: FileCheck %s -input-file %t/inline.rsp -DPREFIX=%t -check-prefix=SHOULD
+
+// RUN: %clang @%t/inline.rsp
+
+// CHECK: "-fcas-path" "[[PREFIX]]/cas"
+// CHECK: "-fcas-include-tree"
+// SHOULD-NOT: "-fcas-fs"
+// SHOULD-NOT: "-fcas-fs-working-directory"
+// SHOULD-NOT: "-isysroot"
+// SHOULD-NOT: "-I"
+// SHOULD-NOT: "[[PREFIX]]/t.c"
+// SHOULD-NOT: "-D"
+
+// RUN: diff -u %t/inline.d %t/daemon.d
+// RUN: FileCheck %s -input-file %t/inline.d -check-prefix=DEPS -DPREFIX=%t
+
+// DEPS: deps:
+// DEPS: [[PREFIX]]/t.c
+// DEPS: [[PREFIX]]/includes/t.h
+
+int test() { return 0; }
+
+//--- t.c
+#include "t.h"
+
+int test(struct S *s) {
+  return s->x;
+}
+
+//--- includes/t.h
+struct S {
+  int x;
+};

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -22,6 +22,10 @@
 // CLANGPP: "-greproducible"
 // CLANGPP: "-x" "c++"
 
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_ENABLE_INCLUDE_TREE=1 %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=INCLUDE-TREE -DPREFIX=%t
+// INCLUDE-TREE: "-cc1depscan" "-fdepscan=auto"
+// INCLUDE-TREE: "-fdepscan-include-tree"
+
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=SESSION -DPREFIX=%t
 // SESSION: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-share-identifier"
 // SESSION: "-fcas-path" "[[PREFIX]]/cas"

--- a/clang/test/CAS/fcas-include-tree.c
+++ b/clang/test/CAS/fcas-include-tree.c
@@ -1,0 +1,67 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 %t/t1.c -E -P -o %t/source.i -isystem %t -DCMD_MACRO=1 -Werror
+// RUN: %clang_cc1 %t/t1.c -emit-llvm -o %t/source.ll -isystem %t -DCMD_MACRO=1 -Werror -dependency-file %t/t1-source.d -MT deps
+
+// RUN: %clang -cc1depscan -o %t/inline.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
+// RUN:     -cc1 %t/t1.c -isystem %t -DCMD_MACRO=1 -fcas-path %t/cas
+// RUN: %clang @%t/inline.rsp -E -P -o %t/tree.i -Werror
+// RUN: diff -u %t/source.i %t/tree.i
+// RUN: %clang @%t/inline.rsp -emit-llvm -o %t/tree.ll -Werror -dependency-file %t/t1-tree.d -MT deps
+// RUN: diff -u %t/source.ll %t/tree.ll
+// RUN: diff -u %t/t1-source.d %t/t1-tree.d
+
+//--- t1.c
+#include "top.h"
+#include "n1.h"
+#include <sys.h>
+
+#define N2H <n2.h>
+#include N2H
+
+int test(struct S *s) {
+  return s->x + gv + gv2 + SOMEVAL + SOMEVAL2 + CMD_MACRO;
+}
+
+//--- top.h
+#ifndef _TOP_H_
+#define _TOP_H_
+
+#if __has_include("n1.h")
+#define SOMEVAL 1
+#endif
+
+#if __has_include("nonexistent.h")
+#define SOMEVAL 7
+#else
+#define SOMEVAL2 2
+#endif
+
+#include "n1.h"
+
+struct S {
+  int x;
+};
+
+#endif
+
+//--- sys.h
+#define SOMECHECK defined(SOMEDEF)
+// This triggers warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
+#if SOMECHECK
+#endif
+
+//--- n1.h
+#ifndef _N1_H_
+#define _N1_H_
+
+#pragma once
+#pragma clang system_header
+
+int gv;
+
+#endif
+
+//--- n2.h
+int gv2;

--- a/clang/test/CAS/print-compile-job-cache-key.c
+++ b/clang/test/CAS/print-compile-job-cache-key.c
@@ -33,3 +33,21 @@
 // CHECK:   file llvmcas://
 // CHECK: version: llvmcas://
 // CHECK:   clang version
+
+// Print a key containing an include-tree.
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_ENABLE_INCLUDE_TREE=1 %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/output.o -Rcompile-job-cache 2> %t/output-tree.txt
+
+// RUN: cat %t/output-tree.txt | sed \
+// RUN:   -e "s/^.*miss for '//" \
+// RUN:   -e "s/' .*$//" > %t/cache-key-tree
+
+// RUN: clang-cas-test -print-compile-job-cache-key -cas %t/cas @%t/cache-key-tree | FileCheck %s -check-prefix=INCLUDE_TREE -DSRC_FILE=%s
+//
+// INCLUDE_TREE: command-line: llvmcas://
+// INCLUDE_TREE: computation: llvmcas://
+// INCLUDE_TREE: include-tree: llvmcas://
+// INCLUDE_TREE-NEXT: [[SRC_FILE]] llvmcas://
+// INCLUDE_TREE: Files:
+// INCLUDE_TREE-NEXT: [[SRC_FILE]] llvmcas://

--- a/clang/test/ClangScanDeps/include-tree.c
+++ b/clang/test/ClangScanDeps/include-tree.c
@@ -20,6 +20,12 @@
 // ORDER-NEXT:     [[PREFIX]]/n3.h
 // ORDER-NEXT: [[PREFIX]]/n3.h
 // ORDER-NEXT: [[PREFIX]]/n2.h
+// ORDER-NEXT: Files:
+// ORDER-NEXT: [[PREFIX]]/t.c
+// ORDER-NEXT: [[PREFIX]]/top.h
+// ORDER-NEXT: [[PREFIX]]/n1.h
+// ORDER-NEXT: [[PREFIX]]/n2.h
+// ORDER-NEXT: [[PREFIX]]/n3.h
 // ORDER-NOT: [[PREFIX]]
 
 

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -128,6 +128,9 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
     } else {
       Args.push_back("-fdepscan");
     }
+    if (::getenv("CLANG_CACHE_ENABLE_INCLUDE_TREE")) {
+      Args.push_back("-fdepscan-include-tree");
+    }
     if (const char *PrefixMaps = ::getenv("LLVM_CACHE_PREFIX_MAPS")) {
       Args.append({"-fdepscan-prefix-map-sdk=/^sdk",
                    "-fdepscan-prefix-map-toolchain=/^toolchain"});


### PR DESCRIPTION
The `include-tree` is added as an alternative method to `casfs` for dep-scanning and for driving a compilation.
For a `clang-cache` invocation it is enabled via the `CLANG_CACHE_ENABLE_INCLUDE_TREE` environment variable.

Due to avoiding header file lookups there's a measurable improvement for preprocessing performance.
The following are wall-time measurements on an M1Pro with a thin-LTO enabled build; preprocess-only compilations
are performed on all the files that are linked to the clang executable, using:

* The arguments produced with include-tree dep-scanning
* The arguments produced with CASFS dep-scanning
* The normal compilation arguments

|              | casfs | normal |
|--------------|-------|--------|
| include-tree | -7.2% | -21.5% |