### PR TITLE
[include-tree] Enable producing an `include-tree` via a driver invocation and replaying it for compilation

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -665,6 +665,9 @@ def warn_drv_fjmc_for_elf_only : Warning<
 def err_drv_target_variant_invalid : Error<
   "unsupported '%0' value '%1'; use 'ios-macabi' instead">;
 
+def err_drv_inputs_and_include_tree : Error<
+  "passing input files is incompatible with '-fcas-include-tree'">;
+
 def err_drv_invalid_directx_shader_module : Error<
   "invalid profile : %0">;
 

--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -129,6 +129,11 @@ def warn_fe_concepts_ts_flag : Warning<
   "-fconcepts-ts is deprecated - use '-std=c++20' for Concepts support">,
   InGroup<Deprecated>;
 
+def err_fe_unable_to_load_include_tree : Error<
+  "unable to load the CAS include-tree '%0': '%1'">;
+def err_unable_to_load_include_tree_node : Error<
+  "unable to load a node from the CAS include-tree: '%0'">;
+
 def err_fe_unable_to_load_basic_block_sections_file : Error<
     "unable to load basic block sections function list: '%0'">;
 

--- a/clang/include/clang/CAS/IncludeTree.h
+++ b/clang/include/clang/CAS/IncludeTree.h
@@ -14,6 +14,9 @@
 
 namespace llvm {
 class SmallBitVector;
+namespace vfs {
+class FileSystem;
+}
 }
 
 namespace clang {
@@ -40,6 +43,7 @@ protected:
   }
 
   friend class IncludeFile;
+  friend class IncludeFileList;
   friend class IncludeTree;
   friend class IncludeTreeRoot;
 };
@@ -98,6 +102,7 @@ public:
 
 private:
   friend class IncludeTreeBase<IncludeFile>;
+  friend class IncludeFileList;
   friend class IncludeTree;
   friend class IncludeTreeRoot;
 
@@ -214,12 +219,77 @@ private:
   }
 };
 
+/// A flat list of \p IncludeFile entries. This is used along with a simple
+/// implementation of a \p vfs::FileSystem produced via
+/// \p createIncludeTreeFileSystem().
+class IncludeFileList : public IncludeTreeBase<IncludeFileList> {
+public:
+  static constexpr StringRef getNodeKind() { return "List"; }
+
+  using FileSizeTy = uint32_t;
+
+  size_t getNumFiles() const { return getNumReferences(); }
+
+  ObjectRef getFileRef(size_t I) const {
+    assert(I < getNumFiles());
+    return getReference(I);
+  }
+
+  Expected<IncludeFile> getFile(size_t I) { return getFile(getFileRef(I)); }
+  FileSizeTy getFileSize(size_t I) const;
+
+  /// \returns each \p IncludeFile entry along with its file size.
+  llvm::Error forEachFile(
+      llvm::function_ref<llvm::Error(IncludeFile, FileSizeTy)> Callback);
+
+  /// We record the file size as well to avoid needing to materialize the
+  /// underlying buffer for the \p IncludeTreeFileSystem::status()
+  /// implementation to provide the file size.
+  struct FileEntry {
+    ObjectRef FileRef;
+    FileSizeTy Size;
+  };
+  static Expected<IncludeFileList> create(CASDB &DB, ArrayRef<FileEntry> Files);
+
+  static Expected<IncludeFileList> get(CASDB &CAS, ObjectRef Ref);
+
+  llvm::Error print(llvm::raw_ostream &OS, unsigned Indent = 0);
+
+private:
+  friend class IncludeTreeBase<IncludeFileList>;
+  friend class IncludeTreeRoot;
+
+  explicit IncludeFileList(ObjectProxy Node)
+      : IncludeTreeBase(std::move(Node)) {
+    assert(isValid(*this));
+  }
+
+  Expected<IncludeFile> getFile(ObjectRef Ref) {
+    auto Node = getCAS().getProxy(Ref);
+    if (!Node)
+      return Node.takeError();
+    return IncludeFile(std::move(*Node));
+  }
+
+  static bool isValid(const ObjectProxy &Node);
+  static bool isValid(CASDB &CAS, ObjectRef Ref) {
+    auto Node = CAS.getProxy(Ref);
+    if (!Node) {
+      llvm::consumeError(Node.takeError());
+      return false;
+    }
+    return isValid(*Node);
+  }
+};
+
 /// Represents the include-tree result for a translation unit.
 class IncludeTreeRoot : public IncludeTreeBase<IncludeTreeRoot> {
 public:
   static constexpr StringRef getNodeKind() { return "Root"; }
 
   ObjectRef getMainFileTreeRef() const { return getReference(0); }
+
+  ObjectRef getFileListRef() const { return getReference(1); }
 
   Expected<IncludeTree> getMainFileTree() {
     auto Node = getCAS().getProxy(getMainFileTreeRef());
@@ -228,7 +298,15 @@ public:
     return IncludeTree(std::move(*Node));
   }
 
-  static Expected<IncludeTreeRoot> create(CASDB &DB, ObjectRef MainFileTree);
+  Expected<IncludeFileList> getFileList() {
+    auto Node = getCAS().getProxy(getFileListRef());
+    if (!Node)
+      return Node.takeError();
+    return IncludeFileList(std::move(*Node));
+  }
+
+  static Expected<IncludeTreeRoot> create(CASDB &DB, ObjectRef MainFileTree,
+                                          ObjectRef FileList);
 
   static Expected<IncludeTreeRoot> get(CASDB &DB, ObjectRef Ref);
 
@@ -238,7 +316,7 @@ public:
     if (!IncludeTreeBase::isValid(Node))
       return false;
     IncludeTreeBase Base(Node);
-    return Base.getNumReferences() == 1 && Base.getData().empty();
+    return Base.getNumReferences() == 2 && Base.getData().empty();
   }
   static bool isValid(CASDB &DB, ObjectRef Ref) {
     auto Node = DB.getProxy(Ref);
@@ -257,6 +335,13 @@ private:
     assert(isValid(*this));
   }
 };
+
+/// An implementation of a \p vfs::FileSystem that supports the simple queries
+/// of the preprocessor, for creating \p FileEntries using a file path, while
+/// "replaying" an \p IncludeTreeRoot. It is not intended to be a complete
+/// implementation of a file system.
+Expected<IntrusiveRefCntPtr<llvm::vfs::FileSystem>>
+createIncludeTreeFileSystem(IncludeTreeRoot &Root);
 
 } // namespace cas
 } // namespace clang

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6303,6 +6303,9 @@ def fdepscan_daemon_EQ : Joined<["-"], "fdepscan-daemon=">, Group<f_Group>,
              " daemon specified, rather than try to spawn its own based on"
              " parent processes.">;
 
+def fdepscan_include_tree : Flag<["-"], "fdepscan-include-tree">,
+    Group<f_Group>, HelpText<"Set dep-scanner to produce the include tree">;
+
 // CAS prefix map options.
 //
 // FIXME: Add DepscanOption flag.
@@ -6360,6 +6363,11 @@ def fcas_fs_working_directory : Separate<["-"], "fcas-fs-working-directory">,
     HelpText<"Working directory for -fcas-fs (if not the root).">,
     ShouldParseIf<!strconcat("!", fcas_fs.KeyPath, ".empty()")>,
     MarshallingInfoString<FileSystemOpts<"CASFileSystemWorkingDirectory">>;
+
+def fcas_include_tree : Separate<["-"], "fcas-include-tree">,
+    Group<f_Group>, MetaVarName<"<tree>">,
+    HelpText<"Configure the frontend to use a CAS include tree.">,
+    MarshallingInfoString<FrontendOpts<"CASIncludeTreeID">>;
 
 // FIXME: Add to driver under -fexperimental-cache=compile-job.
 defm cache_compile_job : BoolFOption<"cache-compile-job",

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -15,6 +15,7 @@
 #include "clang/Sema/CodeCompleteOptions.h"
 #include "clang/Serialization/ModuleFileExtension.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/CAS/CASReference.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include <cassert>
 #include <map>
@@ -227,6 +228,9 @@ class FrontendInputFile {
   /// that it outlives any users.
   llvm::Optional<llvm::MemoryBufferRef> Buffer;
 
+  /// The input, if it comes from \p FrontendOptions::CASIncludeTreeID.
+  Optional<cas::ObjectRef> IncludeTree;
+
   /// The kind of input, e.g., C source, AST file, LLVM IR.
   InputKind Kind;
 
@@ -240,6 +244,10 @@ public:
   FrontendInputFile(llvm::MemoryBufferRef Buffer, InputKind Kind,
                     bool IsSystem = false)
       : Buffer(Buffer), Kind(Kind), IsSystem(IsSystem) {}
+  FrontendInputFile(cas::ObjectRef Tree, StringRef File, InputKind Kind,
+                    bool IsSystem = false)
+      : File(File.str()), IncludeTree(std::move(Tree)), Kind(Kind),
+        IsSystem(IsSystem) {}
 
   InputKind getKind() const { return Kind; }
   bool isSystem() const { return IsSystem; }
@@ -247,6 +255,7 @@ public:
   bool isEmpty() const { return File.empty() && Buffer == None; }
   bool isFile() const { return !isBuffer(); }
   bool isBuffer() const { return Buffer != None; }
+  bool isIncludeTree() const { return IncludeTree.hasValue(); }
   bool isPreprocessed() const { return Kind.isPreprocessed(); }
   bool isHeader() const { return Kind.isHeader(); }
   InputKind::HeaderUnitKind getHeaderUnitKind() const {
@@ -261,6 +270,11 @@ public:
   llvm::MemoryBufferRef getBuffer() const {
     assert(isBuffer());
     return *Buffer;
+  }
+
+  cas::ObjectRef getIncludeTree() const {
+    assert(isIncludeTree());
+    return *IncludeTree;
   }
 };
 
@@ -439,6 +453,9 @@ public:
 
   /// The input files and their types.
   SmallVector<FrontendInputFile, 0> Inputs;
+
+  /// Use the provided CAS include tree.
+  std::string CASIncludeTreeID;
 
   /// When the input is a module map, the original module map file from which
   /// that map was inferred, if any (for umbrella modules).

--- a/clang/include/clang/Frontend/IncludeTreePPActions.h
+++ b/clang/include/clang/Frontend/IncludeTreePPActions.h
@@ -1,0 +1,32 @@
+//===- IncludeTreePPActions.h - PP actions using include-tree ---*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Uses the info from an include-tree to drive the preprocessor via
+// \p PPCachedActions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_FRONTEND_INCLUDETREEPPACTIONS_H
+#define LLVM_CLANG_FRONTEND_INCLUDETREEPPACTIONS_H
+
+#include "clang/Basic/LLVM.h"
+
+namespace clang {
+
+class PPCachedActions;
+
+namespace cas {
+class IncludeTreeRoot;
+}
+
+Expected<std::unique_ptr<PPCachedActions>>
+createPPActionsFromIncludeTree(cas::IncludeTreeRoot &Root);
+
+} // namespace clang
+
+#endif

--- a/clang/include/clang/Lex/PPCachedActions.h
+++ b/clang/include/clang/Lex/PPCachedActions.h
@@ -1,0 +1,53 @@
+//===--- PPCachedActions.h - Callbacks for PP cached actions ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Defines the PPCachedActions interface.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_LEX_PPCACHEDACTIONS_H
+#define LLVM_CLANG_LEX_PPCACHEDACTIONS_H
+
+#include "clang/Basic/SourceLocation.h"
+
+namespace clang {
+
+class Preprocessor;
+
+/// This interface provides a way to override the actions of the preprocessor as
+/// it does its thing.
+///
+/// A client can use this to control how include directives are resolved.
+class PPCachedActions {
+  virtual void anchor();
+
+public:
+  virtual ~PPCachedActions() = default;
+
+  /// \returns the \p FileID that should be used for predefines.
+  virtual FileID handlePredefines(Preprocessor &PP) = 0;
+
+  /// \returns the evaluation result for a \p __has_include check.
+  virtual bool evaluateHasInclude(Preprocessor &PP, SourceLocation Loc,
+                                  bool IsIncludeNext) = 0;
+
+  /// \returns the \p FileID that should be entered for an include directive.
+  /// \p None indicates that the directive should be skipped.
+  virtual Optional<FileID>
+  handleIncludeDirective(Preprocessor &PP, SourceLocation IncludeLoc,
+                         SourceLocation AfterDirectiveLoc) = 0;
+
+  /// Notifies the \p PPCachedActions implementation that the preprocessor
+  /// finished lexing an include file.
+  virtual void exitedFile(Preprocessor &PP, FileID FID) {}
+};
+
+} // namespace clang
+
+#endif

--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -27,6 +27,7 @@
 #include "clang/Lex/MacroInfo.h"
 #include "clang/Lex/ModuleLoader.h"
 #include "clang/Lex/ModuleMap.h"
+#include "clang/Lex/PPCachedActions.h"
 #include "clang/Lex/PPCallbacks.h"
 #include "clang/Lex/Token.h"
 #include "clang/Lex/TokenLexer.h"
@@ -589,6 +590,10 @@ private:
   /// encountered (e.g. a file is \#included, etc).
   std::unique_ptr<PPCallbacks> Callbacks;
 
+  /// Actions that can override certain preprocessor activities, like handling
+  /// of \#include directives.
+  std::unique_ptr<PPCachedActions> CachedActions;
+
   struct MacroExpandsInfo {
     Token Tok;
     MacroDefinition MD;
@@ -1102,6 +1107,11 @@ public:
     Callbacks = std::move(C);
   }
   /// \}
+
+  PPCachedActions *getPPCachedActions() const { return CachedActions.get(); }
+  void setPPCachedActions(std::unique_ptr<PPCachedActions> CA) {
+    CachedActions = std::move(CA);
+  }
 
   /// Get the number of tokens processed so far.
   unsigned getTokenCount() const { return TokenCount; }

--- a/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
@@ -15,6 +15,7 @@
 
 namespace llvm {
 namespace cas {
+class CASDB;
 class CASID;
 }
 } // namespace llvm
@@ -43,7 +44,8 @@ Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
     tooling::dependencies::DependencyScanningTool &Tool,
     DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS, const char *Exec,
     CompilerInvocation &Invocation, StringRef WorkingDirectory,
-    const cc1depscand::DepscanPrefixMapping &PrefixMapping);
+    const cc1depscand::DepscanPrefixMapping &PrefixMapping,
+    llvm::cas::CASDB &DB);
 
 } // end namespace clang
 

--- a/clang/lib/CAS/IncludeTree.cpp
+++ b/clang/lib/CAS/IncludeTree.cpp
@@ -9,7 +9,9 @@
 #include "clang/CAS/IncludeTree.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/Support/EndianStream.h"
+#include "llvm/Support/Errc.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/VirtualFileSystem.h"
 
 using namespace clang;
 using namespace clang::cas;
@@ -18,6 +20,10 @@ template <typename NodeT>
 Expected<NodeT> IncludeTreeBase<NodeT>::create(CASDB &DB,
                                                ArrayRef<ObjectRef> Refs,
                                                ArrayRef<char> Data) {
+  // Using 4 chars for less chance that it will randomly match a wrong node and
+  // makes the buffer 4 bytes "aligned".
+  static_assert(NodeT::getNodeKind().size() == 4,
+                "getNodeKind() should return 4 characters");
   SmallString<256> Buf{NodeT::getNodeKind()};
   Buf.reserve(Data.size() + NodeT::getNodeKind().size());
   Buf.append(Data.begin(), Data.end());
@@ -150,10 +156,67 @@ bool IncludeTree::isValid(const ObjectProxy &Node) {
   return Base.getData().size() >= NumIncludes * sizeof(uint32_t) + 1;
 }
 
-Expected<IncludeTreeRoot> IncludeTreeRoot::create(CASDB &DB,
-                                                  ObjectRef MainFileTree) {
+IncludeFileList::FileSizeTy IncludeFileList::getFileSize(size_t I) const {
+  assert(I < getNumFiles());
+  StringRef Data = getData();
+  assert(Data.size() >= (I + 1) * sizeof(FileSizeTy));
+  return llvm::support::endian::read<FileSizeTy, llvm::support::little>(
+      Data.data() + I * sizeof(FileSizeTy));
+}
+
+llvm::Error IncludeFileList::forEachFile(
+    llvm::function_ref<llvm::Error(IncludeFile, FileSizeTy)> Callback) {
+  size_t I = 0;
+  return forEachReference([&](ObjectRef Ref) -> llvm::Error {
+    auto Include = getFile(Ref);
+    if (!Include)
+      return Include.takeError();
+    return Callback(std::move(*Include), getFileSize(I++));
+  });
+}
+
+Expected<IncludeFileList> IncludeFileList::create(CASDB &DB,
+                                                  ArrayRef<FileEntry> Files) {
+  SmallVector<ObjectRef, 16> Refs;
+  Refs.reserve(Files.size());
+  SmallString<256> Buffer;
+  Buffer.reserve(Files.size() * sizeof(FileSizeTy));
+
+  llvm::raw_svector_ostream BufOS(Buffer);
+  llvm::support::endian::Writer Writer(BufOS, llvm::support::little);
+
+  for (const FileEntry &Entry : Files) {
+    assert(IncludeFile::isValid(DB, Entry.FileRef));
+    Refs.push_back(Entry.FileRef);
+    Writer.write(Entry.Size);
+  }
+  return IncludeTreeBase::create(DB, Refs, Buffer);
+}
+
+Expected<IncludeFileList> IncludeFileList::get(CASDB &DB, ObjectRef Ref) {
+  auto Node = DB.getProxy(Ref);
+  if (!Node)
+    return Node.takeError();
+  if (!isValid(*Node))
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "not a IncludeFileList node kind");
+  return IncludeFileList(std::move(*Node));
+}
+
+bool IncludeFileList::isValid(const ObjectProxy &Node) {
+  if (!IncludeTreeBase::isValid(Node))
+    return false;
+  IncludeTreeBase Base(Node);
+  unsigned NumFiles = Base.getNumReferences();
+  return NumFiles != 0 &&
+         Base.getData().size() == NumFiles * sizeof(FileSizeTy);
+}
+
+Expected<IncludeTreeRoot>
+IncludeTreeRoot::create(CASDB &DB, ObjectRef MainFileTree, ObjectRef FileList) {
   assert(IncludeTree::isValid(DB, MainFileTree));
-  return IncludeTreeBase::create(DB, MainFileTree, {});
+  assert(IncludeFileList::isValid(DB, FileList));
+  return IncludeTreeBase::create(DB, {MainFileTree, FileList}, {});
 }
 
 Expected<IncludeTreeRoot> IncludeTreeRoot::get(CASDB &DB, ObjectRef Ref) {
@@ -200,9 +263,187 @@ llvm::Error IncludeTree::print(llvm::raw_ostream &OS, unsigned Indent) {
       });
 }
 
+llvm::Error IncludeFileList::print(llvm::raw_ostream &OS, unsigned Indent) {
+  return forEachFile([&](cas::IncludeFile File, FileSizeTy) -> llvm::Error {
+    return File.print(OS, Indent);
+  });
+}
+
 llvm::Error IncludeTreeRoot::print(llvm::raw_ostream &OS, unsigned Indent) {
   Optional<cas::IncludeTree> MainTree;
   if (llvm::Error E = getMainFileTree().moveInto(MainTree))
     return E;
-  return MainTree->print(OS, Indent);
+  if (llvm::Error E = MainTree->print(OS.indent(Indent), Indent))
+    return E;
+  OS.indent(Indent) << "Files:\n";
+  Optional<cas::IncludeFileList> List;
+  if (llvm::Error E = getFileList().moveInto(List))
+    return E;
+  return List->print(OS, Indent);
+}
+
+namespace {
+/// An implementation of a \p vfs::FileSystem that supports the simple queries
+/// of the preprocessor, for creating \p FileEntries using a file path, while
+/// "replaying" an \p IncludeTreeRoot. It is not intended to be a complete
+/// implementation of a file system.
+class IncludeTreeFileSystem : public llvm::vfs::FileSystem {
+  llvm::cas::CASDB &CAS;
+
+public:
+  class IncludeTreeFile : public llvm::vfs::File {
+    llvm::vfs::Status Stat;
+    StringRef Contents;
+    cas::ObjectRef ContentsRef;
+
+  public:
+    IncludeTreeFile(llvm::vfs::Status Stat, StringRef Contents,
+                    cas::ObjectRef ContentsRef)
+        : Stat(std::move(Stat)), Contents(Contents),
+          ContentsRef(std::move(ContentsRef)) {}
+
+    llvm::ErrorOr<llvm::vfs::Status> status() override { return Stat; }
+
+    llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+    getBuffer(const Twine &Name, int64_t FileSize, bool RequiresNullTerminator,
+              bool IsVolatile) override {
+      return llvm::MemoryBuffer::getMemBuffer(Contents);
+    }
+
+    llvm::ErrorOr<Optional<cas::ObjectRef>> getObjectRefForContent() override {
+      return ContentsRef;
+    }
+
+    std::error_code close() override { return std::error_code(); }
+  };
+
+  explicit IncludeTreeFileSystem(llvm::cas::CASDB &CAS) : CAS(CAS) {}
+
+  struct FileEntry {
+    cas::ObjectRef ContentsRef;
+    IncludeFileList::FileSizeTy Size;
+    llvm::sys::fs::UniqueID UniqueID;
+  };
+
+  struct MaterializedFile : FileEntry {
+    StringRef Contents;
+
+    MaterializedFile(StringRef Contents, FileEntry FE)
+        : FileEntry(std::move(FE)), Contents(Contents) {}
+  };
+
+  llvm::StringMap<FileEntry> Files;
+  llvm::StringMap<llvm::sys::fs::UniqueID> Directories;
+
+  llvm::ErrorOr<llvm::vfs::Status> status(const Twine &Path) override {
+    SmallString<128> FilenameBuffer;
+    StringRef Filename = Path.toStringRef(FilenameBuffer);
+
+    auto FileEntry = Files.find(Filename);
+    if (FileEntry != Files.end()) {
+      return makeStatus(Filename, FileEntry->second.Size,
+                        FileEntry->second.UniqueID,
+                        llvm::sys::fs::file_type::regular_file);
+    }
+
+    // Also check whether this is a parent directory status query.
+    auto DirEntry = Directories.find(Filename);
+    if (DirEntry != Directories.end()) {
+      return makeStatus(Filename, /*Size*/ 0, DirEntry->second,
+                        llvm::sys::fs::file_type::directory_file);
+    }
+
+    return llvm::errorToErrorCode(fileError(Filename));
+  }
+
+  llvm::ErrorOr<std::unique_ptr<llvm::vfs::File>>
+  openFileForRead(const Twine &Path) override {
+    SmallString<128> FilenameBuffer;
+    StringRef Filename = Path.toStringRef(FilenameBuffer);
+    auto MaterializedFile = materialize(Filename);
+    if (!MaterializedFile)
+      return llvm::errorToErrorCode(MaterializedFile.takeError());
+    llvm::vfs::Status Stat = makeStatus(
+        Filename, MaterializedFile->Contents.size(), MaterializedFile->UniqueID,
+        llvm::sys::fs::file_type::regular_file);
+    return std::make_unique<IncludeTreeFile>(
+        std::move(Stat), MaterializedFile->Contents,
+        std::move(MaterializedFile->ContentsRef));
+  }
+
+  Expected<MaterializedFile> materialize(StringRef Filename) {
+    auto Entry = Files.find(Filename);
+    if (Entry == Files.end())
+      return fileError(Filename);
+    auto ContentsBlob = CAS.getProxy(Entry->second.ContentsRef);
+    if (!ContentsBlob)
+      return ContentsBlob.takeError();
+
+    return MaterializedFile{ContentsBlob->getData(), Entry->second};
+  }
+
+  static llvm::vfs::Status makeStatus(StringRef Filename, uint64_t Size,
+                                      llvm::sys::fs::UniqueID UniqueID,
+                                      llvm::sys::fs::file_type Type) {
+    const llvm::sys::fs::perms Permissions =
+        llvm::sys::fs::perms::all_read | llvm::sys::fs::perms::owner_write;
+    return llvm::vfs::Status(Filename, UniqueID, llvm::sys::TimePoint<>(),
+                             /*User=*/0,
+                             /*Group=*/0, Size, Type, Permissions);
+  }
+
+  static llvm::Error fileError(StringRef Filename) {
+    return llvm::createFileError(
+        Filename,
+        llvm::createStringError(std::errc::no_such_file_or_directory,
+                                "filename not part of include tree list"));
+  }
+
+  llvm::vfs::directory_iterator dir_begin(const Twine &Dir,
+                                          std::error_code &EC) override {
+    EC = llvm::errc::operation_not_permitted;
+    return llvm::vfs::directory_iterator();
+  }
+  llvm::ErrorOr<std::string> getCurrentWorkingDirectory() const override {
+    return llvm::errc::operation_not_permitted;
+  }
+  std::error_code setCurrentWorkingDirectory(const Twine &Path) override {
+    return llvm::errc::operation_not_permitted;
+  }
+};
+} // namespace
+
+Expected<IntrusiveRefCntPtr<llvm::vfs::FileSystem>>
+cas::createIncludeTreeFileSystem(IncludeTreeRoot &Root) {
+  auto FileList = Root.getFileList();
+  if (!FileList)
+    return FileList.takeError();
+
+  IntrusiveRefCntPtr<IncludeTreeFileSystem> IncludeTreeFS =
+      new IncludeTreeFileSystem(Root.getCAS());
+  llvm::Error E = FileList->forEachFile(
+      [&](IncludeFile File, IncludeFileList::FileSizeTy Size) -> llvm::Error {
+        auto FilenameBlob = File.getFilename();
+        if (!FilenameBlob)
+          return FilenameBlob.takeError();
+        StringRef Filename = FilenameBlob->getData();
+
+        StringRef DirName = llvm::sys::path::parent_path(Filename);
+        if (DirName.empty())
+          DirName = ".";
+        auto &DirEntry = IncludeTreeFS->Directories[DirName];
+        if (DirEntry == llvm::sys::fs::UniqueID()) {
+          DirEntry = llvm::vfs::getNextVirtualUniqueID();
+        }
+
+        IncludeTreeFS->Files.insert(
+            std::make_pair(Filename, IncludeTreeFileSystem::FileEntry{
+                                         File.getContentsRef(), Size,
+                                         llvm::vfs::getNextVirtualUniqueID()}));
+        return llvm::Error::success();
+      });
+  if (E)
+    return std::move(E);
+
+  return IncludeTreeFS;
 }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4447,6 +4447,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &Job,
   {
     const OptSpecifier DepScanOpts[] = {
         options::OPT_fdepscan_EQ,
+        options::OPT_fdepscan_include_tree,
         options::OPT_fdepscan_share_EQ,
         options::OPT_fdepscan_share_identifier,
         options::OPT_fdepscan_share_parent,

--- a/clang/lib/Frontend/CMakeLists.txt
+++ b/clang/lib/Frontend/CMakeLists.txt
@@ -27,6 +27,7 @@ add_clang_library(clangFrontend
   FrontendActions.cpp
   FrontendOptions.cpp
   HeaderIncludeGen.cpp
+  IncludeTreePPActions.cpp
   InitPreprocessor.cpp
   LayoutOverrideSource.cpp
   LogDiagnosticPrinter.cpp

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -474,9 +474,11 @@ void CompilerInstance::createPreprocessor(TranslationUnitKind TUKind) {
   InitializeFileRemapping(PP->getDiagnostics(), PP->getSourceManager(),
                           PP->getFileManager(), PPOpts);
 
-  // Predefine macros and configure the preprocessor.
-  InitializePreprocessor(*PP, PPOpts, getPCHContainerReader(),
-                         getFrontendOpts());
+  if (getFrontendOpts().CASIncludeTreeID.empty()) {
+    // Predefine macros and configure the preprocessor.
+    InitializePreprocessor(*PP, PPOpts, getPCHContainerReader(),
+                           getFrontendOpts());
+  }
 
   // Initialize the header search object.  In CUDA compilations, we use the aux
   // triple (the host triple) to initialize our header search, since we need to

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -28,6 +28,7 @@
 #include "clang/Basic/Version.h"
 #include "clang/Basic/Visibility.h"
 #include "clang/Basic/XRayInstr.h"
+#include "clang/CAS/IncludeTree.h"
 #include "clang/Config/config.h"
 #include "clang/Driver/Driver.h"
 #include "clang/Driver/DriverDiagnostic.h"
@@ -2813,11 +2814,46 @@ static void GenerateFrontendArgs(const FrontendOptions &Opts,
 
   // OPT_INPUT has a unique class, generate it directly.
   for (const auto &Input : Opts.Inputs)
-    Args.push_back(SA(Input.getFile()));
+    if (!Input.isIncludeTree())
+      Args.push_back(SA(Input.getFile()));
+}
+
+static void determineInputFromIncludeTree(
+    StringRef IncludeTreeID, CASOptions &CASOpts, DiagnosticsEngine &Diags,
+    Optional<cas::IncludeTreeRoot> &IncludeTree, StringRef &InputFilename) {
+  assert(!IncludeTreeID.empty());
+  auto reportError = [&](llvm::Error &&E) {
+    Diags.Report(diag::err_fe_unable_to_load_include_tree)
+        << IncludeTreeID << llvm::toString(std::move(E));
+  };
+  auto CAS = CASOpts.getOrCreateCAS(Diags);
+  if (!CAS)
+    return;
+  auto ID = CAS->parseID(IncludeTreeID);
+  if (!ID)
+    return reportError(ID.takeError());
+  auto Object = CAS->getReference(*ID);
+  if (!Object)
+    return reportError(llvm::cas::CASDB::createUnknownObjectError(*ID));
+  auto Root = cas::IncludeTreeRoot::get(*CAS, *Object);
+  if (!Root)
+    return reportError(Root.takeError());
+  auto MainTree = Root->getMainFileTree();
+  if (!MainTree)
+    return reportError(MainTree.takeError());
+  auto BaseFile = MainTree->getBaseFile();
+  if (!BaseFile)
+    return reportError(BaseFile.takeError());
+  auto FilenameBlob = BaseFile->getFilename();
+  if (!FilenameBlob)
+    return reportError(FilenameBlob.takeError());
+  InputFilename = FilenameBlob->getData();
+  IncludeTree = *Root;
 }
 
 static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
-                              DiagnosticsEngine &Diags, bool &IsHeaderFile) {
+                              CASOptions &CASOpts, DiagnosticsEngine &Diags,
+                              bool &IsHeaderFile) {
   unsigned NumErrorsBefore = Diags.getNumErrors();
 
   FrontendOptions &FrontendOpts = Opts;
@@ -3033,6 +3069,19 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   // '-' is the default input if none is given.
   std::vector<std::string> Inputs = Args.getAllArgValues(OPT_INPUT);
   Opts.Inputs.clear();
+
+  Optional<cas::IncludeTreeRoot> Tree;
+  if (!Opts.CASIncludeTreeID.empty()) {
+    if (!Inputs.empty()) {
+      Diags.Report(diag::err_drv_inputs_and_include_tree);
+    }
+    StringRef InputFilename;
+    determineInputFromIncludeTree(Opts.CASIncludeTreeID, CASOpts, Diags, Tree,
+                                  InputFilename);
+    if (!InputFilename.empty())
+      Inputs.push_back(InputFilename.str());
+  }
+
   if (Inputs.empty())
     Inputs.push_back("-");
 
@@ -3063,6 +3112,12 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     }
 
     Opts.Inputs.emplace_back(std::move(Inputs[i]), IK, IsSystem);
+  }
+
+  if (Tree) {
+    FrontendInputFile &InputFile = Opts.Inputs.back();
+    InputFile = FrontendInputFile(Tree->getRef(), InputFile.getFile(),
+                                  InputFile.getKind(), InputFile.isSystem());
   }
 
   Opts.DashX = DashX;
@@ -4650,7 +4705,8 @@ bool CompilerInvocation::CreateFromArgsImpl(
   ParseAnalyzerArgs(*Res.getAnalyzerOpts(), Args, Diags);
   ParseDiagnosticArgs(Res.getDiagnosticOpts(), Args, &Diags,
                       /*DefaultDiagColor=*/false);
-  ParseFrontendArgs(Res.getFrontendOpts(), Args, Diags, LangOpts.IsHeaderFile);
+  ParseFrontendArgs(Res.getFrontendOpts(), Args, Res.getCASOpts(), Diags,
+                    LangOpts.IsHeaderFile);
   // FIXME: We shouldn't have to pass the DashX option around here
   InputKind DashX = Res.getFrontendOpts().DashX;
   ParseTargetArgs(Res.getTargetOpts(), Args, Diags);

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -12,10 +12,12 @@
 #include "clang/AST/DeclGroup.h"
 #include "clang/Basic/Builtins.h"
 #include "clang/Basic/LangStandard.h"
+#include "clang/CAS/IncludeTree.h"
 #include "clang/Frontend/ASTUnit.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendDiagnostic.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Frontend/IncludeTreePPActions.h"
 #include "clang/Frontend/LayoutOverrideSource.h"
 #include "clang/Frontend/MultiplexConsumer.h"
 #include "clang/Frontend/Utils.h"
@@ -843,6 +845,31 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
     if (CI.getLangOpts().ModuleName.empty())
       CI.getLangOpts().ModuleName = std::string(FileName);
     CI.getLangOpts().CurrentModule = CI.getLangOpts().ModuleName;
+  }
+
+  if (Input.isIncludeTree()) {
+    auto reportError = [&](llvm::Error &&E) -> bool {
+      std::string IncludeTreeID =
+          CI.getOrCreateCAS().getID(Input.getIncludeTree()).toString();
+      CI.getDiagnostics().Report(diag::err_fe_unable_to_load_include_tree)
+          << IncludeTreeID << llvm::toString(std::move(E));
+      return false;
+    };
+    auto Root =
+        cas::IncludeTreeRoot::get(CI.getOrCreateCAS(), Input.getIncludeTree());
+    if (!Root)
+      return reportError(Root.takeError());
+    auto IncludeTreeFS = cas::createIncludeTreeFileSystem(*Root);
+    if (!IncludeTreeFS)
+      return reportError(IncludeTreeFS.takeError());
+    CI.getFileManager().setVirtualFileSystem(std::move(*IncludeTreeFS));
+
+    Expected<std::unique_ptr<PPCachedActions>> PPCachedAct =
+        createPPActionsFromIncludeTree(*Root);
+    if (!PPCachedAct)
+      return reportError(PPCachedAct.takeError());
+    CI.getPreprocessor().setPPCachedActions(std::move(*PPCachedAct));
+    CI.getFrontendOpts().IncludeTimestamps = false;
   }
 
   if (!CI.InitializeSourceManager(Input))

--- a/clang/lib/Frontend/IncludeTreePPActions.cpp
+++ b/clang/lib/Frontend/IncludeTreePPActions.cpp
@@ -1,0 +1,154 @@
+//===- IncludeTreePPActions.cpp - PP actions using include-tree -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Frontend/IncludeTreePPActions.h"
+#include "clang/CAS/IncludeTree.h"
+#include "clang/Frontend/FrontendDiagnostic.h"
+#include "clang/Lex/PPCachedActions.h"
+#include "clang/Lex/Preprocessor.h"
+
+using namespace clang;
+
+namespace {
+
+struct IncludeStackInfo {
+  cas::IncludeTree Tree;
+  SourceLocation FileStartLoc;
+  unsigned CurIncludeIndex = 0;
+  unsigned CurHasIncludeCheckIndex = 0;
+};
+
+/// Uses the info from an \p IncludeTreeRoot to resolve include directives
+/// and evaluate \p __has_include checks.
+class IncludeTreePPActions final : public PPCachedActions {
+  cas::IncludeTree MainTree;
+  SmallVector<IncludeStackInfo> IncludeStack;
+  bool HasCASErrorOccurred = false;
+
+  void reportError(Preprocessor &PP, llvm::Error &&E) {
+    PP.getDiagnostics().Report(diag::err_unable_to_load_include_tree_node)
+        << llvm::toString(std::move(E));
+    HasCASErrorOccurred = true;
+  }
+
+public:
+  IncludeTreePPActions(cas::IncludeTree MainTree)
+      : MainTree(std::move(MainTree)) {}
+
+  FileID handlePredefines(Preprocessor &PP) override {
+    auto createEmptyFID = [&]() -> FileID {
+      llvm::MemoryBufferRef Buffer({}, "<built-in>");
+      return PP.getSourceManager().createFileID(Buffer);
+    };
+
+    if (HasCASErrorOccurred) {
+      return createEmptyFID();
+    }
+
+    auto reportError = [&](llvm::Error &&E) -> FileID {
+      this->reportError(PP, std::move(E));
+      return createEmptyFID();
+    };
+
+    SourceManager &SM = PP.getSourceManager();
+    SourceLocation MainFileLoc = SM.getLocForStartOfFile(SM.getMainFileID());
+    IncludeStack.push_back({std::move(MainTree), MainFileLoc});
+
+    IncludeStackInfo &IncludeInfo = IncludeStack.back();
+    Expected<cas::IncludeTree> EnteredTree =
+        IncludeInfo.Tree.getInclude(IncludeInfo.CurIncludeIndex++);
+    if (!EnteredTree)
+      return reportError(EnteredTree.takeError());
+    auto FileInfo = EnteredTree->getBaseFileInfo();
+    if (!FileInfo)
+      return reportError(FileInfo.takeError());
+    llvm::MemoryBufferRef Buffer(FileInfo->Contents, FileInfo->Filename);
+    FileID FID = SM.createFileID(Buffer);
+    IncludeStack.push_back(
+        {std::move(*EnteredTree), SM.getLocForStartOfFile(FID)});
+    return FID;
+  }
+
+  bool evaluateHasInclude(Preprocessor &PP, SourceLocation Loc,
+                          bool IsIncludeNext) override {
+    if (HasCASErrorOccurred)
+      return false;
+
+    IncludeStackInfo &IncludeInfo = IncludeStack.back();
+    unsigned Index = IncludeInfo.CurHasIncludeCheckIndex++;
+    return IncludeInfo.Tree.getCheckResult(Index);
+  }
+
+  Optional<FileID>
+  handleIncludeDirective(Preprocessor &PP, SourceLocation IncludeLoc,
+                         SourceLocation AfterDirectiveLoc) override {
+    if (HasCASErrorOccurred)
+      return None;
+
+    IncludeStackInfo &IncludeInfo = IncludeStack.back();
+    if (IncludeInfo.CurIncludeIndex >= IncludeInfo.Tree.getNumIncludes())
+      return None;
+
+    unsigned ExpectedOffset =
+        IncludeInfo.Tree.getIncludeOffset(IncludeInfo.CurIncludeIndex);
+    SourceLocation ExpectedLoc =
+        IncludeInfo.FileStartLoc.getLocWithOffset(ExpectedOffset);
+    if (ExpectedLoc != AfterDirectiveLoc)
+      return None;
+
+    auto reportError = [&](llvm::Error &&E) -> Optional<FileID> {
+      this->reportError(PP, std::move(E));
+      return None;
+    };
+
+    Expected<cas::IncludeTree> EnteredTree =
+        IncludeInfo.Tree.getInclude(IncludeInfo.CurIncludeIndex++);
+    if (!EnteredTree)
+      return reportError(EnteredTree.takeError());
+    auto File = EnteredTree->getBaseFile();
+    if (!File)
+      return reportError(File.takeError());
+    auto FilenameBlob = File->getFilename();
+    if (!FilenameBlob)
+      return reportError(FilenameBlob.takeError());
+
+    SourceManager &SM = PP.getSourceManager();
+    Expected<FileEntryRef> FE =
+        SM.getFileManager().getFileRef(FilenameBlob->getData(),
+                                       /*OpenFile=*/true);
+    if (!FE)
+      return reportError(FE.takeError());
+    FileID FID =
+        SM.createFileID(*FE, IncludeLoc, EnteredTree->getFileCharacteristic());
+    PP.markIncluded(*FE);
+    IncludeStack.push_back(
+        {std::move(*EnteredTree), SM.getLocForStartOfFile(FID)});
+    return FID;
+  }
+
+  void exitedFile(Preprocessor &PP, FileID FID) override {
+    if (HasCASErrorOccurred)
+      return;
+
+    assert(!IncludeStack.empty());
+    assert(IncludeStack.back().FileStartLoc ==
+           PP.getSourceManager().getLocForStartOfFile(FID));
+    assert(IncludeStack.back().CurIncludeIndex ==
+           IncludeStack.back().Tree.getNumIncludes());
+    IncludeStack.pop_back();
+  }
+};
+} // namespace
+
+Expected<std::unique_ptr<PPCachedActions>>
+clang::createPPActionsFromIncludeTree(cas::IncludeTreeRoot &Root) {
+  auto MainTree = Root.getMainFileTree();
+  if (!MainTree)
+    return MainTree.takeError();
+  return std::make_unique<IncludeTreePPActions>(std::move(*MainTree));
+}

--- a/clang/lib/Lex/PPCallbacks.cpp
+++ b/clang/lib/Lex/PPCallbacks.cpp
@@ -8,6 +8,7 @@
 
 #include "clang/Lex/PPCallbacks.h"
 #include "clang/Basic/FileManager.h"
+#include "clang/Lex/PPCachedActions.h"
 
 using namespace clang;
 
@@ -28,3 +29,4 @@ void PPChainedCallbacks::HasInclude(SourceLocation Loc, StringRef FileName,
   Second->HasInclude(Loc, FileName, IsAngled, File, FileType);
 }
 
+void PPCachedActions::anchor() {}

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -1872,6 +1872,32 @@ void Preprocessor::HandleIncludeDirective(SourceLocation HashLoc,
     return;
   }
 
+  if (auto *CActions = getPPCachedActions()) {
+    DiscardUntilEndOfDirective();
+    SourceLocation IncludePos = FilenameTok.getLocation();
+    // If the filename string was the result of macro expansions, set the
+    // include position on the file where it will be included and after the
+    // expansions.
+    if (IncludePos.isMacroID())
+      IncludePos = SourceMgr.getExpansionRange(IncludePos).getEnd();
+    Optional<FileID> FID = CActions->handleIncludeDirective(
+        *this, IncludePos, CurLexer->getSourceLocation());
+    if (!FID) {
+      // FIXME: Report \p Callbacks->FileSkipped? Note that it currently
+      // requires the resolved FileEntry for this particular #include.
+      return;
+    }
+    const FileEntry *FE = SourceMgr.getFileEntryForID(*FID);
+    bool IsImport =
+        IncludeTok.getIdentifierInfo()->getPPKeywordID() == tok::pp_import;
+    if (FE && IsImport) {
+      HeaderInfo.getFileInfo(FE).isImport = true;
+    }
+    EnterSourceFile(*FID, nullptr, FilenameTok.getLocation(),
+                    /*IsFirstIncludeOfFile*/ true);
+    return;
+  }
+
   // Verify that there is nothing after the filename, other than EOD.  Note
   // that we allow macros that expand to nothing after the filename, because
   // this falls into the category of "#include pp-tokens new-line" specified

--- a/clang/lib/Lex/PPLexerChange.cpp
+++ b/clang/lib/Lex/PPLexerChange.cpp
@@ -544,6 +544,10 @@ bool Preprocessor::HandleEndOfFile(Token &Result, SourceLocation EndLoc,
                                   PPCallbacks::LexedFileChangeReason::ExitFile,
                                   FileType, ExitedFID, Loc);
     }
+    if (auto *CActions = getPPCachedActions()) {
+      if (ExitedFID.isValid())
+        CActions->exitedFile(*this, ExitedFID);
+    }
 
     // Restore conditional stack as well as the recorded
     // \#pragma clang assume_nonnull from the preamble right after exiting

--- a/clang/lib/Lex/PPMacroExpansion.cpp
+++ b/clang/lib/Lex/PPMacroExpansion.cpp
@@ -1157,11 +1157,14 @@ static bool HasExtension(const Preprocessor &PP, StringRef Extension) {
 
 /// EvaluateHasIncludeCommon - Process a '__has_include("path")'
 /// or '__has_include_next("path")' expression.
+/// If \p Precomputed is set it progresses the lexer but doesn't do a file
+/// lookup, it returns the value of \p Precomputed instead.
 /// Returns true if successful.
 static bool EvaluateHasIncludeCommon(Token &Tok, IdentifierInfo *II,
                                      Preprocessor &PP,
                                      ConstSearchDirIterator LookupFrom,
-                                     const FileEntry *LookupFromFile) {
+                                     const FileEntry *LookupFromFile,
+                                     Optional<bool> Precomputed) {
   // Save the location of the current token.  If a '(' is later found, use
   // that location.  If not, use the end of this location instead.
   SourceLocation LParenLoc = Tok.getLocation();
@@ -1222,6 +1225,9 @@ static bool EvaluateHasIncludeCommon(Token &Tok, IdentifierInfo *II,
     return false;
   }
 
+  if (Precomputed)
+    return *Precomputed;
+
   bool isAngled = PP.GetIncludeFilenameSpelling(Tok.getLocation(), Filename);
   // If GetIncludeFilenameSpelling set the start ptr to null, there was an
   // error.
@@ -1246,15 +1252,27 @@ static bool EvaluateHasIncludeCommon(Token &Tok, IdentifierInfo *II,
 }
 
 bool Preprocessor::EvaluateHasInclude(Token &Tok, IdentifierInfo *II) {
-  return EvaluateHasIncludeCommon(Tok, II, *this, nullptr, nullptr);
+  Optional<bool> Precomputed;
+  if (auto *CActions = getPPCachedActions()) {
+    Precomputed = CActions->evaluateHasInclude(*this, Tok.getLocation(),
+                                               /*IsIncludeNext*/ false);
+  }
+  return EvaluateHasIncludeCommon(Tok, II, *this, nullptr, nullptr,
+                                  Precomputed);
 }
 
 bool Preprocessor::EvaluateHasIncludeNext(Token &Tok, IdentifierInfo *II) {
+  Optional<bool> Precomputed;
+  if (auto *CActions = getPPCachedActions()) {
+    Precomputed = CActions->evaluateHasInclude(*this, Tok.getLocation(),
+                                               /*IsIncludeNext*/ true);
+  }
   ConstSearchDirIterator Lookup = nullptr;
   const FileEntry *LookupFromFile;
   std::tie(Lookup, LookupFromFile) = getIncludeNextStart(Tok);
 
-  return EvaluateHasIncludeCommon(Tok, II, *this, Lookup, LookupFromFile);
+  return EvaluateHasIncludeCommon(Tok, II, *this, Lookup, LookupFromFile,
+                                  Precomputed);
 }
 
 /// Process single-argument builtin feature-like macros that return

--- a/clang/lib/Lex/Preprocessor.cpp
+++ b/clang/lib/Lex/Preprocessor.cpp
@@ -554,12 +554,17 @@ void Preprocessor::EnterMainSourceFile() {
       markIncluded(FE);
   }
 
-  // Preprocess Predefines to populate the initial preprocessor state.
-  std::unique_ptr<llvm::MemoryBuffer> SB =
-    llvm::MemoryBuffer::getMemBufferCopy(Predefines, "<built-in>");
-  assert(SB && "Cannot create predefined source buffer");
-  FileID FID = SourceMgr.createFileID(std::move(SB));
-  assert(FID.isValid() && "Could not create FileID for predefines?");
+  FileID FID;
+  if (auto *CActions = getPPCachedActions()) {
+    FID = CActions->handlePredefines(*this);
+  } else {
+    // Preprocess Predefines to populate the initial preprocessor state.
+    std::unique_ptr<llvm::MemoryBuffer> SB =
+        llvm::MemoryBuffer::getMemBufferCopy(Predefines, "<built-in>");
+    assert(SB && "Cannot create predefined source buffer");
+    FID = SourceMgr.createFileID(std::move(SB));
+    assert(FID.isValid() && "Could not create FileID for predefines?");
+  }
   setPredefinesFileID(FID);
 
   // Start parsing the predefines.

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -250,6 +250,7 @@ private:
   cas::CASDB &DB;
   Optional<cas::ObjectRef> PCHRef;
   llvm::BitVector SeenIncludeFiles;
+  SmallVector<cas::IncludeFileList::FileEntry> IncludedFiles;
   Optional<cas::ObjectRef> PredefinesBufferRef;
   SmallVector<FilePPState> IncludeStack;
   llvm::DenseMap<const FileEntry *, Optional<cas::ObjectRef>> ObjectForFile;
@@ -332,6 +333,7 @@ IncludeTreePPConsumer::getObjectForFileNonCached(FileManager &FM,
       cas::IncludeFile::create(DB, Filename, **CASContents);
   if (!FileNode)
     return FileNode.takeError();
+  IncludedFiles.push_back({FileNode->getRef(), FI.getContentCache().getSize()});
   return FileNode->getRef();
 }
 
@@ -365,8 +367,12 @@ Expected<cas::IncludeTreeRoot> IncludeTreePPConsumer::getIncludeTree() {
       getCASTreeForFileIncludes(IncludeStack.pop_back_val());
   if (!MainIncludeTree)
     return MainIncludeTree.takeError();
+  auto FileList = cas::IncludeFileList::create(DB, IncludedFiles);
+  if (!FileList)
+    return FileList.takeError();
 
-  return cas::IncludeTreeRoot::create(DB, MainIncludeTree->getRef());
+  return cas::IncludeTreeRoot::create(DB, MainIncludeTree->getRef(),
+                                      FileList->getRef());
 }
 
 Expected<cas::IncludeTreeRoot> DependencyScanningTool::getIncludeTree(

--- a/clang/test/CAS/depscan-include-tree.c
+++ b/clang/test/CAS/depscan-include-tree.c
@@ -1,0 +1,43 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %clang -cc1depscan -o %t/inline.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args -cc1 -triple x86_64-apple-macos11.0 \
+// RUN:     -fsyntax-only %t/t.c -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -DSOME_MACRO -dependency-file %t/inline.d -MT deps
+// RUN: %clang -cc1depscan -o %t/daemon.rsp -fdepscan=daemon -fdepscan-include-tree -cc1-args -cc1 -triple x86_64-apple-macos11.0 \
+// RUN:     -fsyntax-only %t/t.c -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -DSOME_MACRO -dependency-file %t/daemon.d -MT deps
+
+// RUN: diff -u %t/inline.rsp %t/daemon.rsp
+// RUN: FileCheck %s -input-file %t/inline.rsp -DPREFIX=%t
+// RUN: FileCheck %s -input-file %t/inline.rsp -DPREFIX=%t -check-prefix=SHOULD
+
+// RUN: %clang @%t/inline.rsp
+
+// CHECK: "-fcas-path" "[[PREFIX]]/cas"
+// CHECK: "-fcas-include-tree"
+// SHOULD-NOT: "-fcas-fs"
+// SHOULD-NOT: "-fcas-fs-working-directory"
+// SHOULD-NOT: "-isysroot"
+// SHOULD-NOT: "-I"
+// SHOULD-NOT: "[[PREFIX]]/t.c"
+// SHOULD-NOT: "-D"
+
+// RUN: diff -u %t/inline.d %t/daemon.d
+// RUN: FileCheck %s -input-file %t/inline.d -check-prefix=DEPS -DPREFIX=%t
+
+// DEPS: deps:
+// DEPS: [[PREFIX]]/t.c
+// DEPS: [[PREFIX]]/includes/t.h
+
+int test() { return 0; }
+
+//--- t.c
+#include "t.h"
+
+int test(struct S *s) {
+  return s->x;
+}
+
+//--- includes/t.h
+struct S {
+  int x;
+};

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -22,6 +22,10 @@
 // CLANGPP: "-greproducible"
 // CLANGPP: "-x" "c++"
 
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_ENABLE_INCLUDE_TREE=1 %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=INCLUDE-TREE -DPREFIX=%t
+// INCLUDE-TREE: "-cc1depscan" "-fdepscan=auto"
+// INCLUDE-TREE: "-fdepscan-include-tree"
+
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=SESSION -DPREFIX=%t
 // SESSION: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-share-identifier"
 // SESSION: "-fcas-path" "[[PREFIX]]/cas"

--- a/clang/test/CAS/fcas-include-tree.c
+++ b/clang/test/CAS/fcas-include-tree.c
@@ -1,0 +1,67 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 %t/t1.c -E -P -o %t/source.i -isystem %t -DCMD_MACRO=1 -Werror
+// RUN: %clang_cc1 %t/t1.c -emit-llvm -o %t/source.ll -isystem %t -DCMD_MACRO=1 -Werror -dependency-file %t/t1-source.d -MT deps
+
+// RUN: %clang -cc1depscan -o %t/inline.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
+// RUN:     -cc1 %t/t1.c -isystem %t -DCMD_MACRO=1 -fcas-path %t/cas
+// RUN: %clang @%t/inline.rsp -E -P -o %t/tree.i -Werror
+// RUN: diff -u %t/source.i %t/tree.i
+// RUN: %clang @%t/inline.rsp -emit-llvm -o %t/tree.ll -Werror -dependency-file %t/t1-tree.d -MT deps
+// RUN: diff -u %t/source.ll %t/tree.ll
+// RUN: diff -u %t/t1-source.d %t/t1-tree.d
+
+//--- t1.c
+#include "top.h"
+#include "n1.h"
+#include <sys.h>
+
+#define N2H <n2.h>
+#include N2H
+
+int test(struct S *s) {
+  return s->x + gv + gv2 + SOMEVAL + SOMEVAL2 + CMD_MACRO;
+}
+
+//--- top.h
+#ifndef _TOP_H_
+#define _TOP_H_
+
+#if __has_include("n1.h")
+#define SOMEVAL 1
+#endif
+
+#if __has_include("nonexistent.h")
+#define SOMEVAL 7
+#else
+#define SOMEVAL2 2
+#endif
+
+#include "n1.h"
+
+struct S {
+  int x;
+};
+
+#endif
+
+//--- sys.h
+#define SOMECHECK defined(SOMEDEF)
+// This triggers warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
+#if SOMECHECK
+#endif
+
+//--- n1.h
+#ifndef _N1_H_
+#define _N1_H_
+
+#pragma once
+#pragma clang system_header
+
+int gv;
+
+#endif
+
+//--- n2.h
+int gv2;

--- a/clang/test/CAS/print-compile-job-cache-key.c
+++ b/clang/test/CAS/print-compile-job-cache-key.c
@@ -33,3 +33,21 @@
 // CHECK:   file llvmcas://
 // CHECK: version: llvmcas://
 // CHECK:   clang version
+
+// Print a key containing an include-tree.
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_ENABLE_INCLUDE_TREE=1 %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/output.o -Rcompile-job-cache 2> %t/output-tree.txt
+
+// RUN: cat %t/output-tree.txt | sed \
+// RUN:   -e "s/^.*miss for '//" \
+// RUN:   -e "s/' .*$//" > %t/cache-key-tree
+
+// RUN: clang-cas-test -print-compile-job-cache-key -cas %t/cas @%t/cache-key-tree | FileCheck %s -check-prefix=INCLUDE_TREE -DSRC_FILE=%s
+//
+// INCLUDE_TREE: command-line: llvmcas://
+// INCLUDE_TREE: computation: llvmcas://
+// INCLUDE_TREE: include-tree: llvmcas://
+// INCLUDE_TREE-NEXT: [[SRC_FILE]] llvmcas://
+// INCLUDE_TREE: Files:
+// INCLUDE_TREE-NEXT: [[SRC_FILE]] llvmcas://

--- a/clang/test/ClangScanDeps/include-tree.c
+++ b/clang/test/ClangScanDeps/include-tree.c
@@ -20,6 +20,12 @@
 // ORDER-NEXT:     [[PREFIX]]/n3.h
 // ORDER-NEXT: [[PREFIX]]/n3.h
 // ORDER-NEXT: [[PREFIX]]/n2.h
+// ORDER-NEXT: Files:
+// ORDER-NEXT: [[PREFIX]]/t.c
+// ORDER-NEXT: [[PREFIX]]/top.h
+// ORDER-NEXT: [[PREFIX]]/n1.h
+// ORDER-NEXT: [[PREFIX]]/n2.h
+// ORDER-NEXT: [[PREFIX]]/n3.h
 // ORDER-NOT: [[PREFIX]]
 
 

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -260,6 +260,7 @@ llvm::cl::opt<bool> Verbose("v", llvm::cl::Optional,
 } // end anonymous namespace
 
 static bool emitCompilationDBWithCASTreeArguments(
+    std::shared_ptr<llvm::cas::CASDB> DB,
     std::vector<tooling::CompileCommand> Inputs,
     DiagnosticConsumer &DiagsConsumer, const char *Exec,
     const cc1depscand::DepscanPrefixMapping &PrefixMapping,
@@ -274,12 +275,18 @@ static bool emitCompilationDBWithCASTreeArguments(
     DependencyScanningTool Worker;
     llvm::BumpPtrAllocator Alloc;
     llvm::StringSaver Saver;
-    explicit PerThreadState(DependencyScanningService &Service)
-        : Worker(Service), Saver(Alloc) {}
+    PerThreadState(DependencyScanningService &Service,
+                   std::unique_ptr<llvm::vfs::FileSystem> FS)
+        : Worker(Service, std::move(FS)), Saver(Alloc) {}
   };
   std::vector<std::unique_ptr<PerThreadState>> PerThreadStates;
-  for (unsigned I = 0, E = Pool.getThreadCount(); I != E; ++I)
-    PerThreadStates.push_back(std::make_unique<PerThreadState>(Service));
+  for (unsigned I = 0, E = Pool.getThreadCount(); I != E; ++I) {
+    std::unique_ptr<llvm::vfs::FileSystem> FS =
+        llvm::cas::createCASProvidingFileSystem(
+            DB, llvm::vfs::createPhysicalFileSystem());
+    PerThreadStates.push_back(
+        std::make_unique<PerThreadState>(Service, std::move(FS)));
+  }
 
   std::atomic<bool> HadErrors(false);
   std::mutex Lock;
@@ -315,6 +322,7 @@ static bool emitCompilationDBWithCASTreeArguments(
             PerThreadStates[I]->Worker;
 
         class ScanForCC1Action : public ToolAction {
+          llvm::cas::CASDB &DB;
           tooling::dependencies::DependencyScanningTool &WorkerTool;
           DiagnosticConsumer &DiagsConsumer;
           const char *Exec;
@@ -325,13 +333,14 @@ static bool emitCompilationDBWithCASTreeArguments(
 
         public:
           ScanForCC1Action(
+              llvm::cas::CASDB &DB,
               tooling::dependencies::DependencyScanningTool &WorkerTool,
               DiagnosticConsumer &DiagsConsumer, const char *Exec,
               StringRef CWD,
               const cc1depscand::DepscanPrefixMapping &PrefixMapping,
               SmallVectorImpl<const char *> &OutputArgs,
               llvm::StringSaver &Saver)
-              : WorkerTool(WorkerTool), DiagsConsumer(DiagsConsumer),
+              : DB(DB), WorkerTool(WorkerTool), DiagsConsumer(DiagsConsumer),
                 Exec(Exec), CWD(CWD), PrefixMapping(PrefixMapping),
                 OutputArgs(OutputArgs), Saver(Saver) {}
 
@@ -342,7 +351,7 @@ static bool emitCompilationDBWithCASTreeArguments(
                         DiagnosticConsumer *DiagConsumer) override {
             Expected<llvm::cas::CASID> Root = scanAndUpdateCC1InlineWithTool(
                 WorkerTool, DiagsConsumer, /*VerboseOS*/ nullptr, Exec,
-                *Invocation, CWD, PrefixMapping);
+                *Invocation, CWD, PrefixMapping, DB);
             if (!Root) {
               llvm::consumeError(Root.takeError());
               return false;
@@ -358,8 +367,8 @@ static bool emitCompilationDBWithCASTreeArguments(
         SmallVector<const char *> OutputArgs;
         llvm::StringSaver &Saver = PerThreadStates[I]->Saver;
         OutputArgs.push_back(Saver.save(Input->CommandLine.front()).data());
-        ScanForCC1Action Action(WorkerTool, *IgnoringDiagsConsumer, Exec, CWD,
-                                PrefixMapping, OutputArgs, Saver);
+        ScanForCC1Action Action(*DB, WorkerTool, *IgnoringDiagsConsumer, Exec,
+                                CWD, PrefixMapping, OutputArgs, Saver);
 
         llvm::IntrusiveRefCntPtr<FileManager> FileMgr =
             WorkerTool.getOrCreateFileManager();
@@ -819,8 +828,8 @@ int main(int argc, const char **argv) {
     // FIXME: Configure this.
     cc1depscand::DepscanPrefixMapping PrefixMapping;
     return emitCompilationDBWithCASTreeArguments(
-        AdjustingCompilations->getAllCompileCommands(), *DiagsConsumer, argv[0],
-        PrefixMapping, Service, Pool, llvm::outs());
+        CAS, AdjustingCompilations->getAllCompileCommands(), *DiagsConsumer,
+        argv[0], PrefixMapping, Service, Pool, llvm::outs());
   }
 
   std::vector<std::unique_ptr<DependencyScanningTool>> WorkerTools;

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -126,6 +126,9 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
     } else {
       Args.push_back("-fdepscan");
     }
+    if (::getenv("CLANG_CACHE_ENABLE_INCLUDE_TREE")) {
+      Args.push_back("-fdepscan-include-tree");
+    }
     if (const char *PrefixMaps = ::getenv("LLVM_CACHE_PREFIX_MAPS")) {
       Args.append({"-fdepscan-prefix-map-sdk=/^sdk",
                    "-fdepscan-prefix-map-toolchain=/^toolchain"});


### PR DESCRIPTION
The `include-tree` is added as an alternative method to `casfs` for dep-scanning and for driving a compilation.
For a `clang-cache` invocation it is enabled via the `CLANG_CACHE_ENABLE_INCLUDE_TREE` environment variable.

Due to avoiding header file lookups there's a measurable improvement for preprocessing performance.
The following are wall-time measurements on an M1Pro with a thin-LTO enabled build; preprocess-only compilations
are performed on all the files that are linked to the clang executable, using:

* The arguments produced with include-tree dep-scanning
* The arguments produced with CASFS dep-scanning
* The normal compilation arguments

|              | casfs | normal |
|--------------|-------|--------|
| include-tree | -7.2% | -21.5% |

(cherry picked from commit 5f899118c356b54d11a2bd448ddabf6f2a0346b9)