### PR TITLE
[lldb][Test] Disable flakey tests on Swift branch

### DIFF
--- a/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
+++ b/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
@@ -19,6 +19,7 @@ class TestMultipleSimultaneousDebuggers(TestBase):
 
     @skipIfNoSBHeaders
     @skipIfWindows
+    @skipIfAsan # rdar://95807640
     def test_multiple_debuggers(self):
         env = {self.dylibPath: self.getLLDBLibraryEnvVal()}
 

--- a/lldb/test/Shell/Host/TestCustomShell.test
+++ b/lldb/test/Shell/Host/TestCustomShell.test
@@ -4,6 +4,7 @@
 # XFAIL: system-freebsd
 # XFAIL: system-netbsd
 # XFAIL: system-openbsd
+# REQUIRES: rdar98577095
 
 # RUN: %clang_host %S/Inputs/simple.c -g -o %t.out
 # RUN: SHELL=bogus not %lldb %t.out -b -o 'process launch -X 1 --' 2>&1 | FileCheck %s --check-prefix ERROR


### PR DESCRIPTION
Disable these for now. They are known to be flakey
and the failures reproduce neither on the llvm.org
LLDB build bots nor locally.