### PR TITLE
[cherry-pick][swift/release/5.7] [lldb] Skip target variable tests on Darwin because of chained fixups

### DIFF
--- a/lldb/test/API/commands/target/basic/TestTargetCommand.py
+++ b/lldb/test/API/commands/target/basic/TestTargetCommand.py
@@ -44,7 +44,7 @@ class targetCommandTestCase(TestBase):
         self.buildAll()
         self.do_target_command()
 
-    @expectedFailureDarwin(archs=["arm64", "arm64e"]) # <rdar://problem/37773624>
+    @skipIfDarwin # Chained Fixups
     def test_target_variable_command(self):
         """Test 'target variable' command before and after starting the inferior."""
         d = {'C_SOURCES': 'globals.c', 'EXE': self.getBuildArtifact('globals')}
@@ -53,7 +53,7 @@ class targetCommandTestCase(TestBase):
 
         self.do_target_variable_command('globals')
 
-    @expectedFailureDarwin(archs=["arm64", "arm64e"]) # <rdar://problem/37773624>
+    @skipIfDarwin # Chained Fixups
     def test_target_variable_command_no_fail(self):
         """Test 'target variable' command before and after starting the inferior."""
         d = {'C_SOURCES': 'globals.c', 'EXE': self.getBuildArtifact('globals')}

--- a/lldb/test/API/lang/c/global_variables/TestGlobalVariables.py
+++ b/lldb/test/API/lang/c/global_variables/TestGlobalVariables.py
@@ -20,8 +20,8 @@ class GlobalVariablesTestCase(TestBase):
             self.source, '// Set break point at this line.')
         self.shlib_names = ["a"]
 
+    @skipIfDarwin # Chained Fixups
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764")
-    @expectedFailureDarwin(archs=["arm64", "arm64e"]) # <rdar://problem/37773624>
     def test_without_process(self):
         """Test that static initialized variables can be inspected without
         process."""


### PR DESCRIPTION
When targeting macOS Ventura, ld64 will use authenticated fixups for
x86_64 as well as arm64 (where that has always been the case). This
results in test failures when using an Xcode 14 toolchain on an Intel
mac running macOS Ventura:

  Failed Tests (3):
    lldb-api :: commands/target/basic/TestTargetCommand.py
    lldb-api :: lang/c/global_variables/TestGlobalVariables.py
    lldb-api :: lang/cpp/char8_t/TestCxxChar8_t.py

Rather than trying to come up with a sophisticated decorator based off
the deployment target, I marked them all as skipped with a comment
explaining why.

Differential revision: https://reviews.llvm.org/D131741

(cherry picked from commit abe9599f04f07baae46f4123d4c43d330f34df52)