### PR TITLE
[lldb] Skip target variable tests on Darwin because of chained fixups

### DIFF
--- a/lldb/test/API/commands/target/basic/TestTargetCommand.py
+++ b/lldb/test/API/commands/target/basic/TestTargetCommand.py
@@ -42,7 +42,7 @@ class targetCommandTestCase(TestBase):
         self.buildAll()
         self.do_target_command()
 
-    @expectedFailureDarwin(archs=["arm64", "arm64e"]) # <rdar://problem/37773624>
+    @skipIfDarwin # Chained Fixups
     def test_target_variable_command(self):
         """Test 'target variable' command before and after starting the inferior."""
         d = {'C_SOURCES': 'globals.c', 'EXE': self.getBuildArtifact('globals')}
@@ -51,7 +51,7 @@ class targetCommandTestCase(TestBase):
 
         self.do_target_variable_command('globals')
 
-    @expectedFailureDarwin(archs=["arm64", "arm64e"]) # <rdar://problem/37773624>
+    @skipIfDarwin # Chained Fixups
     def test_target_variable_command_no_fail(self):
         """Test 'target variable' command before and after starting the inferior."""
         d = {'C_SOURCES': 'globals.c', 'EXE': self.getBuildArtifact('globals')}

--- a/lldb/test/API/lang/c/global_variables/TestGlobalVariables.py
+++ b/lldb/test/API/lang/c/global_variables/TestGlobalVariables.py
@@ -18,8 +18,8 @@ class GlobalVariablesTestCase(TestBase):
             self.source, '// Set break point at this line.')
         self.shlib_names = ["a"]
 
+    @skipIfDarwin # Chained Fixups
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764")
-    @expectedFailureDarwin(archs=["arm64", "arm64e"]) # <rdar://problem/37773624>
     def test_without_process(self):
         """Test that static initialized variables can be inspected without
         process."""

--- a/lldb/test/API/lang/cpp/char8_t/TestCxxChar8_t.py
+++ b/lldb/test/API/lang/cpp/char8_t/TestCxxChar8_t.py
@@ -12,8 +12,8 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class CxxChar8_tTestCase(TestBase):
 
+    @skipIfDarwin # Chained Fixups
     @skipIf(compiler="clang", compiler_version=['<', '7.0'])
-    @expectedFailureDarwin(archs=["arm64", "arm64e"]) # <rdar://problem/37773624>
     def test_without_process(self):
         """Test that C++ supports char8_t without a running process."""
         self.build()


### PR DESCRIPTION
When targeting macOS Ventura, ld64 will use authenticated fixups for
x86_64 as well as arm64 (where that has always been the case). This
results in test failures when using an Xcode 14 toolchain on an Intel
mac running macOS Ventura:

  Failed Tests (3):
    lldb-api :: commands/target/basic/TestTargetCommand.py
    lldb-api :: lang/c/global_variables/TestGlobalVariables.py
    lldb-api :: lang/cpp/char8_t/TestCxxChar8_t.py

Rather than trying to come up with a sophisticated decorator based off
the deployment target, I marked them all as skipped with a comment
explaining why.

Differential revision: https://reviews.llvm.org/D131741

(cherry picked from commit abe9599f04f07baae46f4123d4c43d330f34df52)
