### PR TITLE
[lldb] Use on disk hash table as the binary format of SwiftMetadataCache

### DIFF
--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -32,7 +32,7 @@ let Definition = "modulelist" in {
     Desc<"The module loading mode to use when loading modules for Swift.">;
   def EnableSwiftMetadataCache: Property<"enable-swift-metadata-cache", "Boolean">,
     Global,
-    DefaultFalse,
+    DefaultTrue,
     Desc<"Enable caching for Swift reflection metadata in LLDB.">;
   def SwiftMetadataCachePath: Property<"swift-metadata-cache-path", "FileSpec">,
     Global,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftMetadataCache.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftMetadataCache.h
@@ -3,30 +3,111 @@
 #define liblldb_TypeRefCacher_h_
 
 #include <mutex>
-#include <unordered_map>
 
 #include "lldb/Core/DataFileCache.h"
 #include "lldb/Core/Module.h"
 
-#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/DJB.h"
+#include "llvm/Support/OnDiskHashTable.h"
 
 #include "swift/Reflection/ReflectionContext.h"
 #include "swift/Remote/ExternalTypeRefCache.h"
 
 namespace lldb_private {
 
+/// An info object to support serializing/deserializing on disk hash tables.
+/// Check the OnDiskChainedHashTableGenerator and OnDiskChainedHashTable
+/// comments for more info about the interface.
+class TypeRefInfo {
+public:
+  /// The key is the mangled name.
+  using key_type = llvm::StringRef;
+  using key_type_ref = key_type;
+  using internal_key_type = key_type;
+  using external_key_type = key_type;
+  /// The data is the TypeRefInfoLocator's offset.
+  using data_type = uint64_t;
+  using data_type_ref = data_type;
+
+  using hash_value_type = uint32_t;
+  using offset_type = uint32_t;
+
+  explicit TypeRefInfo() = default;
+
+  // Common encoder decoder functions.
+
+  hash_value_type ComputeHash(key_type_ref key) {
+    assert(!key.empty());
+    return llvm::djbHash(key);
+  }
+
+  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
+    return lhs == rhs;
+  }
+
+  // Encoder functions.
+
+  std::pair<uint32_t, uint32_t> EmitKeyDataLength(llvm::raw_ostream &out,
+                                                  key_type_ref key,
+                                                  data_type_ref data) {
+    assert(key.size() < std::numeric_limits<offset_type>::max() &&
+           "Key size is too long!");
+    offset_type key_len = key.size();
+    // Write the key length so we don't have to traverse it later.
+    llvm::support::endian::write<offset_type>(out, key_len,
+                                              llvm::support::little);
+    // Since the data type is always a constant size there's no need to write
+    // it.
+    offset_type data_len = sizeof(data_type);
+    return std::make_pair(key_len, data_len);
+  }
+
+  void EmitKey(llvm::raw_ostream &out, key_type_ref key, unsigned len) {
+    out << key;
+  }
+
+  void EmitData(llvm::raw_ostream &out, key_type_ref key, data_type_ref data,
+                unsigned len) {
+    llvm::support::endian::write<data_type>(out, data, llvm::support::little);
+  }
+
+  // Decoder functions.
+
+  internal_key_type GetInternalKey(external_key_type ID) { return ID; }
+
+  external_key_type GetExternalKey(internal_key_type ID) { return ID; }
+
+  static std::pair<offset_type, offset_type>
+  ReadKeyDataLength(const unsigned char *&data) {
+    offset_type key_len =
+        llvm::support::endian::readNext<offset_type, llvm::support::little,
+                                        llvm::support::unaligned>(data);
+    offset_type data_len = sizeof(data_type);
+    return std::make_pair(key_len, data_len);
+  }
+
+  internal_key_type ReadKey(const unsigned char *data, unsigned length) {
+    return llvm::StringRef((const char *)data, length);
+  }
+
+  static data_type ReadData(internal_key_type key, const uint8_t *data,
+                            unsigned length) {
+    data_type result =
+        llvm::support::endian::readNext<uint32_t, llvm::support::little,
+                                        llvm::support::unaligned>(data);
+    return result;
+  }
+};
+
 /// A cache for data used to speed up retrieving swift metadata.
 /// Currently we only cache typeref information.
 /// This caches files in the directory specified by the SwiftMetadataCachePath
-/// setting. The file format is the following: A header consisting of:
-/// - Version number (uint16_t).
-/// - Module signature.
-/// - Size of the remainder of the contents when decompressed (uint64_t).
-/// A body that is zlib compressed containing:
-/// - The number (N) of name/offset pairs (uint64_t).
-/// - N pairs composed of a c-string mangled name followed by the offset
-///   (uint32_t) where the corresponding field descriptor can be found in
-//    the fieldmd section.
+/// setting. The file format is the following:
+/// A header consisting of:
+/// - The size of the module's UUID.
+/// - The module's UUID.
+/// - The on hash table's control structure offset.
+/// A body consisting of the on disk hash table.
 struct SwiftMetadataCache : swift::remote::ExternalTypeRefCache {
 public:
   SwiftMetadataCache();
@@ -53,27 +134,38 @@ public:
   bool isReflectionInfoCached(uint64_t info_id) override;
 
 private:
-  bool writeMangledNamesAndOffsetsToEncoder(
+  /// Generate the on disk hash table data structure into a blob. Returns
+  /// the start on the hash table's control structure and the blob itself.
+  llvm::Optional<std::pair<uint32_t, llvm::SmallString<32>>>
+  generateHashTableBlob(
       uint64_t info_id,
       const swift::reflection::FieldSection &field_descriptors,
-      const std::vector<std::string> &mangled_names, DataEncoder &encoder);
-
-  void
-  fillMangledNameToOffsetMap(uint64_t info_id,
-                             const swift::reflection::ReflectionInfo &info,
-                             const std::vector<std::string> &mangled_names);
+      const std::vector<std::string> &mangled_names);
 
   /// Gets the file name that the cache file should use for a given module.
   std::string getTyperefCacheFileNameForModule(const lldb::ModuleSP &module);
 
-  /// A map from mangled names to field descriptor locators.
-  llvm::StringMap<swift::remote::FieldDescriptorLocator>
-      m_mangled_name_to_offset;
+  /// The memory buffers that own the data of the hash tables.
+  std::vector<std::unique_ptr<llvm::MemoryBuffer>> m_hash_table_buffers;
+
+  /// A single info object to query all the hash tables with.
+  TypeRefInfo m_info;
+
+  struct ModuleCacheInfo {
+    lldb::ModuleSP module;
+    /// The on disk hash table for this module. The hash tables map mangled
+    /// names to field descriptor offsets. A null pointer means that we have
+    // no cache info for this module yet.
+    std::unique_ptr<llvm::OnDiskChainedHashTable<TypeRefInfo>> cache_hash_table;
+
+    ModuleCacheInfo(lldb::ModuleSP module)
+        : module(module), cache_hash_table() {}
+  };
 
   /// A map from reflection infos ids to a pair constituting of its
   /// corresponding module and whether or not we've inserted the cached metadata
   /// for that reflection info already.
-  llvm::DenseMap<uint32_t, std::pair<lldb::ModuleSP, bool>> m_info_to_module;
+  llvm::DenseMap<uint32_t, ModuleCacheInfo> m_reflection_info_to_module;
 
   std::recursive_mutex m_mutex;
 


### PR DESCRIPTION
Replace the previous, simple, compressed list of string offset pairs
representation with an OnDiskChainedHashTable. This format can be
mmaped and is faster loading up.

(cherry picked from commit 4bdb9ca6a8b3f968a502605ae0106dde6d1dde4b)