### PR TITLE
[CAS] Introduce ActionCache into llvm::cas

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -11,6 +11,9 @@ let Component = "CAS" in {
 def err_builtin_cas_cannot_be_initialized : Error<
   "CAS cannot be initialized from '%0' on disk (check -fcas-path)">,
   DefaultFatal;
+def err_builtin_actioncache_cannot_be_initialized : Error<
+  "ActionCache cannot be initialized from '%0' on disk (check -faction-cache-path)">,
+  DefaultFatal;
 def err_cas_cannot_parse_root_id : Error<
   "CAS cannot parse root-id '%0' specified by -fcas-fs">, DefaultFatal;
 def err_cas_filesystem_cannot_be_initialized : Error<

--- a/clang/include/clang/CAS/CASOptions.h
+++ b/clang/include/clang/CAS/CASOptions.h
@@ -76,7 +76,7 @@ private:
 /// defined in CASConfiguration to enable caching a CAS instance.
 ///
 /// CASOptions includes \a getOrCreateCAS() and \a
-/// getOrCreateActionCache() for creating CAS and ActionAction.
+/// getOrCreateActionCache() for creating CAS and ActionCache.
 ///
 /// FIXME: The the caching is done here, instead of as a field in \a
 /// CompilerInstance, in order to ensure that \a

--- a/clang/include/clang/CAS/CASOptions.h
+++ b/clang/include/clang/CAS/CASOptions.h
@@ -19,7 +19,9 @@
 #include <vector>
 
 namespace llvm {
+class Error;
 namespace cas {
+class ActionCache;
 class CASDB;
 } // end namespace cas
 } // end namespace llvm
@@ -52,10 +54,11 @@ public:
   /// - "auto" is an alias for an automatically chosen location in the user's
   ///   system cache.
   std::string CASPath;
+  std::string CachePath;
 
   friend bool operator==(const CASConfiguration &LHS,
                          const CASConfiguration &RHS) {
-    return LHS.CASPath == RHS.CASPath;
+    return LHS.CASPath == RHS.CASPath && LHS.CachePath == RHS.CachePath;
   }
   friend bool operator!=(const CASConfiguration &LHS,
                          const CASConfiguration &RHS) {
@@ -73,7 +76,7 @@ private:
 /// defined in CASConfiguration to enable caching a CAS instance.
 ///
 /// CASOptions includes \a getOrCreateCAS() and \a
-/// getOrCreateCASAndHideConfig() for creating a CAS and caching it.
+/// getOrCreateActionCache() for creating CAS and ActionAction.
 ///
 /// FIXME: The the caching is done here, instead of as a field in \a
 /// CompilerInstance, in order to ensure that \a
@@ -92,24 +95,38 @@ public:
   getOrCreateCAS(DiagnosticsEngine &Diags,
                  bool CreateEmptyCASOnFailure = false) const;
 
-  /// Get a CAS defined by the options above. Future calls will return the same
+  /// Get a ActionCache defined by the options above. Future calls will return
+  /// the same ActionCache instance... unless the configuration has changed, in
+  /// which case a new one will be created.
+  ///
+  /// If \p CreateEmptyCacheOnFailure, returns an empty in-memory ActionCache on
+  /// failure. Else, returns \c nullptr on failure.
+  std::shared_ptr<llvm::cas::ActionCache>
+  getOrCreateActionCache(DiagnosticsEngine &Diags,
+                         bool CreateEmptyCacheOnFailures = false) const;
+
+  /// Freeze CAS Configuration. Future calls will return the same
   /// CAS instance, even if the configuration changes again later.
   ///
   /// The configuration will be wiped out to prevent it being observable or
   /// affecting the output of something that takes \a CASOptions as an input.
   /// This also "locks in" the return value of \a getOrCreateCAS(): future
   /// calls will not check if the configuration has changed.
-  std::shared_ptr<llvm::cas::CASDB>
-  getOrCreateCASAndHideConfig(DiagnosticsEngine &Diags);
+  void freezeConfig(DiagnosticsEngine &Diags);
 
   /// If the configuration is not for a persistent store, it modifies it to the
   /// default on-disk CAS, otherwise this is a noop.
   void ensurePersistentCAS();
 
 private:
+  /// Initialize Cached CAS and ActionCache.
+  void initCache(DiagnosticsEngine &Diags) const;
+
   struct CachedCAS {
     /// A cached CAS instance.
     std::shared_ptr<llvm::cas::CASDB> CAS;
+    /// An ActionCache instnace.
+    std::shared_ptr<llvm::cas::ActionCache> AC;
 
     /// Remember how the CAS was created.
     CASConfiguration Config;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6446,6 +6446,12 @@ def fcas_path : Separate<["-"], "fcas-path">,
              " '-fcas-path=auto' chooses a path in the user's system cache.">,
     MarshallingInfoString<CASOpts<"CASPath">>;
 
+def faction_cache_path : Separate<["-"], "faction-cache-path">,
+    Group<f_Group>, MetaVarName<"<dir>|auto">,
+    HelpText<"Path to a persistent on-disk backing store for the builtin Cache."
+             " '-faction-cache-path=auto' chooses a path in the user's system cache.">,
+    MarshallingInfoString<CASOpts<"CachePath">>;
+
 // FIXME: Add to driver once it's supported by -fdepscan.
 def fcas_fs : Separate<["-"], "fcas-fs">,
     Group<f_Group>, MetaVarName<"<tree>">,

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -87,6 +87,9 @@ class CompilerInstance : public ModuleLoader {
   /// The CAS, if any.
   std::shared_ptr<llvm::cas::CASDB> CAS;
 
+  /// The ActionCache, if any.
+  std::shared_ptr<llvm::cas::ActionCache> ActionCache;
+
   /// The file manager.
   IntrusiveRefCntPtr<FileManager> FileMgr;
 
@@ -427,6 +430,7 @@ public:
 
   /// Get the CAS, or create it using the configuration in CompilerInvocation.
   llvm::cas::CASDB &getOrCreateCAS();
+  llvm::cas::ActionCache &getOrCreateActionCache();
 
   /// }
   /// @name Source Manager

--- a/clang/include/clang/Lex/PTHManager.h
+++ b/clang/include/clang/Lex/PTHManager.h
@@ -20,6 +20,8 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/CASDB.h"
 #include "llvm/CAS/CASFileSystem.h"
 #include "llvm/CAS/CASID.h"
 #include "llvm/Support/Allocator.h"
@@ -98,6 +100,7 @@ class PTHManager {
   llvm::SpecificBumpPtrAllocator<IdentifierInfo *> IdentifierInfoCacheAlloc;
 
   llvm::cas::CASDB &CAS;
+  llvm::cas::ActionCache &Cache;
   IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS;
   LangOptions CanonicalLangOpts;
   Optional<llvm::cas::CASID> SerializedLangOpts;
@@ -120,7 +123,7 @@ public:
   ~PTHManager();
   PTHManager() = delete;
 
-  PTHManager(llvm::cas::CASDB &CAS,
+  PTHManager(llvm::cas::CASDB &CAS, llvm::cas::ActionCache &Cache,
              IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS, Preprocessor &PP);
 
   void setPreprocessor(Preprocessor *pp) { PP = pp; }

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
@@ -13,6 +13,7 @@
 #include "clang/Tooling/DependencyScanning/DependencyScanningFilesystem.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASID.h"
 #include "llvm/CAS/CASReference.h"
 #include "llvm/CAS/ThreadSafeFileSystem.h"
@@ -104,6 +105,7 @@ private:
   llvm::cas::CachingOnDiskFileSystem &getCachingFS();
 
   llvm::cas::CASDB &CAS;
+  llvm::cas::ActionCache &Cache;
   Optional<llvm::cas::ObjectRef> ClangFullVersionID;
   Optional<llvm::cas::ObjectRef> DepDirectivesID;
   Optional<llvm::cas::ObjectRef> EmptyBlobID;

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
@@ -35,7 +35,8 @@ namespace dependencies {
 class DependencyScanningCASFilesystem : public llvm::cas::ThreadSafeFileSystem {
 public:
   DependencyScanningCASFilesystem(
-      IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> WorkerFS);
+      IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> WorkerFS,
+      llvm::cas::ActionCache &Cache);
 
   ~DependencyScanningCASFilesystem();
 

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
@@ -12,6 +12,7 @@
 #include "clang/CAS/CASOptions.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningFilesystem.h"
+#include "llvm/CAS/ActionCache.h"
 
 namespace clang {
 namespace tooling {
@@ -58,6 +59,7 @@ class DependencyScanningService {
 public:
   DependencyScanningService(
       ScanningMode Mode, ScanningOutputFormat Format, CASOptions CASOpts,
+      std::shared_ptr<llvm::cas::ActionCache> Cache,
       IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> SharedFS,
       bool ReuseFileManager = true, bool OptimizeArgs = false,
       bool EagerLoadModules = false, bool OverrideCASTokenCache = false);
@@ -79,6 +81,10 @@ public:
   }
 
   const CASOptions &getCASOpts() const { return CASOpts; }
+  llvm::cas::ActionCache &getCache() const {
+    assert(Cache && "Cache is not initialized");
+    return *Cache;
+  }
 
   bool overrideCASTokenCache() const { return OverrideCASTokenCache; }
 
@@ -90,6 +96,7 @@ private:
   const ScanningMode Mode;
   const ScanningOutputFormat Format;
   CASOptions CASOpts;
+  std::shared_ptr<llvm::cas::ActionCache> Cache;
   const bool ReuseFileManager;
   /// Whether to optimize the modules' command-line arguments.
   const bool OptimizeArgs;

--- a/clang/lib/CAS/CASOptions.cpp
+++ b/clang/lib/CAS/CASOptions.cpp
@@ -9,14 +9,16 @@
 #include "clang/CAS/CASOptions.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/DiagnosticCAS.h"
+#include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASDB.h"
+#include "llvm/Support/Error.h"
+#include <memory>
 
 using namespace clang;
 using namespace llvm::cas;
 
 static std::shared_ptr<llvm::cas::CASDB>
-createCAS(const CASConfiguration &Config, DiagnosticsEngine &Diags,
-          bool CreateEmptyCASOnFailure) {
+createCAS(const CASConfiguration &Config, DiagnosticsEngine &Diags) {
   if (Config.CASPath.empty())
     return llvm::cas::createInMemoryCAS();
 
@@ -33,7 +35,7 @@ createCAS(const CASConfiguration &Config, DiagnosticsEngine &Diags,
           llvm::expectedToOptional(llvm::cas::createOnDiskCAS(Path)))
     return std::move(*MaybeCAS);
   Diags.Report(diag::err_builtin_cas_cannot_be_initialized) << Path;
-  return CreateEmptyCASOnFailure ? llvm::cas::createInMemoryCAS() : nullptr;
+  return nullptr;
 }
 
 std::shared_ptr<llvm::cas::CASDB>
@@ -42,22 +44,21 @@ CASOptions::getOrCreateCAS(DiagnosticsEngine &Diags,
   if (Cache.Config.IsFrozen)
     return Cache.CAS;
 
-  auto &CurrentConfig = static_cast<const CASConfiguration &>(*this);
-  if (!Cache.CAS || CurrentConfig != Cache.Config) {
-    Cache.Config = CurrentConfig;
-    Cache.CAS = createCAS(Cache.Config, Diags, CreateEmptyCASOnFailure);
-  }
-
+  initCache(Diags);
+  if (Cache.CAS)
+    return Cache.CAS;
+  if (!CreateEmptyCASOnFailure)
+    return nullptr;
+  Cache.CAS = llvm::cas::createInMemoryCAS();
   return Cache.CAS;
 }
 
-std::shared_ptr<llvm::cas::CASDB>
-CASOptions::getOrCreateCASAndHideConfig(DiagnosticsEngine &Diags) {
+void CASOptions::freezeConfig(DiagnosticsEngine &Diags) {
   if (Cache.Config.IsFrozen)
-    return Cache.CAS;
+    return;
 
-  std::shared_ptr<llvm::cas::CASDB> CAS = getOrCreateCAS(Diags);
-  assert(CAS == Cache.CAS && "Expected CAS to be cached");
+  // Make sure the cache is initialized.
+  initCache(Diags);
 
   // Freeze the CAS and wipe out the visible config to hide it from future
   // accesses. For example, future diagnostics cannot see this. Something that
@@ -67,13 +68,48 @@ CASOptions::getOrCreateCASAndHideConfig(DiagnosticsEngine &Diags) {
   CurrentConfig = CASConfiguration();
   CurrentConfig.IsFrozen = Cache.Config.IsFrozen = true;
 
-  if (CAS) {
+  if (Cache.CAS) {
     // Set the CASPath to the hash schema, since that leaks through CASContext's
     // API and is observable.
-    CurrentConfig.CASPath = CAS->getHashSchemaIdentifier().str();
+    CurrentConfig.CASPath = Cache.CAS->getHashSchemaIdentifier().str();
   }
+  if (Cache.AC)
+    CurrentConfig.CachePath = "";
+}
 
-  return CAS;
+static std::shared_ptr<llvm::cas::ActionCache>
+createCache(CASDB &CAS, const CASConfiguration &Config,
+            DiagnosticsEngine &Diags) {
+  if (Config.CachePath.empty())
+    return llvm::cas::createInMemoryActionCache(CAS);
+
+  // Compute the path.
+  std::string Path = Config.CASPath;
+  if (Path == "auto")
+    Path = getDefaultOnDiskActionCachePath();
+
+  // FIXME: Pass on the actual error from the CAS.
+  if (auto MaybeCache = llvm::expectedToOptional(
+          llvm::cas::createOnDiskActionCache(CAS, Path)))
+    return std::move(*MaybeCache);
+  Diags.Report(diag::err_builtin_actioncache_cannot_be_initialized) << Path;
+  return nullptr;
+}
+
+std::shared_ptr<llvm::cas::ActionCache>
+CASOptions::getOrCreateActionCache(DiagnosticsEngine &Diags,
+                                   bool CreateEmptyOnFailure) const {
+  if (Cache.Config.IsFrozen)
+    return Cache.AC;
+
+  initCache(Diags);
+  if (Cache.AC)
+    return Cache.AC;
+  if (!CreateEmptyOnFailure)
+    return nullptr;
+
+  Cache.CAS = Cache.CAS ? Cache.CAS : llvm::cas::createInMemoryCAS();
+  return llvm::cas::createInMemoryActionCache(*Cache.CAS);
 }
 
 void CASOptions::ensurePersistentCAS() {
@@ -83,8 +119,19 @@ void CASOptions::ensurePersistentCAS() {
       llvm_unreachable("Cannot ensure persistent CAS if it's unknown / frozen");
   case InMemoryCAS:
     CASPath = "auto";
+    CachePath = "auto";
     break;
   case OnDiskCAS:
     break;
   }
+}
+
+void CASOptions::initCache(DiagnosticsEngine &Diags) const {
+  auto &CurrentConfig = static_cast<const CASConfiguration &>(*this);
+  if (CurrentConfig == Cache.Config && Cache.CAS && Cache.AC)
+    return;
+
+  Cache.Config = CurrentConfig;
+  Cache.CAS = createCAS(Cache.Config, Diags);
+  Cache.AC = createCache(*Cache.CAS, Cache.Config, Diags);
 }

--- a/clang/lib/CAS/CASOptions.cpp
+++ b/clang/lib/CAS/CASOptions.cpp
@@ -12,7 +12,6 @@
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASDB.h"
 #include "llvm/Support/Error.h"
-#include <memory>
 
 using namespace clang;
 using namespace llvm::cas;

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -470,8 +470,8 @@ void CompilerInstance::createPreprocessor(TranslationUnitKind TUKind) {
     // token-caching can fall back to ingesting into an in-memory CAS itself.
     llvm::vfs::FileSystem &FS = getFileManager().getVirtualFileSystem();
     if (FS.isCASFS())
-      PP->setPTHManager(
-          std::make_unique<PTHManager>(getOrCreateCAS(), &FS, *PP));
+      PP->setPTHManager(std::make_unique<PTHManager>(
+          getOrCreateCAS(), getOrCreateActionCache(), &FS, *PP));
   }
 
   if (PPOpts.DetailedRecord)
@@ -862,6 +862,16 @@ llvm::cas::CASDB &CompilerInstance::getOrCreateCAS() {
       getDiagnostics(),
       /*CreateEmptyCASOnFailure=*/true);
   return *CAS;
+}
+
+llvm::cas::ActionCache &CompilerInstance::getOrCreateActionCache() {
+  if (ActionCache)
+    return *ActionCache;
+
+  ActionCache = getInvocation().getCASOpts().getOrCreateActionCache(
+      getDiagnostics(),
+      /*CreateEmptyActionCacheOnFailure=*/true);
+  return *ActionCache;
 }
 
 std::unique_ptr<raw_pwrite_stream>

--- a/clang/lib/Lex/PTHLexer.cpp
+++ b/clang/lib/Lex/PTHLexer.cpp
@@ -614,7 +614,10 @@ Expected<llvm::cas::CASID> PTHManager::computePTH(llvm::cas::CASID InputFile) {
                llvm::cas::TreeEntry::Regular, "lang-opts");
 
   llvm::cas::CASID CacheKey = CAS.getID(llvm::cantFail(Builder.create(CAS)));
-  if (Optional<llvm::cas::ObjectRef> CachedPTH = Cache.get(CacheKey))
+  auto Cached = Cache.get(CacheKey);
+  if (!Cached)
+    return Cached.takeError();
+  if (Optional<llvm::cas::ObjectRef> CachedPTH = *Cached)
     return CAS.getID(*CachedPTH);
 
   SmallString<256> PTHString;

--- a/clang/lib/Lex/PTHLexer.cpp
+++ b/clang/lib/Lex/PTHLexer.cpp
@@ -26,6 +26,7 @@
 #include "clang/Lex/Token.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASDB.h"
 #include "llvm/CAS/HierarchicalTreeBuilder.h"
 #include "llvm/Support/DJB.h"
@@ -343,10 +344,10 @@ SourceLocation PTHLexer::getSourceLocation() {
 // PTHManager methods.
 //===----------------------------------------------------------------------===//
 
-PTHManager::PTHManager(llvm::cas::CASDB &CAS,
+PTHManager::PTHManager(llvm::cas::CASDB &CAS, llvm::cas::ActionCache &Cache,
                        IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS,
                        Preprocessor &PP)
-    : CAS(CAS), FS(std::move(FS)), PP(&PP) {
+    : CAS(CAS), Cache(Cache), FS(std::move(FS)), PP(&PP) {
   // TODO: Allow the filesystem NOT to have a CAS instance, or (maybe?) to have
   // a different CAS instance. This requires ingesting files from FS into CAS.
 
@@ -613,9 +614,8 @@ Expected<llvm::cas::CASID> PTHManager::computePTH(llvm::cas::CASID InputFile) {
                llvm::cas::TreeEntry::Regular, "lang-opts");
 
   llvm::cas::CASID CacheKey = CAS.getID(llvm::cantFail(Builder.create(CAS)));
-  if (Optional<llvm::cas::CASID> CachedPTH =
-          expectedToOptional(CAS.getCachedResult(CacheKey)))
-    return *CachedPTH;
+  if (Optional<llvm::cas::ObjectRef> CachedPTH = Cache.get(CacheKey))
+    return CAS.getID(*CachedPTH);
 
   SmallString<256> PTHString;
   {
@@ -628,7 +628,7 @@ Expected<llvm::cas::CASID> PTHManager::computePTH(llvm::cas::CASID InputFile) {
                        CanonicalLangOpts);
   }
   auto PTH = llvm::cantFail(CAS.createProxy(None, PTHString));
-  llvm::cantFail(CAS.putCachedResult(CacheKey, PTH));
+  llvm::cantFail(Cache.put(CacheKey, PTH.getRef()));
   return PTH;
 }
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
@@ -165,7 +165,8 @@ void DependencyScanningCASFilesystem::scanForDirectives(
   }
 
   // Check the result cache.
-  if (Optional<ObjectRef> OutputRef = Cache.get(*InputID)) {
+  if (Optional<ObjectRef> OutputRef =
+          reportAsFatalIfError(Cache.get(*InputID))) {
     reportAsFatalIfError(
         loadDepDirectives(CAS, *OutputRef, Tokens, Directives));
     return;

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
@@ -9,6 +9,7 @@
 #include "clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h"
 #include "clang/Basic/Version.h"
 #include "clang/Lex/DependencyDirectivesScanner.h"
+#include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASDB.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/CAS/HierarchicalTreeBuilder.h"
@@ -34,9 +35,10 @@ static void reportAsFatalIfError(llvm::Error E) {
 using llvm::Error;
 
 DependencyScanningCASFilesystem::DependencyScanningCASFilesystem(
-    IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> WorkerFS)
-    : FS(WorkerFS), Entries(EntryAlloc), CAS(WorkerFS->getCAS()),
-      Cache(WorkerFS->getCache()) {}
+    IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> WorkerFS,
+    llvm::cas::ActionCache &Cache)
+    : FS(WorkerFS), Entries(EntryAlloc), CAS(WorkerFS->getCAS()), Cache(Cache) {
+}
 
 DependencyScanningCASFilesystem::~DependencyScanningCASFilesystem() = default;
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/Tooling/DependencyScanning/DependencyScanningService.h"
+#include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASDB.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/Support/TargetSelect.h"
@@ -17,10 +18,11 @@ using namespace dependencies;
 
 DependencyScanningService::DependencyScanningService(
     ScanningMode Mode, ScanningOutputFormat Format, CASOptions CASOpts,
+    std::shared_ptr<llvm::cas::ActionCache> Cache,
     IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> SharedFS,
     bool ReuseFileManager, bool OptimizeArgs, bool EagerLoadModules,
     bool OverrideCASTokenCache)
-    : Mode(Mode), Format(Format), CASOpts(std::move(CASOpts)),
+    : Mode(Mode), Format(Format), CASOpts(std::move(CASOpts)), Cache(Cache),
       ReuseFileManager(ReuseFileManager), OptimizeArgs(OptimizeArgs),
       EagerLoadModules(EagerLoadModules),
       OverrideCASTokenCache(OverrideCASTokenCache),

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -416,7 +416,8 @@ DependencyScanningWorker::DependencyScanningWorker(
 
   if (Service.getMode() == ScanningMode::DependencyDirectivesScan) {
     if (Service.useCASScanning())
-      DepCASFS = new DependencyScanningCASFilesystem(CacheFS);
+      DepCASFS =
+          new DependencyScanningCASFilesystem(CacheFS, Service.getCache());
     else
       DepFS = new DependencyScanningWorkerFilesystem(Service.getSharedCache(),
                                                      RealFS);

--- a/clang/test/CAS/cas-backend.c
+++ b/clang/test/CAS/cas-backend.c
@@ -2,7 +2,7 @@
 // RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
 //
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 -fcas-backend \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Rcompile-job-cache -emit-obj -o %t/output.o \
 // RUN:   -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb \
 // RUN:   -dependency-file %t/deps.d -MT %t/output.o 2>&1 \
@@ -13,7 +13,7 @@
 //
 // RUN: CLANG_CAS_BACKEND_SAVE_CASID_FILE=1 %clang -cc1 \
 // RUN:   -triple x86_64-apple-macos11 -fcas-backend \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Rcompile-job-cache -emit-obj -o %t/output.o \
 // RUN:   -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb \
 // RUN:   -dependency-file %t/deps.d -MT %t/output.o 2>&1 \

--- a/clang/test/CAS/daemon-cwd.c
+++ b/clang/test/CAS/daemon-cwd.c
@@ -4,7 +4,7 @@
 
 // RUN: rm -rf %t && mkdir -p %t/include
 // RUN: cp %S/Inputs/test.h %t/include
-// RUN: %clang -cc1depscand -start %{clang-daemon-dir}/daemon-cwd
+// RUN: %clang -cc1depscand -start %{clang-daemon-dir}/daemon-cwd -fcas-path %t/cas -faction-cache-path %t/cache
 // RUN: (cd %t && %clang -target x86_64-apple-macos11 -fdepscan=daemon    \
 // RUN:    -fdepscan-prefix-map=%S=/^source                               \
 // RUN:    -fdepscan-prefix-map=%t=/^build                                \

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -13,12 +13,12 @@
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas PATH="%t:$PATH" %clang-cache clang-symlink-outside-bindir -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG -DPREFIX=%t
 
 // CLANG: "-cc1depscan" "-fdepscan=auto"
-// CLANG: "-fcas-path" "[[PREFIX]]/cas" "-faction-cache-path" "[[PREFIX]]/cas" "-fcas-token-cache"
+// CLANG: "-fcas-path" "[[PREFIX]]/cas/cas" "-faction-cache-path" "[[PREFIX]]/cas/actioncache" "-fcas-token-cache"
 // CLANG: "-greproducible"
 // CLANG: "-x" "c"
 
 // CLANGPP: "-cc1depscan" "-fdepscan=auto"
-// CLANGPP: "-fcas-path" "[[PREFIX]]/cas" "-faction-cache-path" "[[PREFIX]]/cas" "-fcas-token-cache"
+// CLANGPP: "-fcas-path" "[[PREFIX]]/cas/cas" "-faction-cache-path" "[[PREFIX]]/cas/actioncache" "-fcas-token-cache"
 // CLANGPP: "-greproducible"
 // CLANGPP: "-x" "c++"
 
@@ -28,7 +28,7 @@
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=SESSION -DPREFIX=%t
 // SESSION: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-share-identifier"
-// SESSION: "-fcas-path" "[[PREFIX]]/cas" "-faction-cache-path" "[[PREFIX]]/cas" "-fcas-token-cache"
+// SESSION: "-fcas-path" "[[PREFIX]]/cas/cas" "-faction-cache-path" "[[PREFIX]]/cas/actioncache" "-fcas-token-cache"
 // SESSION: "-greproducible"
 
 // RUN: cp -R %S/Inputs/cmake-build %t/cmake-build

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -13,12 +13,12 @@
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas PATH="%t:$PATH" %clang-cache clang-symlink-outside-bindir -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG -DPREFIX=%t
 
 // CLANG: "-cc1depscan" "-fdepscan=auto"
-// CLANG: "-fcas-path" "[[PREFIX]]/cas" "-fcas-token-cache"
+// CLANG: "-fcas-path" "[[PREFIX]]/cas" "-faction-cache-path" "[[PREFIX]]/cas" "-fcas-token-cache"
 // CLANG: "-greproducible"
 // CLANG: "-x" "c"
 
 // CLANGPP: "-cc1depscan" "-fdepscan=auto"
-// CLANGPP: "-fcas-path" "[[PREFIX]]/cas" "-fcas-token-cache"
+// CLANGPP: "-fcas-path" "[[PREFIX]]/cas" "-faction-cache-path" "[[PREFIX]]/cas" "-fcas-token-cache"
 // CLANGPP: "-greproducible"
 // CLANGPP: "-x" "c++"
 
@@ -28,7 +28,7 @@
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=SESSION -DPREFIX=%t
 // SESSION: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-share-identifier"
-// SESSION: "-fcas-path" "[[PREFIX]]/cas" "-fcas-token-cache"
+// SESSION: "-fcas-path" "[[PREFIX]]/cas" "-faction-cache-path" "[[PREFIX]]/cas" "-fcas-token-cache"
 // SESSION: "-greproducible"
 
 // RUN: cp -R %S/Inputs/cmake-build %t/cmake-build

--- a/clang/test/CAS/fcache-compile-job-dependency-file.c
+++ b/clang/test/CAS/fcache-compile-job-dependency-file.c
@@ -3,7 +3,7 @@
 // RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
 //
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Rcompile-job-cache %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
 // RUN:   -dependency-file %t/deps1.d -MT depends 2>&1 \
 // RUN:   | FileCheck %s --allow-empty --check-prefix=CACHE-MISS
@@ -17,7 +17,7 @@
 // RUN: ls %t/output.o && rm %t/output.o
 //
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Rcompile-job-cache %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
 // RUN:   -dependency-file %t/deps2.d -MT depends 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CACHE-HIT
@@ -29,7 +29,7 @@
 // CACHE-MISS-NOT: remark: compile job cache hit
 
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Rcompile-job-cache %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
 // RUN:   -dependency-file %t/deps3.d -MT other1 -MT other2 -MP 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CACHE-HIT
@@ -42,7 +42,7 @@
 // DEPS_OTHER: my_header.h:
 
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Rcompile-job-cache %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
 // RUN:   -sys-header-deps -dependency-file %t/deps4.d -MT depends 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CACHE-MISS

--- a/clang/test/CAS/fcache-compile-job-serialized-diagnostics.c
+++ b/clang/test/CAS/fcache-compile-job-serialized-diagnostics.c
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
 
-// RUN: %clang -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas \
+// RUN: %clang -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -faction-cache-path %t/cache \
 // RUN:   -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Wimplicit-function-declaration \
 // RUN:   -Wno-error=implicit-function-declaration \
@@ -13,7 +13,7 @@
 
 // RUN: ls %t/output.o && rm %t/output.o
 
-// RUN: %clang -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas \
+// RUN: %clang -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -faction-cache-path %t/cache \
 // RUN:   -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Wimplicit-function-declaration \
 // RUN:   -Wno-error=implicit-function-declaration \

--- a/clang/test/CAS/fcache-compile-job.c
+++ b/clang/test/CAS/fcache-compile-job.c
@@ -2,27 +2,27 @@
 // RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
 //
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache-hit -emit-obj -o %t/output.o 2>&1 \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache-hit -emit-obj %s -o %t/output.o 2>&1 \
 // RUN:   | FileCheck %s --allow-empty --check-prefix=CACHE-MISS
 // RUN: ls %t/output.o && rm %t/output.o
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache-hit -emit-obj -o %t/output.o 2>&1 \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache-hit -emit-obj %s -o %t/output.o 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CACHE-HIT
 // RUN: ls %t/output.o && rm %t/output.o
 // RUN: cd %t
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache-hit -emit-obj -o output.o 2>&1 \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache-hit -emit-obj %s -o output.o 2>&1 \
 // RUN:   | FileCheck %s --allow-empty --check-prefix=CACHE-HIT
 // RUN: ls %t/output.o
 //
 // Check for a cache hit if the CAS moves:
 // RUN: mv %t/cas %t/cas.moved
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas.moved -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache-hit -emit-obj -o output.o 2>&1 \
+// RUN:   -fcas-path %t/cas.moved -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache-hit -emit-obj %s -o output.o 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CACHE-HIT
 // RUN: ls %t/output.o
 //

--- a/clang/test/CAS/fdepscan-daemon.c
+++ b/clang/test/CAS/fdepscan-daemon.c
@@ -2,8 +2,9 @@
 //
 // REQUIRES: system-darwin, clang-cc1daemon
 
-// RUN: %clang -cc1depscand -start %{clang-daemon-dir}/fdepscan-daemon
-// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=daemon -fdepscan-daemon=%{clang-daemon-dir}/fdepscan-daemon -fsyntax-only -x c %s
+// RUN: %clang -cc1depscand -start %{clang-daemon-dir}/fdepscan-daemon -fcas-path %t/cas -faction-cache-path %t/cache
+// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs \
+// RUN:   -fdepscan=daemon -fdepscan-daemon=%{clang-daemon-dir}/fdepscan-daemon -fsyntax-only -x c %s
 // RUN: %clang -cc1depscand -shutdown %{clang-daemon-dir}/fdepscan-daemon
 
 #include "test.h"

--- a/clang/test/CAS/include-tree-with-sanitizer.c
+++ b/clang/test/CAS/include-tree-with-sanitizer.c
@@ -10,7 +10,7 @@
 // RUN:   -e "s/^.*miss for '//" \
 // RUN:   -e "s/' .*$//" > %t/cache-key-tree
 
-// RUN: clang-cas-test -print-compile-job-cache-key -cas %t/cas @%t/cache-key-tree > %t/key.txt
+// RUN: clang-cas-test -print-compile-job-cache-key -cas %t/cas/cas @%t/cache-key-tree > %t/key.txt
 // RUN: FileCheck %s -DSRC_FILE=%s -DOUT_DIR=%t -input-file %t/key.txt
 //
 // CHECK: -fsanitize=address \

--- a/clang/test/CAS/print-compile-job-cache-key.c
+++ b/clang/test/CAS/print-compile-job-cache-key.c
@@ -43,7 +43,7 @@
 // RUN:   -e "s/^.*miss for '//" \
 // RUN:   -e "s/' .*$//" > %t/cache-key-tree
 
-// RUN: clang-cas-test -print-compile-job-cache-key -cas %t/cas @%t/cache-key-tree | FileCheck %s -check-prefix=INCLUDE_TREE -DSRC_FILE=%s
+// RUN: clang-cas-test -print-compile-job-cache-key -cas %t/cas/cas @%t/cache-key-tree | FileCheck %s -check-prefix=INCLUDE_TREE -DSRC_FILE=%s
 //
 // INCLUDE_TREE: command-line: llvmcas://
 // INCLUDE_TREE: computation: llvmcas://

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -19,6 +19,7 @@
 #include "clang/Tooling/Tooling.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASDB.h"
 #include "llvm/CAS/CASProvidingFileSystem.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
@@ -30,6 +31,7 @@
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/ThreadPool.h"
 #include "llvm/Support/Threading.h"
+#include <memory>
 #include <mutex>
 #include <thread>
 
@@ -776,6 +778,7 @@ int main(int argc, const char **argv) {
 
   CASOptions CASOpts;
   std::shared_ptr<llvm::cas::CASDB> CAS;
+  std::shared_ptr<llvm::cas::ActionCache> Cache;
   IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> FS;
   if (outputFormatRequiresCAS()) {
     if (!InMemoryCAS) {
@@ -785,10 +788,13 @@ int main(int argc, const char **argv) {
         CASOpts.ensurePersistentCAS();
     }
     CAS = CASOpts.getOrCreateCAS(Diags);
+    // FIXME: Cache is not used here so just create a dummy in-memory cache.
+    Cache = CASOpts.getOrCreateActionCache(Diags);
     if (!CAS)
       return 1;
     if (Format != ScanningOutputFormat::IncludeTree)
-      FS = llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*CAS));
+      FS = llvm::cantFail(
+          llvm::cas::createCachingOnDiskFileSystem(*CAS, *Cache));
   }
   DependencyScanningService Service(ScanMode, Format, CASOpts, FS,
                                     ReuseFileManager, OptimizeArgs,

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -31,7 +31,6 @@
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/ThreadPool.h"
 #include "llvm/Support/Threading.h"
-#include <memory>
 #include <mutex>
 #include <thread>
 
@@ -793,10 +792,9 @@ int main(int argc, const char **argv) {
     if (!CAS)
       return 1;
     if (Format != ScanningOutputFormat::IncludeTree)
-      FS = llvm::cantFail(
-          llvm::cas::createCachingOnDiskFileSystem(*CAS, *Cache));
+      FS = llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*CAS));
   }
-  DependencyScanningService Service(ScanMode, Format, CASOpts, FS,
+  DependencyScanningService Service(ScanMode, Format, CASOpts, Cache, FS,
                                     ReuseFileManager, OptimizeArgs,
                                     EagerLoadModules, OverrideCASTokenCache);
   llvm::ThreadPool Pool(llvm::hardware_concurrency(NumThreads));

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -144,6 +144,8 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
     }
     if (const char *CASPath = ::getenv("LLVM_CACHE_CAS_PATH")) {
       Args.append({"-Xclang", "-fcas-path", "-Xclang", CASPath});
+      // Put ActionCache in the same directory as CAS.
+      Args.append({"-Xclang", "-faction-cache-path", "-Xclang", CASPath});
     }
     Args.append({"-greproducible", "-Xclang", "-fcas-token-cache"});
     return None;

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -143,9 +143,14 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
       }
     }
     if (const char *CASPath = ::getenv("LLVM_CACHE_CAS_PATH")) {
-      Args.append({"-Xclang", "-fcas-path", "-Xclang", CASPath});
-      // Put ActionCache in the same directory as CAS.
-      Args.append({"-Xclang", "-faction-cache-path", "-Xclang", CASPath});
+      llvm::SmallString<256> CASArg(CASPath);
+      llvm::sys::path::append(CASArg, "cas");
+      Args.append({"-Xclang", "-fcas-path", "-Xclang",
+                   Saver.save(CASArg.str()).data()});
+      llvm::SmallString<256> CacheArg(CASPath);
+      llvm::sys::path::append(CacheArg, "actioncache");
+      Args.append({"-Xclang", "-faction-cache-path", "-Xclang",
+                   Saver.save(CacheArg.str()).data()});
     }
     Args.append({"-greproducible", "-Xclang", "-fcas-token-cache"});
     return None;

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -62,7 +62,6 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Target/TargetMachine.h"
 #include <cstdio>
-#include <memory>
 
 #ifdef CLANG_HAVE_RLIMITS
 #include <sys/resource.h>

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -446,7 +446,10 @@ Optional<int> CompileJobCache::tryReplayCachedResult(CompilerInstance &Clang) {
   if (!ResultCacheKey)
     return 1;
 
-  Optional<llvm::cas::ObjectRef> Result = Cache->get(*ResultCacheKey);
+  Optional<llvm::cas::ObjectRef> Result;
+  if (auto E = Cache->get(*ResultCacheKey).moveInto(Result))
+    consumeError(std::move(E)); // ignore error and treat it as a cache miss.
+
   if (Result) {
     Diags.Report(diag::remark_compile_job_cache_hit)
         << ResultCacheKey->toString() << CAS->getID(*Result).toString();

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -28,6 +28,7 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Bitstream/BitstreamReader.h"
+#include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASDB.h"
 #include "llvm/CAS/CASProvidingFileSystem.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
@@ -47,6 +48,7 @@
 #include "llvm/Support/VirtualOutputBackends.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdio>
+#include <memory>
 #include <mutex>
 #include <shared_mutex>
 
@@ -366,7 +368,8 @@ static Expected<llvm::cas::CASID> scanAndUpdateCC1Inline(
     bool ProduceIncludeTree, bool &DiagnosticErrorOccurred,
     const cc1depscand::DepscanPrefixMapping &PrefixMapping,
     llvm::function_ref<const char *(const Twine &)> SaveArg,
-    const CASOptions &CASOpts, std::shared_ptr<llvm::cas::CASDB> DB);
+    const CASOptions &CASOpts, std::shared_ptr<llvm::cas::CASDB> DB,
+    std::shared_ptr<llvm::cas::ActionCache> Cache);
 
 static Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
     tooling::dependencies::DependencyScanningTool &Tool,
@@ -507,6 +510,7 @@ static int scanAndUpdateCC1(const char *Exec, ArrayRef<const char *> OldArgs,
                             const llvm::opt::ArgList &Args,
                             const CASOptions &CASOpts,
                             std::shared_ptr<llvm::cas::CASDB> DB,
+                            std::shared_ptr<llvm::cas::ActionCache> Cache,
                             llvm::Optional<llvm::cas::CASID> &RootID) {
   using namespace clang::driver;
 
@@ -578,7 +582,7 @@ static int scanAndUpdateCC1(const char *Exec, ArrayRef<const char *> OldArgs,
           PrefixMapping, *DaemonPath, Sharing, SaveArg, *DB);
     return scanAndUpdateCC1Inline(Exec, OldArgs, WorkingDirectory, NewArgs,
                                   ProduceIncludeTree, DiagnosticErrorOccurred,
-                                  PrefixMapping, SaveArg, CASOpts, DB);
+                                  PrefixMapping, SaveArg, CASOpts, DB, Cache);
   };
   if (llvm::Error E = ScanAndUpdate().moveInto(RootID)) {
     Diag.Report(diag::err_cas_depscan_failed) << toString(std::move(E));
@@ -631,8 +635,13 @@ int cc1depscan_main(ArrayRef<const char *> Argv, const char *Argv0,
   if (!CAS)
     return 1;
 
+  std::shared_ptr<llvm::cas::ActionCache> Cache =
+      CASOpts.getOrCreateActionCache(Diags);
+  if (!Cache)
+    return 1;
+
   if (int Ret = scanAndUpdateCC1(Argv0, CC1Args->getValues(), NewArgs, Diags,
-                                 Args, CASOpts, CAS, RootID))
+                                 Args, CASOpts, CAS, Cache, RootID))
     return Ret;
 
   // FIXME: Use OutputBackend to OnDisk only now.
@@ -869,9 +878,14 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
   if (!CAS)
     llvm::report_fatal_error("clang -cc1depscand: cannot create CAS");
 
+  std::shared_ptr<llvm::cas::ActionCache> Cache =
+      CASOpts.getOrCreateActionCache(Diags);
+  if (!Cache)
+    llvm::report_fatal_error("clang -cc1depscand: cannot create ActionCache");
+
   IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> FS;
   if (!ProduceIncludeTree)
-    FS = llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*CAS));
+    FS = llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*CAS, *Cache));
   tooling::dependencies::DependencyScanningService Service(
       tooling::dependencies::ScanningMode::DependencyDirectivesScan,
       ProduceIncludeTree
@@ -1119,10 +1133,11 @@ static Expected<llvm::cas::CASID> scanAndUpdateCC1Inline(
     bool ProduceIncludeTree, bool &DiagnosticErrorOccurred,
     const cc1depscand::DepscanPrefixMapping &PrefixMapping,
     llvm::function_ref<const char *(const Twine &)> SaveArg,
-    const CASOptions &CASOpts, std::shared_ptr<llvm::cas::CASDB> DB) {
+    const CASOptions &CASOpts, std::shared_ptr<llvm::cas::CASDB> DB,
+    std::shared_ptr<llvm::cas::ActionCache> Cache) {
   IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> FS;
   if (!ProduceIncludeTree)
-    FS = llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*DB));
+    FS = llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*DB, *Cache));
 
   tooling::dependencies::DependencyScanningService Service(
       tooling::dependencies::ScanningMode::DependencyDirectivesScan,

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -48,7 +48,6 @@
 #include "llvm/Support/VirtualOutputBackends.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdio>
-#include <memory>
 #include <mutex>
 #include <shared_mutex>
 
@@ -885,13 +884,13 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
 
   IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> FS;
   if (!ProduceIncludeTree)
-    FS = llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*CAS, *Cache));
+    FS = llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*CAS));
   tooling::dependencies::DependencyScanningService Service(
       tooling::dependencies::ScanningMode::DependencyDirectivesScan,
       ProduceIncludeTree
           ? tooling::dependencies::ScanningOutputFormat::IncludeTree
           : tooling::dependencies::ScanningOutputFormat::Tree,
-      CASOpts, FS,
+      CASOpts, Cache, FS,
       /*ReuseFileManager=*/false,
       /*SkipExcludedPPRanges=*/true);
 
@@ -1137,14 +1136,14 @@ static Expected<llvm::cas::CASID> scanAndUpdateCC1Inline(
     std::shared_ptr<llvm::cas::ActionCache> Cache) {
   IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> FS;
   if (!ProduceIncludeTree)
-    FS = llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*DB, *Cache));
+    FS = llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*DB));
 
   tooling::dependencies::DependencyScanningService Service(
       tooling::dependencies::ScanningMode::DependencyDirectivesScan,
       ProduceIncludeTree
           ? tooling::dependencies::ScanningOutputFormat::IncludeTree
           : tooling::dependencies::ScanningOutputFormat::Tree,
-      CASOpts, FS,
+      CASOpts, Cache, FS,
       /*ReuseFileManager=*/false,
       /*SkipExcludedPPRanges=*/true);
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> UnderlyingFS =

--- a/clang/unittests/CAS/CASOptionsTest.cpp
+++ b/clang/unittests/CAS/CASOptionsTest.cpp
@@ -104,7 +104,7 @@ TEST(CASOptionsTest, getOrCreateCASInvalid) {
   ASSERT_EQ(Contents, MemBuffer->getBuffer());
 }
 
-TEST(CASOptionsTest, getOrCreateCASAndHideConfig) {
+TEST(CASOptionsTest, freezeConfig) {
   DiagnosticsEngine Diags(new DiagnosticIDs(), new DiagnosticOptions,
                           new IgnoringDiagConsumer());
 
@@ -112,7 +112,8 @@ TEST(CASOptionsTest, getOrCreateCASAndHideConfig) {
   unittest::TempDir Dir("cas-options", /*Unique=*/true);
   CASOptions Opts;
   Opts.CASPath = Dir.path("cas").str().str();
-  std::shared_ptr<CASDB> CAS = Opts.getOrCreateCASAndHideConfig(Diags);
+  Opts.freezeConfig(Diags);
+  std::shared_ptr<CASDB> CAS = Opts.getOrCreateCAS(Diags);
   ASSERT_TRUE(CAS);
   EXPECT_EQ(CASOptions::UnknownCAS, Opts.getKind());
 
@@ -124,13 +125,9 @@ TEST(CASOptionsTest, getOrCreateCASAndHideConfig) {
   Opts.CASPath = "";
   EXPECT_EQ(CAS, Opts.getOrCreateCAS(Diags));
   EXPECT_EQ(CASOptions::UnknownCAS, Opts.getKind());
-  EXPECT_EQ(CAS, Opts.getOrCreateCASAndHideConfig(Diags));
-  EXPECT_EQ(CASOptions::UnknownCAS, Opts.getKind());
 
   Opts.CASPath = Dir.path("ignored-cas").str().str();
   EXPECT_EQ(CAS, Opts.getOrCreateCAS(Diags));
-  EXPECT_EQ(CASOptions::UnknownCAS, Opts.getKind());
-  EXPECT_EQ(CAS, Opts.getOrCreateCASAndHideConfig(Diags));
   EXPECT_EQ(CASOptions::UnknownCAS, Opts.getKind());
 }
 #endif

--- a/clang/unittests/CAS/IncludeTreeTest.cpp
+++ b/clang/unittests/CAS/IncludeTreeTest.cpp
@@ -39,7 +39,7 @@ TEST(IncludeTree, IncludeTreeScan) {
 
   DependencyScanningService Service(ScanningMode::DependencyDirectivesScan,
                                     ScanningOutputFormat::IncludeTree,
-                                    CASOptions(), nullptr);
+                                    CASOptions(), nullptr, nullptr);
   DependencyScanningTool ScanTool(Service, std::move(VFS));
 
   std::vector<std::string> CommandLine = {"clang",

--- a/clang/unittests/Tooling/DependencyScannerTest.cpp
+++ b/clang/unittests/Tooling/DependencyScannerTest.cpp
@@ -233,7 +233,7 @@ TEST(DependencyScanner, ScanDepsWithFS) {
 
   DependencyScanningService Service(ScanningMode::DependencyDirectivesScan,
                                     ScanningOutputFormat::Make, CASOptions(),
-                                    nullptr);
+                                    nullptr, nullptr);
   DependencyScanningTool ScanTool(Service, VFS);
 
   std::string DepFile;
@@ -256,7 +256,7 @@ TEST(DependencyScanner, DepScanFSWithCASProvider) {
 
   DependencyScanningService Service(ScanningMode::DependencyDirectivesScan,
                                     ScanningOutputFormat::Make, CASOptions(),
-                                    nullptr);
+                                    nullptr, nullptr);
   {
     DependencyScanningWorkerFilesystem DepFS(Service.getSharedCache(),
                                              std::move(CASFS));

--- a/lld/MachO/Config.h
+++ b/lld/MachO/Config.h
@@ -26,7 +26,6 @@
 #include "llvm/TextAPI/Platform.h"
 #include "llvm/TextAPI/Target.h"
 
-#include <memory>
 #include <vector>
 
 namespace llvm {

--- a/lld/MachO/Config.h
+++ b/lld/MachO/Config.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/BinaryFormat/MachO.h"
+#include "llvm/CAS/ActionCache.h"
 #include "llvm/Support/CachePruning.h"
 #include "llvm/Support/GlobPattern.h"
 #include "llvm/Support/VersionTuple.h"
@@ -25,6 +26,7 @@
 #include "llvm/TextAPI/Platform.h"
 #include "llvm/TextAPI/Target.h"
 
+#include <memory>
 #include <vector>
 
 namespace llvm {
@@ -200,6 +202,7 @@ struct Configuration {
 
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs;
   std::unique_ptr<llvm::cas::CASDB> CAS;
+  std::unique_ptr<llvm::cas::ActionCache> actionCache;
   std::unique_ptr<llvm::casobjectformats::ObjectFormatSchemaPool> CASSchemas;
   bool depScanning = false;
 

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -37,6 +37,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/MachO.h"
 #include "llvm/BinaryFormat/Magic.h"
+#include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASDB.h"
 #include "llvm/CAS/CASFileSystem.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
@@ -1469,7 +1470,7 @@ static bool linkWithResultCaching(InputArgList &args, bool canExitEarly,
     // FIXME: Allow doing input scanning using a CAS-FS. Need to have a \p
     // CachingOnDiskFileSystem that can track accesses over a CAS tree, instead
     // of the real filesystem.
-    auto cacheFS = createCachingOnDiskFileSystem(CAS);
+    auto cacheFS = createCachingOnDiskFileSystem(CAS, *config->actionCache);
     if (!cacheFS) {
       error("error creating caching filesystem: " +
             toString(cacheFS.takeError()));
@@ -1507,11 +1508,12 @@ static bool linkWithResultCaching(InputArgList &args, bool canExitEarly,
   }
 
   CASID cacheKey = *optCacheKey;
-  Expected<CASID> result = config->CAS->getCachedResult(cacheKey);
+  Optional<ObjectRef> result = config->actionCache->get(cacheKey);
   if (result) {
-    log("Caching: cache hit, result: " + result->toString() +
+    CASID resultID = config->CAS->getID(*result);
+    log("Caching: cache hit, result: " + resultID.toString() +
         ", key: " + cacheKey.toString());
-    if (Error E = replayResult(CAS, std::move(*result))) {
+    if (Error E = replayResult(CAS, resultID)) {
       error("error replaying cached result: " + toString(std::move(E)));
       return false;
     }
@@ -1522,7 +1524,6 @@ static bool linkWithResultCaching(InputArgList &args, bool canExitEarly,
     TimeTraceScope timeScope("Caching: link after cache miss");
 
     log("Caching: cache miss, key: " + cacheKey.toString());
-    consumeError(result.takeError());
 
     SmallString<128> workingDirectory;
     if (std::error_code ec = sys::fs::current_path(workingDirectory)) {
@@ -1579,12 +1580,13 @@ static bool linkWithResultCaching(InputArgList &args, bool canExitEarly,
       return false;
     }
 
-    cas::CASID resultID = CAS.getID(*resultTree);
-    if (Error E = CAS.putCachedResult(cacheKey, resultID)) {
+    if (Error E =
+            config->actionCache->put(cacheKey, CAS.getReference(*resultTree))) {
       error("error storing cached result: " + toString(std::move(E)));
       return false;
     }
 
+    cas::CASID resultID = CAS.getID(*resultTree);
     log("Caching: cached result: " + resultID.toString());
   }
 
@@ -1766,6 +1768,15 @@ bool macho::link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
       error("error loading CAS at path '" + path +
             "': " + toString(CAS.takeError()));
     }
+    std::string defaultCachePath = llvm::cas::getDefaultOnDiskActionCachePath();
+    StringRef cachePath =
+        args.getLastArgValue(OPT_cache_path, defaultCachePath);
+    auto cache = llvm::cas::createOnDiskActionCache(*config->CAS, cachePath);
+    if (cache)
+      config->actionCache = std::move(*cache);
+    else
+      error("error loading ActionCache at path '" + cachePath +
+            "': " + toString(cache.takeError()));
   }
   Optional<StringRef> CASFileSystemRootID;
   if (args.hasArg(OPT_fcas_fs))

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1470,7 +1470,7 @@ static bool linkWithResultCaching(InputArgList &args, bool canExitEarly,
     // FIXME: Allow doing input scanning using a CAS-FS. Need to have a \p
     // CachingOnDiskFileSystem that can track accesses over a CAS tree, instead
     // of the real filesystem.
-    auto cacheFS = createCachingOnDiskFileSystem(CAS, *config->actionCache);
+    auto cacheFS = createCachingOnDiskFileSystem(CAS);
     if (!cacheFS) {
       error("error creating caching filesystem: " +
             toString(cacheFS.takeError()));

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1508,9 +1508,13 @@ static bool linkWithResultCaching(InputArgList &args, bool canExitEarly,
   }
 
   CASID cacheKey = *optCacheKey;
-  Optional<ObjectRef> result = config->actionCache->get(cacheKey);
-  if (result) {
-    CASID resultID = config->CAS->getID(*result);
+  auto result = config->actionCache->get(cacheKey);
+  if (!result) {
+    error("ActionCache lookup failed: " + toString(result.takeError()));
+    return false;
+  }
+  if (*result) {
+    CASID resultID = config->CAS->getID(**result);
     log("Caching: cache hit, result: " + resultID.toString() +
         ", key: " + cacheKey.toString());
     if (Error E = replayResult(CAS, resultID)) {

--- a/lld/MachO/Options.td
+++ b/lld/MachO/Options.td
@@ -100,6 +100,10 @@ def cas_path : Separate<["--"], "fcas-builtin-path">,
     HelpText<"Path to a persistent on-disk backing store for the builtin CAS.">,
     MetaVarName<"<path>">,
     Group<grp_lld>;
+def cache_path : Separate<["--"], "faction-cache-path">,
+    HelpText<"Path to a persistent on-disk backing store for the action cache.">,
+    MetaVarName<"<path>">,
+    Group<grp_lld>;
 def fcas_fs : Separate<["--"], "fcas-fs">,
     HelpText<"Configure the filesystem to read from the provided CAS tree.">,
     MetaVarName<"<tree>">,

--- a/lld/test/MachO/CAS/cache-results.s
+++ b/lld/test/MachO/CAS/cache-results.s
@@ -15,60 +15,60 @@
 
 // Check result caching.
 
-// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-MISS
 // RUN: diff %t/exe %t/exe-normal
 
 // RUN: rm %t/exe
-// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-HIT
 // RUN: diff %t/exe %t/exe-normal
 
 // RUN: touch %t/main.o %t/alib/libt1.a %t/dlib/libt2.dylib
-// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-HIT
 
 // Check that changing output executable filename doesn't affect cache key for executables.
-// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe2 -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe2 -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-HIT
 // RUN: diff %t/exe2 %t/exe-normal
 
 // But changing output dylib filename affects cache key.
-// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose -dylib %t/main.o -o %t/exe1.dylib -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose -dylib %t/main.o -o %t/exe1.dylib -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-MISS
-// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose -dylib %t/main.o -o %t/exe2.dylib -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose -dylib %t/main.o -o %t/exe2.dylib -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-MISS
 // RUN: not diff %t/exe1.dylib %t/exe2.dylib
 
 // Check that re-exports in a dylib are handled for dependency scanning (libc++ re-exports libc++abi)
-// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose -lc++ %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose -lc++ %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-MISS
 
 // Change order of search paths.
-// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt2 -lt1 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt2 -lt1 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-MISS
-// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt2 -lt1 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt2 -lt1 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-HIT
 
 // Change .o contents
 // RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/main2.s -o %t/main.o
-// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-MISS
-// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-HIT
 
 // Change .a and .dylib contents
 // RUN: llvm-ar rcs %t/alib/libt1.a %t/t2.o
 // RUN: %lld -dylib -o %t/dlib/libt2.dylib %t/t1.o
-// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-MISS
-// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-HIT
 
 // Check using relative paths.
 
 // RUN: mv %t/exe %t/exe.bak; cd %t
-// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose main.o -o exe -lt1 -lt2 -Lalib -Ldlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose main.o -o exe -lt1 -lt2 -Lalib -Ldlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-HIT
 // RUN: diff %t/exe %t/exe.bak
 

--- a/llvm/include/llvm/CAS/ActionCache.h
+++ b/llvm/include/llvm/CAS/ActionCache.h
@@ -85,10 +85,13 @@ private:
 /// Create an action cache in memory.
 std::unique_ptr<ActionCache> createInMemoryActionCache(CASDB &CAS);
 
+/// Get a reasonable default on-disk path for a persistent ActionCache for the
+/// current user.
+std::string getDefaultOnDiskActionCachePath();
+
 /// Create an action cache on disk.
 Expected<std::unique_ptr<ActionCache>> createOnDiskActionCache(CASDB &CAS,
                                                                StringRef Path);
-
 } // end namespace llvm::cas
 
 #endif // LLVM_CAS_CASACTIONCACHE_H

--- a/llvm/include/llvm/CAS/ActionCache.h
+++ b/llvm/include/llvm/CAS/ActionCache.h
@@ -1,0 +1,94 @@
+//===- llvm/CAS/ActionCache.h -----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CAS_CASACTIONCACHE_H
+#define LLVM_CAS_CASACTIONCACHE_H
+
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/CAS/CASReference.h"
+#include "llvm/Support/Error.h"
+
+namespace llvm::cas {
+
+class CASDB;
+class CASID;
+class ObjectProxy;
+
+/// A key for caching an operation.
+/// It is implemented as a bag of bytes and provides a convenient constructor
+/// for CAS types.
+class CacheKey {
+public:
+  StringRef getKey() const { return Key; }
+
+  // TODO: Support CacheKey other than a CASID but rather any array of bytes.
+  // To do that, ActionCache need to be able to rehash the key into the index,
+  // which then `getOrCompute` method can be used to avoid multiple calls to
+  // has function.
+  CacheKey(const CASID &ID);
+  CacheKey(const ObjectProxy &Proxy);
+  CacheKey(const CASDB &CAS, const ObjectRef &Ref);
+
+private:
+  std::string Key;
+};
+
+/// A cache from a key describing an action to the result of doing it.
+///
+/// Actions are expected to be pure (collision is an error).
+class ActionCache {
+  virtual void anchor();
+
+public:
+  /// Get a previously computed result for \p ActionKey.
+  Optional<ObjectRef> get(const CacheKey &ActionKey) const {
+    return getImpl(arrayRefFromStringRef(ActionKey.getKey()));
+  }
+
+  /// Cache \p Result for the \p ActionKey computation.
+  Error put(const CacheKey &ActionKey, const ObjectRef &Result) {
+    return putImpl(arrayRefFromStringRef(ActionKey.getKey()), Result);
+  }
+
+  /// Cache \p Result using \p ObjectRef as a key.
+  Error put(const ObjectRef &RefKey, const ObjectRef &Result) {
+    CacheKey ActionKey(CAS, RefKey);
+    return putImpl(arrayRefFromStringRef(ActionKey.getKey()), Result);
+  }
+
+  /// Get or compute a result for \p ActionKey. Equivalent to calling \a get()
+  /// (followed by \a compute() and \a put() on failure).
+  Expected<ObjectRef> getOrCompute(const CacheKey &ActionKey,
+                                   function_ref<Expected<ObjectRef>()> Compute);
+
+  virtual ~ActionCache() = default;
+
+protected:
+  virtual Optional<ObjectRef> getImpl(ArrayRef<uint8_t> ResolvedKey) const = 0;
+  virtual Error putImpl(ArrayRef<uint8_t> ResolvedKey,
+                        const ObjectRef &Result) = 0;
+
+  ActionCache(CASDB &CAS) : CAS(CAS) {}
+
+  CASDB &getCAS() const { return CAS; }
+
+private:
+  CASDB &CAS;
+};
+
+/// Create an action cache in memory.
+std::unique_ptr<ActionCache> createInMemoryActionCache(CASDB &CAS);
+
+/// Create an action cache on disk.
+Expected<std::unique_ptr<ActionCache>> createOnDiskActionCache(CASDB &CAS,
+                                                               StringRef Path);
+
+} // end namespace llvm::cas
+
+#endif // LLVM_CAS_CASACTIONCACHE_H

--- a/llvm/include/llvm/CAS/ActionCache.h
+++ b/llvm/include/llvm/CAS/ActionCache.h
@@ -47,7 +47,7 @@ class ActionCache {
 
 public:
   /// Get a previously computed result for \p ActionKey.
-  Optional<ObjectRef> get(const CacheKey &ActionKey) const {
+  Expected<Optional<ObjectRef>> get(const CacheKey &ActionKey) const {
     return getImpl(arrayRefFromStringRef(ActionKey.getKey()));
   }
 
@@ -70,7 +70,8 @@ public:
   virtual ~ActionCache() = default;
 
 protected:
-  virtual Optional<ObjectRef> getImpl(ArrayRef<uint8_t> ResolvedKey) const = 0;
+  virtual Expected<Optional<ObjectRef>>
+  getImpl(ArrayRef<uint8_t> ResolvedKey) const = 0;
   virtual Error putImpl(ArrayRef<uint8_t> ResolvedKey,
                         const ObjectRef &Result) = 0;
 

--- a/llvm/include/llvm/CAS/CASDB.h
+++ b/llvm/include/llvm/CAS/CASDB.h
@@ -145,6 +145,9 @@ public:
   /// Returns \c None if not stored in this CAS.
   virtual Optional<ObjectRef> getReference(const CASID &ID) const = 0;
 
+  /// Get a reference to the object has the hash value \p Hash.
+  virtual Optional<ObjectRef> getReference(ArrayRef<uint8_t> Hash) const = 0;
+
   /// Get a Ref from Handle.
   virtual ObjectRef getReference(ObjectHandle Handle) const = 0;
 

--- a/llvm/include/llvm/CAS/CASDB.h
+++ b/llvm/include/llvm/CAS/CASDB.h
@@ -170,13 +170,6 @@ public:
   virtual ArrayRef<char> getData(ObjectHandle Node,
                                  bool RequiresNullTerminator = false) const = 0;
 
-public:
-  /// ActionCache APIs.
-  // FIXME: Split out in the future. This should also be generic key-value
-  // storage interface, rather than CASID -> CASID.
-  virtual Expected<CASID> getCachedResult(CASID InputID) = 0;
-  virtual Error putCachedResult(CASID InputID, CASID OutputID) = 0;
-
 protected:
   virtual Expected<ObjectHandle>
   storeFromOpenFileImpl(sys::fs::file_t FD,

--- a/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
+++ b/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
@@ -14,12 +14,10 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include <map>
-#include <memory>
 
 namespace llvm {
 namespace cas {
 
-class ActionCache;
 class ObjectProxy;
 
 /// A mostly-thread-safe caching on-disk filesystem. The only unsafe operation
@@ -102,7 +100,6 @@ public:
   virtual std::unique_ptr<TreeBuilder> createTreeBuilder() = 0;
 
   CASDB &getCAS() const { return DB; }
-  ActionCache &getCache() const { return Cache; }
 
   /// Get a proxy FS that has an independent working directory but uses the
   /// same thread-safe cache.
@@ -113,23 +110,19 @@ public:
   }
 
 protected:
-  CachingOnDiskFileSystem(std::shared_ptr<CASDB> DB,
-                          std::shared_ptr<ActionCache> Cache);
-  CachingOnDiskFileSystem(CASDB &DB, ActionCache &Cache);
+  CachingOnDiskFileSystem(std::shared_ptr<CASDB> DB);
+  CachingOnDiskFileSystem(CASDB &DB);
   CachingOnDiskFileSystem(const CachingOnDiskFileSystem &) = default;
 
   CASDB &DB;
   std::shared_ptr<CASDB> OwnedDB;
-  ActionCache &Cache;
-  std::shared_ptr<ActionCache> OwnedCache;
 };
 
 Expected<IntrusiveRefCntPtr<CachingOnDiskFileSystem>>
-createCachingOnDiskFileSystem(std::shared_ptr<CASDB> DB,
-                              std::shared_ptr<ActionCache> Cache);
+createCachingOnDiskFileSystem(std::shared_ptr<CASDB> DB);
 
 Expected<IntrusiveRefCntPtr<CachingOnDiskFileSystem>>
-createCachingOnDiskFileSystem(CASDB &DB, ActionCache &Cache);
+createCachingOnDiskFileSystem(CASDB &DB);
 
 } // namespace cas
 } // namespace llvm

--- a/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
+++ b/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
@@ -14,10 +14,12 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include <map>
+#include <memory>
 
 namespace llvm {
 namespace cas {
 
+class ActionCache;
 class ObjectProxy;
 
 /// A mostly-thread-safe caching on-disk filesystem. The only unsafe operation
@@ -100,6 +102,7 @@ public:
   virtual std::unique_ptr<TreeBuilder> createTreeBuilder() = 0;
 
   CASDB &getCAS() const { return DB; }
+  ActionCache &getCache() const { return Cache; }
 
   /// Get a proxy FS that has an independent working directory but uses the
   /// same thread-safe cache.
@@ -110,19 +113,23 @@ public:
   }
 
 protected:
-  CachingOnDiskFileSystem(std::shared_ptr<CASDB> DB);
-  CachingOnDiskFileSystem(CASDB &DB);
+  CachingOnDiskFileSystem(std::shared_ptr<CASDB> DB,
+                          std::shared_ptr<ActionCache> Cache);
+  CachingOnDiskFileSystem(CASDB &DB, ActionCache &Cache);
   CachingOnDiskFileSystem(const CachingOnDiskFileSystem &) = default;
 
   CASDB &DB;
   std::shared_ptr<CASDB> OwnedDB;
+  ActionCache &Cache;
+  std::shared_ptr<ActionCache> OwnedCache;
 };
 
 Expected<IntrusiveRefCntPtr<CachingOnDiskFileSystem>>
-createCachingOnDiskFileSystem(std::shared_ptr<CASDB> DB);
+createCachingOnDiskFileSystem(std::shared_ptr<CASDB> DB,
+                              std::shared_ptr<ActionCache> Cache);
 
 Expected<IntrusiveRefCntPtr<CachingOnDiskFileSystem>>
-createCachingOnDiskFileSystem(CASDB &DB);
+createCachingOnDiskFileSystem(CASDB &DB, ActionCache &Cache);
 
 } // namespace cas
 } // namespace llvm

--- a/llvm/include/llvm/TableGen/ScanDependencies.h
+++ b/llvm/include/llvm/TableGen/ScanDependencies.h
@@ -19,6 +19,7 @@
 namespace llvm {
 
 namespace cas {
+class ActionCache;
 class CachingOnDiskFileSystem;
 } // end namespace cas
 
@@ -42,8 +43,8 @@ void scanTextForIncludes(StringRef Input, SmallVectorImpl<StringRef> &Includes);
 ///
 /// \p ExecID is the Blob for the running executable. It can be used as part of
 /// the key for caching to avoid (fixed) bugs poisoning results.
-Error scanTextForIncludes(cas::CASDB &CAS, cas::ObjectRef ExecID,
-                          const cas::ObjectProxy &Blob,
+Error scanTextForIncludes(cas::CASDB &CAS, cas::ActionCache &Cache,
+                          cas::ObjectRef ExecID, const cas::ObjectProxy &Blob,
                           SmallVectorImpl<StringRef> &Includes);
 
 /// Match logic from SourceMgr::AddIncludeFile.
@@ -79,8 +80,8 @@ struct ScanIncludesResult {
 /// it'd be useful for build systems that want to collect dependencies ahead of
 /// time. Maybe can separate a tool/etc. for that.
 Expected<ScanIncludesResult>
-scanIncludes(cas::CASDB &CAS, cas::ObjectRef ExecID, StringRef MainFilename,
-             ArrayRef<std::string> IncludeDirs,
+scanIncludes(cas::CASDB &CAS, cas::ActionCache &Cache, cas::ObjectRef ExecID,
+             StringRef MainFilename, ArrayRef<std::string> IncludeDirs,
              ArrayRef<MappedPrefix> PrefixMappings = None,
              Optional<TreePathPrefixMapper> *CapturedPM = nullptr);
 
@@ -91,8 +92,8 @@ scanIncludes(cas::CASDB &CAS, cas::ObjectRef ExecID, StringRef MainFilename,
 /// \p ExecID is the Blob for the running executable. It can be used as part of
 /// the key for caching to avoid (fixed) bugs poisoning results.
 Expected<ScanIncludesResult>
-scanIncludesAndRemap(cas::CASDB &CAS, cas::ObjectRef ExecID,
-                     std::string &MainFilename,
+scanIncludesAndRemap(cas::CASDB &CAS, cas::ActionCache &Cache,
+                     cas::ObjectRef ExecID, std::string &MainFilename,
                      std::vector<std::string> &IncludeDirs,
                      ArrayRef<MappedPrefix> PrefixMappings);
 

--- a/llvm/include/llvm/TableGen/ScanDependencies.h
+++ b/llvm/include/llvm/TableGen/ScanDependencies.h
@@ -58,7 +58,8 @@ Optional<cas::ObjectRef> lookupIncludeID(cas::CachingOnDiskFileSystem &FS,
 ///
 /// \p ExecID is the Blob for the running executable. It can be used as part of
 /// the key for caching to avoid (fixed) bugs poisoning results.
-Error accessAllIncludes(cas::CachingOnDiskFileSystem &FS, cas::ObjectRef ExecID,
+Error accessAllIncludes(cas::CachingOnDiskFileSystem &FS,
+                        cas::ActionCache &Cache, cas::ObjectRef ExecID,
                         ArrayRef<std::string> IncludeDirs,
                         const cas::ObjectProxy &MainFileBlob);
 

--- a/llvm/lib/CAS/ActionCache.cpp
+++ b/llvm/lib/CAS/ActionCache.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "BuiltinCAS.h"
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASDB.h"
 #include "llvm/CAS/CASID.h"
@@ -25,8 +26,8 @@ Expected<ObjectRef>
 ActionCache::getOrCompute(const CacheKey &ActionKey,
                           function_ref<Expected<ObjectRef>()> Computation) {
   ArrayRef<uint8_t> Key = arrayRefFromStringRef(ActionKey.getKey());
-  if (Optional<ObjectRef> Result = getImpl(Key))
-    return *Result;
+  if (Optional<Expected<ObjectRef>> Result = builtin::transpose(getImpl(Key)))
+    return std::move(*Result);
   Optional<ObjectRef> Result;
   if (Error E = Computation().moveInto(Result))
     return std::move(E);

--- a/llvm/lib/CAS/ActionCache.cpp
+++ b/llvm/lib/CAS/ActionCache.cpp
@@ -1,0 +1,36 @@
+//===- ActionCache.cpp ------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/CASDB.h"
+#include "llvm/CAS/CASID.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+
+void ActionCache::anchor() {}
+
+CacheKey::CacheKey(const CASID &ID) : Key(toStringRef(ID.getHash()).str()) {}
+CacheKey::CacheKey(const ObjectProxy &Proxy)
+    : CacheKey(Proxy.getCAS(), Proxy.getRef()) {}
+CacheKey::CacheKey(const CASDB &CAS, const ObjectRef &Ref)
+    : Key(toStringRef(CAS.getID(Ref).getHash())) {}
+
+Expected<ObjectRef>
+ActionCache::getOrCompute(const CacheKey &ActionKey,
+                          function_ref<Expected<ObjectRef>()> Computation) {
+  ArrayRef<uint8_t> Key = arrayRefFromStringRef(ActionKey.getKey());
+  if (Optional<ObjectRef> Result = getImpl(Key))
+    return *Result;
+  Optional<ObjectRef> Result;
+  if (Error E = Computation().moveInto(Result))
+    return std::move(E);
+  if (Error E = putImpl(Key, *Result))
+    return std::move(E);
+  return *Result;
+}

--- a/llvm/lib/CAS/ActionCaches.cpp
+++ b/llvm/lib/CAS/ActionCaches.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "BuiltinCAS.h"
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASDB.h"
 #include "llvm/CAS/HashMappedTrie.h"
@@ -184,12 +185,13 @@ Error OnDiskActionCache::putImpl(ArrayRef<uint8_t> Key,
                                         Observed->getValue());
 }
 
-static constexpr StringLiteral DefaultName = "llvm.actioncache.builtin.default";
+static constexpr StringLiteral DefaultName = "actioncache";
+
 std::string cas::getDefaultOnDiskActionCachePath() {
   SmallString<128> Path;
   if (!llvm::sys::path::cache_directory(Path))
     report_fatal_error("cannot get default cache directory");
-  llvm::sys::path::append(Path, DefaultName);
+  llvm::sys::path::append(Path, builtin::DefaultDir, DefaultName);
   return Path.str().str();
 }
 

--- a/llvm/lib/CAS/ActionCaches.cpp
+++ b/llvm/lib/CAS/ActionCaches.cpp
@@ -15,7 +15,6 @@
 #include "llvm/Support/Alignment.h"
 #include "llvm/Support/BLAKE3.h"
 #include "llvm/Support/Path.h"
-#include <memory>
 
 #define DEBUG_TYPE "action-caches"
 

--- a/llvm/lib/CAS/ActionCaches.cpp
+++ b/llvm/lib/CAS/ActionCaches.cpp
@@ -1,0 +1,205 @@
+//===- ActionCaches.cpp -----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/CASDB.h"
+#include "llvm/CAS/HashMappedTrie.h"
+#include "llvm/CAS/OnDiskHashMappedTrie.h"
+#include "llvm/Config/llvm-config.h"
+#include "llvm/Support/Alignment.h"
+#include "llvm/Support/BLAKE3.h"
+#include "llvm/Support/Path.h"
+#include <memory>
+
+#define DEBUG_TYPE "action-caches"
+
+using namespace llvm;
+using namespace llvm::cas;
+
+namespace {
+
+using HasherT = BLAKE3;
+using HashType = decltype(HasherT::hash(std::declval<ArrayRef<uint8_t> &>()));
+
+template <size_t Size> class CacheEntry {
+public:
+  CacheEntry() = default;
+  CacheEntry(ArrayRef<uint8_t> Hash) { llvm::copy(Hash, Value.data()); }
+  CacheEntry(const CacheEntry &Entry) { llvm::copy(Entry.Value, Value.data()); }
+  ArrayRef<uint8_t> getValue() const { return Value; }
+
+private:
+  std::array<uint8_t, Size> Value;
+};
+
+class InMemoryActionCache final : public ActionCache {
+public:
+  InMemoryActionCache(CASDB &CAS);
+
+  Error putImpl(ArrayRef<uint8_t> ActionKey, const ObjectRef &Result) final;
+  Optional<ObjectRef> getImpl(ArrayRef<uint8_t> ActionKey) const final;
+
+private:
+  using DataT = CacheEntry<sizeof(HashType)>;
+  using InMemoryCacheT = ThreadSafeHashMappedTrie<DataT, sizeof(HashType)>;
+
+  InMemoryCacheT Cache;
+};
+
+#if LLVM_ENABLE_ONDISK_CAS
+class OnDiskActionCache final : public ActionCache {
+public:
+  Error putImpl(ArrayRef<uint8_t> ActionKey, const ObjectRef &Result) final;
+  Optional<ObjectRef> getImpl(ArrayRef<uint8_t> ActionKey) const final;
+
+  static Expected<std::unique_ptr<OnDiskActionCache>> create(CASDB &CAS,
+                                                             StringRef Path);
+
+private:
+  static StringRef getHashName() { return "BLAKE3"; }
+  static StringRef getActionCacheTableName() {
+    static const std::string Name =
+        ("llvm.actioncache[" + getHashName() + "->" + getHashName() + "]")
+            .str();
+    return Name;
+  }
+  static constexpr StringLiteral ActionCacheFile = "actions";
+  static constexpr StringLiteral FilePrefix = "v1.";
+
+  OnDiskActionCache(CASDB &CAS, StringRef RootPath,
+                    OnDiskHashMappedTrie ActionCache);
+
+  std::string Path;
+  OnDiskHashMappedTrie Cache;
+  using DataT = CacheEntry<sizeof(HashType)>;
+};
+#endif /* LLVM_ENABLE_ONDISK_CAS */
+} // end namespace
+
+// TODO: Check the hash schema is the same between action cache and CAS. If we
+// can derive that from static type information, that would be even better.
+InMemoryActionCache::InMemoryActionCache(CASDB &CAS) : ActionCache(CAS) {}
+
+Optional<ObjectRef> InMemoryActionCache::getImpl(ArrayRef<uint8_t> Key) const {
+  auto Result = Cache.find(Key);
+  if (!Result)
+    return None;
+  return getCAS().getReference(Result->Data.getValue());
+}
+
+static std::string hashToString(ArrayRef<uint8_t> Hash) {
+  SmallString<64> Str;
+  toHex(Hash, /*LowerCase=*/true, Str);
+  return Str.str().str();
+}
+
+static Error createResultCachePoisonedError(StringRef Key, CASDB &CAS,
+                                            ObjectRef Output,
+                                            ArrayRef<uint8_t> ExistingOutput) {
+  std::string OutID = CAS.getID(Output).toString();
+  Optional<ObjectRef> ExistingRef = CAS.getReference(ExistingOutput);
+  std::string Existing = ExistingRef ? CAS.getID(*ExistingRef).toString()
+                                     : hashToString(ExistingOutput);
+  return createStringError(std::make_error_code(std::errc::invalid_argument),
+                           "cache poisoned for '" + Key + "' (new='" + OutID +
+                               "' vs. existing '" + Existing + "')");
+}
+
+Error InMemoryActionCache::putImpl(ArrayRef<uint8_t> Key,
+                                   const ObjectRef &Result) {
+  DataT Expected(getCAS().getID(Result).getHash());
+  const InMemoryCacheT::value_type &Cached = *Cache.insertLazy(
+      Key, [&](auto ValueConstructor) { ValueConstructor.emplace(Expected); });
+
+  const DataT &Observed = Cached.Data;
+  if (Expected.getValue() == Observed.getValue())
+    return Error::success();
+
+  return createResultCachePoisonedError(hashToString(Key), getCAS(), Result,
+                                        Observed.getValue());
+}
+
+std::unique_ptr<ActionCache> cas::createInMemoryActionCache(CASDB &CAS) {
+  return std::make_unique<InMemoryActionCache>(CAS);
+}
+
+#if LLVM_ENABLE_ONDISK_CAS
+OnDiskActionCache::OnDiskActionCache(CASDB &CAS, StringRef Path,
+                                     OnDiskHashMappedTrie Cache)
+    : ActionCache(CAS), Path(Path.str()), Cache(std::move(Cache)) {}
+
+Expected<std::unique_ptr<OnDiskActionCache>>
+OnDiskActionCache::create(CASDB &CAS, StringRef AbsPath) {
+  if (std::error_code EC = sys::fs::create_directories(AbsPath))
+    return createFileError(AbsPath, EC);
+
+  SmallString<256> CachePath(AbsPath);
+  sys::path::append(CachePath, FilePrefix + ActionCacheFile);
+  constexpr uint64_t MB = 1024ull * 1024ull;
+  constexpr uint64_t GB = 1024ull * 1024ull * 1024ull;
+
+  Optional<OnDiskHashMappedTrie> ActionCache;
+  if (Error E = OnDiskHashMappedTrie::create(
+                    CachePath, getActionCacheTableName(), sizeof(HashType) * 8,
+                    /*DataSize=*/sizeof(DataT), /*MaxFileSize=*/GB,
+                    /*MinFileSize=*/MB)
+                    .moveInto(ActionCache))
+    return std::move(E);
+
+  return std::unique_ptr<OnDiskActionCache>(
+      new OnDiskActionCache(CAS, AbsPath, std::move(*ActionCache)));
+}
+
+Optional<ObjectRef> OnDiskActionCache::getImpl(ArrayRef<uint8_t> Key) const {
+  // Check the result cache.
+  OnDiskHashMappedTrie::const_pointer ActionP = Cache.find(Key);
+  if (!ActionP)
+    return None;
+
+  const DataT *Output = reinterpret_cast<const DataT *>(ActionP->Data.data());
+  return getCAS().getReference(Output->getValue());
+}
+
+Error OnDiskActionCache::putImpl(ArrayRef<uint8_t> Key,
+                                 const ObjectRef &Result) {
+  DataT Expected(getCAS().getID(Result).getHash());
+  OnDiskHashMappedTrie::pointer ActionP = Cache.insertLazy(
+      Key, [&](FileOffset TentativeOffset,
+               OnDiskHashMappedTrie::ValueProxy TentativeValue) {
+        assert(TentativeValue.Data.size() == sizeof(DataT));
+        assert(isAddrAligned(Align::Of<DataT>(), TentativeValue.Data.data()));
+        new (TentativeValue.Data.data()) DataT{Expected};
+      });
+  const DataT *Observed = reinterpret_cast<const DataT *>(ActionP->Data.data());
+
+  if (Expected.getValue() == Observed->getValue())
+    return Error::success();
+
+  return createResultCachePoisonedError(hashToString(Key), getCAS(), Result,
+                                        Observed->getValue());
+}
+
+static constexpr StringLiteral DefaultName = "llvm.actioncache.builtin.default";
+std::string cas::getDefaultOnDiskActionCachePath() {
+  SmallString<128> Path;
+  if (!llvm::sys::path::cache_directory(Path))
+    report_fatal_error("cannot get default cache directory");
+  llvm::sys::path::append(Path, DefaultName);
+  return Path.str().str();
+}
+
+Expected<std::unique_ptr<ActionCache>>
+cas::createOnDiskActionCache(CASDB &CAS, StringRef Path) {
+  return OnDiskActionCache::create(CAS, Path);
+}
+# else
+Expected<std::unique_ptr<ActionCache>>
+cas::createOnDiskActionCache(CASDB &CAS, StringRef Path) {
+  return createStringError(inconvertibleErrorCode(), "OnDiskCache is disabled");
+}
+#endif /* LLVM_ENABLE_ONDISK_CAS */

--- a/llvm/lib/CAS/BuiltinCAS.h
+++ b/llvm/lib/CAS/BuiltinCAS.h
@@ -207,27 +207,6 @@ public:
                              "corrupt storage");
   }
 
-  /// FIXME: This should not use Error.
-  Error createResultCacheMissError(CASID Input) const {
-    return createStringError(std::make_error_code(std::errc::invalid_argument),
-                             "no result for '" + Input.toString() + "'");
-  }
-
-  Error createResultCachePoisonedError(CASID Input, CASID Output,
-                                       CASID ExistingOutput) const {
-    return createStringError(std::make_error_code(std::errc::invalid_argument),
-                             "cache poisoned for '" + Input.toString() +
-                                 "' (new='" + Output.toString() +
-                                 "' vs. existing '" +
-                                 ExistingOutput.toString() + "')");
-  }
-
-  Error createResultCacheCorruptError(CASID Input) const {
-    return createStringError(std::make_error_code(std::errc::invalid_argument),
-                             "result cache corrupt for '" + Input.toString() +
-                                 "'");
-  }
-
   Error validate(const CASID &ID) final;
 };
 

--- a/llvm/lib/CAS/BuiltinCAS.h
+++ b/llvm/lib/CAS/BuiltinCAS.h
@@ -231,6 +231,10 @@ public:
   Error validate(const CASID &ID) final;
 };
 
+// FIXME: Proxy not portable. Maybe also error-prone?
+constexpr StringLiteral DefaultDirProxy = "/^llvm::cas::builtin::default";
+constexpr StringLiteral DefaultDir = "llvm.cas.builtin.default";
+
 } // end namespace builtin
 } // end namespace cas
 } // end namespace llvm

--- a/llvm/lib/CAS/CMakeLists.txt
+++ b/llvm/lib/CAS/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_llvm_component_library(LLVMCAS
+  ActionCache.cpp
+  ActionCaches.cpp
   BuiltinCAS.cpp
   CASDB.cpp
   CASFileSystem.cpp

--- a/llvm/lib/CAS/InMemoryCAS.cpp
+++ b/llvm/lib/CAS/InMemoryCAS.cpp
@@ -272,6 +272,11 @@ public:
       return toReference(*Object);
     return None;
   }
+  Optional<ObjectRef> getReference(ArrayRef<uint8_t> Hash) const final {
+    if (InMemoryIndexT::const_pointer P = Index.find(Hash))
+      return toReference(*P->Data);
+    return None;
+  }
   ObjectRef getReference(ObjectHandle Handle) const final {
     return toReference(asInMemoryObject(Handle));
   }

--- a/llvm/lib/CAS/OnDiskCAS.cpp
+++ b/llvm/lib/CAS/OnDiskCAS.cpp
@@ -2002,13 +2002,11 @@ Expected<std::unique_ptr<CASDB>> cas::createOnDiskCAS(const Twine &Path) {
 
 #endif /* LLVM_ENABLE_ONDISK_CAS */
 
-// FIXME: Proxy not portable. Maybe also error-prone?
-constexpr StringLiteral DefaultDirProxy = "/^llvm::cas::builtin::default";
-constexpr StringLiteral DefaultName = "llvm.cas.builtin.default";
+static constexpr StringLiteral DefaultName = "cas";
 
 void cas::getDefaultOnDiskCASStableID(SmallVectorImpl<char> &Path) {
   Path.assign(DefaultDirProxy.begin(), DefaultDirProxy.end());
-  llvm::sys::path::append(Path, DefaultName);
+  llvm::sys::path::append(Path, DefaultDir, DefaultName);
 }
 
 std::string cas::getDefaultOnDiskCASStableID() {
@@ -2021,7 +2019,7 @@ void cas::getDefaultOnDiskCASPath(SmallVectorImpl<char> &Path) {
   // FIXME: Should this return 'Error' instead of hard-failing?
   if (!llvm::sys::path::cache_directory(Path))
     report_fatal_error("cannot get default cache directory");
-  llvm::sys::path::append(Path, DefaultName);
+  llvm::sys::path::append(Path, DefaultDir, DefaultName);
 }
 
 std::string cas::getDefaultOnDiskCASPath() {

--- a/llvm/lib/TableGen/Main.cpp
+++ b/llvm/lib/TableGen/Main.cpp
@@ -402,7 +402,10 @@ Error TableGenCache::lookupCachedResult(ArrayRef<const char *> Args) {
     return E;
 
   // Not an error for the result to be missing.
-  if (Optional<cas::ObjectRef> ID = Cache->get(CAS->getID(*ActionID)))
+  auto Result = Cache->get(CAS->getID(*ActionID));
+  if (!Result)
+    return Result.takeError();
+  if (Optional<cas::ObjectRef> ID = *Result)
     ResultID = *ID;
   return Error::success();
 }

--- a/llvm/lib/TableGen/Main.cpp
+++ b/llvm/lib/TableGen/Main.cpp
@@ -36,7 +36,6 @@
 #include "llvm/TableGen/Record.h"
 #include "llvm/TableGen/ScanDependencies.h"
 #include <algorithm>
-#include <memory>
 #include <system_error>
 using namespace llvm;
 using namespace llvm::tablegen;

--- a/llvm/lib/TableGen/Main.cpp
+++ b/llvm/lib/TableGen/Main.cpp
@@ -19,6 +19,7 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASFileSystem.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/CAS/HierarchicalTreeBuilder.h"
@@ -35,6 +36,7 @@
 #include "llvm/TableGen/Record.h"
 #include "llvm/TableGen/ScanDependencies.h"
 #include <algorithm>
+#include <memory>
 #include <system_error>
 using namespace llvm;
 using namespace llvm::tablegen;
@@ -252,6 +254,7 @@ int llvm::TableGenMain(const char *argv0, TableGenMainFn *MainFn) {
 namespace {
 struct TableGenCache {
   std::unique_ptr<cas::CASDB> CAS;
+  std::unique_ptr<cas::ActionCache> Cache;
   Optional<cas::ObjectRef> ExecutableID;
   Optional<cas::ObjectRef> IncludesTreeID;
   Optional<cas::ObjectRef> ActionID;
@@ -374,12 +377,18 @@ Error TableGenCache::lookupCachedResult(ArrayRef<const char *> Args) {
           cas::createOnDiskCAS(cas::getDefaultOnDiskCASPath()).moveInto(CAS))
     return E;
 
+  if (Error E = cas::createOnDiskActionCache(
+                    *CAS, cas::getDefaultOnDiskActionCachePath())
+                    .moveInto(Cache))
+    return E;
+
   if (Error E = createExecutableBlob(Args[0]).moveInto(ExecutableID))
     return E;
 
   OriginalInputFilename = InputFilename.getValue();
-  Expected<ScanIncludesResult> Scan = scanIncludesAndRemap(
-      *CAS, *ExecutableID, InputFilename, *&IncludeDirs, PrefixMappings);
+  Expected<ScanIncludesResult> Scan =
+      scanIncludesAndRemap(*CAS, *Cache, *ExecutableID, InputFilename,
+                           *&IncludeDirs, PrefixMappings);
   if (!Scan)
     return Scan.takeError();
 
@@ -393,9 +402,8 @@ Error TableGenCache::lookupCachedResult(ArrayRef<const char *> Args) {
     return E;
 
   // Not an error for the result to be missing.
-  if (Optional<cas::CASID> ID =
-          expectedToOptional(CAS->getCachedResult(CAS->getID(*ActionID))))
-    ResultID = CAS->getReference(*ID);
+  if (Optional<cas::ObjectRef> ID = Cache->get(CAS->getID(*ActionID)))
+    ResultID = *ID;
   return Error::success();
 }
 
@@ -479,7 +487,7 @@ Error TableGenCache::computeResult(TableGenMainFn *MainFn) {
   Expected<cas::ObjectHandle> Tree = Builder.create(*CAS);
   if (!Tree)
     return Tree.takeError();
-  return CAS->putCachedResult(CAS->getID(*ActionID), CAS->getID(*Tree));
+  return Cache->put(CAS->getID(*ActionID), CAS->getReference(*Tree));
 }
 
 Error TableGenCache::replayResult() {

--- a/llvm/lib/TableGen/ScanDependencies.cpp
+++ b/llvm/lib/TableGen/ScanDependencies.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/TableGen/ScanDependencies.h"
+#include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/PrefixMapper.h"
@@ -74,7 +75,7 @@ void tablegen::scanTextForIncludes(StringRef Input,
 }
 
 static Error
-fetchCachedIncludedFiles(cas::CASDB &CAS, cas::CASID ID,
+fetchCachedIncludedFiles(cas::CASDB &CAS, cas::ObjectRef ID,
                          SmallVectorImpl<StringRef> &IncludedFiles) {
   Expected<cas::ObjectProxy> ExpectedBlob = CAS.getProxy(ID);
   if (!ExpectedBlob)
@@ -83,8 +84,8 @@ fetchCachedIncludedFiles(cas::CASDB &CAS, cas::CASID ID,
   return Error::success();
 }
 
-static Error computeIncludedFiles(cas::CASDB &CAS, cas::CASID Key,
-                                  StringRef Input,
+static Error computeIncludedFiles(cas::CASDB &CAS, cas::ActionCache &Cache,
+                                  cas::CASID Key, StringRef Input,
                                   SmallVectorImpl<StringRef> &IncludedFiles) {
   SmallString<256> ResultToCache;
   scanTextForIncludes(Input, IncludedFiles);
@@ -94,12 +95,13 @@ static Error computeIncludedFiles(cas::CASDB &CAS, cas::CASID Key,
       CAS.createProxy(None, ResultToCache);
   if (!ExpectedResult)
     return ExpectedResult.takeError();
-  if (Error E = CAS.putCachedResult(Key, *ExpectedResult))
+  if (Error E = Cache.put(Key, ExpectedResult->getRef()))
     return E;
   return Error::success();
 }
 
-Error tablegen::scanTextForIncludes(cas::CASDB &CAS, cas::ObjectRef ExecID,
+Error tablegen::scanTextForIncludes(cas::CASDB &CAS, cas::ActionCache &Cache,
+                                    cas::ObjectRef ExecID,
                                     const cas::ObjectProxy &Blob,
                                     SmallVectorImpl<StringRef> &Includes) {
   constexpr StringLiteral CacheKeyData = "llvm::tablegen::scanTextForIncludes";
@@ -110,10 +112,9 @@ Error tablegen::scanTextForIncludes(cas::CASDB &CAS, cas::ObjectRef ExecID,
     return Key.takeError();
 
   cas::CASID KeyID = CAS.getID(*Key);
-  if (Optional<cas::CASID> ResultID =
-          expectedToOptional(CAS.getCachedResult(KeyID)))
+  if (Optional<cas::ObjectRef> ResultID = Cache.get(KeyID))
     return fetchCachedIncludedFiles(CAS, *ResultID, Includes);
-  return computeIncludedFiles(CAS, KeyID, Blob.getData(), Includes);
+  return computeIncludedFiles(CAS, Cache, KeyID, Blob.getData(), Includes);
 }
 
 Optional<cas::ObjectRef>
@@ -140,6 +141,7 @@ Error tablegen::accessAllIncludes(cas::CachingOnDiskFileSystem &FS,
                                   ArrayRef<std::string> IncludeDirs,
                                   const cas::ObjectProxy &MainFileBlob) {
   cas::CASDB &CAS = FS.getCAS();
+  cas::ActionCache &Cache = FS.getCache();
 
   // Helper for adding to the worklist.
   SmallVector<cas::ObjectProxy> Worklist = {MainFileBlob};
@@ -160,8 +162,8 @@ Error tablegen::accessAllIncludes(cas::CachingOnDiskFileSystem &FS,
   SmallVector<StringRef> IncludedFiles;
   while (!Worklist.empty()) {
     IncludedFiles.clear();
-    if (Error E = scanTextForIncludes(CAS, ExecID, Worklist.pop_back_val(),
-                                      IncludedFiles))
+    if (Error E = scanTextForIncludes(CAS, Cache, ExecID,
+                                      Worklist.pop_back_val(), IncludedFiles))
       return E;
 
     // Add included files to the worklist. Ignore files not found, since the
@@ -202,12 +204,14 @@ Error tablegen::createMainFileError(StringRef MainFilename,
                                    "': " + EC.message());
 }
 
-Expected<ScanIncludesResult> tablegen::scanIncludes(
-    cas::CASDB &CAS, cas::ObjectRef ExecID, StringRef MainFilename,
-    ArrayRef<std::string> IncludeDirs, ArrayRef<MappedPrefix> PrefixMappings,
-    Optional<TreePathPrefixMapper> *CapturedPM) {
+Expected<ScanIncludesResult>
+tablegen::scanIncludes(cas::CASDB &CAS, cas::ActionCache &Cache,
+                       cas::ObjectRef ExecID, StringRef MainFilename,
+                       ArrayRef<std::string> IncludeDirs,
+                       ArrayRef<MappedPrefix> PrefixMappings,
+                       Optional<TreePathPrefixMapper> *CapturedPM) {
   IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS;
-  if (Error E = cas::createCachingOnDiskFileSystem(CAS).moveInto(FS))
+  if (Error E = cas::createCachingOnDiskFileSystem(CAS, Cache).moveInto(FS))
     return std::move(E);
 
   FS->trackNewAccesses();
@@ -239,13 +243,13 @@ Expected<ScanIncludesResult> tablegen::scanIncludes(
 }
 
 Expected<ScanIncludesResult>
-tablegen::scanIncludesAndRemap(cas::CASDB &CAS, cas::ObjectRef ExecID,
-                               std::string &MainFilename,
+tablegen::scanIncludesAndRemap(cas::CASDB &CAS, cas::ActionCache &Cache,
+                               cas::ObjectRef ExecID, std::string &MainFilename,
                                std::vector<std::string> &IncludeDirs,
                                ArrayRef<MappedPrefix> PrefixMappings) {
   Optional<TreePathPrefixMapper> PM;
-  auto Result =
-      scanIncludes(CAS, ExecID, MainFilename, IncludeDirs, PrefixMappings, &PM);
+  auto Result = scanIncludes(CAS, Cache, ExecID, MainFilename, IncludeDirs,
+                             PrefixMappings, &PM);
   if (!Result)
     return Result.takeError();
 

--- a/llvm/lib/TableGen/ScanDependencies.cpp
+++ b/llvm/lib/TableGen/ScanDependencies.cpp
@@ -140,11 +140,11 @@ tablegen::lookupIncludeID(cas::CachingOnDiskFileSystem &FS,
 }
 
 Error tablegen::accessAllIncludes(cas::CachingOnDiskFileSystem &FS,
+                                  cas::ActionCache &Cache,
                                   cas::ObjectRef ExecID,
                                   ArrayRef<std::string> IncludeDirs,
                                   const cas::ObjectProxy &MainFileBlob) {
   cas::CASDB &CAS = FS.getCAS();
-  cas::ActionCache &Cache = FS.getCache();
 
   // Helper for adding to the worklist.
   SmallVector<cas::ObjectProxy> Worklist = {MainFileBlob};
@@ -214,7 +214,7 @@ tablegen::scanIncludes(cas::CASDB &CAS, cas::ActionCache &Cache,
                        ArrayRef<MappedPrefix> PrefixMappings,
                        Optional<TreePathPrefixMapper> *CapturedPM) {
   IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS;
-  if (Error E = cas::createCachingOnDiskFileSystem(CAS, Cache).moveInto(FS))
+  if (Error E = cas::createCachingOnDiskFileSystem(CAS).moveInto(FS))
     return std::move(E);
 
   FS->trackNewAccesses();
@@ -223,7 +223,7 @@ tablegen::scanIncludes(cas::CASDB &CAS, cas::ActionCache &Cache,
     return MainBlob.takeError();
 
   // Helper for adding to the worklist.
-  if (Error E = accessAllIncludes(*FS, ExecID, IncludeDirs, *MainBlob))
+  if (Error E = accessAllIncludes(*FS, Cache, ExecID, IncludeDirs, *MainBlob))
     return std::move(E);
 
   Optional<TreePathPrefixMapper> LocalPM;

--- a/llvm/lib/TableGen/ScanDependencies.cpp
+++ b/llvm/lib/TableGen/ScanDependencies.cpp
@@ -112,7 +112,10 @@ Error tablegen::scanTextForIncludes(cas::CASDB &CAS, cas::ActionCache &Cache,
     return Key.takeError();
 
   cas::CASID KeyID = CAS.getID(*Key);
-  if (Optional<cas::ObjectRef> ResultID = Cache.get(KeyID))
+  auto Result = Cache.get(KeyID);
+  if (!Result)
+    return Result.takeError();
+  if (Optional<cas::ObjectRef> ResultID = *Result)
     return fetchCachedIncludedFiles(CAS, *ResultID, Includes);
   return computeIncludedFiles(CAS, Cache, KeyID, Blob.getData(), Includes);
 }

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ADT/Optional.h"
+#include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASDB.h"
 #include "llvm/CAS/CASFileSystem.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
@@ -45,8 +46,9 @@ static int makeBlob(CASDB &CAS, StringRef DataPath);
 static int makeNode(CASDB &CAS, ArrayRef<std::string> References, StringRef DataPath);
 static int diffGraphs(CASDB &CAS, CASID LHS, CASID RHS);
 static int traverseGraph(CASDB &CAS, CASID ID);
-static int ingestFileSystem(CASDB &CAS, StringRef Path);
-static int mergeTrees(CASDB &CAS, ArrayRef<std::string> Objects);
+static int ingestFileSystem(CASDB &CAS, ActionCache &Cache, StringRef Path);
+static int mergeTrees(CASDB &CAS, ActionCache &Cache,
+                      ArrayRef<std::string> Objects);
 static int getCASIDForFile(CASDB &CAS, CASID ID, StringRef Path);
 static int validateObject(CASDB &CAS, CASID ID);
 
@@ -56,6 +58,9 @@ int main(int Argc, char **Argv) {
   cl::list<std::string> Objects(cl::Positional, cl::desc("<object>..."));
   cl::opt<std::string> CASPath("cas", cl::desc("Path to CAS on disk."),
                                cl::value_desc("path"));
+  cl::opt<std::string> CachePath("cache",
+                                 cl::desc("Path to ActionCache on disk."),
+                                 cl::value_desc("path"));
   cl::opt<std::string> DataPath("data",
                                 cl::desc("Path to data or '-' for stdin."),
                                 cl::value_desc("path"));
@@ -118,6 +123,12 @@ int main(int Argc, char **Argv) {
     CAS = ExitOnErr(llvm::cas::createOnDiskCAS(CASPath));
   assert(CAS);
 
+  std::unique_ptr<ActionCache> Cache;
+  if (CachePath.empty())
+    Cache = llvm::cas::createInMemoryActionCache(*CAS);
+  else
+    Cache = ExitOnErr(llvm::cas::createOnDiskActionCache(*CAS, CachePath));
+
   if (Command == Dump)
     return dump(*CAS);
 
@@ -140,10 +151,10 @@ int main(int Argc, char **Argv) {
   }
 
   if (Command == IngestFileSystem)
-    return ingestFileSystem(*CAS, DataPath);
+    return ingestFileSystem(*CAS, *Cache, DataPath);
 
   if (Command == MergeTrees)
-    return mergeTrees(*CAS, Objects);
+    return mergeTrees(*CAS, *Cache, Objects);
 
   // Remaining commands need exactly one CAS object.
   if (Objects.empty())
@@ -399,8 +410,9 @@ static Error recursiveAccess(CachingOnDiskFileSystem &FS, StringRef Path) {
   return Error::success();
 }
 
-static Expected<ObjectProxy> ingestFileSystemImpl(CASDB &CAS, StringRef Path) {
-  auto FS = createCachingOnDiskFileSystem(CAS);
+static Expected<ObjectProxy>
+ingestFileSystemImpl(CASDB &CAS, ActionCache &Cache, StringRef Path) {
+  auto FS = createCachingOnDiskFileSystem(CAS, Cache);
   if (!FS)
     return FS.takeError();
 
@@ -425,17 +437,18 @@ static Expected<ObjectProxy> ingestFileSystemImpl(CASDB &CAS, StringRef Path) {
       });
 }
 
-int ingestFileSystem(CASDB &CAS, StringRef Path) {
+int ingestFileSystem(CASDB &CAS, ActionCache &Cache, StringRef Path) {
   ExitOnError ExitOnErr("llvm-cas: ingest: ");
   if (Path.empty())
     ExitOnErr(
         createStringError(inconvertibleErrorCode(), "missing --data=<path>"));
-  auto Ref = ExitOnErr(ingestFileSystemImpl(CAS, Path));
+  auto Ref = ExitOnErr(ingestFileSystemImpl(CAS, Cache, Path));
   outs() << Ref.getID() << "\n";
   return 0;
 }
 
-static int mergeTrees(CASDB &CAS, ArrayRef<std::string> Objects) {
+static int mergeTrees(CASDB &CAS, ActionCache &Cache,
+                      ArrayRef<std::string> Objects) {
   ExitOnError ExitOnErr("llvm-cas: merge: ");
 
   HierarchicalTreeBuilder Builder;
@@ -449,7 +462,7 @@ static int mergeTrees(CASDB &CAS, ArrayRef<std::string> Objects) {
                                     "unknown node with id: " + ID->toString()));
     } else {
       consumeError(ID.takeError());
-      auto Ref = ExitOnErr(ingestFileSystemImpl(CAS, Object));
+      auto Ref = ExitOnErr(ingestFileSystemImpl(CAS, Cache, Object));
       Builder.pushTreeContent(Ref.getRef(), "");
     }
   }

--- a/llvm/unittests/CAS/ActionCacheTest.cpp
+++ b/llvm/unittests/CAS/ActionCacheTest.cpp
@@ -14,7 +14,6 @@
 #include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
-#include <memory>
 
 using namespace llvm;
 using namespace llvm::cas;

--- a/llvm/unittests/CAS/ActionCacheTest.cpp
+++ b/llvm/unittests/CAS/ActionCacheTest.cpp
@@ -1,0 +1,63 @@
+//===- ActionCacheTest.cpp ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CASTestConfig.h"
+#include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/CASDB.h"
+#include "llvm/Config/llvm-config.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Testing/Support/Error.h"
+#include "llvm/Testing/Support/SupportHelpers.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+
+TEST_P(CASTest, ActionCacheHit) {
+  std::unique_ptr<CASDB> CAS = createCAS();
+  std::unique_ptr<ActionCache> Cache = createActionCache(*CAS);
+
+  Optional<ObjectProxy> ID;
+  ASSERT_THAT_ERROR(CAS->createProxy(None, "1").moveInto(ID), Succeeded());
+  ASSERT_THAT_ERROR(Cache->put(*ID, CAS->getReference(*ID)), Succeeded());
+  Optional<ObjectRef> Result = Cache->get(*ID);
+  ASSERT_TRUE(Result);
+  ASSERT_EQ(*ID, *Result);
+}
+
+TEST_P(CASTest, ActionCacheMiss) {
+  std::unique_ptr<CASDB> CAS = createCAS();
+  std::unique_ptr<ActionCache> Cache = createActionCache(*CAS);
+
+  Optional<ObjectProxy> ID1, ID2;
+  ASSERT_THAT_ERROR(CAS->createProxy(None, "1").moveInto(ID1), Succeeded());
+  ASSERT_THAT_ERROR(CAS->createProxy(None, "2").moveInto(ID2), Succeeded());
+  ASSERT_THAT_ERROR(Cache->put(*ID1, CAS->getReference(*ID2)), Succeeded());
+  // This is a cache miss for looking up a key doesn't exist.
+  ASSERT_FALSE(Cache->get(*ID2));
+
+  ASSERT_THAT_ERROR(Cache->put(*ID2, CAS->getReference(*ID1)), Succeeded());
+  // Cache hit after adding the value.
+  Optional<ObjectRef> Result = Cache->get(*ID2);
+  ASSERT_TRUE(Result);
+  ASSERT_EQ(*ID1, *Result);
+}
+
+TEST_P(CASTest, ActionCacheRewrite) {
+  std::unique_ptr<CASDB> CAS = createCAS();
+  std::unique_ptr<ActionCache> Cache = createActionCache(*CAS);
+
+  Optional<ObjectProxy> ID1, ID2;
+  ASSERT_THAT_ERROR(CAS->createProxy(None, "1").moveInto(ID1), Succeeded());
+  ASSERT_THAT_ERROR(CAS->createProxy(None, "2").moveInto(ID2), Succeeded());
+  ASSERT_THAT_ERROR(Cache->put(*ID1, CAS->getReference(*ID1)), Succeeded());
+  // Writing to the same key with different value is error.
+  ASSERT_THAT_ERROR(Cache->put(*ID1, CAS->getReference(*ID2)), Failed());
+  // Writing the same value multiple times to the same key is fine.
+  ASSERT_THAT_ERROR(Cache->put(*ID1, CAS->getReference(*ID1)), Succeeded());
+}

--- a/llvm/unittests/CAS/ActionCacheTest.cpp
+++ b/llvm/unittests/CAS/ActionCacheTest.cpp
@@ -14,6 +14,7 @@
 #include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
+#include <memory>
 
 using namespace llvm;
 using namespace llvm::cas;
@@ -24,8 +25,9 @@ TEST_P(CASTest, ActionCacheHit) {
 
   Optional<ObjectProxy> ID;
   ASSERT_THAT_ERROR(CAS->createProxy(None, "1").moveInto(ID), Succeeded());
-  ASSERT_THAT_ERROR(Cache->put(*ID, CAS->getReference(*ID)), Succeeded());
-  Optional<ObjectRef> Result = Cache->get(*ID);
+  ASSERT_THAT_ERROR(Cache->put(*ID, ID->getRef()), Succeeded());
+  Optional<ObjectRef> Result;
+  ASSERT_THAT_ERROR(Cache->get(*ID).moveInto(Result), Succeeded());
   ASSERT_TRUE(Result);
   ASSERT_EQ(*ID, *Result);
 }
@@ -37,15 +39,18 @@ TEST_P(CASTest, ActionCacheMiss) {
   Optional<ObjectProxy> ID1, ID2;
   ASSERT_THAT_ERROR(CAS->createProxy(None, "1").moveInto(ID1), Succeeded());
   ASSERT_THAT_ERROR(CAS->createProxy(None, "2").moveInto(ID2), Succeeded());
-  ASSERT_THAT_ERROR(Cache->put(*ID1, CAS->getReference(*ID2)), Succeeded());
+  ASSERT_THAT_ERROR(Cache->put(*ID1, ID2->getRef()), Succeeded());
   // This is a cache miss for looking up a key doesn't exist.
-  ASSERT_FALSE(Cache->get(*ID2));
+  Optional<ObjectRef> Result1;
+  ASSERT_THAT_ERROR(Cache->get(*ID2).moveInto(Result1), Succeeded());
+  ASSERT_FALSE(Result1);
 
-  ASSERT_THAT_ERROR(Cache->put(*ID2, CAS->getReference(*ID1)), Succeeded());
+  ASSERT_THAT_ERROR(Cache->put(*ID2, ID1->getRef()), Succeeded());
   // Cache hit after adding the value.
-  Optional<ObjectRef> Result = Cache->get(*ID2);
-  ASSERT_TRUE(Result);
-  ASSERT_EQ(*ID1, *Result);
+  Optional<ObjectRef> Result2;
+  ASSERT_THAT_ERROR(Cache->get(*ID2).moveInto(Result2), Succeeded());
+  ASSERT_TRUE(Result2);
+  ASSERT_EQ(*ID1, *Result2);
 }
 
 TEST_P(CASTest, ActionCacheRewrite) {
@@ -55,9 +60,37 @@ TEST_P(CASTest, ActionCacheRewrite) {
   Optional<ObjectProxy> ID1, ID2;
   ASSERT_THAT_ERROR(CAS->createProxy(None, "1").moveInto(ID1), Succeeded());
   ASSERT_THAT_ERROR(CAS->createProxy(None, "2").moveInto(ID2), Succeeded());
-  ASSERT_THAT_ERROR(Cache->put(*ID1, CAS->getReference(*ID1)), Succeeded());
+  ASSERT_THAT_ERROR(Cache->put(*ID1, ID1->getRef()), Succeeded());
   // Writing to the same key with different value is error.
-  ASSERT_THAT_ERROR(Cache->put(*ID1, CAS->getReference(*ID2)), Failed());
+  ASSERT_THAT_ERROR(Cache->put(*ID1, ID2->getRef()), Failed());
   // Writing the same value multiple times to the same key is fine.
-  ASSERT_THAT_ERROR(Cache->put(*ID1, CAS->getReference(*ID1)), Succeeded());
+  ASSERT_THAT_ERROR(Cache->put(*ID1, ID1->getRef()), Succeeded());
+}
+
+TEST(OnDiskActionCache, ActionCacheResultInvalid) {
+  unittest::TempDir Temp("on-disk-cache", /*Unique=*/true);
+  std::unique_ptr<CASDB> CAS1 = createInMemoryCAS();
+  std::unique_ptr<CASDB> CAS2 = createInMemoryCAS();
+
+  Optional<ObjectProxy> ID1, ID2, ID3;
+  ASSERT_THAT_ERROR(CAS1->createProxy(None, "1").moveInto(ID1), Succeeded());
+  ASSERT_THAT_ERROR(CAS1->createProxy(None, "2").moveInto(ID2), Succeeded());
+  ASSERT_THAT_ERROR(CAS2->createProxy(None, "1").moveInto(ID3), Succeeded());
+
+  std::unique_ptr<ActionCache> Cache1 =
+      cantFail(createOnDiskActionCache(*CAS1, Temp.path()));
+  // Test put and get.
+  ASSERT_THAT_ERROR(Cache1->put(*ID1, ID2->getRef()), Succeeded());
+  Optional<ObjectRef> Result;
+  ASSERT_THAT_ERROR(Cache1->get(*ID1).moveInto(Result), Succeeded());
+  ASSERT_TRUE(Result);
+
+  // Create OnDiskCAS from the same location but a different underlying CAS.
+  std::unique_ptr<ActionCache> Cache2 =
+      cantFail(createOnDiskActionCache(*CAS2, Temp.path()));
+  // Loading an key that points to an invalid object.
+  Optional<ObjectRef> Result2;
+  ASSERT_THAT_ERROR(Cache2->get(*ID3).moveInto(Result2), Failed());
+  // Write a different value will cause error.
+  ASSERT_THAT_ERROR(Cache2->put(*ID3, ID3->getRef()), Failed());
 }

--- a/llvm/unittests/CAS/CASTestConfig.cpp
+++ b/llvm/unittests/CAS/CASTestConfig.cpp
@@ -10,7 +10,6 @@
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASDB.h"
 #include "gtest/gtest.h"
-#include <memory>
 
 using namespace llvm;
 using namespace llvm::cas;

--- a/llvm/unittests/CAS/CASTestConfig.cpp
+++ b/llvm/unittests/CAS/CASTestConfig.cpp
@@ -1,0 +1,41 @@
+//===- CASTestConfig.cpp --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CASTestConfig.h"
+#include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/CASDB.h"
+#include "gtest/gtest.h"
+#include <memory>
+
+using namespace llvm;
+using namespace llvm::cas;
+
+TestingAndDir createInMemory(int I) {
+  std::unique_ptr<CASDB> CAS = createInMemoryCAS();
+  return TestingAndDir{std::move(CAS), createInMemoryActionCache, None};
+}
+
+INSTANTIATE_TEST_SUITE_P(InMemoryCAS, CASTest,
+                         ::testing::Values(createInMemory));
+
+#if LLVM_ENABLE_ONDISK_CAS
+TestingAndDir createOnDisk(int I) {
+  unittest::TempDir Temp("on-disk-cas", /*Unique=*/true);
+  std::unique_ptr<CASDB> CAS;
+  EXPECT_THAT_ERROR(createOnDiskCAS(Temp.path()).moveInto(CAS), Succeeded());
+  std::string TempPath = Temp.path().str();
+  auto CreateFn = [&, TempPath](CASDB &CAS) -> std::unique_ptr<ActionCache> {
+    std::unique_ptr<ActionCache> Cache;
+    EXPECT_THAT_ERROR(createOnDiskActionCache(CAS, TempPath).moveInto(Cache),
+                      Succeeded());
+    return Cache;
+  };
+  return TestingAndDir{std::move(CAS), CreateFn, std::move(Temp)};
+}
+INSTANTIATE_TEST_SUITE_P(OnDiskCAS, CASTest, ::testing::Values(createOnDisk));
+#endif /* LLVM_ENABLE_ONDISK_CAS */

--- a/llvm/unittests/CAS/CASTestConfig.h
+++ b/llvm/unittests/CAS/CASTestConfig.h
@@ -6,19 +6,26 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASDB.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
+#include <memory>
+
+#ifndef LLVM_UNITTESTS_CASTESTCONFIG_H
+#define LLVM_UNITTESTS_CASTESTCONFIG_H
 
 struct TestingAndDir {
-  std::unique_ptr<llvm::cas::CASDB> DB;
+  std::unique_ptr<llvm::cas::CASDB> CAS;
+  std::function<std::unique_ptr<llvm::cas::ActionCache>(llvm::cas::CASDB &)>
+      CreateCacheFn;
   llvm::Optional<llvm::unittest::TempDir> Temp;
 };
 
-class CASDBTest
+class CASTest
     : public testing::TestWithParam<std::function<TestingAndDir(int)>> {
 protected:
   llvm::Optional<int> NextCASIndex;
@@ -26,10 +33,15 @@ protected:
   llvm::SmallVector<llvm::unittest::TempDir> Dirs;
 
   std::unique_ptr<llvm::cas::CASDB> createCAS() {
-    auto TD = GetParam()((*NextCASIndex)++);
+    auto TD = GetParam()(++(*NextCASIndex));
     if (TD.Temp)
       Dirs.push_back(std::move(*TD.Temp));
-    return std::move(TD.DB);
+    return std::move(TD.CAS);
+  }
+  std::unique_ptr<llvm::cas::ActionCache>
+  createActionCache(llvm::cas::CASDB &CAS) {
+    auto TD = GetParam()(*NextCASIndex);
+    return TD.CreateCacheFn(CAS);
   }
   void SetUp() { NextCASIndex = 0; }
   void TearDown() {
@@ -38,12 +50,4 @@ protected:
   }
 };
 
-#if LLVM_ENABLE_ONDISK_CAS
-static TestingAndDir createOnDisk(int I) {
-  llvm::unittest::TempDir Temp("on-disk-cas", /*Unique=*/true);
-  std::unique_ptr<llvm::cas::CASDB> CAS;
-  EXPECT_THAT_ERROR(llvm::cas::createOnDiskCAS(Temp.path()).moveInto(CAS),
-                    llvm::Succeeded());
-  return TestingAndDir{std::move(CAS), std::move(Temp)};
-}
-#endif /* LLVM_ENABLE_ONDISK_CAS */
+#endif

--- a/llvm/unittests/CAS/CASTestConfig.h
+++ b/llvm/unittests/CAS/CASTestConfig.h
@@ -13,7 +13,6 @@
 #include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
-#include <memory>
 
 #ifndef LLVM_UNITTESTS_CASTESTCONFIG_H
 #define LLVM_UNITTESTS_CASTESTCONFIG_H

--- a/llvm/unittests/CAS/CMakeLists.txt
+++ b/llvm/unittests/CAS/CMakeLists.txt
@@ -5,8 +5,10 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_llvm_unittest(CASTests
+  ActionCacheTest.cpp
   CASDBTest.cpp
   CASFileSystemTest.cpp
+  CASTestConfig.cpp
   CASOutputBackendTest.cpp
   CASProvidingFileSystemTest.cpp
   CachingOnDiskFileSystemTest.cpp

--- a/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
-#include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASDB.h"
 #include "llvm/CAS/TreeSchema.h"
 #include "llvm/Support/Errc.h"
@@ -36,10 +35,8 @@ namespace {
 
 TEST(CachingOnDiskFileSystemTest, BasicRealFSIteration) {
   TempDir TestDirectory("virtual-file-system-test", /*Unique*/ true);
-  auto CAS = cas::createInMemoryCAS();
-  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<vfs::FileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
+      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
 
   std::error_code EC;
   vfs::directory_iterator I = FS->dir_begin(Twine(TestDirectory.path()), EC);
@@ -74,10 +71,8 @@ TEST(CachingOnDiskFileSystemTest, MultipleWorkingDirs) {
   TempLink C(ADir.path(), Root.path("c"));
   TempFile AA(ADir.path("aa"), "", "aaaa");
   TempFile BB(BDir.path("bb"), "", "bbbb");
-  auto CAS = cas::createInMemoryCAS();
-  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<vfs::FileSystem> BFS =
-      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
+      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
   IntrusiveRefCntPtr<vfs::FileSystem> CFS;
   //,
   //                                    CFS = cantFail(
@@ -142,10 +137,8 @@ TEST(CachingOnDiskFileSystemTest, MultipleWorkingDirs) {
 
 TEST(CachingOnDiskFileSystemTest, BrokenSymlinkRealFSIteration) {
   TempDir TestDirectory("virtual-file-system-test", /*Unique*/ true);
-  auto CAS = cas::createInMemoryCAS();
-  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<vfs::FileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
+      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
 
   TempLink _a("no_such_file", TestDirectory.path("a"));
   TempDir _b(TestDirectory.path("b"));
@@ -174,10 +167,8 @@ TEST(CachingOnDiskFileSystemTest, BrokenSymlinkRealFSIteration) {
 
 TEST(CachingOnDiskFileSystemTest, BasicRealFSRecursiveIteration) {
   TempDir TestDirectory("virtual-file-system-test", /*Unique*/ true);
-  auto CAS = cas::createInMemoryCAS();
-  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<vfs::FileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
+      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
 
   std::error_code EC;
   auto I =
@@ -226,10 +217,8 @@ TEST(CachingOnDiskFileSystemTest, BasicRealFSRecursiveIterationNoPush) {
   TempDir _ef(TestDirectory.path("e/f"));
   TempDir _g(TestDirectory.path("g"));
 
-  auto CAS = cas::createInMemoryCAS();
-  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<vfs::FileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
+      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
 
   // Test that calling no_push on entries without subdirectories has no effect.
   {
@@ -301,10 +290,8 @@ TEST(CachingOnDiskFileSystemTest, BasicRealFSRecursiveIterationNoPush) {
 
 TEST(CachingOnDiskFileSystemTest, BrokenSymlinkRealFSRecursiveIteration) {
   TempDir TestDirectory("virtual-file-system-test", /*Unique*/ true);
-  auto CAS = cas::createInMemoryCAS();
-  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<vfs::FileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
+      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
 
   TempLink _a("no_such_file", TestDirectory.path("a"));
   TempDir _b(TestDirectory.path("b"));
@@ -342,10 +329,8 @@ TEST(CachingOnDiskFileSystemTest, BrokenSymlinkRealFSRecursiveIteration) {
 
 TEST(CachingOnDiskFileSystemTest, TrackNewAccesses) {
   TempDir TestDirectory("virtual-file-system-test", /*Unique*/ true);
-  auto CAS = cas::createInMemoryCAS();
-  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
+      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
   ASSERT_FALSE(FS->setCurrentWorkingDirectory(TestDirectory.path()));
 
   TreePathPrefixMapper Remapper(FS);
@@ -391,10 +376,8 @@ TEST(CachingOnDiskFileSystemTest, TrackNewAccesses) {
 
 TEST(CachingOnDiskFileSystemTest, getRealPath) {
   TempDir D("caching-on-disk-file-system-test", /*Unique=*/true);
-  auto CAS = cas::createInMemoryCAS();
-  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
+      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
   ASSERT_FALSE(FS->setCurrentWorkingDirectory(D.path()));
 
   TempFile File(D.path("file"), "", "content");
@@ -408,10 +391,8 @@ TEST(CachingOnDiskFileSystemTest, getRealPath) {
 
 TEST(CachingOnDiskFileSystemTest, caseSensitivityFile) {
   TempDir D("caching-on-disk-file-system-test", /*Unique=*/true);
-  auto CAS = cas::createInMemoryCAS();
-  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
+      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
   ASSERT_FALSE(FS->setCurrentWorkingDirectory(D.path()));
 
   std::vector<std::pair<std::string, std::string>> Files = {{"file", "File"},
@@ -452,10 +433,8 @@ TEST(CachingOnDiskFileSystemTest, caseSensitivityFile) {
 
 TEST(CachingOnDiskFileSystemTest, caseSensitivityDir) {
   TempDir D("caching-on-disk-file-system-test", /*Unique=*/true);
-  auto CAS = cas::createInMemoryCAS();
-  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
+      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
   ASSERT_FALSE(FS->setCurrentWorkingDirectory(D.path()));
 
   TempDir Dir1(D.path("dir"));

--- a/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
+#include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASDB.h"
 #include "llvm/CAS/TreeSchema.h"
 #include "llvm/Support/Errc.h"
@@ -35,8 +36,10 @@ namespace {
 
 TEST(CachingOnDiskFileSystemTest, BasicRealFSIteration) {
   TempDir TestDirectory("virtual-file-system-test", /*Unique*/ true);
+  auto CAS = cas::createInMemoryCAS();
+  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<vfs::FileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
+      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
 
   std::error_code EC;
   vfs::directory_iterator I = FS->dir_begin(Twine(TestDirectory.path()), EC);
@@ -71,8 +74,10 @@ TEST(CachingOnDiskFileSystemTest, MultipleWorkingDirs) {
   TempLink C(ADir.path(), Root.path("c"));
   TempFile AA(ADir.path("aa"), "", "aaaa");
   TempFile BB(BDir.path("bb"), "", "bbbb");
+  auto CAS = cas::createInMemoryCAS();
+  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<vfs::FileSystem> BFS =
-      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
+      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
   IntrusiveRefCntPtr<vfs::FileSystem> CFS;
   //,
   //                                    CFS = cantFail(
@@ -137,8 +142,10 @@ TEST(CachingOnDiskFileSystemTest, MultipleWorkingDirs) {
 
 TEST(CachingOnDiskFileSystemTest, BrokenSymlinkRealFSIteration) {
   TempDir TestDirectory("virtual-file-system-test", /*Unique*/ true);
+  auto CAS = cas::createInMemoryCAS();
+  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<vfs::FileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
+      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
 
   TempLink _a("no_such_file", TestDirectory.path("a"));
   TempDir _b(TestDirectory.path("b"));
@@ -167,8 +174,10 @@ TEST(CachingOnDiskFileSystemTest, BrokenSymlinkRealFSIteration) {
 
 TEST(CachingOnDiskFileSystemTest, BasicRealFSRecursiveIteration) {
   TempDir TestDirectory("virtual-file-system-test", /*Unique*/ true);
+  auto CAS = cas::createInMemoryCAS();
+  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<vfs::FileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
+      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
 
   std::error_code EC;
   auto I =
@@ -217,8 +226,10 @@ TEST(CachingOnDiskFileSystemTest, BasicRealFSRecursiveIterationNoPush) {
   TempDir _ef(TestDirectory.path("e/f"));
   TempDir _g(TestDirectory.path("g"));
 
+  auto CAS = cas::createInMemoryCAS();
+  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<vfs::FileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
+      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
 
   // Test that calling no_push on entries without subdirectories has no effect.
   {
@@ -290,8 +301,10 @@ TEST(CachingOnDiskFileSystemTest, BasicRealFSRecursiveIterationNoPush) {
 
 TEST(CachingOnDiskFileSystemTest, BrokenSymlinkRealFSRecursiveIteration) {
   TempDir TestDirectory("virtual-file-system-test", /*Unique*/ true);
+  auto CAS = cas::createInMemoryCAS();
+  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<vfs::FileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
+      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
 
   TempLink _a("no_such_file", TestDirectory.path("a"));
   TempDir _b(TestDirectory.path("b"));
@@ -329,8 +342,10 @@ TEST(CachingOnDiskFileSystemTest, BrokenSymlinkRealFSRecursiveIteration) {
 
 TEST(CachingOnDiskFileSystemTest, TrackNewAccesses) {
   TempDir TestDirectory("virtual-file-system-test", /*Unique*/ true);
+  auto CAS = cas::createInMemoryCAS();
+  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
+      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
   ASSERT_FALSE(FS->setCurrentWorkingDirectory(TestDirectory.path()));
 
   TreePathPrefixMapper Remapper(FS);
@@ -376,8 +391,10 @@ TEST(CachingOnDiskFileSystemTest, TrackNewAccesses) {
 
 TEST(CachingOnDiskFileSystemTest, getRealPath) {
   TempDir D("caching-on-disk-file-system-test", /*Unique=*/true);
+  auto CAS = cas::createInMemoryCAS();
+  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
+      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
   ASSERT_FALSE(FS->setCurrentWorkingDirectory(D.path()));
 
   TempFile File(D.path("file"), "", "content");
@@ -391,8 +408,10 @@ TEST(CachingOnDiskFileSystemTest, getRealPath) {
 
 TEST(CachingOnDiskFileSystemTest, caseSensitivityFile) {
   TempDir D("caching-on-disk-file-system-test", /*Unique=*/true);
+  auto CAS = cas::createInMemoryCAS();
+  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
+      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
   ASSERT_FALSE(FS->setCurrentWorkingDirectory(D.path()));
 
   std::vector<std::pair<std::string, std::string>> Files = {{"file", "File"},
@@ -433,8 +452,10 @@ TEST(CachingOnDiskFileSystemTest, caseSensitivityFile) {
 
 TEST(CachingOnDiskFileSystemTest, caseSensitivityDir) {
   TempDir D("caching-on-disk-file-system-test", /*Unique=*/true);
+  auto CAS = cas::createInMemoryCAS();
+  auto Cache = cas::createInMemoryActionCache(*CAS);
   IntrusiveRefCntPtr<cas::CachingOnDiskFileSystem> FS =
-      cantFail(cas::createCachingOnDiskFileSystem(cas::createInMemoryCAS()));
+      cantFail(cas::createCachingOnDiskFileSystem(*CAS, *Cache));
   ASSERT_FALSE(FS->setCurrentWorkingDirectory(D.path()));
 
   TempDir Dir1(D.path("dir"));


### PR DESCRIPTION
Introduce ActionCache which can be used together with a CAS to cache
computation results with a key.