### PR TITLE
[lldb] Log Swift demangleSymbolAsNode usage

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1885,8 +1885,8 @@ static bool FindFunctionInModule(ConstString &mangled_name,
       // see if we can find it in the demangled nodes.
       demangle_ctx.clear();
 
-      auto *node_ptr = SwiftLanguageRuntime::DemangleSymbolAsNode(
-          fi->getName(), &demangle_ctx);
+      auto *node_ptr = SwiftLanguageRuntime::DemangleSymbolAsNode(fi->getName(),
+                                                                  demangle_ctx);
       if (node_ptr) {
         if (node_ptr->getKind() != swift::Demangle::Node::Kind::Global)
           continue;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1885,8 +1885,8 @@ static bool FindFunctionInModule(ConstString &mangled_name,
       // see if we can find it in the demangled nodes.
       demangle_ctx.clear();
 
-      swift::Demangle::NodePointer node_ptr =
-          demangle_ctx.demangleSymbolAsNode(fi->getName());
+      auto *node_ptr = SwiftLanguageRuntime::DemangleSymbolAsNode(
+          fi->getName(), &demangle_ctx);
       if (node_ptr) {
         if (node_ptr->getKind() != swift::Demangle::Node::Kind::Global)
           continue;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
@@ -207,8 +207,8 @@ public:
 
     for (const IRExecutionUnit::JittedGlobalVariable &variable :
          execution_unit->GetJittedGlobalVariables()) {
-      swift::Demangle::NodePointer node_pointer =
-          demangle_ctx.demangleSymbolAsNode(variable.m_name.GetStringRef());
+      auto *node_pointer = SwiftLanguageRuntime::DemangleSymbolAsNode(
+          variable.m_name.GetStringRef(), &demangle_ctx);
 
       llvm::StringRef variable_name = GetNameOfDemangledVariable(node_pointer);
       if (variable_name == result_name) {
@@ -365,8 +365,8 @@ public:
       //     kind=Module, text="lldb_expr_0"
       //     kind=Identifier, text="a"
 
-      swift::Demangle::NodePointer node_pointer =
-          demangle_ctx.demangleSymbolAsNode(variable.m_name.GetStringRef());
+      auto *node_pointer = SwiftLanguageRuntime::DemangleSymbolAsNode(
+          variable.m_name.GetStringRef(), &demangle_ctx);
 
       llvm::StringRef last_component = GetNameOfDemangledVariable(node_pointer);
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
@@ -208,7 +208,7 @@ public:
     for (const IRExecutionUnit::JittedGlobalVariable &variable :
          execution_unit->GetJittedGlobalVariables()) {
       auto *node_pointer = SwiftLanguageRuntime::DemangleSymbolAsNode(
-          variable.m_name.GetStringRef(), &demangle_ctx);
+          variable.m_name.GetStringRef(), demangle_ctx);
 
       llvm::StringRef variable_name = GetNameOfDemangledVariable(node_pointer);
       if (variable_name == result_name) {
@@ -366,7 +366,7 @@ public:
       //     kind=Identifier, text="a"
 
       auto *node_pointer = SwiftLanguageRuntime::DemangleSymbolAsNode(
-          variable.m_name.GetStringRef(), &demangle_ctx);
+          variable.m_name.GetStringRef(), demangle_ctx);
 
       llvm::StringRef last_component = GetNameOfDemangledVariable(node_pointer);
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2051,14 +2051,16 @@ protected:
     for (size_t i = 0; i < command.GetArgumentCount(); i++) {
       StringRef name = command.GetArgumentAtIndex(i);
       if (!name.empty()) {
+        Context ctx;
         NodePointer node_ptr = nullptr;
         // Match the behavior of swift-demangle and accept Swift symbols without
         // the leading `$`. This makes symbol copy & paste more convenient.
         if (name.startswith("S") || name.startswith("s")) {
           std::string correctedName = std::string("$") + name.str();
-          node_ptr = SwiftLanguageRuntime::DemangleSymbolAsNode(correctedName);
+          node_ptr =
+              SwiftLanguageRuntime::DemangleSymbolAsNode(correctedName, ctx);
         } else {
-          node_ptr = SwiftLanguageRuntime::DemangleSymbolAsNode(name);
+          node_ptr = SwiftLanguageRuntime::DemangleSymbolAsNode(name, ctx);
         }
         if (node_ptr) {
           if (m_options.m_expand)

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2051,15 +2051,14 @@ protected:
     for (size_t i = 0; i < command.GetArgumentCount(); i++) {
       StringRef name = command.GetArgumentAtIndex(i);
       if (!name.empty()) {
-        swift::Demangle::Context demangle_ctx;
         NodePointer node_ptr = nullptr;
         // Match the behavior of swift-demangle and accept Swift symbols without
         // the leading `$`. This makes symbol copy & paste more convenient.
         if (name.startswith("S") || name.startswith("s")) {
           std::string correctedName = std::string("$") + name.str();
-          node_ptr = demangle_ctx.demangleSymbolAsNode(correctedName);
+          node_ptr = SwiftLanguageRuntime::DemangleSymbolAsNode(correctedName);
         } else {
-          node_ptr = demangle_ctx.demangleSymbolAsNode(name);
+          node_ptr = SwiftLanguageRuntime::DemangleSymbolAsNode(name);
         }
         if (node_ptr) {
           if (m_options.m_expand)

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -153,8 +153,7 @@ public:
   ///
   /// This is a central point of access, for purposes such as logging.
   static swift::Demangle::NodePointer
-  DemangleSymbolAsNode(llvm::StringRef symbol,
-                       swift::Demangle::Context *ctx = nullptr);
+  DemangleSymbolAsNode(llvm::StringRef symbol, swift::Demangle::Context &ctx);
 
   void DumpTyperef(CompilerType type, TypeSystemSwiftTypeRef *module_holder,
                    Stream *s);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -19,6 +19,7 @@
 #include "lldb/Core/PluginInterface.h"
 #include "lldb/Target/LanguageRuntime.h"
 #include "lldb/lldb-private.h"
+#include "swift/Demangling/Demangle.h"
 
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringSet.h"
@@ -147,6 +148,13 @@ public:
   static std::string DemangleSymbolAsString(llvm::StringRef symbol,
                                             DemangleMode mode,
                                             const SymbolContext *sc = nullptr);
+
+  /// Demangle a symbol to a swift::Demangle node tree.
+  ///
+  /// This is a central point of access, for purposes such as logging.
+  static swift::Demangle::NodePointer
+  DemangleSymbolAsNode(llvm::StringRef symbol,
+                       swift::Demangle::Context *ctx = nullptr);
 
   void DumpTyperef(CompilerType type, TypeSystemSwiftTypeRef *module_holder,
                    Stream *s);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1544,7 +1544,8 @@ bool SwiftLanguageRuntime::IsSelf(Variable &variable) {
   if (!function)
     return false;
   StringRef func_name = function->GetMangled().GetMangledName().GetStringRef();
-  auto *node_ptr = SwiftLanguageRuntime::DemangleSymbolAsNode(func_name);
+  Context ctx;
+  auto *node_ptr = SwiftLanguageRuntime::DemangleSymbolAsNode(func_name, ctx);
   if (!node_ptr)
     return false;
   if (node_ptr->getKind() != swift::Demangle::Node::Kind::Global)

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1544,9 +1544,7 @@ bool SwiftLanguageRuntime::IsSelf(Variable &variable) {
   if (!function)
     return false;
   StringRef func_name = function->GetMangled().GetMangledName().GetStringRef();
-  swift::Demangle::Context demangle_ctx;
-  swift::Demangle::NodePointer node_ptr =
-      demangle_ctx.demangleSymbolAsNode(func_name);
+  auto *node_ptr = SwiftLanguageRuntime::DemangleSymbolAsNode(func_name);
   if (!node_ptr)
     return false;
   if (node_ptr->getKind() != swift::Demangle::Node::Kind::Global)


### PR DESCRIPTION
Creates a single/central function in `SwiftLanguageRuntime` for demangling Swift symbols to node trees. This is to ensure calls to `Demangle::Context::demangleSymbolAsNode` are logged to the "demangle" log channel.

Outside of logging, this is NFC.