### PR TITLE
[clang] Fixing arm-common, windows and openmp header install targets

### DIFF
--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -363,7 +363,7 @@ set_target_properties("clang-resource-headers" PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${output_dir}")
 add_dependencies("clang-resource-headers"
                  "core-resource-headers"
-                 "arm-common-headers"
+                 "arm-common-resource-headers"
                  "arm-resource-headers"
                  "aarch64-resource-headers"
                  "cuda-resource-headers"
@@ -383,7 +383,7 @@ add_dependencies("clang-resource-headers"
 
 # Core/common headers
 add_header_target("core-resource-headers" ${core_files})
-add_header_target("arm-common-headers" "${arm_common_files};${arm_common_generated_files}")
+add_header_target("arm-common-resource-headers" "${arm_common_files};${arm_common_generated_files}")
 
 # Architecture/platform specific targets
 add_header_target("arm-resource-headers" "${arm_only_files};${arm_only_generated_files}")
@@ -535,7 +535,7 @@ install(
 
 install(
   FILES ${openmp_wrapper_files}
-  DESTINATION ${header_install_dir}
+  DESTINATION ${header_install_dir}/openmp_wrappers
   EXCLUDE_FROM_ALL
   COMPONENT openmp-resource-headers)
 
@@ -546,7 +546,7 @@ install(
   COMPONENT utility-resource-headers)
 
 install(
-  FILES ${windows_files}
+  FILES ${windows_only_files}
   DESTINATION ${header_install_dir}
   EXCLUDE_FROM_ALL
   COMPONENT windows-resource-headers)
@@ -607,7 +607,7 @@ if (NOT LLVM_ENABLE_IDE)
                            DEPENDS openmp-resource-headers
                            COMPONENT openmp-resource-headers)
   add_llvm_install_targets(install-windows-resource-headers
-                           DEPENDS window-resource-headers
+                           DEPENDS windows-resource-headers
                            COMPONENT windows-resource-headers)
   add_llvm_install_targets(install-utility-resource-headers
                            DEPENDS utility-resource-headers


### PR DESCRIPTION
https://reviews.llvm.org/D123498 contains a few errors resulting in incorrect target contents or mismatched target/list names. This patch fixes all the known errors.

Reviewed By: craig.topper

Differential Revision: https://reviews.llvm.org/D126002

(cherry picked from commit 1f12718ccfd660f01ac0e444d4632cf8ce6b98e2)