### PR TITLE
[Tests] SwiftREPL: Switch from using yaml to strings format

### DIFF
--- a/lldb/test/Shell/SwiftREPL/DiagnosticOptions.test
+++ b/lldb/test/Shell/SwiftREPL/DiagnosticOptions.test
@@ -15,6 +15,5 @@ _ = "An unterminated string
 :quit
 
 
-//--- fr.yaml
-- id: "lex_unterminated_string"
-  msg: "chaîne non terminée littérale"
+//--- fr.strings
+"lex_unterminated_string" = "chaîne non terminée littérale";


### PR DESCRIPTION
This is related to switch from `.yaml` to `.strings` - https://github.com/apple/swift/pull/60707