### PR TITLE
[libclang][deps] Split translation units into individual -cc1 or other commands

### DIFF
--- a/clang/test/Index/Core/scan-deps-by-mod-name.m
+++ b/clang/test/Index/Core/scan-deps-by-mod-name.m
@@ -22,8 +22,9 @@
 // CHECK-NEXT:       [[PREFIX]]/Inputs/module/module.modulemap
 // CHECK-NEXT:     build-args: {{.*}} -emit-module {{.*}} -fmodule-name=ModA {{.*}} -fno-implicit-modules {{.*}}
 // CHECK-NEXT: dependencies:
-// CHECK-NEXT:   context-hash:
-// CHECK-NEXT:   module-deps:
-// CHECK-NEXT:     ModA:[[HASH_MOD_A]]
-// CHECK-NEXT:   file-deps:
-// CHECK-NEXT:   build-args: {{.*}} -fno-implicit-modules -fno-implicit-module-maps {{.*}} -fmodule-file={{(ModA=)?}}{{.*}}ModA_{{.*}}.pcm
+// CHECK-NEXT:   command 0:
+// CHECK-NEXT:     context-hash:
+// CHECK-NEXT:     module-deps:
+// CHECK-NEXT:       ModA:[[HASH_MOD_A]]
+// CHECK-NEXT:     file-deps:
+// CHECK-NEXT:     build-args: -cc1 {{.*}} -fmodule-file={{(ModA=)?}}{{.*}}ModA_{{.*}}.pcm

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -280,7 +280,9 @@ LLVM_13 {
     clang_experimental_DependencyScannerWorker_create_v0;
     clang_experimental_DependencyScannerWorker_dispose_v0;
     clang_experimental_DependencyScannerWorker_getFileDependencies_v3;
+    clang_experimental_DependencyScannerWorker_getFileDependencies_v4;
     clang_experimental_FileDependencies_dispose;
+    clang_experimental_FileDependenciesList_dispose;
     clang_experimental_ModuleDependencySet_dispose;
     clang_findIncludesInFile;
     clang_findIncludesInFileWithBlock;


### PR DESCRIPTION
Exposes the new multi-command model from
https://reviews.llvm.org/D132405 in libclang.