### PR TITLE
[Sema][ObjC] Don't warn about implicitly-retained self in an unevaluated context

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -2915,7 +2915,7 @@ ExprResult Sema::BuildIvarRefExpr(Scope *S, SourceLocation Loc,
         !Diags.isIgnored(diag::warn_arc_repeated_use_of_weak, Loc))
       getCurFunction()->recordUseOfWeak(Result);
   }
-  if (getLangOpts().ObjCAutoRefCount)
+  if (getLangOpts().ObjCAutoRefCount && !isUnevaluatedContext())
     if (const BlockDecl *BD = CurContext->getInnermostBlockDecl())
       ImplicitlyRetainedSelfLocs.push_back({Loc, BD});
 

--- a/clang/test/SemaObjCXX/warn-implicit-self-in-block.mm
+++ b/clang/test/SemaObjCXX/warn-implicit-self-in-block.mm
@@ -39,4 +39,8 @@ void escapeFunc(BlockTy);
     noescapeFunc(^{ [&](){ (void)_bar; }(); });
     escapeFunc(^{ [&](){ (void)_bar; }(); }); // expected-warning {{block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior}}
   }
+
+  - (BlockTy)testDeclType{
+    return ^{ decltype(_bar) i = 12; (void)i; };
+  }
 @end


### PR DESCRIPTION
(cherry picked from commit 5d794552bc0c15bbe9852080e60bcecead09302f)