### PR TITLE
[stable][clang][cas/include-tree] Make sure to record the files referenced via `-fsanitize-ignorelist=`

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -300,6 +300,27 @@ void IncludeTreePPConsumer::handleHasIncludeCheck(Preprocessor &PP,
 }
 
 void IncludeTreePPConsumer::finalize(CompilerInstance &CI) {
+  FileManager &FM = CI.getFileManager();
+
+  auto addFile = [&](StringRef FilePath) -> bool {
+    llvm::ErrorOr<const FileEntry *> FE = FM.getFile(FilePath);
+    if (!FE) {
+      ErrorToReport = llvm::errorCodeToError(FE.getError());
+      return false;
+    }
+    Expected<cas::ObjectRef> Ref = addToFileList(FM, *FE);
+    if (!Ref) {
+      ErrorToReport = Ref.takeError();
+      return false;
+    }
+    return true;
+  };
+
+  for (StringRef FilePath : CI.getLangOpts().NoSanitizeFiles) {
+    if (!addFile(FilePath))
+      return;
+  }
+
   PreprocessorOptions &PPOpts = CI.getPreprocessorOpts();
   if (PPOpts.ImplicitPCHInclude.empty())
     return; // no need for additional work.
@@ -318,7 +339,6 @@ void IncludeTreePPConsumer::finalize(CompilerInstance &CI) {
     return LHS->getUID() < RHS->getUID();
   });
 
-  FileManager &FM = CI.getFileManager();
   for (const FileEntry *FE : NotSeenIncludes) {
     auto FileNode = addToFileList(FM, FE);
     if (!FileNode) {

--- a/clang/test/CAS/include-tree-with-sanitizer.c
+++ b/clang/test/CAS/include-tree-with-sanitizer.c
@@ -1,0 +1,20 @@
+// RUN: rm -rf %t && mkdir %t
+// RUN: touch %t/asan_ignorelist.txt
+// RUN: touch %t/sys_asan_ignorelist.txt
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_ENABLE_INCLUDE_TREE=1 %clang-cache \
+// RUN:   %clang -fsanitize=address -Xclang -fsanitize-ignorelist=%t/asan_ignorelist.txt -Xclang -fsanitize-system-ignorelist=%t/sys_asan_ignorelist.txt \
+// RUN:   -target x86_64-apple-macos11 -c %s -o %t/output.o -Rcompile-job-cache 2> %t/output-tree.txt
+
+// RUN: cat %t/output-tree.txt | sed \
+// RUN:   -e "s/^.*miss for '//" \
+// RUN:   -e "s/' .*$//" > %t/cache-key-tree
+
+// RUN: clang-cas-test -print-compile-job-cache-key -cas %t/cas @%t/cache-key-tree > %t/key.txt
+// RUN: FileCheck %s -DSRC_FILE=%s -DOUT_DIR=%t -input-file %t/key.txt
+//
+// CHECK: -fsanitize=address \
+// CHECK: -fsanitize-ignorelist=[[OUT_DIR]]{{/|\\}}asan_ignorelist.txt \
+// CHECK: -fsanitize-ignorelist=[[OUT_DIR]]{{/|\\}}sys_asan_ignorelist.txt \
+
+void test() {}


### PR DESCRIPTION
Otherwise include-tree compilation will fail due to not being able to access these files.

(cherry picked from commit adaaec6027f00be5bf8130742a21faf502e6a673)