### PR TITLE
Move SwiftASTContext::GetResourceDir to HostInfo.

### DIFF
--- a/lldb/include/lldb/Host/HostInfoBase.h
+++ b/lldb/include/lldb/Host/HostInfoBase.h
@@ -108,6 +108,7 @@ public:
   static FileSpec GetXcodeDeveloperDirectory() { return {}; }
 #ifdef LLDB_ENABLE_SWIFT
   static FileSpec GetSwiftResourceDir() { return {}; }
+  static FileSpec GetSwiftResourceDir(llvm::Triple triple) { return {}; }
   static bool ComputeSwiftResourceDirectory(
       FileSpec &lldb_shlib_spec, FileSpec &file_spec, bool verify) {
     return false;

--- a/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
+++ b/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
@@ -31,6 +31,22 @@ public:
 
 #ifdef LLDB_ENABLE_SWIFT
   static FileSpec GetSwiftResourceDir();
+  static std::string GetSwiftResourceDir(llvm::Triple triple,
+                                         llvm::StringRef platform_sdk_path);
+
+  /// Return the name of the OS-specific subdirectory containing the
+  /// Swift stdlib needed for \p target. Only exposed for unit tests.
+  static std::string GetSwiftStdlibOSDir(llvm::Triple target,
+                                         llvm::Triple host);
+
+  /// Private implementation detail of GetSwiftResourceDir, exposed for unit
+  /// tests.
+  static std::string DetectSwiftResourceDir(llvm::StringRef platform_sdk_path,
+                                            llvm::StringRef swift_stdlib_os_dir,
+                                            std::string swift_dir,
+                                            std::string xcode_contents_path,
+                                            std::string toolchain_path,
+                                            std::string cl_tools_path);
   static bool ComputeSwiftResourceDirectory(FileSpec &lldb_shlib_spec,
                                             FileSpec &file_spec, bool verify);
 #endif

--- a/lldb/include/lldb/Host/posix/HostInfoPosix.h
+++ b/lldb/include/lldb/Host/posix/HostInfoPosix.h
@@ -37,6 +37,8 @@ public:
 
 #ifdef LLDB_ENABLE_SWIFT
   static FileSpec GetSwiftResourceDir();
+  static std::string GetSwiftResourceDir(llvm::Triple triple,
+                                         llvm::StringRef platform_sdk_path);
   static bool ComputeSwiftResourceDirectory(FileSpec &lldb_shlib_spec,
                                             FileSpec &file_spec, bool verify);
 #endif

--- a/lldb/include/lldb/Host/windows/HostInfoWindows.h
+++ b/lldb/include/lldb/Host/windows/HostInfoWindows.h
@@ -34,6 +34,8 @@ public:
   static FileSpec GetDefaultShell();
 #ifdef LLDB_ENABLE_SWIFT
   static FileSpec GetSwiftResourceDir();
+  static std::string GetSwiftResourceDir(llvm::Triple triple,
+                                         llvm::StringRef platform_sdk_path);
   static bool ComputeSwiftResourceDirectory(FileSpec &lldb_shlib_spec,
                                             FileSpec &file_spec, bool verify);
 #endif

--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSXSwift.cpp
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSXSwift.cpp
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include "lldb/Host/HostInfo.h"
+
+#include "Plugins/Platform/MacOSX/PlatformDarwin.h"
 #include "lldb/Host/Config.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
@@ -13,7 +16,7 @@
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
-
+#include <regex>
 #include <string>
 
 using namespace lldb_private;
@@ -51,4 +54,238 @@ FileSpec HostInfoMacOSX::GetSwiftResourceDir() {
     LLDB_LOG(log, "swift dir -> '{0}'", g_swift_resource_dir);
   });
   return g_swift_resource_dir;
+}
+
+/// Return the Xcode sdk type for the target triple, if that makes sense.
+/// Otherwise, return the unknown sdk type.
+static XcodeSDK::Type GetSDKType(const llvm::Triple &target,
+                                 const llvm::Triple &host) {
+  // Only Darwin platforms know the concept of an SDK.
+  auto host_os = host.getOS();
+  if (host_os != llvm::Triple::OSType::MacOSX)
+    return XcodeSDK::Type::unknown;
+
+  auto is_simulator = [&]() -> bool {
+    return target.getEnvironment() == llvm::Triple::Simulator ||
+           !target.getArchName().startswith("arm");
+  };
+
+  switch (target.getOS()) {
+  case llvm::Triple::OSType::MacOSX:
+  case llvm::Triple::OSType::Darwin:
+    return XcodeSDK::Type::MacOSX;
+  case llvm::Triple::OSType::IOS:
+    if (is_simulator())
+      return XcodeSDK::Type::iPhoneSimulator;
+    return XcodeSDK::Type::iPhoneOS;
+  case llvm::Triple::OSType::TvOS:
+    if (is_simulator())
+      return XcodeSDK::Type::AppleTVSimulator;
+    return XcodeSDK::Type::AppleTVOS;
+  case llvm::Triple::OSType::WatchOS:
+    if (is_simulator())
+      return XcodeSDK::Type::WatchSimulator;
+    return XcodeSDK::Type::watchOS;
+  default:
+    return XcodeSDK::Type::unknown;
+  }
+}
+
+std::string HostInfoMacOSX::GetSwiftStdlibOSDir(llvm::Triple target,
+                                                llvm::Triple host) {
+  XcodeSDK::Info sdk_info;
+  sdk_info.type = GetSDKType(target, host);
+  std::string sdk_name = XcodeSDK::GetCanonicalName(sdk_info);
+  if (!sdk_name.empty())
+    return sdk_name;
+  return target.getOSName().str();
+}
+
+static bool IsDirectory(const FileSpec &spec) {
+  return llvm::sys::fs::is_directory(spec.GetPath());
+}
+
+std::string HostInfoMacOSX::DetectSwiftResourceDir(
+    llvm::StringRef platform_sdk_path, llvm::StringRef swift_stdlib_os_dir,
+    std::string swift_dir, std::string xcode_contents_path,
+    std::string toolchain_path, std::string cl_tools_path) {
+  llvm::SmallString<16> m_description("SwiftASTContext");
+  // First, check if there's something in our bundle.
+  {
+    FileSpec swift_dir_spec(swift_dir);
+    if (swift_dir_spec) {
+      LLDB_LOGF(GetLog(LLDBLog::Types), "trying ePathTypeSwiftDir: %s",
+                 swift_dir_spec.GetCString());
+      // We can't just check for the Swift directory, because that
+      // always exists.  We have to look for "clang" inside that.
+      FileSpec swift_clang_dir_spec = swift_dir_spec;
+      swift_clang_dir_spec.AppendPathComponent("clang");
+
+      if (IsDirectory(swift_clang_dir_spec)) {
+        LLDB_LOGF(GetLog(LLDBLog::Types),
+                   "found Swift resource dir via ePathTypeSwiftDir': %s",
+                   swift_dir_spec.GetCString());
+        return swift_dir_spec.GetPath();
+      }
+    }
+  }
+
+  // Nothing in our bundle. Are we in a toolchain that has its own Swift
+  // compiler resource dir?
+
+  {
+    llvm::SmallString<256> path(toolchain_path);
+    LLDB_LOGF(GetLog(LLDBLog::Types), "trying toolchain path: %s",
+               path.c_str());
+
+    if (!path.empty()) {
+      llvm::sys::path::append(path, "usr/lib/swift");
+      LLDB_LOGF(GetLog(LLDBLog::Types), "trying toolchain-based lib path: %s",
+                 path.c_str());
+
+      if (IsDirectory(FileSpec(path))) {
+        LLDB_LOGF(GetLog(LLDBLog::Types),
+                   "found Swift resource dir via "
+                   "toolchain path + 'usr/lib/swift': %s",
+                   path.c_str());
+        return std::string(path);
+      }
+    }
+  }
+
+  // We're not in a toolchain that has one. Use the Xcode default toolchain.
+
+  {
+    llvm::SmallString<256> path(xcode_contents_path);
+    LLDB_LOGF(GetLog(LLDBLog::Types), "trying Xcode path: %s", path.c_str());
+
+    if (!path.empty()) {
+      llvm::sys::path::append(path, "Developer",
+                              "Toolchains/XcodeDefault.xctoolchain",
+                              "usr/lib/swift");
+      LLDB_LOGF(GetLog(LLDBLog::Types), "trying Xcode-based lib path: %s",
+                 path.c_str());
+
+      if (IsDirectory(FileSpec(path))) {
+        llvm::StringRef resource_dir = path;
+        llvm::sys::path::append(path, swift_stdlib_os_dir);
+        std::string s(path);
+        if (IsDirectory(FileSpec(path))) {
+          LLDB_LOGF(GetLog(LLDBLog::Types),
+                     "found Swift resource dir via "
+                     "Xcode contents path + default toolchain "
+                     "relative dir: %s",
+                     resource_dir.str().c_str());
+          return resource_dir.str();
+        } else {
+          // Search the SDK for a matching cross-SDK.
+          path = platform_sdk_path;
+          llvm::sys::path::append(path, "usr/lib/swift");
+          llvm::StringRef resource_dir = path;
+          llvm::sys::path::append(path, swift_stdlib_os_dir);
+          if (IsDirectory(FileSpec(path))) {
+            LLDB_LOGF(GetLog(LLDBLog::Types),
+                       "found Swift resource dir via "
+                       "Xcode contents path + cross-compilation SDK "
+                       "relative dir: %s",
+                       resource_dir.str().c_str());
+            return resource_dir.str();
+          }
+        }
+      }
+    }
+  }
+
+  // We're not in Xcode. We might be in the command-line tools.
+
+  {
+    llvm::SmallString<256> path(cl_tools_path);
+    LLDB_LOGF(GetLog(LLDBLog::Types), "trying command-line tools path: %s",
+               path.c_str());
+
+    if (!path.empty()) {
+      llvm::sys::path::append(path, "usr/lib/swift");
+      LLDB_LOGF(GetLog(LLDBLog::Types),
+                 "trying command-line tools-based lib path: %s", path.c_str());
+
+      if (IsDirectory(FileSpec(path))) {
+        LLDB_LOGF(GetLog(LLDBLog::Types),
+                   "found Swift resource dir via command-line tools "
+                   "path + usr/lib/swift: %s",
+                   path.c_str());
+        return std::string(path);
+      }
+    }
+  }
+
+  // We might be in the build-dir configuration for a
+  // build-script-driven LLDB build, which has the Swift build dir as
+  // a sibling directory to the lldb build dir.  This looks much
+  // different than the install- dir layout that the previous checks
+  // would try.
+  {
+    FileSpec faux_swift_dir_spec(swift_dir);
+    if (faux_swift_dir_spec) {
+      // Let's try to regex this.
+      // We're looking for /some/path/lldb-{os}-{arch}, and want to
+      // build the following:
+      //    /some/path/swift-{os}-{arch}/lib/swift/{os}/{arch}
+      // In a match, these are the following assignments for
+      // backrefs:
+      //   $1 - first part of path before swift build dir
+      //   $2 - the host OS path separator character
+      //   $3 - all the stuff that should come after changing
+      //        lldb to swift for the lib dir.
+      auto match_regex =
+          std::regex("^(.+([/\\\\]))lldb-(.+)$");
+      const std::string replace_format = "$1swift-$3";
+      const std::string faux_swift_dir =
+          faux_swift_dir_spec.GetCString();
+      const std::string build_tree_resource_dir =
+          std::regex_replace(faux_swift_dir, match_regex,
+                             replace_format);
+      LLDB_LOGF(GetLog(LLDBLog::Types),
+                 "trying ePathTypeSwiftDir regex-based build dir: %s",
+                 build_tree_resource_dir.c_str());
+      FileSpec swift_resource_dir_spec(build_tree_resource_dir.c_str());
+      if (IsDirectory(swift_resource_dir_spec)) {
+        LLDB_LOGF(GetLog(LLDBLog::Types),
+                   "found Swift resource dir via "
+                   "ePathTypeSwiftDir + inferred build-tree dir: %s",
+                   swift_resource_dir_spec.GetCString());
+        return swift_resource_dir_spec.GetCString();
+      }
+    }
+  }
+
+  // We failed to find a reasonable Swift resource dir.
+  LLDB_LOGF(GetLog(LLDBLog::Types), "failed to find a Swift resource dir");
+
+  return {};
+}
+
+std::string
+HostInfoMacOSX::GetSwiftResourceDir(llvm::Triple triple,
+                                    llvm::StringRef platform_sdk_path) {
+  static std::mutex g_mutex;
+  std::lock_guard<std::mutex> locker(g_mutex);
+  std::string swift_stdlib_os_dir =
+      GetSwiftStdlibOSDir(triple, HostInfo::GetArchitecture().GetTriple());
+
+  // The resource dir depends on the SDK path and the expected OS name.
+  llvm::SmallString<128> key(platform_sdk_path);
+  key.append(swift_stdlib_os_dir);
+  static llvm::StringMap<std::string> g_resource_dir_cache;
+  auto it = g_resource_dir_cache.find(key);
+  if (it != g_resource_dir_cache.end())
+    return it->getValue();
+
+  auto value = DetectSwiftResourceDir(
+      platform_sdk_path, swift_stdlib_os_dir,
+      HostInfo::GetSwiftResourceDir().GetPath(),
+      HostInfo::GetXcodeContentsDirectory().GetPath(),
+      PlatformDarwin::GetCurrentToolchainDirectory().GetPath(),
+      PlatformDarwin::GetCurrentCommandLineToolsDirectory().GetPath());
+  g_resource_dir_cache.insert({key, value});
+  return g_resource_dir_cache[key];
 }

--- a/lldb/source/Host/posix/HostInfoPosixSwift.cpp
+++ b/lldb/source/Host/posix/HostInfoPosixSwift.cpp
@@ -37,3 +37,9 @@ FileSpec HostInfoPosix::GetSwiftResourceDir() {
   });
   return g_swift_resource_dir;
 }
+
+std::string
+HostInfoPosix::GetSwiftResourceDir(llvm::Triple triple,
+                                   llvm::StringRef platform_sdk_path) {
+  return GetSwiftResourceDir().GetPath();
+}

--- a/lldb/source/Host/windows/HostInfoWindowsSwift.cpp
+++ b/lldb/source/Host/windows/HostInfoWindowsSwift.cpp
@@ -17,14 +17,14 @@
 
 using namespace lldb_private;
 
-bool HostInfoPosix::ComputeSwiftResourceDirectory(FileSpec &lldb_shlib_spec,
-                                                  FileSpec &file_spec,
-                                                  bool verify) {
+bool HostInfoWindows::ComputeSwiftResourceDirectory(FileSpec &lldb_shlib_spec,
+                                                    FileSpec &file_spec,
+                                                    bool verify) {
   return DefaultComputeSwiftResourceDirectory(lldb_shlib_spec, file_spec,
                                               verify);
 }
 
-FileSpec HostInfoPosix::GetSwiftResourceDir() {
+FileSpec HostInfoWindows::GetSwiftResourceDir() {
   static std::once_flag g_once_flag;
   static FileSpec g_swift_resource_dir;
   std::call_once(g_once_flag, []() {
@@ -35,4 +35,10 @@ FileSpec HostInfoPosix::GetSwiftResourceDir() {
     LLDB_LOG(log, "swift dir -> '{0}'", g_swift_resource_dir);
   });
   return g_swift_resource_dir;
+}
+
+std::string
+HostInfoWindows::GetSwiftResourceDir(llvm::Triple triple,
+                                     llvm::StringRef platform_sdk_path) {
+  return GetSwiftResourceDir().GetPath();
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -119,13 +119,11 @@
 
 #include "Plugins/Language/Swift/LogChannelSwift.h"
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
-#include "Plugins/Platform/MacOSX/PlatformDarwin.h"
 #include "Plugins/SymbolFile/DWARF/DWARFASTParserClang.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 
 #include <mutex>
 #include <queue>
-#include <regex>
 #include <set>
 #include <sstream>
 
@@ -293,12 +291,6 @@ static EnumInfoCache *GetEnumInfoCache(const swift::ASTContext *a) {
   }
   return pos->second.get();
 }
-
-namespace {
-bool IsDirectory(const FileSpec &spec) {
-  return llvm::sys::fs::is_directory(spec.GetPath());
-}
-} // namespace
 
 llvm::LLVMContext &SwiftASTContext::GetGlobalLLVMContext() {
   static llvm::LLVMContext s_global_context;
@@ -950,239 +942,6 @@ SwiftASTContextForModule::~SwiftASTContextForModule() {
     GetASTMap().Erase(ctx);
 }
 
-/// Return the Xcode sdk type for the target triple, if that makes sense.
-/// Otherwise, return the unknown sdk type.
-static XcodeSDK::Type GetSDKType(const llvm::Triple &target,
-                                 const llvm::Triple &host) {
-  // Only Darwin platforms know the concept of an SDK.
-  auto host_os = host.getOS();
-  if (host_os != llvm::Triple::OSType::MacOSX)
-    return XcodeSDK::Type::unknown;
-
-  auto is_simulator = [&]() -> bool {
-    return target.getEnvironment() == llvm::Triple::Simulator ||
-           !target.getArchName().startswith("arm");
-  };
-
-  switch (target.getOS()) {
-  case llvm::Triple::OSType::MacOSX:
-  case llvm::Triple::OSType::Darwin:
-    return XcodeSDK::Type::MacOSX;
-  case llvm::Triple::OSType::IOS:
-    if (is_simulator())
-      return XcodeSDK::Type::iPhoneSimulator;
-    return XcodeSDK::Type::iPhoneOS;
-  case llvm::Triple::OSType::TvOS:
-    if (is_simulator())
-      return XcodeSDK::Type::AppleTVSimulator;
-    return XcodeSDK::Type::AppleTVOS;
-  case llvm::Triple::OSType::WatchOS:
-    if (is_simulator())
-      return XcodeSDK::Type::WatchSimulator;
-    return XcodeSDK::Type::watchOS;
-  default:
-    return XcodeSDK::Type::unknown;
-  }
-}
-
-/// Return the name of the OS-specific subdirectory containing the
-/// Swift stdlib needed for \p target.
-std::string SwiftASTContext::GetSwiftStdlibOSDir(const llvm::Triple &target,
-                                                 const llvm::Triple &host) {
-  XcodeSDK::Info sdk_info;
-  sdk_info.type = GetSDKType(target, host);
-  std::string sdk_name = XcodeSDK::GetCanonicalName(sdk_info);
-  if (!sdk_name.empty())
-    return sdk_name;
-  return target.getOSName().str();
-}
-
-std::string SwiftASTContext::GetResourceDir(const llvm::Triple &triple) {
-  static std::mutex g_mutex;
-  std::lock_guard<std::mutex> locker(g_mutex);
-  StringRef platform_sdk_path = GetPlatformSDKPath();
-  std::string swift_stdlib_os_dir =
-      GetSwiftStdlibOSDir(triple, HostInfo::GetArchitecture().GetTriple());
-
-  // The resource dir depends on the SDK path and the expected os name.
-  llvm::SmallString<128> key(platform_sdk_path);
-  key.append(swift_stdlib_os_dir);
-  static llvm::StringMap<std::string> g_resource_dir_cache;
-  auto it = g_resource_dir_cache.find(key);
-  if (it != g_resource_dir_cache.end())
-    return it->getValue();
-
-  auto value = GetResourceDir(
-      platform_sdk_path, swift_stdlib_os_dir,
-      HostInfo::GetSwiftResourceDir().GetPath(),
-      HostInfo::GetXcodeContentsDirectory().GetPath(),
-      PlatformDarwin::GetCurrentToolchainDirectory().GetPath(),
-      PlatformDarwin::GetCurrentCommandLineToolsDirectory().GetPath());
-  g_resource_dir_cache.insert({key, value});
-  return g_resource_dir_cache[key];
-}
-
-std::string SwiftASTContext::GetResourceDir(StringRef platform_sdk_path,
-                                            StringRef swift_stdlib_os_dir,
-                                            std::string swift_dir,
-                                            std::string xcode_contents_path,
-                                            std::string toolchain_path,
-                                            std::string cl_tools_path) {
-  llvm::SmallString<16> m_description("SwiftASTContext");
-  // First, check if there's something in our bundle.
-  {
-    FileSpec swift_dir_spec(swift_dir);
-    if (swift_dir_spec) {
-      LOG_PRINTF(GetLog(LLDBLog::Types), "trying ePathTypeSwiftDir: %s",
-                 swift_dir_spec.GetCString());
-      // We can't just check for the Swift directory, because that
-      // always exists.  We have to look for "clang" inside that.
-      FileSpec swift_clang_dir_spec = swift_dir_spec;
-      swift_clang_dir_spec.AppendPathComponent("clang");
-
-      if (IsDirectory(swift_clang_dir_spec)) {
-        LOG_PRINTF(GetLog(LLDBLog::Types),
-                   "found Swift resource dir via ePathTypeSwiftDir': %s",
-                   swift_dir_spec.GetCString());
-        return swift_dir_spec.GetPath();
-      }
-    }
-  }
-
-  // Nothing in our bundle. Are we in a toolchain that has its own Swift
-  // compiler resource dir?
-
-  {
-    llvm::SmallString<256> path(toolchain_path);
-    LOG_PRINTF(GetLog(LLDBLog::Types), "trying toolchain path: %s",
-               path.c_str());
-
-    if (!path.empty()) {
-      llvm::sys::path::append(path, "usr/lib/swift");
-      LOG_PRINTF(GetLog(LLDBLog::Types), "trying toolchain-based lib path: %s",
-                 path.c_str());
-
-      if (IsDirectory(FileSpec(path))) {
-        LOG_PRINTF(GetLog(LLDBLog::Types),
-                   "found Swift resource dir via "
-                   "toolchain path + 'usr/lib/swift': %s",
-                   path.c_str());
-        return std::string(path);
-      }
-    }
-  }
-
-  // We're not in a toolchain that has one. Use the Xcode default toolchain.
-
-  {
-    llvm::SmallString<256> path(xcode_contents_path);
-    LOG_PRINTF(GetLog(LLDBLog::Types), "trying Xcode path: %s", path.c_str());
-
-    if (!path.empty()) {
-      llvm::sys::path::append(path, "Developer",
-                              "Toolchains/XcodeDefault.xctoolchain",
-                              "usr/lib/swift");
-      LOG_PRINTF(GetLog(LLDBLog::Types), "trying Xcode-based lib path: %s",
-                 path.c_str());
-
-      if (IsDirectory(FileSpec(path))) {
-        StringRef resource_dir = path;
-        llvm::sys::path::append(path, swift_stdlib_os_dir);
-        std::string s(path);
-        if (IsDirectory(FileSpec(path))) {
-          LOG_PRINTF(GetLog(LLDBLog::Types),
-                     "found Swift resource dir via "
-                     "Xcode contents path + default toolchain "
-                     "relative dir: %s",
-                     resource_dir.str().c_str());
-          return resource_dir.str();
-        } else {
-          // Search the SDK for a matching cross-SDK.
-          path = platform_sdk_path;
-          llvm::sys::path::append(path, "usr/lib/swift");
-          StringRef resource_dir = path;
-          llvm::sys::path::append(path, swift_stdlib_os_dir);
-          if (IsDirectory(FileSpec(path))) {
-            LOG_PRINTF(GetLog(LLDBLog::Types),
-                       "found Swift resource dir via "
-                       "Xcode contents path + cross-compilation SDK "
-                       "relative dir: %s",
-                       resource_dir.str().c_str());
-            return resource_dir.str();
-          }
-        }
-      }
-    }
-  }
-
-  // We're not in Xcode. We might be in the command-line tools.
-
-  {
-    llvm::SmallString<256> path(cl_tools_path);
-    LOG_PRINTF(GetLog(LLDBLog::Types), "trying command-line tools path: %s",
-               path.c_str());
-
-    if (!path.empty()) {
-      llvm::sys::path::append(path, "usr/lib/swift");
-      LOG_PRINTF(GetLog(LLDBLog::Types),
-                 "trying command-line tools-based lib path: %s", path.c_str());
-
-      if (IsDirectory(FileSpec(path))) {
-        LOG_PRINTF(GetLog(LLDBLog::Types),
-                   "found Swift resource dir via command-line tools "
-                   "path + usr/lib/swift: %s",
-                   path.c_str());
-        return std::string(path);
-      }
-    }
-  }
-
-  // We might be in the build-dir configuration for a
-  // build-script-driven LLDB build, which has the Swift build dir as
-  // a sibling directory to the lldb build dir.  This looks much
-  // different than the install- dir layout that the previous checks
-  // would try.
-  {
-    FileSpec faux_swift_dir_spec(swift_dir);
-    if (faux_swift_dir_spec) {
-      // Let's try to regex this.
-      // We're looking for /some/path/lldb-{os}-{arch}, and want to
-      // build the following:
-      //    /some/path/swift-{os}-{arch}/lib/swift/{os}/{arch}
-      // In a match, these are the following assignments for
-      // backrefs:
-      //   $1 - first part of path before swift build dir
-      //   $2 - the host OS path separator character
-      //   $3 - all the stuff that should come after changing
-      //        lldb to swift for the lib dir.
-      auto match_regex =
-          std::regex("^(.+([/\\\\]))lldb-(.+)$");
-      const std::string replace_format = "$1swift-$3";
-      const std::string faux_swift_dir =
-          faux_swift_dir_spec.GetCString();
-      const std::string build_tree_resource_dir =
-          std::regex_replace(faux_swift_dir, match_regex,
-                             replace_format);
-      LOG_PRINTF(GetLog(LLDBLog::Types),
-                 "trying ePathTypeSwiftDir regex-based build dir: %s",
-                 build_tree_resource_dir.c_str());
-      FileSpec swift_resource_dir_spec(build_tree_resource_dir.c_str());
-      if (IsDirectory(swift_resource_dir_spec)) {
-        LOG_PRINTF(GetLog(LLDBLog::Types),
-                   "found Swift resource dir via "
-                   "ePathTypeSwiftDir + inferred build-tree dir: %s",
-                   swift_resource_dir_spec.GetCString());
-        return swift_resource_dir_spec.GetCString();
-      }
-    }
-  }
-
-  // We failed to find a reasonable Swift resource dir.
-  LOG_PRINTF(GetLog(LLDBLog::Types), "failed to find a Swift resource dir");
-
-  return {};
-}
-
 /// This code comes from CompilerInvocation.cpp (setRuntimeResourcePath).
 static void ConfigureResourceDirs(swift::CompilerInvocation &invocation,
                                   FileSpec resource_dir, llvm::Triple triple) {
@@ -1785,7 +1544,8 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
   // CompilerInvocation with the triple recovered from the binary.
   swift_ast_sp->SetTriple(triple, &module);
 
-  std::string resource_dir = swift_ast_sp->GetResourceDir(triple);
+  std::string resource_dir =
+      HostInfo::GetSwiftResourceDir(triple, swift_ast_sp->GetPlatformSDKPath());
   ConfigureResourceDirs(swift_ast_sp->GetCompilerInvocation(),
                         FileSpec(resource_dir), triple);
 
@@ -2279,7 +2039,8 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   }
 
   llvm::Triple triple = swift_ast_sp->GetTriple();
-  std::string resource_dir = swift_ast_sp->GetResourceDir(triple);
+  std::string resource_dir = HostInfo::GetSwiftResourceDir(
+      triple, swift_ast_sp->GetPlatformSDKPath());
   ConfigureResourceDirs(swift_ast_sp->GetCompilerInvocation(),
                         FileSpec(resource_dir), triple);
   const bool discover_implicit_search_paths =
@@ -2660,7 +2421,8 @@ void SwiftASTContext::InitializeSearchPathOptions(
   }
 
   llvm::Triple triple(GetTriple());
-  std::string resource_dir = GetResourceDir(triple);
+  std::string resource_dir =
+      HostInfo::GetSwiftResourceDir(triple, GetPlatformSDKPath());
   ConfigureResourceDirs(GetCompilerInvocation(), FileSpec(resource_dir),
                         triple);
 
@@ -3189,7 +2951,8 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
   }
   std::string prebuiltModuleCachePath =
       swift::CompilerInvocation::computePrebuiltCachePath(
-          GetResourceDir(triple), triple, sdk_version);
+          HostInfo::GetSwiftResourceDir(triple, GetPlatformSDKPath()), triple,
+          sdk_version);
   if (sdk_version)
     LOG_PRINTF(GetLog(LLDBLog::Types), "SDK version: %s",
                sdk_version->getAsString().c_str());

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -926,22 +926,6 @@ protected:
   /// Apply a PathMappingList dictionary on all search paths in the
   /// ClangImporterOptions.
   void RemapClangImporterOptions(const PathMappingList &path_map);
-
-  /// Infer the appropriate Swift resource directory for a target triple.
-  std::string GetResourceDir(const llvm::Triple &target);
-
-  /// Implementation of \c GetResourceDir.
-  static std::string GetResourceDir(llvm::StringRef platform_sdk_path,
-                                    llvm::StringRef swift_stdlib_os_dir,
-                                    std::string swift_dir,
-                                    std::string xcode_contents_path,
-                                    std::string toolchain_path,
-                                    std::string cl_tools_path);
-
-  /// Return the name of the OS-specific subdirectory containing the
-  /// Swift stdlib needed for \p target.
-  static std::string GetSwiftStdlibOSDir(const llvm::Triple &target,
-                                         const llvm::Triple &host);
 };
 
 /// Deprecated.

--- a/lldb/unittests/Host/HostInfoSwiftTest.cpp
+++ b/lldb/unittests/Host/HostInfoSwiftTest.cpp
@@ -11,12 +11,32 @@
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/lldb-defines.h"
+#include "llvm/Support/FileSystem.h"
 #include "gtest/gtest.h"
 
 using namespace lldb_private;
+using namespace llvm::sys;
 
 namespace {
 struct SwiftHostTest : public testing::Test {
+  /// Unique temporary directory in which all created filesystem entities must
+  /// be placed. It is removed at the end of the test suite.
+  llvm::SmallString<128> m_base_dir;
+
+  void SetUp() override {
+    // Get the name of the current test. To prevent that by chance two tests
+    // get the same temporary directory if createUniqueDirectory fails.
+    auto test_info = ::testing::UnitTest::GetInstance()->current_test_info();
+    ASSERT_TRUE(test_info != nullptr);
+    std::string name = test_info->name();
+    ASSERT_NO_ERROR(
+        fs::createUniqueDirectory("SwiftHostTest-" + name, m_base_dir));
+  }
+
+  void TearDown() override {
+    ASSERT_NO_ERROR(fs::remove_directories(m_base_dir));
+  }
+
   static void SetUpTestCase() {
     FileSystem::Initialize();
     HostInfo::Initialize();
@@ -63,5 +83,114 @@ TEST_F(SwiftHostTest, MacOSX) {
   path_to_swift_dir = "/foo/bar/lib/LLDB.framework/Resources/Swift";
   EXPECT_EQ(ComputeSwiftResourceDirectoryHelper(path_to_liblldb),
             path_to_swift_dir);
+}
+
+TEST_F(SwiftHostTest, ResourceDir) {
+  const char *paths[] = {
+      // Toolchains.
+      "/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/"
+      "lib/swift/macosx",
+
+      "/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/"
+      "lib/swift/iphoneos",
+
+      "/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/"
+      "lib/swift/iphonesimulator",
+
+      // SDKs.
+      "/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/"
+      "MacOSX10.13.sdk/usr",
+
+      "/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/"
+      "SDKs/"
+      "iPhoneOS11.3.sdk/usr",
+
+      "/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/"
+      "Developer/SDKs/iPhoneSimulatorOS12.0.sdk/usr",
+
+      "/Xcode.app/Contents/Developer/Platforms/Linux.platform/Developer/SDKs/"
+      "Linux.sdk/usr/lib/swift/linux",
+
+      // Custom toolchains.
+      "/Xcode.app/Contents/Developer/Toolchains/"
+      "Swift-4.1-development-snapshot.xctoolchain/usr/lib/swift/macosx",
+
+      // CLTools.
+      "/Library/Developer/CommandLineTools/usr/lib/swift/macosx",
+
+      // Local builds.
+      "/build/LLDB.framework/Resources/Swift/clang",
+  };
+
+  using SmallString = llvm::SmallString<256>;
+  std::vector<std::string> abs_paths;
+  for (auto dir : paths) {
+    SmallString path = m_base_dir.str();
+    path::append(path, dir);
+    ASSERT_NO_ERROR(fs::create_directories(path));
+    abs_paths.push_back(std::string(path));
+  }
+
+  llvm::StringRef macosx_sdk = path::parent_path(abs_paths[3]);
+  llvm::StringRef ios_sdk = path::parent_path(abs_paths[4]);
+  llvm::StringRef iossim_sdk = path::parent_path(abs_paths[5]);
+  llvm::StringRef cross_sdk = path::parent_path(
+      path::parent_path(path::parent_path(path::parent_path(abs_paths[6]))));
+
+  SmallString swift_dir = m_base_dir.str();
+  path::append(swift_dir,
+      "/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Resources/Swift");
+  SmallString xcode_contents = m_base_dir.str();
+  path::append(xcode_contents, "/Xcode.app/Contents");
+  SmallString toolchain = m_base_dir.str();
+  path::append(toolchain, "/Xcode.app/Contents/Developer/Toolchains");
+  SmallString cl_tools = m_base_dir.str();
+  path::append(cl_tools, "/Library/Developer/CommandLineTools");
+
+  SmallString tc_rdir = m_base_dir.str();
+  llvm::sys::path::append(tc_rdir, "/Xcode.app/Contents/Developer/Toolchains/"
+                                   "XcodeDefault.xctoolchain/usr/lib/swift");
+
+  auto GetResourceDir = [&](const char *triple_string,
+                            llvm::StringRef sdk_path) {
+    llvm::Triple host("x86_64-apple-macosx10.14");
+    llvm::Triple target(triple_string);
+    return HostInfoMacOSX::DetectSwiftResourceDir(
+        sdk_path, HostInfoMacOSX::GetSwiftStdlibOSDir(target, host),
+        std::string(swift_dir), std::string(xcode_contents),
+        std::string(toolchain), std::string(cl_tools));
+  };
+
+  EXPECT_EQ(GetResourceDir("x86_64-apple-macosx10.14", macosx_sdk),
+            tc_rdir.str());
+  EXPECT_EQ(GetResourceDir("x86_64-apple-darwin", macosx_sdk), tc_rdir);
+  EXPECT_EQ(GetResourceDir("aarch64-apple-ios11.3", ios_sdk), tc_rdir);
+  // Old-style simulator triple with missing environment.
+  EXPECT_EQ(GetResourceDir("x86_64-apple-ios11.3", iossim_sdk), tc_rdir);
+  EXPECT_EQ(GetResourceDir("x86_64-apple-ios11.3-simulator", iossim_sdk),
+            tc_rdir);
+  EXPECT_EQ(GetResourceDir("x86_64-unknown-linux", cross_sdk),
+            path::parent_path(abs_paths[6]));
+
+  // Version is too low, but we still expect a valid resource directory.
+  EXPECT_EQ(GetResourceDir("x86_64-apple-ios11.0", ios_sdk), tc_rdir);
+  std::string s = GetResourceDir("armv7k-apple-watchos4.0", ios_sdk);
+  EXPECT_NE(GetResourceDir("armv7k-apple-watchos4.0", ios_sdk), "");
+
+  // Custom toolchain.
+  toolchain = path::parent_path(
+      path::parent_path(path::parent_path(path::parent_path(abs_paths[7]))));
+  std::string custom_tc = path::parent_path(abs_paths[7]).str();
+  EXPECT_EQ(GetResourceDir("x86_64-apple-macosx", macosx_sdk), custom_tc);
+
+  // CLTools.
+  xcode_contents = "";
+  toolchain = "";
+  std::string cl_tools_rd = path::parent_path(abs_paths[8]).str();
+  EXPECT_EQ(GetResourceDir("x86_64-apple-macosx", macosx_sdk), cl_tools_rd);
+
+  // Local builds.
+  swift_dir = path::parent_path(abs_paths[9]);
+  EXPECT_EQ(GetResourceDir("x86_64-apple-macosx", macosx_sdk), swift_dir);
 }
 #endif

--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -18,7 +18,6 @@
 
 using namespace lldb;
 using namespace lldb_private;
-using namespace llvm::sys;
 
 #define ASSERT_NO_ERROR(x)                                                     \
   if (std::error_code ASSERT_NO_ERROR_ec = x) {                                \
@@ -32,24 +31,6 @@ using namespace llvm::sys;
   }
 
 struct TestSwiftASTContext : public testing::Test {
-  /// Unique temporary directory in which all created filesystem entities must
-  /// be placed. It is removed at the end of the test suite.
-  llvm::SmallString<128> m_base_dir;
-
-  void SetUp() override {
-    // Get the name of the current test. To prevent that by chance two tests
-    // get the same temporary directory if createUniqueDirectory fails.
-    auto test_info = ::testing::UnitTest::GetInstance()->current_test_info();
-    ASSERT_TRUE(test_info != nullptr);
-    std::string name = test_info->name();
-    ASSERT_NO_ERROR(
-        fs::createUniqueDirectory("SwiftASTCtx-" + name, m_base_dir));
-  }
-
-  void TearDown() override {
-    ASSERT_NO_ERROR(fs::remove_directories(m_base_dir));
-  }
-
   static void SetUpTestCase() {
     FileSystem::Initialize();
     HostInfo::Initialize();  }
@@ -69,132 +50,8 @@ struct SwiftASTContextTester : public SwiftASTContext {
     return m_typeref_typesystem;
   }
 
-  static std::string GetResourceDir(llvm::StringRef platform_sdk_path,
-                                    std::string swift_dir,
-                                    std::string swift_stdlib_os_dir,
-                                    std::string xcode_contents_path,
-                                    std::string toolchain_path,
-                                    std::string cl_tools_path) {
-    return SwiftASTContext::GetResourceDir(
-        platform_sdk_path, swift_dir, swift_stdlib_os_dir, xcode_contents_path,
-        toolchain_path, cl_tools_path);
-  }
-  static std::string GetSwiftStdlibOSDir(const llvm::Triple &target,
-                                         const llvm::Triple &host) {
-    return SwiftASTContext::GetSwiftStdlibOSDir(target, host);
-  }
   TypeSystemSwiftTypeRef m_typeref_typesystem;
 };
-
-TEST_F(TestSwiftASTContext, ResourceDir) {
-  const char *paths[] = {
-      // Toolchains.
-      "/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/"
-      "lib/swift/macosx",
-
-      "/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/"
-      "lib/swift/iphoneos",
-
-      "/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/"
-      "lib/swift/iphonesimulator",
-
-      // SDKs.
-      "/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/"
-      "MacOSX10.13.sdk/usr",
-
-      "/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/"
-      "SDKs/"
-      "iPhoneOS11.3.sdk/usr",
-
-      "/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/"
-      "Developer/SDKs/iPhoneSimulatorOS12.0.sdk/usr",
-
-      "/Xcode.app/Contents/Developer/Platforms/Linux.platform/Developer/SDKs/"
-      "Linux.sdk/usr/lib/swift/linux",
-
-      // Custom toolchains.
-      "/Xcode.app/Contents/Developer/Toolchains/"
-      "Swift-4.1-development-snapshot.xctoolchain/usr/lib/swift/macosx",
-
-      // CLTools.
-      "/Library/Developer/CommandLineTools/usr/lib/swift/macosx",
-
-      // Local builds.
-      "/build/LLDB.framework/Resources/Swift/clang",
-  };
-
-  using SmallString = llvm::SmallString<256>;
-  std::vector<std::string> abs_paths;
-  for (auto dir : paths) {
-    SmallString path = m_base_dir.str();
-    path::append(path, dir);
-    ASSERT_NO_ERROR(fs::create_directories(path));
-    abs_paths.push_back(std::string(path));
-  }
-
-  llvm::StringRef macosx_sdk = path::parent_path(abs_paths[3]);
-  llvm::StringRef ios_sdk = path::parent_path(abs_paths[4]);
-  llvm::StringRef iossim_sdk = path::parent_path(abs_paths[5]);
-  llvm::StringRef cross_sdk = path::parent_path(
-      path::parent_path(path::parent_path(path::parent_path(abs_paths[6]))));
-
-  SmallString swift_dir = m_base_dir.str();
-  path::append(swift_dir,
-      "/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Resources/Swift");
-  SmallString xcode_contents = m_base_dir.str();
-  path::append(xcode_contents, "/Xcode.app/Contents");
-  SmallString toolchain = m_base_dir.str();
-  path::append(toolchain, "/Xcode.app/Contents/Developer/Toolchains");
-  SmallString cl_tools = m_base_dir.str();
-  path::append(cl_tools, "/Library/Developer/CommandLineTools");
-
-  SmallString tc_rdir = m_base_dir.str();
-  llvm::sys::path::append(tc_rdir, "/Xcode.app/Contents/Developer/Toolchains/"
-                                   "XcodeDefault.xctoolchain/usr/lib/swift");
-
-  auto GetResourceDir = [&](const char *triple_string,
-                            llvm::StringRef sdk_path) {
-    llvm::Triple host("x86_64-apple-macosx10.14");
-    llvm::Triple target(triple_string);
-    return SwiftASTContextTester::GetResourceDir(
-        sdk_path,
-        SwiftASTContextTester::GetSwiftStdlibOSDir(target, host),
-        std::string(swift_dir), std::string(xcode_contents),
-        std::string(toolchain), std::string(cl_tools));
-  };
-
-  EXPECT_EQ(GetResourceDir("x86_64-apple-macosx10.14", macosx_sdk),
-            tc_rdir.str());
-  EXPECT_EQ(GetResourceDir("x86_64-apple-darwin", macosx_sdk), tc_rdir);
-  EXPECT_EQ(GetResourceDir("aarch64-apple-ios11.3", ios_sdk), tc_rdir);
-  // Old-style simulator triple with missing environment.
-  EXPECT_EQ(GetResourceDir("x86_64-apple-ios11.3", iossim_sdk), tc_rdir);
-  EXPECT_EQ(GetResourceDir("x86_64-apple-ios11.3-simulator", iossim_sdk),
-            tc_rdir);
-  EXPECT_EQ(GetResourceDir("x86_64-unknown-linux", cross_sdk),
-            path::parent_path(abs_paths[6]));
-
-  // Version is too low, but we still expect a valid resource directory.
-  EXPECT_EQ(GetResourceDir("x86_64-apple-ios11.0", ios_sdk), tc_rdir);
-  std::string s = GetResourceDir("armv7k-apple-watchos4.0", ios_sdk);
-  EXPECT_NE(GetResourceDir("armv7k-apple-watchos4.0", ios_sdk), "");
-
-  // Custom toolchain.
-  toolchain = path::parent_path(
-      path::parent_path(path::parent_path(path::parent_path(abs_paths[7]))));
-  std::string custom_tc = path::parent_path(abs_paths[7]).str();
-  EXPECT_EQ(GetResourceDir("x86_64-apple-macosx", macosx_sdk), custom_tc);
-
-  // CLTools.
-  xcode_contents = "";
-  toolchain = "";
-  std::string cl_tools_rd = path::parent_path(abs_paths[8]).str();
-  EXPECT_EQ(GetResourceDir("x86_64-apple-macosx", macosx_sdk), cl_tools_rd);
-
-  // Local builds.
-  swift_dir = path::parent_path(abs_paths[9]);
-  EXPECT_EQ(GetResourceDir("x86_64-apple-macosx", macosx_sdk), swift_dir);
-}
 
 TEST_F(TestSwiftASTContext, IsNonTriviallyManagedReferenceType) {
 #ifndef NDEBUG


### PR DESCRIPTION
This allows us to simplify and customize the implementations for
non-macOS hosts.