### PR TITLE
Disable regex REPL test. It passes on macOS Ventura

### DIFF
--- a/lldb/test/Shell/SwiftREPL/Regex.test
+++ b/lldb/test/Shell/SwiftREPL/Regex.test
@@ -1,6 +1,7 @@
 // Test that we can use Swift's regex functionalities on the REPL.
 // REQUIRES: swift
-// XFAIL: system-darwin
+// REQUIRES: macOSVentura
+// FIXME: add a mechanism to skip lit tests based on OS.
 // This is expected to fail on macOS for now because Regex has an availability of 9999 (for now).
 
 // RUN: %lldb --repl < %s | FileCheck %s


### PR DESCRIPTION
Disable regex REPL test. It passes on macOS Ventura and we currently don't have an equivalent of skipIf (os>) for LIT tests.