### PR TITLE
lldb: repair the build

### DIFF
--- a/lldb/source/Host/windows/HostInfoWindowsSwift.cpp
+++ b/lldb/source/Host/windows/HostInfoWindowsSwift.cpp
@@ -9,6 +9,7 @@
 #include "lldb/Host/Config.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
+#include "lldb/Host/common/HostInfoSwift.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
@@ -28,9 +29,9 @@ FileSpec HostInfoWindows::GetSwiftResourceDir() {
   static std::once_flag g_once_flag;
   static FileSpec g_swift_resource_dir;
   std::call_once(g_once_flag, []() {
-    FileSpec lldb_file_spec = HostInfoPosix::GetShlibDir();
-    HostInfoPosix::ComputeSwiftResourceDirectory(lldb_file_spec,
-                                                 g_swift_resource_dir, true);
+    FileSpec lldb_file_spec = HostInfoBase::GetShlibDir();
+    HostInfoWindows::ComputeSwiftResourceDirectory(lldb_file_spec,
+                                                   g_swift_resource_dir, true);
     Log *log = GetLog(LLDBLog::Host);
     LLDB_LOG(log, "swift dir -> '{0}'", g_swift_resource_dir);
   });


### PR DESCRIPTION
Correct the reference to some internal functions and add missing
include.  This should hopefully repair the windows build after #5182.