### PR TITLE
Replace eTypeIsGeneric, eTypeIsBound with eTypeHasUnboundGeneric (NFC)

### DIFF
--- a/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
+++ b/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
@@ -88411,6 +88411,12 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "eArgTypeColumnNum",SWIG_From_int(static_cast< int >(lldb::eArgTypeColumnNum)));
   SWIG_Python_SetConstant(d, "eArgTypeModuleUUID",SWIG_From_int(static_cast< int >(lldb::eArgTypeModuleUUID)));
   SWIG_Python_SetConstant(d, "eArgTypeSaveCoreStyle",SWIG_From_int(static_cast< int >(lldb::eArgTypeSaveCoreStyle)));
+  SWIG_Python_SetConstant(d, "eArgTypeLogHandler",SWIG_From_int(static_cast< int >(lldb::eArgTypeLogHandler)));
+  SWIG_Python_SetConstant(d, "eArgTypeSEDStylePair",SWIG_From_int(static_cast< int >(lldb::eArgTypeSEDStylePair)));
+  SWIG_Python_SetConstant(d, "eArgTypeRecognizerID",SWIG_From_int(static_cast< int >(lldb::eArgTypeRecognizerID)));
+  SWIG_Python_SetConstant(d, "eArgTypeConnectURL",SWIG_From_int(static_cast< int >(lldb::eArgTypeConnectURL)));
+  SWIG_Python_SetConstant(d, "eArgTypeTargetID",SWIG_From_int(static_cast< int >(lldb::eArgTypeTargetID)));
+  SWIG_Python_SetConstant(d, "eArgTypeStopHookID",SWIG_From_int(static_cast< int >(lldb::eArgTypeStopHookID)));
   SWIG_Python_SetConstant(d, "eArgTypeLastArg",SWIG_From_int(static_cast< int >(lldb::eArgTypeLastArg)));
   SWIG_Python_SetConstant(d, "eSymbolTypeAny",SWIG_From_int(static_cast< int >(lldb::eSymbolTypeAny)));
   SWIG_Python_SetConstant(d, "eSymbolTypeInvalid",SWIG_From_int(static_cast< int >(lldb::eSymbolTypeInvalid)));
@@ -88704,8 +88710,7 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "eTypeIsProtocol",SWIG_From_int(static_cast< int >(lldb::eTypeIsProtocol)));
   SWIG_Python_SetConstant(d, "eTypeIsTuple",SWIG_From_int(static_cast< int >(lldb::eTypeIsTuple)));
   SWIG_Python_SetConstant(d, "eTypeIsMetatype",SWIG_From_int(static_cast< int >(lldb::eTypeIsMetatype)));
-  SWIG_Python_SetConstant(d, "eTypeIsGeneric",SWIG_From_int(static_cast< int >(lldb::eTypeIsGeneric)));
-  SWIG_Python_SetConstant(d, "eTypeIsBound",SWIG_From_int(static_cast< int >(lldb::eTypeIsBound)));
+  SWIG_Python_SetConstant(d, "eTypeHasUnboundGeneric",SWIG_From_int(static_cast< int >(lldb::eTypeHasUnboundGeneric)));
   SWIG_Python_SetConstant(d, "eCommandRequiresTarget",SWIG_From_int(static_cast< int >(lldb::eCommandRequiresTarget)));
   SWIG_Python_SetConstant(d, "eCommandRequiresProcess",SWIG_From_int(static_cast< int >(lldb::eCommandRequiresProcess)));
   SWIG_Python_SetConstant(d, "eCommandRequiresThread",SWIG_From_int(static_cast< int >(lldb::eCommandRequiresThread)));

--- a/lldb/bindings/python/static-binding/lldb.py
+++ b/lldb/bindings/python/static-binding/lldb.py
@@ -940,6 +940,18 @@ eArgTypeModuleUUID = _lldb.eArgTypeModuleUUID
 
 eArgTypeSaveCoreStyle = _lldb.eArgTypeSaveCoreStyle
 
+eArgTypeLogHandler = _lldb.eArgTypeLogHandler
+
+eArgTypeSEDStylePair = _lldb.eArgTypeSEDStylePair
+
+eArgTypeRecognizerID = _lldb.eArgTypeRecognizerID
+
+eArgTypeConnectURL = _lldb.eArgTypeConnectURL
+
+eArgTypeTargetID = _lldb.eArgTypeTargetID
+
+eArgTypeStopHookID = _lldb.eArgTypeStopHookID
+
 eArgTypeLastArg = _lldb.eArgTypeLastArg
 
 eSymbolTypeAny = _lldb.eSymbolTypeAny
@@ -1526,9 +1538,7 @@ eTypeIsTuple = _lldb.eTypeIsTuple
 
 eTypeIsMetatype = _lldb.eTypeIsMetatype
 
-eTypeIsGeneric = _lldb.eTypeIsGeneric
-
-eTypeIsBound = _lldb.eTypeIsBound
+eTypeHasUnboundGeneric = _lldb.eTypeHasUnboundGeneric
 
 eCommandRequiresTarget = _lldb.eCommandRequiresTarget
 

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -1066,8 +1066,7 @@ FLAGS_ENUM(TypeFlags){
     eTypeIsProtocol = (1u << 25),
     eTypeIsTuple = (1u << 26),
     eTypeIsMetatype = (1u << 27),
-    eTypeIsGeneric = (1u << 28),
-    eTypeIsBound = (1u << 29)};
+    eTypeHasUnboundGeneric = (1u << 28)};
 
 FLAGS_ENUM(CommandFlags){
     /// eCommandRequiresTarget

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -134,7 +134,7 @@ lldb::Format TypeSystemSwift::GetFormat(opaque_compiler_type_t type) {
   if (swift_flags & eTypeIsClass)
     return eFormatHex;
 
-  if (swift_flags & eTypeIsGeneric)
+  if (swift_flags & eTypeIsGenericTypeParam)
     return eFormatUnsigned;
 
   if (swift_flags & eTypeIsFuncPrototype || swift_flags & eTypeIsBlock)

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -247,8 +247,17 @@ TEST_F(TestTypeSystemSwiftTypeRef, GetTypeInfo) {
                                          b.NodeWithIndex(Node::Kind::Index,
                                                          0)))))))));
     CompilerType p = GetCompilerType(b.Mangle(n));
-    ASSERT_EQ(p.GetTypeInfo(), (eTypeIsEnumeration | eTypeIsSwift |
-                                eTypeIsGeneric | eTypeIsBound));
+    ASSERT_EQ(p.GetTypeInfo(),
+              (eTypeIsEnumeration | eTypeIsSwift | eTypeHasUnboundGeneric));
+  }
+  {
+    NodePointer n = b.GlobalType(b.Node(Node::Kind::DependentGenericParamType,
+                                        b.NodeWithIndex(Node::Kind::Index, 0),
+                                        b.NodeWithIndex(Node::Kind::Index, 0)));
+    CompilerType p = GetCompilerType(b.Mangle(n));
+    ASSERT_EQ(p.GetTypeInfo(),
+              (eTypeHasValue | eTypeIsPointer | eTypeIsScalar | eTypeIsSwift |
+               eTypeIsGenericTypeParam | eTypeHasUnboundGeneric));
   }
 }
 


### PR DESCRIPTION
This is meant to make the type info more useful and consistent. The
main reason for clients to as about the generic-ness of a type is to
check whether the type contains unbound generics.