### PR TITLE
Don't attempt to bind non-generic types. (NFC)

### DIFF
--- a/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
+++ b/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
@@ -88411,6 +88411,12 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "eArgTypeColumnNum",SWIG_From_int(static_cast< int >(lldb::eArgTypeColumnNum)));
   SWIG_Python_SetConstant(d, "eArgTypeModuleUUID",SWIG_From_int(static_cast< int >(lldb::eArgTypeModuleUUID)));
   SWIG_Python_SetConstant(d, "eArgTypeSaveCoreStyle",SWIG_From_int(static_cast< int >(lldb::eArgTypeSaveCoreStyle)));
+  SWIG_Python_SetConstant(d, "eArgTypeLogHandler",SWIG_From_int(static_cast< int >(lldb::eArgTypeLogHandler)));
+  SWIG_Python_SetConstant(d, "eArgTypeSEDStylePair",SWIG_From_int(static_cast< int >(lldb::eArgTypeSEDStylePair)));
+  SWIG_Python_SetConstant(d, "eArgTypeRecognizerID",SWIG_From_int(static_cast< int >(lldb::eArgTypeRecognizerID)));
+  SWIG_Python_SetConstant(d, "eArgTypeConnectURL",SWIG_From_int(static_cast< int >(lldb::eArgTypeConnectURL)));
+  SWIG_Python_SetConstant(d, "eArgTypeTargetID",SWIG_From_int(static_cast< int >(lldb::eArgTypeTargetID)));
+  SWIG_Python_SetConstant(d, "eArgTypeStopHookID",SWIG_From_int(static_cast< int >(lldb::eArgTypeStopHookID)));
   SWIG_Python_SetConstant(d, "eArgTypeLastArg",SWIG_From_int(static_cast< int >(lldb::eArgTypeLastArg)));
   SWIG_Python_SetConstant(d, "eSymbolTypeAny",SWIG_From_int(static_cast< int >(lldb::eSymbolTypeAny)));
   SWIG_Python_SetConstant(d, "eSymbolTypeInvalid",SWIG_From_int(static_cast< int >(lldb::eSymbolTypeInvalid)));
@@ -88704,8 +88710,7 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "eTypeIsProtocol",SWIG_From_int(static_cast< int >(lldb::eTypeIsProtocol)));
   SWIG_Python_SetConstant(d, "eTypeIsTuple",SWIG_From_int(static_cast< int >(lldb::eTypeIsTuple)));
   SWIG_Python_SetConstant(d, "eTypeIsMetatype",SWIG_From_int(static_cast< int >(lldb::eTypeIsMetatype)));
-  SWIG_Python_SetConstant(d, "eTypeIsGeneric",SWIG_From_int(static_cast< int >(lldb::eTypeIsGeneric)));
-  SWIG_Python_SetConstant(d, "eTypeIsBound",SWIG_From_int(static_cast< int >(lldb::eTypeIsBound)));
+  SWIG_Python_SetConstant(d, "eTypeHasUnboundGeneric",SWIG_From_int(static_cast< int >(lldb::eTypeHasUnboundGeneric)));
   SWIG_Python_SetConstant(d, "eCommandRequiresTarget",SWIG_From_int(static_cast< int >(lldb::eCommandRequiresTarget)));
   SWIG_Python_SetConstant(d, "eCommandRequiresProcess",SWIG_From_int(static_cast< int >(lldb::eCommandRequiresProcess)));
   SWIG_Python_SetConstant(d, "eCommandRequiresThread",SWIG_From_int(static_cast< int >(lldb::eCommandRequiresThread)));

--- a/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
+++ b/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
@@ -88711,6 +88711,7 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "eTypeIsTuple",SWIG_From_int(static_cast< int >(lldb::eTypeIsTuple)));
   SWIG_Python_SetConstant(d, "eTypeIsMetatype",SWIG_From_int(static_cast< int >(lldb::eTypeIsMetatype)));
   SWIG_Python_SetConstant(d, "eTypeHasUnboundGeneric",SWIG_From_int(static_cast< int >(lldb::eTypeHasUnboundGeneric)));
+  SWIG_Python_SetConstant(d, "eTypeHasDynamicSelf",SWIG_From_int(static_cast< int >(lldb::eTypeHasDynamicSelf)));
   SWIG_Python_SetConstant(d, "eCommandRequiresTarget",SWIG_From_int(static_cast< int >(lldb::eCommandRequiresTarget)));
   SWIG_Python_SetConstant(d, "eCommandRequiresProcess",SWIG_From_int(static_cast< int >(lldb::eCommandRequiresProcess)));
   SWIG_Python_SetConstant(d, "eCommandRequiresThread",SWIG_From_int(static_cast< int >(lldb::eCommandRequiresThread)));

--- a/lldb/bindings/python/static-binding/lldb.py
+++ b/lldb/bindings/python/static-binding/lldb.py
@@ -940,6 +940,18 @@ eArgTypeModuleUUID = _lldb.eArgTypeModuleUUID
 
 eArgTypeSaveCoreStyle = _lldb.eArgTypeSaveCoreStyle
 
+eArgTypeLogHandler = _lldb.eArgTypeLogHandler
+
+eArgTypeSEDStylePair = _lldb.eArgTypeSEDStylePair
+
+eArgTypeRecognizerID = _lldb.eArgTypeRecognizerID
+
+eArgTypeConnectURL = _lldb.eArgTypeConnectURL
+
+eArgTypeTargetID = _lldb.eArgTypeTargetID
+
+eArgTypeStopHookID = _lldb.eArgTypeStopHookID
+
 eArgTypeLastArg = _lldb.eArgTypeLastArg
 
 eSymbolTypeAny = _lldb.eSymbolTypeAny
@@ -1526,9 +1538,7 @@ eTypeIsTuple = _lldb.eTypeIsTuple
 
 eTypeIsMetatype = _lldb.eTypeIsMetatype
 
-eTypeIsGeneric = _lldb.eTypeIsGeneric
-
-eTypeIsBound = _lldb.eTypeIsBound
+eTypeHasUnboundGeneric = _lldb.eTypeHasUnboundGeneric
 
 eCommandRequiresTarget = _lldb.eCommandRequiresTarget
 

--- a/lldb/bindings/python/static-binding/lldb.py
+++ b/lldb/bindings/python/static-binding/lldb.py
@@ -1540,6 +1540,8 @@ eTypeIsMetatype = _lldb.eTypeIsMetatype
 
 eTypeHasUnboundGeneric = _lldb.eTypeHasUnboundGeneric
 
+eTypeHasDynamicSelf = _lldb.eTypeHasDynamicSelf
+
 eCommandRequiresTarget = _lldb.eCommandRequiresTarget
 
 eCommandRequiresProcess = _lldb.eCommandRequiresProcess

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -1066,8 +1066,7 @@ FLAGS_ENUM(TypeFlags){
     eTypeIsProtocol = (1u << 25),
     eTypeIsTuple = (1u << 26),
     eTypeIsMetatype = (1u << 27),
-    eTypeIsGeneric = (1u << 28),
-    eTypeIsBound = (1u << 29)};
+    eTypeHasUnboundGeneric = (1u << 28)};
 
 FLAGS_ENUM(CommandFlags){
     /// eCommandRequiresTarget

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -1066,7 +1066,8 @@ FLAGS_ENUM(TypeFlags){
     eTypeIsProtocol = (1u << 25),
     eTypeIsTuple = (1u << 26),
     eTypeIsMetatype = (1u << 27),
-    eTypeHasUnboundGeneric = (1u << 28)};
+    eTypeHasUnboundGeneric = (1u << 28),
+    eTypeHasDynamicSelf = (1u << 29)};
 
 FLAGS_ENUM(CommandFlags){
     /// eCommandRequiresTarget

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2258,8 +2258,9 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Value(
     Address &address) {
   class_type_or_name.SetCompilerType(bound_type);
 
-  llvm::Optional<uint64_t> size = bound_type.GetByteSize(
-      in_value.GetExecutionContextRef().GetFrameSP().get());
+  ExecutionContext exe_ctx = in_value.GetExecutionContextRef().Lock(true);
+  llvm::Optional<uint64_t> size =
+      bound_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
   if (!size)
     return false;
   lldb::addr_t val_address = in_value.GetAddressOf(true, nullptr);
@@ -2625,14 +2626,19 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress(
     success = GetDynamicTypeAndAddress_Protocol(in_value, val_type, use_dynamic,
                                                 class_type_or_name, address);
   else {
-    // Perform generic type resolution.
-    StackFrameSP frame = in_value.GetExecutionContextRef().GetFrameSP();
-    if (!frame)
-      return false;
+    CompilerType bound_type;
+    if (type_info.AnySet(eTypeHasUnboundGeneric | eTypeHasDynamicSelf)) {
+      // Perform generic type resolution.
+      StackFrameSP frame = in_value.GetExecutionContextRef().GetFrameSP();
+      if (!frame)
+        return false;
 
-    CompilerType bound_type = BindGenericTypeParameters(*frame.get(), val_type);
-    if (!bound_type)
-      return false;
+      bound_type = BindGenericTypeParameters(*frame.get(), val_type);
+      if (!bound_type)
+        return false;
+    } else {
+      bound_type = val_type;
+    }
 
     Flags subst_type_info(bound_type.GetTypeInfo());
     if (subst_type_info.AnySet(eTypeIsClass)) {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5182,6 +5182,9 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
   const swift::TypeKind type_kind = swift_can_type->getKind();
   uint32_t swift_flags = eTypeIsSwift;
+  if (swift_can_type->hasUnboundGenericType() ||
+      swift_can_type->hasTypeParameter())
+    swift_flags |= eTypeHasUnboundGeneric;
   switch (type_kind) {
   case swift::TypeKind::BuiltinDefaultActorStorage:
   case swift::TypeKind::BuiltinExecutor:
@@ -5211,12 +5214,9 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
     assert(false && "Internal compiler type");
     break;
   case swift::TypeKind::UnboundGeneric:
-    swift_flags |= eTypeIsGeneric;
     break;
 
   case swift::TypeKind::GenericFunction:
-    swift_flags |= eTypeIsGeneric;
-    LLVM_FALLTHROUGH;
   case swift::TypeKind::Function:
     swift_flags |= eTypeIsPointer | eTypeHasValue;
     break;
@@ -5260,7 +5260,6 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
                        .GetTypeInfo(pointee_or_element_clang_type);
     break;
   case swift::TypeKind::BoundGenericEnum:
-    swift_flags |= eTypeIsGeneric | eTypeIsBound;
     LLVM_FALLTHROUGH;
   case swift::TypeKind::Enum: {
     SwiftEnumDescriptor *cached_enum_info = GetCachedEnumInfo(type);
@@ -5271,7 +5270,6 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
   } break;
 
   case swift::TypeKind::BoundGenericStruct:
-    swift_flags |= eTypeIsGeneric | eTypeIsBound;
     LLVM_FALLTHROUGH;
   case swift::TypeKind::Struct:
     if (auto *ndecl = swift_can_type.getAnyNominal())
@@ -5284,7 +5282,6 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
     break;
 
   case swift::TypeKind::BoundGenericClass:
-    swift_flags |= eTypeIsGeneric | eTypeIsBound;
     LLVM_FALLTHROUGH;
   case swift::TypeKind::Class:
     swift_flags |= eTypeHasChildren | eTypeIsClass | eTypeHasValue |
@@ -5313,7 +5310,7 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
     swift_flags |= eTypeHasChildren | eTypeIsReference | eTypeHasValue;
     break;
   case swift::TypeKind::DynamicSelf:
-    swift_flags |= eTypeIsGeneric | eTypeIsBound | eTypeHasValue;
+    swift_flags |= eTypeHasValue;
     break;
 
   case swift::TypeKind::Optional:

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5185,6 +5185,8 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
   if (swift_can_type->hasUnboundGenericType() ||
       swift_can_type->hasTypeParameter())
     swift_flags |= eTypeHasUnboundGeneric;
+  if (swift_can_type->hasDynamicSelfType())
+    swift_flags |= eTypeHasDynamicSelf;
   switch (type_kind) {
   case swift::TypeKind::BuiltinDefaultActorStorage:
   case swift::TypeKind::BuiltinExecutor:

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -134,7 +134,7 @@ lldb::Format TypeSystemSwift::GetFormat(opaque_compiler_type_t type) {
   if (swift_flags & eTypeIsClass)
     return eFormatHex;
 
-  if (swift_flags & eTypeIsGeneric)
+  if (swift_flags & eTypeIsGenericTypeParam)
     return eFormatUnsigned;
 
   if (swift_flags & eTypeIsFuncPrototype || swift_flags & eTypeIsBlock)

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -247,8 +247,17 @@ TEST_F(TestTypeSystemSwiftTypeRef, GetTypeInfo) {
                                          b.NodeWithIndex(Node::Kind::Index,
                                                          0)))))))));
     CompilerType p = GetCompilerType(b.Mangle(n));
-    ASSERT_EQ(p.GetTypeInfo(), (eTypeIsEnumeration | eTypeIsSwift |
-                                eTypeIsGeneric | eTypeIsBound));
+    ASSERT_EQ(p.GetTypeInfo(),
+              (eTypeIsEnumeration | eTypeIsSwift | eTypeHasUnboundGeneric));
+  }
+  {
+    NodePointer n = b.GlobalType(b.Node(Node::Kind::DependentGenericParamType,
+                                        b.NodeWithIndex(Node::Kind::Index, 0),
+                                        b.NodeWithIndex(Node::Kind::Index, 0)));
+    CompilerType p = GetCompilerType(b.Mangle(n));
+    ASSERT_EQ(p.GetTypeInfo(),
+              (eTypeHasValue | eTypeIsPointer | eTypeIsScalar | eTypeIsSwift |
+               eTypeIsGenericTypeParam | eTypeHasUnboundGeneric));
   }
 }
 

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -251,13 +251,20 @@ TEST_F(TestTypeSystemSwiftTypeRef, GetTypeInfo) {
               (eTypeIsEnumeration | eTypeIsSwift | eTypeHasUnboundGeneric));
   }
   {
-    NodePointer n = b.GlobalType(b.Node(Node::Kind::DependentGenericParamType,
-                                        b.NodeWithIndex(Node::Kind::Index, 0),
-                                        b.NodeWithIndex(Node::Kind::Index, 0)));
+    NodePointer n = b.GlobalType(
+        b.Node(Node::Kind::Tuple,
+               b.Node(Node::Kind::TupleElement,
+                      b.Node(Node::Kind::TupleElementName, "self"), 
+                                 b.Node(Node::Kind::DynamicSelf,
+                                        b.Node(Node::Kind::Type,
+                                        b.Node(Node::Kind::Class,
+                               b.Node(Node::Kind::Module, "a"),
+                               b.Node(Node::Kind::Identifier,
+                                      "Child")))))));
+
     CompilerType p = GetCompilerType(b.Mangle(n));
-    ASSERT_EQ(p.GetTypeInfo(),
-              (eTypeHasValue | eTypeIsPointer | eTypeIsScalar | eTypeIsSwift |
-               eTypeIsGenericTypeParam | eTypeHasUnboundGeneric));
+    ASSERT_EQ(p.GetTypeInfo(), (eTypeHasChildren | eTypeIsSwift | eTypeIsTuple |
+                                eTypeHasDynamicSelf));
   }
 }
 


### PR DESCRIPTION
Don't attempt to bind non-generic types. (NFC)

This is a minor performance improvement and theoretically allows get
the dynamic type of an object without having a valid stack frame.

rdar://95389942