### PR TITLE
[CAS] Fix new-delete-type-mismatch in HashMappedTrie

### DIFF
--- a/llvm/lib/CAS/HashMappedTrie.cpp
+++ b/llvm/lib/CAS/HashMappedTrie.cpp
@@ -23,6 +23,9 @@ struct TrieNode {
   const bool IsSubtrie = false;
 
   TrieNode(bool IsSubtrie) : IsSubtrie(IsSubtrie) {}
+
+  static void *operator new(size_t Size) { return ::malloc(Size); }
+  void operator delete(void *Ptr) { ::free(Ptr); }
 };
 
 struct TrieContent final : public TrieNode {
@@ -115,7 +118,7 @@ static size_t getTrieTailSize(size_t StartBit, size_t NumBits) {
 std::unique_ptr<TrieSubtrie> TrieSubtrie::create(size_t StartBit,
                                                  size_t NumBits) {
   size_t Size = sizeof(TrieSubtrie) + getTrieTailSize(StartBit, NumBits);
-  void *Memory = ::operator new(Size);
+  void *Memory = ::malloc(Size);
   TrieSubtrie *S = ::new (Memory) TrieSubtrie(StartBit, NumBits);
   return std::unique_ptr<TrieSubtrie>(S);
 }
@@ -155,9 +158,12 @@ TrieSubtrie *TrieSubtrie::sink(
 struct ThreadSafeHashMappedTrieBase::ImplType {
   static ImplType *create(size_t StartBit, size_t NumBits) {
     size_t Size = sizeof(ImplType) + getTrieTailSize(StartBit, NumBits);
-    void *Memory = ::operator new(Size);
+    void *Memory = ::malloc(Size);
     return ::new (Memory) ImplType(StartBit, NumBits);
   }
+
+  static void *operator new(size_t Size) { return ::malloc(Size); }
+  void operator delete(void *Ptr) { ::free(Ptr); }
 
   TrieSubtrie *save(std::unique_ptr<TrieSubtrie> S) {
     assert(!S->Next && "Expected S to a freshly-constructed leaf");


### PR DESCRIPTION
Proper fix the asan error when allocating SubTries as the fix in
rdar://98413686 introduced a different error.

rdar://99106259