### PR TITLE
[clang][cas] ScanAndUpdateArgs: Keep the preprocessor option macros for the include-tree

### DIFF
--- a/clang/test/CAS/cmd-macro-and-pch.c
+++ b/clang/test/CAS/cmd-macro-and-pch.c
@@ -1,0 +1,20 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// Normal compilation for baseline.
+// RUN: %clang_cc1 -x c-header %t/prefix.h -DSOME_MACRO=1 -emit-pch -o %t/prefix1.pch -Werror
+// RUN: %clang_cc1 %t/t1.c -include-pch %t/prefix1.pch -DSOME_MACRO=1 -fsyntax-only -Werror
+
+// RUN: %clang -cc1depscan -o %t/pch.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
+// RUN:     -cc1 -x c-header %t/prefix.h -emit-pch -DSOME_MACRO=1 -fcas-path %t/cas -Werror
+// RUN: %clang @%t/pch.rsp -emit-pch -o %t/prefix2.pch
+
+// RUN: %clang -cc1depscan -o %t/tu.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
+// RUN:     -cc1 %t/t1.c -include-pch %t/prefix2.pch -DSOME_MACRO=1 -fcas-path %t/cas -Werror
+// RUN: %clang @%t/tu.rsp -fsyntax-only
+
+//--- t1.c
+
+//--- prefix.h
+#undef SOME_MACRO
+#define SOME_MACRO 0


### PR DESCRIPTION
Even though the macros are written in the predefines buffer which is saved in the include-tree root,
we still need to keep them as preprocessor options so that they are preserved in a PCH file and
compared with the preprocessor options of another invocation that uses the PCH.