### PR TITLE
[depscand] Fix clang depscand that can leak on linux

### DIFF
--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -1083,7 +1083,9 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
     ShutDown.store(true);
   }
 
-  return 0;
+  // Exit instead of return. Otherwise, it will wait on ~ThreadPool() which will
+  // never return since all threads might still be sleeping on ::accept().
+  ::exit(0);
 }
 
 static Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(


### PR DESCRIPTION
On Linux, clang-depscand can be leaked because it is waiting on the
destructor of ThreadPool before return. Use `exit()` directly.