### PR TITLE
[clang][cas] Fix tests not using cas-related paths correctly

### DIFF
--- a/clang/lib/CAS/CASOptions.cpp
+++ b/clang/lib/CAS/CASOptions.cpp
@@ -83,7 +83,7 @@ createCache(ObjectStore &CAS, const CASConfiguration &Config,
     return llvm::cas::createInMemoryActionCache(CAS);
 
   // Compute the path.
-  std::string Path = Config.CASPath;
+  std::string Path = Config.CachePath;
   if (Path == "auto")
     Path = getDefaultOnDiskActionCachePath();
 

--- a/clang/test/CAS/daemon-cwd.c
+++ b/clang/test/CAS/daemon-cwd.c
@@ -4,7 +4,7 @@
 
 // RUN: rm -rf %t && mkdir -p %t/include
 // RUN: cp %S/Inputs/test.h %t/include
-// RUN: %clang -cc1depscand -start %{clang-daemon-dir}/daemon-cwd -fcas-path %t/cas -faction-cache-path %t/cache
+// RUN: %clang -cc1depscand -start %{clang-daemon-dir}/daemon-cwd -cas-args -fcas-path %t/cas -faction-cache-path %t/cache
 // RUN: (cd %t && %clang -target x86_64-apple-macos11 -fdepscan=daemon    \
 // RUN:    -fdepscan-prefix-map=%S=/^source                               \
 // RUN:    -fdepscan-prefix-map=%t=/^build                                \

--- a/clang/test/CAS/depscan-include-tree-daemon.c
+++ b/clang/test/CAS/depscan-include-tree-daemon.c
@@ -5,7 +5,7 @@
 // RUN: %clang -cc1depscan -o %t/inline.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args -cc1 -triple x86_64-apple-macos11.0 \
 // RUN:     -fsyntax-only %t/t.c -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -DSOME_MACRO -dependency-file %t/inline.d -MT deps
 
-// RUN: %clang -cc1depscand -start %{clang-daemon-dir}/depscan-include-tree-daemon -fcas-path %t/cas -faction-cache-path %t/cache
+// RUN: %clang -cc1depscand -start %{clang-daemon-dir}/depscan-include-tree-daemon -cas-args -fcas-path %t/cas -faction-cache-path %t/cache
 // RUN: %clang -cc1depscan -o %t/daemon.rsp -fdepscan=daemon -fdepscan-include-tree -cc1-args -cc1 -triple x86_64-apple-macos11.0 \
 // RUN:     -fsyntax-only %t/t.c -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -DSOME_MACRO -dependency-file %t/daemon.d -MT deps
 // RUN: %clang -cc1depscand -shutdown %{clang-daemon-dir}/depscan-include-tree-daemon

--- a/clang/test/CAS/fdepscan-daemon.c
+++ b/clang/test/CAS/fdepscan-daemon.c
@@ -2,7 +2,8 @@
 //
 // REQUIRES: system-darwin, clang-cc1daemon
 
-// RUN: %clang -cc1depscand -start %{clang-daemon-dir}/fdepscan-daemon -fcas-path %t/cas -faction-cache-path %t/cache
+// RUN: rm -rf %t
+// RUN: %clang -cc1depscand -start %{clang-daemon-dir}/fdepscan-daemon -cas-args -fcas-path %t/cas -faction-cache-path %t/cache
 // RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs \
 // RUN:   -fdepscan=daemon -fdepscan-daemon=%{clang-daemon-dir}/fdepscan-daemon -fsyntax-only -x c %s
 // RUN: %clang -cc1depscand -shutdown %{clang-daemon-dir}/fdepscan-daemon


### PR DESCRIPTION
Tests using cc1depscand directly need to pass -cas-args to delineate the
start of cas-related arguments, like cc1depscanProtocol does already.
This was causing tests to use the default CAS location, which could
cause failures during development.

We were also incorrectly using CASPath instead of CachePath when
creating the ActionCache.