### PR TITLE
[cas] Remove vestiges of action cache from OnDiskCAS and InMemoryCAS

### DIFF
--- a/llvm/lib/CAS/BuiltinCAS.h
+++ b/llvm/lib/CAS/BuiltinCAS.h
@@ -120,9 +120,8 @@ inline ArrayRef<char> toArrayRef(StringRef Data) {
 /// clear if we always (or ever) need the full 32B, and for an ephemeral
 /// in-memory CAS, we almost certainly don't need it.
 ///
-/// Note that the cost is linear in the number of objects for the builtin CAS
-/// and embedded action cache, since we're using internal offsets and/or
-/// pointers as an optimization.
+/// Note that the cost is linear in the number of objects for the builtin CAS,
+/// since we're using internal offsets and/or pointers as an optimization.
 ///
 /// However, it's possible we'll want to hook up a local builtin CAS to, e.g.,
 /// a distributed generic hash map to use as an ActionCache. In that scenario,

--- a/llvm/lib/CAS/InMemoryCAS.cpp
+++ b/llvm/lib/CAS/InMemoryCAS.cpp
@@ -39,11 +39,6 @@ using InMemoryStringPoolT =
     ThreadSafeHashMappedTrie<LazyAtomicPointer<const InMemoryString>,
                              sizeof(HashType)>;
 
-/// Action cache type (map: Hash -> InMemoryObject*). Always refers to existing
-/// objects.
-using InMemoryCacheT =
-    ThreadSafeHashMappedTrie<const InMemoryIndexValueT *, sizeof(HashType)>;
-
 class InMemoryObject {
 public:
   enum class Kind {
@@ -309,9 +304,6 @@ private:
   /// String pool for trees.
   InMemoryStringPoolT StringPool;
 
-  /// Action cache (map: Hash -> InMemoryObject*).
-  InMemoryCacheT ActionCache;
-
   ThreadSafeAllocator<BumpPtrAllocator> Objects;
   ThreadSafeAllocator<BumpPtrAllocator> Strings;
   ThreadSafeAllocator<SpecificBumpPtrAllocator<sys::fs::mapped_file_region>>
@@ -337,8 +329,6 @@ void InMemoryCAS::print(raw_ostream &OS) const {
   Index.print(OS);
   OS << "strings: ";
   StringPool.print(OS);
-  OS << "action-cache: ";
-  ActionCache.print(OS);
 }
 
 Expected<ObjectRef>


### PR DESCRIPTION
The ActionCache APIs were removed, but the hash maps for the builtin
action cache were still being setup.