### PR TITLE
[clang][deps][cas] Sink CASFileSystemRootID into DependencyScanningAction NFC

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -206,17 +206,19 @@ public:
     ContextHash = std::move(Hash);
   }
 
+  void handleCASFileSystemRootID(cas::CASID ID) override {
+    CASFileSystemRootID = ID;
+  }
+
   std::string lookupModuleOutput(const ModuleID &ID,
                                  ModuleOutputKind Kind) override {
     return LookupModuleOutput(ID, Kind);
   }
 
   FullDependenciesResult getFullDependenciesLegacyDriverCommand(
-      const std::vector<std::string> &OriginalCommandLine,
-      Optional<cas::CASID> CASFileSystemRootID = None) const;
+      const std::vector<std::string> &OriginalCommandLine) const;
 
-  FullDependenciesResult takeFullDependencies(
-      Optional<cas::CASID> CASFileSystemRootID = None);
+  FullDependenciesResult takeFullDependencies();
 
 private:
   std::vector<std::string> Dependencies;
@@ -225,6 +227,7 @@ private:
       ClangModuleDeps;
   std::vector<Command> Commands;
   std::string ContextHash;
+  Optional<cas::CASID> CASFileSystemRootID;
   std::vector<std::string> OutputPaths;
   const llvm::StringSet<> &AlreadySeen;
   LookupModuleOutputCallback LookupModuleOutput;

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -42,6 +42,9 @@ struct Command {
   std::vector<std::string> Arguments;
 };
 
+using RemapPathCallback =
+    llvm::function_ref<StringRef(const llvm::vfs::CachedDirectoryEntry &)>;
+
 class DependencyConsumer {
 public:
   virtual ~DependencyConsumer() {}
@@ -60,6 +63,8 @@ public:
   virtual void handleModuleDependency(ModuleDeps MD) = 0;
 
   virtual void handleContextHash(std::string Hash) = 0;
+
+  virtual void handleCASFileSystemRootID(cas::CASID ID) = 0;
 
   virtual std::string lookupModuleOutput(const ModuleID &ID,
                                          ModuleOutputKind Kind) = 0;
@@ -91,6 +96,9 @@ protected:
     llvm::report_fatal_error("unexpected callback for include-tree");
   }
   void handleContextHash(std::string Hash) override {
+    llvm::report_fatal_error("unexpected callback for include-tree");
+  }
+  void handleCASFileSystemRootID(cas::CASID ID) override {
     llvm::report_fatal_error("unexpected callback for include-tree");
   }
   std::string lookupModuleOutput(const ModuleID &, ModuleOutputKind) override {
@@ -129,8 +137,8 @@ public:
   void computeDependenciesFromCompilerInvocation(
       std::shared_ptr<CompilerInvocation> Invocation,
       StringRef WorkingDirectory, DependencyConsumer &Consumer,
-      DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
-      bool DiagGenerationAsCompilation);
+      RemapPathCallback RemapPath, DiagnosticConsumer &DiagsConsumer,
+      raw_ostream *VerboseOS, bool DiagGenerationAsCompilation);
 
   ScanningOutputFormat getScanningFormat() const { return Format; }
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/Tooling/DependencyScanning/DependencyScanningWorker.h"
+#include "clang/Basic/DiagnosticCAS.h"
 #include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/CodeGen/ObjectFilePCHContainerOperations.h"
 #include "clang/Driver/Compilation.h"
@@ -204,15 +205,18 @@ public:
       StringRef WorkingDirectory, DependencyConsumer &Consumer,
       llvm::IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS,
       llvm::IntrusiveRefCntPtr<DependencyScanningCASFilesystem> DepCASFS,
+      llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> CacheFS,
       ScanningOutputFormat Format, bool OptimizeArgs, bool EagerLoadModules,
       bool DisableFree, bool EmitDependencyFile,
       bool DiagGenerationAsCompilation, const CASOptions &CASOpts,
-      bool OverrideCASTokenCache, llvm::Optional<StringRef> ModuleName = None,
+      RemapPathCallback RemapPath, bool OverrideCASTokenCache,
+      llvm::Optional<StringRef> ModuleName = None,
       raw_ostream *VerboseOS = nullptr)
       : WorkingDirectory(WorkingDirectory), Consumer(Consumer),
-        DepFS(std::move(DepFS)), DepCASFS(std::move(DepCASFS)), Format(Format),
-        OptimizeArgs(OptimizeArgs), EagerLoadModules(EagerLoadModules),
-        DisableFree(DisableFree), CASOpts(CASOpts),
+        DepFS(std::move(DepFS)), DepCASFS(std::move(DepCASFS)),
+        CacheFS(std::move(CacheFS)), Format(Format), OptimizeArgs(OptimizeArgs),
+        EagerLoadModules(EagerLoadModules), DisableFree(DisableFree),
+        CASOpts(CASOpts), RemapPath(RemapPath),
         OverrideCASTokenCache(OverrideCASTokenCache),
         EmitDependencyFile(EmitDependencyFile),
         DiagGenerationAsCompilation(DiagGenerationAsCompilation),
@@ -234,6 +238,11 @@ public:
       // FIXME: to support multi-arch builds, each arch requires a separate scan
       setLastCC1Arguments(std::move(OriginalInvocation));
       return true;
+    }
+
+    if (CacheFS) {
+      CacheFS->trackNewAccesses();
+      CacheFS->setCurrentWorkingDirectory(WorkingDirectory);
     }
 
     Scanned = true;
@@ -372,6 +381,15 @@ public:
     if (!getDepScanFS())
       FileMgr->clearStatCache();
 
+    if (CacheFS) {
+      auto Tree = CacheFS->createTreeFromNewAccesses(RemapPath);
+      if (Tree)
+        Consumer.handleCASFileSystemRootID(Tree->getID());
+      else
+        ScanInstance.getDiagnostics().Report(diag::err_cas_depscan_failed)
+            << Tree.takeError();
+    }
+
     if (Result)
       setLastCC1Arguments(std::move(OriginalInvocation));
 
@@ -413,11 +431,13 @@ private:
   DependencyConsumer &Consumer;
   llvm::IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS;
   llvm::IntrusiveRefCntPtr<DependencyScanningCASFilesystem> DepCASFS;
+  llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> CacheFS;
   ScanningOutputFormat Format;
   bool OptimizeArgs;
   bool EagerLoadModules;
   bool DisableFree;
   const CASOptions &CASOpts;
+  RemapPathCallback RemapPath;
   bool OverrideCASTokenCache;
   bool EmitDependencyFile = false;
   bool DiagGenerationAsCompilation;
@@ -562,12 +582,14 @@ llvm::Error DependencyScanningWorker::computeDependencies(
         // in-process; preserve the original value, which is
         // always true for a driver invocation.
         bool DisableFree = true;
-        DependencyScanningAction Action(WorkingDirectory, Consumer, DepFS, DepCASFS,
+        DependencyScanningAction Action(WorkingDirectory, Consumer, DepFS,
+                                        DepCASFS, CacheFS,
                                         Format, OptimizeArgs, EagerLoadModules,
                                         DisableFree,
                                         /*EmitDependencyFile=*/false,
                                         /*DiagGenerationAsCompilation=*/false,
-                                        getCASOpts(), OverrideCASTokenCache,
+                                        getCASOpts(), /*RemapPath=*/nullptr,
+                                        OverrideCASTokenCache,
                                         ModuleName);
         bool Success = forEachDriverJob(
             FinalCommandLine, *Diags, *CurrentFiles,
@@ -613,8 +635,9 @@ llvm::Error DependencyScanningWorker::computeDependencies(
 
 void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
     std::shared_ptr<CompilerInvocation> Invocation, StringRef WorkingDirectory,
-    DependencyConsumer &DepsConsumer, DiagnosticConsumer &DiagsConsumer,
-    raw_ostream *VerboseOS, bool DiagGenerationAsCompilation) {
+    DependencyConsumer &DepsConsumer, RemapPathCallback RemapPath,
+    DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
+    bool DiagGenerationAsCompilation) {
   RealFS->setCurrentWorkingDirectory(WorkingDirectory);
 
   // Adjust the invocation.
@@ -641,10 +664,10 @@ void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
   // FIXME: EmitDependencyFile should only be set when it's for a real
   // compilation.
   DependencyScanningAction Action(
-      WorkingDirectory, DepsConsumer, DepFS, DepCASFS, Format,
+      WorkingDirectory, DepsConsumer, DepFS, DepCASFS, CacheFS, Format,
       /*OptimizeArgs=*/false, /*DisableFree=*/false, EagerLoadModules,
       /*EmitDependencyFile=*/!DepFile.empty(), DiagGenerationAsCompilation,
-      getCASOpts(), OverrideCASTokenCache,
+      getCASOpts(), RemapPath, OverrideCASTokenCache,
       /*ModuleName=*/None, VerboseOS);
 
   // Ignore result; we're just collecting dependencies.


### PR DESCRIPTION
Move the computation of CASFileSystemRootID into
DependencyScanningAction. This is in preparation for applying caching to
invocations during full dependency scanning, e.g. for modules. After
https://reviews.llvm.org/D132405 the invocation is determined inside the
scanner, so we need the root id at that point.