### PR TITLE
[clang][cas] Create node schema for comilation cache result

### DIFF
--- a/clang/include/clang/Frontend/CompileJobCacheResult.h
+++ b/clang/include/clang/Frontend/CompileJobCacheResult.h
@@ -1,0 +1,112 @@
+//===- CompileJobCacheResult.h ----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_FRONTEND_COMPILEJOBCACHERESULT_H
+#define LLVM_CLANG_FRONTEND_COMPILEJOBCACHERESULT_H
+
+#include "clang/Basic/LLVM.h"
+#include "llvm/CAS/CASNodeSchema.h"
+#include "llvm/CAS/ObjectStore.h"
+
+namespace clang {
+namespace cas {
+class CompileJobResultSchema;
+
+class CompileJobCacheResult : public ObjectProxy {
+public:
+  /// Categorization for the output kinds that is used to decouple the
+  /// compilation cache key from the specific output paths.
+  enum class OutputKind : char {
+    MainOutput, ///< Main output file, e.g. object file, pcm file, etc.
+    SerializedDiagnostics,
+    Dependencies,
+    Stderr, ///< Contents of stderr.
+  };
+
+  /// Returns all \c OutputKind values.
+  static ArrayRef<OutputKind> getAllOutputKinds();
+
+  /// A single output file or stream.
+  struct Output {
+    /// The CAS object for this output.
+    ObjectRef Object;
+    /// The output kind.
+    OutputKind Kind;
+
+    bool operator==(const Output &Other) const {
+      return Object == Other.Object && Kind == Other.Kind;
+    }
+  };
+
+  /// Retrieves each \c Output from this result.
+  llvm::Error
+  forEachOutput(llvm::function_ref<llvm::Error(Output)> Callback) const;
+
+  size_t getNumOutputs() const;
+
+  /// Print this result to \p OS.
+  llvm::Error print(llvm::raw_ostream &OS);
+
+  /// Helper to build a \c CompileJobCacheResult from individual outputs.
+  class Builder {
+  public:
+    Builder();
+    ~Builder();
+    /// Treat outputs added for \p Path as having the given \p Kind. Otherwise
+    /// they will have kind \c Unknown.
+    void addKindMap(OutputKind Kind, StringRef Path);
+    /// Add an output with an explicit \p Kind.
+    void addOutput(OutputKind Kind, ObjectRef Object);
+    /// Add an output for the given \p Path. There must be a a kind map for it.
+    llvm::Error addOutput(StringRef Path, ObjectRef Object);
+    /// Build a single \c ObjectRef representing the provided outputs. The
+    /// result can be used with \c CompileJobResultSchema to retrieve the
+    /// original outputs.
+    Expected<ObjectRef> build(ObjectStore &CAS);
+
+  private:
+    struct PrivateImpl;
+    PrivateImpl &Impl;
+  };
+
+private:
+  ObjectRef getOutputObject(size_t I) const;
+  ObjectRef getPathsListRef() const;
+  OutputKind getOutputKind(size_t I) const;
+  Expected<ObjectRef> getOutputPath(size_t I) const;
+
+private:
+  friend class CompileJobResultSchema;
+  CompileJobCacheResult(const ObjectProxy &);
+};
+
+class CompileJobResultSchema
+    : public llvm::RTTIExtends<CompileJobResultSchema, llvm::cas::NodeSchema> {
+public:
+  static char ID;
+
+  CompileJobResultSchema(ObjectStore &CAS);
+
+  /// Attempt to load \p Ref as a \c CompileJobCacheResult if it matches the
+  /// schema.
+  Expected<CompileJobCacheResult> load(ObjectRef Ref) const;
+
+  bool isRootNode(const ObjectProxy &Node) const final;
+  bool isNode(const ObjectProxy &Node) const final;
+
+  /// Get this schema's marker node.
+  ObjectRef getKindRef() const { return KindRef; }
+
+private:
+  ObjectRef KindRef;
+};
+
+} // namespace cas
+} // namespace clang
+
+#endif // LLVM_CLANG_FRONTEND_COMPILEJOBCACHERESULT_H

--- a/clang/lib/Frontend/CMakeLists.txt
+++ b/clang/lib/Frontend/CMakeLists.txt
@@ -17,6 +17,7 @@ add_clang_library(clangFrontend
   ChainedDiagnosticConsumer.cpp
   ChainedIncludesSource.cpp
   CompileJobCacheKey.cpp
+  CompileJobCacheResult.cpp
   CompilerInstance.cpp
   CompilerInvocation.cpp
   CreateInvocationFromCommandLine.cpp

--- a/clang/lib/Frontend/CompileJobCacheResult.cpp
+++ b/clang/lib/Frontend/CompileJobCacheResult.cpp
@@ -1,0 +1,151 @@
+//===- CompileJobCacheResult.cpp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Frontend/CompileJobCacheResult.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace clang;
+using namespace clang::cas;
+using namespace llvm::cas;
+using llvm::Error;
+
+ArrayRef<CompileJobCacheResult::OutputKind>
+CompileJobCacheResult::getAllOutputKinds() {
+  static const OutputKind OutputKinds[] = {
+      OutputKind::MainOutput, OutputKind::SerializedDiagnostics,
+      OutputKind::Dependencies, OutputKind::Stderr};
+  return llvm::makeArrayRef(OutputKinds);
+}
+
+Error CompileJobCacheResult::forEachOutput(
+    llvm::function_ref<Error(Output)> Callback) const {
+  size_t Count = getNumOutputs();
+  for (size_t I = 0; I < Count; ++I) {
+    OutputKind Kind = getOutputKind(I);
+    ObjectRef Object = getOutputObject(I);
+    if (auto Err = Callback({Object, Kind}))
+      return Err;
+  }
+  return Error::success();
+}
+
+static void printOutputKind(llvm::raw_ostream &OS,
+                            CompileJobCacheResult::OutputKind Kind) {
+  switch (Kind) {
+  case CompileJobCacheResult::OutputKind::MainOutput:
+    OS << "main   ";
+    break;
+  case CompileJobCacheResult::OutputKind::Dependencies:
+    OS << "deps   ";
+    break;
+  case CompileJobCacheResult::OutputKind::SerializedDiagnostics:
+    OS << "diags  ";
+    break;
+  case CompileJobCacheResult::OutputKind::Stderr:
+    OS << "stderr ";
+    break;
+  }
+}
+
+Error CompileJobCacheResult::print(llvm::raw_ostream &OS) {
+  return forEachOutput([&](Output O) -> Error {
+    printOutputKind(OS, O.Kind);
+    OS << ' ' << getCAS().getID(O.Object) << '\n';
+    return Error::success();
+  });
+}
+
+size_t CompileJobCacheResult::getNumOutputs() const { return getData().size(); }
+ObjectRef CompileJobCacheResult::getOutputObject(size_t I) const {
+  return getReference(I);
+}
+CompileJobCacheResult::OutputKind
+CompileJobCacheResult::getOutputKind(size_t I) const {
+  return static_cast<OutputKind>(getData()[I]);
+}
+
+CompileJobCacheResult::CompileJobCacheResult(const ObjectProxy &Obj)
+    : ObjectProxy(Obj) {}
+
+struct CompileJobCacheResult::Builder::PrivateImpl {
+  SmallVector<ObjectRef> Objects;
+  SmallVector<OutputKind> Kinds;
+
+  struct KindMap {
+    OutputKind Kind;
+    std::string Path;
+  };
+  SmallVector<KindMap> KindMaps;
+};
+
+CompileJobCacheResult::Builder::Builder() : Impl(*new PrivateImpl) {}
+CompileJobCacheResult::Builder::~Builder() { delete &Impl; }
+
+void CompileJobCacheResult::Builder::addKindMap(OutputKind Kind,
+                                                StringRef Path) {
+  Impl.KindMaps.push_back({Kind, std::string(Path)});
+}
+void CompileJobCacheResult::Builder::addOutput(OutputKind Kind,
+                                               ObjectRef Object) {
+  Impl.Kinds.push_back(Kind);
+  Impl.Objects.push_back(Object);
+}
+Error CompileJobCacheResult::Builder::addOutput(StringRef Path,
+                                                ObjectRef Object) {
+  Impl.Objects.push_back(Object);
+  for (auto &KM : Impl.KindMaps) {
+    if (KM.Path == Path) {
+      Impl.Kinds.push_back(KM.Kind);
+      return Error::success();
+    }
+  }
+  return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                 "cached output file has unknown path '" +
+                                     Path + "'");
+}
+
+Expected<ObjectRef> CompileJobCacheResult::Builder::build(ObjectStore &CAS) {
+  CompileJobResultSchema Schema(CAS);
+  // The resulting Refs contents are:
+  // Object 0...N, SchemaKind
+  SmallVector<ObjectRef> Refs;
+  std::swap(Impl.Objects, Refs);
+  Refs.push_back(Schema.getKindRef());
+  return CAS.store(Refs, {(char *)Impl.Kinds.begin(), Impl.Kinds.size()});
+}
+
+static constexpr llvm::StringLiteral CompileJobResultSchemaName =
+    "llvm::cas::schema::compile_job_result::v1";
+
+char CompileJobResultSchema::ID = 0;
+
+CompileJobResultSchema::CompileJobResultSchema(ObjectStore &CAS)
+    : CompileJobResultSchema::RTTIExtends(CAS),
+      KindRef(
+          llvm::cantFail(CAS.storeFromString({}, CompileJobResultSchemaName))) {
+}
+
+Expected<CompileJobCacheResult>
+CompileJobResultSchema::load(ObjectRef Ref) const {
+  auto Proxy = CAS.getProxy(Ref);
+  if (!Proxy)
+    return Proxy.takeError();
+  if (!isNode(*Proxy))
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "not a compile job result");
+  return CompileJobCacheResult(*Proxy);
+}
+
+bool CompileJobResultSchema::isRootNode(const ObjectProxy &Node) const {
+  return isNode(Node);
+}
+
+bool CompileJobResultSchema::isNode(const ObjectProxy &Node) const {
+  size_t N = Node.getNumReferences();
+  return N && Node.getReference(N - 1) == getKindRef();
+}

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -23,6 +23,7 @@
 #include "clang/Tooling/DependencyScanning/ModuleDepCollector.h"
 #include "clang/Tooling/Tooling.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
+#include "llvm/CAS/ObjectStore.h"
 #include "llvm/Support/Host.h"
 
 using namespace clang;

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -23,6 +23,7 @@
 #include "clang/Frontend/CASDependencyCollector.h"
 #include "clang/Frontend/ChainedDiagnosticConsumer.h"
 #include "clang/Frontend/CompileJobCacheKey.h"
+#include "clang/Frontend/CompileJobCacheResult.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/CompilerInvocation.h"
 #include "clang/Frontend/FrontendDiagnostic.h"
@@ -239,24 +240,7 @@ namespace {
 //     handled.
 class CompileJobCache {
 public:
-  /// Categorization for the output kinds that is used to decouple the
-  /// compilation cache key from the specific output paths.
-  enum class OutputKind {
-    MainOutput,
-    SerializedDiagnostics,
-    Dependencies,
-  };
-  static ArrayRef<OutputKind> getAllOutputKinds() {
-    static const OutputKind AllOutputKinds[] = {
-        OutputKind::MainOutput, OutputKind::SerializedDiagnostics,
-        OutputKind::Dependencies};
-    return llvm::makeArrayRef(AllOutputKinds);
-  }
-
-  static StringRef getOutputKindName(OutputKind Kind);
-
-  /// \returns \p None if \p Name doesn't match one of the output kind names.
-  static Optional<OutputKind> getOutputKindForName(StringRef Name);
+  using OutputKind = cas::CompileJobCacheResult::OutputKind;
 
   StringRef getPathForOutputKind(OutputKind Kind);
 
@@ -297,6 +281,7 @@ private:
   std::unique_ptr<llvm::raw_ostream> ResultDiagsOS;
   SmallString<256> SerialDiagsBuf;
   IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> CASOutputs;
+  cas::CompileJobCacheResult::Builder CachedResultBuilder;
   std::string OutputFile;
   std::string SerialDiagsFile;
   std::string DependenciesFile;
@@ -306,32 +291,6 @@ private:
 };
 } // end anonymous namespace
 
-static constexpr llvm::StringLiteral MainOutputKindName = "<output>";
-static constexpr llvm::StringLiteral SerializedDiagnosticsKindName =
-    "<serial-diags>";
-static constexpr llvm::StringLiteral DependenciesOutputKindName =
-    "<dependencies>";
-
-StringRef CompileJobCache::getOutputKindName(OutputKind Kind) {
-  switch (Kind) {
-  case OutputKind::MainOutput:
-    return MainOutputKindName;
-  case OutputKind::SerializedDiagnostics:
-    return SerializedDiagnosticsKindName;
-  case OutputKind::Dependencies:
-    return DependenciesOutputKindName;
-  }
-}
-
-Optional<CompileJobCache::OutputKind>
-CompileJobCache::getOutputKindForName(StringRef Name) {
-  return llvm::StringSwitch<Optional<OutputKind>>(Name)
-      .Case(MainOutputKindName, OutputKind::MainOutput)
-      .Case(SerializedDiagnosticsKindName, OutputKind::SerializedDiagnostics)
-      .Case(DependenciesOutputKindName, OutputKind::Dependencies)
-      .Default(None);
-}
-
 StringRef CompileJobCache::getPathForOutputKind(OutputKind Kind) {
   switch (Kind) {
   case OutputKind::MainOutput:
@@ -340,6 +299,8 @@ StringRef CompileJobCache::getPathForOutputKind(OutputKind Kind) {
     return SerialDiagsFile;
   case OutputKind::Dependencies:
     return DependenciesFile;
+  default:
+    return "";
   }
 }
 
@@ -475,17 +436,19 @@ Optional<int> CompileJobCache::tryReplayCachedResult(CompilerInstance &Clang) {
 
   // Set up the output backend so we can save / cache the result after.
   CASOutputs = llvm::makeIntrusiveRefCnt<llvm::cas::CASOutputBackend>(*CAS);
-  for (OutputKind K : getAllOutputKinds()) {
+  for (OutputKind K : cas::CompileJobCacheResult::getAllOutputKinds()) {
     StringRef OutPath = getPathForOutputKind(K);
     if (!OutPath.empty())
-      CASOutputs->addKindMap(getOutputKindName(K), OutPath);
+      CachedResultBuilder.addKindMap(K, OutPath);
   }
 
-  // When use CAS backend, filter out the output object file.
+  // When use CAS backend, filter out the output object file. Always filter out
+  // the dependencies file, since we build a CAS-specific object for it.
   auto FilterBackend = llvm::vfs::makeFilteringOutputBackend(
       CASOutputs,
       [&](StringRef Path, Optional<llvm::vfs::OutputConfig> Config) {
-        return !(UseCASBackend && Path.equals(OutputFile));
+        return !(UseCASBackend && Path.equals(OutputFile)) &&
+               Path != DependenciesFile;
       });
 
   Clang.setOutputBackend(llvm::vfs::makeMirroringOutputBackend(
@@ -592,10 +555,8 @@ void CompileJobCache::finishComputedResult(CompilerInstance &Clang,
   // Add the MC output to the CAS Outputs.
   if (MCOutputID) {
     auto MCOutputRef = CAS->getReference(*MCOutputID);
-    if (MCOutputRef) {
-      if (auto E = CASOutputs->addObject(OutputFile, *MCOutputRef))
-        llvm::report_fatal_error(std::move(E));
-    }
+    if (MCOutputRef)
+      CachedResultBuilder.addOutput(OutputKind::MainOutput, *MCOutputRef);
   }
 
   if (!SerialDiagsOutput) {
@@ -607,42 +568,38 @@ void CompileJobCache::finishComputedResult(CompilerInstance &Clang,
     // FIXME: Stop calling report_fatal_error().
     if (!SerialDiags)
       llvm::report_fatal_error(SerialDiags.takeError());
-    if (Error E = CASOutputs->addObject(
-            getOutputKindName(OutputKind::SerializedDiagnostics),
-            SerialDiags->getRef()))
-      llvm::report_fatal_error(std::move(E));
+    CachedResultBuilder.addOutput(OutputKind::SerializedDiagnostics,
+                                  SerialDiags->getRef());
   }
 
   if (DependenciesOutput)
-    if (auto E = CASOutputs->addObject(
-            getOutputKindName(OutputKind::Dependencies), *DependenciesOutput))
-      llvm::report_fatal_error(std::move(E));
+    CachedResultBuilder.addOutput(OutputKind::Dependencies,
+                                  *DependenciesOutput);
 
-  Expected<llvm::cas::ObjectProxy> Outputs = CASOutputs->getCASProxy();
-  if (!Outputs)
-    llvm::report_fatal_error(Outputs.takeError());
+  auto BackendOutputs = CASOutputs->takeOutputs();
+  for (auto &Output : BackendOutputs)
+    if (auto Err = CachedResultBuilder.addOutput(Output.Path, Output.Object))
+      llvm::report_fatal_error(std::move(Err));
 
   // Hack around llvm::errs() not being captured by the output backend yet.
   //
   // FIXME: Stop calling report_fatal_error().
-  Expected<llvm::cas::ObjectProxy> Errs = CAS->createProxy(None, ResultDiags);
+  Expected<llvm::cas::ObjectRef> Errs = CAS->storeFromString(None, ResultDiags);
   if (!Errs)
     llvm::report_fatal_error(Errs.takeError());
+  CachedResultBuilder.addOutput(OutputKind::Stderr, *Errs);
 
   // Cache the result.
   //
   // FIXME: Stop calling report_fatal_error().
-  llvm::cas::HierarchicalTreeBuilder Builder;
-  Builder.push(Outputs->getRef(), llvm::cas::TreeEntry::Regular, "outputs");
-  Builder.push(Errs->getRef(), llvm::cas::TreeEntry::Regular, "stderr");
-  Expected<llvm::cas::ObjectProxy> Result = Builder.create(*CAS);
+  Expected<cas::ObjectRef> Result = CachedResultBuilder.build(*CAS);
   if (!Result)
     llvm::report_fatal_error(Result.takeError());
-  if (llvm::Error E = Cache->put(*ResultCacheKey, Result->getRef()))
+  if (llvm::Error E = Cache->put(*ResultCacheKey, *Result))
     llvm::report_fatal_error(std::move(E));
 
   // Replay / decanonicalize as necessary.
-  Optional<int> Status = replayCachedResult(Clang, Result->getRef(),
+  Optional<int> Status = replayCachedResult(Clang, *Result,
                                             /*JustComputedResult=*/true);
   (void)Status;
   assert(Status == None);
@@ -668,101 +625,82 @@ Optional<int> CompileJobCache::replayCachedResult(CompilerInstance &Clang,
   }
 
   // FIXME: Stop calling report_fatal_error().
-  Optional<llvm::cas::TreeProxy> Result;
-  llvm::cas::TreeSchema Schema(*CAS);
+  Optional<cas::CompileJobCacheResult> Result;
+  cas::CompileJobResultSchema Schema(*CAS);
   if (Error E = Schema.load(ResultID).moveInto(Result))
     llvm::report_fatal_error(std::move(E));
 
-  // Replay diagnostics to stderr.
-  if (!JustComputedResult) {
-    Optional<llvm::cas::ObjectProxy> Errs;
-    if (Optional<llvm::cas::NamedTreeEntry> Entry = Result->lookup("stderr"))
-      if (Error E = CAS->getProxy(Entry->getRef()).moveInto(Errs))
-        llvm::report_fatal_error(std::move(E));
-    if (!Errs)
-      llvm::report_fatal_error("CAS error accessing stderr");
-    llvm::errs() << Errs->getData();
-  }
+  auto Err = Result->forEachOutput([&](cas::CompileJobCacheResult::Output O)
+                                       -> Error {
+    if (O.Kind == OutputKind::Stderr) {
+      Optional<llvm::cas::ObjectProxy> Errs;
+      if (Error E = CAS->getProxy(O.Object).moveInto(Errs))
+        return E;
+      llvm::errs() << Errs->getData();
+      return Error::success(); // continue
+    }
 
-  // Replay outputs.
-  //
-  // FIXME: Use a NodeReader here once it exists.
-  Optional<llvm::cas::ObjectProxy> Outputs;
-  if (Optional<llvm::cas::NamedTreeEntry> Entry = Result->lookup("outputs"))
-    if (Error E = CAS->getProxy(Entry->getRef()).moveInto(Outputs))
-      llvm::report_fatal_error(std::move(E));
-  if (!Outputs)
-    llvm::report_fatal_error("CAS error accessing outputs");
-
-  for (size_t I = 0, E = Outputs->getNumReferences(); I + 1 < E; I += 2) {
-    llvm::cas::CASID PathID = Outputs->getReferenceID(I);
-    cas::ObjectRef BytesRef = Outputs->getReference(I + 1);
-    llvm::cas::CASID BytesID = Outputs->getReferenceID(I + 1);
-
-    Optional<llvm::cas::ObjectProxy> PathProxy;
-    if (Error E = CAS->getProxy(PathID).moveInto(PathProxy))
-      llvm::report_fatal_error(std::move(E));
-
-    Optional<OutputKind> OutKind = getOutputKindForName(PathProxy->getData());
-    StringRef Path =
-        OutKind ? getPathForOutputKind(*OutKind) : PathProxy->getData();
-    if (Path.empty()) {
+    std::string Path = std::string(getPathForOutputKind(O.Kind));
+    if (Path.empty())
       // The output may be always generated but not needed with this invocation,
       // like the serialized diagnostics file.
-      continue;
-    }
-    bool IsOutputFile = OutKind && (*OutKind == OutputKind::MainOutput);
+      return Error::success(); // continue
+
+    bool IsOutputFile = O.Kind == OutputKind::MainOutput;
 
     Optional<StringRef> Contents;
     SmallString<50> ContentsStorage;
     if (IsOutputFile && ComputedJobNeedsReplay) {
       llvm::raw_svector_ostream OS(ContentsStorage);
       if (WriteOutputAsCASID)
-        llvm::cas::writeCASIDBuffer(BytesID, OS);
+        llvm::cas::writeCASIDBuffer(CAS->getID(O.Object), OS);
       else if (UseCASBackend) {
         // Replay by write out object file.
         // When the environmental variable is set, save the backend CASID for
         // analysis later.
         if (llvm::sys::Process::GetEnv("CLANG_CAS_BACKEND_SAVE_CASID_FILE")) {
-          std::string CASIDPath = Path.str() + ".casid";
+          std::string CASIDPath = Path + ".casid";
           std::error_code EC;
           llvm::raw_fd_ostream IDOS(CASIDPath, EC);
           if (EC)
-            report_fatal_error(llvm::errorCodeToError(EC));
-          writeCASIDBuffer(BytesID, IDOS);
+            return llvm::errorCodeToError(EC);
+          writeCASIDBuffer(CAS->getID(O.Object), IDOS);
         }
         Optional<llvm::cas::ObjectProxy> CASObj;
-        if (Error E = CAS->getProxy(BytesID).moveInto(CASObj))
-          llvm::report_fatal_error(std::move(E));
+        if (Error E = CAS->getProxy(O.Object).moveInto(CASObj))
+          return E;
         auto Schema =
             std::make_unique<llvm::mccasformats::v1::MCSchema>(*CAS);
         if (auto E = Schema->serializeObjectFile(*CASObj, OS))
-          report_fatal_error(std::move(E));
+          return E;
       }
       Contents = ContentsStorage;
     } else if (JustComputedResult) {
-      continue;
-    } else if (OutKind == OutputKind::Dependencies) {
+      return Error::success(); // continue
+    } else if (O.Kind == OutputKind::Dependencies) {
       llvm::raw_svector_ostream OS(ContentsStorage);
       if (auto E = CASDependencyCollector::replay(
-              Clang.getDependencyOutputOpts(), *CAS, BytesRef, OS))
-        llvm::report_fatal_error(std::move(E));
+              Clang.getDependencyOutputOpts(), *CAS, O.Object, OS))
+        return E;
       Contents = ContentsStorage;
     } else {
       Optional<llvm::cas::ObjectProxy> Bytes;
-      if (Error E = CAS->getProxy(BytesID).moveInto(Bytes))
-        llvm::report_fatal_error(std::move(E));
+      if (Error E = CAS->getProxy(O.Object).moveInto(Bytes))
+        return E;
       Contents = Bytes->getData();
     }
 
     std::unique_ptr<llvm::FileOutputBuffer> Output;
     if (Error E = llvm::FileOutputBuffer::create(Path, Contents->size())
                       .moveInto(Output))
-      llvm::report_fatal_error(std::move(E));
+      return E;
     llvm::copy(*Contents, Output->getBufferStart());
-    if (llvm::Error E = Output->commit())
-      llvm::report_fatal_error(std::move(E));
-  }
+    return Output->commit();
+  });
+
+  // FIXME: Stop calling report_fatal_error().
+  if (Err)
+    llvm::report_fatal_error(std::move(Err));
 
   if (JustComputedResult)
     return None;

--- a/clang/unittests/Frontend/CMakeLists.txt
+++ b/clang/unittests/Frontend/CMakeLists.txt
@@ -1,9 +1,11 @@
 set(LLVM_LINK_COMPONENTS
   Support
+  TestingSupport
   )
 
 add_clang_unittest(FrontendTests
   ASTUnitTest.cpp
+  CompileJobCacheResultTest.cpp
   CompilerInvocationTest.cpp
   CompilerInstanceTest.cpp
   FixedPointString.cpp

--- a/clang/unittests/Frontend/CompileJobCacheResultTest.cpp
+++ b/clang/unittests/Frontend/CompileJobCacheResultTest.cpp
@@ -1,0 +1,105 @@
+//===- unittests/Frontend/CompileJobCacheResultTest.cpp - CI tests //------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Frontend/CompileJobCacheResult.h"
+#include "llvm/Testing/Support/Error.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using namespace clang;
+using namespace clang::cas;
+using namespace llvm::cas;
+using llvm::Succeeded;
+using Output = CompileJobCacheResult::Output;
+using OutputKind = CompileJobCacheResult::OutputKind;
+
+std::vector<Output> getAllOutputs(CompileJobCacheResult Result) {
+  std::vector<Output> Outputs;
+  llvm::cantFail(Result.forEachOutput([&](Output O) {
+    Outputs.push_back(O);
+    return llvm::Error::success();
+  }));
+  return Outputs;
+}
+
+TEST(CompileJobCacheResultTest, Empty) {
+  std::unique_ptr<ObjectStore> CAS = createInMemoryCAS();
+  CompileJobCacheResult::Builder B;
+  Optional<ObjectRef> Result;
+  ASSERT_THAT_ERROR(B.build(*CAS).moveInto(Result), Succeeded());
+
+  Optional<CompileJobCacheResult> Proxy;
+  CompileJobResultSchema Schema(*CAS);
+  ASSERT_THAT_ERROR(Schema.load(*Result).moveInto(Proxy), Succeeded());
+
+  EXPECT_EQ(Proxy->getNumOutputs(), 0u);
+}
+
+TEST(CompileJobCacheResultTest, AddOutputs) {
+  std::unique_ptr<ObjectStore> CAS = createInMemoryCAS();
+
+  auto Obj1 = llvm::cantFail(CAS->storeFromString({}, "obj1"));
+  auto Obj2 = llvm::cantFail(CAS->storeFromString({}, "obj2"));
+  auto Obj3 = llvm::cantFail(CAS->storeFromString({}, "err"));
+
+  std::vector<Output> Expected = {
+      Output{Obj1, OutputKind::MainOutput},
+      Output{Obj2, OutputKind::Dependencies},
+      Output{Obj3, OutputKind::Stderr},
+  };
+
+  CompileJobCacheResult::Builder B;
+  for (const auto &Output : Expected)
+    B.addOutput(Output.Kind, Output.Object);
+
+  Optional<ObjectRef> Result;
+  ASSERT_THAT_ERROR(B.build(*CAS).moveInto(Result), Succeeded());
+
+  Optional<CompileJobCacheResult> Proxy;
+  CompileJobResultSchema Schema(*CAS);
+  ASSERT_THAT_ERROR(Schema.load(*Result).moveInto(Proxy), Succeeded());
+
+  EXPECT_EQ(Proxy->getNumOutputs(), 3u);
+  auto Actual = getAllOutputs(*Proxy);
+
+  EXPECT_EQ(Actual, Expected);
+}
+
+TEST(CompileJobCacheResultTest, AddKindMap) {
+  std::unique_ptr<ObjectStore> CAS = createInMemoryCAS();
+
+  auto Obj1 = llvm::cantFail(CAS->storeFromString({}, "obj1"));
+  auto Obj2 = llvm::cantFail(CAS->storeFromString({}, "obj2"));
+  auto Obj3 = llvm::cantFail(CAS->storeFromString({}, "err"));
+
+  std::vector<Output> Expected = {
+      Output{Obj1, OutputKind::MainOutput},
+      Output{Obj2, OutputKind::Dependencies},
+  };
+
+  CompileJobCacheResult::Builder B;
+  B.addKindMap(OutputKind::MainOutput, "/main");
+  B.addKindMap(OutputKind::Dependencies, "/deps");
+  ASSERT_THAT_ERROR(B.addOutput("/main", Obj1), Succeeded());
+  ASSERT_THAT_ERROR(B.addOutput("/deps", Obj2), Succeeded());
+
+  EXPECT_THAT_ERROR(B.addOutput("/other", Obj3), llvm::Failed());
+
+  Optional<ObjectRef> Result;
+  ASSERT_THAT_ERROR(B.build(*CAS).moveInto(Result), Succeeded());
+
+  Optional<CompileJobCacheResult> Proxy;
+  CompileJobResultSchema Schema(*CAS);
+  ASSERT_THAT_ERROR(Schema.load(*Result).moveInto(Proxy), Succeeded());
+
+  EXPECT_EQ(Proxy->getNumOutputs(), 2u);
+  auto Actual = getAllOutputs(*Proxy);
+
+  EXPECT_EQ(Actual, Expected);
+}

--- a/llvm/lib/CAS/CASOutputBackend.cpp
+++ b/llvm/lib/CAS/CASOutputBackend.cpp
@@ -46,35 +46,9 @@ CASOutputBackend::CASOutputBackend(ObjectStore &CAS) : CAS(CAS) {}
 
 CASOutputBackend::~CASOutputBackend() = default;
 
-struct CASOutputBackend::PrivateImpl {
-  // FIXME: Use a NodeBuilder here once it exists.
-  SmallVector<ObjectRef> Refs;
-  BumpPtrAllocator Alloc;
-  StringSaver Saver{Alloc};
-
-  struct KindMap {
-    StringRef Kind;
-    StringRef Path;
-  };
-  SmallVector<KindMap> KindMaps;
-
-  /// Returns the "kind" name for the path if one was added for it, otherwise
-  /// returns the \p Path itself.
-  StringRef tryRemapPath(StringRef Path) const {
-    for (const KindMap &Map : KindMaps) {
-      if (Map.Path == Path)
-        return Map.Kind;
-    }
-    return Path;
-  }
-};
-
 Expected<std::unique_ptr<vfs::OutputFileImpl>>
 CASOutputBackend::createFileImpl(StringRef ResolvedPath,
                                  Optional<vfs::OutputConfig> Config) {
-  if (!Impl)
-    Impl = std::make_unique<PrivateImpl>();
-
   // FIXME: CASIDOutputBackend.createFile() should be called NOW (not inside
   // the OnKeep closure) so that if there are initialization errors (such as
   // output directory not existing) they're reported by createFileImpl().
@@ -82,50 +56,11 @@ CASOutputBackend::createFileImpl(StringRef ResolvedPath,
   // The opened file can be kept inside \a CASOutputFile and forwarded.
   return std::make_unique<CASOutputFile>(
       ResolvedPath, [&](StringRef Path, StringRef Bytes) -> Error {
-        StringRef Name = Impl->tryRemapPath(Path);
-        Optional<ObjectProxy> NameBlob;
-        Optional<ObjectProxy> BytesBlob;
-        if (Error E = CAS.createProxy(None, Name).moveInto(NameBlob))
+        Optional<ObjectRef> BytesRef;
+        if (Error E = CAS.storeFromString(None, Bytes).moveInto(BytesRef))
           return E;
-        if (Error E = CAS.createProxy(None, Bytes).moveInto(BytesBlob))
-          return E;
-
-        // FIXME: Should there be a lock taken before accessing PrivateImpl?
-        Impl->Refs.push_back(NameBlob->getRef());
-        Impl->Refs.push_back(BytesBlob->getRef());
+        // FIXME: Should there be a lock taken before modifying Outputs?
+        Outputs.push_back({std::string(Path), *BytesRef});
         return Error::success();
       });
-}
-
-Expected<ObjectProxy> CASOutputBackend::getCASProxy() {
-  // FIXME: Should there be a lock taken before accessing PrivateImpl?
-  if (!Impl)
-    return CAS.createProxy(None, "");
-
-  SmallVector<ObjectRef> MovedRefs;
-  std::swap(MovedRefs, Impl->Refs);
-
-  return CAS.createProxy(MovedRefs, "");
-}
-
-Error CASOutputBackend::addObject(StringRef Name, ObjectRef Object) {
-  if (!Impl)
-    Impl = std::make_unique<PrivateImpl>();
-
-  Name = Impl->tryRemapPath(Name);
-  Optional<ObjectProxy> NameBlob;
-  if (Error E = CAS.createProxy(None, Name).moveInto(NameBlob))
-    return E;
-
-  Impl->Refs.push_back(NameBlob->getRef());
-  Impl->Refs.push_back(Object);
-  return Error::success();
-}
-
-void CASOutputBackend::addKindMap(StringRef Kind, StringRef Path) {
-  if (!Impl)
-    Impl = std::make_unique<PrivateImpl>();
-
-  StringSaver &SA = Impl->Saver;
-  Impl->KindMaps.push_back({SA.save(Kind), SA.save(Path)});
 }

--- a/llvm/unittests/CAS/CASOutputBackendTest.cpp
+++ b/llvm/unittests/CAS/CASOutputBackendTest.cpp
@@ -32,56 +32,42 @@ TEST(CASOutputBackendTest, createFiles) {
 
   Optional<ObjectProxy> Content1;
   Optional<ObjectProxy> Content2;
-  Optional<ObjectProxy> AbsolutePath1;
-  Optional<ObjectProxy> AbsolutePath2;
-  Optional<ObjectProxy> RelativePath;
-  Optional<ObjectProxy> WindowsPath;
   ASSERT_THAT_ERROR(CAS->createProxy(None, "content1").moveInto(Content1),
                     Succeeded());
   ASSERT_THAT_ERROR(CAS->createProxy(None, "content2").moveInto(Content2),
                     Succeeded());
-  ASSERT_THAT_ERROR(
-      CAS->createProxy(None, "/absolute/path/1").moveInto(AbsolutePath1),
-      Succeeded());
-  ASSERT_THAT_ERROR(
-      CAS->createProxy(None, "/absolute/path/2").moveInto(AbsolutePath2),
-      Succeeded());
-  ASSERT_THAT_ERROR(
-      CAS->createProxy(None, "relative/path/./2").moveInto(RelativePath),
-      Succeeded());
-  ASSERT_THAT_ERROR(
-      CAS->createProxy(None, "c:\\windows/path").moveInto(WindowsPath),
-      Succeeded());
+  std::string AbsolutePath1 = "/absolute/path/1";
+  std::string AbsolutePath2 = "/absolute/path/2";
+  std::string RelativePath = "relative/path/./2";
+  std::string WindowsPath = "c:\\windows/path";
 
   // FIXME: Add test of duplicate paths. Maybe could error at createFile()...
   struct OutputDescription {
     ObjectProxy Content;
-    ObjectProxy Path;
+    std::string Path;
   };
   OutputDescription OutputDescriptions[] = {
-      {*Content1, *AbsolutePath1}, {*Content2, *AbsolutePath2},
-      {*Content1, *AbsolutePath1}, {*Content1, *RelativePath},
-      {*Content1, *WindowsPath},
+      {*Content1, AbsolutePath1}, {*Content2, AbsolutePath2},
+      {*Content1, AbsolutePath1}, {*Content1, RelativePath},
+      {*Content1, WindowsPath},
   };
-  for (OutputDescription OD : OutputDescriptions) {
+  for (const OutputDescription &OD : OutputDescriptions) {
     // Use consumeDiscardOnDestroy() so that early exits from
     // ASSERT_THAT_ERROR do not crash the unit test suite.
     Optional<vfs::OutputFile> O;
     ASSERT_THAT_ERROR(
-        consumeDiscardOnDestroy(Outputs->createFile(OD.Path.getData()))
-            .moveInto(O),
+        consumeDiscardOnDestroy(Outputs->createFile(OD.Path)).moveInto(O),
         Succeeded());
     *O << OD.Content.getData();
     ASSERT_THAT_ERROR(O->keep(), Succeeded());
   }
 
-  Optional<ObjectProxy> Root;
-  ASSERT_THAT_ERROR(Outputs->getCASProxy().moveInto(Root), Succeeded());
+  SmallVector<CASOutputBackend::OutputFile> OFs = Outputs->takeOutputs();
 
   auto Array = makeArrayRef(OutputDescriptions);
-  ASSERT_EQ(Array.size() * 2, Root->getNumReferences());
+  ASSERT_EQ(OFs.size(), Array.size());
   for (size_t I = 0, E = Array.size(); I != E; ++I) {
-    ASSERT_EQ(Array[I].Path, Root->getReference(I * 2));
-    ASSERT_EQ(Array[I].Content, Root->getReference(I * 2 + 1));
+    EXPECT_EQ(Array[I].Path, OFs[I].Path);
+    EXPECT_EQ(Array[I].Content, OFs[I].Object);
   }
 }


### PR DESCRIPTION
Factor the code for creating and reading a compilation result out of
cc1_main and create a CompileJobCacheResult proxy for working with
cached compilation results. This is in preparation for accessing cached
module compilations.