### PR TITLE
[CAS] Remove unused inline string type storage

### DIFF
--- a/llvm/lib/CAS/InMemoryCAS.cpp
+++ b/llvm/lib/CAS/InMemoryCAS.cpp
@@ -22,7 +22,6 @@ using namespace llvm::cas::builtin;
 namespace {
 
 class InMemoryObject;
-class InMemoryString;
 
 /// Index of referenced IDs (map: Hash -> InMemoryObject*). Uses
 /// LazyAtomicPointer to coordinate creation of objects.
@@ -34,10 +33,6 @@ using InMemoryIndexT =
 /// their hash.
 using InMemoryIndexValueT = InMemoryIndexT::value_type;
 
-/// String pool.
-using InMemoryStringPoolT =
-    ThreadSafeHashMappedTrie<LazyAtomicPointer<const InMemoryString>,
-                             sizeof(HashType)>;
 
 class InMemoryObject {
 public:
@@ -159,29 +154,6 @@ private:
   uint32_t DataSize;
 };
 
-/// Internal string type.
-class InMemoryString {
-public:
-  StringRef get() const {
-    return StringRef(reinterpret_cast<const char *>(this + 1), Size);
-  }
-
-  static InMemoryString &create(function_ref<void *(size_t Size)> Allocate,
-                                StringRef String) {
-    assert(String.size() <= UINT32_MAX && "Expected strings smaller than 4GB");
-    void *Mem = Allocate(sizeof(InMemoryString) + String.size() + 1);
-    return *new (Mem) InMemoryString(String);
-  }
-
-private:
-  InMemoryString(StringRef String) : Size(String.size()) {
-    auto *Begin = reinterpret_cast<char *>(this + 1);
-    llvm::copy(String, Begin);
-    Begin[String.size()] = 0;
-  }
-  size_t Size;
-};
-
 /// In-memory CAS database and action cache (the latter should be separated).
 class InMemoryCAS : public BuiltinCAS {
 public:
@@ -300,11 +272,7 @@ private:
   /// - InMemoryObject points back to here.
   InMemoryIndexT Index;
 
-  /// String pool for trees.
-  InMemoryStringPoolT StringPool;
-
   ThreadSafeAllocator<BumpPtrAllocator> Objects;
-  ThreadSafeAllocator<BumpPtrAllocator> Strings;
   ThreadSafeAllocator<SpecificBumpPtrAllocator<sys::fs::mapped_file_region>>
       MemoryMaps;
 };
@@ -326,8 +294,6 @@ ArrayRef<const InMemoryObject *> InMemoryObject::getRefs() const {
 void InMemoryCAS::print(raw_ostream &OS) const {
   OS << "index: ";
   Index.print(OS);
-  OS << "strings: ";
-  StringPool.print(OS);
 }
 
 Expected<ObjectRef>

--- a/llvm/lib/CAS/OnDiskCAS.cpp
+++ b/llvm/lib/CAS/OnDiskCAS.cpp
@@ -40,9 +40,6 @@ public:
     /// vX.data: main pool, full DataStore record.
     DataPool = 1,
 
-    /// vX.data: main pool, string with 2B size field.
-    DataPoolString2B = 2,
-
     /// vX.<TrieRecordOffset>.data: standalone, with a full DataStore record.
     Standalone = 10,
 
@@ -57,7 +54,7 @@ public:
   };
 
   enum class ObjectKind : uint8_t {
-    /// Object: refs and data.
+    /// Invalid.
     Invalid = 0,
 
     /// Object: refs and data.
@@ -697,9 +694,8 @@ struct OnDiskContent {
 ///   more details.
 /// - db/<prefix>.data: a file for the "data" table, named by \a
 ///   getDataPoolTableName() and managed by \a DataStore. New objects within
-///   TrieRecord::MaxEmbeddedSize are inserted here as either \a
-///   TrieRecord::StorageKind::DataPool or
-///   TrieRecord::StorageKind::DataPoolString2B.
+///   TrieRecord::MaxEmbeddedSize are inserted here as \a
+///   TrieRecord::StorageKind::DataPool.
 ///     - db/<prefix>.<offset>.data: a file storing an object outside the main
 ///       "data" table, named by its offset into the "index" table, with the
 ///       format of \a TrieRecord::StorageKind::Standalone.
@@ -1352,10 +1348,6 @@ void OnDiskCAS::print(raw_ostream &OS) const {
       OS << "datapool         ";
       Pool.push_back({/*IsString2B=*/false, D.Offset.get()});
       break;
-    case TrieRecord::StorageKind::DataPoolString2B:
-      OS << "datapool-string2B";
-      Pool.push_back({/*IsString2B=*/true, D.Offset.get()});
-      break;
     case TrieRecord::StorageKind::Standalone:
       OS << "standalone-data  ";
       break;
@@ -1528,10 +1520,6 @@ OnDiskCAS::makeInternalRef(FileOffset IndexOffset,
 
   case TrieRecord::StorageKind::DataPool:
     return InternalRef::getFromOffset(InternalRef::OffsetKind::DataRecord,
-                                      Object.Offset);
-
-  case TrieRecord::StorageKind::DataPoolString2B:
-    return InternalRef::getFromOffset(InternalRef::OffsetKind::String2B,
                                       Object.Offset);
 
   case TrieRecord::StorageKind::Standalone:


### PR DESCRIPTION
Remove inline string type storage from InMemoryCAS and OnDiskCAS. It was
used to get cheap dedup short strings for tree entries and it is no
longer useful in current implementation.

The other idea was to have an API that allows CAS to allocate
internal-only objects with no refs which also has no ID associated.
We can add this back if this idea become more mature.