### PR TITLE
[clang][cas] Fix -working-directory issues

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -901,7 +901,7 @@ CompilerInstance::createOutputFileImpl(StringRef OutputPath, bool Binary,
   // If '-working-directory' was passed, the output filename should be
   // relative to that.
   Optional<SmallString<128>> AbsPath;
-  if (!llvm::sys::path::is_absolute(OutputPath)) {
+  if (OutputPath != "-" && !llvm::sys::path::is_absolute(OutputPath)) {
     AbsPath.emplace(OutputPath);
     FileMgr->FixupRelativePath(*AbsPath);
     OutputPath = *AbsPath;

--- a/clang/test/CAS/path-independent-cas-outputs.c
+++ b/clang/test/CAS/path-independent-cas-outputs.c
@@ -9,6 +9,25 @@
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/b/t2.o -MMD -MT dependencies -MF %t/b/t2.d --serialize-diagnostics %t/b/t2.dia -Rcompile-job-cache \
 // RUN:   2>&1 | FileCheck %s --check-prefix=CACHE-HIT
 
+// Check that output path is correctly detected with -working-directory.
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -working-directory %t -o a/t1_working_dir.o -DNEW_FLAG -Rcompile-job-cache \
+// RUN:   2>&1 | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -working-directory %t -o b/t2_working_dir.o -DNEW_FLAG -Rcompile-job-cache \
+// RUN:   2>&1 | FileCheck %s --check-prefix=CACHE-HIT
+// RUN: diff %t/a/t1_working_dir.o %t/b/t2_working_dir.o
+
+// Check that output path is correctly detected with - (stdout)
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o - -DNEW_FLAG2 -Rcompile-job-cache > %t/a/t1_stdout.o
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/b/t2_stdout.o -DNEW_FLAG2 -Rcompile-job-cache \
+// RUN:   2>&1 | FileCheck %s --check-prefix=CACHE-HIT
+// RUN: diff %t/a/t1_stdout.o %t/b/t2_stdout.o
+
 // Check PCH output
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \

--- a/clang/test/Frontend/output-paths.c
+++ b/clang/test/Frontend/output-paths.c
@@ -8,3 +8,6 @@
 // RUN: rm -rf %t.d && mkdir -p %t.d/%basename_t-inner.d
 // RUN: %clang_cc1 -emit-llvm -working-directory %t.d -E -o %basename_t-inner.d/somename %s -verify
 // expected-no-diagnostics
+
+// RUN: %clang_cc1 -working-directory %t.d -E %s -o - | FileCheck %s
+// CHECK: # 1

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -343,6 +343,17 @@ StringRef CompileJobCache::getPathForOutputKind(OutputKind Kind) {
   }
 }
 
+static std::string fixupRelativePath(const std::string &Path, FileManager &FM) {
+  // FIXME: this needs to stay in sync with createOutputFileImpl. Ideally, clang
+  // would create output files by their "kind" rather than by path.
+  if (!Path.empty() && Path != "-" && !llvm::sys::path::is_absolute(Path)) {
+    SmallString<128> PathStorage(Path);
+    if (FM.FixupRelativePath(PathStorage))
+      return std::string(PathStorage);
+  }
+  return Path;
+}
+
 Optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
   CompilerInvocation &Invocation = Clang.getInvocation();
   DiagnosticsEngine &Diags = Clang.getDiagnostics();
@@ -385,9 +396,14 @@ Optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
   ComputedJobNeedsReplay |= WriteOutputAsCASID || UseCASBackend;
   FrontendOpts.IncludeTimestamps = false;
 
-  OutputFile = FrontendOpts.OutputFile;
-  SerialDiagsFile = Invocation.getDiagnosticOpts().DiagnosticSerializationFile;
-  DependenciesFile = Invocation.getDependencyOutputOpts().OutputFile;
+  if (!Clang.hasFileManager())
+    Clang.createFileManager();
+  FileManager &FM = Clang.getFileManager();
+  OutputFile = fixupRelativePath(FrontendOpts.OutputFile, FM);
+  SerialDiagsFile = fixupRelativePath(
+      Invocation.getDiagnosticOpts().DiagnosticSerializationFile, FM);
+  DependenciesFile =
+      fixupRelativePath(Invocation.getDependencyOutputOpts().OutputFile, FM);
   return None;
 }
 


### PR DESCRIPTION
* Fix detection of output paths when -working-directory is used with a relative output path. Also add a test when the output path is "-".  After this, we should be able to make unmapped outputs a hard error. I will do that in https://github.com/apple/llvm-project/pull/5232 since it's cleaner to check this condition after my other changes.
* Fix stdout path "-" when -working-directory is set so we don't create a file named "-".  This is not CAS-specific, but it's broken on our CAS branch due to an OutputBackend-related refactoring.