### PR TITLE
[clang][cas] Disable the `#include_next` machinery while replaying an include-tree

### DIFF
--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -1819,6 +1819,11 @@ bool Preprocessor::checkModuleIsAvailable(const LangOptions &LangOpts,
 
 std::pair<ConstSearchDirIterator, const FileEntry *>
 Preprocessor::getIncludeNextStart(const Token &IncludeNextTok) const {
+  if (getPPCachedActions()) {
+    // We have pre-recorded include lookups.
+    return std::make_pair(nullptr, nullptr);
+  }
+
   // #include_next is like #include, except that we start searching after
   // the current found directory.  If we can't do this, issue a
   // diagnostic.

--- a/clang/test/CAS/include-tree-with-include-next.c
+++ b/clang/test/CAS/include-tree-with-include-next.c
@@ -1,0 +1,17 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// Normal compilation for baseline.
+// RUN: %clang_cc1 %t/t.c -I %t/inc -I %t/inc2 -fsyntax-only -Werror
+
+// RUN: %clang -cc1depscan -o %t/tu.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
+// RUN:     -cc1 -fcas-path %t/cas %t/t.c -I %t/inc -I %t/inc2 -Werror
+// RUN: %clang @%t/tu.rsp -fsyntax-only -Werror
+
+//--- t.c
+#include "t.h"
+
+//--- inc/t.h
+#include_next "t.h"
+
+//--- inc2/t.h


### PR DESCRIPTION
(cherry picked from commit 20f954c197eef2d02c4e1b02e648092581edcfc3)