### PR TITLE
[CAS/IncludeTree] Use `BumpPtrAllocator` for the `StringMap`s of `IncludeTreeFileSystem`

### DIFF
--- a/clang/lib/CAS/IncludeTree.cpp
+++ b/clang/lib/CAS/IncludeTree.cpp
@@ -345,8 +345,10 @@ public:
         : FileEntry(std::move(FE)), Contents(Contents) {}
   };
 
-  llvm::StringMap<FileEntry> Files;
-  llvm::StringMap<llvm::sys::fs::UniqueID> Directories;
+  llvm::BumpPtrAllocator Alloc;
+  llvm::StringMap<FileEntry, llvm::BumpPtrAllocator &> Files{Alloc};
+  llvm::StringMap<llvm::sys::fs::UniqueID, llvm::BumpPtrAllocator &>
+      Directories{Alloc};
 
   llvm::ErrorOr<llvm::vfs::Status> status(const Twine &Path) override {
     SmallString<128> FilenameBuffer;


### PR DESCRIPTION
This is just for better efficiency.

(cherry picked from commit 16e1278e6be8aee64502cf71aafdb0d98df72396)