### PR TITLE
[LLDB][build] Allow linker to find Swift LLVM Bindings

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
@@ -49,6 +49,12 @@ if(BOOTSTRAPPING_MODE)
   target_link_libraries(lldbPluginExpressionParserSwift
     PRIVATE
       swiftCompilerModules)
+  if(LLDB_SWIFT_LLVM_BINDINGS_LIBS)
+    # Make sure the linker can discover Swift LLVM Bindings artifacts.
+    # See https://github.com/apple/swift-llvm-bindings.
+    target_link_directories(lldbPluginExpressionParserSwift PUBLIC
+        ${LLDB_SWIFT_LLVM_BINDINGS_LIBS})
+  endif()
 else()
   target_link_libraries(lldbPluginExpressionParserSwift
     PRIVATE


### PR DESCRIPTION
SwiftCompilerSources will soon start using symbols from Swift LLVM Bindings. To make sure LLDB links successfully after the dependency is introduced, this change adds a library search path to allow the linker to discover the static libraries with the bindings.

Fixes this build error:
```
FAILED: bin/lldb-server 
...
ld: library not found for -lLLVM_Utils
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

See https://github.com/apple/swift/pull/60750.
Note that this patch **does not require** https://github.com/apple/swift/pull/60750 and can be merged before https://github.com/apple/swift/pull/60750.