### PR TITLE
[clang][cas/include-tree] Keep track of the filenames as they were recorded in the PCH

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -252,6 +252,10 @@ private:
 
   cas::ObjectStore &DB;
   Optional<cas::ObjectRef> PCHRef;
+  bool StartedEnteringIncludes = false;
+  // When a PCH is used this lists the filenames of the included files as they
+  // are recorded in the PCH, ordered by \p FileEntry::UID index.
+  SmallVector<StringRef> PreIncludedFileNames;
   llvm::BitVector SeenIncludeFiles;
   SmallVector<cas::IncludeFileList::FileEntry> IncludedFiles;
   Optional<cas::ObjectRef> PredefinesBufferRef;
@@ -264,6 +268,19 @@ private:
 void IncludeTreePPConsumer::enteredInclude(Preprocessor &PP, FileID FID) {
   if (hasErrorOccurred())
     return;
+
+  if (!StartedEnteringIncludes) {
+    StartedEnteringIncludes = true;
+
+    // Get the included files (coming from a PCH), and keep track of the
+    // filenames that were recorded in the PCH.
+    for (const FileEntry *FE : PP.getIncludedFiles()) {
+      unsigned UID = FE->getUID();
+      if (UID >= PreIncludedFileNames.size())
+        PreIncludedFileNames.resize(UID + 1);
+      PreIncludedFileNames[UID] = FE->getName();
+    }
+  }
 
   Optional<cas::ObjectRef> FileRef = check(getObjectForFile(PP, FID));
   if (!FileRef)
@@ -439,17 +456,14 @@ IncludeTreePPConsumer::addToFileList(FileManager &FM, const FileEntry *FE) {
     return FileNode->getRef();
   };
 
-  StringRef OtherPath = FE->tryGetRealPathName();
-  if (!OtherPath.empty()) {
-    // Check whether another path is associated due to a symlink.
-    llvm::SmallString<128> AbsPath(Filename);
-    FM.makeAbsolutePath(AbsPath);
-    llvm::sys::path::remove_dots(AbsPath, /*remove_dot_dot=*/true);
-    if (OtherPath != AbsPath) {
-      auto FileNode = addFile(OtherPath);
-      if (!FileNode)
-        return FileNode.takeError();
-    }
+  // Check whether another path coming from the PCH is associated with the same
+  // file.
+  unsigned UID = FE->getUID();
+  if (UID < PreIncludedFileNames.size() && !PreIncludedFileNames[UID].empty() &&
+      PreIncludedFileNames[UID] != Filename) {
+    auto FileNode = addFile(PreIncludedFileNames[UID]);
+    if (!FileNode)
+      return FileNode.takeError();
   }
 
   return addFile(Filename);

--- a/clang/test/CAS/fcas-include-tree-with-pch.c
+++ b/clang/test/CAS/fcas-include-tree-with-pch.c
@@ -5,25 +5,44 @@
 // RUN: ln -s s3.h %t/s3-link2.h
 
 // Normal compilation for baseline.
-// RUN: %clang_cc1 -x c-header %t/prefix.h -DCMD_MACRO=1 -emit-pch -o %t/prefix1.pch
-// RUN: %clang_cc1 %t/t1.c -include-pch %t/prefix1.pch -emit-llvm -o %t/source.ll -DCMD_MACRO=1
+// RUN: %clang_cc1 -x c-header %t/prefix.h -I %t/inc -DCMD_MACRO=1 -emit-pch -o %t/prefix1.pch
+// RUN: %clang_cc1 %t/t1.c -include-pch %t/prefix1.pch -emit-llvm -o %t/source.ll -I %t/inc -DCMD_MACRO=1
 
 // RUN: %clang -cc1depscan -o %t/pch.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
-// RUN:     -cc1 -x c-header %t/prefix.h -DCMD_MACRO=1 -fcas-path %t/cas
+// RUN:     -cc1 -x c-header %t/prefix.h -I %t/inc -DCMD_MACRO=1 -fcas-path %t/cas
 // RUN: %clang @%t/pch.rsp -emit-pch -o %t/prefix2.pch
 
 // RUN: %clang -cc1depscan -o %t/tu.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
-// RUN:     -cc1 %t/t1.c -include-pch %t/prefix2.pch -DCMD_MACRO=1 -fcas-path %t/cas
+// RUN:     -cc1 %t/t1.c -include-pch %t/prefix2.pch -I %t/inc -DCMD_MACRO=1 -fcas-path %t/cas
 // RUN: rm %t/prefix2.pch
 
 // RUN: %clang @%t/tu.rsp -emit-llvm -o %t/tree.ll
 // RUN: diff -u %t/source.ll %t/tree.ll
+
+// Check again with relative paths.
+// RUN: cd %t
+
+// Normal compilation for baseline.
+// RUN: %clang_cc1 -x c-header prefix.h -I %t/inc -DCMD_MACRO=1 -emit-pch -o prefix3.pch
+// RUN: %clang_cc1 t1.c -include-pch prefix3.pch -emit-llvm -o source-rel.ll -I inc -DCMD_MACRO=1
+
+// RUN: %clang -cc1depscan -o pch2.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
+// RUN:     -cc1 -x c-header prefix.h -I %t/inc -DCMD_MACRO=1 -fcas-path %t/cas
+// RUN: %clang @pch2.rsp -emit-pch -o prefix4.pch
+
+// RUN: %clang -cc1depscan -o tu2.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
+// RUN:     -cc1 t1.c -include-pch prefix4.pch -I inc -DCMD_MACRO=1 -fcas-path %t/cas
+// RUN: rm %t/prefix4.pch
+
+// RUN: %clang @tu2.rsp -emit-llvm -o tree-rel.ll
+// RUN: diff -u source-rel.ll tree-rel.ll
 
 //--- t1.c
 #if S2_MACRO
 #include "s2-link.h"
 #endif
 #include "s3-link2.h"
+#include "other.h"
 
 int test(struct S *s, struct S2 *s2) {
   return s->x + s2->y + CMD_MACRO + PREFIX_MACRO + S2_MACRO + S3_MACRO;
@@ -33,6 +52,7 @@ int test(struct S *s, struct S2 *s2) {
 #include "s2.h"
 #include "s3.h"
 #include "s3-link1.h"
+#include "other.h"
 
 #define PREFIX_MACRO S3_MACRO
 
@@ -49,3 +69,8 @@ struct S2 {
 
 //--- s3.h
 #define S3_MACRO 4
+
+//--- inc/other.h
+#include "../inc2/other2.h"
+
+//--- inc2/other2.h


### PR DESCRIPTION
The filenames as recorded in the PCH may differ from the filenames as headers are included for the main file. Keep track of the PCH filenames so that we can record both variants for a `FileEntry` in the include-tree.

(cherry picked from commit 296b4da4ad7bfdc2b7ae4bdc8b361bf9f1a5b998)