### PR TITLE
[stable/20220421] Cherry-pick Optional.h API additions NFC

### DIFF
--- a/clang/include/clang/Basic/DirectoryEntry.h
+++ b/clang/include/clang/Basic/DirectoryEntry.h
@@ -133,13 +133,25 @@ public:
   bool has_value() const { return MaybeRef.hasOptionalValue(); }
   bool hasValue() const { return MaybeRef.hasOptionalValue(); }
 
+  RefTy &value() & {
+    assert(has_value());
+    return MaybeRef;
+  }
   RefTy &getValue() & {
     assert(hasValue());
+    return MaybeRef;
+  }
+  RefTy const &value() const & {
+    assert(has_value());
     return MaybeRef;
   }
   RefTy const &getValue() const & {
     assert(hasValue());
     return MaybeRef;
+  }
+  RefTy &&value() && {
+    assert(has_value());
+    return std::move(MaybeRef);
   }
   RefTy &&getValue() && {
     assert(hasValue());

--- a/clang/include/clang/Basic/DirectoryEntry.h
+++ b/clang/include/clang/Basic/DirectoryEntry.h
@@ -130,6 +130,7 @@ public:
 
   void reset() { MaybeRef = optional_none_tag(); }
 
+  bool has_value() const { return MaybeRef.hasOptionalValue(); }
   bool hasValue() const { return MaybeRef.hasOptionalValue(); }
 
   RefTy &getValue() & {

--- a/llvm/include/llvm/ADT/Optional.h
+++ b/llvm/include/llvm/ADT/Optional.h
@@ -315,11 +315,11 @@ public:
   constexpr const T &operator*() const & { return getValue(); }
   T &operator*() & { return getValue(); }
 
-  template <typename U> constexpr T value_or(U &&value) const & {
-    return hasValue() ? getValue() : std::forward<U>(value);
+  template <typename U> constexpr T value_or(U &&alt) const & {
+    return hasValue() ? getValue() : std::forward<U>(alt);
   }
-  template <typename U> constexpr T getValueOr(U &&value) const & {
-    return hasValue() ? getValue() : std::forward<U>(value);
+  template <typename U> constexpr T getValueOr(U &&alt) const & {
+    return hasValue() ? getValue() : std::forward<U>(alt);
   }
 
   /// Apply a function to the value if present; otherwise return None.
@@ -334,11 +334,11 @@ public:
   T &&getValue() && { return std::move(Storage.getValue()); }
   T &&operator*() && { return std::move(Storage.getValue()); }
 
-  template <typename U> T value_or(U &&value) && {
-    return hasValue() ? std::move(getValue()) : std::forward<U>(value);
+  template <typename U> T value_or(U &&alt) && {
+    return hasValue() ? std::move(getValue()) : std::forward<U>(alt);
   }
-  template <typename U> T getValueOr(U &&value) && {
-    return hasValue() ? std::move(getValue()) : std::forward<U>(value);
+  template <typename U> T getValueOr(U &&alt) && {
+    return hasValue() ? std::move(getValue()) : std::forward<U>(alt);
   }
 
   /// Apply a function to the value if present; otherwise return None.

--- a/llvm/include/llvm/ADT/Optional.h
+++ b/llvm/include/llvm/ADT/Optional.h
@@ -300,53 +300,53 @@ public:
 
   void reset() { Storage.reset(); }
 
-  constexpr const T *getPointer() const { return &Storage.getValue(); }
-  T *getPointer() { return &Storage.getValue(); }
-  constexpr const T &value() const & { return Storage.getValue(); }
-  constexpr const T &getValue() const & { return Storage.getValue(); }
-  T &value() & { return Storage.getValue(); }
-  T &getValue() & { return Storage.getValue(); }
+  constexpr const T *getPointer() const { return &Storage.value(); }
+  T *getPointer() { return &Storage.value(); }
+  constexpr const T &value() const & { return Storage.value(); }
+  constexpr const T &getValue() const & { return Storage.value(); }
+  T &value() & { return Storage.value(); }
+  T &getValue() & { return Storage.value(); }
 
   constexpr explicit operator bool() const { return has_value(); }
   constexpr bool has_value() const { return Storage.has_value(); }
   constexpr bool hasValue() const { return Storage.has_value(); }
   constexpr const T *operator->() const { return getPointer(); }
   T *operator->() { return getPointer(); }
-  constexpr const T &operator*() const & { return getValue(); }
-  T &operator*() & { return getValue(); }
+  constexpr const T &operator*() const & { return value(); }
+  T &operator*() & { return value(); }
 
   template <typename U> constexpr T value_or(U &&alt) const & {
-    return has_value() ? getValue() : std::forward<U>(alt);
+    return has_value() ? value() : std::forward<U>(alt);
   }
   template <typename U> constexpr T getValueOr(U &&alt) const & {
-    return has_value() ? getValue() : std::forward<U>(alt);
+    return has_value() ? value() : std::forward<U>(alt);
   }
 
   /// Apply a function to the value if present; otherwise return None.
   template <class Function>
-  auto map(const Function &F) const & -> Optional<decltype(F(getValue()))> {
+  auto map(const Function &F) const & -> Optional<decltype(F(value()))> {
     if (*this)
-      return F(getValue());
+      return F(value());
     return None;
   }
 
-  T &&value() && { return std::move(Storage.getValue()); }
-  T &&getValue() && { return std::move(Storage.getValue()); }
-  T &&operator*() && { return std::move(Storage.getValue()); }
+  T &&value() && { return std::move(Storage.value()); }
+  T &&getValue() && { return std::move(Storage.value()); }
+  T &&operator*() && { return std::move(Storage.value()); }
 
   template <typename U> T value_or(U &&alt) && {
-    return has_value() ? std::move(getValue()) : std::forward<U>(alt);
+    return has_value() ? std::move(value()) : std::forward<U>(alt);
   }
   template <typename U> T getValueOr(U &&alt) && {
-    return has_value() ? std::move(getValue()) : std::forward<U>(alt);
+    return has_value() ? std::move(value()) : std::forward<U>(alt);
   }
 
   /// Apply a function to the value if present; otherwise return None.
   template <class Function>
   auto map(const Function &F)
-      && -> Optional<decltype(F(std::move(*this).getValue()))> {
+      && -> Optional<decltype(F(std::move(*this).value()))> {
     if (*this)
-      return F(std::move(*this).getValue());
+      return F(std::move(*this).value());
     return None;
   }
 };

--- a/llvm/include/llvm/ADT/Optional.h
+++ b/llvm/include/llvm/ADT/Optional.h
@@ -60,7 +60,7 @@ template <typename T,
 class OptionalStorage {
   union {
     char empty;
-    T value;
+    T val;
   };
   bool hasVal = false;
 
@@ -71,22 +71,22 @@ public:
 
   constexpr OptionalStorage(OptionalStorage const &other) : OptionalStorage() {
     if (other.hasValue()) {
-      emplace(other.value);
+      emplace(other.val);
     }
   }
   constexpr OptionalStorage(OptionalStorage &&other) : OptionalStorage() {
     if (other.hasValue()) {
-      emplace(std::move(other.value));
+      emplace(std::move(other.val));
     }
   }
 
   template <class... Args>
   constexpr explicit OptionalStorage(in_place_t, Args &&...args)
-      : value(std::forward<Args>(args)...), hasVal(true) {}
+      : val(std::forward<Args>(args)...), hasVal(true) {}
 
   void reset() noexcept {
     if (hasVal) {
-      value.~T();
+      val.~T();
       hasVal = false;
     }
   }
@@ -95,37 +95,37 @@ public:
 
   T &getValue() &noexcept {
     assert(hasVal);
-    return value;
+    return val;
   }
   constexpr T const &getValue() const &noexcept {
     assert(hasVal);
-    return value;
+    return val;
   }
   T &&getValue() &&noexcept {
     assert(hasVal);
-    return std::move(value);
+    return std::move(val);
   }
 
   template <class... Args> void emplace(Args &&...args) {
     reset();
-    ::new ((void *)std::addressof(value)) T(std::forward<Args>(args)...);
+    ::new ((void *)std::addressof(val)) T(std::forward<Args>(args)...);
     hasVal = true;
   }
 
   OptionalStorage &operator=(T const &y) {
     if (hasValue()) {
-      value = y;
+      val = y;
     } else {
-      ::new ((void *)std::addressof(value)) T(y);
+      ::new ((void *)std::addressof(val)) T(y);
       hasVal = true;
     }
     return *this;
   }
   OptionalStorage &operator=(T &&y) {
     if (hasValue()) {
-      value = std::move(y);
+      val = std::move(y);
     } else {
-      ::new ((void *)std::addressof(value)) T(std::move(y));
+      ::new ((void *)std::addressof(val)) T(std::move(y));
       hasVal = true;
     }
     return *this;
@@ -134,9 +134,9 @@ public:
   OptionalStorage &operator=(OptionalStorage const &other) {
     if (other.hasValue()) {
       if (hasValue()) {
-        value = other.value;
+        val = other.val;
       } else {
-        ::new ((void *)std::addressof(value)) T(other.value);
+        ::new ((void *)std::addressof(val)) T(other.val);
         hasVal = true;
       }
     } else {
@@ -148,9 +148,9 @@ public:
   OptionalStorage &operator=(OptionalStorage &&other) {
     if (other.hasValue()) {
       if (hasValue()) {
-        value = std::move(other.value);
+        val = std::move(other.val);
       } else {
-        ::new ((void *)std::addressof(value)) T(std::move(other.value));
+        ::new ((void *)std::addressof(val)) T(std::move(other.val));
         hasVal = true;
       }
     } else {
@@ -163,7 +163,7 @@ public:
 template <typename T> class OptionalStorage<T, true> {
   union {
     char empty;
-    T value;
+    T val;
   };
   bool hasVal = false;
 
@@ -179,12 +179,12 @@ public:
   OptionalStorage &operator=(OptionalStorage &&other) = default;
 
   template <class... Args>
-  constexpr explicit OptionalStorage(in_place_t, Args &&... args)
-      : value(std::forward<Args>(args)...), hasVal(true) {}
+  constexpr explicit OptionalStorage(in_place_t, Args &&...args)
+      : val(std::forward<Args>(args)...), hasVal(true) {}
 
   void reset() noexcept {
     if (hasVal) {
-      value.~T();
+      val.~T();
       hasVal = false;
     }
   }
@@ -193,37 +193,37 @@ public:
 
   T &getValue() &noexcept {
     assert(hasVal);
-    return value;
+    return val;
   }
   constexpr T const &getValue() const &noexcept {
     assert(hasVal);
-    return value;
+    return val;
   }
   T &&getValue() &&noexcept {
     assert(hasVal);
-    return std::move(value);
+    return std::move(val);
   }
 
   template <class... Args> void emplace(Args &&...args) {
     reset();
-    ::new ((void *)std::addressof(value)) T(std::forward<Args>(args)...);
+    ::new ((void *)std::addressof(val)) T(std::forward<Args>(args)...);
     hasVal = true;
   }
 
   OptionalStorage &operator=(T const &y) {
     if (hasValue()) {
-      value = y;
+      val = y;
     } else {
-      ::new ((void *)std::addressof(value)) T(y);
+      ::new ((void *)std::addressof(val)) T(y);
       hasVal = true;
     }
     return *this;
   }
   OptionalStorage &operator=(T &&y) {
     if (hasValue()) {
-      value = std::move(y);
+      val = std::move(y);
     } else {
-      ::new ((void *)std::addressof(value)) T(std::move(y));
+      ::new ((void *)std::addressof(val)) T(std::move(y));
       hasVal = true;
     }
     return *this;

--- a/llvm/include/llvm/ADT/Optional.h
+++ b/llvm/include/llvm/ADT/Optional.h
@@ -91,15 +91,28 @@ public:
     }
   }
 
+  constexpr bool has_value() const noexcept { return hasVal; }
   constexpr bool hasValue() const noexcept { return hasVal; }
 
+  T &value() &noexcept {
+    assert(hasVal);
+    return val;
+  }
   T &getValue() &noexcept {
+    assert(hasVal);
+    return val;
+  }
+  constexpr T const &value() const &noexcept {
     assert(hasVal);
     return val;
   }
   constexpr T const &getValue() const &noexcept {
     assert(hasVal);
     return val;
+  }
+  T &&value() &&noexcept {
+    assert(hasVal);
+    return std::move(val);
   }
   T &&getValue() &&noexcept {
     assert(hasVal);
@@ -189,15 +202,28 @@ public:
     }
   }
 
+  constexpr bool has_value() const noexcept { return hasVal; }
   constexpr bool hasValue() const noexcept { return hasVal; }
 
+  T &value() &noexcept {
+    assert(hasVal);
+    return val;
+  }
   T &getValue() &noexcept {
+    assert(hasVal);
+    return val;
+  }
+  constexpr T const &value() const &noexcept {
     assert(hasVal);
     return val;
   }
   constexpr T const &getValue() const &noexcept {
     assert(hasVal);
     return val;
+  }
+  T &&value() &&noexcept {
+    assert(hasVal);
+    return std::move(val);
   }
   T &&getValue() &&noexcept {
     assert(hasVal);
@@ -276,16 +302,22 @@ public:
 
   constexpr const T *getPointer() const { return &Storage.getValue(); }
   T *getPointer() { return &Storage.getValue(); }
+  constexpr const T &value() const & { return Storage.getValue(); }
   constexpr const T &getValue() const & { return Storage.getValue(); }
+  T &value() & { return Storage.getValue(); }
   T &getValue() & { return Storage.getValue(); }
 
   constexpr explicit operator bool() const { return hasValue(); }
+  constexpr bool has_value() const { return Storage.hasValue(); }
   constexpr bool hasValue() const { return Storage.hasValue(); }
   constexpr const T *operator->() const { return getPointer(); }
   T *operator->() { return getPointer(); }
   constexpr const T &operator*() const & { return getValue(); }
   T &operator*() & { return getValue(); }
 
+  template <typename U> constexpr T value_or(U &&value) const & {
+    return hasValue() ? getValue() : std::forward<U>(value);
+  }
   template <typename U> constexpr T getValueOr(U &&value) const & {
     return hasValue() ? getValue() : std::forward<U>(value);
   }
@@ -298,9 +330,13 @@ public:
     return None;
   }
 
+  T &&value() && { return std::move(Storage.getValue()); }
   T &&getValue() && { return std::move(Storage.getValue()); }
   T &&operator*() && { return std::move(Storage.getValue()); }
 
+  template <typename U> T value_or(U &&value) && {
+    return hasValue() ? std::move(getValue()) : std::forward<U>(value);
+  }
   template <typename U> T getValueOr(U &&value) && {
     return hasValue() ? std::move(getValue()) : std::forward<U>(value);
   }

--- a/llvm/include/llvm/ADT/Optional.h
+++ b/llvm/include/llvm/ADT/Optional.h
@@ -70,12 +70,12 @@ public:
   constexpr OptionalStorage() noexcept : empty() {}
 
   constexpr OptionalStorage(OptionalStorage const &other) : OptionalStorage() {
-    if (other.hasValue()) {
+    if (other.has_value()) {
       emplace(other.val);
     }
   }
   constexpr OptionalStorage(OptionalStorage &&other) : OptionalStorage() {
-    if (other.hasValue()) {
+    if (other.has_value()) {
       emplace(std::move(other.val));
     }
   }
@@ -126,7 +126,7 @@ public:
   }
 
   OptionalStorage &operator=(T const &y) {
-    if (hasValue()) {
+    if (has_value()) {
       val = y;
     } else {
       ::new ((void *)std::addressof(val)) T(y);
@@ -135,7 +135,7 @@ public:
     return *this;
   }
   OptionalStorage &operator=(T &&y) {
-    if (hasValue()) {
+    if (has_value()) {
       val = std::move(y);
     } else {
       ::new ((void *)std::addressof(val)) T(std::move(y));
@@ -145,8 +145,8 @@ public:
   }
 
   OptionalStorage &operator=(OptionalStorage const &other) {
-    if (other.hasValue()) {
-      if (hasValue()) {
+    if (other.has_value()) {
+      if (has_value()) {
         val = other.val;
       } else {
         ::new ((void *)std::addressof(val)) T(other.val);
@@ -159,8 +159,8 @@ public:
   }
 
   OptionalStorage &operator=(OptionalStorage &&other) {
-    if (other.hasValue()) {
-      if (hasValue()) {
+    if (other.has_value()) {
+      if (has_value()) {
         val = std::move(other.val);
       } else {
         ::new ((void *)std::addressof(val)) T(std::move(other.val));
@@ -237,7 +237,7 @@ public:
   }
 
   OptionalStorage &operator=(T const &y) {
-    if (hasValue()) {
+    if (has_value()) {
       val = y;
     } else {
       ::new ((void *)std::addressof(val)) T(y);
@@ -246,7 +246,7 @@ public:
     return *this;
   }
   OptionalStorage &operator=(T &&y) {
-    if (hasValue()) {
+    if (has_value()) {
       val = std::move(y);
     } else {
       ::new ((void *)std::addressof(val)) T(std::move(y));
@@ -307,19 +307,19 @@ public:
   T &value() & { return Storage.getValue(); }
   T &getValue() & { return Storage.getValue(); }
 
-  constexpr explicit operator bool() const { return hasValue(); }
-  constexpr bool has_value() const { return Storage.hasValue(); }
-  constexpr bool hasValue() const { return Storage.hasValue(); }
+  constexpr explicit operator bool() const { return has_value(); }
+  constexpr bool has_value() const { return Storage.has_value(); }
+  constexpr bool hasValue() const { return Storage.has_value(); }
   constexpr const T *operator->() const { return getPointer(); }
   T *operator->() { return getPointer(); }
   constexpr const T &operator*() const & { return getValue(); }
   T &operator*() & { return getValue(); }
 
   template <typename U> constexpr T value_or(U &&alt) const & {
-    return hasValue() ? getValue() : std::forward<U>(alt);
+    return has_value() ? getValue() : std::forward<U>(alt);
   }
   template <typename U> constexpr T getValueOr(U &&alt) const & {
-    return hasValue() ? getValue() : std::forward<U>(alt);
+    return has_value() ? getValue() : std::forward<U>(alt);
   }
 
   /// Apply a function to the value if present; otherwise return None.
@@ -335,10 +335,10 @@ public:
   T &&operator*() && { return std::move(Storage.getValue()); }
 
   template <typename U> T value_or(U &&alt) && {
-    return hasValue() ? std::move(getValue()) : std::forward<U>(alt);
+    return has_value() ? std::move(getValue()) : std::forward<U>(alt);
   }
   template <typename U> T getValueOr(U &&alt) && {
-    return hasValue() ? std::move(getValue()) : std::forward<U>(alt);
+    return has_value() ? std::move(getValue()) : std::forward<U>(alt);
   }
 
   /// Apply a function to the value if present; otherwise return None.
@@ -359,7 +359,7 @@ template <typename T, typename U>
 constexpr bool operator==(const Optional<T> &X, const Optional<U> &Y) {
   if (X && Y)
     return *X == *Y;
-  return X.hasValue() == Y.hasValue();
+  return X.has_value() == Y.has_value();
 }
 
 template <typename T, typename U>
@@ -371,7 +371,7 @@ template <typename T, typename U>
 constexpr bool operator<(const Optional<T> &X, const Optional<U> &Y) {
   if (X && Y)
     return *X < *Y;
-  return X.hasValue() < Y.hasValue();
+  return X.has_value() < Y.has_value();
 }
 
 template <typename T, typename U>
@@ -414,7 +414,7 @@ template <typename T> constexpr bool operator<(const Optional<T> &, NoneType) {
 }
 
 template <typename T> constexpr bool operator<(NoneType, const Optional<T> &X) {
-  return X.hasValue();
+  return X.has_value();
 }
 
 template <typename T>

--- a/llvm/include/llvm/ADT/Optional.h
+++ b/llvm/include/llvm/ADT/Optional.h
@@ -324,6 +324,12 @@ public:
 
   /// Apply a function to the value if present; otherwise return None.
   template <class Function>
+  auto transform(const Function &F) const & -> Optional<decltype(F(value()))> {
+    if (*this)
+      return F(value());
+    return None;
+  }
+  template <class Function>
   auto map(const Function &F) const & -> Optional<decltype(F(value()))> {
     if (*this)
       return F(value());
@@ -342,6 +348,13 @@ public:
   }
 
   /// Apply a function to the value if present; otherwise return None.
+  template <class Function>
+  auto transform(
+      const Function &F) && -> Optional<decltype(F(std::move(*this).value()))> {
+    if (*this)
+      return F(std::move(*this).value());
+    return None;
+  }
   template <class Function>
   auto map(const Function &F)
       && -> Optional<decltype(F(std::move(*this).value()))> {

--- a/llvm/unittests/ADT/OptionalTest.cpp
+++ b/llvm/unittests/ADT/OptionalTest.cpp
@@ -622,6 +622,40 @@ TEST(OptionalTest, MoveGetValueOr) {
   EXPECT_EQ(2u, MoveOnly::Destructions);
 }
 
+TEST(OptionalTest, Transform) {
+  Optional<int> A;
+
+  Optional<int> B = A.transform([&](int N) { return N + 1; });
+  EXPECT_FALSE(B.has_value());
+
+  A = 3;
+  Optional<int> C = A.transform([&](int N) { return N + 1; });
+  EXPECT_TRUE(C.has_value());
+  EXPECT_EQ(4, C.value());
+}
+
+TEST(OptionalTest, MoveTransform) {
+  Optional<MoveOnly> A;
+
+  MoveOnly::ResetCounts();
+  Optional<int> B =
+      std::move(A).transform([&](const MoveOnly &M) { return M.val + 2; });
+  EXPECT_FALSE(B.has_value());
+  EXPECT_EQ(0u, MoveOnly::MoveConstructions);
+  EXPECT_EQ(0u, MoveOnly::MoveAssignments);
+  EXPECT_EQ(0u, MoveOnly::Destructions);
+
+  A = MoveOnly(5);
+  MoveOnly::ResetCounts();
+  Optional<int> C =
+      std::move(A).transform([&](const MoveOnly &M) { return M.val + 2; });
+  EXPECT_TRUE(C.has_value());
+  EXPECT_EQ(7, C.value());
+  EXPECT_EQ(0u, MoveOnly::MoveConstructions);
+  EXPECT_EQ(0u, MoveOnly::MoveAssignments);
+  EXPECT_EQ(0u, MoveOnly::Destructions);
+}
+
 struct EqualTo {
   template <typename T, typename U> static bool apply(const T &X, const U &Y) {
     return X == Y;


### PR DESCRIPTION
Upstream has adopted `getValue -> value`, `hasValue -> has_value` API changes. This pulls the API additions into the stable branch, but does not include the deprecation of the old APIs, nor does it change any call sites outside Optional.h itself. This should help avoid needing to make changes when cherry-picking.