### PR TITLE
[clang][cas] Add cc1 option -fmodule-file-cache-key=

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -27,6 +27,8 @@ def err_cas_depscan_daemon_connection: Error<
 def err_cas_depscan_failed: Error<
   "CAS-based dependency scan failed: %0">, DefaultFatal;
 def err_cas_store: Error<"failed to store to CAS: %0">, DefaultFatal;
+def err_cas_cannot_get_module_cache_key : Error<
+  "CAS cannot load module with key '%0' from %1: %2">, DefaultFatal;
 
 def warn_clang_cache_disabled_caching: Warning<
   "caching disabled because %0">,

--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -312,6 +312,9 @@ def warn_alias_with_section : Warning<
   "as the %select{aliasee|resolver}2">,
   InGroup<IgnoredAttributes>;
 
+def err_module_cache_key_spelling : Error<
+  "option '-fmodule-file-cache-key' should be of the form <path>=<key>">;
+
 let CategoryName = "Instrumentation Issue" in {
 def warn_profile_data_out_of_date : Warning<
   "profile data may be out of date: of %0 function%s0, %1 %plural{1:has|:have}1"

--- a/clang/include/clang/Basic/LLVM.h
+++ b/clang/include/clang/Basic/LLVM.h
@@ -53,6 +53,7 @@ namespace llvm {
   // TODO: DenseMap, ...
 
   namespace cas {
+  class ActionCache;
   class ObjectStore;
   class CASID;
   class ObjectProxy;
@@ -99,6 +100,7 @@ namespace clang {
   using llvm::raw_pwrite_stream;
 
   namespace cas {
+  using llvm::cas::ActionCache;
   using llvm::cas::CASID;
   using llvm::cas::ObjectProxy;
   using llvm::cas::ObjectRef;

--- a/clang/include/clang/Basic/Module.h
+++ b/clang/include/clang/Basic/Module.h
@@ -184,6 +184,9 @@ private:
   /// corresponding serialized AST file, or null otherwise.
   Optional<FileEntryRef> ASTFile;
 
+  /// The \c ActionCache key for this module, if any.
+  Optional<std::string> ModuleCacheKey;
+
   /// The top-level headers associated with this module.
   llvm::SmallSetVector<const FileEntry *, 2> TopHeaders;
 
@@ -611,6 +614,15 @@ public:
     assert((!File || !getASTFile() || getASTFile() == File) &&
            "file path changed");
     getTopLevelModule()->ASTFile = File;
+  }
+
+  Optional<std::string> getModuleCacheKey() const {
+    return getTopLevelModule()->ModuleCacheKey;
+  }
+
+  void setModuleCacheKey(std::string Key) {
+    assert(!getModuleCacheKey() || *getModuleCacheKey() == Key);
+    getTopLevelModule()->ModuleCacheKey = std::move(Key);
   }
 
   /// Retrieve the directory for which this module serves as the

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5820,6 +5820,12 @@ def ftest_module_file_extension_EQ :
   Joined<["-"], "ftest-module-file-extension=">,
   HelpText<"introduce a module file extension for testing purposes. "
            "The argument is parsed as blockname:major:minor:hashed:user info">;
+def fmodule_file_cache_key : Joined<["-"], "fmodule-file-cache-key=">,
+  MetaVarName<"<path>=<key>">,
+  HelpText<"Make the module with the given compile job cache key available as "
+           "if it were at <path>. This option may be combined with "
+           "-fmodule-file= to import the module. The module must have "
+           "previously been built with -fcache-compile-job.">;
 def fconcepts_ts : Flag<["-"], "fconcepts-ts">,
   HelpText<"Enable C++ Extensions for Concepts. (deprecated - use -std=c++2a)">;
 

--- a/clang/include/clang/Frontend/CompileJobCacheResult.h
+++ b/clang/include/clang/Frontend/CompileJobCacheResult.h
@@ -49,6 +49,9 @@ public:
 
   size_t getNumOutputs() const;
 
+  /// Retrieves a specific output specified by \p Kind, if it exists.
+  Optional<Output> getOutput(OutputKind Kind) const;
+
   /// Print this result to \p OS.
   llvm::Error print(llvm::raw_ostream &OS);
 

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -21,6 +21,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/CAS/CASID.h"
 #include "llvm/CAS/CASOutputBackend.h"
 #include "llvm/Support/BuryPointer.h"
 #include "llvm/Support/FileSystem.h"
@@ -89,6 +90,9 @@ class CompilerInstance : public ModuleLoader {
 
   /// The ActionCache, if any.
   std::shared_ptr<llvm::cas::ActionCache> ActionCache;
+
+  /// The \c ActionCache key for this compilation, if caching is enabled.
+  Optional<cas::CASID> CompileJobCacheKey;
 
   /// The file manager.
   IntrusiveRefCntPtr<FileManager> FileMgr;
@@ -327,6 +331,14 @@ public:
   }
   const CASOptions &getCASOpts() const {
     return Invocation->getCASOpts();
+  }
+
+  Optional<cas::CASID> getCompileJobCacheKey() const {
+    return CompileJobCacheKey;
+  }
+  void setCompileJobCacheKey(cas::CASID Key) {
+    assert(!CompileJobCacheKey || CompileJobCacheKey == Key);
+    CompileJobCacheKey = std::move(Key);
   }
 
   /// }
@@ -693,6 +705,7 @@ public:
       ArrayRef<std::shared_ptr<DependencyCollector>> DependencyCollectors,
       void *DeserializationListener, bool OwnDeserializationListener,
       bool Preamble, bool UseGlobalModuleIndex,
+      cas::ObjectStore &CAS, cas::ActionCache &Cache,
       std::unique_ptr<llvm::MemoryBuffer> PCHBuffer = nullptr);
 
   /// Create a code completion consumer using the invocation; note that this
@@ -835,6 +848,16 @@ public:
   }
 
   void setExternalSemaSource(IntrusiveRefCntPtr<ExternalSemaSource> ESS);
+
+  /// Adds a module to the \c InMemoryModuleCache at \p Path by retrieving the
+  /// pcm output from the \c ActionCache for \p CacheKey.
+  ///
+  /// \param Provider description of what provided this cache key, e.g.
+  /// "-fmodule-file-cache-key", or an imported pcm file. Used in diagnostics.
+  ///
+  /// \returns true on failure.
+  bool addCachedModuleFile(StringRef Path, StringRef CacheKey,
+                           StringRef Provider);
 
   InMemoryModuleCache &getModuleCache() const { return *ModuleCache; }
 };

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -505,6 +505,10 @@ public:
   /// The list of AST files to merge.
   std::vector<std::string> ASTMergeFiles;
 
+  /// The list of prebuilt module file paths to make available by reading their
+  /// contents from the \c ActionCache with the given compile job cache key.
+  std::vector<std::pair<std::string, std::string>> ModuleCacheKeys;
+
   /// A list of arguments to forward to LLVM's option processing; this
   /// should only be used for debugging and experimental features.
   std::vector<std::string> LLVMArgs;

--- a/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/clang/include/clang/Serialization/ASTBitCodes.h
@@ -41,7 +41,7 @@ namespace serialization {
 /// Version 4 of AST files also requires that the version control branch and
 /// revision match exactly, since there is no backward compatibility of
 /// AST files at this time.
-const unsigned VERSION_MAJOR = 22;
+const unsigned VERSION_MAJOR = 23;
 
 /// AST file minor version number supported by this version of
 /// Clang.
@@ -360,6 +360,9 @@ enum ControlRecordTypes {
 
   /// Record code for the module build directory.
   MODULE_DIRECTORY,
+
+  /// Record code for the (optional) \c ActionCache  key for this module.
+  MODULE_CACHE_KEY,
 };
 
 /// Record types that occur within the options block inside

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -221,6 +221,14 @@ public:
   /// AST file imported by this AST file.
   virtual void visitImport(StringRef ModuleName, StringRef Filename) {}
 
+  /// Called for each module cache key.
+  ///
+  /// \returns true to indicate the key cannot be loaded.
+  virtual bool readModuleCacheKey(StringRef ModuleName, StringRef Filename,
+                                  StringRef CacheKey) {
+    return false;
+  }
+
   /// Indicates that a particular module file extension has been read.
   virtual void readModuleFileExtension(
                  const ModuleFileExtensionMetadata &Metadata) {}
@@ -266,6 +274,8 @@ public:
                        serialization::ModuleKind Kind) override;
   bool visitInputFile(StringRef Filename, bool isSystem,
                       bool isOverridden, bool isExplicitModule) override;
+  bool readModuleCacheKey(StringRef ModuleName, StringRef Filename,
+                          StringRef CacheKey) override;
   void readModuleFileExtension(
          const ModuleFileExtensionMetadata &Metadata) override;
 };

--- a/clang/include/clang/Serialization/ModuleFile.h
+++ b/clang/include/clang/Serialization/ModuleFile.h
@@ -125,6 +125,9 @@ public:
   /// The file name of the module file.
   std::string FileName;
 
+  /// The \c ActionCache key for this module, or empty.
+  std::string ModuleCacheKey;
+
   /// The name of the module.
   std::string ModuleName;
 

--- a/clang/lib/Frontend/CompileJobCacheResult.cpp
+++ b/clang/lib/Frontend/CompileJobCacheResult.cpp
@@ -34,6 +34,17 @@ Error CompileJobCacheResult::forEachOutput(
   return Error::success();
 }
 
+Optional<CompileJobCacheResult::Output>
+CompileJobCacheResult::getOutput(OutputKind Kind) const {
+  size_t Count = getNumOutputs();
+  for (size_t I = 0; I < Count; ++I) {
+    OutputKind K = getOutputKind(I);
+    if (Kind == K)
+      return Output{getOutputObject(I), Kind};
+  }
+  return None;
+}
+
 static void printOutputKind(llvm::raw_ostream &OS,
                             CompileJobCacheResult::OutputKind Kind) {
   switch (Kind) {

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -12,6 +12,7 @@
 #include "clang/AST/Decl.h"
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/DiagnosticCAS.h"
 #include "clang/Basic/DiagnosticOptions.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/LangStandard.h"
@@ -22,6 +23,7 @@
 #include "clang/Config/config.h"
 #include "clang/Frontend/CASDependencyCollector.h"
 #include "clang/Frontend/ChainedDiagnosticConsumer.h"
+#include "clang/Frontend/CompileJobCacheResult.h"
 #include "clang/Frontend/FrontendAction.h"
 #include "clang/Frontend/FrontendActions.h"
 #include "clang/Frontend/FrontendDiagnostic.h"
@@ -43,6 +45,8 @@
 #include "clang/Serialization/InMemoryModuleCache.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/Statistic.h"
+#include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/ObjectStore.h"
 #include "llvm/Support/BuryPointer.h"
 #include "llvm/Support/CrashRecoveryContext.h"
 #include "llvm/Support/Errc.h"
@@ -627,6 +631,23 @@ struct ReadModuleNames : ASTReaderListener {
     LoadedModules.clear();
   }
 };
+
+class CompileCacheASTReaderHelper : public ASTReaderListener {
+public:
+  CompileCacheASTReaderHelper(cas::ObjectStore &CAS, cas::ActionCache &Cache,
+                              InMemoryModuleCache &ModuleCache,
+                              DiagnosticsEngine &Diags)
+      : CAS(CAS), Cache(Cache), ModuleCache(ModuleCache), Diags(Diags) {}
+
+  bool readModuleCacheKey(StringRef ModuleName, StringRef Filename,
+                          StringRef CacheKey) override;
+
+private:
+  cas::ObjectStore &CAS;
+  cas::ActionCache &Cache;
+  InMemoryModuleCache &ModuleCache;
+  DiagnosticsEngine &Diags;
+};
 } // namespace
 
 void CompilerInstance::createPCHExternalASTSource(
@@ -641,7 +662,8 @@ void CompilerInstance::createPCHExternalASTSource(
       getASTContext(), getPCHContainerReader(),
       getFrontendOpts().ModuleFileExtensions, DependencyCollectors,
       DeserializationListener, OwnDeserializationListener, Preamble,
-      getFrontendOpts().UseGlobalModuleIndex, std::move(PCHBuffer));
+      getFrontendOpts().UseGlobalModuleIndex,
+      getOrCreateObjectStore(), getOrCreateActionCache(), std::move(PCHBuffer));
 }
 
 IntrusiveRefCntPtr<ASTReader> CompilerInstance::createPCHExternalASTSource(
@@ -654,6 +676,7 @@ IntrusiveRefCntPtr<ASTReader> CompilerInstance::createPCHExternalASTSource(
     ArrayRef<std::shared_ptr<DependencyCollector>> DependencyCollectors,
     void *DeserializationListener, bool OwnDeserializationListener,
     bool Preamble, bool UseGlobalModuleIndex,
+    cas::ObjectStore &CAS, cas::ActionCache &Cache,
     std::unique_ptr<llvm::MemoryBuffer> PCHBuffer) {
   HeaderSearchOptions &HSOpts = PP.getHeaderSearchInfo().getHeaderSearchOpts();
 
@@ -674,6 +697,9 @@ IntrusiveRefCntPtr<ASTReader> CompilerInstance::createPCHExternalASTSource(
 
   for (auto &Listener : DependencyCollectors)
     Listener->attachToASTReader(*Reader);
+
+  Reader->addListener(std::make_unique<CompileCacheASTReaderHelper>(
+      CAS, Cache, ModuleCache, PP.getDiagnostics()));
 
   auto Listener = std::make_unique<ReadModuleNames>(PP);
   auto &ListenerRef = *Listener;
@@ -1686,6 +1712,10 @@ void CompilerInstance::createASTReader() {
 
   for (auto &Listener : DependencyCollectors)
     Listener->attachToASTReader(*TheASTReader);
+
+  TheASTReader->addListener(std::make_unique<CompileCacheASTReaderHelper>(
+      getOrCreateObjectStore(), getOrCreateActionCache(), getModuleCache(),
+      getDiagnostics()));
 }
 
 bool CompilerInstance::loadModuleFile(StringRef FileName) {
@@ -2287,4 +2317,67 @@ void CompilerInstance::resetAndLeakSema() { llvm::BuryPointer(takeSema()); }
 void CompilerInstance::setExternalSemaSource(
     IntrusiveRefCntPtr<ExternalSemaSource> ESS) {
   ExternalSemaSrc = std::move(ESS);
+}
+
+static bool addCachedModuleFileToInMemoryCache(
+    StringRef Path, StringRef CacheKey, StringRef Provider,
+    cas::ObjectStore &CAS, cas::ActionCache &Cache,
+    InMemoryModuleCache &ModuleCache, DiagnosticsEngine &Diags) {
+
+  if (ModuleCache.lookupPCM(Path))
+    return false;
+
+  auto ID = CAS.parseID(CacheKey);
+  if (!ID) {
+    Diags.Report(diag::err_cas_cannot_get_module_cache_key)
+        << CacheKey << Provider << ID.takeError();
+    return true;
+  }
+
+  auto Value = Cache.get(*ID);
+  if (!Value || !*Value) {
+    auto Diag = Diags.Report(diag::err_cas_cannot_get_module_cache_key)
+                << CacheKey << Provider;
+    if (!Value)
+      Diag << Value.takeError();
+    else
+      Diag << "no such entry in action cache";
+    return true;
+  }
+
+  Optional<cas::CompileJobCacheResult> Result;
+  cas::CompileJobResultSchema Schema(CAS);
+  if (llvm::Error E = Schema.load(**Value).moveInto(Result)) {
+    Diags.Report(diag::err_cas_cannot_get_module_cache_key)
+        << CacheKey << Provider << std::move(E);
+    return true;
+  }
+  auto Output =
+      Result->getOutput(cas::CompileJobCacheResult::OutputKind::MainOutput);
+  if (!Output)
+    llvm::report_fatal_error("missing main output");
+  auto OutputProxy = CAS.getProxy(Output->Object);
+  if (!OutputProxy) {
+    Diags.Report(diag::err_cas_cannot_get_module_cache_key)
+        << CacheKey << Provider << OutputProxy.takeError();
+    return true;
+  }
+
+  ModuleCache.addPCM(Path, OutputProxy->getMemoryBuffer());
+  return false;
+}
+
+bool CompilerInstance::addCachedModuleFile(StringRef Path, StringRef CacheKey,
+                                           StringRef Provider) {
+  return addCachedModuleFileToInMemoryCache(
+      Path, CacheKey, Provider, getOrCreateObjectStore(),
+      getOrCreateActionCache(), getModuleCache(), getDiagnostics());
+}
+
+bool CompileCacheASTReaderHelper::readModuleCacheKey(StringRef ModuleName,
+                                                     StringRef Filename,
+                                                     StringRef CacheKey) {
+  // FIXME: add name/path of the importing module?
+  return addCachedModuleFileToInMemoryCache(
+      Filename, CacheKey, "imported module", CAS, Cache, ModuleCache, Diags);
 }

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2664,6 +2664,8 @@ static void GenerateFrontendArgs(const FrontendOptions &Opts,
 
   for (const auto &ModuleFile : Opts.ModuleFiles)
     GenerateArg(Args, OPT_fmodule_file, ModuleFile, SA);
+  for (const auto &A : Opts.ModuleCacheKeys)
+    GenerateArg(Args, OPT_fmodule_file_cache_key, A.first + "=" + A.second, SA);
 
   if (Opts.AuxTargetCPU)
     GenerateArg(Args, OPT_aux_target_cpu, *Opts.AuxTargetCPU, SA);
@@ -2897,6 +2899,14 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     StringRef Val = A->getValue();
     if (!Val.contains('='))
       Opts.ModuleFiles.push_back(std::string(Val));
+  }
+  for (const Arg *A : Args.filtered(OPT_fmodule_file_cache_key)) {
+    auto [Path, Key] = StringRef(A->getValue()).rsplit('=');
+    if (Key.empty() || Path.empty()) {
+      Diags.Report(diag::err_module_cache_key_spelling);
+    } else {
+      Opts.ModuleCacheKeys.emplace_back(std::string(Path), std::string(Key));
+    }
   }
 
   if (Opts.ProgramAction != frontend::GenerateModule && Opts.IsSystemModule)

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -510,6 +510,9 @@ static Module *prepareToBuildModule(CompilerInstance &CI,
   // be resolved relative to the build directory of the module map file.
   CI.getPreprocessor().setMainFileDir(M->Directory);
 
+  if (auto CacheKey = CI.getCompileJobCacheKey())
+    M->setModuleCacheKey(CacheKey->toString());
+
   // If the module was inferred from a different module map (via an expanded
   // umbrella module definition), track that fact.
   // FIXME: It would be preferable to fill this in as part of processing
@@ -1054,6 +1057,12 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
            "modules enabled but created an external source that "
            "doesn't support modules");
   }
+
+  // Provide any modules from the action cache.
+  for (const auto &KeyPair : CI.getFrontendOpts().ModuleCacheKeys)
+    if (CI.addCachedModuleFile(KeyPair.first, KeyPair.second,
+                               "-fmodule-file-cache-key"))
+      return false;
 
   // If we were asked to load any module files, do so now.
   for (const auto &ModuleFile : CI.getFrontendOpts().ModuleFiles)

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -253,6 +253,13 @@ bool ChainedASTReaderListener::visitInputFile(StringRef Filename,
   return Continue;
 }
 
+bool ChainedASTReaderListener::readModuleCacheKey(StringRef ModuleName,
+                                                  StringRef Filename,
+                                                  StringRef CacheKey) {
+  return First->readModuleCacheKey(ModuleName, Filename, CacheKey) ||
+         Second->readModuleCacheKey(ModuleName, Filename, CacheKey);
+}
+
 void ChainedASTReaderListener::readModuleFileExtension(
        const ModuleFileExtensionMetadata &Metadata) {
   First->readModuleFileExtension(Metadata);
@@ -2819,6 +2826,7 @@ ASTReader::ReadControlBlock(ModuleFile &F,
 
         std::string ImportedName = ReadString(Record, Idx);
         std::string ImportedFile;
+        std::string ImportedCacheKey;
 
         // For prebuilt and explicit modules first consult the file map for
         // an override. Note that here we don't search prebuilt module
@@ -2829,12 +2837,26 @@ ASTReader::ReadControlBlock(ModuleFile &F,
           ImportedFile = PP.getHeaderSearchInfo().getPrebuiltModuleFileName(
             ImportedName, /*FileMapOnly*/ true);
 
-        if (ImportedFile.empty())
+        if (ImportedFile.empty()) {
           // Use BaseDirectoryAsWritten to ensure we use the same path in the
           // ModuleCache as when writing.
           ImportedFile = ReadPath(BaseDirectoryAsWritten, Record, Idx);
-        else
+          ImportedCacheKey = ReadString(Record, Idx);
+        } else {
           SkipPath(Record, Idx);
+          SkipString(Record, Idx);
+        }
+
+        if (!ImportedCacheKey.empty()) {
+          if (!Listener || Listener->readModuleCacheKey(
+                               ImportedName, ImportedFile, ImportedCacheKey)) {
+            Diag(diag::err_ast_file_not_found)
+                << moduleKindForDiagnostic(ImportedKind) << ImportedFile << true
+                << std::string("missing or unloadable module cache key") +
+                       ImportedCacheKey;
+            return Failure;
+          }
+        }
 
         // If our client can't cope with us being out of date, we can't cope with
         // our dependency being missing.
@@ -2943,6 +2965,10 @@ ASTReader::ReadControlBlock(ModuleFile &F,
           (const llvm::support::unaligned_uint64_t *)Blob.data();
       F.InputFilesLoaded.resize(NumInputs);
       F.NumUserInputFiles = NumUserInputs;
+      break;
+
+    case MODULE_CACHE_KEY:
+      F.ModuleCacheKey = Blob.str();
       break;
     }
   }
@@ -5360,6 +5386,8 @@ bool ASTReader::readASTFileControlBlock(
         std::string ModuleName = ReadString(Record, Idx);
         std::string Filename = ReadString(Record, Idx);
         ResolveImportedPath(Filename, ModuleDir);
+        std::string CacheKey = ReadString(Record, Idx);
+        Listener.readModuleCacheKey(ModuleName, Filename, CacheKey);
         Listener.visitImport(ModuleName, Filename);
       }
       break;
@@ -5563,6 +5591,8 @@ llvm::Error ASTReader::ReadSubmoduleBlock(ModuleFile &F,
         F.DidReadTopLevelSubmodule = true;
         CurrentModule->setASTFile(F.File);
         CurrentModule->PresumedModuleMapFile = F.ModuleMapPath;
+        if (!F.ModuleCacheKey.empty())
+          CurrentModule->setModuleCacheKey(F.ModuleCacheKey);
       }
 
       CurrentModule->Kind = Kind;

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -788,6 +788,7 @@ void ASTWriter::WriteBlockInfoBlock() {
   RECORD(ORIGINAL_FILE);
   RECORD(ORIGINAL_FILE_ID);
   RECORD(INPUT_FILE_OFFSETS);
+  RECORD(MODULE_CACHE_KEY);
 
   BLOCK(OPTIONS_BLOCK);
   RECORD(LANGUAGE_OPTIONS);
@@ -1296,6 +1297,18 @@ void ASTWriter::WriteControlBlock(Preprocessor &PP, ASTContext &Context,
     Stream.EmitRecord(MODULE_MAP_FILE, Record);
   }
 
+  // Module Cache Key
+  if (WritingModule) {
+    if (auto Key = WritingModule->getModuleCacheKey()) {
+      auto Abbrev = std::make_shared<BitCodeAbbrev>();
+      Abbrev->Add(BitCodeAbbrevOp(MODULE_CACHE_KEY));
+      Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Blob));
+      unsigned AbbrevCode = Stream.EmitAbbrev(std::move(Abbrev));
+      RecordData::value_type Record[] = {MODULE_CACHE_KEY};
+      Stream.EmitRecordWithBlob(AbbrevCode, Record, *Key);
+    }
+  }
+
   // Imports
   if (Chain) {
     serialization::ModuleManager &Mgr = Chain->getModuleManager();
@@ -1318,6 +1331,7 @@ void ASTWriter::WriteControlBlock(Preprocessor &PP, ASTContext &Context,
 
       AddString(M.ModuleName, Record);
       AddPath(M.FileName, Record);
+      AddString(M.ModuleCacheKey, Record);
     }
     Stream.EmitRecord(IMPORTS, Record);
   }

--- a/clang/lib/Serialization/GlobalModuleIndex.cpp
+++ b/clang/lib/Serialization/GlobalModuleIndex.cpp
@@ -658,6 +658,9 @@ llvm::Error GlobalModuleIndexBuilder::loadModuleFile(const FileEntry *File) {
                                       Record.begin() + Idx + Length);
         Idx += Length;
 
+        // Skip the module cache key.
+        Idx += Record[Idx] + 1;
+
         // Find the imported module file.
         auto DependsOnFile
           = FileMgr.getFile(ImportedFile, /*OpenFile=*/false,

--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -463,6 +463,16 @@ bool ModuleManager::lookupModuleFile(StringRef FileName, off_t ExpectedSize,
   Optional<FileEntryRef> FileOrErr =
       expectedToOptional(FileMgr.getFileRef(FileName, /*OpenFile=*/true,
                                             /*CacheFailure=*/false));
+
+  // If the file is known to the module cache but not in the filesystem, it is
+  // a memory buffer. Create a virtual file for it.
+  if (!FileOrErr) {
+    if (auto *KnownBuffer = getModuleCache().lookupPCM(FileName)) {
+      FileOrErr =
+          FileMgr.getVirtualFileRef(FileName, KnownBuffer->getBufferSize(), 0);
+    }
+  }
+
   if (!FileOrErr)
     return false;
 

--- a/clang/test/CAS/fmodule-file-cache-key-errors.c
+++ b/clang/test/CAS/fmodule-file-cache-key-errors.c
@@ -1,0 +1,54 @@
+// Checks error conditions related to -fmodule-file-cache-key, e.g. missing
+// cache entry, invalid id, etc.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+
+// RUN: not %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   -fmodule-file-cache-key=INVALID \
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/invalid.txt
+// RUN: cat %t/invalid.txt | FileCheck %s -check-prefix=INVALID
+
+// INVALID: error: option '-fmodule-file-cache-key' should be of the form <path>=<key>
+
+// RUN: not %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   -fmodule-file-cache-key=PATH=KEY \
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/bad_key.txt
+// RUN: cat %t/bad_key.txt | FileCheck %s -check-prefix=BAD_KEY
+
+// BAD_KEY: error: CAS cannot load module with key 'KEY' from -fmodule-file-cache-key: invalid cas-id 'KEY'
+
+// RUN: echo -n '-fmodule-file-cache-key=PATH=' > %t/not_in_cache.rsp
+// RUN: cat %t/casid >> %t/not_in_cache.rsp
+
+// RUN: not %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   @%t/not_in_cache.rsp \
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/not_in_cache.txt
+// RUN: cat %t/not_in_cache.txt | FileCheck %s -check-prefix=NOT_IN_CACHE
+
+// NOT_IN_CACHE: error: CAS cannot load module with key '{{.*}}' from -fmodule-file-cache-key: no such entry in action cache
+
+//--- module.modulemap
+module A { header "A.h" }
+
+//--- A.h
+void A(void);
+
+//--- tu.c
+#include "A.h"
+void tu(void) {
+  A();
+}

--- a/clang/test/CAS/fmodule-file-cache-key-lazy.c
+++ b/clang/test/CAS/fmodule-file-cache-key-lazy.c
@@ -1,0 +1,77 @@
+// Tests for combining -fmodule-file-cache-key with lazy-loading modules via
+// -fmodule-file=<NAME>=<PATH>.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+
+// == Build B
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=B -fno-implicit-modules \
+// RUN:   -emit-module %t/module.modulemap -o %t/B.pcm \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.txt
+// RUN: cat %t/B.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: cat %t/B.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/B.key
+
+// == Build A, importing B
+
+// RUN: echo -n '-fmodule-file-cache-key=%t/B.pcm=' > %t/B.import.rsp
+// RUN: cat %t/B.key >> %t/B.import.rsp
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
+// RUN:   @%t/B.import.rsp -fmodule-file=B=%t/B.pcm \
+// RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
+// RUN: cat %t/A.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: cat %t/A.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/A.key
+
+// == Build tu, importing A (implicitly importing B)
+
+// RUN: echo -n '-fmodule-file-cache-key=%t/A.pcm=' > %t/A.import.rsp
+// RUN: cat %t/A.key >> %t/A.import.rsp
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   @%t/A.import.rsp -fmodule-file=A=%t/A.pcm \
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.txt
+// RUN: cat %t/tu.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+
+// == Ensure we're reading pcm from cache
+
+// RUN: rm %t/*.pcm
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   @%t/A.import.rsp -fmodule-file=A=%t/A.pcm \
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.2.txt
+// RUN: cat %t/tu.out.2.txt | FileCheck %s --check-prefix=CACHE-HIT
+
+// CACHE-HIT: remark: compile job cache hit
+// CACHE-MISS: remark: compile job cache miss
+
+//--- module.modulemap
+module A { header "A.h" export * }
+module B { header "B.h" }
+
+//--- A.h
+#include "B.h"
+
+//--- B.h
+void B(void);
+
+//--- tu.c
+#include "A.h"
+void tu(void) {
+  B();
+}

--- a/clang/test/CAS/fmodule-file-cache-key-with-pch.c
+++ b/clang/test/CAS/fmodule-file-cache-key-with-pch.c
@@ -1,0 +1,114 @@
+// Check that -fmodule-file-cache-key works with mixed PCH+modules builds.
+// This test mimics the way the dep scanner handles PCH (ie. treat it as a file
+// input, ingested into the cas fs).
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+
+// == Build B
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=B -fno-implicit-modules \
+// RUN:   -emit-module %t/module.modulemap -o %t/B.pcm \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.txt
+// RUN: cat %t/B.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: cat %t/B.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/B.key
+
+// == Build A, importing B
+
+// RUN: echo -n '-fmodule-file-cache-key=%t/B.pcm=' > %t/B.import.rsp
+// RUN: cat %t/B.key >> %t/B.import.rsp
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
+// RUN:   @%t/B.import.rsp -fmodule-file=%t/B.pcm \
+// RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
+// RUN: cat %t/A.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: cat %t/A.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/A.key
+
+// == Build C, importing B
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=C -fno-implicit-modules \
+// RUN:   @%t/B.import.rsp -fmodule-file=%t/B.pcm \
+// RUN:   -emit-module %t/module.modulemap -o %t/C.pcm \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/C.out.txt
+// RUN: cat %t/C.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: cat %t/C.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/C.key
+
+// == Build PCH, importing A (implicitly importing B)
+
+// RUN: echo -n '-fmodule-file-cache-key=%t/A.pcm=' > %t/A.import.rsp
+// RUN: cat %t/A.key >> %t/A.import.rsp
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   @%t/A.import.rsp -fmodule-file=%t/A.pcm \
+// RUN:   -emit-pch -x c-header %t/prefix.h -o %t/prefix.pch \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/prefix.out.txt
+// RUN: cat %t/prefix.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+
+// == Clear pcms to ensure they load from cache, and re-ingest with pch
+
+// RUN: rm %t/*.pcm
+// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+// RUN: rm %t/*.pch
+
+// == Build tu
+
+// RUN: echo -n '-fmodule-file-cache-key=%t/C.pcm=' > %t/C.import.rsp
+// RUN: cat %t/C.key >> %t/C.import.rsp
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   @%t/C.import.rsp -fmodule-file=%t/C.pcm -include-pch %t/prefix.pch \
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.txt
+// RUN: cat %t/tu.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+
+// == Ensure we're reading pcm from cache
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   @%t/C.import.rsp -fmodule-file=%t/C.pcm -include-pch %t/prefix.pch \
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.2.txt
+// RUN: cat %t/tu.out.2.txt | FileCheck %s --check-prefix=CACHE-HIT
+
+// CACHE-HIT: remark: compile job cache hit
+// CACHE-MISS: remark: compile job cache miss
+
+//--- module.modulemap
+module A { header "A.h" export * }
+module B { header "B.h" }
+module C { header "C.h" export * }
+
+//--- A.h
+#include "B.h"
+
+//--- B.h
+void B(void);
+
+//--- C.h
+#include "B.h"
+void B(void);
+
+//--- prefix.h
+#include "A.h"
+
+//--- tu.c
+#include "C.h"
+void tu(void) {
+  B();
+}

--- a/clang/test/CAS/fmodule-file-cache-key.c
+++ b/clang/test/CAS/fmodule-file-cache-key.c
@@ -1,0 +1,77 @@
+// Tests for providing the contents of pcm files via -fmodule-file-cache-key and
+// previously cached module compilations.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+
+// == Build B
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=B -fno-implicit-modules \
+// RUN:   -emit-module %t/module.modulemap -o %t/B.pcm \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.txt
+// RUN: cat %t/B.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: cat %t/B.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/B.key
+
+// == Build A, importing B
+
+// RUN: echo -n '-fmodule-file-cache-key=%t/B.pcm=' > %t/B.import.rsp
+// RUN: cat %t/B.key >> %t/B.import.rsp
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
+// RUN:   @%t/B.import.rsp -fmodule-file=%t/B.pcm \
+// RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
+// RUN: cat %t/A.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: cat %t/A.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/A.key
+
+// == Build tu, importing A (implicitly importing B)
+
+// RUN: echo -n '-fmodule-file-cache-key=%t/A.pcm=' > %t/A.import.rsp
+// RUN: cat %t/A.key >> %t/A.import.rsp
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   @%t/A.import.rsp -fmodule-file=%t/A.pcm\
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.txt
+// RUN: cat %t/tu.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+
+// == Ensure we're reading pcm from cache
+
+// RUN: rm %t/*.pcm
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   @%t/A.import.rsp -fmodule-file=%t/A.pcm\
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.2.txt
+// RUN: cat %t/tu.out.2.txt | FileCheck %s --check-prefix=CACHE-HIT
+
+// CACHE-HIT: remark: compile job cache hit
+// CACHE-MISS: remark: compile job cache miss
+
+//--- module.modulemap
+module A { header "A.h" export * }
+module B { header "B.h" }
+
+//--- A.h
+#include "B.h"
+
+//--- B.h
+void B(void);
+
+//--- tu.c
+#include "A.h"
+void tu(void) {
+  B();
+}

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -522,6 +522,8 @@ Optional<int> CompileJobCache::tryReplayCachedResult(CompilerInstance &Clang) {
   if (!ResultCacheKey)
     return 1;
 
+  Clang.setCompileJobCacheKey(*ResultCacheKey);
+
   Expected<bool> ReplayedResult =
       CacheBackend->tryReplayCachedResult(*ResultCacheKey);
   if (!ReplayedResult)


### PR DESCRIPTION
This option provides a way to read modules that were built using `-fcache-compile-job` by looking them up in the action cache. This will be used as a building block for adding compile-job caching support to explicit modules builds. A future change will teach the dep scanner to produce invocations that build modules with caching enabled, and load them using the action cache.

The option takes a string of the form `<path>=<key>`, and reads a compile-job cache result for `<key>` from the action cache. The contents of the previously built pcm are made available as if they were at `<path>`. The path is significant for -gmodules builds, which embed the path for debug info. Otherwise, the path must at least be unique. The intention is that we will eventually canonicalize this path when building with prefix mappings.

The `-fmodule-file-cache-key=` option is currently designed to be combined with the existing `-fmodule-file=` option -- the cache key makes the module file available, while `-fmodule-file=` controls when it is imported (eagerly or lazily).