### PR TITLE
[stable][clang][cas] Ignore the `-fdepfile-entry=` dependency option when calculating the cache key

### DIFF
--- a/clang/include/clang/Frontend/CASDependencyCollector.h
+++ b/clang/include/clang/Frontend/CASDependencyCollector.h
@@ -27,7 +27,7 @@ public:
   /// \param Callback Callback that receives the resulting dependencies on
   ///                 completion, or \c None if an error occurred.
   CASDependencyCollector(
-      const DependencyOutputOptions &Opts, cas::ObjectStore &CAS,
+      DependencyOutputOptions Opts, cas::ObjectStore &CAS,
       std::function<void(Optional<cas::ObjectRef>)> Callback);
 
   /// Replay the given result, which should have been created by a

--- a/clang/lib/Frontend/CompileJobCacheKey.cpp
+++ b/clang/lib/Frontend/CompileJobCacheKey.cpp
@@ -79,6 +79,9 @@ clang::createCompileJobCacheKey(ObjectStore &CAS, DiagnosticsEngine &Diags,
   if (!DepOpts.Targets.empty())
     DepOpts.Targets = {"-"};
   DepOpts.UsePhonyTargets = false;
+  // These are added in when the dependency file is generated, but they don't
+  // affect the actual compilation.
+  DepOpts.ExtraDeps.clear();
 
   // Generate a new command-line in case Invocation has been canonicalized.
   llvm::BumpPtrAllocator Alloc;


### PR DESCRIPTION
`-fdepfile-entry=` is a dependency option that can be treated as "transparent", not affecting the cached compilation. The passed-in filenames are added at the point where the dependency file is generated and are not read from the file system.

rdar://99683427
(cherry picked from commit dde9a72957d7964532affa8ee1118e53576bc99b)