### PR TITLE
[Lex/DependencyDirectivesScanner] Handle the case where the source line starts with a `tok::hashhash`

### DIFF
--- a/clang/lib/Lex/DependencyDirectivesScanner.cpp
+++ b/clang/lib/Lex/DependencyDirectivesScanner.cpp
@@ -742,6 +742,14 @@ bool Scanner::lexPPLine(const char *&First, const char *const End) {
 
   // Lex '#'.
   const dependency_directives_scan::Token &HashTok = lexToken(First, End);
+  if (HashTok.is(tok::hashhash)) {
+    // A \p tok::hashhash at this location is passed by the preprocessor to the
+    // parser to interpret, like any other token. So for dependency scanning
+    // skip it like a normal token not affecting the preprocessor.
+    skipLine(First, End);
+    assert(First <= End);
+    return false;
+  }
   assert(HashTok.is(tok::hash));
   (void)HashTok;
 

--- a/clang/unittests/Lex/DependencyDirectivesScannerTest.cpp
+++ b/clang/unittests/Lex/DependencyDirectivesScannerTest.cpp
@@ -124,6 +124,21 @@ TEST(MinimizeSourceToDependencyDirectivesTest, EmptyHash) {
   EXPECT_STREQ("#define MACRO a\n", Out.data());
 }
 
+TEST(MinimizeSourceToDependencyDirectivesTest, HashHash) {
+  SmallVector<char, 128> Out;
+
+  StringRef Source = R"(
+    #define S
+    #if 0
+      ##pragma cool
+      ##include "t.h"
+    #endif
+    #define E
+    )";
+  ASSERT_FALSE(minimizeSourceToDependencyDirectives(Source, Out));
+  EXPECT_STREQ("#define S\n#if 0\n#endif\n#define E\n", Out.data());
+}
+
 TEST(MinimizeSourceToDependencyDirectivesTest, Define) {
   SmallVector<char, 128> Out;
   SmallVector<dependency_directives_scan::Token, 4> Tokens;


### PR DESCRIPTION
Differential Revision: https://reviews.llvm.org/D133674

(cherry picked from commit b340c5ae4221a9752712621cd1df06cbc6dfd50b)