### PR TITLE
[next][clang][cas] Provide an abstraction for the mechanism that stores and retrieves compilation artifacts

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -42,8 +42,7 @@ def remark_compile_job_cache_hit : Remark<
   "compile job cache hit for '%0' => '%1'">, InGroup<CompileJobCacheHit>;
 def remark_compile_job_cache_miss : Remark<
   "compile job cache miss for '%0'">, InGroup<CompileJobCacheMiss>;
-def remark_compile_job_cache_miss_result_not_found : Remark<
-  "compile job cache miss for '%0' (result not found: '%1')">,
-  InGroup<CompileJobCacheMiss>;
+def err_compile_job_cache_failed : Error<
+  "compile job cache error: %0">, DefaultFatal;
 
 } // let Component = "CAS" in

--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -37,12 +37,12 @@ def err_clang_cache_cannot_find_binary: Error<
   "clang-cache cannot find compiler binary %0">;
 def err_clang_cache_missing_compiler_command: Error<
   "missing compiler command for clang-cache">;
+def err_caching_backend_fail: Error<
+  "caching backend error: %0">, DefaultFatal;
 
 def remark_compile_job_cache_hit : Remark<
   "compile job cache hit for '%0' => '%1'">, InGroup<CompileJobCacheHit>;
 def remark_compile_job_cache_miss : Remark<
   "compile job cache miss for '%0'">, InGroup<CompileJobCacheMiss>;
-def err_compile_job_cache_failed : Error<
-  "compile job cache error: %0">, DefaultFatal;
 
 } // let Component = "CAS" in

--- a/clang/test/CAS/fcache-compile-job.c
+++ b/clang/test/CAS/fcache-compile-job.c
@@ -3,18 +3,18 @@
 //
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache-hit -emit-obj %s -o %t/output.o 2>&1 \
+// RUN:   -Rcompile-job-cache -emit-obj %s -o %t/output.o 2>&1 \
 // RUN:   | FileCheck %s --allow-empty --check-prefix=CACHE-MISS
 // RUN: ls %t/output.o && rm %t/output.o
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache-hit -emit-obj %s -o %t/output.o 2>&1 \
+// RUN:   -Rcompile-job-cache -emit-obj %s -o %t/output.o 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CACHE-HIT
 // RUN: ls %t/output.o && rm %t/output.o
 // RUN: cd %t
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache-hit -emit-obj %s -o output.o 2>&1 \
+// RUN:   -Rcompile-job-cache -emit-obj %s -o output.o 2>&1 \
 // RUN:   | FileCheck %s --allow-empty --check-prefix=CACHE-HIT
 // RUN: ls %t/output.o
 //
@@ -22,9 +22,19 @@
 // RUN: mv %t/cas %t/cas.moved
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fcas-path %t/cas.moved -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache-hit -emit-obj %s -o output.o 2>&1 \
+// RUN:   -Rcompile-job-cache -emit-obj %s -o output.o 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CACHE-HIT
+// RUN: ls %t/output.o
+//
+// Check for a handling error if the CAS is removed but not action cache.
+// First need to ignest the input file so the compile cache can be constructed.
+// RUN: llvm-cas --ingest --cas %t/cas.new --data %s
+// RUN: not %clang -cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fcas-path %t/cas.new -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache -emit-obj %s -o output.o 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CACHE-ERROR
 // RUN: ls %t/output.o
 //
 // CACHE-HIT: remark: compile job cache hit
 // CACHE-MISS-NOT: remark: compile job cache hit
+// CACHE-ERROR: fatal error: compile job cache error:

--- a/clang/test/CAS/fcache-compile-job.c
+++ b/clang/test/CAS/fcache-compile-job.c
@@ -37,4 +37,4 @@
 //
 // CACHE-HIT: remark: compile job cache hit
 // CACHE-MISS-NOT: remark: compile job cache hit
-// CACHE-ERROR: fatal error: compile job cache error:
+// CACHE-ERROR: fatal error: caching backend error:

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -201,6 +201,77 @@ static int PrintSupportedCPUs(std::string TargetStr) {
 
 namespace {
 
+/// Represents a mechanism for storing and retrieving compilation artifacts.
+/// It includes common functionality and extension points for specific backend
+/// implementations.
+class CachingOutputs {
+public:
+  using OutputKind = cas::CompileJobCacheResult::OutputKind;
+
+  CachingOutputs(CompilerInstance &Clang);
+  virtual ~CachingOutputs() = default;
+
+  /// \returns true if result was found and replayed, false otherwise.
+  virtual Expected<bool>
+  tryReplayCachedResult(const llvm::cas::CASID &ResultCacheKey) = 0;
+
+  /// \returns true on failure, false on success.
+  virtual bool prepareOutputCollection() = 0;
+
+  /// Finish writing outputs from a computed result, after a cache miss.
+  virtual Error
+  finishComputedResult(const llvm::cas::CASID &ResultCacheKey) = 0;
+
+  void finishSerializedDiagnostics();
+
+protected:
+  StringRef getPathForOutputKind(OutputKind Kind);
+
+  bool prepareOutputCollectionCommon(
+      IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CacheOutputs);
+
+  CompilerInstance &Clang;
+  cas::CompileJobCacheResult::Builder CachedResultBuilder;
+  std::string OutputFile;
+  std::string SerialDiagsFile;
+  std::string DependenciesFile;
+  SmallString<256> ResultDiags;
+  std::unique_ptr<llvm::raw_ostream> ResultDiagsOS;
+  SmallString<256> SerialDiagsBuf;
+  Optional<llvm::vfs::OutputFile> SerialDiagsOutput;
+};
+
+/// Store and retrieve compilation artifacts using \p llvm::cas::ObjectStore and
+/// \p llvm::cas::ActionCache.
+class ObjectStoreCachingOutputs : public CachingOutputs {
+public:
+  ObjectStoreCachingOutputs(CompilerInstance &Clang,
+                            std::shared_ptr<llvm::cas::ObjectStore> DB,
+                            std::shared_ptr<llvm::cas::ActionCache> Cache)
+      : CachingOutputs(Clang), CAS(std::move(DB)), Cache(std::move(Cache)) {
+    CASOutputs = llvm::makeIntrusiveRefCnt<llvm::cas::CASOutputBackend>(*CAS);
+  }
+
+private:
+  Expected<bool>
+  tryReplayCachedResult(const llvm::cas::CASID &ResultCacheKey) override;
+
+  bool prepareOutputCollection() override;
+
+  Error finishComputedResult(const llvm::cas::CASID &ResultCacheKey) override;
+
+  /// Replay a cache hit.
+  ///
+  /// Return status if should exit immediately, otherwise None.
+  Optional<int> replayCachedResult(llvm::cas::ObjectRef ResultID,
+                                   bool JustComputedResult);
+
+  std::shared_ptr<llvm::cas::ObjectStore> CAS;
+  std::shared_ptr<llvm::cas::ActionCache> Cache;
+  IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> CASOutputs;
+  Optional<llvm::cas::ObjectRef> DependenciesOutput;
+};
+
 // Manage caching and replay of compile jobs.
 //
 // The high-level model is:
@@ -261,32 +332,22 @@ public:
   void finishComputedResult(CompilerInstance &Clang, bool Success);
 
 private:
-  /// Replay a cache hit.
-  ///
-  /// Return status if should exit immediately, otherwise None.
-  Optional<int> replayCachedResult(CompilerInstance &Clang,
-                                   llvm::cas::ObjectRef ResultID,
-                                   bool JustComputedResult);
+  int reportCachingBackendError(DiagnosticsEngine &Diag, Error &&E) {
+    Diag.Report(diag::err_caching_backend_fail) << llvm::toString(std::move(E));
+    return 1;
+  }
 
   bool CacheCompileJob = false;
 
   std::shared_ptr<llvm::cas::ObjectStore> CAS;
   std::shared_ptr<llvm::cas::ActionCache> Cache;
-  SmallString<256> ResultDiags;
   Optional<llvm::cas::CASID> ResultCacheKey;
-  std::unique_ptr<llvm::raw_ostream> ResultDiagsOS;
-  SmallString<256> SerialDiagsBuf;
-  IntrusiveRefCntPtr<llvm::cas::CASOutputBackend> CASOutputs;
-  cas::CompileJobCacheResult::Builder CachedResultBuilder;
-  std::string OutputFile;
-  std::string SerialDiagsFile;
-  std::string DependenciesFile;
-  Optional<llvm::cas::ObjectRef> DependenciesOutput;
-  Optional<llvm::vfs::OutputFile> SerialDiagsOutput;
+
+  std::unique_ptr<CachingOutputs> CacheBackend;
 };
 } // end anonymous namespace
 
-StringRef CompileJobCache::getPathForOutputKind(OutputKind Kind) {
+StringRef CachingOutputs::getPathForOutputKind(OutputKind Kind) {
   switch (Kind) {
   case OutputKind::MainOutput:
     return OutputFile;
@@ -344,6 +405,13 @@ Optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
   // other outputs during replay.
   FrontendOpts.IncludeTimestamps = false;
 
+  CacheBackend = std::make_unique<ObjectStoreCachingOutputs>(Clang, CAS, Cache);
+  return None;
+}
+
+CachingOutputs::CachingOutputs(CompilerInstance &Clang) : Clang(Clang) {
+  CompilerInvocation &Invocation = Clang.getInvocation();
+  FrontendOptions &FrontendOpts = Invocation.getFrontendOpts();
   if (!Clang.hasFileManager())
     Clang.createFileManager();
   FileManager &FM = Clang.getFileManager();
@@ -352,7 +420,6 @@ Optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
       Invocation.getDiagnosticOpts().DiagnosticSerializationFile, FM);
   DependenciesFile =
       fixupRelativePath(Invocation.getDependencyOutputOpts().OutputFile, FM);
-  return None;
 }
 
 namespace {
@@ -398,6 +465,28 @@ createBinaryOutputFile(CompilerInstance &Clang, StringRef OutputPath) {
   return O;
 }
 
+Expected<bool> ObjectStoreCachingOutputs::tryReplayCachedResult(
+    const llvm::cas::CASID &ResultCacheKey) {
+  DiagnosticsEngine &Diags = Clang.getDiagnostics();
+
+  Expected<Optional<llvm::cas::ObjectRef>> Result = Cache->get(ResultCacheKey);
+  if (!Result)
+    return Result.takeError();
+
+  if (Optional<llvm::cas::ObjectRef> ResultRef = *Result) {
+    Diags.Report(diag::remark_compile_job_cache_hit)
+        << ResultCacheKey.toString() << CAS->getID(*ResultRef).toString();
+    Optional<int> Status =
+        replayCachedResult(*ResultRef, /*JustComputedResult=*/false);
+    assert(Status && "Expected a status for a cache hit");
+    assert(*Status == 0 && "Expected success status for a cache hit");
+    return true;
+  }
+  Diags.Report(diag::remark_compile_job_cache_miss)
+      << ResultCacheKey.toString();
+  return false;
+}
+
 Optional<int> CompileJobCache::tryReplayCachedResult(CompilerInstance &Clang) {
   if (!CacheCompileJob)
     return None;
@@ -409,24 +498,22 @@ Optional<int> CompileJobCache::tryReplayCachedResult(CompilerInstance &Clang) {
   if (!ResultCacheKey)
     return 1;
 
-  if (Expected<Optional<llvm::cas::ObjectRef>> Result =
-          Cache->get(*ResultCacheKey)) {
-    if (*Result) {
-      Diags.Report(diag::remark_compile_job_cache_hit)
-          << ResultCacheKey->toString() << CAS->getID(**Result).toString();
-      Optional<int> Status =
-          replayCachedResult(Clang, **Result, /*JustComputedResult=*/false);
-      assert(Status && "Expected a status for a cache hit");
-      return *Status;
-    }
-    Diags.Report(diag::remark_compile_job_cache_miss)
-        << ResultCacheKey->toString();
-  } else {
-    Diags.Report(diag::err_compile_job_cache_failed)
-        << toString(Result.takeError());
-    return 1;
-  }
+  Expected<bool> ReplayedResult =
+      CacheBackend->tryReplayCachedResult(*ResultCacheKey);
+  if (!ReplayedResult)
+    return reportCachingBackendError(Clang.getDiagnostics(),
+                                     ReplayedResult.takeError());
+  if (*ReplayedResult)
+    return 0;
 
+  if (CacheBackend->prepareOutputCollection())
+    return 1;
+
+  return None;
+}
+
+bool CachingOutputs::prepareOutputCollectionCommon(
+    IntrusiveRefCntPtr<llvm::vfs::OutputBackend> CacheOutputs) {
   // Create an on-disk backend for streaming the results live if we run the
   // computation. If we're writing the output as a CASID, skip it here, since
   // it'll be handled during replay.
@@ -434,7 +521,6 @@ Optional<int> CompileJobCache::tryReplayCachedResult(CompilerInstance &Clang) {
       llvm::makeIntrusiveRefCnt<llvm::vfs::OnDiskOutputBackend>();
 
   // Set up the output backend so we can save / cache the result after.
-  CASOutputs = llvm::makeIntrusiveRefCnt<llvm::cas::CASOutputBackend>(*CAS);
   for (OutputKind K : cas::CompileJobCacheResult::getAllOutputKinds()) {
     StringRef OutPath = getPathForOutputKind(K);
     if (!OutPath.empty())
@@ -444,7 +530,7 @@ Optional<int> CompileJobCache::tryReplayCachedResult(CompilerInstance &Clang) {
   // Always filter out the dependencies file, since we build a CAS-specific
   // object for it.
   auto FilterBackend = llvm::vfs::makeFilteringOutputBackend(
-      CASOutputs,
+      CacheOutputs,
       [&](StringRef Path, Optional<llvm::vfs::OutputConfig> Config) {
         return Path != DependenciesFile;
       });
@@ -453,11 +539,6 @@ Optional<int> CompileJobCache::tryReplayCachedResult(CompilerInstance &Clang) {
       FilterBackend, std::move(OnDiskOutputs)));
   ResultDiagsOS = std::make_unique<raw_mirroring_ostream>(
       llvm::errs(), std::make_unique<llvm::raw_svector_ostream>(ResultDiags));
-
-  if (!Clang.getDependencyOutputOpts().OutputFile.empty())
-    Clang.addDependencyCollector(std::make_shared<CASDependencyCollector>(
-        Clang.getDependencyOutputOpts(), *CAS,
-        [this](Optional<cas::ObjectRef> Deps) { DependenciesOutput = Deps; }));
 
   // FIXME: This should be saving/replaying structured diagnostics, not saving
   // stderr and a separate diagnostics file, thus using the current llvm::errs()
@@ -481,6 +562,7 @@ Optional<int> CompileJobCache::tryReplayCachedResult(CompilerInstance &Clang) {
   // Notify the existing diagnostic client that all files were processed.
   Clang.getDiagnosticClient().finish();
 
+  DiagnosticsEngine &Diags = Clang.getDiagnostics();
   DiagnosticOptions &DiagOpts = Clang.getInvocation().getDiagnosticOpts();
   Clang.getDiagnostics().setClient(
       new TextDiagnosticPrinter(*ResultDiagsOS, &DiagOpts),
@@ -518,7 +600,19 @@ Optional<int> CompileJobCache::tryReplayCachedResult(CompilerInstance &Clang) {
         Diags.takeClient(), std::move(SerializedConsumer)));
   }
 
-  return None;
+  return false;
+}
+
+bool ObjectStoreCachingOutputs::prepareOutputCollection() {
+  if (prepareOutputCollectionCommon(CASOutputs))
+    return true;
+
+  if (!Clang.getDependencyOutputOpts().OutputFile.empty())
+    Clang.addDependencyCollector(std::make_shared<CASDependencyCollector>(
+        Clang.getDependencyOutputOpts(), *CAS,
+        [this](Optional<cas::ObjectRef> Deps) { DependenciesOutput = Deps; }));
+
+  return false;
 }
 
 void CompileJobCache::finishComputedResult(CompilerInstance &Clang,
@@ -527,6 +621,30 @@ void CompileJobCache::finishComputedResult(CompilerInstance &Clang,
   if (!CacheCompileJob)
     return;
 
+  CacheBackend->finishSerializedDiagnostics();
+
+  // Don't cache failed builds.
+  //
+  // TODO: Consider caching failed builds! Note: when output files are written
+  // without a temporary (non-atomically), failure may cause the removal of a
+  // preexisting file. That behaviour is not currently modeled by the cache.
+  if (!Success)
+    return;
+
+  // Existing diagnostic client is finished, create a new one in case we need
+  // to print more diagnostics.
+  Clang.getDiagnostics().setClient(
+      new TextDiagnosticPrinter(llvm::errs(),
+                                &Clang.getInvocation().getDiagnosticOpts()),
+      /*ShouldOwnClient=*/true);
+
+  if (Error E = CacheBackend->finishComputedResult(*ResultCacheKey)) {
+    reportCachingBackendError(Clang.getDiagnostics(), std::move(E));
+    Success = false;
+  }
+}
+
+void CachingOutputs::finishSerializedDiagnostics() {
   if (SerialDiagsOutput) {
     llvm::handleAllErrors(
         SerialDiagsOutput->keep(),
@@ -540,15 +658,10 @@ void CompileJobCache::finishComputedResult(CompilerInstance &Clang,
               << E.getOutputPath() << E.convertToErrorCode().message();
         });
   }
+}
 
-  // Don't cache failed builds.
-  //
-  // TODO: Consider caching failed builds! Note: when output files are written
-  // without a temporary (non-atomically), failure may cause the removal of a
-  // preexisting file. That behaviour is not currently modeled by the cache.
-  if (!Success)
-    return;
-
+Error ObjectStoreCachingOutputs::finishComputedResult(
+    const llvm::cas::CASID &ResultCacheKey) {
   // FIXME: Stop calling report_fatal_error().
   if (!SerialDiagsOutput) {
     // Not requested to get a serialized diagnostics file but we generated it
@@ -586,20 +699,21 @@ void CompileJobCache::finishComputedResult(CompilerInstance &Clang,
   Expected<cas::ObjectRef> Result = CachedResultBuilder.build(*CAS);
   if (!Result)
     llvm::report_fatal_error(Result.takeError());
-  if (llvm::Error E = Cache->put(*ResultCacheKey, *Result))
+  if (llvm::Error E = Cache->put(ResultCacheKey, *Result))
     llvm::report_fatal_error(std::move(E));
 
   // Replay / decanonicalize as necessary.
-  Optional<int> Status = replayCachedResult(Clang, *Result,
+  Optional<int> Status = replayCachedResult(*Result,
                                             /*JustComputedResult=*/true);
   (void)Status;
   assert(Status == None);
+  return Error::success();
 }
 
 /// Replay a result after a cache hit.
-Optional<int> CompileJobCache::replayCachedResult(CompilerInstance &Clang,
-                                                  llvm::cas::ObjectRef ResultID,
-                                                  bool JustComputedResult) {
+Optional<int>
+ObjectStoreCachingOutputs::replayCachedResult(llvm::cas::ObjectRef ResultID,
+                                              bool JustComputedResult) {
   if (JustComputedResult)
     return None;
 


### PR DESCRIPTION
This also cherry-picks "[clang-cache] Handle the errors when lookup results from CAS".