### PR TITLE
[clang-scan-deps][cas] Initial support for caching modules + PCH using casfs

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -29,6 +29,8 @@ def err_cas_depscan_failed: Error<
 def err_cas_store: Error<"failed to store to CAS: %0">, DefaultFatal;
 def err_cas_cannot_get_module_cache_key : Error<
   "CAS cannot load module with key '%0' from %1: %2">, DefaultFatal;
+def err_cas_missing_root_id : Error<
+  "CAS missing expected root-id '%0'">, DefaultFatal;
 
 def warn_clang_cache_disabled_caching: Warning<
   "caching disabled because %0">,

--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -31,6 +31,8 @@ def err_cas_cannot_get_module_cache_key : Error<
   "CAS cannot load module with key '%0' from %1: %2">, DefaultFatal;
 def err_cas_missing_root_id : Error<
   "CAS missing expected root-id '%0'">, DefaultFatal;
+def err_cas_cannot_parse_root_id_for_module : Error<
+  "CAS cannot parse root-id '%0' for module '%1'">, DefaultFatal;
 
 def warn_clang_cache_disabled_caching: Warning<
   "caching disabled because %0">,

--- a/clang/include/clang/Basic/Module.h
+++ b/clang/include/clang/Basic/Module.h
@@ -190,6 +190,10 @@ private:
   /// The \c ActionCache key for this module, if any.
   Optional<std::string> ModuleCacheKey;
 
+  /// The CAS filesystem root ID for implicit modules built with the dependency
+  /// scanner, if any.
+  Optional<std::string> CASFileSystemRootID;
+
   /// The top-level headers associated with this module.
   llvm::SmallSetVector<const FileEntry *, 2> TopHeaders;
 
@@ -625,6 +629,15 @@ public:
   void setModuleCacheKey(std::string Key) {
     assert(!getModuleCacheKey() || *getModuleCacheKey() == Key);
     getTopLevelModule()->ModuleCacheKey = std::move(Key);
+  }
+
+  Optional<std::string> getCASFileSystemRootID() const {
+    return getTopLevelModule()->CASFileSystemRootID;
+  }
+
+  void setCASFileSystemRootID(std::string ID) {
+    assert(!getCASFileSystemRootID() || *getCASFileSystemRootID() == ID);
+    getTopLevelModule()->CASFileSystemRootID = std::move(ID);
   }
 
   /// Retrieve the directory for which this module serves as the

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -175,6 +175,14 @@ class CompilerInstance : public ModuleLoader {
   /// The list of active output files.
   std::list<llvm::vfs::OutputFile> OutputFiles;
 
+  using GenModuleActionWrapperFunc =
+      std::function<std::unique_ptr<FrontendAction>(
+          const FrontendOptions &opts, std::unique_ptr<FrontendAction> action)>;
+
+  /// An optional callback function used to wrap all FrontendActions
+  /// produced to generate imported modules before they are executed.
+  GenModuleActionWrapperFunc GenModuleActionWrapper;
+
   /// Force an output buffer.
   std::unique_ptr<llvm::raw_pwrite_stream> OutputStream;
 
@@ -843,6 +851,14 @@ public:
   GlobalModuleIndex *loadGlobalModuleIndex(SourceLocation TriggerLoc) override;
 
   bool lookupMissingImports(StringRef Name, SourceLocation TriggerLoc) override;
+
+  void setGenModuleActionWrapper(GenModuleActionWrapperFunc Wrapper) {
+    GenModuleActionWrapper = Wrapper;
+  }
+
+  GenModuleActionWrapperFunc getGenModuleActionWrapper() const {
+    return GenModuleActionWrapper;
+  }
 
   void addDependencyCollector(std::shared_ptr<DependencyCollector> Listener) {
     DependencyCollectors.push_back(std::move(Listener));

--- a/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/clang/include/clang/Serialization/ASTBitCodes.h
@@ -363,6 +363,10 @@ enum ControlRecordTypes {
 
   /// Record code for the (optional) \c ActionCache  key for this module.
   MODULE_CACHE_KEY,
+
+  /// Record code for the (optional) CAS filesystem root ID for implicit modules
+  /// built with the dependency scanner.
+  CASFS_ROOT_ID,
 };
 
 /// Record types that occur within the options block inside

--- a/clang/include/clang/Serialization/ModuleFile.h
+++ b/clang/include/clang/Serialization/ModuleFile.h
@@ -128,6 +128,10 @@ public:
   /// The \c ActionCache key for this module, or empty.
   std::string ModuleCacheKey;
 
+  /// The CAS filesystem root ID for implicit modules built with the dependency
+  /// scanner, or empty.
+  std::string CASFileSystemRootID;
+
   /// The name of the module.
   std::string ModuleName;
 

--- a/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
@@ -34,11 +34,13 @@ struct PrebuiltModuleDep {
   std::string ModuleName;
   std::string PCMFile;
   std::string ModuleMapFile;
+  Optional<std::string> ModuleCacheKey;
 
   explicit PrebuiltModuleDep(const Module *M)
       : ModuleName(M->getTopLevelModuleName()),
         PCMFile(M->getASTFile()->getName()),
-        ModuleMapFile(M->PresumedModuleMapFile) {}
+        ModuleMapFile(M->PresumedModuleMapFile),
+        ModuleCacheKey(M->getModuleCacheKey()) {}
 };
 
 /// This is used to identify a specific module.

--- a/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
@@ -18,6 +18,7 @@
 #include "clang/Serialization/ASTReader.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/CAS/CASID.h"
 #include "llvm/Support/raw_ostream.h"
 #include <string>
 #include <unordered_map>
@@ -113,6 +114,12 @@ struct ModuleDeps {
   // the primary TU.
   bool ImportedByMainFile = false;
 
+  /// The CASID for the module input dependency tree, if any.
+  llvm::Optional<llvm::cas::CASID> CASFileSystemRootID;
+
+  /// The \c ActionCache key for this module, if any.
+  llvm::Optional<std::string> ModuleCacheKey;
+
   /// Compiler invocation that can be used to build this module. Does not
   /// include argv[0].
   std::vector<std::string> BuildArguments;
@@ -191,6 +198,10 @@ public:
   /// invocation, (e.g. disable implicit modules, add explicit module paths).
   void applyDiscoveredDependencies(CompilerInvocation &CI);
 
+  /// Set a CAS filesystem root ID for the main file, which will be included by
+  /// \c applyDiscoveredDependencies.
+  void setMainFileCASFileSystemRootID(cas::CASID ID);
+
 private:
   friend ModuleDepCollectorPP;
 
@@ -216,6 +227,13 @@ private:
   std::unique_ptr<DependencyOutputOptions> Opts;
   /// The original Clang invocation passed to dependency scanner.
   CompilerInvocation OriginalInvocation;
+  /// The CAS filesystem root ID for the main input file, if any. This is used
+  /// in \c applyDiscoveredDependencies.
+  Optional<cas::CASID> MainFileCASFileSystemRootID;
+  /// CAS options to apply to invocations.
+  CASOptions CASOpts;
+  /// CAS options to apply to invocations.
+  bool CacheCompileJob;
   /// Whether to optimize the modules' command-line arguments.
   bool OptimizeArgs;
   /// Whether to set up command-lines to load PCM files eagerly.

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4807,6 +4807,10 @@ std::string CompilerInvocation::getModuleHash() const {
   if (!SanHash.empty())
     HBuilder.add(SanHash.Mask);
 
+  // Caching + implicit modules, which is only set in clang-scan-deps, puts
+  // additional CASIDs in the pcm.
+  HBuilder.add(getFrontendOpts().CacheCompileJob);
+
   llvm::MD5::MD5Result Result;
   HBuilder.getHasher().final(Result);
   uint64_t Hash = Result.high() ^ Result.low();

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -5400,7 +5400,8 @@ bool ASTReader::readASTFileControlBlock(
         std::string Filename = ReadString(Record, Idx);
         ResolveImportedPath(Filename, ModuleDir);
         std::string CacheKey = ReadString(Record, Idx);
-        Listener.readModuleCacheKey(ModuleName, Filename, CacheKey);
+        if (!CacheKey.empty())
+          Listener.readModuleCacheKey(ModuleName, Filename, CacheKey);
         Listener.visitImport(ModuleName, Filename);
       }
       break;

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -2967,6 +2967,10 @@ ASTReader::ReadControlBlock(ModuleFile &F,
     case MODULE_CACHE_KEY:
       F.ModuleCacheKey = Blob.str();
       break;
+
+    case CASFS_ROOT_ID:
+      F.CASFileSystemRootID = Blob.str();
+      break;
     }
   }
 }
@@ -5603,6 +5607,8 @@ llvm::Error ASTReader::ReadSubmoduleBlock(ModuleFile &F,
         CurrentModule->PresumedModuleMapFile = F.ModuleMapPath;
         if (!F.ModuleCacheKey.empty())
           CurrentModule->setModuleCacheKey(F.ModuleCacheKey);
+        if (!F.CASFileSystemRootID.empty())
+          CurrentModule->setCASFileSystemRootID(F.CASFileSystemRootID);
       }
 
       CurrentModule->Kind = Kind;

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -790,6 +790,7 @@ void ASTWriter::WriteBlockInfoBlock() {
   RECORD(ORIGINAL_FILE_ID);
   RECORD(INPUT_FILE_OFFSETS);
   RECORD(MODULE_CACHE_KEY);
+  RECORD(CASFS_ROOT_ID);
 
   BLOCK(OPTIONS_BLOCK);
   RECORD(LANGUAGE_OPTIONS);
@@ -1299,8 +1300,8 @@ void ASTWriter::WriteControlBlock(Preprocessor &PP, ASTContext &Context,
     Stream.EmitRecord(MODULE_MAP_FILE, Record);
   }
 
-  // Module Cache Key
   if (WritingModule) {
+    // Module Cache Key
     if (auto Key = WritingModule->getModuleCacheKey()) {
       auto Abbrev = std::make_shared<BitCodeAbbrev>();
       Abbrev->Add(BitCodeAbbrevOp(MODULE_CACHE_KEY));
@@ -1308,6 +1309,15 @@ void ASTWriter::WriteControlBlock(Preprocessor &PP, ASTContext &Context,
       unsigned AbbrevCode = Stream.EmitAbbrev(std::move(Abbrev));
       RecordData::value_type Record[] = {MODULE_CACHE_KEY};
       Stream.EmitRecordWithBlob(AbbrevCode, Record, *Key);
+    }
+    // CAS filesystem root id, for the scanner.
+    if (auto ID = WritingModule->getCASFileSystemRootID()) {
+      auto Abbrev = std::make_shared<BitCodeAbbrev>();
+      Abbrev->Add(BitCodeAbbrevOp(CASFS_ROOT_ID));
+      Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Blob));
+      unsigned AbbrevCode = Stream.EmitAbbrev(std::move(Abbrev));
+      RecordData::value_type Record[] = {CASFS_ROOT_ID};
+      Stream.EmitRecordWithBlob(AbbrevCode, Record, *ID);
     }
   }
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -17,6 +17,7 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/CompilerInvocation.h"
 #include "clang/Frontend/FrontendActions.h"
+#include "clang/Frontend/MultiplexConsumer.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Frontend/Utils.h"
 #include "clang/Lex/PreprocessorOptions.h"
@@ -198,6 +199,72 @@ public:
   }
 };
 
+/// See \c WrapScanModuleBuildAction.
+class WrapScanModuleBuildConsumer : public ASTConsumer {
+public:
+  WrapScanModuleBuildConsumer(CompilerInstance &CI, Module &M,
+                              llvm::cas::CachingOnDiskFileSystem &FS)
+      : M(M), FS(FS) {}
+
+  void HandleTranslationUnit(ASTContext &Ctx) override {
+    auto Tree = FS.createTreeFromNewAccesses();
+    if (Tree)
+      M.setCASFileSystemRootID(Tree->getID().toString());
+    else
+      Ctx.getDiagnostics().Report(diag::err_cas_depscan_failed)
+          << toString(Tree.takeError());
+  }
+
+private:
+  Module &M;
+  llvm::cas::CachingOnDiskFileSystem &FS;
+};
+
+/// A wrapper for implicit module build actions in the scanner.
+///
+/// Captures per-module information such as the CAS filesystem root ID for
+/// module inputs.
+class WrapScanModuleBuildAction : public WrapperFrontendAction {
+public:
+  WrapScanModuleBuildAction(
+      std::unique_ptr<FrontendAction> WrappedAction,
+      IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> FS)
+      : WrapperFrontendAction(std::move(WrappedAction)), FS(std::move(FS)) {
+    assert(this->FS);
+  }
+
+private:
+  bool BeginInvocation(CompilerInstance &CI) override {
+    // FIXME: exclude unnecessary files such as implicit module pcms from the
+    // scanner itself. These are wasteful and cause spurious cache misses.
+    FS->trackNewAccesses();
+    // Normally this would be looked up while creating the VFS, but implicit
+    // modules share their VFS.
+    for (const auto &File : CI.getHeaderSearchOpts().VFSOverlayFiles)
+      (void)FS->status(File);
+    return WrapperFrontendAction::BeginInvocation(CI);
+  }
+
+  std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
+                                                 StringRef InFile) override {
+    auto OtherConsumer = WrapperFrontendAction::CreateASTConsumer(CI, InFile);
+    if (!OtherConsumer)
+      return nullptr;
+    Module *M = CI.getPreprocessor().getCurrentModule();
+    assert(M && "WrapScanModuleBuildAction should only be used with module");
+    if (!M)
+      return OtherConsumer;
+    auto Consumer = std::make_unique<WrapScanModuleBuildConsumer>(CI, *M, *FS);
+    std::vector<std::unique_ptr<ASTConsumer>> Consumers;
+    Consumers.push_back(std::move(Consumer));
+    Consumers.push_back(std::move(OtherConsumer));
+    return std::make_unique<MultiplexConsumer>(std::move(Consumers));
+  }
+
+private:
+  llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> FS;
+};
+
 /// A clang tool that runs the preprocessor in a mode that's optimized for
 /// dependency scanning for the given compiler invocation.
 class DependencyScanningAction : public tooling::ToolAction {
@@ -241,11 +308,6 @@ public:
       return true;
     }
 
-    if (CacheFS) {
-      CacheFS->trackNewAccesses();
-      CacheFS->setCurrentWorkingDirectory(WorkingDirectory);
-    }
-
     Scanned = true;
 
     // Create a compiler instance to handle the actual work.
@@ -253,6 +315,13 @@ public:
     CompilerInstance &ScanInstance = *ScanInstanceStorage;
     ScanInstance.setInvocation(std::move(Invocation));
     ScanInstance.getInvocation().getCASOpts() = CASOpts;
+
+    if (CacheFS) {
+      CacheFS->trackNewAccesses();
+      CacheFS->setCurrentWorkingDirectory(WorkingDirectory);
+      // Enable caching in the resulting commands.
+      ScanInstance.getFrontendOpts().CacheCompileJob = true;
+    }
 
     // Create the compiler's actual diagnostics engine.
     if (!DiagGenerationAsCompilation)
@@ -356,6 +425,14 @@ public:
           std::move(Opts), ScanInstance, Consumer, OriginalInvocation,
           OptimizeArgs, EagerLoadModules);
       ScanInstance.addDependencyCollector(MDC);
+      if (CacheFS) {
+        ScanInstance.setGenModuleActionWrapper(
+            [CacheFS = CacheFS](const FrontendOptions &Opts,
+                                std::unique_ptr<FrontendAction> Wrapped) {
+              return std::make_unique<WrapScanModuleBuildAction>(
+                  std::move(Wrapped), std::move(CacheFS));
+            });
+      }
       break;
     }
 
@@ -382,9 +459,11 @@ public:
 
     if (CacheFS) {
       auto Tree = CacheFS->createTreeFromNewAccesses(RemapPath);
-      if (Tree)
+      if (Tree) {
+        if (MDC)
+          MDC->setMainFileCASFileSystemRootID(Tree->getID());
         Consumer.handleCASFileSystemRootID(Tree->getID());
-      else
+      } else
         ScanInstance.getDiagnostics().Report(diag::err_cas_depscan_failed)
             << Tree.takeError();
     }

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -159,8 +159,12 @@ ModuleDepCollector::makeInvocationForModuleBuildWithoutOutputs(
   }
 
   // Report the prebuilt modules this module uses.
-  for (const auto &PrebuiltModule : Deps.PrebuiltModuleDeps)
+  for (const auto &PrebuiltModule : Deps.PrebuiltModuleDeps) {
     CI.getFrontendOpts().ModuleFiles.push_back(PrebuiltModule.PCMFile);
+    if (PrebuiltModule.ModuleCacheKey)
+      CI.getFrontendOpts().ModuleCacheKeys.emplace_back(
+          PrebuiltModule.PCMFile, *PrebuiltModule.ModuleCacheKey);
+  }
 
   // Remove any macro definitions that are explicitly ignored.
   if (!CI.getHeaderSearchOpts().ModulesIgnoreMacros.empty()) {

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -8,10 +8,14 @@
 
 #include "clang/Tooling/DependencyScanning/ModuleDepCollector.h"
 
+#include "clang/Basic/DiagnosticCAS.h"
 #include "clang/Basic/MakeSupport.h"
+#include "clang/Frontend/CompileJobCacheKey.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningWorker.h"
+#include "llvm/CAS/CASID.h"
+#include "llvm/CAS/ObjectStore.h"
 #include "llvm/Support/BLAKE3.h"
 #include "llvm/Support/StringSaver.h"
 
@@ -117,6 +121,9 @@ ModuleDepCollector::makeInvocationForModuleBuildWithoutOutputs(
   CI.getFrontendOpts().ProgramAction = frontend::GenerateModule;
   CI.getLangOpts()->ModuleName = Deps.ID.ModuleName;
   CI.getFrontendOpts().IsSystemModule = Deps.IsSystem;
+  CI.getCASOpts() = CASOpts;
+  CI.getFrontendOpts().CacheCompileJob = CacheCompileJob;
+  CI.getFrontendOpts().IncludeTimestamps = false;
 
   // Inputs
   InputKind ModuleMapInputKind(CI.getFrontendOpts().DashX.getLanguage(),
@@ -212,6 +219,13 @@ void ModuleDepCollector::addModuleFiles(
   for (const ModuleID &MID : ClangModuleDeps) {
     std::string PCMPath =
         Consumer.lookupModuleOutput(MID, ModuleOutputKind::ModuleFile);
+
+    ModuleDeps *MD = ModuleDepsByID.lookup(MID);
+    assert(MD && "Inconsistent dependency info");
+    if (MD->ModuleCacheKey)
+      CI.getFrontendOpts().ModuleCacheKeys.emplace_back(PCMPath,
+                                                        *MD->ModuleCacheKey);
+
     if (EagerLoadModules)
       CI.getFrontendOpts().ModuleFiles.push_back(std::move(PCMPath));
     else
@@ -233,6 +247,15 @@ static bool needsModules(FrontendInputFile FIF) {
 
 void ModuleDepCollector::applyDiscoveredDependencies(CompilerInvocation &CI) {
   CI.clearImplicitModuleBuildOptions();
+
+  // FIXME: refactor to share common code with scanAndUpdateCC1InlineWithTool
+  // and apply prefix mappings, if available.
+  CI.getCASOpts() = CASOpts;
+  CI.getFrontendOpts().CacheCompileJob = CacheCompileJob;
+  if (auto ID = MainFileCASFileSystemRootID)
+    CI.getFileSystemOpts().CASFileSystemRootID = ID->toString();
+  if (CacheCompileJob)
+    CI.getFrontendOpts().IncludeTimestamps = false;
 
   if (llvm::any_of(CI.getFrontendOpts().Inputs, needsModules)) {
     Preprocessor &PP = ScanInstance.getPreprocessor();
@@ -257,6 +280,11 @@ void ModuleDepCollector::applyDiscoveredDependencies(CompilerInvocation &CI) {
     for (const auto &KV : DirectPrebuiltModularDeps)
       CI.getFrontendOpts().ModuleFiles.push_back(KV.second.PCMFile);
   }
+}
+
+void ModuleDepCollector::setMainFileCASFileSystemRootID(cas::CASID ID) {
+  assert(!MainFileCASFileSystemRootID || *MainFileCASFileSystemRootID == ID);
+  MainFileCASFileSystemRootID = std::move(ID);
 }
 
 static std::string getModuleContextHash(const ModuleDeps &MD,
@@ -416,6 +444,15 @@ ModuleID ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
   MD.ImplicitModulePCMPath = std::string(M->getASTFile()->getName());
   MD.IsSystem = M->IsSystem;
 
+  if (auto ID = M->getCASFileSystemRootID()) {
+    auto &CAS = MDC.ScanInstance.getOrCreateObjectStore();
+    if (auto Err = CAS.parseID(*ID).moveInto(MD.CASFileSystemRootID)) {
+      MDC.ScanInstance.getDiagnostics().Report(
+          diag::err_cas_cannot_parse_root_id_for_module)
+          << *ID << MD.ID.ModuleName;
+    }
+  }
+
   ModuleMap &ModMapInfo =
       MDC.ScanInstance.getPreprocessor().getHeaderSearchInfo().getModuleMap();
 
@@ -465,8 +502,23 @@ ModuleID ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
 
   MDC.associateWithContextHash(CI, MD);
 
+  // Set CAS filesystem root ID after we compute the module hash. The root ID
+  // represents the contents of the filesystem which is not part of the hash.
+  // FIXME: refactor to share common code with scanAndUpdateCC1InlineWithTool
+  // and apply prefix mappings, if available.
+  if (auto ID = MD.CASFileSystemRootID)
+    CI.getFileSystemOpts().CASFileSystemRootID = ID->toString();
+
   // Finish the compiler invocation. Requires dependencies and the context hash.
   MDC.addOutputPaths(CI, MD);
+
+  // Compute the cache key, if needed. Requires dependencies and outputs.
+  if (MDC.CacheCompileJob) {
+    auto &CAS = MDC.ScanInstance.getOrCreateObjectStore();
+    auto &Diags = MDC.ScanInstance.getDiagnostics();
+    if (auto Key = createCompileJobCacheKey(CAS, Diags, CI))
+      MD.ModuleCacheKey = Key->toString();
+  }
 
   MD.BuildArguments = CI.getCC1CommandLine();
 
@@ -559,8 +611,10 @@ ModuleDepCollector::ModuleDepCollector(
     CompilerInstance &ScanInstance, DependencyConsumer &C,
     CompilerInvocation OriginalCI, bool OptimizeArgs, bool EagerLoadModules)
     : ScanInstance(ScanInstance), Consumer(C), Opts(std::move(Opts)),
-      OriginalInvocation(std::move(OriginalCI)), OptimizeArgs(OptimizeArgs),
-      EagerLoadModules(EagerLoadModules) {}
+      OriginalInvocation(std::move(OriginalCI)),
+      CASOpts(ScanInstance.getCASOpts()),
+      CacheCompileJob(ScanInstance.getFrontendOpts().CacheCompileJob),
+      OptimizeArgs(OptimizeArgs), EagerLoadModules(EagerLoadModules) {}
 
 void ModuleDepCollector::attachToPreprocessor(Preprocessor &PP) {
   PP.addPPCallbacks(std::make_unique<ModuleDepCollectorPP>(*this));

--- a/clang/test/CAS/output-path-error.c
+++ b/clang/test/CAS/output-path-error.c
@@ -19,4 +19,4 @@
 // RUN: cat %t/output.txt | FileCheck %s --check-prefix=ERROR
 
 // CACHE-MISS: remark: compile job cache miss
-// ERROR: fatal error: error in backend: cannot handle unknown compile-job cache key
+// ERROR: fatal error: CAS missing expected root-id

--- a/clang/test/ClangScanDeps/modules-cas-fs-symlink-dir-from-module.c
+++ b/clang/test/ClangScanDeps/modules-cas-fs-symlink-dir-from-module.c
@@ -1,0 +1,68 @@
+// Check that the path of an "affecting" modulemap file matches what is captured
+// in the cas fs.
+
+// REQUIRES: shell
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.in > %t/cdb.json
+// RUN: ln -s module %t/include/symlink-to-module
+
+// RUN: clang-scan-deps -cas-path %t/cas -action-cache-path %t/cache  -compilation-database %t/cdb.json -j 1 \
+// RUN:   -format experimental-full  -mode=preprocess-dependency-directives \
+// RUN:   -optimize-args -module-files-dir %t/build > %t/deps.json
+
+// RUN: %deps-to-rsp %t/deps.json --module-name=Mod > %t/mod.cc1.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name=Other > %t/other.cc1.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name=Foo > %t/foo.cc1.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name=Foo_Private > %t/foo_private.cc1.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name=Test > %t/test.cc1.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.cc1.rsp
+
+// RUN: %clang @%t/mod.cc1.rsp
+// RUN: %clang @%t/other.cc1.rsp
+// RUN: %clang @%t/foo.cc1.rsp
+// RUN: %clang @%t/foo_private.cc1.rsp
+// RUN: %clang @%t/test.cc1.rsp
+// RUN: %clang @%t/tu.cc1.rsp
+
+//--- cdb.json.in
+[{
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/test.c -F DIR/Frameworks -I DIR/include -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache",
+  "file": "DIR/test.c"
+}]
+
+//--- include/module/module.modulemap
+module Mod { header "mod.h" export * }
+
+//--- include/module/mod.h
+
+//--- include/module.modulemap
+module Other { header "other.h" export * }
+
+//--- include/other.h
+#include "symlink-to-module/mod.h"
+#include "module/mod.h"
+
+//--- Frameworks/Foo.framework/Modules/module.modulemap
+framework module Foo { header "Foo.h" export * }
+//--- Frameworks/Foo.framework/Modules/module.private.modulemap
+framework module Foo_Private { header "Priv.h" export * }
+
+//--- Frameworks/Foo.framework/Headers/Foo.h
+#include "module/mod.h"
+
+//--- Frameworks/Foo.framework/PrivateHeaders/Priv.h
+#include <Foo/Foo.h>
+#include "other.h"
+
+//--- module.modulemap
+module Test { header "test.h" export * }
+
+//--- test.h
+#include <Foo/Priv.h>
+#include <Foo/Foo.h>
+
+//--- test.c
+#include "test.h"

--- a/clang/test/ClangScanDeps/modules-cas-trees-with-pch.c
+++ b/clang/test/ClangScanDeps/modules-cas-trees-with-pch.c
@@ -1,0 +1,232 @@
+// Check that we can scan pch + modules with caching enabled and build the
+// resulting commands.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb_pch.json.template > %t/cdb_pch.json
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// == Scan PCH
+// RUN: clang-scan-deps -compilation-database %t/cdb_pch.json \
+// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -format experimental-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps_pch.json
+
+// == Check specifics of the command-line
+// RUN: cat %t/deps_pch.json | FileCheck %s -DPREFIX=%/t -check-prefix=PCH
+
+// == Build PCH
+// RUN: %deps-to-rsp %t/deps_pch.json --module-name A > %t/A.rsp
+// RUN: %deps-to-rsp %t/deps_pch.json --module-name B > %t/B.rsp
+// RUN: %deps-to-rsp %t/deps_pch.json --tu-index 0 > %t/pch.rsp
+
+// RUN: %clang @%t/B.rsp 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: %clang @%t/A.rsp 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// Ensure we load pcms from action cache
+// RUN: rm -rf %t/outputs
+// RUN: %clang @%t/pch.rsp 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: %clang @%t/pch.rsp 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+
+// == Scan TU, including PCH
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -format experimental-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// == Check specifics of the command-line
+// RUN: cat %t/deps.json | FileCheck %s -DPREFIX=%/t
+
+// == Build TU, including PCH
+// RUN: %deps-to-rsp %t/deps.json --module-name C > %t/C.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+
+// RUN: %clang @%t/C.rsp 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// Ensure we load pcms from action cache
+// RUN: rm -rf %t/outputs
+// RUN: %clang @%t/tu.rsp 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: %clang @%t/tu.rsp 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+
+// PCH:      {
+// PCH-NEXT:   "modules": [
+// PCH-NEXT:     {
+// PCH:            "casfs-root-id": "[[A_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// PCH:            "clang-module-deps": [
+// PCH:              {
+// PCH:                "module-name": "B"
+// PCH:              }
+// PCH-NEXT:       ]
+// PCH:            "command-line": [
+// PCH-NEXT:         "-cc1"
+// PCH:              "-fcas-path"
+// PCH-NEXT:         "[[PREFIX]]{{.}}cas"
+// PCH:              "-faction-cache-path"
+// PCH-NEXT:         "[[PREFIX]]{{.}}cache"
+// PCH:              "-fcas-fs"
+// PCH-NEXT:         "[[A_ROOT_ID]]"
+// PCH:              "-o"
+// PCH-NEXT:         "[[A_PCM:.*outputs.*A-.*\.pcm]]"
+// PCH:              "-fcache-compile-job"
+// PCH:              "-emit-module"
+// PCH:              "-fmodule-file-cache-key=[[B_PCM:.*outputs.*B-.*\.pcm]]=[[B_CACHE_KEY:llvmcas://[[:xdigit:]]+]]"
+// PCH:              "-fmodule-file={{(B=)?}}[[B_PCM]]"
+// PCH:            ]
+// PCH:            "file-deps": [
+// PCH-NEXT:         "[[PREFIX]]{{.}}A.h"
+// PCH-NEXT:         "[[PREFIX]]{{.}}module.modulemap"
+// PCH-NEXT:       ]
+// PCH:            "name": "A"
+// PCH:          }
+// PCH-NEXT:     {
+// PCH:            "casfs-root-id": "[[B_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// PCH:            "clang-module-deps": []
+// PCH:            "command-line": [
+// PCH-NEXT:         "-cc1"
+// PCH:              "-fcas-path"
+// PCH-NEXT:         "[[PREFIX]]{{.}}cas"
+// PCH:              "-faction-cache-path"
+// PCH-NEXT:         "[[PREFIX]]{{.}}cache"
+// PCH:              "-fcas-fs"
+// PCH-NEXT:         "[[B_ROOT_ID]]"
+// PCH:              "-o"
+// PCH-NEXT:         "[[B_PCM]]"
+// PCH:              "-fcache-compile-job"
+// PCH:              "-emit-module"
+// PCH:            ]
+// PCH:            "file-deps": [
+// PCH-NEXT:         "[[PREFIX]]{{.}}B.h"
+// PCH-NEXT:         "[[PREFIX]]{{.}}module.modulemap"
+// PCH-NEXT:       ]
+// PCH:            "name": "B"
+// PCH:          }
+// PCH-NEXT:   ]
+// PCH:        "translation-units": [
+// PCH:          {
+// PCH:            "commands": [
+// PCH:              {
+// PCH:                "casfs-root-id": "[[PCH_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// PCH:                "clang-module-deps": [
+// PCH:                  {
+// PCH:                    "module-name": "A"
+// PCH:                  }
+// PCH-NEXT:           ]
+// PCH:                "command-line": [
+// PCH-NEXT:             "-cc1"
+// PCH:                  "-fcas-path"
+// PCH-NEXT:             "[[PREFIX]]{{.}}cas"
+// PCH:                  "-faction-cache-path"
+// PCH-NEXT:             "[[PREFIX]]{{.}}cache"
+// PCH:                  "-fcas-fs"
+// PCH-NEXT:             "[[PCH_ROOT_ID]]"
+// PCH:                  "-fno-pch-timestamp"
+// PCH:                  "-fcache-compile-job"
+// PCH:                  "-emit-pch"
+// PCH:                  "-fmodule-file-cache-key=[[A_PCM]]={{llvmcas://[[:xdigit:]]+}}"
+// PCH:                  "-fmodule-file={{(A=)?}}[[A_PCM]]"
+// PCH:                ]
+// PCH:                "file-deps": [
+// PCH-NEXT:             "[[PREFIX]]{{.}}prefix.h"
+// PCH-NEXT:           ]
+// PCH:              }
+
+// CHECK:      {
+// CHECK-NEXT:   "modules": [
+// CHECK-NEXT:     {
+// CHECK:            "casfs-root-id": "[[C_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// CHECK:            "clang-module-deps": []
+// CHECK:            "command-line": [
+// CHECK-NEXT:         "-cc1"
+// CHECK:              "-fcas-path"
+// CHECK-NEXT:         "[[PREFIX]]{{.}}cas"
+// CHECK:              "-faction-cache-path"
+// CHECK-NEXT:         "[[PREFIX]]{{.}}cache"
+// CHECK:              "-fcas-fs"
+// CHECK-NEXT:         "[[C_ROOT_ID]]"
+// CHECK:              "-o"
+// CHECK-NEXT:         "[[C_PCM:.*outputs.*C-.*\.pcm]]"
+// CHECK:              "-fcache-compile-job"
+// CHECK:              "-emit-module"
+// CHECK:              "-fmodule-file={{(B=)?}}[[B_PCM:.*outputs.*B-.*\.pcm]]"
+// CHECK:              "-fmodule-file-cache-key=[[B_PCM]]=[[B_CACHE_KEY:llvmcas://[[:xdigit:]]+]]"
+// CHECK:            ]
+// CHECK:            "file-deps": [
+// CHECK-NEXT:         "[[PREFIX]]{{.}}C.h"
+// CHECK-NEXT:         "[[PREFIX]]{{.}}module.modulemap"
+// CHECK-NEXT:       ]
+// CHECK:            "name": "C"
+// CHECK:          }
+// CHECK-NEXT:   ]
+// CHECK:        "translation-units": [
+// CHECK:          {
+// CHECK:            "commands": [
+// CHECK:              {
+// CHECK:                "casfs-root-id": "[[TU_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// CHECK:                "clang-module-deps": [
+// CHECK:                  {
+// CHECK:                    "module-name": "C"
+// CHECK:                  }
+// CHECK-NEXT:           ]
+// CHECK:                "command-line": [
+// CHECK-NEXT:             "-cc1"
+// CHECK:                  "-fcas-path"
+// CHECK-NEXT:             "[[PREFIX]]{{.}}cas"
+// CHECK:                  "-faction-cache-path"
+// CHECK-NEXT:             "[[PREFIX]]{{.}}cache"
+// CHECK:                  "-fcas-fs"
+// CHECK-NEXT:             "[[TU_ROOT_ID]]"
+// CHECK:                  "-fno-pch-timestamp"
+// CHECK:                  "-fcache-compile-job"
+// CHECK:                  "-fmodule-file-cache-key=[[C_PCM]]={{llvmcas://[[:xdigit:]]+}}"
+// CHECK:                  "-fmodule-file={{(C=)?}}[[C_PCM]]"
+// CHECK:                ]
+// CHECK:                "file-deps": [
+// CHECK-NEXT:             "[[PREFIX]]{{.}}tu.c"
+// CHECK-NEXT:             "[[PREFIX]]{{.}}prefix.h.pch"
+// CHECK-NEXT:           ]
+// CHECK:              }
+
+// CACHE-HIT: remark: compile job cache hit
+// CACHE-MISS: remark: compile job cache miss
+
+//--- cdb_pch.json.template
+[
+  {
+    "directory" : "DIR",
+    "command" : "clang_tool -x c-header DIR/prefix.h -o DIR/prefix.h.pch -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache",
+    "file" : "DIR/prefix.h"
+  },
+]
+
+//--- cdb.json.template
+[
+  {
+    "directory" : "DIR",
+    "command" : "clang_tool -fsyntax-only DIR/tu.c -include DIR/prefix.h -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache",
+    "file" : "DIR/tu.c"
+  },
+]
+
+//--- module.modulemap
+module A { header "A.h" export * }
+module B { header "B.h" }
+module C { header "C.h" export * }
+
+//--- A.h
+#include "B.h"
+
+//--- B.h
+void B(void);
+
+//--- C.h
+#include "B.h"
+void B(void);
+
+//--- prefix.h
+#include "A.h"
+
+//--- tu.c
+#include "C.h"
+void tu(void) {
+  B();
+}

--- a/clang/test/ClangScanDeps/modules-cas-trees.c
+++ b/clang/test/ClangScanDeps/modules-cas-trees.c
@@ -1,0 +1,213 @@
+// Check that we can scan modules with caching enabled and build the resulting
+// commands.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -format experimental-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// Full and tree-full modes are identical here.
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -format experimental-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps_tree.json
+// RUN: diff -u %t/deps_tree.json %t/deps.json
+
+// Disabling/re-enabling the cas should not be cached in the implicit pcms
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -module-files-dir %t/outputs \
+// RUN:   -format experimental-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps_no_cas.json
+// RUN: cat %t/deps_no_cas.json | FileCheck %s -check-prefix=NO_CAS
+// NO_CAS-NOT: fcas
+// NO_CAS-NOT: faction-cache
+// NO_CAS-NOT: fcache-compile-job
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -format experimental-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps_cas_2.json
+// RUN: diff -u %t/deps_cas_2.json %t/deps.json
+
+// RUN: %deps-to-rsp %t/deps.json --module-name Top > %t/Top.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name Left > %t/Left.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name Right > %t/Right.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+
+// Missing pcm in action cache
+// RUN: not %clang @%t/Left.rsp 2> %t/error.txt
+// RUN: cat %t/error.txt | FileCheck %s -check-prefix=MISSING
+// MISSING: error: CAS cannot load module with key '{{.*}}' from -fmodule-file-cache-key: no such entry in action cache
+
+// Build everything
+// RUN: %clang @%t/Top.rsp 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: %clang @%t/Left.rsp 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: %clang @%t/Left.rsp 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: %clang @%t/Right.rsp 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: %clang @%t/Right.rsp 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+// Ensure we load pcms from action cache
+// RUN: rm -rf %t/outputs
+// RUN: %clang @%t/tu.rsp 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: %clang @%t/tu.rsp 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+
+// CACHE-HIT: remark: compile job cache hit
+// CACHE-MISS: remark: compile job cache miss
+
+// Check specifics of the command-line
+// RUN: cat %t/deps.json | FileCheck %s -DPREFIX=%/t
+
+// CHECK:      {
+// CHECK-NEXT:   "modules": [
+// CHECK-NEXT:     {
+// CHECK:            "casfs-root-id": "[[LEFT_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// CHECK:            "clang-module-deps": [
+// CHECK:              {
+// CHECK:                "module-name": "Top"
+// CHECK:              }
+// CHECK-NEXT:       ]
+// CHECK:            "command-line": [
+// CHECK-NEXT:         "-cc1"
+// CHECK:              "-fcas-path"
+// CHECK-NEXT:         "[[PREFIX]]{{.}}cas"
+// CHECK:              "-faction-cache-path"
+// CHECK-NEXT:         "[[PREFIX]]{{.}}cache"
+// CHECK:              "-fcas-fs"
+// CHECK-NEXT:         "[[LEFT_ROOT_ID]]"
+// CHECK:              "-o"
+// CHECK-NEXT:         "[[LEFT_PCM:.*outputs.*Left-.*\.pcm]]"
+// CHECK:              "-fcache-compile-job"
+// CHECK:              "-emit-module"
+// CHECK:              "-fmodule-file-cache-key=[[TOP_PCM:.*outputs.*Top-.*\.pcm]]=[[TOP_CACHE_KEY:llvmcas://[[:xdigit:]]+]]"
+// CHECK:              "-fmodule-file={{(Top=)?}}[[TOP_PCM]]"
+// CHECK:            ]
+// CHECK:            "file-deps": [
+// CHECK-NEXT:         "[[PREFIX]]{{.}}Left.h"
+// CHECK-NEXT:         "[[PREFIX]]{{.}}module.modulemap"
+// CHECK-NEXT:       ]
+// CHECK:            "name": "Left"
+// CHECK:          }
+// CHECK-NEXT:     {
+// CHECK:            "casfs-root-id": "[[RIGHT_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// CHECK:            "clang-module-deps": [
+// CHECK:              {
+// CHECK:                "module-name": "Top"
+// CHECK:              }
+// CHECK-NEXT:       ]
+// CHECK:            "command-line": [
+// CHECK-NEXT:         "-cc1"
+// CHECK:              "-fcas-path"
+// CHECK-NEXT:         "[[PREFIX]]{{.}}cas"
+// CHECK:              "-faction-cache-path"
+// CHECK-NEXT:         "[[PREFIX]]{{.}}cache"
+// CHECK:              "-fcas-fs"
+// CHECK-NEXT:         "[[RIGHT_ROOT_ID]]"
+// CHECK:              "-o"
+// CHECK-NEXT:         "[[RIGHT_PCM:.*outputs.*Right-.*\.pcm]]"
+// CHECK:              "-fcache-compile-job"
+// CHECK:              "-emit-module"
+// CHECK:              "-fmodule-file-cache-key=[[TOP_PCM]]=[[TOP_CACHE_KEY:llvmcas://[[:xdigit:]]+]]"
+// CHECK:              "-fmodule-file={{(Top=)?}}[[TOP_PCM]]"
+// CHECK:            ]
+// CHECK:            "file-deps": [
+// CHECK-NEXT:         "[[PREFIX]]{{.}}Right.h"
+// CHECK-NEXT:         "[[PREFIX]]{{.}}module.modulemap"
+// CHECK:            ]
+// CHECK:            "name": "Right"
+// CHECK:          }
+// CHECK-NEXT:     {
+// CHECK:            "casfs-root-id": "[[TOP_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// CHECK:            "clang-module-deps": []
+// CHECK:            "command-line": [
+// CHECK-NEXT:         "-cc1"
+// CHECK:              "-fcas-path"
+// CHECK-NEXT:         "[[PREFIX]]{{.}}cas"
+// CHECK:              "-faction-cache-path"
+// CHECK-NEXT:         "[[PREFIX]]{{.}}cache"
+// CHECK:              "-fcas-fs"
+// CHECK-NEXT:         "[[TOP_ROOT_ID]]"
+// CHECK:              "-o"
+// CHECK-NEXT:         "[[TOP_PCM]]"
+// CHECK:              "-fcache-compile-job"
+// CHECK:              "-emit-module"
+// CHECK:            ]
+// CHECK:            "file-deps": [
+// CHECK-NEXT:         "[[PREFIX]]{{.}}Top.h"
+// CHECK-NEXT:         "[[PREFIX]]{{.}}module.modulemap"
+// CHECK:            ]
+// CHECK:            "name": "Top"
+// CHECK:          }
+// CHECK-NEXT:   ]
+// CHECK:        "translation-units": [
+// CHECK:          {
+// CHECK:            "commands": [
+// CHECK:              {
+// CHECK:                "casfs-root-id": "[[TU_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// CHECK:                "clang-module-deps": [
+// CHECK:                  {
+// CHECK:                    "module-name": "Left"
+// CHECK:                  }
+// CHECK:                  {
+// CHECK:                    "module-name": "Right"
+// CHECK:                  }
+// CHECK-NEXT:           ]
+// CHECK:                "command-line": [
+// CHECK-NEXT:             "-cc1"
+// CHECK:                  "-fcas-path"
+// CHECK-NEXT:             "[[PREFIX]]{{.}}cas"
+// CHECK:                  "-faction-cache-path"
+// CHECK-NEXT:             "[[PREFIX]]{{.}}cache"
+// CHECK:                  "-fcas-fs"
+// CHECK-NEXT:             "[[TU_ROOT_ID]]"
+// CHECK:                  "-fcache-compile-job"
+// CHECK:                  "-fmodule-file-cache-key=[[LEFT_PCM]]={{llvmcas://[[:xdigit:]]+}}"
+// CHECK:                  "-fmodule-file-cache-key=[[RIGHT_PCM]]={{llvmcas://[[:xdigit:]]+}}"
+// CHECK:                  "-fmodule-file={{(Left=)?}}[[LEFT_PCM]]"
+// CHECK:                  "-fmodule-file={{(Right=)?}}[[RIGHT_PCM]]"
+// CHECK:                ]
+// CHECK:                "file-deps": [
+// CHECK-NEXT:             "[[PREFIX]]{{.}}tu.c"
+// CHECK-NEXT:           ]
+// CHECK:              }
+
+
+
+//--- cdb.json.template
+[{
+  "directory" : "DIR",
+  "command" : "clang_tool -fsyntax-only DIR/tu.c -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache",
+  "file" : "DIR/tu.c"
+}]
+
+//--- module.modulemap
+module Top { header "Top.h" export * }
+module Left { header "Left.h" export * }
+module Right { header "Right.h" export * }
+
+//--- Top.h
+#pragma once
+void Top(void);
+
+//--- Left.h
+#pragma once
+#include "Top.h"
+void Left(void);
+
+//--- Right.h
+#pragma once
+#include "Top.h"
+void Right(void);
+
+//--- tu.c
+#include "Left.h"
+#include "Right.h"
+
+void tu(void) {
+  Top();
+  Left();
+  Right();
+}

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -238,6 +238,11 @@ llvm::cl::opt<bool> InMemoryCAS(
     llvm::cl::desc("Use an in-memory CAS instead of on-disk."),
     llvm::cl::init(false), llvm::cl::cat(DependencyScannerCategory));
 
+llvm::cl::opt<std::string>
+    ActionCachePath("action-cache-path",
+                    llvm::cl::desc("Path for on-disk action cache."),
+                    llvm::cl::cat(DependencyScannerCategory));
+
 llvm::cl::opt<bool> Verbose("v", llvm::cl::Optional,
                             llvm::cl::desc("Use verbose output."),
                             llvm::cl::init(false),
@@ -491,6 +496,10 @@ static bool outputFormatRequiresCAS() {
   }
 }
 
+static bool useCAS() {
+  return InMemoryCAS || !OnDiskCASPath.empty() || outputFormatRequiresCAS();
+}
+
 static llvm::json::Array toJSONSorted(const llvm::StringSet<> &Set) {
   std::vector<llvm::StringRef> Strings;
   for (auto &&I : Set)
@@ -569,6 +578,8 @@ public:
           {"clang-modulemap-file", MD.ClangModuleMapFile},
           {"command-line", MD.BuildArguments},
       };
+      if (MD.CASFileSystemRootID)
+        O.try_emplace("casfs-root-id", MD.CASFileSystemRootID->toString());
       OutModules.push_back(std::move(O));
     }
 
@@ -803,15 +814,17 @@ int main(int argc, const char **argv) {
   std::shared_ptr<llvm::cas::ObjectStore> CAS;
   std::shared_ptr<llvm::cas::ActionCache> Cache;
   IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> FS;
-  if (outputFormatRequiresCAS()) {
+  if (useCAS()) {
     if (!InMemoryCAS) {
       if (!OnDiskCASPath.empty())
         CASOpts.CASPath = OnDiskCASPath;
       else
         CASOpts.ensurePersistentCAS();
     }
+    if (!ActionCachePath.empty())
+      CASOpts.CachePath = ActionCachePath;
+
     CAS = CASOpts.getOrCreateObjectStore(Diags);
-    // FIXME: Cache is not used here so just create a dummy in-memory cache.
     Cache = CASOpts.getOrCreateActionCache(Diags);
     if (!CAS)
       return 1;


### PR DESCRIPTION
When a CAS and ActionCache are available to to the scanner, we can
produce build commands for modules as well as the main TU that use
the cc1 option -fcache-compile-job to enable compilation caching. This
makes use of the newly added -fmodule-file-cache-key= to support
creating commands that import a given module via an action cache key
without needing that module to have been built yet. This means that
unlike with PCH, we do not need to scan commands that use modules in
dependency order with respect to building those modules, and we do not
need to read the pcm files back from disk repeatedly in order to ingest
them into a casfs. Like any scanned explicit modules build, the modules
must still be *built* in dependency order by the build system, or else
the action cache lookup will fail in the same places that an uncached
build would fail due to a missing .pcm on disk.

Also extend the support for caching module compilations to also support
mixing PCH + modules. The PCH itself still requires scanning in
dependency order (scan PCH, build PCH, scan TU that uses PCH), but the
module dependencies of the PCH and the TU phases do not add any
additional constraints on scanning.

This PR contains the primary changes needed to build modules files
via the cache. However, there are some additional changes that will be
needed before this is practical to use:

* Support prefix mapping for paths
* Thinning out the set of files ingested into the casfs to reduce
  spurious cache misses - in particular, removing unnecessary volatile
  files such as the implicit module pcm files created by the scanner.