### PR TITLE
[clang] Avoid creating file named "-" when using -working-directory

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -914,7 +914,7 @@ CompilerInstance::createOutputFileImpl(StringRef OutputPath, bool Binary,
   // If '-working-directory' was passed, the output filename should be
   // relative to that.
   Optional<SmallString<128>> AbsPath;
-  if (!llvm::sys::path::is_absolute(OutputPath)) {
+  if (OutputPath != "-" && !llvm::sys::path::is_absolute(OutputPath)) {
     AbsPath.emplace(OutputPath);
     FileMgr->FixupRelativePath(*AbsPath);
     OutputPath = *AbsPath;

--- a/clang/test/Frontend/output-paths.c
+++ b/clang/test/Frontend/output-paths.c
@@ -8,3 +8,6 @@
 // RUN: rm -rf %t.d && mkdir -p %t.d/%basename_t-inner.d
 // RUN: %clang_cc1 -emit-llvm -working-directory %t.d -E -o %basename_t-inner.d/somename %s -verify
 // expected-no-diagnostics
+
+// RUN: %clang_cc1 -working-directory %t.d -E %s -o - | FileCheck %s
+// CHECK: # 1


### PR DESCRIPTION
We handle "-" specially in most places related to output files, but we accidentally missed one when -working-directory is set.

(cherry picked from commit 9c37f5c98d68d0c1912b623236f22d9a64c11e86)
(cherry picked from commit 7df160a7e056e152ba5bf21d60878044614ac1ab)