### PR TITLE
[clang][cas] Fix incomplete type error in DependencyScanningWorker.h

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -15,15 +15,10 @@
 #include "clang/Frontend/PCHContainerOperations.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningService.h"
 #include "clang/Tooling/DependencyScanning/ModuleDepCollector.h"
+#include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include <string>
-
-namespace llvm {
-namespace cas {
-class CachingOnDiskFileSystem;
-}
-} // namespace llvm
 
 namespace clang {
 


### PR DESCRIPTION
Fix missing include; the header was not actually standalone due to a an incomplete type used in IntrusiveRefCntPtr.

(cherry picked from commit 4fd7b9842c184dce7b71fcf16c69e4f539607d43)