### PR TITLE
[clang-cache] Introduce `CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS` environment variable

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6495,6 +6495,11 @@ defm cache_compile_job : BoolFOption<"cache-compile-job",
                          " (for now) without -fcas-fs.">,
     NegFlag<SetFalse>>;
 
+defm cache_disable_replay : BoolFOption<"cache-disable-replay",
+    FrontendOpts<"DisableCachedCompileJobReplay">, DefaultFalse,
+    PosFlag<SetTrue, [], "Disable replaying a cached compile job">,
+    NegFlag<SetFalse>>;
+
 // FIXME: Add to driver under -fexperimental-cache=raw-lex.
 defm cache_raw_lex : BoolFOption<"cache-raw-lex",
     PreprocessorOpts<"CacheRawLex">, DefaultFalse,

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -362,6 +362,10 @@ public:
   /// is specified.
   unsigned CacheCompileJob : 1;
 
+  /// Avoid checking if the compile job is already cached, force compilation and
+  /// caching of compilation outputs. This is used for testing purposes.
+  unsigned DisableCachedCompileJobReplay : 1;
+
   /// When using CacheCompileJob, write a CASID for the output file.
   ///
   /// FIXME: Add clang tests for this functionality.
@@ -542,8 +546,9 @@ public:
         ASTDumpLookups(false), BuildingImplicitModule(false),
         BuildingImplicitModuleUsesLock(true), ModulesEmbedAllFiles(false),
         IncludeTimestamps(true), UseTemporary(true), CacheCompileJob(false),
-        WriteOutputAsCASID(false), AllowPCMWithCompilerErrors(false),
-        ModulesShareFileManager(true), TimeTraceGranularity(500) {}
+        DisableCachedCompileJobReplay(false), WriteOutputAsCASID(false),
+        AllowPCMWithCompilerErrors(false), ModulesShareFileManager(true),
+        TimeTraceGranularity(500) {}
 
   /// getInputKindForExtension - Return the appropriate input kind for a file
   /// extension. For example, "c" would return Language::C.

--- a/clang/test/CAS/test-for-deterministic-outputs.c
+++ b/clang/test/CAS/test-for-deterministic-outputs.c
@@ -1,0 +1,10 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// This compiles twice with replay disabled, ensuring that we get the same outputs for the same key.
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS=1 %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache 2> %t/out.txt
+// RUN: FileCheck %s --check-prefix=CACHE-MISS --input-file=%t/out.txt
+
+// CACHE-MISS: remark: compile job cache miss
+// CACHE-MISS: remark: compile job cache miss

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -61,6 +61,23 @@ static bool shouldCacheInvocation(ArrayRef<const char *> Args,
   return true;
 }
 
+static int executeAsProcess(ArrayRef<const char *> Args,
+                            DiagnosticsEngine &Diags) {
+  SmallVector<StringRef, 128> RefArgs;
+  RefArgs.reserve(Args.size());
+  for (const char *Arg : Args) {
+    RefArgs.push_back(Arg);
+  }
+  std::string ErrMsg;
+  int Result = llvm::sys::ExecuteAndWait(Args[0], RefArgs, /*Env*/ None,
+                                         /*Redirects*/ {}, /*SecondsToWait*/ 0,
+                                         /*MemoryLimit*/ 0, &ErrMsg);
+  if (!ErrMsg.empty()) {
+    Diags.Report(diag::err_clang_cache_failed_execution) << ErrMsg;
+  }
+  return Result;
+}
+
 Optional<int>
 clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
                                   llvm::StringSaver &Saver) {
@@ -155,6 +172,16 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
                    Saver.save(CacheArg.str()).data()});
     }
     Args.append({"-greproducible", "-Xclang", "-fcas-token-cache"});
+
+    if (llvm::sys::Process::GetEnv("CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS")) {
+      // Run the compilation twice, without replaying, to check that we get the
+      // same compilation artifacts for the same key. If they are not the same
+      // the action cache will trigger a fatal error.
+      Args.append({"-Xclang", "-fcache-disable-replay"});
+      int Result = executeAsProcess(Args, Diags);
+      if (Result != 0)
+        return Result;
+    }
     return None;
   }
 
@@ -166,17 +193,5 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
   Diags.Report(diag::warn_clang_cache_disabled_caching)
       << "clang-cache invokes a different clang binary than itself";
 
-  SmallVector<StringRef, 128> RefArgs;
-  RefArgs.reserve(Args.size());
-  for (const char *Arg : Args) {
-    RefArgs.push_back(Arg);
-  }
-  std::string ErrMsg;
-  int Result = llvm::sys::ExecuteAndWait(compilerPath, RefArgs, /*Env*/ None,
-                                         /*Redirects*/ {}, /*SecondsToWait*/ 0,
-                                         /*MemoryLimit*/ 0, &ErrMsg);
-  if (!ErrMsg.empty()) {
-    Diags.Report(diag::err_clang_cache_failed_execution) << ErrMsg;
-  }
-  return Result;
+  return executeAsProcess(Args, Diags);
 }


### PR DESCRIPTION
This is used for testing purposes. It instructs `clang-cache` to run the compilation twice, without replaying, to check that we get the same compilation artifacts for the same key. If they are not the same the action cache will trigger a fatal error.