### PR TITLE
SwiftUserExpression: Sink initialization of scratch context into Parse() 

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -179,11 +179,11 @@ private:
     void DidDematerialize(lldb::ExpressionVariableSP &variable) override;
   };
 
+  llvm::Optional<SwiftScratchContextReader> m_swift_scratch_ctx;
   SwiftASTContextForExpressions *m_swift_ast_ctx;
   PersistentVariableDelegate m_persistent_variable_delegate;
   std::unique_ptr<SwiftExpressionParser> m_parser;
   Status m_err;
-  llvm::Optional<SwiftScratchContextReader> m_swift_scratch_ctx;
   bool m_runs_in_playground_or_repl;
   bool m_needs_object_ptr = false;
   bool m_in_static_method = false;


### PR DESCRIPTION
so it can (in a follow-up commit) be initialized with the current
frame as ExecutionContextScope.

NFC