### PR TITLE
[lldb][tests] Remove no-dynamic-values setting

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -56,8 +56,7 @@ swiftLibrary = None
 dwarf_version = 0
 
 # Any overridden settings.
-# Always disable default dynamic types for testing purposes.
-settings = [('target.prefer-dynamic-value', 'no-dynamic-values')]
+settings = []
 
 # Path to the FileCheck testing tool. Not optional.
 filecheck = None

--- a/lldb/test/API/commands/expression/po_verbosity/TestPoVerbosity.py
+++ b/lldb/test/API/commands/expression/po_verbosity/TestPoVerbosity.py
@@ -41,6 +41,8 @@ class PoVerbosityTestCase(TestBase):
 
         self.runCmd("run", RUN_SUCCEEDED)
 
+        self.runCmd("settings set target.prefer-dynamic-value no-dynamic-values")
+
         self.expect("expr -O -v -- foo",
                     substrs=['(id) $', ' = 0x', '1 = 2', '2 = 3;'])
         self.expect("expr -O -vfull -- foo",

--- a/lldb/test/API/commands/expression/two-files/TestObjCTypeQueryFromOtherCompileUnit.py
+++ b/lldb/test/API/commands/expression/two-files/TestObjCTypeQueryFromOtherCompileUnit.py
@@ -32,6 +32,8 @@ class ObjCTypeQueryTestCase(TestBase):
 
         self.runCmd("run", RUN_SUCCEEDED)
 
+        self.runCmd("settings set target.prefer-dynamic-value no-dynamic-values")
+
         # Now do a NSArry type query from the 'main.m' compile uint.
         self.expect("expression (NSArray*)array_token",
                     substrs=['(NSArray *) $0 = 0x'])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCCF.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCCF.py
@@ -27,6 +27,8 @@ class ObjCDataFormatterCF(ObjCDataFormatterTestCase):
             STOPPED_DUE_TO_BREAKPOINT,
             substrs=['stopped', 'stop reason = breakpoint'])
 
+        self.runCmd('settings set target.prefer-dynamic-value no-dynamic-values')
+
         # check formatters for common Objective-C types
         expect_strings = [
             '(CFGregorianUnits) cf_greg_units = 1 years, 3 months, 5 days, 12 hours, 5 minutes 7 seconds',

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCExpr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCExpr.py
@@ -27,6 +27,8 @@ class ObjCDataFormatterExpr(ObjCDataFormatterTestCase):
             STOPPED_DUE_TO_BREAKPOINT,
             substrs=['stopped', 'stop reason = breakpoint'])
 
+        self.runCmd('settings set target.prefer-dynamic-value no-dynamic-values')
+
         # This is the function to remove the custom formats in order to have a
         # clean slate for the next test case.
         def cleanup():

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCKVO.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCKVO.py
@@ -21,6 +21,8 @@ class ObjCDataFormatterKVO(ObjCDataFormatterTestCase):
             self, '// Set break point at this line.',
             lldb.SBFileSpec('main.m', False))
 
+        self.runCmd('settings set target.prefer-dynamic-value no-dynamic-values')
+
         # The stop reason of the thread should be breakpoint.
         self.expect(
             "thread list",

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSContainer.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSContainer.py
@@ -19,6 +19,8 @@ class ObjCDataFormatterNSContainer(ObjCDataFormatterTestCase):
         self.appkit_tester_impl(self.nscontainers_data_formatter_commands, False)
 
     def nscontainers_data_formatter_commands(self):
+        self.runCmd('settings set target.prefer-dynamic-value no-dynamic-values')
+
         self.expect(
             'frame variable newArray nsDictionary newDictionary nscfDictionary cfDictionaryRef newMutableDictionary copyDictionary newMutableDictionaryRef cfarray_ref mutable_array_ref',
             substrs=[

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSData.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSData.py
@@ -24,6 +24,8 @@ class ObjCDataFormatterNSData(ObjCDataFormatterTestCase):
         self.appkit_tester_impl(self.nsdata_data_formatter_commands, False)
 
     def nsdata_data_formatter_commands(self):
+        self.runCmd('settings set target.prefer-dynamic-value no-dynamic-values')
+
         self.expect(
             'frame variable immutableData mutableData data_ref mutable_data_ref mutable_string_ref concreteData concreteMutableData',
             substrs=[

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSNumber.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSNumber.py
@@ -26,6 +26,8 @@ class ObjCDataFormatterNSNumber(ObjCDataFormatterTestCase):
         self.appkit_tester_impl(self.nscontainers_data_formatter_commands, False)
 
     def nscontainers_data_formatter_commands(self):
+        self.runCmd('settings set target.prefer-dynamic-value no-dynamic-values')
+
         self.expect(
             'frame variable newArray nsDictionary newDictionary nscfDictionary cfDictionaryRef newMutableDictionary cfarray_ref mutable_array_ref',
             substrs=[

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/nsstring/TestDataFormatterNSString.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/nsstring/TestDataFormatterNSString.py
@@ -22,6 +22,8 @@ class NSStringDataFormatterTestCase(TestBase):
 
         self.runCmd("run", RUN_SUCCEEDED)
 
+        self.runCmd("settings set target.prefer-dynamic-value no-dynamic-values")
+
         # The stop reason of the thread should be breakpoint.
         self.expect("thread list", STOPPED_DUE_TO_BREAKPOINT,
                     substrs=['stopped',

--- a/lldb/test/API/functionalities/data-formatter/nsarraysynth/TestNSArraySynthetic.py
+++ b/lldb/test/API/functionalities/data-formatter/nsarraysynth/TestNSArraySynthetic.py
@@ -74,7 +74,7 @@ class NSArraySyntheticTestCase(TestBase):
             substrs=[
                 '@"0 elements"'])
         self.expect(
-            'frame variable arr --ptr-depth 1 -d no-run-target',
+            'frame variable arr --ptr-depth 1',
             substrs=[
                 '@"6 elements"',
                 '@"hello"',
@@ -84,14 +84,14 @@ class NSArraySyntheticTestCase(TestBase):
                 '@"me"',
                 '@"http://www.apple.com'])
         self.expect(
-            'frame variable other_arr --ptr-depth 1 -d no-run-target',
+            'frame variable other_arr --ptr-depth 1',
             substrs=[
                 '@"4 elements"',
                 '(int)5',
                 '@"a string"',
                 '@"6 elements"'])
         self.expect(
-            'frame variable other_arr --ptr-depth 2 -d no-run-target',
+            'frame variable other_arr --ptr-depth 2',
             substrs=[
                 '@"4 elements"',
                 '@"6 elements" {',

--- a/lldb/test/API/functionalities/data-formatter/nsdictionarysynth/TestNSDictionarySynthetic.py
+++ b/lldb/test/API/functionalities/data-formatter/nsdictionarysynth/TestNSDictionarySynthetic.py
@@ -86,7 +86,7 @@ class NSDictionarySyntheticTestCase(TestBase):
                 '[2] = ',
                 '[3] = '])
         self.expect(
-            'frame variable dictionary --ptr-depth 1 --dynamic-type no-run-target',
+            'frame variable dictionary --ptr-depth 1',
             substrs=[
                 '3 key/value pairs',
                 '@"bar"',
@@ -94,7 +94,7 @@ class NSDictionarySyntheticTestCase(TestBase):
                 '@"baz"',
                 '2 key/value pairs'])
         self.expect(
-            'frame variable mutabledict --ptr-depth 1 --dynamic-type no-run-target',
+            'frame variable mutabledict --ptr-depth 1',
             substrs=[
                 '4 key/value pairs',
                 '(int)23',
@@ -103,7 +103,7 @@ class NSDictionarySyntheticTestCase(TestBase):
                 '@"sourceofstuff"',
                 '3 key/value pairs'])
         self.expect(
-            'frame variable mutabledict --ptr-depth 2 --dynamic-type no-run-target',
+            'frame variable mutabledict --ptr-depth 2',
             substrs=[
                 '4 key/value pairs',
                 '(int)23',
@@ -114,7 +114,7 @@ class NSDictionarySyntheticTestCase(TestBase):
                 '@"bar"',
                 '@"2 elements"'])
         self.expect(
-            'frame variable mutabledict --ptr-depth 3 --dynamic-type no-run-target',
+            'frame variable mutabledict --ptr-depth 3',
             substrs=[
                 '4 key/value pairs',
                 '(int)23',

--- a/lldb/test/API/lang/cpp/diamond/TestCppDiamond.py
+++ b/lldb/test/API/lang/cpp/diamond/TestCppDiamond.py
@@ -19,6 +19,8 @@ class TestCase(TestBase):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "// breakpoint 1", lldb.SBFileSpec("main.cpp"))
 
+        self.runCmd("settings set target.prefer-dynamic-value no-dynamic-values")
+
         j1 = self.frame().FindVariable("j1")
         j1_Derived1 = j1.GetChildAtIndex(0)
         j1_Derived2 = j1.GetChildAtIndex(1)

--- a/lldb/test/API/lang/objc/blocks/TestObjCIvarsInBlocks.py
+++ b/lldb/test/API/lang/objc/blocks/TestObjCIvarsInBlocks.py
@@ -44,6 +44,8 @@ class TestObjCIvarsInBlocks(TestBase):
             process.GetState(), lldb.eStateStopped,
             "Stopped it too.")
 
+        self.runCmd('settings set target.prefer-dynamic-value no-dynamic-values')
+
         thread_list = lldbutil.get_threads_stopped_at_breakpoint(
             process, breakpoint)
         self.assertEqual(len(thread_list), 1)

--- a/lldb/test/API/lang/objc/exceptions/TestObjCExceptions.py
+++ b/lldb/test/API/lang/objc/exceptions/TestObjCExceptions.py
@@ -64,7 +64,7 @@ class ObjCExceptionsTestCase(TestBase):
             ])
 
         self.expect(
-            'frame variable --dynamic-type no-run-target *e1',
+            'frame variable *e1',
             substrs=[
                 '(NSException) *e1 = ',
                 'name = ', '"ExceptionName"',
@@ -93,7 +93,7 @@ class ObjCExceptionsTestCase(TestBase):
             ])
 
         self.expect(
-            'frame variable --dynamic-type no-run-target *e2',
+            'frame variable *e2',
             substrs=[
                 '(NSException) *e2 = ',
                 'name = ', '"ThrownException"',

--- a/lldb/test/API/lang/objc/foundation/TestObjCMethods.py
+++ b/lldb/test/API/lang/objc/foundation/TestObjCMethods.py
@@ -127,6 +127,8 @@ class FoundationTestCase(TestBase):
 
         self.runCmd("run", RUN_SUCCEEDED)
 
+        self.runCmd("settings set target.prefer-dynamic-value no-dynamic-values")
+
         # The backtrace should show we stop at -[MyString description].
         self.expect("thread backtrace", "Stop at -[MyString description]",
                     substrs=["a.out`-[MyString description]"])

--- a/lldb/test/API/lang/objc/foundation/TestObjCMethodsString.py
+++ b/lldb/test/API/lang/objc/foundation/TestObjCMethodsString.py
@@ -19,6 +19,8 @@ class FoundationTestCaseString(TestBase):
                 self, '// Break here for NSString tests',
                 lldb.SBFileSpec('main.m', False))
 
+        self.runCmd("settings set target.prefer-dynamic-value no-dynamic-values")
+
         # Test_NSString:
         self.runCmd("thread backtrace")
         self.expect("expression (int)[str length]",

--- a/lldb/test/API/lang/objc/foundation/TestRuntimeTypes.py
+++ b/lldb/test/API/lang/objc/foundation/TestRuntimeTypes.py
@@ -31,6 +31,8 @@ class RuntimeTypesTestCase(TestBase):
 
         self.runCmd("run", RUN_SUCCEEDED)
 
+        self.runCmd("settings set target.prefer-dynamic-value no-dynamic-values")
+
         # The backtrace should show we stop at -[MyString description].
         self.expect("thread backtrace", "Stop at -[MyString description]",
                     substrs=["a.out`-[MyString description]"])

--- a/lldb/test/API/lang/objc/objc-new-syntax/TestObjCNewSyntaxLiteral.py
+++ b/lldb/test/API/lang/objc/objc-new-syntax/TestObjCNewSyntaxLiteral.py
@@ -54,6 +54,8 @@ class ObjCNewSyntaxTestCaseLiteral(ObjCNewSyntaxTest):
     def test_float_literal(self):
         self.runToBreakpoint()
 
+        self.runCmd("settings set target.prefer-dynamic-value no-dynamic-values")
+
         self.expect("expr -- @123.45", VARIABLES_DISPLAYED_CORRECTLY,
                     substrs=["NSNumber", "123.45"])
 
@@ -61,6 +63,8 @@ class ObjCNewSyntaxTestCaseLiteral(ObjCNewSyntaxTest):
     @expectedFailureAll(archs=["i[3-6]86"])
     def test_expressions_in_literals(self):
         self.runToBreakpoint()
+
+        self.runCmd("settings set target.prefer-dynamic-value no-dynamic-values")
 
         self.expect(
             "expr --object-description -- @( 1 + 3 )",

--- a/lldb/test/API/lang/objc/real-definition/TestRealDefinition.py
+++ b/lldb/test/API/lang/objc/real-definition/TestRealDefinition.py
@@ -28,6 +28,8 @@ class TestRealDefinition(TestBase):
         # Run at stop at main
         lldbutil.check_breakpoint(self, bpno = 1, expected_hit_count = 1)
 
+        self.runCmd("settings set target.prefer-dynamic-value no-dynamic-values")
+
         # This should display correctly.
         self.expect(
             "frame variable foo->_bar->_hidden_ivar",
@@ -52,6 +54,8 @@ class TestRealDefinition(TestBase):
 
         # Run at stop at main
         lldbutil.check_breakpoint(self, bpno = 1, expected_hit_count = 1)
+
+        self.runCmd("settings set target.prefer-dynamic-value no-dynamic-values")
 
         # This should display correctly.
         self.expect(

--- a/lldb/test/API/lang/swift/any_object/TestSwiftAnyObjectType.py
+++ b/lldb/test/API/lang/swift/any_object/TestSwiftAnyObjectType.py
@@ -34,7 +34,8 @@ class TestSwiftAnyObjectType(TestBase):
 
         frame = thread.frames[0]
 
-        var_object = frame.FindVariable("object")
+        var_object = frame.FindVariable("object", lldb.eNoDynamicValues)
+
         lldbutil.check_variable(
             self,
             var_object,

--- a/lldb/test/API/lang/swift/deserialization_failure/TestSwiftDeserializationFailure.py
+++ b/lldb/test/API/lang/swift/deserialization_failure/TestSwiftDeserializationFailure.py
@@ -33,7 +33,7 @@ class TestSwiftDeserializationFailure(TestBase):
 
         lldbutil.continue_to_breakpoint(process, generic_bkpt)
         # FIXME: this is formatted incorrectly.
-        self.expect("fr var t", substrs=["(T)"]) #, "world"])
+        self.expect("fr var -d no-dynamic t", substrs=["(T)"]) #, "world"])
 
     @swiftTest
     @skipIf(oslist=['windows'])

--- a/lldb/test/API/lang/swift/dynamic_self/TestSwiftDynamicSelf.py
+++ b/lldb/test/API/lang/swift/dynamic_self/TestSwiftDynamicSelf.py
@@ -9,14 +9,14 @@ class TestSwiftDynamicSelf(lldbtest.TestBase):
 
     def get_self_from_Base_method(self, frame):
         '''When stopped in a method in Base, get the 'self' with type Base.'''
-        var_self = frame.FindVariable("self")
+        var_self = frame.FindVariable("self", lldb.eNoDynamicValues)
         self.assertEqual(var_self.GetNumChildren(), 2)
         return var_self
 
     def get_self_as_Base_from_Child_method(self, frame):
         '''When stopped in a method in Child, get the 'self' with type Base.'''
-        var_self = frame.FindVariable("self")
-        dyn_self = var_self.GetDynamicValue(True)
+        dyn_self = frame.FindVariable("self")
+        self.assertTrue(dyn_self.IsDynamic())
         self.assertEqual(dyn_self.GetNumChildren(), 1)
         var_self_base = dyn_self.GetChildAtIndex(0)
         self.assertEqual(var_self_base.GetNumChildren(), 2)
@@ -48,6 +48,6 @@ class TestSwiftDynamicSelf(lldbtest.TestBase):
         lldbutil.continue_to_breakpoint(process, bkpt) # Stop in Child.show.
         frame = thread.frames[0]
         # When stopped in Child.show(), 'self' doesn't have a child.
-        self.assertEqual(frame.FindVariable("self").GetNumChildren(), 0)
+        self.assertEqual(frame.FindVariable("self", lldb.eNoDynamicValues).GetNumChildren(), 0)
         self.check_members(self.get_self_as_Base_from_Child_method(frame),
                 "100", "220")

--- a/lldb/test/API/lang/swift/dynamic_value/TestSwiftDynamicValue.py
+++ b/lldb/test/API/lang/swift/dynamic_value/TestSwiftDynamicValue.py
@@ -35,7 +35,7 @@ class SwiftDynamicValueTest(TestBase):
         lldbutil.run_to_source_breakpoint(self, "// Set a breakpoint here", lldb.SBFileSpec("main.swift"))
 
         self.expect(
-            "frame variable",
+            "frame variable -d no-dynamic",
             substrs=[
                 "AWrapperClass) aWrapper",
                 "SomeClass) anItem = ",
@@ -43,7 +43,7 @@ class SwiftDynamicValueTest(TestBase):
                 "Base<Int>) aBase = 0x",
                 "v = 449493530"])
         self.expect(
-            "frame variable -d run --show-types",
+            "frame variable --show-types",
             substrs=[
                 "AWrapperClass) aWrapper",
                 "YetAnotherClass) anItem = ",
@@ -57,7 +57,7 @@ class SwiftDynamicValueTest(TestBase):
                 "q = 3735928559"])
         self.runCmd("continue")
         self.expect(
-            "frame variable",
+            "frame variable -d no-dynamic",
             substrs=[
                 "AWrapperClass) aWrapper",
                 "SomeClass) anItem = ",
@@ -65,7 +65,7 @@ class SwiftDynamicValueTest(TestBase):
                 "Base<Int>) aBase = 0x",
                 "v = 449493530"])
         self.expect(
-            "frame variable -d run --show-types",
+            "frame variable --show-types",
             substrs=[
                 "AWrapperClass) aWrapper",
                 "YetAnotherClass) anItem = ",

--- a/lldb/test/API/lang/swift/multilang_category/TestMultilangFormatterCategories.py
+++ b/lldb/test/API/lang/swift/multilang_category/TestMultilangFormatterCategories.py
@@ -24,11 +24,10 @@ class TestMultilangFormatterCategories(TestBase):
         frame = thread.frames[0]
         self.assertTrue(frame, "Frame 0 is valid.")
 
-        dic = frame.FindVariable("dic", lldb.eNoDynamicValues)
+        dic = frame.FindVariable("dic")
         lldbutil.check_variable(
             self,
             dic,
-            use_dynamic=False,
             summary="2 key/value pairs",
             num_children=2)
 
@@ -36,12 +35,11 @@ class TestMultilangFormatterCategories(TestBase):
         lldbutil.check_variable(
             self,
             child0,
-            use_dynamic=False,
             num_children=2,
             typename="__lldb_autogen_nspair")
 
         id1 = child0.GetChildAtIndex(1)
-        lldbutil.check_variable(self, id1, use_dynamic=False, typename="id")
+        lldbutil.check_variable(self, id1, typename="__NSCFNumber *")
 
         id1child0 = dic.GetChildAtIndex(1).GetChildAtIndex(0)
         lldbutil.check_variable(

--- a/lldb/test/API/lang/swift/multilang_category/TestMultilangFormatterCategories.py
+++ b/lldb/test/API/lang/swift/multilang_category/TestMultilangFormatterCategories.py
@@ -24,7 +24,7 @@ class TestMultilangFormatterCategories(TestBase):
         frame = thread.frames[0]
         self.assertTrue(frame, "Frame 0 is valid.")
 
-        dic = frame.FindVariable("dic")
+        dic = frame.FindVariable("dic", lldb.eNoDynamicValues)
         lldbutil.check_variable(
             self,
             dic,

--- a/lldb/test/API/lang/swift/reflection_only/TestSwiftReflectionOnly.py
+++ b/lldb/test/API/lang/swift/reflection_only/TestSwiftReflectionOnly.py
@@ -54,7 +54,7 @@ class TestSwiftReflectionOnly(lldbtest.TestBase):
 
         check_var(self, frame.FindVariable("generic"), use_dynamic=True, value="42")
 
-        gtup = frame.FindVariable("generic_tuple")
+        gtup = frame.FindVariable("generic_tuple", lldb.eNoDynamicValues)
         check_var(self, gtup, num_children=2)
         check_var(self, gtup.GetChildAtIndex(0), use_dynamic=True, value="42")
         check_var(self, gtup.GetChildAtIndex(1), use_dynamic=True, value="42")

--- a/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
+++ b/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
@@ -58,7 +58,8 @@ class TestSwiftProtocolTypes(TestBase):
         self.assertTrue(len(threads) == 1)
         self.thread = threads[0]
 
-        self.expect("frame variable --raw-output --show-types loc2d",
+        self.expect("frame variable --dynamic-type no-dynamic-values"
+                    " --raw-output --show-types loc2d",
                     substrs=['PointUtils) loc2d =',
                              '(Builtin.RawPointer) payload_data_0 = 0x',
                              '(Builtin.RawPointer) payload_data_1 = 0x',
@@ -66,11 +67,12 @@ class TestSwiftProtocolTypes(TestBase):
                              '(Any.Type) metadata = 0x',
                              '(Builtin.RawPointer) wtable = 0x'])
  
-        self.expect("frame variable --dynamic-type run-target loc2d",
+        self.expect("frame variable loc2d",
                     substrs=['Point2D) loc2d =',
                              'x = 1.25', 'y = 2.5'])
  
-        self.expect("frame variable --raw-output --show-types loc3d",
+        self.expect("frame variable --dynamic-type no-dynamic-values"
+                    " --raw-output --show-types loc3d",
                     substrs=['PointUtils) loc3d =',
                              '(Builtin.RawPointer) payload_data_0 = 0x',
                              '(Builtin.RawPointer) payload_data_1 = 0x',
@@ -79,14 +81,15 @@ class TestSwiftProtocolTypes(TestBase):
                              '(Builtin.RawPointer) wtable = 0x'])
  
         self.expect(
-            "frame variable --dynamic-type run-target loc3d",
+            "frame variable loc3d",
             substrs=[
                 'Point3D) loc3d = 0x',
                 'x = 1.25',
                 'y = 2.5',
                 'z = 1.25'])
  
-        self.expect("expression --raw-output --show-types -- loc2d",
+        self.expect("expression --dynamic-type no-dynamic-values"
+                    " --raw-output --show-types -- loc2d",
                     substrs=['PointUtils) $R',
                              '(Builtin.RawPointer) payload_data_0 = 0x',
                              '(Builtin.RawPointer) payload_data_1 = 0x',
@@ -94,25 +97,27 @@ class TestSwiftProtocolTypes(TestBase):
                              '(Any.Type) metadata = 0x',
                              '(Builtin.RawPointer) wtable = 0x'])
  
-        self.expect("expression --dynamic-type run-target -- loc2d",
+        self.expect("expression -- loc2d",
                     substrs=['Point2D) $R',
                              'x = 1.25', 'y = 2.5'])
  
-        self.expect("expression --raw-output --show-types -- loc3dCB",
+        self.expect("expression --dynamic-type no-dynamic-values"
+                    " --raw-output --show-types -- loc3dCB",
                     substrs=['PointUtils & Swift.AnyObject) $R',
                              '(Builtin.RawPointer) object = 0x',
                              '(Builtin.RawPointer) wtable = 0x'])
  
-        self.expect("expression --dynamic-type run-target -- loc3dCB",
+        self.expect("expression -- loc3dCB",
                     substrs=['Point3D) $R', 'x = 1.25', 'y = 2.5', 'z = 1.25'])
 
-        self.expect("expression --raw-output --show-types -- loc3dSuper",
+        self.expect("expression --dynamic-type no-dynamic-values"
+                    " --raw-output --show-types -- loc3dSuper",
                     substrs=['(a.PointSuperclass & a.PointUtils) $R',
 #                             Only supported by SwiftASTContext and of little usefulness.
 #                             '(a.PointSuperclass) object = 0x',
 #                             '(Swift.Int) superData = ',
                              '(Builtin.RawPointer) wtable = 0x'])
 
-        self.expect("expression --dynamic-type run-target -- loc3dSuper",
+        self.expect("expression -- loc3dSuper",
                     substrs=['Point3D) $R', 'x = 1.25', 'y = 2.5', 'z = 1.25'])
 

--- a/lldb/test/API/sanity/TestSettingSkipping.py
+++ b/lldb/test/API/sanity/TestSettingSkipping.py
@@ -12,12 +12,12 @@ class SettingSkipSanityTestCase(TestBase):
 
   NO_DEBUG_INFO_TESTCASE = True
 
-  @skipIf(setting=('target.prefer-dynamic-value', 'no-dynamic-values'))
+  @skipIf(py_version=('>=', (3, 0)))
   def testSkip(self):
     """This setting is on by default"""
     self.assertTrue(False, "This test should not run!")
 
-  @skipIf(setting=('target.prefer-dynamic-value', 'run-target'))
+  @skipIf(py_version=('<', (3, 0)))
   def testNoMatch(self):
     self.assertTrue(True, "This test should run!")
 
@@ -25,11 +25,11 @@ class SettingSkipSanityTestCase(TestBase):
   def testNotExisting(self):
     self.assertTrue(True, "This test should run!")
 
-  @expectedFailureAll(setting=('target.prefer-dynamic-value', 'no-dynamic-values'))
+  @expectedFailureAll(py_version=('>=', (3, 0)))
   def testXFAIL(self):
     self.assertTrue(False, "This test should run and fail!")
 
-  @expectedFailureAll(setting=('target.prefer-dynamic-value', 'run-target'))
+  @expectedFailureAll(py_version=('<', (3, 0)))
   def testNotXFAIL(self):
     self.assertTrue(True, "This test should run and succeed!")
 


### PR DESCRIPTION
Cherry picks [D132382](https://reviews.llvm.org/D132382) and applies fixes to apple/llvm-project specific tests (mostly swift related).