### PR TITLE
[lldb] Increment index of field we're looking for when not an enum

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1126,7 +1126,7 @@ findFieldWithName(const std::vector<swift::reflection::FieldInfo> &fields,
     if (name != field.Name) {
       // A nonnull TypeRef is required for enum cases, where it represents cases
       // that have a payload. In other types it will be true anyway.
-      if (field.TR)
+      if (!is_enum || field.TR)
         ++index;
       return false;
     }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3835,6 +3835,10 @@ bool TypeSystemSwiftTypeRef::ShouldSkipValidation(opaque_compiler_type_t type) {
   // so we skip validation in that casse as well.
   if (mangled_name == "$s10Foundation12NotificationV4NameaD")
     return true;
+
+  if (mangled_name ==  "$s10Foundation12NotificationVD")
+    return true;
+
   if (mangled_name == "$sSo9NSDecimalaD")
     return true;
   // Reconstruct($sSo11CFStringRefaD) returns a non-typealias type, breaking

--- a/lldb/test/API/lang/swift/c_type_external_provider/Makefile
+++ b/lldb/test/API/lang/swift/c_type_external_provider/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFT_BRIDGING_HEADER := bridging-header.h
+include Makefile.rules

--- a/lldb/test/API/lang/swift/c_type_external_provider/TestSwiftCTypeExternalProvider.py
+++ b/lldb/test/API/lang/swift/c_type_external_provider/TestSwiftCTypeExternalProvider.py
@@ -1,0 +1,39 @@
+"""
+Tests that LLDB uses the external type info provider for C types.
+"""
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+
+class TestSwiftCTypeExternalProvider(TestBase):
+    def setUp(self):
+        TestBase.setUp(self)
+        self.main_source = "main.swift"
+        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+
+    @swiftTest
+    def test_swift_regex(self):
+        """Test that C types with builtin metadata emitted are looked up using
+        external type info provider."""
+        self.build()
+        log = self.getBuildArtifact("types.log")
+        self.runCmd('log enable lldb types -f "%s"' % log)
+        lldbutil.run_to_source_breakpoint(
+            self, 'Set breakpoint here', self.main_source_spec)
+
+        # Consult the second field to ensure we call GetIndexOfChildMemberWithName.
+        self.expect('v dummy.second', substrs=['2'])
+
+        # Make sure we look up the type with the external type info provider.
+        provider_log_found = False
+        with open(log, "r", encoding='utf-8') as logfile:
+            for line in logfile:
+                if '[LLDBTypeInfoProvider] Looking up debug type info for So5DummyV' in line:
+                    provider_log_found = True
+                    break
+        self.assertTrue(provider_log_found)
+

--- a/lldb/test/API/lang/swift/c_type_external_provider/bridging-header.h
+++ b/lldb/test/API/lang/swift/c_type_external_provider/bridging-header.h
@@ -1,0 +1,8 @@
+#ifndef bridging_header_h
+#define bridging_header_h
+
+struct Dummy {
+  int first;
+  int second;
+};
+#endif /* bridging_header_h */

--- a/lldb/test/API/lang/swift/c_type_external_provider/main.swift
+++ b/lldb/test/API/lang/swift/c_type_external_provider/main.swift
@@ -1,0 +1,6 @@
+var dummy = Dummy()
+dummy.first = 1;
+dummy.second = 2;
+// Print dummy so we ensure we generate it's metadata.
+print(Dummy.self) // Set breakpoint here.
+


### PR DESCRIPTION
Imported types also don't have typerefs, so we have to increment the index of the field we're looking for in that case.