### PR TITLE
Restore the per-module scratch context fallback mechanism.

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -302,10 +302,7 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
     return false;
   }
 
-  ExecutionContext target_scope(*target);
-  m_swift_scratch_ctx = target->GetSwiftScratchContext(
-      m_err, /* FIXME: should be exe_scope */ *target_scope
-                 .GetBestExecutionContextScope());
+  m_swift_scratch_ctx = target->GetSwiftScratchContext(m_err, *exe_scope);
   if (!m_swift_scratch_ctx) {
     LLDB_LOG(log, "no scratch context", m_err.AsCString());
     return false;
@@ -314,7 +311,12 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
       m_swift_scratch_ctx->get()->GetSwiftASTContext());
 
   if (!m_swift_ast_ctx) {
-    LLDB_LOG(log, "no Swift AST Context");
+    LLDB_LOG(log, "no Swift AST context");
+    return false;
+  }
+
+  if (m_swift_ast_ctx->HasFatalErrors()) {
+    LLDB_LOG(log, "Swift AST context is in a fatal error state");
     return false;
   }
   

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -179,11 +179,11 @@ private:
     void DidDematerialize(lldb::ExpressionVariableSP &variable) override;
   };
 
+  llvm::Optional<SwiftScratchContextReader> m_swift_scratch_ctx;
   SwiftASTContextForExpressions *m_swift_ast_ctx;
   PersistentVariableDelegate m_persistent_variable_delegate;
   std::unique_ptr<SwiftExpressionParser> m_parser;
   Status m_err;
-  llvm::Optional<SwiftScratchContextReader> m_swift_scratch_ctx;
   bool m_runs_in_playground_or_repl;
   bool m_needs_object_ptr = false;
   bool m_in_static_method = false;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2154,17 +2154,22 @@ Status SwiftASTContext::IsCompatible() { return GetFatalErrors(); }
 
 Status SwiftASTContext::GetFatalErrors() const {
   Status error;
-  if (HasFatalErrors()) {
-    error = m_fatal_errors;
-    if (error.Success()) {
-      // Retrieve the error message from the DiagnosticConsumer.
-      DiagnosticManager diagnostic_manager;
-      PrintDiagnostics(diagnostic_manager);
-      error.SetErrorString(diagnostic_manager.GetString());
-    }
+  if (HasFatalErrors())
+    error = GetAllErrors();
+  return error;
+}
+
+Status SwiftASTContext::GetAllErrors() const {
+  Status error = m_fatal_errors;
+  if (error.Success()) {
+    // Retrieve the error message from the DiagnosticConsumer.
+    DiagnosticManager diagnostic_manager;
+    PrintDiagnostics(diagnostic_manager);
+    error.SetErrorString(diagnostic_manager.GetString());
   }
   return error;
 }
+
 
 void SwiftASTContext::LogFatalErrors() const {
   // Avoid spamming the health log with redundant copies of the fatal error.

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -437,12 +437,13 @@ public:
 
   const SwiftModuleMap &GetModuleCache() { return m_swift_module_cache; }
 
+  void RaiseFatalError(std::string msg) { m_fatal_errors.SetErrorString(msg); }
   static bool HasFatalErrors(swift::ASTContext *ast_context);
-
   bool HasFatalErrors() const {
     return m_fatal_errors.Fail() || HasFatalErrors(m_ast_context_ap.get());
   }
 
+  Status GetAllErrors() const;
   Status GetFatalErrors() const;
   void DiagnoseWarnings(Process &process, Module &module) const override;
   void LogFatalErrors() const;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2352,8 +2352,9 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
   }
 
   if (m_cant_make_scratch_type_system.count(language))
-    return llvm::make_error<llvm::StringError>("unable to construct scratch type system",
-                                               llvm::inconvertibleErrorCode());
+    return llvm::make_error<llvm::StringError>(
+        "unable to construct scratch type system",
+        llvm::inconvertibleErrorCode());
 
   auto type_system_or_err = m_scratch_type_system_map.GetTypeSystemForLanguage(
       language, this, create_on_demand, compiler_options);
@@ -2587,7 +2588,7 @@ Target::CreateUtilityFunction(std::string expression, std::string name,
 #ifdef LLDB_ENABLE_SWIFT
 llvm::Optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
     Status &error, ExecutionContextScope &exe_scope, bool create_on_demand) {
-  Log *log = GetLog(LLDBLog::Target);
+  Log *log = GetLog(LLDBLog::Target | LLDBLog::Types | LLDBLog::Expressions);
   LLDB_SCOPED_TIMER();
 
   Module *lldb_module = nullptr;
@@ -2624,20 +2625,29 @@ llvm::Optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
       return cached_ts;
     }
 
-    if (!create_on_demand || !GetSwiftScratchContextLock().try_lock())
+    if (!create_on_demand) {
+      if (log)
+        log->Printf("not allowed to create a new context\n");
       return nullptr;
+    }
+    if (!GetSwiftScratchContextLock().try_lock()) {
+      if (log)
+        log->Printf("couldn't acquire scratch context lock\n");
+      return nullptr;
+    }
 
     auto unlock = llvm::make_scope_exit(
         [this] { GetSwiftScratchContextLock().unlock(); });
 
-    auto type_system_or_err = GetScratchTypeSystemForLanguage(eLanguageTypeSwift, false);
+    auto type_system_or_err =
+        GetScratchTypeSystemForLanguage(eLanguageTypeSwift, false);
     if (!type_system_or_err) {
       llvm::consumeError(type_system_or_err.takeError());
       return nullptr;
     }
 
     if (auto *global_scratch_ctx =
-            llvm::cast_or_null<SwiftASTContextForExpressions>(
+            llvm::cast_or_null<TypeSystemSwiftTypeRefForExpressions>(
                 &*type_system_or_err))
       if (auto *swift_ast_ctx =
               llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
@@ -2676,7 +2686,8 @@ llvm::Optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
 
   if (!swift_scratch_ctx)
     return llvm::None;
-  return SwiftScratchContextReader(GetSwiftScratchContextLock(), *swift_scratch_ctx);
+  return SwiftScratchContextReader(GetSwiftScratchContextLock(),
+                                   *swift_scratch_ctx);
 }
 
 static SharedMutex *

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Bar/Bar.h
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Bar/Bar.h
@@ -1,0 +1,3 @@
+MACRO Bar {
+  int i;
+};

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Bar/module.modulemap
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Bar/module.modulemap
@@ -1,0 +1,3 @@
+module Bar {
+  header "Bar.h"
+}

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Foo/Foo.h
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Foo/Foo.h
@@ -1,0 +1,3 @@
+struct Foo {
+  MACRO j;
+};

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Foo/module.modulemap
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Foo/module.modulemap
@@ -1,0 +1,3 @@
+module Foo {
+  header "Foo.h"
+}

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Framework.swift
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Framework.swift
@@ -1,0 +1,8 @@
+@_implementationOnly import Foo
+
+func use<T>(_ t: T) {}
+
+public func f() {
+  let foo = Foo(j: 23)
+  use(foo) // break here
+}

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Makefile
@@ -1,0 +1,23 @@
+SWIFT_SOURCES = main.swift
+SWIFT_OBJC_INTEROP := 1
+
+all: Framework.framework a.out
+
+include Makefile.rules
+BAR_FLAGS= -Xcc -I$(SRCDIR)/Bar -Xcc -DMACRO=struct
+FOO_FLAGS= -Xcc -I$(SRCDIR)/Foo -Xcc -DMACRO=int
+SWIFTFLAGS_EXTRAS=$(BAR_FLAGS) \
+  -F$(BUILDDIR) -framework Framework -L$(BUILDDIR) \
+  -Xlinker -rpath -Xlinker $(BUILDDIR)
+
+Framework.framework: Framework.swift
+	$(MAKE) -f $(MAKEFILE_RULES) -C $(BUILDDIR) VPATH=$(VPATH) \
+                MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		DYLIB_NAME=$(shell basename $< .swift) \
+		DYLIB_ONLY=YES DYLIB_SWIFT_SOURCES=Framework.swift \
+		SWIFT_OBJC_INTEROP=1 \
+		SWIFTFLAGS_EXTRAS="$(FOO_FLAGS)" \
+		FRAMEWORK=Framework
+	rm -f $(BUILDDIR)/Framework.swiftmodule
+	ln -s $(BUILDDIR)/Framework.framework/Framework $(BUILDDIR)/Framework # FIXME

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/TestSwiftHardMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/TestSwiftHardMacroConflict.py
@@ -1,0 +1,47 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+import shutil
+
+class TestSwiftHardMacroConflict(TestBase):
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    NO_DEBUG_INFO_TESTCASE = True
+
+    # Don't run ClangImporter tests if Clangimporter is disabled.
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.runCmd("settings set symbols.use-swift-dwarfimporter false")
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'),
+            extra_images=['Framework.framework'])
+        b_breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here', lldb.SBFileSpec('Framework.swift'))
+        log = self.getBuildArtifact("types.log")
+        self.runCmd('log enable lldb types -f "%s"' % log)
+
+        # This is expected to succeed because ClangImporter was set up
+        # with the flags from the main executable.
+        self.expect("expr bar", "expected result", substrs=["42"])
+
+        process.Continue()
+        threads = lldbutil.get_threads_stopped_at_breakpoint(
+            process, b_breakpoint)
+        self.expect("p foo", error=True)
+
+        per_module_fallback = 0
+        import io
+        with open(log, "r", encoding='utf-8') as logfile:
+            for line in logfile:
+                if 'SwiftASTContextForExpressions("Framework")' in line:
+                    per_module_fallback += 1
+        self.assertGreater(per_module_fallback, 0,
+                           "failed to create per-module scratch context")

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/main.swift
@@ -1,0 +1,12 @@
+import Bar
+import Framework
+
+func use<T>(_ t: T) {}
+
+func main() {
+  let bar = Bar(i: 42)
+  f() // break here
+  use(bar)
+}
+
+main()

--- a/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
+++ b/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
@@ -20,7 +20,7 @@ class TestSwiftLazyFramework(lldbtest.TestBase):
         self.expect("settings set target.swift-auto-import-frameworks true")
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('main.swift'))
-        
+
         # Verify that lazy is not linked in.
         self.runCmd("image list")
         output = self.res.GetOutput()


### PR DESCRIPTION
This feature has been accidentally disabled when introducing
TypeSystemSwiftTypeRefForExpressions and thanks to how good
TypeSystemSwiftTypeRef has become, all of the tests for the feature
were still passing.