### PR TITLE
[clang][ExtractAPI] Record availability information on all platforms

### DIFF
--- a/clang/lib/ExtractAPI/API.cpp
+++ b/clang/lib/ExtractAPI/API.cpp
@@ -43,68 +43,77 @@ RecordTy *addTopLevelRecord(APISet::RecordMap<RecordTy> &RecordMap,
 
 GlobalVariableRecord *
 APISet::addGlobalVar(StringRef Name, StringRef USR, PresumedLoc Loc,
-                     const AvailabilityInfo &Availability, LinkageInfo Linkage,
+                     AvailabilitySet Availabilities, LinkageInfo Linkage,
                      const DocComment &Comment, DeclarationFragments Fragments,
                      DeclarationFragments SubHeading) {
-  return addTopLevelRecord(GlobalVariables, USR, Name, Loc, Availability,
-                           Linkage, Comment, Fragments, SubHeading);
+  return addTopLevelRecord(GlobalVariables, USR, Name, Loc,
+                           std::move(Availabilities), Linkage, Comment,
+                           Fragments, SubHeading);
 }
 
 GlobalFunctionRecord *APISet::addGlobalFunction(
     StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, LinkageInfo Linkage,
+    AvailabilitySet Availabilities, LinkageInfo Linkage,
     const DocComment &Comment, DeclarationFragments Fragments,
     DeclarationFragments SubHeading, FunctionSignature Signature) {
-  return addTopLevelRecord(GlobalFunctions, USR, Name, Loc, Availability,
-                           Linkage, Comment, Fragments, SubHeading, Signature);
+  return addTopLevelRecord(GlobalFunctions, USR, Name, Loc,
+                           std::move(Availabilities), Linkage, Comment,
+                           Fragments, SubHeading, Signature);
 }
 
-EnumConstantRecord *APISet::addEnumConstant(
-    EnumRecord *Enum, StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, const DocComment &Comment,
-    DeclarationFragments Declaration, DeclarationFragments SubHeading) {
+EnumConstantRecord *APISet::addEnumConstant(EnumRecord *Enum, StringRef Name,
+                                            StringRef USR, PresumedLoc Loc,
+                                            AvailabilitySet Availabilities,
+                                            const DocComment &Comment,
+                                            DeclarationFragments Declaration,
+                                            DeclarationFragments SubHeading) {
   auto Record = std::make_unique<EnumConstantRecord>(
-      USR, Name, Loc, Availability, Comment, Declaration, SubHeading);
+      USR, Name, Loc, std::move(Availabilities), Comment, Declaration,
+      SubHeading);
   return Enum->Constants.emplace_back(std::move(Record)).get();
 }
 
 EnumRecord *APISet::addEnum(StringRef Name, StringRef USR, PresumedLoc Loc,
-                            const AvailabilityInfo &Availability,
+                            AvailabilitySet Availabilities,
                             const DocComment &Comment,
                             DeclarationFragments Declaration,
                             DeclarationFragments SubHeading) {
-  return addTopLevelRecord(Enums, USR, Name, Loc, Availability, Comment,
-                           Declaration, SubHeading);
+  return addTopLevelRecord(Enums, USR, Name, Loc, std::move(Availabilities),
+                           Comment, Declaration, SubHeading);
 }
 
 StructFieldRecord *APISet::addStructField(StructRecord *Struct, StringRef Name,
                                           StringRef USR, PresumedLoc Loc,
-                                          const AvailabilityInfo &Availability,
+                                          AvailabilitySet Availabilities,
                                           const DocComment &Comment,
                                           DeclarationFragments Declaration,
                                           DeclarationFragments SubHeading) {
   auto Record = std::make_unique<StructFieldRecord>(
-      USR, Name, Loc, Availability, Comment, Declaration, SubHeading);
+      USR, Name, Loc, std::move(Availabilities), Comment, Declaration,
+      SubHeading);
   return Struct->Fields.emplace_back(std::move(Record)).get();
 }
 
 StructRecord *APISet::addStruct(StringRef Name, StringRef USR, PresumedLoc Loc,
-                                const AvailabilityInfo &Availability,
+                                AvailabilitySet Availabilities,
                                 const DocComment &Comment,
                                 DeclarationFragments Declaration,
                                 DeclarationFragments SubHeading) {
-  return addTopLevelRecord(Structs, USR, Name, Loc, Availability, Comment,
-                           Declaration, SubHeading);
+  return addTopLevelRecord(Structs, USR, Name, Loc, std::move(Availabilities),
+                           Comment, Declaration, SubHeading);
 }
 
-ObjCCategoryRecord *APISet::addObjCCategory(
-    StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, const DocComment &Comment,
-    DeclarationFragments Declaration, DeclarationFragments SubHeading,
-    SymbolReference Interface) {
+ObjCCategoryRecord *APISet::addObjCCategory(StringRef Name, StringRef USR,
+                                            PresumedLoc Loc,
+                                            AvailabilitySet Availabilities,
+                                            const DocComment &Comment,
+                                            DeclarationFragments Declaration,
+                                            DeclarationFragments SubHeading,
+                                            SymbolReference Interface) {
   // Create the category record.
-  auto *Record = addTopLevelRecord(ObjCCategories, USR, Name, Loc, Availability,
-                                   Comment, Declaration, SubHeading, Interface);
+  auto *Record = addTopLevelRecord(ObjCCategories, USR, Name, Loc,
+                                   std::move(Availabilities), Comment,
+                                   Declaration, SubHeading, Interface);
 
   // If this category is extending a known interface, associate it with the
   // ObjCInterfaceRecord.
@@ -117,56 +126,57 @@ ObjCCategoryRecord *APISet::addObjCCategory(
 
 ObjCInterfaceRecord *APISet::addObjCInterface(
     StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, LinkageInfo Linkage,
+    AvailabilitySet Availabilities, LinkageInfo Linkage,
     const DocComment &Comment, DeclarationFragments Declaration,
     DeclarationFragments SubHeading, SymbolReference SuperClass) {
-  return addTopLevelRecord(ObjCInterfaces, USR, Name, Loc, Availability,
-                           Linkage, Comment, Declaration, SubHeading,
-                           SuperClass);
+  return addTopLevelRecord(ObjCInterfaces, USR, Name, Loc,
+                           std::move(Availabilities), Linkage, Comment,
+                           Declaration, SubHeading, SuperClass);
 }
 
 ObjCMethodRecord *APISet::addObjCMethod(
     ObjCContainerRecord *Container, StringRef Name, StringRef USR,
-    PresumedLoc Loc, const AvailabilityInfo &Availability,
-    const DocComment &Comment, DeclarationFragments Declaration,
-    DeclarationFragments SubHeading, FunctionSignature Signature,
-    bool IsInstanceMethod) {
+    PresumedLoc Loc, AvailabilitySet Availabilities, const DocComment &Comment,
+    DeclarationFragments Declaration, DeclarationFragments SubHeading,
+    FunctionSignature Signature, bool IsInstanceMethod) {
   auto Record = std::make_unique<ObjCMethodRecord>(
-      USR, Name, Loc, Availability, Comment, Declaration, SubHeading, Signature,
-      IsInstanceMethod);
+      USR, Name, Loc, std::move(Availabilities), Comment, Declaration,
+      SubHeading, Signature, IsInstanceMethod);
   return Container->Methods.emplace_back(std::move(Record)).get();
 }
 
 ObjCPropertyRecord *APISet::addObjCProperty(
     ObjCContainerRecord *Container, StringRef Name, StringRef USR,
-    PresumedLoc Loc, const AvailabilityInfo &Availability,
-    const DocComment &Comment, DeclarationFragments Declaration,
-    DeclarationFragments SubHeading,
+    PresumedLoc Loc, AvailabilitySet Availabilities, const DocComment &Comment,
+    DeclarationFragments Declaration, DeclarationFragments SubHeading,
     ObjCPropertyRecord::AttributeKind Attributes, StringRef GetterName,
     StringRef SetterName, bool IsOptional) {
   auto Record = std::make_unique<ObjCPropertyRecord>(
-      USR, Name, Loc, Availability, Comment, Declaration, SubHeading,
-      Attributes, GetterName, SetterName, IsOptional);
+      USR, Name, Loc, std::move(Availabilities), Comment, Declaration,
+      SubHeading, Attributes, GetterName, SetterName, IsOptional);
   return Container->Properties.emplace_back(std::move(Record)).get();
 }
 
 ObjCInstanceVariableRecord *APISet::addObjCInstanceVariable(
     ObjCContainerRecord *Container, StringRef Name, StringRef USR,
-    PresumedLoc Loc, const AvailabilityInfo &Availability,
-    const DocComment &Comment, DeclarationFragments Declaration,
-    DeclarationFragments SubHeading,
+    PresumedLoc Loc, AvailabilitySet Availabilities, const DocComment &Comment,
+    DeclarationFragments Declaration, DeclarationFragments SubHeading,
     ObjCInstanceVariableRecord::AccessControl Access) {
   auto Record = std::make_unique<ObjCInstanceVariableRecord>(
-      USR, Name, Loc, Availability, Comment, Declaration, SubHeading, Access);
+      USR, Name, Loc, std::move(Availabilities), Comment, Declaration,
+      SubHeading, Access);
   return Container->Ivars.emplace_back(std::move(Record)).get();
 }
 
-ObjCProtocolRecord *APISet::addObjCProtocol(
-    StringRef Name, StringRef USR, PresumedLoc Loc,
-    const AvailabilityInfo &Availability, const DocComment &Comment,
-    DeclarationFragments Declaration, DeclarationFragments SubHeading) {
-  return addTopLevelRecord(ObjCProtocols, USR, Name, Loc, Availability, Comment,
-                           Declaration, SubHeading);
+ObjCProtocolRecord *APISet::addObjCProtocol(StringRef Name, StringRef USR,
+                                            PresumedLoc Loc,
+                                            AvailabilitySet Availabilities,
+                                            const DocComment &Comment,
+                                            DeclarationFragments Declaration,
+                                            DeclarationFragments SubHeading) {
+  return addTopLevelRecord(ObjCProtocols, USR, Name, Loc,
+                           std::move(Availabilities), Comment, Declaration,
+                           SubHeading);
 }
 
 MacroDefinitionRecord *
@@ -178,13 +188,13 @@ APISet::addMacroDefinition(StringRef Name, StringRef USR, PresumedLoc Loc,
 
 TypedefRecord *APISet::addTypedef(StringRef Name, StringRef USR,
                                   PresumedLoc Loc,
-                                  const AvailabilityInfo &Availability,
+                                  AvailabilitySet Availabilities,
                                   const DocComment &Comment,
                                   DeclarationFragments Declaration,
                                   DeclarationFragments SubHeading,
                                   SymbolReference UnderlyingType) {
-  return addTopLevelRecord(Typedefs, USR, Name, Loc, Availability, Comment,
-                           Declaration, SubHeading, UnderlyingType);
+  return addTopLevelRecord(Typedefs, USR, Name, Loc, std::move(Availabilities),
+                           Comment, Declaration, SubHeading, UnderlyingType);
 }
 
 StringRef APISet::recordUSR(const Decl *D) {

--- a/clang/lib/ExtractAPI/AvailabilityInfo.cpp
+++ b/clang/lib/ExtractAPI/AvailabilityInfo.cpp
@@ -1,0 +1,50 @@
+#include "clang/ExtractAPI/AvailabilityInfo.h"
+#include "clang/AST/Attr.h"
+#include "llvm/ADT/STLExtras.h"
+
+using namespace clang;
+using namespace extractapi;
+
+AvailabilitySet::AvailabilitySet(const Decl *Decl) {
+  // Collect availability attributes from all redeclrations.
+  for (const auto *RD : Decl->redecls()) {
+    if (const auto *A = RD->getAttr<UnavailableAttr>()) {
+      if (!A->isImplicit()) {
+        this->Availabilities.clear();
+        UnconditionallyUnavailable = true;
+      }
+    }
+
+    if (const auto *A = RD->getAttr<DeprecatedAttr>()) {
+      if (!A->isImplicit()) {
+        this->Availabilities.clear();
+        UnconditionallyDeprecated = true;
+      }
+    }
+
+    for (const auto *Attr : RD->specific_attrs<AvailabilityAttr>()) {
+      StringRef Domain = Attr->getPlatform()->getName();
+      auto *Availability =
+          llvm::find_if(Availabilities, [Domain](const AvailabilityInfo &Info) {
+            return Domain.equals(Info.Domain);
+          });
+      if (Availability != Availabilities.end()) {
+        // Get the highest introduced version for all redeclarations.
+        if (Availability->Introduced < Attr->getIntroduced())
+          Availability->Introduced = Attr->getIntroduced();
+
+        // Get the lowest deprecated version for all redeclarations.
+        if (Availability->Deprecated > Attr->getDeprecated())
+          Availability->Deprecated = Attr->getDeprecated();
+
+        // Get the lowest obsoleted version for all redeclarations.
+        if (Availability->Obsoleted > Attr->getObsoleted())
+          Availability->Obsoleted = Attr->getObsoleted();
+      } else {
+        Availabilities.emplace_back(Domain, Attr->getIntroduced(),
+                                    Attr->getDeprecated(),
+                                    Attr->getObsoleted());
+      }
+    }
+  }
+}

--- a/clang/lib/ExtractAPI/CMakeLists.txt
+++ b/clang/lib/ExtractAPI/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_LINK_COMPONENTS
 
 add_clang_library(clangExtractAPI
   API.cpp
+  AvailabilityInfo.cpp
   ExtractAPIConsumer.cpp
   DeclarationFragments.cpp
   Serialization/SerializerBase.cpp

--- a/clang/lib/ExtractAPI/ExtractAPIConsumer.cpp
+++ b/clang/lib/ExtractAPI/ExtractAPIConsumer.cpp
@@ -264,7 +264,6 @@ public:
     StringRef USR = API.recordUSR(Decl);
     PresumedLoc Loc =
         Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-    AvailabilityInfo Availability = getAvailability(Decl);
     LinkageInfo Linkage = Decl->getLinkageAndVisibility();
     DocComment Comment;
     if (auto *RawComment = Context.getRawCommentForDeclNoCache(Decl))
@@ -278,7 +277,7 @@ public:
         DeclarationFragmentsBuilder::getSubHeading(Decl);
 
     // Add the global variable record to the API set.
-    API.addGlobalVar(Name, USR, Loc, Availability, Linkage, Comment,
+    API.addGlobalVar(Name, USR, Loc, AvailabilitySet(Decl), Linkage, Comment,
                      Declaration, SubHeading);
     return true;
   }
@@ -324,7 +323,6 @@ public:
     StringRef USR = API.recordUSR(Decl);
     PresumedLoc Loc =
         Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-    AvailabilityInfo Availability = getAvailability(Decl);
     LinkageInfo Linkage = Decl->getLinkageAndVisibility();
     DocComment Comment;
     if (auto *RawComment = Context.getRawCommentForDeclNoCache(Decl))
@@ -340,8 +338,8 @@ public:
         DeclarationFragmentsBuilder::getFunctionSignature(Decl);
 
     // Add the function record to the API set.
-    API.addGlobalFunction(Name, USR, Loc, Availability, Linkage, Comment,
-                          Declaration, SubHeading, Signature);
+    API.addGlobalFunction(Name, USR, Loc, AvailabilitySet(Decl), Linkage,
+                          Comment, Declaration, SubHeading, Signature);
     return true;
   }
 
@@ -365,7 +363,6 @@ public:
     StringRef USR = API.recordUSR(Decl);
     PresumedLoc Loc =
         Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-    AvailabilityInfo Availability = getAvailability(Decl);
     DocComment Comment;
     if (auto *RawComment = Context.getRawCommentForDeclNoCache(Decl))
       Comment = RawComment->getFormattedLines(Context.getSourceManager(),
@@ -378,8 +375,8 @@ public:
         DeclarationFragmentsBuilder::getSubHeading(Decl);
 
     EnumRecord *EnumRecord =
-        API.addEnum(API.copyString(Name), USR, Loc, Availability, Comment,
-                    Declaration, SubHeading);
+        API.addEnum(API.copyString(Name), USR, Loc, AvailabilitySet(Decl),
+                    Comment, Declaration, SubHeading);
 
     // Now collect information about the enumerators in this enum.
     recordEnumConstants(EnumRecord, Decl->enumerators());
@@ -406,7 +403,6 @@ public:
     StringRef USR = API.recordUSR(Decl);
     PresumedLoc Loc =
         Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-    AvailabilityInfo Availability = getAvailability(Decl);
     DocComment Comment;
     if (auto *RawComment = Context.getRawCommentForDeclNoCache(Decl))
       Comment = RawComment->getFormattedLines(Context.getSourceManager(),
@@ -418,8 +414,9 @@ public:
     DeclarationFragments SubHeading =
         DeclarationFragmentsBuilder::getSubHeading(Decl);
 
-    StructRecord *StructRecord = API.addStruct(
-        Name, USR, Loc, Availability, Comment, Declaration, SubHeading);
+    StructRecord *StructRecord =
+        API.addStruct(Name, USR, Loc, AvailabilitySet(Decl), Comment,
+                      Declaration, SubHeading);
 
     // Now collect information about the fields in this struct.
     recordStructFields(StructRecord, Decl->fields());
@@ -440,7 +437,6 @@ public:
     StringRef USR = API.recordUSR(Decl);
     PresumedLoc Loc =
         Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-    AvailabilityInfo Availability = getAvailability(Decl);
     LinkageInfo Linkage = Decl->getLinkageAndVisibility();
     DocComment Comment;
     if (auto *RawComment = Context.getRawCommentForDeclNoCache(Decl))
@@ -461,8 +457,8 @@ public:
     }
 
     ObjCInterfaceRecord *ObjCInterfaceRecord =
-        API.addObjCInterface(Name, USR, Loc, Availability, Linkage, Comment,
-                             Declaration, SubHeading, SuperClass);
+        API.addObjCInterface(Name, USR, Loc, AvailabilitySet(Decl), Linkage,
+                             Comment, Declaration, SubHeading, SuperClass);
 
     // Record all methods (selectors). This doesn't include automatically
     // synthesized property methods.
@@ -487,7 +483,6 @@ public:
     StringRef USR = API.recordUSR(Decl);
     PresumedLoc Loc =
         Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-    AvailabilityInfo Availability = getAvailability(Decl);
     DocComment Comment;
     if (auto *RawComment = Context.getRawCommentForDeclNoCache(Decl))
       Comment = RawComment->getFormattedLines(Context.getSourceManager(),
@@ -499,8 +494,9 @@ public:
     DeclarationFragments SubHeading =
         DeclarationFragmentsBuilder::getSubHeading(Decl);
 
-    ObjCProtocolRecord *ObjCProtocolRecord = API.addObjCProtocol(
-        Name, USR, Loc, Availability, Comment, Declaration, SubHeading);
+    ObjCProtocolRecord *ObjCProtocolRecord =
+        API.addObjCProtocol(Name, USR, Loc, AvailabilitySet(Decl), Comment,
+                            Declaration, SubHeading);
 
     recordObjCMethods(ObjCProtocolRecord, Decl->methods());
     recordObjCProperties(ObjCProtocolRecord, Decl->properties());
@@ -523,7 +519,6 @@ public:
     PresumedLoc Loc =
         Context.getSourceManager().getPresumedLoc(Decl->getLocation());
     StringRef Name = Decl->getName();
-    AvailabilityInfo Availability = getAvailability(Decl);
     StringRef USR = API.recordUSR(Decl);
     DocComment Comment;
     if (auto *RawComment = Context.getRawCommentForDeclNoCache(Decl))
@@ -535,7 +530,7 @@ public:
         TypedefUnderlyingTypeResolver(Context).getSymbolReferenceForType(Type,
                                                                          API);
 
-    API.addTypedef(Name, USR, Loc, Availability, Comment,
+    API.addTypedef(Name, USR, Loc, AvailabilitySet(Decl), Comment,
                    DeclarationFragmentsBuilder::getFragmentsForTypedef(Decl),
                    DeclarationFragmentsBuilder::getSubHeading(Decl), SymRef);
 
@@ -548,7 +543,6 @@ public:
     StringRef USR = API.recordUSR(Decl);
     PresumedLoc Loc =
         Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-    AvailabilityInfo Availability = getAvailability(Decl);
     DocComment Comment;
     if (auto *RawComment = Context.getRawCommentForDeclNoCache(Decl))
       Comment = RawComment->getFormattedLines(Context.getSourceManager(),
@@ -564,8 +558,8 @@ public:
                               API.recordUSR(InterfaceDecl));
 
     ObjCCategoryRecord *ObjCCategoryRecord =
-        API.addObjCCategory(Name, USR, Loc, Availability, Comment, Declaration,
-                            SubHeading, Interface);
+        API.addObjCCategory(Name, USR, Loc, AvailabilitySet(Decl), Comment,
+                            Declaration, SubHeading, Interface);
 
     recordObjCMethods(ObjCCategoryRecord, Decl->methods());
     recordObjCProperties(ObjCCategoryRecord, Decl->properties());
@@ -576,37 +570,6 @@ public:
   }
 
 private:
-  /// Get availability information of the declaration \p D.
-  AvailabilityInfo getAvailability(const Decl *D) const {
-    StringRef PlatformName = Context.getTargetInfo().getPlatformName();
-
-    AvailabilityInfo Availability;
-    // Collect availability attributes from all redeclarations.
-    for (const auto *RD : D->redecls()) {
-      for (const auto *A : RD->specific_attrs<AvailabilityAttr>()) {
-        if (A->getPlatform()->getName() != PlatformName)
-          continue;
-        Availability = AvailabilityInfo(A->getIntroduced(), A->getDeprecated(),
-                                        A->getObsoleted(), A->getUnavailable(),
-                                        /* UnconditionallyDeprecated */ false,
-                                        /* UnconditionallyUnavailable */ false);
-        break;
-      }
-
-      if (const auto *A = RD->getAttr<UnavailableAttr>())
-        if (!A->isImplicit()) {
-          Availability.Unavailable = true;
-          Availability.UnconditionallyUnavailable = true;
-        }
-
-      if (const auto *A = RD->getAttr<DeprecatedAttr>())
-        if (!A->isImplicit())
-          Availability.UnconditionallyDeprecated = true;
-    }
-
-    return Availability;
-  }
-
   /// Collect API information for the enum constants and associate with the
   /// parent enum.
   void recordEnumConstants(EnumRecord *EnumRecord,
@@ -617,7 +580,6 @@ private:
       StringRef USR = API.recordUSR(Constant);
       PresumedLoc Loc =
           Context.getSourceManager().getPresumedLoc(Constant->getLocation());
-      AvailabilityInfo Availability = getAvailability(Constant);
       DocComment Comment;
       if (auto *RawComment = Context.getRawCommentForDeclNoCache(Constant))
         Comment = RawComment->getFormattedLines(Context.getSourceManager(),
@@ -629,8 +591,8 @@ private:
       DeclarationFragments SubHeading =
           DeclarationFragmentsBuilder::getSubHeading(Constant);
 
-      API.addEnumConstant(EnumRecord, Name, USR, Loc, Availability, Comment,
-                          Declaration, SubHeading);
+      API.addEnumConstant(EnumRecord, Name, USR, Loc, AvailabilitySet(Constant),
+                          Comment, Declaration, SubHeading);
     }
   }
 
@@ -644,7 +606,6 @@ private:
       StringRef USR = API.recordUSR(Field);
       PresumedLoc Loc =
           Context.getSourceManager().getPresumedLoc(Field->getLocation());
-      AvailabilityInfo Availability = getAvailability(Field);
       DocComment Comment;
       if (auto *RawComment = Context.getRawCommentForDeclNoCache(Field))
         Comment = RawComment->getFormattedLines(Context.getSourceManager(),
@@ -656,8 +617,8 @@ private:
       DeclarationFragments SubHeading =
           DeclarationFragmentsBuilder::getSubHeading(Field);
 
-      API.addStructField(StructRecord, Name, USR, Loc, Availability, Comment,
-                         Declaration, SubHeading);
+      API.addStructField(StructRecord, Name, USR, Loc, AvailabilitySet(Field),
+                         Comment, Declaration, SubHeading);
     }
   }
 
@@ -674,7 +635,6 @@ private:
       StringRef USR = API.recordUSR(Method);
       PresumedLoc Loc =
           Context.getSourceManager().getPresumedLoc(Method->getLocation());
-      AvailabilityInfo Availability = getAvailability(Method);
       DocComment Comment;
       if (auto *RawComment = Context.getRawCommentForDeclNoCache(Method))
         Comment = RawComment->getFormattedLines(Context.getSourceManager(),
@@ -688,8 +648,8 @@ private:
       FunctionSignature Signature =
           DeclarationFragmentsBuilder::getFunctionSignature(Method);
 
-      API.addObjCMethod(Container, Name, USR, Loc, Availability, Comment,
-                        Declaration, SubHeading, Signature,
+      API.addObjCMethod(Container, Name, USR, Loc, AvailabilitySet(Method),
+                        Comment, Declaration, SubHeading, Signature,
                         Method->isInstanceMethod());
     }
   }
@@ -701,7 +661,6 @@ private:
       StringRef USR = API.recordUSR(Property);
       PresumedLoc Loc =
           Context.getSourceManager().getPresumedLoc(Property->getLocation());
-      AvailabilityInfo Availability = getAvailability(Property);
       DocComment Comment;
       if (auto *RawComment = Context.getRawCommentForDeclNoCache(Property))
         Comment = RawComment->getFormattedLines(Context.getSourceManager(),
@@ -727,8 +686,8 @@ private:
         Attributes |= ObjCPropertyRecord::Class;
 
       API.addObjCProperty(
-          Container, Name, USR, Loc, Availability, Comment, Declaration,
-          SubHeading,
+          Container, Name, USR, Loc, AvailabilitySet(Property), Comment,
+          Declaration, SubHeading,
           static_cast<ObjCPropertyRecord::AttributeKind>(Attributes),
           GetterName, SetterName, Property->isOptional());
     }
@@ -744,7 +703,6 @@ private:
       StringRef USR = API.recordUSR(Ivar);
       PresumedLoc Loc =
           Context.getSourceManager().getPresumedLoc(Ivar->getLocation());
-      AvailabilityInfo Availability = getAvailability(Ivar);
       DocComment Comment;
       if (auto *RawComment = Context.getRawCommentForDeclNoCache(Ivar))
         Comment = RawComment->getFormattedLines(Context.getSourceManager(),
@@ -759,8 +717,9 @@ private:
       ObjCInstanceVariableRecord::AccessControl Access =
           Ivar->getCanonicalAccessControl();
 
-      API.addObjCInstanceVariable(Container, Name, USR, Loc, Availability,
-                                  Comment, Declaration, SubHeading, Access);
+      API.addObjCInstanceVariable(Container, Name, USR, Loc,
+                                  AvailabilitySet(Ivar), Comment, Declaration,
+                                  SubHeading, Access);
     }
   }
 

--- a/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
+++ b/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
@@ -135,30 +135,42 @@ Object serializeSourceRange(const PresumedLoc &BeginLoc,
 /// Serialize the availability attributes of a symbol.
 ///
 /// Availability information contains the introduced, deprecated, and obsoleted
-/// versions of the symbol as semantic versions, if not default.
-/// Availability information also contains flags to indicate if the symbol is
-/// unconditionally unavailable or deprecated,
-/// i.e. \c __attribute__((unavailable)) and \c __attribute__((deprecated)).
+/// versions of the symbol for a given domain (roughly corresponds to a
+/// platform) as semantic versions, if not default.  Availability information
+/// also contains flags to indicate if the symbol is unconditionally unavailable
+/// or deprecated, i.e. \c __attribute__((unavailable)) and \c
+/// __attribute__((deprecated)).
 ///
 /// \returns \c None if the symbol has default availability attributes, or
-/// an \c Object containing the formatted availability information.
-Optional<Object> serializeAvailability(const AvailabilityInfo &Avail) {
-  if (Avail.isDefault())
+/// an \c Array containing the formatted availability information.
+Optional<Array> serializeAvailability(const AvailabilitySet &Availabilities) {
+  if (Availabilities.isDefault())
     return None;
 
-  Object Availbility;
-  serializeObject(Availbility, "introducedVersion",
-                  serializeSemanticVersion(Avail.Introduced));
-  serializeObject(Availbility, "deprecatedVersion",
-                  serializeSemanticVersion(Avail.Deprecated));
-  serializeObject(Availbility, "obsoletedVersion",
-                  serializeSemanticVersion(Avail.Obsoleted));
-  if (Avail.isUnavailable())
-    Availbility["isUnconditionallyUnavailable"] = true;
-  if (Avail.isUnconditionallyDeprecated())
-    Availbility["isUnconditionallyDeprecated"] = true;
+  Array AvailabilityArray;
 
-  return Availbility;
+  if (Availabilities.isUnconditionallyDeprecated()) {
+    Object UnconditionallyDeprecated;
+    UnconditionallyDeprecated["domain"] = "*";
+    UnconditionallyDeprecated["isUnconditionallyDeprecated"] = true;
+    AvailabilityArray.emplace_back(std::move(UnconditionallyDeprecated));
+  }
+
+  // Note unconditionally unavailable records are skipped.
+
+  for (const auto &AvailInfo : Availabilities) {
+    Object Availability;
+    Availability["domain"] = AvailInfo.Domain;
+    serializeObject(Availability, "introducedVersion",
+                    serializeSemanticVersion(AvailInfo.Introduced));
+    serializeObject(Availability, "deprecatedVersion",
+                    serializeSemanticVersion(AvailInfo.Deprecated));
+    serializeObject(Availability, "obsoletedVersion",
+                    serializeSemanticVersion(AvailInfo.Obsoleted));
+    AvailabilityArray.emplace_back(std::move(Availability));
+  }
+
+  return AvailabilityArray;
 }
 
 /// Get the language name string for interface language references.
@@ -464,7 +476,7 @@ Object SymbolGraphSerializer::serializeModule() const {
 
 bool SymbolGraphSerializer::shouldSkip(const APIRecord &Record) const {
   // Skip unconditionally unavailable symbols
-  if (Record.Availability.isUnconditionallyUnavailable())
+  if (Record.Availabilities.isUnconditionallyUnavailable())
     return true;
 
   // Filter out symbols prefixed with an underscored as they are understood to
@@ -489,8 +501,8 @@ SymbolGraphSerializer::serializeAPIRecord(const RecordTy &Record) const {
   serializeObject(
       Obj, "location",
       serializeSourceLocation(Record.Location, /*IncludeFileURI=*/true));
-  serializeObject(Obj, "availbility",
-                  serializeAvailability(Record.Availability));
+  serializeArray(Obj, "availability",
+                 serializeAvailability(Record.Availabilities));
   serializeObject(Obj, "docComment", serializeDocComment(Record.Comment));
   serializeArray(Obj, "declarationFragments",
                  serializeDeclarationFragments(Record.Declaration));

--- a/clang/test/ExtractAPI/availability.c
+++ b/clang/test/ExtractAPI/availability.c
@@ -1,0 +1,459 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s@INPUT_DIR@%{/t:regex_replacement}@g" \
+// RUN: %t/reference.output.json.in >> %t/reference.output.json
+// RUN: %clang_cc1 -extract-api --product-name=Availability -triple arm64-apple-macosx -x c-header %t/input.h -o %t/output.json -verify
+
+// Generator version is not consistent across test runs, normalize it.
+// RUN: sed -e "s@\"generator\": \".*\"@\"generator\": \"?\"@g" \
+// RUN: %t/output.json >> %t/output-normalized.json
+// RUN: diff %t/reference.output.json %t/output-normalized.json
+
+// CHECK-NOT: error:
+// CHECK-NOT: warning:
+
+//--- input.h
+void a(void);
+
+void b(void) __attribute__((availability(macos, introduced=12.0)));
+
+void c(void) __attribute__((availability(macos, introduced=11.0, deprecated=12.0, obsoleted=20.0)));
+
+void d(void) __attribute__((availability(macos, introduced=11.0, deprecated=12.0, obsoleted=20.0))) __attribute__((availability(ios, introduced=13.0)));
+
+void e(void) __attribute__((deprecated)) __attribute__((availability(macos, introduced=11.0)));
+
+void f(void) __attribute__((unavailable)) __attribute__((availability(macos, introduced=11.0)));
+
+void d(void) __attribute__((availability(tvos, introduced=15.0)));
+///expected-no-diagnostics
+
+//--- reference.output.json.in
+{
+  "metadata": {
+    "formatVersion": {
+      "major": 0,
+      "minor": 5,
+      "patch": 3
+    },
+    "generator": "?"
+  },
+  "module": {
+    "name": "Availability",
+    "platform": {
+      "architecture": "arm64",
+      "operatingSystem": {
+        "minimumVersion": {
+          "major": 11,
+          "minor": 0,
+          "patch": 0
+        },
+        "name": "macosx"
+      },
+      "vendor": "apple"
+    }
+  },
+  "relationships": [],
+  "symbols": [
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:v",
+          "spelling": "void"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "a"
+        },
+        {
+          "kind": "text",
+          "spelling": "()"
+        }
+      ],
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:v",
+            "spelling": "void"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "c",
+        "precise": "c:@F@a"
+      },
+      "kind": {
+        "displayName": "Function",
+        "identifier": "c.func"
+      },
+      "location": {
+        "position": {
+          "character": 6,
+          "line": 1
+        },
+        "uri": "file://INPUT_DIR/input.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "a"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "a"
+          }
+        ],
+        "title": "a"
+      },
+      "pathComponents": [
+        "a"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "availability": [
+        {
+          "domain": "macos",
+          "introducedVersion": {
+            "major": 12,
+            "minor": 0,
+            "patch": 0
+          }
+        }
+      ],
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:v",
+          "spelling": "void"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "b"
+        },
+        {
+          "kind": "text",
+          "spelling": "()"
+        }
+      ],
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:v",
+            "spelling": "void"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "c",
+        "precise": "c:@F@b"
+      },
+      "kind": {
+        "displayName": "Function",
+        "identifier": "c.func"
+      },
+      "location": {
+        "position": {
+          "character": 6,
+          "line": 3
+        },
+        "uri": "file://INPUT_DIR/input.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "b"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "b"
+          }
+        ],
+        "title": "b"
+      },
+      "pathComponents": [
+        "b"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "availability": [
+        {
+          "deprecatedVersion": {
+            "major": 12,
+            "minor": 0,
+            "patch": 0
+          },
+          "domain": "macos",
+          "introducedVersion": {
+            "major": 11,
+            "minor": 0,
+            "patch": 0
+          },
+          "obsoletedVersion": {
+            "major": 20,
+            "minor": 0,
+            "patch": 0
+          }
+        }
+      ],
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:v",
+          "spelling": "void"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "c"
+        },
+        {
+          "kind": "text",
+          "spelling": "()"
+        }
+      ],
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:v",
+            "spelling": "void"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "c",
+        "precise": "c:@F@c"
+      },
+      "kind": {
+        "displayName": "Function",
+        "identifier": "c.func"
+      },
+      "location": {
+        "position": {
+          "character": 6,
+          "line": 5
+        },
+        "uri": "file://INPUT_DIR/input.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "c"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "c"
+          }
+        ],
+        "title": "c"
+      },
+      "pathComponents": [
+        "c"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "availability": [
+        {
+          "deprecatedVersion": {
+            "major": 12,
+            "minor": 0,
+            "patch": 0
+          },
+          "domain": "macos",
+          "introducedVersion": {
+            "major": 11,
+            "minor": 0,
+            "patch": 0
+          },
+          "obsoletedVersion": {
+            "major": 20,
+            "minor": 0,
+            "patch": 0
+          }
+        },
+        {
+          "domain": "ios",
+          "introducedVersion": {
+            "major": 13,
+            "minor": 0,
+            "patch": 0
+          }
+        },
+        {
+          "domain": "tvos",
+          "introducedVersion": {
+            "major": 15,
+            "minor": 0,
+            "patch": 0
+          }
+        }
+      ],
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:v",
+          "spelling": "void"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "d"
+        },
+        {
+          "kind": "text",
+          "spelling": "()"
+        }
+      ],
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:v",
+            "spelling": "void"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "c",
+        "precise": "c:@F@d"
+      },
+      "kind": {
+        "displayName": "Function",
+        "identifier": "c.func"
+      },
+      "location": {
+        "position": {
+          "character": 6,
+          "line": 7
+        },
+        "uri": "file://INPUT_DIR/input.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "d"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "d"
+          }
+        ],
+        "title": "d"
+      },
+      "pathComponents": [
+        "d"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "availability": [
+        {
+          "domain": "*",
+          "isUnconditionallyDeprecated": true
+        },
+        {
+          "domain": "macos",
+          "introducedVersion": {
+            "major": 11,
+            "minor": 0,
+            "patch": 0
+          }
+        }
+      ],
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:v",
+          "spelling": "void"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "e"
+        },
+        {
+          "kind": "text",
+          "spelling": "()"
+        }
+      ],
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:v",
+            "spelling": "void"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "c",
+        "precise": "c:@F@e"
+      },
+      "kind": {
+        "displayName": "Function",
+        "identifier": "c.func"
+      },
+      "location": {
+        "position": {
+          "character": 6,
+          "line": 9
+        },
+        "uri": "file://INPUT_DIR/input.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "e"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "e"
+          }
+        ],
+        "title": "e"
+      },
+      "pathComponents": [
+        "e"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Currently ExtractAPI only emits availability information for the current platform. This makes it easy for clients to get all availability information for a given symbol in one invocation as opposed to having to invoke clang once per-platform and then merge the symbol-graphs.

Differential Revision: https://reviews.llvm.org/D130918

Cherry picked from 57c9780d60b15baf0eba4393857affce47f60aa7 in llvm.org/main