### PR TITLE
[next][clang-cache] Introduce `CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS` environment variable

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6569,6 +6569,11 @@ defm cache_compile_job : BoolFOption<"cache-compile-job",
                          " (for now) without -fcas-fs.">,
     NegFlag<SetFalse>>;
 
+defm cache_disable_replay : BoolFOption<"cache-disable-replay",
+    FrontendOpts<"DisableCachedCompileJobReplay">, DefaultFalse,
+    PosFlag<SetTrue, [], "Disable replaying a cached compile job">,
+    NegFlag<SetFalse>>;
+
 } // let Flags = [CC1Option, NoDriverOption]
 
 def sycl_std_EQ : Joined<["-"], "sycl-std=">, Group<sycl_Group>,

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -367,6 +367,10 @@ public:
   /// is specified.
   unsigned CacheCompileJob : 1;
 
+  /// Avoid checking if the compile job is already cached, force compilation and
+  /// caching of compilation outputs. This is used for testing purposes.
+  unsigned DisableCachedCompileJobReplay : 1;
+
   /// Output (and read) PCM files regardless of compiler errors.
   unsigned AllowPCMWithCompilerErrors : 1;
 
@@ -545,8 +549,8 @@ public:
         ASTDumpLookups(false), BuildingImplicitModule(false),
         BuildingImplicitModuleUsesLock(true), ModulesEmbedAllFiles(false),
         IncludeTimestamps(true), UseTemporary(true), CacheCompileJob(false),
-        AllowPCMWithCompilerErrors(false), ModulesShareFileManager(true),
-        TimeTraceGranularity(500) {}
+        DisableCachedCompileJobReplay(false), AllowPCMWithCompilerErrors(false),
+        ModulesShareFileManager(true), TimeTraceGranularity(500) {}
 
   /// getInputKindForExtension - Return the appropriate input kind for a file
   /// extension. For example, "c" would return Language::C.

--- a/clang/test/CAS/test-for-deterministic-outputs.c
+++ b/clang/test/CAS/test-for-deterministic-outputs.c
@@ -1,0 +1,10 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// This compiles twice with replay disabled, ensuring that we get the same outputs for the same key.
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS=1 %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache 2> %t/out.txt
+// RUN: FileCheck %s --check-prefix=CACHE-MISS --input-file=%t/out.txt
+
+// CACHE-MISS: remark: compile job cache miss
+// CACHE-MISS: remark: compile job cache miss


### PR DESCRIPTION
This is used for testing purposes. It instructs `clang-cache` to run the compilation twice, without replaying, to check that we get the same compilation artifacts for the same key. If they are not the same the action cache will trigger a fatal error.