### PR TITLE
[stable][clang-cache] Introduce `CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS` environment variable

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6382,6 +6382,11 @@ defm cache_compile_job : BoolFOption<"cache-compile-job",
                          " (for now) without -fcas-fs.">,
     NegFlag<SetFalse>>;
 
+defm cache_disable_replay : BoolFOption<"cache-disable-replay",
+    FrontendOpts<"DisableCachedCompileJobReplay">, DefaultFalse,
+    PosFlag<SetTrue, [], "Disable replaying a cached compile job">,
+    NegFlag<SetFalse>>;
+
 } // let Flags = [CC1Option, NoDriverOption]
 
 def sycl_std_EQ : Joined<["-"], "sycl-std=">, Group<sycl_Group>,

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -367,6 +367,10 @@ public:
   /// is specified.
   unsigned CacheCompileJob : 1;
 
+  /// Avoid checking if the compile job is already cached, force compilation and
+  /// caching of compilation outputs. This is used for testing purposes.
+  unsigned DisableCachedCompileJobReplay : 1;
+
   /// Output (and read) PCM files regardless of compiler errors.
   unsigned AllowPCMWithCompilerErrors : 1;
 
@@ -542,8 +546,8 @@ public:
         ASTDumpLookups(false), BuildingImplicitModule(false),
         BuildingImplicitModuleUsesLock(true), ModulesEmbedAllFiles(false),
         IncludeTimestamps(true), UseTemporary(true), CacheCompileJob(false),
-        AllowPCMWithCompilerErrors(false), ModulesShareFileManager(true),
-        TimeTraceGranularity(500) {}
+        DisableCachedCompileJobReplay(false), AllowPCMWithCompilerErrors(false),
+        ModulesShareFileManager(true), TimeTraceGranularity(500) {}
 
   /// getInputKindForExtension - Return the appropriate input kind for a file
   /// extension. For example, "c" would return Language::C.

--- a/clang/test/CAS/test-for-deterministic-outputs.c
+++ b/clang/test/CAS/test-for-deterministic-outputs.c
@@ -1,0 +1,10 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// This compiles twice with replay disabled, ensuring that we get the same outputs for the same key.
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS=1 %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache 2> %t/out.txt
+// RUN: FileCheck %s --check-prefix=CACHE-MISS --input-file=%t/out.txt
+
+// CACHE-MISS: remark: compile job cache miss
+// CACHE-MISS: remark: compile job cache miss

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -59,6 +59,23 @@ static bool shouldCacheInvocation(ArrayRef<const char *> Args,
   return true;
 }
 
+static int executeAsProcess(ArrayRef<const char *> Args,
+                            DiagnosticsEngine &Diags) {
+  SmallVector<StringRef, 128> RefArgs;
+  RefArgs.reserve(Args.size());
+  for (const char *Arg : Args) {
+    RefArgs.push_back(Arg);
+  }
+  std::string ErrMsg;
+  int Result = llvm::sys::ExecuteAndWait(RefArgs[0], RefArgs, /*Env*/ None,
+                                         /*Redirects*/ {}, /*SecondsToWait*/ 0,
+                                         /*MemoryLimit*/ 0, &ErrMsg);
+  if (!ErrMsg.empty()) {
+    Diags.Report(diag::err_clang_cache_failed_execution) << ErrMsg;
+  }
+  return Result;
+}
+
 Optional<int>
 clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
                                   llvm::StringSaver &Saver) {
@@ -153,6 +170,16 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
                    Saver.save(CacheArg.str()).data()});
     }
     Args.append({"-greproducible"});
+
+    if (llvm::sys::Process::GetEnv("CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS")) {
+      // Run the compilation twice, without replaying, to check that we get the
+      // same compilation artifacts for the same key. If they are not the same
+      // the action cache will trigger a fatal error.
+      Args.append({"-Xclang", "-fcache-disable-replay"});
+      int Result = executeAsProcess(Args, Diags);
+      if (Result != 0)
+        return Result;
+    }
     return None;
   }
 
@@ -164,17 +191,5 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
   Diags.Report(diag::warn_clang_cache_disabled_caching)
       << "clang-cache invokes a different clang binary than itself";
 
-  SmallVector<StringRef, 128> RefArgs;
-  RefArgs.reserve(Args.size());
-  for (const char *Arg : Args) {
-    RefArgs.push_back(Arg);
-  }
-  std::string ErrMsg;
-  int Result = llvm::sys::ExecuteAndWait(compilerPath, RefArgs, /*Env*/ None,
-                                         /*Redirects*/ {}, /*SecondsToWait*/ 0,
-                                         /*MemoryLimit*/ 0, &ErrMsg);
-  if (!ErrMsg.empty()) {
-    Diags.Report(diag::err_clang_cache_failed_execution) << ErrMsg;
-  }
-  return Result;
+  return executeAsProcess(Args, Diags);
 }

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -339,6 +339,7 @@ private:
   }
 
   bool CacheCompileJob = false;
+  bool DisableCachedCompileJobReplay = false;
 
   std::shared_ptr<llvm::cas::ObjectStore> CAS;
   std::shared_ptr<llvm::cas::ActionCache> Cache;
@@ -404,6 +405,8 @@ Optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
   // TODO: Canonicalize DiagnosticOptions here to be "serialized" only. Pass in
   // a hook to mirror diagnostics to stderr (when writing there), and handle
   // other outputs during replay.
+  DisableCachedCompileJobReplay = FrontendOpts.DisableCachedCompileJobReplay;
+  FrontendOpts.DisableCachedCompileJobReplay = false;
   FrontendOpts.IncludeTimestamps = false;
 
   CacheBackend = std::make_unique<ObjectStoreCachingOutputs>(Clang, CAS, Cache);
@@ -483,8 +486,6 @@ Expected<bool> ObjectStoreCachingOutputs::tryReplayCachedResult(
     assert(*Status == 0 && "Expected success status for a cache hit");
     return true;
   }
-  Diags.Report(diag::remark_compile_job_cache_miss)
-      << ResultCacheKey.toString();
   return false;
 }
 
@@ -500,12 +501,16 @@ Optional<int> CompileJobCache::tryReplayCachedResult(CompilerInstance &Clang) {
     return 1;
 
   Expected<bool> ReplayedResult =
-      CacheBackend->tryReplayCachedResult(*ResultCacheKey);
+      DisableCachedCompileJobReplay
+          ? false
+          : CacheBackend->tryReplayCachedResult(*ResultCacheKey);
   if (!ReplayedResult)
     return reportCachingBackendError(Clang.getDiagnostics(),
                                      ReplayedResult.takeError());
   if (*ReplayedResult)
     return 0;
+  Diags.Report(diag::remark_compile_job_cache_miss)
+      << ResultCacheKey->toString();
 
   if (CacheBackend->prepareOutputCollection())
     return 1;


### PR DESCRIPTION
This is used for testing purposes. It instructs `clang-cache` to run the compilation twice, without replaying, to check that we get the same compilation artifacts for the same key. If they are not the same the action cache will trigger a fatal error.

(cherry picked from commit 814a3feb586ab24e39e3bbecc10e30b051ba04e1)