### PR TITLE
[clang][cas] Fix double-computation of cache key

### DIFF
--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -403,6 +403,8 @@ Optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
   CompileJobCachingOptions CacheOpts;
   ResultCacheKey =
       canonicalizeAndCreateCacheKey(*CAS, Diags, Invocation, CacheOpts);
+  if (!ResultCacheKey)
+    return 1; // Exit with error!
 
   DisableCachedCompileJobReplay = CacheOpts.DisableCachedCompileJobReplay;
   bool UseCASBackend = Invocation.getCodeGenOpts().UseCASBackend;
@@ -503,10 +505,7 @@ Optional<int> CompileJobCache::tryReplayCachedResult(CompilerInstance &Clang) {
 
   DiagnosticsEngine &Diags = Clang.getDiagnostics();
 
-  // Create the result cache key once Invocation has been canonicalized.
-  ResultCacheKey = createCompileJobCacheKey(*CAS, Diags, Clang.getInvocation());
-  if (!ResultCacheKey)
-    return 1;
+  assert(ResultCacheKey.has_value() && "ResultCacheKey not initialized?");
 
   Expected<bool> ReplayedResult =
       DisableCachedCompileJobReplay


### PR DESCRIPTION
Remove duplicate calculation of cache key in cc1_main introduced by prevous commit.