### PR TITLE
[llvm][cas] Allow CachingOnDiskFileSystem tracked accesses to be nested

### DIFF
--- a/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
+++ b/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
@@ -38,10 +38,15 @@ public:
 
   /// Start tracking all stats (and other accesses). Only affects this
   /// filesystem instance, not current (or future) proxies.
+  ///
+  /// Calls to \c trackNewAccesses implicitly push a new tracking scope. They
+  /// should be paired with a call to \c createTreeFromNewAccesses, which pops
+  /// the current tracking scope. If there are multiple tracking scopes active,
+  /// accesses are only recorded in the currently active scope.
   virtual void trackNewAccesses() = 0;
 
   /// Create a tree that represents all stats tracked since the call to \a
-  /// trackNewAccesses(). Stops tracking new accesses.
+  /// trackNewAccesses(). Removes the current tracking scope.
   ///
   /// If provided, \p RemapPath is used to adjust paths in the created CAS
   /// tree.


### PR DESCRIPTION
Extend trackNewAccesses/createTreeFromNewAccesses to allow nesting - each tracking scope is pushed onto a stack so that accesses from the inner scope are independent of the outer scope.

This will be used in clang to support capturing a casfs for module inputs, where the current module's inputs are independent of the inputs of any other imported modules.

(cherry picked from commit fb141ee83433da6fbf5a323c114a17df21ee7e1d)