### PR TITLE
[CMake] Disable the new Swift Swift parser if we can't find its targets file

### DIFF
--- a/lldb/CMakeLists.txt
+++ b/lldb/CMakeLists.txt
@@ -45,8 +45,14 @@ endif()
 
 # When we have the early SwiftSyntax build, we can include its parser.
 if(SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR)
-  set(SWIFT_SWIFT_PARSER TRUE)
-  include(${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/cmake/SwiftSyntaxTargets.cmake)
+  set(SWIFT_PATH_TO_EARLYSWIFTSYNTAX_TARGETS
+    ${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/cmake/SwiftSyntaxTargets.cmake)
+  if(NOT EXISTS "${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_TARGETS}")
+    message(STATUS "Skipping Swift Swift parser integration due to missing early SwiftSyntax")
+  else()
+    set(SWIFT_SWIFT_PARSER TRUE)
+    include(${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_TARGETS})
+  endif()
 endif()
 # END - Swift Mods
 


### PR DESCRIPTION
This allows us to more gracefully degrade when a host Swift toolchain can't be found, and the early SwiftSyntax build is skipped as a result.