### PR TITLE
[clang][cas] Refactor destructive changes to CI for cache key

### DIFF
--- a/clang/include/clang/Frontend/CompileJobCacheKey.h
+++ b/clang/include/clang/Frontend/CompileJobCacheKey.h
@@ -29,10 +29,26 @@ namespace clang {
 class CompilerInvocation;
 class DiagnosticsEngine;
 
-/// Create a cache key for the given \c CompilerInvocation as a \c CASID.
+/// Caching-related options for a given \c CompilerInvocation that are
+/// canonicalized away by the cache key.  See \c canonicalizeAndCreateCacheKey.
+struct CompileJobCachingOptions {
+  /// See \c FrontendOptions::DisableCachedCompileJobReplay.
+  bool DisableCachedCompileJobReplay;
+};
+
+/// Create a cache key for the given \c CompilerInvocation as a \c CASID. If \p
+/// Invocation will later be used to compile code, use \c
+/// canonicalizeAndCreateCacheKey instead.
 llvm::Optional<llvm::cas::CASID>
 createCompileJobCacheKey(llvm::cas::ObjectStore &CAS, DiagnosticsEngine &Diags,
                          const CompilerInvocation &Invocation);
+
+/// Perform any destructive changes needed to canonicalize \p Invocation for
+/// caching, extracting the settings that affect compilation even if they do not
+/// affect caching, and return the resulting cache key as a \c CASID.
+llvm::Optional<llvm::cas::CASID> canonicalizeAndCreateCacheKey(
+    llvm::cas::ObjectStore &CAS, DiagnosticsEngine &Diags,
+    CompilerInvocation &Invocation, CompileJobCachingOptions &Opts);
 
 /// Print the structure of the cache key given by \p Key to \p OS. Returns an
 /// error if the key object does not exist in \p CAS, or is malformed.

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -377,22 +377,12 @@ Optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
   CompilerInvocation &Invocation = Clang.getInvocation();
   DiagnosticsEngine &Diags = Clang.getDiagnostics();
   FrontendOptions &FrontendOpts = Invocation.getFrontendOpts();
-
-  // Extract whether caching is on (and canonicalize setting).
   CacheCompileJob = FrontendOpts.CacheCompileJob;
-  FrontendOpts.CacheCompileJob = false;
 
   // Nothing else to do if we're not caching.
   if (!CacheCompileJob)
     return None;
 
-  // Hide the CAS configuration, canonicalizing it to keep the path to the
-  // CAS from leaking to the compile job, where it might affecting its
-  // output (e.g., in a diagnostic).
-  //
-  // TODO: Extract CASOptions.Path first if we need it later since it'll
-  // disappear here.
-  Invocation.getCASOpts().freezeConfig(Diags);
   CAS = Invocation.getCASOpts().getOrCreateObjectStore(Diags);
   if (!CAS)
     return 1; // Exit with error!
@@ -400,14 +390,11 @@ Optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
   if (!Cache)
     return 1; // Exit with error!
 
-  // Canonicalize Invocation and save things in a side channel.
-  //
-  // TODO: Canonicalize DiagnosticOptions here to be "serialized" only. Pass in
-  // a hook to mirror diagnostics to stderr (when writing there), and handle
-  // other outputs during replay.
-  DisableCachedCompileJobReplay = FrontendOpts.DisableCachedCompileJobReplay;
-  FrontendOpts.DisableCachedCompileJobReplay = false;
-  FrontendOpts.IncludeTimestamps = false;
+  CompileJobCachingOptions CacheOpts;
+  ResultCacheKey =
+      canonicalizeAndCreateCacheKey(*CAS, Diags, Invocation, CacheOpts);
+
+  DisableCachedCompileJobReplay = CacheOpts.DisableCachedCompileJobReplay;
 
   CacheBackend = std::make_unique<ObjectStoreCachingOutputs>(Clang, CAS, Cache);
   return None;

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -393,6 +393,8 @@ Optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
   CompileJobCachingOptions CacheOpts;
   ResultCacheKey =
       canonicalizeAndCreateCacheKey(*CAS, Diags, Invocation, CacheOpts);
+  if (!ResultCacheKey)
+    return 1; // Exit with error!
 
   DisableCachedCompileJobReplay = CacheOpts.DisableCachedCompileJobReplay;
 
@@ -482,10 +484,7 @@ Optional<int> CompileJobCache::tryReplayCachedResult(CompilerInstance &Clang) {
 
   DiagnosticsEngine &Diags = Clang.getDiagnostics();
 
-  // Create the result cache key once Invocation has been canonicalized.
-  ResultCacheKey = createCompileJobCacheKey(*CAS, Diags, Clang.getInvocation());
-  if (!ResultCacheKey)
-    return 1;
+  assert(ResultCacheKey.has_value() && "ResultCacheKey not initialized?");
 
   Expected<bool> ReplayedResult =
       DisableCachedCompileJobReplay


### PR DESCRIPTION
Cherry-pick https://github.com/apple/llvm-project/pull/5318 to stable/20220421

---

Centralize the CompilerInvocation changes done to canonicalize for
caching - we need all users of compile job cache keys to be in sync. In
particular, this enables a future change for caching modules to compute
correct keys.

Move the code that mutated the invocation out of cc1_main into a
function that shares implementation with creating a cache key. Any
options that we need to capture the value of are extracted explicitly.