### PR TITLE
[ConstraintElimination] Fix crash when combining results.

### DIFF
--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -264,29 +264,28 @@ decompose(Value *V, SmallVector<PreconditionTy, 4> &Preconditions,
     V = Op0;
   }
 
+  auto MergeResults = [&Preconditions, IsSigned](
+                          Value *A, Value *B,
+                          bool IsSignedB) -> SmallVector<DecompEntry, 4> {
+    auto ResA = decompose(A, Preconditions, IsSigned);
+    auto ResB = decompose(B, Preconditions, IsSignedB);
+    if (ResA.empty() || ResB.empty())
+      return {};
+    ResA[0].Coefficient += ResB[0].Coefficient;
+    append_range(ResA, drop_begin(ResB));
+    return ResA;
+  };
   Value *Op1;
   ConstantInt *CI;
-  if (match(V, m_NUWAdd(m_Value(Op0), m_ConstantInt(CI))) &&
-      !CI->uge(MaxConstraintValue)) {
-    auto Res = decompose(Op0, Preconditions, IsSigned);
-    Res[0].Coefficient += int(CI->getZExtValue());
-    return Res;
+  if (match(V, m_NUWAdd(m_Value(Op0), m_Value(Op1)))) {
+    return MergeResults(Op0, Op1, IsSigned);
   }
   if (match(V, m_Add(m_Value(Op0), m_ConstantInt(CI))) && CI->isNegative() &&
       CanUseSExt(CI)) {
     Preconditions.emplace_back(
         CmpInst::ICMP_UGE, Op0,
         ConstantInt::get(Op0->getType(), CI->getSExtValue() * -1));
-    auto Res = decompose(Op0, Preconditions, IsSigned);
-    Res[0].Coefficient += int(CI->getSExtValue());
-    return Res;
-  }
-  if (match(V, m_NUWAdd(m_Value(Op0), m_Value(Op1)))) {
-    auto Res = decompose(Op0, Preconditions, IsSigned);
-    auto D1 = decompose(Op1, Preconditions, IsSigned);
-    Res[0].Coefficient += D1[0].Coefficient;
-    append_range(Res, drop_begin(D1));
-    return Res;
+    return MergeResults(Op0, CI, true);
   }
 
   if (match(V, m_NUWSub(m_Value(Op0), m_ConstantInt(CI))) && CanUseSExt(CI))

--- a/llvm/test/Transforms/ConstraintElimination/large-constant-ints.ll
+++ b/llvm/test/Transforms/ConstraintElimination/large-constant-ints.ll
@@ -281,3 +281,25 @@ then:
 else:
   ret i1 false
 }
+
+define i1 @add_nuw_decomp_recursive() {
+; CHECK-LABEL: @add_nuw_decomp_recursive(
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i64 -9223372036854775808, 10
+; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i64 [[ADD]], 10
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %add = add nuw nsw i64 -9223372036854775808, 10
+  %cmp = icmp uge i64 %add, 10
+  ret i1 %cmp
+}
+
+define i1 @add_minus_one_decomp_recursive() {
+; CHECK-LABEL: @add_minus_one_decomp_recursive(
+; CHECK-NEXT:    [[ADD:%.*]] = add i64 -9223372036854775808, -1
+; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i64 [[ADD]], 10
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %add = add i64 -9223372036854775808, -1
+  %cmp = icmp uge i64 %add, 10
+  ret i1 %cmp
+}


### PR DESCRIPTION
f213128b292d didn't account for the possibility that the result of decompose may be empty. Fix that by explicitly checking. Use a newly introduced helper to also reduce some duplication.

Thanks @bjope for finding the issue!

(cherry-picked from 7914e53e312074828293356f569d190ac6eae3bd)