### PR TITLE
[cherry-pick][stable/20220421][clang] DeclContext::localUncachedLookup: Continue lookup into decl chain when regular lookup fails

### DIFF
--- a/clang/lib/AST/DeclBase.cpp
+++ b/clang/lib/AST/DeclBase.cpp
@@ -1761,7 +1761,8 @@ void DeclContext::localUncachedLookup(DeclarationName Name,
   if (!hasExternalVisibleStorage() && !hasExternalLexicalStorage() && Name) {
     lookup_result LookupResults = lookup(Name);
     Results.insert(Results.end(), LookupResults.begin(), LookupResults.end());
-    return;
+    if (!Results.empty())
+      return;
   }
 
   // If we have a lookup table, check there first. Maybe we'll get lucky.

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -4879,9 +4879,9 @@ TEST_P(ASTImporterLookupTableTest,
   FooDC->getRedeclContext()->localUncachedLookup(FooName, FoundDecls);
   EXPECT_EQ(FoundDecls.size(), 0u);
 
-  // Cannot find in the LookupTable of its LexicalDC (A).
+  // Finds via linear search of its LexicalDC (A).
   FooLexicalDC->getRedeclContext()->localUncachedLookup(FooName, FoundDecls);
-  EXPECT_EQ(FoundDecls.size(), 0u);
+  EXPECT_EQ(FoundDecls.size(), 1u);
 
   // Can't find in the list of Decls of the DC.
   EXPECT_EQ(findInDeclListOfDC(FooDC, FooName), nullptr);

--- a/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/Makefile
+++ b/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES   := main.cpp module1.cpp module2.cpp base_module.cpp
+
+include Makefile.rules

--- a/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/TestTemplateWithSameArg.py
+++ b/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/TestTemplateWithSameArg.py
@@ -34,7 +34,6 @@ class TestTemplateWithSameArg(TestBase):
         self.main_source_file = lldb.SBFileSpec("main.cpp")
 
     @add_test_categories(["gmodules"])
-    @skipIf(bugnumber='rdar://96581048')
     def test_same_template_arg(self):
         lldbutil.run_to_source_breakpoint(self, "Break here", self.main_source_file)
 
@@ -51,7 +50,6 @@ class TestTemplateWithSameArg(TestBase):
             ])
 
     @add_test_categories(["gmodules"])
-    @skipIf(bugnumber='rdar://96581048')
     def test_duplicate_decls(self):
         lldbutil.run_to_source_breakpoint(self, "Break here", self.main_source_file)
 

--- a/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/TestTemplateWithSameArg.py
+++ b/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/TestTemplateWithSameArg.py
@@ -1,0 +1,72 @@
+"""
+Tests the scenario where we evaluate expressions
+of two types in different modules that reference
+a class template instantiated with the same
+template argument.
+
+Note that,
+1. Since the decls originate from modules, LLDB
+   marks them as such and Clang doesn't create
+   a LookupPtr map on the corresponding DeclContext.
+   This prevents regular DeclContext::lookup from
+   succeeding.
+2. Because we reference the same class template
+   from two different modules we get a redeclaration
+   chain for the class's ClassTemplateSpecializationDecl.
+   The importer will import all FieldDecls into the
+   same DeclContext on the redeclaration chain. If
+   we don't do the bookkeeping correctly we end up
+   with duplicate decls on the same DeclContext leading
+   to crashes down the line.
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestTemplateWithSameArg(TestBase):
+
+    def setUp(self):
+        TestBase.setUp(self)
+        self.build()
+        self.main_source_file = lldb.SBFileSpec("main.cpp")
+
+    @add_test_categories(["gmodules"])
+    @skipIf(bugnumber='rdar://96581048')
+    def test_same_template_arg(self):
+        lldbutil.run_to_source_breakpoint(self, "Break here", self.main_source_file)
+
+        self.expect_expr("FromMod1", result_type="ClassInMod1", result_children=[
+                ValueCheck(name="VecInMod1", children=[
+                            ValueCheck(name="Member", value="137")
+                    ])
+            ])
+
+        self.expect_expr("FromMod2", result_type="ClassInMod2", result_children=[
+                ValueCheck(name="VecInMod2", children=[
+                            ValueCheck(name="Member", value="42")
+                    ])
+            ])
+
+    @add_test_categories(["gmodules"])
+    @skipIf(bugnumber='rdar://96581048')
+    def test_duplicate_decls(self):
+        lldbutil.run_to_source_breakpoint(self, "Break here", self.main_source_file)
+
+        self.expect_expr("(intptr_t)&FromMod1 + (intptr_t)&FromMod2")
+
+        # Make sure we only have a single 'Member' decl on the AST
+        self.filecheck("target module dump ast", __file__)
+# CHECK:      ClassTemplateSpecializationDecl {{.*}} imported in Module2 struct ClassInMod3 definition
+# CHECK-NEXT: |-DefinitionData pass_in_registers aggregate standard_layout trivially_copyable pod trivial
+# CHECK-NEXT: | |-DefaultConstructor exists trivial needs_implicit
+# CHECK-NEXT: | |-CopyConstructor simple trivial has_const_param needs_implicit implicit_has_const_param
+# CHECK-NEXT: | |-MoveConstructor exists simple trivial needs_implicit
+# CHECK-NEXT: | |-CopyAssignment simple trivial has_const_param needs_implicit implicit_has_const_param
+# CHECK-NEXT: | |-MoveAssignment exists simple trivial needs_implicit
+# CHECK-NEXT: | `-Destructor simple irrelevant trivial needs_implicit
+# CHECK-NEXT: |-TemplateArgument type 'int'
+# CHECK-NEXT: | `-BuiltinType {{.*}} 'int'
+# CHECK-NEXT: `-FieldDecl {{.*}} imported in Module2 Member 'int'

--- a/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/base_module.cpp
+++ b/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/base_module.cpp
@@ -1,0 +1,3 @@
+#include "base_module.h"
+
+namespace crash {} // namespace crash

--- a/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/base_module.h
+++ b/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/base_module.h
@@ -1,0 +1,6 @@
+#ifndef MOD3_H_IN
+#define MOD3_H_IN
+
+template <typename SIZE_T> struct ClassInMod3 { int Member = 0; };
+
+#endif // _H_IN

--- a/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/main.cpp
+++ b/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/main.cpp
@@ -1,0 +1,15 @@
+#include "module1.h"
+#include "module2.h"
+
+#include <cstdio>
+
+int main() {
+  ClassInMod1 FromMod1;
+  ClassInMod2 FromMod2;
+
+  FromMod1.VecInMod1.Member = 137;
+  FromMod2.VecInMod2.Member = 42;
+
+  std::puts("Break here");
+  return 0;
+}

--- a/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/module.modulemap
+++ b/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/module.modulemap
@@ -1,0 +1,14 @@
+module Module1 {
+  header "module1.h"
+  export *
+}
+
+module Module2 {
+  header "module2.h"
+  export *
+}
+
+module BaseModule {
+  header "base_module.h"
+  export *
+}

--- a/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/module1.cpp
+++ b/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/module1.cpp
@@ -1,0 +1,3 @@
+#include "module1.h"
+
+namespace crash {} // namespace crash

--- a/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/module1.h
+++ b/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/module1.h
@@ -1,0 +1,10 @@
+#ifndef MOD1_H_IN
+#define MOD1_H_IN
+
+#include "base_module.h"
+
+struct ClassInMod1 {
+  ClassInMod3<int> VecInMod1;
+};
+
+#endif // _H_IN

--- a/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/module2.cpp
+++ b/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/module2.cpp
@@ -1,0 +1,3 @@
+#include "module2.h"
+
+namespace crash {} // namespace crash

--- a/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/module2.h
+++ b/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/module2.h
@@ -1,0 +1,10 @@
+#ifndef MOD2_H_IN
+#define MOD2_H_IN
+
+#include "base_module.h"
+
+struct ClassInMod2 {
+  ClassInMod3<int> VecInMod2;
+};
+
+#endif


### PR DESCRIPTION
The uncached lookup is mainly used in the ASTImporter/LLDB code-path
where we're not allowed to load from external storage. When importing
a FieldDecl with a DeclContext that had no external visible storage
(but came from a Clang module or PCH) the above call to `lookup(Name)`
the regular `DeclContext::lookup` fails because:
1. `DeclContext::buildLookup` doesn't set `LookupPtr` for decls
   that came from a module
2. LLDB doesn't use the `SharedImporterState`

In such a case we would never continue with the "slow" path of iterating
through the decl chain on the DeclContext. In some cases this means that
ASTNodeImporter::VisitFieldDecl ends up importing a decl into the
DeclContext a second time.

The patch removes the short-circuit in the case where we don't find
any decls via the regular lookup.

**Tests**

* Un-skip the failing LLDB API tests

Differential Revision: https://reviews.llvm.org/D133945

(cherry picked from commit https://github.com/apple/llvm-project/commit/e456d2ba8bcadaa63386b339a4f2abcb39505502)