### PR TITLE
[test] [fuzzer] Enable tests for iossim, disable for ios (update2)

### DIFF
--- a/compiler-rt/test/fuzzer/cross_over.test
+++ b/compiler-rt/test/fuzzer/cross_over.test
@@ -1,3 +1,5 @@
+# For IOS, we fail to permute the run lines properly (rdar://99889376)
+XFAIL: ios && !iossim
 # Tests CrossOverTest.
 # We want to make sure that the test can find the input
 # ABCDEFGHIJ when given two other inputs in the seed corpus:

--- a/compiler-rt/test/fuzzer/merge-control-file.test
+++ b/compiler-rt/test/fuzzer/merge-control-file.test
@@ -1,4 +1,5 @@
-XFAIL: ios
+# For IOS, we fail to permute the run lines properly (rdar://99889376)
+XFAIL: ios && !iossim
 RUN: mkdir -p %t
 # Use a ".exe" extension because it is needed on Windows to call system()
 # to execute itself again.


### PR DESCRIPTION
The fuzzer tests cross_over.test and merge-control-file.test are not handled correctly on ios device testing. On-device testing requires the macros %t, %s, etc. to be expanded for a different default directory than when testing on host.

rdar://99889376

Differential Revision: https://reviews.llvm.org/D133811

(cherry picked from commit 17dde371e773d0409cd010ade1f3f3376973d16c)