### PR TITLE
[clang][cas] Add cc1 option -fmodule-file-cache-key=

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -27,6 +27,8 @@ def err_cas_depscan_daemon_connection: Error<
 def err_cas_depscan_failed: Error<
   "CAS-based dependency scan failed: %0">, DefaultFatal;
 def err_cas_store: Error<"failed to store to CAS: %0">, DefaultFatal;
+def err_cas_cannot_get_module_cache_key : Error<
+  "CAS cannot load module with key '%0' from %1: %2">, DefaultFatal;
 
 def warn_clang_cache_disabled_caching: Warning<
   "caching disabled because %0">,

--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -316,6 +316,9 @@ def warn_alias_with_section : Warning<
   "as the %select{aliasee|resolver}2">,
   InGroup<IgnoredAttributes>;
 
+def err_module_cache_key_spelling : Error<
+  "option '-fmodule-file-cache-key' should be of the form <path>=<key>">;
+
 let CategoryName = "Instrumentation Issue" in {
 def warn_profile_data_out_of_date : Warning<
   "profile data may be out of date: of %0 function%s0, %1 %plural{1:has|:have}1"

--- a/clang/include/clang/Basic/LLVM.h
+++ b/clang/include/clang/Basic/LLVM.h
@@ -53,6 +53,7 @@ namespace llvm {
   // TODO: DenseMap, ...
 
   namespace cas {
+  class ActionCache;
   class ObjectStore;
   class CASID;
   class ObjectProxy;
@@ -99,6 +100,7 @@ namespace clang {
   using llvm::raw_pwrite_stream;
 
   namespace cas {
+  using llvm::cas::ActionCache;
   using llvm::cas::CASID;
   using llvm::cas::ObjectProxy;
   using llvm::cas::ObjectRef;

--- a/clang/include/clang/Basic/Module.h
+++ b/clang/include/clang/Basic/Module.h
@@ -187,6 +187,9 @@ private:
   /// corresponding serialized AST file, or null otherwise.
   Optional<FileEntryRef> ASTFile;
 
+  /// The \c ActionCache key for this module, if any.
+  Optional<std::string> ModuleCacheKey;
+
   /// The top-level headers associated with this module.
   llvm::SmallSetVector<const FileEntry *, 2> TopHeaders;
 
@@ -617,6 +620,15 @@ public:
     assert((!File || !getASTFile() || getASTFile() == File) &&
            "file path changed");
     getTopLevelModule()->ASTFile = File;
+  }
+
+  Optional<std::string> getModuleCacheKey() const {
+    return getTopLevelModule()->ModuleCacheKey;
+  }
+
+  void setModuleCacheKey(std::string Key) {
+    assert(!getModuleCacheKey() || *getModuleCacheKey() == Key);
+    getTopLevelModule()->ModuleCacheKey = std::move(Key);
   }
 
   /// Retrieve the directory for which this module serves as the

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5896,6 +5896,12 @@ def ftest_module_file_extension_EQ :
   Joined<["-"], "ftest-module-file-extension=">,
   HelpText<"introduce a module file extension for testing purposes. "
            "The argument is parsed as blockname:major:minor:hashed:user info">;
+def fmodule_file_cache_key : Joined<["-"], "fmodule-file-cache-key=">,
+  MetaVarName<"<path>=<key>">,
+  HelpText<"Make the module with the given compile job cache key available as "
+           "if it were at <path>. This option may be combined with "
+           "-fmodule-file= to import the module. The module must have "
+           "previously been built with -fcache-compile-job.">;
 def fconcepts_ts : Flag<["-"], "fconcepts-ts">,
   HelpText<"Enable C++ Extensions for Concepts. (deprecated - use -std=c++2a)">;
 

--- a/clang/include/clang/Frontend/CompileJobCacheResult.h
+++ b/clang/include/clang/Frontend/CompileJobCacheResult.h
@@ -49,6 +49,9 @@ public:
 
   size_t getNumOutputs() const;
 
+  /// Retrieves a specific output specified by \p Kind, if it exists.
+  Optional<Output> getOutput(OutputKind Kind) const;
+
   /// Print this result to \p OS.
   llvm::Error print(llvm::raw_ostream &OS);
 

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -512,6 +512,10 @@ public:
   /// The list of AST files to merge.
   std::vector<std::string> ASTMergeFiles;
 
+  /// The list of prebuilt module file paths to make available by reading their
+  /// contents from the \c ActionCache with the given compile job cache key.
+  std::vector<std::pair<std::string, std::string>> ModuleCacheKeys;
+
   /// A list of arguments to forward to LLVM's option processing; this
   /// should only be used for debugging and experimental features.
   std::vector<std::string> LLVMArgs;

--- a/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/clang/include/clang/Serialization/ASTBitCodes.h
@@ -41,7 +41,7 @@ namespace serialization {
 /// Version 4 of AST files also requires that the version control branch and
 /// revision match exactly, since there is no backward compatibility of
 /// AST files at this time.
-const unsigned VERSION_MAJOR = 22;
+const unsigned VERSION_MAJOR = 23;
 
 /// AST file minor version number supported by this version of
 /// Clang.
@@ -360,6 +360,9 @@ enum ControlRecordTypes {
 
   /// Record code for the module build directory.
   MODULE_DIRECTORY,
+
+  /// Record code for the (optional) \c ActionCache  key for this module.
+  MODULE_CACHE_KEY,
 };
 
 /// Record types that occur within the options block inside

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -221,6 +221,14 @@ public:
   /// AST file imported by this AST file.
   virtual void visitImport(StringRef ModuleName, StringRef Filename) {}
 
+  /// Called for each module cache key.
+  ///
+  /// \returns true to indicate the key cannot be loaded.
+  virtual bool readModuleCacheKey(StringRef ModuleName, StringRef Filename,
+                                  StringRef CacheKey) {
+    return false;
+  }
+
   /// Indicates that a particular module file extension has been read.
   virtual void readModuleFileExtension(
                  const ModuleFileExtensionMetadata &Metadata) {}
@@ -266,6 +274,8 @@ public:
                        serialization::ModuleKind Kind) override;
   bool visitInputFile(StringRef Filename, bool isSystem,
                       bool isOverridden, bool isExplicitModule) override;
+  bool readModuleCacheKey(StringRef ModuleName, StringRef Filename,
+                          StringRef CacheKey) override;
   void readModuleFileExtension(
          const ModuleFileExtensionMetadata &Metadata) override;
 };

--- a/clang/include/clang/Serialization/ModuleFile.h
+++ b/clang/include/clang/Serialization/ModuleFile.h
@@ -125,6 +125,9 @@ public:
   /// The file name of the module file.
   std::string FileName;
 
+  /// The \c ActionCache key for this module, or empty.
+  std::string ModuleCacheKey;
+
   /// The name of the module.
   std::string ModuleName;
 

--- a/clang/lib/Frontend/CompileJobCacheResult.cpp
+++ b/clang/lib/Frontend/CompileJobCacheResult.cpp
@@ -34,6 +34,17 @@ Error CompileJobCacheResult::forEachOutput(
   return Error::success();
 }
 
+Optional<CompileJobCacheResult::Output>
+CompileJobCacheResult::getOutput(OutputKind Kind) const {
+  size_t Count = getNumOutputs();
+  for (size_t I = 0; I < Count; ++I) {
+    OutputKind K = getOutputKind(I);
+    if (Kind == K)
+      return Output{getOutputObject(I), Kind};
+  }
+  return None;
+}
+
 static void printOutputKind(llvm::raw_ostream &OS,
                             CompileJobCacheResult::OutputKind Kind) {
   switch (Kind) {

--- a/clang/lib/Serialization/GlobalModuleIndex.cpp
+++ b/clang/lib/Serialization/GlobalModuleIndex.cpp
@@ -658,6 +658,9 @@ llvm::Error GlobalModuleIndexBuilder::loadModuleFile(const FileEntry *File) {
                                       Record.begin() + Idx + Length);
         Idx += Length;
 
+        // Skip the module cache key.
+        Idx += Record[Idx] + 1;
+
         // Find the imported module file.
         auto DependsOnFile
           = FileMgr.getFile(ImportedFile, /*OpenFile=*/false,

--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -471,6 +471,16 @@ bool ModuleManager::lookupModuleFile(StringRef FileName, off_t ExpectedSize,
     FileOrErr = FileMgr.getBypassFile(*FileOrErr);
   }
 #endif
+
+  // If the file is known to the module cache but not in the filesystem, it is
+  // a memory buffer. Create a virtual file for it.
+  if (!FileOrErr) {
+    if (auto *KnownBuffer = getModuleCache().lookupPCM(FileName)) {
+      FileOrErr =
+          FileMgr.getVirtualFileRef(FileName, KnownBuffer->getBufferSize(), 0);
+    }
+  }
+
   if (!FileOrErr)
     return false;
 

--- a/clang/test/CAS/fmodule-file-cache-key-errors.c
+++ b/clang/test/CAS/fmodule-file-cache-key-errors.c
@@ -1,0 +1,54 @@
+// Checks error conditions related to -fmodule-file-cache-key, e.g. missing
+// cache entry, invalid id, etc.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+
+// RUN: not %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   -fmodule-file-cache-key=INVALID \
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/invalid.txt
+// RUN: cat %t/invalid.txt | FileCheck %s -check-prefix=INVALID
+
+// INVALID: error: option '-fmodule-file-cache-key' should be of the form <path>=<key>
+
+// RUN: not %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   -fmodule-file-cache-key=PATH=KEY \
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/bad_key.txt
+// RUN: cat %t/bad_key.txt | FileCheck %s -check-prefix=BAD_KEY
+
+// BAD_KEY: error: CAS cannot load module with key 'KEY' from -fmodule-file-cache-key: invalid cas-id 'KEY'
+
+// RUN: echo -n '-fmodule-file-cache-key=PATH=' > %t/not_in_cache.rsp
+// RUN: cat %t/casid >> %t/not_in_cache.rsp
+
+// RUN: not %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   @%t/not_in_cache.rsp \
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/not_in_cache.txt
+// RUN: cat %t/not_in_cache.txt | FileCheck %s -check-prefix=NOT_IN_CACHE
+
+// NOT_IN_CACHE: error: CAS cannot load module with key '{{.*}}' from -fmodule-file-cache-key: no such entry in action cache
+
+//--- module.modulemap
+module A { header "A.h" }
+
+//--- A.h
+void A(void);
+
+//--- tu.c
+#include "A.h"
+void tu(void) {
+  A();
+}

--- a/clang/test/CAS/fmodule-file-cache-key-lazy.c
+++ b/clang/test/CAS/fmodule-file-cache-key-lazy.c
@@ -1,0 +1,77 @@
+// Tests for combining -fmodule-file-cache-key with lazy-loading modules via
+// -fmodule-file=<NAME>=<PATH>.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+
+// == Build B
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=B -fno-implicit-modules \
+// RUN:   -emit-module %t/module.modulemap -o %t/B.pcm \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.txt
+// RUN: cat %t/B.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: cat %t/B.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/B.key
+
+// == Build A, importing B
+
+// RUN: echo -n '-fmodule-file-cache-key=%t/B.pcm=' > %t/B.import.rsp
+// RUN: cat %t/B.key >> %t/B.import.rsp
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
+// RUN:   @%t/B.import.rsp -fmodule-file=B=%t/B.pcm \
+// RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
+// RUN: cat %t/A.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: cat %t/A.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/A.key
+
+// == Build tu, importing A (implicitly importing B)
+
+// RUN: echo -n '-fmodule-file-cache-key=%t/A.pcm=' > %t/A.import.rsp
+// RUN: cat %t/A.key >> %t/A.import.rsp
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   @%t/A.import.rsp -fmodule-file=A=%t/A.pcm \
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.txt
+// RUN: cat %t/tu.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+
+// == Ensure we're reading pcm from cache
+
+// RUN: rm %t/*.pcm
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   @%t/A.import.rsp -fmodule-file=A=%t/A.pcm \
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.2.txt
+// RUN: cat %t/tu.out.2.txt | FileCheck %s --check-prefix=CACHE-HIT
+
+// CACHE-HIT: remark: compile job cache hit
+// CACHE-MISS: remark: compile job cache miss
+
+//--- module.modulemap
+module A { header "A.h" export * }
+module B { header "B.h" }
+
+//--- A.h
+#include "B.h"
+
+//--- B.h
+void B(void);
+
+//--- tu.c
+#include "A.h"
+void tu(void) {
+  B();
+}

--- a/clang/test/CAS/fmodule-file-cache-key-with-pch.c
+++ b/clang/test/CAS/fmodule-file-cache-key-with-pch.c
@@ -1,0 +1,114 @@
+// Check that -fmodule-file-cache-key works with mixed PCH+modules builds.
+// This test mimics the way the dep scanner handles PCH (ie. treat it as a file
+// input, ingested into the cas fs).
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+
+// == Build B
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=B -fno-implicit-modules \
+// RUN:   -emit-module %t/module.modulemap -o %t/B.pcm \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.txt
+// RUN: cat %t/B.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: cat %t/B.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/B.key
+
+// == Build A, importing B
+
+// RUN: echo -n '-fmodule-file-cache-key=%t/B.pcm=' > %t/B.import.rsp
+// RUN: cat %t/B.key >> %t/B.import.rsp
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
+// RUN:   @%t/B.import.rsp -fmodule-file=%t/B.pcm \
+// RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
+// RUN: cat %t/A.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: cat %t/A.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/A.key
+
+// == Build C, importing B
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=C -fno-implicit-modules \
+// RUN:   @%t/B.import.rsp -fmodule-file=%t/B.pcm \
+// RUN:   -emit-module %t/module.modulemap -o %t/C.pcm \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/C.out.txt
+// RUN: cat %t/C.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: cat %t/C.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/C.key
+
+// == Build PCH, importing A (implicitly importing B)
+
+// RUN: echo -n '-fmodule-file-cache-key=%t/A.pcm=' > %t/A.import.rsp
+// RUN: cat %t/A.key >> %t/A.import.rsp
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   @%t/A.import.rsp -fmodule-file=%t/A.pcm \
+// RUN:   -emit-pch -x c-header %t/prefix.h -o %t/prefix.pch \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/prefix.out.txt
+// RUN: cat %t/prefix.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+
+// == Clear pcms to ensure they load from cache, and re-ingest with pch
+
+// RUN: rm %t/*.pcm
+// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+// RUN: rm %t/*.pch
+
+// == Build tu
+
+// RUN: echo -n '-fmodule-file-cache-key=%t/C.pcm=' > %t/C.import.rsp
+// RUN: cat %t/C.key >> %t/C.import.rsp
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   @%t/C.import.rsp -fmodule-file=%t/C.pcm -include-pch %t/prefix.pch \
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.txt
+// RUN: cat %t/tu.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+
+// == Ensure we're reading pcm from cache
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   @%t/C.import.rsp -fmodule-file=%t/C.pcm -include-pch %t/prefix.pch \
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.2.txt
+// RUN: cat %t/tu.out.2.txt | FileCheck %s --check-prefix=CACHE-HIT
+
+// CACHE-HIT: remark: compile job cache hit
+// CACHE-MISS: remark: compile job cache miss
+
+//--- module.modulemap
+module A { header "A.h" export * }
+module B { header "B.h" }
+module C { header "C.h" export * }
+
+//--- A.h
+#include "B.h"
+
+//--- B.h
+void B(void);
+
+//--- C.h
+#include "B.h"
+void B(void);
+
+//--- prefix.h
+#include "A.h"
+
+//--- tu.c
+#include "C.h"
+void tu(void) {
+  B();
+}

--- a/clang/test/CAS/fmodule-file-cache-key-with-pch.c
+++ b/clang/test/CAS/fmodule-file-cache-key-with-pch.c
@@ -13,6 +13,7 @@
 
 // RUN: %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fmodule-name=B -fno-implicit-modules \
+// RUN:   -fmodule-related-to-pch \
 // RUN:   -emit-module %t/module.modulemap -o %t/B.pcm \
 // RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.txt
@@ -26,6 +27,7 @@
 
 // RUN: %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
+// RUN:   -fmodule-related-to-pch \
 // RUN:   @%t/B.import.rsp -fmodule-file=%t/B.pcm \
 // RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
 // RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
@@ -37,6 +39,7 @@
 
 // RUN: %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fmodule-name=C -fno-implicit-modules \
+// RUN:   -fmodule-related-to-pch \
 // RUN:   @%t/B.import.rsp -fmodule-file=%t/B.pcm \
 // RUN:   -emit-module %t/module.modulemap -o %t/C.pcm \
 // RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \

--- a/clang/test/CAS/fmodule-file-cache-key.c
+++ b/clang/test/CAS/fmodule-file-cache-key.c
@@ -1,0 +1,77 @@
+// Tests for providing the contents of pcm files via -fmodule-file-cache-key and
+// previously cached module compilations.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+
+// == Build B
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=B -fno-implicit-modules \
+// RUN:   -emit-module %t/module.modulemap -o %t/B.pcm \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.txt
+// RUN: cat %t/B.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: cat %t/B.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/B.key
+
+// == Build A, importing B
+
+// RUN: echo -n '-fmodule-file-cache-key=%t/B.pcm=' > %t/B.import.rsp
+// RUN: cat %t/B.key >> %t/B.import.rsp
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
+// RUN:   @%t/B.import.rsp -fmodule-file=%t/B.pcm \
+// RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
+// RUN: cat %t/A.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: cat %t/A.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/A.key
+
+// == Build tu, importing A (implicitly importing B)
+
+// RUN: echo -n '-fmodule-file-cache-key=%t/A.pcm=' > %t/A.import.rsp
+// RUN: cat %t/A.key >> %t/A.import.rsp
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   @%t/A.import.rsp -fmodule-file=%t/A.pcm\
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.txt
+// RUN: cat %t/tu.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+
+// == Ensure we're reading pcm from cache
+
+// RUN: rm %t/*.pcm
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   @%t/A.import.rsp -fmodule-file=%t/A.pcm\
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.2.txt
+// RUN: cat %t/tu.out.2.txt | FileCheck %s --check-prefix=CACHE-HIT
+
+// CACHE-HIT: remark: compile job cache hit
+// CACHE-MISS: remark: compile job cache miss
+
+//--- module.modulemap
+module A { header "A.h" export * }
+module B { header "B.h" }
+
+//--- A.h
+#include "B.h"
+
+//--- B.h
+void B(void);
+
+//--- tu.c
+#include "A.h"
+void tu(void) {
+  B();
+}

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -485,6 +485,8 @@ Optional<int> CompileJobCache::tryReplayCachedResult(CompilerInstance &Clang) {
 
   assert(ResultCacheKey.has_value() && "ResultCacheKey not initialized?");
 
+  Clang.setCompileJobCacheKey(*ResultCacheKey);
+
   Expected<bool> ReplayedResult =
       DisableCachedCompileJobReplay
           ? false


### PR DESCRIPTION
Cherry-pick https://github.com/apple/llvm-project/pull/5270 to next

---

This option provides a way to read modules that were built using `-fcache-compile-job` by looking them up in the action cache. This will be used as a building block for adding compile-job caching support to explicit modules builds. A future change will teach the dep scanner to produce invocations that build modules with caching enabled, and load them using the action cache.

The option takes a string of the form `<path>=<key>`, and reads a compile-job cache result for `<key>` from the action cache. The contents of the previously built pcm are made available as if they were at `<path>`. The path is significant for -gmodules builds, which embed the path for debug info. Otherwise, the path must at least be unique. The intention is that we will eventually canonicalize this path when building with prefix mappings.

The `-fmodule-file-cache-key=` option is currently designed to be combined with the existing `-fmodule-file=` option -- the cache key makes the module file available, while `-fmodule-file=` controls when it is imported (eagerly or lazily).