### PR TITLE
[next] Fix deprecation warnings from Optional

### DIFF
--- a/clang/lib/APINotes/APINotesWriter.cpp
+++ b/clang/lib/APINotes/APINotesWriter.cpp
@@ -590,11 +590,11 @@ namespace {
 
       uint8_t payload = 0;
       if (auto swiftImportAsNonGeneric = info.getSwiftImportAsNonGeneric()) {
-        payload |= (0x01 << 1) | swiftImportAsNonGeneric.getValue();
+        payload |= (0x01 << 1) | *swiftImportAsNonGeneric;
       }
       payload <<= 2;
       if (auto swiftObjCMembers = info.getSwiftObjCMembers()) {
-        payload |= (0x01 << 1) | swiftObjCMembers.getValue();
+        payload |= (0x01 << 1) | *swiftObjCMembers;
       }
       payload <<= 3;
       if (auto nullable = info.getDefaultNullability()) {
@@ -631,7 +631,7 @@ namespace {
       uint8_t flags = 0;
       if (Optional<bool> value = info.getSwiftImportAsAccessors()) {
         flags |= 1 << 0;
-        flags |= value.getValue() << 1;
+        flags |= *value << 1;
       }
       out << flags;
     }
@@ -725,7 +725,7 @@ namespace {
     }
     payload <<= 3;
     if (auto retainCountConvention = info.getRetainCountConvention()) {
-      payload |= static_cast<uint8_t>(retainCountConvention.getValue()) + 1;
+      payload |= static_cast<uint8_t>(*retainCountConvention) + 1;
     }
     writer.write<uint8_t>(payload);
   }
@@ -752,7 +752,7 @@ namespace {
     payload |= info.NullabilityAudited;
     payload <<= 3;
     if (auto retainCountConvention = info.getRetainCountConvention()) {
-      payload |= static_cast<uint8_t>(retainCountConvention.getValue()) + 1;
+      payload |= static_cast<uint8_t>(*retainCountConvention) + 1;
     }
     writer.write<uint8_t>(payload);
 
@@ -1084,14 +1084,14 @@ namespace {
 
       uint8_t payload = 0;
       if (auto enumExtensibility = info.EnumExtensibility) {
-        payload |= static_cast<uint8_t>(enumExtensibility.getValue()) + 1;
+        payload |= static_cast<uint8_t>(*enumExtensibility) + 1;
         assert((payload < (1 << 2)) && "must fit in two bits");
       }
 
       payload <<= 2;
       if (Optional<bool> value = info.isFlagEnum()) {
         payload |= 1 << 0;
-        payload |= value.getValue() << 1;
+        payload |= *value << 1;
       }
 
       writer.write<uint8_t>(payload);

--- a/clang/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/clang/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -1075,7 +1075,7 @@ namespace {
                 t.Name + ")");
             continue;
           }
-          switch (t.EnumConvenienceKind.getValue()) {
+          switch (*t.EnumConvenienceKind) {
           case EnumConvenienceAliasKind::None:
             tagInfo.EnumExtensibility = EnumExtensibilityKind::None;
             tagInfo.setFlagEnum(false);

--- a/clang/lib/Index/IndexUnitWriter.cpp
+++ b/clang/lib/Index/IndexUnitWriter.cpp
@@ -251,7 +251,7 @@ Optional<bool> IndexUnitWriter::isUnitUpToDateForOutputFile(StringRef FilePath,
     return false;
   }
 
-  if (!TimeCompareFilePath.hasValue())
+  if (!TimeCompareFilePath)
     return true;
 
   llvm::sys::fs::file_status CompareStat;

--- a/clang/lib/Index/IndexingAction.cpp
+++ b/clang/lib/Index/IndexingAction.cpp
@@ -995,7 +995,7 @@ static bool produceIndexDataForModuleFile(serialization::ModuleFile &Mod,
   // get rebuilt along with their index data).
   auto IsUptodateOpt =
       ParentUnitWriter.isUnitUpToDateForOutputFile(Mod.FileName, None, Error);
-  if (!IsUptodateOpt.hasValue()) {
+  if (!IsUptodateOpt) {
     unsigned DiagID = Diag.getCustomDiagID(DiagnosticsEngine::Error,
                                            "failed file status check: %0");
     Diag.Report(DiagID) << Error;

--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -235,7 +235,7 @@ static void handleAPINotedRetainCountConvention(
     Optional<api_notes::RetainCountConventionKind> convention) {
   if (!convention)
     return;
-  switch (convention.getValue()) {
+  switch (*convention) {
   case api_notes::RetainCountConventionKind::None:
     if (isa<FunctionDecl>(D)) {
       handleAPINotedRetainCountAttribute<CFUnknownTransferAttr>(
@@ -644,7 +644,7 @@ static void ProcessAPINotes(Sema &S, TagDecl *D,
     handleAPINotedAttribute<EnumExtensibilityAttr>(S, D, shouldAddAttribute,
                                                    metadata, [&] {
       EnumExtensibilityAttr::Kind kind;
-      switch (extensibility.getValue()) {
+      switch (*extensibility) {
       case EnumExtensibilityKind::None:
         llvm_unreachable("remove only");
       case EnumExtensibilityKind::Open:
@@ -661,7 +661,7 @@ static void ProcessAPINotes(Sema &S, TagDecl *D,
   }
 
   if (auto flagEnum = info.isFlagEnum()) {
-    handleAPINotedAttribute<FlagEnumAttr>(S, D, flagEnum.getValue(), metadata,
+    handleAPINotedAttribute<FlagEnumAttr>(S, D, *flagEnum, metadata,
                                           [&] {
       return new (S.Context) FlagEnumAttr(S.Context, getDummyAttrInfo());
     });
@@ -798,7 +798,7 @@ static void ProcessVersionedAPINotes(
 
   maybeAttachUnversionedSwiftName(S, D, Info);
 
-  unsigned Selected = Info.getSelected().getValueOr(Info.size());
+  unsigned Selected = Info.getSelected().value_or(Info.size());
 
   VersionTuple Version;
   SpecificInfo InfoSlice;

--- a/clang/lib/Tooling/Refactor/RenamingOperation.cpp
+++ b/clang/lib/Tooling/Refactor/RenamingOperation.cpp
@@ -57,7 +57,7 @@ bool isNewNameValid(const OldSymbolName &NewName,
                     const LangOptions &LangOpts) {
   assert(!Operation.symbols().empty());
   return isNewNameValid(NewName,
-                        Operation.symbols().front().ObjCSelector.hasValue(),
+                        Operation.symbols().front().ObjCSelector.has_value(),
                         IDs, LangOpts);
 }
 

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -484,7 +484,7 @@ static int printStoreFileRecord(StringRef storePath, StringRef filePath,
     return 1;
   }
 
-  if (!lineStart.hasValue())
+  if (!lineStart)
     return printStoreRecord(store, recName, filePath, OS);
 
   indexstore::IndexRecordReader Reader(store, recName, error);
@@ -1001,7 +1001,7 @@ bool deconstructPathAndRange(StringRef input,
     errs() << "couldn't convert to integer: " << end << '\n';
     return true;
   }
-  lineCount = num-lineStart.getValue();
+  lineCount = num - *lineStart;
   return false;
 }
 

--- a/llvm/lib/IR/GlobalPtrAuthInfo.cpp
+++ b/llvm/lib/IR/GlobalPtrAuthInfo.cpp
@@ -146,7 +146,7 @@ Constant *GlobalPtrAuthInfo::create(Module &M, Constant *Pointer,
 
   auto Result = ConstantExpr::getBitCast(GV, Pointer->getType());
 
-  assert(analyze(Result).hasValue() && "invalid ptrauth constant");
+  assert(analyze(Result).has_value() && "invalid ptrauth constant");
 
   return Result;
 }

--- a/llvm/unittests/CAS/TreeSchemaTest.cpp
+++ b/llvm/unittests/CAS/TreeSchemaTest.cpp
@@ -262,7 +262,7 @@ TEST(TreeSchemaTest, walkFileTreeRecursively) {
         auto ExpectedEntry = RemainingEntries.front();
         RemainingEntries = RemainingEntries.drop_front();
         EXPECT_EQ(ExpectedEntry.first, Entry.getName());
-        EXPECT_EQ(ExpectedEntry.second, Tree.hasValue());
+        EXPECT_EQ(ExpectedEntry.second, Tree.has_value());
         return Error::success();
       });
   EXPECT_THAT_ERROR(std::move(E), Succeeded());


### PR DESCRIPTION
Optional::{hasValue(),getValue(),getValueOr()} are deprecated and all upstream uses have been updated to (operator*, operator->, operator bool, value(), has_value(), or value_or()). This commit updates the code on "next" branch so we stop getting hundreds of deprecation warnings.