### PR TITLE
[clang-cache] Introduce `CLANG_CACHE_REDACT_TIME_MACROS` environment variable

### DIFF
--- a/clang/test/CAS/test-for-deterministic-outputs.c
+++ b/clang/test/CAS/test-for-deterministic-outputs.c
@@ -2,9 +2,15 @@
 
 // This compiles twice with replay disabled, ensuring that we get the same outputs for the same key.
 
-// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS=1 %clang-cache \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS=1 CLANG_CACHE_REDACT_TIME_MACROS=1 %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache 2> %t/out.txt
 // RUN: FileCheck %s --check-prefix=CACHE-SKIPPED --input-file=%t/out.txt
 
 // CACHE-SKIPPED: remark: compile job cache skipped
 // CACHE-SKIPPED: remark: compile job cache skipped
+
+void getit(const char **p1, const char **p2, const char **p3) {
+  *p1 = __DATE__;
+  *p2 = __TIMESTAMP__;
+  *p3 = __TIME__;
+}

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -173,6 +173,13 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
     }
     Args.append({"-greproducible", "-Xclang", "-fcas-token-cache"});
 
+    if (llvm::sys::Process::GetEnv("CLANG_CACHE_REDACT_TIME_MACROS")) {
+      // Remove use of these macros to get reproducible outputs. This can
+      // accompany CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS to avoid fatal errors
+      // when the source uses these macros.
+      Args.append({"-Wno-builtin-macro-redefined", "-D__DATE__=\"redacted\"",
+                   "-D__TIMESTAMP__=\"redacted\"", "-D__TIME__=\"redacted\""});
+    }
     if (llvm::sys::Process::GetEnv("CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS")) {
       // Run the compilation twice, without replaying, to check that we get the
       // same compilation artifacts for the same key. If they are not the same


### PR DESCRIPTION
This can be used to get deterministic outputs for source that uses the `__DATE__`, `__TIMESTAMP__`, `__TIME__` macros.

Related to rdar://100185558