### PR TITLE
[clang][cas] Create the parent directory for cached outputs

### DIFF
--- a/clang/test/CAS/output-path-create-directories.c
+++ b/clang/test/CAS/output-path-create-directories.c
@@ -1,0 +1,38 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=Mod -fno-implicit-modules \
+// RUN:   -emit-module %t/module.modulemap -o %t/out/B.pcm \
+// RUN:   -serialize-diagnostic-file %t/out/B.dia
+// RUN: ls %t/out/B.pcm
+// RUN: ls %t/out/B.dia
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=Mod -fno-implicit-modules \
+// RUN:   -emit-module %t/module.modulemap -o %t/out_miss/B.pcm \
+// RUN:   -serialize-diagnostic-file %t/out_miss/B.dia \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.txt
+// RUN: cat %t/B.out.txt | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: ls %t/out_miss/B.pcm
+// RUN: ls %t/out_miss/B.dia
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=Mod -fno-implicit-modules \
+// RUN:   -emit-module %t/module.modulemap -o %t/out_hit/B.pcm \
+// RUN:   -serialize-diagnostic-file %t/out_hit/B.dia \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.hit.txt
+// RUN: cat %t/B.out.hit.txt | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: ls %t/out_hit/B.pcm
+// RUN: ls %t/out_hit/B.dia
+
+// CACHE-HIT: remark: compile job cache hit
+// CACHE-MISS: remark: compile job cache miss
+
+//--- module.modulemap
+module Mod { header "Header.h" }
+
+//--- Header.h

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -472,7 +472,10 @@ createBinaryOutputFile(CompilerInstance &Clang, StringRef OutputPath) {
                       .setTextWithCRLF(false)
                       .setDiscardOnSignal(true)
                       .setAtomicWrite(true)
-                      .setImplyCreateDirectories(false));
+                      // To avoid failures that would not happen in uncached
+                      // builds, always create the parent directory. See comment
+                      // in replayCachedResult.
+                      .setImplyCreateDirectories(true));
   if (!O)
     return O.takeError();
 
@@ -794,6 +797,14 @@ ObjectStoreCachingOutputs::replayCachedResult(llvm::cas::ObjectRef ResultID,
       // The output may be always generated but not needed with this invocation,
       // like the serialized diagnostics file.
       return Error::success(); // continue
+
+    // Always create parent directory of outputs, since it is hard to precisely
+    // match which outputs rely on creating parents and the order outputs are
+    // replayed in, in case a previous output would create the parent
+    // (e.g. a .pcm and .diag file in the same directory).
+    StringRef ParentPath = llvm::sys::path::parent_path(Path);
+    if (!ParentPath.empty())
+      llvm::sys::fs::create_directories(ParentPath);
 
     bool IsOutputFile = O.Kind == OutputKind::MainOutput;
 


### PR DESCRIPTION
There are cases where we rely on certain outputs creating their parent directories in order for a compilation to succeed. Sometimes we implicitly depend on a previously handled output to create the directory (e.g. a .pcm and .diag file in the same directory). To avoid complex tracking of exactly which outputs the uncached build creates parent directories for, as well as the order they are handled, we always create parent directories for outputs in the cached build whenever it could affect the result.