### PR TITLE
[clang][cas] Stop ignoring errors during cache replay

### DIFF
--- a/clang/test/CAS/output-path-error.c
+++ b/clang/test/CAS/output-path-error.c
@@ -1,0 +1,23 @@
+// Check that fatal errors from cache-related output paths show up.
+
+// REQUIRES: shell
+
+// RUN: rm -rf %t && mkdir -p %t/a
+// RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
+
+// RUN: %clang -cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache -emit-obj %s -o %t/a/output.o 2>&1 \
+// RUN:   | FileCheck %s --allow-empty --check-prefix=CACHE-MISS
+
+// RUN: mkdir %t/b
+// RUN: chmod -w %t/b
+
+// RUN: not %clang -cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache -emit-obj %s -o %t/b/output.o 2>&1 \
+// RUN:   | FileCheck %s --allow-empty --check-prefixes=CACHE-HIT,ERROR
+
+// CACHE-MISS: remark: compile job cache miss
+// CACHE-HIT: remark: compile job cache hit
+// ERROR: fatal error: error in backend: Permission denied

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -719,8 +719,10 @@ ObjectStoreCachingOutputs::replayCachedResult(llvm::cas::ObjectRef ResultID,
     // See FIXME in CompileJobCache::tryReplayCachedResult() about improving how
     // we handle diagnostics for caching purposes.
     Clang.getDiagnosticClient().finish();
-    Clang.getDiagnostics().setClient(new IgnoringDiagConsumer(),
-                                     /*ShouldOwnClient=*/true);
+    DiagnosticOptions &DiagOpts = Clang.getInvocation().getDiagnosticOpts();
+    Clang.getDiagnostics().setClient(
+        new TextDiagnosticPrinter(llvm::errs(), &DiagOpts),
+        /*ShouldOwnClient=*/true);
   }
 
   // FIXME: Stop calling report_fatal_error().


### PR DESCRIPTION
It's not correct to ignore errors during replay, because we are using llvm::report_fatal_error for some cases, and the fatal error handler for cc1_main uses the diagonstic engine. Use a printing consumer instead so that there is at least some diagnostic output instead of exiting with a non-zero code but no output.

(cherry picked from commit b1c6580a1969c38606ebc82289535f42b7f95542)
(cherry picked from commit ccc8716c49ee2940c9c7def354855cf2cc5a6d0c)