### PR TITLE
[AST] Ignore -Wbitwise-instead-of-logical warnings in SemaPointer functions (NFC)

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1772,8 +1772,10 @@ static bool checkPointerAuthValue(Sema &S, Expr *&Arg,
 
 // The following functions use non-short-circuiting logic on the results of
 // `checkPointerAuthKey` and `checkPointerAuthValue`.
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
+#endif
 
 static ExprResult SemaPointerAuthStrip(Sema &S, CallExpr *Call) {
   if (checkArgCount(S, Call, 2)) return ExprError();
@@ -1838,7 +1840,9 @@ static ExprResult SemaPointerAuthAuthAndResign(Sema &S, CallExpr *Call) {
 }
 
 // Re-enable "-Wbitwise-instead-of-logical"
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 static ExprResult SemaPointerAuthStringDiscriminator(Sema &S, CallExpr *call) {
   if (checkPointerAuthEnabled(S, call)) return ExprError();

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1770,6 +1770,11 @@ static bool checkPointerAuthValue(Sema &S, Expr *&Arg,
   return invalid;
 }
 
+// The following functions use non-short-circuiting logic on the results of
+// `checkPointerAuthKey` and `checkPointerAuthValue`.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
+
 static ExprResult SemaPointerAuthStrip(Sema &S, CallExpr *Call) {
   if (checkArgCount(S, Call, 2)) return ExprError();
   if (checkPointerAuthEnabled(S, Call)) return ExprError();
@@ -1831,6 +1836,9 @@ static ExprResult SemaPointerAuthAuthAndResign(Sema &S, CallExpr *Call) {
   Call->setType(Call->getArgs()[0]->getType());
   return Call;
 }
+
+// Re-enable "-Wbitwise-instead-of-logical"
+#pragma clang diagnostic pop
 
 static ExprResult SemaPointerAuthStringDiscriminator(Sema &S, CallExpr *call) {
   if (checkPointerAuthEnabled(S, call)) return ExprError();


### PR DESCRIPTION
Resolves the following warnings:

```
SemaChecking.cpp:1812:7: warning: use of bitwise '|' with boolean operands [-Wbitwise-instead-of-logical]
```