### PR TITLE
[lldb] Fix completion of 'settings set' values

### DIFF
--- a/lldb/source/Commands/CommandObjectSettings.cpp
+++ b/lldb/source/Commands/CommandObjectSettings.cpp
@@ -153,7 +153,7 @@ insert-before or insert-after.");
       return;
 
     // Complete option name
-    if (arg[0] != '-')
+    if (arg[0] == '-')
       return;
 
     // Complete setting value

--- a/lldb/test/API/functionalities/completion/TestCompletion.py
+++ b/lldb/test/API/functionalities/completion/TestCompletion.py
@@ -404,6 +404,11 @@ class CommandLineCompletionTestCase(TestBase):
                               ['target.process.thread.step-avoid-regexp',
                                'target.process.thread.trace-thread'])
 
+    def test_settings_set_can_complete_setting_enum_values(self):
+        """Checks that we can complete the values of an enum setting."""
+        self.complete_from_to('settings set stop-disassembly-display ',
+                              ['never', 'always', 'no-debuginfo', 'no-source'])
+
     def test_thread_plan_discard(self):
         self.build()
         (_, _, thread, _) = lldbutil.run_to_source_breakpoint(self,


### PR DESCRIPTION
Some time ago, a refactor (1153dc960) broke completion for assigning settings
values (`settings set`). This was most annoying for enum settings, where you'd
have to get the valid enum names separately.

This restores the logic in the post-refactor completion function, as well as
adding a test to catch future regressions.

Differential Revision: https://reviews.llvm.org/D134515

(cherry picked from commit c418f00536001169f40d09bf3bff568aacfc9c30)
