### PR TITLE
[clang][cas] Create the parent directory for cached outputs

### DIFF
--- a/clang/test/CAS/output-path-create-directories.c
+++ b/clang/test/CAS/output-path-create-directories.c
@@ -1,0 +1,38 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=Mod -fno-implicit-modules \
+// RUN:   -emit-module %t/module.modulemap -o %t/out/B.pcm \
+// RUN:   -serialize-diagnostic-file %t/out/B.dia
+// RUN: ls %t/out/B.pcm
+// RUN: ls %t/out/B.dia
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=Mod -fno-implicit-modules \
+// RUN:   -emit-module %t/module.modulemap -o %t/out_miss/B.pcm \
+// RUN:   -serialize-diagnostic-file %t/out_miss/B.dia \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.txt
+// RUN: cat %t/B.out.txt | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: ls %t/out_miss/B.pcm
+// RUN: ls %t/out_miss/B.dia
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=Mod -fno-implicit-modules \
+// RUN:   -emit-module %t/module.modulemap -o %t/out_hit/B.pcm \
+// RUN:   -serialize-diagnostic-file %t/out_hit/B.dia \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.hit.txt
+// RUN: cat %t/B.out.hit.txt | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: ls %t/out_hit/B.pcm
+// RUN: ls %t/out_hit/B.dia
+
+// CACHE-HIT: remark: compile job cache hit
+// CACHE-MISS: remark: compile job cache miss
+
+//--- module.modulemap
+module Mod { header "Header.h" }
+
+//--- Header.h


### PR DESCRIPTION
There are cases where we rely on certain outputs creating their parent directories in order for a compilation to succeed. Sometimes we implicitly depend on a previously handled output to create the directory (e.g. a .pcm and .diag file in the same directory). To avoid complex tracking of exactly which outputs the uncached build creates parent directories for, as well as the order they are handled, we always create parent directories for outputs in the cached build whenever it could affect the result.

(cherry picked from commit e6a1d2c6feb9bd73d3c7eecbf6c894c821d227a8)