### PR TITLE
Activate the per-module scratch context if a dylib has triple 

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -334,7 +334,6 @@ ifeq (,$(filter $(OS), Windows_NT Android Darwin))
 endif
 OBJECTS =
 EXE ?= a.out
-
 ifneq "$(FRAMEWORK)" ""
 	DYLIB_NAME ?= $(FRAMEWORK).framework/Versions/A/$(FRAMEWORK)
 	DYLIB_FILENAME ?= $(FRAMEWORK).framework/Versions/A/$(FRAMEWORK)
@@ -698,9 +697,9 @@ ifeq "$(USESWIFTDRIVER)" "1"
 #----------------------------------------------------------------------
 ifeq "$(OS)" "Darwin"
 DYLIB_SWIFT_FLAGS=  \
-	 -Xlinker -dylib \
-	 -Xlinker -install_name -Xlinker @executable_path/$(shell basename $@) \
-	 $(LD_EXTRAS)
+        -Xlinker -dylib \
+        -Xlinker -install_name -Xlinker "$(DYLIB_INSTALL_NAME)" \
+        $(LD_EXTRAS)
 ifeq "$(DYLIB_HIDE_SWIFTMODULE)" ""
 DYLIB_SWIFT_FLAGS+= -Xlinker -add_ast_path -Xlinker $(DYLIB_NAME).swiftmodule
 endif

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1475,13 +1475,14 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
           : static_cast<SwiftASTContext *>(new SwiftASTContextForModule(
                 m_description, typeref_typesystem)));
   bool suppress_config_log = false;
-  auto defer_log = llvm::make_scope_exit([swift_ast_sp, &suppress_config_log] {
-    // To avoid spamming the log with useless info, we don't log the
-    // configuration if everything went fine and the current module
-    // doesn't have any Swift contents (i.e., the shared cache dylibs).
-    if (!suppress_config_log)
-      swift_ast_sp->LogConfiguration();
-  });
+  auto defer_log =
+      llvm::make_scope_exit([swift_ast_sp, &suppress_config_log, fallback] {
+        // To avoid spamming the log with useless info, we don't log the
+        // configuration if everything went fine and the current module
+        // doesn't have any Swift contents (i.e., the shared cache dylibs).
+        if (!suppress_config_log || fallback)
+          swift_ast_sp->LogConfiguration();
+      });
 
   // This is a module AST context, mark it as such.
   swift_ast_sp->m_is_scratch_context = false;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2592,12 +2592,39 @@ llvm::Optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
   LLDB_SCOPED_TIMER();
 
   Module *lldb_module = nullptr;
-  if (m_use_scratch_typesystem_per_module)
-    if (lldb::StackFrameSP stack_frame = exe_scope.CalculateStackFrame()) {
-      auto sc = stack_frame->GetSymbolContext(lldb::eSymbolContextEverything);
-      lldb_module = sc.module_sp.get();
-    }
+  if (lldb::StackFrameSP stack_frame = exe_scope.CalculateStackFrame()) {
+    auto sc = stack_frame->GetSymbolContext(lldb::eSymbolContextEverything);
+    lldb_module = sc.module_sp.get();
+  }
 
+  // Opt into the per-module scratch context if we find incompatible triples.
+  if (!m_use_scratch_typesystem_per_module) {
+    TargetSP target_sp = exe_scope.CalculateTarget();
+    if (lldb_module) {
+      auto module_arch = lldb_module->GetArchitecture();
+      auto target_arch = target_sp->GetArchitecture();
+      auto module_triple = module_arch.GetTriple();
+      auto target_triple = target_arch.GetTriple();
+      if (!module_arch.IsCompatibleMatch(target_arch) ||
+          (module_triple.isArm64e() != target_triple.isArm64e())) {
+        m_use_scratch_typesystem_per_module = true;
+        std::string module_name = lldb_module->GetSpecificationDescription();
+        const char *msg = "%sModule \"%s\" uses triple \"%s\", which is "
+                          "not compatible with the target triple \"%s\". "
+                          "Enabling per-module Swift scratch context.\n";
+
+        StreamSP errs = GetDebugger().GetAsyncErrorStream();
+        if (errs)
+          errs->Printf(msg, "warning: ", module_name.c_str(),
+                       module_triple.str().c_str(),
+                       target_triple.str().c_str());
+        if (log)
+          log->Printf(msg, "", module_name.c_str(), module_triple.str().c_str(),
+                      target_triple.str().c_str());
+      }
+    }
+  }
+ 
   auto get_or_create_fallback_context =
       [&]() -> TypeSystemSwiftTypeRefForExpressions * {
     if (!lldb_module || !m_use_scratch_typesystem_per_module)

--- a/lldb/test/API/lang/swift/other_arch_dylib/Makefile
+++ b/lldb/test/API/lang/swift/other_arch_dylib/Makefile
@@ -1,0 +1,21 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -F$(BUILDDIR) -Xlinker -rpath -Xlinker $(BUILDDIR)
+
+all: OtherArch.framework/Versions/A/OtherArch $(EXE)
+
+include Makefile.rules
+
+OtherArch.framework/Versions/A/OtherArch: $(SRCDIR)/OtherArch.swift
+	touch OtherArch.h
+	$(MAKE) -f $(MAKEFILE_RULES) \
+	    MAKE_DSYM=YES \
+		DYLIB_ONLY=YES \
+		DYLIB_SWIFT_SOURCES=OtherArch.swift \
+		MODULENAME=OtherArch \
+		FRAMEWORK=OtherArch \
+		FRAMEWORK_MODULES=OtherArch.swiftinterface \
+		FRAMEWORK_HEADERS=OtherArch.h \
+		SWIFTFLAGS_EXTRAS="-target arm64e-apple-macos12" \
+		SDKROOT=$(shell xcrun --sdk macosx.internal --show-sdk-path)
+	rm -f $(BUILDDIR)/OtherArch.swiftmodule $(BUILDDIR)/OtherArch.swiftinterface
+	rm -f OtherArch.o OtherArch.h OtherArch.partial.swiftmodule

--- a/lldb/test/API/lang/swift/other_arch_dylib/OtherArch.swift
+++ b/lldb/test/API/lang/swift/other_arch_dylib/OtherArch.swift
@@ -1,0 +1,3 @@
+public func foo() {
+  print("break here")
+}

--- a/lldb/test/API/lang/swift/other_arch_dylib/TestSwiftOtherArchDylib.py
+++ b/lldb/test/API/lang/swift/other_arch_dylib/TestSwiftOtherArchDylib.py
@@ -1,0 +1,55 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+
+class TestSwiftOtherArchDylib(TestBase):
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @swiftTest
+    @skipUnlessDarwin
+    @skipIfDarwinEmbedded
+    @expectedFailure("the swift.org toolchain cannot produce arm64e binaries")
+    def test(self):
+        """Test module import from dylibs with an architecture
+           that uses a different SDK"""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(
+            self, "foo", extra_images=['OtherArch.framework/OtherArch'])
+        types_log = self.getBuildArtifact('types.log')
+        self.expect("log enable lldb types -f "+ types_log)
+
+        self.expect("expression 1", substrs=['1'])
+        frame = thread.frames[0]
+        while 'OtherArch.foo' not in frame.name:
+            frame = frame.parent
+            self.assertIsNotNone(frame)
+        thread.SetSelectedFrame(frame.idx)
+        self.expect("expression 1", substrs=['1'])
+
+        # Check the types log.
+        import re
+        import io
+        types_logfile = io.open(types_log, "r", encoding='utf-8')
+        re0 = re.compile(r'SwiftASTContextForExpressions::LogConfiguration().*arm64-apple-macosx')
+        re1 = re.compile(r'Enabling per-module Swift scratch context')
+        re2 = re.compile(r'wiftASTContextForExpressions..OtherArch..::LogConfiguration().*arm64e-apple-macosx')
+        found = 0
+        for line in types_logfile:
+            if self.TraceOn():
+                print(line[:-1])
+            if found == 0 and re0.search(line):
+                found = 1
+            elif found == 1 and re1.search(line):
+                found = 2
+            elif found == 2 and re2.search(line):
+                found = 3
+                break
+        self.assertEquals(found, 3)

--- a/lldb/test/API/lang/swift/other_arch_dylib/main.swift
+++ b/lldb/test/API/lang/swift/other_arch_dylib/main.swift
@@ -1,0 +1,3 @@
+import OtherArch
+
+foo()


### PR DESCRIPTION
that is incompatible with the target triple used by the per-process scratch context. On macOS this can happen with system framework, which are typically arm64e and arm64 applications. Even though the two ABIs are interoperable, they need different Swift standard libraries and aren't compatible from a Swift AST perspective.

rdar://92248684