### PR TITLE
[clang][cas] Allow spelling differences in paths for DependencyScanningCASFilesystem

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
@@ -69,7 +69,7 @@ public:
   /// \returns The scanned preprocessor directive tokens of the file that are
   /// used to speed up preprocessing, if available.
   Optional<ArrayRef<dependency_directives_scan::Directive>>
-  getDirectiveTokens(const Twine &Path) const;
+  getDirectiveTokens(const Twine &Path);
 
 private:
   /// Check whether the file should be scanned for preprocessor directives.

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
@@ -354,15 +354,9 @@ DependencyScanningCASFilesystem::openFileForRead(const Twine &Path) {
 }
 
 Optional<ArrayRef<dependency_directives_scan::Directive>>
-DependencyScanningCASFilesystem::getDirectiveTokens(const Twine &Path) const {
-  SmallString<256> PathStorage;
-  StringRef PathRef = Path.toStringRef(PathStorage);
-  auto I = Entries.find(PathRef);
-  if (I == Entries.end())
-    return None;
-
-  const FileEntry &Entry = I->second;
-  if (Entry.DepDirectives.empty())
-    return None;
-  return llvm::makeArrayRef(Entry.DepDirectives);
+DependencyScanningCASFilesystem::getDirectiveTokens(const Twine &Path) {
+  LookupPathResult Result = lookupPath(Path);
+  if (Result.Entry && !Result.Entry->DepDirectives.empty())
+    return llvm::makeArrayRef(Result.Entry->DepDirectives);
+  return None;
 }

--- a/clang/unittests/Tooling/CMakeLists.txt
+++ b/clang/unittests/Tooling/CMakeLists.txt
@@ -13,6 +13,7 @@ add_clang_unittest(ToolingTests
   CommentHandlerTest.cpp
   CompilationDatabaseTest.cpp
   DependencyScannerTest.cpp
+  DependencyScanningCASFilesystemTest.cpp
   DiagnosticsYamlTest.cpp
   ExecutionTest.cpp
   FixItTest.cpp

--- a/clang/unittests/Tooling/DependencyScanningCASFilesystemTest.cpp
+++ b/clang/unittests/Tooling/DependencyScanningCASFilesystemTest.cpp
@@ -1,0 +1,44 @@
+//===- unittest/Tooling/DependencyScanningCASFilesystemTest.cpp -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h"
+#include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/CachingOnDiskFileSystem.h"
+#include "llvm/CAS/ObjectStore.h"
+#include "llvm/Testing/Support/SupportHelpers.h"
+#include "gtest/gtest.h"
+
+using namespace clang;
+using namespace clang::cas;
+using namespace clang::cas;
+using namespace clang::tooling::dependencies;
+using llvm::unittest::TempDir;
+using llvm::unittest::TempFile;
+using llvm::unittest::TempLink;
+
+TEST(DependencyScanningCASFilesystem, FilenameSpelling) {
+  TempDir TestDir("DependencyScanningCASFilesystemTest", /*Unique=*/true);
+  TempFile TestFile(TestDir.path("File.h"), "", "#define FOO\n");
+  TempLink TestLink("File.h", TestDir.path("SymFile.h"));
+
+  std::unique_ptr<ObjectStore> CAS = llvm::cas::createInMemoryCAS();
+  std::unique_ptr<ActionCache> Cache = llvm::cas::createInMemoryActionCache();
+  auto CacheFS = llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*CAS));
+  DependencyScanningCASFilesystem FS(CacheFS, *Cache);
+
+  EXPECT_EQ(FS.status(TestFile.path()).getError(), std::error_code());
+  auto Directives = FS.getDirectiveTokens(TestFile.path());
+  ASSERT_TRUE(Directives);
+  EXPECT_EQ(Directives->size(), 2u);
+  auto DirectivesDots = FS.getDirectiveTokens(TestDir.path("././File.h"));
+  ASSERT_TRUE(DirectivesDots);
+  EXPECT_EQ(DirectivesDots->size(), 2u);
+  auto DirectivesSymlink = FS.getDirectiveTokens(TestLink.path());
+  ASSERT_TRUE(DirectivesSymlink);
+  EXPECT_EQ(DirectivesSymlink->size(), 2u);
+}


### PR DESCRIPTION
Do not require getDirectiveTokens to receive an identical filename to a previous filesystem operation, as this is hard to guarantee when the calls are far apart and go through complex filesystem layers such as FileManager and VFS, any of which could modify the path. In practice, this was causing breakage when using a VFS which canonicalized away "./" in a path.

Note: because all the actual filesystem accesses go through CachingOnDiskFileSystem, and the directive scanning itself is cached in the ActionCache, the cost of mismatching the spelling should be low.

(cherry picked from commit 3f96618a56383c56806d2ff668d9454580c0e7c2)