### PR TITLE
XFAIL 'lldb-shell :: SwiftREPL/BreakpointSimple.test'

### DIFF
--- a/lldb/test/Shell/SwiftREPL/BreakpointSimple.test
+++ b/lldb/test/Shell/SwiftREPL/BreakpointSimple.test
@@ -1,5 +1,6 @@
 // Test that we can set breakpoints in the REPL.
 // REQUIRES: swift
+// REQUIRES: rdar79730016
 // RUN: %lldb --repl < %s | FileCheck %s
 
 func foo() -> Int {


### PR DESCRIPTION
This test sporadically often fails in CI. We need to investigate why.