### PR TITLE
Prefer to store persistent variables as TypeRef types. 

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1069,14 +1069,8 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
       auto *swift_ast_ctx =
           llvm::cast<SwiftASTContext>(actual_type.GetTypeSystem());
 
-      // Currently the Swift runtime cannot resolve types that were
-      // defined in the expression evaluator. That's because we don't
-      // tell it about type metadata sections that were JIT-compiled
-      // by the expression evaluator. Until that is implemented, fall
-      // back to SwiftASTContext.
-      if (!FromLLDBModule(transformed_type.getPointer()))
-        actual_type =
-            swift_ast_ctx->GetTypeRefType(actual_type.GetOpaqueQualType());
+      actual_type =
+          swift_ast_ctx->GetTypeRefType(actual_type.GetOpaqueQualType());
 
       offset = materializer.AddResultVariable(
           actual_type, false, true,
@@ -1139,7 +1133,7 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
           variable.GetType(), variable.GetDecl(),
           &user_expression.GetPersistentVariableDelegate(), error);
     } else {
-      // Transform the variable metadata to a typeref type if necessary.
+      // Transform the variable metadata to a typeref type if possible.
       auto compiler_type =
           variable_metadata->m_persistent_variable_sp->GetCompilerType();
       if (auto *swift_ast_ctx =

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1037,14 +1037,11 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
     if (repl) {
       if (!variable.GetType().IsVoidType()) {
         auto &repl_mat = *llvm::cast<SwiftREPLMaterializer>(&materializer);
-        if (is_result)
-          offset = repl_mat.AddREPLResultVariable(
-              variable.GetType(), variable.GetDecl(),
-              &user_expression.GetResultDelegate(), error);
-        else
-          offset = repl_mat.AddREPLResultVariable(
-              variable.GetType(), variable.GetDecl(),
-              &user_expression.GetErrorDelegate(), error);
+        offset = repl_mat.AddREPLResultVariable(
+            variable.GetType(), variable.GetDecl(),
+            is_result ? &user_expression.GetResultDelegate()
+                      : &user_expression.GetErrorDelegate(),
+            error);
       }
     } else {
       CompilerType actual_type = variable.GetType();
@@ -1081,14 +1078,11 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
         actual_type =
             swift_ast_ctx->GetTypeRefType(actual_type.GetOpaqueQualType());
 
-      if (is_result)
-        offset = materializer.AddResultVariable(
-            actual_type, false, true, &user_expression.GetResultDelegate(),
-            error);
-      else
-        offset = materializer.AddResultVariable(
-            actual_type, false, true, &user_expression.GetErrorDelegate(),
-            error);
+      offset = materializer.AddResultVariable(
+          actual_type, false, true,
+          is_result ? &user_expression.GetResultDelegate()
+                    : &user_expression.GetErrorDelegate(),
+          error);
     }
 
     if (!error.Success()) {


### PR DESCRIPTION
This increases robustness when SBAPI clients hold on to types whose
SwiftASTContext has been torn down.