### PR TITLE
Enable disabled test. 

### DIFF
--- a/lldb/test/API/lang/swift/reflection_only/TestSwiftReflectionOnly.py
+++ b/lldb/test/API/lang/swift/reflection_only/TestSwiftReflectionOnly.py
@@ -64,8 +64,7 @@ class TestSwiftReflectionOnly(lldbtest.TestBase):
         enum2 = frame.FindVariable("enum2")
         check_var(self, enum2, value="with")
         check_var(self, enum2, num_children=1)
-        # FIXME:  Fails in swift::reflection::NoPayloadEnumTypeInfo::projectEnumValue: .second
-        # check_var(self, enum2.GetChildAtIndex(0), value="42")
+        check_var(self, enum2.GetChildAtIndex(0).GetChildAtIndex(0), value="42")
 
         # Scan through the types log.
         import io


### PR DESCRIPTION
This seems to work now, with the only wrinkle that a payload-enum has two levels of children.

rdar://88412112