### PR TITLE
Remove workaround from Makefile

### DIFF
--- a/lldb/test/API/lang/swift/framework_paths/Makefile
+++ b/lldb/test/API/lang/swift/framework_paths/Makefile
@@ -26,4 +26,3 @@ Direct.framework: $(SRCDIR)/Direct.swift.in Discovered.framework
 		FRAMEWORK=Direct \
 		SWIFTFLAGS_EXTRAS=-F$(BUILDDIR)/secret_path
 	rm -f $(BUILDDIR)/Direct.swiftmodule $(BUILDDIR)/Direct.swiftinterface $(BUILDDIR)/Direct.swift
-	ln -s $(BUILDDIR)/Direct.framework/Direct $(BUILDDIR)/Direct # FIXME


### PR DESCRIPTION
the underlying bug in Makefile.rules was fixed in 1d4c1e46edb66b966d39925106598904632203a5