### PR TITLE
[libclang][scanner] Add API returning structured diagnostics

### DIFF
--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -21,6 +21,7 @@
 #define LLVM_CLANG_C_DEPENDENCIES_H
 
 #include "clang-c/BuildSystem.h"
+#include "clang-c/CXDiagnostic.h"
 #include "clang-c/CXErrorCode.h"
 #include "clang-c/CXString.h"
 #include "clang-c/Platform.h"
@@ -249,7 +250,7 @@ typedef size_t CXModuleLookupOutputCallback(void *Context,
                                             char *Output, size_t MaxLen);
 
 /**
- * See \c clang_experimental_DependencyScannerWorker_getFileDependencies_v4.
+ * See \c clang_experimental_DependencyScannerWorker_getFileDependencies_v5.
  */
 CINDEX_LINKAGE CXFileDependencies *
 clang_experimental_DependencyScannerWorker_getFileDependencies_v3(
@@ -257,6 +258,18 @@ clang_experimental_DependencyScannerWorker_getFileDependencies_v3(
     const char *ModuleName, const char *WorkingDirectory, void *MDCContext,
     CXModuleDiscoveredCallback *MDC, void *MLOContext,
     CXModuleLookupOutputCallback *MLO, unsigned Options, CXString *error);
+
+/**
+ * See \c clang_experimental_DependencyScannerWorker_getFileDependencies_v5.
+ * Returns diagnostics in an unstructured CXString instead of CXDiagnosticSet.
+ */
+CINDEX_LINKAGE CXErrorCode
+clang_experimental_DependencyScannerWorker_getFileDependencies_v4(
+    CXDependencyScannerWorker Worker, int argc, const char *const *argv,
+    const char *ModuleName, const char *WorkingDirectory, void *MDCContext,
+    CXModuleDiscoveredCallback *MDC, void *MLOContext,
+    CXModuleLookupOutputCallback *MLO, unsigned Options,
+    CXFileDependenciesList **Out, CXString *error);
 
 /**
  * Calculates the list of file dependencies for a particular compiler
@@ -288,18 +301,19 @@ clang_experimental_DependencyScannerWorker_getFileDependencies_v3(
  * \param [out] Out A non-NULL pointer to store the resulting dependencies. The
  *                  output must be freed by calling
  *                  \c clang_experimental_FileDependenciesList_dispose.
- * \param [out] error the error string to pass back to client (if any).
+ * \param [out] OutDiags The diagnostics emitted during scanning. These must be
+ *                       always freed by calling \c clang_disposeDiagnosticSet.
  *
  * \returns \c CXError_Success on success; otherwise a non-zero \c CXErrorCode
  * indicating the kind of error.
  */
 CINDEX_LINKAGE CXErrorCode
-clang_experimental_DependencyScannerWorker_getFileDependencies_v4(
+clang_experimental_DependencyScannerWorker_getFileDependencies_v5(
     CXDependencyScannerWorker Worker, int argc, const char *const *argv,
     const char *ModuleName, const char *WorkingDirectory, void *MDCContext,
     CXModuleDiscoveredCallback *MDC, void *MLOContext,
     CXModuleLookupOutputCallback *MLO, unsigned Options,
-    CXFileDependenciesList **Out, CXString *error);
+    CXFileDependenciesList **Out, CXDiagnosticSet *OutDiags);
 
 /**
  * @}

--- a/clang/tools/libclang/CXDiagnosticSetDiagnosticConsumer.h
+++ b/clang/tools/libclang/CXDiagnosticSetDiagnosticConsumer.h
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_LIBCLANG_CXDIAGNOSTICSETDIAGNOSTICCONSUMER_H
+#define LLVM_CLANG_TOOLS_LIBCLANG_CXDIAGNOSTICSETDIAGNOSTICCONSUMER_H
+
+#include "CIndexDiagnostic.h"
+
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/LangOptions.h"
+
+namespace clang {
+class CXDiagnosticSetDiagnosticConsumer : public DiagnosticConsumer {
+  SmallVector<StoredDiagnostic, 4> Errors;
+
+public:
+  void HandleDiagnostic(DiagnosticsEngine::Level level,
+                        const Diagnostic &Info) override {
+    if (level >= DiagnosticsEngine::Error) {
+      Errors.push_back(StoredDiagnostic(level, Info));
+      ++NumErrors;
+    }
+  }
+
+  CXDiagnosticSet getDiagnosticSet() {
+    return cxdiag::createStoredDiags(Errors, LangOptions());
+  }
+};
+} // namespace clang
+
+#endif

--- a/clang/tools/libclang/Driver.cpp
+++ b/clang/tools/libclang/Driver.cpp
@@ -13,6 +13,7 @@
 #include "clang-c/Driver.h"
 
 #include "CIndexDiagnostic.h"
+#include "CXDiagnosticSetDiagnosticConsumer.h"
 
 #include "clang/Driver/Compilation.h"
 #include "clang/Driver/Driver.h"
@@ -22,21 +23,6 @@
 #include "llvm/Support/Host.h"
 
 using namespace clang;
-
-class CXDiagnosticSetDiagnosticConsumer : public DiagnosticConsumer {
-  SmallVector<StoredDiagnostic, 4> Errors;
-public:
-
-  void HandleDiagnostic(DiagnosticsEngine::Level level,
-  const Diagnostic &Info) override {
-    if (level >= DiagnosticsEngine::Error)
-      Errors.push_back(StoredDiagnostic(level, Info));
-  }
-
-  CXDiagnosticSet getDiagnosticSet() {
-    return cxdiag::createStoredDiags(Errors, LangOptions());
-  }
-};
 
 CXExternalActionList *
 clang_Driver_getExternalActionsForCommand_v0(int ArgC, const char **ArgV,

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -475,6 +475,7 @@ LLVM_16 {
     clang_getUnqualifiedType;
     clang_getNonReferenceType;
     clang_CXXMethod_isDeleted;
+    clang_experimental_DependencyScannerWorker_getFileDependencies_v5;
 };
 
 # Example of how to add a new symbol version entry.  If you do add a new symbol


### PR DESCRIPTION
This PR adds new function to the libclang scanner API that returns structured `CXDiagnostic` objects.