### PR TITLE
[lldb] Add newline in output of `target modules lookup`

### DIFF
--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -1539,6 +1539,7 @@ static uint32_t LookupSymbolInModule(CommandInterpreter &interpreter,
         DumpAddress(
             interpreter.GetExecutionContext().GetBestExecutionContextScope(),
             symbol->GetAddressRef(), verbose, all_ranges, strm);
+        strm.EOL();
       }
     }
     strm.IndentLess();

--- a/lldb/test/Shell/Commands/Inputs/symbols.yaml
+++ b/lldb/test/Shell/Commands/Inputs/symbols.yaml
@@ -1,0 +1,48 @@
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_REL
+  Machine:         EM_AARCH64
+  SectionHeaderStringTable: .strtab
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    AddressAlign:    0x4
+  - Type:            SectionHeaderTable
+    Sections:
+      - Name:            .text
+      - Name:            .strtab
+      - Name:            .symtab
+Symbols:
+  - Name:            _Z8someFunciii
+    Type:            STT_FUNC
+    Section:         .text
+    Binding:         STB_GLOBAL
+    Size:            0x1C
+  - Name:            _Z8someFuncci
+    Type:            STT_FUNC
+    Section:         .text
+    Binding:         STB_GLOBAL
+    Value:           0x1C
+    Size:            0x18
+  - Name:            _Z13someOtherFuncv
+    Type:            STT_FUNC
+    Section:         .text
+    Binding:         STB_GLOBAL
+    Value:           0x34
+    Size:            0x4
+  - Name:            _Z13someOtherFuncd
+    Type:            STT_FUNC
+    Section:         .text
+    Binding:         STB_GLOBAL
+    Value:           0x38
+    Size:            0x10
+  - Name:            _Z18ignoreThisFunctionv
+    Type:            STT_FUNC
+    Section:         .text
+    Binding:         STB_GLOBAL
+    Value:           0x48
+    Size:            0x8
+...

--- a/lldb/test/Shell/Commands/command-target-modules-lookup.test
+++ b/lldb/test/Shell/Commands/command-target-modules-lookup.test
@@ -1,0 +1,12 @@
+# RUN: yaml2obj %S/Inputs/symbols.yaml -o %t
+
+# RUN: %lldb %t -b -o "target modules lookup -A -r -s some" | FileCheck %s -DMODULE=%basename_t.tmp --implicit-check-not ignoreThisFunction
+# CHECK:      4 symbols match the regular expression 'some' in {{.*}}[[MODULE]]:
+# CHECK-NEXT: Address: [[MODULE]][0x0000000000000000] ([[MODULE]]..text + 0)
+# CHECK-NEXT: Summary: [[MODULE]]`someFunc(int, int, int)
+# CHECK-NEXT: Address: [[MODULE]][0x000000000000001c] ([[MODULE]]..text + 28)
+# CHECK-NEXT: Summary: [[MODULE]]`someFunc(char, int)
+# CHECK-NEXT: Address: [[MODULE]][0x0000000000000034] ([[MODULE]]..text + 52)
+# CHECK-NEXT: Summary: [[MODULE]]`someOtherFunc()
+# CHECK-NEXT: Address: [[MODULE]][0x0000000000000038] ([[MODULE]]..text + 56)
+# CHECK-NEXT: Summary: [[MODULE]]`someOtherFunc(double)


### PR DESCRIPTION
[lldb] Add newline in output of `target modules lookup`

This adds a line break between each result address in the output of the lldb command `target modules lookup`. Before this change, a new address result will be printed on the same line as the summary of the last result, making the output difficult to view.

Also adds a test for this command.

Reviewed By: labath

Differential Revision: https://reviews.llvm.org/D134111

(cherry picked from commit a426753ef0290362a0268f917dba46d6b9744b02)