### PR TITLE
[clang-cache] Skip caching when date-time macro is used

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -41,6 +41,8 @@ def err_clang_cache_missing_compiler_command: Error<
   "missing compiler command for clang-cache">;
 def err_caching_backend_fail: Error<
   "caching backend error: %0">, DefaultFatal;
+def err_caching_output_non_deterministic: Error<
+  "caching failed because the output can be non-deterministic">;
 
 def remark_compile_job_cache_hit : Remark<
   "compile job cache hit for '%0' => '%1'">, InGroup<CompileJobCacheHit>;

--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -717,6 +717,12 @@ def warn_pp_date_time : Warning<
   "expansion of date or time macro is not reproducible">,
   ShowInSystemHeader, DefaultIgnore, InGroup<DiagGroup<"date-time">>;
 
+def warn_pp_encounter_nonreproducible: Warning<
+  "encountered non-reproducible token, caching will be skipped">,
+  InGroup<DiagGroup<"reproducible-caching">>;
+def err_pp_encounter_nonreproducible: Error<
+  "encountered non-reproducible token, caching failed">;
+
 // Module map parsing
 def err_mmap_unknown_token : Error<"skipping stray token">;
 def err_mmap_expected_module : Error<"expected module declaration">;

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -353,6 +353,7 @@ public:
     assert(!CompileJobCacheKey || CompileJobCacheKey == Key);
     CompileJobCacheKey = std::move(Key);
   }
+  bool isSourceNonReproducible() const;
 
   /// }
   /// @name Diagnostics Engine

--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -243,6 +243,9 @@ class Preprocessor {
   /// True if we are pre-expanding macro arguments.
   bool InMacroArgPreExpansion;
 
+  /// True if we encountered any of the non-deterministic macros.
+  bool IsSourceNonReproducible;
+
   /// Mapping/lookup information for all identifiers in
   /// the program, including program keywords.
   mutable IdentifierTable Identifiers;
@@ -1055,6 +1058,8 @@ public:
 
   void setPragmasEnabled(bool Enabled) { PragmasEnabled = Enabled; }
   bool getPragmasEnabled() const { return PragmasEnabled; }
+
+  bool isSourceNonReproducible() const { return IsSourceNonReproducible; }
 
   void SetSuppressIncludeNotFoundError(bool Suppress) {
     SuppressIncludeNotFoundError = Suppress;

--- a/clang/include/clang/Lex/PreprocessorOptions.h
+++ b/clang/include/clang/Lex/PreprocessorOptions.h
@@ -60,6 +60,18 @@ enum class DisableValidationForModuleKind {
   LLVM_MARK_AS_BITMASK_ENUM(Module)
 };
 
+/// Diagnostic options for caching related behaviors.
+enum class CachingDiagKind {
+  /// Do not emit diagnosis for caching.
+  None = 0,
+
+  /// Warning about nondeterministic caching.
+  Warning = 1,
+
+  /// Error about nondeterministic caching.
+  Error = 2
+};
+
 /// PreprocessorOptions - This class is used for passing the various options
 /// used in preprocessor initialization to InitializePreprocessor().
 class PreprocessorOptions {
@@ -219,6 +231,9 @@ public:
 
   /// Prevents intended crashes when using #pragma clang __debug. For testing.
   bool DisablePragmaDebugCrash = false;
+
+  /// Should diagnose caching related issues.
+  CachingDiagKind CachingDiagOption = CachingDiagKind::None;
 
 public:
   PreprocessorOptions() : PrecompiledPreambleBytes(0, false) {}

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -96,6 +96,11 @@ void CompilerInstance::setDiagnostics(DiagnosticsEngine *Value) {
   Diagnostics = Value;
 }
 
+bool CompilerInstance::isSourceNonReproducible() const {
+  assert(PP && "Need to have preprocessor");
+  return PP->isSourceNonReproducible();
+}
+
 void CompilerInstance::setVerboseOutputStream(raw_ostream &Value) {
   OwnedVerboseOutputStream.reset();
   VerboseOutputStream = &Value;

--- a/clang/lib/Lex/PPMacroExpansion.cpp
+++ b/clang/lib/Lex/PPMacroExpansion.cpp
@@ -1472,6 +1472,19 @@ void Preprocessor::ExpandBuiltinMacro(Token &Tok) {
   Tok.clearFlag(Token::NeedsCleaning);
   bool IsAtStartOfLine = Tok.isAtStartOfLine();
   bool HasLeadingSpace = Tok.hasLeadingSpace();
+  auto handleDateTimeWarnings = [&](SourceLocation Loc) {
+    IsSourceNonReproducible = true;
+    switch (getPreprocessorOpts().CachingDiagOption) {
+    case CachingDiagKind::None:
+      return;
+    case CachingDiagKind::Warning:
+      Diag(Loc, diag::warn_pp_encounter_nonreproducible);
+      return;
+    case CachingDiagKind::Error:
+      Diag(Loc, diag::err_pp_encounter_nonreproducible);
+      return;
+    }
+  };
 
   if (II == Ident__LINE__) {
     // C99 6.10.8: "__LINE__: The presumed line number (within the current
@@ -1536,6 +1549,7 @@ void Preprocessor::ExpandBuiltinMacro(Token &Tok) {
     Tok.setKind(tok::string_literal);
   } else if (II == Ident__DATE__) {
     Diag(Tok.getLocation(), diag::warn_pp_date_time);
+    handleDateTimeWarnings(Tok.getLocation());
     if (!DATELoc.isValid())
       ComputeDATE_TIME(DATELoc, TIMELoc, *this);
     Tok.setKind(tok::string_literal);
@@ -1546,6 +1560,7 @@ void Preprocessor::ExpandBuiltinMacro(Token &Tok) {
     return;
   } else if (II == Ident__TIME__) {
     Diag(Tok.getLocation(), diag::warn_pp_date_time);
+    handleDateTimeWarnings(Tok.getLocation());
     if (!TIMELoc.isValid())
       ComputeDATE_TIME(DATELoc, TIMELoc, *this);
     Tok.setKind(tok::string_literal);
@@ -1571,6 +1586,7 @@ void Preprocessor::ExpandBuiltinMacro(Token &Tok) {
     Tok.setKind(tok::numeric_constant);
   } else if (II == Ident__TIMESTAMP__) {
     Diag(Tok.getLocation(), diag::warn_pp_date_time);
+    handleDateTimeWarnings(Tok.getLocation());
     // MSVC, ICC, GCC, VisualAge C++ extension.  The generated string should be
     // of the form "Ddd Mmm dd hh::mm::ss yyyy", which is returned by asctime.
 

--- a/clang/lib/Lex/Preprocessor.cpp
+++ b/clang/lib/Lex/Preprocessor.cpp
@@ -109,6 +109,7 @@ Preprocessor::Preprocessor(std::shared_ptr<PreprocessorOptions> PPOpts,
   PragmasEnabled = true;
   ParsingIfOrElifDirective = false;
   PreprocessedOutput = false;
+  IsSourceNonReproducible = false;
 
   // We haven't read anything from the external source.
   ReadMacrosFromExternalSource = false;

--- a/clang/test/CAS/test-for-deterministic-module.c
+++ b/clang/test/CAS/test-for-deterministic-module.c
@@ -1,0 +1,27 @@
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+//
+// RUN: not %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
+// RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
+// RUN: FileCheck %s --input-file=%t/A.out.txt
+
+// CHECK: remark: compile job cache miss
+// CHECK: error: encountered non-reproducible token, caching failed
+// CHECK: error: encountered non-reproducible token, caching failed
+// CHECK: error: encountered non-reproducible token, caching failed
+
+//--- module.modulemap
+module A { header "A.h" }
+
+//--- A.h
+void getit(const char **p1, const char **p2, const char **p3) {
+  *p1 = __DATE__;
+  *p2 = __TIMESTAMP__;
+  *p3 = __TIME__;
+}

--- a/clang/test/CAS/test-for-deterministic-outputs.c
+++ b/clang/test/CAS/test-for-deterministic-outputs.c
@@ -9,6 +9,21 @@
 // CACHE-SKIPPED: remark: compile job cache skipped
 // CACHE-SKIPPED: remark: compile job cache skipped
 
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache 2> %t/out.txt
+// RUN: FileCheck %s --check-prefix=CACHE-WARN --input-file=%t/out.txt
+
+/// Check still a cache miss.
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache 2> %t/out.txt
+// RUN: FileCheck %s --check-prefix=CACHE-WARN --input-file=%t/out.txt
+
+// CACHE-WARN: remark: compile job cache miss
+// CACHE-WARN: warning: encountered non-reproducible token, caching will be skipped
+// CACHE-WARN: warning: encountered non-reproducible token, caching will be skipped
+// CACHE-WARN: warning: encountered non-reproducible token, caching will be skipped
+// CACHE-WARN: remark: compile job cache skipped
+
 void getit(const char **p1, const char **p2, const char **p3) {
   *p1 = __DATE__;
   *p2 = __TIMESTAMP__;

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -33,6 +33,7 @@
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Frontend/Utils.h"
 #include "clang/FrontendTool/Utils.h"
+#include "clang/Lex/PreprocessorOptions.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/CAS/ActionCache.h"
@@ -221,8 +222,10 @@ public:
   virtual bool prepareOutputCollection() = 0;
 
   /// Finish writing outputs from a computed result, after a cache miss.
-  virtual Error
-  finishComputedResult(const llvm::cas::CASID &ResultCacheKey) = 0;
+  /// If SkipCache is true, it should not insert the ResultCacheKey into
+  /// Cache for future uses.
+  virtual Error finishComputedResult(const llvm::cas::CASID &ResultCacheKey,
+                                     bool SkipCache) = 0;
 
   void finishSerializedDiagnostics();
 
@@ -260,7 +263,8 @@ private:
 
   bool prepareOutputCollection() override;
 
-  Error finishComputedResult(const llvm::cas::CASID &ResultCacheKey) override;
+  Error finishComputedResult(const llvm::cas::CASID &ResultCacheKey,
+                             bool SkipCache) override;
 
   /// Replay a cache hit.
   ///
@@ -318,7 +322,7 @@ public:
 
   /// Canonicalize \p Clang.
   ///
-  /// Return status if should exit immediately, otherwise None.
+  /// \returns status if should exit immediately, otherwise None.
   ///
   /// TODO: Refactor \a cc1_main() so that instead this canonicalizes the
   /// CompilerInvocation before Clang gets access to command-line arguments, to
@@ -327,11 +331,13 @@ public:
 
   /// Try looking up a cached result and replaying it.
   ///
-  /// Return status if should exit immediately, otherwise None.
+  /// \returns status if should exit immediately, otherwise None.
   Optional<int> tryReplayCachedResult(CompilerInstance &Clang);
 
   /// Finish writing outputs from a computed result, after a cache miss.
-  void finishComputedResult(CompilerInstance &Clang, bool Success);
+  ///
+  /// \returns true if finished successfully.
+  bool finishComputedResult(CompilerInstance &Clang, bool Success);
 
 private:
   int reportCachingBackendError(DiagnosticsEngine &Diag, Error &&E) {
@@ -396,6 +402,18 @@ Optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
       canonicalizeAndCreateCacheKey(*CAS, Diags, Invocation, CacheOpts);
   if (!ResultCacheKey)
     return 1; // Exit with error!
+
+  switch (FrontendOpts.ProgramAction) {
+  case frontend::GenerateModule:
+  case frontend::GenerateModuleInterface:
+  case frontend::GenerateHeaderModule:
+  case frontend::GeneratePCH:
+    Clang.getPreprocessorOpts().CachingDiagOption = CachingDiagKind::Error;
+    break;
+  default:
+    Clang.getPreprocessorOpts().CachingDiagOption = CachingDiagKind::Warning;
+    break;
+  }
 
   DisableCachedCompileJobReplay = CacheOpts.DisableCachedCompileJobReplay;
 
@@ -626,11 +644,11 @@ bool ObjectStoreCachingOutputs::prepareOutputCollection() {
   return false;
 }
 
-void CompileJobCache::finishComputedResult(CompilerInstance &Clang,
+bool CompileJobCache::finishComputedResult(CompilerInstance &Clang,
                                            bool Success) {
   // Nothing to do if not caching.
   if (!CacheCompileJob)
-    return;
+    return Success;
 
   CacheBackend->finishSerializedDiagnostics();
 
@@ -640,7 +658,7 @@ void CompileJobCache::finishComputedResult(CompilerInstance &Clang,
   // without a temporary (non-atomically), failure may cause the removal of a
   // preexisting file. That behaviour is not currently modeled by the cache.
   if (!Success)
-    return;
+    return false;
 
   // Existing diagnostic client is finished, create a new one in case we need
   // to print more diagnostics.
@@ -649,10 +667,29 @@ void CompileJobCache::finishComputedResult(CompilerInstance &Clang,
                                 &Clang.getInvocation().getDiagnosticOpts()),
       /*ShouldOwnClient=*/true);
 
-  if (Error E = CacheBackend->finishComputedResult(*ResultCacheKey)) {
-    reportCachingBackendError(Clang.getDiagnostics(), std::move(E));
-    Success = false;
+  // Check if we encounter any source that would generate non-reproducible
+  // outputs.
+  bool SkipCache = Clang.hasPreprocessor() && Clang.isSourceNonReproducible();
+  if (SkipCache) {
+    DiagnosticsEngine &Diags = Clang.getDiagnostics();
+    switch (Clang.getPreprocessorOpts().CachingDiagOption) {
+      case CachingDiagKind::None:
+        break;
+      case CachingDiagKind::Warning:
+        Diags.Report(diag::remark_compile_job_cache_skipped)
+            << ResultCacheKey->toString();
+        break;
+      case CachingDiagKind::Error:
+        llvm_unreachable("Should not reach here if there is an error");
+    }
   }
+
+  if (Error E =
+          CacheBackend->finishComputedResult(*ResultCacheKey, SkipCache)) {
+    reportCachingBackendError(Clang.getDiagnostics(), std::move(E));
+    return false;
+  }
+  return true;
 }
 
 void CachingOutputs::finishSerializedDiagnostics() {
@@ -672,7 +709,7 @@ void CachingOutputs::finishSerializedDiagnostics() {
 }
 
 Error ObjectStoreCachingOutputs::finishComputedResult(
-    const llvm::cas::CASID &ResultCacheKey) {
+    const llvm::cas::CASID &ResultCacheKey, bool SkipCache) {
   // FIXME: Stop calling report_fatal_error().
   if (!SerialDiagsOutput) {
     // Not requested to get a serialized diagnostics file but we generated it
@@ -710,8 +747,12 @@ Error ObjectStoreCachingOutputs::finishComputedResult(
   Expected<cas::ObjectRef> Result = CachedResultBuilder.build(*CAS);
   if (!Result)
     llvm::report_fatal_error(Result.takeError());
-  if (llvm::Error E = Cache->put(ResultCacheKey, CAS->getID(*Result)))
-    llvm::report_fatal_error(std::move(E));
+
+  // Skip caching if requested.
+  if (!SkipCache) {
+    if (llvm::Error E = Cache->put(ResultCacheKey, CAS->getID(*Result)))
+      llvm::report_fatal_error(std::move(E));
+  }
 
   // Replay / decanonicalize as necessary.
   Optional<int> Status = replayCachedResult(*Result,
@@ -893,7 +934,7 @@ int cc1_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainAddr) {
   }
 
   // Cache the result, and decanonicalize and finish outputs.
-  JobCache.finishComputedResult(*Clang, Success);
+  Success = JobCache.finishComputedResult(*Clang, Success);
 
   // If any timers were active but haven't been destroyed yet, print their
   // results now.  This happens in -disable-free mode.


### PR DESCRIPTION
When caching is enabled but clang encouters one of those date time macro that will make output non deterministic:
* If the output is module/pch, error out.
* if the output is other kind, skip caching so the output is not recorded in ActionCache. Issue a warning and advice how to fix it.

rdar://100224905