### PR TITLE
[llvm-remote-cache-test] Add an option to configure the socket path separately from the cache directory

### DIFF
--- a/clang/test/CAS/lit.local.cfg
+++ b/clang/test/CAS/lit.local.cfg
@@ -26,4 +26,6 @@ if len(config.daemon_temp_dir) < 80:
     # This also needs small path for unix domain socket path.
     if config.enable_remote_cache:
         config.available_features.add('remote-cache-service')
-        config.substitutions.append(('%{remote-cache-dir}', os.path.join(config.daemon_temp_dir, 'rmt')))
+        remote_cache_dir = os.path.join(config.daemon_temp_dir, 'rmt')
+        os.mkdir(remote_cache_dir)
+        config.substitutions.append(('%{remote-cache-dir}', remote_cache_dir))

--- a/clang/test/CAS/remote-cache-service.c
+++ b/clang/test/CAS/remote-cache-service.c
@@ -1,16 +1,15 @@
-// REQUIRES: remote-cache-service, shell
+// REQUIRES: remote-cache-service
 
-// Need a short path for the unix domain socket.
-// RUN: CACHE=%{remote-cache-dir}/$(basename %t)
-// RUN: rm -rf $CACHE && mkdir -p $CACHE
+// Need a short path for the unix domain socket (and unique for this test file).
+// RUN: rm -f %{remote-cache-dir}/%basename_t
 // RUN: rm -rf %t && mkdir -p %t
 
 // Baseline to check we got expected outputs.
 // RUN: %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -MMD -MT dependencies -MF %t/t.d --serialize-diagnostics %t/t.dia
-// RUN: llvm-remote-cache-test -cache-path=$CACHE -- env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN: llvm-remote-cache-test -socket-path=%{remote-cache-dir}/%basename_t -cache-path=%t/cache -- env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t1.o -MMD -MT dependencies -MF %t/t1.d --serialize-diagnostics %t/t1.dia -Rcompile-job-cache \
 // RUN:   2>&1 | FileCheck %s --check-prefix=CACHE-MISS
-// RUN: llvm-remote-cache-test -cache-path=$CACHE -- env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN: llvm-remote-cache-test -socket-path=%{remote-cache-dir}/%basename_t -cache-path=%t/cache -- env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t2.o -MMD -MT dependencies -MF %t/t2.d --serialize-diagnostics %t/t2.dia -Rcompile-job-cache \
 // RUN:   2>&1 | FileCheck %s --check-prefix=CACHE-HIT
 

--- a/llvm/tools/llvm-remote-cache-test/llvm-remote-cache-test.cpp
+++ b/llvm/tools/llvm-remote-cache-test/llvm-remote-cache-test.cpp
@@ -44,6 +44,9 @@ int main(int Argc, const char **Argv) {
   cl::opt<std::string> CachePath("cache-path", cl::desc("Cache data path"),
                                  cl::Required, cl::value_desc("path"),
                                  cl::cat(OptCategory));
+  cl::opt<std::string> OptSocketPath(
+      "socket-path", cl::desc("Socket path (default is '<cache-path>/sock')"),
+      cl::value_desc("path"), cl::cat(OptCategory));
   // This is here only to improve the help message (for "USAGE:" line).
   cl::list<std::string> Inputs(cl::Positional, cl::desc("[-- command ...]"));
 
@@ -55,8 +58,11 @@ int main(int Argc, const char **Argv) {
   cl::HideUnrelatedOptions(OptCategory);
   cl::ParseCommandLineOptions(Sep - Argv, Argv, "llvm-remote-cache-test");
 
-  SmallString<128> SocketPath{CachePath};
-  sys::path::append(SocketPath, "sock");
+  SmallString<128> SocketPath{OptSocketPath};
+  if (SocketPath.empty()) {
+    SocketPath = CachePath;
+    sys::path::append(SocketPath, "sock");
+  }
 
   static ExitOnError ExitOnErr("llvm-remote-cache-test: ");
 


### PR DESCRIPTION
Previously `llvm-remote-cache-test` would only accept one "cache path" option, and it would put both the socket and the cache-related files inside that directory. Part of the service interaction is that the service writes out a temporary file for the requested blob and clang moves the file into place (e.g. for the output object file).

However, in a testing environment the `%{remote-cache-dir}` may be in a different volume than the test output directory, so clang may not be able to move the blob file. To address this add an option to `llvm-remote-cache-test` so that we only put the socket in `%{remote-cache-dir}` and use the test output directory for the service's cache-related files.

(cherry picked from commit 9a81b88dc0058bdf6bfc74d0541b47356cfe5470)