### PR TITLE
[lldb] Add the experimental swift-enable-cxx-interop flag

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -184,6 +184,8 @@ public:
 
   bool GetSwiftEnableBareSlashRegex() const;
 
+  bool GetSwiftEnableCxxInterop() const;
+
   bool GetSwiftAutoImportFrameworks() const;
 
   bool GetEnableAutoImportClangModules() const;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1491,6 +1491,8 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
   swift_ast_sp->GetLanguageOptions().EnableAccessControl = false;
   swift_ast_sp->GetLanguageOptions().EnableTargetOSChecking = false;
 
+  swift_ast_sp->GetLanguageOptions().EnableCXXInterop =
+      Target::GetGlobalProperties().GetSwiftEnableCxxInterop();
   bool found_swift_modules = false;
   SymbolFile *sym_file = module.GetSymbolFile();
 
@@ -1911,7 +1913,8 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   swift_ast_sp->m_is_scratch_context = true;
 
   swift_ast_sp->GetLanguageOptions().EnableTargetOSChecking = false;
-
+  swift_ast_sp->GetLanguageOptions().EnableCXXInterop =
+      target.GetSwiftEnableCxxInterop();
   bool handled_sdk_path = false;
   const size_t num_images = target.GetImages().GetSize();
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4524,6 +4524,19 @@ bool TargetProperties::GetSwiftEnableBareSlashRegex() const {
 
   return true;
 }
+
+bool TargetProperties::GetSwiftEnableCxxInterop() const {
+  const Property *exp_property = m_collection_sp->GetPropertyAtIndex(
+      nullptr, false, ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    return exp_values->GetPropertyAtIndexAsBoolean(
+        nullptr, ePropertySwiftEnableCxxInterop, false);
+
+  return false;
+}
+
 bool TargetProperties::GetSwiftAutoImportFrameworks() const {
   const uint32_t idx = ePropertySwiftAutoImportFrameworks;
   return m_collection_sp->GetPropertyAtIndexAsBoolean(

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -22,6 +22,9 @@ let Definition = "target_experimental" in {
   def SwiftEnableBareSlashRegex: Property<"swift-enable-bare-slash-regex", "Boolean">,
     DefaultFalse,
     Desc<"Passes the -enable-bare-slash-regex compiler flag to the swift compiler.">;
+  def SwiftEnableCxxInterop: Property<"swift-enable-cxx-interop", "Boolean">,
+    DefaultFalse,
+    Desc<"Passes the -enable-cxx-interop flag to the swift compiler.">;
 }
 
 let Definition = "target" in {


### PR DESCRIPTION
Add an experimental flag to turn on C++ interop in lldb.

(cherry picked from commit e90476c1a6cf624f19faa28c4a5dcc075f945338)