### PR TITLE
[clang][cas] Attempt to improve test involving fatal error

### DIFF
--- a/clang/test/CAS/output-path-error.c
+++ b/clang/test/CAS/output-path-error.c
@@ -2,22 +2,21 @@
 
 // REQUIRES: shell
 
-// RUN: rm -rf %t && mkdir -p %t/a
+// RUN: rm -rf %t && mkdir -p %t
 // RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
 
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache -emit-obj %s -o %t/a/output.o 2>&1 \
+// RUN:   -Rcompile-job-cache -emit-obj %s -o %t/output.o 2>&1 \
 // RUN:   | FileCheck %s --allow-empty --check-prefix=CACHE-MISS
 
-// RUN: mkdir %t/b
-// RUN: chmod -w %t/b
+// Remove only the CAS, but leave the ActionCache.
+// RUN: rm -rf %t/cas
 
 // RUN: not %clang -cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache -emit-obj %s -o %t/b/output.o 2>&1 \
-// RUN:   | FileCheck %s --allow-empty --check-prefixes=CACHE-HIT,ERROR
+// RUN:   -Rcompile-job-cache -emit-obj %s -o %t/output.o &> %t/output.txt
+// RUN: cat %t/output.txt | FileCheck %s --check-prefix=ERROR
 
 // CACHE-MISS: remark: compile job cache miss
-// CACHE-HIT: remark: compile job cache hit
-// ERROR: fatal error: error in backend: Permission denied
+// ERROR: fatal error: error in backend: cannot handle unknown compile-job cache key


### PR DESCRIPTION
Get a fatal error from the cas going missing instead of permissions failure. In at least one CI environment the old test wasn't working.

rdar://100736092
(cherry picked from commit 47626df14dc5aace53e9003e5ea515f4415ca5db)