### PR TITLE
[lldb] Remove data formatters for outdated types

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -295,17 +295,6 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
   if (!clang_ast_context)
     return nullptr;
 
-  if (valobj_typename.startswith("Swift._NSSwiftArray")) {
-    CompilerType anyobject_type = clang_ast_context->GetBasicType(
-            lldb::eBasicTypeObjCID);
-    auto handler = std::unique_ptr<SwiftArrayBufferHandler>(
-        new SwiftArrayNativeBufferHandler(valobj, valobj.GetPointerValue(),
-                                          anyobject_type));
-    if (handler && handler->IsValid())
-      return handler;
-    return nullptr;
-  }
-
   // For now we have to keep the old mangled name since the Objc->Swift bindings
   // that are in Foundation don't get the new mangling.
   if (valobj_typename.startswith("_TtCs23_ContiguousArrayStorage") ||

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -549,18 +549,6 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                 "GLKit summary provider", ConstString(GLKitTypes),
                 simd_summary_flags, true);
 
-  TypeSummaryImpl::Flags nil_summary_flags;
-  nil_summary_flags.SetCascades(true)
-      .SetDontShowChildren(true)
-      .SetDontShowValue(true)
-      .SetHideItemNames(false)
-      .SetShowMembersOneLiner(false)
-      .SetSkipPointers(true)
-      .SetSkipReferences(false);
-
-  AddStringSummary(swift_category_sp, "nil", ConstString("Swift._Nil"),
-                   nil_summary_flags);
-
   AddStringSummary(swift_category_sp, "${var.native}",
                    ConstString("CoreGraphics.CGFloat"), summary_flags);
   AddStringSummary(swift_category_sp, "${var.native}",

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -288,10 +288,6 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                 lldb_private::formatters::swift::Array_SummaryProvider,
                 "Swift.Array summary provider",
                 ConstString("^Swift.Array<.+>$"), summary_flags, true);
-  AddCXXSummary(swift_category_sp,
-                lldb_private::formatters::swift::Array_SummaryProvider,
-                "Swift.Array summary provider",
-                ConstString("Swift._NSSwiftArray"), summary_flags, false);
   AddCXXSummary(
       swift_category_sp, lldb_private::formatters::swift::Array_SummaryProvider,
       "Swift.ContiguousArray summary provider",
@@ -341,11 +337,6 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       lldb_private::formatters::swift::ArraySyntheticFrontEndCreator,
       "Swift.Array synthetic children", ConstString("^Swift.Array<.+>$"),
       synth_flags, true);
-  AddCXXSynthetic(
-      swift_category_sp,
-      lldb_private::formatters::swift::ArraySyntheticFrontEndCreator,
-      "Swift.Array synthetic children", ConstString("Swift._NSSwiftArray"),
-      synth_flags, false);
   AddCXXSynthetic(
       swift_category_sp,
       lldb_private::formatters::swift::ArraySyntheticFrontEndCreator,

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -471,8 +471,6 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
 
   // do not move the relative order of these - @unchecked needs to come first or
   // else pain will ensue
-  AddSummary(swift_category_sp, swift_unchecked_optional_summary_sp,
-             ConstString("^Swift.ImplicitlyUnwrappedOptional<.+>$"), true);
   AddSummary(swift_category_sp, swift_optional_summary_sp,
              ConstString("^Swift.Optional<.+>$"), true);
 
@@ -486,12 +484,6 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   AddSummary(swift_category_sp, swift_optional_summary_sp, ConstString("()?"),
              false);
 
-  AddCXXSynthetic(swift_category_sp,
-                  lldb_private::formatters::swift::
-                      SwiftUncheckedOptionalSyntheticFrontEndCreator,
-                  "Swift.Optional synthetic children",
-                  ConstString("^Swift.ImplicitlyUnwrappedOptional<.+>$"),
-                  optional_synth_flags, true);
   AddCXXSynthetic(
       swift_category_sp,
       lldb_private::formatters::swift::SwiftOptionalSyntheticFrontEndCreator,


### PR DESCRIPTION
Remove data formatters for old types: `ImplicitlyUnwrappedOptional` (unavailable), `_NSSwiftArray` (renamed), and `_Nil` (deleted).

This is a cleanup, these have not need of use in some time. See each commit for a reference to the commit where they were removed/renamed/etc.

rdar://82653050