### PR TITLE
Fix cyclic dependency between MC and DebugInfoDWARF when building clang with modules enabled

### DIFF
--- a/clang/tools/driver/NullRemoteCache/CMakeLists.txt
+++ b/clang/tools/driver/NullRemoteCache/CMakeLists.txt
@@ -1,5 +1,4 @@
 # Create an object library instead of a whole static archive.
-add_library(clangNullRemoteCache OBJECT EXCLUDE_FROM_ALL
+add_clang_library(clangNullRemoteCache
   NullClient.cpp
 )
-llvm_update_compile_flags(clangNullRemoteCache)

--- a/llvm/lib/MC/MCCASObjectV1.cpp
+++ b/llvm/lib/MC/MCCASObjectV1.cpp
@@ -11,6 +11,11 @@
 #include "llvm/BinaryFormat/MachO.h"
 #include "llvm/CAS/CASID.h"
 #include "llvm/CAS/ObjectStore.h"
+#include "llvm/DebugInfo/DWARF/DWARFCompileUnit.h"
+#include "llvm/DebugInfo/DWARF/DWARFContext.h"
+#include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
+#include "llvm/DebugInfo/DWARF/DWARFDebugAbbrev.h"
+#include "llvm/DebugInfo/DWARF/DWARFDebugLine.h"
 #include "llvm/MC/MCAsmBackend.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCObjectFileInfo.h"
@@ -66,6 +71,69 @@ cl::opt<RelEncodeLoc> RelocLocation(
     cl::values(clEnumVal(Atom, "In atom"), clEnumVal(Section, "In section"),
                clEnumVal(CompileUnit, "In compile unit")),
     cl::init(Atom));
+
+template <> struct DenseMapInfo<llvm::dwarf::Form> {
+  static llvm::dwarf::Form getEmptyKey() {
+    return static_cast<llvm::dwarf::Form>(
+        DenseMapInfo<uint16_t>::getEmptyKey());
+  }
+
+  static llvm::dwarf::Form getTombstoneKey() {
+    return static_cast<llvm::dwarf::Form>(
+        DenseMapInfo<uint16_t>::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const llvm::dwarf::Form &OVal) {
+    return DenseMapInfo<uint16_t>::getHashValue(OVal);
+  }
+
+  static bool isEqual(const llvm::dwarf::Form &LHS,
+                      const llvm::dwarf::Form &RHS) {
+    return LHS == RHS;
+  }
+};
+
+/// A DWARFObject implementation that can be used to dwarfdump CAS-formatted
+/// debug info.
+class InMemoryCASDWARFObject : public DWARFObject {
+  ArrayRef<char> DebugAbbrevSection;
+  bool IsLittleEndian;
+
+public:
+  InMemoryCASDWARFObject(ArrayRef<char> AbbrevContents, bool IsLittleEndian)
+      : DebugAbbrevSection(AbbrevContents), IsLittleEndian(IsLittleEndian) {}
+  bool isLittleEndian() const override { return IsLittleEndian; }
+
+  StringRef getAbbrevSection() const override {
+    return toStringRef(DebugAbbrevSection);
+  }
+
+  Optional<RelocAddrEntry> find(const DWARFSection &Sec,
+                                uint64_t Pos) const override {
+    return {};
+  }
+
+  /// This struct represents the Data in one Compile Unit. The DistinctData is
+  /// the data that doesn't deduplicate and must be stored separately, the
+  /// DebugInfoRefData is the data that is stored in one DebugInfoCURef cas
+  /// object and will deduplicate for a link ODR function.
+  struct PartitionedDebugInfoSection {
+    SmallVector<char, 0> DebugInfoCURefData;
+    SmallVector<char, 0> DistinctData;
+    constexpr static std::array FormsToPartition{
+        llvm::dwarf::Form::DW_FORM_strp, llvm::dwarf::Form::DW_FORM_sec_offset};
+  };
+
+  /// Create a DwarfCompileUnit that represents the compile unit at \p CUOffset
+  /// in the debug info section, and iterate over the individual DIEs to
+  /// identify and separate the Forms that do not deduplicate in
+  /// PartitionedDebugInfoSection::FormsToPartition and those that do
+  /// deduplicate. Store both kinds of Forms in their own buffers per compile
+  /// unit.
+  Expected<PartitionedDebugInfoSection>
+  splitUpCUData(ArrayRef<char> DebugInfoData, uint64_t AbbrevOffset,
+                uint64_t CUOffset, DWARFContext *Ctx);
+};
 
 struct CUInfo {
   size_t CUSize;

--- a/llvm/lib/MC/MCCASObjectV1.cpp
+++ b/llvm/lib/MC/MCCASObjectV1.cpp
@@ -72,7 +72,7 @@ cl::opt<RelEncodeLoc> RelocLocation(
                clEnumVal(CompileUnit, "In compile unit")),
     cl::init(Atom));
 
-template <> struct DenseMapInfo<llvm::dwarf::Form> {
+template <> struct llvm::DenseMapInfo<llvm::dwarf::Form> {
   static llvm::dwarf::Form getEmptyKey() {
     return static_cast<llvm::dwarf::Form>(
         DenseMapInfo<uint16_t>::getEmptyKey());

--- a/llvm/tools/llvm-cas-dump/CASDWARFObject.h
+++ b/llvm/tools/llvm-cas-dump/CASDWARFObject.h
@@ -9,6 +9,11 @@
 #ifndef LLVM_TOOLS_LLVM_CAS_DUMP_CASDWARFOBJECT_H
 #define LLVM_TOOLS_LLVM_CAS_DUMP_CASDWARFOBJECT_H
 
+#include "llvm/DebugInfo/DWARF/DWARFCompileUnit.h"
+#include "llvm/DebugInfo/DWARF/DWARFContext.h"
+#include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
+#include "llvm/DebugInfo/DWARF/DWARFDebugAbbrev.h"
+#include "llvm/DebugInfo/DWARF/DWARFDebugLine.h"
 #include "llvm/DebugInfo/DWARF/DWARFObject.h"
 #include "llvm/MC/CAS/MCCASObjectV1.h"
 


### PR DESCRIPTION
When building with clang modules enabled we see the error:

/Volumes/Data/llvm-cas/llvm/include/llvm/Object/Wasm.h:23:10: fatal error: cyclic dependency in module 'LLVM_MC': LLVM_MC -> LLVM_DebugInfo_DWARF -> LLVM_DebugInfo -> LLVM_Object -> LLVM_MC
#include "llvm/MC/MCSymbolWasm.h"

To fix this we just need to remove the DwbugInfoDWARF header includes from the header files. This change does that.

We also see an error in building Clang_Basic:

/Users/shubham/Development/llvm-project-cas/llvm-project/clang/tools/driver/NullRemoteCache/NullClient.cpp
While building module 'Clang_Basic' imported from /Users/shubham/Development/llvm-project-cas/llvm-project/clang/tools/driver/NullRemoteCache/../RemoteCache/Client.h:17:
In file included from <module-includes>:4:
/Users/shubham/Development/llvm-project-cas/llvm-project/clang/include/clang/Basic/AttrKinds.h:27:10: fatal error: 'clang/Basic/AttrList.inc' file not found
#include "clang/Basic/AttrList.inc"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /Users/shubham/Development/llvm-project-cas/llvm-project/clang/tools/driver/NullRemoteCache/NullClient.cpp:14:
/Users/shubham/Development/llvm-project-cas/llvm-project/clang/tools/driver/NullRemoteCache/../RemoteCache/Client.h:17:10: fatal error: could not build module 'Clang_Basic'
#include "clang/Basic/LLVM.h"
 ~~~~~~~~^~~~~~~~~~~~~~~~~~~~
2 errors generated.

This PR fixes that too