### PR TITLE
[clang] initialize type qualifiers for FunctionNoProtoType

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -3957,7 +3957,10 @@ protected:
   }
 
   Qualifiers getFastTypeQuals() const {
-    return Qualifiers::fromFastMask(FunctionTypeBits.FastTypeQuals);
+    if (isFunctionProtoType())
+      return Qualifiers::fromFastMask(FunctionTypeBits.FastTypeQuals);
+
+    return Qualifiers();
   }
 
 public:

--- a/clang/unittests/AST/DeclTest.cpp
+++ b/clang/unittests/AST/DeclTest.cpp
@@ -292,3 +292,25 @@ TEST(Decl, ModuleAndInternalLinkage) {
   EXPECT_EQ(b->getLinkageInternal(), ModuleLinkage);
   EXPECT_EQ(g->getLinkageInternal(), ModuleLinkage);
 }
+
+TEST(Decl, NoProtoFunctionDeclAttributes) {
+  llvm::Annotations Code(R"(
+    void f();
+    )");
+
+  auto AST = tooling::buildASTFromCodeWithArgs(
+      Code.code(),
+      /*Args=*/{"-target", "i386-apple-darwin", "-x", "objective-c",
+                "-std=c89"});
+  ASTContext &Ctx = AST->getASTContext();
+
+  auto *f = selectFirst<FunctionDecl>(
+      "f", match(functionDecl(hasName("f")).bind("f"), Ctx));
+
+  const auto *FPT = f->getType()->getAs<FunctionNoProtoType>();
+
+  // Functions without prototypes always have 0 initialized qualifiers
+  EXPECT_FALSE(FPT->isConst());
+  EXPECT_FALSE(FPT->isVolatile());
+  EXPECT_FALSE(FPT->isRestrict());
+}


### PR DESCRIPTION
When initializing FunctionNoProtoType types, zero out the type qualifiers. This will ensure the ODR hash remains stable as it hashes the values for these qualifiers for all function types.

Reviewed By: aaron.ballman

Differential Revision: https://reviews.llvm.org/D133586

(cherry picked from commit 1f451a8bd6f32465b6ff26c30ba7fb6fc7e0e689)