### PR TITLE
[libclang] Refer to CXErrorCode with enum tag in Dependencies.h

### DIFF
--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -263,7 +263,7 @@ clang_experimental_DependencyScannerWorker_getFileDependencies_v3(
  * See \c clang_experimental_DependencyScannerWorker_getFileDependencies_v5.
  * Returns diagnostics in an unstructured CXString instead of CXDiagnosticSet.
  */
-CINDEX_LINKAGE CXErrorCode
+CINDEX_LINKAGE enum CXErrorCode
 clang_experimental_DependencyScannerWorker_getFileDependencies_v4(
     CXDependencyScannerWorker Worker, int argc, const char *const *argv,
     const char *ModuleName, const char *WorkingDirectory, void *MDCContext,
@@ -307,7 +307,7 @@ clang_experimental_DependencyScannerWorker_getFileDependencies_v4(
  * \returns \c CXError_Success on success; otherwise a non-zero \c CXErrorCode
  * indicating the kind of error.
  */
-CINDEX_LINKAGE CXErrorCode
+CINDEX_LINKAGE enum CXErrorCode
 clang_experimental_DependencyScannerWorker_getFileDependencies_v5(
     CXDependencyScannerWorker Worker, int argc, const char *const *argv,
     const char *ModuleName, const char *WorkingDirectory, void *MDCContext,


### PR DESCRIPTION
The missing enum tag could cause failures building the Clang_C module.