### PR TITLE
[stable/20220421] [libclang] Refer to CXErrorCode with enum tag in Dependencies.h

### DIFF
--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -293,7 +293,7 @@ clang_experimental_DependencyScannerWorker_getFileDependencies_v3(
  * \returns \c CXError_Success on success; otherwise a non-zero \c CXErrorCode
  * indicating the kind of error.
  */
-CINDEX_LINKAGE CXErrorCode
+CINDEX_LINKAGE enum CXErrorCode
 clang_experimental_DependencyScannerWorker_getFileDependencies_v4(
     CXDependencyScannerWorker Worker, int argc, const char *const *argv,
     const char *ModuleName, const char *WorkingDirectory, void *MDCContext,


### PR DESCRIPTION
The missing enum tag could cause failures building the Clang_C module.

(cherry picked from commit 2107919589921fcf2e2d6cf32dcb4da72d104848)
Cherry-picked from #5417 