### PR TITLE
Allow DynamicLoaderDarwinKernel to activate without binary

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -152,7 +152,8 @@ DynamicLoader *DynamicLoaderDarwinKernel::CreateInstance(Process *process,
   if (!force) {
     // If the user provided an executable binary and it is not a kernel, this
     // plugin should not create an instance.
-    if (!is_kernel(process->GetTarget().GetExecutableModulePointer()))
+    Module *exec = process->GetTarget().GetExecutableModulePointer();
+    if (exec && !is_kernel(exec))
       return nullptr;
 
     // If the target's architecture does not look like an Apple environment,


### PR DESCRIPTION
Allow DynamicLoaderDarwinKernel to activate without binary

In https://reviews.llvm.org/D133534 I made a little cleanup to DynamicLoaderDarwinKernel::CreateInstance and unintentionally changed the logic.  Previously it would not create an instance if there was a binary given to lldb and it was not a kernel. With my change, the absence of any binary would also cause it to not create.  So connecting to a kernel without any binaries would fail.

rdar://100985097
(cherry picked from commit b8a8c2d47a38ba08012fe9cbb28169a1e0f7be2a)