### PR TITLE
[lldb] Rename `TypeKind::SequenceArchetype` to `TypeKind::PackArchetype`.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5231,7 +5231,7 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
   case swift::TypeKind::SILFunction:
   case swift::TypeKind::SILMoveOnlyWrapped:
   case swift::TypeKind::SILToken:
-  case swift::TypeKind::SequenceArchetype:
+  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::Unresolved:
   case swift::TypeKind::VariadicSequence:
@@ -5368,7 +5368,7 @@ lldb::TypeClass SwiftASTContext::GetTypeClass(opaque_compiler_type_t type) {
   case swift::TypeKind::SILBox:
   case swift::TypeKind::SILMoveOnlyWrapped:
   case swift::TypeKind::SILToken:
-  case swift::TypeKind::SequenceArchetype:
+  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::Unresolved:
   case swift::TypeKind::VariadicSequence:
     assert(false && "Internal compiler type");
@@ -5860,7 +5860,7 @@ lldb::Encoding SwiftASTContext::GetEncoding(opaque_compiler_type_t type,
   case swift::TypeKind::SILMoveOnlyWrapped:
   case swift::TypeKind::SILFunction:
   case swift::TypeKind::SILToken:
-  case swift::TypeKind::SequenceArchetype:
+  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::Unresolved:
   case swift::TypeKind::VariadicSequence:
@@ -5960,7 +5960,7 @@ uint32_t SwiftASTContext::GetNumChildren(opaque_compiler_type_t type,
   case swift::TypeKind::SILMoveOnlyWrapped:
   case swift::TypeKind::SILFunction:
   case swift::TypeKind::SILToken:
-  case swift::TypeKind::SequenceArchetype:
+  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::Unresolved:
   case swift::TypeKind::VariadicSequence:
@@ -6096,7 +6096,7 @@ uint32_t SwiftASTContext::GetNumFields(opaque_compiler_type_t type,
   case swift::TypeKind::SILMoveOnlyWrapped:
   case swift::TypeKind::SILFunction:
   case swift::TypeKind::SILToken:
-  case swift::TypeKind::SequenceArchetype:
+  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::Unresolved:
   case swift::TypeKind::VariadicSequence:
@@ -6324,7 +6324,7 @@ CompilerType SwiftASTContext::GetFieldAtIndex(opaque_compiler_type_t type,
   case swift::TypeKind::SILMoveOnlyWrapped:
   case swift::TypeKind::SILFunction:
   case swift::TypeKind::SILToken:
-  case swift::TypeKind::SequenceArchetype:
+  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::Unresolved:
   case swift::TypeKind::VariadicSequence:
@@ -6510,7 +6510,7 @@ uint32_t SwiftASTContext::GetNumPointeeChildren(opaque_compiler_type_t type) {
   case swift::TypeKind::SILMoveOnlyWrapped:
   case swift::TypeKind::SILFunction:
   case swift::TypeKind::SILToken:
-  case swift::TypeKind::SequenceArchetype:
+  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::Unresolved:
   case swift::TypeKind::VariadicSequence:
@@ -6696,7 +6696,7 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
   case swift::TypeKind::SILMoveOnlyWrapped:
   case swift::TypeKind::SILFunction:
   case swift::TypeKind::SILToken:
-  case swift::TypeKind::SequenceArchetype:
+  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::Unresolved:
   case swift::TypeKind::VariadicSequence:
@@ -7003,7 +7003,7 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
     case swift::TypeKind::SILMoveOnlyWrapped:
     case swift::TypeKind::SILFunction:
     case swift::TypeKind::SILToken:
-    case swift::TypeKind::SequenceArchetype:
+    case swift::TypeKind::PackArchetype:
     case swift::TypeKind::TypeVariable:
     case swift::TypeKind::Unresolved:
     case swift::TypeKind::VariadicSequence:
@@ -7384,7 +7384,7 @@ bool SwiftASTContext::DumpTypeValue(
   case swift::TypeKind::SILMoveOnlyWrapped:
   case swift::TypeKind::SILFunction:
   case swift::TypeKind::SILToken:
-  case swift::TypeKind::SequenceArchetype:
+  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::Unresolved:
   case swift::TypeKind::VariadicSequence:


### PR DESCRIPTION
To match the corresponding Swift change here: https://github.com/apple/swift/pull/61537