### PR TITLE
[CMake] Fix FindGRPC cmake module to allow different layering

### DIFF
--- a/clang-tools-extra/clangd/CMakeLists.txt
+++ b/clang-tools-extra/clangd/CMakeLists.txt
@@ -194,7 +194,7 @@ if ( CLANGD_BUILD_XPC )
 endif ()
 
 if (CLANGD_ENABLE_REMOTE)
-  include(FindGRPC)
+  include(AddGRPC)
 endif()
 
 if(CLANG_INCLUDE_TESTS)

--- a/clang-tools-extra/clangd/index/remote/CMakeLists.txt
+++ b/clang-tools-extra/clangd/index/remote/CMakeLists.txt
@@ -1,8 +1,8 @@
 if (CLANGD_ENABLE_REMOTE)
-  generate_protos(clangdRemoteIndexProto "Index.proto")
-  generate_protos(clangdMonitoringServiceProto "MonitoringService.proto"
+  generate_clang_protos_library(clangdRemoteIndexProto "Index.proto")
+  generate_clang_protos_library(clangdMonitoringServiceProto "MonitoringService.proto"
     GRPC)
-  generate_protos(clangdRemoteIndexServiceProto "Service.proto"
+  generate_clang_protos_library(clangdRemoteIndexServiceProto "Service.proto"
     DEPENDS "Index.proto"
     GRPC)
   # FIXME: Move this into generate_protos. Currently we only mention proto

--- a/clang/cmake/modules/AddGRPC.cmake
+++ b/clang/cmake/modules/AddGRPC.cmake
@@ -1,0 +1,11 @@
+include(FindGRPC)
+
+function(generate_clang_protos_library LibraryName ProtoFile)
+  # Take the first two args and forward the remaining to generate_proto_sources.
+  cmake_parse_arguments(PARSE_ARGV 2 PROTO "" "" "")
+  generate_proto_sources(ProtoSource ${ProtoFile} ${PROTO_UNPARSED_ARGUMENTS})
+
+  add_clang_library(${LibraryName} ${ProtoSource}
+    PARTIAL_SOURCES_INTENDED
+    LINK_LIBS PUBLIC grpc++ protobuf)
+endfunction()

--- a/cmake/Modules/FindGRPC.cmake
+++ b/cmake/Modules/FindGRPC.cmake
@@ -112,7 +112,7 @@ endif()
 # If the "GRPC" argument is given, services are also generated.
 # The DEPENDS list should name *.proto source files that are imported.
 # They may be relative to the source dir or absolute (for generated protos).
-function(generate_protos LibraryName ProtoFile)
+function(generate_proto_sources GeneratedSource ProtoFile)
   cmake_parse_arguments(PARSE_ARGV 2 PROTO "GRPC" "" "DEPENDS")
   get_filename_component(ProtoSourceAbsolutePath "${CMAKE_CURRENT_SOURCE_DIR}/${ProtoFile}" ABSOLUTE)
   get_filename_component(ProtoSourcePath ${ProtoSourceAbsolutePath} PATH)
@@ -136,9 +136,7 @@ function(generate_protos LibraryName ProtoFile)
         ARGS ${Flags} "${ProtoSourceAbsolutePath}"
         DEPENDS "${ProtoSourceAbsolutePath}")
 
-  add_llvm_library(${LibraryName} ${GeneratedProtoSource}
-    PARTIAL_SOURCES_INTENDED
-    LINK_LIBS PUBLIC grpc++ gpr protobuf)
+  set(${GeneratedSource} ${GeneratedProtoSource} PARENT_SCOPE)
 
   # Ensure dependency headers are generated before dependent protos are built.
   # DEPENDS arg is a list of "Foo.proto". While they're logically relative to

--- a/llvm/lib/RemoteCachingService/RemoteCacheProto/CMakeLists.txt
+++ b/llvm/lib/RemoteCachingService/RemoteCacheProto/CMakeLists.txt
@@ -1,3 +1,13 @@
-generate_protos(LLVMRemoteCacheKVProto "compilation_caching_kv.proto" GRPC)
-generate_protos(LLVMRemoteCacheCASProto "compilation_caching_cas.proto" GRPC)
+function(generate_llvm_protos_library LibraryName ProtoFile)
+  # Take the first two args and forward the remaining to generate_proto_sources.
+  cmake_parse_arguments(PARSE_ARGV 2 PROTO "" "" "")
+  generate_proto_sources(ProtoSource ${ProtoFile} ${PROTO_UNPARSED_ARGUMENTS})
+
+  add_llvm_library(${LibraryName} ${ProtoSource}
+    PARTIAL_SOURCES_INTENDED
+    LINK_LIBS PUBLIC grpc++ gpr protobuf)
+endfunction()
+
+generate_llvm_protos_library(LLVMRemoteCacheKVProto "compilation_caching_kv.proto" GRPC)
+generate_llvm_protos_library(LLVMRemoteCacheCASProto "compilation_caching_cas.proto" GRPC)
 


### PR DESCRIPTION
Take the library target out of `generate_protos` function so the caller can decide where to layer the library using the source generated from the function. Use `add_llvm_protos_library` and
`add_clang_protos_library` to decide which layer is the library exported.

Fixes: https://github.com/llvm/llvm-project/issues/58075

Differential Revision: https://reviews.llvm.org/D135712