### PR TITLE
PlatformDarwinKernel calls the ctor directly, not setting no-jit

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -186,7 +186,6 @@ DynamicLoader *DynamicLoaderDarwinKernel::CreateInstance(Process *process,
   // the kernel load address, we need to look around in memory to find it.
   const addr_t kernel_load_address = SearchForDarwinKernel(process);
   if (CheckForKernelImageAtAddress(kernel_load_address, process).IsValid()) {
-    process->SetCanRunCode(false);
     return new DynamicLoaderDarwinKernel(process, kernel_load_address);
   }
   return nullptr;
@@ -509,6 +508,7 @@ DynamicLoaderDarwinKernel::DynamicLoaderDarwinKernel(Process *process,
       m_kext_summary_header(), m_known_kexts(), m_mutex(),
       m_break_id(LLDB_INVALID_BREAK_ID) {
   Status error;
+  process->SetCanRunCode(false);
   PlatformSP platform_sp =
       process->GetTarget().GetDebugger().GetPlatformList().Create(
           PlatformDarwinKernel::GetPluginNameStatic());


### PR DESCRIPTION
PlatformDarwinKernel calls the ctor directly, not setting no-jit

Fix a small thinko in https://reviews.llvm.org/D133534 .  Normally DynamicLoaderDarwinKernels are created via the CreateInstance plugin method, and that plugin method sets the Process CanJIT to false. In the above patch, I added a new code path that can call the DynamicLoaderDarwinKernel ctor directly, without going through CreateInstance, and CanJIT was not being correctly set for the process.

rdar://101148552
(cherry picked from commit 3d8d9c9884db2b2a0fbd518990019b24de6f72d8)