### PR TITLE
[Attributes] Improve writing `ExprArgument` value.

### DIFF
--- a/clang/test/SemaCXX/attr-print.cpp
+++ b/clang/test/SemaCXX/attr-print.cpp
@@ -43,3 +43,6 @@ class __multiple_inheritance MultipleInheritance;
 
 // CHECK: class __virtual_inheritance VirtualInheritance;
 class __virtual_inheritance VirtualInheritance;
+
+// CHECK: typedef double *aligned_double __attribute__((align_value(64)));
+typedef double * __attribute__((align_value(64))) aligned_double;

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -1173,6 +1173,13 @@ namespace {
       OS << "      }\n";
     }
 
+    void writeValue(raw_ostream &OS) const override {
+      OS << "\";\n";
+      OS << "    get" << getUpperName()
+         << "()->printPretty(OS, nullptr, Policy);\n";
+      OS << "    OS << \"";
+    }
+
     void writeDump(raw_ostream &OS) const override {}
 
     void writeDumpChildren(raw_ostream &OS) const override {


### PR DESCRIPTION
Instead of dumping `Expr*` memory address, output `Expr` representation.

Differential Revision: https://reviews.llvm.org/D135931

(cherry picked from commit 1783253c41f1b0ac378ab7fa4b6fe5547369c6b0)