### PR TITLE
[clang][modules] Serialize non-affecting input files

### DIFF
--- a/clang-tools-extra/clang-tidy/ExpandModularHeadersPPCallbacks.cpp
+++ b/clang-tools-extra/clang-tidy/ExpandModularHeadersPPCallbacks.cpp
@@ -121,7 +121,8 @@ void ExpandModularHeadersPPCallbacks::handleModuleFile(
   // contents later.
   Compiler.getASTReader()->visitInputFiles(
       *MF, true, false,
-      [this](const serialization::InputFile &IF, bool /*IsSystem*/) {
+      [this](const serialization::InputFile &IF, bool /*IsSystem*/,
+             bool /*IsAffecting*/) {
         Recorder->addNecessaryFile(IF.getFile());
       });
   // Recursively handle all transitively imported modules.

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -1243,18 +1243,8 @@ private:
   /// Reads a statement from the specified cursor.
   Stmt *ReadStmtFromStream(ModuleFile &F);
 
-  struct InputFileInfo {
-    std::string Filename;
-    uint64_t ContentHash;
-    off_t StoredSize;
-    time_t StoredTime;
-    bool Overridden;
-    bool Transient;
-    bool TopLevelModuleMap;
-  };
-
-  /// Reads the stored information about an input file.
-  InputFileInfo readInputFileInfo(ModuleFile &F, unsigned ID);
+  /// Retrieve the stored information about an input file.
+  serialization::InputFileInfo getInputFileInfo(ModuleFile &F, unsigned ID);
 
   /// Retrieve the file entry and 'overridden' bit for an input
   /// file in the given module file.

--- a/clang/include/clang/Serialization/ASTWriter.h
+++ b/clang/include/clang/Serialization/ASTWriter.h
@@ -444,9 +444,6 @@ private:
   std::vector<std::unique_ptr<ModuleFileExtensionWriter>>
       ModuleFileExtensionWriters;
 
-  /// User ModuleMaps skipped when writing control block.
-  std::set<const FileEntry *> SkippedModuleMaps;
-
   /// Retrieve or create a submodule ID for this module.
   unsigned getSubmoduleID(Module *Mod);
 

--- a/clang/include/clang/Serialization/ModuleFile.h
+++ b/clang/include/clang/Serialization/ModuleFile.h
@@ -59,6 +59,17 @@ enum ModuleKind {
   MK_PrebuiltModule
 };
 
+/// The input file info that has been loaded from an AST file.
+struct InputFileInfo {
+  std::string Filename;
+  uint64_t ContentHash;
+  off_t StoredSize;
+  time_t StoredTime;
+  bool Overridden;
+  bool Transient;
+  bool TopLevelModuleMap;
+};
+
 /// The input file that has been loaded from this AST file, along with
 /// bools indicating whether this was an overridden buffer or if it was
 /// out-of-date or not-found.
@@ -237,6 +248,9 @@ public:
 
   /// The input files that have been loaded from this AST file.
   std::vector<InputFile> InputFilesLoaded;
+
+  /// The input file infos that have been loaded from this AST file.
+  std::vector<InputFileInfo> InputFileInfosLoaded;
 
   // All user input files reside at the index range [0, NumUserInputFiles), and
   // system input files reside at [NumUserInputFiles, InputFilesLoaded.size()).

--- a/clang/include/clang/Serialization/ModuleFile.h
+++ b/clang/include/clang/Serialization/ModuleFile.h
@@ -68,6 +68,7 @@ struct InputFileInfo {
   bool Overridden;
   bool Transient;
   bool TopLevelModuleMap;
+  bool Affecting;
 };
 
 /// The input file that has been loaded from this AST file, along with

--- a/clang/lib/Frontend/DependencyFile.cpp
+++ b/clang/lib/Frontend/DependencyFile.cpp
@@ -151,8 +151,8 @@ struct DepCollectorASTListener : public ASTReaderListener {
                                    /*IsSystem*/false, /*IsModuleFile*/true,
                                    /*IsMissing*/false);
   }
-  bool visitInputFile(StringRef Filename, bool IsSystem,
-                      bool IsOverridden, bool IsExplicitModule) override {
+  bool visitInputFile(StringRef Filename, bool IsSystem, bool IsOverridden,
+                      bool IsAffecting, bool IsExplicitModule) override {
     if (IsOverridden || IsExplicitModule)
       return true;
 

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -644,7 +644,7 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
           CI.getFrontendOpts().ModuleFiles.push_back(MF.FileName);
 
       ASTReader->visitTopLevelModuleMaps(
-          PrimaryModule, [&](const FileEntry *FE) {
+          PrimaryModule, [&](const FileEntry *FE, bool) {
             CI.getFrontendOpts().ModuleMapFiles.push_back(
                 std::string(FE->getName()));
           });

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -779,19 +779,24 @@ namespace {
     ///
     /// \returns true to continue receiving the next input file, false to stop.
     bool visitInputFile(StringRef Filename, bool isSystem,
-                        bool isOverridden, bool isExplicitModule) override {
+                        bool isOverridden, bool isAffecting, bool isExplicitModule) override {
 
       Out.indent(2) << "Input file: " << Filename;
 
-      if (isSystem || isOverridden || isExplicitModule) {
+      if (isSystem || isOverridden || isAffecting || isExplicitModule) {
         Out << " [";
         if (isSystem) {
           Out << "System";
-          if (isOverridden || isExplicitModule)
+          if (isOverridden || isAffecting || isExplicitModule)
             Out << ", ";
         }
         if (isOverridden) {
           Out << "Overridden";
+          if (isAffecting || isExplicitModule)
+            Out << ", ";
+        }
+        if (isAffecting) {
+          Out << "Affecting";
           if (isExplicitModule)
             Out << ", ";
         }

--- a/clang/lib/Frontend/ModuleDependencyCollector.cpp
+++ b/clang/lib/Frontend/ModuleDependencyCollector.cpp
@@ -32,8 +32,9 @@ public:
   bool needsInputFileVisitation() override { return true; }
   bool needsSystemInputFileVisitation() override { return true; }
   bool visitInputFile(StringRef Filename, bool IsSystem, bool IsOverridden,
-                      bool IsExplicitModule) override {
-    Collector.addFile(Filename);
+                      bool IsAffecting, bool IsExplicitModule) override {
+    if (IsAffecting)
+      Collector.addFile(Filename);
     return true;
   }
 };

--- a/clang/lib/Index/IndexingAction.cpp
+++ b/clang/lib/Index/IndexingAction.cpp
@@ -909,7 +909,7 @@ public:
     Reader->visitInputFiles(
         ModFile, RecordOpts.RecordSystemDependencies,
         /*Complain=*/false,
-        [&](const serialization::InputFile &IF, bool isSystem) {
+        [&](const serialization::InputFile &IF, bool isSystem, bool) {
           auto FE = IF.getFile();
           if (!FE)
             return;

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -2242,8 +2242,15 @@ bool ASTReader::shouldDisableValidationForFile(
   return false;
 }
 
-ASTReader::InputFileInfo
-ASTReader::readInputFileInfo(ModuleFile &F, unsigned ID) {
+InputFileInfo ASTReader::getInputFileInfo(ModuleFile &F, unsigned ID) {
+  // If this ID is bogus, just return an empty input file.
+  if (ID == 0 || ID > F.InputFileInfosLoaded.size())
+    return InputFileInfo();
+
+  // If we've already loaded this input file, return it.
+  if (!F.InputFileInfosLoaded[ID - 1].Filename.empty())
+    return F.InputFileInfosLoaded[ID - 1];
+
   // Go find this input file.
   BitstreamCursor &Cursor = F.InputFilesCursor;
   SavedStreamPosition SavedPosition(Cursor);
@@ -2296,6 +2303,9 @@ ASTReader::readInputFileInfo(ModuleFile &F, unsigned ID) {
   }
   R.ContentHash = (static_cast<uint64_t>(Record[1]) << 32) |
                   static_cast<uint64_t>(Record[0]);
+
+  // Note that we've loaded this input file info.
+  F.InputFileInfosLoaded[ID - 1] = R;
   return R;
 }
 
@@ -2320,7 +2330,7 @@ InputFile ASTReader::getInputFile(ModuleFile &F, unsigned ID, bool Complain) {
     consumeError(std::move(Err));
   }
 
-  InputFileInfo FI = readInputFileInfo(F, ID);
+  InputFileInfo FI = getInputFileInfo(F, ID);
   off_t StoredSize = FI.StoredSize;
   time_t StoredTime = FI.StoredTime;
   bool Overridden = FI.Overridden;
@@ -2663,7 +2673,7 @@ ASTReader::ReadControlBlock(ModuleFile &F,
                                                                 : NumUserInputs;
         for (unsigned I = 0; I < N; ++I) {
           bool IsSystem = I >= NumUserInputs;
-          InputFileInfo FI = readInputFileInfo(F, I+1);
+          InputFileInfo FI = getInputFileInfo(F, I + 1);
           Listener->visitInputFile(FI.Filename, IsSystem, FI.Overridden,
                                    F.Kind == MK_ExplicitModule ||
                                    F.Kind == MK_PrebuiltModule);
@@ -2955,6 +2965,7 @@ ASTReader::ReadControlBlock(ModuleFile &F,
       F.InputFileOffsets =
           (const llvm::support::unaligned_uint64_t *)Blob.data();
       F.InputFilesLoaded.resize(NumInputs);
+      F.InputFileInfosLoaded.resize(NumInputs);
       F.NumUserInputFiles = NumUserInputs;
       break;
 
@@ -2974,7 +2985,7 @@ void ASTReader::readIncludedFiles(ModuleFile &F, StringRef Blob,
 
   for (unsigned I = 0; I < FileCount; ++I) {
     size_t ID = endian::readNext<uint32_t, little, unaligned>(D);
-    InputFileInfo IFI = readInputFileInfo(F, ID);
+    InputFileInfo IFI = getInputFileInfo(F, ID);
     if (llvm::ErrorOr<const FileEntry *> File =
             PP.getFileManager().getFile(IFI.Filename))
       PP.getIncludedFiles().insert(*File);
@@ -9212,9 +9223,8 @@ void ASTReader::visitTopLevelModuleMaps(
     llvm::function_ref<void(const FileEntry *FE)> Visitor) {
   unsigned NumInputs = MF.InputFilesLoaded.size();
   for (unsigned I = 0; I < NumInputs; ++I) {
-    InputFileInfo IFI = readInputFileInfo(MF, I + 1);
+    InputFileInfo IFI = getInputFileInfo(MF, I + 1);
     if (IFI.TopLevelModuleMap)
-      // FIXME: This unnecessarily re-reads the InputFileInfo.
       if (auto FE = getInputFile(MF, I + 1).getFile())
         Visitor(FE);
   }

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -84,7 +84,7 @@ public:
   }
 
   bool visitInputFile(StringRef Filename, bool isSystem, bool isOverridden,
-                      bool isExplicitModule) override {
+                      bool isAffecting, bool isExplicitModule) override {
     InputFiles.insert(Filename);
     return true;
   }

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -431,7 +431,10 @@ ModuleID ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
       MDC.ScanInstance.getASTReader()->getModuleManager().lookup(
           M->getASTFile());
   MDC.ScanInstance.getASTReader()->visitInputFiles(
-      *MF, true, true, [&](const serialization::InputFile &IF, bool isSystem) {
+      *MF, true, true,
+      [&](const serialization::InputFile &IF, bool IsSystem, bool IsAffecting) {
+        if (!IsAffecting)
+          return;
         // __inferred_module.map is the result of the way in which an implicit
         // module build handles inferred modules. It adds an overlay VFS with
         // this file in the proper directory and relies on the rest of Clang to
@@ -450,7 +453,9 @@ ModuleID ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
   addAllAffectingModules(M, MD, SeenDeps);
 
   MDC.ScanInstance.getASTReader()->visitTopLevelModuleMaps(
-      *MF, [&](const FileEntry *FE) {
+      *MF, [&](const FileEntry *FE, bool IsAffecting) {
+        if (!IsAffecting)
+          return;
         if (FE->getName().endswith("__inferred_module.map"))
           return;
         MD.ModuleMapFileDeps.emplace_back(FE->getName());

--- a/clang/test/Modules/non-affecting-input-file-rebuilds.c
+++ b/clang/test/Modules/non-affecting-input-file-rebuilds.c
@@ -1,0 +1,61 @@
+// This test checks that reading a non-affecting module map during PCM
+// compilation doesn't cause the PCM to be recompiled when the file changes.
+
+// RUN: rm -rf %t && mkdir %t
+// RUN: split-file %s %t
+
+// XFAIL: *
+// rdar://101268970
+
+//--- include/a/module.modulemap
+module a {}
+//--- include/a/a.h
+// empty
+
+//--- include/b/module.modulemap
+module b { header "b.h" }
+//--- include/b/b.h
+#include "a/a.h"
+
+//--- include/c/module.modulemap
+module c { header "c.h" }
+//--- include/c/c.h
+#include "b/b.h"
+
+//--- test-b.m
+@import b; // expected-remark-re{{building module 'b' {{.*}}}} \
+           // expected-remark{{finished building module 'b'}} \
+           // expected-remark-re{{importing module 'b' from {{.*}}}}
+
+//--- test-c.m
+@import c; // expected-remark-re{{building module 'c' {{.*}}}} \
+           // expected-remark{{finished building module 'c'}} \
+           // expected-remark-re{{importing module 'c' from {{.*}}}} \
+           // expected-remark-re{{importing module 'b' into 'c' from {{.*}}}}
+
+//--- test-c-no-rebuild.m
+@import c; // expected-remark-re{{importing module 'c' from {{.*}}}} \
+           // expected-remark-re{{importing module 'b' into 'c' from {{.*}}}}
+
+// Build module 'b' for the first time.
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache -fdisable-module-hash -I %t/include %t/test-b.m -Rmodule-build -Rmodule-import -verify
+
+// Verify that changing the mtime doesn't trigger re-build.
+// RUN: touch %t/include/a/module.modulemap
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache -fdisable-module-hash -I %t/include %t/test-c.m -Rmodule-build -Rmodule-import -verify
+
+// Verify that modifying the contents doesn't trigger re-build.
+// RUN: echo " " >> %t/include/a/module.modulemap
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache -fdisable-module-hash -I %t/include %t/test-c-no-rebuild.m -Rmodule-build -Rmodule-import -verify
+
+// Verify that removing the file doesn't trigger re-build.
+// RUN: rm %t/include/a/module.modulemap
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache -fdisable-module-hash -I %t/include %t/test-c-no-rebuild.m -Rmodule-build -Rmodule-import -verify
+
+// Verify that existing signature still works after removing the 'a' module map.
+// RUN: rm %t/cache/b.pcm
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache -fdisable-module-hash -I %t/include %t/test-b.m -Rmodule-build -Rmodule-import -verify
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache -fdisable-module-hash -I %t/include %t/test-c-no-rebuild.m -Rmodule-build -Rmodule-import -verify
+//      ^^^ will first try to import 'c.pcm' with the stale signature and then rebuild it to reflect the new signature of 'b.pcm'
+
+// RUN: false

--- a/clang/test/Modules/non-affecting-module-maps-source-locations.m
+++ b/clang/test/Modules/non-affecting-module-maps-source-locations.m
@@ -1,0 +1,32 @@
+// This patch tests that non-affecting files are serialized in such way that
+// does not break subsequent source locations (e.g. in serialized pragma
+// diagnostic mappings).
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+//--- tu.m
+#include "first.h"
+
+//--- first/module.modulemap
+module first { header "first.h" }
+//--- first/first.h
+@import second;
+#pragma clang diagnostic ignored "-Wunreachable-code"
+
+//--- second/extra/module.modulemap
+module second_extra {}
+//--- second/module.modulemap
+module second { module sub { header "second_sub.h" } }
+//--- second/second_sub.h
+@import third;
+
+//--- third/module.modulemap
+module third { header "third.h" }
+//--- third/third.h
+#if __has_feature(nullability)
+#endif
+#if __has_feature(nullability)
+#endif
+
+// RUN: %clang_cc1 -I %t/first -I %t/second -I %t/third -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache %t/tu.m -o %t/tu.o

--- a/clang/test/Modules/non-affecting-module-maps.m
+++ b/clang/test/Modules/non-affecting-module-maps.m
@@ -1,6 +1,9 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: split-file %s %t
 
+// XFAIL: *
+// rdar://101268970
+
 //--- a.modulemap
 module a {}
 

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -271,9 +271,10 @@ static void dumpModuleFileInputs(serialization::ModuleFile &Mod,
                                  ASTReader &Reader,
                                  raw_ostream &OS) {
   OS << "---- Module Inputs ----\n";
-  Reader.visitInputFiles(Mod, /*IncludeSystem=*/true, /*Complain=*/false,
-                        [&](const serialization::InputFile &IF, bool isSystem) {
-    OS << (isSystem ? "system" : "user") << " | ";
+  Reader.visitInputFiles(
+      Mod, /*IncludeSystem=*/true, /*Complain=*/false,
+      [&](const serialization::InputFile &IF, bool IsSystem, bool IsAffecting) {
+        OS << (IsSystem ? "system" : "user") << " | ";
     OS << IF.getFile()->getName() << '\n';
   });
 }


### PR DESCRIPTION
This patch reworks the pruning of non-affecting module map files introduced in D106876. The problem with the original approach is that it creates holes in the list of source location offsets we serialize for `SourceManager`. This makes the binary search in `SourceManager::getFileIDLoaded()` fail with "incorrectly-formatted source location entry in AST file" and in general makes source locations pointing into files loaded after the removed one invalid.

This patch works around that by serializing information about all input files into the PCM again and adding a bit designating whether the file is affecting or not. This bit is then used to preserve the optimization in dependency scanner.

Note that this breaks the original use-case of the patch: to be able to freely use PCM files on machines that do/don't have non-affecting files on the file system. This can be re-instated by reverting this commit and adding logic to adjust all `SourceLocations` before serializing them, to account for the holes in source manager.

rdar://97759136
rdar://101051569