### PR TITLE
[lldb] Remove unused FromLLDBModule function from SwiftExpressionPars…

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -986,23 +986,6 @@ CreateMainFile(SwiftASTContextForExpressions &swift_ast_context,
   return {buffer_id, filename.str()};
 }
 
-/// Determine whether this type was defined inside an LLDB expression.
-template <typename TypeType> bool FromLLDBModuleImpl(TypeType *type) {
-  if (auto *decl = type->getDecl())
-    if (auto *module = decl->getModuleContext())
-      return module->getName().str().startswith("__lldb_expr_");
-  return false;
-};
-
-/// Determine whether this type was defined inside an LLDB expression.
-static bool FromLLDBModule(swift::TypeBase *type) {
-  if (auto *type_alias = llvm::dyn_cast<swift::TypeAliasType>(type))
-    return FromLLDBModuleImpl(type_alias);
-  if (auto *nominal = llvm::dyn_cast<swift::NominalType>(type))
-    return FromLLDBModuleImpl(nominal);
-  return false;
-}
-
 /// Attempt to materialize one variable.
 static llvm::Optional<SwiftExpressionParser::SILVariableInfo>
 MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,


### PR DESCRIPTION
…er.cpp

FromLLDBModule was previously used to tell if a type was defined in a JIT-compiled lldb module, since LLDB didn't have metadata for them. It has stopped being used since we now read metadata from those modules as well, so we don't need to skip them anymore.

rdar://100874898
(cherry picked from commit ddc822917b6e697a96669dff6e3a4bb627981fdb)