### PR TITLE
[clang][cas] Introduce `-Rcompile-job-cache-timing` to emit caching-related timings via remarks

### DIFF
--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -39,6 +39,7 @@
 
 namespace llvm {
 class Error;
+class format_object_base;
 class raw_ostream;
 } // namespace llvm
 
@@ -1546,6 +1547,9 @@ inline DiagnosticBuilder DiagnosticsEngine::Report(SourceLocation Loc,
 
 const StreamingDiagnostic &operator<<(const StreamingDiagnostic &DB,
                                       llvm::Error &&E);
+
+const StreamingDiagnostic &operator<<(const StreamingDiagnostic &DB,
+                                      const llvm::format_object_base &Fmt);
 
 inline DiagnosticBuilder DiagnosticsEngine::Report(unsigned DiagID) {
   return Report(SourceLocation(), DiagID);

--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -56,5 +56,15 @@ def remark_compile_job_cache_backend_output_not_found : Remark<
   InGroup<CompileJobCacheMiss>;
 def remark_compile_job_cache_skipped : Remark<
   "compile job cache skipped for '%0'">, InGroup<CompileJobCache>;
+def remark_compile_job_cache_timing_depscan : Remark<
+  "compile job dependency scanning time: %0">, InGroup<CompileJobCacheTiming>;
+def remark_compile_job_cache_timing_backend_key_query : Remark<
+  "compile job cache backend key query time: %0">, InGroup<CompileJobCacheTiming>;
+def remark_compile_job_cache_timing_backend_key_update : Remark<
+  "compile job cache backend key update time: %0">, InGroup<CompileJobCacheTiming>;
+def remark_compile_job_cache_timing_backend_load : Remark<
+  "compile job cache backend load artifacts time: %0">, InGroup<CompileJobCacheTiming>;
+def remark_compile_job_cache_timing_backend_store : Remark<
+  "compile job cache backend store artifacts time: %0">, InGroup<CompileJobCacheTiming>;
 
 } // let Component = "CAS" in

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1379,6 +1379,7 @@ def OpenCLCoreFeaturesDiagGroup : DiagGroup<"pedantic-core-features">;
 // Remarks for cached -cc1.
 def CompileJobCacheMiss : DiagGroup<"compile-job-cache-miss">;
 def CompileJobCacheHit : DiagGroup<"compile-job-cache-hit">;
+def CompileJobCacheTiming : DiagGroup<"compile-job-cache-timing">;
 def CompileJobCache : DiagGroup<"compile-job-cache", [CompileJobCacheMiss,
                                                       CompileJobCacheHit]>;
 

--- a/clang/lib/Basic/Diagnostic.cpp
+++ b/clang/lib/Basic/Diagnostic.cpp
@@ -74,6 +74,14 @@ const StreamingDiagnostic &clang::operator<<(const StreamingDiagnostic &DB,
   return DB;
 }
 
+const StreamingDiagnostic &
+clang::operator<<(const StreamingDiagnostic &DB,
+                  const llvm::format_object_base &Fmt) {
+  SmallString<32> Buf;
+  llvm::raw_svector_ostream(Buf) << Fmt;
+  return DB << Buf;
+}
+
 static void DummyArgToStringFn(DiagnosticsEngine::ArgumentKind AK, intptr_t QT,
                             StringRef Modifier, StringRef Argument,
                             ArrayRef<DiagnosticsEngine::ArgumentValue> PrevArgs,

--- a/clang/test/CAS/remote-timing-remarks.c
+++ b/clang/test/CAS/remote-timing-remarks.c
@@ -1,0 +1,23 @@
+// REQUIRES: remote-cache-service
+
+// Need a short path for the unix domain socket (and unique for this test file).
+// RUN: rm -f %{remote-cache-dir}/%basename_t
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: llvm-remote-cache-test -socket-path=%{remote-cache-dir}/%basename_t -cache-path=%t/cache -- \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache -Rcompile-job-cache-timing 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: llvm-remote-cache-test -socket-path=%{remote-cache-dir}/%basename_t -cache-path=%t/cache -- \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache -Rcompile-job-cache-timing 2>&1 | FileCheck %s --check-prefix=CACHE-HIT
+
+// CACHE-MISS: remark: compile job dependency scanning time:
+// CACHE-MISS: remark: compile job cache backend key query time:
+// CACHE-MISS: remark: compile job cache miss
+// CACHE-MISS: remark: compile job cache backend store artifacts time:
+// CACHE-MISS: remark: compile job cache backend key update time:
+
+// CACHE-HIT: remark: compile job dependency scanning time:
+// CACHE-HIT: remark: compile job cache backend key query time:
+// CACHE-HIT: remark: compile job cache hit
+// CACHE-HIT: remark: compile job cache backend load artifacts time:

--- a/clang/test/CAS/timing-remarks.c
+++ b/clang/test/CAS/timing-remarks.c
@@ -1,0 +1,17 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache -Rcompile-job-cache-timing 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache -Rcompile-job-cache-timing 2>&1 | FileCheck %s --check-prefix=CACHE-HIT
+
+// CACHE-MISS: remark: compile job dependency scanning time:
+// CACHE-MISS: remark: compile job cache backend key query time:
+// CACHE-MISS: remark: compile job cache miss
+// CACHE-MISS: remark: compile job cache backend store artifacts time:
+// CACHE-MISS: remark: compile job cache backend key update time:
+
+// CACHE-HIT: remark: compile job dependency scanning time:
+// CACHE-HIT: remark: compile job cache backend key query time:
+// CACHE-HIT: remark: compile job cache hit
+// CACHE-HIT: remark: compile job cache backend load artifacts time:

--- a/llvm/include/llvm/Support/ScopedDurationTimer.h
+++ b/llvm/include/llvm/Support/ScopedDurationTimer.h
@@ -1,0 +1,50 @@
+//===-- llvm/Support/ScopedDurationTimer.h ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_SCOPEDDURATIONTIMER_H
+#define LLVM_SUPPORT_SCOPEDDURATIONTIMER_H
+
+#include <chrono>
+
+namespace llvm {
+
+/// RAII timer that captures the duration between construction and destruction
+/// and passes it to the provided \p ElapsedHandler at destruction.
+///
+/// Example use:
+/// \code
+///   {
+///     llvm::ScopedDurationTimer ScopedTime([](double Seconds) {
+///       llvm::outs() << "duration: " << Seconds << "\n";
+///     });
+///     // Actions to get duration for.
+///     <...>
+///   }
+/// \endcode
+template <typename Callable> class ScopedDurationTimer {
+public:
+  explicit ScopedDurationTimer(Callable &&ElapsedHandler)
+      : ElapsedHandler(std::move(ElapsedHandler)) {}
+
+  Callable ElapsedHandler;
+  std::chrono::steady_clock::time_point StartTime =
+      std::chrono::steady_clock::now();
+
+  ~ScopedDurationTimer() {
+    using Seconds = std::chrono::duration<double, std::ratio<1>>;
+    ElapsedHandler(
+        Seconds(std::chrono::steady_clock::now() - StartTime).count());
+  }
+};
+
+template <typename Callable>
+ScopedDurationTimer(Callable &&) -> ScopedDurationTimer<Callable>;
+
+} // end namespace llvm
+
+#endif


### PR DESCRIPTION
Emits timings for:
* Dependency scanning
* Caching backend key-value query
* Caching backend storage of artifacts
* Caching backend loading of artifacts