### PR TITLE
[clang][cas] Introduce `-Rcompile-job-cache-timing` to emit caching-related timings via remarks

### DIFF
--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -39,6 +39,7 @@
 
 namespace llvm {
 class Error;
+class format_object_base;
 }
 
 namespace clang {
@@ -1532,6 +1533,9 @@ inline DiagnosticBuilder DiagnosticsEngine::Report(SourceLocation Loc,
 
 const StreamingDiagnostic &operator<<(const StreamingDiagnostic &DB,
                                       llvm::Error &&E);
+
+const StreamingDiagnostic &operator<<(const StreamingDiagnostic &DB,
+                                      const llvm::format_object_base &Fmt);
 
 inline DiagnosticBuilder DiagnosticsEngine::Report(unsigned DiagID) {
   return Report(SourceLocation(), DiagID);

--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -56,5 +56,15 @@ def remark_compile_job_cache_backend_output_not_found : Remark<
   InGroup<CompileJobCacheMiss>;
 def remark_compile_job_cache_skipped : Remark<
   "compile job cache skipped for '%0'">, InGroup<CompileJobCache>;
+def remark_compile_job_cache_timing_depscan : Remark<
+  "compile job dependency scanning time: %0">, InGroup<CompileJobCacheTiming>;
+def remark_compile_job_cache_timing_backend_key_query : Remark<
+  "compile job cache backend key query time: %0">, InGroup<CompileJobCacheTiming>;
+def remark_compile_job_cache_timing_backend_key_update : Remark<
+  "compile job cache backend key update time: %0">, InGroup<CompileJobCacheTiming>;
+def remark_compile_job_cache_timing_backend_load : Remark<
+  "compile job cache backend load artifacts time: %0">, InGroup<CompileJobCacheTiming>;
+def remark_compile_job_cache_timing_backend_store : Remark<
+  "compile job cache backend store artifacts time: %0">, InGroup<CompileJobCacheTiming>;
 
 } // let Component = "CAS" in

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1356,6 +1356,7 @@ def OpenCLCoreFeaturesDiagGroup : DiagGroup<"pedantic-core-features">;
 // Remarks for cached -cc1.
 def CompileJobCacheMiss : DiagGroup<"compile-job-cache-miss">;
 def CompileJobCacheHit : DiagGroup<"compile-job-cache-hit">;
+def CompileJobCacheTiming : DiagGroup<"compile-job-cache-timing">;
 def CompileJobCache : DiagGroup<"compile-job-cache", [CompileJobCacheMiss,
                                                       CompileJobCacheHit]>;
 

--- a/clang/lib/Basic/Diagnostic.cpp
+++ b/clang/lib/Basic/Diagnostic.cpp
@@ -73,6 +73,14 @@ const StreamingDiagnostic &clang::operator<<(const StreamingDiagnostic &DB,
   return DB;
 }
 
+const StreamingDiagnostic &
+clang::operator<<(const StreamingDiagnostic &DB,
+                  const llvm::format_object_base &Fmt) {
+  SmallString<32> Buf;
+  llvm::raw_svector_ostream(Buf) << Fmt;
+  return DB << Buf;
+}
+
 static void DummyArgToStringFn(DiagnosticsEngine::ArgumentKind AK, intptr_t QT,
                             StringRef Modifier, StringRef Argument,
                             ArrayRef<DiagnosticsEngine::ArgumentValue> PrevArgs,

--- a/clang/test/CAS/remote-timing-remarks.c
+++ b/clang/test/CAS/remote-timing-remarks.c
@@ -1,0 +1,23 @@
+// REQUIRES: remote-cache-service
+
+// Need a short path for the unix domain socket (and unique for this test file).
+// RUN: rm -f %{remote-cache-dir}/%basename_t
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: llvm-remote-cache-test -socket-path=%{remote-cache-dir}/%basename_t -cache-path=%t/cache -- \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache -Rcompile-job-cache-timing 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: llvm-remote-cache-test -socket-path=%{remote-cache-dir}/%basename_t -cache-path=%t/cache -- \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache -Rcompile-job-cache-timing 2>&1 | FileCheck %s --check-prefix=CACHE-HIT
+
+// CACHE-MISS: remark: compile job dependency scanning time:
+// CACHE-MISS: remark: compile job cache backend key query time:
+// CACHE-MISS: remark: compile job cache miss
+// CACHE-MISS: remark: compile job cache backend store artifacts time:
+// CACHE-MISS: remark: compile job cache backend key update time:
+
+// CACHE-HIT: remark: compile job dependency scanning time:
+// CACHE-HIT: remark: compile job cache backend key query time:
+// CACHE-HIT: remark: compile job cache hit
+// CACHE-HIT: remark: compile job cache backend load artifacts time:

--- a/clang/test/CAS/timing-remarks.c
+++ b/clang/test/CAS/timing-remarks.c
@@ -1,0 +1,17 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache -Rcompile-job-cache-timing 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache -Rcompile-job-cache-timing 2>&1 | FileCheck %s --check-prefix=CACHE-HIT
+
+// CACHE-MISS: remark: compile job dependency scanning time:
+// CACHE-MISS: remark: compile job cache backend key query time:
+// CACHE-MISS: remark: compile job cache miss
+// CACHE-MISS: remark: compile job cache backend store artifacts time:
+// CACHE-MISS: remark: compile job cache backend key update time:
+
+// CACHE-HIT: remark: compile job dependency scanning time:
+// CACHE-HIT: remark: compile job cache backend key query time:
+// CACHE-HIT: remark: compile job cache hit
+// CACHE-HIT: remark: compile job cache backend load artifacts time:

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -58,6 +58,7 @@
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
+#include "llvm/Support/ScopedDurationTimer.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/TimeProfiler.h"
@@ -267,6 +268,8 @@ private:
   Error finishComputedResult(const llvm::cas::CASID &ResultCacheKey,
                              bool SkipCache) override;
 
+  Expected<cas::ObjectRef> writeOutputs(const llvm::cas::CASID &ResultCacheKey);
+
   /// Replay a cache hit.
   ///
   /// Return status if should exit immediately, otherwise None.
@@ -350,6 +353,9 @@ private:
 
   Error finishComputedResult(const llvm::cas::CASID &ResultCacheKey,
                              bool SkipCache) override;
+
+  Expected<llvm::cas::remote::KeyValueDBClient::ValueTy>
+  saveOutputs(const llvm::cas::CASID &ResultCacheKey);
 
   Expected<bool> replayCachedResult(
       const llvm::cas::CASID &ResultCacheKey,
@@ -588,17 +594,32 @@ Expected<bool> ObjectStoreCachingOutputs::tryReplayCachedResult(
     const llvm::cas::CASID &ResultCacheKey) {
   DiagnosticsEngine &Diags = Clang.getDiagnostics();
 
-  Expected<Optional<llvm::cas::CASID>> Result = Cache->get(ResultCacheKey);
-  if (!Result)
-    return Result.takeError();
+  Optional<llvm::cas::CASID> Result;
+  {
+    auto ElapsedDiag = [&Diags](double Seconds) {
+      Diags.Report(diag::remark_compile_job_cache_timing_backend_key_query)
+          << llvm::format("%.6fs", Seconds);
+    };
+    llvm::ScopedDurationTimer<decltype(ElapsedDiag)> ScopedTime(
+        std::move(ElapsedDiag));
+    if (Error E = Cache->get(ResultCacheKey).moveInto(Result))
+      return std::move(E);
+  }
 
-  if (!*Result) {
+  if (!Result) {
     Diags.Report(diag::remark_compile_job_cache_miss)
         << ResultCacheKey.toString();
     return false;
   }
 
-  Optional<llvm::cas::ObjectRef> ResultRef = CAS->getReference(**Result);
+  auto ElapsedDiag = [&Diags](double Seconds) {
+    Diags.Report(diag::remark_compile_job_cache_timing_backend_load)
+        << llvm::format("%.6fs", Seconds);
+  };
+  llvm::ScopedDurationTimer<decltype(ElapsedDiag)> ScopedTime(
+      std::move(ElapsedDiag));
+
+  Optional<llvm::cas::ObjectRef> ResultRef = CAS->getReference(*Result);
   if (!ResultRef) {
     Diags.Report(diag::remark_compile_job_cache_miss_result_not_found)
         << ResultCacheKey.toString() << "result not in CAS";
@@ -764,18 +785,18 @@ bool CompileJobCache::finishComputedResult(CompilerInstance &Clang,
   if (!Success)
     return false;
 
+  DiagnosticsEngine &Diags = Clang.getDiagnostics();
+
   // Existing diagnostic client is finished, create a new one in case we need
   // to print more diagnostics.
-  Clang.getDiagnostics().setClient(
-      new TextDiagnosticPrinter(llvm::errs(),
-                                &Clang.getInvocation().getDiagnosticOpts()),
-      /*ShouldOwnClient=*/true);
+  Diags.setClient(new TextDiagnosticPrinter(
+                      llvm::errs(), &Clang.getInvocation().getDiagnosticOpts()),
+                  /*ShouldOwnClient=*/true);
 
   // Check if we encounter any source that would generate non-reproducible
   // outputs.
   bool SkipCache = Clang.hasPreprocessor() && Clang.isSourceNonReproducible();
   if (SkipCache) {
-    DiagnosticsEngine &Diags = Clang.getDiagnostics();
     switch (Clang.getPreprocessorOpts().CachingDiagOption) {
       case CachingDiagKind::None:
         break;
@@ -790,7 +811,7 @@ bool CompileJobCache::finishComputedResult(CompilerInstance &Clang,
 
   if (Error E =
           CacheBackend->finishComputedResult(*ResultCacheKey, SkipCache)) {
-    reportCachingBackendError(Clang.getDiagnostics(), std::move(E));
+    reportCachingBackendError(Diags, std::move(E));
     return false;
   }
   return true;
@@ -812,18 +833,24 @@ void CachingOutputs::finishSerializedDiagnostics() {
   }
 }
 
-Error ObjectStoreCachingOutputs::finishComputedResult(
-    const llvm::cas::CASID &ResultCacheKey, bool SkipCache) {
-  // FIXME: Stop calling report_fatal_error().
+Expected<cas::ObjectRef> ObjectStoreCachingOutputs::writeOutputs(
+    const llvm::cas::CASID &ResultCacheKey) {
+  DiagnosticsEngine &Diags = Clang.getDiagnostics();
+  auto ElapsedDiag = [&Diags](double Seconds) {
+    Diags.Report(diag::remark_compile_job_cache_timing_backend_store)
+        << llvm::format("%.6fs", Seconds);
+  };
+  llvm::ScopedDurationTimer<decltype(ElapsedDiag)> ScopedTime(
+      std::move(ElapsedDiag));
+
   if (!SerialDiagsOutput) {
     // Not requested to get a serialized diagnostics file but we generated it
     // and will store it regardless so that the key is independent of the
     // presence of '--serialize-diagnostics'.
     Expected<llvm::cas::ObjectProxy> SerialDiags =
         CAS->createProxy(None, SerialDiagsBuf);
-    // FIXME: Stop calling report_fatal_error().
     if (!SerialDiags)
-      llvm::report_fatal_error(SerialDiags.takeError());
+      return SerialDiags.takeError();
     CachedResultBuilder.addOutput(OutputKind::SerializedDiagnostics,
                                   SerialDiags->getRef());
   }
@@ -835,27 +862,35 @@ Error ObjectStoreCachingOutputs::finishComputedResult(
   auto BackendOutputs = CASOutputs->takeOutputs();
   for (auto &Output : BackendOutputs)
     if (auto Err = CachedResultBuilder.addOutput(Output.Path, Output.Object))
-      llvm::report_fatal_error(std::move(Err));
+      return std::move(Err);
 
   // Hack around llvm::errs() not being captured by the output backend yet.
-  //
-  // FIXME: Stop calling report_fatal_error().
   Expected<llvm::cas::ObjectRef> Errs = CAS->storeFromString(None, ResultDiags);
   if (!Errs)
-    llvm::report_fatal_error(Errs.takeError());
+    return Errs.takeError();
   CachedResultBuilder.addOutput(OutputKind::Stderr, *Errs);
 
   // Cache the result.
-  //
-  // FIXME: Stop calling report_fatal_error().
-  Expected<cas::ObjectRef> Result = CachedResultBuilder.build(*CAS);
+  return CachedResultBuilder.build(*CAS);
+}
+
+Error ObjectStoreCachingOutputs::finishComputedResult(
+    const llvm::cas::CASID &ResultCacheKey, bool SkipCache) {
+  Expected<cas::ObjectRef> Result = writeOutputs(ResultCacheKey);
   if (!Result)
-    llvm::report_fatal_error(Result.takeError());
+    return Result.takeError();
 
   // Skip caching if requested.
   if (!SkipCache) {
+    DiagnosticsEngine &Diags = Clang.getDiagnostics();
+    auto ElapsedDiag = [&Diags](double Seconds) {
+      Diags.Report(diag::remark_compile_job_cache_timing_backend_key_update)
+          << llvm::format("%.6fs", Seconds);
+    };
+    llvm::ScopedDurationTimer<decltype(ElapsedDiag)> ScopedTime(
+        std::move(ElapsedDiag));
     if (llvm::Error E = Cache->put(ResultCacheKey, CAS->getID(*Result)))
-      llvm::report_fatal_error(std::move(E));
+      return E;
   }
 
   // Replay / decanonicalize as necessary.
@@ -953,16 +988,32 @@ Expected<bool> RemoteCachingOutputs::tryReplayCachedResult(
     const llvm::cas::CASID &ResultCacheKey) {
   DiagnosticsEngine &Diags = Clang.getDiagnostics();
 
-  RemoteKVClient->getValueQueue().getValueAsync(ResultCacheKey.getHash());
-  Expected<llvm::cas::remote::KeyValueDBClient::GetValueAsyncQueue::Response>
-      Response = RemoteKVClient->getValueQueue().receiveNext();
-  if (!Response)
-    return Response.takeError();
+  Optional<llvm::cas::remote::KeyValueDBClient::GetValueAsyncQueue::Response>
+      Response;
+  {
+    auto ElapsedDiag = [&Diags](double Seconds) {
+      Diags.Report(diag::remark_compile_job_cache_timing_backend_key_query)
+          << llvm::format("%.6fs", Seconds);
+    };
+    llvm::ScopedDurationTimer<decltype(ElapsedDiag)> ScopedTime(
+        std::move(ElapsedDiag));
+    RemoteKVClient->getValueQueue().getValueAsync(ResultCacheKey.getHash());
+    if (Error E =
+            RemoteKVClient->getValueQueue().receiveNext().moveInto(Response))
+      return std::move(E);
+  }
   if (!Response->Value) {
     Diags.Report(diag::remark_compile_job_cache_miss)
         << ResultCacheKey.toString();
     return false;
   }
+
+  auto ElapsedDiag = [&Diags](double Seconds) {
+    Diags.Report(diag::remark_compile_job_cache_timing_backend_load)
+        << llvm::format("%.6fs", Seconds);
+  };
+  llvm::ScopedDurationTimer<decltype(ElapsedDiag)> ScopedTime(
+      std::move(ElapsedDiag));
 
   Expected<bool> ReplayedResult =
       replayCachedResult(ResultCacheKey, *Response->Value);
@@ -1119,14 +1170,15 @@ bool RemoteCachingOutputs::prepareOutputCollection() {
   return prepareOutputCollectionCommon(CollectingOutputs);
 }
 
-Error RemoteCachingOutputs::finishComputedResult(
-    const llvm::cas::CASID &ResultCacheKey, bool SkipCache) {
-  if (SkipCache)
-    return Error::success();
-
-  // Release the llbuild execution lane while we wait to upload data to remote
-  // cache.
-  tryReleaseLLBuildExecutionLane();
+Expected<llvm::cas::remote::KeyValueDBClient::ValueTy>
+RemoteCachingOutputs::saveOutputs(const llvm::cas::CASID &ResultCacheKey) {
+  DiagnosticsEngine &Diags = Clang.getDiagnostics();
+  auto ElapsedDiag = [&Diags](double Seconds) {
+    Diags.Report(diag::remark_compile_job_cache_timing_backend_store)
+        << llvm::format("%.6fs", Seconds);
+  };
+  llvm::ScopedDurationTimer<decltype(ElapsedDiag)> ScopedTime(
+      std::move(ElapsedDiag));
 
   auto &SaveQueue = RemoteCASClient->saveQueue();
   struct CallCtx : public llvm::cas::remote::AsyncCallerContext {
@@ -1175,8 +1227,33 @@ Error RemoteCachingOutputs::finishComputedResult(
     CompResult[OutputName] = Response->CASID;
   }
 
+  return std::move(CompResult);
+}
+
+Error RemoteCachingOutputs::finishComputedResult(
+    const llvm::cas::CASID &ResultCacheKey, bool SkipCache) {
+  if (SkipCache)
+    return Error::success();
+
+  // Release the llbuild execution lane while we wait to upload data to remote
+  // cache.
+  tryReleaseLLBuildExecutionLane();
+
+  Expected<llvm::cas::remote::KeyValueDBClient::ValueTy> CompResult =
+      saveOutputs(ResultCacheKey);
+  if (!CompResult)
+    return CompResult.takeError();
+
+  DiagnosticsEngine &Diags = Clang.getDiagnostics();
+  auto ElapsedDiag = [&Diags](double Seconds) {
+    Diags.Report(diag::remark_compile_job_cache_timing_backend_key_update)
+        << llvm::format("%.6fs", Seconds);
+  };
+  llvm::ScopedDurationTimer<decltype(ElapsedDiag)> ScopedTime(
+      std::move(ElapsedDiag));
+
   RemoteKVClient->putValueQueue().putValueAsync(ResultCacheKey.getHash(),
-                                                CompResult);
+                                                *CompResult);
   auto Response = RemoteKVClient->putValueQueue().receiveNext();
   if (!Response)
     return Response.takeError();

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -44,6 +44,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/Process.h"
+#include "llvm/Support/ScopedDurationTimer.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/ThreadPool.h"
 #include "llvm/Support/VirtualOutputBackends.h"
@@ -514,6 +515,13 @@ static int scanAndUpdateCC1(const char *Exec, ArrayRef<const char *> OldArgs,
                             llvm::Optional<llvm::cas::CASID> &RootID) {
   using namespace clang::driver;
 
+  auto ElapsedDiag = [&Diag](double Seconds) {
+    Diag.Report(diag::remark_compile_job_cache_timing_depscan)
+        << llvm::format("%.6fs", Seconds);
+  };
+  llvm::ScopedDurationTimer<decltype(ElapsedDiag)> ScopedTime(
+      std::move(ElapsedDiag));
+
   StringRef WorkingDirectory;
   SmallString<128> WorkingDirectoryBuf;
   if (auto *Arg =
@@ -593,10 +601,27 @@ static int scanAndUpdateCC1(const char *Exec, ArrayRef<const char *> OldArgs,
 
 int cc1depscan_main(ArrayRef<const char *> Argv, const char *Argv0,
                     void *MainAddr) {
+  IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts;
+  {
+    auto FoundCC1Args =
+        std::find_if(Argv.begin(), Argv.end(), [](const char *Arg) -> bool {
+          return StringRef(Arg).equals("-cc1-args");
+        });
+    if (FoundCC1Args != Argv.end()) {
+      SmallVector<const char *, 8> WarnOpts{Argv0};
+      WarnOpts.append(FoundCC1Args + 1, Argv.end());
+      DiagOpts = CreateAndPopulateDiagOpts(WarnOpts);
+    } else {
+      DiagOpts = new DiagnosticOptions();
+    }
+  }
   auto DiagsConsumer = std::make_unique<TextDiagnosticPrinter>(
-      llvm::errs(), new DiagnosticOptions(), false);
-  DiagnosticsEngine Diags(new DiagnosticIDs(), new DiagnosticOptions());
+      llvm::errs(), DiagOpts.get(), false);
+  DiagnosticsEngine Diags(new DiagnosticIDs(), DiagOpts);
   Diags.setClient(DiagsConsumer.get(), /*ShouldOwnClient=*/false);
+  ProcessWarningOptions(Diags, *DiagOpts);
+  if (Diags.hasErrorOccurred())
+    return 1;
 
   // FIXME: Create a new OptionFlag group for cc1depscan.
   const OptTable &Opts = clang::driver::getDriverOptTable();

--- a/llvm/include/llvm/Support/ScopedDurationTimer.h
+++ b/llvm/include/llvm/Support/ScopedDurationTimer.h
@@ -1,0 +1,47 @@
+//===-- llvm/Support/ScopedDurationTimer.h ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_SCOPEDDURATIONTIMER_H
+#define LLVM_SUPPORT_SCOPEDDURATIONTIMER_H
+
+#include <chrono>
+
+namespace llvm {
+
+/// RAII timer that captures the duration between construction and destruction
+/// and passes it to the provided \p ElapsedHandler at destruction.
+///
+/// Example use:
+/// \code
+///   {
+///     llvm::ScopedDurationTimer ScopedTime([](double Seconds) {
+///       llvm::outs() << "duration: " << Seconds << "\n";
+///     });
+///     // Actions to get duration for.
+///     <...>
+///   }
+/// \endcode
+template <typename Callable> class ScopedDurationTimer {
+public:
+  explicit ScopedDurationTimer(Callable &&ElapsedHandler)
+      : ElapsedHandler(std::move(ElapsedHandler)) {}
+
+  Callable ElapsedHandler;
+  std::chrono::steady_clock::time_point StartTime =
+      std::chrono::steady_clock::now();
+
+  ~ScopedDurationTimer() {
+    using Seconds = std::chrono::duration<double, std::ratio<1>>;
+    ElapsedHandler(
+        Seconds(std::chrono::steady_clock::now() - StartTime).count());
+  }
+};
+
+} // end namespace llvm
+
+#endif


### PR DESCRIPTION
Emits timings for:
* Dependency scanning
* Caching backend key-value query
* Caching backend storage of artifacts
* Caching backend loading of artifacts

(cherry picked from commit 39a57433f29b218c6b095790e682f8cfaca4b14a)