### PR TITLE
[lldb] Implement extra inhabitants calculation for foreign types in LLDB

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -177,6 +177,11 @@ TypeSystemSwiftTypeRef::GetBaseName(swift::Demangle::NodePointer node) {
   }
 }
 
+bool TypeSystemSwiftTypeRef::IsKnownSpecialImportedType(llvm::StringRef name) {
+  return name == "NSNotificationName" ||
+         swift::ClangImporter::isKnownCFTypeName(name);
+}
+
 /// Create a mangled name for a type node.
 static swift::Demangle::ManglingErrorOr<std::string>
 GetMangledName(swift::Demangle::Demangler &dem,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -298,6 +298,9 @@ public:
   /// Return the base name of the topmost nominal type.
   static llvm::StringRef GetBaseName(swift::Demangle::NodePointer node);
 
+  /// Return whether the type is known to be specially handled by the compiler.
+  static bool IsKnownSpecialImportedType(llvm::StringRef name);
+
   /// Use API notes to determine the swiftified name of \p clang_decl.
   std::string GetSwiftName(const clang::Decl *clang_decl,
                            TypeSystemClang &clang_typesystem) override;

--- a/lldb/test/API/lang/swift/external_provider_extra_inhabitants/Makefile
+++ b/lldb/test/API/lang/swift/external_provider_extra_inhabitants/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/external_provider_extra_inhabitants/TestExternalProviderExtraInhabitants.py
+++ b/lldb/test/API/lang/swift/external_provider_extra_inhabitants/TestExternalProviderExtraInhabitants.py
@@ -1,0 +1,23 @@
+"""
+Test that the external provider calculates the extra inhabitants of clang types correctly
+"""
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class TestExternalProviderExtraInhabitants(TestBase):
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'Set breakpoint here.', lldb.SBFileSpec('main.swift'))
+
+        self.expect('v object.size.some.width', substrs=['10'])
+        self.expect('v object.size.some.height', substrs=['20'])
+

--- a/lldb/test/API/lang/swift/external_provider_extra_inhabitants/main.swift
+++ b/lldb/test/API/lang/swift/external_provider_extra_inhabitants/main.swift
@@ -1,0 +1,14 @@
+import CoreGraphics
+
+public class MyClass {
+  // CGImage is consulted through the external info provider.
+  // This field is here to test that LLDB correctly calculates 
+  // that the size of "CGImage?" is 8 bytes, given that CGImage
+  // has non-zero extra inhabitants.
+	public var unused: CGImage? = nil
+	public var size: CGSize? = nil
+}
+let object = MyClass()
+object.size = CGSize(width:10, height:20)
+print(1) // Set breakpoint here.
+


### PR DESCRIPTION
The Swift reflection machinery uses the number of extra inhabitants to figure out if enum cases were compacted inside the payload. The LLDB external provider was always setting that value to 0, which would subsequently make reflection think that a field was bigger than it actually was, and causing accesses to subsequent fields to be incorrect. This patch implements returning the correct number of extra inhabitants in the external provider.

rdar://100708229