### PR TITLE
Fix bug where EmissionKind to the new compile unit created was not being passed in properly

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -2150,11 +2150,11 @@ void DwarfDebug::beginFunctionImpl(const MachineFunction *MF) {
   if (SP->getUnit()->getEmissionKind() == DICompileUnit::NoDebug)
     return;
 
-  // If the EmissionKind is CasFriendly, this indicates to us that we want to
-  // split up the line tables by function rather than have it as one monolithic
-  // entry. That is, every function gets its own line table header. To achieve
-  // this we are creating a new CompileUnit per function so each function can
-  // get it's own line table header
+  // If the CasFriendlinessKind is CasFriendly, this indicates to us that we
+  // want to split up the line tables by function rather than have it as one
+  // monolithic entry. That is, every function gets its own line table header.
+  // To achieve this we are creating a new CompileUnit per function so each
+  // function can get it's own line table header
   if (SP->getUnit()->getCasFriendlinessKind() !=
       DICompileUnit::NoCasFriendlyDebugInfo) {
     const Module *M = MF->getFunction().getParent();
@@ -2163,7 +2163,7 @@ void DwarfDebug::beginFunctionImpl(const MachineFunction *MF) {
     DICompileUnit *NewDCU = DIB.createCompileUnit(
         DCU->getSourceLanguage(), DCU->getFile(), DCU->getProducer(),
         DCU->isOptimized(), DCU->getFlags(), DCU->getRuntimeVersion(), {},
-        DICompileUnit::DebugEmissionKind::FullDebug, 0, true, false,
+        DCU->getEmissionKind(), 0, true, false,
         DICompileUnit::DebugNameTableKind::Default, false, {}, {},
         DCU->getCasFriendlinessKind());
 


### PR DESCRIPTION
When we want to emit debug information that is "cas friendly" we want to emit one compile unit per function, to do this, we just create a new compile unit and add it to the list of CUs when we begin a new function. The EmissionKind was not being passed in correctly and was always FullDebugInfo, this has now been fixed