### PR TITLE
[support] Add missing #include <ratio> in ScopedDurationTimer.h

### DIFF
--- a/llvm/include/llvm/Support/ScopedDurationTimer.h
+++ b/llvm/include/llvm/Support/ScopedDurationTimer.h
@@ -10,6 +10,7 @@
 #define LLVM_SUPPORT_SCOPEDDURATIONTIMER_H
 
 #include <chrono>
+#include <ratio>
 
 namespace llvm {
 


### PR DESCRIPTION
The missing include was causing build failures in some configurations