### PR TITLE
[cherry-pick][cas][support] Add missing #include <ratio> in ScopedDurationTimer.h

### DIFF
--- a/llvm/include/llvm/Support/ScopedDurationTimer.h
+++ b/llvm/include/llvm/Support/ScopedDurationTimer.h
@@ -10,6 +10,7 @@
 #define LLVM_SUPPORT_SCOPEDDURATIONTIMER_H
 
 #include <chrono>
+#include <ratio>
 
 namespace llvm {
 


### PR DESCRIPTION
(cherry picked from commit 72dfc8749287c45825eb23e3265d79cd1847d517)
Cherry pick from #5486 