### PR TITLE
[clang] Adopt constexpr_builtin support in ptrauth builtins.

### DIFF
--- a/clang/include/clang/Basic/Builtins.def
+++ b/clang/include/clang/Basic/Builtins.def
@@ -1650,12 +1650,12 @@ LANGBUILTIN(__builtin_coro_suspend, "cIb", "n", COR_LANG)
 // Pointer authentication builtins.
 BUILTIN(__builtin_ptrauth_strip, "v*v*i", "tnc")
 BUILTIN(__builtin_ptrauth_blend_discriminator, "zv*i", "tnc")
-BUILTIN(__builtin_ptrauth_sign_constant, "v*v*iv*", "tnc")
+BUILTIN(__builtin_ptrauth_sign_constant, "v*v*iv*", "tncE")
 BUILTIN(__builtin_ptrauth_sign_unauthenticated, "v*v*iv*", "tnc")
 BUILTIN(__builtin_ptrauth_sign_generic_data, "zv*v*", "tnc")
 BUILTIN(__builtin_ptrauth_auth_and_resign, "v*v*iv*iv*", "tn")
 BUILTIN(__builtin_ptrauth_auth, "v*v*iv*", "tn")
-BUILTIN(__builtin_ptrauth_string_discriminator, "zcC*", "nc")
+BUILTIN(__builtin_ptrauth_string_discriminator, "zcC*", "ncE")
 
 // OpenCL v2.0 s6.13.16, s9.17.3.5 - Pipe functions.
 // We need the generic prototype, since the packet type could be anything.

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -4633,7 +4633,6 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
         LLVM_FALLTHROUGH;
 
       case Builtin::BI__builtin_ptrauth_auth:
-      case Builtin::BI__builtin_ptrauth_sign_constant:
       case Builtin::BI__builtin_ptrauth_sign_unauthenticated:
         if (args[2]->getType()->isPointerTy())
           args[2] = Builder.CreatePtrToInt(args[2], IntPtrTy);
@@ -4660,7 +4659,6 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
         return llvm::Intrinsic::ptrauth_blend;
       case Builtin::BI__builtin_ptrauth_sign_generic_data:
         return llvm::Intrinsic::ptrauth_sign_generic;
-      case Builtin::BI__builtin_ptrauth_sign_constant:
       case Builtin::BI__builtin_ptrauth_sign_unauthenticated:
         return llvm::Intrinsic::ptrauth_sign;
       case Builtin::BI__builtin_ptrauth_strip:


### PR DESCRIPTION
5b567637e22bf adds support for __has_constexpr_builtin, and marks existing builtins using an `E` flag in Builtins.def.

This adopts that for:
  __builtin_ptrauth_sign_constant
  __builtin_ptrauth_string_discriminator

This also does a couple cleanups around the way we handle these:
- it merges the downstream-only isGlobalCallLValue helper function into the upstream IsNoOpCall: originally, the latter was specifically about string builtins, but is now general enough that it applies here as well.
- it removes a couple unreachable switch cases.


This fixes a couple test regressions following the upstream change.