### PR TITLE
[LTO] Fix lto_module_create_in_codegen_context return value on error

### DIFF
--- a/llvm/tools/lto/lto.cpp
+++ b/llvm/tools/lto/lto.cpp
@@ -292,6 +292,8 @@ lto_module_t lto_module_create_in_codegen_context(const void *mem,
       codegen::InitTargetOptionsFromCodeGenFlags(Triple());
   ErrorOr<std::unique_ptr<LTOModule>> M = LTOModule::createFromBuffer(
       unwrap(cg)->getContext(), mem, length, Options, StringRef(path));
+  if (!M)
+    return nullptr;
   return wrap(M->release());
 }
 


### PR DESCRIPTION
According to the documentation, lto_module_create_in_codegen_context should return NULL on error but currently it is accidentally return error_code. Since this is a bug fix and it seems to be a one-off bug that only affects this API, there is no need to bump API version.

rdar://101505192

Reviewed By: pete

Differential Revision: https://reviews.llvm.org/D136769

(cherry picked from commit 76ebaf263b20619b3416fbaa715fea25735bfe30)