### PR TITLE
[dwarfdump] Fix bogus incompatible tag warning

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Dwarf.def
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.def
@@ -242,7 +242,7 @@ HANDLE_DW_TAG(0x420d, SUN_fortran_vax_structure, 0, SUN, DW_KIND_NONE)
 HANDLE_DW_TAG(0x42ff, SUN_hi, 0, SUN, DW_KIND_NONE)
 
 // LLVM
-HANDLE_DW_TAG(0x4300, LLVM_ptrauth_type, 0, LLVM, DW_KIND_NONE)
+HANDLE_DW_TAG(0x4300, LLVM_ptrauth_type, 0, LLVM, DW_KIND_TYPE)
 
 // DSP-C/Starcore __circ, _rev
 HANDLE_DW_TAG(0x5101, ALTIUM_circ_type, 0, ALTIUM, DW_KIND_NONE)

--- a/llvm/test/tools/llvm-dwarfdump/AArch64/ptrauth.s
+++ b/llvm/test/tools/llvm-dwarfdump/AArch64/ptrauth.s
@@ -1,6 +1,6 @@
-# RUN: llvm-mc %s -filetype obj -triple arm64-apple-darwin -o - \
-# RUN: | llvm-dwarfdump --debug-info - \
-# RUN: | FileCheck %s
+# RUN: llvm-mc %s -filetype obj -triple arm64-apple-darwin -o %t
+# RUN: llvm-dwarfdump --debug-info %t | FileCheck %s
+# RUN: llvm-dwarfdump --verify %t
 
 # CHECK: 0x0000001e:   DW_TAG_variable
 # CHECK:                 DW_AT_name      ("p1")


### PR DESCRIPTION
Because DW_TAG_LLVM_ptrauth_type is not marked as a type, dwarfdump
currently emits a spurious error: DIE has DW_AT_type with incompatible
tag DW_TAG_LLVM_ptrauth_type. This patch fixes that and adds a test.

(cherry picked from commit d77556549a4ea940edba3dfa388cbec4c3bb7f20)
