### PR TITLE
[lldb][test] Remove empty setUp methods (NFC)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbplaygroundrepl.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplaygroundrepl.py
@@ -37,9 +37,6 @@ class PlaygroundREPLTest(TestBase):
         (exit_status, output) = subprocess.getstatusoutput(command)
         return exit_status
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def repl_set_up(self):
         """
         Playgrounds REPL test specific setup that must happen after class setup

--- a/lldb/test/API/commands/watchpoints/watchpoint_count/TestWatchpointCount.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_count/TestWatchpointCount.py
@@ -6,9 +6,6 @@ from lldbsuite.test import lldbutil
 class TestWatchpointCount(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipIf(oslist=["freebsd", "linux"], archs=["arm", "aarch64"],
             bugnumber="llvm.org/pr26031")
     def test_watchpoint_count(self):

--- a/lldb/test/API/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
@@ -21,9 +21,6 @@ import os
 
 class TestSwiftTypeAliasFormatters(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_swift_type_alias_formatters(self):
         """Test that Swift typealiases get formatted properly"""

--- a/lldb/test/API/functionalities/scripted_process/TestScriptedProcess.py
+++ b/lldb/test/API/functionalities/scripted_process/TestScriptedProcess.py
@@ -14,12 +14,6 @@ class ScriptedProcesTestCase(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
-    def setUp(self):
-        TestBase.setUp(self)
-
-    def tearDown(self):
-        TestBase.tearDown(self)
-
     def test_python_plugin_package(self):
         """Test that the lldb python module has a `plugins.scripted_process`
         package."""

--- a/lldb/test/API/functionalities/scripted_process/TestStackCoreScriptedProcess.py
+++ b/lldb/test/API/functionalities/scripted_process/TestStackCoreScriptedProcess.py
@@ -14,12 +14,6 @@ class StackCoreScriptedProcesTestCase(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
-    def setUp(self):
-        TestBase.setUp(self)
-
-    def tearDown(self):
-        TestBase.tearDown(self)
-
     def create_stack_skinny_corefile(self, file):
         self.build()
         target, process, thread, _ = lldbutil.run_to_source_breakpoint(self, "// break here",

--- a/lldb/test/API/functionalities/tail_call_frames/cross_dso/TestCrossDSOTailCalls.py
+++ b/lldb/test/API/functionalities/tail_call_frames/cross_dso/TestCrossDSOTailCalls.py
@@ -10,9 +10,6 @@ from lldbsuite.test import lldbutil
 
 class TestCrossDSOTailCalls(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipIf(compiler="clang", compiler_version=['<', '10.0'])
     @skipIf(dwarf_version=['<', '4'])
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr26265")

--- a/lldb/test/API/functionalities/tail_call_frames/cross_object/TestCrossObjectTailCalls.py
+++ b/lldb/test/API/functionalities/tail_call_frames/cross_object/TestCrossObjectTailCalls.py
@@ -10,9 +10,6 @@ from lldbsuite.test import lldbutil
 
 class TestCrossObjectTailCalls(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipIf(compiler="clang", compiler_version=['<', '10.0'])
     @skipIf(dwarf_version=['<', '4'])
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr26265")

--- a/lldb/test/API/lang/swift/any_object/TestSwiftAnyObjectType.py
+++ b/lldb/test/API/lang/swift/any_object/TestSwiftAnyObjectType.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftAnyObjectType(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_any_object_type(self):
         """Test the AnyObject type"""

--- a/lldb/test/API/lang/swift/archetype_resolution/TestSwiftArchetypeResolution.py
+++ b/lldb/test/API/lang/swift/archetype_resolution/TestSwiftArchetypeResolution.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftArchetypeResolution(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_swift_archetype_resolution(self):
         """Test that archetype-typed objects get resolved to their proper location in memory"""

--- a/lldb/test/API/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
+++ b/lldb/test/API/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftArchetypeResolution(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_swift_associated_type_resolution(self):
         """Test that archetype-typed objects get resolved to their proper location in memory"""

--- a/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
+++ b/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
@@ -28,9 +28,6 @@ class SwiftPartialBreakTest(TestBase):
         self.build()
         self.break_commands()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def break_commands(self):
         """Tests that we can break on a partial name of a Swift function"""
         self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)

--- a/lldb/test/API/lang/swift/bridged_metatype/TestSwiftBridgedMetatype.py
+++ b/lldb/test/API/lang/swift/bridged_metatype/TestSwiftBridgedMetatype.py
@@ -11,9 +11,6 @@ import unittest2
 
 class TestSwiftBridgedMetatype(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     @skipUnlessFoundation
     def test_swift_bridged_metatype(self):

--- a/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
@@ -6,9 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftWerror(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/bridging_header_headermap/TestSwiftBridgingHeaderHeadermap.py
+++ b/lldb/test/API/lang/swift/clangimporter/bridging_header_headermap/TestSwiftBridgingHeaderHeadermap.py
@@ -21,9 +21,6 @@ import shutil
 class TestSwiftBridgingHeaderHeadermap(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -19,9 +19,6 @@ import unittest2
 
 class TestSwiftDedupMacros(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     # NOTE: rdar://44201206 - This test may sporadically segfault. It's likely

--- a/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
@@ -20,9 +20,6 @@ import shutil
 
 class TestSwiftDynamicTypeResolutionImportConflict(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/expr_import/TestSwiftExprImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/expr_import/TestSwiftExprImport.py
@@ -6,9 +6,6 @@ import unittest2
 
 class TestSwiftExprImport(TestBase):
     
-    def setUp(self):
-        TestBase.setUp(self)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @swiftTest

--- a/lldb/test/API/lang/swift/clangimporter/extra_clang_flags/TestSwiftExtraClangFlags.py
+++ b/lldb/test/API/lang/swift/clangimporter/extra_clang_flags/TestSwiftExtraClangFlags.py
@@ -6,9 +6,6 @@ import unittest2
 
 class TestSwiftExtraClangFlags(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(oslist=['windows'])

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/TestSwiftHardMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/TestSwiftHardMacroConflict.py
@@ -8,9 +8,6 @@ import shutil
 
 class TestSwiftHardMacroConflict(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     NO_DEBUG_INFO_TESTCASE = True
 
     # Don't run ClangImporter tests if Clangimporter is disabled.

--- a/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
@@ -20,9 +20,6 @@ import shutil
 
 class TestSwiftHeadermapConflict(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipIf(bugnumber="rdar://60396797",
             setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
@@ -20,9 +20,6 @@ import shutil
 
 class TestSwiftIncludeConflict(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
@@ -20,9 +20,6 @@ import shutil
 
 class TestSwiftMacroConflict(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/TestSwiftMissingVFSOverlay.py
+++ b/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/TestSwiftMissingVFSOverlay.py
@@ -8,9 +8,6 @@ class TestSwiftMissingVFSOverlay(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
     
-    def setUp(self):
-        TestBase.setUp(self)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
@@ -20,9 +20,6 @@ import shutil
 
 class TestSwiftObjCMainConflictingDylibs(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
@@ -20,9 +20,6 @@ import shutil
 
 class TestSwiftObjCMainConflictingDylibsBridgingHeader(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
@@ -22,9 +22,6 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
+++ b/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
@@ -7,9 +7,6 @@ import unittest2
 
 class TestSwiftRewriteClangPaths(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipUnlessDarwin
     @skipIfDarwinEmbedded
     @swiftTest

--- a/lldb/test/API/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
@@ -19,9 +19,6 @@ import unittest2
 
 class TestSwiftRemoteASTImport(TestBase):
     
-    def setUp(self):
-        TestBase.setUp(self)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -20,9 +20,6 @@ import shutil
 
 class TestSwiftRewriteClangPaths(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
+++ b/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
@@ -19,9 +19,6 @@ import unittest2
 
 class TestSwiftStaticArchiveTwoSwiftmodules(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
+++ b/lldb/test/API/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
@@ -27,9 +27,6 @@ class TestSwiftConditionalBreakpoint(TestBase):
         self.build()
         self.break_commands()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def check_x_and_y(self, frame, x, y):
         x_var = frame.FindVariable("x")
         y_var = frame.FindVariable("y")

--- a/lldb/test/API/lang/swift/cross_module_extension/TestSwiftCrossModuleExtension.py
+++ b/lldb/test/API/lang/swift/cross_module_extension/TestSwiftCrossModuleExtension.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftCrossModuleExtension(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipUnlessDarwin
     @swiftTest
     def test_cross_module_extension(self):

--- a/lldb/test/API/lang/swift/debug_prefix_map/TestSwiftDebugPrefixMap.py
+++ b/lldb/test/API/lang/swift/debug_prefix_map/TestSwiftDebugPrefixMap.py
@@ -28,9 +28,6 @@ class TestSwiftDebugPrefixMap(TestBase):
     def test_debug_prefix_map(self):
         self.do_test()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def do_test(self):
         # Mirror the same source tree layout used in the Makefile. When lldb is
         # invoked in the CWD, it should find the source files with the same

--- a/lldb/test/API/lang/swift/deserialization_failure/TestSwiftDeserializationFailure.py
+++ b/lldb/test/API/lang/swift/deserialization_failure/TestSwiftDeserializationFailure.py
@@ -7,9 +7,6 @@ import unittest2
 
 class TestSwiftDeserializationFailure(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def prepare(self):
         import shutil
         copied_source = self.getBuildArtifact("main.swift")

--- a/lldb/test/API/lang/swift/different_clang_flags/TestSwiftDifferentClangFlags.py
+++ b/lldb/test/API/lang/swift/different_clang_flags/TestSwiftDifferentClangFlags.py
@@ -37,9 +37,6 @@ def execute_command(command):
 
 class TestSwiftDifferentClangFlags(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipUnlessDarwin
     @swiftTest
     @skipIf(

--- a/lldb/test/API/lang/swift/dynamic_value/TestSwiftDynamicValue.py
+++ b/lldb/test/API/lang/swift/dynamic_value/TestSwiftDynamicValue.py
@@ -27,9 +27,6 @@ class SwiftDynamicValueTest(TestBase):
         self.build()
         self.dynamic_val_commands()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def dynamic_val_commands(self):
         """Tests that dynamic values work correctly for Swift"""
         lldbutil.run_to_source_breakpoint(self, "// Set a breakpoint here", lldb.SBFileSpec("main.swift"))

--- a/lldb/test/API/lang/swift/expression/access_control/TestSwiftExpressionAccessControl.py
+++ b/lldb/test/API/lang/swift/expression/access_control/TestSwiftExpressionAccessControl.py
@@ -8,9 +8,6 @@ import unittest2
 
 class TestSwiftExpressionAccessControl(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_swift_expression_access_control(self):
         """Make sure expressions ignore access control"""

--- a/lldb/test/API/lang/swift/expression/classes/fromobjc/TestSwiftExpressionsInMethodsFromObjc.py
+++ b/lldb/test/API/lang/swift/expression/classes/fromobjc/TestSwiftExpressionsInMethodsFromObjc.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestExpressionsInSwiftMethodsFromObjC(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def check_expression(self, expression, expected_result, use_summary=True):
         value = self.frame().EvaluateExpression(expression)
         self.assertTrue(value.IsValid(), expression + "returned a valid value")

--- a/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
+++ b/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestExpressionsInSwiftMethodsPureSwift(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def check_expression(self, expression, expected_result, use_summary=True):
         value = self.frame().EvaluateExpression(expression)
         self.assertTrue(value.IsValid(), expression + "returned a valid value")

--- a/lldb/test/API/lang/swift/expression/equality_operators/TestEqualityOperators.py
+++ b/lldb/test/API/lang/swift/expression/equality_operators/TestEqualityOperators.py
@@ -65,9 +65,6 @@ class TestUnitTests(TestBase):
         self.build()
         self.do_test("Fooey.CompareEm3", "false", 3)
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def do_test(self, bkpt_name, compare_value, counter_value):
         """Test that we resolve expression operators correctly"""
         lldbutil.run_to_name_breakpoint(self, bkpt_name,

--- a/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
+++ b/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
@@ -19,9 +19,6 @@ import unittest2
 
 class TestSwiftExpressionObjCContext(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
+++ b/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestDefiningOverloadedFunctions(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def check_expression(self, expression, expected_result, use_summary=True):
         value = self.frame().EvaluateExpression(expression)
         self.assertTrue(value.IsValid(), expression + "returned a valid value")

--- a/lldb/test/API/lang/swift/expression/protocol_extension/TestExprInProtocolExtension.py
+++ b/lldb/test/API/lang/swift/expression/protocol_extension/TestExprInProtocolExtension.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftExprInProtocolExtension(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def check_expression(self, expression, expected_result, use_summary=True):
         value = self.frame().EvaluateExpression(
             expression, lldb.eDynamicCanRunTarget)

--- a/lldb/test/API/lang/swift/expression/simple/TestSimpleExpressions.py
+++ b/lldb/test/API/lang/swift/expression/simple/TestSimpleExpressions.py
@@ -23,9 +23,6 @@ import unittest2
 
 class TestSimpleSwiftExpressions(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def check_expression(self, expression, expected_result, use_summary=True):
         value = self.frame().EvaluateExpression(expression)
         self.assertTrue(value.IsValid(), expression + "returned a valid value")

--- a/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
+++ b/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftExpressionsInClassFunctions(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def check_expression(self, expression, expected_result, use_summary=True):
         opts = lldb.SBExpressionOptions()
         opts.SetFetchDynamicValue(lldb.eDynamicCanRunTarget)

--- a/lldb/test/API/lang/swift/expression/submodule_import/TestSubmoduleImport.py
+++ b/lldb/test/API/lang/swift/expression/submodule_import/TestSubmoduleImport.py
@@ -24,9 +24,6 @@ class TestSwiftSubmoduleImport(TestBase):
     # Have to find some submodule that is present on both Darwin & Linux for this
     # test to run on both systems...
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipUnlessDarwin
     @swiftTest
     def test_swift_submodule_import(self):

--- a/lldb/test/API/lang/swift/external_provider_extra_inhabitants/TestExternalProviderExtraInhabitants.py
+++ b/lldb/test/API/lang/swift/external_provider_extra_inhabitants/TestExternalProviderExtraInhabitants.py
@@ -8,9 +8,6 @@ from lldbsuite.test.decorators import *
 
 class TestExternalProviderExtraInhabitants(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/foundation_value_types/global/TestSwiftFoundationTypeGlobal.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/global/TestSwiftFoundationTypeGlobal.py
@@ -7,9 +7,6 @@ import unittest2
 
 class TestSwiftFoundationValueTypeGlobal(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     @skipUnlessFoundation
     def test(self):

--- a/lldb/test/API/lang/swift/generics/TestSwiftGenericsResolution.py
+++ b/lldb/test/API/lang/swift/generics/TestSwiftGenericsResolution.py
@@ -27,9 +27,6 @@ class SwiftDynamicTypeGenericsTest(TestBase):
         self.build()
         self.genericresolution_commands()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def genericresolution_commands(self):
         """Check that we can correctly figure out the dynamic type of generic things"""
         lldbutil.run_to_source_breakpoint(self, "//Break here", lldb.SBFileSpec("main.swift"))

--- a/lldb/test/API/lang/swift/get_value/TestSwiftGetValueAsUnsigned.py
+++ b/lldb/test/API/lang/swift/get_value/TestSwiftGetValueAsUnsigned.py
@@ -27,9 +27,6 @@ class SwiftGetValueAsUnsignedAPITest(TestBase):
         self.build()
         self.getvalue_commands()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def getvalue_commands(self):
         """Tests that the SBValue::GetValueAsUnsigned() API works for Swift types"""
         (target, process, thread, breakpoint) = lldbutil.run_to_source_breakpoint(self, 

--- a/lldb/test/API/lang/swift/hashed_containers_enums/TestSwiftHashedContainerEnum.py
+++ b/lldb/test/API/lang/swift/hashed_containers_enums/TestSwiftHashedContainerEnum.py
@@ -13,9 +13,6 @@ import unittest2
 
 class TestSwiftHashedContainerEnum(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_any_object_type(self):
         """Test combinations of hashed swift containers with enums"""

--- a/lldb/test/API/lang/swift/hide_runtimesupport/TestSwiftHideRuntimeSupport.py
+++ b/lldb/test/API/lang/swift/hide_runtimesupport/TestSwiftHideRuntimeSupport.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftHideRuntimeSupport(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_swift_hide_runtime_support(self):
         """Test that we hide runtime support values"""

--- a/lldb/test/API/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
+++ b/lldb/test/API/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftCGImportedTypes(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipUnlessDarwin
     @swiftTest
     def test_swift_cg_imported_types(self):

--- a/lldb/test/API/lang/swift/let_int/TestSwiftLetInt.py
+++ b/lldb/test/API/lang/swift/let_int/TestSwiftLetInt.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftLetIntSupport(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_swift_let_int(self):
         """Test that a 'let' Int is formatted properly"""

--- a/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
+++ b/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftMetatype(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_metatype(self):
         """Test the formatting of Swift metatypes"""

--- a/lldb/test/API/lang/swift/mix_any_object/TestSwiftMixAnyObjectType.py
+++ b/lldb/test/API/lang/swift/mix_any_object/TestSwiftMixAnyObjectType.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftMixAnyObjectType(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipUnlessDarwin
     @swiftTest
     def test_any_object_type(self):

--- a/lldb/test/API/lang/swift/multilang_category/TestMultilangFormatterCategories.py
+++ b/lldb/test/API/lang/swift/multilang_category/TestMultilangFormatterCategories.py
@@ -10,9 +10,6 @@ import os
 
 class TestMultilangFormatterCategories(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     @skipUnlessDarwin
     def test_multilang_formatter_categories(self):

--- a/lldb/test/API/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
+++ b/lldb/test/API/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftMultipayloadEnum(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_swift_multipayload_enum(self):
         """Test that LLDB understands generic enums with more than one payload type"""

--- a/lldb/test/API/lang/swift/nserror/TestNSError.py
+++ b/lldb/test/API/lang/swift/nserror/TestNSError.py
@@ -36,9 +36,6 @@ class SwiftNSErrorTest(TestBase):
         self.build()
         self.nserror_commands(check_userInfo=True)
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def nserror_commands(self, check_userInfo=True):
         """Tests that Swift displays NSError correctly"""
         self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)

--- a/lldb/test/API/lang/swift/objc_inherited_ivars/TestSwiftAtObjCIvars.py
+++ b/lldb/test/API/lang/swift/objc_inherited_ivars/TestSwiftAtObjCIvars.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftAtObjCIvars(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def check_foo(self, theFoo):
         x = theFoo.GetChildMemberWithName("x")
         y = theFoo.GetChildMemberWithName("y")

--- a/lldb/test/API/lang/swift/optional_of_resilient/TestResilientObjectInOptional.py
+++ b/lldb/test/API/lang/swift/optional_of_resilient/TestResilientObjectInOptional.py
@@ -27,9 +27,6 @@ class TestResilientObjectInOptional(TestBase):
         self.build()
         self.doTest()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def doTest(self):
         target, process, thread, breakpoint = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.swift"),

--- a/lldb/test/API/lang/swift/other_arch_dylib/TestSwiftOtherArchDylib.py
+++ b/lldb/test/API/lang/swift/other_arch_dylib/TestSwiftOtherArchDylib.py
@@ -8,9 +8,6 @@ import unittest2
 
 class TestSwiftOtherArchDylib(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest

--- a/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
@@ -20,9 +20,6 @@ import unittest2
 
 class TestSwiftInterfaceDSYM(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     @skipIf(archs=no_match("x86_64"))
     @skipIf(debug_info=no_match(["dsym"]))

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
@@ -97,9 +97,6 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
         with open(self.getBuildArtifact("sdk-root.txt"), "r") as sdkroot:
             return sdkroot.read().rstrip()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def do_test(self):
         # The custom swift module cache location
         swift_mod_cache = self.getBuildArtifact("MCP")

--- a/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
@@ -44,9 +44,6 @@ class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
             open(self.getBuildArtifact(module), 'w').close()
         self.do_test()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def do_test(self):
         # The custom swift module cache location
         swift_mod_cache = self.getBuildArtifact("MCP")

--- a/lldb/test/API/lang/swift/path_with_colons/TestSwiftPathWithColons.py
+++ b/lldb/test/API/lang/swift/path_with_colons/TestSwiftPathWithColons.py
@@ -33,9 +33,6 @@ class TestSwiftPathWithColon(TestBase):
         """Test that LLDB correctly handles paths with colons"""
         self.do_test()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def do_test(self):
         """Test that LLDB correctly handles paths with colons"""
         src = os.path.join(self.getSourceDir(), 'main.swift')

--- a/lldb/test/API/lang/swift/playgrounds-repl/old_playground/TestNonREPLPlayground.py
+++ b/lldb/test/API/lang/swift/playgrounds-repl/old_playground/TestNonREPLPlayground.py
@@ -33,9 +33,6 @@ def execute_command(command):
 
 class TestNonREPLPlayground(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipUnlessDarwin
     @swiftTest
     @skipIf(

--- a/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
+++ b/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftTypeLookup(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_swift_type_lookup(self):
         """Test the ability to look for type definitions at the command line"""

--- a/lldb/test/API/lang/swift/private_import/TestSwiftPrivateImport.py
+++ b/lldb/test/API/lang/swift/private_import/TestSwiftPrivateImport.py
@@ -5,9 +5,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftPrivateImport(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipUnlessDarwin
     @swiftTest
     def test_private_import(self):

--- a/lldb/test/API/lang/swift/private_typealias/TestSwiftPrivateTypeAlias.py
+++ b/lldb/test/API/lang/swift/private_typealias/TestSwiftPrivateTypeAlias.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftPrivateTypeAlias(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_swift_private_typealias(self):
         """Test that we can correctly print variables whose types are private type aliases"""

--- a/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/TestDefaultProtocolExtensionNoSelfReference.py
+++ b/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/TestDefaultProtocolExtensionNoSelfReference.py
@@ -8,9 +8,6 @@ from lldbsuite.test.decorators import *
 
 class TestDefaultProtocolExtensionNoSelfReference(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_protocol_default_extension_no_self_reference(self):
         """

--- a/lldb/test/API/lang/swift/ranges/TestSwiftRangeTypes.py
+++ b/lldb/test/API/lang/swift/ranges/TestSwiftRangeTypes.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftRangeType(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_swift_range_type(self):
         """Test the Swift.Range<T> type"""

--- a/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
+++ b/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftReferenceStorageTypes(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @decorators.skipIf(archs=['ppc64le']) #SR-10215
     @swiftTest
     @skipIf(oslist=["linux"], bugnumber="rdar://76592966")

--- a/lldb/test/API/lang/swift/resilience/TestSwiftResilience.py
+++ b/lldb/test/API/lang/swift/resilience/TestSwiftResilience.py
@@ -60,9 +60,6 @@ class TestSwiftResilience(TestBase):
         self.doTestWithFlavor("b", "b")
 
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def createSymlinks(self, exe_flavor, mod_flavor):
         execute_command("cp " + self.getBuildArtifact("main." + exe_flavor) + " " + self.getBuildArtifact("main"))
         execute_command("ln -sf " + self.getBuildArtifact("main." + exe_flavor + ".dSYM") + " " + self.getBuildArtifact("main.dSYM"))

--- a/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
+++ b/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
@@ -23,9 +23,6 @@ import unittest2
 
 class TestSwiftStructChangeRerun(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_swift_struct_change_rerun(self):
         """Test that we display self correctly for an inline-initialized struct"""

--- a/lldb/test/API/lang/swift/struct_init_display/TestSwiftStructInit.py
+++ b/lldb/test/API/lang/swift/struct_init_display/TestSwiftStructInit.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftStructInit(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     @skipIf(oslist=['windows'])
     def test_swift_struct_init(self):

--- a/lldb/test/API/lang/swift/swift_version/TestSwiftVersion.py
+++ b/lldb/test/API/lang/swift/swift_version/TestSwiftVersion.py
@@ -30,9 +30,6 @@ class TestSwiftVersion(TestBase):
         self.build()
         self.do_test()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def do_test(self):
         """Test that LLDB can debug different Swift language versions"""
         exe_name = "main"

--- a/lldb/test/API/lang/swift/swiftieformatting/TestSwiftieFormatting.py
+++ b/lldb/test/API/lang/swift/swiftieformatting/TestSwiftieFormatting.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftieFormatting(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipUnlessDarwin
     @swiftTest
     def test_swiftie_formatting(self):

--- a/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
+++ b/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftTuple(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_swift_tuples(self):
         """Test that LLDB understands tuple lowering"""

--- a/lldb/test/API/lang/swift/type_metadata/TestSwiftTypeMetadata.py
+++ b/lldb/test/API/lang/swift/type_metadata/TestSwiftTypeMetadata.py
@@ -27,9 +27,6 @@ class SwiftTypeMetadataTest(TestBase):
         self.build()
         self.var_commands()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def var_commands(self):
         """Test that LLDB can effectively use the type metadata to reconstruct dynamic types for Swift"""
         lldbutil.run_to_source_breakpoint(self, "// Set breakpoint here", lldb.SBFileSpec("main.swift"))

--- a/lldb/test/API/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
@@ -25,9 +25,6 @@ import unittest2
 
 class TestSwiftBridgedStringVariables(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipUnlessDarwin
     @swiftTest
     def test_swift_bridged_string_variables(self):

--- a/lldb/test/API/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
+++ b/lldb/test/API/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
@@ -28,9 +28,6 @@ class TestBulkyEnumVariables(TestBase):
         self.build()
         self.do_test()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def do_test(self):
         """Tests that large-size Enum variables display correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/cgtypes/TestCGTypes.py
+++ b/lldb/test/API/lang/swift/variables/cgtypes/TestCGTypes.py
@@ -29,9 +29,6 @@ class TestSwiftCoreGraphicsTypes(TestBase):
         self.build()
         self.do_test()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def do_test(self):
         """Test that we are able to properly format basic CG types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/class/TestSwiftMetadataSymbols.py
+++ b/lldb/test/API/lang/swift/variables/class/TestSwiftMetadataSymbols.py
@@ -28,9 +28,6 @@ class TestSwiftMetadataSymbols(TestBase):
         self.build()
         self.do_test()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def do_test(self):
         """Tests that we can break and display simple types"""
         exe_name = "a.out"

--- a/lldb/test/API/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
+++ b/lldb/test/API/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestDictionaryNSObjectAnyObject(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipUnlessDarwin
     @swiftTest
     def test_dictionary_nsobject_any_object(self):

--- a/lldb/test/API/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
+++ b/lldb/test/API/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftStdlibDictionary(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def get_variable(self, name):
         var = self.frame().FindVariable(
             name).GetDynamicValue(lldb.eDynamicCanRunTarget)

--- a/lldb/test/API/lang/swift/variables/generic_enums/TestSwiftGenericEnums.py
+++ b/lldb/test/API/lang/swift/variables/generic_enums/TestSwiftGenericEnums.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftGenericEnumTypes(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def get_variable(self, name):
         var = self.frame().FindVariable(
             name).GetDynamicValue(lldb.eDynamicCanRunTarget)

--- a/lldb/test/API/lang/swift/variables/objc/TestSwiftObjCImportedTypes.py
+++ b/lldb/test/API/lang/swift/variables/objc/TestSwiftObjCImportedTypes.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftObjCImportedTypes(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     @skipUnlessDarwin
     def test_swift_objc_imported_types(self):

--- a/lldb/test/API/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
+++ b/lldb/test/API/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
@@ -31,9 +31,6 @@ class TestSwiftObjCOptionalType(TestBase):
         self.do_check_visuals()
         self.do_check_api()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def do_check_consistency(self):
         """Check formatting for T? and T! when T is an ObjC type"""
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
+++ b/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
@@ -29,9 +29,6 @@ class TestSwiftOptionalType(TestBase):
         self.do_check_visuals()
         self.do_check_api()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def do_check_consistency(self):
         """Check formatting for T? and T!"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/set/TestSwiftStdlibSet.py
+++ b/lldb/test/API/lang/swift/variables/set/TestSwiftStdlibSet.py
@@ -22,9 +22,6 @@ import unittest2
 
 class TestSwiftStdlibSet(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_swift_stdlib_set(self):
         """Tests that we properly vend synthetic children for Swift.Set"""

--- a/lldb/test/API/lang/swift/variables/static_string/TestSwiftStaticStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/static_string/TestSwiftStaticStringVariables.py
@@ -31,9 +31,6 @@ class TestSwiftStaticStringVariables(TestBase):
         self.build()
         self.do_test()
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     def do_test(self):
         """Test that Swift.String formats properly"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/string/TestSwiftStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/string/TestSwiftStringVariables.py
@@ -25,9 +25,6 @@ import unittest2
 
 class TestSwiftStringVariables(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @swiftTest
     def test_swift_string_variables(self):
         """Test that Swift.String formats properly"""

--- a/lldb/tools/intel-features/intel-mpx/test/TestMPXTable.py
+++ b/lldb/tools/intel-features/intel-mpx/test/TestMPXTable.py
@@ -16,9 +16,6 @@ from lldbsuite.test import lldbutil
 
 class TestMPXTable(TestBase):
 
-    def setUp(self):
-        TestBase.setUp(self)
-
     @skipIf(compiler="clang")
     @skipIf(oslist=no_match(['linux']))
     @skipIf(archs=no_match(['i386', 'x86_64']))


### PR DESCRIPTION
Remove `setUp` (and a couple `tearDown`) methods that do nothing other than call super.