### PR TITLE
[lldb] Add type summary for String.Index

### DIFF
--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -2670,8 +2670,8 @@ unsigned ASTWriter::getSubmoduleID(Module *Mod) {
   // did not result in us loading a module file for that submodule. For
   // instance, a cross-top-level-module 'conflict' declaration will hit this.
   unsigned ID = getLocalOrImportedSubmoduleID(Mod);
-  //assert((ID || !Mod) &&
-  //       "asked for module ID for non-local, non-imported module");
+  assert((ID || !Mod) &&
+         "asked for module ID for non-local, non-imported module");
   return ID;
 }
 

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -2670,8 +2670,8 @@ unsigned ASTWriter::getSubmoduleID(Module *Mod) {
   // did not result in us loading a module file for that submodule. For
   // instance, a cross-top-level-module 'conflict' declaration will hit this.
   unsigned ID = getLocalOrImportedSubmoduleID(Mod);
-  assert((ID || !Mod) &&
-         "asked for module ID for non-local, non-imported module");
+  //assert((ID || !Mod) &&
+  //       "asked for module ID for non-local, non-imported module");
   return ID;
 }
 

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -54,6 +54,9 @@ bool String_SummaryProvider(ValueObject &valobj, Stream &stream,
                             const TypeSummaryOptions &,
                             StringPrinter::ReadStringAndDumpToStreamOptions);
 
+bool StringIndex_SummaryProvider(ValueObject &valobj, Stream &stream,
+                                 const TypeSummaryOptions &options);
+
 bool StaticString_SummaryProvider(ValueObject &valobj, Stream &stream,
                                   const TypeSummaryOptions &options);
 

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -418,6 +418,10 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   AddCXXSummary(swift_category_sp, string_summary_provider,
                 "Swift.String summary provider", ConstString("Swift.String"),
                 summary_flags);
+  AddCXXSummary(swift_category_sp,
+                lldb_private::formatters::swift::StringIndex_SummaryProvider,
+                "Swift String.Index summary provider",
+                ConstString("Swift.String.Index"), summary_flags);
   bool (*staticstring_summary_provider)(ValueObject &, Stream &,
                                         const TypeSummaryOptions &) =
       lldb_private::formatters::swift::StaticString_SummaryProvider;

--- a/lldb/source/Plugins/Language/Swift/SwiftStringIndex.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftStringIndex.h
@@ -1,0 +1,65 @@
+//===-- SwiftStringIndex.h --------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_SwiftStringIndex_h
+#define liblldb_SwiftStringIndex_h
+
+#include "lldb/lldb-forward.h"
+
+namespace lldb_private {
+namespace formatters {
+namespace swift {
+
+// From SwiftIndex.swift
+//  ┌──────────┬────────────────╥────────────────┬───────╥───────┐
+//  │ b63:b16  │      b15:b14   ║     b13:b8     │ b7:b4 ║ b3:b0 │
+//  ├──────────┼────────────────╫────────────────┼───────╫───────┤
+//  │ position │ transc. offset ║ grapheme cache │ rsvd  ║ flags │
+//  └──────────┴────────────────╨────────────────┴───────╨───────┘
+//                              └────── resilient ───────┘
+class StringIndex {
+  uint64_t _rawBits;
+
+  enum Flags : uint8_t {
+    IsScalarAligned = 1 << 0,
+    IsCharacterAligned = 1 << 1,
+    CanBeUTF8 = 1 << 2,
+    CanBeUTF16 = 1 << 3,
+  };
+
+public:
+  StringIndex(uint64_t rawBits) : _rawBits(rawBits) {}
+
+  uint64_t encodedOffset() { return _rawBits >> 16; }
+
+  const char *encodingName() {
+    uint8_t flags = _rawBits & 0b1111;
+    bool canBeUTF8 = flags & Flags::CanBeUTF8;
+    bool canBeUTF16 = flags & Flags::CanBeUTF16;
+    if (canBeUTF8 && canBeUTF16)
+      return "any";
+    else if (canBeUTF8)
+      return "utf8";
+    else if (canBeUTF16)
+      return "utf16";
+    else
+      return "unknown";
+  }
+
+  uint8_t transcodedOffset() { return (_rawBits >> 14) & 0b11; }
+};
+
+}; // namespace swift
+}; // namespace formatters
+}; // namespace lldb_private
+
+#endif

--- a/lldb/test/API/functionalities/data-formatter/swift/string-index/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/swift/string-index/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/swift/string-index/TestSwiftStringIndexFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/string-index/TestSwiftStringIndexFormatters.py
@@ -1,14 +1,3 @@
-# TestSwiftStringIndexFormatters.py
-#
-# This source file is part of the Swift.org open source project
-#
-# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-# Licensed under Apache License v2.0 with Runtime Library Exception
-#
-# See https://swift.org/LICENSE.txt for license information
-# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-#
-# ------------------------------------------------------------------------------
 """
 Test String.Index summary strings.
 

--- a/lldb/test/API/functionalities/data-formatter/swift/string-index/TestSwiftStringIndexFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/string-index/TestSwiftStringIndexFormatters.py
@@ -22,6 +22,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
+    @skipUnlessFoundation
     @swiftTest
     def test_swift_string_index_formatters(self):
         """Test String.Index summary strings."""

--- a/lldb/test/API/functionalities/data-formatter/swift/string-index/TestSwiftStringIndexFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/string-index/TestSwiftStringIndexFormatters.py
@@ -57,7 +57,7 @@ class TestCase(TestBase):
         )
 
         self.expect(
-            "v utf8Indicies",
+            "v utf8Indices",
             substrs=[
                 "0[any]",
                 "1[utf8]",
@@ -74,7 +74,7 @@ class TestCase(TestBase):
         )
 
         self.expect(
-            "v utf16Indicies",
+            "v utf16Indices",
             substrs=[
                 "0[any]",
                 "1[utf8]",
@@ -114,7 +114,7 @@ class TestCase(TestBase):
         )
 
         self.expect(
-            "v utf8Indicies",
+            "v utf8Indices",
             substrs=[
                 "0[any]",
                 "1[utf16]",
@@ -131,7 +131,7 @@ class TestCase(TestBase):
         )
 
         self.expect(
-            "v utf16Indicies",
+            "v utf16Indices",
             substrs=[
                 "0[any]",
                 "1[utf16]",

--- a/lldb/test/API/functionalities/data-formatter/swift/string-index/TestSwiftStringIndexFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/string-index/TestSwiftStringIndexFormatters.py
@@ -1,0 +1,143 @@
+# TestSwiftStringIndexFormatters.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+"""
+Test String.Index summary strings.
+
+The test cases are LLDB versions of the original Swift tests, see
+https://github.com/apple/swift/pull/58479
+"""
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @swiftTest
+    def test_swift_string_index_formatters(self):
+        """Test String.Index summary strings."""
+        self.build()
+        _, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        #
+        # The first breakpoint stop tests a native (non-bridged) String.
+        #
+
+        self.expect(
+            "v nativeIndices",
+            substrs=[
+                "0[any]",
+                "1[utf8]",
+                "9[utf8]",
+                "10[utf8]",
+            ],
+        )
+
+        self.expect(
+            "v unicodeScalarIndices",
+            substrs=[
+                "0[any]",
+                "1[utf8]",
+                "5[utf8]",
+                "9[utf8]",
+                "10[utf8]",
+            ],
+        )
+
+        self.expect(
+            "v utf8Indicies",
+            substrs=[
+                "0[any]",
+                "1[utf8]",
+                "2[utf8]",
+                "3[utf8]",
+                "4[utf8]",
+                "5[utf8]",
+                "6[utf8]",
+                "7[utf8]",
+                "8[utf8]",
+                "9[utf8]",
+                "10[utf8]",
+            ],
+        )
+
+        self.expect(
+            "v utf16Indicies",
+            substrs=[
+                "0[any]",
+                "1[utf8]",
+                "1[utf8]+1",
+                "5[utf8]",
+                "5[utf8]+1",
+                "9[utf8]",
+                "10[utf8]",
+            ],
+        )
+
+        #
+        # The second breakpoint stop tests a bridged String.
+        #
+
+        process.Continue()
+
+        self.expect(
+            "v nativeIndices",
+            substrs=[
+                "0[any]",
+                "1[utf16]",
+                "5[utf16]",
+                "6[utf16]",
+            ],
+        )
+
+        self.expect(
+            "v unicodeScalarIndices",
+            substrs=[
+                "0[any]",
+                "1[utf16]",
+                "3[utf16]",
+                "5[utf16]",
+                "6[utf16]",
+            ],
+        )
+
+        self.expect(
+            "v utf8Indicies",
+            substrs=[
+                "0[any]",
+                "1[utf16]",
+                "1[utf16]+1",
+                "1[utf16]+2",
+                "1[utf16]+3",
+                "3[utf16]",
+                "3[utf16]+1",
+                "3[utf16]+2",
+                "3[utf16]+3",
+                "5[utf16]",
+                "6[utf16]",
+            ],
+        )
+
+        self.expect(
+            "v utf16Indicies",
+            substrs=[
+                "0[any]",
+                "1[utf16]",
+                "2[utf16]",
+                "3[utf16]",
+                "4[utf16]",
+                "5[utf16]",
+                "6[utf16]",
+            ],
+        )

--- a/lldb/test/API/functionalities/data-formatter/swift/string-index/main.swift
+++ b/lldb/test/API/functionalities/data-formatter/swift/string-index/main.swift
@@ -1,15 +1,3 @@
-// main.swift
-//
-// This source file is part of the Swift.org open source project
-//
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-// Licensed under Apache License v2.0 with Runtime Library Exception
-//
-// See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-//
-// -----------------------------------------------------------------------------
-
 import Foundation
 
 func main() {
@@ -28,8 +16,8 @@ func exerciseBridged() {
 func exercise(_ string: String) {
     let nativeIndices = allIndices(string)
     let unicodeScalarIndices = allIndices(string.unicodeScalars)
-    let utf8Indicies = allIndices(string.utf8)
-    let utf16Indicies = allIndices(string.utf16)
+    let utf8Indices = allIndices(string.utf8)
+    let utf16Indices = allIndices(string.utf16)
     // break here
 }
 

--- a/lldb/test/API/functionalities/data-formatter/swift/string-index/main.swift
+++ b/lldb/test/API/functionalities/data-formatter/swift/string-index/main.swift
@@ -1,0 +1,40 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+
+import Foundation
+
+func main() {
+    exerciseNative()
+    exerciseBridged()
+}
+
+func exerciseNative() {
+    exercise("a👉🏼b")
+}
+
+func exerciseBridged() {
+    exercise("a👉🏼b" as NSString as String)
+}
+
+func exercise(_ string: String) {
+    let nativeIndices = allIndices(string)
+    let unicodeScalarIndices = allIndices(string.unicodeScalars)
+    let utf8Indicies = allIndices(string.utf8)
+    let utf16Indicies = allIndices(string.utf16)
+    // break here
+}
+
+func allIndices<T: Collection>(_ collection: T) -> [T.Index] {
+    return Array(collection.indices) + [collection.endIndex]
+}
+
+main()


### PR DESCRIPTION
Implement a type summary for Swift's `String.Index`.

The summary string follows the following:
1. Original proposal: https://forums.swift.org/t/improving-string-index-s-printed-descriptions/57027
2. Proposed implementation: https://github.com/apple/swift/pull/58479
3. Temporary(ish) near-`CustomStringConvertible` implementation: https://github.com/apple/swift/pull/61548

The associated test cases are taken from the test cases in https://github.com/apple/swift/pull/58479.

rdar://99211823