### PR TITLE
[clang][cas] Disable caching with AS_SECURE_LOG_FILE set

### DIFF
--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -80,6 +80,10 @@
 // ASM: warning: caching disabled because assembler language mode is enabled
 // ASM-NOT: "-cc1depscan"
 
+// RUN: env AS_SECURE_LOG_FILE=%t/log %clang-cache %clang -target arm64-apple-macosx12 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=AS_SECURE_LOG_FILE
+// AS_SECURE_LOG_FILE: warning: caching disabled because AS_SECURE_LOG_FILE is set
+// AS_SECURE_LOG_FILE-NOT: "-cc1depscan"
+
 // RUN: env LLVM_CACHE_WARNINGS=-Wno-clang-cache %clang-cache %clang -x c++ -fmodules -fmodules-cache-path=%t/mcp -fcxx-modules -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=MOD_HIDE -DPREFIX=%t
 // MOD_HIDE-NOT: warning: caching disabled
 // MOD_HIDE-NOT: "-cc1depscan"

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -58,6 +58,12 @@ static bool shouldCacheInvocation(ArrayRef<const char *> Args,
         << "assembler language mode is enabled";
     return false;
   }
+  if (llvm::sys::Process::GetEnv("AS_SECURE_LOG_FILE")) {
+    // AS_SECURE_LOG_FILE causes uncaptured output in MC assembler.
+    Diags->Report(diag::warn_clang_cache_disabled_caching)
+        << "AS_SECURE_LOG_FILE is set";
+    return false;
+  }
   return true;
 }
 


### PR DESCRIPTION
Companion to https://reviews.llvm.org/D136888

This environment variable causes unhandled output in llvm MC, so disable caching if it is set.

rdar://101558354