### PR TITLE
Instead of removing the DW_FORM_sec_offset from the DistinctDataRef, remove the DW_AT_stmt_list

### DIFF
--- a/llvm/lib/MC/MCCASObjectV1.cpp
+++ b/llvm/lib/MC/MCCASObjectV1.cpp
@@ -1087,7 +1087,7 @@ materializeCUDie(DWARFCompileUnit &DCU, MutableArrayRef<char> SectionContents,
       memcpy(&SectionContents[SectionOffset],
              &DistinctDataArrayRef[DistinctDataOffset], *FormSize);
       DistinctDataOffset += *FormSize;
-    } else if (Form == llvm::dwarf::DW_FORM_sec_offset) {
+    } else if (AbbrevDecl->getAttrByIndex(I) == llvm::dwarf::DW_AT_stmt_list) {
       memcpy(&SectionContents[SectionOffset], &SecOffsetVals[SecOffsetIndex],
              *FormSize);
       assert(SecOffsetVals.size() != 0 &&
@@ -2081,7 +2081,7 @@ static void partitionCUDie(
                      AttrValue.Value.getForm()))
       append_range(PartitionedData.DistinctData,
                    DebugInfoData.slice(AttrValue.Offset, AttrValue.ByteSize));
-    else if (AttrValue.Value.getForm() != llvm::dwarf::DW_FORM_sec_offset)
+    else if (AttrValue.Attr != llvm::dwarf::DW_AT_stmt_list)
       append_range(PartitionedData.DebugInfoCURefData,
                    DebugInfoData.slice(AttrValue.Offset, AttrValue.ByteSize));
     CUOffset += AttrValue.ByteSize;


### PR DESCRIPTION
This is because the DW_AT_stmt_list is the actual line table offset in a Compile Unit. A DW_FORM_sec_offset can be used for a DW_AT_location as well.

