### PR TITLE
[clang] Move getenv calls to driver, disable caching as necessary

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.h
+++ b/clang/include/clang/Basic/CodeGenOptions.h
@@ -431,6 +431,9 @@ public:
   /// values in order to be included in misexpect diagnostics.
   Optional<uint64_t> DiagnosticsMisExpectTolerance = 0;
 
+  /// The name of a file to use with \c .secure_log_unique directives.
+  std::string AsSecureLogFile;
+
 public:
   // Define accessors/mutators for code generation options of enumeration type.
 #define CODEGENOPT(Name, Bits, Default)

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5197,6 +5197,9 @@ def fno_use_ctor_homing: Flag<["-"], "fno-use-ctor-homing">,
     HelpText<"Don't use constructor homing for debug info">;
 def fuse_ctor_homing: Flag<["-"], "fuse-ctor-homing">,
     HelpText<"Use constructor homing if we are using limited debug info already">;
+def as_secure_log_file : Separate<["-"], "as-secure-log-file">,
+  HelpText<"Emit .secure_log_unique directives to this filename.">,
+  MarshallingInfoString<CodeGenOpts<"AsSecureLogFile">>;
 
 } // let Flags = [CC1Option, CC1AsOption, NoDriverOption]
 

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -476,6 +476,7 @@ static bool initTargetOptions(DiagnosticsEngine &Diags,
           Entry.IgnoreSysRoot ? Entry.Path : HSOpts.Sysroot + Entry.Path);
   Options.MCOptions.Argv0 = CodeGenOpts.Argv0;
   Options.MCOptions.CommandLineArgs = CodeGenOpts.CommandLineArgs;
+  Options.MCOptions.AsSecureLogFile = CodeGenOpts.AsSecureLogFile;
   Options.MisExpect = CodeGenOpts.MisExpect;
 
   return true;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2683,6 +2683,11 @@ static void CollectArgsForIntegratedAssembler(Compilation &C,
   if (C.getDriver().embedBitcodeEnabled() ||
       C.getDriver().embedBitcodeMarkerOnly())
     Args.AddLastArg(CmdArgs, options::OPT_fembed_bitcode_EQ);
+
+  if (const char *AsSecureLogFile = getenv("AS_SECURE_LOG_FILE")) {
+    CmdArgs.push_back("-as-secure-log-file");
+    CmdArgs.push_back(Args.MakeArgString(AsSecureLogFile));
+  }
 }
 
 static void RenderFloatingPointOptions(const ToolChain &TC, const Driver &D,

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -80,6 +80,10 @@
 // ASM: warning: caching disabled because assembler language mode is enabled
 // ASM-NOT: "-cc1depscan"
 
+// RUN: env AS_SECURE_LOG_FILE=%t/log %clang-cache %clang -target arm64-apple-macosx12 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=AS_SECURE_LOG_FILE
+// AS_SECURE_LOG_FILE: warning: caching disabled because AS_SECURE_LOG_FILE is set
+// AS_SECURE_LOG_FILE-NOT: "-cc1depscan"
+
 // RUN: env LLVM_CACHE_WARNINGS=-Wno-clang-cache %clang-cache %clang -x c++ -fmodules -fmodules-cache-path=%t/mcp -fcxx-modules -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=MOD_HIDE -DPREFIX=%t
 // MOD_HIDE-NOT: warning: caching disabled
 // MOD_HIDE-NOT: "-cc1depscan"

--- a/clang/test/CodeGen/as-secure-log-file.c
+++ b/clang/test/CodeGen/as-secure-log-file.c
@@ -1,3 +1,5 @@
+// REQUIRES: x86-registered-target
+
 // RUN: %clang_cc1 -triple x86_64-apple-darwin -emit-obj %s -o %t.o -as-secure-log-file %t.log
 // RUN: FileCheck %s -input-file %t.log
 // CHECK: "foobar"

--- a/clang/test/CodeGen/as-secure-log-file.c
+++ b/clang/test/CodeGen/as-secure-log-file.c
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -triple x86_64-apple-darwin -emit-obj %s -o %t.o -as-secure-log-file %t.log
+// RUN: FileCheck %s -input-file %t.log
+// CHECK: "foobar"
+
+void test(void) {
+  __asm__(".secure_log_unique \"foobar\"");
+}

--- a/clang/test/Driver/AS_SECURE_LOG_FILE.s
+++ b/clang/test/Driver/AS_SECURE_LOG_FILE.s
@@ -1,0 +1,3 @@
+// RUN: env AS_SECURE_LOG_FILE=log_file %clang --target=x86_64-apple-darwin -c %s -### 2>&1 | FileCheck %s
+// CHECK: "-cc1as"
+// CHECK-SAME: "-as-secure-log-file" "log_file"

--- a/clang/test/Misc/cc1as-as-secure-log-file.s
+++ b/clang/test/Misc/cc1as-as-secure-log-file.s
@@ -1,0 +1,5 @@
+// RUN: %clang -cc1as -triple x86_64-apple-darwin %s -o %t.o -as-secure-log-file %t.log
+// RUN: FileCheck %s -input-file %t.log
+// CHECK: "foobar"
+
+.secure_log_unique "foobar"

--- a/clang/test/Misc/cc1as-as-secure-log-file.s
+++ b/clang/test/Misc/cc1as-as-secure-log-file.s
@@ -1,3 +1,5 @@
+// REQUIRES: x86-registered-target
+
 // RUN: %clang -cc1as -triple x86_64-apple-darwin %s -o %t.o -as-secure-log-file %t.log
 // RUN: FileCheck %s -input-file %t.log
 // CHECK: "foobar"

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -56,6 +56,12 @@ static bool shouldCacheInvocation(ArrayRef<const char *> Args,
         << "assembler language mode is enabled";
     return false;
   }
+  if (llvm::sys::Process::GetEnv("AS_SECURE_LOG_FILE")) {
+    // AS_SECURE_LOG_FILE causes uncaptured output in MC assembler.
+    Diags->Report(diag::warn_clang_cache_disabled_caching)
+        << "AS_SECURE_LOG_FILE is set";
+    return false;
+  }
   return true;
 }
 

--- a/clang/tools/driver/cc1as_main.cpp
+++ b/clang/tools/driver/cc1as_main.cpp
@@ -144,6 +144,8 @@ struct AssemblerInvocation {
   /// otherwise.
   std::string TargetABI;
 
+  /// The name of a file to use with \c .secure_log_unique directives.
+  std::string AsSecureLogFile;
   /// @}
 
 public:
@@ -311,6 +313,8 @@ bool AssemblerInvocation::CreateFromArgs(AssemblerInvocation &Opts,
                             .Default(0);
   }
 
+  Opts.AsSecureLogFile = Args.getLastArgValue(OPT_as_secure_log_file);
+
   return Success;
 }
 
@@ -361,6 +365,8 @@ static bool ExecuteAssemblerImpl(AssemblerInvocation &Opts,
   assert(MRI && "Unable to create target register info!");
 
   MCTargetOptions MCOptions;
+  MCOptions.AsSecureLogFile = Opts.AsSecureLogFile;
+
   std::unique_ptr<MCAsmInfo> MAI(
       TheTarget->createMCAsmInfo(*MRI, Opts.Triple, MCOptions));
   assert(MAI && "Unable to create target asm info!");

--- a/clang/tools/driver/cc1as_main.cpp
+++ b/clang/tools/driver/cc1as_main.cpp
@@ -313,7 +313,7 @@ bool AssemblerInvocation::CreateFromArgs(AssemblerInvocation &Opts,
                             .Default(0);
   }
 
-  Opts.AsSecureLogFile = Args.getLastArgValue(OPT_as_secure_log_file);
+  Opts.AsSecureLogFile = std::string(Args.getLastArgValue(OPT_as_secure_log_file));
 
   return Success;
 }

--- a/llvm/include/llvm/MC/MCContext.h
+++ b/llvm/include/llvm/MC/MCContext.h
@@ -172,7 +172,7 @@ private:
   /// The file name of the log file from the environment variable
   /// AS_SECURE_LOG_FILE.  Which must be set before the .secure_log_unique
   /// directive is used or it is an error.
-  char *SecureLogFile;
+  std::string SecureLogFile;
   /// The stream that gets written to for the .secure_log_unique directive.
   std::unique_ptr<raw_fd_ostream> SecureLog;
   /// Boolean toggled when .secure_log_unique / .secure_log_reset is seen to
@@ -812,7 +812,7 @@ public:
 
   /// @}
 
-  char *getSecureLogFile() { return SecureLogFile; }
+  StringRef getSecureLogFile() { return SecureLogFile; }
   raw_fd_ostream *getSecureLog() { return SecureLog.get(); }
 
   void setSecureLog(std::unique_ptr<raw_fd_ostream> Value) {

--- a/llvm/include/llvm/MC/MCTargetOptions.h
+++ b/llvm/include/llvm/MC/MCTargetOptions.h
@@ -62,6 +62,7 @@ public:
   std::string ABIName;
   std::string AssemblyLanguage;
   std::string SplitDwarfFile;
+  std::string AsSecureLogFile;
 
   const char *Argv0 = nullptr;
   ArrayRef<std::string> CommandLineArgs;

--- a/llvm/include/llvm/MC/MCTargetOptionsCommandFlags.h
+++ b/llvm/include/llvm/MC/MCTargetOptionsCommandFlags.h
@@ -44,6 +44,8 @@ bool getNoTypeCheck();
 
 std::string getABIName();
 
+std::string getAsSecureLogFile();
+
 /// Create this object with static storage to register mc-related command
 /// line options.
 struct RegisterMCTargetOptionsFlags {

--- a/llvm/lib/CodeGen/MachineModuleInfo.cpp
+++ b/llvm/lib/CodeGen/MachineModuleInfo.cpp
@@ -66,7 +66,7 @@ MachineModuleInfo::MachineModuleInfo(MachineModuleInfo &&MMI)
     : TM(std::move(MMI.TM)),
       Context(MMI.TM.getTargetTriple(), MMI.TM.getMCAsmInfo(),
               MMI.TM.getMCRegisterInfo(), MMI.TM.getMCSubtargetInfo(), nullptr,
-              nullptr, false),
+              &TM.Options.MCOptions, false),
       MachineFunctions(std::move(MMI.MachineFunctions)) {
   Context.setObjectFileInfo(MMI.TM.getObjFileLowering());
   ObjFileMMI = MMI.ObjFileMMI;
@@ -78,7 +78,7 @@ MachineModuleInfo::MachineModuleInfo(MachineModuleInfo &&MMI)
 MachineModuleInfo::MachineModuleInfo(const LLVMTargetMachine *TM)
     : TM(*TM), Context(TM->getTargetTriple(), TM->getMCAsmInfo(),
                        TM->getMCRegisterInfo(), TM->getMCSubtargetInfo(),
-                       nullptr, nullptr, false) {
+                       nullptr, &TM->Options.MCOptions, false) {
   Context.setObjectFileInfo(TM->getObjFileLowering());
   initialize();
 }
@@ -87,7 +87,7 @@ MachineModuleInfo::MachineModuleInfo(const LLVMTargetMachine *TM,
                                      MCContext *ExtContext)
     : TM(*TM), Context(TM->getTargetTriple(), TM->getMCAsmInfo(),
                        TM->getMCRegisterInfo(), TM->getMCSubtargetInfo(),
-                       nullptr, nullptr, false),
+                       nullptr, &TM->Options.MCOptions, false),
       ExternalContext(ExtContext) {
   Context.setObjectFileInfo(TM->getObjFileLowering());
   initialize();

--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -58,12 +58,6 @@
 
 using namespace llvm;
 
-static cl::opt<char*>
-AsSecureLogFileName("as-secure-log-file-name",
-        cl::desc("As secure log file name (initialized from "
-                 "AS_SECURE_LOG_FILE env variable)"),
-        cl::init(getenv("AS_SECURE_LOG_FILE")), cl::Hidden);
-
 static void defaultDiagHandler(const SMDiagnostic &SMD, bool, const SourceMgr &,
                                std::vector<const MDNode *> &) {
   SMD.print(nullptr, errs());
@@ -79,7 +73,7 @@ MCContext::MCContext(const Triple &TheTriple, const MCAsmInfo *mai,
       InlineAsmUsedLabelNames(Allocator),
       CurrentDwarfLoc(0, 0, 0, DWARF2_FLAG_IS_STMT, 0, 0),
       AutoReset(DoAutoReset), TargetOptions(TargetOpts) {
-  SecureLogFile = AsSecureLogFileName;
+  SecureLogFile = TargetOptions ? TargetOptions->AsSecureLogFile : "";
 
   if (SrcMgr && SrcMgr->getNumBuffers())
     MainFileName = std::string(SrcMgr->getMemoryBuffer(SrcMgr->getMainFileID())

--- a/llvm/lib/MC/MCParser/DarwinAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/DarwinAsmParser.cpp
@@ -767,8 +767,8 @@ bool DarwinAsmParser::parseDirectiveSecureLogUnique(StringRef, SMLoc IDLoc) {
     return Error(IDLoc, ".secure_log_unique specified multiple times");
 
   // Get the secure log path.
-  const char *SecureLogFile = getContext().getSecureLogFile();
-  if (!SecureLogFile)
+  StringRef SecureLogFile = getContext().getSecureLogFile();
+  if (SecureLogFile.empty())
     return Error(IDLoc, ".secure_log_unique used but AS_SECURE_LOG_FILE "
                  "environment variable unset.");
 
@@ -776,9 +776,8 @@ bool DarwinAsmParser::parseDirectiveSecureLogUnique(StringRef, SMLoc IDLoc) {
   raw_fd_ostream *OS = getContext().getSecureLog();
   if (!OS) {
     std::error_code EC;
-    auto NewOS = std::make_unique<raw_fd_ostream>(StringRef(SecureLogFile), EC,
-                                                  sys::fs::OF_Append |
-                                                      sys::fs::OF_TextWithCRLF);
+    auto NewOS = std::make_unique<raw_fd_ostream>(
+        SecureLogFile, EC, sys::fs::OF_Append | sys::fs::OF_TextWithCRLF);
     if (EC)
        return Error(IDLoc, Twine("can't open secure log file: ") +
                                SecureLogFile + " (" + EC.message() + ")");

--- a/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
+++ b/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
@@ -45,6 +45,7 @@ MCOPT(bool, NoWarn)
 MCOPT(bool, NoDeprecatedWarn)
 MCOPT(bool, NoTypeCheck)
 MCOPT(std::string, ABIName)
+MCOPT(std::string, AsSecureLogFile)
 
 llvm::mc::RegisterMCTargetOptionsFlags::RegisterMCTargetOptionsFlags() {
 #define MCBINDOPT(NAME)                                                        \
@@ -101,6 +102,10 @@ llvm::mc::RegisterMCTargetOptionsFlags::RegisterMCTargetOptionsFlags() {
       cl::init(""));
   MCBINDOPT(ABIName);
 
+  static cl::opt<std::string> AsSecureLogFile(
+      "as-secure-log-file", cl::desc("As secure log file name"), cl::Hidden);
+  MCBINDOPT(AsSecureLogFile);
+
 #undef MCBINDOPT
 }
 
@@ -116,5 +121,7 @@ MCTargetOptions llvm::mc::InitMCTargetOptionsFromFlags() {
   Options.MCNoWarn = getNoWarn();
   Options.MCNoDeprecatedWarn = getNoDeprecatedWarn();
   Options.MCNoTypeCheck = getNoTypeCheck();
+  Options.AsSecureLogFile = getAsSecureLogFile();
+
   return Options;
 }

--- a/llvm/test/MC/AsmParser/secure_log_unique.s
+++ b/llvm/test/MC/AsmParser/secure_log_unique.s
@@ -1,6 +1,6 @@
 // RUN: rm -f %t
-// RUN: env AS_SECURE_LOG_FILE=%t llvm-mc -triple x86_64-apple-darwin %s
-// RUN: env AS_SECURE_LOG_FILE=%t llvm-mc -triple x86_64-apple-darwin %s
+// RUN: llvm-mc -as-secure-log-file %t -triple x86_64-apple-darwin %s
+// RUN: llvm-mc -as-secure-log-file %t -triple x86_64-apple-darwin %s
 // RUN: FileCheck --input-file=%t %s
 .secure_log_unique "foobar"
 


### PR DESCRIPTION
* Move getenv call for AS_SECURE_LOG_FILE to clang driver
* Disable caching for AS_SECURE_LOG_FILE since it is not captured in output backend