### PR TITLE
[lldb] Fix Array<T>.SubSequence synthetic

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -376,8 +376,10 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
     if (handler && handler->IsValid())
       return handler;
     return nullptr;
-  } else if (valobj_typename.startswith("Swift.ArraySlice<")) {
-    // Swift.ArraySlice
+  } else if (valobj_typename.startswith("Swift.ArraySlice<") ||
+             (valobj_typename.startswith("Swift.Array<") &&
+              valobj_typename.endswith(">.SubSequence"))) {
+    // ArraySlice or Array<T>.SubSequence, which is a typealias to ArraySlice.
     static ConstString g_buffer("_buffer");
 
     ValueObjectSP buffer_sp(

--- a/lldb/test/API/functionalities/data-formatter/swift/array-slice/TestSwiftArraySliceFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/array-slice/TestSwiftArraySliceFormatters.py
@@ -16,6 +16,5 @@ class TestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.swift")
         )
 
-        # TODO: Fix `arraySubSequence` rdar://92898538
-        for var in ("someSlice", "arraySlice"):
+        for var in ("someSlice", "arraySlice", "arraySubSequence"):
             self.expect(f"v {var}", substrs=[f"{var} = 2 values", "[1] = 2", "[2] = 3"])


### PR DESCRIPTION
`Array<T>.SubSequence` is a typealias to `ArraySlice<T>`. LLDB provides a synthetic type for `ArraySlice`. When printing a value of `Array<T>.SubSequence`, the formatting system correctly peels off the typealias and selects the `ArraySlice` synthetic provider.

However the implementation of the `ArraySlice` synthetic provider (see `SwiftArrayBufferHandler`) handles a number of related array types, including `Array`, `ContiguousArray`, `ArraySlice`, and more.

In handling these types, `SwiftArrayBufferHandler` does string matching on the type name to determine its behavior. This string matching is done on the exact type, no typealias layers are removed.

For `Array<T>.SubSequence` to be handled as `ArraySlice`, the string matching needs to be updated accordingly. This change does that.

rdar://92898538