### PR TITLE
[clang] Move getenv calls to driver, disable caching as necessary

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.h
+++ b/clang/include/clang/Basic/CodeGenOptions.h
@@ -436,6 +436,9 @@ public:
   /// values in order to be included in misexpect diagnostics.
   Optional<uint32_t> DiagnosticsMisExpectTolerance = 0;
 
+  /// The name of a file to use with \c .secure_log_unique directives.
+  std::string AsSecureLogFile;
+
 public:
   // Define accessors/mutators for code generation options of enumeration type.
 #define CODEGENOPT(Name, Bits, Default)

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6379,6 +6379,9 @@ def setup_static_analyzer : Flag<["-"], "setup-static-analyzer">,
 def disable_pragma_debug_crash : Flag<["-"], "disable-pragma-debug-crash">,
   HelpText<"Disable any #pragma clang __debug that can lead to crashing behavior. This is meant for testing.">,
   MarshallingInfoFlag<PreprocessorOpts<"DisablePragmaDebugCrash">>;
+def source_date_epoch : Separate<["-"], "source-date-epoch">,
+  MetaVarName<"<time since Epoch in seconds>">,
+  HelpText<"Time to be used in __DATE__, __TIME__, and __TIMESTAMP__ macros">;
 
 } // let Flags = [CC1Option, NoDriverOption]
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5401,6 +5401,9 @@ def fno_use_ctor_homing: Flag<["-"], "fno-use-ctor-homing">,
     HelpText<"Don't use constructor homing for debug info">;
 def fuse_ctor_homing: Flag<["-"], "fuse-ctor-homing">,
     HelpText<"Use constructor homing if we are using limited debug info already">;
+def as_secure_log_file : Separate<["-"], "as-secure-log-file">,
+  HelpText<"Emit .secure_log_unique directives to this filename.">,
+  MarshallingInfoString<CodeGenOpts<"AsSecureLogFile">>;
 
 } // let Flags = [CC1Option, CC1AsOption, NoDriverOption]
 

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -498,6 +498,7 @@ static bool initTargetOptions(DiagnosticsEngine &Diags,
           Entry.IgnoreSysRoot ? Entry.Path : HSOpts.Sysroot + Entry.Path);
   Options.MCOptions.Argv0 = CodeGenOpts.Argv0;
   Options.MCOptions.CommandLineArgs = CodeGenOpts.CommandLineArgs;
+  Options.MCOptions.AsSecureLogFile = CodeGenOpts.AsSecureLogFile;
   Options.MisExpect = CodeGenOpts.MisExpect;
 
   return true;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1479,6 +1479,11 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
 
   Args.AddLastArg(CmdArgs, options::OPT_ffile_reproducible,
                   options::OPT_fno_file_reproducible);
+
+  if (const char *Epoch = std::getenv("SOURCE_DATE_EPOCH")) {
+    CmdArgs.push_back("-source-date-epoch");
+    CmdArgs.push_back(Args.MakeArgString(Epoch));
+  }
 }
 
 // FIXME: Move to target hook.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2754,6 +2754,11 @@ static void CollectArgsForIntegratedAssembler(Compilation &C,
   if (C.getDriver().embedBitcodeEnabled() ||
       C.getDriver().embedBitcodeMarkerOnly())
     Args.AddLastArg(CmdArgs, options::OPT_fembed_bitcode_EQ);
+
+  if (const char *AsSecureLogFile = getenv("AS_SECURE_LOG_FILE")) {
+    CmdArgs.push_back("-as-secure-log-file");
+    CmdArgs.push_back(Args.MakeArgString(AsSecureLogFile));
+  }
 }
 
 static void RenderFloatingPointOptions(const ToolChain &TC, const Driver &D,

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4487,6 +4487,9 @@ static void GeneratePreprocessorArgs(PreprocessorOptions &Opts,
   for (const auto &RF : Opts.RemappedFiles)
     GenerateArg(Args, OPT_remap_file, RF.first + ";" + RF.second, SA);
 
+  if (Opts.SourceDateEpoch)
+    GenerateArg(Args, OPT_source_date_epoch, Twine(*Opts.SourceDateEpoch), SA);
+
   // Don't handle LexEditorPlaceholders. It is implied by the action that is
   // generated elsewhere.
 }
@@ -4569,14 +4572,15 @@ static bool ParsePreprocessorArgs(PreprocessorOptions &Opts, ArgList &Args,
     Opts.addRemappedFile(Split.first, Split.second);
   }
 
-  if (const char *Epoch = std::getenv("SOURCE_DATE_EPOCH")) {
+  if (const Arg *A = Args.getLastArg(OPT_source_date_epoch)) {
+    StringRef Epoch = A->getValue();
     // SOURCE_DATE_EPOCH, if specified, must be a non-negative decimal integer.
     // On time64 systems, pick 253402300799 (the UNIX timestamp of
     // 9999-12-31T23:59:59Z) as the upper bound.
     const uint64_t MaxTimestamp =
         std::min<uint64_t>(std::numeric_limits<time_t>::max(), 253402300799);
     uint64_t V;
-    if (StringRef(Epoch).getAsInteger(10, V) || V > MaxTimestamp) {
+    if (Epoch.getAsInteger(10, V) || V > MaxTimestamp) {
       Diags.Report(diag::err_fe_invalid_source_date_epoch)
           << Epoch << MaxTimestamp;
     } else {

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -80,6 +80,10 @@
 // ASM: warning: caching disabled because assembler language mode is enabled
 // ASM-NOT: "-cc1depscan"
 
+// RUN: env AS_SECURE_LOG_FILE=%t/log %clang-cache %clang -target arm64-apple-macosx12 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=AS_SECURE_LOG_FILE
+// AS_SECURE_LOG_FILE: warning: caching disabled because AS_SECURE_LOG_FILE is set
+// AS_SECURE_LOG_FILE-NOT: "-cc1depscan"
+
 // RUN: env LLVM_CACHE_WARNINGS=-Wno-clang-cache %clang-cache %clang -x c++ -fmodules -fmodules-cache-path=%t/mcp -fcxx-modules -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=MOD_HIDE -DPREFIX=%t
 // MOD_HIDE-NOT: warning: caching disabled
 // MOD_HIDE-NOT: "-cc1depscan"

--- a/clang/test/CodeGen/as-secure-log-file.c
+++ b/clang/test/CodeGen/as-secure-log-file.c
@@ -1,3 +1,5 @@
+// REQUIRES: x86-registered-target
+
 // RUN: %clang_cc1 -triple x86_64-apple-darwin -emit-obj %s -o %t.o -as-secure-log-file %t.log
 // RUN: FileCheck %s -input-file %t.log
 // CHECK: "foobar"

--- a/clang/test/CodeGen/as-secure-log-file.c
+++ b/clang/test/CodeGen/as-secure-log-file.c
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -triple x86_64-apple-darwin -emit-obj %s -o %t.o -as-secure-log-file %t.log
+// RUN: FileCheck %s -input-file %t.log
+// CHECK: "foobar"
+
+void test(void) {
+  __asm__(".secure_log_unique \"foobar\"");
+}

--- a/clang/test/Driver/AS_SECURE_LOG_FILE.s
+++ b/clang/test/Driver/AS_SECURE_LOG_FILE.s
@@ -1,0 +1,3 @@
+// RUN: env AS_SECURE_LOG_FILE=log_file %clang --target=x86_64-apple-darwin -c %s -### 2>&1 | FileCheck %s
+// CHECK: "-cc1as"
+// CHECK-SAME: "-as-secure-log-file" "log_file"

--- a/clang/test/Driver/SOURCE_DATE_EPOCH.c
+++ b/clang/test/Driver/SOURCE_DATE_EPOCH.c
@@ -1,0 +1,5 @@
+// RUN: %clang -E %s -### 2>&1 | FileCheck %s -check-prefix=NO_EPOCH
+// NO_EPOCH-NOT: "-source-date-epoch"
+
+// RUN: env SOURCE_DATE_EPOCH=123 %clang -E %s -### 2>&1 | FileCheck %s
+// CHECK: "-source-date-epoch" "123"

--- a/clang/test/Misc/cc1as-as-secure-log-file.s
+++ b/clang/test/Misc/cc1as-as-secure-log-file.s
@@ -1,0 +1,5 @@
+// RUN: %clang -cc1as -triple x86_64-apple-darwin %s -o %t.o -as-secure-log-file %t.log
+// RUN: FileCheck %s -input-file %t.log
+// CHECK: "foobar"
+
+.secure_log_unique "foobar"

--- a/clang/test/Misc/cc1as-as-secure-log-file.s
+++ b/clang/test/Misc/cc1as-as-secure-log-file.s
@@ -1,3 +1,5 @@
+// REQUIRES: x86-registered-target
+
 // RUN: %clang -cc1as -triple x86_64-apple-darwin %s -o %t.o -as-secure-log-file %t.log
 // RUN: FileCheck %s -input-file %t.log
 // CHECK: "foobar"

--- a/clang/test/Preprocessor/SOURCE_DATE_EPOCH.c
+++ b/clang/test/Preprocessor/SOURCE_DATE_EPOCH.c
@@ -1,10 +1,10 @@
-// RUN: env SOURCE_DATE_EPOCH=0 %clang_cc1 -E %s | FileCheck %s --check-prefix=19700101
+// RUN: %clang_cc1 -source-date-epoch 0 -E %s | FileCheck %s --check-prefix=19700101
 
 // 19700101:      const char date[] = "Jan  1 1970";
 // 19700101-NEXT: const char time[] = "00:00:00";
 // 19700101-NEXT: const char timestamp[] = "Thu Jan  1 00:00:00 1970";
 
-// RUN: env SOURCE_DATE_EPOCH=2147483647 %clang_cc1 -E -Wdate-time %s 2>&1 | FileCheck %s --check-prefix=Y2038
+// RUN: %clang_cc1 -source-date-epoch 2147483647 -E -Wdate-time %s 2>&1 | FileCheck %s --check-prefix=Y2038
 
 // Y2038:      warning: expansion of date or time macro is not reproducible [-Wdate-time]
 // Y2038:      const char date[] = "Jan 19 2038";
@@ -12,18 +12,18 @@
 // Y2038-NEXT: const char timestamp[] = "Tue Jan 19 03:14:07 2038";
 
 /// Test a large timestamp if the system uses 64-bit time_t and known to support large timestamps.
-// RUN: %if !system-windows && clang-target-64-bits %{ env SOURCE_DATE_EPOCH=253402300799 %clang_cc1 -E -Wdate-time %s 2>&1 | FileCheck %s --check-prefix=99991231 %}
+// RUN: %if !system-windows && clang-target-64-bits %{ %clang_cc1 -source-date-epoch 253402300799 -E -Wdate-time %s 2>&1 | FileCheck %s --check-prefix=99991231 %}
 
 // 99991231:      warning: expansion of date or time macro is not reproducible [-Wdate-time]
 // 99991231:      const char date[] = "Dec 31 9999";
 // 99991231-NEXT: const char time[] = "23:59:59";
 // 99991231-NEXT: const char timestamp[] = "Fri Dec 31 23:59:59 9999";
 
-// RUN: env SOURCE_DATE_EPOCH=253402300800 not %clang_cc1 -E %s 2>&1 | FileCheck %s --check-prefix=TOOBIG
+// RUN: not %clang_cc1 -source-date-epoch 253402300800 -E %s 2>&1 | FileCheck %s --check-prefix=TOOBIG
 
 // TOOBIG: error: environment variable 'SOURCE_DATE_EPOCH' ('253402300800') must be a non-negative decimal integer <= {{(2147483647|253402300799)}}
 
-// RUN: env SOURCE_DATE_EPOCH=0x0 not %clang_cc1 -E %s 2>&1 | FileCheck %s --check-prefix=NOTDECIMAL
+// RUN: not %clang_cc1 -source-date-epoch 0x0 -E %s 2>&1 | FileCheck %s --check-prefix=NOTDECIMAL
 
 // NOTDECIMAL: error: environment variable 'SOURCE_DATE_EPOCH' ('0x0') must be a non-negative decimal integer <= {{(2147483647|253402300799)}}
 

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -58,6 +58,12 @@ static bool shouldCacheInvocation(ArrayRef<const char *> Args,
         << "assembler language mode is enabled";
     return false;
   }
+  if (llvm::sys::Process::GetEnv("AS_SECURE_LOG_FILE")) {
+    // AS_SECURE_LOG_FILE causes uncaptured output in MC assembler.
+    Diags->Report(diag::warn_clang_cache_disabled_caching)
+        << "AS_SECURE_LOG_FILE is set";
+    return false;
+  }
   return true;
 }
 

--- a/clang/tools/driver/cc1as_main.cpp
+++ b/clang/tools/driver/cc1as_main.cpp
@@ -151,6 +151,9 @@ struct AssemblerInvocation {
   /// Darwin target variant triple, the variant of the deployment target
   /// for which the code is being compiled.
   llvm::Optional<llvm::Triple> DarwinTargetVariantTriple;
+
+  /// The name of a file to use with \c .secure_log_unique directives.
+  std::string AsSecureLogFile;
   /// @}
 
 public:
@@ -333,6 +336,8 @@ bool AssemblerInvocation::CreateFromArgs(AssemblerInvocation &Opts,
             .Case("default", EmitDwarfUnwindType::Default);
   }
 
+  Opts.AsSecureLogFile = Args.getLastArgValue(OPT_as_secure_log_file);
+
   return Success;
 }
 
@@ -384,6 +389,7 @@ static bool ExecuteAssemblerImpl(AssemblerInvocation &Opts,
 
   MCTargetOptions MCOptions;
   MCOptions.EmitDwarfUnwind = Opts.EmitDwarfUnwind;
+  MCOptions.AsSecureLogFile = Opts.AsSecureLogFile;
 
   std::unique_ptr<MCAsmInfo> MAI(
       TheTarget->createMCAsmInfo(*MRI, Opts.Triple, MCOptions));

--- a/llvm/include/llvm/MC/MCContext.h
+++ b/llvm/include/llvm/MC/MCContext.h
@@ -178,7 +178,7 @@ private:
   /// The file name of the log file from the environment variable
   /// AS_SECURE_LOG_FILE.  Which must be set before the .secure_log_unique
   /// directive is used or it is an error.
-  char *SecureLogFile;
+  std::string SecureLogFile;
   /// The stream that gets written to for the .secure_log_unique directive.
   std::unique_ptr<raw_fd_ostream> SecureLog;
   /// Boolean toggled when .secure_log_unique / .secure_log_reset is seen to
@@ -828,7 +828,7 @@ public:
 
   /// @}
 
-  char *getSecureLogFile() { return SecureLogFile; }
+  StringRef getSecureLogFile() { return SecureLogFile; }
   raw_fd_ostream *getSecureLog() { return SecureLog.get(); }
 
   void setSecureLog(std::unique_ptr<raw_fd_ostream> Value) {

--- a/llvm/include/llvm/MC/MCTargetOptions.h
+++ b/llvm/include/llvm/MC/MCTargetOptions.h
@@ -76,6 +76,7 @@ public:
   std::string ABIName;
   std::string AssemblyLanguage;
   std::string SplitDwarfFile;
+  std::string AsSecureLogFile;
 
   const char *Argv0 = nullptr;
   ArrayRef<std::string> CommandLineArgs;

--- a/llvm/include/llvm/MC/MCTargetOptionsCommandFlags.h
+++ b/llvm/include/llvm/MC/MCTargetOptionsCommandFlags.h
@@ -47,6 +47,8 @@ bool getNoTypeCheck();
 
 std::string getABIName();
 
+std::string getAsSecureLogFile();
+
 /// Create this object with static storage to register mc-related command
 /// line options.
 struct RegisterMCTargetOptionsFlags {

--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -59,12 +59,6 @@
 
 using namespace llvm;
 
-static cl::opt<char*>
-AsSecureLogFileName("as-secure-log-file-name",
-        cl::desc("As secure log file name (initialized from "
-                 "AS_SECURE_LOG_FILE env variable)"),
-        cl::init(getenv("AS_SECURE_LOG_FILE")), cl::Hidden);
-
 static void defaultDiagHandler(const SMDiagnostic &SMD, bool, const SourceMgr &,
                                std::vector<const MDNode *> &) {
   SMD.print(nullptr, errs());
@@ -80,7 +74,7 @@ MCContext::MCContext(const Triple &TheTriple, const MCAsmInfo *mai,
       InlineAsmUsedLabelNames(Allocator),
       CurrentDwarfLoc(0, 0, 0, DWARF2_FLAG_IS_STMT, 0, 0),
       AutoReset(DoAutoReset), TargetOptions(TargetOpts) {
-  SecureLogFile = AsSecureLogFileName;
+  SecureLogFile = TargetOptions ? TargetOptions->AsSecureLogFile : "";
 
   if (SrcMgr && SrcMgr->getNumBuffers())
     MainFileName = std::string(SrcMgr->getMemoryBuffer(SrcMgr->getMainFileID())

--- a/llvm/lib/MC/MCParser/DarwinAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/DarwinAsmParser.cpp
@@ -767,8 +767,8 @@ bool DarwinAsmParser::parseDirectiveSecureLogUnique(StringRef, SMLoc IDLoc) {
     return Error(IDLoc, ".secure_log_unique specified multiple times");
 
   // Get the secure log path.
-  const char *SecureLogFile = getContext().getSecureLogFile();
-  if (!SecureLogFile)
+  StringRef SecureLogFile = getContext().getSecureLogFile();
+  if (SecureLogFile.empty())
     return Error(IDLoc, ".secure_log_unique used but AS_SECURE_LOG_FILE "
                  "environment variable unset.");
 
@@ -776,9 +776,8 @@ bool DarwinAsmParser::parseDirectiveSecureLogUnique(StringRef, SMLoc IDLoc) {
   raw_fd_ostream *OS = getContext().getSecureLog();
   if (!OS) {
     std::error_code EC;
-    auto NewOS = std::make_unique<raw_fd_ostream>(StringRef(SecureLogFile), EC,
-                                                  sys::fs::OF_Append |
-                                                      sys::fs::OF_TextWithCRLF);
+    auto NewOS = std::make_unique<raw_fd_ostream>(
+        SecureLogFile, EC, sys::fs::OF_Append | sys::fs::OF_TextWithCRLF);
     if (EC)
        return Error(IDLoc, Twine("can't open secure log file: ") +
                                SecureLogFile + " (" + EC.message() + ")");

--- a/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
+++ b/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
@@ -45,6 +45,7 @@ MCOPT(bool, NoWarn)
 MCOPT(bool, NoDeprecatedWarn)
 MCOPT(bool, NoTypeCheck)
 MCOPT(std::string, ABIName)
+MCOPT(std::string, AsSecureLogFile)
 
 llvm::mc::RegisterMCTargetOptionsFlags::RegisterMCTargetOptionsFlags() {
 #define MCBINDOPT(NAME)                                                        \
@@ -114,6 +115,10 @@ llvm::mc::RegisterMCTargetOptionsFlags::RegisterMCTargetOptionsFlags() {
       cl::init(""));
   MCBINDOPT(ABIName);
 
+  static cl::opt<std::string> AsSecureLogFile(
+      "as-secure-log-file", cl::desc("As secure log file name"), cl::Hidden);
+  MCBINDOPT(AsSecureLogFile);
+
 #undef MCBINDOPT
 }
 
@@ -130,6 +135,7 @@ MCTargetOptions llvm::mc::InitMCTargetOptionsFromFlags() {
   Options.MCNoDeprecatedWarn = getNoDeprecatedWarn();
   Options.MCNoTypeCheck = getNoTypeCheck();
   Options.EmitDwarfUnwind = getEmitDwarfUnwind();
+  Options.AsSecureLogFile = getAsSecureLogFile();
 
   return Options;
 }

--- a/llvm/test/MC/AsmParser/secure_log_unique.s
+++ b/llvm/test/MC/AsmParser/secure_log_unique.s
@@ -1,6 +1,6 @@
 // RUN: rm -f %t
-// RUN: env AS_SECURE_LOG_FILE=%t llvm-mc -triple x86_64-apple-darwin %s
-// RUN: env AS_SECURE_LOG_FILE=%t llvm-mc -triple x86_64-apple-darwin %s
+// RUN: llvm-mc -as-secure-log-file %t -triple x86_64-apple-darwin %s
+// RUN: llvm-mc -as-secure-log-file %t -triple x86_64-apple-darwin %s
 // RUN: FileCheck --input-file=%t %s
 .secure_log_unique "foobar"
 


### PR DESCRIPTION
* Move getenv call for SOURCE_DATE_EPOCH out of frontend
* Move getenv call for AS_SECURE_LOG_FILE to clang driver
* Disable caching for AS_SECURE_LOG_FILE since it is not captured in output backend