### PR TITLE
Rewrite platform patch to debugserver to avoid c++17 use

### DIFF
--- a/lldb/tools/debugserver/source/DNB.cpp
+++ b/lldb/tools/debugserver/source/DNB.cpp
@@ -1429,11 +1429,12 @@ nub_bool_t DNBProcessSharedLibrariesUpdated(nub_process_t pid) {
   return false;
 }
 
-std::optional<std::string>
-DNBGetDeploymentInfo(nub_process_t pid, bool is_executable,
-                     const struct load_command &lc,
-                     uint64_t load_command_address, uint32_t &major_version,
-                     uint32_t &minor_version, uint32_t &patch_version) {
+const char *DNBGetDeploymentInfo(nub_process_t pid, bool is_executable,
+                                 const struct load_command &lc,
+                                 uint64_t load_command_address,
+                                 uint32_t &major_version,
+                                 uint32_t &minor_version,
+                                 uint32_t &patch_version) {
   MachProcessSP procSP;
   if (GetProcessSP(pid, procSP)) {
     // FIXME: This doesn't return the correct result when xctest (a

--- a/lldb/tools/debugserver/source/DNB.h
+++ b/lldb/tools/debugserver/source/DNB.h
@@ -21,7 +21,6 @@
 #include <Availability.h>
 #include <mach/machine.h>
 #include <mach/thread_info.h>
-#include <optional>
 #include <string>
 
 #define DNB_EXPORT __attribute__((visibility("default")))
@@ -135,11 +134,12 @@ nub_bool_t DNBProcessSharedLibrariesUpdated(nub_process_t pid) DNB_EXPORT;
 nub_size_t
 DNBProcessGetSharedLibraryInfo(nub_process_t pid, nub_bool_t only_changed,
                                DNBExecutableImageInfo **image_infos) DNB_EXPORT;
-std::optional<std::string>
-DNBGetDeploymentInfo(nub_process_t pid, bool is_executable,
-                     const struct load_command &lc,
-                     uint64_t load_command_address, uint32_t &major_version,
-                     uint32_t &minor_version, uint32_t &patch_version);
+const char *DNBGetDeploymentInfo(nub_process_t pid, bool is_executable,
+                                 const struct load_command &lc,
+                                 uint64_t load_command_address,
+                                 uint32_t &major_version,
+                                 uint32_t &minor_version,
+                                 uint32_t &patch_version);
 nub_bool_t DNBProcessSetNameToAddressCallback(nub_process_t pid,
                                               DNBCallbackNameToAddress callback,
                                               void *baton) DNB_EXPORT;

--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.h
@@ -16,7 +16,6 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <mach-o/loader.h>
 #include <mach/mach.h>
-#include <optional>
 #include <pthread.h>
 #include <sys/signal.h>
 #include <uuid/uuid.h>
@@ -253,7 +252,7 @@ public:
   DeploymentInfo GetDeploymentInfo(const struct load_command &,
                                    uint64_t load_command_address,
                                    bool is_executable);
-  static std::optional<std::string> GetPlatformString(unsigned char platform);
+  static const char *GetPlatformString(unsigned char platform);
   bool GetMachOInformationFromMemory(uint32_t platform,
                                      nub_addr_t mach_o_header_addr,
                                      int wordsize,

--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
@@ -720,8 +720,7 @@ MachProcess::GetDeploymentInfo(const struct load_command &lc,
   return info;
 }
 
-std::optional<std::string>
-MachProcess::GetPlatformString(unsigned char platform) {
+const char *MachProcess::GetPlatformString(unsigned char platform) {
   switch (platform) {
   case PLATFORM_MACOS:
     return "macosx";
@@ -745,7 +744,7 @@ MachProcess::GetPlatformString(unsigned char platform) {
     return "driverkit";
   default:
     DNBLogError("Unknown platform %u found for one binary", platform);
-    return std::nullopt;
+    return nullptr;
   }
 }
 
@@ -870,8 +869,7 @@ bool MachProcess::GetMachOInformationFromMemory(
     }
     if (DeploymentInfo deployment_info = GetDeploymentInfo(
             lc, load_cmds_p, inf.mach_header.filetype == MH_EXECUTE)) {
-      std::optional<std::string> lc_platform =
-          GetPlatformString(deployment_info.platform);
+      const char *lc_platform = GetPlatformString(deployment_info.platform);
       if (dyld_platform != PLATFORM_MACCATALYST &&
           inf.min_version_os_name == "macosx") {
         // macCatalyst support.
@@ -886,7 +884,8 @@ bool MachProcess::GetMachOInformationFromMemory(
         // processed, ignore this one, which is presumed to be a
         // PLATFORM_MACCATALYST one.
       } else {
-        inf.min_version_os_name = lc_platform.value_or("");
+        if (lc_platform)
+          inf.min_version_os_name = lc_platform;
         inf.min_version_os_version = "";
         inf.min_version_os_version +=
             std::to_string(deployment_info.major_version);

--- a/lldb/tools/debugserver/source/RNBRemote.cpp
+++ b/lldb/tools/debugserver/source/RNBRemote.cpp
@@ -6258,12 +6258,12 @@ rnb_err_t RNBRemote::HandlePacket_qProcessInfo(const char *p) {
 
         bool is_executable = true;
         uint32_t major_version, minor_version, patch_version;
-        std::optional<std::string> platform =
+        const char *platform =
             DNBGetDeploymentInfo(pid, is_executable, lc, load_command_addr,
                                  major_version, minor_version, patch_version);
         if (platform) {
           os_handled = true;
-          rep << "ostype:" << *platform << ";";
+          rep << "ostype:" << platform << ";";
           break;
         }
         load_command_addr = load_command_addr + lc.cmdsize;


### PR DESCRIPTION
Rewrite platform patch to debugserver to avoid c++17 use

This branch of lldb is still built c++14, so using std::optional doesn't work.  Update the patch to use a const char* with nullptr return for no value.
This change will not be merged/cherrypicked in to
main/next.

rdar://101718570