### PR TITLE
[lldb] HostInfoMacOSX should explicitly link against PlatformMacOSX

### DIFF
--- a/lldb/source/Host/macosx/objcxx/CMakeLists.txt
+++ b/lldb/source/Host/macosx/objcxx/CMakeLists.txt
@@ -17,6 +17,7 @@ add_lldb_library(lldbHostMacOSXObjCXX
 
   LINK_LIBS
     lldbUtility
+    lldbPluginPlatformMacOSX
     ${EXTRA_LIBS}
 
   LINK_COMPONENTS


### PR DESCRIPTION
HostInfoMacOSX uses PlatformDarwin to locate the swift resource directory. If we do not explicitly add PlatformMacOSX to HostInfoMacOSX LINK_LIBS then we may fail to link. I ran into this while trying to run the test suite.

(cherry picked from commit 18ff81a9fb5b796fd2073f30564cdf91fc66ab76)