### PR TITLE
[lldb] Add information on swiftmodule load times to `statistics dump` command

### DIFF
--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/JSON.h"
 
 #include "lldb/Core/PluginInterface.h"
 #include "lldb/Expression/Expression.h"
@@ -535,6 +536,8 @@ public:
   // formatters that are discovered on such a type as attributable to the
   // meaningless type itself, instead preferring to use the dynamic type
   virtual bool IsMeaninglessWithoutDynamicResolution(void *type);
+
+  virtual llvm::Optional<llvm::json::Value> ReportStatistics();
 
   /// A TypeSystem may belong to more than one debugger, so it doesn't
   /// have a way to communicate errors. This method can be called by a

--- a/lldb/include/lldb/Target/Statistics.h
+++ b/lldb/include/lldb/Target/Statistics.h
@@ -12,6 +12,7 @@
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/Stream.h"
 #include "lldb/lldb-forward.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/Support/JSON.h"
 #include <atomic>
 #include <chrono>
@@ -107,6 +108,7 @@ struct ModuleStats {
   // identifiers of these modules in the global module list. This allows us to
   // track down all of the stats that contribute to this module.
   std::vector<intptr_t> symfile_modules;
+  llvm::StringMap<llvm::json::Value> type_system_stats;
   double symtab_parse_time = 0.0;
   double symtab_index_time = 0.0;
   double debug_parse_time = 0.0;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -20,10 +20,12 @@
 #include "swift/Parse/ParseVersion.h"
 #include "lldb/Core/SwiftForward.h"
 #include "lldb/Core/ThreadSafeDenseSet.h"
+#include "lldb/Target/Statistics.h"
 #include "lldb/Utility/Either.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Target/TargetOptions.h"
+#include "llvm/Support/JSON.h"
 
 namespace swift {
 enum class IRGenDebugInfoLevel : unsigned;
@@ -436,6 +438,14 @@ public:
   typedef llvm::StringMap<swift::ModuleDecl *> SwiftModuleMap;
 
   const SwiftModuleMap &GetModuleCache() { return m_swift_module_cache; }
+
+  typedef llvm::StringMap<StatsDuration> SwiftModuleLoadTimeMap;
+
+  SwiftModuleLoadTimeMap &GetSwiftModuleLoadTimes() {
+    return m_swift_module_load_time_map;
+  }
+
+  llvm::Optional<llvm::json::Value> ReportStatistics() override;
 
   void RaiseFatalError(std::string msg) { m_fatal_errors.SetErrorString(msg); }
   static bool HasFatalErrors(swift::ASTContext *ast_context);
@@ -865,6 +875,7 @@ protected:
       nullptr;
   swift::ClangImporter *m_clang_importer = nullptr;
   SwiftModuleMap m_swift_module_cache;
+  SwiftModuleLoadTimeMap m_swift_module_load_time_map;
   SwiftTypeFromMangledNameMap m_mangled_name_to_type_map;
   SwiftMangledNameFromTypeMap m_type_to_mangled_name_map;
   uint32_t m_pointer_byte_size = 0;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1510,6 +1510,13 @@ Status TypeSystemSwiftTypeRef::IsCompatible() {
   return {};
 }
 
+llvm::Optional<llvm::json::Value> TypeSystemSwiftTypeRef::ReportStatistics() {
+  if (auto *swift_ast_context = GetSwiftASTContextOrNull()) {
+    return swift_ast_context->ReportStatistics();
+  }
+  return llvm::None;
+}
+
 void TypeSystemSwiftTypeRef::DiagnoseWarnings(Process &process,
                                               Module &module) const {
   if (auto *swift_ast_context = GetSwiftASTContextOrNull())

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -86,6 +86,8 @@ public:
   bool SupportsLanguage(lldb::LanguageType language) override;
   Status IsCompatible() override;
 
+  llvm::Optional<llvm::json::Value> ReportStatistics() override;
+
   void DiagnoseWarnings(Process &process, Module &module) const override;
   DWARFASTParser *GetDWARFParser() override;
   // CompilerDecl functions

--- a/lldb/source/Symbol/TypeSystem.cpp
+++ b/lldb/source/Symbol/TypeSystem.cpp
@@ -198,6 +198,10 @@ TypeSystem::CreateUtilityFunction(std::string text, std::string name) {
   return {};
 }
 
+llvm::Optional<llvm::json::Value> TypeSystem::ReportStatistics() {
+  return llvm::None;
+}
+
 #pragma mark TypeSystemMap
 
 TypeSystemMap::TypeSystemMap() : m_mutex(), m_map() {}

--- a/lldb/source/Target/Statistics.cpp
+++ b/lldb/source/Target/Statistics.cpp
@@ -71,6 +71,17 @@ json::Value ModuleStats::ToJSON() const {
       symfile_ids.emplace_back(symfile_id);
     module.try_emplace("symbolFileModuleIdentifiers", std::move(symfile_ids));
   }
+
+  if (!type_system_stats.empty()) {
+    json::Array type_systems;
+    for (const auto &entry : type_system_stats) {
+      json::Object obj;
+      obj.try_emplace(entry.first().str(), entry.second);
+      type_systems.emplace_back(std::move(obj));
+    }
+    module.try_emplace("typeSystemInfo", std::move(type_systems));
+  }
+
   return module;
 }
 
@@ -233,6 +244,11 @@ llvm::json::Value DebuggerStats::ReportStatistics(Debugger &debugger,
     debug_parse_time += module_stat.debug_parse_time;
     debug_index_time += module_stat.debug_index_time;
     debug_info_size += module_stat.debug_info_size;
+    module->ForEachTypeSystem([&](TypeSystem *ts) {
+      if (auto stats = ts->ReportStatistics())
+        module_stat.type_system_stats.insert({ts->GetPluginName(), *stats});
+      return true;
+    });
     json_modules.emplace_back(module_stat.ToJSON());
   }
 

--- a/lldb/test/API/commands/statistics/swift/Makefile
+++ b/lldb/test/API/commands/statistics/swift/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/commands/statistics/swift/TestSwiftStats.py
+++ b/lldb/test/API/commands/statistics/swift/TestSwiftStats.py
@@ -1,0 +1,51 @@
+import lldb
+import json
+import os
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+class TestCase(TestBase):
+
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def get_stats(self):
+        """
+            Get the output of the "statistics dump" command and return the JSON
+            as a python dictionary
+        """
+        return_obj = lldb.SBCommandReturnObject()
+        command = "statistics dump"
+        self.ci.HandleCommand(command, return_obj, False)
+        metrics_json = return_obj.GetOutput()
+        return json.loads(metrics_json)
+
+    def force_module_load(self):
+        """
+            Force a module to load with expression evaluation
+        """
+        self.expect("po point", substrs=["{23, 42}"])
+
+    @swiftTest
+    @skipUnlessFoundation
+    def test_type_system_info(self):
+        """
+            Test 'statistics dump' and the type system info
+        """
+        self.build()
+        target = self.createTestTarget()
+        lldbutil.run_to_source_breakpoint(self, "// break here",
+                                          lldb.SBFileSpec("main.swift"))
+        # Do something to cause modules to load
+        self.force_module_load()
+
+        debug_stats = self.get_stats()
+        self.assertTrue("modules" in debug_stats)
+        modules_array = debug_stats["modules"]
+        for module in modules_array:
+            if "TypeSystemInfo" in module:
+                type_system_info = module["TypeSystemInfo"]
+                self.assertTrue("swiftmodules" in type_system_info)
+                for module_info in type_system_info["swiftmodules"]:
+                    self.assertTrue("loadTime" in module_info)
+                    self.assertTrue("name" in module_info)

--- a/lldb/test/API/commands/statistics/swift/main.swift
+++ b/lldb/test/API/commands/statistics/swift/main.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+func main() {
+    var point = NSMakeRange(23, 42)
+    print(point) // break here
+}
+
+main()


### PR DESCRIPTION
Note: I plan on submitting the first commit here to the llvm phabricator for review. I will link it back to this review to explain to upstream reviewers what I am doing and why.

At Meta, we make extensive use of the `statistics dump` command. One thing we want to track is how long each swiftmodule took to load. We've been using a version of these patches internally for a while and have found them to be useful enough to upstream.