### PR TITLE
Add nested generic LLDB metadata tests

### DIFF
--- a/lldb/test/API/lang/swift/generic_class_nested_in_function/Makefile
+++ b/lldb/test/API/lang/swift/generic_class_nested_in_function/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/generic_class_nested_in_function/TestSwiftGenericClassNestedInFunction.py
+++ b/lldb/test/API/lang/swift/generic_class_nested_in_function/TestSwiftGenericClassNestedInFunction.py
@@ -1,0 +1,16 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class SwiftGenericClassNestedInFunctionTest(TestBase):
+
+    @swiftTest
+    def test(self):
+        """Tests that a generic class type nested inside a function can be resolved correctly from the instance metadata"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"))
+        self.expect("v self", substrs=["B<Int>"])
+

--- a/lldb/test/API/lang/swift/generic_class_nested_in_function/main.swift
+++ b/lldb/test/API/lang/swift/generic_class_nested_in_function/main.swift
@@ -1,0 +1,11 @@
+// This test was created to ensure that the changes in in: apple/swift#61819 did not break behaviour.
+
+func a() {
+  class B<T>{
+    func f() {
+      print(1) // break here
+    }
+  }
+  B<Int>().f()
+}
+a()

--- a/lldb/test/API/lang/swift/hashed_container_storing_nested_generic/Makefile
+++ b/lldb/test/API/lang/swift/hashed_container_storing_nested_generic/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/hashed_container_storing_nested_generic/TestHashedContainerStoringNestedGeneric.py
+++ b/lldb/test/API/lang/swift/hashed_container_storing_nested_generic/TestHashedContainerStoringNestedGeneric.py
@@ -1,0 +1,15 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class SwiftGenericClassInHashedContainerTest(TestBase):
+
+    @swiftTest
+    def test(self):
+        """Tests that the type of hashed container whose value type is a non-generic class declared inside a generic class can be read from instance metadata"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self,"break here", lldb.SBFileSpec("main.swift"))
+        self.expect("v val", substrs=["(a.A<Int>.B) val"])

--- a/lldb/test/API/lang/swift/hashed_container_storing_nested_generic/main.swift
+++ b/lldb/test/API/lang/swift/hashed_container_storing_nested_generic/main.swift
@@ -1,0 +1,16 @@
+public class A<T> {
+    public func addValue() {
+        self.dict["key"] = B()
+    }
+    private class B {}
+    private var dict: [String: B] = [:]
+    func test() {
+        let val = dict["key"]!
+        print(1) // break here
+    }
+}
+
+let foo = A<Int>()
+foo.addValue()
+foo.test()
+

--- a/lldb/test/API/lang/swift/nested_generic_class/Makefile
+++ b/lldb/test/API/lang/swift/nested_generic_class/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/nested_generic_class/TestSwiftNestedGenericClass.py
+++ b/lldb/test/API/lang/swift/nested_generic_class/TestSwiftNestedGenericClass.py
@@ -1,0 +1,16 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class SwiftNestedGenericClassTest(TestBase):
+
+    @swiftTest
+    def test(self):
+        """Tests that a generic class type nested inside another generic class can be resolved correctly from the instance metadata"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"))
+        self.expect("v foo", substrs=["a.A<Int>.B<String>"])
+

--- a/lldb/test/API/lang/swift/nested_generic_class/main.swift
+++ b/lldb/test/API/lang/swift/nested_generic_class/main.swift
@@ -1,0 +1,7 @@
+public class A<T> {
+  public class B<U> {
+  }
+}
+
+let foo = A<Int>.B<String>()
+print(1) // break here

--- a/lldb/test/API/lang/swift/private_nested_generic_class/Makefile
+++ b/lldb/test/API/lang/swift/private_nested_generic_class/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/private_nested_generic_class/TestSwiftPrivateNestedGenericClass.py
+++ b/lldb/test/API/lang/swift/private_nested_generic_class/TestSwiftPrivateNestedGenericClass.py
@@ -1,0 +1,15 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class SwiftPrivateNestedGenericClassTest(TestBase):
+
+    @swiftTest
+    def test(self):
+        """Tests that a private generic class type nested inside another generic class can be resolved correctly from the instance metadata"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"))
+        self.expect("v self", substrs=["A<Int>.B<String>"])

--- a/lldb/test/API/lang/swift/private_nested_generic_class/main.swift
+++ b/lldb/test/API/lang/swift/private_nested_generic_class/main.swift
@@ -1,0 +1,12 @@
+public class A<T> {
+  private class B<U> {
+    func f() {
+        print(1) // break here
+    }
+  }
+  func g() {
+    B<String>().f()
+  }
+}
+
+A<Int>().g()


### PR DESCRIPTION
Add tests checking LLDB is able to correctly read
the type of a non generic type declared within
the a generic type from Swift metadata