### PR TITLE
[lldb] Pass requiresRevisionMatch argument to validateSerializedAST

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1078,7 +1078,8 @@ static bool DeserializeAllCompilerFlags(swift::CompilerInvocation &invocation,
       swift::serialization::ExtendedValidationInfo extended_validation_info;
       info = swift::serialization::validateSerializedAST(
           buf, invocation.getSILOptions().EnableOSSAModules,
-          /*requiredSDK*/StringRef(), &extended_validation_info);
+          /*requiredSDK*/ StringRef(), /*requiresRevisionMatch*/ false,
+          &extended_validation_info);
       bool invalid_ast = info.status != swift::serialization::Status::Valid;
       bool invalid_size = (info.bytes == 0) || (info.bytes > buf.size());
       bool invalid_name = info.name.empty();


### PR DESCRIPTION
Pass `requiresRevisionMatch` argument  to `validateSerializedAST` after it was introduced in Swift: https://github.com/apple/swift/pull/61628