### PR TITLE
Have GetSupportedArchitectures report all supported arches

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
@@ -987,11 +987,8 @@ bool PlatformDarwinKernel::LoadPlatformBinaryAndSetup(Process *process,
 std::vector<ArchSpec> PlatformDarwinKernel::GetSupportedArchitectures(
     const ArchSpec &process_host_arch) {
   std::vector<ArchSpec> result;
-#if defined(__arm__) || defined(__arm64__) || defined(__aarch64__)
   ARMGetSupportedArchitectures(result);
-#else
   x86GetSupportedArchitectures(result);
-#endif
   return result;
 }
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1450,7 +1450,8 @@ void Target::SetExecutableModule(ModuleSP &executable_sp,
     if (!m_arch.GetSpec().IsValid()) {
       m_arch = executable_sp->GetArchitecture();
       LLDB_LOG(log,
-               "setting architecture to {0} ({1}) based on executable file",
+               "Target::SetExecutableModule setting architecture to {0} ({1}) "
+               "based on executable file",
                m_arch.GetSpec().GetArchitectureName(),
                m_arch.GetSpec().GetTriple().getTriple());
     }
@@ -1550,7 +1551,9 @@ bool Target::SetArchitecture(const ArchSpec &arch_spec, bool set_platform,
     // specified
     if (replace_local_arch)
       m_arch = other;
-    LLDB_LOG(log, "set architecture to {0} ({1})",
+    LLDB_LOG(log,
+             "Target::SetArchitecture merging compatible arch; arch "
+             "is now {0} ({1})",
              m_arch.GetSpec().GetArchitectureName(),
              m_arch.GetSpec().GetTriple().getTriple());
     return true;
@@ -1558,9 +1561,13 @@ bool Target::SetArchitecture(const ArchSpec &arch_spec, bool set_platform,
 
   // If we have an executable file, try to reset the executable to the desired
   // architecture
-  LLDB_LOGF(log, "Target::SetArchitecture changing architecture to %s (%s)",
-            arch_spec.GetArchitectureName(),
-            arch_spec.GetTriple().getTriple().c_str());
+  LLDB_LOGF(
+      log,
+      "Target::SetArchitecture changing architecture to %s (%s) from %s (%s)",
+      arch_spec.GetArchitectureName(),
+      arch_spec.GetTriple().getTriple().c_str(),
+      m_arch.GetSpec().GetArchitectureName(),
+      m_arch.GetSpec().GetTriple().getTriple().c_str());
   m_arch = other;
   ModuleSP executable_sp = GetExecutableModule();
 


### PR DESCRIPTION
Have GetSupportedArchitectures report all supported arches

PlatformDarwinKernel::GetSupportedArchitectures returns a list of architectures that are possible for this platform; it was using a compile-time check for the debug host to decide the list of arches that were valid.  This was copied from a codepath doing native process debugging, and was clearly wrong for kernel debugging, but it had not happened to cause problems so it went unnoticed for a long time.

Small NFC change to the logging messages of Target::SetArchitecture to make them a little more explicit about how the architecture is being modified/replaced.

Differential Revision: https://reviews.llvm.org/D137301 rdar://101690111

(cherry picked from commit fd2065b70f2a74503725ebadb39c5dd2f9aa15c9)