### PR TITLE
[lldb] Add an option for playground transformation "high performance" mode

### DIFF
--- a/lldb/include/lldb/API/SBExpressionOptions.h
+++ b/lldb/include/lldb/API/SBExpressionOptions.h
@@ -74,6 +74,11 @@ public:
 
   void SetPlaygroundTransformEnabled(bool enable_playground_transform = true);
 
+  bool GetPlaygroundTransformHighPerformance() const;
+
+  void
+  SetPlaygroundTransformHighPerformance(bool playground_transforms_hp = true);
+
   bool GetREPLMode() const;
 
   void SetREPLMode(bool enable_repl_mode = true);

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -433,6 +433,14 @@ public:
       m_language = lldb::eLanguageTypeSwift;
   }
 
+  bool GetPlaygroundTransformHighPerformance() const {
+    return m_playground_transforms_hp;
+  }
+
+  void SetPlaygroundTransformHighPerformance(bool b) {
+    m_playground_transforms_hp = b;
+  }
+
   void SetCancelCallback(lldb::ExpressionCancelCallback callback, void *baton) {
     m_cancel_callback_baton = baton;
     m_cancel_callback = callback;
@@ -500,6 +508,7 @@ private:
   bool m_trap_exceptions = true;
   bool m_repl = false;
   bool m_playground = false;
+  bool m_playground_transforms_hp = true;
   bool m_generate_debug_info = false;
   bool m_ansi_color_errors = false;
   bool m_result_is_internal = false;

--- a/lldb/source/API/SBExpressionOptions.cpp
+++ b/lldb/source/API/SBExpressionOptions.cpp
@@ -174,6 +174,15 @@ void SBExpressionOptions::SetPlaygroundTransformEnabled(
   m_opaque_up->SetPlaygroundTransformEnabled(enable_playground_transform);
 }
 
+bool SBExpressionOptions::GetPlaygroundTransformHighPerformance() const {
+  return m_opaque_up->GetPlaygroundTransformHighPerformance();
+}
+
+void SBExpressionOptions::SetPlaygroundTransformHighPerformance(
+    bool playground_transforms_hp) {
+  m_opaque_up->SetPlaygroundTransformHighPerformance(playground_transforms_hp);
+}
+
 bool SBExpressionOptions::GetREPLMode() const {
   return m_opaque_up->GetREPLEnabled();
 }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1567,7 +1567,9 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
       return 1;
     }
   } else {
-    swift::performPlaygroundTransform(parsed_expr->source_file, true);
+    swift::performPlaygroundTransform(
+        parsed_expr->source_file,
+        m_options.GetPlaygroundTransformHighPerformance());
   }
 
   // FIXME: We now should have to do the name binding and type


### PR DESCRIPTION
Add an option to control "high performance" mode for Swift Playgrounds
transformations.

rdar://101554275
(cherry picked from commit a83966d65be024d46ccb5b8e141c06fa9d4dc288)
