### PR TITLE
[lldb] Add Substring type summary

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -14,6 +14,7 @@
 #include "Plugins/Language/Swift/SwiftStringIndex.h"
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
+#include "lldb/Core/ValueObject.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
 #include "lldb/DataFormatters/StringPrinter.h"
 #include "lldb/Target/Process.h"
@@ -23,6 +24,7 @@
 #include "lldb/Utility/Timer.h"
 #include "swift/AST/Types.h"
 #include "swift/Demangling/ManglingMacros.h"
+#include "llvm/ADT/None.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -71,6 +73,25 @@ bool lldb_private::formatters::swift::SwiftSharedString_SummaryProvider(
       StringPrinter::ReadStringAndDumpToStreamOptions());
 }
 
+using StringSlice = std::pair<uint64_t, uint64_t>;
+
+template <typename AddrT>
+static void applySlice(AddrT &address, uint64_t &length, StringSlice slice) {
+  // No slicing is performed when the slice starts beyond the string's bounds.
+  if (slice.first > length)
+    return;
+
+  auto offset = slice.first;
+  auto slice_length = slice.second - slice.first;
+
+  // Adjust from the start.
+  address += offset;
+  length -= offset;
+
+  // Reduce to the slice length, unless it's larger than the given length.
+  length = std::min(slice_length, length);
+}
+
 static bool readStringFromAddress(
     uint64_t startAddress, uint64_t length, ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &summary_options,
@@ -95,10 +116,11 @@ static bool readStringFromAddress(
       StringPrinter::StringElementType::UTF8>(read_options);
 };
 
-bool lldb_private::formatters::swift::StringGuts_SummaryProvider(
+static bool makeStringGutsSummary(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &summary_options,
-    StringPrinter::ReadStringAndDumpToStreamOptions read_options) {
+    StringPrinter::ReadStringAndDumpToStreamOptions read_options,
+    StringSlice slice = {0, UINT64_MAX}) {
   LLDB_SCOPED_TIMER();
 
   static ConstString g__object("_object");
@@ -278,11 +300,13 @@ bool lldb_private::formatters::swift::StringGuts_SummaryProvider(
     if (count > maxCount)
       return false;
 
-    uint64_t buffer[2] = {raw0, raw1};
+    uint64_t rawBuffer[2] = {raw0, raw1};
+    auto *buffer = static_cast<uint8_t *>(static_cast<void *>(&rawBuffer));
+    applySlice(buffer, count, slice);
 
     StringPrinter::ReadBufferAndDumpToStreamOptions options(read_options);
-    options.SetData(
-        DataExtractor(buffer, count, process->GetByteOrder(), ptrSize));
+    options.SetData(lldb_private::DataExtractor(
+        buffer, count, process->GetByteOrder(), ptrSize));
     options.SetStream(&stream);
     options.SetSourceSize(count);
     options.SetBinaryZeroIsTerminator(false);
@@ -300,6 +324,7 @@ bool lldb_private::formatters::swift::StringGuts_SummaryProvider(
       return false;
     uint64_t bias = (ptrSize == 8 ? 32 : 20);
     auto address = objectAddress + bias;
+    applySlice(address, count, slice);
     return readStringFromAddress(
       address, count, valobj, stream, summary_options, read_options);
   }
@@ -315,6 +340,7 @@ bool lldb_private::formatters::swift::StringGuts_SummaryProvider(
     if (error.Fail())
       return false;
 
+    applySlice(address, count, slice);
     return readStringFromAddress(
       start, count, valobj, stream, summary_options, read_options);
   }
@@ -333,7 +359,8 @@ bool lldb_private::formatters::swift::StringGuts_SummaryProvider(
             lldb::eBasicTypeObjCID);
 
     // We may have an NSString pointer inline, so try formatting it directly.
-    DataExtractor DE(&objectAddress, ptrSize, process->GetByteOrder(), ptrSize);
+    lldb_private::DataExtractor DE(&objectAddress, ptrSize,
+                                   process->GetByteOrder(), ptrSize);
     auto nsstring = ValueObject::CreateValueObjectFromData(
         "nsstring", DE, valobj.GetExecutionContextRef(), id_type);
     if (!nsstring || nsstring->GetError().Fail())
@@ -350,6 +377,13 @@ bool lldb_private::formatters::swift::StringGuts_SummaryProvider(
 
   // Invalid discriminator.
   return false;
+}
+
+bool lldb_private::formatters::swift::StringGuts_SummaryProvider(
+    ValueObject &valobj, Stream &stream,
+    const TypeSummaryOptions &summary_options,
+    StringPrinter::ReadStringAndDumpToStreamOptions read_options) {
+  return makeStringGutsSummary(valobj, stream, summary_options, read_options);
 }
 
 bool lldb_private::formatters::swift::String_SummaryProvider(
@@ -369,6 +403,53 @@ bool lldb_private::formatters::swift::String_SummaryProvider(
     return StringGuts_SummaryProvider(*guts_sp, stream, summary_options,
                                       read_options);
   return false;
+}
+
+bool lldb_private::formatters::swift::Substring_SummaryProvider(
+    ValueObject &valobj, Stream &stream,
+    const TypeSummaryOptions &summary_options) {
+  static ConstString g__slice("_slice");
+  static ConstString g__base("_base");
+  static ConstString g__startIndex("_startIndex");
+  static ConstString g__endIndex("_endIndex");
+  static ConstString g__rawBits("_rawBits");
+  auto slice_sp = valobj.GetChildMemberWithName(g__slice, true);
+  if (!slice_sp)
+    return false;
+  auto base_sp = slice_sp->GetChildMemberWithName(g__base, true);
+  if (!base_sp)
+    return false;
+
+  auto get_index =
+      [&slice_sp](ConstString index_name) -> Optional<StringIndex> {
+    auto raw_bits_sp = slice_sp->GetChildAtNamePath({index_name, g__rawBits});
+    if (!raw_bits_sp)
+      return None;
+    bool success = false;
+    StringIndex index =
+        raw_bits_sp->GetSyntheticValue()->GetValueAsUnsigned(0, &success);
+    if (!success)
+      return None;
+    return index;
+  };
+
+  Optional<StringIndex> start_index = get_index(g__startIndex);
+  Optional<StringIndex> end_index = get_index(g__endIndex);
+  if (!start_index || !end_index)
+    return false;
+
+  if (!start_index->matchesEncoding(*end_index))
+    return false;
+
+  static ConstString g_guts("_guts");
+  auto guts_sp = base_sp->GetChildMemberWithName(g_guts, true);
+  if (!guts_sp)
+    return false;
+
+  StringPrinter::ReadStringAndDumpToStreamOptions read_options;
+  return makeStringGutsSummary(
+      *guts_sp, stream, summary_options, read_options,
+      {start_index->encodedOffset(), end_index->encodedOffset()});
 }
 
 bool lldb_private::formatters::swift::StringIndex_SummaryProvider(

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -54,6 +54,9 @@ bool String_SummaryProvider(ValueObject &valobj, Stream &stream,
                             const TypeSummaryOptions &,
                             StringPrinter::ReadStringAndDumpToStreamOptions);
 
+bool Substring_SummaryProvider(ValueObject &, Stream &,
+                               const TypeSummaryOptions &);
+
 bool StringIndex_SummaryProvider(ValueObject &valobj, Stream &stream,
                                  const TypeSummaryOptions &options);
 

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -425,6 +425,14 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   bool (*staticstring_summary_provider)(ValueObject &, Stream &,
                                         const TypeSummaryOptions &) =
       lldb_private::formatters::swift::StaticString_SummaryProvider;
+  {
+    TypeSummaryImpl::Flags substring_summary_flags = summary_flags;
+    substring_summary_flags.SetDontShowChildren(false);
+    AddCXXSummary(swift_category_sp,
+                  lldb_private::formatters::swift::Substring_SummaryProvider,
+                  "Swift.Substring summary provider",
+                  ConstString("Swift.Substring"), substring_summary_flags);
+  }
   AddCXXSummary(swift_category_sp, staticstring_summary_provider,
                 "Swift.StaticString summary provider",
                 ConstString("Swift.StaticString"), summary_flags);

--- a/lldb/source/Plugins/Language/Swift/SwiftStringIndex.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftStringIndex.h
@@ -42,7 +42,7 @@ public:
   uint64_t encodedOffset() { return _rawBits >> 16; }
 
   const char *encodingName() {
-    uint8_t flags = _rawBits & 0b1111;
+    auto flags = _flags();
     bool canBeUTF8 = flags & Flags::CanBeUTF8;
     bool canBeUTF16 = flags & Flags::CanBeUTF16;
     if (canBeUTF8 && canBeUTF16)
@@ -56,6 +56,18 @@ public:
   }
 
   uint8_t transcodedOffset() { return (_rawBits >> 14) & 0b11; }
+
+  bool matchesEncoding(StringIndex other) {
+    // Either both are valid utf8 indexes, or valid utf16 indexes.
+    return (_utfFlags() & other._utfFlags()) != 0;
+  }
+
+private:
+  uint8_t _flags() const { return _rawBits & 0b1111; }
+
+  uint8_t _utfFlags() const {
+    return _flags() & (Flags::CanBeUTF8 | Flags::CanBeUTF16);
+  }
 };
 
 }; // namespace swift

--- a/lldb/test/API/functionalities/data-formatter/swift/substring/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/swift/substring/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
@@ -1,0 +1,49 @@
+"""
+Test Substring summary strings.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    # @skipUnlessFoundation
+    @swiftTest
+    def test_swift_substring_formatters(self):
+        """Test Subtring summary strings."""
+        self.build()
+
+        # First stop tests small strings.
+
+        _, process, _, _, = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect(
+            "v substrings",
+            substrs=[
+                '[0] = "abc"',
+                '[1] = "bc"',
+                '[2] = "c"',
+                '[3] = ""',
+            ],
+        )
+
+        # Continue to second stop, to test non-small strings.
+
+        process.Continue()
+
+        # Strings larger that 15 bytes (64-bit) or 10 bytes (32-bit) cannot be
+        # stored directly inside the String struct.
+        alphabet = "abcdefghijklmnopqrstuvwxyz"
+        subalphabets = [alphabet[i:] for i in range(len(alphabet) + 1)]
+
+        self.expect(
+            "v substrings",
+            substrs=[
+                f'[{i}] = "{substring}"'
+                for i, substring in zip(range(26), subalphabets)
+            ],
+        )

--- a/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
@@ -34,7 +34,7 @@ class TestCase(TestBase):
 
         process.Continue()
 
-        # Strings larger that 15 bytes (64-bit) or 10 bytes (32-bit) cannot be
+        # Strings larger than 15 bytes (64-bit) or 10 bytes (32-bit) cannot be
         # stored directly inside the String struct.
         alphabet = "abcdefghijklmnopqrstuvwxyz"
 
@@ -46,6 +46,6 @@ class TestCase(TestBase):
             "v substrings",
             substrs=[
                 f'[{i}] = "{substring}"'
-                for i, substring in zip(range(27), subalphabets)
+                for i, substring in enumerate(subalphabets)
             ],
         )

--- a/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
@@ -9,7 +9,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
-    # @skipUnlessFoundation
     @swiftTest
     def test_swift_substring_formatters(self):
         """Test Subtring summary strings."""
@@ -31,19 +30,22 @@ class TestCase(TestBase):
             ],
         )
 
-        # Continue to second stop, to test non-small strings.
+        # Continue to the second stop, to test non-small strings.
 
         process.Continue()
 
         # Strings larger that 15 bytes (64-bit) or 10 bytes (32-bit) cannot be
         # stored directly inside the String struct.
         alphabet = "abcdefghijklmnopqrstuvwxyz"
-        subalphabets = [alphabet[i:] for i in range(len(alphabet) + 1)]
+
+        # Including the first full substring, and the final empty substring,
+        # there are 27 substrings.
+        subalphabets = [alphabet[i:] for i in range(27)]
 
         self.expect(
             "v substrings",
             substrs=[
                 f'[{i}] = "{substring}"'
-                for i, substring in zip(range(26), subalphabets)
+                for i, substring in zip(range(27), subalphabets)
             ],
         )

--- a/lldb/test/API/functionalities/data-formatter/swift/substring/main.swift
+++ b/lldb/test/API/functionalities/data-formatter/swift/substring/main.swift
@@ -1,0 +1,23 @@
+func main() {
+    exerciseSmallString()
+    exerciseString()
+}
+
+func exerciseSmallString() {
+    exercise("abc")
+}
+
+func exerciseString() {
+    exercise("abcdefghijklmnopqrstuvwxyz")
+}
+
+func exercise(_ string: String) {
+    let substrings = allIndices(string).map { string[$0..<string.endIndex] }
+    // break here
+}
+
+func allIndices<T: Collection>(_ collection: T) -> [T.Index] {
+    return Array(collection.indices) + [collection.endIndex]
+}
+
+main()


### PR DESCRIPTION
Adds a type summary for `Substring` values.

With this change, a summary string shows the substring slice. The substring's children show the base string, and start/end indexes.

```
(lldb) v substring
(Substring) substring = "bcdefghijklmnopqrstuvwxy" {
  _slice = {
    _startIndex = 1[utf8]
    _endIndex = 25[utf8]
    _base = "abcdefghijklmnopqrstuvwxyz"
  }
}
```

Before this change, a literal substring was not shown, only the full base string:

```
(lldb) v substring
(Substring) substring = {
  _slice = {
    _startIndex = 1[utf8]
    _endIndex = 25[utf8]
    _base = "abcdefghijklmnopqrstuvwxyz"
  }
}
```

#### Implementation Notes

This supports Swift native (utf8) strings. NSString (utf16) are not yet supported, that will be a follow up change. Additionally, this change requires that the indexes be matching encoding.

rdar://91431816