### PR TITLE
[cas] Fix unnecessary cache-misses with modules by excluding or canonicalizing files in cas-fs

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
@@ -63,6 +63,7 @@ public:
   createThreadSafeProxyFS() override;
 
   llvm::ErrorOr<llvm::vfs::Status> status(const Twine &Path) override;
+  bool exists(const Twine &Path) override;
   llvm::ErrorOr<std::unique_ptr<llvm::vfs::File>>
   openFileForRead(const Twine &Path) override;
 

--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -952,7 +952,8 @@ static void inferFrameworkLink(Module *Mod, const DirectoryEntry *FrameworkDir,
   // for both before we give up.
   for (const char *extension : {"", ".tbd"}) {
     llvm::sys::path::replace_extension(LibName, extension);
-    if (FileMgr.getFile(LibName)) {
+    // Use VFS exists to avoid depending on the file's contents in cached builds
+    if (FileMgr.getVirtualFileSystem().exists(LibName)) {
       Mod->LinkLibraries.push_back(Module::LinkLibrary(Mod->Name,
                                                        /*IsFramework=*/true));
       return;

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
@@ -299,6 +299,13 @@ DependencyScanningCASFilesystem::status(const Twine &Path) {
   return Result.Entry->Status;
 }
 
+bool DependencyScanningCASFilesystem::exists(const Twine &Path) {
+  // Existence check does not require caching the result at the dependency
+  // scanning level. The CachingOnDiskFileSystem tracks the exists call, which
+  // ensures it is included in any resulting CASFileSystem.
+  return getCachingFS().exists(Path);
+}
+
 IntrusiveRefCntPtr<llvm::cas::ThreadSafeFileSystem>
 DependencyScanningCASFilesystem::createThreadSafeProxyFS() {
   llvm::report_fatal_error("not implemented");

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -253,6 +253,10 @@ private:
     // modules share their VFS.
     for (const auto &File : CI.getHeaderSearchOpts().VFSOverlayFiles)
       (void)FS->status(File);
+    // Exclude the module cache from tracking. The implicit build pcms should
+    // not be needed after scanning.
+    if (!CI.getHeaderSearchOpts().ModuleCachePath.empty())
+      (void)FS->excludeFromTracking(CI.getHeaderSearchOpts().ModuleCachePath);
     return WrapperFrontendAction::BeginInvocation(CI);
   }
 
@@ -469,6 +473,12 @@ public:
     Consumer.finalize(ScanInstance);
 
     if (CacheFS) {
+      // Exclude the module cache from tracking. The implicit build pcms should
+      // not be needed after scanning.
+      if (!ScanInstance.getHeaderSearchOpts().ModuleCachePath.empty())
+        (void)CacheFS->excludeFromTracking(
+            ScanInstance.getHeaderSearchOpts().ModuleCachePath);
+
       auto Tree = CacheFS->createTreeFromNewAccesses(RemapPath);
       if (Tree) {
         if (MDC)

--- a/clang/test/CAS/fcas-fs-framework-autolink.c
+++ b/clang/test/CAS/fcas-fs-framework-autolink.c
@@ -1,0 +1,51 @@
+// Check that when scanning framework modules, changing the framework binary
+// does not change the cache key.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -format experimental-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps_no_fw.json
+
+// RUN: echo 'build 1' > %t/Foo.framework/Foo
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -format experimental-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps_fw1.json
+
+// The existince of the framework is significant, since it affects autolinking.
+// RUN: not diff -u %t/deps_fw1.json %t/deps_fw2.json
+
+// RUN: echo 'build 2' > %t/Foo.framework/Foo
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -format experimental-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps_fw2.json
+
+// But the contents of the binary are not.
+// RUN: diff -u %t/deps_fw1.json %t/deps_fw2.json
+
+//--- cdb.json.template
+[{
+  "directory" : "DIR",
+  "command" : "clang_tool -fsyntax-only DIR/tu.c -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache -F DIR",
+  "file" : "DIR/tu.c"
+}]
+
+//--- Foo.framework/Modules/module.modulemap
+framework module Foo {
+  umbrella header "Foo.h"
+  export *
+}
+
+//--- Foo.framework/Headers/Foo.h
+
+//--- tu.c
+#include "Foo/Foo.h"

--- a/clang/test/ClangScanDeps/modules-cas-trees-exclude-files-from-casfs.c
+++ b/clang/test/ClangScanDeps/modules-cas-trees-exclude-files-from-casfs.c
@@ -1,0 +1,85 @@
+// Check that files that should not impact the module build are not included in
+// the cas-fs, which can cause spurious rebuilds.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+// RUN: sed "s|DIR|%/t|g" %t/cdb_cache2.json.template > %t/cdb_cache2.json
+// RUN: sed "s|DIR|%/t|g" %t/cdb_timestamp.json.template > %t/cdb_timestamp.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -format experimental-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// Changing module cache path should not affect results.
+// RUN: clang-scan-deps -compilation-database %t/cdb_cache2.json \
+// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -format experimental-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps_cache2.json
+// RUN: diff -u %t/deps_cache2.json %t/deps.json
+
+// .pcm.timestamp files created by -fmodules-validate-once-per-build-session should not affect results
+// RUN: touch %t/session
+// RUN: clang-scan-deps -compilation-database %t/cdb_timestamp.json \
+// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -format experimental-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps_pre_timestamp.json
+// RUN: touch %t/Top.h
+// RUN: clang-scan-deps -compilation-database %t/cdb_timestamp.json \
+// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -format experimental-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps_post_timestamp.json
+// RUN: diff -u %t/deps_pre_timestamp.json %t/deps_post_timestamp.json
+
+//--- cdb.json.template
+[{
+  "directory" : "DIR",
+  "command" : "clang_tool -fsyntax-only DIR/tu.c -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache",
+  "file" : "DIR/tu.c"
+}]
+
+//--- cdb_cache2.json.template
+[{
+  "directory" : "DIR",
+  "command" : "clang_tool -fsyntax-only DIR/tu.c -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache2 -Rcompile-job-cache",
+  "file" : "DIR/tu.c"
+}]
+
+//--- cdb_timestamp.json.template
+[{
+  "directory" : "DIR",
+  "command" : "clang_tool -fsyntax-only DIR/tu.c -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache2 -fmodules-validate-once-per-build-session -fbuild-session-file=DIR/session -Rcompile-job-cache",
+  "file" : "DIR/tu.c"
+}]
+
+//--- module.modulemap
+module Top { header "Top.h" export * }
+module Left { header "Left.h" export * }
+module Right { header "Right.h" export * }
+
+//--- Top.h
+#pragma once
+void Top(void);
+
+//--- Left.h
+#pragma once
+#include "Top.h"
+void Left(void);
+
+//--- Right.h
+#pragma once
+#include "Top.h"
+void Right(void);
+
+//--- tu.c
+#include "Left.h"
+#include "Right.h"
+
+void tu(void) {
+  Top();
+  Left();
+  Right();
+}

--- a/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
+++ b/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
@@ -45,6 +45,15 @@ public:
   /// accesses are only recorded in the currently active scope.
   virtual void trackNewAccesses() = 0;
 
+  /// Exclude \p Path from the current tracking scope. If \p Path is a
+  /// directory, this excludes the contents of that directory as well. \returns
+  /// any error seen resolving \p Path.
+  ///
+  /// \note Excluding a path should be done carefully to avoid anti-dependency
+  /// issues. It is important to understand how the path not existing will
+  /// behave when accessing the resulting \c CASFileSystem.
+  virtual std::error_code excludeFromTracking(const Twine &Path) = 0;
+
   /// Create a tree that represents all stats tracked since the call to \a
   /// trackNewAccesses(). Removes the current tracking scope.
   ///

--- a/llvm/include/llvm/CAS/TreeEntry.h
+++ b/llvm/include/llvm/CAS/TreeEntry.h
@@ -29,6 +29,7 @@ public:
   EntryKind getKind() const { return Kind; }
   bool isRegular() const { return Kind == Regular; }
   bool isExecutable() const { return Kind == Executable; }
+  bool isFile() const { return isRegular() || isExecutable(); }
   bool isSymlink() const { return Kind == Symlink; }
   bool isTree() const { return Kind == Tree; }
 

--- a/llvm/include/llvm/Support/VirtualFileSystem.h
+++ b/llvm/include/llvm/Support/VirtualFileSystem.h
@@ -359,8 +359,9 @@ public:
     return createFileError(Path, make_error_code(std::errc::not_supported));
   }
 
-  /// Check whether a file exists. Provided for convenience.
-  bool exists(const Twine &Path);
+  /// Check whether \p Path exists. By default this uses \c status(), but
+  /// filesystems may provide a more efficient implementation if available.
+  virtual bool exists(const Twine &Path);
 
   /// Is the file mounted on a local filesystem?
   virtual std::error_code isLocal(const Twine &Path, bool &Result);
@@ -440,6 +441,7 @@ public:
   void pushOverlay(IntrusiveRefCntPtr<FileSystem> FS);
 
   llvm::ErrorOr<Status> status(const Twine &Path) override;
+  bool exists(const Twine &Path) override;
   llvm::ErrorOr<std::unique_ptr<File>>
   openFileForRead(const Twine &Path) override;
   directory_iterator dir_begin(const Twine &Dir, std::error_code &EC) override;
@@ -491,6 +493,7 @@ public:
   llvm::ErrorOr<Status> status(const Twine &Path) override {
     return FS->status(Path);
   }
+  bool exists(const Twine &Path) override { return FS->exists(Path); }
   llvm::ErrorOr<std::unique_ptr<File>>
   openFileForRead(const Twine &Path) override {
     return FS->openFileForRead(Path);
@@ -1031,6 +1034,7 @@ public:
          bool UseExternalNames, FileSystem &ExternalFS);
 
   ErrorOr<Status> status(const Twine &Path) override;
+  bool exists(const Twine &Path) override;
   ErrorOr<std::unique_ptr<File>> openFileForRead(const Twine &Path) override;
 
   std::error_code getRealPath(const Twine &Path,

--- a/llvm/lib/Support/VirtualFileSystem.cpp
+++ b/llvm/lib/Support/VirtualFileSystem.cpp
@@ -457,6 +457,15 @@ ErrorOr<Status> OverlayFileSystem::status(const Twine &Path) {
   return make_error_code(llvm::errc::no_such_file_or_directory);
 }
 
+bool OverlayFileSystem::exists(const Twine &Path) {
+  // FIXME: handle symlinks that cross file systems
+  for (iterator I = overlays_begin(), E = overlays_end(); I != E; ++I) {
+    if ((*I)->exists(Path))
+      return true;
+  }
+  return false;
+}
+
 ErrorOr<std::unique_ptr<File>>
 OverlayFileSystem::openFileForRead(const llvm::Twine &Path) {
   // FIXME: handle symlinks that cross file systems
@@ -2357,6 +2366,54 @@ ErrorOr<Status> RedirectingFileSystem::status(const Twine &OriginalPath) {
   }
 
   return S;
+}
+
+bool RedirectingFileSystem::exists(const Twine &OriginalPath) {
+  SmallString<256> CanonicalPath;
+  OriginalPath.toVector(CanonicalPath);
+
+  if (makeCanonical(CanonicalPath))
+    return false;
+
+  if (Redirection == RedirectKind::Fallback) {
+    // Attempt to find the original file first, only falling back to the
+    // mapped file if that fails.
+    if (ExternalFS->exists(CanonicalPath))
+      return true;
+  }
+
+  ErrorOr<RedirectingFileSystem::LookupResult> Result =
+      lookupPath(CanonicalPath);
+  if (!Result) {
+    // Was not able to map file, fallthrough to using the original path if
+    // that was the specified redirection type.
+    if (Redirection == RedirectKind::Fallthrough &&
+        isFileNotFound(Result.getError()))
+      return ExternalFS->exists(CanonicalPath);
+    return false;
+  }
+
+  Optional<StringRef> ExtRedirect = Result->getExternalRedirect();
+  if (!ExtRedirect) {
+    assert(isa<RedirectingFileSystem::DirectoryEntry>(Result->E));
+    return true;
+  }
+
+  SmallString<256> CanonicalRemappedPath((*ExtRedirect).str());
+  if (makeCanonical(CanonicalRemappedPath))
+    return false;
+
+  if (ExternalFS->exists(CanonicalRemappedPath))
+    return true;
+
+  if (Redirection == RedirectKind::Fallthrough) {
+    // Mapped the file but it wasn't found in the underlying filesystem,
+    // fallthrough to using the original path if that was the specified
+    // redirection type.
+    return ExternalFS->exists(CanonicalPath);
+  }
+
+  return false;
 }
 
 namespace {


### PR DESCRIPTION
Note: this depends on https://github.com/apple/llvm-project/pull/5294

---

This fixes common issues that cause unnecessary cache misses with modules triggered by the cas-fs being too specific. 

First, we exclude the module cache directory used as an implementation detail of clang-scan-deps entirely from the cas-fs. We do not need access to the scanner's modules, and both the pcm files and timestamp files cause many cache misses if they are included.

Second, we canonicalize the contents of framework binaries (e.g. the dylib `Foo.framework/Foo`) if they are only accessed by clang to check for autolinking. That was causing unnecessary misses every time a framework was rebuilt.  More generally, if a file is accessed using `VirtualFileSystem::exists()` we will canonicalize it to an empty file unless there is another access that requires more information.

There are opportunities to do more canonicalization - e.g.  for files only accessed by `status`, but they are harder to implement (see commit messages for more details).

Note: while some of these changes are in non-CAS code like VFS::exists(), I'm doing them only in our branches because I haven't found any way to motivate such a change upstream.  All upstream exists() calls go through status() anyway, so it would just be more code to accomplish the same thing