### PR TITLE
[clang-cache] Don't issue -Wreproducible-caching by default

### DIFF
--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -764,7 +764,7 @@ def warn_pp_date_time : Warning<
 
 def warn_pp_encounter_nonreproducible: Warning<
   "encountered non-reproducible token, caching will be skipped">,
-  InGroup<DiagGroup<"reproducible-caching">>;
+  InGroup<DiagGroup<"reproducible-caching">>, DefaultIgnore;
 def err_pp_encounter_nonreproducible: Error<
   "encountered non-reproducible token, caching failed">;
 

--- a/clang/test/CAS/test-for-deterministic-outputs.c
+++ b/clang/test/CAS/test-for-deterministic-outputs.c
@@ -10,12 +10,12 @@
 // CACHE-SKIPPED: remark: compile job cache skipped
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
-// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache 2> %t/out.txt
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache -Wreproducible-caching 2> %t/out.txt
 // RUN: FileCheck %s --check-prefix=CACHE-WARN --input-file=%t/out.txt
 
 /// Check still a cache miss.
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
-// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache 2> %t/out.txt
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache -Wreproducible-caching 2> %t/out.txt
 // RUN: FileCheck %s --check-prefix=CACHE-WARN --input-file=%t/out.txt
 
 // CACHE-WARN: remark: compile job cache miss
@@ -23,6 +23,17 @@
 // CACHE-WARN: warning: encountered non-reproducible token, caching will be skipped
 // CACHE-WARN: warning: encountered non-reproducible token, caching will be skipped
 // CACHE-WARN: remark: compile job cache skipped
+
+/// Check -Werror doesn't actually error when we use the launcher.
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Werror -Rcompile-job-cache 2> %t/out.txt
+// RUN: FileCheck %s --check-prefix=NOERROR --input-file=%t/out.txt
+// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_CHECK_REPRODUCIBLE_CACHING_ISSUES=1 %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache 2> %t/out.txt
+// RUN: FileCheck %s --check-prefix=ERROR --input-file=%t/out.txt
+
+// NOERROR-NOT: error:
+// ERROR: error: encountered non-reproducible token, caching will be skipped
 
 void getit(const char **p1, const char **p2, const char **p3) {
   *p1 = __DATE__;

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -191,6 +191,10 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
       Args.append({"-Wno-builtin-macro-redefined", "-D__DATE__=\"redacted\"",
                    "-D__TIMESTAMP__=\"redacted\"", "-D__TIME__=\"redacted\""});
     }
+    if (llvm::sys::Process::GetEnv(
+            "CLANG_CACHE_CHECK_REPRODUCIBLE_CACHING_ISSUES")) {
+      Args.append({"-Werror=reproducible-caching"});
+    }
     if (llvm::sys::Process::GetEnv("CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS")) {
       // Run the compilation twice, without replaying, to check that we get the
       // same compilation artifacts for the same key. If they are not the same


### PR DESCRIPTION
Don't enable the caching warning by default since it changes the behavior and can cause issues for projects using `-Werror`. Instead, add an option to enable -Werror for the option in clang-cache.

rdar://102043619