### PR TITLE
Move the initialization of the DebuggerSupport flag to a single place.

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -917,7 +917,6 @@ SetupASTContext(SwiftASTContextForExpressions &swift_ast_context,
   // swift_ast_context.GetLanguageOptions().DebugConstraintSolver = true;
   swift_ast_context.ClearDiagnostics();
 
-  swift_ast_context.GetLanguageOptions().DebuggerSupport = true;
   // No longer part of debugger support, set it separately.
   swift_ast_context.GetLanguageOptions().EnableDollarIdentifiers = true;
   swift_ast_context.GetLanguageOptions().EnableAccessControl =

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -927,6 +927,7 @@ SwiftASTContext::SwiftASTContext(std::string description,
   // to avoid crashing due to module recovery issues.
   swift::LangOptions &lang_opts = m_compiler_invocation_ap->getLangOptions();
   lang_opts.AllowDeserializingImplementationOnly = true;
+  lang_opts.DebuggerSupport = true;
 }
 
 SwiftASTContext::~SwiftASTContext() {
@@ -1487,7 +1488,6 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
   // This is a module AST context, mark it as such.
   swift_ast_sp->m_is_scratch_context = false;
   swift_ast_sp->m_module = &module;
-  swift_ast_sp->GetLanguageOptions().DebuggerSupport = true;
   swift_ast_sp->GetLanguageOptions().EnableAccessControl = false;
   swift_ast_sp->GetLanguageOptions().EnableTargetOSChecking = false;
 


### PR DESCRIPTION
In the expression context it is currently sometimes initialized too late (i.e., after module deserialization).

(cherry picked from commit e95bfb7a129a947e0f0898e4a38656124eaef2bc)