### PR TITLE
[rebranch] cherry-pick: [ORC] Force linking of eh-frame registration functions from LLJIT.cpp.

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
@@ -16,6 +16,7 @@
 #include "llvm/ExecutionEngine/Orc/ObjectTransformLayer.h"
 #include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcError.h"
+#include "llvm/ExecutionEngine/Orc/TargetProcess/RegisterEHFrames.h"
 #include "llvm/ExecutionEngine/SectionMemoryManager.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/IRBuilder.h"
@@ -1012,6 +1013,13 @@ LLLazyJIT::LLLazyJIT(LLLazyJITBuilderState &S, Error &Err) : LLJIT(S, Err) {
 
   if (S.NumCompileThreads > 0)
     CODLayer->setCloneToNewContextOnEmit(true);
+}
+
+// In-process LLJIT uses eh-frame section wrappers via EPC, so we need to force
+// them to be linked in.
+LLVM_ATTRIBUTE_USED void linkComponents() {
+  errs() << (void *)&llvm_orc_registerEHFrameSectionWrapper
+         << (void *)&llvm_orc_deregisterEHFrameSectionWrapper;
 }
 
 } // End namespace orc.


### PR DESCRIPTION
Since aedeb8d5570, which switched to EPC-based eh-frame registrationin LLJIT, the eh-frame registration functions need to be forcibly linked into the target process.

Failure to link the eh-frame registration functions triggered a test failure in https://green.lab.llvm.org/green/job/clang-stage1-RA/31497, which was fixed by forcibly linking the registration functions into that test case in saf2b2214b4 (rdar://101083784), however it has also caused some tests (e.g. the C API unit tests) that depend on successful construction of an LLJIT instance to be skipped.

Moving the forcible registration into LLJIT.cpp fixes the general issue.