### PR TITLE
[lldb] Fix issue with re.Pattern availability

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -81,7 +81,9 @@ def _match_decorator_property(expected, actual):
     if isinstance(expected, no_match):
         return not _match_decorator_property(expected.item, actual)
 
-    if isinstance(expected, (re.Pattern, str)):
+    # Python 3.6 doesn't declare a `re.Pattern` type, get the dynamic type.
+    pattern_type = type(re.compile(''))
+    if isinstance(expected, (pattern_type, str)):
         return re.search(expected, actual) is not None
 
     if hasattr(expected, "__iter__"):

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -283,18 +283,29 @@ class ValueCheck:
 
         test_base.assertSuccess(val.GetError())
 
+        # Python 3.6 doesn't declare a `re.Pattern` type, get the dynamic type.
+        pattern_type = type(re.compile(''))
+
         if self.expect_name:
             test_base.assertEqual(self.expect_name, val.GetName(),
                                   this_error_msg)
         if self.expect_value:
-            test_base.assertEqual(self.expect_value, val.GetValue(),
-                                  this_error_msg)
+            if isinstance(self.expect_value, pattern_type):
+                test_base.assertRegex(val.GetValue(), self.expect_value,
+                                      this_error_msg)
+            else:
+                test_base.assertEqual(self.expect_value, val.GetValue(),
+                                      this_error_msg)
         if self.expect_type:
             test_base.assertEqual(self.expect_type, val.GetDisplayTypeName(),
                                   this_error_msg)
         if self.expect_summary:
-            test_base.assertEqual(self.expect_summary, val.GetSummary(),
-                                  this_error_msg)
+            if isinstance(self.expect_summary, pattern_type):
+                test_base.assertRegex(val.GetSummary(), self.expect_summary,
+                                      this_error_msg)
+            else:
+                test_base.assertEqual(self.expect_summary, val.GetSummary(),
+                                      this_error_msg)
         if self.children is not None:
             self.check_value_children(test_base, val, error_msg)
 


### PR DESCRIPTION
`re.Pattern` is introduced in Python 3.7. To support Python 3.6, fallback to typechecking against `SRE_Pattern`.

Differential Revision: https://reviews.llvm.org/D137582

(cherry picked from commit 7bf3cb3ee871b6707b7f5114a7fde61485df450e)