### PR TITLE
[SLP]Fix PR58863: Mask index beyond mask size for non-power-2 inserte…

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -6458,6 +6458,8 @@ InstructionCost BoUpSLP::getEntryCost(const TreeEntry *E,
               Mask[I] = I + VecSz;
           for (unsigned I = OffsetEnd + 1 - Offset; I < VecSz; ++I)
             Mask[I] = InMask.test(I) ? UndefMaskElem : I;
+            Mask[I] =
+                ((I >= InMask.size()) || InMask.test(I)) ? UndefMaskElem : I;
           Cost += TTI->getShuffleCost(TTI::SK_PermuteTwoSrc, InsertVecTy, Mask);
         }
       }

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -6457,7 +6457,6 @@ InstructionCost BoUpSLP::getEntryCost(const TreeEntry *E,
             if (Mask[I] != UndefMaskElem)
               Mask[I] = I + VecSz;
           for (unsigned I = OffsetEnd + 1 - Offset; I < VecSz; ++I)
-            Mask[I] = InMask.test(I) ? UndefMaskElem : I;
             Mask[I] =
                 ((I >= InMask.size()) || InMask.test(I)) ? UndefMaskElem : I;
           Cost += TTI->getShuffleCost(TTI::SK_PermuteTwoSrc, InsertVecTy, Mask);


### PR DESCRIPTION
…lement analysis.

Need to check if the insertelement mask size is reached during cost analysis to avoid compiler crash.

Differential Revision: https://reviews.llvm.org/D137639