### PR TITLE
[lldb] Test that optional bools are displayed correctly

### DIFF
--- a/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
+++ b/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
@@ -59,6 +59,10 @@ class TestSwiftOptionalType(TestBase):
         self.expect("frame variable optString_None", substrs=['nil'])
         self.expect("frame variable uoptString_None", substrs=['nil'])
 
+        self.expect("frame variable optTrue", substrs=['Bool?', 'true'])
+        self.expect("frame variable optFalse", substrs=['Bool?','false'])
+        self.expect("frame variable optNil", substrs=['Bool?', 'nil'])
+
     def do_check_api(self):
         """Check formatting for T? and T!"""
         optS_Some = self.frame().FindVariable("optS_Some")
@@ -100,6 +104,30 @@ class TestSwiftOptionalType(TestBase):
             use_dynamic=False,
             num_children=1)
         uoptString_Some.GetChildAtIndex(99)
+
+        optTrue = self.frame().FindVariable("optTrue")
+        lldbutil.check_variable(
+            self,
+            optTrue,
+            use_dynamic=False,
+            num_children=1,
+            summary='true')
+
+        optFalse = self.frame().FindVariable("optFalse")
+        lldbutil.check_variable(
+            self,
+            optFalse,
+            use_dynamic=False,
+            num_children=1,
+            summary='false')
+
+        optNil = self.frame().FindVariable("optNil")
+        lldbutil.check_variable(
+            self,
+            optNil,
+            use_dynamic=False,
+            num_children=0,
+            summary='nil')
 
         # Querying a non-existing child should not crash.
         synth_valobj = self.frame().FindVariable("optString_Some")

--- a/lldb/test/API/lang/swift/variables/optionals/main.swift
+++ b/lldb/test/API/lang/swift/variables/optionals/main.swift
@@ -37,6 +37,10 @@ func main() {
   var optString_None : String? = nil
   var uoptString_None : String! = nil
 
+  var optTrue: Bool? = true
+  var optFalse: Bool? = false
+  var optNil: Bool? = nil
+
   print("//Set breakpoint here") // Set breakpoint here
 }
 

--- a/lldb/test/Shell/SwiftREPL/Optional.test
+++ b/lldb/test/Shell/SwiftREPL/Optional.test
@@ -37,3 +37,12 @@ var q : A? = A(23)
 
 let tinky : UInt8? = 250
 // CHECK-NEXT: {{tinky}}: UInt8? = 250
+
+let optTrue: Bool? = true
+// CHECK-NEXT: {{optTrue}}: Bool? = true
+
+let optFalse: Bool? = false
+// CHECK-NEXT: {{optFalse}}: Bool? = false
+
+let optNil: Bool? = nil
+// CHECK-NEXT: {{optNil}}: Bool? = nil


### PR DESCRIPTION
Bools are special in that they are integer with extra inhabitants. Test that they are displayed correctly when wrapped by an optional. The fix for this problem was implemented in the swift repo in commit 352c4c209aa3f5f250c597dab08bf12b5f360b01 (github pr: https://github.com/apple/swift/pull/61837)

rdar://97501889
(cherry picked from commit 4b5c6e10e34dc47f7204f95222c0c12b23ab2e8d)