### PR TITLE
Check m_dyld_up directly in LoadBinariesViaMetadata

### DIFF
--- a/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
+++ b/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
@@ -327,9 +327,11 @@ void ProcessMachCore::LoadBinariesViaMetadata() {
   // corefile
   core_objfile->LoadCoreFileImages(*this);
 
-  // LoadCoreFileImges may have set the dynamic loader; if we now have
-  // a dynamic loader, save its name so we don't un-set it later.
-  if (GetDynamicLoader())
+  // LoadCoreFileImges may have set the dynamic loader, e.g. in
+  // PlatformDarwinKernel::LoadPlatformBinaryAndSetup().
+  // If we now have a dynamic loader, save its name so we don't 
+  // un-set it later.
+  if (m_dyld_up)
     m_dyld_plugin_name = GetDynamicLoader()->GetPluginName();
 }
 


### PR DESCRIPTION
Check m_dyld_up directly in LoadBinariesViaMetadata

In the restructuring I did in https://reviews.llvm.org/D133680 , I call ObjectFile::LoadBinariesViaMetadata, and the process m_dyld may be set by a method under there -- in
ProcessMachCore::LoadBinariesViaMetadata I wanted to check to see if m_dyld_up had been set.  I did this by calling the GetDynamicLoader() method, but that method will call FindPlugin() if there is no dynamic loader yet, and the static dynamic loader plugin was being loaded, preventing the scan for userland binaries in a userland corefile.

Differential Revision: https://reviews.llvm.org/D137807 rdar://102210820

(cherry picked from commit 48321eea9679e1d8c5a30f4027e1aa49738aebf3)