### PR TITLE
[ClangCAS] Use an accurate check for path length requirement

### DIFF
--- a/clang/test/CAS/lit.local.cfg
+++ b/clang/test/CAS/lit.local.cfg
@@ -16,9 +16,10 @@ config.daemon_temp_dir = tempfile.mkdtemp()
 config.environment['__CLANG_TEST_CC1DEPSCAND_EXTRA_ARGS'] = '-single-command'
 
 # Feature for the temp directory path is not too long for certain tests.
-# The limit is around 100 charactors and this check will leave about 20
-# charactors to be used by individual tests.
-if len(config.daemon_temp_dir) < 80:
+# The limit on Darwin is 104 charactors and the default spawning daemon from
+# clang will take 30 char. This will leave enough room for auto spawned daemon
+# and also leave some room for each tests to use afterwards.
+if len(config.daemon_temp_dir) < 74:
     config.available_features.add('clang-cc1daemon')
     config.substitutions.append(('%{clang-daemon-dir}', config.daemon_temp_dir))
     config.environment['TMPDIR'] = config.daemon_temp_dir


### PR DESCRIPTION
Set an accurate path limit for clang cas daemon to be able to spawn correctly. The original limit is slightly too large which if the temp directory path is just at the wrong length, it will break the test.

rdar://102249472