### PR TITLE
[clang] Disable assertion that can "easily happen"

### DIFF
--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -2660,12 +2660,12 @@ unsigned ASTWriter::getLocalOrImportedSubmoduleID(const Module *Mod) {
 }
 
 unsigned ASTWriter::getSubmoduleID(Module *Mod) {
+  unsigned ID = getLocalOrImportedSubmoduleID(Mod);
   // FIXME: This can easily happen, if we have a reference to a submodule that
   // did not result in us loading a module file for that submodule. For
   // instance, a cross-top-level-module 'conflict' declaration will hit this.
-  unsigned ID = getLocalOrImportedSubmoduleID(Mod);
-  assert((ID || !Mod) &&
-         "asked for module ID for non-local, non-imported module");
+  // assert((ID || !Mod) &&
+  //        "asked for module ID for non-local, non-imported module");
   return ID;
 }
 


### PR DESCRIPTION
Disable the assertion for getting a module ID for non-local,
non-imported module. According to the FIXME this can "easily happen" and
indeed, we're hitting this assertion regularly. Disable it until it can
be properly investigated.

rdar://99352728

Differential revision: https://reviews.llvm.org/D136290

(cherry picked from commit 97b91307b00e958bc1d511c93a8a6bef510485ac)
