### PR TITLE
[LLDB][DataFormatter] Add data formatter for libcxx std::unordered_map iterator

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -942,6 +942,14 @@ static void LoadLibCxxFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
       "std::map iterator synthetic children",
       ConstString("^std::__[[:alnum:]]+::__map_iterator<.+>$"), stl_synth_flags,
       true);
+
+  AddCXXSynthetic(
+      cpp_category_sp,
+      lldb_private::formatters::
+          LibCxxUnorderedMapIteratorSyntheticFrontEndCreator,
+      "std::unordered_map iterator synthetic children",
+      ConstString("^std::__[[:alnum:]]+::__hash_map_(const_)?iterator<.+>$"),
+      stl_synth_flags, true);
 }
 
 static void LoadLibStdcppFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.h
@@ -103,6 +103,56 @@ SyntheticChildrenFrontEnd *
 LibCxxMapIteratorSyntheticFrontEndCreator(CXXSyntheticChildren *,
                                           lldb::ValueObjectSP);
 
+/// Formats libcxx's std::unordered_map iterators
+///
+/// In raw form a std::unordered_map::iterator is represented as follows:
+///
+/// (lldb) var it --raw --ptr-depth 1
+/// (std::__1::__hash_map_iterator<
+///    std::__1::__hash_iterator<
+///      std::__1::__hash_node<
+///        std::__1::__hash_value_type<
+///            std::__1::basic_string<char, std::__1::char_traits<char>,
+///            std::__1::allocator<char> >, std::__1::basic_string<char,
+///            std::__1::char_traits<char>, std::__1::allocator<char> > >,
+///        void *> *> >)
+///  it = {
+///   __i_ = {
+///     __node_ = 0x0000600001700040 {
+///       __next_ = 0x0000600001704000
+///     }
+///   }
+/// }
+class LibCxxUnorderedMapIteratorSyntheticFrontEnd
+    : public SyntheticChildrenFrontEnd {
+public:
+  LibCxxUnorderedMapIteratorSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp);
+
+  ~LibCxxUnorderedMapIteratorSyntheticFrontEnd() override = default;
+
+  size_t CalculateNumChildren() override;
+
+  lldb::ValueObjectSP GetChildAtIndex(size_t idx) override;
+
+  bool Update() override;
+
+  bool MightHaveChildren() override;
+
+  size_t GetIndexOfChildWithName(ConstString name) override;
+
+private:
+  ValueObject *m_iter_ptr = nullptr; ///< Held, not owned. Child of iterator
+                                     ///< ValueObject supplied at construction.
+
+  lldb::ValueObjectSP m_pair_sp; ///< ValueObject for the key/value pair
+                                 ///< that the iterator currently points
+                                 ///< to.
+};
+
+SyntheticChildrenFrontEnd *
+LibCxxUnorderedMapIteratorSyntheticFrontEndCreator(CXXSyntheticChildren *,
+                                                   lldb::ValueObjectSP);
+
 SyntheticChildrenFrontEnd *
 LibCxxVectorIteratorSyntheticFrontEndCreator(CXXSyntheticChildren *,
                                              lldb::ValueObjectSP);

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/unordered_map/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/unordered_map/Makefile
@@ -1,0 +1,6 @@
+CXX_SOURCES := main.cpp
+
+USE_LIBCPP := 1
+
+CXXFLAGS_EXTRAS := -O0
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/unordered_map/TestDataFormatterLibccUnorderedMap.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/unordered_map/TestDataFormatterLibccUnorderedMap.py
@@ -1,0 +1,53 @@
+"""
+Test formatting of std::unordered_map related structures.
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+class LibcxxUnorderedMapDataFormatterTestCase(TestBase):
+
+    @add_test_categories(['libc++'])
+    def test_iterator_formatters(self):
+        """Test that std::unordered_map related structures are formatted correctly when printed.
+           Currently only tests format of std::unordered_map iterators.
+        """
+        self.build()
+        (self.target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
+            self, 'Break here', lldb.SBFileSpec('main.cpp', False))
+
+        # Test empty iterators
+        self.expect_expr('empty_iter', '')
+        self.expect_expr('const_empty_iter', '')
+
+        lldbutil.continue_to_breakpoint(process, bkpt)
+
+        # Check that key/value is correctly formatted
+        self.expect_expr('foo', result_children=[
+                 ValueCheck(name='first', summary='"Foo"'),
+                 ValueCheck(name='second', summary='"Bar"')
+            ])
+
+        # Check invalid iterator is empty
+        self.expect_expr('invalid', '')
+
+        # Const key/val iterator
+        self.expect_expr('const_baz', result_children=[
+                 ValueCheck(name='first', summary='"Baz"'),
+                 ValueCheck(name='second', summary='"Qux"')
+            ])
+
+        # Bucket iterators
+        # I.e., std::__hash_map_const_iterator<const_local_iterator<...>>
+        # and std::__hash_map_iterator<local_iterator<...>>
+        self.expect_expr('bucket_it', result_children=[
+                 ValueCheck(name='first', summary='"Baz"'),
+                 ValueCheck(name='second', summary='"Qux"')
+            ])
+
+        self.expect_expr('const_bucket_it', result_children=[
+                 ValueCheck(name='first', summary='"Baz"'),
+                 ValueCheck(name='second', summary='"Qux"')
+            ])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/unordered_map/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/unordered_map/main.cpp
@@ -1,0 +1,28 @@
+#include <cstdio>
+#include <string>
+#include <unordered_map>
+
+using StringMapT = std::unordered_map<std::string, std::string>;
+
+int main() {
+  StringMapT string_map;
+  {
+    auto empty_iter = string_map.begin();
+    auto const_empty_iter = string_map.cbegin();
+    std::printf("Break here");
+  }
+  string_map["Foo"] = "Bar";
+  string_map["Baz"] = "Qux";
+
+  {
+    auto foo = string_map.find("Foo");
+    auto invalid = string_map.find("Invalid");
+
+    StringMapT::const_iterator const_baz = string_map.find("Baz");
+    auto bucket_it = string_map.begin(string_map.bucket("Baz"));
+    auto const_bucket_it = string_map.cbegin(string_map.bucket("Baz"));
+    std::printf("Break here");
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This patch adds a formatter for libcxx's `std::unordered_map` iterators. The implementation follows a similar appraoch to the `std::map` iterator formatter. I was hesistant about coupling the two into a common implementation since the libcxx layouts might change for one of the the containers but not the other.

All `std::unordered_map` iterators are covered with this patch:
1. const/non-const key/value iterators
2. const/non-const bucket iterators

Note that, we currently don't have a formatter for `std::unordered_map`. This patch doesn't change that, we merely add support for its iterators, because that's what Xcode users requested. One can still see contents of `std::unordered_map`, whereas with iterators it's less ergonomic.

**Testing**

* Added API test

Differential Revision: https://reviews.llvm.org/D129364

(cherry picked from commit d1e9d0b27f3a59f80787bfe5cf10d4373275c477)