### PR TITLE
[dsymutil] Fix assertion in the Reproducer/FileCollector when TMPDIR is empty

### DIFF
--- a/llvm/lib/Support/FileCollector.cpp
+++ b/llvm/lib/Support/FileCollector.cpp
@@ -50,7 +50,9 @@ static bool isCaseSensitivePath(StringRef Path) {
 }
 
 FileCollector::FileCollector(std::string Root, std::string OverlayRoot)
-    : Root(std::move(Root)), OverlayRoot(std::move(OverlayRoot)) {
+    : Root(Root), OverlayRoot(OverlayRoot) {
+  assert(sys::path::is_absolute(Root) && "Root not absolute");
+  assert(sys::path::is_absolute(OverlayRoot) && "OverlayRoot not absolute");
 }
 
 void FileCollector::PathCanonicalizer::updateWithRealPath(

--- a/llvm/test/tools/dsymutil/X86/reproducer.test
+++ b/llvm/test/tools/dsymutil/X86/reproducer.test
@@ -13,6 +13,9 @@ RUN: cp %p/../Inputs/basic3.macho.x86_64.o %t/Inputs
 # Verify all the files are present.
 RUN: dsymutil -f -o - -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
 
+# Make sure we don't crash with an empty TMPDIR.
+RUN: env TMPDIR="" dsymutil -o -f %t.generate -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1
+
 # Create a reproducer.
 RUN: env DSYMUTIL_REPRODUCER_PATH=%t.repro dsymutil -gen-reproducer -f -o %t.generate -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1 | FileCheck %s --check-prefixes=REPRODUCER
 RUN: llvm-dwarfdump -a %t.generate | FileCheck %s

--- a/llvm/tools/dsymutil/Reproducer.cpp
+++ b/llvm/tools/dsymutil/Reproducer.cpp
@@ -20,6 +20,7 @@ static std::string createReproducerDir(std::error_code &EC) {
   } else {
     EC = sys::fs::createUniqueDirectory("dsymutil", Root);
   }
+  sys::fs::make_absolute(Root);
   return EC ? "" : std::string(Root);
 }
 


### PR DESCRIPTION
Fix a assertion in dsymutil coming from the Reproducer/FileCollector.
When TMPDIR is empty, the root becomes a relative path, triggering an
assertion when adding a relative path to the VFS mapping. This patch
fixes the issue by resolving the relative path and also moves the
assertion up to make it easier to diagnose these issues in the future.

rdar://102170986

Differential revision: https://reviews.llvm.org/D137959

(cherry picked from commit 68efb4772c0d0e60cbfb09ea619b58d80c31ff0f)
