### PR TITLE
[ObjC] Fix an assertion failure in EvaluateLValue

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -8222,7 +8222,7 @@ static bool EvaluateLValue(const Expr *E, LValue &Result, EvalInfo &Info,
                            bool InvalidBaseOK) {
   assert(!E->isValueDependent());
   assert(E->isGLValue() || E->getType()->isFunctionType() ||
-         E->getType()->isVoidType() || isa<ObjCSelectorExpr>(E));
+         E->getType()->isVoidType() || isa<ObjCSelectorExpr>(E->IgnoreParens()));
   return LValueExprEvaluator(Info, Result, InvalidBaseOK).Visit(E);
 }
 

--- a/clang/test/SemaObjCXX/sel-address.mm
+++ b/clang/test/SemaObjCXX/sel-address.mm
@@ -15,5 +15,6 @@ void h() {
 
   // Shouldn't crash.
   g(&@selector(foo));
+  g(&(@selector(foo)));
 }
 


### PR DESCRIPTION
Look through parentheses when determining whether the expression is a @selector expression.

(cherry picked from commit 063a43b4fd9f869d57c20145302eb41068bfb54e)