### PR TITLE
[Sema] Use the value category of the base expression when creating an ExtVectorElementExpr

### DIFF
--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -1621,16 +1621,7 @@ static ExprResult LookupMemberExpr(Sema &S, LookupResult &R,
   if (BaseType->isExtVectorType()) {
     // FIXME: this expr should store IsArrow.
     IdentifierInfo *Member = MemberName.getAsIdentifierInfo();
-    ExprValueKind VK;
-    if (IsArrow)
-      VK = VK_LValue;
-    else {
-      if (PseudoObjectExpr *POE = dyn_cast<PseudoObjectExpr>(BaseExpr.get()))
-        VK = POE->getSyntacticForm()->getValueKind();
-      else
-        VK = BaseExpr.get()->getValueKind();
-    }
-
+    ExprValueKind VK = (IsArrow ? VK_LValue : BaseExpr.get()->getValueKind());
     QualType ret = CheckExtVectorComponent(S, BaseType, VK, OpLoc,
                                            Member, MemberLoc);
     if (ret.isNull())

--- a/clang/test/SemaObjC/property-not-lvalue.m
+++ b/clang/test/SemaObjC/property-not-lvalue.m
@@ -7,10 +7,13 @@ typedef struct NSSize {
 		} inner;
 } NSSize;
 
+typedef __attribute__((__ext_vector_type__(2))) float simd_float2;
+
 @interface Foo  {
         NSSize _size;
 }
 @property NSSize size;
+@property simd_float2 f2;
 @end
 
 void foo(void) { 
@@ -32,3 +35,8 @@ void foo(void) {
 }
 - (NSSize)size {}
 @end
+
+// clang used to crash compiling this code.
+void test(Foo *f) {
+  simd_float2 *v = &f.f2.xy; // expected-error {{cannot take the address of an rvalue}}
+}


### PR DESCRIPTION
This fixes a bug where an lvalue ExtVectorElementExpr was created when the base expression was an ObjC property dot operator.

This reverts 220d08d942ab0df3211388e602ed34fa6139ca61.

Differential Revision: https://reviews.llvm.org/D138058

(cherry picked from commit 81e33602f78d135c11b0d74d738263fc6cfaae12)