### PR TITLE
[LLDB Test] Add '-link-objc-runtime' to 'swiftc' invocations when ObjC interop is required by the test.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -527,7 +527,7 @@ endif
 #----------------------------------------------------------------------
 ifeq "$(SWIFT_OBJC_INTEROP)" "1"
         ifeq "$(OS)" "Darwin"
-		SWIFTFLAGS += -framework Foundation -framework CoreGraphics
+		SWIFTFLAGS += -link-objc-runtime -framework Foundation -framework CoreGraphics
 		LDFLAGS += -lswiftObjectiveC -lswiftFoundation -framework Foundation -framework CoreGraphics
         else
                 # CFLAGS_EXTRAS is used via "dotest.py -E" to pass the -I and -L paths


### PR DESCRIPTION
This ensures the Swift Driver will formulate a linker driver invocation that will pick up the ObjC runtime.