### PR TITLE
Make CompilerType safe

### DIFF
--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -793,7 +793,7 @@ public:
 
   bool GetIsDynamicLinkEditor();
 
-  llvm::Expected<TypeSystem &>
+  llvm::Expected<lldb::TypeSystemSP>
   GetTypeSystemForLanguage(lldb::LanguageType language);
 
   // Special error functions that can do printf style formatting that will
@@ -891,7 +891,7 @@ public:
 
   /// Call \p callback for each \p TypeSystem in this \p Module.
   /// Return true from callback to keep iterating, false to stop iterating.
-  void ForEachTypeSystem(std::function<bool(TypeSystem *)> const &callback);
+  void ForEachTypeSystem(llvm::function_ref<bool(lldb::TypeSystemSP)> callback);
 
   std::vector<lldb::DataBufferSP> GetASTData(lldb::LanguageType language);
 

--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -15,10 +15,12 @@
 
 #include "lldb/lldb-private.h"
 #include "llvm/ADT/APSInt.h"
+#include "llvm/Support/Casting.h"
 
 namespace lldb_private {
 
 class DataExtractor;
+class TypeSystem;
 
 /// Generic representation of a type in a programming language.
 ///
@@ -38,38 +40,87 @@ public:
   /// implementation.
   ///
   /// \see lldb_private::TypeSystemClang::GetType(clang::QualType)
-  CompilerType(TypeSystem *type_system, lldb::opaque_compiler_type_t type)
-      : m_type(type), m_type_system(type_system) {
+  CompilerType(lldb::TypeSystemWP type_system,
+               lldb::opaque_compiler_type_t type)
+    : m_type_system(type_system), m_type(type) {
+    assert(Verify() && "verification failed");
+  }
+
+  /// This is a minimal wrapper of a TypeSystem shared pointer as
+  /// returned by CompilerType which conventien dyn_cast support.
+  class TypeSystemSPWrapper {
+    lldb::TypeSystemSP m_typesystem_sp;
+
+  public:
+    TypeSystemSPWrapper() = default;
+    TypeSystemSPWrapper(lldb::TypeSystemSP typesystem_sp)
+        : m_typesystem_sp(typesystem_sp) {}
+
+    template <class TypeSystemType> bool isa_and_nonnull() {
+      if (auto *ts = m_typesystem_sp.get())
+        return llvm::isa<TypeSystemType>(ts);
+      return false;
+    }
+
+    /// Return a shared_ptr<TypeSystemType> if dyn_cast succeeds.
+    template <class TypeSystemType>
+    std::shared_ptr<TypeSystemType> dyn_cast_or_null() {
+      if (isa_and_nonnull<TypeSystemType>())
+        return std::shared_ptr<TypeSystemType>(
+            m_typesystem_sp, llvm::cast<TypeSystemType>(m_typesystem_sp.get()));
+      return nullptr;
+    }
+
+    explicit operator bool() const {
+      return static_cast<bool>(m_typesystem_sp);
+    }
+    bool operator==(const TypeSystemSPWrapper &other) const;
+    bool operator!=(const TypeSystemSPWrapper &other) const {
+      return !(*this == other);
+    }
+
+    /// Only to be used in a one-off situations like
+    ///    if (typesystem && typesystem->method())
+    /// Do not store this pointer!
+    TypeSystem *operator->() const;
+
+    lldb::TypeSystemSP GetSharedPointer() const { return m_typesystem_sp; }
+  };
+
+  CompilerType(TypeSystemSPWrapper type_system, lldb::opaque_compiler_type_t type)
+    : m_type_system(type_system.GetSharedPointer()), m_type(type) {
     assert(Verify() && "verification failed");
   }
 
   CompilerType(const CompilerType &rhs)
-      : m_type(rhs.m_type), m_type_system(rhs.m_type_system) {}
+      : m_type_system(rhs.m_type_system), m_type(rhs.m_type) {}
 
   CompilerType() = default;
 
   /// Operators.
   /// \{
   const CompilerType &operator=(const CompilerType &rhs) {
-    m_type = rhs.m_type;
     m_type_system = rhs.m_type_system;
+    m_type = rhs.m_type;
     return *this;
   }
 
   bool operator<(const CompilerType &rhs) const {
-    if (m_type_system == rhs.m_type_system)
+    auto lts = m_type_system.lock();
+    auto rts = rhs.m_type_system.lock();
+    if (lts.get() == rts.get())
       return m_type < rhs.m_type;
-    return m_type_system < rhs.m_type_system;
+    return lts.get() < rts.get();
   }
   /// \}
 
   /// Tests.
   /// \{
   explicit operator bool() const {
-    return m_type != nullptr && m_type_system != nullptr;
+    return m_type_system.lock() && m_type;
   }
 
-  bool IsValid() const { return m_type != nullptr && m_type_system != nullptr; }
+  bool IsValid() const { return (bool)*this; }
 
   bool IsArrayType(CompilerType *element_type = nullptr,
                    uint64_t *size = nullptr,
@@ -159,7 +210,10 @@ public:
 
   /// Accessors.
   /// \{
-  TypeSystem *GetTypeSystem() const { return m_type_system; }
+
+  /// Returns a shared pointer to the type system. The
+  /// TypeSystem::TypeSystemSPWrapper can be compared for equality.
+  TypeSystemSPWrapper GetTypeSystem() const;
 
   ConstString GetTypeName() const;
 
@@ -176,7 +230,9 @@ public:
 
   lldb::TypeClass GetTypeClass() const;
 
-  void SetCompilerType(TypeSystem *type_system,
+  void SetCompilerType(lldb::TypeSystemWP type_system,
+                       lldb::opaque_compiler_type_t type);
+  void SetCompilerType(TypeSystemSPWrapper type_system,
                        lldb::opaque_compiler_type_t type);
 
   unsigned GetTypeQualifiers() const;
@@ -416,8 +472,8 @@ public:
                         size_t data_byte_size, Scalar &value,
                         ExecutionContextScope *exe_scope) const;
   void Clear() {
+    m_type_system = {};
     m_type = nullptr;
-    m_type_system = nullptr;
   }
 
 private:
@@ -428,8 +484,8 @@ private:
   bool Verify() const;
 #endif
 
+  lldb::TypeSystemWP m_type_system;
   lldb::opaque_compiler_type_t m_type = nullptr;
-  TypeSystem *m_type_system = nullptr;
 };
 
 bool operator==(const CompilerType &lhs, const CompilerType &rhs);

--- a/lldb/include/lldb/Symbol/SymbolFile.h
+++ b/lldb/include/lldb/Symbol/SymbolFile.h
@@ -262,7 +262,7 @@ public:
 
   virtual void PreloadSymbols();
 
-  virtual llvm::Expected<lldb_private::TypeSystem &>
+  virtual llvm::Expected<lldb::TypeSystemSP>
   GetTypeSystemForLanguage(lldb::LanguageType language);
 
   virtual CompilerDeclContext

--- a/lldb/include/lldb/Symbol/TaggedASTType.h
+++ b/lldb/include/lldb/Symbol/TaggedASTType.h
@@ -20,7 +20,8 @@ public:
   TaggedASTType(const CompilerType &compiler_type)
       : CompilerType(compiler_type) {}
 
-  TaggedASTType(lldb::opaque_compiler_type_t type, TypeSystem *type_system)
+  TaggedASTType(lldb::opaque_compiler_type_t type,
+                lldb::TypeSystemWP type_system)
       : CompilerType(type_system, type) {}
 
   TaggedASTType(const TaggedASTType<C> &tw) : CompilerType(tw) {}

--- a/lldb/include/lldb/Symbol/Type.h
+++ b/lldb/include/lldb/Symbol/Type.h
@@ -298,7 +298,7 @@ public:
 
   CompilerType GetCompilerType(bool prefer_dynamic);
 
-  TypeSystem *GetTypeSystem(bool prefer_dynamic);
+  CompilerType::TypeSystemSPWrapper GetTypeSystem(bool prefer_dynamic);
 
   bool GetDescription(lldb_private::Stream &strm,
                       lldb::DescriptionLevel description_level);

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -10,12 +10,12 @@
 #define LLDB_SYMBOL_TYPESYSTEM_H
 
 #include <functional>
-#include <map>
 #include <mutex>
 #include <string>
 
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Error.h"
@@ -68,7 +68,8 @@ struct LanguageSet {
 /// \see lldb_private::CompilerType
 /// \see lldb_private::CompilerDecl
 /// \see lldb_private::CompilerDeclContext
-class TypeSystem : public PluginInterface {
+class TypeSystem : public PluginInterface,
+                   public std::enable_shared_from_this<TypeSystem> {
 public:
   // Constructors and Destructors
   ~TypeSystem() override;
@@ -88,10 +89,16 @@ public:
                                            const char *compiler_options);
   // END SWIFT
 
-  // Free up any resources associated with this TypeSystem.  Done before
-  // removing all the TypeSystems from the TypeSystemMap.
+#if __cplusplus == 201402L
+  std::weak_ptr<TypeSystem> weak_from_this() {
+    return std::weak_ptr<TypeSystem>(shared_from_this());
+  }
+#endif
+  
+  /// Free up any resources associated with this TypeSystem.  Done before
+  /// removing all the TypeSystems from the TypeSystemMap.
   virtual void Finalize() {}
-
+ 
   virtual DWARFASTParser *GetDWARFParser() { return nullptr; }
   virtual PDBASTParser *GetPDBParser() { return nullptr; }
 
@@ -561,18 +568,18 @@ public:
 
   // Iterate through all of the type systems that are created. Return true from
   // callback to keep iterating, false to stop iterating.
-  void ForEach(std::function<bool(TypeSystem *)> const &callback);
+  void ForEach(std::function<bool(lldb::TypeSystemSP)> const &callback);
 
-  llvm::Expected<TypeSystem &>
+  llvm::Expected<lldb::TypeSystemSP>
   GetTypeSystemForLanguage(lldb::LanguageType language, Module *module,
                            bool can_create);
 
-  llvm::Expected<TypeSystem &>
+  llvm::Expected<lldb::TypeSystemSP>
   GetTypeSystemForLanguage(lldb::LanguageType language, Target *target,
                            bool can_create);
 
   // BEGIN SWIFT
-  llvm::Expected<TypeSystem &>
+  llvm::Expected<lldb::TypeSystemSP>
   GetTypeSystemForLanguage(lldb::LanguageType language, Target *target,
                            bool can_create, const char *compiler_options);
 
@@ -580,28 +587,30 @@ public:
   // END SWIFT
 
 protected:
-  typedef std::map<lldb::LanguageType, lldb::TypeSystemSP> collection;
+  typedef llvm::DenseMap<uint16_t, lldb::TypeSystemSP> collection;
   mutable std::mutex m_mutex; ///< A mutex to keep this object happy in
-                              ///multi-threaded environments.
+                              /// multi-threaded environments.
   collection m_map;
   bool m_clear_in_progress = false;
 
 private:
   typedef llvm::function_ref<lldb::TypeSystemSP()> CreateCallback;
   /// Finds the type system for the given language. If no type system could be
-  /// found for a language and a CreateCallback was provided, the value returned
-  /// by the callback will be treated as the TypeSystem for the language.
+  /// found for a language and a CreateCallback was provided, the value
+  /// returned by the callback will be treated as the TypeSystem for the
+  /// language.
   ///
   /// \param language The language for which the type system should be found.
   /// \param create_callback A callback that will be called if no previously
   ///                        created TypeSystem that fits the given language
   ///                        could found. Can be omitted if a non-existent
-  ///                        type system should be treated as an error instead.
+  ///                        type system should be treated as an error
+  ///                        instead.
   /// \return The found type system or an error.
-  llvm::Expected<TypeSystem &> GetTypeSystemForLanguage(
+  llvm::Expected<lldb::TypeSystemSP> GetTypeSystemForLanguage(
       lldb::LanguageType language,
       llvm::Optional<CreateCallback> create_callback = llvm::None);
-};
+  };
 
 } // namespace lldb_private
 

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1189,12 +1189,13 @@ public:
 
   PathMappingList &GetImageSearchPathList();
 
-  llvm::Expected<TypeSystem &>
+  llvm::Expected<lldb::TypeSystemSP>
   GetScratchTypeSystemForLanguage(lldb::LanguageType language,
                                   bool create_on_demand = true,
                                   const char *compiler_options = nullptr);
 
-  std::vector<TypeSystem *> GetScratchTypeSystems(bool create_on_demand = true);
+  std::vector<lldb::TypeSystemSP>
+  GetScratchTypeSystems(bool create_on_demand = true);
 
   PersistentExpressionState *
   GetPersistentExpressionStateForLanguage(lldb::LanguageType language);

--- a/lldb/include/lldb/Utility/Either.h
+++ b/lldb/include/lldb/Utility/Either.h
@@ -19,10 +19,11 @@ private:
   enum class Selected { One, Two };
 
   Selected m_selected;
-  union {
+  // FIXME: This broke when CompilerType added an std::weak_ptr.
+  //union {
     T1 m_t1;
     T2 m_t2;
-  };
+  //};
 
 public:
   Either(const T1 &t1) {
@@ -112,16 +113,17 @@ public:
     return *this;
   }
 
-  ~Either() {
-    switch (m_selected) {
-    case Selected::One:
-      m_t1.T1::~T1();
-      break;
-    case Selected::Two:
-      m_t2.T2::~T2();
-      break;
-    }
-  }
+  // FIXME: This broke when CompilerType added an std::weak_ptr.
+  // ~Either() {
+  //   switch (m_selected) {
+  //   case Selected::One:
+  //     m_t1.T1::~T1();
+  //     break;
+  //   case Selected::Two:
+  //     m_t2.T2::~T2();
+  //     break;
+  //   }
+  // }
 };
 
 } // namespace lldb_utility

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -9,6 +9,7 @@
 #ifndef LLDB_LLDB_ENUMERATIONS_H
 #define LLDB_LLDB_ENUMERATIONS_H
 
+#include <cstdint>
 #include <type_traits>
 
 #ifndef SWIG
@@ -433,7 +434,7 @@ FLAGS_ENUM(WatchpointEventType){
 /// specification for ease of use and consistency.
 /// The enum -> string code is in Language.cpp, don't change this
 /// table without updating that code as well.
-enum LanguageType {
+enum LanguageType : uint16_t {
   eLanguageTypeUnknown = 0x0000,        ///< Unknown or invalid language value.
   eLanguageTypeC89 = 0x0001,            ///< ISO C:1989.
   eLanguageTypeC = 0x0002,              ///< Non-standardized C, such as K&R.

--- a/lldb/include/lldb/lldb-forward.h
+++ b/lldb/include/lldb/lldb-forward.h
@@ -430,6 +430,7 @@ typedef std::shared_ptr<lldb_private::TypeMemberFunctionImpl>
 typedef std::shared_ptr<lldb_private::TypeEnumMemberImpl> TypeEnumMemberImplSP;
 typedef std::shared_ptr<lldb_private::TypeFilterImpl> TypeFilterImplSP;
 typedef std::shared_ptr<lldb_private::TypeSystem> TypeSystemSP;
+typedef std::weak_ptr<lldb_private::TypeSystem> TypeSystemWP;
 typedef std::shared_ptr<lldb_private::TypeFormatImpl> TypeFormatImplSP;
 typedef std::shared_ptr<lldb_private::TypeNameSpecifierImpl>
     TypeNameSpecifierImplSP;

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -1802,7 +1802,7 @@ lldb::SBType SBTarget::FindFirstType(const char *typename_cstr) {
       }
     }
 
-    // Didn't find the type in the symbols; Try the loaded language runtimes
+    // Didn't find the type in the symbols; Try the loaded language runtimes.
     // BEGIN SWIFT
     // FIXME: This depends on clang, but should be able to support any
     // TypeSystem/compiler.
@@ -1824,9 +1824,9 @@ lldb::SBType SBTarget::FindFirstType(const char *typename_cstr) {
     }
     // END SWIFT
 
-    // No matches, search for basic typename matches
-    for (auto *type_system : target_sp->GetScratchTypeSystems())
-      if (auto type = type_system->GetBuiltinTypeByName(const_typename))
+    // No matches, search for basic typename matches.
+    for (auto type_system_sp : target_sp->GetScratchTypeSystems())
+      if (auto type = type_system_sp->GetBuiltinTypeByName(const_typename))
         return SBType(type);
   }
 
@@ -1838,8 +1838,8 @@ SBType SBTarget::GetBasicType(lldb::BasicType type) {
 
   TargetSP target_sp(GetSP());
   if (target_sp) {
-    for (auto *type_system : target_sp->GetScratchTypeSystems())
-      if (auto compiler_type = type_system->GetBasicTypeFromAST(type))
+    for (auto type_system_sp : target_sp->GetScratchTypeSystems())
+      if (auto compiler_type = type_system_sp->GetBasicTypeFromAST(type))
         return SBType(compiler_type);
   }
   return SBType();
@@ -1890,9 +1890,9 @@ lldb::SBTypeList SBTarget::FindTypes(const char *typename_cstr) {
 
     if (sb_type_list.GetSize() == 0) {
       // No matches, search for basic typename matches
-      for (auto *type_system : target_sp->GetScratchTypeSystems())
+      for (auto type_system_sp : target_sp->GetScratchTypeSystems())
         if (auto compiler_type =
-                type_system->GetBuiltinTypeByName(const_typename))
+                type_system_sp->GetBuiltinTypeByName(const_typename))
           sb_type_list.Append(SBType(compiler_type));
     }
   }

--- a/lldb/source/API/SBType.cpp
+++ b/lldb/source/API/SBType.cpp
@@ -28,9 +28,7 @@ using namespace lldb_private;
 
 SBType::SBType() { LLDB_INSTRUMENT_VA(this); }
 
-SBType::SBType(const CompilerType &type)
-    : m_opaque_sp(new TypeImpl(
-          CompilerType(type.GetTypeSystem(), type.GetOpaqueQualType()))) {}
+SBType::SBType(const CompilerType &type) : m_opaque_sp(new TypeImpl(type)) {}
 
 SBType::SBType(const lldb::TypeSP &type_sp)
     : m_opaque_sp(new TypeImpl(type_sp)) {}
@@ -381,8 +379,8 @@ SBType SBType::GetBasicType(lldb::BasicType basic_type) {
   LLDB_INSTRUMENT_VA(this, basic_type);
 
   if (IsValid() && m_opaque_sp->IsValid())
-    return SBType(
-        m_opaque_sp->GetTypeSystem(false)->GetBasicTypeFromAST(basic_type));
+    if (auto ts = m_opaque_sp->GetTypeSystem(false))
+      return SBType(ts->GetBasicTypeFromAST(basic_type));
   return SBType();
 }
 

--- a/lldb/source/Breakpoint/Watchpoint.cpp
+++ b/lldb/source/Breakpoint/Watchpoint.cpp
@@ -43,8 +43,12 @@ Watchpoint::Watchpoint(Target &target, lldb::addr_t addr, uint32_t size,
       LLDB_LOG_ERROR(GetLog(LLDBLog::Watchpoints), std::move(err),
                      "Failed to set type.");
     } else {
-      m_type = type_system_or_err->GetBuiltinTypeForEncodingAndBitSize(
-          eEncodingUint, 8 * size);
+      if (auto ts = *type_system_or_err)
+        m_type =
+            ts->GetBuiltinTypeForEncodingAndBitSize(eEncodingUint, 8 * size);
+      else
+        LLDB_LOG_ERROR(GetLog(LLDBLog::Watchpoints), std::move(err),
+                       "Failed to set type. Typesystem is no longer live.");
     }
   }
 

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -5091,8 +5091,9 @@ public:
 protected:
   bool DoExecute(Args &command, CommandReturnObject &result) override {
     // Go over every scratch TypeSystem and dump to the command output.
-    for (TypeSystem *ts : GetSelectedTarget().GetScratchTypeSystems())
-      ts->Dump(result.GetOutputStream().AsRawOstream());
+    for (lldb::TypeSystemSP ts : GetSelectedTarget().GetScratchTypeSystems())
+      if (ts)
+        ts->Dump(result.GetOutputStream().AsRawOstream());
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
     return result.Succeeded();

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -373,7 +373,7 @@ void Module::SetUUID(const lldb_private::UUID &uuid) {
   }
 }
 
-llvm::Expected<TypeSystem &>
+llvm::Expected<TypeSystemSP>
 Module::GetTypeSystemForLanguage(LanguageType language) {
   return m_type_system_map.GetTypeSystemForLanguage(language, this, true);
 }
@@ -1638,8 +1638,8 @@ bool Module::SetArchitecture(const ArchSpec &new_arch) {
       return true;
     }
 #ifdef LLDB_ENABLE_SWIFT
-    if (auto *ts =
-            llvm::dyn_cast_or_null<TypeSystemSwift>(&*type_system_or_err))
+    if (auto ts =
+            llvm::dyn_cast_or_null<TypeSystemSwift>(type_system_or_err->get()))
       ts->SetTriple(new_arch.GetTriple());
 #endif // LLDB_ENABLE_SWIFT
     return true;
@@ -1766,13 +1766,14 @@ void Module::ClearModuleDependentCaches() {
   }
 
 #ifdef LLDB_ENABLE_SWIFT
-  if (auto *ts = llvm::dyn_cast_or_null<TypeSystemSwift>(&*type_system_or_err))
+  if (auto *ts =
+          llvm::dyn_cast_or_null<TypeSystemSwift>(type_system_or_err->get()))
     ts->ClearModuleDependentCaches();
 #endif // LLDB_ENABLE_SWIFT
 }
 
 void Module::ForEachTypeSystem(
-    std::function<bool(TypeSystem *)> const &callback) {
+    llvm::function_ref<bool(lldb::TypeSystemSP)> callback) {
   m_type_system_map.ForEach(callback);
 }
 

--- a/lldb/source/Core/ValueObjectDynamicValue.cpp
+++ b/lldb/source/Core/ValueObjectDynamicValue.cpp
@@ -436,13 +436,13 @@ bool ValueObjectDynamicValue::DynamicValueTypeInfoNeedsUpdate() {
     return false;
 
 #ifdef LLDB_ENABLE_SWIFT
-  auto *cached_ctx = m_value.GetCompilerType().GetTypeSystem();
+  auto cached_ctx = m_value.GetCompilerType().GetTypeSystem();
   llvm::Optional<SwiftScratchContextReader> scratch_ctx =
       GetSwiftScratchContext();
 
   if (!scratch_ctx || !cached_ctx)
     return true;
-  return cached_ctx != scratch_ctx->get();
+  return cached_ctx.GetSharedPointer().get() != scratch_ctx->get();
 #else // !LLDB_ENABLE_SWIFT
   return false;
 #endif // LLDB_ENABLE_SWIFT

--- a/lldb/source/Core/ValueObjectMemory.cpp
+++ b/lldb/source/Core/ValueObjectMemory.cpp
@@ -83,8 +83,7 @@ ValueObjectMemory::ValueObjectMemory(ExecutionContextScope *exe_scope,
     : ValueObject(exe_scope, manager), m_address(address), m_type_sp(),
       m_compiler_type(ast_type) {
   // Do not attempt to construct one of these objects with no variable!
-  assert(m_compiler_type.GetTypeSystem());
-  assert(m_compiler_type.GetOpaqueQualType());
+  assert(m_compiler_type.IsValid());
 
   TargetSP target_sp(GetTargetSP());
 

--- a/lldb/source/Core/ValueObjectRegister.cpp
+++ b/lldb/source/Core/ValueObjectRegister.cpp
@@ -206,9 +206,9 @@ CompilerType ValueObjectRegister::GetCompilerTypeImpl() {
           LLDB_LOG_ERROR(GetLog(LLDBLog::Types), std::move(err),
                          "Unable to get CompilerType from TypeSystem");
         } else {
-          m_compiler_type =
-              type_system_or_err->GetBuiltinTypeForEncodingAndBitSize(
-                  m_reg_info.encoding, m_reg_info.byte_size * 8);
+          if (auto ts = *type_system_or_err)
+            m_compiler_type = ts->GetBuiltinTypeForEncodingAndBitSize(
+                m_reg_info.encoding, m_reg_info.byte_size * 8);
         }
       }
     }

--- a/lldb/source/Core/ValueObjectVariable.cpp
+++ b/lldb/source/Core/ValueObjectVariable.cpp
@@ -218,8 +218,9 @@ bool ValueObjectVariable::UpdateValue() {
 
 #ifdef LLDB_ENABLE_SWIFT
       if (auto type = variable->GetType())
-        if (llvm::dyn_cast_or_null<TypeSystemSwift>(
-                type->GetForwardCompilerType().GetTypeSystem()) &&
+        if (type->GetForwardCompilerType()
+                .GetTypeSystem()
+                .dyn_cast_or_null<TypeSystemSwift>() &&
             TypePayloadSwift(type->GetPayload()).IsFixedValueBuffer())
           if (auto process_sp = GetProcessSP())
             if (auto runtime = process_sp->GetLanguageRuntime(
@@ -235,7 +236,7 @@ bool ValueObjectVariable::UpdateValue() {
                   m_value.GetScalar() = deref_addr;
                 }
               }
-            }
+          }
 #endif // LLDB_ENABLE_SWIFT
 
       switch (value_type) {

--- a/lldb/source/DataFormatters/FormatManager.cpp
+++ b/lldb/source/DataFormatters/FormatManager.cpp
@@ -196,8 +196,8 @@ void FormatManager::GetPossibleMatches(
         {type_name, did_strip_ptr, did_strip_ref, did_strip_typedef});
 
 // BEGIN SWIFT
-    TypeSystem *ts = compiler_type.GetTypeSystem();
-    if (ts && !llvm::isa<TypeSystemClang>(ts)) {
+    auto ts = compiler_type.GetTypeSystem();
+    if (ts && !ts.isa_and_nonnull<TypeSystemClang>()) {
 // END SWIFT
       const SymbolContext *sc = nullptr;
       if (valobj.GetFrameSP())

--- a/lldb/source/DataFormatters/VectorType.cpp
+++ b/lldb/source/DataFormatters/VectorType.cpp
@@ -23,8 +23,10 @@ using namespace lldb_private::formatters;
 
 static CompilerType GetCompilerTypeForFormat(lldb::Format format,
                                              CompilerType element_type,
-                                             TypeSystem *type_system) {
+                                             TypeSystemSP type_system) {
   lldbassert(type_system && "type_system needs to be not NULL");
+  if (!type_system)
+    return {};
 
   switch (format) {
   case lldb::eFormatAddressInfo:
@@ -219,8 +221,9 @@ public:
     CompilerType parent_type(m_backend.GetCompilerType());
     CompilerType element_type;
     parent_type.IsVectorType(&element_type);
-    m_child_type = ::GetCompilerTypeForFormat(m_parent_format, element_type,
-                                              parent_type.GetTypeSystem());
+    m_child_type = ::GetCompilerTypeForFormat(
+        m_parent_format, element_type,
+        parent_type.GetTypeSystem().GetSharedPointer());
     m_num_children = ::CalculateNumChildren(parent_type, m_child_type);
     m_item_format = GetItemFormatForFormat(m_parent_format, m_child_type);
     return false;

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -1086,7 +1086,14 @@ public:
                                     llvm::toString(std::move(error)).c_str());
         return;
       }
-      persistent_state = type_system_or_err->GetPersistentExpressionState();
+    auto ts = *type_system_or_err;
+    if (!ts) {
+      err.SetErrorStringWithFormat("Couldn't dematerialize a result variable: "
+                                   "couldn't corresponding type system is "
+                                   "no longer live.");
+      return;
+    }
+      persistent_state = ts->GetPersistentExpressionState();
     }
 
     if (!persistent_state) {

--- a/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc64.cpp
+++ b/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc64.cpp
@@ -809,8 +809,7 @@ private:
     // case 3: get from GPRs
 
     // first, check if this is a packed struct or not
-    TypeSystemClang *ast =
-        llvm::dyn_cast<TypeSystemClang>(m_type.GetTypeSystem());
+    auto ast = m_type.GetTypeSystem().dyn_cast_or_null<TypeSystemClang>();
     if (ast) {
       clang::RecordDecl *record_decl = TypeSystemClang::GetAsRecordDecl(m_type);
 

--- a/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
@@ -880,8 +880,8 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectImpl(
       max_register_value_bit_width += 128;
     std::vector<uint32_t> aggregate_field_offsets;
     std::vector<CompilerType> aggregate_compiler_types;
-    if (return_compiler_type.GetTypeSystem()->CanPassInRegisters(
-          return_compiler_type) &&
+    auto ts = return_compiler_type.GetTypeSystem();
+    if (ts && ts->CanPassInRegisters(return_compiler_type) &&
       *bit_width <= max_register_value_bit_width &&
       FlattenAggregateType(thread, exe_ctx, return_compiler_type,
                           0, aggregate_field_offsets,

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
@@ -33,8 +33,7 @@ CompilerType ClangASTImporter::CopyType(TypeSystemClang &dst_ast,
                                         const CompilerType &src_type) {
   clang::ASTContext &dst_clang_ast = dst_ast.getASTContext();
 
-  TypeSystemClang *src_ast =
-      llvm::dyn_cast_or_null<TypeSystemClang>(src_type.GetTypeSystem());
+  auto src_ast = src_type.GetTypeSystem().dyn_cast_or_null<TypeSystemClang>();
   if (!src_ast)
     return CompilerType();
 
@@ -59,7 +58,7 @@ CompilerType ClangASTImporter::CopyType(TypeSystemClang &dst_ast,
   lldb::opaque_compiler_type_t dst_clang_type = ret_or_error->getAsOpaquePtr();
 
   if (dst_clang_type)
-    return CompilerType(&dst_ast, dst_clang_type);
+    return CompilerType(dst_ast.weak_from_this(), dst_clang_type);
   return CompilerType();
 }
 
@@ -305,8 +304,9 @@ CompilerType ClangASTImporter::DeportType(TypeSystemClang &dst,
                                           const CompilerType &src_type) {
   Log *log = GetLog(LLDBLog::Expressions);
 
-  TypeSystemClang *src_ctxt =
-      llvm::cast<TypeSystemClang>(src_type.GetTypeSystem());
+  auto src_ctxt = src_type.GetTypeSystem().dyn_cast_or_null<TypeSystemClang>();
+  if (!src_ctxt)
+    return {};
 
   LLDB_LOG(log,
            "    [ClangASTImporter] DeportType called on ({0}Type*){1} "

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
@@ -1736,10 +1736,10 @@ ClangASTImporter::DeclOrigin ClangASTSource::GetDeclOrigin(const clang::Decl *de
 }
 
 CompilerType ClangASTSource::GuardedCopyType(const CompilerType &src_type) {
-  TypeSystemClang *src_ast =
-      llvm::dyn_cast_or_null<TypeSystemClang>(src_type.GetTypeSystem());
-  if (src_ast == nullptr)
-    return CompilerType();
+  auto ts = src_type.GetTypeSystem();
+  auto src_ast = ts.dyn_cast_or_null<TypeSystemClang>();
+  if (!src_ast)
+    return {};
 
   QualType copied_qual_type = ClangUtil::GetQualType(
       m_ast_importer_sp->CopyType(*m_clang_ast_context, src_type));
@@ -1748,7 +1748,7 @@ CompilerType ClangASTSource::GuardedCopyType(const CompilerType &src_type) {
       copied_qual_type->getCanonicalTypeInternal().isNull())
     // this shouldn't happen, but we're hardening because the AST importer
     // seems to be generating bad types on occasion.
-    return CompilerType();
+    return {};
 
   return m_clang_ast_context->GetType(copied_qual_type);
 }

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.h
@@ -353,7 +353,7 @@ private:
   /// The following values contain layout information for the materialized
   /// struct, but are not specific to a single materialization
   struct StructVars {
-    StructVars() : m_result_name(), m_object_pointer_type(nullptr, nullptr) {}
+    StructVars() : m_result_name(), m_object_pointer_type(nullptr, {}) {}
 
     lldb::offset_t m_struct_alignment =
         0;                    ///< The alignment of the struct in bytes.

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -714,7 +714,7 @@ ClangExpressionParser::ClangExpressionParser(
   m_compiler->createASTContext();
   clang::ASTContext &ast_context = m_compiler->getASTContext();
 
-  m_ast_context = std::make_unique<TypeSystemClang>(
+  m_ast_context = std::make_shared<TypeSystemClang>(
       "Expression ASTContext for '" + m_filename + "'", ast_context);
 
   std::string module_name("$__lldb_module");

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.h
@@ -177,7 +177,7 @@ private:
   class LLDBPreprocessorCallbacks;
   LLDBPreprocessorCallbacks *m_pp_callbacks; ///< Called when the preprocessor
                                              ///encounters module imports
-  std::unique_ptr<TypeSystemClang> m_ast_context;
+  std::shared_ptr<TypeSystemClang> m_ast_context;
 
   std::vector<std::string> m_include_directories;
   /// File name used for the user expression.

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
@@ -126,7 +126,7 @@ private:
   ImportedModuleSet m_user_imported_modules;
   // We assume that every ASTContext has an TypeSystemClang, so we also store
   // a custom TypeSystemClang for our internal ASTContext.
-  std::unique_ptr<TypeSystemClang> m_ast_context;
+  std::shared_ptr<TypeSystemClang> m_ast_context;
 };
 } // anonymous namespace
 
@@ -191,7 +191,7 @@ ClangModulesDeclVendorImpl::ClangModulesDeclVendorImpl(
 
   // Initialize our TypeSystemClang.
   m_ast_context =
-      std::make_unique<TypeSystemClang>("ClangModulesDeclVendor ASTContext",
+      std::make_shared<TypeSystemClang>("ClangModulesDeclVendor ASTContext",
                                         m_compiler_instance->getASTContext());
 }
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.cpp
@@ -101,12 +101,12 @@ ClangPersistentVariables::GetCompilerTypeFromPersistentDecl(
 void ClangPersistentVariables::RegisterPersistentDecl(ConstString name,
                                                       clang::NamedDecl *decl,
                                                       TypeSystemClang *ctx) {
-  PersistentDecl p = {decl, ctx};
+  PersistentDecl p = {decl, ctx->weak_from_this()};
   m_persistent_decls.insert(std::make_pair(name.GetCString(), p));
 
   if (clang::EnumDecl *enum_decl = llvm::dyn_cast<clang::EnumDecl>(decl)) {
     for (clang::EnumConstantDecl *enumerator_decl : enum_decl->enumerators()) {
-      p = {enumerator_decl, ctx};
+      p = {enumerator_decl, ctx->weak_from_this()};
       m_persistent_decls.insert(std::make_pair(
           ConstString(enumerator_decl->getNameAsString()).GetCString(), p));
     }

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.h
@@ -144,7 +144,7 @@ private:
     /// The persistent decl.
     clang::NamedDecl *m_decl = nullptr;
     /// The TypeSystemClang for the ASTContext of m_decl.
-    TypeSystemClang *m_context = nullptr;
+    lldb::TypeSystemWP m_context;
   };
 
   typedef llvm::DenseMap<const char *, PersistentDecl> PersistentDeclMap;

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUtil.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUtil.cpp
@@ -19,7 +19,7 @@ bool ClangUtil::IsClangType(const CompilerType &ct) {
   if (!ct)
     return false;
 
-  if (llvm::dyn_cast_or_null<TypeSystemClang>(ct.GetTypeSystem()) == nullptr)
+  if (!ct.GetTypeSystem().dyn_cast_or_null<TypeSystemClang>())
     return false;
 
   if (!ct.GetOpaqueQualType())

--- a/lldb/source/Plugins/ExpressionParser/Clang/NameSearchContext.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/NameSearchContext.cpp
@@ -19,8 +19,7 @@ clang::NamedDecl *NameSearchContext::AddVarDecl(const CompilerType &type) {
   if (!type.IsValid())
     return nullptr;
 
-  TypeSystemClang *lldb_ast =
-      llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
+  auto lldb_ast = type.GetTypeSystem().dyn_cast_or_null<TypeSystemClang>();
   if (!lldb_ast)
     return nullptr;
 
@@ -46,8 +45,7 @@ clang::NamedDecl *NameSearchContext::AddFunDecl(const CompilerType &type,
   if (m_function_types.count(type))
     return nullptr;
 
-  TypeSystemClang *lldb_ast =
-      llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
+  auto lldb_ast = type.GetTypeSystem().dyn_cast_or_null<TypeSystemClang>();
   if (!lldb_ast)
     return nullptr;
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -1018,8 +1018,8 @@ swift::FuncDecl *SwiftASTManipulator::GetFunctionToInjectVariableInto(
 
 llvm::Optional<swift::Type> SwiftASTManipulator::GetSwiftTypeForVariable(
     const SwiftASTManipulator::VariableInfo &variable, bool is_self) const {
-  auto *type_system_swift =
-      llvm::dyn_cast_or_null<TypeSystemSwift>(variable.m_type.GetTypeSystem());
+  auto type_system_swift =
+      variable.m_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
 
   if (!type_system_swift)
     return {};

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -553,8 +553,8 @@ static void AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
     return;
 
   {
-    auto *swift_type_system = llvm::dyn_cast_or_null<TypeSystemSwift>(
-        imported_self_type.GetTypeSystem());
+    auto swift_type_system =
+        imported_self_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
     if (!swift_type_system)
       return;
 
@@ -567,8 +567,8 @@ static void AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
   }
 
   {
-    auto *swift_type_system = llvm::dyn_cast_or_null<TypeSystemSwift>(
-        imported_self_type.GetTypeSystem());
+    auto swift_type_system =
+        imported_self_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
     if (!swift_type_system)
       return;
 
@@ -1007,8 +1007,8 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
 
   auto compiler_type = variable.GetType();
   // Add the persistent variable as a typeref compiler type.
-  if (auto *swift_ast_ctx =
-          llvm::dyn_cast<SwiftASTContext>(compiler_type.GetTypeSystem())) {
+  if (auto swift_ast_ctx =
+          compiler_type.GetTypeSystem().dyn_cast_or_null<SwiftASTContext>()) {
     variable.SetType(
         swift_ast_ctx->GetTypeRefType(compiler_type.GetOpaqueQualType()));
   }
@@ -1050,8 +1050,8 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
 
       actual_type =
           ToCompilerType(transformed_type->mapTypeOutOfContext().getPointer());
-      auto *swift_ast_ctx =
-          llvm::cast<SwiftASTContext>(actual_type.GetTypeSystem());
+      auto swift_ast_ctx =
+          actual_type.GetTypeSystem().dyn_cast_or_null<SwiftASTContext>();
 
       actual_type =
           swift_ast_ctx->GetTypeRefType(actual_type.GetOpaqueQualType());
@@ -1120,8 +1120,8 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
       // Transform the variable metadata to a typeref type if possible.
       auto compiler_type =
           variable_metadata->m_persistent_variable_sp->GetCompilerType();
-      if (auto *swift_ast_ctx =
-              llvm::dyn_cast<SwiftASTContext>(compiler_type.GetTypeSystem())) {
+      if (auto swift_ast_ctx = compiler_type.GetTypeSystem()
+                                   .dyn_cast_or_null<SwiftASTContext>()) {
         variable_metadata->m_persistent_variable_sp->SetCompilerType(
             swift_ast_ctx->GetTypeRefType(compiler_type.GetOpaqueQualType()));
       }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -565,7 +565,7 @@ void SwiftREPL::CompleteCode(const std::string &current_code,
 
     auto *swift_ts =
         llvm::dyn_cast_or_null<TypeSystemSwiftTypeRefForExpressions>(
-            &*type_system_or_err);
+            type_system_or_err->get());
     auto *target_swift_ast =
         llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
             swift_ts->GetSwiftASTContext());

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
@@ -161,8 +161,8 @@ public:
       Status read_error;
       // Handle resilient globals in fixed-size buffers.
       lldb::addr_t var_addr = variable->m_remote_addr;
-      if (auto *ast_ctx = llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
-              m_type.GetTypeSystem()))
+      if (auto ast_ctx = m_type.GetTypeSystem()
+                             .dyn_cast_or_null<SwiftASTContextForExpressions>())
         if (!ast_ctx->IsFixedSize(m_type))
           var_addr = FixupResilientGlobal(var_addr, m_type, execution_unit,
                                           process_sp, read_error);

--- a/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
@@ -96,7 +96,7 @@ static std::string TranslateObjCNameToSwiftName(std::string className,
     return "";
   }
 
-  auto *ts = llvm::dyn_cast_or_null<TypeSystemSwift>(&*type_system_or_err);
+  auto *ts = llvm::dyn_cast_or_null<TypeSystemSwift>(type_system_or_err->get());
   if (!ts)
     return "";
   auto *ctx = ts->GetSwiftASTContext();

--- a/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
@@ -49,8 +49,10 @@ public:
       return;
     }
 
-    TypeSystemClang *clang_ast_context =
-        llvm::cast<TypeSystemClang>(block_pointer_type.GetTypeSystem());
+    auto ts = block_pointer_type.GetTypeSystem();
+    auto clang_ast_context = ts.dyn_cast_or_null<TypeSystemClang>();
+    if (!clang_ast_context)
+      return;
 
     std::shared_ptr<ClangASTImporter> clang_ast_importer;
     auto *state = target_sp->GetPersistentExpressionStateForLanguage(

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -280,8 +280,8 @@ bool lldb_private::formatters::LibCxxMapIteratorSyntheticFrontEnd::Update() {
       auto addr(m_pair_ptr->GetValueAsUnsigned(LLDB_INVALID_ADDRESS));
       m_pair_ptr = nullptr;
       if (addr && addr != LLDB_INVALID_ADDRESS) {
-        TypeSystemClang *ast_ctx =
-            llvm::dyn_cast_or_null<TypeSystemClang>(pair_type.GetTypeSystem());
+        auto ts = pair_type.GetTypeSystem();
+        auto ast_ctx = ts.dyn_cast_or_null<TypeSystemClang>();
         if (!ast_ctx)
           return false;
 
@@ -449,8 +449,8 @@ bool lldb_private::formatters::LibCxxUnorderedMapIteratorSyntheticFrontEnd::
     if (addr == 0 || addr == LLDB_INVALID_ADDRESS)
       return false;
 
-    TypeSystemClang *ast_ctx =
-        llvm::dyn_cast_or_null<TypeSystemClang>(pair_type.GetTypeSystem());
+    auto ts = pair_type.GetTypeSystem();
+    auto ast_ctx = ts.dyn_cast_or_null<TypeSystemClang>();
     if (!ast_ctx)
       return false;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
@@ -249,7 +249,7 @@ bool lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::GetDataType() {
   static ConstString g_tree_("__tree_");
   static ConstString g_pair3("__pair3_");
 
-  if (m_element_type.GetOpaqueQualType() && m_element_type.GetTypeSystem())
+  if (m_element_type.IsValid())
     return true;
   m_element_type.Clear();
   ValueObjectSP deref;
@@ -295,8 +295,7 @@ void lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::GetValueOffset(
       UINT32_MAX) {
     m_skip_size = bit_offset / 8u;
   } else {
-    TypeSystemClang *ast_ctx =
-        llvm::dyn_cast_or_null<TypeSystemClang>(node_type.GetTypeSystem());
+    auto ast_ctx = node_type.GetTypeSystem().dyn_cast_or_null<TypeSystemClang>();
     if (!ast_ctx)
       return;
     CompilerType tree_node_type = ast_ctx->CreateStructForIdentifier(

--- a/lldb/source/Plugins/Language/ObjC/CoreMedia.cpp
+++ b/lldb/source/Plugins/Language/ObjC/CoreMedia.cpp
@@ -25,7 +25,9 @@ bool lldb_private::formatters::CMTimeSummaryProvider(
   if (!type.IsValid())
     return false;
 
-  TypeSystem *type_system = type.GetTypeSystem();
+  auto type_system = type.GetTypeSystem();
+  if (!type_system)
+    return false;
   // fetch children by offset to compensate for potential lack of debug info
   auto int64_ty =
       type_system->GetBuiltinTypeForEncodingAndBitSize(eEncodingSint, 64);

--- a/lldb/source/Plugins/Language/ObjC/NSArray.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSArray.cpp
@@ -467,7 +467,7 @@ lldb_private::formatters::NSArrayMSyntheticFrontEndBase::
         *valobj_sp->GetExecutionContextRef().GetTargetSP());
     if (clang_ast_context)
       m_id_type = CompilerType(
-          clang_ast_context,
+          clang_ast_context->weak_from_this(),
           clang_ast_context->getASTContext().ObjCBuiltinIdTy.getAsOpaquePtr());
     if (valobj_sp->GetProcessSP())
       m_ptr_size = valobj_sp->GetProcessSP()->GetAddressByteSize();

--- a/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
@@ -49,7 +49,7 @@ public:
   bool Update() override {
     m_impl.Clear();
 
-    TypeSystem *type_system = m_backend.GetCompilerType().GetTypeSystem();
+    auto type_system = m_backend.GetCompilerType().GetTypeSystem();
     if (!type_system)
       return false;
 

--- a/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -338,8 +338,8 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
         swift_runtime->GetMetadataPromise(argmetadata_ptr, valobj));
     if (promise_sp)
       if (CompilerType type = promise_sp->FulfillTypePromise())
-        if (TypeSystemSwift *type_system =
-                llvm::dyn_cast<TypeSystemSwift>(type.GetTypeSystem()))
+        if (auto type_system =
+                type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>())
           argument_type =
               type_system->GetGenericArgumentType(type.GetOpaqueQualType(), 0);
 

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -365,8 +365,7 @@ HashedCollectionConfig::CreateNativeHandler(
   }
   
   if (typeName.startswith(m_nativeStorage_demangledPrefix.GetStringRef())) {
-    auto *type_system =
-        llvm::dyn_cast_or_null<TypeSystemSwift>(type.GetTypeSystem());
+    auto type_system = type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
     if (!type_system)
       return nullptr;
 
@@ -383,8 +382,7 @@ HashedCollectionConfig::CreateNativeHandler(
   // is some valid storage class instance, and attempt to get
   // key/value types from value_sp.
   type = value_sp->GetCompilerType();
-  auto *type_system =
-      llvm::dyn_cast_or_null<TypeSystemSwift>(type.GetTypeSystem());
+  auto type_system = type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
   if (!type_system)
     return nullptr;
   CompilerType key_type = type_system->GetGenericArgumentType(type.GetOpaqueQualType(), 0);
@@ -451,8 +449,8 @@ NativeHashedStorageHandler::NativeHashedStorageHandler(
   if (value_type) {
     auto value_type_stride = value_type.GetByteStride(m_process);
     m_value_stride = value_type_stride ? *value_type_stride : 0;
-    if (TypeSystemSwift *type_system =
-            llvm::dyn_cast_or_null<TypeSystemSwift>(key_type.GetTypeSystem())) {
+    if (auto type_system =
+            key_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>()) {
       auto *runtime = SwiftLanguageRuntime::Get(m_process);
       if (!runtime)
         return;

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -769,9 +769,8 @@ SwiftLanguage::GetHardcodedSynthetics() {
               bool is_imported = false;
 
               if (type.IsValid()) {
-                TypeSystemSwift *swift_ast_ctx =
-                    llvm::dyn_cast_or_null<TypeSystemSwift>(
-                        type.GetTypeSystem());
+                auto swift_ast_ctx =
+                    type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
                 if (swift_ast_ctx && swift_ast_ctx->IsImportedType(
                                          type.GetOpaqueQualType(), nullptr))
                   is_imported = true;
@@ -946,9 +945,8 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
           auto as_decl = m_result.GetAs<swift::Decl *>();
 
           if (as_type.hasValue() && as_type.getValue()) {
-            TypeSystem *type_system = as_type->GetTypeSystem();
-            if (TypeSystemSwift *swift_ast_ctx =
-                    llvm::dyn_cast_or_null<TypeSystemSwift>(type_system))
+            if (auto swift_ast_ctx = as_type->GetTypeSystem()
+                                         .dyn_cast_or_null<TypeSystemSwift>())
               swift_ast_ctx->DumpTypeDescription(
                   as_type->GetOpaqueQualType(), &stream,
                   print_help_if_available, true, eDescriptionLevelFull,
@@ -1278,7 +1276,7 @@ LazyBool SwiftLanguage::IsLogicalTrue(ValueObject &valobj, Status &error) {
   auto swift_ty = GetCanonicalSwiftType(valobj.GetCompilerType());
   CompilerType valobj_type = ToCompilerType(swift_ty);
   Flags type_flags(valobj_type.GetTypeInfo());
-  if (llvm::isa<TypeSystemSwift>(valobj_type.GetTypeSystem())) {
+  if (valobj_type.GetTypeSystem().isa_and_nonnull<TypeSystemSwift>()) {
     if (type_flags.AllSet(eTypeIsStructUnion) &&
         valobj_type.GetTypeName() == g_SwiftBool) {
       ValueObjectSP your_value_sp(valobj.GetChildMemberWithName(g_value, true));

--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
@@ -79,8 +79,7 @@ lldb::addr_t SwiftUnsafeType::GetAddress(llvm::StringRef child_name) {
     return false;
   }
 
-  auto *type_system =
-      llvm::dyn_cast_or_null<TypeSystemSwift>(type.GetTypeSystem());
+  auto type_system = type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
   if (!type_system) {
     LLDB_LOG(GetLog(LLDBLog::DataFormatters),
              "{0}: Couldn't get {1} type system.", __FUNCTION__,
@@ -249,8 +248,7 @@ bool SwiftUnsafeRawBufferPointer::Update() {
       return false;
     }
 
-    auto *type_system =
-        llvm::dyn_cast_or_null<TypeSystemSwift>(type.GetTypeSystem());
+    auto type_system = type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
     if (!type_system) {
       LLDB_LOG(GetLog(LLDBLog::DataFormatters),
                "{0}: Couldn't get {1} type system.", __FUNCTION__,
@@ -312,8 +310,7 @@ bool SwiftUnsafePointer::Update() {
     return false;
   }
 
-  auto *type_system =
-      llvm::dyn_cast_or_null<TypeSystemSwift>(type.GetTypeSystem());
+  auto type_system = type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
   if (!type_system) {
     LLDB_LOG(GetLog(LLDBLog::DataFormatters),
              "{0}: Couldn't get {1} type system.", __FUNCTION__,
@@ -365,8 +362,7 @@ std::unique_ptr<SwiftUnsafeType> SwiftUnsafeType::Create(ValueObject &valobj) {
       return nullptr;
     }
 
-    auto *type_system =
-        llvm::dyn_cast_or_null<TypeSystemSwift>(type.GetTypeSystem());
+    auto type_system = type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
     if (!type_system) {
       LLDB_LOG(GetLog(LLDBLog::DataFormatters),
                "{0}: Couldn't get {1} type system.", __FUNCTION__,

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCDeclVendor.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCDeclVendor.h
@@ -37,7 +37,7 @@ private:
   bool FinishDecl(clang::ObjCInterfaceDecl *decl);
 
   ObjCLanguageRuntime &m_runtime;
-  TypeSystemClang m_ast_ctx;
+  std::shared_ptr<TypeSystemClang> m_ast_ctx;
   ObjCLanguageRuntime::EncodingToTypeSP m_type_realizer_sp;
   AppleObjCExternalASTSource *m_external_source;
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.cpp
@@ -330,8 +330,8 @@ ObjCLanguageRuntime::GetNonKVOClassDescriptor(ObjCISA isa) {
 CompilerType
 ObjCLanguageRuntime::EncodingToType::RealizeType(const char *name,
                                                  bool for_expression) {
-  if (m_scratch_ast_ctx_up)
-    return RealizeType(*m_scratch_ast_ctx_up, name, for_expression);
+  if (m_scratch_ast_ctx_sp)
+    return RealizeType(*m_scratch_ast_ctx_sp, name, for_expression);
   return CompilerType();
 }
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -158,7 +158,7 @@ public:
     virtual CompilerType RealizeType(const char *name, bool for_expression);
 
   protected:
-    std::unique_ptr<TypeSystemClang> m_scratch_ast_ctx_up;
+    std::shared_ptr<TypeSystemClang> m_scratch_ast_ctx_sp;
   };
 
   class ObjCExceptionPrecondition : public BreakpointPrecondition {

--- a/lldb/source/Plugins/Platform/FreeBSD/PlatformFreeBSD.cpp
+++ b/lldb/source/Plugins/Platform/FreeBSD/PlatformFreeBSD.cpp
@@ -187,9 +187,12 @@ MmapArgList PlatformFreeBSD::GetMmapArgumentList(const ArchSpec &arch,
 }
 
 CompilerType PlatformFreeBSD::GetSiginfoType(const llvm::Triple &triple) {
-  if (!m_type_system_up)
-    m_type_system_up.reset(new TypeSystemClang("siginfo", triple));
-  TypeSystemClang *ast = m_type_system_up.get();
+  {
+    std::lock_guard<std::mutex> guard(m_mutex);
+    if (!m_type_system)
+      m_type_system = std::make_shared<TypeSystemClang>("siginfo", triple);
+  }
+  TypeSystemClang *ast = m_type_system.get();
 
   // generic types
   CompilerType int_type = ast->GetBasicType(eBasicTypeInt);

--- a/lldb/source/Plugins/Platform/FreeBSD/PlatformFreeBSD.h
+++ b/lldb/source/Plugins/Platform/FreeBSD/PlatformFreeBSD.h
@@ -60,7 +60,8 @@ public:
   std::vector<ArchSpec> m_supported_architectures;
 
 private:
-  std::unique_ptr<TypeSystemClang> m_type_system_up;
+  std::mutex m_mutex;
+  std::shared_ptr<TypeSystemClang> m_type_system;
 };
 
 } // namespace platform_freebsd

--- a/lldb/source/Plugins/Platform/Linux/PlatformLinux.cpp
+++ b/lldb/source/Plugins/Platform/Linux/PlatformLinux.cpp
@@ -312,9 +312,12 @@ MmapArgList PlatformLinux::GetMmapArgumentList(const ArchSpec &arch,
 }
 
 CompilerType PlatformLinux::GetSiginfoType(const llvm::Triple &triple) {
-  if (!m_type_system_up)
-    m_type_system_up.reset(new TypeSystemClang("siginfo", triple));
-  TypeSystemClang *ast = m_type_system_up.get();
+  {
+    std::lock_guard<std::mutex> guard(m_mutex);
+    if (!m_type_system)
+      m_type_system = std::make_shared<TypeSystemClang>("siginfo", triple);
+  }
+  TypeSystemClang *ast = m_type_system.get();
 
   bool si_errno_then_code = true;
 

--- a/lldb/source/Plugins/Platform/Linux/PlatformLinux.h
+++ b/lldb/source/Plugins/Platform/Linux/PlatformLinux.h
@@ -65,7 +65,8 @@ public:
   std::vector<ArchSpec> m_supported_architectures;
 
 private:
-  std::unique_ptr<TypeSystemClang> m_type_system_up;
+  std::mutex m_mutex;
+  std::shared_ptr<TypeSystemClang> m_type_system;
 };
 
 } // namespace platform_linux

--- a/lldb/source/Plugins/Platform/NetBSD/PlatformNetBSD.cpp
+++ b/lldb/source/Plugins/Platform/NetBSD/PlatformNetBSD.cpp
@@ -206,9 +206,12 @@ MmapArgList PlatformNetBSD::GetMmapArgumentList(const ArchSpec &arch,
 }
 
 CompilerType PlatformNetBSD::GetSiginfoType(const llvm::Triple &triple) {
-  if (!m_type_system_up)
-    m_type_system_up.reset(new TypeSystemClang("siginfo", triple));
-  TypeSystemClang *ast = m_type_system_up.get();
+  {
+    std::lock_guard<std::mutex> guard(m_mutex);
+    if (!m_type_system)
+      m_type_system = std::make_shared<TypeSystemClang>("siginfo", triple);
+  }
+  TypeSystemClang *ast = m_type_system.get();
 
   // generic types
   CompilerType int_type = ast->GetBasicType(eBasicTypeInt);

--- a/lldb/source/Plugins/Platform/NetBSD/PlatformNetBSD.h
+++ b/lldb/source/Plugins/Platform/NetBSD/PlatformNetBSD.h
@@ -62,7 +62,8 @@ public:
   std::vector<ArchSpec> m_supported_architectures;
 
 private:
-  std::unique_ptr<TypeSystemClang> m_type_system_up;
+  std::mutex m_mutex;
+  std::shared_ptr<TypeSystemClang> m_type_system;
 };
 
 } // namespace platform_netbsd

--- a/lldb/source/Plugins/Process/Utility/InferiorCallPOSIX.cpp
+++ b/lldb/source/Plugins/Process/Utility/InferiorCallPOSIX.cpp
@@ -88,9 +88,11 @@ bool lldb_private::InferiorCallMmap(Process *process, addr_t &allocated_addr,
           llvm::consumeError(type_system_or_err.takeError());
           return false;
         }
+        auto ts = *type_system_or_err;
+        if (!ts)
+          return false;
         CompilerType void_ptr_type =
-            type_system_or_err->GetBasicTypeFromAST(eBasicTypeVoid)
-                .GetPointerType();
+            ts->GetBasicTypeFromAST(eBasicTypeVoid).GetPointerType();
         const ArchSpec arch = process->GetTarget().GetArchitecture();
         MmapArgList args =
             process->GetTarget().GetPlatform()->GetMmapArgumentList(

--- a/lldb/source/Plugins/SymbolFile/Breakpad/SymbolFileBreakpad.h
+++ b/lldb/source/Plugins/SymbolFile/Breakpad/SymbolFileBreakpad.h
@@ -127,7 +127,7 @@ public:
                  llvm::DenseSet<SymbolFile *> &searched_symbol_files,
                  TypeMap &types) override;
 
-  llvm::Expected<TypeSystem &>
+  llvm::Expected<lldb::TypeSystemSP>
   GetTypeSystemForLanguage(lldb::LanguageType language) override {
     return llvm::make_error<llvm::StringError>(
         "SymbolFileBreakpad does not support GetTypeSystemForLanguage",

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -236,8 +236,10 @@ static void ForcefullyCompleteType(CompilerType type) {
   lldbassert(started && "Unable to start a class type definition.");
   TypeSystemClang::CompleteTagDeclarationDefinition(type);
   const clang::TagDecl *td = ClangUtil::GetAsTagDecl(type);
-  auto &ts = llvm::cast<TypeSystemClang>(*type.GetTypeSystem());
-  ts.GetMetadata(td)->SetIsForcefullyCompleted();
+  auto ts_sp = type.GetTypeSystem();
+  auto ts = ts_sp.dyn_cast_or_null<TypeSystemClang>();
+  if (ts)
+    ts->GetMetadata(td)->SetIsForcefullyCompleted();
 }
 
 /// Complete a type from debug info, or mark it as forcefully completed if
@@ -827,8 +829,9 @@ TypeSP DWARFASTParserClang::ParseEnum(const SymbolContext &sc,
 
   CompilerType enumerator_clang_type;
   CompilerType clang_type;
-  clang_type.SetCompilerType(
-      &m_ast, dwarf->GetForwardDeclDieToClangType().lookup(die.GetDIE()));
+  clang_type =
+      CompilerType(m_ast.weak_from_this(),
+                   dwarf->GetForwardDeclDieToClangType().lookup(die.GetDIE()));
   if (!clang_type) {
     if (attrs.type.IsValid()) {
       Type *enumerator_type =
@@ -1394,9 +1397,8 @@ void DWARFASTParserClang::ParseInheritance(
     const lldb::ModuleSP &module_sp,
     std::vector<std::unique_ptr<clang::CXXBaseSpecifier>> &base_classes,
     ClangASTImporter::LayoutInfo &layout_info) {
-
-  TypeSystemClang *ast =
-      llvm::dyn_cast_or_null<TypeSystemClang>(class_clang_type.GetTypeSystem());
+  auto ast =
+      class_clang_type.GetTypeSystem().dyn_cast_or_null<TypeSystemClang>();
   if (ast == nullptr)
     return;
 
@@ -1713,8 +1715,9 @@ DWARFASTParserClang::ParseStructureLikeDIE(const SymbolContext &sc,
   assert(tag_decl_kind != -1);
   (void)tag_decl_kind;
   bool clang_type_was_created = false;
-  clang_type.SetCompilerType(
-      &m_ast, dwarf->GetForwardDeclDieToClangType().lookup(die.GetDIE()));
+  clang_type =
+      CompilerType(m_ast.weak_from_this(),
+                   dwarf->GetForwardDeclDieToClangType().lookup(die.GetDIE()));
   if (!clang_type) {
     clang::DeclContext *decl_ctx =
         GetClangDeclContextContainingDIE(die, nullptr);
@@ -2885,8 +2888,8 @@ bool DWARFASTParserClang::ParseChildMembers(
   FieldInfo last_field_info;
 
   ModuleSP module_sp = parent_die.GetDWARF()->GetObjectFile()->GetModule();
-  TypeSystemClang *ast =
-      llvm::dyn_cast_or_null<TypeSystemClang>(class_clang_type.GetTypeSystem());
+  auto ts = class_clang_type.GetTypeSystem();
+  auto ast = ts.dyn_cast_or_null<TypeSystemClang>();
   if (ast == nullptr)
     return false;
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -146,7 +146,7 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
           // For a typedef, store the once desugared type as the name.
           CompilerType type = desugared_type->GetForwardCompilerType();
           if (auto swift_ast_ctx =
-                  llvm::dyn_cast_or_null<TypeSystemSwift>(type.GetTypeSystem()))
+                  type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>())
             preferred_name =
                 swift_ast_ctx->GetMangledTypeName(type.GetOpaqueQualType());
         }

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -432,16 +432,16 @@ UniqueDWARFASTTypeMap &SymbolFileDWARF::GetUniqueDWARFASTTypeMap() {
     return m_unique_ast_type_map;
 }
 
-llvm::Expected<TypeSystem &>
+llvm::Expected<lldb::TypeSystemSP>
 SymbolFileDWARF::GetTypeSystemForLanguage(LanguageType language) {
   if (SymbolFileDWARFDebugMap *debug_map_symfile = GetDebugMapSymfile())
     return debug_map_symfile->GetTypeSystemForLanguage(language);
 
   auto type_system_or_err =
       m_objfile_sp->GetModule()->GetTypeSystemForLanguage(language);
-  if (type_system_or_err) {
-    type_system_or_err->SetSymbolFile(this);
-  }
+  if (type_system_or_err)
+    if (auto ts = *type_system_or_err)
+      ts->SetSymbolFile(this);
   return type_system_or_err;
 }
 
@@ -830,7 +830,10 @@ Function *SymbolFileDWARF::ParseFunction(CompileUnit &comp_unit,
                    "Unable to parse function");
     return nullptr;
   }
-  DWARFASTParser *dwarf_ast = type_system_or_err->GetDWARFParser();
+  auto ts = *type_system_or_err;
+  if (!ts)
+    return nullptr;
+  DWARFASTParser *dwarf_ast = ts->GetDWARFParser();
   if (!dwarf_ast)
     return nullptr;
 
@@ -1554,10 +1557,8 @@ bool SymbolFileDWARF::HasForwardDeclForClangType(
           compiler_type_no_qualifiers.GetOpaqueQualType())) {
     return true;
   }
-  TypeSystem *type_system = compiler_type.GetTypeSystem();
-
-  TypeSystemClang *clang_type_system =
-      llvm::dyn_cast_or_null<TypeSystemClang>(type_system);
+  auto type_system = compiler_type.GetTypeSystem();
+  auto clang_type_system = type_system.dyn_cast_or_null<TypeSystemClang>();
   if (!clang_type_system)
     return false;
   DWARFASTParserClang *ast_parser =
@@ -1567,9 +1568,8 @@ bool SymbolFileDWARF::HasForwardDeclForClangType(
 
 bool SymbolFileDWARF::CompleteType(CompilerType &compiler_type) {
   std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
-
-  TypeSystemClang *clang_type_system =
-      llvm::dyn_cast_or_null<TypeSystemClang>(compiler_type.GetTypeSystem());
+  auto clang_type_system =
+      compiler_type.GetTypeSystem().dyn_cast_or_null<TypeSystemClang>();
   if (clang_type_system) {
     DWARFASTParserClang *ast_parser =
         static_cast<DWARFASTParserClang *>(clang_type_system->GetDWARFParser());
@@ -2132,7 +2132,7 @@ bool SymbolFileDWARF::DeclContextMatchesThisSymbolFile(
     return false;
   }
 
-  if (decl_ctx_type_system == &type_system_or_err.get())
+  if (decl_ctx_type_system == type_system_or_err->get())
     return true; // The type systems match, return true
 
   // The namespace AST was valid, and it does not match...
@@ -2890,7 +2890,7 @@ TypeSP SymbolFileDWARF::FindDefinitionTypeForDWARFDeclContext(
       // use this to ensure any matches we find are in a language that this
       // type system supports
       const LanguageType language = dwarf_decl_ctx.GetLanguage();
-      TypeSystem *type_system = nullptr;
+      TypeSystemSP type_system = nullptr;
       if (language != eLanguageTypeUnknown) {
         auto type_system_or_err = GetTypeSystemForLanguage(language);
         if (auto err = type_system_or_err.takeError()) {
@@ -2898,7 +2898,7 @@ TypeSP SymbolFileDWARF::FindDefinitionTypeForDWARFDeclContext(
                          "Cannot get TypeSystem for language {}",
                          Language::GetNameForLanguageType(language));
         } else {
-          type_system = &type_system_or_err.get();
+          type_system = *type_system_or_err;
         }
       }
 
@@ -3056,8 +3056,11 @@ TypeSP SymbolFileDWARF::ParseType(const SymbolContext &sc, const DWARFDIE &die,
                    "Unable to parse type");
     return {};
   }
+  auto ts = *type_system_or_err;
+  if (!ts)
+    return {};
 
-  DWARFASTParser *dwarf_ast = type_system_or_err->GetDWARFParser();
+  DWARFASTParser *dwarf_ast = ts->GetDWARFParser();
   if (!dwarf_ast)
     return {};
 
@@ -4071,8 +4074,8 @@ void SymbolFileDWARF::DumpClangAST(Stream &s) {
   auto ts_or_err = GetTypeSystemForLanguage(eLanguageTypeC_plus_plus);
   if (!ts_or_err)
     return;
-  TypeSystemClang *clang =
-      llvm::dyn_cast_or_null<TypeSystemClang>(&ts_or_err.get());
+  auto ts = *ts_or_err;
+  TypeSystemClang *clang = llvm::dyn_cast_or_null<TypeSystemClang>(ts.get());
   if (!clang)
     return;
   clang->Dump(s.AsRawOstream());
@@ -4115,7 +4118,8 @@ const std::shared_ptr<SymbolFileDWARFDwo> &SymbolFileDWARF::GetDwpSymbolFile() {
   return m_dwp_symfile;
 }
 
-llvm::Expected<TypeSystem &> SymbolFileDWARF::GetTypeSystem(DWARFUnit &unit) {
+llvm::Expected<lldb::TypeSystemSP>
+SymbolFileDWARF::GetTypeSystem(DWARFUnit &unit) {
   return unit.GetSymbolFileDWARF().GetTypeSystemForLanguage(GetLanguage(unit));
 }
 
@@ -4126,7 +4130,9 @@ DWARFASTParser *SymbolFileDWARF::GetDWARFParser(DWARFUnit &unit) {
                    "Unable to get DWARFASTParser");
     return nullptr;
   }
-  return type_system_or_err->GetDWARFParser();
+  if (auto ts = *type_system_or_err)
+    return ts->GetDWARFParser();
+  return nullptr;
 }
 
 CompilerDecl SymbolFileDWARF::GetDecl(const DWARFDIE &die) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
@@ -219,7 +219,7 @@ public:
                 lldb::TypeClass type_mask,
                 lldb_private::TypeList &type_list) override;
 
-  llvm::Expected<lldb_private::TypeSystem &>
+  llvm::Expected<lldb::TypeSystemSP>
   GetTypeSystemForLanguage(lldb::LanguageType language) override;
 
   lldb_private::CompilerDeclContext FindNamespace(
@@ -312,8 +312,7 @@ public:
 
   lldb_private::FileSpec GetFile(DWARFUnit &unit, size_t file_idx);
 
-  static llvm::Expected<lldb_private::TypeSystem &>
-  GetTypeSystem(DWARFUnit &unit);
+  static llvm::Expected<lldb::TypeSystemSP> GetTypeSystem(DWARFUnit &unit);
 
   static DWARFASTParser *GetDWARFParser(DWARFUnit &unit);
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.cpp
@@ -117,7 +117,7 @@ lldb::TypeSP SymbolFileDWARFDwo::FindCompleteObjCDefinitionTypeForDIE(
       die, type_name, must_be_implementation);
 }
 
-llvm::Expected<TypeSystem &>
+llvm::Expected<lldb::TypeSystemSP>
 SymbolFileDWARFDwo::GetTypeSystemForLanguage(LanguageType language) {
   return GetBaseSymbolFile().GetTypeSystemForLanguage(language);
 }

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.h
@@ -34,7 +34,7 @@ public:
   void GetObjCMethods(lldb_private::ConstString class_name,
                       llvm::function_ref<bool(DWARFDIE die)> callback) override;
 
-  llvm::Expected<lldb_private::TypeSystem &>
+  llvm::Expected<lldb::TypeSystemSP>
   GetTypeSystemForLanguage(lldb::LanguageType language) override;
 
   DWARFDIE

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.cpp
@@ -1562,7 +1562,7 @@ CompilerDecl PdbAstBuilder::ToCompilerDecl(clang::Decl &decl) {
 }
 
 CompilerType PdbAstBuilder::ToCompilerType(clang::QualType qt) {
-  return {&m_clang, qt.getAsOpaquePtr()};
+  return {m_clang.weak_from_this(), qt.getAsOpaquePtr()};
 }
 
 CompilerDeclContext

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.h
@@ -147,7 +147,7 @@ public:
                  llvm::DenseSet<SymbolFile *> &searched_symbol_files,
                  TypeMap &types) override;
 
-  llvm::Expected<TypeSystem &>
+  llvm::Expected<lldb::TypeSystemSP>
   GetTypeSystemForLanguage(lldb::LanguageType language) override;
 
   CompilerDeclContext

--- a/lldb/source/Plugins/SymbolFile/PDB/PDBASTParser.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/PDBASTParser.cpp
@@ -120,24 +120,31 @@ GetBuiltinTypeForPDBEncodingAndBitSize(TypeSystemClang &clang_ast,
     return clang_ast.GetBasicType(eBasicTypeBool);
   case PDB_BuiltinType::Long:
     if (width == ast.getTypeSize(ast.LongTy))
-      return CompilerType(&clang_ast, ast.LongTy.getAsOpaquePtr());
+      return CompilerType(clang_ast.weak_from_this(),
+                          ast.LongTy.getAsOpaquePtr());
     if (width == ast.getTypeSize(ast.LongLongTy))
-      return CompilerType(&clang_ast, ast.LongLongTy.getAsOpaquePtr());
+      return CompilerType(clang_ast.weak_from_this(),
+                          ast.LongLongTy.getAsOpaquePtr());
     break;
   case PDB_BuiltinType::ULong:
     if (width == ast.getTypeSize(ast.UnsignedLongTy))
-      return CompilerType(&clang_ast, ast.UnsignedLongTy.getAsOpaquePtr());
+      return CompilerType(clang_ast.weak_from_this(),
+                          ast.UnsignedLongTy.getAsOpaquePtr());
     if (width == ast.getTypeSize(ast.UnsignedLongLongTy))
-      return CompilerType(&clang_ast, ast.UnsignedLongLongTy.getAsOpaquePtr());
+      return CompilerType(clang_ast.weak_from_this(),
+                          ast.UnsignedLongLongTy.getAsOpaquePtr());
     break;
   case PDB_BuiltinType::WCharT:
     if (width == ast.getTypeSize(ast.WCharTy))
-      return CompilerType(&clang_ast, ast.WCharTy.getAsOpaquePtr());
+      return CompilerType(clang_ast.weak_from_this(),
+                          ast.WCharTy.getAsOpaquePtr());
     break;
   case PDB_BuiltinType::Char16:
-    return CompilerType(&clang_ast, ast.Char16Ty.getAsOpaquePtr());
+    return CompilerType(clang_ast.weak_from_this(),
+                        ast.Char16Ty.getAsOpaquePtr());
   case PDB_BuiltinType::Char32:
-    return CompilerType(&clang_ast, ast.Char32Ty.getAsOpaquePtr());
+    return CompilerType(clang_ast.weak_from_this(),
+                        ast.Char32Ty.getAsOpaquePtr());
   case PDB_BuiltinType::Float:
     // Note: types `long double` and `double` have same bit size in MSVC and
     // there is no information in the PDB to distinguish them. So when falling

--- a/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
@@ -318,8 +318,9 @@ SymbolFilePDB::ParseCompileUnitFunctionForPDBFunc(const PDBSymbolFunc &pdb_func,
     return nullptr;
   }
 
+  auto ts = *type_system_or_err;
   TypeSystemClang *clang_type_system =
-    llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
+    llvm::dyn_cast_or_null<TypeSystemClang>(ts.get());
   if (!clang_type_system)
     return nullptr;
   clang_type_system->GetPDBParser()->GetDeclForSymbol(pdb_func);
@@ -568,8 +569,9 @@ lldb_private::Type *SymbolFilePDB::ResolveTypeUID(lldb::user_id_t type_uid) {
     return nullptr;
   }
 
+  auto ts = *type_system_or_err;
   TypeSystemClang *clang_type_system =
-      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
+      llvm::dyn_cast_or_null<TypeSystemClang>(ts.get());
   if (!clang_type_system)
     return nullptr;
   PDBASTParser *pdb = clang_type_system->GetPDBParser();
@@ -604,9 +606,9 @@ bool SymbolFilePDB::CompleteType(lldb_private::CompilerType &compiler_type) {
                    "Unable to get dynamic array info for UID");
     return false;
   }
-
+  auto ts = *type_system_or_err;
   TypeSystemClang *clang_ast_ctx =
-      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
+      llvm::dyn_cast_or_null<TypeSystemClang>(ts.get());
 
   if (!clang_ast_ctx)
     return false;
@@ -626,9 +628,9 @@ lldb_private::CompilerDecl SymbolFilePDB::GetDeclForUID(lldb::user_id_t uid) {
                    "Unable to get decl for UID");
     return CompilerDecl();
   }
-
+  auto ts = *type_system_or_err;
   TypeSystemClang *clang_ast_ctx =
-      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
+      llvm::dyn_cast_or_null<TypeSystemClang>(ts.get());
   if (!clang_ast_ctx)
     return CompilerDecl();
 
@@ -657,8 +659,9 @@ SymbolFilePDB::GetDeclContextForUID(lldb::user_id_t uid) {
     return CompilerDeclContext();
   }
 
+  auto ts = *type_system_or_err;
   TypeSystemClang *clang_ast_ctx =
-      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
+      llvm::dyn_cast_or_null<TypeSystemClang>(ts.get());
   if (!clang_ast_ctx)
     return CompilerDeclContext();
 
@@ -687,8 +690,9 @@ SymbolFilePDB::GetDeclContextContainingUID(lldb::user_id_t uid) {
     return CompilerDeclContext();
   }
 
+  auto ts = *type_system_or_err;
   TypeSystemClang *clang_ast_ctx =
-      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
+      llvm::dyn_cast_or_null<TypeSystemClang>(ts.get());
   if (!clang_ast_ctx)
     return CompilerDeclContext();
 
@@ -716,8 +720,9 @@ void SymbolFilePDB::ParseDeclsForContext(
     return;
   }
 
+  auto ts = *type_system_or_err;
   TypeSystemClang *clang_ast_ctx =
-      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
+      llvm::dyn_cast_or_null<TypeSystemClang>(ts.get());
   if (!clang_ast_ctx)
     return;
 
@@ -1456,8 +1461,9 @@ void SymbolFilePDB::DumpClangAST(Stream &s) {
     return;
   }
 
-  auto *clang_type_system =
-      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
+  auto ts = *type_system_or_err;
+  TypeSystemClang *clang_type_system =
+      llvm::dyn_cast_or_null<TypeSystemClang>(ts.get());
   if (!clang_type_system)
     return;
   clang_type_system->Dump(s.AsRawOstream());
@@ -1650,12 +1656,13 @@ void SymbolFilePDB::GetTypes(lldb_private::SymbolContextScope *sc_scope,
   }
 }
 
-llvm::Expected<lldb_private::TypeSystem &>
+llvm::Expected<lldb::TypeSystemSP>
 SymbolFilePDB::GetTypeSystemForLanguage(lldb::LanguageType language) {
   auto type_system_or_err =
       m_objfile_sp->GetModule()->GetTypeSystemForLanguage(language);
   if (type_system_or_err) {
-    type_system_or_err->SetSymbolFile(this);
+    if (auto ts = *type_system_or_err)
+      ts->SetSymbolFile(this);
   }
   return type_system_or_err;
 }
@@ -1669,8 +1676,9 @@ PDBASTParser *SymbolFilePDB::GetPDBAstParser() {
     return nullptr;
   }
 
+  auto ts = *type_system_or_err;
   auto *clang_type_system =
-      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
+      llvm::dyn_cast_or_null<TypeSystemClang>(ts.get());
   if (!clang_type_system)
     return nullptr;
 
@@ -1688,9 +1696,9 @@ SymbolFilePDB::FindNamespace(lldb_private::ConstString name,
                    "Unable to find namespace {}", name.AsCString());
     return CompilerDeclContext();
   }
-
+  auto ts = *type_system_or_err;
   auto *clang_type_system =
-      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
+      llvm::dyn_cast_or_null<TypeSystemClang>(ts.get());
   if (!clang_type_system)
     return CompilerDeclContext();
 
@@ -1984,7 +1992,7 @@ bool SymbolFilePDB::DeclContextMatchesThisSymbolFile(
     return false;
   }
 
-  if (decl_ctx_type_system == &type_system_or_err.get())
+  if (decl_ctx_type_system == type_system_or_err->get())
     return true; // The type systems match, return true
 
   return false;

--- a/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.h
+++ b/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.h
@@ -154,7 +154,7 @@ public:
                 lldb::TypeClass type_mask,
                 lldb_private::TypeList &type_list) override;
 
-  llvm::Expected<lldb_private::TypeSystem &>
+  llvm::Expected<lldb::TypeSystemSP>
   GetTypeSystemForLanguage(lldb::LanguageType language) override;
 
   lldb_private::CompilerDeclContext FindNamespace(

--- a/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetItemInfoHandler.cpp
+++ b/lldb/source/Plugins/SystemRuntime/MacOSX/AppleGetItemInfoHandler.cpp
@@ -162,11 +162,15 @@ lldb::addr_t AppleGetItemInfoHandler::SetupGetItemInfoFunction(
               eLanguageTypeC);
       if (auto err = type_system_or_err.takeError()) {
         LLDB_LOG_ERROR(log, std::move(err),
-                       "Error inseting get-item-info function");
+                       "Error inserting get-item-info function");
         return args_addr;
       }
+      auto ts = *type_system_or_err;
+      if (!ts)
+        return args_addr;
+      
       CompilerType get_item_info_return_type =
-          type_system_or_err->GetBasicTypeFromAST(eBasicTypeVoid)
+          ts->GetBasicTypeFromAST(eBasicTypeVoid)
               .GetPointerType();
 
       Status error;
@@ -174,7 +178,7 @@ lldb::addr_t AppleGetItemInfoHandler::SetupGetItemInfoFunction(
           get_item_info_return_type, get_item_info_arglist,
           thread.shared_from_this(), error);
       if (error.Fail() || get_item_info_caller == nullptr) {
-        LLDB_LOGF(log, "Error Inserting get-item-info function: \"%s\".",
+        LLDB_LOGF(log, "Error inserting get-item-info function: \"%s\".",
                   error.AsCString());
         return args_addr;
       }

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -1,4 +1,4 @@
-//===-- TypeSystemClang.cpp -----------------------------------------------===//
+//===-- TypeSystemClang.cpp -----------------------------------------------==='//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -939,7 +939,7 @@ CompilerType TypeSystemClang::GetBasicType(lldb::BasicType basic_type) {
       GetOpaqueCompilerType(&ast, basic_type);
 
   if (clang_type)
-    return CompilerType(this, clang_type);
+    return CompilerType(weak_from_this(), clang_type);
   return CompilerType();
 }
 
@@ -1173,9 +1173,8 @@ CompilerType TypeSystemClang::GetCStringType(bool is_const) {
 
 bool TypeSystemClang::AreTypesSame(CompilerType type1, CompilerType type2,
                                    bool ignore_qualifiers) {
-  TypeSystemClang *ast =
-      llvm::dyn_cast_or_null<TypeSystemClang>(type1.GetTypeSystem());
-  if (!ast || ast != type2.GetTypeSystem())
+  auto ast = type1.GetTypeSystem().dyn_cast_or_null<TypeSystemClang>();
+  if (!ast || type1.GetTypeSystem() != type2.GetTypeSystem())
     return false;
 
   if (type1.GetOpaqueQualType() == type2.GetOpaqueQualType())
@@ -2859,9 +2858,9 @@ bool TypeSystemClang::IsArrayType(lldb::opaque_compiler_type_t type,
   case clang::Type::ConstantArray:
     if (element_type_ptr)
       element_type_ptr->SetCompilerType(
-          this, llvm::cast<clang::ConstantArrayType>(qual_type)
-                    ->getElementType()
-                    .getAsOpaquePtr());
+          weak_from_this(), llvm::cast<clang::ConstantArrayType>(qual_type)
+                                ->getElementType()
+                                .getAsOpaquePtr());
     if (size)
       *size = llvm::cast<clang::ConstantArrayType>(qual_type)
                   ->getSize()
@@ -2873,9 +2872,9 @@ bool TypeSystemClang::IsArrayType(lldb::opaque_compiler_type_t type,
   case clang::Type::IncompleteArray:
     if (element_type_ptr)
       element_type_ptr->SetCompilerType(
-          this, llvm::cast<clang::IncompleteArrayType>(qual_type)
-                    ->getElementType()
-                    .getAsOpaquePtr());
+          weak_from_this(), llvm::cast<clang::IncompleteArrayType>(qual_type)
+                                ->getElementType()
+                                .getAsOpaquePtr());
     if (size)
       *size = 0;
     if (is_incomplete)
@@ -2885,9 +2884,9 @@ bool TypeSystemClang::IsArrayType(lldb::opaque_compiler_type_t type,
   case clang::Type::VariableArray:
     if (element_type_ptr)
       element_type_ptr->SetCompilerType(
-          this, llvm::cast<clang::VariableArrayType>(qual_type)
-                    ->getElementType()
-                    .getAsOpaquePtr());
+          weak_from_this(), llvm::cast<clang::VariableArrayType>(qual_type)
+                                ->getElementType()
+                                .getAsOpaquePtr());
     if (size)
       *size = 0;
     if (is_incomplete)
@@ -2897,9 +2896,10 @@ bool TypeSystemClang::IsArrayType(lldb::opaque_compiler_type_t type,
   case clang::Type::DependentSizedArray:
     if (element_type_ptr)
       element_type_ptr->SetCompilerType(
-          this, llvm::cast<clang::DependentSizedArrayType>(qual_type)
-                    ->getElementType()
-                    .getAsOpaquePtr());
+          weak_from_this(),
+          llvm::cast<clang::DependentSizedArrayType>(qual_type)
+              ->getElementType()
+              .getAsOpaquePtr());
     if (size)
       *size = 0;
     if (is_incomplete)
@@ -2940,7 +2940,8 @@ bool TypeSystemClang::IsVectorType(lldb::opaque_compiler_type_t type,
         *size = ext_vector_type->getNumElements();
       if (element_type)
         *element_type =
-            CompilerType(this, ext_vector_type->getElementType().getAsOpaquePtr());
+            CompilerType(weak_from_this(),
+                         ext_vector_type->getElementType().getAsOpaquePtr());
     }
     return true;
   }
@@ -3107,7 +3108,8 @@ TypeSystemClang::IsHomogeneousAggregate(lldb::opaque_compiler_type_t type,
             ++num_fields;
           }
           if (base_type_ptr)
-            *base_type_ptr = CompilerType(this, base_qual_type.getAsOpaquePtr());
+            *base_type_ptr =
+                CompilerType(weak_from_this(), base_qual_type.getAsOpaquePtr());
           return num_fields;
         }
       }
@@ -3141,7 +3143,7 @@ TypeSystemClang::GetFunctionArgumentAtIndex(lldb::opaque_compiler_type_t type,
         llvm::dyn_cast<clang::FunctionProtoType>(qual_type.getTypePtr());
     if (func) {
       if (index < func->getNumParams())
-        return CompilerType(this, func->getParamType(index).getAsOpaquePtr());
+        return CompilerType(weak_from_this(), func->getParamType(index).getAsOpaquePtr());
     }
   }
   return CompilerType();
@@ -3184,8 +3186,8 @@ bool TypeSystemClang::IsBlockPointerType(
             qual_type->castAs<clang::BlockPointerType>();
         QualType pointee_type = block_pointer_type->getPointeeType();
         QualType function_pointer_type = m_ast_up->getPointerType(pointee_type);
-        *function_pointer_type_ptr =
-            CompilerType(this, function_pointer_type.getAsOpaquePtr());
+        *function_pointer_type_ptr = CompilerType(
+            weak_from_this(), function_pointer_type.getAsOpaquePtr());
       }
       return true;
     }
@@ -3276,20 +3278,21 @@ bool TypeSystemClang::IsPointerType(lldb::opaque_compiler_type_t type,
     case clang::Type::ObjCObjectPointer:
       if (pointee_type)
         pointee_type->SetCompilerType(
-            this, llvm::cast<clang::ObjCObjectPointerType>(qual_type)
-                      ->getPointeeType()
-                      .getAsOpaquePtr());
+            weak_from_this(),
+            llvm::cast<clang::ObjCObjectPointerType>(qual_type)
+                ->getPointeeType()
+                .getAsOpaquePtr());
       return true;
     case clang::Type::BlockPointer:
       if (pointee_type)
         pointee_type->SetCompilerType(
-            this, llvm::cast<clang::BlockPointerType>(qual_type)
-                      ->getPointeeType()
-                      .getAsOpaquePtr());
+            weak_from_this(), llvm::cast<clang::BlockPointerType>(qual_type)
+                                  ->getPointeeType()
+                                  .getAsOpaquePtr());
       return true;
     case clang::Type::Pointer:
       if (pointee_type)
-        pointee_type->SetCompilerType(this,
+        pointee_type->SetCompilerType(weak_from_this(),
                                       llvm::cast<clang::PointerType>(qual_type)
                                           ->getPointeeType()
                                           .getAsOpaquePtr());
@@ -3297,9 +3300,9 @@ bool TypeSystemClang::IsPointerType(lldb::opaque_compiler_type_t type,
     case clang::Type::MemberPointer:
       if (pointee_type)
         pointee_type->SetCompilerType(
-            this, llvm::cast<clang::MemberPointerType>(qual_type)
-                      ->getPointeeType()
-                      .getAsOpaquePtr());
+            weak_from_this(), llvm::cast<clang::MemberPointerType>(qual_type)
+                                  ->getPointeeType()
+                                  .getAsOpaquePtr());
       return true;
     default:
       break;
@@ -3328,19 +3331,21 @@ bool TypeSystemClang::IsPointerOrReferenceType(
     case clang::Type::ObjCObjectPointer:
       if (pointee_type)
         pointee_type->SetCompilerType(
-            this, llvm::cast<clang::ObjCObjectPointerType>(qual_type)
-                                 ->getPointeeType().getAsOpaquePtr());
+            weak_from_this(),
+            llvm::cast<clang::ObjCObjectPointerType>(qual_type)
+                ->getPointeeType()
+                .getAsOpaquePtr());
       return true;
     case clang::Type::BlockPointer:
       if (pointee_type)
         pointee_type->SetCompilerType(
-            this, llvm::cast<clang::BlockPointerType>(qual_type)
-                      ->getPointeeType()
-                      .getAsOpaquePtr());
+            weak_from_this(), llvm::cast<clang::BlockPointerType>(qual_type)
+                                  ->getPointeeType()
+                                  .getAsOpaquePtr());
       return true;
     case clang::Type::Pointer:
       if (pointee_type)
-        pointee_type->SetCompilerType(this,
+        pointee_type->SetCompilerType(weak_from_this(),
                                       llvm::cast<clang::PointerType>(qual_type)
                                           ->getPointeeType()
                                           .getAsOpaquePtr());
@@ -3348,23 +3353,23 @@ bool TypeSystemClang::IsPointerOrReferenceType(
     case clang::Type::MemberPointer:
       if (pointee_type)
         pointee_type->SetCompilerType(
-            this, llvm::cast<clang::MemberPointerType>(qual_type)
-                      ->getPointeeType()
-                      .getAsOpaquePtr());
+            weak_from_this(), llvm::cast<clang::MemberPointerType>(qual_type)
+                                  ->getPointeeType()
+                                  .getAsOpaquePtr());
       return true;
     case clang::Type::LValueReference:
       if (pointee_type)
         pointee_type->SetCompilerType(
-            this, llvm::cast<clang::LValueReferenceType>(qual_type)
-                      ->desugar()
-                      .getAsOpaquePtr());
+            weak_from_this(), llvm::cast<clang::LValueReferenceType>(qual_type)
+                                  ->desugar()
+                                  .getAsOpaquePtr());
       return true;
     case clang::Type::RValueReference:
       if (pointee_type)
         pointee_type->SetCompilerType(
-            this, llvm::cast<clang::RValueReferenceType>(qual_type)
-                      ->desugar()
-                      .getAsOpaquePtr());
+            weak_from_this(), llvm::cast<clang::RValueReferenceType>(qual_type)
+                                  ->desugar()
+                                  .getAsOpaquePtr());
       return true;
     default:
       break;
@@ -3386,18 +3391,18 @@ bool TypeSystemClang::IsReferenceType(lldb::opaque_compiler_type_t type,
     case clang::Type::LValueReference:
       if (pointee_type)
         pointee_type->SetCompilerType(
-            this, llvm::cast<clang::LValueReferenceType>(qual_type)
-                      ->desugar()
-                      .getAsOpaquePtr());
+            weak_from_this(), llvm::cast<clang::LValueReferenceType>(qual_type)
+                                  ->desugar()
+                                  .getAsOpaquePtr());
       if (is_rvalue)
         *is_rvalue = false;
       return true;
     case clang::Type::RValueReference:
       if (pointee_type)
         pointee_type->SetCompilerType(
-            this, llvm::cast<clang::RValueReferenceType>(qual_type)
-                      ->desugar()
-                      .getAsOpaquePtr());
+            weak_from_this(), llvm::cast<clang::RValueReferenceType>(qual_type)
+                                  ->desugar()
+                                  .getAsOpaquePtr());
       if (is_rvalue)
         *is_rvalue = true;
       return true;
@@ -3551,7 +3556,7 @@ bool TypeSystemClang::IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
           llvm::cast<clang::BuiltinType>(qual_type)->getKind() ==
               clang::BuiltinType::ObjCId) {
         if (dynamic_pointee_type)
-          dynamic_pointee_type->SetCompilerType(this, type);
+          dynamic_pointee_type->SetCompilerType(weak_from_this(), type);
         return true;
       }
       break;
@@ -3569,9 +3574,10 @@ bool TypeSystemClang::IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
         }
         if (dynamic_pointee_type)
           dynamic_pointee_type->SetCompilerType(
-              this, llvm::cast<clang::ObjCObjectPointerType>(qual_type)
-                        ->getPointeeType()
-                        .getAsOpaquePtr());
+              weak_from_this(),
+              llvm::cast<clang::ObjCObjectPointerType>(qual_type)
+                  ->getPointeeType()
+                  .getAsOpaquePtr());
         return true;
       }
       break;
@@ -3606,7 +3612,7 @@ bool TypeSystemClang::IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
         case clang::BuiltinType::Void:
           if (dynamic_pointee_type)
             dynamic_pointee_type->SetCompilerType(
-                this, pointee_qual_type.getAsOpaquePtr());
+                weak_from_this(), pointee_qual_type.getAsOpaquePtr());
           return true;
         default:
           break;
@@ -3638,7 +3644,7 @@ bool TypeSystemClang::IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
             if (success) {
               if (dynamic_pointee_type)
                 dynamic_pointee_type->SetCompilerType(
-                    this, pointee_qual_type.getAsOpaquePtr());
+                    weak_from_this(), pointee_qual_type.getAsOpaquePtr());
               return true;
             }
           }
@@ -3650,7 +3656,7 @@ bool TypeSystemClang::IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
         if (check_objc) {
           if (dynamic_pointee_type)
             dynamic_pointee_type->SetCompilerType(
-                this, pointee_qual_type.getAsOpaquePtr());
+                weak_from_this(), pointee_qual_type.getAsOpaquePtr());
           return true;
         }
         break;
@@ -3838,14 +3844,15 @@ TypeSystemClang::GetTypeInfo(lldb::opaque_compiler_type_t type,
     case clang::BuiltinType::ObjCClass:
       if (pointee_or_element_clang_type)
         pointee_or_element_clang_type->SetCompilerType(
-            this, getASTContext().ObjCBuiltinClassTy.getAsOpaquePtr());
+            weak_from_this(),
+            getASTContext().ObjCBuiltinClassTy.getAsOpaquePtr());
       builtin_type_flags |= eTypeIsPointer | eTypeIsObjC;
       break;
 
     case clang::BuiltinType::ObjCSel:
       if (pointee_or_element_clang_type)
         pointee_or_element_clang_type->SetCompilerType(
-            this, getASTContext().CharTy.getAsOpaquePtr());
+            weak_from_this(), getASTContext().CharTy.getAsOpaquePtr());
       builtin_type_flags |= eTypeIsPointer | eTypeIsObjC;
       break;
 
@@ -3888,7 +3895,7 @@ TypeSystemClang::GetTypeInfo(lldb::opaque_compiler_type_t type,
   case clang::Type::BlockPointer:
     if (pointee_or_element_clang_type)
       pointee_or_element_clang_type->SetCompilerType(
-          this, qual_type->getPointeeType().getAsOpaquePtr());
+          weak_from_this(), qual_type->getPointeeType().getAsOpaquePtr());
     return eTypeIsPointer | eTypeHasChildren | eTypeIsBlock;
 
   case clang::Type::Complex: {
@@ -3912,9 +3919,9 @@ TypeSystemClang::GetTypeInfo(lldb::opaque_compiler_type_t type,
   case clang::Type::VariableArray:
     if (pointee_or_element_clang_type)
       pointee_or_element_clang_type->SetCompilerType(
-          this, llvm::cast<clang::ArrayType>(qual_type.getTypePtr())
-                    ->getElementType()
-                    .getAsOpaquePtr());
+          weak_from_this(), llvm::cast<clang::ArrayType>(qual_type.getTypePtr())
+                                ->getElementType()
+                                .getAsOpaquePtr());
     return eTypeHasChildren | eTypeIsArray;
 
   case clang::Type::DependentName:
@@ -3927,10 +3934,10 @@ TypeSystemClang::GetTypeInfo(lldb::opaque_compiler_type_t type,
   case clang::Type::Enum:
     if (pointee_or_element_clang_type)
       pointee_or_element_clang_type->SetCompilerType(
-          this, llvm::cast<clang::EnumType>(qual_type)
-                    ->getDecl()
-                    ->getIntegerType()
-                    .getAsOpaquePtr());
+          weak_from_this(), llvm::cast<clang::EnumType>(qual_type)
+                                ->getDecl()
+                                ->getIntegerType()
+                                .getAsOpaquePtr());
     return eTypeIsEnumeration | eTypeHasValue;
 
   case clang::Type::FunctionProto:
@@ -3944,9 +3951,10 @@ TypeSystemClang::GetTypeInfo(lldb::opaque_compiler_type_t type,
   case clang::Type::RValueReference:
     if (pointee_or_element_clang_type)
       pointee_or_element_clang_type->SetCompilerType(
-          this, llvm::cast<clang::ReferenceType>(qual_type.getTypePtr())
-                    ->getPointeeType()
-                    .getAsOpaquePtr());
+          weak_from_this(),
+          llvm::cast<clang::ReferenceType>(qual_type.getTypePtr())
+              ->getPointeeType()
+              .getAsOpaquePtr());
     return eTypeHasChildren | eTypeIsReference | eTypeHasValue;
 
   case clang::Type::MemberPointer:
@@ -3955,7 +3963,7 @@ TypeSystemClang::GetTypeInfo(lldb::opaque_compiler_type_t type,
   case clang::Type::ObjCObjectPointer:
     if (pointee_or_element_clang_type)
       pointee_or_element_clang_type->SetCompilerType(
-          this, qual_type->getPointeeType().getAsOpaquePtr());
+          weak_from_this(), qual_type->getPointeeType().getAsOpaquePtr());
     return eTypeHasChildren | eTypeIsObjC | eTypeIsClass | eTypeIsPointer |
            eTypeHasValue;
 
@@ -3967,7 +3975,7 @@ TypeSystemClang::GetTypeInfo(lldb::opaque_compiler_type_t type,
   case clang::Type::Pointer:
     if (pointee_or_element_clang_type)
       pointee_or_element_clang_type->SetCompilerType(
-          this, qual_type->getPointeeType().getAsOpaquePtr());
+          weak_from_this(), qual_type->getPointeeType().getAsOpaquePtr());
     return eTypeHasChildren | eTypeIsPointer | eTypeHasValue;
 
   case clang::Type::Record:
@@ -5770,9 +5778,10 @@ CompilerType TypeSystemClang::GetFieldAtIndex(lldb::opaque_compiler_type_t type,
           objc_interface_type->getDecl();
       if (class_interface_decl) {
         return CompilerType(
-            this, GetObjCFieldAtIndex(&getASTContext(), class_interface_decl,
-                                      idx, name, bit_offset_ptr,
-                                      bitfield_bit_size_ptr, is_bitfield_ptr));
+            weak_from_this(),
+            GetObjCFieldAtIndex(&getASTContext(), class_interface_decl, idx,
+                                name, bit_offset_ptr, bitfield_bit_size_ptr,
+                                is_bitfield_ptr));
       }
     }
     break;
@@ -5788,9 +5797,10 @@ CompilerType TypeSystemClang::GetFieldAtIndex(lldb::opaque_compiler_type_t type,
         clang::ObjCInterfaceDecl *class_interface_decl =
             objc_class_type->getInterface();
         return CompilerType(
-            this, GetObjCFieldAtIndex(&getASTContext(), class_interface_decl,
-                                      idx, name, bit_offset_ptr,
-                                      bitfield_bit_size_ptr, is_bitfield_ptr));
+            weak_from_this(),
+            GetObjCFieldAtIndex(&getASTContext(), class_interface_decl, idx,
+                                name, bit_offset_ptr, bitfield_bit_size_ptr,
+                                is_bitfield_ptr));
       }
     }
     break;
@@ -7274,7 +7284,7 @@ TypeSystemClang::GetIntegralTemplateArgument(lldb::opaque_compiler_type_t type,
 
 CompilerType TypeSystemClang::GetTypeForFormatters(void *type) {
   if (type)
-    return ClangUtil::RemoveFastQualifiers(CompilerType(this, type));
+    return ClangUtil::RemoveFastQualifiers(CompilerType(weak_from_this(), type));
   return CompilerType();
 }
 
@@ -7328,8 +7338,8 @@ clang::FieldDecl *TypeSystemClang::AddFieldToRecordType(
     uint32_t bitfield_bit_size) {
   if (!type.IsValid() || !field_clang_type.IsValid())
     return nullptr;
-  TypeSystemClang *ast =
-      llvm::dyn_cast_or_null<TypeSystemClang>(type.GetTypeSystem());
+  auto ts = type.GetTypeSystem();
+  auto ast = ts.dyn_cast_or_null<TypeSystemClang>();
   if (!ast)
     return nullptr;
   clang::ASTContext &clang_ast = ast->getASTContext();
@@ -7422,7 +7432,8 @@ void TypeSystemClang::BuildIndirectFields(const CompilerType &type) {
   if (!type)
     return;
 
-  TypeSystemClang *ast = llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
+  auto ts = type.GetTypeSystem();
+  auto ast = ts.dyn_cast_or_null<TypeSystemClang>();
   if (!ast)
     return;
 
@@ -7528,8 +7539,8 @@ void TypeSystemClang::BuildIndirectFields(const CompilerType &type) {
 
 void TypeSystemClang::SetIsPacked(const CompilerType &type) {
   if (type) {
-    TypeSystemClang *ast =
-        llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
+    auto ts = type.GetTypeSystem();
+    auto ast = ts.dyn_cast_or_null<TypeSystemClang>();
     if (ast) {
       clang::RecordDecl *record_decl = GetAsRecordDecl(type);
 
@@ -7548,7 +7559,8 @@ clang::VarDecl *TypeSystemClang::AddVariableToRecordType(
   if (!type.IsValid() || !var_type.IsValid())
     return nullptr;
 
-  TypeSystemClang *ast = llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
+  auto ts = type.GetTypeSystem();
+  auto ast = ts.dyn_cast_or_null<TypeSystemClang>();
   if (!ast)
     return nullptr;
 
@@ -7848,8 +7860,8 @@ bool TypeSystemClang::TransferBaseClasses(
 
 bool TypeSystemClang::SetObjCSuperClass(
     const CompilerType &type, const CompilerType &superclass_clang_type) {
-  TypeSystemClang *ast =
-      llvm::dyn_cast_or_null<TypeSystemClang>(type.GetTypeSystem());
+  auto ts = type.GetTypeSystem();
+  auto ast = ts.dyn_cast_or_null<TypeSystemClang>();
   if (!ast)
     return false;
   clang::ASTContext &clang_ast = ast->getASTContext();
@@ -7877,7 +7889,8 @@ bool TypeSystemClang::AddObjCClassProperty(
   if (!type || !property_clang_type.IsValid() || property_name == nullptr ||
       property_name[0] == '\0')
     return false;
-  TypeSystemClang *ast = llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
+  auto ts = type.GetTypeSystem();
+  auto ast = ts.dyn_cast_or_null<TypeSystemClang>();
   if (!ast)
     return false;
   clang::ASTContext &clang_ast = ast->getASTContext();
@@ -8096,8 +8109,8 @@ clang::ObjCMethodDecl *TypeSystemClang::AddMethodToObjCObjectType(
 
   if (class_interface_decl == nullptr)
     return nullptr;
-  TypeSystemClang *lldb_ast =
-      llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
+  auto ts = type.GetTypeSystem();
+  auto lldb_ast = ts.dyn_cast_or_null<TypeSystemClang>();
   if (lldb_ast == nullptr)
     return nullptr;
   clang::ASTContext &ast = lldb_ast->getASTContext();
@@ -8300,8 +8313,8 @@ bool TypeSystemClang::CompleteTagDeclarationDefinition(
   if (qual_type.isNull())
     return false;
 
-  TypeSystemClang *lldb_ast =
-      llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
+  auto ts = type.GetTypeSystem();
+  auto lldb_ast = ts.dyn_cast_or_null<TypeSystemClang>();
   if (lldb_ast == nullptr)
     return false;
 
@@ -8385,7 +8398,8 @@ clang::EnumConstantDecl *TypeSystemClang::AddEnumerationValueToEnumerationType(
   if (!enum_type || ConstString(name).IsEmpty())
     return nullptr;
 
-  lldbassert(enum_type.GetTypeSystem() == static_cast<TypeSystem *>(this));
+  lldbassert(enum_type.GetTypeSystem().GetSharedPointer().get() ==
+             static_cast<TypeSystem *>(this));
 
   lldb::opaque_compiler_type_t enum_opaque_compiler_type =
       enum_type.GetOpaqueQualType();
@@ -8452,8 +8466,8 @@ TypeSystemClang::CreateMemberPointerType(const CompilerType &type,
                                          const CompilerType &pointee_type) {
   if (type && pointee_type.IsValid() &&
       type.GetTypeSystem() == pointee_type.GetTypeSystem()) {
-    TypeSystemClang *ast =
-        llvm::dyn_cast<TypeSystemClang>(type.GetTypeSystem());
+    auto ts = type.GetTypeSystem();
+    auto ast = ts.dyn_cast_or_null<TypeSystemClang>();
     if (!ast)
       return CompilerType();
     return ast->GetType(ast->getASTContext().getMemberPointerType(
@@ -9150,7 +9164,7 @@ void TypeSystemClang::DumpTypeDescription(lldb::opaque_compiler_type_t type,
   StreamFile s(stdout, false);
   DumpTypeDescription(type, &s, level);
 
-  CompilerType ct(this, type);
+  CompilerType ct(weak_from_this(), type);
   const clang::Type *clang_type = ClangUtil::GetQualType(ct).getTypePtr();
   ClangASTMetadata *metadata = GetMetadata(clang_type);
   if (metadata) {
@@ -9857,13 +9871,16 @@ ScratchTypeSystemClang::GetForTarget(Target &target,
                    "Couldn't get scratch TypeSystemClang");
     return nullptr;
   }
-  ScratchTypeSystemClang &scratch_ast =
-      llvm::cast<ScratchTypeSystemClang>(type_system_or_err.get());
+  auto ts = *type_system_or_err;
+  ScratchTypeSystemClang *scratch_ast =
+      llvm::dyn_cast_or_null<ScratchTypeSystemClang>(ts.get());
+  if (!scratch_ast)
+    return nullptr;
   // If no dedicated sub-AST was requested, just return the main AST.
   if (ast_kind == DefaultAST)
-    return &scratch_ast;
+    return scratch_ast;
   // Search the sub-ASTs.
-  return &scratch_ast.GetIsolatedAST(*ast_kind);
+  return &scratch_ast->GetIsolatedAST(*ast_kind);
 }
 
 /// Returns a human-readable name that uniquely identifiers the sub-AST kind.
@@ -9976,9 +9993,9 @@ TypeSystemClang &ScratchTypeSystemClang::GetIsolatedAST(
     return *found_ast->second;
 
   // Couldn't find the requested sub-AST, so create it now.
-  std::unique_ptr<TypeSystemClang> new_ast;
-  new_ast.reset(new SpecializedScratchAST(GetSpecializedASTName(feature),
-                                          m_triple, CreateASTSource()));
-  m_isolated_asts[feature] = std::move(new_ast);
-  return *m_isolated_asts[feature];
+  std::shared_ptr<TypeSystemClang> new_ast_sp =
+      std::make_shared<SpecializedScratchAST>(GetSpecializedASTName(feature),
+                                              m_triple, CreateASTSource());
+  m_isolated_asts.insert({feature, new_ast_sp});
+  return *new_ast_sp;
 }

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -13,7 +13,6 @@
 
 #include <functional>
 #include <initializer_list>
-#include <map>
 #include <memory>
 #include <set>
 #include <string>
@@ -242,7 +241,7 @@ public:
     // Check that the type actually belongs to this TypeSystemClang.
     assert(qt->getAsTagDecl() == nullptr ||
            &qt->getAsTagDecl()->getASTContext() == &getASTContext());
-    return CompilerType(this, qt.getAsOpaquePtr());
+    return CompilerType(weak_from_this(), qt.getAsOpaquePtr());
   }
 
   CompilerType GetTypeForDecl(clang::NamedDecl *decl);
@@ -272,9 +271,10 @@ public:
         clang::NamedDecl *named_decl = *result.begin();
         if (const RecordDeclType *record_decl =
                 llvm::dyn_cast<RecordDeclType>(named_decl))
-          compiler_type.SetCompilerType(
-              this, clang::QualType(record_decl->getTypeForDecl(), 0)
-                        .getAsOpaquePtr());
+          compiler_type =
+              CompilerType(weak_from_this(),
+                           clang::QualType(record_decl->getTypeForDecl(), 0)
+                               .getAsOpaquePtr());
       }
     }
 
@@ -1242,7 +1242,7 @@ private:
   /// Map from IsolatedASTKind to their actual TypeSystemClang instance.
   /// This map is lazily filled with sub-ASTs and should be accessed via
   /// `GetSubAST` (which lazily fills this map).
-  std::unordered_map<IsolatedASTKey, std::unique_ptr<TypeSystemClang>>
+  llvm::DenseMap<IsolatedASTKey, std::shared_ptr<TypeSystemClang>>
       m_isolated_asts;
 };
 

--- a/lldb/source/Plugins/TypeSystem/Swift/DWARFImporterDelegate.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/DWARFImporterDelegate.cpp
@@ -239,7 +239,9 @@ public:
           llvm::consumeError(ts.takeError());
           continue;
         }
-        auto *swift_ts = static_cast<TypeSystemSwift *>(&*ts);
+        auto swift_ts = llvm::dyn_cast_or_null<TypeSystemSwift>(ts->get());
+        if (!swift_ts)
+          continue;
         clang_type_sp = swift_ts->GetTypeSystemSwiftTypeRef().LookupClangType(name);
         if (clang_type_sp)
           break;
@@ -257,8 +259,8 @@ public:
     CompilerType compiler_type = clang_type_sp->GetFullCompilerType();
 
     // Filter our non-Clang types.
-    auto *type_system =
-        llvm::dyn_cast_or_null<TypeSystemClang>(compiler_type.GetTypeSystem());
+    auto type_system =
+        compiler_type.GetTypeSystem().dyn_cast_or_null<TypeSystemClang>();
     if (!type_system)
       return;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -198,7 +198,7 @@ CompilerType lldb_private::ToCompilerType(swift::Type qual_type) {
     LOG_PRINTF(GetLog(LLDBLog::Types), "dropped orphaned AST type");
     return {};
   }
-  return {ast_ctx, qual_type.getPointer()};
+  return {ast_ctx->weak_from_this(), qual_type.getPointer()};
 }
 
 TypePayloadSwift::TypePayloadSwift(bool is_fixed_value_buffer) {
@@ -210,12 +210,12 @@ CompilerType SwiftASTContext::GetCompilerType(ConstString mangled_name) {
 }
 
 CompilerType SwiftASTContext::GetCompilerType(swift::TypeBase *swift_type) {
-  return {this, swift_type};
+  return {weak_from_this(), swift_type};
 }
 
 swift::Type TypeSystemSwiftTypeRef::GetSwiftType(CompilerType compiler_type) {
-  auto *ts = llvm::dyn_cast_or_null<TypeSystemSwiftTypeRef>(
-      compiler_type.GetTypeSystem());
+  auto ts =
+      compiler_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwiftTypeRef>();
   if (!ts)
     return {};
 
@@ -228,7 +228,7 @@ swift::Type TypeSystemSwiftTypeRef::GetSwiftType(CompilerType compiler_type) {
 }
 
 swift::Type SwiftASTContext::GetSwiftType(CompilerType compiler_type) {
-  if (llvm::dyn_cast_or_null<SwiftASTContext>(compiler_type.GetTypeSystem()))
+  if (compiler_type.GetTypeSystem().isa_and_nonnull<SwiftASTContext>())
     return reinterpret_cast<swift::TypeBase *>(
         compiler_type.GetOpaqueQualType());
   return {};
@@ -237,20 +237,21 @@ swift::Type SwiftASTContext::GetSwiftType(CompilerType compiler_type) {
 swift::Type SwiftASTContext::GetSwiftType(opaque_compiler_type_t opaque_type) {
   assert(opaque_type && *reinterpret_cast<const char *>(opaque_type) != '$' &&
          "wrong type system");
-  return lldb_private::GetSwiftType(CompilerType(this, opaque_type));
+  return lldb_private::GetSwiftType(CompilerType(weak_from_this(), opaque_type));
 }
 
 swift::CanType
 SwiftASTContext::GetCanonicalSwiftType(opaque_compiler_type_t opaque_type) {
   assert(!opaque_type || *reinterpret_cast<const char *>(opaque_type) != '$' &&
          "wrong type system");
-  return lldb_private::GetCanonicalSwiftType(CompilerType(this, opaque_type));
+  return lldb_private::GetCanonicalSwiftType(
+      CompilerType(weak_from_this(), opaque_type));
 }
 
 ConstString SwiftASTContext::GetMangledTypeName(opaque_compiler_type_t type) {
   VALID_OR_RETURN_CHECK_TYPE(
       type, ConstString("<invalid Swift context or opaque type>"));
-  return GetMangledTypeName(GetSwiftType({this, type}).getPointer());
+  return GetMangledTypeName(GetSwiftType({weak_from_this(), type}).getPointer());
 }
 
 typedef lldb_private::ThreadSafeDenseMap<swift::ASTContext *, SwiftASTContext *>
@@ -1689,7 +1690,7 @@ static SwiftASTContext *GetModuleSwiftASTContext(Module &module) {
     llvm::consumeError(type_system_or_err.takeError());
     return {};
   }
-  auto *ts = static_cast<TypeSystemSwift *>(&*type_system_or_err);
+  auto *ts = llvm::dyn_cast_or_null<TypeSystemSwift>(type_system_or_err->get());
   if (!ts)
     return {};
   return ts->GetSwiftASTContext();
@@ -1847,7 +1848,8 @@ ProcessModule(ModuleSP module_sp, std::string m_description,
       llvm::consumeError(type_system_or_err.takeError());
       return;
     }
-    auto ts = llvm::dyn_cast_or_null<TypeSystemSwift>(&*type_system_or_err);
+    auto ts =
+        llvm::dyn_cast_or_null<TypeSystemSwift>(type_system_or_err->get());
     if (!ts)
       return;
 
@@ -3937,22 +3939,22 @@ CompilerType SwiftASTContext::GetAsClangType(ConstString mangled_name) {
   }
 
   auto *clang_ctx =
-      llvm::dyn_cast_or_null<TypeSystemClang>(&*type_system_or_err);
+      llvm::dyn_cast_or_null<TypeSystemClang>(type_system_or_err->get());
   if (!clang_ctx)
     return {};
   DWARFASTParserClang *clang_ast_parser =
       static_cast<DWARFASTParserClang *>(clang_ctx->GetDWARFParser());
   CompilerType clang_type;
   CompilerType imported_type = GetCompilerType(mangled_name);
-  if (auto *ts = llvm::dyn_cast_or_null<TypeSystemSwift>(
-          imported_type.GetTypeSystem()))
+  if (auto ts =
+          imported_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>())
     ts->IsImportedType(imported_type.GetOpaqueQualType(), &clang_type);
 
   // Import the Clang type into the Clang context.
   if (!clang_type)
     return {};
 
-  if (clang_type.GetTypeSystem() != clang_ctx)
+  if (clang_type.GetTypeSystem().GetSharedPointer().get() != clang_ctx)
     clang_type = clang_ast_parser->GetClangASTImporter().CopyType(*clang_ctx,
                                                                   clang_type);
   // Swift doesn't know pointers. Convert top-level
@@ -4037,8 +4039,8 @@ swift::TypeBase *SwiftASTContext::ReconstructType(ConstString mangled_typename,
     if (!clang_type)
       break;
 
-    auto *clang_ctx =
-        llvm::dyn_cast_or_null<TypeSystemClang>(clang_type.GetTypeSystem());
+    auto clang_ctx =
+        clang_type.GetTypeSystem().dyn_cast_or_null<TypeSystemClang>();
     if (!clang_ctx)
       break;
     auto *interface_decl = TypeSystemClang::GetAsObjCInterfaceDecl(clang_type);
@@ -4067,7 +4069,7 @@ swift::TypeBase *SwiftASTContext::ReconstructType(ConstString mangled_typename,
     // the mapping isn't bijective.
     if (ast_type == found_type)
       CacheDemangledType(mangled_typename, ast_type);
-    CompilerType result_type = {this, ast_type};//ToCompilerType(ast_type);
+    CompilerType result_type = {weak_from_this(), ast_type};//ToCompilerType(ast_type);
     LOG_PRINTF(GetLog(LLDBLog::Types), "(\"%s\") -- found %s", mangled_cstr,
                result_type.GetTypeName().GetCString());
     return ast_type;
@@ -4207,8 +4209,8 @@ SwiftASTContext::FindContainedTypeOrDecl(llvm::StringRef name,
         return DeclToType(decl, GetASTContext());
       });
 
-  if (false == name.empty() &&
-      llvm::dyn_cast_or_null<TypeSystemSwift>(container_type.GetTypeSystem())) {
+  if (!name.empty() &&
+      container_type.GetTypeSystem().isa_and_nonnull<TypeSystemSwift>()) {
     swift::Type swift_type = GetSwiftType(container_type);
     if (!swift_type)
       return 0;
@@ -4363,13 +4365,13 @@ CompilerType SwiftASTContext::ImportType(CompilerType &type, Status &error) {
   if (m_ast_context_ap.get() == NULL)
     return CompilerType();
 
-  auto *ts = type.GetTypeSystem();
-  SwiftASTContext *swift_ast_ctx = llvm::dyn_cast_or_null<SwiftASTContext>(ts);
+  auto ts = type.GetTypeSystem();
+  auto swift_ast_ctx = ts.dyn_cast_or_null<SwiftASTContext>();
 
-  if (swift_ast_ctx == nullptr && (!ts || !llvm::isa<TypeSystemSwift>(ts))) {
+  if (!swift_ast_ctx && (!ts || !ts.isa_and_nonnull<TypeSystemSwift>())) {
     error.SetErrorString("Can't import clang type into a Swift ASTContext.");
     return CompilerType();
-  } else if (swift_ast_ctx == this) {
+  } else if (swift_ast_ctx.get() == this) {
     // This is the same AST context, so the type is already imported.
     return type;
   }
@@ -4381,7 +4383,7 @@ CompilerType SwiftASTContext::ImportType(CompilerType &type, Status &error) {
   ConstString mangled_name(type.GetMangledTypeName());
   if (!mangled_name)
     return {};
-  if (llvm::isa<TypeSystemSwiftTypeRef>(ts))
+  if (ts.isa_and_nonnull<TypeSystemSwiftTypeRef>())
     return GetTypeSystemSwiftTypeRef().GetTypeFromMangledTypename(mangled_name);
   swift::TypeBase *our_type_base =
       m_mangled_name_to_type_map.lookup(mangled_name.GetCString());
@@ -4907,7 +4909,7 @@ SwiftASTContext::GetFunctionArgumentAtIndex(opaque_compiler_type_t type,
     auto params = func.getParams();
     if (index < params.size()) {
       auto param = params[index];
-      return {this, param.getParameterType().getPointer()};
+      return {weak_from_this(), param.getParameterType().getPointer()};
     }
   }
   return {};
@@ -5047,7 +5049,7 @@ BindGenericTypeParameters(CompilerType type, ExecutionContextScope *exe_scope) {
 bool SwiftASTContext::IsErrorType(opaque_compiler_type_t type) {
   VALID_OR_RETURN_CHECK_TYPE(type, false);
   ProtocolInfo protocol_info;
-  if (GetProtocolTypeInfo({this, type}, protocol_info))
+  if (GetProtocolTypeInfo({weak_from_this(), type}, protocol_info))
     return protocol_info.m_is_errortype;
   return false;
 }
@@ -5060,7 +5062,7 @@ CompilerType SwiftASTContext::GetReferentType(opaque_compiler_type_t type) {
     return {};
   swift::TypeBase *swift_typebase = swift_type.getPointer();
   if (swift_type && llvm::isa<swift::WeakStorageType>(swift_typebase))
-    return {this, type};
+    return {weak_from_this(), type};
 
   auto ref_type = swift_type->getReferenceStorageReferent();
   return ToCompilerType({ref_type});
@@ -5638,7 +5640,7 @@ CompilerType SwiftASTContext::GetPointeeType(opaque_compiler_type_t type) {
 CompilerType SwiftASTContext::GetPointerType(opaque_compiler_type_t type) {
   VALID_OR_RETURN_CHECK_TYPE(type, CompilerType());
 
-  auto swift_type = GetSwiftType({this, type});
+  auto swift_type = GetSwiftType({weak_from_this(), type});
   auto pointer_type =
       swift_type->wrapInPointer(swift::PointerTypeKind::PTK_UnsafePointer);
   if (pointer_type)
@@ -5650,7 +5652,7 @@ CompilerType SwiftASTContext::GetPointerType(opaque_compiler_type_t type) {
 CompilerType SwiftASTContext::GetTypedefedType(opaque_compiler_type_t type) {
   VALID_OR_RETURN_CHECK_TYPE(type, CompilerType());
 
-  swift::Type swift_type(GetSwiftType({this, type}));
+  swift::Type swift_type(GetSwiftType({weak_from_this(), type}));
   swift::TypeAliasType *name_alias_type =
       swift::dyn_cast<swift::TypeAliasType>(swift_type.getPointer());
   if (name_alias_type) {
@@ -5724,7 +5726,7 @@ SwiftASTContext::GetBitSize(opaque_compiler_type_t type,
     ExecutionContext exe_ctx;
     exe_scope->CalculateExecutionContext(exe_ctx);
     auto swift_scratch_ctx_lock = SwiftScratchContextLock(&exe_ctx);
-    CompilerType bound_type = BindGenericTypeParameters({this, type}, exe_scope);
+    CompilerType bound_type = BindGenericTypeParameters({weak_from_this(), type}, exe_scope);
 
     // Check that the type has been bound successfully -- and if not,
     // log the event and bail out to avoid an infinite loop.
@@ -5756,7 +5758,7 @@ SwiftASTContext::GetBitSize(opaque_compiler_type_t type,
   if (!exe_scope)
     return {};
   if (auto *runtime = SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
-    return runtime->GetBitSize({this, type}, exe_scope);
+    return runtime->GetBitSize({weak_from_this(), type}, exe_scope);
   return {};
 }
 
@@ -5774,7 +5776,7 @@ SwiftASTContext::GetByteStride(opaque_compiler_type_t type,
     ExecutionContext exe_ctx;
     exe_scope->CalculateExecutionContext(exe_ctx);
     auto swift_scratch_ctx_lock = SwiftScratchContextLock(&exe_ctx);
-    CompilerType bound_type = BindGenericTypeParameters({this, type}, exe_scope);
+    CompilerType bound_type = BindGenericTypeParameters({weak_from_this(), type}, exe_scope);
 
     // Check that the type has been bound successfully -- and if not,
     // log the event and bail out to avoid an infinite loop.
@@ -5799,7 +5801,7 @@ SwiftASTContext::GetByteStride(opaque_compiler_type_t type,
   if (!exe_scope)
     return {};
   if (auto *runtime = SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
-    return runtime->GetByteStride({this, type});
+    return runtime->GetByteStride({weak_from_this(), type});
   return {};
 }
 
@@ -5817,7 +5819,7 @@ SwiftASTContext::GetTypeBitAlign(opaque_compiler_type_t type,
     ExecutionContext exe_ctx;
     exe_scope->CalculateExecutionContext(exe_ctx);
     auto swift_scratch_ctx_lock = SwiftScratchContextLock(&exe_ctx);
-    CompilerType bound_type = BindGenericTypeParameters({this, type}, exe_scope);
+    CompilerType bound_type = BindGenericTypeParameters({weak_from_this(), type}, exe_scope);
 
     // Check that the type has been bound successfully -- and if not,
     // log the event and bail out to avoid an infinite loop.
@@ -5841,7 +5843,7 @@ SwiftASTContext::GetTypeBitAlign(opaque_compiler_type_t type,
   if (!exe_scope)
     return {};
   if (auto *runtime = SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
-    return runtime->GetBitAlignment({this, type}, exe_scope);
+    return runtime->GetBitAlignment({weak_from_this(), type}, exe_scope);
   return {};
 }
 
@@ -7321,15 +7323,17 @@ CompilerType
 SwiftASTContext::GetTypeForFormatters(opaque_compiler_type_t type) {
   VALID_OR_RETURN_CHECK_TYPE(type, CompilerType());
 
-  return {this, type};
+  return {weak_from_this(), type};
 }
 
 LazyBool SwiftASTContext::ShouldPrintAsOneLiner(opaque_compiler_type_t type,
                                                 ValueObject *valobj) {
   if (type) {
     CompilerType can_compiler_type(GetCanonicalType(type));
-    auto *ts = llvm::cast<TypeSystemSwift>(can_compiler_type.GetTypeSystem());
-    if (ts->IsImportedType(can_compiler_type.GetOpaqueQualType(), nullptr))
+    auto ts =
+        can_compiler_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
+    if (ts &&
+        ts->IsImportedType(can_compiler_type.GetOpaqueQualType(), nullptr))
       return eLazyBoolNo;
   }
   if (valobj) {
@@ -7575,14 +7579,16 @@ bool SwiftASTContext::IsImportedType(opaque_compiler_type_t type,
                 llvm::dyn_cast<clang::ObjCInterfaceDecl>(clang_decl)) {
           *original_type =
               CompilerType(TypeSystemClang::GetASTContext(
-                               &objc_interface_decl->getASTContext()),
+                               &objc_interface_decl->getASTContext())
+                               ->weak_from_this(),
                            clang::QualType::getFromOpaquePtr(
                                objc_interface_decl->getTypeForDecl())
                                .getAsOpaquePtr());
         } else if (const clang::TypeDecl *type_decl =
                        llvm::dyn_cast<clang::TypeDecl>(clang_decl)) {
           *original_type = CompilerType(
-              TypeSystemClang::GetASTContext(&type_decl->getASTContext()),
+              TypeSystemClang::GetASTContext(&type_decl->getASTContext())
+                  ->weak_from_this(),
               clang::QualType::getFromOpaquePtr(type_decl->getTypeForDecl())
                   .getAsOpaquePtr());
         } else {

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -30,26 +30,30 @@ using namespace lldb_private;
 
 bool CompilerType::IsAggregateType() const {
   if (IsValid())
-    return m_type_system->IsAggregateType(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsAggregateType(m_type);
   return false;
 }
 
 bool CompilerType::IsAnonymousType() const {
   if (IsValid())
-    return m_type_system->IsAnonymousType(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsAnonymousType(m_type);
   return false;
 }
 
 bool CompilerType::IsScopedEnumerationType() const {
   if (IsValid())
-    return m_type_system->IsScopedEnumerationType(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsScopedEnumerationType(m_type);
   return false;
 }
 
 bool CompilerType::IsArrayType(CompilerType *element_type_ptr, uint64_t *size,
                                bool *is_incomplete) const {
   if (IsValid())
-    return m_type_system->IsArrayType(m_type, element_type_ptr, size,
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsArrayType(m_type, element_type_ptr, size,
                                       is_incomplete);
 
   if (element_type_ptr)
@@ -64,43 +68,50 @@ bool CompilerType::IsArrayType(CompilerType *element_type_ptr, uint64_t *size,
 bool CompilerType::IsVectorType(CompilerType *element_type,
                                 uint64_t *size) const {
   if (IsValid())
-    return m_type_system->IsVectorType(m_type, element_type, size);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsVectorType(m_type, element_type, size);
   return false;
 }
 
 bool CompilerType::IsRuntimeGeneratedType() const {
   if (IsValid())
-    return m_type_system->IsRuntimeGeneratedType(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsRuntimeGeneratedType(m_type);
   return false;
 }
 
 bool CompilerType::IsCharType() const {
   if (IsValid())
-    return m_type_system->IsCharType(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsCharType(m_type);
   return false;
 }
 
 bool CompilerType::IsCompleteType() const {
   if (IsValid())
-    return m_type_system->IsCompleteType(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsCompleteType(m_type);
   return false;
 }
 
 bool CompilerType::IsConst() const {
   if (IsValid())
-    return m_type_system->IsConst(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsConst(m_type);
   return false;
 }
 
 bool CompilerType::IsCStringType(uint32_t &length) const {
   if (IsValid())
-    return m_type_system->IsCStringType(m_type, length);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsCStringType(m_type, length);
   return false;
 }
 
 bool CompilerType::IsFunctionType() const {
   if (IsValid())
-    return m_type_system->IsFunctionType(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsFunctionType(m_type);
   return false;
 }
 
@@ -108,45 +119,52 @@ bool CompilerType::IsFunctionType() const {
 uint32_t
 CompilerType::IsHomogeneousAggregate(CompilerType *base_type_ptr) const {
   if (IsValid())
-    return m_type_system->IsHomogeneousAggregate(m_type, base_type_ptr);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsHomogeneousAggregate(m_type, base_type_ptr);
   return 0;
 }
 
 size_t CompilerType::GetNumberOfFunctionArguments() const {
   if (IsValid())
-    return m_type_system->GetNumberOfFunctionArguments(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetNumberOfFunctionArguments(m_type);
   return 0;
 }
 
 CompilerType
 CompilerType::GetFunctionArgumentAtIndex(const size_t index) const {
   if (IsValid())
-    return m_type_system->GetFunctionArgumentAtIndex(m_type, index);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetFunctionArgumentAtIndex(m_type, index);
   return CompilerType();
 }
 
 bool CompilerType::IsFunctionPointerType() const {
   if (IsValid())
-    return m_type_system->IsFunctionPointerType(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsFunctionPointerType(m_type);
   return false;
 }
 
 bool CompilerType::IsBlockPointerType(
     CompilerType *function_pointer_type_ptr) const {
   if (IsValid())
-    return m_type_system->IsBlockPointerType(m_type, function_pointer_type_ptr);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsBlockPointerType(m_type, function_pointer_type_ptr);
   return false;
 }
 
 bool CompilerType::IsIntegerType(bool &is_signed) const {
   if (IsValid())
-    return m_type_system->IsIntegerType(m_type, is_signed);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsIntegerType(m_type, is_signed);
   return false;
 }
 
 bool CompilerType::IsEnumerationType(bool &is_signed) const {
   if (IsValid())
-    return m_type_system->IsEnumerationType(m_type, is_signed);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsEnumerationType(m_type, is_signed);
   return false;
 }
 
@@ -156,7 +174,8 @@ bool CompilerType::IsIntegerOrEnumerationType(bool &is_signed) const {
 
 bool CompilerType::IsPointerType(CompilerType *pointee_type) const {
   if (IsValid()) {
-    return m_type_system->IsPointerType(m_type, pointee_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsPointerType(m_type, pointee_type);
   }
   if (pointee_type)
     pointee_type->Clear();
@@ -165,7 +184,8 @@ bool CompilerType::IsPointerType(CompilerType *pointee_type) const {
 
 bool CompilerType::IsPointerOrReferenceType(CompilerType *pointee_type) const {
   if (IsValid()) {
-    return m_type_system->IsPointerOrReferenceType(m_type, pointee_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsPointerOrReferenceType(m_type, pointee_type);
   }
   if (pointee_type)
     pointee_type->Clear();
@@ -175,7 +195,8 @@ bool CompilerType::IsPointerOrReferenceType(CompilerType *pointee_type) const {
 bool CompilerType::IsReferenceType(CompilerType *pointee_type,
                                    bool *is_rvalue) const {
   if (IsValid()) {
-    return m_type_system->IsReferenceType(m_type, pointee_type, is_rvalue);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsReferenceType(m_type, pointee_type, is_rvalue);
   }
   if (pointee_type)
     pointee_type->Clear();
@@ -184,14 +205,16 @@ bool CompilerType::IsReferenceType(CompilerType *pointee_type,
 
 bool CompilerType::ShouldTreatScalarValueAsAddress() const {
   if (IsValid())
-    return m_type_system->ShouldTreatScalarValueAsAddress(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->ShouldTreatScalarValueAsAddress(m_type);
   return false;
 }
 
 bool CompilerType::IsFloatingPointType(uint32_t &count,
                                        bool &is_complex) const {
   if (IsValid()) {
-    return m_type_system->IsFloatingPointType(m_type, count, is_complex);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsFloatingPointType(m_type, count, is_complex);
   }
   count = 0;
   is_complex = false;
@@ -200,13 +223,15 @@ bool CompilerType::IsFloatingPointType(uint32_t &count,
 
 bool CompilerType::IsDefined() const {
   if (IsValid())
-    return m_type_system->IsDefined(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsDefined(m_type);
   return true;
 }
 
 bool CompilerType::IsPolymorphicClass() const {
   if (IsValid()) {
-    return m_type_system->IsPolymorphicClass(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsPolymorphicClass(m_type);
   }
   return false;
 }
@@ -215,28 +240,31 @@ bool CompilerType::IsPossibleDynamicType(CompilerType *dynamic_pointee_type,
                                          bool check_cplusplus,
                                          bool check_objc) const {
   if (IsValid())
-    return m_type_system->IsPossibleDynamicType(m_type, dynamic_pointee_type,
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsPossibleDynamicType(m_type, dynamic_pointee_type,
                                                 check_cplusplus, check_objc);
   return false;
 }
 
 bool CompilerType::IsScalarType() const {
-  if (!IsValid())
-    return false;
-
-  return m_type_system->IsScalarType(m_type);
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsScalarType(m_type);
+  return false;
 }
 
 bool CompilerType::IsTypedefType() const {
-  if (!IsValid())
-    return false;
-  return m_type_system->IsTypedefType(m_type);
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsTypedefType(m_type);
+  return false;
 }
 
 bool CompilerType::IsVoidType() const {
-  if (!IsValid())
-    return false;
-  return m_type_system->IsVoidType(m_type);
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsVoidType(m_type);
+  return false;
 }
 
 bool CompilerType::IsPointerToScalarType() const {
@@ -254,29 +282,32 @@ bool CompilerType::IsArrayOfScalarType() const {
 }
 
 bool CompilerType::IsBeingDefined() const {
-  if (!IsValid())
-    return false;
-  return m_type_system->IsBeingDefined(m_type);
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsBeingDefined(m_type);
+  return false;
 }
 
 // Type Completion
 
 bool CompilerType::GetCompleteType() const {
-  if (!IsValid())
-    return false;
-  return m_type_system->GetCompleteType(m_type);
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetCompleteType(m_type);
+  return false;
 }
 
 // AST related queries
 size_t CompilerType::GetPointerByteSize() const {
-  if (m_type_system)
-    return m_type_system->GetPointerByteSize();
+  if (auto type_system_sp = GetTypeSystem())
+    return type_system_sp->GetPointerByteSize();
   return 0;
 }
 
 ConstString CompilerType::GetTypeName() const {
   if (IsValid()) {
-    return m_type_system->GetTypeName(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetTypeName(m_type);
   }
   return ConstString("<invalid>");
 }
@@ -284,49 +315,59 @@ ConstString CompilerType::GetTypeName() const {
 ConstString
 CompilerType::GetDisplayTypeName(const SymbolContext *sc) const {
   if (IsValid()) {
-    return m_type_system->GetDisplayTypeName(m_type, sc);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetDisplayTypeName(m_type, sc);
   }
   return ConstString();
 }
 
 ConstString CompilerType::GetMangledTypeName() const {
   if (IsValid()) {
-    return m_type_system->GetMangledTypeName(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetMangledTypeName(m_type);
   }
   return ConstString();
 }
 
 uint32_t CompilerType::GetTypeInfo(
     CompilerType *pointee_or_element_compiler_type) const {
-  if (!IsValid())
-    return 0;
-
-  return m_type_system->GetTypeInfo(m_type, pointee_or_element_compiler_type);
+  if (IsValid())
+  if (auto type_system_sp = GetTypeSystem())
+    return type_system_sp->GetTypeInfo(m_type,
+                                       pointee_or_element_compiler_type);
+  return 0;
 }
 
 lldb::LanguageType CompilerType::GetMinimumLanguage() {
-  if (!IsValid())
-    return lldb::eLanguageTypeC;
-
-  return m_type_system->GetMinimumLanguage(m_type);
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetMinimumLanguage(m_type);
+  return lldb::eLanguageTypeC;
 }
 
 lldb::TypeClass CompilerType::GetTypeClass() const {
-  if (!IsValid())
-    return lldb::eTypeClassInvalid;
-
-  return m_type_system->GetTypeClass(m_type);
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetTypeClass(m_type);
+  return lldb::eTypeClassInvalid;
 }
 
-void CompilerType::SetCompilerType(TypeSystem *type_system,
+void CompilerType::SetCompilerType(lldb::TypeSystemWP type_system,
                                    lldb::opaque_compiler_type_t type) {
   m_type_system = type_system;
   m_type = type;
 }
 
+void CompilerType::SetCompilerType(CompilerType::TypeSystemSPWrapper type_system,
+                                   lldb::opaque_compiler_type_t type) {
+  m_type_system = type_system.GetSharedPointer();
+  m_type = type;
+}
+
 unsigned CompilerType::GetTypeQualifiers() const {
   if (IsValid())
-    return m_type_system->GetTypeQualifiers(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetTypeQualifiers(m_type);
   return 0;
 }
 
@@ -335,146 +376,160 @@ unsigned CompilerType::GetTypeQualifiers() const {
 CompilerType
 CompilerType::GetArrayElementType(ExecutionContextScope *exe_scope) const {
   if (IsValid()) {
-    return m_type_system->GetArrayElementType(m_type, exe_scope);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetArrayElementType(m_type, exe_scope);
   }
   return CompilerType();
 }
 
 CompilerType CompilerType::GetArrayType(uint64_t size) const {
   if (IsValid()) {
-    return m_type_system->GetArrayType(m_type, size);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetArrayType(m_type, size);
   }
   return CompilerType();
 }
 
 CompilerType CompilerType::GetCanonicalType() const {
   if (IsValid())
-    return m_type_system->GetCanonicalType(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetCanonicalType(m_type);
   return CompilerType();
 }
 
 CompilerType CompilerType::GetFullyUnqualifiedType() const {
   if (IsValid())
-    return m_type_system->GetFullyUnqualifiedType(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetFullyUnqualifiedType(m_type);
   return CompilerType();
 }
 
 CompilerType CompilerType::GetEnumerationIntegerType() const {
   if (IsValid())
-    return m_type_system->GetEnumerationIntegerType(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetEnumerationIntegerType(m_type);
   return CompilerType();
 }
 
 int CompilerType::GetFunctionArgumentCount() const {
   if (IsValid()) {
-    return m_type_system->GetFunctionArgumentCount(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetFunctionArgumentCount(m_type);
   }
   return -1;
 }
 
 CompilerType CompilerType::GetFunctionArgumentTypeAtIndex(size_t idx) const {
   if (IsValid()) {
-    return m_type_system->GetFunctionArgumentTypeAtIndex(m_type, idx);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetFunctionArgumentTypeAtIndex(m_type, idx);
   }
   return CompilerType();
 }
 
 CompilerType CompilerType::GetFunctionReturnType() const {
   if (IsValid()) {
-    return m_type_system->GetFunctionReturnType(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetFunctionReturnType(m_type);
   }
   return CompilerType();
 }
 
 size_t CompilerType::GetNumMemberFunctions() const {
   if (IsValid()) {
-    return m_type_system->GetNumMemberFunctions(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetNumMemberFunctions(m_type);
   }
   return 0;
 }
 
 TypeMemberFunctionImpl CompilerType::GetMemberFunctionAtIndex(size_t idx) {
   if (IsValid()) {
-    return m_type_system->GetMemberFunctionAtIndex(m_type, idx);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetMemberFunctionAtIndex(m_type, idx);
   }
   return TypeMemberFunctionImpl();
 }
 
 CompilerType CompilerType::GetNonReferenceType() const {
   if (IsValid())
-    return m_type_system->GetNonReferenceType(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetNonReferenceType(m_type);
   return CompilerType();
 }
 
 CompilerType CompilerType::GetPointeeType() const {
   if (IsValid()) {
-    return m_type_system->GetPointeeType(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetPointeeType(m_type);
   }
   return CompilerType();
 }
 
 CompilerType CompilerType::GetPointerType() const {
   if (IsValid()) {
-    return m_type_system->GetPointerType(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetPointerType(m_type);
   }
   return CompilerType();
 }
 
 CompilerType CompilerType::GetLValueReferenceType() const {
   if (IsValid())
-    return m_type_system->GetLValueReferenceType(m_type);
-  else
-    return CompilerType();
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetLValueReferenceType(m_type);
+  return CompilerType();
 }
 
 CompilerType CompilerType::GetRValueReferenceType() const {
   if (IsValid())
-    return m_type_system->GetRValueReferenceType(m_type);
-  else
-    return CompilerType();
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetRValueReferenceType(m_type);
+  return CompilerType();
 }
 
 CompilerType CompilerType::GetAtomicType() const {
   if (IsValid())
-    return m_type_system->GetAtomicType(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetAtomicType(m_type);
   return CompilerType();
 }
 
 CompilerType CompilerType::AddConstModifier() const {
   if (IsValid())
-    return m_type_system->AddConstModifier(m_type);
-  else
-    return CompilerType();
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->AddConstModifier(m_type);
+  return CompilerType();
 }
 
 CompilerType CompilerType::AddVolatileModifier() const {
   if (IsValid())
-    return m_type_system->AddVolatileModifier(m_type);
-  else
-    return CompilerType();
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->AddVolatileModifier(m_type);
+  return CompilerType();
 }
 
 CompilerType CompilerType::AddRestrictModifier() const {
   if (IsValid())
-    return m_type_system->AddRestrictModifier(m_type);
-  else
-    return CompilerType();
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->AddRestrictModifier(m_type);
+  return CompilerType();
 }
 
 CompilerType CompilerType::CreateTypedef(const char *name,
                                          const CompilerDeclContext &decl_ctx,
                                          uint32_t payload) const {
   if (IsValid())
-    return m_type_system->CreateTypedef(m_type, name, decl_ctx, payload);
-  else
-    return CompilerType();
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->CreateTypedef(m_type, name, decl_ctx, payload);
+  return CompilerType();
 }
 
 CompilerType CompilerType::GetTypedefedType() const {
   if (IsValid())
-    return m_type_system->GetTypedefedType(m_type);
-  else
-    return CompilerType();
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetTypedefedType(m_type);
+  return CompilerType();
 }
 
 // Create related types using the current type's AST
@@ -482,7 +537,8 @@ CompilerType CompilerType::GetTypedefedType() const {
 CompilerType
 CompilerType::GetBasicTypeFromAST(lldb::BasicType basic_type) const {
   if (IsValid())
-    return m_type_system->GetBasicTypeFromAST(basic_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetBasicTypeFromAST(basic_type);
   return CompilerType();
 }
 // Exploring the type
@@ -490,7 +546,8 @@ CompilerType::GetBasicTypeFromAST(lldb::BasicType basic_type) const {
 llvm::Optional<uint64_t>
 CompilerType::GetBitSize(ExecutionContextScope *exe_scope) const {
   if (IsValid())
-    return m_type_system->GetBitSize(m_type, exe_scope);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetBitSize(m_type, exe_scope);
   return {};
 }
 
@@ -504,41 +561,45 @@ CompilerType::GetByteSize(ExecutionContextScope *exe_scope) const {
 llvm::Optional<uint64_t>
 CompilerType::GetByteStride(ExecutionContextScope *exe_scope) const {
   if (IsValid())
-    return m_type_system->GetByteStride(m_type, exe_scope);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetByteStride(m_type, exe_scope);
   return {};
 }
 
 llvm::Optional<size_t> CompilerType::GetTypeBitAlign(ExecutionContextScope *exe_scope) const {
   if (IsValid())
-    return m_type_system->GetTypeBitAlign(m_type, exe_scope);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetTypeBitAlign(m_type, exe_scope);
   return {};
 }
 
 lldb::Encoding CompilerType::GetEncoding(uint64_t &count) const {
-  if (!IsValid())
-    return lldb::eEncodingInvalid;
-
-  return m_type_system->GetEncoding(m_type, count);
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetEncoding(m_type, count);
+  return lldb::eEncodingInvalid;
 }
 
 lldb::Format CompilerType::GetFormat() const {
-  if (!IsValid())
-    return lldb::eFormatDefault;
-
-  return m_type_system->GetFormat(m_type);
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetFormat(m_type);
+  return lldb::eFormatDefault;
 }
 
 uint32_t CompilerType::GetNumChildren(bool omit_empty_base_classes,
                                       const ExecutionContext *exe_ctx) const {
-  if (!IsValid())
-    return 0;
-  return m_type_system->GetNumChildren(m_type, omit_empty_base_classes,
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetNumChildren(m_type, omit_empty_base_classes,
                                        exe_ctx);
+  return 0;
 }
 
 lldb::BasicType CompilerType::GetBasicTypeEnumeration() const {
   if (IsValid())
-    return m_type_system->GetBasicTypeEnumeration(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetBasicTypeEnumeration(m_type);
   return eBasicTypeInvalid;
 }
 
@@ -547,34 +608,39 @@ void CompilerType::ForEachEnumerator(
                        ConstString name,
                        const llvm::APSInt &value)> const &callback) const {
   if (IsValid())
-    return m_type_system->ForEachEnumerator(m_type, callback);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->ForEachEnumerator(m_type, callback);
 }
 
 uint32_t CompilerType::GetNumFields(ExecutionContext *exe_ctx) const {
-  if (!IsValid())
-    return 0;
-  return m_type_system->GetNumFields(m_type, exe_ctx);
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetNumFields(m_type, exe_ctx);
+  return 0;
 }
 
 CompilerType CompilerType::GetFieldAtIndex(size_t idx, std::string &name,
                                            uint64_t *bit_offset_ptr,
                                            uint32_t *bitfield_bit_size_ptr,
                                            bool *is_bitfield_ptr) const {
-  if (!IsValid())
-    return CompilerType();
-  return m_type_system->GetFieldAtIndex(m_type, idx, name, bit_offset_ptr,
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetFieldAtIndex(m_type, idx, name, bit_offset_ptr,
                                         bitfield_bit_size_ptr, is_bitfield_ptr);
+  return CompilerType();
 }
 
 uint32_t CompilerType::GetNumDirectBaseClasses() const {
   if (IsValid())
-    return m_type_system->GetNumDirectBaseClasses(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetNumDirectBaseClasses(m_type);
   return 0;
 }
 
 uint32_t CompilerType::GetNumVirtualBaseClasses() const {
   if (IsValid())
-    return m_type_system->GetNumVirtualBaseClasses(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetNumVirtualBaseClasses(m_type);
   return 0;
 }
 
@@ -582,7 +648,8 @@ CompilerType
 CompilerType::GetDirectBaseClassAtIndex(size_t idx,
                                         uint32_t *bit_offset_ptr) const {
   if (IsValid())
-    return m_type_system->GetDirectBaseClassAtIndex(m_type, idx,
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetDirectBaseClassAtIndex(m_type, idx,
                                                     bit_offset_ptr);
   return CompilerType();
 }
@@ -591,7 +658,8 @@ CompilerType
 CompilerType::GetVirtualBaseClassAtIndex(size_t idx,
                                          uint32_t *bit_offset_ptr) const {
   if (IsValid())
-    return m_type_system->GetVirtualBaseClassAtIndex(m_type, idx,
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetVirtualBaseClassAtIndex(m_type, idx,
                                                      bit_offset_ptr);
   return CompilerType();
 }
@@ -623,13 +691,15 @@ CompilerType CompilerType::GetChildCompilerTypeAtIndex(
     uint32_t &child_bitfield_bit_offset, bool &child_is_base_class,
     bool &child_is_deref_of_parent, ValueObject *valobj,
     uint64_t &language_flags) const {
-  if (!IsValid())
-    return CompilerType();
-  return m_type_system->GetChildCompilerTypeAtIndex(
-      m_type, exe_ctx, idx, transparent_pointers, omit_empty_base_classes,
-      ignore_array_bounds, child_name, child_byte_size, child_byte_offset,
-      child_bitfield_bit_size, child_bitfield_bit_offset, child_is_base_class,
-      child_is_deref_of_parent, valobj, language_flags);
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetChildCompilerTypeAtIndex(
+          m_type, exe_ctx, idx, transparent_pointers, omit_empty_base_classes,
+          ignore_array_bounds, child_name, child_byte_size, child_byte_offset,
+          child_bitfield_bit_size, child_bitfield_bit_offset,
+          child_is_base_class, child_is_deref_of_parent, valobj,
+          language_flags);
+  return CompilerType();
 }
 
 // Look for a child member (doesn't include base classes, but it does include
@@ -669,7 +739,8 @@ size_t CompilerType::GetIndexOfChildMemberWithName(
     const char *name, ExecutionContext *exe_ctx, bool omit_empty_base_classes,
     std::vector<uint32_t> &child_indexes) const {
   if (IsValid() && name && name[0]) {
-    return m_type_system->GetIndexOfChildMemberWithName(
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetIndexOfChildMemberWithName(
         m_type, name, exe_ctx, omit_empty_base_classes, child_indexes);
   }
   return 0;
@@ -677,7 +748,8 @@ size_t CompilerType::GetIndexOfChildMemberWithName(
 
 size_t CompilerType::GetNumTemplateArguments(bool expand_pack) const {
   if (IsValid()) {
-    return m_type_system->GetNumTemplateArguments(m_type, expand_pack);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetNumTemplateArguments(m_type, expand_pack);
   }
   return 0;
 }
@@ -685,14 +757,16 @@ size_t CompilerType::GetNumTemplateArguments(bool expand_pack) const {
 TemplateArgumentKind
 CompilerType::GetTemplateArgumentKind(size_t idx, bool expand_pack) const {
   if (IsValid())
-    return m_type_system->GetTemplateArgumentKind(m_type, idx, expand_pack);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetTemplateArgumentKind(m_type, idx, expand_pack);
   return eTemplateArgumentKindNull;
 }
 
 CompilerType CompilerType::GetTypeTemplateArgument(size_t idx,
                                                    bool expand_pack) const {
   if (IsValid()) {
-    return m_type_system->GetTypeTemplateArgument(m_type, idx, expand_pack);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetTypeTemplateArgument(m_type, idx, expand_pack);
   }
   return CompilerType();
 }
@@ -700,25 +774,29 @@ CompilerType CompilerType::GetTypeTemplateArgument(size_t idx,
 llvm::Optional<CompilerType::IntegralTemplateArgument>
 CompilerType::GetIntegralTemplateArgument(size_t idx, bool expand_pack) const {
   if (IsValid())
-    return m_type_system->GetIntegralTemplateArgument(m_type, idx, expand_pack);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetIntegralTemplateArgument(m_type, idx, expand_pack);
   return llvm::None;
 }
 
 CompilerType CompilerType::GetTypeForFormatters() const {
   if (IsValid())
-    return m_type_system->GetTypeForFormatters(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetTypeForFormatters(m_type);
   return CompilerType();
 }
 
 LazyBool CompilerType::ShouldPrintAsOneLiner(ValueObject *valobj) const {
   if (IsValid())
-    return m_type_system->ShouldPrintAsOneLiner(m_type, valobj);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->ShouldPrintAsOneLiner(m_type, valobj);
   return eLazyBoolCalculate;
 }
 
 bool CompilerType::IsMeaninglessWithoutDynamicResolution() const {
   if (IsValid())
-    return m_type_system->IsMeaninglessWithoutDynamicResolution(m_type);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsMeaninglessWithoutDynamicResolution(m_type);
   return false;
 }
 
@@ -731,8 +809,9 @@ CompilerType::GetIndexOfChildWithName(const char *name,
                                       ExecutionContext *exe_ctx,
                                       bool omit_empty_base_classes) const {
   if (IsValid() && name && name[0]) {
-    return m_type_system->GetIndexOfChildWithName(m_type, name, exe_ctx,
-                                                  omit_empty_base_classes);
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetIndexOfChildWithName(m_type, name, exe_ctx,
+                                                     omit_empty_base_classes);
   }
   return UINT32_MAX;
 }
@@ -746,11 +825,11 @@ void CompilerType::DumpValue(ExecutionContext *exe_ctx, Stream *s,
                              uint32_t bitfield_bit_offset, bool show_types,
                              bool show_summary, bool verbose, uint32_t depth) {
   if (!IsValid())
-    return;
-  m_type_system->DumpValue(m_type, exe_ctx, s, format, data, data_byte_offset,
-                           data_byte_size, bitfield_bit_size,
-                           bitfield_bit_offset, show_types, show_summary,
-                           verbose, depth);
+    if (auto type_system_sp = GetTypeSystem())
+      type_system_sp->DumpValue(m_type, exe_ctx, s, format, data,
+                                data_byte_offset, data_byte_size,
+                                bitfield_bit_size, bitfield_bit_offset,
+                                show_types, show_summary, verbose, depth);
 }
 
 bool CompilerType::DumpTypeValue(Stream *s, lldb::Format format,
@@ -760,11 +839,12 @@ bool CompilerType::DumpTypeValue(Stream *s, lldb::Format format,
                                  uint32_t bitfield_bit_offset,
                                  ExecutionContextScope *exe_scope,
                                  bool is_base_class) {
-  if (!IsValid())
-    return false;
-  return m_type_system->DumpTypeValue(
-      m_type, s, format, data, byte_offset, byte_size, bitfield_bit_size,
-      bitfield_bit_offset, exe_scope, is_base_class);
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->DumpTypeValue(
+          m_type, s, format, data, byte_offset, byte_size, bitfield_bit_size,
+          bitfield_bit_offset, exe_scope, is_base_class);
+  return false;
 }
 
 void CompilerType::DumpSummary(ExecutionContext *exe_ctx, Stream *s,
@@ -772,29 +852,32 @@ void CompilerType::DumpSummary(ExecutionContext *exe_ctx, Stream *s,
                                lldb::offset_t data_byte_offset,
                                size_t data_byte_size) {
   if (IsValid())
-    m_type_system->DumpSummary(m_type, exe_ctx, s, data, data_byte_offset,
-                               data_byte_size);
+    if (auto type_system_sp = GetTypeSystem())
+      type_system_sp->DumpSummary(m_type, exe_ctx, s, data, data_byte_offset,
+                                  data_byte_size);
 }
 
 void CompilerType::DumpTypeDescription(lldb::DescriptionLevel level,
                                        ExecutionContextScope *exe_scope) const {
   if (IsValid())
-    m_type_system->DumpTypeDescription(m_type, level, exe_scope);
+    if (auto type_system_sp = GetTypeSystem())
+      type_system_sp->DumpTypeDescription(m_type, level, exe_scope);
 }
 
 void CompilerType::DumpTypeDescription(Stream *s, lldb::DescriptionLevel level,
                                        ExecutionContextScope *exe_scope) const {
-  if (IsValid()) {
-    m_type_system->DumpTypeDescription(m_type, s, level, exe_scope);
-  }
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      type_system_sp->DumpTypeDescription(m_type, level, exe_scope);
 }
+
 
 #ifndef NDEBUG
 LLVM_DUMP_METHOD void CompilerType::dump() const {
   if (IsValid())
-    m_type_system->dump(m_type);
-  else
-    llvm::errs() << "<invalid>\n";
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->dump(m_type);
+  llvm::errs() << "<invalid>\n";
 }
 #endif
 
@@ -901,9 +984,31 @@ bool CompilerType::GetValueAsScalar(const lldb_private::DataExtractor &data,
 
 #ifndef NDEBUG
 bool CompilerType::Verify() const {
-  return !IsValid() || m_type_system->Verify(m_type);
+  if (!IsValid())
+    return true;
+  if (auto type_system_sp = GetTypeSystem())
+    return type_system_sp->Verify(m_type);
+  return true;
 }
 #endif
+
+CompilerType::TypeSystemSPWrapper CompilerType::GetTypeSystem() const {
+  return {m_type_system.lock()};
+}
+
+bool CompilerType::TypeSystemSPWrapper::operator==(
+    const CompilerType::TypeSystemSPWrapper &other) const {
+  if (!m_typesystem_sp && !other.m_typesystem_sp)
+    return true;
+  if (m_typesystem_sp && other.m_typesystem_sp)
+    return m_typesystem_sp.get() == other.m_typesystem_sp.get();
+  return false;
+}
+
+TypeSystem *CompilerType::TypeSystemSPWrapper::operator->() const {
+  assert(m_typesystem_sp);
+  return m_typesystem_sp.get();
+}
 
 bool lldb_private::operator==(const lldb_private::CompilerType &lhs,
                               const lldb_private::CompilerType &rhs) {

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -868,7 +868,7 @@ void CompilerType::DumpTypeDescription(Stream *s, lldb::DescriptionLevel level,
                                        ExecutionContextScope *exe_scope) const {
   if (IsValid())
     if (auto type_system_sp = GetTypeSystem())
-      type_system_sp->DumpTypeDescription(m_type, level, exe_scope);
+      type_system_sp->DumpTypeDescription(m_type, s, level, exe_scope);
 }
 
 

--- a/lldb/source/Symbol/SymbolFile.cpp
+++ b/lldb/source/Symbol/SymbolFile.cpp
@@ -89,12 +89,12 @@ SymbolFile *SymbolFile::FindPlugin(ObjectFileSP objfile_sp) {
   return best_symfile_up.release();
 }
 
-llvm::Expected<TypeSystem &>
+llvm::Expected<lldb::TypeSystemSP>
 SymbolFile::GetTypeSystemForLanguage(lldb::LanguageType language) {
   auto type_system_or_err =
       m_objfile_sp->GetModule()->GetTypeSystemForLanguage(language);
-  if (type_system_or_err) {
-    type_system_or_err->SetSymbolFile(this);
+  if (auto ts = *type_system_or_err) {
+    ts->SetSymbolFile(this);
   }
   return type_system_or_err;
 }

--- a/lldb/source/Symbol/SymbolFile.cpp
+++ b/lldb/source/Symbol/SymbolFile.cpp
@@ -93,9 +93,10 @@ llvm::Expected<lldb::TypeSystemSP>
 SymbolFile::GetTypeSystemForLanguage(lldb::LanguageType language) {
   auto type_system_or_err =
       m_objfile_sp->GetModule()->GetTypeSystemForLanguage(language);
-  if (auto ts = *type_system_or_err) {
-    ts->SetSymbolFile(this);
-  }
+  if (!type_system_or_err)
+    return type_system_or_err.takeError();
+  auto ts = *type_system_or_err;
+  ts->SetSymbolFile(this);
   return type_system_or_err;
 }
 

--- a/lldb/source/Symbol/TypeSystem.cpp
+++ b/lldb/source/Symbol/TypeSystem.cpp
@@ -13,7 +13,7 @@
 #include "lldb/Target/Language.h"
 #include "lldb/Utility/Status.h"
 
-#include <set>
+#include "llvm/ADT/DenseSet.h"
 
 using namespace lldb_private;
 using namespace lldb;
@@ -38,20 +38,19 @@ bool LanguageSet::operator[](unsigned i) const { return bitvector[i]; }
 
 TypeSystem::~TypeSystem() = default;
 
-static lldb::TypeSystemSP CreateInstanceHelper(lldb::LanguageType language,
-                                               Module *module, Target *target,
-                                               const char *compiler_options) {
+static TypeSystemSP CreateInstanceHelper(lldb::LanguageType language,
+                                         Module *module, Target *target,
+                                         const char *compiler_options) {
   uint32_t i = 0;
   TypeSystemCreateInstance create_callback;
   while ((create_callback = PluginManager::GetTypeSystemCreateCallbackAtIndex(
               i++)) != nullptr) {
-    lldb::TypeSystemSP type_system_sp =
-        create_callback(language, module, target, compiler_options);
-    if (type_system_sp)
+    if (auto type_system_sp =
+        create_callback(language, module, target, compiler_options))
       return type_system_sp;
   }
 
-  return lldb::TypeSystemSP();
+  return {};
 }
 
 lldb::TypeSystemSP TypeSystem::CreateInstance(lldb::LanguageType language,
@@ -123,7 +122,7 @@ CompilerType TypeSystem::GetBuiltinTypeByName(ConstString name) {
 }
 
 CompilerType TypeSystem::GetTypeForFormatters(void *type) {
-  return CompilerType(this, type);
+  return CompilerType(weak_from_this(), type);
 }
 
 size_t TypeSystem::GetNumTemplateArguments(lldb::opaque_compiler_type_t type,
@@ -213,13 +212,13 @@ void TypeSystemMap::Clear() {
     map = m_map;
     m_clear_in_progress = true;
   }
-  std::set<TypeSystem *> visited;
-  for (auto pair : map) {
-    TypeSystem *type_system = pair.second.get();
-    if (type_system && !visited.count(type_system)) {
-      visited.insert(type_system);
+  llvm::DenseSet<TypeSystem *> visited;
+  for (auto &pair : map) {
+    if (visited.count(pair.second.get()))
+      continue;
+    visited.insert(pair.second.get());
+    if (lldb::TypeSystemSP type_system = pair.second)
       type_system->Finalize();
-    }
   }
   map.clear();
   {
@@ -229,22 +228,24 @@ void TypeSystemMap::Clear() {
   }
 }
 
-void TypeSystemMap::ForEach(std::function<bool(TypeSystem *)> const &callback) {
+void TypeSystemMap::ForEach(
+    std::function<bool(lldb::TypeSystemSP)> const &callback) {
   std::lock_guard<std::mutex> guard(m_mutex);
   // Use a std::set so we only call the callback once for each unique
-  // TypeSystem instance
-  std::set<TypeSystem *> visited;
-  for (auto pair : m_map) {
+  // TypeSystem instance.
+  llvm::DenseSet<TypeSystem *> visited;
+  for (auto &pair : m_map) {
     TypeSystem *type_system = pair.second.get();
-    if (type_system && !visited.count(type_system)) {
-      visited.insert(type_system);
-      if (!callback(type_system))
-        break;
-    }
+    if (!type_system || visited.count(type_system))
+      continue;
+    visited.insert(type_system);
+    assert(type_system);
+    if (!callback(pair.second))
+      break;
   }
 }
 
-llvm::Expected<TypeSystem &> TypeSystemMap::GetTypeSystemForLanguage(
+llvm::Expected<lldb::TypeSystemSP> TypeSystemMap::GetTypeSystemForLanguage(
     lldb::LanguageType language,
     llvm::Optional<CreateCallback> create_callback) {
   std::lock_guard<std::mutex> guard(m_mutex);
@@ -255,9 +256,10 @@ llvm::Expected<TypeSystem &> TypeSystemMap::GetTypeSystemForLanguage(
 
   collection::iterator pos = m_map.find(language);
   if (pos != m_map.end()) {
-    auto *type_system = pos->second.get();
-    if (type_system)
-      return *type_system;
+    if (pos->second) {
+      assert(!pos->second->weak_from_this().expired());
+      return pos->second;
+    }
     return llvm::make_error<llvm::StringError>(
         "TypeSystem for language " +
             llvm::StringRef(Language::GetNameForLanguageType(language)) +
@@ -270,8 +272,8 @@ llvm::Expected<TypeSystem &> TypeSystemMap::GetTypeSystemForLanguage(
       // Add a new mapping for "language" to point to an already existing
       // TypeSystem that supports this language
       m_map[language] = pair.second;
-      if (pair.second.get())
-        return *pair.second.get();
+      if (pair.second)
+        return pair.second;
       return llvm::make_error<llvm::StringError>(
           "TypeSystem for language " +
               llvm::StringRef(Language::GetNameForLanguageType(language)) +
@@ -287,11 +289,11 @@ llvm::Expected<TypeSystem &> TypeSystemMap::GetTypeSystemForLanguage(
         llvm::inconvertibleErrorCode());
 
   // Cache even if we get a shared pointer that contains a null type system
-  // back
+  // back.
   TypeSystemSP type_system_sp = (*create_callback)();
   m_map[language] = type_system_sp;
-  if (type_system_sp.get())
-    return *type_system_sp.get();
+  if (type_system_sp)
+    return type_system_sp;
   return llvm::make_error<llvm::StringError>(
       "TypeSystem for language " +
           llvm::StringRef(Language::GetNameForLanguageType(language)) +
@@ -299,7 +301,7 @@ llvm::Expected<TypeSystem &> TypeSystemMap::GetTypeSystemForLanguage(
       llvm::inconvertibleErrorCode());
 }
 
-llvm::Expected<TypeSystem &>
+llvm::Expected<lldb::TypeSystemSP>
 TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
                                         Module *module, bool can_create) {
   if (can_create) {
@@ -311,7 +313,7 @@ TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
   return GetTypeSystemForLanguage(language);
 }
 
-llvm::Expected<TypeSystem &>
+llvm::Expected<lldb::TypeSystemSP>
 TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
                                         Target *target, bool can_create) {
   if (can_create) {
@@ -324,7 +326,7 @@ TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
 }
 
 // BEGIN SWIFT
-llvm::Expected<TypeSystem &>
+llvm::Expected<TypeSystemSP>
 TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
                                         Target *target, bool can_create,
                                         const char *compiler_options) {

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -6242,8 +6242,11 @@ bool Process::CallVoidArgVoidPtrReturn(const Address *address,
     llvm::consumeError(type_system_or_err.takeError());
     return false;
   }
+  auto ts = *type_system_or_err;
+  if (!ts)
+    return false;
   CompilerType void_ptr_type =
-      type_system_or_err->GetBasicTypeFromAST(eBasicTypeVoid).GetPointerType();
+      ts->GetBasicTypeFromAST(eBasicTypeVoid).GetPointerType();
   lldb::ThreadPlanSP call_plan_sp(new ThreadPlanCallFunction(
       *thread, *address, void_ptr_type, llvm::ArrayRef<addr_t>(), options));
   if (call_plan_sp) {

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -1364,9 +1364,11 @@ lldb::ValueObjectSP StackFrame::GuessValueForAddress(lldb::addr_t addr) {
                          "Unable to guess value for given address");
           return ValueObjectSP();
         } else {
+          auto ts = *c_type_system_or_err;
+          if (!ts)
+            return {};
           CompilerType void_ptr_type =
-              c_type_system_or_err
-                  ->GetBasicTypeFromAST(lldb::BasicType::eBasicTypeChar)
+              ts->GetBasicTypeFromAST(lldb::BasicType::eBasicTypeChar)
                   .GetPointerType();
           return ValueObjectMemory::Create(this, "", addr, void_ptr_type);
         }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2499,7 +2499,8 @@ Target::GetScratchTypeSystems(bool create_on_demand) {
               return a.get() <= b.get();
             });
   scratch_type_systems.erase(
-      std::unique(scratch_type_systems.begin(), scratch_type_systems.end()));
+      std::unique(scratch_type_systems.begin(), scratch_type_systems.end()),
+      scratch_type_systems.end());
   return scratch_type_systems;
 }
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1669,11 +1669,11 @@ void Target::ModulesDidLoad(ModuleList &module_list) {
       m_process_sp->ModulesDidLoad(module_list);
     }
     // Notify all the ASTContext(s).
-    auto notify_callback = [&](TypeSystem *type_system) {
+    auto notify_callback = [&](lldb::TypeSystemSP type_system) {
 #ifdef LLDB_ENABLE_SWIFT
       auto *swift_scratch_ctx =
           llvm::dyn_cast_or_null<TypeSystemSwiftTypeRefForExpressions>(
-              type_system);
+              type_system.get());
       if (!swift_scratch_ctx)
         return true;
       auto *swift_ast_ctx =
@@ -1691,7 +1691,7 @@ void Target::ModulesDidLoad(ModuleList &module_list) {
     // it doens't matter in which order we notify the ASTContext(s).
     for (auto &language : m_scratch_typesystem_for_module) {
       TypeSystemSP type_system = language.second;
-      notify_callback(type_system.get());
+      notify_callback(type_system);
     }
 
     module_list.ClearModuleDependentCaches();
@@ -2333,7 +2333,7 @@ void Target::ImageSearchPathsChanged(const PathMappingList &path_list,
     target->SetExecutableModule(exe_module_sp, eLoadDependentsYes);
 }
 
-llvm::Expected<TypeSystem &>
+llvm::Expected<lldb::TypeSystemSP>
 Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
                                         bool create_on_demand,
                                         const char *compiler_options) {
@@ -2373,7 +2373,7 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
   if (language == eLanguageTypeSwift) {
     if (auto *swift_scratch_ctx =
             llvm::dyn_cast_or_null<TypeSystemSwiftTypeRefForExpressions>(
-                &*type_system_or_err)) {
+                type_system_or_err->get())) {
       auto *swift_ast_ctx =
           llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
               swift_scratch_ctx->GetSwiftASTContextOrNull());
@@ -2417,7 +2417,7 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
 
           if (auto *new_swift_scratch_ctx =
                   llvm::dyn_cast_or_null<TypeSystemSwiftTypeRefForExpressions>(
-                      &*type_system_or_err)) {
+                      type_system_or_err->get())) {
             auto *new_swift_ast_ctx =
                 new_swift_scratch_ctx->GetSwiftASTContext();
             if (!new_swift_ast_ctx || new_swift_ast_ctx->HasFatalErrors()) {
@@ -2468,14 +2468,15 @@ const TypeSystemMap &Target::GetTypeSystemMap() {
   return m_scratch_type_system_map;
 }
 
-std::vector<TypeSystem *> Target::GetScratchTypeSystems(bool create_on_demand) {
+std::vector<lldb::TypeSystemSP>
+Target::GetScratchTypeSystems(bool create_on_demand) {
   if (!m_valid)
     return {};
 
   // Some TypeSystem instances are associated with several LanguageTypes so
   // they will show up several times in the loop below. The SetVector filters
   // out all duplicates as they serve no use for the caller.
-  llvm::SetVector<TypeSystem *> scratch_type_systems;
+  std::vector<lldb::TypeSystemSP> scratch_type_systems;
 
   LanguageSet languages_for_expressions =
       Language::GetLanguagesSupportingTypeSystemsForExpressions();
@@ -2490,10 +2491,16 @@ std::vector<TypeSystem *> Target::GetScratchTypeSystems(bool create_on_demand) {
                      "system available",
                      Language::GetNameForLanguageType(language));
     else
-      scratch_type_systems.insert(&type_system_or_err.get());
+      if (auto ts = *type_system_or_err)
+        scratch_type_systems.push_back(ts);
   }
-
-  return scratch_type_systems.takeVector();
+  std::sort(scratch_type_systems.begin(), scratch_type_systems.end(),
+            [](lldb::TypeSystemSP a, lldb::TypeSystemSP b) {
+              return a.get() <= b.get();
+            });
+  scratch_type_systems.erase(
+      std::unique(scratch_type_systems.begin(), scratch_type_systems.end()));
+  return scratch_type_systems;
 }
 
 PersistentExpressionState *
@@ -2507,7 +2514,13 @@ Target::GetPersistentExpressionStateForLanguage(lldb::LanguageType language) {
     return nullptr;
   }
 
-  return type_system_or_err->GetPersistentExpressionState();
+  if (auto ts = *type_system_or_err)
+    return ts->GetPersistentExpressionState();
+
+  LLDB_LOG(GetLog(LLDBLog::Target),
+           "Unable to get persistent expression state for language {}",
+           Language::GetNameForLanguageType(language));
+  return nullptr;
 }
 
 #ifdef LLDB_ENABLE_SWIFT
@@ -2537,8 +2550,16 @@ UserExpression *Target::GetUserExpressionForLanguage(
     return nullptr;
   }
 
-  auto *user_expr = type_system_or_err->GetUserExpression(
-      expr, prefix, language, desired_type, options, ctx_obj);
+  auto ts = *type_system_or_err;
+  if (!ts) {
+    error.SetErrorStringWithFormat(
+        "Type system for language %s is no longer live",
+        Language::GetNameForLanguageType(language));
+    return nullptr;
+  }
+
+  auto *user_expr = ts->GetUserExpression(expr, prefix, language, desired_type,
+                                          options, ctx_obj);
   if (!user_expr)
     error.SetErrorStringWithFormat(
         "Could not create an expression for language %s",
@@ -2559,9 +2580,15 @@ FunctionCaller *Target::GetFunctionCallerForLanguage(
         llvm::toString(std::move(err)).c_str());
     return nullptr;
   }
-
-  auto *persistent_fn = type_system_or_err->GetFunctionCaller(
-      return_type, function_address, arg_value_list, name);
+  auto ts = *type_system_or_err;
+  if (!ts) {
+    error.SetErrorStringWithFormat(
+        "Type system for language %s is no longer live",
+        Language::GetNameForLanguageType(language));
+    return nullptr;
+  }
+  auto *persistent_fn = ts->GetFunctionCaller(return_type, function_address,
+                                              arg_value_list, name);
   if (!persistent_fn)
     error.SetErrorStringWithFormat(
         "Could not create an expression for language %s",
@@ -2577,10 +2604,15 @@ Target::CreateUtilityFunction(std::string expression, std::string name,
   auto type_system_or_err = GetScratchTypeSystemForLanguage(language);
   if (!type_system_or_err)
     return type_system_or_err.takeError();
-
+  auto ts = *type_system_or_err;
+  if (!ts)
+    return llvm::make_error<llvm::StringError>(
+        llvm::StringRef("Type system for language ") +
+            Language::GetNameForLanguageType(language) +
+            llvm::StringRef(" is no longer live"),
+        llvm::inconvertibleErrorCode());
   std::unique_ptr<UtilityFunction> utility_fn =
-      type_system_or_err->CreateUtilityFunction(std::move(expression),
-                                                std::move(name));
+      ts->CreateUtilityFunction(std::move(expression), std::move(name));
   if (!utility_fn)
     return llvm::make_error<llvm::StringError>(
         llvm::StringRef("Could not create an expression for language") +
@@ -2685,7 +2717,7 @@ llvm::Optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
 
     if (auto *global_scratch_ctx =
             llvm::cast_or_null<TypeSystemSwiftTypeRefForExpressions>(
-                &*type_system_or_err))
+                type_system_or_err->get()))
       if (auto *swift_ast_ctx =
               llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
                   global_scratch_ctx->GetSwiftASTContext()))
@@ -2709,7 +2741,7 @@ llvm::Optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
     if (type_system_or_err)
       swift_scratch_ctx =
           llvm::cast_or_null<TypeSystemSwiftTypeRefForExpressions>(
-              &*type_system_or_err);
+              type_system_or_err->get());
     else
       llvm::consumeError(type_system_or_err.takeError());
   }
@@ -2859,8 +2891,13 @@ ExpressionResults Target::EvaluateExpression(
       LLDB_LOG_ERROR(GetLog(LLDBLog::Target), std::move(err),
                      "Unable to get scratch type system");
     } else {
-      persistent_var_sp =
-          type_system_or_err->GetPersistentExpressionState()->GetVariable(expr);
+      auto ts = *type_system_or_err;
+      if (!ts)
+        LLDB_LOG_ERROR(GetLog(LLDBLog::Target), std::move(err),
+                       "Scratch type system is no longer live");
+      else
+        persistent_var_sp =
+            ts->GetPersistentExpressionState()->GetVariable(expr);
     }
   }
   if (persistent_var_sp) {
@@ -2888,9 +2925,12 @@ ExpressionResults Target::EvaluateExpression(
 lldb::ExpressionVariableSP Target::GetPersistentVariable(ConstString name) {
   lldb::ExpressionVariableSP variable_sp;
   m_scratch_type_system_map.ForEach(
-      [name, &variable_sp](TypeSystem *type_system) -> bool {
+      [name, &variable_sp](TypeSystemSP type_system) -> bool {
+        auto ts = type_system.get();
+        if (!ts)
+          return true;
         if (PersistentExpressionState *persistent_state =
-                type_system->GetPersistentExpressionState()) {
+                ts->GetPersistentExpressionState()) {
           variable_sp = persistent_state->GetVariable(name);
 
           if (variable_sp)
@@ -2905,9 +2945,13 @@ lldb::addr_t Target::GetPersistentSymbol(ConstString name) {
   lldb::addr_t address = LLDB_INVALID_ADDRESS;
 
   m_scratch_type_system_map.ForEach(
-      [name, &address](TypeSystem *type_system) -> bool {
+      [name, &address](lldb::TypeSystemSP type_system) -> bool {
+        auto ts = type_system.get();
+        if (!ts)
+          return true;
+
         if (PersistentExpressionState *persistent_state =
-                type_system->GetPersistentExpressionState()) {
+                ts->GetPersistentExpressionState()) {
           address = persistent_state->LookupSymbol(name);
           if (address != LLDB_INVALID_ADDRESS)
             return false; // Stop iterating the ForEach

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -339,7 +339,7 @@ void Thread::FrameSelectedCallback(StackFrame *frame) {
   }
   SymbolContext msc = frame->GetSymbolContext(eSymbolContextModule);
   if (msc.module_sp)
-    msc.module_sp->ForEachTypeSystem([&](TypeSystem *ts) {
+    msc.module_sp->ForEachTypeSystem([&](lldb::TypeSystemSP ts) {
       if (ts)
         ts->DiagnoseWarnings(*GetProcess(), *msc.module_sp);
       return true;

--- a/lldb/source/Target/ThreadPlanTracer.cpp
+++ b/lldb/source/Target/ThreadPlanTracer.cpp
@@ -110,10 +110,10 @@ TypeFromUser ThreadPlanAssemblyTracer::GetIntPointerType() {
         LLDB_LOG_ERROR(GetLog(LLDBLog::Types), std::move(err),
                        "Unable to get integer pointer type from TypeSystem");
       } else {
-        m_intptr_type = TypeFromUser(
-            type_system_or_err->GetBuiltinTypeForEncodingAndBitSize(
-                eEncodingUint,
-                target_sp->GetArchitecture().GetAddressByteSize() * 8));
+        if (auto ts = *type_system_or_err)
+          m_intptr_type = TypeFromUser(ts->GetBuiltinTypeForEncodingAndBitSize(
+              eEncodingUint,
+              target_sp->GetArchitecture().GetAddressByteSize() * 8));
       }
     }
   }

--- a/lldb/tools/lldb-test/lldb-test.cpp
+++ b/lldb/tools/lldb-test/lldb-test.cpp
@@ -657,13 +657,13 @@ Error opts::symbols::dumpAST(lldb_private::Module &Module) {
   if (!symfile)
     return make_string_error("Module has no symbol file.");
 
-  llvm::Expected<TypeSystem &> type_system_or_err =
+  auto type_system_or_err =
       symfile->GetTypeSystemForLanguage(eLanguageTypeC_plus_plus);
   if (!type_system_or_err)
     return make_string_error("Can't retrieve TypeSystemClang");
 
-  auto *clang_ast_ctx =
-      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
+  auto ts = *type_system_or_err;
+  auto *clang_ast_ctx = llvm::dyn_cast_or_null<TypeSystemClang>(ts.get());
   if (!clang_ast_ctx)
     return make_string_error("Retrieved TypeSystem was not a TypeSystemClang");
 
@@ -685,13 +685,12 @@ Error opts::symbols::dumpEntireClangAST(lldb_private::Module &Module) {
   if (!symfile)
     return make_string_error("Module has no symbol file.");
 
-  llvm::Expected<TypeSystem &> type_system_or_err =
+  auto type_system_or_err =
       symfile->GetTypeSystemForLanguage(eLanguageTypeObjC_plus_plus);
   if (!type_system_or_err)
     return make_string_error("Can't retrieve TypeSystemClang");
-
-  auto *clang_ast_ctx =
-      llvm::dyn_cast_or_null<TypeSystemClang>(&type_system_or_err.get());
+  auto ts = *type_system_or_err;
+  auto *clang_ast_ctx = llvm::dyn_cast_or_null<TypeSystemClang>(ts.get());
   if (!clang_ast_ctx)
     return make_string_error("Retrieved TypeSystem was not a TypeSystemClang");
 

--- a/lldb/unittests/Expression/ClangExpressionDeclMapTest.cpp
+++ b/lldb/unittests/Expression/ClangExpressionDeclMapTest.cpp
@@ -24,9 +24,11 @@ struct FakeClangExpressionDeclMap : public ClangExpressionDeclMap {
   FakeClangExpressionDeclMap(const std::shared_ptr<ClangASTImporter> &importer)
       : ClangExpressionDeclMap(false, nullptr, lldb::TargetSP(), importer,
                                nullptr) {
-    m_scratch_context = clang_utils::createAST();
+    m_holder = std::make_unique<clang_utils::TypeSystemClangHolder>("ast");
+    m_scratch_context = m_holder->GetAST();
   }
-  std::unique_ptr<TypeSystemClang> m_scratch_context;
+  std::unique_ptr<clang_utils::TypeSystemClangHolder> m_holder;
+  TypeSystemClang *m_scratch_context;
   /// Adds a persistent decl that can be found by the ClangExpressionDeclMap
   /// via GetPersistentDecl.
   void AddPersistentDeclForTest(clang::NamedDecl *d) {
@@ -62,20 +64,23 @@ struct ClangExpressionDeclMapTest : public testing::Test {
   /// The ExpressionDeclMap for the current test case.
   std::unique_ptr<FakeClangExpressionDeclMap> decl_map;
 
+  std::unique_ptr<clang_utils::TypeSystemClangHolder> holder;
+  
   /// The target AST that lookup results should be imported to.
-  std::unique_ptr<TypeSystemClang> target_ast;
+  TypeSystemClang *target_ast;
 
   void SetUp() override {
     importer = std::make_shared<ClangASTImporter>();
     decl_map = std::make_unique<FakeClangExpressionDeclMap>(importer);
-    target_ast = clang_utils::createAST();
+    holder = std::make_unique<clang_utils::TypeSystemClangHolder>("target ast");
+    target_ast = holder->GetAST();
     decl_map->InstallASTContext(*target_ast);
   }
 
   void TearDown() override {
     importer.reset();
     decl_map.reset();
-    target_ast.reset();
+    holder.reset();
   }
 };
 } // namespace

--- a/lldb/unittests/Symbol/TestClangASTImporter.cpp
+++ b/lldb/unittests/Symbol/TestClangASTImporter.cpp
@@ -42,7 +42,9 @@ TEST_F(TestClangASTImporter, CopyDeclTagDecl) {
   // Tests that the ClangASTImporter::CopyDecl can copy TagDecls.
   clang_utils::SourceASTWithRecord source;
 
-  std::unique_ptr<TypeSystemClang> target_ast = clang_utils::createAST();
+  auto holder =
+      std::make_unique<clang_utils::TypeSystemClangHolder>("target ast");
+  auto *target_ast = holder->GetAST();
 
   ClangASTImporter importer;
   clang::Decl *imported =
@@ -67,7 +69,9 @@ TEST_F(TestClangASTImporter, CopyTypeTagDecl) {
   // Tests that the ClangASTImporter::CopyType can copy TagDecls types.
   clang_utils::SourceASTWithRecord source;
 
-  std::unique_ptr<TypeSystemClang> target_ast = clang_utils::createAST();
+  auto holder =
+      std::make_unique<clang_utils::TypeSystemClangHolder>("target ast");
+  auto *target_ast = holder->GetAST();
 
   ClangASTImporter importer;
   CompilerType imported = importer.CopyType(*target_ast, source.record_type);
@@ -94,12 +98,16 @@ TEST_F(TestClangASTImporter, CompleteFwdDeclWithOtherOrigin) {
 
   // Create an AST with a type thst is only a forward declaration with the
   // same name as the one in the other source.
-  std::unique_ptr<TypeSystemClang> fwd_decl_source = clang_utils::createAST();
+  auto holder =
+      std::make_unique<clang_utils::TypeSystemClangHolder>("ast");
+  auto *fwd_decl_source = holder->GetAST();
   CompilerType fwd_decl_type = clang_utils::createRecord(
       *fwd_decl_source, source_with_definition.record_decl->getName());
 
   // Create a target and import the forward decl.
-  std::unique_ptr<TypeSystemClang> target = clang_utils::createAST();
+  auto target_holder =
+      std::make_unique<clang_utils::TypeSystemClangHolder>("target ast");
+  auto *target = target_holder->GetAST();
   ClangASTImporter importer;
   CompilerType imported = importer.CopyType(*target, fwd_decl_type);
   ASSERT_TRUE(imported.IsValid());
@@ -119,7 +127,9 @@ TEST_F(TestClangASTImporter, DeportDeclTagDecl) {
   // Tests that the ClangASTImporter::DeportDecl completely copies TagDecls.
   clang_utils::SourceASTWithRecord source;
 
-  std::unique_ptr<TypeSystemClang> target_ast = clang_utils::createAST();
+  auto holder =
+      std::make_unique<clang_utils::TypeSystemClangHolder>("target ast");
+  auto *target_ast = holder->GetAST();
 
   ClangASTImporter importer;
   clang::Decl *imported =
@@ -141,7 +151,9 @@ TEST_F(TestClangASTImporter, DeportTypeTagDecl) {
   // Tests that the ClangASTImporter::CopyType can deport TagDecl types.
   clang_utils::SourceASTWithRecord source;
 
-  std::unique_ptr<TypeSystemClang> target_ast = clang_utils::createAST();
+  auto holder =
+      std::make_unique<clang_utils::TypeSystemClangHolder>("target ast");
+  auto *target_ast = holder->GetAST();
 
   ClangASTImporter importer;
   CompilerType imported = importer.DeportType(*target_ast, source.record_type);
@@ -166,7 +178,9 @@ TEST_F(TestClangASTImporter, MetadataPropagation) {
   const lldb::user_id_t metadata = 123456;
   source.ast->SetMetadataAsUserID(source.record_decl, metadata);
 
-  std::unique_ptr<TypeSystemClang> target_ast = clang_utils::createAST();
+  auto holder =
+      std::make_unique<clang_utils::TypeSystemClangHolder>("target ast");
+  auto *target_ast = holder->GetAST();
 
   ClangASTImporter importer;
   clang::Decl *imported =
@@ -188,14 +202,18 @@ TEST_F(TestClangASTImporter, MetadataPropagationIndirectImport) {
   const lldb::user_id_t metadata = 123456;
   source.ast->SetMetadataAsUserID(source.record_decl, metadata);
 
-  std::unique_ptr<TypeSystemClang> temporary_ast = clang_utils::createAST();
+  auto tmp_holder =
+      std::make_unique<clang_utils::TypeSystemClangHolder>("tmp ast");
+  auto *temporary_ast = tmp_holder->GetAST();
 
   ClangASTImporter importer;
   clang::Decl *temporary_imported =
       importer.CopyDecl(&temporary_ast->getASTContext(), source.record_decl);
   ASSERT_NE(nullptr, temporary_imported);
 
-  std::unique_ptr<TypeSystemClang> target_ast = clang_utils::createAST();
+  auto holder =
+      std::make_unique<clang_utils::TypeSystemClangHolder>("target ast");
+  auto *target_ast = holder->GetAST();
   clang::Decl *imported =
       importer.CopyDecl(&target_ast->getASTContext(), temporary_imported);
   ASSERT_NE(nullptr, imported);
@@ -212,7 +230,9 @@ TEST_F(TestClangASTImporter, MetadataPropagationAfterCopying) {
   clang_utils::SourceASTWithRecord source;
   const lldb::user_id_t metadata = 123456;
 
-  std::unique_ptr<TypeSystemClang> target_ast = clang_utils::createAST();
+  auto holder =
+      std::make_unique<clang_utils::TypeSystemClangHolder>("target ast");
+  auto *target_ast = holder->GetAST();
 
   ClangASTImporter importer;
   clang::Decl *imported =

--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -57,8 +57,8 @@ TEST_F(TestSwiftASTContext, IsNonTriviallyManagedReferenceType) {
 #ifndef NDEBUG
   // The mock constructor is only available in asserts mode.
   SwiftASTContext::NonTriviallyManagedReferenceStrategy strategy;
-  SwiftASTContextTester context;
-  CompilerType t(&context, nullptr);
+  auto context = std::make_shared<SwiftASTContextTester>();
+  CompilerType t(context->weak_from_this(), nullptr);
   EXPECT_FALSE(SwiftASTContext::IsNonTriviallyManagedReferenceType(t, strategy,
                                                                    nullptr));
 #endif

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -27,14 +27,20 @@ public:
   SubsystemRAII<FileSystem, HostInfo> subsystems;
 
   void SetUp() override {
-    m_ast.reset(
-        new TypeSystemClang("test ASTContext", HostInfo::GetTargetTriple()));
+    m_holder =
+        std::make_unique<clang_utils::TypeSystemClangHolder>("test ASTContext");
+    m_ast = m_holder->GetAST();
   }
 
-  void TearDown() override { m_ast.reset(); }
+  void TearDown() override {
+    m_ast = nullptr;
+    m_holder.reset();
+  }
 
 protected:
-  std::unique_ptr<TypeSystemClang> m_ast;
+  
+  TypeSystemClang *m_ast = nullptr;
+  std::unique_ptr<clang_utils::TypeSystemClangHolder> m_holder;
 
   QualType GetBasicQualType(BasicType type) const {
     return ClangUtil::GetQualType(m_ast->GetBasicTypeFromAST(type));
@@ -257,7 +263,10 @@ TEST_F(TestTypeSystemClang, TestGetEnumIntegerTypeBasicTypes) {
     for (lldb::BasicType basic_type : types_to_test) {
       SCOPED_TRACE(std::to_string(basic_type));
 
-      TypeSystemClang ast("enum_ast", HostInfo::GetTargetTriple());
+      auto holder =
+          std::make_unique<clang_utils::TypeSystemClangHolder>("enum_ast");
+      auto &ast = *holder->GetAST();
+
       CompilerType basic_compiler_type = ast.GetBasicType(basic_type);
       EXPECT_TRUE(basic_compiler_type.IsValid());
 
@@ -273,7 +282,9 @@ TEST_F(TestTypeSystemClang, TestGetEnumIntegerTypeBasicTypes) {
 }
 
 TEST_F(TestTypeSystemClang, TestOwningModule) {
-  TypeSystemClang ast("module_ast", HostInfo::GetTargetTriple());
+  auto holder =
+      std::make_unique<clang_utils::TypeSystemClangHolder>("module_ast");
+  auto &ast = *holder->GetAST();
   CompilerType basic_compiler_type = ast.GetBasicType(BasicType::eBasicTypeInt);
   CompilerType enum_type = ast.CreateEnumerationType(
       "my_enum", ast.GetTranslationUnitDecl(), OptionalClangModuleID(100),
@@ -301,7 +312,7 @@ TEST_F(TestTypeSystemClang, TestIsClangType) {
   clang::ASTContext &context = m_ast->getASTContext();
   lldb::opaque_compiler_type_t bool_ctype =
       TypeSystemClang::GetOpaqueCompilerType(&context, lldb::eBasicTypeBool);
-  CompilerType bool_type(m_ast.get(), bool_ctype);
+  CompilerType bool_type(m_ast->weak_from_this(), bool_ctype);
   CompilerType record_type = m_ast->CreateRecordType(
       nullptr, OptionalClangModuleID(100), lldb::eAccessPublic, "FooRecord",
       clang::TTK_Struct, lldb::eLanguageTypeC_plus_plus, nullptr);
@@ -489,13 +500,13 @@ TEST_F(TestTypeSystemClang, TemplateArguments) {
       "foo_def", m_ast->CreateDeclContext(m_ast->GetTranslationUnitDecl()), 0);
 
   CompilerType auto_type(
-      m_ast.get(),
+      m_ast->weak_from_this(),
       m_ast->getASTContext()
           .getAutoType(ClangUtil::GetCanonicalQualType(typedef_type),
                        clang::AutoTypeKeyword::Auto, false)
           .getAsOpaquePtr());
 
-  CompilerType int_type(m_ast.get(),
+  CompilerType int_type(m_ast->weak_from_this(),
                         m_ast->getASTContext().IntTy.getAsOpaquePtr());
   for (CompilerType t : {type, typedef_type, auto_type}) {
     SCOPED_TRACE(t.GetTypeName().AsCString());

--- a/lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp
+++ b/lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp
@@ -9,6 +9,7 @@
 #include "Plugins/SymbolFile/DWARF/DWARFASTParserClang.h"
 #include "Plugins/SymbolFile/DWARF/DWARFCompileUnit.h"
 #include "Plugins/SymbolFile/DWARF/DWARFDIE.h"
+#include "TestingSupport/Symbol/ClangTestUtils.h"
 #include "TestingSupport/Symbol/YAMLModuleTester.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -93,7 +94,9 @@ DWARF:
   YAMLModuleTester t(yamldata);
   ASSERT_TRUE((bool)t.GetDwarfUnit());
 
-  TypeSystemClang ast_ctx("dummy ASTContext", HostInfoBase::GetTargetTriple());
+  auto holder = std::make_unique<clang_utils::TypeSystemClangHolder>("ast");
+  auto &ast_ctx = *holder->GetAST();
+
   DWARFASTParserClangStub ast_parser(ast_ctx);
 
   DWARFUnit *unit = t.GetDwarfUnit();
@@ -244,7 +247,8 @@ DWARF:
   ASSERT_EQ(cu_entry->Tag(), DW_TAG_compile_unit);
   DWARFDIE cu_die(unit, cu_entry);
 
-  TypeSystemClang ast_ctx("dummy ASTContext", HostInfoBase::GetTargetTriple());
+  auto holder = std::make_unique<clang_utils::TypeSystemClangHolder>("ast");
+  auto &ast_ctx = *holder->GetAST();
   DWARFASTParserClangStub ast_parser(ast_ctx);
 
   std::vector<std::string> found_function_types;

--- a/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
+++ b/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
@@ -391,7 +391,7 @@ TEST_F(SymbolFilePDBTests, TestNestedClassTypes) {
   ASSERT_THAT_EXPECTED(clang_ast_ctx_or_err, llvm::Succeeded());
 
   auto clang_ast_ctx =
-      llvm::dyn_cast_or_null<TypeSystemClang>(&clang_ast_ctx_or_err.get());
+      llvm::dyn_cast_or_null<TypeSystemClang>(clang_ast_ctx_or_err->get());
   EXPECT_NE(nullptr, clang_ast_ctx);
 
   symfile->FindTypes(ConstString("Class"), CompilerDeclContext(), 0,
@@ -445,7 +445,7 @@ TEST_F(SymbolFilePDBTests, TestClassInNamespace) {
   ASSERT_THAT_EXPECTED(clang_ast_ctx_or_err, llvm::Succeeded());
 
   auto clang_ast_ctx =
-      llvm::dyn_cast_or_null<TypeSystemClang>(&clang_ast_ctx_or_err.get());
+      llvm::dyn_cast_or_null<TypeSystemClang>(clang_ast_ctx_or_err->get());
   EXPECT_NE(nullptr, clang_ast_ctx);
 
   clang::ASTContext &ast_ctx = clang_ast_ctx->getASTContext();
@@ -540,8 +540,8 @@ TEST_F(SymbolFilePDBTests, TestTypedefs) {
     lldb::TypeSP typedef_type = results.GetTypeAtIndex(0);
     EXPECT_EQ(ConstString(Typedef), typedef_type->GetName());
     CompilerType compiler_type = typedef_type->GetFullCompilerType();
-    TypeSystemClang *clang_type_system =
-        llvm::dyn_cast_or_null<TypeSystemClang>(compiler_type.GetTypeSystem());
+    auto clang_type_system =
+        compiler_type.GetTypeSystem().dyn_cast_or_null<TypeSystemClang>();
     EXPECT_TRUE(
         clang_type_system->IsTypedefType(compiler_type.GetOpaqueQualType()));
 


### PR DESCRIPTION
When a process gets restarted TypeSystem objects associated with it
may get deleted, and any CompilerType objects holding on to a
reference to that type system are a use-after-free in waiting. Because
of the SBAPI, we don't have tight control over where CompilerTypes go
and when they are used. This is particularly a problem in the Swift
plugin, where the scratch TypeSystem can be restarted while the
process is still running. The Swift plugin has a lock to prevent
abuse, but where there's a lock there can be bugs.

This patch changes CompilerType to store a std::weak_ptr<TypeSystem>.
Most of the std::weak_ptr<TypeSystem>* uglyness is hidden by
introducing a wrapper class CompilerType::WrappedTypeSystem that has a
dyn_cast_or_null() method. The only sites that need to know about the
weak pointer implementation detail are the ones that deal with
creating TypeSystems.

rdar://101505232

Differential Revision: https://reviews.llvm.org/D136650

(cherry picked from commit 764f1974c3667d2dd044dc981d5e05d304f6fc6d)
(cherry picked from commit https://github.com/apple/llvm-project/commit/b4c5349df4af4628fac7afa312796b1e8e43375b)