### PR TITLE
[lldb] Warn when static bindings are out of sync

### DIFF
--- a/lldb/bindings/python/CMakeLists.txt
+++ b/lldb/bindings/python/CMakeLists.txt
@@ -190,3 +190,14 @@ function(finish_swig_python swig_target lldb_python_bindings_dir lldb_python_tar
       COMMENT "Copying Python DLL to LLDB binaries directory.")
   endif()
 endfunction()
+
+if(${LLDB_USE_STATIC_BINDINGS})
+  set(SOURCE_STATIC_BINDING ${CMAKE_CURRENT_SOURCE_DIR}/static-binding/lldb.py)
+  set(BINARY_STATIC_BINDING ${CMAKE_CURRENT_BINARY_DIR}/lldb.py)
+  set(COPY_STATIC_BINDING ${LLDB_SOURCE_DIR}/scripts/copy-static-bindings.py)
+
+  add_custom_command(TARGET swig_wrapper_python POST_BUILD VERBATIM
+    COMMAND diff -q ${SOURCE_STATIC_BINDING} ${BINARY_STATIC_BINDING} || ${CMAKE_COMMAND} -E cmake_echo_color --red "Update the static bindings by running the following command: ${COPY_STATIC_BINDING} ${CMAKE_BINARY_DIR}"
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lldb.py
+    COMMENT "Diff the static bindings")
+endif()


### PR DESCRIPTION
Print a warning when the static bindings are out of sync. The warning only triggers when not using the static bindings (because otherwise they'll be identical by design). The warning also includes the command to update them in the project source.