### PR TITLE
[clang][deps] Remove unintentional `move`

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -642,8 +642,8 @@ bool DependencyScanningWorker::computeDependencies(
     ModifiedCommandLine = CommandLine;
     ModifiedCommandLine->emplace_back(*ModuleName);
 
-    auto OverlayFS = llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(
-        std::move(BaseFS));
+    auto OverlayFS =
+        llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(BaseFS);
     auto InMemoryFS =
         llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
     InMemoryFS->setCurrentWorkingDirectory(WorkingDirectory);

--- a/clang/test/ClangScanDeps/modules-full-by-mod-name.cpp
+++ b/clang/test/ClangScanDeps/modules-full-by-mod-name.cpp
@@ -11,7 +11,7 @@
 // RUN: sed -e "s|DIR|%/t.dir|g" %S/Inputs/modules_cdb_by_mod_name.json > %t.cdb
 // RUN: sed -e "s|DIR|%/t.dir|g" %S/Inputs/modules_cdb_clangcl_by_mod_name.json > %t_clangcl.cdb
 //
-// RUN: clang-scan-deps -compilation-database %t.cdb -j 4 -format experimental-full \
+// RUN: clang-scan-deps -compilation-database %t.cdb -j 1 -format experimental-full \
 // RUN:   -mode preprocess-dependency-directives -module-name=header1 > %t.result
 // RUN: cat %t.result | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t.dir --check-prefixes=CHECK %s
 //


### PR DESCRIPTION
This is a fix related to D135414. The original intention was to keep `BaseFS` as a member of the worker and conditionally overlay it with local in-memory FS. The `move` of ref-counted `BaseFS` was not intended, and it's a bug.

Disabling parallelism in the "by-module-name" test reliably reproduces this, and the test itself doesn't *need* parallelism. (I think `-j 4` was cargo culted from another test.) Reusing that test to check for correct behavior...

Reviewed By: DavidSpickett

Differential Revision: https://reviews.llvm.org/D136124

(cherry picked from commit d239f3c627a396a80181806960957d5d0eba7e91)