### PR TITLE
[stable/20221013][Index] Add various missing USR generation

### DIFF
--- a/clang/lib/Index/USRGeneration.cpp
+++ b/clang/lib/Index/USRGeneration.cpp
@@ -168,6 +168,8 @@ public:
   void VisitTemplateName(TemplateName Name);
   void VisitTemplateArgument(const TemplateArgument &Arg);
 
+  void VisitMSGuidDecl(const MSGuidDecl *D);
+
   /// Emit a Decl's name using NamedDecl::printName() and return true if
   ///  the decl had no name.
   bool EmitDeclName(const NamedDecl *D);
@@ -658,120 +660,157 @@ void USRGenerator::VisitType(QualType T) {
     }
 
     if (const BuiltinType *BT = T->getAs<BuiltinType>()) {
-      unsigned char c = '\0';
       switch (BT->getKind()) {
         case BuiltinType::Void:
-          c = 'v'; break;
+          Out << 'v'; break;
         case BuiltinType::Bool:
-          c = 'b'; break;
+          Out << 'b'; break;
         case BuiltinType::UChar:
-          c = 'c'; break;
+          Out << 'c'; break;
         case BuiltinType::Char8:
-          c = 'u'; break; // FIXME: Check this doesn't collide
+          Out << 'u'; break;
         case BuiltinType::Char16:
-          c = 'q'; break;
+          Out << 'q'; break;
         case BuiltinType::Char32:
-          c = 'w'; break;
+          Out << 'w'; break;
         case BuiltinType::UShort:
-          c = 's'; break;
+          Out << 's'; break;
         case BuiltinType::UInt:
-          c = 'i'; break;
+          Out << 'i'; break;
         case BuiltinType::ULong:
-          c = 'l'; break;
+          Out << 'l'; break;
         case BuiltinType::ULongLong:
-          c = 'k'; break;
+          Out << 'k'; break;
         case BuiltinType::UInt128:
-          c = 'j'; break;
+          Out << 'j'; break;
         case BuiltinType::Char_U:
         case BuiltinType::Char_S:
-          c = 'C'; break;
+          Out << 'C'; break;
         case BuiltinType::SChar:
-          c = 'r'; break;
+          Out << 'r'; break;
         case BuiltinType::WChar_S:
         case BuiltinType::WChar_U:
-          c = 'W'; break;
+          Out << 'W'; break;
         case BuiltinType::Short:
-          c = 'S'; break;
+          Out << 'S'; break;
         case BuiltinType::Int:
-          c = 'I'; break;
+          Out << 'I'; break;
         case BuiltinType::Long:
-          c = 'L'; break;
+          Out << 'L'; break;
         case BuiltinType::LongLong:
-          c = 'K'; break;
+          Out << 'K'; break;
         case BuiltinType::Int128:
-          c = 'J'; break;
+          Out << 'J'; break;
         case BuiltinType::Float16:
         case BuiltinType::Half:
-          c = 'h'; break;
+          Out << 'h'; break;
         case BuiltinType::Float:
-          c = 'f'; break;
+          Out << 'f'; break;
         case BuiltinType::Double:
-          c = 'd'; break;
-        case BuiltinType::Ibm128: // FIXME: Need separate tag
+          Out << 'd'; break;
         case BuiltinType::LongDouble:
-          c = 'D'; break;
+          Out << 'D'; break;
         case BuiltinType::Float128:
-          c = 'Q'; break;
+          Out << 'Q'; break;
         case BuiltinType::NullPtr:
-          c = 'n'; break;
+          Out << 'n'; break;
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
+        case BuiltinType::Id: \
+          Out << "@BT@" << #Suffix << "_" << #ImgType; break;
+#include "clang/Basic/OpenCLImageTypes.def"
+#define EXT_OPAQUE_TYPE(ExtType, Id, Ext) \
+        case BuiltinType::Id: \
+          Out << "@BT@" << #ExtType; break;
+#include "clang/Basic/OpenCLExtensionTypes.def"
+        case BuiltinType::OCLEvent:
+          Out << "@BT@OCLEvent"; break;
+        case BuiltinType::OCLClkEvent:
+          Out << "@BT@OCLClkEvent"; break;
+        case BuiltinType::OCLQueue:
+          Out << "@BT@OCLQueue"; break;
+        case BuiltinType::OCLReserveID:
+          Out << "@BT@OCLReserveID"; break;
+        case BuiltinType::OCLSampler:
+          Out << "@BT@OCLSampler"; break;
+#define SVE_TYPE(Name, Id, SingletonId) \
+        case BuiltinType::Id: \
+          Out << "@BT@" << Name; break;
+#include "clang/Basic/AArch64SVEACLETypes.def"
+#define PPC_VECTOR_TYPE(Name, Id, Size) \
+        case BuiltinType::Id: \
+          Out << "@BT@" << #Name; break;
+#include "clang/Basic/PPCTypes.def"
+#define RVV_TYPE(Name, Id, SingletonId) \
+        case BuiltinType::Id: \
+          Out << "@BT@" << Name; break;
+#include "clang/Basic/RISCVVTypes.def"
+        case BuiltinType::ShortAccum:
+          Out << "@BT@ShortAccum"; break;
+        case BuiltinType::Accum:
+          Out << "@BT@Accum"; break;
+        case BuiltinType::LongAccum:
+          Out << "@BT@LongAccum"; break;
+        case BuiltinType::UShortAccum:
+          Out << "@BT@UShortAccum"; break;
+        case BuiltinType::UAccum:
+          Out << "@BT@UAccum"; break;
+        case BuiltinType::ULongAccum:
+          Out << "@BT@ULongAccum"; break;
+        case BuiltinType::ShortFract:
+          Out << "@BT@ShortFract"; break;
+        case BuiltinType::Fract:
+          Out << "@BT@Fract"; break;
+        case BuiltinType::LongFract:
+          Out << "@BT@LongFract"; break;
+        case BuiltinType::UShortFract:
+          Out << "@BT@UShortFract"; break;
+        case BuiltinType::UFract:
+          Out << "@BT@UFract"; break;
+        case BuiltinType::ULongFract:
+          Out << "@BT@ULongFract"; break;
+        case BuiltinType::SatShortAccum:
+          Out << "@BT@SatShortAccum"; break;
+        case BuiltinType::SatAccum:
+          Out << "@BT@SatAccum"; break;
+        case BuiltinType::SatLongAccum:
+          Out << "@BT@SatLongAccum"; break;
+        case BuiltinType::SatUShortAccum:
+          Out << "@BT@SatUShortAccum"; break;
+        case BuiltinType::SatUAccum:
+          Out << "@BT@SatUAccum"; break;
+        case BuiltinType::SatULongAccum:
+          Out << "@BT@SatULongAccum"; break;
+        case BuiltinType::SatShortFract:
+          Out << "@BT@SatShortFract"; break;
+        case BuiltinType::SatFract:
+          Out << "@BT@SatFract"; break;
+        case BuiltinType::SatLongFract:
+          Out << "@BT@SatLongFract"; break;
+        case BuiltinType::SatUShortFract:
+          Out << "@BT@SatUShortFract"; break;
+        case BuiltinType::SatUFract:
+          Out << "@BT@SatUFract"; break;
+        case BuiltinType::SatULongFract:
+          Out << "@BT@SatULongFract"; break;
+        case BuiltinType::BFloat16:
+          Out << "@BT@__bf16"; break;
+        case BuiltinType::Ibm128:
+          Out << "@BT@__ibm128"; break;
+        case BuiltinType::ObjCId:
+          Out << 'o'; break;
+        case BuiltinType::ObjCClass:
+          Out << 'O'; break;
+        case BuiltinType::ObjCSel:
+          Out << 'e'; break;
 #define BUILTIN_TYPE(Id, SingletonId)
 #define PLACEHOLDER_TYPE(Id, SingletonId) case BuiltinType::Id:
 #include "clang/AST/BuiltinTypes.def"
         case BuiltinType::Dependent:
-#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
-        case BuiltinType::Id:
-#include "clang/Basic/OpenCLImageTypes.def"
-#define EXT_OPAQUE_TYPE(ExtType, Id, Ext) \
-        case BuiltinType::Id:
-#include "clang/Basic/OpenCLExtensionTypes.def"
-        case BuiltinType::OCLEvent:
-        case BuiltinType::OCLClkEvent:
-        case BuiltinType::OCLQueue:
-        case BuiltinType::OCLReserveID:
-        case BuiltinType::OCLSampler:
-#define SVE_TYPE(Name, Id, SingletonId) \
-        case BuiltinType::Id:
-#include "clang/Basic/AArch64SVEACLETypes.def"
-#define PPC_VECTOR_TYPE(Name, Id, Size) \
-        case BuiltinType::Id:
-#include "clang/Basic/PPCTypes.def"
-#define RVV_TYPE(Name, Id, SingletonId) case BuiltinType::Id:
-#include "clang/Basic/RISCVVTypes.def"
-        case BuiltinType::ShortAccum:
-        case BuiltinType::Accum:
-        case BuiltinType::LongAccum:
-        case BuiltinType::UShortAccum:
-        case BuiltinType::UAccum:
-        case BuiltinType::ULongAccum:
-        case BuiltinType::ShortFract:
-        case BuiltinType::Fract:
-        case BuiltinType::LongFract:
-        case BuiltinType::UShortFract:
-        case BuiltinType::UFract:
-        case BuiltinType::ULongFract:
-        case BuiltinType::SatShortAccum:
-        case BuiltinType::SatAccum:
-        case BuiltinType::SatLongAccum:
-        case BuiltinType::SatUShortAccum:
-        case BuiltinType::SatUAccum:
-        case BuiltinType::SatULongAccum:
-        case BuiltinType::SatShortFract:
-        case BuiltinType::SatFract:
-        case BuiltinType::SatLongFract:
-        case BuiltinType::SatUShortFract:
-        case BuiltinType::SatUFract:
-        case BuiltinType::SatULongFract:
-        case BuiltinType::BFloat16:
+          // If you're adding a new builtin type, please add its name prefixed
+          // with "@BT@" to `Out` (see cases above).
           IgnoreResults = true;
-          return;
-        case BuiltinType::ObjCId:
-          c = 'o'; break;
-        case BuiltinType::ObjCClass:
-          c = 'O'; break;
-        case BuiltinType::ObjCSel:
-          c = 'e'; break;
+          break;
       }
-      Out << c;
       return;
     }
 
@@ -1015,6 +1054,12 @@ void USRGenerator::VisitConceptDecl(const ConceptDecl *D) {
   VisitDeclContext(D->getDeclContext());
   Out << "@CT@";
   EmitDeclName(D);
+}
+
+void USRGenerator::VisitMSGuidDecl(const MSGuidDecl *D) {
+  VisitDeclContext(D->getDeclContext());
+  Out << "@MG@";
+  D->NamedDecl::printName(Out);
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/test/Index/index-builtin-fixedpoint.c
+++ b/clang/test/Index/index-builtin-fixedpoint.c
@@ -1,0 +1,5 @@
+__attribute__((overloadable))
+void testFixedPoint(_Accum);
+// CHECK: USR: c:@F@testFixedPoint#@BT@Accum#
+
+// RUN: c-index-test -index-file %s -ffixed-point | FileCheck %s

--- a/clang/test/Index/index-builtin-opencl.clcpp
+++ b/clang/test/Index/index-builtin-opencl.clcpp
@@ -1,0 +1,7 @@
+void testImage(read_only image1d_t);
+// CHECK: USR: c:@F@testImage#@BT@ro_image1d#
+
+void testExt(intel_sub_group_avc_mce_payload_t) {}
+// CHECK: USR: c:@F@testExt#@BT@intel_sub_group_avc_mce_payload_t#
+
+// RUN: c-index-test -index-file %s --target=spir | FileCheck %s

--- a/clang/test/Index/index-builtin-ppc.cpp
+++ b/clang/test/Index/index-builtin-ppc.cpp
@@ -1,0 +1,7 @@
+void testPpc(__vector_quad);
+// CHECK: USR: c:@F@testPpc#@BT@__vector_quad#
+
+void testIBM(__ibm128);
+// CHECK: USR: c:@F@testIBM#@BT@__ibm128#
+//
+// RUN: c-index-test -index-file %s --target=powerpc64 -target-cpu pwr10 | FileCheck %s

--- a/clang/test/Index/index-builtin-riscv.c
+++ b/clang/test/Index/index-builtin-riscv.c
@@ -1,0 +1,5 @@
+__attribute__((overloadable))
+void testRiscv(__rvv_int8mf8_t);
+// CHECK: USR: c:@F@testRiscv#@BT@__rvv_int8mf8_t#
+
+// RUN: c-index-test -index-file %s --target=riscv64 -target-feature +v | FileCheck %s

--- a/clang/test/Index/index-builtin-sve.cpp
+++ b/clang/test/Index/index-builtin-sve.cpp
@@ -1,0 +1,7 @@
+void testSve(__SVInt8_t sve);
+// CHECK: USR: c:@F@testSve#@BT@__SVInt8_t#
+
+void testBf16(__bf16);
+// CHECK: USR: c:@F@testBf16#@BT@__bf16#
+
+// RUN: c-index-test -index-file %s --target=aarch64 -target-feature +bf16 -target-feature +sve -std=c++11 | FileCheck %s

--- a/clang/test/Index/index-msguid.cpp
+++ b/clang/test/Index/index-msguid.cpp
@@ -1,0 +1,14 @@
+template <class T, const _GUID &ID = __uuidof(T)>
+class GUIDHolder {
+public:
+  virtual ~GUIDHolder() {}
+};
+
+class  __declspec(uuid("12345678-1234-5678-ABCD-12345678ABCD")) GUIDInterface {};
+
+class GUIDUse : public GUIDHolder<GUIDInterface> {
+  ~GUIDUse() {}
+  // CHECK: RelOver | ~GUIDHolder | c:@S@GUIDHolder>#$@S@GUIDInterface#@MG@GUID{12345678-1234-5678-abcd-12345678abcd}@F@~GUIDHolder#
+};
+
+// RUN: c-index-test core -print-source-symbols -- -std=c++11 -fms-extensions %s | FileCheck %s


### PR DESCRIPTION
Cherry-picks 699ae92f045331b555394b8b9757d7e0fbf97100

-----

Over the years there's been many builtin types added without corresponding USRs. Add a `@BT@<name>` USR for all these types. Also add a comment so that hopefully this doesn't continue happening.

`MSGuid` was also missing a USR, use `@MG@GUID{<uuid>}` for it.

Resolves rdar://102198268.

Differential Revision: https://reviews.llvm.org/D138322