### PR TITLE
[lldb] Restore TypeSystem::CreateInstance(LanguageType, Target *)

### DIFF
--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -84,6 +84,9 @@ public:
   static lldb::TypeSystemSP CreateInstance(lldb::LanguageType language,
                                            Module *module);
 
+  static lldb::TypeSystemSP CreateInstance(lldb::LanguageType language,
+                                           Target *target);
+
   // BEGIN SWIFT
   static lldb::TypeSystemSP CreateInstance(lldb::LanguageType language,
                                            Target *target,


### PR DESCRIPTION
This was probably accidentally dropped during a merge