### PR TITLE
Remove -fexperimental-new-pass-manager from test RUN lines

### DIFF
--- a/clang/test/CodeGen/split-cold-code.c
+++ b/clang/test/CodeGen/split-cold-code.c
@@ -1,38 +1,38 @@
 // === New PM (ditto) ===
 // No splitting at -O0.
-// RUN: %clang_cc1 -O0 -fsplit-cold-code -fexperimental-new-pass-manager -fdebug-pass-manager \
+// RUN: %clang_cc1 -O0 -fsplit-cold-code -fdebug-pass-manager \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-NO-SPLIT %s
 //
 // No splitting at -Oz.
-// RUN: %clang_cc1 -Oz -fsplit-cold-code -fexperimental-new-pass-manager -fdebug-pass-manager \
+// RUN: %clang_cc1 -Oz -fsplit-cold-code -fdebug-pass-manager \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-NO-SPLIT %s
 //
 // Split by default.
-// RUN: %clang_cc1 -O3 -fexperimental-new-pass-manager -fdebug-pass-manager \
+// RUN: %clang_cc1 -O3 -fdebug-pass-manager \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-SPLIT %s
 //
 // No splitting when it's explicitly disabled.
-// RUN: %clang_cc1 -O3 -fno-split-cold-code -fexperimental-new-pass-manager -fdebug-pass-manager \
+// RUN: %clang_cc1 -O3 -fno-split-cold-code -fdebug-pass-manager \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-NO-SPLIT %s
 //
 // No splitting when LLVM passes are disabled.
-// RUN: %clang_cc1 -O3 -fsplit-cold-code -disable-llvm-passes -fexperimental-new-pass-manager -fdebug-pass-manager \
+// RUN: %clang_cc1 -O3 -fsplit-cold-code -disable-llvm-passes -fdebug-pass-manager \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-NO-SPLIT %s
 //
 // Split at -O1.
-// RUN: %clang_cc1 -O1 -fsplit-cold-code -fexperimental-new-pass-manager -fdebug-pass-manager \
+// RUN: %clang_cc1 -O1 -fsplit-cold-code -fdebug-pass-manager \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-SPLIT %s
 //
 // Split at -Os.
-// RUN: %clang_cc1 -Os -fsplit-cold-code -fexperimental-new-pass-manager -fdebug-pass-manager \
+// RUN: %clang_cc1 -Os -fsplit-cold-code -fdebug-pass-manager \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-SPLIT %s
 //
 // Split at -O2.
-// RUN: %clang_cc1 -O2 -fsplit-cold-code -fexperimental-new-pass-manager -fdebug-pass-manager \
+// RUN: %clang_cc1 -O2 -fsplit-cold-code -fdebug-pass-manager \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-SPLIT %s
 //
 // Split at -O3.
-// RUN: %clang_cc1 -O3 -fsplit-cold-code -fexperimental-new-pass-manager -fdebug-pass-manager \
+// RUN: %clang_cc1 -O3 -fsplit-cold-code -fdebug-pass-manager \
 // RUN:   -emit-llvm -o /dev/null %s 2>&1 | FileCheck --check-prefix=NEWPM-SPLIT %s
 
 // NEWPM-NO-SPLIT-NOT: HotColdSplit


### PR DESCRIPTION
The option was removed in 69b2b7282e92a1b576b7bd26f3b16716a5027e8e.