### PR TITLE
[lldb] Only build repl_swift if swift support is enabled

### DIFF
--- a/lldb/tools/CMakeLists.txt
+++ b/lldb/tools/CMakeLists.txt
@@ -23,5 +23,7 @@ if (LLDB_CAN_USE_LLDB_SERVER)
 endif()
 
 # BEGIN Swift Mods
-add_subdirectory(repl/swift)
+if (LLDB_ENABLE_SWIFT_SUPPORT)
+  add_subdirectory(repl/swift)
+endif()
 # END Swift Mods


### PR DESCRIPTION
Technically there is no swift code in repl_swift but it is confusing to have around if swift support isn't enabled.