### PR TITLE
[lldb] Only build repl_swift if swift support is enabled

### DIFF
--- a/lldb/tools/CMakeLists.txt
+++ b/lldb/tools/CMakeLists.txt
@@ -23,5 +23,7 @@ if (LLDB_CAN_USE_LLDB_SERVER)
 endif()
 
 # BEGIN Swift Mods
-add_subdirectory(repl/swift)
+if (LLDB_ENABLE_SWIFT_SUPPORT)
+  add_subdirectory(repl/swift)
+endif()
 # END Swift Mods


### PR DESCRIPTION
(cherry picked from commit cb8d9b64d393f4a863fe5693598d7dd025875585)