### PR TITLE
Create a TypeSystemClang to wrap ClangImporter's clang::ASTContext

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -759,22 +759,7 @@ void TypeSystemClang::CreateASTContext() {
 
 TypeSystemClang *TypeSystemClang::GetASTContext(clang::ASTContext *ast) {
   TypeSystemClang *clang_ast = GetASTMap().Lookup(ast);
-  // BEGIN SWIFT
-  // FIXME: rdar://102525085
-  // The following code existed only on swift-lldb. Presumably it's a
-  // hack to wrap the clang::ASTContext owned by a ClangImporter in a
-  // TypeSystemClang.
-  if (!clang_ast) {
-    /// rdar://102525085
-    auto ts = std::make_shared<TypeSystemClang>(
-        "ASTContext from TypeSystemClang::GetASTContext", *ast);
-    static std::vector<std::shared_ptr<TypeSystemClang>> g_adhoc_typesystems;
-    g_adhoc_typesystems.push_back(ts);
-
-    GetASTMap().Insert(ast, ts.get());
-    clang_ast = ts.get();
-  }
-  // END SWIFT
+  lldbassert(clang_ast && "Orphaned clang::ASTContext");
   return clang_ast;
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3061,9 +3061,12 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
 
   // 4. Install the clang importer.
   if (clang_importer_ap) {
-    m_clang_importer = (swift::ClangImporter *)clang_importer_ap.get();
+    m_clangimporter = (swift::ClangImporter *)clang_importer_ap.get();
     m_ast_context_ap->addModuleLoader(std::move(clang_importer_ap),
                                       /*isClang=*/true);
+    m_clangimporter_typesystem = std::make_shared<TypeSystemClang>(
+        "ClangImporter-owned clang::ASTContext for '" + m_description,
+        m_clangimporter->getClangASTContext());
   }
 
   // Set up the required state for the evaluator in the TypeChecker.
@@ -3095,7 +3098,7 @@ swift::ClangImporter *SwiftASTContext::GetClangImporter() {
   VALID_OR_RETURN(nullptr);
 
   GetASTContext();
-  return m_clang_importer;
+  return m_clangimporter;
 }
 
 const swift::SearchPathOptions *SwiftASTContext::GetSearchPathOptions() const {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -24,6 +24,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Target/TargetOptions.h"
+#include <memory>
 
 namespace swift {
 enum class IRGenDebugInfoLevel : unsigned;
@@ -863,7 +864,9 @@ protected:
   /// Owned by the AST.
   swift::MemoryBufferSerializedModuleLoader *m_memory_buffer_module_loader =
       nullptr;
-  swift::ClangImporter *m_clang_importer = nullptr;
+  swift::ClangImporter *m_clangimporter = nullptr;
+  /// Wraps the clang::ASTContext owned by ClangImporter.
+  std::shared_ptr<TypeSystemClang> m_clangimporter_typesystem;
   SwiftModuleMap m_swift_module_cache;
   SwiftTypeFromMangledNameMap m_mangled_name_to_type_map;
   SwiftMangledNameFromTypeMap m_type_to_mangled_name_map;


### PR DESCRIPTION
The original code here (dating back to Swift 1.0) would create and leak a new TypeSystem on the fly.

rdar://102525085
(cherry picked from commit c2d12fdc09c09cde4811132055bf9443dfdf2060)