### PR TITLE
Modules list args

### DIFF
--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -52,6 +52,7 @@
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/State.h"
 #include "lldb/Utility/Timer.h"
+#include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-private-enumerations.h"
 
 #include "clang/CodeGen/ObjectFilePCHContainerOperations.h"
@@ -2945,8 +2946,10 @@ public:
   CommandObjectTargetModulesList(CommandInterpreter &interpreter)
       : CommandObjectParsed(
             interpreter, "target modules list",
-            "List current executable and dependent shared library images.",
-            "target modules list [<cmd-options>]") {}
+            "List current executable and dependent shared library images.") {
+    CommandArgumentData module_arg{eArgTypeShlibName, eArgRepeatStar};
+    m_arguments.push_back({module_arg});
+  }
 
   ~CommandObjectTargetModulesList() override = default;
 

--- a/lldb/test/API/commands/help/TestHelp.py
+++ b/lldb/test/API/commands/help/TestHelp.py
@@ -104,6 +104,13 @@ class HelpCommandTestCase(TestBase):
                     'Dump the line table for one or more compilation units'])
 
     @no_debug_info_test
+    def test_help_image_list_shows_positional_args(self):
+        """Command 'help image list' should describe positional args."""
+        # 'image' is an alias for 'target modules'.
+        self.expect("help image list", substrs=[
+                    '<shlib-name> [...]'])
+
+    @no_debug_info_test
     def test_help_target_variable_syntax(self):
         """Command 'help target variable' should display <variable-name> ..."""
         self.expect("help target variable",


### PR DESCRIPTION
Missing cherry-pick.  When Dave added this patch, it was just to get the help right.  But a subsequent change I made to require commands specify arguments - so that we could detect and give an error if arguments were provided to a command that doesn't take them - turned this into an error.