### PR TITLE
[lldb] Remove timer from Module::GetNumCompileUnits

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -423,8 +423,6 @@ void Module::DumpSymbolContext(Stream *s) {
 
 size_t Module::GetNumCompileUnits() {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
-  LLDB_SCOPED_TIMERF("Module::GetNumCompileUnits (module = %p)",
-                     static_cast<void *>(this));
   if (SymbolFile *symbols = GetSymbolFile())
     return symbols->GetNumCompileUnits();
   return 0;


### PR DESCRIPTION
`GetNumCompileUnits` has fast execution, and is high firing. Fast and frequent functions are not good candidates for timers. In a recent profile, `GetNumCompileUnits` was called >>10k times with an average duration of 1 microsecond.

Differential Revision: https://reviews.llvm.org/D138878

(cherry picked from commit e2a10d8ca34a3554d8d19d2bbdd3133970e4d09b)
