### PR TITLE
[arm64e] Sign pointers to ObjC atomic property getter/setter copy hel…

### DIFF
--- a/clang/lib/CodeGen/CGObjC.cpp
+++ b/clang/lib/CodeGen/CGObjC.cpp
@@ -3707,6 +3707,15 @@ void CodeGenFunction::EmitExtendGCLifetime(llvm::Value *object) {
   EmitNounwindRuntimeCall(extender, object);
 }
 
+/// Return 'void (void *, const void *)', which is the type of ObjC atomic
+/// property copy helper functions.
+static QualType getObjCAtomicPropertyCopyHelperFunctionType(ASTContext &Ctx) {
+  SmallVector<QualType, 2> ArgTys;
+  ArgTys.push_back(Ctx.VoidPtrTy);
+  ArgTys.push_back(Ctx.getPointerType(Ctx.VoidTy.withConst()));
+  return Ctx.getFunctionType(Ctx.VoidTy, ArgTys, {});
+}
+
 /// GenerateObjCAtomicSetterCopyHelperFunction - Given a c++ object type with
 /// non-trivial copy assignment function, produce following helper function.
 /// static void copyHelper(Ty *dest, const Ty *source) { *dest = *source; }
@@ -3727,6 +3736,8 @@ CodeGenFunction::GenerateObjCAtomicSetterCopyHelperFunction(
     CharUnits Alignment = C.getTypeAlignInChars(Ty);
     llvm::Constant *Fn = getNonTrivialCStructMoveAssignmentOperator(
         CGM, Alignment, Alignment, Ty.isVolatileQualified(), Ty);
+    Fn = CGM.getFunctionPointer(Fn,
+                                getObjCAtomicPropertyCopyHelperFunctionType(C));
     return llvm::ConstantExpr::getBitCast(Fn, VoidPtrTy);
   }
 
@@ -3807,7 +3818,8 @@ CodeGenFunction::GenerateObjCAtomicSetterCopyHelperFunction(
   EmitStmt(TheCall);
 
   FinishFunction();
-  HelperFn = CGM.getFunctionPointer(Fn, FD->getType());
+  HelperFn = CGM.getFunctionPointer(
+      Fn, getObjCAtomicPropertyCopyHelperFunctionType(C));
   HelperFn = llvm::ConstantExpr::getBitCast(HelperFn, VoidPtrTy);
   CGM.setAtomicSetterHelperFnMap(Ty, HelperFn);
   return HelperFn;
@@ -3826,6 +3838,8 @@ llvm::Constant *CodeGenFunction::GenerateObjCAtomicGetterCopyHelperFunction(
     CharUnits Alignment = C.getTypeAlignInChars(Ty);
     llvm::Constant *Fn = getNonTrivialCStructCopyConstructor(
         CGM, Alignment, Alignment, Ty.isVolatileQualified(), Ty);
+    Fn = CGM.getFunctionPointer(Fn,
+                                getObjCAtomicPropertyCopyHelperFunctionType(C));
     return llvm::ConstantExpr::getBitCast(Fn, VoidPtrTy);
   }
 
@@ -3927,7 +3941,8 @@ llvm::Constant *CodeGenFunction::GenerateObjCAtomicGetterCopyHelperFunction(
                   AggValueSlot::IsNotAliased, AggValueSlot::DoesNotOverlap));
 
   FinishFunction();
-  HelperFn = CGM.getFunctionPointer(Fn, FD->getType());
+  HelperFn = CGM.getFunctionPointer(
+      Fn, getObjCAtomicPropertyCopyHelperFunctionType(C));
   HelperFn = llvm::ConstantExpr::getBitCast(HelperFn, VoidPtrTy);
   CGM.setAtomicGetterHelperFnMap(Ty, HelperFn);
   return HelperFn;

--- a/clang/test/CodeGenObjC/nontrivial-c-struct-property.m
+++ b/clang/test/CodeGenObjC/nontrivial-c-struct-property.m
@@ -1,4 +1,5 @@
-// RUN: %clang_cc1 -triple arm64-apple-ios11 -fobjc-arc -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple arm64-apple-ios11 -fobjc-arc -emit-llvm -o - %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-DISABLE-PTRAUTH %s
+// RUN: %clang_cc1 -triple arm64-apple-ios11 -fobjc-arc  -fptrauth-calls -emit-llvm -o - %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-ENABLE-PTRAUTH %s
 
 typedef struct {
   id x;
@@ -24,6 +25,9 @@ typedef struct {
 @end
 
 // CHECK: %[[STRUCT_S0:.*]] = type { ptr }
+
+// CHECK-ENABLE-PTRAUTH: @__copy_constructor_8_8_s0.ptrauth = private constant { ptr, i32, i64, i64 } { ptr @__copy_constructor_8_8_s0, i32 0, i64 0, i64 0 }, section "llvm.ptrauth",
+// CHECK-ENABLE-PTRAUTH: @__move_assignment_8_8_s0.ptrauth = private constant { ptr, i32, i64, i64 } { ptr @__move_assignment_8_8_s0, i32 0, i64 0, i64 0 }, section "llvm.ptrauth",
 
 // Check that parameters of user-defined setters are destructed.
 
@@ -60,11 +64,13 @@ typedef struct {
 // CHECK: ret void
 
 // CHECK-LABEL: define internal i64 @"\01-[C atomic0]"(
-// CHECK: call void @objc_copyCppObjectAtomic({{.*}}, {{.*}}, ptr noundef @__copy_constructor_8_8_s0)
+// CHECK-DISABLE-PTRAUTH: call void @objc_copyCppObjectAtomic({{.*}}, {{.*}}, ptr noundef @__copy_constructor_8_8_s0)
+// CHECK-ENABLE-PTRAUTH: call void @objc_copyCppObjectAtomic({{.*}}, {{.*}}, ptr noundef @__copy_constructor_8_8_s0.ptrauth)
 // CHECK-NOT: call
 // CHECK: ret i64
 
 // CHECK-LABEL: define internal void @"\01-[C setAtomic0:]"(
-// CHECK: call void @objc_copyCppObjectAtomic({{.*}}, {{.*}}, ptr noundef @__move_assignment_8_8_s0)
+// CHECK-DISABLE-PTRAUTH: call void @objc_copyCppObjectAtomic({{.*}}, {{.*}}, ptr noundef @__move_assignment_8_8_s0)
+// CHECK-ENABLE-PTRAUTH: call void @objc_copyCppObjectAtomic({{.*}}, {{.*}}, ptr noundef @__move_assignment_8_8_s0.ptrauth)
 // CHECK-NOT: call
 // CHECK: ret void


### PR DESCRIPTION
…per functions passed to objc_copyCppObjectAtomic (#5674)

* [arm64e] Sign pointers to ObjC atomic property getter/setter copy helper functions passed to objc_copyCppObjectAtomic

This fixes a runtime crash. objc_copyCppObjectAtomic calls the helper functions indirectly through the function pointers and expects the function pointers to be signed using key 0.

* Call getFunctionPointer instead of using a new schema for the helper functions

Pass the correct function type ('void (void *, const void *)') to calls to getFunctionPointer in both C and C++ mode.

(cherry picked from commit d5dfc6093fdef0d8fba14a25fd2c671a74fe7cbf)