### PR TITLE
[Clang] Adjust assert from Sema::BuildCXXTypeConstructExpr

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -251,6 +251,18 @@ Bug Fixes
 - GNU attributes being applied prior to standard attributes would be handled
   improperly, which was corrected to match the behaviour exhibited by GCC.
   `Issue 58229 <https://github.com/llvm/llvm-project/issues/58229>`_
+- The builtin type trait ``__is_aggregate`` now returns ``true`` for arrays of incomplete
+  types in accordance with the suggested fix for `LWG3823 <https://cplusplus.github.io/LWG/issue3823>`_
+- Fix bug with using enum that could lead to enumerators being treated as if
+  they were part of an overload set. This fixes
+  `Issue 58067 <https://github.com/llvm/llvm-project/issues/58057>`_
+  `Issue 59014 <https://github.com/llvm/llvm-project/issues/59014>`_
+  `Issue 54746 <https://github.com/llvm/llvm-project/issues/54746>`_
+- Fix assert that triggers a crash during some types of list initialization that
+  generate a CXXTemporaryObjectExpr instead of a InitListExpr. This fixes
+  `Issue 58302 <https://github.com/llvm/llvm-project/issues/58302>`_
+  `Issue 58753 <https://github.com/llvm/llvm-project/issues/58753>`_
+  `Issue 59100 <https://github.com/llvm/llvm-project/issues/59100>`_
 
 Improvements to Clang's diagnostics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -1452,9 +1452,8 @@ Sema::BuildCXXTypeConstructExpr(TypeSourceInfo *TInfo,
   QualType Ty = TInfo->getType();
   SourceLocation TyBeginLoc = TInfo->getTypeLoc().getBeginLoc();
 
-  assert((!ListInitialization ||
-          (Exprs.size() == 1 && isa<InitListExpr>(Exprs[0]))) &&
-         "List initialization must have initializer list as expression.");
+  assert((!ListInitialization || Exprs.size() == 1) &&
+         "List initialization must have exactly one expression.");
   SourceRange FullRange = SourceRange(TyBeginLoc, RParenOrBraceLoc);
 
   InitializedEntity Entity =

--- a/clang/test/SemaCXX/cxx0x-initializer-references.cpp
+++ b/clang/test/SemaCXX/cxx0x-initializer-references.cpp
@@ -140,3 +140,21 @@ namespace PR20844 {
 namespace PR21834 {
 const int &a = (const int &){0}; // expected-error {{cannot bind to an initializer list}}
 }
+
+namespace GH59100 {
+class v {};
+
+template <typename T>
+class V : public v {};
+
+using T = const V<int> &;
+
+template <class D>
+void f() {
+  auto t = T{};
+}
+
+void z()  {
+    f<int>();
+}
+}

--- a/clang/test/SemaCXX/cxx2a-consteval.cpp
+++ b/clang/test/SemaCXX/cxx2a-consteval.cpp
@@ -1018,3 +1018,14 @@ void g() {
   (void)[](int i) consteval { return i; }(0);
 }
 }  // namespace GH50455
+
+namespace GH58302 {
+struct A {
+   consteval A(){}
+   consteval operator int() { return 1;}
+};
+
+int f() {
+   int x = A{};
+}
+}


### PR DESCRIPTION
Currently Sema::BuildCXXTypeConstructExpr asserts that list initialization must mean we have an InitListExpr as well. We have several cases of valid code the result in CXXTemporaryObjectExpr in the AST instead for list initialization. Commit 1ae689c seems to indicate that this is not unexpected, although may be a design issue

This fixes:

  https://github.com/llvm/llvm-project/issues/58302
  https://github.com/llvm/llvm-project/issues/58753
  https://github.com/llvm/llvm-project/issues/59100

Differential Revision: https://reviews.llvm.org/D138947