### PR TITLE
[Index] Use correct `printName` when generating a `MSGuidDecl` USR

### DIFF
--- a/clang/lib/Index/USRGeneration.cpp
+++ b/clang/lib/Index/USRGeneration.cpp
@@ -1058,7 +1058,7 @@ void USRGenerator::VisitConceptDecl(const ConceptDecl *D) {
 void USRGenerator::VisitMSGuidDecl(const MSGuidDecl *D) {
   VisitDeclContext(D->getDeclContext());
   Out << "@MG@";
-  D->NamedDecl::printName(Out);
+  D->printName(Out);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This is stable/20220421 specific - do not cherry-pick to next.

On stable/20220421, `printName(raw_ostream)` is virtual. But next has changed that method to be non-virtual and to instead call `printName` with a `PrintingPolicy`.

This is a fairly wide-reaching change and would require pulling in a bunch of changes. Just use the virtual `printName` directly instead.