### PR TITLE
Don't revisit the subexpressions of PseudoObjectExpr when building a ParentMap

### DIFF
--- a/clang/lib/AST/ParentMap.cpp
+++ b/clang/lib/AST/ParentMap.cpp
@@ -33,8 +33,10 @@ static void BuildParentMap(MapTy& M, Stmt* S,
 
   switch (S->getStmtClass()) {
   case Stmt::PseudoObjectExprClass: {
-    assert(OVMode == OV_Transparent && "Should not appear alongside OVEs");
     PseudoObjectExpr *POE = cast<PseudoObjectExpr>(S);
+
+    if (OVMode == OV_Opaque && M[POE->getSyntacticForm()])
+      break;
 
     // If we are rebuilding the map, clear out any existing state.
     if (M[POE->getSyntacticForm()])

--- a/clang/test/SemaObjC/arc-repeated-weak.mm
+++ b/clang/test/SemaObjC/arc-repeated-weak.mm
@@ -290,6 +290,18 @@ void doWhileLoop(Test *a) {
   } while(0);
 }
 
+struct S {
+  int a;
+  id b;
+};
+
+@interface C
+@property S p;
+@end
+
+void test_list_init(C *c) {
+  c.p = {0, c.p.b};
+}
 
 @interface Test (Methods)
 @end


### PR DESCRIPTION
The assertion that is removed in this patch was failing when ObjC dot notation expressions appear in both sides of an assignment (see the test case in arc-repeated-weak.mm). Visit the PseudoObjectExpr once when the syntactic expression is visited and return without visiting the subexpressions when it's visited again when the semantic expressions are visited.

Differential Revision: https://reviews.llvm.org/D139171

(cherry picked from commit 1127e479e85011b4284dd5097ca2732347198130)