### PR TITLE
[lldb] @swiftTest decorator should fail if LLDB build config has no swift key

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -647,7 +647,7 @@ def skipUnlessTargetAndroid(func):
 def swiftTest(func):
     """Decorate the item as a Swift test (Darwin/Linux only, no i386)."""
     def is_not_swift_compatible(self):
-        if not _get_bool_config("swift"):
+        if not _get_bool_config("swift", fail_value = False):
            return "Swift plugin not enabled"
         if self.getDebugInfo() == "gmodules":
             return "skipping (gmodules only makes sense for clang tests)"


### PR DESCRIPTION
Currently the test suite relies on a function called `_get_bool_config` to determine whether or not LLDB supports a specific features (e.g. swift, xml, lua, etc). This is useful for enabling and disabling specific tests, e.g. if LLDB doesn't support swift then we can disable swift-specific tests.

Because SBDebugger::GetBuildConfiguration's return value only has a swift entry if `LLDB_ENABLE_SWIFT` is true, `_get_bool_config` needs to return False when no swift entry is found. Otherwise, the `swiftTest` decorator will always enable swift tests regardless of whether or not swift support is present.