### PR TITLE
Fix some potential crashes from cantFail/report_fatal_error

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -26,6 +26,7 @@ def err_cas_depscan_daemon_connection: Error<
   "Failed to establish connection with depscan daemon: %0">, DefaultFatal;
 def err_cas_depscan_failed: Error<
   "CAS-based dependency scan failed: %0">, DefaultFatal;
+def err_cas_load: Error<"failed to load from CAS: %0">, DefaultFatal;
 def err_cas_store: Error<"failed to store to CAS: %0">, DefaultFatal;
 def err_cas_cannot_get_module_cache_key : Error<
   "CAS cannot load module with key '%0' from %1: %2">, DefaultFatal;

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h
@@ -25,15 +25,23 @@
 namespace llvm {
 namespace cas {
 class CachingOnDiskFileSystem;
+class DiagnosticsEngine;
 } // namespace cas
 } // namespace llvm
 
 namespace clang {
+class DiagnosticsEngine;
+
 namespace tooling {
 namespace dependencies {
 
 class DependencyScanningCASFilesystem : public llvm::cas::ThreadSafeFileSystem {
 public:
+  /// Set a \c DiagnosticsEngine to use if there are errors scanning for
+  /// directives. Must be set before scanning.
+  DiagnosticsEngine *Diagnostics = nullptr;
+
+  /// \note Diagnostics must be set before using this filesystem.
   DependencyScanningCASFilesystem(
       IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> WorkerFS,
       llvm::cas::ActionCache &Cache);

--- a/clang/unittests/Tooling/DependencyScanningCASFilesystemTest.cpp
+++ b/clang/unittests/Tooling/DependencyScanningCASFilesystemTest.cpp
@@ -7,9 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/Tooling/DependencyScanning/DependencyScanningCASFilesystem.h"
+#include "clang/Basic/Diagnostic.h"
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/CAS/ObjectStore.h"
+#include "llvm/Testing/CAS/CASHelpers.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
 
@@ -17,6 +19,7 @@ using namespace clang;
 using namespace clang::cas;
 using namespace clang::cas;
 using namespace clang::tooling::dependencies;
+using llvm::cas::unittest::ErroringCAS;
 using llvm::unittest::TempDir;
 using llvm::unittest::TempFile;
 using llvm::unittest::TempLink;
@@ -31,6 +34,11 @@ TEST(DependencyScanningCASFilesystem, FilenameSpelling) {
   auto CacheFS = llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*CAS));
   DependencyScanningCASFilesystem FS(CacheFS, *Cache);
 
+  DiagnosticConsumer CountingConsumer;
+  DiagnosticsEngine Diags(new DiagnosticIDs{}, new DiagnosticOptions{},
+                          &CountingConsumer, /*ShouldOwnClient=*/false);
+  FS.Diagnostics = &Diags;
+
   EXPECT_EQ(FS.status(TestFile.path()).getError(), std::error_code());
   auto Directives = FS.getDirectiveTokens(TestFile.path());
   ASSERT_TRUE(Directives);
@@ -41,4 +49,61 @@ TEST(DependencyScanningCASFilesystem, FilenameSpelling) {
   auto DirectivesSymlink = FS.getDirectiveTokens(TestLink.path());
   ASSERT_TRUE(DirectivesSymlink);
   EXPECT_EQ(DirectivesSymlink->size(), 2u);
+  EXPECT_EQ(CountingConsumer.getNumErrors(), 0u);
+  EXPECT_EQ(CountingConsumer.getNumWarnings(), 0u);
+}
+
+TEST(DependencyScanningCASFilesystem, CASErrors) {
+  TempDir TestDir("DependencyScanningCASFilesystemTest", /*Unique=*/true);
+  TempFile TestFile(TestDir.path("File.h"), "", "#define FOO\n");
+  TempLink TestLink("File.h", TestDir.path("SymFile.h"));
+
+  // Trigger CAS errors after 0, 1, ... operations and ensure there are no
+  // crashes and that errors are reported.
+  unsigned AllowCASOps = 0, MaxCASOps = 100;
+  unsigned DirectiveFailures = 0;
+  for (; AllowCASOps < MaxCASOps; ++AllowCASOps) {
+    std::unique_ptr<ErroringCAS> CAS =
+        std::make_unique<ErroringCAS>(llvm::cas::createInMemoryCAS());
+    std::unique_ptr<ActionCache> Cache = llvm::cas::createInMemoryActionCache();
+    auto CacheFS =
+        llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*CAS));
+    DependencyScanningCASFilesystem FS(CacheFS, *Cache);
+    DiagnosticConsumer CountingConsumer;
+    DiagnosticsEngine Diags(new DiagnosticIDs{}, new DiagnosticOptions{},
+                            &CountingConsumer, /*ShouldOwnClient=*/false);
+    FS.Diagnostics = &Diags;
+
+    // FIXME: There's a crash here to fix; for now prewarm the cache.
+    // EXPECT_EQ(CacheFS->status(TestFile.path()).getError(),
+    // std::error_code());
+
+    // Allow I CAS operations before error.
+    CAS->setErrorCounter(AllowCASOps);
+
+    // Trigger scan.
+    if (FS.status(TestFile.path()).getError()) {
+      // Failed before scan; CachingOnDiskFileSystem reports no diagnostics.
+      EXPECT_EQ(CountingConsumer.getNumErrors(), 0u);
+      EXPECT_EQ(CountingConsumer.getNumWarnings(), 0u);
+      continue;
+    }
+
+    if (auto Directives = FS.getDirectiveTokens(TestFile.path())) {
+      // If we have directives, there should have been no CAS errors.
+      EXPECT_EQ(CountingConsumer.getNumErrors(), 0u);
+      EXPECT_EQ(CountingConsumer.getNumWarnings(), 0u);
+      EXPECT_EQ(Directives->size(), 2u);
+      // Once we finish successfully, we're done.
+      break;
+    }
+
+    // CAS error should be captured as diagnostic.
+    EXPECT_EQ(CountingConsumer.getNumErrors(), 1u);
+    EXPECT_EQ(CountingConsumer.getNumWarnings(), 0u);
+    DirectiveFailures += 1;
+  }
+
+  EXPECT_GT(DirectiveFailures, 5u) << "scanning requires more CAS ops";
+  EXPECT_LT(AllowCASOps, MaxCASOps) << "scanning never succeeded";
 }

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -553,8 +553,10 @@ static Error addCASTree(ObjectFormatSchemaPool &CASSchemas, const CASID &ID) {
   Expected<cas::ObjectProxy> Tree = CASSchemas.getCAS().getProxy(*Object);
   if (!Tree)
     return Tree.takeError();
-  TreeSchema Schema(CASSchemas.getCAS());
-  return Schema.walkFileTreeRecursively(
+  auto Schema = TreeSchema::create(CASSchemas.getCAS());
+  if (!Schema)
+    return Schema.takeError();
+  return Schema->walkFileTreeRecursively(
       CASSchemas.getCAS(), *Tree,
       [&](const NamedTreeEntry &entry, Optional<TreeProxy>) -> Error {
         if (entry.getKind() == TreeEntry::Tree)

--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -127,6 +127,7 @@ class ObjectProxy;
 /// ObjectStore.
 class ObjectStore {
   friend class ObjectProxy;
+  friend class ProxyObjectStore;
   void anchor();
 
 public:
@@ -379,6 +380,62 @@ Expected<std::unique_ptr<ObjectStore>> createCASFromIdentifier(StringRef Path);
 using ObjectStoreCreateFuncTy =
     Expected<std::unique_ptr<ObjectStore>>(const Twine &);
 void registerCASURLScheme(StringRef Prefix, ObjectStoreCreateFuncTy *Func);
+
+/// By default, this delegates all calls to the underlying ObjectStore. This
+/// is useful when derived ObjectStores want to override some calls and still
+/// proxy other calls.
+class ProxyObjectStore : public ObjectStore {
+public:
+  explicit ProxyObjectStore(std::shared_ptr<ObjectStore> CAS)
+      : ObjectStore(CAS->getContext()), CAS(std::move(CAS)) {}
+
+  Expected<CASID> parseID(StringRef ID) override { return CAS->parseID(ID); }
+  Expected<ObjectRef> store(ArrayRef<ObjectRef> Refs,
+                            ArrayRef<char> Data) override {
+    return CAS->store(Refs, Data);
+  }
+  CASID getID(ObjectRef Ref) const override { return CAS->getID(Ref); }
+  CASID getID(ObjectHandle Handle) const override { return CAS->getID(Handle); }
+  Optional<ObjectRef> getReference(const CASID &ID) const override {
+    return CAS->getReference(ID);
+  }
+  Error validate(const CASID &ID) override { return CAS->validate(ID); }
+
+protected:
+  ObjectRef getReference(ObjectHandle Handle) const override {
+    return CAS->getReference(Handle);
+  }
+  Expected<ObjectHandle> load(ObjectRef Ref) override { return CAS->load(Ref); }
+  uint64_t getDataSize(ObjectHandle Node) const override {
+    return CAS->getDataSize(Node);
+  }
+  Error forEachRef(ObjectHandle Node, function_ref<Error(ObjectRef)> Callback) const override {
+    return CAS->forEachRef(Node, Callback);
+  }
+  ObjectRef readRef(ObjectHandle Node, size_t I) const override {
+    return CAS->readRef(Node, I);
+  }
+  size_t getNumRefs(ObjectHandle Node) const override {
+    return CAS->getNumRefs(Node);
+  }
+  ArrayRef<char> getData(ObjectHandle Node,
+                        bool RequiresNullTerminator = false) const override {
+    return CAS->getData(Node, RequiresNullTerminator);
+  }
+  Expected<ObjectRef>
+  storeFromOpenFileImpl(sys::fs::file_t FD,
+                        Optional<sys::fs::file_status> Status) override {
+    return CAS->storeFromOpenFileImpl(FD, Status);
+  }
+
+protected:
+  ObjectStore &getUnderlyingCAS() { return *CAS; }
+
+private:
+  std::shared_ptr<ObjectStore> CAS;
+
+  virtual void anchor();
+};
 
 } // namespace cas
 } // namespace llvm

--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -409,7 +409,8 @@ protected:
   uint64_t getDataSize(ObjectHandle Node) const override {
     return CAS->getDataSize(Node);
   }
-  Error forEachRef(ObjectHandle Node, function_ref<Error(ObjectRef)> Callback) const override {
+  Error forEachRef(ObjectHandle Node,
+                   function_ref<Error(ObjectRef)> Callback) const override {
     return CAS->forEachRef(Node, Callback);
   }
   ObjectRef readRef(ObjectHandle Node, size_t I) const override {
@@ -419,7 +420,7 @@ protected:
     return CAS->getNumRefs(Node);
   }
   ArrayRef<char> getData(ObjectHandle Node,
-                        bool RequiresNullTerminator = false) const override {
+                         bool RequiresNullTerminator = false) const override {
     return CAS->getData(Node, RequiresNullTerminator);
   }
   Expected<ObjectRef>

--- a/llvm/include/llvm/CAS/TreeSchema.h
+++ b/llvm/include/llvm/CAS/TreeSchema.h
@@ -21,6 +21,8 @@ class TreeProxy;
 class TreeSchema : public RTTIExtends<TreeSchema, NodeSchema> {
   void anchor() override;
 
+  TreeSchema(ObjectStore &CAS, ObjectRef TreeKindRef);
+
 public:
   static char ID;
   bool isRootNode(const ObjectProxy &Node) const final {
@@ -28,7 +30,7 @@ public:
   }
   bool isNode(const ObjectProxy &Node) const final;
 
-  TreeSchema(ObjectStore &CAS);
+  static Expected<TreeSchema> create(ObjectStore &CAS);
 
   size_t getNumTreeEntries(TreeProxy Tree) const;
 
@@ -59,11 +61,11 @@ public:
 
 private:
   static constexpr StringLiteral SchemaName = "llvm::cas::schema::tree::v1";
-  Optional<ObjectRef> TreeKindRef;
+  ObjectRef TreeKindRef;
 
   friend class TreeProxy;
 
-  ObjectRef getKindRef() const;
+  ObjectRef getKindRef() const { return TreeKindRef; }
 };
 
 class TreeProxy : public ObjectProxy {

--- a/llvm/include/llvm/Testing/CAS/CASHelpers.h
+++ b/llvm/include/llvm/Testing/CAS/CASHelpers.h
@@ -1,0 +1,49 @@
+//===- Testing/CAS/CASHelpers.h ---------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TESTING_CAS_CASHELPERS_H
+#define LLVM_TESTING_CAS_CASHELPERS_H
+
+#include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/Error.h"
+
+namespace llvm::cas::unittest {
+
+/// An \c ObjectStore wrapper that injects \c Error values into load/store
+/// operations based on a counter. Useful for ensuring that \c Error values are
+/// handled or propogated correctly from code that uses a CAS.
+class ErroringCAS : public llvm::cas::ProxyObjectStore {
+public:
+  ErroringCAS(std::unique_ptr<ObjectStore> CAS)
+      : ProxyObjectStore(std::move(CAS)) {}
+
+  /// Trigger errors after \c Count load or store operations.
+  void setErrorCounter(unsigned Count) { ErrorCounter = Count; }
+
+  Expected<ObjectRef> store(ArrayRef<ObjectRef> Refs,
+                            ArrayRef<char> Data) override {
+    if (ErrorCounter == 0)
+      return llvm::createStringError(std::errc::operation_canceled, "store");
+    ErrorCounter -= 1;
+    return ProxyObjectStore::store(Refs, Data);
+  }
+
+private:
+  Expected<llvm::cas::ObjectHandle> load(ObjectRef Ref) override {
+    if (ErrorCounter == 0)
+      return llvm::createStringError(std::errc::operation_canceled, "load");
+    ErrorCounter -= 1;
+    return ProxyObjectStore::load(Ref);
+  }
+
+  unsigned ErrorCounter = std::numeric_limits<unsigned>::max();
+};
+
+} // namespace llvm::cas::unittest
+
+#endif // LLVM_TESTING_CAS_CASHELPERS_H

--- a/llvm/lib/CAS/CASFileSystem.cpp
+++ b/llvm/lib/CAS/CASFileSystem.cpp
@@ -183,8 +183,10 @@ Error CASFileSystem::loadDirectory(DirectoryEntry &Parent) {
   if (!Object)
     return Object.takeError();
 
-  TreeSchema Schema(DB);
-  if (!Schema.isNode(*Object))
+  auto Schema = TreeSchema::create(DB);
+  if (!Schema)
+    return Schema.takeError();
+  if (!Schema->isNode(*Object))
     report_fatal_error(createStringError(
         inconvertibleErrorCode(),
         "invalid tree '" + Object->getID().toString() + "'"));
@@ -194,7 +196,7 @@ Error CASFileSystem::loadDirectory(DirectoryEntry &Parent) {
   if (D.isComplete())
     return Error::success();
 
-  Expected<TreeProxy> Tree = Schema.load(*Object);
+  Expected<TreeProxy> Tree = Schema->load(*Object);
   if (!Tree)
     return Tree.takeError();
 

--- a/llvm/lib/CAS/ObjectStore.cpp
+++ b/llvm/lib/CAS/ObjectStore.cpp
@@ -154,3 +154,5 @@ void cas::registerCASURLScheme(StringRef Prefix,
                                ObjectStoreCreateFuncTy *Func) {
   getRegisteredScheme().insert({Prefix, Func});
 }
+
+void ProxyObjectStore::anchor() {}

--- a/llvm/lib/CAS/TreeSchema.cpp
+++ b/llvm/lib/CAS/TreeSchema.cpp
@@ -31,12 +31,15 @@ bool TreeSchema::isNode(const ObjectProxy &Node) const {
   return FirstRef == getKindRef();
 }
 
-TreeSchema::TreeSchema(cas::ObjectStore &CAS) : TreeSchema::RTTIExtends(CAS) {
-  auto Kind = cantFail(CAS.createProxy(None, SchemaName));
-  TreeKindRef.emplace(Kind.getRef());
-}
+TreeSchema::TreeSchema(cas::ObjectStore &CAS, ObjectRef TreeKindRef)
+    : TreeSchema::RTTIExtends(CAS), TreeKindRef(TreeKindRef) {}
 
-ObjectRef TreeSchema::getKindRef() const { return *TreeKindRef; }
+Expected<TreeSchema> TreeSchema::create(cas::ObjectStore &CAS) {
+  auto Kind = CAS.createProxy(None, SchemaName);
+  if (!Kind)
+    return Kind.takeError();
+  return TreeSchema(CAS, Kind->getRef());
+}
 
 size_t TreeSchema::getNumTreeEntries(TreeProxy Tree) const {
   return Tree.getNumReferences() - 1;

--- a/llvm/lib/TableGen/Main.cpp
+++ b/llvm/lib/TableGen/Main.cpp
@@ -501,8 +501,10 @@ Error TableGenCache::replayResult() {
   if (!Node)
     return Node.takeError();
 
-  llvm::cas::TreeSchema Schema(*CAS);
-  Expected<cas::TreeProxy> Tree = Schema.load(*Node);
+  auto Schema = cas::TreeSchema::create(*CAS);
+  if (!Schema)
+    return Schema.takeError();
+  Expected<cas::TreeProxy> Tree = Schema->load(*Node);
   if (!Tree)
     return Tree.takeError();
 

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -186,7 +186,7 @@ int main(int Argc, char **Argv) {
 int listTree(ObjectStore &CAS, const CASID &ID) {
   ExitOnError ExitOnErr("llvm-cas: ls-tree: ");
 
-  TreeSchema Schema(CAS);
+  TreeSchema Schema = ExitOnErr(TreeSchema::create(CAS));
   ObjectProxy TreeN = ExitOnErr(CAS.getProxy(ID));
   TreeProxy Tree = ExitOnErr(Schema.load(TreeN));
   ExitOnErr(Tree.forEachEntry([&](const NamedTreeEntry &Entry) {
@@ -199,7 +199,7 @@ int listTree(ObjectStore &CAS, const CASID &ID) {
 
 int listTreeRecursively(ObjectStore &CAS, const CASID &ID) {
   ExitOnError ExitOnErr("llvm-cas: ls-tree-recursively: ");
-  TreeSchema Schema(CAS);
+  TreeSchema Schema = ExitOnErr(TreeSchema::create(CAS));
   ExitOnErr(Schema.walkFileTreeRecursively(
       CAS, ExitOnErr(CAS.getProxy(ID)),
       [&](const NamedTreeEntry &Entry, Optional<TreeProxy> Tree) -> Error {
@@ -249,7 +249,8 @@ int catNodeData(ObjectStore &CAS, const CASID &ID) {
 }
 
 static StringRef getKindString(ObjectStore &CAS, ObjectProxy Object) {
-  TreeSchema Schema(CAS);
+  ExitOnError ExitOnErr("llvm-cas: getKindString");
+  TreeSchema Schema = ExitOnErr(TreeSchema::create(CAS));
   if (Schema.isNode(Object))
     return "tree";
   return "object";
@@ -322,7 +323,7 @@ static GraphInfo traverseObjectGraph(ObjectStore &CAS, const CASID &TopLevel) {
     CASID ID = Worklist.back().first;
     ObjectProxy Object = ExitOnErr(CAS.getProxy(ID));
 
-    TreeSchema Schema(CAS);
+    TreeSchema Schema = ExitOnErr(TreeSchema::create(CAS));
     if (Schema.isNode(Object)) {
       TreeProxy Tree = ExitOnErr(Schema.load(Object));
       ExitOnErr(Tree.forEachEntry([&](const NamedTreeEntry &Entry) {

--- a/llvm/unittests/CAS/ObjectStoreTest.cpp
+++ b/llvm/unittests/CAS/ObjectStoreTest.cpp
@@ -314,5 +314,6 @@ TEST_P(CASTest, ProxyObjectStoreBasics) {
   Optional<ObjectRef> Ref2 = CAS.getReference(*ID2);
   ASSERT_TRUE(Ref2);
 
-  ASSERT_THAT_ERROR(CAS.createProxy({*Ref1, *Ref2}, "1").moveInto(ID1), Succeeded());
+  ASSERT_THAT_ERROR(CAS.createProxy({*Ref1, *Ref2}, "1").moveInto(ID1),
+                    Succeeded());
 }

--- a/llvm/unittests/CAS/ObjectStoreTest.cpp
+++ b/llvm/unittests/CAS/ObjectStoreTest.cpp
@@ -293,3 +293,26 @@ TEST_P(CASTest, ManyNodes) {
   for (auto ID : CreatedNodes)
     ASSERT_THAT_ERROR(CAS->validate(CAS->getID(ID)), Succeeded());
 }
+
+TEST_P(CASTest, ProxyObjectStoreBasics) {
+  ProxyObjectStore CAS(createObjectStore());
+
+  Optional<CASID> ID1, ID2;
+  ASSERT_THAT_ERROR(CAS.createProxy(None, "1").moveInto(ID1), Succeeded());
+  ASSERT_THAT_ERROR(CAS.createProxy(None, "2").moveInto(ID2), Succeeded());
+  std::string PrintedID1 = ID1->toString();
+  std::string PrintedID2 = ID2->toString();
+
+  Optional<CASID> ParsedID1, ParsedID2;
+  ASSERT_THAT_ERROR(CAS.parseID(PrintedID1).moveInto(ParsedID1), Succeeded());
+  ASSERT_THAT_ERROR(CAS.parseID(PrintedID2).moveInto(ParsedID2), Succeeded());
+  EXPECT_EQ(ID1, ParsedID1);
+  EXPECT_EQ(ID2, ParsedID2);
+
+  Optional<ObjectRef> Ref1 = CAS.getReference(*ID1);
+  ASSERT_TRUE(Ref1);
+  Optional<ObjectRef> Ref2 = CAS.getReference(*ID2);
+  ASSERT_TRUE(Ref2);
+
+  ASSERT_THAT_ERROR(CAS.createProxy({*Ref1, *Ref2}, "1").moveInto(ID1), Succeeded());
+}

--- a/llvm/unittests/CAS/TreeSchemaTest.cpp
+++ b/llvm/unittests/CAS/TreeSchemaTest.cpp
@@ -56,7 +56,7 @@ TEST(TreeSchemaTest, Trees) {
 
   SmallVector<ObjectRef> FlatRefs;
   SmallVector<CASID> FlatIDs;
-  TreeSchema Schema1(*CAS1);
+  TreeSchema Schema1 = llvm::cantFail(TreeSchema::create(*CAS1));
 
   for (ArrayRef<NamedTreeEntry> Entries : FlatTreeEntries) {
     Optional<TreeProxy> H;
@@ -98,7 +98,7 @@ TEST(TreeSchemaTest, Trees) {
   // Insert into the other CAS and confirm the IDs are stable.
   for (int I = FlatIDs.size(), E = 0; I != E; --I) {
     for (ObjectStore *CAS : {&*CAS1, &*CAS2}) {
-      TreeSchema Schema(*CAS);
+      TreeSchema Schema = llvm::cantFail(TreeSchema::create(*CAS));
       auto &ID = FlatIDs[I - 1];
       // Make a copy of the original entries and sort them.
       SmallVector<NamedTreeEntry> NewEntries;
@@ -174,7 +174,7 @@ TEST(TreeSchemaTest, Trees) {
       }
       llvm::sort(NewEntries);
 
-      TreeSchema Schema(*CAS);
+      TreeSchema Schema = llvm::cantFail(TreeSchema::create(*CAS));
       Optional<TreeProxy> Tree;
       ASSERT_THAT_ERROR(Schema.create(NewEntries).moveInto(Tree),
                         Succeeded());
@@ -206,7 +206,7 @@ TEST(TreeSchemaTest, Lookup) {
       NamedTreeEntry(Blob, TreeEntry::Regular, "d"),
   };
   Optional<TreeProxy> Tree;
-  TreeSchema Schema(*CAS);
+  TreeSchema Schema = llvm::cantFail(TreeSchema::create(*CAS));
   ASSERT_THAT_ERROR(Schema.create(FlatTreeEntries).moveInto(Tree),
                     Succeeded());
   ASSERT_EQ(Tree->size(), (size_t)6);
@@ -251,7 +251,7 @@ TEST(TreeSchemaTest, walkFileTreeRecursively) {
   };
   auto RemainingEntries = makeArrayRef(ExpectedEntries);
 
-  TreeSchema Schema(*CAS);
+  TreeSchema Schema = llvm::cantFail(TreeSchema::create(*CAS));
   Error E = Schema.walkFileTreeRecursively(
       *CAS, *Root,
       [&](const NamedTreeEntry &Entry, Optional<TreeProxy> Tree) -> Error {


### PR DESCRIPTION
Remove cantFail and report_fatal_error for CAS Errors that are not programming errors, and propagate the errors instead. Add a new ErroringCAS test helper to inject Error values, and test that simple CachingOnDiskFileSystem and DependencyScanningCASFileSystem operations will not crash and propagate errors correctly.

We probably don't want every possible API using a CAS to need this kind of test, but we can add them to high-level places like these.

Most of the code changes are related to adding TreeSchema::create that returns Expected, so it may be easier to review commit-by-commit.