### PR TITLE
[lldb] Allow for the evaluation of self in a generic context

### DIFF
--- a/lldb/include/lldb/Interpreter/OptionGroupValueObjectDisplay.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupValueObjectDisplay.h
@@ -18,7 +18,7 @@ namespace lldb_private {
 
 class OptionGroupValueObjectDisplay : public OptionGroup {
 public:
-  OptionGroupValueObjectDisplay() = default;
+  OptionGroupValueObjectDisplay() : bind_generic_types(true) {}
 
   ~OptionGroupValueObjectDisplay() override = default;
 
@@ -33,7 +33,7 @@ public:
     return show_types || no_summary_depth != 0 || show_location ||
            flat_output || use_objc || max_depth != UINT32_MAX ||
            ptr_depth != 0 || !use_synth || be_raw || ignore_cap ||
-           run_validator;
+           run_validator || !bind_generic_types;
   }
 
   DumpValueObjectOptions GetAsDumpOptions(
@@ -44,7 +44,7 @@ public:
 
   bool show_types : 1, show_location : 1, flat_output : 1, use_objc : 1,
       use_synth : 1, be_raw : 1, ignore_cap : 1, run_validator : 1,
-      max_depth_is_default : 1;
+      max_depth_is_default : 1, bind_generic_types : 1;
 
   uint32_t no_summary_depth;
   uint32_t max_depth;

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -437,6 +437,10 @@ public:
       m_language = lldb::eLanguageTypeSwift;
   }
 
+  bool GetBindGenericTypes() const { return m_bind_generic_types; }
+
+  void SetBindGenericTypes(bool b) { m_bind_generic_types = b; }
+
   bool GetPlaygroundTransformHighPerformance() const {
     return m_playground_transforms_hp;
   }
@@ -521,6 +525,8 @@ private:
   /// True if the executed code should be treated as utility code that is only
   /// used by LLDB internally.
   bool m_running_utility_expression = false;
+
+  bool m_bind_generic_types = true;
 
   lldb::DynamicValueType m_use_dynamic = lldb::eNoDynamicValues;
   Timeout<std::micro> m_timeout = default_timeout;

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -371,6 +371,7 @@ CommandObjectExpression::GetEvalOptions(const Target &target) {
   options.SetDebug(m_command_options.debug);
 
   // BEGIN SWIFT
+  options.SetBindGenericTypes(m_varobj_options.bind_generic_types);
   // If the language was not specified in the expression command,
   // set it to the language in the target's properties if
   // specified, else default to the language for the frame.

--- a/lldb/source/Interpreter/OptionGroupValueObjectDisplay.cpp
+++ b/lldb/source/Interpreter/OptionGroupValueObjectDisplay.cpp
@@ -58,7 +58,13 @@ static const OptionDefinition g_option_table[] = {
     {LLDB_OPT_SET_1, false, "element-count", 'Z',
      OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeCount,
      "Treat the result of the expression as if its type is an array of this "
-     "many values."}};
+     "many values."},
+    {LLDB_OPT_SET_1, false, "bind-generic-types", /* no short option */ 1,
+     OptionParser::eRequiredArgument, nullptr, {}, 0,
+     eArgTypeBoolean, "Controls whether any generic types in the current "
+       "context should be bound to their dynamic concrete types before "
+       "evaluating. Defaults to true."}
+};
 
 llvm::ArrayRef<OptionDefinition>
 OptionGroupValueObjectDisplay::GetDefinitions() {
@@ -144,6 +150,13 @@ Status OptionGroupValueObjectDisplay::SetOptionValue(
 
   case 'V':
     run_validator = OptionArgParser::ToBoolean(option_arg, true, &success);
+    if (!success)
+      error.SetErrorStringWithFormat("invalid validate '%s'",
+                                     option_arg.str().c_str());
+    break;
+
+  case 1:
+    bind_generic_types = OptionArgParser::ToBoolean(option_arg, true, &success);
     if (!success)
       error.SetErrorStringWithFormat("invalid validate '%s'",
                                      option_arg.str().c_str());

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -231,6 +231,10 @@ swift::Type SwiftASTContext::GetSwiftType(CompilerType compiler_type) {
   if (compiler_type.GetTypeSystem().isa_and_nonnull<SwiftASTContext>())
     return reinterpret_cast<swift::TypeBase *>(
         compiler_type.GetOpaqueQualType());
+  if (auto ts = compiler_type.GetTypeSystem()
+                    .dyn_cast_or_null<TypeSystemSwiftTypeRef>())
+    return ts->GetSwiftType(compiler_type);
+
   return {};
 }
 
@@ -4072,7 +4076,7 @@ swift::TypeBase *SwiftASTContext::ReconstructType(ConstString mangled_typename,
     // the mapping isn't bijective.
     if (ast_type == found_type)
       CacheDemangledType(mangled_typename, ast_type);
-    CompilerType result_type = {weak_from_this(), ast_type};//ToCompilerType(ast_type);
+    CompilerType result_type = {weak_from_this(), ast_type};
     LOG_PRINTF(GetLog(LLDBLog::Types), "(\"%s\") -- found %s", mangled_cstr,
                result_type.GetTypeName().GetCString());
     return ast_type;
@@ -7622,6 +7626,17 @@ std::string SwiftASTContext::GetSwiftName(const clang::Decl *clang_decl,
   if (auto name_decl = llvm::dyn_cast<clang::NamedDecl>(clang_decl))
     return ImportName(name_decl);
   return {};
+}
+
+CompilerType SwiftASTContext::GetBuiltinRawPointerType() {
+  return GetTypeFromMangledTypename(ConstString("$sBpD"));
+}
+
+bool SwiftASTContext::TypeHasArchetype(CompilerType type) {
+  auto swift_type = GetSwiftType(type);
+  if (swift_type)
+    return swift_type->hasArchetype();
+  return false;
 }
 
 std::string SwiftASTContext::ImportName(const clang::NamedDecl *clang_decl) {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -361,6 +361,11 @@ public:
   /// clang_decl.
   std::string GetSwiftName(const clang::Decl *clang_decl,
                            TypeSystemClang &clang_typesystem) override;
+
+  CompilerType GetBuiltinRawPointerType() override;
+
+  bool TypeHasArchetype(CompilerType type);
+
   /// Use \p ClangImporter to swiftify the decl's name.
   std::string ImportName(const clang::NamedDecl *clang_decl);
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -162,6 +162,8 @@ public:
   virtual std::string GetSwiftName(const clang::Decl *clang_decl,
                                    TypeSystemClang &clang_typesystem) = 0;
 
+  virtual CompilerType GetBuiltinRawPointerType() = 0;
+
   void DumpValue(lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
                  Stream *s, lldb::Format format, const DataExtractor &data,
                  lldb::offset_t data_offset, size_t data_byte_size,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -80,6 +80,11 @@ public:
   CompilerType GetGenericArgumentType(lldb::opaque_compiler_type_t type,
                                       size_t idx) override;
 
+  /// Returns the list of DependentGenericParamTypes (depth, index pairs) that a
+  /// type has, if any.
+  static llvm::SmallVector<std::pair<int, int>, 1>
+  GetDependentGenericParamListForType(llvm::StringRef type);
+
   // PluginInterface functions
   llvm::StringRef GetPluginName() override { return "TypeSystemSwiftTypeRef"; }
 
@@ -305,6 +310,8 @@ public:
   std::string GetSwiftName(const clang::Decl *clang_decl,
                            TypeSystemClang &clang_typesystem) override;
 
+  CompilerType GetBuiltinRawPointerType() override;
+
   /// Wrap \p node as \p Global(TypeMangling(node)), remangle the type
   /// and create a CompilerType from it.
   CompilerType RemangleAsType(swift::Demangle::Demangler &dem,
@@ -318,7 +325,7 @@ protected:
   /// Helper that creates an AST type from \p type.
   void *ReconstructType(lldb::opaque_compiler_type_t type);
   /// Cast \p opaque_type as a mangled name.
-  const char *AsMangledName(lldb::opaque_compiler_type_t type);
+  static const char *AsMangledName(lldb::opaque_compiler_type_t type);
 
   /// Lookup a type in the debug info.
   lldb::TypeSP FindTypeInModule(lldb::opaque_compiler_type_t type);

--- a/lldb/test/API/lang/swift/private_generic_type/Makefile
+++ b/lldb/test/API/lang/swift/private_generic_type/Makefile
@@ -1,0 +1,34 @@
+SWIFT_SOURCES := main.swift
+
+all:  libPublic.dylib libPrivate.dylib a.out
+
+include Makefile.rules
+LD_EXTRAS = -lPublic -lPrivate -L$(BUILDDIR)
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
+
+libPrivate.dylib: Private.swift
+	$(MAKE) MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=Private \
+		LD_EXTRAS="-lPublic -L$(BUILDDIR)" \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR)" \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		DYLIB_ONLY:=YES DYLIB_NAME=Private \
+		DYLIB_SWIFT_SOURCES:=Private.swift \
+		-f $(MAKEFILE_RULES)
+
+libPublic.dylib: Public.swift
+	$(MAKE) MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=Public \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR)" \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		DYLIB_ONLY:=YES DYLIB_NAME=Public \
+		DYLIB_SWIFT_SOURCES:=Public.swift \
+		-f $(MAKEFILE_RULES)
+
+clean::
+	$(MAKE) BASENAME=Private VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk clean
+	$(MAKE) BASENAME=Public VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk clean
+
+

--- a/lldb/test/API/lang/swift/private_generic_type/Private.swift
+++ b/lldb/test/API/lang/swift/private_generic_type/Private.swift
@@ -1,0 +1,25 @@
+import Public
+
+private struct InvisibleStruct {
+  public var name = "The invisible man."
+}
+
+private class InvisibleClass {
+  public var name = "The invisible class"
+  public var someNumber = 42
+}
+
+public func privateDoIt()  {
+  let structWrapper = StructWrapper(InvisibleStruct())
+  structWrapper.foo()
+
+
+  let classWrapper = ClassWrapper(InvisibleStruct())
+  classWrapper.foo()
+
+  let nonGeneric = NonGeneric()
+  nonGeneric.foo()
+
+  let twoGenericParameters = TwoGenericParameters(InvisibleStruct(), InvisibleClass())
+  twoGenericParameters.foo()
+}

--- a/lldb/test/API/lang/swift/private_generic_type/Public.swift
+++ b/lldb/test/API/lang/swift/private_generic_type/Public.swift
@@ -1,0 +1,45 @@
+
+public struct StructWrapper<T> {
+  let t: T
+
+  public init(_ t: T) {
+    self.t = t
+  }
+  public func foo() {
+    print(self) // break here for struct
+  }
+}
+
+public class ClassWrapper<T> {
+  let t: T
+
+  public init(_ t: T) {
+    self.t = t
+  }
+  public func foo() {
+    print(self) // break here for class
+  }
+}
+
+
+public class NonGeneric {
+  public init() {}
+
+  public func foo() {
+    print(self) // break here for non-generic
+  }
+}
+
+public class TwoGenericParameters<T, U> {
+  let t: T
+  let u: U
+
+  public init(_ t: T, _ u: U) {
+    self.t = t
+    self.u = u
+  }
+
+  public func foo() {
+    print(self) // break here for two generic parameters
+  }
+}

--- a/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
+++ b/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
@@ -1,0 +1,47 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftPrivateGenericType(TestBase):
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test_private_generic_type(self):
+        """ Test that evaluating an expression without binding generic 
+        parameters works for private generic types"""
+        invisible_swift = self.getBuildArtifact("Private.swift")
+        import shutil
+        shutil.copyfile("Private.swift", invisible_swift)
+        self.build()
+        os.unlink(invisible_swift)
+        os.unlink(self.getBuildArtifact("Private.swiftmodule"))
+        os.unlink(self.getBuildArtifact("Private.swiftinterface"))
+
+        target, process, _, _ = lldbutil.run_to_source_breakpoint( self, 'break here for struct', lldb.SBFileSpec('Public.swift'),
+            extra_images=['Public'])
+        # Make sure this fails without generic expression evaluation.
+        self.expect("e --bind-generic-types true -- self", substrs=["Couldn't realize Swift AST type of self."], error=True)
+        self.expect("e --bind-generic-types false -- self", substrs=["Public.StructWrapper<T>", 
+                                             "The invisible man."])
+
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here for class', lldb.SBFileSpec('Public.swift'), None)
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("e --bind-generic-types true -- self", substrs=["Couldn't realize Swift AST type of self."], error=True)
+        self.expect("e --bind-generic-types false -- self", substrs=["Public.ClassWrapper<Private.InvisibleStruct>", 
+                                             "The invisible man."])
+
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here for non-generic', lldb.SBFileSpec('Public.swift'), None)
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("e --bind-generic-types false -- self", substrs=["Could not evaluate the expression as generic."], error=True)
+
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here for two generic parameters', lldb.SBFileSpec('Public.swift'), None)
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("e --bind-generic-types false -- self", substrs=["Could not evaluate the expression as generic."], error=True)
+

--- a/lldb/test/API/lang/swift/private_generic_type/main.swift
+++ b/lldb/test/API/lang/swift/private_generic_type/main.swift
@@ -1,0 +1,7 @@
+@_implementationOnly import Private
+
+func main() {
+  privateDoIt()
+}
+
+main()


### PR DESCRIPTION
There are situations where the compiler may not know all the types involved in evaluating an expression. For example, lldb might be stopped at a point where self is parameterized by some private type which lldb can't reconstruct the AST type. This patch allows for evaluating expressions with such types by not attempting to bind the generic types, this behavior is controlled by a new option.

The approach taken by this patch is setting up a generic function that calls the method with the user's code, and a sink function, which the entry point calls, and is later used to redirect the call to the generic function (at the LLVM-IR level).

rdar://91417802