### PR TITLE
[Clang][Sema] Added space after ',' in a warning

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -1381,7 +1381,7 @@ def warn_atomic_property_rule : Warning<
   "with a user defined %select{getter|setter}2">,
   InGroup<DiagGroup<"atomic-property-with-user-defined-accessor">>;
 def note_atomic_property_fixup_suggest : Note<"setter and getter must both be "
-  "synthesized, or both be user defined,or the property must be nonatomic">;
+  "synthesized, or both be user defined, or the property must be nonatomic">;
 def err_atomic_property_nontrivial_assign_op : Error<
   "atomic property of reference type %0 cannot have non-trivial assignment"
   " operator">;

--- a/clang/test/SemaObjC/atomic-property-synthesis-rules.m
+++ b/clang/test/SemaObjC/atomic-property-synthesis-rules.m
@@ -108,7 +108,7 @@
 // read-write - might warn
 @property int GetSet;
 @property int Get;	// expected-note {{property declared here}} \
-                        // expected-note {{setter and getter must both be synthesized}}
+                        // expected-note {{setter and getter must both be synthesized, or both be user defined, or the property must be nonatomic}}
 @property int Set;	// expected-note {{property declared here}} \
                         // expected-note {{setter and getter must both be synthesized}}
 @property int None;


### PR DESCRIPTION
This change fixes a typo in a warning message.

rdar://79707705

https://reviews.llvm.org/D138434