### PR TITLE
[llvm][profile] Fix Transforms/SampleProfile legacy pm tests

### DIFF
--- a/llvm/lib/Transforms/IPO/SampleProfile.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfile.cpp
@@ -551,7 +551,8 @@ public:
       ThinOrFullLTOPhase LTOPhase = ThinOrFullLTOPhase::None,
       IntrusiveRefCntPtr<vfs::FileSystem> FS = nullptr)
       : ModulePass(ID), SampleLoader(
-                            Name, SampleProfileRemappingFile, LTOPhase, FS,
+                            Name, SampleProfileRemappingFile, LTOPhase,
+                            FS ? FS : vfs::getRealFileSystem(),
                             [&](Function &F) -> AssumptionCache & {
                               return ACT->getAssumptionCache(F);
                             },


### PR DESCRIPTION
There was a null dereference in the legacy pass manager code path.

rdar://102996772