### PR TITLE
[clang][cas] Expose prefix mapping configuration/application code NFC 

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
@@ -12,12 +12,16 @@
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
 
 namespace llvm {
+class StringSaver;
+class TreePathPrefixMapper;
+
 namespace cas {
 class ObjectStore;
 class CASID;
-}
+} // namespace cas
 } // namespace llvm
 
 namespace clang {
@@ -37,6 +41,16 @@ struct DepscanPrefixMapping {
   Optional<StringRef> NewSDKPath;
   Optional<StringRef> NewToolchainPath;
   SmallVector<StringRef> PrefixMap;
+
+  /// Add path mappings from the current path in \p Invocation to the new path
+  /// from \c DepscanPrefixMapping to the \p Mapper.
+  llvm::Error configurePrefixMapper(const CompilerInvocation &Invocation,
+                                    llvm::StringSaver &Saver,
+                                    llvm::TreePathPrefixMapper &Mapper) const;
+
+  /// Apply the mappings from \p Mapper to \p Invocation.
+  static void remapInvocationPaths(CompilerInvocation &Invocation,
+                                   llvm::TreePathPrefixMapper &Mapper);
 };
 } // namespace cc1depscand
 

--- a/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
@@ -33,10 +33,7 @@ class DiagnosticConsumer;
 namespace tooling {
 namespace dependencies {
 class DependencyScanningTool;
-}
-} // namespace tooling
 
-namespace cc1depscand {
 struct DepscanPrefixMapping {
   Optional<StringRef> NewSDKPath;
   Optional<StringRef> NewToolchainPath;
@@ -52,13 +49,14 @@ struct DepscanPrefixMapping {
   static void remapInvocationPaths(CompilerInvocation &Invocation,
                                    llvm::TreePathPrefixMapper &Mapper);
 };
-} // namespace cc1depscand
+} // namespace dependencies
+} // namespace tooling
 
 Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
     tooling::dependencies::DependencyScanningTool &Tool,
     DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
     CompilerInvocation &Invocation, StringRef WorkingDirectory,
-    const cc1depscand::DepscanPrefixMapping &PrefixMapping,
+    const tooling::dependencies::DepscanPrefixMapping &PrefixMapping,
     llvm::cas::ObjectStore &DB);
 
 } // end namespace clang

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -16,6 +16,7 @@
 #include "llvm/Support/PrefixMapper.h"
 
 using namespace clang;
+using namespace clang::tooling::dependencies;
 using llvm::Error;
 
 static void updateCompilerInvocation(CompilerInvocation &Invocation,
@@ -60,10 +61,10 @@ static void updateCompilerInvocation(CompilerInvocation &Invocation,
   Invocation.getDependencyOutputOpts().OutputFile.clear();
 
   // Apply path remappings.
-  cc1depscand::DepscanPrefixMapping::remapInvocationPaths(Invocation, Mapper);
+  DepscanPrefixMapping::remapInvocationPaths(Invocation, Mapper);
 }
 
-void cc1depscand::DepscanPrefixMapping::remapInvocationPaths(
+void DepscanPrefixMapping::remapInvocationPaths(
     CompilerInvocation &Invocation, llvm::TreePathPrefixMapper &Mapper) {
   // If there are no mappings, we're done. Otherwise, continue and remap
   // everything.
@@ -169,7 +170,7 @@ void cc1depscand::DepscanPrefixMapping::remapInvocationPaths(
   Mapper.mapInPlaceOrClear(CodeGenOpts.ProfileRemappingFile);
 }
 
-Error cc1depscand::DepscanPrefixMapping::configurePrefixMapper(
+Error DepscanPrefixMapping::configurePrefixMapper(
     const CompilerInvocation &Invocation, llvm::StringSaver &Saver,
     llvm::TreePathPrefixMapper &Mapper) const {
   auto isPathApplicableAsPrefix = [](StringRef Path) -> bool {
@@ -229,10 +230,9 @@ Error cc1depscand::DepscanPrefixMapping::configurePrefixMapper(
 }
 
 Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
-    tooling::dependencies::DependencyScanningTool &Tool,
-    DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
-    CompilerInvocation &Invocation, StringRef WorkingDirectory,
-    const cc1depscand::DepscanPrefixMapping &PrefixMapping,
+    DependencyScanningTool &Tool, DiagnosticConsumer &DiagsConsumer,
+    raw_ostream *VerboseOS, CompilerInvocation &Invocation,
+    StringRef WorkingDirectory, const DepscanPrefixMapping &PrefixMapping,
     llvm::cas::ObjectStore &DB) {
   llvm::cas::CachingOnDiskFileSystem &FS = Tool.getCachingFileSystem();
 

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -254,7 +254,7 @@ static bool emitCompilationDBWithCASTreeArguments(
     std::shared_ptr<llvm::cas::ObjectStore> DB,
     std::vector<tooling::CompileCommand> Inputs,
     DiagnosticConsumer &DiagsConsumer,
-    const cc1depscand::DepscanPrefixMapping &PrefixMapping,
+    const DepscanPrefixMapping &PrefixMapping,
     DependencyScanningService &Service, llvm::ThreadPool &Pool,
     llvm::raw_ostream &OS) {
 
@@ -317,7 +317,7 @@ static bool emitCompilationDBWithCASTreeArguments(
           tooling::dependencies::DependencyScanningTool &WorkerTool;
           DiagnosticConsumer &DiagsConsumer;
           StringRef CWD;
-          const cc1depscand::DepscanPrefixMapping &PrefixMapping;
+          const DepscanPrefixMapping &PrefixMapping;
           SmallVectorImpl<const char *> &OutputArgs;
           llvm::StringSaver &Saver;
 
@@ -326,7 +326,7 @@ static bool emitCompilationDBWithCASTreeArguments(
               llvm::cas::ObjectStore &DB,
               tooling::dependencies::DependencyScanningTool &WorkerTool,
               DiagnosticConsumer &DiagsConsumer, StringRef CWD,
-              const cc1depscand::DepscanPrefixMapping &PrefixMapping,
+              const DepscanPrefixMapping &PrefixMapping,
               SmallVectorImpl<const char *> &OutputArgs,
               llvm::StringSaver &Saver)
               : DB(DB), WorkerTool(WorkerTool), DiagsConsumer(DiagsConsumer),
@@ -840,7 +840,7 @@ int main(int argc, const char **argv) {
       return 1;
     }
     // FIXME: Configure this.
-    cc1depscand::DepscanPrefixMapping PrefixMapping;
+    DepscanPrefixMapping PrefixMapping;
     return emitCompilationDBWithCASTreeArguments(
         CAS, AdjustingCompilations->getAllCompileCommands(), *DiagsConsumer,
         PrefixMapping, Service, Pool, llvm::outs());

--- a/clang/tools/driver/cc1depscanProtocol.h
+++ b/clang/tools/driver/cc1depscanProtocol.h
@@ -22,10 +22,12 @@
 #include <unistd.h>     // FIXME: Unix-only. Not portable.
 
 namespace clang {
+namespace tooling::dependencies {
+struct DepscanPrefixMapping;
+}
 
 namespace cc1depscand {
-
-struct DepscanPrefixMapping;
+using tooling::dependencies::DepscanPrefixMapping;
 
 struct DepscanSharing {
   bool OnlyShareParent = false;


### PR DESCRIPTION
Refactor the prefix mapping configuration and application code so that
it can be used from outside ScanAndUpdateArgs. This will be used to
enable prefix mapping in more dependency scanning APIs.

Move DepscanPrefixMapping out of the cc1depscand namespace and into
tooling::dependencies to reflect its more general usefulness.