### PR TITLE
[llvm][cas] Add missing forward decl for raw_ostream

### DIFF
--- a/llvm/include/llvm/CAS/HashMappedTrie.h
+++ b/llvm/include/llvm/CAS/HashMappedTrie.h
@@ -18,6 +18,7 @@
 namespace llvm {
 
 class MemoryBuffer;
+class raw_ostream;
 
 namespace cas {
 

--- a/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
+++ b/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
@@ -24,6 +24,7 @@
 namespace llvm {
 
 class MemoryBuffer;
+class raw_ostream;
 
 namespace cas {
 

--- a/llvm/include/llvm/CAS/Utils.h
+++ b/llvm/include/llvm/CAS/Utils.h
@@ -13,6 +13,7 @@
 
 namespace llvm {
 class MemoryBufferRef;
+class raw_ostream;
 
 namespace cas {
 


### PR DESCRIPTION
An upstream commit removed a forward decl from Optional.h, so add it back as necessary to CAS headers.