### PR TITLE
Switch the "command script add" interactive input to use the new comm…

### DIFF
--- a/lldb/source/Commands/CommandObjectCommands.cpp
+++ b/lldb/source/Commands/CommandObjectCommands.cpp
@@ -201,7 +201,7 @@ protected:
 static const char *g_python_command_instructions =
     "Enter your Python command(s). Type 'DONE' to end.\n"
     "You must define a Python function with this signature:\n"
-    "def my_command_impl(debugger, args, result, internal_dict):\n";
+    "def my_command_impl(debugger, args, exe_ctx, result, internal_dict):\n";
 
 class CommandObjectCommandsAlias : public CommandObjectRaw {
 protected:

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -1369,7 +1369,7 @@ bool ScriptInterpreterPythonImpl::GenerateScriptAliasFunction(
   std::string auto_generated_function_name(GenerateUniqueName(
       "lldb_autogen_python_cmd_alias_func", num_created_functions));
 
-  sstr.Printf("def %s (debugger, args, result, internal_dict):",
+  sstr.Printf("def %s (debugger, args, exe_ctx, result, internal_dict):",
               auto_generated_function_name.c_str());
 
   if (!GenerateFunction(sstr.GetData(), user_input).Success())

--- a/lldb/test/Shell/Commands/command-script-add.test
+++ b/lldb/test/Shell/Commands/command-script-add.test
@@ -1,0 +1,9 @@
+# Test that command script add with no arguments prompts for
+# and generates the modern (exe_ctx) version of the command.
+
+# RUN: %lldb < %s | FileCheck %s
+command script add doit
+print(exe_ctx.target)
+DONE
+doit
+# CHECK: No value


### PR DESCRIPTION
…and form.

We're suggesting people use the form of the command that takes an exe_ctx - it is both more convenient and more correct - since you should not be using GetSelected{Target, Process, etc.} in commands.

(cherry picked from commit 9c5877f33d9f7fd317c07920fd24a041ad69077a)