### PR TITLE
[llvm/Support/PrefixMapper] Refactorings for `PrefixMapper`

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
@@ -16,7 +16,7 @@
 
 namespace llvm {
 class StringSaver;
-class TreePathPrefixMapper;
+class PrefixMapper;
 
 namespace cas {
 class ObjectStore;
@@ -43,11 +43,11 @@ struct DepscanPrefixMapping {
   /// from \c DepscanPrefixMapping to the \p Mapper.
   llvm::Error configurePrefixMapper(const CompilerInvocation &Invocation,
                                     llvm::StringSaver &Saver,
-                                    llvm::TreePathPrefixMapper &Mapper) const;
+                                    llvm::PrefixMapper &Mapper) const;
 
   /// Apply the mappings from \p Mapper to \p Invocation.
   static void remapInvocationPaths(CompilerInvocation &Invocation,
-                                   llvm::TreePathPrefixMapper &Mapper);
+                                   llvm::PrefixMapper &Mapper);
 };
 } // namespace dependencies
 } // namespace tooling

--- a/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
@@ -42,7 +42,6 @@ struct DepscanPrefixMapping {
   /// Add path mappings from the current path in \p Invocation to the new path
   /// from \c DepscanPrefixMapping to the \p Mapper.
   llvm::Error configurePrefixMapper(const CompilerInvocation &Invocation,
-                                    llvm::StringSaver &Saver,
                                     llvm::PrefixMapper &Mapper) const;
 
   /// Apply the mappings from \p Mapper to \p Invocation.

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -22,10 +22,9 @@ using llvm::Error;
 static void updateCompilerInvocation(CompilerInvocation &Invocation,
                                      llvm::StringSaver &Saver,
                                      bool ProduceIncludeTree,
-                                     llvm::cas::CachingOnDiskFileSystem &FS,
                                      std::string RootID,
                                      StringRef CASWorkingDirectory,
-                                     llvm::TreePathPrefixMapper &Mapper) {
+                                     llvm::PrefixMapper &Mapper) {
   // "Fix" the CAS options.
   auto &FileSystemOpts = Invocation.getFileSystemOpts();
   if (ProduceIncludeTree) {
@@ -64,8 +63,8 @@ static void updateCompilerInvocation(CompilerInvocation &Invocation,
   DepscanPrefixMapping::remapInvocationPaths(Invocation, Mapper);
 }
 
-void DepscanPrefixMapping::remapInvocationPaths(
-    CompilerInvocation &Invocation, llvm::TreePathPrefixMapper &Mapper) {
+void DepscanPrefixMapping::remapInvocationPaths(CompilerInvocation &Invocation,
+                                                llvm::PrefixMapper &Mapper) {
   // If there are no mappings, we're done. Otherwise, continue and remap
   // everything.
   if (Mapper.getMappings().empty())
@@ -129,7 +128,9 @@ void DepscanPrefixMapping::remapInvocationPaths(
         if (Input.isBuffer())
           return false; // FIXME: Can this happen when parsing command-line?
 
-        Optional<StringRef> RemappedFile = Mapper.mapOrNone(Input.getFile());
+        SmallString<256> PathBuf;
+        Optional<StringRef> RemappedFile =
+            Mapper.mapOrNoneIfError(Input.getFile(), PathBuf);
         if (!RemappedFile)
           return true;
         if (RemappedFile != Input.getFile())
@@ -172,7 +173,7 @@ void DepscanPrefixMapping::remapInvocationPaths(
 
 Error DepscanPrefixMapping::configurePrefixMapper(
     const CompilerInvocation &Invocation, llvm::StringSaver &Saver,
-    llvm::TreePathPrefixMapper &Mapper) const {
+    llvm::PrefixMapper &Mapper) const {
   auto isPathApplicableAsPrefix = [](StringRef Path) -> bool {
     if (Path.empty())
       return false;
@@ -242,7 +243,7 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
 
   llvm::BumpPtrAllocator Alloc;
   llvm::StringSaver Saver(Alloc);
-  llvm::TreePathPrefixMapper Mapper(&FS, Alloc);
+  llvm::TreePathPrefixMapper Mapper(&FS);
   if (Error E = PrefixMapping.configurePrefixMapper(Invocation, Saver, Mapper))
     return std::move(E);
 
@@ -268,12 +269,12 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
                           DiagsConsumer, VerboseOS,
                           /*DiagGenerationAsCompilation*/ true,
                           [&](const llvm::vfs::CachedDirectoryEntry &Entry) {
-                            return Mapper.map(Entry);
+                            return Mapper.mapDirEntry(Entry, Saver);
                           })
                       .moveInto(Root))
       return std::move(E);
   }
-  updateCompilerInvocation(Invocation, Saver, ProduceIncludeTree, FS,
+  updateCompilerInvocation(Invocation, Saver, ProduceIncludeTree,
                            Root->toString(), WorkingDirectory, Mapper);
   return *Root;
 }

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -172,8 +172,7 @@ void DepscanPrefixMapping::remapInvocationPaths(CompilerInvocation &Invocation,
 }
 
 Error DepscanPrefixMapping::configurePrefixMapper(
-    const CompilerInvocation &Invocation, llvm::StringSaver &Saver,
-    llvm::PrefixMapper &Mapper) const {
+    const CompilerInvocation &Invocation, llvm::PrefixMapper &Mapper) const {
   auto isPathApplicableAsPrefix = [](StringRef Path) -> bool {
     if (Path.empty())
       return false;
@@ -190,7 +189,7 @@ Error DepscanPrefixMapping::configurePrefixMapper(
     StringRef SDK = HSOpts.Sysroot;
     if (isPathApplicableAsPrefix(SDK))
       // Need a new copy of the string since the invocation will be modified.
-      if (auto E = Mapper.add({Saver.save(SDK), *NewSDKPath}))
+      if (auto E = Mapper.add({SDK, *NewSDKPath}))
         return E;
   }
   if (NewToolchainPath) {
@@ -208,7 +207,7 @@ Error DepscanPrefixMapping::configurePrefixMapper(
     }
     if (isPathApplicableAsPrefix(Guess))
       // Need a new copy of the string since the invocation will be modified.
-      if (auto E = Mapper.add({Saver.save(Guess), *NewToolchainPath}))
+      if (auto E = Mapper.add({Guess, *NewToolchainPath}))
         return E;
   }
   if (!PrefixMap.empty()) {
@@ -244,7 +243,7 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
   llvm::BumpPtrAllocator Alloc;
   llvm::StringSaver Saver(Alloc);
   llvm::TreePathPrefixMapper Mapper(&FS);
-  if (Error E = PrefixMapping.configurePrefixMapper(Invocation, Saver, Mapper))
+  if (Error E = PrefixMapping.configurePrefixMapper(Invocation, Mapper))
     return std::move(E);
 
   auto ScanInvocation = std::make_shared<CompilerInvocation>(Invocation);

--- a/llvm/include/llvm/Support/PrefixMapper.h
+++ b/llvm/include/llvm/Support/PrefixMapper.h
@@ -24,8 +24,12 @@ class CachedDirectoryEntry;
 } // end namespace vfs
 
 struct MappedPrefix {
-  StringRef Old;
-  StringRef New;
+  std::string Old;
+  std::string New;
+
+  MappedPrefix() = default;
+  MappedPrefix(StringRef Old_, StringRef New_)
+      : Old(Old_.str()), New(New_.str()) {}
 
   MappedPrefix getInverse() const { return MappedPrefix{New, Old}; }
 

--- a/llvm/include/llvm/Support/PrefixMapper.h
+++ b/llvm/include/llvm/Support/PrefixMapper.h
@@ -11,11 +11,12 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/None.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Path.h"
-#include "llvm/Support/StringSaver.h"
 
 namespace llvm {
+class StringSaver;
 
 namespace vfs {
 class FileSystem;
@@ -51,32 +52,49 @@ struct MappedPrefix {
 /// need it, and those could assert/crash if one is not configured.
 class PrefixMapper {
 public:
+  virtual ~PrefixMapper() = default;
+
   /// Map \p Path, and saving the new (or existing) path in \p NewPath.
   ///
   /// \pre \p Path is not a reference into \p NewPath.
-  void map(StringRef Path, SmallVectorImpl<char> &NewPath);
-  void map(StringRef Path, std::string &NewPath);
-
-  /// Map \p Path, returning \a StringSaver::save() for new paths that aren't
-  /// exact matches.
-  StringRef map(StringRef Path);
+  Error map(StringRef Path, SmallVectorImpl<char> &NewPath);
+  Error map(StringRef Path, std::string &NewPath);
 
   /// Map \p Path, returning \a std::string.
-  std::string mapToString(StringRef Path);
+  Expected<std::string> mapToString(StringRef Path);
 
   /// Map \p Path in place.
-  void mapInPlace(SmallVectorImpl<char> &Path);
-  void mapInPlace(std::string &Path);
+  Error mapInPlace(SmallVectorImpl<char> &Path);
+  Error mapInPlace(std::string &Path);
 
-private:
+  void mapInPlaceOrClear(std::string &Path) {
+    if (errorToBool(mapInPlace(Path)))
+      Path.clear();
+  }
+
+  /// Like \p map() except it returns \p None in case of an error.
+  Optional<StringRef> mapOrNoneIfError(StringRef Path,
+                                       SmallVectorImpl<char> &Storage) {
+    if (Error E = map(Path, Storage)) {
+      consumeError(std::move(E));
+      return None;
+    }
+    return StringRef(Storage.begin(), Storage.size());
+  }
+
+protected:
   /// Map (or unmap) \p Path. On a match, fills \p Storage with the mapped path
   /// unless it's an exact match.
   ///
   /// \pre \p Path is not a reference into \p Storage.
-  Optional<StringRef> mapImpl(StringRef Path, SmallVectorImpl<char> &Storage);
+  virtual Expected<Optional<StringRef>> mapImpl(StringRef Path,
+                                                SmallVectorImpl<char> &Storage);
 
 public:
-  void add(const MappedPrefix &MP) { Mappings.push_back(MP); }
+  virtual Error add(const MappedPrefix &MP) {
+    Mappings.push_back(MP);
+    return Error::success();
+  }
 
   /// A path-based reverse lexicographic sort, putting deeper paths first so
   /// that deeper paths are prioritized over their parent paths. For example,
@@ -92,31 +110,39 @@ public:
   /// TODO: Test.
   void sort();
 
-  template <class RangeT> void addRange(const RangeT &Mappings) {
-    this->Mappings.append(Mappings.begin(), Mappings.end());
+  template <class RangeT> Error addRange(const RangeT &Mappings) {
+    for (const MappedPrefix &M : Mappings)
+      if (Error E = add(M))
+        return E;
+    return Error::success();
   }
 
-  template <class RangeT> void addInverseRange(const RangeT &Mappings) {
+  template <class RangeT> Error addInverseRange(const RangeT &Mappings) {
     for (const MappedPrefix &M : Mappings)
-      add(M.getInverse());
+      if (Error E = add(M.getInverse()))
+        return E;
+    return Error::success();
+  }
+
+  template <class RangeT> void addRangeIfValid(const RangeT &Mappings) {
+    for (const MappedPrefix &M : Mappings)
+      consumeError(add(M));
+  }
+
+  template <class RangeT> void addInverseRangeIfValid(const RangeT &Mappings) {
+    for (const MappedPrefix &M : Mappings)
+      consumeError(add(M.getInverse()));
   }
 
   ArrayRef<MappedPrefix> getMappings() const { return Mappings; }
 
-  StringSaver &getStringSaver() { return Saver; }
   sys::path::Style getPathStyle() const { return PathStyle; }
 
   PrefixMapper(sys::path::Style PathStyle = sys::path::Style::native)
-      : PathStyle(PathStyle), Alloc(std::in_place), Saver(*Alloc) {}
-
-  PrefixMapper(BumpPtrAllocator &Alloc,
-               sys::path::Style PathStyle = sys::path::Style::native)
-      : PathStyle(PathStyle), Saver(Alloc) {}
+      : PathStyle(PathStyle) {}
 
 private:
   sys::path::Style PathStyle;
-  Optional<BumpPtrAllocator> Alloc;
-  StringSaver Saver;
   SmallVector<MappedPrefix> Mappings;
 };
 
@@ -149,98 +175,27 @@ private:
 ///
 /// Returns an error if an input cannot be found, except that an empty string
 /// always maps to itself.
-class TreePathPrefixMapper {
-public:
-  void map(const vfs::CachedDirectoryEntry &Entry,
-           SmallVectorImpl<char> &NewPath);
-  void map(const vfs::CachedDirectoryEntry &Entry, std::string &NewPath);
-  StringRef map(const vfs::CachedDirectoryEntry &Entry);
-  std::string mapToString(const vfs::CachedDirectoryEntry &Entry);
-
-  Error map(StringRef Path, SmallVectorImpl<char> &NewPath);
-  Error map(StringRef Path, std::string &NewPath) {
-    return mapToString(Path).moveInto(NewPath);
-  }
-  Expected<StringRef> map(StringRef Path);
-  Expected<std::string> mapToString(StringRef Path);
-  Error mapInPlace(SmallVectorImpl<char> &Path);
-  Error mapInPlace(std::string &Path);
-
-  void mapOrOriginal(StringRef Path, SmallVectorImpl<char> &NewPath) {
-    if (errorToBool(map(Path, NewPath)))
-      NewPath.assign(Path.begin(), Path.end());
-  }
-  void mapOrOriginal(StringRef Path, std::string &NewPath) {
-    if (errorToBool(map(Path, NewPath)))
-      NewPath.assign(Path.begin(), Path.end());
-  }
-  Optional<StringRef> mapOrNone(StringRef Path) {
-    return expectedToOptional(map(Path));
-  }
-  StringRef mapOrOriginal(StringRef Path) {
-    Optional<StringRef> Mapped = mapOrNone(Path);
-    return Mapped ? *Mapped : Path;
-  }
-  Optional<std::string> mapToStringOrNone(StringRef Path) {
-    return expectedToOptional(mapToString(Path));
-  }
-  void mapInPlaceOrClear(SmallVectorImpl<char> &Path) {
-    if (errorToBool(mapInPlace(Path)))
-      Path.clear();
-  }
-  void mapInPlaceOrClear(std::string &Path) {
-    if (errorToBool(mapInPlace(Path)))
-      Path.clear();
-  }
-
+class TreePathPrefixMapper : public PrefixMapper {
 private:
+  Expected<Optional<StringRef>>
+  mapImpl(StringRef Path, SmallVectorImpl<char> &Storage) override;
+
   /// Find the tree path for \p Path, getting the real path for its parent
   /// directory but not following symlinks in \a sys::path::filename().
   Expected<StringRef> getTreePath(StringRef Path);
-  Error getTreePath(StringRef Path, SmallVectorImpl<char> &TreePath);
   Error canonicalizePrefix(StringRef &Prefix);
 
 public:
-  ArrayRef<MappedPrefix> getMappings() const { return PM.getMappings(); }
-  sys::path::Style getPathStyle() const { return PM.getPathStyle(); }
+  Error add(const MappedPrefix &Mapping) override;
 
-  Error add(const MappedPrefix &Mapping);
-
-  template <class RangeT> Error addRange(const RangeT &Mappings) {
-    for (const MappedPrefix &M : Mappings)
-      if (Error E = add(M))
-        return E;
-    return Error::success();
-  }
-
-  template <class RangeT> Error addInverseRange(const RangeT &Mappings) {
-    for (const MappedPrefix &M : Mappings)
-      if (Error E = add(M.getInverse()))
-        return E;
-    return Error::success();
-  }
-
-  template <class RangeT> void addRangeIfValid(const RangeT &Mappings) {
-    for (const MappedPrefix &M : Mappings)
-      consumeError(add(M));
-  }
-
-  template <class RangeT> void addInverseRangeIfValid(const RangeT &Mappings) {
-    for (const MappedPrefix &M : Mappings)
-      consumeError(add(M.getInverse()));
-  }
-
-  void sort() { PM.sort(); }
+  StringRef mapDirEntry(const vfs::CachedDirectoryEntry &Entry,
+                        StringSaver &Saver);
 
   TreePathPrefixMapper(IntrusiveRefCntPtr<vfs::FileSystem> FS,
-                       sys::path::Style PathStyle = sys::path::Style::native);
-  TreePathPrefixMapper(IntrusiveRefCntPtr<vfs::FileSystem> FS,
-                       BumpPtrAllocator &Alloc,
                        sys::path::Style PathStyle = sys::path::Style::native);
   ~TreePathPrefixMapper();
 
 private:
-  PrefixMapper PM;
   IntrusiveRefCntPtr<vfs::FileSystem> FS;
 };
 

--- a/llvm/lib/Support/PrefixMapper.cpp
+++ b/llvm/lib/Support/PrefixMapper.cpp
@@ -9,6 +9,7 @@
 #include "llvm/Support/PrefixMapper.h"
 #include "llvm/ADT/None.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/Support/StringSaver.h"
 #include "llvm/Support/VirtualFileSystem.h"
 
 using namespace llvm;
@@ -94,8 +95,8 @@ static bool startsWith(StringRef Path, StringRef Prefix,
   return true;
 }
 
-Optional<StringRef> PrefixMapper::mapImpl(StringRef Path,
-                                          SmallVectorImpl<char> &Storage) {
+Expected<Optional<StringRef>>
+PrefixMapper::mapImpl(StringRef Path, SmallVectorImpl<char> &Storage) {
   for (const MappedPrefix &Map : Mappings) {
     StringRef Old = Map.Old;
     StringRef New = Map.New;
@@ -117,54 +118,55 @@ Optional<StringRef> PrefixMapper::mapImpl(StringRef Path,
   return None;
 }
 
-void PrefixMapper::map(StringRef Path, SmallVectorImpl<char> &NewPath) {
+Error PrefixMapper::map(StringRef Path, SmallVectorImpl<char> &NewPath) {
   NewPath.clear();
-  Optional<StringRef> Mapped = mapImpl(Path, NewPath);
+  Optional<StringRef> Mapped;
+  if (Error E = mapImpl(Path, NewPath).moveInto(Mapped))
+    return E;
   if (!NewPath.empty())
-    return;
+    return Error::success();
   if (!Mapped)
     Mapped = Path;
   NewPath.assign(Mapped->begin(), Mapped->end());
+  return Error::success();
 }
 
-void PrefixMapper::map(StringRef Path, std::string &NewPath) {
-  NewPath = mapToString(Path);
+Error PrefixMapper::map(StringRef Path, std::string &NewPath) {
+  return mapToString(Path).moveInto(NewPath);
 }
 
-StringRef PrefixMapper::map(StringRef Path) {
+Expected<std::string> PrefixMapper::mapToString(StringRef Path) {
   SmallString<256> Storage;
-  Optional<StringRef> Mapped = mapImpl(Path, Storage);
-  if (!Mapped)
-    return Path;
-  if (Storage.empty())
-    return *Mapped; // Exact match.
-  return Saver.save(StringRef(Storage));
-}
-
-std::string PrefixMapper::mapToString(StringRef Path) {
-  SmallString<256> Storage;
-  Optional<StringRef> Mapped = mapImpl(Path, Storage);
+  Optional<StringRef> Mapped;
+  if (Error E = mapImpl(Path, Storage).moveInto(Mapped))
+    return std::move(E);
   return Mapped ? Mapped->str() : Path.str();
 }
 
-void PrefixMapper::mapInPlace(SmallVectorImpl<char> &Path) {
+Error PrefixMapper::mapInPlace(SmallVectorImpl<char> &Path) {
   SmallString<256> Storage;
-  Optional<StringRef> Mapped =
-      mapImpl(StringRef(Path.begin(), Path.size()), Storage);
+  Optional<StringRef> Mapped;
+  if (Error E = mapImpl(StringRef(Path.begin(), Path.size()), Storage)
+                    .moveInto(Mapped))
+    return E;
   if (!Mapped)
-    return;
+    return Error::success();
   if (Storage.empty())
     Path.assign(Mapped->begin(), Mapped->end());
   else
     Storage.swap(Path);
+  return Error::success();
 }
 
-void PrefixMapper::mapInPlace(std::string &Path) {
+Error PrefixMapper::mapInPlace(std::string &Path) {
   SmallString<256> Storage;
-  Optional<StringRef> Mapped = mapImpl(Path, Storage);
+  Optional<StringRef> Mapped;
+  if (Error E = mapImpl(Path, Storage).moveInto(Mapped))
+    return E;
   if (!Mapped)
-    return;
+    return Error::success();
   Path.assign(Mapped->begin(), Mapped->size());
+  return Error::success();
 }
 
 void PrefixMapper::sort() {
@@ -177,33 +179,23 @@ void PrefixMapper::sort() {
 }
 
 TreePathPrefixMapper::TreePathPrefixMapper(
-    IntrusiveRefCntPtr<vfs::FileSystem> FS, BumpPtrAllocator &Alloc,
-    sys::path::Style PathStyle)
-    : PM(Alloc, PathStyle), FS(std::move(FS)) {}
-
-TreePathPrefixMapper::TreePathPrefixMapper(
     IntrusiveRefCntPtr<vfs::FileSystem> FS, sys::path::Style PathStyle)
-    : PM(PathStyle), FS(std::move(FS)) {}
+    : PrefixMapper(PathStyle), FS(std::move(FS)) {}
 
 TreePathPrefixMapper::~TreePathPrefixMapper() = default;
 
-void TreePathPrefixMapper::map(const vfs::CachedDirectoryEntry &Entry,
-                               SmallVectorImpl<char> &NewPath) {
-  PM.map(Entry.getTreePath(), NewPath);
-}
-
-void TreePathPrefixMapper::map(const vfs::CachedDirectoryEntry &Entry,
-                               std::string &NewPath) {
-  PM.map(Entry.getTreePath(), NewPath);
-}
-
-StringRef TreePathPrefixMapper::map(const vfs::CachedDirectoryEntry &Entry) {
-  return PM.map(Entry.getTreePath());
-}
-
-std::string
-TreePathPrefixMapper::mapToString(const vfs::CachedDirectoryEntry &Entry) {
-  return PM.mapToString(Entry.getTreePath());
+Expected<Optional<StringRef>>
+TreePathPrefixMapper::mapImpl(StringRef Path, SmallVectorImpl<char> &Storage) {
+  StringRef TreePath;
+  if (Error E = getTreePath(Path).moveInto(TreePath))
+    return std::move(E);
+  Optional<StringRef> Mapped =
+      cantFail(PrefixMapper::mapImpl(TreePath, Storage));
+  if (Mapped)
+    return *Mapped;
+  if (TreePath != Path)
+    return TreePath;
+  return None;
 }
 
 Expected<StringRef> TreePathPrefixMapper::getTreePath(StringRef Path) {
@@ -216,61 +208,12 @@ Expected<StringRef> TreePathPrefixMapper::getTreePath(StringRef Path) {
   return Entry->getTreePath();
 }
 
-Error TreePathPrefixMapper::getTreePath(StringRef Path,
-                                        SmallVectorImpl<char> &TreePath) {
-  assert(TreePath.empty() && "Expected to be fed an empty TreePath");
-  StringRef TreePathRef;
-  if (Error E = getTreePath(Path).moveInto(TreePathRef))
-    return E;
-  TreePath.assign(TreePathRef.begin(), TreePathRef.end());
-  return Error::success();
-}
-
-Error TreePathPrefixMapper::map(StringRef Path,
-                                SmallVectorImpl<char> &NewPath) {
-  NewPath.clear();
-  if (Error E = getTreePath(Path, NewPath))
-    return E;
-  PM.mapInPlace(NewPath);
-  return Error::success();
-}
-
-Expected<StringRef> TreePathPrefixMapper::map(StringRef Path) {
-  StringRef TreePath;
-  if (Error E = getTreePath(Path).moveInto(TreePath))
-    return std::move(E);
-  return PM.map(TreePath);
-}
-
-Expected<std::string> TreePathPrefixMapper::mapToString(StringRef Path) {
-  StringRef TreePath;
-  if (Error E = getTreePath(Path).moveInto(TreePath))
-    return std::move(E);
-  return PM.mapToString(TreePath);
-}
-
-Error TreePathPrefixMapper::mapInPlace(SmallVectorImpl<char> &Path) {
-  SmallString<256> TreePath;
-  if (Error E = getTreePath(StringRef(Path.begin(), Path.size()), TreePath))
-    return E;
-  PM.map(TreePath, Path);
-  return Error::success();
-}
-
-Error TreePathPrefixMapper::mapInPlace(std::string &Path) {
-  SmallString<256> TreePath;
-  if (Error E = getTreePath(Path, TreePath))
-    return E;
-  Path = PM.mapToString(TreePath);
-  return Error::success();
-}
-
 Error TreePathPrefixMapper::canonicalizePrefix(StringRef &Prefix) {
-  SmallString<256> TreePath;
-  if (Error E = getTreePath(Prefix, TreePath))
+  StringRef TreePath;
+  if (Error E = getTreePath(Prefix).moveInto(TreePath))
     return E;
   if (TreePath != Prefix)
-    Prefix = PM.getStringSaver().save(StringRef(TreePath));
+    Prefix = TreePath;
   return Error::success();
 }
 
@@ -279,6 +222,15 @@ Error TreePathPrefixMapper::add(const MappedPrefix &Mapping) {
   StringRef New = Mapping.New;
   if (Error E = canonicalizePrefix(Old))
     return E;
-  PM.add(MappedPrefix{Old, New});
-  return Error::success();
+  return PrefixMapper::add(MappedPrefix{Old, New});
+}
+
+StringRef
+TreePathPrefixMapper::mapDirEntry(const vfs::CachedDirectoryEntry &Entry,
+                                  StringSaver &Saver) {
+  StringRef TreePath = Entry.getTreePath();
+  SmallString<256> PathBuf;
+  Optional<StringRef> Mapped =
+      cantFail(PrefixMapper::mapImpl(TreePath, PathBuf));
+  return Mapped ? Saver.save(*Mapped) : TreePath;
 }

--- a/llvm/lib/TableGen/ScanDependencies.cpp
+++ b/llvm/lib/TableGen/ScanDependencies.cpp
@@ -11,6 +11,7 @@
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/PrefixMapper.h"
+#include "llvm/Support/StringSaver.h"
 
 using namespace llvm;
 using namespace llvm::tablegen;
@@ -239,9 +240,12 @@ tablegen::scanIncludes(cas::ObjectStore &CAS, cas::ActionCache &Cache,
     PM->sort();
   }
 
+  BumpPtrAllocator Alloc;
+  StringSaver Saver(Alloc);
+
   Expected<cas::ObjectProxy> Tree = FS->createTreeFromNewAccesses(
       [&](const vfs::CachedDirectoryEntry &Entry) {
-        return PM ? PM->map(Entry) : Entry.getTreePath();
+        return PM ? PM->mapDirEntry(Entry, Saver) : Entry.getTreePath();
       });
   if (!Tree)
     return Tree.takeError();

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -402,7 +402,8 @@ static Expected<ObjectProxy> ingestFileSystemImpl(ObjectStore &CAS,
     return FS.takeError();
 
   BumpPtrAllocator Alloc;
-  TreePathPrefixMapper Mapper(*FS, Alloc);
+  StringSaver Saver(Alloc);
+  TreePathPrefixMapper Mapper(*FS);
   SmallVector<llvm::MappedPrefix> Split;
   if (!PrefixMapPaths.empty()) {
     MappedPrefix::transformJoinedIfValid(PrefixMapPaths, Split);
@@ -418,7 +419,7 @@ static Expected<ObjectProxy> ingestFileSystemImpl(ObjectStore &CAS,
 
   return (*FS)->createTreeFromNewAccesses(
       [&](const llvm::vfs::CachedDirectoryEntry &Entry) {
-        return Mapper.map(Entry);
+        return Mapper.mapDirEntry(Entry, Saver);
       });
 }
 

--- a/llvm/unittests/Support/PrefixMapperTest.cpp
+++ b/llvm/unittests/Support/PrefixMapperTest.cpp
@@ -17,7 +17,7 @@ using namespace llvm;
 
 namespace llvm {
 static inline void PrintTo(const MappedPrefix &P, std::ostream *OS) {
-  *OS << ::testing::PrintToString(P.Old.str() + "=" + P.New.str());
+  *OS << ::testing::PrintToString(P.Old + "=" + P.New);
 }
 } // end namespace llvm
 
@@ -328,7 +328,7 @@ TEST(PrefixMapperTest, mapInPlace) {
   std::string S;
   for (MappedPrefix M : Tests) {
     V = M.Old;
-    S = M.Old.str();
+    S = M.Old;
     ASSERT_THAT_ERROR(PM.mapInPlace(V), Succeeded());
     ASSERT_THAT_ERROR(PM.mapInPlace(S), Succeeded());
     EXPECT_EQ(M.New, V);
@@ -538,7 +538,7 @@ TEST(TreePathPrefixMapperTest, map) {
     EXPECT_THAT_ERROR(State.PM.map(Map.Old, FoundS), Succeeded());
     EXPECT_EQ(Map.New, FoundV);
     EXPECT_EQ(Map.New, FoundS);
-    EXPECT_EQ(Map.New, State.PM.mapOrNoneIfError(Map.Old, FoundV));
+    EXPECT_EQ(StringRef(Map.New), State.PM.mapOrNoneIfError(Map.Old, FoundV));
 
     FoundV = "";
     FoundS = "";
@@ -581,14 +581,14 @@ TEST(TreePathPrefixMapperTest, mapInPlace) {
   }
 
   for (MappedPrefix Map : State.Tests) {
-    FoundS = Map.Old.str();
+    FoundS = Map.Old;
     FoundV = Map.Old;
     EXPECT_THAT_ERROR(State.PM.mapInPlace(FoundS), Succeeded());
     EXPECT_THAT_ERROR(State.PM.mapInPlace(FoundV), Succeeded());
     EXPECT_EQ(Map.New, FoundS);
     EXPECT_EQ(Map.New, FoundV);
 
-    FoundS = Map.Old.str();
+    FoundS = Map.Old;
     FoundV = Map.Old;
     State.PM.mapInPlaceOrClear(FoundS);
     EXPECT_EQ(Map.New, FoundS);

--- a/llvm/unittests/Support/PrefixMapperTest.cpp
+++ b/llvm/unittests/Support/PrefixMapperTest.cpp
@@ -8,7 +8,7 @@
 
 #include "llvm/Support/PrefixMapper.h"
 #include "llvm/ADT/StringMap.h"
-#include "llvm/ADT/None.h"
+#include "llvm/Support/StringSaver.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
@@ -22,6 +22,27 @@ static inline void PrintTo(const MappedPrefix &P, std::ostream *OS) {
 } // end namespace llvm
 
 namespace {
+
+struct PrefixMapperWrapper {
+  PrefixMapper PM;
+  BumpPtrAllocator Alloc;
+  StringSaver Saver;
+
+  PrefixMapperWrapper(sys::path::Style PathStyle)
+      : PM(PathStyle), Saver(Alloc) {}
+
+  void add(const MappedPrefix &Mapping) { return cantFail(PM.add(Mapping)); }
+
+  template <class RangeT> void addRange(const RangeT &Mappings) {
+    return cantFail(PM.addRange(Mappings));
+  }
+
+  StringRef map(StringRef Path) {
+    SmallString<256> PathBuf;
+    cantFail(PM.map(Path, PathBuf));
+    return Saver.save(PathBuf.str());
+  }
+};
 
 TEST(MappedPrefixTest, getInverse) {
   EXPECT_EQ((MappedPrefix{"b", "a"}), (MappedPrefix{"a", "b"}).getInverse());
@@ -115,8 +136,8 @@ TEST(PrefixMapperTest, construct) {
 
 TEST(PrefixMapperTest, add) {
   PrefixMapper PM(sys::path::Style::posix);
-  PM.add(MappedPrefix{"a", "b"});
-  PM.add(MappedPrefix{"b", "a"});
+  ASSERT_THAT_ERROR(PM.add(MappedPrefix{"a", "b"}), Succeeded());
+  ASSERT_THAT_ERROR(PM.add(MappedPrefix{"b", "a"}), Succeeded());
   ASSERT_EQ(2u, PM.getMappings().size());
   ASSERT_EQ((MappedPrefix{"a", "b"}), PM.getMappings().front());
   ASSERT_EQ((MappedPrefix{"b", "a"}), PM.getMappings().back());
@@ -125,15 +146,17 @@ TEST(PrefixMapperTest, add) {
 TEST(PrefixMapperTest, addRange) {
   PrefixMapper PM(sys::path::Style::posix);
 
-  PM.add(MappedPrefix{"/old/before", "/new/before"});
+  ASSERT_THAT_ERROR(PM.add(MappedPrefix{"/old/before", "/new/before"}),
+                    Succeeded());
   MappedPrefix Range[] = {
       {"/old/1", "/new/1"},
       {"/old/2", "/new/2"},
       {"/old/3", "/new/3"},
   };
   auto RangeRef = makeArrayRef(Range);
-  PM.addRange(RangeRef);
-  PM.add(MappedPrefix{"/old/after", "/new/after"});
+  ASSERT_THAT_ERROR(PM.addRange(RangeRef), Succeeded());
+  ASSERT_THAT_ERROR(PM.add(MappedPrefix{"/old/after", "/new/after"}),
+                    Succeeded());
 
   ASSERT_EQ(2u + RangeRef.size(), PM.getMappings().size());
   EXPECT_EQ((MappedPrefix{"/old/before", "/new/before"}),
@@ -144,7 +167,7 @@ TEST(PrefixMapperTest, addRange) {
 }
 
 static void checkPosix(sys::path::Style PathStyle) {
-  PrefixMapper PM(PathStyle);
+  PrefixMapperWrapper PM(PathStyle);
   MappedPrefix Mappings[] = {
       // Simple mappings.
       {"/old", "/new"},
@@ -191,7 +214,7 @@ static void checkPosix(sys::path::Style PathStyle) {
 TEST(PrefixMapperTest, mapPosix) { checkPosix(sys::path::Style::posix); }
 
 static void checkWindows(sys::path::Style PathStyle) {
-  PrefixMapper PM(PathStyle);
+  PrefixMapperWrapper PM(PathStyle);
   MappedPrefix Mappings[] = {
       // Simple mappings.
       {"c:\\old", "c:\\new"},
@@ -250,50 +273,10 @@ TEST(PrefixMapperTest, mapNative) {
     checkWindows(sys::path::Style::native);
 }
 
-TEST(PrefixMapperTest, mapLifetime) {
-  MappedPrefix Mappings[] = {
-      {"/old", "/new"},
-  };
-
-  StringRef Input[] = {
-      "/old/short",
-      "/old/0123456789012345678901234567890123456789-long",
-  };
-
-  StringRef Expected[] = {
-      "/new/short",
-      "/new/0123456789012345678901234567890123456789-long",
-  };
-
-  SmallVector<StringRef> Default;
-  SmallVector<StringRef> WithAlloc;
-
-  PrefixMapper PMDefault(sys::path::Style::posix);
-  BumpPtrAllocator Alloc;
-  {
-    // Shorter lifetime to confirm StringRefs live with Alloc.
-    PrefixMapper PMWithAlloc(Alloc, sys::path::Style::posix);
-
-    PMDefault.addRange(makeArrayRef(Mappings));
-    PMWithAlloc.addRange(makeArrayRef(Mappings));
-    for (StringRef Path : Input) {
-      Default.push_back(PMDefault.map(Path));
-      WithAlloc.push_back(PMWithAlloc.map(Path));
-    }
-    ASSERT_EQ(makeArrayRef(Expected), makeArrayRef(Default));
-    ASSERT_EQ(makeArrayRef(Expected), makeArrayRef(WithAlloc));
-  }
-
-  // Check lifetime of returned StringRef. Sanitizers should crash with
-  // use-after-free if there's a problem.
-  ASSERT_EQ(makeArrayRef(Expected), makeArrayRef(Default));
-  ASSERT_EQ(makeArrayRef(Expected), makeArrayRef(WithAlloc));
-}
-
 TEST(PrefixMapperTest, mapTwoArgs) {
   PrefixMapper PM(sys::path::Style::posix);
   MappedPrefix Mappings[] = {{"/old", "/new"}};
-  PM.addRange(makeArrayRef(Mappings));
+  ASSERT_THAT_ERROR(PM.addRange(makeArrayRef(Mappings)), Succeeded());
 
   MappedPrefix Tests[] = {
       {"/old", "/new"},     {"/old/x/y", "/new/x/y"},
@@ -304,8 +287,8 @@ TEST(PrefixMapperTest, mapTwoArgs) {
   SmallString<128> OutputV;
   std::string OutputS;
   for (MappedPrefix M : Tests) {
-    PM.map(M.Old, OutputV);
-    PM.map(M.Old, OutputS);
+    ASSERT_THAT_ERROR(PM.map(M.Old, OutputV), Succeeded());
+    ASSERT_THAT_ERROR(PM.map(M.Old, OutputS), Succeeded());
     EXPECT_EQ(M.New, OutputV);
     EXPECT_EQ(M.New, OutputS);
   }
@@ -314,7 +297,7 @@ TEST(PrefixMapperTest, mapTwoArgs) {
 TEST(PrefixMapperTest, mapToString) {
   PrefixMapper PM(sys::path::Style::posix);
   MappedPrefix Mappings[] = {{"/old", "/new"}};
-  PM.addRange(makeArrayRef(Mappings));
+  ASSERT_THAT_ERROR(PM.addRange(makeArrayRef(Mappings)), Succeeded());
 
   MappedPrefix Tests[] = {
       {"/old", "/new"},     {"/old/x/y", "/new/x/y"},
@@ -324,7 +307,8 @@ TEST(PrefixMapperTest, mapToString) {
 
   SmallString<128> Output;
   for (MappedPrefix M : Tests) {
-    std::string S = PM.mapToString(M.Old);
+    std::string S;
+    ASSERT_THAT_ERROR(PM.mapToString(M.Old).moveInto(S), Succeeded());
     EXPECT_EQ(M.New, S);
   }
 }
@@ -332,7 +316,7 @@ TEST(PrefixMapperTest, mapToString) {
 TEST(PrefixMapperTest, mapInPlace) {
   PrefixMapper PM(sys::path::Style::posix);
   MappedPrefix Mappings[] = {{"/old", "/new"}};
-  PM.addRange(makeArrayRef(Mappings));
+  ASSERT_THAT_ERROR(PM.addRange(makeArrayRef(Mappings)), Succeeded());
 
   MappedPrefix Tests[] = {
       {"/old", "/new"},     {"/old/x/y", "/new/x/y"},
@@ -345,8 +329,8 @@ TEST(PrefixMapperTest, mapInPlace) {
   for (MappedPrefix M : Tests) {
     V = M.Old;
     S = M.Old.str();
-    PM.mapInPlace(V);
-    PM.mapInPlace(S);
+    ASSERT_THAT_ERROR(PM.mapInPlace(V), Succeeded());
+    ASSERT_THAT_ERROR(PM.mapInPlace(S), Succeeded());
     EXPECT_EQ(M.New, V);
     EXPECT_EQ(M.New, S);
   }
@@ -503,7 +487,6 @@ TEST(TreePathPrefixMapperTest, addInverseRangeIfValid) {
 }
 
 struct MapState {
-  BumpPtrAllocator Alloc;
   IntrusiveRefCntPtr<GetDirectoryEntryFileSystem> FS =
       makeIntrusiveRefCnt<GetDirectoryEntryFileSystem>();
   TreePathPrefixMapper PM;
@@ -524,7 +507,7 @@ struct MapState {
       {"/real/path/2/nested", "/new2/nested"},
   };
   SmallVector<StringRef> FailedTests = {"missing", "/missing", "/relative"};
-  MapState() : PM(FS, Alloc) {
+  MapState() : PM(FS) {
     EXPECT_THAT_ERROR(PM.add(MappedPrefix{"relative", "/new1"}), Succeeded());
     EXPECT_THAT_ERROR(PM.add(MappedPrefix{"/absolute", "/new2"}), Succeeded());
   }
@@ -541,39 +524,24 @@ TEST(TreePathPrefixMapperTest, map) {
   for (StringRef S : State.FailedTests) {
     FoundV = "";
     FoundS = "";
-    EXPECT_THAT_EXPECTED(State.PM.map(S), Failed());
     EXPECT_THAT_EXPECTED(State.PM.mapToString(S), Failed());
     EXPECT_THAT_ERROR(State.PM.map(S, NotFoundV), Failed());
     EXPECT_THAT_ERROR(State.PM.map(S, NotFoundS), Failed());
     EXPECT_EQ("", NotFoundV);
     EXPECT_EQ("", NotFoundS);
-    EXPECT_EQ(None, State.PM.mapOrNone(S));
-    EXPECT_EQ(None, State.PM.mapToStringOrNone(S));
-    EXPECT_EQ(S, State.PM.mapOrOriginal(S));
-
-    State.PM.mapOrOriginal(S, FoundV);
-    State.PM.mapOrOriginal(S, FoundS);
-    EXPECT_EQ(S, FoundV);
-    EXPECT_EQ(S, FoundS);
+    EXPECT_EQ(None, State.PM.mapOrNoneIfError(S, NotFoundV));
   }
 
   for (MappedPrefix Map : State.Tests) {
-    EXPECT_THAT_EXPECTED(State.PM.map(Map.Old), HasValue(Map.New));
     EXPECT_THAT_EXPECTED(State.PM.mapToString(Map.Old), HasValue(Map.New));
     EXPECT_THAT_ERROR(State.PM.map(Map.Old, FoundV), Succeeded());
     EXPECT_THAT_ERROR(State.PM.map(Map.Old, FoundS), Succeeded());
     EXPECT_EQ(Map.New, FoundV);
     EXPECT_EQ(Map.New, FoundS);
-    EXPECT_EQ(Map.New, State.PM.mapOrNone(Map.Old));
-    EXPECT_EQ(Map.New.str(), State.PM.mapToStringOrNone(Map.Old));
-    EXPECT_EQ(Map.New, State.PM.mapOrOriginal(Map.Old));
+    EXPECT_EQ(Map.New, State.PM.mapOrNoneIfError(Map.Old, FoundV));
 
     FoundV = "";
     FoundS = "";
-    State.PM.mapOrOriginal(Map.Old, FoundV);
-    State.PM.mapOrOriginal(Map.Old, FoundS);
-    EXPECT_EQ(Map.New, FoundV);
-    EXPECT_EQ(Map.New, FoundS);
 
     if (Map.Old.empty())
       continue;
@@ -584,10 +552,12 @@ TEST(TreePathPrefixMapperTest, map) {
         Succeeded());
     FoundV = "";
     FoundS = "";
-    State.PM.map(*Entry, FoundV);
-    State.PM.map(*Entry, FoundS);
-    EXPECT_EQ(Map.New, State.PM.map(*Entry));
-    EXPECT_EQ(Map.New, State.PM.mapToString(*Entry));
+    EXPECT_THAT_ERROR(State.PM.map(Entry->getTreePath(), FoundV), Succeeded());
+    EXPECT_THAT_ERROR(State.PM.map(Entry->getTreePath(), FoundS), Succeeded());
+    std::string S;
+    ASSERT_THAT_ERROR(State.PM.mapToString(Entry->getTreePath()).moveInto(S),
+                      Succeeded());
+    EXPECT_EQ(Map.New, S);
     EXPECT_EQ(Map.New, FoundV);
     EXPECT_EQ(Map.New, FoundS);
   }
@@ -607,9 +577,7 @@ TEST(TreePathPrefixMapperTest, mapInPlace) {
     EXPECT_EQ(S, FoundS);
     EXPECT_EQ(S, FoundV);
     State.PM.mapInPlaceOrClear(FoundS);
-    State.PM.mapInPlaceOrClear(FoundV);
     EXPECT_EQ("", FoundS);
-    EXPECT_EQ("", FoundV);
   }
 
   for (MappedPrefix Map : State.Tests) {
@@ -623,9 +591,7 @@ TEST(TreePathPrefixMapperTest, mapInPlace) {
     FoundS = Map.Old.str();
     FoundV = Map.Old;
     State.PM.mapInPlaceOrClear(FoundS);
-    State.PM.mapInPlaceOrClear(FoundV);
     EXPECT_EQ(Map.New, FoundS);
-    EXPECT_EQ(Map.New, FoundV);
   }
 }
 


### PR DESCRIPTION
* Unify `PrefixMapper` and `TreePathPrefixMapper`; make `PrefixMapper` the canonical interface and `TreePathPrefixMapper` a subclass implementation of it that overrides the `add` and `mapImpl` functions.
* Remove `StringSaver` from `PrefixMapper`. I find the fact that it would implicitly allocate memory every time you called `map` undesirable, and returning a `StringRef` was not a commonly needed property anyway.
* Streamline it a bit and remove some APIs that were not used beyond unit tests.

This is a step towards using `PrefixMapper` for include-tree, which doesn't use a `CachingOnDiskFileSystem`.