### PR TITLE
[lldb] Add "auto" option in expression's "bind-generic-types" option

### DIFF
--- a/lldb/include/lldb/Interpreter/OptionGroupValueObjectDisplay.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupValueObjectDisplay.h
@@ -18,7 +18,7 @@ namespace lldb_private {
 
 class OptionGroupValueObjectDisplay : public OptionGroup {
 public:
-  OptionGroupValueObjectDisplay() : bind_generic_types(true) {}
+  OptionGroupValueObjectDisplay() = default;
 
   ~OptionGroupValueObjectDisplay() override = default;
 
@@ -33,7 +33,8 @@ public:
     return show_types || no_summary_depth != 0 || show_location ||
            flat_output || use_objc || max_depth != UINT32_MAX ||
            ptr_depth != 0 || !use_synth || be_raw || ignore_cap ||
-           run_validator || !bind_generic_types;
+           run_validator ||
+           bind_generic_types != lldb::eBindAuto;
   }
 
   DumpValueObjectOptions GetAsDumpOptions(
@@ -44,13 +45,14 @@ public:
 
   bool show_types : 1, show_location : 1, flat_output : 1, use_objc : 1,
       use_synth : 1, be_raw : 1, ignore_cap : 1, run_validator : 1,
-      max_depth_is_default : 1, bind_generic_types : 1;
+      max_depth_is_default : 1;
 
   uint32_t no_summary_depth;
   uint32_t max_depth;
   uint32_t ptr_depth;
   uint32_t elem_count;
   lldb::DynamicValueType use_dynamic;
+  lldb::BindGenericTypes bind_generic_types;
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -54,6 +54,8 @@ class SwiftASTContextForExpressions;
 
 OptionEnumValues GetDynamicValueTypes();
 
+OptionEnumValues GetBindGenericTypesOptions();
+
 enum InlineStrategy {
   eInlineBreakpointsNever = 0,
   eInlineBreakpointsHeaders,
@@ -431,9 +433,13 @@ public:
       m_language = lldb::eLanguageTypeSwift;
   }
 
-  bool GetBindGenericTypes() const { return m_bind_generic_types; }
+  lldb::BindGenericTypes GetBindGenericTypes() const {
+    return m_bind_generic_types;
+  }
 
-  void SetBindGenericTypes(bool b) { m_bind_generic_types = b; }
+  void SetBindGenericTypes(lldb::BindGenericTypes b) {
+    m_bind_generic_types = b;
+  }
 
   bool GetPlaygroundTransformHighPerformance() const {
     return m_playground_transforms_hp;
@@ -520,7 +526,7 @@ private:
   /// used by LLDB internally.
   bool m_running_utility_expression = false;
 
-  bool m_bind_generic_types = true;
+  lldb::BindGenericTypes m_bind_generic_types = lldb::eBindAuto;
 
   lldb::DynamicValueType m_use_dynamic = lldb::eNoDynamicValues;
   Timeout<std::micro> m_timeout = default_timeout;

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -498,6 +498,12 @@ enum DynamicValueType {
   eDynamicDontRunTarget = 2
 };
 
+enum BindGenericTypes {
+  eBindAuto = 0,
+  eBind = 1,
+  eDontBind = 2
+};
+
 enum StopShowColumn {
   eStopShowColumnAnsiOrCaret = 0,
   eStopShowColumnAnsi = 1,

--- a/lldb/source/Interpreter/OptionGroupValueObjectDisplay.cpp
+++ b/lldb/source/Interpreter/OptionGroupValueObjectDisplay.cpp
@@ -60,10 +60,10 @@ static const OptionDefinition g_option_table[] = {
      "Treat the result of the expression as if its type is an array of this "
      "many values."},
     {LLDB_OPT_SET_1, false, "bind-generic-types", /* no short option */ 1,
-     OptionParser::eRequiredArgument, nullptr, {}, 0,
-     eArgTypeBoolean, "Controls whether any generic types in the current "
+     OptionParser::eRequiredArgument, nullptr, GetBindGenericTypesOptions(), 0,
+     eArgTypeNone, "Controls whether any generic types in the current "
        "context should be bound to their dynamic concrete types before "
-       "evaluating. Defaults to true."}
+       "evaluating. Defaults to auto."}
 };
 
 llvm::ArrayRef<OptionDefinition>
@@ -156,10 +156,11 @@ Status OptionGroupValueObjectDisplay::SetOptionValue(
     break;
 
   case 1:
-    bind_generic_types = OptionArgParser::ToBoolean(option_arg, true, &success);
-    if (!success)
-      error.SetErrorStringWithFormat("invalid validate '%s'",
-                                     option_arg.str().c_str());
+    int32_t result;
+    result = OptionArgParser::ToOptionEnum(option_arg, GetBindGenericTypesOptions(),
+                                           0, error);
+    if (error.Success())
+      bind_generic_types = (lldb::BindGenericTypes)result;
     break;
 
   default:
@@ -185,6 +186,7 @@ void OptionGroupValueObjectDisplay::OptionParsingStarting(
   be_raw = false;
   ignore_cap = false;
   run_validator = false;
+  bind_generic_types = lldb::eBindAuto;
 
   TargetSP target_sp =
       execution_context ? execution_context->GetTargetSP() : TargetSP();

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -104,7 +104,7 @@ public:
   };
 
   SwiftASTManipulatorBase(swift::SourceFile &source_file, bool repl,
-                          bool bind_generic_types)
+                          lldb::BindGenericTypes bind_generic_types)
       : m_source_file(source_file), m_variables(), m_repl(repl),
         m_bind_generic_types(bind_generic_types) {
     DoInitialization();
@@ -128,7 +128,7 @@ protected:
 
   bool m_repl = false;
 
-  bool m_bind_generic_types = true;
+  lldb::BindGenericTypes m_bind_generic_types = lldb::eBindAuto;
 
   /// The function containing the expression's code.
   swift::FuncDecl *m_function_decl = nullptr;
@@ -153,7 +153,7 @@ protected:
 class SwiftASTManipulator : public SwiftASTManipulatorBase {
 public:
   SwiftASTManipulator(swift::SourceFile &source_file, bool repl,
-                      bool bind_generic_types);
+                      lldb::BindGenericTypes bind_generic_types);
 
   static void WrapExpression(Stream &wrapped_stream, const char *text,
                              bool needs_object_ptr,

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -42,6 +42,12 @@ class IRExecutionUnit;
 //----------------------------------------------------------------------
 class SwiftExpressionParser : public ExpressionParser {
 public:
+  enum class ParseResult {
+    success,
+    retry_fresh_context, 
+    retry_no_bind_generic_params,
+    unrecoverable_error
+  };
   //------------------------------------------------------------------
   /// Constructor
   ///
@@ -83,8 +89,8 @@ public:
   ///     The number of errors encountered during parsing.  0 means
   ///     success.
   //------------------------------------------------------------------
-  unsigned Parse(DiagnosticManager &diagnostic_manager, uint32_t first_line = 0,
-                 uint32_t last_line = UINT32_MAX);
+  ParseResult Parse(DiagnosticManager &diagnostic_manager,
+                    uint32_t first_line = 0, uint32_t last_line = UINT32_MAX);
 
   //------------------------------------------------------------------
   /// Ready an already-parsed expression for execution, possibly

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "SwiftExpressionParser.h"
 #include "lldb/Expression/LLVMUserExpression.h"
 #include "lldb/Expression/Materializer.h"
 
@@ -26,7 +27,7 @@
 // Project includes
 
 namespace lldb_private {
-class SwiftExpressionParser;
+class SwiftExpressionSourceCode;
   
 //----------------------------------------------------------------------
 /// @class SwiftUserExpression SwiftUserExpression.h
@@ -149,6 +150,11 @@ private:
   bool AddArguments(ExecutionContext &exe_ctx, std::vector<lldb::addr_t> &args,
                     lldb::addr_t struct_address,
                     DiagnosticManager &diagnostic_manager) override;
+
+  SwiftExpressionParser::ParseResult
+  GetTextAndSetExpressionParser(DiagnosticManager &diagnostic_manager,
+                  std::unique_ptr<SwiftExpressionSourceCode> &source_code,
+                  ExecutionContext &exe_ctx, ExecutionContextScope *exe_scope);
 
   SwiftUserExpressionHelper m_type_system_helper;
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4198,6 +4198,30 @@ OptionEnumValues lldb_private::GetDynamicValueTypes() {
   return OptionEnumValues(g_dynamic_value_types);
 }
 
+static constexpr OptionEnumValueElement g_bind_generic_types[] = {
+    {
+        eBindAuto,
+        "auto",
+        "Attempt to run the expression with bound generic parameters first, "
+        "fallback to unbound generic parameters if binding the type parameters "
+        "fails",
+    },
+    {
+        eBind,
+        "true",
+        "Bind the generic type parameters.",
+    },
+    {
+        eDontBind,
+        "false",
+        "Don't bind the generic type parameters.",
+    },
+};
+
+OptionEnumValues lldb_private::GetBindGenericTypesOptions() {
+  return OptionEnumValues(g_bind_generic_types);
+}
+
 static constexpr OptionEnumValueElement g_inline_breakpoint_enums[] = {
     {
         eInlineBreakpointsNever,

--- a/lldb/test/API/lang/swift/private_discriminator/TestSwiftPrivateDiscriminator.py
+++ b/lldb/test/API/lang/swift/private_discriminator/TestSwiftPrivateDiscriminator.py
@@ -24,7 +24,12 @@ class TestSwiftPrivateDiscriminator(lldbtest.TestBase):
 
         self.expect("frame var -d run -- self",
                     substrs=['Builder.Private', 'n', '23'])
-        self.expect("p self", error=True, substrs=["Hint"])
+
+        self.expect("e --bind-generic-types true -- self", error=True, substrs=["Hint"])
+        # This should work because expression evaluation automatically falls back
+        # to not binding generic parameters.
+        self.expect("p self", substrs=['Generic', '<T>', 'n', '23'])
+
         process.Continue()
         # This should work.
         self.expect("frame var -d run -- visible",

--- a/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
+++ b/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
@@ -21,27 +21,52 @@ class TestSwiftPrivateGenericType(TestBase):
         os.unlink(self.getBuildArtifact("Private.swiftmodule"))
         os.unlink(self.getBuildArtifact("Private.swiftinterface"))
 
-        target, process, _, _ = lldbutil.run_to_source_breakpoint( self, 'break here for struct', lldb.SBFileSpec('Public.swift'),
-            extra_images=['Public'])
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(self, 
+                'break here for struct', lldb.SBFileSpec('Public.swift'),
+                extra_images=['Public'])
         # Make sure this fails without generic expression evaluation.
-        self.expect("e --bind-generic-types true -- self", substrs=["Couldn't realize Swift AST type of self."], error=True)
-        self.expect("e --bind-generic-types false -- self", substrs=["Public.StructWrapper<T>", 
-                                             "The invisible man."])
+        self.expect("e --bind-generic-types true -- self", 
+                    substrs=["Couldn't realize Swift AST type of self."], 
+                    error=True)
+        # Test that not binding works.
+        self.expect("e --bind-generic-types false -- self", 
+                    substrs=["Public.StructWrapper<T>", 
+                             "The invisible man."])
+        # Test that the "auto" behavior also works.
+        self.expect("e --bind-generic-types auto -- self", 
+                    substrs=["Public.StructWrapper<T>", 
+                             "The invisible man."])
+        # Test that the default (should be the auto option) also works.
+        self.expect("e -- self", substrs=["Public.StructWrapper<T>", 
+                                          "The invisible man."])
 
         breakpoint = target.BreakpointCreateBySourceRegex(
             'break here for class', lldb.SBFileSpec('Public.swift'), None)
         lldbutil.continue_to_breakpoint(process, breakpoint)
-        self.expect("e --bind-generic-types true -- self", substrs=["Couldn't realize Swift AST type of self."], error=True)
-        self.expect("e --bind-generic-types false -- self", substrs=["Public.ClassWrapper<Private.InvisibleStruct>", 
-                                             "The invisible man."])
+        self.expect("e --bind-generic-types true -- self", 
+                    substrs=["Couldn't realize Swift AST type of self."], 
+                    error=True)
+        self.expect("e --bind-generic-types false -- self", 
+                    substrs=["Public.ClassWrapper<Private.InvisibleStruct>", 
+                             "The invisible man."])
+        self.expect("e --bind-generic-types auto -- self", 
+                    substrs=["Public.ClassWrapper<Private.InvisibleStruct>", 
+                             "The invisible man."])
+        self.expect("e -- self", 
+                    substrs=["Public.ClassWrapper<Private.InvisibleStruct>", 
+                             "The invisible man."])
 
         breakpoint = target.BreakpointCreateBySourceRegex(
             'break here for non-generic', lldb.SBFileSpec('Public.swift'), None)
         lldbutil.continue_to_breakpoint(process, breakpoint)
-        self.expect("e --bind-generic-types false -- self", substrs=["Could not evaluate the expression as generic."], error=True)
+        self.expect("e --bind-generic-types false -- self", 
+                    substrs=["Could not evaluate the expression without binding generic types."], 
+                    error=True)
 
         breakpoint = target.BreakpointCreateBySourceRegex(
             'break here for two generic parameters', lldb.SBFileSpec('Public.swift'), None)
         lldbutil.continue_to_breakpoint(process, breakpoint)
-        self.expect("e --bind-generic-types false -- self", substrs=["Could not evaluate the expression as generic."], error=True)
+        self.expect("e --bind-generic-types false -- self", 
+                    substrs=["Could not evaluate the expression without binding generic types."], 
+                    error=True)
 


### PR DESCRIPTION
This patch modifies the "bind-generic-types" from a boolean to an enum with three states: true, false and auto. True and false behave as expected. Auto attempts to bind the generic parameters, and upon failure, reruns the expression without binding them.

(cherry picked from commit adf0aa73f9c88d0dec664a382b2cd218ee761caf)