### PR TITLE
[lldb] Add an SBExpressionOption to enable the "pc macro" transform for playgrounds

### DIFF
--- a/lldb/bindings/interface/SBExpressionOptions.i
+++ b/lldb/bindings/interface/SBExpressionOptions.i
@@ -98,6 +98,12 @@ public:
     SetPlaygroundTransformEnabled (bool enable_playground_transform = true);
 
     bool
+    GetPCMacroEnabled () const;
+
+    void
+    SetPCMacroEnabled (bool enable_pc_macro = true);
+
+    bool
     GetREPLMode () const;
     
     void

--- a/lldb/include/lldb/API/SBExpressionOptions.h
+++ b/lldb/include/lldb/API/SBExpressionOptions.h
@@ -79,6 +79,10 @@ public:
   void
   SetPlaygroundTransformHighPerformance(bool playground_transforms_hp = true);
 
+  bool GetPCMacroEnabled() const;
+
+  void SetPCMacroEnabled(bool enable_pc_macro = true);
+
   bool GetREPLMode() const;
 
   void SetREPLMode(bool enable_repl_mode = true);

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -443,6 +443,14 @@ public:
     m_playground_transforms_hp = b;
   }
 
+  bool GetPCMacroEnabled() const {
+    return m_pc_macro_enabled;
+  }
+
+  void SetPCMacroEnabled(bool b) {
+    m_pc_macro_enabled = b;
+  }
+
   void SetCancelCallback(lldb::ExpressionCancelCallback callback, void *baton) {
     m_cancel_callback_baton = baton;
     m_cancel_callback = callback;
@@ -511,6 +519,7 @@ private:
   bool m_repl = false;
   bool m_playground = false;
   bool m_playground_transforms_hp = true;
+  bool m_pc_macro_enabled = false;
   bool m_generate_debug_info = false;
   bool m_ansi_color_errors = false;
   bool m_result_is_internal = false;

--- a/lldb/source/API/SBExpressionOptions.cpp
+++ b/lldb/source/API/SBExpressionOptions.cpp
@@ -183,6 +183,14 @@ void SBExpressionOptions::SetPlaygroundTransformHighPerformance(
   m_opaque_up->SetPlaygroundTransformHighPerformance(playground_transforms_hp);
 }
 
+bool SBExpressionOptions::GetPCMacroEnabled() const {
+  return m_opaque_up->GetPCMacroEnabled();
+}
+
+void SBExpressionOptions::SetPCMacroEnabled(bool pc_macro) {
+  m_opaque_up->SetPCMacroEnabled(pc_macro);
+}
+
 bool SBExpressionOptions::GetREPLMode() const {
   return m_opaque_up->GetREPLEnabled();
 }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -89,6 +89,8 @@ void SwiftASTManipulator::WrapExpression(
 @_silgen_name ("playground_log_scope_exit") func __builtin_log_scope_exit (_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleID: Int, _ fileID: Int) -> AnyObject
 @_silgen_name ("playground_log_postprint") func __builtin_postPrint (_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleID: Int, _ fileID: Int) -> AnyObject
 @_silgen_name ("DVTSendPlaygroundLogData") func __builtin_send_data (_ :  AnyObject!)
+@_silgen_name ("playground_pc_before") func __builtin_pc_before(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int)
+@_silgen_name ("playground_pc_after") func __builtin_pc_after(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int)
 __builtin_logger_initialize()
 )";
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1568,6 +1568,9 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
       return 1;
     }
   } else {
+    if (m_options.GetPCMacroEnabled()) {
+      swift::performPCMacro(parsed_expr->source_file);
+    }
     swift::performPlaygroundTransform(
         parsed_expr->source_file,
         m_options.GetPlaygroundTransformHighPerformance());


### PR DESCRIPTION
The Swift compiler has a transform called "pc macro" that inserts calls to `playground_pc_before()` and `playground_pc_after()` before and after each range of code the PC visits (typically each line of source code).  This transform is performed by calling `swift::performPCMacro()` on the parsed source file expression.

This is analogous to the "playground transform" (and can indeed be combined with `swift::performPlaygroundTransform()`, with the restriction that `swift::performPCMacro()` has to be called _before_ `swift::performPlaygroundTransform()` is called).

This change allows this transform to be controlled in the option struct, which already has things like `GetPlaygroundTransformEnabled()` and `GetREPLEnabled()`, and to call `swift::performPCMacro()` when it's set.

I order to maintain existing behaviour, this option is off by default.

rdar://103090524