### PR TITLE
Add a test for dynamically allocated task variables.

### DIFF
--- a/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
+++ b/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
@@ -23,6 +23,8 @@ class TestCase(lldbtest.TestBase):
         b = frame.FindVariable("b")
         self.assertTrue(b.IsValid())
         self.assertEqual(b.unsigned, 0)
+        d = frame.FindVariable("d")
+        lldbutil.check_variable(self, d, False, value='23')
 
         # The first breakpoint resolves to multiple locations, but only the
         # first location is needed. Now that we've stopped, delete it to
@@ -42,3 +44,5 @@ class TestCase(lldbtest.TestBase):
         b = frame.FindVariable("b")
         self.assertTrue(b.IsValid())
         self.assertGreater(b.unsigned, 0)
+        d = frame.FindVariable("d")
+        lldbutil.check_variable(self, d, False, value='23')

--- a/lldb/test/API/lang/swift/async/frame/variable/main.swift
+++ b/lldb/test/API/lang/swift/async/frame/variable/main.swift
@@ -2,10 +2,14 @@ func randInt(_ i: Int) async -> Int {
   return Int.random(in: 1...i)
 }
 
-func inner() async {
+func inner<T>(_ t: T) async {
+  // d is dynamically allocated by swift_task_alloc() because its size
+  // is unknown.
+  let d = t
   let a = await randInt(30)
   let b = await randInt(a + 11) // break one
-  use(a, b) // break two
+  use(a, b)
+  use(d) // break two
 }
 
 func use<T>(_ t: T...) {}
@@ -15,6 +19,6 @@ func use<T>(_ t: T...) {}
     // This call to `inner` is a indirection required to make this test work.
     // If its contents were inlined into `main` (as it was originally written),
     // the test would fail.
-    await inner()
+    await inner(23)
   }
 }


### PR DESCRIPTION
(Note that this is currently broken due to a bug in debug info generation). Fixed in https://github.com/apple/swift/pull/62542