### PR TITLE
[lldb] Make generic expr eval work with multiple toplevel generic params

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -59,6 +59,30 @@ public:
     unsigned GetType() override { return Type(); }
   };
 
+  class VariableMetadataPersistent
+      : public SwiftASTManipulatorBase::VariableMetadata {
+  public:
+    VariableMetadataPersistent(
+        lldb::ExpressionVariableSP &persistent_variable_sp)
+        : m_persistent_variable_sp(persistent_variable_sp) {}
+
+    static constexpr unsigned Type() { return 'Pers'; }
+    unsigned GetType() override { return Type(); }
+    lldb::ExpressionVariableSP m_persistent_variable_sp;
+  };
+
+class VariableMetadataVariable
+    : public SwiftASTManipulatorBase::VariableMetadata {
+public:
+  VariableMetadataVariable(lldb::VariableSP &variable_sp)
+      : m_variable_sp(variable_sp) {}
+
+  static constexpr unsigned Type() { return 'Vari'; }
+  unsigned GetType() override { return Type(); }
+  lldb::VariableSP m_variable_sp;
+};
+
+
   typedef std::shared_ptr<VariableMetadata> VariableMetadataSP;
 
   struct VariableInfo {
@@ -68,6 +92,9 @@ public:
     swift::VarDecl::Introducer GetVarIntroducer() const;
     bool GetIsCaptureList() const;
     bool IsMetadataPointer() const { return m_name.str().startswith("$τ"); }
+    bool IsOutermostMetadataPointer() const {
+      return m_name.str().startswith("$τ_0_");
+    }
     bool IsSelf() const {
       return !m_name.str().compare("$__lldb_injected_self");
     }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -76,8 +76,8 @@
 #include "swift/Demangling/Demangle.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Parse/LocalContext.h"
-#include "swift/Parse/PersistentParserState.h"
 #include "swift/SIL/SILDebuggerClient.h"
+#include "swift/Parse/PersistentParserState.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/TypeLowering.h"
@@ -94,9 +94,11 @@ using llvm::inconvertibleErrorCode;
 SwiftExpressionParser::SwiftExpressionParser(
     ExecutionContextScope *exe_scope,
     SwiftASTContextForExpressions &swift_ast_ctx, Expression &expr,
+      llvm::SmallVector<SwiftASTManipulator::VariableInfo> &&local_variables,
     const EvaluateExpressionOptions &options)
     : ExpressionParser(exe_scope, expr, options.GetGenerateDebugInfo()),
       m_expr(expr), m_swift_ast_ctx(swift_ast_ctx), m_exe_scope(exe_scope),
+      m_local_variables(std::move(local_variables)),
       m_options(options) {
   assert(expr.Language() == lldb::eLanguageTypeSwift);
 
@@ -472,11 +474,10 @@ static CompilerType GetSwiftTypeForVariableValueObject(
 /// more specific private implementations that LLDB can resolve, but
 /// SwiftASTContext cannot see because there is no header file that
 /// would declare them.
-static CompilerType ResolveVariable(lldb::VariableSP variable_sp,
-                                    lldb::StackFrameSP &stack_frame_sp,
-                                    SwiftLanguageRuntime *runtime,
-                                    lldb::DynamicValueType use_dynamic,
-                                    lldb::BindGenericTypes bind_generic_types) {
+CompilerType SwiftExpressionParser::ResolveVariable(
+    lldb::VariableSP variable_sp, lldb::StackFrameSP &stack_frame_sp,
+    SwiftLanguageRuntime *runtime, lldb::DynamicValueType use_dynamic,
+    lldb::BindGenericTypes bind_generic_types) {
   LLDB_SCOPED_TIMER();
   lldb::ValueObjectSP valobj_sp =
       stack_frame_sp->GetValueObjectForFrameVariable(variable_sp,
@@ -503,7 +504,7 @@ static CompilerType ResolveVariable(lldb::VariableSP variable_sp,
   return var_type;
 }
 
-static lldb::VariableSP FindSelfVariable(Block *block) {
+lldb::VariableSP SwiftExpressionParser::FindSelfVariable(Block *block) {
   if (!block)
     return {};
 
@@ -524,24 +525,6 @@ static lldb::VariableSP FindSelfVariable(Block *block) {
   return variable_list_sp->FindVariable(ConstString("self"));
 }
 
-struct BindGenericSelfParamsError : public llvm::ErrorInfo<BindGenericSelfParamsError> {
-  static char ID;
-  std::string msg;
-  bool is_new_dylib;
-
-  BindGenericSelfParamsError() = default;
-
-  void log(llvm::raw_ostream &OS) const override {
-    OS << "Couldn't realize Swift AST type of self. Hint: using `v` to "
-          "directly inspect variables and fields may still work.";
-  }
-  std::error_code convertToErrorCode() const override {
-    return inconvertibleErrorCode();
-  }
-};
-
-char BindGenericSelfParamsError::ID = 0;
-
 static void AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
                                SwiftASTContextForExpressions &swift_ast_context,
                                SwiftASTManipulator &manipulator,
@@ -550,16 +533,16 @@ static void AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
   LLDB_SCOPED_TIMER();
 
   // First emit the typealias for "$__lldb_context".
-  lldb::VariableSP self_var_sp = FindSelfVariable(block);
+  lldb::VariableSP self_var_sp = SwiftExpressionParser::FindSelfVariable(block);
 
   if (!self_var_sp)
     return;
 
   auto *swift_runtime =
       SwiftLanguageRuntime::Get(stack_frame_sp->GetThread()->GetProcess());
-  CompilerType self_type =
-      ResolveVariable(self_var_sp, stack_frame_sp, swift_runtime, use_dynamic,
-                      bind_generic_types);
+  CompilerType self_type = SwiftExpressionParser::ResolveVariable(
+      self_var_sp, stack_frame_sp, swift_runtime, use_dynamic,
+      bind_generic_types);
 
   if (!self_type.IsValid()) {
     if (Type *type = self_var_sp->GetType()) {
@@ -681,183 +664,6 @@ static void AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
   manipulator.MakeGlobalTypealias(
       swift_ast_context.GetASTContext()->getIdentifier("$__lldb_builtin_ptr_t"),
       builtin_ptr_t, false);
-}
-
-/// Create a \c VariableInfo record for \c variable if there isn't
-/// already shadowing inner declaration in \c processed_variables.
-static llvm::Optional<llvm::Error> AddVariableInfo(
-    lldb::VariableSP variable_sp, lldb::StackFrameSP &stack_frame_sp,
-    SwiftASTContextForExpressions &ast_context, SwiftLanguageRuntime *runtime,
-    llvm::SmallDenseSet<const char *, 8> &processed_variables,
-    llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables,
-    lldb::DynamicValueType use_dynamic,
-    lldb::BindGenericTypes bind_generic_types) {
-  LLDB_SCOPED_TIMER();
-
-  StringRef name = variable_sp->GetUnqualifiedName().GetStringRef();
-  const char *name_cstr = name.data();
-  assert(StringRef(name_cstr) == name && "missing null terminator");
-  if (name.empty())
-    return {};
-
-  // To support "guard let self = self" the function argument "self"
-  // is processed (as the special self argument) even if it is
-  // shadowed by a local variable.
-  bool is_self = SwiftLanguageRuntime::IsSelf(*variable_sp);
-  const char *overridden_name = name_cstr;
-  if (is_self)
-    overridden_name = "$__lldb_injected_self";
-
-  if (processed_variables.count(overridden_name))
-    return {};
-
-  if (!stack_frame_sp)
-    return llvm::None;
-
-  CompilerType target_type;
-
-  // If we're not binding the generic types, we need to set the self type as an
-  // opaque pointer type. This is necessary because we don't bind the generic
-  // parameters, and we can't have a type with unbound generics in a non-generic
-  // function.
-  if (is_self && bind_generic_types == lldb::eDontBind) {
-    target_type = ast_context.GetBuiltinRawPointerType();
-  } else {
-    CompilerType var_type =
-        ResolveVariable(variable_sp, stack_frame_sp, runtime, use_dynamic,
-                        bind_generic_types);
-
-    Status error;
-    target_type = ast_context.ImportType(var_type, error);
-  }
-
-  // If the import failed, give up.
-  if (!target_type.IsValid())
-    return {};
-
-  // If we couldn't fully realize the type, then we aren't going
-  // to get very far making a local out of it, so discard it here.
-  Log *log = GetLog(LLDBLog::Types | LLDBLog::Expressions);
-  if (!SwiftASTContext::IsFullyRealized(target_type)) {
-    if (log)
-      log->Printf("Discarding local %s because we couldn't fully realize it, "
-                  "our best attempt was: %s.",
-                  name_cstr, target_type.GetDisplayTypeName().AsCString("<unknown>"));
-    // Not realizing self is a fatal error for an expression and the
-    // Swift compiler error alone is not particularly useful.
-    if (is_self)
-      return make_error<BindGenericSelfParamsError>();
-    return {};
-  }
-
-  if (log && is_self)
-    if (swift::Type swift_type = GetSwiftType(target_type)) {
-      std::string s;
-      llvm::raw_string_ostream ss(s);
-      swift_type->dump(ss);
-      ss.flush();
-      log->Printf("Adding injected self: type (%p) context(%p) is: %s",
-                  static_cast<void *>(swift_type.getPointer()),
-                  static_cast<void *>(ast_context.GetASTContext()), s.c_str());
-    }
-  // A one-off clone of variable_sp with the type replaced by target_type.
-  auto patched_variable_sp = std::make_shared<lldb_private::Variable>(
-      0, variable_sp->GetName().GetCString(), "",
-      std::make_shared<lldb_private::SymbolFileType>(
-          *variable_sp->GetType()->GetSymbolFile(),
-          std::make_shared<lldb_private::Type>(
-              0, variable_sp->GetType()->GetSymbolFile(),
-              variable_sp->GetType()->GetName(), llvm::None,
-              variable_sp->GetType()->GetSymbolContextScope(), LLDB_INVALID_UID,
-              Type::eEncodingIsUID, variable_sp->GetType()->GetDeclaration(),
-              target_type, lldb_private::Type::ResolveState::Full,
-              variable_sp->GetType()->GetPayload())),
-      variable_sp->GetScope(), variable_sp->GetSymbolContextScope(),
-      variable_sp->GetScopeRange(),
-      const_cast<lldb_private::Declaration *>(&variable_sp->GetDeclaration()),
-      variable_sp->LocationExpression(), variable_sp->IsExternal(),
-      variable_sp->IsArtificial(),
-      variable_sp->GetLocationIsConstantValueData(),
-      variable_sp->IsStaticMember(), variable_sp->IsConstant());
-  SwiftASTManipulatorBase::VariableMetadataSP metadata_sp(
-      new VariableMetadataVariable(patched_variable_sp));
-  SwiftASTManipulator::VariableInfo variable_info(
-      target_type, ast_context.GetASTContext()->getIdentifier(overridden_name),
-      metadata_sp,
-      variable_sp->IsConstant() ? swift::VarDecl::Introducer::Let
-                                : swift::VarDecl::Introducer::Var);
-
-  local_variables.push_back(variable_info);
-  processed_variables.insert(overridden_name);
-  return {};
-}
-
-/// Create a \c VariableInfo record for each visible variable.
-static llvm::Optional<llvm::Error> RegisterAllVariables(
-    SymbolContext &sc, lldb::StackFrameSP &stack_frame_sp,
-    SwiftASTContextForExpressions &ast_context,
-    llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables,
-    lldb::DynamicValueType use_dynamic, lldb::BindGenericTypes bind_generic_types) {
-  LLDB_SCOPED_TIMER();
-  if (!sc.block && !sc.function)
-    return {};
-
-  Block *block = sc.block;
-  Block *top_block = block->GetContainingInlinedBlock();
-
-  if (!top_block)
-    top_block = &sc.function->GetBlock(true);
-
-  SwiftLanguageRuntime *language_runtime = nullptr;
-
-  if (stack_frame_sp)
-    language_runtime =
-        SwiftLanguageRuntime::Get(stack_frame_sp->GetThread()->GetProcess());
-
-  // The module scoped variables are stored at the CompUnit level, so
-  // after we go through the current context, then we have to take one
-  // more pass through the variables in the CompUnit.
-  VariableList variables;
-
-  // Proceed from the innermost scope outwards, adding all variables
-  // not already shadowed by an inner declaration.
-  llvm::SmallDenseSet<const char *, 8> processed_names;
-  bool done = false;
-  do {
-    // Iterate over all parent contexts *including* the top_block.
-    if (block == top_block)
-      done = true;
-    bool can_create = true;
-    bool get_parent_variables = false;
-    bool stop_if_block_is_inlined_function = true;
-
-    block->AppendVariables(
-        can_create, get_parent_variables, stop_if_block_is_inlined_function,
-        [](Variable *) { return true; }, &variables);
-
-    if (!done)
-      block = block->GetParent();
-  } while (block && !done);
-
-  // Also add local copies of globals. This is in many cases redundant
-  // work because the globals would also be found in the expression
-  // context's Swift module, but it allows a limited form of
-  // expression evaluation to work even if the Swift module failed to
-  // load, as long as the module isn't necessary to resolve the type
-  // or aother symbols in the expression.
-  if (sc.comp_unit) {
-    lldb::VariableListSP globals_sp = sc.comp_unit->GetVariableList(true);
-    if (globals_sp)
-      variables.AddVariables(globals_sp.get());
-  }
-
-  for (size_t vi = 0, ve = variables.GetSize(); vi != ve; ++vi)
-    if (auto error = AddVariableInfo(
-            {variables.GetVariableAtIndex(vi)}, stack_frame_sp, ast_context,
-            language_runtime, processed_names, local_variables, use_dynamic,
-            bind_generic_types))
-      return error;
-  return {};
 }
 
 static void ResolveSpecialNames(
@@ -1261,91 +1067,6 @@ struct ParsedExpression {
 
 } // namespace
 
-/// Check if we can evaluate the expression as generic.
-/// Currently, evaluating expression as a generic has several limitations:
-/// - Only self will be evaluated with unbound generics.
-/// - The Self type can only have one generic parameter. 
-/// - The Self type has to be the outermost type with unbound generics.
-static bool CanEvaluateExpressionAsGeneric(
-    llvm::ArrayRef<SwiftASTManipulator::VariableInfo> variables, Block *block,
-    StackFrame &stack_frame) {
-  // First, find the compiler type of self with the generic parameters not
-  // bound.
-  auto self_var = FindSelfVariable(block);
-  if (!self_var)
-    return false;
-
-  lldb::ValueObjectSP self_valobj =
-      stack_frame.GetValueObjectForFrameVariable(self_var,
-                                                     lldb::eNoDynamicValues);
-  if (!self_valobj)
-    return false;
-
-  auto self_type = self_valobj->GetCompilerType();
-  if (!self_type)
-    return false;
-
-  auto *ts = self_type.GetTypeSystem()
-                 .dyn_cast_or_null<TypeSystemSwift>()
-                 ->GetSwiftASTContext();
-
-  if (!ts)
-    return false;
-
-  auto swift_type = ts->GetSwiftType(self_type);
-  if (!swift_type)
-    return false;
-
-  auto *decl = swift_type->getAnyGeneric();
-  if (!decl)
-    return false;
-
-
-  auto *env = decl->getGenericEnvironment();
-  if (!env)
-    return false;
-  auto params = env->getGenericParams();
-
-  // If there aren't any generic parameters we can't evaluate the expression as
-  // generic.
-  if (params.empty())
-    return false;
-
-  auto *first_param = params[0];
-  // Currently we only support evaluating self as generic if the generic
-  // parameter is the first one.
-  if (first_param->getDepth() != 0 || first_param->getIndex() != 0)
-    return false;
-
-  bool contains_0_0 = false;
-  bool contains_other_0_depth_params = false;
-  for (auto *pair : params) {
-    if (pair->getDepth() == 0) {
-      if (pair->getIndex() == 0)
-        contains_0_0 = true;
-      else
-        contains_other_0_depth_params = true;
-    }
-  }
-
-  // We only allow generic evaluation when the Self type contains the outermost
-  // generic parameter.
-  if (!contains_0_0)
-    return false;
-
-  // We only allow the Self type to have one generic parameter.
-  if (contains_other_0_depth_params)
-    return false;
-
-  // Now, check that we do have the metadata pointer as a local variable.
-  for (auto &variable : variables) {
-    if (variable.GetName().str() == "$τ_0_0")
-      return true;
-  }
-  // Couldn't find the metadata pointer, so can't evaluate as generic.
-  return false;
-}
-
 /// Attempt to parse an expression and import all the Swift modules
 /// the expression and its context depend on.
 static llvm::Expected<ParsedExpression> ParseAndImport(
@@ -1354,7 +1075,9 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
     DiagnosticManager &diagnostic_manager,
     SwiftExpressionParser &swift_expr_parser,
     lldb::StackFrameWP &stack_frame_wp, SymbolContext &sc,
-    ExecutionContextScope &exe_scope, const EvaluateExpressionOptions &options,
+    ExecutionContextScope &exe_scope, 
+    llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables,
+    const EvaluateExpressionOptions &options,
     bool repl, bool playground) {
   Log *log = GetLog(LLDBLog::Expressions);
   LLDB_SCOPED_TIMER();
@@ -1538,18 +1261,10 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
         local_context_is_swift = false;
     }
 
-    llvm::SmallVector<SwiftASTManipulator::VariableInfo, 5> local_variables;
-
     if (local_context_is_swift) {
       AddRequiredAliases(sc.block, stack_frame_sp, swift_ast_context,
                          *code_manipulator, options.GetUseDynamic(),
                          options.GetBindGenericTypes());
-
-      // Register all local variables so that lookups to them resolve.
-      if (auto error = RegisterAllVariables(
-              sc, stack_frame_sp, swift_ast_context, local_variables,
-              options.GetUseDynamic(), options.GetBindGenericTypes()))
-        return std::move(*error);
     }
 
     // Register all magic variables.
@@ -1562,13 +1277,6 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
 
     ResolveSpecialNames(sc, exe_scope, swift_ast_context, special_names,
                         local_variables);
-
-    if (options.GetBindGenericTypes() == lldb::eDontBind &&
-        !CanEvaluateExpressionAsGeneric(local_variables, sc.block,
-                                        *stack_frame_sp.get()))
-      return make_error<StringError>(
-          inconvertibleErrorCode(),
-          "Could not evaluate the expression without binding generic types.");
 
     if (!code_manipulator->AddExternalVariables(local_variables))
       return make_error<StringError>(inconvertibleErrorCode(),
@@ -1677,19 +1385,27 @@ RedirectCallFromSinkToTrampolineFunction(llvm::Module &module,
   }
 
   auto *trampoline_func_type = trampoline_func->getFunctionType();
-  auto num_params = trampoline_func_type->getNumParams();
-  // There should be 3 params, the raw pointer, the self type, and the pointer
-  // to metadata
-  if (num_params != 3) {
+  auto trampoline_num_params = trampoline_func_type->getNumParams();
+  // There should be at least 3 params, the raw pointer, the self type, and at
+  // least one pointer to metadata.
+  if (trampoline_num_params < 3) {
     log->Printf(
         "[RedirectCallFromSinkToTrampolineFunction] Could not set the call: "
         "trampoline function has %u parameters",
-        num_params);
+        trampoline_num_params);
     return false;
   }
 
-  llvm::Type *param1 = trampoline_func_type->getParamType(1);
-  llvm::Type *param2 = trampoline_func_type->getParamType(2);
+  auto *sink_func_type = sink_func->getFunctionType();
+  auto sink_num_params = sink_func_type->getNumParams();
+
+  if (trampoline_num_params != sink_num_params) {
+    log->Printf(
+        "[RedirectCallFromSinkToTrampolineFunction] Could not set the call: "
+        "trampoline function has %u parameters but sink has %u parameters.",
+        trampoline_num_params, sink_num_params);
+    return false;
+  }
 
   auto &basic_blocks = lldb_expr_func->getBasicBlockList();
   // The entrypoint function should only have one basic block whith
@@ -1728,18 +1444,22 @@ RedirectCallFromSinkToTrampolineFunction(llvm::Module &module,
     return false;
   }
 
-  if (sink_call->arg_size() != 3) {
+  if (sink_call->arg_size() != sink_num_params) {
     log->Printf(
         "[RedirectCallFromSinkToTrampolineFunction] Could not set the call: "
         "call to sink function has %u arguments.",
         sink_call->arg_size());
     return false;
   }
-  // The sink call should have three parameters, the pointer to lldb_arg, a
-  // pointer to self and a pointer to the trampoline metadata of self.
+
+  // The sink call should have at least three parameters, the pointer to
+  // lldb_arg, a pointer to self and a pointer to the trampoline metadata of
+  // self.
   llvm::Value *lldb_arg_ptr = sink_call->getArgOperand(0);
   llvm::Value *self_load = sink_call->getArgOperand(1);
-  llvm::Value *metadata_load = sink_call->getArgOperand(2);
+  llvm::SmallVector<llvm::Value *> metadata_loads;
+  for (size_t i = 2; i < sink_num_params; ++i)
+    metadata_loads.emplace_back(sink_call->getArgOperand(i));
 
   // Delete the sink since we fished out the values we needed.
   sink_call->eraseFromParent();
@@ -1761,14 +1481,23 @@ RedirectCallFromSinkToTrampolineFunction(llvm::Module &module,
   // new call there.
   llvm::IRBuilder<> builder(&it);
 
+  llvm::Type *lldb_arg_type = trampoline_func_type->getParamType(1);
+  llvm::Type *self_type = trampoline_func_type->getParamType(2);
+
   // Bitcast the operands to the expected types, since they were type-erased
   // in the call to the sink.
-  auto *self_ptr = builder.CreateBitCast(self_opaque_ptr, param1);
-  auto *metadata_ptr = builder.CreateBitCast(metadata_load, param2);
+  auto *self_ptr = builder.CreateBitCast(self_opaque_ptr, lldb_arg_type);
+
+  llvm::SmallVector<llvm::Value *> trampoline_call_params;
+  trampoline_call_params.push_back(lldb_arg_ptr);
+  trampoline_call_params.push_back(self_ptr);
+  for (auto &metadata_load : metadata_loads)
+    trampoline_call_params.push_back(
+        builder.CreateBitCast(metadata_load, self_type));
 
   // Finally, create the call.
   builder.CreateCall(trampoline_func_type, trampoline_func,
-                     {lldb_arg_ptr, self_ptr, metadata_ptr});
+                     trampoline_call_params);
   return true;
 }
 
@@ -1799,11 +1528,11 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   // Parse the expression and import all nececssary swift modules.
   auto parsed_expr = ParseAndImport(
       m_swift_ast_ctx, m_expr, variable_map, buffer_id, diagnostic_manager,
-      *this, m_stack_frame_wp, m_sc, *m_exe_scope, m_options, repl, playground);
+      *this, m_stack_frame_wp, m_sc, *m_exe_scope, m_local_variables, m_options,
+      repl, playground);
 
   if (!parsed_expr) {
     bool retry = false;
-    bool bind_gen_params_error = false;
     handleAllErrors(
         parsed_expr.takeError(),
         [&](const ModuleImportError &MIE) {
@@ -1829,14 +1558,8 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
           diagnostic_manager.PutString(eDiagnosticSeverityError,
                                        SE.getMessage());
         },
-        [&](const BindGenericSelfParamsError &E) {
-          diagnostic_manager.PutString(eDiagnosticSeverityError, E.message());
-          bind_gen_params_error = true;
-        },
         [](const PropagatedError &P) {});
 
-    if (bind_gen_params_error) 
-      return ParseResult::retry_no_bind_generic_params;
     // Signal that we want to retry the expression exactly once with a
     // fresh SwiftASTContext initialized with the flags from the
     // current lldb::Module / Swift dylib to avoid header search

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -13,6 +13,7 @@
 #ifndef liblldb_SwiftExpressionParser_h_
 #define liblldb_SwiftExpressionParser_h_
 
+#include "SwiftASTManipulator.h"
 #include "Plugins/ExpressionParser/Clang/IRForTarget.h"
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/Status.h"
@@ -28,6 +29,7 @@
 namespace lldb_private {
 
 class IRExecutionUnit;
+class SwiftLanguageRuntime;
 
 //----------------------------------------------------------------------
 /// @class SwiftExpressionParser SwiftExpressionParser.h
@@ -61,13 +63,16 @@ public:
   /// @param[in] expr
   ///     The expression to be parsed.
   ///
+  /// @param[in] local_variables
+  ///     The local variables that are in scope.
   /// @param[in] options
   ///     Additional options for the parser.
   //------------------------------------------------------------------
-  SwiftExpressionParser(ExecutionContextScope *exe_scope,
-                        SwiftASTContextForExpressions &swift_ast_ctx,
-                        Expression &expr,
-                        const EvaluateExpressionOptions &options);
+  SwiftExpressionParser(
+      ExecutionContextScope *exe_scope,
+      SwiftASTContextForExpressions &swift_ast_ctx, Expression &expr,
+      llvm::SmallVector<SwiftASTManipulator::VariableInfo> &&local_variables,
+      const EvaluateExpressionOptions &options);
 
   //------------------------------------------------------------------
   /// Attempts to find possible command line completions for the given
@@ -139,6 +144,13 @@ public:
 
   bool RewriteExpression(DiagnosticManager &diagnostic_manager) override;
 
+  static CompilerType ResolveVariable(
+      lldb::VariableSP variable_sp, lldb::StackFrameSP &stack_frame_sp,
+      SwiftLanguageRuntime *runtime, lldb::DynamicValueType use_dynamic,
+      lldb::BindGenericTypes bind_generic_types);
+
+
+  static lldb::VariableSP FindSelfVariable(Block *block);
   //------------------------------------------------------------------
   /// Information about each variable provided to the expression, so
   /// that we can generate proper accesses in the SIL.
@@ -180,6 +192,8 @@ private:
   /// The stack frame to use (if possible) when determining dynamic
   /// types.
   lldb::StackFrameWP m_stack_frame_wp;
+
+  llvm::SmallVector<SwiftASTManipulator::VariableInfo> m_local_variables;
   /// If true, we are running in REPL mode
   EvaluateExpressionOptions m_options;
 };

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -26,12 +26,95 @@ static const char *GetUserCodeStartMarker() {
 }
 static const char *GetUserCodeEndMarker() { return "\n/*__LLDB_USER_END__*/"; }
 
-static void WrapExpression(lldb_private::Stream &wrapped_stream,
-                           const char *orig_text, bool needs_object_ptr,
-                           bool static_method, bool is_class, bool weak_self,
-                           const EvaluateExpressionOptions &options,
-                           llvm::StringRef os_version,
-                           uint32_t &first_body_line) {
+
+struct CallsAndArgs {
+  std::string lldb_user_expr;
+  std::string lldb_trampoline;
+  std::string lldb_sink;
+  std::string lldb_call;
+};
+
+/// Constructs the signatures for the expression evaluation functions based on
+/// the metadata variables in scope.
+/// For every outermost metadata pointer in scope ($τ_0_0, $τ_0_1, etc), we want
+/// to generate:
+///
+/// - A $__lldb_user_expr signature that takes in that many metadata pointers:
+///
+/// func $__lldb_user_expr<T0, T1, ..., Tn>
+///     (_ $__lldb_arg: UnsafeMutablePointer<(T0, T1, ..., Tn)>)
+///
+/// - A $__lldb_trampoline signature like the above, but that also takes in a
+/// pointer to self:
+///
+/// func $__lldb_trampoline<T0, T1, ..., Tn>
+///      (_ $__lldb_arg: UnsafeMutablePointer<(T0, T1, ..., Tn)>,
+///       _ $__lldb_injected_self: inout $__lldb_context)
+///
+/// - A $__lldb_sink signature that matches the number of parameters of the
+/// trampoline:
+///
+/// func $__lldb_sink(_ $__lldb_arg : UnsafeMutablePointer<Any>,
+///                   _: $__lldb_builtin_ptr_t, // the self variable
+///                   _: $__lldb_builtin_ptr_t, // T0
+///                   _: $__lldb_builtin_ptr_t, // T1
+///                   ...,
+///                   _: $__lldb_builtin_ptr_t) // Tn
+///
+/// - And a matching call to the sink function:
+///
+/// lldb_sink($__lldb_arg, $__lldb_injected_self, $τ_0_0, $τ_0_1, ..., $τ_0_n)
+static CallsAndArgs MakeGenericSignaturesAndCalls(
+    llvm::ArrayRef<SwiftASTManipulator::VariableInfo> local_variables) {
+  llvm::SmallVector<SwiftASTManipulator::VariableInfo> metadata_variables;
+  for (auto &var : local_variables)
+    if (var.IsOutermostMetadataPointer())
+      metadata_variables.push_back(var);
+
+  StreamString generic_param_list_stream;
+  for (size_t i = 0; i < metadata_variables.size(); ++i)
+    generic_param_list_stream << "T" << std::to_string(i) << ", ";
+
+  auto generic_param_list = generic_param_list_stream.GetString();
+  if (generic_param_list_stream.GetSize() > 0)
+    generic_param_list = generic_param_list.drop_back(2);
+
+  StreamString user_expr_stream;
+  user_expr_stream << "func $__lldb_user_expr<" << generic_param_list
+                   << ">(_ $__lldb_arg: UnsafeMutablePointer<("
+                   << generic_param_list << ")>)";
+
+  std::string lldb_user_expr = user_expr_stream.GetString().str();
+
+  StreamString trampoline_stream;
+  trampoline_stream << "func $__lldb_trampoline<" << generic_param_list
+                    << ">(_ $__lldb_arg: UnsafeMutablePointer<("
+                    << generic_param_list
+                    << ")>, _ $__lldb_injected_self: inout $__lldb_context)";
+
+  StreamString sink_stream;
+  StreamString call_stream;
+  sink_stream << "func $__lldb_sink(_ $__lldb_arg : "
+                 "UnsafeMutablePointer<Any>, _: $__lldb_builtin_ptr_t";
+  call_stream << "$__lldb_sink($__lldb_arg, $__lldb_injected_self";
+  for (auto &var : metadata_variables) {
+    sink_stream << ", _: $__lldb_builtin_ptr_t";
+    call_stream << ", " << var.GetName().str();
+  }
+  sink_stream << ")";
+  call_stream << ")";
+
+  return {user_expr_stream.GetString().str(),
+          trampoline_stream.GetString().str(), sink_stream.GetString().str(),
+          call_stream.GetString().str()};
+}
+
+void WrapExpression(
+    lldb_private::Stream &wrapped_stream, const char *orig_text,
+    bool needs_object_ptr, bool static_method, bool is_class, bool weak_self,
+    const EvaluateExpressionOptions &options, llvm::StringRef os_version,
+    uint32_t &first_body_line,
+    llvm::ArrayRef<SwiftASTManipulator::VariableInfo> local_variables) {
   first_body_line = 0; // set to invalid
   // TODO make the extension private so we're not polluting the class
   static unsigned int counter = 0;
@@ -142,7 +225,8 @@ do {
 }
 )",
                            GetUserCodeStartMarker(), text,
-                           GetUserCodeEndMarker(), SwiftASTManipulator::GetErrorName());
+                           GetUserCodeEndMarker(),
+                           SwiftASTManipulator::GetErrorName());
 
   if (needs_object_ptr || static_method) {
     const char *func_decorator = "";
@@ -201,20 +285,20 @@ do {
       // FIXME: the current approach names the generic parameter "T", use the
       // user's name for the generic parameter, so they can refer to it in
       // their expression.
+      auto c = MakeGenericSignaturesAndCalls(local_variables);
       wrapped_stream.Printf(
           R"(
 extension %s$__lldb_context {
   @LLDBDebuggerFunction %s
-  %s func $__lldb_user_expr_%u<T>(_ $__lldb_arg: UnsafeMutablePointer<(T)>) {
+  %s %s {
     %s
   }
 }
 
 @LLDBDebuggerFunction %s
-func $__lldb_trampoline<T>(_ $__lldb_arg: UnsafeMutablePointer<(T)>,
-                             _ $__lldb_injected_self: inout $__lldb_context) {
+%s {
   do {
-    $__lldb_injected_self.$__lldb_user_expr_%u(
+    $__lldb_injected_self.$__lldb_user_expr(
       $__lldb_arg
     )
   }
@@ -222,20 +306,20 @@ func $__lldb_trampoline<T>(_ $__lldb_arg: UnsafeMutablePointer<(T)>,
 
 
 @LLDBDebuggerFunction %s
-func $__lldb_sink(_ $__lldb_arg : UnsafeMutablePointer<Any>,
-                       _: $__lldb_builtin_ptr_t,
-                       _: $__lldb_builtin_ptr_t) {
+%s {
 }
 
 
 @LLDBDebuggerFunction %s
 func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {
-  $__lldb_sink($__lldb_arg, $__lldb_injected_self, $τ_0_0)
+%s
 }
 )",
           optional_extension, availability.c_str(), func_decorator,
-          current_counter, wrapped_expr_text.GetData(), availability.c_str(),
-          current_counter, availability.c_str(), availability.c_str());
+          c.lldb_user_expr.c_str(), wrapped_expr_text.GetData(),
+          availability.c_str(), c.lldb_trampoline.c_str(),
+          availability.c_str(), c.lldb_sink.c_str(), availability.c_str(),
+          c.lldb_call.c_str());
 
     } else {
       wrapped_stream.Printf(R"(
@@ -270,6 +354,7 @@ func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {
     first_body_line = 4;
   }
 }
+
 /// Format the OS name the way that Swift availability attributes do.
 static llvm::StringRef getAvailabilityName(const llvm::Triple &triple) {
     swift::LangOptions lang_options;
@@ -285,16 +370,11 @@ uint32_t SwiftExpressionSourceCode::GetNumBodyLines() {
 }
 
 bool SwiftExpressionSourceCode::GetText(
-               std::string &text, 
-               lldb::LanguageType wrapping_language,
-               bool needs_object_ptr,
-               bool static_method,
-               bool is_class,
-               bool weak_self,
-               const EvaluateExpressionOptions &options,
-               ExecutionContext &exe_ctx,
-               uint32_t &first_body_line) const
-  {
+    std::string &text, lldb::LanguageType wrapping_language,
+    bool needs_object_ptr, bool static_method, bool is_class, bool weak_self,
+    const EvaluateExpressionOptions &options, ExecutionContext &exe_ctx,
+    uint32_t &first_body_line,
+    llvm::ArrayRef<SwiftASTManipulator::VariableInfo> local_variables) const {
   Target *target = exe_ctx.GetTargetPtr();
 
 
@@ -364,7 +444,7 @@ bool SwiftExpressionSourceCode::GetText(
     std::string full_body = m_prefix + m_body;
     WrapExpression(wrap_stream, full_body.c_str(), needs_object_ptr,
                    static_method, is_class, weak_self, localOptions,
-                   os_vers.str(), first_body_line);
+                   os_vers.str(), first_body_line, local_variables);
 
     text = wrap_stream.GetString().str();
   } else {

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.h
@@ -9,6 +9,7 @@
 #ifndef liblldb_SwiftExpressionSourceCode_h
 #define liblldb_SwiftExpressionSourceCode_h
 
+#include "SwiftASTManipulator.h"
 #include "lldb/Expression/Expression.h"
 #include "lldb/Expression/ExpressionSourceCode.h"
 #include "lldb/lldb-enumerations.h"
@@ -36,15 +37,12 @@ public:
 
   uint32_t GetNumBodyLines();
 
-  bool GetText(std::string &text, 
-               lldb::LanguageType wrapping_language,
-               bool needs_object_ptr,
-               bool static_method,
-               bool is_class,
-               bool weak_self,
-               const EvaluateExpressionOptions &options,
-               ExecutionContext &exe_ctx,
-               uint32_t &first_body_line) const;
+  bool GetText(
+      std::string &text, lldb::LanguageType wrapping_language,
+      bool needs_object_ptr, bool static_method, bool is_class, bool weak_self,
+      const EvaluateExpressionOptions &options, ExecutionContext &exe_ctx,
+      uint32_t &first_body_line,
+      llvm::ArrayRef<SwiftASTManipulator::VariableInfo> local_variables) const;
 
 private:
   SwiftExpressionSourceCode(const char *name, const char *prefix, const char *body,

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -10,6 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/GenericEnvironment.h"
+#include "swift/Demangling/Demangler.h"
 #include <stdio.h>
 #if HAVE_SYS_TYPES_H
 #include <sys/types.h>
@@ -262,12 +265,273 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
             info.type.GetTypeName().AsCString());
 }
 
+/// Create a \c VariableInfo record for \c variable if there isn't
+/// already shadowing inner declaration in \c processed_variables.
+static bool AddVariableInfo(
+    lldb::VariableSP variable_sp, lldb::StackFrameSP &stack_frame_sp,
+    SwiftASTContextForExpressions &ast_context, SwiftLanguageRuntime *runtime,
+    llvm::SmallDenseSet<const char *, 8> &processed_variables,
+    llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables,
+    lldb::DynamicValueType use_dynamic,
+    lldb::BindGenericTypes bind_generic_types) {
+  LLDB_SCOPED_TIMER();
+
+  StringRef name = variable_sp->GetUnqualifiedName().GetStringRef();
+  const char *name_cstr = name.data();
+  assert(StringRef(name_cstr) == name && "missing null terminator");
+  if (name.empty())
+    return true;
+
+  // To support "guard let self = self" the function argument "self"
+  // is processed (as the special self argument) even if it is
+  // shadowed by a local variable.
+  bool is_self = SwiftLanguageRuntime::IsSelf(*variable_sp);
+  const char *overridden_name = name_cstr;
+  if (is_self)
+    overridden_name = "$__lldb_injected_self";
+
+  if (processed_variables.count(overridden_name))
+    return true;
+
+  if (!stack_frame_sp)
+    return true;
+
+  CompilerType target_type;
+
+  // If we're not binding the generic types, we need to set the self type as an
+  // opaque pointer type. This is necessary because we don't bind the generic
+  // parameters, and we can't have a type with unbound generics in a non-generic
+  // function.
+  if (is_self && bind_generic_types == lldb::eDontBind) {
+    target_type = ast_context.GetBuiltinRawPointerType();
+  } else {
+    CompilerType var_type = SwiftExpressionParser::ResolveVariable(
+        variable_sp, stack_frame_sp, runtime, use_dynamic, bind_generic_types);
+
+    Status error;
+    target_type = ast_context.ImportType(var_type, error);
+  }
+
+  // If the import failed, give up.
+  if (!target_type.IsValid())
+    return true;
+
+  // If we couldn't fully realize the type, then we aren't going
+  // to get very far making a local out of it, so discard it here.
+  Log *log = GetLog(LLDBLog::Types | LLDBLog::Expressions);
+  if (!SwiftASTContext::IsFullyRealized(target_type)) {
+    if (log)
+      log->Printf("Discarding local %s because we couldn't fully realize it, "
+                  "our best attempt was: %s.",
+                  name_cstr, target_type.GetDisplayTypeName().AsCString("<unknown>"));
+    // Not realizing self is a fatal error for an expression and the
+    // Swift compiler error alone is not particularly useful.
+    if (is_self)
+      return false;
+    return true;
+  }
+
+  if (log && is_self)
+    if (swift::Type swift_type = GetSwiftType(target_type)) {
+      std::string s;
+      llvm::raw_string_ostream ss(s);
+      swift_type->dump(ss);
+      ss.flush();
+      log->Printf("Adding injected self: type (%p) context(%p) is: %s",
+                  static_cast<void *>(swift_type.getPointer()),
+                  static_cast<void *>(ast_context.GetASTContext()), s.c_str());
+    }
+  // A one-off clone of variable_sp with the type replaced by target_type.
+  auto patched_variable_sp = std::make_shared<lldb_private::Variable>(
+      0, variable_sp->GetName().GetCString(), "",
+      std::make_shared<lldb_private::SymbolFileType>(
+          *variable_sp->GetType()->GetSymbolFile(),
+          std::make_shared<lldb_private::Type>(
+              0, variable_sp->GetType()->GetSymbolFile(),
+              variable_sp->GetType()->GetName(), llvm::None,
+              variable_sp->GetType()->GetSymbolContextScope(), LLDB_INVALID_UID,
+              Type::eEncodingIsUID, variable_sp->GetType()->GetDeclaration(),
+              target_type, lldb_private::Type::ResolveState::Full,
+              variable_sp->GetType()->GetPayload())),
+      variable_sp->GetScope(), variable_sp->GetSymbolContextScope(),
+      variable_sp->GetScopeRange(),
+      const_cast<lldb_private::Declaration *>(&variable_sp->GetDeclaration()),
+      variable_sp->LocationExpression(), variable_sp->IsExternal(),
+      variable_sp->IsArtificial(),
+      variable_sp->GetLocationIsConstantValueData(),
+      variable_sp->IsStaticMember(), variable_sp->IsConstant());
+  SwiftASTManipulatorBase::VariableMetadataSP metadata_sp(
+      new SwiftASTManipulatorBase::VariableMetadataVariable(patched_variable_sp));
+  SwiftASTManipulator::VariableInfo variable_info(
+      target_type, ast_context.GetASTContext()->getIdentifier(overridden_name),
+      metadata_sp,
+      variable_sp->IsConstant() ? swift::VarDecl::Introducer::Let
+                                : swift::VarDecl::Introducer::Var);
+
+  local_variables.push_back(variable_info);
+  processed_variables.insert(overridden_name);
+  return true;
+}
+
+
+
+/// Create a \c VariableInfo record for each visible variable.
+static bool RegisterAllVariables(
+    SymbolContext &sc, lldb::StackFrameSP &stack_frame_sp,
+    SwiftASTContextForExpressions &ast_context,
+    llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables,
+    lldb::DynamicValueType use_dynamic, lldb::BindGenericTypes bind_generic_types) {
+  LLDB_SCOPED_TIMER();
+  if (!sc.block && !sc.function)
+    return true;
+
+  Block *block = sc.block;
+  Block *top_block = block->GetContainingInlinedBlock();
+
+  if (!top_block)
+    top_block = &sc.function->GetBlock(true);
+
+  SwiftLanguageRuntime *language_runtime = nullptr;
+
+  if (stack_frame_sp)
+    language_runtime =
+        SwiftLanguageRuntime::Get(stack_frame_sp->GetThread()->GetProcess());
+
+  // The module scoped variables are stored at the CompUnit level, so
+  // after we go through the current context, then we have to take one
+  // more pass through the variables in the CompUnit.
+  VariableList variables;
+
+  // Proceed from the innermost scope outwards, adding all variables
+  // not already shadowed by an inner declaration.
+  llvm::SmallDenseSet<const char *, 8> processed_names;
+  bool done = false;
+  do {
+    // Iterate over all parent contexts *including* the top_block.
+    if (block == top_block)
+      done = true;
+    bool can_create = true;
+    bool get_parent_variables = false;
+    bool stop_if_block_is_inlined_function = true;
+
+    block->AppendVariables(
+        can_create, get_parent_variables, stop_if_block_is_inlined_function,
+        [](Variable *) { return true; }, &variables);
+
+    if (!done)
+      block = block->GetParent();
+  } while (block && !done);
+
+  // Also add local copies of globals. This is in many cases redundant
+  // work because the globals would also be found in the expression
+  // context's Swift module, but it allows a limited form of
+  // expression evaluation to work even if the Swift module failed to
+  // load, as long as the module isn't necessary to resolve the type
+  // or aother symbols in the expression.
+  if (sc.comp_unit) {
+    lldb::VariableListSP globals_sp = sc.comp_unit->GetVariableList(true);
+    if (globals_sp)
+      variables.AddVariables(globals_sp.get());
+  }
+
+  for (size_t vi = 0, ve = variables.GetSize(); vi != ve; ++vi)
+    if (!AddVariableInfo(
+            {variables.GetVariableAtIndex(vi)}, stack_frame_sp, ast_context,
+            language_runtime, processed_names, local_variables, use_dynamic,
+            bind_generic_types))
+      return false;
+  return true;
+}
+
 static SwiftPersistentExpressionState *
 GetPersistentState(Target *target, ExecutionContext &exe_ctx) {
   auto exe_scope = exe_ctx.GetBestExecutionContextScope();
   if (!exe_scope)
     return nullptr;
   return target->GetSwiftPersistentExpressionState(*exe_scope);
+}
+
+/// Check if we can evaluate the expression as generic.
+/// Currently, evaluating expression as a generic has several limitations:
+/// - Only self will be evaluated with unbound generics.
+/// - The Self type can only have one generic parameter. 
+/// - The Self type has to be the outermost type with unbound generics.
+static bool CanEvaluateExpressionWithoutBindingGenericParams(
+    llvm::ArrayRef<SwiftASTManipulator::VariableInfo> variables, Block *block,
+    StackFrame &stack_frame) {
+  // First, find the compiler type of self with the generic parameters not
+  // bound.
+  auto self_var = SwiftExpressionParser::FindSelfVariable(block);
+  if (!self_var)
+    return false;
+
+  lldb::ValueObjectSP self_valobj =
+      stack_frame.GetValueObjectForFrameVariable(self_var,
+                                                     lldb::eNoDynamicValues);
+  if (!self_valobj)
+    return false;
+
+  auto self_type = self_valobj->GetCompilerType();
+  if (!self_type)
+    return false;
+
+  auto *ts = self_type.GetTypeSystem()
+                 .dyn_cast_or_null<TypeSystemSwift>()
+                 ->GetSwiftASTContext();
+
+  if (!ts)
+    return false;
+
+  auto swift_type = ts->GetSwiftType(self_type);
+  if (!swift_type)
+    return false;
+
+  auto *decl = swift_type->getAnyGeneric();
+  if (!decl)
+    return false;
+
+
+  auto *env = decl->getGenericEnvironment();
+  if (!env)
+    return false;
+  auto params = env->getGenericParams();
+
+  // If there aren't any generic parameters we can't evaluate the expression as
+  // generic.
+  if (params.empty())
+    return false;
+
+  auto *first_param = params[0];
+  // Currently we only support evaluating self as generic if the generic
+  // parameter is the first one.
+  if (first_param->getDepth() != 0 || first_param->getIndex() != 0)
+    return false;
+
+  llvm::SmallVector<SwiftASTManipulator::VariableInfo>
+      outermost_metadata_vars;
+  for (auto &variable : variables)
+    if (variable.IsOutermostMetadataPointer())
+      outermost_metadata_vars.push_back(variable);
+
+  // Check that all metadata belong to the outermost type, and check that we do
+  // have the metadata pointer available.
+  for (auto *pair : params) {
+    if (pair->getDepth() != 0)
+      return false;
+
+    auto var_name = "$τ_0_" + std::to_string(pair->getIndex());
+    auto found = false;
+    for (auto &metadata_var : outermost_metadata_vars) {
+      if (metadata_var.GetName().str() == var_name) {
+        found = true;
+        break;
+      }
+    }
+    if (!found)
+      return false;
+  }
+
+  return true;
 }
 
 SwiftExpressionParser::ParseResult
@@ -279,14 +543,44 @@ SwiftUserExpression::GetTextAndSetExpressionParser(
   Log *log = GetLog(LLDBLog::Expressions);
   uint32_t first_body_line = 0;
 
+  lldb::TargetSP target_sp;
+  SymbolContext sc;
+  lldb::StackFrameSP stack_frame;
+  if (exe_scope) {
+    target_sp = exe_scope->CalculateTarget();
+    stack_frame = exe_scope->CalculateStackFrame();
+
+    if (stack_frame) {
+      sc = stack_frame->GetSymbolContext(lldb::eSymbolContextEverything);
+    }
+  }
+  llvm::SmallVector<SwiftASTManipulator::VariableInfo> local_variables;
+
+  if (!RegisterAllVariables(sc, stack_frame, *m_swift_ast_ctx, local_variables,
+                            m_options.GetUseDynamic(),
+                            m_options.GetBindGenericTypes())) {
+    diagnostic_manager.PutString(
+        eDiagnosticSeverityError,
+        "Couldn't realize Swift AST type of self. Hint: using `v` to "
+        "directly inspect variables and fields may still work.");
+    return ParseResult::retry_no_bind_generic_params;
+  }
+
+  if (m_options.GetBindGenericTypes() == lldb::eDontBind &&
+      !CanEvaluateExpressionWithoutBindingGenericParams(
+          local_variables, sc.block, *stack_frame.get())) {
+    diagnostic_manager.PutString(
+        eDiagnosticSeverityError,
+        "Could not evaluate the expression without binding generic types.");
+    return ParseResult::unrecoverable_error;
+  }
+
   if (!source_code->GetText(m_transformed_text, m_options.GetLanguage(),
-                            m_needs_object_ptr,
-                            m_in_static_method,
-                            m_is_class,
-                            m_is_weak_self,  m_options, exe_ctx,
-                            first_body_line)) {
+                            m_needs_object_ptr, m_in_static_method, m_is_class,
+                            m_is_weak_self, m_options, exe_ctx, first_body_line,
+                            local_variables)) {
     diagnostic_manager.PutString(eDiagnosticSeverityError,
-                                  "couldn't construct expression body");
+                                 "couldn't construct expression body");
     return ParseResult::unrecoverable_error;
   }
 
@@ -303,7 +597,8 @@ SwiftUserExpression::GetTextAndSetExpressionParser(
     m_materializer_up.reset(new Materializer());
 
   auto *swift_parser =
-      new SwiftExpressionParser(exe_scope, *m_swift_ast_ctx, *this, m_options);
+      new SwiftExpressionParser(exe_scope, *m_swift_ast_ctx, *this,
+                                std::move(local_variables), m_options);
   SwiftExpressionParser::ParseResult parse_result =
       swift_parser->Parse(diagnostic_manager, first_body_line,
                           first_body_line + source_code->GetNumBodyLines());

--- a/lldb/test/API/lang/swift/private_generic_type/Private.swift
+++ b/lldb/test/API/lang/swift/private_generic_type/Private.swift
@@ -1,11 +1,11 @@
 import Public
 
 private struct InvisibleStruct {
-  public var name = "The invisible man."
+  public var name = "The invisible struct."
 }
 
 private class InvisibleClass {
-  public var name = "The invisible class"
+  public var name = "The invisible class."
   public var someNumber = 42
 }
 
@@ -17,9 +17,21 @@ public func privateDoIt()  {
   let classWrapper = ClassWrapper(InvisibleStruct())
   classWrapper.foo()
 
+  let twoGenericParameters = TwoGenericParameters(InvisibleClass(), InvisibleStruct())
+  twoGenericParameters.foo()
+
+  let threeGenericParameters = ThreeGenericParameters(InvisibleClass(), InvisibleStruct(), true)
+  threeGenericParameters.foo()
+  
+  let fourGenericParameters = FourGenericParameters(InvisibleStruct(), 
+                                                      InvisibleClass(), 
+                                                      ["One", "two", "three"], 
+                                                      482)
+  fourGenericParameters.foo()
+
   let nonGeneric = NonGeneric()
   nonGeneric.foo()
 
-  let twoGenericParameters = TwoGenericParameters(InvisibleStruct(), InvisibleClass())
-  twoGenericParameters.foo()
+  let nestedParameters = Nested.Parameters(InvisibleClass(), InvisibleStruct())
+  nestedParameters.foo()
 }

--- a/lldb/test/API/lang/swift/private_generic_type/Public.swift
+++ b/lldb/test/API/lang/swift/private_generic_type/Public.swift
@@ -41,5 +41,56 @@ public class TwoGenericParameters<T, U> {
 
   public func foo() {
     print(self) // break here for two generic parameters
+ }
+}
+
+public struct ThreeGenericParameters<T, U, V> {
+  let t: T
+  let u: U
+  let v: V
+
+  public init(_ t: T, _ u: U, _ v: V) {
+    self.t = t
+    self.u = u
+    self.v = v
+  }
+
+  public func foo() {
+    print(self) // break here for three generic parameters
   }
 }
+
+public struct FourGenericParameters<T, U, V, W> {
+  let t: T
+  let u: U
+  let v: V
+  let w: W
+
+  public init(_ t: T, _ u: U, _ v: V, _ w: W) {
+    self.t = t
+    self.u = u
+    self.v = v
+    self.w = w
+  }
+
+  public func foo() {
+    print(self) // break here for four generic parameters
+  }
+}
+
+public struct Nested<T> {
+  public struct Parameters<U>  {
+    let t: T
+    let u: U
+
+    public init(_ t: T, _ u: U) {
+      self.t = t
+      self.u = u
+    }
+
+    public func foo() {
+      print(self) // break here for nested generic parameters
+    }
+  }
+}
+

--- a/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
+++ b/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
@@ -31,14 +31,14 @@ class TestSwiftPrivateGenericType(TestBase):
         # Test that not binding works.
         self.expect("e --bind-generic-types false -- self", 
                     substrs=["Public.StructWrapper<T>", 
-                             "The invisible man."])
+                             'name = "The invisible struct."'])
         # Test that the "auto" behavior also works.
         self.expect("e --bind-generic-types auto -- self", 
                     substrs=["Public.StructWrapper<T>", 
-                             "The invisible man."])
+                             'name = "The invisible struct."'])
         # Test that the default (should be the auto option) also works.
         self.expect("e -- self", substrs=["Public.StructWrapper<T>", 
-                                          "The invisible man."])
+                                          'name = "The invisible struct."'])
 
         breakpoint = target.BreakpointCreateBySourceRegex(
             'break here for class', lldb.SBFileSpec('Public.swift'), None)
@@ -48,13 +48,94 @@ class TestSwiftPrivateGenericType(TestBase):
                     error=True)
         self.expect("e --bind-generic-types false -- self", 
                     substrs=["Public.ClassWrapper<Private.InvisibleStruct>", 
-                             "The invisible man."])
+                             'name = "The invisible struct."'])
         self.expect("e --bind-generic-types auto -- self", 
                     substrs=["Public.ClassWrapper<Private.InvisibleStruct>", 
-                             "The invisible man."])
+                             'name = "The invisible struct."'])
         self.expect("e -- self", 
                     substrs=["Public.ClassWrapper<Private.InvisibleStruct>", 
-                             "The invisible man."])
+                             'name = "The invisible struct."'])
+
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here for two generic parameters', lldb.SBFileSpec('Public.swift'), None)
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("e --bind-generic-types true -- self", 
+                    substrs=["Couldn't realize Swift AST type of self."], 
+                    error=True)
+        self.expect("e --bind-generic-types false -- self", 
+                    substrs=["Public.TwoGenericParameters",
+                             "<Private.InvisibleClass, Private.InvisibleStruct>", 
+                             'name = "The invisible class."',
+                             "someNumber = 42"])
+        self.expect("e --bind-generic-types auto -- self", 
+                    substrs=["Public.TwoGenericParameters",
+                             "<Private.InvisibleClass, Private.InvisibleStruct>", 
+                             'name = "The invisible class."',
+                             "someNumber = 42"])
+        self.expect("e -- self", 
+                    substrs=["Public.TwoGenericParameters",
+                             "<Private.InvisibleClass, Private.InvisibleStruct>", 
+                             'name = "The invisible class."',
+                             "someNumber = 42"])
+
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here for three generic parameters', lldb.SBFileSpec('Public.swift'), None)
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("e --bind-generic-types true -- self", 
+                    substrs=["Couldn't realize Swift AST type of self."], 
+                    error=True)
+        self.expect("e --bind-generic-types false -- self", 
+                    substrs=["Public.ThreeGenericParameters",
+                             "<T, U, V>", 
+                             'name = "The invisible class."',
+                             "someNumber = 42",
+                             'name = "The invisible struct."',
+                             "v = true"])
+        self.expect("e --bind-generic-types auto -- self", 
+                    substrs=["Public.ThreeGenericParameters",
+                             "<T, U, V>", 
+                             'name = "The invisible class."',
+                             "someNumber = 42",
+                             'name = "The invisible struct."',
+                             "v = true"])
+        self.expect("e -- self", 
+                    substrs=["Public.ThreeGenericParameters",
+                             "<T, U, V>", 
+                             'name = "The invisible class."',
+                             "someNumber = 42",
+                             'name = "The invisible struct."',
+                             "v = true"])
+
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here for four generic parameters', lldb.SBFileSpec('Public.swift'), None)
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("e --bind-generic-types true -- self", 
+                    substrs=["Couldn't realize Swift AST type of self."], 
+                    error=True)
+        self.expect("e --bind-generic-types false -- self", 
+                    substrs=["Public.FourGenericParameters",
+                             "<T, U, V, W>", 
+                             'name = "The invisible struct."',
+                             'name = "The invisible class."',
+                             "someNumber = 42",
+                             "v = 3 values", "One", "two", "three",
+                             "w = 482"])
+        self.expect("e --bind-generic-types auto -- self", 
+                    substrs=["Public.FourGenericParameters",
+                             "<T, U, V, W>", 
+                             'name = "The invisible struct."',
+                             'name = "The invisible class."',
+                             "someNumber = 42",
+                             "v = 3 values", "One", "two", "three",
+                             "w = 482"])
+        self.expect("e -- self", 
+                    substrs=["Public.FourGenericParameters",
+                             "<T, U, V, W>", 
+                             'name = "The invisible struct."',
+                             'name = "The invisible class."',
+                             "someNumber = 42",
+                             "v = 3 values", "One", "two", "three",
+                             "w = 482"])
 
         breakpoint = target.BreakpointCreateBySourceRegex(
             'break here for non-generic', lldb.SBFileSpec('Public.swift'), None)
@@ -64,7 +145,7 @@ class TestSwiftPrivateGenericType(TestBase):
                     error=True)
 
         breakpoint = target.BreakpointCreateBySourceRegex(
-            'break here for two generic parameters', lldb.SBFileSpec('Public.swift'), None)
+            'break here for nested generic parameters', lldb.SBFileSpec('Public.swift'), None)
         lldbutil.continue_to_breakpoint(process, breakpoint)
         self.expect("e --bind-generic-types false -- self", 
                     substrs=["Could not evaluate the expression without binding generic types."], 


### PR DESCRIPTION
Before this patch, generic expression evaluation would only work for a single toplevel generic parameter. This patch expands its capabilities to allow for multiple generic parameters.