### PR TITLE
Revert "[AArch64] Add support for 128-bit non temporal loads."

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -766,11 +766,6 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
   setOperationAction(ISD::LOAD, MVT::v8f32, Custom);
   setOperationAction(ISD::LOAD, MVT::v4f64, Custom);
   setOperationAction(ISD::LOAD, MVT::v4i64, Custom);
-  // 128-bit non-temporal loads can be lowered to LDNP using custom lowering.
-  setOperationAction(ISD::LOAD, MVT::v4i32, Custom);
-  setOperationAction(ISD::LOAD, MVT::v2i64, Custom);
-  setOperationAction(ISD::LOAD, MVT::v8i16, Custom);
-  setOperationAction(ISD::LOAD, MVT::v16i8, Custom);
 
   // Lower READCYCLECOUNTER using an mrs from PMCCNTR_EL0.
   // This requires the Performance Monitors extension.
@@ -2259,7 +2254,6 @@ const char *AArch64TargetLowering::getTargetNodeName(unsigned Opcode) const {
     MAKE_CASE(AArch64ISD::SSTNT1_INDEX_PRED)
     MAKE_CASE(AArch64ISD::LDP)
     MAKE_CASE(AArch64ISD::LDNP)
-    MAKE_CASE(AArch64ISD::LDNP128)
     MAKE_CASE(AArch64ISD::STP)
     MAKE_CASE(AArch64ISD::STNP)
     MAKE_CASE(AArch64ISD::BITREVERSE_MERGE_PASSTHRU)
@@ -5110,27 +5104,6 @@ SDValue AArch64TargetLowering::LowerLOAD(SDValue Op,
   SDLoc DL(Op);
   LoadSDNode *LoadNode = cast<LoadSDNode>(Op);
   assert(LoadNode && "Expected custom lowering of a load node");
-  // Handle lowering 128-bit non temporal loads for little-endian targets.
-  EVT MemVT = LoadNode->getMemoryVT();
-  if (LoadNode->isNonTemporal() && Subtarget->isLittleEndian() &&
-      MemVT.getSizeInBits() == 128 &&
-      (MemVT.getScalarSizeInBits() == 8u ||
-       MemVT.getScalarSizeInBits() == 16u ||
-       MemVT.getScalarSizeInBits() == 32u ||
-       MemVT.getScalarSizeInBits() == 64u)) {
-
-    SDValue Result = DAG.getMemIntrinsicNode(
-        AArch64ISD::LDNP128, DL,
-        DAG.getVTList({MemVT.getHalfNumVectorElementsVT(*DAG.getContext()),
-                       MemVT.getHalfNumVectorElementsVT(*DAG.getContext()),
-                       MVT::Other}),
-        {LoadNode->getChain(), LoadNode->getBasePtr()}, LoadNode->getMemoryVT(),
-        LoadNode->getMemOperand());
-
-    SDValue P = DAG.getNode(ISD::CONCAT_VECTORS, SDLoc(Op), MemVT,
-                            Result.getValue(0), Result.getValue(1));
-    return DAG.getMergeValues({P, Result.getValue(2) /* Chain */}, DL);
-  }
 
   if (LoadNode->getMemoryVT() == MVT::i64x8) {
     SmallVector<SDValue, 8> Ops;
@@ -5152,9 +5125,9 @@ SDValue AArch64TargetLowering::LowerLOAD(SDValue Op,
 
   // Custom lowering for extending v4i8 vector loads.
   EVT VT = Op->getValueType(0);
+  assert((VT == MVT::v4i16 || VT == MVT::v4i32) && "Expected v4i16 or v4i32");
 
-  if ((VT != MVT::v4i16 && VT != MVT::v4i32) ||
-      LoadNode->getMemoryVT() != MVT::v4i8)
+  if (LoadNode->getMemoryVT() != MVT::v4i8)
     return SDValue();
 
   unsigned ExtType;

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -450,7 +450,6 @@ enum NodeType : unsigned {
 
   LDP,
   LDNP,
-  LDNP128,
   STP,
   STNP,
 

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -319,7 +319,6 @@ def SDT_AArch64uaddlp : SDTypeProfile<1, 1, [SDTCisVec<0>, SDTCisVec<1>]>;
 
 def SDT_AArch64ldp : SDTypeProfile<2, 1, [SDTCisVT<0, i64>, SDTCisSameAs<0, 1>, SDTCisPtrTy<2>]>;
 def SDT_AArch64ldnp : SDTypeProfile<2, 1, [SDTCisVT<0, v4i32>, SDTCisSameAs<0, 1>, SDTCisPtrTy<2>]>;
-def SDT_AArch64ldnp128 : SDTypeProfile<2, 1, [SDTCisVT<0, v2i32>, SDTCisSameAs<0, 1>, SDTCisPtrTy<2>]>;
 def SDT_AArch64stp : SDTypeProfile<0, 3, [SDTCisVT<0, i64>, SDTCisSameAs<0, 1>, SDTCisPtrTy<2>]>;
 def SDT_AArch64stnp : SDTypeProfile<0, 3, [SDTCisVT<0, v4i32>, SDTCisSameAs<0, 1>, SDTCisPtrTy<2>]>;
 
@@ -669,7 +668,6 @@ def AArch64uunpklo : SDNode<"AArch64ISD::UUNPKLO", SDT_AArch64unpk>;
 
 def AArch64ldp : SDNode<"AArch64ISD::LDP", SDT_AArch64ldp, [SDNPHasChain, SDNPMayLoad, SDNPMemOperand]>;
 def AArch64ldnp : SDNode<"AArch64ISD::LDNP", SDT_AArch64ldnp, [SDNPHasChain, SDNPMayLoad, SDNPMemOperand]>;
-def AArch64ldnp128 : SDNode<"AArch64ISD::LDNP128", SDT_AArch64ldnp128, [SDNPHasChain, SDNPMayLoad, SDNPMemOperand]>;
 def AArch64stp : SDNode<"AArch64ISD::STP", SDT_AArch64stp, [SDNPHasChain, SDNPMayStore, SDNPMemOperand]>;
 def AArch64stnp : SDNode<"AArch64ISD::STNP", SDT_AArch64stnp, [SDNPHasChain, SDNPMayStore, SDNPMemOperand]>;
 
@@ -2602,9 +2600,6 @@ def : Pat<(AArch64ldp (am_indexed7s64 GPR64sp:$Rn, simm7s8:$offset)),
 
 def : Pat<(AArch64ldnp (am_indexed7s128 GPR64sp:$Rn, simm7s16:$offset)),
           (LDNPQi GPR64sp:$Rn, simm7s16:$offset)>;
-
-def : Pat<(AArch64ldnp128 (am_indexed7s64 GPR64sp:$Rn, simm7s8:$offset)),
-          (LDNPDi GPR64sp:$Rn, simm7s8:$offset)>;
 //---
 // (register offset)
 //---

--- a/llvm/test/CodeGen/AArch64/nontemporal-load.ll
+++ b/llvm/test/CodeGen/AArch64/nontemporal-load.ll
@@ -103,8 +103,7 @@ define <32 x i8> @test_ldnp_v32i8(<32 x i8>* %A) {
 define <4 x i32> @test_ldnp_v4i32(<4 x i32>* %A) {
 ; CHECK-LABEL: test_ldnp_v4i32:
 ; CHECK:       ; %bb.0:
-; CHECK-NEXT:    ldnp d0, d1, [x0]
-; CHECK-NEXT:    mov.d v0[1], v1[0]
+; CHECK-NEXT:    ldr q0, [x0]
 ; CHECK-NEXT:    ret
 ;
 ; CHECK-BE-LABEL: test_ldnp_v4i32:
@@ -118,8 +117,7 @@ define <4 x i32> @test_ldnp_v4i32(<4 x i32>* %A) {
 define <4 x float> @test_ldnp_v4f32(<4 x float>* %A) {
 ; CHECK-LABEL: test_ldnp_v4f32:
 ; CHECK:       ; %bb.0:
-; CHECK-NEXT:    ldnp d0, d1, [x0]
-; CHECK-NEXT:    mov.d v0[1], v1[0]
+; CHECK-NEXT:    ldr q0, [x0]
 ; CHECK-NEXT:    ret
 ;
 ; CHECK-BE-LABEL: test_ldnp_v4f32:
@@ -133,8 +131,7 @@ define <4 x float> @test_ldnp_v4f32(<4 x float>* %A) {
 define <8 x i16> @test_ldnp_v8i16(<8 x i16>* %A) {
 ; CHECK-LABEL: test_ldnp_v8i16:
 ; CHECK:       ; %bb.0:
-; CHECK-NEXT:    ldnp d0, d1, [x0]
-; CHECK-NEXT:    mov.d v0[1], v1[0]
+; CHECK-NEXT:    ldr q0, [x0]
 ; CHECK-NEXT:    ret
 ;
 ; CHECK-BE-LABEL: test_ldnp_v8i16:
@@ -148,8 +145,7 @@ define <8 x i16> @test_ldnp_v8i16(<8 x i16>* %A) {
 define <16 x i8> @test_ldnp_v16i8(<16 x i8>* %A) {
 ; CHECK-LABEL: test_ldnp_v16i8:
 ; CHECK:       ; %bb.0:
-; CHECK-NEXT:    ldnp d0, d1, [x0]
-; CHECK-NEXT:    mov.d v0[1], v1[0]
+; CHECK-NEXT:    ldr q0, [x0]
 ; CHECK-NEXT:    ret
 ;
 ; CHECK-BE-LABEL: test_ldnp_v16i8:
@@ -162,8 +158,7 @@ define <16 x i8> @test_ldnp_v16i8(<16 x i8>* %A) {
 define <2 x double> @test_ldnp_v2f64(<2 x double>* %A) {
 ; CHECK-LABEL: test_ldnp_v2f64:
 ; CHECK:       ; %bb.0:
-; CHECK-NEXT:    ldnp d0, d1, [x0]
-; CHECK-NEXT:    mov.d v0[1], v1[0]
+; CHECK-NEXT:    ldr q0, [x0]
 ; CHECK-NEXT:    ret
 ;
 ; CHECK-BE-LABEL: test_ldnp_v2f64:

--- a/llvm/test/CodeGen/AArch64/nontemporal-load.ll
+++ b/llvm/test/CodeGen/AArch64/nontemporal-load.ll
@@ -325,12 +325,18 @@ define <16 x float> @test_ldnp_v16f32(<16 x float>* %A) {
 define <17 x float> @test_ldnp_v17f32(<17 x float>* %A) {
 ; CHECK-LABEL: test_ldnp_v17f32:
 ; CHECK:       ; %bb.0:
-; CHECK-NEXT:    ldp q1, q2, [x0, #32]
-; CHECK-NEXT:    ldp q3, q4, [x0]
-; CHECK-NEXT:    ldr s0, [x0, #64]
-; CHECK-NEXT:    stp q3, q4, [x8]
-; CHECK-NEXT:    stp q1, q2, [x8, #32]
-; CHECK-NEXT:    str s0, [x8, #64]
+; CHECK-NEXT:    ldnp d1, d0, [x0, #16]
+; CHECK-NEXT:    ldnp d3, d2, [x0, #48]
+; CHECK-NEXT:    ldnp d6, d5, [x0, #32]
+; CHECK-NEXT:    mov.d v1[1], v0[0]
+; CHECK-NEXT:    ldnp d16, d7, [x0]
+; CHECK-NEXT:    mov.d v3[1], v2[0]
+; CHECK-NEXT:    ldr s4, [x0, #64]
+; CHECK-NEXT:    mov.d v6[1], v5[0]
+; CHECK-NEXT:    mov.d v16[1], v7[0]
+; CHECK-NEXT:    str s4, [x8, #64]
+; CHECK-NEXT:    stp q6, q3, [x8, #32]
+; CHECK-NEXT:    stp q16, q1, [x8]
 ; CHECK-NEXT:    ret
 ;
 ; CHECK-BE-LABEL: test_ldnp_v17f32:
@@ -359,24 +365,61 @@ define <17 x float> @test_ldnp_v17f32(<17 x float>* %A) {
 define <33 x double> @test_ldnp_v33f64(<33 x double>* %A) {
 ; CHECK-LABEL: test_ldnp_v33f64:
 ; CHECK:       ; %bb.0:
-; CHECK-NEXT:    ldp q0, q1, [x0]
-; CHECK-NEXT:    ldp q2, q3, [x0, #32]
-; CHECK-NEXT:    ldp q4, q5, [x0, #64]
-; CHECK-NEXT:    ldp q6, q7, [x0, #96]
-; CHECK-NEXT:    ldp q16, q17, [x0, #128]
-; CHECK-NEXT:    ldp q18, q19, [x0, #160]
-; CHECK-NEXT:    ldp q21, q22, [x0, #224]
-; CHECK-NEXT:    ldp q23, q24, [x0, #192]
-; CHECK-NEXT:    ldr d20, [x0, #256]
-; CHECK-NEXT:    stp q0, q1, [x8]
-; CHECK-NEXT:    stp q2, q3, [x8, #32]
-; CHECK-NEXT:    stp q4, q5, [x8, #64]
-; CHECK-NEXT:    str d20, [x8, #256]
-; CHECK-NEXT:    stp q6, q7, [x8, #96]
-; CHECK-NEXT:    stp q16, q17, [x8, #128]
-; CHECK-NEXT:    stp q18, q19, [x8, #160]
-; CHECK-NEXT:    stp q23, q24, [x8, #192]
-; CHECK-NEXT:    stp q21, q22, [x8, #224]
+; CHECK-NEXT:    stp d13, d12, [sp, #-48]! ; 16-byte Folded Spill
+; CHECK-NEXT:    .cfi_def_cfa_offset 48
+; CHECK-NEXT:    stp d11, d10, [sp, #16] ; 16-byte Folded Spill
+; CHECK-NEXT:    stp d9, d8, [sp, #32] ; 16-byte Folded Spill
+; CHECK-NEXT:    .cfi_offset b8, -8
+; CHECK-NEXT:    .cfi_offset b9, -16
+; CHECK-NEXT:    .cfi_offset b10, -24
+; CHECK-NEXT:    .cfi_offset b11, -32
+; CHECK-NEXT:    .cfi_offset b12, -40
+; CHECK-NEXT:    .cfi_offset b13, -48
+; CHECK-NEXT:    ldnp d31, d30, [x0, #240]
+; CHECK-NEXT:    ldnp d9, d8, [x0, #224]
+; CHECK-NEXT:    ldnp d0, d1, [x0]
+; CHECK-NEXT:    mov.d v31[1], v30[0]
+; CHECK-NEXT:    ldnp d2, d3, [x0, #16]
+; CHECK-NEXT:    mov.d v9[1], v8[0]
+; CHECK-NEXT:    ldnp d4, d5, [x0, #32]
+; CHECK-NEXT:    mov.d v0[1], v1[0]
+; CHECK-NEXT:    ldnp d6, d7, [x0, #48]
+; CHECK-NEXT:    mov.d v2[1], v3[0]
+; CHECK-NEXT:    ldnp d16, d17, [x0, #64]
+; CHECK-NEXT:    mov.d v4[1], v5[0]
+; CHECK-NEXT:    ldnp d18, d19, [x0, #80]
+; CHECK-NEXT:    mov.d v6[1], v7[0]
+; CHECK-NEXT:    ldnp d21, d20, [x0, #96]
+; CHECK-NEXT:    mov.d v16[1], v17[0]
+; CHECK-NEXT:    ldnp d23, d22, [x0, #112]
+; CHECK-NEXT:    mov.d v18[1], v19[0]
+; CHECK-NEXT:    ldnp d25, d24, [x0, #144]
+; CHECK-NEXT:    mov.d v21[1], v20[0]
+; CHECK-NEXT:    ldnp d27, d26, [x0, #176]
+; CHECK-NEXT:    mov.d v23[1], v22[0]
+; CHECK-NEXT:    ldnp d29, d28, [x0, #208]
+; CHECK-NEXT:    mov.d v25[1], v24[0]
+; CHECK-NEXT:    ldnp d11, d10, [x0, #192]
+; CHECK-NEXT:    mov.d v27[1], v26[0]
+; CHECK-NEXT:    ldnp d12, d30, [x0, #160]
+; CHECK-NEXT:    mov.d v29[1], v28[0]
+; CHECK-NEXT:    ldnp d13, d8, [x0, #128]
+; CHECK-NEXT:    mov.d v11[1], v10[0]
+; CHECK-NEXT:    ldr d28, [x0, #256]
+; CHECK-NEXT:    stp q9, q31, [x8, #224]
+; CHECK-NEXT:    mov.d v12[1], v30[0]
+; CHECK-NEXT:    stp q21, q23, [x8, #96]
+; CHECK-NEXT:    stp q16, q18, [x8, #64]
+; CHECK-NEXT:    mov.d v13[1], v8[0]
+; CHECK-NEXT:    str d28, [x8, #256]
+; CHECK-NEXT:    stp q11, q29, [x8, #192]
+; CHECK-NEXT:    stp q12, q27, [x8, #160]
+; CHECK-NEXT:    stp q4, q6, [x8, #32]
+; CHECK-NEXT:    stp q13, q25, [x8, #128]
+; CHECK-NEXT:    stp q0, q2, [x8]
+; CHECK-NEXT:    ldp d9, d8, [sp, #32] ; 16-byte Folded Reload
+; CHECK-NEXT:    ldp d11, d10, [sp, #16] ; 16-byte Folded Reload
+; CHECK-NEXT:    ldp d13, d12, [sp], #48 ; 16-byte Folded Reload
 ; CHECK-NEXT:    ret
 ;
 ; CHECK-BE-LABEL: test_ldnp_v33f64:
@@ -453,10 +496,13 @@ define <33 x double> @test_ldnp_v33f64(<33 x double>* %A) {
 define <33 x i8> @test_ldnp_v33i8(<33 x i8>* %A) {
 ; CHECK-LABEL: test_ldnp_v33i8:
 ; CHECK:       ; %bb.0:
-; CHECK-NEXT:    ldp q1, q0, [x0]
+; CHECK-NEXT:    ldnp d1, d0, [x0, #16]
+; CHECK-NEXT:    ldnp d3, d2, [x0]
 ; CHECK-NEXT:    ldrb w9, [x0, #32]
-; CHECK-NEXT:    stp q1, q0, [x8]
+; CHECK-NEXT:    mov.d v1[1], v0[0]
+; CHECK-NEXT:    mov.d v3[1], v2[0]
 ; CHECK-NEXT:    strb w9, [x8, #32]
+; CHECK-NEXT:    stp q3, q1, [x8]
 ; CHECK-NEXT:    ret
 ;
 ; CHECK-BE-LABEL: test_ldnp_v33i8:
@@ -497,24 +543,22 @@ define <4 x i65> @test_ldnp_v4i65(<4 x i65>* %A) {
 ; CHECK-BE-NEXT:    ldp x9, x8, [x0, #16]
 ; CHECK-BE-NEXT:    ldp x11, x10, [x0]
 ; CHECK-BE-NEXT:    ldrb w7, [x0, #32]
-; CHECK-BE-NEXT:    lsr x13, x9, #56
-; CHECK-BE-NEXT:    lsr x14, x11, #56
-; CHECK-BE-NEXT:    extr x15, x10, x9, #56
-; CHECK-BE-NEXT:    bfi x7, x8, #8, #56
-; CHECK-BE-NEXT:    extr x8, x9, x8, #56
+; CHECK-BE-NEXT:    extr x13, x9, x8, #56
+; CHECK-BE-NEXT:    extr x9, x10, x9, #56
 ; CHECK-BE-NEXT:    extr x12, x11, x10, #56
-; CHECK-BE-NEXT:    lsr x11, x11, #59
-; CHECK-BE-NEXT:    ubfx x9, x9, #57, #1
-; CHECK-BE-NEXT:    extr x5, x13, x8, #1
-; CHECK-BE-NEXT:    extr x1, x14, x12, #3
-; CHECK-BE-NEXT:    ubfx x12, x10, #58, #1
-; CHECK-BE-NEXT:    fmov d0, x11
-; CHECK-BE-NEXT:    and x11, x8, #0x1
-; CHECK-BE-NEXT:    lsr x10, x10, #56
-; CHECK-BE-NEXT:    fmov d2, x9
-; CHECK-BE-NEXT:    fmov d1, x12
-; CHECK-BE-NEXT:    extr x3, x10, x15, #2
-; CHECK-BE-NEXT:    fmov d3, x11
+; CHECK-BE-NEXT:    bfi x7, x8, #8, #56
+; CHECK-BE-NEXT:    lsr x8, x11, #59
+; CHECK-BE-NEXT:    lsr x10, x11, #56
+; CHECK-BE-NEXT:    and x14, x13, #0x1
+; CHECK-BE-NEXT:    ubfx x15, x9, #1, #1
+; CHECK-BE-NEXT:    ubfx x11, x12, #2, #1
+; CHECK-BE-NEXT:    extr x1, x10, x12, #3
+; CHECK-BE-NEXT:    fmov d0, x8
+; CHECK-BE-NEXT:    extr x3, x12, x9, #2
+; CHECK-BE-NEXT:    extr x5, x9, x13, #1
+; CHECK-BE-NEXT:    fmov d2, x15
+; CHECK-BE-NEXT:    fmov d1, x11
+; CHECK-BE-NEXT:    fmov d3, x14
 ; CHECK-BE-NEXT:    mov v0.d[1], x1
 ; CHECK-BE-NEXT:    mov v2.d[1], x5
 ; CHECK-BE-NEXT:    mov v1.d[1], x3
@@ -561,14 +605,9 @@ define <4 x i63> @test_ldnp_v4i63(<4 x i63>* %A) {
 define <5 x double> @test_ldnp_v5f64(<5 x double>* %A) {
 ; CHECK-LABEL: test_ldnp_v5f64:
 ; CHECK:       ; %bb.0:
-; CHECK-NEXT:    ldp q0, q2, [x0]
-; CHECK-NEXT:    ext.16b v1, v0, v0, #8
-; CHECK-NEXT:    ; kill: def $d0 killed $d0 killed $q0
-; CHECK-NEXT:    ; kill: def $d1 killed $d1 killed $q1
-; CHECK-NEXT:    ext.16b v3, v2, v2, #8
+; CHECK-NEXT:    ldnp d0, d1, [x0]
+; CHECK-NEXT:    ldnp d2, d3, [x0, #16]
 ; CHECK-NEXT:    ldr d4, [x0, #32]
-; CHECK-NEXT:    ; kill: def $d2 killed $d2 killed $q2
-; CHECK-NEXT:    ; kill: def $d3 killed $d3 killed $q3
 ; CHECK-NEXT:    ; kill: def $d4 killed $d4 killed $q4
 ; CHECK-NEXT:    ret
 ;


### PR DESCRIPTION
This reverts commit 661403b85c219a83baa37335a870d4d93dc4b1c3 as the custom lowering of loads prevents expanding unaligned loads with strict-align.

(cherry-picked from 1e723b7ab303)