### PR TITLE
[lldb][NFC] Check if can eval expr without binding earlier

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -149,6 +149,8 @@ public:
       SwiftLanguageRuntime *runtime, lldb::DynamicValueType use_dynamic,
       lldb::BindGenericTypes bind_generic_types);
 
+  static lldb::VariableSP FindSelfVariable(Block *block);
+
   //------------------------------------------------------------------
   /// Information about each variable provided to the expression, so
   /// that we can generate proper accesses in the SIL.


### PR DESCRIPTION
Move the check that we can evaluate the expression without binding the generic paramaters from SwiftExpressionParser (after we generate an AST from the user's expression) to SwiftUserExpression, before we get the text binding the user's expression.