### PR TITLE
[DebugInfo] Fix if-init-statement usage pre C++17 adoption

### DIFF
--- a/llvm/lib/IR/DebugInfoMetadata.cpp
+++ b/llvm/lib/IR/DebugInfoMetadata.cpp
@@ -945,7 +945,8 @@ DILocalScope *DILocalScope::cloneScopeForSubprogram(
 
   for (DIScope *Scope = &RootScope; !isa<DISubprogram>(Scope);
        Scope = Scope->getScope()) {
-    if (auto It = Cache.find(Scope); It != Cache.end()) {
+    auto It = Cache.find(Scope);
+    if (It != Cache.end()) {
       CachedResult = cast<DIScope>(It->second);
       break;
     }

--- a/llvm/lib/IR/DebugLoc.cpp
+++ b/llvm/lib/IR/DebugLoc.cpp
@@ -76,7 +76,8 @@ DebugLoc DebugLoc::replaceInlinedAtSubprogram(
   // Collect the inline chain, stopping if we find a location that has already
   // been processed.
   for (DILocation *Loc = RootLoc; Loc; Loc = Loc->getInlinedAt()) {
-    if (auto It = Cache.find(Loc); It != Cache.end()) {
+    auto It = Cache.find(Loc);
+    if (It != Cache.end()) {
       CachedResult = cast<DILocation>(It->second);
       break;
     }


### PR DESCRIPTION
While this is fine for ToT, this branch was taken prior to the switch.