### PR TITLE
[lldb] Make generic expr eval work with multiple toplevel generic params

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -91,6 +91,9 @@ public:
     swift::VarDecl::Introducer GetVarIntroducer() const;
     bool GetIsCaptureList() const;
     bool IsMetadataPointer() const { return m_name.str().startswith("$τ"); }
+    bool IsOutermostMetadataPointer() const {
+      return m_name.str().startswith("$τ_0_");
+    }
     bool IsSelf() const {
       return !m_name.str().compare("$__lldb_injected_self");
     }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.h
@@ -9,6 +9,7 @@
 #ifndef liblldb_SwiftExpressionSourceCode_h
 #define liblldb_SwiftExpressionSourceCode_h
 
+#include "SwiftASTManipulator.h"
 #include "lldb/Expression/Expression.h"
 #include "lldb/Expression/ExpressionSourceCode.h"
 #include "lldb/lldb-enumerations.h"
@@ -36,15 +37,12 @@ public:
 
   uint32_t GetNumBodyLines();
 
-  bool GetText(std::string &text, 
-               lldb::LanguageType wrapping_language,
-               bool needs_object_ptr,
-               bool static_method,
-               bool is_class,
-               bool weak_self,
-               const EvaluateExpressionOptions &options,
-               ExecutionContext &exe_ctx,
-               uint32_t &first_body_line) const;
+  bool GetText(
+      std::string &text, lldb::LanguageType wrapping_language,
+      bool needs_object_ptr, bool static_method, bool is_class, bool weak_self,
+      const EvaluateExpressionOptions &options, ExecutionContext &exe_ctx,
+      uint32_t &first_body_line,
+      llvm::ArrayRef<SwiftASTManipulator::VariableInfo> local_variables) const;
 
 private:
   SwiftExpressionSourceCode(const char *name, const char *prefix, const char *body,

--- a/lldb/test/API/lang/swift/private_generic_type/Private.swift
+++ b/lldb/test/API/lang/swift/private_generic_type/Private.swift
@@ -1,11 +1,11 @@
 import Public
 
 private struct InvisibleStruct {
-  public var name = "The invisible man."
+  public var name = "The invisible struct."
 }
 
 private class InvisibleClass {
-  public var name = "The invisible class"
+  public var name = "The invisible class."
   public var someNumber = 42
 }
 
@@ -17,9 +17,21 @@ public func privateDoIt()  {
   let classWrapper = ClassWrapper(InvisibleStruct())
   classWrapper.foo()
 
+  let twoGenericParameters = TwoGenericParameters(InvisibleClass(), InvisibleStruct())
+  twoGenericParameters.foo()
+
+  let threeGenericParameters = ThreeGenericParameters(InvisibleClass(), InvisibleStruct(), true)
+  threeGenericParameters.foo()
+  
+  let fourGenericParameters = FourGenericParameters(InvisibleStruct(), 
+                                                      InvisibleClass(), 
+                                                      ["One", "two", "three"], 
+                                                      482)
+  fourGenericParameters.foo()
+
   let nonGeneric = NonGeneric()
   nonGeneric.foo()
 
-  let twoGenericParameters = TwoGenericParameters(InvisibleStruct(), InvisibleClass())
-  twoGenericParameters.foo()
+  let nestedParameters = Nested.Parameters(InvisibleClass(), InvisibleStruct())
+  nestedParameters.foo()
 }

--- a/lldb/test/API/lang/swift/private_generic_type/Public.swift
+++ b/lldb/test/API/lang/swift/private_generic_type/Public.swift
@@ -41,5 +41,56 @@ public class TwoGenericParameters<T, U> {
 
   public func foo() {
     print(self) // break here for two generic parameters
+ }
+}
+
+public struct ThreeGenericParameters<T, U, V> {
+  let t: T
+  let u: U
+  let v: V
+
+  public init(_ t: T, _ u: U, _ v: V) {
+    self.t = t
+    self.u = u
+    self.v = v
+  }
+
+  public func foo() {
+    print(self) // break here for three generic parameters
   }
 }
+
+public struct FourGenericParameters<T, U, V, W> {
+  let t: T
+  let u: U
+  let v: V
+  let w: W
+
+  public init(_ t: T, _ u: U, _ v: V, _ w: W) {
+    self.t = t
+    self.u = u
+    self.v = v
+    self.w = w
+  }
+
+  public func foo() {
+    print(self) // break here for four generic parameters
+  }
+}
+
+public struct Nested<T> {
+  public struct Parameters<U>  {
+    let t: T
+    let u: U
+
+    public init(_ t: T, _ u: U) {
+      self.t = t
+      self.u = u
+    }
+
+    public func foo() {
+      print(self) // break here for nested generic parameters
+    }
+  }
+}
+

--- a/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
+++ b/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
@@ -31,14 +31,14 @@ class TestSwiftPrivateGenericType(TestBase):
         # Test that not binding works.
         self.expect("e --bind-generic-types false -- self", 
                     substrs=["Public.StructWrapper<T>", 
-                             "The invisible man."])
+                             'name = "The invisible struct."'])
         # Test that the "auto" behavior also works.
         self.expect("e --bind-generic-types auto -- self", 
                     substrs=["Public.StructWrapper<T>", 
-                             "The invisible man."])
+                             'name = "The invisible struct."'])
         # Test that the default (should be the auto option) also works.
         self.expect("e -- self", substrs=["Public.StructWrapper<T>", 
-                                          "The invisible man."])
+                                          'name = "The invisible struct."'])
 
         breakpoint = target.BreakpointCreateBySourceRegex(
             'break here for class', lldb.SBFileSpec('Public.swift'), None)
@@ -48,13 +48,94 @@ class TestSwiftPrivateGenericType(TestBase):
                     error=True)
         self.expect("e --bind-generic-types false -- self", 
                     substrs=["Public.ClassWrapper<Private.InvisibleStruct>", 
-                             "The invisible man."])
+                             'name = "The invisible struct."'])
         self.expect("e --bind-generic-types auto -- self", 
                     substrs=["Public.ClassWrapper<Private.InvisibleStruct>", 
-                             "The invisible man."])
+                             'name = "The invisible struct."'])
         self.expect("e -- self", 
                     substrs=["Public.ClassWrapper<Private.InvisibleStruct>", 
-                             "The invisible man."])
+                             'name = "The invisible struct."'])
+
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here for two generic parameters', lldb.SBFileSpec('Public.swift'), None)
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("e --bind-generic-types true -- self", 
+                    substrs=["Couldn't realize Swift AST type of self."], 
+                    error=True)
+        self.expect("e --bind-generic-types false -- self", 
+                    substrs=["Public.TwoGenericParameters",
+                             "<Private.InvisibleClass, Private.InvisibleStruct>", 
+                             'name = "The invisible class."',
+                             "someNumber = 42"])
+        self.expect("e --bind-generic-types auto -- self", 
+                    substrs=["Public.TwoGenericParameters",
+                             "<Private.InvisibleClass, Private.InvisibleStruct>", 
+                             'name = "The invisible class."',
+                             "someNumber = 42"])
+        self.expect("e -- self", 
+                    substrs=["Public.TwoGenericParameters",
+                             "<Private.InvisibleClass, Private.InvisibleStruct>", 
+                             'name = "The invisible class."',
+                             "someNumber = 42"])
+
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here for three generic parameters', lldb.SBFileSpec('Public.swift'), None)
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("e --bind-generic-types true -- self", 
+                    substrs=["Couldn't realize Swift AST type of self."], 
+                    error=True)
+        self.expect("e --bind-generic-types false -- self", 
+                    substrs=["Public.ThreeGenericParameters",
+                             "<T, U, V>", 
+                             'name = "The invisible class."',
+                             "someNumber = 42",
+                             'name = "The invisible struct."',
+                             "v = true"])
+        self.expect("e --bind-generic-types auto -- self", 
+                    substrs=["Public.ThreeGenericParameters",
+                             "<T, U, V>", 
+                             'name = "The invisible class."',
+                             "someNumber = 42",
+                             'name = "The invisible struct."',
+                             "v = true"])
+        self.expect("e -- self", 
+                    substrs=["Public.ThreeGenericParameters",
+                             "<T, U, V>", 
+                             'name = "The invisible class."',
+                             "someNumber = 42",
+                             'name = "The invisible struct."',
+                             "v = true"])
+
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here for four generic parameters', lldb.SBFileSpec('Public.swift'), None)
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("e --bind-generic-types true -- self", 
+                    substrs=["Couldn't realize Swift AST type of self."], 
+                    error=True)
+        self.expect("e --bind-generic-types false -- self", 
+                    substrs=["Public.FourGenericParameters",
+                             "<T, U, V, W>", 
+                             'name = "The invisible struct."',
+                             'name = "The invisible class."',
+                             "someNumber = 42",
+                             "v = 3 values", "One", "two", "three",
+                             "w = 482"])
+        self.expect("e --bind-generic-types auto -- self", 
+                    substrs=["Public.FourGenericParameters",
+                             "<T, U, V, W>", 
+                             'name = "The invisible struct."',
+                             'name = "The invisible class."',
+                             "someNumber = 42",
+                             "v = 3 values", "One", "two", "three",
+                             "w = 482"])
+        self.expect("e -- self", 
+                    substrs=["Public.FourGenericParameters",
+                             "<T, U, V, W>", 
+                             'name = "The invisible struct."',
+                             'name = "The invisible class."',
+                             "someNumber = 42",
+                             "v = 3 values", "One", "two", "three",
+                             "w = 482"])
 
         breakpoint = target.BreakpointCreateBySourceRegex(
             'break here for non-generic', lldb.SBFileSpec('Public.swift'), None)
@@ -64,7 +145,7 @@ class TestSwiftPrivateGenericType(TestBase):
                     error=True)
 
         breakpoint = target.BreakpointCreateBySourceRegex(
-            'break here for two generic parameters', lldb.SBFileSpec('Public.swift'), None)
+            'break here for nested generic parameters', lldb.SBFileSpec('Public.swift'), None)
         lldbutil.continue_to_breakpoint(process, breakpoint)
         self.expect("e --bind-generic-types false -- self", 
                     substrs=["Could not evaluate the expression without binding generic types."], 


### PR DESCRIPTION
Before this patch, generic expression evaluation would only work for a single toplevel generic parameter. This patch expands its capabilities to allow for multiple generic parameters.