### PR TITLE
Emit unwind information in the .debug_frame section when the .cfi_sections .debug_frame directive is used.

### DIFF
--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -1862,7 +1862,7 @@ void MCDwarfFrameEmitter::Emit(MCObjectStreamer &Streamer, MCAsmBackend *MAB,
 
   // Emit the compact unwind info if available.
   bool NeedsEHFrameSection = !MOFI->getSupportsCompactUnwindWithoutEHFrame();
-  if (IsEH && MOFI->getCompactUnwindSection()) {
+  if (MOFI->getCompactUnwindSection()) {
     Streamer.generateCompactUnwindEncodings(MAB);
     bool SectionEmitted = false;
     for (const MCDwarfFrameInfo &Frame : FrameArray) {

--- a/llvm/test/DebugInfo/AArch64/debugframeinfo.s
+++ b/llvm/test/DebugInfo/AArch64/debugframeinfo.s
@@ -1,0 +1,14 @@
+# RUN: llvm-mc -filetype=obj --triple=arm64-apple-darwin22.1.0 %s -o %t.o
+# RUN: llvm-dwarfdump -debug-frame %t.o | FileCheck %s
+
+# CHECK: .debug_frame contents:
+# CHECK-EMPTY:
+# CHECK-NEXT: 00000000 00000014 ffffffff CIE
+# CHECK: .eh_frame contents:
+# CHECK-EMPTY:
+
+ .cfi_startproc
+ .cfi_signal_frame
+ .cfi_def_cfa x28, 0x340
+ .cfi_endproc
+ .cfi_sections .debug_frame


### PR DESCRIPTION
By default the unwind information is emitted in the eh_frame section, but when the `.cfi_sections .debug_frame` directive is used, the information is supposed to be emitted in the .debug_frame section. This doesn't seem to work, however. This patched addresses that bug.