### PR TITLE
[lldb][swift][tsan] Strawman fix for TSAN  tests failing to  compile

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -147,6 +147,14 @@ ifeq "$(OS)" "Darwin"
 endif
 
 #----------------------------------------------------------------------
+# Handle CLANG_RT_DIR on Darwin
+#----------------------------------------------------------------------
+
+ifeq "$(OS)" "Darwin"
+	CLANG_RT_DIR := $(LLDB_LIBS_DIR)/lldb/clang/lib/darwin/
+endif
+
+#----------------------------------------------------------------------
 # SWIFTC defaults to swift.
 # TODO:
 # If you change the defaults of SWIFTC, be sure to also change it in the file

--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -41,7 +41,7 @@ if(LLDB_TEST_SWIFT)
   set(LLDB_SWIFT_LIBS ${SWIFT_LIBRARY_DIR}/swift CACHE STRING "Path to swift libraries")
   # Prefer the just-built stdlib over the system one.
   set(SWIFT_TEST_ARGS
-    --inferior-env "DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/macosx\\\""
+    --inferior-env "DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/macosx:${LLVM_LIBRARY_OUTPUT_INTDIR}/lldb/clang/lib/darwin\\\""
     --inferior-env "LD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/${CMAKE_SYSTEM_PROCESSOR}\\\""
     --inferior-env "SIMCTL_CHILD_DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/macosx\\\"")
 endif()

--- a/lldb/test/API/functionalities/asan/swift/Makefile
+++ b/lldb/test/API/functionalities/asan/swift/Makefile
@@ -1,6 +1,9 @@
 
 SWIFT_SOURCES := main.swift
 
+# Note the lazy variable setting - needs to use CLANG_RT_DIR, defined in Makefile.rules
+LD_EXTRAS = -lclang_rt.asan_osx_dynamic -L$(CLANG_RT_DIR)
+
 include Makefile.rules
 
 SWIFTFLAGS += -sanitize=address

--- a/lldb/test/API/functionalities/tsan/swift/Makefile
+++ b/lldb/test/API/functionalities/tsan/swift/Makefile
@@ -1,6 +1,9 @@
 
 SWIFT_SOURCES := main.swift
 
+# Note the lazy variable setting - needs to use CLANG_RT_DIR, defined in Makefile.rules
+LD_EXTRAS = -lclang_rt.tsan_osx_dynamic -L$(CLANG_RT_DIR)
+
 include Makefile.rules
 
 SWIFTFLAGS += -sanitize=thread

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -166,6 +166,9 @@ if is_configured('dotest_common_args_str'):
 # Library path may be needed to locate just-built clang and libcxx.
 if is_configured('llvm_libs_dir'):
   dotest_cmd += ['--env', 'LLVM_LIBS_DIR=' + config.llvm_libs_dir]
+# Library path may be needed to locate just-built compiler-rt.
+if is_configured('lldb_libs_dir'):
+  dotest_cmd += ['--env', 'LLDB_LIBS_DIR=' + config.lldb_libs_dir]
 
 # Include path may be needed to locate just-built libcxx.
 if is_configured('llvm_include_dir'):


### PR DESCRIPTION

The tests only refer to swift dylib directory in build, and it doesn't contain the TSAN dylib.

Added the directory containing TSAN dylib, from the LLVM build - however could only locate this LLVM directory by walking backwards from CLANG_MODULE_CACHE_DIR , which I'm told is not reliable enough.

Putting out this PR to discuss potential better solutions.

rdar://103001321