### PR TITLE
Fix downstream deprecation warning for llvm::None

### DIFF
--- a/clang/lib/Index/IndexRecordReader.cpp
+++ b/clang/lib/Index/IndexRecordReader.cpp
@@ -247,15 +247,16 @@ struct IndexRecordReader::Implementation {
             llvm::function_ref<bool(const IndexRecordOccurrence &)> receiver) {
     // FIXME: Use binary search and make this more efficient.
     unsigned lineEnd = lineStart+lineCount;
-    return foreachOccurrence(None, None, [&](const IndexRecordOccurrence &occur) -> bool {
-      if (occur.Line > lineEnd)
-        return false; // we're done.
-      if (occur.Line >= lineStart) {
-        if (!receiver(occur))
-          return false;
-      }
-      return true;
-    });
+    return foreachOccurrence(std::nullopt, std::nullopt,
+                             [&](const IndexRecordOccurrence &occur) -> bool {
+                               if (occur.Line > lineEnd)
+                                 return false; // we're done.
+                               if (occur.Line >= lineStart) {
+                                 if (!receiver(occur))
+                                   return false;
+                               }
+                               return true;
+                             });
   }
 
   static uint64_t read(RecordDataImpl &Record, unsigned &I) {
@@ -425,7 +426,7 @@ bool IndexRecordReader::foreachOccurrence(
 
 bool IndexRecordReader::foreachOccurrence(
             llvm::function_ref<bool(const IndexRecordOccurrence &)> Receiver) {
-  return foreachOccurrence(None, None, std::move(Receiver));
+  return foreachOccurrence(std::nullopt, std::nullopt, std::move(Receiver));
 }
 
 bool IndexRecordReader::foreachOccurrenceInLineRange(unsigned lineStart,

--- a/clang/lib/Index/IndexUnitReader.cpp
+++ b/clang/lib/Index/IndexUnitReader.cpp
@@ -472,7 +472,7 @@ IndexUnitReader::getModificationTimeForUnit(StringRef UnitFilename,
   std::error_code EC = sys::fs::status(PathBuf.str(), FileStat);
   if (EC) {
     Error = EC.message();
-    return None;
+    return std::nullopt;
   }
   return FileStat.getLastModificationTime();
 }

--- a/clang/lib/Index/IndexUnitWriter.cpp
+++ b/clang/lib/Index/IndexUnitWriter.cpp
@@ -246,7 +246,7 @@ Optional<bool> IndexUnitWriter::isUnitUpToDateForOutputFile(StringRef FilePath,
       llvm::raw_string_ostream Err(Error);
       Err << "could not access path '" << UnitPath
           << "': " << EC.message();
-      return None;
+      return std::nullopt;
     }
     return false;
   }
@@ -260,7 +260,7 @@ Optional<bool> IndexUnitWriter::isUnitUpToDateForOutputFile(StringRef FilePath,
       llvm::raw_string_ostream Err(Error);
       Err << "could not access path '" << *TimeCompareFilePath
           << "': " << EC.message();
-      return None;
+      return std::nullopt;
     }
     return true;
   }

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -688,7 +688,7 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
                     ArrayRef<std::string> DepTargets, std::string OutputPath,
                     Optional<std::string> CASPath,
                     Optional<std::string> CachePath,
-                    Optional<std::string> ModuleName = None) {
+                    Optional<std::string> ModuleName = std::nullopt) {
   CXDependencyScannerServiceOptions Opts =
       clang_experimental_DependencyScannerServiceOptions_create();
   auto CleanupOpts = llvm::make_scope_exit([&] {
@@ -1171,10 +1171,11 @@ int indextest_core_main(int argc, const char **argv) {
     return aggregateDataAsJSON(storePath, PathRemapper, OS);
   }
 
-  Optional<std::string> CASPath =
-      options::CASPath.empty() ? None : Optional<std::string>(options::CASPath);
+  Optional<std::string> CASPath = options::CASPath.empty()
+                                      ? std::nullopt
+                                      : Optional<std::string>(options::CASPath);
   Optional<std::string> CachePath =
-      options::CachePath.empty() ? None
+      options::CachePath.empty() ? std::nullopt
                                  : Optional<std::string>(options::CachePath);
 
   if (options::Action == ActionType::ScanDeps) {


### PR DESCRIPTION
Update llvm::None -> std::nullopt to fix deprecation warnings.