### PR TITLE
[stable/20221013][lldb] Remove extra add_properties_for_swift_modules

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -149,6 +149,15 @@ endfunction(add_lldb_library)
 
 # BEGIN Swift Mods
 function(add_properties_for_swift_modules target reldir)
+  # The relative directory for build can be passed as an optional
+  # extra argument. Retrieve it, or use reldir instead.
+  list(LENGTH ARGN num_optional_arguments)
+  if (${num_optional_arguments} GREATER 0)
+    list(GET ARGN 0 build_reldir)
+  else()
+    set(build_reldir ${reldir})
+  endif()
+
   if (NOT BOOTSTRAPPING_MODE)
     if (SWIFT_SWIFT_PARSER)
       set(APSM_BOOTSTRAPPING_MODE "HOSTTOOLS")
@@ -185,7 +194,7 @@ function(add_properties_for_swift_modules target reldir)
 
     if (SWIFT_SWIFT_PARSER)
       set_property(TARGET ${target}
-        APPEND PROPERTY BUILD_RPATH "@loader_path/${reldir}lib/swift/host")
+        APPEND PROPERTY BUILD_RPATH "@loader_path/${build_reldir}lib/swift/host")
       set_property(TARGET ${target}
         APPEND PROPERTY INSTALL_RPATH "@loader_path/${reldir}lib/swift/host")
     endif()

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -148,7 +148,7 @@ endif()
 # BEGIN Swift Mods
 # Note that add_properties_for_swift_modules appends RPATHs so it's critical
 # that this is called after lldb_setup_rpaths.
-add_properties_for_swift_modules(liblldb "../../../../")
+add_properties_for_swift_modules(liblldb "../../../../../../usr/" "../../../../")
 # END Swift Mods
 
 if(LLDB_ENABLE_PYTHON)

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -122,10 +122,6 @@ add_lldb_library(liblldb SHARED ${option_framework}
   ${option_install_prefix}
 )
 
-# BEGIN Swift Mods
-add_properties_for_swift_modules(liblldb)
-# END Swift Mods
-
 # lib/pythonX.Y/dist-packages/lldb/_lldb.so is a symlink to lib/liblldb.so,
 # which depends on lib/libLLVM*.so (BUILD_SHARED_LIBS) or lib/libLLVM-10git.so
 # (LLVM_LINK_LLVM_DYLIB). Add an additional rpath $ORIGIN/../../../../lib so


### PR DESCRIPTION
Leave the one after setting up the RPATH, since that's the correct usage.

Also cherry-pick b438e7ae2e821bba13b0659e412fad8a5c5020a1 which is needed as well.