### PR TITLE
[next] Add a `vfs-redirecting-with` feature

### DIFF
--- a/clang/tools/driver/features.json
+++ b/clang/tools/driver/features.json
@@ -10,6 +10,9 @@
       "name": "allow-pcm-with-compiler-errors"
     },
     {
+      "name": "vfs-redirecting-with"
+    },
+    {
       "name": "deployment-target-environment-variables",
       "value": [
         "MACOSX_DEPLOYMENT_TARGET",


### PR DESCRIPTION
Cherry-picks 762e8243fd54817bb375373f93c37460d48db66d.

-----

Mark clang as being able to use the new `redirecting-with` property in VFS overlays.

Resolves rdar://87906715.