### PR TITLE
[stable/20220421][clang-cas-test] Add an option to print an include-tree from its CASID

### DIFF
--- a/clang/test/CAS/print-compile-job-cache-key.c
+++ b/clang/test/CAS/print-compile-job-cache-key.c
@@ -36,18 +36,25 @@
 
 // Print a key containing an include-tree.
 
-// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_ENABLE_INCLUDE_TREE=1 %clang-cache \
-// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/output.o -Rcompile-job-cache 2> %t/output-tree.txt
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/inc.rsp -cc1-args -cc1 -triple x86_64-apple-macos11 -emit-obj \
+// RUN:   %s -o %t/output.o -fcas-path %t/cas -faction-cache-path %t/cache
+// RUN: %clang @%t/inc.rsp -Rcompile-job-cache 2> %t/output-tree.txt
 
 // RUN: cat %t/output-tree.txt | sed \
 // RUN:   -e "s/^.*miss for '//" \
 // RUN:   -e "s/' .*$//" > %t/cache-key-tree
 
-// RUN: clang-cas-test -print-compile-job-cache-key -cas %t/cas/cas @%t/cache-key-tree | FileCheck %s -check-prefix=INCLUDE_TREE -DSRC_FILE=%s
+// RUN: clang-cas-test -print-compile-job-cache-key -cas %t/cas @%t/cache-key-tree | FileCheck %s -check-prefix=INCLUDE_TREE_KEY -check-prefix=INCLUDE_TREE -DSRC_FILE=%s
 //
-// INCLUDE_TREE: command-line: llvmcas://
-// INCLUDE_TREE: computation: llvmcas://
-// INCLUDE_TREE: include-tree: llvmcas://
-// INCLUDE_TREE-NEXT: [[SRC_FILE]] llvmcas://
+// INCLUDE_TREE_KEY: command-line: llvmcas://
+// INCLUDE_TREE_KEY: computation: llvmcas://
+// INCLUDE_TREE_KEY: include-tree: llvmcas://
+// INCLUDE_TREE: [[SRC_FILE]] llvmcas://
 // INCLUDE_TREE: Files:
 // INCLUDE_TREE-NEXT: [[SRC_FILE]] llvmcas://
+
+// RUN: cat %t/inc.rsp | sed \
+// RUN:   -e "s/^.*\"-fcas-include-tree\" \"//" \
+// RUN:   -e "s/\" .*$//" > %t/include-tree-id
+
+// RUN: clang-cas-test -print-include-tree -cas %t/cas @%t/include-tree-id | FileCheck %s -check-prefix=INCLUDE_TREE -DSRC_FILE=%s


### PR DESCRIPTION
(cherry picked from commit 594a935fda94ca7dc97e6a024b12d3d154d93cee)