### PR TITLE
Headers: tweak inclusion condition for stdatomic.h

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -171,6 +171,8 @@ Major New Features
 
 Bug Fixes
 ---------
+- ``stdatomic.h`` will use the internal declarations when targeting pre-C++-23
+  on Windows platforms as the MSVC support requires newer C++ standard.
 - Correct ``_Static_assert`` to accept the same set of extended integer
   constant expressions as is accpted in other contexts that accept them.
   This fixes `Issue 57687 <https://github.com/llvm/llvm-project/issues/57687>`_.

--- a/clang/lib/Headers/stdatomic.h
+++ b/clang/lib/Headers/stdatomic.h
@@ -20,7 +20,7 @@
  */
 #if __STDC_HOSTED__ &&                                                         \
     __has_include_next(<stdatomic.h>) &&                                       \
-    !(defined(_MSC_VER) && defined(__cplusplus) && __cplusplus < 202002L)
+    (!defined(_MSC_VER) || (defined(__cplusplus) && __cplusplus >= 202002L))
 # include_next <stdatomic.h>
 #else
 

--- a/clang/lib/Headers/stdatomic.h
+++ b/clang/lib/Headers/stdatomic.h
@@ -15,10 +15,12 @@
  *
  * Exclude the MSVC path as well as the MSVC header as of the 14.31.30818
  * explicitly disallows `stdatomic.h` in the C mode via an `#error`.  Fallback
- * to the clang resource header until that is fully supported.
+ * to the clang resource header until that is fully supported.  The
+ * `stdatomic.h` header requires C++ 23 or newer.
  */
 #if __STDC_HOSTED__ &&                                                         \
-    __has_include_next(<stdatomic.h>) && !(defined(_MSC_VER) && !defined(__cplusplus))
+    __has_include_next(<stdatomic.h>) &&                                       \
+    !(defined(_MSC_VER) && defined(__cplusplus) && __cplusplus < 202002L)
 # include_next <stdatomic.h>
 #else
 


### PR DESCRIPTION
MSVC requires that C++23 be available (_HAS_CXX23) else the entire content is elided. Conditionalise the inclusion properly so that C/C++ code using stdatomic.h for memory_order_* constants are able to do so without changing the C++ standard. This repairs builds of Swift and libdispatch after ba49d39b20cc5358da28af2ac82bd336028780bc.

Differential Revision: https://reviews.llvm.org/D139266 Reviewed By: aaron.ballman, Mordante, fsb4000

(cherry picked from commit e0c3142af075e2ef89395dbed5939071345eb622)