### PR TITLE
[clang/cas] Introduce mechanism for caching diagnostics with full source location fidelity

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6609,9 +6609,10 @@ def fdepscan_include_tree : Flag<["-"], "fdepscan-include-tree">,
 //
 // FIXME: Add DepscanOption flag.
 def fdepscan_prefix_map_EQ : Joined<["-"], "fdepscan-prefix-map=">,
-    Group<f_Group>, MetaVarName<"<old>=<new>">,
+    Group<f_Group>, Flags<[CC1Option]>, MetaVarName<"<old>=<new>">,
     HelpText<"With -fdepscan, seamlessly filter the CAS filesystem to"
-             " apply the given prefix, updating the command-line to match.">;
+             " apply the given prefix, updating the command-line to match.">,
+    MarshallingInfoStringVector<FrontendOpts<"PathPrefixMappings">>;
 def fdepscan_prefix_map_sdk_EQ :
     Joined<["-"], "fdepscan-prefix-map-sdk=">,
     Group<f_Group>, MetaVarName<"<new>">,

--- a/clang/include/clang/Frontend/CompileJobCacheKey.h
+++ b/clang/include/clang/Frontend/CompileJobCacheKey.h
@@ -36,6 +36,8 @@ struct CompileJobCachingOptions {
   std::string CompilationCachingServicePath;
   /// See \c FrontendOptions::DisableCachedCompileJobReplay.
   bool DisableCachedCompileJobReplay;
+  /// See \c FrontendOptions::PathPrefixMappings.
+  std::vector<std::string> PathPrefixMappings;
 };
 
 /// Create a cache key for the given \c CompilerInvocation as a \c CASID. If \p

--- a/clang/include/clang/Frontend/CompileJobCacheResult.h
+++ b/clang/include/clang/Frontend/CompileJobCacheResult.h
@@ -25,7 +25,6 @@ public:
     MainOutput, ///< Main output file, e.g. object file, pcm file, etc.
     SerializedDiagnostics,
     Dependencies,
-    Stderr, ///< Contents of stderr.
   };
 
   /// Returns all \c OutputKind values.

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -227,6 +227,9 @@ public:
   // of the context or else not CompilerInstance specific.
   bool ExecuteAction(FrontendAction &Act);
 
+  /// At the end of a compilation, print the number of warnings/errors.
+  void printDiagnosticStats();
+
   /// Load the list of plugins requested in the \c FrontendOptions.
   void LoadRequestedPlugins();
 

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -487,6 +487,11 @@ public:
   /// Socket path for remote caching service.
   std::string CompilationCachingServicePath;
 
+  /// When caching is enabled, represents remappings for all the file paths that
+  /// the compilation may access. This is useful for canonicalizing the
+  /// compilation for caching purposes.
+  std::vector<std::string> PathPrefixMappings;
+
   // Currently this is only used as part of the `-extract-api` action.
   /// The file providing a list of APIs to ignore when extracting documentation
   std::string ExtractAPIIgnoresFile;

--- a/clang/lib/Frontend/CompileJobCacheResult.cpp
+++ b/clang/lib/Frontend/CompileJobCacheResult.cpp
@@ -16,9 +16,9 @@ using llvm::Error;
 
 ArrayRef<CompileJobCacheResult::OutputKind>
 CompileJobCacheResult::getAllOutputKinds() {
-  static const OutputKind OutputKinds[] = {
-      OutputKind::MainOutput, OutputKind::SerializedDiagnostics,
-      OutputKind::Dependencies, OutputKind::Stderr};
+  static const OutputKind OutputKinds[] = {OutputKind::MainOutput,
+                                           OutputKind::SerializedDiagnostics,
+                                           OutputKind::Dependencies};
   return llvm::makeArrayRef(OutputKinds);
 }
 
@@ -56,9 +56,6 @@ static void printOutputKind(llvm::raw_ostream &OS,
     break;
   case CompileJobCacheResult::OutputKind::SerializedDiagnostics:
     OS << "diags  ";
-    break;
-  case CompileJobCacheResult::OutputKind::Stderr:
-    OS << "stderr ";
     break;
   }
 }

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1075,30 +1075,7 @@ bool CompilerInstance::ExecuteAction(FrontendAction &Act) {
     }
   }
 
-  if (getDiagnosticOpts().ShowCarets) {
-    // We can have multiple diagnostics sharing one diagnostic client.
-    // Get the total number of warnings/errors from the client.
-    unsigned NumWarnings = getDiagnostics().getClient()->getNumWarnings();
-    unsigned NumErrors = getDiagnostics().getClient()->getNumErrors();
-
-    if (NumWarnings)
-      OS << NumWarnings << " warning" << (NumWarnings == 1 ? "" : "s");
-    if (NumWarnings && NumErrors)
-      OS << " and ";
-    if (NumErrors)
-      OS << NumErrors << " error" << (NumErrors == 1 ? "" : "s");
-    if (NumWarnings || NumErrors) {
-      OS << " generated";
-      if (getLangOpts().CUDA) {
-        if (!getLangOpts().CUDAIsDevice) {
-          OS << " when compiling for host";
-        } else {
-          OS << " when compiling for " << getTargetOpts().CPU;
-        }
-      }
-      OS << ".\n";
-    }
-  }
+  printDiagnosticStats();
 
   if (getFrontendOpts().ShowStats) {
     if (hasFileManager()) {
@@ -1121,6 +1098,36 @@ bool CompilerInstance::ExecuteAction(FrontendAction &Act) {
   }
 
   return !getDiagnostics().getClient()->getNumErrors();
+}
+
+void CompilerInstance::printDiagnosticStats() {
+  if (!getDiagnosticOpts().ShowCarets)
+    return;
+
+  raw_ostream &OS = getVerboseOutputStream();
+
+  // We can have multiple diagnostics sharing one diagnostic client.
+  // Get the total number of warnings/errors from the client.
+  unsigned NumWarnings = getDiagnostics().getClient()->getNumWarnings();
+  unsigned NumErrors = getDiagnostics().getClient()->getNumErrors();
+
+  if (NumWarnings)
+    OS << NumWarnings << " warning" << (NumWarnings == 1 ? "" : "s");
+  if (NumWarnings && NumErrors)
+    OS << " and ";
+  if (NumErrors)
+    OS << NumErrors << " error" << (NumErrors == 1 ? "" : "s");
+  if (NumWarnings || NumErrors) {
+    OS << " generated";
+    if (getLangOpts().CUDA) {
+      if (!getLangOpts().CUDAIsDevice) {
+        OS << " when compiling for host";
+      } else {
+        OS << " when compiling for " << getTargetOpts().CPU;
+      }
+    }
+    OS << ".\n";
+  }
 }
 
 void CompilerInstance::LoadRequestedPlugins() {

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -56,6 +56,13 @@ static void updateCompilerInvocation(CompilerInvocation &Invocation,
   auto &FrontendOpts = Invocation.getFrontendOpts();
   FrontendOpts.CacheCompileJob = true; // FIXME: Don't set.
 
+  FrontendOpts.PathPrefixMappings.clear();
+  // Pass the remappings so that we can map cached diagnostics to the local
+  // paths during diagnostic rendering.
+  for (const llvm::MappedPrefix &Map : Mapper.getMappings()) {
+    FrontendOpts.PathPrefixMappings.push_back(Map.Old + "=" + Map.New);
+  }
+
   // Turn off dependency outputs. Should have already been emitted.
   Invocation.getDependencyOutputOpts().OutputFile.clear();
 

--- a/clang/test/CAS/cached-diagnostics.c
+++ b/clang/test/CAS/cached-diagnostics.c
@@ -1,0 +1,64 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t/src
+// RUN: mkdir %t/out
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos12 -fsyntax-only %t/src/main.c -I %t/src/inc -Wunknown-pragmas 2> %t/regular-diags1.txt
+
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -fdepscan-prefix-map=%t/src=/^src -o %t/t1.rsp -cc1-args \
+// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -faction-cache-path %t/cache \
+// RUN:     -emit-obj %t/src/main.c -o %t/out/output.o -I %t/src/inc -Wunknown-pragmas
+
+// Compare diagnostics after a miss.
+// RUN: %clang @%t/t1.rsp 2> %t/diags1.txt
+// RUN: diff -u %t/regular-diags1.txt %t/diags1.txt
+
+// Check that we have both the remark and source diagnostics.
+// RUN: %clang @%t/t1.rsp -Rcompile-job-cache 2> %t/diags-hit1.txt
+// RUN: FileCheck %s -input-file %t/diags-hit1.txt
+// CHECK: remark: compile job cache hit for
+// CHECK: warning: some warning
+// CHECK: warning: unknown pragma ignored
+// CHECK: warning: using the result of an assignment as a condition without parentheses
+
+// RUN: cat %t/diags-hit1.txt | grep remark: | sed \
+// RUN:   -e "s/^.*hit for '//" \
+// RUN:   -e "s/' .*$//" > %t/cache-key1
+
+// Compare diagnostics after a hit.
+// RUN: %clang @%t/t1.rsp 2> %t/cached-diags1.txt
+// RUN: diff -u %t/regular-diags1.txt %t/cached-diags1.txt
+
+// RUN: split-file %s %t/src2
+// RUN: mkdir %t/out2
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos12 -fsyntax-only %t/src2/main.c -I %t/src2/inc -Wunknown-pragmas 2> %t/regular-diags2.txt
+
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -fdepscan-prefix-map=%t/src2=/^src -o %t/t2.rsp -cc1-args \
+// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -faction-cache-path %t/cache \
+// RUN:     -emit-obj %t/src2/main.c -o %t/out2/output.o -I %t/src2/inc -Wunknown-pragmas
+// RUN: %clang @%t/t2.rsp -Rcompile-job-cache 2> %t/diags-hit2.txt
+
+// RUN: cat %t/diags-hit2.txt | grep remark: | sed \
+// RUN:   -e "s/^.*hit for '//" \
+// RUN:   -e "s/' .*$//" > %t/cache-key2
+// RUN: diff -u %t/cache-key1 %t/cache-key2
+
+// RUN: %clang @%t/t2.rsp 2> %t/cached-diags2.txt
+// RUN: diff -u %t/regular-diags2.txt %t/cached-diags2.txt
+
+//--- main.c
+
+#include "t1.h"
+
+//--- inc/t1.h
+
+#warning some warning
+
+_Pragma("unknown1")
+
+#define PRAG(x) _Pragma(x)
+PRAG("unknown2")
+
+void test(int x) {
+  if (x=0) {}
+}

--- a/clang/test/CAS/fcache-compile-job-serialized-diagnostics.c
+++ b/clang/test/CAS/fcache-compile-job-serialized-diagnostics.c
@@ -5,11 +5,11 @@
 // RUN:   -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Wimplicit-function-declaration \
 // RUN:   -Wno-error=implicit-function-declaration \
-// RUN:   -Rcompile-job-cache-hit -emit-obj -o %t/output.o \
+// RUN:   -Rcompile-job-cache -emit-obj -o %t/output.o \
 // RUN:   -serialize-diagnostic-file %t/diags %s 2>&1 \
 // RUN:   | FileCheck %s --allow-empty --check-prefix=CACHE-MISS
 
-// RUN: c-index-test -read-diagnostics %t/diags 2>&1 | FileCheck %s --check-prefix=SERIALIZED-MISS
+// RUN: c-index-test -read-diagnostics %t/diags 2>&1 | FileCheck %s --check-prefix=SERIALIZED-MISS --check-prefix=SERIALIZED-COMMON
 
 // RUN: ls %t/output.o && rm %t/output.o
 
@@ -17,24 +17,22 @@
 // RUN:   -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Wimplicit-function-declaration \
 // RUN:   -Wno-error=implicit-function-declaration \
-// RUN:   -Rcompile-job-cache-hit -emit-obj -o %t/output.o \
+// RUN:   -Rcompile-job-cache -emit-obj -o %t/output.o \
 // RUN:   -serialize-diagnostic-file %t/diags %s 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CACHE-HIT
 
-// RUN: c-index-test -read-diagnostics %t/diags 2>&1 | FileCheck %s --check-prefix=SERIALIZED-HIT
+// RUN: c-index-test -read-diagnostics %t/diags 2>&1 | FileCheck %s --check-prefix=SERIALIZED-HIT --check-prefix=SERIALIZED-COMMON
 
 // CACHE-HIT: remark: compile job cache hit
 // CACHE-HIT: warning: some warning
 
+// CACHE-MISS: remark: compile job cache miss
 // CACHE-MISS: warning: some warning
-// CACHE-MISS-NOT: remark: compile job cache hit
 
-// FIXME: serialized diagnostics should include the "compile job cache" remark but without storing
-// it in a diagnostics file that we put in the CAS.
-// SERIALIZED-HIT: warning: some warning
-// SERIALIZED-HIT: Number of diagnostics: 1
-// SERIALIZED-MISS: warning: some warning
-// SERIALIZED-MISS: Number of diagnostics: 1
+// SERIALIZED-HIT: warning: compile job cache hit
+// SERIALIZED-MISS: warning: compile job cache miss
+// SERIALIZED-COMMON: warning: some warning
+// SERIALIZED-COMMON: Number of diagnostics: 2
 
 // Make sure warnings are merged with driver ones.
 // Using normal compilation as baseline.

--- a/clang/test/CAS/path-independent-cas-outputs.c
+++ b/clang/test/CAS/path-independent-cas-outputs.c
@@ -86,8 +86,11 @@
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t2.o -Rcompile-job-cache \
 // RUN:   2>&1 | FileCheck %s --check-prefix=CACHE-HIT
 
-// RUN: diff %t/t1.dia %t/t2.dia
-// RUN: diff %t/t.dia %t/t1.dia
+// RUN: c-index-test -read-diagnostics %t/t1.dia 2>&1 | FileCheck %s --check-prefix=SERIAL_DIAG-HIT --check-prefix=SERIAL_DIAG-COMMON
+// RUN: c-index-test -read-diagnostics %t/t2.dia 2>&1 | FileCheck %s --check-prefix=SERIAL_DIAG-MISS --check-prefix=SERIAL_DIAG-COMMON
+// SERIAL_DIAG-MISS: warning: compile job cache miss
+// SERIAL_DIAG-HIT: warning: compile job cache hit
+// SERIAL_DIAG-COMMON: warning: some warning
 
 #warning some warning
 void test() {}

--- a/clang/test/CAS/pgo-profile.c
+++ b/clang/test/CAS/pgo-profile.c
@@ -41,18 +41,34 @@
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -faction-cache-path %t.dir/cache -fprofile-instrument-use-path=%t.dir/a/a.profdata
 // RUN: %clang -cc1depscan -fdepscan=inline -o %t5.rsp -fdepscan-prefix-map=%t.dir/b=/^testdir -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache \
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -faction-cache-path %t.dir/cache -fprofile-instrument-use-path=%t.dir/b/a.profdata
-// RUN: diff %t4.rsp %t5.rsp
 // RUN: cat %t4.rsp | FileCheck %s --check-prefix=REMAP
 // RUN: %clang @%t4.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: %clang @%t5.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-HIT
+
+// RUN: cat %t4.rsp | sed \
+// RUN:   -e "s/^.*\"-fcas-fs\" \"//" \
+// RUN:   -e "s/\" .*$//" > %t.dir/cache-key1
+// RUN: cat %t5.rsp | sed \
+// RUN:   -e "s/^.*\"-fcas-fs\" \"//" \
+// RUN:   -e "s/\" .*$//" > %t.dir/cache-key2
+// RUN: grep llvmcas %t.dir/cache-key1
+// RUN: diff -u %t.dir/cache-key1 %t.dir/cache-key2
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t4.inc.rsp -fdepscan-prefix-map=%t.dir/a=/^testdir -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache \
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -faction-cache-path %t.dir/cache -fprofile-instrument-use-path=%t.dir/a/a.profdata
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t5.inc.rsp -fdepscan-prefix-map=%t.dir/b=/^testdir -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache \
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -faction-cache-path %t.dir/cache -fprofile-instrument-use-path=%t.dir/b/a.profdata
-// RUN: diff -u %t4.inc.rsp %t5.inc.rsp
 // RUN: cat %t4.inc.rsp | FileCheck %s --check-prefix=REMAP
 // RUN: %clang @%t4.inc.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: %clang @%t5.inc.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-HIT
+
+// RUN: cat %t4.inc.rsp | sed \
+// RUN:   -e "s/^.*\"-fcas-include-tree\" \"//" \
+// RUN:   -e "s/\" .*$//" > %t.dir/inc-cache-key1
+// RUN: cat %t5.inc.rsp | sed \
+// RUN:   -e "s/^.*\"-fcas-include-tree\" \"//" \
+// RUN:   -e "s/\" .*$//" > %t.dir/inc-cache-key2
+// RUN: grep llvmcas %t.dir/inc-cache-key1
+// RUN: diff -u %t.dir/inc-cache-key1 %t.dir/inc-cache-key2
 
 // REMAP: -fprofile-instrument-use-path=/^testdir/a.profdata

--- a/clang/test/CAS/remote-cache-service.c
+++ b/clang/test/CAS/remote-cache-service.c
@@ -22,11 +22,14 @@
 // RUN: diff %t/t1.o %t/t2.o
 // RUN: diff %t/t.o %t/t1.o
 
-// RUN: diff %t/t1.dia %t/t2.dia
-// RUN: diff %t/t.dia %t/t1.dia
-
 // RUN: diff %t/t1.d %t/t2.d
 // RUN: diff %t/t.d %t/t1.d
+
+// RUN: c-index-test -read-diagnostics %t/t1.dia 2>&1 | FileCheck %s --check-prefix=SERIAL_DIAG-MISS --check-prefix=SERIAL_DIAG-COMMON
+// RUN: c-index-test -read-diagnostics %t/t2.dia 2>&1 | FileCheck %s --check-prefix=SERIAL_DIAG-HIT --check-prefix=SERIAL_DIAG-COMMON
+// SERIAL_DIAG-MISS: warning: compile job cache miss
+// SERIAL_DIAG-HIT: warning: compile job cache hit
+// SERIAL_DIAG-COMMON: warning: some warning
 
 // Verify the outputs did not go into the on-disk ObjectStore.
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \

--- a/clang/tools/driver/CMakeLists.txt
+++ b/clang/tools/driver/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 
 add_clang_tool(clang
   driver.cpp
+  CachedDiagnostics.cpp
   CacheLauncherMode.cpp
   cc1_main.cpp
   cc1as_main.cpp
@@ -50,7 +51,6 @@ clang_target_link_libraries(clang
   clangFrontend
   clangFrontendTool
   clangSerialization
-  ${REMOTE_CACHE_TARGET}
   )
 
 if(WIN32 AND NOT CYGWIN)

--- a/clang/tools/driver/CachedDiagnostics.cpp
+++ b/clang/tools/driver/CachedDiagnostics.cpp
@@ -1,0 +1,740 @@
+//===- CachedDiagnostics.h - Serializing diagnostics for caching ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This is a mechanism for caching diagnostics with full source location
+// fidelity. It serializes the subset of SourceManager state for the diagnostic
+// source locations (FileIDs, macro expansions, etc.) and replays diagnostics by
+// materializing their SourceLocations; that way the diagnostic consumers have
+// full access to the include stack, expanded macros, etc.
+//
+// This allows us to only cache the diagnostic information that is essential for
+// the compilation and ignore the various ways that diagnostics can be rendered.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CachedDiagnostics.h"
+#include "clang/Basic/DiagnosticCAS.h"
+#include "clang/Basic/SourceManager.h"
+#include "llvm/Support/Base64.h"
+#include "llvm/Support/Compression.h"
+#include "llvm/Support/EndianStream.h"
+#include "llvm/Support/StringSaver.h"
+#include "llvm/Support/YAMLTraits.h"
+
+using namespace clang;
+using namespace clang::cas;
+using namespace llvm;
+
+namespace {
+
+namespace cached_diagnostics {
+
+struct Location {
+  unsigned SLocIdx;
+  unsigned Offset;
+};
+
+struct Range {
+  std::optional<Location> Begin;
+  std::optional<Location> End;
+  bool IsTokenRange;
+};
+
+struct FixItHint {
+  std::optional<Range> RemoveRange;
+  std::optional<Range> InsertFromRange;
+  std::string CodeToInsert;
+  bool BeforePreviousInsertions;
+};
+
+struct SLocEntry {
+  struct FileInfo {
+    std::string Filename;
+    std::optional<std::string> Buffer;
+    std::optional<Location> IncludeLoc;
+  };
+
+  struct ExpansionInfo {
+    std::optional<Location> SpellingLoc;
+    std::optional<Location> ExpansionStartLoc;
+    std::optional<Location> ExpansionEndLoc;
+    unsigned Length;
+    bool IsTokenRange;
+  };
+
+  std::variant<FileInfo, ExpansionInfo> Data;
+};
+
+struct Diagnostic {
+  unsigned ID;
+  DiagnosticsEngine::Level Level;
+  std::string Message;
+  std::optional<Location> Loc;
+  std::vector<Range> Ranges;
+  std::vector<FixItHint> FixIts;
+};
+
+struct Diagnostics {
+  std::vector<SLocEntry> SLocEntries;
+  std::vector<Diagnostic> Diags;
+
+  size_t getNumDiags() const { return Diags.size(); }
+
+  void clear() {
+    SLocEntries.clear();
+    Diags.clear();
+  }
+};
+
+} // namespace cached_diagnostics
+
+/// Converts diagnostics from/to the \p cached_diagnostics structures, and
+/// de/serializes diagnostics from/to a buffer. It "materializes" source
+/// locations using its own \p SourceManager.
+struct CachedDiagnosticSerializer {
+  PrefixMapper &Mapper;
+  DiagnosticsEngine DiagEngine;
+  SourceManager SourceMgr;
+  /// Diagnostics either emitted during compilation or deserialized from a
+  /// buffer.
+  cached_diagnostics::Diagnostics CachedDiags;
+  /// Associates a \p FileID with the index of a
+  /// \p cached_diagnostics::SLocEntry object.
+  SmallDenseMap<FileID, unsigned> FileIDToCachedSLocIdx;
+  /// Associates the indices of \p cached_diagnostics::SLocEntry objects with
+  /// their "materialized" \p FileID.
+  SmallVector<FileID> FileIDBySlocIdx;
+  /// Keeps track of \p MemoryBuffers for ownership purposes.
+  SmallVector<std::unique_ptr<MemoryBuffer>> FileBuffers;
+  BumpPtrAllocator Alloc;
+  StringSaver Saver{Alloc};
+
+  CachedDiagnosticSerializer(PrefixMapper &Mapper, FileManager &FileMgr)
+      : Mapper(Mapper),
+        DiagEngine(new DiagnosticIDs(), new DiagnosticOptions()),
+        SourceMgr(DiagEngine, FileMgr) {}
+
+  size_t getNumDiags() const { return CachedDiags.getNumDiags(); }
+  bool empty() const { return getNumDiags() == 0; }
+  void clear() { CachedDiags.clear(); }
+
+  /// \returns the index of the created \p cached_diagnostics::Diagnostic
+  /// object.
+  unsigned addDiag(const StoredDiagnostic &Diag);
+  StoredDiagnostic getDiag(unsigned Idx);
+
+  std::optional<cached_diagnostics::Location>
+  convertLoc(const FullSourceLoc &Loc);
+  FullSourceLoc convertCachedLoc(
+      const std::optional<cached_diagnostics::Location> &CachedLoc);
+
+  std::optional<cached_diagnostics::Range>
+  convertRange(const CharSourceRange &Range, const SourceManager &SM);
+  CharSourceRange convertCachedRange(
+      const std::optional<cached_diagnostics::Range> &CachedRange);
+
+  cached_diagnostics::FixItHint convertFixIt(const FixItHint &FixIt,
+                                             const SourceManager &SM);
+  FixItHint
+  convertCachedFixIt(const cached_diagnostics::FixItHint &CachedFixIt);
+
+  unsigned convertFileID(FileID FID, const SourceManager &SM);
+  unsigned convertFileIDFromScratchSpace(FileID FID, const SourceManager &SM);
+  FileID convertCachedSLocEntry(unsigned Idx);
+
+  /// \returns a serialized buffer of the currently recorded
+  /// \p cached_diagnostics::Diagnostics, or \p std::nullopt if there's no
+  /// diagnostic. The buffer can be passed to \p deserializeCachedDiagnostics to
+  /// get back the same diagnostics.
+  ///
+  /// There is no stability guarantee for the format of the buffer, the
+  /// expectation is that the buffer will be deserialized only by the same
+  /// compiler version that produced it. The format can change without
+  /// restrictions.
+  ///
+  /// The intended use is as implementation detail of compilation caching, where
+  /// the diagnostic output is associated with a compilation cache key. A
+  /// different compiler version will create different cache keys, which ensures
+  /// that the diagnostics buffer will only be read by the same compiler that
+  /// produced it.
+  std::optional<std::string> serializeEmittedDiagnostics();
+  Error deserializeCachedDiagnostics(StringRef Buffer);
+};
+
+} // anonymous namespace
+
+unsigned CachedDiagnosticSerializer::addDiag(const StoredDiagnostic &Diag) {
+  cached_diagnostics::Diagnostic CachedDiag;
+  CachedDiag.ID = Diag.getID();
+  CachedDiag.Level = Diag.getLevel();
+  CachedDiag.Message = Diag.getMessage();
+  CachedDiag.Loc = convertLoc(Diag.getLocation());
+  if (Diag.getLocation().isValid()) {
+    const SourceManager &SM = Diag.getLocation().getManager();
+    for (const CharSourceRange &Range : Diag.getRanges()) {
+      if (std::optional<cached_diagnostics::Range> CachedRange =
+              convertRange(Range, SM))
+        CachedDiag.Ranges.push_back(std::move(*CachedRange));
+    }
+    for (const FixItHint &FixIt : Diag.getFixIts()) {
+      CachedDiag.FixIts.push_back(convertFixIt(FixIt, SM));
+    }
+  }
+
+  unsigned Idx = CachedDiags.Diags.size();
+  CachedDiags.Diags.push_back(std::move(CachedDiag));
+  return Idx;
+}
+
+StoredDiagnostic CachedDiagnosticSerializer::getDiag(unsigned Idx) {
+  assert(Idx < getNumDiags());
+  const cached_diagnostics::Diagnostic &CachedDiag = CachedDiags.Diags[Idx];
+  FullSourceLoc Loc = convertCachedLoc(CachedDiag.Loc);
+  SmallVector<CharSourceRange> Ranges;
+  for (const cached_diagnostics::Range &CachedRange : CachedDiag.Ranges) {
+    Ranges.push_back(convertCachedRange(CachedRange));
+  }
+  SmallVector<FixItHint> FixIts;
+  for (const cached_diagnostics::FixItHint &CachedFixIt : CachedDiag.FixIts) {
+    FixIts.push_back(convertCachedFixIt(CachedFixIt));
+  }
+
+  StoredDiagnostic Diag(CachedDiag.Level, CachedDiag.ID, CachedDiag.Message,
+                        Loc, Ranges, FixIts);
+  return Diag;
+}
+
+std::optional<cached_diagnostics::Location>
+CachedDiagnosticSerializer::convertLoc(const FullSourceLoc &Loc) {
+  if (Loc.isInvalid())
+    return std::nullopt;
+
+  FileID FID;
+  unsigned Offset;
+  std::tie(FID, Offset) = Loc.getDecomposedLoc();
+  cached_diagnostics::Location CachedLoc;
+  CachedLoc.SLocIdx = convertFileID(FID, Loc.getManager());
+  CachedLoc.Offset = Offset;
+  return CachedLoc;
+}
+
+FullSourceLoc CachedDiagnosticSerializer::convertCachedLoc(
+    const std::optional<cached_diagnostics::Location> &CachedLoc) {
+  if (!CachedLoc)
+    return FullSourceLoc();
+
+  FileID FID = convertCachedSLocEntry(CachedLoc->SLocIdx);
+  SourceLocation Loc = SourceMgr.getComposedLoc(FID, CachedLoc->Offset);
+  return FullSourceLoc(Loc, SourceMgr);
+}
+
+std::optional<cached_diagnostics::Range>
+CachedDiagnosticSerializer::convertRange(const CharSourceRange &Range,
+                                         const SourceManager &SM) {
+  if (Range.isInvalid())
+    return std::nullopt;
+
+  cached_diagnostics::Range CachedRange;
+  CachedRange.Begin = convertLoc(FullSourceLoc(Range.getBegin(), SM));
+  CachedRange.End = convertLoc(FullSourceLoc(Range.getEnd(), SM));
+  CachedRange.IsTokenRange = Range.isTokenRange();
+  return CachedRange;
+}
+
+CharSourceRange CachedDiagnosticSerializer::convertCachedRange(
+    const std::optional<cached_diagnostics::Range> &CachedRange) {
+  if (!CachedRange)
+    return CharSourceRange();
+
+  FullSourceLoc Begin = convertCachedLoc(CachedRange->Begin);
+  FullSourceLoc End = convertCachedLoc(CachedRange->End);
+  return CharSourceRange(SourceRange(Begin, End), CachedRange->IsTokenRange);
+}
+
+cached_diagnostics::FixItHint
+CachedDiagnosticSerializer::convertFixIt(const FixItHint &FixIt,
+                                         const SourceManager &SM) {
+  cached_diagnostics::FixItHint CachedFixIt;
+  CachedFixIt.RemoveRange = convertRange(FixIt.RemoveRange, SM);
+  CachedFixIt.InsertFromRange = convertRange(FixIt.InsertFromRange, SM);
+  CachedFixIt.CodeToInsert = FixIt.CodeToInsert;
+  CachedFixIt.BeforePreviousInsertions = FixIt.BeforePreviousInsertions;
+  return CachedFixIt;
+}
+
+FixItHint CachedDiagnosticSerializer::convertCachedFixIt(
+    const cached_diagnostics::FixItHint &CachedFixIt) {
+  FixItHint FixIt;
+  FixIt.RemoveRange = convertCachedRange(CachedFixIt.RemoveRange);
+  FixIt.InsertFromRange = convertCachedRange(CachedFixIt.InsertFromRange);
+  FixIt.CodeToInsert = CachedFixIt.CodeToInsert;
+  FixIt.BeforePreviousInsertions = CachedFixIt.BeforePreviousInsertions;
+  return FixIt;
+}
+
+unsigned CachedDiagnosticSerializer::convertFileID(FileID FID,
+                                                   const SourceManager &SM) {
+  if (SM.isWrittenInScratchSpace(SM.getLocForStartOfFile(FID)))
+    return convertFileIDFromScratchSpace(FID, SM);
+
+  auto Found = FileIDToCachedSLocIdx.find(FID);
+  if (Found != FileIDToCachedSLocIdx.end())
+    return Found->second;
+
+  cached_diagnostics::SLocEntry CachedEntry;
+  const SrcMgr::SLocEntry &Entry = SM.getSLocEntry(FID);
+  if (Entry.isFile()) {
+    const SrcMgr::FileInfo &FI = Entry.getFile();
+    cached_diagnostics::SLocEntry::FileInfo CachedFI;
+    if (const FileEntry *FE = FI.getContentCache().ContentsEntry) {
+      CachedFI.Filename = FE->getName();
+    } else {
+      CachedFI.Filename = FI.getName();
+      CachedFI.Buffer = *FI.getContentCache().getBufferDataIfLoaded();
+    }
+    CachedFI.IncludeLoc = convertLoc(FullSourceLoc(FI.getIncludeLoc(), SM));
+    CachedEntry.Data = std::move(CachedFI);
+  } else {
+    const SrcMgr::ExpansionInfo &EI = Entry.getExpansion();
+    cached_diagnostics::SLocEntry::ExpansionInfo CachedEI;
+    CachedEI.Length = SM.getFileIDSize(FID);
+    CachedEI.SpellingLoc = convertLoc(FullSourceLoc(EI.getSpellingLoc(), SM));
+    CachedEI.ExpansionStartLoc =
+        convertLoc(FullSourceLoc(EI.getExpansionLocStart(), SM));
+    CachedEI.ExpansionEndLoc =
+        convertLoc(FullSourceLoc(EI.getExpansionLocEnd(), SM));
+    CachedEI.IsTokenRange = EI.isExpansionTokenRange();
+    CachedEntry.Data = std::move(CachedEI);
+  }
+
+  unsigned Idx = CachedDiags.SLocEntries.size();
+  CachedDiags.SLocEntries.push_back(std::move(CachedEntry));
+  FileIDToCachedSLocIdx[FID] = Idx;
+  return Idx;
+}
+
+unsigned CachedDiagnosticSerializer::convertFileIDFromScratchSpace(
+    FileID FID, const SourceManager &SM) {
+  // Scratch space is treated specially:
+  // 1. The scratch space buffer can get new contents as preprocessing proceeds,
+  //    so we update the \p cached_diagnostics::SLocEntry_FileInfo with the new
+  //    contents each time there's an update.
+  // 2. The allocated buffer is large (~4K) but commonly a very small part of
+  //    that is used, so we truncate it for serialization.
+
+  const SrcMgr::SLocEntry &Entry = SM.getSLocEntry(FID);
+  assert(Entry.isFile());
+  const SrcMgr::FileInfo &FI = Entry.getFile();
+  assert(FI.getIncludeLoc().isInvalid());
+  StringRef ScratchBuffer = *FI.getContentCache().getBufferDataIfLoaded();
+  // There's a '\0' between each addition in the scratch space, look for the end
+  // of actual contents using '\0\0'.
+  size_t EndIdx = ScratchBuffer.find(StringRef("\0\0", 2));
+  assert(EndIdx != StringRef::npos);
+  StringRef Contents = ScratchBuffer.substr(0, EndIdx);
+
+  unsigned Idx;
+  auto Found = FileIDToCachedSLocIdx.find(FID);
+  if (Found != FileIDToCachedSLocIdx.end()) {
+    Idx = Found->second;
+    auto &CachedFI = std::get<cached_diagnostics::SLocEntry::FileInfo>(
+        CachedDiags.SLocEntries[Idx].Data);
+    if (CachedFI.Buffer->size() != Contents.size()) {
+      CachedFI.Buffer = Contents;
+      // If a \p FileID is already associated, reset it so a new one is created
+      // for the new buffer next time it is needed.
+      if (Idx < FileIDBySlocIdx.size())
+        FileIDBySlocIdx[Idx] = FileID();
+    }
+  } else {
+    cached_diagnostics::SLocEntry CachedEntry;
+    cached_diagnostics::SLocEntry::FileInfo CachedFI;
+    CachedFI.Filename = FI.getName();
+    CachedFI.Buffer = Contents;
+    CachedEntry.Data = std::move(CachedFI);
+    Idx = CachedDiags.SLocEntries.size();
+    CachedDiags.SLocEntries.push_back(std::move(CachedEntry));
+    FileIDToCachedSLocIdx[FID] = Idx;
+  }
+  return Idx;
+}
+
+FileID CachedDiagnosticSerializer::convertCachedSLocEntry(unsigned Idx) {
+  if (Idx >= FileIDBySlocIdx.size())
+    FileIDBySlocIdx.resize(Idx + 1);
+  if (FileIDBySlocIdx[Idx].isValid())
+    return FileIDBySlocIdx[Idx];
+
+  const cached_diagnostics::SLocEntry &CachedSLocEntry =
+      CachedDiags.SLocEntries[Idx];
+  FileID FID;
+  if (std::holds_alternative<cached_diagnostics::SLocEntry::FileInfo>(
+          CachedSLocEntry.Data)) {
+    const auto &FI =
+        std::get<cached_diagnostics::SLocEntry::FileInfo>(CachedSLocEntry.Data);
+    FullSourceLoc IncludeLoc = convertCachedLoc(FI.IncludeLoc);
+    if (FI.Buffer) {
+      FID = SourceMgr.createFileID(
+          MemoryBufferRef(FI.Buffer.value(), FI.Filename), SrcMgr::C_User,
+          /*LoadedID*/ 0, /*LoadedOffset*/ 0, IncludeLoc);
+    } else {
+      auto MemBufOrErr =
+          SourceMgr.getFileManager().getBufferForFile(FI.Filename);
+      if (!MemBufOrErr)
+        report_fatal_error(
+            createFileError(FI.Filename, MemBufOrErr.getError()));
+      SmallString<128> PathBuf;
+      cantFail(Mapper.map(FI.Filename, PathBuf));
+      if (PathBuf.str() != FI.Filename) {
+        // The file path was remapped. Keep the original buffer and pass a new
+        // buffer using the remapped file path.
+        FileBuffers.push_back(std::move(*MemBufOrErr));
+        MemoryBufferRef NewBuffer(FileBuffers.back()->getBuffer(),
+                                  Saver.save(PathBuf.str()));
+        // Using \p SrcMgr::C_User as default since \p
+        // SrcMgr::CharacteristicKind is irrelevant for diagnostic consumers; if
+        // it becomes relevant we need to serialize this value as well.
+        FID =
+            SourceMgr.createFileID(NewBuffer, SrcMgr::C_User, 0, 0, IncludeLoc);
+      } else {
+        FID = SourceMgr.createFileID(std::move(*MemBufOrErr), SrcMgr::C_User, 0,
+                                     0, IncludeLoc);
+      }
+    }
+  } else {
+    const auto &EI = std::get<cached_diagnostics::SLocEntry::ExpansionInfo>(
+        CachedSLocEntry.Data);
+    FullSourceLoc SpellingLoc = convertCachedLoc(EI.SpellingLoc);
+    FullSourceLoc ExpansionStartLoc = convertCachedLoc(EI.ExpansionStartLoc);
+    FullSourceLoc ExpansionEndLoc = convertCachedLoc(EI.ExpansionEndLoc);
+    SourceLocation ExpansionLoc = SourceMgr.createExpansionLoc(
+        SpellingLoc, ExpansionStartLoc, ExpansionEndLoc, EI.Length,
+        EI.IsTokenRange);
+    FID = SourceMgr.getDecomposedLoc(ExpansionLoc).first;
+  }
+
+  assert(FID.isValid());
+  FileIDBySlocIdx[Idx] = FID;
+  return FID;
+}
+
+namespace llvm::yaml {
+template <> struct MappingTraits<cached_diagnostics::SLocEntry> {
+  static void mapping(IO &io, cached_diagnostics::SLocEntry &s) {
+    if (io.outputting()) {
+      if (std::holds_alternative<cached_diagnostics::SLocEntry::FileInfo>(
+              s.Data)) {
+        io.mapRequired(
+            "file", std::get<cached_diagnostics::SLocEntry::FileInfo>(s.Data));
+      } else {
+        io.mapRequired(
+            "expansion",
+            std::get<cached_diagnostics::SLocEntry::ExpansionInfo>(s.Data));
+      }
+    } else {
+      std::optional<cached_diagnostics::SLocEntry::FileInfo> FI;
+      io.mapOptional("file", FI);
+      if (FI) {
+        s.Data = std::move(*FI);
+      } else {
+        cached_diagnostics::SLocEntry::ExpansionInfo EI;
+        io.mapRequired("expansion", EI);
+        s.Data = std::move(EI);
+      }
+    }
+  }
+};
+
+template <> struct MappingTraits<cached_diagnostics::SLocEntry::FileInfo> {
+  static void mapping(IO &io, cached_diagnostics::SLocEntry::FileInfo &s) {
+    io.mapRequired("filename", s.Filename);
+    io.mapOptional("include_loc", s.IncludeLoc);
+    if (io.outputting()) {
+      if (s.Buffer) {
+        std::string EncodedContents = encodeBase64(s.Buffer.value());
+        io.mapRequired("buffer", EncodedContents);
+      }
+    } else {
+      std::optional<std::string> EncodedContents;
+      io.mapOptional("buffer", EncodedContents);
+      if (EncodedContents) {
+        std::vector<char> Decoded;
+        cantFail(decodeBase64(*EncodedContents, Decoded));
+        s.Buffer = StringRef(Decoded.data(), Decoded.size());
+      }
+    }
+  }
+};
+
+template <> struct MappingTraits<cached_diagnostics::SLocEntry::ExpansionInfo> {
+  static void mapping(IO &io, cached_diagnostics::SLocEntry::ExpansionInfo &s) {
+    io.mapRequired("length", s.Length);
+    io.mapOptional("spelling_loc", s.SpellingLoc);
+    io.mapOptional("expansion_start_loc", s.ExpansionStartLoc);
+    io.mapOptional("expansion_end_loc", s.ExpansionEndLoc);
+    io.mapRequired("is_token_range", s.IsTokenRange);
+  }
+};
+
+template <> struct MappingTraits<cached_diagnostics::Location> {
+  static void mapping(IO &io, cached_diagnostics::Location &s) {
+    io.mapRequired("sloc_idx", s.SLocIdx);
+    io.mapRequired("offset", s.Offset);
+  }
+};
+
+template <> struct MappingTraits<cached_diagnostics::Range> {
+  static void mapping(IO &io, cached_diagnostics::Range &s) {
+    io.mapOptional("begin", s.Begin);
+    io.mapOptional("end", s.End);
+    io.mapRequired("is_token_range", s.IsTokenRange);
+  }
+};
+
+template <> struct MappingTraits<cached_diagnostics::FixItHint> {
+  static void mapping(IO &io, cached_diagnostics::FixItHint &s) {
+    io.mapOptional("remove_range", s.RemoveRange);
+    io.mapOptional("insert_range", s.InsertFromRange);
+    io.mapOptional("code", s.CodeToInsert);
+    io.mapRequired("before_previous", s.BeforePreviousInsertions);
+  }
+};
+
+template <> struct MappingTraits<cached_diagnostics::Diagnostic> {
+  static void mapping(IO &io, cached_diagnostics::Diagnostic &s) {
+    io.mapRequired("id", s.ID);
+    io.mapRequired("level", (unsigned &)s.Level);
+    io.mapRequired("message", s.Message);
+    io.mapOptional("loc", s.Loc);
+    io.mapOptional("ranges", s.Ranges);
+    io.mapOptional("fixits", s.FixIts);
+  }
+};
+
+template <> struct MappingTraits<cached_diagnostics::Diagnostics> {
+  static void mapping(IO &io, cached_diagnostics::Diagnostics &s) {
+    io.mapRequired("sloc_entries", s.SLocEntries);
+    io.mapRequired("diagnostics", s.Diags);
+  }
+};
+} // namespace llvm::yaml
+
+LLVM_YAML_IS_SEQUENCE_VECTOR(cached_diagnostics::SLocEntry)
+LLVM_YAML_IS_SEQUENCE_VECTOR(cached_diagnostics::Diagnostic)
+LLVM_YAML_IS_SEQUENCE_VECTOR(cached_diagnostics::Range)
+LLVM_YAML_IS_SEQUENCE_VECTOR(cached_diagnostics::FixItHint)
+
+std::optional<std::string>
+CachedDiagnosticSerializer::serializeEmittedDiagnostics() {
+  if (empty())
+    return std::nullopt;
+
+  SmallString<512> Buf;
+  raw_svector_ostream OS(Buf);
+  yaml::Output YOut(OS);
+  YOut << CachedDiags;
+  StringRef YamlContents = OS.str();
+
+  // Use compression to reduce the size of the yaml output. Note that we don't
+  // need to track whether compression was used or not, see doc-comments of \p
+  // serializeEmittedDiagnostics().
+  SmallVector<uint8_t, 512> CompressedBuffer;
+  if (compression::zstd::isAvailable()) {
+    compression::zstd::compress(arrayRefFromStringRef(YamlContents),
+                                CompressedBuffer);
+
+  } else if (compression::zlib::isAvailable()) {
+    compression::zlib::compress(arrayRefFromStringRef(YamlContents),
+                                CompressedBuffer);
+  }
+  if (!CompressedBuffer.empty()) {
+    raw_svector_ostream BufOS((SmallVectorImpl<char> &)CompressedBuffer);
+    support::endian::Writer Writer(BufOS, support::little);
+    Writer.write(uint32_t(YamlContents.size()));
+    return toStringRef(CompressedBuffer).str();
+  }
+
+  return YamlContents.str();
+}
+
+Error CachedDiagnosticSerializer::deserializeCachedDiagnostics(
+    StringRef Buffer) {
+
+  StringRef YamlContents;
+  SmallVector<uint8_t, 512> UncompressedBuffer;
+  if (compression::zstd::isAvailable() || compression::zlib::isAvailable()) {
+    uint32_t UncompressedSize =
+        support::endian::read<uint32_t, llvm::support::little>(
+            Buffer.data() + Buffer.size() - sizeof(uint32_t));
+    StringRef CompressedData = Buffer.drop_back(sizeof(uint32_t));
+    if (compression::zstd::isAvailable()) {
+      if (Error E = compression::zstd::decompress(
+              arrayRefFromStringRef(CompressedData), UncompressedBuffer,
+              UncompressedSize)) {
+        return E;
+      }
+    } else {
+      if (Error E = compression::zlib::decompress(
+              arrayRefFromStringRef(CompressedData), UncompressedBuffer,
+              UncompressedSize)) {
+        return E;
+      }
+    }
+    YamlContents = toStringRef(UncompressedBuffer);
+  } else {
+    YamlContents = Buffer;
+  }
+
+  CachedDiags.clear();
+  yaml::Input YIn(YamlContents);
+  YIn >> CachedDiags;
+  if (YIn.error())
+    return createStringError(YIn.error(),
+                             "failed deserializing cached diagnostics");
+  return Error::success();
+}
+
+/// Captures diagnostics emitted during compilation while also passing them
+/// along to the original consumer.
+struct CachingDiagnosticsProcessor::DiagnosticsConsumer
+    : public DiagnosticConsumer {
+
+  CachedDiagnosticSerializer Serializer;
+  DiagnosticConsumer *OrigConsumer;
+  bool EngineOwnedOrigConsumer;
+
+  DiagnosticsConsumer(PrefixMapper &Mapper, FileManager &FileMgr,
+                      DiagnosticConsumer *OrigConsumer, bool EngineOwnedOrig)
+      : Serializer(Mapper, FileMgr), OrigConsumer(OrigConsumer),
+        EngineOwnedOrigConsumer(EngineOwnedOrig) {
+    // Using the new DiagnosticsEngine as a way to propagate converted
+    // StoredDiagnostics to the original consumer. The new DiagnosticsEngine
+    // contains the SourceManager that the SourceLocations of the converted
+    // StoredDiagnostics came from.
+    Serializer.DiagEngine.setClient(OrigConsumer, /*ShouldOwnClient*/ false);
+  }
+
+  ~DiagnosticsConsumer() {
+    if (OrigConsumer && EngineOwnedOrigConsumer)
+      delete OrigConsumer;
+  }
+
+  void clearConsumer() {
+    OrigConsumer = nullptr;
+    EngineOwnedOrigConsumer = false;
+    Serializer.DiagEngine.setClient(nullptr);
+  }
+
+  void BeginSourceFile(const LangOptions &LangOpts,
+                       const Preprocessor *PP) override {
+    return OrigConsumer->BeginSourceFile(LangOpts, PP);
+  }
+
+  void EndSourceFile() override { return OrigConsumer->EndSourceFile(); }
+
+  void finish() override { return OrigConsumer->finish(); }
+
+  void HandleDiagnostic(DiagnosticsEngine::Level Level,
+                        const Diagnostic &Info) override {
+    if (shouldCacheDiagnostic(Level, Info)) {
+      unsigned DiagIdx = Serializer.addDiag(StoredDiagnostic(Level, Info));
+      StoredDiagnostic NewDiag = Serializer.getDiag(DiagIdx);
+      // Pass the converted diagnostic to the original consumer. We do this
+      // because:
+      // 1. It ensures that the rendered diagnostics will use the same
+      // diagnostics source for both a cache miss or a cache hit.
+      // 2. If path prefixing is enabled, we'll pass locations with
+      // de-canonicalized filenames during compilation (the original diagnostic
+      // uses canonical paths).
+      assert(Serializer.DiagEngine.getClient() == OrigConsumer);
+      Serializer.DiagEngine.Report(NewDiag);
+    } else {
+      OrigConsumer->HandleDiagnostic(Level, Info);
+    }
+    // Update stats.
+    NumWarnings = OrigConsumer->getNumWarnings();
+    NumErrors = OrigConsumer->getNumErrors();
+  }
+
+  bool shouldCacheDiagnostic(DiagnosticsEngine::Level Level,
+                             const Diagnostic &Info) {
+    if (Level < DiagnosticsEngine::Note)
+      return false;
+
+#ifndef NDEBUG
+    // These are intended for caching introspection, they should not be cached.
+    // If the \p CachingDiagnosticsProcessor::DiagnosticsConsumer received one
+    // of these it means that the diagnostic was emitted in-between a normal
+    // compilation starting & finishing, which should not be happening.
+    switch (Info.getID()) {
+    case diag::remark_compile_job_cache_hit:
+    case diag::remark_compile_job_cache_miss:
+    case diag::remark_compile_job_cache_miss_result_not_found:
+    case diag::remark_compile_job_cache_backend_output_not_found:
+    case diag::remark_compile_job_cache_skipped:
+    case diag::remark_compile_job_cache_timing_backend_key_query:
+    case diag::remark_compile_job_cache_timing_backend_key_update:
+    case diag::remark_compile_job_cache_timing_backend_load:
+    case diag::remark_compile_job_cache_timing_backend_store:
+      assert(0 && "unexpected caching remark diagnostic!");
+    }
+#endif
+
+    return true;
+  }
+
+  void clear() override {
+    Serializer.clear();
+    DiagnosticConsumer::clear();
+    OrigConsumer->clear();
+  }
+
+  bool IncludeInDiagnosticCounts() const override {
+    return OrigConsumer->IncludeInDiagnosticCounts();
+  }
+};
+
+CachingDiagnosticsProcessor::CachingDiagnosticsProcessor(PrefixMapper Mapper,
+                                                         FileManager &FileMgr)
+    : Mapper(std::move(Mapper)), FileMgr(FileMgr) {}
+
+CachingDiagnosticsProcessor::~CachingDiagnosticsProcessor() = default;
+
+void CachingDiagnosticsProcessor::insertDiagConsumer(DiagnosticsEngine &Diags) {
+  assert(!DiagConsumer && "already called insertDiagConsumer?");
+  DiagConsumer.reset(new DiagnosticsConsumer(Mapper, FileMgr, Diags.getClient(),
+                                             Diags.ownsClient()));
+  Diags.takeClient().release(); // DiagnosticsConsumer accepted ownership.
+  Diags.setClient(DiagConsumer.get(), /*ShouldOwnClient*/ false);
+}
+
+void CachingDiagnosticsProcessor::removeDiagConsumer(DiagnosticsEngine &Diags) {
+  assert(DiagConsumer && "didn't call insertDiagConsumer?");
+  assert(DiagConsumer->OrigConsumer && "already called removeDiagConsumer?");
+  assert(Diags.getClient() == DiagConsumer.get());
+  Diags.setClient(DiagConsumer->OrigConsumer,
+                  /*ShouldOwnClient*/ DiagConsumer->EngineOwnedOrigConsumer);
+  DiagConsumer->clearConsumer();
+}
+
+Expected<std::optional<std::string>>
+CachingDiagnosticsProcessor::serializeEmittedDiagnostics() {
+  return DiagConsumer->Serializer.serializeEmittedDiagnostics();
+}
+
+Error CachingDiagnosticsProcessor::replayCachedDiagnostics(
+    StringRef Buffer, DiagnosticConsumer &Consumer) {
+  CachedDiagnosticSerializer Serializer(Mapper, FileMgr);
+  if (Error E = Serializer.deserializeCachedDiagnostics(Buffer))
+    return E;
+  Serializer.DiagEngine.setClient(&Consumer, /*ShouldOwnClient*/ false);
+  for (unsigned I = 0, E = Serializer.getNumDiags(); I != E; I++) {
+    Serializer.DiagEngine.Report(Serializer.getDiag(I));
+  }
+  return Error::success();
+}

--- a/clang/tools/driver/CachedDiagnostics.h
+++ b/clang/tools/driver/CachedDiagnostics.h
@@ -1,0 +1,66 @@
+//===- CachedDiagnostics.h - Serializing diagnostics for caching-*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_DRIVER_CACHEDDIAGNOSTICS_H
+#define LLVM_CLANG_TOOLS_DRIVER_CACHEDDIAGNOSTICS_H
+
+#include "clang/Basic/LLVM.h"
+#include "llvm/Support/PrefixMapper.h"
+
+namespace clang {
+class DiagnosticConsumer;
+class DiagnosticsEngine;
+class FileManager;
+
+namespace cas {
+
+class CachingDiagnosticsProcessor {
+public:
+  /// The \p Mapper is used for de-canonicalizing the paths of diagnostics
+  /// before rendering them.
+  CachingDiagnosticsProcessor(llvm::PrefixMapper Mapper, FileManager &FileMgr);
+  ~CachingDiagnosticsProcessor();
+
+  /// Insert a diagnostic consumer for capturing diagnostics before starting a
+  /// normal compilation.
+  void insertDiagConsumer(DiagnosticsEngine &Diags);
+  /// Remove the diagnostic consumer after the normal compilation finished.
+  void removeDiagConsumer(DiagnosticsEngine &Diags);
+
+  /// \returns a serialized buffer of the currently recorded diagnostics, or
+  /// \p std::nullopt if there's no diagnostic. The buffer can be passed to
+  /// \p replayCachedDiagnostics for rendering the same diagnostics.
+  ///
+  /// There is no stability guarantee for the format of the buffer, the
+  /// expectation is that the buffer will be deserialized only by the same
+  /// compiler version that produced it. The format can change without
+  /// restrictions.
+  ///
+  /// The intended use is as implementation detail of compilation caching, where
+  /// the diagnostic output is associated with a compilation cache key. A
+  /// different compiler version will create different cache keys, which ensures
+  /// that the diagnostics buffer will only be read by the same compiler that
+  /// produced it.
+  Expected<std::optional<std::string>> serializeEmittedDiagnostics();
+
+  /// Used to replay the previously cached diagnostics, after a cache hit.
+  llvm::Error replayCachedDiagnostics(StringRef Buffer,
+                                      DiagnosticConsumer &Consumer);
+
+private:
+  llvm::PrefixMapper Mapper;
+  FileManager &FileMgr;
+
+  struct DiagnosticsConsumer;
+  std::unique_ptr<DiagnosticsConsumer> DiagConsumer;
+};
+
+} // namespace cas
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_DRIVER_CACHEDDIAGNOSTICS_H

--- a/clang/unittests/Frontend/CompileJobCacheResultTest.cpp
+++ b/clang/unittests/Frontend/CompileJobCacheResultTest.cpp
@@ -46,12 +46,10 @@ TEST(CompileJobCacheResultTest, AddOutputs) {
 
   auto Obj1 = llvm::cantFail(CAS->storeFromString({}, "obj1"));
   auto Obj2 = llvm::cantFail(CAS->storeFromString({}, "obj2"));
-  auto Obj3 = llvm::cantFail(CAS->storeFromString({}, "err"));
 
   std::vector<Output> Expected = {
       Output{Obj1, OutputKind::MainOutput},
       Output{Obj2, OutputKind::Dependencies},
-      Output{Obj3, OutputKind::Stderr},
   };
 
   CompileJobCacheResult::Builder B;
@@ -65,7 +63,7 @@ TEST(CompileJobCacheResultTest, AddOutputs) {
   CompileJobResultSchema Schema(*CAS);
   ASSERT_THAT_ERROR(Schema.load(*Result).moveInto(Proxy), Succeeded());
 
-  EXPECT_EQ(Proxy->getNumOutputs(), 3u);
+  EXPECT_EQ(Proxy->getNumOutputs(), 2u);
   auto Actual = getAllOutputs(*Proxy);
 
   EXPECT_EQ(Actual, Expected);


### PR DESCRIPTION
It serializes the subset of `SourceManager` state for the diagnostic source locations (`FileID`s, macro expansions, etc.) and replays diagnostics by materializing their `SourceLocation`s; that way the diagnostic consumers have full access to the include stack, expanded macros, etc.

This allows us to only cache the diagnostic information that is essential for the compilation and ignore the various ways that diagnostics can be rendered. And since diagnostic rendering runs in the context of the "local" compilation we can also remap the canonical file paths of diagnostics to their original sources.

rdar://103448355
(cherry picked from commit 82ac92ab37023b0e8d0f555c127e1bd659cb6472)