### PR TITLE
[stable/20221013] Cherry-pick a few commits related to `llvm::None` -> `std::nullopt` migration

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -316,7 +316,7 @@ public:
     if (FileBuildID)
       return StringRef(*FileBuildID);
 
-    return NoneType();
+    return None;
   }
   void setFileBuildID(StringRef ID) { FileBuildID = std::string(ID); }
 

--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -979,7 +979,7 @@ public:
       if (Callback(StringRef(Name)))
         return StringRef(Name);
 
-    return NoneType();
+    return None;
   }
 
   /// Check if (possibly one out of many) function name matches the given
@@ -1317,7 +1317,7 @@ public:
   /// Return the name of the section this function originated from.
   Optional<StringRef> getOriginSectionName() const {
     if (!OriginSection)
-      return NoneType();
+      return None;
     return OriginSection->getName();
   }
 

--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -136,7 +136,7 @@ private:
                                          unsigned Index) const {
     const MCInst *AnnotationInst = getAnnotationInst(Inst);
     if (!AnnotationInst)
-      return NoneType();
+      return None;
 
     for (int I = AnnotationInst->getNumOperands() - 1; I >= 0; --I) {
       int64_t ImmValue = AnnotationInst->getOperand(I).getImm();
@@ -145,7 +145,7 @@ private:
       }
     }
 
-    return NoneType();
+    return None;
   }
 
 protected:
@@ -1670,7 +1670,7 @@ public:
     auto AI = AnnotationNameIndexMap.find(Name);
     if (AI != AnnotationNameIndexMap.end())
       return AI->second;
-    return NoneType();
+    return None;
   }
 
   /// Return annotation index matching the \p Name. Create a new index if the

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -1899,7 +1899,7 @@ BinaryContext::getBaseAddressForMapping(uint64_t MMapAddress,
     }
   }
 
-  return NoneType();
+  return None;
 }
 
 ErrorOr<BinarySection &> BinaryContext::getSectionForAddress(uint64_t Address) {

--- a/bolt/lib/Core/MCPlusBuilder.cpp
+++ b/bolt/lib/Core/MCPlusBuilder.cpp
@@ -135,15 +135,15 @@ bool MCPlusBuilder::isTailCall(const MCInst &Inst) const {
 
 Optional<MCLandingPad> MCPlusBuilder::getEHInfo(const MCInst &Inst) const {
   if (!isCall(Inst))
-    return NoneType();
+    return None;
   Optional<int64_t> LPSym =
       getAnnotationOpValue(Inst, MCAnnotation::kEHLandingPad);
   if (!LPSym)
-    return NoneType();
+    return None;
   Optional<int64_t> Action =
       getAnnotationOpValue(Inst, MCAnnotation::kEHAction);
   if (!Action)
-    return NoneType();
+    return None;
 
   return std::make_pair(reinterpret_cast<const MCSymbol *>(*LPSym),
                         static_cast<uint64_t>(*Action));
@@ -221,7 +221,7 @@ MCPlusBuilder::getConditionalTailCall(const MCInst &Inst) const {
   Optional<int64_t> Value =
       getAnnotationOpValue(Inst, MCAnnotation::kConditionalTailCall);
   if (!Value)
-    return NoneType();
+    return None;
   return static_cast<uint64_t>(*Value);
 }
 
@@ -243,7 +243,7 @@ bool MCPlusBuilder::unsetConditionalTailCall(MCInst &Inst) {
 Optional<uint32_t> MCPlusBuilder::getOffset(const MCInst &Inst) const {
   Optional<int64_t> Value = getAnnotationOpValue(Inst, MCAnnotation::kOffset);
   if (!Value)
-    return NoneType();
+    return None;
   return static_cast<uint32_t>(*Value);
 }
 

--- a/bolt/lib/Profile/BoltAddressTranslation.cpp
+++ b/bolt/lib/Profile/BoltAddressTranslation.cpp
@@ -263,7 +263,7 @@ BoltAddressTranslation::getFallthroughsInTrace(uint64_t FuncAddress,
 
   auto Iter = Maps.find(FuncAddress);
   if (Iter == Maps.end())
-    return NoneType();
+    return None;
 
   const MapTy &Map = Iter->second;
   auto FromIter = Map.upper_bound(From);

--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -943,7 +943,7 @@ DataAggregator::getFallthroughsInTrace(BinaryFunction &BF,
   SmallVector<std::pair<uint64_t, uint64_t>, 16> Res;
 
   if (!recordTrace(BF, FirstLBR, SecondLBR, Count, &Res))
-    return NoneType();
+    return None;
 
   return Res;
 }
@@ -1820,13 +1820,13 @@ Optional<int32_t> DataAggregator::parseCommExecEvent() {
   if (LineEnd == StringRef::npos) {
     reportError("expected rest of line");
     Diag << "Found: " << ParsingBuf << "\n";
-    return NoneType();
+    return None;
   }
   StringRef Line = ParsingBuf.substr(0, LineEnd);
 
   size_t Pos = Line.find("PERF_RECORD_COMM exec");
   if (Pos == StringRef::npos)
-    return NoneType();
+    return None;
   Line = Line.drop_front(Pos);
 
   // Line:
@@ -1836,7 +1836,7 @@ Optional<int32_t> DataAggregator::parseCommExecEvent() {
   if (PIDStr.getAsInteger(10, PID)) {
     reportError("expected PID");
     Diag << "Found: " << PIDStr << "in '" << Line << "'\n";
-    return NoneType();
+    return None;
   }
 
   return PID;
@@ -1850,7 +1850,7 @@ Optional<uint64_t> parsePerfTime(const StringRef TimeStr) {
   uint64_t USecTime;
   if (SecTimeStr.getAsInteger(10, SecTime) ||
       USecTimeStr.getAsInteger(10, USecTime))
-    return NoneType();
+    return None;
   return SecTime * 1000000ULL + USecTime;
 }
 }
@@ -1863,14 +1863,14 @@ Optional<DataAggregator::ForkInfo> DataAggregator::parseForkEvent() {
   if (LineEnd == StringRef::npos) {
     reportError("expected rest of line");
     Diag << "Found: " << ParsingBuf << "\n";
-    return NoneType();
+    return None;
   }
   StringRef Line = ParsingBuf.substr(0, LineEnd);
 
   size_t Pos = Line.find("PERF_RECORD_FORK");
   if (Pos == StringRef::npos) {
     consumeRestOfLine();
-    return NoneType();
+    return None;
   }
 
   ForkInfo FI;
@@ -1889,14 +1889,14 @@ Optional<DataAggregator::ForkInfo> DataAggregator::parseForkEvent() {
   if (ChildPIDStr.getAsInteger(10, FI.ChildPID)) {
     reportError("expected PID");
     Diag << "Found: " << ChildPIDStr << "in '" << Line << "'\n";
-    return NoneType();
+    return None;
   }
 
   const StringRef ParentPIDStr = Line.rsplit('(').second.split(':').first;
   if (ParentPIDStr.getAsInteger(10, FI.ParentPID)) {
     reportError("expected PID");
     Diag << "Found: " << ParentPIDStr << "in '" << Line << "'\n";
-    return NoneType();
+    return None;
   }
 
   consumeRestOfLine();
@@ -2147,17 +2147,17 @@ DataAggregator::parseNameBuildIDPair() {
 
   ErrorOr<StringRef> BuildIDStr = parseString(FieldSeparator, true);
   if (std::error_code EC = BuildIDStr.getError())
-    return NoneType();
+    return None;
 
   // If one of the strings is missing, don't issue a parsing error, but still
   // do not return a value.
   consumeAllRemainingFS();
   if (checkNewLine())
-    return NoneType();
+    return None;
 
   ErrorOr<StringRef> NameStr = parseString(FieldSeparator, true);
   if (std::error_code EC = NameStr.getError())
-    return NoneType();
+    return None;
 
   consumeRestOfLine();
   return std::make_pair(NameStr.get(), BuildIDStr.get());
@@ -2205,7 +2205,7 @@ DataAggregator::getFileNameForBuildID(StringRef FileBuildID) {
   if (!FileName.empty())
     return FileName;
 
-  return NoneType();
+  return None;
 }
 
 std::error_code

--- a/bolt/lib/Profile/DataReader.cpp
+++ b/bolt/lib/Profile/DataReader.cpp
@@ -49,7 +49,7 @@ Optional<StringRef> getLTOCommonName(const StringRef Name) {
     return Name.substr(0, LTOSuffixPos + 11);
   if ((LTOSuffixPos = Name.find(".llvm.")) != StringRef::npos)
     return Name.substr(0, LTOSuffixPos + 6);
-  return NoneType();
+  return None;
 }
 
 namespace {

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -673,7 +673,7 @@ void RewriteInstance::parseBuildID() {
 
 Optional<std::string> RewriteInstance::getPrintableBuildID() const {
   if (BuildID.empty())
-    return NoneType();
+    return None;
 
   std::string Str;
   raw_string_ostream OS(Str);
@@ -4741,7 +4741,7 @@ void RewriteInstance::updateELFSymbolTable(
     assert(SymbolName && "cannot get symbol name");
 
     auto updateSymbolValue = [&](const StringRef Name,
-                                 Optional<uint64_t> Value = NoneType()) {
+                                 Optional<uint64_t> Value = None) {
       NewSymbol.st_value = Value ? *Value : getNewValueForSymbol(Name);
       NewSymbol.st_shndx = ELF::SHN_ABS;
       outs() << "BOLT-INFO: setting " << Name << " to 0x"

--- a/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
+++ b/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
@@ -2600,7 +2600,7 @@ public:
     if (FKI.Flags & MCFixupKindInfo::FKF_IsPCRel) {
       switch (FKI.TargetSize) {
       default:
-        return NoneType();
+        return None;
       case  8: RelType = ELF::R_X86_64_PC8; break;
       case 16: RelType = ELF::R_X86_64_PC16; break;
       case 32: RelType = ELF::R_X86_64_PC32; break;
@@ -2609,7 +2609,7 @@ public:
     } else {
       switch (FKI.TargetSize) {
       default:
-        return NoneType();
+        return None;
       case  8: RelType = ELF::R_X86_64_8; break;
       case 16: RelType = ELF::R_X86_64_16; break;
       case 32: RelType = ELF::R_X86_64_32; break;

--- a/bolt/lib/Utils/Utils.cpp
+++ b/bolt/lib/Utils/Utils.cpp
@@ -69,7 +69,7 @@ std::string getUnescapedName(const StringRef &Name) {
 Optional<uint8_t> readDWARFExpressionTargetReg(StringRef ExprBytes) {
   uint8_t Opcode = ExprBytes[0];
   if (Opcode == dwarf::DW_CFA_def_cfa_expression)
-    return NoneType();
+    return None;
   assert((Opcode == dwarf::DW_CFA_expression ||
           Opcode == dwarf::DW_CFA_val_expression) &&
          "invalid DWARF expression CFI");

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -69,7 +69,7 @@ llvm::Optional<std::string> tryParseProfile(StringRef Profile) {
   SmallVector<StringRef, 3> Parts;
   Profile.split(Parts, "_");
   if (Parts.size() != 3)
-    return NoneType();
+    return None;
 
   Triple::EnvironmentType Kind =
       StringSwitch<Triple::EnvironmentType>(Parts[0])
@@ -84,17 +84,17 @@ llvm::Optional<std::string> tryParseProfile(StringRef Profile) {
           .Case("as", Triple::EnvironmentType::Amplification)
           .Default(Triple::EnvironmentType::UnknownEnvironment);
   if (Kind == Triple::EnvironmentType::UnknownEnvironment)
-    return NoneType();
+    return None;
 
   unsigned long long Major = 0;
   if (llvm::getAsUnsignedInteger(Parts[1], 0, Major))
-    return NoneType();
+    return None;
 
   unsigned long long Minor = 0;
   if (Parts[2] == "x" && Kind == Triple::EnvironmentType::Library)
     Minor = OfflineLibMinor;
   else if (llvm::getAsUnsignedInteger(Parts[2], 0, Minor))
-    return NoneType();
+    return None;
 
   // dxil-unknown-shadermodel-hull
   llvm::Triple T;
@@ -105,7 +105,7 @@ llvm::Optional<std::string> tryParseProfile(StringRef Profile) {
   if (isLegalShaderModel(T))
     return T.getTriple();
   else
-    return NoneType();
+    return None;
 }
 
 bool isLegalValidatorVersion(StringRef ValVersionStr, const Driver &D) {

--- a/lldb/source/Plugins/ExpressionParser/Clang/CppModuleConfiguration.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/CppModuleConfiguration.cpp
@@ -50,10 +50,10 @@ getTargetIncludePaths(const llvm::Triple &triple) {
 static llvm::Optional<llvm::StringRef>
 guessIncludePath(llvm::StringRef path_to_file, llvm::StringRef pattern) {
   if (pattern.empty())
-    return llvm::NoneType();
+    return llvm::None;
   size_t pos = path_to_file.find(pattern);
   if (pos == llvm::StringRef::npos)
-    return llvm::NoneType();
+    return llvm::None;
 
   return path_to_file.substr(0, pos + pattern.size());
 }

--- a/llvm/include/llvm/ADT/None.h
+++ b/llvm/include/llvm/ADT/None.h
@@ -19,8 +19,7 @@
 namespace llvm {
 /// A simple null object to allow implicit construction of Optional<T>
 /// and similar types without having to spell out the specialization's name.
-// (constant value 1 in an attempt to workaround MSVC build issue... )
-enum class NoneType { None = 1 };
+enum class NoneType { None };
 const NoneType None = NoneType::None;
 }
 

--- a/llvm/include/llvm/ADT/None.h
+++ b/llvm/include/llvm/ADT/None.h
@@ -16,11 +16,13 @@
 #ifndef LLVM_ADT_NONE_H
 #define LLVM_ADT_NONE_H
 
+#include <optional>
+
 namespace llvm {
 /// A simple null object to allow implicit construction of Optional<T>
 /// and similar types without having to spell out the specialization's name.
-enum class NoneType { None };
-const NoneType None = NoneType::None;
+using NoneType = std::nullopt_t;
+inline constexpr std::nullopt_t None = std::nullopt;
 }
 
 #endif

--- a/llvm/include/llvm/Analysis/InlineAdvisor.h
+++ b/llvm/include/llvm/Analysis/InlineAdvisor.h
@@ -200,7 +200,7 @@ public:
 
 protected:
   InlineAdvisor(Module &M, FunctionAnalysisManager &FAM,
-                Optional<InlineContext> IC = NoneType::None);
+                Optional<InlineContext> IC = llvm::None);
   virtual std::unique_ptr<InlineAdvice> getAdviceImpl(CallBase &CB) = 0;
   virtual std::unique_ptr<InlineAdvice> getMandatoryAdvice(CallBase &CB,
                                                            bool Advice);

--- a/llvm/include/llvm/Analysis/ObjCARCAnalysisUtils.h
+++ b/llvm/include/llvm/Analysis/ObjCARCAnalysisUtils.h
@@ -240,9 +240,9 @@ class ARCMDKindCache {
 public:
   void init(Module *Mod) {
     M = Mod;
-    ImpreciseReleaseMDKind = NoneType::None;
-    CopyOnEscapeMDKind = NoneType::None;
-    NoObjCARCExceptionsMDKind = NoneType::None;
+    ImpreciseReleaseMDKind = llvm::None;
+    CopyOnEscapeMDKind = llvm::None;
+    NoObjCARCExceptionsMDKind = llvm::None;
   }
 
   unsigned get(ARCMDKindID ID) {

--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -3705,8 +3705,7 @@ public:
 
   DebugVariable(const DILocalVariable *Var, const DIExpression *DIExpr,
                 const DILocation *InlinedAt)
-      : Variable(Var),
-        Fragment(DIExpr ? DIExpr->getFragmentInfo() : NoneType()),
+      : Variable(Var), Fragment(DIExpr ? DIExpr->getFragmentInfo() : None),
         InlinedAt(InlinedAt) {}
 
   const DILocalVariable *getVariable() const { return Variable; }
@@ -3737,7 +3736,7 @@ template <> struct DenseMapInfo<DebugVariable> {
 
   /// Empty key: no key should be generated that has no DILocalVariable.
   static inline DebugVariable getEmptyKey() {
-    return DebugVariable(nullptr, NoneType(), nullptr);
+    return DebugVariable(nullptr, None, nullptr);
   }
 
   /// Difference in tombstone is that the Optional is meaningful.

--- a/llvm/lib/CodeGen/RemoveRedundantDebugValues.cpp
+++ b/llvm/lib/CodeGen/RemoveRedundantDebugValues.cpp
@@ -89,7 +89,7 @@ static bool reduceDbgValsForwardScan(MachineBasicBlock &MBB) {
 
   for (auto &MI : MBB) {
     if (MI.isDebugValue()) {
-      DebugVariable Var(MI.getDebugVariable(), NoneType(),
+      DebugVariable Var(MI.getDebugVariable(), None,
                         MI.getDebugLoc()->getInlinedAt());
       auto VMI = VariableMap.find(Var);
       // Just stop tracking this variable, until we cover DBG_VALUE_LIST.

--- a/llvm/lib/Transforms/Utils/BasicBlockUtils.cpp
+++ b/llvm/lib/Transforms/Utils/BasicBlockUtils.cpp
@@ -416,8 +416,7 @@ static bool removeRedundantDbgInstrsUsingForwardScan(BasicBlock *BB) {
       VariableMap;
   for (auto &I : *BB) {
     if (DbgValueInst *DVI = dyn_cast<DbgValueInst>(&I)) {
-      DebugVariable Key(DVI->getVariable(),
-                        NoneType(),
+      DebugVariable Key(DVI->getVariable(), None,
                         DVI->getDebugLoc()->getInlinedAt());
       auto VMI = VariableMap.find(Key);
       // Update the map if we found a new value/expression describing the

--- a/llvm/unittests/DebugInfo/DWARF/DWARFExpressionCopyBytesTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFExpressionCopyBytesTest.cpp
@@ -159,7 +159,7 @@ void DWARFExpressionCopyBytesTest::parseCFIsAndCheckExpression(
         return Instr;
       }
     }
-    return NoneType();
+    return None;
   };
 
   std::unique_ptr<DWARFContext> Ctx = DWARFContext::create(E);

--- a/llvm/unittests/IR/MetadataTest.cpp
+++ b/llvm/unittests/IR/MetadataTest.cpp
@@ -3611,9 +3611,9 @@ TEST_F(DebugVariableTest, DenseMap) {
   DILocalVariable *VarB =
       DILocalVariable::get(Context, Scope, "B", File, 7, Type, 3, Flags, 8, nullptr);
 
-  DebugVariable DebugVariableA(VarA, NoneType(), nullptr);
-  DebugVariable DebugVariableInlineA(VarA, NoneType(), InlinedLoc);
-  DebugVariable DebugVariableB(VarB, NoneType(), nullptr);
+  DebugVariable DebugVariableA(VarA, None, nullptr);
+  DebugVariable DebugVariableInlineA(VarA, None, InlinedLoc);
+  DebugVariable DebugVariableB(VarB, None, nullptr);
   DebugVariable DebugVariableFragB(VarB, {{16, 16}}, nullptr);
 
   DebugVariableMap.insert({DebugVariableA, 2});

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -237,12 +237,12 @@ static ParseResult parseScheduleClause(
       if (parser.parseOperand(*chunkSize) || parser.parseColonType(chunkType))
         return failure();
     } else {
-      chunkSize = llvm::NoneType::None;
+      chunkSize = llvm::None;
     }
     break;
   case ClauseScheduleKind::Auto:
   case ClauseScheduleKind::Runtime:
-    chunkSize = llvm::NoneType::None;
+    chunkSize = llvm::None;
   }
 
   // If there is a comma, we have one or more modifiers..


### PR DESCRIPTION
This is the subset of commits to get `using NoneType = std::nullopt_t;` so that we can cherry-pick commits that use `std::nullopt_t` without needing to make divergent changes in the stable branch.