### PR TITLE
[lldb] allow modules with compiler errors in scratch contexts

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1940,6 +1940,13 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   // This is a scratch AST context, mark it as such.
   swift_ast_sp->m_is_scratch_context = true;
 
+  // When loading Swift types that conform to ObjC protocols that have
+  // been renamed with NS_SWIFT_NAME the DwarfImporterDelegate will crash
+  // during protocol conformance checks as the underlying type cannot be
+  // found. Allowing module compilation to proceed with compiler
+  // errors will prevent crashing, instead we will have empty type info
+  // for the protocol conforming types.
+  swift_ast_sp->GetLanguageOptions().AllowModuleWithCompilerErrors = true;
   swift_ast_sp->GetLanguageOptions().EnableTargetOSChecking = false;
   swift_ast_sp->GetLanguageOptions().EnableCXXInterop =
       target.GetSwiftEnableCxxInterop();


### PR DESCRIPTION
When constructing Swift scratch contexts, allow module compiler errors. This avoids crashing the debugger when inspecting types with the DwarfImporterDelegate that conform to protocols that have been renamed with `NS_SWIFT_NAME`. The name mapping logic occurs during clang module loading, so if we are using the DWARF instead for ObjC types we will not have the tables to be able to remap the protocol names.