### PR TITLE
[clangd] Wait for stdlib indexing to finish before destroying the index

### DIFF
--- a/clang-tools-extra/clangd/ClangdServer.cpp
+++ b/clang-tools-extra/clangd/ClangdServer.cpp
@@ -233,6 +233,9 @@ ClangdServer::ClangdServer(const GlobalCompilationDatabase &CDB,
 }
 
 ClangdServer::~ClangdServer() {
+  // Wait for stdlib indexing to finish.
+  if (IndexTasks)
+    IndexTasks->wait();
   // Destroying TUScheduler first shuts down request threads that might
   // otherwise access members concurrently.
   // (Nobody can be using TUScheduler because we're on the main thread).


### PR DESCRIPTION
This will need to be fixed upstream, but temporarily fix on stable/20221013 to get LSP tests passing.