### PR TITLE
[depscand] Always use a timeout in depscan daemon

### DIFF
--- a/clang/tools/driver/cc1depscanProtocol.cpp
+++ b/clang/tools/driver/cc1depscanProtocol.cpp
@@ -252,7 +252,7 @@ ScanDaemon::constructAndShakeHands(StringRef BasePath, const char *Arg0,
 }
 
 Expected<ScanDaemon> ScanDaemon::connectToDaemonAndShakeHands(StringRef Path) {
-  auto Daemon = ScanDaemon::connectToExistingDaemon(Path);
+  auto Daemon = ScanDaemon::connectToDaemon(Path, /*ShouldWait=*/true);
   if (!Daemon)
     return Daemon.takeError();
 


### PR DESCRIPTION
To avoid leaking daemon, there should always be a daemon for the clang depscan daemon. For the server launch mode, use a very long timeout in case the shutdown command was not issued. For single command mode, run the server in the thread and still use a timeout in case the one command it waits for never issued.

rdar://103519851