### PR TITLE
[lldb] Replace use of llvm::None with std::nullopt in REPL.cpp

### DIFF
--- a/lldb/source/Expression/REPL.cpp
+++ b/lldb/source/Expression/REPL.cpp
@@ -335,7 +335,7 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
       expr_options.SetStopOthers(false);
 
       // Don't time out REPL expressions.
-      expr_options.SetTimeout(llvm::None);
+      expr_options.SetTimeout(std::nullopt);
 
       expr_options.SetLanguage(GetLanguage());
 


### PR DESCRIPTION
Fixes the lldb build on next.