### PR TITLE
[clang/cas] Streamline and simplify the depscan daemon

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -43,6 +43,8 @@ def err_clang_cache_cannot_find_binary: Error<
   "clang-cache cannot find compiler binary %0">;
 def err_clang_cache_missing_compiler_command: Error<
   "missing compiler command for clang-cache">;
+def err_clang_cache_scanserve_missing_args: Error<
+  "missing arguments for dep-scanning server mode">;
 def err_caching_backend_fail: Error<
   "caching backend error: %0">, DefaultFatal;
 def err_caching_output_non_deterministic: Error<

--- a/clang/test/CAS/daemon-cwd.c
+++ b/clang/test/CAS/daemon-cwd.c
@@ -4,15 +4,19 @@
 
 // RUN: rm -rf %t && mkdir -p %t/include
 // RUN: cp %S/Inputs/test.h %t/include
-// RUN: %clang -cc1depscand -start %{clang-daemon-dir}/daemon-cwd -cas-args -fcas-path %t/cas -faction-cache-path %t/cache
-// RUN: (cd %t && %clang -target x86_64-apple-macos11 -fdepscan=daemon    \
+// RUN: echo "#!/bin/sh" >> %t/cmd.sh
+// RUN: echo cd %t >> %t/cmd.sh
+// RUN: echo %clang -target x86_64-apple-macos11 -fdepscan=daemon         \
 // RUN:    -fdepscan-prefix-map=%S=/^source                               \
 // RUN:    -fdepscan-prefix-map=%t=/^build                                \
 // RUN:    -fdepscan-prefix-map-toolchain=/^toolchain                     \
-// RUN:    -fdepscan-daemon=%{clang-daemon-dir}/daemon-cwd                \
+// RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t               \
 // RUN:    -MD -MF %t/test.d -Iinclude                                    \
-// RUN:    -fsyntax-only -x c %s)
-// RUN: %clang -cc1depscand -shutdown %{clang-daemon-dir}/daemon-cwd
+// RUN:    -fsyntax-only -x c %s >> %t/cmd.sh
+// RUN: chmod +x %t/cmd.sh
+
+// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas -faction-cache-path %t/cache -- \
+// RUN:   %t/cmd.sh
 // RUN: (cd %t && %clang -target x86_64-apple-macos11 -MD -MF %t/test2.d  \
 // RUN:    -Iinclude -fsyntax-only -x c %s)
 // RUN: diff %t/test.d %t/test2.d

--- a/clang/test/CAS/depscan-include-tree-daemon.c
+++ b/clang/test/CAS/depscan-include-tree-daemon.c
@@ -3,12 +3,12 @@
 // RUN: split-file %s %t
 
 // RUN: %clang -cc1depscan -o %t/inline.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args -cc1 -triple x86_64-apple-macos11.0 \
-// RUN:     -fsyntax-only %t/t.c -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -DSOME_MACRO -dependency-file %t/inline.d -MT deps
+// RUN:     -fsyntax-only %t/t.c -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -faction-cache-path %t/cache -DSOME_MACRO -dependency-file %t/inline.d -MT deps
 
-// RUN: %clang -cc1depscand -start %{clang-daemon-dir}/depscan-include-tree-daemon -cas-args -fcas-path %t/cas -faction-cache-path %t/cache
-// RUN: %clang -cc1depscan -o %t/daemon.rsp -fdepscan=daemon -fdepscan-include-tree -cc1-args -cc1 -triple x86_64-apple-macos11.0 \
+// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fdepscan-include-tree -fcas-path %t/cas -faction-cache-path %t/cache -- \
+// RUN:   %clang -cc1depscan -o %t/daemon.rsp -fdepscan=daemon -fdepscan-daemon=%{clang-daemon-dir}/%basename_t -fdepscan-include-tree \
+// RUN:     -cc1-args -cc1 -triple x86_64-apple-macos11.0 \
 // RUN:     -fsyntax-only %t/t.c -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -DSOME_MACRO -dependency-file %t/daemon.d -MT deps
-// RUN: %clang -cc1depscand -shutdown %{clang-daemon-dir}/depscan-include-tree-daemon
 
 // RUN: diff -u %t/inline.rsp %t/daemon.rsp
 // RUN: diff -u %t/inline.d %t/daemon.d

--- a/clang/test/CAS/depscan-prefix-map.c
+++ b/clang/test/CAS/depscan-prefix-map.c
@@ -30,7 +30,9 @@
 // RUN:              -working-directory %t.d                              \
 // RUN:              -fcas-path %t.d/cas                                  \
 // RUN: | FileCheck %s -DPREFIX=%t.d
+// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t.d/cas -- \
 // RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon    \
+// RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t               \
 // RUN:    -fdepscan-prefix-map=%S=/^source                               \
 // RUN:    -fdepscan-prefix-map=%t.d=/^testdir                            \
 // RUN:    -fdepscan-prefix-map=%{objroot}=/^objroot                      \
@@ -61,19 +63,25 @@
 // CHECK-ROOT-NEXT: file {{.*}} /^source/depscan-prefix-map.c{{$}}
 // CHECK-ROOT-NEXT: file {{.*}} /^toolchain/usr/lib/clang/1000/include/stdarg.h{{$}}
 
-// RUN: not %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon    \
+// RUN: not %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t.d/cas -- \
+// RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon        \
+// RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t                   \
 // RUN:    -fdepscan-prefix-map=/=/^foo                                       \
 // RUN:    -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %t.d/out.o     \
 // RUN: 2>&1 | FileCheck %s -DPREFIX=%t.d -check-prefix=ERROR_ROOT
 // ERROR_ROOT: invalid prefix map: '/=/^foo'
 
-// RUN: not %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon    \
+// RUN: not %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t.d/cas -- \
+// RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon        \
+// RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t                   \
 // RUN:    -fdepscan-prefix-map==/^foo                                        \
 // RUN:    -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %t.d/out.o     \
 // RUN: 2>&1 | FileCheck %s -DPREFIX=%t.d -check-prefix=ERROR_EMPTY
 // ERROR_EMPTY: invalid prefix map: '=/^foo'
 
-// RUN: not %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon    \
+// RUN: not %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t.d/cas -- \
+// RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon        \
+// RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t                   \
 // RUN:    -fdepscan-prefix-map=relative=/^foo                                \
 // RUN:    -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %t.d/out.o     \
 // RUN: 2>&1 | FileCheck %s -DPREFIX=%t.d -check-prefix=ERROR_RELATIVE

--- a/clang/test/CAS/depscan-with-error.c
+++ b/clang/test/CAS/depscan-with-error.c
@@ -11,7 +11,8 @@
 // RUN: not env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t.o -Wl,-none --serialize-diagnostics %t/t2.diag \
 // RUN:   2>&1 | FileCheck %s -check-prefix=ERROR -check-prefix=DRIVER
-// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache \
+// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas/cas -faction-cache-path %t/cas/cache -- \
+// RUN: %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t.o -Wl,-none --serialize-diagnostics %t/t3.diag \
 // RUN:   2>&1 | FileCheck %s -check-prefix=ERROR -check-prefix=DRIVER
 
@@ -27,7 +28,8 @@
 // RUN: echo "int y;" > %t/b.c
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %t/a.c -o %t.o --serialize-diagnostics %t/t2.diag
-// RUN: env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas/cas -faction-cache-path %t/cas/cache -- \
+// RUN: %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %t/b.c -o %t.o --serialize-diagnostics %t/t3.diag
 
 // RUN: c-index-test -read-diagnostics %t/t2.diag 2>&1 | FileCheck %s -check-prefix=SERIAL
@@ -47,7 +49,8 @@
 // RUN: not env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t.o -fdiagnostics-color=always -fansi-escape-codes \
 // RUN:   2>&1 | FileCheck %s -check-prefix=COLOR-DIAG
-// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache \
+// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas/cas -faction-cache-path %t/cas/cache -- \
+// RUN: %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t.o -fdiagnostics-color=always -fansi-escape-codes \
 // RUN:   2>&1 | FileCheck %s -check-prefix=COLOR-DIAG
 // COLOR-DIAG: [[RED:.\[0;1;31m]]fatal error: [[RESET:.\[0m]]

--- a/clang/test/CAS/depscan.c
+++ b/clang/test/CAS/depscan.c
@@ -6,7 +6,9 @@
 //
 // Check that inline/daemon have identical output.
 // RUN: %clang -cc1depscan -o %t/inline.rsp -fdepscan=inline -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %s.o -MT %s.o -dependency-file %t/inline.d -fcas-path %t/cas
-// RUN: %clang -cc1depscan -o %t/daemon.rsp -fdepscan=daemon -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %s.o -MT %s.o -dependency-file %t/daemon.d -fcas-path %t/cas
+// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas -- \
+// RUN:   %clang -cc1depscan -o %t/daemon.rsp -fdepscan=daemon -fdepscan-daemon=%{clang-daemon-dir}/%basename_t -cc1-args \
+// RUN:     -triple x86_64-apple-macos11.0 -x c %s -o %s.o -MT %s.o -dependency-file %t/daemon.d -fcas-path %t/cas
 // RUN: diff %t/inline.rsp %t/daemon.rsp
 // RUN: diff %t/inline.d %t/daemon.d
 

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -31,6 +31,13 @@
 // SESSION: "-fcas-path" "[[PREFIX]]/cas/cas" "-faction-cache-path" "[[PREFIX]]/cas/actioncache" "-fcas-token-cache"
 // SESSION: "-greproducible"
 
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_SCAN_DAEMON_SOCKET_PATH=%t/scand cache-build-session %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=SPECIFIC-DAEMON -DPREFIX=%t
+// SPECIFIC-DAEMON-NOT: "-fdepscan-share-identifier"
+// SPECIFIC-DAEMON: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-daemon=[[PREFIX]]/scand"
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH=%t/ccremote %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=REMOTE -DPREFIX=%t
+// REMOTE: "-fcompilation-caching-service-path" "[[PREFIX]]/ccremote"
+
 // Using multi-arch invocation.
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang -target x86_64-apple-macos12 -arch x86_64 -arch arm64 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=MULTIARCH
 // MULTIARCH: "-cc1depscan" "-fdepscan=auto"

--- a/clang/test/CAS/fdepscan-daemon.c
+++ b/clang/test/CAS/fdepscan-daemon.c
@@ -3,10 +3,9 @@
 // REQUIRES: system-darwin, clang-cc1daemon
 
 // RUN: rm -rf %t
-// RUN: %clang -cc1depscand -start %{clang-daemon-dir}/fdepscan-daemon -cas-args -fcas-path %t/cas -faction-cache-path %t/cache
-// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs \
-// RUN:   -fdepscan=daemon -fdepscan-daemon=%{clang-daemon-dir}/fdepscan-daemon -fsyntax-only -x c %s
-// RUN: %clang -cc1depscand -shutdown %{clang-daemon-dir}/fdepscan-daemon
+// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas -faction-cache-path %t/cache -- \
+// RUN:   %clang -target x86_64-apple-macos11 -I %S/Inputs \
+// RUN:     -fdepscan=daemon -fdepscan-daemon=%{clang-daemon-dir}/%basename_t -fsyntax-only -x c %s
 
 #include "test.h"
 

--- a/clang/test/CAS/fdepscan.c
+++ b/clang/test/CAS/fdepscan.c
@@ -3,7 +3,8 @@
 // REQUIRES: system-darwin, clang-cc1daemon
 
 // RUN: rm -rf %t-*.d %t.cas
-// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=daemon \
+// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas -- \
+// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=daemon -fdepscan-daemon=%{clang-daemon-dir}/%basename_t \
 // RUN:   -E -MD -MF %t-daemon.d -x c %s -Xclang -fcas-path -Xclang %t.cas >/dev/null
 // RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=inline \
 // RUN:   -E -MD -MF %t-inline.d -x c %s -Xclang -fcas-path -Xclang %t.cas >/dev/null

--- a/clang/test/CAS/lit.local.cfg
+++ b/clang/test/CAS/lit.local.cfg
@@ -9,12 +9,6 @@ if platform.system() == 'Windows':
 import tempfile
 config.daemon_temp_dir = tempfile.mkdtemp()
 
-# Setup environment so that all the daemons spawned from clang are in single
-# command mode and will quit once finishes its first command. If need to have
-# daemon sharing, the daemon can be launched directly or the test can be added
-# in a different directory.
-config.environment['__CLANG_TEST_CC1DEPSCAND_EXTRA_ARGS'] = '-single-command'
-
 # Feature for the temp directory path is not too long for certain tests.
 # The limit on Darwin is 104 charactors and the default spawning daemon from
 # clang will take 30 char. This will leave enough room for auto spawned daemon

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -85,6 +85,100 @@ static int executeAsProcess(ArrayRef<const char *> Args,
   return Result;
 }
 
+/// Arguments common to both \p clang-cache compiler launcher and depscan server
+/// functionalities.
+static void addCommonArgs(bool ForDriver, SmallVectorImpl<const char *> &Args,
+                          llvm::StringSaver &Saver) {
+  if (::getenv("CLANG_CACHE_ENABLE_INCLUDE_TREE")) {
+    Args.push_back("-fdepscan-include-tree");
+  }
+  if (const char *CASPath = ::getenv("LLVM_CACHE_CAS_PATH")) {
+    llvm::SmallString<256> CASArg(CASPath);
+    llvm::sys::path::append(CASArg, "cas");
+    if (ForDriver) {
+      Args.append({"-Xclang", "-fcas-path", "-Xclang",
+                   Saver.save(CASArg.str()).data()});
+    } else {
+      Args.append({"-fcas-path", Saver.save(CASArg.str()).data()});
+    }
+    llvm::SmallString<256> CacheArg(CASPath);
+    llvm::sys::path::append(CacheArg, "actioncache");
+    if (ForDriver) {
+      Args.append({"-Xclang", "-faction-cache-path", "-Xclang",
+                   Saver.save(CacheArg.str()).data()});
+    } else {
+      Args.append({"-faction-cache-path", Saver.save(CacheArg.str()).data()});
+    }
+  }
+}
+
+/// Arguments specific to \p clang-cache compiler launcher functionality.
+static void addLauncherArgs(SmallVectorImpl<const char *> &Args,
+                            llvm::StringSaver &Saver) {
+  if (const char *DaemonPath =
+          ::getenv("CLANG_CACHE_SCAN_DAEMON_SOCKET_PATH")) {
+    // Instruct clang to connect to scanning daemon that is listening on the
+    // provided socket path. The caller is responsible for ensuring the daemon
+    // is compatible with the invoked clang.
+    Args.push_back("-fdepscan=daemon");
+    Args.push_back(Saver.save(Twine("-fdepscan-daemon=") + DaemonPath).data());
+  } else if (const char *SessionId = ::getenv("LLVM_CACHE_BUILD_SESSION_ID")) {
+    // `LLVM_CACHE_BUILD_SESSION_ID` enables sharing of a depscan daemon
+    // using the string it is set to. The clang invocations under the same
+    // `LLVM_CACHE_BUILD_SESSION_ID` will launch and re-use the same daemon.
+    //
+    // This is a scheme where we are still launching daemons on-demand,
+    // instead of a scheme where we start a daemon at the beginning of the
+    // "build session" for all clang invocations to connect to.
+    // Launcing daemons on-demand is preferable because it allows having mixed
+    // toolchains, with different clang versions, running under the same
+    // `LLVM_CACHE_BUILD_SESSION_ID`; in such a case there will be one daemon
+    // started and shared for each unique clang version.
+    Args.append({"-fdepscan=daemon", "-fdepscan-share-identifier", SessionId});
+  } else {
+    Args.push_back("-fdepscan");
+  }
+
+  addCommonArgs(/*ForDriver*/ true, Args, Saver);
+
+  if (const char *PrefixMaps = ::getenv("LLVM_CACHE_PREFIX_MAPS")) {
+    Args.append({"-fdepscan-prefix-map-sdk=/^sdk",
+                 "-fdepscan-prefix-map-toolchain=/^toolchain"});
+    StringRef PrefixMap, Remaining = PrefixMaps;
+    while (true) {
+      std::tie(PrefixMap, Remaining) = Remaining.split(';');
+      if (PrefixMap.empty())
+        break;
+      Args.push_back(Saver.save("-fdepscan-prefix-map=" + PrefixMap).data());
+    }
+  }
+  if (const char *ServicePath =
+          ::getenv("LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH")) {
+    Args.append({"-Xclang", "-fcompilation-caching-service-path", "-Xclang",
+                 ServicePath});
+  }
+  Args.append({"-greproducible", "-Xclang", "-fcas-token-cache"});
+
+  if (llvm::sys::Process::GetEnv("CLANG_CACHE_REDACT_TIME_MACROS")) {
+    // Remove use of these macros to get reproducible outputs. This can
+    // accompany CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS to avoid fatal errors
+    // when the source uses these macros.
+    Args.append({"-Wno-builtin-macro-redefined", "-D__DATE__=\"redacted\"",
+                 "-D__TIMESTAMP__=\"redacted\"", "-D__TIME__=\"redacted\""});
+  }
+  if (llvm::sys::Process::GetEnv(
+          "CLANG_CACHE_CHECK_REPRODUCIBLE_CACHING_ISSUES")) {
+    Args.append({"-Werror=reproducible-caching"});
+  }
+}
+
+static void addScanServerArgs(const char *SocketPath,
+                              SmallVectorImpl<const char *> &Args,
+                              llvm::StringSaver &Saver) {
+  Args.append({"-cc1depscand", "-serve", SocketPath, "-cas-args"});
+  addCommonArgs(/*ForDriver*/ false, Args, Saver);
+}
+
 Optional<int>
 clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
                                   llvm::StringSaver &Saver) {
@@ -121,6 +215,20 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
   // Drop initial '/path/to/clang-cache' program name.
   Args.erase(Args.begin());
 
+  if (StringRef(Args.front()) == "-depscan-server") {
+    // Run "clang -cc1depscand -serve ..." after translating some of the
+    // environment variables that \p clang-cache understands.
+    if (Args.size() == 1) {
+      Diags.Report(diag::err_clang_cache_scanserve_missing_args);
+      return 1;
+    }
+    const char *SocketPath = Args[1];
+    Args.clear();
+    Args.push_back(clangCachePath);
+    addScanServerArgs(SocketPath, Args, Saver);
+    return std::nullopt;
+  }
+
   llvm::ErrorOr<std::string> compilerPathOrErr =
       llvm::sys::findProgramByName(Args.front());
   if (!compilerPathOrErr) {
@@ -137,65 +245,7 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
         return 1;
       return std::nullopt;
     }
-    if (const char *SessionId = ::getenv("LLVM_CACHE_BUILD_SESSION_ID")) {
-      // `LLVM_CACHE_BUILD_SESSION_ID` enables sharing of a depscan daemon
-      // using the string it is set to. The clang invocations under the same
-      // `LLVM_CACHE_BUILD_SESSION_ID` will launch and re-use the same daemon.
-      //
-      // This is a scheme where we are still launching daemons on-demand,
-      // instead of a scheme where we start a daemon at the beginning of the
-      // "build session" for all clang invocations to connect to.
-      // Launcing daemons on-demand is preferable because it allows having mixed
-      // toolchains, with different clang versions, running under the same
-      // `LLVM_CACHE_BUILD_SESSION_ID`; in such a case there will be one daemon
-      // started and shared for each unique clang version.
-      Args.append(
-          {"-fdepscan=daemon", "-fdepscan-share-identifier", SessionId});
-    } else {
-      Args.push_back("-fdepscan");
-    }
-    if (::getenv("CLANG_CACHE_ENABLE_INCLUDE_TREE")) {
-      Args.push_back("-fdepscan-include-tree");
-    }
-    if (const char *PrefixMaps = ::getenv("LLVM_CACHE_PREFIX_MAPS")) {
-      Args.append({"-fdepscan-prefix-map-sdk=/^sdk",
-                   "-fdepscan-prefix-map-toolchain=/^toolchain"});
-      StringRef PrefixMap, Remaining = PrefixMaps;
-      while (true) {
-        std::tie(PrefixMap, Remaining) = Remaining.split(';');
-        if (PrefixMap.empty())
-          break;
-        Args.push_back(Saver.save("-fdepscan-prefix-map=" + PrefixMap).data());
-      }
-    }
-    if (const char *ServicePath =
-            ::getenv("LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH")) {
-      Args.append({"-Xclang", "-fcompilation-caching-service-path", "-Xclang",
-                   ServicePath});
-    }
-    if (const char *CASPath = ::getenv("LLVM_CACHE_CAS_PATH")) {
-      llvm::SmallString<256> CASArg(CASPath);
-      llvm::sys::path::append(CASArg, "cas");
-      Args.append({"-Xclang", "-fcas-path", "-Xclang",
-                   Saver.save(CASArg.str()).data()});
-      llvm::SmallString<256> CacheArg(CASPath);
-      llvm::sys::path::append(CacheArg, "actioncache");
-      Args.append({"-Xclang", "-faction-cache-path", "-Xclang",
-                   Saver.save(CacheArg.str()).data()});
-    }
-    Args.append({"-greproducible", "-Xclang", "-fcas-token-cache"});
-
-    if (llvm::sys::Process::GetEnv("CLANG_CACHE_REDACT_TIME_MACROS")) {
-      // Remove use of these macros to get reproducible outputs. This can
-      // accompany CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS to avoid fatal errors
-      // when the source uses these macros.
-      Args.append({"-Wno-builtin-macro-redefined", "-D__DATE__=\"redacted\"",
-                   "-D__TIMESTAMP__=\"redacted\"", "-D__TIME__=\"redacted\""});
-    }
-    if (llvm::sys::Process::GetEnv(
-            "CLANG_CACHE_CHECK_REPRODUCIBLE_CACHING_ISSUES")) {
-      Args.append({"-Werror=reproducible-caching"});
-    }
+    addLauncherArgs(Args, Saver);
     if (llvm::sys::Process::GetEnv("CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS")) {
       // Run the compilation twice, without replaying, to check that we get the
       // same compilation artifacts for the same key. If they are not the same

--- a/llvm/tools/llvm-remote-cache-test/llvm-remote-cache-test.cpp
+++ b/llvm/tools/llvm-remote-cache-test/llvm-remote-cache-test.cpp
@@ -114,10 +114,9 @@ int main(int Argc, const char **Argv) {
 
   remote::RemoteCacheServer Server(SocketPath, TempPath, std::move(*CAS),
                                    std::move(*Cache));
-  std::thread ServerThread([&Server]() {
-    Server.Start();
-    Server.Listen();
-  });
+  // Make sure to start the server before executing the command.
+  Server.Start();
+  std::thread ServerThread([&Server]() { Server.Listen(); });
 
   setenv("LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH", SocketPath.c_str(), true);
 


### PR DESCRIPTION
Have 3 ways for how the daemon functions:
1. `-run`: Runs the daemon until a timeout is reached without a new connection.
2. `-serve`: Runs the daemon indefinitely.
3. `-execute`: Sets up the connection, runs a command, and quits.

With `-execute` we can have lit tests for the daemon that don't leave lingering clang processes around.

rdar://103519851