### PR TITLE
[lldb] Re-enable unknown_reference tests

### DIFF
--- a/lldb/test/API/lang/swift/unknown_reference/TestSwiftUnknownReference.py
+++ b/lldb/test/API/lang/swift/unknown_reference/TestSwiftUnknownReference.py
@@ -27,7 +27,6 @@ class TestSwiftUnknownReference(lldbtest.TestBase):
         lldbutil.check_variable(self, m_string, summary='"world"')
 
     @swiftTest
-    @skipIfDarwin # This test fails non-reproducibly in CI. rdar://100034078
     @skipUnlessFoundation
     def test_unknown_objc_ref(self):
         """Test unknown references to Objective-C objects."""


### PR DESCRIPTION
This reverts commit 76d733c06df3fafd7b666a677cb680f8d54411f1, reversing changes made to b286431e856da31704fbf2b4f6127939a9a4ae73.
