### PR TITLE
[clang/cas] Streamline and simplify the depscan daemon

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -43,6 +43,8 @@ def err_clang_cache_cannot_find_binary: Error<
   "clang-cache cannot find compiler binary %0">;
 def err_clang_cache_missing_compiler_command: Error<
   "missing compiler command for clang-cache">;
+def err_clang_cache_scanserve_missing_args: Error<
+  "missing arguments for dep-scanning server mode">;
 def err_caching_backend_fail: Error<
   "caching backend error: %0">, DefaultFatal;
 def err_caching_output_non_deterministic: Error<

--- a/clang/test/CAS/daemon-cwd.c
+++ b/clang/test/CAS/daemon-cwd.c
@@ -4,15 +4,19 @@
 
 // RUN: rm -rf %t && mkdir -p %t/include
 // RUN: cp %S/Inputs/test.h %t/include
-// RUN: %clang -cc1depscand -start %{clang-daemon-dir}/daemon-cwd -cas-args -fcas-path %t/cas -faction-cache-path %t/cache
-// RUN: (cd %t && %clang -target x86_64-apple-macos11 -fdepscan=daemon    \
+// RUN: echo "#!/bin/sh" >> %t/cmd.sh
+// RUN: echo cd %t >> %t/cmd.sh
+// RUN: echo %clang -target x86_64-apple-macos11 -fdepscan=daemon         \
 // RUN:    -fdepscan-prefix-map=%S=/^source                               \
 // RUN:    -fdepscan-prefix-map=%t=/^build                                \
 // RUN:    -fdepscan-prefix-map-toolchain=/^toolchain                     \
-// RUN:    -fdepscan-daemon=%{clang-daemon-dir}/daemon-cwd                \
+// RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t               \
 // RUN:    -MD -MF %t/test.d -Iinclude                                    \
-// RUN:    -fsyntax-only -x c %s)
-// RUN: %clang -cc1depscand -shutdown %{clang-daemon-dir}/daemon-cwd
+// RUN:    -fsyntax-only -x c %s >> %t/cmd.sh
+// RUN: chmod +x %t/cmd.sh
+
+// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas -faction-cache-path %t/cache -- \
+// RUN:   %t/cmd.sh
 // RUN: (cd %t && %clang -target x86_64-apple-macos11 -MD -MF %t/test2.d  \
 // RUN:    -Iinclude -fsyntax-only -x c %s)
 // RUN: diff %t/test.d %t/test2.d

--- a/clang/test/CAS/depscan-include-tree-daemon.c
+++ b/clang/test/CAS/depscan-include-tree-daemon.c
@@ -3,12 +3,12 @@
 // RUN: split-file %s %t
 
 // RUN: %clang -cc1depscan -o %t/inline.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args -cc1 -triple x86_64-apple-macos11.0 \
-// RUN:     -fsyntax-only %t/t.c -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -DSOME_MACRO -dependency-file %t/inline.d -MT deps
+// RUN:     -fsyntax-only %t/t.c -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -faction-cache-path %t/cache -DSOME_MACRO -dependency-file %t/inline.d -MT deps
 
-// RUN: %clang -cc1depscand -start %{clang-daemon-dir}/depscan-include-tree-daemon -cas-args -fcas-path %t/cas -faction-cache-path %t/cache
-// RUN: %clang -cc1depscan -o %t/daemon.rsp -fdepscan=daemon -fdepscan-include-tree -cc1-args -cc1 -triple x86_64-apple-macos11.0 \
+// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fdepscan-include-tree -fcas-path %t/cas -faction-cache-path %t/cache -- \
+// RUN:   %clang -cc1depscan -o %t/daemon.rsp -fdepscan=daemon -fdepscan-daemon=%{clang-daemon-dir}/%basename_t -fdepscan-include-tree \
+// RUN:     -cc1-args -cc1 -triple x86_64-apple-macos11.0 \
 // RUN:     -fsyntax-only %t/t.c -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -DSOME_MACRO -dependency-file %t/daemon.d -MT deps
-// RUN: %clang -cc1depscand -shutdown %{clang-daemon-dir}/depscan-include-tree-daemon
 
 // RUN: diff -u %t/inline.rsp %t/daemon.rsp
 // RUN: diff -u %t/inline.d %t/daemon.d

--- a/clang/test/CAS/depscan-prefix-map.c
+++ b/clang/test/CAS/depscan-prefix-map.c
@@ -30,7 +30,9 @@
 // RUN:              -working-directory %t.d                              \
 // RUN:              -fcas-path %t.d/cas                                  \
 // RUN: | FileCheck %s -DPREFIX=%t.d
+// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t.d/cas -- \
 // RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon    \
+// RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t               \
 // RUN:    -fdepscan-prefix-map=%S=/^source                               \
 // RUN:    -fdepscan-prefix-map=%t.d=/^testdir                            \
 // RUN:    -fdepscan-prefix-map=%{objroot}=/^objroot                      \
@@ -61,19 +63,25 @@
 // CHECK-ROOT-NEXT: file {{.*}} /^source/depscan-prefix-map.c{{$}}
 // CHECK-ROOT-NEXT: file {{.*}} /^toolchain/usr/lib/clang/1000/include/stdarg.h{{$}}
 
-// RUN: not %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon    \
+// RUN: not %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t.d/cas -- \
+// RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon        \
+// RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t                   \
 // RUN:    -fdepscan-prefix-map=/=/^foo                                       \
 // RUN:    -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %t.d/out.o     \
 // RUN: 2>&1 | FileCheck %s -DPREFIX=%t.d -check-prefix=ERROR_ROOT
 // ERROR_ROOT: invalid prefix map: '/=/^foo'
 
-// RUN: not %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon    \
+// RUN: not %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t.d/cas -- \
+// RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon        \
+// RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t                   \
 // RUN:    -fdepscan-prefix-map==/^foo                                        \
 // RUN:    -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %t.d/out.o     \
 // RUN: 2>&1 | FileCheck %s -DPREFIX=%t.d -check-prefix=ERROR_EMPTY
 // ERROR_EMPTY: invalid prefix map: '=/^foo'
 
-// RUN: not %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon    \
+// RUN: not %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t.d/cas -- \
+// RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon        \
+// RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t                   \
 // RUN:    -fdepscan-prefix-map=relative=/^foo                                \
 // RUN:    -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %t.d/out.o     \
 // RUN: 2>&1 | FileCheck %s -DPREFIX=%t.d -check-prefix=ERROR_RELATIVE

--- a/clang/test/CAS/depscan-with-error.c
+++ b/clang/test/CAS/depscan-with-error.c
@@ -11,7 +11,8 @@
 // RUN: not env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t.o -arch=nonexistent --serialize-diagnostics %t/t2.diag \
 // RUN:   2>&1 | FileCheck %s -check-prefix=ERROR -check-prefix=DRIVER
-// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache \
+// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas/cas -faction-cache-path %t/cas/cache -- \
+// RUN: %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t.o -arch=nonexistent --serialize-diagnostics %t/t3.diag \
 // RUN:   2>&1 | FileCheck %s -check-prefix=ERROR -check-prefix=DRIVER
 
@@ -27,7 +28,8 @@
 // RUN: echo "int y;" > %t/b.c
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %t/a.c -o %t.o --serialize-diagnostics %t/t2.diag
-// RUN: env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas/cas -faction-cache-path %t/cas/cache -- \
+// RUN: %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %t/b.c -o %t.o --serialize-diagnostics %t/t3.diag
 
 // RUN: c-index-test -read-diagnostics %t/t2.diag 2>&1 | FileCheck %s -check-prefix=SERIAL
@@ -47,7 +49,8 @@
 // RUN: not env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t.o -fdiagnostics-color=always -fansi-escape-codes \
 // RUN:   2>&1 | FileCheck %s -check-prefix=COLOR-DIAG
-// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache \
+// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas/cas -faction-cache-path %t/cas/cache -- \
+// RUN: %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t.o -fdiagnostics-color=always -fansi-escape-codes \
 // RUN:   2>&1 | FileCheck %s -check-prefix=COLOR-DIAG
 // COLOR-DIAG: [[RED:.\[0;1;31m]]fatal error: [[RESET:.\[0m]]

--- a/clang/test/CAS/depscan.c
+++ b/clang/test/CAS/depscan.c
@@ -6,7 +6,9 @@
 //
 // Check that inline/daemon have identical output.
 // RUN: %clang -cc1depscan -o %t/inline.rsp -fdepscan=inline -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %s.o -MT %s.o -dependency-file %t/inline.d -fcas-path %t/cas
-// RUN: %clang -cc1depscan -o %t/daemon.rsp -fdepscan=daemon -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %s.o -MT %s.o -dependency-file %t/daemon.d -fcas-path %t/cas
+// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas -- \
+// RUN:   %clang -cc1depscan -o %t/daemon.rsp -fdepscan=daemon -fdepscan-daemon=%{clang-daemon-dir}/%basename_t -cc1-args \
+// RUN:     -triple x86_64-apple-macos11.0 -x c %s -o %s.o -MT %s.o -dependency-file %t/daemon.d -fcas-path %t/cas
 // RUN: diff %t/inline.rsp %t/daemon.rsp
 // RUN: diff %t/inline.d %t/daemon.d
 

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -31,6 +31,13 @@
 // SESSION: "-fcas-path" "[[PREFIX]]/cas/cas" "-faction-cache-path" "[[PREFIX]]/cas/actioncache"
 // SESSION: "-greproducible"
 
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_SCAN_DAEMON_SOCKET_PATH=%t/scand cache-build-session %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=SPECIFIC-DAEMON -DPREFIX=%t
+// SPECIFIC-DAEMON-NOT: "-fdepscan-share-identifier"
+// SPECIFIC-DAEMON: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-daemon=[[PREFIX]]/scand"
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH=%t/ccremote %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=REMOTE -DPREFIX=%t
+// REMOTE: "-fcompilation-caching-service-path" "[[PREFIX]]/ccremote"
+
 // Using multi-arch invocation.
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang -target x86_64-apple-macos12 -arch x86_64 -arch arm64 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=MULTIARCH
 // MULTIARCH: "-cc1depscan" "-fdepscan=auto"

--- a/clang/test/CAS/fdepscan-daemon.c
+++ b/clang/test/CAS/fdepscan-daemon.c
@@ -3,10 +3,9 @@
 // REQUIRES: system-darwin, clang-cc1daemon
 
 // RUN: rm -rf %t
-// RUN: %clang -cc1depscand -start %{clang-daemon-dir}/fdepscan-daemon -cas-args -fcas-path %t/cas -faction-cache-path %t/cache
-// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs \
-// RUN:   -fdepscan=daemon -fdepscan-daemon=%{clang-daemon-dir}/fdepscan-daemon -fsyntax-only -x c %s
-// RUN: %clang -cc1depscand -shutdown %{clang-daemon-dir}/fdepscan-daemon
+// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas -faction-cache-path %t/cache -- \
+// RUN:   %clang -target x86_64-apple-macos11 -I %S/Inputs \
+// RUN:     -fdepscan=daemon -fdepscan-daemon=%{clang-daemon-dir}/%basename_t -fsyntax-only -x c %s
 
 #include "test.h"
 

--- a/clang/test/CAS/fdepscan.c
+++ b/clang/test/CAS/fdepscan.c
@@ -3,7 +3,8 @@
 // REQUIRES: system-darwin, clang-cc1daemon
 
 // RUN: rm -rf %t-*.d %t.cas
-// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=daemon \
+// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas -- \
+// RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=daemon -fdepscan-daemon=%{clang-daemon-dir}/%basename_t \
 // RUN:   -E -MD -MF %t-daemon.d -x c %s -Xclang -fcas-path -Xclang %t.cas >/dev/null
 // RUN: %clang -target x86_64-apple-macos11 -I %S/Inputs -fdepscan=inline \
 // RUN:   -E -MD -MF %t-inline.d -x c %s -Xclang -fcas-path -Xclang %t.cas >/dev/null

--- a/clang/test/CAS/lit.local.cfg
+++ b/clang/test/CAS/lit.local.cfg
@@ -9,12 +9,6 @@ if platform.system() == 'Windows':
 import tempfile
 config.daemon_temp_dir = tempfile.mkdtemp()
 
-# Setup environment so that all the daemons spawned from clang are in single
-# command mode and will quit once finishes its first command. If need to have
-# daemon sharing, the daemon can be launched directly or the test can be added
-# in a different directory.
-config.environment['__CLANG_TEST_CC1DEPSCAND_EXTRA_ARGS'] = '-single-command'
-
 # Feature for the temp directory path is not too long for certain tests.
 # The limit is around 100 charactors and this check will leave about 20
 # charactors to be used by individual tests.

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -82,6 +82,100 @@ static int executeAsProcess(ArrayRef<const char *> Args,
   return Result;
 }
 
+/// Arguments common to both \p clang-cache compiler launcher and depscan server
+/// functionalities.
+static void addCommonArgs(bool ForDriver, SmallVectorImpl<const char *> &Args,
+                          llvm::StringSaver &Saver) {
+  if (::getenv("CLANG_CACHE_ENABLE_INCLUDE_TREE")) {
+    Args.push_back("-fdepscan-include-tree");
+  }
+  if (const char *CASPath = ::getenv("LLVM_CACHE_CAS_PATH")) {
+    llvm::SmallString<256> CASArg(CASPath);
+    llvm::sys::path::append(CASArg, "cas");
+    if (ForDriver) {
+      Args.append({"-Xclang", "-fcas-path", "-Xclang",
+                   Saver.save(CASArg.str()).data()});
+    } else {
+      Args.append({"-fcas-path", Saver.save(CASArg.str()).data()});
+    }
+    llvm::SmallString<256> CacheArg(CASPath);
+    llvm::sys::path::append(CacheArg, "actioncache");
+    if (ForDriver) {
+      Args.append({"-Xclang", "-faction-cache-path", "-Xclang",
+                   Saver.save(CacheArg.str()).data()});
+    } else {
+      Args.append({"-faction-cache-path", Saver.save(CacheArg.str()).data()});
+    }
+  }
+}
+
+/// Arguments specific to \p clang-cache compiler launcher functionality.
+static void addLauncherArgs(SmallVectorImpl<const char *> &Args,
+                            llvm::StringSaver &Saver) {
+  if (const char *DaemonPath =
+          ::getenv("CLANG_CACHE_SCAN_DAEMON_SOCKET_PATH")) {
+    // Instruct clang to connect to scanning daemon that is listening on the
+    // provided socket path. The caller is responsible for ensuring the daemon
+    // is compatible with the invoked clang.
+    Args.push_back("-fdepscan=daemon");
+    Args.push_back(Saver.save(Twine("-fdepscan-daemon=") + DaemonPath).data());
+  } else if (const char *SessionId = ::getenv("LLVM_CACHE_BUILD_SESSION_ID")) {
+    // `LLVM_CACHE_BUILD_SESSION_ID` enables sharing of a depscan daemon
+    // using the string it is set to. The clang invocations under the same
+    // `LLVM_CACHE_BUILD_SESSION_ID` will launch and re-use the same daemon.
+    //
+    // This is a scheme where we are still launching daemons on-demand,
+    // instead of a scheme where we start a daemon at the beginning of the
+    // "build session" for all clang invocations to connect to.
+    // Launcing daemons on-demand is preferable because it allows having mixed
+    // toolchains, with different clang versions, running under the same
+    // `LLVM_CACHE_BUILD_SESSION_ID`; in such a case there will be one daemon
+    // started and shared for each unique clang version.
+    Args.append({"-fdepscan=daemon", "-fdepscan-share-identifier", SessionId});
+  } else {
+    Args.push_back("-fdepscan");
+  }
+
+  addCommonArgs(/*ForDriver*/ true, Args, Saver);
+
+  if (const char *PrefixMaps = ::getenv("LLVM_CACHE_PREFIX_MAPS")) {
+    Args.append({"-fdepscan-prefix-map-sdk=/^sdk",
+                 "-fdepscan-prefix-map-toolchain=/^toolchain"});
+    StringRef PrefixMap, Remaining = PrefixMaps;
+    while (true) {
+      std::tie(PrefixMap, Remaining) = Remaining.split(';');
+      if (PrefixMap.empty())
+        break;
+      Args.push_back(Saver.save("-fdepscan-prefix-map=" + PrefixMap).data());
+    }
+  }
+  if (const char *ServicePath =
+          ::getenv("LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH")) {
+    Args.append({"-Xclang", "-fcompilation-caching-service-path", "-Xclang",
+                 ServicePath});
+  }
+  Args.append({"-greproducible"});
+
+  if (llvm::sys::Process::GetEnv("CLANG_CACHE_REDACT_TIME_MACROS")) {
+    // Remove use of these macros to get reproducible outputs. This can
+    // accompany CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS to avoid fatal errors
+    // when the source uses these macros.
+    Args.append({"-Wno-builtin-macro-redefined", "-D__DATE__=\"redacted\"",
+                 "-D__TIMESTAMP__=\"redacted\"", "-D__TIME__=\"redacted\""});
+  }
+  if (llvm::sys::Process::GetEnv(
+          "CLANG_CACHE_CHECK_REPRODUCIBLE_CACHING_ISSUES")) {
+    Args.append({"-Werror=reproducible-caching"});
+  }
+}
+
+static void addScanServerArgs(const char *SocketPath,
+                              SmallVectorImpl<const char *> &Args,
+                              llvm::StringSaver &Saver) {
+  Args.append({"-cc1depscand", "-serve", SocketPath, "-cas-args"});
+  addCommonArgs(/*ForDriver*/ false, Args, Saver);
+}
+
 Optional<int>
 clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
                                   llvm::StringSaver &Saver) {
@@ -118,6 +212,20 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
   // Drop initial '/path/to/clang-cache' program name.
   Args.erase(Args.begin());
 
+  if (StringRef(Args.front()) == "-depscan-server") {
+    // Run "clang -cc1depscand -serve ..." after translating some of the
+    // environment variables that \p clang-cache understands.
+    if (Args.size() == 1) {
+      Diags.Report(diag::err_clang_cache_scanserve_missing_args);
+      return 1;
+    }
+    const char *SocketPath = Args[1];
+    Args.clear();
+    Args.push_back(clangCachePath);
+    addScanServerArgs(SocketPath, Args, Saver);
+    return None;
+  }
+
   llvm::ErrorOr<std::string> compilerPathOrErr =
       llvm::sys::findProgramByName(Args.front());
   if (!compilerPathOrErr) {
@@ -134,65 +242,7 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
         return 1;
       return None;
     }
-    if (const char *SessionId = ::getenv("LLVM_CACHE_BUILD_SESSION_ID")) {
-      // `LLVM_CACHE_BUILD_SESSION_ID` enables sharing of a depscan daemon
-      // using the string it is set to. The clang invocations under the same
-      // `LLVM_CACHE_BUILD_SESSION_ID` will launch and re-use the same daemon.
-      //
-      // This is a scheme where we are still launching daemons on-demand,
-      // instead of a scheme where we start a daemon at the beginning of the
-      // "build session" for all clang invocations to connect to.
-      // Launcing daemons on-demand is preferable because it allows having mixed
-      // toolchains, with different clang versions, running under the same
-      // `LLVM_CACHE_BUILD_SESSION_ID`; in such a case there will be one daemon
-      // started and shared for each unique clang version.
-      Args.append(
-          {"-fdepscan=daemon", "-fdepscan-share-identifier", SessionId});
-    } else {
-      Args.push_back("-fdepscan");
-    }
-    if (::getenv("CLANG_CACHE_ENABLE_INCLUDE_TREE")) {
-      Args.push_back("-fdepscan-include-tree");
-    }
-    if (const char *PrefixMaps = ::getenv("LLVM_CACHE_PREFIX_MAPS")) {
-      Args.append({"-fdepscan-prefix-map-sdk=/^sdk",
-                   "-fdepscan-prefix-map-toolchain=/^toolchain"});
-      StringRef PrefixMap, Remaining = PrefixMaps;
-      while (true) {
-        std::tie(PrefixMap, Remaining) = Remaining.split(';');
-        if (PrefixMap.empty())
-          break;
-        Args.push_back(Saver.save("-fdepscan-prefix-map=" + PrefixMap).data());
-      }
-    }
-    if (const char *ServicePath =
-            ::getenv("LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH")) {
-      Args.append({"-Xclang", "-fcompilation-caching-service-path", "-Xclang",
-                   ServicePath});
-    }
-    if (const char *CASPath = ::getenv("LLVM_CACHE_CAS_PATH")) {
-      llvm::SmallString<256> CASArg(CASPath);
-      llvm::sys::path::append(CASArg, "cas");
-      Args.append({"-Xclang", "-fcas-path", "-Xclang",
-                   Saver.save(CASArg.str()).data()});
-      llvm::SmallString<256> CacheArg(CASPath);
-      llvm::sys::path::append(CacheArg, "actioncache");
-      Args.append({"-Xclang", "-faction-cache-path", "-Xclang",
-                   Saver.save(CacheArg.str()).data()});
-    }
-    Args.append({"-greproducible"});
-
-    if (llvm::sys::Process::GetEnv("CLANG_CACHE_REDACT_TIME_MACROS")) {
-      // Remove use of these macros to get reproducible outputs. This can
-      // accompany CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS to avoid fatal errors
-      // when the source uses these macros.
-      Args.append({"-Wno-builtin-macro-redefined", "-D__DATE__=\"redacted\"",
-                   "-D__TIMESTAMP__=\"redacted\"", "-D__TIME__=\"redacted\""});
-    }
-    if (llvm::sys::Process::GetEnv(
-            "CLANG_CACHE_CHECK_REPRODUCIBLE_CACHING_ISSUES")) {
-      Args.append({"-Werror=reproducible-caching"});
-    }
+    addLauncherArgs(Args, Saver);
     if (llvm::sys::Process::GetEnv("CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS")) {
       // Run the compilation twice, without replaying, to check that we get the
       // same compilation artifacts for the same key. If they are not the same

--- a/clang/tools/driver/cc1depscanProtocol.cpp
+++ b/clang/tools/driver/cc1depscanProtocol.cpp
@@ -105,9 +105,16 @@ Expected<OpenSocket> OpenSocket::create(StringRef BasePath) {
 
 Expected<ScanDaemon> ScanDaemon::connectToDaemon(StringRef BasePath,
                                                  bool ShouldWait) {
+  auto reportError = [BasePath](Error &&E) -> Error {
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        Twine("could not connect to scan daemon on path '") + BasePath +
+            "': " + toString(std::move(E)));
+  };
+
   Expected<OpenSocket> Socket = OpenSocket::create(BasePath);
   if (!Socket)
-    return Socket.takeError();
+    return reportError(Socket.takeError());
 
   // Wait up to 30 seconds.
   constexpr int MaxWait = 30 * 1000 * 1000;
@@ -127,12 +134,12 @@ Expected<ScanDaemon> ScanDaemon::connectToDaemon(StringRef BasePath,
       return ScanDaemon(std::move(*Socket));
 
     if (errno != ENOENT && errno != ECONNREFUSED)
-      return llvm::errorCodeToError(
-          std::error_code(errno, std::generic_category()));
+      return reportError(llvm::errorCodeToError(
+          std::error_code(errno, std::generic_category())));
   }
 
-  return llvm::errorCodeToError(
-      std::error_code(ENOENT, std::generic_category()));
+  return reportError(
+      llvm::errorCodeToError(std::error_code(ENOENT, std::generic_category())));
 }
 
 Expected<ScanDaemon> ScanDaemon::launchDaemon(StringRef BasePath,
@@ -142,31 +149,15 @@ Expected<ScanDaemon> ScanDaemon::launchDaemon(StringRef BasePath,
   const char *Args[] = {
       Arg0,
       "-cc1depscand",
-      "-run", // -launch if we want the daemon to fork itself.
+      "-run",
       BasePathCStr.c_str(),
   };
 
-  static bool LaunchTestDaemon =
-      llvm::sys::Process::GetEnv("__CLANG_TEST_CC1DEPSCAND_SHUTDOWN")
-          .hasValue();
-  static Optional<std::string> LaunchTestArgs =
-      llvm::sys::Process::GetEnv("__CLANG_TEST_CC1DEPSCAND_EXTRA_ARGS");
-
   ArrayRef<const char *> InitialArgs = makeArrayRef(Args);
   SmallVector<const char *> LaunchArgs(InitialArgs.begin(), InitialArgs.end());
-  if (LaunchTestDaemon)
-    LaunchArgs.push_back("-shutdown");
 
   llvm::BumpPtrAllocator Alloc;
   llvm::StringSaver Saver(Alloc);
-  if (LaunchTestArgs) {
-    StringRef Arg, Remaining = *LaunchTestArgs;
-    while (!Remaining.empty()) {
-      std::tie(Arg, Remaining) = Remaining.split(' ');
-      StringRef A = Saver.save(Arg);
-      LaunchArgs.push_back(A.data());
-    }
-  }
 
   if (Sharing.ShareViaIdentifier) {
     // Invocations that share state via identifier will be isolated from
@@ -176,9 +167,6 @@ Expected<ScanDaemon> ScanDaemon::launchDaemon(StringRef BasePath,
   LaunchArgs.push_back("-cas-args");
   LaunchArgs.append(Sharing.CASArgs);
   LaunchArgs.push_back(nullptr);
-
-  // Only do it the first time.
-  LaunchTestDaemon = false;
 
   // Spawn attributes
   posix_spawnattr_t Attrs;
@@ -204,14 +192,6 @@ Expected<ScanDaemon> ScanDaemon::launchDaemon(StringRef BasePath,
                          /*envp=*/nullptr);
   if (EC)
     return llvm::errorCodeToError(std::error_code(EC, std::generic_category()));
-
-  // If we use -launch above, we should do the following here:
-  //
-  // int Status;
-  // if (::waitpid(Pid, &Status, 0) != Pid)
-  //   return createStringError("failed to spawn clang -cc1depscand");
-  // if (!WIFEXITED(Status) || WEXITSTATUS(Status))
-  //   return createStringError("clang -cc1depscand failed to launch");
 
   return connectToJustLaunchedDaemon(BasePath);
 }

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -163,17 +163,6 @@ static void ensureSufficientStack() {
 static void ensureSufficientStack() {}
 #endif
 
-static void reportAsFatalIfError(llvm::Error E) {
-  if (E)
-    llvm::report_fatal_error(std::move(E));
-}
-
-template <typename T> static T reportAsFatalIfError(Expected<T> ValOrErr) {
-  if (!ValOrErr)
-    reportAsFatalIfError(ValOrErr.takeError());
-  return std::move(*ValOrErr);
-}
-
 namespace {
 class OneOffCompilationDatabase : public tooling::CompilationDatabase {
 public:
@@ -380,35 +369,6 @@ static Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
     SmallVectorImpl<const char *> &OutputArgs,
     const DepscanPrefixMapping &PrefixMapping, llvm::cas::ObjectStore &DB,
     llvm::function_ref<const char *(const Twine &)> SaveArg);
-
-static void shutdownCC1ScanDepsDaemon(StringRef Path) {
-  using namespace clang::cc1depscand;
-  SmallString<128> WorkingDirectory;
-  reportAsFatalIfError(
-      llvm::errorCodeToError(llvm::sys::fs::current_path(WorkingDirectory)));
-
-  // llvm::dbgs() << "connecting to daemon...\n";
-  auto Daemon = ScanDaemon::connectToDaemonAndShakeHands(Path);
-
-  if (!Daemon) {
-    logAllUnhandledErrors(Daemon.takeError(), llvm::errs(),
-                          "Cannot connect to the daemon to shutdown: ");
-    return;
-  }
-  CC1DepScanDProtocol Comms(*Daemon);
-
-  DepscanPrefixMapping Mapping;
-  const char *Args[] = {"-shutdown", nullptr};
-  // llvm::dbgs() << "sending shutdown request...\n";
-  reportAsFatalIfError(Comms.putCommand(WorkingDirectory, Args[0], Mapping));
-
-  // Wait for the ack before return.
-  CC1DepScanDProtocol::ResultKind Result;
-  reportAsFatalIfError(Comms.getResultKind(Result));
-
-  if (Result != CC1DepScanDProtocol::SuccessResult)
-    llvm::report_fatal_error("Daemon shutdown failed");
-}
 
 static llvm::Expected<llvm::cas::CASID> scanAndUpdateCC1UsingDaemon(
     const char *Exec, ArrayRef<const char *> OldArgs,
@@ -700,24 +660,79 @@ int cc1depscan_main(ArrayRef<const char *> Argv, const char *Argv0,
   return 0;
 }
 
+namespace {
+struct ScanServer {
+  const char *Argv0 = nullptr;
+  SmallString<128> BasePath;
+  /// List of cas options.
+  ArrayRef<const char *> CASArgs;
+  int PidFD = -1;
+  int ListenSocket = -1;
+  /// \p std::nullopt means it runs indefinitely.
+  Optional<unsigned> TimeoutSeconds;
+  std::atomic<bool> ShutDown{false};
+
+  ~ScanServer() { shutdown(); }
+
+  void start(bool Exclusive);
+  int listen();
+
+  /// Tear down the socket and bind file immediately but wait till all existing
+  /// jobs to finish.
+  void shutdown() {
+    ShutDown.store(true);
+    cc1depscand::unlinkBoundSocket(BasePath);
+    // Clean up the pidfile when we're done.
+    if (PidFD != -1)
+      ::close(PidFD);
+    ::shutdown(ListenSocket, SHUT_RD);
+    ::close(ListenSocket);
+  }
+};
+} // anonymous namespace
+
+static llvm::ExitOnError ExitOnErr("clang -cc1depscand: ");
+
+static void reportError(const llvm::Twine &Message) {
+  ExitOnErr(llvm::createStringError(llvm::inconvertibleErrorCode(), Message));
+}
+
+/// Accepted options are:
+///
+/// * -run <path> [-long-running] [-cas-args ...]
+/// Runs the daemon until a timeout is reached without a new connection.
+/// "-long-running" increases the timeout. stdout/stderr are redirected to files
+/// relative to <path>. This is how the clang driver auto-spawns a new daemon.
+///
+/// * -serve <path> [-cas-args ...]
+/// Runs indefinitely (until ctrl+c or the process is killed). There's no
+/// stdout/stderr redirection. Useful for debugging and for starting a permanent
+/// daemon before directing clang invocations to connect to it.
+///
+/// * -execute <path> [-cas-args ...] -- <command ...>
+/// Sets up the socket path, sets \p CLANG_CACHE_SCAN_DAEMON_SOCKET_PATH
+/// enviroment variable to the socket path, and executes the provided command.
+/// It exits with the same exit code as the command. Useful for lit testing.
 int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
                      void *MainAddr) {
   ensureSufficientStack();
 
   if (Argv.size() < 2)
-    llvm::report_fatal_error(
-        "clang -cc1depscand: missing command and base-path");
+    reportError("missing command and base-path");
+
+  ScanServer Server;
+  Server.Argv0 = Argv0;
 
   StringRef Command = Argv[0];
-  StringRef BasePath = Argv[1];
+  Server.BasePath = Argv[1];
 
-  // Shutdown test mode. In shutdown test mode, daemon will open acception, but
-  // not replying anything, just tear down the connect immediately.
-  bool ShutDownTest = false;
-  bool KeepAlive = false;
-  bool Detached = false;
-  bool Debug = false;
-  bool SingleCommandMode = false;
+  ArrayRef<const char *> CommandArgsToExecute;
+  auto Sep = llvm::find_if(
+      Argv, [](const char *Arg) { return StringRef(Arg) == "--"; });
+  if (Sep != Argv.end()) {
+    CommandArgsToExecute = Argv.drop_front(Sep - Argv.begin() + 1);
+    Argv = Argv.slice(0, Sep - Argv.begin());
+  }
 
   // Whether the daemon can safely stay alive a longer period of time.
   // FIXME: Consider designing a mechanism to notify daemons, started for a
@@ -725,98 +740,68 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
   // session is finished.
   bool LongRunning = false;
 
-  // List of cas options.
-  ArrayRef<const char *> CASArgs;
-
   for (const auto *A = Argv.begin() + 2; A != Argv.end(); ++A) {
     StringRef Arg(*A);
-    if (Arg == "-shutdown")
-      ShutDownTest = true;
-    else if (Arg == "-detach")
-      Detached = true;
-    else if (Arg == "-long-running")
+    if (Arg == "-long-running")
       LongRunning = true;
-    else if (Arg == "-single-command")
-      SingleCommandMode = true;
-    else if (Arg == "-debug") {
-      // Debug mode. Running in detach mode.
-      Debug = true;
-      Detached = true;
-    } else if (Arg == "-cas-args") {
-      CASArgs = llvm::makeArrayRef(A + 1, Argv.end());
+    else if (Arg == "-cas-args") {
+      Server.CASArgs = llvm::makeArrayRef(A + 1, Argv.end());
       break;
     }
   }
 
-  auto formSpawnArgsForCommand =
-      [&](const char *Command) -> SmallVector<const char *> {
-    SmallVector<const char *> Args{Argv0,     "-cc1depscand",
-                                   Command,   BasePath.begin(),
-                                   "-detach", "-cas-args"};
-    Args.append(CASArgs.begin(), CASArgs.end());
-    Args.push_back(nullptr);
-    return Args;
-  };
+  // Create the base directory if necessary.
+  StringRef BaseDir = llvm::sys::path::parent_path(Server.BasePath);
+  if (std::error_code EC = llvm::sys::fs::create_directories(BaseDir))
+    reportError(Twine("cannot create basedir: ") + EC.message());
 
-  if (Command == "-launch") {
-    signal(SIGCHLD, SIG_IGN);
-    auto Args = formSpawnArgsForCommand("-run");
-    int IgnoredPid;
-    int EC = ::posix_spawn(&IgnoredPid, Args[0], /*file_actions=*/nullptr,
-                           /*attrp=*/nullptr, const_cast<char **>(Args.data()),
-                           /*envp=*/nullptr);
-    if (EC)
-      llvm::report_fatal_error("clang -cc1depscand: failed to daemonize");
-    ::exit(0);
-  }
+  if (Command == "-serve") {
+    Server.start(/*Exclusive*/ true);
+    return Server.listen();
 
-  if (Command == "-start") {
-    KeepAlive = true;
-    llvm::EnableStatistics(/*DoPrintOnExit=*/true);
-    if (!Detached) {
-      signal(SIGCHLD, SIG_IGN);
-      auto Args = formSpawnArgsForCommand("-start");
-      int IgnoredPid;
-      int EC =
-          ::posix_spawn(&IgnoredPid, Args[0], /*file_actions=*/nullptr,
-                        /*attrp=*/nullptr, const_cast<char **>(Args.data()),
-                        /*envp=*/nullptr);
-      if (EC)
-        llvm::report_fatal_error("clang -cc1depscand: failed to daemonize");
-      ::exit(0);
+  } else if (Command == "-execute") {
+    SmallVector<StringRef, 32> RefArgs;
+    RefArgs.reserve(CommandArgsToExecute.size());
+    for (const char *Arg : CommandArgsToExecute) {
+      RefArgs.push_back(Arg);
     }
+
+    // Make sure to start the server before executing the command.
+    Server.start(/*Exclusive*/ true);
+    std::thread ServerThread([&Server]() { Server.listen(); });
+
+    setenv("CLANG_CACHE_SCAN_DAEMON_SOCKET_PATH", Server.BasePath.c_str(),
+           true);
+
+    std::string ErrMsg;
+    int Result = llvm::sys::ExecuteAndWait(
+        RefArgs.front(), RefArgs, /*Env*/ None,
+        /*Redirects*/ {}, /*SecondsToWait*/ 0,
+        /*MemoryLimit*/ 0, &ErrMsg);
+
+    Server.shutdown();
+    ServerThread.join();
+
+    if (!ErrMsg.empty())
+      reportError("failed executing command: " + ErrMsg);
+    return Result;
+
+  } else if (Command != "-run") {
+    reportError("unknown command '" + Command + "'");
   }
 
-  if (Command == "-shutdown") {
-    // When shutdown command is received, connect to daemon and sent shuwdown
-    // command.
-    shutdownCC1ScanDepsDaemon(BasePath);
-    ::exit(0);
-  }
-
-  if (Command != "-run" && Command != "-start")
-    llvm::report_fatal_error("clang -cc1depscand: unknown command '" + Command +
-                             "'");
+  Server.TimeoutSeconds = LongRunning ? 45 : 15;
 
   // Daemonize.
   if (::signal(SIGHUP, SIG_IGN) == SIG_ERR)
-    llvm::report_fatal_error("clang -cc1depscand: failed to ignore SIGHUP");
-  if (!Debug) {
-    if (::setsid() == -1)
-      llvm::report_fatal_error("clang -cc1depscand: setsid failed");
-  }
+    reportError("failed to ignore SIGHUP");
+  if (::setsid() == -1)
+    reportError("setsid failed");
 
   // Check the pidfile.
-  SmallString<128> PidPath, LogOutPath, LogErrPath;
-  (BasePath + ".pid").toVector(PidPath);
-  (BasePath + ".out").toVector(LogOutPath);
-  (BasePath + ".err").toVector(LogErrPath);
-
-  // Create the base directory if necessary.
-  StringRef BaseDir = llvm::sys::path::parent_path(BasePath);
-  if (std::error_code EC = llvm::sys::fs::create_directories(BaseDir))
-    llvm::report_fatal_error(
-        Twine("clang -cc1depscand: cannot create basedir: ") + EC.message());
+  SmallString<128> LogOutPath, LogErrPath;
+  (Server.BasePath + ".out").toVector(LogOutPath);
+  (Server.BasePath + ".err").toVector(LogErrPath);
 
   auto openAndReplaceFD = [&](int ReplacedFD, StringRef Path) {
     int FD;
@@ -833,65 +818,44 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
   openAndReplaceFD(1, LogOutPath);
   openAndReplaceFD(2, LogErrPath);
 
-  bool ShouldKeepOutputs = true;
-  auto DropOutputs = llvm::make_scope_exit([&]() {
-    if (ShouldKeepOutputs)
-      return;
-    ::unlink(LogOutPath.c_str());
-    ::unlink(LogErrPath.c_str());
-  });
+  Server.start(/*Exclusive*/ false);
+  return Server.listen();
+}
 
-  int PidFD;
+void ScanServer::start(bool Exclusive) {
+  // Check the pidfile.
+  SmallString<128> PidPath;
+  (BasePath + ".pid").toVector(PidPath);
+
   [&]() {
     if (std::error_code EC = llvm::sys::fs::openFile(
             PidPath, PidFD, llvm::sys::fs::CD_OpenAlways,
             llvm::sys::fs::FA_Write, llvm::sys::fs::OF_None))
-      llvm::report_fatal_error("clang -cc1depscand: cannot open pidfile");
+      reportError("cannot open pidfile");
 
     // Try to lock; failure means there's another daemon running.
-    if (::flock(PidFD, LOCK_EX | LOCK_NB))
+    if (::flock(PidFD, LOCK_EX | LOCK_NB)) {
+      if (Exclusive)
+        reportError("another daemon using the base path");
       ::exit(0);
+    }
 
     // FIXME: Should we actually write the pid here? Maybe we don't care.
   }();
 
-  // Clean up the pidfile when we're done.
-  auto ClosePidFile = [&]() {
-    if (PidFD != -1)
-      ::close(PidFD);
-    PidFD = -1;
-  };
-  auto ClosePidFileAtExit = llvm::make_scope_exit([&]() { ClosePidFile(); });
-
   // Open the socket and start listening.
-  int ListenSocket = cc1depscand::createSocket();
+  ListenSocket = cc1depscand::createSocket();
   if (ListenSocket == -1)
-    llvm::report_fatal_error("clang -cc1depscand: cannot open socket");
+    reportError("cannot open socket");
 
   if (cc1depscand::bindToSocket(BasePath, ListenSocket))
-    llvm::report_fatal_error(StringRef() +
-                             "clang -cc1depscand: cannot bind to socket" +
-                             ": " + strerror(errno));
-  bool IsBound = true;
-  auto RemoveBindFile = [&] {
-    assert(IsBound);
-    cc1depscand::unlinkBoundSocket(BasePath);
-    IsBound = false;
-  };
-  auto RemoveBindFileAtExit = llvm::make_scope_exit([&]() {
-    if (IsBound)
-      RemoveBindFile();
-  });
+    reportError(StringRef() + "cannot bind to socket" + ": " + strerror(errno));
+}
 
+int ScanServer::listen() {
   llvm::ThreadPool Pool;
   if (::listen(ListenSocket, /*MaxBacklog=*/Pool.getThreadCount() * 16))
-    llvm::report_fatal_error("clang -cc1depscand: cannot listen to socket");
-
-  auto ShutdownCleanUp = [&]() {
-    RemoveBindFile();
-    ClosePidFile();
-    ::close(ListenSocket);
-  };
+    reportError("cannot listen to socket");
 
   DiagnosticsEngine Diags(new DiagnosticIDs(), new DiagnosticOptions());
   CASOptions CASOpts;
@@ -907,12 +871,12 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
   std::shared_ptr<llvm::cas::ObjectStore> CAS =
       CASOpts.getOrCreateObjectStore(Diags);
   if (!CAS)
-    llvm::report_fatal_error("clang -cc1depscand: cannot create CAS");
+    reportError("cannot create CAS");
 
   std::shared_ptr<llvm::cas::ActionCache> Cache =
       CASOpts.getOrCreateActionCache(Diags);
   if (!Cache)
-    llvm::report_fatal_error("clang -cc1depscand: cannot create ActionCache");
+    reportError("cannot create ActionCache");
 
   IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> FS;
   if (!ProduceIncludeTree)
@@ -926,7 +890,6 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
       /*ReuseFileManager=*/false,
       /*SkipExcludedPPRanges=*/true);
 
-  std::atomic<bool> ShutDown(false);
   std::atomic<int> NumRunning(0);
 
   std::chrono::steady_clock::time_point Start =
@@ -935,15 +898,8 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
 
   SharedStream SharedOS(llvm::errs());
 
-#ifndef NDEBUG
-  if (ShutDownTest)
-    llvm::outs() << "launched in shutdown test state\n";
-#endif
-
-  auto ServiceLoop = [&CAS, &Service, &ShutDown, &ListenSocket, &NumRunning,
-                      &Start, &SecondsSinceLastClose, Argv0, &SharedOS,
-                      ShutDownTest, &ShutdownCleanUp,
-                      SingleCommandMode](unsigned I) {
+  auto ServiceLoop = [this, &CAS, &Service, &NumRunning, &Start,
+                      &SecondsSinceLastClose, &SharedOS](unsigned I) {
     Optional<tooling::dependencies::DependencyScanningTool> Tool;
     SmallString<256> Message;
     while (true) {
@@ -968,12 +924,6 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
       {
         ++NumRunning;
 
-        // In test mode, just tear down everything.
-        if (ShutDownTest) {
-          ShutdownCleanUp();
-          ShutDown.store(true);
-          continue;
-        }
         // Check again for shutdown, since the main thread could have
         // requested it before we created the service.
         //
@@ -1008,14 +958,6 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
           logAllUnhandledErrors(std::move(E), OS);
         });
         continue; // FIXME: Tell the client something went wrong.
-      }
-
-      if (StringRef(Args[0]) == "-shutdown") {
-        consumeError(Comms.putResultKind(
-            cc1depscand::CC1DepScanDProtocol::SuccessResult));
-        ShutdownCleanUp();
-        ShutDown.store(true);
-        continue;
       }
 
       // cc1 request.
@@ -1089,26 +1031,20 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
         printComputedCC1(OS);
       });
 #endif
-      if (SingleCommandMode) {
-        ShutdownCleanUp();
-        ShutDown.store(true);
-        return;
-      }
     }
   };
-
-  if (SingleCommandMode) {
-    // If in run once mode. Run it single thread then exit.
-    ServiceLoop(0);
-    ::exit(0);
-  }
 
   for (unsigned I = 0; I < Pool.getThreadCount(); ++I)
     Pool.async(ServiceLoop, I);
 
+  if (!TimeoutSeconds) {
+    Pool.wait();
+    return 0;
+  }
+
   // Wait for the work to finish.
   const uint64_t SecondsBetweenAttempts = 5;
-  const uint64_t SecondsBeforeDestruction = LongRunning ? 45 : 15;
+  const uint64_t SecondsBeforeDestruction = *TimeoutSeconds;
   uint64_t SleepTime = SecondsBeforeDestruction;
   while (true) {
     ::sleep(SleepTime);
@@ -1119,9 +1055,6 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
 
     if (ShutDown.load())
       break;
-
-    if (KeepAlive)
-      continue;
 
     // Figure out the latest access time that we'll delete.
     uint64_t LastAccessToDestroy =
@@ -1135,15 +1068,10 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
     if (LastAccessToDestroy < SecondsSinceLastClose)
       continue;
 
-    // Tear down the socket and bind file immediately but wait till all existing
-    // jobs to finish.
-    ShutdownCleanUp();
-    ShutDown.store(true);
+    shutdown();
   }
 
-  // Exit instead of return. Otherwise, it will wait on ~ThreadPool() which will
-  // never return since all threads might still be sleeping on ::accept().
-  ::exit(0);
+  return 0;
 }
 
 static Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(

--- a/llvm/tools/llvm-remote-cache-test/llvm-remote-cache-test.cpp
+++ b/llvm/tools/llvm-remote-cache-test/llvm-remote-cache-test.cpp
@@ -114,10 +114,9 @@ int main(int Argc, const char **Argv) {
 
   remote::RemoteCacheServer Server(SocketPath, TempPath, std::move(*CAS),
                                    std::move(*Cache));
-  std::thread ServerThread([&Server]() {
-    Server.Start();
-    Server.Listen();
-  });
+  // Make sure to start the server before executing the command.
+  Server.Start();
+  std::thread ServerThread([&Server]() { Server.Listen(); });
 
   setenv("LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH", SocketPath.c_str(), true);
 


### PR DESCRIPTION
Have 3 ways for how the daemon functions:
1. `-run`: Runs the daemon until a timeout is reached without a new connection.
2. `-serve`: Runs the daemon indefinitely.
3. `-execute`: Sets up the connection, runs a command, and quits.

With `-execute` we can have lit tests for the daemon that don't leave lingering clang processes around.

rdar://103519851
(cherry picked from commit 42d3c8706014c58e48dd6903c701a20ea004c679) (cherry picked from commit fbc1db200344063c68b53ff50df8b1be8b6421ff)