### PR TITLE
Revert "[lldb] Remove -link-objc-runtime from the tests Makefile.rules"

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -527,7 +527,7 @@ endif
 #----------------------------------------------------------------------
 ifeq "$(SWIFT_OBJC_INTEROP)" "1"
         ifeq "$(OS)" "Darwin"
-		SWIFTFLAGS += -framework Foundation -framework CoreGraphics
+		SWIFTFLAGS += -link-objc-runtime -framework Foundation -framework CoreGraphics
 		LDFLAGS += -lswiftObjectiveC -lswiftFoundation -framework Foundation -framework CoreGraphics
         else
                 # CFLAGS_EXTRAS is used via "dotest.py -E" to pass the -I and -L paths


### PR DESCRIPTION
Reverts apple/llvm-project#5854

Seeing some `ld` failures ("dylib not assigned ordinal") that may be caused by this.