### PR TITLE
Remove unnecessary import of `swift/Parser/LocalContext.h`.

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -75,7 +75,6 @@
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Frontend/Frontend.h"
-#include "swift/Parse/LocalContext.h"
 #include "swift/Parse/PersistentParserState.h"
 #include "swift/SIL/SILDebuggerClient.h"
 #include "swift/SIL/SILFunction.h"


### PR DESCRIPTION
We don't use anything from this header, and it's going away.