### PR TITLE
[lldb] Fix incorrect cherry-pick moving AddVariableInfo

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -363,7 +363,7 @@ static bool AddVariableInfo(
       variable_sp->GetScope(), variable_sp->GetSymbolContextScope(),
       variable_sp->GetScopeRange(),
       const_cast<lldb_private::Declaration *>(&variable_sp->GetDeclaration()),
-      variable_sp->LocationExpression(), variable_sp->IsExternal(),
+      variable_sp->LocationExpressionList(), variable_sp->IsExternal(),
       variable_sp->IsArtificial(),
       variable_sp->GetLocationIsConstantValueData(),
       variable_sp->IsStaticMember(), variable_sp->IsConstant());


### PR DESCRIPTION
(cherry picked from commit 9f761394fade44d6729bac82feceeccab2e834c5)