### PR TITLE
[clang/cas] Fix a couple of problems with dependency file output and include-tree

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -28,6 +28,7 @@ namespace tooling {
 namespace dependencies {
 
 class DependencyScanningWorkerFilesystem;
+struct DepscanPrefixMapping;
 
 /// A command-line tool invocation that is part of building a TU.
 ///
@@ -81,6 +82,12 @@ public:
                              FileID Include, SourceLocation ExitLoc) = 0;
 
   virtual void handleHasIncludeCheck(Preprocessor &PP, bool Result) = 0;
+
+  /// FIXME: This is temporary until we eliminate the split between consumers in
+  /// \p DependencyScanningTool and collectors in \p DependencyScanningWorker
+  /// and have them both in the same file. see FIXME in \p
+  /// DependencyScanningAction::runInvocation.
+  virtual const DepscanPrefixMapping &getPrefixMapping() = 0;
 
 protected:
   void handleBuildCommand(Command) override {}

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -197,6 +197,10 @@ private:
 
   void handleHasIncludeCheck(Preprocessor &PP, bool Result) override;
 
+  const DepscanPrefixMapping &getPrefixMapping() override {
+    return PrefixMapping;
+  }
+
   Error finalize(CompilerInstance &CI) override;
 
   Expected<cas::ObjectRef> getObjectForFile(Preprocessor &PP, FileID FID);

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -23,10 +23,12 @@
 #include "clang/Lex/PreprocessorOptions.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningService.h"
 #include "clang/Tooling/DependencyScanning/ModuleDepCollector.h"
+#include "clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h"
 #include "clang/Tooling/Tooling.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/Support/Host.h"
+#include "llvm/Support/PrefixMapper.h"
 
 using namespace clang;
 using namespace tooling;
@@ -192,6 +194,7 @@ class IncludeTreeCollector : public DependencyFileGenerator {
   PPIncludeActionsConsumer &Consumer;
   std::unique_ptr<DependencyOutputOptions> Opts;
   bool EmitDependencyFile = false;
+  llvm::PrefixMapper ReverseMapper;
 
 public:
   IncludeTreeCollector(PPIncludeActionsConsumer &Consumer,
@@ -200,9 +203,37 @@ public:
       : DependencyFileGenerator(*Opts), Consumer(Consumer),
         Opts(std::move(Opts)), EmitDependencyFile(EmitDependencyFile) {}
 
+  Error initialize(const CompilerInvocation &CI,
+                   const DepscanPrefixMapping &PrefixMapping) {
+    llvm::PrefixMapper Mapper;
+    if (Error E = PrefixMapping.configurePrefixMapper(CI, Mapper))
+      return E;
+    if (Mapper.empty())
+      return Error::success();
+
+    if (Error E = ReverseMapper.addInverseRange(Mapper.getMappings()))
+      return E;
+    ReverseMapper.sort();
+    return Error::success();
+  }
+
   void attachToPreprocessor(Preprocessor &PP) override {
     PP.addPPCallbacks(std::make_unique<IncludeTreePPCallbacks>(Consumer, PP));
     DependencyFileGenerator::attachToPreprocessor(PP);
+  }
+
+  void maybeAddDependency(StringRef Filename, bool FromModule, bool IsSystem,
+                          bool IsModuleFile, bool IsMissing) override {
+    if (ReverseMapper.empty())
+      return DependencyFileGenerator::maybeAddDependency(
+          Filename, FromModule, IsSystem, IsModuleFile, IsMissing);
+
+    // We may get canonicalized paths if prefix headers/PCH are used, so make
+    // sure to remap them back to original source paths.
+    SmallString<256> New{Filename};
+    cantFail(ReverseMapper.mapInPlace(New));
+    return DependencyFileGenerator::maybeAddDependency(
+        New, FromModule, IsSystem, IsModuleFile, IsMissing);
   }
 
   void finishedMainFile(DiagnosticsEngine &Diags) override {
@@ -419,7 +450,25 @@ public:
       Opts->Targets = {
           deduceDepTarget(ScanInstance.getFrontendOpts().OutputFile,
                           ScanInstance.getFrontendOpts().Inputs)};
-    Opts->IncludeSystemHeaders = true;
+    if (Format == ScanningOutputFormat::Make) {
+      // Only 'Make' scanning needs this because that mode depends on getting
+      // the dependencies directly from \p DependencyFileGenerator.
+      // FIXME: The caller APIs in \p DependencyScanningTool expect a specific
+      // DependencyCollector to get attached to the preprocessor in order to
+      // function properly (e.g. \p FullDependencyConsumer needs \p
+      // ModuleDepCollector) but this association is very indirect via the value
+      // of the \p ScanningOutputFormat. We should remove \p Format field from
+      // \p DependencyScanningAction, and have the callers pass in a
+      // “DependencyCollector factory” so the connection of collector<->consumer
+      // is explicit in each \p DependencyScanningTool function.
+      Opts->IncludeSystemHeaders = true;
+    }
+
+    auto reportError = [&ScanInstance](Error &&E) -> bool {
+      ScanInstance.getDiagnostics().Report(diag::err_cas_depscan_failed)
+          << std::move(E);
+      return false;
+    };
 
     switch (Format) {
     case ScanningOutputFormat::Make:
@@ -429,10 +478,13 @@ public:
               std::move(Opts), WorkingDirectory, Consumer, EmitDependencyFile));
       break;
     case ScanningOutputFormat::IncludeTree: {
-      ScanInstance.addDependencyCollector(
-          std::make_shared<IncludeTreeCollector>(
-              static_cast<PPIncludeActionsConsumer &>(Consumer),
-              std::move(Opts), EmitDependencyFile));
+      auto &IncConsumer = static_cast<PPIncludeActionsConsumer &>(Consumer);
+      auto IncTreeCollector = std::make_shared<IncludeTreeCollector>(
+          IncConsumer, std::move(Opts), EmitDependencyFile);
+      if (Error E = IncTreeCollector->initialize(
+              ScanInstance.getInvocation(), IncConsumer.getPrefixMapping()))
+        return reportError(std::move(E));
+      ScanInstance.addDependencyCollector(std::move(IncTreeCollector));
       break;
     }
     case ScanningOutputFormat::Full:
@@ -469,12 +521,6 @@ public:
       Action = std::make_unique<GetDependenciesByModuleNameAction>(*ModuleName);
     else
       Action = std::make_unique<ReadPCHAndPreprocessAction>();
-
-    auto reportError = [&ScanInstance](Error &&E) -> bool {
-      ScanInstance.getDiagnostics().Report(diag::err_cas_depscan_failed)
-          << std::move(E);
-      return false;
-    };
 
     if (Error E = Consumer.initialize(ScanInstance))
       return reportError(std::move(E));

--- a/clang/test/CAS/depscan-dependency-file.c
+++ b/clang/test/CAS/depscan-dependency-file.c
@@ -1,0 +1,29 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: split-file %s %t
+
+// Baseline for comparison.
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
+// RUN:   -MT deps -dependency-file %t/regular.d
+
+// Including system headers.
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
+// RUN:   -MT deps -sys-header-deps -dependency-file %t/regular-sys.d
+
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/t.rsp -cc1-args \
+// RUN:   -cc1 -triple x86_64-apple-macos11 %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
+// RUN:     -MT deps -dependency-file %t/t.d
+// RUN: diff -u %t/regular.d %t/t.d
+
+// Including system headers.
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/t.rsp -cc1-args \
+// RUN:   -cc1 -triple x86_64-apple-macos11 %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
+// RUN:     -MT deps -sys-header-deps -dependency-file %t/t-sys.d
+// RUN: diff -u %t/regular-sys.d %t/t-sys.d
+
+//--- main.c
+#include "my_header.h"
+#include <sys.h>
+
+//--- my_header.h
+
+//--- sys/sys.h

--- a/clang/test/CAS/fcas-include-tree-prefix-mapping.c
+++ b/clang/test/CAS/fcas-include-tree-prefix-mapping.c
@@ -9,7 +9,8 @@
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out \
-// RUN:       -emit-llvm %t/src/main.c -o %t/out/output.ll -include %t/src/prefix.h -I %t/src/inc
+// RUN:       -emit-llvm %t/src/main.c -o %t/out/output.ll -include %t/src/prefix.h -I %t/src/inc \
+// RUN:       -MT deps -dependency-file %t/t1.d
 // RUN: %clang @%t/t1.rsp 2> %t/output.txt
 
 // RUN: cat %t/output.txt | sed \
@@ -46,7 +47,8 @@
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out2 \
-// RUN:       -emit-llvm %t/src2/main.c -o %t/out2/output.ll -include %t/src2/prefix.h -I %t/src2/inc
+// RUN:       -emit-llvm %t/src2/main.c -o %t/out2/output.ll -include %t/src2/prefix.h -I %t/src2/inc \
+// RUN:       -MT deps -dependency-file %t/t2.d
 // RUN: %clang @%t/t2.rsp 2> %t/output2.txt
 
 // RUN: cat %t/output2.txt | sed \
@@ -54,6 +56,23 @@
 // RUN:   -e "s/' .*$//" > %t/cache-key2
 
 // RUN: diff -u %t/cache-key %t/cache-key2
+
+// Check dependencies.
+
+// Baseline for comparison.
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
+// RUN:   -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
+// RUN:   -emit-obj %t/src/main.c -o %t/out/main.o -include %t/src/prefix.h -I %t/src/inc \
+// RUN:   -MT deps -dependency-file %t/regular1.d
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
+// RUN:   -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
+// RUN:   -emit-obj %t/src2/main.c -o %t/out2/main.o -include %t/src2/prefix.h -I %t/src2/inc \
+// RUN:   -MT deps -dependency-file %t/regular2.d
+
+// RUN: diff -u %t/regular1.d %t/t1.d
+// RUN: diff -u %t/regular2.d %t/t2.d
 
 // Check with PCH.
 
@@ -87,7 +106,8 @@
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out \
-// RUN:       -emit-obj %t/src/main.c -o %t/out/main.o -include-pch %t/out/prefix.h.pch -I %t/src/inc
+// RUN:       -emit-obj %t/src/main.c -o %t/out/main.o -include-pch %t/out/prefix.h.pch -I %t/src/inc \
+// RUN:       -MT deps -dependency-file %t/t1.pch.d
 // RUN: %clang @%t/t3.rsp 2> %t/output3.txt
 
 // RUN: cat %t/output3.txt | sed \
@@ -101,7 +121,8 @@
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out2 \
-// RUN:       -emit-obj %t/src2/main.c -o %t/out2/main.o -include-pch %t/out2/prefix.h.pch -I %t/src2/inc
+// RUN:       -emit-obj %t/src2/main.c -o %t/out2/main.o -include-pch %t/out2/prefix.h.pch -I %t/src2/inc \
+// RUN:       -MT deps -dependency-file %t/t2.pch.d
 // RUN: %clang @%t/t4.rsp 2> %t/output4.txt
 
 // RUN: cat %t/output4.txt | sed \
@@ -110,6 +131,31 @@
 
 // RUN: diff -u %t/cache-key3 %t/cache-key4
 // RUN: diff %t/out/main.o %t/out2/main.o
+
+// Check dependencies.
+
+// Baseline for comparison.
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -faction-cache-path %t/cache -Rcompile-job-cache \
+// RUN:   -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
+// RUN:   -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
+// RUN:   -emit-pch -x c-header %t/src/prefix.h -o %t/out/reg-prefix.h.pch -include %t/src/prefix.h -I %t/src/inc
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
+// RUN:   -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
+// RUN:   -emit-obj %t/src/main.c -o %t/out/main.o -include-pch %t/out/reg-prefix.h.pch -I %t/src/inc \
+// RUN:   -MT deps -dependency-file %t/regular1.pch.d
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -faction-cache-path %t/cache -Rcompile-job-cache \
+// RUN:   -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
+// RUN:   -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
+// RUN:   -emit-pch -x c-header %t/src2/prefix.h -o %t/out2/reg-prefix.h.pch -include %t/src2/prefix.h -I %t/src2/inc
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
+// RUN:   -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
+// RUN:   -emit-obj %t/src2/main.c -o %t/out2/main.o -include-pch %t/out2/reg-prefix.h.pch -I %t/src2/inc \
+// RUN:   -MT deps -dependency-file %t/regular2.pch.d
+
+// RUN: diff -u %t/regular1.pch.d %t/t1.pch.d
+// RUN: diff -u %t/regular2.pch.d %t/t2.pch.d
 
 //--- main.c
 #include "t.h"


### PR DESCRIPTION
* If a prefix header is used, the dependency file will list it with a canonical path
* System header dependencies are always included even when they are not requested.