### PR TITLE
[clang/cc1depscan_main] Make sure to call `::listen()` as part of the `ScanServer::start()` function

### DIFF
--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -848,12 +848,15 @@ void ScanServer::start(bool Exclusive) {
 
   if (cc1depscand::bindToSocket(BasePath, ListenSocket))
     reportError(StringRef() + "cannot bind to socket" + ": " + strerror(errno));
+
+  unsigned MaxBacklog =
+      llvm::hardware_concurrency().compute_thread_count() * 16;
+  if (::listen(ListenSocket, MaxBacklog))
+    reportError("cannot listen to socket");
 }
 
 int ScanServer::listen() {
   llvm::ThreadPool Pool;
-  if (::listen(ListenSocket, /*MaxBacklog=*/Pool.getThreadCount() * 16))
-    reportError("cannot listen to socket");
 
   DiagnosticsEngine Diags(new DiagnosticIDs(), new DiagnosticOptions());
   CASOptions CASOpts;


### PR DESCRIPTION
For the `-execute` daemon mode, `::listen()` is needed to fully prepare the socket before executing the command; otherwise it's possible the command may start before the `ScanServer::listen()` function and fail to connect to the socket.