### PR TITLE
[CMake] Only enable LLVM_ENABLE_ONDISK_CAS_default for 64-bit or larger architectures

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -625,7 +625,7 @@ option (LLVM_ENABLE_SPHINX "Use Sphinx to generate llvm documentation." OFF)
 option (LLVM_ENABLE_OCAMLDOC "Build OCaml bindings documentation." ON)
 option (LLVM_ENABLE_BINDINGS "Build bindings." ON)
 
-if(UNIX)
+if(UNIX AND CMAKE_SIZEOF_VOID_P GREATER_EQUAL 8)
   set(LLVM_ENABLE_ONDISK_CAS_default ON)
 else()
   set(LLVM_ENABLE_ONDISK_CAS_default OFF)


### PR DESCRIPTION
This [currently breaks when building the Swift toolchain for Android armv7](https://github.com/buttaface/termux-packages/actions/runs/3782196643/jobs/6429725153#step:6:4602), so [I have it disabled](https://github.com/buttaface/termux-packages/commit/17b135319d3b4b7614f80bd94a3652dd22b9a1d5#diff-b88813731694daf66031cd2af3211e6e909707416aa273dde2ef7add02fe7762R8) there [by default for the last couple months](https://github.com/buttaface/termux-packages/commit/17b135319d3b4b7614f80bd94a3652dd22b9a1d5#diff-a3bcec5381cf1ae076d0c16e6be6792a91869d20be55c919085f0704fa11424cR117).

Instead, this pull should only enable it by default for commonly used 64-bit architectures, until someone gets it working for 32-bit architectures.

@cachemeifyoucan, please review whenever you get back from break.