### PR TITLE
[lldb][Test] TestRerunAndExpr.py: explicitly delete a.out before rebuilding it

### DIFF
--- a/lldb/test/API/functionalities/rerun_and_expr_dylib/TestRerunAndExprDylib.py
+++ b/lldb/test/API/functionalities/rerun_and_expr_dylib/TestRerunAndExprDylib.py
@@ -52,6 +52,9 @@ class TestRerunExprDylib(TestBase):
                 ValueCheck(name='m_val', value='42')
             ])
 
+        # Delete the dylib to force make to rebuild it.
+        remove_file(self.getBuildArtifact(FULL_DYLIB_NAME))
+
         # Re-build libfoo.dylib
         self.build(dictionary={'DYLIB_CXX_SOURCES':'rebuild.cpp',
                                'DYLIB_ONLY':'YES',


### PR DESCRIPTION
This applies the same fix as in `ad3870d6552305d2d6bd6aa2faca6f0644052d9a` for `TestRerunAndExpr.py` to this test.

D138724

(cherry picked from commit 2a0829d83fc6d1701940ad9f429b6ae47009f369)