### PR TITLE
Fix typeo in LoadBinariesViaExhaustiveSearch when looking for kernel

### DIFF
--- a/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
+++ b/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
@@ -357,7 +357,7 @@ void ProcessMachCore::LoadBinariesViaExhaustiveSearch() {
         if (dyld != LLDB_INVALID_ADDRESS)
           dylds_found.push_back(dyld);
         if (kernel != LLDB_INVALID_ADDRESS)
-          kernels_found.push_back(dyld);
+          kernels_found.push_back(kernel);
       }
     }
   }


### PR DESCRIPTION
Fix typeo in LoadBinariesViaExhaustiveSearch when looking for kernel

As a last resort, with a Mach-O corefile, lldb will iterate through all memory segments looking for a dyld binary (for a userland process core dump) or an xnu kernel binary (kernel coredump).  We often have metadata via LC_NOTEs so this final search mechanism is not needed.  During the rewrite in https://reviews.llvm.org/D133680 I did not handle the case of finding the xnu kernel by exhaustive search correctly.

rdar://103813200
(cherry picked from commit 0dc7ecb1a70ec9f6eb41ebb4d1edf5d2acdfb4ce)