### PR TITLE
[ObjC][ARC] Fix non-deterministic behavior in ProvenanceAnalysis

### DIFF
--- a/llvm/lib/Transforms/ObjCARC/ProvenanceAnalysis.cpp
+++ b/llvm/lib/Transforms/ObjCARC/ProvenanceAnalysis.cpp
@@ -42,10 +42,16 @@ bool ProvenanceAnalysis::relatedSelect(const SelectInst *A,
                                        const Value *B) {
   // If the values are Selects with the same condition, we can do a more precise
   // check: just check for relations between the values on corresponding arms.
-  if (const SelectInst *SB = dyn_cast<SelectInst>(B))
+  if (const SelectInst *SB = dyn_cast<SelectInst>(B)) {
     if (A->getCondition() == SB->getCondition())
       return related(A->getTrueValue(), SB->getTrueValue()) ||
              related(A->getFalseValue(), SB->getFalseValue());
+
+    // Check both arms of B individually. Return false if neither arm is related
+    // to A.
+    if (!(related(SB->getTrueValue(), A) || related(SB->getFalseValue(), A)))
+      return false;
+  }
 
   // Check both arms of the Select node individually.
   return related(A->getTrueValue(), B) || related(A->getFalseValue(), B);

--- a/llvm/test/Transforms/ObjCARC/related-check.ll
+++ b/llvm/test/Transforms/ObjCARC/related-check.ll
@@ -137,6 +137,19 @@ define i8* @foo() {
   ret i8* %call78
 }
 
+; CHECK-LABEL: define void @test_select(
+; CHECK: call ptr @llvm.objc.retain(
+; CHECK: call void @llvm.objc.release(
+
+define void @test_select(i1 %c0, i1 %c1, i8* %p0, i8* %p1) {
+  %cond = select i1 %c0, i8* %p0, i8* %p1
+  %cond5 = select i1 %c0, i8* %p1, i8* %p0
+  %cond14 = select i1 %c1, i8* %cond5, i8* null
+  call i8* @llvm.objc.retain(i8* %cond14)
+  call void @llvm.objc.release(i8* %cond)
+  ret void
+}
+
 declare i8* @bar(i8*)
 
 declare i8* @llvm.objc.retain(i8*)


### PR DESCRIPTION
If the second value passed to relatedSelect is a select, check whether neither arm of the select is related to the first value.

(cherry picked from commit 665e47777df17db406c698d57b4f3c28d67c432e)

Conflicts:
	llvm/test/Transforms/ObjCARC/related-check.ll