### PR TITLE
[lldb/Commands] Prevent crash due to reading memory from page zero.

### DIFF
--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -593,7 +593,10 @@ protected:
       return false;
     }
 
-    ABISP abi = m_exe_ctx.GetProcessPtr()->GetABI();
+    ABISP abi;
+    if (Process *proc = m_exe_ctx.GetProcessPtr())
+      abi = proc->GetABI();
+
     if (abi)
       addr = abi->FixDataAddress(addr);
 

--- a/lldb/test/Shell/Driver/TestPageZeroRead.test
+++ b/lldb/test/Shell/Driver/TestPageZeroRead.test
@@ -1,0 +1,6 @@
+# REQUIRES: system-darwin
+# Ensure that the read from memory command doesn't try and read from page zero.
+# RUN: %clang_host %p/Inputs/hello.c -g -o a.out
+# RUN: %lldb -b a.out -o 'settings set interpreter.stop-command-source-on-error false' -s %s 2>&1 | FileCheck %s
+x 0
+# CHECK: error: error reading data from section __PAGEZERO


### PR DESCRIPTION
Adds a check to ensure that a process exists before attempting to get
its ABI to prevent lldb from crashing due to trying to read from page zero.

Differential revision: https://reviews.llvm.org/D127016

(cherry picked from commit 0f02dd34f22650d8af0070e7ad21632525e33da8)
