### PR TITLE
Revert an unintentional API ABI break

### DIFF
--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -434,7 +434,10 @@ FLAGS_ENUM(WatchpointEventType){
 /// specification for ease of use and consistency.
 /// The enum -> string code is in Language.cpp, don't change this
 /// table without updating that code as well.
-enum LanguageType : uint16_t {
+///
+/// This datatype is used in SBExpressionOptions::SetLanguage() which
+/// makes this type API. Do not change its underlying storage type!
+enum LanguageType {
   eLanguageTypeUnknown = 0x0000,        ///< Unknown or invalid language value.
   eLanguageTypeC89 = 0x0001,            ///< ISO C:1989.
   eLanguageTypeC = 0x0002,              ///< Non-standardized C, such as K&R.


### PR DESCRIPTION
lldb::LanguageType is used as a parameter in
SBExpressionOptions::SetLanguage(), which actually makes this type API too. Commit 6eaedbb52f2a616e644e5acc7279c8b07c4cfe82 added a `: uint16_t` to it, which broke binary compatibility for the SBAPI. This patch reverts to the original enum.

I tried moving the entire enum into include/API, but that created a cyclic module dependency between API and Utility. To keep things simple, this just reverts to the original code and adds a warning.

rdar://103415402

Differential Revision: https://reviews.llvm.org/D141087

(cherry picked from commit 69f2b5fcf1be2226181cce21066f072279ba5d14)