### PR TITLE
Remove the dependency between lib/DebugInfoDWARF and MC.

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -73,9 +73,21 @@ void DWARFExpression::UpdateValue(uint64_t const_value,
 
 void DWARFExpression::DumpLocation(Stream *s, lldb::DescriptionLevel level,
                                    ABI *abi) const {
+  std::function<llvm::StringRef(uint64_t DwarfRegNum, bool IsEH)> GetRegName;
+  if (abi) {
+    auto RegInfo = abi->GetMCRegisterInfo();
+    GetRegName = [RegInfo](uint64_t DwarfRegNum, bool IsEH) -> llvm::StringRef {
+      if (llvm::Optional<unsigned> LLVMRegNum =
+              RegInfo.getLLVMRegNum(DwarfRegNum, IsEH))
+        if (const char *RegName = RegInfo.getName(*LLVMRegNum))
+          return llvm::StringRef(RegName);
+      return {};
+    };
+  }
+  auto DumpOpts = llvm::DIDumpOptions();
+  DumpOpts.GetNameForDWARFReg = GetRegName;
   llvm::DWARFExpression(m_data.GetAsLLVM(), m_data.GetAddressByteSize())
-      .print(s->AsRawOstream(), llvm::DIDumpOptions(),
-             abi ? &abi->GetMCRegisterInfo() : nullptr, nullptr);
+      .print(s->AsRawOstream(), DumpOpts, nullptr);
 }
 
 RegisterKind DWARFExpression::GetRegisterKind() const { return m_reg_kind; }

--- a/lldb/source/Symbol/UnwindPlan.cpp
+++ b/lldb/source/Symbol/UnwindPlan.cpp
@@ -84,7 +84,7 @@ static void DumpDWARFExpr(Stream &s, llvm::ArrayRef<uint8_t> expr, Thread *threa
     llvm::DataExtractor data(expr, order_and_width->first == eByteOrderLittle,
                              order_and_width->second);
     llvm::DWARFExpression(data, order_and_width->second, llvm::dwarf::DWARF32)
-        .print(s.AsRawOstream(), llvm::DIDumpOptions(), nullptr, nullptr);
+        .print(s.AsRawOstream(), llvm::DIDumpOptions(), nullptr);
   } else
     s.PutCString("dwarf-expr");
 }

--- a/lldb/unittests/Symbol/PostfixExpressionTest.cpp
+++ b/lldb/unittests/Symbol/PostfixExpressionTest.cpp
@@ -159,7 +159,7 @@ static std::string ParseAndGenerateDWARF(llvm::StringRef expr) {
   std::string result;
   llvm::raw_string_ostream os(result);
   llvm::DWARFExpression(extractor, addr_size, llvm::dwarf::DWARF32)
-      .print(os, llvm::DIDumpOptions(), nullptr, nullptr);
+      .print(os, llvm::DIDumpOptions(), nullptr);
   return std::move(os.str());
 }
 

--- a/lldb/unittests/SymbolFile/NativePDB/PdbFPOProgramToDWARFExpressionTests.cpp
+++ b/lldb/unittests/SymbolFile/NativePDB/PdbFPOProgramToDWARFExpressionTests.cpp
@@ -40,7 +40,7 @@ CheckValidProgramTranslation(llvm::StringRef fpo_program,
   std::string result;
   llvm::raw_string_ostream os(result);
   llvm::DWARFExpression(extractor, /*AddressSize=*/4, llvm::dwarf::DWARF32)
-      .print(os, llvm::DIDumpOptions(), nullptr, nullptr);
+      .print(os, llvm::DIDumpOptions(), nullptr);
 
   // actual check
   ASSERT_EQ(expected_dwarf_expression, os.str());

--- a/llvm/include/llvm/DebugInfo/DIContext.h
+++ b/llvm/include/llvm/DebugInfo/DIContext.h
@@ -198,6 +198,9 @@ struct DIDumpOptions {
   bool SummarizeTypes = false;
   bool Verbose = false;
   bool DisplayRawContents = false;
+  bool IsEH = false;
+  std::function<llvm::StringRef(uint64_t DwarfRegNum, bool IsEH)>
+      GetNameForDWARFReg;
 
   /// Return default option set for printing a single DIE without children.
   static DIDumpOptions getForSingleDIE() {

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
@@ -27,7 +27,6 @@
 
 namespace llvm {
 
-class MCRegisterInfo;
 class MemoryBuffer;
 class AppleAcceleratorTable;
 class DWARFCompileUnit;
@@ -81,9 +80,6 @@ class DWARFContext : public DIContext {
   std::weak_ptr<DWOFile> DWP;
   bool CheckedForDWP = false;
   std::string DWPName;
-
-  std::unique_ptr<MCRegisterInfo> RegInfo;
-
   std::function<void(Error)> RecoverableErrorHandler =
       WithColor::defaultErrorHandler;
   std::function<void(Error)> WarningHandler = WithColor::defaultWarningHandler;
@@ -408,8 +404,6 @@ public:
 
   std::shared_ptr<DWARFContext> getDWOContext(StringRef AbsolutePath);
 
-  const MCRegisterInfo *getRegisterInfo() const { return RegInfo.get(); }
-
   function_ref<void(Error)> getRecoverableErrorHandler() {
     return RecoverableErrorHandler;
   }
@@ -434,11 +428,6 @@ public:
              WithColor::defaultErrorHandler,
          std::function<void(Error)> WarningHandler =
              WithColor::defaultWarningHandler);
-
-  /// Loads register info for the architecture of the provided object file.
-  /// Improves readability of dumped DWARF expressions. Requires the caller to
-  /// have initialized the relevant target descriptions.
-  Error loadRegisterInfo(const object::ObjectFile &Obj);
 
   /// Get address size from CUs.
   /// TODO: refactor compile_units() to make this const.

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugFrame.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugFrame.h
@@ -162,7 +162,7 @@ public:
   /// instead of from .debug_frame. This is needed for register number
   /// conversion because some register numbers differ between the two sections
   /// for certain architectures like x86.
-  void dump(raw_ostream &OS, const MCRegisterInfo *MRI, bool IsEH) const;
+  void dump(raw_ostream &OS, DIDumpOptions DumpOpts) const;
 
   bool operator==(const UnwindLocation &RHS) const;
 };
@@ -220,7 +220,7 @@ public:
   /// instead of from .debug_frame. This is needed for register number
   /// conversion because some register numbers differ between the two sections
   /// for certain architectures like x86.
-  void dump(raw_ostream &OS, const MCRegisterInfo *MRI, bool IsEH) const;
+  void dump(raw_ostream &OS, DIDumpOptions DumpOpts) const;
 
   /// Returns true if we have any register locations in this object.
   bool hasLocations() const { return !Locations.empty(); }
@@ -301,7 +301,7 @@ public:
   ///
   /// \param IndentLevel specify the indent level as an integer. The UnwindRow
   /// will be output to the stream preceded by 2 * IndentLevel number of spaces.
-  void dump(raw_ostream &OS, const MCRegisterInfo *MRI, bool IsEH,
+  void dump(raw_ostream &OS, DIDumpOptions DumpOpts,
             unsigned IndentLevel = 0) const;
 };
 
@@ -346,7 +346,7 @@ public:
   ///
   /// \param IndentLevel specify the indent level as an integer. The UnwindRow
   /// will be output to the stream preceded by 2 * IndentLevel number of spaces.
-  void dump(raw_ostream &OS, const MCRegisterInfo *MRI, bool IsEH,
+  void dump(raw_ostream &OS, DIDumpOptions DumpOpts,
             unsigned IndentLevel = 0) const;
 
   /// Create an UnwindTable from a Common Information Entry (CIE).
@@ -452,8 +452,8 @@ public:
   /// where a problem occurred in case an error is returned.
   Error parse(DWARFDataExtractor Data, uint64_t *Offset, uint64_t EndOffset);
 
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts, const MCRegisterInfo *MRI,
-            bool IsEH, unsigned IndentLevel = 1) const;
+  void dump(raw_ostream &OS, DIDumpOptions DumpOpts,
+            unsigned IndentLevel = 1) const;
 
   void addInstruction(const Instruction &I) { Instructions.push_back(I); }
 
@@ -521,7 +521,6 @@ private:
 
   /// Print \p Opcode's operand number \p OperandIdx which has value \p Operand.
   void printOperand(raw_ostream &OS, DIDumpOptions DumpOpts,
-                    const MCRegisterInfo *MRI, bool IsEH,
                     const Instruction &Instr, unsigned OperandIdx,
                     uint64_t Operand) const;
 };
@@ -546,8 +545,7 @@ public:
   CFIProgram &cfis() { return CFIs; }
 
   /// Dump the instructions in this CFI fragment
-  virtual void dump(raw_ostream &OS, DIDumpOptions DumpOpts,
-                    const MCRegisterInfo *MRI, bool IsEH) const = 0;
+  virtual void dump(raw_ostream &OS, DIDumpOptions DumpOpts) const = 0;
 
 protected:
   const FrameKind Kind;
@@ -601,8 +599,7 @@ public:
 
   uint32_t getLSDAPointerEncoding() const { return LSDAPointerEncoding; }
 
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts, const MCRegisterInfo *MRI,
-            bool IsEH) const override;
+  void dump(raw_ostream &OS, DIDumpOptions DumpOpts) const override;
 
 private:
   /// The following fields are defined in section 6.4.1 of the DWARF standard v4
@@ -642,8 +639,7 @@ public:
   uint64_t getAddressRange() const { return AddressRange; }
   Optional<uint64_t> getLSDAAddress() const { return LSDAAddress; }
 
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts, const MCRegisterInfo *MRI,
-            bool IsEH) const override;
+  void dump(raw_ostream &OS, DIDumpOptions DumpOpts) const override;
 
   static bool classof(const FrameEntry *FE) { return FE->getKind() == FK_FDE; }
 
@@ -685,7 +681,7 @@ public:
   ~DWARFDebugFrame();
 
   /// Dump the section data into the given stream.
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts, const MCRegisterInfo *MRI,
+  void dump(raw_ostream &OS, DIDumpOptions DumpOpts,
             Optional<uint64_t> Offset) const;
 
   /// Parse the section from raw data. \p Data is assumed to contain the whole

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLoc.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLoc.h
@@ -67,9 +67,8 @@ public:
   /// updated to point past the end of the current list).
   bool dumpLocationList(uint64_t *Offset, raw_ostream &OS,
                         Optional<object::SectionedAddress> BaseAddr,
-                        const MCRegisterInfo *MRI, const DWARFObject &Obj,
-                        DWARFUnit *U, DIDumpOptions DumpOpts,
-                        unsigned Indent) const;
+                        const DWARFObject &Obj, DWARFUnit *U,
+                        DIDumpOptions DumpOpts, unsigned Indent) const;
 
   Error visitAbsoluteLocationList(
       uint64_t Offset, Optional<object::SectionedAddress> BaseAddr,
@@ -109,8 +108,7 @@ public:
       : DWARFLocationTable(std::move(Data)) {}
 
   /// Print the location lists found within the debug_loc section.
-  void dump(raw_ostream &OS, const MCRegisterInfo *RegInfo,
-            const DWARFObject &Obj, DIDumpOptions DumpOpts,
+  void dump(raw_ostream &OS, const DWARFObject &Obj, DIDumpOptions DumpOpts,
             Optional<uint64_t> Offset) const;
 
   Error visitLocationList(
@@ -134,8 +132,7 @@ public:
 
   /// Dump all location lists within the given range.
   void dumpRange(uint64_t StartOffset, uint64_t Size, raw_ostream &OS,
-                 const MCRegisterInfo *MRI, const DWARFObject &Obj,
-                 DIDumpOptions DumpOpts);
+                 const DWARFObject &Obj, DIDumpOptions DumpOpts);
 
 protected:
   void dumpRawEntry(const DWARFLocationEntry &Entry, raw_ostream &OS,

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFExpression.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFExpression.h
@@ -94,8 +94,7 @@ public:
     uint64_t getEndOffset() const { return EndOffset; }
     bool isError() const { return Error; }
     bool print(raw_ostream &OS, DIDumpOptions DumpOpts,
-               const DWARFExpression *Expr, const MCRegisterInfo *RegInfo,
-               DWARFUnit *U, bool isEH) const;
+               const DWARFExpression *Expr, DWARFUnit *U) const;
 
     /// Verify \p Op. Does not affect the return of \a isError().
     static bool verify(const Operation &Op, DWARFUnit *U);
@@ -148,15 +147,15 @@ public:
   iterator begin() const { return iterator(this, 0); }
   iterator end() const { return iterator(this, Data.getData().size()); }
 
-  void print(raw_ostream &OS, DIDumpOptions DumpOpts,
-             const MCRegisterInfo *RegInfo, DWARFUnit *U,
-             bool IsEH = false) const;
+  void print(raw_ostream &OS, DIDumpOptions DumpOpts, DWARFUnit *U) const;
 
   /// Print the expression in a format intended to be compact and useful to a
   /// user, but not perfectly unambiguous, or capable of representing every
   /// valid DWARF expression. Returns true if the expression was sucessfully
   /// printed.
-  bool printCompact(raw_ostream &OS, const MCRegisterInfo &RegInfo);
+  bool printCompact(raw_ostream &OS,
+                    std::function<StringRef(uint64_t RegNum, bool IsEH)>
+                        GetNameForDWARFReg = nullptr);
 
   bool verify(DWARFUnit *U);
 

--- a/llvm/lib/DebugInfo/DWARF/CMakeLists.txt
+++ b/llvm/lib/DebugInfo/DWARF/CMakeLists.txt
@@ -36,6 +36,5 @@ add_llvm_component_library(LLVMDebugInfoDWARF
   LINK_COMPONENTS
   BinaryFormat
   Object
-  MC
   Support
   )

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -38,7 +38,6 @@
 #include "llvm/DebugInfo/DWARF/DWARFTypeUnit.h"
 #include "llvm/DebugInfo/DWARF/DWARFUnitIndex.h"
 #include "llvm/DebugInfo/DWARF/DWARFVerifier.h"
-#include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Object/Decompressor.h"
 #include "llvm/Object/MachO.h"
@@ -309,9 +308,7 @@ DWARFContext::parseMacroOrMacinfo(MacroSecType SectionType) {
 }
 
 static void dumpLoclistsSection(raw_ostream &OS, DIDumpOptions DumpOpts,
-                                DWARFDataExtractor Data,
-                                const MCRegisterInfo *MRI,
-                                const DWARFObject &Obj,
+                                DWARFDataExtractor Data, const DWARFObject &Obj,
                                 Optional<uint64_t> DumpOffset) {
   uint64_t Offset = 0;
 
@@ -330,13 +327,13 @@ static void dumpLoclistsSection(raw_ostream &OS, DIDumpOptions DumpOpts,
     if (DumpOffset) {
       if (DumpOffset >= Offset && DumpOffset < EndOffset) {
         Offset = *DumpOffset;
-        Loc.dumpLocationList(&Offset, OS, /*BaseAddr=*/None, MRI, Obj, nullptr,
+        Loc.dumpLocationList(&Offset, OS, /*BaseAddr=*/None, Obj, nullptr,
                              DumpOpts, /*Indent=*/0);
         OS << "\n";
         return;
       }
     } else {
-      Loc.dumpRange(Offset, EndOffset - Offset, OS, MRI, Obj, DumpOpts);
+      Loc.dumpRange(Offset, EndOffset - Offset, OS, Obj, DumpOpts);
     }
     Offset = EndOffset;
   }
@@ -424,21 +421,21 @@ void DWARFContext::dump(
 
   if (const auto *Off = shouldDump(Explicit, ".debug_loc", DIDT_ID_DebugLoc,
                                    DObj->getLocSection().Data)) {
-    getDebugLoc()->dump(OS, getRegisterInfo(), *DObj, LLDumpOpts, *Off);
+    getDebugLoc()->dump(OS, *DObj, LLDumpOpts, *Off);
   }
   if (const auto *Off =
           shouldDump(Explicit, ".debug_loclists", DIDT_ID_DebugLoclists,
                      DObj->getLoclistsSection().Data)) {
     DWARFDataExtractor Data(*DObj, DObj->getLoclistsSection(), isLittleEndian(),
                             0);
-    dumpLoclistsSection(OS, LLDumpOpts, Data, getRegisterInfo(), *DObj, *Off);
+    dumpLoclistsSection(OS, LLDumpOpts, Data, *DObj, *Off);
   }
   if (const auto *Off =
           shouldDump(ExplicitDWO, ".debug_loclists.dwo", DIDT_ID_DebugLoclists,
                      DObj->getLoclistsDWOSection().Data)) {
     DWARFDataExtractor Data(*DObj, DObj->getLoclistsDWOSection(),
                             isLittleEndian(), 0);
-    dumpLoclistsSection(OS, LLDumpOpts, Data, getRegisterInfo(), *DObj, *Off);
+    dumpLoclistsSection(OS, LLDumpOpts, Data, *DObj, *Off);
   }
 
   if (const auto *Off =
@@ -450,12 +447,11 @@ void DWARFContext::dump(
     if (*Off) {
       uint64_t Offset = **Off;
       Loc.dumpLocationList(&Offset, OS,
-                           /*BaseAddr=*/None, getRegisterInfo(), *DObj, nullptr,
-                           LLDumpOpts, /*Indent=*/0);
+                           /*BaseAddr=*/None, *DObj, nullptr, LLDumpOpts,
+                           /*Indent=*/0);
       OS << "\n";
     } else {
-      Loc.dumpRange(0, Data.getData().size(), OS, getRegisterInfo(), *DObj,
-                    LLDumpOpts);
+      Loc.dumpRange(0, Data.getData().size(), OS, *DObj, LLDumpOpts);
     }
   }
 
@@ -463,7 +459,7 @@ void DWARFContext::dump(
           shouldDump(Explicit, ".debug_frame", DIDT_ID_DebugFrame,
                      DObj->getFrameSection().Data)) {
     if (Expected<const DWARFDebugFrame *> DF = getDebugFrame())
-      (*DF)->dump(OS, DumpOpts, getRegisterInfo(), *Off);
+      (*DF)->dump(OS, DumpOpts, *Off);
     else
       RecoverableErrorHandler(DF.takeError());
   }
@@ -472,7 +468,7 @@ void DWARFContext::dump(
           shouldDump(Explicit, ".eh_frame", DIDT_ID_DebugFrame,
                      DObj->getEHFrameSection().Data)) {
     if (Expected<const DWARFDebugFrame *> DF = getEHFrame())
-      (*DF)->dump(OS, DumpOpts, getRegisterInfo(), *Off);
+      (*DF)->dump(OS, DumpOpts, *Off);
     else
       RecoverableErrorHandler(DF.takeError());
   }
@@ -2017,23 +2013,6 @@ DWARFContext::create(const StringMap<std::unique_ptr<MemoryBuffer>> &Sections,
       std::make_unique<DWARFObjInMemory>(Sections, AddrSize, isLittleEndian);
   return std::make_unique<DWARFContext>(
       std::move(DObj), "", RecoverableErrorHandler, WarningHandler);
-}
-
-Error DWARFContext::loadRegisterInfo(const object::ObjectFile &Obj) {
-  // Detect the architecture from the object file. We usually don't need OS
-  // info to lookup a target and create register info.
-  Triple TT;
-  TT.setArch(Triple::ArchType(Obj.getArch()));
-  TT.setVendor(Triple::UnknownVendor);
-  TT.setOS(Triple::UnknownOS);
-  std::string TargetLookupError;
-  const Target *TheTarget =
-      TargetRegistry::lookupTarget(TT.str(), TargetLookupError);
-  if (!TargetLookupError.empty())
-    return createStringError(errc::invalid_argument,
-                             TargetLookupError.c_str());
-  RegInfo.reset(TheTarget->createMCRegInfo(TT.str()));
-  return Error::success();
 }
 
 uint8_t DWARFContext::getCUAddrSize() {

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLoc.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLoc.cpp
@@ -110,19 +110,17 @@ DWARFLocationInterpreter::Interpret(const DWARFLocationEntry &E) {
 
 static void dumpExpression(raw_ostream &OS, DIDumpOptions DumpOpts,
                            ArrayRef<uint8_t> Data, bool IsLittleEndian,
-                           unsigned AddressSize, const MCRegisterInfo *MRI,
-                           DWARFUnit *U) {
+                           unsigned AddressSize, DWARFUnit *U) {
   DWARFDataExtractor Extractor(Data, IsLittleEndian, AddressSize);
   // Note. We do not pass any format to DWARFExpression, even if the
   // corresponding unit is known. For now, there is only one operation,
   // DW_OP_call_ref, which depends on the format; it is rarely used, and
   // is unexpected in location tables.
-  DWARFExpression(Extractor, AddressSize).print(OS, DumpOpts, MRI, U);
+  DWARFExpression(Extractor, AddressSize).print(OS, DumpOpts, U);
 }
 
 bool DWARFLocationTable::dumpLocationList(uint64_t *Offset, raw_ostream &OS,
                                           Optional<SectionedAddress> BaseAddr,
-                                          const MCRegisterInfo *MRI,
                                           const DWARFObject &Obj, DWARFUnit *U,
                                           DIDumpOptions DumpOpts,
                                           unsigned Indent) const {
@@ -158,7 +156,7 @@ bool DWARFLocationTable::dumpLocationList(uint64_t *Offset, raw_ostream &OS,
         E.Kind != dwarf::DW_LLE_end_of_list) {
       OS << ": ";
       dumpExpression(OS, DumpOpts, E.Loc, Data.isLittleEndian(),
-                     Data.getAddressSize(), MRI, U);
+                     Data.getAddressSize(), U);
     }
     return true;
   });
@@ -184,13 +182,13 @@ Error DWARFLocationTable::visitAbsoluteLocationList(
   });
 }
 
-void DWARFDebugLoc::dump(raw_ostream &OS, const MCRegisterInfo *MRI,
-                         const DWARFObject &Obj, DIDumpOptions DumpOpts,
+void DWARFDebugLoc::dump(raw_ostream &OS, const DWARFObject &Obj,
+                         DIDumpOptions DumpOpts,
                          Optional<uint64_t> DumpOffset) const {
   auto BaseAddr = None;
   unsigned Indent = 12;
   if (DumpOffset) {
-    dumpLocationList(&*DumpOffset, OS, BaseAddr, MRI, Obj, nullptr, DumpOpts,
+    dumpLocationList(&*DumpOffset, OS, BaseAddr, Obj, nullptr, DumpOpts,
                      Indent);
   } else {
     uint64_t Offset = 0;
@@ -200,7 +198,7 @@ void DWARFDebugLoc::dump(raw_ostream &OS, const MCRegisterInfo *MRI,
       OS << Separator;
       Separator = "\n";
 
-      CanContinue = dumpLocationList(&Offset, OS, BaseAddr, MRI, Obj, nullptr,
+      CanContinue = dumpLocationList(&Offset, OS, BaseAddr, Obj, nullptr,
                                      DumpOpts, Indent);
       OS << '\n';
     }
@@ -387,8 +385,7 @@ void DWARFDebugLoclists::dumpRawEntry(const DWARFLocationEntry &Entry,
 }
 
 void DWARFDebugLoclists::dumpRange(uint64_t StartOffset, uint64_t Size,
-                                   raw_ostream &OS, const MCRegisterInfo *MRI,
-                                   const DWARFObject &Obj,
+                                   raw_ostream &OS, const DWARFObject &Obj,
                                    DIDumpOptions DumpOpts) {
   if (!Data.isValidOffsetForDataOfSize(StartOffset, Size))  {
     OS << "Invalid dump range\n";
@@ -401,8 +398,8 @@ void DWARFDebugLoclists::dumpRange(uint64_t StartOffset, uint64_t Size,
     OS << Separator;
     Separator = "\n";
 
-    CanContinue = dumpLocationList(&Offset, OS, /*BaseAddr=*/None, MRI, Obj,
-                                   nullptr, DumpOpts, /*Indent=*/12);
+    CanContinue = dumpLocationList(&Offset, OS, /*BaseAddr=*/None, Obj, nullptr,
+                                   DumpOpts, /*Indent=*/12);
     OS << '\n';
   }
 }

--- a/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
@@ -76,7 +76,6 @@ static void dumpLocationList(raw_ostream &OS, const DWARFFormValue &FormValue,
   assert(FormValue.isFormClass(DWARFFormValue::FC_SectionOffset) &&
          "bad FORM for location list");
   DWARFContext &Ctx = U->getContext();
-  const MCRegisterInfo *MRI = Ctx.getRegisterInfo();
   uint64_t Offset = *FormValue.getAsSectionOffset();
 
   if (FormValue.getForm() == DW_FORM_loclistx) {
@@ -87,9 +86,8 @@ static void dumpLocationList(raw_ostream &OS, const DWARFFormValue &FormValue,
     else
       return;
   }
-  U->getLocationTable().dumpLocationList(&Offset, OS, U->getBaseAddress(), MRI,
-                                         Ctx.getDWARFObj(), U, DumpOpts,
-                                         Indent);
+  U->getLocationTable().dumpLocationList(
+      &Offset, OS, U->getBaseAddress(), Ctx.getDWARFObj(), U, DumpOpts, Indent);
 }
 
 static void dumpLocationExpr(raw_ostream &OS, const DWARFFormValue &FormValue,
@@ -99,12 +97,11 @@ static void dumpLocationExpr(raw_ostream &OS, const DWARFFormValue &FormValue,
           FormValue.isFormClass(DWARFFormValue::FC_Exprloc)) &&
          "bad FORM for location expression");
   DWARFContext &Ctx = U->getContext();
-  const MCRegisterInfo *MRI = Ctx.getRegisterInfo();
   ArrayRef<uint8_t> Expr = *FormValue.getAsBlock();
   DataExtractor Data(StringRef((const char *)Expr.data(), Expr.size()),
                      Ctx.isLittleEndian(), 0);
   DWARFExpression(Data, U->getAddressByteSize(), U->getFormParams().Format)
-      .print(OS, DumpOpts, MRI, U);
+      .print(OS, DumpOpts, U);
 }
 
 static DWARFDie resolveReferencedType(DWARFDie D, DWARFFormValue F) {

--- a/llvm/lib/DebugInfo/DWARF/DWARFExpression.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFExpression.cpp
@@ -8,7 +8,6 @@
 
 #include "llvm/DebugInfo/DWARF/DWARFExpression.h"
 #include "llvm/DebugInfo/DWARF/DWARFUnit.h"
-#include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/Support/Format.h"
 #include <cassert>
 #include <cstdint>
@@ -227,9 +226,8 @@ static void prettyPrintBaseTypeRef(DWARFUnit *U, raw_ostream &OS,
 
 static bool prettyPrintRegisterOp(DWARFUnit *U, raw_ostream &OS,
                                   DIDumpOptions DumpOpts, uint8_t Opcode,
-                                  const uint64_t Operands[2],
-                                  const MCRegisterInfo *MRI, bool isEH) {
-  if (!MRI)
+                                  const uint64_t Operands[2]) {
+  if (!DumpOpts.GetNameForDWARFReg)
     return false;
 
   uint64_t DwarfRegNum;
@@ -243,18 +241,17 @@ static bool prettyPrintRegisterOp(DWARFUnit *U, raw_ostream &OS,
   else
     DwarfRegNum = Opcode - DW_OP_reg0;
 
-  if (Optional<unsigned> LLVMRegNum = MRI->getLLVMRegNum(DwarfRegNum, isEH)) {
-    if (const char *RegName = MRI->getName(*LLVMRegNum)) {
-      if ((Opcode >= DW_OP_breg0 && Opcode <= DW_OP_breg31) ||
-          Opcode == DW_OP_bregx)
-        OS << format(" %s%+" PRId64, RegName, Operands[OpNum]);
-      else
-        OS << ' ' << RegName;
+  auto RegName = DumpOpts.GetNameForDWARFReg(DwarfRegNum, DumpOpts.IsEH);
+  if (!RegName.empty()) {
+    if ((Opcode >= DW_OP_breg0 && Opcode <= DW_OP_breg31) ||
+        Opcode == DW_OP_bregx)
+      OS << ' ' << RegName << format("%+" PRId64, Operands[OpNum]);
+    else
+      OS << ' ' << RegName.data();
 
-      if (Opcode == DW_OP_regval_type)
-        prettyPrintBaseTypeRef(U, OS, DumpOpts, Operands, 1);
-      return true;
-    }
+    if (Opcode == DW_OP_regval_type)
+      prettyPrintBaseTypeRef(U, OS, DumpOpts, Operands, 1);
+    return true;
   }
 
   return false;
@@ -262,8 +259,7 @@ static bool prettyPrintRegisterOp(DWARFUnit *U, raw_ostream &OS,
 
 bool DWARFExpression::Operation::print(raw_ostream &OS, DIDumpOptions DumpOpts,
                                        const DWARFExpression *Expr,
-                                       const MCRegisterInfo *RegInfo,
-                                       DWARFUnit *U, bool isEH) const {
+                                       DWARFUnit *U) const {
   if (Error) {
     OS << "<decoding error>";
     return false;
@@ -277,7 +273,7 @@ bool DWARFExpression::Operation::print(raw_ostream &OS, DIDumpOptions DumpOpts,
       (Opcode >= DW_OP_reg0 && Opcode <= DW_OP_reg31) ||
       Opcode == DW_OP_bregx || Opcode == DW_OP_regx ||
       Opcode == DW_OP_regval_type)
-    if (prettyPrintRegisterOp(U, OS, DumpOpts, Opcode, Operands, RegInfo, isEH))
+    if (prettyPrintRegisterOp(U, OS, DumpOpts, Opcode, Operands))
       return true;
 
   for (unsigned Operand = 0; Operand < 2; ++Operand) {
@@ -323,15 +319,14 @@ bool DWARFExpression::Operation::print(raw_ostream &OS, DIDumpOptions DumpOpts,
 }
 
 void DWARFExpression::print(raw_ostream &OS, DIDumpOptions DumpOpts,
-                            const MCRegisterInfo *RegInfo, DWARFUnit *U,
-                            bool IsEH) const {
+                            DWARFUnit *U) const {
   uint32_t EntryValExprSize = 0;
   uint64_t EntryValStartOffset = 0;
   if (Data.getData().empty())
     OS << "<empty>";
 
   for (auto &Op : *this) {
-    if (!Op.print(OS, DumpOpts, this, RegInfo, U, IsEH)) {
+    if (!Op.print(OS, DumpOpts, this, U)) {
       uint64_t FailOffset = Op.getEndOffset();
       while (FailOffset < Data.getData().size())
         OS << format(" %02x", Data.getU8(&FailOffset));
@@ -402,9 +397,11 @@ struct PrintedExpr {
   PrintedExpr(ExprKind K = Address) : Kind(K) {}
 };
 
-static bool printCompactDWARFExpr(raw_ostream &OS, DWARFExpression::iterator I,
-                                  const DWARFExpression::iterator E,
-                                  const MCRegisterInfo &MRI) {
+static bool printCompactDWARFExpr(
+    raw_ostream &OS, DWARFExpression::iterator I,
+    const DWARFExpression::iterator E,
+    std::function<StringRef(uint64_t RegNum, bool IsEH)> GetNameForDWARFReg =
+        nullptr) {
   SmallVector<PrintedExpr, 4> Stack;
 
   while (I != E) {
@@ -415,25 +412,21 @@ static bool printCompactDWARFExpr(raw_ostream &OS, DWARFExpression::iterator I,
       // DW_OP_regx: A register, with the register num given as an operand.
       // Printed as the plain register name.
       uint64_t DwarfRegNum = Op.getRawOperand(0);
-      Optional<unsigned> LLVMRegNum = MRI.getLLVMRegNum(DwarfRegNum, false);
-      if (!LLVMRegNum) {
-        OS << "<unknown register " << DwarfRegNum << ">";
+      auto RegName = GetNameForDWARFReg(DwarfRegNum, false);
+      if (RegName.empty())
         return false;
-      }
       raw_svector_ostream S(Stack.emplace_back(PrintedExpr::Value).String);
-      S << MRI.getName(*LLVMRegNum);
+      S << RegName;
       break;
     }
     case dwarf::DW_OP_bregx: {
       int DwarfRegNum = Op.getRawOperand(0);
       int64_t Offset = Op.getRawOperand(1);
-      Optional<unsigned> LLVMRegNum = MRI.getLLVMRegNum(DwarfRegNum, false);
-      if (!LLVMRegNum) {
-        OS << "<unknown register " << DwarfRegNum << ">";
+      auto RegName = GetNameForDWARFReg(DwarfRegNum, false);
+      if (RegName.empty())
         return false;
-      }
       raw_svector_ostream S(Stack.emplace_back().String);
-      S << MRI.getName(*LLVMRegNum);
+      S << RegName;
       if (Offset)
         S << format("%+" PRId64, Offset);
       break;
@@ -447,7 +440,7 @@ static bool printCompactDWARFExpr(raw_ostream &OS, DWARFExpression::iterator I,
       ++I;
       raw_svector_ostream S(Stack.emplace_back().String);
       S << "entry(";
-      printCompactDWARFExpr(S, I, SubExprEnd, MRI);
+      printCompactDWARFExpr(S, I, SubExprEnd, GetNameForDWARFReg);
       S << ")";
       I = SubExprEnd;
       continue;
@@ -464,24 +457,20 @@ static bool printCompactDWARFExpr(raw_ostream &OS, DWARFExpression::iterator I,
         // DW_OP_reg<N>: A register, with the register num implied by the
         // opcode. Printed as the plain register name.
         uint64_t DwarfRegNum = Opcode - dwarf::DW_OP_reg0;
-        Optional<unsigned> LLVMRegNum = MRI.getLLVMRegNum(DwarfRegNum, false);
-        if (!LLVMRegNum) {
-          OS << "<unknown register " << DwarfRegNum << ">";
+        auto RegName = GetNameForDWARFReg(DwarfRegNum, false);
+        if (RegName.empty())
           return false;
-        }
         raw_svector_ostream S(Stack.emplace_back(PrintedExpr::Value).String);
-        S << MRI.getName(*LLVMRegNum);
+        S << RegName;
       } else if (Opcode >= dwarf::DW_OP_breg0 &&
                  Opcode <= dwarf::DW_OP_breg31) {
         int DwarfRegNum = Opcode - dwarf::DW_OP_breg0;
         int64_t Offset = Op.getRawOperand(0);
-        Optional<unsigned> LLVMRegNum = MRI.getLLVMRegNum(DwarfRegNum, false);
-        if (!LLVMRegNum) {
-          OS << "<unknown register " << DwarfRegNum << ">";
+        auto RegName = GetNameForDWARFReg(DwarfRegNum, false);
+        if (RegName.empty())
           return false;
-        }
         raw_svector_ostream S(Stack.emplace_back().String);
-        S << MRI.getName(*LLVMRegNum);
+        S << RegName;
         if (Offset)
           S << format("%+" PRId64, Offset);
       } else {
@@ -506,8 +495,10 @@ static bool printCompactDWARFExpr(raw_ostream &OS, DWARFExpression::iterator I,
   return true;
 }
 
-bool DWARFExpression::printCompact(raw_ostream &OS, const MCRegisterInfo &MRI) {
-  return printCompactDWARFExpr(OS, begin(), end(), MRI);
+bool DWARFExpression::printCompact(
+    raw_ostream &OS,
+    std::function<StringRef(uint64_t RegNum, bool IsEH)> GetNameForDWARFReg) {
+  return printCompactDWARFExpr(OS, begin(), end(), GetNameForDWARFReg);
 }
 
 bool DWARFExpression::operator==(const DWARFExpression &RHS) const {

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -18,6 +18,8 @@
 #include "llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h"
 #include "llvm/DebugInfo/DWARF/DWARFCompileUnit.h"
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/TargetRegistry.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Object/MachOUniversal.h"
 #include "llvm/Object/ObjectFile.h"
@@ -341,9 +343,11 @@ using HandlerFn = std::function<bool(ObjectFile &, DWARFContext &DICtx,
                                      const Twine &, raw_ostream &)>;
 
 /// Print only DIEs that have a certain name.
-static bool filterByName(const StringSet<> &Names, DWARFDie Die,
-                         StringRef NameRef, raw_ostream &OS) {
+static bool filterByName(
+    const StringSet<> &Names, DWARFDie Die, StringRef NameRef, raw_ostream &OS,
+    std::function<StringRef(uint64_t RegNum, bool IsEH)> GetNameForDWARFReg) {
   DIDumpOptions DumpOpts = getDumpOpts(Die.getDwarfUnit()->getContext());
+  DumpOpts.GetNameForDWARFReg = GetNameForDWARFReg;
   std::string Name =
       (IgnoreCase && !UseRegex) ? NameRef.lower() : NameRef.str();
   if (UseRegex) {
@@ -369,17 +373,18 @@ static bool filterByName(const StringSet<> &Names, DWARFDie Die,
 }
 
 /// Print only DIEs that have a certain name.
-static void filterByName(const StringSet<> &Names,
-                         DWARFContext::unit_iterator_range CUs,
-                         raw_ostream &OS) {
+static void filterByName(
+    const StringSet<> &Names, DWARFContext::unit_iterator_range CUs,
+    raw_ostream &OS,
+    std::function<StringRef(uint64_t RegNum, bool IsEH)> GetNameForDWARFReg) {
   for (const auto &CU : CUs)
     for (const auto &Entry : CU->dies()) {
       DWARFDie Die = {CU.get(), &Entry};
       if (const char *Name = Die.getName(DINameKind::ShortName))
-        if (filterByName(Names, Die, Name, OS))
+        if (filterByName(Names, Die, Name, OS, GetNameForDWARFReg))
           continue;
       if (const char *Name = Die.getName(DINameKind::LinkageName))
-        filterByName(Names, Die, Name, OS);
+        filterByName(Names, Die, Name, OS, GetNameForDWARFReg);
     }
 }
 
@@ -423,8 +428,9 @@ static void getDies(DWARFContext &DICtx, const DWARFDebugNames &Accel,
 }
 
 /// Print only DIEs that have a certain name.
-static void filterByAccelName(ArrayRef<std::string> Names, DWARFContext &DICtx,
-                              raw_ostream &OS) {
+static void filterByAccelName(
+    ArrayRef<std::string> Names, DWARFContext &DICtx, raw_ostream &OS,
+    std::function<StringRef(uint64_t RegNum, bool IsEH)> GetNameForDWARFReg) {
   SmallVector<DWARFDie, 4> Dies;
   for (const auto &Name : Names) {
     getDies(DICtx, DICtx.getAppleNames(), Name, Dies);
@@ -436,6 +442,7 @@ static void filterByAccelName(ArrayRef<std::string> Names, DWARFContext &DICtx,
   Dies.erase(std::unique(Dies.begin(), Dies.end()), Dies.end());
 
   DIDumpOptions DumpOpts = getDumpOpts(DICtx);
+  DumpOpts.GetNameForDWARFReg = GetNameForDWARFReg;
   for (DWARFDie Die : Dies)
     Die.dump(OS, 0, DumpOpts);
 }
@@ -552,10 +559,41 @@ static bool collectObjectSources(ObjectFile &Obj, DWARFContext &DICtx,
   return Result;
 }
 
+static std::unique_ptr<MCRegisterInfo>
+createRegInfo(const object::ObjectFile &Obj) {
+  std::unique_ptr<MCRegisterInfo> MCRegInfo;
+  Triple TT;
+  TT.setArch(Triple::ArchType(Obj.getArch()));
+  TT.setVendor(Triple::UnknownVendor);
+  TT.setOS(Triple::UnknownOS);
+  std::string TargetLookupError;
+  const Target *TheTarget =
+      TargetRegistry::lookupTarget(TT.str(), TargetLookupError);
+  if (!TargetLookupError.empty())
+    return nullptr;
+  MCRegInfo.reset(TheTarget->createMCRegInfo(TT.str()));
+  return MCRegInfo;
+}
+
 static bool dumpObjectFile(ObjectFile &Obj, DWARFContext &DICtx,
                            const Twine &Filename, raw_ostream &OS) {
-  logAllUnhandledErrors(DICtx.loadRegisterInfo(Obj), errs(),
-                        Filename.str() + ": ");
+
+  auto MCRegInfo = createRegInfo(Obj);
+  if (!MCRegInfo)
+    logAllUnhandledErrors(createStringError(inconvertibleErrorCode(),
+                                            "Error in creating MCRegInfo"),
+                          errs(), Filename.str() + ": ");
+
+  auto GetRegName = [&MCRegInfo](uint64_t DwarfRegNum, bool IsEH) -> StringRef {
+    if (!MCRegInfo)
+      return {};
+    if (llvm::Optional<unsigned> LLVMRegNum =
+            MCRegInfo->getLLVMRegNum(DwarfRegNum, IsEH))
+      if (const char *RegName = MCRegInfo->getName(*LLVMRegNum))
+        return StringRef(RegName);
+    return {};
+  };
+
   // The UUID dump already contains all the same information.
   if (!(DumpType & DIDT_UUID) || DumpType == DIDT_All)
     OS << Filename << ":\tfile format " << Obj.getFileFormatName() << '\n';
@@ -570,19 +608,21 @@ static bool dumpObjectFile(ObjectFile &Obj, DWARFContext &DICtx,
     for (auto name : Name)
       Names.insert((IgnoreCase && !UseRegex) ? StringRef(name).lower() : name);
 
-    filterByName(Names, DICtx.normal_units(), OS);
-    filterByName(Names, DICtx.dwo_units(), OS);
+    filterByName(Names, DICtx.normal_units(), OS, GetRegName);
+    filterByName(Names, DICtx.dwo_units(), OS, GetRegName);
     return true;
   }
 
   // Handle the --find option and lower it to --debug-info=<offset>.
   if (!Find.empty()) {
-    filterByAccelName(Find, DICtx, OS);
+    filterByAccelName(Find, DICtx, OS, GetRegName);
     return true;
   }
 
   // Dump the complete DWARF structure.
-  DICtx.dump(OS, getDumpOpts(DICtx), DumpOffsets);
+  auto DumpOpts = getDumpOpts(DICtx);
+  DumpOpts.GetNameForDWARFReg = GetRegName;
+  DICtx.dump(OS, DumpOpts, DumpOffsets);
   return true;
 }
 

--- a/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
+++ b/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
@@ -285,7 +285,6 @@ static llvm::Error handleObjectFile(ObjectFile &Obj,
   if (!DICtx)
     return createStringError(std::errc::invalid_argument,
                              "unable to create DWARF context");
-  logAllUnhandledErrors(DICtx->loadRegisterInfo(Obj), OS, "DwarfTransformer: ");
 
   // Make a DWARF transformer object and populate the ranges of the code
   // so we don't end up adding invalid functions to GSYM data.

--- a/llvm/tools/llvm-objdump/SourcePrinter.h
+++ b/llvm/tools/llvm-objdump/SourcePrinter.h
@@ -13,6 +13,7 @@
 #include "llvm/ADT/StringSet.h"
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
 #include "llvm/DebugInfo/Symbolize/Symbolize.h"
+#include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/Support/FormattedStream.h"
 #include <unordered_map>

--- a/llvm/tools/llvm-readobj/DwarfCFIEHPrinter.h
+++ b/llvm/tools/llvm-readobj/DwarfCFIEHPrinter.h
@@ -226,8 +226,9 @@ void PrinterContext<ELFT>::printEHFrame(const Elf_Shdr *EHFrameShdr) const {
     W.getOStream() << "\n";
     W.startLine() << "Program:\n";
     W.indent();
-    Entry.cfis().dump(W.getOStream(), DIDumpOptions(), nullptr,
-                      W.getIndentLevel());
+    auto DumpOpts = DIDumpOptions();
+    DumpOpts.IsEH = true;
+    Entry.cfis().dump(W.getOStream(), DumpOpts, W.getIndentLevel());
     W.unindent();
     W.unindent();
     W.getOStream() << "\n";

--- a/llvm/unittests/DebugInfo/DWARF/DWARFDebugFrameTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFDebugFrameTest.cpp
@@ -41,7 +41,9 @@ void expectDumpResult(const dwarf::CIE &TestCIE, bool IsEH,
                       StringRef ExpectedFirstLine) {
   std::string Output;
   raw_string_ostream OS(Output);
-  TestCIE.dump(OS, DIDumpOptions(), /*MRI=*/nullptr, IsEH);
+  auto DumpOpts = DIDumpOptions();
+  DumpOpts.IsEH = IsEH;
+  TestCIE.dump(OS, DumpOpts);
   OS.flush();
   StringRef FirstLine = StringRef(Output).split('\n').first;
   EXPECT_EQ(FirstLine, ExpectedFirstLine);
@@ -51,7 +53,9 @@ void expectDumpResult(const dwarf::FDE &TestFDE, bool IsEH,
                       StringRef ExpectedFirstLine) {
   std::string Output;
   raw_string_ostream OS(Output);
-  TestFDE.dump(OS, DIDumpOptions(), /*MRI=*/nullptr, IsEH);
+  auto DumpOpts = DIDumpOptions();
+  DumpOpts.IsEH = IsEH;
+  TestFDE.dump(OS, DumpOpts);
   OS.flush();
   StringRef FirstLine = StringRef(Output).split('\n').first;
   EXPECT_EQ(FirstLine, ExpectedFirstLine);

--- a/llvm/unittests/DebugInfo/DWARF/DWARFExpressionCompactPrinterTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFExpressionCompactPrinterTest.cpp
@@ -60,7 +60,17 @@ void DWARFExpressionCompactPrinterTest::TestExprPrinter(
   raw_string_ostream OS(Result);
   DataExtractor DE(ExprData, true, 8);
   DWARFExpression Expr(DE, 8);
-  Expr.printCompact(OS, *MRI);
+
+  auto GetRegName = [&](uint64_t DwarfRegNum, bool IsEH) -> StringRef {
+    if (llvm::Optional<unsigned> LLVMRegNum =
+            this->MRI->getLLVMRegNum(DwarfRegNum, IsEH))
+      if (const char *RegName = this->MRI->getName(*LLVMRegNum))
+        return llvm::StringRef(RegName);
+    OS << "<unknown register " << DwarfRegNum << ">";
+    return {};
+  };
+
+  Expr.printCompact(OS, GetRegName);
   EXPECT_EQ(OS.str(), Expected);
 }
 


### PR DESCRIPTION
This patch had to be reverted because on gcc 7.5.0 we see an error converting from std::unique_ptr<MCRegisterInfo> to Expected<std::unique_ptr<MCRegisterInfo>> as the return type for the function createRegInfo. This has now been fixed.

(cherry picked from commit d96ade00c3c96bd451c60e34a17e613cdd5fdc38)