### PR TITLE
[Sema] Fix a bug where clang doesn't detect uses of unavailable decls in C++ base or member initializers

### DIFF
--- a/clang/lib/Sema/SemaAvailability.cpp
+++ b/clang/lib/Sema/SemaAvailability.cpp
@@ -895,6 +895,11 @@ void Sema::DiagnoseUnguardedAvailabilityViolations(Decl *D) {
       return;
 
     Body = FD->getBody();
+
+    if (auto *CD = dyn_cast<CXXConstructorDecl>(FD))
+      for (const CXXCtorInitializer *CI : CD->inits())
+        DiagnoseUnguardedAvailability(*this, D).IssueDiagnostics(CI->getInit());
+
   } else if (auto *MD = dyn_cast<ObjCMethodDecl>(D))
     Body = MD->getBody();
   else if (auto *BD = dyn_cast<BlockDecl>(D))

--- a/clang/test/SemaCXX/attr-availability.cpp
+++ b/clang/test/SemaCXX/attr-availability.cpp
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -triple x86_64-apple-macosx10.9.0 -std=c++11 -fsyntax-only -verify %s
+
+__attribute__((availability(macos, introduced = 10.0))) int init10();
+__attribute__((availability(macos, introduced = 11.0))) int init11(); // expected-note 2 {{'init11' has been marked as being introduced in macOS 11.0}}
+
+struct B0 {
+  B0(int);
+};
+
+struct B1 {
+  B1(int);
+};
+
+struct S : B0, B1 {
+  S() : B0(init10()),
+        B1(init11()), // expected-warning {{'init11' is only available on macOS 11.0}} expected-note {{enclose 'init11'}}
+        i0(init10()),
+        i1(init11())  // expected-warning {{'init11' is only available on macOS 11.0}} expected-note {{enclose 'init11'}}
+  {}
+  int i0, i1;
+};


### PR DESCRIPTION
Differential Revision: https://reviews.llvm.org/D127442

(cherry picked from commit 143ec502e9859141e9d340ed59046dad0fc4ee6f)