### PR TITLE
[lldb] Fix spurious assertion in PrintCommandOutput

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -3013,22 +3013,18 @@ void CommandInterpreter::PrintCommandOutput(IOHandler &io_handler,
   lldb::StreamFileSP stream = is_stdout ? io_handler.GetOutputStreamFileSP()
                                         : io_handler.GetErrorStreamFileSP();
   // Split the output into lines and poll for interrupt requests
-  size_t size = str.size();
-  while (size > 0 && !WasInterrupted()) {
+  while (!str.empty() && !WasInterrupted()) {
     llvm::StringRef line;
-    size_t written = 0;
     std::tie(line, str) = str.split('\n');
     {
       std::lock_guard<std::recursive_mutex> guard(io_handler.GetOutputMutex());
-      written += stream->Write(line.data(), line.size());
-      written += stream->Write("\n", 1);
+      stream->Write(line.data(), line.size());
+      stream->Write("\n", 1);
     }
-    lldbassert(size >= written);
-    size -= written;
   }
 
   std::lock_guard<std::recursive_mutex> guard(io_handler.GetOutputMutex());
-  if (size > 0)
+  if (!str.empty())
     stream->Printf("\n... Interrupted.\n");
   stream->Flush();
 }


### PR DESCRIPTION
When the string passed to PrintCommandOutput doesn't end with a newline,
`written` will exceed `size` and result in an lldbassert.

After 8e776bb660dda6c51ce7ca6cea641db1f47aa9cf we don't really need
written anymore and we can check whether `str` is empty instead. This
patch simplifies the code and removes the assert that's no longer
relevant.

Differential revision: https://reviews.llvm.org/D126081

(cherry picked from commit d252d9231c4a5008a69c6791db498aaf95bda8e7)
