### PR TITLE
[llvm][cas] Simplify path remapper callback and align mapDirEntry

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -113,9 +113,7 @@ public:
   getDependencyTreeFromCompilerInvocation(
       std::shared_ptr<CompilerInvocation> Invocation, StringRef CWD,
       DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
-      bool DiagGenerationAsCompilation,
-      llvm::function_ref<StringRef(const llvm::vfs::CachedDirectoryEntry &)>
-          RemapPath = nullptr);
+      bool DiagGenerationAsCompilation, RemapPathCallback RemapPath = nullptr);
 
   Expected<cas::IncludeTreeRoot>
   getIncludeTree(cas::ObjectStore &DB,

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -37,8 +37,7 @@ struct Command {
   std::vector<std::string> Arguments;
 };
 
-using RemapPathCallback =
-    llvm::function_ref<StringRef(const llvm::vfs::CachedDirectoryEntry &)>;
+using RemapPathCallback = llvm::cas::CachingOnDiskFileSystem::RemapPathCallback;
 
 class DependencyConsumer {
 public:

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -168,9 +168,7 @@ llvm::Expected<llvm::cas::ObjectProxy>
 DependencyScanningTool::getDependencyTreeFromCompilerInvocation(
     std::shared_ptr<CompilerInvocation> Invocation, StringRef CWD,
     DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
-    bool DiagGenerationAsCompilation,
-    llvm::function_ref<StringRef(const llvm::vfs::CachedDirectoryEntry &)>
-        RemapPath) {
+    bool DiagGenerationAsCompilation, RemapPathCallback RemapPath) {
   GetDependencyTree Consumer(Worker.getCASFS().getCAS());
   Worker.computeDependenciesFromCompilerInvocation(
       std::move(Invocation), CWD, Consumer, RemapPath, DiagsConsumer, VerboseOS,

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -247,8 +247,6 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
       Tool.getScanningFormat() ==
       tooling::dependencies::ScanningOutputFormat::IncludeTree;
 
-  llvm::BumpPtrAllocator Alloc;
-  llvm::StringSaver Saver(Alloc);
   std::unique_ptr<llvm::PrefixMapper> MapperPtr;
   if (ProduceIncludeTree) {
     MapperPtr = std::make_unique<llvm::PrefixMapper>();
@@ -279,9 +277,10 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
                     std::move(ScanInvocation), WorkingDirectory, DiagsConsumer,
                     VerboseOS,
                     /*DiagGenerationAsCompilation*/ true,
-                    [&](const llvm::vfs::CachedDirectoryEntry &Entry) {
+                    [&](const llvm::vfs::CachedDirectoryEntry &Entry,
+                        SmallVectorImpl<char> &Storage) {
                       return static_cast<llvm::TreePathPrefixMapper &>(Mapper)
-                          .mapDirEntry(Entry, Saver);
+                          .mapDirEntry(Entry, Storage);
                     })
                 .moveInto(Root))
       return std::move(E);

--- a/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
+++ b/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
@@ -54,6 +54,10 @@ public:
   /// behave when accessing the resulting \c CASFileSystem.
   virtual std::error_code excludeFromTracking(const Twine &Path) = 0;
 
+  /// Callback to adjust the given path.
+  using RemapPathCallback = llvm::function_ref<StringRef(
+      const vfs::CachedDirectoryEntry &, SmallVectorImpl<char> &Storage)>;
+
   /// Create a tree that represents all stats tracked since the call to \a
   /// trackNewAccesses(). Removes the current tracking scope.
   ///
@@ -82,9 +86,8 @@ public:
   ///     /new/filename
   ///     /new/sym2 -> filename
   ///     /new/sym3 -> /new/filename [broken]
-  virtual Expected<ObjectProxy> createTreeFromNewAccesses(
-      llvm::function_ref<StringRef(const vfs::CachedDirectoryEntry &)>
-          RemapPath = nullptr) = 0;
+  virtual Expected<ObjectProxy>
+  createTreeFromNewAccesses(RemapPathCallback RemapPath = nullptr) = 0;
 
   /// Create a tree that represents all known directories, files, and symlinks.
   virtual Expected<ObjectProxy> createTreeFromAllAccesses() = 0;

--- a/llvm/include/llvm/Support/PrefixMapper.h
+++ b/llvm/include/llvm/Support/PrefixMapper.h
@@ -194,7 +194,7 @@ public:
   Error add(const MappedPrefix &Mapping) override;
 
   StringRef mapDirEntry(const vfs::CachedDirectoryEntry &Entry,
-                        StringSaver &Saver);
+                        SmallVectorImpl<char> &Storage);
 
   TreePathPrefixMapper(IntrusiveRefCntPtr<vfs::FileSystem> FS,
                        sys::path::Style PathStyle = sys::path::Style::native);

--- a/llvm/lib/Support/PrefixMapper.cpp
+++ b/llvm/lib/Support/PrefixMapper.cpp
@@ -226,10 +226,9 @@ Error TreePathPrefixMapper::add(const MappedPrefix &Mapping) {
 
 StringRef
 TreePathPrefixMapper::mapDirEntry(const vfs::CachedDirectoryEntry &Entry,
-                                  StringSaver &Saver) {
+                                  SmallVectorImpl<char> &Storage) {
   StringRef TreePath = Entry.getTreePath();
-  SmallString<256> PathBuf;
   Optional<StringRef> Mapped =
-      cantFail(PrefixMapper::mapImpl(TreePath, PathBuf));
-  return Mapped ? Saver.save(*Mapped) : TreePath;
+      cantFail(PrefixMapper::mapImpl(TreePath, Storage));
+  return Mapped ? *Mapped : TreePath;
 }

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -402,8 +402,6 @@ static Expected<ObjectProxy> ingestFileSystemImpl(ObjectStore &CAS,
   if (!FS)
     return FS.takeError();
 
-  BumpPtrAllocator Alloc;
-  StringSaver Saver(Alloc);
   TreePathPrefixMapper Mapper(*FS);
   SmallVector<llvm::MappedPrefix> Split;
   if (!PrefixMapPaths.empty()) {
@@ -419,8 +417,9 @@ static Expected<ObjectProxy> ingestFileSystemImpl(ObjectStore &CAS,
     return std::move(E);
 
   return (*FS)->createTreeFromNewAccesses(
-      [&](const llvm::vfs::CachedDirectoryEntry &Entry) {
-        return Mapper.mapDirEntry(Entry, Saver);
+      [&](const llvm::vfs::CachedDirectoryEntry &Entry,
+          SmallVectorImpl<char> &Storage) {
+        return Mapper.mapDirEntry(Entry, Storage);
       });
 }
 


### PR DESCRIPTION
Returning a bare StringRef forced the implementation to internally save the string unnecessarily, but we do not need to save the string long term, only long enough to push onto the tree builder. Instead, forward through a SmallVectorImpl<char> for storage. Also align mapDirEntry with this new signature to avoid using StringSaver.

(cherry picked from commit 666ec39c046e5bdb974cae341b2d1623ae040c10)