### PR TITLE
When loading mach-o corefile, new fallback for finding images

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOSXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOSXDYLD.cpp
@@ -277,6 +277,16 @@ bool DynamicLoaderMacOSXDYLD::ReadDYLDInfoFromMemoryAndSetNotificationCallback(
           m_dyld_all_image_infos_addr = symbol->GetLoadAddress(&target);
       }
 
+      if (m_dyld_all_image_infos_addr == LLDB_INVALID_ADDRESS) {
+        ConstString g_sect_name("__all_image_info");
+        SectionSP dyld_aii_section_sp =
+            dyld_module_sp->GetSectionList()->FindSectionByName(g_sect_name);
+        if (dyld_aii_section_sp) {
+          Address dyld_aii_addr(dyld_aii_section_sp, 0);
+          m_dyld_all_image_infos_addr = dyld_aii_addr.GetLoadAddress(&target);
+        }
+      }
+
       // Update all image infos
       InitializeFromAllImageInfos();
 


### PR DESCRIPTION
When loading mach-o corefile, new fallback for finding images

When lldb is reading a user process corefile, it starts by finding dyld, then finding the dyld_all_image_infos structure in dyld by symbol name, then getting the list of loaded binaries.  If it fails to find the structure by name, it can't load binaries.  There is an additional fallback that this patch adds, which is to look for this object by the section name it is stored in, if the symbol name lookup fails.

Differential Revision: https://reviews.llvm.org/D140066 rdar://103369931

(cherry picked from commit 75d268d1fa607a2a9c814040a8d8d5267b49de4c)