### PR TITLE
[stable/20221013] Proper fix for race in ClangdServer shutdown

### DIFF
--- a/clang-tools-extra/clangd/ClangdServer.cpp
+++ b/clang-tools-extra/clangd/ClangdServer.cpp
@@ -233,9 +233,6 @@ ClangdServer::ClangdServer(const GlobalCompilationDatabase &CDB,
 }
 
 ClangdServer::~ClangdServer() {
-  // Wait for stdlib indexing to finish.
-  if (IndexTasks)
-    IndexTasks->wait();
   // Destroying TUScheduler first shuts down request threads that might
   // otherwise access members concurrently.
   // (Nobody can be using TUScheduler because we're on the main thread).


### PR DESCRIPTION
Cherry-picks the upstream fix b494f67f67968c50289148fb423a108607be83e9 and reverts the temporary one.