### PR TITLE
[lldb] Remove data formatters for long since renamed _NSSwiftArray

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -294,17 +294,6 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
   if (!clang_ts_sp)
     return nullptr;
 
-  if (valobj_typename.startswith("Swift._NSSwiftArray")) {
-    CompilerType anyobject_type =
-        clang_ts_sp->GetBasicType(lldb::eBasicTypeObjCID);
-    auto handler = std::unique_ptr<SwiftArrayBufferHandler>(
-        new SwiftArrayNativeBufferHandler(valobj, valobj.GetPointerValue(),
-                                          anyobject_type));
-    if (handler && handler->IsValid())
-      return handler;
-    return nullptr;
-  }
-
   // For now we have to keep the old mangled name since the Objc->Swift bindings
   // that are in Foundation don't get the new mangling.
   if (valobj_typename.startswith("_TtCs23_ContiguousArrayStorage") ||

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -288,10 +288,6 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                 lldb_private::formatters::swift::Array_SummaryProvider,
                 "Swift.Array summary provider",
                 ConstString("^Swift.Array<.+>$"), summary_flags, true);
-  AddCXXSummary(swift_category_sp,
-                lldb_private::formatters::swift::Array_SummaryProvider,
-                "Swift.Array summary provider",
-                ConstString("Swift._NSSwiftArray"), summary_flags, false);
   AddCXXSummary(
       swift_category_sp, lldb_private::formatters::swift::Array_SummaryProvider,
       "Swift.ContiguousArray summary provider",
@@ -341,11 +337,6 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       lldb_private::formatters::swift::ArraySyntheticFrontEndCreator,
       "Swift.Array synthetic children", ConstString("^Swift.Array<.+>$"),
       synth_flags, true);
-  AddCXXSynthetic(
-      swift_category_sp,
-      lldb_private::formatters::swift::ArraySyntheticFrontEndCreator,
-      "Swift.Array synthetic children", ConstString("Swift._NSSwiftArray"),
-      synth_flags, false);
   AddCXXSynthetic(
       swift_category_sp,
       lldb_private::formatters::swift::ArraySyntheticFrontEndCreator,


### PR DESCRIPTION
This type was renamed long ago:

```
commit 418aa75eb21c2e08f7bb968875081532cf35c438
Date:   Fri Oct 24 15:48:46 2014 +0000

    [stdlib] Rename _NSSwiftXXX => _SwiftNativeNSXXX
```

There are currently no data formatters for `_SwiftNativeNSXXX`, which would be
a new addition.

(cherry picked from commit f51a5394e064b228e6e217da57ab6c8a1b44ec17)
