### PR TITLE
[llvm][cas] Simplify PrefixMapper to remove Error return values

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -259,7 +259,7 @@ Error IncludeTreePPConsumer::initialize(CompilerInstance &CI) {
     // allows remapping back to the non-canonical source paths so that they are
     // found during dep-scanning.
     llvm::PrefixMapper ReverseMapper;
-    cantFail(ReverseMapper.addInverseRange(PrefixMapper.getMappings()));
+    ReverseMapper.addInverseRange(PrefixMapper.getMappings());
     ReverseMapper.sort();
     std::unique_ptr<llvm::vfs::FileSystem> FS =
         llvm::vfs::createPrefixMappingFileSystem(std::move(ReverseMapper),
@@ -268,7 +268,7 @@ Error IncludeTreePPConsumer::initialize(CompilerInstance &CI) {
 
     // These are written in the predefines buffer, so we need to remap them.
     for (std::string &Include : PPOpts.Includes)
-      cantFail(PrefixMapper.mapInPlace(Include));
+      PrefixMapper.mapInPlace(Include);
   };
   ensurePathRemapping();
 
@@ -497,7 +497,7 @@ IncludeTreePPConsumer::createIncludeFile(StringRef Filename,
                                          cas::ObjectRef Contents) {
   SmallString<256> MappedPath;
   if (!PrefixMapper.empty()) {
-    cantFail(PrefixMapper.map(Filename, MappedPath));
+    PrefixMapper.map(Filename, MappedPath);
     Filename = MappedPath;
   }
   return cas::IncludeFile::create(DB, Filename, std::move(Contents));

--- a/clang/tools/driver/CachedDiagnostics.cpp
+++ b/clang/tools/driver/CachedDiagnostics.cpp
@@ -389,7 +389,7 @@ FileID CachedDiagnosticSerializer::convertCachedSLocEntry(unsigned Idx) {
         report_fatal_error(
             createFileError(FI.Filename, MemBufOrErr.getError()));
       SmallString<128> PathBuf;
-      cantFail(Mapper.map(FI.Filename, PathBuf));
+      Mapper.map(FI.Filename, PathBuf);
       if (PathBuf.str() != FI.Filename) {
         // The file path was remapped. Keep the original buffer and pass a new
         // buffer using the remapped file path.

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -538,8 +538,7 @@ Optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
   for (const auto &MappedPrefix : Split) {
     // We use the inverse mapping because the \p PrefixMapper will be used for
     // de-canonicalization of paths.
-    if (auto E = PrefixMapper.add(MappedPrefix.getInverse()))
-      return reportCachingBackendError(Clang.getDiagnostics(), std::move(E));
+    PrefixMapper.add(MappedPrefix.getInverse());
   }
 
   if (!CacheOpts.CompilationCachingServicePath.empty()) {

--- a/llvm/lib/Support/PrefixMappingFileSystem.cpp
+++ b/llvm/lib/Support/PrefixMappingFileSystem.cpp
@@ -26,9 +26,7 @@ public:
 #define PREFIX_MAP_PATH(Old, New)                                              \
   SmallString<256> New;                                                        \
   Old.toVector(New);                                                           \
-  if (Error E = Mapper.mapInPlace(New)) {                                      \
-    return errorToErrorCode(std::move(E));                                     \
-  }
+  Mapper.mapInPlace(New);
 
   llvm::ErrorOr<Status> status(const Twine &Path) override {
     PREFIX_MAP_PATH(Path, MappedPath)
@@ -45,10 +43,7 @@ public:
                                std::error_code &EC) override {
     SmallString<256> MappedPath;
     Path.toVector(MappedPath);
-    if (Error E = Mapper.mapInPlace(MappedPath)) {
-      EC = errorToErrorCode(std::move(E));
-      return {};
-    }
+    Mapper.mapInPlace(MappedPath);
     return ProxyFileSystem::dir_begin(MappedPath, EC);
   }
 

--- a/llvm/lib/TableGen/Main.cpp
+++ b/llvm/lib/TableGen/Main.cpp
@@ -122,8 +122,7 @@ static Error createDependencyFile(const StringSetT &Dependencies) {
     for (StringRef DepRef : Dependencies) {
       std::string Dep = DepRef.str();
       if (CreateDependencyFilePM)
-        if (Error E = CreateDependencyFilePM->mapInPlace(Dep))
-          return E;
+        CreateDependencyFilePM->mapInPlace(Dep);
       OS << ' ' << Dep;
     }
     OS << "\n";
@@ -283,19 +282,17 @@ struct TableGenCache {
   Error computeResult(TableGenMainFn *MainFn);
   Error replayResult();
 
-  Error createInversePrefixMap();
+  void createInversePrefixMap();
 };
 } // end namespace
 
-Error TableGenCache::createInversePrefixMap() {
+void TableGenCache::createInversePrefixMap() {
   if (PrefixMappings.empty())
-    return Error::success();
+    return;
 
   InversePM.emplace();
-  if (Error E = InversePM->addInverseRange(PrefixMappings))
-    return E;
+  InversePM->addInverseRange(PrefixMappings);
   CreateDependencyFilePM = &*InversePM;
-  return Error::success();
 }
 
 Expected<cas::ObjectRef> TableGenCache::createExecutableBlob(StringRef Argv0) {
@@ -564,8 +561,7 @@ int llvm::TableGenMain(ArrayRef<const char *> Args, TableGenMainFn *MainFn) {
   if (Error E =
           MappedPrefix::transformJoined(DepscanPrefixMap, Cache.PrefixMappings))
     return reportError(Args[0], std::move(E));
-  if (Error E = Cache.createInversePrefixMap())
-    return reportError(Args[0], std::move(E));
+  Cache.createInversePrefixMap();
 
   if (Error E = Cache.lookupCachedResult(Args))
     return reportError(Args[0], std::move(E));

--- a/llvm/lib/TableGen/ScanDependencies.cpp
+++ b/llvm/lib/TableGen/ScanDependencies.cpp
@@ -235,8 +235,7 @@ tablegen::scanIncludes(cas::ObjectStore &CAS, cas::ActionCache &Cache,
   Optional<TreePathPrefixMapper> &PM = CapturedPM ? *CapturedPM : LocalPM;
   if (!PrefixMappings.empty()) {
     PM.emplace(FS);
-    if (Error E = PM->addRange(PrefixMappings))
-      return std::move(E);
+    PM->addRange(PrefixMappings);
     PM->sort();
   }
 
@@ -265,16 +264,12 @@ tablegen::scanIncludesAndRemap(cas::ObjectStore &CAS, cas::ActionCache &Cache,
   if (!PM)
     return Result;
 
-  // Remap the main filename. Since it was already loaded and should be cached
-  // by the filesystem, an error here would be most surprising.
-  if (Error E = PM->mapInPlace(MainFilename))
-    return std::move(E);
+  // Remap the main filename.
+  PM->mapInPlace(MainFilename);
 
-  // Remap includes and strip invalid ones. If there have been no includes,
-  // it's possible these will be new accesses, but they won't be needed anyway.
-  // Clear and erase them.
+  // Remap includes.
   for (std::string &Dir : IncludeDirs)
-    PM->mapInPlaceOrClear(Dir);
+    PM->mapInPlace(Dir);
   llvm::erase_value(IncludeDirs, "");
 
   return Result;

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -406,8 +406,7 @@ static Expected<ObjectProxy> ingestFileSystemImpl(ObjectStore &CAS,
   SmallVector<llvm::MappedPrefix> Split;
   if (!PrefixMapPaths.empty()) {
     MappedPrefix::transformJoinedIfValid(PrefixMapPaths, Split);
-    if (llvm::Error E = Mapper.addRange(Split))
-      return std::move(E);
+    Mapper.addRange(Split);
     Mapper.sort();
   }
 

--- a/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
@@ -351,8 +351,7 @@ TEST(CachingOnDiskFileSystemTest, TrackNewAccesses) {
   ASSERT_FALSE(FS->setCurrentWorkingDirectory(TestDirectory.path()));
 
   TreePathPrefixMapper Remapper(FS);
-  ASSERT_THAT_ERROR(Remapper.add(MappedPrefix{TestDirectory.path(), "/"}),
-                    Succeeded());
+  Remapper.add(MappedPrefix{TestDirectory.path(), "/"});
 
   TempFile Extra(TestDirectory.path("Extra"), "", "content");
   SmallVector<TempFile> Temps;
@@ -399,8 +398,7 @@ TEST(CachingOnDiskFileSystemTest, TrackNewAccessesStack) {
   ASSERT_FALSE(FS->setCurrentWorkingDirectory(TestDirectory.path()));
 
   TreePathPrefixMapper Remapper(FS);
-  ASSERT_THAT_ERROR(Remapper.add(MappedPrefix{TestDirectory.path(), "/"}),
-                    Succeeded());
+  Remapper.add(MappedPrefix{TestDirectory.path(), "/"});
 
   TempFile Extra(TestDirectory.path("Extra"), "", "content");
   SmallVector<TempFile> Temps;
@@ -470,8 +468,7 @@ TEST(CachingOnDiskFileSystemTest, TrackNewAccessesExists) {
   ASSERT_FALSE(FS->setCurrentWorkingDirectory(TestDirectory.path()));
 
   TreePathPrefixMapper Remapper(FS);
-  ASSERT_THAT_ERROR(Remapper.add(MappedPrefix{TestDirectory.path(), "/"}),
-                    Succeeded());
+  Remapper.add(MappedPrefix{TestDirectory.path(), "/"});
 
   SmallVector<TempFile> Temps;
   for (size_t I = 0, E = 4; I != E; ++I)
@@ -608,8 +605,7 @@ TEST(CachingOnDiskFileSystemTest, ExcludeFromTacking) {
   ASSERT_FALSE(FS->setCurrentWorkingDirectory(TestDirectory.path()));
 
   TreePathPrefixMapper Remapper(FS);
-  ASSERT_THAT_ERROR(Remapper.add(MappedPrefix{TestDirectory.path(), "/"}),
-                    Succeeded());
+  Remapper.add(MappedPrefix{TestDirectory.path(), "/"});
 
   TempDir D1(TestDirectory.path("d1"));
   TempDir D2(TestDirectory.path("d2"));


### PR DESCRIPTION
This simplifies the PrefixMapper interface to no longer have Error/Expected return values when adding or mapping a path. For the subclass TreePathPrefixMapper, we stop producing errors for missing files/prefix paths, and instead fallback to mapping without getting the tree path first.

- This brings TreePathPrefixMapper closer to the behaviour of normal PrefixMapper
- This enables mapping paths that do not actually exist (yet), which is important for adding prefix mapping to module build commands
- This removes a lot of error code paths.