### PR TITLE
[llvm][cas] Simplify PrefixMapper to remove Error return values

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -259,7 +259,7 @@ Error IncludeTreePPConsumer::initialize(CompilerInstance &CI) {
     // allows remapping back to the non-canonical source paths so that they are
     // found during dep-scanning.
     llvm::PrefixMapper ReverseMapper;
-    cantFail(ReverseMapper.addInverseRange(PrefixMapper.getMappings()));
+    ReverseMapper.addInverseRange(PrefixMapper.getMappings());
     ReverseMapper.sort();
     std::unique_ptr<llvm::vfs::FileSystem> FS =
         llvm::vfs::createPrefixMappingFileSystem(std::move(ReverseMapper),
@@ -268,7 +268,7 @@ Error IncludeTreePPConsumer::initialize(CompilerInstance &CI) {
 
     // These are written in the predefines buffer, so we need to remap them.
     for (std::string &Include : PPOpts.Includes)
-      cantFail(PrefixMapper.mapInPlace(Include));
+      PrefixMapper.mapInPlace(Include);
   };
   ensurePathRemapping();
 
@@ -497,7 +497,7 @@ IncludeTreePPConsumer::createIncludeFile(StringRef Filename,
                                          cas::ObjectRef Contents) {
   SmallString<256> MappedPath;
   if (!PrefixMapper.empty()) {
-    cantFail(PrefixMapper.map(Filename, MappedPath));
+    PrefixMapper.map(Filename, MappedPath);
     Filename = MappedPath;
   }
   return cas::IncludeFile::create(DB, Filename, std::move(Contents));

--- a/clang/tools/driver/CachedDiagnostics.cpp
+++ b/clang/tools/driver/CachedDiagnostics.cpp
@@ -389,7 +389,7 @@ FileID CachedDiagnosticSerializer::convertCachedSLocEntry(unsigned Idx) {
         report_fatal_error(
             createFileError(FI.Filename, MemBufOrErr.getError()));
       SmallString<128> PathBuf;
-      cantFail(Mapper.map(FI.Filename, PathBuf));
+      Mapper.map(FI.Filename, PathBuf);
       if (PathBuf.str() != FI.Filename) {
         // The file path was remapped. Keep the original buffer and pass a new
         // buffer using the remapped file path.

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -520,8 +520,7 @@ Optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
   for (const auto &MappedPrefix : Split) {
     // We use the inverse mapping because the \p PrefixMapper will be used for
     // de-canonicalization of paths.
-    if (auto E = PrefixMapper.add(MappedPrefix.getInverse()))
-      return reportCachingBackendError(Clang.getDiagnostics(), std::move(E));
+    PrefixMapper.add(MappedPrefix.getInverse());
   }
 
   if (!CacheOpts.CompilationCachingServicePath.empty()) {

--- a/llvm/include/llvm/Support/PrefixMapper.h
+++ b/llvm/include/llvm/Support/PrefixMapper.h
@@ -60,44 +60,26 @@ public:
   /// Map \p Path, and saving the new (or existing) path in \p NewPath.
   ///
   /// \pre \p Path is not a reference into \p NewPath.
-  Error map(StringRef Path, SmallVectorImpl<char> &NewPath);
-  Error map(StringRef Path, std::string &NewPath);
+  void map(StringRef Path, SmallVectorImpl<char> &NewPath);
+  void map(StringRef Path, std::string &NewPath);
 
   /// Map \p Path, returning \a std::string.
-  Expected<std::string> mapToString(StringRef Path);
+  std::string mapToString(StringRef Path);
 
   /// Map \p Path in place.
-  Error mapInPlace(SmallVectorImpl<char> &Path);
-  Error mapInPlace(std::string &Path);
-
-  void mapInPlaceOrClear(std::string &Path) {
-    if (errorToBool(mapInPlace(Path)))
-      Path.clear();
-  }
-
-  /// Like \p map() except it returns \p None in case of an error.
-  Optional<StringRef> mapOrNoneIfError(StringRef Path,
-                                       SmallVectorImpl<char> &Storage) {
-    if (Error E = map(Path, Storage)) {
-      consumeError(std::move(E));
-      return None;
-    }
-    return StringRef(Storage.begin(), Storage.size());
-  }
+  void mapInPlace(SmallVectorImpl<char> &Path);
+  void mapInPlace(std::string &Path);
 
 protected:
   /// Map (or unmap) \p Path. On a match, fills \p Storage with the mapped path
   /// unless it's an exact match.
   ///
   /// \pre \p Path is not a reference into \p Storage.
-  virtual Expected<Optional<StringRef>> mapImpl(StringRef Path,
-                                                SmallVectorImpl<char> &Storage);
+  virtual Optional<StringRef> mapImpl(StringRef Path,
+                                      SmallVectorImpl<char> &Storage);
 
 public:
-  virtual Error add(const MappedPrefix &MP) {
-    Mappings.push_back(MP);
-    return Error::success();
-  }
+  virtual void add(const MappedPrefix &MP) { Mappings.push_back(MP); }
 
   /// A path-based reverse lexicographic sort, putting deeper paths first so
   /// that deeper paths are prioritized over their parent paths. For example,
@@ -113,28 +95,14 @@ public:
   /// TODO: Test.
   void sort();
 
-  template <class RangeT> Error addRange(const RangeT &Mappings) {
+  template <class RangeT> void addRange(const RangeT &Mappings) {
     for (const MappedPrefix &M : Mappings)
-      if (Error E = add(M))
-        return E;
-    return Error::success();
+      add(M);
   }
 
-  template <class RangeT> Error addInverseRange(const RangeT &Mappings) {
+  template <class RangeT> void addInverseRange(const RangeT &Mappings) {
     for (const MappedPrefix &M : Mappings)
-      if (Error E = add(M.getInverse()))
-        return E;
-    return Error::success();
-  }
-
-  template <class RangeT> void addRangeIfValid(const RangeT &Mappings) {
-    for (const MappedPrefix &M : Mappings)
-      consumeError(add(M));
-  }
-
-  template <class RangeT> void addInverseRangeIfValid(const RangeT &Mappings) {
-    for (const MappedPrefix &M : Mappings)
-      consumeError(add(M.getInverse()));
+      add(M.getInverse());
   }
 
   bool empty() const { return getMappings().empty(); }
@@ -151,7 +119,8 @@ private:
   SmallVector<MappedPrefix> Mappings;
 };
 
-/// Wrapper for \a PrefixMapper that remaps paths that contain symlinks correctly.
+/// Wrapper for \a PrefixMapper that remaps paths that contain symlinks
+/// correctly.
 ///
 /// This compares paths (included the prefix) using a "tree" path (like a real
 /// path that does not follow symlinks in the basename). That is, the path to
@@ -178,20 +147,21 @@ private:
 /// The implementation relies on \a vfs::CachedDirectoryEntry::getTreePath(),
 /// which is only available in some filesystems.
 ///
-/// Returns an error if an input cannot be found, except that an empty string
-/// always maps to itself.
+/// Falls back to a simple path prefix map if an input cannot be found, and
+/// an empty string always maps to itself.
 class TreePathPrefixMapper : public PrefixMapper {
 private:
-  Expected<Optional<StringRef>>
-  mapImpl(StringRef Path, SmallVectorImpl<char> &Storage) override;
+  Optional<StringRef> mapImpl(StringRef Path,
+                              SmallVectorImpl<char> &Storage) override;
 
   /// Find the tree path for \p Path, getting the real path for its parent
   /// directory but not following symlinks in \a sys::path::filename().
-  Expected<StringRef> getTreePath(StringRef Path);
-  Error canonicalizePrefix(StringRef &Prefix);
+  ///
+  /// \returns The tree path, or the original path if there are any errors.
+  StringRef getTreePath(StringRef Path);
 
 public:
-  Error add(const MappedPrefix &Mapping) override;
+  void add(const MappedPrefix &Mapping) override;
 
   StringRef mapDirEntry(const vfs::CachedDirectoryEntry &Entry,
                         SmallVectorImpl<char> &Storage);

--- a/llvm/lib/Support/PrefixMapper.cpp
+++ b/llvm/lib/Support/PrefixMapper.cpp
@@ -94,8 +94,8 @@ static bool startsWith(StringRef Path, StringRef Prefix,
   return true;
 }
 
-Expected<Optional<StringRef>>
-PrefixMapper::mapImpl(StringRef Path, SmallVectorImpl<char> &Storage) {
+Optional<StringRef> PrefixMapper::mapImpl(StringRef Path,
+                                          SmallVectorImpl<char> &Storage) {
   for (const MappedPrefix &Map : Mappings) {
     StringRef Old = Map.Old;
     StringRef New = Map.New;
@@ -117,55 +117,44 @@ PrefixMapper::mapImpl(StringRef Path, SmallVectorImpl<char> &Storage) {
   return None;
 }
 
-Error PrefixMapper::map(StringRef Path, SmallVectorImpl<char> &NewPath) {
+void PrefixMapper::map(StringRef Path, SmallVectorImpl<char> &NewPath) {
   NewPath.clear();
-  Optional<StringRef> Mapped;
-  if (Error E = mapImpl(Path, NewPath).moveInto(Mapped))
-    return E;
+  Optional<StringRef> Mapped = mapImpl(Path, NewPath);
   if (!NewPath.empty())
-    return Error::success();
+    return;
   if (!Mapped)
     Mapped = Path;
   NewPath.assign(Mapped->begin(), Mapped->end());
-  return Error::success();
 }
 
-Error PrefixMapper::map(StringRef Path, std::string &NewPath) {
-  return mapToString(Path).moveInto(NewPath);
+void PrefixMapper::map(StringRef Path, std::string &NewPath) {
+  NewPath = mapToString(Path);
 }
 
-Expected<std::string> PrefixMapper::mapToString(StringRef Path) {
+std::string PrefixMapper::mapToString(StringRef Path) {
   SmallString<256> Storage;
-  Optional<StringRef> Mapped;
-  if (Error E = mapImpl(Path, Storage).moveInto(Mapped))
-    return std::move(E);
+  Optional<StringRef> Mapped = mapImpl(Path, Storage);
   return Mapped ? Mapped->str() : Path.str();
 }
 
-Error PrefixMapper::mapInPlace(SmallVectorImpl<char> &Path) {
+void PrefixMapper::mapInPlace(SmallVectorImpl<char> &Path) {
   SmallString<256> Storage;
-  Optional<StringRef> Mapped;
-  if (Error E = mapImpl(StringRef(Path.begin(), Path.size()), Storage)
-                    .moveInto(Mapped))
-    return E;
+  Optional<StringRef> Mapped =
+      mapImpl(StringRef(Path.begin(), Path.size()), Storage);
   if (!Mapped)
-    return Error::success();
+    return;
   if (Storage.empty())
     Path.assign(Mapped->begin(), Mapped->end());
   else
     Storage.swap(Path);
-  return Error::success();
 }
 
-Error PrefixMapper::mapInPlace(std::string &Path) {
+void PrefixMapper::mapInPlace(std::string &Path) {
   SmallString<256> Storage;
-  Optional<StringRef> Mapped;
-  if (Error E = mapImpl(Path, Storage).moveInto(Mapped))
-    return E;
+  Optional<StringRef> Mapped = mapImpl(Path, Storage);
   if (!Mapped)
-    return Error::success();
+    return;
   Path.assign(Mapped->begin(), Mapped->size());
-  return Error::success();
 }
 
 void PrefixMapper::sort() {
@@ -183,13 +172,10 @@ TreePathPrefixMapper::TreePathPrefixMapper(
 
 TreePathPrefixMapper::~TreePathPrefixMapper() = default;
 
-Expected<Optional<StringRef>>
+Optional<StringRef>
 TreePathPrefixMapper::mapImpl(StringRef Path, SmallVectorImpl<char> &Storage) {
-  StringRef TreePath;
-  if (Error E = getTreePath(Path).moveInto(TreePath))
-    return std::move(E);
-  Optional<StringRef> Mapped =
-      cantFail(PrefixMapper::mapImpl(TreePath, Storage));
+  StringRef TreePath = getTreePath(Path);
+  Optional<StringRef> Mapped = PrefixMapper::mapImpl(TreePath, Storage);
   if (Mapped)
     return *Mapped;
   if (TreePath != Path)
@@ -197,38 +183,33 @@ TreePathPrefixMapper::mapImpl(StringRef Path, SmallVectorImpl<char> &Storage) {
   return None;
 }
 
-Expected<StringRef> TreePathPrefixMapper::getTreePath(StringRef Path) {
+StringRef TreePathPrefixMapper::getTreePath(StringRef Path) {
   if (Path.empty())
     return Path;
-  const vfs::CachedDirectoryEntry *Entry = nullptr;
-  if (Error E =
-          FS->getDirectoryEntry(Path, /*FollowSymlinks=*/false).moveInto(Entry))
-    return std::move(E);
-  return Entry->getTreePath();
+  auto Entry = FS->getDirectoryEntry(Path, /*FollowSymlinks=*/false);
+  if (!Entry) {
+    consumeError(Entry.takeError());
+    return Path;
+  }
+  return (*Entry)->getTreePath();
 }
 
-Error TreePathPrefixMapper::canonicalizePrefix(StringRef &Prefix) {
-  StringRef TreePath;
-  if (Error E = getTreePath(Prefix).moveInto(TreePath))
-    return E;
-  if (TreePath != Prefix)
-    Prefix = TreePath;
-  return Error::success();
-}
-
-Error TreePathPrefixMapper::add(const MappedPrefix &Mapping) {
-  StringRef Old = Mapping.Old;
+void TreePathPrefixMapper::add(const MappedPrefix &Mapping) {
+  // Add the original mapping. If it contains a non-canonical path, this will
+  // only affect the behaviour when later mapping a path that cannot be
+  // canonicalized, since a non-canonical prefix cannot match a canonical path.
+  PrefixMapper::add(Mapping);
+  StringRef Old = getTreePath(Mapping.Old);
   StringRef New = Mapping.New;
-  if (Error E = canonicalizePrefix(Old))
-    return E;
-  return PrefixMapper::add(MappedPrefix{Old, New});
+  // Add the canonical prefix mapping, if different.
+  if (Old != Mapping.Old)
+    PrefixMapper::add(MappedPrefix{Old, New});
 }
 
 StringRef
 TreePathPrefixMapper::mapDirEntry(const vfs::CachedDirectoryEntry &Entry,
                                   SmallVectorImpl<char> &Storage) {
   StringRef TreePath = Entry.getTreePath();
-  Optional<StringRef> Mapped =
-      cantFail(PrefixMapper::mapImpl(TreePath, Storage));
+  Optional<StringRef> Mapped = PrefixMapper::mapImpl(TreePath, Storage);
   return Mapped ? *Mapped : TreePath;
 }

--- a/llvm/lib/Support/PrefixMappingFileSystem.cpp
+++ b/llvm/lib/Support/PrefixMappingFileSystem.cpp
@@ -26,9 +26,7 @@ public:
 #define PREFIX_MAP_PATH(Old, New)                                              \
   SmallString<256> New;                                                        \
   Old.toVector(New);                                                           \
-  if (Error E = Mapper.mapInPlace(New)) {                                      \
-    return errorToErrorCode(std::move(E));                                     \
-  }
+  Mapper.mapInPlace(New);
 
   llvm::ErrorOr<Status> status(const Twine &Path) override {
     PREFIX_MAP_PATH(Path, MappedPath)
@@ -45,10 +43,7 @@ public:
                                std::error_code &EC) override {
     SmallString<256> MappedPath;
     Path.toVector(MappedPath);
-    if (Error E = Mapper.mapInPlace(MappedPath)) {
-      EC = errorToErrorCode(std::move(E));
-      return {};
-    }
+    Mapper.mapInPlace(MappedPath);
     return ProxyFileSystem::dir_begin(MappedPath, EC);
   }
 

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -405,8 +405,7 @@ static Expected<ObjectProxy> ingestFileSystemImpl(ObjectStore &CAS,
   SmallVector<llvm::MappedPrefix> Split;
   if (!PrefixMapPaths.empty()) {
     MappedPrefix::transformJoinedIfValid(PrefixMapPaths, Split);
-    if (llvm::Error E = Mapper.addRange(Split))
-      return std::move(E);
+    Mapper.addRange(Split);
     Mapper.sort();
   }
 

--- a/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
@@ -351,8 +351,7 @@ TEST(CachingOnDiskFileSystemTest, TrackNewAccesses) {
   ASSERT_FALSE(FS->setCurrentWorkingDirectory(TestDirectory.path()));
 
   TreePathPrefixMapper Remapper(FS);
-  ASSERT_THAT_ERROR(Remapper.add(MappedPrefix{TestDirectory.path(), "/"}),
-                    Succeeded());
+  Remapper.add(MappedPrefix{TestDirectory.path(), "/"});
 
   TempFile Extra(TestDirectory.path("Extra"), "", "content");
   SmallVector<TempFile> Temps;
@@ -399,8 +398,7 @@ TEST(CachingOnDiskFileSystemTest, TrackNewAccessesStack) {
   ASSERT_FALSE(FS->setCurrentWorkingDirectory(TestDirectory.path()));
 
   TreePathPrefixMapper Remapper(FS);
-  ASSERT_THAT_ERROR(Remapper.add(MappedPrefix{TestDirectory.path(), "/"}),
-                    Succeeded());
+  Remapper.add(MappedPrefix{TestDirectory.path(), "/"});
 
   TempFile Extra(TestDirectory.path("Extra"), "", "content");
   SmallVector<TempFile> Temps;
@@ -470,8 +468,7 @@ TEST(CachingOnDiskFileSystemTest, TrackNewAccessesExists) {
   ASSERT_FALSE(FS->setCurrentWorkingDirectory(TestDirectory.path()));
 
   TreePathPrefixMapper Remapper(FS);
-  ASSERT_THAT_ERROR(Remapper.add(MappedPrefix{TestDirectory.path(), "/"}),
-                    Succeeded());
+  Remapper.add(MappedPrefix{TestDirectory.path(), "/"});
 
   SmallVector<TempFile> Temps;
   for (size_t I = 0, E = 4; I != E; ++I)
@@ -608,8 +605,7 @@ TEST(CachingOnDiskFileSystemTest, ExcludeFromTacking) {
   ASSERT_FALSE(FS->setCurrentWorkingDirectory(TestDirectory.path()));
 
   TreePathPrefixMapper Remapper(FS);
-  ASSERT_THAT_ERROR(Remapper.add(MappedPrefix{TestDirectory.path(), "/"}),
-                    Succeeded());
+  Remapper.add(MappedPrefix{TestDirectory.path(), "/"});
 
   TempDir D1(TestDirectory.path("d1"));
   TempDir D2(TestDirectory.path("d2"));

--- a/llvm/unittests/Support/PrefixMapperTest.cpp
+++ b/llvm/unittests/Support/PrefixMapperTest.cpp
@@ -31,15 +31,15 @@ struct PrefixMapperWrapper {
   PrefixMapperWrapper(sys::path::Style PathStyle)
       : PM(PathStyle), Saver(Alloc) {}
 
-  void add(const MappedPrefix &Mapping) { return cantFail(PM.add(Mapping)); }
+  void add(const MappedPrefix &Mapping) { return PM.add(Mapping); }
 
   template <class RangeT> void addRange(const RangeT &Mappings) {
-    return cantFail(PM.addRange(Mappings));
+    return PM.addRange(Mappings);
   }
 
   StringRef map(StringRef Path) {
     SmallString<256> PathBuf;
-    cantFail(PM.map(Path, PathBuf));
+    PM.map(Path, PathBuf);
     return Saver.save(PathBuf.str());
   }
 };
@@ -136,8 +136,8 @@ TEST(PrefixMapperTest, construct) {
 
 TEST(PrefixMapperTest, add) {
   PrefixMapper PM(sys::path::Style::posix);
-  ASSERT_THAT_ERROR(PM.add(MappedPrefix{"a", "b"}), Succeeded());
-  ASSERT_THAT_ERROR(PM.add(MappedPrefix{"b", "a"}), Succeeded());
+  PM.add(MappedPrefix{"a", "b"});
+  PM.add(MappedPrefix{"b", "a"});
   ASSERT_EQ(2u, PM.getMappings().size());
   ASSERT_EQ((MappedPrefix{"a", "b"}), PM.getMappings().front());
   ASSERT_EQ((MappedPrefix{"b", "a"}), PM.getMappings().back());
@@ -146,17 +146,15 @@ TEST(PrefixMapperTest, add) {
 TEST(PrefixMapperTest, addRange) {
   PrefixMapper PM(sys::path::Style::posix);
 
-  ASSERT_THAT_ERROR(PM.add(MappedPrefix{"/old/before", "/new/before"}),
-                    Succeeded());
+  PM.add(MappedPrefix{"/old/before", "/new/before"});
   MappedPrefix Range[] = {
       {"/old/1", "/new/1"},
       {"/old/2", "/new/2"},
       {"/old/3", "/new/3"},
   };
   auto RangeRef = makeArrayRef(Range);
-  ASSERT_THAT_ERROR(PM.addRange(RangeRef), Succeeded());
-  ASSERT_THAT_ERROR(PM.add(MappedPrefix{"/old/after", "/new/after"}),
-                    Succeeded());
+  PM.addRange(RangeRef);
+  PM.add(MappedPrefix{"/old/after", "/new/after"});
 
   ASSERT_EQ(2u + RangeRef.size(), PM.getMappings().size());
   EXPECT_EQ((MappedPrefix{"/old/before", "/new/before"}),
@@ -276,7 +274,7 @@ TEST(PrefixMapperTest, mapNative) {
 TEST(PrefixMapperTest, mapTwoArgs) {
   PrefixMapper PM(sys::path::Style::posix);
   MappedPrefix Mappings[] = {{"/old", "/new"}};
-  ASSERT_THAT_ERROR(PM.addRange(makeArrayRef(Mappings)), Succeeded());
+  PM.addRange(makeArrayRef(Mappings));
 
   MappedPrefix Tests[] = {
       {"/old", "/new"},     {"/old/x/y", "/new/x/y"},
@@ -287,8 +285,8 @@ TEST(PrefixMapperTest, mapTwoArgs) {
   SmallString<128> OutputV;
   std::string OutputS;
   for (MappedPrefix M : Tests) {
-    ASSERT_THAT_ERROR(PM.map(M.Old, OutputV), Succeeded());
-    ASSERT_THAT_ERROR(PM.map(M.Old, OutputS), Succeeded());
+    PM.map(M.Old, OutputV);
+    PM.map(M.Old, OutputS);
     EXPECT_EQ(M.New, OutputV);
     EXPECT_EQ(M.New, OutputS);
   }
@@ -297,7 +295,7 @@ TEST(PrefixMapperTest, mapTwoArgs) {
 TEST(PrefixMapperTest, mapToString) {
   PrefixMapper PM(sys::path::Style::posix);
   MappedPrefix Mappings[] = {{"/old", "/new"}};
-  ASSERT_THAT_ERROR(PM.addRange(makeArrayRef(Mappings)), Succeeded());
+  PM.addRange(makeArrayRef(Mappings));
 
   MappedPrefix Tests[] = {
       {"/old", "/new"},     {"/old/x/y", "/new/x/y"},
@@ -307,8 +305,7 @@ TEST(PrefixMapperTest, mapToString) {
 
   SmallString<128> Output;
   for (MappedPrefix M : Tests) {
-    std::string S;
-    ASSERT_THAT_ERROR(PM.mapToString(M.Old).moveInto(S), Succeeded());
+    std::string S = PM.mapToString(M.Old);
     EXPECT_EQ(M.New, S);
   }
 }
@@ -316,7 +313,7 @@ TEST(PrefixMapperTest, mapToString) {
 TEST(PrefixMapperTest, mapInPlace) {
   PrefixMapper PM(sys::path::Style::posix);
   MappedPrefix Mappings[] = {{"/old", "/new"}};
-  ASSERT_THAT_ERROR(PM.addRange(makeArrayRef(Mappings)), Succeeded());
+  PM.addRange(makeArrayRef(Mappings));
 
   MappedPrefix Tests[] = {
       {"/old", "/new"},     {"/old/x/y", "/new/x/y"},
@@ -329,8 +326,8 @@ TEST(PrefixMapperTest, mapInPlace) {
   for (MappedPrefix M : Tests) {
     V = M.Old;
     S = M.Old;
-    ASSERT_THAT_ERROR(PM.mapInPlace(V), Succeeded());
-    ASSERT_THAT_ERROR(PM.mapInPlace(S), Succeeded());
+    PM.mapInPlace(V);
+    PM.mapInPlace(S);
     EXPECT_EQ(M.New, V);
     EXPECT_EQ(M.New, S);
   }
@@ -406,84 +403,74 @@ TEST(TreePathPrefixMapperTest, add) {
   auto FS = makeIntrusiveRefCnt<GetDirectoryEntryFileSystem>();
   TreePathPrefixMapper PM(FS);
 
-  EXPECT_THAT_ERROR(PM.add(MappedPrefix{"relative", "/new1"}), Succeeded());
-  EXPECT_THAT_ERROR(PM.add(MappedPrefix{"/absolute", "/new2"}), Succeeded());
-  ASSERT_EQ(2u, PM.getMappings().size());
-  EXPECT_EQ((MappedPrefix{"/real/path/1", "/new1"}), PM.getMappings().front());
-  EXPECT_EQ((MappedPrefix{"/real/path/2", "/new2"}), PM.getMappings().back());
+  // Non-canonical paths create two map entries: one for the canonical and one
+  // for the non-canonical path.
+  PM.add(MappedPrefix{"relative", "/new1"});
+  PM.add(MappedPrefix{"/absolute", "/new2"});
+  ASSERT_EQ(4u, PM.getMappings().size());
+  EXPECT_EQ((MappedPrefix{"relative", "/new1"}), PM.getMappings()[0]);
+  EXPECT_EQ((MappedPrefix{"/real/path/1", "/new1"}), PM.getMappings()[1]);
+  EXPECT_EQ((MappedPrefix{"/absolute", "/new2"}), PM.getMappings()[2]);
+  EXPECT_EQ((MappedPrefix{"/real/path/2", "/new2"}), PM.getMappings()[3]);
 
-  EXPECT_THAT_ERROR(PM.add(MappedPrefix{"missing", "/new"}), Failed());
-  EXPECT_EQ(2u, PM.getMappings().size());
+  // Canonical paths create a single entry.
+  PM.add(MappedPrefix{"/real/path", "/new3"});
+  ASSERT_EQ(5u, PM.getMappings().size());
+  EXPECT_EQ((MappedPrefix{"/real/path", "/new3"}), PM.getMappings().back());
+
+  PM.add(MappedPrefix{"missing", "/new"});
+  EXPECT_EQ(6u, PM.getMappings().size());
+  EXPECT_EQ((MappedPrefix{"missing", "/new"}), PM.getMappings().back());
 }
 
 TEST(TreePathPrefixMapperTest, addRange) {
   auto FS = makeIntrusiveRefCnt<GetDirectoryEntryFileSystem>();
   TreePathPrefixMapper PM(FS);
 
-  MappedPrefix BadMapping[] = {
+  MappedPrefix MissingMapping[] = {
       {"missing", "/new"},
   };
   MappedPrefix Mappings[] = {
       {"relative", "/new1"},
       {"/absolute", "/new2"},
+      {"/real/path", "/new3"},
   };
-  EXPECT_THAT_ERROR(PM.addRange(makeArrayRef(Mappings)), Succeeded());
-  ASSERT_EQ(2u, PM.getMappings().size());
-  EXPECT_EQ((MappedPrefix{"/real/path/1", "/new1"}), PM.getMappings().front());
-  EXPECT_EQ((MappedPrefix{"/real/path/2", "/new2"}), PM.getMappings().back());
+  PM.addRange(makeArrayRef(Mappings));
+  ASSERT_EQ(5u, PM.getMappings().size());
+  EXPECT_EQ((MappedPrefix{"relative", "/new1"}), PM.getMappings()[0]);
+  EXPECT_EQ((MappedPrefix{"/real/path/1", "/new1"}), PM.getMappings()[1]);
+  EXPECT_EQ((MappedPrefix{"/absolute", "/new2"}), PM.getMappings()[2]);
+  EXPECT_EQ((MappedPrefix{"/real/path/2", "/new2"}), PM.getMappings()[3]);
+  EXPECT_EQ((MappedPrefix{"/real/path", "/new3"}), PM.getMappings()[4]);
 
-  EXPECT_THAT_ERROR(PM.addRange(makeArrayRef(BadMapping)), Failed());
-  EXPECT_EQ(2u, PM.getMappings().size());
-}
-
-TEST(TreePathPrefixMapperTest, addRangeIfValid) {
-  auto FS = makeIntrusiveRefCnt<GetDirectoryEntryFileSystem>();
-  TreePathPrefixMapper PM(FS);
-
-  MappedPrefix Mappings[] = {
-      {"missing-before", "/new"}, {"relative", "/new1"},
-      {"missing", "/new"},        {"/absolute", "/new2"},
-      {"missing-after", "/new"},
-  };
-  PM.addRangeIfValid(makeArrayRef(Mappings));
-  ASSERT_EQ(2u, PM.getMappings().size());
-  EXPECT_EQ((MappedPrefix{"/real/path/1", "/new1"}), PM.getMappings().front());
-  EXPECT_EQ((MappedPrefix{"/real/path/2", "/new2"}), PM.getMappings().back());
+  PM.addRange(makeArrayRef(MissingMapping));
+  EXPECT_EQ(6u, PM.getMappings().size());
+  EXPECT_EQ((MappedPrefix{"missing", "/new"}), PM.getMappings().back());
 }
 
 TEST(TreePathPrefixMapperTest, addInverseRange) {
   auto FS = makeIntrusiveRefCnt<GetDirectoryEntryFileSystem>();
   TreePathPrefixMapper PM(FS);
 
-  MappedPrefix BadMapping[] = {
+  MappedPrefix MissingMapping[] = {
       {"/new", "missing"},
   };
   MappedPrefix Mappings[] = {
       {"/new1", "relative"},
       {"/new2", "/absolute"},
+      {"/new3", "/real/path"},
   };
-  EXPECT_THAT_ERROR(PM.addInverseRange(makeArrayRef(Mappings)), Succeeded());
-  ASSERT_EQ(2u, PM.getMappings().size());
-  EXPECT_EQ((MappedPrefix{"/real/path/1", "/new1"}), PM.getMappings().front());
-  EXPECT_EQ((MappedPrefix{"/real/path/2", "/new2"}), PM.getMappings().back());
+  PM.addInverseRange(makeArrayRef(Mappings));
+  ASSERT_EQ(5u, PM.getMappings().size());
+  EXPECT_EQ((MappedPrefix{"relative", "/new1"}), PM.getMappings()[0]);
+  EXPECT_EQ((MappedPrefix{"/real/path/1", "/new1"}), PM.getMappings()[1]);
+  EXPECT_EQ((MappedPrefix{"/absolute", "/new2"}), PM.getMappings()[2]);
+  EXPECT_EQ((MappedPrefix{"/real/path/2", "/new2"}), PM.getMappings()[3]);
+  EXPECT_EQ((MappedPrefix{"/real/path", "/new3"}), PM.getMappings()[4]);
 
-  EXPECT_THAT_ERROR(PM.addInverseRange(makeArrayRef(BadMapping)), Failed());
-  EXPECT_EQ(2u, PM.getMappings().size());
-}
-
-TEST(TreePathPrefixMapperTest, addInverseRangeIfValid) {
-  auto FS = makeIntrusiveRefCnt<GetDirectoryEntryFileSystem>();
-  TreePathPrefixMapper PM(FS);
-
-  MappedPrefix Mappings[] = {
-      {"/new", "missing-before"}, {"/new1", "relative"},
-      {"/new", "missing"},        {"/new2", "/absolute"},
-      {"/new", "missing-after"},
-  };
-  PM.addInverseRangeIfValid(makeArrayRef(Mappings));
-  ASSERT_EQ(2u, PM.getMappings().size());
-  EXPECT_EQ((MappedPrefix{"/real/path/1", "/new1"}), PM.getMappings().front());
-  EXPECT_EQ((MappedPrefix{"/real/path/2", "/new2"}), PM.getMappings().back());
+  PM.addInverseRange(makeArrayRef(MissingMapping));
+  EXPECT_EQ(6u, PM.getMappings().size());
+  EXPECT_EQ((MappedPrefix{"missing", "/new"}), PM.getMappings().back());
 }
 
 struct MapState {
@@ -506,39 +493,53 @@ struct MapState {
       {"/real/path/2", "/new2"},
       {"/real/path/2/nested", "/new2/nested"},
   };
-  SmallVector<StringRef> FailedTests = {"missing", "/missing", "/relative"};
+  SmallVector<MappedPrefix> MissingTests = {
+      {"missing/nested", "missing/nested"},
+      {"/missing/nested", "/missing/nested"},
+      {"/relative/nested", "/relative/nested"},
+  };
   MapState() : PM(FS) {
-    EXPECT_THAT_ERROR(PM.add(MappedPrefix{"relative", "/new1"}), Succeeded());
-    EXPECT_THAT_ERROR(PM.add(MappedPrefix{"/absolute", "/new2"}), Succeeded());
+    PM.add(MappedPrefix{"relative", "/new1"});
+    PM.add(MappedPrefix{"/absolute", "/new2"});
   }
 };
 
 TEST(TreePathPrefixMapperTest, map) {
   MapState State;
-  ASSERT_EQ(2u, State.PM.getMappings().size());
+  ASSERT_EQ(4u, State.PM.getMappings().size());
 
   SmallString<128> NotFoundV;
   std::string NotFoundS;
   SmallString<128> FoundV;
   std::string FoundS;
-  for (StringRef S : State.FailedTests) {
+  for (MappedPrefix Map : State.MissingTests) {
     FoundV = "";
     FoundS = "";
-    EXPECT_THAT_EXPECTED(State.PM.mapToString(S), Failed());
-    EXPECT_THAT_ERROR(State.PM.map(S, NotFoundV), Failed());
-    EXPECT_THAT_ERROR(State.PM.map(S, NotFoundS), Failed());
-    EXPECT_EQ("", NotFoundV);
-    EXPECT_EQ("", NotFoundS);
-    EXPECT_EQ(None, State.PM.mapOrNoneIfError(S, NotFoundV));
+    EXPECT_EQ(State.PM.mapToString(Map.Old), Map.New);
+    State.PM.map(Map.Old, FoundV);
+    State.PM.map(Map.Old, FoundS);
+    EXPECT_EQ(Map.New, FoundV);
+    EXPECT_EQ(Map.New, FoundS);
+
+    FoundV = "";
+    FoundS = "";
+
+    if (Map.Old.empty())
+      continue;
+
+    const vfs::CachedDirectoryEntry *Entry = nullptr;
+    ASSERT_THAT_ERROR(
+        State.FS->getDirectoryEntry(Map.Old, /*FollowSymlinks=*/false)
+            .moveInto(Entry),
+        Failed());
   }
 
   for (MappedPrefix Map : State.Tests) {
-    EXPECT_THAT_EXPECTED(State.PM.mapToString(Map.Old), HasValue(Map.New));
-    EXPECT_THAT_ERROR(State.PM.map(Map.Old, FoundV), Succeeded());
-    EXPECT_THAT_ERROR(State.PM.map(Map.Old, FoundS), Succeeded());
+    EXPECT_EQ(State.PM.mapToString(Map.Old), Map.New);
+    State.PM.map(Map.Old, FoundV);
+    State.PM.map(Map.Old, FoundS);
     EXPECT_EQ(Map.New, FoundV);
     EXPECT_EQ(Map.New, FoundS);
-    EXPECT_EQ(StringRef(Map.New), State.PM.mapOrNoneIfError(Map.Old, FoundV));
 
     FoundV = "";
     FoundS = "";
@@ -552,11 +553,9 @@ TEST(TreePathPrefixMapperTest, map) {
         Succeeded());
     FoundV = "";
     FoundS = "";
-    EXPECT_THAT_ERROR(State.PM.map(Entry->getTreePath(), FoundV), Succeeded());
-    EXPECT_THAT_ERROR(State.PM.map(Entry->getTreePath(), FoundS), Succeeded());
-    std::string S;
-    ASSERT_THAT_ERROR(State.PM.mapToString(Entry->getTreePath()).moveInto(S),
-                      Succeeded());
+    State.PM.map(Entry->getTreePath(), FoundV);
+    State.PM.map(Entry->getTreePath(), FoundS);
+    std::string S = State.PM.mapToString(Entry->getTreePath());
     EXPECT_EQ(Map.New, S);
     EXPECT_EQ(Map.New, FoundV);
     EXPECT_EQ(Map.New, FoundS);
@@ -565,33 +564,19 @@ TEST(TreePathPrefixMapperTest, map) {
 
 TEST(TreePathPrefixMapperTest, mapInPlace) {
   MapState State;
-  ASSERT_EQ(2u, State.PM.getMappings().size());
+  ASSERT_EQ(4u, State.PM.getMappings().size());
 
   std::string FoundS;
   SmallString<128> FoundV;
-  for (StringRef S : State.FailedTests) {
-    FoundS = S.str();
-    FoundV = S;
-    EXPECT_THAT_ERROR(State.PM.mapInPlace(FoundS), Failed());
-    EXPECT_THAT_ERROR(State.PM.mapInPlace(FoundV), Failed());
-    EXPECT_EQ(S, FoundS);
-    EXPECT_EQ(S, FoundV);
-    State.PM.mapInPlaceOrClear(FoundS);
-    EXPECT_EQ("", FoundS);
-  }
-
-  for (MappedPrefix Map : State.Tests) {
+  auto Tests = State.Tests;
+  Tests.append(State.MissingTests);
+  for (MappedPrefix Map : Tests) {
     FoundS = Map.Old;
     FoundV = Map.Old;
-    EXPECT_THAT_ERROR(State.PM.mapInPlace(FoundS), Succeeded());
-    EXPECT_THAT_ERROR(State.PM.mapInPlace(FoundV), Succeeded());
+    State.PM.mapInPlace(FoundS);
+    State.PM.mapInPlace(FoundV);
     EXPECT_EQ(Map.New, FoundS);
     EXPECT_EQ(Map.New, FoundV);
-
-    FoundS = Map.Old;
-    FoundV = Map.Old;
-    State.PM.mapInPlaceOrClear(FoundS);
-    EXPECT_EQ(Map.New, FoundS);
   }
 }
 


### PR DESCRIPTION
This simplifies the PrefixMapper interface to no longer have Error/Expected return values when adding or mapping a path. For the subclass TreePathPrefixMapper, we stop producing errors for missing files/prefix paths, and instead fallback to mapping without getting the tree path first.

- This brings TreePathPrefixMapper closer to the behaviour of normal PrefixMapper
- This enables mapping paths that do not actually exist (yet), which is important for adding prefix mapping to module build commands
- This removes a lot of error code paths.

(cherry picked from commit 56aec2e83a848b145d76752c8c84cbc1e79a29fd)