### PR TITLE
[CAS] Return error when the ondisk object kind is corrupted

### DIFF
--- a/llvm/lib/CAS/OnDiskCAS.cpp
+++ b/llvm/lib/CAS/OnDiskCAS.cpp
@@ -798,8 +798,9 @@ public:
   Expected<ObjectHandle> load(const IndexProxy &I, TrieRecord::Data Object,
                               InternalRef Ref);
 
-  ObjectHandle getLoadedObject(const IndexProxy &I, TrieRecord::Data Object,
-                               InternalHandle Handle) const;
+  Expected<ObjectHandle> getLoadedObject(const IndexProxy &I,
+                                         TrieRecord::Data Object,
+                                         InternalHandle Handle) const;
 
   struct PooledDataRecord {
     FileOffset Offset;
@@ -1474,14 +1475,15 @@ Expected<ObjectHandle> OnDiskCAS::load(ObjectRef ExternalRef) {
   return load(*I, I->Ref.load(), Ref);
 }
 
-ObjectHandle OnDiskCAS::getLoadedObject(const IndexProxy &I,
-                                        TrieRecord::Data Object,
-                                        InternalHandle Handle) const {
+Expected<ObjectHandle> OnDiskCAS::getLoadedObject(const IndexProxy &I,
+                                                  TrieRecord::Data Object,
+                                                  InternalHandle Handle) const {
   switch (Object.OK) {
   case TrieRecord::ObjectKind::Invalid:
   case TrieRecord::ObjectKind::Object:
     return makeObjectHandle(Handle.getRawData());
   }
+  return createCorruptObjectError(getID(I));
 }
 
 Expected<ObjectHandle>


### PR DESCRIPTION
If the object kind value in the OnDiskCAS is corrupted, report error. This potentially fixes an undefined behavior (function doesn't return a value) when the CAS is corrupted.

rdar://104047245
(cherry picked from commit db4c59a2eac773e786d6021ed747d757cbcb2c07)