### PR TITLE
Suppress lambdas modern test failure properly on 20220421

### DIFF
--- a/clang/test/Analysis/lambdas-modern.cpp
+++ b/clang/test/Analysis/lambdas-modern.cpp
@@ -1,6 +1,8 @@
 // RUN: %clang_analyze_cc1 -std=c++14 -analyzer-checker=core,debug.ExprInspection -analyzer-config inline-lambdas=true -verify %s
 // RUN: %clang_analyze_cc1 -std=c++17 -analyzer-checker=core,debug.ExprInspection -analyzer-config inline-lambdas=true -verify %s
-// XFAIL: *
+
+// rdar://104094220
+// REQUIRES: !asserts
 
 #include "Inputs/system-header-simulator-cxx.h"
 


### PR DESCRIPTION
XFAIL wasn't right because it actually passes when assertions are disabled.

rdar://104094220 to complete investigation of why it's failing in the first place (might be another missing cherry-pick).