### PR TITLE
[lldb] Only add lldb-framework-cleanup dependency to existing targets

### DIFF
--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -239,10 +239,15 @@ endif()
 if(LLDB_BUILD_FRAMEWORK)
   include(LLDBFramework)
 
-  add_dependencies(install-liblldb
-    lldb-framework-cleanup)
-  add_dependencies(install-liblldb-stripped
-    lldb-framework-cleanup)
+  if (TARGET install-liblldb)
+    add_dependencies(install-liblldb
+      lldb-framework-cleanup)
+  endif()
+
+  if (TARGET install-liblldb-stripped)
+    add_dependencies(install-liblldb-stripped
+      lldb-framework-cleanup)
+  endif()
 endif()
 
 ## BEGIN SWIFT


### PR DESCRIPTION
The Xcode standalone build doesn't have the install-liblldb and
install-liblldb-stripped targets. Fix the resulting CMake error "Cannot
add target-level dependencies to non-existent target" by only adding the
dependency when the targets exist.

(cherry picked from commit 302f4aef7930c125236f071140eb9482532f2877)
