### PR TITLE
[mccas] Use LEB encoding for debug forms ref4 and strp

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Dwarf.def
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.def
@@ -680,6 +680,8 @@ HANDLE_DW_FORM(0x1f20, GNU_ref_alt, 0, GNU)
 HANDLE_DW_FORM(0x1f21, GNU_strp_alt, 0, GNU)
 // LLVM addr+offset extension
 HANDLE_DW_FORM(0x2001, LLVM_addrx_offset, 0, LLVM)
+// CAS Extensions
+HANDLE_DW_FORM(0x7e, ref4_cas, 0, APPLE)
 
 // DWARF Expression operators.
 HANDLE_DW_OP(0x03, addr, 2, DWARF)

--- a/llvm/include/llvm/BinaryFormat/Dwarf.def
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.def
@@ -681,6 +681,7 @@ HANDLE_DW_FORM(0x1f21, GNU_strp_alt, 0, GNU)
 // LLVM addr+offset extension
 HANDLE_DW_FORM(0x2001, LLVM_addrx_offset, 0, LLVM)
 // CAS Extensions
+HANDLE_DW_FORM(0x7d, strp_cas, 0, APPLE)
 HANDLE_DW_FORM(0x7e, ref4_cas, 0, APPLE)
 
 // DWARF Expression operators.

--- a/llvm/include/llvm/MC/CAS/MCCASDebugV1.h
+++ b/llvm/include/llvm/MC/CAS/MCCASDebugV1.h
@@ -83,6 +83,10 @@ protected:
   raw_svector_ostream DataStream;
 };
 
+/// Use a more efficient format for storing 4-byte wide form data.
+uint64_t convertFourByteFormDataToULEB(ArrayRef<char> FormData,
+                                       DataWriter &Writer);
+
 // Helper class to write a DIE's abbreviation contents to a buffer.
 struct AbbrevEntryWriter : DataWriter {
   void writeAbbrevEntry(DWARFDie DIE);

--- a/llvm/lib/MC/MCCASDebugV1.cpp
+++ b/llvm/lib/MC/MCCASDebugV1.cpp
@@ -112,6 +112,7 @@ mccasformats::v1::getFormSize(dwarf::Form Form, dwarf::FormParams FP,
     case dwarf::DW_FORM_udata:
     case dwarf::DW_FORM_ref_udata:
     case dwarf::DW_FORM_ref4_cas:
+    case dwarf::DW_FORM_strp_cas:
     case dwarf::DW_FORM_rnglistx:
     case dwarf::DW_FORM_loclistx:
     case dwarf::DW_FORM_GNU_addr_index:
@@ -199,6 +200,7 @@ bool mccasformats::v1::doesntDedup(dwarf::Form Form, dwarf::Attribute Attr) {
       FormsToPartition{
           {dwarf::Form::DW_FORM_ref_addr, {}},
           {dwarf::Form::DW_FORM_strp, {}},
+          {dwarf::Form::DW_FORM_strp_cas, {}},
           {dwarf::Form::DW_FORM_ref4, {}},
           {dwarf::Form::DW_FORM_ref4_cas, {}},
           {dwarf::Form::DW_FORM_data1,
@@ -248,6 +250,8 @@ void AbbrevEntryWriter::writeAbbrevEntry(DWARFDie DIE) {
     dwarf::Form Form = AttrValue.Value.getForm();
     if (Form == dwarf::Form::DW_FORM_ref4)
       Form = dwarf::Form::DW_FORM_ref4_cas;
+    if (Form == dwarf::Form::DW_FORM_strp)
+      Form = dwarf::Form::DW_FORM_strp_cas;
     writeULEB128(Form);
   }
 }
@@ -321,6 +325,8 @@ mccasformats::v1::reconstructAbbrevSection(raw_ostream &OS,
       auto Form = static_cast<dwarf::Form>(FormAsInt);
       if (Form == dwarf::Form::DW_FORM_ref4_cas)
         Form = dwarf::Form::DW_FORM_ref4;
+      if (Form == dwarf::Form::DW_FORM_strp_cas)
+        Form = dwarf::Form::DW_FORM_strp;
 
       WrittenSize += encodeULEB128(Form, OS);
     }

--- a/llvm/lib/MC/MCCASObjectV1.cpp
+++ b/llvm/lib/MC/MCCASObjectV1.cpp
@@ -2504,10 +2504,10 @@ static void writeDIEAttrs(DWARFDie &DIE, ArrayRef<char> DebugInfoData,
     dwarf::Form Form = AttrValue.Value.getForm();
     ArrayRef<char> FormData =
         DebugInfoData.slice(AttrValue.Offset, AttrValue.ByteSize);
-    if (doesntDedup(Form, Attr))
-      DistinctWriter.writeData(FormData);
-    else
-      DIEWriter.writeData(FormData);
+    auto &WriterToUse = doesntDedup(Form, Attr)
+                            ? static_cast<DataWriter &>(DistinctWriter)
+                            : DIEWriter;
+    WriterToUse.writeData(FormData);
   }
 }
 

--- a/llvm/lib/MC/MCCASObjectV1.cpp
+++ b/llvm/lib/MC/MCCASObjectV1.cpp
@@ -505,7 +505,8 @@ materializeDebugInfoFromTagImpl(MCCASReader &Reader,
 
   auto AttrCallback = [&](dwarf::Attribute, dwarf::Form Form,
                           StringRef FormData, bool) {
-    if (Form == dwarf::Form::DW_FORM_ref4_cas) {
+    if (Form == dwarf::Form::DW_FORM_ref4_cas ||
+        Form == dwarf::Form::DW_FORM_strp_cas) {
       auto Reader = BinaryStreamReader(FormData, support::endianness::little);
       uint64_t Data64;
       if (auto Err = Reader.readULEB128(Data64))
@@ -2516,7 +2517,7 @@ static void writeDIEAttrs(DWARFDie &DIE, ArrayRef<char> DebugInfoData,
     auto &WriterToUse = doesntDedup(Form, Attr)
                             ? static_cast<DataWriter &>(DistinctWriter)
                             : DIEWriter;
-    if (Form == dwarf::Form::DW_FORM_ref4)
+    if (Form == dwarf::Form::DW_FORM_ref4 || Form == dwarf::Form::DW_FORM_strp)
       convertFourByteFormDataToULEB(FormData, WriterToUse);
     else
       WriterToUse.writeData(FormData);

--- a/llvm/test/tools/llvm-cas-dump/basic_debug_test.ll
+++ b/llvm/test/tools/llvm-cas-dump/basic_debug_test.ll
@@ -57,12 +57,12 @@
 ; DWARF-DIE-NEXT:   Header = [4B 0 0 0 4 0 0 0 0 0 8]
 ; DWARF-DIE-NEXT:   CAS Block: llvmcas://{{.*}}
 ; DWARF-DIE-NEXT:   DW_TAG_compile_unit  AbbrevIdx = 2
-; DWARF-DIE-NEXT:     DW_AT_producer                 DW_FORM_strp           [distinct]    [{{.*}}]
+; DWARF-DIE-NEXT:     DW_AT_producer                 DW_FORM_strp_cas       [distinct]    [{{.*}}]
 ; DWARF-DIE-NEXT:     DW_AT_language                 DW_FORM_data2          [dedups]    [{{.*}}]
-; DWARF-DIE-NEXT:     DW_AT_name                     DW_FORM_strp           [distinct]    [{{.*}}]
-; DWARF-DIE-NEXT:     DW_AT_LLVM_sysroot             DW_FORM_strp           [distinct]    [{{.*}}]
+; DWARF-DIE-NEXT:     DW_AT_name                     DW_FORM_strp_cas       [distinct]    [{{.*}}]
+; DWARF-DIE-NEXT:     DW_AT_LLVM_sysroot             DW_FORM_strp_cas       [distinct]    [{{.*}}]
 ; DWARF-DIE-NEXT:     DW_AT_stmt_list                DW_FORM_sec_offset     [dedups]    [{{.*}}]
-; DWARF-DIE-NEXT:     DW_AT_comp_dir                 DW_FORM_strp           [distinct]    [{{.*}}]
+; DWARF-DIE-NEXT:     DW_AT_comp_dir                 DW_FORM_strp_cas       [distinct]    [{{.*}}]
 ; DWARF-DIE-NEXT:     DW_AT_low_pc                   DW_FORM_addr           [dedups]    [{{.*}}]
 ; DWARF-DIE-NEXT:     DW_AT_high_pc                  DW_FORM_data4          [dedups]    [{{.*}}]
 ; DWARF-DIE-NEXT:     CAS Block: llvmcas://{{.*}}
@@ -71,13 +71,13 @@
 ; DWARF-DIE-NEXT:       DW_AT_high_pc                  DW_FORM_data4        [dedups]     [{{.*}}]
 ; DWARF-DIE-NEXT:       DW_AT_APPLE_omit_frame_ptr     DW_FORM_flag_present [dedups]      []
 ; DWARF-DIE-NEXT:       DW_AT_frame_base               DW_FORM_exprloc      [dedups]      [{{.*}}]
-; DWARF-DIE-NEXT:       DW_AT_name                     DW_FORM_strp         [distinct]      [{{.*}}]
+; DWARF-DIE-NEXT:       DW_AT_name                     DW_FORM_strp_cas     [distinct]      [{{.*}}]
 ; DWARF-DIE-NEXT:       DW_AT_decl_file                DW_FORM_data1        [distinct]      [{{.*}}]
 ; DWARF-DIE-NEXT:       DW_AT_decl_line                DW_FORM_data1        [dedups]      [{{.*}}]
 ; DWARF-DIE-NEXT:       DW_AT_type                     DW_FORM_ref4_cas     [distinct]      [{{.*}}]
 ; DWARF-DIE-NEXT:       DW_AT_external                 DW_FORM_flag_present [dedups]      []
 ; DWARF-DIE-NEXT:     DW_TAG_base_type  AbbrevIdx = 4
-; DWARF-DIE-NEXT:       DW_AT_name                     DW_FORM_strp         [distinct]      [{{.*}}]
+; DWARF-DIE-NEXT:       DW_AT_name                     DW_FORM_strp_cas     [distinct]      [{{.*}}]
 ; DWARF-DIE-NEXT:       DW_AT_encoding                 DW_FORM_data1        [dedups]      [{{.*}}]
 ; DWARF-DIE-NEXT:       DW_AT_byte_size                DW_FORM_data1        [dedups]      [{{.*}}]
 

--- a/llvm/test/tools/llvm-cas-dump/basic_debug_test.ll
+++ b/llvm/test/tools/llvm-cas-dump/basic_debug_test.ll
@@ -74,7 +74,7 @@
 ; DWARF-DIE-NEXT:       DW_AT_name                     DW_FORM_strp         [distinct]      [{{.*}}]
 ; DWARF-DIE-NEXT:       DW_AT_decl_file                DW_FORM_data1        [distinct]      [{{.*}}]
 ; DWARF-DIE-NEXT:       DW_AT_decl_line                DW_FORM_data1        [dedups]      [{{.*}}]
-; DWARF-DIE-NEXT:       DW_AT_type                     DW_FORM_ref4         [distinct]      [{{.*}}]
+; DWARF-DIE-NEXT:       DW_AT_type                     DW_FORM_ref4_cas     [distinct]      [{{.*}}]
 ; DWARF-DIE-NEXT:       DW_AT_external                 DW_FORM_flag_present [dedups]      []
 ; DWARF-DIE-NEXT:     DW_TAG_base_type  AbbrevIdx = 4
 ; DWARF-DIE-NEXT:       DW_AT_name                     DW_FORM_strp         [distinct]      [{{.*}}]

--- a/llvm/test/tools/llvm-cas-dump/enums_split.ll
+++ b/llvm/test/tools/llvm-cas-dump/enums_split.ll
@@ -9,15 +9,15 @@
 ; DWARF-DIE-NEXT:   DW_TAG_enumeration_type     AbbrevIdx = 3
 ; DWARF-DIE-NEXT:     DW_AT_type                     DW_FORM_ref4_cas           [distinct] [47]
 ; DWARF-DIE-NEXT:     DW_AT_enum_class               DW_FORM_flag_present       [dedups]   []
-; DWARF-DIE-NEXT:     DW_AT_name                     DW_FORM_strp               [distinct] [88 0 0 0]
+; DWARF-DIE-NEXT:     DW_AT_name                     DW_FORM_strp_cas           [distinct] [88 1]
 ; DWARF-DIE-NEXT:     DW_AT_byte_size                DW_FORM_data1              [dedups]   [4]
 ; DWARF-DIE-NEXT:     DW_AT_decl_file                DW_FORM_data1              [distinct] [1]
 ; DWARF-DIE-NEXT:     DW_AT_decl_line                DW_FORM_data1              [dedups]   [3]
 ; DWARF-DIE-NEXT:     DW_TAG_enumerator         AbbrevIdx = 4
-; DWARF-DIE-NEXT:       DW_AT_name                     DW_FORM_strp               [distinct] [96 0 0 0]
+; DWARF-DIE-NEXT:       DW_AT_name                     DW_FORM_strp_cas           [distinct] [96 1]
 ; DWARF-DIE-NEXT:       DW_AT_const_value              DW_FORM_sdata              [dedups]   [0]
 ; DWARF-DIE-NEXT:     DW_TAG_enumerator         AbbrevIdx = 4
-; DWARF-DIE-NEXT:       DW_AT_name                     DW_FORM_strp               [distinct] [9B 0 0 0]
+; DWARF-DIE-NEXT:       DW_AT_name                     DW_FORM_strp_cas           [distinct] [9B 1]
 ; DWARF-DIE-NEXT:       DW_AT_const_value              DW_FORM_sdata              [dedups]   [1]
 
 target triple = "arm64-apple-macosx13.0.0"

--- a/llvm/test/tools/llvm-cas-dump/enums_split.ll
+++ b/llvm/test/tools/llvm-cas-dump/enums_split.ll
@@ -7,7 +7,7 @@
 ; DWARF-DIE-NEXT:   DW_TAG_compile_unit  AbbrevIdx = 2
 ; DWARF-DIE:        CAS Block: llvmcas://{{.*}}
 ; DWARF-DIE-NEXT:   DW_TAG_enumeration_type     AbbrevIdx = 3
-; DWARF-DIE-NEXT:     DW_AT_type                     DW_FORM_ref4               [distinct] [47 0 0 0]
+; DWARF-DIE-NEXT:     DW_AT_type                     DW_FORM_ref4_cas           [distinct] [47]
 ; DWARF-DIE-NEXT:     DW_AT_enum_class               DW_FORM_flag_present       [dedups]   []
 ; DWARF-DIE-NEXT:     DW_AT_name                     DW_FORM_strp               [distinct] [88 0 0 0]
 ; DWARF-DIE-NEXT:     DW_AT_byte_size                DW_FORM_data1              [dedups]   [4]

--- a/llvm/test/tools/llvm-cas-dump/types_split.ll
+++ b/llvm/test/tools/llvm-cas-dump/types_split.ll
@@ -10,12 +10,12 @@
 ; DWARF-DIE:        CAS Block: llvmcas://{{.*}}
 ; DWARF-DIE-NEXT:   DW_TAG_structure_type    AbbrevIdx = 6
 ; DWARF-DIE-NEXT:     DW_AT_calling_convention       DW_FORM_data1              [dedups]   [5]
-; DWARF-DIE-NEXT:     DW_AT_name                     DW_FORM_strp               [distinct] [92 0 0 0]
+; DWARF-DIE-NEXT:     DW_AT_name                     DW_FORM_strp_cas           [distinct] [92 1]
 ; DWARF-DIE-NEXT:     DW_AT_byte_size                DW_FORM_data1              [dedups]   [20]
 ; DWARF-DIE-NEXT:     DW_AT_decl_file                DW_FORM_data1              [distinct] [1]
 ; DWARF-DIE-NEXT:     DW_AT_decl_line                DW_FORM_data1              [dedups]   [2]
 ; DWARF-DIE-NEXT:     DW_TAG_member             AbbrevIdx = 7
-; DWARF-DIE-NEXT:       DW_AT_name                     DW_FORM_strp               [distinct] [9B 0 0 0]
+; DWARF-DIE-NEXT:       DW_AT_name                     DW_FORM_strp_cas           [distinct] [9B 1]
 ; DWARF-DIE-NEXT:       DW_AT_type                     DW_FORM_ref4_cas           [distinct] [5B]
 ; DWARF-DIE-NEXT:       DW_AT_decl_file                DW_FORM_data1              [distinct] [1]
 ; DWARF-DIE-NEXT:       DW_AT_decl_line                DW_FORM_data1              [dedups]   [4]

--- a/llvm/test/tools/llvm-cas-dump/types_split.ll
+++ b/llvm/test/tools/llvm-cas-dump/types_split.ll
@@ -16,7 +16,7 @@
 ; DWARF-DIE-NEXT:     DW_AT_decl_line                DW_FORM_data1              [dedups]   [2]
 ; DWARF-DIE-NEXT:     DW_TAG_member             AbbrevIdx = 7
 ; DWARF-DIE-NEXT:       DW_AT_name                     DW_FORM_strp               [distinct] [9B 0 0 0]
-; DWARF-DIE-NEXT:       DW_AT_type                     DW_FORM_ref4               [distinct] [5B 0 0 0]
+; DWARF-DIE-NEXT:       DW_AT_type                     DW_FORM_ref4_cas           [distinct] [5B]
 ; DWARF-DIE-NEXT:       DW_AT_decl_file                DW_FORM_data1              [distinct] [1]
 ; DWARF-DIE-NEXT:       DW_AT_decl_line                DW_FORM_data1              [dedups]   [4]
 ; DWARF-DIE-NEXT:       DW_AT_data_member_location     DW_FORM_data1              [dedups]   [0]


### PR DESCRIPTION
This PR contains the necessary steps towards reducing the amount of space occupied by the the forms above. 
The total size of the CAS is reduced by about 240MB (3160 MB -> 2915 MB).

I measured how much space each form takes in the distinct data block, and the biggest offenders are:

```
FORM_strp   | 429,805,300    ->  315,020,226 using LEB encoding
FORM_data1  |  57,466,076
FORM_data2  |   1,612,042
FORM_ref4   | 575,143,588    ->  430,054,932 using LEB encoding
```