### PR TITLE
[stable/20220421][clang/cas] Address review feedback for "Introduce mechanism for caching diagnostics with full source location fidelity"

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6278,7 +6278,7 @@ def fsycl_is_host : Flag<["-"], "fsycl-is-host">,
 //         -fdepscan-prefix-map=/my/build/dir=/^build
 // ```
 
-// Driver-only CAS options.
+// Driver CAS options.
 def fdepscan_EQ : Joined<["-"], "fdepscan=">,
     Group<f_Group>,
     HelpText<"Scan for dependencies ahead of compiling, generating a"

--- a/clang/lib/Frontend/CompileJobCacheKey.cpp
+++ b/clang/lib/Frontend/CompileJobCacheKey.cpp
@@ -154,8 +154,7 @@ canonicalizeForCaching(llvm::cas::ObjectStore &CAS, DiagnosticsEngine &Diags,
       FrontendOpts.DisableCachedCompileJobReplay;
   FrontendOpts.DisableCachedCompileJobReplay = false;
   FrontendOpts.IncludeTimestamps = false;
-  Opts.PathPrefixMappings = std::move(FrontendOpts.PathPrefixMappings);
-  FrontendOpts.PathPrefixMappings.clear();
+  std::swap(Opts.PathPrefixMappings, FrontendOpts.PathPrefixMappings);
 
   // Hide the CAS configuration, canonicalizing it to keep the path to the
   // CAS from leaking to the compile job, where it might affecting its

--- a/clang/tools/driver/CachedDiagnostics.cpp
+++ b/clang/tools/driver/CachedDiagnostics.cpp
@@ -774,6 +774,14 @@ CachingDiagnosticsProcessor::serializeEmittedDiagnostics() {
 
 Error CachingDiagnosticsProcessor::replayCachedDiagnostics(
     StringRef Buffer, DiagnosticConsumer &Consumer) {
+
+  // A compilation that only includes "#import <Foundation/Foundation.h>" and
+  // passes "-Weverything -Wsystem-headers" generated 3780 warnings and when
+  // replaying them:
+  //   * Deserialization of diagnostics: ~40ms
+  //   * Rendering the diagnostics: ~240ms
+  // FIXME: Look into improving performance of diagnostic rendering.
+
   CachedDiagnosticSerializer Serializer(Mapper, FileMgr);
   if (Error E = Serializer.deserializeCachedDiagnostics(Buffer))
     return E;


### PR DESCRIPTION
* Change comment "Driver-only CAS options." -> "Driver CAS options."
* Use `std::swap`
* Add a `FIXME` comment for `CachingDiagnosticsProcessor::replayCachedDiagnostics()`.

(cherry picked from commit 663b0288c9e82f7f0363a4283befc2e101099997)