### PR TITLE
[lldb] Limit `nothreadallow` to Python in SWIG bindings

### DIFF
--- a/lldb/bindings/interface/SBValueList.i
+++ b/lldb/bindings/interface/SBValueList.i
@@ -105,7 +105,9 @@ public:
     lldb::SBError GetError();
 
     %extend {
+#ifdef SWIGPYTHON
        %nothreadallow;
+#endif
        std::string lldb::SBValueList::__str__ (){
            lldb::SBStream description;
            const size_t n = $self->GetSize();
@@ -124,7 +126,9 @@ public:
                --desc_len;
            return std::string(desc, desc_len);
        }
+#ifdef SWIGPYTHON
        %clearnothreadallow;
+#endif
     }
 
 #ifdef SWIGPYTHON


### PR DESCRIPTION
SWIG allows you to partially disable thread support for a given function
in Python with `nothreadallow`. This functionality is limited to Python,
but until SWIG 4.1, it would silently ignore this for other languages,
such as Lua. New versions of SWIG are more strict and therefore we need
to guard this with `SWIGPYTHON`.

For more details on the functionality, I recommend reading the commit
message from 070a1d562b30.

(cherry picked from commit ba35c27ec9aa9807f5b4be2a0c33ca9b045accc7)
