### PR TITLE
[lldb] Fix compile error in Lua typemap

### DIFF
--- a/lldb/bindings/lua/lua-typemaps.swig
+++ b/lldb/bindings/lua/lua-typemaps.swig
@@ -247,7 +247,7 @@ LLDB_NUMBER_TYPEMAP(enum SWIGTYPE);
 // Typemap for file handles (e.g. used in SBDebugger::GetOutputFileHandle)
 
 %typemap(out) lldb::FileSP {
-  lldb::FileSP &sp = $1;
+  lldb::FileSP sp = $1;
   if (sp && sp->IsValid()) {
     luaL_Stream *p = (luaL_Stream *)lua_newuserdata(L, sizeof(luaL_Stream));
     p->closef = &LLDBSwigLuaCloseFileHandle;


### PR DESCRIPTION
Fix error "non-const lvalue reference to type 'lldb::FileSP'  cannot
bind to a value of unrelated type" in Lua typemap.

(cherry picked from commit 9ec115978ea2bdfc60800cd3c21264341cdc8b0a)
