### PR TITLE
[stable/20220421][clang/cas/remote] Don't fatal error if `LLBUILD_TASK_ID` is set but `LLBUILD_CONTROL_FD` is not

### DIFF
--- a/clang/test/CAS/remote-cache-service.c
+++ b/clang/test/CAS/remote-cache-service.c
@@ -6,7 +6,8 @@
 
 // Baseline to check we got expected outputs.
 // RUN: %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -MMD -MT dependencies -MF %t/t.d --serialize-diagnostics %t/t.dia
-// RUN: llvm-remote-cache-test -socket-path=%{remote-cache-dir}/%basename_t -cache-path=%t/cache -- env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// Adding `LLBUILD_TASK_ID` just to make sure there's no failure if that is set but `LLBUILD_CONTROL_FD` is not.
+// RUN: llvm-remote-cache-test -socket-path=%{remote-cache-dir}/%basename_t -cache-path=%t/cache -- env LLBUILD_TASK_ID=1 LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t1.o -MMD -MT dependencies -MF %t/t1.d --serialize-diagnostics %t/t1.dia -Rcompile-job-cache \
 // RUN:   2>&1 | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: llvm-remote-cache-test -socket-path=%{remote-cache-dir}/%basename_t -cache-path=%t/cache -- env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -1134,18 +1134,18 @@ void RemoteCachingOutputs::tryReleaseLLBuildExecutionLane() {
   if (TriedReleaseLLBuildExecutionLane)
     return;
   TriedReleaseLLBuildExecutionLane = true;
-  if (const char *LLTaskID = getenv("LLBUILD_TASK_ID")) {
+  if (auto LLTaskID = llvm::sys::Process::GetEnv("LLBUILD_TASK_ID")) {
     // Use the llbuild protocol to request to release the execution lane for
     // this task.
-    const char *LLControlFD = getenv("LLBUILD_CONTROL_FD");
+    auto LLControlFD = llvm::sys::Process::GetEnv("LLBUILD_CONTROL_FD");
     if (!LLControlFD)
-      llvm::report_fatal_error("'LLBUILD_CONTROL_FD' env var is not set!");
+      return; // LLBUILD_CONTROL_FD may not be set if a shell script is invoked.
     int LLCtrlFD;
-    bool HasErr = StringRef(LLControlFD).getAsInteger(10, LLCtrlFD);
+    bool HasErr = StringRef(*LLControlFD).getAsInteger(10, LLCtrlFD);
     if (HasErr)
       llvm::report_fatal_error(Twine("failed converting 'LLBUILD_CONTROL_FD' "
                                      "to an integer, it was: ") +
-                               LLControlFD);
+                               *LLControlFD);
     llvm::raw_fd_ostream FDOS(LLCtrlFD, /*shouldClose*/ false);
     FDOS << "llbuild.1\n" << LLTaskID << '\n';
     FDOS.flush();


### PR DESCRIPTION
This can happen if the clang invocation is not directly from llbuild but a shell script that llbuild invoked.

(cherry picked from commit 7b4a8c1864eac3eb8c1b0540f81c11c813939fd2)