### PR TITLE
[cas] Remove `ObjectRef getReference(ObjectHandle)` API from `ObjectStore`

### DIFF
--- a/clang/lib/Frontend/CompileJobCacheKey.cpp
+++ b/clang/lib/Frontend/CompileJobCacheKey.cpp
@@ -188,15 +188,11 @@ clang::createCompileJobCacheKey(ObjectStore &CAS, DiagnosticsEngine &Diags,
   return createCompileJobCacheKeyImpl(CAS, Diags, std::move(CI));
 }
 
-static Error printFileSystem(ObjectStore &CAS, ObjectRef Ref, raw_ostream &OS) {
-  Expected<ObjectProxy> Root = CAS.getProxy(Ref);
-  if (!Root)
-    return Root.takeError();
-
+static Error printFileSystem(ObjectStore &CAS, ObjectRef Root,
+                             raw_ostream &OS) {
   TreeSchema Schema(CAS);
   return Schema.walkFileTreeRecursively(
-      CAS, *Root,
-      [&](const NamedTreeEntry &Entry, Optional<TreeProxy> Tree) {
+      CAS, Root, [&](const NamedTreeEntry &Entry, Optional<TreeProxy> Tree) {
         if (Entry.getKind() != TreeEntry::Tree || Tree->empty()) {
           OS << "\n  ";
           Entry.print(OS, CAS);

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
@@ -72,10 +72,7 @@ storeDepDirectives(cas::ObjectStore &CAS,
     TokenIdx += Directive.Tokens.size();
   }
 
-  auto Blob = CAS.createProxy(None, Buffer);
-  if (!Blob)
-    return Blob.takeError();
-  return Blob->getRef();
+  return CAS.storeFromString(None, Buffer);
 }
 
 template <typename T> static void readle(StringRef &Slice, T &Out) {
@@ -142,18 +139,17 @@ void DependencyScanningCASFilesystem::scanForDirectives(
 
   // Get a blob for the clang version string.
   if (!ClangFullVersionID)
-    ClangFullVersionID =
-        reportAsFatalIfError(CAS.createProxy(None, getClangFullVersion()))
-            .getRef();
+    ClangFullVersionID = reportAsFatalIfError(
+        CAS.storeFromString(None, getClangFullVersion()));
 
   // Get a blob for the dependency directives scan command.
   if (!DepDirectivesID)
     DepDirectivesID =
-        reportAsFatalIfError(CAS.createProxy(None, "directives")).getRef();
+        reportAsFatalIfError(CAS.storeFromString(std::nullopt, "directives"));
 
   // Get an empty blob.
   if (!EmptyBlobID)
-    EmptyBlobID = reportAsFatalIfError(CAS.createProxy(None, "")).getRef();
+    EmptyBlobID = reportAsFatalIfError(CAS.storeFromString(None, ""));
 
   // Construct a tree for the input.
   Optional<CASID> InputID;

--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -155,9 +155,6 @@ public:
   virtual Error validate(const CASID &ID) = 0;
 
 protected:
-  /// Get a Ref from Handle.
-  virtual ObjectRef getReference(ObjectHandle Handle) const = 0;
-
   /// Load the object referenced by \p Ref.
   ///
   /// Errors if the object cannot be loaded.
@@ -198,8 +195,6 @@ protected:
   /// Read all the refs from object in a SmallVector.
   virtual void readRefs(ObjectHandle Node,
                         SmallVectorImpl<ObjectRef> &Refs) const;
-
-  Expected<ObjectProxy> getProxy(Expected<ObjectHandle> Ref);
 
   /// Allow ObjectStore implementations to create internal handles.
 #define MAKE_CAS_HANDLE_CONSTRUCTOR(HandleKind)                                \
@@ -280,7 +275,7 @@ public:
   const ObjectStore &getCAS() const { return *CAS; }
   ObjectStore &getCAS() { return *CAS; }
   CASID getID() const { return CAS->getID(H); }
-  ObjectRef getRef() const { return CAS->getReference(H); }
+  ObjectRef getRef() const { return Ref; }
   size_t getNumReferences() const { return CAS->getNumRefs(H); }
   ObjectRef getReference(size_t I) const { return CAS->readRef(H, I); }
 
@@ -321,14 +316,16 @@ public:
 public:
   ObjectProxy() = delete;
 
-  static ObjectProxy load(ObjectStore &CAS, ObjectHandle Node) {
-    return ObjectProxy(CAS, Node);
+  static ObjectProxy load(ObjectStore &CAS, ObjectRef Ref, ObjectHandle Node) {
+    return ObjectProxy(CAS, Ref, Node);
   }
 
 private:
-  ObjectProxy(ObjectStore &CAS, ObjectHandle H) : CAS(&CAS), H(H) {}
+  ObjectProxy(ObjectStore &CAS, ObjectRef Ref, ObjectHandle H)
+      : CAS(&CAS), Ref(Ref), H(H) {}
 
   ObjectStore *CAS;
+  ObjectRef Ref;
   ObjectHandle H;
 };
 

--- a/llvm/include/llvm/CAS/TreeSchema.h
+++ b/llvm/include/llvm/CAS/TreeSchema.h
@@ -45,7 +45,7 @@ public:
   /// Passes the \p TreeNodeProxy if the entry is a \p TreeEntry::Tree,
   /// otherwise passes \p None.
   Error walkFileTreeRecursively(
-      ObjectStore &CAS, const ObjectProxy &Root,
+      ObjectStore &CAS, ObjectRef Root,
       function_ref<Error(const NamedTreeEntry &, Optional<TreeProxy>)>
           Callback);
 

--- a/llvm/lib/CAS/BuiltinCAS.cpp
+++ b/llvm/lib/CAS/BuiltinCAS.cpp
@@ -115,7 +115,7 @@ Error BuiltinCAS::validate(const CASID &ID) {
   if (!Handle)
     return Handle.takeError();
 
-  auto Proxy = ObjectProxy::load(*this, *Handle);
+  auto Proxy = ObjectProxy::load(*this, *Ref, *Handle);
   SmallVector<ObjectRef> Refs;
   if (auto E = Proxy.forEachReference([&](ObjectRef Ref) -> Error {
         Refs.push_back(Ref);

--- a/llvm/lib/CAS/CASProvidingFileSystem.cpp
+++ b/llvm/lib/CAS/CASProvidingFileSystem.cpp
@@ -43,10 +43,10 @@ public:
                                             /*RequiresNullTerminator*/ false);
     if (!Buffer)
       return Buffer.getError();
-    auto Blob = DB->createProxy(None, (*Buffer)->getBuffer());
+    auto Blob = DB->storeFromString(None, (*Buffer)->getBuffer());
     if (!Blob)
       return errorToErrorCode(Blob.takeError());
-    return Blob->getRef();
+    return *Blob;
   }
 
   std::error_code close() override { return UnderlyingFile->close(); }

--- a/llvm/lib/CAS/HierarchicalTreeBuilder.cpp
+++ b/llvm/lib/CAS/HierarchicalTreeBuilder.cpp
@@ -70,14 +70,10 @@ Expected<ObjectProxy> HierarchicalTreeBuilder::create(ObjectStore &CAS) {
   // use a more efficient algorithm to merge contents.
   TreeSchema Schema(CAS);
   for (const auto &TreeContent : TreeContents) {
-    Optional<ObjectProxy> LoadedTree;
-    if (Error E = CAS.getProxy(*TreeContent.getRef()).moveInto(LoadedTree))
-      return std::move(E);
     StringRef Path = TreeContent.getPath();
     Error E = Schema.walkFileTreeRecursively(
-        CAS, *LoadedTree,
-        [&](const NamedTreeEntry &Entry,
-            Optional<TreeProxy> Tree) -> Error {
+        CAS, *TreeContent.getRef(),
+        [&](const NamedTreeEntry &Entry, Optional<TreeProxy> Tree) -> Error {
           if (Entry.getKind() != TreeEntry::Tree) {
             pushImpl(Entry.getRef(), Entry.getKind(), Path + Entry.getName());
             return Error::success();

--- a/llvm/lib/CAS/InMemoryCAS.cpp
+++ b/llvm/lib/CAS/InMemoryCAS.cpp
@@ -252,9 +252,6 @@ public:
       return toReference(*Object);
     return None;
   }
-  ObjectRef getReference(ObjectHandle Handle) const final {
-    return toReference(asInMemoryObject(Handle));
-  }
 
   ArrayRef<char> getDataConst(ObjectHandle Node) const final {
     return cast<InMemoryObject>(asInMemoryObject(Node)).getData();

--- a/llvm/lib/CAS/ObjectStore.cpp
+++ b/llvm/lib/CAS/ObjectStore.cpp
@@ -80,21 +80,15 @@ Expected<ObjectProxy> ObjectStore::getProxy(const CASID &ID) {
   if (!Ref)
     return createUnknownObjectError(ID);
 
-  Optional<ObjectHandle> H;
-  if (Error E = load(*Ref).moveInto(H))
-    return std::move(E);
-
-  return ObjectProxy::load(*this, *H);
+  return getProxy(*Ref);
 }
 
 Expected<ObjectProxy> ObjectStore::getProxy(ObjectRef Ref) {
-  return getProxy(load(Ref));
-}
+  Optional<ObjectHandle> H;
+  if (Error E = load(Ref).moveInto(H))
+    return std::move(E);
 
-Expected<ObjectProxy> ObjectStore::getProxy(Expected<ObjectHandle> H) {
-  if (!H)
-    return H.takeError();
-  return ObjectProxy::load(*this, *H);
+  return ObjectProxy::load(*this, Ref, *H);
 }
 
 Error ObjectStore::createUnknownObjectError(const CASID &ID) {

--- a/llvm/lib/CAS/OnDiskCAS.cpp
+++ b/llvm/lib/CAS/OnDiskCAS.cpp
@@ -823,9 +823,6 @@ public:
   }
 
   Optional<ObjectRef> getReference(const CASID &ID) const final;
-  ObjectRef getReference(ObjectHandle Handle) const final {
-    return getExternalReference(getInternalHandle(Handle).getRef());
-  }
 
   OnDiskHashMappedTrie::const_pointer
   getInternalIndexPointer(InternalRef Ref) const;

--- a/llvm/lib/CAS/TreeSchema.cpp
+++ b/llvm/lib/CAS/TreeSchema.cpp
@@ -32,8 +32,7 @@ bool TreeSchema::isNode(const ObjectProxy &Node) const {
 }
 
 TreeSchema::TreeSchema(cas::ObjectStore &CAS) : TreeSchema::RTTIExtends(CAS) {
-  auto Kind = cantFail(CAS.createProxy(None, SchemaName));
-  TreeKindRef.emplace(Kind.getRef());
+  TreeKindRef = cantFail(CAS.storeFromString(None, SchemaName));
 }
 
 ObjectRef TreeSchema::getKindRef() const { return *TreeKindRef; }
@@ -53,13 +52,13 @@ Error TreeSchema::forEachTreeEntry(
 }
 
 Error TreeSchema::walkFileTreeRecursively(
-    ObjectStore &CAS, const ObjectProxy &Root,
+    ObjectStore &CAS, ObjectRef Root,
     function_ref<Error(const NamedTreeEntry &, Optional<TreeProxy>)> Callback) {
   BumpPtrAllocator Alloc;
   StringSaver Saver(Alloc);
   SmallString<128> PathStorage;
   SmallVector<NamedTreeEntry> Stack;
-  Stack.emplace_back(Root.getRef(), TreeEntry::Tree, "/");
+  Stack.emplace_back(Root, TreeEntry::Tree, "/");
 
   while (!Stack.empty()) {
     if (Stack.back().getKind() != TreeEntry::Tree) {

--- a/llvm/lib/RemoteCachingService/CAS/GRPCRelayCAS.cpp
+++ b/llvm/lib/RemoteCachingService/CAS/GRPCRelayCAS.cpp
@@ -117,7 +117,6 @@ public:
   CASID getID(ObjectRef Ref) const final;
   CASID getID(ObjectHandle Handle) const final;
   Optional<ObjectRef> getReference(const CASID &ID) const final;
-  ObjectRef getReference(ObjectHandle Handle) const final;
   Expected<ObjectHandle> load(ObjectRef Ref) final;
   Error validate(const CASID &ID) final {
     // Not supported yet. Always return success.
@@ -305,10 +304,6 @@ Optional<ObjectRef> GRPCRelayCAS::getReference(const CASID &ID) const {
          "Expected ID from same hash schema");
   auto &I = indexHash(ID.getHash());
   return toReference(I);
-}
-
-ObjectRef GRPCRelayCAS::getReference(ObjectHandle Handle) const {
-  return toReference(asInMemoryCASData(Handle));
 }
 
 Expected<ObjectHandle> GRPCRelayCAS::load(ObjectRef Ref) {

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -201,7 +201,7 @@ int listTreeRecursively(ObjectStore &CAS, const CASID &ID) {
   ExitOnError ExitOnErr("llvm-cas: ls-tree-recursively: ");
   TreeSchema Schema(CAS);
   ExitOnErr(Schema.walkFileTreeRecursively(
-      CAS, ExitOnErr(CAS.getProxy(ID)),
+      CAS, *CAS.getReference(ID),
       [&](const NamedTreeEntry &Entry, Optional<TreeProxy> Tree) -> Error {
         if (Entry.getKind() != TreeEntry::Tree) {
           Entry.print(llvm::outs(), CAS);

--- a/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
@@ -583,7 +583,7 @@ TEST(CachingOnDiskFileSystemTest, TrackNewAccessesExists) {
 
   unsigned FileCount = 0;
   cantFail(Schema.walkFileTreeRecursively(
-      FS->getCAS(), *Tree,
+      FS->getCAS(), Tree->getRef(),
       [&](const cas::NamedTreeEntry &Entry, Optional<cas::TreeProxy>) {
         if (Entry.isFile()) {
           FileCount++;

--- a/llvm/unittests/CAS/TreeSchemaTest.cpp
+++ b/llvm/unittests/CAS/TreeSchemaTest.cpp
@@ -253,7 +253,7 @@ TEST(TreeSchemaTest, walkFileTreeRecursively) {
 
   TreeSchema Schema(*CAS);
   Error E = Schema.walkFileTreeRecursively(
-      *CAS, *Root,
+      *CAS, Root->getRef(),
       [&](const NamedTreeEntry &Entry, Optional<TreeProxy> Tree) -> Error {
         if (RemainingEntries.empty())
           return createStringError(inconvertibleErrorCode(),


### PR DESCRIPTION
This is a preamble step towards making the following changes for the on-disk CAS:

1. `ObjectRef` points to the hash-table entry instead of the stored value (allowing it to be "not associated with a value yet")
2. The stored value no longer needs to store the reference back to the hash-table entry.

The rationale for (2) is that the caller will always have the `ObjectRef` available, and after (1) the value doesn't need the back-reference anymore.

In preparation for such changes:

1. Found call-sites that were creating an `ObjectProxy` object just to get its reference, and changed them to use `storeFromString()` instead.
2. Added `ObjectRef` in `ObjectProxy` for convenience of other code that works with objects but also wants to have their reference available.

(cherry picked from commit c54eb2e0c93ebae9a8bcffcb847aa28f8e362570)