### PR TITLE
[clang/cas/include-tree] Fix issue where the generated dependency file lists the prefix header with a canonical path

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -28,6 +28,7 @@ namespace tooling {
 namespace dependencies {
 
 class DependencyScanningWorkerFilesystem;
+struct DepscanPrefixMapping;
 
 /// A command-line tool invocation that is part of building a TU.
 ///
@@ -80,6 +81,12 @@ public:
                              FileID Include, SourceLocation ExitLoc) = 0;
 
   virtual void handleHasIncludeCheck(Preprocessor &PP, bool Result) = 0;
+
+  /// FIXME: This is temporary until we eliminate the split between consumers in
+  /// \p DependencyScanningTool and collectors in \p DependencyScanningWorker
+  /// and have them both in the same file. see FIXME in \p
+  /// DependencyScanningAction::runInvocation.
+  virtual const DepscanPrefixMapping &getPrefixMapping() = 0;
 
 protected:
   void handleBuildCommand(Command) override {}

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -195,6 +195,10 @@ private:
 
   void handleHasIncludeCheck(Preprocessor &PP, bool Result) override;
 
+  const DepscanPrefixMapping &getPrefixMapping() override {
+    return PrefixMapping;
+  }
+
   Error finalize(CompilerInstance &CI) override;
 
   Expected<cas::ObjectRef> getObjectForFile(Preprocessor &PP, FileID FID);


### PR DESCRIPTION
(cherry picked from commit 88a4124cb213eb04face0973c0d65388119caadb)