### PR TITLE
[lldb] Update TestHelp.py for downstream option

### DIFF
--- a/lldb/test/API/commands/help/TestHelp.py
+++ b/lldb/test/API/commands/help/TestHelp.py
@@ -268,7 +268,7 @@ class HelpCommandTestCase(TestBase):
         """Test that we put a break between the usage and the options help lines,
            and between the options themselves."""
         self.expect("help memory read", substrs=[
-                    "[<address-expression>]\n\n       -A ( --show-all-children )",
+                    "[<address-expression>]\n\n       --bind-generic-types <none>",
                     # Starts with the end of the show-all-children line
                     "to show.\n\n       -D"])
 


### PR DESCRIPTION
The swift fork has an additional option (--bind-generic-types) before
--show-all-children. Update the test accordingly.

(cherry picked from commit 7451dc2332f2a1ce547cef8d8e894abc335dc41d)
