### PR TITLE
Implement IsNonTriviallyManagedReferenceType in TypeSystemSwiftTypeRef 

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -343,9 +343,7 @@ public:
   /// task is to strip those bits if necessary and return a pure
   /// pointer (or a tagged pointer).
   lldb::addr_t MaybeMaskNonTrivialReferencePointer(
-      lldb::addr_t,
-      SwiftASTContext::NonTriviallyManagedReferenceStrategy strategy);
-
+      lldb::addr_t, TypeSystemSwift::NonTriviallyManagedReferenceKind kind);
   /// \return true if this is a Swift tagged pointer (as opposed to an
   /// Objective-C tagged pointer).
   bool IsTaggedPointer(lldb::addr_t addr, CompilerType type);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -121,8 +121,7 @@ SwiftLanguageRuntime::MaskMaybeBridgedPointer(lldb::addr_t addr,
 }
 
 lldb::addr_t SwiftLanguageRuntime::MaybeMaskNonTrivialReferencePointer(
-    lldb::addr_t addr,
-    SwiftASTContext::NonTriviallyManagedReferenceStrategy strategy) {
+    lldb::addr_t addr, TypeSystemSwift::NonTriviallyManagedReferenceKind kind) {
 
   if (addr == 0)
     return addr;
@@ -162,8 +161,7 @@ lldb::addr_t SwiftLanguageRuntime::MaybeMaskNonTrivialReferencePointer(
 
   lldb::addr_t mask = 0;
 
-  if (strategy ==
-      SwiftASTContext::NonTriviallyManagedReferenceStrategy::eWeak) {
+  if (kind == TypeSystemSwift::NonTriviallyManagedReferenceKind::eWeak) {
     bool is_indirect = true;
 
     // On non-objc platforms, the weak reference pointer always pointed to a
@@ -217,7 +215,6 @@ lldb::addr_t SwiftLanguageRuntime::MaybeMaskNonTrivialReferencePointer(
       return addr;
     }
     return isa_addr;
-
   }
 
   if (is_arm && is_64)

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4567,6 +4567,26 @@ bool SwiftASTContext::IsTupleType(lldb::opaque_compiler_type_t type) {
   return llvm::isa<::swift::TupleType>(swift_type);
 }
 
+llvm::Optional<TypeSystemSwift::NonTriviallyManagedReferenceKind>
+SwiftASTContext::GetNonTriviallyManagedReferenceKind(
+    lldb::opaque_compiler_type_t type) {
+  VALID_OR_RETURN({});
+  if (swift::CanType swift_can_type = GetCanonicalSwiftType(type)) {
+    const swift::TypeKind type_kind = swift_can_type->getKind();
+    switch (type_kind) {
+    default:
+      return {};
+    case swift::TypeKind::UnmanagedStorage:
+      return NonTriviallyManagedReferenceKind::eUnmanaged;
+    case swift::TypeKind::UnownedStorage:
+      return NonTriviallyManagedReferenceKind::eUnowned;
+    case swift::TypeKind::WeakStorage:
+      return NonTriviallyManagedReferenceKind::eWeak;
+    }
+  }
+  return {};
+}
+
 CompilerType SwiftASTContext::GetErrorType() {
   VALID_OR_RETURN(CompilerType());
 
@@ -6651,40 +6671,6 @@ GetInstanceVariableOffset(ValueObject *valobj, ExecutionContext *exe_ctx,
 
   return GetInstanceVariableOffset_Metadata(valobj, exe_ctx, class_type,
                                             ivar_name, ivar_type);
-}
-
-bool SwiftASTContext::IsNonTriviallyManagedReferenceType(
-    const CompilerType &type, NonTriviallyManagedReferenceStrategy &strategy,
-    CompilerType *underlying_type) {
-  if (swift::CanType swift_can_type = ::GetCanonicalSwiftType(type)) {
-    const swift::TypeKind type_kind = swift_can_type->getKind();
-    switch (type_kind) {
-    default:
-      break;
-    case swift::TypeKind::UnmanagedStorage: {
-      strategy = NonTriviallyManagedReferenceStrategy::eUnmanaged;
-      if (underlying_type)
-        *underlying_type = ToCompilerType(
-            swift_can_type->getReferenceStorageReferent().getPointer());
-    }
-      return true;
-    case swift::TypeKind::UnownedStorage: {
-      strategy = NonTriviallyManagedReferenceStrategy::eUnowned;
-      if (underlying_type)
-        *underlying_type = ToCompilerType(
-            swift_can_type->getReferenceStorageReferent().getPointer());
-    }
-      return true;
-    case swift::TypeKind::WeakStorage: {
-      strategy = NonTriviallyManagedReferenceStrategy::eWeak;
-      if (underlying_type)
-        *underlying_type = ToCompilerType(
-            swift_can_type->getReferenceStorageReferent().getPointer());
-    }
-      return true;
-    }
-  }
-  return false;
 }
 
 CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -408,6 +408,9 @@ public:
   CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) override;
   bool IsTupleType(lldb::opaque_compiler_type_t type) override;
+  llvm::Optional<NonTriviallyManagedReferenceKind>
+  GetNonTriviallyManagedReferenceKind(
+      lldb::opaque_compiler_type_t type) override;
 
   CompilerType GetErrorType() override;
 
@@ -552,16 +555,6 @@ public:
 
   static bool GetProtocolTypeInfo(const CompilerType &type,
                                   ProtocolInfo &protocol_info);
-
-  enum class NonTriviallyManagedReferenceStrategy {
-    eWeak,
-    eUnowned,
-    eUnmanaged
-  };
-
-  static bool IsNonTriviallyManagedReferenceType(
-      const CompilerType &type, NonTriviallyManagedReferenceStrategy &strategy,
-      CompilerType *underlying_type = nullptr);
 
   static void ApplyWorkingDir(llvm::SmallVectorImpl<char> &clang_argument,
                               llvm::StringRef cur_working_dir);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -142,3 +142,22 @@ lldb::Format TypeSystemSwift::GetFormat(opaque_compiler_type_t type) {
 
   return eFormatBytes;
 }
+
+namespace llvm {
+llvm::raw_ostream &
+operator<<(llvm::raw_ostream &os,
+           TypeSystemSwift::NonTriviallyManagedReferenceKind k) {
+  switch (k) {
+  case TypeSystemSwift::NonTriviallyManagedReferenceKind::eWeak:
+    os << "eWeak";
+    break;
+  case TypeSystemSwift::NonTriviallyManagedReferenceKind:: eUnowned:
+    os << "eUnowned";
+    break;
+  case TypeSystemSwift::NonTriviallyManagedReferenceKind::eUnmanaged:
+    os << "eUnmanaged";
+    break;
+  }
+  return os;
+}
+} // namespace llvm

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -139,6 +139,15 @@ public:
   virtual CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) = 0;
   virtual bool IsTupleType(lldb::opaque_compiler_type_t type) = 0;
+
+  enum class NonTriviallyManagedReferenceKind : uint8_t {
+    eWeak,
+    eUnowned,
+    eUnmanaged
+  };
+  virtual llvm::Optional<NonTriviallyManagedReferenceKind>
+  GetNonTriviallyManagedReferenceKind(lldb::opaque_compiler_type_t type) = 0;
+
   using TypeSystem::DumpTypeDescription;
   virtual void DumpTypeDescription(
       lldb::opaque_compiler_type_t type, bool print_help_if_available,
@@ -173,7 +182,7 @@ public:
 
   /// \see lldb_private::TypeSystem::Dump
   void Dump(llvm::raw_ostream &output) override;
-  
+
   lldb::Format GetFormat(lldb::opaque_compiler_type_t type) override;
 
   /// Unavailable hardcoded functions that don't make sense for Swift.
@@ -181,134 +190,143 @@ public:
   ConstString DeclContextGetName(void *opaque_decl_ctx) override { return {}; }
   ConstString DeclContextGetScopeQualifiedName(void *opaque_decl_ctx) override {
     return {};
-  }
-  bool
-  DeclContextIsClassMethod(void *opaque_decl_ctx,
-                           lldb::LanguageType *language_ptr,
-                           bool *is_instance_method_ptr,
-                           ConstString *language_object_name_ptr) override {
-    return false;
-  }
-  bool IsRuntimeGeneratedType(lldb::opaque_compiler_type_t type) override {
-    return false;
-  }
-  bool IsCharType(lldb::opaque_compiler_type_t type) override { return false; }
-  bool IsCompleteType(lldb::opaque_compiler_type_t type) override {
-    return true;
-  }
-  bool IsConst(lldb::opaque_compiler_type_t type) override { return false; }
-  bool IsFloatingPointType(lldb::opaque_compiler_type_t type, uint32_t &count,
-                           bool &is_complex) override;
-  bool IsIntegerType(lldb::opaque_compiler_type_t type,
-                     bool &is_signed) override;
-  bool IsScopedEnumerationType(lldb::opaque_compiler_type_t type) override {
-    return false;
-  }
-  CompilerType
-  GetEnumerationIntegerType(lldb::opaque_compiler_type_t type) override {
-    return {};
-  }
-  bool IsScalarType(lldb::opaque_compiler_type_t type) override;
-  bool IsCStringType(lldb::opaque_compiler_type_t type,
-                     uint32_t &length) override {
-    return false;
-  }
-  bool IsVectorType(lldb::opaque_compiler_type_t type,
-                    CompilerType *element_type, uint64_t *size) override {
-    return false;
-  }
-  uint32_t IsHomogeneousAggregate(lldb::opaque_compiler_type_t type,
-                                  CompilerType *base_type_ptr) override {
-    return 0;
-  }
-  bool IsBlockPointerType(lldb::opaque_compiler_type_t type,
-                          CompilerType *function_pointer_type_ptr) override {
-    return false;
-  }
-  bool IsPolymorphicClass(lldb::opaque_compiler_type_t type) override {
-    return false;
-  }
-  bool IsBeingDefined(lldb::opaque_compiler_type_t type) override {
-    return false;
-  }
-  bool GetCompleteType(lldb::opaque_compiler_type_t type) override {
-    return true;
-  }
-  bool CanPassInRegisters(const CompilerType &type) override {
-    // FIXME: Implement this. There was an abort() here to figure out which
-    // tests where hitting this code. At least TestSwiftReturns and
-    // TestSwiftStepping were failing because of this Darwin.
-    return false;
-  }
-  lldb::LanguageType
-  GetMinimumLanguage(lldb::opaque_compiler_type_t type) override {
-    assert(type && "CompilerType::GetMinimumLanguage() is not supposed to "
-                   "forward calls with NULL types ");
-    return lldb::eLanguageTypeSwift;
-  }
-  unsigned GetTypeQualifiers(lldb::opaque_compiler_type_t type) override {
-    return 0;
-  }
-  CompilerType
-  GetTypeForDecl(lldb::opaque_compiler_type_t opaque_decl) override {
-    llvm_unreachable("GetTypeForDecl not implemented");
-  }
-  CompilerType GetBasicTypeFromAST(lldb::BasicType basic_type) override {
-    return {};
-  }
-  const llvm::fltSemantics &GetFloatTypeSemantics(size_t byte_size) override {
-    // See: https://reviews.llvm.org/D67239. At this time of writing this API
-    // is only used by DumpDataExtractor for the C type system.
-    llvm_unreachable("GetFloatTypeSemantics not implemented.");
-  }
-  lldb::BasicType
-  GetBasicTypeEnumeration(lldb::opaque_compiler_type_t type) override {
-    return lldb::eBasicTypeInvalid;
-  }
-  uint32_t
-  GetNumVirtualBaseClasses(lldb::opaque_compiler_type_t opaque_type) override {
-    return 0;
-  }
-  CompilerType
-  GetVirtualBaseClassAtIndex(lldb::opaque_compiler_type_t opaque_type,
-                             size_t idx, uint32_t *bit_offset_ptr) override {
-    return {};
-  }
-  bool
-  ShouldTreatScalarValueAsAddress(lldb::opaque_compiler_type_t type) override;
+    }
+    bool DeclContextIsClassMethod(
+        void *opaque_decl_ctx, lldb::LanguageType *language_ptr,
+        bool *is_instance_method_ptr, ConstString *language_object_name_ptr)
+        override {
+      return false;
+    }
+    bool IsRuntimeGeneratedType(lldb::opaque_compiler_type_t type) override {
+      return false;
+    }
+    bool IsCharType(lldb::opaque_compiler_type_t type) override {
+      return false;
+    }
+    bool IsCompleteType(lldb::opaque_compiler_type_t type) override {
+      return true;
+    }
+    bool IsConst(lldb::opaque_compiler_type_t type) override { return false; }
+    bool IsFloatingPointType(lldb::opaque_compiler_type_t type,
+                             uint32_t & count, bool &is_complex) override;
+    bool IsIntegerType(lldb::opaque_compiler_type_t type, bool &is_signed)
+        override;
+    bool IsScopedEnumerationType(lldb::opaque_compiler_type_t type) override {
+      return false;
+    }
+    CompilerType GetEnumerationIntegerType(lldb::opaque_compiler_type_t type)
+        override {
+      return {};
+    }
+    bool IsScalarType(lldb::opaque_compiler_type_t type) override;
+    bool IsCStringType(lldb::opaque_compiler_type_t type, uint32_t & length)
+        override {
+      return false;
+    }
+    bool IsVectorType(lldb::opaque_compiler_type_t type,
+                      CompilerType * element_type, uint64_t * size) override {
+      return false;
+    }
+    uint32_t IsHomogeneousAggregate(lldb::opaque_compiler_type_t type,
+                                    CompilerType * base_type_ptr) override {
+      return 0;
+    }
+    bool IsBlockPointerType(lldb::opaque_compiler_type_t type,
+                            CompilerType * function_pointer_type_ptr) override {
+      return false;
+    }
+    bool IsPolymorphicClass(lldb::opaque_compiler_type_t type) override {
+      return false;
+    }
+    bool IsBeingDefined(lldb::opaque_compiler_type_t type) override {
+      return false;
+    }
+    bool GetCompleteType(lldb::opaque_compiler_type_t type) override {
+      return true;
+    }
+    bool CanPassInRegisters(const CompilerType &type) override {
+      // FIXME: Implement this. There was an abort() here to figure out which
+      // tests where hitting this code. At least TestSwiftReturns and
+      // TestSwiftStepping were failing because of this Darwin.
+      return false;
+    }
+    lldb::LanguageType GetMinimumLanguage(lldb::opaque_compiler_type_t type)
+        override {
+      assert(type && "CompilerType::GetMinimumLanguage() is not supposed to "
+                     "forward calls with NULL types ");
+      return lldb::eLanguageTypeSwift;
+    }
+    unsigned GetTypeQualifiers(lldb::opaque_compiler_type_t type) override {
+      return 0;
+    }
+    CompilerType GetTypeForDecl(lldb::opaque_compiler_type_t opaque_decl)
+        override {
+      llvm_unreachable("GetTypeForDecl not implemented");
+    }
+    CompilerType GetBasicTypeFromAST(lldb::BasicType basic_type) override {
+      return {};
+    }
+    const llvm::fltSemantics &GetFloatTypeSemantics(size_t byte_size) override {
+      // See: https://reviews.llvm.org/D67239. At this time of writing this API
+      // is only used by DumpDataExtractor for the C type system.
+      llvm_unreachable("GetFloatTypeSemantics not implemented.");
+    }
+    lldb::BasicType GetBasicTypeEnumeration(lldb::opaque_compiler_type_t type)
+        override {
+      return lldb::eBasicTypeInvalid;
+    }
+    uint32_t GetNumVirtualBaseClasses(lldb::opaque_compiler_type_t opaque_type)
+        override {
+      return 0;
+    }
+    CompilerType GetVirtualBaseClassAtIndex(
+        lldb::opaque_compiler_type_t opaque_type, size_t idx,
+        uint32_t * bit_offset_ptr) override {
+      return {};
+    }
+    bool ShouldTreatScalarValueAsAddress(lldb::opaque_compiler_type_t type)
+        override;
 
-  /// Lookup a child given a name. This function will match base class names
-  /// and member names in \p type only, not descendants.
-  uint32_t GetIndexOfChildWithName(lldb::opaque_compiler_type_t type,
-                                   const char *name, ExecutionContext *exe_ctx,
-                                   bool omit_empty_base_classes) override;
+    /// Lookup a child given a name. This function will match base class names
+    /// and member names in \p type only, not descendants.
+    uint32_t GetIndexOfChildWithName(
+        lldb::opaque_compiler_type_t type, const char *name,
+        ExecutionContext *exe_ctx, bool omit_empty_base_classes) override;
 
-  CompilerType
-  GetLValueReferenceType(lldb::opaque_compiler_type_t type) override {
-    return {};
-  }
+    CompilerType GetLValueReferenceType(lldb::opaque_compiler_type_t type)
+        override {
+      return {};
+    }
 
-  CompilerType
-  GetRValueReferenceType(lldb::opaque_compiler_type_t type) override {
-    return {};
-  }
+    CompilerType GetRValueReferenceType(lldb::opaque_compiler_type_t type)
+        override {
+      return {};
+    }
 
-  CompilerType GetNonReferenceType(lldb::opaque_compiler_type_t type) override {
-    return {};
-  }
+    CompilerType GetNonReferenceType(lldb::opaque_compiler_type_t type)
+        override {
+      return {};
+    }
 
-  // TODO: This method appear unused. Should they be removed?
-  void DumpSummary(lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
-                   Stream *s, const DataExtractor &data,
-                   lldb::offset_t data_offset, size_t data_byte_size) override {
-  }
-  /// \}
-protected:
-  /// Used in the logs.
-  std::string m_description;
-  /// The module this typesystem belongs to if any.
-  Module *m_module = nullptr;
-};
+    // TODO: This method appear unused. Should they be removed?
+    void DumpSummary(lldb::opaque_compiler_type_t type,
+                     ExecutionContext * exe_ctx, Stream * s,
+                     const DataExtractor &data, lldb::offset_t data_offset,
+                     size_t data_byte_size) override {}
+    /// \}
+  protected:
+    /// Used in the logs.
+    std::string m_description;
+    /// The module this typesystem belongs to if any.
+    Module *m_module = nullptr;
+  };
 
 } // namespace lldb_private
+
+namespace llvm {
+raw_ostream &
+operator<<(raw_ostream &os,
+           lldb_private::TypeSystemSwift::NonTriviallyManagedReferenceKind k);
+}
+
 #endif

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3328,6 +3328,8 @@ CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
       tuple_element->addChild(type, dem);
       auto *element_type = GetDemangledType(
           dem, element.element_type.GetMangledTypeName().GetStringRef());
+      if (!element_type)
+        return {};
       type->addChild(element_type, dem);
     }
 
@@ -3371,7 +3373,7 @@ bool TypeSystemSwiftTypeRef::IsTupleType(lldb::opaque_compiler_type_t type) {
     using namespace swift::Demangle;
     Demangler dem;
     NodePointer node = GetDemangledType(dem, AsMangledName(type));
-    return node->getKind() == Node::Kind::Tuple;
+    return node && node->getKind() == Node::Kind::Tuple;
   };
   VALIDATE_AND_RETURN(impl, IsTupleType, type, g_no_exe_ctx,
                       (ReconstructType(type)), (ReconstructType(type)));
@@ -3385,6 +3387,8 @@ TypeSystemSwiftTypeRef::GetNonTriviallyManagedReferenceKind(
     using namespace swift::Demangle;
     Demangler dem;
     NodePointer node = GetDemangledType(dem, AsMangledName(type));
+    if (!node)
+      return {};
     switch (node->getKind()) {
     default:
       return {};
@@ -3866,6 +3870,8 @@ TypeSystemSwiftTypeRef::GetDependentGenericParamListForType(
   llvm::SmallVector<std::pair<int, int>, 1> dependent_params;
   Demangler dem;
   NodePointer type_node = GetDemangledType(dem, type);
+  if (!type_node)
+    return dependent_params;
   if (type_node->getNumChildren() != 2)
     return dependent_params;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -272,6 +272,9 @@ public:
   CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) override;
   bool IsTupleType(lldb::opaque_compiler_type_t type) override;
+  llvm::Optional<NonTriviallyManagedReferenceKind>
+  GetNonTriviallyManagedReferenceKind(
+      lldb::opaque_compiler_type_t type) override;
 
   /// Return the nth tuple element's type and name, if it has one.
   llvm::Optional<TupleElement>

--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -56,11 +56,8 @@ struct SwiftASTContextTester : public SwiftASTContext {
 TEST_F(TestSwiftASTContext, IsNonTriviallyManagedReferenceType) {
 #ifndef NDEBUG
   // The mock constructor is only available in asserts mode.
-  SwiftASTContext::NonTriviallyManagedReferenceStrategy strategy;
   auto context = std::make_shared<SwiftASTContextTester>();
-  CompilerType t(context->weak_from_this(), nullptr);
-  EXPECT_FALSE(SwiftASTContext::IsNonTriviallyManagedReferenceType(t, strategy,
-                                                                   nullptr));
+  EXPECT_FALSE(context->GetNonTriviallyManagedReferenceKind(nullptr));
 #endif
 }
 


### PR DESCRIPTION
to avoid spinning up a SwiftASTContext in the Swift::Optional dataformatter.

rdar://104145100