### PR TITLE
[stable/20221013][lldb][test] TestExprInsideLambdas.py: fix expected error message

### DIFF
--- a/lldb/test/API/commands/expression/expr_inside_lambda/TestExprInsideLambdas.py
+++ b/lldb/test/API/commands/expression/expr_inside_lambda/TestExprInsideLambdas.py
@@ -112,7 +112,7 @@ class ExprInsideLambdaTestCase(TestBase):
                                            " 'base_var'"))
 
         self.expectExprError("local_var", ("use of non-static data member 'local_var'"
-                                           " of '' from nested type 'LocalLambdaClass'"))
+                                           " of '(unnamed class)' from nested type 'LocalLambdaClass'"))
 
         # Inside non_capturing_method
         lldbutil.continue_to_breakpoint(process, bkpt)


### PR DESCRIPTION
Previously failed on the rebranch CI: https://ci.swift.org/view/Swift%20rebranch/job/oss-swift-rebranch-lldb-incremental-macos-cmake/2619/console