### PR TITLE
[clang/DependencyScanning] Don't emit system header dependencies during CAS depscan, if not requested

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -449,7 +449,11 @@ public:
       Opts->Targets = {
           deduceDepTarget(ScanInstance.getFrontendOpts().OutputFile,
                           ScanInstance.getFrontendOpts().Inputs)};
-    Opts->IncludeSystemHeaders = true;
+    if (Format == ScanningOutputFormat::Make) {
+      // Only 'Make' scanning needs to force this because that mode depends on
+      // getting the dependencies directly from \p DependencyFileGenerator.
+      Opts->IncludeSystemHeaders = true;
+    }
 
     auto reportError = [&ScanInstance](Error &&E) -> bool {
       ScanInstance.getDiagnostics().Report(diag::err_cas_depscan_failed)

--- a/clang/test/CAS/depscan-dependency-file.c
+++ b/clang/test/CAS/depscan-dependency-file.c
@@ -1,0 +1,27 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: split-file %s %t
+
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/t.rsp -cc1-args \
+// RUN:   -cc1 -triple x86_64-apple-macos11 %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
+// RUN:     -MT deps -dependency-file %t/t.d
+// RUN: FileCheck %s -input-file=%t/t.d -check-prefix=NOSYS
+// RUN: FileCheck %s -input-file=%t/t.d -check-prefix=COMMON
+
+// Including system headers.
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/t.rsp -cc1-args \
+// RUN:   -cc1 -triple x86_64-apple-macos11 %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
+// RUN:     -MT deps -sys-header-deps -dependency-file %t/t-sys.d
+// RUN: FileCheck %s -input-file=%t/t-sys.d -check-prefix=WITHSYS -check-prefix=COMMON
+
+// NOSYS-NOT: sys.h
+// COMMON: main.c
+// COMMON: my_header.h
+// WITHSYS: sys.h
+
+//--- main.c
+#include "my_header.h"
+#include <sys.h>
+
+//--- my_header.h
+
+//--- sys/sys.h

--- a/clang/test/CAS/fcas-include-tree-prefix-mapping.c
+++ b/clang/test/CAS/fcas-include-tree-prefix-mapping.c
@@ -71,8 +71,8 @@
 // RUN:   -emit-obj %t/src2/main.c -o %t/out2/main.o -include %t/src2/prefix.h -I %t/src2/inc \
 // RUN:   -MT deps -dependency-file %t/regular2.d
 
-// RUN: FileCheck %s -input-file %t/t1.d -check-prefix=CHECK-DEPS
-// CHECK-DEPS-NOT: ^src
+// RUN: diff -u %t/regular1.d %t/t1.d
+// RUN: diff -u %t/regular2.d %t/t2.d
 
 // Check with PCH.
 
@@ -154,8 +154,8 @@
 // RUN:   -emit-obj %t/src2/main.c -o %t/out2/main.o -include-pch %t/out2/reg-prefix.h.pch -I %t/src2/inc \
 // RUN:   -MT deps -dependency-file %t/regular2.pch.d
 
-// RUN: FileCheck %s -input-file %t/t1.d -check-prefix=CHECK-DEPS-PCH
-// CHECK-DEPS-PCH-NOT: ^src
+// RUN: diff -u %t/regular1.pch.d %t/t1.pch.d
+// RUN: diff -u %t/regular2.pch.d %t/t2.pch.d
 
 //--- main.c
 #include "t.h"


### PR DESCRIPTION
Previously the resulting dependency file after doing CAS dep-scanning would always include system headers.