### PR TITLE
[stable/20221013][lldb][test] TestConstStaticIntegralMember.py: un-XFAIL test-case

### DIFF
--- a/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
+++ b/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
@@ -100,9 +100,6 @@ class TestCase(TestBase):
 
         self.expect_expr("ClassWithOnlyConstStatic::member", result_value="3")
 
-    # With older versions of Clang, LLDB fails to evaluate classes with only
-    # constexpr members when dsymutil is enabled
-    @expectedFailureAll(debug_info=["dsym"], compiler=["clang"], compiler_version=["<", "14.0"])
     def test_class_with_only_constexpr_static(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "// break here", lldb.SBFileSpec("main.cpp"))


### PR DESCRIPTION
This is strictly better behaviour and seems to pass on the rebranch. So simply un-XFAIL the test.