### PR TITLE
[lldb] Fix building lldb with swift support off

### DIFF
--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -313,7 +313,7 @@ public:
   GetBitSize(lldb::opaque_compiler_type_t type,
              ExecutionContextScope *exe_scope) = 0;
 
-  virtual llvm::Optional<uint64_t>
+  virtual std::optional<uint64_t>
   GetByteStride(lldb::opaque_compiler_type_t type,
                 ExecutionContextScope *exe_scope) = 0;
 

--- a/lldb/include/lldb/Target/ThreadPlanStepOut.h
+++ b/lldb/include/lldb/Target/ThreadPlanStepOut.h
@@ -62,7 +62,7 @@ private:
   StackID m_immediate_step_from_id;
   lldb::break_id_t m_return_bp_id;
   lldb::addr_t m_return_addr;
-  llvm::Optional<Value> m_swift_error_return;
+  std::optional<Value> m_swift_error_return;
   bool m_swift_error_check_after_return;
   bool m_stop_others;
   lldb::ThreadPlanSP m_step_out_to_inline_plan_sp; // This plan implements step

--- a/lldb/source/Core/ValueObjectVariable.cpp
+++ b/lldb/source/Core/ValueObjectVariable.cpp
@@ -32,7 +32,9 @@
 #include "lldb/lldb-private-enumerations.h"
 #include "lldb/lldb-types.h"
 
+#if defined(LLDB_ENABLE_SWIFT)
 #include "Plugins/TypeSystem/Swift/TypeSystemSwift.h"
+#endif
 
 #include "llvm/ADT/StringRef.h"
 
@@ -141,7 +143,7 @@ bool ValueObjectVariable::UpdateValue() {
   CompilerType var_type(GetCompilerTypeImpl());
   if (var_type.IsValid() && var_type.GetMinimumLanguage() == lldb::eLanguageTypeSwift) {
     ExecutionContext exe_ctx(GetExecutionContextRef());
-    llvm::Optional<uint64_t> size =
+    std::optional<uint64_t> size =
       var_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
     if (size && *size == 0) {
       m_value.SetCompilerType(var_type);

--- a/lldb/source/DataFormatters/TypeFormat.cpp
+++ b/lldb/source/DataFormatters/TypeFormat.cpp
@@ -99,11 +99,6 @@ bool TypeFormatImpl_Format::FormatObject(ValueObject *valobj,
             return false;
         }
 
-        ExecutionContextScope *exe_scope =
-            exe_ctx.GetBestExecutionContextScope();
-        std::optional<uint64_t> size = compiler_type.GetByteSize(exe_scope);
-        if (!size)
-          return false;
         StreamString sstr;
         compiler_type.DumpTypeValue(
             &sstr,                          // The stream to use for display

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -537,7 +537,7 @@ public:
         valobj_sp->GetData(data, extract_error);
         if (!extract_error.Success()) {
           if (valobj_type.GetMinimumLanguage() == lldb::eLanguageTypeSwift) {
-            llvm::Optional<uint64_t> size =
+            std::optional<uint64_t> size =
                 valobj_type.GetByteSize(frame_sp.get());
             if (size && *size == 0) {
               // We don't need to materialize empty structs in Swift.
@@ -676,7 +676,7 @@ public:
 
       if (!extract_error.Success()) {
         if (valobj_type.GetMinimumLanguage() == lldb::eLanguageTypeSwift) {
-          llvm::Optional<uint64_t> size =
+          std::optional<uint64_t> size =
               valobj_type.GetByteSize(frame_sp.get());
           if (size && *size == 0)
             // We don't need to dematerialize empty structs in Swift.

--- a/lldb/source/Symbol/TypeSystem.cpp
+++ b/lldb/source/Symbol/TypeSystem.cpp
@@ -342,7 +342,7 @@ TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
   if (can_create) {
     return GetTypeSystemForLanguage(
         language,
-        llvm::Optional<CreateCallback>([language, target, compiler_options]() {
+        std::optional<CreateCallback>([language, target, compiler_options]() {
           return TypeSystem::CreateInstance(language, target, compiler_options);
         }));
   }


### PR DESCRIPTION
Building LLDB on `next` has not worked in a while because of a transition from llvm::Optional to std::optional. There were a few other issues too, namely a small mismerge and a place that needed a swift guard.