### PR TITLE
[lldb] Fix remark when retrying expr eval not binding params

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -731,7 +731,9 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
       if (m_options.GetBindGenericTypes() != lldb::eBindAuto) 
         return false;
       diagnostic_manager.Clear();
-      diagnostic_manager.PutString(eDiagnosticSeverityRemark, "asdfasdf");
+      diagnostic_manager.PutString(eDiagnosticSeverityRemark,
+                                   "Expression evaluation failed. Retrying "
+                                   "without binding generic parameters");
       // Retry without binding generic parameters, this is the only
       // case that will loop.
       m_options.SetBindGenericTypes(lldb::eDontBind);


### PR DESCRIPTION
(cherry picked from commit 6f1495d98d4cf186ea0eb88b192610b7f14ac3fa)