### PR TITLE
Work around an infinite recursion with deadlock that only exists on

### DIFF
--- a/lldb/include/lldb/Expression/IRExecutionUnit.h
+++ b/lldb/include/lldb/Expression/IRExecutionUnit.h
@@ -391,6 +391,9 @@ private:
   std::vector<ConstString> m_failed_lookups;
 
   std::atomic<bool> m_did_jit;
+  // BEGIN SWIFT
+  std::atomic<bool> m_in_populate_symtab = false;
+  // END SWIFT
 
   lldb::addr_t m_function_load_addr;
   lldb::addr_t m_function_end_load_addr;

--- a/lldb/packages/Python/lldbsuite/test/lldbplaygroundrepl.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplaygroundrepl.py
@@ -77,7 +77,6 @@ class PlaygroundREPLTest(TestBase):
 
         with open(inputFile, 'r') as contents_file:
             contents = contents_file.read()
-        self.expect("log enable lldb types expr -f /tmp/types.log")
         result = self.frame.EvaluateExpression(contents, self.options)
         output = self.frame.EvaluateExpression("get_output()")
         with recording(self, self.TraceOn()) as sbuf:

--- a/lldb/test/API/lang/swift/playgrounds/Import.swift
+++ b/lldb/test/API/lang/swift/playgrounds/Import.swift
@@ -1,0 +1,2 @@
+import Dylib
+f()

--- a/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
+++ b/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
@@ -88,6 +88,7 @@ class TestSwiftPlaygrounds(TestBase):
     @swiftTest
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(debug_info=decorators.no_match("dsym"))
+    @skipIf(macos_version=["<", "12"])
     def test_concurrency(self):
         """Test that concurrency is available in playgrounds"""
         self.launch(True)
@@ -144,15 +145,35 @@ class TestSwiftPlaygrounds(TestBase):
         self.options.SetTryAllThreads(True)
 
 
-    def do_basic_test(self, force_target):
-        contents = ""
-
-        with open('Contents.swift', 'r') as contents_file:
+    def execute_code(self, input_file, expect_error=False):
+        contents = "syntax error"
+        with open(input_file, 'r') as contents_file:
             contents = contents_file.read()
-
-        self.frame().EvaluateExpression(contents, self.options)
+        res = self.frame().EvaluateExpression(contents, self.options)
         ret = self.frame().EvaluateExpression("get_output()")
+        is_error = res.GetError().Fail() and not (
+                     res.GetError().GetType() == 1 and
+                     res.GetError().GetError() == 0x1001)
         playground_output = ret.GetSummary()
+        with recording(self, self.TraceOn()) as sbuf:
+            print("playground result: ", file=sbuf)
+            print(str(res), file=sbuf)
+            if is_error:
+                print("error:", file=sbuf)
+                print(str(res.GetError()), file=sbuf)
+            else:
+                print("playground output:", file=sbuf)
+                print(str(ret), file=sbuf)
+
+        if expect_error:
+            self.assertTrue(is_error)
+            return playground_output
+        self.assertFalse(is_error)
+        self.assertIsNotNone(playground_output)
+        return playground_output
+        
+    def do_basic_test(self, force_target):
+        playground_output = self.execute_code('Contents.swift', not force_target)
         if not force_target:
             # This is expected to fail because the deployment target
             # is less than the availability of the function being
@@ -160,31 +181,20 @@ class TestSwiftPlaygrounds(TestBase):
             self.assertEqual(playground_output, '""')
             return
 
-        self.assertTrue(playground_output is not None)
-        self.assertTrue("a=\\'3\\'" in playground_output)
-        self.assertTrue("b=\\'5\\'" in playground_output)
-        self.assertTrue("=\\'8\\'" in playground_output)
-        self.assertTrue("=\\'11\\'" in playground_output)
+        self.assertIn("a=\\'3\\'", playground_output)
+        self.assertIn("b=\\'5\\'", playground_output)
+        self.assertIn("=\\'8\\'", playground_output)
+        self.assertIn("=\\'11\\'", playground_output)
 
     def do_concurrency_test(self):
-        contents = "error"
-        with open('Concurrency.swift', 'r') as contents_file:
-            contents = contents_file.read()
-        res = self.frame().EvaluateExpression(contents, self.options)
-        ret = self.frame().EvaluateExpression("get_output()")
-        playground_output = ret.GetSummary()
-        self.assertTrue(playground_output is not None)
+        playground_output = self.execute_code('Concurrency.swift')
         self.assertIn("=\\'23\\'", playground_output)
 
     def do_import_test(self):
         # Test importing a library that adds new Clang options.
         log = self.getBuildArtifact('types.log')
         self.expect('log enable lldb types -f ' + log)
-        contents = "import Dylib\nf()\n"
-        res = self.frame().EvaluateExpression(contents, self.options)
-        ret = self.frame().EvaluateExpression("get_output()")
-        playground_output = ret.GetSummary()
-        self.assertTrue(playground_output is not None)
+        playground_output = self.execute_code('Import.swift')
         self.assertIn("Hello from the Dylib", playground_output)
 
         # Scan through the types log to make sure the SwiftASTContext was poisoned.

--- a/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
+++ b/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
@@ -100,8 +100,7 @@ class TestSwiftPlaygrounds(TestBase):
     def test_import(self):
         """Test that a dylib can be imported in playgrounds"""
         self.launch(True)
-        self.do_concurrency_test()
-
+        self.do_import_test()
         
     def launch(self, force_target):
         """Test that playgrounds work"""


### PR DESCRIPTION
the swift branch.

The function IRExecutionUnit::PopulateSymtab() is only implemented in swift-lldb.

One thing it does is resolve any unresolved global symbols in the JIT
module. This global search can cause the JIT module to recursively be
asked for its symtab.

This patch works around the problem by removing the JIT module from
the list of modules being searched while in PopulateSymtab. That isn't
done in the most elegant fashion, as it does so by changing the state
of the IRExecutionUnit object.