### PR TITLE
[stable/20220421][Lex] For dependency directive lexing, angled includes in `__has_include` should be lexed as string literals

### DIFF
--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -4174,6 +4174,22 @@ bool Lexer::LexDependencyDirectiveToken(Token &Result) {
     MIOpt.ReadToken();
   }
 
+  if (ParsingFilename && DDTok.is(tok::less)) {
+    BufferPtr = BufferStart + DDTok.Offset;
+    LexAngledStringLiteral(Result, BufferPtr + 1);
+    if (Result.isNot(tok::header_name))
+      return true;
+    // Advance the index of lexed tokens.
+    while (true) {
+      const dependency_directives_scan::Token &NextTok =
+          DepDirectives.front().Tokens[NextDepDirectiveTokenIndex];
+      if (BufferStart + NextTok.Offset >= BufferPtr)
+        break;
+      ++NextDepDirectiveTokenIndex;
+    }
+    return true;
+  }
+
   const char *TokPtr = convertDependencyDirectiveToken(DDTok, Result);
 
   if (Result.is(tok::hash) && Result.isAtStartOfLine()) {

--- a/clang/test/ClangScanDeps/depscan-lex-has-include.c
+++ b/clang/test/ClangScanDeps/depscan-lex-has-include.c
@@ -1,0 +1,46 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json | FileCheck %s
+// CHECK: t.c
+// CHECK: something.h
+
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb-error.json.template > %t/cdb-error.json
+// RUN: not clang-scan-deps -compilation-database %t/cdb-error.json 2>&1 | FileCheck %s -check-prefix=ERROR
+// ERROR: error: expected '>'
+// ERROR: error: expected value in expression
+
+//--- cdb.json.template
+[
+  {
+    "directory": "DIR",
+    "command": "clang -fsyntax-only DIR/t.c -I DIR",
+    "file": "DIR/t.c"
+  }
+]
+
+//--- cdb-error.json.template
+[
+  {
+    "directory": "DIR",
+    "command": "clang -fsyntax-only DIR/error.c",
+    "file": "DIR/error.c"
+  }
+]
+
+//--- t.c
+
+#define something
+
+// Make sure the include is lexed as a literal, ignoring the macro.
+#if __has_include(<something/something.h>)
+#include <something/something.h>
+#endif
+
+//--- something/something.h
+
+//--- error.c
+#if __has_include(<something/something.h)
+#define MAC
+#endif


### PR DESCRIPTION
rdar://104386604

Differential Revision: https://reviews.llvm.org/D142143

(cherry picked from commit ed6d09dd4ead70d2858d56c530af38eefa1ef595)