### PR TITLE
[lldb] Re-enable xmm/ymm/zmm tests with the system debugserver

### DIFF
--- a/lldb/test/Shell/Register/x86-64-ymm-write.test
+++ b/lldb/test/Shell/Register/x86-64-ymm-write.test
@@ -1,9 +1,3 @@
-# xfail with system debugserver until the fix for
-# https://reviews.llvm.org/D123269 in
-# lldb/tools/debugserver/source/MacOSX/x86_64/DNBArchImplX86_64.cpp
-# has made it into released tools.
-# XFAIL: system-debugserver
-
 # XFAIL: system-windows
 # REQUIRES: native && target-x86_64 && native-cpu-avx
 # RUN: %clangxx_host %p/Inputs/x86-ymm-write.cpp -o %t

--- a/lldb/test/Shell/Register/x86-64-zmm-write.test
+++ b/lldb/test/Shell/Register/x86-64-zmm-write.test
@@ -1,9 +1,3 @@
-# xfail with system debugserver until the fix for
-# https://reviews.llvm.org/D123269 in
-# lldb/tools/debugserver/source/MacOSX/x86_64/DNBArchImplX86_64.cpp
-# has made it into released tools.
-# XFAIL: system-debugserver
-
 # XFAIL: system-freebsd
 # XFAIL: system-linux
 # XFAIL: system-netbsd


### PR DESCRIPTION
Re-enable the xmm/ymm/zmm tests now that the system debugserver used by
our CI is capable or writing xmm/ymm/zmm registers.

(cherry picked from commit 60834105d85cba27e1e1b2b4ecf4cd658019d867)
