### PR TITLE
[lldb] Disable deserialization safety for lldb

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -944,6 +944,10 @@ SwiftASTContext::SwiftASTContext(std::string description,
   // for the protocol conforming types.
   lang_opts.AllowModuleWithCompilerErrors = true;
   lang_opts.EnableTargetOSChecking = false;
+
+  // Bypass deserialization safety to allow deserializing internal details from
+  // swiftmodule files.
+  lang_opts.EnableDeserializationSafety = false;
 }
 
 SwiftASTContext::~SwiftASTContext() {


### PR DESCRIPTION
Deserialization safety prevents reading internal implementation details from swiftmodules files. Let's disable it for LLDB as these details are useful for debugging and LLDB enables more deserialization recovery. The recovery should help handle the same issues avoided by the safety. We can also expand the recovery more liberally if it crashes under paths avoided under safety.