### PR TITLE
[lldb] Allow Archetypes to be referred to in expression evaluation

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -221,9 +221,12 @@ public:
 
   bool FixCaptures();
 
-  swift::ValueDecl *MakeGlobalTypealias(swift::Identifier name,
-                                        CompilerType &type,
-                                        bool make_private = true);
+  /// Makes a typealias binding name to type in the scope of the decl_ctx. If
+  /// decl_ctx is a nullptr this is a global typealias.
+  swift::TypeAliasDecl *MakeTypealias(swift::Identifier name,
+                                      CompilerType &type,
+                                      bool make_private = true,
+                                      swift::DeclContext *decl_ctx = nullptr);
 
   bool FixupResultAfterTypeChecking(Status &error);
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4586,6 +4586,13 @@ SwiftASTContext::GetNonTriviallyManagedReferenceKind(
   return {};
 }
 
+CompilerType
+SwiftASTContext::CreateGenericTypeParamType(unsigned int depth,
+                                                 unsigned int index) {
+  return ToCompilerType(
+      swift::GenericTypeParamType::get(false, depth, index, *GetASTContext()));
+}
+
 CompilerType SwiftASTContext::GetErrorType() {
   VALID_OR_RETURN(CompilerType());
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -412,6 +412,10 @@ public:
   GetNonTriviallyManagedReferenceKind(
       lldb::opaque_compiler_type_t type) override;
 
+  /// Creates a GenericTypeParamType with the desired depth and index.
+  CompilerType CreateGenericTypeParamType(unsigned int depth,
+                                               unsigned int index) override;
+
   CompilerType GetErrorType() override;
 
   bool HasErrors();

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -148,6 +148,10 @@ public:
   virtual llvm::Optional<NonTriviallyManagedReferenceKind>
   GetNonTriviallyManagedReferenceKind(lldb::opaque_compiler_type_t type) = 0;
 
+  /// Creates a GenericTypeParamType with the desired depth and index.
+  virtual CompilerType CreateGenericTypeParamType(unsigned int depth,
+                                                       unsigned int index) = 0;
+                                                       
   using TypeSystem::DumpTypeDescription;
   virtual void DumpTypeDescription(
       lldb::opaque_compiler_type_t type, bool print_help_if_available,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1905,6 +1905,25 @@ swift::Demangle::NodePointer TypeSystemSwiftTypeRef::DemangleCanonicalType(
   return GetDemangledType(dem, type.GetMangledTypeName().GetStringRef());
 }
 
+CompilerType
+TypeSystemSwiftTypeRef::CreateGenericTypeParamType(unsigned int depth,
+                                                   unsigned int index) {
+  Demangler dem;
+  NodePointer type_node = dem.createNode(Node::Kind::Type);
+
+  NodePointer dep_type_node =
+      dem.createNode(Node::Kind::DependentGenericParamType);
+  type_node->addChild(dep_type_node, dem);
+
+  NodePointer depth_node = dem.createNode(Node::Kind::Index, depth);
+  NodePointer index_node = dem.createNode(Node::Kind::Index, index);
+
+  dep_type_node->addChild(depth_node, dem);
+  dep_type_node->addChild(index_node, dem);
+  auto type = RemangleAsType(dem, type_node);
+  return type;
+}
+
 bool TypeSystemSwiftTypeRef::IsArrayType(opaque_compiler_type_t type,
                                          CompilerType *element_type,
                                          uint64_t *size, bool *is_incomplete) {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -280,6 +280,10 @@ public:
   llvm::Optional<TupleElement>
   GetTupleElement(lldb::opaque_compiler_type_t type, size_t idx);
 
+  /// Creates a GenericTypeParamType with the desired depth and index.
+  CompilerType CreateGenericTypeParamType(unsigned int depth,
+                                    unsigned int index) override;
+
   /// Get the Swift raw pointer type.
   CompilerType GetRawPointerType();
   /// Determine whether \p type is a protocol.

--- a/lldb/test/API/lang/swift/archetype_in_cond_breakpoint/Makefile
+++ b/lldb/test/API/lang/swift/archetype_in_cond_breakpoint/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/archetype_in_cond_breakpoint/TestArchetypeInConditionalBreakpoint.py
+++ b/lldb/test/API/lang/swift/archetype_in_cond_breakpoint/TestArchetypeInConditionalBreakpoint.py
@@ -1,0 +1,44 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestArchetypeInConditionalBreakpoint(TestBase):
+
+    @swiftTest
+    def test_stops(self):
+        """Tests that using archetypes in a conditional breakpoint's expression works correctly"""
+        self.build()
+        target = lldbutil.run_to_breakpoint_make_target(self)
+
+        breakpoint = target.BreakpointCreateBySourceRegex(
+                "break here", lldb.SBFileSpec("main.swift"))
+
+        breakpoint.SetCondition("T.self == Int.self")
+        _, process, _, _ = lldbutil.run_to_breakpoint_do_run(self, target, breakpoint)
+    
+        self.assertEqual(process.state, lldb.eStateStopped)
+
+
+    @swiftTest
+    def test_doesnt_stop(self):
+        """Tests that using archetypes in a conditional breakpoint's expression works correctly"""
+        self.build()
+        target = lldbutil.run_to_breakpoint_make_target(self)
+
+        breakpoint = target.BreakpointCreateBySourceRegex(
+                "break here", lldb.SBFileSpec("main.swift"))
+
+        breakpoint.SetCondition("T.self == Double.self")
+
+        launch_info = target.GetLaunchInfo()
+        launch_info.SetWorkingDirectory(self.get_process_working_directory())
+
+        error = lldb.SBError()
+        process = target.Launch(launch_info, error)
+
+        # Make sure that we didn't stop since the condition doesn't match
+        self.assertEqual(process.state, lldb.eStateExited)
+

--- a/lldb/test/API/lang/swift/archetype_in_cond_breakpoint/main.swift
+++ b/lldb/test/API/lang/swift/archetype_in_cond_breakpoint/main.swift
@@ -1,0 +1,4 @@
+func f<T>(t: T) {
+  print(1) // break here
+}
+f(t: 5)

--- a/lldb/test/API/lang/swift/archetype_in_expression/Makefile
+++ b/lldb/test/API/lang/swift/archetype_in_expression/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/archetype_in_expression/TestArchetypeInExpression.py
+++ b/lldb/test/API/lang/swift/archetype_in_expression/TestArchetypeInExpression.py
@@ -1,0 +1,49 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestArchetypeInExpression(TestBase):
+
+    @swiftTest
+    def test(self):
+        """Tests that a user can refer to the archetypes in their expressions"""         
+        self.build()
+
+        # Check that you can refer to all types and function's archetypes.
+        _, process, _, breakpoint = lldbutil.run_to_source_breakpoint(self, 
+                "break here", lldb.SBFileSpec("main.swift"))
+        self.expect("e First.self", substrs=["Int.Type"])
+        self.expect("e Second.self", substrs=["Double.Type"])
+        self.expect("e Third.self", substrs=["Bool.Type"])
+        self.expect("e T.self", substrs=["String.Type"])
+        self.expect("e U.self", substrs=["[Int].Type"])
+        # Assert that frame variable doesn't work
+        self.expect("v First.self", 
+                substrs=["no variable named 'First' found in this frame"], 
+                error=True)
+        self.expect("v T.self", 
+                substrs=["no variable named 'T' found in this frame"], 
+                error=True)
+
+        # Check that referring to a shadowed archetype works correctly.
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("e T.self", substrs=["String.Type"])
+        # Assert that frame variable doesn't work
+        self.expect("v T.self", 
+                substrs=["no variable named 'T' found in this frame"], 
+                error=True)
+
+        # Check that you refer to archetypes in nested generic functions.
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("e T.self", substrs=["Bool.Type"])
+        self.expect("e U.self", substrs=["Double.Type"])
+
+        # Check that you refer to archetypes in nested generic functions with shadowed archetypes.
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("e T.self", substrs=["String.Type"])
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("e T.self", substrs=["Int.Type"])
+        

--- a/lldb/test/API/lang/swift/archetype_in_expression/main.swift
+++ b/lldb/test/API/lang/swift/archetype_in_expression/main.swift
@@ -1,0 +1,38 @@
+struct A<First, Second> {
+  class B<Third> {
+    func f<T, U>(t: T, u: U) {
+      print(1) // break here
+    }
+  }
+}
+
+class D<T> {
+  func f<T>(t: T) {
+    print(1) // break here
+  }
+}
+
+func a<T>(t: T) {
+  func b<U>(u: U) {
+    print(1) // break here
+  }
+  b(u: 4.2)
+}
+
+func c<T>(t: T) {
+  func d<T>(t: T) {
+    print(1) // break here
+  }
+  d(t: 42) // break here
+}
+
+let b = A<Int, Double>.B<Bool>();
+b.f(t: "Hello", u: [1, 2, 3])
+
+let d = D<Int>()
+d.f(t: "Hello")
+
+a(t: true)
+
+c(t: "Hello")
+


### PR DESCRIPTION
This patch allows users to refer to the archetypes in their expressions. For example, in a function such as:

```
func f<T>(t: T) {
  print(t) // break here
}
```

Users can now use "T" in their expressions.

rdar://101976441
(cherry picked from commit bf704e0639b0eb0868a8f0e79ff781a476ef9b2a)