### PR TITLE
[stable/20220421][clang-cache] Make the include-tree the default and use `CLANG_CACHE_USE_CASFS_DEPSCAN` for switching to casfs depscanning

### DIFF
--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -22,9 +22,12 @@
 // CLANGPP: "-greproducible"
 // CLANGPP: "-x" "c++"
 
-// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_ENABLE_INCLUDE_TREE=1 %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=INCLUDE-TREE -DPREFIX=%t
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=INCLUDE-TREE -DPREFIX=%t
 // INCLUDE-TREE: "-cc1depscan" "-fdepscan=auto"
 // INCLUDE-TREE: "-fdepscan-include-tree"
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_USE_CASFS_DEPSCAN=1 %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CASFS-SCAN -DPREFIX=%t
+// CASFS-SCAN-NOT: "-fdepscan-include-tree"
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=SESSION -DPREFIX=%t
 // SESSION: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-share-identifier"

--- a/clang/test/CAS/fcache-compile-job-serialized-diagnostics.c
+++ b/clang/test/CAS/fcache-compile-job-serialized-diagnostics.c
@@ -38,10 +38,10 @@
 // Using normal compilation as baseline.
 // RUN: %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -arch=nonexistent --serialize-diagnostics %t/t1.diag \
 // RUN:   2>&1 | FileCheck %s -check-prefix=WARN
-// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_USE_CASFS_DEPSCAN=1 %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -arch=nonexistent --serialize-diagnostics %t/t2.diag \
 // RUN:   2>&1 | FileCheck %s -check-prefix=WARN
-// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_ENABLE_INCLUDE_TREE=1 %clang-cache \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -arch=nonexistent --serialize-diagnostics %t/t2.inc.diag \
 // RUN:   2>&1 | FileCheck %s -check-prefix=WARN
 // RUN: diff %t/t1.diag %t/t2.diag
@@ -49,9 +49,9 @@
 
 // Try again with cache hit.
 // RUN: rm %t/t2.diag
-// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_USE_CASFS_DEPSCAN=1 %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -arch=nonexistent --serialize-diagnostics %t/t2.diag
-// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_ENABLE_INCLUDE_TREE=1 %clang-cache \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -arch=nonexistent --serialize-diagnostics %t/t2.inc.diag \
 // RUN:   2>&1 | FileCheck %s -check-prefix=WARN
 // RUN: diff %t/t1.diag %t/t2.diag

--- a/clang/test/CAS/include-tree-with-sanitizer.c
+++ b/clang/test/CAS/include-tree-with-sanitizer.c
@@ -2,7 +2,7 @@
 // RUN: touch %t/asan_ignorelist.txt
 // RUN: touch %t/sys_asan_ignorelist.txt
 
-// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_ENABLE_INCLUDE_TREE=1 %clang-cache \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
 // RUN:   %clang -fsanitize=address -Xclang -fsanitize-ignorelist=%t/asan_ignorelist.txt -Xclang -fsanitize-system-ignorelist=%t/sys_asan_ignorelist.txt \
 // RUN:   -target x86_64-apple-macos11 -c %s -o %t/output.o -Rcompile-job-cache 2> %t/output-tree.txt
 

--- a/clang/test/CAS/path-independent-cas-outputs.c
+++ b/clang/test/CAS/path-independent-cas-outputs.c
@@ -58,15 +58,12 @@
 // RUN: diff %t/a/t1.d %t/b/t2.d
 // RUN: diff %t/t.d %t/a/t1.d
 
-// Baseline to check we got expected output.
-// RUN: %clang -target x86_64-apple-macos11 -x c-header %s -o %t/t.pch -Xclang -fno-pch-timestamp
 // RUN: env LLVM_CACHE_CAS_PATH=%t/a/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -x c-header %s -o %t/a/t1.pch
 // RUN: env LLVM_CACHE_CAS_PATH=%t/b/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -x c-header %s -o %t/b/t2.pch
 
 // RUN: diff %t/a/t1.pch %t/b/t2.pch
-// RUN: diff %t/t.pch %t/a/t1.pch
 
 // Check that caching is independent of whether '--serialize-diagnostics' exists or not.
 

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -86,11 +86,11 @@ static int executeAsProcess(ArrayRef<const char *> Args,
 /// functionalities.
 static void addCommonArgs(bool ForDriver, SmallVectorImpl<const char *> &Args,
                           llvm::StringSaver &Saver) {
-  if (::getenv("CLANG_CACHE_ENABLE_INCLUDE_TREE")) {
+  if (!llvm::sys::Process::GetEnv("CLANG_CACHE_USE_CASFS_DEPSCAN")) {
     Args.push_back("-fdepscan-include-tree");
   }
-  if (const char *CASPath = ::getenv("LLVM_CACHE_CAS_PATH")) {
-    llvm::SmallString<256> CASArg(CASPath);
+  if (auto CASPath = llvm::sys::Process::GetEnv("LLVM_CACHE_CAS_PATH")) {
+    llvm::SmallString<256> CASArg(*CASPath);
     llvm::sys::path::append(CASArg, "cas");
     if (ForDriver) {
       Args.append({"-Xclang", "-fcas-path", "-Xclang",
@@ -98,7 +98,7 @@ static void addCommonArgs(bool ForDriver, SmallVectorImpl<const char *> &Args,
     } else {
       Args.append({"-fcas-path", Saver.save(CASArg.str()).data()});
     }
-    llvm::SmallString<256> CacheArg(CASPath);
+    llvm::SmallString<256> CacheArg(*CASPath);
     llvm::sys::path::append(CacheArg, "actioncache");
     if (ForDriver) {
       Args.append({"-Xclang", "-faction-cache-path", "-Xclang",


### PR DESCRIPTION
(cherry picked from commit 91b9116f74eac7a61019c986b41dabccf3abf2bb)