### PR TITLE
[Clang] [Sema] Removed a fix-it for system headers

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -270,6 +270,7 @@ Bug Fixes
 
 Improvements to Clang's diagnostics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- Disabled FIT-IT suggested for a case of bad conversion in system headers.
 - Clang will now check compile-time determinable string literals as format strings.
   Fixes `Issue 55805: <https://github.com/llvm/llvm-project/issues/55805>`_.
 - ``-Wformat`` now recognizes ``%b`` for the ``printf``/``scanf`` family of

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -10914,10 +10914,13 @@ static void DiagnoseBadConversion(Sema &S, OverloadCandidate *Cand,
         << ToTy << (unsigned)isObjectArgument << I + 1
         << (unsigned)(Cand->Fix.Kind);
 
-  // If we can fix the conversion, suggest the FixIts.
-  for (std::vector<FixItHint>::iterator HI = Cand->Fix.Hints.begin(),
-       HE = Cand->Fix.Hints.end(); HI != HE; ++HI)
-    FDiag << *HI;
+  // Check that location of Fn is not in system header.
+  if (!S.SourceMgr.isInSystemHeader(Fn->getLocation())) {
+    // If we can fix the conversion, suggest the FixIts.
+    for (const FixItHint &HI : Cand->Fix.Hints)
+        FDiag << HI;
+  }
+
   S.Diag(Fn->getLocation(), FDiag);
 
   MaybeEmitInheritedConstructorNote(S, Cand->FoundDecl);

--- a/clang/test/Index/fixit-sys-header.h
+++ b/clang/test/Index/fixit-sys-header.h
@@ -1,0 +1,6 @@
+#pragma clang system_header
+
+int func_in_sys_header(char * s, unsigned long len)
+{
+    return 0;
+}

--- a/clang/test/Index/fixit-sysheader-test.cpp
+++ b/clang/test/Index/fixit-sysheader-test.cpp
@@ -1,0 +1,21 @@
+// RUN: c-index-test -test-load-source all %s 2>&1 | FileCheck %s
+
+#include "fixit-sys-header.h"
+#include "fixit-user-header.h"
+
+int main(int argc, char const *argv[])
+{
+    char* str;{};
+    
+    func_in_sys_header(str, str + 10);
+    // CHECK: Number FIX-ITs = 0
+    // CHECK-NEXT: candidate function not viable: no known conversion from 'char *' to 'unsigned long' for 2nd argument; dereference the argument with *
+    // CHECK-NEXT: Number FIX-ITs = 0
+    
+    func_in_user_header(str, str + 10);
+    // CHECK: Number FIX-ITs = 0
+    // CHECK-NEXT: candidate function not viable: no known conversion from 'char *' to 'unsigned long' for 2nd argument; dereference the argument with *
+    // CHECK-NEXT: Number FIX-ITs = 2
+
+    return 0;
+}

--- a/clang/test/Index/fixit-user-header.h
+++ b/clang/test/Index/fixit-user-header.h
@@ -1,0 +1,4 @@
+int func_in_user_header(char * s, unsigned long len)
+{
+    return 0;
+}


### PR DESCRIPTION
Disabled an invalid fix-it which suggested fixes to be applied in system headers for some programs in IDEs like Xcode.

rdar://100890960

Differential Revision: https://reviews.llvm.org/D141868