### PR TITLE
[lldb] Fix call to default swift metadata cache path

### DIFF
--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -113,7 +113,8 @@ ModuleListProperties::ModuleListProperties() {
   if (llvm::sys::path::cache_directory(path)) {
     llvm::sys::path::append(path, "lldb");
     llvm::sys::path::append(path, "SwiftMetadataCache");
-    lldbassert(SetLLDBIndexCachePath(FileSpec(path)));
+    bool success = SetSwiftMetadataCachePath(FileSpec(path));
+    lldbassert(success);
   }
   // END SWIFT
   


### PR DESCRIPTION
(cherry picked from commit b4933598b672904ae8c58b6c393ac1e6f951c406)