### PR TITLE
[stable/20221013][clang/cache] For include-tree disable `-gmodules` to avoid debug info referencing a non-existent PCH filename

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -54,6 +54,12 @@ void tooling::dependencies::configureInvocationForCaching(
       PPOpts.MacroIncludes.clear();
       PPOpts.Includes.clear();
     }
+    // Disable `-gmodules` to avoid debug info referencing a non-existent PCH
+    // filename.
+    // NOTE: We'd have to preserve \p HeaderSearchOptions::ModuleFormat (code
+    // above resets \p HeaderSearchOptions) when properly supporting
+    // `-gmodules`.
+    CI.getCodeGenOpts().DebugTypeExtRefs = false;
   } else {
     FileSystemOpts.CASFileSystemRootID = std::move(RootID);
     FileSystemOpts.CASFileSystemWorkingDirectory = std::move(WorkingDir);

--- a/clang/test/CAS/depscan-include-tree.c
+++ b/clang/test/CAS/depscan-include-tree.c
@@ -2,7 +2,8 @@
 // RUN: split-file %s %t
 
 // RUN: %clang -cc1depscan -o %t/inline.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args -cc1 -triple x86_64-apple-macos11.0 \
-// RUN:     -fsyntax-only %t/t.c -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -DSOME_MACRO -dependency-file %t/inline.d -MT deps
+// RUN:     -emit-obj %t/t.c -o %t/t.o -dwarf-ext-refs -fmodule-format=obj \
+// RUN:     -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -DSOME_MACRO -dependency-file %t/inline.d -MT deps
 
 // RUN: FileCheck %s -input-file %t/inline.rsp -DPREFIX=%t
 // RUN: FileCheck %s -input-file %t/inline.rsp -DPREFIX=%t -check-prefix=SHOULD
@@ -17,6 +18,8 @@
 // SHOULD-NOT: "-I"
 // SHOULD-NOT: "[[PREFIX]]/t.c"
 // SHOULD-NOT: "-D"
+// SHOULD-NOT: "-dwarf-ext-refs"
+// SHOULD-NOT: "-fmodule-format=obj"
 
 // RUN: FileCheck %s -input-file %t/inline.d -check-prefix=DEPS -DPREFIX=%t
 


### PR DESCRIPTION
rdar://104493507
(cherry picked from commit 714b927a2b4b614c3ab28366ec430d9fc2523bb1)