### PR TITLE
[clang][deps][cas] Fix fatal error: CAS filesystem cannot set working next

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -285,6 +285,10 @@ private:
     // modules share their VFS.
     for (const auto &File : CI.getHeaderSearchOpts().VFSOverlayFiles)
       (void)FS->status(File);
+    // If the working directory is not otherwise accessed by the module build,
+    // we still need it due to -fcas-fs-working-directory being set.
+    if (auto CWD = FS->getCurrentWorkingDirectory())
+      (void)FS->status(*CWD);
     // Exclude the module cache from tracking. The implicit build pcms should
     // not be needed after scanning.
     if (!CI.getHeaderSearchOpts().ModuleCachePath.empty())

--- a/clang/test/ClangScanDeps/modules-cas-trees-cwd.c
+++ b/clang/test/ClangScanDeps/modules-cas-trees-cwd.c
@@ -1,0 +1,61 @@
+// Ensure the working directory is correctly captured in cas-fs when compiling
+// with caching from outside the source directory.
+// FIXME: ideally we could further canonicalize the working directory when it
+// is irrelevant to the compilation, but for now ensure we can compile at all.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+// RUN: mkdir -p %t/B
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -format experimental-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// RUN: %deps-to-rsp %t/deps.json --module-name Mod > %t/Mod.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+
+// RUN: %clang @%t/Mod.rsp
+// RUN: %clang @%t/tu.rsp
+
+// Check specifics of the command-line
+// RUN: cat %t/deps.json | FileCheck %s -DPREFIX=%/t
+
+// CHECK:      {
+// CHECK-NEXT:   "modules": [
+// CHECK-NEXT:     {
+// CHECK:            "command-line": [
+// CHECK:              "-fcas-fs-working-directory"
+// CHECK-NEXT:         "[[PREFIX]]/B"
+// CHECK:            ]
+// CHECK:            "name": "Mod"
+// CHECK:          }
+// CHECK-NEXT:   ]
+// CHECK:        "translation-units": [
+// CHECK:          {
+// CHECK:            "commands": [
+// CHECK:              {
+// CHECK:                "command-line": [
+// CHECK:                  "-fcas-fs-working-directory"
+// CHECK-NEXT:             "[[PREFIX]]/B"
+// CHECK:                ]
+
+//--- cdb.json.template
+[{
+  "directory" : "DIR/B",
+  "command" : "clang_tool -fsyntax-only DIR/A/tu.c -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/A/module-cache -Rcompile-job-cache",
+  "file" : "DIR/A/tu.c"
+}]
+
+//--- A/module.modulemap
+module Mod { header "Mod.h" }
+
+//--- A/Mod.h
+#pragma once
+void Top(void);
+
+//--- A/tu.c
+#include "Mod.h"


### PR DESCRIPTION
Originally we were not setting -fcas-fs-working-directory for module compiles (only the TU), but after 456537b9 we shared the implementation with the TU so it was set, causing a regression: if the working directory was not otherwise accessed by the module compilation it would be configured but not available in the cas-fs, causing an error.

(cherry picked from commit c94c861a1961a3cc5a0625a05ef9f2cf7ce866a5)