### PR TITLE
[clang][cas] Make DepscanPrefixMapping own its strings

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
@@ -41,9 +41,9 @@ void configureInvocationForCaching(CompilerInvocation &CI, CASOptions CASOpts,
                                    bool ProduceIncludeTree);
 
 struct DepscanPrefixMapping {
-  Optional<StringRef> NewSDKPath;
-  Optional<StringRef> NewToolchainPath;
-  SmallVector<StringRef> PrefixMap;
+  Optional<std::string> NewSDKPath;
+  Optional<std::string> NewToolchainPath;
+  SmallVector<std::string> PrefixMap;
 
   /// Add path mappings from the current path in \p Invocation to the new path
   /// from \c DepscanPrefixMapping to the \p Mapper.

--- a/clang/tools/driver/cc1depscanProtocol.cpp
+++ b/clang/tools/driver/cc1depscanProtocol.cpp
@@ -343,7 +343,7 @@ CC1DepScanDProtocol::getDepscanPrefixMapping(llvm::StringSaver &Saver,
         Mapping.NewToolchainPath = Map;
       break;
     default:
-      Mapping.PrefixMap.push_back(Map);
+      Mapping.PrefixMap.push_back(std::string(Map));
       break;
     }
   }

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -452,7 +452,7 @@ parseCASFSAutoPrefixMappings(DiagnosticsEngine &Diag, const ArgList &Args) {
       Diag.Report(diag::err_drv_invalid_argument_to_option)
           << Map << A->getOption().getName();
     else
-      Mapping.PrefixMap.push_back(Map);
+      Mapping.PrefixMap.push_back(std::string(Map));
     A->claim();
   }
   if (const Arg *A = Args.getLastArg(options::OPT_fdepscan_prefix_map_sdk_EQ))


### PR DESCRIPTION
Using StringRef is a footgun for this API and inhibits code that wants to store the DepscanPrefixMapping without immediately running the scan. In practice, this type stores a very small number of strings and is rarely copied, so just use std::string.

(cherry picked from commit 6c7eacba217a69449ef68315d99685fc601bacca)