### PR TITLE
[clang][deps] Add module files for input dependencies earlier

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -60,11 +60,6 @@ static std::vector<std::string> splitString(std::string S, char Separator) {
 
 void ModuleDepCollector::addOutputPaths(CompilerInvocation &CI,
                                         ModuleDeps &Deps) {
-  // These are technically *inputs* to the compilation, but we populate them
-  // here in order to make \c getModuleContextHash() independent of
-  // \c lookupModuleOutput().
-  addModuleFiles(CI, Deps.ClangModuleDeps);
-
   CI.getFrontendOpts().OutputFile =
       Consumer.lookupModuleOutput(Deps.ID, ModuleOutputKind::ModuleFile);
   if (!CI.getDiagnosticOpts().DiagnosticSerializationFile.empty())
@@ -166,6 +161,9 @@ ModuleDepCollector::makeInvocationForModuleBuildWithoutOutputs(
       CI.getFrontendOpts().ModuleCacheKeys.emplace_back(
           PrebuiltModule.PCMFile, *PrebuiltModule.ModuleCacheKey);
   }
+
+  // Add module file inputs from dependencies.
+  addModuleFiles(CI, Deps.ClangModuleDeps);
 
   // Remove any macro definitions that are explicitly ignored.
   if (!CI.getHeaderSearchOpts().ModulesIgnoreMacros.empty()) {


### PR DESCRIPTION
I originally thought we needed to add module file inputs for modular deps at the same time as outputs because they depend on the lookupModuleOutput callback, but this is not the case: they only depend on the callback results for other modules, which have already been computed by this point. So move them earlier so that they're set in the CompilerInvocation at the same time as other inputs. This makes the code easier to understand.

This change is effectively NFC, though it technically changes the module exact value of the context hash.

Differential Revision: https://reviews.llvm.org/D142392

(cherry picked from commit 43854fa263d2c96aa9e6c2bc5eafd66ac9727641)