### PR TITLE
[20221013][CMake] Only enable LLVM_ENABLE_ONDISK_CAS_default for 64-bit or larger architectures

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -719,7 +719,7 @@ option (LLVM_ENABLE_SPHINX "Use Sphinx to generate llvm documentation." OFF)
 option (LLVM_ENABLE_OCAMLDOC "Build OCaml bindings documentation." ON)
 option (LLVM_ENABLE_BINDINGS "Build bindings." ON)
 
-if(UNIX)
+if(UNIX AND CMAKE_SIZEOF_VOID_P GREATER_EQUAL 8)
   set(LLVM_ENABLE_ONDISK_CAS_default ON)
 else()
   set(LLVM_ENABLE_ONDISK_CAS_default OFF)


### PR DESCRIPTION
@cachemeifyoucan, submitting here too as you asked.