### PR TITLE
[CompilerRT] Remove sanitizers support for i386 iossim

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -142,6 +142,11 @@ function(darwin_test_archs os valid_archs)
     list(REMOVE_ITEM archs "x86_64h")
   endif()
 
+  if(${os} MATCHES "iossim")
+    message(STATUS "Disabling i386 slice for iossim")
+    list(REMOVE_ITEM archs "i386")
+  endif()
+
   set(working_archs)
   foreach(arch ${archs})
    


### PR DESCRIPTION
Cherrypicks [revision](https://reviews.llvm.org/rG4729f6e03a12b0f3613416dc6f65407afa7e8f19)
