### PR TITLE
[lldb][test] Skip TestRerunAndExprDylib on Ubuntu 18.04

### DIFF
--- a/lldb/test/API/functionalities/rerun_and_expr_dylib/TestRerunAndExprDylib.py
+++ b/lldb/test/API/functionalities/rerun_and_expr_dylib/TestRerunAndExprDylib.py
@@ -9,7 +9,24 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 from lldbsuite.test.decorators import *
 
+
+def isUbuntu18_04():
+    """
+    Check if the host OS is Ubuntu 18.04.
+    Derived from `platform.freedesktop_os_release` in Python 3.10.
+    """
+    for path in ("/etc/os-release", "/usr/lib/os-release"):
+        if os.path.exists(path):
+            with open(path) as f:
+                contents = f.read()
+            if "Ubuntu 18.04" in contents:
+                return True
+
+    return False
+
+
 class TestRerunExprDylib(TestBase):
+    @skipTestIfFn(isUbuntu18_04, bugnumber="rdar://103831050")
     @skipIfWindows
     def test(self):
         """


### PR DESCRIPTION
Disable this test on Ubuntu 18.04, where it fails for yet to be determined reasons.

Differential Revision: https://reviews.llvm.org/D142141

(cherry-picked from commit cd4180dbf90b04014b65ff69c33002806680ced9)