### PR TITLE
[lldb] Fix inverted if-condition in CMake

### DIFF
--- a/lldb/bindings/python/CMakeLists.txt
+++ b/lldb/bindings/python/CMakeLists.txt
@@ -200,7 +200,7 @@ function(finish_swig_python swig_target lldb_python_bindings_dir lldb_python_tar
 
 endfunction()
 
-if(${LLDB_USE_STATIC_BINDINGS})
+if(NOT ${LLDB_USE_STATIC_BINDINGS})
   set(SOURCE_STATIC_BINDING ${CMAKE_CURRENT_SOURCE_DIR}/static-binding/lldb.py)
   set(BINARY_STATIC_BINDING ${CMAKE_CURRENT_BINARY_DIR}/lldb.py)
   set(COPY_STATIC_BINDING ${LLDB_SOURCE_DIR}/scripts/copy-static-bindings.py)


### PR DESCRIPTION
The logic that checks whether the static bindings are out of sync should run when you're not using the static bindings (otherwise they will be identical by design). Fix the inverted if condition in lldb/bindings/python/CMakeLists.txt.

(cherry picked from commit 06c706363103dc5b842de4c718cd8252c5af2546)