### PR TITLE
Change SwiftLanguageRuntime::GetNumChildren() to take an exe_scope

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -289,7 +289,7 @@ public:
   }
 
   llvm::Optional<unsigned> GetNumChildren(CompilerType type,
-                                          ValueObject *valobj) {
+                                          ExecutionContextScope *exe_scopej) {
     STUB_LOG();
     return {};
   }
@@ -2309,8 +2309,9 @@ llvm::Optional<uint64_t> SwiftLanguageRuntime::GetMemberVariableOffset(
 }
 
 llvm::Optional<unsigned>
-SwiftLanguageRuntime::GetNumChildren(CompilerType type, ValueObject *valobj) {
-  FORWARD(GetNumChildren, type, valobj);
+SwiftLanguageRuntime::GetNumChildren(CompilerType type,
+                                     ExecutionContextScope *exe_scope) {
+  FORWARD(GetNumChildren, type, exe_scope);
 }
 
 llvm::Optional<std::string> SwiftLanguageRuntime::GetEnumCaseName(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -277,7 +277,7 @@ public:
 
   /// Ask Remote Mirrors about the children of a composite type.
   llvm::Optional<unsigned> GetNumChildren(CompilerType type,
-                                          ValueObject *valobj);
+                                          ExecutionContextScope *exe_scope);
 
   /// Determine the enum case name for the \p data value of the enum \p type.
   /// This is performed using Swift reflection.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -123,7 +123,7 @@ public:
                                                    Status *error);
 
   llvm::Optional<unsigned> GetNumChildren(CompilerType type,
-                                          ValueObject *valobj);
+                                          ExecutionContextScope *exe_scope);
 
   llvm::Optional<unsigned> GetNumFields(CompilerType type,
                                         ExecutionContext *exe_ctx);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2680,7 +2680,7 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
       if (auto *exe_scope = exe_ctx->GetBestExecutionContextScope())
         if (auto *runtime =
                 SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
-          return runtime->GetNumChildren(GetCanonicalType(type), nullptr);
+          return runtime->GetNumChildren(GetCanonicalType(type), exe_scope);
 
     if (CompilerType clang_type = GetAsClangTypeOrNull(type)) {
       bool is_signed;
@@ -2844,7 +2844,7 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
             return GetTypeFromMangledTypename(ConstString("$sSo8NSStringCD"));
           if (result.GetMangledTypeName().GetStringRef().count('$') > 1 &&
               get_ast_num_children() ==
-                  runtime->GetNumChildren({weak_from_this(), type}, valobj))
+                  runtime->GetNumChildren({weak_from_this(), type}, exe_scope))
             // If available, prefer the AST for private types. Private
             // identifiers are not ABI; the runtime returns anonymous private
             // identifiers (using a '$' prefix) which cannot match identifiers
@@ -2950,7 +2950,8 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
   // can't mix&match between the two typesystems if there is such a
   // divergence. We'll need to replace all calls at once.
   if (get_ast_num_children() <
-      runtime->GetNumChildren({weak_from_this(), type}, valobj).getValueOr(0))
+      runtime->GetNumChildren({weak_from_this(), type}, exe_scope)
+          .getValueOr(0))
     return impl();
   if (ShouldSkipValidation(type))
     return impl();
@@ -3554,6 +3555,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
                                bitfield_bit_size, bitfield_bit_offset,
                                exe_scope);
     }
+    case Node::Kind::DynamicSelf:
     case Node::Kind::Unmanaged:
     case Node::Kind::Unowned:
     case Node::Kind::Weak: {

--- a/lldb/test/API/lang/swift/dynamic_self/TestSwiftDynamicSelf.py
+++ b/lldb/test/API/lang/swift/dynamic_self/TestSwiftDynamicSelf.py
@@ -49,7 +49,6 @@ class TestSwiftDynamicSelf(lldbtest.TestBase):
 
         lldbutil.continue_to_breakpoint(process, bkpt) # Stop in Child.show.
         frame = thread.frames[0]
-        # When stopped in Child.show(), 'self' doesn't have a child.
-        self.assertEqual(frame.FindVariable("self", lldb.eNoDynamicValues).GetNumChildren(), 0)
+        self.assertEqual(frame.FindVariable("self", lldb.eNoDynamicValues).GetNumChildren(), 1)
         self.check_members(self.get_self_as_Base_from_Child_method(frame),
                 "100", "220")


### PR DESCRIPTION
This is closer to what the function actually needs, fixes a race condition in SwiftLanguageRuntimeImpl::GetChildCompilerTypeAtIndex(), and allows TypeSystemSwiftTypeRef::GetNumChildren() to pass in the exe_scope, which fixes a flaky test on the bots.