### PR TITLE
Create REPL incomplete ObjC types test

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/incomplete_types/objc/Foo/foo.h
+++ b/lldb/test/API/lang/swift/clangimporter/incomplete_types/objc/Foo/foo.h
@@ -1,0 +1,3 @@
+@class Foo;
+
+Foo* getAFoo();

--- a/lldb/test/API/lang/swift/clangimporter/incomplete_types/objc/Foo/foo.m
+++ b/lldb/test/API/lang/swift/clangimporter/incomplete_types/objc/Foo/foo.m
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+
+#import "foo.h"
+
+@interface Foo : NSObject
+@end
+
+@implementation Foo
+@end
+
+Foo* getAFoo() {
+    return [[Foo alloc] init];
+}

--- a/lldb/test/API/lang/swift/clangimporter/incomplete_types/objc/Foo/module.modulemap
+++ b/lldb/test/API/lang/swift/clangimporter/incomplete_types/objc/Foo/module.modulemap
@@ -1,0 +1,3 @@
+module Foo {
+    header "foo.h"
+}

--- a/lldb/test/API/lang/swift/clangimporter/incomplete_types/objc/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/incomplete_types/objc/Makefile
@@ -1,0 +1,14 @@
+SWIFT_SOURCES := main.swift
+SWIFT_OBJC_INTEROP := 1
+SWIFTFLAGS_EXTRAS = -I$(SRCDIR)/Foo -L$(shell pwd) -lFoo -Xfrontend -enable-import-objc-forward-declarations
+LD_FLAGS = some_nonesense
+
+include Makefile.rules
+
+a.out: libFoo.dylib
+
+libFoo.dylib: $(SRCDIR)/Foo/foo.m
+	$(CC) -framework Foundation -dynamiclib $(CFLAGS) -o $@ $<
+
+clean::
+	# rm -rf *.swiftmodule *.swiftdoc *.dSYM lib*.dylib a.out *.o

--- a/lldb/test/API/lang/swift/clangimporter/incomplete_types/objc/TestImportObjCForwardDeclarationsDisabled.py
+++ b/lldb/test/API/lang/swift/clangimporter/incomplete_types/objc/TestImportObjCForwardDeclarationsDisabled.py
@@ -1,0 +1,16 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+class ImportObjCForwardDeclarationsDisabledInLLDBExpressionEvaluationTest(TestBase):
+
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @swiftTest
+    def test(self):
+        """Tests that values whose type was imported by the ClangImporter as a placeholder for a forward declared type cannot be used in LLDB expression evaluation"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self,"break here", lldb.SBFileSpec("main.swift"))
+        self.expect("p foo", substrs=["aasdf"])
+

--- a/lldb/test/API/lang/swift/clangimporter/incomplete_types/objc/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/incomplete_types/objc/main.swift
@@ -1,0 +1,4 @@
+import Foo
+
+let foo = getAFoo()
+print("break here")

--- a/lldb/test/Shell/SwiftREPL/ImportObjCForwardDeclarationsDisabled.test
+++ b/lldb/test/Shell/SwiftREPL/ImportObjCForwardDeclarationsDisabled.test
@@ -1,0 +1,27 @@
+// REQUIRES: swift
+
+// RUN: %lldb --repl='-enable-objc-interop -I %S/Inputs/custom-modules/IncompleteTypes' --repl-language swift < %s 2>&1  | FileCheck %s
+// RUN: %lldb --repl='-enable-objc-interop -I %S/Inputs/custom-modules/IncompleteTypes -swift-version 6' --repl-language swift < %s 2>&1  | FileCheck %s
+// RUN: %lldb --repl='-enable-objc-interop -I %S/Inputs/custom-modules/IncompleteTypes -enable-import-objc-forward-declarations' --repl-language swift < %s 2>&1  | FileCheck %s
+
+import Foo
+
+// CHECK-NOT: error: no such module 'Foo'
+
+getAFoo()
+
+// CHECK: error: cannot find 'getAFoo' in scope
+// CHECK: getAFoo()
+// CHECK: ^~~~~~~
+// CHECK: foo.h:{{[0-9]+}}:{{[0-9]+}}: note: function 'getAFoo' not imported
+// CHECK: Foo* getAFoo();
+// CHECK: ^
+// CHECK: foo.h:{{[0-9]+}}:{{[0-9]+}}: note: return type not imported
+// CHECK: Foo* getAFoo();
+// CHECK: ^
+// CHECK: foo.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' is incomplete
+// CHECK: Foo* getAFoo();
+// CHECK: ^
+// CHECK: foo.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'Foo' forward declared here
+// CHECK: @class Foo;
+// CHECK: ^

--- a/lldb/test/Shell/SwiftREPL/Inputs/custom-modules/IncompleteTypes/foo.h
+++ b/lldb/test/Shell/SwiftREPL/Inputs/custom-modules/IncompleteTypes/foo.h
@@ -1,0 +1,3 @@
+@class Foo;
+
+Foo* getAFoo();

--- a/lldb/test/Shell/SwiftREPL/Inputs/custom-modules/IncompleteTypes/foo.m
+++ b/lldb/test/Shell/SwiftREPL/Inputs/custom-modules/IncompleteTypes/foo.m
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+@interface Foo : NSObject
+@end
+
+Foo* getAFoo() {
+    return [[Foo alloc] init];
+}

--- a/lldb/test/Shell/SwiftREPL/Inputs/custom-modules/IncompleteTypes/module.modulemap
+++ b/lldb/test/Shell/SwiftREPL/Inputs/custom-modules/IncompleteTypes/module.modulemap
@@ -1,0 +1,3 @@
+module Foo {
+    header "foo.h"
+}


### PR DESCRIPTION
Create a test that verifies the REPL makes
no attempt at importing forward declared Objective-C interfaces and protocols, even if either of
`-enable-import-objc-forward-declarations` and `swift-version 6` are passed.

Built to test https://github.com/apple/swift/pull/61606