### PR TITLE
Change SwiftLanguageRuntime::GetNumChildren() to take an exe_scope

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -289,7 +289,7 @@ public:
   }
 
   llvm::Optional<unsigned> GetNumChildren(CompilerType type,
-                                          ValueObject *valobj) {
+                                          ExecutionContextScope *exe_scopej) {
     STUB_LOG();
     return {};
   }
@@ -2309,8 +2309,9 @@ llvm::Optional<uint64_t> SwiftLanguageRuntime::GetMemberVariableOffset(
 }
 
 llvm::Optional<unsigned>
-SwiftLanguageRuntime::GetNumChildren(CompilerType type, ValueObject *valobj) {
-  FORWARD(GetNumChildren, type, valobj);
+SwiftLanguageRuntime::GetNumChildren(CompilerType type,
+                                     ExecutionContextScope *exe_scope) {
+  FORWARD(GetNumChildren, type, exe_scope);
 }
 
 llvm::Optional<std::string> SwiftLanguageRuntime::GetEnumCaseName(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -277,7 +277,7 @@ public:
 
   /// Ask Remote Mirrors about the children of a composite type.
   llvm::Optional<unsigned> GetNumChildren(CompilerType type,
-                                          ValueObject *valobj);
+                                          ExecutionContextScope *exe_scope);
 
   /// Determine the enum case name for the \p data value of the enum \p type.
   /// This is performed using Swift reflection.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -982,19 +982,20 @@ static CompilerType GetWeakReferent(TypeSystemSwiftTypeRef &ts,
 
 llvm::Optional<unsigned>
 SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
-                                         ValueObject *valobj) {
+                                         ExecutionContextScope *exe_scope) {
   LLDB_SCOPED_TIMER();
   auto ts = type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwiftTypeRef>();
   if (!ts)
     return {};
 
   // Try the static type metadata.
-  auto frame =
-      valobj ? valobj->GetExecutionContextRef().GetFrameSP().get() : nullptr;
   const swift::reflection::TypeRef *tr = nullptr;
-  auto *ti = GetSwiftRuntimeTypeInfo(type, frame, &tr);
-  if (!ti)
+  auto *ti = GetSwiftRuntimeTypeInfo(type, exe_scope, &tr);
+  if (!ti) {
+    LLDB_LOG(GetLog(LLDBLog::Types), "GetSwiftRuntimeTypeInfo() failed for {0}",
+             type.GetMangledTypeName());
     return {};
+  }
   // Structs and Tuples.
   if (auto *rti = llvm::dyn_cast<swift::reflection::RecordTypeInfo>(ti)) {
     switch (rti->getRecordKind()) {
@@ -1063,7 +1064,8 @@ SwiftLanguageRuntimeImpl::GetNumFields(CompilerType type,
   using namespace swift::reflection;
   // Try the static type metadata.
   const TypeRef *tr = nullptr;
-  auto *ti = GetSwiftRuntimeTypeInfo(type, exe_ctx->GetFramePtr(), &tr);
+  auto *ti = GetSwiftRuntimeTypeInfo(
+      type, exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr, &tr);
   if (!ti)
     return {};
   // Structs and Tuples.
@@ -1324,9 +1326,12 @@ CompilerType SwiftLanguageRuntimeImpl::GetChildCompilerTypeAtIndex(
   };
 
   // Try the static type metadata.
-  auto frame =
-      valobj ? valobj->GetExecutionContextRef().GetFrameSP().get() : nullptr;
-  auto *ti = GetSwiftRuntimeTypeInfo(type, frame);
+  ExecutionContext exe_ctx;
+  if (valobj)
+    exe_ctx = valobj->GetExecutionContextRef();
+
+  auto *ti =
+      GetSwiftRuntimeTypeInfo(type, exe_ctx.GetBestExecutionContextScope());
   if (!ti)
     return {};
   // Structs and Tuples.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -123,7 +123,7 @@ public:
                                                    Status *error);
 
   llvm::Optional<unsigned> GetNumChildren(CompilerType type,
-                                          ValueObject *valobj);
+                                          ExecutionContextScope *exe_scope);
 
   llvm::Optional<unsigned> GetNumFields(CompilerType type,
                                         ExecutionContext *exe_ctx);

--- a/lldb/test/API/lang/swift/dynamic_self/TestSwiftDynamicSelf.py
+++ b/lldb/test/API/lang/swift/dynamic_self/TestSwiftDynamicSelf.py
@@ -47,7 +47,6 @@ class TestSwiftDynamicSelf(lldbtest.TestBase):
 
         lldbutil.continue_to_breakpoint(process, bkpt) # Stop in Child.show.
         frame = thread.frames[0]
-        # When stopped in Child.show(), 'self' doesn't have a child.
-        self.assertEqual(frame.FindVariable("self", lldb.eNoDynamicValues).GetNumChildren(), 0)
+        self.assertEqual(frame.FindVariable("self", lldb.eNoDynamicValues).GetNumChildren(), 1)
         self.check_members(self.get_self_as_Base_from_Child_method(frame),
                 "100", "220")


### PR DESCRIPTION
This is closer to what the function actually needs, fixes a race condition in SwiftLanguageRuntimeImpl::GetChildCompilerTypeAtIndex(), and allows TypeSystemSwiftTypeRef::GetNumChildren() to pass in the exe_scope, which fixes a flaky test on the bots.

(cherry picked from commit 1aaa123818656e0b5a6a1f6a248d7b585f6b9641)

 Conflicts:
	lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp