### PR TITLE
[lldb] Pass exec context/scope to functions in LLDBTypeInfoProvider

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -192,6 +192,8 @@ public:
     std::function<const swift::reflection::TypeRef *()> get_typeref;
   };
 
+  Process &GetProcess() const;
+
   /// An abstract interface to swift::reflection::ReflectionContext
   /// objects of varying pointer sizes.  This class encapsulates all
   /// traffic to ReflectionContext and abstracts the detail that


### PR DESCRIPTION
Pass the optional execution context/scope to calls of clang type functions that take them in.

(cherry picked from commit b804fe817cf3917830e81cfdf0acf2505bf4afa8)