### PR TITLE
[clang][deps][cas] Move casfs caching config into FullDependencyConsumer 

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -81,6 +81,8 @@ struct FullDependenciesResult {
   std::vector<ModuleDeps> DiscoveredModules;
 };
 
+using RemapPathCallback = llvm::cas::CachingOnDiskFileSystem::RemapPathCallback;
+
 /// The high-level implementation of the dependency discovery tool that runs on
 /// an individual worker thread.
 class DependencyScanningTool {
@@ -157,7 +159,7 @@ public:
 
   const CASOptions &getCASOpts() const { return Worker.getCASOpts(); }
 
-  llvm::cas::CachingOnDiskFileSystem &getCachingFileSystem() {
+  CachingOnDiskFileSystemPtr getCachingFileSystem() {
     return Worker.getCASFS();
   }
 
@@ -182,9 +184,23 @@ class FullDependencyConsumer : public DependencyConsumer {
 public:
   FullDependencyConsumer(const llvm::StringSet<> &AlreadySeen,
                          LookupModuleOutputCallback LookupModuleOutput,
-                         bool EagerLoadModules)
-      : AlreadySeen(AlreadySeen), LookupModuleOutput(LookupModuleOutput),
+                         bool EagerLoadModules,
+                         CachingOnDiskFileSystemPtr CacheFS = nullptr,
+                         RemapPathCallback RemapPath = nullptr)
+      : CacheFS(std::move(CacheFS)), RemapPath(RemapPath),
+        AlreadySeen(AlreadySeen), LookupModuleOutput(LookupModuleOutput),
         EagerLoadModules(EagerLoadModules) {}
+
+  llvm::Error initialize(CompilerInstance &ScanInstance,
+                         CompilerInvocation &NewInvocation) override;
+  llvm::Error finalize(CompilerInstance &ScanInstance,
+                       CompilerInvocation &NewInvocation) override;
+  llvm::Error
+  initializeModuleBuild(CompilerInstance &ModuleScanInstance) override;
+  llvm::Error
+  finalizeModuleBuild(CompilerInstance &ModuleScanInstance) override;
+  llvm::Error finalizeModuleInvocation(CompilerInvocation &CI,
+                                       const ModuleDeps &MD) override;
 
   void handleBuildCommand(Command Cmd) override {
     Commands.push_back(std::move(Cmd));
@@ -212,6 +228,10 @@ public:
     CASFileSystemRootID = ID;
   }
 
+  std::optional<cas::CASID> getCASFileSystemRootID() const {
+    return CASFileSystemRootID;
+  }
+
   std::string lookupModuleOutput(const ModuleID &ID,
                                  ModuleOutputKind Kind) override {
     return LookupModuleOutput(ID, Kind);
@@ -229,7 +249,10 @@ private:
       ClangModuleDeps;
   std::vector<Command> Commands;
   std::string ContextHash;
-  Optional<cas::CASID> CASFileSystemRootID;
+  CachingOnDiskFileSystemPtr CacheFS;
+  RemapPathCallback RemapPath;
+  CASOptions CASOpts;
+  std::optional<cas::CASID> CASFileSystemRootID;
   std::vector<std::string> OutputPaths;
   const llvm::StringSet<> &AlreadySeen;
   LookupModuleOutputCallback LookupModuleOutput;

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -28,6 +28,9 @@ class DependencyOutputOptions;
 namespace tooling {
 namespace dependencies {
 
+using CachingOnDiskFileSystemPtr =
+    llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem>;
+
 class DependencyScanningWorkerFilesystem;
 struct DepscanPrefixMapping;
 
@@ -38,8 +41,6 @@ struct Command {
   std::string Executable;
   std::vector<std::string> Arguments;
 };
-
-using RemapPathCallback = llvm::cas::CachingOnDiskFileSystem::RemapPathCallback;
 
 class DependencyConsumer {
 public:
@@ -52,6 +53,21 @@ public:
 
   virtual llvm::Error finalize(CompilerInstance &ScanInstance,
                                CompilerInvocation &NewInvocation) {
+    return llvm::Error::success();
+  }
+
+  virtual llvm::Error
+  initializeModuleBuild(CompilerInstance &ModuleScanInstance) {
+    return llvm::Error::success();
+  }
+
+  virtual llvm::Error
+  finalizeModuleBuild(CompilerInstance &ModuleScanInstance) {
+    return llvm::Error::success();
+  }
+
+  virtual llvm::Error finalizeModuleInvocation(CompilerInvocation &CI,
+                                               const ModuleDeps &MD) {
     return llvm::Error::success();
   }
 
@@ -155,12 +171,12 @@ public:
   void computeDependenciesFromCompilerInvocation(
       std::shared_ptr<CompilerInvocation> Invocation,
       StringRef WorkingDirectory, DependencyConsumer &Consumer,
-      RemapPathCallback RemapPath, DiagnosticConsumer &DiagsConsumer,
-      raw_ostream *VerboseOS, bool DiagGenerationAsCompilation);
+      DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
+      bool DiagGenerationAsCompilation);
 
   ScanningOutputFormat getScanningFormat() const { return Format; }
 
-  llvm::cas::CachingOnDiskFileSystem &getCASFS() { return *CacheFS; }
+  CachingOnDiskFileSystemPtr getCASFS() { return CacheFS; }
   bool useCAS() const { return UseCAS; }
   const CASOptions &getCASOpts() const { return CASOpts; }
 
@@ -188,7 +204,7 @@ private:
   bool EagerLoadModules;
 
   /// The caching file system.
-  llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> CacheFS;
+  CachingOnDiskFileSystemPtr CacheFS;
   /// The CAS Dependency Filesytem. This is not set at the sametime as DepFS;
   llvm::IntrusiveRefCntPtr<DependencyScanningCASFilesystem> DepCASFS;
   CASOptions CASOpts;

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -45,11 +45,13 @@ class DependencyConsumer {
 public:
   virtual ~DependencyConsumer() {}
 
-  virtual llvm::Error initialize(CompilerInstance &CI) {
+  virtual llvm::Error initialize(CompilerInstance &ScanInstance,
+                                 CompilerInvocation &NewInvocation) {
     return llvm::Error::success();
   }
 
-  virtual llvm::Error finalize(CompilerInstance &CI) {
+  virtual llvm::Error finalize(CompilerInstance &ScanInstance,
+                               CompilerInvocation &NewInvocation) {
     return llvm::Error::success();
   }
 

--- a/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
@@ -189,8 +189,8 @@ class ModuleDepCollector final : public DependencyCollector {
 public:
   ModuleDepCollector(std::unique_ptr<DependencyOutputOptions> Opts,
                      CompilerInstance &ScanInstance, DependencyConsumer &C,
-                     CompilerInvocation OriginalCI, StringRef WorkingDirectory,
-                     bool OptimizeArgs, bool EagerLoadModules);
+                     CompilerInvocation OriginalCI, bool OptimizeArgs,
+                     bool EagerLoadModules);
 
   void attachToPreprocessor(Preprocessor &PP) override;
   void attachToASTReader(ASTReader &R) override;
@@ -198,10 +198,6 @@ public:
   /// Apply any changes implied by the discovered dependencies to the given
   /// invocation, (e.g. disable implicit modules, add explicit module paths).
   void applyDiscoveredDependencies(CompilerInvocation &CI);
-
-  /// Set a CAS filesystem root ID for the main file, which will be included by
-  /// \c applyDiscoveredDependencies.
-  void setMainFileCASFileSystemRootID(cas::CASID ID);
 
 private:
   friend ModuleDepCollectorPP;
@@ -228,15 +224,6 @@ private:
   std::unique_ptr<DependencyOutputOptions> Opts;
   /// The original Clang invocation passed to dependency scanner.
   CompilerInvocation OriginalInvocation;
-  /// The original working directory.
-  std::string WorkingDirectory;
-  /// The CAS filesystem root ID for the main input file, if any. This is used
-  /// in \c applyDiscoveredDependencies.
-  Optional<cas::CASID> MainFileCASFileSystemRootID;
-  /// CAS options to apply to invocations.
-  CASOptions CASOpts;
-  /// CAS options to apply to invocations.
-  bool CacheCompileJob;
   /// Whether to optimize the modules' command-line arguments.
   bool OptimizeArgs;
   /// Whether to set up command-lines to load PCM files eagerly.

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -122,7 +122,7 @@ llvm::Expected<std::string> DependencyScanningTool::getDependencyFile(
 
 namespace {
 /// Returns a CAS tree containing the dependencies.
-class GetDependencyTree : public DependencyConsumer {
+class GetDependencyTree : public FullDependencyConsumer {
 public:
   void handleBuildCommand(Command) override {}
   void handleFileDependency(StringRef File) override {}
@@ -131,33 +131,33 @@ public:
   void handleDependencyOutputOpts(const DependencyOutputOptions &) override {}
   void handleContextHash(std::string) override {}
 
-  void handleCASFileSystemRootID(cas::CASID ID) override {
-    CASFileSystemRootID = ID;
-  }
-
   std::string lookupModuleOutput(const ModuleID &, ModuleOutputKind) override {
     llvm::report_fatal_error("unexpected call to lookupModuleOutput");
   }
 
   Expected<llvm::cas::ObjectProxy> getTree() {
-    if (CASFileSystemRootID)
-      return CAS.getProxy(*CASFileSystemRootID);
+    if (auto ID = getCASFileSystemRootID())
+      return FS.getCAS().getProxy(*ID);
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "failed to get casfs");
   }
 
-  GetDependencyTree(cas::ObjectStore &CAS) : CAS(CAS) {}
+  GetDependencyTree(llvm::cas::CachingOnDiskFileSystem &FS,
+                    RemapPathCallback RemapPath)
+      : FullDependencyConsumer(AlreadySeen, nullptr, /*EagerModules=*/false,
+                               &FS, RemapPath),
+        FS(FS) {}
 
 private:
-  cas::ObjectStore &CAS;
-  Optional<cas::CASID> CASFileSystemRootID;
+  llvm::cas::CachingOnDiskFileSystem &FS;
+  llvm::StringSet<> AlreadySeen;
 };
 }
 
 llvm::Expected<llvm::cas::ObjectProxy>
 DependencyScanningTool::getDependencyTree(
     const std::vector<std::string> &CommandLine, StringRef CWD) {
-  GetDependencyTree Consumer(Worker.getCASFS().getCAS());
+  GetDependencyTree Consumer(*Worker.getCASFS(), /*RemapPath=*/nullptr);
   auto Result = Worker.computeDependencies(CWD, CommandLine, Consumer);
   if (Result)
     return std::move(Result);
@@ -169,9 +169,9 @@ DependencyScanningTool::getDependencyTreeFromCompilerInvocation(
     std::shared_ptr<CompilerInvocation> Invocation, StringRef CWD,
     DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
     bool DiagGenerationAsCompilation, RemapPathCallback RemapPath) {
-  GetDependencyTree Consumer(Worker.getCASFS().getCAS());
+  GetDependencyTree Consumer(*Worker.getCASFS(), RemapPath);
   Worker.computeDependenciesFromCompilerInvocation(
-      std::move(Invocation), CWD, Consumer, RemapPath, DiagsConsumer, VerboseOS,
+      std::move(Invocation), CWD, Consumer, DiagsConsumer, VerboseOS,
       DiagGenerationAsCompilation);
   return Consumer.getTree();
 }
@@ -548,8 +548,8 @@ DependencyScanningTool::getIncludeTreeFromCompilerInvocation(
     bool DiagGenerationAsCompilation) {
   IncludeTreePPConsumer Consumer(DB, PrefixMapping);
   Worker.computeDependenciesFromCompilerInvocation(
-      std::move(Invocation), CWD, Consumer, /*RemapPath=*/nullptr,
-      DiagsConsumer, VerboseOS, DiagGenerationAsCompilation);
+      std::move(Invocation), CWD, Consumer, DiagsConsumer, VerboseOS,
+      DiagGenerationAsCompilation);
   return Consumer.getIncludeTree();
 }
 
@@ -560,7 +560,8 @@ DependencyScanningTool::getFullDependencies(
     LookupModuleOutputCallback LookupModuleOutput,
     std::optional<StringRef> ModuleName) {
   FullDependencyConsumer Consumer(AlreadySeen, LookupModuleOutput,
-                                  Worker.shouldEagerLoadModules());
+                                  Worker.shouldEagerLoadModules(),
+                                  Worker.getCASFS());
   llvm::Error Result =
       Worker.computeDependencies(CWD, CommandLine, Consumer, ModuleName);
   if (Result)
@@ -575,12 +576,103 @@ DependencyScanningTool::getFullDependenciesLegacyDriverCommand(
     LookupModuleOutputCallback LookupModuleOutput,
     std::optional<StringRef> ModuleName) {
   FullDependencyConsumer Consumer(AlreadySeen, LookupModuleOutput,
-                                  Worker.shouldEagerLoadModules());
+                                  Worker.shouldEagerLoadModules(),
+                                  Worker.getCASFS());
   llvm::Error Result =
       Worker.computeDependencies(CWD, CommandLine, Consumer, ModuleName);
   if (Result)
     return std::move(Result);
   return Consumer.getFullDependenciesLegacyDriverCommand(CommandLine);
+}
+
+Error FullDependencyConsumer::initialize(CompilerInstance &ScanInstance,
+                                         CompilerInvocation &NewInvocation) {
+  if (CacheFS) {
+    CacheFS->trackNewAccesses();
+    if (auto CWD =
+            ScanInstance.getVirtualFileSystem().getCurrentWorkingDirectory())
+      CacheFS->setCurrentWorkingDirectory(*CWD);
+    // Track paths that are accessed by the scanner before we reach here.
+    for (const auto &File : ScanInstance.getHeaderSearchOpts().VFSOverlayFiles)
+      (void)CacheFS->status(File);
+    // Enable caching in the resulting commands.
+    ScanInstance.getFrontendOpts().CacheCompileJob = true;
+    CASOpts = ScanInstance.getCASOpts();
+  }
+  return Error::success();
+}
+
+Error FullDependencyConsumer::finalize(CompilerInstance &ScanInstance,
+                                       CompilerInvocation &NewInvocation) {
+  if (CacheFS) {
+    // Exclude the module cache from tracking. The implicit build pcms should
+    // not be needed after scanning.
+    if (!ScanInstance.getHeaderSearchOpts().ModuleCachePath.empty())
+      (void)CacheFS->excludeFromTracking(
+          ScanInstance.getHeaderSearchOpts().ModuleCachePath);
+
+    // Handle profile mappings.
+    (void)CacheFS->status(
+        NewInvocation.getCodeGenOpts().ProfileInstrumentUsePath);
+    (void)CacheFS->status(NewInvocation.getCodeGenOpts().SampleProfileFile);
+    (void)CacheFS->status(NewInvocation.getCodeGenOpts().ProfileRemappingFile);
+
+    if (auto E = CacheFS->createTreeFromNewAccesses(RemapPath).moveInto(
+            CASFileSystemRootID))
+      return E;
+
+    configureInvocationForCaching(NewInvocation, CASOpts,
+                                  CASFileSystemRootID->toString(),
+                                  CacheFS->getCurrentWorkingDirectory().get(),
+                                  /*ProduceIncludeTree=*/false);
+  }
+  return Error::success();
+}
+
+Error FullDependencyConsumer::initializeModuleBuild(
+    CompilerInstance &ModuleScanInstance) {
+  if (CacheFS) {
+    CacheFS->trackNewAccesses();
+    auto &HSOpts = ModuleScanInstance.getHeaderSearchOpts();
+    // Normally this would be looked up while creating the VFS, but implicit
+    // modules share their VFS.
+    for (const auto &File : HSOpts.VFSOverlayFiles)
+      (void)CacheFS->status(File);
+    // If the working directory is not otherwise accessed by the module build,
+    // we still need it due to -fcas-fs-working-directory being set.
+    if (auto CWD = CacheFS->getCurrentWorkingDirectory())
+      (void)CacheFS->status(*CWD);
+    // Exclude the module cache from tracking. The implicit build pcms should
+    // not be needed after scanning.
+    if (!HSOpts.ModuleCachePath.empty())
+      (void)CacheFS->excludeFromTracking(HSOpts.ModuleCachePath);
+  }
+  return Error::success();
+}
+
+Error FullDependencyConsumer::finalizeModuleBuild(
+    CompilerInstance &ModuleScanInstance) {
+  if (CacheFS) {
+    std::optional<cas::CASID> RootID;
+    if (auto E = CacheFS->createTreeFromNewAccesses(RemapPath).moveInto(RootID))
+      return E;
+
+    Module *M = ModuleScanInstance.getPreprocessor().getCurrentModule();
+    assert(M && "finalizing without a module");
+
+    M->setCASFileSystemRootID(RootID->toString());
+  }
+  return Error::success();
+}
+
+Error FullDependencyConsumer::finalizeModuleInvocation(CompilerInvocation &CI,
+                                                       const ModuleDeps &MD) {
+  if (auto ID = MD.CASFileSystemRootID) {
+    configureInvocationForCaching(CI, CASOpts, ID->toString(),
+                                  CacheFS->getCurrentWorkingDirectory().get(),
+                                  /*ProduceIncludeTree=*/false);
+  }
+  return llvm::Error::success();
 }
 
 FullDependenciesResult FullDependencyConsumer::takeFullDependencies() {

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -526,12 +526,12 @@ public:
     else
       Action = std::make_unique<ReadPCHAndPreprocessAction>();
 
-    if (Error E = Consumer.initialize(ScanInstance))
+    if (Error E = Consumer.initialize(ScanInstance, OriginalInvocation))
       return reportError(std::move(E));
 
     const bool Result = ScanInstance.ExecuteAction(*Action);
 
-    if (Error E = Consumer.finalize(ScanInstance))
+    if (Error E = Consumer.finalize(ScanInstance, OriginalInvocation))
       return reportError(std::move(E));
 
     if (CacheFS) {

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -245,54 +245,34 @@ public:
 /// See \c WrapScanModuleBuildAction.
 class WrapScanModuleBuildConsumer : public ASTConsumer {
 public:
-  WrapScanModuleBuildConsumer(CompilerInstance &CI, Module &M,
-                              llvm::cas::CachingOnDiskFileSystem &FS)
-      : M(M), FS(FS) {}
+  WrapScanModuleBuildConsumer(CompilerInstance &CI,
+                              DependencyConsumer &Consumer)
+      : CI(CI), Consumer(Consumer) {}
 
   void HandleTranslationUnit(ASTContext &Ctx) override {
-    auto Tree = FS.createTreeFromNewAccesses();
-    if (Tree)
-      M.setCASFileSystemRootID(Tree->getID().toString());
-    else
-      Ctx.getDiagnostics().Report(diag::err_cas_depscan_failed)
-          << Tree.takeError();
+    if (auto E = Consumer.finalizeModuleBuild(CI))
+      Ctx.getDiagnostics().Report(diag::err_cas_depscan_failed) << std::move(E);
   }
 
 private:
-  Module &M;
-  llvm::cas::CachingOnDiskFileSystem &FS;
+  CompilerInstance &CI;
+  DependencyConsumer &Consumer;
 };
 
 /// A wrapper for implicit module build actions in the scanner.
-///
-/// Captures per-module information such as the CAS filesystem root ID for
-/// module inputs.
 class WrapScanModuleBuildAction : public WrapperFrontendAction {
 public:
-  WrapScanModuleBuildAction(
-      std::unique_ptr<FrontendAction> WrappedAction,
-      IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> FS)
-      : WrapperFrontendAction(std::move(WrappedAction)), FS(std::move(FS)) {
-    assert(this->FS);
+  WrapScanModuleBuildAction(std::unique_ptr<FrontendAction> WrappedAction,
+                            DependencyConsumer &Consumer)
+      : WrapperFrontendAction(std::move(WrappedAction)), DepConsumer(Consumer) {
   }
 
 private:
   bool BeginInvocation(CompilerInstance &CI) override {
-    // FIXME: exclude unnecessary files such as implicit module pcms from the
-    // scanner itself. These are wasteful and cause spurious cache misses.
-    FS->trackNewAccesses();
-    // Normally this would be looked up while creating the VFS, but implicit
-    // modules share their VFS.
-    for (const auto &File : CI.getHeaderSearchOpts().VFSOverlayFiles)
-      (void)FS->status(File);
-    // If the working directory is not otherwise accessed by the module build,
-    // we still need it due to -fcas-fs-working-directory being set.
-    if (auto CWD = FS->getCurrentWorkingDirectory())
-      (void)FS->status(*CWD);
-    // Exclude the module cache from tracking. The implicit build pcms should
-    // not be needed after scanning.
-    if (!CI.getHeaderSearchOpts().ModuleCachePath.empty())
-      (void)FS->excludeFromTracking(CI.getHeaderSearchOpts().ModuleCachePath);
+    if (auto E = DepConsumer.initializeModuleBuild(CI)) {
+      CI.getDiagnostics().Report(diag::err_cas_depscan_failed) << std::move(E);
+      return false;
+    }
     return WrapperFrontendAction::BeginInvocation(CI);
   }
 
@@ -305,7 +285,8 @@ private:
     assert(M && "WrapScanModuleBuildAction should only be used with module");
     if (!M)
       return OtherConsumer;
-    auto Consumer = std::make_unique<WrapScanModuleBuildConsumer>(CI, *M, *FS);
+    auto Consumer =
+        std::make_unique<WrapScanModuleBuildConsumer>(CI, DepConsumer);
     std::vector<std::unique_ptr<ASTConsumer>> Consumers;
     Consumers.push_back(std::move(Consumer));
     Consumers.push_back(std::move(OtherConsumer));
@@ -313,7 +294,7 @@ private:
   }
 
 private:
-  llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> FS;
+  DependencyConsumer &DepConsumer;
 };
 
 /// A clang tool that runs the preprocessor in a mode that's optimized for
@@ -328,15 +309,14 @@ public:
       ScanningOutputFormat Format, bool OptimizeArgs, bool EagerLoadModules,
       bool DisableFree, bool EmitDependencyFile,
       bool DiagGenerationAsCompilation, const CASOptions &CASOpts,
-      RemapPathCallback RemapPath, bool OverrideCASTokenCache,
+      bool OverrideCASTokenCache,
       std::optional<StringRef> ModuleName = std::nullopt,
       raw_ostream *VerboseOS = nullptr)
       : WorkingDirectory(WorkingDirectory), Consumer(Consumer),
         DepFS(std::move(DepFS)), DepCASFS(std::move(DepCASFS)),
         CacheFS(std::move(CacheFS)), Format(Format), OptimizeArgs(OptimizeArgs),
         EagerLoadModules(EagerLoadModules), DisableFree(DisableFree),
-        CASOpts(CASOpts), RemapPath(RemapPath),
-        OverrideCASTokenCache(OverrideCASTokenCache),
+        CASOpts(CASOpts), OverrideCASTokenCache(OverrideCASTokenCache),
         EmitDependencyFile(EmitDependencyFile),
         DiagGenerationAsCompilation(DiagGenerationAsCompilation),
         ModuleName(ModuleName), VerboseOS(VerboseOS) {}
@@ -355,7 +335,13 @@ public:
       // jobs. For any dependent jobs, reuse the scanning result and just
       // update the LastCC1Arguments to correspond to the new invocation.
       // FIXME: to support multi-arch builds, each arch requires a separate scan
-      setLastCC1Arguments(std::move(OriginalInvocation));
+      if (MDC)
+        MDC->applyDiscoveredDependencies(OriginalInvocation);
+
+      // FIXME: caching + multi-job will not work because the consumer will not
+      // apply the changes.
+
+      LastCC1Arguments = OriginalInvocation.getCC1CommandLine();
       return true;
     }
 
@@ -366,13 +352,6 @@ public:
     CompilerInstance &ScanInstance = *ScanInstanceStorage;
     ScanInstance.setInvocation(std::move(Invocation));
     ScanInstance.getInvocation().getCASOpts() = CASOpts;
-
-    if (CacheFS) {
-      CacheFS->trackNewAccesses();
-      CacheFS->setCurrentWorkingDirectory(WorkingDirectory);
-      // Enable caching in the resulting commands.
-      ScanInstance.getFrontendOpts().CacheCompileJob = true;
-    }
 
     // Create the compiler's actual diagnostics engine.
     if (!DiagGenerationAsCompilation)
@@ -495,14 +474,15 @@ public:
     case ScanningOutputFormat::FullTree:
       MDC = std::make_shared<ModuleDepCollector>(
           std::move(Opts), ScanInstance, Consumer, OriginalInvocation,
-          WorkingDirectory, OptimizeArgs, EagerLoadModules);
+          OptimizeArgs, EagerLoadModules);
       ScanInstance.addDependencyCollector(MDC);
       if (CacheFS) {
         ScanInstance.setGenModuleActionWrapper(
-            [CacheFS = CacheFS](const FrontendOptions &Opts,
-                                std::unique_ptr<FrontendAction> Wrapped) {
+            [CacheFS = CacheFS,
+             &Consumer = Consumer](const FrontendOptions &Opts,
+                                   std::unique_ptr<FrontendAction> Wrapped) {
               return std::make_unique<WrapScanModuleBuildAction>(
-                  std::move(Wrapped), std::move(CacheFS));
+                  std::move(Wrapped), Consumer);
             });
       }
       break;
@@ -529,40 +509,18 @@ public:
     if (Error E = Consumer.initialize(ScanInstance, OriginalInvocation))
       return reportError(std::move(E));
 
-    const bool Result = ScanInstance.ExecuteAction(*Action);
+    if (!ScanInstance.ExecuteAction(*Action))
+      return false;
+
+    if (MDC)
+      MDC->applyDiscoveredDependencies(OriginalInvocation);
 
     if (Error E = Consumer.finalize(ScanInstance, OriginalInvocation))
       return reportError(std::move(E));
 
-    if (CacheFS) {
-      // Exclude the module cache from tracking. The implicit build pcms should
-      // not be needed after scanning.
-      if (!ScanInstance.getHeaderSearchOpts().ModuleCachePath.empty())
-        (void)CacheFS->excludeFromTracking(
-            ScanInstance.getHeaderSearchOpts().ModuleCachePath);
+    LastCC1Arguments = OriginalInvocation.getCC1CommandLine();
 
-      // Handle profile mappings.
-      (void)CacheFS->status(
-          OriginalInvocation.getCodeGenOpts().ProfileInstrumentUsePath);
-      (void)CacheFS->status(
-          OriginalInvocation.getCodeGenOpts().SampleProfileFile);
-      (void)CacheFS->status(
-          OriginalInvocation.getCodeGenOpts().ProfileRemappingFile);
-
-      auto Tree = CacheFS->createTreeFromNewAccesses(RemapPath);
-      if (Tree) {
-        if (MDC)
-          MDC->setMainFileCASFileSystemRootID(Tree->getID());
-        Consumer.handleCASFileSystemRootID(Tree->getID());
-      } else
-        ScanInstance.getDiagnostics().Report(diag::err_cas_depscan_failed)
-            << Tree.takeError();
-    }
-
-    if (Result)
-      setLastCC1Arguments(std::move(OriginalInvocation));
-
-    return Result;
+    return true;
   }
 
   bool hasScanned() const { return Scanned; }
@@ -589,13 +547,6 @@ public:
   }
 
 private:
-  void setLastCC1Arguments(CompilerInvocation &&CI) {
-    if (MDC)
-      MDC->applyDiscoveredDependencies(CI);
-    LastCC1Arguments = CI.getCC1CommandLine();
-  }
-
-private:
   StringRef WorkingDirectory;
   DependencyConsumer &Consumer;
   llvm::IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS;
@@ -606,7 +557,6 @@ private:
   bool EagerLoadModules;
   bool DisableFree;
   const CASOptions &CASOpts;
-  RemapPathCallback RemapPath;
   bool OverrideCASTokenCache;
   bool EmitDependencyFile = false;
   bool DiagGenerationAsCompilation;
@@ -760,7 +710,7 @@ bool DependencyScanningWorker::computeDependencies(
       OptimizeArgs, EagerLoadModules, DisableFree,
       /*EmitDependencyFile=*/false,
       /*DiagGenerationAsCompilation=*/false, getCASOpts(),
-      /*RemapPath=*/nullptr, OverrideCASTokenCache, ModuleName);
+      OverrideCASTokenCache, ModuleName);
   bool Success = forEachDriverJob(
       FinalCommandLine, *Diags, *FileMgr, [&](const driver::Command &Cmd) {
         if (StringRef(Cmd.getCreator().getName()) != "clang") {
@@ -801,9 +751,8 @@ bool DependencyScanningWorker::computeDependencies(
 
 void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
     std::shared_ptr<CompilerInvocation> Invocation, StringRef WorkingDirectory,
-    DependencyConsumer &DepsConsumer, RemapPathCallback RemapPath,
-    DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
-    bool DiagGenerationAsCompilation) {
+    DependencyConsumer &DepsConsumer, DiagnosticConsumer &DiagsConsumer,
+    raw_ostream *VerboseOS, bool DiagGenerationAsCompilation) {
   BaseFS->setCurrentWorkingDirectory(WorkingDirectory);
 
   // Adjust the invocation.
@@ -833,7 +782,7 @@ void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
       WorkingDirectory, DepsConsumer, DepFS, DepCASFS, CacheFS, Format,
       /*OptimizeArgs=*/false, /*DisableFree=*/false, EagerLoadModules,
       /*EmitDependencyFile=*/!DepFile.empty(), DiagGenerationAsCompilation,
-      getCASOpts(), RemapPath, OverrideCASTokenCache,
+      getCASOpts(), OverrideCASTokenCache,
       /*ModuleName=*/std::nullopt, VerboseOS);
 
   // Ignore result; we're just collecting dependencies.

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -14,7 +14,6 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningWorker.h"
-#include "clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h"
 #include "llvm/CAS/CASID.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/Support/BLAKE3.h"
@@ -179,10 +178,6 @@ ModuleDepCollector::makeInvocationForModuleBuildWithoutOutputs(
 
   Optimize(CI);
 
-  if (auto ID = Deps.CASFileSystemRootID)
-    configureInvocationForCaching(CI, CASOpts, ID->toString(), WorkingDirectory,
-                                  /*ProduceIncludeTree=*/false);
-
   return CI;
 }
 
@@ -269,15 +264,6 @@ void ModuleDepCollector::applyDiscoveredDependencies(CompilerInvocation &CI) {
     for (const auto &KV : DirectPrebuiltModularDeps)
       CI.getFrontendOpts().ModuleFiles.push_back(KV.second.PCMFile);
   }
-
-  if (auto ID = MainFileCASFileSystemRootID)
-    configureInvocationForCaching(CI, CASOpts, ID->toString(), WorkingDirectory,
-                                  /*ProduceIncludeTree=*/false);
-}
-
-void ModuleDepCollector::setMainFileCASFileSystemRootID(cas::CASID ID) {
-  assert(!MainFileCASFileSystemRootID || *MainFileCASFileSystemRootID == ID);
-  MainFileCASFileSystemRootID = std::move(ID);
 }
 
 static std::string getModuleContextHash(const ModuleDeps &MD,
@@ -499,15 +485,19 @@ ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
                                    *MDC.ScanInstance.getASTReader(), *MF);
       });
 
+  auto &Diags = MDC.ScanInstance.getDiagnostics();
+
+  if (auto E = MDC.Consumer.finalizeModuleInvocation(CI, MD))
+    Diags.Report(diag::err_cas_depscan_failed) << std::move(E);
+
   MDC.associateWithContextHash(CI, MD);
 
   // Finish the compiler invocation. Requires dependencies and the context hash.
   MDC.addOutputPaths(CI, MD);
 
   // Compute the cache key, if needed. Requires dependencies and outputs.
-  if (MDC.CacheCompileJob) {
+  if (MDC.ScanInstance.getFrontendOpts().CacheCompileJob) {
     auto &CAS = MDC.ScanInstance.getOrCreateObjectStore();
-    auto &Diags = MDC.ScanInstance.getDiagnostics();
     if (auto Key = createCompileJobCacheKey(CAS, Diags, CI))
       MD.ModuleCacheKey = Key->toString();
   }
@@ -601,14 +591,10 @@ void ModuleDepCollectorPP::addAffectingClangModule(
 ModuleDepCollector::ModuleDepCollector(
     std::unique_ptr<DependencyOutputOptions> Opts,
     CompilerInstance &ScanInstance, DependencyConsumer &C,
-    CompilerInvocation OriginalCI, StringRef WorkingDirectory,
-    bool OptimizeArgs, bool EagerLoadModules)
+    CompilerInvocation OriginalCI, bool OptimizeArgs, bool EagerLoadModules)
     : ScanInstance(ScanInstance), Consumer(C), Opts(std::move(Opts)),
-      OriginalInvocation(std::move(OriginalCI)),
-      WorkingDirectory(WorkingDirectory.str()),
-      CASOpts(ScanInstance.getCASOpts()),
-      CacheCompileJob(ScanInstance.getFrontendOpts().CacheCompileJob),
-      OptimizeArgs(OptimizeArgs), EagerLoadModules(EagerLoadModules) {}
+      OriginalInvocation(std::move(OriginalCI)), OptimizeArgs(OptimizeArgs),
+      EagerLoadModules(EagerLoadModules) {}
 
 void ModuleDepCollector::attachToPreprocessor(Preprocessor &PP) {
   PP.addPPCallbacks(std::make_unique<ModuleDepCollectorPP>(*this));

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -237,7 +237,7 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
     MapperPtr = std::make_unique<llvm::PrefixMapper>();
   } else {
     MapperPtr = std::make_unique<llvm::TreePathPrefixMapper>(
-        &Tool.getCachingFileSystem());
+        Tool.getCachingFileSystem());
   }
   llvm::PrefixMapper &Mapper = *MapperPtr;
   if (Error E = PrefixMapping.configurePrefixMapper(Invocation, Mapper))


### PR DESCRIPTION
This lifts the code related to configuring caching and manipulating the
CachingOnDiskFileSystem tracking out of the core dependency scanner and
into the consumer - specifically the FullDependencyConsumer.

This improves the separation of concerns between the specific use-cases
and the core scanner. It is also in line with how include-tree-based
compilation caching works.

This is also in preparation for centralizing prefix mapping code.