### PR TITLE
[clang][deps][cas] Add prefix mapping support to the cas-fs caching modes to clang-scan-deps

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -103,7 +103,8 @@ public:
 
   /// Collect dependency tree.
   llvm::Expected<llvm::cas::ObjectProxy>
-  getDependencyTree(const std::vector<std::string> &CommandLine, StringRef CWD);
+  getDependencyTree(const std::vector<std::string> &CommandLine, StringRef CWD,
+                    DepscanPrefixMapping PrefixMapping = {});
 
   /// If \p DiagGenerationAsCompilation is true it will generate error
   /// diagnostics same way as the normal compilation, with "N errors generated"
@@ -150,7 +151,8 @@ public:
   getFullDependencies(const std::vector<std::string> &CommandLine,
                       StringRef CWD, const llvm::StringSet<> &AlreadySeen,
                       LookupModuleOutputCallback LookupModuleOutput,
-                      std::optional<StringRef> ModuleName = std::nullopt);
+                      std::optional<StringRef> ModuleName = std::nullopt,
+                      DepscanPrefixMapping PrefixMapping = {});
 
   ScanningOutputFormat getScanningFormat() const {
     return Worker.getScanningFormat();

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -12,11 +12,13 @@
 #include "clang/Tooling/DependencyScanning/DependencyScanningService.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningWorker.h"
 #include "clang/Tooling/DependencyScanning/ModuleDepCollector.h"
+#include "clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h"
 #include "clang/Tooling/JSONCompilationDatabase.h"
 #include "llvm/ADT/MapVector.h"
-#include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/CAS/CASID.h"
+#include "llvm/Support/PrefixMapper.h"
 #include <string>
 #include <vector>
 
@@ -32,8 +34,6 @@ class IncludeTreeRoot;
 }
 namespace tooling {
 namespace dependencies {
-
-struct DepscanPrefixMapping;
 
 /// A callback to lookup module outputs for "-fmodule-file=", "-o" etc.
 using LookupModuleOutputCallback =
@@ -81,8 +81,6 @@ struct FullDependenciesResult {
   std::vector<ModuleDeps> DiscoveredModules;
 };
 
-using RemapPathCallback = llvm::cas::CachingOnDiskFileSystem::RemapPathCallback;
-
 /// The high-level implementation of the dependency discovery tool that runs on
 /// an individual worker thread.
 class DependencyScanningTool {
@@ -115,7 +113,8 @@ public:
   getDependencyTreeFromCompilerInvocation(
       std::shared_ptr<CompilerInvocation> Invocation, StringRef CWD,
       DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
-      bool DiagGenerationAsCompilation, RemapPathCallback RemapPath = nullptr);
+      bool DiagGenerationAsCompilation,
+      DepscanPrefixMapping PrefixMapping = {});
 
   Expected<cas::IncludeTreeRoot>
   getIncludeTree(cas::ObjectStore &DB,
@@ -186,8 +185,8 @@ public:
                          LookupModuleOutputCallback LookupModuleOutput,
                          bool EagerLoadModules,
                          CachingOnDiskFileSystemPtr CacheFS = nullptr,
-                         RemapPathCallback RemapPath = nullptr)
-      : CacheFS(std::move(CacheFS)), RemapPath(RemapPath),
+                         DepscanPrefixMapping PrefixMapping = {})
+      : CacheFS(std::move(CacheFS)), PrefixMapping(std::move(PrefixMapping)),
         AlreadySeen(AlreadySeen), LookupModuleOutput(LookupModuleOutput),
         EagerLoadModules(EagerLoadModules) {}
 
@@ -250,7 +249,8 @@ private:
   std::vector<Command> Commands;
   std::string ContextHash;
   CachingOnDiskFileSystemPtr CacheFS;
-  RemapPathCallback RemapPath;
+  DepscanPrefixMapping PrefixMapping;
+  std::optional<llvm::TreePathPrefixMapper> Mapper;
   CASOptions CASOpts;
   std::optional<cas::CASID> CASFileSystemRootID;
   std::vector<std::string> OutputPaths;

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -156,8 +156,9 @@ private:
 
 llvm::Expected<llvm::cas::ObjectProxy>
 DependencyScanningTool::getDependencyTree(
-    const std::vector<std::string> &CommandLine, StringRef CWD) {
-  GetDependencyTree Consumer(*Worker.getCASFS(), /*PrefixMapping=*/{});
+    const std::vector<std::string> &CommandLine, StringRef CWD,
+    DepscanPrefixMapping PrefixMapping) {
+  GetDependencyTree Consumer(*Worker.getCASFS(), std::move(PrefixMapping));
   auto Result = Worker.computeDependencies(CWD, CommandLine, Consumer);
   if (Result)
     return std::move(Result);
@@ -558,10 +559,10 @@ DependencyScanningTool::getFullDependencies(
     const std::vector<std::string> &CommandLine, StringRef CWD,
     const llvm::StringSet<> &AlreadySeen,
     LookupModuleOutputCallback LookupModuleOutput,
-    std::optional<StringRef> ModuleName) {
+    std::optional<StringRef> ModuleName, DepscanPrefixMapping PrefixMapping) {
   FullDependencyConsumer Consumer(AlreadySeen, LookupModuleOutput,
                                   Worker.shouldEagerLoadModules(),
-                                  Worker.getCASFS());
+                                  Worker.getCASFS(), std::move(PrefixMapping));
   llvm::Error Result =
       Worker.computeDependencies(CWD, CommandLine, Consumer, ModuleName);
   if (Result)
@@ -637,6 +638,10 @@ Error FullDependencyConsumer::finalize(CompilerInstance &ScanInstance,
                                   CacheFS->getCurrentWorkingDirectory().get(),
                                   /*ProduceIncludeTree=*/false);
   }
+
+  if (Mapper)
+    DepscanPrefixMapping::remapInvocationPaths(NewInvocation, *Mapper);
+
   return Error::success();
 }
 

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -257,17 +257,11 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
                       .moveInto(Root))
       return std::move(E);
   } else {
-    if (Error E =
-            Tool.getDependencyTreeFromCompilerInvocation(
-                    std::move(ScanInvocation), WorkingDirectory, DiagsConsumer,
-                    VerboseOS,
-                    /*DiagGenerationAsCompilation*/ true,
-                    [&](const llvm::vfs::CachedDirectoryEntry &Entry,
-                        SmallVectorImpl<char> &Storage) {
-                      return static_cast<llvm::TreePathPrefixMapper &>(Mapper)
-                          .mapDirEntry(Entry, Storage);
-                    })
-                .moveInto(Root))
+    if (Error E = Tool.getDependencyTreeFromCompilerInvocation(
+                          std::move(ScanInvocation), WorkingDirectory,
+                          DiagsConsumer, VerboseOS,
+                          /*DiagGenerationAsCompilation*/ true, PrefixMapping)
+                      .moveInto(Root))
       return std::move(E);
   }
 

--- a/clang/test/ClangScanDeps/cas-fs-prefix-mapping.c
+++ b/clang/test/ClangScanDeps/cas-fs-prefix-mapping.c
@@ -1,0 +1,96 @@
+// Test path prefix-mapping when using a cas-fs with clang-scan-deps in
+// tree, full-tree, and full dependencies modes.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%t|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb.json.template > %t/cdb.json
+
+// == Tree
+// Ensure the filesystem has the mapped paths.
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-tree -cas-path %t/cas \
+// RUN:    -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:  | sed -E 's/tree ([^ ]+) for.*/\1/' > %t/tree_id.txt
+// RUN: llvm-cas -cas %t/cas -ls-tree-recursive @%t/tree_id.txt > %t/tree_result.txt
+// RUN: FileCheck %s -input-file %t/tree_result.txt -check-prefix=FILES
+
+// FILES: file llvmcas://{{.*}} /^sdk/usr/include/stdlib.h
+// FILES: file llvmcas://{{.*}} /^src/t.c
+// FILES: file llvmcas://{{.*}} /^src/top.h
+// FILES: file llvmcas://{{.*}} /^tc/lib/clang/{{.*}}/include/stdarg.h
+
+// == Full Tree
+// This should have the same filesystem as above, and we also check the command-
+// line.
+
+// RUN: cat %t/tree_id.txt > %t/full_tree_result.txt
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-tree-full -cas-path %t/cas \
+// RUN:    -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:  >> %t/full_tree_result.txt
+// RUN: FileCheck %s -input-file %t/full_tree_result.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK
+
+// == Full
+// Same as full tree.
+
+// RUN: cat %t/tree_id.txt > %t/full_result.txt
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-full -cas-path %t/cas \
+// RUN:    -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:  >> %t/full_result.txt
+// RUN: FileCheck %s -input-file %t/full_result.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK
+
+// CHECK: [[MAPPED_FS_ID:llvmcas://[[:xdigit:]]+]]
+// CHECK:      "modules": []
+// CHECK:      "translation-units": [
+// CHECK:        {
+// CHECK:          "commands": [
+// CHECK:            {
+// CHECK:              "casfs-root-id": "[[MAPPED_FS_ID]]"
+// CHECK:              "clang-module-deps": []
+// CHECK:              "command-line": [
+// CHECK:                "-fcas-path"
+// CHECK-NEXT:           "[[PREFIX]]/cas"
+// CHECK:                "-fcas-fs"
+// CHECK-NEXT:           "[[MAPPED_FS_ID]]"
+// CHECK:                "-fcas-fs-working-directory"
+// CHECK-NEXT:           "/^src"
+// CHECK:                "-x"
+// CHECK-NEXT:           "c"
+// CHECK-NEXT:           "/^src/t.c"
+// CHECK:                "-isysroot"
+// CHECK-NEXT:           "/^sdk"
+// CHECK:                "-resource-dir"
+// CHECK-NEXT:           "/^tc/lib/clang/{{.*}}"
+// CHECK:                "-isystem"
+// CHECK-NEXT:           "/^sdk/usr/local/include
+// CHECK:                "-isystem"
+// CHECK-NEXT:           "/^tc/lib/clang/{{.*}}/include"
+// CHECK:                "-internal-externc-isystem"
+// CHECK-NEXT:           "/^sdk/usr/include"
+// CHECK:                "-fdebug-compilation-dir=/^src"
+// CHECK:                "-fcoverage-compilation-dir=/^src"
+// CHECK-NOT: [[PREFIX]]
+// CHECK-NOT: [[SDK_PREFIX]]
+// CHECK:              ]
+// CHECK:              "file-deps": [
+// CHECK:                "[[PREFIX]]/t.c"
+// CHECK:                "[[PREFIX]]/top.h"
+// CHECK:                "{{.*}}include/stdarg.h"
+// CHECK:                "[[SDK_PREFIX]]/usr/include/stdlib.h"
+// CHECK:              ]
+// CHECK:              "input-file": "[[PREFIX]]/t.c"
+
+//--- cdb.json.template
+[
+  {
+    "directory": "DIR",
+    "command": "CLANG -fsyntax-only DIR/t.c -target x86_64-apple-macos11 -isysroot SDK",
+    "file": "DIR/t.c"
+  }
+]
+
+//--- t.c
+#include "top.h"
+
+//--- top.h
+#include <stdarg.h>
+#include <stdlib.h>

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -941,8 +941,8 @@ int main(int argc, const char **argv) {
                                              Errs))
             HadErrors = true;
         } else if (Format == ScanningOutputFormat::Tree) {
-          auto MaybeTree =
-              WorkerTools[I]->getDependencyTree(Input->CommandLine, CWD);
+          auto MaybeTree = WorkerTools[I]->getDependencyTree(
+              Input->CommandLine, CWD, PrefixMapping);
           std::unique_lock<std::mutex> LockGuard(Lock);
           TreeResults.emplace_back(LocalIndex, std::move(Filename),
                                    std::move(MaybeTree));
@@ -963,7 +963,7 @@ int main(int argc, const char **argv) {
         } else {
           auto MaybeFullDeps = WorkerTools[I]->getFullDependencies(
               Input->CommandLine, CWD, AlreadySeenModules, LookupOutput,
-              MaybeModuleName);
+              MaybeModuleName, PrefixMapping);
           if (handleFullDependencyToolResult(Filename, MaybeFullDeps, FD,
                                              LocalIndex, DependencyOS, Errs))
             HadErrors = true;


### PR DESCRIPTION
### [clang][deps][cas] Perform prefix mapping inside FullDependencyConsumer

This makes FullDependencyConsumer behave more like the include-tree
consumer, which does prefix mapping internally rather than via callback.
This is in preparation for expanding the availability of prefix mapping
to all users of the FullDependenciesConsumer rather than only in
ScanAndUpdateArgs.

Note: there is some duplication of prefix mappers in scanAndUpdateArgs
because it is prefix-mapping a different CompilerInvocation than the one
that is inside the consumer. That duplication is the same for the
existing include-tree code path.

### [clang][deps][cas] Add prefix mapping support to the cas-fs caching modes

Previously, cc1depscan supported prefix mapping for cas-fs and
include-tree, but clang-scan-deps only supported prefix mapping for
include-tree. Now it supports both.