### PR TITLE
[unittest] Fix a potential hang in CASTest

### DIFF
--- a/llvm/unittests/CAS/LazyAtomicPointerTest.cpp
+++ b/llvm/unittests/CAS/LazyAtomicPointerTest.cpp
@@ -60,7 +60,7 @@ TEST(LazyAtomicPointer, BusyState) {
 
   // Wait for busy state.
   std::unique_lock<std::mutex> LBusy(BusyLock);
-  Busy.wait(LBusy);
+  Busy.wait(LBusy, [&]() { return IsBusy; });
   int *ExistingValue = nullptr;
   // Busy state will not exchange the value.
   EXPECT_FALSE(Ptr.compare_exchange_weak(ExistingValue, nullptr));


### PR DESCRIPTION
Fix a wrong use of conditional variable that can cause the test to hang forever in rare conditions due to spurious wake-up calls.

rdar://104749939