### PR TITLE
Don't flag memory-only mach-o corefiles as invalid

### DIFF
--- a/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
+++ b/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
@@ -483,13 +483,6 @@ Status ProcessMachCore::DoLoadCore() {
     return error;
   }
 
-  if (core_objfile->GetNumThreadContexts() == 0) {
-    error.SetErrorString("core file doesn't contain any LC_THREAD load "
-                         "commands, or the LC_THREAD architecture is not "
-                         "supported in this lldb");
-    return error;
-  }
-
   SetCanJIT(false);
 
   // The corefile's architecture is our best starting point.


### PR DESCRIPTION
Don't flag memory-only mach-o corefiles as invalid

It is possible to have a memory-only mach-o corefile, with the threads provided by an os-plugin thread provider, or a scripted process, in Python.

Differential Revision: https://reviews.llvm.org/D142662 rdar://102579544

(cherry picked from commit 841b26f1d80f69c45bbf2426761f3e3b9c927d86)