### PR TITLE
[cherry-pick][stable/20221013][clang][DebugInfo] Don't canonicalize names in template argument list for alias templates

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -1293,9 +1293,21 @@ llvm::DIType *CGDebugInfo::CreateType(const TemplateSpecializationType *Ty,
 
   SmallString<128> NS;
   llvm::raw_svector_ostream OS(NS);
-  Ty->getTemplateName().print(OS, getPrintingPolicy(),
-                              TemplateName::Qualified::None);
-  printTemplateArgumentList(OS, Ty->template_arguments(), getPrintingPolicy());
+
+  auto PP = getPrintingPolicy();
+  Ty->getTemplateName().print(OS, PP, TemplateName::Qualified::None);
+
+  // Disable PrintCanonicalTypes here because we want
+  // the DW_AT_name to benefit from the TypePrinter's ability
+  // to skip defaulted template arguments.
+  //
+  // FIXME: Once -gsimple-template-names is enabled by default
+  // and we attach template parameters to alias template DIEs
+  // we don't need to worry about customizing the PrintingPolicy
+  // here anymore.
+  PP.PrintCanonicalTypes = false;
+  printTemplateArgumentList(OS, Ty->template_arguments(), PP,
+                            TD->getTemplateParameters());
 
   SourceLocation Loc = AliasDecl->getLocation();
   return DBuilder.createTypedef(Src, OS.str(), getOrCreateFile(Loc),

--- a/clang/test/CodeGenCXX/debug-info-alias.cpp
+++ b/clang/test/CodeGenCXX/debug-info-alias.cpp
@@ -3,6 +3,11 @@
 template<typename T>
 struct foo {
 };
+
+template<typename T, typename T2 = int>
+struct baz {
+};
+
 namespace x {
 // splitting these over multiple lines to make sure the right token is used for
 // the location
@@ -18,6 +23,9 @@ x::bar<int> bi;
 // CHECK: !DIGlobalVariable(name: "bf",{{.*}} type: [[BFLOAT:![0-9]+]]
 // CHECK: [[BFLOAT]] = !DIDerivedType(tag: DW_TAG_typedef, name: "bar<float>"
 x::bar<float> bf;
+// CHECK: !DIGlobalVariable(name: "bz",{{.*}} type: [[BBAZ:![0-9]+]]
+// CHECK: [[BBAZ]] = !DIDerivedType(tag: DW_TAG_typedef, name: "bar<baz<int> >"
+x::bar<baz<int>> bz;
 
 using
 // CHECK: !DIGlobalVariable(name: "n",{{.*}} type: [[NARF:![0-9]+]]


### PR DESCRIPTION
**Summary**

This patch customizes the `CGDebugInfo` printing policy to stop canonicalizing the template arugment list in `DW_AT_name` for alias templates. The motivation for this is that we want to be able to use the `TypePrinter`s support for omitting defaulted template arguments when emitting `DW_AT_name`.

For reference, GCC currently completely omits the template arguments when emitting alias template DIEs.

**Testing**

* Added unit-test

Differential Revision: https://reviews.llvm.org/D142268

(cherry picked from commit bee8860525acbfe33f5b32870ad5e13de07fa6ff)