### PR TITLE
[cherry-pick][stable/20221013][clang][DebugInfo] Backport DW_AT_default_value on template params and simplify logic

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -5634,6 +5634,13 @@ void printTemplateArgumentList(raw_ostream &OS,
                                const PrintingPolicy &Policy,
                                const TemplateParameterList *TPL = nullptr);
 
+/// Make a best-effort determination of whether the type T can be produced by
+/// substituting Args into the default argument of Param.
+bool isSubstitutedDefaultArgument(ASTContext &Ctx, TemplateArgument Arg,
+                                  const NamedDecl *Param,
+                                  ArrayRef<TemplateArgument> Args,
+                                  unsigned Depth);
+
 /// The injected class name of a C++ class template or class
 /// template partial specialization.  Used to record that a type was
 /// spelled with a bare identifier rather than as a template-id; the

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -2029,6 +2029,16 @@ static bool isSubstitutedTemplateArgument(ASTContext &Ctx, TemplateArgument Arg,
     }
   }
 
+  if (Arg.getKind() == TemplateArgument::Integral &&
+      Pattern.getKind() == TemplateArgument::Expression) {
+    Expr const *expr = Pattern.getAsExpr();
+
+    if (!expr->isValueDependent() && expr->isIntegerConstantExpr(Ctx)) {
+      return llvm::APSInt::isSameValue(expr->EvaluateKnownConstInt(Ctx),
+                                       Arg.getAsIntegral());
+    }
+  }
+
   if (Arg.getKind() != Pattern.getKind())
     return false;
 

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -2048,9 +2048,7 @@ static bool isSubstitutedTemplateArgument(ASTContext &Ctx, TemplateArgument Arg,
   return false;
 }
 
-/// Make a best-effort determination of whether the type T can be produced by
-/// substituting Args into the default argument of Param.
-static bool isSubstitutedDefaultArgument(ASTContext &Ctx, TemplateArgument Arg,
+bool clang::isSubstitutedDefaultArgument(ASTContext &Ctx, TemplateArgument Arg,
                                          const NamedDecl *Param,
                                          ArrayRef<TemplateArgument> Args,
                                          unsigned Depth) {

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -2018,7 +2018,7 @@ CGDebugInfo::CollectTemplateParams(Optional<TemplateArgs> OArgs,
     } break;
     case TemplateArgument::Integral: {
       llvm::DIType *TTy = getOrCreateType(TA.getIntegralType(), Unit);
-      if (Args.TList && CGM.getCodeGenOpts().DwarfVersion >= 5)
+      if (Args.TList)
         if (auto *templateType = dyn_cast_or_null<NonTypeTemplateParmDecl>(
                 Args.TList->getParam(i)))
           if (templateType->hasDefaultArgument() &&

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -2091,7 +2091,7 @@ CGDebugInfo::CollectTemplateParams(Optional<TemplateArgs> OArgs,
       TA.getAsTemplate().getAsTemplateDecl()->printQualifiedName(
           OS, getPrintingPolicy());
       TemplateParams.push_back(DBuilder.createTemplateTemplateParameter(
-          TheCU, Name, nullptr, OS.str()));
+          TheCU, Name, nullptr, OS.str(), defaultParameter));
       break;
     }
     case TemplateArgument::Pack:

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -1999,35 +1999,23 @@ CGDebugInfo::CollectTemplateParams(Optional<TemplateArgs> OArgs,
     const TemplateArgument &TA = Args.Args[i];
     StringRef Name;
     bool defaultParameter = false;
-    if (Args.TList)
+    if (Args.TList) {
       Name = Args.TList->getParam(i)->getName();
+
+      NamedDecl const *ND = Args.TList->getParam(i);
+      defaultParameter = clang::isSubstitutedDefaultArgument(
+          CGM.getContext(), TA, ND, Args.Args, Args.TList->getDepth());
+    }
+
     switch (TA.getKind()) {
     case TemplateArgument::Type: {
       llvm::DIType *TTy = getOrCreateType(TA.getAsType(), Unit);
-
-      if (Args.TList)
-        if (auto *templateType =
-                dyn_cast_or_null<TemplateTypeParmDecl>(Args.TList->getParam(i)))
-          if (templateType->hasDefaultArgument())
-            defaultParameter =
-                templateType->getDefaultArgument() == TA.getAsType();
-
       TemplateParams.push_back(DBuilder.createTemplateTypeParameter(
           TheCU, Name, TTy, defaultParameter));
 
     } break;
     case TemplateArgument::Integral: {
       llvm::DIType *TTy = getOrCreateType(TA.getIntegralType(), Unit);
-      if (Args.TList)
-        if (auto *templateType = dyn_cast_or_null<NonTypeTemplateParmDecl>(
-                Args.TList->getParam(i)))
-          if (templateType->hasDefaultArgument() &&
-              !templateType->getDefaultArgument()->isValueDependent())
-            defaultParameter = llvm::APSInt::isSameValue(
-                templateType->getDefaultArgument()->EvaluateKnownConstInt(
-                    CGM.getContext()),
-                TA.getAsIntegral());
-
       TemplateParams.push_back(DBuilder.createTemplateValueParameter(
           TheCU, Name, TTy, defaultParameter,
           llvm::ConstantInt::get(CGM.getLLVMContext(), TA.getAsIntegral())));

--- a/clang/test/CXX/temp/temp.arg/temp.arg.template/p3-0x.cpp
+++ b/clang/test/CXX/temp/temp.arg/temp.arg.template/p3-0x.cpp
@@ -15,7 +15,7 @@ eval<A<int>> eA;
 eval<B<int, float>> eB;
 eval<C<17>> eC; // expected-error{{implicit instantiation of undefined template 'eval<C<17>>'}}
 eval<D<int, 17>> eD; // expected-error{{implicit instantiation of undefined template 'eval<D<int, 17>>'}}
-eval<E<int, float>> eE; // expected-error{{implicit instantiation of undefined template 'eval<E<int, float, 17>>}}
+eval<E<int, float>> eE; // expected-error{{implicit instantiation of undefined template 'eval<E<int, float>>}}
 
 template<template <int ...N> class TT> struct X0 { }; // expected-note{{previous non-type template parameter with type 'int' is here}}
 template<int I, int J, int ...Rest> struct X0a;

--- a/clang/test/CodeGenCXX/debug-info-template-parameter.cpp
+++ b/clang/test/CodeGenCXX/debug-info-template-parameter.cpp
@@ -3,6 +3,7 @@
 
 // RUN: %clang_cc1 -emit-llvm %std_cxx11-14 -dwarf-version=5 -triple x86_64 %s -O0 -disable-llvm-passes -debug-info-kind=standalone -o - | FileCheck %s --check-prefixes=CHECK,PRE17
 // RUN: %clang_cc1 -emit-llvm %std_cxx17- -dwarf-version=5 -triple x86_64 %s -O0 -disable-llvm-passes -debug-info-kind=standalone -o - | FileCheck %s --check-prefixes=CHECK,CXX17
+// RUN: %clang_cc1 -emit-llvm %std_cxx17- -dwarf-version=4 -triple x86_64 %s -O0 -disable-llvm-passes -debug-info-kind=standalone -o - | FileCheck %s --check-prefixes=CHECK,CXX17
 
 // CHECK: DILocalVariable(name: "f1", {{.*}}, type: ![[TEMPLATE_TYPE:[0-9]+]]
 // CHECK: [[TEMPLATE_TYPE]] = {{.*}}!DICompositeType({{.*}}, templateParams: ![[F1_TYPE:[0-9]+]]

--- a/clang/test/CodeGenCXX/debug-info-template-parameter.cpp
+++ b/clang/test/CodeGenCXX/debug-info-template-parameter.cpp
@@ -4,8 +4,6 @@
 // RUN: %clang_cc1 -emit-llvm %std_cxx11-14 -dwarf-version=5 -triple x86_64 %s -O0 -disable-llvm-passes -debug-info-kind=standalone -o - | FileCheck %s --check-prefixes=CHECK,PRE17
 // RUN: %clang_cc1 -emit-llvm %std_cxx17- -dwarf-version=5 -triple x86_64 %s -O0 -disable-llvm-passes -debug-info-kind=standalone -o - | FileCheck %s --check-prefixes=CHECK,CXX17
 // RUN: %clang_cc1 -emit-llvm %std_cxx17- -dwarf-version=4 -triple x86_64 %s -O0 -disable-llvm-passes -debug-info-kind=standalone -o - | FileCheck %s --check-prefixes=CHECK,CXX17
-// RUN: %clang_cc1 %std_cxx17- -dwarf-version=4 -gstrict-dwarf -triple x86_64 %s -O0 -disable-llvm-passes -debug-info-kind=standalone -emit-obj -o - %s | llvm-dwarfdump --debug-info - | FileCheck %s --check-prefixes=DWARF-DUMP,STRICT
-// RUN: %clang_cc1 %std_cxx17- -dwarf-version=4 -triple x86_64 %s -O0 -disable-llvm-passes -debug-info-kind=standalone -emit-obj -o - %s | llvm-dwarfdump --debug-info - | FileCheck %s --check-prefixes=DWARF-DUMP,DWARFv4
 
 // CHECK: DILocalVariable(name: "f1", {{.*}}, type: ![[TEMPLATE_TYPE:[0-9]+]]
 // CHECK: [[TEMPLATE_TYPE]] = {{.*}}!DICompositeType({{.*}}, templateParams: ![[F1_TYPE:[0-9]+]]
@@ -22,25 +20,6 @@
 // CHECK: [[SECOND]] = !DITemplateValueParameter(name: "i", type: !{{[0-9]*}}, defaulted: true, value: i32 3)
 // PRE17: [[THIRD]] = !DITemplateValueParameter(name: "b", type: !{{[0-9]*}}, defaulted: true, value: i8 1)
 // CXX17: [[THIRD]] = !DITemplateValueParameter(name: "b", type: !{{[0-9]*}}, defaulted: true, value: i1 true)
-
-// DWARF-DUMP:       DW_TAG_class_type
-// DWARF-DUMP-LABEL:   DW_AT_name      ("foo<char, 3, true, 1>")
-// DWARF-DUMP:         DW_TAG_template_type_parameter
-// DWARF-DUMP-DAG:       DW_AT_type    ({{.*}} "char")
-// DWARF-DUMP-DAG:       DW_AT_name    ("T")
-// DWARFv4-DAG:          DW_AT_default_value   (true)
-// STRICT-NOT:           DW_AT_default_value
-// DWARF-DUMP:         DW_TAG_template_value_parameter
-// DWARF-DUMP-DAG:       DW_AT_type    ({{.*}} "int")
-// DWARF-DUMP-DAG:       DW_AT_name    ("i")
-// DWARFv4-DAG:          DW_AT_default_value   (true)
-// STRICT-NOT:           DW_AT_default_value   (true)
-// DWARF-DUMP:         DW_TAG_template_value_parameter
-// DWARF-DUMP-DAG:       DW_AT_type    ({{.*}} "bool")
-// DWARF-DUMP-DAG:       DW_AT_name    ("b")
-// DWARFv4-DAG:          DW_AT_default_value   (true)
-// STRICT-NOT:           DW_AT_default_value
-// DWARF-DUMP:           {{DW_TAG|NULL}}
 
 template <typename T = char, int i = 3, bool b = true, int x = sizeof(T)>
 class foo {

--- a/clang/test/CodeGenCXX/debug-info-template-parameter.cpp
+++ b/clang/test/CodeGenCXX/debug-info-template-parameter.cpp
@@ -7,26 +7,33 @@
 
 // CHECK: DILocalVariable(name: "f1", {{.*}}, type: ![[TEMPLATE_TYPE:[0-9]+]]
 // CHECK: [[TEMPLATE_TYPE]] = {{.*}}!DICompositeType({{.*}}, templateParams: ![[F1_TYPE:[0-9]+]]
-// CHECK: [[F1_TYPE]] = !{![[FIRST:[0-9]+]], ![[SECOND:[0-9]+]], ![[THIRD:[0-9]+]], ![[FORTH:[0-9]+]]}
+// CHECK: [[F1_TYPE]] = !{![[FIRST:[0-9]+]], ![[SECOND:[0-9]+]], ![[THIRD:[0-9]+]], ![[FORTH:[0-9]+]], ![[FIFTH:[0-9]+]]}
 // CHECK: [[FIRST]] = !DITemplateTypeParameter(name: "T", type: !{{[0-9]*}})
 // CHECK: [[SECOND]] = !DITemplateValueParameter(name: "i", type: !{{[0-9]*}}, value: i32 6)
 // PRE17: [[THIRD]] = !DITemplateValueParameter(name: "b", type: !{{[0-9]*}}, value: i8 0)
 // CXX17: [[THIRD]] = !DITemplateValueParameter(name: "b", type: !{{[0-9]*}}, value: i1 false)
+// CHECK: [[FIFTH]] = !DITemplateTypeParameter(name: "d", type: !{{[0-9]*}})
 
 // CHECK: DILocalVariable(name: "f2", {{.*}}, type: ![[TEMPLATE_TYPE:[0-9]+]]
 // CHECK: [[TEMPLATE_TYPE]] = {{.*}}!DICompositeType({{.*}}, templateParams: ![[F2_TYPE:[0-9]+]]
-// CHECK: [[F2_TYPE]] = !{![[FIRST:[0-9]+]], ![[SECOND:[0-9]+]], ![[THIRD:[0-9]+]], ![[FORTH:[0-9]+]]}
+// CHECK: [[F2_TYPE]] = !{![[FIRST:[0-9]+]], ![[SECOND:[0-9]+]], ![[THIRD:[0-9]+]], ![[FORTH:[0-9]+]], ![[FIFTH:[0-9]+]]}
 // CHECK: [[FIRST]] = !DITemplateTypeParameter(name: "T", type: !{{[0-9]*}}, defaulted: true)
 // CHECK: [[SECOND]] = !DITemplateValueParameter(name: "i", type: !{{[0-9]*}}, defaulted: true, value: i32 3)
 // PRE17: [[THIRD]] = !DITemplateValueParameter(name: "b", type: !{{[0-9]*}}, defaulted: true, value: i8 1)
 // CXX17: [[THIRD]] = !DITemplateValueParameter(name: "b", type: !{{[0-9]*}}, defaulted: true, value: i1 true)
+// CHECK: [[FIFTH]] = !DITemplateTypeParameter(name: "d", type: !{{[0-9]*}}, defaulted: true)
 
-template <typename T = char, int i = 3, bool b = true, int x = sizeof(T)>
+template <typename T>
+class bar {
+};
+
+template <typename T = char, int i = 3, bool b = true, int x = sizeof(T),
+          typename d = bar<T>>
 class foo {
 };
 
 int main() {
-  foo<int, 6, false, 3> f1;
+  foo<int, 6, false, 3, double> f1;
   foo<> f2;
   return 0;
 }

--- a/clang/test/CodeGenCXX/debug-info-template-parameter.cpp
+++ b/clang/test/CodeGenCXX/debug-info-template-parameter.cpp
@@ -4,6 +4,8 @@
 // RUN: %clang_cc1 -emit-llvm %std_cxx11-14 -dwarf-version=5 -triple x86_64 %s -O0 -disable-llvm-passes -debug-info-kind=standalone -o - | FileCheck %s --check-prefixes=CHECK,PRE17
 // RUN: %clang_cc1 -emit-llvm %std_cxx17- -dwarf-version=5 -triple x86_64 %s -O0 -disable-llvm-passes -debug-info-kind=standalone -o - | FileCheck %s --check-prefixes=CHECK,CXX17
 // RUN: %clang_cc1 -emit-llvm %std_cxx17- -dwarf-version=4 -triple x86_64 %s -O0 -disable-llvm-passes -debug-info-kind=standalone -o - | FileCheck %s --check-prefixes=CHECK,CXX17
+// RUN: %clang_cc1 %std_cxx17- -dwarf-version=4 -gstrict-dwarf -triple x86_64 %s -O0 -disable-llvm-passes -debug-info-kind=standalone -emit-obj -o - %s | llvm-dwarfdump --debug-info - | FileCheck %s --check-prefixes=DWARF-DUMP,STRICT
+// RUN: %clang_cc1 %std_cxx17- -dwarf-version=4 -triple x86_64 %s -O0 -disable-llvm-passes -debug-info-kind=standalone -emit-obj -o - %s | llvm-dwarfdump --debug-info - | FileCheck %s --check-prefixes=DWARF-DUMP,DWARFv4
 
 // CHECK: DILocalVariable(name: "f1", {{.*}}, type: ![[TEMPLATE_TYPE:[0-9]+]]
 // CHECK: [[TEMPLATE_TYPE]] = {{.*}}!DICompositeType({{.*}}, templateParams: ![[F1_TYPE:[0-9]+]]
@@ -20,6 +22,25 @@
 // CHECK: [[SECOND]] = !DITemplateValueParameter(name: "i", type: !{{[0-9]*}}, defaulted: true, value: i32 3)
 // PRE17: [[THIRD]] = !DITemplateValueParameter(name: "b", type: !{{[0-9]*}}, defaulted: true, value: i8 1)
 // CXX17: [[THIRD]] = !DITemplateValueParameter(name: "b", type: !{{[0-9]*}}, defaulted: true, value: i1 true)
+
+// DWARF-DUMP:       DW_TAG_class_type
+// DWARF-DUMP-LABEL:   DW_AT_name      ("foo<char, 3, true, 1>")
+// DWARF-DUMP:         DW_TAG_template_type_parameter
+// DWARF-DUMP-DAG:       DW_AT_type    ({{.*}} "char")
+// DWARF-DUMP-DAG:       DW_AT_name    ("T")
+// DWARFv4-DAG:          DW_AT_default_value   (true)
+// STRICT-NOT:           DW_AT_default_value
+// DWARF-DUMP:         DW_TAG_template_value_parameter
+// DWARF-DUMP-DAG:       DW_AT_type    ({{.*}} "int")
+// DWARF-DUMP-DAG:       DW_AT_name    ("i")
+// DWARFv4-DAG:          DW_AT_default_value   (true)
+// STRICT-NOT:           DW_AT_default_value   (true)
+// DWARF-DUMP:         DW_TAG_template_value_parameter
+// DWARF-DUMP-DAG:       DW_AT_type    ({{.*}} "bool")
+// DWARF-DUMP-DAG:       DW_AT_name    ("b")
+// DWARFv4-DAG:          DW_AT_default_value   (true)
+// STRICT-NOT:           DW_AT_default_value
+// DWARF-DUMP:           {{DW_TAG|NULL}}
 
 template <typename T = char, int i = 3, bool b = true, int x = sizeof(T)>
 class foo {

--- a/clang/test/CodeGenCXX/debug-info-template-parameter.cpp
+++ b/clang/test/CodeGenCXX/debug-info-template-parameter.cpp
@@ -23,8 +23,22 @@
 // CXX17: [[THIRD]] = !DITemplateValueParameter(name: "b", type: !{{[0-9]*}}, defaulted: true, value: i1 true)
 // CHECK: [[FIFTH]] = !DITemplateTypeParameter(name: "d", type: !{{[0-9]*}}, defaulted: true)
 
+// CHECK: DILocalVariable(name: "b1", {{.*}}, type: ![[TEMPLATE_TYPE:[0-9]+]]
+// CHECK: [[TEMPLATE_TYPE]] = {{.*}}!DICompositeType({{.*}}, templateParams: ![[B1_TYPE:[0-9]+]]
+// CHECK: [[B1_TYPE]] = !{![[FIRST:[0-9]+]]}
+// CHECK: [[FIRST]] = !DITemplateValueParameter(tag: DW_TAG_GNU_template_template_param, name: "CT", value: !"qux")
+
+// CHECK: DILocalVariable(name: "b2", {{.*}}, type: ![[TEMPLATE_TYPE:[0-9]+]]
+// CHECK: [[TEMPLATE_TYPE]] = {{.*}}!DICompositeType({{.*}}, templateParams: ![[B2_TYPE:[0-9]+]]
+// CHECK: [[B2_TYPE]] = !{![[FIRST:[0-9]+]]}
+// CHECK: [[FIRST]] = !DITemplateValueParameter(tag: DW_TAG_GNU_template_template_param, name: "CT", defaulted: true, value: !"bar")
+
 template <typename T>
 class bar {
+};
+
+template <typename T>
+class qux {
 };
 
 template <typename T = char, int i = 3, bool b = true, int x = sizeof(T),
@@ -32,8 +46,14 @@ template <typename T = char, int i = 3, bool b = true, int x = sizeof(T),
 class foo {
 };
 
+template <template <typename T> class CT = bar>
+class baz {
+};
+
 int main() {
   foo<int, 6, false, 3, double> f1;
   foo<> f2;
+  baz<qux> b1;
+  baz<> b2;
   return 0;
 }

--- a/clang/test/CodeGenObjCXX/encode.mm
+++ b/clang/test/CodeGenObjCXX/encode.mm
@@ -90,8 +90,11 @@ namespace rdar9357400 {
   typedef vector< float,  fixed<4> > vector4f;
 
   // FIXME: This difference is due to D76801. It was probably an unintentional change. Maybe we want to undo it?
-  // CHECKCXX98: @_ZN11rdar93574002ggE ={{.*}} constant [49 x i8] c"{vector<float, rdar9357400::fixed<4, -1> >=[4f]}\00"
-  // CHECKCXX20: @_ZN11rdar93574002ggE ={{.*}} constant [48 x i8] c"{vector<float, rdar9357400::fixed<4, -1>>=[4f]}\00"
+  // @encoding for C++ is dependent on the TypePrinter implementation, which is a known issue. But since there
+  // are currently no system frameworks that vend Objective-C++ types, a potential ABI break caused by changes
+  // to the TypePrinter should not be a concern.
+  // CHECKCXX98: @_ZN11rdar93574002ggE ={{.*}} constant [45 x i8] c"{vector<float, rdar9357400::fixed<4> >=[4f]}\00"
+  // CHECKCXX20: @_ZN11rdar93574002ggE ={{.*}} constant [44 x i8] c"{vector<float, rdar9357400::fixed<4>>=[4f]}\00"
   extern const char gg[] = @encode(vector4f);
 }
 

--- a/clang/test/Misc/diag-template-diffing.cpp
+++ b/clang/test/Misc/diag-template-diffing.cpp
@@ -1415,8 +1415,8 @@ B<> b3 = B<const A<>>();
 B<const A<>> b4 = B<>();
 // CHECK-ELIDE-NOTREE: error: no viable conversion from 'A<(default) 0>' to 'A<1>'
 // CHECK-ELIDE-NOTREE: error: no viable conversion from 'A<1>' to 'A<(default) 0>'
-// CHECK-ELIDE-NOTREE: error: no viable conversion from 'B<int>' to 'B<(default) ZeroArgs::A<0>>'
-// CHECK-ELIDE-NOTREE: error: no viable conversion from 'B<(default) ZeroArgs::A<0>>' to 'B<int>'
+// CHECK-ELIDE-NOTREE: error: no viable conversion from 'B<int>' to 'B<(default) ZeroArgs::A<>>'
+// CHECK-ELIDE-NOTREE: error: no viable conversion from 'B<(default) ZeroArgs::A<>>' to 'B<int>'
 // CHECK-ELIDE-NOTREE: error: no viable conversion from 'B<const A<...>>' to 'B<A<...>>'
 // CHECK-ELIDE-NOTREE: error: no viable conversion from 'B<A<...>>' to 'B<const A<...>>'
 }

--- a/clang/test/Misc/diag-template.cpp
+++ b/clang/test/Misc/diag-template.cpp
@@ -26,7 +26,7 @@ namespace default_args {
     f(ups).f(); // expected-note {{in instantiation of member function 'default_args::unique_ptr<default_args::basic_string<char>>::f' requested here}}
   }
 
-  template<int A, int B = A> struct Z { int error[B]; }; // expected-error {{negative size}}
+  template<int A, int B = A, int C = 42> struct Z { int error[B]; }; // expected-error {{negative size}}
   Z<-1> z; // expected-note {{in instantiation of template class 'default_args::Z<-1>' requested here}}
 
   template<template<typename> class A = allocator, template<typename> class B = A> struct Q {};

--- a/clang/test/SemaCUDA/device-use-host-var.cu
+++ b/clang/test/SemaCUDA/device-use-host-var.cu
@@ -272,7 +272,7 @@ not_a_texture<int> not_a_texture<int>::ref; // dev-note {{host variable declared
 
 __device__ void test_not_a_texture() {
   not_a_texture<int> inst;
-  inst.c(); // dev-note {{in instantiation of member function 'not_a_texture<int, 1, 1>::c' requested here}}
+  inst.c(); // dev-note {{in instantiation of member function 'not_a_texture<int>::c' requested here}}
 }
 
 // Test static variable in host function used by device function.

--- a/clang/test/SemaCXX/co_await-range-for-exp-namespace.cpp
+++ b/clang/test/SemaCXX/co_await-range-for-exp-namespace.cpp
@@ -151,7 +151,7 @@ template <class T>
 ForLoopAwaiterCoawaitLookup test_coawait_lookup(T) {
   Range<T> R;
   for co_await (auto i : R) {}
-  // expected-error@-1 {{no member named 'await_ready' in 'CoawaitTag<Iter<int>, false>'}}
+  // expected-error@-1 {{no member named 'await_ready' in 'CoawaitTag<Iter<int>>'}}
 }
 template ForLoopAwaiterCoawaitLookup test_coawait_lookup(int); // expected-note {{requested here}}
 

--- a/clang/test/SemaCXX/co_await-range-for.cpp
+++ b/clang/test/SemaCXX/co_await-range-for.cpp
@@ -150,7 +150,7 @@ template <class T>
 ForLoopAwaiterCoawaitLookup test_coawait_lookup(T) {
   Range<T> R;
   for co_await(auto i : R) {} // expected-warning {{'for co_await' belongs to CoroutineTS instead of C++20, which is deprecated}}
-  // expected-error@-1 {{no member named 'await_ready' in 'CoawaitTag<Iter<int>, false>'}}
+  // expected-error@-1 {{no member named 'await_ready' in 'CoawaitTag<Iter<int>>'}}
 }
 template ForLoopAwaiterCoawaitLookup test_coawait_lookup(int); // expected-note {{requested here}}
 

--- a/clang/test/SemaCXX/coroutines-exp-namespace.cpp
+++ b/clang/test/SemaCXX/coroutines-exp-namespace.cpp
@@ -1046,7 +1046,7 @@ struct NoCopy {
 };
 template <class T, class U>
 void test_dependent_param(T t, U) {
-  // expected-error@-1 {{call to deleted constructor of 'NoCopy<0>'}}
+  // expected-error@-1 {{call to deleted constructor of 'NoCopy<>'}}
   // expected-error@-2 {{call to deleted constructor of 'NoCopy<1>'}}
   ((void)t);
   co_return 42;

--- a/clang/test/SemaCXX/coroutines.cpp
+++ b/clang/test/SemaCXX/coroutines.cpp
@@ -1067,7 +1067,7 @@ struct NoCopy {
 };
 template <class T, class U>
 void test_dependent_param(T t, U) {
-  // expected-error@-1 {{call to deleted constructor of 'NoCopy<0>'}}
+  // expected-error@-1 {{call to deleted constructor of 'NoCopy<>'}}
   // expected-error@-2 {{call to deleted constructor of 'NoCopy<1>'}}
   ((void)t);
   co_return 42;

--- a/clang/test/SemaCXX/cxx11-call-to-deleted-constructor.cpp
+++ b/clang/test/SemaCXX/cxx11-call-to-deleted-constructor.cpp
@@ -34,7 +34,7 @@ void getLaplacianClosedForm()
 {
     Matrix<double> winI(0, 3);
     RGBFValue* inputPreL;
-    winI = { inputPreL->at() }; // expected-error {{call to deleted constructor of 'cva::Matrix<double, 0, 0> &&'}}
+    winI = { inputPreL->at() }; // expected-error {{call to deleted constructor of 'cva::Matrix<double> &&'}}
 }
 
 }

--- a/clang/test/SemaTemplate/deduction-guide.cpp
+++ b/clang/test/SemaTemplate/deduction-guide.cpp
@@ -233,7 +233,7 @@ F s(0);
 // CHECK: | `-CXXBoolLiteralExpr {{.*}} 'bool' false
 // CHECK: |-CXXDeductionGuideDecl {{.*}} implicit <deduction guide for F> 'auto (type-parameter-0-1) -> F<>'
 // CHECK: | `-ParmVarDecl {{.*}} 'type-parameter-0-1'
-// CHECK: `-CXXDeductionGuideDecl {{.*}} implicit <deduction guide for F> 'auto (int) -> F<'x'>'
+// CHECK: `-CXXDeductionGuideDecl {{.*}} implicit <deduction guide for F> 'auto (int) -> F<>'
 // CHECK:   |-TemplateArgument integral 120
 // CHECK:   |-TemplateArgument type 'int'
 // CHECK:   | `-BuiltinType {{.*}} 'int'

--- a/clang/test/SemaTemplate/dependent-names.cpp
+++ b/clang/test/SemaTemplate/dependent-names.cpp
@@ -338,7 +338,7 @@ template < unsigned > struct X {
   struct Y: Y<dim> { }; // expected-error{{circular inheritance between 'Y<dim>' and 'Y<dim>'}}
 };
 typedef X<3> X3;
-X3::Y<>::iterator it; // expected-error {{no type named 'iterator' in 'PR11421::X<3>::Y<3>'}}
+X3::Y<>::iterator it; // expected-error {{no type named 'iterator' in 'PR11421::X<3>::Y<>'}}
 }
 
 namespace rdar12629723 {

--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -522,10 +522,10 @@ namespace llvm {
     /// \param Name         Value parameter name.
     /// \param Ty           Parameter type.
     /// \param Val          The fully qualified name of the template.
-    DITemplateValueParameter *createTemplateTemplateParameter(DIScope *Scope,
-                                                              StringRef Name,
-                                                              DIType *Ty,
-                                                              StringRef Val);
+    /// \param IsDefault    Parameter is default or not.
+    DITemplateValueParameter *
+    createTemplateTemplateParameter(DIScope *Scope, StringRef Name, DIType *Ty,
+                                    StringRef Val, bool IsDefault = false);
 
     /// Create debugging information for a template parameter pack.
     /// \param Scope        Scope in which this type is defined.

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -1070,7 +1070,7 @@ void DwarfUnit::constructTemplateTypeParameterDIE(
     addType(ParamDIE, TP->getType());
   if (!TP->getName().empty())
     addString(ParamDIE, dwarf::DW_AT_name, TP->getName());
-  if (TP->isDefault() && (DD->getDwarfVersion() >= 5))
+  if (TP->isDefault() && isCompatibleWithVersion(5))
     addFlag(ParamDIE, dwarf::DW_AT_default_value);
 }
 
@@ -1084,7 +1084,7 @@ void DwarfUnit::constructTemplateValueParameterDIE(
     addType(ParamDIE, VP->getType());
   if (!VP->getName().empty())
     addString(ParamDIE, dwarf::DW_AT_name, VP->getName());
-  if (VP->isDefault() && (DD->getDwarfVersion() >= 5))
+  if (VP->isDefault() && isCompatibleWithVersion(5))
     addFlag(ParamDIE, dwarf::DW_AT_default_value);
   if (Metadata *Val = VP->getValue()) {
     if (ConstantInt *CI = mdconst::dyn_extract<ConstantInt>(Val))
@@ -1861,4 +1861,8 @@ void DwarfUnit::addRnglistsBase() {
 
 void DwarfTypeUnit::finishNonUnitTypeDIE(DIE& D, const DICompositeType *CTy) {
   DD->getAddressPool().resetUsedFlag(true);
+}
+
+bool DwarfUnit::isCompatibleWithVersion(uint16_t Version) const {
+  return !Asm->TM.Options.DebugStrictDwarf || DD->getDwarfVersion() >= Version;
 }

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
@@ -350,6 +350,10 @@ private:
 
   virtual bool isDwoUnit() const = 0;
   const MCSymbol *getCrossSectionRelativeBaseAddress() const override;
+
+  /// Returns 'true' if the current DwarfVersion is compatible
+  /// with the specified \p Version.
+  bool isCompatibleWithVersion(uint16_t Version) const;
 };
 
 class DwarfTypeUnit final : public DwarfUnit {

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -484,10 +484,11 @@ DIBuilder::createTemplateValueParameter(DIScope *Context, StringRef Name,
 
 DITemplateValueParameter *
 DIBuilder::createTemplateTemplateParameter(DIScope *Context, StringRef Name,
-                                           DIType *Ty, StringRef Val) {
+                                           DIType *Ty, StringRef Val,
+                                           bool IsDefault) {
   return createTemplateValueParameterHelper(
       VMContext, dwarf::DW_TAG_GNU_template_template_param, Context, Name, Ty,
-      false, MDString::get(VMContext, Val));
+      IsDefault, MDString::get(VMContext, Val));
 }
 
 DITemplateValueParameter *

--- a/llvm/test/DebugInfo/X86/debug-info-default-template-parameter.ll
+++ b/llvm/test/DebugInfo/X86/debug-info-default-template-parameter.ll
@@ -1,0 +1,98 @@
+; Tests that DW_AT_default_value is correctly emitted for C++ template
+; parameters that are defaulted.
+;
+; ModuleID = 'debug-info-template-parameter.cpp'
+;
+; template <typename T = char, int i = 3, bool b = true, int x = sizeof(T)>
+; class foo {
+; };
+; 
+; int main() {
+;   foo<int, 6, false, 3> f1;
+;   foo<> f2;
+;   return 0;
+; }
+;
+; RUN: llc -filetype=obj -dwarf-version=4 %s -o - | llvm-dwarfdump - --debug-info | FileCheck %s --check-prefixes=DWARF-DUMP,DWARFv4
+; RUN: llc -filetype=obj -dwarf-version=4 -strict-dwarf=true %s -o - | llvm-dwarfdump - --debug-info | FileCheck %s --check-prefixes=DWARF-DUMP,STRICT
+
+; DWARF-DUMP:       DW_TAG_class_type
+; DWARF-DUMP-LABEL:   DW_AT_name      ("foo<char, 3, true, 1>")
+; DWARF-DUMP:         DW_TAG_template_type_parameter
+; DWARF-DUMP-DAG:       DW_AT_type    ({{.*}} "char")
+; DWARF-DUMP-DAG:       DW_AT_name    ("T")
+; DWARFv4-DAG:          DW_AT_default_value   (true)
+; STRICT-NOT:           DW_AT_default_value
+; DWARF-DUMP:         DW_TAG_template_value_parameter
+; DWARF-DUMP-DAG:       DW_AT_type    ({{.*}} "int")
+; DWARF-DUMP-DAG:       DW_AT_name    ("i")
+; DWARFv4-DAG:          DW_AT_default_value   (true)
+; STRICT-NOT:           DW_AT_default_value   (true)
+; DWARF-DUMP:         DW_TAG_template_value_parameter
+; DWARF-DUMP-DAG:       DW_AT_type    ({{.*}} "bool")
+; DWARF-DUMP-DAG:       DW_AT_name    ("b")
+; DWARFv4-DAG:          DW_AT_default_value   (true)
+; STRICT-NOT:           DW_AT_default_value
+; DWARF-DUMP:           {{DW_TAG|NULL}}
+
+source_filename = "/tmp/debug-info-template-parameter.cpp"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64"
+
+%class.foo = type { i8 }
+%class.foo.0 = type { i8 }
+
+; Function Attrs: mustprogress noinline norecurse nounwind optnone
+define dso_local noundef i32 @main() #0 !dbg !6 {
+entry:
+  %retval = alloca i32, align 4
+  %f1 = alloca %class.foo, align 1
+  %f2 = alloca %class.foo.0, align 1
+  store i32 0, ptr %retval, align 4
+  call void @llvm.dbg.declare(metadata ptr %f1, metadata !12, metadata !DIExpression()), !dbg !20
+  call void @llvm.dbg.declare(metadata ptr %f2, metadata !21, metadata !DIExpression()), !dbg !29
+  ret i32 0, !dbg !30
+}
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
+
+attributes #0 = { mustprogress noinline norecurse nounwind optnone "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-features"="+cx8,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+
+!llvm.dbg.cu = !{!0}
+!llvm.linker.options = !{}
+!llvm.module.flags = !{!2, !3, !4}
+!llvm.ident = !{!5}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 16.0.0", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "/tmp/debug-info-template-parameter.cpp", directory: "/")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{!"clang version 16.0.0"}
+!6 = distinct !DISubprogram(name: "main", scope: !7, file: !7, line: 49, type: !8, scopeLine: 49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !11)
+!7 = !DIFile(filename: "/tmp/debug-info-template-parameter.cpp", directory: "/")
+!8 = !DISubroutineType(types: !9)
+!9 = !{!10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !{}
+!12 = !DILocalVariable(name: "f1", scope: !6, file: !7, line: 50, type: !13)
+!13 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "foo<int, 6, false, 3>", file: !7, line: 46, size: 8, flags: DIFlagTypePassByValue, elements: !11, templateParams: !14, identifier: "_ZTS3fooIiLi6ELb0ELi3EE")
+!14 = !{!15, !16, !17, !19}
+!15 = !DITemplateTypeParameter(name: "T", type: !10)
+!16 = !DITemplateValueParameter(name: "i", type: !10, value: i32 6)
+!17 = !DITemplateValueParameter(name: "b", type: !18, value: i1 false)
+!18 = !DIBasicType(name: "bool", size: 8, encoding: DW_ATE_boolean)
+!19 = !DITemplateValueParameter(name: "x", type: !10, value: i32 3)
+!20 = !DILocation(line: 50, column: 25, scope: !6)
+!21 = !DILocalVariable(name: "f2", scope: !6, file: !7, line: 51, type: !22)
+!22 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "foo<char, 3, true, 1>", file: !7, line: 46, size: 8, flags: DIFlagTypePassByValue, elements: !11, templateParams: !23, identifier: "_ZTS3fooIcLi3ELb1ELi1EE")
+!23 = !{!24, !26, !27, !28}
+!24 = !DITemplateTypeParameter(name: "T", type: !25, defaulted: true)
+!25 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_signed_char)
+!26 = !DITemplateValueParameter(name: "i", type: !10, defaulted: true, value: i32 3)
+!27 = !DITemplateValueParameter(name: "b", type: !18, defaulted: true, value: i1 true)
+!28 = !DITemplateValueParameter(name: "x", type: !10, value: i32 1)
+!29 = !DILocation(line: 51, column: 9, scope: !6)
+!30 = !DILocation(line: 52, column: 3, scope: !6)


### PR DESCRIPTION
This series of cherry-picks makes clang attach `DW_AT_default_value` to defaulted template parameters (a DWARFv5 feature) regardless of DWARF version.

Additionally, we simplify and extend the emission of this attribute to more cases.