### PR TITLE
[CAS/LazyMappedFileRegion] Fix racing issue during the initial creation of a database file

### DIFF
--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -1200,7 +1200,10 @@ std::error_code getRealPathFromHandle(file_t Handle,
 /// Lock the file.
 ///
 /// This function acts as @ref tryLockFile but it waits infinitely.
-std::error_code lockFile(int FD);
+/// \param FD file descriptor to use for locking.
+/// \param Exclusive if \p true use exclusive/writer lock, otherwise use
+/// shared/reader lock.
+std::error_code lockFile(int FD, bool Exclusive = true);
 
 /// Unlock the file.
 ///

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -1260,10 +1260,10 @@ std::error_code tryLockFile(int FD, std::chrono::milliseconds Timeout) {
   return make_error_code(errc::no_lock_available);
 }
 
-std::error_code lockFile(int FD) {
+std::error_code lockFile(int FD, bool Exclusive) {
   struct flock Lock;
   memset(&Lock, 0, sizeof(Lock));
-  Lock.l_type = F_WRLCK;
+  Lock.l_type = Exclusive ? F_WRLCK : F_RDLCK;
   Lock.l_whence = SEEK_SET;
   Lock.l_start = 0;
   Lock.l_len = 0;

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -1305,8 +1305,8 @@ std::error_code tryLockFile(int FD, std::chrono::milliseconds Timeout) {
   return mapWindowsError(ERROR_LOCK_VIOLATION);
 }
 
-std::error_code lockFile(int FD) {
-  DWORD Flags = LOCKFILE_EXCLUSIVE_LOCK;
+std::error_code lockFile(int FD, bool Exclusive) {
+  DWORD Flags = Exclusive ? LOCKFILE_EXCLUSIVE_LOCK : 0;
   OVERLAPPED OV = {};
   file_t File = convertFDToNativeFile(FD);
   if (::LockFileEx(File, Flags, 0, MAXDWORD, MAXDWORD, &OV))

--- a/llvm/test/CAS/Inputs/cas-creation-stress-test.sh
+++ b/llvm/test/CAS/Inputs/cas-creation-stress-test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# parameters are: <llvm-cas path> <CAS path> <file to ingest> <number of repeats>
+LLVM_CAS_TOOL=$1
+CAS_PATH=$2
+INGEST_FILE=$3
+NUM_REPEAT=$4
+
+set -e
+
+for c in $(seq 1 $NUM_REPEAT); do
+  rm -rf $CAS_PATH
+
+  pids=""
+  for x in $(seq 1 10); do
+    $LLVM_CAS_TOOL --ingest --data $INGEST_FILE --cas $CAS_PATH &
+    pids="$pids $!"
+  done
+
+  for pid in $pids; do
+    wait "$pid"
+  done
+done

--- a/llvm/test/CAS/databasefile-concurrent-creation.c
+++ b/llvm/test/CAS/databasefile-concurrent-creation.c
@@ -1,0 +1,10 @@
+// REQUIRES: ondisk_cas, shell
+
+// RUN: mkdir -p %t
+
+// This uses a script that triggers parallel `llvm-cas` invocations on an empty directory.
+// It's intended to ensure there are no racing issues at creation time that will create failures.
+// The last parameter controls how many times it will try.
+// To stress-test this extensively change it locally and pass a large number.
+
+// RUN: %S/Inputs/cas-creation-stress-test.sh llvm-cas %t/cas %s 5


### PR DESCRIPTION
There's a racing issue when multiple processes try to create a new database file on the same directory. Due to insufficient synchronization one process may try to use a newly created database file that another process haven't finished initializing yet. This can manifest with errors like "database: bad magic" or crashes.

I've verified the fix with a long-running script that stress-tests database file creation, this is not easily reproducible via a unit test.

rdar://104829275