### PR TITLE
[AArch64] Reject ptrauth global refs. as GOT-equivalent candidates.

### DIFF
--- a/llvm/test/CodeGen/AArch64/ptrauth-got-equivalent.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-got-equivalent.ll
@@ -1,0 +1,15 @@
+; RUN: llc %s -o - -mtriple=arm64e-apple-ios | FileCheck %s
+
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+
+@foo = external global i64, align 8
+@foo.ptrauth = private constant { ptr, i32, i64, i64 } { ptr @foo, i32 2, i64 0, i64 12345 }, section "llvm.ptrauth", align 8
+
+; CHECK-LABEL: l_got.foo:
+; CHECK-NEXT: 	.quad	_foo@AUTH(da,12345)
+
+; CHECK-LABEL: _foo_ref:
+; CHECK-NEXT: 	.long	l_got.foo-_foo_ref
+
+@got.foo = private unnamed_addr constant ptr @foo.ptrauth
+@foo_ref = constant i32 trunc (i64 sub (i64 ptrtoint (ptr @got.foo to i64), i64 ptrtoint (ptr @foo_ref to i64)) to i32), align 8


### PR DESCRIPTION
AsmPrinter has the ability to recognize "GOT equivalents", which are symbols that just point to another symbol and are used in 32-bit relative-offset references.  When possible, we form GOTPCREL relocations to the pointed-to symbol, which lets us avoid a global needing a bind in its initializer symbol relocation at load-time.

If the GOTPCREL relocation isn't possible, we can fallback to the global we emitted as a GOT equivalent placeholder.  The reference to it can still be a 32-bit link-time relative offset, and we still need to pay for an additional bind at load-time, but it's just one more rather than one for each use.

ptrauth puts a wrench in all that: if the symbol reference is intended to be signed, we need a way to express "a GOTPCREL reference to a symbol but also sign the symbol's address in this funky way".  We don't have the bits to encode all that.

Concretely, this means we don't have a way to encode ptrauth GOT-equivalents today.  We may have that in the future: rdar://84309968.

So far, we have gotten lucky and these ptrauth GOT-equivalents have been silently rejected as ineligible for GOTPCREL, thanks to the weird struct type the ptrauth wrapper references have.  This hid the ptrauth wrappers from the `isa<GlobalValue>` isGOTEquivalentCandidate does, since the ptrauth wrappers always needed a pointer bitcast.

However, with opaque pointers, we don't need the pointer bitcast anymore, and the direct use of the wrapper global as a `ptr` passes the `isa<GlobalValue>` check.
We end up trying to turn that into a GOTPCREL reference, but we're still pointing to the fake ptrauth wrapper symbol.  The GOTPCREL reference is done using raw MCSymbols and MCExprs.  But the ptrauth wrapper symbol lowering (to MCAuthExprs and __auth_ptr symbols) is done when lowering the ConstantExpr initializer.  So it never happens for GOT equivalents, and we end up with missing symbols.

Reject ptrauth wrapper globals outright as GOT equivalent candidates. We can somehow support the combination separately.

rdar://101041228
rdar://103610908