### PR TITLE
[lldb] Remove unimplemented SBTraceCursor::GetExecutionContextRef

### DIFF
--- a/lldb/include/lldb/API/SBTraceCursor.h
+++ b/lldb/include/lldb/API/SBTraceCursor.h
@@ -124,11 +124,6 @@ public:
   ///     \b true if and only if the cursor ends up pointing to a valid item.
   bool Seek(int64_t offset, lldb::TraceCursorSeekType origin);
 
-  /// \return
-  ///   The \a ExecutionContextRef of the backing thread from the creation time
-  ///   of this cursor.
-  SBExecutionContext &GetExecutionContextRef();
-
   /// Trace item information (instructions, errors and events)
   /// \{
 


### PR DESCRIPTION
Fixes TAPI verification error:

  SBTraceCursor.h:130:23: error: declaration has external linkage, but dynamic library doesn't have symbol '__ZN4lldb13SBTraceCursor22GetExecutionContextRefEv'
  SBExecutionContext &GetExecutionContextRef();
                      ^

Remove the method as it doesn't have an implementation.

(cherry picked from commit d6eaaa1f13a9f7c3d3f87257ea2cf18e0dc13d86)
