### PR TITLE
[lldb] Use ${CMAKE_COMMAND} -E remove instead of remove_directory

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -301,10 +301,8 @@ function(lldb_add_to_buildtree_lldb_framework name subdir)
 
   # Create a custom target to remove the copy again from LLDB.framework in the
   # build tree.
-  # Intentionally use remove_directory because the target can be a either a
-  # file or directory and using remove_directory is harmless for files.
   add_custom_target(${name}-cleanup
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${copy_dest}
+    COMMAND ${CMAKE_COMMAND} -E remove ${copy_dest}
     COMMENT "Removing ${name} from LLDB.framework")
   add_dependencies(lldb-framework-cleanup
     ${name}-cleanup)


### PR DESCRIPTION
We no longer need to remove a directory downstream and also contrary to
my previous observations, remove_directory isn't sufficient to remove a
regular file.

Differential revision: https://reviews.llvm.org/D143024

(cherry picked from commit 9f8fd57cb6638f8137d82b1ceb02845626816b4f)
