### PR TITLE
[clang][cas] Initial support for prefix-mapping with modules and PCH

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -250,6 +250,22 @@ private:
 };
 } // namespace
 
+/// The PCH recorded file paths with canonical paths, create a VFS that
+/// allows remapping back to the non-canonical source paths so that they are
+/// found during dep-scanning.
+static void
+addReversePrefixMappingFileSystem(const llvm::PrefixMapper &PrefixMapper,
+                                  CompilerInstance &ScanInstance) {
+  llvm::PrefixMapper ReverseMapper;
+  ReverseMapper.addInverseRange(PrefixMapper.getMappings());
+  ReverseMapper.sort();
+  std::unique_ptr<llvm::vfs::FileSystem> FS =
+      llvm::vfs::createPrefixMappingFileSystem(
+          std::move(ReverseMapper), &ScanInstance.getVirtualFileSystem());
+
+  ScanInstance.getFileManager().setVirtualFileSystem(std::move(FS));
+}
+
 Error IncludeTreePPConsumer::initialize(CompilerInstance &ScanInstance,
                                         CompilerInvocation &NewInvocation) {
   if (Error E =
@@ -264,17 +280,7 @@ Error IncludeTreePPConsumer::initialize(CompilerInstance &ScanInstance,
     if (PPOpts.Includes.empty() && PPOpts.ImplicitPCHInclude.empty())
       return;
 
-    // The PCH recorded file paths with canonical paths, create a VFS that
-    // allows remapping back to the non-canonical source paths so that they are
-    // found during dep-scanning.
-    llvm::PrefixMapper ReverseMapper;
-    ReverseMapper.addInverseRange(PrefixMapper.getMappings());
-    ReverseMapper.sort();
-    std::unique_ptr<llvm::vfs::FileSystem> FS =
-        llvm::vfs::createPrefixMappingFileSystem(
-            std::move(ReverseMapper), &ScanInstance.getVirtualFileSystem());
-
-    ScanInstance.getFileManager().setVirtualFileSystem(std::move(FS));
+    addReversePrefixMappingFileSystem(PrefixMapper, ScanInstance);
 
     // These are written in the predefines buffer, so we need to remap them.
     for (std::string &Include : PPOpts.Includes)
@@ -595,6 +601,10 @@ Error FullDependencyConsumer::initialize(CompilerInstance &ScanInstance,
     if (Error E = PrefixMapping.configurePrefixMapper(NewInvocation, *Mapper))
       return E;
 
+    const PreprocessorOptions &PPOpts = ScanInstance.getPreprocessorOpts();
+    if (!PPOpts.Includes.empty() || !PPOpts.ImplicitPCHInclude.empty())
+      addReversePrefixMappingFileSystem(*Mapper, ScanInstance);
+
     CacheFS->trackNewAccesses();
     if (auto CWD =
             ScanInstance.getVirtualFileSystem().getCurrentWorkingDirectory())
@@ -696,6 +706,10 @@ Error FullDependencyConsumer::finalizeModuleInvocation(CompilerInvocation &CI,
                                   CacheFS->getCurrentWorkingDirectory().get(),
                                   /*ProduceIncludeTree=*/false);
   }
+
+  if (Mapper)
+    DepscanPrefixMapping::remapInvocationPaths(CI, *Mapper);
+
   return llvm::Error::success();
 }
 

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -282,10 +282,12 @@ static std::string getModuleContextHash(const ModuleDeps &MD,
   HashBuilder.add(serialization::VERSION_MAJOR, serialization::VERSION_MINOR);
 
   // Save and restore options that should not affect the hash, e.g. the exact
-  // contents of input files.
+  // contents of input files, or prefix mappings.
   auto &MutableCI = const_cast<CompilerInvocation &>(CI);
   llvm::SaveAndRestore<std::string> RestoreCASFSRootID(
-      MutableCI.getFileSystemOpts().CASFileSystemRootID);
+      MutableCI.getFileSystemOpts().CASFileSystemRootID, "");
+  llvm::SaveAndRestore<std::vector<std::string>> RestorePrefixMappings(
+      MutableCI.getFrontendOpts().PathPrefixMappings, {});
 
   // Hash the BuildInvocation without any input files.
   SmallVector<const char *, 32> DummyArgs;

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -146,6 +146,8 @@ void DepscanPrefixMapping::remapInvocationPaths(CompilerInvocation &Invocation,
   mapInPlaceAll(FrontendOpts.ASTMergeFiles);
   Mapper.mapInPlace(FrontendOpts.OverrideRecordLayoutsFile);
   Mapper.mapInPlace(FrontendOpts.StatsFile);
+  for (auto &[Path, _] : FrontendOpts.ModuleCacheKeys)
+    Mapper.mapInPlace(Path);
 
   // Filesystem options.
   Mapper.mapInPlace(FileSystemOpts.WorkingDir);

--- a/clang/test/ClangScanDeps/modules-cas-fs-prefix-mapping-caching.c
+++ b/clang/test/ClangScanDeps/modules-cas-fs-prefix-mapping-caching.c
@@ -1,0 +1,67 @@
+// Test that we get cache hits across directories with modules.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: cp -r %t/dir1 %t/dir2
+// RUN: sed -e "s|DIR|%t/dir1|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb.json.template > %t/dir1/cdb.json
+// RUN: sed -e "s|DIR|%t/dir2|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb.json.template > %t/dir2/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/dir1/cdb.json -format experimental-full \
+// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/dir1/modules \
+// RUN:    -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:    -prefix-map=%t/dir1/modules=/^modules -prefix-map=%t/dir1=/^src \
+// RUN:  > %t/dir1.txt
+
+// RUN: clang-scan-deps -compilation-database %t/dir2/cdb.json -format experimental-full \
+// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/dir2/modules \
+// RUN:    -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:    -prefix-map=%t/dir2/modules=/^modules -prefix-map=%t/dir2=/^src \
+// RUN:  > %t/dir2.txt
+
+// Extract individual commands.
+// RUN: %deps-to-rsp %t/dir1.txt --module-name=B > %t/dir1/B.cc1.rsp
+// RUN: %deps-to-rsp %t/dir1.txt --module-name=A > %t/dir1/A.cc1.rsp
+// RUN: %deps-to-rsp %t/dir1.txt --tu-index 0 > %t/dir1/tu.cc1.rsp
+
+// RUN: %deps-to-rsp %t/dir2.txt --module-name=B > %t/dir2/B.cc1.rsp
+// RUN: %deps-to-rsp %t/dir2.txt --module-name=A > %t/dir2/A.cc1.rsp
+// RUN: %deps-to-rsp %t/dir2.txt --tu-index 0 > %t/dir2/tu.cc1.rsp
+
+// RUN: (cd %t/dir1; %clang @B.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: (cd %t/dir1; %clang @A.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: (cd %t/dir1; %clang @tu.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+
+// CACHE-MISS: compile job cache miss
+
+// RUN: (cd %t/dir2; %clang @B.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: (cd %t/dir2; %clang @A.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: (cd %t/dir2; %clang @tu.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+
+// CACHE-HIT: compile job cache hit
+
+// RUN: diff -r -u %t/dir1/modules %t/dir2/modules
+
+//--- cdb.json.template
+[
+  {
+    "directory": "DIR",
+    "command": "CLANG -fsyntax-only DIR/t.c -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/mcp -target x86_64-apple-macos11 -isysroot SDK -Rcompile-job-cache",
+    "file": "DIR/t.c"
+  }
+]
+
+//--- dir1/t.c
+#include "a.h"
+
+//--- dir1/module.modulemap
+module A { header "a.h" }
+module B { header "b.h" }
+
+//--- dir1/a.h
+#include "b.h"
+
+//--- dir1/b.h
+#include <stdarg.h>
+#include <stdlib.h>

--- a/clang/test/ClangScanDeps/modules-cas-fs-prefix-mapping.c
+++ b/clang/test/ClangScanDeps/modules-cas-fs-prefix-mapping.c
@@ -1,0 +1,189 @@
+// Test path prefix-mapping when using a cas-fs with clang-scan-deps in
+// modules.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%t|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-full \
+// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/modules \
+// RUN:    -prefix-map=%t/modules=/^modules -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:  > %t/full_result.txt
+
+// Check the command-lines.
+// RUN: FileCheck %s -input-file %t/full_result.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK
+
+// Extract individual commands.
+// RUN: %deps-to-rsp %t/full_result.txt --module-name=B > %t/B.cc1.rsp
+// RUN: %deps-to-rsp %t/full_result.txt --module-name=A > %t/A.cc1.rsp
+// RUN: %deps-to-rsp %t/full_result.txt --tu-index 0 > %t/tu.cc1.rsp
+
+// Check the casfs.
+// RUN: cat %t/B.cc1.rsp | sed -E 's/.* "-fcas-fs" "([^ ]+)" .*/\1/' > %t/B_id.txt
+// RUN: cat %t/A.cc1.rsp | sed -E 's/.* "-fcas-fs" "([^ ]+)" .*/\1/' > %t/A_id.txt
+// RUN: cat %t/tu.cc1.rsp | sed -E 's/.* "-fcas-fs" "([^ ]+)" .*/\1/' > %t/tu_id.txt
+// RUN: llvm-cas -cas %t/cas -ls-tree-recursive @%t/B_id.txt > %t/B_fs.txt
+// RUN: llvm-cas -cas %t/cas -ls-tree-recursive @%t/A_id.txt > %t/A_fs.txt
+// RUN: llvm-cas -cas %t/cas -ls-tree-recursive @%t/tu_id.txt > %t/tu_fs.txt
+// RUN: FileCheck %s -input-file %t/A_fs.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK -check-prefixes=FS_NEG,FS
+// RUN: FileCheck %s -input-file %t/B_fs.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK -check-prefixes=FS_NEG,FS
+// RUN: FileCheck %s -input-file %t/tu_fs.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK -check-prefixes=FS_NEG,FS
+
+// FS_NEG-NOT: [[PREFIX]]
+// FS_NEG-NOT: [[SDK_PREFIX]]
+// FS_NEG-NOT: .pcm{{$}}
+// FS: file llvmcas://{{.*}} /^sdk/usr/include/stdlib.h
+// FS: file llvmcas://{{.*}} /^src/a.h
+// FS: file llvmcas://{{.*}} /^src/b.h
+// FS: file llvmcas://{{.*}} /^src/module.modulemap
+// FS: file llvmcas://{{.*}} /^tc/lib/clang/{{.*}}/include/stdarg.h
+
+// Check that it builds.
+// RUN: %clang @%t/B.cc1.rsp
+// RUN: %clang @%t/A.cc1.rsp
+// RUN: %clang @%t/tu.cc1.rsp
+
+// CHECK:      {
+// CHECK:        "modules": [
+// CHECK:          {
+// CHECK:            "casfs-root-id": "[[A_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// CHECK:            "clang-module-deps": [
+// CHECK:              {
+// CHECK:                "module-name": "B"
+// CHECK:              }
+// CHECK:            ]
+// CHECK:            "clang-modulemap-file": "[[PREFIX]]/module.modulemap"
+// CHECK:            "command-line": [
+// CHECK:              "-fcas-path"
+// CHECK:              "[[PREFIX]]/cas"
+// CHECK:              "-faction-cache-path"
+// CHECK:              "[[PREFIX]]/cache"
+// CHECK:              "-fcas-fs"
+// CHECK:              "[[A_ROOT_ID]]"
+// CHECK:              "-fcas-fs-working-directory"
+// CHECK:              "/^src"
+// CHECK:              "-fmodule-map-file=/^src/module.modulemap"
+// CHECK:              "-o"
+// CHECK:              "[[PREFIX]]/modules/{{.*}}/A-{{.*}}.pcm"
+// CHECK:              "-fmodule-file-cache-key=/^modules/{{.*}}/B-[[B_CONTEXT_HASH:[^.]+]].pcm=llvmcas://{{.*}}"
+// CHECK:              "-x"
+// CHECK:              "c"
+// CHECK:              "/^src/module.modulemap"
+// CHECK:              "-isysroot"
+// CHECK:              "/^sdk"
+// CHECK:              "-resource-dir"
+// CHECK:              "/^tc/lib/clang/{{.*}}"
+// CHECK:              "-fmodule-file=B=/^modules/{{.*}}/B-[[B_CONTEXT_HASH]].pcm"
+// CHECK:              "-isystem"
+// CHECK:              "/^tc/lib/clang/{{.*}}/include"
+// CHECK:              "-internal-externc-isystem"
+// CHECK:              "/^sdk/usr/include"
+// CHECK:            ]
+// CHECK:            "file-deps": [
+// CHECK:              "[[PREFIX]]/a.h"
+// CHECK:              "[[PREFIX]]/module.modulemap"
+// CHECK:            ]
+// CHECK:            "name": "A"
+// CHECK:          }
+// CHECK:          {
+// CHECK:            "casfs-root-id": "[[B_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// CHECK:            "clang-module-deps": [],
+// CHECK:            "clang-modulemap-file": "[[PREFIX]]/module.modulemap"
+// CHECK:            "command-line": [
+// CHECK:              "-fcas-path"
+// CHECK:              "[[PREFIX]]/cas"
+// CHECK:              "-faction-cache-path"
+// CHECK:              "[[PREFIX]]/cache"
+// CHECK:              "-fcas-fs"
+// CHECK:              "[[B_ROOT_ID]]"
+// CHECK:              "-fcas-fs-working-directory"
+// CHECK:              "/^src"
+// CHECK:              "-o"
+// CHECK:              "[[PREFIX]]/modules/{{.*}}/B-[[B_CONTEXT_HASH]].pcm"
+// CHECK:              "-x"
+// CHECK:              "c"
+// CHECK:              "/^src/module.modulemap"
+// CHECK:              "-isysroot"
+// CHECK:              "/^sdk"
+// CHECK:              "-resource-dir"
+// CHECK:              "/^tc/lib/clang/{{.*}}"
+// CHECK:              "-isystem"
+// CHECK:              "/^tc/lib/clang/{{.*}}/include"
+// CHECK:              "-internal-externc-isystem"
+// CHECK:              "/^sdk/usr/include"
+// CHECK:            ]
+// CHECK:            "context-hash": "[[B_CONTEXT_HASH]]"
+// CHECK:            "file-deps": [
+// CHECK:              "{{.*}}/include/stdarg.h"
+// CHECK:              "[[PREFIX]]/b.h"
+// CHECK:              "[[PREFIX]]/module.modulemap"
+// CHECK:              "[[SDK_PREFIX]]/usr/include/stdlib.h"
+// CHECK:            ]
+// CHECK:            "name": "B"
+// CHECK:          }
+// CHECK:        ]
+// CHECK:        "translation-units": [
+// CHECK:          {
+// CHECK:            "commands": [
+// CHECK:              {
+// CHECK:                "casfs-root-id": "[[TU_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// CHECK:                "clang-module-deps": [
+// CHECK:                  {
+// CHECK:                    "module-name": "A"
+// CHECK:                  }
+// CHECK:                ]
+// CHECK:                "command-line": [
+// CHECK:                  "-fcas-path"
+// CHECK:                  "[[PREFIX]]/cas"
+// CHECK:                  "-faction-cache-path"
+// CHECK:                  "[[PREFIX]]/cache"
+// CHECK:                  "-fcas-fs"
+// CHECK:                  "[[TU_ROOT_ID]]"
+// CHECK:                  "-fcas-fs-working-directory"
+// CHECK:                  "/^src"
+// CHECK:                  "-fmodule-map-file=/^src/module.modulemap"
+// CHECK:                  "-fmodule-file-cache-key=/^modules/{{.*}}A-{{.*}}.pcm=llvmcas://{{.*}}"
+// CHECK:                  "-x"
+// CHECK:                  "c"
+// CHECK:                  "/^src/t.c"
+// CHECK:                  "-isysroot"
+// CHECK:                  "/^sdk"
+// CHECK:                  "-resource-dir"
+// CHECK:                  "/^tc/lib/clang/{{.*}}"
+// CHECK:                  "-fmodule-file=A=/^modules/{{.*}}/A-{{.*}}.pcm"
+// CHECK:                  "-isystem"
+// CHECK:                  "/^tc/lib/clang/{{.*}}/include"
+// CHECK:                  "-internal-externc-isystem"
+// CHECK:                  "/^sdk/usr/include"
+// CHECK:                ],
+// CHECK:                "file-deps": [
+// CHECK:                  "[[PREFIX]]/t.c"
+// CHECK:                ]
+// CHECK:                "input-file": "[[PREFIX]]/t.c"
+// CHECK:              }
+
+
+//--- cdb.json.template
+[
+  {
+    "directory": "DIR",
+    "command": "CLANG -fsyntax-only DIR/t.c -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/mcp -target x86_64-apple-macos11 -isysroot SDK",
+    "file": "DIR/t.c"
+  }
+]
+
+//--- t.c
+#include "a.h"
+
+//--- module.modulemap
+module A { header "a.h" }
+module B { header "b.h" }
+
+//--- a.h
+#include "b.h"
+
+//--- b.h
+#include <stdarg.h>
+#include <stdlib.h>

--- a/clang/test/ClangScanDeps/modules-pch-cas-fs-prefix-mapping-caching.c
+++ b/clang/test/ClangScanDeps/modules-pch-cas-fs-prefix-mapping-caching.c
@@ -1,0 +1,105 @@
+// Test that we get cache hits across directories with modules and PCH.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: cp -r %t/dir1 %t/dir2
+// RUN: sed -e "s|DIR|%t/dir1|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb.json.template > %t/dir1/cdb.json
+// RUN: sed -e "s|DIR|%t/dir1|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb_pch.json.template > %t/dir1/cdb_pch.json
+// RUN: sed -e "s|DIR|%t/dir2|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb.json.template > %t/dir2/cdb.json
+// RUN: sed -e "s|DIR|%t/dir2|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb_pch.json.template > %t/dir2/cdb_pch.json
+
+// == Scan PCH
+// RUN: clang-scan-deps -compilation-database %t/dir1/cdb_pch.json -format experimental-full \
+// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/dir1/modules \
+// RUN:    -prefix-map=%t/dir1/modules=/^modules -prefix-map=%t/dir1=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:  > %t/pch_dir1.txt
+
+// RUN: clang-scan-deps -compilation-database %t/dir2/cdb_pch.json -format experimental-full \
+// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/dir2/modules \
+// RUN:    -prefix-map=%t/dir2/modules=/^modules -prefix-map=%t/dir2=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:  > %t/pch_dir2.txt
+
+// == Build PCH
+// RUN: %deps-to-rsp %t/pch_dir1.txt --module-name=B > %t/dir1/B.cc1.rsp
+// RUN: %deps-to-rsp %t/pch_dir1.txt --module-name=A > %t/dir1/A.cc1.rsp
+// RUN: %deps-to-rsp %t/pch_dir1.txt --tu-index 0 > %t/dir1/pch.cc1.rsp
+// RUN: (cd %t/dir1; %clang @B.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: (cd %t/dir1; %clang @A.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: (cd %t/dir1; %clang @pch.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+
+// CACHE-MISS: compile job cache miss
+
+// RUN: %deps-to-rsp %t/pch_dir2.txt --module-name=B > %t/dir2/B.cc1.rsp
+// RUN: %deps-to-rsp %t/pch_dir2.txt --module-name=A > %t/dir2/A.cc1.rsp
+// RUN: %deps-to-rsp %t/pch_dir2.txt --tu-index 0 > %t/dir2/pch.cc1.rsp
+// RUN: (cd %t/dir2; %clang @B.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: (cd %t/dir2; %clang @A.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: (cd %t/dir2; %clang @pch.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+
+// CACHE-HIT: compile job cache hit
+
+// == Scan TU, including PCH
+// RUN: clang-scan-deps -compilation-database %t/dir1/cdb.json -format experimental-full \
+// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/dir1/modules \
+// RUN:    -prefix-map=%t/dir1/modules=/^modules -prefix-map=%t/dir1=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:  > %t/dir1.txt
+
+// RUN: clang-scan-deps -compilation-database %t/dir2/cdb.json -format experimental-full \
+// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/dir2/modules \
+// RUN:    -prefix-map=%t/dir2/modules=/^modules -prefix-map=%t/dir2=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:  > %t/dir2.txt
+
+// == Build TU
+// RUN: %deps-to-rsp %t/dir1.txt --module-name=C > %t/dir1/C.cc1.rsp
+// RUN: %deps-to-rsp %t/dir1.txt --tu-index 0 > %t/dir1/tu.cc1.rsp
+// RUN: (cd %t/dir1; %clang @C.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: (cd %t/dir1; %clang @tu.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+
+// RUN: %deps-to-rsp %t/dir2.txt --module-name=C > %t/dir2/C.cc1.rsp
+// RUN: %deps-to-rsp %t/dir2.txt --tu-index 0 > %t/dir2/tu.cc1.rsp
+// RUN: (cd %t/dir2; %clang @C.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: (cd %t/dir2; %clang @tu.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+
+// RUN: diff -u %t/dir1/prefix.h.pch %t/dir2/prefix.h.pch
+// RUN: diff -r -u %t/dir1/modules %t/dir2/modules
+
+//--- cdb.json.template
+[
+  {
+    "directory": "DIR",
+    "command": "CLANG -fsyntax-only DIR/t.c -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/mcp -target x86_64-apple-macos11 -isysroot SDK -include DIR/prefix.h -Rcompile-job-cache",
+    "file": "DIR/t.c"
+  }
+]
+
+//--- cdb_pch.json.template
+[
+  {
+    "directory" : "DIR",
+    "command" : "CLANG -x c-header DIR/prefix.h -o DIR/prefix.h.pch -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/mcp -target x86_64-apple-macos11 -isysroot SDK -Rcompile-job-cache",
+    "file" : "DIR/prefix.h"
+  },
+]
+
+//--- dir1/t.c
+#include "c.h"
+
+//--- dir1/prefix.h
+#include "a.h"
+
+//--- dir1/module.modulemap
+module A { header "a.h" }
+module B { header "b.h" }
+module C { header "c.h" }
+
+//--- dir1/a.h
+#include "b.h"
+
+//--- dir1/b.h
+#include <stdarg.h>
+#include <stdlib.h>
+
+//--- dir1/c.h
+#include "b.h"

--- a/clang/test/ClangScanDeps/modules-pch-cas-fs-prefix-mapping.c
+++ b/clang/test/ClangScanDeps/modules-pch-cas-fs-prefix-mapping.c
@@ -1,0 +1,311 @@
+// Test path prefix-mapping when using a cas-fs with clang-scan-deps in
+// modules with a PCH.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%t|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb.json.template > %t/cdb.json
+// RUN: sed -e "s|DIR|%t|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb_pch.json.template > %t/cdb_pch.json
+
+// == Scan PCH
+// RUN: clang-scan-deps -compilation-database %t/cdb_pch.json -format experimental-full \
+// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/modules \
+// RUN:    -prefix-map=%t/modules=/^modules -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:  > %t/pch_result.txt
+
+// == Check specifics of the PCH command-line
+// RUN: FileCheck %s -input-file %t/pch_result.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK -check-prefix=PCH
+
+// == Build PCH
+// RUN: %deps-to-rsp %t/pch_result.txt --module-name=B > %t/B.cc1.rsp
+// RUN: %deps-to-rsp %t/pch_result.txt --module-name=A > %t/A.cc1.rsp
+// RUN: %deps-to-rsp %t/pch_result.txt --tu-index 0 > %t/pch.cc1.rsp
+// RUN: %clang @%t/B.cc1.rsp
+// RUN: %clang @%t/A.cc1.rsp
+// Ensure we load pcms from action cache
+// RUN: rm -rf %t/modules
+// RUN: %clang @%t/pch.cc1.rsp
+
+// == Scan TU, including PCH
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-full \
+// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/modules \
+// RUN:    -prefix-map=%t/modules=/^modules -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:  > %t/result.txt
+
+// == Check specifics of the TU command-line
+// RUN: FileCheck %s -input-file %t/result.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK
+
+// == Build TU
+// RUN: %deps-to-rsp %t/result.txt --module-name=C > %t/C.cc1.rsp
+// RUN: %deps-to-rsp %t/result.txt --tu-index 0 > %t/tu.cc1.rsp
+// RUN: %clang @%t/C.cc1.rsp
+// RUN: %clang @%t/tu.cc1.rsp
+
+// == Check the casfs.
+// RUN: cat %t/A.cc1.rsp | sed -E 's/.* "-fcas-fs" "([^ ]+)" .*/\1/' > %t/A_id.txt
+// RUN: cat %t/B.cc1.rsp | sed -E 's/.* "-fcas-fs" "([^ ]+)" .*/\1/' > %t/B_id.txt
+// RUN: cat %t/C.cc1.rsp | sed -E 's/.* "-fcas-fs" "([^ ]+)" .*/\1/' > %t/C_id.txt
+// RUN: cat %t/pch.cc1.rsp | sed -E 's/.* "-fcas-fs" "([^ ]+)" .*/\1/' > %t/pch_id.txt
+// RUN: cat %t/tu.cc1.rsp | sed -E 's/.* "-fcas-fs" "([^ ]+)" .*/\1/' > %t/tu_id.txt
+
+// RUN: llvm-cas -cas %t/cas -ls-tree-recursive @%t/A_id.txt > %t/A_fs.txt
+// RUN: llvm-cas -cas %t/cas -ls-tree-recursive @%t/B_id.txt > %t/B_fs.txt
+// RUN: llvm-cas -cas %t/cas -ls-tree-recursive @%t/C_id.txt > %t/C_fs.txt
+// RUN: llvm-cas -cas %t/cas -ls-tree-recursive @%t/pch_id.txt > %t/pch_fs.txt
+// RUN: llvm-cas -cas %t/cas -ls-tree-recursive @%t/tu_id.txt > %t/tu_fs.txt
+
+// RUN: FileCheck %s -input-file %t/A_fs.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK -check-prefixes=FS_NEG,FS
+// RUN: FileCheck %s -input-file %t/B_fs.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK -check-prefixes=FS_NEG,FS
+// RUN: FileCheck %s -input-file %t/C_fs.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK -check-prefixes=FS_NEG,FS
+// RUN: FileCheck %s -input-file %t/pch_fs.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK -check-prefixes=FS_NEG,FS
+// RUN: FileCheck %s -input-file %t/tu_fs.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK -check-prefixes=FS_NEG,FS
+
+// FS_NEG-NOT: [[PREFIX]]
+// FS_NEG-NOT: [[SDK_PREFIX]]
+// FS_NEG-NOT: .pcm{{$}}
+// FS: file llvmcas://{{.*}} /^sdk/usr/include/stdlib.h
+// FS: file llvmcas://{{.*}} /^src/a.h
+// FS: file llvmcas://{{.*}} /^src/b.h
+// FS: file llvmcas://{{.*}} /^src/module.modulemap
+// FS: file llvmcas://{{.*}} /^tc/lib/clang/{{.*}}/include/stdarg.h
+
+// Check that it builds.
+// RUN: %clang @%t/B.cc1.rsp
+// RUN: %clang @%t/A.cc1.rsp
+// RUN: %clang @%t/tu.cc1.rsp
+
+// PCH:      {
+// PCH:        "modules": [
+// PCH:          {
+// PCH:            "casfs-root-id": "[[A_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// PCH:            "clang-module-deps": [
+// PCH:              {
+// PCH:                "module-name": "B"
+// PCH:              }
+// PCH:            ]
+// PCH:            "clang-modulemap-file": "[[PREFIX]]/module.modulemap"
+// PCH:            "command-line": [
+// PCH:              "-fcas-path"
+// PCH:              "[[PREFIX]]/cas"
+// PCH:              "-faction-cache-path"
+// PCH:              "[[PREFIX]]/cache"
+// PCH:              "-fcas-fs"
+// PCH:              "[[A_ROOT_ID]]"
+// PCH:              "-fcas-fs-working-directory"
+// PCH:              "/^src"
+// PCH:              "-fmodule-map-file=/^src/module.modulemap"
+// PCH:              "-o"
+// PCH:              "[[PREFIX]]/modules/{{.*}}/A-{{.*}}.pcm"
+// PCH:              "-fmodule-file-cache-key=/^modules/{{.*}}/B-[[B_CONTEXT_HASH:[^.]+]].pcm=llvmcas://{{.*}}"
+// PCH:              "-x"
+// PCH:              "c"
+// PCH:              "/^src/module.modulemap"
+// PCH:              "-isysroot"
+// PCH:              "/^sdk"
+// PCH:              "-resource-dir"
+// PCH:              "/^tc/lib/clang/{{.*}}"
+// PCH:              "-fmodule-file=B=/^modules/{{.*}}/B-[[B_CONTEXT_HASH]].pcm"
+// PCH:              "-isystem"
+// PCH:              "/^tc/lib/clang/{{.*}}/include"
+// PCH:              "-internal-externc-isystem"
+// PCH:              "/^sdk/usr/include"
+// PCH:            ]
+// PCH:            "file-deps": [
+// PCH:              "[[PREFIX]]/a.h"
+// PCH:              "[[PREFIX]]/module.modulemap"
+// PCH:            ]
+// PCH:            "name": "A"
+// PCH:          }
+// PCH:          {
+// PCH:            "casfs-root-id": "[[B_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// PCH:            "clang-module-deps": [],
+// PCH:            "clang-modulemap-file": "[[PREFIX]]/module.modulemap"
+// PCH:            "command-line": [
+// PCH:              "-fcas-path"
+// PCH:              "[[PREFIX]]/cas"
+// PCH:              "-faction-cache-path"
+// PCH:              "[[PREFIX]]/cache"
+// PCH:              "-fcas-fs"
+// PCH:              "[[B_ROOT_ID]]"
+// PCH:              "-fcas-fs-working-directory"
+// PCH:              "/^src"
+// PCH:              "-o"
+// PCH:              "[[PREFIX]]/modules/{{.*}}/B-[[B_CONTEXT_HASH]].pcm"
+// PCH:              "-x"
+// PCH:              "c"
+// PCH:              "/^src/module.modulemap"
+// PCH:              "-isysroot"
+// PCH:              "/^sdk"
+// PCH:              "-resource-dir"
+// PCH:              "/^tc/lib/clang/{{.*}}"
+// PCH:              "-isystem"
+// PCH:              "/^tc/lib/clang/{{.*}}/include"
+// PCH:              "-internal-externc-isystem"
+// PCH:              "/^sdk/usr/include"
+// PCH:            ]
+// PCH:            "context-hash": "[[B_CONTEXT_HASH]]"
+// PCH:            "file-deps": [
+// PCH:              "{{.*}}/include/stdarg.h"
+// PCH:              "[[PREFIX]]/b.h"
+// PCH:              "[[PREFIX]]/module.modulemap"
+// PCH:              "[[SDK_PREFIX]]/usr/include/stdlib.h"
+// PCH:            ]
+// PCH:            "name": "B"
+// PCH:          }
+// PCH:        ]
+// PCH:        "translation-units": [
+// PCH:          {
+// PCH:            "commands": [
+// PCH:              {
+// PCH:                "casfs-root-id": "[[TU_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// PCH:                "clang-module-deps": [
+// PCH:                  {
+// PCH:                    "module-name": "A"
+// PCH:                  }
+// PCH:                ]
+// PCH:                "command-line": [
+// PCH:                  "-fcas-path"
+// PCH:                  "[[PREFIX]]/cas"
+// PCH:                  "-faction-cache-path"
+// PCH:                  "[[PREFIX]]/cache"
+// PCH:                  "-fcas-fs"
+// PCH:                  "[[TU_ROOT_ID]]"
+// PCH:                  "-fcas-fs-working-directory"
+// PCH:                  "/^src"
+// PCH:                  "-fmodule-map-file=/^src/module.modulemap"
+// PCH:                  "-fmodule-file-cache-key=/^modules/{{.*}}A-{{.*}}.pcm=llvmcas://{{.*}}"
+// PCH:                  "-x"
+// PCH:                  "c-header"
+// PCH:                  "/^src/prefix.h"
+// PCH:                  "-isysroot"
+// PCH:                  "/^sdk"
+// PCH:                  "-resource-dir"
+// PCH:                  "/^tc/lib/clang/{{.*}}"
+// PCH:                  "-fmodule-file=A=/^modules/{{.*}}/A-{{.*}}.pcm"
+// PCH:                  "-isystem"
+// PCH:                  "/^tc/lib/clang/{{.*}}/include"
+// PCH:                  "-internal-externc-isystem"
+// PCH:                  "/^sdk/usr/include"
+// PCH:                ],
+// PCH:                "file-deps": [
+// PCH:                  "[[PREFIX]]/prefix.h"
+// PCH:                ]
+// PCH:                "input-file": "[[PREFIX]]/prefix.h"
+// PCH:              }
+
+// CHECK:      {
+// CHECK-NEXT:   "modules": [
+// CHECK-NEXT:     {
+// CHECK:            "casfs-root-id": "[[C_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// CHECK:            "clang-module-deps": []
+// CHECK:            "command-line": [
+// CHECK-NEXT:         "-cc1"
+// CHECK:              "-fcas-path"
+// CHECK-NEXT:         "[[PREFIX]]{{.}}cas"
+// CHECK:              "-faction-cache-path"
+// CHECK-NEXT:         "[[PREFIX]]{{.}}cache"
+// CHECK:              "-fcas-fs"
+// CHECK-NEXT:         "[[C_ROOT_ID]]"
+// CHECK:              "-fcas-fs-working-directory"
+// CHECK-NEXT:         "/^src"
+// CHECK:              "-fcache-compile-job"
+// CHECK:              "-emit-module"
+// CHECK:              "-fmodule-file=/^modules/{{.*}}/B-{{.*}}.pcm"
+// CHECK:              "-fmodule-file-cache-key=/^modules/{{.*}}/B-{{.*}}.pcm=llvmcas://{{.*}}"
+// CHECK:              "-x"
+// CHECK-NEXT:         "c"
+// CHECK-NEXT:         "/^src/module.modulemap"
+// CHECK:              "-isysroot"
+// CHECK-NEXT:         "/^sdk"
+// CHECK:              "-resource-dir"
+// CHECK-NEXT:         "/^tc/lib/clang/{{.*}}"
+// CHECK-NOT: [[PREFIX]]
+// CHECK-NOT: [[SDK_PREFIX]]
+// CHECK:            ]
+// CHECK:            "name": "C"
+// CHECK:          }
+// CHECK-NEXT:   ]
+// CHECK:        "translation-units": [
+// CHECK:          {
+// CHECK:            "commands": [
+// CHECK:              {
+// CHECK:                "casfs-root-id": "[[TU_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// CHECK:                "clang-module-deps": [
+// CHECK:                  {
+// CHECK:                    "module-name": "C"
+// CHECK:                  }
+// CHECK:                ]
+// CHECK:                "command-line": [
+// CHECK:                  "-fcas-path"
+// CHECK-NEXT:             "[[PREFIX]]/cas"
+// CHECK:                  "-faction-cache-path"
+// CHECK-NEXT:             "[[PREFIX]]/cache"
+// CHECK:                  "-fcas-fs"
+// CHECK-NEXT:             "[[TU_ROOT_ID]]"
+// CHECK:                  "-fcas-fs-working-directory"
+// CHECK-NEXT:             "/^src"
+// CHECK:                  "-fmodule-map-file=/^src/module.modulemap"
+// CHECK:                  "-fmodule-file-cache-key=/^modules/{{.*}}C-{{.*}}.pcm=llvmcas://{{.*}}"
+// CHECK:                  "-x"
+// CHECK-NEXT:             "c"
+// CHECK-NEXT:             "/^src/t.c"
+// CHECK:                  "-isysroot"
+// CHECK-NEXT:             "/^sdk"
+// CHECK:                  "-resource-dir"
+// CHECK-NEXT:             "/^tc/lib/clang/{{.*}}"
+// CHECK:                  "-fmodule-file=C=/^modules/{{.*}}/C-{{.*}}.pcm"
+// CHECK:                  "-isystem"
+// CHECK-NEXT:             "/^sdk/usr/local/include"
+// CHECK:                  "-isystem"
+// CHECK-NEXT:             "/^tc/lib/clang/{{.*}}/include"
+// CHECK:                  "-internal-externc-isystem"
+// CHECK-NEXT:             "/^sdk/usr/include"
+// CHECK:                  "-include-pch"
+// CHECK-NEXT:             "/^src/prefix.h.pch"
+// CHECK:                ],
+// CHECK:                "file-deps": [
+// CHECK:                  "[[PREFIX]]/t.c"
+// CHECK:                  "[[PREFIX]]/prefix.h.pch"
+// CHECK:                ]
+// CHECK:                "input-file": "[[PREFIX]]/t.c"
+// CHECK:              }
+
+//--- cdb.json.template
+[
+  {
+    "directory": "DIR",
+    "command": "CLANG -fsyntax-only DIR/t.c -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/mcp -target x86_64-apple-macos11 -isysroot SDK -include DIR/prefix.h",
+    "file": "DIR/t.c"
+  }
+]
+
+//--- cdb_pch.json.template
+[
+  {
+    "directory" : "DIR",
+    "command" : "CLANG -x c-header DIR/prefix.h -o DIR/prefix.h.pch -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/mcp -target x86_64-apple-macos11 -isysroot SDK",
+    "file" : "DIR/prefix.h"
+  },
+]
+
+//--- t.c
+#include "c.h"
+
+//--- prefix.h
+#include "a.h"
+
+//--- module.modulemap
+module A { header "a.h" }
+module B { header "b.h" }
+module C { header "c.h" }
+
+//--- a.h
+#include "b.h"
+
+//--- b.h
+#include <stdarg.h>
+#include <stdlib.h>
+
+//--- c.h
+#include "b.h"


### PR DESCRIPTION
Add initial support to compilation caching to allow prefix-mapping paths when working with modules and PCH in a cas-fs/caching-on-disk-filesystem.

(cherry picked from commit a3340803945ebc03cffe7b9865d7008f379f4f34)