### PR TITLE
[llvm/CAS] Reduce uses of `LLVM_ENABLE_ONDISK_CAS` macro

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -721,7 +721,7 @@ option (LLVM_ENABLE_SPHINX "Use Sphinx to generate llvm documentation." OFF)
 option (LLVM_ENABLE_OCAMLDOC "Build OCaml bindings documentation." ON)
 option (LLVM_ENABLE_BINDINGS "Build bindings." ON)
 
-if(UNIX)
+if(UNIX AND CMAKE_SIZEOF_VOID_P GREATER_EQUAL 8)
   set(LLVM_ENABLE_ONDISK_CAS_default ON)
 else()
   set(LLVM_ENABLE_ONDISK_CAS_default OFF)

--- a/llvm/include/llvm/CAS/LazyMappedFileRegion.h
+++ b/llvm/include/llvm/CAS/LazyMappedFileRegion.h
@@ -15,8 +15,6 @@
 #include <atomic>
 #include <mutex>
 
-#if LLVM_ENABLE_ONDISK_CAS
-
 namespace llvm {
 
 class MemoryBuffer;
@@ -155,5 +153,4 @@ private:
 } // namespace cas
 } // namespace llvm
 
-#endif // LLVM_ENABLE_ONDISK_CAS
 #endif // LLVM_CAS_LAZYMAPPEDFILEREGION_H

--- a/llvm/include/llvm/CAS/LazyMappedFileRegionBumpPtr.h
+++ b/llvm/include/llvm/CAS/LazyMappedFileRegionBumpPtr.h
@@ -15,8 +15,6 @@
 #include "llvm/Support/FileSystem.h"
 #include <atomic>
 
-#if LLVM_ENABLE_ONDISK_CAS
-
 namespace llvm {
 
 class MemoryBuffer;
@@ -71,5 +69,4 @@ private:
 } // namespace cas
 } // namespace llvm
 
-#endif // LLVM_ENABLE_ONDISK_CAS
 #endif // LLVM_CAS_LAZYMAPPEDFILEREGIONBUMPPTR_H

--- a/llvm/include/llvm/CAS/OnDiskGraphDB.h
+++ b/llvm/include/llvm/CAS/OnDiskGraphDB.h
@@ -12,8 +12,6 @@
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/CAS/OnDiskHashMappedTrie.h"
 
-#if LLVM_ENABLE_ONDISK_CAS
-
 namespace llvm::cas::ondisk {
 
 /// 8B reference.
@@ -350,5 +348,4 @@ private:
 
 } // namespace llvm::cas::ondisk
 
-#endif // LLVM_ENABLE_ONDISK_CAS
 #endif // LLVM_CAS_ONDISKGRAPHDB_H

--- a/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
+++ b/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
@@ -19,8 +19,6 @@
 #include <atomic>
 #include <mutex>
 
-#if LLVM_ENABLE_ONDISK_CAS
-
 namespace llvm {
 
 class MemoryBuffer;
@@ -378,5 +376,4 @@ private:
 } // namespace cas
 } // namespace llvm
 
-#endif // LLVM_ENABLE_ONDISK_CAS
 #endif // LLVM_CAS_ONDISKHASHMAPPEDTRIE_H

--- a/llvm/lib/CAS/ActionCaches.cpp
+++ b/llvm/lib/CAS/ActionCaches.cpp
@@ -52,7 +52,6 @@ private:
   InMemoryCacheT Cache;
 };
 
-#if LLVM_ENABLE_ONDISK_CAS
 class OnDiskActionCache final : public ActionCache {
 public:
   Error putImpl(ArrayRef<uint8_t> ActionKey, const CASID &Result) final;
@@ -77,7 +76,6 @@ private:
   OnDiskHashMappedTrie Cache;
   using DataT = CacheEntry<sizeof(HashType)>;
 };
-#endif /* LLVM_ENABLE_ONDISK_CAS */
 } // end namespace
 
 static std::string hashToString(ArrayRef<uint8_t> Hash) {
@@ -139,7 +137,6 @@ std::unique_ptr<ActionCache> createInMemoryActionCache() {
 } // namespace cas
 } // namespace llvm
 
-#if LLVM_ENABLE_ONDISK_CAS
 constexpr StringLiteral OnDiskActionCache::ActionCacheFile;
 constexpr StringLiteral OnDiskActionCache::FilePrefix;
 
@@ -198,6 +195,7 @@ Error OnDiskActionCache::putImpl(ArrayRef<uint8_t> Key, const CASID &Result) {
                                         Observed->getValue());
 }
 
+#if LLVM_ENABLE_ONDISK_CAS
 namespace llvm {
 namespace cas {
 

--- a/llvm/lib/CAS/LazyMappedFileRegion.cpp
+++ b/llvm/lib/CAS/LazyMappedFileRegion.cpp
@@ -20,8 +20,6 @@
 #include "llvm/Support/WindowsError.h"
 #endif
 
-#if LLVM_ENABLE_ONDISK_CAS
-
 using namespace llvm;
 using namespace llvm::cas;
 
@@ -393,5 +391,3 @@ void LazyMappedFileRegion::destroyImpl() {
     CloseHandle(Region);
 #endif
 }
-
-#endif // LLVM_ENABLE_ONDISK_CAS

--- a/llvm/lib/CAS/LazyMappedFileRegionBumpPtr.cpp
+++ b/llvm/lib/CAS/LazyMappedFileRegionBumpPtr.cpp
@@ -9,7 +9,6 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/CAS/LazyMappedFileRegionBumpPtr.h"
 
-#if LLVM_ENABLE_ONDISK_CAS
 using namespace llvm;
 using namespace llvm::cas;
 
@@ -38,4 +37,3 @@ int64_t LazyMappedFileRegionBumpPtr::allocateOffset(uint64_t AllocSize) {
   }
   return OldEnd;
 }
-#endif // LLVM_ENABLE_ONDISK_CAS

--- a/llvm/lib/CAS/OnDiskCAS.cpp
+++ b/llvm/lib/CAS/OnDiskCAS.cpp
@@ -14,7 +14,6 @@ using namespace llvm;
 using namespace llvm::cas;
 using namespace llvm::cas::builtin;
 
-#if LLVM_ENABLE_ONDISK_CAS
 namespace {
 
 class OnDiskCAS : public BuiltinCAS {
@@ -132,6 +131,8 @@ Expected<std::unique_ptr<OnDiskCAS>> OnDiskCAS::open(StringRef AbsPath) {
     return DB.takeError();
   return std::unique_ptr<OnDiskCAS>(new OnDiskCAS(std::move(*DB)));
 }
+
+#if LLVM_ENABLE_ONDISK_CAS
 
 Expected<std::unique_ptr<ObjectStore>> cas::createOnDiskCAS(const Twine &Path) {
   // FIXME: An absolute path isn't really good enough. Should open a directory

--- a/llvm/lib/CAS/OnDiskGraphDB.cpp
+++ b/llvm/lib/CAS/OnDiskGraphDB.cpp
@@ -55,8 +55,6 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
 
-#if LLVM_ENABLE_ONDISK_CAS
-
 #define DEBUG_TYPE "on-disk-cas"
 
 using namespace llvm;
@@ -1312,5 +1310,3 @@ OnDiskGraphDB::OnDiskGraphDB(StringRef RootPath, OnDiskHashMappedTrie Index,
 OnDiskGraphDB::~OnDiskGraphDB() {
   delete static_cast<StandaloneDataMapTy *>(StandaloneData);
 }
-
-#endif // LLVM_ENABLE_ONDISK_CAS

--- a/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
+++ b/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
@@ -21,6 +21,8 @@
 using namespace llvm;
 using namespace llvm::cas;
 
+#if LLVM_ENABLE_ONDISK_CAS
+
 static_assert(sizeof(size_t) == sizeof(uint64_t), "64-bit only");
 static_assert(sizeof(std::atomic<int64_t>) == sizeof(uint64_t),
               "Requires lock-free 64-bit atomics");
@@ -1114,14 +1116,6 @@ Expected<OnDiskHashMappedTrie> OnDiskHashMappedTrie::create(
   return OnDiskHashMappedTrie(std::make_unique<ImplType>(std::move(Impl)));
 }
 
-OnDiskHashMappedTrie::OnDiskHashMappedTrie(std::unique_ptr<ImplType> Impl)
-    : Impl(std::move(Impl)) {}
-OnDiskHashMappedTrie::OnDiskHashMappedTrie(OnDiskHashMappedTrie &&RHS) =
-    default;
-OnDiskHashMappedTrie &
-OnDiskHashMappedTrie::operator=(OnDiskHashMappedTrie &&RHS) = default;
-OnDiskHashMappedTrie::~OnDiskHashMappedTrie() = default;
-
 //===----------------------------------------------------------------------===//
 // DataAllocator data structures.
 //===----------------------------------------------------------------------===//
@@ -1265,6 +1259,68 @@ const char *OnDiskDataAllocator::beginData(FileOffset Offset) const {
 
 OnDiskDataAllocator::OnDiskDataAllocator(std::unique_ptr<ImplType> Impl)
     : Impl(std::move(Impl)) {}
+
+#else // !LLVM_ENABLE_ONDISK_CAS
+
+struct OnDiskHashMappedTrie::ImplType {};
+
+Expected<OnDiskHashMappedTrie> OnDiskHashMappedTrie::create(
+    const Twine &PathTwine, const Twine &TrieNameTwine, size_t NumHashBits,
+    uint64_t DataSize, uint64_t MaxFileSize,
+    Optional<uint64_t> NewFileInitialSize, Optional<size_t> NewTableNumRootBits,
+    Optional<size_t> NewTableNumSubtrieBits) {
+  llvm_unreachable("not supported");
+}
+
+OnDiskHashMappedTrie::pointer
+OnDiskHashMappedTrie::insertLazy(const_pointer Hint, ArrayRef<uint8_t> Hash,
+                                 LazyInsertOnConstructCB OnConstruct,
+                                 LazyInsertOnLeakCB OnLeak) {
+  llvm_unreachable("not supported");
+}
+
+OnDiskHashMappedTrie::const_pointer
+OnDiskHashMappedTrie::recoverFromFileOffset(FileOffset Offset) const {
+  llvm_unreachable("not supported");
+}
+
+OnDiskHashMappedTrie::const_pointer
+OnDiskHashMappedTrie::find(ArrayRef<uint8_t> Hash) const {
+  llvm_unreachable("not supported");
+}
+
+void OnDiskHashMappedTrie::print(
+    raw_ostream &OS, function_ref<void(ArrayRef<char>)> PrintRecordData) const {
+  llvm_unreachable("not supported");
+}
+
+struct OnDiskDataAllocator::ImplType {};
+
+Expected<OnDiskDataAllocator>
+OnDiskDataAllocator::create(const Twine &PathTwine, const Twine &TableNameTwine,
+                            uint64_t MaxFileSize,
+                            Optional<uint64_t> NewFileInitialSize) {
+  llvm_unreachable("not supported");
+}
+
+OnDiskDataAllocator::pointer OnDiskDataAllocator::allocate(size_t Size) {
+  llvm_unreachable("not supported");
+}
+
+const char *OnDiskDataAllocator::beginData(FileOffset Offset) const {
+  llvm_unreachable("not supported");
+}
+
+#endif // LLVM_ENABLE_ONDISK_CAS
+
+OnDiskHashMappedTrie::OnDiskHashMappedTrie(std::unique_ptr<ImplType> Impl)
+    : Impl(std::move(Impl)) {}
+OnDiskHashMappedTrie::OnDiskHashMappedTrie(OnDiskHashMappedTrie &&RHS) =
+    default;
+OnDiskHashMappedTrie &
+OnDiskHashMappedTrie::operator=(OnDiskHashMappedTrie &&RHS) = default;
+OnDiskHashMappedTrie::~OnDiskHashMappedTrie() = default;
+
 OnDiskDataAllocator::OnDiskDataAllocator(OnDiskDataAllocator &&RHS) = default;
 OnDiskDataAllocator &
 OnDiskDataAllocator::operator=(OnDiskDataAllocator &&RHS) = default;

--- a/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
+++ b/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
@@ -18,8 +18,6 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 
-#if LLVM_ENABLE_ONDISK_CAS
-
 using namespace llvm;
 using namespace llvm::cas;
 
@@ -1271,5 +1269,3 @@ OnDiskDataAllocator::OnDiskDataAllocator(OnDiskDataAllocator &&RHS) = default;
 OnDiskDataAllocator &
 OnDiskDataAllocator::operator=(OnDiskDataAllocator &&RHS) = default;
 OnDiskDataAllocator::~OnDiskDataAllocator() = default;
-
-#endif // LLVM_ENABLE_ONDISK_CAS


### PR DESCRIPTION
`LLVM_ENABLE_ONDISK_CAS` in `llvm/CAS` headers is not a good idea because any file that includes them needs to get the macro definition. Reduce use of the macro and use it only for:

* Removing the functionality from the high-level CAS creation functions.
* Removing the functionality from tests.

Essentially we should treat `LLVM_ENABLE_ONDISK_CAS` as a temporary macro until Windows is fully supported.