### PR TITLE
[CAS][LTO] Move setCacheDir function into .cpp file

### DIFF
--- a/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
+++ b/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
@@ -166,40 +166,7 @@ public:
 
   /// Provide a path to a directory where to store the cached files for
   /// incremental build.
-  Error setCacheDir(std::string Path) {
-    // CacheDir can only be set once.
-    if (!CacheOptions.Path.empty())
-      return Error::success();
-
-    StringRef PathStr = Path;
-    // The environment overwrites the option parameter.
-    if (PathStr.consume_front("cas:")) {
-      CacheOptions.Type = CachingOptions::CacheType::CAS;
-      // Create ObjectStore and ActionCache.
-      auto MaybeCAS = cas::createOnDiskCAS(PathStr);
-      if (!MaybeCAS)
-        return MaybeCAS.takeError();
-      CacheOptions.CAS = std::move(*MaybeCAS);
-      auto MaybeCache = cas::createOnDiskActionCache(PathStr);
-      if (!MaybeCache)
-        return MaybeCache.takeError();
-      CacheOptions.Cache = std::move(*MaybeCache);
-      CacheOptions.Path = PathStr.str();
-    } else if (PathStr.consume_front("grpc:")) {
-      CacheOptions.Type = CachingOptions::CacheType::RemoteService;
-      auto MaybeService =
-          cas::remote::createCompilationCachingRemoteClient(PathStr);
-      if (!MaybeService)
-        return MaybeService.takeError();
-      CacheOptions.Service = std::move(*MaybeService);
-      CacheOptions.Path = PathStr.str();
-    } else {
-      CacheOptions.Type = CachingOptions::CacheType::CacheDirectory;
-      CacheOptions.Path = std::move(Path);
-    }
-
-    return Error::success();
-  }
+  Error setCacheDir(std::string Path);
 
   /// Create a cache entry for the module
   std::unique_ptr<ModuleCacheEntry> createModuleCacheEntry(

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -843,6 +843,41 @@ Error ModuleCacheEntry::writeObject(const MemoryBuffer &OutputBuffer,
   return Error::success();
 }
 
+Error ThinLTOCodeGenerator::setCacheDir(std::string Path) {
+  // CacheDir can only be set once.
+  if (!CacheOptions.Path.empty())
+    return Error::success();
+
+  StringRef PathStr = Path;
+  // The environment overwrites the option parameter.
+  if (PathStr.consume_front("cas:")) {
+    CacheOptions.Type = CachingOptions::CacheType::CAS;
+    // Create ObjectStore and ActionCache.
+    auto MaybeCAS = cas::createOnDiskCAS(PathStr);
+    if (!MaybeCAS)
+      return MaybeCAS.takeError();
+    CacheOptions.CAS = std::move(*MaybeCAS);
+    auto MaybeCache = cas::createOnDiskActionCache(PathStr);
+    if (!MaybeCache)
+      return MaybeCache.takeError();
+    CacheOptions.Cache = std::move(*MaybeCache);
+    CacheOptions.Path = PathStr.str();
+  } else if (PathStr.consume_front("grpc:")) {
+    CacheOptions.Type = CachingOptions::CacheType::RemoteService;
+    auto MaybeService =
+        cas::remote::createCompilationCachingRemoteClient(PathStr);
+    if (!MaybeService)
+      return MaybeService.takeError();
+    CacheOptions.Service = std::move(*MaybeService);
+    CacheOptions.Path = PathStr.str();
+  } else {
+    CacheOptions.Type = CachingOptions::CacheType::CacheDirectory;
+    CacheOptions.Path = std::move(Path);
+  }
+
+  return Error::success();
+}
+
 std::unique_ptr<ModuleCacheEntry> ThinLTOCodeGenerator::createModuleCacheEntry(
     const ModuleSummaryIndex &Index, StringRef ModuleID, StringRef OutputPath,
     const FunctionImporter::ImportMapTy &ImportList,


### PR DESCRIPTION
setCacheDir function calls into CAS/RemoteCachingService creating function that will add extra dependency for the tools that calls this method. Fold the call into libLLVMLTO since this function is not in critical path that inlining will help performance.

rdar://104907472
(cherry picked from commit 832f52cd2a6a3d2add47aef021f560fd858ecfd4)