### PR TITLE
[clang][cas][test] Fix some tests that depended on build directory name

### DIFF
--- a/clang/test/ClangScanDeps/modules-cas-fs-prefix-mapping.c
+++ b/clang/test/ClangScanDeps/modules-cas-fs-prefix-mapping.c
@@ -116,10 +116,11 @@
 // CHECK:            ]
 // CHECK:            "context-hash": "[[B_CONTEXT_HASH]]"
 // CHECK:            "file-deps": [
-// CHECK:              "{{.*}}/include/stdarg.h"
-// CHECK:              "[[PREFIX]]/b.h"
-// CHECK:              "[[PREFIX]]/module.modulemap"
-// CHECK:              "[[SDK_PREFIX]]/usr/include/stdlib.h"
+// Note: PREFIX, SDK_PREFIX and toolchain path are unordered
+// CHECK-DAG:          "{{.*}}/include/stdarg.h"
+// CHECK-DAG:          "[[PREFIX]]/b.h"
+// CHECK-DAG:          "[[PREFIX]]/module.modulemap"
+// CHECK-DAG:          "[[SDK_PREFIX]]/usr/include/stdlib.h"
 // CHECK:            ]
 // CHECK:            "name": "B"
 // CHECK:          }

--- a/clang/test/ClangScanDeps/modules-pch-cas-fs-prefix-mapping.c
+++ b/clang/test/ClangScanDeps/modules-pch-cas-fs-prefix-mapping.c
@@ -146,10 +146,11 @@
 // PCH:            ]
 // PCH:            "context-hash": "[[B_CONTEXT_HASH]]"
 // PCH:            "file-deps": [
-// PCH:              "{{.*}}/include/stdarg.h"
-// PCH:              "[[PREFIX]]/b.h"
-// PCH:              "[[PREFIX]]/module.modulemap"
-// PCH:              "[[SDK_PREFIX]]/usr/include/stdlib.h"
+// Note: PREFIX, SDK_PREFIX and toolchain path are unordered
+// PCH-DAG:          "{{.*}}/include/stdarg.h"
+// PCH-DAG:          "[[PREFIX]]/b.h"
+// PCH-DAG:          "[[PREFIX]]/module.modulemap"
+// PCH-DAG:          "[[SDK_PREFIX]]/usr/include/stdlib.h"
 // PCH:            ]
 // PCH:            "name": "B"
 // PCH:          }


### PR DESCRIPTION
We sort module file-deps by name, but tests that have deps spanning different directory "roots" such as build and source directories need to ignore the ordering.

(cherry picked from commit acab3889a6f4e2745c4d8aa3c7d80d7926a204ee)