### PR TITLE
[cherry-pick][stable/20221013] [lldb][SymbolFileDWARF] Support by-name lookup of global variables in inline namespaces

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2242,8 +2242,14 @@ void SymbolFileDWARF::FindGlobalVariables(
       if (DWARFASTParser *dwarf_ast = GetDWARFParser(*die.GetCU())) {
         CompilerDeclContext actual_parent_decl_ctx =
             dwarf_ast->GetDeclContextContainingUIDFromDWARF(die);
+
+        /// If the actual namespace is inline (i.e., had a DW_AT_export_symbols)
+        /// and a child (possibly through other layers of inline namespaces)
+        /// of the namespace referred to by 'basename', allow the lookup to
+        /// succeed.
         if (!actual_parent_decl_ctx ||
-            actual_parent_decl_ctx != parent_decl_ctx)
+            (actual_parent_decl_ctx != parent_decl_ctx &&
+             !parent_decl_ctx.IsContainedInLookup(actual_parent_decl_ctx)))
           return true;
       }
     }

--- a/lldb/test/API/commands/expression/inline-namespace/TestInlineNamespace.py
+++ b/lldb/test/API/commands/expression/inline-namespace/TestInlineNamespace.py
@@ -23,3 +23,35 @@ class TestInlineNamespace(TestBase):
         # But we should still find the function when we pretend the inline
         # namespace is not inline.
         self.expect_expr("A::B::f()", result_type="int", result_value="3")
+
+        self.expect_expr("A::B::global_var", result_type="int", result_value="0")
+        # FIXME: should be ambiguous lookup but ClangExpressionDeclMap takes
+        #        first global variable that the lookup found, which in this case
+        #        is A::B::global_var
+        self.expect_expr("A::global_var", result_type="int", result_value="0")
+
+        self.expect_expr("A::B::C::global_var", result_type="int", result_value="1")
+        self.expect_expr("A::C::global_var", result_type="int", result_value="1")
+
+        self.expect_expr("A::B::D::nested_var", result_type="int", result_value="2")
+        self.expect_expr("A::D::nested_var", result_type="int", result_value="2")
+        self.expect_expr("A::B::nested_var", result_type="int", result_value="2")
+        self.expect_expr("A::nested_var", result_type="int", result_value="2")
+
+        self.expect_expr("A::E::F::other_var", result_type="int", result_value="3")
+        self.expect_expr("A::E::other_var", result_type="int", result_value="3")
+
+        self.expect("expr A::E::global_var", error=True, substrs=["no member named 'global_var' in namespace 'A::E'"])
+        self.expect("expr A::E::F::global_var", error=True, substrs=["no member named 'global_var' in namespace 'A::E::F'"])
+
+        self.expect("expr A::other_var", error=True, substrs=["no member named 'other_var' in namespace 'A'"])
+        self.expect("expr A::B::other_var", error=True, substrs=["no member named 'other_var' in namespace 'A::B'"])
+        self.expect("expr B::other_var", error=True, substrs=["no member named 'other_var' in namespace 'A::B'"])
+
+        # 'frame variable' can correctly distinguish between A::B::global_var and A::global_var
+        gvars = self.target().FindGlobalVariables("A::global_var", 10)
+        self.assertEqual(len(gvars), 1)
+        self.assertEqual(gvars[0].GetValueAsSigned(), 4)
+
+        self.expect("frame variable A::global_var", substrs=["(int) A::global_var = 4"])
+        self.expect("frame variable A::B::global_var", substrs=["(int) A::B::global_var = 0"])

--- a/lldb/test/API/commands/expression/inline-namespace/main.cpp
+++ b/lldb/test/API/commands/expression/inline-namespace/main.cpp
@@ -1,10 +1,28 @@
 namespace A {
   inline namespace B {
     int f() { return 3; }
+    int global_var = 0;
+
+    namespace C {
+    int global_var = 1;
+    }
+
+    inline namespace D {
+    int nested_var = 2;
+    }
   };
+
+  namespace E {
+  inline namespace F {
+  int other_var = 3;
+  }
+  } // namespace E
+
+  int global_var = 4;
 }
 
 int main(int argc, char **argv) {
   // Set break point at this line.
-  return A::f();
+  return A::f() + A::B::global_var + A::C::global_var + A::E::F::other_var +
+         A::B::D::nested_var;
 }


### PR DESCRIPTION
Currently evaluating an expression involving a global variable inside an inline namespace will fail to lookup said variable. This is because the `SymbolFileDWARF::FindGlobalVariables` discards from consideration all DIEs whose decl_context doesn't exactly match that of the lookup.

This patch relaxes this restriction by checking whether C++ rules would permit the lookup. This is permitted by the DWARFv5 spec in chapter `3.2.2 Namespace Entries`:
```
A namespace may have a DW_AT_export_symbols attribute which is a flag
which indicates that all member names defined within the namespace may be
referenced as if they were defined within the containing namespace.
```

The motivation for this is evaluating `std::ranges` expressions, which heavily rely on global variables inside inline namespaces. E.g., `std::views::all(...)` is just an invocation of the `operator()` on `std::ranges::views::__cpo::all`.

**Testing**

* Added API tests

Differential Revision: https://reviews.llvm.org/D143068

(cherry picked from commit f8c9b30eb3e8cffc6c7adaa3003c774422643cf7)