### PR TITLE
[stable/20221013][lldb][Test] Fix incorrect assertion on omitted template argument

### DIFF
--- a/lldb/test/API/lang/cpp/complete-type-check/TestCppIsTypeComplete.py
+++ b/lldb/test/API/lang/cpp/complete-type-check/TestCppIsTypeComplete.py
@@ -51,7 +51,7 @@ class TestCase(TestBase):
         # Record types without a defining declaration are not complete.
         self.assertPointeeIncomplete("FwdClass *", "fwd_class")
         self.assertPointeeIncomplete("FwdClassTypedef *", "fwd_class_typedef")
-        self.assertPointeeIncomplete("FwdTemplateClass<> *", "fwd_template_class")
+        self.assertPointeeIncomplete("FwdTemplateClass<int> *", "fwd_template_class")
 
         # A pointer type is complete even when it points to an incomplete type.
         fwd_class_ptr = self.expect_expr("fwd_class", result_type="FwdClass *")


### PR DESCRIPTION
This is just a missing cherry-pick of `a842f74056793d9ab41411aa343811368164e6a8`. The test was really asserting the wrong thing. The template argument shouldn’t be omitted.

I don’t think we want to pull in the whole commit. So I’ll just adjust the test case.

What I think happened is that independently, my cherry-picks to stable/20221013 for omitting default template arguments fixed this flawed test-case `e5d4d9d50c7782aba2bbb9670db9e0a19bfcedae`