### PR TITLE
Revert "[lldb] Fix --bind-generic-types to only apply to expression"

### DIFF
--- a/lldb/include/lldb/Interpreter/OptionGroupValueObjectDisplay.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupValueObjectDisplay.h
@@ -33,7 +33,8 @@ public:
     return show_types || no_summary_depth != 0 || show_location ||
            flat_output || use_objc || max_depth != UINT32_MAX ||
            ptr_depth != 0 || !use_synth || be_raw || ignore_cap ||
-           run_validator;
+           run_validator ||
+           bind_generic_types != lldb::eBindAuto;
   }
 
   DumpValueObjectOptions GetAsDumpOptions(
@@ -51,6 +52,7 @@ public:
   uint32_t ptr_depth;
   uint32_t elem_count;
   lldb::DynamicValueType use_dynamic;
+  lldb::BindGenericTypes bind_generic_types;
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -54,6 +54,8 @@ class SwiftASTContextForExpressions;
 
 OptionEnumValues GetDynamicValueTypes();
 
+OptionEnumValues GetBindGenericTypesOptions();
+
 enum InlineStrategy {
   eInlineBreakpointsNever = 0,
   eInlineBreakpointsHeaders,

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -504,15 +504,11 @@ enum DynamicValueType {
   eDynamicDontRunTarget = 2
 };
 
-// BEGIN SWIFT
-//  Enumeration to control whether generic type parameters should be bound or
-//  not in expression evaluation.
-enum BindGenericTypes { 
-  eBindAuto = 0, 
-  eBind = 1, 
-  eDontBind = 2 
+enum BindGenericTypes {
+  eBindAuto = 0,
+  eBind = 1,
+  eDontBind = 2
 };
-// END SWIFT
 
 enum StopShowColumn {
   eStopShowColumnAnsiOrCaret = 0,

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -149,17 +149,6 @@ Status CommandObjectExpression::CommandOptions::SetOptionValue(
     break;
   }
 
-  // BEGIN SWIFT
-  case '\x01': {
-    int32_t result;
-    result = OptionArgParser::ToOptionEnum(option_arg, BindGenTypeParamValue(),
-                                           0, error);
-    if (error.Success())
-      bind_generic_types = (BindGenericTypes)result;
-    break;
-  }
-  // END SWIFT
-
   default:
     llvm_unreachable("Unimplemented option");
   }
@@ -188,9 +177,6 @@ void CommandObjectExpression::CommandOptions::OptionParsingStarting(
   auto_apply_fixits = eLazyBoolCalculate;
   top_level = false;
   allow_jit = true;
-  // BEGIN SWIFT
-  bind_generic_types = eBindAuto;
-  // END SWIFT
 }
 
 llvm::ArrayRef<OptionDefinition>
@@ -374,7 +360,7 @@ CommandObjectExpression::GetEvalOptions(const Target &target) {
   options.SetDebug(m_command_options.debug);
 
   // BEGIN SWIFT
-  options.SetBindGenericTypes(m_command_options.bind_generic_types);
+  options.SetBindGenericTypes(m_varobj_options.bind_generic_types);
   // If the language was not specified in the expression command,
   // set it to the language in the target's properties if
   // specified, else default to the language for the frame.

--- a/lldb/source/Commands/CommandObjectExpression.h
+++ b/lldb/source/Commands/CommandObjectExpression.h
@@ -19,24 +19,6 @@
 
 namespace lldb_private {
 
-// BEGIN SWIFT
-static constexpr OptionEnumValueElement g_bind_gen_type_params[] = {
-    {
-        lldb::eBindAuto,
-        "auto",
-        "Attempt to run the expression with bound generic parameters first, "
-        "fallback to unbound generic parameters if binding the type parameters "
-        "fails",
-    },
-    {lldb::eBind, "true", "Bind generic type parameters."},
-    {lldb::eDontBind, "false", "Don't bind generic type parameters."},
-};
-
-static constexpr OptionEnumValues BindGenTypeParamValue() {
-  return OptionEnumValues(g_bind_gen_type_params);
-}
-// END SWIFT
-
 class CommandObjectExpression : public CommandObjectRaw,
                                 public IOHandlerDelegate {
 public:
@@ -65,9 +47,6 @@ public:
     lldb::LanguageType language;
     LanguageRuntimeDescriptionDisplayVerbosity m_verbosity;
     LazyBool auto_apply_fixits;
-// BEGIN SWIFT
-    lldb::BindGenericTypes bind_generic_types;
-// END SWIFT
   };
 
   CommandObjectExpression(CommandInterpreter &interpreter);

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -392,12 +392,6 @@ let Command = "expression" in {
     Arg<"Boolean">,
     Desc<"Controls whether the expression can fall back to being JITted if it's "
     "not supported by the interpreter (defaults to true).">;
-  // BEGIN SWIFT
-  def bind_generic_types : Option<"bind-generic-types", "\\x01">,
-    EnumArg<"Value", "BindGenTypeParamValue()">, Desc<"Controls whether any "
-    "generic types in the current context should be bound to their dynamic "
-    "type before evaluating. Defaults to auto.">;
-  // END SWIFT
 }
 
 let Command = "frame diag" in {

--- a/lldb/source/Interpreter/OptionGroupValueObjectDisplay.cpp
+++ b/lldb/source/Interpreter/OptionGroupValueObjectDisplay.cpp
@@ -59,6 +59,11 @@ static const OptionDefinition g_option_table[] = {
      OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeCount,
      "Treat the result of the expression as if its type is an array of this "
      "many values."},
+    {LLDB_OPT_SET_1, false, "bind-generic-types", /* no short option */ 1,
+     OptionParser::eRequiredArgument, nullptr, GetBindGenericTypesOptions(), 0,
+     eArgTypeNone, "Controls whether any generic types in the current "
+       "context should be bound to their dynamic concrete types before "
+       "evaluating. Defaults to auto."}
 };
 
 llvm::ArrayRef<OptionDefinition>
@@ -150,6 +155,14 @@ Status OptionGroupValueObjectDisplay::SetOptionValue(
                                      option_arg.str().c_str());
     break;
 
+  case 1:
+    int32_t result;
+    result = OptionArgParser::ToOptionEnum(option_arg, GetBindGenericTypesOptions(),
+                                           0, error);
+    if (error.Success())
+      bind_generic_types = (lldb::BindGenericTypes)result;
+    break;
+
   default:
     llvm_unreachable("Unimplemented option");
   }
@@ -173,6 +186,7 @@ void OptionGroupValueObjectDisplay::OptionParsingStarting(
   be_raw = false;
   ignore_cap = false;
   run_validator = false;
+  bind_generic_types = lldb::eBindAuto;
 
   TargetSP target_sp =
       execution_context ? execution_context->GetTargetSP() : TargetSP();

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4231,6 +4231,30 @@ OptionEnumValues lldb_private::GetDynamicValueTypes() {
   return OptionEnumValues(g_dynamic_value_types);
 }
 
+static constexpr OptionEnumValueElement g_bind_generic_types[] = {
+    {
+        eBindAuto,
+        "auto",
+        "Attempt to run the expression with bound generic parameters first, "
+        "fallback to unbound generic parameters if binding the type parameters "
+        "fails",
+    },
+    {
+        eBind,
+        "true",
+        "Bind the generic type parameters.",
+    },
+    {
+        eDontBind,
+        "false",
+        "Don't bind the generic type parameters.",
+    },
+};
+
+OptionEnumValues lldb_private::GetBindGenericTypesOptions() {
+  return OptionEnumValues(g_bind_generic_types);
+}
+
 static constexpr OptionEnumValueElement g_inline_breakpoint_enums[] = {
     {
         eInlineBreakpointsNever,


### PR DESCRIPTION
This reverts commit 86ad59f602f81344c1cb83073c2632ac24eac1d2.

(cherry picked from commit 701ada47ac3daa9718cfeca026e84afe7a96ea38)