### PR TITLE
[lldb][test] Replace use of p with expression (NFC)

### DIFF
--- a/lldb/test/API/commands/expression/call-function/TestCallStdStringFunction.py
+++ b/lldb/test/API/commands/expression/call-function/TestCallStdStringFunction.py
@@ -19,7 +19,7 @@ class ExprCommandCallFunctionTestCase(TestBase):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "// break here", lldb.SBFileSpec("main.cpp"))
 
-        self.expect("print str",
+        self.expect("expression str",
                     substrs=['Hello world'])
 
         # Calling this function now succeeds, but we follow the typedef return type through to
@@ -32,5 +32,5 @@ class ExprCommandCallFunctionTestCase(TestBase):
         if triple in ["arm64-apple-ios", "arm64e-apple-ios", "arm64-apple-tvos", "armv7k-apple-watchos", "arm64-apple-bridgeos", "arm64_32-apple-watchos"]:
             do_cstr_test = False
         if do_cstr_test:
-            self.expect("print str.c_str()",
+            self.expect("expression str.c_str()",
                         substrs=['Hello world'])

--- a/lldb/test/API/commands/expression/codegen-crash-typedefdecl-not-in_declcontext/main.cpp
+++ b/lldb/test/API/commands/expression/codegen-crash-typedefdecl-not-in_declcontext/main.cpp
@@ -23,7 +23,7 @@ struct E {
   E(B &b) : b_ref(b) {}
   NS::DW f() { return {}; };
   void g() {
-    return; //%self.expect("p b_ref", substrs=['(B) $0 =', '(spd = NS::DW', 'a = 0)'])
+    return; //%self.expect("expression b_ref", substrs=['(B) $0 =', '(spd = NS::DW', 'a = 0)'])
   }
 
   B &b_ref;

--- a/lldb/test/API/commands/expression/persist_objc_pointeetype/TestPersistObjCPointeeType.py
+++ b/lldb/test/API/commands/expression/persist_objc_pointeetype/TestPersistObjCPointeeType.py
@@ -38,11 +38,16 @@ class PersistObjCPointeeType(TestBase):
 
         self.runCmd("run", RUN_SUCCEEDED)
 
-        self.expect("p *self", substrs=['_sc_name = nil',
-                                        '_sc_name2 = nil',
-                                        '_sc_name3 = nil',
-                                        '_sc_name4 = nil',
-                                        '_sc_name5 = nil',
-                                        '_sc_name6 = nil',
-                                        '_sc_name7 = nil',
-                                        '_sc_name8 = nil'])
+        self.expect(
+            "expression *self",
+            substrs=[
+                "_sc_name = nil",
+                "_sc_name2 = nil",
+                "_sc_name3 = nil",
+                "_sc_name4 = nil",
+                "_sc_name5 = nil",
+                "_sc_name6 = nil",
+                "_sc_name7 = nil",
+                "_sc_name8 = nil",
+            ],
+        )

--- a/lldb/test/API/commands/expression/rdar44436068/main.c
+++ b/lldb/test/API/commands/expression/rdar44436068/main.c
@@ -2,7 +2,7 @@ int main(void)
 {
     __int128_t n = 1;
     n = n + n;
-    return n; //%self.expect("p n", substrs=['(__int128_t) $0 = 2'])
-              //%self.expect("p n + 6", substrs=['(__int128) $1 = 8'])
-              //%self.expect("p n + n", substrs=['(__int128) $2 = 4'])
+    return n; //%self.expect("expression n", substrs=['(__int128_t) $0 = 2'])
+              //%self.expect("expression n + 6", substrs=['(__int128) $1 = 8'])
+              //%self.expect("expression n + n", substrs=['(__int128) $2 = 4'])
 }

--- a/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_static_config/TestSVERegisters.py
+++ b/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_static_config/TestSVERegisters.py
@@ -163,7 +163,7 @@ class RegisterCommandsTestCase(TestBase):
         self.check_sve_regs_read(z_reg_size)
 
         # Evaluate simple expression and print function expr_eval_func address.
-        self.expect("p expr_eval_func", substrs=["= 0x"])
+        self.expect("expression expr_eval_func", substrs=["= 0x"])
 
         # Evaluate expression call function expr_eval_func.
         self.expect_expr("expr_eval_func()",

--- a/lldb/test/API/commands/target/dump-pcm-info/TestDumpPCMInfo.py
+++ b/lldb/test/API/commands/target/dump-pcm-info/TestDumpPCMInfo.py
@@ -30,7 +30,7 @@ class TestCase(TestBase):
         self.runCmd(f"settings set symbols.clang-modules-cache-path '{mod_cache}'")
 
         # Cause lldb to generate a Darwin-*.pcm
-        self.runCmd("p @import Darwin")
+        self.runCmd("expression @import Darwin")
 
         # root/<config-hash>/<module-name>-<modulemap-path-hash>.pcm
         pcm_paths = glob.glob(os.path.join(mod_cache, '*', 'Darwin-*.pcm'))

--- a/lldb/test/API/functionalities/alias/Makefile
+++ b/lldb/test/API/functionalities/alias/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/alias/TestPAlias.py
+++ b/lldb/test/API/functionalities/alias/TestPAlias.py
@@ -1,0 +1,11 @@
+import lldb
+from lldbsuite.test.lldbtest import TestBase
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "return", lldb.SBFileSpec("main.c"))
+        self.expect("p -g", substrs=["$0 = -"])
+        self.expect("p -i0 -g", error=True)

--- a/lldb/test/API/functionalities/alias/main.c
+++ b/lldb/test/API/functionalities/alias/main.c
@@ -1,0 +1,4 @@
+int main() {
+  int g = 41;
+  return 0;
+}

--- a/lldb/test/API/functionalities/backticks/TestBackticksWithoutATarget.py
+++ b/lldb/test/API/functionalities/backticks/TestBackticksWithoutATarget.py
@@ -15,5 +15,5 @@ class BackticksWithNoTargetTestCase(TestBase):
     @no_debug_info_test
     def test_backticks_no_target(self):
         """A simple test of backticks without a target."""
-        self.expect("print `1+2-3`",
+        self.expect("expression `1+2-3`",
                     substrs=[' = 0'])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-categories/TestDataFormatterCategories.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-categories/TestDataFormatterCategories.py
@@ -260,13 +260,13 @@ class CategoriesDataFormatterTestCase(TestBase):
             "type summary add Shape -w BaseCategory --summary-string \"AShape\"")
         self.runCmd("type category enable BaseCategory")
 
-        self.expect("print (Shape*)&c1",
+        self.expect("expression (Shape*)&c1",
                     substrs=['AShape'])
-        self.expect("print (Shape*)&r1",
+        self.expect("expression (Shape*)&r1",
                     substrs=['AShape'])
-        self.expect("print (Shape*)c_ptr",
+        self.expect("expression (Shape*)c_ptr",
                     substrs=['AShape'])
-        self.expect("print (Shape*)r_ptr",
+        self.expect("expression (Shape*)r_ptr",
                     substrs=['AShape'])
 
         self.runCmd(

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
@@ -102,17 +102,17 @@ class CppDataFormatterTestCase(TestBase):
 
         # check that rdar://problem/10011145 (Standard summary format for
         # char[] doesn't work as the result of "expr".) is solved
-        self.expect("p strarr",
+        self.expect("expression strarr",
                     substrs=['arr = "Hello world!'])
 
         self.expect("frame variable strptr",
                     substrs=['ptr = "Hello world!"'])
 
-        self.expect("p strptr",
+        self.expect("expression strptr",
                     substrs=['ptr = "Hello world!"'])
 
         self.expect(
-            "p (char*)\"1234567890123456789012345678901234567890123456789012345678901234ABC\"",
+            "expression (char*)\"1234567890123456789012345678901234567890123456789012345678901234ABC\"",
             substrs=[
                 '(char *) $',
                 ' = ptr = ',

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-ptr-to-array/TestPtrToArrayFormatting.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-ptr-to-array/TestPtrToArrayFormatting.py
@@ -45,10 +45,10 @@ class PtrToArrayDataFormatterTestCase(TestBase):
         # Execute the cleanup function during test case tear down.
         self.addTearDownHook(cleanup)
 
-        self.expect('p *(int (*)[3])foo',
+        self.expect('expression *(int (*)[3])foo',
                     substrs=['(int[3]) $', '[0] = 1', '[1] = 2', '[2] = 3'])
 
-        self.expect('p *(int (*)[3])foo', matching=False,
+        self.expect('expression *(int (*)[3])foo', matching=False,
                     substrs=['01 00 00 00 02 00 00 00 03 00 00 00'])
-        self.expect('p *(int (*)[3])foo', matching=False,
+        self.expect('expression *(int (*)[3])foo', matching=False,
                     substrs=['0x000000030000000200000001'])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-smart-array/TestDataFormatterSmartArray.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-smart-array/TestDataFormatterSmartArray.py
@@ -76,11 +76,11 @@ class SmartArrayDataFormatterTestCase(TestBase):
                     substrs=['arr = \"',
                              'Nested Hello world!'])
 
-        self.expect("p strarr",
+        self.expect("expression strarr",
                     substrs=['arr = \"',
                              'Hello world!'])
 
-        self.expect("p other.strarr",
+        self.expect("expression other.strarr",
                     substrs=['arr = \"',
                              'Nested Hello world!'])
 
@@ -96,11 +96,11 @@ class SmartArrayDataFormatterTestCase(TestBase):
                     substrs=['ptr = \"',
                              'Nested Hello world!'])
 
-        self.expect("p strptr",
+        self.expect("expression strptr",
                     substrs=['ptr = \"',
                              'Hello world!'])
 
-        self.expect("p other.strptr",
+        self.expect("expression other.strptr",
                     substrs=['ptr = \"',
                              'Nested Hello world!'])
 
@@ -115,11 +115,11 @@ class SmartArrayDataFormatterTestCase(TestBase):
                     substrs=['arr = \"',
                              'Nested Hello world!'])
 
-        self.expect("p strarr",
+        self.expect("expression strarr",
                     substrs=['arr = \"',
                              'Hello world!'])
 
-        self.expect("p other.strarr",
+        self.expect("expression other.strarr",
                     substrs=['arr = \"',
                              'Nested Hello world!'])
 
@@ -135,11 +135,11 @@ class SmartArrayDataFormatterTestCase(TestBase):
                     substrs=['arr = ',
                              'Nested Hello world!'])
 
-        self.expect("p strarr",
+        self.expect("expression strarr",
                     substrs=['arr = \"',
                              'Hello world!'])
 
-        self.expect("p other.strarr",
+        self.expect("expression other.strarr",
                     substrs=['arr = ',
                              'Nested Hello world!'])
 
@@ -154,11 +154,11 @@ class SmartArrayDataFormatterTestCase(TestBase):
                     substrs=['ptr = \"',
                              'Nested Hello world!'])
 
-        self.expect("p strptr",
+        self.expect("expression strptr",
                     substrs=['ptr = \"',
                              'Hello world!'])
 
-        self.expect("p other.strptr",
+        self.expect("expression other.strptr",
                     substrs=['ptr = \"',
                              'Nested Hello world!'])
 
@@ -174,11 +174,11 @@ class SmartArrayDataFormatterTestCase(TestBase):
                     substrs=['arr = ',
                              'Nested Hello world!'])
 
-        self.expect("p strarr",
+        self.expect("expression strarr",
                     substrs=['arr = \"',
                              'Hello world!'])
 
-        self.expect("p other.strarr",
+        self.expect("expression other.strarr",
                     substrs=['arr = ',
                              'Nested Hello world!'])
 
@@ -193,11 +193,11 @@ class SmartArrayDataFormatterTestCase(TestBase):
                     substrs=['ptr = \"',
                              'Nested Hello world!'])
 
-        self.expect("p strptr",
+        self.expect("expression strptr",
                     substrs=['ptr = \"',
                              'Hello world!'])
 
-        self.expect("p other.strptr",
+        self.expect("expression other.strptr",
                     substrs=['ptr = \"',
                              'Nested Hello world!'])
 
@@ -214,11 +214,11 @@ class SmartArrayDataFormatterTestCase(TestBase):
                     substrs=['ptr = \"',
                              'Nested Hello world!'])
 
-        self.expect("p strptr", matching=False,
+        self.expect("expression strptr", matching=False,
                     substrs=['ptr = \"',
                              'Hello world!'])
 
-        self.expect("p other.strptr", matching=False,
+        self.expect("expression other.strptr", matching=False,
                     substrs=['ptr = \"',
                              'Nested Hello world!'])
 
@@ -234,11 +234,11 @@ class SmartArrayDataFormatterTestCase(TestBase):
                     substrs=['ptr = ',
                              '[{N},{e}]'])
 
-        self.expect("p strptr",
+        self.expect("expression strptr",
                     substrs=['ptr = ',
                              '[{H},{e}]'])
 
-        self.expect("p other.strptr",
+        self.expect("expression other.strptr",
                     substrs=['ptr = ',
                              '[{N},{e}]'])
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/list/TestDataFormatterGenericList.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/list/TestDataFormatterGenericList.py
@@ -73,7 +73,7 @@ class GenericListDataFormatterTestCase(TestBase):
                     substrs=['size=0',
                              '{}'])
 
-        self.expect("p numbers_list",
+        self.expect("expression numbers_list",
                     substrs=['size=0',
                              '{}'])
 
@@ -114,7 +114,7 @@ class GenericListDataFormatterTestCase(TestBase):
                              '[5] =',
                              '0x0cab0cab'])
 
-        self.expect("p numbers_list",
+        self.expect("expression numbers_list",
                     substrs=['size=6',
                              '[0] = ',
                              '0x12345678',
@@ -186,7 +186,7 @@ class GenericListDataFormatterTestCase(TestBase):
                              '[2]', 'smart',
                              '[3]', '!!!'])
 
-        self.expect("p text_list",
+        self.expect("expression text_list",
                     substrs=['size=4',
                              '\"goofy\"',
                              '\"is\"',

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/multimap/TestDataFormatterGenericMultiMap.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/multimap/TestDataFormatterGenericMultiMap.py
@@ -119,7 +119,7 @@ class GenericMultiMapDataFormatterTestCase(TestBase):
 
         self.check("ii", 8)
 
-        self.expect("p ii",
+        self.expect("expression ii",
                     substrs=[multimap, 'size=8',
                              '[5] = ',
                              'first = 5',
@@ -180,7 +180,7 @@ class GenericMultiMapDataFormatterTestCase(TestBase):
                 '[3] = (first = "zero", second = 0)',
             ])
 
-        self.expect("p si",
+        self.expect("expression si",
                     substrs=[multimap, 'size=4',
                 '[0] = (first = "one", second = 1)',
                 '[1] = (first = "three", second = 3)',
@@ -232,7 +232,7 @@ class GenericMultiMapDataFormatterTestCase(TestBase):
             ])
 
         self.expect(
-            "p is",
+            "expression is",
             substrs=[
                 multimap,
                 'size=4',
@@ -291,7 +291,7 @@ class GenericMultiMapDataFormatterTestCase(TestBase):
         self.check("ss", 3)
 
         self.expect(
-            "p ss",
+            "expression ss",
             substrs=[
                 multimap,
                 'size=3',

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/multiset/TestDataFormatterGenericMultiSet.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/multiset/TestDataFormatterGenericMultiSet.py
@@ -106,7 +106,7 @@ class GenericMultiSetDataFormatterTestCase(TestBase):
             ])
         self.check("ss", 4)
         self.expect(
-            "p ss",
+            "expression ss",
             substrs=[
                 "size=4",
                 '[0] = "a"',

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/set/TestDataFormatterGenericSet.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/set/TestDataFormatterGenericSet.py
@@ -101,7 +101,7 @@ class GenericSetDataFormatterTestCase(TestBase):
                      '[2] = "b"',
                      '[3] = "c"'])
         self.expect(
-            "p ss",
+            "expression ss",
             substrs=["size=4",
                      '[0] = "a"',
                      '[1] = "a very long string is right here"',

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/map/TestDataFormatterLibccMap.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/map/TestDataFormatterLibccMap.py
@@ -90,7 +90,7 @@ class LibcxxMapDataFormatterTestCase(TestBase):
 
         lldbutil.continue_to_breakpoint(self.process(), bkpt)
 
-        self.expect("p ii",
+        self.expect("expression ii",
                     substrs=['%s::map' % ns, 'size=8',
                              '[5] = ',
                              'first = 5',
@@ -161,7 +161,7 @@ class LibcxxMapDataFormatterTestCase(TestBase):
             ])
 
         self.expect(
-            "p si",
+            "expression si",
             substrs=[
                 '%s::map' % ns,
                 'size=4',
@@ -215,7 +215,7 @@ class LibcxxMapDataFormatterTestCase(TestBase):
             ])
 
         self.expect(
-            "p is",
+            "expression is",
             substrs=[
                 '%s::map' % ns,
                 'size=4',
@@ -268,7 +268,7 @@ class LibcxxMapDataFormatterTestCase(TestBase):
             ])
 
         self.expect(
-            "p ss",
+            "expression ss",
             substrs=[
                 '%s::map' % ns,
                 'size=3',

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/vector/TestDataFormatterLibcxxVector.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/vector/TestDataFormatterLibcxxVector.py
@@ -88,7 +88,7 @@ class LibcxxVectorDataFormatterTestCase(TestBase):
                              '[3] = 1234',
                              '}'])
 
-        self.expect("p numbers",
+        self.expect("expression numbers",
                     substrs=['$', 'size=4',
                              '[0] = 1',
                              '[1] = 12',
@@ -135,7 +135,7 @@ class LibcxxVectorDataFormatterTestCase(TestBase):
                              'is',
                              'smart'])
 
-        self.expect("p strings",
+        self.expect("expression strings",
                     substrs=['goofy',
                              'is',
                              'smart'])
@@ -149,7 +149,7 @@ class LibcxxVectorDataFormatterTestCase(TestBase):
                              'is',
                              'smart'])
 
-        self.expect("p strings",
+        self.expect("expression strings",
                     substrs=['vector has 3 items',
                              'goofy',
                              'is',
@@ -185,4 +185,4 @@ class LibcxxVectorDataFormatterTestCase(TestBase):
 
         self.expect("frame variable ptr", substrs=['ptr =', ' size=7'])
 
-        self.expect("p ptr", substrs=['$', 'size=7'])
+        self.expect("expression ptr", substrs=['$', 'size=7'])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/map/TestDataFormatterStdMap.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/map/TestDataFormatterStdMap.py
@@ -91,7 +91,7 @@ class StdMapDataFormatterTestCase(TestBase):
                              'first = 7',
                              'second = 1'])
 
-        self.expect("p ii",
+        self.expect("expression ii",
                     substrs=['map has 9 items',
                              '[5] = ',
                              'first = 5',
@@ -158,7 +158,7 @@ class StdMapDataFormatterTestCase(TestBase):
             ])
 
         self.expect(
-            "p si",
+            "expression si",
             substrs=[
                 'map has 5 items',
                 '[0] = (first = "four", second = 4)',
@@ -210,7 +210,7 @@ class StdMapDataFormatterTestCase(TestBase):
             ])
 
         self.expect(
-            "p is",
+            "expression is",
             substrs=[
                 'map has 4 items', '[0] = (first = 1, second = "is")',
                 '[1] = (first = 2, second = "smart")',
@@ -261,7 +261,7 @@ class StdMapDataFormatterTestCase(TestBase):
             ])
 
         self.expect(
-            "p ss",
+            "expression ss",
             substrs=[
                 'map has 4 items',
                 '[0] = (first = "a Mac..", second = "..is always a Mac!")',

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/vector/TestDataFormatterStdVector.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/vector/TestDataFormatterStdVector.py
@@ -72,7 +72,7 @@ class StdVectorDataFormatterTestCase(TestBase):
                              '[3] = 1234',
                              '}'])
 
-        self.expect("p numbers",
+        self.expect("expression numbers",
                     substrs=['$', 'size=4',
                              '[0] = 1',
                              '[1] = 12',
@@ -110,7 +110,7 @@ class StdVectorDataFormatterTestCase(TestBase):
                              '[6] = 1234567',
                              '}'])
 
-        self.expect("p numbers",
+        self.expect("expression numbers",
                     substrs=['$', 'size=7',
                              '[0] = 1',
                              '[1] = 12',
@@ -164,7 +164,7 @@ class StdVectorDataFormatterTestCase(TestBase):
                              'is',
                              'smart'])
 
-        self.expect("p strings",
+        self.expect("expression strings",
                     substrs=['goofy',
                              'is',
                              'smart'])
@@ -178,7 +178,7 @@ class StdVectorDataFormatterTestCase(TestBase):
                              'is',
                              'smart'])
 
-        self.expect("p strings",
+        self.expect("expression strings",
                     substrs=['vector has 3 items',
                              'goofy',
                              'is',

--- a/lldb/test/API/functionalities/inferior-assert/TestInferiorAssert.py
+++ b/lldb/test/API/functionalities/inferior-assert/TestInferiorAssert.py
@@ -243,10 +243,10 @@ class AssertingInferiorTestCase(TestBase):
             if 'main' == frame.GetFunctionName():
                 frame_id = frame.GetFrameID()
                 self.runCmd("frame select " + str(frame_id), RUN_SUCCEEDED)
-                self.expect("p argc", substrs=['(int)', ' = 1'])
-                self.expect("p hello_world", substrs=['Hello'])
-                self.expect("p argv[0]", substrs=['a.out'])
-                self.expect("p null_ptr", substrs=['= 0x0'])
+                self.expect("expression argc", substrs=['(int)', ' = 1'])
+                self.expect("expression hello_world", substrs=['Hello'])
+                self.expect("expression argv[0]", substrs=['a.out'])
+                self.expect("expression null_ptr", substrs=['= 0x0'])
                 return True
         return False
 

--- a/lldb/test/API/functionalities/inferior-crashing/TestInferiorCrashing.py
+++ b/lldb/test/API/functionalities/inferior-crashing/TestInferiorCrashing.py
@@ -124,8 +124,8 @@ class CrashingInferiorTestCase(TestBase):
 
         # The lldb expression interpreter should be able to read from addresses
         # of the inferior after a crash.
-        self.expect("p argc",
+        self.expect("expression argc",
                     startstr='(int) $0 = 1')
 
-        self.expect("p hello_world",
+        self.expect("expression hello_world",
                     substrs=['Hello'])

--- a/lldb/test/API/functionalities/inferior-crashing/TestInferiorCrashingStep.py
+++ b/lldb/test/API/functionalities/inferior-crashing/TestInferiorCrashingStep.py
@@ -145,9 +145,9 @@ class CrashingInferiorStepTestCase(TestBase):
 
         # The lldb expression interpreter should be able to read from addresses
         # of the inferior after a crash.
-        self.expect("p argc", startstr='(int) $0 = 1')
+        self.expect("expression argc", startstr='(int) $0 = 1')
 
-        self.expect("p hello_world", substrs=['Hello'])
+        self.expect("expression hello_world", substrs=['Hello'])
 
     def inferior_crashing_step(self):
         """Test that lldb functions correctly after stepping through a crash."""
@@ -167,8 +167,8 @@ class CrashingInferiorStepTestCase(TestBase):
 
         # The lldb expression interpreter should be able to read from addresses
         # of the inferior after a crash.
-        self.expect("p argv[0]", substrs=['a.out'])
-        self.expect("p null_ptr", substrs=['= 0x0'])
+        self.expect("expression argv[0]", substrs=['a.out'])
+        self.expect("expression null_ptr", substrs=['= 0x0'])
 
         # lldb should be able to read from registers from the inferior after
         # crashing.
@@ -212,11 +212,11 @@ class CrashingInferiorStepTestCase(TestBase):
 
         # The lldb expression interpreter should be able to read from addresses
         # of the inferior after a crash.
-        self.expect("p argv[0]", substrs=['a.out'])
+        self.expect("expression argv[0]", substrs=['a.out'])
 
         self.runCmd("next")
         self.check_stop_reason()
 
         # The lldb expression interpreter should be able to read from addresses
         # of the inferior after a crash.
-        self.expect("p argv[0]", substrs=['a.out'])
+        self.expect("expression argv[0]", substrs=['a.out'])

--- a/lldb/test/API/functionalities/inferior-crashing/recursive-inferior/TestRecursiveInferior.py
+++ b/lldb/test/API/functionalities/inferior-crashing/recursive-inferior/TestRecursiveInferior.py
@@ -134,5 +134,5 @@ class CrashingRecursiveInferiorTestCase(TestBase):
 
         # The lldb expression interpreter should be able to read from addresses
         # of the inferior after a crash.
-        self.expect("p i",
+        self.expect("expression i",
                     startstr='(int) $0 =')

--- a/lldb/test/API/functionalities/inferior-crashing/recursive-inferior/TestRecursiveInferiorStep.py
+++ b/lldb/test/API/functionalities/inferior-crashing/recursive-inferior/TestRecursiveInferiorStep.py
@@ -68,7 +68,7 @@ class CrashingRecursiveInferiorStepTestCase(TestBase):
 
         # The lldb expression interpreter should be able to read from addresses
         # of the inferior after a crash.
-        self.expect("p i", substrs=['(int) $0 ='])
+        self.expect("expression i", substrs=['(int) $0 ='])
 
         # lldb should be able to read from registers from the inferior after
         # crashing.
@@ -111,12 +111,12 @@ class CrashingRecursiveInferiorStepTestCase(TestBase):
 
         # The lldb expression interpreter should be able to read from addresses
         # of the inferior after a crash.
-        self.expect("p null", startstr='(char *) $0 = 0x0')
+        self.expect("expression null", startstr='(char *) $0 = 0x0')
 
         self.runCmd("next")
 
         # The lldb expression interpreter should be able to read from addresses
         # of the inferior after a step.
-        self.expect("p null", startstr='(char *) $1 = 0x0')
+        self.expect("expression null", startstr='(char *) $1 = 0x0')
 
         self.check_stop_reason()

--- a/lldb/test/API/functionalities/multiple-slides/TestMultipleSlides.py
+++ b/lldb/test/API/functionalities/multiple-slides/TestMultipleSlides.py
@@ -31,8 +31,8 @@ class MultipleSlidesTestCase(TestBase):
 
         # View the first element of `first` and `second` while
         # they have no load address set.
-        self.expect("p/d ((int*)&first)[0]", substrs=['= 5'])
-        self.expect("p/d ((int*)&second)[0]", substrs=['= 6'])
+        self.expect("expression/d ((int*)&first)[0]", substrs=['= 5'])
+        self.expect("expression/d ((int*)&second)[0]", substrs=['= 6'])
         self.assertEqual(first_sym.GetStartAddress().GetLoadAddress(target), lldb.LLDB_INVALID_ADDRESS)
         self.assertEqual(second_sym.GetStartAddress().GetLoadAddress(target), lldb.LLDB_INVALID_ADDRESS)
 
@@ -44,8 +44,8 @@ class MultipleSlidesTestCase(TestBase):
         #    0x1000 - 0x17ff  first[]
         #    0x1800 - 0x1fff  second[]
         target.SetModuleLoadAddress(module, 0)
-        self.expect("p/d ((int*)&first)[0]", substrs=['= 5'])
-        self.expect("p/d ((int*)&second)[0]", substrs=['= 6'])
+        self.expect("expression/d ((int*)&first)[0]", substrs=['= 5'])
+        self.expect("expression/d ((int*)&second)[0]", substrs=['= 6'])
         self.assertEqual(first_sym.GetStartAddress().GetLoadAddress(target), 
                          first_sym.GetStartAddress().GetFileAddress())
         self.assertEqual(second_sym.GetStartAddress().GetLoadAddress(target),
@@ -61,8 +61,8 @@ class MultipleSlidesTestCase(TestBase):
         # the beginning address of second[] will get a load address
         # of 0x1800, instead of 0x17c0 (0x1800-64) as we need to get.
         target.SetModuleLoadAddress(module, first_size - 64)
-        self.expect("p/d ((int*)&first)[0]", substrs=['= 5'])
-        self.expect("p/d ((int*)&second)[0]", substrs=['= 6'])
+        self.expect("expression/d ((int*)&first)[0]", substrs=['= 5'])
+        self.expect("expression/d ((int*)&second)[0]", substrs=['= 6'])
         self.assertNotEqual(first_sym.GetStartAddress().GetLoadAddress(target), 
                          first_sym.GetStartAddress().GetFileAddress())
         self.assertNotEqual(second_sym.GetStartAddress().GetLoadAddress(target),
@@ -70,8 +70,8 @@ class MultipleSlidesTestCase(TestBase):
 
         # Slide it back to the original vmaddr.
         target.SetModuleLoadAddress(module, 0)
-        self.expect("p/d ((int*)&first)[0]", substrs=['= 5'])
-        self.expect("p/d ((int*)&second)[0]", substrs=['= 6'])
+        self.expect("expression/d ((int*)&first)[0]", substrs=['= 5'])
+        self.expect("expression/d ((int*)&second)[0]", substrs=['= 6'])
         self.assertEqual(first_sym.GetStartAddress().GetLoadAddress(target), 
                          first_sym.GetStartAddress().GetFileAddress())
         self.assertEqual(second_sym.GetStartAddress().GetLoadAddress(target),

--- a/lldb/test/API/functionalities/set-data/TestSetData.py
+++ b/lldb/test/API/functionalities/set-data/TestSetData.py
@@ -24,7 +24,7 @@ class SetDataTestCase(TestBase):
 
         self.runCmd("run", RUN_SUCCEEDED)
 
-        self.expect("p myFoo.x", VARIABLES_DISPLAYED_CORRECTLY,
+        self.expect("expression myFoo.x", VARIABLES_DISPLAYED_CORRECTLY,
                     substrs=['2'])
 
         process = self.dbg.GetSelectedTarget().GetProcess()
@@ -40,7 +40,7 @@ class SetDataTestCase(TestBase):
 
         self.runCmd("continue")
 
-        self.expect("p myFoo.x", VARIABLES_DISPLAYED_CORRECTLY,
+        self.expect("expression myFoo.x", VARIABLES_DISPLAYED_CORRECTLY,
                     substrs=['4'])
 
         frame = process.GetSelectedThread().GetFrameAtIndex(0)

--- a/lldb/test/API/functionalities/ubsan/user-expression/TestUbsanUserExpression.py
+++ b/lldb/test/API/functionalities/ubsan/user-expression/TestUbsanUserExpression.py
@@ -38,7 +38,7 @@ class UbsanUserExpressionTestCase(TestBase):
         self.expect("thread list", STOPPED_DUE_TO_BREAKPOINT,
                     substrs=['stopped', 'stop reason = breakpoint'])
 
-        self.expect("p foo()", substrs=["(int) $0 = 42"])
+        self.expect("expression foo()", substrs=["(int) $0 = 42"])
 
         self.expect("thread list", STOPPED_DUE_TO_BREAKPOINT,
                     substrs=['stopped', 'stop reason = breakpoint'])

--- a/lldb/test/API/lang/c/enum_types/TestEnumTypes.py
+++ b/lldb/test/API/lang/c/enum_types/TestEnumTypes.py
@@ -42,7 +42,7 @@ class EnumTypesTestCase(TestBase):
         # Test the behavior in case have a variable of a type considered
         # 'bitfield' by the heuristic, but the value isn't actually fully
         # covered by the enumerators.
-        self.expect("p (enum bitfield)nonsense", DATA_TYPES_DISPLAYED_CORRECTLY,
+        self.expect("expression (enum bitfield)nonsense", DATA_TYPES_DISPLAYED_CORRECTLY,
                     patterns=[' = B | C | 0x10$'])
 
         # Break inside the main.

--- a/lldb/test/API/lang/c/strings/TestCStrings.py
+++ b/lldb/test/API/lang/c/strings/TestCStrings.py
@@ -40,14 +40,14 @@ class CStringsTestCase(TestBase):
                     substrs=['[0] = \'h\'',
                              '[5] = \'\\0\''])
 
-        self.expect("p \"hello\"",
+        self.expect("expression \"hello\"",
                     substrs=['[6]) $', 'hello'])
 
-        self.expect("p (char*)\"hello\"",
+        self.expect("expression (char*)\"hello\"",
                     substrs=['(char *) $', ' = 0x',
                              'hello'])
 
-        self.expect("p (int)strlen(\"\")",
+        self.expect("expression (int)strlen(\"\")",
                     substrs=['(int) $', ' = 0'])
 
         self.expect("expression !z",

--- a/lldb/test/API/lang/cpp/namespace/TestNamespace.py
+++ b/lldb/test/API/lang/cpp/namespace/TestNamespace.py
@@ -220,8 +220,8 @@ class NamespaceTestCase(TestBase):
         # global namespace qualification with function in anonymous namespace
         self.expect_expr("myanonfunc(4)", result_value="8")
 
-        self.expect("p myanonfunc",
+        self.expect("expression myanonfunc",
                     patterns=['\(anonymous namespace\)::myanonfunc\(int\)'])
 
-        self.expect("p variadic_sum", patterns=[
+        self.expect("expression variadic_sum", patterns=[
                     '\(anonymous namespace\)::variadic_sum\(int, ...\)'])

--- a/lldb/test/API/lang/objc/foundation/TestObjCMethodsNSError.py
+++ b/lldb/test/API/lang/objc/foundation/TestObjCMethodsNSError.py
@@ -41,6 +41,6 @@ class FoundationTestCaseNSError(TestBase):
         self.target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
                 self, '// Set break point at this line',
                 lldb.SBFileSpec('main.m', False))
-        self.expect("p [NSError thisMethodIsntImplemented:0]", error=True, patterns=[
+        self.expect("expression [NSError thisMethodIsntImplemented:0]", error=True, patterns=[
                     "no known method", "cast the message send to the method's return type"])
         self.runCmd("process continue")

--- a/lldb/test/API/lang/objc/modules-auto-import/TestModulesAutoImport.py
+++ b/lldb/test/API/lang/objc/modules-auto-import/TestModulesAutoImport.py
@@ -40,5 +40,5 @@ class ObjCModulesAutoImportTestCase(TestBase):
 
         self.runCmd("settings set target.auto-import-clang-modules true")
 
-        self.expect("p getpid()", VARIABLES_DISPLAYED_CORRECTLY,
+        self.expect("expression getpid()", VARIABLES_DISPLAYED_CORRECTLY,
                     substrs=["pid_t"])

--- a/lldb/test/API/lang/objc/modules/TestObjCModules.py
+++ b/lldb/test/API/lang/objc/modules/TestObjCModules.py
@@ -62,7 +62,7 @@ class ObjCModulesTestCase(TestBase):
                     substrs=["NSUInteger", "3"])
 
         self.expect(
-            "p *[NSURL URLWithString:@\"http://lldb.llvm.org\"]",
+            "expression *[NSURL URLWithString:@\"http://lldb.llvm.org\"]",
             VARIABLES_DISPLAYED_CORRECTLY,
             substrs=[
                 "NSURL",
@@ -70,7 +70,7 @@ class ObjCModulesTestCase(TestBase):
                 "_urlString"])
 
         self.expect(
-            "p [NSURL URLWithString:@\"http://lldb.llvm.org\"].scheme",
+            "expression [NSURL URLWithString:@\"http://lldb.llvm.org\"].scheme",
             VARIABLES_DISPLAYED_CORRECTLY,
             substrs=["http"])
         # Test that the NULL macro still works with a loaded module.

--- a/lldb/test/API/lang/objc/objc-struct-argument/TestObjCStructArgument.py
+++ b/lldb/test/API/lang/objc/objc-struct-argument/TestObjCStructArgument.py
@@ -51,7 +51,7 @@ class TestObjCStructArgument(TestBase):
         frame = thread_list[0].GetFrameAtIndex(0)
         self.assertTrue(frame, "Got a valid frame 0 frame.")
 
-        self.expect("p [summer sumThings:tts]", substrs=['9'])
+        self.expect("expression [summer sumThings:tts]", substrs=['9'])
 
         self.expect(
             "po [NSValue valueWithRect:rect]",

--- a/lldb/test/API/lang/objc/radar-9691614/TestObjCMethodReturningBOOL.py
+++ b/lldb/test/API/lang/objc/radar-9691614/TestObjCMethodReturningBOOL.py
@@ -43,4 +43,4 @@ class MethodReturningBOOLTestCase(TestBase):
             ])
 
         # rdar://problem/9691614
-        self.runCmd('p (int)[my isValid]')
+        self.runCmd('expression (int)[my isValid]')

--- a/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
@@ -23,7 +23,7 @@ class TestSwiftWerror(TestBase):
         log = self.getBuildArtifact("types.log")
         self.expect("log enable lldb types -f "+log)
         
-        self.expect("p foo", DATA_TYPES_DISPLAYED_CORRECTLY, substrs=["42"])
+        self.expect("expression foo", DATA_TYPES_DISPLAYED_CORRECTLY, substrs=["42"])
         sanity = 0
         import io
         logfile = io.open(log, "r", encoding='utf-8')

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -44,7 +44,7 @@ class TestSwiftDedupMacros(TestBase):
         log = self.getBuildArtifact("types.log")
         self.expect("log enable lldb types -f "+log)
         
-        self.expect("p foo", DATA_TYPES_DISPLAYED_CORRECTLY, substrs=["42"])
+        self.expect("expression foo", DATA_TYPES_DISPLAYED_CORRECTLY, substrs=["42"])
         debug = 0
         space = 0
         ndebug = 0

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/TestSwiftHardMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/TestSwiftHardMacroConflict.py
@@ -32,7 +32,7 @@ class TestSwiftHardMacroConflict(TestBase):
         process.Continue()
         threads = lldbutil.get_threads_stopped_at_breakpoint(
             process, b_breakpoint)
-        self.expect("p foo", error=True)
+        self.expect("expression foo", error=True)
 
         per_module_fallback = 0
         import io

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
@@ -48,11 +48,11 @@ class TestSwiftObjCMainConflictingDylibs(TestBase):
         process = target.LaunchSimple(None, None, os.getcwd())
         # This is failing because the Target-SwiftASTContext uses the
         # amalgamated target header search options from all dylibs.
-        self.expect("p baz", "wrong baz", substrs=["i_am_from_Foo"])
+        self.expect("expression baz", "wrong baz", substrs=["i_am_from_Foo"])
         self.expect("fr var baz", "wrong baz", substrs=["i_am_from_Foo"])
 
 
         process.Continue()
-        self.expect("p baz", "correct baz", substrs=["i_am_from_Foo"])
+        self.expect("expression baz", "correct baz", substrs=["i_am_from_Foo"])
         self.expect("fr var baz", "correct baz", substrs=["i_am_from_Foo"])
         

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
@@ -33,14 +33,14 @@ class TestSwiftObjCMainConflictingDylibsBridgingHeader(TestBase):
 
 
         self.expect("fr var bar", "expected result", substrs=["42"])
-        self.expect("p bar", "expected result", substrs=["$R0", "42"])
-        self.expect("p $R0", "expected result", substrs=["$R1", "42"])
-        self.expect("p $R1", "expected result", substrs=["$R2", "42"])
+        self.expect("expression bar", "expected result", substrs=["$R0", "42"])
+        self.expect("expression $R0", "expected result", substrs=["$R1", "42"])
+        self.expect("expression $R1", "expected result", substrs=["$R2", "42"])
         
         foo_breakpoint = target.BreakpointCreateBySourceRegex(
             'break here', lldb.SBFileSpec('Foo.swift'))
         process.Continue()
         self.expect("fr var foo", "expected result", substrs=["23"])
-        self.expect("p foo", "expected result", substrs=["$R3", "23"])
-        self.expect("p $R3", "expected result", substrs=["23"])
-        self.expect("p $R4", "expected result", substrs=["23"])
+        self.expect("expression foo", "expected result", substrs=["$R3", "23"])
+        self.expect("expression $R3", "expected result", substrs=["23"])
+        self.expect("expression $R4", "expected result", substrs=["23"])

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
@@ -48,9 +48,9 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
         
         # This initially fails with the shared scratch context and is
         # then retried with the per-dylib scratch context.
-        # self.expect("p bar", "expected result", substrs=["$R0", "42"])
-        # self.expect("p $R0", "expected result", substrs=["$R1", "42"])
-        # self.expect("p $R1", "expected result", substrs=["$R2", "42"])
+        # self.expect("expression bar", "expected result", substrs=["$R0", "42"])
+        # self.expect("expression $R0", "expected result", substrs=["$R1", "42"])
+        # self.expect("expression $R1", "expected result", substrs=["$R2", "42"])
         
         # This works by accident because the search paths are in the right order.
         foo_breakpoint = target.BreakpointCreateBySourceRegex(
@@ -60,7 +60,7 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
         # FIXME: The following expression evaluator tests are disabled
         # because it's nondeterministic which one will work.
 
-        # self.expect("p foo", "expected result", substrs=["$R3", "23"])
-        # self.expect("p $R3", "expected result", substrs=["23"])
-        # self.expect("p $R4", "expected result", substrs=["23"])
+        # self.expect("expression foo", "expected result", substrs=["$R3", "23"])
+        # self.expect("expression $R3", "expected result", substrs=["23"])
+        # self.expect("expression $R4", "expected result", substrs=["23"])
 

--- a/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
+++ b/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
@@ -17,7 +17,7 @@ class TestSwiftRewriteClangPaths(TestBase):
         self.runCmd('log enable lldb types -f "%s"' % log)
         target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(
             self, 'main')
-        self.expect("p 1", substrs=["1"])
+        self.expect("expression 1", substrs=["1"])
 
         # Scan through the types log.
         import io

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -77,13 +77,13 @@ class TestSwiftRewriteClangPaths(TestBase):
 
         if remap:
             comment = "returns correct value"
-            self.expect("p foo", comment, substrs=["x", "23"])
-            self.expect("p bar", comment, substrs=["y", "42"])
+            self.expect("expression foo", comment, substrs=["x", "23"])
+            self.expect("expression bar", comment, substrs=["y", "42"])
             self.expect("fr var foo", comment, substrs=["x", "23"])
             self.expect("fr var bar", comment, substrs=["y", "42"])
             self.assertTrue(os.path.isdir(mod_cache), "module cache exists")
         else:
-            self.expect("p foo", error=True)
+            self.expect("expression foo", error=True)
 
         # Scan through the types log.
         errs = 0

--- a/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
+++ b/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
@@ -46,7 +46,7 @@ class TestSwiftStaticArchiveTwoSwiftmodules(TestBase):
         # This test tests that the search paths from all swiftmodules
         # that are part of the main binary are honored.
         self.expect("fr var foo", "expected result", substrs=["23"])
-        self.expect("p foo", "expected result", substrs=["$R0", "i", "23"])
+        self.expect("expression foo", "expected result", substrs=["$R0", "i", "23"])
         process.Continue()
         self.expect("fr var bar", "expected result", substrs=["42"])
-        self.expect("p bar", "expected result", substrs=["j", "42"])
+        self.expect("expression bar", "expected result", substrs=["j", "42"])

--- a/lldb/test/API/lang/swift/class_empty/main.swift
+++ b/lldb/test/API/lang/swift/class_empty/main.swift
@@ -17,7 +17,7 @@ class Empty : CustomStringConvertible {
 
 func main() {
   var e = Empty()
-  print(e) //% self.expect("p 1", substrs=['1'])
+  print(e) //% self.expect("expression 1", substrs=['1'])
 }
 
 main()

--- a/lldb/test/API/lang/swift/closure_shortcuts/main.swift
+++ b/lldb/test/API/lang/swift/closure_shortcuts/main.swift
@@ -15,8 +15,8 @@ func main() -> Int {
   let names = ["foo", "patatino"]
 
   var reversedNames = names.sorted(by: {
-    $0 > $1 } //%self.expect('p $0', substrs=['patatino'])
-              //%self.expect('p $1', substrs=['foo'])
+    $0 > $1 } //%self.expect('expr $0', substrs=['patatino'])
+              //%self.expect('expr $1', substrs=['foo'])
               //%self.expect('frame var $0', substrs=['patatino'])
               //%self.expect('frame var $1', substrs=['foo'])
   )

--- a/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -32,7 +32,7 @@ class TestSwiftDeploymentTarget(TestBase):
         lldbutil.run_to_source_breakpoint(self,
                                           "break here",
                                           lldb.SBFileSpec('main.swift'))
-        self.expect("p f", substrs=['i = 23'])
+        self.expect("expression f", substrs=['i = 23'])
 
     @skipUnlessDarwin
     @skipIfDarwinEmbedded # This test uses macOS triples explicitly.
@@ -45,7 +45,7 @@ class TestSwiftDeploymentTarget(TestBase):
         bkpt = target.BreakpointCreateBySourceRegex(
             'break here', lldb.SBFileSpec('NewerTarget.swift'))
         lldbutil.continue_to_breakpoint(process, bkpt)
-        self.expect("p self", substrs=['i = 23'])
+        self.expect("expression self", substrs=['i = 23'])
 
     @skipUnlessDarwin
     @skipIfDarwinEmbedded # This test uses macOS triples explicitly.
@@ -59,7 +59,7 @@ class TestSwiftDeploymentTarget(TestBase):
         lldbutil.run_to_source_breakpoint(self,
                                           "break here",
                                           lldb.SBFileSpec('main.swift'))
-        self.expect("p f", substrs=['i = 23'])
+        self.expect("expression f", substrs=['i = 23'])
 
         found_no_ast = False
         found_triple = False

--- a/lldb/test/API/lang/swift/expression/allocator/TestSwiftExprAllocator.py
+++ b/lldb/test/API/lang/swift/expression/allocator/TestSwiftExprAllocator.py
@@ -17,4 +17,4 @@ class TestSwiftExprAllocator(lldbtest.TestBase):
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('main.swift'))
 
-        self.expect("p x", substrs=['23'])
+        self.expect("expression x", substrs=['23'])

--- a/lldb/test/API/lang/swift/macCatalyst/TestSwiftMacCatalyst.py
+++ b/lldb/test/API/lang/swift/macCatalyst/TestSwiftMacCatalyst.py
@@ -34,7 +34,7 @@ class TestSwiftMacCatalyst(TestBase):
         self.expect("fr v s", "Hello macCatalyst")
         expr_log = self.getBuildArtifact("expr.log")
         self.expect('log enable lldb expr -f "%s"' % expr_log)
-        self.expect("p s", "Hello macCatalyst")
+        self.expect("expression s", "Hello macCatalyst")
         import io
         expr_logfile = io.open(expr_log, "r", encoding='utf-8')
 

--- a/lldb/test/API/lang/swift/missing_sdk/TestMissingSDK.py
+++ b/lldb/test/API/lang/swift/missing_sdk/TestMissingSDK.py
@@ -24,6 +24,6 @@ class TestSwiftMissingSDK(TestBase):
         os.unlink(self.getBuildArtifact("fakesdk"))
         lldbutil.run_to_source_breakpoint(self, 'break here',
                                           lldb.SBFileSpec('main.swift'))
-        self.expect("p message", VARIABLES_DISPLAYED_CORRECTLY,
+        self.expect("expression message", VARIABLES_DISPLAYED_CORRECTLY,
                     substrs = ["Hello"])
 

--- a/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
@@ -110,7 +110,7 @@ class TestSwiftInterfaceDSYM(TestBase):
         # prints the type *name*.
         self.assertEqual(var.GetTypeName(), "AA.MyPoint")
         # Evaluating an expression fails, though.
-        self.expect("p x", error=1)
+        self.expect("expression x", error=1)
 
     @swiftTest
     @skipIf(archs=no_match("x86_64"))
@@ -149,7 +149,7 @@ class TestSwiftInterfaceDSYM(TestBase):
 
         # The expression evaluator sees the whole program, so it also
         # sees the private members.
-        self.expect("p x", substrs=["x = 10"])
+        self.expect("expression x", substrs=["x = 10"])
         # FIXME: this doesn't work, the summary/value is null/null.
         #lldbutil.check_expression(
         #    self, frame, "x", "x = 10", use_summary=False)
@@ -164,5 +164,5 @@ class TestSwiftInterfaceDSYM(TestBase):
         # MyPoint.x is private and we should still see it.
         child_x = var.GetChildMemberWithName("x")
         lldbutil.check_variable(self, child_x, value="10")
-        self.expect("p self", substrs=["x = 10"])
+        self.expect("expression self", substrs=["x = 10"])
 

--- a/lldb/test/API/lang/swift/private_discriminator/TestSwiftPrivateDiscriminator.py
+++ b/lldb/test/API/lang/swift/private_discriminator/TestSwiftPrivateDiscriminator.py
@@ -27,10 +27,10 @@ class TestSwiftPrivateDiscriminator(lldbtest.TestBase):
         self.expect("e --bind-generic-types true -- self", error=True, substrs=["Hint"])
         # This should work because expression evaluation automatically falls back
         # to not binding generic parameters.
-        self.expect("p self", substrs=['Generic', '<T>', 'n', '23'])
+        self.expect("expression self", substrs=['Generic', '<T>', 'n', '23'])
 
         process.Continue()
         # This should work.
         self.expect("frame var -d run -- visible",
                     substrs=['Generic.Visible', 'n', '42'])
-        self.expect("p visible", substrs=['Generic.Visible', 'n', '42'])
+        self.expect("expression visible", substrs=['Generic.Visible', 'n', '42'])

--- a/lldb/test/API/lang/swift/protocol_extension_computed_property/main.swift
+++ b/lldb/test/API/lang/swift/protocol_extension_computed_property/main.swift
@@ -13,8 +13,8 @@ extension Measurement where UnitType == UnitAngle {
   }
 
   func f() {
-    return //%self.expect('p self.radians', substrs=["CGFloat) $R0", "= 1.745"])
-           //%self.expect('p self', substrs=["Measurement<UnitAngle>"])
+    return //%self.expect('expression self.radians', substrs=["CGFloat) $R0", "= 1.745"])
+           //%self.expect('expression self', substrs=["Measurement<UnitAngle>"])
   }
 }
 

--- a/lldb/test/API/lang/swift/protocol_extension_two/main.swift
+++ b/lldb/test/API/lang/swift/protocol_extension_two/main.swift
@@ -10,8 +10,8 @@ extension Patatino where T == Winky {
   }
 
   func f() {
-    return //%self.expect('p self.baciotto', substrs=["(Int) $R0 = 0"])
-           //%self.expect('p self', substrs=["a.Patatino<a.Winky>"])
+    return //%self.expect('expression self.baciotto', substrs=["(Int) $R0 = 0"])
+           //%self.expect('expression self', substrs=["a.Patatino<a.Winky>"])
   }
 }
 

--- a/lldb/test/API/lang/swift/runtime_library_path/TestSwiftRuntimeLibraryPath.py
+++ b/lldb/test/API/lang/swift/runtime_library_path/TestSwiftRuntimeLibraryPath.py
@@ -23,7 +23,7 @@ class TestSwiftRuntimeLibraryPath(lldbtest.TestBase):
         target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(
             self, 'main')
 
-        self.expect("p 1")
+        self.expect("expression 1")
         import io
         logfile = io.open(log, "r", encoding='utf-8')
         in_expr_log = 0

--- a/lldb/test/API/lang/swift/swift-healthcheck/TestSwiftHealthCheck.py
+++ b/lldb/test/API/lang/swift/swift-healthcheck/TestSwiftHealthCheck.py
@@ -18,7 +18,7 @@ class TestSwiftHealthCheck(TestBase):
 
         target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(
             self, 'main')
-        self.expect("p 1")
+        self.expect("expression 1")
         result = lldb.SBCommandReturnObject()
         ret_val = self.dbg.GetCommandInterpreter().HandleCommand("swift-healthcheck", result)
         log = result.GetOutput()[:-1].split(" ")[-1]

--- a/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
+++ b/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
@@ -25,7 +25,7 @@ class TestSwiftTripleDetection(TestBase):
                                                               arch+"-apple-macos-unknown")
         bkpt = target.BreakpointCreateByName("main")
         process = target.LaunchSimple(None, None, self.get_process_working_directory())
-        self.expect("p 1")
+        self.expect("expression 1")
         import io
         types_logfile = io.open(types_log, "r", encoding='utf-8')
 

--- a/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
+++ b/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
@@ -175,9 +175,9 @@ class TestSwiftTypes(TestBase):
 
         self.expect("frame variable --raw hello", substrs=['String'])
 
-        self.expect("p/x int64_minus_two", substrs=['0xfffffffffffffffe'])
-        self.expect("p/u ~1", substrs=['18446744073709551614'])
-        self.expect("p/d ~1", substrs=['-2'])
+        self.expect("expression/x int64_minus_two", substrs=['0xfffffffffffffffe'])
+        self.expect("expression/u ~1", substrs=['18446744073709551614'])
+        self.expect("expression/d ~1", substrs=['-2'])
 
         self.expect('frame variable uint8_max', substrs=['-1'], matching=False)
         self.expect(

--- a/lldb/test/API/lang/swift/xcode_sdk/TestSwiftXcodeSDK.py
+++ b/lldb/test/API/lang/swift/xcode_sdk/TestSwiftXcodeSDK.py
@@ -33,7 +33,7 @@ class TestSwiftXcodeSDK(lldbtest.TestBase):
 
         lldbutil.run_to_name_breakpoint(self, 'main')
 
-        self.expect("p 1")
+        self.expect("expression 1")
         self.check_log(log, "MacOSX")
 
     @swiftTest
@@ -52,7 +52,7 @@ class TestSwiftXcodeSDK(lldbtest.TestBase):
 
         lldbutil.run_to_name_breakpoint(self, 'main')
 
-        self.expect("p 1")
+        self.expect("expression 1")
         self.check_log(log, "iPhoneSimulator")
 
     @swiftTest
@@ -72,5 +72,5 @@ class TestSwiftXcodeSDK(lldbtest.TestBase):
 
         lldbutil.run_to_name_breakpoint(self, 'main')
 
-        self.expect("p 1")
+        self.expect("expression 1")
         self.check_log(log, ios_sdk)

--- a/lldb/test/API/linux/builtin_trap/TestBuiltinTrap.py
+++ b/lldb/test/API/linux/builtin_trap/TestBuiltinTrap.py
@@ -46,4 +46,4 @@ class BuiltinTrapTestCase(TestBase):
         self.runCmd("up", RUN_SUCCEEDED)
 
         # evaluate a local
-        self.expect('p foo', substrs=['= 5'])
+        self.expect('expression foo', substrs=['= 5'])

--- a/lldb/test/API/lua_api/TestFileHandle.lua
+++ b/lldb/test/API/lua_api/TestFileHandle.lua
@@ -16,7 +16,7 @@ end
 function _T:TestLegacyFileOut()
     local f = io.open(self.output, 'w')
     self.debugger:SetOutputFile(f)
-    self:handle_command('p/x 3735928559', false)
+    self:handle_command('expression/x 3735928559', false)
     f:close()
 
     f = io.open(self.output, 'r')

--- a/lldb/test/API/macosx/early-process-launch/TestEarlyProcessLaunch.py
+++ b/lldb/test/API/macosx/early-process-launch/TestEarlyProcessLaunch.py
@@ -39,14 +39,14 @@ class TestEarlyProcessLaunch(TestBase):
         logfile_early = os.path.join(self.getBuildDir(), "types-log-early.txt")
         self.addTearDownHook(lambda: self.runCmd("log disable lldb types"))
         self.runCmd("log enable -f %s lldb types" % logfile_early)
-        self.runCmd("p global = 15")
+        self.runCmd("expression global = 15")
 
         err = process.Continue()
         self.assertTrue(err.Success())
 
         logfile_later = os.path.join(self.getBuildDir(), "types-log-later.txt")
         self.runCmd("log enable -f %s lldb types" % logfile_later)
-        self.runCmd("p global = 25")
+        self.runCmd("expression global = 25")
 
         self.assertTrue(os.path.exists(logfile_early))
         self.assertTrue(os.path.exists(logfile_later))

--- a/lldb/test/API/macosx/macCatalyst/TestMacCatalyst.py
+++ b/lldb/test/API/macosx/macCatalyst/TestMacCatalyst.py
@@ -22,7 +22,7 @@ class TestMacCatalyst(TestBase):
                     patterns=[self.getArchitecture() +
                               r'.*-apple-ios.*-macabi a\.out'])
         self.expect("fr v s", substrs=["Hello macCatalyst"])
-        self.expect("p s", substrs=["Hello macCatalyst"])
+        self.expect("expression s", substrs=["Hello macCatalyst"])
         self.check_debugserver(log)
 
     def check_debugserver(self, log):

--- a/lldb/test/API/macosx/macCatalystAppMacOSFramework/TestMacCatalystAppWithMacOSFramework.py
+++ b/lldb/test/API/macosx/macCatalystAppMacOSFramework/TestMacCatalystAppWithMacOSFramework.py
@@ -25,7 +25,7 @@ class TestMacCatalystAppWithMacOSFramework(TestBase):
                     patterns=[arch + r'.*-apple-ios.*-macabi a\.out',
                               arch + r'.*-apple-macosx.* libfoo.dylib[^(]'])
         self.expect("fr v s", "Hello macCatalyst")
-        self.expect("p s", "Hello macCatalyst")
+        self.expect("expression s", "Hello macCatalyst")
         self.check_debugserver(log)
 
     def check_debugserver(self, log):

--- a/lldb/test/API/python_api/file_handle/TestFileHandle.py
+++ b/lldb/test/API/python_api/file_handle/TestFileHandle.py
@@ -135,7 +135,7 @@ class FileHandleTestCase(lldbtest.TestBase):
     def test_legacy_file_out(self):
         with open(self.out_filename, 'w') as f:
             self.dbg.SetOutputFileHandle(f, False)
-            self.handleCmd('p/x 3735928559', collect_result=False, check=False)
+            self.handleCmd('expression/x 3735928559', collect_result=False, check=False)
         with open(self.out_filename, 'r') as f:
             self.assertIn('deadbeef', f.read())
 
@@ -359,7 +359,7 @@ class FileHandleTestCase(lldbtest.TestBase):
 
 
     def test_string_inout(self):
-        inf = io.StringIO("help help\np/x ~0\n")
+        inf = io.StringIO("help help\nexpression/x ~0\n")
         outf = io.StringIO()
         status = self.dbg.SetOutputFile(lldb.SBFile(outf))
         self.assertSuccess(status)

--- a/lldb/test/API/types/TestRecursiveTypes.py
+++ b/lldb/test/API/types/TestRecursiveTypes.py
@@ -48,5 +48,5 @@ class RecursiveTypesTestCase(TestBase):
 
         self.runCmd("run", RUN_SUCCEEDED)
 
-        self.runCmd("print tpi")
-        self.runCmd("print *tpi")
+        self.runCmd("expression tpi")
+        self.runCmd("expression *tpi")


### PR DESCRIPTION
In API tests, replace use of the `p` alias with the `expression` command.

To avoid conflating tests of the alias with tests of the expression command,
this patch canonicalizes to the use `expression`.

Differential Revision: https://reviews.llvm.org/D141539

(cherry picked from commit 40766642283854d035a992513e314d59c1b4ca53)
