### PR TITLE
[clang][deps] Fix module context hash for constant strings

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -307,13 +307,12 @@ static std::string getModuleContextHash(const ModuleDeps &MD,
   HashBuilder.add(serialization::VERSION_MAJOR, serialization::VERSION_MINOR);
 
   // Hash the BuildInvocation without any input files.
-  SmallVector<const char *, 32> DummyArgs;
-  CI.generateCC1CommandLine(DummyArgs, [&](const Twine &Arg) {
-    Scratch.clear();
-    StringRef Str = Arg.toStringRef(Scratch);
-    HashBuilder.add(Str);
-    return "<unused>";
-  });
+  SmallVector<const char *, 32> Args;
+  llvm::BumpPtrAllocator Alloc;
+  llvm::StringSaver Saver(Alloc);
+  CI.generateCC1CommandLine(
+      Args, [&](const Twine &Arg) { return Saver.save(Arg).data(); });
+  HashBuilder.addRange(Args);
 
   // Hash the module dependencies. These paths may differ even if the invocation
   // is identical if they depend on the contents of the files in the TU -- for

--- a/clang/test/ClangScanDeps/Inputs/modules-context-hash/cdb_b2.json.template
+++ b/clang/test/ClangScanDeps/Inputs/modules-context-hash/cdb_b2.json.template
@@ -1,0 +1,7 @@
+[
+  {
+    "directory": "DIR",
+    "command": "clang -c DIR/tu.c -fmodules -fmodules-cache-path=DIR/cache -IDIR/b -o DIR/tu_b.o -fapplication-extension",
+    "file": "DIR/tu.c"
+  }
+]


### PR DESCRIPTION
We were not hashing constant strings in the command-line, only ones that required allocations. This was causing us to get the same hash across different flag options.

rdar://101053855

Differential Revision: https://reviews.llvm.org/D143027

(cherry picked from commit 223e99fb698dd63b5bb9266e11c2582261e05ad9)