### PR TITLE
Update LLDB test for mangled macro names.

### DIFF
--- a/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
+++ b/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
@@ -20,7 +20,7 @@ class TestSwiftMacro(lldbtest.TestBase):
         thread.StepInto()
         # This is the expanded macro source, we should be able to step into it.
         self.expect('reg read pc', substrs=[
-            '[inlined] stringify at',
+            '[inlined] freestanding macro expansion #1 of stringify',
             '13testStringify'
         ])
 


### PR DESCRIPTION
(cherry picked from commit 745d17a63cc53943d3a13026c69ddd3eae2f8b4a)