### PR TITLE
[cas/libclang] Enhance the CAS-related libclang APIs for CAS configuration

### DIFF
--- a/clang/include/clang-c/CAS.h
+++ b/clang/include/clang-c/CAS.h
@@ -33,6 +33,17 @@ extern "C" {
  */
 
 /**
+ * Configuration options for ObjectStore and ActionCache.
+ */
+typedef struct CXOpaqueCASOptions *CXCASOptions;
+
+/**
+ * Encapsulates instances of ObjectStore and ActionCache, created from a
+ * particular configuration of \p CXCASOptions.
+ */
+typedef struct CXOpaqueCASDatabases *CXCASDatabases;
+
+/**
  * Content-addressable storage for objects.
  */
 typedef struct CXOpaqueCASObjectStore *CXCASObjectStore;
@@ -41,6 +52,39 @@ typedef struct CXOpaqueCASObjectStore *CXCASObjectStore;
  * A cache from a key describing an action to the result of doing it.
  */
 typedef struct CXOpaqueCASActionCache *CXCASActionCache;
+
+/**
+ * Create a \c CXCASOptions object.
+ */
+CINDEX_LINKAGE CXCASOptions clang_experimental_cas_Options_create(void);
+
+/**
+ * Dispose of a \c CXCASOptions object.
+ */
+CINDEX_LINKAGE void clang_experimental_cas_Options_dispose(CXCASOptions);
+
+/**
+ * Configure the file path to use for on-disk CAS/cache instances.
+ */
+CINDEX_LINKAGE void
+clang_experimental_cas_Options_setOnDiskPath(CXCASOptions, const char *Path);
+
+/**
+ * Creates instances for a CAS object store and action cache based on the
+ * configuration of a \p CXCASOptions.
+ *
+ * \param Opts configuration options.
+ * \param[out] Error The error string to pass back to client (if any).
+ *
+ * \returns The resulting instances object, or null if there was an error.
+ */
+CINDEX_LINKAGE CXCASDatabases
+clang_experimental_cas_Databases_create(CXCASOptions Opts, CXString *Error);
+
+/**
+ * Dispose of a \c CXCASDatabases object.
+ */
+CINDEX_LINKAGE void clang_experimental_cas_Databases_dispose(CXCASDatabases);
 
 /**
  * Dispose of a \c CXCASObjectStore object.
@@ -56,27 +100,29 @@ clang_experimental_cas_ActionCache_dispose(CXCASActionCache Cache);
 
 /**
  * Gets or creates a persistent on-disk CAS object store at \p Path.
+ * Deprecated, use \p clang_experimental_cas_Databases_create() instead.
  *
  * \param Path The path to locate the object store.
  * \param[out] Error The error string to pass back to client (if any).
  *
  * \returns The resulting object store, or null if there was an error.
  */
-CINDEX_LINKAGE CXCASObjectStore
-clang_experimental_cas_OnDiskObjectStore_create(
-    const char *Path, CXString *Error);
+CINDEX_DEPRECATED CINDEX_LINKAGE CXCASObjectStore
+clang_experimental_cas_OnDiskObjectStore_create(const char *Path,
+                                                CXString *Error);
 
 /**
  * Gets or creates a persistent on-disk action cache at \p Path.
+ * Deprecated, use \p clang_experimental_cas_Databases_create() instead.
  *
  * \param Path The path to locate the object store.
  * \param[out] Error The error string to pass back to client (if any).
  *
  * \returns The resulting object store, or null if there was an error.
  */
-CINDEX_LINKAGE CXCASActionCache
-clang_experimental_cas_OnDiskActionCache_create(
-    const char *Path, CXString *Error);
+CINDEX_DEPRECATED CINDEX_LINKAGE CXCASActionCache
+clang_experimental_cas_OnDiskActionCache_create(const char *Path,
+                                                CXString *Error);
 
 /**
  * @}

--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -203,18 +203,32 @@ clang_experimental_DependencyScannerServiceOptions_setDependencyMode(
     CXDependencyScannerServiceOptions Opts, CXDependencyMode Mode);
 
 /**
- * Specify a \c CXCASObjectStore in the given options. If an object store and
- * action cache are available, the scanner will produce cached commands.
+ * Specify the object store and action cache databases in the given options.
+ * With this set, the scanner will produce cached commands.
  */
 CINDEX_LINKAGE void
+clang_experimental_DependencyScannerServiceOptions_setCASDatabases(
+    CXDependencyScannerServiceOptions Opts, CXCASDatabases);
+
+/**
+ * Specify a \c CXCASObjectStore in the given options. If an object store and
+ * action cache are available, the scanner will produce cached commands.
+ * Deprecated, use
+ * \p clang_experimental_DependencyScannerServiceOptions_setCASDatabases()
+ * instead.
+ */
+CINDEX_DEPRECATED CINDEX_LINKAGE void
 clang_experimental_DependencyScannerServiceOptions_setObjectStore(
     CXDependencyScannerServiceOptions Opts, CXCASObjectStore CAS);
 
 /**
  * Specify a \c CXCASActionCache in the given options. If an object store and
  * action cache are available, the scanner will produce cached commands.
+ * Deprecated, use
+ * \p clang_experimental_DependencyScannerServiceOptions_setCASDatabases()
+ * instead.
  */
-CINDEX_LINKAGE void
+CINDEX_DEPRECATED CINDEX_LINKAGE void
 clang_experimental_DependencyScannerServiceOptions_setActionCache(
     CXDependencyScannerServiceOptions Opts, CXCASActionCache Cache);
 

--- a/clang/test/Index/Core/scan-deps-cas.m
+++ b/clang/test/Index/Core/scan-deps-cas.m
@@ -1,8 +1,7 @@
 // RUN: rm -rf %t.mcp %t
 // RUN: echo %S > %t.result
 //
-// RUN: c-index-test core --scan-deps %S -output-dir=%t \
-// RUN:     -cas-path %t/cas -action-cache-path %t/cache \
+// RUN: c-index-test core --scan-deps %S -output-dir=%t -cas-path %t/cas \
 // RUN:  -- %clang -c -I %S/Inputs/module \
 // RUN:     -fmodules -fmodules-cache-path=%t.mcp \
 // RUN:     -o FoE.o -x objective-c %s >> %t.result

--- a/clang/tools/libclang/CASUtils.h
+++ b/clang/tools/libclang/CASUtils.h
@@ -11,6 +11,7 @@
 
 #include "clang-c/CAS.h"
 #include "clang/Basic/LLVM.h"
+#include "clang/CAS/CASOptions.h"
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/Support/CBindingWrapping.h"
@@ -18,6 +19,12 @@
 
 namespace clang {
 namespace cas {
+
+struct WrappedCASDatabases {
+  CASOptions CASOpts;
+  std::shared_ptr<cas::ObjectStore> CAS;
+  std::shared_ptr<cas::ActionCache> Cache;
+};
 
 struct WrappedObjectStore {
   std::shared_ptr<ObjectStore> CAS;
@@ -29,6 +36,8 @@ struct WrappedActionCache {
   std::string CachePath;
 };
 
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(CASOptions, CXCASOptions)
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(WrappedCASDatabases, CXCASDatabases)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(WrappedObjectStore, CXCASObjectStore)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(WrappedActionCache, CXCASActionCache)
 

--- a/clang/tools/libclang/CCAS.cpp
+++ b/clang/tools/libclang/CCAS.cpp
@@ -13,11 +13,65 @@
 
 #include "clang/Basic/LLVM.h"
 #include "clang/CAS/CASOptions.h"
+#include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/Path.h"
 
 using namespace clang;
 using namespace clang::cas;
+
+CXCASOptions clang_experimental_cas_Options_create(void) {
+  return wrap(new CASOptions());
+}
+
+void clang_experimental_cas_Options_dispose(CXCASOptions Opts) {
+  delete unwrap(Opts);
+}
+
+void clang_experimental_cas_Options_setOnDiskPath(CXCASOptions COpts,
+                                                  const char *Path) {
+  CASOptions &Opts = *unwrap(COpts);
+  SmallString<256> PathBuf;
+  PathBuf = Path;
+  llvm::sys::path::append(PathBuf, "cas");
+  Opts.CASPath = std::string(PathBuf);
+  llvm::sys::path::remove_filename(PathBuf);
+  llvm::sys::path::append(PathBuf, "cache");
+  Opts.CachePath = std::string(PathBuf);
+}
+
+CXCASDatabases clang_experimental_cas_Databases_create(CXCASOptions COpts,
+                                                       CXString *Error) {
+  CASOptions &Opts = *unwrap(COpts);
+
+  SmallString<128> DiagBuf;
+  llvm::raw_svector_ostream OS(DiagBuf);
+  IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts = new DiagnosticOptions();
+  TextDiagnosticPrinter DiagPrinter(OS, DiagOpts.get());
+  DiagnosticsEngine Diags(
+      IntrusiveRefCntPtr<DiagnosticIDs>(new DiagnosticIDs()), DiagOpts.get(),
+      &DiagPrinter, /*ShouldOwnClient=*/false);
+
+  auto CAS = Opts.getOrCreateObjectStore(Diags);
+  if (!CAS) {
+    if (Error)
+      *Error = cxstring::createDup(OS.str());
+    return nullptr;
+  }
+  auto Cache = Opts.getOrCreateActionCache(Diags);
+  if (!Cache) {
+    if (Error)
+      *Error = cxstring::createDup(OS.str());
+    return nullptr;
+  }
+
+  return wrap(new WrappedCASDatabases{Opts, std::move(CAS), std::move(Cache)});
+}
+
+void clang_experimental_cas_Databases_dispose(CXCASDatabases CDBs) {
+  delete unwrap(CDBs);
+}
 
 void clang_experimental_cas_ObjectStore_dispose(CXCASObjectStore CAS) {
   delete unwrap(CAS);

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -96,6 +96,14 @@ void clang_experimental_DependencyScannerServiceOptions_setDependencyMode(
   unwrap(Opts)->Format = unwrap(Mode);
 }
 
+void clang_experimental_DependencyScannerServiceOptions_setCASDatabases(
+    CXDependencyScannerServiceOptions Opts, CXCASDatabases CDBs) {
+  cas::WrappedCASDatabases &DBs = *cas::unwrap(CDBs);
+  unwrap(Opts)->CASOpts = DBs.CASOpts;
+  unwrap(Opts)->CAS = DBs.CAS;
+  unwrap(Opts)->Cache = DBs.Cache;
+}
+
 void clang_experimental_DependencyScannerServiceOptions_setObjectStore(
     CXDependencyScannerServiceOptions Opts, CXCASObjectStore CAS) {
   unwrap(Opts)->CAS = cas::unwrap(CAS)->CAS;

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -472,13 +472,19 @@ LLVM_13 {
 LLVM_16 {
   global:
     clang_experimental_cas_ActionCache_dispose;
+    clang_experimental_cas_Databases_create;
+    clang_experimental_cas_Databases_dispose;
     clang_experimental_cas_ObjectStore_dispose;
     clang_experimental_cas_OnDiskActionCache_create;
     clang_experimental_cas_OnDiskObjectStore_create;
+    clang_experimental_cas_Options_create;
+    clang_experimental_cas_Options_dispose;
+    clang_experimental_cas_Options_setOnDiskPath;
     clang_experimental_DependencyScannerService_create_v1;
     clang_experimental_DependencyScannerServiceOptions_create;
     clang_experimental_DependencyScannerServiceOptions_dispose;
     clang_experimental_DependencyScannerServiceOptions_setActionCache;
+    clang_experimental_DependencyScannerServiceOptions_setCASDatabases;
     clang_experimental_DependencyScannerServiceOptions_setDependencyMode;
     clang_experimental_DependencyScannerServiceOptions_setObjectStore;
     clang_experimental_DependencyScannerWorker_getFileDependencies_v5;


### PR DESCRIPTION
The main changes are:

* Added `CXCASOptions` which is a wrapper for `clang::CASOptions`
* Added `CXCASCacheInstances` which encapsulates `ObjectStore` and `ActionCache` instances created from a particular `CXCASOptions` configuration.
* Added `clang_experimental_DependencyScannerServiceOptions_setCacheInstances` for configuring a `CXDependencyScannerServiceOptions` object for caching functionality.
* Simplified the setup by only needing the client to call `clang_experimental_cas_Options_setOnDiskPath` for configuring the path for on-disk caches.

This scheme deprecates:

* `clang_experimental_cas_OnDiskActionCache_create`
* `clang_experimental_cas_OnDiskObjectStore_create`
* `clang_experimental_DependencyScannerServiceOptions_setObjectStore`
* `clang_experimental_DependencyScannerServiceOptions_setActionCache`

The benefits of this scheme are:

* It makes it explicit that the libclang client gets instances of `ObjectStore` and `ActionCache` the same way as how the `cc1` invocation will create them (both using the `clang::CASOptions` mechanism).
* Improved flexibility; adding CAS configurations only needs adding new `clang_experimental_cas_Options_*` functions.