### PR TITLE
Fix clang tests using -fobjc-arc on Linux

### DIFF
--- a/clang/test/Refactor/Extract/captured-variable-types.m
+++ b/clang/test/Refactor/Extract/captured-variable-types.m
@@ -53,4 +53,4 @@ void silenceStrongInARC() {
 // CHECK-ARC: "static int extracted(Interface *pointer) {\nreturn mutationOfObjCPointer(pointer);\n}\n\n"
 // CHECK-ARC: "static void extracted(Interface **pointer) {\n*pointer = 0;\n}\n\n"
 
-// RUN: clang-refactor-test perform -action extract -selected=silence-strong-in-arc -selected=silence-strong2-in-arc %s -fobjc-arc | FileCheck --check-prefix=CHECK-ARC %s
+// RUN: clang-refactor-test perform -action extract -selected=silence-strong-in-arc -selected=silence-strong2-in-arc %s -fobjc-arc -fobjc-runtime=macosx | FileCheck --check-prefix=CHECK-ARC %s

--- a/clang/test/Refactor/Extract/extract-objc-property.m
+++ b/clang/test/Refactor/Extract/extract-objc-property.m
@@ -26,8 +26,8 @@
 // CHECK: "static HasProperty *extracted(HasProperty *object) {\nreturn object.implicitProp;\n}\n\n"
 }
 
-// RUN: clang-refactor-test perform -action extract -selected=property -selected=implicit %s -fobjc-arc | FileCheck %s
-// RUN: clang-refactor-test perform -action extract -selected=property-name -selected=implicit-name %s -fobjc-arc | FileCheck %s
+// RUN: clang-refactor-test perform -action extract -selected=property -selected=implicit %s -fobjc-arc -fobjc-runtime=macosx | FileCheck %s
+// RUN: clang-refactor-test perform -action extract -selected=property-name -selected=implicit-name %s -fobjc-arc -fobjc-runtime=macosx | FileCheck %s
 
 - (void)prohibitSetterExtraction {
 // setter-pref-begin: +2:8
@@ -42,7 +42,7 @@
 // implicit-setter-pref-end: -2:22
 }
 // CHECK-SETTER: Failed to initiate the refactoring action (property setter can't be extracted)!
-// RUN: not clang-refactor-test initiate -action extract -selected=setter -selected=setter-pref -selected=implicit-setter -selected=implicit-setter-pref %s -fobjc-arc 2>&1 | FileCheck --check-prefix=CHECK-SETTER %s
+// RUN: not clang-refactor-test initiate -action extract -selected=setter -selected=setter-pref -selected=implicit-setter -selected=implicit-setter-pref %s -fobjc-arc -fobjc-runtime=macosx 2>&1 | FileCheck --check-prefix=CHECK-SETTER %s
 
 @end
 
@@ -57,4 +57,4 @@ void avoidExtractionCrash(HasIntProp *f) {
 // avoid-extraction-crash-end: -1:5
 }
 
-// RUN: clang-refactor-test perform -action extract -selected=avoid-extraction-crash %s -fobjc-arc | FileCheck --check-prefix=AVOID-CRASH %s
+// RUN: clang-refactor-test perform -action extract -selected=avoid-extraction-crash %s -fobjc-arc -fobjc-runtime=macosx | FileCheck --check-prefix=AVOID-CRASH %s

--- a/clang/test/Refactor/Extract/return-block.m
+++ b/clang/test/Refactor/Extract/return-block.m
@@ -1,4 +1,4 @@
-// RUN: clang-refactor-test perform -action extract -selected=%s:16:27-18:4 %s -fobjc-arc | FileCheck %s
+// RUN: clang-refactor-test perform -action extract -selected=%s:16:27-18:4 %s -fobjc-arc -fobjc-runtime=macosx | FileCheck %s
 // RUN: clang-refactor-test perform -action extract -selected=%s:16:27-18:4 %s | FileCheck --check-prefix=NOARC %s
 @interface I
 
@@ -7,7 +7,7 @@
 @implementation I
 
 - (void) doStuff: (int)x block: (void (^)(int))block {
-  
+
 }
 
 - (void)foo {}


### PR DESCRIPTION
A few tests that used `-fobjc-arc` were failing because the default runtime on Linux does not support arc. Manually specify the macosx runtime for these tests.