### PR TITLE
[clang][cas] Dump module cache key if it fails to load

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -23,6 +23,7 @@
 #include "clang/Config/config.h"
 #include "clang/Frontend/CASDependencyCollector.h"
 #include "clang/Frontend/ChainedDiagnosticConsumer.h"
+#include "clang/Frontend/CompileJobCacheKey.h"
 #include "clang/Frontend/CompileJobCacheResult.h"
 #include "clang/Frontend/FrontendAction.h"
 #include "clang/Frontend/FrontendActions.h"
@@ -2358,10 +2359,16 @@ static bool addCachedModuleFileToInMemoryCache(
   if (!Value || !*Value) {
     auto Diag = Diags.Report(diag::err_cas_cannot_get_module_cache_key)
                 << CacheKey << Provider;
-    if (!Value)
+    if (!Value) {
       Diag << Value.takeError();
-    else
-      Diag << "no such entry in action cache";
+    } else {
+      std::string ErrStr("no such entry in action cache; expected compile:\n");
+      llvm::raw_string_ostream Err(ErrStr);
+      if (auto E = printCompileJobCacheKey(CAS, *ID, Err))
+        Diag << std::move(E);
+      else
+        Diag << Err.str();
+    }
     return true;
   }
   auto ValueRef = CAS.getReference(**Value);

--- a/clang/test/CAS/fmodule-file-cache-key-errors.c
+++ b/clang/test/CAS/fmodule-file-cache-key-errors.c
@@ -28,18 +28,48 @@
 
 // BAD_KEY: error: CAS cannot load module with key 'KEY' from -fmodule-file-cache-key: invalid cas-id 'KEY'
 
+// RUN: echo -n '-fmodule-file-cache-key=PATH=' > %t/bad_key2.rsp
+// RUN: cat %t/casid >> %t/bad_key2.rsp
+
+// RUN: not %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fno-implicit-modules \
+// RUN:   @%t/bad_key2.rsp \
+// RUN:   -fsyntax-only %t/tu.c \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/bad_key2.txt
+// RUN: cat %t/bad_key2.txt | FileCheck %s -check-prefix=BAD_KEY2
+
+// BAD_KEY2: error: CAS cannot load module with key '{{.*}}' from -fmodule-file-cache-key: cas object is not a valid cache key
+
+// == Build A
+
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 \
+// RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
+// RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
+// RUN: cat %t/A.out.txt | FileCheck %s --check-prefix=CACHE-MISS
+// CACHE-MISS: remark: compile job cache miss
+// RUN: cat %t/A.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/A.key
+
+// == Try to import A with a different action cache, simulating a missing module
+
 // RUN: echo -n '-fmodule-file-cache-key=PATH=' > %t/not_in_cache.rsp
-// RUN: cat %t/casid >> %t/not_in_cache.rsp
+// RUN: cat %t/A.key >> %t/not_in_cache.rsp
 
 // RUN: not %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/not_in_cache.rsp \
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache_2 -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/not_in_cache.txt
-// RUN: cat %t/not_in_cache.txt | FileCheck %s -check-prefix=NOT_IN_CACHE
+// RUN: cat %t/not_in_cache.txt | FileCheck %s -check-prefix=NOT_IN_CACHE -DPREFIX=%/t
 
-// NOT_IN_CACHE: error: CAS cannot load module with key '{{.*}}' from -fmodule-file-cache-key: no such entry in action cache
+// NOT_IN_CACHE: error: CAS cannot load module with key '{{.*}}' from -fmodule-file-cache-key: no such entry in action cache; expected compile:
+// NOT_IN_CACHE: command-line:
+// NOT_IN_CACHE:   -cc1
+// NOT_IN_CACHE: filesystem:
+// NOT_IN_CACHE:   file llvmcas://{{.*}} [[PREFIX]]/A.h
 
 //--- module.modulemap
 module A { header "A.h" }


### PR DESCRIPTION
If a module fails to load via fmodule-file-cache-key, dump out the structured form of the key (compiler arguments, cas-fs/include-tree) in the diagnostic. This makes it easier to triage such issues when only a build log is available, since it can be used to figure out if the command to produce the expected module was not run, or was run with the wrong compiler arguments, or inputs. While the diagnostic message with be "large" it is expected that these errors are rare and typically implicate a bug in the compiler or in the build system rather than an error the user is responsible for.