### PR TITLE
Various Scripted Process fixes and improvements

### DIFF
--- a/lldb/bindings/interface/SBProcess.i
+++ b/lldb/bindings/interface/SBProcess.i
@@ -345,6 +345,12 @@ public:
     GetDescription (lldb::SBStream &description);
 
     %feature("autodoc", "
+    Returns the implementation object of the process plugin if available. None
+    otherwise.") GetScriptedImplementation;
+    ScriptedObject
+    GetScriptedImplementation();
+
+    %feature("autodoc", "
     Returns the process' extended crash information.") GetExtendedCrashInformation;
     lldb::SBStructuredData
     GetExtendedCrashInformation ();

--- a/lldb/bindings/python/python-typemaps.swig
+++ b/lldb/bindings/python/python-typemaps.swig
@@ -54,6 +54,16 @@
   free((char *) $1);
 }
 
+%typemap(out) lldb::ScriptedObject {
+  $result = nullptr;
+  if (const void* impl = $1)
+    $result = (PyObject*) impl;
+  if (!$result) {
+    $result = Py_None;
+    Py_INCREF(Py_None);
+  }
+}
+
 %typemap(out) char** {
   int len;
   int i;

--- a/lldb/examples/python/scripted_process/scripted_process.py
+++ b/lldb/examples/python/scripted_process/scripted_process.py
@@ -196,7 +196,7 @@ class ScriptedProcess(metaclass=ABCMeta):
 
         Returns:
             Dict: A dictionary containing metadata for the scripted process.
-                  None is the process as no metadata.
+                  None if the process as no metadata.
         """
         return self.metadata
 
@@ -346,7 +346,7 @@ class ScriptedThread(metaclass=ABCMeta):
 
         Returns:
             List: A list containing the extended information for the scripted process.
-                  None is the thread as no extended information.
+                  None if the thread as no extended information.
         """
         return self.extended_info
 

--- a/lldb/include/lldb/API/SBDefines.h
+++ b/lldb/include/lldb/API/SBDefines.h
@@ -109,6 +109,7 @@ class LLDB_API SBUnixSignals;
 typedef bool (*SBBreakpointHitCallback)(void *baton, SBProcess &process,
                                         SBThread &thread,
                                         lldb::SBBreakpointLocation &location);
+typedef void *ScriptedObject;
 }
 
 #endif // LLDB_API_SBDEFINES_H

--- a/lldb/include/lldb/API/SBProcess.h
+++ b/lldb/include/lldb/API/SBProcess.h
@@ -409,6 +409,8 @@ public:
   ///
   lldb::SBError DeallocateMemory(lldb::addr_t ptr);
 
+  lldb::ScriptedObject GetScriptedImplementation();
+
 protected:
   friend class SBAddress;
   friend class SBBreakpoint;

--- a/lldb/include/lldb/Interpreter/ScriptInterpreter.h
+++ b/lldb/include/lldb/Interpreter/ScriptInterpreter.h
@@ -143,10 +143,7 @@ public:
     eScriptReturnTypeOpaqueObject
   };
 
-  ScriptInterpreter(
-      Debugger &debugger, lldb::ScriptLanguage script_lang,
-      lldb::ScriptedProcessInterfaceUP scripted_process_interface_up =
-          std::make_unique<ScriptedProcessInterface>());
+  ScriptInterpreter(Debugger &debugger, lldb::ScriptLanguage script_lang);
 
   virtual StructuredData::DictionarySP GetInterpreterInfo();
 
@@ -558,8 +555,8 @@ public:
 
   lldb::ScriptLanguage GetLanguage() { return m_script_lang; }
 
-  ScriptedProcessInterface &GetScriptedProcessInterface() {
-    return *m_scripted_process_interface_up;
+  virtual lldb::ScriptedProcessInterfaceUP CreateScriptedProcessInterface() {
+    return std::make_unique<ScriptedProcessInterface>();
   }
 
   lldb::DataExtractorSP
@@ -573,7 +570,6 @@ public:
 protected:
   Debugger &m_debugger;
   lldb::ScriptLanguage m_script_lang;
-  lldb::ScriptedProcessInterfaceUP m_scripted_process_interface_up;
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Interpreter/ScriptedInterface.h
+++ b/lldb/include/lldb/Interpreter/ScriptedInterface.h
@@ -30,6 +30,10 @@ public:
                      StructuredData::DictionarySP args_sp,
                      StructuredData::Generic *script_obj = nullptr) = 0;
 
+  StructuredData::GenericSP GetScriptObjectInstance() {
+    return m_object_instance_sp;
+  }
+
   template <typename Ret>
   static Ret ErrorWithMessage(llvm::StringRef caller_name,
                               llvm::StringRef error_msg, Status &error,

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -2541,6 +2541,8 @@ void PruneThreadPlans();
   lldb::StructuredDataPluginSP
   GetStructuredDataPlugin(ConstString type_name) const;
 
+  virtual void *GetImplementation() { return nullptr; }
+
 protected:
   friend class Trace;
 

--- a/lldb/source/API/SBProcess.cpp
+++ b/lldb/source/API/SBProcess.cpp
@@ -1254,3 +1254,9 @@ lldb::SBError SBProcess::DeallocateMemory(lldb::addr_t ptr) {
   }
   return sb_error;
 }
+
+ScriptedObject SBProcess::GetScriptedImplementation() {
+  LLDB_INSTRUMENT_VA(this);
+  ProcessSP process_sp(GetSP());
+  return (process_sp) ? process_sp->GetImplementation() : nullptr;
+}

--- a/lldb/source/Interpreter/ScriptInterpreter.cpp
+++ b/lldb/source/Interpreter/ScriptInterpreter.cpp
@@ -27,11 +27,8 @@ using namespace lldb;
 using namespace lldb_private;
 
 ScriptInterpreter::ScriptInterpreter(
-    Debugger &debugger, lldb::ScriptLanguage script_lang,
-    lldb::ScriptedProcessInterfaceUP scripted_process_interface_up)
-    : m_debugger(debugger), m_script_lang(script_lang),
-      m_scripted_process_interface_up(
-          std::move(scripted_process_interface_up)) {}
+    Debugger &debugger, lldb::ScriptLanguage script_lang)
+    : m_debugger(debugger), m_script_lang(script_lang) {}
 
 void ScriptInterpreter::CollectDataForBreakpointCommandCallback(
     std::vector<std::reference_wrapper<BreakpointOptions>> &bp_options_vec,

--- a/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
@@ -512,3 +512,10 @@ void ScriptedProcess::UpdateQueueListIfNeeded() {
 ScriptedProcessInterface &ScriptedProcess::GetInterface() const {
   return m_interpreter->GetScriptedProcessInterface();
 }
+
+void *ScriptedProcess::GetImplementation() {
+  if (m_script_object_sp &&
+      m_script_object_sp->GetType() == eStructuredDataTypeGeneric)
+    return m_script_object_sp->GetAsGeneric()->GetValue();
+  return nullptr;
+}

--- a/lldb/source/Plugins/Process/scripted/ScriptedProcess.h
+++ b/lldb/source/Plugins/Process/scripted/ScriptedProcess.h
@@ -93,15 +93,16 @@ protected:
 private:
   friend class ScriptedThread;
 
-  void CheckInterpreterAndScriptObject() const;
+  inline void CheckScriptedInterface() const {
+    lldbassert(m_interface_up && "Invalid scripted process interface.");
+  }
+
   ScriptedProcessInterface &GetInterface() const;
   static bool IsScriptLanguageSupported(lldb::ScriptLanguage language);
 
   // Member variables.
   const ScriptedMetadata m_scripted_metadata;
-  lldb_private::ScriptInterpreter *m_interpreter = nullptr;
-  lldb_private::StructuredData::ObjectSP m_script_object_sp = nullptr;
-  //@}
+  lldb::ScriptedProcessInterfaceUP m_interface_up;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/Process/scripted/ScriptedProcess.h
+++ b/lldb/source/Plugins/Process/scripted/ScriptedProcess.h
@@ -74,6 +74,8 @@ public:
 
   void UpdateQueueListIfNeeded() override;
 
+  void *GetImplementation() override;
+
 protected:
   ScriptedProcess(lldb::TargetSP target_sp, lldb::ListenerSP listener_sp,
                   const ScriptedMetadata &scripted_metadata, Status &error);

--- a/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
@@ -34,7 +34,7 @@ ScriptedThread::Create(ScriptedProcess &process,
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "Invalid scripted process.");
 
-  process.CheckInterpreterAndScriptObject();
+  process.CheckScriptedInterface();
 
   auto scripted_thread_interface =
       process.GetInterface().CreateScriptedThreadInterface();

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -436,9 +436,6 @@ ScriptInterpreterPythonImpl::ScriptInterpreterPythonImpl(Debugger &debugger)
       m_active_io_handler(eIOHandlerNone), m_session_is_active(false),
       m_pty_secondary_is_open(false), m_valid_session(true), m_lock_count(0),
       m_command_thread_state(nullptr) {
-  m_scripted_process_interface_up =
-      std::make_unique<ScriptedProcessPythonInterface>(*this);
-
   m_dictionary_name.append("_dict");
   StreamString run_string;
   run_string.Printf("%s = dict()", m_dictionary_name.c_str());
@@ -1506,6 +1503,11 @@ lldb::ValueObjectListSP ScriptInterpreterPythonImpl::GetRecognizedArguments(
     return result;
   }
   return ValueObjectListSP();
+}
+
+ScriptedProcessInterfaceUP
+ScriptInterpreterPythonImpl::CreateScriptedProcessInterface() {
+  return std::make_unique<ScriptedProcessPythonInterface>(*this);
 }
 
 StructuredData::GenericSP

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPythonImpl.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPythonImpl.h
@@ -124,6 +124,8 @@ public:
   GetRecognizedArguments(const StructuredData::ObjectSP &implementor,
                          lldb::StackFrameSP frame_sp) override;
 
+  lldb::ScriptedProcessInterfaceUP CreateScriptedProcessInterface() override;
+
   StructuredData::GenericSP
   OSPlugin_CreatePluginObject(const char *class_name,
                               lldb::ProcessSP process_sp) override;

--- a/lldb/test/API/functionalities/scripted_process/TestScriptedProcess.py
+++ b/lldb/test/API/functionalities/scripted_process/TestScriptedProcess.py
@@ -10,6 +10,8 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 from lldbsuite.test import lldbtest
 
+import dummy_scripted_process
+
 class ScriptedProcesTestCase(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
@@ -109,8 +111,21 @@ class ScriptedProcesTestCase(TestBase):
         process = target.Launch(launch_info, error)
         self.assertTrue(process and process.IsValid(), PROCESS_IS_VALID)
         self.assertEqual(process.GetProcessID(), 42)
-
         self.assertEqual(process.GetNumThreads(), 1)
+
+        py_impl = process.GetScriptedImplementation()
+        self.assertTrue(py_impl)
+        self.assertTrue(isinstance(py_impl, dummy_scripted_process.DummyScriptedProcess))
+        self.assertFalse(hasattr(py_impl, 'my_super_secret_member'))
+        py_impl.my_super_secret_member = 42
+        self.assertTrue(hasattr(py_impl, 'my_super_secret_member'))
+        self.assertEqual(py_impl.my_super_secret_method(), 42)
+
+        addr = 0x500000000
+        message = "Hello, world!"
+        buff = process.ReadCStringFromMemory(addr, len(message) + 1, error)
+        self.assertSuccess(error)
+        self.assertEqual(buff, message)
 
         thread = process.GetSelectedThread()
         self.assertTrue(thread, "Invalid thread.")

--- a/lldb/test/API/functionalities/scripted_process/TestScriptedProcess.py
+++ b/lldb/test/API/functionalities/scripted_process/TestScriptedProcess.py
@@ -91,8 +91,8 @@ class ScriptedProcesTestCase(TestBase):
         id, name stop reason and register context.
         """
         self.build()
-        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
-        self.assertTrue(target, VALID_TARGET)
+        target_0 = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.assertTrue(target_0, VALID_TARGET)
 
         os.environ['SKIP_SCRIPTED_PROCESS_LAUNCH'] = '1'
         def cleanup():
@@ -108,12 +108,12 @@ class ScriptedProcesTestCase(TestBase):
         launch_info.SetScriptedProcessClassName("dummy_scripted_process.DummyScriptedProcess")
 
         error = lldb.SBError()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process and process.IsValid(), PROCESS_IS_VALID)
-        self.assertEqual(process.GetProcessID(), 42)
-        self.assertEqual(process.GetNumThreads(), 1)
+        process_0 = target_0.Launch(launch_info, error)
+        self.assertTrue(process_0 and process_0.IsValid(), PROCESS_IS_VALID)
+        self.assertEqual(process_0.GetProcessID(), 42)
+        self.assertEqual(process_0.GetNumThreads(), 1)
 
-        py_impl = process.GetScriptedImplementation()
+        py_impl = process_0.GetScriptedImplementation()
         self.assertTrue(py_impl)
         self.assertTrue(isinstance(py_impl, dummy_scripted_process.DummyScriptedProcess))
         self.assertFalse(hasattr(py_impl, 'my_super_secret_member'))
@@ -121,13 +121,37 @@ class ScriptedProcesTestCase(TestBase):
         self.assertTrue(hasattr(py_impl, 'my_super_secret_member'))
         self.assertEqual(py_impl.my_super_secret_method(), 42)
 
+        # Try reading from target #0 process ...
         addr = 0x500000000
-        message = "Hello, world!"
-        buff = process.ReadCStringFromMemory(addr, len(message) + 1, error)
+        message = "Hello, target 0"
+        buff = process_0.ReadCStringFromMemory(addr, len(message) + 1, error)
         self.assertSuccess(error)
         self.assertEqual(buff, message)
 
-        thread = process.GetSelectedThread()
+        target_1 = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.assertTrue(target_1, VALID_TARGET)
+        error = lldb.SBError()
+        process_1 = target_1.Launch(launch_info, error)
+        self.assertTrue(process_1 and process_1.IsValid(), PROCESS_IS_VALID)
+        self.assertEqual(process_1.GetProcessID(), 42)
+        self.assertEqual(process_1.GetNumThreads(), 1)
+
+        # ... then try reading from target #1 process ...
+        addr = 0x500000000
+        message = "Hello, target 1"
+        buff = process_1.ReadCStringFromMemory(addr, len(message) + 1, error)
+        self.assertSuccess(error)
+        self.assertEqual(buff, message)
+
+        # ... now, reading again from target #0 process to make sure the call
+        # gets dispatched to the right target.
+        addr = 0x500000000
+        message = "Hello, target 0"
+        buff = process_0.ReadCStringFromMemory(addr, len(message) + 1, error)
+        self.assertSuccess(error)
+        self.assertEqual(buff, message)
+
+        thread = process_0.GetSelectedThread()
         self.assertTrue(thread, "Invalid thread.")
         self.assertEqual(thread.GetThreadID(), 0x19)
         self.assertEqual(thread.GetName(), "DummyScriptedThread.thread-1")
@@ -151,5 +175,5 @@ class ScriptedProcesTestCase(TestBase):
             self.assertEqual(idx, int(reg.value, 16))
 
         self.assertTrue(frame.IsArtificial(), "Frame is not artificial")
-        pc = frame.GetPCAddress().GetLoadAddress(target)
+        pc = frame.GetPCAddress().GetLoadAddress(target_0)
         self.assertEqual(pc, 0x0100001b00)

--- a/lldb/test/API/functionalities/scripted_process/dummy_scripted_process.py
+++ b/lldb/test/API/functionalities/scripted_process/dummy_scripted_process.py
@@ -21,10 +21,12 @@ class DummyScriptedProcess(ScriptedProcess):
         return {}
 
     def read_memory_at_address(self, addr: int, size: int) -> lldb.SBData:
+        debugger = self.target.GetDebugger()
+        index = debugger.GetIndexOfTarget(self.target)
         data = lldb.SBData().CreateDataFromCString(
                                     self.target.GetByteOrder(),
                                     self.target.GetCodeByteSize(),
-                                    "Hello, world!")
+                                    "Hello, target " + str(index))
         return data
 
     def get_loaded_images(self):

--- a/lldb/test/API/functionalities/scripted_process/dummy_scripted_process.py
+++ b/lldb/test/API/functionalities/scripted_process/dummy_scripted_process.py
@@ -42,6 +42,12 @@ class DummyScriptedProcess(ScriptedProcess):
     def get_scripted_thread_plugin(self):
         return DummyScriptedThread.__module__ + "." + DummyScriptedThread.__name__
 
+    def my_super_secret_method(self):
+        if hasattr(self, 'my_super_secret_member'):
+            return self.my_super_secret_member
+        else:
+            return None
+
 
 class DummyScriptedThread(ScriptedThread):
     def __init__(self, process, args):

--- a/lldb/test/API/python_api/process/TestProcessAPI.py
+++ b/lldb/test/API/python_api/process/TestProcessAPI.py
@@ -21,6 +21,18 @@ class ProcessAPITestCase(TestBase):
             "main.cpp",
             "// Set break point at this line and check variable 'my_char'.")
 
+    def test_scripted_implementation(self):
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+
+        (target, process, _, _) = \
+            lldbutil.run_to_source_breakpoint(self, "Set break point",
+                                              lldb.SBFileSpec("main.cpp"))
+
+        self.assertTrue(process, PROCESS_IS_VALID)
+        self.assertEqual(process.GetScriptedImplementation(), None)
+
+
     def test_read_memory(self):
         """Test Python SBProcess.ReadMemory() API."""
         self.build()


### PR DESCRIPTION
This PR should address an issue when using multiple scripted processes in the same debugger instance.
This also adds a new `SBProcess` method to fetch the scripted process python implementation.