### PR TITLE
Revert "[lldb] Update TestHelp.py for downstream option"

### DIFF
--- a/lldb/test/API/commands/help/TestHelp.py
+++ b/lldb/test/API/commands/help/TestHelp.py
@@ -268,7 +268,7 @@ class HelpCommandTestCase(TestBase):
         """Test that we put a break between the usage and the options help lines,
            and between the options themselves."""
         self.expect("help memory read", substrs=[
-                    "[<address-expression>]\n\n       --bind-generic-types <none>",
+                    "[<address-expression>]\n\n       -A ( --show-all-children )",
                     # Starts with the end of the show-all-children line
                     "to show.\n\n       -D"])
 


### PR DESCRIPTION
This reverts commit 7451dc2332f2a1ce547cef8d8e894abc335dc41d.

(cherry picked from commit e4e792c338bab7f4bad4a4f09816f2b558e98d20)