### PR TITLE
[lldb] Adapt lldb-swift usage of types to always be owned by TypeLists

### DIFF
--- a/lldb/include/lldb/Symbol/SymbolFile.h
+++ b/lldb/include/lldb/Symbol/SymbolFile.h
@@ -456,6 +456,8 @@ public:
 
   virtual lldb::TypeSP CopyType(const lldb::TypeSP &other_type) = 0;
 
+  virtual lldb::TypeSP CopyType(const lldb::TypeSP &other_type) = 0;
+
 protected:
   void AssertModuleLock();
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -353,9 +353,8 @@ static bool AddVariableInfo(
       0, variable_sp->GetName().GetCString(), "",
       std::make_shared<lldb_private::SymbolFileType>(
           *variable_sp->GetType()->GetSymbolFile(),
-          std::make_shared<lldb_private::Type>(
-              0, variable_sp->GetType()->GetSymbolFile(),
-              variable_sp->GetType()->GetName(), llvm::None,
+          variable_sp->GetType()->GetSymbolFile()->MakeType(
+              0, variable_sp->GetType()->GetName(), llvm::None,
               variable_sp->GetType()->GetSymbolContextScope(), LLDB_INVALID_UID,
               Type::eEncodingIsUID, variable_sp->GetType()->GetDeclaration(),
               target_type, lldb_private::Type::ResolveState::Full,

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -134,7 +134,7 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
     if (name.GetStringRef().equals("$swift.fixedbuffer")) {
       if (auto wrapped_type = get_type(die.GetFirstChild())) {
         // Create a unique pointer for the type + fixed buffer flag.
-        type_sp.reset(new Type(*wrapped_type));
+        type_sp = wrapped_type->GetSymbolFile()->CopyType(wrapped_type);
         type_sp->SetPayload(TypePayloadSwift(true));
         return type_sp;
       }
@@ -194,13 +194,13 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
   }
 
   if (compiler_type) {
-    type_sp = TypeSP(new Type(
-        die.GetID(), die.GetDWARF(),
+    type_sp = die.GetDWARF()->MakeType(
+        die.GetID(),
         preferred_name ? preferred_name : compiler_type.GetTypeName(),
         // We don't have an exe_scope here by design, so we need to
         // read the size from DWARF.
         dwarf_byte_size, nullptr, LLDB_INVALID_UID, Type::eEncodingIsUID, &decl,
-        compiler_type, Type::ResolveState::Full));
+        compiler_type, Type::ResolveState::Full);
   }
 
   // Cache this type.


### PR DESCRIPTION
(cherry picked from commit 4ae003240b65edccd5bb1eb31ee4fcef5cdd14ab) (cherry picked from commit 2656fd589947eef95cdcbf93b9a9e18423624642)