### PR TITLE
[lldb] Fix 'error: non-const lvalue...' caused by SWIG 4.1.0

### DIFF
--- a/lldb/bindings/python/python-typemaps.swig
+++ b/lldb/bindings/python/python-typemaps.swig
@@ -435,7 +435,7 @@ template <> bool SetNumberFromPyObject<double>(double &number, PyObject *obj) {
 
 %typemap(out) lldb::FileSP {
   $result = nullptr;
-  lldb::FileSP &sp = $1;
+  const lldb::FileSP &sp = $1;
   if (sp) {
     PythonFile pyfile = unwrapOrSetPythonException(PythonFile::FromFile(*sp));
     if (!pyfile.IsValid())


### PR DESCRIPTION
Fix the failure caused by change in SwigValueWraper for C++11 and later
for improved move semantics in SWIG commit.

https://github.com/swig/swig/commit/d1055f4b3d51cb8060893f8036846ac743302dab
(cherry picked from commit f0a25fe0b746f56295d5c02116ba28d2f965c175)
