### PR TITLE
[stable/20221013][cas/libclang] Enhance the CAS-related libclang APIs for CAS configuration

### DIFF
--- a/clang/include/clang-c/CAS.h
+++ b/clang/include/clang-c/CAS.h
@@ -33,6 +33,17 @@ extern "C" {
  */
 
 /**
+ * Configuration options for ObjectStore and ActionCache.
+ */
+typedef struct CXOpaqueCASOptions *CXCASOptions;
+
+/**
+ * Encapsulates instances of ObjectStore and ActionCache, created from a
+ * particular configuration of \p CXCASOptions.
+ */
+typedef struct CXOpaqueCASDatabases *CXCASDatabases;
+
+/**
  * Content-addressable storage for objects.
  */
 typedef struct CXOpaqueCASObjectStore *CXCASObjectStore;
@@ -41,6 +52,39 @@ typedef struct CXOpaqueCASObjectStore *CXCASObjectStore;
  * A cache from a key describing an action to the result of doing it.
  */
 typedef struct CXOpaqueCASActionCache *CXCASActionCache;
+
+/**
+ * Create a \c CXCASOptions object.
+ */
+CINDEX_LINKAGE CXCASOptions clang_experimental_cas_Options_create(void);
+
+/**
+ * Dispose of a \c CXCASOptions object.
+ */
+CINDEX_LINKAGE void clang_experimental_cas_Options_dispose(CXCASOptions);
+
+/**
+ * Configure the file path to use for on-disk CAS/cache instances.
+ */
+CINDEX_LINKAGE void
+clang_experimental_cas_Options_setOnDiskPath(CXCASOptions, const char *Path);
+
+/**
+ * Creates instances for a CAS object store and action cache based on the
+ * configuration of a \p CXCASOptions.
+ *
+ * \param Opts configuration options.
+ * \param[out] Error The error string to pass back to client (if any).
+ *
+ * \returns The resulting instances object, or null if there was an error.
+ */
+CINDEX_LINKAGE CXCASDatabases
+clang_experimental_cas_Databases_create(CXCASOptions Opts, CXString *Error);
+
+/**
+ * Dispose of a \c CXCASDatabases object.
+ */
+CINDEX_LINKAGE void clang_experimental_cas_Databases_dispose(CXCASDatabases);
 
 /**
  * Dispose of a \c CXCASObjectStore object.
@@ -56,27 +100,29 @@ clang_experimental_cas_ActionCache_dispose(CXCASActionCache Cache);
 
 /**
  * Gets or creates a persistent on-disk CAS object store at \p Path.
+ * Deprecated, use \p clang_experimental_cas_Databases_create() instead.
  *
  * \param Path The path to locate the object store.
  * \param[out] Error The error string to pass back to client (if any).
  *
  * \returns The resulting object store, or null if there was an error.
  */
-CINDEX_LINKAGE CXCASObjectStore
-clang_experimental_cas_OnDiskObjectStore_create(
-    const char *Path, CXString *Error);
+CINDEX_DEPRECATED CINDEX_LINKAGE CXCASObjectStore
+clang_experimental_cas_OnDiskObjectStore_create(const char *Path,
+                                                CXString *Error);
 
 /**
  * Gets or creates a persistent on-disk action cache at \p Path.
+ * Deprecated, use \p clang_experimental_cas_Databases_create() instead.
  *
  * \param Path The path to locate the object store.
  * \param[out] Error The error string to pass back to client (if any).
  *
  * \returns The resulting object store, or null if there was an error.
  */
-CINDEX_LINKAGE CXCASActionCache
-clang_experimental_cas_OnDiskActionCache_create(
-    const char *Path, CXString *Error);
+CINDEX_DEPRECATED CINDEX_LINKAGE CXCASActionCache
+clang_experimental_cas_OnDiskActionCache_create(const char *Path,
+                                                CXString *Error);
 
 /**
  * @}

--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -198,18 +198,32 @@ clang_experimental_DependencyScannerServiceOptions_setDependencyMode(
     CXDependencyScannerServiceOptions Opts, CXDependencyMode Mode);
 
 /**
- * Specify a \c CXCASObjectStore in the given options. If an object store and
- * action cache are available, the scanner will produce cached commands.
+ * Specify the object store and action cache databases in the given options.
+ * With this set, the scanner will produce cached commands.
  */
 CINDEX_LINKAGE void
+clang_experimental_DependencyScannerServiceOptions_setCASDatabases(
+    CXDependencyScannerServiceOptions Opts, CXCASDatabases);
+
+/**
+ * Specify a \c CXCASObjectStore in the given options. If an object store and
+ * action cache are available, the scanner will produce cached commands.
+ * Deprecated, use
+ * \p clang_experimental_DependencyScannerServiceOptions_setCASDatabases()
+ * instead.
+ */
+CINDEX_DEPRECATED CINDEX_LINKAGE void
 clang_experimental_DependencyScannerServiceOptions_setObjectStore(
     CXDependencyScannerServiceOptions Opts, CXCASObjectStore CAS);
 
 /**
  * Specify a \c CXCASActionCache in the given options. If an object store and
  * action cache are available, the scanner will produce cached commands.
+ * Deprecated, use
+ * \p clang_experimental_DependencyScannerServiceOptions_setCASDatabases()
+ * instead.
  */
-CINDEX_LINKAGE void
+CINDEX_DEPRECATED CINDEX_LINKAGE void
 clang_experimental_DependencyScannerServiceOptions_setActionCache(
     CXDependencyScannerServiceOptions Opts, CXCASActionCache Cache);
 

--- a/clang/test/Index/Core/scan-deps-cas.m
+++ b/clang/test/Index/Core/scan-deps-cas.m
@@ -1,8 +1,7 @@
 // RUN: rm -rf %t.mcp %t
 // RUN: echo %S > %t.result
 //
-// RUN: c-index-test core --scan-deps %S -output-dir=%t \
-// RUN:     -cas-path %t/cas -action-cache-path %t/cache \
+// RUN: c-index-test core --scan-deps %S -output-dir=%t -cas-path %t/cas \
 // RUN:  -- %clang -c -I %S/Inputs/module \
 // RUN:     -fmodules -fmodules-cache-path=%t.mcp \
 // RUN:     -o FoE.o -x objective-c %s >> %t.result

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -138,10 +138,7 @@ static cl::list<std::string> DependencyTargets(
     "dependency-target",
     cl::desc("module builds should use the given dependency target(s)"));
 static llvm::cl::opt<std::string>
-    CASPath("cas-path", llvm::cl::desc("Path for on-disk CAS."));
-static llvm::cl::opt<std::string>
-    CachePath("action-cache-path",
-              llvm::cl::desc("Path for on-disk action cache."));
+    CASPath("cas-path", llvm::cl::desc("Path for on-disk CAS/cache."));
 }
 } // anonymous namespace
 
@@ -684,8 +681,7 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
                     bool SerializeDiags, bool DependencyFile,
                     ArrayRef<std::string> DepTargets, std::string OutputPath,
                     Optional<std::string> CASPath,
-                    Optional<std::string> CachePath,
-                    Optional<std::string> ModuleName = None) {
+                    Optional<std::string> ModuleName = std::nullopt) {
   CXDependencyScannerServiceOptions Opts =
       clang_experimental_DependencyScannerServiceOptions_create();
   auto CleanupOpts = llvm::make_scope_exit([&] {
@@ -696,32 +692,22 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
 
   CXString Error;
   if (CASPath) {
-    CXCASObjectStore CAS = clang_experimental_cas_OnDiskObjectStore_create(
-        CASPath->c_str(), &Error);
-    auto CleanupCache = llvm::make_scope_exit(
-        [&] { clang_experimental_cas_ObjectStore_dispose(CAS); });
-    if (!CAS) {
-      llvm::errs() << "error: failed to create ObjectStore\n";
+    CXCASOptions CASOpts = clang_experimental_cas_Options_create();
+    auto CleanupCASOpts = llvm::make_scope_exit(
+        [&] { clang_experimental_cas_Options_dispose(CASOpts); });
+    clang_experimental_cas_Options_setOnDiskPath(CASOpts, CASPath->c_str());
+    CXCASDatabases DBs =
+        clang_experimental_cas_Databases_create(CASOpts, &Error);
+    auto CleanupCaches = llvm::make_scope_exit(
+        [&] { clang_experimental_cas_Databases_dispose(DBs); });
+    if (!DBs) {
+      llvm::errs() << "error: failed to create cache instances\n";
       llvm::errs() << clang_getCString(Error) << "\n";
       clang_disposeString(Error);
       return 1;
     }
-    clang_experimental_DependencyScannerServiceOptions_setObjectStore(Opts,
-                                                                      CAS);
-    if (CachePath) {
-      CXCASActionCache Cache = clang_experimental_cas_OnDiskActionCache_create(
-          CachePath->c_str(), &Error);
-      auto CleanupCache = llvm::make_scope_exit(
-          [&] { clang_experimental_cas_ActionCache_dispose(Cache); });
-      if (!Cache) {
-        llvm::errs() << "error: failed to create ActionCache\n";
-        llvm::errs() << clang_getCString(Error) << "\n";
-        clang_disposeString(Error);
-        return 1;
-      }
-      clang_experimental_DependencyScannerServiceOptions_setActionCache(Opts,
-                                                                        Cache);
-    }
+    clang_experimental_DependencyScannerServiceOptions_setCASDatabases(Opts,
+                                                                       DBs);
   }
 
   CXDependencyScannerService Service =
@@ -1146,11 +1132,9 @@ int indextest_core_main(int argc, const char **argv) {
     return aggregateDataAsJSON(storePath, PathRemapper, OS);
   }
 
-  Optional<std::string> CASPath =
-      options::CASPath.empty() ? None : Optional<std::string>(options::CASPath);
-  Optional<std::string> CachePath =
-      options::CachePath.empty() ? None
-                                 : Optional<std::string>(options::CachePath);
+  Optional<std::string> CASPath = options::CASPath.empty()
+                                      ? std::nullopt
+                                      : Optional<std::string>(options::CASPath);
 
   if (options::Action == ActionType::ScanDeps) {
     if (options::InputFiles.empty()) {
@@ -1159,7 +1143,7 @@ int indextest_core_main(int argc, const char **argv) {
     }
     return scanDeps(CompArgs, options::InputFiles[0], options::SerializeDiags,
                     options::DependencyFile, options::DependencyTargets,
-                    options::OutputDir, CASPath, CachePath);
+                    options::OutputDir, CASPath);
   }
 
   if (options::Action == ActionType::ScanDepsByModuleName) {
@@ -1174,8 +1158,7 @@ int indextest_core_main(int argc, const char **argv) {
     }
     return scanDeps(CompArgs, options::InputFiles[0], options::SerializeDiags,
                     options::DependencyFile, options::DependencyTargets,
-                    options::OutputDir, CASPath, CachePath,
-                    options::ModuleName);
+                    options::OutputDir, CASPath, options::ModuleName);
   }
 
   if (options::Action == ActionType::WatchDir) {

--- a/clang/tools/libclang/CASUtils.h
+++ b/clang/tools/libclang/CASUtils.h
@@ -11,6 +11,7 @@
 
 #include "clang-c/CAS.h"
 #include "clang/Basic/LLVM.h"
+#include "clang/CAS/CASOptions.h"
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/Support/CBindingWrapping.h"
@@ -18,6 +19,12 @@
 
 namespace clang {
 namespace cas {
+
+struct WrappedCASDatabases {
+  CASOptions CASOpts;
+  std::shared_ptr<cas::ObjectStore> CAS;
+  std::shared_ptr<cas::ActionCache> Cache;
+};
 
 struct WrappedObjectStore {
   std::shared_ptr<ObjectStore> CAS;
@@ -29,6 +36,8 @@ struct WrappedActionCache {
   std::string CachePath;
 };
 
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(CASOptions, CXCASOptions)
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(WrappedCASDatabases, CXCASDatabases)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(WrappedObjectStore, CXCASObjectStore)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(WrappedActionCache, CXCASActionCache)
 

--- a/clang/tools/libclang/CCAS.cpp
+++ b/clang/tools/libclang/CCAS.cpp
@@ -13,11 +13,65 @@
 
 #include "clang/Basic/LLVM.h"
 #include "clang/CAS/CASOptions.h"
+#include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/Path.h"
 
 using namespace clang;
 using namespace clang::cas;
+
+CXCASOptions clang_experimental_cas_Options_create(void) {
+  return wrap(new CASOptions());
+}
+
+void clang_experimental_cas_Options_dispose(CXCASOptions Opts) {
+  delete unwrap(Opts);
+}
+
+void clang_experimental_cas_Options_setOnDiskPath(CXCASOptions COpts,
+                                                  const char *Path) {
+  CASOptions &Opts = *unwrap(COpts);
+  SmallString<256> PathBuf;
+  PathBuf = Path;
+  llvm::sys::path::append(PathBuf, "cas");
+  Opts.CASPath = std::string(PathBuf);
+  llvm::sys::path::remove_filename(PathBuf);
+  llvm::sys::path::append(PathBuf, "cache");
+  Opts.CachePath = std::string(PathBuf);
+}
+
+CXCASDatabases clang_experimental_cas_Databases_create(CXCASOptions COpts,
+                                                       CXString *Error) {
+  CASOptions &Opts = *unwrap(COpts);
+
+  SmallString<128> DiagBuf;
+  llvm::raw_svector_ostream OS(DiagBuf);
+  IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts = new DiagnosticOptions();
+  TextDiagnosticPrinter DiagPrinter(OS, DiagOpts.get());
+  DiagnosticsEngine Diags(
+      IntrusiveRefCntPtr<DiagnosticIDs>(new DiagnosticIDs()), DiagOpts.get(),
+      &DiagPrinter, /*ShouldOwnClient=*/false);
+
+  auto CAS = Opts.getOrCreateObjectStore(Diags);
+  if (!CAS) {
+    if (Error)
+      *Error = cxstring::createDup(OS.str());
+    return nullptr;
+  }
+  auto Cache = Opts.getOrCreateActionCache(Diags);
+  if (!Cache) {
+    if (Error)
+      *Error = cxstring::createDup(OS.str());
+    return nullptr;
+  }
+
+  return wrap(new WrappedCASDatabases{Opts, std::move(CAS), std::move(Cache)});
+}
+
+void clang_experimental_cas_Databases_dispose(CXCASDatabases CDBs) {
+  delete unwrap(CDBs);
+}
 
 void clang_experimental_cas_ObjectStore_dispose(CXCASObjectStore CAS) {
   delete unwrap(CAS);

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -96,6 +96,14 @@ void clang_experimental_DependencyScannerServiceOptions_setDependencyMode(
   unwrap(Opts)->Format = unwrap(Mode);
 }
 
+void clang_experimental_DependencyScannerServiceOptions_setCASDatabases(
+    CXDependencyScannerServiceOptions Opts, CXCASDatabases CDBs) {
+  cas::WrappedCASDatabases &DBs = *cas::unwrap(CDBs);
+  unwrap(Opts)->CASOpts = DBs.CASOpts;
+  unwrap(Opts)->CAS = DBs.CAS;
+  unwrap(Opts)->Cache = DBs.Cache;
+}
+
 void clang_experimental_DependencyScannerServiceOptions_setObjectStore(
     CXDependencyScannerServiceOptions Opts, CXCASObjectStore CAS) {
   unwrap(Opts)->CAS = cas::unwrap(CAS)->CAS;

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -472,13 +472,19 @@ LLVM_13 {
 LLVM_16 {
   global:
     clang_experimental_cas_ActionCache_dispose;
+    clang_experimental_cas_Databases_create;
+    clang_experimental_cas_Databases_dispose;
     clang_experimental_cas_ObjectStore_dispose;
     clang_experimental_cas_OnDiskActionCache_create;
     clang_experimental_cas_OnDiskObjectStore_create;
+    clang_experimental_cas_Options_create;
+    clang_experimental_cas_Options_dispose;
+    clang_experimental_cas_Options_setOnDiskPath;
     clang_experimental_DependencyScannerService_create_v1;
     clang_experimental_DependencyScannerServiceOptions_create;
     clang_experimental_DependencyScannerServiceOptions_dispose;
     clang_experimental_DependencyScannerServiceOptions_setActionCache;
+    clang_experimental_DependencyScannerServiceOptions_setCASDatabases;
     clang_experimental_DependencyScannerServiceOptions_setDependencyMode;
     clang_experimental_DependencyScannerServiceOptions_setObjectStore;
     clang_experimental_DependencyScannerWorker_getFileDependencies_v5;


### PR DESCRIPTION
The main changes are:

* Added `CXCASOptions` which is a wrapper for `clang::CASOptions`
* Added `CXCASDatabases` which encapsulates `ObjectStore` and `ActionCache` instances created from a particular `CXCASOptions` configuration.
* Added `clang_experimental_DependencyScannerServiceOptions_setCASDatabases` for configuring a `CXDependencyScannerServiceOptions` object for caching functionality.
* Simplified the setup by only needing the client to call `clang_experimental_cas_Options_setOnDiskPath` for configuring the path for on-disk databases.

This scheme deprecates:

* `clang_experimental_cas_OnDiskActionCache_create`
* `clang_experimental_cas_OnDiskObjectStore_create`
* `clang_experimental_DependencyScannerServiceOptions_setObjectStore`
* `clang_experimental_DependencyScannerServiceOptions_setActionCache`

The benefits of this scheme are:

* It makes it explicit that the libclang client gets instances of `ObjectStore` and `ActionCache` the same way as how the `cc1` invocation will create them (both using the `clang::CASOptions` mechanism).
* Improved flexibility; adding CAS configurations only needs adding new `clang_experimental_cas_Options_*` functions.

(cherry picked from commit e80aa811e99ce5d5f49dd045ffe4e431a11ed052)