### PR TITLE
[clang][cas] Treat implicit module as out-of-date if root ID is missing from CAS

### DIFF
--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -239,6 +239,13 @@ public:
   /// AST file imported by this AST file.
   virtual void visitImport(StringRef ModuleName, StringRef Filename) {}
 
+  /// Called for each CAS filesystem root ID.
+  ///
+  /// \returns true to indicate \p RootID is invalid, or false otherwise.
+  virtual bool readCASFileSystemRootID(StringRef RootID, bool Complain) {
+    return false;
+  }
+
   /// Called for each module cache key.
   ///
   /// \returns true to indicate the key cannot be loaded.
@@ -292,6 +299,7 @@ public:
                        serialization::ModuleKind Kind) override;
   bool visitInputFile(StringRef Filename, bool isSystem,
                       bool isOverridden, bool isExplicitModule) override;
+  bool readCASFileSystemRootID(StringRef RootID, bool Complain) override;
   bool readModuleCacheKey(StringRef ModuleName, StringRef Filename,
                           StringRef CacheKey) override;
   void readModuleFileExtension(

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -647,6 +647,7 @@ public:
                               DiagnosticsEngine &Diags)
       : CAS(CAS), Cache(Cache), ModuleCache(ModuleCache), Diags(Diags) {}
 
+  bool readCASFileSystemRootID(StringRef RootID, bool Complain) override;
   bool readModuleCacheKey(StringRef ModuleName, StringRef Filename,
                           StringRef CacheKey) override;
 
@@ -2407,4 +2408,23 @@ bool CompileCacheASTReaderHelper::readModuleCacheKey(StringRef ModuleName,
   // FIXME: add name/path of the importing module?
   return addCachedModuleFileToInMemoryCache(
       Filename, CacheKey, "imported module", CAS, Cache, ModuleCache, Diags);
+}
+
+bool CompileCacheASTReaderHelper::readCASFileSystemRootID(StringRef RootID,
+                                                          bool Complain) {
+  // Verify that RootID is in the CAS. Otherwise the module cache probably was
+  // created with a different CAS.
+  std::optional<cas::CASID> ID;
+  if (errorToBool(CAS.parseID(RootID).moveInto(ID))) {
+    if (Complain)
+      Diags.Report(diag::err_cas_cannot_parse_root_id) << RootID;
+    return true;
+  }
+  if (errorToBool(CAS.getProxy(*ID).takeError())) {
+    if (Complain) {
+      Diags.Report(diag::err_cas_missing_root_id) << RootID;
+    }
+    return true;
+  }
+  return false;
 }

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -252,6 +252,11 @@ bool ChainedASTReaderListener::visitInputFile(StringRef Filename,
                                        isExplicitModule);
   return Continue;
 }
+bool ChainedASTReaderListener::readCASFileSystemRootID(StringRef RootID,
+                                                       bool Complain) {
+  return First->readCASFileSystemRootID(RootID, Complain) ||
+         Second->readCASFileSystemRootID(RootID, Complain);
+}
 
 bool ChainedASTReaderListener::readModuleCacheKey(StringRef ModuleName,
                                                   StringRef Filename,
@@ -3013,6 +3018,12 @@ ASTReader::ReadControlBlock(ModuleFile &F,
 
     case CASFS_ROOT_ID:
       F.CASFileSystemRootID = Blob.str();
+      if (Listener) {
+        bool Complain =
+            !canRecoverFromOutOfDate(F.FileName, ClientLoadCapabilities);
+        if (Listener->readCASFileSystemRootID(F.CASFileSystemRootID, Complain))
+          return OutOfDate;
+      }
       break;
     }
   }

--- a/clang/test/ClangScanDeps/modules-cas-implicit-module-cache.c
+++ b/clang/test/ClangScanDeps/modules-cas-implicit-module-cache.c
@@ -1,0 +1,49 @@
+// Check that the implicit modules build that the scanner performs detects
+// missing cas objects.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// Scan to populate module cache
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -format experimental-full -mode preprocess-dependency-directives
+
+// Clear cas and re-scan
+
+// RUN: rm -rf %t/cas
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -format experimental-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// Build module and TU
+
+// RUN: %deps-to-rsp %t/deps.json --module-name Mod > %t/Mod.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: %clang @%t/Mod.rsp
+// RUN: %clang @%t/tu.rsp
+
+//--- cdb.json.template
+[{
+  "directory" : "DIR",
+  "command" : "clang_tool -fsyntax-only DIR/tu.c -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache",
+  "file" : "DIR/tu.c"
+}]
+
+//--- module.modulemap
+module Mod { header "Mod.h" }
+
+//--- Mod.h
+void mod(void);
+
+//--- tu.c
+#include "Mod.h"
+void tu(void) {
+  mod();
+}


### PR DESCRIPTION
If the module cache was built with a different CAS, the cas-fs-root-id will be missing and we should rebuild the module, which will ensure we have the root id in the current CAS.

Note: while there is code to emit error messages it will only be exercised if we have some kind of catastrophic error after we already tried to rebuild the module - e.g. corrupted root id string, or cas removed in the middle of the compilation - so it is not tested here.