### PR TITLE
[lldb] Remove data formatter for unavailable ImplicitlyUnwrappedOptional

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -462,8 +462,6 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
 
   // do not move the relative order of these - @unchecked needs to come first or
   // else pain will ensue
-  AddSummary(swift_category_sp, swift_unchecked_optional_summary_sp,
-             ConstString("^Swift.ImplicitlyUnwrappedOptional<.+>$"), true);
   AddSummary(swift_category_sp, swift_optional_summary_sp,
              ConstString("^Swift.Optional<.+>$"), true);
 
@@ -477,12 +475,6 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   AddSummary(swift_category_sp, swift_optional_summary_sp, ConstString("()?"),
              false);
 
-  AddCXXSynthetic(swift_category_sp,
-                  lldb_private::formatters::swift::
-                      SwiftUncheckedOptionalSyntheticFrontEndCreator,
-                  "Swift.Optional synthetic children",
-                  ConstString("^Swift.ImplicitlyUnwrappedOptional<.+>$"),
-                  optional_synth_flags, true);
   AddCXXSynthetic(
       swift_category_sp,
       lldb_private::formatters::swift::SwiftOptionalSyntheticFrontEndCreator,


### PR DESCRIPTION
The alias `ImplicitlyUnwrappedOptional` was removed and made into an
unavailable typealias some time ago. Key commits below.

```
commit 2008674495a32800872eba5b40c8df06b529b5ba
Date:   Fri Jan 26 00:25:27 2018 -0800

    Make ImplicitlyUnwrappedOptional<T> an unavailable typealias.
```

```
commit f08823757ae39ef7b6ad5b1eb2d7f50942b3f689
Date:   Wed Dec 27 13:24:15 2017 -0800

    IUO: Generate Optional<T> rather than ImplicitlyUnwrappedOptional<T>.

    ...

    ImplicitlyUnwrappedOptional<T> is is dead, long live implicitly
    unwrapped Optional<T>!
```

(cherry picked from commit 92c002294334832622ce473a756ebd95ba17d983)
