### PR TITLE
[lldb] Remove data formatter for long gone Swift._Nil

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -549,18 +549,6 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                 "GLKit summary provider", ConstString(GLKitTypes),
                 simd_summary_flags, true);
 
-  TypeSummaryImpl::Flags nil_summary_flags;
-  nil_summary_flags.SetCascades(true)
-      .SetDontShowChildren(true)
-      .SetDontShowValue(true)
-      .SetHideItemNames(false)
-      .SetShowMembersOneLiner(false)
-      .SetSkipPointers(true)
-      .SetSkipReferences(false);
-
-  AddStringSummary(swift_category_sp, "nil", ConstString("Swift._Nil"),
-                   nil_summary_flags);
-
   AddStringSummary(swift_category_sp, "${var.native}",
                    ConstString("CoreGraphics.CGFloat"), summary_flags);
   AddStringSummary(swift_category_sp, "${var.native}",


### PR DESCRIPTION
```
commit 60fc0e6cd2c93e166fab5b5977c6a2b80af33078
Date:   Sun Jun 15 22:59:03 2014 +0000

    Implement <rdar://problem/16951729> nil should be a literal type
```

(cherry picked from commit ca854612f244c1dbac4fd5a0e5a3c3dbf66f9cd1)
