### PR TITLE
[lldb] Support CoreFoundation as a module for CGFloat (#5412)

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -553,6 +553,8 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                    ConstString("CoreGraphics.CGFloat"), summary_flags);
   AddStringSummary(swift_category_sp, "${var.native}",
                    ConstString("Foundation.CGFloat"), summary_flags);
+  AddStringSummary(swift_category_sp, "${var.native}",
+                   ConstString("CoreFoundation.CGFloat"), summary_flags);
 }
 
 static void

--- a/lldb/test/API/lang/swift/variables/cgtypes/TestCGTypes.py
+++ b/lldb/test/API/lang/swift/variables/cgtypes/TestCGTypes.py
@@ -40,10 +40,10 @@ class TestSwiftCoreGraphicsTypes(TestBase):
         lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
 
-        self.expect('frame variable f', substrs=[' = 1'])
-        self.expect('frame variable p', substrs=[' = (x = 1, y = 1)'])
+        self.expect('frame variable f', substrs=[' f = 1'])
+        self.expect('frame variable p', substrs=[' p = (x = 1, y = 1)'])
         self.expect('frame variable r', substrs=[
-            ' = (origin = (x = 0, y = 0), size = (width = 0, height = 0))'])
+            ' r = (origin = (x = 0, y = 0), size = (width = 0, height = 0))'])
 
         self.expect('expr f', substrs=[' = 1'])
         self.expect('expr p', substrs=[' = (x = 1, y = 1)'])


### PR DESCRIPTION
A type summary is registered for `Foundation.CGFloat` and `CoreGraphics.CGFloat`, but currently `CGFloat` is reported as `CoreFoundation.CGFloat`. This change adds the same summary for `CoreFoundation.CGFloat`.

I would think `CoreGraphics.CGFloat` would be the expected type, but it seems this can change over the course of internal reorganizations, re-exports, etc.

rdar://100789061
(cherry picked from commit 1b4132b92fedb39723d0490098c1d7bd77550246)
