### PR TITLE
[lldb][test] Add regression test for Swift.ArraySlice (NFC) (#5519)

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/swift/array-slice/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/swift/array-slice/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/swift/array-slice/TestSwiftArraySliceFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/array-slice/TestSwiftArraySliceFormatters.py
@@ -1,0 +1,21 @@
+"""
+Test ArraySlice synthetic types.
+"""
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @swiftTest
+    def test_swift_array_slice_formatters(self):
+        """Test ArraySlice synthetic types."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        # TODO: Fix `arraySubSequence` rdar://92898538
+        for var in ("someSlice", "arraySlice"):
+            self.expect(f"v {var}", substrs=[f"{var} = 2 values", "[1] = 2", "[2] = 3"])

--- a/lldb/test/API/functionalities/data-formatter/swift/array-slice/main.swift
+++ b/lldb/test/API/functionalities/data-formatter/swift/array-slice/main.swift
@@ -1,0 +1,9 @@
+func main() {
+    let a = [1, 2, 3]
+    let someSlice = a[1...]
+    let arraySlice: ArraySlice<Int> = a[1...]
+    let arraySubSequence: Array<Int>.SubSequence = a[1...]
+    // break here
+}
+
+main()


### PR DESCRIPTION
Add regression tests for printing `ArraySlice` values.

rdar://92898538
(cherry picked from commit 0c3768ef07a397277177c6c9bf49f069836ac9e5)
