### PR TITLE
[lldb] Add Substring type summary (#5559)

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -54,6 +54,9 @@ bool String_SummaryProvider(ValueObject &valobj, Stream &stream,
                             const TypeSummaryOptions &,
                             StringPrinter::ReadStringAndDumpToStreamOptions);
 
+bool Substring_SummaryProvider(ValueObject &, Stream &,
+                               const TypeSummaryOptions &);
+
 bool StringIndex_SummaryProvider(ValueObject &valobj, Stream &stream,
                                  const TypeSummaryOptions &options);
 

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -425,6 +425,14 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   bool (*staticstring_summary_provider)(ValueObject &, Stream &,
                                         const TypeSummaryOptions &) =
       lldb_private::formatters::swift::StaticString_SummaryProvider;
+  {
+    TypeSummaryImpl::Flags substring_summary_flags = summary_flags;
+    substring_summary_flags.SetDontShowChildren(false);
+    AddCXXSummary(swift_category_sp,
+                  lldb_private::formatters::swift::Substring_SummaryProvider,
+                  "Swift.Substring summary provider",
+                  ConstString("Swift.Substring"), substring_summary_flags);
+  }
   AddCXXSummary(swift_category_sp, staticstring_summary_provider,
                 "Swift.StaticString summary provider",
                 ConstString("Swift.StaticString"), summary_flags);

--- a/lldb/source/Plugins/Language/Swift/SwiftStringIndex.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftStringIndex.h
@@ -42,7 +42,7 @@ public:
   uint64_t encodedOffset() { return _rawBits >> 16; }
 
   const char *encodingName() {
-    uint8_t flags = _rawBits & 0b1111;
+    auto flags = _flags();
     bool canBeUTF8 = flags & Flags::CanBeUTF8;
     bool canBeUTF16 = flags & Flags::CanBeUTF16;
     if (canBeUTF8 && canBeUTF16)
@@ -56,6 +56,18 @@ public:
   }
 
   uint8_t transcodedOffset() { return (_rawBits >> 14) & 0b11; }
+
+  bool matchesEncoding(StringIndex other) {
+    // Either both are valid utf8 indexes, or valid utf16 indexes.
+    return (_utfFlags() & other._utfFlags()) != 0;
+  }
+
+private:
+  uint8_t _flags() const { return _rawBits & 0b1111; }
+
+  uint8_t _utfFlags() const {
+    return _flags() & (Flags::CanBeUTF8 | Flags::CanBeUTF16);
+  }
 };
 
 }; // namespace swift

--- a/lldb/test/API/functionalities/data-formatter/swift/substring/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/swift/substring/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
@@ -1,0 +1,51 @@
+"""
+Test Substring summary strings.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @swiftTest
+    def test_swift_substring_formatters(self):
+        """Test Subtring summary strings."""
+        self.build()
+
+        # First stop tests small strings.
+
+        _, process, _, _, = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect(
+            "v substrings",
+            substrs=[
+                '[0] = "abc"',
+                '[1] = "bc"',
+                '[2] = "c"',
+                '[3] = ""',
+            ],
+        )
+
+        # Continue to the second stop, to test non-small strings.
+
+        process.Continue()
+
+        # Strings larger than 15 bytes (64-bit) or 10 bytes (32-bit) cannot be
+        # stored directly inside the String struct.
+        alphabet = "abcdefghijklmnopqrstuvwxyz"
+
+        # Including the first full substring, and the final empty substring,
+        # there are 27 substrings.
+        subalphabets = [alphabet[i:] for i in range(27)]
+
+        self.expect(
+            "v substrings",
+            substrs=[
+                f'[{i}] = "{substring}"'
+                for i, substring in enumerate(subalphabets)
+            ],
+        )

--- a/lldb/test/API/functionalities/data-formatter/swift/substring/main.swift
+++ b/lldb/test/API/functionalities/data-formatter/swift/substring/main.swift
@@ -1,0 +1,23 @@
+func main() {
+    exerciseSmallString()
+    exerciseString()
+}
+
+func exerciseSmallString() {
+    exercise("abc")
+}
+
+func exerciseString() {
+    exercise("abcdefghijklmnopqrstuvwxyz")
+}
+
+func exercise(_ string: String) {
+    let substrings = allIndices(string).map { string[$0..<string.endIndex] }
+    // break here
+}
+
+func allIndices<T: Collection>(_ collection: T) -> [T.Index] {
+    return Array(collection.indices) + [collection.endIndex]
+}
+
+main()


### PR DESCRIPTION
Adds a type summary for `Substring` values.

With this change, a summary string shows the substring slice. The substring's children show the base string, and start/end indexes.

```
(lldb) v substring
(Substring) substring = "bcdefghijklmnopqrstuvwxy" {
  _slice = {
    _startIndex = 1[utf8]
    _endIndex = 25[utf8]
    _base = "abcdefghijklmnopqrstuvwxyz"
  }
}
```

Before this change, a literal substring was not shown, only the full base string:

```
(lldb) v substring
(Substring) substring = {
  _slice = {
    _startIndex = 1[utf8]
    _endIndex = 25[utf8]
    _base = "abcdefghijklmnopqrstuvwxyz"
  }
}
```

#### Implementation Notes

This supports Swift native (utf8) strings. NSString (utf16) are not yet supported, that will be a follow up change. Additionally, this change requires that the indexes be matching encoding.

rdar://91431816
(cherry picked from commit a514263ec3e3e99812dc08548e3aff5581b779fa)
