### PR TITLE
[lldb] Allow "var" expr variables to be modified (#5651)

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1811,14 +1811,10 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
 
       swift::VarDecl *decl = variable_info.GetDecl();
       if (decl) {
-        if (decl->isLet()) {
-          llvm::cast<SwiftExpressionVariable>(persistent_variable.get())
-              ->SetIsModifiable(false);
-        }
-        if (!decl->hasStorage()) {
-          llvm::cast<SwiftExpressionVariable>(persistent_variable.get())
-              ->SetIsComputed(true);
-        }
+        auto swift_var =
+            llvm::cast<SwiftExpressionVariable>(persistent_variable.get());
+        swift_var->SetIsModifiable(!decl->isLet());
+        swift_var->SetIsComputed(!decl->hasStorage());
       }
 
       variable_info.m_metadata.reset(

--- a/lldb/test/API/lang/swift/expression/mutable_persistent_var/Makefile
+++ b/lldb/test/API/lang/swift/expression/mutable_persistent_var/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/expression/mutable_persistent_var/TestSwiftMutablePersistentVar.py
+++ b/lldb/test/API/lang/swift/expression/mutable_persistent_var/TestSwiftMutablePersistentVar.py
@@ -1,0 +1,14 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @swiftTest
+    def test(self):
+        """Test that persistent variables are mutable."""
+        self.build()
+        lldbutil.run_to_name_breakpoint(self, "main")
+        self.expect("expr var $count = 30")
+        self.expect("expr $count = 41")

--- a/lldb/test/API/lang/swift/expression/mutable_persistent_var/main.swift
+++ b/lldb/test/API/lang/swift/expression/mutable_persistent_var/main.swift
@@ -1,0 +1,1 @@
+// does nothing


### PR DESCRIPTION
Unconditionally call `SwiftExpressionVariable::SetIsModifiable`, for both `let` and `var` variables. Previously `SetIsModifiable(false)` was called for `let` variables - now `var` variables will result in `SetIsModifiable(true)`.

This fixes the following bug:

    (lldb) expr var $count = 123
    (lldb) expr $count = 456
    error: expression failed to parse:
    error: <EXPR>:3:1: error: cannot assign to value: '$count' is immutable
    $count = 456
    ^~

rdar://102675900
(cherry picked from commit 6089edae4c1d67e875dfa6febc564baf9ec056ec)
