### PR TITLE
[clang][cas] Add missing SDKSettings.json to cas-fs 

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -609,22 +609,42 @@ static void trackASTFileInputs(CompilerInstance &CI,
   }
 }
 
+/// Ensure files that are not accessed during the scan (or accessed before the
+/// tracking scope) are tracked.
+static void trackFilesCommon(CompilerInstance &CI,
+                             llvm::cas::CachingOnDiskFileSystem &CacheFS) {
+  trackASTFileInputs(CI, CacheFS);
+
+  // Exclude the module cache from tracking. The implicit build pcms should
+  // not be needed after scanning.
+  if (!CI.getHeaderSearchOpts().ModuleCachePath.empty())
+    (void)CacheFS.excludeFromTracking(CI.getHeaderSearchOpts().ModuleCachePath);
+
+  // Normally this would be looked up while creating the VFS, but implicit
+  // modules share their VFS and it happens too early for the TU scan.
+  for (const auto &File : CI.getHeaderSearchOpts().VFSOverlayFiles)
+    (void)CacheFS.status(File);
+
+  StringRef Sysroot = CI.getHeaderSearchOpts().Sysroot;
+  if (!Sysroot.empty()) {
+    // Include 'SDKSettings.json', if it exists, to accomodate availability
+    // checks during the compilation.
+    llvm::SmallString<256> FilePath = Sysroot;
+    llvm::sys::path::append(FilePath, "SDKSettings.json");
+    (void)CacheFS.status(FilePath);
+  }
+}
+
 Error FullDependencyConsumer::finalize(CompilerInstance &ScanInstance,
                                        CompilerInvocation &NewInvocation) {
   if (CacheFS) {
-    // Exclude the module cache from tracking. The implicit build pcms should
-    // not be needed after scanning.
-    if (!ScanInstance.getHeaderSearchOpts().ModuleCachePath.empty())
-      (void)CacheFS->excludeFromTracking(
-          ScanInstance.getHeaderSearchOpts().ModuleCachePath);
-
     // Handle profile mappings.
     (void)CacheFS->status(
         NewInvocation.getCodeGenOpts().ProfileInstrumentUsePath);
     (void)CacheFS->status(NewInvocation.getCodeGenOpts().SampleProfileFile);
     (void)CacheFS->status(NewInvocation.getCodeGenOpts().ProfileRemappingFile);
 
-    trackASTFileInputs(ScanInstance, *CacheFS);
+    trackFilesCommon(ScanInstance, *CacheFS);
 
     auto E = CacheFS
                  ->createTreeFromNewAccesses(
@@ -652,19 +672,10 @@ Error FullDependencyConsumer::initializeModuleBuild(
     CompilerInstance &ModuleScanInstance) {
   if (CacheFS) {
     CacheFS->trackNewAccesses();
-    auto &HSOpts = ModuleScanInstance.getHeaderSearchOpts();
-    // Normally this would be looked up while creating the VFS, but implicit
-    // modules share their VFS.
-    for (const auto &File : HSOpts.VFSOverlayFiles)
-      (void)CacheFS->status(File);
     // If the working directory is not otherwise accessed by the module build,
     // we still need it due to -fcas-fs-working-directory being set.
     if (auto CWD = CacheFS->getCurrentWorkingDirectory())
       (void)CacheFS->status(*CWD);
-    // Exclude the module cache from tracking. The implicit build pcms should
-    // not be needed after scanning.
-    if (!HSOpts.ModuleCachePath.empty())
-      (void)CacheFS->excludeFromTracking(HSOpts.ModuleCachePath);
   }
   return Error::success();
 }
@@ -672,7 +683,7 @@ Error FullDependencyConsumer::initializeModuleBuild(
 Error FullDependencyConsumer::finalizeModuleBuild(
     CompilerInstance &ModuleScanInstance) {
   if (CacheFS) {
-    trackASTFileInputs(ModuleScanInstance, *CacheFS);
+    trackFilesCommon(ModuleScanInstance, *CacheFS);
 
     std::optional<cas::CASID> RootID;
     auto E = CacheFS

--- a/clang/test/CAS/availability-check.c
+++ b/clang/test/CAS/availability-check.c
@@ -5,9 +5,14 @@
 // RUN: %clang -cc1depscan -o %t/cmd.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
 // RUN:     -cc1 -fcas-path %t/cas -triple x86_64-apple-ios14-macabi -isysroot %S/Inputs/MacOSX11.0.sdk %s
 
+// RUN: %clang -cc1depscan -o %t/cmd-casfs.rsp -fdepscan=inline -cc1-args \
+// RUN:     -cc1 -fcas-path %t/cas -triple x86_64-apple-ios14-macabi -isysroot %S/Inputs/MacOSX11.0.sdk %s
+
 // FIXME: `-verify` should work with a CAS invocation.
 // RUN: not %clang @%t/cmd.rsp -fsyntax-only 2> %t/out.txt
+// RUN: not %clang @%t/cmd-casfs.rsp -fsyntax-only 2> %t/out-casfs.txt
 // RUN: FileCheck -input-file %t/out.txt %s
+// RUN: FileCheck -input-file %t/out-casfs.txt %s
 // CHECK: error: 'fUnavail' is unavailable
 
 void fUnavail(void) __attribute__((availability(macOS, obsoleted = 10.15))); // expected-note {{marked unavailable here}}

--- a/clang/test/ClangScanDeps/modules-availability-check.c
+++ b/clang/test/ClangScanDeps/modules-availability-check.c
@@ -1,0 +1,43 @@
+// Check cas-fs-based caching works with availability check based on
+// SDKSettings.json.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -j 1 \
+// RUN:   -format experimental-full -mode preprocess-dependency-directives \
+// RUN:   -cas-path %t/cas -action-cache-path %t/cache > %t/deps.json
+
+// RUN: %deps-to-rsp %t/deps.json --module-name=mod > %t/mod.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: not %clang @%t/mod.rsp 2>&1 | FileCheck %s
+
+// CHECK: error: 'fUnavail' is unavailable
+
+//--- cdb.json.template
+[{
+  "directory": "DIR",
+  "command": "clang -target x86_64-apple-macos11 -fsyntax-only DIR/tu.c -isysroot DIR/MacOSX11.0.sdk -fmodules -fmodules-cache-path=DIR/module-cache -fimplicit-modules -fimplicit-module-maps",
+  "file": "DIR/tu.c"
+}]
+
+//--- MacOSX11.0.sdk/SDKSettings.json
+{
+  "DefaultVariant": "macos", "DisplayName": "macOS 11",
+  "Version": "11.0",
+  "MaximumDeploymentTarget": "11.0.99"
+}
+
+//--- module.modulemap
+module mod { header "mod.h" }
+
+//--- mod.h
+void fUnavail(void) __attribute__((availability(macOS, obsoleted = 10.15)));
+
+static inline void module(void) {
+  fUnavail();
+}
+
+//--- tu.c
+#include "mod.h"

--- a/clang/test/ClangScanDeps/modules-cas-fs-vfsoverlay.c
+++ b/clang/test/ClangScanDeps/modules-cas-fs-vfsoverlay.c
@@ -1,0 +1,51 @@
+// Check cas-fs-based caching works with vfsoverlay files.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+// RUN: sed -e "s|DIR|%/t|g" %t/vfs.yaml.template > %t/vfs.yaml
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -j 1 \
+// RUN:   -format experimental-full -mode preprocess-dependency-directives \
+// RUN:   -cas-path %t/cas -action-cache-path %t/cache > %t/deps.json
+
+// RUN: %deps-to-rsp %t/deps.json --module-name=A > %t/A.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: %clang @%t/A.rsp
+// RUN: %clang @%t/tu.rsp
+
+//--- cdb.json.template
+[{
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu.c -fmodules -fmodules-cache-path=DIR/module-cache -fimplicit-modules -fimplicit-module-maps -ivfsoverlay DIR/vfs.yaml",
+  "file": "DIR/tu.c"
+}]
+
+//--- vfs.yaml.template
+{
+  "version": 0,
+  "case-sensitive": "false",
+  "roots": [
+    {
+      "name": "DIR/A",
+      "type": "directory"
+      "contents": [
+        {
+          "external-contents": "DIR/elsewhere1/A.modulemap",
+          "name": "module.modulemap",
+          "type": "file"
+        }
+      ]
+    }
+  ]
+}
+
+//--- elsewhere1/A.modulemap
+module A { header "A.h" }
+
+//--- A/A.h
+typedef int A_t;
+
+//--- tu.c
+#include "A/A.h"
+A_t a = 0;


### PR DESCRIPTION
We handled this in include-tree, but not in cas-fs. We need
SDKSettings.json in order to handle availability diagnostics, but it is
not accessed during the scan otherwise. Refactor the code so we share
more between cas-fs TU and cas-fs modules; ideally we would also have
sharing with include-tree, but the differences are much greater there.

rdar://105278547

Incidentally add a test for vfsoverlay files with cas-fs -- this already worked, but I noticed it wasn't tested and it's touched by this change.