### PR TITLE
Adapt TestCustomShell and TestMultipleDebuggers to run under ASAN

### DIFF
--- a/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
+++ b/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
@@ -15,7 +15,9 @@ class TestMultipleSimultaneousDebuggers(TestBase):
     @skipIfNoSBHeaders
     @skipIfWindows
     def test_multiple_debuggers(self):
-        env = {self.dylibPath: self.getLLDBLibraryEnvVal()}
+        env = {self.dylibPath: self.getLLDBLibraryEnvVal(),
+              # We need this in order to run under ASAN, in case only LLDB is ASANified.
+              'ASAN_OPTIONS': os.getenv('ASAN_OPTIONS', None)}
 
         self.driver_exe = self.getBuildArtifact("multi-process-driver")
         self.buildDriver('multi-process-driver.cpp', self.driver_exe)

--- a/lldb/test/Shell/Host/TestCustomShell.test
+++ b/lldb/test/Shell/Host/TestCustomShell.test
@@ -7,7 +7,7 @@
 
 # RUN: %clang_host %S/Inputs/simple.c -g -o %t.out
 # RUN: SHELL=bogus not %lldb %t.out -b -o 'process launch -X 1 --' 2>&1 | FileCheck %s --check-prefix ERROR
-# RUN: env -i %lldb %t.out -b -o 'process launch -X 1 --' 2>&1 | FileCheck %s
+# RUN: env -i ASAN_OPTIONS='detect_container_overflow=0' %lldb %t.out -b -o 'process launch -X 1 --' 2>&1 | FileCheck %s
 
 # ERROR: error: shell expansion failed
 # CHECK-NOT: error: shell expansion failed


### PR DESCRIPTION
In situations where only LLDB is ASANified, a false positive occurs unless ASAN_OPTIONS=detect_container_overflow=0 is set in the environment.

Differential Revision: https://reviews.llvm.org/D143772

(cherry picked from commit 294ca122956f78aef3ab4e81108b69518e353b07)