### PR TITLE
[lldb] Fix passing None as an env variable in TestMultipleDebuggers

### DIFF
--- a/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
+++ b/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
@@ -15,9 +15,12 @@ class TestMultipleSimultaneousDebuggers(TestBase):
     @skipIfNoSBHeaders
     @skipIfWindows
     def test_multiple_debuggers(self):
-        env = {self.dylibPath: self.getLLDBLibraryEnvVal(),
-              # We need this in order to run under ASAN, in case only LLDB is ASANified.
-              'ASAN_OPTIONS': os.getenv('ASAN_OPTIONS', None)}
+        env = {self.dylibPath: self.getLLDBLibraryEnvVal()}
+
+        # We need this in order to run under ASAN, in case only LLDB is ASANified.
+        asan_options = os.getenv('ASAN_OPTIONS', None)
+        if (asan_options is not None):
+            env['ASAN_OPTIONS'] = asan_options
 
         self.driver_exe = self.getBuildArtifact("multi-process-driver")
         self.buildDriver('multi-process-driver.cpp', self.driver_exe)


### PR DESCRIPTION
(cherry picked from commit 29fa21eb61293e677a8de4bacd843ef57192b60b)