### PR TITLE
Fix atomic file rename in docker container mounted volumes

### DIFF
--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -480,7 +480,8 @@ static std::error_code rename_internal(HANDLE FromHandle, const Twine &To,
     if (Error == ERROR_SUCCESS)
       Error = ERROR_CALL_NOT_IMPLEMENTED; // Wine doesn't always set error code.
     else if (Error == ERROR_INVALID_PARAMETER) {
-      // In a Docker container, the call fails for paths in mounted volumes.
+      // This operation can fail on file systems that do not properly support
+      // the extended POSIX semantics for renames.
       Error = ERROR_CALL_NOT_IMPLEMENTED;
     }
     return mapWindowsError(Error);

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -479,6 +479,11 @@ static std::error_code rename_internal(HANDLE FromHandle, const Twine &To,
     unsigned Error = GetLastError();
     if (Error == ERROR_SUCCESS)
       Error = ERROR_CALL_NOT_IMPLEMENTED; // Wine doesn't always set error code.
+    else if (Error == ERROR_INVALID_PARAMETER)
+    {
+      // In a Docker container, the call fails for paths in mounted volumes.
+      Error = ERROR_CALL_NOT_IMPLEMENTED;
+    }
     return mapWindowsError(Error);
   }
 

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -479,8 +479,7 @@ static std::error_code rename_internal(HANDLE FromHandle, const Twine &To,
     unsigned Error = GetLastError();
     if (Error == ERROR_SUCCESS)
       Error = ERROR_CALL_NOT_IMPLEMENTED; // Wine doesn't always set error code.
-    else if (Error == ERROR_INVALID_PARAMETER)
-    {
+    else if (Error == ERROR_INVALID_PARAMETER) {
       // In a Docker container, the call fails for paths in mounted volumes.
       Error = ERROR_CALL_NOT_IMPLEMENTED;
     }


### PR DESCRIPTION
The effort to containerize the Windows build is blocked by a `swift-frontend.exe` crash, because the atomic file rename operation is not supported in a docker container with files under mounted volumes. This fix detects the atomic rename failure and goes down the same fallback that exists for WINE.

Repro:
- Create a dummy `main.swift` file
- `swift-frontend.exe -c -primary-file main.swift -emit-reference-dependencies-path main.swift.obj.swiftdeps -sdk %SDKROOT%`

This would crash inside a docker container if `main.swift` was under a mounted volume, and works with this change. CMake causes such a `swift-frontend.exe` invocation in its logic to test whether the Swift compiler it finds is valid.