### PR TITLE
[lldb] Fix image lookup crash

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -1154,9 +1154,9 @@ bool DWARFExpression::Evaluate(
           uint8_t addr_bytes[8];
           Status error;
 
-          if (exe_ctx->GetTargetRef().ReadMemory(
-                  so_addr, &addr_bytes, size, error,
-                  /*force_live_memory=*/false) == size) {
+          if (target &&
+              target->ReadMemory(so_addr, &addr_bytes, size, error,
+                                 /*force_live_memory=*/false) == size) {
             ObjectFile *objfile = module_sp->GetObjectFile();
 
             stack.back().GetScalar() = DerefSizeExtractDataHelper(

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/DW_OP_deref_size_static_var.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/DW_OP_deref_size_static_var.s
@@ -1,11 +1,17 @@
 # RUN: llvm-mc -filetype=obj -o %t -triple x86_64-apple-macosx10.15.0 %s
-# RUN: %lldb %t -o "target variable ug" -b | FileCheck %s
+# RUN: %lldb %t -o "target variable ug" -b \
+# RUN:  | FileCheck --check-prefix=TARGET-VARIABLE %s
+# RUN: %lldb %t -o "image lookup --verbose --address 0x0" -b \
+# RUN:  | FileCheck --check-prefix=IMAGE-LOOKUP %s
 
-# CHECK: (lldb) target variable ug
-# CHECK: (U) ug = {
-# CHECK:   raw = 0
-# CHECK:    = (a = 0, b = 0, c = 0, d = 0, e = 0, f = 0)
-# CHECK: }
+# TARGET-VARIABLE: (lldb) target variable ug
+# TARGET-VARIABLE: (U) ug = {
+# TARGET-VARIABLE:   raw = 0
+# TARGET-VARIABLE:    = (a = 0, b = 0, c = 0, d = 0, e = 0, f = 0)
+# TARGET-VARIABLE: }
+
+# IMAGE-LOOKUP: Summary:
+# IMAGE-LOOKUP: Module: file =
 
 # We are testing how DWARFExpression::Evaluate(...) in the case of
 # DW_OP_deref_size deals with static variable.


### PR DESCRIPTION
lldb may crash when performing `image lookup --verbose --address $ADDR`. The ExecutionContext that gets passed into DWARFExpression::Evaluate may be valid but unpopulated. However, in one specific case, we were assuming that it has a valid Target and using it without checking first.

We reach this codepath when we attempt to get information about an address that doesn't map to a CompileUnit in the module containing the requested address. lldb then checks to see if it maps to a global variable, so lldb has to evaluate the location of each global variable in the module. If a location expression contains DW_OP_deref_size that uses a FileAddress, we hit this code path. The simplest test case is to take a module that has a global variable with DW_OP_deref_size in its location expression, attempt to read an address that doesn't map to a CompileUnit (e.g. 0x0) and ensure we don't crash.

Differential Revision: https://reviews.llvm.org/D143792

(cherry picked from commit f841c4af5f5ec887777c33130ad744ee57ad672f)