### PR TITLE
Find SDK path more lazily in Apple Simulator platforms

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
@@ -41,12 +41,15 @@ PlatformAppleSimulator::PlatformAppleSimulator(
     const char *class_name, const char *description, ConstString plugin_name,
     llvm::Triple::OSType preferred_os,
     llvm::SmallVector<llvm::StringRef, 4> supported_triples,
-    llvm::StringRef sdk, lldb_private::XcodeSDK::Type sdk_type,
+    std::string sdk_name_primary, std::string sdk_name_secondary,
+    lldb_private::XcodeSDK::Type sdk_type,
     CoreSimulatorSupport::DeviceType::ProductFamilyID kind)
     : PlatformDarwin(true), m_class_name(class_name),
       m_description(description), m_plugin_name(plugin_name), m_kind(kind),
       m_os_type(preferred_os), m_supported_triples(supported_triples),
-      m_sdk(sdk), m_sdk_type(sdk_type) {}
+      m_sdk_name_primary(std::move(sdk_name_primary)),
+      m_sdk_name_secondary(std::move(sdk_name_secondary)),
+      m_sdk_type(sdk_type) {}
 
 /// Destructor.
 ///
@@ -83,8 +86,9 @@ lldb_private::Status PlatformAppleSimulator::LaunchProcess(
 
 void PlatformAppleSimulator::GetStatus(Stream &strm) {
   Platform::GetStatus(strm);
-  if (!m_sdk.empty())
-    strm << "  SDK Path: \"" << m_sdk << "\"\n";
+  llvm::StringRef sdk = GetSDKFilepath();
+  if (!sdk.empty())
+    strm << "  SDK Path: \"" << sdk << "\"\n";
   else
     strm << "  SDK Path: error: unable to locate SDK\n";
 
@@ -295,13 +299,21 @@ static llvm::StringRef GetXcodeSDKDir(std::string preferred,
   return sdk;
 }
 
+llvm::StringRef PlatformAppleSimulator::GetSDKFilepath() {
+  if (!m_have_searched_for_sdk) {
+    m_sdk = GetXcodeSDKDir(m_sdk_name_primary, m_sdk_name_secondary);
+    m_have_searched_for_sdk = true;
+  }
+  return m_sdk;
+}
+
 PlatformSP PlatformAppleSimulator::CreateInstance(
     const char *class_name, const char *description, ConstString plugin_name,
     llvm::SmallVector<llvm::Triple::ArchType, 4> supported_arch,
     llvm::Triple::OSType preferred_os,
     llvm::SmallVector<llvm::Triple::OSType, 4> supported_os,
     llvm::SmallVector<llvm::StringRef, 4> supported_triples,
-    std::string sdk_name_preferred, std::string sdk_name_secondary,
+    std::string sdk_name_primary, std::string sdk_name_secondary,
     lldb_private::XcodeSDK::Type sdk_type,
     CoreSimulatorSupport::DeviceType::ProductFamilyID kind, bool force,
     const ArchSpec *arch) {
@@ -360,11 +372,9 @@ PlatformSP PlatformAppleSimulator::CreateInstance(
   if (create) {
     LLDB_LOGF(log, "%s::%s() creating platform", class_name, __FUNCTION__);
 
-    llvm::StringRef sdk =
-        GetXcodeSDKDir(sdk_name_preferred, sdk_name_secondary);
     return PlatformSP(new PlatformAppleSimulator(
         class_name, description, plugin_name, preferred_os, supported_triples,
-        sdk, sdk_type, kind));
+        sdk_name_primary, sdk_name_secondary, sdk_type, kind));
   }
 
   LLDB_LOGF(log, "%s::%s() aborting creation of platform", class_name,
@@ -456,9 +466,10 @@ Status PlatformAppleSimulator::GetSymbolFile(const FileSpec &platform_file,
   if (platform_file.GetPath(platform_file_path, sizeof(platform_file_path))) {
     char resolved_path[PATH_MAX];
 
-    if (!m_sdk.empty()) {
+    llvm::StringRef sdk = GetSDKFilepath();
+    if (!sdk.empty()) {
       ::snprintf(resolved_path, sizeof(resolved_path), "%s/%s",
-                 m_sdk.str().c_str(), platform_file_path);
+                 sdk.str().c_str(), platform_file_path);
 
       // First try in the SDK and see if the file is in there
       local_file.SetFile(resolved_path, FileSpec::Style::native);

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.h
@@ -49,7 +49,8 @@ public:
       const char *class_name, const char *description, ConstString plugin_name,
       llvm::Triple::OSType preferred_os,
       llvm::SmallVector<llvm::StringRef, 4> supported_triples,
-      llvm::StringRef sdk, XcodeSDK::Type sdk_type,
+      std::string sdk_name_primary, std::string sdk_name_secondary,
+      XcodeSDK::Type sdk_type,
       CoreSimulatorSupport::DeviceType::ProductFamilyID kind);
 
   static lldb::PlatformSP
@@ -59,7 +60,7 @@ public:
                  llvm::Triple::OSType preferred_os,
                  llvm::SmallVector<llvm::Triple::OSType, 4> supported_os,
                  llvm::SmallVector<llvm::StringRef, 4> supported_triples,
-                 std::string sdk_name_preferred, std::string sdk_name_secondary,
+                 std::string sdk_name_primary, std::string sdk_name_secondary,
                  XcodeSDK::Type sdk_type,
                  CoreSimulatorSupport::DeviceType::ProductFamilyID kind,
                  bool force, const ArchSpec *arch);
@@ -117,8 +118,13 @@ protected:
 
   FileSpec GetCoreSimulatorPath();
 
+  llvm::StringRef GetSDKFilepath();
+
   llvm::Triple::OSType m_os_type = llvm::Triple::UnknownOS;
   llvm::SmallVector<llvm::StringRef, 4> m_supported_triples = {};
+  std::string m_sdk_name_primary;
+  std::string m_sdk_name_secondary;
+  bool m_have_searched_for_sdk = false;
   llvm::StringRef m_sdk;
   XcodeSDK::Type m_sdk_type;
 


### PR DESCRIPTION
Find SDK path more lazily in Apple Simulator platforms

In https://reviews.llvm.org/D122373 I delayed the search for the SDK filepath until the simulator platform is Created. In the qProcessInfo binary-addresses key, I have to force-Create every platform to find one that can handle a kernel fileset; this forced all of the simulator platforms to create, taking the SDK filepath discovery perf hit.

This patch delays that path search further until the Apple Simulator platform calls a method that actually needs the full filepath; it saves the SDK name ("WatchSimulator.sdk" etc) until it needs to expand it.

Differential Revision: https://reviews.llvm.org/D143932 rdar://103380717

(cherry picked from commit ee88f11770032eac8998664e7102d37f54b9f027)