### PR TITLE
X86: force enable the mandatory tailcall on Win64

### DIFF
--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -819,11 +819,10 @@ public:
     case CC_PreserveAll:
     case CC_X86_64SysV:
     case CC_Swift:
+    case CC_SwiftAsync:
     case CC_X86RegCall:
     case CC_OpenCLKernel:
       return CCCR_OK;
-    case CC_SwiftAsync:
-      return CCCR_Error;
     default:
       return CCCR_Warning;
     }

--- a/llvm/lib/Target/X86/X86FrameLowering.cpp
+++ b/llvm/lib/Target/X86/X86FrameLowering.cpp
@@ -1510,7 +1510,8 @@ void X86FrameLowering::emitPrologue(MachineFunction &MF,
   // Space reserved for stack-based arguments when making a (ABI-guaranteed)
   // tail call.
   unsigned TailCallArgReserveSize = -X86FI->getTCReturnAddrDelta();
-  if (TailCallArgReserveSize  && IsWin64Prologue)
+  if (TailCallArgReserveSize && IsWin64Prologue &&
+      !MF.getFunction().getAttributes().hasAttrSomewhere(Attribute::SwiftAsync))
     report_fatal_error("Can't handle guaranteed tail call under win64 yet");
 
   const bool EmitStackProbeCall =


### PR DESCRIPTION
Enable the guaranteed tailcall on Windows x86_64 when we encounter a Swift function call.  This function will not conform to the Windows prologue requirements which will implicitly break the unwinder and the debugger, but is required to enable the proper Concurrency behaviour for non-trivial programs.  This requires associated changes in the Swift repository to update the test expectations.