### PR TITLE
[llvm-cas] Avoid crash when the provided CASID is not in CAS

### DIFF
--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -199,8 +199,9 @@ int listTree(ObjectStore &CAS, const CASID &ID) {
 int listTreeRecursively(ObjectStore &CAS, const CASID &ID) {
   ExitOnError ExitOnErr("llvm-cas: ls-tree-recursively: ");
   TreeSchema Schema(CAS);
+  ObjectProxy TreeN = ExitOnErr(CAS.getProxy(ID));
   ExitOnErr(Schema.walkFileTreeRecursively(
-      CAS, *CAS.getReference(ID),
+      CAS, TreeN.getRef(),
       [&](const NamedTreeEntry &Entry, Optional<TreeProxy> Tree) -> Error {
         if (Entry.getKind() != TreeEntry::Tree) {
           Entry.print(llvm::outs(), CAS);


### PR DESCRIPTION
Properly error out when the provided CASID is not in the CAS during `ls-tree-recursive` instead of crashing.