### PR TITLE
Remove comments for getP1689ModuleDependencyFile method

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -138,17 +138,6 @@ public:
       DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
       bool DiagGenerationAsCompilation);
 
-  /// Collect the module dependency in P1689 format for C++20 named modules.
-  ///
-  /// \param MakeformatOutput The output parameter for dependency information
-  /// in make format if the command line requires to generate make-format
-  /// dependency information by `-MD -MF <dep_file>`.
-  ///
-  /// \param MakeformatOutputPath The output parameter for the path to
-  /// \param MakeformatOutput.
-  ///
-  /// \returns A \c StringError with the diagnostic output if clang errors
-  /// occurred, P1689 dependency format rules otherwise.
   llvm::Expected<P1689Rule>
   getP1689ModuleDependencyFile(const CompileCommand &Command, StringRef CWD);
 


### PR DESCRIPTION
The comments should've been removed in `f76fe50`.