### PR TITLE
[OnDiskGraphDB] Provide capability to track and report the total storage size of the database

### DIFF
--- a/llvm/include/llvm/CAS/OnDiskGraphDB.h
+++ b/llvm/include/llvm/CAS/OnDiskGraphDB.h
@@ -291,6 +291,12 @@ public:
     return make_range(Refs.begin(), Refs.end());
   }
 
+  /// \returns Total size of stored objects.
+  ///
+  /// NOTE: There's a possibility that the returned size is not including a
+  /// large object if the process crashed right at the point of inserting it.
+  size_t getStorageSize() const;
+
   void print(raw_ostream &OS) const;
 
   /// How to fault-in nodes if an upstream database is used.
@@ -365,6 +371,11 @@ private:
   getIndexProxyFromPointer(OnDiskHashMappedTrie::const_pointer P) const;
 
   InternalRefArrayRef getInternalRefs(ObjectHandle Node) const;
+
+  void recordStandaloneSizeIncrease(size_t SizeIncrease);
+
+  std::atomic<uint64_t> &getStandaloneStorageSize();
+  uint64_t getStandaloneStorageSize() const;
 
   OnDiskGraphDB(StringRef RootPath, OnDiskHashMappedTrie Index,
                 OnDiskDataAllocator DataPool,

--- a/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
+++ b/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
@@ -271,6 +271,8 @@ public:
     return insert(const_pointer(), Value);
   }
 
+  size_t size() const;
+
   /// Gets or creates a file at \p Path with a hash-mapped trie named \p
   /// TrieName. The hash size is \p NumHashBits (in bits) and the records store
   /// data of size \p DataSize (in bytes).
@@ -354,9 +356,17 @@ public:
     return save(ArrayRef<char>(Data.begin(), Data.size()));
   }
 
+  /// \returns the buffer that was allocated at \p create time, with size
+  /// \p UserHeaderSize.
+  MutableArrayRef<uint8_t> getUserHeader();
+
+  size_t size() const;
+
   static Expected<OnDiskDataAllocator>
   create(const Twine &Path, const Twine &TableName, uint64_t MaxFileSize,
-         std::optional<uint64_t> NewFileInitialSize);
+         std::optional<uint64_t> NewFileInitialSize,
+         uint32_t UserHeaderSize = 0,
+         function_ref<void(void *)> UserHeaderInit = nullptr);
 
   OnDiskDataAllocator(OnDiskDataAllocator &&RHS);
   OnDiskDataAllocator &operator=(OnDiskDataAllocator &&RHS);


### PR DESCRIPTION
Part of this is extending `OnDiskDataAllocator` for optionally creating it with a "user header" buffer that a caller is free to use for their own purposes. `OnDiskGraphDB` uses that to keep track of the total size of standalone files.