### PR TITLE
Fix atomic file rename in docker container mounted volumes

### DIFF
--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -479,6 +479,11 @@ static std::error_code rename_internal(HANDLE FromHandle, const Twine &To,
     unsigned Error = GetLastError();
     if (Error == ERROR_SUCCESS)
       Error = ERROR_CALL_NOT_IMPLEMENTED; // Wine doesn't always set error code.
+    else if (Error == ERROR_INVALID_PARAMETER) {
+      // This operation can fail on file systems that do not properly support
+      // the extended POSIX semantics for renames.
+      Error = ERROR_CALL_NOT_IMPLEMENTED;
+    }
     return mapWindowsError(Error);
   }
 


### PR DESCRIPTION
Cherry-picked from `f018fde0b839b717e1740914dba3089cbd1ee24d` on `stable/20220421`.

See https://github.com/apple/llvm-project/pull/6276