### PR TITLE
[stable/20220421] Revert "[lldb] Disable deserialization safety for lldb"

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -944,10 +944,6 @@ SwiftASTContext::SwiftASTContext(std::string description,
   // for the protocol conforming types.
   lang_opts.AllowModuleWithCompilerErrors = true;
   lang_opts.EnableTargetOSChecking = false;
-
-  // Bypass deserialization safety to allow deserializing internal details from
-  // swiftmodule files.
-  lang_opts.EnableDeserializationSafety = false;
 }
 
 SwiftASTContext::~SwiftASTContext() {


### PR DESCRIPTION
Reverts apple/llvm-project#6060