### PR TITLE
[lldb] Remove pydoc import during script interpreter init

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -437,7 +437,7 @@ ScriptInterpreterPythonImpl::ScriptInterpreterPythonImpl(Debugger &debugger)
   // do their task
   run_string.Clear();
   run_string.Printf(
-      "run_one_line (%s, 'import lldb.formatters, lldb.formatters.cpp, pydoc')",
+      "run_one_line (%s, 'import lldb.formatters, lldb.formatters.cpp')",
       m_dictionary_name.c_str());
   PyRun_SimpleString(run_string.GetData());
   run_string.Clear();
@@ -450,7 +450,7 @@ ScriptInterpreterPythonImpl::ScriptInterpreterPythonImpl(Debugger &debugger)
   run_string.Clear();
 
   run_string.Printf("run_one_line (%s, 'lldb.debugger_unique_id = %" PRIu64
-                    "; pydoc.pager = pydoc.plainpager')",
+                    "')",
                     m_dictionary_name.c_str(), m_debugger.GetID());
   PyRun_SimpleString(run_string.GetData());
 }


### PR DESCRIPTION
The Python script interpreter imports `pydoc` during initialization, but this can be
slow in some cases, and doesn't seem to be necessary any more.

This can be slow because pydoc may execute shell commands (for example `xcrun` on
macOS). The shell commands may have variable performance, depending on their caches and
search space.

The 2012 bug report for the original commit (f71a8399997bfdc1ddeeb30c6a8897554a11c382)
says the following:

> "script help" in lldb pipes the help documentation through less(1) but there's some
> problem with the key handling and often the keys you'd use to move in less (space to
> move down a page, 'q' to quit) are not received by less (they're going to lldb
> instead)

This was resolved at the time by overriding `pydoc`'s pager to be the `plainpager`
function.

I have manually tested `script help(lldb.SBDebugger)` and found no issues with the
pager, including using "space" for paging, "/" for searching, and "q" for quitting.

The presumption is that lldb and/or Python have improved I/O handling that eliminates
the original problem.

The original bug report gave an ~/.lldbinit workaround:

```
script import pydoc; pydoc.pager = pydoc.plainpager
```

Note that calling Python's `help()` will import `pydoc`, but this will only happen for
users who use `help()` from the `script` command.

Differential Revision: https://reviews.llvm.org/D144138

(cherry picked from commit f1ddfa6d8a72bcc89e01ab8f73bbe5ae5a0dc475)
