### PR TITLE
[ASAN] Removed special case controlling allocator consts for __aarch64

### DIFF
--- a/compiler-rt/lib/asan/asan_allocator.h
+++ b/compiler-rt/lib/asan/asan_allocator.h
@@ -135,12 +135,6 @@ typedef VeryCompactSizeClassMap SizeClassMap;
 const uptr kAllocatorSpace = ~(uptr)0;
 const uptr kAllocatorSize = 0x2000000000ULL;  // 128G.
 typedef VeryDenseSizeClassMap SizeClassMap;
-# elif defined(__aarch64__)
-// AArch64/SANITIZER_CAN_USE_ALLOCATOR64 is only for 42-bit VMA
-// so no need to different values for different VMA.
-const uptr kAllocatorSpace =  0x10000000000ULL;
-const uptr kAllocatorSize  =  0x10000000000ULL;  // 3T.
-typedef DefaultSizeClassMap SizeClassMap;
 #elif defined(__sparc__)
 const uptr kAllocatorSpace = ~(uptr)0;
 const uptr kAllocatorSize = 0x20000000000ULL;  // 2T.


### PR DESCRIPTION


This patch should land before D137136 to make sure that the leak sanitizer allocator works correctly. This patch is NFC without D137136.

Reviewed By: vitalybuka

Differential Revision: https://reviews.llvm.org/D137265

(cherry picked from commit a8604f2254f6ec9f5e775e04a2da968e3bc998ad)