### PR TITLE
[Sema] Relax a failing assertion in TransformBlockExpr

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -271,6 +271,9 @@ Bug Fixes
   `Issue 59100 <https://github.com/llvm/llvm-project/issues/59100>`_
 - Fix issue using __attribute__((format)) on non-variadic functions that expect
   more than one formatted argument.
+- Fix assert that fails when the expression causing the this pointer to be
+  captured by a block is part of a constexpr if statement's branch and
+  instantiation of the enclosing method causes the branch to be discarded.
 
 Improvements to Clang's diagnostics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -14439,7 +14439,12 @@ TreeTransform<Derived>::TransformBlockExpr(BlockExpr *E) {
                                                  oldCapture));
       assert(blockScope->CaptureMap.count(newCapture));
     }
-    assert(oldBlock->capturesCXXThis() == blockScope->isCXXThisCaptured());
+
+    // The this pointer may not be captured by the instantiated block, even when
+    // it's captured by the original block, if the expression causing the
+    // capture is in the discarded branch of a constexpr if statement.
+    assert((!blockScope->isCXXThisCaptured() || oldBlock->capturesCXXThis()) &&
+           "this pointer isn't captured in the old block");
   }
 #endif
 

--- a/clang/test/CodeGenCXX/cxx1z-constexpr-if.cpp
+++ b/clang/test/CodeGenCXX/cxx1z-constexpr-if.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++1z %s -emit-llvm -o - | FileCheck %s --implicit-check-not=should_not_be_used
+// RUN: %clang_cc1 -std=c++1z %s -emit-llvm -fblocks -triple x86_64-apple-darwin10 -o - | FileCheck %s --implicit-check-not=should_not_be_used
 
 void should_be_used_1();
 void should_be_used_2();
@@ -32,3 +32,20 @@ foo: should_not_be_used();
 // CHECK: should_be_used_1
 // CHECK: should_be_used_2
 // CHECK: should_be_used_3
+
+namespace BlockThisCapture {
+  void foo();
+  struct S {
+    template <bool b>
+    void m() {
+      ^{ if constexpr(b) (void)this; else foo();  }();
+    }
+  };
+
+  void test() {
+    S().m<false>();
+  }
+}
+
+// CHECK-LABEL: define internal void @___ZN16BlockThisCapture1S1mILb0EEEvv_block_invoke(
+// CHECK: call void @_ZN16BlockThisCapture3fooEv(


### PR DESCRIPTION
The assertion fails when the expression causing the this pointer to be captured is part of a constexpr if statement's branch and the branch gets discarded when the enclosing method is instantiated.

Note that the test case is added to CodeGen instead of Sema since the translation unit has to be free of errors in order for the assertion to be checked.

Differential Revision: https://reviews.llvm.org/D144016

(cherry picked from commit cda4a0e918b591be9ae0732f7df07678efb75047)

Conflicts:
	clang/docs/ReleaseNotes.rst