### PR TITLE
[asan][darwin] This test is x86_64 specific, not non-ios in general.

### DIFF
--- a/compiler-rt/test/asan/TestCases/Darwin/asan_gen_prefixes.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/asan_gen_prefixes.cpp
@@ -4,7 +4,8 @@
 // RUN: %clang_asan %s -S -o %t.s
 // RUN: cat %t.s | FileCheck %s || exit 1
 
-// UNSUPPORTED: ios
+// We test x86_64-specific peculiarities of ld on Darwin.
+// REQUIRES: x86_64-target-arch
 
 int x, y, z;
 int main() { return 0; }


### PR DESCRIPTION
This test was unsupported in iOS when a more accurate test is that the architecture is x86_64. This "fix" is first in a series of updates intended to get asan arm64 tests fully functional.

Reviewed By: thetruestblue, vitalybuka

Differential Revision: https://reviews.llvm.org/D138001

(cherry picked from commit b2d9e08c4428c1d1c65487d6fa4d6bdf80c32450)