### PR TITLE
[lldb] StructuredData should not truncate uint64_t values

### DIFF
--- a/lldb/source/Utility/StructuredData.cpp
+++ b/lldb/source/Utility/StructuredData.cpp
@@ -68,6 +68,9 @@ static StructuredData::ObjectSP ParseJSONValue(json::Value &value) {
   if (auto b = value.getAsBoolean())
     return std::make_shared<StructuredData::Boolean>(*b);
 
+  if (auto u = value.getAsUINT64())
+    return std::make_shared<StructuredData::Integer>(*u);
+
   if (auto i = value.getAsInteger())
     return std::make_shared<StructuredData::Integer>(*i);
 


### PR DESCRIPTION
In json::Value, getAsInteger returns an optional<int64_t> and getAsNumber returns an optional<double>. If a value is larger than what an int64_t can hold but smaller than what a uint64_t can hold, the getAsInteger function will fail but the getAsNumber will succeed. However, the value shouldn't be interpreted as a double.

rdar://105556974

Differential Revision: https://reviews.llvm.org/D144238

(cherry picked from commit 2f88c07cf820cff829dec5906d298fc7147af8dd)