### PR TITLE
[lldb] Implement formatting of Swift types in C++ frames via interop

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -139,6 +139,12 @@ class Builder:
                     "LIBCPP_LIBRARY_DIR={}".format(configuration.libcxx_library_dir)]
         return []
 
+    def getLLDBSwiftLibs(self):
+        if configuration.swift_libs_dir:
+            return ["SWIFT_LIBS_DIR={}".format(
+                configuration.swift_libs_dir)]
+        return []
+
     def _getDebugInfoArgs(self, debug_info):
         if debug_info is None:
             return []
@@ -163,7 +169,8 @@ class Builder:
             self.getSwiftTargetFlags(architecture), self.getCCSpec(compiler),
             self.getSwiftCSpec(), self.getExtraMakeArgs(),
             self.getSDKRootSpec(), self.getModuleCacheSpec(),
-            self.getLibCxxArgs(), self.getCmdLine(dictionary)]
+            self.getLibCxxArgs(), self.getLLDBSwiftLibs(), 
+            self.getCmdLine(dictionary)]
         command = list(itertools.chain(*command_parts))
 
         return command

--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -118,6 +118,8 @@ lldb_module_cache_dir = None
 # The clang module cache directory used by clang.
 clang_module_cache_dir = None
 
+swift_libs_dir = None
+
 # Test results handling globals
 test_result = None
 

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -428,6 +428,9 @@ def parseOptionsAndInitTestdirs():
         configuration.clang_module_cache_dir = os.path.join(
             configuration.test_build_dir, 'module-cache-clang')
 
+    if args.swift_libs_dir:
+        configuration.swift_libs_dir = args.swift_libs_dir
+
     if args.lldb_libs_dir:
         configuration.lldb_libs_dir = args.lldb_libs_dir
 

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -165,6 +165,11 @@ def create_parser():
         metavar='The clang module cache directory used by Clang',
         help='The clang module cache directory used in the Make files by Clang while building tests. Defaults to <test build directory>/module-cache-clang.')
     group.add_argument(
+        '--swift-libs-dir',
+        dest='swift_libs_dir',
+        metavar='The lib directory inside the Swift build directory',
+        help='The lib directory inside the Swift build directory.')
+    group.add_argument(
         '--lldb-libs-dir',
         dest='lldb_libs_dir',
         metavar='path',

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -280,6 +280,12 @@ ifndef NO_TEST_COMMON_H
   CFLAGS += -include $(THIS_FILE_DIR)/test_common.h
 endif
 
+# If C++ interop is enabled, the generated header file will try to include 
+# SWIFT_LIBS_DIR/swiftToCxx/_SwiftCxxInteroperability.h
+ifneq "$(SWIFT_CXX_INTEROP)" ""
+  CFLAGS += -I$(SWIFT_LIBS_DIR)
+endif
+
 CFLAGS += $(NO_LIMIT_DEBUG_INFO_FLAGS) $(ARCH_CFLAGS)
 SWIFTFLAGS += $(SWIFTFLAGS_EXTRAS)
 SWIFTFLAGS += $(FRAMEWORK_INCLUDES)
@@ -563,6 +569,11 @@ ifneq "$(strip $(DYLIB_SWIFT_SOURCES))" ""
 	USESWIFTDRIVER = 1
 endif
 
+ifneq "$(strip $(SWIFT_SOURCES_FOR_CXX_HEADER))" ""
+	SWIFT_CXX_HEADER =$(strip $(SWIFT_SOURCES:.swift=.o))
+	USESWIFTDRIVER = 1
+endif
+
 ifeq "$(USESWIFTDRIVER)" "1"
 	LDFLAGS +=-L"$(SWIFTLIBS)"
 	ifeq "$(OS)" "Darwin"
@@ -704,6 +715,14 @@ $(SWIFT_OBJC_HEADER): $(SWIFT_SOURCES) $(DYLIB_SWIFT_SOURCES)
 	$(SWIFT_FE) -typecheck $(VPATHSOURCES) \
 	  $(SWIFT_FEFLAGS) $(SWIFT_HFLAGS) -module-name $(MODULENAME) \
 	  -emit-objc-header-path $(SWIFT_OBJC_HEADER)
+endif
+
+ifneq "$(SWIFT_CXX_HEADER)" ""
+$(SWIFT_CXX_HEADER): $(SWIFT_SOURCES) $(SWIFT_BRIDGING_PCH) 
+	@echo "### Building C++ header from Swift" $<
+	$(SWIFT_FE) -typecheck $(VPATHSOURCES) \
+	  $(SWIFT_FEFLAGS) $(SWIFT_HFLAGS) -module-name $(MODULENAME) \
+	  -clang-header-expose-decls=all-public -emit-clang-header-path  $(SWIFT_CXX_HEADER)
 endif
 
 else # USESWIFTDRIVER = 0
@@ -850,7 +869,7 @@ endif
 %.o: %.c %.d
 	$(CC) $(CFLAGS) -MT $@ -MD -MP -MF $*.d -c -o $@ $<
 
-%.o: %.cpp %.d $(PCH_OUTPUT)
+%.o: %.cpp %.d $(PCH_OUTPUT) $(SWIFT_CXX_HEADER)
 	$(CXX) $(PCHFLAGS) $(CXXFLAGS) -MT $@ -MD -MP -MF $*.d -c -o $@ $<
 
 %.o: %.m %.d

--- a/lldb/source/DataFormatters/FormatManager.cpp
+++ b/lldb/source/DataFormatters/FormatManager.cpp
@@ -573,11 +573,15 @@ FormatManager::GetCandidateLanguages(lldb::LanguageType lang_type) {
   case lldb::eLanguageTypeC89:
   case lldb::eLanguageTypeC99:
   case lldb::eLanguageTypeC11:
+  // BEGIN SWIFT
+    return {lldb::eLanguageTypeC_plus_plus, lldb::eLanguageTypeObjC};
   case lldb::eLanguageTypeC_plus_plus:
   case lldb::eLanguageTypeC_plus_plus_03:
   case lldb::eLanguageTypeC_plus_plus_11:
   case lldb::eLanguageTypeC_plus_plus_14:
-    return {lldb::eLanguageTypeC_plus_plus, lldb::eLanguageTypeObjC};
+    // Swift can format C++ types due to Swift/C++ iterop.
+    return {lldb::eLanguageTypeC_plus_plus, lldb::eLanguageTypeObjC, lldb::eLanguageTypeSwift};
+  // END SWIFT
   default:
     return {lang_type};
   }

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -24,6 +24,7 @@
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/Progress.h"
 #include "lldb/Core/Section.h"
+#include "lldb/Core/ValueObjectCast.h"
 #include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/StringPrinter.h"
 #include "lldb/Host/OptionParser.h"
@@ -375,6 +376,12 @@ public:
 
   lldb::SyntheticChildrenSP
   GetBridgedSyntheticChildProvider(ValueObject &valobj) {
+    STUB_LOG();
+    return {};
+  }
+
+  lldb::SyntheticChildrenSP
+  GetCxxBridgedSyntheticChildProvider(ValueObjectSP valobj) {
     STUB_LOG();
     return {};
   }
@@ -1616,7 +1623,7 @@ public:
     int32_t byte_offset;
 
     FieldProjection(CompilerType parent_type, ExecutionContext *exe_ctx,
-                    size_t idx) {
+                    size_t idx, ValueObject *valobj) {
       const bool transparent_pointers = false;
       const bool omit_empty_base_classes = true;
       const bool ignore_array_bounds = false;
@@ -1633,7 +1640,7 @@ public:
           exe_ctx, idx, transparent_pointers, omit_empty_base_classes,
           ignore_array_bounds, child_name, child_byte_size, byte_offset,
           child_bitfield_bit_size, child_bitfield_bit_offset,
-          child_is_base_class, child_is_deref_of_parent, nullptr,
+          child_is_base_class, child_is_deref_of_parent, valobj,
           language_flags);
 
       if (child_is_base_class)
@@ -1766,7 +1773,7 @@ SwiftLanguageRuntimeImpl::GetBridgedSyntheticChildProvider(
         // if a projection fails, keep going - we have offsets here, so it
         // should be OK to skip some members
         if (auto projection = ProjectionSyntheticChildren::FieldProjection(
-                swift_type, &exe_ctx, idx)) {
+                swift_type, &exe_ctx, idx, &valobj)) {
           any_projected = true;
           type_projection->field_projections.push_back(projection);
         }
@@ -1784,6 +1791,113 @@ SwiftLanguageRuntimeImpl::GetBridgedSyntheticChildProvider(
   }
 
   return nullptr;
+}
+
+lldb::ValueObjectSP SwiftLanguageRuntime::ExtractSwiftValueObjectFromCxxWrapper(
+    ValueObject &valobj) {
+  ValueObjectSP swift_valobj;
+
+  // There are two flavors of c++ wrapper classes:
+  // - Reference types wrappers, which have no ivars, and have one super class
+  // which contains an opaque pointer to the swift instance.
+  // - Value type wrappers, which has one ivar, a single char array with the
+  // swift value embedded directly in it.
+  // In both cases the valobj should have exactly one child.
+  if (valobj.GetNumChildren() != 1)
+    return swift_valobj;
+
+  auto child_valobj = valobj.GetChildAtIndex(0, true);
+  auto child_type = child_valobj->GetCompilerType();
+  // If this is a reference wrapper, the first child is actually the super
+  // class.
+  if (child_type.GetMangledTypeName() == "swift::_impl::RefCountedClass") {
+    // The super class should have exactly one ivar, the opaque pointer that
+    // points to the Swift instance.
+    if (child_valobj->GetNumChildren() != 1)
+      return swift_valobj;
+
+    auto opaque_ptr_valobj = child_valobj->GetChildAtIndex(0, true);
+    swift_valobj = opaque_ptr_valobj;
+  } else {
+    CompilerType element_type;
+    if (child_type.IsArrayType(&element_type)) {
+      if (element_type.IsCharType()) {
+        swift_valobj = valobj.GetSP();
+      }
+    }
+  }
+  return swift_valobj;
+}
+/// Synthetic child for Swift types wrapped in C++ interop wrapper classes.
+class CxxBridgedSyntheticChildren : public SyntheticChildren {
+  class CxxBridgedFrontEndProvider : public SyntheticChildrenFrontEnd {
+  public:
+    CxxBridgedFrontEndProvider(ValueObject &backend)
+        : SyntheticChildrenFrontEnd(backend) {}
+
+    size_t CalculateNumChildren() override {
+      return 1;
+    }
+
+    lldb::ValueObjectSP GetChildAtIndex(size_t idx) override {
+      return idx == 0 ? m_backend.GetSP() : nullptr;
+    }
+
+    size_t GetIndexOfChildWithName(ConstString name) override {
+      return m_backend.GetName() == name ? 0 : UINT32_MAX;
+    }
+
+    bool Update() override { return false; }
+
+    bool MightHaveChildren() override { return true; }
+
+    ConstString GetSyntheticTypeName() override {
+      return m_backend.GetCompilerType().GetTypeName();
+    }
+  };
+
+public:
+  CxxBridgedSyntheticChildren(ValueObjectSP valobj, const Flags &flags) 
+      : SyntheticChildren(flags), m_valobj(valobj) {}
+
+  SyntheticChildrenFrontEnd::AutoPointer
+  GetFrontEnd(ValueObject &backend) override {
+    if (!m_valobj)
+      return nullptr;
+    // We ignore the backend parameter here, as we have a more specific one
+    // available.
+    return std::make_unique<CxxBridgedFrontEndProvider>(*m_valobj); 
+  }
+
+  bool IsScripted() override { return false; }
+
+  std::string GetDescription() override {
+    return "C++ bridged synthetic children";
+  }
+
+private:
+  ValueObjectSP m_valobj;
+};
+
+lldb::SyntheticChildrenSP
+SwiftLanguageRuntimeImpl::GetCxxBridgedSyntheticChildProvider(
+    ValueObjectSP valobj) {
+  auto swift_type = valobj->GetCompilerType();
+  if (!swift_type)
+    return nullptr;
+  ConstString type_name = swift_type.GetDisplayTypeName();
+
+  if (!type_name.IsEmpty()) {
+    auto iter = m_bridged_synthetics_map.find(type_name.AsCString()),
+         end = m_bridged_synthetics_map.end();
+    if (iter != end)
+      return iter->second;
+  }
+
+  SyntheticChildrenSP synth_sp = SyntheticChildrenSP(
+      new CxxBridgedSyntheticChildren(valobj, SyntheticChildren::Flags()));
+  m_bridged_synthetics_map.insert({type_name.AsCString(), synth_sp});
+  return synth_sp;
 }
 
 void SwiftLanguageRuntimeImpl::WillStartExecutingUserExpression(
@@ -2405,6 +2519,12 @@ bool SwiftLanguageRuntime::IsValidErrorValue(ValueObject &in_value) {
 lldb::SyntheticChildrenSP
 SwiftLanguageRuntime::GetBridgedSyntheticChildProvider(ValueObject &valobj) {
   FORWARD(GetBridgedSyntheticChildProvider, valobj);
+}
+
+lldb::SyntheticChildrenSP
+SwiftLanguageRuntime::GetCxxBridgedSyntheticChildProvider(
+    ValueObjectSP valobj) {
+  FORWARD(GetCxxBridgedSyntheticChildProvider, valobj);
 }
 
 void SwiftLanguageRuntime::WillStartExecutingUserExpression(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -218,6 +218,12 @@ public:
                                 TypeAndOrName &class_type_or_name,
                                 Address &address,
                                 Value::ValueType &value_type) override;
+
+  /// Extract the value object which contains the Swift type's "contents".
+  /// Returns null if this is not a C++ wrapping a Swift type. 
+  static lldb::ValueObjectSP
+  ExtractSwiftValueObjectFromCxxWrapper(ValueObject &valobj);
+
   TypeAndOrName FixUpDynamicType(const TypeAndOrName &type_and_or_name,
                                  ValueObject &static_value) override;
   lldb::BreakpointResolverSP CreateExceptionResolver(const lldb::BreakpointSP &bkpt,
@@ -402,6 +408,10 @@ public:
 
   lldb::SyntheticChildrenSP
   GetBridgedSyntheticChildProvider(ValueObject &valobj);
+
+  /// Get the synthethic child provider that displays Swift in C++ frames.
+  lldb::SyntheticChildrenSP
+  GetCxxBridgedSyntheticChildProvider(lldb::ValueObjectSP valobj);
 
   /// Expression Callbacks.
   /// \{

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -179,6 +179,10 @@ public:
   lldb::SyntheticChildrenSP
   GetBridgedSyntheticChildProvider(ValueObject &valobj);
 
+  /// Get the synthethic child provider that displays Swift in C++ frames.
+  lldb::SyntheticChildrenSP
+  GetCxxBridgedSyntheticChildProvider(lldb::ValueObjectSP valobj);
+
   bool IsABIStable();
 
   void DumpTyperef(CompilerType type, TypeSystemSwiftTypeRef *module_holder,

--- a/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/Makefile
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/Makefile
@@ -1,0 +1,7 @@
+SWIFT_CXX_HEADER := swift-types.h
+SWIFT_SOURCES := swift-types.swift
+CXX_SOURCES := main.cpp
+SWIFT_CXX_INTEROP := 1
+SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR) -parse-as-library
+CFLAGS = -I. -g
+include Makefile.rules

--- a/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/TestSwiftFormatSwiftTypesInCxx.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/TestSwiftFormatSwiftTypesInCxx.py
@@ -1,0 +1,36 @@
+
+"""
+Test that Swift types are displayed correctly in C++
+"""
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class TestSwiftFormatSwiftTypesInCxx(TestBase):
+
+    @swiftTest
+    def test_class(self):
+        self.build()
+        self.runCmd('setting set target.experimental.swift-enable-cxx-interop true')
+        _, _, _, _= lldbutil.run_to_source_breakpoint(
+            self, 'Set breakpoint here', lldb.SBFileSpec('main.cpp'))
+
+        self.expect('v swiftClass', substrs=['SwiftClass', 'field = 42', 
+            'arr = 4 values', '[0] = "An"', '[1] = "array"', '[2] = "of"', 
+            '[3] = "strings"'])
+        self.expect('p swiftClass', substrs=['SwiftClass', 'field = 42', 
+            'arr = 4 values', '[0] = "An"', '[1] = "array"', '[2] = "of"', 
+            '[3] = "strings"'])
+        
+        self.expect('v swiftSublass', substrs=['SwiftSubclass', 'field = 42', 
+            'arr = 4 values', '[0] = "An"', '[1] = "array"', '[2] = "of"', 
+            '[3] = "strings"', 'extraField = "this is an extra subclass field"'])
+        self.expect('p swiftSublass', substrs=['SwiftSubclass', 'field = 42', 
+            'arr = 4 values', '[0] = "An"', '[1] = "array"', '[2] = "of"', 
+            '[3] = "strings"', 'extraField = "this is an extra subclass field"'])
+
+        self.expect('v swiftStruct', substrs=['SwiftStruct', 'str = "Hello this is a big string"', 
+            'boolean = true'])
+        self.expect('p swiftStruct', substrs=['SwiftStruct', 'str = "Hello this is a big string"', 
+            'boolean = true'])
+

--- a/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/main.cpp
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/main.cpp
@@ -1,0 +1,9 @@
+#include "swift-types.h"
+
+int main() {
+  using namespace a;
+  auto swiftClass = returnSwiftClass();
+  auto swiftSublass = returnSwiftSubclassAsClass();
+  auto swiftStruct = returnSwiftStruct();
+  return 0; // Set breakpoint here.
+}

--- a/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/swift-types.swift
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/swift-types.swift
@@ -1,0 +1,26 @@
+
+public class SwiftClass {
+  var field = 42
+  var arr = ["An", "array", "of", "strings"]
+}
+
+public class SwiftSubclass: SwiftClass {
+  var extraField = "this is an extra subclass field"
+}
+
+public struct SwiftStruct {
+  var str = "Hello this is a big string"
+  var boolean = true
+}
+
+public func returnSwiftClass() -> SwiftClass {
+  return SwiftClass()
+}
+
+public func returnSwiftSubclassAsClass() -> SwiftClass {
+  return SwiftSubclass()
+}
+
+public func returnSwiftStruct() -> SwiftStruct {
+  return SwiftStruct()
+}

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -205,6 +205,9 @@ if is_configured('clang_module_cache'):
   delete_module_cache(config.clang_module_cache)
   dotest_cmd += ['--clang-module-cache-dir', config.clang_module_cache]
 
+if is_configured('swift_libs_dir'):
+  dotest_cmd += ['--swift-libs-dir', config.swift_libs_dir]
+
 if is_configured('lldb_executable'):
   dotest_cmd += ['--executable', config.lldb_executable]
 

--- a/lldb/test/API/lit.site.cfg.py.in
+++ b/lldb/test/API/lit.site.cfg.py.in
@@ -36,6 +36,7 @@ config.has_libcxx = @LLDB_HAS_LIBCXX@
 # The API tests use their own module caches.
 config.lldb_module_cache = os.path.join("@LLDB_TEST_MODULE_CACHE_LLDB@", "lldb-api")
 config.clang_module_cache = os.path.join("@LLDB_TEST_MODULE_CACHE_CLANG@", "lldb-api")
+config.swift_libs_dir = '@LLDB_SWIFT_LIBS@' 
 
 # Plugins
 lldb_build_intel_pt = '@LLDB_BUILD_INTEL_PT@'

--- a/lldb/unittests/DataFormatter/FormatManagerTests.cpp
+++ b/lldb/unittests/DataFormatter/FormatManagerTests.cpp
@@ -21,6 +21,9 @@ TEST(FormatManagerTests, CompatibleLangs) {
   EXPECT_EQ(FormatManager::GetCandidateLanguages(eLanguageTypeC99), candidates);
   EXPECT_EQ(FormatManager::GetCandidateLanguages(eLanguageTypeC11), candidates);
 
+  // BEGIN SWIFT
+  candidates = {eLanguageTypeC_plus_plus, eLanguageTypeObjC,
+                eLanguageTypeSwift};
   EXPECT_EQ(FormatManager::GetCandidateLanguages(eLanguageTypeC_plus_plus),
             candidates);
   EXPECT_EQ(FormatManager::GetCandidateLanguages(eLanguageTypeC_plus_plus_03),
@@ -33,4 +36,5 @@ TEST(FormatManagerTests, CompatibleLangs) {
   candidates = {eLanguageTypeObjC, eLanguageTypeSwift};
   EXPECT_EQ(FormatManager::GetCandidateLanguages(eLanguageTypeObjC),
             candidates);
+  // END SWIFT
 }

--- a/lldb/utils/lldb-dotest/lldb-dotest.in
+++ b/lldb/utils/lldb-dotest/lldb-dotest.in
@@ -14,6 +14,7 @@ lldb_build_intel_pt = "@LLDB_BUILD_INTEL_PT@"
 lldb_framework_dir = "@LLDB_FRAMEWORK_DIR_CONFIGURED@"
 lldb_libs_dir = "@LLDB_LIBS_DIR_CONFIGURED@"
 llvm_tools_dir = "@LLVM_TOOLS_DIR_CONFIGURED@"
+swift_libs_dir = '@LLDB_SWIFT_LIBS@' 
 
 if __name__ == '__main__':
     wrapper_args = sys.argv[1:]


### PR DESCRIPTION
Swift types imported in C++ are wrapped by compiler generated types.
This patch adds functionality to recognize those types, and present the
underlying Swift types via synthetic child providers.

rdar://100285269