### PR TITLE
[CAS] Adopt `UnifiedOnDiskCache` for the on-disk CAS for clang

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -12,7 +12,7 @@ def err_builtin_cas_cannot_be_initialized : Error<
   "CAS cannot be initialized from '%0' on disk (check -fcas-path)">,
   DefaultFatal;
 def err_builtin_actioncache_cannot_be_initialized : Error<
-  "ActionCache cannot be initialized from '%0' on disk (check -faction-cache-path)">,
+  "ActionCache cannot be initialized from '%0' on disk (check -fcas-path)">,
   DefaultFatal;
 def err_cas_cannot_parse_root_id : Error<
   "CAS cannot parse root-id '%0' specified by -fcas-fs">, DefaultFatal;

--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -9,7 +9,7 @@
 let Component = "CAS" in {
 
 def err_builtin_cas_cannot_be_initialized : Error<
-  "CAS cannot be initialized from '%0' on disk (check -fcas-path)">,
+  "CAS cannot be initialized from '%0' on disk (check -fcas-path): %1">,
   DefaultFatal;
 def err_builtin_actioncache_cannot_be_initialized : Error<
   "ActionCache cannot be initialized from '%0' on disk (check -fcas-path)">,

--- a/clang/include/clang/CAS/CASOptions.h
+++ b/clang/include/clang/CAS/CASOptions.h
@@ -14,12 +14,10 @@
 #ifndef LLVM_CLANG_CAS_CASOPTIONS_H
 #define LLVM_CLANG_CAS_CASOPTIONS_H
 
-#include <memory>
+#include "llvm/ADT/SmallVector.h"
 #include <string>
-#include <vector>
 
 namespace llvm {
-class Error;
 namespace cas {
 class ActionCache;
 class ObjectStore;
@@ -29,6 +27,9 @@ class ObjectStore;
 namespace clang {
 
 class DiagnosticsEngine;
+
+/// Set \p Path to a reasonable default on-disk cache path for the current user.
+void getClangDefaultCachePath(llvm::SmallVectorImpl<char> &Path);
 
 /// Base class for options configuring which CAS to use. Separated for the
 /// fields where we don't need special move/copy logic.
@@ -74,8 +75,8 @@ private:
 /// Options configuring which CAS to use. User-accessible fields should be
 /// defined in CASConfiguration to enable caching a CAS instance.
 ///
-/// CASOptions includes \a getOrCreateObjectStore() and \a
-/// getOrCreateActionCache() for creating CAS and ActionCache.
+/// CASOptions includes \a getOrCreateDatabases() for creating CAS and
+/// ActionCache.
 ///
 /// FIXME: The the caching is done here, instead of as a field in \a
 /// CompilerInstance, in order to ensure that \a
@@ -84,32 +85,23 @@ private:
 /// it would be better to update all callers and remove it from here.
 class CASOptions : public CASConfiguration {
 public:
-  /// Get a CAS defined by the options above. Future calls will return the same
-  /// CAS instance... unless the configuration has changed, in which case a new
-  /// one will be created.
+  /// Get a CAS & ActionCache defined by the options above. Future calls will
+  /// return the same instances... unless the configuration has changed, in
+  /// which case new ones will be created.
   ///
-  /// If \p CreateEmptyCASOnFailure, returns an empty in-memory CAS on failure.
-  /// Else, returns \c nullptr on failure.
-  std::shared_ptr<llvm::cas::ObjectStore>
-  getOrCreateObjectStore(DiagnosticsEngine &Diags,
-                         bool CreateEmptyCASOnFailure = false) const;
-
-  /// Get a ActionCache defined by the options above. Future calls will return
-  /// the same ActionCache instance... unless the configuration has changed, in
-  /// which case a new one will be created.
-  ///
-  /// If \p CreateEmptyCacheOnFailure, returns an empty in-memory ActionCache on
+  /// If \p CreateEmptyDBsOnFailure, returns empty in-memory databases on
   /// failure. Else, returns \c nullptr on failure.
-  std::shared_ptr<llvm::cas::ActionCache>
-  getOrCreateActionCache(DiagnosticsEngine &Diags,
-                         bool CreateEmptyCacheOnFailures = false) const;
+  std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
+            std::shared_ptr<llvm::cas::ActionCache>>
+  getOrCreateDatabases(DiagnosticsEngine &Diags,
+                       bool CreateEmptyDBsOnFailure = false) const;
 
   /// Freeze CAS Configuration. Future calls will return the same
   /// CAS instance, even if the configuration changes again later.
   ///
   /// The configuration will be wiped out to prevent it being observable or
   /// affecting the output of something that takes \a CASOptions as an input.
-  /// This also "locks in" the return value of \a getOrCreateObjectStore():
+  /// This also "locks in" the return value of \a getOrCreateDatabases():
   /// future calls will not check if the configuration has changed.
   void freezeConfig(DiagnosticsEngine &Diags);
 

--- a/clang/include/clang/CAS/CASOptions.h
+++ b/clang/include/clang/CAS/CASOptions.h
@@ -54,11 +54,10 @@ public:
   /// - "auto" is an alias for an automatically chosen location in the user's
   ///   system cache.
   std::string CASPath;
-  std::string CachePath;
 
   friend bool operator==(const CASConfiguration &LHS,
                          const CASConfiguration &RHS) {
-    return LHS.CASPath == RHS.CASPath && LHS.CachePath == RHS.CachePath;
+    return LHS.CASPath == RHS.CASPath;
   }
   friend bool operator!=(const CASConfiguration &LHS,
                          const CASConfiguration &RHS) {

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6704,12 +6704,6 @@ def fcas_path : Separate<["-"], "fcas-path">,
              " '-fcas-path=auto' chooses a path in the user's system cache.">,
     MarshallingInfoString<CASOpts<"CASPath">>;
 
-def faction_cache_path : Separate<["-"], "faction-cache-path">,
-    Group<f_Group>, MetaVarName<"<dir>|auto">,
-    HelpText<"Path to a persistent on-disk backing store for the builtin Cache."
-             " '-faction-cache-path=auto' chooses a path in the user's system cache.">,
-    MarshallingInfoString<CASOpts<"CachePath">>;
-
 // FIXME: Add to driver once it's supported by -fdepscan.
 def fcas_fs : Separate<["-"], "fcas-fs">,
     Group<f_Group>, MetaVarName<"<tree>">,

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -187,6 +187,8 @@ class CompilerInstance : public ModuleLoader {
   /// Force an output buffer.
   std::unique_ptr<llvm::raw_pwrite_stream> OutputStream;
 
+  void createCASDatabases();
+
   CompilerInstance(const CompilerInstance &) = delete;
   void operator=(const CompilerInstance &) = delete;
 public:

--- a/clang/lib/CAS/CASOptions.cpp
+++ b/clang/lib/CAS/CASOptions.cpp
@@ -10,6 +10,7 @@
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/DiagnosticCAS.h"
 #include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/Support/Path.h"
 

--- a/clang/lib/CAS/CASOptions.cpp
+++ b/clang/lib/CAS/CASOptions.cpp
@@ -11,44 +11,31 @@
 #include "clang/Basic/DiagnosticCAS.h"
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/ObjectStore.h"
-#include "llvm/Support/Error.h"
+#include "llvm/Support/Path.h"
 
 using namespace clang;
 using namespace llvm::cas;
 
-static std::shared_ptr<llvm::cas::ObjectStore>
-createObjectStoreWithoutPath(const CASConfiguration &Config,
-                             DiagnosticsEngine &Diags) {
-  if (Config.CASPath.empty())
-    return llvm::cas::createInMemoryCAS();
-
-  assert(Config.CASPath == "auto");
-  // Compute the path.
-  SmallString<128> Storage;
-  llvm::cas::getDefaultOnDiskCASPath(Storage);
-  StringRef Path = Storage;
-
-  // FIXME: Pass on the actual error from the CAS.
-  if (auto MaybeCAS =
-          llvm::expectedToOptional(llvm::cas::createOnDiskCAS(Path)))
-    return std::move(*MaybeCAS);
-  Diags.Report(diag::err_builtin_cas_cannot_be_initialized) << Path;
-  return nullptr;
+void clang::getClangDefaultCachePath(SmallVectorImpl<char> &Path) {
+  // FIXME: Should this return 'Error' instead of hard-failing?
+  if (!llvm::sys::path::cache_directory(Path))
+    llvm::report_fatal_error("cannot get default cache directory");
+  llvm::sys::path::append(Path, "clang-cache");
 }
 
-std::shared_ptr<llvm::cas::ObjectStore>
-CASOptions::getOrCreateObjectStore(DiagnosticsEngine &Diags,
-                                   bool CreateEmptyCASOnFailure) const {
+std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
+          std::shared_ptr<llvm::cas::ActionCache>>
+CASOptions::getOrCreateDatabases(DiagnosticsEngine &Diags,
+                                 bool CreateEmptyDBsOnFailure) const {
   if (Cache.Config.IsFrozen)
-    return Cache.CAS;
+    return {Cache.CAS, Cache.AC};
 
   initCache(Diags);
-  if (Cache.CAS)
-    return Cache.CAS;
-  if (!CreateEmptyCASOnFailure)
-    return nullptr;
-  Cache.CAS = llvm::cas::createInMemoryCAS();
-  return Cache.CAS;
+  if (!Cache.CAS && CreateEmptyDBsOnFailure)
+    Cache.CAS = llvm::cas::createInMemoryCAS();
+  if (!Cache.AC && CreateEmptyDBsOnFailure)
+    Cache.AC = llvm::cas::createInMemoryActionCache();
+  return {Cache.CAS, Cache.AC};
 }
 
 void CASOptions::freezeConfig(DiagnosticsEngine &Diags) {
@@ -74,45 +61,11 @@ void CASOptions::freezeConfig(DiagnosticsEngine &Diags) {
   }
 }
 
-static std::shared_ptr<llvm::cas::ActionCache>
-createCacheWithoutPath(const CASConfiguration &Config,
-                       DiagnosticsEngine &Diags) {
-  if (Config.CASPath.empty())
-    return llvm::cas::createInMemoryActionCache();
-
-  assert(Config.CASPath == "auto");
-  // Compute the path.
-  std::string Path = getDefaultOnDiskActionCachePath();
-
-  // FIXME: Pass on the actual error from the CAS.
-  if (auto MaybeCache =
-          llvm::expectedToOptional(llvm::cas::createOnDiskActionCache(Path)))
-    return std::move(*MaybeCache);
-  Diags.Report(diag::err_builtin_actioncache_cannot_be_initialized) << Path;
-  return nullptr;
-}
-
-std::shared_ptr<llvm::cas::ActionCache>
-CASOptions::getOrCreateActionCache(DiagnosticsEngine &Diags,
-                                   bool CreateEmptyOnFailure) const {
-  if (Cache.Config.IsFrozen)
-    return Cache.AC;
-
-  initCache(Diags);
-  if (Cache.AC)
-    return Cache.AC;
-  if (!CreateEmptyOnFailure)
-    return nullptr;
-
-  Cache.CAS = Cache.CAS ? Cache.CAS : llvm::cas::createInMemoryCAS();
-  return llvm::cas::createInMemoryActionCache();
-}
-
 void CASOptions::ensurePersistentCAS() {
   assert(!IsFrozen && "Expected to check for a persistent CAS before freezing");
   switch (getKind()) {
   case UnknownCAS:
-      llvm_unreachable("Cannot ensure persistent CAS if it's unknown / frozen");
+    llvm_unreachable("Cannot ensure persistent CAS if it's unknown / frozen");
   case InMemoryCAS:
     CASPath = "auto";
     break;
@@ -128,16 +81,22 @@ void CASOptions::initCache(DiagnosticsEngine &Diags) const {
 
   Cache.Config = CurrentConfig;
   StringRef CASPath = Cache.Config.CASPath;
-  if (!CASPath.empty() && CASPath != "auto") {
-    std::pair<std::unique_ptr<ObjectStore>, std::unique_ptr<ActionCache>> DBs;
-    if (llvm::Error E =
-            createOnDiskUnifiedCASDatabases(CASPath).moveInto(DBs)) {
-      Diags.Report(diag::err_builtin_cas_cannot_be_initialized) << CASPath;
-      return;
-    }
-    std::tie(Cache.CAS, Cache.AC) = std::move(DBs);
-  } else {
-    Cache.CAS = createObjectStoreWithoutPath(Cache.Config, Diags);
-    Cache.AC = createCacheWithoutPath(Cache.Config, Diags);
+  if (CASPath.empty()) {
+    Cache.CAS = llvm::cas::createInMemoryCAS();
+    Cache.AC = llvm::cas::createInMemoryActionCache();
+    return;
   }
+
+  SmallString<256> PathBuf;
+  if (CASPath == "auto") {
+    getClangDefaultCachePath(PathBuf);
+    CASPath = PathBuf;
+  }
+  std::pair<std::unique_ptr<ObjectStore>, std::unique_ptr<ActionCache>> DBs;
+  if (llvm::Error E = createOnDiskUnifiedCASDatabases(CASPath).moveInto(DBs)) {
+    Diags.Report(diag::err_builtin_cas_cannot_be_initialized)
+        << CASPath << toString(std::move(E));
+    return;
+  }
+  std::tie(Cache.CAS, Cache.AC) = std::move(DBs);
 }

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -460,7 +460,7 @@ static bool initTargetOptions(DiagnosticsEngine &Diags,
   }
 
   // CASOpts.
-  Options.MCOptions.CAS = CASOpts.getOrCreateObjectStore(Diags);
+  Options.MCOptions.CAS = CASOpts.getOrCreateDatabases(Diags).first;
   Options.MCOptions.ResultCallBack = CodeGenOpts.MCCallBack;
   Options.MCOptions.CASObjMode = CodeGenOpts.getCASObjMode();
 

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -890,25 +890,24 @@ llvm::vfs::OutputBackend &CompilerInstance::getOrCreateOutputBackend() {
   return getOutputBackend();
 }
 
-llvm::cas::ObjectStore &CompilerInstance::getOrCreateObjectStore() {
-  if (CAS)
-    return *CAS;
-
-  // Create a new CAS instance from the CompilerInvocation. Future calls to
+void CompilerInstance::createCASDatabases() {
+  // Create a new CAS databases from the CompilerInvocation. Future calls to
   // createFileManager() will use the same CAS.
-  CAS = getInvocation().getCASOpts().getOrCreateObjectStore(
-      getDiagnostics(),
-      /*CreateEmptyCASOnFailure=*/true);
+  std::tie(CAS, ActionCache) =
+      getInvocation().getCASOpts().getOrCreateDatabases(
+          getDiagnostics(),
+          /*CreateEmptyCASOnFailure=*/true);
+}
+
+llvm::cas::ObjectStore &CompilerInstance::getOrCreateObjectStore() {
+  if (!CAS)
+    createCASDatabases();
   return *CAS;
 }
 
 llvm::cas::ActionCache &CompilerInstance::getOrCreateActionCache() {
-  if (ActionCache)
-    return *ActionCache;
-
-  ActionCache = getInvocation().getCASOpts().getOrCreateActionCache(
-      getDiagnostics(),
-      /*CreateEmptyActionCacheOnFailure=*/true);
+  if (!ActionCache)
+    createCASDatabases();
   return *ActionCache;
 }
 

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1352,7 +1352,7 @@ createBaseFS(const FileSystemOptions &FSOpts, const FrontendOptions &FEOpts,
   // If no CAS was provided, create one with CASOptions.
   std::shared_ptr<llvm::cas::ObjectStore> CAS = std::move(OverrideCAS);
   if (!CAS)
-    CAS = CASOpts.getOrCreateObjectStore(Diags);
+    CAS = CASOpts.getOrCreateDatabases(Diags).first;
 
   // Helper for creating a valid (but empty) CASFS if an error is encountered.
   auto makeEmptyCASFS = [&CAS]() {
@@ -2831,7 +2831,7 @@ determineInputFromIncludeTree(StringRef IncludeTreeID, CASOptions &CASOpts,
     Diags.Report(diag::err_fe_unable_to_load_include_tree)
         << IncludeTreeID << llvm::toString(std::move(E));
   };
-  auto CAS = CASOpts.getOrCreateObjectStore(Diags);
+  auto CAS = CASOpts.getOrCreateDatabases(Diags).first;
   if (!CAS)
     return;
   auto ID = CAS->parseID(IncludeTreeID);

--- a/clang/test/CAS/cached-diagnostics.c
+++ b/clang/test/CAS/cached-diagnostics.c
@@ -5,7 +5,7 @@
 // RUN: %clang_cc1 -triple x86_64-apple-macos12 -fsyntax-only %t/src/main.c -I %t/src/inc -Wunknown-pragmas 2> %t/regular-diags1.txt
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -fdepscan-prefix-map=%t/src=/^src -o %t/t1.rsp -cc1-args \
-// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -faction-cache-path %t/cache \
+// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas \
 // RUN:     -emit-obj %t/src/main.c -o %t/out/output.o -I %t/src/inc -Wunknown-pragmas
 
 // Compare diagnostics after a miss.
@@ -13,7 +13,7 @@
 // RUN: diff -u %t/regular-diags1.txt %t/diags1.txt
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/t1.noprefix.rsp -cc1-args \
-// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -faction-cache-path %t/cache \
+// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas \
 // RUN:     -emit-obj %t/src/main.c -o %t/out/output.o -I %t/src/inc -Wunknown-pragmas
 
 // Compare diagnostics without prefix mappings.
@@ -42,7 +42,7 @@
 // RUN: %clang_cc1 -triple x86_64-apple-macos12 -fsyntax-only %t/src2/main.c -I %t/src2/inc -Wunknown-pragmas 2> %t/regular-diags2.txt
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -fdepscan-prefix-map=%t/src2=/^src -o %t/t2.rsp -cc1-args \
-// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -faction-cache-path %t/cache \
+// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas \
 // RUN:     -emit-obj %t/src2/main.c -o %t/out2/output.o -I %t/src2/inc -Wunknown-pragmas
 // RUN: %clang @%t/t2.rsp -Rcompile-job-cache 2> %t/diags-hit2.txt
 

--- a/clang/test/CAS/cas-backend.c
+++ b/clang/test/CAS/cas-backend.c
@@ -2,7 +2,7 @@
 // RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
 //
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 -fcas-backend \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Rcompile-job-cache -emit-obj -o %t/output.o \
 // RUN:   -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb \
 // RUN:   -dependency-file %t/deps.d -MT %t/output.o 2>&1 \
@@ -13,7 +13,7 @@
 //
 // RUN: CLANG_CAS_BACKEND_SAVE_CASID_FILE=1 %clang -cc1 \
 // RUN:   -triple x86_64-apple-macos11 -fcas-backend \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Rcompile-job-cache -emit-obj -o %t/output.o \
 // RUN:   -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb \
 // RUN:   -dependency-file %t/deps.d -MT %t/output.o 2>&1 \

--- a/clang/test/CAS/daemon-cwd.c
+++ b/clang/test/CAS/daemon-cwd.c
@@ -11,13 +11,13 @@
 // RUN:    -fdepscan-prefix-map=%t=/^build                                \
 // RUN:    -fdepscan-prefix-map-toolchain=/^toolchain                     \
 // RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t               \
-// RUN:    -Xclang -fcas-path -Xclang %t/cas -Xclang -faction-cache-path -Xclang %t/cache \
+// RUN:    -Xclang -fcas-path -Xclang %t/cas                              \
 // RUN:    -MD -MF %t/test.d -Iinclude                                    \
 // RUN:    -fsyntax-only -x c %s >> %t/cmd.sh
 // RUN: chmod +x %t/cmd.sh
 
 // RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t      \
-// RUN:   -cas-args -fcas-path %t/cas -faction-cache-path %t/cache -- %t/cmd.sh
+// RUN:   -cas-args -fcas-path %t/cas -- %t/cmd.sh
 // RUN: (cd %t && %clang -target x86_64-apple-macos11 -MD -MF %t/test2.d  \
 // RUN:    -Iinclude -fsyntax-only -x c %s)
 // RUN: diff %t/test.d %t/test2.d

--- a/clang/test/CAS/depscan-dependency-file.c
+++ b/clang/test/CAS/depscan-dependency-file.c
@@ -2,14 +2,14 @@
 // RUN: split-file %s %t
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/t.rsp -cc1-args \
-// RUN:   -cc1 -fcas-path %t/cas -faction-cache-path %t/cache -triple x86_64-apple-macos11 %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
+// RUN:   -cc1 -fcas-path %t/cas -triple x86_64-apple-macos11 %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
 // RUN:     -MT deps -dependency-file %t/t.d
 // RUN: FileCheck %s -input-file=%t/t.d -check-prefix=NOSYS
 // RUN: FileCheck %s -input-file=%t/t.d -check-prefix=COMMON
 
 // Including system headers.
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/t.rsp -cc1-args \
-// RUN:   -cc1 -fcas-path %t/cas -faction-cache-path %t/cache -triple x86_64-apple-macos11 %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
+// RUN:   -cc1 -fcas-path %t/cas -triple x86_64-apple-macos11 %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
 // RUN:     -MT deps -sys-header-deps -dependency-file %t/t-sys.d
 // RUN: FileCheck %s -input-file=%t/t-sys.d -check-prefix=WITHSYS -check-prefix=COMMON
 

--- a/clang/test/CAS/depscan-include-tree-daemon.c
+++ b/clang/test/CAS/depscan-include-tree-daemon.c
@@ -3,9 +3,9 @@
 // RUN: split-file %s %t
 
 // RUN: %clang -cc1depscan -o %t/inline.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args -cc1 -triple x86_64-apple-macos11.0 \
-// RUN:     -fsyntax-only %t/t.c -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -faction-cache-path %t/cache -DSOME_MACRO -dependency-file %t/inline.d -MT deps
+// RUN:     -fsyntax-only %t/t.c -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -DSOME_MACRO -dependency-file %t/inline.d -MT deps
 
-// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fdepscan-include-tree -fcas-path %t/cas -faction-cache-path %t/cache -- \
+// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fdepscan-include-tree -fcas-path %t/cas -- \
 // RUN:   %clang -cc1depscan -o %t/daemon.rsp -fdepscan=daemon -fdepscan-daemon=%{clang-daemon-dir}/%basename_t -fdepscan-include-tree \
 // RUN:     -cc1-args -cc1 -triple x86_64-apple-macos11.0 \
 // RUN:     -fsyntax-only %t/t.c -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -DSOME_MACRO -dependency-file %t/daemon.d -MT deps

--- a/clang/test/CAS/depscan-prefix-map.c
+++ b/clang/test/CAS/depscan-prefix-map.c
@@ -15,7 +15,7 @@
 // RUN:              -resource-dir %S/Inputs/toolchain_dir/usr/lib/clang/1000 \
 // RUN:              -internal-isystem %S/Inputs/toolchain_dir/usr/lib/clang/1000/include \
 // RUN:              -working-directory %t.d                              \
-// RUN:              -fcas-path %t.d/cas -faction-cache-path %t.d/cache   \
+// RUN:              -fcas-path %t.d/cas                                  \
 // RUN: | FileCheck %s -DPREFIX=%t.d
 // RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=inline    \
 // RUN:    -fdepscan-prefix-map=%S=/^source                               \
@@ -28,10 +28,10 @@
 // RUN:              -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 \
 // RUN:              -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:              -working-directory %t.d                              \
-// RUN:              -fcas-path %t.d/cas -faction-cache-path %t.d/cache   \
+// RUN:              -fcas-path %t.d/cas                                  \
 // RUN: | FileCheck %s -DPREFIX=%t.d
 // RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t      \
-// RUN:   -cas-args -fcas-path %t.d/cas -faction-cache-path %t.d/cache -- \
+// RUN:   -cas-args -fcas-path %t.d/cas --                                \
 // RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon    \
 // RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t               \
 // RUN:    -fdepscan-prefix-map=%S=/^source                               \
@@ -44,7 +44,7 @@
 // RUN:              -resource-dir %S/Inputs/toolchain_dir/usr/lib/clang/1000 \
 // RUN:              -internal-isystem %S/Inputs/toolchain_dir/usr/lib/clang/1000/include \
 // RUN:              -working-directory %t.d                              \
-// RUN:              -fcas-path %t.d/cas -faction-cache-path %t.d/cache   \
+// RUN:              -fcas-path %t.d/cas                                  \
 // RUN: | FileCheck %s -DPREFIX=%t.d
 //
 // CHECK:      "-fcas-path" "[[PREFIX]]/cas"
@@ -65,32 +65,32 @@
 // CHECK-ROOT-NEXT: file {{.*}} /^toolchain/usr/lib/clang/1000/include/stdarg.h{{$}}
 
 // RUN: not %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t      \
-// RUN:   -cas-args -fcas-path %t.d/cas -faction-cache-path %t.d/cache --     \
+// RUN:   -cas-args -fcas-path %t.d/cas --                                    \
 // RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon        \
 // RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t                   \
 // RUN:    -fdepscan-prefix-map=/=/^foo                                       \
 // RUN:    -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %t.d/out.o     \
-// RUN:      -fcas-path %t.d/cas -faction-cache-path %t.d/cache               \
+// RUN:      -fcas-path %t.d/cas                                              \
 // RUN: 2>&1 | FileCheck %s -DPREFIX=%t.d -check-prefix=ERROR_ROOT
 // ERROR_ROOT: invalid prefix map: '/=/^foo'
 
 // RUN: not %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t      \
-// RUN:   -cas-args -fcas-path %t.d/cas -faction-cache-path %t.d/cache --     \
+// RUN:   -cas-args -fcas-path %t.d/cas --                                    \
 // RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon        \
 // RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t                   \
 // RUN:    -fdepscan-prefix-map==/^foo                                        \
 // RUN:    -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %t.d/out.o     \
-// RUN:      -fcas-path %t.d/cas -faction-cache-path %t.d/cache               \
+// RUN:      -fcas-path %t.d/cas                                              \
 // RUN: 2>&1 | FileCheck %s -DPREFIX=%t.d -check-prefix=ERROR_EMPTY
 // ERROR_EMPTY: invalid prefix map: '=/^foo'
 
 // RUN: not %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t      \
-// RUN:   -cas-args -fcas-path %t.d/cas -faction-cache-path %t.d/cache --     \
+// RUN:   -cas-args -fcas-path %t.d/cas --                                    \
 // RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon        \
 // RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t                   \
 // RUN:    -fdepscan-prefix-map=relative=/^foo                                \
 // RUN:    -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %t.d/out.o     \
-// RUN:      -fcas-path %t.d/cas -faction-cache-path %t.d/cache               \
+// RUN:      -fcas-path %t.d/cas                                              \
 // RUN: 2>&1 | FileCheck %s -DPREFIX=%t.d -check-prefix=ERROR_RELATIVE
 // ERROR_RELATIVE: invalid prefix map: 'relative=/^foo'
 

--- a/clang/test/CAS/depscan-with-error.c
+++ b/clang/test/CAS/depscan-with-error.c
@@ -11,7 +11,7 @@
 // RUN: not env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t.o -Wl,-none --serialize-diagnostics %t/t2.diag \
 // RUN:   2>&1 | FileCheck %s -check-prefix=ERROR -check-prefix=DRIVER
-// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas/cas -faction-cache-path %t/cas/cache -- \
+// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas -- \
 // RUN: %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t.o -Wl,-none --serialize-diagnostics %t/t3.diag \
 // RUN:   2>&1 | FileCheck %s -check-prefix=ERROR -check-prefix=DRIVER
@@ -28,7 +28,7 @@
 // RUN: echo "int y;" > %t/b.c
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %t/a.c -o %t.o --serialize-diagnostics %t/t2.diag
-// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas/cas -faction-cache-path %t/cas/cache -- \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas -- \
 // RUN: %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %t/b.c -o %t.o --serialize-diagnostics %t/t3.diag
 
@@ -49,7 +49,7 @@
 // RUN: not env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t.o -fdiagnostics-color=always -fansi-escape-codes \
 // RUN:   2>&1 | FileCheck %s -check-prefix=COLOR-DIAG
-// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas/cas -faction-cache-path %t/cas/cache -- \
+// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas -- \
 // RUN: %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t.o -fdiagnostics-color=always -fansi-escape-codes \
 // RUN:   2>&1 | FileCheck %s -check-prefix=COLOR-DIAG

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -13,12 +13,12 @@
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas PATH="%t:$PATH" %clang-cache clang-symlink-outside-bindir -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG -DPREFIX=%t
 
 // CLANG: "-cc1depscan" "-fdepscan=auto"
-// CLANG: "-fcas-path" "[[PREFIX]]/cas/cas" "-faction-cache-path" "[[PREFIX]]/cas/actioncache" "-fcas-token-cache"
+// CLANG: "-fcas-path" "[[PREFIX]]/cas" "-fcas-token-cache"
 // CLANG: "-greproducible"
 // CLANG: "-x" "c"
 
 // CLANGPP: "-cc1depscan" "-fdepscan=auto"
-// CLANGPP: "-fcas-path" "[[PREFIX]]/cas/cas" "-faction-cache-path" "[[PREFIX]]/cas/actioncache" "-fcas-token-cache"
+// CLANGPP: "-fcas-path" "[[PREFIX]]/cas" "-fcas-token-cache"
 // CLANGPP: "-greproducible"
 // CLANGPP: "-x" "c++"
 
@@ -31,7 +31,7 @@
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=SESSION -DPREFIX=%t
 // SESSION: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-share-identifier"
-// SESSION: "-fcas-path" "[[PREFIX]]/cas/cas" "-faction-cache-path" "[[PREFIX]]/cas/actioncache" "-fcas-token-cache"
+// SESSION: "-fcas-path" "[[PREFIX]]/cas" "-fcas-token-cache"
 // SESSION: "-greproducible"
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_SCAN_DAEMON_SOCKET_PATH=%t/scand cache-build-session %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=SPECIFIC-DAEMON -DPREFIX=%t

--- a/clang/test/CAS/fcache-compile-job-dependency-file.c
+++ b/clang/test/CAS/fcache-compile-job-dependency-file.c
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: split-file %s %t
-// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+// RUN: split-file %s %t/src
+// RUN: llvm-cas --cas %t/cas --ingest --data %t/src > %t/casid
 //
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache %t/src/main.c -emit-obj -o %t/output.o -isystem %t/src/sys \
 // RUN:   -dependency-file %t/deps1.d -MT depends 2>&1 \
 // RUN:   | FileCheck %s --allow-empty --check-prefix=CACHE-MISS
 //
@@ -17,8 +17,8 @@
 // RUN: ls %t/output.o && rm %t/output.o
 //
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache %t/src/main.c -emit-obj -o %t/output.o -isystem %t/src/sys \
 // RUN:   -dependency-file %t/deps2.d -MT depends 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CACHE-HIT
 //
@@ -29,8 +29,8 @@
 // CACHE-MISS-NOT: remark: compile job cache hit
 
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache %t/src/main.c -emit-obj -o %t/output.o -isystem %t/src/sys \
 // RUN:   -dependency-file %t/deps3.d -MT other1 -MT other2 -MP -fdepfile-entry=extra-depfile.json 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CACHE-HIT
 
@@ -43,8 +43,8 @@
 // DEPS_OTHER: my_header.h:
 
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache %t/src/main.c -emit-obj -o %t/output.o -isystem %t/src/sys \
 // RUN:   -sys-header-deps -dependency-file %t/deps4.d -MT depends 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CACHE-MISS
 
@@ -57,11 +57,12 @@
 // DEPS_SYS: my_header.h
 // DEPS_SYS: sys.h
 
-// Using another cache path to avoid reusing artifacts.
+// Using another cas path to avoid reusing artifacts.
+// RUN: llvm-cas --cas %t/cas2 --ingest --data %t/src
 
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache2 -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
+// RUN:   -fcas-path %t/cas2 -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache %t/src/main.c -emit-obj -o %t/output.o -isystem %t/src/sys \
 // RUN:   -dependency-file %t/deps-depfile1.d -MT deps -fdepfile-entry=extra-depfile.json -fdepfile-entry=%t/main.c 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CACHE-MISS
 
@@ -71,8 +72,8 @@
 // DEPS_DEPFILE1: main.c
 
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache2 -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache %t/main.c -emit-obj -o %t/output.o -isystem %t/sys \
+// RUN:   -fcas-path %t/cas2 -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache %t/src/main.c -emit-obj -o %t/output.o -isystem %t/src/sys \
 // RUN:   -dependency-file %t/deps-depfile2.d -MT deps 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CACHE-HIT
 

--- a/clang/test/CAS/fcache-compile-job-serialized-diagnostics.c
+++ b/clang/test/CAS/fcache-compile-job-serialized-diagnostics.c
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
 
-// RUN: %clang -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -faction-cache-path %t/cache \
+// RUN: %clang -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas \
 // RUN:   -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Wimplicit-function-declaration \
 // RUN:   -Wno-error=implicit-function-declaration \
@@ -13,7 +13,7 @@
 
 // RUN: ls %t/output.o && rm %t/output.o
 
-// RUN: %clang -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -faction-cache-path %t/cache \
+// RUN: %clang -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas \
 // RUN:   -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Wimplicit-function-declaration \
 // RUN:   -Wno-error=implicit-function-declaration \

--- a/clang/test/CAS/fcache-compile-job.c
+++ b/clang/test/CAS/fcache-compile-job.c
@@ -2,18 +2,18 @@
 // RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
 //
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Rcompile-job-cache -emit-obj %s -o %t/output.o 2>&1 \
 // RUN:   | FileCheck %s --allow-empty --check-prefix=CACHE-MISS
 // RUN: ls %t/output.o && rm %t/output.o
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Rcompile-job-cache -emit-obj %s -o %t/output.o 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CACHE-HIT
 // RUN: ls %t/output.o && rm %t/output.o
 // RUN: cd %t
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Rcompile-job-cache -emit-obj %s -o output.o 2>&1 \
 // RUN:   | FileCheck %s --allow-empty --check-prefix=CACHE-HIT
 // RUN: ls %t/output.o
@@ -21,16 +21,25 @@
 // Check for a cache hit if the CAS moves:
 // RUN: mv %t/cas %t/cas.moved
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas.moved -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
-// RUN:   -Rcompile-job-cache -emit-obj %s -o output.o 2>&1 \
-// RUN:   | FileCheck %s --check-prefix=CACHE-HIT
+// RUN:   -fcas-path %t/cas.moved -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -Rcompile-job-cache -emit-obj %s -o output.o 2> %t/cache-hit.out
+// RUN: FileCheck %s -input-file=%t/cache-hit.out --check-prefix=CACHE-HIT
 // RUN: ls %t/output.o
-//
+
+// RUN: cat %t/cache-hit.out | sed \
+// RUN:   -e "s/^.*hit for '//" \
+// RUN:   -e "s/' .*$//" > %t/cache-key
+// RUN: cat %t/cache-hit.out | sed \
+// RUN:   -e "s/^.*=> '//" \
+// RUN:   -e "s/' .*$//" > %t/cache-result
+
 // Check for a handling error if the CAS is removed but not action cache.
-// First need to ignest the input file so the compile cache can be constructed.
+// First need to ingest the input file so the compile cache can be constructed.
 // RUN: llvm-cas --ingest --cas %t/cas.new --data %s
+// Add the 'key => result' association we got earlier.
+// RUN: llvm-cas --cas %t/cas.new --put-cache-key @%t/cache-key @%t/cache-result
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas.new -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -fcas-path %t/cas.new -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Rcompile-job-cache -emit-obj %s -o output.o 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CACHE-RESULT
 // RUN: ls %t/output.o

--- a/clang/test/CAS/fcas-fs-framework-autolink.c
+++ b/clang/test/CAS/fcas-fs-framework-autolink.c
@@ -8,14 +8,14 @@
 // RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives \
 // RUN:   > %t/deps_no_fw.json
 
 // RUN: echo 'build 1' > %t/Foo.framework/Foo
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives \
 // RUN:   > %t/deps_fw1.json
 
@@ -25,7 +25,7 @@
 // RUN: echo 'build 2' > %t/Foo.framework/Foo
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives \
 // RUN:   > %t/deps_fw2.json
 

--- a/clang/test/CAS/fcas-include-tree-prefix-mapping.c
+++ b/clang/test/CAS/fcas-include-tree-prefix-mapping.c
@@ -5,7 +5,7 @@
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree \
 // RUN:   -fdepscan-prefix-map=%t/src=/^src -fdepscan-prefix-map=%t/out=/^out -fdepscan-prefix-map-toolchain=/^toolchain -fdepscan-prefix-map-sdk=/^sdk \
 // RUN:   -o %t/t1.rsp -cc1-args \
-// RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -faction-cache-path %t/cache -Rcompile-job-cache \
+// RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out \
@@ -43,7 +43,7 @@
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree \
 // RUN:   -fdepscan-prefix-map=%t/src2=/^src -fdepscan-prefix-map=%t/out2=/^out -fdepscan-prefix-map-toolchain=/^toolchain -fdepscan-prefix-map-sdk=/^sdk \
 // RUN:   -o %t/t2.rsp -cc1-args \
-// RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -faction-cache-path %t/cache -Rcompile-job-cache \
+// RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out2 \
@@ -79,7 +79,7 @@
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree \
 // RUN:   -fdepscan-prefix-map=%t/src=/^src -fdepscan-prefix-map=%t/out=/^out -fdepscan-prefix-map-toolchain=/^toolchain -fdepscan-prefix-map-sdk=/^sdk \
 // RUN:   -o %t/pch1.rsp -cc1-args \
-// RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -faction-cache-path %t/cache -Rcompile-job-cache \
+// RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out \
@@ -90,7 +90,7 @@
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree \
 // RUN:   -fdepscan-prefix-map=%t/src2=/^src -fdepscan-prefix-map=%t/out2=/^out -fdepscan-prefix-map-toolchain=/^toolchain -fdepscan-prefix-map-sdk=/^sdk \
 // RUN:   -o %t/pch2.rsp -cc1-args \
-// RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas2 -faction-cache-path %t/cache2 -Rcompile-job-cache \
+// RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas2 -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out2 \
@@ -102,7 +102,7 @@
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree \
 // RUN:   -fdepscan-prefix-map=%t/src=/^src -fdepscan-prefix-map=%t/out=/^out -fdepscan-prefix-map-toolchain=/^toolchain -fdepscan-prefix-map-sdk=/^sdk \
 // RUN:   -o %t/t3.rsp -cc1-args \
-// RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -faction-cache-path %t/cache -Rcompile-job-cache \
+// RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out \
@@ -117,7 +117,7 @@
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree \
 // RUN:   -fdepscan-prefix-map=%t/src2=/^src -fdepscan-prefix-map=%t/out2=/^out -fdepscan-prefix-map-toolchain=/^toolchain -fdepscan-prefix-map-sdk=/^sdk \
 // RUN:   -o %t/t4.rsp -cc1-args \
-// RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -faction-cache-path %t/cache -Rcompile-job-cache \
+// RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out2 \
@@ -135,7 +135,7 @@
 // Check dependencies.
 
 // Baseline for comparison.
-// RUN: %clang_cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -faction-cache-path %t/cache -Rcompile-job-cache \
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:   -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:   -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
 // RUN:   -emit-pch -x c-header %t/src/prefix.h -o %t/out/reg-prefix.h.pch -include %t/src/prefix.h -I %t/src/inc
@@ -144,7 +144,7 @@
 // RUN:   -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
 // RUN:   -emit-obj %t/src/main.c -o %t/out/main.o -include-pch %t/out/reg-prefix.h.pch -I %t/src/inc \
 // RUN:   -MT deps -dependency-file %t/regular1.pch.d
-// RUN: %clang_cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -faction-cache-path %t/cache -Rcompile-job-cache \
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:   -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:   -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
 // RUN:   -emit-pch -x c-header %t/src2/prefix.h -o %t/out2/reg-prefix.h.pch -include %t/src2/prefix.h -I %t/src2/inc

--- a/clang/test/CAS/fdepscan-daemon.c
+++ b/clang/test/CAS/fdepscan-daemon.c
@@ -3,9 +3,9 @@
 // REQUIRES: system-darwin, clang-cc1daemon
 
 // RUN: rm -rf %t
-// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas -faction-cache-path %t/cache -- \
+// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas -- \
 // RUN:   %clang -target x86_64-apple-macos11 -I %S/Inputs \
-// RUN:     -Xclang -fcas-path -Xclang %t/cas -Xclang -faction-cache-path -Xclang %t/cache \
+// RUN:     -Xclang -fcas-path -Xclang %t/cas \
 // RUN:     -fdepscan=daemon -fdepscan-daemon=%{clang-daemon-dir}/%basename_t -fsyntax-only -x c %s
 
 #include "test.h"

--- a/clang/test/CAS/fmodule-file-cache-key-errors.c
+++ b/clang/test/CAS/fmodule-file-cache-key-errors.c
@@ -12,7 +12,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   -fmodule-file-cache-key=INVALID \
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/invalid.txt
 // RUN: cat %t/invalid.txt | FileCheck %s -check-prefix=INVALID
 
@@ -22,7 +22,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   -fmodule-file-cache-key=PATH=KEY \
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/bad_key.txt
 // RUN: cat %t/bad_key.txt | FileCheck %s -check-prefix=BAD_KEY
 
@@ -35,7 +35,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/bad_key2.rsp \
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/bad_key2.txt
 // RUN: cat %t/bad_key2.txt | FileCheck %s -check-prefix=BAD_KEY2
 
@@ -46,13 +46,15 @@
 // RUN: %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
 // RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
 // RUN: cat %t/A.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 // CACHE-MISS: remark: compile job cache miss
 // RUN: cat %t/A.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/A.key
 
-// == Try to import A with a different action cache, simulating a missing module
+// == Try to import A with an empty action cache, simulating a missing module
+
+// RUN: llvm-cas --cas %t/cas_2 --import --upstream-cas %t/cas @%t/A.key
 
 // RUN: echo -n '-fmodule-file-cache-key=PATH=' > %t/not_in_cache.rsp
 // RUN: cat %t/A.key >> %t/not_in_cache.rsp
@@ -61,7 +63,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/not_in_cache.rsp \
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache_2 -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas_2 -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/not_in_cache.txt
 // RUN: cat %t/not_in_cache.txt | FileCheck %s -check-prefix=NOT_IN_CACHE -DPREFIX=%/t
 

--- a/clang/test/CAS/fmodule-file-cache-key-lazy.c
+++ b/clang/test/CAS/fmodule-file-cache-key-lazy.c
@@ -13,7 +13,7 @@
 // RUN: %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fmodule-name=B -fno-implicit-modules \
 // RUN:   -emit-module %t/module.modulemap -o %t/B.pcm \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.txt
 // RUN: cat %t/B.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: cat %t/B.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/B.key
@@ -27,7 +27,7 @@
 // RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
 // RUN:   @%t/B.import.rsp -fmodule-file=B=%t/B.pcm \
 // RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
 // RUN: cat %t/A.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: cat %t/A.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/A.key
@@ -41,7 +41,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/A.import.rsp -fmodule-file=A=%t/A.pcm \
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.txt
 // RUN: cat %t/tu.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 
@@ -53,7 +53,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/A.import.rsp -fmodule-file=A=%t/A.pcm \
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.2.txt
 // RUN: cat %t/tu.out.2.txt | FileCheck %s --check-prefix=CACHE-HIT
 

--- a/clang/test/CAS/fmodule-file-cache-key-with-pch.c
+++ b/clang/test/CAS/fmodule-file-cache-key-with-pch.c
@@ -14,7 +14,7 @@
 // RUN: %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fmodule-name=B -fno-implicit-modules \
 // RUN:   -emit-module %t/module.modulemap -o %t/B.pcm \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.txt
 // RUN: cat %t/B.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: cat %t/B.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/B.key
@@ -28,7 +28,7 @@
 // RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
 // RUN:   @%t/B.import.rsp -fmodule-file=%t/B.pcm \
 // RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
 // RUN: cat %t/A.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: cat %t/A.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/A.key
@@ -39,7 +39,7 @@
 // RUN:   -fmodules -fmodule-name=C -fno-implicit-modules \
 // RUN:   @%t/B.import.rsp -fmodule-file=%t/B.pcm \
 // RUN:   -emit-module %t/module.modulemap -o %t/C.pcm \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/C.out.txt
 // RUN: cat %t/C.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: cat %t/C.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/C.key
@@ -53,7 +53,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/A.import.rsp -fmodule-file=%t/A.pcm \
 // RUN:   -emit-pch -x c-header %t/prefix.h -o %t/prefix.pch \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/prefix.out.txt
 // RUN: cat %t/prefix.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 
@@ -72,7 +72,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/C.import.rsp -fmodule-file=%t/C.pcm -include-pch %t/prefix.pch \
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.txt
 // RUN: cat %t/tu.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 
@@ -82,7 +82,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/C.import.rsp -fmodule-file=%t/C.pcm -include-pch %t/prefix.pch \
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.2.txt
 // RUN: cat %t/tu.out.2.txt | FileCheck %s --check-prefix=CACHE-HIT
 

--- a/clang/test/CAS/fmodule-file-cache-key.c
+++ b/clang/test/CAS/fmodule-file-cache-key.c
@@ -13,7 +13,7 @@
 // RUN: %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fmodule-name=B -fno-implicit-modules \
 // RUN:   -emit-module %t/module.modulemap -o %t/B.pcm \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.txt
 // RUN: cat %t/B.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: cat %t/B.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/B.key
@@ -27,7 +27,7 @@
 // RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
 // RUN:   @%t/B.import.rsp -fmodule-file=%t/B.pcm \
 // RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
 // RUN: cat %t/A.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: cat %t/A.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/A.key
@@ -41,7 +41,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/A.import.rsp -fmodule-file=%t/A.pcm\
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.txt
 // RUN: cat %t/tu.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 
@@ -53,7 +53,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/A.import.rsp -fmodule-file=%t/A.pcm\
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.2.txt
 // RUN: cat %t/tu.out.2.txt | FileCheck %s --check-prefix=CACHE-HIT
 

--- a/clang/test/CAS/include-tree-with-sanitizer.c
+++ b/clang/test/CAS/include-tree-with-sanitizer.c
@@ -10,7 +10,7 @@
 // RUN:   -e "s/^.*miss for '//" \
 // RUN:   -e "s/' .*$//" > %t/cache-key-tree
 
-// RUN: clang-cas-test -print-compile-job-cache-key -cas %t/cas/cas @%t/cache-key-tree > %t/key.txt
+// RUN: clang-cas-test -print-compile-job-cache-key -cas %t/cas @%t/cache-key-tree > %t/key.txt
 // RUN: FileCheck %s -DSRC_FILE=%s -DOUT_DIR=%t -input-file %t/key.txt
 //
 // CHECK: -fsanitize=address \
@@ -25,7 +25,7 @@
 // RUN:   -e "s/^.*miss for '//" \
 // RUN:   -e "s/' .*$//" > %t/cache-key-tree2
 
-// RUN: clang-cas-test -print-compile-job-cache-key -cas %t/cas/cas @%t/cache-key-tree2 > %t/key2.txt
+// RUN: clang-cas-test -print-compile-job-cache-key -cas %t/cas @%t/cache-key-tree2 > %t/key2.txt
 // RUN: FileCheck %s -input-file %t/key2.txt -check-prefix=PREFIXED
 //
 // PREFIXED: -fsanitize=address \

--- a/clang/test/CAS/output-path-create-directories.c
+++ b/clang/test/CAS/output-path-create-directories.c
@@ -13,7 +13,7 @@
 // RUN:   -fmodules -fmodule-name=Mod -fno-implicit-modules \
 // RUN:   -emit-module %t/module.modulemap -o %t/out_miss/B.pcm \
 // RUN:   -serialize-diagnostic-file %t/out_miss/B.dia \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.txt
 // RUN: cat %t/B.out.txt | FileCheck %s -check-prefix=CACHE-MISS
 // RUN: ls %t/out_miss/B.pcm
@@ -23,7 +23,7 @@
 // RUN:   -fmodules -fmodule-name=Mod -fno-implicit-modules \
 // RUN:   -emit-module %t/module.modulemap -o %t/out_hit/B.pcm \
 // RUN:   -serialize-diagnostic-file %t/out_hit/B.dia \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.hit.txt
 // RUN: cat %t/B.out.hit.txt | FileCheck %s -check-prefix=CACHE-HIT
 // RUN: ls %t/out_hit/B.pcm

--- a/clang/test/CAS/output-path-error.c
+++ b/clang/test/CAS/output-path-error.c
@@ -6,7 +6,7 @@
 // RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
 
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Rcompile-job-cache -emit-obj %s -o %t/output.o 2>&1 \
 // RUN:   | FileCheck %s --allow-empty --check-prefix=CACHE-MISS
 
@@ -14,7 +14,7 @@
 // RUN: rm -rf %t/cas
 
 // RUN: not %clang -cc1 -triple x86_64-apple-macos11 \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid -fcache-compile-job \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Rcompile-job-cache -emit-obj %s -o %t/output.o &> %t/output.txt
 // RUN: cat %t/output.txt | FileCheck %s --check-prefix=ERROR
 

--- a/clang/test/CAS/pgo-profile.c
+++ b/clang/test/CAS/pgo-profile.c
@@ -3,7 +3,7 @@
 /// Check use pgo profile.
 // RUN: llvm-profdata merge -o %t.profdata %S/Inputs/pgo.profraw
 // RUN: %clang -cc1depscan -fdepscan=inline -o %t.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache \
-// RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -faction-cache-path %t.dir/cache -fprofile-instrument-use-path=%t.profdata
+// RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.profdata
 
 /// Remove profile data to make sure the cc1 command is not reading from file system.
 // RUN: rm %t.profdata
@@ -13,7 +13,7 @@
 /// Check include tree.
 // RUN: llvm-profdata merge -o %t.profdata %S/Inputs/pgo.profraw
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t1.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache \
-// RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -faction-cache-path %t.dir/cache -fprofile-instrument-use-path=%t.profdata
+// RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.profdata
 // RUN: rm %t.profdata
 // RUN: %clang @%t1.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: %clang @%t1.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-HIT
@@ -21,12 +21,12 @@
 /// Check change profile data will cause cache miss.
 // RUN: llvm-profdata merge -o %t.profdata %S/Inputs/pgo2.profraw
 // RUN: %clang -cc1depscan -fdepscan=inline -o %t2.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache \
-// RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -faction-cache-path %t.dir/cache -fprofile-instrument-use-path=%t.profdata
+// RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.profdata
 // RUN: not diff %t.rsp %t2.rsp
 // RUN: %clang @%t2.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t3.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache \
-// RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -faction-cache-path %t.dir/cache -fprofile-instrument-use-path=%t.profdata
+// RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.profdata
 // RUN: not diff %t1.rsp %t3.rsp
 // RUN: %clang @%t3.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
 
@@ -38,9 +38,9 @@
 // RUN: cp %t.profdata %t.dir/a/a.profdata
 // RUN: cp %t.profdata %t.dir/b/a.profdata
 // RUN: %clang -cc1depscan -fdepscan=inline -o %t4.rsp -fdepscan-prefix-map=%t.dir/a=/^testdir -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache \
-// RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -faction-cache-path %t.dir/cache -fprofile-instrument-use-path=%t.dir/a/a.profdata
+// RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.dir/a/a.profdata
 // RUN: %clang -cc1depscan -fdepscan=inline -o %t5.rsp -fdepscan-prefix-map=%t.dir/b=/^testdir -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache \
-// RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -faction-cache-path %t.dir/cache -fprofile-instrument-use-path=%t.dir/b/a.profdata
+// RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.dir/b/a.profdata
 // RUN: cat %t4.rsp | FileCheck %s --check-prefix=REMAP
 // RUN: %clang @%t4.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: %clang @%t5.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-HIT
@@ -55,9 +55,9 @@
 // RUN: diff -u %t.dir/cache-key1 %t.dir/cache-key2
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t4.inc.rsp -fdepscan-prefix-map=%t.dir/a=/^testdir -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache \
-// RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -faction-cache-path %t.dir/cache -fprofile-instrument-use-path=%t.dir/a/a.profdata
+// RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.dir/a/a.profdata
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t5.inc.rsp -fdepscan-prefix-map=%t.dir/b=/^testdir -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache \
-// RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -faction-cache-path %t.dir/cache -fprofile-instrument-use-path=%t.dir/b/a.profdata
+// RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.dir/b/a.profdata
 // RUN: cat %t4.inc.rsp | FileCheck %s --check-prefix=REMAP
 // RUN: %clang @%t4.inc.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: %clang @%t5.inc.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-HIT

--- a/clang/test/CAS/print-compile-job-cache-key.c
+++ b/clang/test/CAS/print-compile-job-cache-key.c
@@ -37,7 +37,7 @@
 // Print a key containing an include-tree.
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/inc.rsp -cc1-args -cc1 -triple x86_64-apple-macos11 -emit-obj \
-// RUN:   %s -o %t/output.o -fcas-path %t/cas -faction-cache-path %t/cache
+// RUN:   %s -o %t/output.o -fcas-path %t/cas
 // RUN: %clang @%t/inc.rsp -Rcompile-job-cache 2> %t/output-tree.txt
 
 // RUN: cat %t/output-tree.txt | sed \

--- a/clang/test/CAS/test-for-deterministic-module.c
+++ b/clang/test/CAS/test-for-deterministic-module.c
@@ -7,7 +7,7 @@
 // RUN: not %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
 // RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
-// RUN:   -fcas-path %t/cas -faction-cache-path %t/cache -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
 // RUN: FileCheck %s --input-file=%t/A.out.txt
 

--- a/clang/test/ClangScanDeps/cas-trees.c
+++ b/clang/test/ClangScanDeps/cas-trees.c
@@ -11,7 +11,7 @@
 // CHECK:      tree {{.*}} for '[[PREFIX]]/t1.c'
 // CHECK-NEXT: tree {{.*}} for '[[PREFIX]]/t2.c'
 
-// RUN: clang-scan-deps -compilation-database %t/cdb.json -cas-path %t/cas -action-cache-path %t/cache -format experimental-tree-full -mode preprocess > %t/full_result.json
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -cas-path %t/cas -format experimental-tree-full -mode preprocess > %t/full_result.json
 // RUN: cat %t/full_result.json | FileCheck %s -DPREFIX=%/t --check-prefix=FULL-TREE
 
 // FULL-TREE:      {
@@ -24,8 +24,6 @@
 // FULL-TREE-NEXT:       "command-line": [
 // FULL-TREE:              "-fcas-path"
 // FULL-TREE-NEXT:         "[[PREFIX]]{{.}}cas"
-// FULL-TREE:              "-faction-cache-path"
-// FULL-TREE-NEXT:         "[[PREFIX]]{{.}}cache"
 // FULL-TREE:              "-fcas-fs"
 // FULL-TREE-NEXT:         "[[T1_ROOT_ID]]"
 // FULL-TREE:              "-fcache-compile-job"
@@ -44,8 +42,6 @@
 // FULL-TREE-NEXT:       "command-line": [
 // FULL-TREE:              "-fcas-path"
 // FULL-TREE-NEXT:         "[[PREFIX]]{{.}}cas"
-// FULL-TREE:              "-faction-cache-path"
-// FULL-TREE-NEXT:         "[[PREFIX]]{{.}}cache"
 // FULL-TREE:              "-fcas-fs"
 // FULL-TREE-NEXT:         "[[T2_ROOT_ID]]"
 // FULL-TREE:              "-fcache-compile-job"

--- a/clang/test/ClangScanDeps/modules-availability-check.c
+++ b/clang/test/ClangScanDeps/modules-availability-check.c
@@ -7,7 +7,7 @@
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json -j 1 \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache > %t/deps.json
+// RUN:   -cas-path %t/cas > %t/deps.json
 
 // RUN: %deps-to-rsp %t/deps.json --module-name=mod > %t/mod.rsp
 // RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp

--- a/clang/test/ClangScanDeps/modules-cas-fs-prefix-mapping-caching.c
+++ b/clang/test/ClangScanDeps/modules-cas-fs-prefix-mapping-caching.c
@@ -9,13 +9,13 @@
 // RUN: sed -e "s|DIR|%t/dir2|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb.json.template > %t/dir2/cdb.json
 
 // RUN: clang-scan-deps -compilation-database %t/dir1/cdb.json -format experimental-full \
-// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/dir1/modules \
+// RUN:    -cas-path %t/cas -module-files-dir %t/dir1/modules \
 // RUN:    -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
 // RUN:    -prefix-map=%t/dir1/modules=/^modules -prefix-map=%t/dir1=/^src \
 // RUN:  > %t/dir1.txt
 
 // RUN: clang-scan-deps -compilation-database %t/dir2/cdb.json -format experimental-full \
-// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/dir2/modules \
+// RUN:    -cas-path %t/cas -module-files-dir %t/dir2/modules \
 // RUN:    -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
 // RUN:    -prefix-map=%t/dir2/modules=/^modules -prefix-map=%t/dir2=/^src \
 // RUN:  > %t/dir2.txt

--- a/clang/test/ClangScanDeps/modules-cas-fs-prefix-mapping.c
+++ b/clang/test/ClangScanDeps/modules-cas-fs-prefix-mapping.c
@@ -8,7 +8,7 @@
 // RUN: sed -e "s|DIR|%t|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb.json.template > %t/cdb.json
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-full \
-// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/modules \
+// RUN:    -cas-path %t/cas -module-files-dir %t/modules \
 // RUN:    -prefix-map=%t/modules=/^modules -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
 // RUN:  > %t/full_result.txt
 
@@ -58,8 +58,6 @@
 // CHECK:            "command-line": [
 // CHECK:              "-fcas-path"
 // CHECK:              "[[PREFIX]]/cas"
-// CHECK:              "-faction-cache-path"
-// CHECK:              "[[PREFIX]]/cache"
 // CHECK:              "-fcas-fs"
 // CHECK:              "[[A_ROOT_ID]]"
 // CHECK:              "-fcas-fs-working-directory"
@@ -94,8 +92,6 @@
 // CHECK:            "command-line": [
 // CHECK:              "-fcas-path"
 // CHECK:              "[[PREFIX]]/cas"
-// CHECK:              "-faction-cache-path"
-// CHECK:              "[[PREFIX]]/cache"
 // CHECK:              "-fcas-fs"
 // CHECK:              "[[B_ROOT_ID]]"
 // CHECK:              "-fcas-fs-working-directory"
@@ -138,8 +134,6 @@
 // CHECK:                "command-line": [
 // CHECK:                  "-fcas-path"
 // CHECK:                  "[[PREFIX]]/cas"
-// CHECK:                  "-faction-cache-path"
-// CHECK:                  "[[PREFIX]]/cache"
 // CHECK:                  "-fcas-fs"
 // CHECK:                  "[[TU_ROOT_ID]]"
 // CHECK:                  "-fcas-fs-working-directory"

--- a/clang/test/ClangScanDeps/modules-cas-fs-symlink-dir-from-module.c
+++ b/clang/test/ClangScanDeps/modules-cas-fs-symlink-dir-from-module.c
@@ -8,7 +8,7 @@
 // RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.in > %t/cdb.json
 // RUN: ln -s module %t/include/symlink-to-module
 
-// RUN: clang-scan-deps -cas-path %t/cas -action-cache-path %t/cache  -compilation-database %t/cdb.json -j 1 \
+// RUN: clang-scan-deps -cas-path %t/cas -compilation-database %t/cdb.json -j 1 \
 // RUN:   -format experimental-full  -mode=preprocess-dependency-directives \
 // RUN:   -optimize-args -module-files-dir %t/build > %t/deps.json
 

--- a/clang/test/ClangScanDeps/modules-cas-fs-vfsoverlay.c
+++ b/clang/test/ClangScanDeps/modules-cas-fs-vfsoverlay.c
@@ -7,7 +7,7 @@
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json -j 1 \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache > %t/deps.json
+// RUN:   -cas-path %t/cas > %t/deps.json
 
 // RUN: %deps-to-rsp %t/deps.json --module-name=A > %t/A.rsp
 // RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp

--- a/clang/test/ClangScanDeps/modules-cas-full-by-mod-name.c
+++ b/clang/test/ClangScanDeps/modules-cas-full-by-mod-name.c
@@ -29,8 +29,7 @@ module transitive { header "transitive.h" }
 
 // RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache \
-// RUN:   -format experimental-full -module-name=root > %t/result.json
+// RUN:   -cas-path %t/cas -format experimental-full -module-name=root > %t/result.json
 // RUN: cat %t/result.json | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
 
 // CHECK:      {

--- a/clang/test/ClangScanDeps/modules-cas-implicit-module-cache.c
+++ b/clang/test/ClangScanDeps/modules-cas-implicit-module-cache.c
@@ -10,7 +10,7 @@
 // Scan to populate module cache
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives
 
 // Clear cas and re-scan
@@ -18,7 +18,7 @@
 // RUN: rm -rf %t/cas
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives \
 // RUN:   > %t/deps.json
 

--- a/clang/test/ClangScanDeps/modules-cas-trees-cwd.c
+++ b/clang/test/ClangScanDeps/modules-cas-trees-cwd.c
@@ -11,7 +11,7 @@
 // RUN: mkdir -p %t/B
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives \
 // RUN:   > %t/deps.json
 

--- a/clang/test/ClangScanDeps/modules-cas-trees-exclude-files-from-casfs.c
+++ b/clang/test/ClangScanDeps/modules-cas-trees-exclude-files-from-casfs.c
@@ -10,13 +10,13 @@
 // RUN: sed "s|DIR|%/t|g" %t/cdb_timestamp.json.template > %t/cdb_timestamp.json
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives \
 // RUN:   > %t/deps.json
 
 // Changing module cache path should not affect results.
 // RUN: clang-scan-deps -compilation-database %t/cdb_cache2.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives \
 // RUN:   > %t/deps_cache2.json
 // RUN: diff -u %t/deps_cache2.json %t/deps.json
@@ -24,12 +24,12 @@
 // .pcm.timestamp files created by -fmodules-validate-once-per-build-session should not affect results
 // RUN: touch %t/session
 // RUN: clang-scan-deps -compilation-database %t/cdb_timestamp.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives \
 // RUN:   > %t/deps_pre_timestamp.json
 // RUN: touch %t/Top.h
 // RUN: clang-scan-deps -compilation-database %t/cdb_timestamp.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives \
 // RUN:   > %t/deps_post_timestamp.json
 // RUN: diff -u %t/deps_pre_timestamp.json %t/deps_post_timestamp.json

--- a/clang/test/ClangScanDeps/modules-cas-trees-input-files.c
+++ b/clang/test/ClangScanDeps/modules-cas-trees-input-files.c
@@ -9,7 +9,7 @@
 
 // == Scan PCH
 // RUN: clang-scan-deps -compilation-database %t/cdb_pch.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives \
 // RUN:   > %t/deps_pch.json
 
@@ -22,7 +22,7 @@
 
 // == Scan TU, including PCH
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives \
 // RUN:   > %t/deps.json
 

--- a/clang/test/ClangScanDeps/modules-cas-trees-with-pch.c
+++ b/clang/test/ClangScanDeps/modules-cas-trees-with-pch.c
@@ -10,7 +10,7 @@
 
 // == Scan PCH
 // RUN: clang-scan-deps -compilation-database %t/cdb_pch.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives \
 // RUN:   > %t/deps_pch.json
 
@@ -31,7 +31,7 @@
 
 // == Scan TU, including PCH
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives \
 // RUN:   > %t/deps.json
 
@@ -61,8 +61,6 @@
 // PCH-NEXT:         "-cc1"
 // PCH:              "-fcas-path"
 // PCH-NEXT:         "[[PREFIX]]{{.}}cas"
-// PCH:              "-faction-cache-path"
-// PCH-NEXT:         "[[PREFIX]]{{.}}cache"
 // PCH:              "-fcas-fs"
 // PCH-NEXT:         "[[A_ROOT_ID]]"
 // PCH:              "-o"
@@ -85,8 +83,6 @@
 // PCH-NEXT:         "-cc1"
 // PCH:              "-fcas-path"
 // PCH-NEXT:         "[[PREFIX]]{{.}}cas"
-// PCH:              "-faction-cache-path"
-// PCH-NEXT:         "[[PREFIX]]{{.}}cache"
 // PCH:              "-fcas-fs"
 // PCH-NEXT:         "[[B_ROOT_ID]]"
 // PCH:              "-o"
@@ -115,8 +111,6 @@
 // PCH-NEXT:             "-cc1"
 // PCH:                  "-fcas-path"
 // PCH-NEXT:             "[[PREFIX]]{{.}}cas"
-// PCH:                  "-faction-cache-path"
-// PCH-NEXT:             "[[PREFIX]]{{.}}cache"
 // PCH:                  "-fcas-fs"
 // PCH-NEXT:             "[[PCH_ROOT_ID]]"
 // PCH:                  "-fno-pch-timestamp"
@@ -139,8 +133,6 @@
 // CHECK-NEXT:         "-cc1"
 // CHECK:              "-fcas-path"
 // CHECK-NEXT:         "[[PREFIX]]{{.}}cas"
-// CHECK:              "-faction-cache-path"
-// CHECK-NEXT:         "[[PREFIX]]{{.}}cache"
 // CHECK:              "-fcas-fs"
 // CHECK-NEXT:         "[[C_ROOT_ID]]"
 // CHECK:              "-o"
@@ -171,8 +163,6 @@
 // CHECK-NEXT:             "-cc1"
 // CHECK:                  "-fcas-path"
 // CHECK-NEXT:             "[[PREFIX]]{{.}}cas"
-// CHECK:                  "-faction-cache-path"
-// CHECK-NEXT:             "[[PREFIX]]{{.}}cache"
 // CHECK:                  "-fcas-fs"
 // CHECK-NEXT:             "[[TU_ROOT_ID]]"
 // CHECK:                  "-fno-pch-timestamp"

--- a/clang/test/ClangScanDeps/modules-cas-trees.c
+++ b/clang/test/ClangScanDeps/modules-cas-trees.c
@@ -8,13 +8,13 @@
 // RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives \
 // RUN:   > %t/deps.json
 
 // Full and tree-full modes are identical here.
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
 // RUN:   -format experimental-tree-full -mode preprocess-dependency-directives \
 // RUN:   > %t/deps_tree.json
 // RUN: diff -u %t/deps_tree.json %t/deps.json
@@ -29,7 +29,7 @@
 // NO_CAS-NOT: faction-cache
 // NO_CAS-NOT: fcache-compile-job
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
-// RUN:   -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/outputs \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
 // RUN:   -format experimental-full -mode preprocess-dependency-directives \
 // RUN:   > %t/deps_cas_2.json
 // RUN: diff -u %t/deps_cas_2.json %t/deps.json
@@ -74,8 +74,6 @@
 // CHECK-NEXT:         "-cc1"
 // CHECK:              "-fcas-path"
 // CHECK-NEXT:         "[[PREFIX]]{{.}}cas"
-// CHECK:              "-faction-cache-path"
-// CHECK-NEXT:         "[[PREFIX]]{{.}}cache"
 // CHECK:              "-fcas-fs"
 // CHECK-NEXT:         "[[LEFT_ROOT_ID]]"
 // CHECK:              "-o"
@@ -102,8 +100,6 @@
 // CHECK-NEXT:         "-cc1"
 // CHECK:              "-fcas-path"
 // CHECK-NEXT:         "[[PREFIX]]{{.}}cas"
-// CHECK:              "-faction-cache-path"
-// CHECK-NEXT:         "[[PREFIX]]{{.}}cache"
 // CHECK:              "-fcas-fs"
 // CHECK-NEXT:         "[[RIGHT_ROOT_ID]]"
 // CHECK:              "-o"
@@ -126,8 +122,6 @@
 // CHECK-NEXT:         "-cc1"
 // CHECK:              "-fcas-path"
 // CHECK-NEXT:         "[[PREFIX]]{{.}}cas"
-// CHECK:              "-faction-cache-path"
-// CHECK-NEXT:         "[[PREFIX]]{{.}}cache"
 // CHECK:              "-fcas-fs"
 // CHECK-NEXT:         "[[TOP_ROOT_ID]]"
 // CHECK:              "-o"
@@ -159,8 +153,6 @@
 // CHECK-NEXT:             "-cc1"
 // CHECK:                  "-fcas-path"
 // CHECK-NEXT:             "[[PREFIX]]{{.}}cas"
-// CHECK:                  "-faction-cache-path"
-// CHECK-NEXT:             "[[PREFIX]]{{.}}cache"
 // CHECK:                  "-fcas-fs"
 // CHECK-NEXT:             "[[TU_ROOT_ID]]"
 // CHECK:                  "-fcache-compile-job"

--- a/clang/test/ClangScanDeps/modules-pch-cas-fs-prefix-mapping-caching.c
+++ b/clang/test/ClangScanDeps/modules-pch-cas-fs-prefix-mapping-caching.c
@@ -12,12 +12,12 @@
 
 // == Scan PCH
 // RUN: clang-scan-deps -compilation-database %t/dir1/cdb_pch.json -format experimental-full \
-// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/dir1/modules \
+// RUN:    -cas-path %t/cas -module-files-dir %t/dir1/modules \
 // RUN:    -prefix-map=%t/dir1/modules=/^modules -prefix-map=%t/dir1=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
 // RUN:  > %t/pch_dir1.txt
 
 // RUN: clang-scan-deps -compilation-database %t/dir2/cdb_pch.json -format experimental-full \
-// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/dir2/modules \
+// RUN:    -cas-path %t/cas -module-files-dir %t/dir2/modules \
 // RUN:    -prefix-map=%t/dir2/modules=/^modules -prefix-map=%t/dir2=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
 // RUN:  > %t/pch_dir2.txt
 
@@ -42,12 +42,12 @@
 
 // == Scan TU, including PCH
 // RUN: clang-scan-deps -compilation-database %t/dir1/cdb.json -format experimental-full \
-// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/dir1/modules \
+// RUN:    -cas-path %t/cas -module-files-dir %t/dir1/modules \
 // RUN:    -prefix-map=%t/dir1/modules=/^modules -prefix-map=%t/dir1=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
 // RUN:  > %t/dir1.txt
 
 // RUN: clang-scan-deps -compilation-database %t/dir2/cdb.json -format experimental-full \
-// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/dir2/modules \
+// RUN:    -cas-path %t/cas -module-files-dir %t/dir2/modules \
 // RUN:    -prefix-map=%t/dir2/modules=/^modules -prefix-map=%t/dir2=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
 // RUN:  > %t/dir2.txt
 

--- a/clang/test/ClangScanDeps/modules-pch-cas-fs-prefix-mapping.c
+++ b/clang/test/ClangScanDeps/modules-pch-cas-fs-prefix-mapping.c
@@ -10,7 +10,7 @@
 
 // == Scan PCH
 // RUN: clang-scan-deps -compilation-database %t/cdb_pch.json -format experimental-full \
-// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/modules \
+// RUN:    -cas-path %t/cas -module-files-dir %t/modules \
 // RUN:    -prefix-map=%t/modules=/^modules -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
 // RUN:  > %t/pch_result.txt
 
@@ -29,7 +29,7 @@
 
 // == Scan TU, including PCH
 // RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-full \
-// RUN:    -cas-path %t/cas -action-cache-path %t/cache -module-files-dir %t/modules \
+// RUN:    -cas-path %t/cas -module-files-dir %t/modules \
 // RUN:    -prefix-map=%t/modules=/^modules -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
 // RUN:  > %t/result.txt
 
@@ -88,8 +88,6 @@
 // PCH:            "command-line": [
 // PCH:              "-fcas-path"
 // PCH:              "[[PREFIX]]/cas"
-// PCH:              "-faction-cache-path"
-// PCH:              "[[PREFIX]]/cache"
 // PCH:              "-fcas-fs"
 // PCH:              "[[A_ROOT_ID]]"
 // PCH:              "-fcas-fs-working-directory"
@@ -124,8 +122,6 @@
 // PCH:            "command-line": [
 // PCH:              "-fcas-path"
 // PCH:              "[[PREFIX]]/cas"
-// PCH:              "-faction-cache-path"
-// PCH:              "[[PREFIX]]/cache"
 // PCH:              "-fcas-fs"
 // PCH:              "[[B_ROOT_ID]]"
 // PCH:              "-fcas-fs-working-directory"
@@ -168,8 +164,6 @@
 // PCH:                "command-line": [
 // PCH:                  "-fcas-path"
 // PCH:                  "[[PREFIX]]/cas"
-// PCH:                  "-faction-cache-path"
-// PCH:                  "[[PREFIX]]/cache"
 // PCH:                  "-fcas-fs"
 // PCH:                  "[[TU_ROOT_ID]]"
 // PCH:                  "-fcas-fs-working-directory"
@@ -204,8 +198,6 @@
 // CHECK-NEXT:         "-cc1"
 // CHECK:              "-fcas-path"
 // CHECK-NEXT:         "[[PREFIX]]{{.}}cas"
-// CHECK:              "-faction-cache-path"
-// CHECK-NEXT:         "[[PREFIX]]{{.}}cache"
 // CHECK:              "-fcas-fs"
 // CHECK-NEXT:         "[[C_ROOT_ID]]"
 // CHECK:              "-fcas-fs-working-directory"
@@ -240,8 +232,6 @@
 // CHECK:                "command-line": [
 // CHECK:                  "-fcas-path"
 // CHECK-NEXT:             "[[PREFIX]]/cas"
-// CHECK:                  "-faction-cache-path"
-// CHECK-NEXT:             "[[PREFIX]]/cache"
 // CHECK:                  "-fcas-fs"
 // CHECK-NEXT:             "[[TU_ROOT_ID]]"
 // CHECK:                  "-fcas-fs-working-directory"

--- a/clang/tools/clang-cas-test/ClangCASTest.cpp
+++ b/clang/tools/clang-cas-test/ClangCASTest.cpp
@@ -71,7 +71,8 @@ int main(int Argc, const char **Argv) {
   Opts.CASPath = CASPath.empty() ? std::string("auto") : CASPath;
 
   auto CAS =
-      Opts.getOrCreateObjectStore(*Diags, /*CreateEmptyCASOnFailure=*/false);
+      Opts.getOrCreateDatabases(*Diags, /*CreateEmptyCASOnFailure=*/false)
+          .first;
   if (!CAS)
     return 1;
 

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -254,10 +254,6 @@ llvm::cl::list<std::string>
     PrefixMaps("prefix-map",
                llvm::cl::desc("Path to remap, as \"<old>=<new>\"."),
                llvm::cl::cat(DependencyScannerCategory));
-llvm::cl::opt<std::string>
-    ActionCachePath("action-cache-path",
-                    llvm::cl::desc("Path for on-disk action cache."),
-                    llvm::cl::cat(DependencyScannerCategory));
 
 #ifndef NDEBUG
 static constexpr bool DoRoundTripDefault = true;
@@ -1075,8 +1071,6 @@ int main(int argc, const char **argv) {
       else
         CASOpts.ensurePersistentCAS();
     }
-    if (!ActionCachePath.empty())
-      CASOpts.CachePath = ActionCachePath;
 
     CAS = CASOpts.getOrCreateObjectStore(Diags);
     Cache = CASOpts.getOrCreateActionCache(Diags);

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -239,8 +239,7 @@ llvm::cl::opt<std::string>
                   llvm::cl::cat(DependencyScannerCategory));
 
 llvm::cl::opt<bool> InMemoryCAS(
-    "in-memory-cas",
-    llvm::cl::desc("Use an in-memory CAS instead of on-disk."),
+    "in-memory-cas", llvm::cl::desc("Use an in-memory CAS instead of on-disk."),
     llvm::cl::init(false), llvm::cl::cat(DependencyScannerCategory));
 
 llvm::cl::opt<std::string>
@@ -1072,8 +1071,7 @@ int main(int argc, const char **argv) {
         CASOpts.ensurePersistentCAS();
     }
 
-    CAS = CASOpts.getOrCreateObjectStore(Diags);
-    Cache = CASOpts.getOrCreateActionCache(Diags);
+    std::tie(CAS, Cache) = CASOpts.getOrCreateDatabases(Diags);
     if (!CAS)
       return 1;
     if (Format != ScanningOutputFormat::IncludeTree)

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -93,21 +93,11 @@ static void addCommonArgs(bool ForDriver, SmallVectorImpl<const char *> &Args,
     Args.push_back("-fdepscan-include-tree");
   }
   if (auto CASPath = llvm::sys::Process::GetEnv("LLVM_CACHE_CAS_PATH")) {
-    llvm::SmallString<256> CASArg(*CASPath);
-    llvm::sys::path::append(CASArg, "cas");
     if (ForDriver) {
-      Args.append({"-Xclang", "-fcas-path", "-Xclang",
-                   Saver.save(CASArg.str()).data()});
+      Args.append(
+          {"-Xclang", "-fcas-path", "-Xclang", Saver.save(*CASPath).data()});
     } else {
-      Args.append({"-fcas-path", Saver.save(CASArg.str()).data()});
-    }
-    llvm::SmallString<256> CacheArg(*CASPath);
-    llvm::sys::path::append(CacheArg, "actioncache");
-    if (ForDriver) {
-      Args.append({"-Xclang", "-faction-cache-path", "-Xclang",
-                   Saver.save(CacheArg.str()).data()});
-    } else {
-      Args.append({"-faction-cache-path", Saver.save(CacheArg.str()).data()});
+      Args.append({"-fcas-path", Saver.save(*CASPath).data()});
     }
   }
 }

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -500,11 +500,8 @@ std::optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
   if (!CacheCompileJob)
     return std::nullopt;
 
-  CAS = Invocation.getCASOpts().getOrCreateObjectStore(Diags);
-  if (!CAS)
-    return 1; // Exit with error!
-  Cache = Invocation.getCASOpts().getOrCreateActionCache(Diags);
-  if (!Cache)
+  std::tie(CAS, Cache) = Invocation.getCASOpts().getOrCreateDatabases(Diags);
+  if (!CAS || !Cache)
     return 1; // Exit with error!
 
   CompileJobCachingOptions CacheOpts;

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -613,14 +613,8 @@ int cc1depscan_main(ArrayRef<const char *> Argv, const char *Argv0,
   CompilerInvocation::ParseCASArgs(CASOpts, ParsedCC1Args, Diags);
   CASOpts.ensurePersistentCAS();
 
-  std::shared_ptr<llvm::cas::ObjectStore> CAS =
-      CASOpts.getOrCreateObjectStore(Diags);
-  if (!CAS)
-    return 1;
-
-  std::shared_ptr<llvm::cas::ActionCache> Cache =
-      CASOpts.getOrCreateActionCache(Diags);
-  if (!Cache)
+  auto [CAS, Cache] = CASOpts.getOrCreateDatabases(Diags);
+  if (!CAS || !Cache)
     return 1;
 
   if (int Ret = scanAndUpdateCC1(Argv0, CC1Args->getValues(), NewArgs, Diags,
@@ -870,13 +864,11 @@ int ScanServer::listen() {
   bool ProduceIncludeTree =
       ParsedCASArgs.hasArg(driver::options::OPT_fdepscan_include_tree);
 
-  std::shared_ptr<llvm::cas::ObjectStore> CAS =
-      CASOpts.getOrCreateObjectStore(Diags);
+  std::shared_ptr<llvm::cas::ObjectStore> CAS;
+  std::shared_ptr<llvm::cas::ActionCache> Cache;
+  std::tie(CAS, Cache) = CASOpts.getOrCreateDatabases(Diags);
   if (!CAS)
     reportError("cannot create CAS");
-
-  std::shared_ptr<llvm::cas::ActionCache> Cache =
-      CASOpts.getOrCreateActionCache(Diags);
   if (!Cache)
     reportError("cannot create ActionCache");
 

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -39,6 +39,7 @@
 #include "llvm/BinaryFormat/MachO.h"
 #include "llvm/BinaryFormat/Magic.h"
 #include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
 #include "llvm/CAS/CASFileSystem.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/CAS/HierarchicalTreeBuilder.h"

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1901,24 +1901,15 @@ bool macho::link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
   // mechanism as on the clang side to be able to use any kind of CAS.
   if (args.hasArg(OPT_cas_path)) {
     StringRef path = args.getLastArgValue(OPT_cas_path);
-    auto CAS = llvm::cas::createOnDiskCAS(path);
-    if (CAS) {
-      config->CAS = std::move(*CAS);
+    std::pair<std::unique_ptr<ObjectStore>, std::unique_ptr<ActionCache>> DBs;
+    if (Error E = createOnDiskUnifiedCASDatabases(path).moveInto(DBs)) {
+      error("error loading CAS at path '" + path +
+            "': " + toString(std::move(E)));
+    } else {
+      std::tie(config->CAS, config->actionCache) = std::move(DBs);
       config->CASSchemas =
           std::make_unique<ObjectFormatSchemaPool>(*config->CAS);
-    } else {
-      error("error loading CAS at path '" + path +
-            "': " + toString(CAS.takeError()));
     }
-    std::string defaultCachePath = llvm::cas::getDefaultOnDiskActionCachePath();
-    StringRef cachePath =
-        args.getLastArgValue(OPT_cache_path, defaultCachePath);
-    auto cache = llvm::cas::createOnDiskActionCache(cachePath);
-    if (cache)
-      config->actionCache = std::move(*cache);
-    else
-      error("error loading ActionCache at path '" + cachePath +
-            "': " + toString(cache.takeError()));
   }
   Optional<StringRef> CASFileSystemRootID;
   if (args.hasArg(OPT_fcas_fs))

--- a/lld/MachO/Options.td
+++ b/lld/MachO/Options.td
@@ -129,10 +129,6 @@ def cas_path : Separate<["--"], "fcas-builtin-path">,
     HelpText<"Path to a persistent on-disk backing store for the builtin CAS.">,
     MetaVarName<"<path>">,
     Group<grp_lld>;
-def cache_path : Separate<["--"], "faction-cache-path">,
-    HelpText<"Path to a persistent on-disk backing store for the action cache.">,
-    MetaVarName<"<path>">,
-    Group<grp_lld>;
 def fcas_fs : Separate<["--"], "fcas-fs">,
     HelpText<"Configure the filesystem to read from the provided CAS tree.">,
     MetaVarName<"<tree>">,

--- a/lld/test/MachO/CAS/cache-results.s
+++ b/lld/test/MachO/CAS/cache-results.s
@@ -15,60 +15,60 @@
 
 // Check result caching.
 
-// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-MISS
 // RUN: diff %t/exe %t/exe-normal
 
 // RUN: rm %t/exe
-// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-HIT
 // RUN: diff %t/exe %t/exe-normal
 
 // RUN: touch %t/main.o %t/alib/libt1.a %t/dlib/libt2.dylib
-// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-HIT
 
 // Check that changing output executable filename doesn't affect cache key for executables.
-// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe2 -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe2 -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-HIT
 // RUN: diff %t/exe2 %t/exe-normal
 
 // But changing output dylib filename affects cache key.
-// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose -dylib %t/main.o -o %t/exe1.dylib -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose -dylib %t/main.o -o %t/exe1.dylib -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-MISS
-// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose -dylib %t/main.o -o %t/exe2.dylib -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose -dylib %t/main.o -o %t/exe2.dylib -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-MISS
 // RUN: not diff %t/exe1.dylib %t/exe2.dylib
 
 // Check that re-exports in a dylib are handled for dependency scanning (libc++ re-exports libc++abi)
-// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose -lc++ %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose -lc++ %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-MISS
 
 // Change order of search paths.
-// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt2 -lt1 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt2 -lt1 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-MISS
-// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt2 -lt1 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt2 -lt1 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-HIT
 
 // Change .o contents
 // RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/main2.s -o %t/main.o
-// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-MISS
-// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-HIT
 
 // Change .a and .dylib contents
 // RUN: llvm-ar rcs %t/alib/libt1.a %t/t2.o
 // RUN: %lld -dylib -o %t/dlib/libt2.dylib %t/t1.o
-// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-MISS
-// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose %t/main.o -o %t/exe -lt1 -lt2 -L%t/alib -L%t/dlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-HIT
 
 // Check using relative paths.
 
 // RUN: mv %t/exe %t/exe.bak; cd %t
-// RUN: %lld --fcas-builtin-path %t/cas --faction-cache-path %t/cache --fcas-cache-results --verbose main.o -o exe -lt1 -lt2 -Lalib -Ldlib 2>&1 \
+// RUN: %lld --fcas-builtin-path %t/cas --fcas-cache-results --verbose main.o -o exe -lt1 -lt2 -Lalib -Ldlib 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CACHE-HIT
 // RUN: diff %t/exe %t/exe.bak
 

--- a/llvm/include/llvm/CAS/BuiltinUnifiedCASDatabases.h
+++ b/llvm/include/llvm/CAS/BuiltinUnifiedCASDatabases.h
@@ -1,0 +1,26 @@
+//===- BuiltinUnifiedCASDatabases.h -----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CAS_BUILTINUNIFIEDCASDATABASES_H
+#define LLVM_CAS_BUILTINUNIFIEDCASDATABASES_H
+
+#include "llvm/Support/Error.h"
+
+namespace llvm::cas {
+
+class ActionCache;
+class ObjectStore;
+
+/// Create on-disk \c ObjectStore and \c ActionCache instances based on
+/// \c ondisk::UnifiedOnDiskCache, with built-in hashing.
+Expected<std::pair<std::unique_ptr<ObjectStore>, std::unique_ptr<ActionCache>>>
+createOnDiskUnifiedCASDatabases(StringRef Path);
+
+} // namespace llvm::cas
+
+#endif // LLVM_CAS_BUILTINUNIFIEDCASDATABASES_H

--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -382,13 +382,6 @@ using ObjectStoreCreateFuncTy =
     Expected<std::unique_ptr<ObjectStore>>(const Twine &);
 void registerCASURLScheme(StringRef Prefix, ObjectStoreCreateFuncTy *Func);
 
-class ActionCache;
-
-/// Create on-disk \p ObjectStore and \p ActionCache instances based on \p
-/// ondisk::UnifiedOnDiskCache.
-Expected<std::pair<std::unique_ptr<ObjectStore>, std::unique_ptr<ActionCache>>>
-createOnDiskUnifiedCASDatabases(StringRef Path);
-
 } // namespace cas
 } // namespace llvm
 

--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -379,6 +379,13 @@ using ObjectStoreCreateFuncTy =
     Expected<std::unique_ptr<ObjectStore>>(const Twine &);
 void registerCASURLScheme(StringRef Prefix, ObjectStoreCreateFuncTy *Func);
 
+class ActionCache;
+
+/// Create on-disk \p ObjectStore and \p ActionCache instances based on \p
+/// ondisk::UnifiedOnDiskCache.
+Expected<std::pair<std::unique_ptr<ObjectStore>, std::unique_ptr<ActionCache>>>
+createOnDiskUnifiedCASDatabases(StringRef Path);
+
 } // namespace cas
 } // namespace llvm
 

--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -335,6 +335,9 @@ createPluginCAS(StringRef PluginPath,
                 ArrayRef<std::string> PluginArgs = std::nullopt);
 std::unique_ptr<ObjectStore> createInMemoryCAS();
 
+/// \returns true if \c LLVM_ENABLE_ONDISK_CAS configuration was enabled.
+bool isOnDiskCASEnabled();
+
 /// Gets or creates a persistent on-disk path at \p Path.
 ///
 /// Deprecated: if \p Path resolves to \a getDefaultOnDiskCASStableID(),

--- a/llvm/lib/CAS/BuiltinCAS.cpp
+++ b/llvm/lib/CAS/BuiltinCAS.cpp
@@ -9,6 +9,7 @@
 #include "BuiltinCAS.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/CAS/BuiltinObjectHasher.h"
+#include "llvm/CAS/UnifiedOnDiskCache.h"
 #include "llvm/Support/Alignment.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Process.h"
@@ -78,4 +79,11 @@ Error BuiltinCAS::validate(const CASID &ID) {
     return createCorruptObjectError(ID);
 
   return Error::success();
+}
+
+Expected<std::unique_ptr<ondisk::UnifiedOnDiskCache>>
+cas::builtin::createBuiltinUnifiedOnDiskCache(StringRef Path) {
+  return ondisk::UnifiedOnDiskCache::open(Path, /*SizeLimit=*/std::nullopt,
+                                          BuiltinCASContext::getHashName(),
+                                          sizeof(HashType));
 }

--- a/llvm/lib/CAS/BuiltinCAS.h
+++ b/llvm/lib/CAS/BuiltinCAS.h
@@ -18,6 +18,10 @@
 
 namespace llvm {
 namespace cas {
+class ActionCache;
+namespace ondisk {
+class UnifiedOnDiskCache;
+}
 namespace builtin {
 
 /// Current hash type for the internal CAS.
@@ -134,6 +138,20 @@ public:
 
   Error validate(const CASID &ID) final;
 };
+
+/// Create a \p UnifiedOnDiskCache instance that uses \p BLAKE3 hashing.
+Expected<std::unique_ptr<ondisk::UnifiedOnDiskCache>>
+createBuiltinUnifiedOnDiskCache(StringRef Path);
+
+/// \param UniDB A \p UnifiedOnDiskCache instance from \p
+/// createBuiltinUnifiedOnDiskCache.
+std::unique_ptr<ObjectStore> createObjectStoreFromUnifiedOnDiskCache(
+    std::shared_ptr<ondisk::UnifiedOnDiskCache> UniDB);
+
+/// \param UniDB A \p UnifiedOnDiskCache instance from \p
+/// createBuiltinUnifiedOnDiskCache.
+std::unique_ptr<ActionCache> createActionCacheFromUnifiedOnDiskCache(
+    std::shared_ptr<ondisk::UnifiedOnDiskCache> UniDB);
 
 // FIXME: Proxy not portable. Maybe also error-prone?
 constexpr StringLiteral DefaultDirProxy = "/^llvm::cas::builtin::default";

--- a/llvm/lib/CAS/BuiltinUnifiedCASDatabases.cpp
+++ b/llvm/lib/CAS/BuiltinUnifiedCASDatabases.cpp
@@ -1,0 +1,25 @@
+//===- BuiltinUnifiedCASDatabases.cpp ---------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
+#include "BuiltinCAS.h"
+#include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/UnifiedOnDiskCache.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+
+Expected<std::pair<std::unique_ptr<ObjectStore>, std::unique_ptr<ActionCache>>>
+cas::createOnDiskUnifiedCASDatabases(StringRef Path) {
+  std::shared_ptr<ondisk::UnifiedOnDiskCache> UniDB;
+  if (Error E = builtin::createBuiltinUnifiedOnDiskCache(Path).moveInto(UniDB))
+    return std::move(E);
+  auto CAS = builtin::createObjectStoreFromUnifiedOnDiskCache(UniDB);
+  auto AC = builtin::createActionCacheFromUnifiedOnDiskCache(std::move(UniDB));
+  return std::make_pair(std::move(CAS), std::move(AC));
+}

--- a/llvm/lib/CAS/CMakeLists.txt
+++ b/llvm/lib/CAS/CMakeLists.txt
@@ -6,6 +6,7 @@ add_llvm_component_library(LLVMCAS
   ActionCache.cpp
   ActionCaches.cpp
   BuiltinCAS.cpp
+  BuiltinUnifiedCASDatabases.cpp
   CASFileSystem.cpp
   CASNodeSchema.cpp
   CASOutputBackend.cpp

--- a/llvm/lib/CAS/ObjectStore.cpp
+++ b/llvm/lib/CAS/ObjectStore.cpp
@@ -10,7 +10,6 @@
 #include "BuiltinCAS.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringMap.h"
-#include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/UnifiedOnDiskCache.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
@@ -191,14 +190,4 @@ cas::createCASFromIdentifier(StringRef Path) {
 void cas::registerCASURLScheme(StringRef Prefix,
                                ObjectStoreCreateFuncTy *Func) {
   getRegisteredScheme().insert({Prefix, Func});
-}
-
-Expected<std::pair<std::unique_ptr<ObjectStore>, std::unique_ptr<ActionCache>>>
-cas::createOnDiskUnifiedCASDatabases(StringRef Path) {
-  std::shared_ptr<ondisk::UnifiedOnDiskCache> UniDB;
-  if (Error E = builtin::createBuiltinUnifiedOnDiskCache(Path).moveInto(UniDB))
-    return std::move(E);
-  auto CAS = builtin::createObjectStoreFromUnifiedOnDiskCache(UniDB);
-  auto AC = builtin::createActionCacheFromUnifiedOnDiskCache(std::move(UniDB));
-  return std::make_pair(std::move(CAS), std::move(AC));
 }

--- a/llvm/lib/CAS/OnDiskCAS.cpp
+++ b/llvm/lib/CAS/OnDiskCAS.cpp
@@ -139,6 +139,14 @@ Expected<std::unique_ptr<OnDiskCAS>> OnDiskCAS::open(StringRef AbsPath) {
   return std::unique_ptr<OnDiskCAS>(new OnDiskCAS(std::move(*DB)));
 }
 
+bool cas::isOnDiskCASEnabled() {
+#if LLVM_ENABLE_ONDISK_CAS
+  return true;
+#else
+  return false;
+#endif
+}
+
 #if LLVM_ENABLE_ONDISK_CAS
 
 Expected<std::unique_ptr<ObjectStore>> cas::createOnDiskCAS(const Twine &Path) {

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/ADT/Optional.h"
 #include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
 #include "llvm/CAS/CASFileSystem.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/CAS/HierarchicalTreeBuilder.h"

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -50,6 +50,10 @@ static int traverseGraph(ObjectStore &CAS, const CASID &ID);
 static int ingestFileSystem(ObjectStore &CAS, StringRef Path);
 static int mergeTrees(ObjectStore &CAS, ArrayRef<std::string> Objects);
 static int getCASIDForFile(ObjectStore &CAS, const CASID &ID, StringRef Path);
+static int import(ObjectStore &CAS, ObjectStore &UpstreamCAS,
+                  ArrayRef<std::string> Objects);
+static int putCacheKey(ObjectStore &CAS, ActionCache &AC,
+                       ArrayRef<std::string> Objects);
 static int validateObject(ObjectStore &CAS, const CASID &ID);
 
 int main(int Argc, char **Argv) {
@@ -59,6 +63,8 @@ int main(int Argc, char **Argv) {
   cl::list<std::string> Objects(cl::Positional, cl::desc("<object>..."));
   cl::opt<std::string> CASPath("cas", cl::desc("Path to CAS on disk."),
                                cl::value_desc("path"));
+  cl::opt<std::string> UpstreamCASPath(
+      "upstream-cas", cl::desc("Path to another CAS."), cl::value_desc("path"));
   cl::opt<std::string> DataPath("data",
                                 cl::desc("Path to data or '-' for stdin."),
                                 cl::value_desc("path"));
@@ -79,6 +85,8 @@ int main(int Argc, char **Argv) {
     IngestFileSystem,
     MergeTrees,
     GetCASIDForFile,
+    Import,
+    PutCacheKey,
     Validate,
   };
   cl::opt<CommandKind> Command(
@@ -99,6 +107,9 @@ int main(int Argc, char **Argv) {
           clEnumValN(IngestFileSystem, "ingest", "ingest file system"),
           clEnumValN(MergeTrees, "merge", "merge paths/cas-ids"),
           clEnumValN(GetCASIDForFile, "get-cas-id", "get cas id for file"),
+          clEnumValN(Import, "import", "import objects from another CAS"),
+          clEnumValN(PutCacheKey, "put-cache-key",
+                     "set a value for a cache key"),
           clEnumValN(Validate, "validate", "validate the object for CASID")),
       cl::init(CommandKind::Invalid));
 
@@ -114,9 +125,17 @@ int main(int Argc, char **Argv) {
     ExitOnErr(
         createStringError(inconvertibleErrorCode(), "missing --cas=<path>"));
 
-  std::unique_ptr<ObjectStore> CAS =
-      ExitOnErr(createCASFromIdentifier(CASPath));
+  std::unique_ptr<ObjectStore> CAS;
+  std::unique_ptr<ActionCache> AC;
+  if (sys::path::is_absolute(CASPath))
+    std::tie(CAS, AC) = ExitOnErr(createOnDiskUnifiedCASDatabases(CASPath));
+  else
+    CAS = ExitOnErr(createCASFromIdentifier(CASPath));
   assert(CAS);
+
+  std::unique_ptr<ObjectStore> UpstreamCAS;
+  if (!UpstreamCASPath.empty())
+    UpstreamCAS = ExitOnErr(createCASFromIdentifier(UpstreamCASPath));
 
   if (Command == Dump)
     return dump(*CAS);
@@ -145,10 +164,25 @@ int main(int Argc, char **Argv) {
   if (Command == MergeTrees)
     return mergeTrees(*CAS, Objects);
 
-  // Remaining commands need exactly one CAS object.
   if (Objects.empty())
     ExitOnErr(createStringError(inconvertibleErrorCode(),
                                 "missing <object> to operate on"));
+
+  if (Command == Import) {
+    if (!UpstreamCAS)
+      ExitOnErr(createStringError(inconvertibleErrorCode(),
+                                  "missing '-upstream-cas'"));
+    return import(*CAS, *UpstreamCAS, Objects);
+  }
+
+  if (Command == PutCacheKey) {
+    if (!AC)
+      ExitOnErr(createStringError(inconvertibleErrorCode(),
+                                  "no action-cache available"));
+    return putCacheKey(*CAS, *AC, Objects);
+  }
+
+  // Remaining commands need exactly one CAS object.
   if (Objects.size() > 1)
     ExitOnErr(createStringError(inconvertibleErrorCode(),
                                 "too many <object>s, expected 1"));
@@ -469,6 +503,52 @@ int getCASIDForFile(ObjectStore &CAS, const CASID &ID, StringRef Path) {
 
   CASID FileID = CAS.getID(**FileRef);
   outs() << FileID << "\n";
+  return 0;
+}
+
+static ObjectRef importNode(ObjectStore &CAS, ObjectStore &UpstreamCAS,
+                            const CASID &ID) {
+  ExitOnError ExitOnErr("llvm-cas: import: ");
+
+  std::optional<ObjectRef> PrimaryRef = CAS.getReference(ID);
+  if (PrimaryRef)
+    return *PrimaryRef; // object is present.
+
+  ObjectProxy UpstreamObj = ExitOnErr(UpstreamCAS.getProxy(ID));
+  SmallVector<ObjectRef> Refs;
+  ExitOnErr(UpstreamObj.forEachReference([&](ObjectRef UpstreamRef) -> Error {
+    ObjectRef Ref =
+        importNode(CAS, UpstreamCAS, UpstreamCAS.getID(UpstreamRef));
+    Refs.push_back(Ref);
+    return Error::success();
+  }));
+  return ExitOnErr(CAS.storeFromString(Refs, UpstreamObj.getData()));
+}
+
+static int import(ObjectStore &CAS, ObjectStore &UpstreamCAS,
+                  ArrayRef<std::string> Objects) {
+  ExitOnError ExitOnErr("llvm-cas: import: ");
+
+  for (StringRef Object : Objects) {
+    CASID ID = ExitOnErr(CAS.parseID(Object));
+    importNode(CAS, UpstreamCAS, ID);
+  }
+  return 0;
+}
+
+static int putCacheKey(ObjectStore &CAS, ActionCache &AC,
+                       ArrayRef<std::string> Objects) {
+  ExitOnError ExitOnErr("llvm-cas: put-cache-key: ");
+
+  if (Objects.size() % 2 != 0)
+    ExitOnErr(createStringError(inconvertibleErrorCode(),
+                                "expected pairs of inputs"));
+  while (!Objects.empty()) {
+    CASID Key = ExitOnErr(CAS.parseID(Objects[0]));
+    CASID Result = ExitOnErr(CAS.parseID(Objects[1]));
+    Objects = Objects.drop_front(2);
+    ExitOnErr(AC.put(Key, Result));
+  }
   return 0;
 }
 

--- a/llvm/tools/llvm-libtool-darwin/llvm-libtool-darwin.cpp
+++ b/llvm/tools/llvm-libtool-darwin/llvm-libtool-darwin.cpp
@@ -812,10 +812,7 @@ static Expected<Config> parseCommandLine(int Argc, char **Argv) {
     return createStringError(std::errc::invalid_argument,
                              "plugin CAS not supported");
   } else if (CASSelection == CASKind::Builtin) {
-    std::string CASPath = CASBuiltinPath;
-    if (CASPath.empty())
-      CASPath = llvm::cas::getDefaultOnDiskCASStableID();
-    auto MaybeCAS = cas::createOnDiskCAS(CASPath);
+    auto MaybeCAS = cas::createCASFromIdentifier(CASBuiltinPath);
     if (Error E = MaybeCAS.takeError())
       return std::move(E);
     C.CAS = std::move(*MaybeCAS);

--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -536,9 +536,7 @@ int main(int argc, char **argv) {
   if (CASPath.empty())
     CAS = cas::createInMemoryCAS();
   else {
-    auto MaybeCAS = CASPath == "auto"
-                        ? cas::createOnDiskCAS(cas::getDefaultOnDiskCASPath())
-                        : cas::createOnDiskCAS(CASPath);
+    auto MaybeCAS = cas::createCASFromIdentifier(CASPath);
     if (!MaybeCAS) {
       WithColor::error() << toString(MaybeCAS.takeError()) << "\n";
       return 1;

--- a/llvm/tools/llvm-remote-cache-test/llvm-remote-cache-test.cpp
+++ b/llvm/tools/llvm-remote-cache-test/llvm-remote-cache-test.cpp
@@ -76,18 +76,14 @@ int main(int Argc, const char **Argv) {
 
   SmallString<256> CASPath(CachePath);
   sys::path::append(CASPath, "cas");
-  auto CAS = createOnDiskCAS(CASPath);
-  if (!CAS)
-    ExitOnErr(CAS.takeError());
-
-  auto Cache = createOnDiskActionCache(CASPath);
-  if (!Cache)
-    ExitOnErr(Cache.takeError());
+  std::unique_ptr<ObjectStore> CAS;
+  std::unique_ptr<ActionCache> AC;
+  std::tie(CAS, AC) = ExitOnErr(createOnDiskUnifiedCASDatabases(CASPath));
 
   auto createServer = [&]() -> remote::RemoteCacheServer {
     return remote::RemoteCacheServer(
-        SocketPath, remote::createLLVMCASCacheProvider(
-                        TempPath, std::move(*CAS), std::move(*Cache)));
+        SocketPath, remote::createLLVMCASCacheProvider(TempPath, std::move(CAS),
+                                                       std::move(AC)));
   };
 
   if (ServerMode) {

--- a/llvm/tools/llvm-remote-cache-test/llvm-remote-cache-test.cpp
+++ b/llvm/tools/llvm-remote-cache-test/llvm-remote-cache-test.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/RemoteCachingService/LLVMCASCacheProvider.h"
 #include "llvm/RemoteCachingService/RemoteCacheProvider.h"


### PR DESCRIPTION
Notable changes:

* Having a separate flag for on-disk path for `ActionCache` becomes redundant (only one on-disk path for CAS/cache configuration is sufficient), so `-faction-cache-path` and related flags of testing tools are removed.
* To accomodate testing, other testing tools adopt `UnifiedOnDiskCache` as well.
* `llvm-cas` gets new functionality to accomodate testing:
  * `-import`: import objects from another CAS
  * `-put-cache-key`: set a value for a cache key

Note that clang opens a `UnifiedOnDiskCache` without imposing any size limit, it is assumed that a higher level service, e.g. the build system or the clang daemon, is going to be responsible for managing growth of the CAS databases during a build.