### PR TITLE
[CAS] Avoid using `mmap` for `storeFromOpenFileImpl`

### DIFF
--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -172,7 +172,7 @@ protected:
   /// Get ObjectRef from open file.
   virtual Expected<ObjectRef>
   storeFromOpenFileImpl(sys::fs::file_t FD,
-                        Optional<sys::fs::file_status> Status) = 0;
+                        Optional<sys::fs::file_status> Status);
 
   /// Get a lifetime-extended StringRef pointing at \p Data.
   ///
@@ -245,6 +245,9 @@ public:
     OS << toStringRef(Data);
     return Data.size();
   }
+
+  /// Validate the whole node tree.
+  Error validateTree(ObjectRef Ref);
 
   /// Print the ObjectStore internals for debugging purpose.
   virtual void print(raw_ostream &) const {}

--- a/llvm/lib/CAS/BuiltinCAS.cpp
+++ b/llvm/lib/CAS/BuiltinCAS.cpp
@@ -49,57 +49,6 @@ const BuiltinCASContext &BuiltinCASContext::getDefaultContext() {
   return DefaultContext;
 }
 
-static size_t getPageSize() {
-  static int PageSize = sys::Process::getPageSizeEstimate();
-  return PageSize;
-}
-
-Expected<ObjectRef>
-BuiltinCAS::storeFromOpenFileImpl(sys::fs::file_t FD,
-                                  Optional<sys::fs::file_status> Status) {
-  int PageSize = getPageSize();
-
-  if (!Status) {
-    Status.emplace();
-    if (std::error_code EC = sys::fs::status(FD, *Status))
-      return errorCodeToError(EC);
-  }
-
-  constexpr size_t MinMappedSize = 4 * 4096;
-  auto readWithStream = [&]() -> Expected<ObjectRef> {
-    // FIXME: MSVC: SmallString<MinMappedSize * 2>
-    SmallString<4 * 4096 * 2> Data;
-    if (Error E = sys::fs::readNativeFileToEOF(FD, Data, MinMappedSize))
-      return std::move(E);
-    return store(std::nullopt, ArrayRef(Data.data(), Data.size()));
-  };
-
-  // Check whether we can trust the size from stat.
-  if (Status->type() != sys::fs::file_type::regular_file &&
-      Status->type() != sys::fs::file_type::block_file)
-    return readWithStream();
-
-  if (Status->getSize() < MinMappedSize)
-    return readWithStream();
-
-  std::error_code EC;
-  sys::fs::mapped_file_region Map(FD, sys::fs::mapped_file_region::readonly,
-                                  Status->getSize(),
-                                  /*offset=*/0, EC);
-  if (EC)
-    return errorCodeToError(EC);
-
-  // If the file is guaranteed to be null-terminated, use it directly. Note
-  // that the file size may have changed from ::stat if this file is volatile,
-  // so we need to check for an actual null character at the end.
-  ArrayRef<char> Data(Map.data(), Map.size());
-  HashType ComputedHash =
-      BuiltinObjectHasher<HasherT>::hashObject(*this, std::nullopt, Data);
-  if (!isAligned(Align(PageSize), Data.size()) && Data.end()[0] == 0)
-    return storeFromNullTerminatedRegion(ComputedHash, std::move(Map));
-  return storeImpl(ComputedHash, std::nullopt, Data);
-}
-
 Expected<ObjectRef> BuiltinCAS::store(ArrayRef<ObjectRef> Refs,
                                       ArrayRef<char> Data) {
   return storeImpl(BuiltinObjectHasher<HasherT>::hashObject(*this, Refs, Data),

--- a/llvm/lib/CAS/BuiltinCAS.h
+++ b/llvm/lib/CAS/BuiltinCAS.h
@@ -96,9 +96,6 @@ public:
                                         ArrayRef<ObjectRef> Refs,
                                         ArrayRef<char> Data) = 0;
 
-  Expected<ObjectRef>
-  storeFromOpenFileImpl(sys::fs::file_t FD,
-                        Optional<sys::fs::file_status> Status) override;
   virtual Expected<ObjectRef>
   storeFromNullTerminatedRegion(ArrayRef<uint8_t> ComputedHash,
                                 sys::fs::mapped_file_region Map) {

--- a/llvm/lib/CAS/HierarchicalTreeBuilder.cpp
+++ b/llvm/lib/CAS/HierarchicalTreeBuilder.cpp
@@ -254,5 +254,12 @@ Expected<ObjectProxy> HierarchicalTreeBuilder::create(ObjectStore &CAS) {
     T->Ref = ExpectedTree->getRef();
   }
 
-  return cantFail(CAS.getProxy(*Root.Ref));
+  Expected<ObjectProxy> Obj = cantFail(CAS.getProxy(*Root.Ref));
+#ifndef NDEBUG
+  if (Obj) {
+    if (Error E = CAS.validateTree(Obj->getRef()))
+      return std::move(E);
+  }
+#endif
+  return Obj;
 }


### PR DESCRIPTION
`mmap` is unsafe since the contents of the mapped region may change after we get the contents digest. This manifested as an issue in linux, where all the tests doing

```
llvm-cas --cas %t/cas --ingest --data %t
```

were ingesting the files of the CAS directory itself, and were creating invalid objects.