### PR TITLE
Refactor: clear up some code for readability

### DIFF
--- a/clang/lib/Tooling/Refactor/RefactoringContinuations.h
+++ b/clang/lib/Tooling/Refactor/RefactoringContinuations.h
@@ -303,7 +303,7 @@ private:
   gatherQueries(std::index_sequence<Is...>) {
     assert(Inputs && "TU-dependent state is already converted");
     std::vector<indexer::IndexerQuery *> Queries;
-    std::make_tuple(gatherQueries(Queries, std::get<Is>(*Inputs))...);
+    (gatherQueries(Queries, std::get<Is>(*Inputs)), ...);
     return Queries;
   }
 


### PR DESCRIPTION
The function used `std::make_tuple` to construct the tuple to walk the tuple.  However, this was confusing as the result of the tuple was discarded.  Use a C++17 feature of packed tuple to fold the expression and build the query set.

This can be further simplified by folding this helper into the single caller and using `std::apply`:

~~~
std::vector<indexer::IndexerQuery *>
getAdditionalIndexerQueries() override {
  assert(Inputs && "TU-dependent state is already converted");
  std::vector<indexer::IndexerQuery *> Queries;
  std::apply([&this](auto && ...inputs) {
    (gatherQueries(Queries, std::get<Is>(*Inputs)), ...);
  }, *Inputs);
  return Queries;
}
~~~