### PR TITLE
[debugserver] Add one additional sleep before attaching after waiting

### DIFF
--- a/lldb/tools/debugserver/source/DNB.cpp
+++ b/lldb/tools/debugserver/source/DNB.cpp
@@ -793,6 +793,14 @@ DNBProcessAttachWait(RNBContext *ctx, const char *waitfor_process_name,
   if (waitfor_pid != INVALID_NUB_PROCESS) {
     DNBLogThreadedIf(LOG_PROCESS, "Attaching to %s with pid %i...\n",
                      waitfor_process_name, waitfor_pid);
+    // In some cases, we attempt to attach during the transition from
+    // /usr/lib/dyld to the dyld in the shared cache. If that happens, we may
+    // end up in a state where there is no dyld in the process and from there
+    // the debugging session is doomed.
+    // In an attempt to make this scenario much less likely, we sleep
+    // for an additional `waitfor_interval` number of microseconds before
+    // attaching.
+    ::usleep(waitfor_interval);
     waitfor_pid = DNBProcessAttach(waitfor_pid, timeout_abstime,
                                    ctx->GetIgnoredExceptions(), err_str, 
                                    err_len);


### PR DESCRIPTION
It's possible for debugserver to attach to a process during the handoff between /usr/lib/dyld and the dyld in the shared cache. When that happens, we may end up in a state where there is no dyld in the process and our debugging session is doomed. To make that scenario a lot less likely, we can insert a sleep right before attaching after waiting to find the right pid.

rdar://105513180

Differential Revision: https://reviews.llvm.org/D144311

(cherry picked from commit 97b579d3140476cd32d94a6e052f0908e2c21228)