### PR TITLE
[ODRHash] Rename `isDeclToBeProcessed` to `isSubDeclToBeProcessed`. NFC intended.

### DIFF
--- a/clang/include/clang/AST/ODRDiagsEmitter.h
+++ b/clang/include/clang/AST/ODRDiagsEmitter.h
@@ -59,7 +59,7 @@ private:
 
   // Used with err_module_odr_violation_mismatch_decl and
   // note_module_odr_violation_mismatch_decl
-  // This list should be the same Decl's as in ODRHash::isDeclToBeProcessed
+  // This list should be the same Decl's as in ODRHash::isSubDeclToBeProcessed
   enum ODRMismatchDecl {
     EndOfClass,
     PublicSpecifer,

--- a/clang/include/clang/AST/ODRHash.h
+++ b/clang/include/clang/AST/ODRHash.h
@@ -93,7 +93,7 @@ public:
   // Save booleans until the end to lower the size of data to process.
   void AddBoolean(bool value);
 
-  static bool isDeclToBeProcessed(const Decl* D, const DeclContext *Parent);
+  static bool isSubDeclToBeProcessed(const Decl *D, const DeclContext *Parent);
 
 private:
   void AddDeclarationNameImpl(DeclarationName Name);

--- a/clang/lib/AST/ODRDiagsEmitter.cpp
+++ b/clang/lib/AST/ODRDiagsEmitter.cpp
@@ -571,7 +571,7 @@ bool ODRDiagsEmitter::diagnoseMismatch(
   auto PopulateHashes = [](DeclHashes &Hashes, const RecordDecl *Record,
                            const DeclContext *DC) {
     for (const Decl *D : Record->decls()) {
-      if (!ODRHash::isDeclToBeProcessed(D, DC))
+      if (!ODRHash::isSubDeclToBeProcessed(D, DC))
         continue;
       Hashes.emplace_back(D, computeODRHash(D));
     }
@@ -1279,7 +1279,7 @@ bool ODRDiagsEmitter::diagnoseMismatch(const RecordDecl *FirstRecord,
   auto PopulateHashes = [](DeclHashes &Hashes, const RecordDecl *Record,
                            const DeclContext *DC) {
     for (const Decl *D : Record->decls()) {
-      if (!ODRHash::isDeclToBeProcessed(D, DC))
+      if (!ODRHash::isSubDeclToBeProcessed(D, DC))
         continue;
       Hashes.emplace_back(D, computeODRHash(D));
     }
@@ -1571,7 +1571,7 @@ bool ODRDiagsEmitter::diagnoseMismatch(const EnumDecl *FirstEnum,
     for (const Decl *D : Enum->decls()) {
       // Due to decl merging, the first EnumDecl is the parent of
       // Decls in both records.
-      if (!ODRHash::isDeclToBeProcessed(D, FirstEnum))
+      if (!ODRHash::isSubDeclToBeProcessed(D, FirstEnum))
         continue;
       assert(isa<EnumConstantDecl>(D) && "Unexpected Decl kind");
       Hashes.emplace_back(cast<EnumConstantDecl>(D), computeODRHash(D));

--- a/clang/lib/AST/ODRHash.cpp
+++ b/clang/lib/AST/ODRHash.cpp
@@ -441,7 +441,7 @@ public:
 
 // Only allow a small portion of Decl's to be processed.  Remove this once
 // all Decl's can be handled.
-bool ODRHash::isDeclToBeProcessed(const Decl *D, const DeclContext *Parent) {
+bool ODRHash::isSubDeclToBeProcessed(const Decl *D, const DeclContext *Parent) {
   if (D->isImplicit()) return false;
   if (D->getDeclContext() != Parent) return false;
 
@@ -488,7 +488,7 @@ void ODRHash::AddCXXRecordDecl(const CXXRecordDecl *Record) {
   // accurate count of Decl's.
   llvm::SmallVector<const Decl *, 16> Decls;
   for (Decl *SubDecl : Record->decls()) {
-    if (isDeclToBeProcessed(SubDecl, Record)) {
+    if (isSubDeclToBeProcessed(SubDecl, Record)) {
       Decls.push_back(SubDecl);
       if (auto *Function = dyn_cast<FunctionDecl>(SubDecl)) {
         // Compute/Preload ODRHash into FunctionDecl.
@@ -526,7 +526,7 @@ void ODRHash::AddRecordDecl(const RecordDecl *Record) {
   // accurate count of Decl's.
   llvm::SmallVector<const Decl *, 16> Decls;
   for (Decl *SubDecl : Record->decls()) {
-    if (isDeclToBeProcessed(SubDecl, Record))
+    if (isSubDeclToBeProcessed(SubDecl, Record))
       Decls.push_back(SubDecl);
   }
 
@@ -607,7 +607,7 @@ void ODRHash::AddFunctionDecl(const FunctionDecl *Function,
   // accurate count of Decl's.
   llvm::SmallVector<const Decl *, 16> Decls;
   for (Decl *SubDecl : Function->decls()) {
-    if (isDeclToBeProcessed(SubDecl, Function)) {
+    if (isSubDeclToBeProcessed(SubDecl, Function)) {
       Decls.push_back(SubDecl);
     }
   }
@@ -633,7 +633,7 @@ void ODRHash::AddEnumDecl(const EnumDecl *Enum) {
   // accurate count of Decl's.
   llvm::SmallVector<const Decl *, 16> Decls;
   for (Decl *SubDecl : Enum->decls()) {
-    if (isDeclToBeProcessed(SubDecl, Enum)) {
+    if (isSubDeclToBeProcessed(SubDecl, Enum)) {
       assert(isa<EnumConstantDecl>(SubDecl) && "Unexpected Decl");
       Decls.push_back(SubDecl);
     }


### PR DESCRIPTION
The method is used only for sub-Decls, so reflect that in the name.

(cherry picked from commit 37fdca21f7f61dee5426f55b0ee7bf601d95afcd)