### PR TITLE
[llvm][cas] Make it an error to --ingest the CAS itself

### DIFF
--- a/clang/test/CAS/fmodule-file-cache-key-errors.c
+++ b/clang/test/CAS/fmodule-file-cache-key-errors.c
@@ -3,16 +3,16 @@
 
 // REQUIRES: ondisk_cas
 
-// RUN: rm -rf %t
+// RUN: rm -rf %t %t.cas %t.cas_2
 // RUN: split-file %s %t
 
-// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+// RUN: llvm-cas --cas %t.cas --ingest --data %t > %t/casid
 
 // RUN: not %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   -fmodule-file-cache-key=INVALID \
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/invalid.txt
 // RUN: cat %t/invalid.txt | FileCheck %s -check-prefix=INVALID
 
@@ -22,7 +22,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   -fmodule-file-cache-key=PATH=KEY \
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/bad_key.txt
 // RUN: cat %t/bad_key.txt | FileCheck %s -check-prefix=BAD_KEY
 
@@ -35,7 +35,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/bad_key2.rsp \
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/bad_key2.txt
 // RUN: cat %t/bad_key2.txt | FileCheck %s -check-prefix=BAD_KEY2
 
@@ -46,7 +46,7 @@
 // RUN: %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
 // RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
 // RUN: cat %t/A.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 // CACHE-MISS: remark: compile job cache miss
@@ -54,7 +54,7 @@
 
 // == Try to import A with an empty action cache, simulating a missing module
 
-// RUN: llvm-cas --cas %t/cas_2 --import --upstream-cas %t/cas @%t/A.key
+// RUN: llvm-cas --cas %t.cas_2 --import --upstream-cas %t.cas @%t/A.key
 
 // RUN: echo -n '-fmodule-file-cache-key=PATH=' > %t/not_in_cache.rsp
 // RUN: cat %t/A.key >> %t/not_in_cache.rsp
@@ -63,7 +63,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/not_in_cache.rsp \
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas_2 -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas_2 -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/not_in_cache.txt
 // RUN: cat %t/not_in_cache.txt | FileCheck %s -check-prefix=NOT_IN_CACHE -DPREFIX=%/t
 

--- a/clang/test/CAS/fmodule-file-cache-key-lazy.c
+++ b/clang/test/CAS/fmodule-file-cache-key-lazy.c
@@ -3,17 +3,17 @@
 
 // REQUIRES: ondisk_cas
 
-// RUN: rm -rf %t
+// RUN: rm -rf %t %t.cas
 // RUN: split-file %s %t
 
-// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+// RUN: llvm-cas --cas %t.cas --ingest --data %t > %t/casid
 
 // == Build B
 
 // RUN: %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fmodule-name=B -fno-implicit-modules \
 // RUN:   -emit-module %t/module.modulemap -o %t/B.pcm \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.txt
 // RUN: cat %t/B.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: cat %t/B.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/B.key
@@ -27,7 +27,7 @@
 // RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
 // RUN:   @%t/B.import.rsp -fmodule-file=B=%t/B.pcm \
 // RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
 // RUN: cat %t/A.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: cat %t/A.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/A.key
@@ -41,7 +41,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/A.import.rsp -fmodule-file=A=%t/A.pcm \
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.txt
 // RUN: cat %t/tu.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 
@@ -53,7 +53,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/A.import.rsp -fmodule-file=A=%t/A.pcm \
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.2.txt
 // RUN: cat %t/tu.out.2.txt | FileCheck %s --check-prefix=CACHE-HIT
 

--- a/clang/test/CAS/fmodule-file-cache-key-with-pch.c
+++ b/clang/test/CAS/fmodule-file-cache-key-with-pch.c
@@ -4,17 +4,17 @@
 
 // REQUIRES: ondisk_cas
 
-// RUN: rm -rf %t
+// RUN: rm -rf %t %t.cas
 // RUN: split-file %s %t
 
-// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+// RUN: llvm-cas --cas %t.cas --ingest --data %t > %t/casid
 
 // == Build B
 
 // RUN: %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fmodule-name=B -fno-implicit-modules \
 // RUN:   -emit-module %t/module.modulemap -o %t/B.pcm \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.txt
 // RUN: cat %t/B.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: cat %t/B.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/B.key
@@ -28,7 +28,7 @@
 // RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
 // RUN:   @%t/B.import.rsp -fmodule-file=%t/B.pcm \
 // RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
 // RUN: cat %t/A.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: cat %t/A.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/A.key
@@ -39,7 +39,7 @@
 // RUN:   -fmodules -fmodule-name=C -fno-implicit-modules \
 // RUN:   @%t/B.import.rsp -fmodule-file=%t/B.pcm \
 // RUN:   -emit-module %t/module.modulemap -o %t/C.pcm \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/C.out.txt
 // RUN: cat %t/C.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: cat %t/C.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/C.key
@@ -53,14 +53,14 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/A.import.rsp -fmodule-file=%t/A.pcm \
 // RUN:   -emit-pch -x c-header %t/prefix.h -o %t/prefix.pch \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/prefix.out.txt
 // RUN: cat %t/prefix.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 
 // == Clear pcms to ensure they load from cache, and re-ingest with pch
 
 // RUN: rm %t/*.pcm
-// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+// RUN: llvm-cas --cas %t.cas --ingest --data %t > %t/casid
 // RUN: rm %t/*.pch
 
 // == Build tu
@@ -72,7 +72,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/C.import.rsp -fmodule-file=%t/C.pcm -include-pch %t/prefix.pch \
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.txt
 // RUN: cat %t/tu.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 
@@ -82,7 +82,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/C.import.rsp -fmodule-file=%t/C.pcm -include-pch %t/prefix.pch \
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.2.txt
 // RUN: cat %t/tu.out.2.txt | FileCheck %s --check-prefix=CACHE-HIT
 

--- a/clang/test/CAS/fmodule-file-cache-key.c
+++ b/clang/test/CAS/fmodule-file-cache-key.c
@@ -3,17 +3,17 @@
 
 // REQUIRES: ondisk_cas
 
-// RUN: rm -rf %t
+// RUN: rm -rf %t %t.cas
 // RUN: split-file %s %t
 
-// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+// RUN: llvm-cas --cas %t.cas --ingest --data %t > %t/casid
 
 // == Build B
 
 // RUN: %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fmodule-name=B -fno-implicit-modules \
 // RUN:   -emit-module %t/module.modulemap -o %t/B.pcm \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.txt
 // RUN: cat %t/B.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: cat %t/B.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/B.key
@@ -27,7 +27,7 @@
 // RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
 // RUN:   @%t/B.import.rsp -fmodule-file=%t/B.pcm \
 // RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
 // RUN: cat %t/A.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 // RUN: cat %t/A.out.txt | sed -E "s:^.*cache [a-z]+ for '([^']+)'.*$:\1:" > %t/A.key
@@ -41,7 +41,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/A.import.rsp -fmodule-file=%t/A.pcm\
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.txt
 // RUN: cat %t/tu.out.txt | FileCheck %s --check-prefix=CACHE-MISS
 
@@ -53,7 +53,7 @@
 // RUN:   -fmodules -fno-implicit-modules \
 // RUN:   @%t/A.import.rsp -fmodule-file=%t/A.pcm\
 // RUN:   -fsyntax-only %t/tu.c \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/tu.out.2.txt
 // RUN: cat %t/tu.out.2.txt | FileCheck %s --check-prefix=CACHE-HIT
 

--- a/clang/test/CAS/output-path-create-directories.c
+++ b/clang/test/CAS/output-path-create-directories.c
@@ -1,6 +1,6 @@
-// RUN: rm -rf %t
+// RUN: rm -rf %t %t.cas
 // RUN: split-file %s %t
-// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+// RUN: llvm-cas --cas %t.cas --ingest --data %t > %t/casid
 
 // RUN: %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fmodule-name=Mod -fno-implicit-modules \
@@ -13,7 +13,7 @@
 // RUN:   -fmodules -fmodule-name=Mod -fno-implicit-modules \
 // RUN:   -emit-module %t/module.modulemap -o %t/out_miss/B.pcm \
 // RUN:   -serialize-diagnostic-file %t/out_miss/B.dia \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.txt
 // RUN: cat %t/B.out.txt | FileCheck %s -check-prefix=CACHE-MISS
 // RUN: ls %t/out_miss/B.pcm
@@ -23,7 +23,7 @@
 // RUN:   -fmodules -fmodule-name=Mod -fno-implicit-modules \
 // RUN:   -emit-module %t/module.modulemap -o %t/out_hit/B.pcm \
 // RUN:   -serialize-diagnostic-file %t/out_hit/B.dia \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/B.out.hit.txt
 // RUN: cat %t/B.out.hit.txt | FileCheck %s -check-prefix=CACHE-HIT
 // RUN: ls %t/out_hit/B.pcm

--- a/clang/test/CAS/test-for-deterministic-module.c
+++ b/clang/test/CAS/test-for-deterministic-module.c
@@ -2,12 +2,12 @@
 
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: llvm-cas --cas %t/cas --ingest --data %t > %t/casid
+// RUN: llvm-cas --cas %t.cas --ingest --data %t > %t/casid
 //
 // RUN: not %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \
 // RUN:   -emit-module %t/module.modulemap -o %t/A.pcm \
-// RUN:   -fcas-path %t/cas -fcas-fs @%t/casid \
+// RUN:   -fcas-path %t.cas -fcas-fs @%t/casid \
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/A.out.txt
 // RUN: FileCheck %s --input-file=%t/A.out.txt
 

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -48,7 +48,8 @@ static int makeNode(ObjectStore &CAS, ArrayRef<std::string> References,
                     StringRef DataPath);
 static int diffGraphs(ObjectStore &CAS, const CASID &LHS, const CASID &RHS);
 static int traverseGraph(ObjectStore &CAS, const CASID &ID);
-static int ingestFileSystem(ObjectStore &CAS, StringRef Path);
+static int ingestFileSystem(ObjectStore &CAS, std::optional<StringRef> CASPath,
+                            StringRef Path);
 static int mergeTrees(ObjectStore &CAS, ArrayRef<std::string> Objects);
 static int getCASIDForFile(ObjectStore &CAS, const CASID &ID, StringRef Path);
 static int import(ObjectStore &CAS, ObjectStore &UpstreamCAS,
@@ -128,10 +129,13 @@ int main(int Argc, char **Argv) {
 
   std::unique_ptr<ObjectStore> CAS;
   std::unique_ptr<ActionCache> AC;
-  if (sys::path::is_absolute(CASPath))
+  std::optional<StringRef> CASFilePath;
+  if (sys::path::is_absolute(CASPath)) {
+    CASFilePath = CASPath;
     std::tie(CAS, AC) = ExitOnErr(createOnDiskUnifiedCASDatabases(CASPath));
-  else
+  } else {
     CAS = ExitOnErr(createCASFromIdentifier(CASPath));
+  }
   assert(CAS);
 
   std::unique_ptr<ObjectStore> UpstreamCAS;
@@ -160,7 +164,7 @@ int main(int Argc, char **Argv) {
   }
 
   if (Command == IngestFileSystem)
-    return ingestFileSystem(*CAS, DataPath);
+    return ingestFileSystem(*CAS, CASFilePath, DataPath);
 
   if (Command == MergeTrees)
     return mergeTrees(*CAS, Objects);
@@ -457,11 +461,31 @@ static Expected<ObjectProxy> ingestFileSystemImpl(ObjectStore &CAS,
       });
 }
 
-int ingestFileSystem(ObjectStore &CAS, StringRef Path) {
+/// Check that we are not attempting to ingest the CAS into itself, which can
+/// accidentally create a weird or large cas.
+Error checkCASIngestPath(StringRef CASPath, StringRef DataPath) {
+  SmallString<128> RealCAS, RealData;
+  if (std::error_code EC = sys::fs::real_path(StringRef(CASPath), RealCAS))
+    return createFileError(CASPath, EC);
+  if (std::error_code EC = sys::fs::real_path(StringRef(DataPath), RealData))
+    return createFileError(CASPath, EC);
+  if (RealCAS.startswith(RealData) &&
+      (RealCAS.size() == RealData.size() ||
+       sys::path::is_separator(RealCAS[RealData.size()])))
+    return createStringError(inconvertibleErrorCode(),
+                             "-cas is inside -data directory, which would "
+                             "ingest the cas into itself");
+  return Error::success();
+}
+
+int ingestFileSystem(ObjectStore &CAS, std::optional<StringRef> CASPath,
+                     StringRef Path) {
   ExitOnError ExitOnErr("llvm-cas: ingest: ");
   if (Path.empty())
     ExitOnErr(
         createStringError(inconvertibleErrorCode(), "missing --data=<path>"));
+  if (CASPath)
+    ExitOnErr(checkCASIngestPath(*CASPath, Path));
   auto Ref = ExitOnErr(ingestFileSystemImpl(CAS, Path));
   outs() << Ref.getID() << "\n";
   return 0;


### PR DESCRIPTION
Ingesting the cas into itself is probably never intended, and it creates a strange result since the CAS is being mutated while it happens. Moreover, when CAS files are large it can double or more the size of the CAS.