### PR TITLE
Update debugserver xcode proj to build with c++17

### DIFF
--- a/lldb/tools/debugserver/debugserver.xcodeproj/project.pbxproj
+++ b/lldb/tools/debugserver/debugserver.xcodeproj/project.pbxproj
@@ -490,7 +490,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = "/bin/sh -x";
-			shellScript = "if [ \"${CONFIGURATION}\" != BuildAndIntegration ]\nthen\n    if [ -n \"${DEBUGSERVER_USE_FROM_SYSTEM}\" ]\n    then\n\t\tditto \"${DEVELOPER_DIR}/../SharedFrameworks/LLDB.framework/Resources/debugserver\" \"${TARGET_BUILD_DIR}/${TARGET_NAME}\"\n    elif [ \"${DEBUGSERVER_DISABLE_CODESIGN}\" == \"\" ]\n    then\n        codesign -f -s lldb_codesign --entitlements ${SRCROOT}/../../resources/debugserver-macosx-entitlements.plist \"${TARGET_BUILD_DIR}/${TARGET_NAME}\"\n    fi\nfi\n";
+			shellScript = "if [ \"${CONFIGURATION}\" != BuildAndIntegration ]\nthen\n    if [ -n \"${DEBUGSERVER_USE_FROM_SYSTEM}\" ]\n    then\n\t\tditto \"${DEVELOPER_DIR}/../SharedFrameworks/LLDB.framework/Resources/debugserver\" \"${TARGET_BUILD_DIR}/${TARGET_NAME}\"\n    elif [ \"${DEBUGSERVER_DISABLE_CODESIGN}\" == \"\" ]\n    then\n        codesign -f -s lldb_codesign --entitlements ${SRCROOT}/resources/debugserver-macosx-entitlements.plist \"${TARGET_BUILD_DIR}/${TARGET_NAME}\"\n    fi\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -664,7 +664,7 @@
 		26CE0596115C31C30022F371 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_CXX_LIBRARY = "libc++";
 				"CODE_SIGN_ENTITLEMENTS[sdk=*]" = "source/debugserver-entitlements.plist";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "source/debugserver-macosx-entitlements.plist";
@@ -764,7 +764,7 @@
 		26CE0597115C31C30022F371 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_CXX_LIBRARY = "libc++";
 				"CODE_SIGN_ENTITLEMENTS[sdk=*]" = "source/debugserver-entitlements.plist";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "source/debugserver-macosx-entitlements.plist";

--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
@@ -3266,7 +3266,7 @@ pid_t MachProcess::LaunchForDebug(
         return m_pid; // A successful SBLaunchForDebug() returns and assigns a
                       // non-zero m_pid.
     }
-    DNBLog("Failed to launch '%s' with FBS", app_bundle_path);
+    DNBLog("Failed to launch '%s' with FBS", app_bundle_path.c_str());
   } break;
 #endif
 #ifdef WITH_BKS
@@ -3280,7 +3280,7 @@ pid_t MachProcess::LaunchForDebug(
         return m_pid; // A successful SBLaunchForDebug() returns and assigns a
                       // non-zero m_pid.
     }
-    DNBLog("Failed to launch '%s' with BKS", app_bundle_path);
+    DNBLog("Failed to launch '%s' with BKS", app_bundle_path.c_str());
   } break;
 #endif
 #ifdef WITH_SPRINGBOARD
@@ -3292,7 +3292,7 @@ pid_t MachProcess::LaunchForDebug(
         return m_pid; // A successful SBLaunchForDebug() returns and assigns a
                       // non-zero m_pid.
     }
-    DNBLog("Failed to launch '%s' with SpringBoard", app_bundle_path);
+    DNBLog("Failed to launch '%s' with SpringBoard", app_bundle_path.c_str());
   } break;
 
 #endif


### PR DESCRIPTION
Update debugserver xcode proj to build with c++17

Also a few small fixes for building debugserver on iOS in c++17.

(cherry picked from commit b22dcaf113280278293639a02207edf78d103fb8)