### PR TITLE
Remove -fcas-friendly-debug-info option and LLVM IR Metadata for cas friendliness, and replace it with an -mllvm option in DwarfDebug.cpp

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -390,9 +390,6 @@ VALUE_CODEGENOPT(SSPBufferSize, 32, 0)
 /// The kind of generated debug info.
 ENUM_CODEGENOPT(DebugInfo, codegenoptions::DebugInfoKind, 4, codegenoptions::NoDebugInfo)
 
-/// How to split up the debug info.
-ENUM_CODEGENOPT(CasFriendliness, codegenoptions::CasFriendlinessKind, 1, codegenoptions::NoCasFriendlyDebugInfo)
-
 /// Whether to make debug info reproducible.
 CODEGENOPT(ReproducibleDebugInfo, 1, 0)
 

--- a/clang/include/clang/Basic/DebugInfoOptions.h
+++ b/clang/include/clang/Basic/DebugInfoOptions.h
@@ -17,16 +17,6 @@ enum DebugInfoFormat {
   DIF_CodeView,
 };
 
-enum CasFriendlinessKind {
-  NoCasFriendlyDebugInfo,
-
-  /// Generate CAS friendly debug info to go along with the work being done for
-  /// llvm-cas. This option will make the line table split-able by inserting a
-  /// DW_LNE_end_sequence at the end of a function's contribution to a line
-  /// table.
-  DebugLineOnly,
-};
-
 enum DebugInfoKind {
   /// Don't generate debug info.
   NoDebugInfo,

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -369,9 +369,6 @@ def warn_drv_unsupported_opt_for_target : Warning<
 def warn_drv_unsupported_debug_info_opt_for_target : Warning<
   "debug information option '%0' is not supported for target '%1'">,
   InGroup<UnsupportedTargetOpt>;
-def warn_drv_unsupported_cas_friendliness_opt_for_target : Warning<
-  "cas friendliness option '%0' is not supported for target '%1'">,
-  InGroup<UnsupportedTargetOpt>;
 def warn_drv_dwarf_version_limited_by_target : Warning<
   "debug information option '%0' is not supported; requires DWARF-%2 but "
   "target '%1' only provides DWARF-%3">,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2893,9 +2893,6 @@ def ftrivial_auto_var_init_stop_after : Joined<["-"], "ftrivial-auto-var-init-st
   MarshallingInfoInt<LangOpts<"TrivialAutoVarInitStopAfter">>;
 def fstandalone_debug : Flag<["-"], "fstandalone-debug">, Group<f_Group>, Flags<[CoreOption]>,
   HelpText<"Emit full debug info for all types used by the program">;
-def fcas_friendly_debug_info : Joined<["-"], "fcas-friendly-debug-info=">, Group<f_Group>,
-  Flags<[CoreOption]>, HelpText<"Emit debug information that is cas friendly"
-  "debug-line-only: Only split up the debug_line section">;
 def fno_standalone_debug : Flag<["-"], "fno-standalone-debug">, Group<f_Group>, Flags<[CoreOption]>,
   HelpText<"Limit debug information produced to reduce size of debug binary">;
 def flimit_debug_info : Flag<["-"], "flimit-debug-info">, Flags<[CoreOption]>, Alias<fno_standalone_debug>;
@@ -5476,7 +5473,6 @@ def mrelocation_model : Separate<["-"], "mrelocation-model">,
 let Flags = [CC1Option, CC1AsOption, NoDriverOption] in {
 
 def debug_info_kind_EQ : Joined<["-"], "debug-info-kind=">;
-def cas_friendliness_kind_EQ : Joined<["-"], "cas-friendliness-kind=">;
 def debug_info_macro : Flag<["-"], "debug-info-macro">,
   HelpText<"Emit macro debug information">,
   MarshallingInfoFlag<CodeGenOpts<"MacroDebugInfo">>;

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -70,8 +70,6 @@ static uint32_t getDeclAlignIfRequired(const Decl *D, const ASTContext &Ctx) {
 
 CGDebugInfo::CGDebugInfo(CodeGenModule &CGM)
     : CGM(CGM), DebugKind(CGM.getCodeGenOpts().getDebugInfo()),
-      CasFriendliness(static_cast<codegenoptions::CasFriendlinessKind>(
-          CGM.getCodeGenOpts().getCasFriendliness())),
       DebugTypeExtRefs(CGM.getCodeGenOpts().DebugTypeExtRefs),
       DBuilder(CGM.getModule()) {
   for (const auto &KV : CGM.getCodeGenOpts().DebugPrefixMap)
@@ -619,16 +617,6 @@ void CGDebugInfo::CreateCompileUnit() {
     break;
   }
 
-  llvm::DICompileUnit::CasFriendlinessKind CasFriendlinessKind;
-  switch (CasFriendliness) {
-  case codegenoptions::NoCasFriendlyDebugInfo:
-    CasFriendlinessKind = llvm::DICompileUnit::NoCasFriendlyDebugInfo;
-    break;
-  case codegenoptions::DebugLineOnly:
-    CasFriendlinessKind = llvm::DICompileUnit::DebugLineOnly;
-    break;
-  }
-
   uint64_t DwoId = 0;
   auto &CGOpts = CGM.getCodeGenOpts();
   // The DIFile used by the CU is distinct from the main source
@@ -661,8 +649,7 @@ void CGDebugInfo::CreateCompileUnit() {
           ? llvm::DICompileUnit::DebugNameTableKind::None
           : static_cast<llvm::DICompileUnit::DebugNameTableKind>(
                 CGOpts.DebugNameTable),
-      CGOpts.DebugRangesBaseAddress, remapDIPath(Sysroot), SDK,
-      CasFriendlinessKind);
+      CGOpts.DebugRangesBaseAddress, remapDIPath(Sysroot), SDK);
 }
 
 llvm::DIType *CGDebugInfo::CreateType(const BuiltinType *BT) {

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -57,7 +57,6 @@ class CGDebugInfo {
   friend class SaveAndRestoreLocation;
   CodeGenModule &CGM;
   const codegenoptions::DebugInfoKind DebugKind;
-  const codegenoptions::CasFriendlinessKind CasFriendliness;
   bool DebugTypeExtRefs;
   llvm::DIBuilder DBuilder;
   llvm::DICompileUnit *TheCU = nullptr;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4283,15 +4283,6 @@ static void renderDebugOptions(const ToolChain &TC, const Driver &D,
   if (T.isOSBinFormatELF() && SplitDWARFInlining)
     CmdArgs.push_back("-fsplit-dwarf-inlining");
 
-  if (const Arg *A = Args.getLastArg(options::OPT_fcas_friendly_debug_info)) {
-    StringRef ArgValue = A->getValue();
-    if (ArgValue == "debug-line-only")
-      CmdArgs.push_back("-cas-friendliness-kind=debug-line-only");
-    else
-      D.Diag(diag::warn_drv_unsupported_debug_info_opt_for_target)
-          << A->getAsString(Args) << TC.getTripleString();
-  }
-
   // After we've dealt with all combinations of things that could
   // make DebugInfoKind be other than None or DebugLineTablesOnly,
   // figure out if we need to "upgrade" it to standalone debug info.

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1523,18 +1523,6 @@ void CompilerInvocation::GenerateCodeGenArgs(
   if (DebugInfoVal)
     GenerateArg(Args, OPT_debug_info_kind_EQ, *DebugInfoVal, SA);
 
-  std::optional<StringRef> CasFriendlinessVal;
-  switch (Opts.CasFriendliness) {
-  case codegenoptions::NoCasFriendlyDebugInfo:
-    CasFriendlinessVal = std::nullopt;
-    break;
-  case codegenoptions::DebugLineOnly:
-    CasFriendlinessVal = "debug-line-only";
-    break;
-  }
-  if (CasFriendlinessVal)
-    GenerateArg(Args, OPT_cas_friendliness_kind_EQ, *CasFriendlinessVal, SA);
-
   for (const auto &Prefix : Opts.DebugPrefixMap)
     GenerateArg(Args, OPT_fdebug_prefix_map_EQ,
                 Prefix.first + "=" + Prefix.second, SA);
@@ -1776,15 +1764,6 @@ bool CompilerInvocation::ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args,
       Args.hasArg(OPT_fdirect_access_external_data) ||
       (!Args.hasArg(OPT_fno_direct_access_external_data) &&
        LangOpts->PICLevel == 0);
-
-  if (Arg *A = Args.getLastArg(OPT_cas_friendliness_kind_EQ)) {
-    unsigned Val = llvm::StringSwitch<unsigned>(A->getValue())
-                       .Case("debug-line-only", codegenoptions::DebugLineOnly)
-                       .Default(codegenoptions::NoCasFriendlyDebugInfo);
-
-    Opts.CasFriendliness =
-        static_cast<codegenoptions::CasFriendlinessKind>(Val);
-  }
 
   if (Arg *A = Args.getLastArg(OPT_debug_info_kind_EQ)) {
     unsigned Val =

--- a/clang/test/CodeGen/debug-info-cas-friendly-option-test.c
+++ b/clang/test/CodeGen/debug-info-cas-friendly-option-test.c
@@ -1,6 +1,0 @@
-// RUN: %clang -cc1 -debug-info-kind=standalone -cas-friendliness-kind=debug-line-only %s -emit-llvm -o - | FileCheck %s --check-prefix DEBUG_LINE_ONLY
-// DEBUG_LINE_ONLY: !DICompileUnit{{.+}}casFriendly: DebugLineOnly{{.*}}
-
-void foo() {
-  return;
-}

--- a/clang/test/Driver/debug-options.c
+++ b/clang/test/Driver/debug-options.c
@@ -306,15 +306,6 @@
 // RUN: %clang -### -gno-modules %s 2>&1 | FileCheck -check-prefix=GNOMOD %s
 //
 
-// RUN: %clang -### -c -g -fcas-friendly-debug-info=debug-line-only %s -target x86_64-apple-darwin14 2>&1 \
-// RUN:             | FileCheck -check-prefix=F_CASFRIENDLY_DEBUG_LINE \
-// RUN:                         -check-prefix=G_DWARF2 \
-// RUN:                         -check-prefix=G_LLDB %s
-// RUN: %clang -### -c -g -fcas-friendly-debug-info=debug-line-only %s -target x86_64-apple-darwin16 2>&1 \
-// RUN:             | FileCheck -check-prefix=F_CASFRIENDLY_DEBUG_LINE \
-// RUN:                         -check-prefix=G_DWARF4 \
-// RUN:                         -check-prefix=G_LLDB %s
-
 // NOG_PS: "-cc1"
 // NOG_PS-NOT: "-dwarf-version=
 // NOG_PS: "-generate-arange-section"
@@ -354,8 +345,6 @@
 //
 // G_STANDALONE: "-cc1"
 // G_STANDALONE: "-debug-info-kind=standalone"
-// F_CASFRIENDLY_DEBUG_LINE: "-cc1"
-// F_CASFRIENDLY_DEBUG_LINE: "-cas-friendliness-kind=debug-line-only"
 // G_LIMITED: "-cc1"
 // G_LIMITED: "-debug-info-kind=constructor"
 // G_DWARF2: "-dwarf-version=2"

--- a/llvm/include/llvm/AsmParser/LLToken.h
+++ b/llvm/include/llvm/AsmParser/LLToken.h
@@ -454,25 +454,24 @@ enum Kind {
   SummaryID,  // ^42
 
   // String valued tokens (StrVal).
-  LabelStr,            // foo:
-  GlobalVar,           // @foo @"foo"
-  ComdatVar,           // $foo
-  LocalVar,            // %foo %"foo"
-  MetadataVar,         // !foo
-  StringConstant,      // "foo"
-  DwarfTag,            // DW_TAG_foo
-  DwarfAttEncoding,    // DW_ATE_foo
-  DwarfVirtuality,     // DW_VIRTUALITY_foo
-  DwarfLang,           // DW_LANG_foo
-  DwarfCC,             // DW_CC_foo
-  EmissionKind,        // lineTablesOnly
-  CasFriendlinessKind, // casFriendliness
-  NameTableKind,       // GNU
-  DwarfOp,             // DW_OP_foo
-  DIFlag,              // DIFlagFoo
-  DISPFlag,            // DISPFlagFoo
-  DwarfMacinfo,        // DW_MACINFO_foo
-  ChecksumKind,        // CSK_foo
+  LabelStr,         // foo:
+  GlobalVar,        // @foo @"foo"
+  ComdatVar,        // $foo
+  LocalVar,         // %foo %"foo"
+  MetadataVar,      // !foo
+  StringConstant,   // "foo"
+  DwarfTag,         // DW_TAG_foo
+  DwarfAttEncoding, // DW_ATE_foo
+  DwarfVirtuality,  // DW_VIRTUALITY_foo
+  DwarfLang,        // DW_LANG_foo
+  DwarfCC,          // DW_CC_foo
+  EmissionKind,     // lineTablesOnly
+  NameTableKind,    // GNU
+  DwarfOp,          // DW_OP_foo
+  DIFlag,           // DIFlagFoo
+  DISPFlag,         // DISPFlagFoo
+  DwarfMacinfo,     // DW_MACINFO_foo
+  ChecksumKind,     // CSK_foo
 
   // Type valued tokens (TyVal).
   Type,

--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -154,19 +154,18 @@ namespace llvm {
     /// \param SysRoot       The clang system root (value of -isysroot).
     /// \param SDK           The SDK name. On Darwin, this is the last component
     ///                      of the sysroot.
-    DICompileUnit *createCompileUnit(
-        unsigned Lang, DIFile *File, StringRef Producer, bool isOptimized,
-        StringRef Flags, unsigned RV, StringRef SplitName = StringRef(),
-        DICompileUnit::DebugEmissionKind Kind =
-            DICompileUnit::DebugEmissionKind::FullDebug,
-        uint64_t DWOId = 0, bool SplitDebugInlining = true,
-        bool DebugInfoForProfiling = false,
-        DICompileUnit::DebugNameTableKind NameTableKind =
-            DICompileUnit::DebugNameTableKind::Default,
-        bool RangesBaseAddress = false, StringRef SysRoot = {},
-        StringRef SDK = {},
-        DICompileUnit::CasFriendlinessKind CasFriendliness =
-            DICompileUnit::CasFriendlinessKind::NoCasFriendlyDebugInfo);
+    DICompileUnit *
+    createCompileUnit(unsigned Lang, DIFile *File, StringRef Producer,
+                      bool isOptimized, StringRef Flags, unsigned RV,
+                      StringRef SplitName = StringRef(),
+                      DICompileUnit::DebugEmissionKind Kind =
+                          DICompileUnit::DebugEmissionKind::FullDebug,
+                      uint64_t DWOId = 0, bool SplitDebugInlining = true,
+                      bool DebugInfoForProfiling = false,
+                      DICompileUnit::DebugNameTableKind NameTableKind =
+                          DICompileUnit::DebugNameTableKind::Default,
+                      bool RangesBaseAddress = false, StringRef SysRoot = {},
+                      StringRef SDK = {});
 
     /// Create a file descriptor to hold debugging information for a file.
     /// \param Filename  File name.

--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -1380,16 +1380,8 @@ public:
     LastDebugNameTableKind = None
   };
 
-  enum CasFriendlinessKind : unsigned {
-    NoCasFriendlyDebugInfo = 0,
-    DebugLineOnly,
-    LastCasFriendlinessKind = DebugLineOnly
-  };
-
   static std::optional<DebugEmissionKind> getEmissionKind(StringRef Str);
-  static std::optional<CasFriendlinessKind> getCasFriendlinessKind(StringRef Str);
   static const char *emissionKindString(DebugEmissionKind EK);
-  static const char *casFriendlinessString(CasFriendlinessKind CFK);
   static std::optional<DebugNameTableKind> getNameTableKind(StringRef Str);
   static const char *nameTableKindString(DebugNameTableKind PK);
 
@@ -1403,14 +1395,12 @@ private:
   bool DebugInfoForProfiling;
   unsigned NameTableKind;
   bool RangesBaseAddress;
-  unsigned CasFriendliness;
 
   DICompileUnit(LLVMContext &C, StorageType Storage, unsigned SourceLanguage,
                 bool IsOptimized, unsigned RuntimeVersion,
                 unsigned EmissionKind, uint64_t DWOId, bool SplitDebugInlining,
                 bool DebugInfoForProfiling, unsigned NameTableKind,
-                bool RangesBaseAddress, ArrayRef<Metadata *> Ops,
-                unsigned CasFriendliness);
+                bool RangesBaseAddress, ArrayRef<Metadata *> Ops);
   ~DICompileUnit() = default;
 
   static DICompileUnit *
@@ -1423,8 +1413,7 @@ private:
           DIImportedEntityArray ImportedEntities, DIMacroNodeArray Macros,
           uint64_t DWOId, bool SplitDebugInlining, bool DebugInfoForProfiling,
           unsigned NameTableKind, bool RangesBaseAddress, StringRef SysRoot,
-          StringRef SDK, unsigned CasFriendlieness, StorageType Storage,
-          bool ShouldCreate = true) {
+          StringRef SDK, StorageType Storage, bool ShouldCreate = true) {
     return getImpl(
         Context, SourceLanguage, File, getCanonicalMDString(Context, Producer),
         IsOptimized, getCanonicalMDString(Context, Flags), RuntimeVersion,
@@ -1433,8 +1422,7 @@ private:
         ImportedEntities.get(), Macros.get(), DWOId, SplitDebugInlining,
         DebugInfoForProfiling, NameTableKind, RangesBaseAddress,
         getCanonicalMDString(Context, SysRoot),
-        getCanonicalMDString(Context, SDK), CasFriendlieness, Storage,
-        ShouldCreate);
+        getCanonicalMDString(Context, SDK), Storage, ShouldCreate);
   }
   static DICompileUnit *
   getImpl(LLVMContext &Context, unsigned SourceLanguage, Metadata *File,
@@ -1445,8 +1433,7 @@ private:
           Metadata *Macros, uint64_t DWOId, bool SplitDebugInlining,
           bool DebugInfoForProfiling, unsigned NameTableKind,
           bool RangesBaseAddress, MDString *SysRoot, MDString *SDK,
-          unsigned CasFriendliness, StorageType Storage,
-          bool ShouldCreate = true);
+          StorageType Storage, bool ShouldCreate = true);
 
   TempDICompileUnit cloneImpl() const {
     return getTemporary(
@@ -1455,8 +1442,7 @@ private:
         getEmissionKind(), getEnumTypes(), getRetainedTypes(),
         getGlobalVariables(), getImportedEntities(), getMacros(), DWOId,
         getSplitDebugInlining(), getDebugInfoForProfiling(), getNameTableKind(),
-        getRangesBaseAddress(), getSysRoot(), getSDK(),
-        getCasFriendlinessKind());
+        getRangesBaseAddress(), getSysRoot(), getSDK());
   }
 
 public:
@@ -1473,12 +1459,12 @@ public:
        DIImportedEntityArray ImportedEntities, DIMacroNodeArray Macros,
        uint64_t DWOId, bool SplitDebugInlining, bool DebugInfoForProfiling,
        DebugNameTableKind NameTableKind, bool RangesBaseAddress,
-       StringRef SysRoot, StringRef SDK, unsigned CasFriendliness),
+       StringRef SysRoot, StringRef SDK),
       (SourceLanguage, File, Producer, IsOptimized, Flags, RuntimeVersion,
        SplitDebugFilename, EmissionKind, EnumTypes, RetainedTypes,
        GlobalVariables, ImportedEntities, Macros, DWOId, SplitDebugInlining,
        DebugInfoForProfiling, (unsigned)NameTableKind, RangesBaseAddress,
-       SysRoot, SDK, CasFriendliness))
+       SysRoot, SDK))
   DEFINE_MDNODE_GET_DISTINCT_TEMPORARY(
       DICompileUnit,
       (unsigned SourceLanguage, Metadata *File, MDString *Producer,
@@ -1488,12 +1474,11 @@ public:
        Metadata *ImportedEntities, Metadata *Macros, uint64_t DWOId,
        bool SplitDebugInlining, bool DebugInfoForProfiling,
        unsigned NameTableKind, bool RangesBaseAddress, MDString *SysRoot,
-       MDString *SDK, unsigned CasFriendliness),
+       MDString *SDK),
       (SourceLanguage, File, Producer, IsOptimized, Flags, RuntimeVersion,
        SplitDebugFilename, EmissionKind, EnumTypes, RetainedTypes,
        GlobalVariables, ImportedEntities, Macros, DWOId, SplitDebugInlining,
-       DebugInfoForProfiling, NameTableKind, RangesBaseAddress, SysRoot, SDK,
-       CasFriendliness))
+       DebugInfoForProfiling, NameTableKind, RangesBaseAddress, SysRoot, SDK))
 
   TempDICompileUnit clone() const { return cloneImpl(); }
 
@@ -1502,9 +1487,6 @@ public:
   unsigned getRuntimeVersion() const { return RuntimeVersion; }
   DebugEmissionKind getEmissionKind() const {
     return (DebugEmissionKind)EmissionKind;
-  }
-  CasFriendlinessKind getCasFriendlinessKind() const {
-    return (CasFriendlinessKind)CasFriendliness;
   }
   bool isDebugDirectivesOnly() const {
     return EmissionKind == DebugDirectivesOnly;

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -946,11 +946,6 @@ lltok::Kind LLLexer::LexIdentifier() {
     return lltok::EmissionKind;
   }
 
-  if (Keyword == "NoCasFriendlyDebugInfo" || Keyword == "DebugLineOnly") {
-    StrVal.assign(Keyword.begin(), Keyword.end());
-    return lltok::CasFriendlinessKind;
-  }
-
   if (Keyword == "GNU" || Keyword == "None" || Keyword == "Default") {
     StrVal.assign(Keyword.begin(), Keyword.end());
     return lltok::NameTableKind;

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4316,11 +4316,6 @@ struct EmissionKindField : public MDUnsignedField {
   EmissionKindField() : MDUnsignedField(0, DICompileUnit::LastEmissionKind) {}
 };
 
-struct CasFriendlinessKindField : public MDUnsignedField {
-  CasFriendlinessKindField()
-      : MDUnsignedField(0, DICompileUnit::LastCasFriendlinessKind) {}
-};
-
 struct NameTableKindField : public MDUnsignedField {
   NameTableKindField()
       : MDUnsignedField(
@@ -4540,25 +4535,6 @@ bool LLParser::parseMDField(LocTy Loc, StringRef Name,
     return tokError("invalid emission kind" + Twine(" '") + Lex.getStrVal() +
                     "'");
   assert(*Kind <= Result.Max && "Expected valid emission kind");
-  Result.assign(*Kind);
-  Lex.Lex();
-  return false;
-}
-
-template <>
-bool LLParser::parseMDField(LocTy Loc, StringRef Name,
-                            CasFriendlinessKindField &Result) {
-  if (Lex.getKind() == lltok::APSInt)
-    return parseMDField(Loc, Name, static_cast<MDUnsignedField &>(Result));
-
-  if (Lex.getKind() != lltok::CasFriendlinessKind)
-    return tokError("expected cas friendliness kind");
-
-  auto Kind = DICompileUnit::getCasFriendlinessKind(Lex.getStrVal());
-  if (!Kind)
-    return tokError("invalid cas friendliness kind" + Twine(" '") +
-                    Lex.getStrVal() + "'");
-  assert(*Kind <= Result.Max && "Expected valid cas friendliness kind");
   Result.assign(*Kind);
   Lex.Lex();
   return false;
@@ -5230,8 +5206,7 @@ bool LLParser::parseDICompileUnit(MDNode *&Result, bool IsDistinct) {
   OPTIONAL(nameTableKind, NameTableKindField, );                               \
   OPTIONAL(rangesBaseAddress, MDBoolField, = false);                           \
   OPTIONAL(sysroot, MDStringField, );                                          \
-  OPTIONAL(sdk, MDStringField, );                                              \
-  OPTIONAL(casFriendly, CasFriendlinessKindField, );
+  OPTIONAL(sdk, MDStringField, );
   PARSE_MD_FIELDS();
 #undef VISIT_MD_FIELDS
 
@@ -5240,7 +5215,7 @@ bool LLParser::parseDICompileUnit(MDNode *&Result, bool IsDistinct) {
       runtimeVersion.Val, splitDebugFilename.Val, emissionKind.Val, enums.Val,
       retainedTypes.Val, globals.Val, imports.Val, macros.Val, dwoId.Val,
       splitDebugInlining.Val, debugInfoForProfiling.Val, nameTableKind.Val,
-      rangesBaseAddress.Val, sysroot.Val, sdk.Val, casFriendly.Val);
+      rangesBaseAddress.Val, sysroot.Val, sdk.Val);
   return false;
 }
 

--- a/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
+++ b/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
@@ -1659,8 +1659,7 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
         Record.size() <= 18 ? 0 : Record[18],
         Record.size() <= 19 ? false : Record[19],
         Record.size() <= 20 ? nullptr : getMDString(Record[20]),
-        Record.size() <= 21 ? nullptr : getMDString(Record[21]),
-        Record.size() <= 22 ? 0 : Record[22]);
+        Record.size() <= 21 ? nullptr : getMDString(Record[21]));
 
     MetadataList.assignValue(CU, NextMetadataNo);
     NextMetadataNo++;

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -1848,7 +1848,6 @@ void ModuleBitcodeWriter::writeDICompileUnit(const DICompileUnit *N,
   Record.push_back(N->getRangesBaseAddress());
   Record.push_back(VE.getMetadataOrNullID(N->getRawSysRoot()));
   Record.push_back(VE.getMetadataOrNullID(N->getRawSDK()));
-  Record.push_back(N->getCasFriendlinessKind());
 
   Stream.EmitRecord(bitc::METADATA_COMPILE_UNIT, Record, Abbrev);
   Record.clear();

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h
@@ -379,6 +379,9 @@ class DwarfDebug : public DebugHandlerBase {
   /// Avoid using DW_OP_convert due to consumer incompatibilities.
   bool EnableOpConvert;
 
+  /// Generate debug info that is Cas Friendly
+  bool GenerateCasFriendlyDebugInfo;
+
 public:
   enum class MinimizeAddrInV5 {
     Default,

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -1696,9 +1696,6 @@ struct MDFieldPrinter {
   void printDwarfEnum(StringRef Name, IntTy Value, Stringifier toString,
                       bool ShouldSkipZero = true);
   void printEmissionKind(StringRef Name, DICompileUnit::DebugEmissionKind EK);
-  void printCasFriendlinessKind(
-      StringRef Name, DICompileUnit::CasFriendlinessKind EK,
-      std::optional<DICompileUnit::CasFriendlinessKind> Default = std::nullopt);
   void printNameTableKind(StringRef Name,
                           DICompileUnit::DebugNameTableKind NTK);
 };
@@ -1828,14 +1825,6 @@ void MDFieldPrinter::printDISPFlags(StringRef Name,
 void MDFieldPrinter::printEmissionKind(StringRef Name,
                                        DICompileUnit::DebugEmissionKind EK) {
   Out << FS << Name << ": " << DICompileUnit::emissionKindString(EK);
-}
-
-void MDFieldPrinter::printCasFriendlinessKind(
-    StringRef Name, DICompileUnit::CasFriendlinessKind EK,
-    std::optional<DICompileUnit::CasFriendlinessKind> Default) {
-  if (Default && *Default == EK)
-    return;
-  Out << FS << Name << ": " << DICompileUnit::casFriendlinessString(EK);
 }
 
 void MDFieldPrinter::printNameTableKind(StringRef Name,
@@ -2143,8 +2132,6 @@ static void writeDICompileUnit(raw_ostream &Out, const DICompileUnit *N,
   Printer.printBool("rangesBaseAddress", N->getRangesBaseAddress(), false);
   Printer.printString("sysroot", N->getSysRoot());
   Printer.printString("sdk", N->getSDK());
-  Printer.printCasFriendlinessKind("casFriendly", N->getCasFriendlinessKind(),
-                                   DICompileUnit::NoCasFriendlyDebugInfo);
   Out << ")";
 }
 

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -154,8 +154,7 @@ DICompileUnit *DIBuilder::createCompileUnit(
     DICompileUnit::DebugEmissionKind Kind, uint64_t DWOId,
     bool SplitDebugInlining, bool DebugInfoForProfiling,
     DICompileUnit::DebugNameTableKind NameTableKind, bool RangesBaseAddress,
-    StringRef SysRoot, StringRef SDK,
-    DICompileUnit::CasFriendlinessKind CasFriendliness) {
+    StringRef SysRoot, StringRef SDK) {
 
   assert(((Lang <= dwarf::DW_LANG_Ada2012 && Lang >= dwarf::DW_LANG_C89) ||
           (Lang <= dwarf::DW_LANG_hi_user && Lang >= dwarf::DW_LANG_lo_user)) &&
@@ -166,7 +165,7 @@ DICompileUnit *DIBuilder::createCompileUnit(
       VMContext, Lang, File, Producer, isOptimized, Flags, RunTimeVer,
       SplitName, Kind, nullptr, nullptr, nullptr, nullptr, nullptr, DWOId,
       SplitDebugInlining, DebugInfoForProfiling, NameTableKind,
-      RangesBaseAddress, SysRoot, SDK, CasFriendliness);
+      RangesBaseAddress, SysRoot, SDK);
 
   // Create a named metadata so that it is easier to find cu in a module.
   NamedMDNode *NMD = M.getOrInsertNamedMetadata("llvm.dbg.cu");

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -692,8 +692,7 @@ private:
         RetainedTypes, GlobalVariables, ImportedEntities, CU->getMacros(),
         CU->getDWOId(), CU->getSplitDebugInlining(),
         CU->getDebugInfoForProfiling(), CU->getNameTableKind(),
-        CU->getRangesBaseAddress(), CU->getSysRoot(), CU->getSDK(),
-        CU->getCasFriendlinessKind());
+        CU->getRangesBaseAddress(), CU->getSysRoot(), CU->getSDK());
   }
 
   DILocation *getReplacementMDLocation(DILocation *MLD) {
@@ -1049,9 +1048,7 @@ LLVMMetadataRef LLVMDIBuilderCreateCompileUnit(
       static_cast<DICompileUnit::DebugEmissionKind>(Kind), DWOId,
       SplitDebugInlining, DebugInfoForProfiling,
       DICompileUnit::DebugNameTableKind::Default, false,
-      StringRef(SysRoot, SysRootLen), StringRef(SDK, SDKLen),
-      /*NoCasFriendlyDebugInfo*/
-      static_cast<DICompileUnit::CasFriendlinessKind>(0)));
+      StringRef(SysRoot, SysRootLen), StringRef(SDK, SDKLen)));
 }
 
 LLVMMetadataRef

--- a/llvm/lib/IR/DebugInfoMetadata.cpp
+++ b/llvm/lib/IR/DebugInfoMetadata.cpp
@@ -850,15 +850,13 @@ DICompileUnit::DICompileUnit(LLVMContext &C, StorageType Storage,
                              unsigned RuntimeVersion, unsigned EmissionKind,
                              uint64_t DWOId, bool SplitDebugInlining,
                              bool DebugInfoForProfiling, unsigned NameTableKind,
-                             bool RangesBaseAddress, ArrayRef<Metadata *> Ops,
-                             unsigned CasFriendliness)
+                             bool RangesBaseAddress, ArrayRef<Metadata *> Ops)
     : DIScope(C, DICompileUnitKind, Storage, dwarf::DW_TAG_compile_unit, Ops),
       SourceLanguage(SourceLanguage), IsOptimized(IsOptimized),
       RuntimeVersion(RuntimeVersion), EmissionKind(EmissionKind), DWOId(DWOId),
       SplitDebugInlining(SplitDebugInlining),
       DebugInfoForProfiling(DebugInfoForProfiling),
-      NameTableKind(NameTableKind), RangesBaseAddress(RangesBaseAddress),
-      CasFriendliness(CasFriendliness) {
+      NameTableKind(NameTableKind), RangesBaseAddress(RangesBaseAddress) {
   assert(Storage != Uniqued);
 }
 
@@ -870,8 +868,7 @@ DICompileUnit *DICompileUnit::getImpl(
     Metadata *GlobalVariables, Metadata *ImportedEntities, Metadata *Macros,
     uint64_t DWOId, bool SplitDebugInlining, bool DebugInfoForProfiling,
     unsigned NameTableKind, bool RangesBaseAddress, MDString *SysRoot,
-    MDString *SDK, unsigned CasFriendliness, StorageType Storage,
-    bool ShouldCreate) {
+    MDString *SDK, StorageType Storage, bool ShouldCreate) {
   assert(Storage != Uniqued && "Cannot unique DICompileUnit");
   assert(isCanonical(Producer) && "Expected canonical MDString");
   assert(isCanonical(Flags) && "Expected canonical MDString");
@@ -892,7 +889,7 @@ DICompileUnit *DICompileUnit::getImpl(
                        Context, Storage, SourceLanguage, IsOptimized,
                        RuntimeVersion, EmissionKind, DWOId, SplitDebugInlining,
                        DebugInfoForProfiling, NameTableKind, RangesBaseAddress,
-                       Ops, CasFriendliness),
+                       Ops),
                    Storage);
 }
 
@@ -903,14 +900,6 @@ DICompileUnit::getEmissionKind(StringRef Str) {
       .Case("FullDebug", FullDebug)
       .Case("LineTablesOnly", LineTablesOnly)
       .Case("DebugDirectivesOnly", DebugDirectivesOnly)
-      .Default(std::nullopt);
-}
-
-std::optional<DICompileUnit::CasFriendlinessKind>
-DICompileUnit::getCasFriendlinessKind(StringRef Str) {
-  return StringSwitch<std::optional<CasFriendlinessKind>>(Str)
-      .Case("NoCasFriendlyDebugInfo", NoCasFriendlyDebugInfo)
-      .Case("DebugLineOnly", DebugLineOnly)
       .Default(std::nullopt);
 }
 
@@ -933,16 +922,6 @@ const char *DICompileUnit::emissionKindString(DebugEmissionKind EK) {
     return "LineTablesOnly";
   case DebugDirectivesOnly:
     return "DebugDirectivesOnly";
-  }
-  return nullptr;
-}
-
-const char *DICompileUnit::casFriendlinessString(CasFriendlinessKind CFK) {
-  switch (CFK) {
-  case NoCasFriendlyDebugInfo:
-    return "NoCasFriendlyDebugInfo";
-  case DebugLineOnly:
-    return "DebugLineOnly";
   }
   return nullptr;
 }

--- a/llvm/test/Assembler/dicompileunit.ll
+++ b/llvm/test/Assembler/dicompileunit.ll
@@ -16,14 +16,14 @@
 !6 = distinct !{}
 !7 = distinct !{}
 
-; CHECK: !8 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, flags: "-O2", runtimeVersion: 2, splitDebugFilename: "abc.debug", emissionKind: FullDebug, enums: !2, retainedTypes: !3, globals: !5, imports: !6, macros: !7, dwoId: 42, rangesBaseAddress: true, sysroot: "/", casFriendly: DebugLineOnly)
+; CHECK: !8 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, flags: "-O2", runtimeVersion: 2, splitDebugFilename: "abc.debug", emissionKind: FullDebug, enums: !2, retainedTypes: !3, globals: !5, imports: !6, macros: !7, dwoId: 42, rangesBaseAddress: true, sysroot: "/")
 !8 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang",
                              isOptimized: true, flags: "-O2", runtimeVersion: 2,
                              splitDebugFilename: "abc.debug",
                              emissionKind: FullDebug,
                              enums: !2, retainedTypes: !3,
                              globals: !5, imports: !6, macros: !7, dwoId: 42,
-                             splitDebugInlining: true, rangesBaseAddress: true, sysroot: "/", casFriendly: DebugLineOnly)
+                             splitDebugInlining: true, rangesBaseAddress: true, sysroot: "/")
 
 ; CHECK: !9 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, isOptimized: false, runtimeVersion: 0, emissionKind: NoDebug)
 !9 = distinct !DICompileUnit(language: 12, file: !1, producer: "",

--- a/llvm/test/DebugInfo/CAS/AArch64/debug_line_and_info_dedupe.test
+++ b/llvm/test/DebugInfo/CAS/AArch64/debug_line_and_info_dedupe.test
@@ -1,8 +1,8 @@
 RUN: rm -rf %t && mkdir -p %t
 RUN: split-file %s %t
 
-RUN: llc -O0 --filetype=obj --cas-backend --cas=%t/cas --mccas-casid %t/a.ll -o %t/a.id
-RUN: llc -O0 --filetype=obj --cas-backend --cas=%t/cas --mccas-casid %t/b.ll -o %t/b.id
+RUN: llc -cas-friendly-debug-info -O0 --filetype=obj --cas-backend --cas=%t/cas --mccas-casid %t/a.ll -o %t/a.id
+RUN: llc -cas-friendly-debug-info -O0 --filetype=obj --cas-backend --cas=%t/cas --mccas-casid %t/b.ll -o %t/b.id
 RUN: llvm-cas-dump --die-refs --cas=%t/cas --casid-file %t/a.id %t/b.id | FileCheck %s
 
 CHECK: mc:debug_DIE_top_level
@@ -37,7 +37,7 @@ define void @bar(i32 noundef %x) #0 !dbg !15 {
 attributes #0 = { noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git d74d0d9fde90cccba7bf18066ac56e55e4402948)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git d74d0d9fde90cccba7bf18066ac56e55e4402948)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/")
 !1 = !DIFile(filename: "a.c", directory: "/Users/shubham/Development/CASDelta")
 !2 = !{i32 7, !"Dwarf Version", i32 4}
 !3 = !{i32 2, !"Debug Info Version", i32 3}
@@ -73,7 +73,7 @@ ret void, !dbg !27
 attributes #0 = { noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git d74d0d9fde90cccba7bf18066ac56e55e4402948)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 16.0.0 (https://github.com/apple/llvm-project.git d74d0d9fde90cccba7bf18066ac56e55e4402948)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/")
 !1 = !DIFile(filename: "b.c", directory: "/Users/shubham/Development/CASDelta")
 !2 = !{i32 7, !"Dwarf Version", i32 4}
 !3 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/DebugInfo/X86/cas-friendly.ll
+++ b/llvm/test/DebugInfo/X86/cas-friendly.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=x86_64-apple-macosx12.0.0 -filetype=obj %s -o %t 
+; RUN: llc -cas-friendly-debug-info -mtriple=x86_64-apple-macosx12.0.0 -filetype=obj %s -o %t 
 ; RUN: llvm-dwarfdump -debug-line --debug-info %t | FileCheck %s
 
 ; This test checks if the line tables are emitted in a cas-friendly manner, which means they emit end_sequences when a function's contribution to the line table has ended. This is done to be able to split a function's contribution to the line table into individual cas blocks.
@@ -86,7 +86,7 @@ attributes #1 = { nofree nosync nounwind readnone speculatable willreturn }
 !llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
 !llvm.ident = !{!8}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 14.0.0 (git@github.com:apple/llvm-project.git 24e049152a8c2239a157a36f6a4d065e7a1b183b)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 14.0.0 (git@github.com:apple/llvm-project.git 24e049152a8c2239a157a36f6a4d065e7a1b183b)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/")
 !1 = !DIFile(filename: "test.c", directory: "/Users/shubham/Development/testClangDebugInfo")
 !2 = !{i32 7, !"Dwarf Version", i32 4}
 !3 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/tools/llvm-cas-dump/basic_debug_test.ll
+++ b/llvm/test/tools/llvm-cas-dump/basic_debug_test.ll
@@ -1,7 +1,7 @@
-; RUN: llc -O0 --filetype=obj --cas-backend --cas=%t.casdb --mccas-casid -o %t.casid %s
+; RUN: llc -cas-friendly-debug-info -O0 --filetype=obj --cas-backend --cas=%t.casdb --mccas-casid -o %t.casid %s
 ; RUN: llvm-cas-dump --cas=%t.casdb --dwarf-sections-only --dwarf-dump --casid-file %t.casid | FileCheck %s --check-prefix=DWARF
 ; RUN: llvm-cas-dump --cas=%t.casdb --dwarf-sections-only --casid-file %t.casid | FileCheck %s
-; RUN: llc -O0 --filetype=obj --cas-backend --cas=%t.casdb --mccas-casid -o %t_DIE.casid %s
+; RUN: llc -cas-friendly-debug-info -O0 --filetype=obj --cas-backend --cas=%t.casdb --mccas-casid -o %t_DIE.casid %s
 ; RUN: llvm-cas-dump --cas=%t.casdb --casid-file %t_DIE.casid  --die-refs | FileCheck %s --check-prefix=DWARF-DIE
 
 ; This test is created from a C program like:
@@ -92,7 +92,7 @@ entry:
 !llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
 !llvm.ident = !{!8}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "some_clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "some_clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/")
 !1 = !DIFile(filename: "test.c", directory: "some_dir")
 !2 = !{i32 7, !"Dwarf Version", i32 4}
 !3 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/tools/llvm-cas-object-format/Inputs/debug_line_split.ll
+++ b/llvm/test/tools/llvm-cas-object-format/Inputs/debug_line_split.ll
@@ -54,7 +54,7 @@ attributes #1 = { nofree nosync nounwind readnone speculatable willreturn }
 !llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
 !llvm.ident = !{!8}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 15.0.0 (git@github.com:apple/llvm-project.git d70b109980a620c1041801e0eef829da0ea7aef6)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/", casFriendly: DebugLineOnly)
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 15.0.0 (git@github.com:apple/llvm-project.git d70b109980a620c1041801e0eef829da0ea7aef6)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None, sysroot: "/")
 !1 = !DIFile(filename: "test.c", directory: "/Users/shubham/Development/testCASSymbols")
 !2 = !{i32 7, !"Dwarf Version", i32 4}
 !3 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/unittests/IR/MetadataTest.cpp
+++ b/llvm/unittests/IR/MetadataTest.cpp
@@ -98,8 +98,7 @@ protected:
         Context, 1, getFile(), "clang", false, "-g", 2, "",
         DICompileUnit::FullDebug, getTuple(), getTuple(), getTuple(),
         getTuple(), getTuple(), 0, true, false,
-        DICompileUnit::DebugNameTableKind::Default, false, "/", "",
-        DICompileUnit::NoCasFriendlyDebugInfo);
+        DICompileUnit::DebugNameTableKind::Default, false, "/", "");
   }
   DIType *getBasicType(StringRef Name) {
     return DIBasicType::get(Context, dwarf::DW_TAG_unspecified_type, Name);
@@ -2255,13 +2254,11 @@ TEST_F(DICompileUnitTest, get) {
   MDTuple *Macros = getTuple();
   StringRef SysRoot = "/";
   StringRef SDK = "MacOSX.sdk";
-  auto CasFriendlinessKind = DICompileUnit::NoCasFriendlyDebugInfo;
   auto *N = DICompileUnit::getDistinct(
       Context, SourceLanguage, File, Producer, IsOptimized, Flags,
       RuntimeVersion, SplitDebugFilename, EmissionKind, EnumTypes,
       RetainedTypes, GlobalVariables, ImportedEntities, Macros, DWOId, true,
-      false, DICompileUnit::DebugNameTableKind::Default, false, SysRoot, SDK,
-      CasFriendlinessKind);
+      false, DICompileUnit::DebugNameTableKind::Default, false, SysRoot, SDK);
 
   EXPECT_EQ(dwarf::DW_TAG_compile_unit, N->getTag());
   EXPECT_EQ(SourceLanguage, N->getSourceLanguage());
@@ -2280,7 +2277,6 @@ TEST_F(DICompileUnitTest, get) {
   EXPECT_EQ(DWOId, N->getDWOId());
   EXPECT_EQ(SysRoot, N->getSysRoot());
   EXPECT_EQ(SDK, N->getSDK());
-  EXPECT_EQ(CasFriendlinessKind, N->getCasFriendlinessKind());
 
   TempDICompileUnit Temp = N->clone();
   EXPECT_EQ(dwarf::DW_TAG_compile_unit, Temp->getTag());
@@ -2299,7 +2295,6 @@ TEST_F(DICompileUnitTest, get) {
   EXPECT_EQ(Macros, Temp->getMacros().get());
   EXPECT_EQ(SysRoot, Temp->getSysRoot());
   EXPECT_EQ(SDK, Temp->getSDK());
-  EXPECT_EQ(CasFriendlinessKind, Temp->getCasFriendlinessKind());
 
   auto *TempAddress = Temp.get();
   auto *Clone = MDNode::replaceWithPermanent(std::move(Temp));
@@ -2322,13 +2317,11 @@ TEST_F(DICompileUnitTest, replaceArrays) {
   uint64_t DWOId = 0xc0ffee;
   StringRef SysRoot = "/";
   StringRef SDK = "MacOSX.sdk";
-  auto CasFriendlinessKind = DICompileUnit::NoCasFriendlyDebugInfo;
   auto *N = DICompileUnit::getDistinct(
       Context, SourceLanguage, File, Producer, IsOptimized, Flags,
       RuntimeVersion, SplitDebugFilename, EmissionKind, EnumTypes,
       RetainedTypes, nullptr, ImportedEntities, nullptr, DWOId, true, false,
-      DICompileUnit::DebugNameTableKind::Default, false, SysRoot, SDK,
-      CasFriendlinessKind);
+      DICompileUnit::DebugNameTableKind::Default, false, SysRoot, SDK);
 
   auto *GlobalVariables = MDTuple::getDistinct(Context, std::nullopt);
   EXPECT_EQ(nullptr, N->getGlobalVariables().get());


### PR DESCRIPTION
In an effort to make merging into the stable apple/llvm-project branch easier, and also making cas friendly debug info generation not depend on the driver, this patch removes the old -fcas-friendly-debug-info= option and replaced it with an mllvm option in DwarfDebug.cpp.

This is better because the cas friendly debug info is only generated in the backend and doesn't have anything to do with the compile unit, so the driver should not have any knowledge of this.