### PR TITLE
Driver: introduce GNU spellings to control MSVC paths

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -7131,6 +7131,15 @@ def _SLASH_Gv : CLFlag<"Gv">,
 def _SLASH_Gregcall : CLFlag<"Gregcall">,
   HelpText<"Set __regcall as a default calling convention">;
 
+// Swift extension flags
+def : Separate<["-"], "Xmicrosoft-windows-sdk-root">, Alias<_SLASH_winsdkdir>;
+def : Separate<["-"], "Xmicrosoft-windows-sdk-version">,
+    Alias<_SLASH_winsdkversion>;
+def : Separate<["-"], "Xmicrosoft-visualc-tools-root">,
+    Alias<_SLASH_vctoolsdir>;
+def : Separate<["-"], "Xmicrosoft-visualc-tools-version">,
+    Alias<_SLASH_vctoolsversion>;
+
 // Ignored:
 
 def _SLASH_analyze_ : CLIgnoredFlag<"analyze-">;


### PR DESCRIPTION
Add a set of `-Xmicrosoft` flags to control the Windows SDK and VisualC tools directories.  This allows control over the selection of teh SDK and tools when using the GNU driver.