### PR TITLE
[clang][cas] Fix error accessing cached failure for dep directive scan

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
@@ -165,6 +165,8 @@ void DependencyScanningCASFilesystem::scanForDirectives(
   if (std::optional<CASID> OutputID =
           reportAsFatalIfError(Cache.get(*InputID))) {
     if (std::optional<ObjectRef> OutputRef = CAS.getReference(*OutputID)) {
+      if (OutputRef == EmptyBlobID)
+        return; // Cached directive scanning failure.
       reportAsFatalIfError(
           loadDepDirectives(CAS, *OutputRef, Tokens, Directives));
       return;


### PR DESCRIPTION
When we fail to scan directives in a file we store an empty blob to cache the failure, but we didn't correctly handle it when loading that empty blob from the cache. This was triggering crashes the second time we try to scan a script file. Note: failure to scan is correct here; it's not C++ code but we had no way to know that up front.

rdar://106090616