### PR TITLE
[clang][cas] Fix build warnings

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -27,7 +27,6 @@
 #include "clang/Tooling/Tooling.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/CAS/ObjectStore.h"
-#include "llvm/Support/Host.h"
 #include "llvm/Support/PrefixMapper.h"
 #include "llvm/TargetParser/Host.h"
 #include <optional>

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -508,13 +508,12 @@ handleIncludeTreeToolResult(llvm::cas::ObjectStore &CAS,
 
 static bool outputFormatRequiresCAS() {
   switch (Format) {
-    case ScanningOutputFormat::Make:
-    case ScanningOutputFormat::Full:
-      return false;
     case ScanningOutputFormat::Tree:
     case ScanningOutputFormat::FullTree:
     case ScanningOutputFormat::IncludeTree:
       return true;
+    default:
+      return false;
   }
 }
 

--- a/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
@@ -10,7 +10,6 @@
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/CAS/TreeSchema.h"
 #include "llvm/Support/Errc.h"
-#include "llvm/Support/Host.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/PrefixMapper.h"


### PR DESCRIPTION
* Handle all scan formats in switch
* Remove include of deprecated header (in one case we already include the new one; in another case it was unnecessary)