### PR TITLE
[clang][cas] Fix error accessing cached failure for dep directive scan

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
@@ -165,6 +165,8 @@ void DependencyScanningCASFilesystem::scanForDirectives(
   if (Optional<CASID> OutputID =
           reportAsFatalIfError(Cache.get(*InputID))) {
     if (Optional<ObjectRef> OutputRef = CAS.getReference(*OutputID)) {
+      if (OutputRef == EmptyBlobID)
+        return; // Cached directive scanning failure.
       reportAsFatalIfError(
           loadDepDirectives(CAS, *OutputRef, Tokens, Directives));
       return;

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -493,13 +493,12 @@ handleIncludeTreeToolResult(llvm::cas::ObjectStore &CAS,
 
 static bool outputFormatRequiresCAS() {
   switch (Format) {
-    case ScanningOutputFormat::Make:
-    case ScanningOutputFormat::Full:
-      return false;
     case ScanningOutputFormat::Tree:
     case ScanningOutputFormat::FullTree:
     case ScanningOutputFormat::IncludeTree:
       return true;
+    default:
+      return false;
   }
 }
 


### PR DESCRIPTION
Cherry-pick https://github.com/apple/llvm-project/pull/6352 and https://github.com/apple/llvm-project/pull/6353