### PR TITLE
[clang][cas] Fix error accessing cached failure for dep directive scan

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
@@ -165,6 +165,8 @@ void DependencyScanningCASFilesystem::scanForDirectives(
   if (std::optional<CASID> OutputID =
           reportAsFatalIfError(Cache.get(*InputID))) {
     if (std::optional<ObjectRef> OutputRef = CAS.getReference(*OutputID)) {
+      if (OutputRef == EmptyBlobID)
+        return; // Cached directive scanning failure.
       reportAsFatalIfError(
           loadDepDirectives(CAS, *OutputRef, Tokens, Directives));
       return;

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -503,14 +503,12 @@ handleIncludeTreeToolResult(llvm::cas::ObjectStore &CAS,
 
 static bool outputFormatRequiresCAS() {
   switch (Format) {
-    case ScanningOutputFormat::Make:
-    case ScanningOutputFormat::Full:
-    case ScanningOutputFormat::P1689:
-      return false;
     case ScanningOutputFormat::Tree:
     case ScanningOutputFormat::FullTree:
     case ScanningOutputFormat::IncludeTree:
       return true;
+    default:
+      return false;
   }
 }
 

--- a/clang/tools/libclang/Driver.cpp
+++ b/clang/tools/libclang/Driver.cpp
@@ -20,7 +20,7 @@
 #include "clang/Driver/DriverDiagnostic.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/Support/Host.h"
+#include "llvm/TargetParser/Host.h"
 
 using namespace clang;
 

--- a/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
@@ -10,7 +10,6 @@
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/CAS/TreeSchema.h"
 #include "llvm/Support/Errc.h"
-#include "llvm/Support/Host.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/PrefixMapper.h"


### PR DESCRIPTION
Cherry-pick https://github.com/apple/llvm-project/pull/6352 and https://github.com/apple/llvm-project/pull/6353.  Incidentally fix another Host.h warning that is only on this branch.