### PR TITLE
[clang][ExtractAPI] Handle platform specific unavailability correctly

### DIFF
--- a/clang/include/clang/ExtractAPI/AvailabilityInfo.h
+++ b/clang/include/clang/ExtractAPI/AvailabilityInfo.h
@@ -33,12 +33,14 @@ struct AvailabilityInfo {
   VersionTuple Introduced;
   VersionTuple Deprecated;
   VersionTuple Obsoleted;
+  bool Unavailable;
 
   AvailabilityInfo() = default;
 
   AvailabilityInfo(StringRef Domain, VersionTuple I, VersionTuple D,
-                   VersionTuple O)
-      : Domain(Domain), Introduced(I), Deprecated(D), Obsoleted(O) {}
+                   VersionTuple O, bool U)
+      : Domain(Domain), Introduced(I), Deprecated(D), Obsoleted(O),
+        Unavailable(U) {}
 };
 
 class AvailabilitySet {

--- a/clang/lib/ExtractAPI/AvailabilityInfo.cpp
+++ b/clang/lib/ExtractAPI/AvailabilityInfo.cpp
@@ -42,8 +42,8 @@ AvailabilitySet::AvailabilitySet(const Decl *Decl) {
           Availability->Obsoleted = Attr->getObsoleted();
       } else {
         Availabilities.emplace_back(Domain, Attr->getIntroduced(),
-                                    Attr->getDeprecated(),
-                                    Attr->getObsoleted());
+                                    Attr->getDeprecated(), Attr->getObsoleted(),
+                                    Attr->getUnavailable());
       }
     }
   }

--- a/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
+++ b/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
@@ -169,12 +169,16 @@ Optional<Array> serializeAvailability(const AvailabilitySet &Availabilities) {
   for (const auto &AvailInfo : Availabilities) {
     Object Availability;
     Availability["domain"] = AvailInfo.Domain;
-    serializeObject(Availability, "introducedVersion",
-                    serializeSemanticVersion(AvailInfo.Introduced));
-    serializeObject(Availability, "deprecatedVersion",
-                    serializeSemanticVersion(AvailInfo.Deprecated));
-    serializeObject(Availability, "obsoletedVersion",
-                    serializeSemanticVersion(AvailInfo.Obsoleted));
+    if (AvailInfo.Unavailable)
+      Availability["isUnconditionallyUnavailable"] = true;
+    else {
+      serializeObject(Availability, "introducedVersion",
+                      serializeSemanticVersion(AvailInfo.Introduced));
+      serializeObject(Availability, "deprecatedVersion",
+                      serializeSemanticVersion(AvailInfo.Deprecated));
+      serializeObject(Availability, "obsoletedVersion",
+                      serializeSemanticVersion(AvailInfo.Obsoleted));
+    }
     AvailabilityArray.emplace_back(std::move(Availability));
   }
 

--- a/clang/test/ExtractAPI/availability.c
+++ b/clang/test/ExtractAPI/availability.c
@@ -26,6 +26,9 @@ void e(void) __attribute__((deprecated)) __attribute__((availability(macos, intr
 void f(void) __attribute__((unavailable)) __attribute__((availability(macos, introduced=11.0)));
 
 void d(void) __attribute__((availability(tvos, introduced=15.0)));
+
+void e(void) __attribute__((availability(tvos, unavailable)));
+
 ///expected-no-diagnostics
 
 //--- reference.output.json.in
@@ -391,6 +394,10 @@ void d(void) __attribute__((availability(tvos, introduced=15.0)));
             "minor": 0,
             "patch": 0
           }
+        },
+        {
+          "domain": "tvos",
+          "isUnconditionallyUnavailable": true
         }
       ],
       "declarationFragments": [


### PR DESCRIPTION
Cherry picked from 65f7a84cf38b9839de0f29877d5ba4895848ea73

This Patch gives ExtractAPI the ability to emit correct availability information for symbols marked as unavailable on a specific platform ( PR#60954 )

Reviewed By: dang

Differential Revision: https://reviews.llvm.org/D144940

rdar://103557598
