### PR TITLE
Remove the undocumented `help` subcommand.

### DIFF
--- a/lldb/source/Commands/CommandObjectMultiword.cpp
+++ b/lldb/source/Commands/CommandObjectMultiword.cpp
@@ -173,11 +173,6 @@ bool CommandObjectMultiword::Execute(const char *args_string,
     return result.Succeeded();
   }
 
-  if (sub_command.equals_insensitive("help")) {
-    this->CommandObject::GenerateHelpText(result);
-    return result.Succeeded();
-  }
-
   if (m_subcommand_dict.empty()) {
     result.AppendErrorWithFormat("'%s' does not have any subcommands.\n",
                                  GetCommandName().str().c_str());

--- a/lldb/test/API/functionalities/multiword-commands/TestMultiWordCommands.py
+++ b/lldb/test/API/functionalities/multiword-commands/TestMultiWordCommands.py
@@ -19,13 +19,3 @@ class MultiwordCommandsTestCase(TestBase):
     @no_debug_info_test
     def test_empty_subcommand(self):
         self.expect("platform \"\"", error=True, substrs=["Need to specify a non-empty subcommand."])
-
-    @no_debug_info_test
-    def test_help(self):
-        # <multiword> help brings up help.
-        self.expect("platform help",
-                    substrs=["Commands to manage and create platforms.",
-                             "Syntax: platform [",
-                             "The following subcommands are supported:",
-                             "connect",
-                             "Select the current platform"])


### PR DESCRIPTION
This is processed by hand in CommandObjectMultiword, and is undiscoverable, it doesn't work in all cases.  Because it is a bare word, it can't really be extended w/o introducing the possibility of collisions as well.  If we did want to do something like this we should add a --help flag to CommandObject.  That way the feature would be consistent and documented.

Differential Revision: https://reviews.llvm.org/D142067

(cherry picked from commit 887240faf769395511d1568b4e50aafc6fe3b696)