### PR TITLE
Fix stop locker

### DIFF
--- a/lldb/source/API/SBFrame.cpp
+++ b/lldb/source/API/SBFrame.cpp
@@ -20,6 +20,7 @@
 #include "lldb/Core/StructuredDataImpl.h"
 #include "lldb/Core/ValueObjectRegister.h"
 #include "lldb/Core/ValueObjectVariable.h"
+#include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/Expression/ExpressionVariable.h"
 #include "lldb/Expression/UserExpression.h"
 #include "lldb/Host/Host.h"
@@ -993,6 +994,12 @@ SBValue SBFrame::EvaluateExpression(const char *expr) {
     else
       options.SetLanguage(frame->GetLanguage());
     return EvaluateExpression(expr, options);
+  } else {
+    Status error;
+    error.SetErrorString("can't evaluate expressions when the "
+                           "process is running.");
+    ValueObjectSP error_val_sp = ValueObjectConstResult::Create(nullptr, error);
+    result.SetSP(error_val_sp, false);
   }
   return result;
 }
@@ -1056,7 +1063,6 @@ lldb::SBValue SBFrame::EvaluateExpression(const char *expr,
   std::unique_lock<std::recursive_mutex> lock;
   ExecutionContext exe_ctx(m_opaque_sp.get(), lock);
 
-
   StackFrame *frame = nullptr;
   Target *target = exe_ctx.GetTargetPtr();
   Process *process = exe_ctx.GetProcessPtr();
@@ -1080,13 +1086,30 @@ lldb::SBValue SBFrame::EvaluateExpression(const char *expr,
         target->EvaluateExpression(expr, frame, expr_value_sp, options.ref());
         expr_result.SetSP(expr_value_sp, options.GetFetchDynamicValue());
       }
+    } else {
+      Status error;
+      error.SetErrorString("can't evaluate expressions when the "
+                           "process is running.");
+      expr_value_sp = ValueObjectConstResult::Create(nullptr, error);
+      expr_result.SetSP(expr_value_sp, false);
     }
+  } else {
+      Status error;
+      error.SetErrorString("sbframe object is not valid.");
+      expr_value_sp = ValueObjectConstResult::Create(nullptr, error);
+      expr_result.SetSP(expr_value_sp, false);
   }
 
-  LLDB_LOGF(expr_log,
-            "** [SBFrame::EvaluateExpression] Expression result is "
-            "%s, summary %s **",
-            expr_result.GetValue(), expr_result.GetSummary());
+  if (expr_result.GetError().Success())
+    LLDB_LOGF(expr_log,
+              "** [SBFrame::EvaluateExpression] Expression result is "
+              "%s, summary %s **",
+              expr_result.GetValue(), expr_result.GetSummary());
+  else
+    LLDB_LOGF(expr_log,
+              "** [SBFrame::EvaluateExpression] Expression evaluation failed: "
+              "%s **",
+              expr_result.GetError().GetCString());
 
   return expr_result;
 }

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -2277,12 +2277,25 @@ lldb::SBValue SBTarget::EvaluateExpression(const char *expr,
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     ExecutionContext exe_ctx(m_opaque_sp.get());
 
-
     frame = exe_ctx.GetFramePtr();
     Target *target = exe_ctx.GetTargetPtr();
+    Process *process = exe_ctx.GetProcessPtr();
 
     if (target) {
-      target->EvaluateExpression(expr, frame, expr_value_sp, options.ref());
+      // If we have a process, make sure to lock the runlock:
+      if (process) {
+        Process::StopLocker stop_locker;
+        if (stop_locker.TryLock(&process->GetRunLock())) {
+          target->EvaluateExpression(expr, frame, expr_value_sp, options.ref());
+        } else {
+          Status error;
+          error.SetErrorString("can't evaluate expressions when the "
+                               "process is running.");
+          expr_value_sp = ValueObjectConstResult::Create(nullptr, error);
+        }
+      } else {
+        target->EvaluateExpression(expr, frame, expr_value_sp, options.ref());
+      }
 
       expr_result.SetSP(expr_value_sp, options.GetFetchDynamicValue());
     }

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -1250,6 +1250,15 @@ bool ValueObject::DumpPrintableRepresentation(
     Stream &s, ValueObjectRepresentationStyle val_obj_display,
     Format custom_format, PrintableRepresentationSpecialCases special,
     bool do_dump_error) {
+    
+  // If the ValueObject has an error, we might end up dumping the type, which
+  // is useful, but if we don't even have a type, then don't examine the object
+  // further as that's not meaningful, only the error is.
+  if (m_error.Fail() && !GetCompilerType().IsValid()) {
+    if (do_dump_error)
+      s.Printf("<%s>", m_error.AsCString());
+    return false;
+  }
 
   Flags flags(GetTypeInfo());
 
@@ -1451,6 +1460,8 @@ bool ValueObject::DumpPrintableRepresentation(
     if (!str.empty())
       s << str;
     else {
+      // We checked for errors at the start, but do it again here in case
+      // realizing the value for dumping produced an error.
       if (m_error.Fail()) {
         if (do_dump_error)
           s.Printf("<%s>", m_error.AsCString());

--- a/lldb/source/DataFormatters/ValueObjectPrinter.cpp
+++ b/lldb/source/DataFormatters/ValueObjectPrinter.cpp
@@ -71,6 +71,18 @@ void ValueObjectPrinter::Init(
 }
 
 bool ValueObjectPrinter::PrintValueObject() {
+  if (!m_orig_valobj)
+    return false;
+
+  // If the incoming ValueObject is in an error state, the best we're going to 
+  // get out of it is its type.  But if we don't even have that, just print
+  // the error and exit early.
+  if (m_orig_valobj->GetError().Fail() 
+      && !m_orig_valobj->GetCompilerType().IsValid()) {
+    m_stream->Printf("Error: '%s'", m_orig_valobj->GetError().AsCString());
+    return true;
+  }
+   
   if (!GetMostSpecializedValue() || m_valobj == nullptr)
     return false;
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3612,7 +3612,7 @@ Status Target::Launch(ProcessLaunchInfo &launch_info, Stream *stream) {
       // SyncResume hijacker.
       m_process_sp->ResumeSynchronous(stream);
     else
-      error = m_process_sp->PrivateResume();
+      error = m_process_sp->Resume();
     if (!error.Success()) {
       Status error2;
       error2.SetErrorStringWithFormat(

--- a/lldb/test/API/python_api/run_locker/Makefile
+++ b/lldb/test/API/python_api/run_locker/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
+
+include Makefile.rules

--- a/lldb/test/API/python_api/run_locker/TestRunLocker.py
+++ b/lldb/test/API/python_api/run_locker/TestRunLocker.py
@@ -1,0 +1,89 @@
+"""
+Test that the run locker really does work to keep
+us from running SB API that should only be run
+while stopped.  This test is mostly concerned with
+what happens between launch and first stop.
+"""
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+
+
+class TestRunLocker(TestBase):
+
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_run_locker(self):
+        """Test that the run locker is set correctly when we launch"""
+        self.build()
+        self.runlocker_test(False)
+
+    def test_run_locker_stop_at_entry(self):
+        """Test that the run locker is set correctly when we launch"""
+        self.build()
+        self.runlocker_test(False)
+
+    def setUp(self):
+        # Call super's setUp().
+        TestBase.setUp(self)
+        self.main_source_file = lldb.SBFileSpec("main.c")
+
+    def runlocker_test(self, stop_at_entry):
+        """The code to stop at entry handles events slightly differently, so 
+           we test both versions of process launch."""
+
+        target = lldbutil.run_to_breakpoint_make_target(self)
+        
+        launch_info = target.GetLaunchInfo()
+        if stop_at_entry:
+            flags = launch_info.GetFlags()
+            launch_info.SetFlags(flags | lldb.eLaunchFlagStopAtEntry)
+
+        error = lldb.SBError()
+        # We are trying to do things when the process is running, so
+        # we have to run the debugger asynchronously.
+        self.dbg.SetAsync(True)
+        
+        listener = lldb.SBListener("test-run-lock-listener")
+        launch_info.SetListener(listener)
+        process = target.Launch(launch_info, error)
+        self.assertSuccess(error, "Launched the process")
+        
+        event = lldb.SBEvent()
+        
+        event_result = listener.WaitForEvent(10, event)
+        self.assertTrue(event_result, "timed out waiting for launch")
+        state_type = lldb.SBProcess.GetStateFromEvent(event)
+        # We don't always see a launching...
+        if state_type == lldb.eStateLaunching:
+            event_result = listener.WaitForEvent(10, event)
+            self.assertTrue(event_result, "Timed out waiting for running after launching")
+            state_type = lldb.SBProcess.GetStateFromEvent(event)
+            
+        self.assertState(state_type, lldb.eStateRunning, "Didn't get a running event")
+        
+        # We aren't checking the entry state, but just making sure
+        # the running state is set properly if we continue in this state.
+        
+        if stop_at_entry:
+            event_result = listener.WaitForEvent(10, event)
+            self.assertTrue(event_result, "Timed out waiting for stop at entry stop")
+            state_type = lldb.SBProcess.GetStateFromEvent(event)
+            self.assertState(state_type, eStateStopped, "Stop at entry stopped")
+            process.Continue()
+
+        # Okay, now the process is running, make sure we can't do things
+        # you aren't supposed to do while running, and that we get some
+        # actual error:
+        val = target.EvaluateExpression("SomethingToCall()")
+        error = val.GetError()
+        self.assertTrue(error.Fail(), "Failed to run expression")
+        print(f"Got Error: {error.GetCString()}")
+        self.assertIn("can't evaluate expressions when the process is running", error.GetCString(), "Stopped by stop locker")
+
+        # This should also fail if we try to use the script interpreter directly:
+        interp = self.dbg.GetCommandInterpreter()
+        result = lldb.SBCommandReturnObject()
+        ret = interp.HandleCommand("script var = lldb.frame.EvaluateExpression('SomethingToCall()'); var.GetError().GetCString()", result)
+        self.assertIn("can't evaluate expressions when the process is running", result.GetOutput())

--- a/lldb/test/API/python_api/run_locker/main.c
+++ b/lldb/test/API/python_api/run_locker/main.c
@@ -1,0 +1,15 @@
+#include <unistd.h>
+
+int
+SomethingToCall() {
+  return 100;
+}
+
+int
+main()
+{
+  while (1) {
+    sleep(1);
+  }
+  return SomethingToCall();
+}


### PR DESCRIPTION
This is two patches in one patch.  

commit a92f7832f35c6c4792d8693e724c19802da75b36 (origin/main, origin/HEAD)
Author: Jim Ingham <jingham@apple.com>
Date:   Tue Feb 28 17:14:46 2023 -0800

    Fix the run locker setting for async launches that don't stop at the
    initial stop.  The code was using PrivateResume when it should have
    used Resume.
    
    This was allowing expression evaluation while the target was running,
    and though that was caught a litle later on, we should never have gotten
    that far.  To make sure that this is caught immediately I made an error
    SBValue when this happens, and test that we get this error.
    
    Differential Revision: https://reviews.llvm.org/D144665

and

commit e8a2fd5e7be23e4087e7ff58efa354dfae1a17c4
Author: Jim Ingham <jingham@apple.com>
Date:   Tue Feb 28 16:38:50 2023 -0800

    An SBValue whose underlying ValueObject has no valid value, but does
    hold an error should:
    
    (a) return false for IsValid, since that's the current behavior and is
        a convenient way to check "should I get the value for this".
    (b) preserve the error when an SBValue is made from it, and print the
        error in the ValueObjectPrinter.
    
    Make that happen.
    
    Differential Revision: https://reviews.llvm.org/D144664

The second is the important one, the first just makes it possible to test the second.