### PR TITLE
[lldb] Implement identification of generic Swift types in C++

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -219,8 +219,12 @@ public:
                                 Address &address,
                                 Value::ValueType &value_type) override;
 
+  CompilerType BindGenericTypeParameters(
+      CompilerType unbound_type,
+      std::function<CompilerType(unsigned, unsigned)> finder);
+
   /// Extract the value object which contains the Swift type's "contents".
-  /// Returns null if this is not a C++ wrapping a Swift type. 
+  /// Returns null if this is not a C++ wrapping a Swift type.
   static lldb::ValueObjectSP
   ExtractSwiftValueObjectFromCxxWrapper(ValueObject &valobj);
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -145,6 +145,10 @@ public:
       bool &child_is_deref_of_parent, ValueObject *valobj,
       uint64_t &language_flags);
 
+  CompilerType BindGenericTypeParameters(
+      CompilerType unbound_type,
+      std::function<CompilerType(unsigned, unsigned)> type_resolver);
+
   /// Like \p BindGenericTypeParameters but for TypeSystemSwiftTypeRef.
   CompilerType BindGenericTypeParameters(StackFrame &stack_frame,
                                          TypeSystemSwiftTypeRef &ts,

--- a/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/TestSwiftFormatSwiftTypesInCxx.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/TestSwiftFormatSwiftTypesInCxx.py
@@ -34,3 +34,9 @@ class TestSwiftFormatSwiftTypesInCxx(TestBase):
         self.expect('p swiftStruct', substrs=['SwiftStruct', 'str = "Hello this is a big string"', 
             'boolean = true'])
 
+        self.expect('v wrapper', substrs=['a.GenericPair<a.SwiftClass, a.SwiftStruct>', 
+                'field = 42', 'arr = 4 values', '[0] = "An"', '[1] = "array"', '[2] = "of"', 
+                '[3] = "strings"', 'str = "Hello this is a big string"', 'boolean = true'])
+        self.expect('p wrapper', substrs=['a.GenericPair<a.SwiftClass, a.SwiftStruct>', 
+                'field = 42', 'arr = 4 values', '[0] = "An"', '[1] = "array"', '[2] = "of"', 
+                '[3] = "strings"', 'str = "Hello this is a big string"', 'boolean = true'])

--- a/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/main.cpp
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/main.cpp
@@ -5,5 +5,6 @@ int main() {
   auto swiftClass = returnSwiftClass();
   auto swiftSublass = returnSwiftSubclassAsClass();
   auto swiftStruct = returnSwiftStruct();
+  auto wrapper = returnPair(swiftClass, swiftStruct);
   return 0; // Set breakpoint here.
 }

--- a/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/swift-types.swift
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/swift-types.swift
@@ -13,6 +13,17 @@ public struct SwiftStruct {
   var boolean = true
 }
 
+@frozen
+public struct GenericPair<T, T2> {
+    var x: T
+    var y: T2
+
+    init(x: T, y: T2) {
+        self.x = x
+        self.y = y
+    }
+}
+
 public func returnSwiftClass() -> SwiftClass {
   return SwiftClass()
 }
@@ -23,4 +34,8 @@ public func returnSwiftSubclassAsClass() -> SwiftClass {
 
 public func returnSwiftStruct() -> SwiftStruct {
   return SwiftStruct()
+}
+
+public func returnPair<T, U>(t: T, u: U) -> GenericPair<T, U> {
+  return GenericPair<T, U>(x: t, y: u)
 }


### PR DESCRIPTION
The mangled name generated for generic Swift types contain unbound generics. Implement substituting those generic types in by consulting the C++ generated type's templates, and recursively resolving those to their Swift counterpart.