### PR TITLE
[cherry-pick][stable/20221013] [lldb] Ignore libcxx std::ranges global variables in frame var

### DIFF
--- a/lldb/include/lldb/Target/LanguageRuntime.h
+++ b/lldb/include/lldb/Target/LanguageRuntime.h
@@ -172,6 +172,11 @@ public:
     return llvm::None;
   }
 
+  /// Returns 'true' if we the variable with the specified 'name'
+  /// should be hidden from variable views (e.g., when listing variables in
+  /// 'frame variable' or 'target variable')
+  virtual bool ShouldHideVariable(llvm::StringRef name) const { return false; }
+
   void ModulesDidLoad(const ModuleList &module_list) override {}
 
   // Called by ClangExpressionParser::PrepareForExecution to query for any

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -1679,12 +1679,20 @@ bool ValueObject::IsRuntimeSupportValue() {
   if (!process)
     return false;
 
-  // We trust that the compiler did the right thing and marked runtime support
-  // values as artificial.
-  if (!GetVariable() || !GetVariable()->IsArtificial())
+  if (!GetVariable())
     return false;
 
-  if (auto *runtime = process->GetLanguageRuntime(GetVariable()->GetLanguage()))
+  auto *runtime = process->GetLanguageRuntime(GetVariable()->GetLanguage());
+  if (runtime)
+    if (runtime->ShouldHideVariable(GetName().GetStringRef()))
+      return true;
+
+  // We trust that the compiler did the right thing and marked runtime support
+  // values as artificial.
+  if (!GetVariable()->IsArtificial())
+    return false;
+
+  if (runtime)
     if (runtime->IsAllowedRuntimeValue(GetName()))
       return false;
 

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
@@ -28,6 +28,7 @@
 #include "lldb/Target/StackFrame.h"
 #include "lldb/Target/ThreadPlanRunToAddress.h"
 #include "lldb/Target/ThreadPlanStepInRange.h"
+#include "lldb/Utility/RegularExpression.h"
 #include "lldb/Utility/Timer.h"
 
 using namespace lldb;
@@ -39,6 +40,17 @@ char CPPLanguageRuntime::ID = 0;
 
 CPPLanguageRuntime::CPPLanguageRuntime(Process *process)
     : LanguageRuntime(process) {}
+
+bool CPPLanguageRuntime::ShouldHideVariable(llvm::StringRef name) const {
+  // Matches the global function objects in std::ranges/std::ranges::views
+  // E.g.,
+  //   std::__1::ranges::views::__cpo::take
+  //   std::__1::ranges::__cpo::max_element
+  static RegularExpression ignore_global_ranges_pattern(
+      "std::__[[:alnum:]]+::ranges(::views)*::__cpo");
+
+  return ignore_globale_ranges_pattern.Execute(name);
+}
 
 bool CPPLanguageRuntime::IsAllowedRuntimeValue(ConstString name) {
   return name == g_this;

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
@@ -49,7 +49,7 @@ bool CPPLanguageRuntime::ShouldHideVariable(llvm::StringRef name) const {
   static RegularExpression ignore_global_ranges_pattern(
       "std::__[[:alnum:]]+::ranges(::views)*::__cpo");
 
-  return ignore_globale_ranges_pattern.Execute(name);
+  return ignore_global_ranges_pattern.Execute(name);
 }
 
 bool CPPLanguageRuntime::IsAllowedRuntimeValue(ConstString name) {

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.h
@@ -77,6 +77,8 @@ public:
   lldb::ThreadPlanSP GetStepThroughTrampolinePlan(Thread &thread,
                                                   bool stop_others) override;
 
+  bool ShouldHideVariable(llvm::StringRef name) const override;
+
   bool IsAllowedRuntimeValue(ConstString name) override;
 protected:
   // Classes that inherit from CPPLanguageRuntime can see and modify these

--- a/lldb/test/API/lang/cpp/hide_global_ranges_vars/Makefile
+++ b/lldb/test/API/lang/cpp/hide_global_ranges_vars/Makefile
@@ -1,0 +1,4 @@
+CXX_SOURCES := main.cpp
+CXXFLAGS_EXTRAS := -std=c++20
+
+include Makefile.rules

--- a/lldb/test/API/lang/cpp/hide_global_ranges_vars/TestHideGlobalRangesVars.py
+++ b/lldb/test/API/lang/cpp/hide_global_ranges_vars/TestHideGlobalRangesVars.py
@@ -1,0 +1,27 @@
+"""Test that frame var and target var hide
+the global function objects in the libc++
+ranges implementation"""
+
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+class HideGlobalRangesVarsTestCase(TestBase):
+
+    @add_test_categories(["libc++"])
+    @skipIf(compiler=no_match("clang"))
+    @skipIf(compiler="clang", compiler_version=['<', '16.0'])
+    def test(self):
+        self.build()
+
+        lldbutil.run_to_source_breakpoint(self, "return", lldb.SBFileSpec('main.cpp', False))
+
+        self.expect("frame variable --show-globals",
+                    substrs=["::ranges::views::__cpo",
+                             "::ranges::__cpo"],
+                    matching=False)
+
+        self.expect("target variable",
+                    substrs=["::ranges::views::__cpo",
+                             "::ranges::__cpo"],
+                    matching=False)

--- a/lldb/test/API/lang/cpp/hide_global_ranges_vars/main.cpp
+++ b/lldb/test/API/lang/cpp/hide_global_ranges_vars/main.cpp
@@ -1,0 +1,9 @@
+#include <ranges>
+
+int main(int argc, char const *argv[]) {
+  int arr[3] = {1, 2, 3};
+  auto arr_view = std::ranges::views::all(arr);
+  auto arr_max = std::ranges::max_element(arr);
+
+  return 0;
+}


### PR DESCRIPTION
The motivation is to avoid cluttering LLDB's global variable view for std::ranges users.

Before:
```
(lldb) frame var -g
...
(const std::ranges::__end::__fn) std::__1::ranges::__cpo::end = {}
(const std::ranges::views::__all::__fn) std::__1::ranges::views::__cpo::all = {}
(const std::ranges::__begin::__fn) std::__1::ranges::__cpo::begin = {}
(const std::ranges::views::__take::__fn) std::__1::ranges::views::__cpo::take = {}
(const std::ranges::__max_element::__fn) std::__1::ranges::__cpo::max_element = {}
(const std::ranges::__size::__fn) std::__1::ranges::__cpo::size = {}
(const std::ranges::__data::__fn) std::__1::ranges::__cpo::data = {}
```

After this patch none of these __cpo variables would show up.

Differential Revision: https://reviews.llvm.org/D145245

(cherry picked from commit de10c1a824405833a0f49b22e7fa3f32a1393cc3)