### PR TITLE
[cherry-pick][stable/20221013] [lldb] Format member pointers as regular pointers

### DIFF
--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -163,6 +163,8 @@ public:
 
   bool IsFunctionPointerType() const;
 
+  bool IsMemberFunctionPointerType() const;
+
   bool
   IsBlockPointerType(CompilerType *function_pointer_type_ptr = nullptr) const;
 

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -173,6 +173,9 @@ public:
 
   virtual bool IsFunctionPointerType(lldb::opaque_compiler_type_t type) = 0;
 
+  virtual bool
+  IsMemberFunctionPointerType(lldb::opaque_compiler_type_t type) = 0;
+
   virtual bool IsBlockPointerType(lldb::opaque_compiler_type_t type,
                                   CompilerType *function_pointer_type_ptr) = 0;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -1343,7 +1343,8 @@ CPlusPlusLanguage::GetHardcodedSummaries() {
                   TypeSummaryImpl::Flags(),
                   lldb_private::formatters::CXXFunctionPointerSummaryProvider,
                   "Function pointer summary provider"));
-          if (valobj.GetCompilerType().IsFunctionPointerType()) {
+          if (CompilerType CT = valobj.GetCompilerType();
+              CT.IsFunctionPointerType() || CT.IsMemberFunctionPointerType()) {
             return formatter_sp;
           }
           return nullptr;

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -5249,7 +5249,7 @@ lldb::Format TypeSystemClang::GetFormat(lldb::opaque_compiler_type_t type) {
   case clang::Type::RValueReference:
     return lldb::eFormatHex;
   case clang::Type::MemberPointer:
-    break;
+    return lldb::eFormatHex;
   case clang::Type::Complex: {
     if (qual_type->isComplexType())
       return lldb::eFormatComplex;

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -3162,6 +3162,15 @@ bool TypeSystemClang::IsTypeImpl(
   return false;
 }
 
+bool TypeSystemClang::IsMemberFunctionPointerType(
+    lldb::opaque_compiler_type_t type) {
+  auto isMemberFunctionPointerType = [](clang::QualType qual_type) {
+    return qual_type->isMemberFunctionPointerType();
+  };
+
+  return IsTypeImpl(type, isMemberFunctionPointerType);
+}
+
 bool TypeSystemClang::IsFunctionPointerType(lldb::opaque_compiler_type_t type) {
   auto isFunctionPointerType = [](clang::QualType qual_type) {
     return qual_type->isFunctionPointerType();

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -3018,28 +3018,11 @@ bool TypeSystemClang::IsCStringType(lldb::opaque_compiler_type_t type,
 }
 
 bool TypeSystemClang::IsFunctionType(lldb::opaque_compiler_type_t type) {
-  if (type) {
-    clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
+  auto isFunctionType = [&](clang::QualType qual_type) {
+    return qual_type->isFunctionType();
+  };
 
-    if (qual_type->isFunctionType()) {
-      return true;
-    }
-
-    const clang::Type::TypeClass type_class = qual_type->getTypeClass();
-    switch (type_class) {
-    default:
-      break;
-    case clang::Type::LValueReference:
-    case clang::Type::RValueReference: {
-      const clang::ReferenceType *reference_type =
-          llvm::cast<clang::ReferenceType>(qual_type.getTypePtr());
-      if (reference_type)
-        return IsFunctionType(
-            reference_type->getPointeeType().getAsOpaquePtr());
-    } break;
-    }
-  }
-  return false;
+  return IsTypeImpl(type, isFunctionType);
 }
 
 // Used to detect "Homogeneous Floating-point Aggregates"
@@ -3153,11 +3136,13 @@ TypeSystemClang::GetFunctionArgumentAtIndex(lldb::opaque_compiler_type_t type,
   return CompilerType();
 }
 
-bool TypeSystemClang::IsFunctionPointerType(lldb::opaque_compiler_type_t type) {
+bool TypeSystemClang::IsTypeImpl(
+    lldb::opaque_compiler_type_t type,
+    llvm::function_ref<bool(clang::QualType)> predicate) const {
   if (type) {
     clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
 
-    if (qual_type->isFunctionPointerType())
+    if (predicate(qual_type))
       return true;
 
     const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -3170,20 +3155,25 @@ bool TypeSystemClang::IsFunctionPointerType(lldb::opaque_compiler_type_t type) {
       const clang::ReferenceType *reference_type =
           llvm::cast<clang::ReferenceType>(qual_type.getTypePtr());
       if (reference_type)
-        return IsFunctionPointerType(
-            reference_type->getPointeeType().getAsOpaquePtr());
+        return IsTypeImpl(reference_type->getPointeeType().getAsOpaquePtr(), predicate);
     } break;
     }
   }
   return false;
 }
 
+bool TypeSystemClang::IsFunctionPointerType(lldb::opaque_compiler_type_t type) {
+  auto isFunctionPointerType = [](clang::QualType qual_type) {
+    return qual_type->isFunctionPointerType();
+  };
+
+  return IsTypeImpl(type, isFunctionPointerType);
+}
+
 bool TypeSystemClang::IsBlockPointerType(
     lldb::opaque_compiler_type_t type,
     CompilerType *function_pointer_type_ptr) {
-  if (type) {
-    clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
-
+  auto isBlockPointerType = [&](clang::QualType qual_type) {
     if (qual_type->isBlockPointerType()) {
       if (function_pointer_type_ptr) {
         const clang::BlockPointerType *block_pointer_type =
@@ -3196,23 +3186,10 @@ bool TypeSystemClang::IsBlockPointerType(
       return true;
     }
 
-    const clang::Type::TypeClass type_class = qual_type->getTypeClass();
-    switch (type_class) {
-    default:
-      break;
+    return false;
+  };
 
-    case clang::Type::LValueReference:
-    case clang::Type::RValueReference: {
-      const clang::ReferenceType *reference_type =
-          llvm::cast<clang::ReferenceType>(qual_type.getTypePtr());
-      if (reference_type)
-        return IsBlockPointerType(
-            reference_type->getPointeeType().getAsOpaquePtr(),
-            function_pointer_type_ptr);
-    } break;
-    }
-  }
-  return false;
+  return IsTypeImpl(type, isBlockPointerType);
 }
 
 bool TypeSystemClang::IsIntegerType(lldb::opaque_compiler_type_t type,

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -649,6 +649,8 @@ public:
 
   bool IsFunctionPointerType(lldb::opaque_compiler_type_t type) override;
 
+  bool IsMemberFunctionPointerType(lldb::opaque_compiler_type_t type) override;
+
   bool IsBlockPointerType(lldb::opaque_compiler_type_t type,
                           CompilerType *function_pointer_type_ptr) override;
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -1137,6 +1137,9 @@ private:
   const clang::ClassTemplateSpecializationDecl *
   GetAsTemplateSpecialization(lldb::opaque_compiler_type_t type);
 
+  bool IsTypeImpl(lldb::opaque_compiler_type_t type,
+                  llvm::function_ref<bool(clang::QualType)> predicate) const;
+
   // Classes that inherit from TypeSystemClang can see and modify these
   std::string m_target_triple;
   std::unique_ptr<clang::ASTContext> m_ast_up;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -240,6 +240,10 @@ public:
                           CompilerType *function_pointer_type_ptr) override {
     return false;
   }
+  bool IsMemberFunctionPointerType(
+          lldb::opaque_compiler_type_t type) override {
+    return false;
+  }
   bool IsPolymorphicClass(lldb::opaque_compiler_type_t type) override {
     return false;
   }

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -146,6 +146,13 @@ bool CompilerType::IsFunctionPointerType() const {
   return false;
 }
 
+bool CompilerType::IsMemberFunctionPointerType() const {
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsMemberFunctionPointerType(m_type);
+  return false;
+}
+
 bool CompilerType::IsBlockPointerType(
     CompilerType *function_pointer_type_ptr) const {
   if (IsValid())

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
@@ -292,7 +292,9 @@ class CppDataFormatterTestCase(TestBase):
             substrs=['member_ptr = 0x'])
         self.expect(
             "frame variable member_func_ptr",
-            substrs=['member_func_ptr = 0x'])
+            substrs=['member_func_ptr = 0x',
+                     '(a.out`IUseCharStar::member_func(int) at main.cpp:61)'])
         self.expect(
             "frame variable ref_to_member_func_ptr",
-            substrs=['ref_to_member_func_ptr = 0x'])
+            substrs=['ref_to_member_func_ptr = 0x',
+                     '(a.out`IUseCharStar::member_func(int) at main.cpp:61)'])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
@@ -285,3 +285,14 @@ class CppDataFormatterTestCase(TestBase):
             matching=False,
             substrs=['(int) iAmInt = 0x00000001'])
         self.expect("frame variable iAmInt", substrs=['(int) iAmInt = 1'])
+
+        # Check that pointer to members are correctly formatted
+        self.expect(
+            "frame variable member_ptr",
+            substrs=['member_ptr = 0x'])
+        self.expect(
+            "frame variable member_func_ptr",
+            substrs=['member_func_ptr = 0x'])
+        self.expect(
+            "frame variable ref_to_member_func_ptr",
+            substrs=['ref_to_member_func_ptr = 0x'])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/main.cpp
@@ -57,6 +57,8 @@ struct IUseCharStar
 {
 	const char* pointer;
 	IUseCharStar() : pointer("Hello world") {}
+
+        char const *member_func(int) { return ""; }
 };
 
 int main (int argc, const char * argv[])
@@ -106,7 +108,12 @@ int main (int argc, const char * argv[])
     char* strptr     = "Hello world!";
     
     i_am_cooler the_coolest_guy(1,2,3.14,6.28,'E','G');
-        
+
+    const char *IUseCharStar::*member_ptr = &IUseCharStar::pointer;
+    const char *(IUseCharStar::*member_func_ptr)(int) =
+        &IUseCharStar::member_func;
+    auto &ref_to_member_func_ptr = member_func_ptr;
+
     return 0; // Set break point at this line.
 }
 

--- a/lldb/test/Shell/SymbolFile/NativePDB/ast-types.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/ast-types.cpp
@@ -131,15 +131,15 @@ int SI::*mp9 = nullptr;
 // CHECK: (Anonymous<int>) AnonInt = (AnonymousMember = 0)
 // CHECK: (Anonymous<A::B::C<void>>) AnonABCVoid = (AnonymousMember = 0)
 // CHECK: (Anonymous<A::B::C<void>>::D) AnonABCVoidD = (AnonymousDMember = 0)
-// CHECK: (void (SI::*)()) mp1 = 00 00 00 00 00 00 00 00
-// CHECK: (void (MI::*)()) mp2 = 00 00 00 00 00 00 00 00
-// CHECK: (void (MI2::*)()) mp3 = 00 00 00 00 00 00 00 00
-// CHECK: (void (VI::*)()) mp4 = 00 00 00 00 00 00 00 00
-// CHECK: (void (VI2::*)()) mp5 = 00 00 00 00 00 00 00 00
-// CHECK: (void (UI::*)()) mp6 = 00 00 00 00 00 00 00 00
+// CHECK: (void (SI::*)()) mp1 = 0x0000000000000000
+// CHECK: (void (MI::*)()) mp2 = 0x0000000000000000
+// CHECK: (void (MI2::*)()) mp3 = 0x0000000000000000
+// CHECK: (void (VI::*)()) mp4 = 0x0000000000000000
+// CHECK: (void (VI2::*)()) mp5 = 0x0000000000000000
+// CHECK: (void (UI::*)()) mp6 = 0x0000000000000000
 // CHECK: (void (MI::**)()) mp7 = 0x0000000000000000
 // CHECK: (void (VI2::**)()) mp8 = 0x0000000000000000
-// CHECK: (int SI::*) mp9 = ff ff ff ff
+// CHECK: (int SI::*) mp9 = 0xffffffff
 // CHECK: Dumping clang ast for 1 modules.
 // CHECK: TranslationUnitDecl {{.*}}
 // CHECK: |-CXXRecordDecl {{.*}} class TrivialC definition


### PR DESCRIPTION
This patch turns,
```
(lldb) v pointer_to_member_func
(void (Foo::*)()) $1 = 94 3f 00 00 01 00 00 00 00 00 00 00 00 00 00 00
```
into
```
(lldb) v pointer_to_member_func
(void (Foo::*)()) ::pointer_to_member_func = 0x00000000000000000000000100003f94 (a.out`Foo::member_func() at main.cpp:3)
```