### PR TITLE
[lldb] Implement identification of generic Swift types in C++

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -219,8 +219,12 @@ public:
                                 Address &address,
                                 Value::ValueType &value_type) override;
 
+  CompilerType BindGenericTypeParameters(
+      CompilerType unbound_type,
+      std::function<CompilerType(unsigned, unsigned)> finder);
+
   /// Extract the value object which contains the Swift type's "contents".
-  /// Returns null if this is not a C++ wrapping a Swift type. 
+  /// Returns null if this is not a C++ wrapping a Swift type.
   static lldb::ValueObjectSP
   ExtractSwiftValueObjectFromCxxWrapper(ValueObject &valobj);
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2034,6 +2034,75 @@ ForEachGenericParameter(swift::Demangle::NodePointer node,
   }
 }
 
+CompilerType SwiftLanguageRuntimeImpl::BindGenericTypeParameters(
+    CompilerType unbound_type,
+    std::function<CompilerType(unsigned, unsigned)> type_resolver) {
+  LLDB_SCOPED_TIMER();
+  using namespace swift::Demangle;
+
+  auto ts =
+      unbound_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
+  Status error;
+  auto *reflection_ctx = GetReflectionContext();
+  if (!reflection_ctx) {
+    LLDB_LOG(GetLog(LLDBLog::Types),
+             "No reflection context available.");
+    return unbound_type;
+  }
+
+  Demangler dem;
+  NodePointer unbound_node =
+      dem.demangleSymbol(unbound_type.GetMangledTypeName().GetStringRef());
+  auto type_ref_or_err =
+      decodeMangledType(reflection_ctx->getBuilder(), unbound_node);
+  if (type_ref_or_err.isError()) {
+    LLDB_LOG(GetLog(LLDBLog::Expressions | LLDBLog::Types),
+             "Couldn't get TypeRef of unbound type.");
+    return {};
+  }
+
+  swift::reflection::GenericArgumentMap substitutions;
+  bool failure = false;
+  ForEachGenericParameter(unbound_node, [&](unsigned depth, unsigned index) {
+    if (failure)
+      return;
+    if (substitutions.count({depth, index}))
+      return;
+
+    auto type = type_resolver(depth, index);
+    if (!type) {
+      LLDB_LOG(GetLog(LLDBLog::Expressions | LLDBLog::Types),
+               "type_finder function failed to find type.");
+      failure = true;
+      return;
+    }
+
+    NodePointer child_node =
+        dem.demangleSymbol(type.GetMangledTypeName().GetStringRef());
+    auto type_ref_or_err =
+        decodeMangledType(reflection_ctx->getBuilder(), child_node);
+    if (type_ref_or_err.isError()) {
+      LLDB_LOG(GetLog(LLDBLog::Expressions | LLDBLog::Types),
+               "Couldn't get TypeRef when binding generic type parameters.");
+      failure = true;
+      return;
+    }
+
+    substitutions.insert({{depth, index}, type_ref_or_err.getType()});
+  });
+
+  if (failure)
+    return {};
+
+  const swift::reflection::TypeRef *type_ref = type_ref_or_err.getType();
+
+  // Apply the substitutions.
+  const swift::reflection::TypeRef *bound_type_ref =
+      type_ref->subst(reflection_ctx->getBuilder(), substitutions);
+  NodePointer node = bound_type_ref->getDemangling(dem);
+  return ts->GetTypeSystemSwiftTypeRef().RemangleAsType(dem, node);
+}
+
 CompilerType
 SwiftLanguageRuntimeImpl::BindGenericTypeParameters(StackFrame &stack_frame,
                                                     TypeSystemSwiftTypeRef &ts,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -145,6 +145,10 @@ public:
       bool &child_is_deref_of_parent, ValueObject *valobj,
       uint64_t &language_flags);
 
+  CompilerType BindGenericTypeParameters(
+      CompilerType unbound_type,
+      std::function<CompilerType(unsigned, unsigned)> type_resolver);
+
   /// Like \p BindGenericTypeParameters but for TypeSystemSwiftTypeRef.
   CompilerType BindGenericTypeParameters(StackFrame &stack_frame,
                                          TypeSystemSwiftTypeRef &ts,

--- a/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/TestSwiftFormatSwiftTypesInCxx.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/TestSwiftFormatSwiftTypesInCxx.py
@@ -34,3 +34,9 @@ class TestSwiftFormatSwiftTypesInCxx(TestBase):
         self.expect('p swiftStruct', substrs=['SwiftStruct', 'str = "Hello this is a big string"', 
             'boolean = true'])
 
+        self.expect('v wrapper', substrs=['a.GenericPair<a.SwiftClass, a.SwiftStruct>', 
+                'field = 42', 'arr = 4 values', '[0] = "An"', '[1] = "array"', '[2] = "of"', 
+                '[3] = "strings"', 'str = "Hello this is a big string"', 'boolean = true'])
+        self.expect('p wrapper', substrs=['a.GenericPair<a.SwiftClass, a.SwiftStruct>', 
+                'field = 42', 'arr = 4 values', '[0] = "An"', '[1] = "array"', '[2] = "of"', 
+                '[3] = "strings"', 'str = "Hello this is a big string"', 'boolean = true'])

--- a/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/main.cpp
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/main.cpp
@@ -5,5 +5,6 @@ int main() {
   auto swiftClass = returnSwiftClass();
   auto swiftSublass = returnSwiftSubclassAsClass();
   auto swiftStruct = returnSwiftStruct();
+  auto wrapper = returnPair(swiftClass, swiftStruct);
   return 0; // Set breakpoint here.
 }

--- a/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/swift-types.swift
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/test-format-swift-types-in-cxx/swift-types.swift
@@ -13,6 +13,17 @@ public struct SwiftStruct {
   var boolean = true
 }
 
+@frozen
+public struct GenericPair<T, T2> {
+    var x: T
+    var y: T2
+
+    init(x: T, y: T2) {
+        self.x = x
+        self.y = y
+    }
+}
+
 public func returnSwiftClass() -> SwiftClass {
   return SwiftClass()
 }
@@ -23,4 +34,8 @@ public func returnSwiftSubclassAsClass() -> SwiftClass {
 
 public func returnSwiftStruct() -> SwiftStruct {
   return SwiftStruct()
+}
+
+public func returnPair<T, U>(t: T, u: U) -> GenericPair<T, U> {
+  return GenericPair<T, U>(x: t, y: u)
 }


### PR DESCRIPTION
The mangled name generated for generic Swift types contain unbound generics. Implement substituting those generic types in by consulting the C++ generated type's templates, and recursively resolving those to their Swift counterpart.

(cherry picked from commit b3aa2dd96073404b49038cdcdf4370d676f41aa2)