### PR TITLE
[lldb] When Swift/C++ is enabled, let Clang imported types format as …

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -811,6 +811,59 @@ ExtractSwiftTypeFromCxxInteropType(CompilerType type, TypeSystemSwift &ts,
   return {};
 }
 
+
+/// Synthetic child that wraps a value object.
+class ValueObjectWrapperSyntheticChildren : public SyntheticChildren {
+  class ValueObjectWrapperFrontEndProvider : public SyntheticChildrenFrontEnd {
+  public:
+    ValueObjectWrapperFrontEndProvider(ValueObject &backend)
+        : SyntheticChildrenFrontEnd(backend) {}
+
+    size_t CalculateNumChildren() override {
+      return 1;
+    }
+
+    lldb::ValueObjectSP GetChildAtIndex(size_t idx) override {
+      return idx == 0 ? m_backend.GetSP() : nullptr;
+    }
+
+    size_t GetIndexOfChildWithName(ConstString name) override {
+      return m_backend.GetName() == name ? 0 : UINT32_MAX;
+    }
+
+    bool Update() override { return false; }
+
+    bool MightHaveChildren() override { return true; }
+
+    ConstString GetSyntheticTypeName() override {
+      return m_backend.GetCompilerType().GetTypeName();
+    }
+  };
+
+public:
+  ValueObjectWrapperSyntheticChildren(ValueObjectSP valobj, const Flags &flags) 
+      : SyntheticChildren(flags), m_valobj(valobj) {}
+
+  SyntheticChildrenFrontEnd::AutoPointer
+  GetFrontEnd(ValueObject &backend) override {
+    if (!m_valobj)
+      return nullptr;
+    // We ignore the backend parameter here, as we have a more specific one
+    // available.
+    return std::make_unique<ValueObjectWrapperFrontEndProvider>(*m_valobj); 
+  }
+
+  bool IsScripted() override { return false; }
+
+  std::string GetDescription() override {
+    return "C++ bridged synthetic children";
+  }
+
+private:
+  ValueObjectSP m_valobj;
+};
+
+
 HardcodedFormatters::HardcodedSyntheticFinder
 SwiftLanguage::GetHardcodedSynthetics() {
   static std::once_flag g_initialize;
@@ -1007,11 +1060,68 @@ SwiftLanguage::GetHardcodedSynthetics() {
           swift_type = type_or_name.GetCompilerType();
           // Cast it to the more specific type.
           casted_to_swift = casted_to_swift->Cast(swift_type);
+          if (!casted_to_swift) {
+            LLDB_LOGF(log,
+                      "[Matching CxxBridgedSyntheticChildProvider] - "
+                      "Could not cast value object to dynamic swift type.");
+            return nullptr;
+          }
         }
       }
 
-      return swift_runtime->GetCxxBridgedSyntheticChildProvider(
-          casted_to_swift);
+      casted_to_swift->SetName(ConstString("Swift_Type"));
+
+      SyntheticChildrenSP synth_sp =
+          SyntheticChildrenSP(new ValueObjectWrapperSyntheticChildren(
+              casted_to_swift, SyntheticChildren::Flags()));
+      return synth_sp;
+    });
+    g_formatters.push_back([](lldb_private::ValueObject &valobj,
+                              lldb::DynamicValueType,
+                              FormatManager &) -> lldb::SyntheticChildrenSP {
+      // If C++ interop is enabled, format imported clang types as clang types,
+      // instead of attempting to disguise them as Swift types.
+
+      Log *log(GetLog(LLDBLog::DataFormatters));
+
+      if (!valobj.GetTargetSP()->GetSwiftEnableCxxInterop())
+        return nullptr;
+
+      CompilerType type(valobj.GetCompilerType());
+      auto swift_type_system =
+          type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
+      if (!swift_type_system)
+        return nullptr;
+
+      CompilerType original_type;
+      if (!swift_type_system->IsImportedType(type.GetOpaqueQualType(),
+                                        &original_type))
+        return nullptr;
+
+      if (!original_type.GetTypeSystem().isa_and_nonnull<TypeSystemClang>())
+        return nullptr;
+
+      auto qual_type =
+          TypeSystemClang::GetQualType(original_type.GetOpaqueQualType());
+      auto *decl = qual_type->getAsCXXRecordDecl();
+      if (!decl) {
+        LLDB_LOGV(log, "[Matching Clang imported type] - "
+                       "Could not get decl from clang type");
+        return nullptr;
+      }
+      auto casted = valobj.Cast(original_type);
+      if (!casted) {
+        LLDB_LOGV(log, "[Matching Clang imported type] - "
+                       "Could not cast value object to clang type");
+        return nullptr;
+      }
+
+      casted->SetName(ConstString("Clang_Type"));
+
+      SyntheticChildrenSP synth_sp =
+          SyntheticChildrenSP(new ValueObjectWrapperSyntheticChildren(
+              casted, SyntheticChildren::Flags()));
+      return synth_sp;
     });
   });
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -413,9 +413,6 @@ public:
   lldb::SyntheticChildrenSP
   GetBridgedSyntheticChildProvider(ValueObject &valobj);
 
-  /// Get the synthethic child provider that displays Swift in C++ frames.
-  lldb::SyntheticChildrenSP
-  GetCxxBridgedSyntheticChildProvider(lldb::ValueObjectSP valobj);
 
   /// Expression Callbacks.
   /// \{

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -183,10 +183,6 @@ public:
   lldb::SyntheticChildrenSP
   GetBridgedSyntheticChildProvider(ValueObject &valobj);
 
-  /// Get the synthethic child provider that displays Swift in C++ frames.
-  lldb::SyntheticChildrenSP
-  GetCxxBridgedSyntheticChildProvider(lldb::ValueObjectSP valobj);
-
   bool IsABIStable();
 
   void DumpTyperef(CompilerType type, TypeSystemSwiftTypeRef *module_holder,

--- a/lldb/test/API/lang/swift/cxx_interop/forward/test-cxx-class/TestCxxClass.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/test-cxx-class/TestCxxClass.py
@@ -17,3 +17,7 @@ class TestClass(TestBase):
 
         self.expect('v x', substrs=['CxxClass', 'a1', '10', 'a2', '20', 'a3', '30'])
         self.expect('po x', substrs=['CxxClass', 'a1', '10', 'a2', '20', 'a3', '30'])
+
+        self.expect('v y', substrs=['InheritedCxxClass', 'a1', '10', 'a2', '20', 'a3', '30', 'a4', '40'])
+        # FIXME: rdar://106216567
+        self.expect('po y', substrs=['InheritedCxxClass', 'a4', '40'])

--- a/lldb/test/API/lang/swift/cxx_interop/forward/test-cxx-class/main.swift
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/test-cxx-class/main.swift
@@ -2,6 +2,7 @@ import ReturnsClass
 
 func main() {
   let x = CxxClass()
+  let y = InheritedCxxClass()
   print(x) // Set breakpoint here
 }
 main()

--- a/lldb/test/API/lang/swift/cxx_interop/forward/test-cxx-class/returns-class.h
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/test-cxx-class/returns-class.h
@@ -5,3 +5,6 @@ struct CxxClass {
   long long a3 = 30;
 };
 
+struct InheritedCxxClass: CxxClass {
+  long long a4 = 40;
+};


### PR DESCRIPTION
…Clang types.

Instead of attempting to format Clang types as Swift types, let existing engine to format Clang types do the job.

rdar://100285267