### PR TITLE
[CMake][lldb] change the runpath to an architecture-specific directory on ELF platforms

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -186,7 +186,7 @@ function(add_properties_for_swift_modules target reldir)
     elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
       string(REGEX MATCH "^[^-]*" arch ${LLVM_TARGET_TRIPLE})
       target_link_libraries(${target} PRIVATE swiftCore-linux-${arch})
-      set(SWIFT_RPATH "${LLDB_SWIFT_LIBS}/linux;$ORIGIN/../lib/swift/linux")
+      set(SWIFT_RPATH "${LLDB_SWIFT_LIBS}/linux/${arch};$ORIGIN/../lib/swift/linux/${arch}")
     endif()
 
     set_property(TARGET ${target} APPEND PROPERTY BUILD_RPATH "${SWIFT_RPATH}")

--- a/lldb/tools/repl/swift/CMakeLists.txt
+++ b/lldb/tools/repl/swift/CMakeLists.txt
@@ -26,11 +26,11 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
       BUILD_RPATH ${SWIFT_LIBRARY_DIR}/swift/linux/powerpc64le)
   else()
     set_target_properties(repl_swift PROPERTIES
-      BUILD_RPATH ${SWIFT_LIBRARY_DIR}/swift/linux)
+      BUILD_RPATH ${SWIFT_LIBRARY_DIR}/swift/linux/${CMAKE_SYSTEM_PROCESSOR})
   endif()
   set_target_properties(repl_swift PROPERTIES
     BUILD_WITH_INSTALL_RPATH NO
-    INSTALL_RPATH "$ORIGIN/../lib/swift/linux")
+    INSTALL_RPATH "$ORIGIN/../lib/swift/linux/${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 
 # The dummy repl executable is a C program, but we always look for a mangled


### PR DESCRIPTION
This is needed for apple/swift#63782, which changes the Unix toolchain to look for libraries in architecture-specific directories.