### PR TITLE
[SelectionDag] Remove old code handling dbg.addr

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -5778,49 +5778,6 @@ bool SelectionDAGBuilder::EmitFuncArgumentDbgValue(
   if (!Op)
     return false;
 
-  // If we had a dbg declare, just emit it here.
-  if (Kind == FuncArgumentDbgValueKind::Declare) {
-    if (!Op->isReg()) {
-      LLVM_DEBUG(
-          llvm::dbgs()
-          << "Failed to emit dbg_value for llvm.dbg.addr since not a reg?!\n");
-      return false;
-    }
-
-    // Today, this code is only used on swift async contexts, so if we don't
-    // have one, then return early and emit an LLVM_DEBUG.
-    if (!Arg->getParent()->hasParamAttribute(Arg->getArgNo(),
-                                             Attribute::SwiftAsync) ||
-        Arg->getArgNo() != 0) {
-      LLVM_DEBUG(
-          llvm::dbgs()
-          << "Failed to emit dbg_value for llvm.dbg.addr since going along "
-             "swift async parameter path, but not a swift async parameter?!\n");
-      return false;
-    }
-
-    // Reg is always by nature of the swift async ABI to be the register of the
-    // first livein variable of a machine function.
-    unsigned Reg = MF.getRegInfo().livein_begin()->first;
-
-    // Then add the entry value to our expression.
-    Expr = DIExpression::prepend(Expr, DIExpression::EntryValue);
-
-    // And create the vreg dbg value with an entry value expression prepended.
-    SDDbgValue *SDV = DAG.getVRegDbgValue(
-        Variable, Expr, Reg, true /*is indirect*/, DL, SDNodeOrder);
-
-    // It may seem counter-intuitive that we are passing something that is
-    // clearly a parameter with false to "is parameter". The reason why we are
-    // doing this is semantically marking a debug value with this marker causes
-    // InstrEmitter to hoist the emitted debug info to the beginning of the
-    // entry block. This is a code pattern only valid with dbg.declare. In
-    // contrast, we need to emit dbg.addr at the specific location where it was
-    // asked to be emitted.
-    DAG.AddDbgValue(SDV, false /*treat as dbg.declare byval parameter*/);
-    return true;
-  }
-
   assert(Variable->isValidLocationForIntrinsic(DL) &&
          "Expected inlined-at fields to agree");
   MachineInstr *NewMI = nullptr;


### PR DESCRIPTION
Prior to the removal of dbg.addr, the deleted code in this commit was handling said intrinsic. In an attempt to resolve the merge issues, the `if is dbg addr` was replaced with an `if is dbg declare`. This is clearly incorrect, as it changes how those intrinsics are handled and makes a lot of tests fail; we now delete all of this code.

Of note, all the deleted code assumes it is handling swift code; as such, if the swift front-end just switches dbg.addr to dbg.declare, it may encounter problems. That said, no tests fail right now, so either this concern is irrelevant or the old behavior was not tested.