### PR TITLE
[lldb] When Swift/C++ is enabled, let Clang imported types format as …

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -413,9 +413,6 @@ public:
   lldb::SyntheticChildrenSP
   GetBridgedSyntheticChildProvider(ValueObject &valobj);
 
-  /// Get the synthethic child provider that displays Swift in C++ frames.
-  lldb::SyntheticChildrenSP
-  GetCxxBridgedSyntheticChildProvider(lldb::ValueObjectSP valobj);
 
   /// Expression Callbacks.
   /// \{

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -183,10 +183,6 @@ public:
   lldb::SyntheticChildrenSP
   GetBridgedSyntheticChildProvider(ValueObject &valobj);
 
-  /// Get the synthethic child provider that displays Swift in C++ frames.
-  lldb::SyntheticChildrenSP
-  GetCxxBridgedSyntheticChildProvider(lldb::ValueObjectSP valobj);
-
   bool IsABIStable();
 
   void DumpTyperef(CompilerType type, TypeSystemSwiftTypeRef *module_holder,

--- a/lldb/test/API/lang/swift/cxx_interop/forward/test-cxx-class/TestCxxClass.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/test-cxx-class/TestCxxClass.py
@@ -17,3 +17,7 @@ class TestClass(TestBase):
 
         self.expect('v x', substrs=['CxxClass', 'a1', '10', 'a2', '20', 'a3', '30'])
         self.expect('po x', substrs=['CxxClass', 'a1', '10', 'a2', '20', 'a3', '30'])
+
+        self.expect('v y', substrs=['InheritedCxxClass', 'a1', '10', 'a2', '20', 'a3', '30', 'a4', '40'])
+        # FIXME: rdar://106216567
+        self.expect('po y', substrs=['InheritedCxxClass', 'a4', '40'])

--- a/lldb/test/API/lang/swift/cxx_interop/forward/test-cxx-class/main.swift
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/test-cxx-class/main.swift
@@ -2,6 +2,7 @@ import ReturnsClass
 
 func main() {
   let x = CxxClass()
+  let y = InheritedCxxClass()
   print(x) // Set breakpoint here
 }
 main()

--- a/lldb/test/API/lang/swift/cxx_interop/forward/test-cxx-class/returns-class.h
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/test-cxx-class/returns-class.h
@@ -5,3 +5,6 @@ struct CxxClass {
   long long a3 = 30;
 };
 
+struct InheritedCxxClass: CxxClass {
+  long long a4 = 40;
+};


### PR DESCRIPTION
…Clang types.

Instead of attempting to format Clang types as Swift types, let existing engine to format Clang types do the job.

rdar://100285267
(cherry picked from commit b55f83381a8d0b96e7ed73bd0f87986a55ff63d2)