### PR TITLE
[lldb] Implement formatting of Swift types in C++ frames via interop

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -149,6 +149,12 @@ class Builder:
                 configuration.swift_libs_dir)]
         return []
 
+    def getLLDBSwiftLibs(self):
+        if configuration.swift_libs_dir:
+            return ["SWIFT_LIBS_DIR={}".format(
+                configuration.swift_libs_dir)]
+        return []
+
     def _getDebugInfoArgs(self, debug_info):
         if debug_info is None:
             return []

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -387,6 +387,12 @@ public:
     return {};
   }
 
+  lldb::SyntheticChildrenSP
+  GetCxxBridgedSyntheticChildProvider(ValueObjectSP valobj) {
+    STUB_LOG();
+    return {};
+  }
+
   void WillStartExecutingUserExpression(bool runs_in_playground_or_repl) {
     if (!runs_in_playground_or_repl)
       STUB_LOG();
@@ -2469,6 +2475,12 @@ bool SwiftLanguageRuntime::IsValidErrorValue(ValueObject &in_value) {
 lldb::SyntheticChildrenSP
 SwiftLanguageRuntime::GetBridgedSyntheticChildProvider(ValueObject &valobj) {
   FORWARD(GetBridgedSyntheticChildProvider, valobj);
+}
+
+lldb::SyntheticChildrenSP
+SwiftLanguageRuntime::GetCxxBridgedSyntheticChildProvider(
+    ValueObjectSP valobj) {
+  FORWARD(GetCxxBridgedSyntheticChildProvider, valobj);
 }
 
 void SwiftLanguageRuntime::WillStartExecutingUserExpression(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -413,7 +413,6 @@ public:
   lldb::SyntheticChildrenSP
   GetBridgedSyntheticChildProvider(ValueObject &valobj);
 
-
   /// Expression Callbacks.
   /// \{
   void WillStartExecutingUserExpression(bool);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -183,6 +183,10 @@ public:
   lldb::SyntheticChildrenSP
   GetBridgedSyntheticChildProvider(ValueObject &valobj);
 
+  /// Get the synthethic child provider that displays Swift in C++ frames.
+  lldb::SyntheticChildrenSP
+  GetCxxBridgedSyntheticChildProvider(lldb::ValueObjectSP valobj);
+
   bool IsABIStable();
 
   void DumpTyperef(CompilerType type, TypeSystemSwiftTypeRef *module_holder,


### PR DESCRIPTION
Swift types imported in C++ are wrapped by compiler generated types. This patch adds functionality to recognize those types, and present the underlying Swift types via synthetic child providers.

rdar://100285269
(cherry picked from commit 707ab21960fd8d1c1c44b75bf614efd6a617a06a)