### PR TITLE
Support variadic generics in LLDB.

### DIFF
--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -1106,7 +1106,8 @@ FLAGS_ENUM(TypeFlags){
     eTypeIsTuple = (1u << 26),
     eTypeIsMetatype = (1u << 27),
     eTypeHasUnboundGeneric = (1u << 28),
-    eTypeHasDynamicSelf = (1u << 29)};
+    eTypeHasDynamicSelf = (1u << 29),
+    eTypeIsPack = (1u << 30)};
 
 FLAGS_ENUM(CommandFlags){
     /// eCommandRequiresTarget

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -261,6 +261,12 @@ public:
   };
 
 protected:
+  static void
+  ForEachGenericParameter(swift::Demangle::NodePointer node,
+                          std::function<void(unsigned, unsigned)> callback) {
+    SwiftLanguageRuntime::ForEachGenericParameter(node, callback);
+  }
+
   /// Use the reflection context to build a TypeRef object.
   const swift::reflection::TypeRef *
   GetTypeRef(CompilerType type, TypeSystemSwiftTypeRef *module_holder);
@@ -276,7 +282,11 @@ protected:
   Value::ValueType GetValueType(ValueObject &in_value,
                                 CompilerType dynamic_type,
                                 bool is_indirect_enum_case);
-
+  bool GetDynamicTypeAndAddress_Pack(ValueObject &in_value,
+                                     CompilerType pack_type,
+                                     lldb::DynamicValueType use_dynamic,
+                                     TypeAndOrName &class_type_or_name,
+                                     Address &address);
   bool GetDynamicTypeAndAddress_Class(ValueObject &in_value,
                                       CompilerType class_type,
                                       lldb::DynamicValueType use_dynamic,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -1172,5 +1172,172 @@ SwiftLanguageRuntime::GetStepThroughTrampolinePlan(Thread &thread,
                                                    bool stop_others) {
   return ::GetStepThroughTrampolinePlan(thread, stop_others);
 }
+
+llvm::Optional<SwiftLanguageRuntime::GenericSignature>
+SwiftLanguageRuntime::GetGenericSignature(StringRef function_name,
+                                          TypeSystemSwiftTypeRef &ts) {
+  GenericSignature signature;
+  unsigned num_generic_params = 0;
+
+  // Walk to the function type.
+  Context ctx;
+  auto *node = SwiftLanguageRuntime::DemangleSymbolAsNode(function_name, ctx);
+  if (!node)
+    return {};
+  if (node->getKind() != swift::Demangle::Node::Kind::Global)
+    return {};
+  if (node->getNumChildren() != 1)
+    return {};
+  node = node->getFirstChild();
+  for (auto child : *node)
+    if (child->getKind() == swift::Demangle::Node::Kind::Type) {
+      node = child;
+      break;
+    }
+  if (node->getKind() != swift::Demangle::Node::Kind::Type)
+    return {};
+  if (node->getNumChildren() != 1)
+    return {};
+  node = node->getFirstChild();
+
+  // Collect all the generic parameters.
+  // Build a sorted map of (depth, index) -> <idx in signature.generic_params>.
+  std::map<std::pair<unsigned, unsigned>, unsigned> param_idx;
+  ForEachGenericParameter(node, [&](unsigned depth, unsigned index) {
+    param_idx[{depth, index}] = 0;
+  });
+  num_generic_params = param_idx.size();
+  unsigned i = 0;
+  for (auto &p : param_idx) {
+    param_idx[p.first] = i;
+    signature.generic_params.emplace_back(p.first.first, p.first.second,
+                                          num_generic_params);
+    // Every generic parameter has the same shape as itself.
+    signature.generic_params.back().same_shape.set(i);
+    ++i;
+  }
+
+  // Collect the same shape requirements and store them in the
+  // same_shape bit vector.
+  if (node->getKind() != swift::Demangle::Node::Kind::DependentGenericType)
+    return {};
+  if (node->getNumChildren() != 2)
+    return {};
+  auto sig_node = node->getFirstChild();
+  if (sig_node->getKind() !=
+      swift::Demangle::Node::Kind::DependentGenericSignature)
+    return {};
+  for (auto child : *sig_node) {
+    if (child->getKind() ==
+            swift::Demangle::Node::Kind::DependentGenericParamCount &&
+        child->hasIndex()) {
+      if (child->getIndex() != num_generic_params)
+        return {};
+      continue;
+    }
+    if (child->getKind() ==
+        swift::Demangle::Node::Kind::DependentGenericSameShapeRequirement) {
+      if (child->getNumChildren() != 2)
+        return {};
+      llvm::SmallVector<unsigned, 2> idx;
+      ForEachGenericParameter(child, [&](unsigned depth, unsigned index) {
+        idx.push_back(param_idx[{depth, index}]);
+      });
+      if (idx.size() != 2)
+        return {};
+
+      signature.generic_params[idx[0]].same_shape.set(idx[1]);
+      signature.generic_params[idx[1]].same_shape.set(idx[0]);
+    }
+  }
+
+  // Collect the shapes of the packs.
+  node = node->getLastChild();
+  if (node->getKind() != swift::Demangle::Node::Kind::Type)
+    return {};
+  bool error = false;
+  // For each pack_expansion...
+  swift::Demangle::NodePointer type_node = nullptr;
+  TypeSystemSwiftTypeRef::PreOrderTraversal(
+      node, [&](swift::Demangle::NodePointer node) {
+        if (node->getKind() == swift::Demangle::Node::Kind::PackExpansion) {
+          if (node->getNumChildren() != 2) {
+            error = true;
+            return false;
+          }
+          unsigned n = 0;
+          // Store the shape of each pack expansion as index into
+          // signature.generic_params.
+          ForEachGenericParameter(
+              node->getLastChild(), [&](unsigned depth, unsigned index) {
+                unsigned idx = param_idx[{depth, index}];
+                signature.pack_expansions.push_back({num_generic_params, idx});
+                ++n;
+              });
+          if (n != 1)
+            error = true;
+
+          // Record the generic parameters used in this expansion.
+          ForEachGenericParameter(
+              node->getFirstChild(), [&](unsigned depth, unsigned index) {
+                unsigned idx = param_idx[{depth, index}];
+                signature.pack_expansions.back().generic_params.set(idx);
+              });
+
+          // Store the various type packs.
+          swift::Demangle::Demangler dem;
+          auto mangling = swift::Demangle::mangleNode(type_node);
+          if (mangling.isSuccess())
+            signature.pack_expansions.back().mangled_type =
+                ts.RemangleAsType(dem, type_node).GetMangledTypeName();
+
+          // Assuming that there are no nested pack_expansions.
+          return false;
+        }
+        type_node = node;
+        return true;
+      });
+
+  if (error)
+    return {};
   
+  // Build the maps associating value and type packs with their count
+  // arguments.
+  unsigned next_count = 0;
+  unsigned sentinel = num_generic_params;
+  // Lists all shape inidices that were already processed.
+  llvm::BitVector skip(num_generic_params);
+  // Count argument for each shape.
+  llvm::SmallVector<unsigned, 4> value_pack_count(num_generic_params, sentinel);
+  // For each pack_expansion (= value pack) ...
+  for (unsigned j = 0; j < signature.pack_expansions.size(); ++j) {
+    unsigned shape_idx = signature.pack_expansions[j].shape;
+    unsigned count = value_pack_count[shape_idx];
+    // If this pack_expansion doesn't share the shape of a previous
+    // argument, allocate a new count argument.
+    if (count == sentinel) {
+      count = next_count++;
+      // Store the count argument for this shape.
+      value_pack_count[shape_idx] = count;
+    }
+    signature.count_for_value_pack.push_back(count);
+
+    if (skip[shape_idx])
+      continue;
+
+    // All type packs used in this expansion share same count argument.
+    for (unsigned p : signature.pack_expansions[j].generic_params.set_bits())
+      if (signature.generic_params[p].same_shape[shape_idx])
+        signature.count_for_type_pack.push_back(count);
+
+    // Mark all pack_expansions with the same shape for skipping.
+    auto shape = signature.generic_params[shape_idx];
+    skip |= shape.same_shape;
+  }
+  assert(signature.count_for_value_pack.size() ==
+         signature.pack_expansions.size());
+
+  return signature;
+}
+
 } // namespace lldb_private

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5276,8 +5276,6 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
   case swift::TypeKind::Module:
   case swift::TypeKind::ElementArchetype:
   case swift::TypeKind::OpenedArchetype:
-  case swift::TypeKind::Pack:
-  case swift::TypeKind::PackExpansion:
   case swift::TypeKind::ParameterizedProtocol:
   case swift::TypeKind::Placeholder:
   case swift::TypeKind::PrimaryArchetype:
@@ -5286,7 +5284,6 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
   case swift::TypeKind::SILFunction:
   case swift::TypeKind::SILMoveOnlyWrapped:
   case swift::TypeKind::SILToken:
-  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::Unresolved:
   case swift::TypeKind::VariadicSequence:
@@ -5393,6 +5390,12 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
     break;
   case swift::TypeKind::DynamicSelf:
     swift_flags |= eTypeHasValue;
+    break;
+
+  case swift::TypeKind::Pack:
+  case swift::TypeKind::PackExpansion:
+  case swift::TypeKind::PackArchetype:
+    swift_flags |= eTypeIsPack;
     break;
 
   case swift::TypeKind::Optional:

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -269,6 +269,15 @@ public:
   CompilerType GetErrorType() override;
   CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
   CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) override;
+  /// Wrap type inside a SILPackType.
+  CompilerType CreateSILPackType(CompilerType type, bool indirect);
+  struct PackTypeInfo {
+    unsigned count = 0;
+    bool indirect = false;
+    bool expanded = false;
+  };
+  llvm::Optional<PackTypeInfo> IsSILPackType(CompilerType type);
+  CompilerType GetSILPackElementAtIndex(CompilerType type, unsigned i);
   CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) override;
   bool IsTupleType(lldb::opaque_compiler_type_t type) override;
@@ -296,7 +305,13 @@ public:
   static swift::Demangle::NodePointer Transform(
       swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
       std::function<swift::Demangle::NodePointer(swift::Demangle::NodePointer)>
-          fn);
+          visitor);
+
+  /// A left-to-right preorder traversal. Don't visit children if
+  /// visitor returns false.
+  static void
+  PreOrderTraversal(swift::Demangle::NodePointer node,
+                    std::function<bool(swift::Demangle::NodePointer)>);
 
   /// Canonicalize Array, Dictionary and Optional to their sugared form.
   static swift::Demangle::NodePointer

--- a/lldb/test/API/lang/swift/variadic_generics/Makefile
+++ b/lldb/test/API/lang/swift/variadic_generics/Makefile
@@ -1,0 +1,6 @@
+#C_SOURCES := main.c
+SWIFT_SOURCES := a.swift
+#HIDE_SWIFTMODULE = YES
+SWIFTFLAGS_EXTRAS = -Xfrontend -disable-round-trip-debug-types -enable-experimental-feature VariadicGenerics
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/variadic_generics/TestSwiftVariadicGenerics.py
+++ b/lldb/test/API/lang/swift/variadic_generics/TestSwiftVariadicGenerics.py
@@ -1,0 +1,19 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+class TestSwiftVariadicGenerics(TestBase):
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+
+        target,  _, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec('a.swift'))
+
+        self.expect("frame variable",
+                    substrs=["Pack{(a.A, a.B)}", "args", "i = 23", "d = 2.71"])
+

--- a/lldb/test/API/lang/swift/variadic_generics/a.swift
+++ b/lldb/test/API/lang/swift/variadic_generics/a.swift
@@ -1,0 +1,14 @@
+public struct A {
+  var i: Int
+}
+public struct B {
+  var d: Double
+}
+
+public func variadic_function<each T>(args: repeat each T) {
+  print("break here")
+}
+
+let a = A(i: 23)
+let b = B(d: 2.71)
+variadic_function(args: a, b)


### PR DESCRIPTION
This implements dynamic type resolution for pack expansion types by walking the metadata and replacing them with an "expanded" SIL pack type that contains a tuple type in which all generic parameters from type packs have been substituted with the concrete types from the type pack(s).  SwiftLanguageRuntimeImpl::GetChildCompilerTypeAtIndex() recognizes these expanded SIL pack types and performs the appropriate offset computation.

rdar://104842059
(cherry picked from commit 8b297173ea1077eb8a900414a11cd3f4340b29e8)