### PR TITLE
[lldb] Respect empty arguments in target.run-args

### DIFF
--- a/lldb/source/Host/common/ProcessLaunchInfo.cpp
+++ b/lldb/source/Host/common/ProcessLaunchInfo.cpp
@@ -321,6 +321,8 @@ bool ProcessLaunchInfo::ConvertArgumentsForLaunchingInShell(
       } else {
         for (size_t i = 0; argv[i] != nullptr; ++i) {
           std::string safe_arg = Args::GetShellSafeArgument(m_shell, argv[i]);
+          if (safe_arg.empty())
+            safe_arg = "\"\"";
           // Add a space to separate this arg from the previous one.
           shell_command.PutCString(" ");
           shell_command.PutCString(safe_arg);

--- a/lldb/source/Interpreter/OptionValueArgs.cpp
+++ b/lldb/source/Interpreter/OptionValueArgs.cpp
@@ -17,8 +17,7 @@ size_t OptionValueArgs::GetArgs(Args &args) const {
   args.Clear();
   for (const auto &value : m_values) {
     llvm::StringRef string_value = value->GetStringValue();
-    if (!string_value.empty())
-      args.AppendArgument(string_value);
+    args.AppendArgument(string_value);
   }
 
   return args.GetArgumentCount();

--- a/lldb/test/Shell/Driver/Inputs/dumpargs.c
+++ b/lldb/test/Shell/Driver/Inputs/dumpargs.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+  for (int i = 0; i < argc; i++) {
+    printf("argv[%d] = \"%s\"\n", i, argv[i]);
+  }
+  return 0;
+}

--- a/lldb/test/Shell/Driver/TestEmptyArgument.test
+++ b/lldb/test/Shell/Driver/TestEmptyArgument.test
@@ -1,0 +1,7 @@
+# RUN: %clang_host %S/Inputs/dumpargs.c -o %t.out
+# RUN: %lldb -b -o "r" %t.out -- "one" "two" "" "three" | FileCheck %s
+
+# CHECK: argv[1] = "one"
+# CHECK: argv[2] = "two"
+# CHECK: argv[3] = ""
+# CHECK: argv[4] = "three"


### PR DESCRIPTION
Currently empty arguments are not respected. They are silently dropped in two places: (1) when extracting them from the target.run-args setting and (2) when constructing the lldb-argdumper invocation.

(1) is actually a regression from a few years ago. We did not always drop empty arguments. See 31d97a5c8ab78c619deada0cdb1fcf64021d25dd.

rdar://106279228

Differential Revision: https://reviews.llvm.org/D145450

(cherry picked from commit ca8faf8f465962e5c39d145a0e2236648cbcc27d)