### PR TITLE
[cherry-pick][stable/20221013] [lldb][test] TestDataFormatterCpp.py: fix expected format for member pointers

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
@@ -289,7 +289,7 @@ class CppDataFormatterTestCase(TestBase):
     def test_mem_func_ptr_formats(self):
         self.build()
 
-        lldbutil.run_to_name_breakpoint(self, "has_local_mem_func_pointers")
+        lldbutil.run_to_source_breakpoint(self, "Break in has_local_mem_func_pointers", lldb.SBFileSpec("main.cpp"))
 
         # FIXME: don't format pointer to members as bytes, but rather as regular pointers
         self.expect(

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
@@ -291,16 +291,17 @@ class CppDataFormatterTestCase(TestBase):
 
         lldbutil.run_to_source_breakpoint(self, "Break in has_local_mem_func_pointers", lldb.SBFileSpec("main.cpp"))
 
-        # FIXME: don't format pointer to members as bytes, but rather as regular pointers
         self.expect(
             "frame variable member_ptr",
-            patterns=['member_ptr = [0-9a-z]{2}\s'])
+            patterns=['member_ptr = 0x[0-9a-z]+'])
         self.expect(
             "frame variable member_func_ptr",
-            patterns=['member_func_ptr = [0-9a-z]{2}\s'])
+            patterns=['member_func_ptr = 0x[0-9a-z]+'],
+            substrs=['(a.out`IUseCharStar::member_func(int) at main.cpp:61)'])
         self.expect(
             "frame variable ref_to_member_func_ptr",
-            patterns=['ref_to_member_func_ptr = [0-9a-z]{2}\s'])
+            patterns=['ref_to_member_func_ptr = 0x[0-9a-z]+'],
+            substrs=['(a.out`IUseCharStar::member_func(int) at main.cpp:61)'])
         self.expect(
             "frame variable virt_member_func_ptr",
-            patterns=['virt_member_func_ptr = [0-9a-z]{2}\s'])
+            patterns=['virt_member_func_ptr = 0x[0-9a-z]+$'])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
@@ -11,7 +11,6 @@ from lldbsuite.test import lldbutil
 
 
 class CppDataFormatterTestCase(TestBase):
-
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)
@@ -285,6 +284,12 @@ class CppDataFormatterTestCase(TestBase):
             matching=False,
             substrs=['(int) iAmInt = 0x00000001'])
         self.expect("frame variable iAmInt", substrs=['(int) iAmInt = 1'])
+
+    @skipIfWindows
+    def test_mem_func_ptr_formats(self):
+        self.build()
+
+        lldbutil.run_to_name_breakpoint(self, "has_local_mem_func_pointers")
 
         # FIXME: don't format pointer to members as bytes, but rather as regular pointers
         self.expect(

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
@@ -286,15 +286,16 @@ class CppDataFormatterTestCase(TestBase):
             substrs=['(int) iAmInt = 0x00000001'])
         self.expect("frame variable iAmInt", substrs=['(int) iAmInt = 1'])
 
-        # Check that pointer to members are correctly formatted
+        # FIXME: don't format pointer to members as bytes, but rather as regular pointers
         self.expect(
             "frame variable member_ptr",
-            substrs=['member_ptr = 0x'])
+            patterns=['member_ptr = [0-9a-z]{2}\s'])
         self.expect(
             "frame variable member_func_ptr",
-            substrs=['member_func_ptr = 0x',
-                     '(a.out`IUseCharStar::member_func(int) at main.cpp:61)'])
+            patterns=['member_func_ptr = [0-9a-z]{2}\s'])
         self.expect(
             "frame variable ref_to_member_func_ptr",
-            substrs=['ref_to_member_func_ptr = 0x',
-                     '(a.out`IUseCharStar::member_func(int) at main.cpp:61)'])
+            patterns=['ref_to_member_func_ptr = [0-9a-z]{2}\s'])
+        self.expect(
+            "frame variable virt_member_func_ptr",
+            patterns=['virt_member_func_ptr = [0-9a-z]{2}\s'])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/main.cpp
@@ -70,6 +70,8 @@ void has_local_mem_func_pointers() {
   
   void (IUseCharStar::*virt_member_func_ptr)() =
       &IUseCharStar::virt_member_func;
+
+  ::puts("Break in has_local_mem_func_pointers");
 }
 
 int main (int argc, const char * argv[])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/main.cpp
@@ -59,6 +59,7 @@ struct IUseCharStar
 	IUseCharStar() : pointer("Hello world") {}
 
         char const *member_func(int) { return ""; }
+        virtual void virt_member_func() {}
 };
 
 int main (int argc, const char * argv[])
@@ -113,6 +114,9 @@ int main (int argc, const char * argv[])
     const char *(IUseCharStar::*member_func_ptr)(int) =
         &IUseCharStar::member_func;
     auto &ref_to_member_func_ptr = member_func_ptr;
+
+    void (IUseCharStar::*virt_member_func_ptr)() =
+        &IUseCharStar::virt_member_func;
 
     return 0; // Set break point at this line.
 }

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/main.cpp
@@ -62,6 +62,16 @@ struct IUseCharStar
         virtual void virt_member_func() {}
 };
 
+void has_local_mem_func_pointers() {
+  const char *IUseCharStar::*member_ptr = &IUseCharStar::pointer;
+  const char *(IUseCharStar::*member_func_ptr)(int) =
+      &IUseCharStar::member_func;
+  auto &ref_to_member_func_ptr = member_func_ptr;
+  
+  void (IUseCharStar::*virt_member_func_ptr)() =
+      &IUseCharStar::virt_member_func;
+}
+
 int main (int argc, const char * argv[])
 {
     
@@ -110,13 +120,7 @@ int main (int argc, const char * argv[])
     
     i_am_cooler the_coolest_guy(1,2,3.14,6.28,'E','G');
 
-    const char *IUseCharStar::*member_ptr = &IUseCharStar::pointer;
-    const char *(IUseCharStar::*member_func_ptr)(int) =
-        &IUseCharStar::member_func;
-    auto &ref_to_member_func_ptr = member_func_ptr;
-
-    void (IUseCharStar::*virt_member_func_ptr)() =
-        &IUseCharStar::virt_member_func;
+    has_local_mem_func_pointers();
 
     return 0; // Set break point at this line.
 }


### PR DESCRIPTION
 sync with upstream changes (https://reviews.llvm.org/rG8200848c4125)