### PR TITLE
[ThinLTO] Don't try to replay cache if no hash was computed

### DIFF
--- a/llvm/test/ThinLTO/X86/cache-no-replay.ll
+++ b/llvm/test/ThinLTO/X86/cache-no-replay.ll
@@ -1,0 +1,16 @@
+; No hash produced, empty file module entry.
+; RUN: opt -module-summary %s -o %t.bc
+
+; RUN: rm -rf %t.cache.noindex && mkdir %t.cache.noindex
+; RUN: llvm-lto -thinlto-action=run -exported-symbol=globalfunc %t.bc \
+; RUN:   -thinlto-cache-dir %t.cache.noindex -thinlto-save-objects %t.save.noindex | FileCheck %s --allow-empty
+
+; CHECK-NOT: remarks
+
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx10.11.0"
+
+define void @globalfunc() #0 {
+entry:
+  ret void
+}


### PR DESCRIPTION
There are certain cases where an bitcode arrives in ThinLTOCodeGenerator and it lacks information to compute a cache key for incremental builds. In those cases, don't try to replay the output object file from an non-existing location.

rdar://106432595