### PR TITLE
Change SwiftLanguageRuntime::GetNumChildren() to take an exe_scope

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1034,8 +1034,8 @@ SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
   const swift::reflection::TypeRef *tr = nullptr;
   auto *ti = GetSwiftRuntimeTypeInfo(type, exe_scope, &tr);
   if (!ti) {
-    LLDB_LOGF(GetLog(LLDBLog::Types), "GetSwiftRuntimeTypeInfo() failed for %s",
-              type.GetMangledTypeName().GetCString());
+    LLDB_LOG(GetLog(LLDBLog::Types), "GetSwiftRuntimeTypeInfo() failed for {0}",
+             type.GetMangledTypeName());
     return {};
   }
   // Structs and Tuples.
@@ -1401,6 +1401,10 @@ CompilerType SwiftLanguageRuntimeImpl::GetChildCompilerTypeAtIndex(
   };
 
   // Try the static type metadata.
+  ExecutionContext exe_ctx;
+  if (valobj)
+    exe_ctx = valobj->GetExecutionContextRef();
+
   auto *ti =
       GetSwiftRuntimeTypeInfo(type, exe_ctx.GetBestExecutionContextScope());
   if (!ti)


### PR DESCRIPTION
This is closer to what the function actually needs, fixes a race condition in SwiftLanguageRuntimeImpl::GetChildCompilerTypeAtIndex(), and allows TypeSystemSwiftTypeRef::GetNumChildren() to pass in the exe_scope, which fixes a flaky test on the bots.

(cherry picked from commit 1aaa123818656e0b5a6a1f6a248d7b585f6b9641)

 Conflicts:
	lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp

(cherry picked from commit cf9cbed2dcf23e2c570e5ed3d7fbae9ad9b341cc)