### PR TITLE
[lldb] Build decl contexts when looking up clang types

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/DWARFImporterDelegate.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/DWARFImporterDelegate.cpp
@@ -219,6 +219,7 @@ public:
 
     // Find the type in the debug info.
     TypeSP clang_type_sp;
+    // FIXME: LookupClangType won't work for nested C++ types.
     if (m_swift_typesystem.GetModule())
       clang_type_sp = m_swift_typesystem.LookupClangType(name);
     else if (TargetSP target_sp = m_swift_typesystem.GetTargetWP().lock()) {
@@ -242,6 +243,7 @@ public:
         auto swift_ts = llvm::dyn_cast_or_null<TypeSystemSwift>(ts->get());
         if (!swift_ts)
           continue;
+        // FIXME: LookupClangType won't work for nested C++ types.
         clang_type_sp = swift_ts->GetTypeSystemSwiftTypeRef().LookupClangType(name);
         if (clang_type_sp)
           break;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -339,9 +339,15 @@ public:
   CompilerType RemangleAsType(swift::Demangle::Demangler &dem,
                               swift::Demangle::NodePointer node);
 
-  /// Search the debug info for a Clang type with the specified name and cache
-  /// the result.
-  lldb::TypeSP LookupClangType(llvm::StringRef name);
+  /// Search the debug info for a non-nested Clang type with the specified name
+  /// and cache the result. Users should prefer the version that takes in the
+  /// decl_context.
+  lldb::TypeSP LookupClangType(llvm::StringRef name_ref);
+
+  /// Search the debug info for a Clang type with the specified name and decl
+  /// context, and cache the result.
+  lldb::TypeSP LookupClangType(llvm::StringRef name_ref,
+                               llvm::ArrayRef<CompilerContext> decl_context);
 
 protected:
   /// Helper that creates an AST type from \p type.
@@ -387,7 +393,8 @@ protected:
   clang::api_notes::APINotesManager *
   GetAPINotesManager(ClangExternalASTSourceCallbacks *source, unsigned id);
 
-  CompilerType LookupClangForwardType(llvm::StringRef name);
+  CompilerType LookupClangForwardType(llvm::StringRef name, 
+                  llvm::ArrayRef<CompilerContext> decl_context);
 
   std::pair<swift::Demangle::NodePointer, CompilerType>
   ResolveTypeAlias(swift::Demangle::Demangler &dem,

--- a/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/Makefile
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_CXX_INTEROP := 1
+SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR) 
+include Makefile.rules

--- a/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/TestClassInNamespace.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/TestClassInNamespace.py
@@ -1,0 +1,46 @@
+
+"""
+Test that C++ classes defined in namespaces are displayed correctly in Swift.
+"""
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class TestClassInNamespace(TestBase):
+
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @swiftTest
+    def test_class(self):
+        self.build()
+        self.runCmd('settings set target.experimental.swift-enable-cxx-interop true')
+        _, _, _, _= lldbutil.run_to_source_breakpoint(
+            self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
+
+        self.expect('v fooClass', substrs=['foo::CxxClass', 'foo_field = 10'])
+        self.expect('expr fooClass', substrs=['foo::CxxClass', 'foo_field = 10'])
+
+        self.expect('v barClass', substrs=['bar::CxxClass', 'bar_field = 30'])
+        self.expect('expr barClass', substrs=['bar::CxxClass', 'bar_field = 30'])
+
+
+        self.expect('v bazClass', substrs=['baz::CxxClass', 'baz_field = 50'])
+        self.expect('expr bazClass', substrs=['baz::CxxClass', 'baz_field = 50'])
+
+        self.expect('v bazClass', substrs=['baz::CxxClass', 'baz_field = 50'])
+        self.expect('expr bazClass', substrs=['baz::CxxClass', 'baz_field = 50'])
+
+        self.expect('v fooInherited', substrs=['foo::InheritedCxxClass', 
+            'foo::CxxClass = (foo_field = 10)', 'foo_subfield = 20'])
+        self.expect('e fooInherited', substrs=['foo::InheritedCxxClass', 
+            'foo::CxxClass = (foo_field = 10)', 'foo_subfield = 20'])
+
+        self.expect('v barInherited', substrs=['bar::InheritedCxxClass', 
+            'bar::CxxClass = (bar_field = 30)', 'bar_subfield = 40'])
+        self.expect('expr barInherited', substrs=['bar::InheritedCxxClass', 
+            'bar::CxxClass = (bar_field = 30)', 'bar_subfield = 40'])
+
+
+        self.expect('v bazInherited', substrs=['bar::baz::InheritedCxxClass', 
+                'bar::baz::CxxClass = (baz_field = 50)', 'baz_subfield = 60'])
+        self.expect('expr bazInherited', substrs=['bar::baz::InheritedCxxClass', 
+                'bar::baz::CxxClass = (baz_field = 50)', 'baz_subfield = 60'])

--- a/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/main.swift
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/main.swift
@@ -1,0 +1,16 @@
+import ReturnsClass
+
+func main() {
+  let fooClass = foo.CxxClass()
+  let fooInherited = foo.InheritedCxxClass()
+
+  let barClass = bar.CxxClass()
+  let barInherited = bar.InheritedCxxClass()
+
+  let bazClass = bar.baz.CxxClass()
+  let bazInherited = bar.baz.InheritedCxxClass()
+
+  print(1) // Set breakpoint here
+}
+main()
+

--- a/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/module.modulemap
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/module.modulemap
@@ -1,0 +1,5 @@
+module ReturnsClass {
+  header "returns-class.h"
+  requires cplusplus
+}
+

--- a/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/returns-class.h
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/returns-class.h
@@ -1,0 +1,29 @@
+
+namespace foo {
+struct CxxClass {
+  long long foo_field = 10;
+};
+
+struct InheritedCxxClass: CxxClass {
+  long long foo_subfield = 20;
+};
+} // namespace foo
+namespace bar {
+struct CxxClass {
+  long long bar_field = 30;
+};
+
+struct InheritedCxxClass: CxxClass {
+  long long bar_subfield = 40;
+};
+
+namespace baz {
+struct CxxClass {
+  long long baz_field = 50;
+};
+
+struct InheritedCxxClass: CxxClass {
+  long long baz_subfield = 60;
+};
+} // namespace baz
+} // namespace bar


### PR DESCRIPTION
    [lldb] Build decl contexts when looking up clang types

    With C++ interop, TypeSystemSwiftTypeRef has to deal with the
    possibility of nested Clang types. Add functionality to import those.

    Also add a test for C++ types defined in namespaces.

    rdar://100284870
    rdar://106463006