### PR TITLE
Pass argument by reference to a void a use-after-free. 

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3367,7 +3367,7 @@ CompilerType TypeSystemSwiftTypeRef::CreateSILPackType(CompilerType type,
 }
 
 static llvm::Optional<TypeSystemSwiftTypeRef::PackTypeInfo>
-decodeSILPackType(swift::Demangle::Demangler dem, CompilerType type,
+decodeSILPackType(swift::Demangle::Demangler &dem, CompilerType type,
                   swift::Demangle::NodePointer &node) {
   TypeSystemSwiftTypeRef::PackTypeInfo info;
   node = GetDemangledType(dem, type.GetMangledTypeName().GetStringRef());


### PR DESCRIPTION
rdar://106464908