### PR TITLE
[dsymutil] Fix offset calculation for universal binaries

### DIFF
--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -36,6 +36,7 @@
 #include "llvm/Support/CrashRecoveryContext.h"
 #include "llvm/Support/FileCollector.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/TargetSelect.h"
@@ -796,12 +797,14 @@ int dsymutil_main(int argc, char **argv) {
         ErrorOr<vfs::Status> stat = Options.LinkOpts.VFS->status(File.path());
         if (!stat)
           break;
-        FileOffset += stat->getSize();
         if (FileOffset > UINT32_MAX) {
-          WithColor::error() << "the universal binary has a slice with an "
-              "offset exceeds 4GB and will produce an invalid Mach-O file.";
+          WithColor::error() << formatv(
+              "the universal binary has a slice with a starting offset ({0:x}) "
+              "that exceeds 4GB and will produce an invalid Mach-O file.",
+              FileOffset);
           return EXIT_FAILURE;
         }
+        FileOffset += stat->getSize();
       }
       if (!MachOUtils::generateUniversalBinary(TempFiles,
                                                OutputLocationOrErr->DWARFFile,


### PR DESCRIPTION
The Mach-O file format uses 32-bit values to encodes offsets which they
cannot exceed UIN32_MAX (4GB). The Mach-O file itself can be larger than
4GB as long as none of the offsets fall within this limit.

For universal binaries, dsymutil determines if the offset is going to
exceed the 4GB limit by computing the size of the header and adding it
to the size of all the slices. This is incorrect because it computes the
end offset of the final slice. For the purpose of the 4GB limit, only
the starting offset matters. The size of the last slice is irrelevant as
long as it itself is a valid Mach-O.

rdar://104435018

Differential revision: https://reviews.llvm.org/D145637

(cherry picked from commit 244a6acff0b8c3bac93949e262166b5f1fe12b1f)
