### PR TITLE
Pass argument by reference to a void a use-after-free.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3370,7 +3370,7 @@ CompilerType TypeSystemSwiftTypeRef::CreateSILPackType(CompilerType type,
 }
 
 static llvm::Optional<TypeSystemSwiftTypeRef::PackTypeInfo>
-decodeSILPackType(swift::Demangle::Demangler dem, CompilerType type,
+decodeSILPackType(swift::Demangle::Demangler &dem, CompilerType type,
                   swift::Demangle::NodePointer &node) {
   TypeSystemSwiftTypeRef::PackTypeInfo info;
   node = GetDemangledType(dem, type.GetMangledTypeName().GetStringRef());


### PR DESCRIPTION
rdar://106464908
(cherry picked from commit bb651430a26f43fc06438b10c9470a1db8b09a86)