### PR TITLE
[lldb][InstrumentationRuntime] Make 'data' struct anonymous in order to avoid collisions with types in the debuggee

### DIFF
--- a/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
@@ -88,6 +88,9 @@ extern "C"
     int (*ptr__tsan_get_report_loc_object_type)(void *report, unsigned long idx, const char **object_type);
     int (*ptr__tsan_get_report_tag)(void *report, unsigned long *tag);
 }
+)";
+
+const char *thread_sanitizer_retrieve_report_data_command = R"(
 
 const int REPORT_TRACE_SIZE = 128;
 const int REPORT_ARRAY_SIZE = 4;
@@ -156,11 +159,7 @@ struct data {
         int idx;
         int tid;
     } unique_tids[REPORT_ARRAY_SIZE];
-};
-)";
-
-const char *thread_sanitizer_retrieve_report_data_command = R"(
-data t = {0};
+} t = {0};
 
 ptr__tsan_get_report_loc_object_type = (typeof(ptr__tsan_get_report_loc_object_type))(void *)dlsym((void*)-2 /*RTLD_DEFAULT*/, "__tsan_get_report_loc_object_type");
 ptr__tsan_get_report_tag = (typeof(ptr__tsan_get_report_tag))(void *)dlsym((void*)-2 /*RTLD_DEFAULT*/, "__tsan_get_report_tag");

--- a/lldb/source/Plugins/InstrumentationRuntime/UBSan/InstrumentationRuntimeUBSan.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/UBSan/InstrumentationRuntimeUBSan.cpp
@@ -67,19 +67,18 @@ __ubsan_get_current_report_data(const char **OutIssueKind,
     const char **OutMessage, const char **OutFilename, unsigned *OutLine,
     unsigned *OutCol, char **OutMemoryAddr);
 }
+)";
 
-struct data {
+static const char *ub_sanitizer_retrieve_report_data_command = R"(
+struct {
   const char *issue_kind;
   const char *message;
   const char *filename;
   unsigned line;
   unsigned col;
   char *memory_addr;
-};
-)";
+} t;
 
-static const char *ub_sanitizer_retrieve_report_data_command = R"(
-data t;
 __ubsan_get_current_report_data(&t.issue_kind, &t.message, &t.filename, &t.line,
                                 &t.col, &t.memory_addr);
 t;

--- a/lldb/source/Plugins/MemoryHistory/asan/MemoryHistoryASan.cpp
+++ b/lldb/source/Plugins/MemoryHistory/asan/MemoryHistoryASan.cpp
@@ -67,8 +67,11 @@ const char *memory_history_asan_command_prefix = R"(
         size_t __asan_get_alloc_stack(void *addr, void **trace, size_t size, int *thread_id);
         size_t __asan_get_free_stack(void *addr, void **trace, size_t size, int *thread_id);
     }
+)";
 
-    struct data {
+const char *memory_history_asan_command_format =
+    R"(
+    struct {
         void *alloc_trace[256];
         size_t alloc_count;
         int alloc_tid;
@@ -76,12 +79,7 @@ const char *memory_history_asan_command_prefix = R"(
         void *free_trace[256];
         size_t free_count;
         int free_tid;
-    };
-)";
-
-const char *memory_history_asan_command_format =
-    R"(
-    data t;
+    } t;
 
     t.alloc_count = __asan_get_alloc_stack((void *)0x%)" PRIx64
     R"(, t.alloc_trace, 256, &t.alloc_tid);


### PR DESCRIPTION
The `UBSAN`/`ASAN` plugins would previously call the internal helper structure injected into the source expression `struct data { ... };`

This occasionally collided with user-defined types of the same (quite common) name. In the presence of varibale with the same name LLDB would simply fail to run the injected `InstrumentationRuntime` expressions with:
```
warning: cannot evaluate AddressSanitizer expression:
expression failed to parse:
error: <user expression 2>:2:5: must use 'struct' tag to refer to type 'data' in this scope
    data t;
```

In the presence of another type called 'data', LLDB would most likely crash with something like:
```
0x00000001198de614 clang::ASTNodeImporter::ImportDeclContext(clang::DeclContext*, bool) + 1088
0x00000001198de614 clang::ASTNodeImporter::ImportDeclContext(clang::DeclContext*, bool) + 1088
0x0000000119907930 clang::ASTImporter::ImportDefinition(clang::Decl*) + 596
0x00000001163db928 lldb_private::ClangASTImporter::ASTImporterDelegate::ImportDefinitionTo(clang::Decl*, clang::Decl*) + 100
0x00000001163da070 (anonymous namespace)::CompleteTagDeclsScope::~CompleteTagDeclsScope() + 572
...
```
...because it got the types confused.

This patch makes these structures anonymous so there's no chance of clashing with other types in the program. This is already the approach taken in `UBSan/InstrumentationRuntimeABSan.cpp`.

**Testing**

- API tests still pass
- Tested manually that the `memory history` command now works in the presence of a local called `data`

Differential Revision: https://reviews.llvm.org/D145569

(cherry picked from commit adc5168d7114190ec7d931a6c346276e19b0e117)