### PR TITLE
[lldb] Build decl contexts when looking up clang types

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/DWARFImporterDelegate.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/DWARFImporterDelegate.cpp
@@ -219,6 +219,7 @@ public:
 
     // Find the type in the debug info.
     TypeSP clang_type_sp;
+    // FIXME: LookupClangType won't work for nested C++ types.
     if (m_swift_typesystem.GetModule())
       clang_type_sp = m_swift_typesystem.LookupClangType(name);
     else if (TargetSP target_sp = m_swift_typesystem.GetTargetWP().lock()) {
@@ -242,6 +243,7 @@ public:
         auto swift_ts = llvm::dyn_cast_or_null<TypeSystemSwift>(ts->get());
         if (!swift_ts)
           continue;
+        // FIXME: LookupClangType won't work for nested C++ types.
         clang_type_sp = swift_ts->GetTypeSystemSwiftTypeRef().LookupClangType(name);
         if (clang_type_sp)
           break;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -196,10 +196,17 @@ GetMangledName(swift::Demangle::Demangler &dem,
 
 /// Find a Clang type by name in the modules in \p module_holder.
 TypeSP TypeSystemSwiftTypeRef::LookupClangType(StringRef name_ref) {
-  auto lookup = [](Module &M, ConstString name) -> TypeSP {
-    llvm::SmallVector<CompilerContext, 2> decl_context;
-    decl_context.push_back({CompilerContextKind::AnyModule, ConstString()});
-    decl_context.push_back({CompilerContextKind::AnyType, ConstString(name)});
+  llvm::SmallVector<CompilerContext, 2> decl_context;
+  // Make up a decl context for non-nested types.
+  decl_context.push_back({CompilerContextKind::AnyModule, ConstString()});
+  decl_context.push_back({CompilerContextKind::AnyType, ConstString(name_ref)});
+  return LookupClangType(name_ref, decl_context);
+}
+
+/// Find a Clang type by name in the modules in \p module_holder.
+TypeSP TypeSystemSwiftTypeRef::LookupClangType(
+    StringRef name_ref, llvm::ArrayRef<CompilerContext> decl_context) {
+  auto lookup = [&decl_context](Module &M, ConstString name) -> TypeSP {
     llvm::DenseSet<SymbolFile *> searched_symbol_files;
     TypeMap clang_types;
     M.FindTypes(decl_context, TypeSystemClang::GetSupportedLanguagesForTypes(),
@@ -241,8 +248,9 @@ TypeSP TypeSystemSwiftTypeRef::LookupClangType(StringRef name_ref) {
 }
 
 /// Find a Clang type by name in module \p M.
-CompilerType TypeSystemSwiftTypeRef::LookupClangForwardType(StringRef name) {
-  if (TypeSP type = LookupClangType(name))
+CompilerType TypeSystemSwiftTypeRef::LookupClangForwardType(
+    StringRef name, llvm::ArrayRef<CompilerContext> decl_context) {
+  if (TypeSP type = LookupClangType(name, decl_context))
     return type->GetForwardCompilerType();
   return {};
 }
@@ -467,6 +475,38 @@ GetBuiltinAnyObjectNode(swift::Demangle::Demangler &dem) {
   return proto_list_any;
 }
 
+/// Builds the decl context to look up clang types with.
+static bool
+IsClangImportedType(NodePointer node,
+                 llvm::SmallVectorImpl<CompilerContext> &decl_context) {
+  if (node->getKind() == Node::Kind::Module && node->hasText() &&
+      node->getText() == swift::MANGLING_MODULE_OBJC) {
+    decl_context.push_back({CompilerContextKind::AnyModule, ConstString()});
+    return true;
+  }
+
+  if (node->getNumChildren() != 2 || !node->getLastChild()->hasText())
+    return false;
+
+  switch (node->getKind()) {
+  case Node::Kind::Structure:
+  case Node::Kind::Class:
+  case Node::Kind::Enum:
+  case Node::Kind::TypeAlias:
+    if (!IsClangImportedType(node->getFirstChild(), decl_context))
+    return false;
+
+    // When C++ interop is enabled, Swift enums represent Swift namespaces.
+    decl_context.push_back({node->getKind() == Node::Kind::Enum
+                                ? CompilerContextKind::Namespace
+                                : CompilerContextKind::AnyType,
+                            ConstString(node->getLastChild()->getText())});
+    return true;
+  default:
+    return false;
+  }
+}
+
 /// Resolve a type alias node and return a demangle tree for the
 /// resolved type. If the type alias resolves to a Clang type, return
 /// a Clang CompilerType.
@@ -479,22 +519,6 @@ TypeSystemSwiftTypeRef::ResolveTypeAlias(swift::Demangle::Demangler &dem,
                                          swift::Demangle::NodePointer node,
                                          bool prefer_clang_types) {
   LLDB_SCOPED_TIMER();
-  auto resolve_clang_type = [&]() -> CompilerType {
-    auto maybe_module_and_type_names = GetNominal(dem, node);
-    if (!maybe_module_and_type_names)
-      return {};
-
-    auto module_name = maybe_module_and_type_names->first;
-    if (module_name != swift::MANGLING_MODULE_OBJC)
-      return {};
-
-    // Resolve the typedef within the Clang debug info.
-    auto clang_type = LookupClangForwardType(node->getChild(1)->getText());
-    if (!clang_type)
-      return {};
-
-    return clang_type.GetCanonicalType();
-  };
 
   // Hardcode that the Swift.AnyObject type alias always resolves to
   // the builtin AnyObject type.
@@ -513,6 +537,25 @@ TypeSystemSwiftTypeRef::ResolveTypeAlias(swift::Demangle::Demangler &dem,
     return {{}, {}};
   }
   ConstString mangled(mangling.result());
+
+  auto resolve_clang_type = [&]() -> CompilerType {
+    auto maybe_module_and_type_names = GetNominal(dem, node);
+    if (!maybe_module_and_type_names)
+      return {};
+
+    // This is an imported Objective-C type; look it up in the debug info.
+    llvm::SmallVector<CompilerContext, 2> decl_context;
+    if (!IsClangImportedType(node, decl_context))
+      return {};
+
+    // Resolve the typedef within the Clang debug info.
+    auto clang_type = LookupClangForwardType(mangled.GetStringRef(), decl_context);
+    if (!clang_type)
+      return {};
+
+    return clang_type.GetCanonicalType();
+  };
+
   TypeList types;
   if (!prefer_clang_types) {
     llvm::DenseSet<SymbolFile *> searched_symbol_files;
@@ -869,14 +912,6 @@ CompilerType TypeSystemSwiftTypeRef::GetBuiltinRawPointerType() {
   return GetTypeFromMangledTypename(ConstString("$sBpD"));
 }
 
-/// Determine whether \p node is an Objective-C type and return its name.
-static StringRef GetObjCTypeName(swift::Demangle::NodePointer node) {
-  if (node && node->getNumChildren() == 2 && node->getChild(0)->hasText() &&
-      node->getChild(0)->getText() == swift::MANGLING_MODULE_OBJC &&
-      node->getChild(1)->hasText())
-    return node->getChild(1)->getText();
-  return {};
-}
 
 swift::Demangle::NodePointer
 TypeSystemSwiftTypeRef::GetSwiftified(swift::Demangle::Demangler &dem,
@@ -884,16 +919,20 @@ TypeSystemSwiftTypeRef::GetSwiftified(swift::Demangle::Demangler &dem,
                                       bool resolve_objc_module) {
   LLDB_SCOPED_TIMER();
 
-  using namespace swift::Demangle;
-  StringRef ident = GetObjCTypeName(node);
-  if (ident.empty())
+  auto mangling = GetMangledName(dem, node);
+  if (!mangling.isSuccess()) {
+    LLDB_LOGF(GetLog(LLDBLog::Types), "Failed while getting swiftified (%d:%u)",
+              mangling.error().code, mangling.error().line);
+    return node;
+  }
+
+  llvm::SmallVector<CompilerContext, 2> decl_context;
+  if (!IsClangImportedType(node, decl_context))
     return node;
 
-  if (ident.equals("NSURL") || ident.equals("URL"))
-    llvm::errs();
   // This is an imported Objective-C type; look it up in the
   // debug info.
-  TypeSP clang_type = LookupClangType(ident);
+  TypeSP clang_type = LookupClangType(mangling.result(), decl_context);
   if (!clang_type)
     return node;
 
@@ -1199,33 +1238,38 @@ TypeSystemSwiftTypeRef::CollectTypeInfo(swift::Demangle::Demangler &dem,
     }
     case Node::Kind::BoundGenericStructure:
     case Node::Kind::Structure: {
-      swift_flags |= eTypeHasChildren | eTypeIsStructUnion;
-      if (node->getNumChildren() != 2)
-        break;
-      auto module = node->getChild(0);
-      auto ident = node->getChild(1);
-      // Builtin types.
-      if (module->hasText() && module->getText() == swift::STDLIB_NAME) {
-        if (ident->hasText() &&
-            ident->getText().startswith(swift::BUILTIN_TYPE_NAME_INT))
-          swift_flags |= eTypeIsScalar | eTypeIsInteger;
-        else if (ident->hasText() &&
-                 ident->getText().startswith(swift::BUILTIN_TYPE_NAME_FLOAT))
-          swift_flags |= eTypeIsScalar | eTypeIsFloat;
-      }
-
-      // Clang-imported types.
-      if (module->hasText() &&
-          module->getText() == swift::MANGLING_MODULE_OBJC) {
-        if (ident->getKind() != Node::Kind::Identifier || !ident->hasText())
-          break;
-
-        // Look up the Clang type in DWARF.
-        CompilerType clang_type = LookupClangForwardType(ident->getText());
-        collect_clang_type(clang_type.GetCanonicalType());
-        return swift_flags;
-      }
+    swift_flags |= eTypeHasChildren | eTypeIsStructUnion;
+    if (node->getNumChildren() != 2)
       break;
+    auto module = node->getChild(0);
+    auto ident = node->getChild(1);
+    // Builtin types.
+    if (module->hasText() && module->getText() == swift::STDLIB_NAME) {
+      if (ident->hasText() &&
+          ident->getText().startswith(swift::BUILTIN_TYPE_NAME_INT))
+        swift_flags |= eTypeIsScalar | eTypeIsInteger;
+      else if (ident->hasText() &&
+               ident->getText().startswith(swift::BUILTIN_TYPE_NAME_FLOAT))
+        swift_flags |= eTypeIsScalar | eTypeIsFloat;
+    }
+
+    // Clang-imported types.
+    llvm::SmallVector<CompilerContext, 2> decl_context;
+    if (!IsClangImportedType(node, decl_context))
+      break;
+
+    auto mangling = GetMangledName(dem, node);
+    if (!mangling.isSuccess()) {
+      LLDB_LOGF(GetLog(LLDBLog::Types),
+                "Failed mangling while collecting type infos (%d:%u)",
+                mangling.error().code, mangling.error().line);
+
+      return {};
+    }
+    // Resolve the typedef within the Clang debug info.
+    auto clang_type = LookupClangForwardType(mangling.result(), decl_context);
+    collect_clang_type(clang_type.GetCanonicalType());
+    return swift_flags;
     }
     case Node::Kind::BoundGenericClass:
     case Node::Kind::Class:
@@ -3231,11 +3275,11 @@ bool TypeSystemSwiftTypeRef::IsImportedType(opaque_compiler_type_t type,
                 AsMangledName(type));
 
     // This is an imported Objective-C type; look it up in the debug info.
-    StringRef ident = GetObjCTypeName(node);
-    if (ident.empty())
-      return {};
+    llvm::SmallVector<CompilerContext, 2> decl_context;
+    if (!IsClangImportedType(node, decl_context))
+      return false;
     if (original_type)
-      if (TypeSP clang_type = LookupClangType(ident))
+      if (TypeSP clang_type = LookupClangType(AsMangledName(type), decl_context))
         *original_type = clang_type->GetForwardCompilerType();
     return true;
   };

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -339,9 +339,15 @@ public:
   CompilerType RemangleAsType(swift::Demangle::Demangler &dem,
                               swift::Demangle::NodePointer node);
 
-  /// Search the debug info for a Clang type with the specified name and cache
-  /// the result.
-  lldb::TypeSP LookupClangType(llvm::StringRef name);
+  /// Search the debug info for a non-nested Clang type with the specified name
+  /// and cache the result. Users should prefer the version that takes in the
+  /// decl_context.
+  lldb::TypeSP LookupClangType(llvm::StringRef name_ref);
+
+  /// Search the debug info for a Clang type with the specified name and decl
+  /// context, and cache the result.
+  lldb::TypeSP LookupClangType(llvm::StringRef name_ref,
+                               llvm::ArrayRef<CompilerContext> decl_context);
 
 protected:
   /// Helper that creates an AST type from \p type.
@@ -387,7 +393,8 @@ protected:
   clang::api_notes::APINotesManager *
   GetAPINotesManager(ClangExternalASTSourceCallbacks *source, unsigned id);
 
-  CompilerType LookupClangForwardType(llvm::StringRef name);
+  CompilerType LookupClangForwardType(llvm::StringRef name, 
+                  llvm::ArrayRef<CompilerContext> decl_context);
 
   std::pair<swift::Demangle::NodePointer, CompilerType>
   ResolveTypeAlias(swift::Demangle::Demangler &dem,

--- a/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/Makefile
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_CXX_INTEROP := 1
+SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR) 
+include Makefile.rules

--- a/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/TestClassInNamespace.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/TestClassInNamespace.py
@@ -1,0 +1,46 @@
+
+"""
+Test that C++ classes defined in namespaces are displayed correctly in Swift.
+"""
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class TestClassInNamespace(TestBase):
+
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @swiftTest
+    def test_class(self):
+        self.build()
+        self.runCmd('settings set target.experimental.swift-enable-cxx-interop true')
+        _, _, _, _= lldbutil.run_to_source_breakpoint(
+            self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
+
+        self.expect('v fooClass', substrs=['foo::CxxClass', 'foo_field = 10'])
+        self.expect('expr fooClass', substrs=['foo::CxxClass', 'foo_field = 10'])
+
+        self.expect('v barClass', substrs=['bar::CxxClass', 'bar_field = 30'])
+        self.expect('expr barClass', substrs=['bar::CxxClass', 'bar_field = 30'])
+
+
+        self.expect('v bazClass', substrs=['baz::CxxClass', 'baz_field = 50'])
+        self.expect('expr bazClass', substrs=['baz::CxxClass', 'baz_field = 50'])
+
+        self.expect('v bazClass', substrs=['baz::CxxClass', 'baz_field = 50'])
+        self.expect('expr bazClass', substrs=['baz::CxxClass', 'baz_field = 50'])
+
+        self.expect('v fooInherited', substrs=['foo::InheritedCxxClass', 
+            'foo::CxxClass = (foo_field = 10)', 'foo_subfield = 20'])
+        self.expect('e fooInherited', substrs=['foo::InheritedCxxClass', 
+            'foo::CxxClass = (foo_field = 10)', 'foo_subfield = 20'])
+
+        self.expect('v barInherited', substrs=['bar::InheritedCxxClass', 
+            'bar::CxxClass = (bar_field = 30)', 'bar_subfield = 40'])
+        self.expect('expr barInherited', substrs=['bar::InheritedCxxClass', 
+            'bar::CxxClass = (bar_field = 30)', 'bar_subfield = 40'])
+
+
+        self.expect('v bazInherited', substrs=['bar::baz::InheritedCxxClass', 
+                'bar::baz::CxxClass = (baz_field = 50)', 'baz_subfield = 60'])
+        self.expect('expr bazInherited', substrs=['bar::baz::InheritedCxxClass', 
+                'bar::baz::CxxClass = (baz_field = 50)', 'baz_subfield = 60'])

--- a/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/main.swift
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/main.swift
@@ -1,0 +1,16 @@
+import ReturnsClass
+
+func main() {
+  let fooClass = foo.CxxClass()
+  let fooInherited = foo.InheritedCxxClass()
+
+  let barClass = bar.CxxClass()
+  let barInherited = bar.InheritedCxxClass()
+
+  let bazClass = bar.baz.CxxClass()
+  let bazInherited = bar.baz.InheritedCxxClass()
+
+  print(1) // Set breakpoint here
+}
+main()
+

--- a/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/module.modulemap
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/module.modulemap
@@ -1,0 +1,5 @@
+module ReturnsClass {
+  header "returns-class.h"
+  requires cplusplus
+}
+

--- a/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/returns-class.h
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/returns-class.h
@@ -1,0 +1,29 @@
+
+namespace foo {
+struct CxxClass {
+  long long foo_field = 10;
+};
+
+struct InheritedCxxClass: CxxClass {
+  long long foo_subfield = 20;
+};
+} // namespace foo
+namespace bar {
+struct CxxClass {
+  long long bar_field = 30;
+};
+
+struct InheritedCxxClass: CxxClass {
+  long long bar_subfield = 40;
+};
+
+namespace baz {
+struct CxxClass {
+  long long baz_field = 50;
+};
+
+struct InheritedCxxClass: CxxClass {
+  long long baz_subfield = 60;
+};
+} // namespace baz
+} // namespace bar


### PR DESCRIPTION
With C++ interop, TypeSystemSwiftTypeRef has to deal with the possibility of nested Clang types. Add functionality to import those.

Also add a test for C++ types defined in namespaces.

rdar://100284870
rdar://106463006
(cherry picked from commit 3d54620c7419b7795f56e6a822b27db433f015dd)