### PR TITLE
[lldb][TypeSystemSwift] Implement `IsMemberFunctionPointerType`

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -241,6 +241,10 @@ public:
                           CompilerType *function_pointer_type_ptr) override {
     return false;
   }
+  bool IsMemberFunctionPointerType(
+          lldb::opaque_compiler_type_t type) override {
+    return false;
+  }
   bool IsPolymorphicClass(lldb::opaque_compiler_type_t type) override {
     return false;
   }


### PR DESCRIPTION
Introduced for `TypeSystemClang` in `603ebc545d03` but not required for Swift.

(cherry picked from commit 3f445fcf41811698738699066a7e787ec60b9cda)