### PR TITLE
[lldb] Support `po` of memory addresses from Swift frames

### DIFF
--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -15,11 +15,13 @@
 #include "lldb/Interpreter/CommandReturnObject.h"
 #include "lldb/Interpreter/OptionGroupFormat.h"
 #include "lldb/Interpreter/OptionGroupValueObjectDisplay.h"
+#include "lldb/Target/MemoryRegionInfo.h"
 #include "lldb/Target/StackFrame.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/lldb-defines.h"
 #include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-forward.h"
+#include "lldb/lldb-types.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FormatVariadic.h"
 
@@ -84,8 +86,10 @@ bool CommandObjectDWIMPrint::DoExecute(StringRef command,
       m_expr_options.m_verbosity, m_format_options.GetFormat());
   dump_options.SetHideName(eval_options.GetSuppressPersistentResult());
 
+  StackFrame *frame = m_exe_ctx.GetFramePtr();
+
   // First, try `expr` as the name of a frame variable.
-  if (StackFrame *frame = m_exe_ctx.GetFramePtr()) {
+  if (frame) {
     auto valobj_sp = frame->FindVariable(ConstString(expr));
     if (valobj_sp && valobj_sp->GetError().Success()) {
       if (!eval_options.GetSuppressPersistentResult())
@@ -102,6 +106,50 @@ bool CommandObjectDWIMPrint::DoExecute(StringRef command,
       valobj_sp->Dump(result.GetOutputStream(), dump_options);
       result.SetStatus(eReturnStatusSuccessFinishResult);
       return true;
+    }
+  }
+
+  // For Swift frames, rewrite `po 0x12345600` to use `unsafeBitCast`.
+  //
+  // This works only when the address points to an instance of a class. This
+  // matches the behavior of `po` in Objective-C frames.
+  //
+  // The following conditions are required:
+  //   1. The command is `po` (or equivalently the `-O` flag is used)
+  //   2. The current language is Swift
+  //   3. The expression is entirely a hex value
+  //   4. The hex value passes address/memory sanity checks
+  //
+  // The address sanity checks are:
+  //   1. The hex value is a readable memory address
+  //
+  // Future potential sanity checks:
+  //   1. Accept tagged pointers/values
+  //   2. Verify the isa pointer is a known class
+  //   3. Require addresses to be on the heap
+  std::string modified_expr_storage;
+  // Either Swift was explicitly specified, or the frame is Swift.
+  bool is_swift = false;
+  if (m_expr_options.language == lldb::eLanguageTypeSwift)
+    is_swift = true;
+  else if (m_expr_options.language == lldb::eLanguageTypeUnknown)
+    is_swift = frame && frame->GuessLanguage() == lldb::eLanguageTypeSwift;
+  bool is_po = m_varobj_options.use_objc;
+  if (is_swift && is_po) {
+    if (expr.startswith("0x")) {
+      lldb::addr_t addr;
+      bool is_hex = !expr.drop_front(2).getAsInteger(16, addr);
+      if (is_hex) {
+        MemoryRegionInfo mem_info;
+        m_exe_ctx.GetProcessRef().GetMemoryRegionInfo(addr, mem_info);
+        bool is_readable = mem_info.GetReadable() == MemoryRegionInfo::eYes;
+        if (is_readable) {
+          modified_expr_storage =
+              llvm::formatv("unsafeBitCast({0}, to: AnyObject.self)", expr)
+                  .str();
+          expr = modified_expr_storage;
+        }
+      }
     }
   }
 

--- a/lldb/test/API/commands/dwim-print/swift/Makefile
+++ b/lldb/test/API/commands/dwim-print/swift/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/commands/dwim-print/swift/TestDWIMPrintSwift.py
+++ b/lldb/test/API/commands/dwim-print/swift/TestDWIMPrintSwift.py
@@ -1,0 +1,28 @@
+"""
+In Swift, test `po 0x12345600`, via dwim-print.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    def test_swift_po_address(self):
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.frame[0]
+        addr = frame.FindVariable("object").GetLoadAddress()
+        hex_addr = f"0x{addr:x}"
+        self.expect(f"dwim-print -O -- {hex_addr}", substrs=[f"<Object: {hex_addr}>"])
+
+    def test_swift_po_non_address_hex(self):
+        """No special handling of non-memory hex values."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect(f"dwim-print -O -- 0x1000", substrs=["4096"])

--- a/lldb/test/API/commands/dwim-print/swift/TestDWIMPrintSwift.py
+++ b/lldb/test/API/commands/dwim-print/swift/TestDWIMPrintSwift.py
@@ -16,11 +16,12 @@ class TestCase(TestBase):
         )
         frame = thread.frame[0]
         addr = frame.FindVariable("object").GetLoadAddress()
-        hex_addr = f"0x{addr:x}"
-        self.expect(f"dwim-print -O -- {hex_addr}", substrs=[f"<Object: {hex_addr}>"])
+        hex_addr = f"{addr:x}"
+        self.expect(f"dwim-print -O -- 0x{hex_addr}", patterns=[f"Object@0x0*{hex_addr}"])
+        self.expect(f"dwim-print -O -- {addr}", patterns=[f"Object@0x0*{hex_addr}"])
 
     def test_swift_po_non_address_hex(self):
-        """No special handling of non-memory hex values."""
+        """No special handling of non-memory integer values."""
         self.build()
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.swift")

--- a/lldb/test/API/commands/dwim-print/swift/main.swift
+++ b/lldb/test/API/commands/dwim-print/swift/main.swift
@@ -1,4 +1,10 @@
-class Object {}
+class Object: CustomStringConvertible {
+  var description: String {
+    let address = unsafeBitCast(self, to: Int.self)
+    let hexAddress = String(address, radix: 16)
+    return "Object@0x\(hexAddress)"
+  }
+}
 
 func main() {
     let object = Object()

--- a/lldb/test/API/commands/dwim-print/swift/main.swift
+++ b/lldb/test/API/commands/dwim-print/swift/main.swift
@@ -1,0 +1,8 @@
+class Object {}
+
+func main() {
+    let object = Object()
+    _ = object // break here
+}
+
+main()


### PR DESCRIPTION
Update `dwim-print` to support `po 0xaddress` in Swift frames, to match the support of doing the same in ObjC frames.

rdar://101174673