### PR TITLE
[lldb] Support primitive C++ types as Swift type parameters

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -730,7 +730,7 @@ $(SWIFT_CXX_HEADER): $(SWIFT_SOURCES) $(SWIFT_BRIDGING_PCH)
 	@echo "### Building C++ header from Swift" $<
 	$(SWIFT_FE) -typecheck $(VPATHSOURCES) \
 	  $(SWIFT_FEFLAGS) $(SWIFT_HFLAGS) -module-name $(MODULENAME) \
-	  -clang-header-expose-decls=all-public -emit-clang-header-path  $(SWIFT_CXX_HEADER)
+	  -emit-clang-header-path  $(SWIFT_CXX_HEADER)
 endif
 
 else # USESWIFTDRIVER = 0

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -7656,6 +7656,27 @@ CompilerType SwiftASTContext::GetBuiltinRawPointerType() {
   return GetTypeFromMangledTypename(ConstString("$sBpD"));
 }
 
+CompilerType
+SwiftASTContext::ConvertClangTypeToSwiftType(CompilerType clang_type) {
+  auto typeref_type = 
+      GetTypeSystemSwiftTypeRef().ConvertClangTypeToSwiftType(clang_type);
+
+  if (!typeref_type)
+    return {};
+
+  Status error;
+  auto *ast_type = ReconstructType(typeref_type.GetMangledTypeName(), error);
+  if (error.Fail()) {
+    LLDB_LOGF(GetLog(LLDBLog::Types),
+              "[SwiftASTContext::ConvertClangTypeToSwiftType] Could not "
+              "reconstruct type. Error: %s",
+              error.AsCString());
+    return {};
+  }
+
+  return {this->weak_from_this(), ast_type};
+}
+
 bool SwiftASTContext::TypeHasArchetype(CompilerType type) {
   auto swift_type = GetSwiftType(type);
   if (swift_type)

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -364,6 +364,10 @@ public:
 
   CompilerType GetBuiltinRawPointerType() override;
 
+  /// Attempts to convert a Clang type into a Swift type.
+  /// For example, int is converted to Int32.
+  CompilerType ConvertClangTypeToSwiftType(CompilerType clang_type) override;
+
   bool TypeHasArchetype(CompilerType type);
 
   /// Use \p ClangImporter to swiftify the decl's name.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -176,6 +176,10 @@ public:
 
   virtual CompilerType GetBuiltinRawPointerType() = 0;
 
+  /// Attempts to convert a Clang type into a Swift type.
+  /// For example, int is converted to Int32.
+  virtual CompilerType ConvertClangTypeToSwiftType(CompilerType clang_type) = 0;
+
   void DumpValue(lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
                  Stream *s, lldb::Format format, const DataExtractor &data,
                  lldb::offset_t data_offset, size_t data_byte_size,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2860,6 +2860,19 @@ TypeSystemSwiftTypeRef::GetClangTypeTypeNode(swift::Demangle::Demangler &dem,
   return type;
 }
 
+CompilerType
+TypeSystemSwiftTypeRef::ConvertClangTypeToSwiftType(CompilerType clang_type) {
+  assert(clang_type.GetTypeSystem().isa_and_nonnull<TypeSystemClang>() &&
+         "Unexpected type system!");
+
+  if (!clang_type.GetTypeSystem().isa_and_nonnull<TypeSystemClang>())
+    return {};
+
+  swift::Demangle::Demangler dem;
+  swift::Demangle::NodePointer node = GetClangTypeTypeNode(dem, clang_type);
+  return RemangleAsType(dem, node);
+}
+
 CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
     opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
     bool transparent_pointers, bool omit_empty_base_classes,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -349,6 +349,10 @@ public:
   lldb::TypeSP LookupClangType(llvm::StringRef name_ref,
                                llvm::ArrayRef<CompilerContext> decl_context);
 
+  /// Attempts to convert a Clang type into a Swift type.
+  /// For example, int is converted to Int32.
+  CompilerType ConvertClangTypeToSwiftType(CompilerType clang_type) override;
+
 protected:
   /// Helper that creates an AST type from \p type.
   void *ReconstructType(lldb::opaque_compiler_type_t type);

--- a/lldb/test/API/lang/swift/cxx_interop/backward/format-swift-stdlib-types/Makefile
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/format-swift-stdlib-types/Makefile
@@ -1,0 +1,7 @@
+SWIFT_CXX_HEADER := swift-types.h
+SWIFT_SOURCES := swift-types.swift
+CXX_SOURCES := main.cpp
+SWIFT_CXX_INTEROP := 1
+SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR) -parse-as-library
+CFLAGS = -I. -g
+include Makefile.rules

--- a/lldb/test/API/lang/swift/cxx_interop/backward/format-swift-stdlib-types/TestFormatSwiftStdlibTypes.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/format-swift-stdlib-types/TestFormatSwiftStdlibTypes.py
@@ -1,0 +1,49 @@
+
+"""
+Test that Swift types are displayed correctly in C++
+"""
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class TestFormatSwiftStdlibTypes(TestBase):
+    def setup(self, bkpt_str): 
+        self.build()
+        self.runCmd('setting set target.experimental.swift-enable-cxx-interop true')
+        _, _, _, _= lldbutil.run_to_source_breakpoint(
+            self, bkpt_str, lldb.SBFileSpec('main.cpp'))
+
+
+    @swiftTest
+    def test_array(self):
+        self.setup('break here for array')
+        self.expect('v array', substrs=['Swift.Array<a.SwiftClass>',
+            '[0]', 'str = "Hello from the Swift class!"', 
+            '[1]', 'str = "Hello from the Swift class!"',])
+
+    @swiftTest
+    def test_array_of_ints(self):
+        self.setup('break here for array of ints')
+
+        self.expect('v array', substrs=['Swift.Array<Swift.Int32>', '1', '2', '3', '4'])
+
+    @swiftTest
+    def test_optional(self):
+        self.setup('break here for optional')
+
+        self.expect('v optional', substrs=['Swift.Optional<a.SwiftClass>', 
+            'str = "Hello from the Swift class!"'])
+
+    @swiftTest
+    def test_optional_primitive(self):
+        self.setup('break here for optional primitive')
+
+        self.expect('v optional', substrs=['Swift.Optional<Swift.Double>', 
+            '4.2'])
+
+    @swiftTest
+    def test_string(self):
+        self.setup('break here for string')
+
+        self.expect('v string', substrs=['"Hello from Swift!"'])
+

--- a/lldb/test/API/lang/swift/cxx_interop/backward/format-swift-stdlib-types/main.cpp
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/format-swift-stdlib-types/main.cpp
@@ -1,0 +1,39 @@
+#include "swift-types.h"
+
+
+using namespace swift;
+using namespace a;
+
+int testArray() {
+  auto array = createArray();
+  return 0; // break here for array
+}
+
+int testArrayOfInts() {
+  auto array = createArrayOfInts();
+  return 0; // break here for array of ints
+}
+
+
+int testOptional() {
+  auto optional = createOptional();
+  return 0; // break here for optional
+}
+
+int testOptionalPrimitive() {
+  auto optional = createOptionalPrimitive();
+  return 0; // break here for optional primitive
+}
+
+int testString() {
+  auto string = createString();
+  return 0; // break here for string
+}
+
+int main() {
+  testArray();
+  testArrayOfInts();
+  testOptional();
+  testOptionalPrimitive();
+  testString();
+}

--- a/lldb/test/API/lang/swift/cxx_interop/backward/format-swift-stdlib-types/swift-types.swift
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/format-swift-stdlib-types/swift-types.swift
@@ -1,0 +1,34 @@
+public class SwiftClass {
+  let str = "Hello from the Swift class!"
+}
+
+@_expose(Cxx)
+public func createArray() -> [SwiftClass] {
+    return [SwiftClass(), SwiftClass()]
+}
+
+@_expose(Cxx)
+public func createArrayOfInts() -> [CInt] {
+    return [1, 2, 3, 4]
+}
+
+@_expose(Cxx)
+public func createDict() -> [CInt : SwiftClass] {
+    return [1: SwiftClass(), 4: SwiftClass()]
+}
+
+
+@_expose(Cxx)
+public func createOptional() -> SwiftClass? {
+  return SwiftClass()
+}
+
+@_expose(Cxx)
+public func createOptionalPrimitive() -> Double? {
+  return 4.2
+}
+
+@_expose(Cxx)
+public func createString() -> String {
+  return "Hello from Swift!"
+}


### PR DESCRIPTION
It's possible to have primitive C++ types as type parameters of generic Swift types when interop is enabled. For example, a Swift Array<CInt> is mapped to a Swift::Array<int>. Support recognizing these cases when printing Swift types in C++ when interop is enabled. Also add a test for Swift stdlib types.

rdar://100284870