### PR TITLE
[lldb] Change default value of dwim-print-verbosity setting

### DIFF
--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -227,7 +227,7 @@ let Definition = "debugger" in {
     Desc<"When displaying suggestion in a color-enabled terminal, use the ANSI terminal code specified in this format immediately after the suggestion.">;
   def DWIMPrintVerbosity: Property<"dwim-print-verbosity", "Enum">,
     Global,
-    DefaultEnumValue<"eDWIMPrintVerbosityExpression">,
+    DefaultEnumValue<"eDWIMPrintVerbosityNone">,
     EnumValues<"OptionEnumValues(g_dwim_print_verbosities)">,
     Desc<"The verbosity level used by dwim-print.">;
 }


### PR DESCRIPTION
Reduce the default value of `dwim-print-verbosity` to `eDWIMPrintVerbosityNone`.

Users who wish to see the rewritten expression can set this setting manually. Not unlike
`interpreter.expand-regex-aliases`.

Differential Revision: https://reviews.llvm.org/D145529

(cherry picked from commit 632c396499eb4f6f7a36ba0246ba57e011357a55)
