### PR TITLE
[lldb] Implement direct ivar access for Swift

### DIFF
--- a/lldb/include/lldb/Symbol/CompilerDeclContext.h
+++ b/lldb/include/lldb/Symbol/CompilerDeclContext.h
@@ -61,16 +61,6 @@ public:
 
   /// Checks if this decl context represents a method of a class.
   ///
-  /// \param[out] language_ptr
-  ///     If non NULL and \b true is returned from this function,
-  ///     this will indicate if the language that respresents the method.
-  ///
-  /// \param[out] is_instance_method_ptr
-  ///     If non NULL and \b true is returned from this function,
-  ///     this will indicate if the method is an instance function (true)
-  ///     or a class method (false indicating the function is static, or
-  ///     doesn't require an instance of the class to be called).
-  ///
   /// \param[out] language_object_name_ptr
   ///     If non NULL and \b true is returned from this function,
   ///     this will indicate if implicit object name for the language
@@ -79,9 +69,7 @@ public:
   /// \return
   ///     Returns true if this is a decl context that represents a method
   ///     in a struct, union or class.
-  bool IsClassMethod(lldb::LanguageType *language_ptr,
-                     bool *is_instance_method_ptr,
-                     ConstString *language_object_name_ptr);
+  bool IsClassMethod(ConstString *language_object_name_ptr = nullptr);
 
   /// Check if the given other decl context is contained in the lookup
   /// of this decl context (for example because the other context is a nested

--- a/lldb/include/lldb/Symbol/CompilerDeclContext.h
+++ b/lldb/include/lldb/Symbol/CompilerDeclContext.h
@@ -61,15 +61,21 @@ public:
 
   /// Checks if this decl context represents a method of a class.
   ///
-  /// \param[out] language_object_name_ptr
-  ///     If non NULL and \b true is returned from this function,
-  ///     this will indicate if implicit object name for the language
-  ///     like "this" for C++, and "self" for Objective C.
-  ///
   /// \return
   ///     Returns true if this is a decl context that represents a method
   ///     in a struct, union or class.
-  bool IsClassMethod(ConstString *language_object_name_ptr = nullptr);
+  bool IsClassMethod();
+
+  /// Determines the original language of the decl context.
+  lldb::LanguageType GetLanguage();
+
+  /// Determines the name of the instance variable for the this decl context.
+  ///
+  /// For C++ the name is "this", for Objective-C the name is "self".
+  ///
+  /// \return
+  ///     Returns a string for the name of the instance variable.
+  ConstString GetInstanceVariableName(lldb::LanguageType language);
 
   /// Check if the given other decl context is contained in the lookup
   /// of this decl context (for example because the other context is a nested

--- a/lldb/include/lldb/Symbol/CompilerDeclContext.h
+++ b/lldb/include/lldb/Symbol/CompilerDeclContext.h
@@ -69,14 +69,6 @@ public:
   /// Determines the original language of the decl context.
   lldb::LanguageType GetLanguage();
 
-  /// Determines the name of the instance variable for the this decl context.
-  ///
-  /// For C++ the name is "this", for Objective-C the name is "self".
-  ///
-  /// \return
-  ///     Returns a string for the name of the instance variable.
-  ConstString GetInstanceVariableName(lldb::LanguageType language);
-
   /// Check if the given other decl context is contained in the lookup
   /// of this decl context (for example because the other context is a nested
   /// inline namespace).

--- a/lldb/include/lldb/Symbol/SymbolContext.h
+++ b/lldb/include/lldb/Symbol/SymbolContext.h
@@ -248,13 +248,6 @@ public:
   /// If this symbol context represents a function that is a method, return
   /// true and provide information about the method.
   ///
-  /// \param[out] language
-  ///     If \b true is returned, the language for the method.
-  ///
-  /// \param[out] is_instance_method
-  ///     If \b true is returned, \b true if this is a instance method,
-  ///     \b false if this is a static/class function.
-  ///
   /// \param[out] language_object_name
   ///     If \b true is returned, the name of the artificial variable
   ///     for the language ("this" for C++, "self" for ObjC).
@@ -262,9 +255,7 @@ public:
   /// \return
   ///     \b True if this symbol context represents a function that
   ///     is a method of a class, \b false otherwise.
-  bool GetFunctionMethodInfo(lldb::LanguageType &language,
-                             bool &is_instance_method,
-                             ConstString &language_object_name);
+  bool GetFunctionMethodInfo(ConstString &language_object_name);
 
   /// Sorts the types in TypeMap according to SymbolContext to TypeList
   ///

--- a/lldb/include/lldb/Symbol/SymbolContext.h
+++ b/lldb/include/lldb/Symbol/SymbolContext.h
@@ -245,17 +245,13 @@ public:
   ///     represented by this symbol context object, nullptr otherwise.
   Block *GetFunctionBlock();
 
-  /// If this symbol context represents a function that is a method, return
-  /// true and provide information about the method.
+  /// Determines the name of the instance variable for the this decl context.
   ///
-  /// \param[out] language_object_name
-  ///     If \b true is returned, the name of the artificial variable
-  ///     for the language ("this" for C++, "self" for ObjC).
+  /// For C++ the name is "this", for Objective-C the name is "self".
   ///
   /// \return
-  ///     \b True if this symbol context represents a function that
-  ///     is a method of a class, \b false otherwise.
-  bool GetFunctionMethodInfo(ConstString &language_object_name);
+  ///     Returns a string for the name of the instance variable.
+  ConstString GetInstanceVariableName();
 
   /// Sorts the types in TypeMap according to SymbolContext to TypeList
   ///

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -131,12 +131,12 @@ public:
   virtual ConstString
   DeclContextGetScopeQualifiedName(void *opaque_decl_ctx) = 0;
 
-  virtual bool
-  DeclContextIsClassMethod(void *opaque_decl_ctx,
-                           ConstString *language_object_name_ptr) = 0;
+  virtual bool DeclContextIsClassMethod(void *opaque_decl_ctx) = 0;
 
   virtual bool DeclContextIsContainedInLookup(void *opaque_decl_ctx,
                                               void *other_opaque_decl_ctx) = 0;
+
+  virtual lldb::LanguageType DeclContextGetLanguage(void *opaque_decl_ctx) = 0;
 
   // Tests
 #ifndef NDEBUG
@@ -216,6 +216,10 @@ public:
   // with this type system. For such cases, languages can check and return
   // an error.
   virtual Status IsCompatible();
+
+  /// The name of the variable used for explicitly accessing data scoped to the
+  /// current instance (or type). C++ uses "this", ObjC uses "self".
+  virtual ConstString GetInstanceVariableName(lldb::LanguageType language) = 0;
 
   // Type Completion
 

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -131,9 +131,9 @@ public:
   virtual ConstString
   DeclContextGetScopeQualifiedName(void *opaque_decl_ctx) = 0;
 
-  virtual bool DeclContextIsClassMethod(
-      void *opaque_decl_ctx, lldb::LanguageType *language_ptr,
-      bool *is_instance_method_ptr, ConstString *language_object_name_ptr) = 0;
+  virtual bool
+  DeclContextIsClassMethod(void *opaque_decl_ctx,
+                           ConstString *language_object_name_ptr) = 0;
 
   virtual bool DeclContextIsContainedInLookup(void *opaque_decl_ctx,
                                               void *other_opaque_decl_ctx) = 0;

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -217,10 +217,6 @@ public:
   // an error.
   virtual Status IsCompatible();
 
-  /// The name of the variable used for explicitly accessing data scoped to the
-  /// current instance (or type). C++ uses "this", ObjC uses "self".
-  virtual ConstString GetInstanceVariableName(lldb::LanguageType language) = 0;
-
   // Type Completion
 
   virtual bool GetCompleteType(lldb::opaque_compiler_type_t type) = 0;

--- a/lldb/include/lldb/Target/Language.h
+++ b/lldb/include/lldb/Target/Language.h
@@ -318,6 +318,8 @@ public:
     return ConstString();
   }
 
+  virtual ConstString GetInstanceVariableName() { return {}; }
+
 protected:
   // Classes that inherit from Language can see and modify these
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
@@ -1173,8 +1173,7 @@ SymbolContextList ClangExpressionDeclMap::SearchFunctionsInSymbolContexts(
     // class/instance methods, since they'll be skipped in the code that
     // follows anyway.
     CompilerDeclContext func_decl_context = function->GetDeclContext();
-    if (!func_decl_context ||
-        func_decl_context.IsClassMethod(nullptr, nullptr, nullptr))
+    if (!func_decl_context || func_decl_context.IsClassMethod())
       continue;
     // We can only prune functions for which we can copy the type.
     CompilerType func_clang_type = function->GetType()->GetFullCompilerType();
@@ -1308,7 +1307,7 @@ void ClangExpressionDeclMap::LookupFunction(
           continue;
 
         // Filter out class/instance methods.
-        if (decl_ctx.IsClassMethod(nullptr, nullptr, nullptr))
+        if (decl_ctx.IsClassMethod())
           continue;
 
         AddOneFunction(context, sym_ctx.function, nullptr);

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.h
@@ -153,6 +153,8 @@ public:
   ConstString FindBestAlternateFunctionMangledName(
       const Mangled mangled, const SymbolContext &sym_ctx) const override;
 
+  ConstString GetInstanceVariableName() override { return ConstString("this"); }
+
   // PluginInterface protocol
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
 };

--- a/lldb/source/Plugins/Language/ObjC/ObjCLanguage.h
+++ b/lldb/source/Plugins/Language/ObjC/ObjCLanguage.h
@@ -155,6 +155,8 @@ public:
       return false;
   }
 
+  ConstString GetInstanceVariableName() override { return ConstString("self"); }
+
   // PluginInterface protocol
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
 };

--- a/lldb/source/Plugins/Language/ObjCPlusPlus/ObjCPlusPlusLanguage.h
+++ b/lldb/source/Plugins/Language/ObjCPlusPlus/ObjCPlusPlusLanguage.h
@@ -40,6 +40,8 @@ public:
 
   static lldb_private::Language *CreateInstance(lldb::LanguageType language);
 
+  ConstString GetInstanceVariableName() override { return ConstString("self"); }
+
   static llvm::StringRef GetPluginNameStatic() { return "objcplusplus"; }
 
   // PluginInterface protocol

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.h
@@ -18,6 +18,7 @@
 // Other libraries and framework includes
 // Project includes
 #include "lldb/Target/Language.h"
+#include "lldb/Utility/ConstString.h"
 #include "lldb/lldb-private.h"
 
 namespace lldb_private {
@@ -87,6 +88,8 @@ public:
   static llvm::StringRef GetPluginNameStatic() { return "swift"; }
 
   bool SymbolNameFitsToLanguage(Mangled mangled) const override;
+
+  ConstString GetInstanceVariableName() override { return ConstString("self"); }
 
   //------------------------------------------------------------------
   // PluginInterface protocol

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -9722,36 +9722,25 @@ TypeSystemClang::DeclContextGetScopeQualifiedName(void *opaque_decl_ctx) {
 }
 
 bool TypeSystemClang::DeclContextIsClassMethod(
-    void *opaque_decl_ctx, lldb::LanguageType *language_ptr,
-    bool *is_instance_method_ptr, ConstString *language_object_name_ptr) {
+    void *opaque_decl_ctx, ConstString *language_object_name_ptr) {
   if (opaque_decl_ctx) {
     clang::DeclContext *decl_ctx = (clang::DeclContext *)opaque_decl_ctx;
     if (ObjCMethodDecl *objc_method =
             llvm::dyn_cast<clang::ObjCMethodDecl>(decl_ctx)) {
-      if (is_instance_method_ptr)
-        *is_instance_method_ptr = objc_method->isInstanceMethod();
-      if (language_ptr)
-        *language_ptr = eLanguageTypeObjC;
-      if (language_object_name_ptr)
-        language_object_name_ptr->SetCString("self");
+      if (objc_method->isInstanceMethod())
+        if (language_object_name_ptr)
+          language_object_name_ptr->SetCString("self");
       return true;
     } else if (CXXMethodDecl *cxx_method =
                    llvm::dyn_cast<clang::CXXMethodDecl>(decl_ctx)) {
-      if (is_instance_method_ptr)
-        *is_instance_method_ptr = cxx_method->isInstance();
-      if (language_ptr)
-        *language_ptr = eLanguageTypeC_plus_plus;
-      if (language_object_name_ptr)
-        language_object_name_ptr->SetCString("this");
+      if (cxx_method->isInstance())
+        if (language_object_name_ptr)
+          language_object_name_ptr->SetCString("this");
       return true;
     } else if (clang::FunctionDecl *function_decl =
                    llvm::dyn_cast<clang::FunctionDecl>(decl_ctx)) {
       ClangASTMetadata *metadata = GetMetadata(function_decl);
       if (metadata && metadata->HasObjectPtr()) {
-        if (is_instance_method_ptr)
-          *is_instance_method_ptr = true;
-        if (language_ptr)
-          *language_ptr = eLanguageTypeObjC;
         if (language_object_name_ptr)
           language_object_name_ptr->SetCString(metadata->GetObjectPtrName());
         return true;

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -8,6 +8,8 @@
 
 #include "TypeSystemClang.h"
 
+#include "clang/AST/DeclBase.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/FormatVariadic.h"
 
@@ -3705,6 +3707,22 @@ bool TypeSystemClang::CanPassInRegisters(const CompilerType &type) {
 
 bool TypeSystemClang::SupportsLanguage(lldb::LanguageType language) {
   return TypeSystemClangSupportsLanguage(language);
+}
+
+ConstString
+TypeSystemClang::GetInstanceVariableName(lldb::LanguageType language) {
+  switch (language) {
+  case LanguageType::eLanguageTypeC_plus_plus:
+  case LanguageType::eLanguageTypeC_plus_plus_03:
+  case LanguageType::eLanguageTypeC_plus_plus_11:
+  case LanguageType::eLanguageTypeC_plus_plus_14:
+    return ConstString("this");
+  case LanguageType::eLanguageTypeObjC:
+  case LanguageType::eLanguageTypeObjC_plus_plus:
+    return ConstString("self");
+  default:
+    return {};
+  }
 }
 
 Optional<std::string>
@@ -9721,32 +9739,21 @@ TypeSystemClang::DeclContextGetScopeQualifiedName(void *opaque_decl_ctx) {
   return ConstString();
 }
 
-bool TypeSystemClang::DeclContextIsClassMethod(
-    void *opaque_decl_ctx, ConstString *language_object_name_ptr) {
-  if (opaque_decl_ctx) {
-    clang::DeclContext *decl_ctx = (clang::DeclContext *)opaque_decl_ctx;
-    if (ObjCMethodDecl *objc_method =
-            llvm::dyn_cast<clang::ObjCMethodDecl>(decl_ctx)) {
-      if (objc_method->isInstanceMethod())
-        if (language_object_name_ptr)
-          language_object_name_ptr->SetCString("self");
-      return true;
-    } else if (CXXMethodDecl *cxx_method =
-                   llvm::dyn_cast<clang::CXXMethodDecl>(decl_ctx)) {
-      if (cxx_method->isInstance())
-        if (language_object_name_ptr)
-          language_object_name_ptr->SetCString("this");
-      return true;
-    } else if (clang::FunctionDecl *function_decl =
-                   llvm::dyn_cast<clang::FunctionDecl>(decl_ctx)) {
-      ClangASTMetadata *metadata = GetMetadata(function_decl);
-      if (metadata && metadata->HasObjectPtr()) {
-        if (language_object_name_ptr)
-          language_object_name_ptr->SetCString(metadata->GetObjectPtrName());
-        return true;
-      }
-    }
+bool TypeSystemClang::DeclContextIsClassMethod(void *opaque_decl_ctx) {
+  if (!opaque_decl_ctx)
+    return false;
+
+  clang::DeclContext *decl_ctx = (clang::DeclContext *)opaque_decl_ctx;
+  if (llvm::isa<clang::ObjCMethodDecl>(decl_ctx)) {
+    return true;
+  } else if (llvm::isa<clang::CXXMethodDecl>(decl_ctx)) {
+    return true;
+  } else if (clang::FunctionDecl *fun_decl =
+                 llvm::dyn_cast<clang::FunctionDecl>(decl_ctx)) {
+    if (ClangASTMetadata *metadata = GetMetadata(fun_decl))
+      return metadata->HasObjectPtr();
   }
+
   return false;
 }
 
@@ -9765,6 +9772,24 @@ bool TypeSystemClang::DeclContextIsContainedInLookup(
   } while (other->isInlineNamespace() && (other = other->getParent()));
 
   return false;
+}
+
+lldb::LanguageType
+TypeSystemClang::DeclContextGetLanguage(void *opaque_decl_ctx) {
+  if (!opaque_decl_ctx)
+    return eLanguageTypeUnknown;
+
+  auto *decl_ctx = (clang::DeclContext *)opaque_decl_ctx;
+  if (llvm::isa<clang::ObjCMethodDecl>(decl_ctx)) {
+    return eLanguageTypeObjC;
+  } else if (llvm::isa<clang::CXXMethodDecl>(decl_ctx)) {
+    return eLanguageTypeC_plus_plus;
+  } else if (auto *fun_decl = llvm::dyn_cast<clang::FunctionDecl>(decl_ctx)) {
+    if (ClangASTMetadata *metadata = GetMetadata(fun_decl))
+      return metadata->GetObjectPtrLanguage();
+  }
+
+  return eLanguageTypeUnknown;
 }
 
 static bool IsClangDeclContext(const CompilerDeclContext &dc) {

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -3709,22 +3709,6 @@ bool TypeSystemClang::SupportsLanguage(lldb::LanguageType language) {
   return TypeSystemClangSupportsLanguage(language);
 }
 
-ConstString
-TypeSystemClang::GetInstanceVariableName(lldb::LanguageType language) {
-  switch (language) {
-  case LanguageType::eLanguageTypeC_plus_plus:
-  case LanguageType::eLanguageTypeC_plus_plus_03:
-  case LanguageType::eLanguageTypeC_plus_plus_11:
-  case LanguageType::eLanguageTypeC_plus_plus_14:
-    return ConstString("this");
-  case LanguageType::eLanguageTypeObjC:
-  case LanguageType::eLanguageTypeObjC_plus_plus:
-    return ConstString("self");
-  default:
-    return {};
-  }
-}
-
 Optional<std::string>
 TypeSystemClang::GetCXXClassName(const CompilerType &type) {
   if (!type)

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -570,11 +570,12 @@ public:
 
   ConstString DeclContextGetScopeQualifiedName(void *opaque_decl_ctx) override;
 
-  bool DeclContextIsClassMethod(void *opaque_decl_ctx,
-                                ConstString *language_object_name_ptr) override;
+  bool DeclContextIsClassMethod(void *opaque_decl_ctx) override;
 
   bool DeclContextIsContainedInLookup(void *opaque_decl_ctx,
                                       void *other_opaque_decl_ctx) override;
+
+  lldb::LanguageType DeclContextGetLanguage(void *opaque_decl_ctx) override;
 
   // Clang specific clang::DeclContext functions
 
@@ -702,6 +703,8 @@ public:
   bool CanPassInRegisters(const CompilerType &type) override;
 
   bool SupportsLanguage(lldb::LanguageType language) override;
+
+  ConstString GetInstanceVariableName(lldb::LanguageType language) override;
 
   static llvm::Optional<std::string> GetCXXClassName(const CompilerType &type);
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -571,8 +571,6 @@ public:
   ConstString DeclContextGetScopeQualifiedName(void *opaque_decl_ctx) override;
 
   bool DeclContextIsClassMethod(void *opaque_decl_ctx,
-                                lldb::LanguageType *language_ptr,
-                                bool *is_instance_method_ptr,
                                 ConstString *language_object_name_ptr) override;
 
   bool DeclContextIsContainedInLookup(void *opaque_decl_ctx,

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -704,8 +704,6 @@ public:
 
   bool SupportsLanguage(lldb::LanguageType language) override;
 
-  ConstString GetInstanceVariableName(lldb::LanguageType language) override;
-
   static llvm::Optional<std::string> GetCXXClassName(const CompilerType &type);
 
   // Type Completion

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -19,6 +19,7 @@
 #include "lldb/Symbol/TypeSystem.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/Flags.h"
+#include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-private.h"
 
 namespace clang {
@@ -198,12 +199,11 @@ public:
   ConstString DeclContextGetScopeQualifiedName(void *opaque_decl_ctx) override {
     return {};
   }
-  bool
-  DeclContextIsClassMethod(void *opaque_decl_ctx,
-                           lldb::LanguageType *language_ptr,
-                           bool *is_instance_method_ptr,
-                           ConstString *language_object_name_ptr) override {
+  bool DeclContextIsClassMethod(void *opaque_decl_ctx) override {
     return false;
+  }
+  lldb::LanguageType DeclContextGetLanguage(void *) override {
+    return lldb::eLanguageTypeSwift;
   }
   bool IsRuntimeGeneratedType(lldb::opaque_compiler_type_t type) override {
     return false;

--- a/lldb/source/Symbol/CompilerDeclContext.cpp
+++ b/lldb/source/Symbol/CompilerDeclContext.cpp
@@ -34,13 +34,10 @@ ConstString CompilerDeclContext::GetScopeQualifiedName() const {
   return ConstString();
 }
 
-bool CompilerDeclContext::IsClassMethod(lldb::LanguageType *language_ptr,
-                                        bool *is_instance_method_ptr,
-                                        ConstString *language_object_name_ptr) {
+bool CompilerDeclContext::IsClassMethod(ConstString *language_object_name_ptr) {
   if (IsValid())
-    return m_type_system->DeclContextIsClassMethod(
-        m_opaque_decl_ctx, language_ptr, is_instance_method_ptr,
-        language_object_name_ptr);
+    return m_type_system->DeclContextIsClassMethod(m_opaque_decl_ctx,
+                                                   language_object_name_ptr);
   return false;
 }
 

--- a/lldb/source/Symbol/CompilerDeclContext.cpp
+++ b/lldb/source/Symbol/CompilerDeclContext.cpp
@@ -34,11 +34,23 @@ ConstString CompilerDeclContext::GetScopeQualifiedName() const {
   return ConstString();
 }
 
-bool CompilerDeclContext::IsClassMethod(ConstString *language_object_name_ptr) {
+bool CompilerDeclContext::IsClassMethod() {
   if (IsValid())
-    return m_type_system->DeclContextIsClassMethod(m_opaque_decl_ctx,
-                                                   language_object_name_ptr);
+    return m_type_system->DeclContextIsClassMethod(m_opaque_decl_ctx);
   return false;
+}
+
+lldb::LanguageType CompilerDeclContext::GetLanguage() {
+  if (IsValid())
+    return m_type_system->DeclContextGetLanguage(m_opaque_decl_ctx);
+  return {};
+}
+
+ConstString
+CompilerDeclContext::GetInstanceVariableName(lldb::LanguageType language) {
+  if (IsValid())
+    return m_type_system->GetInstanceVariableName(language);
+  return {};
 }
 
 bool CompilerDeclContext::IsContainedInLookup(CompilerDeclContext other) const {

--- a/lldb/source/Symbol/CompilerDeclContext.cpp
+++ b/lldb/source/Symbol/CompilerDeclContext.cpp
@@ -46,13 +46,6 @@ lldb::LanguageType CompilerDeclContext::GetLanguage() {
   return {};
 }
 
-ConstString
-CompilerDeclContext::GetInstanceVariableName(lldb::LanguageType language) {
-  if (IsValid())
-    return m_type_system->GetInstanceVariableName(language);
-  return {};
-}
-
 bool CompilerDeclContext::IsContainedInLookup(CompilerDeclContext other) const {
   if (!IsValid())
     return false;

--- a/lldb/source/Symbol/SymbolContext.cpp
+++ b/lldb/source/Symbol/SymbolContext.cpp
@@ -539,14 +539,16 @@ Block *SymbolContext::GetFunctionBlock() {
   return nullptr;
 }
 
-bool SymbolContext::GetFunctionMethodInfo(ConstString &language_object_name) {
-  Block *function_block = GetFunctionBlock();
-  if (function_block) {
-    CompilerDeclContext decl_ctx = function_block->GetDeclContext();
-    if (decl_ctx)
-      return decl_ctx.IsClassMethod(&language_object_name);
-  }
-  return false;
+ConstString SymbolContext::GetInstanceVariableName() {
+  if (Block *function_block = GetFunctionBlock())
+    if (CompilerDeclContext decl_ctx = function_block->GetDeclContext()) {
+      auto language = decl_ctx.GetLanguage();
+      if (language == eLanguageTypeUnknown)
+        language = GetLanguage();
+      return decl_ctx.GetInstanceVariableName(language);
+    }
+
+  return {};
 }
 
 void SymbolContext::SortTypeList(TypeMap &type_map, TypeList &type_list) const {

--- a/lldb/source/Symbol/SymbolContext.cpp
+++ b/lldb/source/Symbol/SymbolContext.cpp
@@ -539,17 +539,12 @@ Block *SymbolContext::GetFunctionBlock() {
   return nullptr;
 }
 
-bool SymbolContext::GetFunctionMethodInfo(lldb::LanguageType &language,
-                                          bool &is_instance_method,
-                                          ConstString &language_object_name)
-
-{
+bool SymbolContext::GetFunctionMethodInfo(ConstString &language_object_name) {
   Block *function_block = GetFunctionBlock();
   if (function_block) {
     CompilerDeclContext decl_ctx = function_block->GetDeclContext();
     if (decl_ctx)
-      return decl_ctx.IsClassMethod(&language, &is_instance_method,
-                                    &language_object_name);
+      return decl_ctx.IsClassMethod(&language_object_name);
   }
   return false;
 }

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -567,23 +567,20 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
     // Check for direct ivars access which helps us with implicit access to
     // ivars using "this" or "self".
     GetSymbolContext(eSymbolContextFunction | eSymbolContextBlock);
-    ConstString method_object_name;
-    if (m_sc.GetFunctionMethodInfo(method_object_name)) {
-      if (method_object_name) {
-        var_sp = variable_list->FindVariable(method_object_name);
-        if (var_sp) {
-          separator_idx = 0;
-          if (Type *var_type = var_sp->GetType())
-            if (auto compiler_type = var_type->GetForwardCompilerType())
-              if (!compiler_type.IsPointerType())
-                var_expr_storage = ".";
+    if (auto instance_var_name = m_sc.GetInstanceVariableName()) {
+      var_sp = variable_list->FindVariable(instance_var_name);
+      if (var_sp) {
+        separator_idx = 0;
+        if (Type *var_type = var_sp->GetType())
+          if (auto compiler_type = var_type->GetForwardCompilerType())
+            if (!compiler_type.IsPointerType())
+              var_expr_storage = ".";
 
-          if (var_expr_storage.empty())
-            var_expr_storage = "->";
-          var_expr_storage += var_expr;
-          var_expr = var_expr_storage;
-          synthetically_added_instance_object = true;
-        }
+        if (var_expr_storage.empty())
+          var_expr_storage = "->";
+        var_expr_storage += var_expr;
+        var_expr = var_expr_storage;
+        synthetically_added_instance_object = true;
       }
     }
   }

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -567,12 +567,9 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
     // Check for direct ivars access which helps us with implicit access to
     // ivars using "this" or "self".
     GetSymbolContext(eSymbolContextFunction | eSymbolContextBlock);
-    lldb::LanguageType method_language = eLanguageTypeUnknown;
-    bool is_instance_method = false;
     ConstString method_object_name;
-    if (m_sc.GetFunctionMethodInfo(method_language, is_instance_method,
-                                   method_object_name)) {
-      if (is_instance_method && method_object_name) {
+    if (m_sc.GetFunctionMethodInfo(method_object_name)) {
+      if (method_object_name) {
         var_sp = variable_list->FindVariable(method_object_name);
         if (var_sp) {
           separator_idx = 0;

--- a/lldb/test/API/commands/frame/var/direct-ivar/cpp/Makefile
+++ b/lldb/test/API/commands/frame/var/direct-ivar/cpp/Makefile
@@ -1,0 +1,2 @@
+CXX_SOURCES := main.cpp
+include Makefile.rules

--- a/lldb/test/API/commands/frame/var/direct-ivar/cpp/TestFrameVarDirectIvarCpp.py
+++ b/lldb/test/API/commands/frame/var/direct-ivar/cpp/TestFrameVarDirectIvarCpp.py
@@ -1,0 +1,11 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+    def test_cpp_this(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "// check this", lldb.SBFileSpec("main.cpp"))
+        self.expect("frame variable m_field", startstr="(int) m_field = 30")

--- a/lldb/test/API/commands/frame/var/direct-ivar/cpp/main.cpp
+++ b/lldb/test/API/commands/frame/var/direct-ivar/cpp/main.cpp
@@ -1,0 +1,12 @@
+struct Structure {
+  int m_field;
+  void fun() {
+    // check this
+  }
+};
+
+int main() {
+  Structure s;
+  s.m_field = 30;
+  s.fun();
+}

--- a/lldb/test/API/commands/frame/var/direct-ivar/objc/Makefile
+++ b/lldb/test/API/commands/frame/var/direct-ivar/objc/Makefile
@@ -1,0 +1,2 @@
+OBJC_SOURCES := main.m
+include Makefile.rules

--- a/lldb/test/API/commands/frame/var/direct-ivar/objc/Makefile
+++ b/lldb/test/API/commands/frame/var/direct-ivar/objc/Makefile
@@ -1,2 +1,4 @@
 OBJC_SOURCES := main.m
+CFLAGS_EXTRAS := -fblocks -fobjc-arc
+LD_EXTRAS := -lobjc
 include Makefile.rules

--- a/lldb/test/API/commands/frame/var/direct-ivar/objc/TestFrameVarDirectIvarObjC.py
+++ b/lldb/test/API/commands/frame/var/direct-ivar/objc/TestFrameVarDirectIvarObjC.py
@@ -1,0 +1,12 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+    @skipUnlessDarwin
+    def test_objc_self(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "// check self", lldb.SBFileSpec("main.m"))
+        self.expect("frame variable _ivar", startstr="(int) _ivar = 30")

--- a/lldb/test/API/commands/frame/var/direct-ivar/objc/TestFrameVarDirectIvarObjC.py
+++ b/lldb/test/API/commands/frame/var/direct-ivar/objc/TestFrameVarDirectIvarObjC.py
@@ -10,3 +10,11 @@ class TestCase(TestBase):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "// check self", lldb.SBFileSpec("main.m"))
         self.expect("frame variable _ivar", startstr="(int) _ivar = 30")
+
+    @skipUnlessDarwin
+    def test_objc_self_capture_idiom(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "// check idiomatic self", lldb.SBFileSpec("main.m"))
+        self.expect("frame variable weakSelf", startstr="(Classic *) weakSelf = 0x")
+        self.expect("frame variable self", startstr="(Classic *) self = 0x")
+        self.expect("frame variable _ivar", startstr="(int) _ivar = 30")

--- a/lldb/test/API/commands/frame/var/direct-ivar/objc/main.m
+++ b/lldb/test/API/commands/frame/var/direct-ivar/objc/main.m
@@ -1,0 +1,19 @@
+#include <objc/NSObject.h>
+
+@interface Classic : NSObject {
+@public
+  int _ivar;
+}
+@end
+
+@implementation Classic
+- (int)fun {
+  // check self
+}
+@end
+
+int main() {
+  Classic *c = [Classic new];
+  c->_ivar = 30;
+  [c fun];
+}

--- a/lldb/test/API/commands/frame/var/direct-ivar/objc/main.m
+++ b/lldb/test/API/commands/frame/var/direct-ivar/objc/main.m
@@ -7,8 +7,19 @@
 @end
 
 @implementation Classic
-- (int)fun {
+- (void)fun {
   // check self
+}
+
+- (void)run {
+  __weak Classic *weakSelf = self;
+  ^{
+    Classic *self = weakSelf;
+    // check idiomatic self
+
+    // Use `self` to extend its lifetime (for lldb to inspect the variable).
+    [self copy];
+  }();
 }
 @end
 
@@ -16,4 +27,5 @@ int main() {
   Classic *c = [Classic new];
   c->_ivar = 30;
   [c fun];
+  [c run];
 }

--- a/lldb/test/API/commands/frame/var/direct-ivar/swift/Makefile
+++ b/lldb/test/API/commands/frame/var/direct-ivar/swift/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/commands/frame/var/direct-ivar/swift/TestFrameVarDirectIvarSwift.py
+++ b/lldb/test/API/commands/frame/var/direct-ivar/swift/TestFrameVarDirectIvarSwift.py
@@ -1,0 +1,19 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+    @skipUnlessDarwin
+    def test_objc_self(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "check self", lldb.SBFileSpec("main.swift"))
+        self.expect("frame variable _prop", startstr="(Int) _prop = 30")
+
+    @skipUnlessDarwin
+    def test_objc_self_capture_idiom(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "check idiomatic self", lldb.SBFileSpec("main.swift"))
+        self.expect("frame variable self", startstr="(a.Classic) self = 0x")
+        self.expect("frame variable _prop", startstr="(Int) _prop = 30")

--- a/lldb/test/API/commands/frame/var/direct-ivar/swift/main.swift
+++ b/lldb/test/API/commands/frame/var/direct-ivar/swift/main.swift
@@ -1,0 +1,22 @@
+class Classic {
+  var _prop = 30
+
+  func fun() {
+    print("check self")
+  }
+
+  func run() {
+    { [weak self] in
+      guard let self else { fatalError("cannot happen") }
+      print("check idiomatic self")
+      self.fun()
+    }()
+  }
+}
+
+func main() {
+  var c = Classic()
+  c.run()
+}
+
+main()

--- a/lldb/test/API/lang/swift/archetype_in_expression/TestArchetypeInExpression.py
+++ b/lldb/test/API/lang/swift/archetype_in_expression/TestArchetypeInExpression.py
@@ -22,10 +22,10 @@ class TestArchetypeInExpression(TestBase):
         self.expect("e U.self", substrs=["[Int].Type"])
         # Assert that frame variable doesn't work
         self.expect("v First.self", 
-                substrs=["no variable named 'First' found in this frame"], 
+                substrs=["no variable or instance variable named 'First' found in this frame"],
                 error=True)
         self.expect("v T.self", 
-                substrs=["no variable named 'T' found in this frame"], 
+                substrs=["no variable or instance variable named 'T' found in this frame"],
                 error=True)
 
         # Check that referring to a shadowed archetype works correctly.
@@ -33,7 +33,7 @@ class TestArchetypeInExpression(TestBase):
         self.expect("e T.self", substrs=["String.Type"])
         # Assert that frame variable doesn't work
         self.expect("v T.self", 
-                substrs=["no variable named 'T' found in this frame"], 
+                substrs=["no variable or instance variable named 'T' found in this frame"],
                 error=True)
 
         # Check that you refer to archetypes in nested generic functions.


### PR DESCRIPTION
`frame variable` can print "ivars" directly (as lldb calls them, or equivalently "properties" in Swift parlance), without the user explicitly going through `this` or `self`.

This PR cherry picks upstream LLVM refactoring commits, and adds a single Swift specific commit: "Support direct ivar access in Swift".

Example:

```swift
class Thing {
    var number: Int = 41
    func run() {
        // ...
    }
}
```

Inside `run()`:

```
(lldb) v self.number
(Int) 41
(lldb) v number
(Int) 41
```