### PR TITLE
[clang][cas] Move include-tree-specific code out of core scanner 

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -286,30 +286,6 @@ private:
   LookupModuleOutputCallback LookupModuleOutput;
 };
 
-class CASFSActionController : public CallbackActionController {
-public:
-  CASFSActionController(LookupModuleOutputCallback LookupModuleOutput,
-                        llvm::cas::CachingOnDiskFileSystem &CacheFS,
-                        DepscanPrefixMapping PrefixMapping);
-
-  llvm::Error initialize(CompilerInstance &ScanInstance,
-                         CompilerInvocation &NewInvocation) override;
-  llvm::Error finalize(CompilerInstance &ScanInstance,
-                       CompilerInvocation &NewInvocation) override;
-  llvm::Error
-  initializeModuleBuild(CompilerInstance &ModuleScanInstance) override;
-  llvm::Error
-  finalizeModuleBuild(CompilerInstance &ModuleScanInstance) override;
-  llvm::Error finalizeModuleInvocation(CompilerInvocation &CI,
-                                       const ModuleDeps &MD) override;
-
-private:
-  llvm::cas::CachingOnDiskFileSystem &CacheFS;
-  DepscanPrefixMapping PrefixMapping;
-  std::optional<llvm::TreePathPrefixMapper> Mapper;
-  CASOptions CASOpts;
-};
-
 } // end namespace dependencies
 } // end namespace tooling
 } // end namespace clang

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -64,6 +64,8 @@ public:
   virtual void handleContextHash(std::string Hash) = 0;
 
   virtual void handleCASFileSystemRootID(std::string ID) {}
+
+  virtual void handleIncludeTreeID(std::string ID) {}
 };
 
 /// Dependency scanner callbacks that are used during scanning to influence the

--- a/clang/lib/Tooling/DependencyScanning/CASFSActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/CASFSActionController.cpp
@@ -1,0 +1,204 @@
+//===- CASFSActionController.cpp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CachingActions.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Lex/Preprocessor.h"
+#include "llvm/CAS/CachingOnDiskFileSystem.h"
+#include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/PrefixMapper.h"
+
+using namespace clang;
+using namespace tooling;
+using namespace dependencies;
+using llvm::Error;
+
+namespace {
+class CASFSActionController : public CallbackActionController {
+public:
+  CASFSActionController(LookupModuleOutputCallback LookupModuleOutput,
+                        llvm::cas::CachingOnDiskFileSystem &CacheFS,
+                        DepscanPrefixMapping PrefixMapping);
+
+  llvm::Error initialize(CompilerInstance &ScanInstance,
+                         CompilerInvocation &NewInvocation) override;
+  llvm::Error finalize(CompilerInstance &ScanInstance,
+                       CompilerInvocation &NewInvocation) override;
+  llvm::Error
+  initializeModuleBuild(CompilerInstance &ModuleScanInstance) override;
+  llvm::Error
+  finalizeModuleBuild(CompilerInstance &ModuleScanInstance) override;
+  llvm::Error finalizeModuleInvocation(CompilerInvocation &CI,
+                                       const ModuleDeps &MD) override;
+
+private:
+  llvm::cas::CachingOnDiskFileSystem &CacheFS;
+  DepscanPrefixMapping PrefixMapping;
+  std::optional<llvm::TreePathPrefixMapper> Mapper;
+  CASOptions CASOpts;
+};
+} // anonymous namespace
+
+CASFSActionController::CASFSActionController(
+    LookupModuleOutputCallback LookupModuleOutput,
+    llvm::cas::CachingOnDiskFileSystem &CacheFS,
+    DepscanPrefixMapping PrefixMapping)
+    : CallbackActionController(std::move(LookupModuleOutput)), CacheFS(CacheFS),
+      PrefixMapping(std::move(PrefixMapping)) {}
+
+Error CASFSActionController::initialize(CompilerInstance &ScanInstance,
+                                        CompilerInvocation &NewInvocation) {
+  // Setup prefix mapping.
+  Mapper.emplace(&CacheFS);
+  if (Error E = PrefixMapping.configurePrefixMapper(NewInvocation, *Mapper))
+    return E;
+
+  const PreprocessorOptions &PPOpts = ScanInstance.getPreprocessorOpts();
+  if (!PPOpts.Includes.empty() || !PPOpts.ImplicitPCHInclude.empty())
+    addReversePrefixMappingFileSystem(*Mapper, ScanInstance);
+
+  CacheFS.trackNewAccesses();
+  if (auto CWD =
+          ScanInstance.getVirtualFileSystem().getCurrentWorkingDirectory())
+    CacheFS.setCurrentWorkingDirectory(*CWD);
+  // Track paths that are accessed by the scanner before we reach here.
+  for (const auto &File : ScanInstance.getHeaderSearchOpts().VFSOverlayFiles)
+    (void)CacheFS.status(File);
+  // Enable caching in the resulting commands.
+  ScanInstance.getFrontendOpts().CacheCompileJob = true;
+  CASOpts = ScanInstance.getCASOpts();
+  return Error::success();
+}
+
+/// Ensure that all files reachable from imported modules/pch are tracked.
+/// These could be loaded lazily during compilation.
+static void trackASTFileInputs(CompilerInstance &CI,
+                               llvm::cas::CachingOnDiskFileSystem &CacheFS) {
+  auto Reader = CI.getASTReader();
+  if (!Reader)
+    return;
+
+  for (serialization::ModuleFile &MF : Reader->getModuleManager()) {
+    Reader->visitInputFiles(
+        MF, /*IncludeSystem=*/true, /*Complain=*/false,
+        [](const serialization::InputFile &IF, bool isSystem) {
+          // Visiting input files triggers the file system lookup.
+        });
+  }
+}
+
+/// Ensure files that are not accessed during the scan (or accessed before the
+/// tracking scope) are tracked.
+static void trackFilesCommon(CompilerInstance &CI,
+                             llvm::cas::CachingOnDiskFileSystem &CacheFS) {
+  trackASTFileInputs(CI, CacheFS);
+
+  // Exclude the module cache from tracking. The implicit build pcms should
+  // not be needed after scanning.
+  if (!CI.getHeaderSearchOpts().ModuleCachePath.empty())
+    (void)CacheFS.excludeFromTracking(CI.getHeaderSearchOpts().ModuleCachePath);
+
+  // Normally this would be looked up while creating the VFS, but implicit
+  // modules share their VFS and it happens too early for the TU scan.
+  for (const auto &File : CI.getHeaderSearchOpts().VFSOverlayFiles)
+    (void)CacheFS.status(File);
+
+  StringRef Sysroot = CI.getHeaderSearchOpts().Sysroot;
+  if (!Sysroot.empty()) {
+    // Include 'SDKSettings.json', if it exists, to accomodate availability
+    // checks during the compilation.
+    llvm::SmallString<256> FilePath = Sysroot;
+    llvm::sys::path::append(FilePath, "SDKSettings.json");
+    (void)CacheFS.status(FilePath);
+  }
+}
+
+Error CASFSActionController::finalize(CompilerInstance &ScanInstance,
+                                      CompilerInvocation &NewInvocation) {
+  // Handle profile mappings.
+  (void)CacheFS.status(NewInvocation.getCodeGenOpts().ProfileInstrumentUsePath);
+  (void)CacheFS.status(NewInvocation.getCodeGenOpts().SampleProfileFile);
+  (void)CacheFS.status(NewInvocation.getCodeGenOpts().ProfileRemappingFile);
+
+  trackFilesCommon(ScanInstance, CacheFS);
+
+  auto CASFileSystemRootID = CacheFS.createTreeFromNewAccesses(
+      [&](const llvm::vfs::CachedDirectoryEntry &Entry,
+          SmallVectorImpl<char> &Storage) {
+        return Mapper->mapDirEntry(Entry, Storage);
+      });
+  if (!CASFileSystemRootID)
+    return CASFileSystemRootID.takeError();
+
+  configureInvocationForCaching(NewInvocation, CASOpts,
+                                CASFileSystemRootID->getID().toString(),
+                                CacheFS.getCurrentWorkingDirectory().get(),
+                                /*ProduceIncludeTree=*/false);
+
+  if (Mapper)
+    DepscanPrefixMapping::remapInvocationPaths(NewInvocation, *Mapper);
+
+  return Error::success();
+}
+
+Error CASFSActionController::initializeModuleBuild(
+    CompilerInstance &ModuleScanInstance) {
+
+  CacheFS.trackNewAccesses();
+  // If the working directory is not otherwise accessed by the module build,
+  // we still need it due to -fcas-fs-working-directory being set.
+  if (auto CWD = CacheFS.getCurrentWorkingDirectory())
+    (void)CacheFS.status(*CWD);
+
+  return Error::success();
+}
+
+Error CASFSActionController::finalizeModuleBuild(
+    CompilerInstance &ModuleScanInstance) {
+  trackFilesCommon(ModuleScanInstance, CacheFS);
+
+  std::optional<cas::CASID> RootID;
+  auto E = CacheFS
+               .createTreeFromNewAccesses(
+                   [&](const llvm::vfs::CachedDirectoryEntry &Entry,
+                       SmallVectorImpl<char> &Storage) {
+                     return Mapper->mapDirEntry(Entry, Storage);
+                   })
+               .moveInto(RootID);
+  if (E)
+    return E;
+
+  Module *M = ModuleScanInstance.getPreprocessor().getCurrentModule();
+  assert(M && "finalizing without a module");
+
+  M->setCASFileSystemRootID(RootID->toString());
+  return Error::success();
+}
+
+Error CASFSActionController::finalizeModuleInvocation(CompilerInvocation &CI,
+                                                      const ModuleDeps &MD) {
+  if (auto ID = MD.CASFileSystemRootID) {
+    configureInvocationForCaching(CI, CASOpts, ID->toString(),
+                                  CacheFS.getCurrentWorkingDirectory().get(),
+                                  /*ProduceIncludeTree=*/false);
+  }
+
+  if (Mapper)
+    DepscanPrefixMapping::remapInvocationPaths(CI, *Mapper);
+
+  return llvm::Error::success();
+}
+
+std::unique_ptr<DependencyActionController>
+dependencies::createCASFSActionController(
+    LookupModuleOutputCallback LookupModuleOutput,
+    llvm::cas::CachingOnDiskFileSystem &CacheFS,
+    DepscanPrefixMapping PrefixMapping) {
+  return std::make_unique<CASFSActionController>(LookupModuleOutput, CacheFS,
+                                                 std::move(PrefixMapping));
+}

--- a/clang/lib/Tooling/DependencyScanning/CMakeLists.txt
+++ b/clang/lib/Tooling/DependencyScanning/CMakeLists.txt
@@ -8,11 +8,13 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_clang_library(clangDependencyScanning
+  CASFSActionController.cpp
   DependencyScanningCASFilesystem.cpp
   DependencyScanningFilesystem.cpp
   DependencyScanningService.cpp
   DependencyScanningWorker.cpp
   DependencyScanningTool.cpp
+  IncludeTreeActionController.cpp
   ModuleDepCollector.cpp
   ScanAndUpdateArgs.cpp
 

--- a/clang/lib/Tooling/DependencyScanning/CachingActions.h
+++ b/clang/lib/Tooling/DependencyScanning/CachingActions.h
@@ -1,0 +1,37 @@
+//===- CachingActions.h -----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLING_DEPENDENCYSCANNING_CACHINGACTIONS_H
+#define LLVM_CLANG_TOOLING_DEPENDENCYSCANNING_CACHINGACTIONS_H
+
+#include "clang/Tooling/DependencyScanning/DependencyScanningTool.h"
+#include "clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h"
+
+namespace llvm::cas {
+class CachingOnDiskFileSystem;
+}
+
+namespace clang::tooling::dependencies {
+
+std::unique_ptr<DependencyActionController>
+createIncludeTreeActionController(cas::ObjectStore &DB,
+                                  DepscanPrefixMapping PrefixMapping);
+
+std::unique_ptr<DependencyActionController>
+createCASFSActionController(LookupModuleOutputCallback LookupModuleOutput,
+                            llvm::cas::CachingOnDiskFileSystem &CacheFS,
+                            DepscanPrefixMapping PrefixMapping);
+
+/// The PCH recorded file paths with canonical paths, create a VFS that
+/// allows remapping back to the non-canonical source paths so that they are
+/// found during dep-scanning.
+void addReversePrefixMappingFileSystem(const llvm::PrefixMapper &PrefixMapper,
+                                       CompilerInstance &ScanInstance);
+
+} // namespace clang::tooling::dependencies
+#endif // LLVM_CLANG_TOOLING_DEPENDENCYSCANNING_CACHINGACTIONS_H

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -7,15 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/Tooling/DependencyScanning/DependencyScanningTool.h"
+#include "CachingActions.h"
 #include "clang/CAS/IncludeTree.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/Utils.h"
-#include "clang/Lex/Preprocessor.h"
 #include "clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h"
-#include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/CAS/ObjectStore.h"
-#include "llvm/Support/PrefixMapper.h"
-#include "llvm/Support/PrefixMappingFileSystem.h"
 
 using namespace clang;
 using namespace tooling;
@@ -133,6 +130,34 @@ private:
   llvm::cas::CachingOnDiskFileSystem &FS;
   std::optional<std::string> CASFileSystemRootID;
 };
+
+/// Returns an IncludeTree containing the dependencies.
+class GetIncludeTree : public EmptyDependencyConsumer {
+public:
+  void handleIncludeTreeID(std::string ID) override { IncludeTreeID = ID; }
+
+  Expected<cas::IncludeTreeRoot> getIncludeTree() {
+    if (IncludeTreeID) {
+      auto ID = DB.parseID(*IncludeTreeID);
+      if (!ID)
+        return ID.takeError();
+      auto Ref = DB.getReference(*ID);
+      if (!Ref)
+        return llvm::createStringError(
+            llvm::inconvertibleErrorCode(),
+            llvm::Twine("missing expected include-tree ") + ID->toString());
+      return cas::IncludeTreeRoot::get(DB, *Ref);
+    }
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "failed to get include-tree");
+  }
+
+  GetIncludeTree(cas::ObjectStore &DB) : DB(DB) {}
+
+private:
+  cas::ObjectStore &DB;
+  std::optional<std::string> IncludeTreeID;
+};
 }
 
 llvm::Expected<llvm::cas::ObjectProxy>
@@ -140,10 +165,10 @@ DependencyScanningTool::getDependencyTree(
     const std::vector<std::string> &CommandLine, StringRef CWD,
     DepscanPrefixMapping PrefixMapping) {
   GetDependencyTree Consumer(*Worker.getCASFS());
-  CASFSActionController Controller(nullptr, *Worker.getCASFS(),
-                                   std::move(PrefixMapping));
+  auto Controller = createCASFSActionController(nullptr, *Worker.getCASFS(),
+                                                std::move(PrefixMapping));
   auto Result =
-      Worker.computeDependencies(CWD, CommandLine, Consumer, Controller);
+      Worker.computeDependencies(CWD, CommandLine, Consumer, *Controller);
   if (Result)
     return std::move(Result);
   return Consumer.getTree();
@@ -155,439 +180,25 @@ DependencyScanningTool::getDependencyTreeFromCompilerInvocation(
     DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
     bool DiagGenerationAsCompilation, DepscanPrefixMapping PrefixMapping) {
   GetDependencyTree Consumer(*Worker.getCASFS());
-  CASFSActionController Controller(nullptr, *Worker.getCASFS(),
-                                   std::move(PrefixMapping));
+  auto Controller = createCASFSActionController(nullptr, *Worker.getCASFS(),
+                                                std::move(PrefixMapping));
   Worker.computeDependenciesFromCompilerInvocation(
-      std::move(Invocation), CWD, Consumer, Controller, DiagsConsumer,
+      std::move(Invocation), CWD, Consumer, *Controller, DiagsConsumer,
       VerboseOS, DiagGenerationAsCompilation);
   return Consumer.getTree();
-}
-
-namespace {
-class IncludeTreeActionController : public CallbackActionController {
-public:
-  IncludeTreeActionController(cas::ObjectStore &DB,
-                              const DepscanPrefixMapping &PrefixMapping)
-      : CallbackActionController(nullptr), DB(DB),
-        PrefixMapping(PrefixMapping) {}
-
-  Expected<cas::IncludeTreeRoot> getIncludeTree();
-
-private:
-  Error initialize(CompilerInstance &ScanInstance,
-                   CompilerInvocation &NewInvocation) override;
-
-  void enteredInclude(Preprocessor &PP, FileID FID) override;
-
-  void exitedInclude(Preprocessor &PP, FileID IncludedBy, FileID Include,
-                     SourceLocation ExitLoc) override;
-
-  void handleHasIncludeCheck(Preprocessor &PP, bool Result) override;
-
-  const DepscanPrefixMapping *getPrefixMapping() override {
-    return &PrefixMapping;
-  }
-
-  Error finalize(CompilerInstance &ScanInstance,
-                 CompilerInvocation &NewInvocation) override;
-
-  Expected<cas::ObjectRef> getObjectForFile(Preprocessor &PP, FileID FID);
-  Expected<cas::ObjectRef>
-  getObjectForFileNonCached(FileManager &FM, const SrcMgr::FileInfo &FI);
-  Expected<cas::ObjectRef> getObjectForBuffer(const SrcMgr::FileInfo &FI);
-  Expected<cas::ObjectRef> addToFileList(FileManager &FM, const FileEntry *FE);
-
-  struct FilePPState {
-    SrcMgr::CharacteristicKind FileCharacteristic;
-    cas::ObjectRef File;
-    SmallVector<std::pair<cas::ObjectRef, uint32_t>, 6> Includes;
-    llvm::SmallBitVector HasIncludeChecks;
-  };
-
-  Expected<cas::IncludeTree> getCASTreeForFileIncludes(FilePPState &&PPState);
-
-  Expected<cas::IncludeFile> createIncludeFile(StringRef Filename,
-                                               cas::ObjectRef Contents);
-
-  bool hasErrorOccurred() const { return ErrorToReport.has_value(); }
-
-  template <typename T> std::optional<T> check(Expected<T> &&E) {
-    if (!E) {
-      ErrorToReport = E.takeError();
-      return std::nullopt;
-    }
-    return *E;
-  }
-
-  cas::ObjectStore &DB;
-  const DepscanPrefixMapping &PrefixMapping;
-  llvm::PrefixMapper PrefixMapper;
-  std::optional<cas::ObjectRef> PCHRef;
-  bool StartedEnteringIncludes = false;
-  // When a PCH is used this lists the filenames of the included files as they
-  // are recorded in the PCH, ordered by \p FileEntry::UID index.
-  SmallVector<StringRef> PreIncludedFileNames;
-  llvm::BitVector SeenIncludeFiles;
-  SmallVector<cas::IncludeFileList::FileEntry> IncludedFiles;
-  std::optional<cas::ObjectRef> PredefinesBufferRef;
-  SmallVector<FilePPState> IncludeStack;
-  llvm::DenseMap<const FileEntry *, std::optional<cas::ObjectRef>>
-      ObjectForFile;
-  std::optional<llvm::Error> ErrorToReport;
-};
-
-/// A utility for adding \c PPCallbacks to a compiler instance at the
-/// appropriate time.
-struct PPCallbacksDependencyCollector : public DependencyCollector {
-  using MakeCB =
-      llvm::unique_function<std::unique_ptr<PPCallbacks>(Preprocessor &)>;
-  MakeCB Create;
-  PPCallbacksDependencyCollector(MakeCB Create) : Create(std::move(Create)) {}
-  void attachToPreprocessor(Preprocessor &PP) final {
-    std::unique_ptr<PPCallbacks> CB = Create(PP);
-    assert(CB);
-    PP.addPPCallbacks(std::move(CB));
-  }
-};
-
-struct IncludeTreePPCallbacks : public PPCallbacks {
-  DependencyActionController &Controller;
-  Preprocessor &PP;
-
-public:
-  IncludeTreePPCallbacks(DependencyActionController &Controller,
-                         Preprocessor &PP)
-      : Controller(Controller), PP(PP) {}
-
-  void LexedFileChanged(FileID FID, LexedFileChangeReason Reason,
-                        SrcMgr::CharacteristicKind FileType, FileID PrevFID,
-                        SourceLocation Loc) override {
-    switch (Reason) {
-    case LexedFileChangeReason::EnterFile:
-      Controller.enteredInclude(PP, FID);
-      break;
-    case LexedFileChangeReason::ExitFile: {
-      Controller.exitedInclude(PP, FID, PrevFID, Loc);
-      break;
-    }
-    }
-  }
-
-  void HasInclude(SourceLocation Loc, StringRef FileName, bool IsAngled,
-                  OptionalFileEntryRef File,
-                  SrcMgr::CharacteristicKind FileType) override {
-    Controller.handleHasIncludeCheck(PP, File.has_value());
-  }
-};
-} // namespace
-
-/// The PCH recorded file paths with canonical paths, create a VFS that
-/// allows remapping back to the non-canonical source paths so that they are
-/// found during dep-scanning.
-static void
-addReversePrefixMappingFileSystem(const llvm::PrefixMapper &PrefixMapper,
-                                  CompilerInstance &ScanInstance) {
-  llvm::PrefixMapper ReverseMapper;
-  ReverseMapper.addInverseRange(PrefixMapper.getMappings());
-  ReverseMapper.sort();
-  std::unique_ptr<llvm::vfs::FileSystem> FS =
-      llvm::vfs::createPrefixMappingFileSystem(
-          std::move(ReverseMapper), &ScanInstance.getVirtualFileSystem());
-
-  ScanInstance.getFileManager().setVirtualFileSystem(std::move(FS));
-}
-
-Error IncludeTreeActionController::initialize(
-    CompilerInstance &ScanInstance, CompilerInvocation &NewInvocation) {
-  if (Error E =
-          PrefixMapping.configurePrefixMapper(NewInvocation, PrefixMapper))
-    return E;
-
-  auto ensurePathRemapping = [&]() {
-    if (PrefixMapper.empty())
-      return;
-
-    PreprocessorOptions &PPOpts = ScanInstance.getPreprocessorOpts();
-    if (PPOpts.Includes.empty() && PPOpts.ImplicitPCHInclude.empty())
-      return;
-
-    addReversePrefixMappingFileSystem(PrefixMapper, ScanInstance);
-
-    // These are written in the predefines buffer, so we need to remap them.
-    for (std::string &Include : PPOpts.Includes)
-      PrefixMapper.mapInPlace(Include);
-  };
-  ensurePathRemapping();
-
-  // Attach callbacks for the IncludeTree of the TU. The preprocessor
-  // does not exist yet, so we need to indirect this via DependencyCollector.
-  auto DC = std::make_shared<PPCallbacksDependencyCollector>(
-      [this](Preprocessor &PP) {
-        return std::make_unique<IncludeTreePPCallbacks>(*this, PP);
-      });
-  ScanInstance.addDependencyCollector(std::move(DC));
-
-  return Error::success();
-}
-
-void IncludeTreeActionController::enteredInclude(Preprocessor &PP, FileID FID) {
-  if (hasErrorOccurred())
-    return;
-
-  if (!StartedEnteringIncludes) {
-    StartedEnteringIncludes = true;
-
-    // Get the included files (coming from a PCH), and keep track of the
-    // filenames that were recorded in the PCH.
-    for (const FileEntry *FE : PP.getIncludedFiles()) {
-      unsigned UID = FE->getUID();
-      if (UID >= PreIncludedFileNames.size())
-        PreIncludedFileNames.resize(UID + 1);
-      PreIncludedFileNames[UID] = FE->getName();
-    }
-  }
-
-  std::optional<cas::ObjectRef> FileRef = check(getObjectForFile(PP, FID));
-  if (!FileRef)
-    return;
-  const SrcMgr::FileInfo &FI =
-      PP.getSourceManager().getSLocEntry(FID).getFile();
-  IncludeStack.push_back({FI.getFileCharacteristic(), *FileRef, {}, {}});
-}
-
-void IncludeTreeActionController::exitedInclude(Preprocessor &PP,
-                                                FileID IncludedBy,
-                                                FileID Include,
-                                                SourceLocation ExitLoc) {
-  if (hasErrorOccurred())
-    return;
-
-  assert(*check(getObjectForFile(PP, Include)) == IncludeStack.back().File);
-  std::optional<cas::IncludeTree> IncludeTree =
-      check(getCASTreeForFileIncludes(IncludeStack.pop_back_val()));
-  if (!IncludeTree)
-    return;
-  assert(*check(getObjectForFile(PP, IncludedBy)) == IncludeStack.back().File);
-  SourceManager &SM = PP.getSourceManager();
-  std::pair<FileID, unsigned> LocInfo = SM.getDecomposedExpansionLoc(ExitLoc);
-  IncludeStack.back().Includes.push_back(
-      {IncludeTree->getRef(), LocInfo.second});
-}
-
-void IncludeTreeActionController::handleHasIncludeCheck(Preprocessor &PP,
-                                                        bool Result) {
-  if (hasErrorOccurred())
-    return;
-
-  IncludeStack.back().HasIncludeChecks.push_back(Result);
-}
-
-Error IncludeTreeActionController::finalize(CompilerInstance &ScanInstance,
-                                            CompilerInvocation &NewInvocation) {
-  FileManager &FM = ScanInstance.getFileManager();
-
-  auto addFile = [&](StringRef FilePath,
-                     bool IgnoreFileError = false) -> Error {
-    llvm::ErrorOr<const FileEntry *> FE = FM.getFile(FilePath);
-    if (!FE) {
-      if (IgnoreFileError)
-        return Error::success();
-      return llvm::errorCodeToError(FE.getError());
-    }
-    std::optional<cas::ObjectRef> Ref;
-    return addToFileList(FM, *FE).moveInto(Ref);
-  };
-
-  for (StringRef FilePath : NewInvocation.getLangOpts()->NoSanitizeFiles) {
-    if (Error E = addFile(FilePath))
-      return E;
-  }
-  // Add profile files.
-  // FIXME: Do not have the logic here to determine which path should be set
-  // but ideally only the path needed for the compilation is set and we already
-  // checked the file needed exists. Just try load and ignore errors.
-  if (Error E = addFile(NewInvocation.getCodeGenOpts().ProfileInstrumentUsePath,
-                        /*IgnoreFileError=*/true))
-    return E;
-  if (Error E = addFile(NewInvocation.getCodeGenOpts().SampleProfileFile,
-                        /*IgnoreFileError=*/true))
-    return E;
-  if (Error E = addFile(NewInvocation.getCodeGenOpts().ProfileRemappingFile,
-                        /*IgnoreFileError=*/true))
-    return E;
-
-  StringRef Sysroot = NewInvocation.getHeaderSearchOpts().Sysroot;
-  if (!Sysroot.empty()) {
-    // Include 'SDKSettings.json', if it exists, to accomodate availability
-    // checks during the compilation.
-    llvm::SmallString<256> FilePath = Sysroot;
-    llvm::sys::path::append(FilePath, "SDKSettings.json");
-    if (Error E = addFile(FilePath, /*IgnoreFileError*/ true))
-      return E;
-  }
-
-  PreprocessorOptions &PPOpts = NewInvocation.getPreprocessorOpts();
-  if (PPOpts.ImplicitPCHInclude.empty())
-    return Error::success(); // no need for additional work.
-
-  // Go through all the recorded included files; we'll get additional files from
-  // the PCH that we need to include in the file list, in case they are
-  // referenced while replaying the include-tree.
-  SmallVector<const FileEntry *, 32> NotSeenIncludes;
-  for (const FileEntry *FE :
-       ScanInstance.getPreprocessor().getIncludedFiles()) {
-    if (FE->getUID() >= SeenIncludeFiles.size() ||
-        !SeenIncludeFiles[FE->getUID()])
-      NotSeenIncludes.push_back(FE);
-  }
-  // Sort so we can visit the files in deterministic order.
-  llvm::sort(NotSeenIncludes, [](const FileEntry *LHS, const FileEntry *RHS) {
-    return LHS->getUID() < RHS->getUID();
-  });
-
-  for (const FileEntry *FE : NotSeenIncludes) {
-    auto FileNode = addToFileList(FM, FE);
-    if (!FileNode)
-      return FileNode.takeError();
-  }
-
-  llvm::ErrorOr<std::optional<cas::ObjectRef>> CASContents =
-      FM.getObjectRefForFileContent(PPOpts.ImplicitPCHInclude);
-  if (!CASContents)
-    return llvm::errorCodeToError(CASContents.getError());
-  PCHRef = **CASContents;
-
-  return Error::success();
-}
-
-Expected<cas::ObjectRef>
-IncludeTreeActionController::getObjectForFile(Preprocessor &PP, FileID FID) {
-  SourceManager &SM = PP.getSourceManager();
-  const SrcMgr::FileInfo &FI = SM.getSLocEntry(FID).getFile();
-  if (PP.getPredefinesFileID() == FID) {
-    if (!PredefinesBufferRef) {
-      auto Ref = getObjectForBuffer(FI);
-      if (!Ref)
-        return Ref.takeError();
-      PredefinesBufferRef = *Ref;
-    }
-    return *PredefinesBufferRef;
-  }
-  assert(FI.getContentCache().OrigEntry);
-  auto &FileRef = ObjectForFile[FI.getContentCache().OrigEntry];
-  if (!FileRef) {
-    auto Ref = getObjectForFileNonCached(SM.getFileManager(), FI);
-    if (!Ref)
-      return Ref.takeError();
-    FileRef = *Ref;
-  }
-  return *FileRef;
-}
-
-Expected<cas::ObjectRef> IncludeTreeActionController::getObjectForFileNonCached(
-    FileManager &FM, const SrcMgr::FileInfo &FI) {
-  const FileEntry *FE = FI.getContentCache().OrigEntry;
-  assert(FE);
-
-  // Mark the include as already seen.
-  if (FE->getUID() >= SeenIncludeFiles.size())
-    SeenIncludeFiles.resize(FE->getUID() + 1);
-  SeenIncludeFiles.set(FE->getUID());
-
-  return addToFileList(FM, FE);
-}
-
-Expected<cas::ObjectRef>
-IncludeTreeActionController::getObjectForBuffer(const SrcMgr::FileInfo &FI) {
-  // This is a non-file buffer, like the predefines.
-  auto Ref = DB.storeFromString(
-      {}, FI.getContentCache().getBufferIfLoaded()->getBuffer());
-  if (!Ref)
-    return Ref.takeError();
-  Expected<cas::IncludeFile> FileNode = createIncludeFile(FI.getName(), *Ref);
-  if (!FileNode)
-    return FileNode.takeError();
-  return FileNode->getRef();
-}
-
-Expected<cas::ObjectRef>
-IncludeTreeActionController::addToFileList(FileManager &FM,
-                                           const FileEntry *FE) {
-  StringRef Filename = FE->getName();
-  llvm::ErrorOr<std::optional<cas::ObjectRef>> CASContents =
-      FM.getObjectRefForFileContent(Filename);
-  if (!CASContents)
-    return llvm::errorCodeToError(CASContents.getError());
-  assert(*CASContents);
-
-  auto addFile = [&](StringRef Filename) -> Expected<cas::ObjectRef> {
-    assert(!Filename.empty());
-    auto FileNode = createIncludeFile(Filename, **CASContents);
-    if (!FileNode)
-      return FileNode.takeError();
-    IncludedFiles.push_back(
-        {FileNode->getRef(),
-         static_cast<cas::IncludeFileList::FileSizeTy>(FE->getSize())});
-    return FileNode->getRef();
-  };
-
-  // Check whether another path coming from the PCH is associated with the same
-  // file.
-  unsigned UID = FE->getUID();
-  if (UID < PreIncludedFileNames.size() && !PreIncludedFileNames[UID].empty() &&
-      PreIncludedFileNames[UID] != Filename) {
-    auto FileNode = addFile(PreIncludedFileNames[UID]);
-    if (!FileNode)
-      return FileNode.takeError();
-  }
-
-  return addFile(Filename);
-}
-
-Expected<cas::IncludeTree>
-IncludeTreeActionController::getCASTreeForFileIncludes(FilePPState &&PPState) {
-  return cas::IncludeTree::create(DB, PPState.FileCharacteristic, PPState.File,
-                                  PPState.Includes, PPState.HasIncludeChecks);
-}
-
-Expected<cas::IncludeFile>
-IncludeTreeActionController::createIncludeFile(StringRef Filename,
-                                               cas::ObjectRef Contents) {
-  SmallString<256> MappedPath;
-  if (!PrefixMapper.empty()) {
-    PrefixMapper.map(Filename, MappedPath);
-    Filename = MappedPath;
-  }
-  return cas::IncludeFile::create(DB, Filename, std::move(Contents));
-}
-
-Expected<cas::IncludeTreeRoot> IncludeTreeActionController::getIncludeTree() {
-  if (ErrorToReport)
-    return std::move(*ErrorToReport);
-
-  assert(IncludeStack.size() == 1);
-  Expected<cas::IncludeTree> MainIncludeTree =
-      getCASTreeForFileIncludes(IncludeStack.pop_back_val());
-  if (!MainIncludeTree)
-    return MainIncludeTree.takeError();
-  auto FileList = cas::IncludeFileList::create(DB, IncludedFiles);
-  if (!FileList)
-    return FileList.takeError();
-
-  return cas::IncludeTreeRoot::create(DB, MainIncludeTree->getRef(),
-                                      FileList->getRef(), PCHRef);
 }
 
 Expected<cas::IncludeTreeRoot> DependencyScanningTool::getIncludeTree(
     cas::ObjectStore &DB, const std::vector<std::string> &CommandLine,
     StringRef CWD, const DepscanPrefixMapping &PrefixMapping) {
-  EmptyDependencyConsumer Consumer;
-  IncludeTreeActionController Controller(DB, PrefixMapping);
+  GetIncludeTree Consumer(DB);
+  auto Controller =
+      createIncludeTreeActionController(DB, std::move(PrefixMapping));
   llvm::Error Result =
-      Worker.computeDependencies(CWD, CommandLine, Consumer, Controller);
+      Worker.computeDependencies(CWD, CommandLine, Consumer, *Controller);
   if (Result)
     return std::move(Result);
-  return Controller.getIncludeTree();
+  return Consumer.getIncludeTree();
 }
 
 Expected<cas::IncludeTreeRoot>
@@ -596,12 +207,13 @@ DependencyScanningTool::getIncludeTreeFromCompilerInvocation(
     StringRef CWD, const DepscanPrefixMapping &PrefixMapping,
     DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
     bool DiagGenerationAsCompilation) {
-  EmptyDependencyConsumer Consumer;
-  IncludeTreeActionController Controller(DB, PrefixMapping);
+  GetIncludeTree Consumer(DB);
+  auto Controller =
+      createIncludeTreeActionController(DB, std::move(PrefixMapping));
   Worker.computeDependenciesFromCompilerInvocation(
-      std::move(Invocation), CWD, Consumer, Controller, DiagsConsumer,
+      std::move(Invocation), CWD, Consumer, *Controller, DiagsConsumer,
       VerboseOS, DiagGenerationAsCompilation);
-  return Controller.getIncludeTree();
+  return Consumer.getIncludeTree();
 }
 
 llvm::Expected<P1689Rule> DependencyScanningTool::getP1689ModuleDependencyFile(
@@ -736,8 +348,8 @@ DependencyScanningTool::createActionController(
     LookupModuleOutputCallback LookupModuleOutput,
     DepscanPrefixMapping PrefixMapping) {
   if (auto CacheFS = Worker.getCASFS())
-    return std::make_unique<CASFSActionController>(LookupModuleOutput, *CacheFS,
-                                                   std::move(PrefixMapping));
+    return createCASFSActionController(LookupModuleOutput, *CacheFS,
+                                       std::move(PrefixMapping));
   return std::make_unique<CallbackActionController>(LookupModuleOutput);
 }
 
@@ -747,154 +359,4 @@ DependencyScanningTool::createActionController(
     DepscanPrefixMapping PrefixMapping) {
   return createActionController(Worker, std::move(LookupModuleOutput),
                                 std::move(PrefixMapping));
-}
-
-CASFSActionController::CASFSActionController(
-    LookupModuleOutputCallback LookupModuleOutput,
-    llvm::cas::CachingOnDiskFileSystem &CacheFS,
-    DepscanPrefixMapping PrefixMapping)
-    : CallbackActionController(std::move(LookupModuleOutput)), CacheFS(CacheFS),
-      PrefixMapping(std::move(PrefixMapping)) {}
-
-Error CASFSActionController::initialize(CompilerInstance &ScanInstance,
-                                        CompilerInvocation &NewInvocation) {
-  // Setup prefix mapping.
-  Mapper.emplace(&CacheFS);
-  if (Error E = PrefixMapping.configurePrefixMapper(NewInvocation, *Mapper))
-    return E;
-
-  const PreprocessorOptions &PPOpts = ScanInstance.getPreprocessorOpts();
-  if (!PPOpts.Includes.empty() || !PPOpts.ImplicitPCHInclude.empty())
-    addReversePrefixMappingFileSystem(*Mapper, ScanInstance);
-
-  CacheFS.trackNewAccesses();
-  if (auto CWD =
-          ScanInstance.getVirtualFileSystem().getCurrentWorkingDirectory())
-    CacheFS.setCurrentWorkingDirectory(*CWD);
-  // Track paths that are accessed by the scanner before we reach here.
-  for (const auto &File : ScanInstance.getHeaderSearchOpts().VFSOverlayFiles)
-    (void)CacheFS.status(File);
-  // Enable caching in the resulting commands.
-  ScanInstance.getFrontendOpts().CacheCompileJob = true;
-  CASOpts = ScanInstance.getCASOpts();
-  return Error::success();
-}
-
-/// Ensure that all files reachable from imported modules/pch are tracked.
-/// These could be loaded lazily during compilation.
-static void trackASTFileInputs(CompilerInstance &CI,
-                               llvm::cas::CachingOnDiskFileSystem &CacheFS) {
-  auto Reader = CI.getASTReader();
-  if (!Reader)
-    return;
-
-  for (serialization::ModuleFile &MF : Reader->getModuleManager()) {
-    Reader->visitInputFiles(
-        MF, /*IncludeSystem=*/true, /*Complain=*/false,
-        [](const serialization::InputFile &IF, bool isSystem) {
-          // Visiting input files triggers the file system lookup.
-        });
-  }
-}
-
-/// Ensure files that are not accessed during the scan (or accessed before the
-/// tracking scope) are tracked.
-static void trackFilesCommon(CompilerInstance &CI,
-                             llvm::cas::CachingOnDiskFileSystem &CacheFS) {
-  trackASTFileInputs(CI, CacheFS);
-
-  // Exclude the module cache from tracking. The implicit build pcms should
-  // not be needed after scanning.
-  if (!CI.getHeaderSearchOpts().ModuleCachePath.empty())
-    (void)CacheFS.excludeFromTracking(CI.getHeaderSearchOpts().ModuleCachePath);
-
-  // Normally this would be looked up while creating the VFS, but implicit
-  // modules share their VFS and it happens too early for the TU scan.
-  for (const auto &File : CI.getHeaderSearchOpts().VFSOverlayFiles)
-    (void)CacheFS.status(File);
-
-  StringRef Sysroot = CI.getHeaderSearchOpts().Sysroot;
-  if (!Sysroot.empty()) {
-    // Include 'SDKSettings.json', if it exists, to accomodate availability
-    // checks during the compilation.
-    llvm::SmallString<256> FilePath = Sysroot;
-    llvm::sys::path::append(FilePath, "SDKSettings.json");
-    (void)CacheFS.status(FilePath);
-  }
-}
-
-Error CASFSActionController::finalize(CompilerInstance &ScanInstance,
-                                      CompilerInvocation &NewInvocation) {
-  // Handle profile mappings.
-  (void)CacheFS.status(NewInvocation.getCodeGenOpts().ProfileInstrumentUsePath);
-  (void)CacheFS.status(NewInvocation.getCodeGenOpts().SampleProfileFile);
-  (void)CacheFS.status(NewInvocation.getCodeGenOpts().ProfileRemappingFile);
-
-  trackFilesCommon(ScanInstance, CacheFS);
-
-  auto CASFileSystemRootID = CacheFS.createTreeFromNewAccesses(
-      [&](const llvm::vfs::CachedDirectoryEntry &Entry,
-          SmallVectorImpl<char> &Storage) {
-        return Mapper->mapDirEntry(Entry, Storage);
-      });
-  if (!CASFileSystemRootID)
-    return CASFileSystemRootID.takeError();
-
-  configureInvocationForCaching(NewInvocation, CASOpts,
-                                CASFileSystemRootID->getID().toString(),
-                                CacheFS.getCurrentWorkingDirectory().get(),
-                                /*ProduceIncludeTree=*/false);
-
-  if (Mapper)
-    DepscanPrefixMapping::remapInvocationPaths(NewInvocation, *Mapper);
-
-  return Error::success();
-}
-
-Error CASFSActionController::initializeModuleBuild(
-    CompilerInstance &ModuleScanInstance) {
-
-  CacheFS.trackNewAccesses();
-  // If the working directory is not otherwise accessed by the module build,
-  // we still need it due to -fcas-fs-working-directory being set.
-  if (auto CWD = CacheFS.getCurrentWorkingDirectory())
-    (void)CacheFS.status(*CWD);
-
-  return Error::success();
-}
-
-Error CASFSActionController::finalizeModuleBuild(
-    CompilerInstance &ModuleScanInstance) {
-  trackFilesCommon(ModuleScanInstance, CacheFS);
-
-  std::optional<cas::CASID> RootID;
-  auto E = CacheFS
-               .createTreeFromNewAccesses(
-                   [&](const llvm::vfs::CachedDirectoryEntry &Entry,
-                       SmallVectorImpl<char> &Storage) {
-                     return Mapper->mapDirEntry(Entry, Storage);
-                   })
-               .moveInto(RootID);
-  if (E)
-    return E;
-
-  Module *M = ModuleScanInstance.getPreprocessor().getCurrentModule();
-  assert(M && "finalizing without a module");
-
-  M->setCASFileSystemRootID(RootID->toString());
-  return Error::success();
-}
-
-Error CASFSActionController::finalizeModuleInvocation(CompilerInvocation &CI,
-                                                      const ModuleDeps &MD) {
-  if (auto ID = MD.CASFileSystemRootID) {
-    configureInvocationForCaching(CI, CASOpts, ID->toString(),
-                                  CacheFS.getCurrentWorkingDirectory().get(),
-                                  /*ProduceIncludeTree=*/false);
-  }
-
-  if (Mapper)
-    DepscanPrefixMapping::remapInvocationPaths(CI, *Mapper);
-
-  return llvm::Error::success();
 }

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -477,9 +477,13 @@ public:
     if (Error E = Controller.finalize(ScanInstance, OriginalInvocation))
       return reportError(std::move(E));
 
+    // Forward any CAS results to consumer.
     std::string ID = OriginalInvocation.getFileSystemOpts().CASFileSystemRootID;
     if (!ID.empty())
       Consumer.handleCASFileSystemRootID(std::move(ID));
+    ID = OriginalInvocation.getFrontendOpts().CASIncludeTreeID;
+    if (!ID.empty())
+      Consumer.handleIncludeTreeID(std::move(ID));
 
     LastCC1Arguments = OriginalInvocation.getCC1CommandLine();
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -162,48 +162,17 @@ static void sanitizeDiagOpts(DiagnosticOptions &DiagOpts) {
   DiagOpts.IgnoreWarnings = true;
 }
 
-struct IncludeTreePPCallbacks : public PPCallbacks {
-  DependencyActionController &Controller;
-  Preprocessor &PP;
-
-public:
-  IncludeTreePPCallbacks(DependencyActionController &Controller,
-                         Preprocessor &PP)
-      : Controller(Controller), PP(PP) {}
-
-  void LexedFileChanged(FileID FID, LexedFileChangeReason Reason,
-                        SrcMgr::CharacteristicKind FileType, FileID PrevFID,
-                        SourceLocation Loc) override {
-    switch (Reason) {
-    case LexedFileChangeReason::EnterFile:
-      Controller.enteredInclude(PP, FID);
-      break;
-    case LexedFileChangeReason::ExitFile: {
-      Controller.exitedInclude(PP, FID, PrevFID, Loc);
-      break;
-    }
-    }
-  }
-
-  void HasInclude(SourceLocation Loc, StringRef FileName, bool IsAngled,
-                  OptionalFileEntryRef File,
-                  SrcMgr::CharacteristicKind FileType) override {
-    Controller.handleHasIncludeCheck(PP, File.has_value());
-  }
-};
-
-class IncludeTreeCollector : public DependencyFileGenerator {
-  DependencyActionController &Controller;
-  std::unique_ptr<DependencyOutputOptions> Opts;
-  bool EmitDependencyFile = false;
+/// Builds a dependency file after reversing prefix mappings. This allows
+/// emitting a .d file that has real paths where they would otherwise be
+/// canonicalized.
+class ReversePrefixMappingDependencyFileGenerator
+    : public DependencyFileGenerator {
   llvm::PrefixMapper ReverseMapper;
 
 public:
-  IncludeTreeCollector(DependencyActionController &Controller,
-                       std::unique_ptr<DependencyOutputOptions> Opts,
-                       bool EmitDependencyFile)
-      : DependencyFileGenerator(*Opts), Controller(Controller),
-        Opts(std::move(Opts)), EmitDependencyFile(EmitDependencyFile) {}
+  ReversePrefixMappingDependencyFileGenerator(
+      const DependencyOutputOptions &Opts)
+      : DependencyFileGenerator(Opts) {}
 
   Error initialize(const CompilerInvocation &CI,
                    const DepscanPrefixMapping &PrefixMapping) {
@@ -218,11 +187,6 @@ public:
     return Error::success();
   }
 
-  void attachToPreprocessor(Preprocessor &PP) override {
-    PP.addPPCallbacks(std::make_unique<IncludeTreePPCallbacks>(Controller, PP));
-    DependencyFileGenerator::attachToPreprocessor(PP);
-  }
-
   void maybeAddDependency(StringRef Filename, bool FromModule, bool IsSystem,
                           bool IsModuleFile, bool IsMissing) override {
     if (ReverseMapper.empty())
@@ -235,11 +199,6 @@ public:
     ReverseMapper.mapInPlace(New);
     return DependencyFileGenerator::maybeAddDependency(
         New, FromModule, IsSystem, IsModuleFile, IsMissing);
-  }
-
-  void finishedMainFile(DiagnosticsEngine &Diags) override {
-    if (EmitDependencyFile)
-      DependencyFileGenerator::finishedMainFile(Diags);
   }
 };
 
@@ -457,18 +416,20 @@ public:
           std::make_shared<DependencyConsumerForwarder>(
               std::move(Opts), WorkingDirectory, Consumer, EmitDependencyFile));
       break;
-    case ScanningOutputFormat::IncludeTree: {
-      auto IncTreeCollector = std::make_shared<IncludeTreeCollector>(
-          Controller, std::move(Opts), EmitDependencyFile);
-      if (Error E = IncTreeCollector->initialize(
-              ScanInstance.getInvocation(), *Controller.getPrefixMapping()))
-        return reportError(std::move(E));
-      ScanInstance.addDependencyCollector(std::move(IncTreeCollector));
-      break;
-    }
+    case ScanningOutputFormat::IncludeTree:
     case ScanningOutputFormat::P1689:
     case ScanningOutputFormat::Full:
     case ScanningOutputFormat::FullTree:
+      if (EmitDependencyFile) {
+        auto DFG =
+            std::make_shared<ReversePrefixMappingDependencyFileGenerator>(
+                *Opts);
+        if (auto *Mapping = Controller.getPrefixMapping())
+          if (auto E = DFG->initialize(ScanInstance.getInvocation(), *Mapping))
+            return reportError(std::move(E));
+        ScanInstance.addDependencyCollector(std::move(DFG));
+      }
+
       MDC = std::make_shared<ModuleDepCollector>(
           std::move(Opts), ScanInstance, Consumer, Controller,
           OriginalInvocation, OptimizeArgs, EagerLoadModules,

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -1,0 +1,456 @@
+//===- IncludeTreeActionController.cpp ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CachingActions.h"
+#include "clang/CAS/IncludeTree.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Lex/Preprocessor.h"
+#include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/PrefixMapper.h"
+#include "llvm/Support/PrefixMappingFileSystem.h"
+
+using namespace clang;
+using namespace tooling;
+using namespace dependencies;
+using llvm::Error;
+
+namespace {
+class IncludeTreeActionController : public CallbackActionController {
+public:
+  IncludeTreeActionController(cas::ObjectStore &DB,
+                              DepscanPrefixMapping PrefixMapping)
+      : CallbackActionController(nullptr), DB(DB),
+        PrefixMapping(std::move(PrefixMapping)) {}
+
+  Expected<cas::IncludeTreeRoot> getIncludeTree();
+
+private:
+  Error initialize(CompilerInstance &ScanInstance,
+                   CompilerInvocation &NewInvocation) override;
+
+  void enteredInclude(Preprocessor &PP, FileID FID) override;
+
+  void exitedInclude(Preprocessor &PP, FileID IncludedBy, FileID Include,
+                     SourceLocation ExitLoc) override;
+
+  void handleHasIncludeCheck(Preprocessor &PP, bool Result) override;
+
+  const DepscanPrefixMapping *getPrefixMapping() override {
+    return &PrefixMapping;
+  }
+
+  Error finalize(CompilerInstance &ScanInstance,
+                 CompilerInvocation &NewInvocation) override;
+
+  Expected<cas::ObjectRef> getObjectForFile(Preprocessor &PP, FileID FID);
+  Expected<cas::ObjectRef>
+  getObjectForFileNonCached(FileManager &FM, const SrcMgr::FileInfo &FI);
+  Expected<cas::ObjectRef> getObjectForBuffer(const SrcMgr::FileInfo &FI);
+  Expected<cas::ObjectRef> addToFileList(FileManager &FM, const FileEntry *FE);
+
+  struct FilePPState {
+    SrcMgr::CharacteristicKind FileCharacteristic;
+    cas::ObjectRef File;
+    SmallVector<std::pair<cas::ObjectRef, uint32_t>, 6> Includes;
+    llvm::SmallBitVector HasIncludeChecks;
+  };
+
+  Expected<cas::IncludeTree> getCASTreeForFileIncludes(FilePPState &&PPState);
+
+  Expected<cas::IncludeFile> createIncludeFile(StringRef Filename,
+                                               cas::ObjectRef Contents);
+
+  bool hasErrorOccurred() const { return ErrorToReport.has_value(); }
+
+  template <typename T> std::optional<T> check(Expected<T> &&E) {
+    if (!E) {
+      ErrorToReport = E.takeError();
+      return std::nullopt;
+    }
+    return *E;
+  }
+
+  cas::ObjectStore &DB;
+  DepscanPrefixMapping PrefixMapping;
+  llvm::PrefixMapper PrefixMapper;
+  std::optional<cas::ObjectRef> PCHRef;
+  bool StartedEnteringIncludes = false;
+  // When a PCH is used this lists the filenames of the included files as they
+  // are recorded in the PCH, ordered by \p FileEntry::UID index.
+  SmallVector<StringRef> PreIncludedFileNames;
+  llvm::BitVector SeenIncludeFiles;
+  SmallVector<cas::IncludeFileList::FileEntry> IncludedFiles;
+  std::optional<cas::ObjectRef> PredefinesBufferRef;
+  SmallVector<FilePPState> IncludeStack;
+  llvm::DenseMap<const FileEntry *, std::optional<cas::ObjectRef>>
+      ObjectForFile;
+  std::optional<llvm::Error> ErrorToReport;
+};
+
+/// A utility for adding \c PPCallbacks to a compiler instance at the
+/// appropriate time.
+struct PPCallbacksDependencyCollector : public DependencyCollector {
+  using MakeCB =
+      llvm::unique_function<std::unique_ptr<PPCallbacks>(Preprocessor &)>;
+  MakeCB Create;
+  PPCallbacksDependencyCollector(MakeCB Create) : Create(std::move(Create)) {}
+  void attachToPreprocessor(Preprocessor &PP) final {
+    std::unique_ptr<PPCallbacks> CB = Create(PP);
+    assert(CB);
+    PP.addPPCallbacks(std::move(CB));
+  }
+};
+
+struct IncludeTreePPCallbacks : public PPCallbacks {
+  DependencyActionController &Controller;
+  Preprocessor &PP;
+
+public:
+  IncludeTreePPCallbacks(DependencyActionController &Controller,
+                         Preprocessor &PP)
+      : Controller(Controller), PP(PP) {}
+
+  void LexedFileChanged(FileID FID, LexedFileChangeReason Reason,
+                        SrcMgr::CharacteristicKind FileType, FileID PrevFID,
+                        SourceLocation Loc) override {
+    switch (Reason) {
+    case LexedFileChangeReason::EnterFile:
+      Controller.enteredInclude(PP, FID);
+      break;
+    case LexedFileChangeReason::ExitFile: {
+      Controller.exitedInclude(PP, FID, PrevFID, Loc);
+      break;
+    }
+    }
+  }
+
+  void HasInclude(SourceLocation Loc, StringRef FileName, bool IsAngled,
+                  OptionalFileEntryRef File,
+                  SrcMgr::CharacteristicKind FileType) override {
+    Controller.handleHasIncludeCheck(PP, File.has_value());
+  }
+};
+} // namespace
+
+/// The PCH recorded file paths with canonical paths, create a VFS that
+/// allows remapping back to the non-canonical source paths so that they are
+/// found during dep-scanning.
+void dependencies::addReversePrefixMappingFileSystem(
+    const llvm::PrefixMapper &PrefixMapper, CompilerInstance &ScanInstance) {
+  llvm::PrefixMapper ReverseMapper;
+  ReverseMapper.addInverseRange(PrefixMapper.getMappings());
+  ReverseMapper.sort();
+  std::unique_ptr<llvm::vfs::FileSystem> FS =
+      llvm::vfs::createPrefixMappingFileSystem(
+          std::move(ReverseMapper), &ScanInstance.getVirtualFileSystem());
+
+  ScanInstance.getFileManager().setVirtualFileSystem(std::move(FS));
+}
+
+Error IncludeTreeActionController::initialize(
+    CompilerInstance &ScanInstance, CompilerInvocation &NewInvocation) {
+  if (Error E =
+          PrefixMapping.configurePrefixMapper(NewInvocation, PrefixMapper))
+    return E;
+
+  auto ensurePathRemapping = [&]() {
+    if (PrefixMapper.empty())
+      return;
+
+    PreprocessorOptions &PPOpts = ScanInstance.getPreprocessorOpts();
+    if (PPOpts.Includes.empty() && PPOpts.ImplicitPCHInclude.empty())
+      return;
+
+    addReversePrefixMappingFileSystem(PrefixMapper, ScanInstance);
+
+    // These are written in the predefines buffer, so we need to remap them.
+    for (std::string &Include : PPOpts.Includes)
+      PrefixMapper.mapInPlace(Include);
+  };
+  ensurePathRemapping();
+
+  // Attach callbacks for the IncludeTree of the TU. The preprocessor
+  // does not exist yet, so we need to indirect this via DependencyCollector.
+  auto DC = std::make_shared<PPCallbacksDependencyCollector>(
+      [this](Preprocessor &PP) {
+        return std::make_unique<IncludeTreePPCallbacks>(*this, PP);
+      });
+  ScanInstance.addDependencyCollector(std::move(DC));
+
+  return Error::success();
+}
+
+void IncludeTreeActionController::enteredInclude(Preprocessor &PP, FileID FID) {
+  if (hasErrorOccurred())
+    return;
+
+  if (!StartedEnteringIncludes) {
+    StartedEnteringIncludes = true;
+
+    // Get the included files (coming from a PCH), and keep track of the
+    // filenames that were recorded in the PCH.
+    for (const FileEntry *FE : PP.getIncludedFiles()) {
+      unsigned UID = FE->getUID();
+      if (UID >= PreIncludedFileNames.size())
+        PreIncludedFileNames.resize(UID + 1);
+      PreIncludedFileNames[UID] = FE->getName();
+    }
+  }
+
+  std::optional<cas::ObjectRef> FileRef = check(getObjectForFile(PP, FID));
+  if (!FileRef)
+    return;
+  const SrcMgr::FileInfo &FI =
+      PP.getSourceManager().getSLocEntry(FID).getFile();
+  IncludeStack.push_back({FI.getFileCharacteristic(), *FileRef, {}, {}});
+}
+
+void IncludeTreeActionController::exitedInclude(Preprocessor &PP,
+                                                FileID IncludedBy,
+                                                FileID Include,
+                                                SourceLocation ExitLoc) {
+  if (hasErrorOccurred())
+    return;
+
+  assert(*check(getObjectForFile(PP, Include)) == IncludeStack.back().File);
+  std::optional<cas::IncludeTree> IncludeTree =
+      check(getCASTreeForFileIncludes(IncludeStack.pop_back_val()));
+  if (!IncludeTree)
+    return;
+  assert(*check(getObjectForFile(PP, IncludedBy)) == IncludeStack.back().File);
+  SourceManager &SM = PP.getSourceManager();
+  std::pair<FileID, unsigned> LocInfo = SM.getDecomposedExpansionLoc(ExitLoc);
+  IncludeStack.back().Includes.push_back(
+      {IncludeTree->getRef(), LocInfo.second});
+}
+
+void IncludeTreeActionController::handleHasIncludeCheck(Preprocessor &PP,
+                                                        bool Result) {
+  if (hasErrorOccurred())
+    return;
+
+  IncludeStack.back().HasIncludeChecks.push_back(Result);
+}
+
+Error IncludeTreeActionController::finalize(CompilerInstance &ScanInstance,
+                                            CompilerInvocation &NewInvocation) {
+  FileManager &FM = ScanInstance.getFileManager();
+
+  auto addFile = [&](StringRef FilePath,
+                     bool IgnoreFileError = false) -> Error {
+    llvm::ErrorOr<const FileEntry *> FE = FM.getFile(FilePath);
+    if (!FE) {
+      if (IgnoreFileError)
+        return Error::success();
+      return llvm::errorCodeToError(FE.getError());
+    }
+    std::optional<cas::ObjectRef> Ref;
+    return addToFileList(FM, *FE).moveInto(Ref);
+  };
+
+  for (StringRef FilePath : NewInvocation.getLangOpts()->NoSanitizeFiles) {
+    if (Error E = addFile(FilePath))
+      return E;
+  }
+  // Add profile files.
+  // FIXME: Do not have the logic here to determine which path should be set
+  // but ideally only the path needed for the compilation is set and we already
+  // checked the file needed exists. Just try load and ignore errors.
+  if (Error E = addFile(NewInvocation.getCodeGenOpts().ProfileInstrumentUsePath,
+                        /*IgnoreFileError=*/true))
+    return E;
+  if (Error E = addFile(NewInvocation.getCodeGenOpts().SampleProfileFile,
+                        /*IgnoreFileError=*/true))
+    return E;
+  if (Error E = addFile(NewInvocation.getCodeGenOpts().ProfileRemappingFile,
+                        /*IgnoreFileError=*/true))
+    return E;
+
+  StringRef Sysroot = NewInvocation.getHeaderSearchOpts().Sysroot;
+  if (!Sysroot.empty()) {
+    // Include 'SDKSettings.json', if it exists, to accomodate availability
+    // checks during the compilation.
+    llvm::SmallString<256> FilePath = Sysroot;
+    llvm::sys::path::append(FilePath, "SDKSettings.json");
+    if (Error E = addFile(FilePath, /*IgnoreFileError*/ true))
+      return E;
+  }
+
+  auto FinishIncludeTree = [&]() -> Error {
+    PreprocessorOptions &PPOpts = NewInvocation.getPreprocessorOpts();
+    if (PPOpts.ImplicitPCHInclude.empty())
+      return Error::success(); // no need for additional work.
+
+    // Go through all the recorded included files; we'll get additional files
+    // from the PCH that we need to include in the file list, in case they are
+    // referenced while replaying the include-tree.
+    SmallVector<const FileEntry *, 32> NotSeenIncludes;
+    for (const FileEntry *FE :
+         ScanInstance.getPreprocessor().getIncludedFiles()) {
+      if (FE->getUID() >= SeenIncludeFiles.size() ||
+          !SeenIncludeFiles[FE->getUID()])
+        NotSeenIncludes.push_back(FE);
+    }
+    // Sort so we can visit the files in deterministic order.
+    llvm::sort(NotSeenIncludes, [](const FileEntry *LHS, const FileEntry *RHS) {
+      return LHS->getUID() < RHS->getUID();
+    });
+
+    for (const FileEntry *FE : NotSeenIncludes) {
+      auto FileNode = addToFileList(FM, FE);
+      if (!FileNode)
+        return FileNode.takeError();
+    }
+
+    llvm::ErrorOr<std::optional<cas::ObjectRef>> CASContents =
+        FM.getObjectRefForFileContent(PPOpts.ImplicitPCHInclude);
+    if (!CASContents)
+      return llvm::errorCodeToError(CASContents.getError());
+    PCHRef = **CASContents;
+
+    return Error::success();
+  };
+
+  if (Error E = FinishIncludeTree())
+    return E;
+
+  auto IncludeTreeRoot = getIncludeTree();
+  if (!IncludeTreeRoot)
+    return IncludeTreeRoot.takeError();
+
+  // FIXME: use configureInvocationForCaching
+  NewInvocation.getFrontendOpts().CASIncludeTreeID =
+      IncludeTreeRoot->getID().toString();
+
+  return Error::success();
+}
+
+Expected<cas::ObjectRef>
+IncludeTreeActionController::getObjectForFile(Preprocessor &PP, FileID FID) {
+  SourceManager &SM = PP.getSourceManager();
+  const SrcMgr::FileInfo &FI = SM.getSLocEntry(FID).getFile();
+  if (PP.getPredefinesFileID() == FID) {
+    if (!PredefinesBufferRef) {
+      auto Ref = getObjectForBuffer(FI);
+      if (!Ref)
+        return Ref.takeError();
+      PredefinesBufferRef = *Ref;
+    }
+    return *PredefinesBufferRef;
+  }
+  assert(FI.getContentCache().OrigEntry);
+  auto &FileRef = ObjectForFile[FI.getContentCache().OrigEntry];
+  if (!FileRef) {
+    auto Ref = getObjectForFileNonCached(SM.getFileManager(), FI);
+    if (!Ref)
+      return Ref.takeError();
+    FileRef = *Ref;
+  }
+  return *FileRef;
+}
+
+Expected<cas::ObjectRef> IncludeTreeActionController::getObjectForFileNonCached(
+    FileManager &FM, const SrcMgr::FileInfo &FI) {
+  const FileEntry *FE = FI.getContentCache().OrigEntry;
+  assert(FE);
+
+  // Mark the include as already seen.
+  if (FE->getUID() >= SeenIncludeFiles.size())
+    SeenIncludeFiles.resize(FE->getUID() + 1);
+  SeenIncludeFiles.set(FE->getUID());
+
+  return addToFileList(FM, FE);
+}
+
+Expected<cas::ObjectRef>
+IncludeTreeActionController::getObjectForBuffer(const SrcMgr::FileInfo &FI) {
+  // This is a non-file buffer, like the predefines.
+  auto Ref = DB.storeFromString(
+      {}, FI.getContentCache().getBufferIfLoaded()->getBuffer());
+  if (!Ref)
+    return Ref.takeError();
+  Expected<cas::IncludeFile> FileNode = createIncludeFile(FI.getName(), *Ref);
+  if (!FileNode)
+    return FileNode.takeError();
+  return FileNode->getRef();
+}
+
+Expected<cas::ObjectRef>
+IncludeTreeActionController::addToFileList(FileManager &FM,
+                                           const FileEntry *FE) {
+  StringRef Filename = FE->getName();
+  llvm::ErrorOr<std::optional<cas::ObjectRef>> CASContents =
+      FM.getObjectRefForFileContent(Filename);
+  if (!CASContents)
+    return llvm::errorCodeToError(CASContents.getError());
+  assert(*CASContents);
+
+  auto addFile = [&](StringRef Filename) -> Expected<cas::ObjectRef> {
+    assert(!Filename.empty());
+    auto FileNode = createIncludeFile(Filename, **CASContents);
+    if (!FileNode)
+      return FileNode.takeError();
+    IncludedFiles.push_back(
+        {FileNode->getRef(),
+         static_cast<cas::IncludeFileList::FileSizeTy>(FE->getSize())});
+    return FileNode->getRef();
+  };
+
+  // Check whether another path coming from the PCH is associated with the same
+  // file.
+  unsigned UID = FE->getUID();
+  if (UID < PreIncludedFileNames.size() && !PreIncludedFileNames[UID].empty() &&
+      PreIncludedFileNames[UID] != Filename) {
+    auto FileNode = addFile(PreIncludedFileNames[UID]);
+    if (!FileNode)
+      return FileNode.takeError();
+  }
+
+  return addFile(Filename);
+}
+
+Expected<cas::IncludeTree>
+IncludeTreeActionController::getCASTreeForFileIncludes(FilePPState &&PPState) {
+  return cas::IncludeTree::create(DB, PPState.FileCharacteristic, PPState.File,
+                                  PPState.Includes, PPState.HasIncludeChecks);
+}
+
+Expected<cas::IncludeFile>
+IncludeTreeActionController::createIncludeFile(StringRef Filename,
+                                               cas::ObjectRef Contents) {
+  SmallString<256> MappedPath;
+  if (!PrefixMapper.empty()) {
+    PrefixMapper.map(Filename, MappedPath);
+    Filename = MappedPath;
+  }
+  return cas::IncludeFile::create(DB, Filename, std::move(Contents));
+}
+
+Expected<cas::IncludeTreeRoot> IncludeTreeActionController::getIncludeTree() {
+  if (ErrorToReport)
+    return std::move(*ErrorToReport);
+
+  assert(IncludeStack.size() == 1);
+  Expected<cas::IncludeTree> MainIncludeTree =
+      getCASTreeForFileIncludes(IncludeStack.pop_back_val());
+  if (!MainIncludeTree)
+    return MainIncludeTree.takeError();
+  auto FileList = cas::IncludeFileList::create(DB, IncludedFiles);
+  if (!FileList)
+    return FileList.takeError();
+
+  return cas::IncludeTreeRoot::create(DB, MainIncludeTree->getRef(),
+                                      FileList->getRef(), PCHRef);
+}
+
+std::unique_ptr<DependencyActionController>
+dependencies::createIncludeTreeActionController(
+    cas::ObjectStore &DB, DepscanPrefixMapping PrefixMapping) {
+  return std::make_unique<IncludeTreeActionController>(
+      DB, std::move(PrefixMapping));
+}


### PR DESCRIPTION
This hoists most of the include-tree specific code out of the core dependency scanner, and instead injects the necessary `PPCallbacks` as part `IncludeTreeActionController::initialize`. In addition to improved division of responsibility in the code, this allows include-tree to be used with `ModuleDepCollector`, which will (in future commits) allow us to use include-tree to build and import modules.

Move the `IncludeTreeActionController` and `CASFSActionController` into their own files.

Note: the first commit is the interesting change; splitting the files is mostly mechanical.