### PR TITLE
[clang][cas] Enable "full" dependencies output with include-tree

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
@@ -52,6 +52,9 @@ enum class ScanningOutputFormat {
   /// This emits the CAS ID of the include tree.
   IncludeTree,
 
+  /// This emits the full dependency graph but with include tree.
+  FullIncludeTree,
+
   /// This outputs the dependency graph for standard c++ modules in P1689R5
   /// format.
   P1689,
@@ -63,6 +66,7 @@ class DependencyScanningService {
 public:
   DependencyScanningService(
       ScanningMode Mode, ScanningOutputFormat Format, CASOptions CASOpts,
+      std::shared_ptr<llvm::cas::ObjectStore> CAS,
       std::shared_ptr<llvm::cas::ActionCache> Cache,
       IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> SharedFS,
       bool OptimizeArgs = false, bool EagerLoadModules = false,
@@ -83,21 +87,21 @@ public:
   }
 
   const CASOptions &getCASOpts() const { return CASOpts; }
-  llvm::cas::ActionCache &getCache() const {
-    assert(Cache && "Cache is not initialized");
-    return *Cache;
-  }
+
+  std::shared_ptr<llvm::cas::ObjectStore> getCAS() const { return CAS; }
+  std::shared_ptr<llvm::cas::ActionCache> getCache() const { return Cache; }
 
   bool overrideCASTokenCache() const { return OverrideCASTokenCache; }
 
   llvm::cas::CachingOnDiskFileSystem &getSharedFS() { return *SharedFS; }
 
-  bool useCASScanning() const { return (bool)SharedFS; }
+  bool useCASFS() const { return (bool)SharedFS; }
 
 private:
   const ScanningMode Mode;
   const ScanningOutputFormat Format;
   CASOptions CASOpts;
+  std::shared_ptr<llvm::cas::ObjectStore> CAS;
   std::shared_ptr<llvm::cas::ActionCache> Cache;
   /// Whether to optimize the modules' command-line arguments.
   const bool OptimizeArgs;

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -161,8 +161,8 @@ public:
   ScanningOutputFormat getScanningFormat() const { return Format; }
 
   CachingOnDiskFileSystemPtr getCASFS() { return CacheFS; }
-  bool useCAS() const { return UseCAS; }
   const CASOptions &getCASOpts() const { return CASOpts; }
+  std::shared_ptr<cas::ObjectStore> getCAS() const { return CAS; }
 
   /// If \p DependencyScanningService enabled sharing of \p FileManager this
   /// will return the same instance, otherwise it will create a new one for
@@ -192,7 +192,7 @@ private:
   /// The CAS Dependency Filesytem. This is not set at the sametime as DepFS;
   llvm::IntrusiveRefCntPtr<DependencyScanningCASFilesystem> DepCASFS;
   CASOptions CASOpts;
-  bool UseCAS;
+  std::shared_ptr<cas::ObjectStore> CAS;
   bool OverrideCASTokenCache;
 };
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
@@ -18,10 +18,11 @@ using namespace dependencies;
 
 DependencyScanningService::DependencyScanningService(
     ScanningMode Mode, ScanningOutputFormat Format, CASOptions CASOpts,
+    std::shared_ptr<llvm::cas::ObjectStore> CAS,
     std::shared_ptr<llvm::cas::ActionCache> Cache,
     IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> SharedFS,
     bool OptimizeArgs, bool EagerLoadModules, bool OverrideCASTokenCache)
-    : Mode(Mode), Format(Format), CASOpts(std::move(CASOpts)), Cache(Cache),
+    : Mode(Mode), Format(Format), CASOpts(std::move(CASOpts)), CAS(std::move(CAS)), Cache(std::move(Cache)),
       OptimizeArgs(OptimizeArgs), EagerLoadModules(EagerLoadModules),
       OverrideCASTokenCache(OverrideCASTokenCache),
       SharedFS(std::move(SharedFS)) {

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -347,6 +347,8 @@ DependencyScanningTool::createActionController(
     DependencyScanningWorker &Worker,
     LookupModuleOutputCallback LookupModuleOutput,
     DepscanPrefixMapping PrefixMapping) {
+  if (Worker.getScanningFormat() == ScanningOutputFormat::FullIncludeTree)
+    return createIncludeTreeActionController(*Worker.getCAS(), std::move(PrefixMapping));
   if (auto CacheFS = Worker.getCASFS())
     return createCASFSActionController(LookupModuleOutput, *CacheFS,
                                        std::move(PrefixMapping));

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -420,6 +420,7 @@ public:
     case ScanningOutputFormat::P1689:
     case ScanningOutputFormat::Full:
     case ScanningOutputFormat::FullTree:
+    case ScanningOutputFormat::FullIncludeTree:
       if (EmitDependencyFile) {
         auto DFG =
             std::make_shared<ReversePrefixMappingDependencyFileGenerator>(
@@ -543,7 +544,7 @@ DependencyScanningWorker::DependencyScanningWorker(
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS)
     : Format(Service.getFormat()), OptimizeArgs(Service.canOptimizeArgs()),
       EagerLoadModules(Service.shouldEagerLoadModules()),
-      CASOpts(Service.getCASOpts()), UseCAS(Service.useCASScanning()),
+      CASOpts(Service.getCASOpts()), CAS(Service.getCAS()),
       OverrideCASTokenCache(Service.overrideCASTokenCache()) {
   PCHContainerOps = std::make_shared<PCHContainerOperations>();
   PCHContainerOps->registerReader(
@@ -553,9 +554,9 @@ DependencyScanningWorker::DependencyScanningWorker(
   PCHContainerOps->registerWriter(
       std::make_unique<ObjectFilePCHContainerWriter>());
 
-  if (Service.useCASScanning()) {
+  if (Service.useCASFS()) {
     CacheFS = Service.getSharedFS().createProxyFS();
-    DepCASFS = new DependencyScanningCASFilesystem(CacheFS, Service.getCache());
+    DepCASFS = new DependencyScanningCASFilesystem(CacheFS, *Service.getCache());
     BaseFS = DepCASFS;
     return;
   }

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -76,6 +76,7 @@ private:
   }
 
   cas::ObjectStore &DB;
+  CASOptions CASOpts;
   DepscanPrefixMapping PrefixMapping;
   llvm::PrefixMapper PrefixMapper;
   std::optional<cas::ObjectRef> PCHRef;
@@ -181,6 +182,8 @@ Error IncludeTreeActionController::initialize(
         return std::make_unique<IncludeTreePPCallbacks>(*this, PP);
       });
   ScanInstance.addDependencyCollector(std::move(DC));
+
+  CASOpts = ScanInstance.getCASOpts();
 
   return Error::success();
 }
@@ -323,9 +326,12 @@ Error IncludeTreeActionController::finalize(CompilerInstance &ScanInstance,
   if (!IncludeTreeRoot)
     return IncludeTreeRoot.takeError();
 
-  // FIXME: use configureInvocationForCaching
-  NewInvocation.getFrontendOpts().CASIncludeTreeID =
-      IncludeTreeRoot->getID().toString();
+  configureInvocationForCaching(NewInvocation, CASOpts,
+                                IncludeTreeRoot->getID().toString(),
+                                /*CASFSWorkingDir=*/"",
+                                /*ProduceIncludeTree=*/true);
+
+  DepscanPrefixMapping::remapInvocationPaths(NewInvocation, PrefixMapper);
 
   return Error::success();
 }

--- a/clang/test/ClangScanDeps/include-tree-prefix-mapping.c
+++ b/clang/test/ClangScanDeps/include-tree-prefix-mapping.c
@@ -2,7 +2,7 @@
 // RUN: split-file %s %t
 // RUN: sed -e "s|DIR|%t|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb.json.template > %t/cdb.json
 
-// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-include-tree -in-memory-cas \
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-include-tree -cas-path %t/cas \
 // RUN:   -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc > %t/result.txt
 // RUN: FileCheck %s -input-file %t/result.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK
 
@@ -13,6 +13,59 @@
 // CHECK: /^src{{[/\\]}}top.h
 // CHECK: /^tc{{[/\\]}}lib{{[/\\]}}clang{{[/\\]}}{{.*}}{{[/\\]}}include{{[/\\]}}stdarg.h
 // CHECK: /^sdk{{[/\\]}}usr{{[/\\]}}include{{[/\\]}}stdlib.h
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -format experimental-include-tree-full -cas-path %t/cas \
+// RUN:   -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc > %t/deps.json
+
+// RUN: cat %t/result.txt > %t/full.txt
+// RUN: echo "FULL DEPS START" >> %t/full.txt
+// RUN: cat %t/deps.json | sed 's:\\\\\?:/:g' >> %t/full.txt
+
+// RUN: FileCheck %s -DPREFIX=%/t -DSDK_PREFIX=%S/Inputs/SDK -check-prefix=FULL -input-file %t/full.txt
+
+// Capture the tree id from experimental-include-tree ; ensure that it matches
+// the result from experimental-full.
+// FULL: [[TREE_ID:llvmcas://[[:xdigit:]]+]] - [[PREFIX]]/t.c
+// FULL: FULL DEPS START
+
+// FULL-NEXT: {
+// FULL-NEXT:   "modules": []
+// FULL-NEXT:   "translation-units": [
+// FULL-NEXT:     {
+// FULL-NEXT:       "commands": [
+// FULL-NEXT:         {
+// FULL:                "clang-module-deps": []
+// FULL:                "command-line": [
+// FULL-NEXT:             "-cc1"
+// FULL:                  "-fcas-path"
+// FULL-NEXT:             "[[PREFIX]]/cas"
+// FULL:                  "-disable-free"
+// FULL:                  "-fcas-include-tree"
+// FULL-NEXT:             "[[TREE_ID]]"
+// FULL:                  "-fcache-compile-job"
+// FULL:                  "-fsyntax-only"
+// FULL:                  "-x"
+// FULL-NEXT:             "c"
+// FULL:                  "-isysroot"
+// FULL-NEXT:             "/^sdk"
+// FULL:                ]
+// FULL:                "file-deps": [
+// FULL-DAG:              "[[PREFIX]]/t.c"
+// FULL-DAG:              "[[PREFIX]]/top.h"
+// FULL-DAG:              "{{.*}}/stdarg.h"
+// FULL-DAG:              "[[SDK_PREFIX]]/usr/include/stdlib.h"
+// FULL:                ]
+// FULL:                "input-file": "[[PREFIX]]/t.c"
+// FULL:              }
+// FULL:            ]
+// FULL:          }
+// FULL:        ]
+// FULL:      }
+
+// Build the include-tree command
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: %clang @%t/tu.rsp
 
 //--- cdb.json.template
 [

--- a/clang/test/ClangScanDeps/include-tree-with-pch.c
+++ b/clang/test/ClangScanDeps/include-tree-with-pch.c
@@ -20,6 +20,59 @@
 // CHECK-NEXT: [[PREFIX]]/n3.h
 // CHECK-NOT: [[PREFIX]]
 
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-include-tree-full -cas-path %t/cas > %t/deps.json
+
+// RUN: cat %t/result.txt > %t/full.txt
+// RUN: echo "FULL DEPS START" >> %t/full.txt
+// RUN: cat %t/deps.json | sed 's:\\\\\?:/:g' >> %t/full.txt
+
+// RUN: FileCheck %s -DPREFIX=%/t -check-prefix=FULL -input-file %t/full.txt
+
+// Capture the tree id from experimental-include-tree ; ensure that it matches
+// the result from experimental-full.
+// FULL: [[TREE_ID:llvmcas://[[:xdigit:]]+]] - [[PREFIX]]/t.c
+// FULL: FULL DEPS START
+
+// FULL-NEXT: {
+// FULL-NEXT:   "modules": []
+// FULL-NEXT:   "translation-units": [
+// FULL-NEXT:     {
+// FULL-NEXT:       "commands": [
+// FULL-NEXT:         {
+// FULL:                "clang-module-deps": []
+// FULL:                "command-line": [
+// FULL-NEXT:             "-cc1"
+// FULL:                  "-fcas-path"
+// FULL-NEXT:             "[[PREFIX]]/cas"
+// FULL:                  "-disable-free"
+// FULL:                  "-fcas-include-tree"
+// FULL-NEXT:             "[[TREE_ID]]"
+// FULL:                  "-fcache-compile-job"
+// FULL:                  "-fsyntax-only"
+// FULL:                  "-x"
+// FULL-NEXT:             "c"
+// FULL-NOT:              "t.c"
+// FULL:                  "-main-file-name"
+// FULL-NEXT:             "t.c"
+// FULL-NOT:              "t.c"
+// FULL:                ]
+// FULL:                "executable": "clang"
+// FULL:                "file-deps": [
+// FULL-NEXT:             "[[PREFIX]]/t.c"
+// FULL-NEXT:             "[[PREFIX]]/t.h"
+// FULL-NEXT:             "[[PREFIX]]/prefix.pch"
+// FULL-NEXT:           ]
+// FULL:                "input-file": "[[PREFIX]]/t.c"
+// FULL:              }
+// FULL:            ]
+// FULL:          }
+// FULL:        ]
+// FULL:      }
+
+// Build the include-tree command
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: %clang @%t/tu.rsp
+
 //--- prefix.h
 #include "n1.h"
 #import "n2.h"

--- a/clang/test/ClangScanDeps/include-tree.c
+++ b/clang/test/ClangScanDeps/include-tree.c
@@ -28,6 +28,63 @@
 // ORDER-NEXT: [[PREFIX]]/n3.h
 // ORDER-NOT: [[PREFIX]]
 
+// Full dependency output
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-include-tree-full -cas-path %t/cas > %t/deps.json
+
+// RUN: cat %t/result1.txt > %t/full.txt
+// RUN: echo "FULL DEPS START" >> %t/full.txt
+// RUN: cat %t/deps.json | sed 's:\\\\\?:/:g' >> %t/full.txt
+
+// RUN: FileCheck %s -DPREFIX=%/t -check-prefix=FULL -input-file %t/full.txt
+
+// Capture the tree id from experimental-include-tree ; ensure that it matches
+// the result from experimental-full.
+// FULL: [[TREE_ID:llvmcas://[[:xdigit:]]+]] - [[PREFIX]]/t.c
+// FULL: FULL DEPS START
+
+// FULL-NEXT: {
+// FULL-NEXT:   "modules": []
+// FULL-NEXT:   "translation-units": [
+// FULL-NEXT:     {
+// FULL-NEXT:       "commands": [
+// FULL-NEXT:         {
+// FULL:                "clang-module-deps": []
+// FULL:                "command-line": [
+// FULL-NEXT:             "-cc1"
+// FULL:                  "-fcas-path"
+// FULL-NEXT:             "[[PREFIX]]/cas"
+// FULL:                  "-disable-free"
+// FULL:                  "-fcas-include-tree"
+// FULL-NEXT:             "[[TREE_ID]]"
+// FULL:                  "-fcache-compile-job"
+// FULL:                  "-fsyntax-only"
+// FULL:                  "-x"
+// FULL-NEXT:             "c"
+// FULL-NOT:              "t.c"
+// FULL:                  "-main-file-name"
+// FULL-NEXT:             "t.c"
+// FULL-NOT:              "t.c"
+// FULL:                ]
+// FULL:                "executable": "clang"
+// FULL:                "file-deps": [
+// FULL-NEXT:             "[[PREFIX]]/t.c"
+// FULL-NEXT:             "[[PREFIX]]/top.h"
+// FULL-NEXT:             "[[PREFIX]]/n1.h"
+// FULL-NEXT:             "[[PREFIX]]/n2.h"
+// FULL-NEXT:             "[[PREFIX]]/n3.h"
+// FULL-NEXT:             "[[PREFIX]]/n3.h"
+// FULL-NEXT:             "[[PREFIX]]/n2.h"
+// FULL-NEXT:           ]
+// FULL:                "input-file": "[[PREFIX]]/t.c"
+// FULL:              }
+// FULL:            ]
+// FULL:          }
+// FULL:        ]
+// FULL:      }
+
+// Build the include-tree command
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: %clang @%t/tu.rsp
 
 //--- cdb.json.template
 [

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -880,7 +880,7 @@ int ScanServer::listen() {
       ProduceIncludeTree
           ? tooling::dependencies::ScanningOutputFormat::IncludeTree
           : tooling::dependencies::ScanningOutputFormat::Tree,
-      CASOpts, Cache, FS,
+      CASOpts, CAS, Cache, FS,
       /*ReuseFileManager=*/false,
       /*SkipExcludedPPRanges=*/true);
 
@@ -1111,7 +1111,7 @@ static Expected<llvm::cas::CASID> scanAndUpdateCC1Inline(
       ProduceIncludeTree
           ? tooling::dependencies::ScanningOutputFormat::IncludeTree
           : tooling::dependencies::ScanningOutputFormat::Tree,
-      CASOpts, Cache, FS,
+      CASOpts, DB, Cache, FS,
       /*ReuseFileManager=*/false,
       /*SkipExcludedPPRanges=*/true);
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> UnderlyingFS =

--- a/clang/unittests/CAS/IncludeTreeTest.cpp
+++ b/clang/unittests/CAS/IncludeTreeTest.cpp
@@ -40,7 +40,7 @@ TEST(IncludeTree, IncludeTreeScan) {
 
   DependencyScanningService Service(ScanningMode::DependencyDirectivesScan,
                                     ScanningOutputFormat::IncludeTree,
-                                    CASOptions(), nullptr, nullptr);
+                                    CASOptions(), nullptr, nullptr, nullptr);
   DependencyScanningTool ScanTool(Service, std::move(VFS));
 
   std::vector<std::string> CommandLine = {"clang",

--- a/clang/unittests/Tooling/DependencyScannerTest.cpp
+++ b/clang/unittests/Tooling/DependencyScannerTest.cpp
@@ -233,7 +233,7 @@ TEST(DependencyScanner, ScanDepsWithFS) {
 
   DependencyScanningService Service(ScanningMode::DependencyDirectivesScan,
                                     ScanningOutputFormat::Make, CASOptions(),
-                                    nullptr, nullptr);
+                                    nullptr, nullptr, nullptr);
   DependencyScanningTool ScanTool(Service, VFS);
 
   std::string DepFile;
@@ -256,7 +256,7 @@ TEST(DependencyScanner, DepScanFSWithCASProvider) {
 
   DependencyScanningService Service(ScanningMode::DependencyDirectivesScan,
                                     ScanningOutputFormat::Make, CASOptions(),
-                                    nullptr, nullptr);
+                                    nullptr, nullptr, nullptr);
   {
     DependencyScanningWorkerFilesystem DepFS(Service.getSharedCache(),
                                              std::move(CASFS));


### PR DESCRIPTION
This allows getting full dependencies output with include-tree enabled for caching, similar to what we already do for cas-fs.

note: depends on ~https://github.com/apple/llvm-project/pull/6465~