### PR TITLE
[clang][cas] Cherry-pick include-tree support for full dependencies and libclang

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
@@ -51,6 +51,9 @@ enum class ScanningOutputFormat {
 
   /// This emits the CAS ID of the include tree.
   IncludeTree,
+
+  /// This emits the full dependency graph but with include tree.
+  FullIncludeTree,
 };
 
 /// The dependency scanning service contains shared configuration and state that
@@ -59,6 +62,7 @@ class DependencyScanningService {
 public:
   DependencyScanningService(
       ScanningMode Mode, ScanningOutputFormat Format, CASOptions CASOpts,
+      std::shared_ptr<llvm::cas::ObjectStore> CAS,
       std::shared_ptr<llvm::cas::ActionCache> Cache,
       IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> SharedFS,
       bool OptimizeArgs = false, bool EagerLoadModules = false);
@@ -78,19 +82,19 @@ public:
   }
 
   const CASOptions &getCASOpts() const { return CASOpts; }
-  llvm::cas::ActionCache &getCache() const {
-    assert(Cache && "Cache is not initialized");
-    return *Cache;
-  }
+
+  std::shared_ptr<llvm::cas::ObjectStore> getCAS() const { return CAS; }
+  std::shared_ptr<llvm::cas::ActionCache> getCache() const { return Cache; }
 
   llvm::cas::CachingOnDiskFileSystem &getSharedFS() { return *SharedFS; }
 
-  bool useCASScanning() const { return (bool)SharedFS; }
+  bool useCASFS() const { return (bool)SharedFS; }
 
 private:
   const ScanningMode Mode;
   const ScanningOutputFormat Format;
   CASOptions CASOpts;
+  std::shared_ptr<llvm::cas::ObjectStore> CAS;
   std::shared_ptr<llvm::cas::ActionCache> Cache;
   /// Whether to optimize the modules' command-line arguments.
   const bool OptimizeArgs;

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -265,30 +265,6 @@ private:
   LookupModuleOutputCallback LookupModuleOutput;
 };
 
-class CASFSActionController : public CallbackActionController {
-public:
-  CASFSActionController(LookupModuleOutputCallback LookupModuleOutput,
-                        llvm::cas::CachingOnDiskFileSystem &CacheFS,
-                        DepscanPrefixMapping PrefixMapping);
-
-  llvm::Error initialize(CompilerInstance &ScanInstance,
-                         CompilerInvocation &NewInvocation) override;
-  llvm::Error finalize(CompilerInstance &ScanInstance,
-                       CompilerInvocation &NewInvocation) override;
-  llvm::Error
-  initializeModuleBuild(CompilerInstance &ModuleScanInstance) override;
-  llvm::Error
-  finalizeModuleBuild(CompilerInstance &ModuleScanInstance) override;
-  llvm::Error finalizeModuleInvocation(CompilerInvocation &CI,
-                                       const ModuleDeps &MD) override;
-
-private:
-  llvm::cas::CachingOnDiskFileSystem &CacheFS;
-  DepscanPrefixMapping PrefixMapping;
-  std::optional<llvm::TreePathPrefixMapper> Mapper;
-  CASOptions CASOpts;
-};
-
 } // end namespace dependencies
 } // end namespace tooling
 } // end namespace clang

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -186,23 +186,8 @@ private:
 
 class FullDependencyConsumer : public DependencyConsumer {
 public:
-  FullDependencyConsumer(const llvm::StringSet<> &AlreadySeen,
-                         LookupModuleOutputCallback LookupModuleOutput,
-                         CachingOnDiskFileSystemPtr CacheFS = nullptr,
-                         DepscanPrefixMapping PrefixMapping = {})
-      : CacheFS(std::move(CacheFS)), PrefixMapping(std::move(PrefixMapping)),
-        AlreadySeen(AlreadySeen), LookupModuleOutput(LookupModuleOutput) {}
-
-  llvm::Error initialize(CompilerInstance &ScanInstance,
-                         CompilerInvocation &NewInvocation) override;
-  llvm::Error finalize(CompilerInstance &ScanInstance,
-                       CompilerInvocation &NewInvocation) override;
-  llvm::Error
-  initializeModuleBuild(CompilerInstance &ModuleScanInstance) override;
-  llvm::Error
-  finalizeModuleBuild(CompilerInstance &ModuleScanInstance) override;
-  llvm::Error finalizeModuleInvocation(CompilerInvocation &CI,
-                                       const ModuleDeps &MD) override;
+  FullDependencyConsumer(const llvm::StringSet<> &AlreadySeen)
+      : AlreadySeen(AlreadySeen) {}
 
   void handleBuildCommand(Command Cmd) override {
     Commands.push_back(std::move(Cmd));
@@ -226,17 +211,8 @@ public:
     ContextHash = std::move(Hash);
   }
 
-  void handleCASFileSystemRootID(cas::CASID ID) override {
-    CASFileSystemRootID = ID;
-  }
-
-  Optional<cas::CASID> getCASFileSystemRootID() const {
-    return CASFileSystemRootID;
-  }
-
-  std::string lookupModuleOutput(const ModuleID &ID,
-                                 ModuleOutputKind Kind) override {
-    return LookupModuleOutput(ID, Kind);
+  void handleCASFileSystemRootID(std::string ID) override {
+    CASFileSystemRootID = std::move(ID);
   }
 
   TranslationUnitDeps takeTranslationUnitDeps();
@@ -249,13 +225,33 @@ private:
       ClangModuleDeps;
   std::vector<Command> Commands;
   std::string ContextHash;
-  CachingOnDiskFileSystemPtr CacheFS;
-  DepscanPrefixMapping PrefixMapping;
-  std::optional<llvm::TreePathPrefixMapper> Mapper;
-  CASOptions CASOpts;
-  Optional<cas::CASID> CASFileSystemRootID;
+  Optional<std::string> CASFileSystemRootID;
   std::vector<std::string> OutputPaths;
   const llvm::StringSet<> &AlreadySeen;
+};
+
+/// A simple dependency action controller that uses a callback. If no callback
+/// is provided, it is assumed that looking up module outputs is unreachable.
+class CallbackActionController : public DependencyActionController {
+public:
+  virtual ~CallbackActionController();
+
+  CallbackActionController(LookupModuleOutputCallback LMO)
+      : LookupModuleOutput(std::move(LMO)) {
+    if (!LookupModuleOutput) {
+      LookupModuleOutput = [](const ModuleID &,
+                              ModuleOutputKind) -> std::string {
+        llvm::report_fatal_error("unexpected call to lookupModuleOutput");
+      };
+    }
+  }
+
+  std::string lookupModuleOutput(const ModuleID &ID,
+                                 ModuleOutputKind Kind) override {
+    return LookupModuleOutput(ID, Kind);
+  }
+
+private:
   LookupModuleOutputCallback LookupModuleOutput;
 };
 

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -156,8 +156,8 @@ public:
   ScanningOutputFormat getScanningFormat() const { return Format; }
 
   CachingOnDiskFileSystemPtr getCASFS() { return CacheFS; }
-  bool useCAS() const { return UseCAS; }
   const CASOptions &getCASOpts() const { return CASOpts; }
+  std::shared_ptr<cas::ObjectStore> getCAS() const { return CAS; }
 
   /// If \p DependencyScanningService enabled sharing of \p FileManager this
   /// will return the same instance, otherwise it will create a new one for
@@ -187,7 +187,7 @@ private:
   /// The CAS Dependency Filesytem. This is not set at the sametime as DepFS;
   llvm::IntrusiveRefCntPtr<DependencyScanningCASFilesystem> DepCASFS;
   CASOptions CASOpts;
-  bool UseCAS;
+  std::shared_ptr<cas::ObjectStore> CAS;
 };
 
 } // end namespace dependencies

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -59,6 +59,8 @@ public:
   virtual void handleContextHash(std::string Hash) = 0;
 
   virtual void handleCASFileSystemRootID(std::string ID) {}
+
+  virtual void handleIncludeTreeID(std::string ID) {}
 };
 
 /// Dependency scanner callbacks that are used during scanning to influence the

--- a/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
@@ -28,6 +28,7 @@ namespace clang {
 namespace tooling {
 namespace dependencies {
 
+class DependencyActionController;
 class DependencyConsumer;
 
 /// Modular dependency that has already been built prior to the dependency scan.
@@ -192,6 +193,7 @@ class ModuleDepCollector final : public DependencyCollector {
 public:
   ModuleDepCollector(std::unique_ptr<DependencyOutputOptions> Opts,
                      CompilerInstance &ScanInstance, DependencyConsumer &C,
+                     DependencyActionController &Controller,
                      CompilerInvocation OriginalCI, bool OptimizeArgs,
                      bool EagerLoadModules);
 
@@ -209,6 +211,8 @@ private:
   CompilerInstance &ScanInstance;
   /// The consumer of collected dependency information.
   DependencyConsumer &Consumer;
+  /// Callbacks for computing dependency information.
+  DependencyActionController &Controller;
   /// Path to the main source file.
   std::string MainFile;
   /// Hash identifying the compilation conditions of the current TU.

--- a/clang/lib/Tooling/DependencyScanning/CASFSActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/CASFSActionController.cpp
@@ -1,0 +1,204 @@
+//===- CASFSActionController.cpp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CachingActions.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Lex/Preprocessor.h"
+#include "llvm/CAS/CachingOnDiskFileSystem.h"
+#include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/PrefixMapper.h"
+
+using namespace clang;
+using namespace tooling;
+using namespace dependencies;
+using llvm::Error;
+
+namespace {
+class CASFSActionController : public CallbackActionController {
+public:
+  CASFSActionController(LookupModuleOutputCallback LookupModuleOutput,
+                        llvm::cas::CachingOnDiskFileSystem &CacheFS,
+                        DepscanPrefixMapping PrefixMapping);
+
+  llvm::Error initialize(CompilerInstance &ScanInstance,
+                         CompilerInvocation &NewInvocation) override;
+  llvm::Error finalize(CompilerInstance &ScanInstance,
+                       CompilerInvocation &NewInvocation) override;
+  llvm::Error
+  initializeModuleBuild(CompilerInstance &ModuleScanInstance) override;
+  llvm::Error
+  finalizeModuleBuild(CompilerInstance &ModuleScanInstance) override;
+  llvm::Error finalizeModuleInvocation(CompilerInvocation &CI,
+                                       const ModuleDeps &MD) override;
+
+private:
+  llvm::cas::CachingOnDiskFileSystem &CacheFS;
+  DepscanPrefixMapping PrefixMapping;
+  std::optional<llvm::TreePathPrefixMapper> Mapper;
+  CASOptions CASOpts;
+};
+} // anonymous namespace
+
+CASFSActionController::CASFSActionController(
+    LookupModuleOutputCallback LookupModuleOutput,
+    llvm::cas::CachingOnDiskFileSystem &CacheFS,
+    DepscanPrefixMapping PrefixMapping)
+    : CallbackActionController(std::move(LookupModuleOutput)), CacheFS(CacheFS),
+      PrefixMapping(std::move(PrefixMapping)) {}
+
+Error CASFSActionController::initialize(CompilerInstance &ScanInstance,
+                                        CompilerInvocation &NewInvocation) {
+  // Setup prefix mapping.
+  Mapper.emplace(&CacheFS);
+  if (Error E = PrefixMapping.configurePrefixMapper(NewInvocation, *Mapper))
+    return E;
+
+  const PreprocessorOptions &PPOpts = ScanInstance.getPreprocessorOpts();
+  if (!PPOpts.Includes.empty() || !PPOpts.ImplicitPCHInclude.empty())
+    addReversePrefixMappingFileSystem(*Mapper, ScanInstance);
+
+  CacheFS.trackNewAccesses();
+  if (auto CWD =
+          ScanInstance.getVirtualFileSystem().getCurrentWorkingDirectory())
+    CacheFS.setCurrentWorkingDirectory(*CWD);
+  // Track paths that are accessed by the scanner before we reach here.
+  for (const auto &File : ScanInstance.getHeaderSearchOpts().VFSOverlayFiles)
+    (void)CacheFS.status(File);
+  // Enable caching in the resulting commands.
+  ScanInstance.getFrontendOpts().CacheCompileJob = true;
+  CASOpts = ScanInstance.getCASOpts();
+  return Error::success();
+}
+
+/// Ensure that all files reachable from imported modules/pch are tracked.
+/// These could be loaded lazily during compilation.
+static void trackASTFileInputs(CompilerInstance &CI,
+                               llvm::cas::CachingOnDiskFileSystem &CacheFS) {
+  auto Reader = CI.getASTReader();
+  if (!Reader)
+    return;
+
+  for (serialization::ModuleFile &MF : Reader->getModuleManager()) {
+    Reader->visitInputFiles(
+        MF, /*IncludeSystem=*/true, /*Complain=*/false,
+        [](const serialization::InputFile &IF, bool isSystem) {
+          // Visiting input files triggers the file system lookup.
+        });
+  }
+}
+
+/// Ensure files that are not accessed during the scan (or accessed before the
+/// tracking scope) are tracked.
+static void trackFilesCommon(CompilerInstance &CI,
+                             llvm::cas::CachingOnDiskFileSystem &CacheFS) {
+  trackASTFileInputs(CI, CacheFS);
+
+  // Exclude the module cache from tracking. The implicit build pcms should
+  // not be needed after scanning.
+  if (!CI.getHeaderSearchOpts().ModuleCachePath.empty())
+    (void)CacheFS.excludeFromTracking(CI.getHeaderSearchOpts().ModuleCachePath);
+
+  // Normally this would be looked up while creating the VFS, but implicit
+  // modules share their VFS and it happens too early for the TU scan.
+  for (const auto &File : CI.getHeaderSearchOpts().VFSOverlayFiles)
+    (void)CacheFS.status(File);
+
+  StringRef Sysroot = CI.getHeaderSearchOpts().Sysroot;
+  if (!Sysroot.empty()) {
+    // Include 'SDKSettings.json', if it exists, to accomodate availability
+    // checks during the compilation.
+    llvm::SmallString<256> FilePath = Sysroot;
+    llvm::sys::path::append(FilePath, "SDKSettings.json");
+    (void)CacheFS.status(FilePath);
+  }
+}
+
+Error CASFSActionController::finalize(CompilerInstance &ScanInstance,
+                                      CompilerInvocation &NewInvocation) {
+  // Handle profile mappings.
+  (void)CacheFS.status(NewInvocation.getCodeGenOpts().ProfileInstrumentUsePath);
+  (void)CacheFS.status(NewInvocation.getCodeGenOpts().SampleProfileFile);
+  (void)CacheFS.status(NewInvocation.getCodeGenOpts().ProfileRemappingFile);
+
+  trackFilesCommon(ScanInstance, CacheFS);
+
+  auto CASFileSystemRootID = CacheFS.createTreeFromNewAccesses(
+      [&](const llvm::vfs::CachedDirectoryEntry &Entry,
+          SmallVectorImpl<char> &Storage) {
+        return Mapper->mapDirEntry(Entry, Storage);
+      });
+  if (!CASFileSystemRootID)
+    return CASFileSystemRootID.takeError();
+
+  configureInvocationForCaching(NewInvocation, CASOpts,
+                                CASFileSystemRootID->getID().toString(),
+                                CacheFS.getCurrentWorkingDirectory().get(),
+                                /*ProduceIncludeTree=*/false);
+
+  if (Mapper)
+    DepscanPrefixMapping::remapInvocationPaths(NewInvocation, *Mapper);
+
+  return Error::success();
+}
+
+Error CASFSActionController::initializeModuleBuild(
+    CompilerInstance &ModuleScanInstance) {
+
+  CacheFS.trackNewAccesses();
+  // If the working directory is not otherwise accessed by the module build,
+  // we still need it due to -fcas-fs-working-directory being set.
+  if (auto CWD = CacheFS.getCurrentWorkingDirectory())
+    (void)CacheFS.status(*CWD);
+
+  return Error::success();
+}
+
+Error CASFSActionController::finalizeModuleBuild(
+    CompilerInstance &ModuleScanInstance) {
+  trackFilesCommon(ModuleScanInstance, CacheFS);
+
+  Optional<cas::CASID> RootID;
+  auto E = CacheFS
+               .createTreeFromNewAccesses(
+                   [&](const llvm::vfs::CachedDirectoryEntry &Entry,
+                       SmallVectorImpl<char> &Storage) {
+                     return Mapper->mapDirEntry(Entry, Storage);
+                   })
+               .moveInto(RootID);
+  if (E)
+    return E;
+
+  Module *M = ModuleScanInstance.getPreprocessor().getCurrentModule();
+  assert(M && "finalizing without a module");
+
+  M->setCASFileSystemRootID(RootID->toString());
+  return Error::success();
+}
+
+Error CASFSActionController::finalizeModuleInvocation(CompilerInvocation &CI,
+                                                      const ModuleDeps &MD) {
+  if (auto ID = MD.CASFileSystemRootID) {
+    configureInvocationForCaching(CI, CASOpts, ID->toString(),
+                                  CacheFS.getCurrentWorkingDirectory().get(),
+                                  /*ProduceIncludeTree=*/false);
+  }
+
+  if (Mapper)
+    DepscanPrefixMapping::remapInvocationPaths(CI, *Mapper);
+
+  return llvm::Error::success();
+}
+
+std::unique_ptr<DependencyActionController>
+dependencies::createCASFSActionController(
+    LookupModuleOutputCallback LookupModuleOutput,
+    llvm::cas::CachingOnDiskFileSystem &CacheFS,
+    DepscanPrefixMapping PrefixMapping) {
+  return std::make_unique<CASFSActionController>(LookupModuleOutput, CacheFS,
+                                                 std::move(PrefixMapping));
+}

--- a/clang/lib/Tooling/DependencyScanning/CMakeLists.txt
+++ b/clang/lib/Tooling/DependencyScanning/CMakeLists.txt
@@ -7,11 +7,13 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_clang_library(clangDependencyScanning
+  CASFSActionController.cpp
   DependencyScanningCASFilesystem.cpp
   DependencyScanningFilesystem.cpp
   DependencyScanningService.cpp
   DependencyScanningWorker.cpp
   DependencyScanningTool.cpp
+  IncludeTreeActionController.cpp
   ModuleDepCollector.cpp
   ScanAndUpdateArgs.cpp
 

--- a/clang/lib/Tooling/DependencyScanning/CachingActions.h
+++ b/clang/lib/Tooling/DependencyScanning/CachingActions.h
@@ -1,0 +1,37 @@
+//===- CachingActions.h -----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLING_DEPENDENCYSCANNING_CACHINGACTIONS_H
+#define LLVM_CLANG_TOOLING_DEPENDENCYSCANNING_CACHINGACTIONS_H
+
+#include "clang/Tooling/DependencyScanning/DependencyScanningTool.h"
+#include "clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h"
+
+namespace llvm::cas {
+class CachingOnDiskFileSystem;
+}
+
+namespace clang::tooling::dependencies {
+
+std::unique_ptr<DependencyActionController>
+createIncludeTreeActionController(cas::ObjectStore &DB,
+                                  DepscanPrefixMapping PrefixMapping);
+
+std::unique_ptr<DependencyActionController>
+createCASFSActionController(LookupModuleOutputCallback LookupModuleOutput,
+                            llvm::cas::CachingOnDiskFileSystem &CacheFS,
+                            DepscanPrefixMapping PrefixMapping);
+
+/// The PCH recorded file paths with canonical paths, create a VFS that
+/// allows remapping back to the non-canonical source paths so that they are
+/// found during dep-scanning.
+void addReversePrefixMappingFileSystem(const llvm::PrefixMapper &PrefixMapper,
+                                       CompilerInstance &ScanInstance);
+
+} // namespace clang::tooling::dependencies
+#endif // LLVM_CLANG_TOOLING_DEPENDENCYSCANNING_CACHINGACTIONS_H

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
@@ -18,12 +18,12 @@ using namespace dependencies;
 
 DependencyScanningService::DependencyScanningService(
     ScanningMode Mode, ScanningOutputFormat Format, CASOptions CASOpts,
+    std::shared_ptr<llvm::cas::ObjectStore> CAS,
     std::shared_ptr<llvm::cas::ActionCache> Cache,
     IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> SharedFS,
     bool OptimizeArgs, bool EagerLoadModules)
-    : Mode(Mode), Format(Format), CASOpts(std::move(CASOpts)), Cache(Cache),
-      OptimizeArgs(OptimizeArgs), SharedFS(std::move(SharedFS)),
-      EagerLoadModules(EagerLoadModules) {
+    : Mode(Mode), Format(Format), CASOpts(std::move(CASOpts)), CAS(std::move(CAS)), Cache(std::move(Cache)),
+      OptimizeArgs(OptimizeArgs), SharedFS(std::move(SharedFS)), EagerLoadModules(EagerLoadModules) {
   if (!this->SharedFS)
     SharedCache.emplace();
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -292,6 +292,8 @@ DependencyScanningTool::createActionController(
     DependencyScanningWorker &Worker,
     LookupModuleOutputCallback LookupModuleOutput,
     DepscanPrefixMapping PrefixMapping) {
+  if (Worker.getScanningFormat() == ScanningOutputFormat::FullIncludeTree)
+    return createIncludeTreeActionController(*Worker.getCAS(), std::move(PrefixMapping));
   if (auto CacheFS = Worker.getCASFS())
     return createCASFSActionController(LookupModuleOutput, *CacheFS,
                                        std::move(PrefixMapping));

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -7,15 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/Tooling/DependencyScanning/DependencyScanningTool.h"
+#include "CachingActions.h"
 #include "clang/CAS/IncludeTree.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/Utils.h"
-#include "clang/Lex/Preprocessor.h"
 #include "clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h"
-#include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/CAS/ObjectStore.h"
-#include "llvm/Support/PrefixMapper.h"
-#include "llvm/Support/PrefixMappingFileSystem.h"
 
 using namespace clang;
 using namespace tooling;
@@ -133,6 +130,34 @@ private:
   llvm::cas::CachingOnDiskFileSystem &FS;
   Optional<std::string> CASFileSystemRootID;
 };
+
+/// Returns an IncludeTree containing the dependencies.
+class GetIncludeTree : public EmptyDependencyConsumer {
+public:
+  void handleIncludeTreeID(std::string ID) override { IncludeTreeID = ID; }
+
+  Expected<cas::IncludeTreeRoot> getIncludeTree() {
+    if (IncludeTreeID) {
+      auto ID = DB.parseID(*IncludeTreeID);
+      if (!ID)
+        return ID.takeError();
+      auto Ref = DB.getReference(*ID);
+      if (!Ref)
+        return llvm::createStringError(
+            llvm::inconvertibleErrorCode(),
+            llvm::Twine("missing expected include-tree ") + ID->toString());
+      return cas::IncludeTreeRoot::get(DB, *Ref);
+    }
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "failed to get include-tree");
+  }
+
+  GetIncludeTree(cas::ObjectStore &DB) : DB(DB) {}
+
+private:
+  cas::ObjectStore &DB;
+  std::optional<std::string> IncludeTreeID;
+};
 }
 
 llvm::Expected<llvm::cas::ObjectProxy>
@@ -140,10 +165,10 @@ DependencyScanningTool::getDependencyTree(
     const std::vector<std::string> &CommandLine, StringRef CWD,
     DepscanPrefixMapping PrefixMapping) {
   GetDependencyTree Consumer(*Worker.getCASFS());
-  CASFSActionController Controller(nullptr, *Worker.getCASFS(),
-                                   std::move(PrefixMapping));
+  auto Controller = createCASFSActionController(nullptr, *Worker.getCASFS(),
+                                                std::move(PrefixMapping));
   auto Result =
-      Worker.computeDependencies(CWD, CommandLine, Consumer, Controller);
+      Worker.computeDependencies(CWD, CommandLine, Consumer, *Controller);
   if (Result)
     return std::move(Result);
   return Consumer.getTree();
@@ -155,438 +180,25 @@ DependencyScanningTool::getDependencyTreeFromCompilerInvocation(
     DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
     bool DiagGenerationAsCompilation, DepscanPrefixMapping PrefixMapping) {
   GetDependencyTree Consumer(*Worker.getCASFS());
-  CASFSActionController Controller(nullptr, *Worker.getCASFS(),
-                                   std::move(PrefixMapping));
+  auto Controller = createCASFSActionController(nullptr, *Worker.getCASFS(),
+                                                std::move(PrefixMapping));
   Worker.computeDependenciesFromCompilerInvocation(
-      std::move(Invocation), CWD, Consumer, Controller, DiagsConsumer,
+      std::move(Invocation), CWD, Consumer, *Controller, DiagsConsumer,
       VerboseOS, DiagGenerationAsCompilation);
   return Consumer.getTree();
-}
-
-namespace {
-class IncludeTreeActionController : public CallbackActionController {
-public:
-  IncludeTreeActionController(cas::ObjectStore &DB,
-                              const DepscanPrefixMapping &PrefixMapping)
-      : CallbackActionController(nullptr), DB(DB),
-        PrefixMapping(PrefixMapping) {}
-
-  Expected<cas::IncludeTreeRoot> getIncludeTree();
-
-private:
-  Error initialize(CompilerInstance &ScanInstance,
-                   CompilerInvocation &NewInvocation) override;
-
-  void enteredInclude(Preprocessor &PP, FileID FID) override;
-
-  void exitedInclude(Preprocessor &PP, FileID IncludedBy, FileID Include,
-                     SourceLocation ExitLoc) override;
-
-  void handleHasIncludeCheck(Preprocessor &PP, bool Result) override;
-
-  const DepscanPrefixMapping *getPrefixMapping() override {
-    return &PrefixMapping;
-  }
-
-  Error finalize(CompilerInstance &ScanInstance,
-                 CompilerInvocation &NewInvocation) override;
-
-  Expected<cas::ObjectRef> getObjectForFile(Preprocessor &PP, FileID FID);
-  Expected<cas::ObjectRef>
-  getObjectForFileNonCached(FileManager &FM, const SrcMgr::FileInfo &FI);
-  Expected<cas::ObjectRef> getObjectForBuffer(const SrcMgr::FileInfo &FI);
-  Expected<cas::ObjectRef> addToFileList(FileManager &FM, const FileEntry *FE);
-
-  struct FilePPState {
-    SrcMgr::CharacteristicKind FileCharacteristic;
-    cas::ObjectRef File;
-    SmallVector<std::pair<cas::ObjectRef, uint32_t>, 6> Includes;
-    llvm::SmallBitVector HasIncludeChecks;
-  };
-
-  Expected<cas::IncludeTree> getCASTreeForFileIncludes(FilePPState &&PPState);
-
-  Expected<cas::IncludeFile> createIncludeFile(StringRef Filename,
-                                               cas::ObjectRef Contents);
-
-  bool hasErrorOccurred() const { return ErrorToReport.has_value(); }
-
-  template <typename T> Optional<T> check(Expected<T> &&E) {
-    if (!E) {
-      ErrorToReport = E.takeError();
-      return None;
-    }
-    return *E;
-  }
-
-  cas::ObjectStore &DB;
-  const DepscanPrefixMapping &PrefixMapping;
-  llvm::PrefixMapper PrefixMapper;
-  Optional<cas::ObjectRef> PCHRef;
-  bool StartedEnteringIncludes = false;
-  // When a PCH is used this lists the filenames of the included files as they
-  // are recorded in the PCH, ordered by \p FileEntry::UID index.
-  SmallVector<StringRef> PreIncludedFileNames;
-  llvm::BitVector SeenIncludeFiles;
-  SmallVector<cas::IncludeFileList::FileEntry> IncludedFiles;
-  Optional<cas::ObjectRef> PredefinesBufferRef;
-  SmallVector<FilePPState> IncludeStack;
-  llvm::DenseMap<const FileEntry *, Optional<cas::ObjectRef>> ObjectForFile;
-  Optional<llvm::Error> ErrorToReport;
-};
-
-/// A utility for adding \c PPCallbacks to a compiler instance at the
-/// appropriate time.
-struct PPCallbacksDependencyCollector : public DependencyCollector {
-  using MakeCB =
-      llvm::unique_function<std::unique_ptr<PPCallbacks>(Preprocessor &)>;
-  MakeCB Create;
-  PPCallbacksDependencyCollector(MakeCB Create) : Create(std::move(Create)) {}
-  void attachToPreprocessor(Preprocessor &PP) final {
-    std::unique_ptr<PPCallbacks> CB = Create(PP);
-    assert(CB);
-    PP.addPPCallbacks(std::move(CB));
-  }
-};
-
-struct IncludeTreePPCallbacks : public PPCallbacks {
-  DependencyActionController &Controller;
-  Preprocessor &PP;
-
-public:
-  IncludeTreePPCallbacks(DependencyActionController &Controller,
-                         Preprocessor &PP)
-      : Controller(Controller), PP(PP) {}
-
-  void LexedFileChanged(FileID FID, LexedFileChangeReason Reason,
-                        SrcMgr::CharacteristicKind FileType, FileID PrevFID,
-                        SourceLocation Loc) override {
-    switch (Reason) {
-    case LexedFileChangeReason::EnterFile:
-      Controller.enteredInclude(PP, FID);
-      break;
-    case LexedFileChangeReason::ExitFile: {
-      Controller.exitedInclude(PP, FID, PrevFID, Loc);
-      break;
-    }
-    }
-  }
-
-  void HasInclude(SourceLocation Loc, StringRef FileName, bool IsAngled,
-                  OptionalFileEntryRef File,
-                  SrcMgr::CharacteristicKind FileType) override {
-    Controller.handleHasIncludeCheck(PP, File.has_value());
-  }
-};
-} // namespace
-
-/// The PCH recorded file paths with canonical paths, create a VFS that
-/// allows remapping back to the non-canonical source paths so that they are
-/// found during dep-scanning.
-static void
-addReversePrefixMappingFileSystem(const llvm::PrefixMapper &PrefixMapper,
-                                  CompilerInstance &ScanInstance) {
-  llvm::PrefixMapper ReverseMapper;
-  ReverseMapper.addInverseRange(PrefixMapper.getMappings());
-  ReverseMapper.sort();
-  std::unique_ptr<llvm::vfs::FileSystem> FS =
-      llvm::vfs::createPrefixMappingFileSystem(
-          std::move(ReverseMapper), &ScanInstance.getVirtualFileSystem());
-
-  ScanInstance.getFileManager().setVirtualFileSystem(std::move(FS));
-}
-
-Error IncludeTreeActionController::initialize(
-    CompilerInstance &ScanInstance, CompilerInvocation &NewInvocation) {
-  if (Error E =
-          PrefixMapping.configurePrefixMapper(NewInvocation, PrefixMapper))
-    return E;
-
-  auto ensurePathRemapping = [&]() {
-    if (PrefixMapper.empty())
-      return;
-
-    PreprocessorOptions &PPOpts = ScanInstance.getPreprocessorOpts();
-    if (PPOpts.Includes.empty() && PPOpts.ImplicitPCHInclude.empty())
-      return;
-
-    addReversePrefixMappingFileSystem(PrefixMapper, ScanInstance);
-
-    // These are written in the predefines buffer, so we need to remap them.
-    for (std::string &Include : PPOpts.Includes)
-      PrefixMapper.mapInPlace(Include);
-  };
-  ensurePathRemapping();
-
-  // Attach callbacks for the IncludeTree of the TU. The preprocessor
-  // does not exist yet, so we need to indirect this via DependencyCollector.
-  auto DC = std::make_shared<PPCallbacksDependencyCollector>(
-      [this](Preprocessor &PP) {
-        return std::make_unique<IncludeTreePPCallbacks>(*this, PP);
-      });
-  ScanInstance.addDependencyCollector(std::move(DC));
-
-  return Error::success();
-}
-
-void IncludeTreeActionController::enteredInclude(Preprocessor &PP, FileID FID) {
-  if (hasErrorOccurred())
-    return;
-
-  if (!StartedEnteringIncludes) {
-    StartedEnteringIncludes = true;
-
-    // Get the included files (coming from a PCH), and keep track of the
-    // filenames that were recorded in the PCH.
-    for (const FileEntry *FE : PP.getIncludedFiles()) {
-      unsigned UID = FE->getUID();
-      if (UID >= PreIncludedFileNames.size())
-        PreIncludedFileNames.resize(UID + 1);
-      PreIncludedFileNames[UID] = FE->getName();
-    }
-  }
-
-  Optional<cas::ObjectRef> FileRef = check(getObjectForFile(PP, FID));
-  if (!FileRef)
-    return;
-  const SrcMgr::FileInfo &FI =
-      PP.getSourceManager().getSLocEntry(FID).getFile();
-  IncludeStack.push_back({FI.getFileCharacteristic(), *FileRef, {}, {}});
-}
-
-void IncludeTreeActionController::exitedInclude(Preprocessor &PP,
-                                                FileID IncludedBy,
-                                                FileID Include,
-                                                SourceLocation ExitLoc) {
-  if (hasErrorOccurred())
-    return;
-
-  assert(*check(getObjectForFile(PP, Include)) == IncludeStack.back().File);
-  Optional<cas::IncludeTree> IncludeTree =
-      check(getCASTreeForFileIncludes(IncludeStack.pop_back_val()));
-  if (!IncludeTree)
-    return;
-  assert(*check(getObjectForFile(PP, IncludedBy)) == IncludeStack.back().File);
-  SourceManager &SM = PP.getSourceManager();
-  std::pair<FileID, unsigned> LocInfo = SM.getDecomposedExpansionLoc(ExitLoc);
-  IncludeStack.back().Includes.push_back(
-      {IncludeTree->getRef(), LocInfo.second});
-}
-
-void IncludeTreeActionController::handleHasIncludeCheck(Preprocessor &PP,
-                                                        bool Result) {
-  if (hasErrorOccurred())
-    return;
-
-  IncludeStack.back().HasIncludeChecks.push_back(Result);
-}
-
-Error IncludeTreeActionController::finalize(CompilerInstance &ScanInstance,
-                                            CompilerInvocation &NewInvocation) {
-  FileManager &FM = ScanInstance.getFileManager();
-
-  auto addFile = [&](StringRef FilePath,
-                     bool IgnoreFileError = false) -> Error {
-    llvm::ErrorOr<const FileEntry *> FE = FM.getFile(FilePath);
-    if (!FE) {
-      if (IgnoreFileError)
-        return Error::success();
-      return llvm::errorCodeToError(FE.getError());
-    }
-    Optional<cas::ObjectRef> Ref;
-    return addToFileList(FM, *FE).moveInto(Ref);
-  };
-
-  for (StringRef FilePath : NewInvocation.getLangOpts()->NoSanitizeFiles) {
-    if (Error E = addFile(FilePath))
-      return E;
-  }
-  // Add profile files.
-  // FIXME: Do not have the logic here to determine which path should be set
-  // but ideally only the path needed for the compilation is set and we already
-  // checked the file needed exists. Just try load and ignore errors.
-  if (Error E = addFile(NewInvocation.getCodeGenOpts().ProfileInstrumentUsePath,
-                        /*IgnoreFileError=*/true))
-    return E;
-  if (Error E = addFile(NewInvocation.getCodeGenOpts().SampleProfileFile,
-                        /*IgnoreFileError=*/true))
-    return E;
-  if (Error E = addFile(NewInvocation.getCodeGenOpts().ProfileRemappingFile,
-                        /*IgnoreFileError=*/true))
-    return E;
-
-  StringRef Sysroot = NewInvocation.getHeaderSearchOpts().Sysroot;
-  if (!Sysroot.empty()) {
-    // Include 'SDKSettings.json', if it exists, to accomodate availability
-    // checks during the compilation.
-    llvm::SmallString<256> FilePath = Sysroot;
-    llvm::sys::path::append(FilePath, "SDKSettings.json");
-    if (Error E = addFile(FilePath, /*IgnoreFileError*/ true))
-      return E;
-  }
-
-  PreprocessorOptions &PPOpts = NewInvocation.getPreprocessorOpts();
-  if (PPOpts.ImplicitPCHInclude.empty())
-    return Error::success(); // no need for additional work.
-
-  // Go through all the recorded included files; we'll get additional files from
-  // the PCH that we need to include in the file list, in case they are
-  // referenced while replaying the include-tree.
-  SmallVector<const FileEntry *, 32> NotSeenIncludes;
-  for (const FileEntry *FE :
-       ScanInstance.getPreprocessor().getIncludedFiles()) {
-    if (FE->getUID() >= SeenIncludeFiles.size() ||
-        !SeenIncludeFiles[FE->getUID()])
-      NotSeenIncludes.push_back(FE);
-  }
-  // Sort so we can visit the files in deterministic order.
-  llvm::sort(NotSeenIncludes, [](const FileEntry *LHS, const FileEntry *RHS) {
-    return LHS->getUID() < RHS->getUID();
-  });
-
-  for (const FileEntry *FE : NotSeenIncludes) {
-    auto FileNode = addToFileList(FM, FE);
-    if (!FileNode)
-      return FileNode.takeError();
-  }
-
-  llvm::ErrorOr<Optional<cas::ObjectRef>> CASContents =
-      FM.getObjectRefForFileContent(PPOpts.ImplicitPCHInclude);
-  if (!CASContents)
-    return llvm::errorCodeToError(CASContents.getError());
-  PCHRef = **CASContents;
-
-  return Error::success();
-}
-
-Expected<cas::ObjectRef>
-IncludeTreeActionController::getObjectForFile(Preprocessor &PP, FileID FID) {
-  SourceManager &SM = PP.getSourceManager();
-  const SrcMgr::FileInfo &FI = SM.getSLocEntry(FID).getFile();
-  if (PP.getPredefinesFileID() == FID) {
-    if (!PredefinesBufferRef) {
-      auto Ref = getObjectForBuffer(FI);
-      if (!Ref)
-        return Ref.takeError();
-      PredefinesBufferRef = *Ref;
-    }
-    return *PredefinesBufferRef;
-  }
-  assert(FI.getContentCache().OrigEntry);
-  auto &FileRef = ObjectForFile[FI.getContentCache().OrigEntry];
-  if (!FileRef) {
-    auto Ref = getObjectForFileNonCached(SM.getFileManager(), FI);
-    if (!Ref)
-      return Ref.takeError();
-    FileRef = *Ref;
-  }
-  return *FileRef;
-}
-
-Expected<cas::ObjectRef> IncludeTreeActionController::getObjectForFileNonCached(
-    FileManager &FM, const SrcMgr::FileInfo &FI) {
-  const FileEntry *FE = FI.getContentCache().OrigEntry;
-  assert(FE);
-
-  // Mark the include as already seen.
-  if (FE->getUID() >= SeenIncludeFiles.size())
-    SeenIncludeFiles.resize(FE->getUID() + 1);
-  SeenIncludeFiles.set(FE->getUID());
-
-  return addToFileList(FM, FE);
-}
-
-Expected<cas::ObjectRef>
-IncludeTreeActionController::getObjectForBuffer(const SrcMgr::FileInfo &FI) {
-  // This is a non-file buffer, like the predefines.
-  auto Ref = DB.storeFromString(
-      {}, FI.getContentCache().getBufferIfLoaded()->getBuffer());
-  if (!Ref)
-    return Ref.takeError();
-  Expected<cas::IncludeFile> FileNode = createIncludeFile(FI.getName(), *Ref);
-  if (!FileNode)
-    return FileNode.takeError();
-  return FileNode->getRef();
-}
-
-Expected<cas::ObjectRef>
-IncludeTreeActionController::addToFileList(FileManager &FM,
-                                           const FileEntry *FE) {
-  StringRef Filename = FE->getName();
-  llvm::ErrorOr<Optional<cas::ObjectRef>> CASContents =
-      FM.getObjectRefForFileContent(Filename);
-  if (!CASContents)
-    return llvm::errorCodeToError(CASContents.getError());
-  assert(*CASContents);
-
-  auto addFile = [&](StringRef Filename) -> Expected<cas::ObjectRef> {
-    assert(!Filename.empty());
-    auto FileNode = createIncludeFile(Filename, **CASContents);
-    if (!FileNode)
-      return FileNode.takeError();
-    IncludedFiles.push_back(
-        {FileNode->getRef(),
-         static_cast<cas::IncludeFileList::FileSizeTy>(FE->getSize())});
-    return FileNode->getRef();
-  };
-
-  // Check whether another path coming from the PCH is associated with the same
-  // file.
-  unsigned UID = FE->getUID();
-  if (UID < PreIncludedFileNames.size() && !PreIncludedFileNames[UID].empty() &&
-      PreIncludedFileNames[UID] != Filename) {
-    auto FileNode = addFile(PreIncludedFileNames[UID]);
-    if (!FileNode)
-      return FileNode.takeError();
-  }
-
-  return addFile(Filename);
-}
-
-Expected<cas::IncludeTree>
-IncludeTreeActionController::getCASTreeForFileIncludes(FilePPState &&PPState) {
-  return cas::IncludeTree::create(DB, PPState.FileCharacteristic, PPState.File,
-                                  PPState.Includes, PPState.HasIncludeChecks);
-}
-
-Expected<cas::IncludeFile>
-IncludeTreeActionController::createIncludeFile(StringRef Filename,
-                                               cas::ObjectRef Contents) {
-  SmallString<256> MappedPath;
-  if (!PrefixMapper.empty()) {
-    PrefixMapper.map(Filename, MappedPath);
-    Filename = MappedPath;
-  }
-  return cas::IncludeFile::create(DB, Filename, std::move(Contents));
-}
-
-Expected<cas::IncludeTreeRoot> IncludeTreeActionController::getIncludeTree() {
-  if (ErrorToReport)
-    return std::move(*ErrorToReport);
-
-  assert(IncludeStack.size() == 1);
-  Expected<cas::IncludeTree> MainIncludeTree =
-      getCASTreeForFileIncludes(IncludeStack.pop_back_val());
-  if (!MainIncludeTree)
-    return MainIncludeTree.takeError();
-  auto FileList = cas::IncludeFileList::create(DB, IncludedFiles);
-  if (!FileList)
-    return FileList.takeError();
-
-  return cas::IncludeTreeRoot::create(DB, MainIncludeTree->getRef(),
-                                      FileList->getRef(), PCHRef);
 }
 
 Expected<cas::IncludeTreeRoot> DependencyScanningTool::getIncludeTree(
     cas::ObjectStore &DB, const std::vector<std::string> &CommandLine,
     StringRef CWD, const DepscanPrefixMapping &PrefixMapping) {
-  EmptyDependencyConsumer Consumer;
-  IncludeTreeActionController Controller(DB, PrefixMapping);
+  GetIncludeTree Consumer(DB);
+  auto Controller =
+      createIncludeTreeActionController(DB, std::move(PrefixMapping));
   llvm::Error Result =
-      Worker.computeDependencies(CWD, CommandLine, Consumer, Controller);
+      Worker.computeDependencies(CWD, CommandLine, Consumer, *Controller);
   if (Result)
     return std::move(Result);
-  return Controller.getIncludeTree();
+  return Consumer.getIncludeTree();
 }
 
 Expected<cas::IncludeTreeRoot>
@@ -595,12 +207,13 @@ DependencyScanningTool::getIncludeTreeFromCompilerInvocation(
     StringRef CWD, const DepscanPrefixMapping &PrefixMapping,
     DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
     bool DiagGenerationAsCompilation) {
-  EmptyDependencyConsumer Consumer;
-  IncludeTreeActionController Controller(DB, PrefixMapping);
+  GetIncludeTree Consumer(DB);
+  auto Controller =
+      createIncludeTreeActionController(DB, std::move(PrefixMapping));
   Worker.computeDependenciesFromCompilerInvocation(
-      std::move(Invocation), CWD, Consumer, Controller, DiagsConsumer,
+      std::move(Invocation), CWD, Consumer, *Controller, DiagsConsumer,
       VerboseOS, DiagGenerationAsCompilation);
-  return Controller.getIncludeTree();
+  return Consumer.getIncludeTree();
 }
 
 llvm::Expected<TranslationUnitDeps>
@@ -680,8 +293,8 @@ DependencyScanningTool::createActionController(
     LookupModuleOutputCallback LookupModuleOutput,
     DepscanPrefixMapping PrefixMapping) {
   if (auto CacheFS = Worker.getCASFS())
-    return std::make_unique<CASFSActionController>(LookupModuleOutput, *CacheFS,
-                                                   std::move(PrefixMapping));
+    return createCASFSActionController(LookupModuleOutput, *CacheFS,
+                                       std::move(PrefixMapping));
   return std::make_unique<CallbackActionController>(LookupModuleOutput);
 }
 
@@ -691,154 +304,4 @@ DependencyScanningTool::createActionController(
     DepscanPrefixMapping PrefixMapping) {
   return createActionController(Worker, std::move(LookupModuleOutput),
                                 std::move(PrefixMapping));
-}
-
-CASFSActionController::CASFSActionController(
-    LookupModuleOutputCallback LookupModuleOutput,
-    llvm::cas::CachingOnDiskFileSystem &CacheFS,
-    DepscanPrefixMapping PrefixMapping)
-    : CallbackActionController(std::move(LookupModuleOutput)), CacheFS(CacheFS),
-      PrefixMapping(std::move(PrefixMapping)) {}
-
-Error CASFSActionController::initialize(CompilerInstance &ScanInstance,
-                                        CompilerInvocation &NewInvocation) {
-  // Setup prefix mapping.
-  Mapper.emplace(&CacheFS);
-  if (Error E = PrefixMapping.configurePrefixMapper(NewInvocation, *Mapper))
-    return E;
-
-  const PreprocessorOptions &PPOpts = ScanInstance.getPreprocessorOpts();
-  if (!PPOpts.Includes.empty() || !PPOpts.ImplicitPCHInclude.empty())
-    addReversePrefixMappingFileSystem(*Mapper, ScanInstance);
-
-  CacheFS.trackNewAccesses();
-  if (auto CWD =
-          ScanInstance.getVirtualFileSystem().getCurrentWorkingDirectory())
-    CacheFS.setCurrentWorkingDirectory(*CWD);
-  // Track paths that are accessed by the scanner before we reach here.
-  for (const auto &File : ScanInstance.getHeaderSearchOpts().VFSOverlayFiles)
-    (void)CacheFS.status(File);
-  // Enable caching in the resulting commands.
-  ScanInstance.getFrontendOpts().CacheCompileJob = true;
-  CASOpts = ScanInstance.getCASOpts();
-  return Error::success();
-}
-
-/// Ensure that all files reachable from imported modules/pch are tracked.
-/// These could be loaded lazily during compilation.
-static void trackASTFileInputs(CompilerInstance &CI,
-                               llvm::cas::CachingOnDiskFileSystem &CacheFS) {
-  auto Reader = CI.getASTReader();
-  if (!Reader)
-    return;
-
-  for (serialization::ModuleFile &MF : Reader->getModuleManager()) {
-    Reader->visitInputFiles(
-        MF, /*IncludeSystem=*/true, /*Complain=*/false,
-        [](const serialization::InputFile &IF, bool isSystem) {
-          // Visiting input files triggers the file system lookup.
-        });
-  }
-}
-
-/// Ensure files that are not accessed during the scan (or accessed before the
-/// tracking scope) are tracked.
-static void trackFilesCommon(CompilerInstance &CI,
-                             llvm::cas::CachingOnDiskFileSystem &CacheFS) {
-  trackASTFileInputs(CI, CacheFS);
-
-  // Exclude the module cache from tracking. The implicit build pcms should
-  // not be needed after scanning.
-  if (!CI.getHeaderSearchOpts().ModuleCachePath.empty())
-    (void)CacheFS.excludeFromTracking(CI.getHeaderSearchOpts().ModuleCachePath);
-
-  // Normally this would be looked up while creating the VFS, but implicit
-  // modules share their VFS and it happens too early for the TU scan.
-  for (const auto &File : CI.getHeaderSearchOpts().VFSOverlayFiles)
-    (void)CacheFS.status(File);
-
-  StringRef Sysroot = CI.getHeaderSearchOpts().Sysroot;
-  if (!Sysroot.empty()) {
-    // Include 'SDKSettings.json', if it exists, to accomodate availability
-    // checks during the compilation.
-    llvm::SmallString<256> FilePath = Sysroot;
-    llvm::sys::path::append(FilePath, "SDKSettings.json");
-    (void)CacheFS.status(FilePath);
-  }
-}
-
-Error CASFSActionController::finalize(CompilerInstance &ScanInstance,
-                                      CompilerInvocation &NewInvocation) {
-  // Handle profile mappings.
-  (void)CacheFS.status(NewInvocation.getCodeGenOpts().ProfileInstrumentUsePath);
-  (void)CacheFS.status(NewInvocation.getCodeGenOpts().SampleProfileFile);
-  (void)CacheFS.status(NewInvocation.getCodeGenOpts().ProfileRemappingFile);
-
-  trackFilesCommon(ScanInstance, CacheFS);
-
-  auto CASFileSystemRootID = CacheFS.createTreeFromNewAccesses(
-      [&](const llvm::vfs::CachedDirectoryEntry &Entry,
-          SmallVectorImpl<char> &Storage) {
-        return Mapper->mapDirEntry(Entry, Storage);
-      });
-  if (!CASFileSystemRootID)
-    return CASFileSystemRootID.takeError();
-
-  configureInvocationForCaching(NewInvocation, CASOpts,
-                                CASFileSystemRootID->getID().toString(),
-                                CacheFS.getCurrentWorkingDirectory().get(),
-                                /*ProduceIncludeTree=*/false);
-
-  if (Mapper)
-    DepscanPrefixMapping::remapInvocationPaths(NewInvocation, *Mapper);
-
-  return Error::success();
-}
-
-Error CASFSActionController::initializeModuleBuild(
-    CompilerInstance &ModuleScanInstance) {
-
-  CacheFS.trackNewAccesses();
-  // If the working directory is not otherwise accessed by the module build,
-  // we still need it due to -fcas-fs-working-directory being set.
-  if (auto CWD = CacheFS.getCurrentWorkingDirectory())
-    (void)CacheFS.status(*CWD);
-
-  return Error::success();
-}
-
-Error CASFSActionController::finalizeModuleBuild(
-    CompilerInstance &ModuleScanInstance) {
-  trackFilesCommon(ModuleScanInstance, CacheFS);
-
-  Optional<cas::CASID> RootID;
-  auto E = CacheFS
-               .createTreeFromNewAccesses(
-                   [&](const llvm::vfs::CachedDirectoryEntry &Entry,
-                       SmallVectorImpl<char> &Storage) {
-                     return Mapper->mapDirEntry(Entry, Storage);
-                   })
-               .moveInto(RootID);
-  if (E)
-    return E;
-
-  Module *M = ModuleScanInstance.getPreprocessor().getCurrentModule();
-  assert(M && "finalizing without a module");
-
-  M->setCASFileSystemRootID(RootID->toString());
-  return Error::success();
-}
-
-Error CASFSActionController::finalizeModuleInvocation(CompilerInvocation &CI,
-                                                      const ModuleDeps &MD) {
-  if (auto ID = MD.CASFileSystemRootID) {
-    configureInvocationForCaching(CI, CASOpts, ID->toString(),
-                                  CacheFS.getCurrentWorkingDirectory().get(),
-                                  /*ProduceIncludeTree=*/false);
-  }
-
-  if (Mapper)
-    DepscanPrefixMapping::remapInvocationPaths(CI, *Mapper);
-
-  return llvm::Error::success();
 }

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -234,6 +234,50 @@ private:
   llvm::DenseMap<const FileEntry *, Optional<cas::ObjectRef>> ObjectForFile;
   Optional<llvm::Error> ErrorToReport;
 };
+
+/// A utility for adding \c PPCallbacks to a compiler instance at the
+/// appropriate time.
+struct PPCallbacksDependencyCollector : public DependencyCollector {
+  using MakeCB =
+      llvm::unique_function<std::unique_ptr<PPCallbacks>(Preprocessor &)>;
+  MakeCB Create;
+  PPCallbacksDependencyCollector(MakeCB Create) : Create(std::move(Create)) {}
+  void attachToPreprocessor(Preprocessor &PP) final {
+    std::unique_ptr<PPCallbacks> CB = Create(PP);
+    assert(CB);
+    PP.addPPCallbacks(std::move(CB));
+  }
+};
+
+struct IncludeTreePPCallbacks : public PPCallbacks {
+  DependencyActionController &Controller;
+  Preprocessor &PP;
+
+public:
+  IncludeTreePPCallbacks(DependencyActionController &Controller,
+                         Preprocessor &PP)
+      : Controller(Controller), PP(PP) {}
+
+  void LexedFileChanged(FileID FID, LexedFileChangeReason Reason,
+                        SrcMgr::CharacteristicKind FileType, FileID PrevFID,
+                        SourceLocation Loc) override {
+    switch (Reason) {
+    case LexedFileChangeReason::EnterFile:
+      Controller.enteredInclude(PP, FID);
+      break;
+    case LexedFileChangeReason::ExitFile: {
+      Controller.exitedInclude(PP, FID, PrevFID, Loc);
+      break;
+    }
+    }
+  }
+
+  void HasInclude(SourceLocation Loc, StringRef FileName, bool IsAngled,
+                  OptionalFileEntryRef File,
+                  SrcMgr::CharacteristicKind FileType) override {
+    Controller.handleHasIncludeCheck(PP, File.has_value());
+  }
+};
 } // namespace
 
 /// The PCH recorded file paths with canonical paths, create a VFS that
@@ -273,6 +317,14 @@ Error IncludeTreeActionController::initialize(
       PrefixMapper.mapInPlace(Include);
   };
   ensurePathRemapping();
+
+  // Attach callbacks for the IncludeTree of the TU. The preprocessor
+  // does not exist yet, so we need to indirect this via DependencyCollector.
+  auto DC = std::make_shared<PPCallbacksDependencyCollector>(
+      [this](Preprocessor &PP) {
+        return std::make_unique<IncludeTreePPCallbacks>(*this, PP);
+      });
+  ScanInstance.addDependencyCollector(std::move(DC));
 
   return Error::success();
 }

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -84,65 +84,6 @@ protected:
 
 llvm::Expected<std::string> DependencyScanningTool::getDependencyFile(
     const std::vector<std::string> &CommandLine, StringRef CWD) {
-  /// Prints out all of the gathered dependencies into a string.
-  class MakeDependencyPrinterConsumer : public DependencyConsumer {
-  public:
-    void handleBuildCommand(Command) override {}
-
-    void
-    handleDependencyOutputOpts(const DependencyOutputOptions &Opts) override {
-      this->Opts = std::make_unique<DependencyOutputOptions>(Opts);
-    }
-
-    void handleFileDependency(StringRef File) override {
-      Dependencies.push_back(std::string(File));
-    }
-
-    void handlePrebuiltModuleDependency(PrebuiltModuleDep PMD) override {
-      // Same as `handleModuleDependency`.
-    }
-
-    void handleModuleDependency(ModuleDeps MD) override {
-      // These are ignored for the make format as it can't support the full
-      // set of deps, and handleFileDependency handles enough for implicitly
-      // built modules to work.
-    }
-
-    void handleContextHash(std::string Hash) override {}
-    void handleCASFileSystemRootID(cas::CASID) override {}
-
-    std::string lookupModuleOutput(const ModuleID &ID,
-                                   ModuleOutputKind Kind) override {
-      llvm::report_fatal_error("unexpected call to lookupModuleOutput");
-    }
-
-    void printDependencies(std::string &S) {
-      assert(Opts && "Handled dependency output options.");
-
-      class DependencyPrinter : public DependencyFileGenerator {
-      public:
-        DependencyPrinter(DependencyOutputOptions &Opts,
-                          ArrayRef<std::string> Dependencies)
-            : DependencyFileGenerator(Opts) {
-          for (const auto &Dep : Dependencies)
-            addDependency(Dep);
-        }
-
-        void printDependencies(std::string &S) {
-          llvm::raw_string_ostream OS(S);
-          outputDependencyFile(OS);
-        }
-      };
-
-      DependencyPrinter Generator(*Opts, Dependencies);
-      Generator.printDependencies(S);
-    }
-
-  private:
-    std::unique_ptr<DependencyOutputOptions> Opts;
-    std::vector<std::string> Dependencies;
-  };
-
   MakeDependencyPrinterConsumer Consumer;
   CallbackActionController Controller(nullptr);
   auto Result =
@@ -186,8 +127,7 @@ public:
                                    "failed to get casfs");
   }
 
-  GetDependencyTree(llvm::cas::CachingOnDiskFileSystem &FS)
-      : FS(FS) {}
+  GetDependencyTree(llvm::cas::CachingOnDiskFileSystem &FS) : FS(FS) {}
 
 private:
   llvm::cas::CachingOnDiskFileSystem &FS;
@@ -202,7 +142,8 @@ DependencyScanningTool::getDependencyTree(
   GetDependencyTree Consumer(*Worker.getCASFS());
   CASFSActionController Controller(nullptr, *Worker.getCASFS(),
                                    std::move(PrefixMapping));
-  auto Result = Worker.computeDependencies(CWD, CommandLine, Consumer, Controller);
+  auto Result =
+      Worker.computeDependencies(CWD, CommandLine, Consumer, Controller);
   if (Result)
     return std::move(Result);
   return Consumer.getTree();
@@ -217,8 +158,8 @@ DependencyScanningTool::getDependencyTreeFromCompilerInvocation(
   CASFSActionController Controller(nullptr, *Worker.getCASFS(),
                                    std::move(PrefixMapping));
   Worker.computeDependenciesFromCompilerInvocation(
-      std::move(Invocation), CWD, Consumer, Controller, DiagsConsumer, VerboseOS,
-      DiagGenerationAsCompilation);
+      std::move(Invocation), CWD, Consumer, Controller, DiagsConsumer,
+      VerboseOS, DiagGenerationAsCompilation);
   return Consumer.getTree();
 }
 
@@ -226,8 +167,9 @@ namespace {
 class IncludeTreeActionController : public CallbackActionController {
 public:
   IncludeTreeActionController(cas::ObjectStore &DB,
-                        const DepscanPrefixMapping &PrefixMapping)
-      : CallbackActionController(nullptr), DB(DB), PrefixMapping(PrefixMapping) {}
+                              const DepscanPrefixMapping &PrefixMapping)
+      : CallbackActionController(nullptr), DB(DB),
+        PrefixMapping(PrefixMapping) {}
 
   Expected<cas::IncludeTreeRoot> getIncludeTree();
 
@@ -310,8 +252,8 @@ addReversePrefixMappingFileSystem(const llvm::PrefixMapper &PrefixMapper,
   ScanInstance.getFileManager().setVirtualFileSystem(std::move(FS));
 }
 
-Error IncludeTreeActionController::initialize(CompilerInstance &ScanInstance,
-                                        CompilerInvocation &NewInvocation) {
+Error IncludeTreeActionController::initialize(
+    CompilerInstance &ScanInstance, CompilerInvocation &NewInvocation) {
   if (Error E =
           PrefixMapping.configurePrefixMapper(NewInvocation, PrefixMapper))
     return E;
@@ -360,9 +302,10 @@ void IncludeTreeActionController::enteredInclude(Preprocessor &PP, FileID FID) {
   IncludeStack.push_back({FI.getFileCharacteristic(), *FileRef, {}, {}});
 }
 
-void IncludeTreeActionController::exitedInclude(Preprocessor &PP, FileID IncludedBy,
-                                          FileID Include,
-                                          SourceLocation ExitLoc) {
+void IncludeTreeActionController::exitedInclude(Preprocessor &PP,
+                                                FileID IncludedBy,
+                                                FileID Include,
+                                                SourceLocation ExitLoc) {
   if (hasErrorOccurred())
     return;
 
@@ -379,7 +322,7 @@ void IncludeTreeActionController::exitedInclude(Preprocessor &PP, FileID Include
 }
 
 void IncludeTreeActionController::handleHasIncludeCheck(Preprocessor &PP,
-                                                  bool Result) {
+                                                        bool Result) {
   if (hasErrorOccurred())
     return;
 
@@ -387,7 +330,7 @@ void IncludeTreeActionController::handleHasIncludeCheck(Preprocessor &PP,
 }
 
 Error IncludeTreeActionController::finalize(CompilerInstance &ScanInstance,
-                                      CompilerInvocation &NewInvocation) {
+                                            CompilerInvocation &NewInvocation) {
   FileManager &FM = ScanInstance.getFileManager();
 
   auto addFile = [&](StringRef FilePath,
@@ -488,9 +431,8 @@ IncludeTreeActionController::getObjectForFile(Preprocessor &PP, FileID FID) {
   return *FileRef;
 }
 
-Expected<cas::ObjectRef>
-IncludeTreeActionController::getObjectForFileNonCached(FileManager &FM,
-                                                 const SrcMgr::FileInfo &FI) {
+Expected<cas::ObjectRef> IncludeTreeActionController::getObjectForFileNonCached(
+    FileManager &FM, const SrcMgr::FileInfo &FI) {
   const FileEntry *FE = FI.getContentCache().OrigEntry;
   assert(FE);
 
@@ -516,9 +458,10 @@ IncludeTreeActionController::getObjectForBuffer(const SrcMgr::FileInfo &FI) {
 }
 
 Expected<cas::ObjectRef>
-IncludeTreeActionController::addToFileList(FileManager &FM, const FileEntry *FE) {
+IncludeTreeActionController::addToFileList(FileManager &FM,
+                                           const FileEntry *FE) {
   StringRef Filename = FE->getName();
-  llvm::ErrorOr<std::optional<cas::ObjectRef>> CASContents =
+  llvm::ErrorOr<Optional<cas::ObjectRef>> CASContents =
       FM.getObjectRefForFileContent(Filename);
   if (!CASContents)
     return llvm::errorCodeToError(CASContents.getError());
@@ -556,7 +499,7 @@ IncludeTreeActionController::getCASTreeForFileIncludes(FilePPState &&PPState) {
 
 Expected<cas::IncludeFile>
 IncludeTreeActionController::createIncludeFile(StringRef Filename,
-                                         cas::ObjectRef Contents) {
+                                               cas::ObjectRef Contents) {
   SmallString<256> MappedPath;
   if (!PrefixMapper.empty()) {
     PrefixMapper.map(Filename, MappedPath);
@@ -587,7 +530,8 @@ Expected<cas::IncludeTreeRoot> DependencyScanningTool::getIncludeTree(
     StringRef CWD, const DepscanPrefixMapping &PrefixMapping) {
   EmptyDependencyConsumer Consumer;
   IncludeTreeActionController Controller(DB, PrefixMapping);
-  llvm::Error Result = Worker.computeDependencies(CWD, CommandLine, Consumer, Controller);
+  llvm::Error Result =
+      Worker.computeDependencies(CWD, CommandLine, Consumer, Controller);
   if (Result)
     return std::move(Result);
   return Controller.getIncludeTree();
@@ -602,8 +546,8 @@ DependencyScanningTool::getIncludeTreeFromCompilerInvocation(
   EmptyDependencyConsumer Consumer;
   IncludeTreeActionController Controller(DB, PrefixMapping);
   Worker.computeDependenciesFromCompilerInvocation(
-      std::move(Invocation), CWD, Consumer, Controller, DiagsConsumer, VerboseOS,
-      DiagGenerationAsCompilation);
+      std::move(Invocation), CWD, Consumer, Controller, DiagsConsumer,
+      VerboseOS, DiagGenerationAsCompilation);
   return Controller.getIncludeTree();
 }
 
@@ -614,7 +558,8 @@ DependencyScanningTool::getTranslationUnitDependencies(
     LookupModuleOutputCallback LookupModuleOutput,
     DepscanPrefixMapping PrefixMapping) {
   FullDependencyConsumer Consumer(AlreadySeen);
-  auto Controller = createActionController(LookupModuleOutput, std::move(PrefixMapping));
+  auto Controller =
+      createActionController(LookupModuleOutput, std::move(PrefixMapping));
   llvm::Error Result =
       Worker.computeDependencies(CWD, CommandLine, Consumer, *Controller);
   if (Result)
@@ -628,7 +573,8 @@ llvm::Expected<ModuleDepsGraph> DependencyScanningTool::getModuleDependencies(
     LookupModuleOutputCallback LookupModuleOutput,
     DepscanPrefixMapping PrefixMapping) {
   FullDependencyConsumer Consumer(AlreadySeen);
-  auto Controller = createActionController(LookupModuleOutput, std::move(PrefixMapping));
+  auto Controller =
+      createActionController(LookupModuleOutput, std::move(PrefixMapping));
   llvm::Error Result = Worker.computeDependencies(CWD, CommandLine, Consumer,
                                                   *Controller, ModuleName);
   if (Result)
@@ -675,7 +621,6 @@ ModuleDepsGraph FullDependencyConsumer::takeModuleGraphDeps() {
 }
 
 CallbackActionController::~CallbackActionController() {}
-
 
 std::unique_ptr<DependencyActionController>
 DependencyScanningTool::createActionController(
@@ -832,8 +777,8 @@ Error CASFSActionController::finalizeModuleBuild(
   return Error::success();
 }
 
-Error CASFSActionController::finalizeModuleInvocation(
-    CompilerInvocation &CI, const ModuleDeps &MD) {
+Error CASFSActionController::finalizeModuleInvocation(CompilerInvocation &CI,
+                                                      const ModuleDeps &MD) {
   if (auto ID = MD.CASFileSystemRootID) {
     configureInvocationForCaching(CI, CASOpts, ID->toString(),
                                   CacheFS.getCurrentWorkingDirectory().get(),

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -469,9 +469,13 @@ public:
     if (Error E = Controller.finalize(ScanInstance, OriginalInvocation))
       return reportError(std::move(E));
 
+    // Forward any CAS results to consumer.
     std::string ID = OriginalInvocation.getFileSystemOpts().CASFileSystemRootID;
     if (!ID.empty())
       Consumer.handleCASFileSystemRootID(std::move(ID));
+    ID = OriginalInvocation.getFrontendOpts().CASIncludeTreeID;
+    if (!ID.empty())
+      Consumer.handleIncludeTreeID(std::move(ID));
 
     LastCC1Arguments = OriginalInvocation.getCC1CommandLine();
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -417,6 +417,7 @@ public:
     case ScanningOutputFormat::IncludeTree:
     case ScanningOutputFormat::Full:
     case ScanningOutputFormat::FullTree:
+    case ScanningOutputFormat::FullIncludeTree:
       if (EmitDependencyFile) {
         auto DFG =
             std::make_shared<ReversePrefixMappingDependencyFileGenerator>(
@@ -534,7 +535,7 @@ DependencyScanningWorker::DependencyScanningWorker(
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS)
     : Format(Service.getFormat()), OptimizeArgs(Service.canOptimizeArgs()),
       EagerLoadModules(Service.shouldEagerLoadModules()),
-      CASOpts(Service.getCASOpts()), UseCAS(Service.useCASScanning()) {
+      CASOpts(Service.getCASOpts()), CAS(Service.getCAS()) {
   PCHContainerOps = std::make_shared<PCHContainerOperations>();
   PCHContainerOps->registerReader(
       std::make_unique<ObjectFilePCHContainerReader>());
@@ -543,9 +544,9 @@ DependencyScanningWorker::DependencyScanningWorker(
   PCHContainerOps->registerWriter(
       std::make_unique<ObjectFilePCHContainerWriter>());
 
-  if (Service.useCASScanning()) {
+  if (Service.useCASFS()) {
     CacheFS = Service.getSharedFS().createProxyFS();
-    DepCASFS = new DependencyScanningCASFilesystem(CacheFS, Service.getCache());
+    DepCASFS = new DependencyScanningCASFilesystem(CacheFS, *Service.getCache());
     BaseFS = DepCASFS;
     return;
   }

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -161,48 +161,17 @@ static void sanitizeDiagOpts(DiagnosticOptions &DiagOpts) {
   DiagOpts.IgnoreWarnings = true;
 }
 
-struct IncludeTreePPCallbacks : public PPCallbacks {
-  DependencyActionController &Controller;
-  Preprocessor &PP;
-
-public:
-  IncludeTreePPCallbacks(DependencyActionController &Controller,
-                         Preprocessor &PP)
-      : Controller(Controller), PP(PP) {}
-
-  void LexedFileChanged(FileID FID, LexedFileChangeReason Reason,
-                        SrcMgr::CharacteristicKind FileType, FileID PrevFID,
-                        SourceLocation Loc) override {
-    switch (Reason) {
-    case LexedFileChangeReason::EnterFile:
-      Controller.enteredInclude(PP, FID);
-      break;
-    case LexedFileChangeReason::ExitFile: {
-      Controller.exitedInclude(PP, FID, PrevFID, Loc);
-      break;
-    }
-    }
-  }
-
-  void HasInclude(SourceLocation Loc, StringRef FileName, bool IsAngled,
-                  Optional<FileEntryRef> File,
-                  SrcMgr::CharacteristicKind FileType) override {
-    Controller.handleHasIncludeCheck(PP, File.has_value());
-  }
-};
-
-class IncludeTreeCollector : public DependencyFileGenerator {
-  DependencyActionController &Controller;
-  std::unique_ptr<DependencyOutputOptions> Opts;
-  bool EmitDependencyFile = false;
+/// Builds a dependency file after reversing prefix mappings. This allows
+/// emitting a .d file that has real paths where they would otherwise be
+/// canonicalized.
+class ReversePrefixMappingDependencyFileGenerator
+    : public DependencyFileGenerator {
   llvm::PrefixMapper ReverseMapper;
 
 public:
-  IncludeTreeCollector(DependencyActionController &Controller,
-                       std::unique_ptr<DependencyOutputOptions> Opts,
-                       bool EmitDependencyFile)
-      : DependencyFileGenerator(*Opts), Controller(Controller),
-        Opts(std::move(Opts)), EmitDependencyFile(EmitDependencyFile) {}
+  ReversePrefixMappingDependencyFileGenerator(
+      const DependencyOutputOptions &Opts)
+      : DependencyFileGenerator(Opts) {}
 
   Error initialize(const CompilerInvocation &CI,
                    const DepscanPrefixMapping &PrefixMapping) {
@@ -217,11 +186,6 @@ public:
     return Error::success();
   }
 
-  void attachToPreprocessor(Preprocessor &PP) override {
-    PP.addPPCallbacks(std::make_unique<IncludeTreePPCallbacks>(Controller, PP));
-    DependencyFileGenerator::attachToPreprocessor(PP);
-  }
-
   void maybeAddDependency(StringRef Filename, bool FromModule, bool IsSystem,
                           bool IsModuleFile, bool IsMissing) override {
     if (ReverseMapper.empty())
@@ -234,11 +198,6 @@ public:
     ReverseMapper.mapInPlace(New);
     return DependencyFileGenerator::maybeAddDependency(
         New, FromModule, IsSystem, IsModuleFile, IsMissing);
-  }
-
-  void finishedMainFile(DiagnosticsEngine &Diags) override {
-    if (EmitDependencyFile)
-      DependencyFileGenerator::finishedMainFile(Diags);
   }
 };
 
@@ -455,17 +414,19 @@ public:
           std::make_shared<DependencyConsumerForwarder>(
               std::move(Opts), WorkingDirectory, Consumer, EmitDependencyFile));
       break;
-    case ScanningOutputFormat::IncludeTree: {
-      auto IncTreeCollector = std::make_shared<IncludeTreeCollector>(
-          Controller, std::move(Opts), EmitDependencyFile);
-      if (Error E = IncTreeCollector->initialize(
-              ScanInstance.getInvocation(), *Controller.getPrefixMapping()))
-        return reportError(std::move(E));
-      ScanInstance.addDependencyCollector(std::move(IncTreeCollector));
-      break;
-    }
+    case ScanningOutputFormat::IncludeTree:
     case ScanningOutputFormat::Full:
     case ScanningOutputFormat::FullTree:
+      if (EmitDependencyFile) {
+        auto DFG =
+            std::make_shared<ReversePrefixMappingDependencyFileGenerator>(
+                *Opts);
+        if (auto *Mapping = Controller.getPrefixMapping())
+          if (auto E = DFG->initialize(ScanInstance.getInvocation(), *Mapping))
+            return reportError(std::move(E));
+        ScanInstance.addDependencyCollector(std::move(DFG));
+      }
+
       MDC = std::make_shared<ModuleDepCollector>(
           std::move(Opts), ScanInstance, Consumer, Controller,
           OriginalInvocation, OptimizeArgs, EagerLoadModules);

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -561,8 +561,8 @@ DependencyScanningWorker::DependencyScanningWorker(
     DependencyScanningService &Service,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS)
     : Format(Service.getFormat()), OptimizeArgs(Service.canOptimizeArgs()),
-      CASOpts(Service.getCASOpts()), UseCAS(Service.useCASScanning()),
-      EagerLoadModules(Service.shouldEagerLoadModules()) {
+      EagerLoadModules(Service.shouldEagerLoadModules()),
+      CASOpts(Service.getCASOpts()), UseCAS(Service.useCASScanning()) {
   PCHContainerOps = std::make_shared<PCHContainerOperations>();
   PCHContainerOps->registerReader(
       std::make_unique<ObjectFilePCHContainerReader>());

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -162,22 +162,23 @@ static void sanitizeDiagOpts(DiagnosticOptions &DiagOpts) {
 }
 
 struct IncludeTreePPCallbacks : public PPCallbacks {
-  PPIncludeActionsConsumer &Consumer;
+  DependencyActionController &Controller;
   Preprocessor &PP;
 
 public:
-  IncludeTreePPCallbacks(PPIncludeActionsConsumer &Consumer, Preprocessor &PP)
-      : Consumer(Consumer), PP(PP) {}
+  IncludeTreePPCallbacks(DependencyActionController &Controller,
+                         Preprocessor &PP)
+      : Controller(Controller), PP(PP) {}
 
   void LexedFileChanged(FileID FID, LexedFileChangeReason Reason,
                         SrcMgr::CharacteristicKind FileType, FileID PrevFID,
                         SourceLocation Loc) override {
     switch (Reason) {
     case LexedFileChangeReason::EnterFile:
-      Consumer.enteredInclude(PP, FID);
+      Controller.enteredInclude(PP, FID);
       break;
     case LexedFileChangeReason::ExitFile: {
-      Consumer.exitedInclude(PP, FID, PrevFID, Loc);
+      Controller.exitedInclude(PP, FID, PrevFID, Loc);
       break;
     }
     }
@@ -186,21 +187,21 @@ public:
   void HasInclude(SourceLocation Loc, StringRef FileName, bool IsAngled,
                   Optional<FileEntryRef> File,
                   SrcMgr::CharacteristicKind FileType) override {
-    Consumer.handleHasIncludeCheck(PP, File.has_value());
+    Controller.handleHasIncludeCheck(PP, File.has_value());
   }
 };
 
 class IncludeTreeCollector : public DependencyFileGenerator {
-  PPIncludeActionsConsumer &Consumer;
+  DependencyActionController &Controller;
   std::unique_ptr<DependencyOutputOptions> Opts;
   bool EmitDependencyFile = false;
   llvm::PrefixMapper ReverseMapper;
 
 public:
-  IncludeTreeCollector(PPIncludeActionsConsumer &Consumer,
+  IncludeTreeCollector(DependencyActionController &Controller,
                        std::unique_ptr<DependencyOutputOptions> Opts,
                        bool EmitDependencyFile)
-      : DependencyFileGenerator(*Opts), Consumer(Consumer),
+      : DependencyFileGenerator(*Opts), Controller(Controller),
         Opts(std::move(Opts)), EmitDependencyFile(EmitDependencyFile) {}
 
   Error initialize(const CompilerInvocation &CI,
@@ -217,7 +218,7 @@ public:
   }
 
   void attachToPreprocessor(Preprocessor &PP) override {
-    PP.addPPCallbacks(std::make_unique<IncludeTreePPCallbacks>(Consumer, PP));
+    PP.addPPCallbacks(std::make_unique<IncludeTreePPCallbacks>(Controller, PP));
     DependencyFileGenerator::attachToPreprocessor(PP);
   }
 
@@ -245,30 +246,30 @@ public:
 class WrapScanModuleBuildConsumer : public ASTConsumer {
 public:
   WrapScanModuleBuildConsumer(CompilerInstance &CI,
-                              DependencyConsumer &Consumer)
-      : CI(CI), Consumer(Consumer) {}
+                              DependencyActionController &Controller)
+      : CI(CI), Controller(Controller) {}
 
   void HandleTranslationUnit(ASTContext &Ctx) override {
-    if (auto E = Consumer.finalizeModuleBuild(CI))
+    if (auto E = Controller.finalizeModuleBuild(CI))
       Ctx.getDiagnostics().Report(diag::err_cas_depscan_failed) << std::move(E);
   }
 
 private:
   CompilerInstance &CI;
-  DependencyConsumer &Consumer;
+  DependencyActionController &Controller;
 };
 
 /// A wrapper for implicit module build actions in the scanner.
 class WrapScanModuleBuildAction : public WrapperFrontendAction {
 public:
   WrapScanModuleBuildAction(std::unique_ptr<FrontendAction> WrappedAction,
-                            DependencyConsumer &Consumer)
-      : WrapperFrontendAction(std::move(WrappedAction)), DepConsumer(Consumer) {
-  }
+                            DependencyActionController &Controller)
+      : WrapperFrontendAction(std::move(WrappedAction)),
+        Controller(Controller) {}
 
 private:
   bool BeginInvocation(CompilerInstance &CI) override {
-    if (auto E = DepConsumer.initializeModuleBuild(CI)) {
+    if (auto E = Controller.initializeModuleBuild(CI)) {
       CI.getDiagnostics().Report(diag::err_cas_depscan_failed) << std::move(E);
       return false;
     }
@@ -285,7 +286,7 @@ private:
     if (!M)
       return OtherConsumer;
     auto Consumer =
-        std::make_unique<WrapScanModuleBuildConsumer>(CI, DepConsumer);
+        std::make_unique<WrapScanModuleBuildConsumer>(CI, Controller);
     std::vector<std::unique_ptr<ASTConsumer>> Consumers;
     Consumers.push_back(std::move(Consumer));
     Consumers.push_back(std::move(OtherConsumer));
@@ -293,7 +294,7 @@ private:
   }
 
 private:
-  DependencyConsumer &DepConsumer;
+  DependencyActionController &Controller;
 };
 
 /// A clang tool that runs the preprocessor in a mode that's optimized for
@@ -302,6 +303,7 @@ class DependencyScanningAction : public tooling::ToolAction {
 public:
   DependencyScanningAction(
       StringRef WorkingDirectory, DependencyConsumer &Consumer,
+      DependencyActionController &Controller,
       llvm::IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS,
       llvm::IntrusiveRefCntPtr<DependencyScanningCASFilesystem> DepCASFS,
       llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> CacheFS,
@@ -311,6 +313,7 @@ public:
       llvm::Optional<StringRef> ModuleName = None,
       raw_ostream *VerboseOS = nullptr)
       : WorkingDirectory(WorkingDirectory), Consumer(Consumer),
+        Controller(Controller),
         DepFS(std::move(DepFS)), DepCASFS(std::move(DepCASFS)),
         CacheFS(std::move(CacheFS)), Format(Format), OptimizeArgs(OptimizeArgs),
         EagerLoadModules(EagerLoadModules), DisableFree(DisableFree),
@@ -453,11 +456,10 @@ public:
               std::move(Opts), WorkingDirectory, Consumer, EmitDependencyFile));
       break;
     case ScanningOutputFormat::IncludeTree: {
-      auto &IncConsumer = static_cast<PPIncludeActionsConsumer &>(Consumer);
       auto IncTreeCollector = std::make_shared<IncludeTreeCollector>(
-          IncConsumer, std::move(Opts), EmitDependencyFile);
+          Controller, std::move(Opts), EmitDependencyFile);
       if (Error E = IncTreeCollector->initialize(
-              ScanInstance.getInvocation(), IncConsumer.getPrefixMapping()))
+              ScanInstance.getInvocation(), *Controller.getPrefixMapping()))
         return reportError(std::move(E));
       ScanInstance.addDependencyCollector(std::move(IncTreeCollector));
       break;
@@ -465,16 +467,16 @@ public:
     case ScanningOutputFormat::Full:
     case ScanningOutputFormat::FullTree:
       MDC = std::make_shared<ModuleDepCollector>(
-          std::move(Opts), ScanInstance, Consumer, OriginalInvocation,
-          OptimizeArgs, EagerLoadModules);
+          std::move(Opts), ScanInstance, Consumer, Controller,
+          OriginalInvocation, OptimizeArgs, EagerLoadModules);
       ScanInstance.addDependencyCollector(MDC);
       if (CacheFS) {
         ScanInstance.setGenModuleActionWrapper(
-            [CacheFS = CacheFS,
-             &Consumer = Consumer](const FrontendOptions &Opts,
-                                   std::unique_ptr<FrontendAction> Wrapped) {
+            [CacheFS = CacheFS, &Controller = Controller](
+                const FrontendOptions &Opts,
+                std::unique_ptr<FrontendAction> Wrapped) {
               return std::make_unique<WrapScanModuleBuildAction>(
-                  std::move(Wrapped), Consumer);
+                  std::move(Wrapped), Controller);
             });
       }
       break;
@@ -494,7 +496,7 @@ public:
     else
       Action = std::make_unique<ReadPCHAndPreprocessAction>();
 
-    if (Error E = Consumer.initialize(ScanInstance, OriginalInvocation))
+    if (Error E = Controller.initialize(ScanInstance, OriginalInvocation))
       return reportError(std::move(E));
 
     if (!ScanInstance.ExecuteAction(*Action))
@@ -503,8 +505,12 @@ public:
     if (MDC)
       MDC->applyDiscoveredDependencies(OriginalInvocation);
 
-    if (Error E = Consumer.finalize(ScanInstance, OriginalInvocation))
+    if (Error E = Controller.finalize(ScanInstance, OriginalInvocation))
       return reportError(std::move(E));
+
+    std::string ID = OriginalInvocation.getFileSystemOpts().CASFileSystemRootID;
+    if (!ID.empty())
+      Consumer.handleCASFileSystemRootID(std::move(ID));
 
     LastCC1Arguments = OriginalInvocation.getCC1CommandLine();
 
@@ -537,6 +543,7 @@ public:
 private:
   StringRef WorkingDirectory;
   DependencyConsumer &Consumer;
+  DependencyActionController &Controller;
   llvm::IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS;
   llvm::IntrusiveRefCntPtr<DependencyScanningCASFilesystem> DepCASFS;
   llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> CacheFS;
@@ -598,7 +605,8 @@ DependencyScanningWorker::getOrCreateFileManager() const {
 
 llvm::Error DependencyScanningWorker::computeDependencies(
     StringRef WorkingDirectory, const std::vector<std::string> &CommandLine,
-    DependencyConsumer &Consumer, llvm::Optional<StringRef> ModuleName) {
+    DependencyConsumer &Consumer, DependencyActionController &Controller,
+    llvm::Optional<StringRef> ModuleName) {
   std::vector<const char *> CLI;
   for (const std::string &Arg : CommandLine)
     CLI.push_back(Arg.c_str());
@@ -611,8 +619,8 @@ llvm::Error DependencyScanningWorker::computeDependencies(
   llvm::raw_string_ostream DiagnosticsOS(DiagnosticOutput);
   TextDiagnosticPrinter DiagPrinter(DiagnosticsOS, DiagOpts.release());
 
-  if (computeDependencies(WorkingDirectory, CommandLine, Consumer, DiagPrinter,
-                          ModuleName))
+  if (computeDependencies(WorkingDirectory, CommandLine, Consumer, Controller,
+                          DiagPrinter, ModuleName))
     return llvm::Error::success();
   return llvm::make_error<llvm::StringError>(DiagnosticsOS.str(),
                                              llvm::inconvertibleErrorCode());
@@ -644,8 +652,8 @@ static bool forEachDriverJob(
 
 bool DependencyScanningWorker::computeDependencies(
     StringRef WorkingDirectory, const std::vector<std::string> &CommandLine,
-    DependencyConsumer &Consumer, DiagnosticConsumer &DC,
-    llvm::Optional<StringRef> ModuleName) {
+    DependencyConsumer &Consumer, DependencyActionController &Controller,
+    DiagnosticConsumer &DC, llvm::Optional<StringRef> ModuleName) {
   // Reset what might have been modified in the previous worker invocation.
   BaseFS->setCurrentWorkingDirectory(WorkingDirectory);
 
@@ -701,12 +709,13 @@ bool DependencyScanningWorker::computeDependencies(
   // in-process; preserve the original value, which is
   // always true for a driver invocation.
   bool DisableFree = true;
-  DependencyScanningAction Action(
-      WorkingDirectory, Consumer, DepFS, DepCASFS, CacheFS, Format,
-      OptimizeArgs, EagerLoadModules, DisableFree,
-      /*EmitDependencyFile=*/false,
-      /*DiagGenerationAsCompilation=*/false, getCASOpts(),
-      ModuleName);
+  DependencyScanningAction Action(WorkingDirectory, Consumer, Controller, DepFS,
+                                  DepCASFS, CacheFS,
+                                  Format, OptimizeArgs, EagerLoadModules,
+                                  DisableFree,
+                                  /*EmitDependencyFile=*/false,
+                                  /*DiagGenerationAsCompilation=*/false, getCASOpts(),
+                                  ModuleName);
   bool Success = forEachDriverJob(
       FinalCommandLine, *Diags, *FileMgr, [&](const driver::Command &Cmd) {
         if (StringRef(Cmd.getCreator().getName()) != "clang") {
@@ -745,10 +754,13 @@ bool DependencyScanningWorker::computeDependencies(
   return Success && Action.hasScanned();
 }
 
+DependencyActionController::~DependencyActionController() {}
+
 void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
     std::shared_ptr<CompilerInvocation> Invocation, StringRef WorkingDirectory,
-    DependencyConsumer &DepsConsumer, DiagnosticConsumer &DiagsConsumer,
-    raw_ostream *VerboseOS, bool DiagGenerationAsCompilation) {
+    DependencyConsumer &DepsConsumer, DependencyActionController &Controller,
+    DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
+    bool DiagGenerationAsCompilation) {
   BaseFS->setCurrentWorkingDirectory(WorkingDirectory);
 
   // Adjust the invocation.
@@ -775,7 +787,8 @@ void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
   // FIXME: EmitDependencyFile should only be set when it's for a real
   // compilation.
   DependencyScanningAction Action(
-      WorkingDirectory, DepsConsumer, DepFS, DepCASFS, CacheFS, Format,
+      WorkingDirectory, DepsConsumer, Controller, DepFS, DepCASFS, CacheFS,
+      Format,
       /*OptimizeArgs=*/false, /*DisableFree=*/false, EagerLoadModules,
       /*EmitDependencyFile=*/!DepFile.empty(), DiagGenerationAsCompilation,
       getCASOpts(),

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -1,0 +1,455 @@
+//===- IncludeTreeActionController.cpp ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CachingActions.h"
+#include "clang/CAS/IncludeTree.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Lex/Preprocessor.h"
+#include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/PrefixMapper.h"
+#include "llvm/Support/PrefixMappingFileSystem.h"
+
+using namespace clang;
+using namespace tooling;
+using namespace dependencies;
+using llvm::Error;
+
+namespace {
+class IncludeTreeActionController : public CallbackActionController {
+public:
+  IncludeTreeActionController(cas::ObjectStore &DB,
+                              DepscanPrefixMapping PrefixMapping)
+      : CallbackActionController(nullptr), DB(DB),
+        PrefixMapping(std::move(PrefixMapping)) {}
+
+  Expected<cas::IncludeTreeRoot> getIncludeTree();
+
+private:
+  Error initialize(CompilerInstance &ScanInstance,
+                   CompilerInvocation &NewInvocation) override;
+
+  void enteredInclude(Preprocessor &PP, FileID FID) override;
+
+  void exitedInclude(Preprocessor &PP, FileID IncludedBy, FileID Include,
+                     SourceLocation ExitLoc) override;
+
+  void handleHasIncludeCheck(Preprocessor &PP, bool Result) override;
+
+  const DepscanPrefixMapping *getPrefixMapping() override {
+    return &PrefixMapping;
+  }
+
+  Error finalize(CompilerInstance &ScanInstance,
+                 CompilerInvocation &NewInvocation) override;
+
+  Expected<cas::ObjectRef> getObjectForFile(Preprocessor &PP, FileID FID);
+  Expected<cas::ObjectRef>
+  getObjectForFileNonCached(FileManager &FM, const SrcMgr::FileInfo &FI);
+  Expected<cas::ObjectRef> getObjectForBuffer(const SrcMgr::FileInfo &FI);
+  Expected<cas::ObjectRef> addToFileList(FileManager &FM, const FileEntry *FE);
+
+  struct FilePPState {
+    SrcMgr::CharacteristicKind FileCharacteristic;
+    cas::ObjectRef File;
+    SmallVector<std::pair<cas::ObjectRef, uint32_t>, 6> Includes;
+    llvm::SmallBitVector HasIncludeChecks;
+  };
+
+  Expected<cas::IncludeTree> getCASTreeForFileIncludes(FilePPState &&PPState);
+
+  Expected<cas::IncludeFile> createIncludeFile(StringRef Filename,
+                                               cas::ObjectRef Contents);
+
+  bool hasErrorOccurred() const { return ErrorToReport.has_value(); }
+
+  template <typename T> Optional<T> check(Expected<T> &&E) {
+    if (!E) {
+      ErrorToReport = E.takeError();
+      return None;
+    }
+    return *E;
+  }
+
+  cas::ObjectStore &DB;
+  DepscanPrefixMapping PrefixMapping;
+  llvm::PrefixMapper PrefixMapper;
+  Optional<cas::ObjectRef> PCHRef;
+  bool StartedEnteringIncludes = false;
+  // When a PCH is used this lists the filenames of the included files as they
+  // are recorded in the PCH, ordered by \p FileEntry::UID index.
+  SmallVector<StringRef> PreIncludedFileNames;
+  llvm::BitVector SeenIncludeFiles;
+  SmallVector<cas::IncludeFileList::FileEntry> IncludedFiles;
+  Optional<cas::ObjectRef> PredefinesBufferRef;
+  SmallVector<FilePPState> IncludeStack;
+  llvm::DenseMap<const FileEntry *, Optional<cas::ObjectRef>> ObjectForFile;
+  Optional<llvm::Error> ErrorToReport;
+};
+
+/// A utility for adding \c PPCallbacks to a compiler instance at the
+/// appropriate time.
+struct PPCallbacksDependencyCollector : public DependencyCollector {
+  using MakeCB =
+      llvm::unique_function<std::unique_ptr<PPCallbacks>(Preprocessor &)>;
+  MakeCB Create;
+  PPCallbacksDependencyCollector(MakeCB Create) : Create(std::move(Create)) {}
+  void attachToPreprocessor(Preprocessor &PP) final {
+    std::unique_ptr<PPCallbacks> CB = Create(PP);
+    assert(CB);
+    PP.addPPCallbacks(std::move(CB));
+  }
+};
+
+struct IncludeTreePPCallbacks : public PPCallbacks {
+  DependencyActionController &Controller;
+  Preprocessor &PP;
+
+public:
+  IncludeTreePPCallbacks(DependencyActionController &Controller,
+                         Preprocessor &PP)
+      : Controller(Controller), PP(PP) {}
+
+  void LexedFileChanged(FileID FID, LexedFileChangeReason Reason,
+                        SrcMgr::CharacteristicKind FileType, FileID PrevFID,
+                        SourceLocation Loc) override {
+    switch (Reason) {
+    case LexedFileChangeReason::EnterFile:
+      Controller.enteredInclude(PP, FID);
+      break;
+    case LexedFileChangeReason::ExitFile: {
+      Controller.exitedInclude(PP, FID, PrevFID, Loc);
+      break;
+    }
+    }
+  }
+
+  void HasInclude(SourceLocation Loc, StringRef FileName, bool IsAngled,
+                  Optional<FileEntryRef> File,
+                  SrcMgr::CharacteristicKind FileType) override {
+    Controller.handleHasIncludeCheck(PP, File.has_value());
+  }
+};
+} // namespace
+
+/// The PCH recorded file paths with canonical paths, create a VFS that
+/// allows remapping back to the non-canonical source paths so that they are
+/// found during dep-scanning.
+void dependencies::addReversePrefixMappingFileSystem(
+    const llvm::PrefixMapper &PrefixMapper, CompilerInstance &ScanInstance) {
+  llvm::PrefixMapper ReverseMapper;
+  ReverseMapper.addInverseRange(PrefixMapper.getMappings());
+  ReverseMapper.sort();
+  std::unique_ptr<llvm::vfs::FileSystem> FS =
+      llvm::vfs::createPrefixMappingFileSystem(
+          std::move(ReverseMapper), &ScanInstance.getVirtualFileSystem());
+
+  ScanInstance.getFileManager().setVirtualFileSystem(std::move(FS));
+}
+
+Error IncludeTreeActionController::initialize(
+    CompilerInstance &ScanInstance, CompilerInvocation &NewInvocation) {
+  if (Error E =
+          PrefixMapping.configurePrefixMapper(NewInvocation, PrefixMapper))
+    return E;
+
+  auto ensurePathRemapping = [&]() {
+    if (PrefixMapper.empty())
+      return;
+
+    PreprocessorOptions &PPOpts = ScanInstance.getPreprocessorOpts();
+    if (PPOpts.Includes.empty() && PPOpts.ImplicitPCHInclude.empty())
+      return;
+
+    addReversePrefixMappingFileSystem(PrefixMapper, ScanInstance);
+
+    // These are written in the predefines buffer, so we need to remap them.
+    for (std::string &Include : PPOpts.Includes)
+      PrefixMapper.mapInPlace(Include);
+  };
+  ensurePathRemapping();
+
+  // Attach callbacks for the IncludeTree of the TU. The preprocessor
+  // does not exist yet, so we need to indirect this via DependencyCollector.
+  auto DC = std::make_shared<PPCallbacksDependencyCollector>(
+      [this](Preprocessor &PP) {
+        return std::make_unique<IncludeTreePPCallbacks>(*this, PP);
+      });
+  ScanInstance.addDependencyCollector(std::move(DC));
+
+  return Error::success();
+}
+
+void IncludeTreeActionController::enteredInclude(Preprocessor &PP, FileID FID) {
+  if (hasErrorOccurred())
+    return;
+
+  if (!StartedEnteringIncludes) {
+    StartedEnteringIncludes = true;
+
+    // Get the included files (coming from a PCH), and keep track of the
+    // filenames that were recorded in the PCH.
+    for (const FileEntry *FE : PP.getIncludedFiles()) {
+      unsigned UID = FE->getUID();
+      if (UID >= PreIncludedFileNames.size())
+        PreIncludedFileNames.resize(UID + 1);
+      PreIncludedFileNames[UID] = FE->getName();
+    }
+  }
+
+  Optional<cas::ObjectRef> FileRef = check(getObjectForFile(PP, FID));
+  if (!FileRef)
+    return;
+  const SrcMgr::FileInfo &FI =
+      PP.getSourceManager().getSLocEntry(FID).getFile();
+  IncludeStack.push_back({FI.getFileCharacteristic(), *FileRef, {}, {}});
+}
+
+void IncludeTreeActionController::exitedInclude(Preprocessor &PP,
+                                                FileID IncludedBy,
+                                                FileID Include,
+                                                SourceLocation ExitLoc) {
+  if (hasErrorOccurred())
+    return;
+
+  assert(*check(getObjectForFile(PP, Include)) == IncludeStack.back().File);
+  Optional<cas::IncludeTree> IncludeTree =
+      check(getCASTreeForFileIncludes(IncludeStack.pop_back_val()));
+  if (!IncludeTree)
+    return;
+  assert(*check(getObjectForFile(PP, IncludedBy)) == IncludeStack.back().File);
+  SourceManager &SM = PP.getSourceManager();
+  std::pair<FileID, unsigned> LocInfo = SM.getDecomposedExpansionLoc(ExitLoc);
+  IncludeStack.back().Includes.push_back(
+      {IncludeTree->getRef(), LocInfo.second});
+}
+
+void IncludeTreeActionController::handleHasIncludeCheck(Preprocessor &PP,
+                                                        bool Result) {
+  if (hasErrorOccurred())
+    return;
+
+  IncludeStack.back().HasIncludeChecks.push_back(Result);
+}
+
+Error IncludeTreeActionController::finalize(CompilerInstance &ScanInstance,
+                                            CompilerInvocation &NewInvocation) {
+  FileManager &FM = ScanInstance.getFileManager();
+
+  auto addFile = [&](StringRef FilePath,
+                     bool IgnoreFileError = false) -> Error {
+    llvm::ErrorOr<const FileEntry *> FE = FM.getFile(FilePath);
+    if (!FE) {
+      if (IgnoreFileError)
+        return Error::success();
+      return llvm::errorCodeToError(FE.getError());
+    }
+    Optional<cas::ObjectRef> Ref;
+    return addToFileList(FM, *FE).moveInto(Ref);
+  };
+
+  for (StringRef FilePath : NewInvocation.getLangOpts()->NoSanitizeFiles) {
+    if (Error E = addFile(FilePath))
+      return E;
+  }
+  // Add profile files.
+  // FIXME: Do not have the logic here to determine which path should be set
+  // but ideally only the path needed for the compilation is set and we already
+  // checked the file needed exists. Just try load and ignore errors.
+  if (Error E = addFile(NewInvocation.getCodeGenOpts().ProfileInstrumentUsePath,
+                        /*IgnoreFileError=*/true))
+    return E;
+  if (Error E = addFile(NewInvocation.getCodeGenOpts().SampleProfileFile,
+                        /*IgnoreFileError=*/true))
+    return E;
+  if (Error E = addFile(NewInvocation.getCodeGenOpts().ProfileRemappingFile,
+                        /*IgnoreFileError=*/true))
+    return E;
+
+  StringRef Sysroot = NewInvocation.getHeaderSearchOpts().Sysroot;
+  if (!Sysroot.empty()) {
+    // Include 'SDKSettings.json', if it exists, to accomodate availability
+    // checks during the compilation.
+    llvm::SmallString<256> FilePath = Sysroot;
+    llvm::sys::path::append(FilePath, "SDKSettings.json");
+    if (Error E = addFile(FilePath, /*IgnoreFileError*/ true))
+      return E;
+  }
+
+  auto FinishIncludeTree = [&]() -> Error {
+    PreprocessorOptions &PPOpts = NewInvocation.getPreprocessorOpts();
+    if (PPOpts.ImplicitPCHInclude.empty())
+      return Error::success(); // no need for additional work.
+
+    // Go through all the recorded included files; we'll get additional files
+    // from the PCH that we need to include in the file list, in case they are
+    // referenced while replaying the include-tree.
+    SmallVector<const FileEntry *, 32> NotSeenIncludes;
+    for (const FileEntry *FE :
+         ScanInstance.getPreprocessor().getIncludedFiles()) {
+      if (FE->getUID() >= SeenIncludeFiles.size() ||
+          !SeenIncludeFiles[FE->getUID()])
+        NotSeenIncludes.push_back(FE);
+    }
+    // Sort so we can visit the files in deterministic order.
+    llvm::sort(NotSeenIncludes, [](const FileEntry *LHS, const FileEntry *RHS) {
+      return LHS->getUID() < RHS->getUID();
+    });
+
+    for (const FileEntry *FE : NotSeenIncludes) {
+      auto FileNode = addToFileList(FM, FE);
+      if (!FileNode)
+        return FileNode.takeError();
+    }
+
+    llvm::ErrorOr<Optional<cas::ObjectRef>> CASContents =
+        FM.getObjectRefForFileContent(PPOpts.ImplicitPCHInclude);
+    if (!CASContents)
+      return llvm::errorCodeToError(CASContents.getError());
+    PCHRef = **CASContents;
+
+    return Error::success();
+  };
+
+  if (Error E = FinishIncludeTree())
+    return E;
+
+  auto IncludeTreeRoot = getIncludeTree();
+  if (!IncludeTreeRoot)
+    return IncludeTreeRoot.takeError();
+
+  // FIXME: use configureInvocationForCaching
+  NewInvocation.getFrontendOpts().CASIncludeTreeID =
+      IncludeTreeRoot->getID().toString();
+
+  return Error::success();
+}
+
+Expected<cas::ObjectRef>
+IncludeTreeActionController::getObjectForFile(Preprocessor &PP, FileID FID) {
+  SourceManager &SM = PP.getSourceManager();
+  const SrcMgr::FileInfo &FI = SM.getSLocEntry(FID).getFile();
+  if (PP.getPredefinesFileID() == FID) {
+    if (!PredefinesBufferRef) {
+      auto Ref = getObjectForBuffer(FI);
+      if (!Ref)
+        return Ref.takeError();
+      PredefinesBufferRef = *Ref;
+    }
+    return *PredefinesBufferRef;
+  }
+  assert(FI.getContentCache().OrigEntry);
+  auto &FileRef = ObjectForFile[FI.getContentCache().OrigEntry];
+  if (!FileRef) {
+    auto Ref = getObjectForFileNonCached(SM.getFileManager(), FI);
+    if (!Ref)
+      return Ref.takeError();
+    FileRef = *Ref;
+  }
+  return *FileRef;
+}
+
+Expected<cas::ObjectRef> IncludeTreeActionController::getObjectForFileNonCached(
+    FileManager &FM, const SrcMgr::FileInfo &FI) {
+  const FileEntry *FE = FI.getContentCache().OrigEntry;
+  assert(FE);
+
+  // Mark the include as already seen.
+  if (FE->getUID() >= SeenIncludeFiles.size())
+    SeenIncludeFiles.resize(FE->getUID() + 1);
+  SeenIncludeFiles.set(FE->getUID());
+
+  return addToFileList(FM, FE);
+}
+
+Expected<cas::ObjectRef>
+IncludeTreeActionController::getObjectForBuffer(const SrcMgr::FileInfo &FI) {
+  // This is a non-file buffer, like the predefines.
+  auto Ref = DB.storeFromString(
+      {}, FI.getContentCache().getBufferIfLoaded()->getBuffer());
+  if (!Ref)
+    return Ref.takeError();
+  Expected<cas::IncludeFile> FileNode = createIncludeFile(FI.getName(), *Ref);
+  if (!FileNode)
+    return FileNode.takeError();
+  return FileNode->getRef();
+}
+
+Expected<cas::ObjectRef>
+IncludeTreeActionController::addToFileList(FileManager &FM,
+                                           const FileEntry *FE) {
+  StringRef Filename = FE->getName();
+  llvm::ErrorOr<Optional<cas::ObjectRef>> CASContents =
+      FM.getObjectRefForFileContent(Filename);
+  if (!CASContents)
+    return llvm::errorCodeToError(CASContents.getError());
+  assert(*CASContents);
+
+  auto addFile = [&](StringRef Filename) -> Expected<cas::ObjectRef> {
+    assert(!Filename.empty());
+    auto FileNode = createIncludeFile(Filename, **CASContents);
+    if (!FileNode)
+      return FileNode.takeError();
+    IncludedFiles.push_back(
+        {FileNode->getRef(),
+         static_cast<cas::IncludeFileList::FileSizeTy>(FE->getSize())});
+    return FileNode->getRef();
+  };
+
+  // Check whether another path coming from the PCH is associated with the same
+  // file.
+  unsigned UID = FE->getUID();
+  if (UID < PreIncludedFileNames.size() && !PreIncludedFileNames[UID].empty() &&
+      PreIncludedFileNames[UID] != Filename) {
+    auto FileNode = addFile(PreIncludedFileNames[UID]);
+    if (!FileNode)
+      return FileNode.takeError();
+  }
+
+  return addFile(Filename);
+}
+
+Expected<cas::IncludeTree>
+IncludeTreeActionController::getCASTreeForFileIncludes(FilePPState &&PPState) {
+  return cas::IncludeTree::create(DB, PPState.FileCharacteristic, PPState.File,
+                                  PPState.Includes, PPState.HasIncludeChecks);
+}
+
+Expected<cas::IncludeFile>
+IncludeTreeActionController::createIncludeFile(StringRef Filename,
+                                               cas::ObjectRef Contents) {
+  SmallString<256> MappedPath;
+  if (!PrefixMapper.empty()) {
+    PrefixMapper.map(Filename, MappedPath);
+    Filename = MappedPath;
+  }
+  return cas::IncludeFile::create(DB, Filename, std::move(Contents));
+}
+
+Expected<cas::IncludeTreeRoot> IncludeTreeActionController::getIncludeTree() {
+  if (ErrorToReport)
+    return std::move(*ErrorToReport);
+
+  assert(IncludeStack.size() == 1);
+  Expected<cas::IncludeTree> MainIncludeTree =
+      getCASTreeForFileIncludes(IncludeStack.pop_back_val());
+  if (!MainIncludeTree)
+    return MainIncludeTree.takeError();
+  auto FileList = cas::IncludeFileList::create(DB, IncludedFiles);
+  if (!FileList)
+    return FileList.takeError();
+
+  return cas::IncludeTreeRoot::create(DB, MainIncludeTree->getRef(),
+                                      FileList->getRef(), PCHRef);
+}
+
+std::unique_ptr<DependencyActionController>
+dependencies::createIncludeTreeActionController(
+    cas::ObjectStore &DB, DepscanPrefixMapping PrefixMapping) {
+  return std::make_unique<IncludeTreeActionController>(
+      DB, std::move(PrefixMapping));
+}

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -60,16 +60,16 @@ static std::vector<std::string> splitString(std::string S, char Separator) {
 void ModuleDepCollector::addOutputPaths(CompilerInvocation &CI,
                                         ModuleDeps &Deps) {
   CI.getFrontendOpts().OutputFile =
-      Consumer.lookupModuleOutput(Deps.ID, ModuleOutputKind::ModuleFile);
+      Controller.lookupModuleOutput(Deps.ID, ModuleOutputKind::ModuleFile);
   if (!CI.getDiagnosticOpts().DiagnosticSerializationFile.empty())
     CI.getDiagnosticOpts().DiagnosticSerializationFile =
-        Consumer.lookupModuleOutput(
+        Controller.lookupModuleOutput(
             Deps.ID, ModuleOutputKind::DiagnosticSerializationFile);
   if (!CI.getDependencyOutputOpts().OutputFile.empty()) {
-    CI.getDependencyOutputOpts().OutputFile =
-        Consumer.lookupModuleOutput(Deps.ID, ModuleOutputKind::DependencyFile);
+    CI.getDependencyOutputOpts().OutputFile = Controller.lookupModuleOutput(
+        Deps.ID, ModuleOutputKind::DependencyFile);
     CI.getDependencyOutputOpts().Targets =
-        splitString(Consumer.lookupModuleOutput(
+        splitString(Controller.lookupModuleOutput(
                         Deps.ID, ModuleOutputKind::DependencyTargets),
                     '\0');
     if (!CI.getDependencyOutputOpts().OutputFile.empty() &&
@@ -220,7 +220,7 @@ void ModuleDepCollector::addModuleFiles(
     CompilerInvocation &CI, ArrayRef<ModuleID> ClangModuleDeps) const {
   for (const ModuleID &MID : ClangModuleDeps) {
     std::string PCMPath =
-        Consumer.lookupModuleOutput(MID, ModuleOutputKind::ModuleFile);
+        Controller.lookupModuleOutput(MID, ModuleOutputKind::ModuleFile);
 
     ModuleDeps *MD = ModuleDepsByID.lookup(MID);
     assert(MD && "Inconsistent dependency info");
@@ -499,7 +499,7 @@ ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
 
   auto &Diags = MDC.ScanInstance.getDiagnostics();
 
-  if (auto E = MDC.Consumer.finalizeModuleInvocation(CI, MD))
+  if (auto E = MDC.Controller.finalizeModuleInvocation(CI, MD))
     Diags.Report(diag::err_cas_depscan_failed) << std::move(E);
 
   MDC.associateWithContextHash(CI, MD);
@@ -603,10 +603,11 @@ void ModuleDepCollectorPP::addAffectingModule(
 ModuleDepCollector::ModuleDepCollector(
     std::unique_ptr<DependencyOutputOptions> Opts,
     CompilerInstance &ScanInstance, DependencyConsumer &C,
-    CompilerInvocation OriginalCI, bool OptimizeArgs, bool EagerLoadModules)
-    : ScanInstance(ScanInstance), Consumer(C), Opts(std::move(Opts)),
-      OriginalInvocation(std::move(OriginalCI)), OptimizeArgs(OptimizeArgs),
-      EagerLoadModules(EagerLoadModules) {}
+    DependencyActionController &Controller, CompilerInvocation OriginalCI,
+    bool OptimizeArgs, bool EagerLoadModules)
+    : ScanInstance(ScanInstance), Consumer(C), Controller(Controller),
+      Opts(std::move(Opts)), OriginalInvocation(std::move(OriginalCI)),
+      OptimizeArgs(OptimizeArgs), EagerLoadModules(EagerLoadModules) {}
 
 void ModuleDepCollector::attachToPreprocessor(Preprocessor &PP) {
   PP.addPPCallbacks(std::make_unique<ModuleDepCollectorPP>(*this));

--- a/clang/test/ClangScanDeps/include-tree-prefix-mapping.c
+++ b/clang/test/ClangScanDeps/include-tree-prefix-mapping.c
@@ -2,7 +2,7 @@
 // RUN: split-file %s %t
 // RUN: sed -e "s|DIR|%t|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb.json.template > %t/cdb.json
 
-// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-include-tree -in-memory-cas \
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-include-tree -cas-path %t/cas \
 // RUN:   -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc > %t/result.txt
 // RUN: FileCheck %s -input-file %t/result.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK
 
@@ -13,6 +13,59 @@
 // CHECK: /^src{{[/\\]}}top.h
 // CHECK: /^tc{{[/\\]}}lib{{[/\\]}}clang{{[/\\]}}{{.*}}{{[/\\]}}include{{[/\\]}}stdarg.h
 // CHECK: /^sdk{{[/\\]}}usr{{[/\\]}}include{{[/\\]}}stdlib.h
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -format experimental-include-tree-full -cas-path %t/cas \
+// RUN:   -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc > %t/deps.json
+
+// RUN: cat %t/result.txt > %t/full.txt
+// RUN: echo "FULL DEPS START" >> %t/full.txt
+// RUN: cat %t/deps.json | sed 's:\\\\\?:/:g' >> %t/full.txt
+
+// RUN: FileCheck %s -DPREFIX=%/t -DSDK_PREFIX=%S/Inputs/SDK -check-prefix=FULL -input-file %t/full.txt
+
+// Capture the tree id from experimental-include-tree ; ensure that it matches
+// the result from experimental-full.
+// FULL: [[TREE_ID:llvmcas://[[:xdigit:]]+]] - [[PREFIX]]/t.c
+// FULL: FULL DEPS START
+
+// FULL-NEXT: {
+// FULL-NEXT:   "modules": []
+// FULL-NEXT:   "translation-units": [
+// FULL-NEXT:     {
+// FULL-NEXT:       "commands": [
+// FULL-NEXT:         {
+// FULL:                "clang-module-deps": []
+// FULL:                "command-line": [
+// FULL-NEXT:             "-cc1"
+// FULL:                  "-fcas-path"
+// FULL-NEXT:             "[[PREFIX]]/cas"
+// FULL:                  "-disable-free"
+// FULL:                  "-fcas-include-tree"
+// FULL-NEXT:             "[[TREE_ID]]"
+// FULL:                  "-fcache-compile-job"
+// FULL:                  "-fsyntax-only"
+// FULL:                  "-x"
+// FULL-NEXT:             "c"
+// FULL:                  "-isysroot"
+// FULL-NEXT:             "/^sdk"
+// FULL:                ]
+// FULL:                "file-deps": [
+// FULL-DAG:              "[[PREFIX]]/t.c"
+// FULL-DAG:              "[[PREFIX]]/top.h"
+// FULL-DAG:              "{{.*}}/stdarg.h"
+// FULL-DAG:              "[[SDK_PREFIX]]/usr/include/stdlib.h"
+// FULL:                ]
+// FULL:                "input-file": "[[PREFIX]]/t.c"
+// FULL:              }
+// FULL:            ]
+// FULL:          }
+// FULL:        ]
+// FULL:      }
+
+// Build the include-tree command
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: %clang @%t/tu.rsp
 
 //--- cdb.json.template
 [

--- a/clang/test/ClangScanDeps/include-tree-with-pch.c
+++ b/clang/test/ClangScanDeps/include-tree-with-pch.c
@@ -20,6 +20,59 @@
 // CHECK-NEXT: [[PREFIX]]/n3.h
 // CHECK-NOT: [[PREFIX]]
 
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-include-tree-full -cas-path %t/cas > %t/deps.json
+
+// RUN: cat %t/result.txt > %t/full.txt
+// RUN: echo "FULL DEPS START" >> %t/full.txt
+// RUN: cat %t/deps.json | sed 's:\\\\\?:/:g' >> %t/full.txt
+
+// RUN: FileCheck %s -DPREFIX=%/t -check-prefix=FULL -input-file %t/full.txt
+
+// Capture the tree id from experimental-include-tree ; ensure that it matches
+// the result from experimental-full.
+// FULL: [[TREE_ID:llvmcas://[[:xdigit:]]+]] - [[PREFIX]]/t.c
+// FULL: FULL DEPS START
+
+// FULL-NEXT: {
+// FULL-NEXT:   "modules": []
+// FULL-NEXT:   "translation-units": [
+// FULL-NEXT:     {
+// FULL-NEXT:       "commands": [
+// FULL-NEXT:         {
+// FULL:                "clang-module-deps": []
+// FULL:                "command-line": [
+// FULL-NEXT:             "-cc1"
+// FULL:                  "-fcas-path"
+// FULL-NEXT:             "[[PREFIX]]/cas"
+// FULL:                  "-disable-free"
+// FULL:                  "-fcas-include-tree"
+// FULL-NEXT:             "[[TREE_ID]]"
+// FULL:                  "-fcache-compile-job"
+// FULL:                  "-fsyntax-only"
+// FULL:                  "-x"
+// FULL-NEXT:             "c"
+// FULL-NOT:              "t.c"
+// FULL:                  "-main-file-name"
+// FULL-NEXT:             "t.c"
+// FULL-NOT:              "t.c"
+// FULL:                ]
+// FULL:                "executable": "clang"
+// FULL:                "file-deps": [
+// FULL-NEXT:             "[[PREFIX]]/t.c"
+// FULL-NEXT:             "[[PREFIX]]/t.h"
+// FULL-NEXT:             "[[PREFIX]]/prefix.pch"
+// FULL-NEXT:           ]
+// FULL:                "input-file": "[[PREFIX]]/t.c"
+// FULL:              }
+// FULL:            ]
+// FULL:          }
+// FULL:        ]
+// FULL:      }
+
+// Build the include-tree command
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: %clang @%t/tu.rsp
+
 //--- prefix.h
 #include "n1.h"
 #import "n2.h"

--- a/clang/test/ClangScanDeps/include-tree.c
+++ b/clang/test/ClangScanDeps/include-tree.c
@@ -28,6 +28,63 @@
 // ORDER-NEXT: [[PREFIX]]/n3.h
 // ORDER-NOT: [[PREFIX]]
 
+// Full dependency output
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-include-tree-full -cas-path %t/cas > %t/deps.json
+
+// RUN: cat %t/result1.txt > %t/full.txt
+// RUN: echo "FULL DEPS START" >> %t/full.txt
+// RUN: cat %t/deps.json | sed 's:\\\\\?:/:g' >> %t/full.txt
+
+// RUN: FileCheck %s -DPREFIX=%/t -check-prefix=FULL -input-file %t/full.txt
+
+// Capture the tree id from experimental-include-tree ; ensure that it matches
+// the result from experimental-full.
+// FULL: [[TREE_ID:llvmcas://[[:xdigit:]]+]] - [[PREFIX]]/t.c
+// FULL: FULL DEPS START
+
+// FULL-NEXT: {
+// FULL-NEXT:   "modules": []
+// FULL-NEXT:   "translation-units": [
+// FULL-NEXT:     {
+// FULL-NEXT:       "commands": [
+// FULL-NEXT:         {
+// FULL:                "clang-module-deps": []
+// FULL:                "command-line": [
+// FULL-NEXT:             "-cc1"
+// FULL:                  "-fcas-path"
+// FULL-NEXT:             "[[PREFIX]]/cas"
+// FULL:                  "-disable-free"
+// FULL:                  "-fcas-include-tree"
+// FULL-NEXT:             "[[TREE_ID]]"
+// FULL:                  "-fcache-compile-job"
+// FULL:                  "-fsyntax-only"
+// FULL:                  "-x"
+// FULL-NEXT:             "c"
+// FULL-NOT:              "t.c"
+// FULL:                  "-main-file-name"
+// FULL-NEXT:             "t.c"
+// FULL-NOT:              "t.c"
+// FULL:                ]
+// FULL:                "executable": "clang"
+// FULL:                "file-deps": [
+// FULL-NEXT:             "[[PREFIX]]/t.c"
+// FULL-NEXT:             "[[PREFIX]]/top.h"
+// FULL-NEXT:             "[[PREFIX]]/n1.h"
+// FULL-NEXT:             "[[PREFIX]]/n2.h"
+// FULL-NEXT:             "[[PREFIX]]/n3.h"
+// FULL-NEXT:             "[[PREFIX]]/n3.h"
+// FULL-NEXT:             "[[PREFIX]]/n2.h"
+// FULL-NEXT:           ]
+// FULL:                "input-file": "[[PREFIX]]/t.c"
+// FULL:              }
+// FULL:            ]
+// FULL:          }
+// FULL:        ]
+// FULL:      }
+
+// Build the include-tree command
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: %clang @%t/tu.rsp
 
 //--- cdb.json.template
 [

--- a/clang/test/Index/Core/scan-deps-cas.m
+++ b/clang/test/Index/Core/scan-deps-cas.m
@@ -1,11 +1,22 @@
 // RUN: rm -rf %t.mcp %t
-// RUN: echo %S > %t.result
-//
+
 // RUN: c-index-test core --scan-deps %S -output-dir=%t -cas-path %t/cas \
 // RUN:  -- %clang -c -I %S/Inputs/module \
 // RUN:     -fmodules -fmodules-cache-path=%t.mcp \
-// RUN:     -o FoE.o -x objective-c %s >> %t.result
-// RUN: cat %t.result | sed 's/\\/\//g' | FileCheck %s -DOUTPUTS=%/t
+// RUN:     -o FoE.o -x objective-c %s > %t.result
+// RUN: cat %t.result | sed 's/\\/\//g' | FileCheck %s -DPREFIX=%S -DOUTPUTS=%/t
+
+// RUN: env CLANG_CACHE_USE_CASFS_DEPSCAN=1 c-index-test core --scan-deps %S -output-dir=%t -cas-path %t/cas \
+// RUN:  -- %clang -c -I %S/Inputs/module \
+// RUN:     -fmodules -fmodules-cache-path=%t.mcp \
+// RUN:     -o FoE.o -x objective-c %s > %t.casfs.result
+// RUN: cat %t.casfs.result | sed 's/\\/\//g' | FileCheck %s -DPREFIX=%S -DOUTPUTS=%/t
+
+// FIXME: enable modules when supported.
+// RUN: env CLANG_CACHE_USE_INCLUDE_TREE=1 c-index-test core --scan-deps %S -output-dir=%t -cas-path %t/cas \
+// RUN:  -- %clang -c -I %S/Inputs/module \
+// RUN:     -o FoE.o -x objective-c %s > %t.includetree.result
+// RUN: cat %t.includetree.result | sed 's/\\/\//g' | FileCheck %s -DPREFIX=%S -DOUTPUTS=%/t -check-prefix=INCLUDE_TREE
 
 // RUN: c-index-test core --scan-deps %S -output-dir=%t \
 // RUN:  -- %clang -c -I %S/Inputs/module \
@@ -15,10 +26,9 @@
 // NO_CAS-NOT: faction-cache
 // NO_CAS-NOT: fcache-compile-job
 
-@import ModA;
+#include "ModA.h"
 
-// CHECK: [[PREFIX:.*]]
-// CHECK-NEXT: modules:
+// CHECK:       modules:
 // CHECK-NEXT:   module:
 // CHECK-NEXT:     name: ModA
 // CHECK-NEXT:     context-hash: [[HASH_MOD_A:[A-Z0-9]+]]
@@ -52,3 +62,16 @@
 // CHECK-SAME:       -fcache-compile-job
 // CHECK-SAME:       -fmodule-file-cache-key [[PCM:.*ModA_.*pcm]] llvmcas://{{[[:xdigit:]]+}}
 // CHECK-SAME:       -fmodule-file={{(ModA=)?}}[[PCM]]
+
+// INCLUDE_TREE:      dependencies:
+// INCLUDE_TREE-NEXT:   command 0:
+// INCLUDE_TREE-NEXT:     context-hash: [[HASH_TU:[A-Z0-9]+]]
+// INCLUDE_TREE-NEXT:     module-deps:
+// INCLUDE_TREE-NEXT:     file-deps:
+// INCLUDE_TREE-NEXT:       [[PREFIX]]/scan-deps-cas.m
+// INCLUDE_TREE-NEXT:       [[PREFIX]]/Inputs/module/ModA.h
+// INCLUDE_TREE-NEXT:     build-args:
+// INCLUDE_TREE-SAME:       -cc1
+// INCLUDE_TREE-SAME:       -fcas-path
+// INCLUDE_TREE-SAME:       -fcas-include-tree llvmcas://{{[[:xdigit:]]+}}
+// INCLUDE_TREE-SAME:       -fcache-compile-job

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -539,7 +539,7 @@ public:
     ID.ContextHash = std::move(TUDeps.ID.ContextHash);
     ID.FileDeps = std::move(TUDeps.FileDeps);
     ID.ModuleDeps = std::move(TUDeps.ClangModuleDeps);
-    ID.CASFileSystemRootID = TUDeps.CASFileSystemRootID;
+    ID.CASFileSystemRootID = std::move(TUDeps.CASFileSystemRootID);
     ID.DriverCommandLine = std::move(TUDeps.DriverCommandLine);
     ID.Commands = std::move(TUDeps.Commands);
 
@@ -637,7 +637,7 @@ public:
               {"command-line", Cmd.Arguments},
           };
           if (I.CASFileSystemRootID)
-            O.try_emplace("casfs-root-id", I.CASFileSystemRootID->toString());
+            O.try_emplace("casfs-root-id", I.CASFileSystemRootID);
           Commands.push_back(std::move(O));
         }
       } else {
@@ -650,7 +650,7 @@ public:
             {"command-line", I.DriverCommandLine},
         };
         if (I.CASFileSystemRootID)
-          O.try_emplace("casfs-root-id", I.CASFileSystemRootID->toString());
+          O.try_emplace("casfs-root-id", I.CASFileSystemRootID);
         Commands.push_back(std::move(O));
       }
       TUs.push_back(Object{
@@ -690,7 +690,7 @@ private:
     std::string ContextHash;
     std::vector<std::string> FileDeps;
     std::vector<ModuleID> ModuleDeps;
-    llvm::Optional<llvm::cas::CASID> CASFileSystemRootID;
+    llvm::Optional<std::string> CASFileSystemRootID;
     std::vector<std::string> DriverCommandLine;
     std::vector<Command> Commands;
   };

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -879,7 +879,7 @@ int ScanServer::listen() {
       ProduceIncludeTree
           ? tooling::dependencies::ScanningOutputFormat::IncludeTree
           : tooling::dependencies::ScanningOutputFormat::Tree,
-      CASOpts, Cache, FS,
+      CASOpts, CAS, Cache, FS,
       /*ReuseFileManager=*/false,
       /*SkipExcludedPPRanges=*/true);
 
@@ -1110,7 +1110,7 @@ static Expected<llvm::cas::CASID> scanAndUpdateCC1Inline(
       ProduceIncludeTree
           ? tooling::dependencies::ScanningOutputFormat::IncludeTree
           : tooling::dependencies::ScanningOutputFormat::Tree,
-      CASOpts, Cache, FS,
+      CASOpts, DB, Cache, FS,
       /*ReuseFileManager=*/false,
       /*SkipExcludedPPRanges=*/true);
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> UnderlyingFS =

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -22,16 +22,19 @@
 #include "clang/Tooling/DependencyScanning/DependencyScanningTool.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningWorker.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
+#include "llvm/Support/Process.h"
 
 using namespace clang;
 using namespace clang::tooling::dependencies;
 
 namespace {
 struct DependencyScannerServiceOptions {
-  ScanningOutputFormat Format = ScanningOutputFormat::Full;
+  ScanningOutputFormat ConfiguredFormat = ScanningOutputFormat::Full;
   CASOptions CASOpts;
   std::shared_ptr<cas::ObjectStore> CAS;
   std::shared_ptr<cas::ActionCache> Cache;
+
+  ScanningOutputFormat getFormat() const;
 };
 } // end anonymous namespace
 
@@ -93,7 +96,7 @@ void clang_experimental_DependencyScannerServiceOptions_dispose(
 
 void clang_experimental_DependencyScannerServiceOptions_setDependencyMode(
     CXDependencyScannerServiceOptions Opts, CXDependencyMode Mode) {
-  unwrap(Opts)->Format = unwrap(Mode);
+  unwrap(Opts)->ConfiguredFormat = unwrap(Mode);
 }
 
 void clang_experimental_DependencyScannerServiceOptions_setCASDatabases(
@@ -122,8 +125,25 @@ clang_experimental_DependencyScannerService_create_v0(CXDependencyMode Format) {
   IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> FS;
   return wrap(new DependencyScanningService(
       ScanningMode::DependencyDirectivesScan, unwrap(Format), CASOpts,
-      /*ActionCache=*/nullptr, FS,
+      /*CAS=*/nullptr, /*ActionCache=*/nullptr, FS,
       /*ReuseFilemanager=*/false));
+}
+
+ScanningOutputFormat DependencyScannerServiceOptions::getFormat() const {
+  if (ConfiguredFormat != ScanningOutputFormat::Full)
+    return ConfiguredFormat;
+
+  if (!CAS || !Cache)
+    return ConfiguredFormat;
+
+  if (llvm::sys::Process::GetEnv("CLANG_CACHE_USE_INCLUDE_TREE"))
+    return ScanningOutputFormat::FullIncludeTree;
+
+  if (llvm::sys::Process::GetEnv("CLANG_CACHE_USE_CASFS_DEPSCAN"))
+    return ScanningOutputFormat::FullTree;
+
+  // Note: default caching behaviour is currently cas-fs.
+  return ConfiguredFormat;
 }
 
 CXDependencyScannerService
@@ -137,11 +157,11 @@ clang_experimental_DependencyScannerService_create_v1(
     assert(unwrap(Opts)->CASOpts.getKind() != CASOptions::UnknownCAS &&
            "CAS and ActionCache must match CASOptions");
     FS = llvm::cantFail(
-        llvm::cas::createCachingOnDiskFileSystem(std::move(CAS)));
+        llvm::cas::createCachingOnDiskFileSystem(CAS));
   }
   return wrap(new DependencyScanningService(
-      ScanningMode::DependencyDirectivesScan, unwrap(Opts)->Format,
-      unwrap(Opts)->CASOpts, std::move(Cache), std::move(FS),
+      ScanningMode::DependencyDirectivesScan, unwrap(Opts)->getFormat(),
+      unwrap(Opts)->CASOpts, std::move(CAS), std::move(Cache), std::move(FS),
       /*ReuseFilemanager=*/false));
 }
 
@@ -257,7 +277,9 @@ static CXErrorCode getFileDependencies(CXDependencyScannerWorker W, int argc,
 
   DependencyScanningWorker *Worker = unwrap(W);
 
-  if (Worker->getScanningFormat() != ScanningOutputFormat::Full)
+  if (Worker->getScanningFormat() != ScanningOutputFormat::Full &&
+      Worker->getScanningFormat() != ScanningOutputFormat::FullTree &&
+      Worker->getScanningFormat() != ScanningOutputFormat::FullIncludeTree)
     return CXError_InvalidArguments;
 
   std::vector<std::string> Compilation{argv, argv + argc};

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -194,21 +194,23 @@ static CXErrorCode getFullDependencies(DependencyScanningWorker *Worker,
                                        llvm::Optional<StringRef> ModuleName,
                                        HandleTUDepsCallback HandleTUDeps) {
   llvm::StringSet<> AlreadySeen;
-  FullDependencyConsumer DepConsumer(AlreadySeen, LookupOutput,
-                                     Worker->getCASFS());
+  FullDependencyConsumer DepConsumer(AlreadySeen);
+  auto Controller = DependencyScanningTool::createActionController(
+      *Worker, std::move(LookupOutput), /*PrefixMapping=*/{});
 
   bool HasDiagConsumer = DiagConsumer;
   bool HasError = Error;
   assert(HasDiagConsumer ^ HasError && "Both DiagConsumer and Error provided");
 
   if (DiagConsumer) {
-    bool Result = Worker->computeDependencies(
-        WorkingDirectory, Compilation, DepConsumer, *DiagConsumer, ModuleName);
+    bool Result =
+        Worker->computeDependencies(WorkingDirectory, Compilation, DepConsumer,
+                                    *Controller, *DiagConsumer, ModuleName);
     if (!Result)
       return CXError_Failure;
   } else if (Error) {
-    auto Result = Worker->computeDependencies(WorkingDirectory, Compilation,
-                                              DepConsumer, ModuleName);
+    auto Result = Worker->computeDependencies(
+        WorkingDirectory, Compilation, DepConsumer, *Controller, ModuleName);
     if (Result) {
       *Error = cxstring::createDup(llvm::toString(std::move(Result)));
       return CXError_Failure;
@@ -255,7 +257,7 @@ static CXErrorCode getFileDependencies(CXDependencyScannerWorker W, int argc,
 
   DependencyScanningWorker *Worker = unwrap(W);
 
-  if (Worker->getFormat() != ScanningOutputFormat::Full)
+  if (Worker->getScanningFormat() != ScanningOutputFormat::Full)
     return CXError_InvalidArguments;
 
   std::vector<std::string> Compilation{argv, argv + argc};

--- a/clang/unittests/CAS/IncludeTreeTest.cpp
+++ b/clang/unittests/CAS/IncludeTreeTest.cpp
@@ -40,7 +40,7 @@ TEST(IncludeTree, IncludeTreeScan) {
 
   DependencyScanningService Service(ScanningMode::DependencyDirectivesScan,
                                     ScanningOutputFormat::IncludeTree,
-                                    CASOptions(), nullptr, nullptr);
+                                    CASOptions(), nullptr, nullptr, nullptr);
   DependencyScanningTool ScanTool(Service, std::move(VFS));
 
   std::vector<std::string> CommandLine = {"clang",

--- a/clang/unittests/Tooling/DependencyScannerTest.cpp
+++ b/clang/unittests/Tooling/DependencyScannerTest.cpp
@@ -233,7 +233,7 @@ TEST(DependencyScanner, ScanDepsWithFS) {
 
   DependencyScanningService Service(ScanningMode::DependencyDirectivesScan,
                                     ScanningOutputFormat::Make, CASOptions(),
-                                    nullptr, nullptr);
+                                    nullptr, nullptr, nullptr);
   DependencyScanningTool ScanTool(Service, VFS);
 
   std::string DepFile;
@@ -256,7 +256,7 @@ TEST(DependencyScanner, DepScanFSWithCASProvider) {
 
   DependencyScanningService Service(ScanningMode::DependencyDirectivesScan,
                                     ScanningOutputFormat::Make, CASOptions(),
-                                    nullptr, nullptr);
+                                    nullptr, nullptr, nullptr);
   {
     DependencyScanningWorkerFilesystem DepFS(Service.getSharedCache(),
                                              std::move(CASFS));


### PR DESCRIPTION
Cherry-pick recent dependency scanner improvements that enable using include-tree in clang-scan-deps for full dependencies, as well as optionally in libclang.

rdar://106670774