### PR TITLE
[next][IndexStore] Remove unnecessary link components

### DIFF
--- a/clang/tools/IndexStore/CMakeLists.txt
+++ b/clang/tools/IndexStore/CMakeLists.txt
@@ -8,11 +8,6 @@ set(SOURCES
   ../../include/indexstore/IndexStoreCXX.h
   )
 
-set(LIBS
-  clangIndex
-  clangIndexDataStore
-)
-
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
   set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/IndexStore.exports)
 endif()
@@ -28,11 +23,10 @@ add_clang_library(IndexStore SHARED
   ${SOURCES}
 
   LINK_LIBS
-  ${LIBS}
+  clangIndex
+  clangIndexDataStore
 
   LINK_COMPONENTS
-  ${LLVM_TARGETS_TO_BUILD}
-  Core
   Support
   )
 


### PR DESCRIPTION
The indexstore only depends on LLVM support. Only link to it rather than core and `LLVM_TARGETS_TO_BUILD`.

Resolves rdar://106575658.

(cherry picked from commit 8fd265290bfa7302aacb98e611f3da6513d53a7c)