### PR TITLE
[clang][cas] Scaffolding for modules with include-tree

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -36,6 +36,10 @@ def err_cas_missing_root_id : Error<
   "CAS missing expected root-id '%0'">, DefaultFatal;
 def err_cas_cannot_parse_root_id_for_module : Error<
   "CAS cannot parse root-id '%0' for module '%1'">, DefaultFatal;
+def err_cas_cannot_parse_include_tree_id : Error<
+  "CAS cannot parse include-tree-id '%0'">, DefaultFatal;
+def err_cas_missing_include_tree_id : Error<
+  "CAS missing expected include-tree '%0'">, DefaultFatal;
 
 def warn_clang_cache_disabled_caching: Warning<
   "caching disabled because %0">,

--- a/clang/include/clang/Basic/Module.h
+++ b/clang/include/clang/Basic/Module.h
@@ -209,6 +209,10 @@ private:
   /// scanner, if any.
   std::optional<std::string> CASFileSystemRootID;
 
+  /// The include-tree root ID for implicit modules built with the dependency
+  /// scanner, if any.
+  std::optional<std::string> IncludeTreeID;
+
   /// The top-level headers associated with this module.
   llvm::SmallSetVector<const FileEntry *, 2> TopHeaders;
 
@@ -656,6 +660,15 @@ public:
   void setCASFileSystemRootID(std::string ID) {
     assert(!getCASFileSystemRootID() || *getCASFileSystemRootID() == ID);
     getTopLevelModule()->CASFileSystemRootID = std::move(ID);
+  }
+
+  std::optional<std::string> getIncludeTreeID() const {
+    return getTopLevelModule()->IncludeTreeID;
+  }
+
+  void setIncludeTreeID(std::string ID) {
+    assert(!getIncludeTreeID() || *getIncludeTreeID() == ID);
+    getTopLevelModule()->IncludeTreeID = std::move(ID);
   }
 
   /// Retrieve the directory for which this module serves as the

--- a/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/clang/include/clang/Serialization/ASTBitCodes.h
@@ -41,7 +41,7 @@ namespace serialization {
 /// Version 4 of AST files also requires that the version control branch and
 /// revision match exactly, since there is no backward compatibility of
 /// AST files at this time.
-const unsigned VERSION_MAJOR = 25;
+const unsigned VERSION_MAJOR = 26;
 
 /// AST file minor version number supported by this version of
 /// Clang.
@@ -367,6 +367,10 @@ enum ControlRecordTypes {
   /// Record code for the (optional) CAS filesystem root ID for implicit modules
   /// built with the dependency scanner.
   CASFS_ROOT_ID,
+
+  /// Record code for the (optional) include-tree ID for implicit modules
+  /// built with the dependency scanner.
+  CAS_INCLUDE_TREE_ID,
 };
 
 /// Record types that occur within the options block inside

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -246,6 +246,11 @@ public:
     return false;
   }
 
+  /// Called for each CAS include-tree root ID.
+  ///
+  /// \returns true to indicate \p RootID is invalid, or false otherwise.
+  virtual bool readIncludeTreeID(StringRef ID, bool Complain) { return false; }
+
   /// Called for each module cache key.
   ///
   /// \returns true to indicate the key cannot be loaded.
@@ -300,6 +305,7 @@ public:
   bool visitInputFile(StringRef Filename, bool isSystem,
                       bool isOverridden, bool isExplicitModule) override;
   bool readCASFileSystemRootID(StringRef RootID, bool Complain) override;
+  bool readIncludeTreeID(StringRef ID, bool Complain) override;
   bool readModuleCacheKey(StringRef ModuleName, StringRef Filename,
                           StringRef CacheKey) override;
   void readModuleFileExtension(

--- a/clang/include/clang/Serialization/ModuleFile.h
+++ b/clang/include/clang/Serialization/ModuleFile.h
@@ -143,6 +143,10 @@ public:
   /// scanner, or empty.
   std::string CASFileSystemRootID;
 
+  /// The include-tree root ID for implicit modules built with the dependency
+  /// scanner, or empty.
+  std::string IncludeTreeID;
+
   /// The name of the module.
   std::string ModuleName;
 

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -70,6 +70,9 @@ struct TranslationUnitDeps {
   /// The CASID for input file dependency tree.
   std::optional<std::string> CASFileSystemRootID;
 
+  /// The include-tree for input file dependency tree.
+  std::optional<std::string> IncludeTreeID;
+
   /// The sequence of commands required to build the translation unit. Commands
   /// should be executed in order.
   ///
@@ -141,6 +144,7 @@ public:
   Expected<cas::IncludeTreeRoot>
   getIncludeTree(cas::ObjectStore &DB,
                  const std::vector<std::string> &CommandLine, StringRef CWD,
+                 LookupModuleOutputCallback LookupModuleOutput,
                  const DepscanPrefixMapping &PrefixMapping);
 
   /// If \p DiagGenerationAsCompilation is true it will generate error
@@ -149,7 +153,8 @@ public:
   /// \p DiagOpts.DiagnosticSerializationFile setting is set for the invocation.
   Expected<cas::IncludeTreeRoot> getIncludeTreeFromCompilerInvocation(
       cas::ObjectStore &DB, std::shared_ptr<CompilerInvocation> Invocation,
-      StringRef CWD, const DepscanPrefixMapping &PrefixMapping,
+      StringRef CWD, LookupModuleOutputCallback LookupModuleOutput,
+      const DepscanPrefixMapping &PrefixMapping,
       DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
       bool DiagGenerationAsCompilation);
 
@@ -246,6 +251,10 @@ public:
     CASFileSystemRootID = std::move(ID);
   }
 
+  void handleIncludeTreeID(std::string ID) override {
+    IncludeTreeID = std::move(ID);
+  }
+
   TranslationUnitDeps takeTranslationUnitDeps();
   ModuleDepsGraph takeModuleGraphDeps();
 
@@ -257,6 +266,7 @@ private:
   std::vector<Command> Commands;
   std::string ContextHash;
   std::optional<std::string> CASFileSystemRootID;
+  std::optional<std::string> IncludeTreeID;
   std::vector<std::string> OutputPaths;
   const llvm::StringSet<> &AlreadySeen;
 };

--- a/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
@@ -139,6 +139,9 @@ struct ModuleDeps {
   /// The CASID for the module input dependency tree, if any.
   std::optional<llvm::cas::CASID> CASFileSystemRootID;
 
+  /// The CASID for the module include-tree, if any.
+  std::optional<std::string> IncludeTreeID;
+
   /// The \c ActionCache key for this module, if any.
   std::optional<std::string> ModuleCacheKey;
 

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -649,10 +649,14 @@ public:
       : CAS(CAS), Cache(Cache), ModuleCache(ModuleCache), Diags(Diags) {}
 
   bool readCASFileSystemRootID(StringRef RootID, bool Complain) override;
+  bool readIncludeTreeID(StringRef ID, bool Complain) override;
   bool readModuleCacheKey(StringRef ModuleName, StringRef Filename,
                           StringRef CacheKey) override;
 
 private:
+  bool checkCASID(bool Complain, StringRef RootID, unsigned ParseDiagID,
+                  unsigned MissingDiagID);
+
   cas::ObjectStore &CAS;
   cas::ActionCache &Cache;
   InMemoryModuleCache &ModuleCache;
@@ -2415,21 +2419,36 @@ bool CompileCacheASTReaderHelper::readModuleCacheKey(StringRef ModuleName,
       Filename, CacheKey, "imported module", CAS, Cache, ModuleCache, Diags);
 }
 
-bool CompileCacheASTReaderHelper::readCASFileSystemRootID(StringRef RootID,
-                                                          bool Complain) {
-  // Verify that RootID is in the CAS. Otherwise the module cache probably was
-  // created with a different CAS.
+/// Verify that ID is in the CAS. Otherwise the module cache probably was
+/// created with a different CAS.
+bool CompileCacheASTReaderHelper::checkCASID(bool Complain, StringRef RootID,
+                                             unsigned ParseDiagID,
+                                             unsigned MissingDiagID) {
   std::optional<cas::CASID> ID;
   if (errorToBool(CAS.parseID(RootID).moveInto(ID))) {
     if (Complain)
-      Diags.Report(diag::err_cas_cannot_parse_root_id) << RootID;
+      Diags.Report(ParseDiagID) << RootID;
     return true;
   }
   if (errorToBool(CAS.getProxy(*ID).takeError())) {
     if (Complain) {
-      Diags.Report(diag::err_cas_missing_root_id) << RootID;
+      Diags.Report(MissingDiagID) << RootID;
     }
     return true;
   }
   return false;
+}
+
+bool CompileCacheASTReaderHelper::readCASFileSystemRootID(StringRef RootID,
+                                                          bool Complain) {
+  return checkCASID(Complain, RootID, diag::err_cas_cannot_parse_root_id,
+                    diag::err_cas_missing_root_id);
+}
+
+bool CompileCacheASTReaderHelper::readIncludeTreeID(StringRef ID,
+                                                    bool Complain) {
+  // Verify that ID is in the CAS. Otherwise the module cache probably was
+  // created with a different CAS.
+  return checkCASID(Complain, ID, diag::err_cas_cannot_parse_include_tree_id,
+                    diag::err_cas_missing_include_tree_id);
 }

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -257,7 +257,10 @@ bool ChainedASTReaderListener::readCASFileSystemRootID(StringRef RootID,
   return First->readCASFileSystemRootID(RootID, Complain) ||
          Second->readCASFileSystemRootID(RootID, Complain);
 }
-
+bool ChainedASTReaderListener::readIncludeTreeID(StringRef ID, bool Complain) {
+  return First->readIncludeTreeID(ID, Complain) ||
+         Second->readIncludeTreeID(ID, Complain);
+}
 bool ChainedASTReaderListener::readModuleCacheKey(StringRef ModuleName,
                                                   StringRef Filename,
                                                   StringRef CacheKey) {
@@ -3048,6 +3051,15 @@ ASTReader::ReadControlBlock(ModuleFile &F,
           return OutOfDate;
       }
       break;
+    case CAS_INCLUDE_TREE_ID:
+      F.IncludeTreeID = Blob.str();
+      if (Listener) {
+        bool Complain =
+            !canRecoverFromOutOfDate(F.FileName, ClientLoadCapabilities);
+        if (Listener->readIncludeTreeID(F.IncludeTreeID, Complain))
+          return OutOfDate;
+      }
+      break;
     }
   }
 }
@@ -5694,6 +5706,8 @@ llvm::Error ASTReader::ReadSubmoduleBlock(ModuleFile &F,
           CurrentModule->setModuleCacheKey(F.ModuleCacheKey);
         if (!F.CASFileSystemRootID.empty())
           CurrentModule->setCASFileSystemRootID(F.CASFileSystemRootID);
+        if (!F.IncludeTreeID.empty())
+          CurrentModule->setIncludeTreeID(F.IncludeTreeID);
       }
 
       CurrentModule->Kind = Kind;

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -801,6 +801,7 @@ void ASTWriter::WriteBlockInfoBlock() {
   RECORD(INPUT_FILE_OFFSETS);
   RECORD(MODULE_CACHE_KEY);
   RECORD(CASFS_ROOT_ID);
+  RECORD(CAS_INCLUDE_TREE_ID);
 
   BLOCK(OPTIONS_BLOCK);
   RECORD(LANGUAGE_OPTIONS);
@@ -1357,6 +1358,15 @@ void ASTWriter::WriteControlBlock(Preprocessor &PP, ASTContext &Context,
       Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Blob));
       unsigned AbbrevCode = Stream.EmitAbbrev(std::move(Abbrev));
       RecordData::value_type Record[] = {CASFS_ROOT_ID};
+      Stream.EmitRecordWithBlob(AbbrevCode, Record, *ID);
+    }
+    // CAS include-tree id, for the scanner.
+    if (auto ID = WritingModule->getIncludeTreeID()) {
+      auto Abbrev = std::make_shared<BitCodeAbbrev>();
+      Abbrev->Add(BitCodeAbbrevOp(CAS_INCLUDE_TREE_ID));
+      Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Blob));
+      unsigned AbbrevCode = Stream.EmitAbbrev(std::move(Abbrev));
+      RecordData::value_type Record[] = {CAS_INCLUDE_TREE_ID};
       Stream.EmitRecordWithBlob(AbbrevCode, Record, *ID);
     }
   }

--- a/clang/lib/Tooling/DependencyScanning/CachingActions.h
+++ b/clang/lib/Tooling/DependencyScanning/CachingActions.h
@@ -19,7 +19,8 @@ class CachingOnDiskFileSystem;
 namespace clang::tooling::dependencies {
 
 std::unique_ptr<DependencyActionController>
-createIncludeTreeActionController(cas::ObjectStore &DB,
+createIncludeTreeActionController(LookupModuleOutputCallback LookupModuleOutput,
+                                  cas::ObjectStore &DB,
                                   DepscanPrefixMapping PrefixMapping);
 
 std::unique_ptr<DependencyActionController>

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -439,15 +439,12 @@ public:
           OriginalInvocation, OptimizeArgs, EagerLoadModules,
           Format == ScanningOutputFormat::P1689);
       ScanInstance.addDependencyCollector(MDC);
-      if (CacheFS) {
-        ScanInstance.setGenModuleActionWrapper(
-            [CacheFS = CacheFS, &Controller = Controller](
-                const FrontendOptions &Opts,
-                std::unique_ptr<FrontendAction> Wrapped) {
-              return std::make_unique<WrapScanModuleBuildAction>(
-                  std::move(Wrapped), Controller);
-            });
-      }
+      ScanInstance.setGenModuleActionWrapper(
+          [&Controller = Controller](const FrontendOptions &Opts,
+                                     std::unique_ptr<FrontendAction> Wrapped) {
+            return std::make_unique<WrapScanModuleBuildAction>(
+                std::move(Wrapped), Controller);
+          });
       break;
     }
 

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -468,6 +468,7 @@ ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
           << *ID << MD.ID.ModuleName;
     }
   }
+  MD.IncludeTreeID = M->getIncludeTreeID();
 
   ModuleMap &ModMapInfo =
       MDC.ScanInstance.getPreprocessor().getHeaderSearchInfo().getModuleMap();

--- a/clang/test/ClangScanDeps/modules-include-tree.c
+++ b/clang/test/ClangScanDeps/modules-include-tree.c
@@ -1,0 +1,202 @@
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// RUN: FileCheck %s -input-file %t/deps.json  -DPREFIX=%/t
+
+// CHECK:      {
+// CHECK-NEXT   "modules": [
+// CHECK-NEXT     {
+// CHECK:            "cas-include-tree-id": "[[LEFT_TREE:llvmcas://[[:xdigit:]]+]]"
+// CHECK:            "clang-module-deps": [
+// CHECK:              {
+// CHECK:                "module-name": "Top"
+// CHECK:              }
+// CHECK-NEXT:       ]
+// CHECK:            "clang-modulemap-file": "[[PREFIX]]/module.modulemap"
+// CHECK:            "command-line": [
+// CHECK-NEXT:         "-cc1"
+// CHECK:              "-fcas-path"
+// CHECK-NEXT:         "[[PREFIX]]/cas"
+// CHECK:              "-fmodule-map-file=[[PREFIX]]/module.modulemap"
+// CHECK:              "-o"
+// CHECK-NEXT:         "[[PREFIX]]/outputs/{{.*}}/Left-{{.*}}.pcm"
+// CHECK:              "-disable-free"
+// CHECK:              "-fno-pch-timestamp"
+// CHECK:              "-fcas-include-tree"
+// CHECK-NEXT:         "[[LEFT_TREE]]"
+// CHECK:              "-fcache-compile-job"
+// CHECK:              "-emit-module"
+// CHECK:              "-fmodule-file-cache-key"
+// CHECK-NEXT:         "[[PREFIX]]/outputs/{{.*}}/Top-{{.*}}.pcm"
+// CHECK-NEXT:         "llvmcas://{{[[:xdigit:]]+}}"
+// CHECK:              "-x"
+// CHECK-NEXT:         "c"
+// CHECK:              "-fmodule-file=Top=[[PREFIX]]/outputs/{{.*}}/Top-{{.*}}.pcm"
+// CHECK:              "-fmodules"
+// CHECK:              "-fmodule-name=Left"
+// CHECK:              "-fno-implicit-modules"
+// CHECK:            ]
+// CHECK:            "file-deps": [
+// CHECK-NEXT:         "[[PREFIX]]/Left.h"
+// CHECK-NEXT:         "[[PREFIX]]/module.modulemap"
+// CHECK:            ]
+// CHECK:            "name": "Left"
+// CHECK:          }
+// CHECK-NEXT:     {
+// CHECK:            "cas-include-tree-id": "[[RIGHT_TREE:llvmcas://[[:xdigit:]]+]]"
+// CHECK:            "clang-module-deps": [
+// CHECK-NEXT:         {
+// CHECK:                "module-name": "Top"
+// CHECK:              }
+// CHECK-NEXT:       ]
+// CHECK:            "clang-modulemap-file": "[[PREFIX]]/module.modulemap"
+// CHECK:            "command-line": [
+// CHECK-NEXT:         "-cc1"
+// CHECK:              "-fcas-path"
+// CHECK-NEXT:         "[[PREFIX]]/cas"
+// CHECK:              "-fmodule-map-file=[[PREFIX]]/module.modulemap"
+// CHECK:              "-o"
+// CHECK-NEXT:         "[[PREFIX]]/outputs/{{.*}}/Right-{{.*}}.pcm"
+// CHECK:              "-disable-free"
+// CHECK:              "-fno-pch-timestamp"
+// CHECK:              "-fcas-include-tree"
+// CHECK-NEXT:         "[[RIGHT_TREE]]"
+// CHECK:              "-fcache-compile-job"
+// CHECK:              "-emit-module"
+// CHECK:              "-fmodule-file-cache-key
+// CHECK-NEXT:         "[[PREFIX]]/outputs/{{.*}}/Top-{{.*}}.pcm"
+// CHECK-NEXT:         "llvmcas://{{[[:xdigit:]]+}}"
+// CHECK:              "-x"
+// CHECK-NEXT:         "c"
+// CHECK:              "-fmodule-file=Top=[[PREFIX]]/outputs/{{.*}}/Top-{{.*}}.pcm"
+// CHECK:              "-fmodules"
+// CHECK:              "-fmodule-name=Right"
+// CHECK:              "-fno-implicit-modules"
+// CHECK:            ]
+// CHECK:            "file-deps": [
+// CHECK-NEXT:         "[[PREFIX]]/Right.h"
+// CHECK-NEXT:         "[[PREFIX]]/module.modulemap"
+// CHECK-NEXT:       ]
+// CHECK:            "name": "Right"
+// CHECK:          }
+// CHECK-NEXT:     {
+// CHECK:            "cas-include-tree-id": "[[TOP_TREE:llvmcas://[[:xdigit:]]+]]"
+// CHECK:            "clang-module-deps": []
+// CHECK:            "clang-modulemap-file": "[[PREFIX]]/module.modulemap"
+// CHECK:            "command-line": [
+// CHECK-NEXT:         "-cc1"
+// CHECK:              "-fcas-path"
+// CHECK-NEXT:         "[[PREFIX]]/cas"
+// CHECK:              "-o"
+// CHECK-NEXT:         "[[PREFIX]]/outputs/{{.*}}/Top-{{.*}}.pcm"
+// CHECK:              "-disable-free"
+// CHECK:              "-fno-pch-timestamp"
+// CHECK:              "-fcas-include-tree"
+// CHECK-NEXT:         "[[TOP_TREE]]"
+// CHECK:              "-fcache-compile-job"
+// CHECK:              "-emit-module"
+// CHECK:              "-x"
+// CHECK-NEXT:         "c"
+// CHECK:              "-fmodules"
+// CHECK:              "-fmodule-name=Top"
+// CHECK:              "-fno-implicit-modules"
+// CHECK:            ]
+// CHECK:            "file-deps": [
+// CHECK-NEXT:         "[[PREFIX]]/Top.h"
+// CHECK-NEXT:         "[[PREFIX]]/module.modulemap"
+// CHECK-NEXT:       ]
+// CHECK:            "name": "Top"
+// CHECK:          }
+// CHECK:        ]
+// CHECK-NEXT:   "translation-units": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "commands": [
+// CHECK-NEXT:         {
+// CHECK:                "cas-include-tree-id": "[[TU_TREE:llvmcas://[[:xdigit:]]+]]"
+// CHECK:                "clang-module-deps": [
+// CHECK-NEXT:             {
+// CHECK:                    "module-name": "Left"
+// CHECK:                  }
+// CHECK-NEXT:             {
+// CHECK:                    "module-name": "Right"
+// CHECK:                  }
+// CHECK-NEXT:           ]
+// CHECK:                "command-line": [
+// CHECK-NEXT:             "-cc1"
+// CHECK:                  "-fcas-path"
+// CHECK-NEXT:             "[[PREFIX]]/cas"
+// CHECK:                  "-fmodule-map-file=[[PREFIX]]/module.modulemap"
+// CHECK:                  "-disable-free"
+// CHECK:                  "-fcas-include-tree"
+// CHECK-NEXT:             "[[TU_TREE]]"
+// CHECK:                  "-fcache-compile-job"
+// CHECK:                  "-fsyntax-only"
+// CHECK:                  "-fmodule-file-cache-key"
+// CHECK-NEXT:             "[[PREFIX]]/outputs/{{.*}}/Left-{{.*}}.pcm"
+// CHECK-NEXT:             "llvmcas://{{[[:xdigit:]]+}}"
+// CHECK:                  "-fmodule-file-cache-key"
+// CHECK-NEXT:             "[[PREFIX]]/outputs/{{.*}}/Right-{{.*}}.pcm"
+// CHECK-NEXT:             "llvmcas://{{[[:xdigit:]]+}}"
+// CHECK:                  "-x"
+// CHECK-NEXT:             "c"
+// CHECK:                  "-fmodule-file=Left=[[PREFIX]]/outputs/{{.*}}/Left-{{.*}}.pcm"
+// CHECK:                  "-fmodule-file=Right=[[PREFIX]]/outputs/{{.*}}/Right-{{.*}}.pcm"
+// CHECK:                  "-fmodules"
+// CHECK:                  "-fno-implicit-modules"
+// CHECK:                ]
+// CHECK:                "file-deps": [
+// CHECK-NEXT:             "[[PREFIX]]/tu.c"
+// CHECK-NEXT:           ]
+// CHECK:                "input-file": "[[PREFIX]]/tu.c"
+// CHECK:              }
+// CHECK-NEXT:       ]
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ]
+// CHECK-NEXT: }
+
+//--- cdb.json.template
+[{
+  "file": "DIR/tu.c",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu.c -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+}]
+
+//--- module.modulemap
+module Top { header "Top.h" export *}
+module Left { header "Left.h" export *}
+module Right { header "Right.h" export *}
+
+//--- Top.h
+#pragma once
+struct Top {
+  int x;
+};
+void top(void);
+
+//--- Left.h
+#pragma once
+#include "Top.h"
+void left(void);
+
+//--- Right.h
+#pragma once
+#include "Top.h"
+void right(void);
+
+//--- tu.c
+#include "Left.h"
+#include "Right.h"
+
+void tu(void) {
+  left();
+  right();
+  top();
+}

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -561,6 +561,7 @@ public:
     ID.FileDeps = std::move(TUDeps.FileDeps);
     ID.ModuleDeps = std::move(TUDeps.ClangModuleDeps);
     ID.CASFileSystemRootID = std::move(TUDeps.CASFileSystemRootID);
+    ID.IncludeTreeID = std::move(TUDeps.IncludeTreeID);
     ID.DriverCommandLine = std::move(TUDeps.DriverCommandLine);
     ID.Commands = std::move(TUDeps.Commands);
 
@@ -638,6 +639,8 @@ public:
       };
       if (MD.CASFileSystemRootID)
         O.try_emplace("casfs-root-id", MD.CASFileSystemRootID->toString());
+      if (MD.IncludeTreeID)
+        O.try_emplace("cas-include-tree-id", MD.IncludeTreeID);
       OutModules.push_back(std::move(O));
     }
 
@@ -656,6 +659,8 @@ public:
           };
           if (I.CASFileSystemRootID)
             O.try_emplace("casfs-root-id", I.CASFileSystemRootID);
+          if (I.IncludeTreeID)
+            O.try_emplace("cas-include-tree-id", I.IncludeTreeID);
           Commands.push_back(std::move(O));
         }
       } else {
@@ -669,6 +674,8 @@ public:
         };
         if (I.CASFileSystemRootID)
           O.try_emplace("casfs-root-id", I.CASFileSystemRootID);
+        if (I.IncludeTreeID)
+          O.try_emplace("cas-include-tree-id", I.IncludeTreeID);
         Commands.push_back(std::move(O));
       }
       TUs.push_back(Object{
@@ -709,6 +716,7 @@ private:
     std::vector<std::string> FileDeps;
     std::vector<ModuleID> ModuleDeps;
     std::optional<std::string> CASFileSystemRootID;
+    std::optional<std::string> IncludeTreeID;
     std::vector<std::string> DriverCommandLine;
     std::vector<Command> Commands;
   };
@@ -1189,7 +1197,7 @@ int main(int argc, const char **argv) {
                                    std::move(MaybeTree));
         } else if (Format == ScanningOutputFormat::IncludeTree) {
           auto MaybeTree = WorkerTools[I]->getIncludeTree(
-              *CAS, Input->CommandLine, CWD, PrefixMapping);
+              *CAS, Input->CommandLine, CWD, LookupOutput, PrefixMapping);
           std::unique_lock<std::mutex> LockGuard(Lock);
           TreeResults.emplace_back(LocalIndex, std::move(Filename),
                                    std::move(MaybeTree));

--- a/clang/unittests/CAS/IncludeTreeTest.cpp
+++ b/clang/unittests/CAS/IncludeTreeTest.cpp
@@ -55,7 +55,8 @@ TEST(IncludeTree, IncludeTreeScan) {
   std::optional<IncludeTreeRoot> Root;
   DepscanPrefixMapping PrefixMapping;
   ASSERT_THAT_ERROR(
-      ScanTool.getIncludeTree(*DB, CommandLine, /*CWD*/ "", PrefixMapping)
+      ScanTool
+          .getIncludeTree(*DB, CommandLine, /*CWD*/ "", nullptr, PrefixMapping)
           .moveInto(Root),
       llvm::Succeeded());
 


### PR DESCRIPTION
This adds the scaffolding needed for include-tree to push IncludeTreeBuilder stacks, to compute an include-tree for a module and to get fmodule-file-cache-key options for dependencies. Note: this does not yet support building or importing modules, but it lets us compute dependencies in the right way.

Note: depends on https://github.com/apple/llvm-project/pull/6489