### PR TITLE
Enable disabled variadic generic tests.

### DIFF
--- a/lldb/test/API/lang/swift/variadic_generics/TestSwiftVariadicGenerics.py
+++ b/lldb/test/API/lang/swift/variadic_generics/TestSwiftVariadicGenerics.py
@@ -27,7 +27,7 @@ class TestSwiftVariadicGenerics(TestBase):
         # f3(ts: a, b, more_ts: a, b)
         process.Continue()
         self.expect("frame variable",
-                    substrs=["Pack{(a.A, a.B)}", "ts", "i = 23", # FIXME! "d = 2.71",
+                    substrs=["Pack{(a.A, a.B)}", "ts", "i = 23", "d = 2.71",
                              "Pack{(a.A, a.B)}", "more_ts", "i = 23", "d = 2.71"])
 
         # f4(uvs: (a, b), (a, b))
@@ -51,9 +51,9 @@ class TestSwiftVariadicGenerics(TestBase):
         # f7(us: a, vs: 1, b, more_us: a, more_vs: 2, b)
         process.Continue()
         self.expect("frame variable",
-                    substrs=["Pack{(a.A)}", "us", # FIXME: "i = 23"
+                    substrs=["Pack{(a.A)}", "us", "i = 23",
                              "Pack{(Int, a.B)}", "vs", "= 1", "d = 2.71",
-                             "Pack{(a.A)}", "more_us", #FIXME: "i = 23"
+                             "Pack{(a.A)}", "more_us", "i = 23",
                              "Pack{(Int, a.B)}", "more_vs", "= 2", "d = 2.71"
                     ])
                         

--- a/lldb/test/API/lang/swift/variadic_generics/a.swift
+++ b/lldb/test/API/lang/swift/variadic_generics/a.swift
@@ -51,3 +51,11 @@ public func f7<each U, each V>(us: repeat each U, vs: repeat each V, more_us: re
 }
  
 f7(us: a, vs: 1, b, more_us: a, more_vs: 2, b)
+
+//FIXME: Crashes the compiler.
+//struct S<each T> {
+//    let vals : repeat each T
+//}
+//
+//let variadic_struct = S<Int, String, Float>(vals: (23, "hello", 3.14))
+//print("break here")


### PR DESCRIPTION
Apparently these were compiler bugs, not LLDB bugs.

(cherry picked from commit 16b18f98fa496617d955464b54219913169818df)