### PR TITLE
[lldb] Disable swift move function test

### DIFF
--- a/lldb/test/API/lang/swift/variables/move_function/TestSwiftMoveFunction.py
+++ b/lldb/test/API/lang/swift/variables/move_function/TestSwiftMoveFunction.py
@@ -28,6 +28,7 @@ class TestSwiftMoveFunctionType(TestBase):
 
     # Skip on aarch64 linux: rdar://91005071
     @skipIf(archs=['aarch64'], oslist=['linux'])
+    @skipIf(bugnumber="rdar://106810588")
     @swiftTest
     def test_swift_move_function(self):
         """Check that we properly show variables at various points of the CFG while


### PR DESCRIPTION
An existing bug prevents this test from passing on CI. It is currently being investigated, but we're disabling this test to allow the release CI to proceed.