### PR TITLE
[stable][libclang][cas] Add libclang APIs to setup options for the LLVM CAS plugin library

### DIFF
--- a/clang/include/clang-c/CAS.h
+++ b/clang/include/clang-c/CAS.h
@@ -70,6 +70,19 @@ CINDEX_LINKAGE void
 clang_experimental_cas_Options_setOnDiskPath(CXCASOptions, const char *Path);
 
 /**
+ * Configure the path to a library that implements the LLVM CAS plugin API.
+ */
+CINDEX_LINKAGE void
+clang_experimental_cas_Options_setPluginPath(CXCASOptions, const char *Path);
+
+/**
+ * Set a value for a named option that the CAS plugin supports.
+ */
+CINDEX_LINKAGE void
+clang_experimental_cas_Options_setPluginOption(CXCASOptions, const char *Name,
+                                               const char *Value);
+
+/**
  * Creates instances for a CAS object store and action cache based on the
  * configuration of a \p CXCASOptions.
  *

--- a/clang/tools/libclang/CCAS.cpp
+++ b/clang/tools/libclang/CCAS.cpp
@@ -35,6 +35,19 @@ void clang_experimental_cas_Options_setOnDiskPath(CXCASOptions COpts,
   Opts.CASPath = Path;
 }
 
+void clang_experimental_cas_Options_setPluginPath(CXCASOptions COpts,
+                                                  const char *Path) {
+  CASOptions &Opts = *unwrap(COpts);
+  Opts.PluginPath = Path;
+}
+
+void clang_experimental_cas_Options_setPluginOption(CXCASOptions COpts,
+                                                    const char *Name,
+                                                    const char *Value) {
+  CASOptions &Opts = *unwrap(COpts);
+  Opts.PluginOptions.emplace_back(Name, Value);
+}
+
 CXCASDatabases clang_experimental_cas_Databases_create(CXCASOptions COpts,
                                                        CXString *Error) {
   CASOptions &Opts = *unwrap(COpts);

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -480,6 +480,8 @@ LLVM_16 {
     clang_experimental_cas_Options_create;
     clang_experimental_cas_Options_dispose;
     clang_experimental_cas_Options_setOnDiskPath;
+    clang_experimental_cas_Options_setPluginOption;
+    clang_experimental_cas_Options_setPluginPath;
     clang_experimental_DependencyScannerService_create_v1;
     clang_experimental_DependencyScannerServiceOptions_create;
     clang_experimental_DependencyScannerServiceOptions_dispose;


### PR DESCRIPTION
(cherry picked from commit b55116bfd3d80d3dd04c213eb7f34f68dad75b0b)