### PR TITLE
[lldb] Add forward interop expression evaluation tests

### DIFF
--- a/lldb/test/API/lang/swift/cxx_interop/forward/expressions/Makefile
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/expressions/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_CXX_INTEROP := 1
+SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR) 
+include Makefile.rules

--- a/lldb/test/API/lang/swift/cxx_interop/forward/expressions/TestSwiftForwardInteropExpressions.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/expressions/TestSwiftForwardInteropExpressions.py
@@ -1,0 +1,62 @@
+
+"""
+Test that evaluating expressions works on forward interop mode.
+"""
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class TestSwiftForwardInteropExpressions(TestBase):
+
+    def setup(self, bkpt_str):
+         self.build()
+         self.runCmd('setting set target.experimental.swift-enable-cxx-interop true')
+         _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+             self, bkpt_str, lldb.SBFileSpec('main.swift'))
+         return thread
+
+    @expectedFailureAll(oslist=["linux"], bugnumber="rdar://106871422")
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false')) # rdar://106871275
+    @swiftTest
+    def test(self):
+        self.setup('Break here')
+        
+        # Check that we can call free functions.
+        self.expect('expr returnsInt()', substrs=['Int32', '42'])
+
+        # Check that we can call unused free functions.
+        self.expect('expr returnsIntUnused()', substrs=['Int32', '37'])
+
+        # Check that we can call a C++ constructor.
+        self.expect('expr CxxClass()', substrs=['CxxClass', 'a = 100', 'b = 101'])
+
+        # Check that we can call methods.
+        self.expect('expr cxxClass.sum()', substrs=['Int32', '201'])
+
+        # Check that we can access a C++ type's ivars
+        self.expect('expr cxxClass.a', substrs=['Int32', '100'])
+        self.expect('expr cxxSubclass.a', substrs=['Int32', '100'])
+        self.expect('expr cxxSubclass.c', substrs=['Int32', '102'])
+
+        # Check that calling a function that throws an exception fails on expression evaluation
+        self.expect('expr throwException()', substrs=['internal c++ exception breakpoint'], error=True)
+
+        # Check that we can make persistent variables.
+        self.expect('expr var $cxxClass = CxxClass()')
+
+        # Check that we can refer to the persistent variable.
+        self.expect('expr $cxxClass', substrs=['CxxClass', 'a = 100', 'b = 101'])
+
+        # Check that we can call methods on the persistent variable.
+        self.expect('expr $cxxClass.sum()', substrs=['Int32', '201'])
+
+        # Check that po prints the fields of a base class
+        self.expect('po cxxClass', substrs=['CxxClass', 'a : 100', 'b : 101'])
+
+    @expectedFailureAll(bugnumber="rdar://106216567")
+    @swiftTest
+    def test_po_subclass(self):
+        self.setup('Break here')
+
+        self.expect('po CxxSubclass()', substrs=['CxxClass', 'a : 100', 'b : 101', 'c : 102'])
+

--- a/lldb/test/API/lang/swift/cxx_interop/forward/expressions/main.swift
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/expressions/main.swift
@@ -1,0 +1,11 @@
+import ReturnsClass
+
+func main() {
+  _ = returnsInt();
+  var cxxClass = CxxClass();
+  var cxxSubclass = CxxSubclass();
+  print(1) // Break here
+}
+
+main()
+

--- a/lldb/test/API/lang/swift/cxx_interop/forward/expressions/module.modulemap
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/expressions/module.modulemap
@@ -1,0 +1,5 @@
+module ReturnsClass {
+  header "returns-class.h"
+  requires cplusplus
+}
+

--- a/lldb/test/API/lang/swift/cxx_interop/forward/expressions/returns-class.h
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/expressions/returns-class.h
@@ -1,0 +1,29 @@
+#include <iostream>
+
+int returnsInt()  {
+  return 42;
+}
+
+int returnsIntUnused() {
+  return 37;
+}
+
+void throwException() {
+  throw "Division by zero condition!";
+}
+
+struct CxxClass {
+  int a = 100;
+  int b = 101;
+
+  int sum() {
+    return a + b;
+  }
+};
+
+struct CxxSubclass: public CxxClass {
+  int c = 102;
+};
+
+
+


### PR DESCRIPTION
rdar://100284870
(cherry picked from commit 0ef66798991f2d49a6aa5a36ff8869da6c4a753d)