### PR TITLE
[swift] Rename move function related tests to consume operator.

### DIFF
--- a/lldb/test/API/lang/swift/variables/consume_operator/Makefile
+++ b/lldb/test/API/lang/swift/variables/consume_operator/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS :=
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/consume_operator/TestSwiftConsumeOperator.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator/TestSwiftConsumeOperator.py
@@ -1,4 +1,4 @@
-# TestSwiftMoveFunction.py
+# TestSwiftConsumeOperator.py
 #
 # This source file is part of the Swift.org open source project
 #
@@ -11,7 +11,7 @@
 # ------------------------------------------------------------------------------
 """
 Check that we properly show variables at various points of the CFG while
-stepping with the move function.
+stepping with the consume operator.
 """
 import lldb
 from lldbsuite.test.lldbtest import *
@@ -24,16 +24,16 @@ import unittest2
 def stderr_print(line):
     sys.stderr.write(line + "\n")
 
-class TestSwiftMoveFunctionType(TestBase):
+class TestSwiftConsumeOperatorType(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
     # Skip on aarch64 linux: rdar://91005071
     @skipIf(archs=['aarch64'], oslist=['linux'])
     @swiftTest
-    def test_swift_move_function(self):
+    def test_swift_consume_operator(self):
         """Check that we properly show variables at various points of the CFG while
-        stepping with the move function.
+        stepping with the consume operator.
         """
         self.build()
 
@@ -82,7 +82,7 @@ class TestSwiftMoveFunctionType(TestBase):
 
         # Go to breakpoint 3. k should no longer be valid.
         self.process.Continue()
-        self.assertIsNone(varK.value, "K is live but was moved?!")
+        self.assertIsNone(varK.value, "K is live but was consumed?!")
 
         # Run so we hit the next breakpoint to jump to the next test's
         # breakpoint.
@@ -99,7 +99,7 @@ class TestSwiftMoveFunctionType(TestBase):
 
         # Go to breakpoint 3. We invalidated k
         self.process.Continue()
-        self.assertIsNone(varK.value, "K is live but was moved?!")
+        self.assertIsNone(varK.value, "K is live but was consumed?!")
 
         # Go to the last breakpoint and make sure that k is reinitialized
         # properly.
@@ -138,7 +138,7 @@ class TestSwiftMoveFunctionType(TestBase):
 
         # Go to breakpoint 3. K was invalidated.
         self.process.Continue()
-        self.assertIsNone(varK.value, "K is live but was moved?!")
+        self.assertIsNone(varK.value, "K is live but was consumed?!")
 
         # Go to the last breakpoint and make sure that k is reinitialized
         # properly.
@@ -159,7 +159,7 @@ class TestSwiftMoveFunctionType(TestBase):
 
         # Go to breakpoint 3. k should no longer be valid.
         self.process.Continue()
-        #self.assertIsNone(varK.value, "K is live but was moved?!")
+        #self.assertIsNone(varK.value, "K is live but was consumed?!")
 
         # Run so we hit the next breakpoint to jump to the next test's
         # breakpoint.
@@ -176,7 +176,7 @@ class TestSwiftMoveFunctionType(TestBase):
 
         # Go to breakpoint 3. We invalidated k
         self.process.Continue()
-        self.assertIsNone(varK.value, "K is live but was moved?!")
+        self.assertIsNone(varK.value, "K is live but was consumed?!")
 
         # Go to the last breakpoint and make sure that k is reinitialized
         # properly.
@@ -217,7 +217,7 @@ class TestSwiftMoveFunctionType(TestBase):
 
         # Go to breakpoint 3. K was invalidated.
         self.process.Continue()
-        self.assertIsNone(varK.value, "K is live but was moved?!")
+        self.assertIsNone(varK.value, "K is live but was consumed?!")
 
         # Go to the last breakpoint and make sure that k is reinitialized
         # properly.
@@ -296,13 +296,13 @@ class TestSwiftMoveFunctionType(TestBase):
         # Now we have executed the move and we are about to run code using
         # m. Make sure that K is not available!
         self.assertEqual(varK.unsigned, 0,
-                         "varK was already moved! Should be nullptr")
+                         "varK was already consumed! Should be nullptr")
         self.process.Continue()
 
         # We are now out of the conditional lexical block on the line of code
         # that redefines k. k should still be not available.
         self.assertEqual(varK.unsigned, 0,
-                         "varK was already moved! Should be nullptr")
+                         "varK was already consumed! Should be nullptr")
         self.process.Continue()
 
         # Ok, we have now reinit k and are about to call a method on it. We
@@ -328,7 +328,7 @@ class TestSwiftMoveFunctionType(TestBase):
         # Now we have executed the move and we are about to reinit k but have
         # not yet. Make sure we are not available!
         self.assertEqual(varK.unsigned, 0,
-                         "varK was already moved! Should be nullptr")
+                         "varK was already consumed! Should be nullptr")
         self.process.Continue()
 
         # We are now still inside the conditional part of the code, but have
@@ -361,7 +361,7 @@ class TestSwiftMoveFunctionType(TestBase):
         # line. Since this is reachable from the move and we haven't reinit yet,
         # k should not be available.
         self.assertEqual(varK.unsigned, 0,
-                         "varK was already moved! Should be nullptr")
+                         "varK was already consumed! Should be nullptr")
         self.process.Continue()
 
         # Ok, we have now reinit k and are about to call a method on it. We

--- a/lldb/test/API/lang/swift/variables/consume_operator/main.swift
+++ b/lldb/test/API/lang/swift/variables/consume_operator/main.swift
@@ -34,7 +34,7 @@ public func copyableValueTest() {
     print("stop here") // Set breakpoint
     let k = Klass()
     k.doSomething()
-    let m = _move k // Set breakpoint
+    let m = consume k // Set breakpoint
     m.doSomething() // Set breakpoint
 }
 
@@ -42,7 +42,7 @@ public func copyableVarTest() {
     print("stop here") // Set breakpoint
     var k = Klass()
     k.doSomething()
-    let m = _move k // Set breakpoint
+    let m = consume k // Set breakpoint
     m.doSomething()
     k = Klass()     // Set breakpoint
     k.doSomething() // Set breakpoint
@@ -53,7 +53,7 @@ public func addressOnlyValueTest<T : P>(_ x: T) {
     print("stop here") // Set breakpoint
     let k = x
     k.doSomething()
-    let m = _move k // Set breakpoint
+    let m = consume k // Set breakpoint
     m.doSomething() // Set breakpoint
 }
 
@@ -61,7 +61,7 @@ public func addressOnlyVarTest<T : P>(_ x: T) {
     print("stop here") // Set breakpoint
     var k = x
     k.doSomething()
-    let m = _move k // Set breakpoint
+    let m = consume k // Set breakpoint
     m.doSomething()
     k = x // Set breakpoint
     k.doSomething() // Set breakpoint
@@ -74,14 +74,14 @@ public func addressOnlyVarTest<T : P>(_ x: T) {
 public func copyableValueArgTest(_ k: __owned Klass) {
     print("stop here") // Set breakpoint
     k.doSomething()
-    let m = _move k // Set breakpoint
+    let m = consume k // Set breakpoint
     m.doSomething() // Set breakpoint
 }
 
 public func copyableVarArgTest(_ k: inout Klass) {
     print("stop here") // Set breakpoint
     k.doSomething()
-    let m = _move k // Set breakpoint
+    let m = consume k // Set breakpoint
     m.doSomething()
     k = Klass()     // Set breakpoint
     k.doSomething() // Set breakpoint
@@ -91,14 +91,14 @@ public func copyableVarArgTest(_ k: inout Klass) {
 public func addressOnlyValueArgTest<T : P>(_ k: __owned T) {
     print("stop here") // Set breakpoint
     k.doSomething()
-    let m = _move k // Set breakpoint
+    let m = consume k // Set breakpoint
     m.doSomething() // Set breakpoint
 }
 
 public func addressOnlyVarArgTest<T : P>(_ k: inout T, _ x: T) {
     print("stop here") // Set breakpoint
     k.doSomething()
-    let m = _move k // Set breakpoint
+    let m = consume k // Set breakpoint
     m.doSomething()
     k = x // Set breakpoint
     k.doSomething() // Set breakpoint
@@ -112,7 +112,7 @@ public func copyableValueCCFTrueTest() {
     let k = Klass() // Set breakpoint
     k.doSomething() // Set breakpoint
     if trueBoolValue {
-        let m = _move k // Set breakpoint
+        let m = consume k // Set breakpoint
         m.doSomething() // Set breakpoint
     }
     // Set breakpoint
@@ -122,7 +122,7 @@ public func copyableValueCCFFalseTest() {
     let k = Klass() // Set breakpoint
     k.doSomething() // Set breakpoint
     if falseBoolValue {
-        let m = _move k
+        let m = consume k
         m.doSomething()
     }
     // Set breakpoint
@@ -132,7 +132,7 @@ public func copyableVarTestCCFlowTrueReinitOutOfBlockTest() {
     var k = Klass() // Set breakpoint
     k.doSomething()
     if trueBoolValue {
-        let m = _move k // Set breakpoint
+        let m = consume k // Set breakpoint
         m.doSomething() // Set breakpoint
     }
     k = Klass() // Set breakpoint
@@ -143,7 +143,7 @@ public func copyableVarTestCCFlowTrueReinitInBlockTest() {
     var k = Klass() // Set breakpoint
     k.doSomething()
     if trueBoolValue {
-        let m = _move k // Set breakpoint
+        let m = consume k // Set breakpoint
         m.doSomething()
         k = Klass() // Set breakpoint
         k.doSomething() // Set breakpoint
@@ -155,7 +155,7 @@ public func copyableVarTestCCFlowFalseReinitOutOfBlockTest() {
     var k = Klass() // Set breakpoint
     k.doSomething() // Set breakpoint
     if falseBoolValue {
-        let m = _move k
+        let m = consume k
         m.doSomething()
     }
     k = Klass() // Set breakpoint
@@ -166,7 +166,7 @@ public func copyableVarTestCCFlowFalseReinitInBlockTest() {
     var k = Klass() // Set breakpoint
     k.doSomething()  // Set breakpoint
     if falseBoolValue {
-        let m = _move k
+        let m = consume k
         m.doSomething()
         k = Klass()
     }

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/Makefile
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
@@ -1,4 +1,4 @@
-# TestSwiftMoveFunctionAsync.py
+# TestSwiftConsumeOperatorAsync.py
 #
 # This source file is part of the Swift.org open source project
 #
@@ -11,7 +11,7 @@
 # ------------------------------------------------------------------------------
 """
 Check that we properly show variables at various points of the CFG while
-stepping with the move function.
+stepping with the consume operator.
 """
 import lldb
 from lldbsuite.test.lldbtest import *
@@ -24,14 +24,14 @@ import unittest2
 def stderr_print(line):
     sys.stderr.write(line + "\n")
 
-class TestSwiftMoveFunctionAsyncType(TestBase):
+class TestSwiftConsumeOperatorAsyncType(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    def test_swift_move_function_async(self):
+    def test_swift_consume_operator_async(self):
         """Check that we properly show variables at various points of the CFG while
-        stepping with the move function.
+        stepping with the consume operator.
         """
         self.build()
 
@@ -89,16 +89,16 @@ class TestSwiftMoveFunctionAsyncType(TestBase):
         varK = self.get_var('k')
         self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
 
-        # We are now at break point 3. We have moved k, it should be empty.
+        # We are now at break point 3. We have consumed k, it should be empty.
         self.continue_to(3)
         varK = self.get_var('k')
-        self.assertIsNone(varK.value, "K is live but was moved?!")
+        self.assertIsNone(varK.value, "K is live but was consumed?!")
 
         # Finally, we are on the other side of the final force split. Make sure
         # the value still isn't available.
         self.continue_to(4)
         varK = self.get_var('k')
-        self.assertIsNone(varK.value, "K is live but was moved?!")
+        self.assertIsNone(varK.value, "K is live but was consumed?!")
 
     def do_check_copyable_var_test(self):
         # Run so we hit the next breakpoint to jump to the next test's
@@ -125,17 +125,17 @@ class TestSwiftMoveFunctionAsyncType(TestBase):
         varK = self.get_var('k')
         self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
 
-        # We are now at break point 8. We have moved k, it should be empty.
+        # We are now at break point 8. We have consumed k, it should be empty.
         self.continue_to(8)
         varK = self.get_var('k')
-        self.assertIsNone(varK.value, "K is live but was moved?!")
+        self.assertIsNone(varK.value, "K is live but was consumed?!")
 
         # Now, we are on the other side of the final force split. Make sure
         # the value still isn't available.
         self.continue_to(9)
         self.runCmd('# On other side of force split')
         varK = self.get_var('k')
-        self.assertIsNone(varK.value, "K is live but was moved?!")
+        self.assertIsNone(varK.value, "K is live but was consumed?!")
 
         # Finally, we have reinitialized k, look for k.
         self.continue_to(10)

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/main.swift
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/main.swift
@@ -25,7 +25,7 @@ public func copyableValueTest() async {
     let k = Klass()
     k.doSomething()
     await forceSplit() // Set breakpoint 01
-    let m = _move k    // Set breakpoint 02
+    let m = consume k    // Set breakpoint 02
     m.doSomething()    // Set breakpoint 03
     await forceSplit()
     m.doSomething()    // Set breakpoint 04
@@ -36,7 +36,7 @@ public func copyableVarTest() async {
     var k = Klass()    // Set breakpoint 05
     k.doSomething()
     await forceSplit() // Set breakpoint 06
-    let m = _move k    // Set breakpoint 07
+    let m = consume k    // Set breakpoint 07
     m.doSomething()    // Set breakpoint 08
     await forceSplit()
     k = Klass()        // Set breakpoint 09

--- a/lldb/test/API/lang/swift/variables/move_function/Makefile
+++ b/lldb/test/API/lang/swift/variables/move_function/Makefile
@@ -1,4 +1,0 @@
-SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -Xfrontend -enable-experimental-move-only
-
-include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/move_function_async/Makefile
+++ b/lldb/test/API/lang/swift/variables/move_function_async/Makefile
@@ -1,4 +1,0 @@
-SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library -Xfrontend -enable-experimental-move-only
-
-include Makefile.rules


### PR DESCRIPTION
I deleted the relevant feature flag and renamed things to use the final version of the move function (the consume operator).

rdar://106921827