### PR TITLE
[lldb] Introduce CMake variable LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -404,6 +404,25 @@ function(lldb_find_system_debugserver path)
   endif()
 endfunction()
 
+function(lldb_find_python_module module)
+  set(MODULE_FOUND PY_${module}_FOUND)
+  if (DEFINED ${MODULE_FOUND})
+    return()
+  endif()
+
+  execute_process(COMMAND "${Python3_EXECUTABLE}" "-c" "import ${module}"
+    RESULT_VARIABLE status
+    ERROR_QUIET)
+
+  if (status)
+    set(${MODULE_FOUND} OFF CACHE BOOL "Failed to find python module '${module}'")
+    message(STATUS "Could NOT find Python module '${module}'")
+  else()
+    set(${MODULE_FOUND} ON CACHE BOOL "Found python module '${module}'")
+    message(STATUS "Found Python module '${module}'")
+  endif()
+endfunction()
+
 # Removes all module flags from the current CMAKE_CXX_FLAGS. Used for
 # the Objective-C++ code in lldb which we don't want to build with modules.
 # Reasons for this are that modules with Objective-C++ would require that

--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -82,6 +82,8 @@ option(LLDB_NO_INSTALL_DEFAULT_RPATH "Disable default RPATH settings in binaries
 option(LLDB_USE_SYSTEM_DEBUGSERVER "Use the system's debugserver for testing (Darwin only)." OFF)
 option(LLDB_SKIP_STRIP "Whether to skip stripping of binaries when installing lldb." OFF)
 option(LLDB_SKIP_DSYM "Whether to skip generating a dSYM when installing lldb." OFF)
+option(LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS
+  "Fail to configure if certain requirements are not met for testing." OFF)
 
 # BEGIN SWIFT MOD
 option(LLDB_ENABLE_SWIFT_SUPPORT "Enable swift support" ON)

--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -1,5 +1,30 @@
 # Test runner infrastructure for LLDB. This configures the LLDB test trees
 # for use by Lit, and delegates to LLVM's lit test handlers.
+# Lit requires a Python3 interpreter, let's be careful and fail early if it's
+# not present.
+if (NOT DEFINED Python3_EXECUTABLE)
+  message(FATAL_ERROR
+    "LLDB test suite requires a Python3 interpreter but none "
+    "was found. Please install Python3 or disable tests with "
+    "`LLDB_INCLUDE_TESTS=OFF`.")
+endif()
+
+if(LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS)
+  message(STATUS "Enforcing strict test requirements for LLDB")
+  set(useful_python_modules
+    psutil # Lit uses psutil to do per-test timeouts.
+  )
+  foreach(module ${useful_python_modules})
+    lldb_find_python_module(${module})
+    if (NOT PY_${module}_FOUND)
+      message(FATAL_ERROR
+        "Python module '${module}' not found. Please install it via pip or via "
+        "your operating system's package manager. Alternatively, disable "
+        "strict testing requirements with "
+        "`LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS=OFF`")
+    endif()
+  endforeach()
+endif()
 
 if(LLDB_BUILT_STANDALONE)
   # In order to run check-lldb-* we need the correct map_config directives in


### PR DESCRIPTION
The goal of this patch is to add the ability for the CMake configure to fail when some optional test dependencies are not met. LLDB tries to be flexible when test dependencies are not present but there are cases where it would be useful to know that these dependencies are missing before we run the test suite.

The intent here is to apply this setting on CI machines and make sure that they have useful optional dependencies installed. We recently hit a case where some CI machines were timing out while running the test suite because a few tests were hanging. With this option, we'll be able to know if the machine does not have psutil installed so we can install it and avoid the timeout scenario altogether.

rdar://103194447

Differential Revision: https://reviews.llvm.org/D146335

(cherry picked from commit c47da7f109468efbe77c27d436fd69fa2b3ad991)