### PR TITLE
[clang][cas] Basic building and importing modules with include-tree 

### DIFF
--- a/clang/include/clang/Lex/PPCachedActions.h
+++ b/clang/include/clang/Lex/PPCachedActions.h
@@ -20,6 +20,7 @@
 namespace clang {
 
 class IdentifierInfo;
+class Module;
 class Preprocessor;
 
 /// This interface provides a way to override the actions of the preprocessor as
@@ -33,6 +34,7 @@ public:
   /// The file that is included by an \c #include directive.
   struct IncludeFile {
     FileID FID;
+    Module *Submodule;
   };
   /// The module that is imported by an \c #include directive or \c @import.
   struct IncludeModule {

--- a/clang/include/clang/Lex/PPCachedActions.h
+++ b/clang/include/clang/Lex/PPCachedActions.h
@@ -15,9 +15,11 @@
 #define LLVM_CLANG_LEX_PPCACHEDACTIONS_H
 
 #include "clang/Basic/SourceLocation.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace clang {
 
+class IdentifierInfo;
 class Preprocessor;
 
 /// This interface provides a way to override the actions of the preprocessor as
@@ -28,6 +30,15 @@ class PPCachedActions {
   virtual void anchor();
 
 public:
+  /// The file that is included by an \c #include directive.
+  struct IncludeFile {
+    FileID FID;
+  };
+  /// The module that is imported by an \c #include directive or \c @import.
+  struct IncludeModule {
+    SmallVector<std::pair<IdentifierInfo *, SourceLocation>, 2> ImportPath;
+  };
+
   virtual ~PPCachedActions() = default;
 
   /// \returns the \p FileID that should be used for predefines.
@@ -37,9 +48,10 @@ public:
   virtual bool evaluateHasInclude(Preprocessor &PP, SourceLocation Loc,
                                   bool IsIncludeNext) = 0;
 
-  /// \returns the \p FileID that should be entered for an include directive.
-  /// \p None indicates that the directive should be skipped.
-  virtual std::optional<FileID>
+  /// \returns the file that should be entered or module that should be imported
+  /// for an \c #include directive. \c {} indicates that the directive
+  /// should be skipped.
+  virtual std::variant<std::monostate, IncludeFile, IncludeModule>
   handleIncludeDirective(Preprocessor &PP, SourceLocation IncludeLoc,
                          SourceLocation AfterDirectiveLoc) = 0;
 

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2859,12 +2859,23 @@ determineInputFromIncludeTree(StringRef IncludeTreeID, CASOptions &CASOpts,
   auto Root = cas::IncludeTreeRoot::get(*CAS, *Object);
   if (!Root)
     return reportError(Root.takeError());
-  auto MainTree = Root->getMainFileTree();
-  if (!MainTree)
-    return reportError(MainTree.takeError());
-  auto BaseFile = MainTree->getBaseFile();
-  if (!BaseFile)
-    return reportError(BaseFile.takeError());
+
+  std::optional<cas::IncludeTree::File> BaseFile;
+
+  auto MaybeModuleMap = Root->getModuleMapFile();
+  if (!MaybeModuleMap)
+    return reportError(MaybeModuleMap.takeError());
+  if (*MaybeModuleMap) {
+    // Building a module from a modulemap, the modulemap is the primary input.
+    BaseFile = *MaybeModuleMap;
+  } else {
+    auto MainTree = Root->getMainFileTree();
+    if (!MainTree)
+      return reportError(MainTree.takeError());
+    if (llvm::Error E = MainTree->getBaseFile().moveInto(BaseFile))
+      return reportError(std::move(E));
+  }
+
   auto FilenameBlob = BaseFile->getFilename();
   if (!FilenameBlob)
     return reportError(FilenameBlob.takeError());

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -855,28 +855,31 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
     CI.getLangOpts().CurrentModule = CI.getLangOpts().ModuleName;
   }
 
+  auto reportError = [&](llvm::Error &&E) -> bool {
+    std::string IncludeTreeID =
+        CI.getOrCreateObjectStore().getID(Input.getIncludeTree()).toString();
+    CI.getDiagnostics().Report(diag::err_fe_unable_to_load_include_tree)
+        << IncludeTreeID << llvm::toString(std::move(E));
+    return false;
+  };
+
+  std::optional<cas::IncludeTreeRoot> IncludeTreeRoot;
   std::optional<StringRef> IncludeTreePCHBuffer;
   if (Input.isIncludeTree()) {
-    auto reportError = [&](llvm::Error &&E) -> bool {
-      std::string IncludeTreeID =
-          CI.getOrCreateObjectStore().getID(Input.getIncludeTree()).toString();
-      CI.getDiagnostics().Report(diag::err_fe_unable_to_load_include_tree)
-          << IncludeTreeID << llvm::toString(std::move(E));
-      return false;
-    };
-    auto Root = cas::IncludeTreeRoot::get(CI.getOrCreateObjectStore(),
-                                          Input.getIncludeTree());
-    if (!Root)
-      return reportError(Root.takeError());
+    if (llvm::Error E = cas::IncludeTreeRoot::get(CI.getOrCreateObjectStore(),
+                                                  Input.getIncludeTree())
+                            .moveInto(IncludeTreeRoot))
+      return reportError(std::move(E));
 
     Expected<std::unique_ptr<PPCachedActions>> PPCachedAct =
-        createPPActionsFromIncludeTree(*Root);
+        createPPActionsFromIncludeTree(*IncludeTreeRoot);
     if (!PPCachedAct)
       return reportError(PPCachedAct.takeError());
     CI.getPreprocessor().setPPCachedActions(std::move(*PPCachedAct));
     CI.getFrontendOpts().IncludeTimestamps = false;
 
-    if (llvm::Error E = Root->getPCHBuffer().moveInto(IncludeTreePCHBuffer))
+    if (llvm::Error E =
+            IncludeTreeRoot->getPCHBuffer().moveInto(IncludeTreePCHBuffer))
       return reportError(std::move(E));
   }
 
@@ -920,10 +923,25 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
       // If the module contents are in the same file, skip to them.
       CI.getPreprocessor().setSkipMainFilePreamble(OffsetToContents, true);
     else {
-      // Otherwise, convert the module description to a suitable input buffer.
-      auto Buffer = getInputBufferForModule(CI, CurrentModule);
-      if (!Buffer)
-        return false;
+      std::unique_ptr<llvm::MemoryBuffer> Buffer;
+      if (Input.isIncludeTree()) {
+        // Get the existing module include buffer from the include-tree.
+        assert(IncludeTreeRoot);
+        auto MainTree = IncludeTreeRoot->getMainFileTree();
+        if (!MainTree)
+          return reportError(MainTree.takeError());
+        auto BaseFile = MainTree->getBaseFile();
+        if (!BaseFile)
+          return reportError(BaseFile.takeError());
+        if (auto E = BaseFile->getMemoryBuffer().moveInto(Buffer))
+          return reportError(std::move(E));
+        assert(Buffer);
+      } else {
+        // Otherwise, convert the module description to a suitable input buffer.
+        Buffer = getInputBufferForModule(CI, CurrentModule);
+        if (!Buffer)
+          return false;
+      }
 
       // Reinitialize the main file entry to refer to the new input.
       auto Kind = CurrentModule->IsSystem ? SrcMgr::C_System : SrcMgr::C_User;

--- a/clang/lib/Frontend/IncludeTreePPActions.cpp
+++ b/clang/lib/Frontend/IncludeTreePPActions.cpp
@@ -61,7 +61,7 @@ public:
 
     IncludeStackInfo &IncludeInfo = IncludeStack.back();
     Expected<cas::IncludeTree> EnteredTree =
-        IncludeInfo.Tree.getInclude(IncludeInfo.CurIncludeIndex++);
+        IncludeInfo.Tree.getIncludeTree(IncludeInfo.CurIncludeIndex++);
     if (!EnteredTree)
       return reportError(EnteredTree.takeError());
     auto FileInfo = EnteredTree->getBaseFileInfo();
@@ -84,33 +84,47 @@ public:
     return IncludeInfo.Tree.getCheckResult(Index);
   }
 
-  std::optional<FileID>
+  std::variant<std::monostate, IncludeFile, IncludeModule>
   handleIncludeDirective(Preprocessor &PP, SourceLocation IncludeLoc,
                          SourceLocation AfterDirectiveLoc) override {
     if (HasCASErrorOccurred)
-      return std::nullopt;
+      return {};
 
     IncludeStackInfo &IncludeInfo = IncludeStack.back();
     if (IncludeInfo.CurIncludeIndex >= IncludeInfo.Tree.getNumIncludes())
-      return std::nullopt;
+      return {};
 
     unsigned ExpectedOffset =
         IncludeInfo.Tree.getIncludeOffset(IncludeInfo.CurIncludeIndex);
     SourceLocation ExpectedLoc =
         IncludeInfo.FileStartLoc.getLocWithOffset(ExpectedOffset);
     if (ExpectedLoc != AfterDirectiveLoc)
-      return std::nullopt;
+      return {};
 
-    auto reportError = [&](llvm::Error &&E) -> std::optional<FileID> {
+    auto reportError = [&](llvm::Error &&E) -> std::monostate {
       this->reportError(PP, std::move(E));
-      return std::nullopt;
+      return {};
     };
 
-    Expected<cas::IncludeTree> EnteredTree =
-        IncludeInfo.Tree.getInclude(IncludeInfo.CurIncludeIndex++);
-    if (!EnteredTree)
-      return reportError(EnteredTree.takeError());
-    auto File = EnteredTree->getBaseFile();
+    Expected<cas::IncludeTree::Node> Node =
+        IncludeInfo.Tree.getIncludeNode(IncludeInfo.CurIncludeIndex++);
+    if (!Node)
+      return reportError(Node.takeError());
+
+    if (Node->getKind() == cas::IncludeTree::NodeKind::ModuleImport) {
+      cas::IncludeTree::ModuleImport Import = Node->getModuleImport();
+      SmallVector<std::pair<IdentifierInfo *, SourceLocation>, 2> Path;
+      SmallVector<StringRef, 2> ModuleComponents;
+      Import.getModuleName().split(ModuleComponents, '.');
+      for (StringRef Component : ModuleComponents)
+        Path.emplace_back(PP.getIdentifierInfo(Component), IncludeLoc);
+      return IncludeModule{std::move(Path)};
+    }
+
+    assert(Node->getKind() == cas::IncludeTree::NodeKind::Tree);
+
+    cas::IncludeTree EnteredTree = Node->getIncludeTree();
+    auto File = EnteredTree.getBaseFile();
     if (!File)
       return reportError(File.takeError());
     auto FilenameBlob = File->getFilename();
@@ -124,11 +138,11 @@ public:
     if (!FE)
       return reportError(FE.takeError());
     FileID FID =
-        SM.createFileID(*FE, IncludeLoc, EnteredTree->getFileCharacteristic());
+        SM.createFileID(*FE, IncludeLoc, EnteredTree.getFileCharacteristic());
     PP.markIncluded(*FE);
     IncludeStack.push_back(
-        {std::move(*EnteredTree), SM.getLocForStartOfFile(FID)});
-    return FID;
+        {std::move(EnteredTree), SM.getLocForStartOfFile(FID)});
+    return IncludeFile{FID};
   }
 
   void exitedFile(Preprocessor &PP, FileID FID) override {

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2081,6 +2081,15 @@ void Preprocessor::HandleIncludeDirective(SourceLocation HashLoc,
       }
       EnterSourceFile(File->FID, nullptr, FilenameTok.getLocation(),
                       /*IsFirstIncludeOfFile*/ true);
+
+      if (Module *SM = File->Submodule) {
+        assert(!CurLexerSubmodule &&
+               "should not have marked this as a module yet");
+        CurLexerSubmodule = SM;
+        EnterSubmodule(SM, EndLoc, /*ForPragma=*/false);
+        EnterAnnotationToken(SourceRange(HashLoc, EndLoc),
+                             tok::annot_module_begin, SM);
+      }
       return;
     }
     if (auto *Import = std::get_if<PPCachedActions::IncludeModule>(&Include)) {

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2055,38 +2055,58 @@ void Preprocessor::HandleIncludeDirective(SourceLocation HashLoc,
     return;
   }
 
-  if (auto *CActions = getPPCachedActions()) {
-    DiscardUntilEndOfDirective();
-    SourceLocation IncludePos = FilenameTok.getLocation();
-    // If the filename string was the result of macro expansions, set the
-    // include position on the file where it will be included and after the
-    // expansions.
-    if (IncludePos.isMacroID())
-      IncludePos = SourceMgr.getExpansionRange(IncludePos).getEnd();
-    std::optional<FileID> FID = CActions->handleIncludeDirective(
-        *this, IncludePos, CurLexer->getSourceLocation());
-    if (!FID) {
-      // FIXME: Report \p Callbacks->FileSkipped? Note that it currently
-      // requires the resolved FileEntry for this particular #include.
-      return;
-    }
-    const FileEntry *FE = SourceMgr.getFileEntryForID(*FID);
-    bool IsImport =
-        IncludeTok.getIdentifierInfo()->getPPKeywordID() == tok::pp_import;
-    if (FE && IsImport) {
-      HeaderInfo.getFileInfo(FE).isImport = true;
-    }
-    EnterSourceFile(*FID, nullptr, FilenameTok.getLocation(),
-                    /*IsFirstIncludeOfFile*/ true);
-    return;
-  }
-
   // Verify that there is nothing after the filename, other than EOD.  Note
   // that we allow macros that expand to nothing after the filename, because
   // this falls into the category of "#include pp-tokens new-line" specified
   // in C99 6.10.2p4.
   SourceLocation EndLoc =
       CheckEndOfDirective(IncludeTok.getIdentifierInfo()->getNameStart(), true);
+
+  if (auto *CActions = getPPCachedActions()) {
+    SourceLocation IncludePos = FilenameTok.getLocation();
+    // If the filename string was the result of macro expansions, set the
+    // include position on the file where it will be included and after the
+    // expansions.
+    if (IncludePos.isMacroID())
+      IncludePos = SourceMgr.getExpansionRange(IncludePos).getEnd();
+    auto Include = CActions->handleIncludeDirective(
+        *this, IncludePos, CurLexer->getSourceLocation());
+
+    if (auto *File = std::get_if<PPCachedActions::IncludeFile>(&Include)) {
+      const FileEntry *FE = SourceMgr.getFileEntryForID(File->FID);
+      bool IsImport =
+          IncludeTok.getIdentifierInfo()->getPPKeywordID() == tok::pp_import;
+      if (FE && IsImport) {
+        HeaderInfo.getFileInfo(FE).isImport = true;
+      }
+      EnterSourceFile(File->FID, nullptr, FilenameTok.getLocation(),
+                      /*IsFirstIncludeOfFile*/ true);
+      return;
+    }
+    if (auto *Import = std::get_if<PPCachedActions::IncludeModule>(&Include)) {
+      ModuleLoadResult Imported = TheModuleLoader.loadModule(
+          IncludeTok.getLocation(), Import->ImportPath, Module::Hidden,
+          /*IsIncludeDirective=*/true);
+      if (!Imported) {
+        assert(hadModuleLoaderFatalFailure() && "unexpected failure kind");
+        if (hadModuleLoaderFatalFailure()) {
+          IncludeTok.setKind(tok::eof);
+          CurLexer->cutOffLexing();
+        }
+        return;
+      }
+      makeModuleVisible(Imported, EndLoc);
+      if (IncludeTok.getIdentifierInfo()->getPPKeywordID() !=
+          tok::pp___include_macros)
+        EnterAnnotationToken(SourceRange(HashLoc, EndLoc),
+                             tok::annot_module_include, Imported);
+      return;
+    }
+    assert(std::holds_alternative<std::monostate>(Include));
+    // FIXME: Report \p Callbacks->FileSkipped? Note that it currently
+    // requires the resolved FileEntry for this particular #include.
+    return;
+  }
 
   auto Action = HandleHeaderIncludeOrImport(HashLoc, IncludeTok, FilenameTok,
                                             EndLoc, LookupFrom, LookupFromFile);

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -486,6 +486,10 @@ IncludeTreeBuilder::finishIncludeTree(CompilerInstance &ScanInstance,
       return std::move(E);
   }
 
+  for (StringRef ModuleMap : FrontendOpts.ModuleMapFiles)
+    if (Error E = addFile(ModuleMap))
+      return std::move(E);
+
   auto FinishIncludeTree = [&]() -> Error {
     IntrusiveRefCntPtr<ASTReader> Reader = ScanInstance.getASTReader();
     if (!Reader)

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -35,12 +35,16 @@ void tooling::dependencies::configureInvocationForCaching(
   if (ProduceIncludeTree) {
     FrontendOpts.CASIncludeTreeID = std::move(RootID);
     FrontendOpts.Inputs.clear();
-    // Preserve sysroot path to accommodate lookup for 'SDKSettings.json' during
-    // availability checking, and module files.
     HeaderSearchOptions &HSOpts = CI.getHeaderSearchOpts();
     HeaderSearchOptions OriginalHSOpts;
     std::swap(HSOpts, OriginalHSOpts);
+    // Preserve sysroot path to accommodate lookup for 'SDKSettings.json' during
+    // availability checking.
     HSOpts.Sysroot = std::move(OriginalHSOpts.Sysroot);
+    // Preserve resource-dir, which is added back by cc1_main if missing, and
+    // affects the cache key.
+    HSOpts.ResourceDir = std::move(OriginalHSOpts.ResourceDir);
+    // Preserve fmodule-file options.
     HSOpts.PrebuiltModuleFiles = std::move(OriginalHSOpts.PrebuiltModuleFiles);
     auto &PPOpts = CI.getPreprocessorOpts();
     // We don't need this because we save the contents of the PCH file in the

--- a/clang/test/ClangScanDeps/modules-include-tree-implementation.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-implementation.c
@@ -1,0 +1,58 @@
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// RUN: FileCheck %s -input-file %t/deps.json -check-prefix=NO_MODULES
+// NO_MODULES: "modules": []
+
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: cat %t/tu.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/tu.casid
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/tu.casid | FileCheck %s -DPREFIX=%/t
+// RUN: %clang @%t/tu.rsp
+
+// CHECK: [[PREFIX]]/tu.c llvmcas://{{[[:xdigit:]]+}}
+// CHECK: 1:1 <built-in> llvmcas://{{[[:xdigit:]]+}}
+
+// Note: this is surprising, but correct: when building the implementation files
+// of a module, the first include is textual but still uses the submodule
+// machinery. The second include is treated as a module import (unless in a PCH)
+// but will not actually import the module only trigger visibility changes.
+
+// CHECK: 2:1 [[PREFIX]]/Mod.h llvmcas://{{[[:xdigit:]]+}}
+// CHECK:   Submodule: Mod
+// CHECK: 3:1 (Module) Mod
+
+// CHECK: Files:
+// CHECK: [[PREFIX]]/tu.c llvmcas://{{[[:xdigit:]]+}}
+// CHECK: [[PREFIX]]/Mod.h llvmcas://{{[[:xdigit:]]+}}
+
+// Despite not importing the module, we need its modulemap for submodule info.
+// CHECK: [[PREFIX]]/module.modulemap llvmcas://{{[[:xdigit:]]+}}
+
+//--- cdb.json.template
+[{
+  "file": "DIR/tu.c",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu.c -I DIR -fmodule-name=Mod -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+}]
+
+//--- module.modulemap
+module Mod { header "Mod.h" }
+
+//--- Mod.h
+#pragma once
+void top(void);
+
+//--- tu.c
+#include "Mod.h"
+#include "Mod.h"
+void tu(void) {
+  top();
+}

--- a/clang/test/ClangScanDeps/modules-include-tree-submodules.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-submodules.c
@@ -1,0 +1,147 @@
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -j 1 \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// Extract the include-tree commands
+// RUN: %deps-to-rsp %t/deps.json --module-name TwoSubs > %t/TwoSubs.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name WithExplicit > %t/WithExplicit.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu1.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 1 > %t/tu2.rsp
+
+// Extract include-tree casids
+// RUN: cat %t/TwoSubs.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/TwoSubs.casid
+// RUN: cat %t/WithExplicit.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/WithExplicit.casid
+// RUN: cat %t/tu1.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/tu1.casid
+// RUN: cat %t/tu2.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/tu2.casid
+
+// RUN: echo "MODULE TwoSubs" > %t/result.txt
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/TwoSubs.casid >> %t/result.txt
+// RUN: echo "MODULE WithExplicit" >> %t/result.txt
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/WithExplicit.casid >> %t/result.txt
+// RUN: echo "TRANSLATION UNIT 1" >> %t/result.txt
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/tu1.casid >> %t/result.txt
+// RUN: echo "TRANSLATION UNIT 2" >> %t/result.txt
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/tu2.casid >> %t/result.txt
+
+// RUN: FileCheck %s -input-file %t/result.txt -DPREFIX=%/t
+
+// Build the include-tree commands
+// RUN: %clang @%t/TwoSubs.rsp
+// RUN: %clang @%t/WithExplicit.rsp
+// RUN: not %clang @%t/tu1.rsp 2>&1 | FileCheck %s -check-prefix=TU1
+// RUN: not %clang @%t/tu2.rsp 2>&1 | FileCheck %s -check-prefix=TU2
+
+// CHECK: MODULE TwoSubs
+// CHECK: 2:1 [[PREFIX]]/Sub1.h llvmcas://{{[[:xdigit:]]+}}
+// CHECK:   Submodule: TwoSubs.Sub1
+// CHECK: 3:1 [[PREFIX]]/Sub2.h llvmcas://{{[[:xdigit:]]+}}
+// CHECK:   Submodule: TwoSubs.Sub2
+
+// CHECK: MODULE WithExplicit
+// CHECK: 2:1 [[PREFIX]]/TopLevel.h llvmcas://{{[[:xdigit:]]+}}
+// CHECK:   Submodule: WithExplicit
+// CHECK: 3:1 [[PREFIX]]/Implicit.h llvmcas://{{[[:xdigit:]]+}}
+// CHECK:   Submodule: WithExplicit.Implicit
+// CHECK: 4:1 [[PREFIX]]/Explicit.h llvmcas://{{[[:xdigit:]]+}}
+// CHECK:   Submodule: WithExplicit.Explicit
+
+// CHECK: TRANSLATION UNIT 1
+// CHECK: [[PREFIX]]/tu1.c llvmcas://{{[[:xdigit:]]+}}
+// CHECK: 1:1 <built-in> llvmcas://{{[[:xdigit:]]+}}
+// CHECK: 2:1 (Module) TwoSubs.Sub1
+// CHECK: 3:1 (Module) WithExplicit
+
+// CHECK: TRANSLATION UNIT 2
+// CHECK: [[PREFIX]]/tu2.c llvmcas://{{[[:xdigit:]]+}}
+// CHECK: 1:1 <built-in> llvmcas://{{[[:xdigit:]]+}}
+// CHECK: 2:1 (Module) TwoSubs.Sub2
+// CHECK: 3:1 (Module) WithExplicit.Explicit
+
+//--- cdb.json.template
+[
+{
+  "file": "DIR/tu1.c",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu1.c -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+},
+{
+  "file": "DIR/tu2.c",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu2.c -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+},
+]
+
+//--- module.modulemap
+module TwoSubs {
+  module Sub1 { header "Sub1.h" }
+  module Sub2 { header "Sub2.h" }
+}
+
+module WithExplicit {
+  header "TopLevel.h"
+  module Implicit { header "Implicit.h" }
+  explicit module Explicit { header "Explicit.h" }
+}
+
+//--- Sub1.h
+void sub1(void);
+
+//--- Sub2.h
+void sub2(void);
+
+//--- TopLevel.h
+void top(void);
+
+//--- Implicit.h
+void implicit(void);
+
+//--- Explicit.h
+void explicit(void);
+
+//--- tu1.c
+#include "Sub1.h"
+#include "TopLevel.h"
+
+void tu1(void) {
+  top();
+  sub1();
+  implicit();
+  sub2();
+// TU1-NOT: error:
+// TU1: error: call to undeclared function 'sub2'
+// TU1: error: missing '#include "Sub2.h"'
+// TU1: note: declaration here is not visible
+  explicit();
+// TU1: error: call to undeclared function 'explicit'
+// TU1: error: missing '#include "Explicit.h"'
+// TU1: Explicit.h:1:6: note: declaration here is not visible
+}
+
+//--- tu2.c
+#include "Sub2.h"
+#include "Explicit.h"
+
+void tu2(void) {
+  sub2();
+  explicit();
+// TU2-NOT: error:
+  top();
+// TU2: error: call to undeclared function 'top'
+// TU2: error: missing '#include "TopLevel.h"'
+// TU2: note: declaration here is not visible
+  sub1();
+// TU2: error: call to undeclared function 'sub1'
+// TU2: error: missing '#include "Sub1.h"'
+// TU2: note: declaration here is not visible
+  implicit();
+// TU2: error: call to undeclared function 'implicit'
+// TU2: error: missing '#include "Implicit.h"'
+// TU2: note: declaration here is not visible
+}

--- a/clang/test/ClangScanDeps/modules-include-tree-with-pch.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-with-pch.c
@@ -1,0 +1,156 @@
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+// RUN: sed "s|DIR|%/t|g" %t/cdb_pch.json.template > %t/cdb_pch.json
+
+// Scan PCH
+// RUN: clang-scan-deps -compilation-database %t/cdb_pch.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps_pch.json
+
+// Build PCH
+// RUN: %deps-to-rsp %t/deps_pch.json --module-name Top > %t/Top.rsp
+// RUN: %deps-to-rsp %t/deps_pch.json --module-name Left > %t/Left.rsp
+// RUN: %deps-to-rsp %t/deps_pch.json --tu-index 0 > %t/pch.rsp
+// RUN: %clang @%t/Top.rsp
+// RUN: %clang @%t/Left.rsp
+// RUN: rm -rf %t/outputs
+// RUN: %clang @%t/pch.rsp
+// RUN: rm -rf %t/outputs
+
+// Scan TU with PCH
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// Build TU
+// RUN: %deps-to-rsp %t/deps.json --module-name Right > %t/Right.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: %clang @%t/Right.rsp
+// RUN: rm -rf %t/outputs
+// RUN: %clang @%t/tu.rsp
+
+// RUN: FileCheck %s -input-file %t/deps.json -DPREFIX=%/t
+
+// CHECK:      {
+// CHECK-NEXT:  "modules": [
+// CHECK-NEXT:     {
+// CHECK:            "clang-module-deps": []
+// CHECK:            "clang-modulemap-file": "[[PREFIX]]/module.modulemap"
+// CHECK:            "command-line": [
+// CHECK-NEXT:         "-cc1"
+// CHECK:              "-fcas-path"
+// CHECK-NEXT:         "[[PREFIX]]/cas"
+// CHECK:              "-o"
+// CHECK-NEXT:         "[[PREFIX]]/outputs/{{.*}}/Right-{{.*}}.pcm"
+// CHECK:              "-disable-free"
+// CHECK:              "-fno-pch-timestamp"
+// CHECK:              "-fcas-include-tree"
+// CHECK-NEXT:         "[[RIGHT_TREE:llvmcas://[[:xdigit:]]+]]"
+// CHECK:              "-fcache-compile-job"
+// CHECK:              "-emit-module"
+// CHECK:              "-fmodule-file=[[PREFIX]]/outputs/{{.*}}/Top-{{.*}}.pcm"
+// CHECK:              "-fmodule-file-cache-key"
+// CHECK-NEXT:         "[[PREFIX]]/{{.*}}/Top-{{.*}}.pcm"
+// CHECK-NEXT:         "llvmcas://{{[[:xdigit:]]+}}"
+// CHECK:              "-x"
+// CHECK-NEXT:         "c"
+// CHECK:              "-fmodules"
+// CHECK:              "-fmodule-name=Right"
+// CHECK:              "-fno-implicit-modules"
+// CHECK:            ]
+// CHECK:            "file-deps": [
+// CHECK-NEXT:         "[[PREFIX]]/Right.h"
+// CHECK-NEXT:         "[[PREFIX]]/module.modulemap"
+// CHECK-NEXT:       ]
+// CHECK:            "name": "Right"
+// CHECK:          }
+// CHECK-NOT: "clang-modulemap-file"
+// CHECK:        ]
+// CHECK-NEXT:   "translation-units": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "commands": [
+// CHECK-NEXT:         {
+// CHECK:                "clang-module-deps": [
+// CHECK-NEXT:             {
+// CHECK:                    "module-name": "Right"
+// CHECK:                  }
+// CHECK-NEXT:           ]
+// CHECK:                "command-line": [
+// CHECK-NEXT:             "-cc1"
+// CHECK:                  "-fcas-path"
+// CHECK-NEXT:             "[[PREFIX]]/cas"
+// CHECK:                  "-fmodule-map-file=[[PREFIX]]/module.modulemap"
+// CHECK:                  "-disable-free"
+// CHECK:                  "-fcas-include-tree"
+// CHECK-NEXT:             "llvmcas://{{[[:xdigit:]]+}}"
+// CHECK:                  "-fcache-compile-job"
+// CHECK:                  "-fsyntax-only"
+// CHECK:                  "-fmodule-file-cache-key"
+// CHECK-NEXT:             "[[PREFIX]]/outputs/{{.*}}/Right-{{.*}}.pcm"
+// CHECK-NEXT:             "llvmcas://{{[[:xdigit:]]+}}"
+// CHECK:                  "-x"
+// CHECK-NEXT:             "c"
+// CHECK:                  "-fmodule-file=Right=[[PREFIX]]/outputs/{{.*}}/Right-{{.*}}.pcm"
+// CHECK:                  "-fmodules"
+// CHECK:                  "-fno-implicit-modules"
+// CHECK:                ]
+// CHECK:                "file-deps": [
+// CHECK-NEXT:             "[[PREFIX]]/tu.c"
+// CHECK-NEXT:             "[[PREFIX]]/prefix.h.pch"
+// CHECK-NEXT:           ]
+// CHECK:                "input-file": "[[PREFIX]]/tu.c"
+// CHECK:              }
+// CHECK-NEXT:       ]
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ]
+// CHECK-NEXT: }
+
+//--- cdb_pch.json.template
+[{
+  "file": "DIR/prefix.h",
+  "directory": "DIR",
+  "command": "clang -x c-header DIR/prefix.h -o DIR/prefix.h.pch -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+}]
+
+//--- cdb.json.template
+[{
+  "file": "DIR/tu.c",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu.c -include DIR/prefix.h -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+}]
+
+//--- module.modulemap
+module Top { header "Top.h" export *}
+module Left { header "Left.h" export *}
+module Right { header "Right.h" export *}
+
+//--- Top.h
+#pragma once
+struct Top { int x; };
+
+//--- Left.h
+#pragma once
+#include "Top.h"
+struct Left { struct Top top; };
+
+//--- Right.h
+#pragma once
+#include "Top.h"
+struct Right { struct Top top; };
+
+//--- prefix.h
+#include "Left.h"
+
+//--- tu.c
+#include "Right.h"
+
+void tu(void) {
+  struct Left _left;
+  struct Right _right;
+  struct Top _top;
+}

--- a/clang/test/ClangScanDeps/modules-include-tree.c
+++ b/clang/test/ClangScanDeps/modules-include-tree.c
@@ -13,6 +13,8 @@
 // RUN: %deps-to-rsp %t/deps.json --module-name Top > %t/Top.rsp
 // RUN: %deps-to-rsp %t/deps.json --module-name Left > %t/Left.rsp
 // RUN: %deps-to-rsp %t/deps.json --module-name Right > %t/Right.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name ZAtImport > %t/ZAtImport.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name ZPragmaImport > %t/ZPragmaImport.rsp
 // RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
 
 // Extract include-tree casids
@@ -65,10 +67,15 @@
 // CHECK: [[PREFIX]]/Top.h llvmcas://{{[[:xdigit:]]+}}
 
 // CHECK-LABEL: TRANSLATION UNIT
-// CHECK: [[PREFIX]]/tu.c llvmcas://{{[[:xdigit:]]+}}
+// CHECK: [[PREFIX]]/tu.m llvmcas://{{[[:xdigit:]]+}}
 // CHECK: 1:1 <built-in> llvmcas://{{[[:xdigit:]]+}}
 // CHECK: 2:1 (Module) Left
 // CHECK: 3:1 (Module) Right
+
+// Note: the modules with explicit imports are imported via parser and are not
+// recorded in the include-tree; it's handled entirely by fmodule-map-file,
+// fmodule-file, and fmodule-file-cache-key options.
+
 // CHECK: Files:
 // CHECK: [[PREFIX]]/Left.h llvmcas://{{[[:xdigit:]]+}}
 // CHECK: [[PREFIX]]/module.modulemap llvmcas://{{[[:xdigit:]]+}}
@@ -101,8 +108,6 @@
 // CHECK:              "-fmodule-file-cache-key"
 // CHECK-NEXT:         "[[PREFIX]]/outputs/{{.*}}/Top-{{.*}}.pcm"
 // CHECK-NEXT:         "llvmcas://{{[[:xdigit:]]+}}"
-// CHECK:              "-x"
-// CHECK-NEXT:         "c"
 // CHECK:              "-fmodule-file=Top=[[PREFIX]]/outputs/{{.*}}/Top-{{.*}}.pcm"
 // CHECK:              "-fmodules"
 // CHECK:              "-fmodule-name=Left"
@@ -138,8 +143,6 @@
 // CHECK:              "-fmodule-file-cache-key
 // CHECK-NEXT:         "[[PREFIX]]/outputs/{{.*}}/Top-{{.*}}.pcm"
 // CHECK-NEXT:         "llvmcas://{{[[:xdigit:]]+}}"
-// CHECK:              "-x"
-// CHECK-NEXT:         "c"
 // CHECK:              "-fmodule-file=Top=[[PREFIX]]/outputs/{{.*}}/Top-{{.*}}.pcm"
 // CHECK:              "-fmodules"
 // CHECK:              "-fmodule-name=Right"
@@ -167,8 +170,6 @@
 // CHECK-NEXT:         "[[TOP_TREE]]"
 // CHECK:              "-fcache-compile-job"
 // CHECK:              "-emit-module"
-// CHECK:              "-x"
-// CHECK-NEXT:         "c"
 // CHECK:              "-fmodules"
 // CHECK:              "-fmodule-name=Top"
 // CHECK:              "-fno-implicit-modules"
@@ -178,6 +179,58 @@
 // CHECK-NEXT:         "[[PREFIX]]/module.modulemap"
 // CHECK-NEXT:       ]
 // CHECK:            "name": "Top"
+// CHECK:          }
+// CHECK-NEXT:     {
+// CHECK:            "cas-include-tree-id": "[[AT_IMPORT_TREE:llvmcas://[[:xdigit:]]+]]"
+// CHECK:            "clang-module-deps": []
+// CHECK:            "clang-modulemap-file": "[[PREFIX]]/module.modulemap"
+// CHECK:            "command-line": [
+// CHECK-NEXT:         "-cc1"
+// CHECK:              "-fcas-path"
+// CHECK-NEXT:         "[[PREFIX]]/cas"
+// CHECK:              "-o"
+// CHECK-NEXT:         "[[PREFIX]]/outputs/{{.*}}/ZAtImport-{{.*}}.pcm"
+// CHECK:              "-disable-free"
+// CHECK:              "-fno-pch-timestamp"
+// CHECK:              "-fcas-include-tree"
+// CHECK-NEXT:         "[[AT_IMPORT_TREE]]"
+// CHECK:              "-fcache-compile-job"
+// CHECK:              "-emit-module"
+// CHECK:              "-fmodules"
+// CHECK:              "-fmodule-name=ZAtImport"
+// CHECK:              "-fno-implicit-modules"
+// CHECK:            ]
+// CHECK:            "file-deps": [
+// CHECK-NEXT:         "[[PREFIX]]/AtImport.h"
+// CHECK-NEXT:         "[[PREFIX]]/module.modulemap"
+// CHECK-NEXT:       ]
+// CHECK:            "name": "ZAtImport"
+// CHECK:          }
+// CHECK-NEXT:     {
+// CHECK:            "cas-include-tree-id": "[[PRAGMA_IMPORT_TREE:llvmcas://[[:xdigit:]]+]]"
+// CHECK:            "clang-module-deps": []
+// CHECK:            "clang-modulemap-file": "[[PREFIX]]/module.modulemap"
+// CHECK:            "command-line": [
+// CHECK-NEXT:         "-cc1"
+// CHECK:              "-fcas-path"
+// CHECK-NEXT:         "[[PREFIX]]/cas"
+// CHECK:              "-o"
+// CHECK-NEXT:         "[[PREFIX]]/outputs/{{.*}}/ZPragmaImport-{{.*}}.pcm"
+// CHECK:              "-disable-free"
+// CHECK:              "-fno-pch-timestamp"
+// CHECK:              "-fcas-include-tree"
+// CHECK-NEXT:         "[[PRAGMA_IMPORT_TREE]]"
+// CHECK:              "-fcache-compile-job"
+// CHECK:              "-emit-module"
+// CHECK:              "-fmodules"
+// CHECK:              "-fmodule-name=ZPragmaImport"
+// CHECK:              "-fno-implicit-modules"
+// CHECK:            ]
+// CHECK:            "file-deps": [
+// CHECK-NEXT:         "[[PREFIX]]/PragmaImport.h"
+// CHECK-NEXT:         "[[PREFIX]]/module.modulemap"
+// CHECK-NEXT:       ]
+// CHECK:            "name": "ZPragmaImport"
 // CHECK:          }
 // CHECK:        ]
 // CHECK-NEXT:   "translation-units": [
@@ -191,6 +244,12 @@
 // CHECK:                  }
 // CHECK-NEXT:             {
 // CHECK:                    "module-name": "Right"
+// CHECK:                  }
+// CHECK-NEXT:             {
+// CHECK:                    "module-name": "ZAtImport"
+// CHECK:                  }
+// CHECK-NEXT:             {
+// CHECK:                    "module-name": "ZPragmaImport"
 // CHECK:                  }
 // CHECK-NEXT:           ]
 // CHECK:                "command-line": [
@@ -209,17 +268,15 @@
 // CHECK:                  "-fmodule-file-cache-key"
 // CHECK-NEXT:             "[[PREFIX]]/outputs/{{.*}}/Right-{{.*}}.pcm"
 // CHECK-NEXT:             "llvmcas://{{[[:xdigit:]]+}}"
-// CHECK:                  "-x"
-// CHECK-NEXT:             "c"
 // CHECK:                  "-fmodule-file=Left=[[PREFIX]]/outputs/{{.*}}/Left-{{.*}}.pcm"
 // CHECK:                  "-fmodule-file=Right=[[PREFIX]]/outputs/{{.*}}/Right-{{.*}}.pcm"
 // CHECK:                  "-fmodules"
 // CHECK:                  "-fno-implicit-modules"
 // CHECK:                ]
 // CHECK:                "file-deps": [
-// CHECK-NEXT:             "[[PREFIX]]/tu.c"
+// CHECK-NEXT:             "[[PREFIX]]/tu.m"
 // CHECK-NEXT:           ]
-// CHECK:                "input-file": "[[PREFIX]]/tu.c"
+// CHECK:                "input-file": "[[PREFIX]]/tu.m"
 // CHECK:              }
 // CHECK-NEXT:       ]
 // CHECK-NEXT:     }
@@ -234,12 +291,18 @@
 // RUN: rm -rf %t/outputs
 // RUN: %clang @%t/Right.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_MISS
 // RUN: rm -rf %t/outputs
+// RUN: %clang @%t/ZAtImport.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_MISS
+// RUN: rm -rf %t/outputs
+// RUN: %clang @%t/ZPragmaImport.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_MISS
+// RUN: rm -rf %t/outputs
 // RUN: %clang @%t/tu.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_MISS
 
 // Check cache hits
 // RUN: %clang @%t/Top.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_HIT
 // RUN: %clang @%t/Left.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_HIT
 // RUN: %clang @%t/Right.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_HIT
+// RUN: %clang @%t/ZAtImport.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_HIT
+// RUN: %clang @%t/ZPragmaImport.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_HIT
 // RUN: %clang @%t/tu.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_HIT
 
 // CACHE_MISS: compile job cache miss
@@ -247,15 +310,17 @@
 
 //--- cdb.json.template
 [{
-  "file": "DIR/tu.c",
+  "file": "DIR/tu.m",
   "directory": "DIR",
-  "command": "clang -fsyntax-only DIR/tu.c -I DIR -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache"
+  "command": "clang -fsyntax-only DIR/tu.m -I DIR -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache"
 }]
 
 //--- module.modulemap
 module Top { header "Top.h" export *}
 module Left { header "Left.h" export *}
 module Right { header "Right.h" export *}
+module ZAtImport { header "AtImport.h" }
+module ZPragmaImport { header "PragmaImport.h" }
 
 //--- Top.h
 #pragma once
@@ -272,12 +337,22 @@ void left(void);
 #include "Top.h"
 void right(void);
 
-//--- tu.c
+//--- AtImport.h
+void at_import(void);
+
+//--- PragmaImport.h
+void pragma_import(void);
+
+//--- tu.m
 #import "Left.h"
 #import <Right.h>
+@import ZAtImport;
+#pragma clang module import ZPragmaImport
 
 void tu(void) {
   top();
   left();
   right();
+  at_import();
+  pragma_import();
 }

--- a/clang/unittests/CAS/IncludeTreeTest.cpp
+++ b/clang/unittests/CAS/IncludeTreeTest.cpp
@@ -79,7 +79,8 @@ TEST(IncludeTree, IncludeTreeScan) {
   ASSERT_EQ(Main->getNumIncludes(), uint32_t(3));
 
   std::optional<IncludeTree> Predef;
-  ASSERT_THAT_ERROR(Main->getInclude(0).moveInto(Predef), llvm::Succeeded());
+  ASSERT_THAT_ERROR(Main->getIncludeTree(0).moveInto(Predef),
+                    llvm::Succeeded());
   EXPECT_EQ(Main->getIncludeOffset(0), uint32_t(0));
   {
     EXPECT_EQ(Predef->getFileCharacteristic(), SrcMgr::C_User);
@@ -90,7 +91,7 @@ TEST(IncludeTree, IncludeTreeScan) {
   }
 
   std::optional<IncludeTree> A1;
-  ASSERT_THAT_ERROR(Main->getInclude(1).moveInto(A1), llvm::Succeeded());
+  ASSERT_THAT_ERROR(Main->getIncludeTree(1).moveInto(A1), llvm::Succeeded());
   EXPECT_EQ(Main->getIncludeOffset(1), uint32_t(21));
   {
     ASSERT_THAT_ERROR(A1->getBaseFile().moveInto(A1File), llvm::Succeeded());
@@ -104,7 +105,7 @@ TEST(IncludeTree, IncludeTreeScan) {
 
     ASSERT_EQ(A1->getNumIncludes(), uint32_t(1));
     std::optional<IncludeTree> B1;
-    ASSERT_THAT_ERROR(A1->getInclude(0).moveInto(B1), llvm::Succeeded());
+    ASSERT_THAT_ERROR(A1->getIncludeTree(0).moveInto(B1), llvm::Succeeded());
     EXPECT_EQ(A1->getIncludeOffset(0), uint32_t(122));
     {
       ASSERT_THAT_ERROR(B1->getBaseFile().moveInto(B1File), llvm::Succeeded());
@@ -119,7 +120,7 @@ TEST(IncludeTree, IncludeTreeScan) {
   }
 
   std::optional<IncludeTree> Sys;
-  ASSERT_THAT_ERROR(Main->getInclude(2).moveInto(Sys), llvm::Succeeded());
+  ASSERT_THAT_ERROR(Main->getIncludeTree(2).moveInto(Sys), llvm::Succeeded());
   EXPECT_EQ(Main->getIncludeOffset(2), uint32_t(42));
   {
     ASSERT_THAT_ERROR(Sys->getBaseFile().moveInto(SysFile), llvm::Succeeded());


### PR DESCRIPTION
This handles building and importing simple modules and PCH with modules
using include-tree, when modules are found via header path or explicit import.

* Extend `IncludeTree` to represent module imports and modulemap mainfile
* Make `IncludeTreeBuilder` add the new nodes for `#include`
* Make `PPDirectives` import modules from `PPCachedActions` in `#include`
* Teach FrontendAction/CompilerInvocation how to setup the main input file modulemap and module includes buffer from `IncludeTreeRoot`.
* Track the submodule of each modular header and enter the submodule via `PPCachedActions`


**Note: this is currently parsing modulemap files** even when building with the include-tree. A future commit will replace that with an explicit data structure for the specific things we need for include-tree builds.