### PR TITLE
[lldb] Fix crash when launching in terminal

### DIFF
--- a/lldb/source/Host/posix/ConnectionFileDescriptorPosix.cpp
+++ b/lldb/source/Host/posix/ConnectionFileDescriptorPosix.cpp
@@ -122,7 +122,8 @@ bool ConnectionFileDescriptor::IsConnected() const {
 
 ConnectionStatus ConnectionFileDescriptor::Connect(llvm::StringRef path,
                                                    Status *error_ptr) {
-  return Connect(path, nullptr, error_ptr);
+  return Connect(
+      path, [](llvm::StringRef) {}, error_ptr);
 }
 
 ConnectionStatus

--- a/lldb/unittests/Host/ConnectionFileDescriptorTest.cpp
+++ b/lldb/unittests/Host/ConnectionFileDescriptorTest.cpp
@@ -22,12 +22,21 @@ public:
     std::unique_ptr<TCPSocket> socket_a_up;
     std::unique_ptr<TCPSocket> socket_b_up;
     CreateTCPConnectedSockets(ip, &socket_a_up, &socket_b_up);
-    auto socket = socket_a_up.release();
+    auto *socket = socket_a_up.release();
     ConnectionFileDescriptor connection_file_descriptor(socket);
 
     std::string uri(connection_file_descriptor.GetURI());
     EXPECT_EQ((URI{"connect", ip, socket->GetRemotePortNumber(), "/"}),
               URI::Parse(uri).value());
+  }
+
+  void TestConnect(std::string ip, std::string path) {
+    std::unique_ptr<TCPSocket> socket_a_up;
+    std::unique_ptr<TCPSocket> socket_b_up;
+    CreateTCPConnectedSockets(ip, &socket_a_up, &socket_b_up);
+    auto *socket = socket_a_up.release();
+    ConnectionFileDescriptor connection_file_descriptor(socket);
+    connection_file_descriptor.Connect(path, nullptr);
   }
 };
 
@@ -41,4 +50,16 @@ TEST_F(ConnectionFileDescriptorTest, TCPGetURIv6) {
   if (!HostSupportsIPv6())
     return;
   TestGetURI("::1");
+}
+
+TEST_F(ConnectionFileDescriptorTest, Connectv4) {
+  if (!HostSupportsIPv4())
+    return;
+  TestConnect("127.0.0.1", "accept://127.0.0.1");
+}
+
+TEST_F(ConnectionFileDescriptorTest, Connectv6) {
+  if (!HostSupportsIPv6())
+    return;
+  TestConnect("::1", "accept://::1");
 }


### PR DESCRIPTION
This patch fixes a crash when using process launch -t to launch the
inferior from a TTY. The issue is that on Darwin, Host.mm is calling
ConnectionFileDescriptor::Connect without a socket_id_callback_type. The
overload passes nullptr as the function ref, which gets called
unconditionally as the socket_id_callback.

One potential way to fix this is to change all the lambdas to include a
null check, but instead I went with an empty lambda.

Differential revision: https://reviews.llvm.org/D124535

(cherry picked from commit 9aa6a479738c7bf21128f9c45ea4ffcf82d80cbf)
