### PR TITLE
[lldb] Skip TestSwiftForwardInteropExpressions on Linux instead of xfail

### DIFF
--- a/lldb/test/API/lang/swift/cxx_interop/forward/expressions/TestSwiftForwardInteropExpressions.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/expressions/TestSwiftForwardInteropExpressions.py
@@ -15,7 +15,7 @@ class TestSwiftForwardInteropExpressions(TestBase):
              self, bkpt_str, lldb.SBFileSpec('main.swift'))
          return thread
 
-    @expectedFailureAll(oslist=["linux"], bugnumber="rdar://106871422")
+    @skipIfLinux # rdar://106871422"
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false')) # rdar://106871275
     @swiftTest
     def test(self):


### PR DESCRIPTION
(cherry picked from commit f5d82443f0469bb86014b4d9a7a0ceec7924d95b)