### PR TITLE
SymbolFile: ensure that we have a value before invoking `getBitWidth`

### DIFF
--- a/lldb/source/Plugins/SymbolFile/PDB/PDBASTParser.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/PDBASTParser.cpp
@@ -1299,6 +1299,15 @@ void PDBASTParser::AddRecordMembers(
       // Query the symbol's value as the variable initializer if valid.
       if (member_comp_type.IsConst()) {
         auto value = member->getValue();
+        if (value.Type == llvm::pdb::Empty) {
+          LLDB_LOG(GetLog(LLDBLog::AST),
+                   "Class '{0}' has member '{1}' of type '{2}' with an unknown "
+                   "constant size.",
+                   record_type.GetTypeName(), member_name,
+                   member_comp_type.GetTypeName());
+          continue;
+        }
+
         clang::QualType qual_type = decl->getType();
         unsigned type_width = m_ast.getASTContext().getIntWidth(qual_type);
         unsigned constant_width = value.getBitWidth();


### PR DESCRIPTION
Ensure that the variant returned by `member->getValue()` has a value and is not `Empty`.  Failure to do so will trigger an assertion failure in `llvm::pdb::Variant::getBitWidth()`.  This can occur when the `static` member is a forward declaration.

Differential Revision: https://reviews.llvm.org/D146536
Reviewed By: sgraenitz

(cherry picked from commit 16b7cf245ec0ff5428daee4f71af62e1938bfc73)