### PR TITLE
[clang][cas] Move IncludeFile[List] to IncludeTree::File[List] NFC

### DIFF
--- a/clang/lib/CAS/IncludeTree.cpp
+++ b/clang/lib/CAS/IncludeTree.cpp
@@ -42,6 +42,20 @@ Expected<IncludeFile> IncludeFile::create(ObjectStore &DB, StringRef Filename,
   return IncludeTreeBase::create(DB, Refs, {});
 }
 
+Expected<IncludeFile> IncludeTree::getBaseFile() {
+  auto Node = getCAS().getProxy(getBaseFileRef());
+  if (!Node)
+    return Node.takeError();
+  return IncludeFile(std::move(*Node));
+}
+
+Expected<IncludeTree::FileInfo> IncludeTree::getBaseFileInfo() {
+  auto File = getBaseFile();
+  if (!File)
+    return File.takeError();
+  return File->getFileInfo();
+}
+
 llvm::Error IncludeTree::forEachInclude(
     llvm::function_ref<llvm::Error(std::pair<IncludeTree, uint32_t>)>
         Callback) {

--- a/clang/unittests/CAS/IncludeTreeTest.cpp
+++ b/clang/unittests/CAS/IncludeTreeTest.cpp
@@ -60,10 +60,10 @@ TEST(IncludeTree, IncludeTreeScan) {
           .moveInto(Root),
       llvm::Succeeded());
 
-  std::optional<IncludeFile> MainFile;
-  std::optional<IncludeFile> A1File;
-  std::optional<IncludeFile> B1File;
-  std::optional<IncludeFile> SysFile;
+  std::optional<IncludeTree::File> MainFile;
+  std::optional<IncludeTree::File> A1File;
+  std::optional<IncludeTree::File> B1File;
+  std::optional<IncludeTree::File> SysFile;
 
   std::optional<IncludeTree> Main;
   ASSERT_THAT_ERROR(Root->getMainFileTree().moveInto(Main), llvm::Succeeded());
@@ -132,31 +132,31 @@ TEST(IncludeTree, IncludeTreeScan) {
     ASSERT_EQ(Sys->getNumIncludes(), uint32_t(0));
   }
 
-  std::optional<IncludeFileList> FileList;
+  std::optional<IncludeTree::FileList> FileList;
   ASSERT_THAT_ERROR(Root->getFileList().moveInto(FileList), llvm::Succeeded());
   ASSERT_EQ(FileList->getNumFiles(), size_t(4));
   {
-    std::optional<IncludeFile> File;
+    std::optional<IncludeTree::File> File;
     ASSERT_THAT_ERROR(FileList->getFile(0).moveInto(File), llvm::Succeeded());
     EXPECT_EQ(File->getRef(), MainFile->getRef());
     EXPECT_EQ(FileList->getFileSize(0), MainContents.size());
   }
   {
-    std::optional<IncludeFile> File;
+    std::optional<IncludeTree::File> File;
     ASSERT_THAT_ERROR(FileList->getFile(1).moveInto(File), llvm::Succeeded());
     EXPECT_EQ(File->getRef(), A1File->getRef());
     EXPECT_EQ(FileList->getFileSize(1), A1Contents.size());
   }
   {
-    std::optional<IncludeFile> File;
+    std::optional<IncludeTree::File> File;
     ASSERT_THAT_ERROR(FileList->getFile(2).moveInto(File), llvm::Succeeded());
     EXPECT_EQ(File->getRef(), B1File->getRef());
-    EXPECT_EQ(FileList->getFileSize(2), IncludeFileList::FileSizeTy(0));
+    EXPECT_EQ(FileList->getFileSize(2), IncludeTree::FileList::FileSizeTy(0));
   }
   {
-    std::optional<IncludeFile> File;
+    std::optional<IncludeTree::File> File;
     ASSERT_THAT_ERROR(FileList->getFile(3).moveInto(File), llvm::Succeeded());
     EXPECT_EQ(File->getRef(), SysFile->getRef());
-    EXPECT_EQ(FileList->getFileSize(3), IncludeFileList::FileSizeTy(0));
+    EXPECT_EQ(FileList->getFileSize(3), IncludeTree::FileList::FileSizeTy(0));
   }
 }

--- a/clang/unittests/CAS/IncludeTreeTest.cpp
+++ b/clang/unittests/CAS/IncludeTreeTest.cpp
@@ -71,7 +71,7 @@ TEST(IncludeTree, IncludeTreeScan) {
     ASSERT_THAT_ERROR(Main->getBaseFile().moveInto(MainFile),
                       llvm::Succeeded());
     EXPECT_EQ(Main->getFileCharacteristic(), SrcMgr::C_User);
-    IncludeFile::FileInfo FI;
+    IncludeTree::FileInfo FI;
     ASSERT_THAT_ERROR(MainFile->getFileInfo().moveInto(FI), llvm::Succeeded());
     EXPECT_EQ(FI.Filename, "t.cpp");
     EXPECT_EQ(FI.Contents, MainContents);
@@ -83,7 +83,7 @@ TEST(IncludeTree, IncludeTreeScan) {
   EXPECT_EQ(Main->getIncludeOffset(0), uint32_t(0));
   {
     EXPECT_EQ(Predef->getFileCharacteristic(), SrcMgr::C_User);
-    IncludeFile::FileInfo FI;
+    IncludeTree::FileInfo FI;
     ASSERT_THAT_ERROR(Predef->getBaseFileInfo().moveInto(FI),
                       llvm::Succeeded());
     EXPECT_EQ(FI.Filename, "<built-in>");
@@ -95,7 +95,7 @@ TEST(IncludeTree, IncludeTreeScan) {
   {
     ASSERT_THAT_ERROR(A1->getBaseFile().moveInto(A1File), llvm::Succeeded());
     EXPECT_EQ(A1->getFileCharacteristic(), SrcMgr::C_User);
-    IncludeFile::FileInfo FI;
+    IncludeTree::FileInfo FI;
     ASSERT_THAT_ERROR(A1File->getFileInfo().moveInto(FI), llvm::Succeeded());
     EXPECT_EQ(FI.Filename, "./a1.h");
     EXPECT_EQ(FI.Contents, A1Contents);
@@ -109,7 +109,7 @@ TEST(IncludeTree, IncludeTreeScan) {
     {
       ASSERT_THAT_ERROR(B1->getBaseFile().moveInto(B1File), llvm::Succeeded());
       EXPECT_EQ(B1->getFileCharacteristic(), SrcMgr::C_User);
-      IncludeFile::FileInfo FI;
+      IncludeTree::FileInfo FI;
       ASSERT_THAT_ERROR(B1->getBaseFileInfo().moveInto(FI), llvm::Succeeded());
       EXPECT_EQ(FI.Filename, "./b1.h");
       EXPECT_EQ(FI.Contents, "");
@@ -124,7 +124,7 @@ TEST(IncludeTree, IncludeTreeScan) {
   {
     ASSERT_THAT_ERROR(Sys->getBaseFile().moveInto(SysFile), llvm::Succeeded());
     EXPECT_EQ(Sys->getFileCharacteristic(), SrcMgr::C_System);
-    IncludeFile::FileInfo FI;
+    IncludeTree::FileInfo FI;
     ASSERT_THAT_ERROR(Sys->getBaseFileInfo().moveInto(FI), llvm::Succeeded());
     EXPECT_EQ(FI.Filename, "sys/sys.h");
     EXPECT_EQ(FI.Contents, "");


### PR DESCRIPTION
First commit moves IncludeFile after IncludeTree in the header file, and  couple of methods moved to the cpp file due to incomplete types. Second commit does the actual move inside IncludeTree class, which is mechanical after the first commit.