### PR TITLE
[clang][cas] Create explicit IncludeTree::ModuleMap 

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -451,6 +451,14 @@ class ASTContext : public RefCountedBase<ASTContext> {
   /// we are building.
   Module *TopLevelCXXNamedModule = nullptr;
 
+  /// The include tree that is being built, if any.
+  /// See \c FrontendOptions::CASIncludeTreeID.
+  std::optional<std::string> CASIncludeTreeID;
+
+  /// The cas-fs tree that is being built, if any.
+  /// See \c FileSystemOptions::CASFileSystemRootID.
+  std::optional<std::string> CASFileSystemRootID;
+
   static constexpr unsigned ConstantArrayTypesLog2InitSize = 8;
   static constexpr unsigned GeneralTypesLog2InitSize = 9;
   static constexpr unsigned FunctionProtoTypesLog2InitSize = 12;
@@ -1056,6 +1064,20 @@ public:
 
   /// Get module under construction, nullptr if this is not a C++20 module.
   Module *getNamedModuleForCodeGen() const { return TopLevelCXXNamedModule; }
+
+  std::optional<std::string> getCASIncludeTreeID() const {
+    return CASIncludeTreeID;
+  }
+  void setCASIncludeTreeID(std::string ID) {
+    CASIncludeTreeID = std::move(ID);
+  }
+
+  std::optional<std::string> getCASFileSystemRootID() const {
+    return CASFileSystemRootID;
+  }
+  void setCASFileSystemRootID(std::string ID) {
+    CASFileSystemRootID = std::move(ID);
+  }
 
   TranslationUnitDecl *getTranslationUnitDecl() const {
     return TUDecl->getMostRecentDecl();

--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -228,6 +228,8 @@ def err_missing_module_name : Error<
   DefaultFatal;
 def err_missing_module : Error<
   "no module named '%0' declared in module map file '%1'">, DefaultFatal;
+def err_missing_module_include_tree : Error<
+  "no module named '%0' declared in include-tree module map '%1'">, DefaultFatal;
 def err_no_submodule : Error<"no submodule named %0 in module '%1'">;
 def err_no_submodule_suggest : Error<
   "no submodule named %0 in module '%1'; did you mean '%2'?">;

--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -932,6 +932,9 @@ def warn_defined_in_function_type_macro : Extension<
   "macro expansion producing 'defined' has undefined behavior">,
   InGroup<ExpansionToDefined>;
 
+def err_pp_missing_module_include_tree : Error<
+  "no module named '%0' declared in include-tree module map">, DefaultFatal;
+
 let CategoryName = "Nullability Issue" in {
 
 def err_pp_assume_nonnull_syntax : Error<"expected 'begin' or 'end'">;

--- a/clang/include/clang/Basic/Module.h
+++ b/clang/include/clang/Basic/Module.h
@@ -205,14 +205,6 @@ private:
   /// The \c ActionCache key for this module, if any.
   std::optional<std::string> ModuleCacheKey;
 
-  /// The CAS filesystem root ID for implicit modules built with the dependency
-  /// scanner, if any.
-  std::optional<std::string> CASFileSystemRootID;
-
-  /// The include-tree root ID for implicit modules built with the dependency
-  /// scanner, if any.
-  std::optional<std::string> IncludeTreeID;
-
   /// The top-level headers associated with this module.
   llvm::SmallSetVector<const FileEntry *, 2> TopHeaders;
 
@@ -651,24 +643,6 @@ public:
   void setModuleCacheKey(std::string Key) {
     assert(!getModuleCacheKey() || *getModuleCacheKey() == Key);
     getTopLevelModule()->ModuleCacheKey = std::move(Key);
-  }
-
-  std::optional<std::string> getCASFileSystemRootID() const {
-    return getTopLevelModule()->CASFileSystemRootID;
-  }
-
-  void setCASFileSystemRootID(std::string ID) {
-    assert(!getCASFileSystemRootID() || *getCASFileSystemRootID() == ID);
-    getTopLevelModule()->CASFileSystemRootID = std::move(ID);
-  }
-
-  std::optional<std::string> getIncludeTreeID() const {
-    return getTopLevelModule()->IncludeTreeID;
-  }
-
-  void setIncludeTreeID(std::string ID) {
-    assert(!getIncludeTreeID() || *getIncludeTreeID() == ID);
-    getTopLevelModule()->IncludeTreeID = std::move(ID);
   }
 
   /// Retrieve the directory for which this module serves as the

--- a/clang/include/clang/Basic/Module.h
+++ b/clang/include/clang/Basic/Module.h
@@ -108,6 +108,10 @@ public:
     /// of header files.
     ModuleMapModule,
 
+    /// This is a module that was defined by a module map and built out
+    /// of header files as part of an \c IncludeTree.
+    IncludeTreeModuleMap,
+
     /// This is a C++20 module interface unit.
     ModuleInterfaceUnit,
 
@@ -188,7 +192,9 @@ public:
 
   bool isPrivateModule() const { return Kind == PrivateModuleFragment; }
 
-  bool isModuleMapModule() const { return Kind == ModuleMapModule; }
+  bool isModuleMapModule() const {
+    return Kind == ModuleMapModule || Kind == IncludeTreeModuleMap;
+  }
 
 private:
   /// The submodules of this module, indexed by name.

--- a/clang/include/clang/CAS/IncludeTree.h
+++ b/clang/include/clang/CAS/IncludeTree.h
@@ -483,4 +483,26 @@ createIncludeTreeFileSystem(IncludeTreeRoot &Root);
 } // namespace cas
 } // namespace clang
 
+namespace llvm {
+template <> struct DenseMapInfo<clang::cas::IncludeTree::FileList::FileEntry> {
+  using FileEntry = clang::cas::IncludeTree::FileList::FileEntry;
+
+  static FileEntry getEmptyKey() {
+    return {cas::ObjectRef::getDenseMapEmptyKey(), 0};
+  }
+
+  static FileEntry getTombstoneKey() {
+    return {cas::ObjectRef::getDenseMapTombstoneKey(), 0};
+  }
+
+  static unsigned getHashValue(FileEntry F) {
+    return F.FileRef.getDenseMapHash();
+  }
+
+  static bool isEqual(FileEntry LHS, FileEntry RHS) {
+    return LHS.FileRef == RHS.FileRef && LHS.Size == RHS.Size;
+  }
+};
+} // namespace llvm
+
 #endif

--- a/clang/include/clang/CAS/IncludeTree.h
+++ b/clang/include/clang/CAS/IncludeTree.h
@@ -331,9 +331,12 @@ class IncludeTree::ModuleImport : public IncludeTreeBase<ModuleImport> {
 public:
   static constexpr StringRef getNodeKind() { return "ModI"; }
 
-  static Expected<ModuleImport> create(ObjectStore &DB, StringRef ModuleName);
+  static Expected<ModuleImport> create(ObjectStore &DB, StringRef ModuleName,
+                                       bool VisibilityOnly);
 
-  StringRef getModuleName() { return getData(); }
+  StringRef getModuleName() const { return getData().drop_front(); }
+  /// Whether this module should only be "marked visible" rather than imported.
+  bool visibilityOnly() const { return (bool)getData()[0]; }
 
   llvm::Error print(llvm::raw_ostream &OS, unsigned Indent = 0);
 
@@ -341,7 +344,7 @@ public:
     if (!IncludeTreeBase::isValid(Node))
       return false;
     IncludeTreeBase Base(Node);
-    return Base.getNumReferences() == 0 && !Base.getData().empty();
+    return Base.getNumReferences() == 0 && Base.getData().size() > 1;
   }
   static bool isValid(ObjectStore &DB, ObjectRef Ref) {
     auto Node = DB.getProxy(Ref);

--- a/clang/include/clang/CAS/IncludeTree.h
+++ b/clang/include/clang/CAS/IncludeTree.h
@@ -309,6 +309,10 @@ private:
     return File(std::move(*Node));
   }
 
+  llvm::Error
+  forEachFileImpl(llvm::DenseSet<ObjectRef> &Seen,
+                  llvm::function_ref<llvm::Error(File, FileSizeTy)> Callback);
+
   static bool isValid(const ObjectProxy &Node);
   static bool isValid(ObjectStore &CAS, ObjectRef Ref) {
     auto Node = CAS.getProxy(Ref);

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -246,6 +246,10 @@ public:
                     bool IsSystem = false)
       : File(File.str()), IncludeTree(std::move(Tree)), Kind(Kind),
         IsSystem(IsSystem) {}
+  FrontendInputFile(cas::ObjectRef Tree, llvm::MemoryBufferRef Buffer,
+                    InputKind Kind, bool IsSystem = false)
+      : Buffer(Buffer), IncludeTree(std::move(Tree)), Kind(Kind),
+        IsSystem(IsSystem) {}
 
   InputKind getKind() const { return Kind; }
   bool isSystem() const { return IsSystem; }

--- a/clang/include/clang/Lex/PPCachedActions.h
+++ b/clang/include/clang/Lex/PPCachedActions.h
@@ -39,6 +39,8 @@ public:
   /// The module that is imported by an \c #include directive or \c @import.
   struct IncludeModule {
     SmallVector<std::pair<IdentifierInfo *, SourceLocation>, 2> ImportPath;
+    // Whether this module should only be "marked visible" rather than imported.
+    bool VisibilityOnly;
   };
 
   virtual ~PPCachedActions() = default;

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -1596,6 +1596,7 @@ Module *Decl::getOwningModuleForLinkage(bool IgnoreLinkage) const {
 
   switch (M->Kind) {
   case Module::ModuleMapModule:
+  case Module::IncludeTreeModuleMap:
     // Module map modules have no special linkage semantics.
     return nullptr;
 

--- a/clang/lib/CAS/IncludeTree.cpp
+++ b/clang/lib/CAS/IncludeTree.cpp
@@ -212,9 +212,12 @@ bool IncludeTree::isValid(const ObjectProxy &Node) {
 }
 
 Expected<IncludeTree::ModuleImport>
-IncludeTree::ModuleImport::create(ObjectStore &DB, StringRef ModuleName) {
-  return IncludeTreeBase::create(DB, {},
-                                 llvm::arrayRefFromStringRef<char>(ModuleName));
+IncludeTree::ModuleImport::create(ObjectStore &DB, StringRef ModuleName,
+                                  bool VisibilityOnly) {
+  SmallString<64> Buffer;
+  Buffer.push_back((char)VisibilityOnly);
+  Buffer.append(ModuleName);
+  return IncludeTreeBase::create(DB, {}, Buffer);
 }
 
 IncludeTree::FileList::FileSizeTy
@@ -600,7 +603,11 @@ llvm::Error IncludeTree::FileList::print(llvm::raw_ostream &OS,
 
 llvm::Error IncludeTree::ModuleImport::print(llvm::raw_ostream &OS,
                                              unsigned Indent) {
-  OS << "(Module) " << getModuleName() << '\n';
+  if (visibilityOnly())
+    OS << "(Module for visibility only) ";
+  else
+    OS << "(Module) ";
+  OS << getModuleName() << '\n';
   return llvm::Error::success();
 }
 

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2837,11 +2837,10 @@ static void GenerateFrontendArgs(const FrontendOptions &Opts,
       Args.push_back(SA(Input.getFile()));
 }
 
-static void
-determineInputFromIncludeTree(StringRef IncludeTreeID, CASOptions &CASOpts,
-                              DiagnosticsEngine &Diags,
-                              std::optional<cas::IncludeTreeRoot> &IncludeTree,
-                              StringRef &InputFilename) {
+static void determineInputFromIncludeTree(
+    StringRef IncludeTreeID, CASOptions &CASOpts, DiagnosticsEngine &Diags,
+    std::optional<cas::IncludeTreeRoot> &IncludeTree,
+    std::optional<llvm::MemoryBufferRef> &Buffer, StringRef &InputFilename) {
   assert(!IncludeTreeID.empty());
   auto reportError = [&](llvm::Error &&E) {
     Diags.Report(diag::err_fe_unable_to_load_include_tree)
@@ -2859,28 +2858,27 @@ determineInputFromIncludeTree(StringRef IncludeTreeID, CASOptions &CASOpts,
   auto Root = cas::IncludeTreeRoot::get(*CAS, *Object);
   if (!Root)
     return reportError(Root.takeError());
-
-  std::optional<cas::IncludeTree::File> BaseFile;
-
-  auto MaybeModuleMap = Root->getModuleMapFile();
-  if (!MaybeModuleMap)
-    return reportError(MaybeModuleMap.takeError());
-  if (*MaybeModuleMap) {
-    // Building a module from a modulemap, the modulemap is the primary input.
-    BaseFile = *MaybeModuleMap;
-  } else {
-    auto MainTree = Root->getMainFileTree();
-    if (!MainTree)
-      return reportError(MainTree.takeError());
-    if (llvm::Error E = MainTree->getBaseFile().moveInto(BaseFile))
-      return reportError(std::move(E));
-  }
-
+  auto MainTree = Root->getMainFileTree();
+  if (!MainTree)
+    return reportError(MainTree.takeError());
+  auto BaseFile = MainTree->getBaseFile();
+  if (!BaseFile)
+    return reportError(BaseFile.takeError());
   auto FilenameBlob = BaseFile->getFilename();
   if (!FilenameBlob)
     return reportError(FilenameBlob.takeError());
+
   InputFilename = FilenameBlob->getData();
   IncludeTree = *Root;
+
+  if (InputFilename != Module::getModuleInputBufferName())
+    return;
+
+  // Handle <module-include> buffer
+  auto Contents = BaseFile->getContents();
+  if (!Contents)
+    return reportError(Contents.takeError());
+  Buffer = llvm::MemoryBufferRef(Contents->getData(), InputFilename);
 }
 
 static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
@@ -3102,13 +3100,14 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   Opts.Inputs.clear();
 
   std::optional<cas::IncludeTreeRoot> Tree;
+  std::optional<llvm::MemoryBufferRef> TreeInputBuffer;
   if (!Opts.CASIncludeTreeID.empty()) {
     if (!Inputs.empty()) {
       Diags.Report(diag::err_drv_inputs_and_include_tree);
     }
     StringRef InputFilename;
     determineInputFromIncludeTree(Opts.CASIncludeTreeID, CASOpts, Diags, Tree,
-                                  InputFilename);
+                                  TreeInputBuffer, InputFilename);
     if (!InputFilename.empty())
       Inputs.push_back(InputFilename.str());
   }
@@ -3147,8 +3146,16 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
 
   if (Tree) {
     FrontendInputFile &InputFile = Opts.Inputs.back();
-    InputFile = FrontendInputFile(Tree->getRef(), InputFile.getFile(),
-                                  InputFile.getKind(), InputFile.isSystem());
+    if (TreeInputBuffer) {
+      // This is automatically set to modulemap when building a module; revert
+      // to a source file for the module includes buffer.
+      auto Kind = InputFile.getKind().withFormat(InputKind::Source);
+      InputFile = FrontendInputFile(Tree->getRef(), *TreeInputBuffer, Kind,
+                                    InputFile.isSystem());
+    } else {
+      InputFile = FrontendInputFile(Tree->getRef(), InputFile.getFile(),
+                                    InputFile.getKind(), InputFile.isSystem());
+    }
   }
 
   Opts.DashX = DashX;

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -549,6 +549,116 @@ static Module *prepareToBuildModule(CompilerInstance &CI,
   return M;
 }
 
+static Expected<Module *> makeIncludeTreeModule(CompilerInstance &CI,
+                                                cas::IncludeTree::Module Mod,
+                                                Module *Parent) {
+  ModuleMap &MMap = CI.getPreprocessor().getHeaderSearchInfo().getModuleMap();
+  auto Flags = Mod.getFlags();
+  Module *M = nullptr;
+  bool NewModule = false;
+  std::tie(M, NewModule) = MMap.findOrCreateModule(
+      Mod.getName(), Parent, Flags.IsFramework, Flags.IsExplicit);
+  assert(NewModule);
+  M->Kind = Module::IncludeTreeModuleMap;
+  M->IsExternC = Flags.IsExternC;
+  M->IsSystem = Flags.IsSystem;
+
+  auto ExportList = Mod.getExports();
+  if (!ExportList)
+    return ExportList.takeError();
+  if (*ExportList) {
+    if ((*ExportList)->hasGlobalWildcard())
+      M->Exports.push_back(Module::ExportDecl(nullptr, true));
+
+    llvm::Error Err = (*ExportList)->forEachExplicitExport([&](auto Export) {
+      Module::UnresolvedExportDecl UED;
+      SmallVector<StringRef> ModuleComponents;
+      Export.ModuleName.split(ModuleComponents, '.');
+      for (StringRef Name : ModuleComponents)
+        UED.Id.push_back({std::string(Name), SourceLocation()});
+      UED.Wildcard = Export.Wildcard;
+      M->UnresolvedExports.push_back(std::move(UED));
+      return llvm::Error::success();
+    });
+    if (Err)
+      return std::move(Err);
+  }
+
+  auto LinkLibs = Mod.getLinkLibraries();
+  if (!LinkLibs)
+    return LinkLibs.takeError();
+  if (*LinkLibs) {
+    llvm::Error Err = (*LinkLibs)->forEachLinkLibrary([&](auto LL) {
+      M->LinkLibraries.emplace_back(std::string(LL.Library), LL.IsFramework);
+      return llvm::Error::success();
+    });
+    if (Err)
+      return std::move(Err);
+  }
+
+  llvm::Error Err = Mod.forEachSubmodule([&](cas::IncludeTree::Module Sub) {
+    return makeIncludeTreeModule(CI, Sub, M).takeError();
+  });
+  if (Err)
+    return std::move(Err);
+  return M;
+}
+
+/// Loads the include tree modulemap \p MM.
+/// \returns true if there was an error.
+static bool loadIncludeTreeModuleMap(CompilerInstance &CI,
+                                     cas::IncludeTree::ModuleMap MM) {
+  llvm::Error Err = MM.forEachModule([&](auto M) -> llvm::Error {
+    return makeIncludeTreeModule(CI, M, /*Parent=*/nullptr).takeError();
+  });
+  if (Err) {
+    CI.getDiagnostics().Report(diag::err_fe_unable_to_load_include_tree)
+        << CI.getFrontendOpts().CASIncludeTreeID << std::move(Err);
+    return true;
+  }
+  return false;
+}
+
+static Module *prepareToBuildModule(CompilerInstance &CI,
+                                    cas::IncludeTree::ModuleMap MM) {
+  if (CI.getLangOpts().CurrentModule.empty()) {
+    CI.getDiagnostics().Report(diag::err_missing_module_name);
+
+    // FIXME: Eventually, we could consider asking whether there was just
+    // a single module described in the module map, and use that as a
+    // default. Then it would be fairly trivial to just "compile" a module
+    // map with a single module (the common case).
+    return nullptr;
+  }
+
+  if (loadIncludeTreeModuleMap(CI, MM))
+    return nullptr;
+
+  // Dig out the module definition.
+  HeaderSearch &HS = CI.getPreprocessor().getHeaderSearchInfo();
+  Module *M = HS.lookupModule(CI.getLangOpts().CurrentModule, SourceLocation(),
+                              /*AllowSearch=*/false);
+  if (!M) {
+    CI.getDiagnostics().Report(diag::err_missing_module_include_tree)
+        << CI.getLangOpts().CurrentModule
+        << CI.getFrontendOpts().CASIncludeTreeID;
+
+    return nullptr;
+  }
+
+  if (auto CacheKey = CI.getCompileJobCacheKey())
+    M->setModuleCacheKey(CacheKey->toString());
+
+  // If we're being run from the command-line, the module build stack will not
+  // have been filled in yet, so complete it now in order to allow us to detect
+  // module cycles.
+  SourceManager &SourceMgr = CI.getSourceManager();
+  if (SourceMgr.getModuleBuildStack().empty())
+    SourceMgr.pushModuleBuildStack(CI.getLangOpts().CurrentModule,
+                                   FullSourceLoc(SourceLocation(), SourceMgr));
+  return M;
+}
+
 /// Compute the input buffer that should be used to build the specified module.
 static std::unique_ptr<llvm::MemoryBuffer>
 getInputBufferForModule(CompilerInstance &CI, Module *M) {
@@ -881,6 +991,21 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
     if (llvm::Error E =
             IncludeTreeRoot->getPCHBuffer().moveInto(IncludeTreePCHBuffer))
       return reportError(std::move(E));
+
+    auto ModMap = IncludeTreeRoot->getModuleMap();
+    if (!ModMap)
+      return reportError(ModMap.takeError());
+    if (*ModMap) {
+      if (CI.getFrontendOpts().ProgramAction == frontend::GenerateModule) {
+        auto *CurrentModule = prepareToBuildModule(CI, **ModMap);
+        if (!CurrentModule)
+          return false;
+        CI.getLangOpts().setCompilingModule(LangOptions::CMK_ModuleMap);
+      } else {
+        if (loadIncludeTreeModuleMap(CI, **ModMap))
+          return false;
+      }
+    }
   }
 
   if (!CI.InitializeSourceManager(Input))
@@ -923,25 +1048,10 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
       // If the module contents are in the same file, skip to them.
       CI.getPreprocessor().setSkipMainFilePreamble(OffsetToContents, true);
     else {
-      std::unique_ptr<llvm::MemoryBuffer> Buffer;
-      if (Input.isIncludeTree()) {
-        // Get the existing module include buffer from the include-tree.
-        assert(IncludeTreeRoot);
-        auto MainTree = IncludeTreeRoot->getMainFileTree();
-        if (!MainTree)
-          return reportError(MainTree.takeError());
-        auto BaseFile = MainTree->getBaseFile();
-        if (!BaseFile)
-          return reportError(BaseFile.takeError());
-        if (auto E = BaseFile->getMemoryBuffer().moveInto(Buffer))
-          return reportError(std::move(E));
-        assert(Buffer);
-      } else {
-        // Otherwise, convert the module description to a suitable input buffer.
-        Buffer = getInputBufferForModule(CI, CurrentModule);
-        if (!Buffer)
-          return false;
-      }
+      // Otherwise, convert the module description to a suitable input buffer.
+      auto Buffer = getInputBufferForModule(CI, CurrentModule);
+      if (!Buffer)
+        return false;
 
       // Reinitialize the main file entry to refer to the new input.
       auto Kind = CurrentModule->IsSystem ? SrcMgr::C_System : SrcMgr::C_User;

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -1066,6 +1066,10 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
       }
     }
 
+    if (!CI.getFrontendOpts().CASIncludeTreeID.empty())
+      CI.getASTContext().setCASIncludeTreeID(
+          CI.getFrontendOpts().CASIncludeTreeID);
+
     CI.setASTConsumer(std::move(Consumer));
     if (!CI.hasASTConsumer())
       return false;

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -757,6 +757,8 @@ static StringRef ModuleKindName(Module::ModuleKind MK) {
   switch (MK) {
   case Module::ModuleMapModule:
     return "Module Map Module";
+  case Module::IncludeTreeModuleMap:
+    return "Include Tree Module";
   case Module::ModuleInterfaceUnit:
     return "Interface Unit";
   case Module::ModulePartitionInterface:

--- a/clang/lib/Frontend/IncludeTreePPActions.cpp
+++ b/clang/lib/Frontend/IncludeTreePPActions.cpp
@@ -123,7 +123,7 @@ public:
       Import.getModuleName().split(ModuleComponents, '.');
       for (StringRef Component : ModuleComponents)
         Path.emplace_back(PP.getIdentifierInfo(Component), IncludeLoc);
-      return IncludeModule{std::move(Path)};
+      return IncludeModule{std::move(Path), Import.visibilityOnly()};
     }
 
     assert(Node->getKind() == cas::IncludeTree::NodeKind::Tree);

--- a/clang/lib/Frontend/IncludeTreePPActions.cpp
+++ b/clang/lib/Frontend/IncludeTreePPActions.cpp
@@ -167,6 +167,12 @@ public:
           return reportErrorTwine(
               llvm::Twine("failed to find or infer submodule '") + Sub + "'");
       }
+
+      // Add to known headers for the module.
+      ModuleMap &MMap = PP.getHeaderSearchInfo().getModuleMap();
+      Module::Header H;
+      H.Entry = *FE;
+      MMap.addHeader(M, std::move(H), ModuleMap::NormalHeader);
     }
 
     return IncludeFile{FID, M};

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2093,17 +2093,36 @@ void Preprocessor::HandleIncludeDirective(SourceLocation HashLoc,
       return;
     }
     if (auto *Import = std::get_if<PPCachedActions::IncludeModule>(&Include)) {
-      ModuleLoadResult Imported = TheModuleLoader.loadModule(
-          IncludeTok.getLocation(), Import->ImportPath, Module::Hidden,
-          /*IsIncludeDirective=*/true);
-      if (!Imported) {
-        assert(hadModuleLoaderFatalFailure() && "unexpected failure kind");
-        if (hadModuleLoaderFatalFailure()) {
-          IncludeTok.setKind(tok::eof);
-          CurLexer->cutOffLexing();
+      ModuleLoadResult Imported;
+      if (Import->VisibilityOnly) {
+        ModuleMap &MMap = getHeaderSearchInfo().getModuleMap();
+        Module *M = nullptr;
+        for (auto &NameLoc : Import->ImportPath) {
+          M = MMap.lookupModuleQualified(NameLoc.first->getName(), M);
+          if (!M)
+            break;
         }
-        return;
+        if (!M) {
+          Diags->Report(diag::err_pp_missing_module_include_tree)
+              << getLangOpts().CurrentModule;
+
+          return;
+        }
+        Imported = M;
+      } else {
+        Imported = TheModuleLoader.loadModule(
+            IncludeTok.getLocation(), Import->ImportPath, Module::Hidden,
+            /*IsIncludeDirective=*/true);
+        if (!Imported) {
+          assert(hadModuleLoaderFatalFailure() && "unexpected failure kind");
+          if (hadModuleLoaderFatalFailure()) {
+            IncludeTok.setKind(tok::eof);
+            CurLexer->cutOffLexing();
+          }
+          return;
+        }
       }
+
       makeModuleVisible(Imported, EndLoc);
       if (IncludeTok.getIdentifierInfo()->getPPKeywordID() !=
           tok::pp___include_macros)

--- a/clang/lib/Sema/SemaModule.cpp
+++ b/clang/lib/Sema/SemaModule.cpp
@@ -411,6 +411,7 @@ Sema::ActOnPrivateModuleFragmentDecl(SourceLocation ModuleLoc,
   switch (ModuleScopes.empty() ? Module::ExplicitGlobalModuleFragment
                                : ModuleScopes.back().Module->Kind) {
   case Module::ModuleMapModule:
+  case Module::IncludeTreeModuleMap:
   case Module::ExplicitGlobalModuleFragment:
   case Module::ImplicitGlobalModuleFragment:
   case Module::ModulePartitionImplementation:

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -5691,10 +5691,6 @@ llvm::Error ASTReader::ReadSubmoduleBlock(ModuleFile &F,
         CurrentModule->PresumedModuleMapFile = F.ModuleMapPath;
         if (!F.ModuleCacheKey.empty())
           CurrentModule->setModuleCacheKey(F.ModuleCacheKey);
-        if (!F.CASFileSystemRootID.empty())
-          CurrentModule->setCASFileSystemRootID(F.CASFileSystemRootID);
-        if (!F.IncludeTreeID.empty())
-          CurrentModule->setIncludeTreeID(F.IncludeTreeID);
       }
 
       CurrentModule->Kind = Kind;

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -3054,8 +3054,7 @@ static bool isConsumerInterestedIn(ASTContext &Ctx, Decl *D, bool HasBody) {
   // emitted when we import the relevant module.
   if (isPartOfPerModuleInitializer(D)) {
     auto *M = D->getImportedOwningModule();
-    if (M && M->Kind == Module::ModuleMapModule &&
-        Ctx.DeclMustBeEmitted(D))
+    if (M && M->isModuleMapModule() && Ctx.DeclMustBeEmitted(D))
       return false;
   }
 

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -2754,7 +2754,7 @@ void ASTWriter::WriteSubmodules(Module *WritingModule) {
   Abbrev->Add(BitCodeAbbrevOp(SUBMODULE_DEFINITION));
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // ID
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // Parent
-  Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 3)); // Kind
+  Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 4)); // Kind
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // IsFramework
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // IsExplicit
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // IsSystem

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -1351,24 +1351,25 @@ void ASTWriter::WriteControlBlock(Preprocessor &PP, ASTContext &Context,
       RecordData::value_type Record[] = {MODULE_CACHE_KEY};
       Stream.EmitRecordWithBlob(AbbrevCode, Record, *Key);
     }
-    // CAS filesystem root id, for the scanner.
-    if (auto ID = WritingModule->getCASFileSystemRootID()) {
-      auto Abbrev = std::make_shared<BitCodeAbbrev>();
-      Abbrev->Add(BitCodeAbbrevOp(CASFS_ROOT_ID));
-      Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Blob));
-      unsigned AbbrevCode = Stream.EmitAbbrev(std::move(Abbrev));
-      RecordData::value_type Record[] = {CASFS_ROOT_ID};
-      Stream.EmitRecordWithBlob(AbbrevCode, Record, *ID);
-    }
-    // CAS include-tree id, for the scanner.
-    if (auto ID = WritingModule->getIncludeTreeID()) {
-      auto Abbrev = std::make_shared<BitCodeAbbrev>();
-      Abbrev->Add(BitCodeAbbrevOp(CAS_INCLUDE_TREE_ID));
-      Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Blob));
-      unsigned AbbrevCode = Stream.EmitAbbrev(std::move(Abbrev));
-      RecordData::value_type Record[] = {CAS_INCLUDE_TREE_ID};
-      Stream.EmitRecordWithBlob(AbbrevCode, Record, *ID);
-    }
+  }
+
+  // CAS include-tree id, for the scanner.
+  if (auto ID = Context.getCASIncludeTreeID()) {
+    auto Abbrev = std::make_shared<BitCodeAbbrev>();
+    Abbrev->Add(BitCodeAbbrevOp(CAS_INCLUDE_TREE_ID));
+    Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Blob));
+    unsigned AbbrevCode = Stream.EmitAbbrev(std::move(Abbrev));
+    RecordData::value_type Record[] = {CAS_INCLUDE_TREE_ID};
+    Stream.EmitRecordWithBlob(AbbrevCode, Record, *ID);
+  }
+  // CAS filesystem root id, for the scanner.
+  if (auto ID = Context.getCASFileSystemRootID()) {
+    auto Abbrev = std::make_shared<BitCodeAbbrev>();
+    Abbrev->Add(BitCodeAbbrevOp(CASFS_ROOT_ID));
+    Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Blob));
+    unsigned AbbrevCode = Stream.EmitAbbrev(std::move(Abbrev));
+    RecordData::value_type Record[] = {CASFS_ROOT_ID};
+    Stream.EmitRecordWithBlob(AbbrevCode, Record, *ID);
   }
 
   // Imports

--- a/clang/lib/Tooling/DependencyScanning/CASFSActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/CASFSActionController.cpp
@@ -176,7 +176,7 @@ Error CASFSActionController::finalizeModuleBuild(
   Module *M = ModuleScanInstance.getPreprocessor().getCurrentModule();
   assert(M && "finalizing without a module");
 
-  M->setCASFileSystemRootID(RootID->toString());
+  ModuleScanInstance.getASTContext().setCASFileSystemRootID(RootID->toString());
   return Error::success();
 }
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -466,6 +466,10 @@ public:
     else
       Action = std::make_unique<ReadPCHAndPreprocessAction>();
 
+    // Normally this would be handled by GeneratePCHAction
+    if (ScanInstance.getFrontendOpts().ProgramAction == frontend::GeneratePCH)
+      ScanInstance.getLangOpts().CompilingPCH = true;
+
     if (Error E = Controller.initialize(ScanInstance, OriginalInvocation))
       return reportError(std::move(E));
 

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -398,8 +398,9 @@ void IncludeTreeBuilder::handleHasIncludeCheck(Preprocessor &PP, bool Result) {
 
 void IncludeTreeBuilder::moduleImport(Preprocessor &PP, const Module *M,
                                       SourceLocation EndLoc) {
-  auto Import =
-      check(cas::IncludeTree::ModuleImport::create(DB, M->getFullModuleName()));
+  bool VisibilityOnly = M->isForBuilding(PP.getLangOpts());
+  auto Import = check(cas::IncludeTree::ModuleImport::create(
+      DB, M->getFullModuleName(), VisibilityOnly));
   if (!Import)
     return;
 

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -99,6 +99,7 @@ private:
     llvm::SmallBitVector HasIncludeChecks;
   };
 
+  Error addModuleInputs(ASTReader &Reader);
   Expected<cas::ObjectRef> getObjectForFile(Preprocessor &PP, FileID FID);
   Expected<cas::ObjectRef>
   getObjectForFileNonCached(FileManager &FM, const SrcMgr::FileInfo &FI);
@@ -128,7 +129,7 @@ private:
   // are recorded in the PCH, ordered by \p FileEntry::UID index.
   SmallVector<StringRef> PreIncludedFileNames;
   llvm::BitVector SeenIncludeFiles;
-  SmallVector<cas::IncludeTree::FileList::FileEntry> IncludedFiles;
+  llvm::SetVector<cas::IncludeTree::FileList::FileEntry> IncludedFiles;
   std::optional<cas::ObjectRef> PredefinesBufferRef;
   std::optional<cas::ObjectRef> ModuleIncludesBufferRef;
   std::optional<cas::ObjectRef> ModuleMapFileRef;
@@ -495,30 +496,8 @@ IncludeTreeBuilder::finishIncludeTree(CompilerInstance &ScanInstance,
       return Error::success(); // no need for additional work.
 
     // Go through all the recorded input files.
-    SmallVector<const FileEntry *, 32> NotSeenIncludes;
-    for (serialization::ModuleFile &MF : Reader->getModuleManager()) {
-      if (hasErrorOccurred())
-        break;
-      Reader->visitInputFiles(
-          MF, /*IncludeSystem=*/true, /*Complain=*/false,
-          [&](const serialization::InputFile &IF, bool isSystem) {
-            OptionalFileEntryRef FE = IF.getFile();
-            assert(FE);
-            if (FE->getUID() >= SeenIncludeFiles.size() ||
-                !SeenIncludeFiles[FE->getUID()])
-              NotSeenIncludes.push_back(*FE);
-          });
-    }
-    // Sort so we can visit the files in deterministic order.
-    llvm::sort(NotSeenIncludes, [](const FileEntry *LHS, const FileEntry *RHS) {
-      return LHS->getUID() < RHS->getUID();
-    });
-
-    for (const FileEntry *FE : NotSeenIncludes) {
-      auto FileNode = addToFileList(FM, FE);
-      if (!FileNode)
-        return FileNode.takeError();
-    }
+    if (Error E = addModuleInputs(*Reader))
+      return E;
 
     PreprocessorOptions &PPOpts = NewInvocation.getPreprocessorOpts();
     if (PPOpts.ImplicitPCHInclude.empty())
@@ -544,13 +523,47 @@ IncludeTreeBuilder::finishIncludeTree(CompilerInstance &ScanInstance,
       getCASTreeForFileIncludes(IncludeStack.pop_back_val());
   if (!MainIncludeTree)
     return MainIncludeTree.takeError();
-  auto FileList = cas::IncludeTree::FileList::create(DB, IncludedFiles);
+  auto FileList =
+      cas::IncludeTree::FileList::create(DB, IncludedFiles.getArrayRef());
   if (!FileList)
     return FileList.takeError();
 
   return cas::IncludeTreeRoot::create(DB, MainIncludeTree->getRef(),
                                       FileList->getRef(), PCHRef,
                                       ModuleMapFileRef);
+}
+
+Error IncludeTreeBuilder::addModuleInputs(ASTReader &Reader) {
+  for (serialization::ModuleFile &MF : Reader.getModuleManager()) {
+    // Only add direct imports to avoid duplication. Each include tree is a
+    // superset of its imported modules' include trees.
+    if (!MF.isDirectlyImported())
+      continue;
+
+    assert(!MF.IncludeTreeID.empty() && "missing include-tree for import");
+
+    std::optional<cas::CASID> ID;
+    if (Error E = DB.parseID(MF.IncludeTreeID).moveInto(ID))
+      return E;
+    std::optional<cas::ObjectRef> Ref = DB.getReference(*ID);
+    if (!Ref)
+      return DB.createUnknownObjectError(*ID);
+    std::optional<cas::IncludeTreeRoot> Root;
+    if (Error E = cas::IncludeTreeRoot::get(DB, *Ref).moveInto(Root))
+      return E;
+    std::optional<cas::IncludeTree::FileList> Files;
+    if (Error E = Root->getFileList().moveInto(Files))
+      return E;
+
+    Error E = Files->forEachFile([&](auto IF, auto Size) -> Error {
+      IncludedFiles.insert({IF.getRef(), Size});
+      return Error::success();
+    });
+    if (E)
+      return E;
+  }
+
+  return Error::success();
 }
 
 Expected<cas::ObjectRef> IncludeTreeBuilder::getObjectForFile(Preprocessor &PP,
@@ -628,7 +641,7 @@ IncludeTreeBuilder::addToFileList(FileManager &FM, const FileEntry *FE) {
     auto FileNode = createIncludeFile(Filename, **CASContents);
     if (!FileNode)
       return FileNode.takeError();
-    IncludedFiles.push_back(
+    IncludedFiles.insert(
         {FileNode->getRef(),
          static_cast<cas::IncludeTree::FileList::FileSizeTy>(FE->getSize())});
     return FileNode->getRef();

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -328,9 +328,8 @@ Error IncludeTreeActionController::finalizeModuleBuild(
   if (!Tree)
     return Tree.takeError();
 
-  Module *M = ModuleScanInstance.getPreprocessor().getCurrentModule();
-  assert(M && "finalizing without a module");
-  M->setIncludeTreeID(Tree->getID().toString());
+  ModuleScanInstance.getASTContext().setCASIncludeTreeID(
+      Tree->getID().toString());
 
   return Error::success();
 }

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -587,7 +587,7 @@ IncludeTreeBuilder::finishIncludeTree(CompilerInstance &ScanInstance,
       Module *PM =
           MMap.findModule(ScanInstance.getLangOpts().ModuleName + "_Private");
       if (PM)
-        if (Error E = AddModule(M))
+        if (Error E = AddModule(PM))
           return std::move(E);
     }
 

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -640,13 +640,11 @@ IncludeTreeBuilder::finishIncludeTree(CompilerInstance &ScanInstance,
       // that case we need both of those modules.
       ModuleMap &MMap =
           ScanInstance.getPreprocessor().getHeaderSearchInfo().getModuleMap();
-      M = MMap.findModule(ScanInstance.getLangOpts().CurrentModule);
-      assert(M && "missing current module?");
-      if (Error E = AddModule(M))
-        return std::move(E);
-      Module *PM =
-          MMap.findModule(ScanInstance.getLangOpts().ModuleName + "_Private");
-      if (PM)
+      if (Module *M = MMap.findModule(ScanInstance.getLangOpts().CurrentModule))
+        if (Error E = AddModule(M))
+          return std::move(E);
+      if (Module *PM =
+          MMap.findModule(ScanInstance.getLangOpts().ModuleName + "_Private"))
         if (Error E = AddModule(PM))
           return std::move(E);
     }

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -393,11 +393,14 @@ Error IncludeTreeActionController::finalizeModuleBuild(
 
 Error IncludeTreeActionController::finalizeModuleInvocation(
     CompilerInvocation &CI, const ModuleDeps &MD) {
-  if (auto ID = MD.IncludeTreeID) {
-    configureInvocationForCaching(CI, CASOpts, std::move(*ID),
-                                  /*CASFSWorkingDir=*/"",
-                                  /*ProduceIncludeTree=*/true);
-  }
+  if (!MD.IncludeTreeID)
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "missing include-tree for module '%s'",
+                                   MD.ID.ModuleName.c_str());
+
+  configureInvocationForCaching(CI, CASOpts, *MD.IncludeTreeID,
+                                /*CASFSWorkingDir=*/"",
+                                /*ProduceIncludeTree=*/true);
 
   DepscanPrefixMapping::remapInvocationPaths(CI, PrefixMapper);
   return Error::success();

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -460,16 +460,6 @@ ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
   MD.ImportedByMainFile = DirectModularDeps.contains(M);
   MD.IsSystem = M->IsSystem;
 
-  if (auto ID = M->getCASFileSystemRootID()) {
-    auto &CAS = MDC.ScanInstance.getOrCreateObjectStore();
-    if (auto Err = CAS.parseID(*ID).moveInto(MD.CASFileSystemRootID)) {
-      MDC.ScanInstance.getDiagnostics().Report(
-          diag::err_cas_cannot_parse_root_id_for_module)
-          << *ID << MD.ID.ModuleName;
-    }
-  }
-  MD.IncludeTreeID = M->getIncludeTreeID();
-
   ModuleMap &ModMapInfo =
       MDC.ScanInstance.getPreprocessor().getHeaderSearchInfo().getModuleMap();
 
@@ -509,6 +499,19 @@ ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
           return;
         MD.ModuleMapFileDeps.emplace_back(FE.getNameAsRequested());
       });
+
+  if (!MF->IncludeTreeID.empty())
+    MD.IncludeTreeID = MF->IncludeTreeID;
+
+  if (!MF->CASFileSystemRootID.empty()) {
+    auto &CAS = MDC.ScanInstance.getOrCreateObjectStore();
+    if (auto Err = CAS.parseID(MF->CASFileSystemRootID)
+                       .moveInto(MD.CASFileSystemRootID)) {
+      MDC.ScanInstance.getDiagnostics().Report(
+          diag::err_cas_cannot_parse_root_id_for_module)
+          << MF->CASFileSystemRootID << MD.ID.ModuleName;
+    }
+  }
 
   CompilerInvocation CI = MDC.makeInvocationForModuleBuildWithoutOutputs(
       MD, [&](CompilerInvocation &BuildInvocation) {

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -35,6 +35,7 @@ void tooling::dependencies::configureInvocationForCaching(
   if (ProduceIncludeTree) {
     FrontendOpts.CASIncludeTreeID = std::move(RootID);
     FrontendOpts.Inputs.clear();
+    FrontendOpts.ModuleMapFiles.clear();
     HeaderSearchOptions &HSOpts = CI.getHeaderSearchOpts();
     HeaderSearchOptions OriginalHSOpts;
     std::swap(HSOpts, OriginalHSOpts);

--- a/clang/test/ClangScanDeps/modules-include-tree-exports.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-exports.c
@@ -1,0 +1,128 @@
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -j 1 \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// Extract the include-tree commands
+// RUN: %deps-to-rsp %t/deps.json --module-name TwoSubs > %t/TwoSubs.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name ExportExplicit > %t/ExportExplicit.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name ExportWildcard > %t/ExportWildcard.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name ExportGlobalWildcard > %t/ExportGlobalWildcard.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name NoExports > %t/NoExports.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu_export_explicit.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 1 > %t/tu_export_wildcard.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 2 > %t/tu_export_global_wildcard.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 3 > %t/tu_export_none.rsp
+
+// Build
+// RUN: %clang @%t/TwoSubs.rsp
+// RUN: %clang @%t/ExportExplicit.rsp
+// RUN: %clang @%t/ExportWildcard.rsp
+// RUN: %clang @%t/ExportGlobalWildcard.rsp
+// RUN: %clang @%t/NoExports.rsp
+// RUN: not %clang @%t/tu_export_explicit.rsp 2>&1 | FileCheck %s -check-prefix=tu_export_explicit
+// RUN: %clang @%t/tu_export_wildcard.rsp 2>&1 | FileCheck %s -check-prefix=tu_export_wildcard -allow-empty
+// RUN: %clang @%t/tu_export_global_wildcard.rsp 2>&1 | FileCheck %s -check-prefix=tu_export_global_wildcard -allow-empty
+// RUN: not %clang @%t/tu_export_none.rsp 2>&1 | FileCheck %s -check-prefix=tu_export_none
+
+//--- cdb.json.template
+[
+{
+  "file": "DIR/tu_export_explicit.c",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu_export_explicit.c -I DIR -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+},
+{
+  "file": "DIR/tu_export_wildcard.c",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu_export_wildcard.c -I DIR -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+},
+{
+  "file": "DIR/tu_export_global_wildcard.c",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu_export_global_wildcard.c -I DIR -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+},
+{
+  "file": "DIR/tu_export_none.c",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu_export_none.c -I DIR -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+},
+]
+
+//--- module.modulemap
+module TwoSubs {
+  module Sub1 { header "Sub1.h" }
+  module Sub2 { header "Sub2.h" }
+}
+
+module ExportExplicit {
+  header "Import.h"
+  export TwoSubs.Sub2
+}
+
+module ExportWildcard {
+  header "Import.h"
+  export TwoSubs.*
+}
+
+module ExportGlobalWildcard {
+  header "Import.h"
+  export *
+}
+
+module NoExports {
+  header "Import.h"
+}
+
+//--- Sub1.h
+void sub1(void);
+
+//--- Sub2.h
+void sub2(void);
+
+//--- Import.h
+#include "Sub1.h"
+#include "Sub2.h"
+
+//--- tu_export_explicit.c
+#pragma clang module import ExportExplicit
+void tu1(void) {
+  sub2();
+  // tu_export_explicit-NOT: error
+  sub1();
+  // tu_export_explicit: error: call to undeclared function 'sub1'
+  // tu_export_explicit: error: missing '#include "Sub1.h"'
+}
+
+//--- tu_export_wildcard.c
+#pragma clang module import ExportWildcard
+void tu1(void) {
+  sub1();
+  sub2();
+  // tu_export_wildcard-NOT: error
+}
+
+//--- tu_export_global_wildcard.c
+#pragma clang module import ExportGlobalWildcard
+void tu1(void) {
+  sub1();
+  sub2();
+  // tu_export_global_wildcard-NOT: error
+}
+
+//--- tu_export_none.c
+#pragma clang module import NoExports
+void tu1(void) {
+  sub1();
+  // tu_export_none: error: call to undeclared function 'sub1'
+  // tu_export_none: error: missing '#include "Sub1.h"'
+  sub2();
+  // tu_export_none: error: call to undeclared function 'sub2'
+  // tu_export_none: error: missing '#include "Sub2.h"'
+}

--- a/clang/test/ClangScanDeps/modules-include-tree-implementation-private.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-implementation-private.c
@@ -23,6 +23,8 @@
 // CHECK:   Submodule: Mod
 // CHECK: 3:1 [[PREFIX]]/Mod.framework/PrivateHeaders/Priv.h  llvmcas://
 // CHECK:   Submodule: Mod_Private
+// CHECK: 4:1 (Module for visibility only) Mod
+// CHECK: 5:1 (Module for visibility only) Mod_Private
 // CHECK: Module Map:
 // CHECK: Mod (framework)
 // CHECK:   link Mod (framework)
@@ -57,6 +59,8 @@ void pub(void);
 void priv(void);
 
 //--- tu.m
+#import <Mod/Mod.h>
+#import <Mod/Priv.h>
 #import <Mod/Mod.h>
 #import <Mod/Priv.h>
 void tu(void) {

--- a/clang/test/ClangScanDeps/modules-include-tree-implementation-private.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-implementation-private.c
@@ -1,0 +1,65 @@
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// RUN: FileCheck %s -input-file %t/deps.json -check-prefix=NO_MODULES
+// NO_MODULES: "modules": []
+
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: cat %t/tu.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/tu.casid
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/tu.casid | FileCheck %s -DPREFIX=%/t
+// RUN: %clang @%t/tu.rsp
+
+// CHECK: [[PREFIX]]/tu.m llvmcas://
+// CHECK: 1:1 <built-in> llvmcas://
+// CHECK: 2:1 [[PREFIX]]/Mod.framework/Headers/Mod.h llvmcas://
+// CHECK:   Submodule: Mod
+// CHECK: 3:1 [[PREFIX]]/Mod.framework/PrivateHeaders/Priv.h  llvmcas://
+// CHECK:   Submodule: Mod_Private
+// CHECK: Module Map:
+// CHECK: Mod (framework)
+// CHECK:   link Mod (framework)
+// CHECK: Mod_Private (framework)
+// CHECK:   link Mod_Private (framework)
+
+// CHECK: Files:
+// CHECK: [[PREFIX]]/tu.m llvmcas://
+// CHECK-NOT: [[PREFIX]]/module.modulemap
+// CHECK: [[PREFIX]]/Mod.framework/Headers/Mod.h llvmcas://
+// CHECK-NOT: [[PREFIX]]/module.modulemap
+// CHECK: [[PREFIX]]/Mod.framework/PrivateHeaders/Priv.h llvmcas://
+// CHECK-NOT: [[PREFIX]]/module.modulemap
+
+//--- cdb.json.template
+[{
+  "file": "DIR/tu.m",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu.m -F DIR -fmodule-name=Mod -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+}]
+
+//--- Mod.framework/Modules/module.modulemap
+framework module Mod { header "Mod.h" }
+
+//--- Mod.framework/Modules/module.private.modulemap
+framework module Mod_Private { header "Priv.h" }
+
+//--- Mod.framework/Headers/Mod.h
+void pub(void);
+
+//--- Mod.framework/PrivateHeaders/Priv.h
+void priv(void);
+
+//--- tu.m
+#import <Mod/Mod.h>
+#import <Mod/Priv.h>
+void tu(void) {
+  pub();
+  priv();
+}

--- a/clang/test/ClangScanDeps/modules-include-tree-implementation.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-implementation.c
@@ -27,7 +27,7 @@
 
 // CHECK: 2:1 [[PREFIX]]/Mod.h llvmcas://{{[[:xdigit:]]+}}
 // CHECK:   Submodule: Mod
-// CHECK: 3:1 (Module) Mod
+// CHECK: 3:1 (Module for visibility only) Mod
 
 // CHECK: Files:
 // CHECK: [[PREFIX]]/tu.c llvmcas://{{[[:xdigit:]]+}}

--- a/clang/test/ClangScanDeps/modules-include-tree-implementation.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-implementation.c
@@ -31,10 +31,9 @@
 
 // CHECK: Files:
 // CHECK: [[PREFIX]]/tu.c llvmcas://{{[[:xdigit:]]+}}
+// CHECK-NOT: [[PREFIX]]/module.modulemap
 // CHECK: [[PREFIX]]/Mod.h llvmcas://{{[[:xdigit:]]+}}
-
-// Despite not importing the module, we need its modulemap for submodule info.
-// CHECK: [[PREFIX]]/module.modulemap llvmcas://{{[[:xdigit:]]+}}
+// CHECK-NOT: [[PREFIX]]/module.modulemap
 
 //--- cdb.json.template
 [{

--- a/clang/test/ClangScanDeps/modules-include-tree-inferred.m
+++ b/clang/test/ClangScanDeps/modules-include-tree-inferred.m
@@ -1,0 +1,48 @@
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// RUN: %deps-to-rsp %t/deps.json --module-name Mod > %t/Mod.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: cat %t/Mod.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/Mod.casid
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/Mod.casid | FileCheck %s -DPREFIX=%/t
+// RUN: %clang @%t/Mod.rsp
+// RUN: %clang @%t/tu.rsp
+
+// CHECK: <module-includes> llvmcas://
+// CHECK: 1:1 <built-in> llvmcas://
+// CHECK: 2:1 [[PREFIX]]/Mod.framework/Headers/Mod.h llvmcas://
+// CHECK:   Submodule: Mod
+// CHECK: Module Map:
+// CHECK: Mod (framework)
+// CHECK:   link Mod (framework)
+// CHECK: Files:
+// CHECK-NOT: [[PREFIX]]/module.modulemap
+// CHECK: [[PREFIX]]/Mod.framework/Headers/Mod.h llvmcas://
+// CHECK-NOT: [[PREFIX]]/module.modulemap
+
+//--- cdb.json.template
+[{
+  "file": "DIR/tu.m",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu.m -F DIR -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+}]
+
+//--- module.modulemap
+framework module * {}
+
+//--- Mod.framework/Headers/Mod.h
+void pub(void);
+
+//--- tu.m
+#import <Mod/Mod.h>
+void tu(void) {
+  pub();
+}

--- a/clang/test/ClangScanDeps/modules-include-tree-pch-with-private.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-pch-with-private.c
@@ -1,0 +1,65 @@
+// Test importing a private module whose public module was previously imported
+// via a PCH.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+// RUN: sed "s|DIR|%/t|g" %t/cdb_pch.json.template > %t/cdb_pch.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb_pch.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps_pch.json
+
+// RUN: %deps-to-rsp %t/deps_pch.json --module-name Mod > %t/Mod.rsp
+// RUN: %deps-to-rsp %t/deps_pch.json --tu-index 0 > %t/pch.rsp
+// RUN: %clang @%t/Mod.rsp
+// RUN: %clang @%t/pch.rsp
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// RUN: %deps-to-rsp %t/deps.json --module-name Mod_Private > %t/Mod_Private.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: %clang @%t/Mod_Private.rsp
+// RUN: %clang @%t/tu.rsp
+
+//--- cdb.json.template
+[{
+  "file": "DIR/tu.m",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu.m -include prefix.h -F DIR -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+}]
+
+//--- cdb_pch.json.template
+[{
+  "file": "DIR/prefix.h",
+  "directory": "DIR",
+  "command": "clang -x objective-c-header DIR/prefix.h -o DIR/prefix.h.pch -F DIR -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+}]
+
+//--- Mod.framework/Modules/module.modulemap
+framework module Mod { header "Mod.h" }
+
+//--- Mod.framework/Modules/module.private.modulemap
+framework module Mod_Private { header "Priv.h" }
+
+//--- Mod.framework/Headers/Mod.h
+void pub(void);
+
+//--- Mod.framework/PrivateHeaders/Priv.h
+void priv(void);
+
+//--- prefix.h
+#import <Mod/Mod.h>
+
+//--- tu.m
+#import <Mod/Priv.h>
+void tu(void) {
+  pub();
+  priv();
+}

--- a/clang/test/ClangScanDeps/modules-include-tree-prefix-map.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-prefix-map.c
@@ -1,0 +1,305 @@
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t/dir1
+// RUN: cp -r %t/dir1 %t/dir2
+// RUN: sed "s|DIR|%/t/dir1|g" %t/dir1/cdb.json.template > %t/cdb1.json
+// RUN: sed "s|DIR|%/t/dir2|g" %t/dir1/cdb.json.template > %t/cdb2.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb1.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/dir1/outputs \
+// RUN:   -prefix-map=%t/dir1/outputs=/^modules -prefix-map=%t/dir1=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// Extract the include-tree commands
+// RUN: %deps-to-rsp %t/deps.json --module-name Top > %t/Top.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name Left > %t/Left.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name Right > %t/Right.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+
+// Extract include-tree casids
+// RUN: cat %t/Top.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/Top.casid
+// RUN: cat %t/Left.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/Left.casid
+// RUN: cat %t/Right.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/Right.casid
+// RUN: cat %t/tu.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/tu.casid
+
+// RUN: echo "MODULE Top" > %t/result.txt
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/Top.casid >> %t/result.txt
+// RUN: echo "MODULE Left" >> %t/result.txt
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/Left.casid >> %t/result.txt
+// RUN: echo "MODULE Right" >> %t/result.txt
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/Right.casid >> %t/result.txt
+// RUN: echo "TRANSLATION UNIT" >> %t/result.txt
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/tu.casid >> %t/result.txt
+
+// RUN: FileCheck %s -input-file %t/result.txt -DPREFIX=%/t -check-prefix=NO_PATHS
+// NO_PATHS-NOT: [[PREFIX]]
+
+// RUN: cat %t/deps.json >> %t/result.txt
+
+// RUN: FileCheck %s -input-file %t/result.txt -DPREFIX=%/t
+
+// CHECK-LABEL: MODULE Top
+// CHECK: <module-includes> llvmcas://{{[[:xdigit:]]+}}
+// CHECK: 1:1 <built-in> llvmcas://{{[[:xdigit:]]+}}
+// CHECK: 2:1 /^src/Top.h llvmcas://{{[[:xdigit:]]+}}
+// CHECK: Module Map:
+// CHECK: Top
+// CHECK:   export *
+// CHECK: Files:
+// CHECK-NOT: module.modulemap
+// CHECK: /^src/Top.h llvmcas://{{[[:xdigit:]]+}}
+// CHECK-NOT: module.modulemap
+
+// CHECK-LABEL: MODULE Left
+// CHECK: <module-includes> llvmcas://{{[[:xdigit:]]+}}
+// CHECK: 1:1 <built-in> llvmcas://{{[[:xdigit:]]+}}
+// CHECK: 2:1 /^src/Left.h llvmcas://{{[[:xdigit:]]+}}
+// CHECK:   2:1 (Module) Top
+// CHECK: Module Map:
+// CHECK: Left
+// CHECK:   export *
+// CHECK: Files:
+// CHECK-NOT: module.modulemap
+// CHECK: /^src/Left.h llvmcas://{{[[:xdigit:]]+}}
+// CHECK-NOT: module.modulemap
+// CHECK: /^src/Top.h llvmcas://{{[[:xdigit:]]+}}
+
+// CHECK-LABEL: MODULE Right
+// CHECK: <module-includes> llvmcas://{{[[:xdigit:]]+}}
+// CHECK: 1:1 <built-in> llvmcas://{{[[:xdigit:]]+}}
+// CHECK: 2:1 /^src/Right.h llvmcas://{{[[:xdigit:]]+}}
+// CHECK:   2:1 (Module) Top
+// CHECK: Module Map:
+// CHECK: Right
+// CHECK:   export *
+// CHECK: Files:
+// CHECK-NOT: module.modulemap
+// CHECK: /^src/Right.h llvmcas://{{[[:xdigit:]]+}}
+// CHECK-NOT: module.modulemap
+// CHECK: /^src/Top.h llvmcas://{{[[:xdigit:]]+}}
+
+// CHECK-LABEL: TRANSLATION UNIT
+// CHECK: /^src/tu.m llvmcas://{{[[:xdigit:]]+}}
+// CHECK: 1:1 <built-in> llvmcas://{{[[:xdigit:]]+}}
+// CHECK: 2:1 (Module) Left
+// CHECK: 3:1 (Module) Right
+
+// Note: the modules with explicit imports are imported via parser and are not
+// recorded in the include-tree; it's handled entirely by fmodule-map-file,
+// fmodule-file, and fmodule-file-cache-key options.
+
+// CHECK-NOT: Module Map
+// CHECK: Files:
+// CHECK-NOT: module.modulemap
+// CHECK: /^src/Left.h llvmcas://{{[[:xdigit:]]+}}
+// CHECK: /^src/Top.h llvmcas://{{[[:xdigit:]]+}}
+// CHECK: /^src/Right.h llvmcas://{{[[:xdigit:]]+}}
+
+// CHECK:      {
+// CHECK-NEXT   "modules": [
+// CHECK-NEXT     {
+// CHECK:            "cas-include-tree-id": "[[LEFT_TREE:llvmcas://[[:xdigit:]]+]]"
+// CHECK:            "clang-module-deps": [
+// CHECK:              {
+// CHECK:                "module-name": "Top"
+// CHECK:              }
+// CHECK-NEXT:       ]
+// CHECK:            "clang-modulemap-file": "[[PREFIX]]/dir1/module.modulemap"
+// CHECK:            "command-line": [
+// CHECK-NEXT:         "-cc1"
+// CHECK:              "-fcas-path"
+// CHECK-NEXT:         "[[PREFIX]]/cas"
+// CHECK-NOT: -fmodule-map-file
+// CHECK:              "-o"
+// CHECK-NEXT:         "[[PREFIX]]/dir1/outputs/{{.*}}/Left-{{.*}}.pcm"
+// CHECK:              "-disable-free"
+// CHECK:              "-fno-pch-timestamp"
+// CHECK:              "-fcas-include-tree"
+// CHECK-NEXT:         "[[LEFT_TREE]]"
+// CHECK:              "-fcache-compile-job"
+// CHECK:              "-emit-module"
+// CHECK:              "-fmodule-file-cache-key"
+// CHECK-NEXT:         "/^modules/{{.*}}/Top-{{.*}}.pcm"
+// CHECK-NEXT:         "llvmcas://{{[[:xdigit:]]+}}"
+// CHECK:              "-fmodule-file=Top=/^modules/{{.*}}/Top-{{.*}}.pcm"
+// CHECK:              "-fmodules"
+// CHECK:              "-fmodule-name=Left"
+// CHECK:              "-fno-implicit-modules"
+// CHECK:            ]
+// CHECK:            "file-deps": [
+// CHECK-NEXT:         "[[PREFIX]]/dir1/Left.h"
+// CHECK-NEXT:         "[[PREFIX]]/dir1/module.modulemap"
+// CHECK:            ]
+// CHECK:            "name": "Left"
+// CHECK:          }
+// CHECK-NEXT:     {
+// CHECK:            "cas-include-tree-id": "[[RIGHT_TREE:llvmcas://[[:xdigit:]]+]]"
+// CHECK:            "clang-module-deps": [
+// CHECK-NEXT:         {
+// CHECK:                "module-name": "Top"
+// CHECK:              }
+// CHECK-NEXT:       ]
+// CHECK:            "clang-modulemap-file": "[[PREFIX]]/dir1/module.modulemap"
+// CHECK:            "command-line": [
+// CHECK-NEXT:         "-cc1"
+// CHECK:              "-fcas-path"
+// CHECK-NEXT:         "[[PREFIX]]/cas"
+// CHECK-NOT: -fmodule-map-file
+// CHECK:              "-o"
+// CHECK-NEXT:         "[[PREFIX]]/dir1/outputs/{{.*}}/Right-{{.*}}.pcm"
+// CHECK:              "-disable-free"
+// CHECK:              "-fno-pch-timestamp"
+// CHECK:              "-fcas-include-tree"
+// CHECK-NEXT:         "[[RIGHT_TREE]]"
+// CHECK:              "-fcache-compile-job"
+// CHECK:              "-emit-module"
+// CHECK:              "-fmodule-file-cache-key
+// CHECK-NEXT:         "/^modules/{{.*}}/Top-{{.*}}.pcm"
+// CHECK-NEXT:         "llvmcas://{{[[:xdigit:]]+}}"
+// CHECK:              "-fmodule-file=Top=/^modules/{{.*}}/Top-{{.*}}.pcm"
+// CHECK:              "-fmodules"
+// CHECK:              "-fmodule-name=Right"
+// CHECK:              "-fno-implicit-modules"
+// CHECK:            ]
+// CHECK:            "file-deps": [
+// CHECK-NEXT:         "[[PREFIX]]/dir1/Right.h"
+// CHECK-NEXT:         "[[PREFIX]]/dir1/module.modulemap"
+// CHECK-NEXT:       ]
+// CHECK:            "name": "Right"
+// CHECK:          }
+// CHECK-NEXT:     {
+// CHECK:            "cas-include-tree-id": "[[TOP_TREE:llvmcas://[[:xdigit:]]+]]"
+// CHECK:            "clang-module-deps": []
+// CHECK:            "clang-modulemap-file": "[[PREFIX]]/dir1/module.modulemap"
+// CHECK:            "command-line": [
+// CHECK-NEXT:         "-cc1"
+// CHECK:              "-fcas-path"
+// CHECK-NEXT:         "[[PREFIX]]/cas"
+// CHECK:              "-o"
+// CHECK-NEXT:         "[[PREFIX]]/dir1/outputs/{{.*}}/Top-{{.*}}.pcm"
+// CHECK:              "-disable-free"
+// CHECK:              "-fno-pch-timestamp"
+// CHECK:              "-fcas-include-tree"
+// CHECK-NEXT:         "[[TOP_TREE]]"
+// CHECK:              "-fcache-compile-job"
+// CHECK:              "-emit-module"
+// CHECK:              "-fmodules"
+// CHECK:              "-fmodule-name=Top"
+// CHECK:              "-fno-implicit-modules"
+// CHECK:            ]
+// CHECK:            "file-deps": [
+// CHECK-NEXT:         "[[PREFIX]]/dir1/Top.h"
+// CHECK-NEXT:         "[[PREFIX]]/dir1/module.modulemap"
+// CHECK-NEXT:       ]
+// CHECK:            "name": "Top"
+// CHECK:          }
+// CHECK:        ]
+// CHECK-NEXT:   "translation-units": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "commands": [
+// CHECK-NEXT:         {
+// CHECK:                "cas-include-tree-id": "[[TU_TREE:llvmcas://[[:xdigit:]]+]]"
+// CHECK:                "clang-module-deps": [
+// CHECK-NEXT:             {
+// CHECK:                    "module-name": "Left"
+// CHECK:                  }
+// CHECK-NEXT:             {
+// CHECK:                    "module-name": "Right"
+// CHECK:                  }
+// CHECK-NEXT:           ]
+// CHECK:                "command-line": [
+// CHECK-NEXT:             "-cc1"
+// CHECK:                  "-fcas-path"
+// CHECK-NEXT:             "[[PREFIX]]/cas"
+// CHECK-NOT: -fmodule-map-file
+// CHECK:                  "-disable-free"
+// CHECK:                  "-fcas-include-tree"
+// CHECK-NEXT:             "[[TU_TREE]]"
+// CHECK:                  "-fcache-compile-job"
+// CHECK:                  "-fsyntax-only"
+// CHECK:                  "-fmodule-file-cache-key"
+// CHECK-NEXT:             "/^modules/{{.*}}/Left-{{.*}}.pcm"
+// CHECK-NEXT:             "llvmcas://{{[[:xdigit:]]+}}"
+// CHECK:                  "-fmodule-file-cache-key"
+// CHECK-NEXT:             "/^modules/{{.*}}/Right-{{.*}}.pcm"
+// CHECK-NEXT:             "llvmcas://{{[[:xdigit:]]+}}"
+// CHECK:                  "-fmodule-file=Left=/^modules/{{.*}}/Left-{{.*}}.pcm"
+// CHECK:                  "-fmodule-file=Right=/^modules/{{.*}}/Right-{{.*}}.pcm"
+// CHECK:                  "-fmodules"
+// CHECK:                  "-fno-implicit-modules"
+// CHECK:                ]
+// CHECK:                "file-deps": [
+// CHECK-NEXT:             "[[PREFIX]]/dir1/tu.m"
+// CHECK-NEXT:           ]
+// CHECK:                "input-file": "[[PREFIX]]/dir1/tu.m"
+// CHECK:              }
+// CHECK-NEXT:       ]
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ]
+// CHECK-NEXT: }
+
+// Build the include-tree commands
+// RUN: %clang @%t/Top.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_MISS
+// RUN: %clang @%t/Left.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_MISS
+// RUN: %clang @%t/Right.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_MISS
+// RUN: %clang @%t/tu.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_MISS
+
+// Scan in a different directory
+// RUN: clang-scan-deps -compilation-database %t/cdb2.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/dir2/outputs \
+// RUN:   -prefix-map=%t/dir2/outputs=/^modules -prefix-map=%t/dir2=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps2.json
+
+// RUN: %deps-to-rsp %t/deps2.json --module-name Top > %t/Top2.rsp
+// RUN: %deps-to-rsp %t/deps2.json --module-name Left > %t/Left2.rsp
+// RUN: %deps-to-rsp %t/deps2.json --module-name Right > %t/Right2.rsp
+// RUN: %deps-to-rsp %t/deps2.json --tu-index 0 > %t/tu2.rsp
+
+// Check cache hits
+// RUN: %clang @%t/Top2.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_HIT
+// RUN: %clang @%t/Left2.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_HIT
+// RUN: %clang @%t/Right2.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_HIT
+// RUN: %clang @%t/tu2.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_HIT
+
+// CACHE_MISS: compile job cache miss
+// CACHE_HIT: compile job cache hit
+
+//--- cdb.json.template
+[{
+  "file": "DIR/tu.m",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu.m -I DIR -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache"
+}]
+
+//--- module.modulemap
+module Top { header "Top.h" export *}
+module Left { header "Left.h" export *}
+module Right { header "Right.h" export *}
+
+//--- Top.h
+#pragma once
+struct Top {
+  int x;
+};
+void top(void);
+
+//--- Left.h
+#include "Top.h"
+void left(void);
+
+//--- Right.h
+#include "Top.h"
+void right(void);
+
+//--- tu.m
+#import "Left.h"
+#import <Right.h>
+
+void tu(void) {
+  top();
+  left();
+  right();
+}

--- a/clang/test/ClangScanDeps/modules-include-tree-vfsoverlay.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-vfsoverlay.c
@@ -1,0 +1,99 @@
+// Check include-tree-based caching works with vfsoverlay files.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+// RUN: sed -e "s|DIR|%/t|g" %t/vfs.yaml.template > %t/vfs.yaml
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -j 1 \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   -cas-path %t/cas > %t/deps.json
+
+// RUN: %deps-to-rsp %t/deps.json --module-name=A > %t/A.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: %clang @%t/A.rsp
+// RUN: %clang @%t/tu.rsp
+
+// Extract include-tree casids
+// RUN: cat %t/A.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/A.casid
+// RUN: cat %t/tu.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/tu.casid
+
+// RUN: echo "MODULE A" > %t/result.txt
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/A.casid >> %t/result.txt
+// RUN: echo "TRANSLATION UNIT" >> %t/result.txt
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/tu.casid >> %t/result.txt
+
+// RUN: FileCheck %s -input-file %t/result.txt -DPREFIX=%/t
+
+// CHECK-LABEL: MODULE A
+// CHECK: <module-includes> llvmcas://
+// CHECK: 2:1 [[PREFIX]]/elsewhere2/A.h llvmcas://
+// CHECK:   Submodule: A
+// CHECK: Module Map:
+// CHECK: A (framework)
+// CHECK:   link A (framework)
+// CHECK: Files:
+// CHECK-NOT: modulemap
+// CHECK: [[PREFIX]]/elsewhere2/A.h llvmcas://
+// CHECK-NOT: modulemap
+
+// CHECK-LABEL: TRANSLATION UNIT
+// CHECK: Files:
+// CHECK-NOT: .modulemap
+// CHECK-NOT: .yaml
+// CHECK: [[PREFIX]]/elsewhere2/A.h llvmcas://
+// CHECK-NOT: .modulemap
+// CHECK-NOT: .yaml
+
+//--- cdb.json.template
+[{
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu.c -fmodules -fmodules-cache-path=DIR/module-cache -fimplicit-modules -fimplicit-module-maps -ivfsoverlay DIR/vfs.yaml -F DIR",
+  "file": "DIR/tu.c"
+}]
+
+//--- vfs.yaml.template
+{
+  "version": 0,
+  "case-sensitive": "false",
+  "roots": [
+    {
+      "name": "DIR/A.framework",
+      "type": "directory"
+      "contents": [
+        {
+          "name": "Modules",
+          "type": "directory"
+          "contents": [
+            {
+              "external-contents": "DIR/elsewhere1/A.modulemap",
+              "name": "module.modulemap",
+              "type": "file"
+            }
+          ]
+        },
+        {
+          "name": "Headers",
+          "type": "directory"
+          "contents": [
+            {
+              "external-contents": "DIR/elsewhere2/A.h",
+              "name": "A.h",
+              "type": "file"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+//--- elsewhere1/A.modulemap
+framework module A { header "A.h" }
+
+//--- elsewhere2/A.h
+typedef int A_t;
+
+//--- tu.c
+#include "A/A.h"
+A_t a = 0;

--- a/clang/test/ClangScanDeps/modules-include-tree-with-pch.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-with-pch.c
@@ -84,7 +84,7 @@
 // CHECK-NEXT:             "-cc1"
 // CHECK:                  "-fcas-path"
 // CHECK-NEXT:             "[[PREFIX]]/cas"
-// CHECK:                  "-fmodule-map-file=[[PREFIX]]/module.modulemap"
+// CHECK-NOT: -fmodule-map-file=
 // CHECK:                  "-disable-free"
 // CHECK:                  "-fcas-include-tree"
 // CHECK-NEXT:             "llvmcas://{{[[:xdigit:]]+}}"

--- a/clang/test/ClangScanDeps/modules-include-tree.c
+++ b/clang/test/ClangScanDeps/modules-include-tree.c
@@ -77,8 +77,8 @@
 // fmodule-file, and fmodule-file-cache-key options.
 
 // CHECK: Files:
-// CHECK: [[PREFIX]]/Left.h llvmcas://{{[[:xdigit:]]+}}
 // CHECK: [[PREFIX]]/module.modulemap llvmcas://{{[[:xdigit:]]+}}
+// CHECK: [[PREFIX]]/Left.h llvmcas://{{[[:xdigit:]]+}}
 // CHECK: [[PREFIX]]/Top.h llvmcas://{{[[:xdigit:]]+}}
 // CHECK: [[PREFIX]]/Right.h llvmcas://{{[[:xdigit:]]+}}
 

--- a/clang/test/ClangScanDeps/modules-include-tree.c
+++ b/clang/test/ClangScanDeps/modules-include-tree.c
@@ -39,20 +39,26 @@
 // CHECK: <module-includes> llvmcas://{{[[:xdigit:]]+}}
 // CHECK: 1:1 <built-in> llvmcas://{{[[:xdigit:]]+}}
 // CHECK: 2:1 [[PREFIX]]/Top.h llvmcas://{{[[:xdigit:]]+}}
-// CHECK: Module Map: [[PREFIX]]/module.modulemap llvmcas://{{[[:xdigit:]]+}}
+// CHECK: Module Map:
+// CHECK: Top
+// CHECK:   export *
 // CHECK: Files:
+// CHECK-NOT: [[PREFIX]]/module.modulemap
 // CHECK: [[PREFIX]]/Top.h llvmcas://{{[[:xdigit:]]+}}
-// CHECK: [[PREFIX]]/module.modulemap llvmcas://{{[[:xdigit:]]+}}
+// CHECK-NOT: [[PREFIX]]/module.modulemap
 
 // CHECK-LABEL: MODULE Left
 // CHECK: <module-includes> llvmcas://{{[[:xdigit:]]+}}
 // CHECK: 1:1 <built-in> llvmcas://{{[[:xdigit:]]+}}
 // CHECK: 2:1 [[PREFIX]]/Left.h llvmcas://{{[[:xdigit:]]+}}
 // CHECK:   2:1 (Module) Top
-// CHECK: Module Map: [[PREFIX]]/module.modulemap llvmcas://{{[[:xdigit:]]+}}
+// CHECK: Module Map:
+// CHECK: Left
+// CHECK:   export *
 // CHECK: Files:
+// CHECK-NOT: [[PREFIX]]/module.modulemap llvmcas://{{[[:xdigit:]]+}}
 // CHECK: [[PREFIX]]/Left.h llvmcas://{{[[:xdigit:]]+}}
-// CHECK: [[PREFIX]]/module.modulemap llvmcas://{{[[:xdigit:]]+}}
+// CHECK-NOT: [[PREFIX]]/module.modulemap llvmcas://{{[[:xdigit:]]+}}
 // CHECK: [[PREFIX]]/Top.h llvmcas://{{[[:xdigit:]]+}}
 
 // CHECK-LABEL: MODULE Right
@@ -60,10 +66,13 @@
 // CHECK: 1:1 <built-in> llvmcas://{{[[:xdigit:]]+}}
 // CHECK: 2:1 [[PREFIX]]/Right.h llvmcas://{{[[:xdigit:]]+}}
 // CHECK:   2:1 (Module) Top
-// CHECK: Module Map: [[PREFIX]]/module.modulemap llvmcas://{{[[:xdigit:]]+}}
+// CHECK: Module Map:
+// CHECK: Right
+// CHECK:   export *
 // CHECK: Files:
+// CHECK-NOT: [[PREFIX]]/module.modulemap llvmcas://{{[[:xdigit:]]+}}
 // CHECK: [[PREFIX]]/Right.h llvmcas://{{[[:xdigit:]]+}}
-// CHECK: [[PREFIX]]/module.modulemap llvmcas://{{[[:xdigit:]]+}}
+// CHECK-NOT: [[PREFIX]]/module.modulemap llvmcas://{{[[:xdigit:]]+}}
 // CHECK: [[PREFIX]]/Top.h llvmcas://{{[[:xdigit:]]+}}
 
 // CHECK-LABEL: TRANSLATION UNIT
@@ -76,8 +85,9 @@
 // recorded in the include-tree; it's handled entirely by fmodule-map-file,
 // fmodule-file, and fmodule-file-cache-key options.
 
+// CHECK-NOT: Module Map
 // CHECK: Files:
-// CHECK: [[PREFIX]]/module.modulemap llvmcas://{{[[:xdigit:]]+}}
+// CHECK-NOT: [[PREFIX]]/module.modulemap llvmcas://{{[[:xdigit:]]+}}
 // CHECK: [[PREFIX]]/Left.h llvmcas://{{[[:xdigit:]]+}}
 // CHECK: [[PREFIX]]/Top.h llvmcas://{{[[:xdigit:]]+}}
 // CHECK: [[PREFIX]]/Right.h llvmcas://{{[[:xdigit:]]+}}
@@ -96,7 +106,7 @@
 // CHECK-NEXT:         "-cc1"
 // CHECK:              "-fcas-path"
 // CHECK-NEXT:         "[[PREFIX]]/cas"
-// CHECK:              "-fmodule-map-file=[[PREFIX]]/module.modulemap"
+// CHECK-NOT: -fmodule-map-file
 // CHECK:              "-o"
 // CHECK-NEXT:         "[[PREFIX]]/outputs/{{.*}}/Left-{{.*}}.pcm"
 // CHECK:              "-disable-free"
@@ -131,7 +141,7 @@
 // CHECK-NEXT:         "-cc1"
 // CHECK:              "-fcas-path"
 // CHECK-NEXT:         "[[PREFIX]]/cas"
-// CHECK:              "-fmodule-map-file=[[PREFIX]]/module.modulemap"
+// CHECK-NOT: -fmodule-map-file
 // CHECK:              "-o"
 // CHECK-NEXT:         "[[PREFIX]]/outputs/{{.*}}/Right-{{.*}}.pcm"
 // CHECK:              "-disable-free"
@@ -256,7 +266,7 @@
 // CHECK-NEXT:             "-cc1"
 // CHECK:                  "-fcas-path"
 // CHECK-NEXT:             "[[PREFIX]]/cas"
-// CHECK:                  "-fmodule-map-file=[[PREFIX]]/module.modulemap"
+// CHECK-NOT: -fmodule-map-file
 // CHECK:                  "-disable-free"
 // CHECK:                  "-fcas-include-tree"
 // CHECK-NEXT:             "[[TU_TREE]]"

--- a/clang/unittests/CAS/IncludeTreeTest.cpp
+++ b/clang/unittests/CAS/IncludeTreeTest.cpp
@@ -4,6 +4,7 @@
 #include "llvm/CAS/CASProvidingFileSystem.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
 
@@ -135,29 +136,74 @@ TEST(IncludeTree, IncludeTreeScan) {
 
   std::optional<IncludeTree::FileList> FileList;
   ASSERT_THAT_ERROR(Root->getFileList().moveInto(FileList), llvm::Succeeded());
-  ASSERT_EQ(FileList->getNumFiles(), size_t(4));
-  {
+
+  SmallVector<std::pair<IncludeTree::File, IncludeTree::FileList::FileSizeTy>>
+      Files;
+  ASSERT_THAT_ERROR(FileList->forEachFile([&](auto F, auto S) -> llvm::Error {
+    Files.push_back({F, S});
+    return llvm::Error::success();
+  }),
+                    llvm::Succeeded());
+
+  ASSERT_EQ(Files.size(), size_t(4));
+  EXPECT_EQ(Files[0].first.getRef(), MainFile->getRef());
+  EXPECT_EQ(Files[0].second, MainContents.size());
+  EXPECT_EQ(Files[1].first.getRef(), A1File->getRef());
+  EXPECT_EQ(Files[1].second, A1Contents.size());
+  EXPECT_EQ(Files[2].first.getRef(), B1File->getRef());
+  EXPECT_EQ(Files[2].second, IncludeTree::FileList::FileSizeTy(0));
+  EXPECT_EQ(Files[3].first.getRef(), SysFile->getRef());
+  EXPECT_EQ(Files[3].second, IncludeTree::FileList::FileSizeTy(0));
+}
+
+TEST(IncludeTree, IncludeTreeFileList) {
+  std::shared_ptr<ObjectStore> DB = llvm::cas::createInMemoryCAS();
+  SmallVector<IncludeTree::File> Files;
+  for (unsigned I = 0; I < 10; ++I) {
     std::optional<IncludeTree::File> File;
-    ASSERT_THAT_ERROR(FileList->getFile(0).moveInto(File), llvm::Succeeded());
-    EXPECT_EQ(File->getRef(), MainFile->getRef());
-    EXPECT_EQ(FileList->getFileSize(0), MainContents.size());
+    std::string Path = "/file" + std::to_string(I);
+    static constexpr StringRef Bytes = "123456789";
+    std::optional<ObjectRef> Content;
+    ASSERT_THAT_ERROR(
+        DB->storeFromString({}, Bytes.substr(0, I)).moveInto(Content),
+        llvm::Succeeded());
+    ASSERT_THAT_ERROR(
+        IncludeTree::File::create(*DB, Path, *Content).moveInto(File),
+        llvm::Succeeded());
+    Files.push_back(std::move(*File));
   }
-  {
-    std::optional<IncludeTree::File> File;
-    ASSERT_THAT_ERROR(FileList->getFile(1).moveInto(File), llvm::Succeeded());
-    EXPECT_EQ(File->getRef(), A1File->getRef());
-    EXPECT_EQ(FileList->getFileSize(1), A1Contents.size());
-  }
-  {
-    std::optional<IncludeTree::File> File;
-    ASSERT_THAT_ERROR(FileList->getFile(2).moveInto(File), llvm::Succeeded());
-    EXPECT_EQ(File->getRef(), B1File->getRef());
-    EXPECT_EQ(FileList->getFileSize(2), IncludeTree::FileList::FileSizeTy(0));
-  }
-  {
-    std::optional<IncludeTree::File> File;
-    ASSERT_THAT_ERROR(FileList->getFile(3).moveInto(File), llvm::Succeeded());
-    EXPECT_EQ(File->getRef(), SysFile->getRef());
-    EXPECT_EQ(FileList->getFileSize(3), IncludeTree::FileList::FileSizeTy(0));
-  }
+
+  auto MakeFileList = [&](unsigned Begin, unsigned End,
+                          ArrayRef<ObjectRef> Lists) {
+    SmallVector<IncludeTree::FileList::FileEntry> Entries;
+    for (; Begin != End; ++Begin)
+      Entries.push_back({Files[Begin].getRef(), Begin});
+    return IncludeTree::FileList::create(*DB, Entries, Lists);
+  };
+
+  std::optional<IncludeTree::FileList> L89, L7, L29, L;
+  ASSERT_THAT_ERROR(MakeFileList(8, 10, {}).moveInto(L89), llvm::Succeeded());
+  EXPECT_EQ(L89->getNumReferences(), 2u);
+  ASSERT_THAT_ERROR(MakeFileList(7, 8, {}).moveInto(L7), llvm::Succeeded());
+  EXPECT_EQ(L7->getNumReferences(), 1u);
+  ASSERT_THAT_ERROR(
+      MakeFileList(2, 7, {L7->getRef(), L89->getRef()}).moveInto(L29),
+      llvm::Succeeded());
+  EXPECT_EQ(L29->getNumReferences(), 7u); // 2,3,4,5,6, {7}, {8, 9}
+  ASSERT_THAT_ERROR(MakeFileList(0, 2, {L29->getRef()}).moveInto(L),
+                    llvm::Succeeded());
+  EXPECT_EQ(L->getNumReferences(), 3u); // 0, 1, {2, ...}
+
+  size_t I = 0;
+  ASSERT_THAT_ERROR(
+      L->forEachFile([&](IncludeTree::File F, auto Size) -> llvm::Error {
+        EXPECT_EQ(F.getFilenameRef(), Files[I].getFilenameRef())
+            << "filename mismatch at " << I;
+        EXPECT_EQ(F.getContentsRef(), Files[I].getContentsRef())
+            << "contents mismatch at " << I;
+        EXPECT_EQ(Size, I) << "size mismatch at " << I;
+        I += 1;
+        return llvm::Error::success();
+      }),
+      llvm::Succeeded());
 }


### PR DESCRIPTION
Instead of putting the modulemap file in the include-tree filesystem and parsing it at build time, create a data structure that represents just the parts of the modulemap we need when building the module:

* Flags (explicit, system, framework, etc.)
* Exports (export *, export Foo)
* LinkLibraries (implicit framework autolink, link Foo)

Additionally, we add modular headers lazily by inserting known headers when we encounter an include-tree header that is part of a submodule (this is needed for missing #include diagnostics).

This removes the possibility of mismatches between header paths seen during modulemap parsing from the paths we embed due to #includes, for exmaple due to VFS virtual vs external paths.

---

Other changes
* IncludeTree filesystem merges from imported PCH/modules: this gets input by merging across PCH/module include-trees. While this could pull in more files than necessary if there are files that are only needed during building, it turns out to be much better in practice for avoiding extra files we don't want such as modulemap files. It cannot cause extra cache misses, since all the files needed to build a module would already be in the cache keys for inputs.
* Tests for VFS, framework autolinking, inferred framework modules
* Handled visibility-only imports accurately

rdar://104386617