### PR TITLE
[lldb] Add ability to hide the root name of a value

### DIFF
--- a/lldb/include/lldb/DataFormatters/DumpValueObjectOptions.h
+++ b/lldb/include/lldb/DataFormatters/DumpValueObjectOptions.h
@@ -105,6 +105,8 @@ public:
 
   DumpValueObjectOptions &SetHideRootType(bool hide_root_type = false);
 
+  DumpValueObjectOptions &SetHideRootName(bool hide_root_name);
+
   DumpValueObjectOptions &SetHideName(bool hide_name = false);
 
   DumpValueObjectOptions &SetHideValue(bool hide_value = false);
@@ -146,6 +148,7 @@ public:
   bool m_show_location : 1;
   bool m_use_objc : 1;
   bool m_hide_root_type : 1;
+  bool m_hide_root_name : 1;
   bool m_hide_name : 1;
   bool m_hide_value : 1;
   bool m_run_validator : 1;

--- a/lldb/include/lldb/DataFormatters/ValueObjectPrinter.h
+++ b/lldb/include/lldb/DataFormatters/ValueObjectPrinter.h
@@ -120,6 +120,8 @@ protected:
   bool HasReachedMaximumDepth();
 
 private:
+  bool ShouldShowName() const;
+
   ValueObject *m_orig_valobj;
   ValueObject *m_valobj;
   Stream *m_stream;

--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -84,7 +84,7 @@ bool CommandObjectDWIMPrint::DoExecute(StringRef command,
 
   DumpValueObjectOptions dump_options = m_varobj_options.GetAsDumpOptions(
       m_expr_options.m_verbosity, m_format_options.GetFormat());
-  dump_options.SetHideName(eval_options.GetSuppressPersistentResult());
+  dump_options.SetHideRootName(eval_options.GetSuppressPersistentResult());
 
   StackFrame *frame = m_exe_ctx.GetFramePtr();
 

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -482,7 +482,7 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
 
         DumpValueObjectOptions options(m_varobj_options.GetAsDumpOptions(
             m_command_options.m_verbosity, format));
-        options.SetHideName(eval_options.GetSuppressPersistentResult());
+        options.SetHideRootName(eval_options.GetSuppressPersistentResult());
         options.SetVariableFormatDisplayLanguage(
             result_valobj_sp->GetPreferredDisplayLanguage());
 

--- a/lldb/source/DataFormatters/DumpValueObjectOptions.cpp
+++ b/lldb/source/DataFormatters/DumpValueObjectOptions.cpp
@@ -19,10 +19,10 @@ DumpValueObjectOptions::DumpValueObjectOptions()
       m_decl_printing_helper(), m_pointer_as_array(), m_use_synthetic(true),
       m_scope_already_checked(false), m_flat_output(false), m_ignore_cap(false),
       m_show_types(false), m_show_location(false), m_use_objc(false),
-      m_hide_root_type(false), m_hide_name(false), m_hide_value(false),
-      m_run_validator(false), m_use_type_display_name(true),
-      m_allow_oneliner_mode(true), m_hide_pointer_value(false),
-      m_reveal_empty_aggregates(true) {}
+      m_hide_root_type(false), m_hide_root_name(false), m_hide_name(false),
+      m_hide_value(false), m_run_validator(false),
+      m_use_type_display_name(true), m_allow_oneliner_mode(true),
+      m_hide_pointer_value(false), m_reveal_empty_aggregates(true) {}
 
 DumpValueObjectOptions::DumpValueObjectOptions(ValueObject &valobj)
     : DumpValueObjectOptions() {
@@ -140,6 +140,12 @@ DumpValueObjectOptions::SetRootValueObjectName(const char *name) {
 DumpValueObjectOptions &
 DumpValueObjectOptions::SetHideRootType(bool hide_root_type) {
   m_hide_root_type = hide_root_type;
+  return *this;
+}
+
+DumpValueObjectOptions &
+DumpValueObjectOptions::SetHideRootName(bool hide_root_name) {
+  m_hide_root_name = hide_root_name;
   return *this;
 }
 

--- a/lldb/source/DataFormatters/ValueObjectPrinter.cpp
+++ b/lldb/source/DataFormatters/ValueObjectPrinter.cpp
@@ -275,7 +275,7 @@ void ValueObjectPrinter::PrintDecl() {
 
   StreamString varName;
 
-  if (!m_options.m_hide_name) {
+  if (ShouldShowName()) {
     if (m_options.m_flat_output)
       m_valobj->GetExpressionPath(varName);
     else
@@ -314,7 +314,7 @@ void ValueObjectPrinter::PrintDecl() {
       m_stream->Printf("(%s) ", typeName.GetData());
     if (!varName.Empty())
       m_stream->Printf("%s =", varName.GetData());
-    else if (!m_options.m_hide_name)
+    else if (ShouldShowName())
       m_stream->Printf(" =");
   }
 }
@@ -437,7 +437,7 @@ bool ValueObjectPrinter::PrintValueAndSummaryIfNeeded(bool &value_printed,
         if (m_options.m_hide_pointer_value &&
             IsPointerValue(m_valobj->GetCompilerType())) {
         } else {
-          if (!m_options.m_hide_name)
+          if (ShouldShowName())
             m_stream->PutChar(' ');
           m_stream->PutCString(m_value);
           value_printed = true;
@@ -459,7 +459,7 @@ bool ValueObjectPrinter::PrintObjectDescriptionIfNeeded(bool value_printed,
     // let's avoid the overly verbose no description error for a nil thing
     if (m_options.m_use_objc && !IsNil() && !IsUninitialized() &&
         (!m_options.m_pointer_as_array)) {
-      if (!m_options.m_hide_value || !m_options.m_hide_name)
+      if (!m_options.m_hide_value || ShouldShowName())
         m_stream->Printf(" ");
       const char *object_desc = nullptr;
       if (value_printed || summary_printed)
@@ -587,8 +587,14 @@ void ValueObjectPrinter::PrintChildrenPreamble() {
     if (ShouldPrintValueObject())
       m_stream->EOL();
   } else {
-    if (ShouldPrintValueObject())
-      m_stream->PutCString(IsRef() ? ": {\n" : " {\n");
+    if (ShouldPrintValueObject()) {
+      if (IsRef()) {
+        m_stream->PutCString(": ");
+      } else if (ShouldShowName()) {
+        m_stream->PutChar(' ');
+      }
+      m_stream->PutCString("{\n");
+    }
     m_stream->IndentMore();
   }
 }
@@ -840,4 +846,10 @@ void ValueObjectPrinter::PrintChildrenIfNeeded(bool value_printed,
 
 bool ValueObjectPrinter::HasReachedMaximumDepth() {
   return m_curr_depth >= m_options.m_max_depth;
+}
+
+bool ValueObjectPrinter::ShouldShowName() const {
+  if (m_curr_depth == 0)
+    return !m_options.m_hide_root_name && !m_options.m_hide_name;
+  return !m_options.m_hide_name;
 }

--- a/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
+++ b/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
@@ -112,3 +112,11 @@ class TestCase(TestBase):
         lldbutil.run_to_name_breakpoint(self, "main")
         self._expect_cmd(f"dwim-print -l c++ -- argc", "frame variable")
         self._expect_cmd(f"dwim-print -l c++ -- argc + 1", "expression")
+
+    def test_nested_values(self):
+        """Test dwim-print with nested values (structs, etc)."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "// break here", lldb.SBFileSpec("main.c"))
+        self.runCmd("settings set auto-one-line-summaries false")
+        self._expect_cmd(f"dwim-print s", "frame variable")
+        self._expect_cmd(f"dwim-print (struct Structure)s", "expression")

--- a/lldb/test/API/commands/dwim-print/main.c
+++ b/lldb/test/API/commands/dwim-print/main.c
@@ -1,3 +1,10 @@
+struct Structure {
+  int number;
+};
+
 int main(int argc, char **argv) {
+  struct Structure s;
+  s.number = 30;
+  // break here
   return 0;
 }


### PR DESCRIPTION
When printing a value, allow the root value's name to be elided, without omiting the
names of child values.

At the API level, this adds `SetHideRootName()`, which joins the existing
`SetHideName()` function.

This functionality is used by `dwim-print` and `expression`.

Fixes an issue identified by @jgorbe in https://reviews.llvm.org/D145609.

Differential Revision: https://reviews.llvm.org/D146783

(cherry picked from commit 23349d83a98f23e67ff0321dad7c378b117ce6aa)