### PR TITLE
[lldb] Remove errant call to SBReproducer.SetWorkingDirectory

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -553,7 +553,6 @@ class Base(unittest2.TestCase):
         if traceAlways:
             print("Change dir to:", full_dir, file=sys.stderr)
         os.chdir(full_dir)
-        lldb.SBReproducer.SetWorkingDirectory(full_dir)
 
         # Set platform context.
         cls.platformContext = lldbplatformutil.createPlatformContext()


### PR DESCRIPTION
The old reproducer functionality has been removed. Remove this call as
it's now just a NO-OP.

(cherry picked from commit 0016f476ab1f9013d336491924495ec01f43a045)
