### PR TITLE
TypeSystem: early exit if there are 0 imports

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -8344,6 +8344,8 @@ bool SwiftASTContext::GetCompileUnitImportsImpl(
     return true;
 
   auto cu_imports = compile_unit->GetImportedModules();
+  if (cu_imports.size() == 0)
+    return true;
 
   Progress progress(
       llvm::formatv("Getting Swift compile unit imports for '{0}'",


### PR DESCRIPTION
This is a minor u-opt but more importantly the `Progress` type requires that the count of imports being >=1.  This avoids an assertion being triggered.