### PR TITLE
[lldb] Selectively turn on NO_PLUGIN_DEPENDENCIES depending on swift support

### DIFF
--- a/lldb/source/Host/macosx/objcxx/CMakeLists.txt
+++ b/lldb/source/Host/macosx/objcxx/CMakeLists.txt
@@ -2,12 +2,17 @@ set(SWIFT_SOURCES HostInfoMacOSXSwift.cpp)
 set(LLVM_OPTIONAL_SOURCES ${SWIFT_SOURCES})
 if (NOT LLDB_ENABLE_SWIFT_SUPPORT)
   unset(SWIFT_SOURCES)
+  set(PLUGIN_DEPENDENCY_ARG NO_PLUGIN_DEPENDENCIES)
+  set(LLDB_PLUGIN_DEPENDENCIES)
+else()
+  set(PLUGIN_DEPENDENCY_ARG)
+  set(LLDB_PLUGIN_DEPENDENCIES lldbPluginPlatformMacOSX)
 endif()
 
 remove_module_flags()
 include_directories(..)
 
-add_lldb_library(lldbHostMacOSXObjCXX NO_PLUGIN_DEPENDENCIES
+add_lldb_library(lldbHostMacOSXObjCXX ${PLUGIN_DEPENDENCY_ARG}
   Host.mm
   HostInfoMacOSX.mm
   HostThreadMacOSX.mm
@@ -16,7 +21,7 @@ add_lldb_library(lldbHostMacOSXObjCXX NO_PLUGIN_DEPENDENCIES
 
   LINK_LIBS
     lldbUtility
-    lldbPluginPlatformMacOSX
+    ${LLDB_PLUGIN_DEPENDENCIES}
     ${EXTRA_LIBS}
 
   LINK_COMPONENTS

--- a/lldb/source/Symbol/CMakeLists.txt
+++ b/lldb/source/Symbol/CMakeLists.txt
@@ -19,9 +19,14 @@ list(APPEND LLVM_OPTIONAL_SOURCES ${SWIFT_SOURCES})
 if (NOT LLDB_ENABLE_SWIFT_SUPPORT)
   unset(SWIFT_SOURCES)
   unset(SWIFT_LIBS)
+  set(PLUGIN_DEPENDENCY_ARG NO_PLUGIN_DEPENDENCIES)
+  set(LLDB_PLUGIN_DEPENDENCIES)
+else()
+  set(PLUGIN_DEPENDENCY_ARG)
+  set(LLDB_PLUGIN_DEPENDENCIES lldbPluginSwiftLanguageRuntime)
 endif()
 
-add_lldb_library(lldbSymbol NO_PLUGIN_DEPENDENCIES
+add_lldb_library(lldbSymbol ${PLUGIN_DEPENDENCY_ARG}
   ArmUnwindInfo.cpp
   Block.cpp
   CompactUnwindInfo.cpp
@@ -67,7 +72,7 @@ add_lldb_library(lldbSymbol NO_PLUGIN_DEPENDENCIES
     lldbHost
     lldbTarget
     lldbUtility
-    lldbPluginPlatformMacOSX
+    ${LLDB_PLUGIN_DEPENDENCIES}
     ${SWIFT_LIBS}
 
   LINK_COMPONENTS


### PR DESCRIPTION
As it turns out, lldbHostMacOSX and lldbSymbol technically do depend on plugins downstream. We cannot apply NO_PLUGIN_DEPENDENCIES to these libraries if swift support is enabled.