### PR TITLE
[dsymutil] Initialize the debug map before loading the main binary

### DIFF
--- a/llvm/tools/dsymutil/MachODebugMapParser.cpp
+++ b/llvm/tools/dsymutil/MachODebugMapParser.cpp
@@ -113,6 +113,8 @@ private:
                          StringRef BinaryPath);
 
   void Warning(const Twine &Msg, StringRef File = StringRef()) {
+    assert(Result &&
+           "The debug map must be initialized before calling this function");
     WithColor::warning() << "("
                          << MachOUtils::getArchName(
                                 Result->getTriple().getArchName())
@@ -199,10 +201,9 @@ static std::string getArchName(const object::MachOObjectFile &Obj) {
 std::unique_ptr<DebugMap>
 MachODebugMapParser::parseOneBinary(const MachOObjectFile &MainBinary,
                                     StringRef BinaryPath) {
+  Result = std::make_unique<DebugMap>(MainBinary.getArchTriple(), BinaryPath,
+                                      MainBinary.getUuid());
   loadMainBinarySymbols(MainBinary);
-  ArrayRef<uint8_t> UUID = MainBinary.getUuid();
-  Result =
-      std::make_unique<DebugMap>(MainBinary.getArchTriple(), BinaryPath, UUID);
   MainBinaryStrings = MainBinary.getStringTableData();
   for (const SymbolRef &Symbol : MainBinary.symbols()) {
     const DataRefImpl &DRI = Symbol.getRawDataRefImpl();


### PR DESCRIPTION
Fix a crash when a warning is emitted while loading the symbols from the
main binary. The warning helper assumes that the resulting debug map is
initialized, but this happened after loading the main binary. Since
there's no dependency between the two the initialization can be moved
up.

rdar://107298776
(cherry picked from commit 568be31c9e50a7d7263417841ee1b12334529903)
