### PR TITLE
[lldb] Support Universal Mach-O binaries with a fat64 header

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -183,7 +183,7 @@ ARCHFLAG ?= -arch
 #----------------------------------------------------------------------
 ifeq "$(OS)" "Darwin"
 	DS := $(DSYMUTIL)
-	DSFLAGS =
+	DSFLAGS := $(DSFLAGS_EXTRAS)
 	DSYM = $(EXE).dSYM
 	AR := $(CROSS_COMPILE)libtool
 	ARFLAGS := -static -o

--- a/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.h
+++ b/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.h
@@ -63,11 +63,46 @@ public:
 
 protected:
   llvm::MachO::fat_header m_header;
-  std::vector<llvm::MachO::fat_arch> m_fat_archs;
+
+  struct FatArch {
+    FatArch(llvm::MachO::fat_arch arch) : m_arch(arch), m_is_fat64(false) {}
+    FatArch(llvm::MachO::fat_arch_64 arch) : m_arch(arch), m_is_fat64(true) {}
+
+    uint32_t GetCPUType() const {
+      return m_is_fat64 ? m_arch.fat_arch_64.cputype : m_arch.fat_arch.cputype;
+    }
+
+    uint32_t GetCPUSubType() const {
+      return m_is_fat64 ? m_arch.fat_arch_64.cpusubtype
+                        : m_arch.fat_arch.cpusubtype;
+    }
+
+    uint64_t GetOffset() const {
+      return m_is_fat64 ? m_arch.fat_arch_64.offset : m_arch.fat_arch.offset;
+    }
+
+    uint64_t GetSize() const {
+      return m_is_fat64 ? m_arch.fat_arch_64.size : m_arch.fat_arch.size;
+    }
+
+    uint32_t GetAlign() const {
+      return m_is_fat64 ? m_arch.fat_arch_64.align : m_arch.fat_arch.align;
+    }
+
+  private:
+    const union Arch {
+      Arch(llvm::MachO::fat_arch arch) : fat_arch(arch) {}
+      Arch(llvm::MachO::fat_arch_64 arch) : fat_arch_64(arch) {}
+      llvm::MachO::fat_arch fat_arch;
+      llvm::MachO::fat_arch_64 fat_arch_64;
+    } m_arch;
+    const bool m_is_fat64;
+  };
+  std::vector<FatArch> m_fat_archs;
 
   static bool ParseHeader(lldb_private::DataExtractor &data,
                           llvm::MachO::fat_header &header,
-                          std::vector<llvm::MachO::fat_arch> &fat_archs);
+                          std::vector<FatArch> &fat_archs);
 };
 
 #endif // LLDB_SOURCE_PLUGINS_OBJECTCONTAINER_UNIVERSAL_MACH_O_OBJECTCONTAINERUNIVERSALMACHO_H

--- a/lldb/test/API/macosx/universal64/Makefile
+++ b/lldb/test/API/macosx/universal64/Makefile
@@ -1,0 +1,24 @@
+EXE := fat.out
+
+ifdef FAT64_DSYM
+	DSFLAGS_EXTRAS=-fat64
+endif
+
+include Makefile.rules
+
+all: fat.out
+
+fat.out: fat.arm64.out fat.x86_64.out
+	lipo -fat64 -create -o $@ $^
+
+fat.x86_64.out: fat.x86_64.o
+	$(CC) -isysroot $(SDKROOT) -target x86_64-apple-macosx10.9 -o $@ $<
+
+fat.arm64.out: fat.arm64.o
+	$(CC) -isysroot $(SDKROOT) -target arm64-apple-macosx10.9 -o $@ $<
+
+fat.x86_64.o: main.c
+	$(CC) -isysroot $(SDKROOT) -g -O0 -target x86_64-apple-macosx11 -c -o $@ $<
+
+fat.arm64.o: main.c
+	$(CC) -isysroot $(SDKROOT) -g -O0 -target arm64-apple-macosx11 -c -o $@ $<

--- a/lldb/test/API/macosx/universal64/TestUniversal64.py
+++ b/lldb/test/API/macosx/universal64/TestUniversal64.py
@@ -1,0 +1,39 @@
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class Universal64TestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def do_test(self):
+        # Get the executable.
+        exe = self.getBuildArtifact("fat.out")
+
+        # Create a target.
+        self.target = self.dbg.CreateTarget(exe)
+
+        # Create a breakpoint on main.
+        main_bp = self.target.BreakpointCreateByName("main")
+        self.assertTrue(main_bp, VALID_BREAKPOINT)
+
+        # Make sure the binary and the dSYM are in the image list.
+        self.expect("image list ", patterns=['fat.out', 'fat.out.dSYM'])
+
+        # The dynamic loader doesn't support fat64 executables so we can't
+        # actually launch them here.
+
+    @skipUnlessDarwin
+    @skipIfDarwinEmbedded
+    def test_universal64_executable(self):
+        """Test fat64 universal executable"""
+        self.build(debug_info="dsym")
+        self.do_test()
+
+    @skipUnlessDarwin
+    @skipIfDarwinEmbedded
+    @skipIf(compiler="clang", compiler_version=['<', '7.0'])
+    def test_universal64_dsym(self):
+        """Test fat64 universal dSYM"""
+        self.build(debug_info="dsym", dictionary={'FAT64_DSYM': '1'})
+        self.do_test()

--- a/lldb/test/API/macosx/universal64/main.c
+++ b/lldb/test/API/macosx/universal64/main.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int foo() { return 0; }
+
+int main(int argc, char **argv) { return foo(); }


### PR DESCRIPTION
Support universal Mach-O binaries with a fat64 header. After
4d683f7fa7d4, dsymutil can now generate such binaries when the offsets
would otherwise overflow the 32-bit offsets in the regular fat header.

rdar://107289570

Differential revision: https://reviews.llvm.org/D147012

(cherry picked from commit fda53ad9374b60fc83f1a6065ae3e7985182a5d2)
