### PR TITLE
[lldb] Fix value printing for a specific case

### DIFF
--- a/lldb/include/lldb/DataFormatters/ValueObjectPrinter.h
+++ b/lldb/include/lldb/DataFormatters/ValueObjectPrinter.h
@@ -98,7 +98,7 @@ protected:
 
   ValueObject *GetValueObjectForChildrenGeneration();
 
-  void PrintChildrenPreamble();
+  void PrintChildrenPreamble(bool value_printed, bool summary_printed);
 
   void PrintChildrenPostamble(bool print_dotdotdot);
 

--- a/lldb/source/DataFormatters/ValueObjectPrinter.cpp
+++ b/lldb/source/DataFormatters/ValueObjectPrinter.cpp
@@ -445,7 +445,9 @@ bool ValueObjectPrinter::PrintValueAndSummaryIfNeeded(bool &value_printed,
       }
 
       if (m_summary.size()) {
-        m_stream->Printf(" %s", m_summary.c_str());
+        if (ShouldShowName() || value_printed)
+          m_stream->PutChar(' ');
+        m_stream->PutCString(m_summary);
         summary_printed = true;
       }
     }
@@ -582,7 +584,8 @@ ValueObject *ValueObjectPrinter::GetValueObjectForChildrenGeneration() {
   return m_valobj;
 }
 
-void ValueObjectPrinter::PrintChildrenPreamble() {
+void ValueObjectPrinter::PrintChildrenPreamble(bool value_printed,
+                                               bool summary_printed) {
   if (m_options.m_flat_output) {
     if (ShouldPrintValueObject())
       m_stream->EOL();
@@ -590,7 +593,7 @@ void ValueObjectPrinter::PrintChildrenPreamble() {
     if (ShouldPrintValueObject()) {
       if (IsRef()) {
         m_stream->PutCString(": ");
-      } else if (ShouldShowName()) {
+      } else if (value_printed || summary_printed || ShouldShowName()) {
         m_stream->PutChar(' ');
       }
       m_stream->PutCString("{\n");
@@ -716,7 +719,7 @@ void ValueObjectPrinter::PrintChildren(
     for (size_t idx = 0; idx < num_children; ++idx) {
       if (ValueObjectSP child_sp = GenerateChild(synth_m_valobj, idx)) {
         if (!any_children_printed) {
-          PrintChildrenPreamble();
+          PrintChildrenPreamble(value_printed, summary_printed);
           any_children_printed = true;
         }
         PrintChild(child_sp, curr_ptr_depth);

--- a/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
+++ b/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
@@ -120,3 +120,12 @@ class TestCase(TestBase):
         self.runCmd("settings set auto-one-line-summaries false")
         self._expect_cmd(f"dwim-print s", "frame variable")
         self._expect_cmd(f"dwim-print (struct Structure)s", "expression")
+
+    def test_summary_strings(self):
+        """Test dwim-print with nested values (structs, etc)."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "// break here", lldb.SBFileSpec("main.c"))
+        self.runCmd("settings set auto-one-line-summaries false")
+        self.runCmd("type summary add -e -s 'stub summary' Structure")
+        self._expect_cmd(f"dwim-print s", "frame variable")
+        self._expect_cmd(f"dwim-print (struct Structure)s", "expression")


### PR DESCRIPTION
Fixes printing of spaces in cases where the following are true:

  1. Persistent results are disabled
  2. The type has a summary string

As reported by @jgorbe in D146783, two spaces were being printed before the summary
string, and no spaces were printed after.

Differential Revision: https://reviews.llvm.org/D147006

(cherry picked from commit 51dd8a20c1c32c60d03719e0e40bbc8e6c125477)
