### PR TITLE
[apple clang] modularize ptrauth.h in clang builtin headers

### DIFF
--- a/clang/lib/Headers/module.modulemap
+++ b/clang/lib/Headers/module.modulemap
@@ -162,3 +162,8 @@ module opencl_c {
   header "opencl-c.h"
   header "opencl-c-base.h"
 }
+
+module ptrauth {
+  header "ptrauth.h"
+  export *
+}


### PR DESCRIPTION
(cherry picked from commit ed4cb6992a0934959168f7ddbff8e04df7a6d5cd)