### PR TITLE
[clang][cas] Strip -coverage-data-file and -coverage-notes-file from PCH

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -29,6 +29,12 @@ void tooling::dependencies::configureInvocationForCaching(
   // Clear this otherwise it defeats the purpose of making the compilation key
   // independent of certain arguments.
   CI.getCodeGenOpts().DwarfDebugFlags.clear();
+  if (FrontendOpts.ProgramAction == frontend::GeneratePCH) {
+    // Clear paths that are emitted into binaries; they do not affect PCH.
+    // For modules this is handled in ModuleDepCollector.
+    CI.getCodeGenOpts().CoverageDataFile.clear();
+    CI.getCodeGenOpts().CoverageNotesFile.clear();
+  }
 
   // "Fix" the CAS options.
   auto &FileSystemOpts = CI.getFileSystemOpts();

--- a/clang/test/CAS/depscan-include-tree.c
+++ b/clang/test/CAS/depscan-include-tree.c
@@ -2,7 +2,8 @@
 // RUN: split-file %s %t
 
 // RUN: %clang -cc1depscan -o %t/inline.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args -cc1 -triple x86_64-apple-macos11.0 \
-// RUN:     -emit-obj %t/t.c -o %t/t.o -dwarf-ext-refs -fmodule-format=obj \
+// RUN:     -emit-obj %t/t.c -o %t/t.o -dwarf-ext-refs -fmodule-format=obj  \
+// RUN:     -ftest-coverage -coverage-notes-file %t/t.gcno -coverage-data-file %t/t.gcda \
 // RUN:     -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -DSOME_MACRO -dependency-file %t/inline.d -MT deps
 
 // RUN: FileCheck %s -input-file %t/inline.rsp -DPREFIX=%t
@@ -13,6 +14,9 @@
 // CHECK: "-fcas-path" "[[PREFIX]]/cas"
 // CHECK: "-fcas-include-tree"
 // CHECK: "-isysroot"
+// CHECK: "-ftest-coverage"
+// CHECK: "-coverage-data-file" "[[PREFIX]]/t.gcda"
+// CHECK: "-coverage-notes-file" "[[PREFIX]]/t.gcno"
 // SHOULD-NOT: "-fcas-fs"
 // SHOULD-NOT: "-fcas-fs-working-directory"
 // SHOULD-NOT: "-I"

--- a/clang/test/CAS/fcas-include-tree-with-pch.c
+++ b/clang/test/CAS/fcas-include-tree-with-pch.c
@@ -37,6 +37,14 @@
 // RUN: %clang @tu2.rsp -emit-llvm -o tree-rel.ll
 // RUN: diff -u source-rel.ll tree-rel.ll
 
+// Check that -coverage-notes-file and -coverage-data-file are stripped
+// RUN: %clang -cc1depscan -o pch3.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
+// RUN:     -cc1 -emit-pch -x c-header prefix.h -I %t/inc -DCMD_MACRO=1 -fcas-path %t/cas \
+// RUN:     -ftest-coverage -coverage-notes-file %t/pch.gcno -coverage-data-file %t/pch.gcda
+// RUN: FileCheck %s -check-prefix=COVERAGE -input-file %t/pch3.rsp
+// COVERAGE-NOT: -coverage-data-file
+// COVERAGE-NOT: -coverage-notes-file
+
 //--- t1.c
 #if S2_MACRO
 #include "s2-link.h"


### PR DESCRIPTION
Companion to https://reviews.llvm.org/D147282; when caching a PCH, remove the -coverage-data-file and -coverage-notes-file options. These paths cannot currently be prefix-mapped, because they are emitted into the binary for the coverage runtime to use. However, they have no effect on PCH, so remove them.

rdar://107443796