### PR TITLE
[libclang/depscan] Fix use-after-free issue when using diagnostics of `clang_experimental_DepGraph_getDiagnostics`

### DIFF
--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -315,7 +315,9 @@ typedef size_t CXModuleLookupOutputCallback(void *Context,
                                             char *Output, size_t MaxLen);
 
 /**
- * See \c clang_experimental_DependencyScannerWorker_getFileDependencies_v5.
+ * Deprecated, use \c clang_experimental_DependencyScannerWorker_getDepGraph.
+ *
+ * See \c clang_experimental_DependencyScannerWorker_getFileDependencies_v4.
  */
 CINDEX_LINKAGE CXFileDependencies *
 clang_experimental_DependencyScannerWorker_getFileDependencies_v3(
@@ -325,18 +327,8 @@ clang_experimental_DependencyScannerWorker_getFileDependencies_v3(
     CXModuleLookupOutputCallback *MLO, unsigned Options, CXString *error);
 
 /**
- * See \c clang_experimental_DependencyScannerWorker_getFileDependencies_v5.
- * Returns diagnostics in an unstructured CXString instead of CXDiagnosticSet.
- */
-CINDEX_LINKAGE enum CXErrorCode
-clang_experimental_DependencyScannerWorker_getFileDependencies_v4(
-    CXDependencyScannerWorker Worker, int argc, const char *const *argv,
-    const char *ModuleName, const char *WorkingDirectory, void *MDCContext,
-    CXModuleDiscoveredCallback *MDC, void *MLOContext,
-    CXModuleLookupOutputCallback *MLO, unsigned Options,
-    CXFileDependenciesList **Out, CXString *error);
-
-/**
+ * Deprecated, use \c clang_experimental_DependencyScannerWorker_getDepGraph.
+ *
  * Calculates the list of file dependencies for a particular compiler
  * invocation.
  *
@@ -366,19 +358,18 @@ clang_experimental_DependencyScannerWorker_getFileDependencies_v4(
  * \param [out] Out A non-NULL pointer to store the resulting dependencies. The
  *                  output must be freed by calling
  *                  \c clang_experimental_FileDependenciesList_dispose.
- * \param [out] OutDiags The diagnostics emitted during scanning. These must be
- *                       always freed by calling \c clang_disposeDiagnosticSet.
+ * \param [out] error the error string to pass back to client (if any).
  *
  * \returns \c CXError_Success on success; otherwise a non-zero \c CXErrorCode
  * indicating the kind of error.
  */
 CINDEX_LINKAGE enum CXErrorCode
-clang_experimental_DependencyScannerWorker_getFileDependencies_v5(
+clang_experimental_DependencyScannerWorker_getFileDependencies_v4(
     CXDependencyScannerWorker Worker, int argc, const char *const *argv,
     const char *ModuleName, const char *WorkingDirectory, void *MDCContext,
     CXModuleDiscoveredCallback *MDC, void *MLOContext,
     CXModuleLookupOutputCallback *MLO, unsigned Options,
-    CXFileDependenciesList **Out, CXDiagnosticSet *OutDiags);
+    CXFileDependenciesList **Out, CXString *error);
 
 /**
  * Output of \c clang_experimental_DependencyScannerWorker_getDepGraph.

--- a/clang/include/clang/Frontend/SerializedDiagnosticReader.h
+++ b/clang/include/clang/Frontend/SerializedDiagnosticReader.h
@@ -65,6 +65,9 @@ public:
   /// Read the diagnostics in \c File
   std::error_code readDiagnostics(StringRef File);
 
+  /// Read the diagnostics in \c Buffer.
+  std::error_code readDiagnostics(llvm::MemoryBufferRef Buffer);
+
 private:
   enum class Cursor;
 

--- a/clang/lib/Frontend/SerializedDiagnosticPrinter.cpp
+++ b/clang/lib/Frontend/SerializedDiagnosticPrinter.cpp
@@ -587,6 +587,9 @@ void SDiagsWriter::HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
     return;
   }
 
+  // Call base class to update diagnostic counts.
+  DiagnosticConsumer::HandleDiagnostic(DiagLevel, Info);
+
   // Enter the block for a non-note diagnostic immediately, rather than waiting
   // for beginDiagnostic, in case associated notes are emitted before we get
   // there.

--- a/clang/lib/Frontend/SerializedDiagnosticReader.cpp
+++ b/clang/lib/Frontend/SerializedDiagnosticReader.cpp
@@ -34,7 +34,12 @@ std::error_code SerializedDiagnosticReader::readDiagnostics(StringRef File) {
   if (!Buffer)
     return SDError::CouldNotLoad;
 
-  llvm::BitstreamCursor Stream(**Buffer);
+  return readDiagnostics(**Buffer);
+}
+
+std::error_code
+SerializedDiagnosticReader::readDiagnostics(llvm::MemoryBufferRef Buffer) {
+  llvm::BitstreamCursor Stream(Buffer);
   std::optional<llvm::BitstreamBlockInfo> BlockInfo;
 
   if (Stream.AtEndOfStream())

--- a/clang/test/Index/Core/scan-deps-with-diags.m
+++ b/clang/test/Index/Core/scan-deps-with-diags.m
@@ -1,0 +1,6 @@
+// RUN: not c-index-test core --scan-deps %S -output-dir=%t -- \
+// RUN:   %clang -c %s -o %t/t.o 2> %t.err.txt
+// RUN: FileCheck -input-file=%t.err.txt %s
+
+// CHECK: [[@LINE+1]]:10: fatal error: 'not-existent.h' file not found
+#include "not-existent.h"

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -846,7 +846,8 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
       llvm::make_scope_exit([&]() { clang_disposeDiagnosticSet(Diags); });
   for (unsigned I = 0, N = clang_getNumDiagnosticsInSet(Diags); I < N; ++I) {
     CXDiagnostic Diag = clang_getDiagnosticInSet(Diags, I);
-    CXString Spelling = clang_getDiagnosticSpelling(Diag);
+    CXString Spelling =
+        clang_formatDiagnostic(Diag, clang_defaultDiagnosticDisplayOptions());
     llvm::errs() << clang_getCString(Spelling) << "\n";
     clang_disposeString(Spelling);
     clang_disposeDiagnostic(Diag);

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -13,11 +13,13 @@
 
 #include "CASUtils.h"
 #include "CXDiagnosticSetDiagnosticConsumer.h"
+#include "CXLoadedDiagnostic.h"
 #include "CXString.h"
 
 #include "clang-c/Dependencies.h"
 
 #include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/SerializedDiagnosticPrinter.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningService.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningTool.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningWorker.h"
@@ -374,50 +376,6 @@ CXErrorCode clang_experimental_DependencyScannerWorker_getFileDependencies_v4(
   return Result;
 }
 
-CXErrorCode clang_experimental_DependencyScannerWorker_getFileDependencies_v5(
-    CXDependencyScannerWorker W, int argc, const char *const *argv,
-    const char *ModuleName, const char *WorkingDirectory, void *MDCContext,
-    CXModuleDiscoveredCallback *MDC, void *MLOContext,
-    CXModuleLookupOutputCallback *MLO, unsigned, CXFileDependenciesList **Out,
-    CXDiagnosticSet *OutDiags) {
-  OutputLookup OL(MLOContext, MLO);
-  auto LookupOutputs = [&](const ModuleID &ID, ModuleOutputKind MOK) {
-    return OL.lookupModuleOutput(ID, MOK);
-  };
-
-  if (!Out)
-    return CXError_InvalidArguments;
-  *Out = nullptr;
-
-  CXDiagnosticSetDiagnosticConsumer DiagConsumer;
-
-  CXErrorCode Result = getFileDependencies(
-      W, argc, argv, WorkingDirectory, MDC, MDCContext, nullptr, &DiagConsumer,
-      LookupOutputs,
-      ModuleName ? std::optional<StringRef>(ModuleName) : std::nullopt,
-      [&](TranslationUnitDeps TU) {
-        assert(TU.DriverCommandLine.empty());
-        std::vector<std::string> Modules;
-        for (const ModuleID &MID : TU.ClangModuleDeps)
-          Modules.push_back(MID.ModuleName + ":" + MID.ContextHash);
-        auto *Commands = new CXTranslationUnitCommand[TU.Commands.size()];
-        for (size_t I = 0, E = TU.Commands.size(); I < E; ++I) {
-          Commands[I].ContextHash = cxstring::createDup(TU.ID.ContextHash);
-          Commands[I].FileDeps = cxstring::createSet(TU.FileDeps);
-          Commands[I].ModuleDeps = cxstring::createSet(Modules);
-          Commands[I].Executable =
-              cxstring::createDup(TU.Commands[I].Executable);
-          Commands[I].BuildArguments =
-              cxstring::createSet(TU.Commands[I].Arguments);
-        }
-        *Out = new CXFileDependenciesList{TU.Commands.size(), Commands};
-      });
-
-  *OutDiags = DiagConsumer.getDiagnosticSet();
-
-  return Result;
-}
-
 namespace {
 
 struct DependencyScannerWorkerScanSettings {
@@ -471,8 +429,18 @@ struct CStringsManager {
 
 struct DependencyGraph {
   TranslationUnitDeps TUDeps;
-  CXDiagnosticSetDiagnosticConsumer DiagConsumer;
+  SmallString<256> SerialDiagBuf;
   CStringsManager StrMgr{};
+
+  CXDiagnosticSet getDiagnosticSet() const {
+    CXLoadDiag_Error Error;
+    CXString ErrorString;
+    CXDiagnosticSet DiagSet = loadCXDiagnosticsFromBuffer(
+        llvm::MemoryBufferRef(SerialDiagBuf, "<diags>"), &Error, &ErrorString);
+    assert(Error == CXLoadDiag_None);
+    clang_disposeString(ErrorString);
+    return DiagSet;
+  }
 };
 
 struct DependencyGraphModule {
@@ -530,9 +498,18 @@ enum CXErrorCode clang_experimental_DependencyScannerWorker_getDepGraph(
 
   DependencyGraph *DepGraph = new DependencyGraph();
 
+  // We capture diagnostics as a serialized diagnostics buffer, so that we don't
+  // need to keep a valid SourceManager in order to access diagnostic locations.
+  auto DiagOpts = llvm::makeIntrusiveRefCnt<DiagnosticOptions>();
+  auto DiagOS =
+      std::make_unique<llvm::raw_svector_ostream>(DepGraph->SerialDiagBuf);
+  std::unique_ptr<DiagnosticConsumer> SerialDiagConsumer =
+      serialized_diags::create("<diagnostics>", DiagOpts.get(),
+                               /*MergeChildRecords=*/false, std::move(DiagOS));
+
   CXErrorCode Result = getFileDependencies(
       W, argc, argv, WorkingDirectory, /*MDC=*/nullptr, /*MDCContext=*/nullptr,
-      /*Error=*/nullptr, &DepGraph->DiagConsumer, LookupOutputs,
+      /*Error=*/nullptr, SerialDiagConsumer.get(), LookupOutputs,
       ModuleName ? std::optional<StringRef>(ModuleName) : std::nullopt,
       [&](TranslationUnitDeps TU) { DepGraph->TUDeps = std::move(TU); });
 
@@ -648,7 +625,7 @@ const char *clang_experimental_DepGraph_getTUContextHash(CXDepGraph Graph) {
 }
 
 CXDiagnosticSet clang_experimental_DepGraph_getDiagnostics(CXDepGraph Graph) {
-  return unwrap(Graph)->DiagConsumer.getDiagnosticSet();
+  return unwrap(Graph)->getDiagnosticSet();
 }
 
 static std::string lookupModuleOutput(const ModuleID &ID, ModuleOutputKind MOK,

--- a/clang/tools/libclang/CXLoadedDiagnostic.cpp
+++ b/clang/tools/libclang/CXLoadedDiagnostic.cpp
@@ -243,6 +243,9 @@ public:
   }
 
   CXDiagnosticSet load(const char *file);
+  CXDiagnosticSet load(llvm::MemoryBufferRef Buffer);
+
+  CXDiagnosticSet reportError(std::error_code EC);
 };
 } // end anonymous namespace
 
@@ -250,22 +253,36 @@ CXDiagnosticSet DiagLoader::load(const char *file) {
   TopDiags = std::make_unique<CXLoadedDiagnosticSetImpl>();
 
   std::error_code EC = readDiagnostics(file);
-  if (EC) {
-    switch (EC.value()) {
-    case static_cast<int>(serialized_diags::SDError::HandlerFailed):
-      // We've already reported the problem.
-      break;
-    case static_cast<int>(serialized_diags::SDError::CouldNotLoad):
-      reportBad(CXLoadDiag_CannotLoad, EC.message());
-      break;
-    default:
-      reportInvalidFile(EC.message());
-      break;
-    }
-    return nullptr;
-  }
+  if (EC)
+    return reportError(EC);
 
   return (CXDiagnosticSet)TopDiags.release();
+}
+
+CXDiagnosticSet DiagLoader::load(llvm::MemoryBufferRef Buffer) {
+  TopDiags = std::make_unique<CXLoadedDiagnosticSetImpl>();
+
+  std::error_code EC = readDiagnostics(Buffer);
+  if (EC)
+    return reportError(EC);
+
+  return (CXDiagnosticSet)TopDiags.release();
+}
+
+CXDiagnosticSet DiagLoader::reportError(std::error_code EC) {
+  assert(EC);
+  switch (EC.value()) {
+  case static_cast<int>(serialized_diags::SDError::HandlerFailed):
+    // We've already reported the problem.
+    break;
+  case static_cast<int>(serialized_diags::SDError::CouldNotLoad):
+    reportBad(CXLoadDiag_CannotLoad, EC.message());
+    break;
+  default:
+    reportInvalidFile(EC.message());
+    break;
+  }
+  return nullptr;
 }
 
 std::error_code
@@ -391,4 +408,11 @@ CXDiagnosticSet clang_loadDiagnostics(const char *file,
                                       CXString *errorString) {
   DiagLoader L(error, errorString);
   return L.load(file);
+}
+
+CXDiagnosticSet clang::loadCXDiagnosticsFromBuffer(llvm::MemoryBufferRef buffer,
+                                                   enum CXLoadDiag_Error *error,
+                                                   CXString *errorString) {
+  DiagLoader L(error, errorString);
+  return L.load(buffer);
 }

--- a/clang/tools/libclang/CXLoadedDiagnostic.h
+++ b/clang/tools/libclang/CXLoadedDiagnostic.h
@@ -19,6 +19,10 @@
 #include "clang/Basic/LLVM.h"
 #include <vector>
 
+namespace llvm {
+class MemoryBufferRef;
+}
+
 namespace clang {
 class CXLoadedDiagnostic : public CXDiagnosticImpl {
 public:
@@ -88,6 +92,13 @@ public:
   unsigned severity;
   unsigned category;
 };
-}
+
+/// Read a serialized diagnostics \p buffer and create a \c CXDiagnosticSet
+/// object for the loaded diagnostics.
+CXDiagnosticSet loadCXDiagnosticsFromBuffer(llvm::MemoryBufferRef buffer,
+                                            enum CXLoadDiag_Error *error,
+                                            CXString *errorString);
+
+} // namespace clang
 
 #endif

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -490,7 +490,6 @@ LLVM_16 {
     clang_experimental_DependencyScannerServiceOptions_setDependencyMode;
     clang_experimental_DependencyScannerServiceOptions_setObjectStore;
     clang_experimental_DependencyScannerWorker_getDepGraph;
-    clang_experimental_DependencyScannerWorker_getFileDependencies_v5;
     clang_experimental_DependencyScannerWorkerScanSettings_create;
     clang_experimental_DependencyScannerWorkerScanSettings_dispose;
     clang_experimental_DepGraph_dispose;


### PR DESCRIPTION
The `StoredDiagnostic`s captured from the `getFileDependencies()` call reference a `SourceManager` object that gets destroyed and is invalid to use for getting diagnostic location info.

To address this, capture diagnostics as a serialized diagnostics buffer and "materialize" it for the `clang_experimental_DepGraph_getDiagnostics` call, by re-using existing libclang machinery for loading serialized diagnostics.

rdar://105978877