### PR TITLE
[lldb] Update for full enablement of experimental string processing

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1343,8 +1343,6 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
       sc.target_sp->GetSwiftEnableBareSlashRegex();
   invocation.getLangOptions().EnableBareSlashRegexLiterals =
       enable_bare_slash_regex_literals;
-  invocation.getLangOptions().EnableExperimentalStringProcessing =
-      enable_bare_slash_regex_literals;
   invocation.getLangOptions().Features.insert(swift::Feature::VariadicGenerics);
 
   auto should_use_prestable_abi = [&]() {

--- a/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
+++ b/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
@@ -50,6 +50,11 @@ class TestSwiftRegex(TestBase):
         self.build()
         lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', self.main_source_spec)
+
+        # Make sure we can use the extended syntax without enabling anything.
+        self.expect('e -- #/Order from <(.*)>, type: (.*), count in dozen: ([0-9]+)/#',
+                    substrs=['_StringProcessing.Regex<(Substring, Substring, Substring, Substring)>'])
+
         self.runCmd(
             "settings set target.experimental.swift-enable-bare-slash-regex true")
         self.expect('e -- /Order from <(.*)>, type: (.*), count in dozen: ([0-9]+)/',

--- a/lldb/test/Shell/SwiftREPL/Regex.test
+++ b/lldb/test/Shell/SwiftREPL/Regex.test
@@ -3,8 +3,13 @@
 
 // RUN: %lldb --repl < %s | FileCheck %s
 
+// Make sure we can use an extended literal without enabling anything.
+let regex1 = #/Order from <(.*)>, type: (.*), count in dozen: ([0-9]+)/#
+// CHECK: _StringProcessing.Regex<(Substring, Substring, Substring, Substring)> =
+
 :settings set target.experimental.swift-enable-bare-slash-regex true
-let regex = /Order from <(.*)>, type: (.*), count in dozen: ([0-9]+)/
+
+let regex2 = /Order from <(.*)>, type: (.*), count in dozen: ([0-9]+)/
 // CHECK: _StringProcessing.Regex<(Substring, Substring, Substring, Substring)> =
 
 import RegexBuilder
@@ -16,6 +21,7 @@ let dslRegex = Regex { .digit }
 if #unavailable(macOS 13, iOS 16, watchOS 9, tvOS 16) {
   // Work around the fact that the REPL doesn't print results for
   // variables declared inside of a conditional.
+  print("_StringProcessing.Regex<(Substring, Substring, Substring, Substring)> =")
   print("_StringProcessing.Regex<(Substring, Substring, Substring, Substring)> =")
   print("_StringProcessing.Regex<Substring> = ")
 }


### PR DESCRIPTION
Update for https://github.com/apple/swift/pull/64817, ensuring that LLDB can parse extended regex literals without having to enable the bare slash syntax.

rdar://107419385
rdar://101765556