### PR TITLE
[libclang/depscan] Fix use-after-free issue when using diagnostics of `clang_experimental_DepGraph_getDiagnostics`

### DIFF
--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -310,18 +310,8 @@ typedef size_t CXModuleLookupOutputCallback(void *Context,
                                             char *Output, size_t MaxLen);
 
 /**
- * See \c clang_experimental_DependencyScannerWorker_getFileDependencies_v5.
- * Returns diagnostics in an unstructured CXString instead of CXDiagnosticSet.
- */
-CINDEX_LINKAGE enum CXErrorCode
-clang_experimental_DependencyScannerWorker_getFileDependencies_v4(
-    CXDependencyScannerWorker Worker, int argc, const char *const *argv,
-    const char *ModuleName, const char *WorkingDirectory, void *MDCContext,
-    CXModuleDiscoveredCallback *MDC, void *MLOContext,
-    CXModuleLookupOutputCallback *MLO, unsigned Options,
-    CXFileDependenciesList **Out, CXString *error);
-
-/**
+ * Deprecated, use \c clang_experimental_DependencyScannerWorker_getDepGraph.
+ *
  * Calculates the list of file dependencies for a particular compiler
  * invocation.
  *
@@ -351,19 +341,18 @@ clang_experimental_DependencyScannerWorker_getFileDependencies_v4(
  * \param [out] Out A non-NULL pointer to store the resulting dependencies. The
  *                  output must be freed by calling
  *                  \c clang_experimental_FileDependenciesList_dispose.
- * \param [out] OutDiags The diagnostics emitted during scanning. These must be
- *                       always freed by calling \c clang_disposeDiagnosticSet.
+ * \param [out] error the error string to pass back to client (if any).
  *
  * \returns \c CXError_Success on success; otherwise a non-zero \c CXErrorCode
  * indicating the kind of error.
  */
 CINDEX_LINKAGE enum CXErrorCode
-clang_experimental_DependencyScannerWorker_getFileDependencies_v5(
+clang_experimental_DependencyScannerWorker_getFileDependencies_v4(
     CXDependencyScannerWorker Worker, int argc, const char *const *argv,
     const char *ModuleName, const char *WorkingDirectory, void *MDCContext,
     CXModuleDiscoveredCallback *MDC, void *MLOContext,
     CXModuleLookupOutputCallback *MLO, unsigned Options,
-    CXFileDependenciesList **Out, CXDiagnosticSet *OutDiags);
+    CXFileDependenciesList **Out, CXString *error);
 
 /**
  * Output of \c clang_experimental_DependencyScannerWorker_getDepGraph.

--- a/clang/include/clang/Frontend/SerializedDiagnosticReader.h
+++ b/clang/include/clang/Frontend/SerializedDiagnosticReader.h
@@ -65,6 +65,9 @@ public:
   /// Read the diagnostics in \c File
   std::error_code readDiagnostics(StringRef File);
 
+  /// Read the diagnostics in \c Buffer.
+  std::error_code readDiagnostics(llvm::MemoryBufferRef Buffer);
+
 private:
   enum class Cursor;
 

--- a/clang/lib/Frontend/SerializedDiagnosticPrinter.cpp
+++ b/clang/lib/Frontend/SerializedDiagnosticPrinter.cpp
@@ -608,6 +608,9 @@ void SDiagsWriter::HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
     return;
   }
 
+  // Call base class to update diagnostic counts.
+  DiagnosticConsumer::HandleDiagnostic(DiagLevel, Info);
+
   // Enter the block for a non-note diagnostic immediately, rather than waiting
   // for beginDiagnostic, in case associated notes are emitted before we get
   // there.

--- a/clang/lib/Frontend/SerializedDiagnosticReader.cpp
+++ b/clang/lib/Frontend/SerializedDiagnosticReader.cpp
@@ -34,7 +34,12 @@ std::error_code SerializedDiagnosticReader::readDiagnostics(StringRef File) {
   if (!Buffer)
     return SDError::CouldNotLoad;
 
-  llvm::BitstreamCursor Stream(**Buffer);
+  return readDiagnostics(**Buffer);
+}
+
+std::error_code
+SerializedDiagnosticReader::readDiagnostics(llvm::MemoryBufferRef Buffer) {
+  llvm::BitstreamCursor Stream(Buffer);
   Optional<llvm::BitstreamBlockInfo> BlockInfo;
 
   if (Stream.AtEndOfStream())

--- a/clang/test/Index/Core/scan-deps-with-diags.m
+++ b/clang/test/Index/Core/scan-deps-with-diags.m
@@ -1,0 +1,6 @@
+// RUN: not c-index-test core --scan-deps %S -output-dir=%t -- \
+// RUN:   %clang -c %s -o %t/t.o 2> %t.err.txt
+// RUN: FileCheck -input-file=%t.err.txt %s
+
+// CHECK: [[@LINE+1]]:10: fatal error: 'not-existent.h' file not found
+#include "not-existent.h"

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -846,7 +846,8 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
       llvm::make_scope_exit([&]() { clang_disposeDiagnosticSet(Diags); });
   for (unsigned I = 0, N = clang_getNumDiagnosticsInSet(Diags); I < N; ++I) {
     CXDiagnostic Diag = clang_getDiagnosticInSet(Diags, I);
-    CXString Spelling = clang_getDiagnosticSpelling(Diag);
+    CXString Spelling =
+        clang_formatDiagnostic(Diag, clang_defaultDiagnosticDisplayOptions());
     llvm::errs() << clang_getCString(Spelling) << "\n";
     clang_disposeString(Spelling);
     clang_disposeDiagnostic(Diag);

--- a/clang/tools/libclang/CXLoadedDiagnostic.h
+++ b/clang/tools/libclang/CXLoadedDiagnostic.h
@@ -19,6 +19,10 @@
 #include "clang/Basic/LLVM.h"
 #include <vector>
 
+namespace llvm {
+class MemoryBufferRef;
+}
+
 namespace clang {
 class CXLoadedDiagnostic : public CXDiagnosticImpl {
 public:
@@ -88,6 +92,13 @@ public:
   unsigned severity;
   unsigned category;
 };
-}
+
+/// Read a serialized diagnostics \p buffer and create a \c CXDiagnosticSet
+/// object for the loaded diagnostics.
+CXDiagnosticSet loadCXDiagnosticsFromBuffer(llvm::MemoryBufferRef buffer,
+                                            enum CXLoadDiag_Error *error,
+                                            CXString *errorString);
+
+} // namespace clang
 
 #endif

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -490,7 +490,6 @@ LLVM_16 {
     clang_experimental_DependencyScannerServiceOptions_setDependencyMode;
     clang_experimental_DependencyScannerServiceOptions_setObjectStore;
     clang_experimental_DependencyScannerWorker_getDepGraph;
-    clang_experimental_DependencyScannerWorker_getFileDependencies_v5;
     clang_experimental_DependencyScannerWorkerScanSettings_create;
     clang_experimental_DependencyScannerWorkerScanSettings_dispose;
     clang_experimental_DepGraph_dispose;


### PR DESCRIPTION
The `StoredDiagnostic`s captured from the `getFileDependencies()` call reference a `SourceManager` object that gets destroyed and is invalid to use for getting diagnostic location info.

To address this, capture diagnostics as a serialized diagnostics buffer and "materialize" it for the `clang_experimental_DepGraph_getDiagnostics` call, by re-using existing libclang machinery for loading serialized diagnostics.

Also delete `clang_experimental_DependencyScannerWorker_getFileDependencies_v5` since it's unsafe to use to get diagnostics and its functionality is superseeded by `clang_experimental_DependencyScannerWorker_getDepGraph`.

rdar://105978877
(cherry picked from commit 397a30d9d20ed76388700605076da468d02dbf3b)