### PR TITLE
[clang] Set ShowInSystemHeader for module-build and module-import remarks

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -252,8 +252,10 @@ def warn_module_config_macro_undef : Warning<
 def note_module_def_undef_here : Note<
   "macro was %select{defined|#undef'd}0 here">;
 def remark_module_build : Remark<"building module '%0' as '%1'">,
+  ShowInSystemHeader,
   InGroup<ModuleBuild>;
 def remark_module_build_done : Remark<"finished building module '%0'">,
+  ShowInSystemHeader,
   InGroup<ModuleBuild>;
 def remark_module_lock : Remark<"locking '%0' to build module '%1'">,
   InGroup<ModuleLock>;

--- a/clang/include/clang/Basic/DiagnosticSerializationKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSerializationKinds.td
@@ -75,6 +75,7 @@ def note_module_file_conflict : Note<
 
 def remark_module_import : Remark<
   "importing module '%0'%select{| into '%3'}2 from '%1'">,
+  ShowInSystemHeader,
   InGroup<ModuleImport>;
 
 def err_imported_module_not_found : Error<

--- a/clang/test/Modules/system-Rmodule-build.m
+++ b/clang/test/Modules/system-Rmodule-build.m
@@ -1,0 +1,16 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t/sys
+// RUN: echo '#include <B.h>' > %t/sys/A.h
+// RUN: echo '' > %t/sys/B.h
+// RUN: echo 'module A { header "A.h" }' > %t/sys/module.modulemap
+// RUN: echo 'module B { header "B.h" }' >> %t/sys/module.modulemap
+
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t -fsyntax-only %s \
+// RUN:            -isystem %t/sys -Rmodule-build 2>&1 | FileCheck %s
+
+@import A;
+
+// CHECK: building module 'A' as
+// CHECK: building module 'B' as
+// CHECK: finished building module 'B'
+// CHECK: finished building module 'A'


### PR DESCRIPTION
Without this change, the use of `-Rmodule-build` and `-Rmodule-import` only
produces diagnostics for modules built or imported by non-system code.

For example, if a project source file requires the Foundation module to be
built, then `-Rmodule-build` will show a single diagnostic for Foundation, but
not in turn for any of Foundation's (direct or indirect) dependencies. This is
because the locations of those transitive module builds are initiated from
system headers, which are ignored by default. When wanting to observe module
building/importing, the system modules can represent a significant amount of
module diagnostics, and I think should be shown by default when
`-Rmodule-build` and `-Rmodule-import` are specified.

I noticed some other remarks use `ShowInSystemHeader`.

Differential Revision: https://reviews.llvm.org/D139653

(cherry picked from commit ba6e747f9b05e541e88822e1dbd6bd5424cfe2fb)
