### PR TITLE
[clang][cas] Extend fix for private modules to module builds

### DIFF
--- a/clang/test/ClangScanDeps/modules-include-tree-pch-with-private.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-pch-with-private.c
@@ -14,8 +14,10 @@
 // RUN:   > %t/deps_pch.json
 
 // RUN: %deps-to-rsp %t/deps_pch.json --module-name Mod > %t/Mod.rsp
+// RUN: %deps-to-rsp %t/deps_pch.json --module-name Indirect1 > %t/Indirect1.rsp
 // RUN: %deps-to-rsp %t/deps_pch.json --tu-index 0 > %t/pch.rsp
 // RUN: %clang @%t/Mod.rsp
+// RUN: %clang @%t/Indirect1.rsp
 // RUN: %clang @%t/pch.rsp
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
@@ -24,9 +26,38 @@
 // RUN:   > %t/deps.json
 
 // RUN: %deps-to-rsp %t/deps.json --module-name Mod_Private > %t/Mod_Private.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name Indirect2 > %t/Indirect2.rsp
 // RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
 // RUN: %clang @%t/Mod_Private.rsp
+// RUN: %clang @%t/Indirect2.rsp
 // RUN: %clang @%t/tu.rsp
+
+// Extract include-tree casids
+// RUN: cat %t/Indirect2.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/Indirect.casid
+// RUN: cat %t/tu.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/tu.casid
+
+// RUN: echo "MODULE Indirect2" > %t/result.txt
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/Indirect.casid >> %t/result.txt
+// RUN: echo "TRANSLATION UNIT" >> %t/result.txt
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/tu.casid >> %t/result.txt
+
+// Explicitly check that Mod_Private is imported as a module and not a header.
+// RUN: FileCheck %s -DPREFIX=%/t -input-file %t/result.txt
+
+// CHECK-LABEL: MODULE Indirect2
+// CHECK: <module-includes> llvmcas://
+// CHECK: 1:1 <built-in> llvmcas://
+// CHECK: 2:1 [[PREFIX]]/indirect2.h llvmcas://
+// CHECK:   Submodule: Indirect2
+// CHECK:   2:1 (Module) Indirect1
+// CHECK:   3:1 (Module) Mod_Private
+
+// CHECK-LABEL: TRANSLATION UNIT
+// CHECK: (PCH) llvmcas://
+// CHECK: [[PREFIX]]/tu.m llvmcas://
+// CHECK: 1:1 <built-in> llvmcas://
+// CHECK: 2:1 (Module) Mod_Private
+// CHECK: 3:1 (Module) Indirect2
 
 //--- cdb.json.template
 [{
@@ -54,12 +85,38 @@ void pub(void);
 //--- Mod.framework/PrivateHeaders/Priv.h
 void priv(void);
 
+//--- module.modulemap
+module Indirect1 {
+  header "indirect1.h"
+  export *
+}
+module Indirect2 {
+  header "indirect2.h"
+  export *
+}
+
+//--- indirect1.h
+#import <Mod/Mod.h>
+
+//--- indirect2.h
+#import "indirect1.h"
+#import <Mod/Priv.h>
+
+static inline void indirect(void) {
+  pub();
+  priv();
+}
+
 //--- prefix.h
 #import <Mod/Mod.h>
+#import "indirect1.h"
 
 //--- tu.m
 #import <Mod/Priv.h>
+#import "indirect2.h"
+
 void tu(void) {
   pub();
   priv();
+  indirect();
 }


### PR DESCRIPTION
In 6034ccd1ea9 we fixed an issue where if a public module is imported via PCH we cannot import the private module in a TU because the modulemap is not parsed. This is also an issue when building a module that imports the private module and the TU used a PCH, because even though we don't import the PCH itself, we still use the prebuilt/explicit module found via the PCH instead of building an implicit scanner module.

This commit generalizes the original fix to handle all prebuilt/explicit modules.

rdar://107446573