### PR TITLE
[stable][clang/cas/dep-scan] Include the translation unit cache key in the scanning output

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -39,6 +39,9 @@ struct DepscanPrefixMapping;
 struct Command {
   std::string Executable;
   std::vector<std::string> Arguments;
+
+  /// The \c ActionCache key for this translation unit, if any.
+  std::optional<std::string> TUCacheKey;
 };
 
 class DependencyConsumer {

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -15,6 +15,7 @@
 #include "clang/Driver/Driver.h"
 #include "clang/Driver/Job.h"
 #include "clang/Driver/Tool.h"
+#include "clang/Frontend/CompileJobCacheKey.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/CompilerInvocation.h"
 #include "clang/Frontend/FrontendActions.h"
@@ -484,6 +485,13 @@ public:
 
     LastCC1Arguments = OriginalInvocation.getCC1CommandLine();
 
+    if (ScanInstance.getFrontendOpts().CacheCompileJob) {
+      auto &CAS = ScanInstance.getOrCreateObjectStore();
+      if (auto Key = createCompileJobCacheKey(
+              CAS, ScanInstance.getDiagnostics(), OriginalInvocation))
+        TUCacheKey = Key->toString();
+    }
+
     return true;
   }
 
@@ -497,6 +505,8 @@ public:
     std::swap(Result, LastCC1Arguments); // Reset LastCC1Arguments to empty.
     return Result;
   }
+
+  const std::optional<std::string> &getTUCacheKey() const { return TUCacheKey; }
 
   IntrusiveRefCntPtr<llvm::vfs::FileSystem> getDepScanFS() {
     if (DepFS) {
@@ -528,6 +538,7 @@ private:
   Optional<CompilerInstance> ScanInstanceStorage;
   std::shared_ptr<ModuleDepCollector> MDC;
   std::vector<std::string> LastCC1Arguments;
+  std::optional<std::string> TUCacheKey;
   bool Scanned = false;
   raw_ostream *VerboseOS;
 };
@@ -706,7 +717,8 @@ bool DependencyScanningWorker::computeDependencies(
           // consumer.
           Consumer.handleBuildCommand(
               {Cmd.getExecutable(),
-               {Cmd.getArguments().begin(), Cmd.getArguments().end()}});
+               {Cmd.getArguments().begin(), Cmd.getArguments().end()},
+               /*TUCacheKey=*/std::nullopt});
           return true;
         }
 
@@ -727,7 +739,8 @@ bool DependencyScanningWorker::computeDependencies(
           return false;
 
         std::vector<std::string> Args = Action.takeLastCC1Arguments();
-        Consumer.handleBuildCommand({Cmd.getExecutable(), std::move(Args)});
+        Consumer.handleBuildCommand(
+            {Cmd.getExecutable(), std::move(Args), Action.getTUCacheKey()});
         return true;
       });
 

--- a/clang/test/ClangScanDeps/include-tree.c
+++ b/clang/test/ClangScanDeps/include-tree.c
@@ -48,6 +48,7 @@
 // FULL-NEXT:     {
 // FULL-NEXT:       "commands": [
 // FULL-NEXT:         {
+// FULL-NEXT:           "cache-key": "[[TU_CACHE_KEY:llvmcas://[[:xdigit:]]+]]"
 // FULL:                "clang-module-deps": []
 // FULL:                "command-line": [
 // FULL-NEXT:             "-cc1"
@@ -84,7 +85,17 @@
 
 // Build the include-tree command
 // RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
-// RUN: %clang @%t/tu.rsp
+// RUN: %clang @%t/tu.rsp -Rcompile-job-cache 2> %t/t.err
+
+// Check cache key.
+// RUN: cp %t/full.txt %t/combined.txt
+// RUN: cat %t/t.err >> %t/combined.txt
+// RUN: FileCheck %s -input-file=%t/combined.txt -check-prefix=COMBINED
+
+// COMBINED:        "commands": [
+// COMBINED-NEXT:     {
+// COMBINED-NEXT:       "cache-key": "[[TU_CACHE_KEY:llvmcas://[[:xdigit:]]+]]"
+// COMBINED:      remark: compile job cache miss for '[[TU_CACHE_KEY]]'
 
 //--- cdb.json.template
 [

--- a/clang/test/ClangScanDeps/modules-cas-full-by-mod-name.c
+++ b/clang/test/ClangScanDeps/modules-cas-full-by-mod-name.c
@@ -35,6 +35,7 @@ module transitive { header "transitive.h" }
 // CHECK:      {
 // CHECK-NEXT:   "modules": [
 // CHECK-NEXT:     {
+// CHECK-NEXT:       "cache-key": "[[DIRECT_CACHE_KEY:llvmcas://[[:xdigit:]]+]]"
 // CHECK-NEXT:       "casfs-root-id": "[[LEFT_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
 // CHECK-NEXT:       "clang-module-deps": [
 // CHECK-NEXT:         {
@@ -44,6 +45,9 @@ module transitive { header "transitive.h" }
 // CHECK-NEXT:       ],
 // CHECK-NEXT:       "clang-modulemap-file": "[[PREFIX]]/module.modulemap",
 // CHECK-NEXT:       "command-line": [
+// CHECK:              "-fmodule-file-cache-key"
+// CHECK-NEXT:         "{{.*transitive-.*\.pcm}}"
+// CHECK-NEXT:         "[[TRANSITIVE_CACHE_KEY:llvmcas://[[:xdigit:]]+]]"
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
 // CHECK-NEXT:       "file-deps": [
@@ -53,7 +57,8 @@ module transitive { header "transitive.h" }
 // CHECK-NEXT:       "name": "direct"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
-// CHECK-NEXT:       "casfs-root-id": "[[LEFT_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// CHECK-NEXT:       "cache-key": "[[ROOT_CACHE_KEY:llvmcas://[[:xdigit:]]+]]"
+// CHECK-NEXT:       "casfs-root-id": "[[ROOT_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
 // CHECK-NEXT:       "clang-module-deps": [
 // CHECK-NEXT:         {
 // CHECK-NEXT:           "context-hash": "{{.*}}",
@@ -62,6 +67,9 @@ module transitive { header "transitive.h" }
 // CHECK-NEXT:       ],
 // CHECK-NEXT:       "clang-modulemap-file": "[[PREFIX]]/module.modulemap",
 // CHECK-NEXT:       "command-line": [
+// CHECK:              "-fmodule-file-cache-key"
+// CHECK-NEXT:         "{{.*direct-.*\.pcm}}"
+// CHECK-NEXT:         "[[DIRECT_CACHE_KEY]]"
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
 // CHECK-NEXT:       "file-deps": [
@@ -72,7 +80,8 @@ module transitive { header "transitive.h" }
 // CHECK-NEXT:       "name": "root"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
-// CHECK-NEXT:       "casfs-root-id": "[[LEFT_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
+// CHECK-NEXT:       "cache-key": "[[TRANSITIVE_CACHE_KEY]]"
+// CHECK-NEXT:       "casfs-root-id": "[[LEFT_ROOT_ID]]"
 // CHECK-NEXT:       "clang-module-deps": [],
 // CHECK-NEXT:       "clang-modulemap-file": "[[PREFIX]]/module.modulemap",
 // CHECK-NEXT:       "command-line": [

--- a/clang/test/ClangScanDeps/modules-cas-trees.c
+++ b/clang/test/ClangScanDeps/modules-cas-trees.c
@@ -64,6 +64,7 @@
 // CHECK:      {
 // CHECK-NEXT:   "modules": [
 // CHECK-NEXT:     {
+// CHECK:            "cache-key": "[[LEFT_CACHE_KEY:llvmcas://[[:xdigit:]]+]]"
 // CHECK:            "casfs-root-id": "[[LEFT_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
 // CHECK:            "clang-module-deps": [
 // CHECK:              {
@@ -92,6 +93,7 @@
 // CHECK:            "name": "Left"
 // CHECK:          }
 // CHECK-NEXT:     {
+// CHECK:            "cache-key": "[[RIGHT_CACHE_KEY:llvmcas://[[:xdigit:]]+]]"
 // CHECK:            "casfs-root-id": "[[RIGHT_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
 // CHECK:            "clang-module-deps": [
 // CHECK:              {
@@ -110,7 +112,7 @@
 // CHECK:              "-emit-module"
 // CHECK:              "-fmodule-file-cache-key"
 // CHECK:              "[[TOP_PCM]]"
-// CHECK:              "[[TOP_CACHE_KEY:llvmcas://[[:xdigit:]]+]]"
+// CHECK:              "[[TOP_CACHE_KEY]]"
 // CHECK:              "-fmodule-file={{(Top=)?}}[[TOP_PCM]]"
 // CHECK:            ]
 // CHECK:            "file-deps": [
@@ -120,6 +122,7 @@
 // CHECK:            "name": "Right"
 // CHECK:          }
 // CHECK-NEXT:     {
+// CHECK:            "cache-key": "[[TOP_CACHE_KEY]]"
 // CHECK:            "casfs-root-id": "[[TOP_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
 // CHECK:            "clang-module-deps": []
 // CHECK:            "command-line": [
@@ -144,6 +147,7 @@
 // CHECK:          {
 // CHECK:            "commands": [
 // CHECK:              {
+// CHECK:                "cache-key": "[[TU_CACHE_KEY:llvmcas://[[:xdigit:]]+]]"
 // CHECK:                "casfs-root-id": "[[TU_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
 // CHECK:                "clang-module-deps": [
 // CHECK:                  {
@@ -162,10 +166,10 @@
 // CHECK:                  "-fcache-compile-job"
 // CHECK:                  "-fmodule-file-cache-key"
 // CHECK:                  "[[LEFT_PCM]]"
-// CHECK:                  "{{llvmcas://[[:xdigit:]]+}}"
+// CHECK:                  "[[LEFT_CACHE_KEY]]"
 // CHECK:                  "-fmodule-file-cache-key"
 // CHECK:                  "[[RIGHT_PCM]]"
-// CHECK:                  "{{llvmcas://[[:xdigit:]]+}}"
+// CHECK:                  "[[RIGHT_CACHE_KEY]]"
 // CHECK:                  "-fmodule-file={{(Left=)?}}[[LEFT_PCM]]"
 // CHECK:                  "-fmodule-file={{(Right=)?}}[[RIGHT_PCM]]"
 // CHECK:                ]

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -623,6 +623,8 @@ public:
           {"clang-modulemap-file", MD.ClangModuleMapFile},
           {"command-line", MD.BuildArguments},
       };
+      if (MD.ModuleCacheKey)
+        O.try_emplace("cache-key", MD.ModuleCacheKey);
       if (MD.CASFileSystemRootID)
         O.try_emplace("casfs-root-id", MD.CASFileSystemRootID->toString());
       if (MD.IncludeTreeID)
@@ -643,6 +645,8 @@ public:
               {"executable", Cmd.Executable},
               {"command-line", Cmd.Arguments},
           };
+          if (Cmd.TUCacheKey)
+            O.try_emplace("cache-key", *Cmd.TUCacheKey);
           if (I.CASFileSystemRootID)
             O.try_emplace("casfs-root-id", I.CASFileSystemRootID);
           if (I.IncludeTreeID)


### PR DESCRIPTION
Also add translation unit and module cache keys in the json output of `clang-scan-deps` for testing purposes.

(cherry picked from commit c1784bd8f6ecc21eb41e820b77e65deafaded82a)