### PR TITLE
[stable][libclang][cas] Expose the module and TU cache keys from the libclang dep-scan API

### DIFF
--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -526,6 +526,12 @@ CINDEX_LINKAGE CXCStringArray
     clang_experimental_DepGraphModule_getBuildArguments(CXDepGraphModule);
 
 /**
+ * \returns the \c ActionCache key for this module, if any.
+ */
+CINDEX_LINKAGE
+const char *clang_experimental_DepGraphModule_getCacheKey(CXDepGraphModule);
+
+/**
  * \returns the number \c CXDepGraphTUCommand objects in the graph.
  */
 CINDEX_LINKAGE size_t clang_experimental_DepGraph_getNumTUCommands(CXDepGraph);
@@ -562,6 +568,12 @@ CINDEX_LINKAGE const char *
  */
 CINDEX_LINKAGE CXCStringArray
     clang_experimental_DepGraphTUCommand_getBuildArguments(CXDepGraphTUCommand);
+
+/**
+ * \returns the \c ActionCache key for this translation unit, if any.
+ */
+CINDEX_LINKAGE const char *
+    clang_experimental_DepGraphTUCommand_getCacheKey(CXDepGraphTUCommand);
 
 /**
  * \returns the list of files which this translation unit directly depends on.

--- a/clang/test/Index/Core/scan-deps-cas.m
+++ b/clang/test/Index/Core/scan-deps-cas.m
@@ -33,6 +33,7 @@
 // CHECK-NEXT:     name: ModA
 // CHECK-NEXT:     context-hash: [[HASH_MOD_A:[A-Z0-9]+]]
 // CHECK-NEXT:     module-map-path: [[PREFIX]]/Inputs/module/module.modulemap
+// CHECK-NEXT:     cache-key: [[CASFS_MODA_CACHE_KEY:llvmcas://[[:xdigit:]]+]]
 // CHECK-NEXT:     module-deps:
 // CHECK-NEXT:     file-deps:
 // CHECK-NEXT:       [[PREFIX]]/Inputs/module/ModA.h
@@ -51,6 +52,7 @@
 // CHECK-NEXT: dependencies:
 // CHECK-NEXT:   command 0:
 // CHECK-NEXT:     context-hash: [[HASH_TU:[A-Z0-9]+]]
+// CHECK-NEXT:     cache-key: [[CASFS_TU_CACHE_KEY:llvmcas://[[:xdigit:]]+]]
 // CHECK-NEXT:     module-deps:
 // CHECK-NEXT:       ModA:[[HASH_MOD_A]]
 // CHECK-NEXT:     file-deps:
@@ -66,6 +68,7 @@
 // INCLUDE_TREE:      dependencies:
 // INCLUDE_TREE-NEXT:   command 0:
 // INCLUDE_TREE-NEXT:     context-hash: [[HASH_TU:[A-Z0-9]+]]
+// INCLUDE_TREE-NEXT:     cache-key: [[INC_TU_CACHE_KEY:llvmcas://[[:xdigit:]]+]]
 // INCLUDE_TREE-NEXT:     module-deps:
 // INCLUDE_TREE-NEXT:     file-deps:
 // INCLUDE_TREE-NEXT:       [[PREFIX]]/scan-deps-cas.m

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -546,6 +546,14 @@ clang_experimental_DepGraphModule_getBuildArguments(CXDepGraphModule CXDepMod) {
   return unwrap(CXDepMod)->StrMgr.createCStringsRef(ModDeps.BuildArguments);
 }
 
+const char *
+clang_experimental_DepGraphModule_getCacheKey(CXDepGraphModule CXDepMod) {
+  ModuleDeps &ModDeps = *unwrap(CXDepMod)->ModDeps;
+  if (ModDeps.ModuleCacheKey)
+    return ModDeps.ModuleCacheKey->c_str();
+  return nullptr;
+}
+
 size_t clang_experimental_DepGraph_getNumTUCommands(CXDepGraph Graph) {
   TranslationUnitDeps &TUDeps = unwrap(Graph)->TUDeps;
   return TUDeps.Commands.size();
@@ -571,6 +579,14 @@ CXCStringArray clang_experimental_DepGraphTUCommand_getBuildArguments(
     CXDepGraphTUCommand CXCmd) {
   Command &TUCmd = *unwrap(CXCmd)->TUCmd;
   return unwrap(CXCmd)->StrMgr.createCStringsRef(TUCmd.Arguments);
+}
+
+const char *
+clang_experimental_DepGraphTUCommand_getCacheKey(CXDepGraphTUCommand CXCmd) {
+  Command &TUCmd = *unwrap(CXCmd)->TUCmd;
+  if (TUCmd.TUCacheKey)
+    return TUCmd.TUCacheKey->c_str();
+  return nullptr;
 }
 
 CXCStringArray clang_experimental_DepGraph_getTUFileDeps(CXDepGraph Graph) {

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -503,6 +503,7 @@ LLVM_16 {
     clang_experimental_DepGraph_getTUModuleDeps;
     clang_experimental_DepGraphModule_dispose;
     clang_experimental_DepGraphModule_getBuildArguments;
+    clang_experimental_DepGraphModule_getCacheKey;
     clang_experimental_DepGraphModule_getContextHash;
     clang_experimental_DepGraphModule_getFileDeps;
     clang_experimental_DepGraphModule_getModuleDeps;
@@ -510,6 +511,7 @@ LLVM_16 {
     clang_experimental_DepGraphModule_getName;
     clang_experimental_DepGraphTUCommand_dispose;
     clang_experimental_DepGraphTUCommand_getBuildArguments;
+    clang_experimental_DepGraphTUCommand_getCacheKey;
     clang_experimental_DepGraphTUCommand_getExecutable;
     clang_getUnqualifiedType;
     clang_getNonReferenceType;


### PR DESCRIPTION
(cherry picked from commit b5ca7144d571408eb402d6017256955d442eea4b)