### PR TITLE
[clang][cas] Switch to include-tree by default

### DIFF
--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -145,8 +145,8 @@ ScanningOutputFormat DependencyScannerServiceOptions::getFormat() const {
   if (llvm::sys::Process::GetEnv("CLANG_CACHE_USE_CASFS_DEPSCAN"))
     return ScanningOutputFormat::FullTree;
 
-  // Note: default caching behaviour is currently cas-fs.
-  return ScanningOutputFormat::FullTree;
+  // Use include-tree by default.
+  return ScanningOutputFormat::FullIncludeTree;
 }
 
 CXDependencyScannerService


### PR DESCRIPTION
As of 3a924f2d4d we have significantly fewer known isuses with include-tree caching than with cas-fs, so it's time to switch the default.

rdar://107575958