### PR TITLE
[sanitizers] Explainer about dyld and weak overrides on Darwin. (NFC)

### DIFF
--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -181,16 +181,14 @@ Changes to Sanitizers
   only consider symbols in other mach-o modules which themselves contain at
   least one weak symbol. A consequence is that if your program or dylib contains
   an intended override of a weak symbol, then it must contain at least one weak
-  symbol as well for the override to be effective. That weak symbol may be the
-  intended override itself, an otherwise usused weak symbol added solely to meet
-  the requirement, or an existing but unrelated weak symbol.
+  symbol as well for the override to take effect.
 
-    Examples:
-      __attribute__((weak)) const char * __asan_default_options(void) {...}
-
+    Example:
+      // Add this to make sure your override takes effect
       __attribute__((weak,unused)) unsigned __enableOverrides;
-      
-      __attribute__((weak)) bool unrelatedWeakFlag;
+
+      // Example override
+      extern "C" const char *__asan_default_options() { ... }
 
 
 Other Changes

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -177,6 +177,20 @@ Changes to LLDB
 
 Changes to Sanitizers
 ---------------------
+* For Darwin users that override weak symbols, note that the dynamic linker will
+  only consider symbols in other mach-o modules which themselves contain at
+  least one weak symbol. A consequence is that if your program or dylib contains
+  an intended override of a weak symbol, then it must contain at least one weak
+  symbol as well for the override to be effective. That weak symbol may be the
+  intended override itself, an otherwise usused weak symbol added solely to meet
+  the requirement, or an existing but unrelated weak symbol.
+
+    Examples:
+      __attribute__((weak)) const char * __asan_default_options(void) {...}
+
+      __attribute__((weak,unused)) unsigned __enableOverrides;
+      
+      __attribute__((weak)) bool unrelatedWeakFlag;
 
 
 Other Changes

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -183,12 +183,15 @@ Changes to Sanitizers
   an intended override of a weak symbol, then it must contain at least one weak
   symbol as well for the override to take effect.
 
-    Example:
-      // Add this to make sure your override takes effect
-      __attribute__((weak,unused)) unsigned __enableOverrides;
+  Example:
 
-      // Example override
-      extern "C" const char *__asan_default_options() { ... }
+  .. code-block:: c
+
+    // Add this to make sure your override takes effect
+    __attribute__((weak,unused)) unsigned __enableOverrides;
+
+    // Example override
+    extern "C" const char *__asan_default_options() { ... }
 
 
 Other Changes


### PR DESCRIPTION
Explain in the release notes that the Darwin dynamic linker (dyld) requires that at least one weak symbol be present in any mach-o file that defines an intended override of a sanitizer dylib weak reference.

rdar://103453678

Reviewed By: thetruestblue

Differential Revision: https://reviews.llvm.org/D146745

(cherry picked from commit f1c5c84ae1a87c6ea707ae3b3e524e9eeaf1d70a)